### PR TITLE
feat: add transport Python types, fix docs, drop py3.8 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,23 +71,13 @@ jobs:
           path: target/wheels/*.whl
 
   # ── Python tests: matrix over OS × Python versions ──
-  # Python 3.8 uses ubuntu-20.04 (ubuntu-latest=24.04 doesn't ship 3.8).
-  # Windows/macOS runners provide Python 3.8 natively.
   python-test:
     name: Test (${{ matrix.os }}, py${{ matrix.python-version }})
     needs: [build-wheel]
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-        include:
-          # Python 3.8 on Linux needs an older Ubuntu that ships it
-          - os: ubuntu-20.04
-            python-version: "3.8"
-        exclude:
-          # Exclude ubuntu-latest + 3.8 (not available); ubuntu-20.04 above covers it
-          - os: ubuntu-latest
-            python-version: "3.8"
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -99,7 +89,7 @@ jobs:
       - name: Download wheel
         uses: actions/download-artifact@v4
         with:
-          name: wheel-${{ matrix.os == 'ubuntu-20.04' && 'ubuntu-latest' || matrix.os }}
+          name: wheel-${{ matrix.os }}
           path: dist/
       - name: Install wheel + test deps
         run: pip install --no-index --find-links dist dcc-mcp-core && pip install pytest pytest-cov

--- a/crates/dcc-mcp-transport/src/lib.rs
+++ b/crates/dcc-mcp-transport/src/lib.rs
@@ -24,4 +24,4 @@ pub use transport::TransportManager;
 
 // Re-export Python bindings
 #[cfg(feature = "python-bindings")]
-pub use python::PyTransportManager;
+pub use python::{PyServiceEntry, PyServiceStatus, PyTransportManager};

--- a/crates/dcc-mcp-transport/src/python.rs
+++ b/crates/dcc-mcp-transport/src/python.rs
@@ -1,6 +1,6 @@
 //! Python bindings for the transport layer via PyO3.
 //!
-//! Exposes `PyTransportManager` and `PyServiceEntry` as Python classes.
+//! Exposes `PyTransportManager`, `PyServiceEntry`, and `PyServiceStatus` as Python classes.
 //! Async operations are bridged to synchronous calls via an internal Tokio runtime.
 
 #[cfg(feature = "python-bindings")]
@@ -14,9 +14,148 @@ use std::collections::HashMap;
 #[cfg(feature = "python-bindings")]
 use crate::config::{PoolConfig, SessionConfig, TransportConfig};
 #[cfg(feature = "python-bindings")]
-use crate::discovery::types::{ServiceEntry, ServiceKey};
+use crate::discovery::types::{ServiceEntry, ServiceKey, ServiceStatus};
 #[cfg(feature = "python-bindings")]
 use crate::transport::TransportManager;
+
+// ── PyServiceStatus ──
+
+/// Python-facing enum for DCC service status.
+///
+/// ```python
+/// from dcc_mcp_core import ServiceStatus
+///
+/// status = ServiceStatus.AVAILABLE
+/// print(status)  # "AVAILABLE"
+/// ```
+#[cfg(feature = "python-bindings")]
+#[pyclass(name = "ServiceStatus", eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PyServiceStatus {
+    /// Service is available and accepting connections.
+    #[pyo3(name = "AVAILABLE")]
+    Available,
+    /// Service is busy (processing a request).
+    #[pyo3(name = "BUSY")]
+    Busy,
+    /// Service is unreachable (health check failed).
+    #[pyo3(name = "UNREACHABLE")]
+    Unreachable,
+    /// Service is shutting down.
+    #[pyo3(name = "SHUTTING_DOWN")]
+    ShuttingDown,
+}
+
+#[cfg(feature = "python-bindings")]
+#[pymethods]
+impl PyServiceStatus {
+    fn __repr__(&self) -> String {
+        format!("ServiceStatus.{}", self.__str__())
+    }
+
+    fn __str__(&self) -> &'static str {
+        match self {
+            Self::Available => "AVAILABLE",
+            Self::Busy => "BUSY",
+            Self::Unreachable => "UNREACHABLE",
+            Self::ShuttingDown => "SHUTTING_DOWN",
+        }
+    }
+}
+
+#[cfg(feature = "python-bindings")]
+impl From<ServiceStatus> for PyServiceStatus {
+    fn from(s: ServiceStatus) -> Self {
+        match s {
+            ServiceStatus::Available => PyServiceStatus::Available,
+            ServiceStatus::Busy => PyServiceStatus::Busy,
+            ServiceStatus::Unreachable => PyServiceStatus::Unreachable,
+            ServiceStatus::ShuttingDown => PyServiceStatus::ShuttingDown,
+        }
+    }
+}
+
+// ── PyServiceEntry ──
+
+/// Python-facing service entry representing a discovered DCC instance.
+///
+/// ```python
+/// from dcc_mcp_core import TransportManager
+///
+/// transport = TransportManager("/path/to/registry")
+/// instance_id = transport.register_service("maya", "127.0.0.1", 18812)
+/// entry = transport.get_service("maya", instance_id)
+/// print(entry.dcc_type)      # "maya"
+/// print(entry.host)          # "127.0.0.1"
+/// print(entry.port)          # 18812
+/// print(entry.status)        # ServiceStatus.AVAILABLE
+/// ```
+#[cfg(feature = "python-bindings")]
+#[pyclass(name = "ServiceEntry", get_all)]
+#[derive(Debug, Clone)]
+pub struct PyServiceEntry {
+    /// DCC application type (e.g. "maya", "houdini", "blender").
+    pub dcc_type: String,
+    /// Unique instance identifier (UUID string).
+    pub instance_id: String,
+    /// Host address.
+    pub host: String,
+    /// Port number.
+    pub port: u16,
+    /// DCC application version (e.g. "2024.2").
+    pub version: Option<String>,
+    /// Currently open scene/file.
+    pub scene: Option<String>,
+    /// Arbitrary metadata.
+    pub metadata: HashMap<String, String>,
+    /// Current service status.
+    pub status: PyServiceStatus,
+}
+
+#[cfg(feature = "python-bindings")]
+#[pymethods]
+impl PyServiceEntry {
+    fn __repr__(&self) -> String {
+        format!(
+            "ServiceEntry(dcc_type={:?}, host={:?}, port={}, instance_id={:?}, status={})",
+            self.dcc_type,
+            self.host,
+            self.port,
+            self.instance_id,
+            self.status.__str__()
+        )
+    }
+
+    /// Convert to a dictionary for backward compatibility.
+    fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+        let dict = PyDict::new(py);
+        dict.set_item("dcc_type", &self.dcc_type)?;
+        dict.set_item("instance_id", &self.instance_id)?;
+        dict.set_item("host", &self.host)?;
+        dict.set_item("port", self.port)?;
+        dict.set_item("version", &self.version)?;
+        dict.set_item("scene", &self.scene)?;
+        dict.set_item("metadata", &self.metadata)?;
+        dict.set_item("status", self.status.__str__())?;
+        Ok(dict.into())
+    }
+}
+
+#[cfg(feature = "python-bindings")]
+impl From<&ServiceEntry> for PyServiceEntry {
+    fn from(entry: &ServiceEntry) -> Self {
+        Self {
+            dcc_type: entry.dcc_type.clone(),
+            instance_id: entry.instance_id.to_string(),
+            host: entry.host.clone(),
+            port: entry.port,
+            version: entry.version.clone(),
+            scene: entry.scene.clone(),
+            metadata: entry.metadata.clone(),
+            status: entry.status.into(),
+        }
+    }
+}
 
 // ── PyTransportManager ──
 
@@ -161,18 +300,53 @@ impl PyTransportManager {
     /// List all instances for a given DCC type.
     ///
     /// Returns:
-    ///     List of dicts with service info.
+    ///     List of ServiceEntry objects.
     #[pyo3(name = "list_instances")]
-    fn py_list_instances(&self, py: Python, dcc_type: &str) -> PyResult<Vec<PyObject>> {
-        let entries = self.inner.list_instances(dcc_type);
-        entries.iter().map(|e| service_entry_to_py(py, e)).collect()
+    fn py_list_instances(&self, dcc_type: &str) -> Vec<PyServiceEntry> {
+        self.inner
+            .list_instances(dcc_type)
+            .iter()
+            .map(PyServiceEntry::from)
+            .collect()
     }
 
     /// List all registered services.
+    ///
+    /// Returns:
+    ///     List of ServiceEntry objects.
     #[pyo3(name = "list_all_services")]
-    fn py_list_all_services(&self, py: Python) -> PyResult<Vec<PyObject>> {
-        let entries = self.inner.list_all_services();
-        entries.iter().map(|e| service_entry_to_py(py, e)).collect()
+    fn py_list_all_services(&self) -> Vec<PyServiceEntry> {
+        self.inner
+            .list_all_services()
+            .iter()
+            .map(PyServiceEntry::from)
+            .collect()
+    }
+
+    /// Get a specific service entry by DCC type and instance ID.
+    ///
+    /// Args:
+    ///     dcc_type: DCC application type.
+    ///     instance_id: Instance UUID string.
+    ///
+    /// Returns:
+    ///     ServiceEntry if found, None otherwise.
+    #[pyo3(name = "get_service")]
+    fn py_get_service(
+        &self,
+        dcc_type: &str,
+        instance_id: &str,
+    ) -> PyResult<Option<PyServiceEntry>> {
+        let uuid = parse_uuid(instance_id)?;
+        let key = ServiceKey {
+            dcc_type: dcc_type.to_string(),
+            instance_id: uuid,
+        };
+        Ok(self
+            .inner
+            .get_service(&key)
+            .as_ref()
+            .map(PyServiceEntry::from))
     }
 
     /// Update heartbeat for a service.
@@ -282,6 +456,22 @@ impl PyTransportManager {
             .collect()
     }
 
+    /// List sessions for a specific DCC type.
+    ///
+    /// Args:
+    ///     dcc_type: DCC application type.
+    ///
+    /// Returns:
+    ///     List of session info dicts for the given DCC type.
+    #[pyo3(name = "list_sessions_for_dcc")]
+    fn py_list_sessions_for_dcc(&self, py: Python, dcc_type: &str) -> Vec<PyObject> {
+        self.inner
+            .list_sessions_for_dcc(dcc_type)
+            .iter()
+            .map(|s| session_to_py(py, s))
+            .collect()
+    }
+
     /// Get the number of active sessions.
     #[pyo3(name = "session_count")]
     fn py_session_count(&self) -> usize {
@@ -318,6 +508,18 @@ impl PyTransportManager {
     #[pyo3(name = "pool_size")]
     fn py_pool_size(&self) -> usize {
         self.inner.pool_size()
+    }
+
+    /// Get the number of connections for a specific DCC type.
+    ///
+    /// Args:
+    ///     dcc_type: DCC application type.
+    ///
+    /// Returns:
+    ///     Number of pooled connections for the given DCC type.
+    #[pyo3(name = "pool_count_for_dcc")]
+    fn py_pool_count_for_dcc(&self, dcc_type: &str) -> usize {
+        self.inner.pool_count_for_dcc(dcc_type)
     }
 
     // ── Lifecycle ──
@@ -365,20 +567,6 @@ impl PyTransportManager {
 fn parse_uuid(s: &str) -> PyResult<uuid::Uuid> {
     uuid::Uuid::parse_str(s)
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("invalid UUID: {}", e)))
-}
-
-#[cfg(feature = "python-bindings")]
-fn service_entry_to_py(py: Python, entry: &ServiceEntry) -> PyResult<PyObject> {
-    let dict = PyDict::new(py);
-    dict.set_item("dcc_type", &entry.dcc_type)?;
-    dict.set_item("instance_id", entry.instance_id.to_string())?;
-    dict.set_item("host", &entry.host)?;
-    dict.set_item("port", entry.port)?;
-    dict.set_item("version", entry.version.as_deref())?;
-    dict.set_item("scene", entry.scene.as_deref())?;
-    dict.set_item("metadata", &entry.metadata)?;
-    dict.set_item("status", entry.status.to_string())?;
-    Ok(dict.into())
 }
 
 #[cfg(feature = "python-bindings")]

--- a/crates/dcc-mcp-transport/src/transport.rs
+++ b/crates/dcc-mcp-transport/src/transport.rs
@@ -344,7 +344,7 @@ mod tests {
             .unwrap();
 
         // Should auto-pick the available instance
-        let session_id = manager.get_or_create_session("maya", None).unwrap();
+        let _session_id = manager.get_or_create_session("maya", None).unwrap();
         assert_eq!(manager.session_count(), 1);
     }
 
@@ -406,7 +406,7 @@ mod tests {
             .unwrap();
 
         assert!(!manager.is_shutdown());
-        let (sessions, connections) = manager.shutdown();
+        let (sessions, _connections) = manager.shutdown();
         assert!(manager.is_shutdown());
         assert_eq!(sessions.len(), 1);
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -20,7 +20,7 @@ export default defineConfig({
           { text: 'Guide', link: '/guide/getting-started' },
           { text: 'API', link: '/api/models' },
           {
-            text: 'v0.11.0',
+            text: 'v0.12.0',
             items: [
               { text: 'Changelog', link: 'https://github.com/loonghao/dcc-mcp-core/blob/main/CHANGELOG.md' },
               { text: 'PyPI', link: 'https://pypi.org/project/dcc-mcp-core/' },
@@ -39,19 +39,17 @@ export default defineConfig({
             {
               text: 'Core Concepts',
               items: [
-                { text: 'Actions', link: '/guide/actions' },
-                { text: 'Action Manager', link: '/guide/action-manager' },
-                { text: 'Middleware', link: '/guide/middleware' },
+                { text: 'Actions & Registry', link: '/guide/actions' },
                 { text: 'Event System', link: '/guide/events' },
                 { text: 'Skills System', link: '/guide/skills' },
                 { text: 'MCP Protocols', link: '/guide/protocols' },
+                { text: 'Transport Layer', link: '/guide/transport' },
               ]
             },
             {
               text: 'Advanced',
               items: [
                 { text: 'Custom Actions', link: '/guide/custom-actions' },
-                { text: 'Function Adapters', link: '/guide/function-adapters' },
               ]
             },
           ],
@@ -61,10 +59,10 @@ export default defineConfig({
               items: [
                 { text: 'Models', link: '/api/models' },
                 { text: 'Actions', link: '/api/actions' },
-                { text: 'Middleware', link: '/api/middleware' },
                 { text: 'Events', link: '/api/events' },
                 { text: 'Skills', link: '/api/skills' },
                 { text: 'Protocols', link: '/api/protocols' },
+                { text: 'Transport', link: '/api/transport' },
                 { text: 'Utilities', link: '/api/utilities' },
               ]
             }
@@ -81,7 +79,7 @@ export default defineConfig({
           { text: '指南', link: '/zh/guide/getting-started' },
           { text: 'API', link: '/zh/api/models' },
           {
-            text: 'v0.11.0',
+            text: 'v0.12.0',
             items: [
               { text: '更新日志', link: 'https://github.com/loonghao/dcc-mcp-core/blob/main/CHANGELOG.md' },
               { text: 'PyPI', link: 'https://pypi.org/project/dcc-mcp-core/' },
@@ -101,18 +99,16 @@ export default defineConfig({
               text: '核心概念',
               items: [
                 { text: 'Actions 动作', link: '/zh/guide/actions' },
-                { text: 'Action Manager', link: '/zh/guide/action-manager' },
-                { text: '中间件', link: '/zh/guide/middleware' },
                 { text: '事件系统', link: '/zh/guide/events' },
                 { text: 'Skills 技能包', link: '/zh/guide/skills' },
                 { text: 'MCP 协议', link: '/zh/guide/protocols' },
+                { text: '传输层', link: '/zh/guide/transport' },
               ]
             },
             {
               text: '进阶',
               items: [
                 { text: '自定义 Action', link: '/zh/guide/custom-actions' },
-                { text: '函数适配器', link: '/zh/guide/function-adapters' },
               ]
             },
           ],
@@ -122,10 +118,10 @@ export default defineConfig({
               items: [
                 { text: '数据模型', link: '/zh/api/models' },
                 { text: 'Actions', link: '/zh/api/actions' },
-                { text: '中间件', link: '/zh/api/middleware' },
                 { text: '事件', link: '/zh/api/events' },
                 { text: 'Skills', link: '/zh/api/skills' },
                 { text: '协议', link: '/zh/api/protocols' },
+                { text: '传输层', link: '/zh/api/transport' },
                 { text: '工具函数', link: '/zh/api/utilities' },
               ]
             }

--- a/docs/api/actions.md
+++ b/docs/api/actions.md
@@ -1,72 +1,51 @@
 # Actions API
 
-## Action Base Class
+`dcc_mcp_core.ActionRegistry`
 
-`dcc_mcp_core.actions.base.Action`
+## ActionRegistry
 
-### Class Attributes
+Thread-safe action registry backed by DashMap. Each registry instance is independent.
 
-| Attribute | Type | Description |
-|-----------|------|-------------|
-| `name` | `str` | Action name |
-| `description` | `str` | Description |
-| `tags` | `List[str]` | Tags |
-| `dcc` | `str` | Target DCC |
-| `order` | `int` | Priority (lower = first) |
-| `category` | `str` | Category |
-| `abstract` | `bool` | If `True`, not registered |
-
-### Inner Classes
-
-- `InputModel(Action.InputModel)` — Define input parameters
-- `OutputModel(Action.OutputModel)` — Define structured output
-
-### Methods
-
-- `setup(**kwargs) -> Action` — Validate input, chainable
-- `validate_input(**kwargs) -> InputModel`
-- `process() -> ActionResultModel` — Sync execute
-- `process_async() -> ActionResultModel` — Async execute
-- `_execute() -> None` — **Must implement**
-- `_execute_async() -> None` — Override for native async
-
-## ActionManager
-
-`dcc_mcp_core.actions.manager.ActionManager`
-
-### Factory Functions
+### Constructor
 
 ```python
-create_action_manager(dcc_name, ...) -> ActionManager  # always new
-get_action_manager(dcc_name, ...) -> ActionManager      # cached singleton
+from dcc_mcp_core import ActionRegistry
+registry = ActionRegistry()
 ```
 
 ### Methods
 
-- `discover_actions_from_path(path)`
-- `discover_actions_from_package(package_name)`
-- `refresh_actions(force=True)`
-- `call_action(name, **kwargs) -> ActionResultModel`
-- `call_action_async(name, **kwargs) -> ActionResultModel`
-- `get_actions_info() -> ActionResultModel`
-- `list_available_actions() -> List[str]`
-- `add_middleware(cls, **kwargs)`
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `register(name, description="", category="", tags=[], dcc="python", version="1.0.0", input_schema=None, output_schema=None, source_file=None)` | — | Register an action |
+| `get_action(name, dcc_name=None)` | `dict?` | Get action metadata as dict |
+| `list_actions(dcc_name=None)` | `List[dict]` | List all actions as metadata dicts |
+| `list_actions_for_dcc(dcc_name)` | `List[str]` | List action names for a DCC |
+| `get_all_dccs()` | `List[str]` | List all registered DCC names |
+| `reset()` | — | Clear all registered actions |
 
-## ActionRegistry
+### Dunder Methods
 
-`dcc_mcp_core.actions.registry.ActionRegistry` (singleton)
+| Method | Description |
+|--------|-------------|
+| `__len__` | Number of registered actions |
+| `__contains__(name)` | Check if action is registered |
+| `__repr__` | `ActionRegistry(actions=N)` |
 
-### Methods
+### Action Metadata Dict
 
-- `register(action_class) -> bool`
-- `get_action(name, dcc_name=None) -> Optional[Type[Action]]`
-- `list_actions(dcc_name=None, tag=None) -> List[Dict]`
-- `get_actions_by_dcc(dcc_name) -> Dict[str, Type[Action]]`
-- `get_all_dccs() -> List[str]`
+When retrieved via `get_action()` or `list_actions()`, each action is a dict:
 
-## Function Adapters
-
-`dcc_mcp_core.actions.function_adapter`
-
-- `create_function_adapter(action_name, dcc_name=None) -> Callable`
-- `create_function_adapters(dcc_name=None, manager=None) -> Dict[str, Callable]`
+```python
+{
+    "name": "create_sphere",
+    "description": "Creates a sphere",
+    "category": "geometry",
+    "tags": ["geometry"],
+    "dcc": "maya",
+    "version": "1.0.0",
+    "input_schema": {"type": "object", "properties": {}},
+    "output_schema": {"type": "object", "properties": {}},
+    "source_file": "/path/to/source.py"  # or null
+}
+```

--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -1,27 +1,49 @@
 # Events API
 
-`dcc_mcp_core.actions.events`
+`dcc_mcp_core.EventBus`
 
 ## EventBus
 
-Global instance: `event_bus`
+Thread-safe publish/subscribe event bus backed by DashMap.
+
+### Constructor
+
+```python
+from dcc_mcp_core import EventBus
+bus = EventBus()
+```
 
 ### Methods
 
-- `subscribe(event_name: str, handler: Callable)` — Subscribe to an event
-- `unsubscribe(event_name: str, handler: Callable)` — Unsubscribe
-- `publish(event_name: str, data: dict)` — Publish an event
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `subscribe(event_name, callback)` | `int` | Subscribe a callable. Returns subscriber ID |
+| `unsubscribe(event_name, subscriber_id)` | `bool` | Unsubscribe by ID. Returns True if found |
+| `publish(event_name, **kwargs)` | — | Call all subscribers with kwargs |
 
-## Built-in Events
+### Dunder Methods
 
-| Event | Published By | Data |
-|-------|-------------|------|
-| `action_manager.created` | ActionManager init | `{"manager": ...}` |
-| `action_manager.before_discover_path` | `discover_actions_from_path` | `{"path": ...}` |
-| `action_manager.after_discover_path` | `discover_actions_from_path` | `{"path": ..., "actions": ...}` |
-| `action_manager.before_refresh` | `refresh_actions` | `{"force": ...}` |
-| `action_manager.after_refresh` | `refresh_actions` | `{"actions_count": ...}` |
-| `action.before_execute.{name}` | `call_action` | `{"action_name": ..., "kwargs": ...}` |
-| `action.after_execute.{name}` | `call_action` | `{"action_name": ..., "result": ...}` |
-| `action.error.{name}` | `call_action` | `{"action_name": ..., "error": ...}` |
-| `skill.loaded` | skill loader | `{"skill_name": ..., "actions": ...}` |
+| Method | Description |
+|--------|-------------|
+| `__repr__` | `EventBus(subscriptions=N)` |
+
+### Behavior
+
+- Subscribers receive keyword arguments from `publish(event_name, **kwargs)`
+- Exceptions in subscribers are logged via `tracing` but do not propagate
+- Callbacks are collected before invocation to avoid DashMap deadlocks
+- Multiple subscribers per event are supported
+- Subscriber IDs are monotonically increasing (starting at 1)
+
+### Example
+
+```python
+bus = EventBus()
+
+def on_action(action_name=None, **kwargs):
+    print(f"Action: {action_name}")
+
+sid = bus.subscribe("action.executed", on_action)
+bus.publish("action.executed", action_name="create_sphere")
+bus.unsubscribe("action.executed", sid)
+```

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -2,14 +2,14 @@
 
 ## ActionResultModel
 
-Standardized result for all action executions.
+Standardized result for all action executions. Backed by a Rust struct via PyO3.
 
 ### Fields
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `success` | `bool` | `True` | Whether the execution was successful |
-| `message` | `str` | — | Human-readable result description |
+| `message` | `str` | `""` | Human-readable result description |
 | `prompt` | `Optional[str]` | `None` | Suggestion for AI about next steps |
 | `error` | `Optional[str]` | `None` | Error message when `success` is `False` |
 | `context` | `Dict[str, Any]` | `{}` | Additional context data |
@@ -20,21 +20,40 @@ Standardized result for all action executions.
 |--------|---------|-------------|
 | `with_error(error)` | `ActionResultModel` | Create copy with error info (sets `success=False`) |
 | `with_context(**kwargs)` | `ActionResultModel` | Create copy with updated context |
-| `to_dict()` | `Dict[str, Any]` | Pydantic v1/v2 compatible dict conversion |
+| `to_dict()` | `Dict[str, Any]` | Convert to dictionary |
 
 ### Factory Functions
 
 ```python
-from dcc_mcp_core import success_result, error_result, from_exception
+from dcc_mcp_core import success_result, error_result, from_exception, validate_action_result
 
+# Success result with context
 result = success_result("Created 5 spheres", prompt="Use modify_spheres next", count=5)
-error = error_result("Failed", "File not found", prompt="Check path", path="/bad/path")
-exc_result = from_exception(e, message="Import failed", include_traceback=True)
+
+# Error result with possible solutions
+error = error_result(
+    "Failed", "File not found",
+    prompt="Check path",
+    possible_solutions=["Verify file exists", "Check permissions"],
+    path="/bad/path",
+)
+
+# From exception string
+exc_result = from_exception(
+    "ValueError: bad input",
+    message="Import failed",
+    include_traceback=True,
+)
+
+# Validate/normalize any value to ActionResultModel
+validate_action_result(result)                          # pass-through
+validate_action_result({"success": True, "message": "OK"})  # dict → ARM
+validate_action_result("hello")                         # wrap as success
 ```
 
 ## SkillMetadata
 
-Metadata parsed from SKILL.md frontmatter.
+Metadata parsed from SKILL.md frontmatter. All fields are readable and writable.
 
 ### Fields
 
@@ -48,3 +67,5 @@ Metadata parsed from SKILL.md frontmatter.
 | `scripts` | `List[str]` | `[]` | Discovered script file paths |
 | `skill_path` | `str` | `""` | Absolute path to skill directory |
 | `version` | `str` | `"1.0.0"` | Skill version |
+| `depends` | `List[str]` | `[]` | Names of required skills |
+| `metadata_files` | `List[str]` | `[]` | Files in metadata/ directory |

--- a/docs/api/protocols.md
+++ b/docs/api/protocols.md
@@ -1,85 +1,99 @@
 # Protocols API
 
-`dcc_mcp_core.protocols`
+`dcc_mcp_core.protocols` types — MCP specification-compliant type definitions.
 
-## Type Definitions
-
-### ToolDefinition
+## ToolDefinition
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `name` | `str` | Tool name |
 | `description` | `str` | Tool description |
-| `inputSchema` | `dict` | JSON Schema for input |
-| `annotations` | `ToolAnnotations` | Optional annotations |
+| `input_schema` | `str` | JSON Schema string for input (serde: `inputSchema`) |
+| `output_schema` | `Optional[str]` | JSON Schema string for output (serde: `outputSchema`) |
 
-### ResourceDefinition
+```python
+from dcc_mcp_core import ToolDefinition
+
+tool = ToolDefinition(
+    name="create_sphere",
+    description="Creates a sphere",
+    input_schema='{"type": "object"}',
+)
+```
+
+## ToolAnnotations
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `uri` | `str` | Resource URI |
-| `name` | `str` | Resource name |
-| `description` | `str` | Description |
-| `mimeType` | `str` | MIME type |
+| `title` | `Optional[str]` | Human-readable title |
+| `read_only_hint` | `Optional[bool]` | serde: `readOnlyHint` |
+| `destructive_hint` | `Optional[bool]` | serde: `destructiveHint` |
+| `idempotent_hint` | `Optional[bool]` | serde: `idempotentHint` |
+| `open_world_hint` | `Optional[bool]` | serde: `openWorldHint` |
 
-### PromptDefinition
+```python
+from dcc_mcp_core import ToolAnnotations
+
+ann = ToolAnnotations(read_only_hint=True)
+```
+
+## ResourceDefinition
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `uri` | `str` | — | Resource URI |
+| `name` | `str` | — | Resource name |
+| `description` | `str` | — | Description |
+| `mime_type` | `str` | `"text/plain"` | MIME type (serde: `mimeType`) |
+
+```python
+from dcc_mcp_core import ResourceDefinition
+
+res = ResourceDefinition(uri="scene://objects", name="Objects", description="Scene objects")
+```
+
+## ResourceTemplateDefinition
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `uri_template` | `str` | — | URI template (serde: `uriTemplate`) |
+| `name` | `str` | — | Template name |
+| `description` | `str` | — | Description |
+| `mime_type` | `str` | `"text/plain"` | MIME type (serde: `mimeType`) |
+
+```python
+from dcc_mcp_core import ResourceTemplateDefinition
+
+tmpl = ResourceTemplateDefinition(
+    uri_template="scene://objects/{name}",
+    name="Object",
+    description="A scene object",
+)
+```
+
+## PromptArgument
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `str` | — | Argument name |
+| `description` | `str` | — | Description |
+| `required` | `bool` | `False` | Whether required |
+
+```python
+from dcc_mcp_core import PromptArgument
+
+arg = PromptArgument(name="object_name", description="Object to review", required=True)
+```
+
+## PromptDefinition
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `name` | `str` | Prompt name |
 | `description` | `str` | Description |
-| `arguments` | `List[PromptArgument]` | Arguments |
-
-## Abstract Base Classes
-
-### Resource
 
 ```python
-class Resource(ABC):
-    uri: str
-    name: str
-    description: str
-    mime_type: str
-    dcc: str
+from dcc_mcp_core import PromptDefinition
 
-    @abstractmethod
-    def read(self, **params) -> str: ...
-```
-
-### Prompt
-
-```python
-class Prompt(ABC):
-    name: str
-    description: str
-
-    class ArgumentsModel(BaseModel): ...
-
-    @abstractmethod
-    def render(self, **kwargs) -> str: ...
-```
-
-## MCPAdapter
-
-| Method | Description |
-|--------|-------------|
-| `action_to_tool(action_class)` | Convert Action to ToolDefinition |
-| `resource_to_definition(resource_class)` | Convert Resource to ResourceDefinition |
-| `prompt_to_definition(prompt_class)` | Convert Prompt to PromptDefinition |
-| `parse_uri_template_params(template)` | Extract params from URI template |
-| `match_uri_to_template(uri, template)` | Match URI against template |
-
-## MCPServerProtocol
-
-```python
-class MCPServerProtocol:
-    name: str
-    version: str
-
-    async def list_tools() -> List[ToolDefinition]
-    async def call_tool(name, arguments) -> Any
-    async def list_resources() -> List[ResourceDefinition]
-    async def read_resource(uri) -> str
-    async def list_prompts() -> List[PromptDefinition]
-    async def get_prompt(name, arguments=None) -> str
+prompt = PromptDefinition(name="review", description="Review a model")
 ```

--- a/docs/api/skills.md
+++ b/docs/api/skills.md
@@ -1,13 +1,35 @@
 # Skills API
 
-`dcc_mcp_core.skills`
+`dcc_mcp_core.SkillScanner`, `dcc_mcp_core.parse_skill_md`, `dcc_mcp_core.scan_skill_paths`
 
 ## SkillScanner
 
+Scanner for discovering Skill packages in directories. Caches file modification times for efficient repeated scans.
+
 ```python
+from dcc_mcp_core import SkillScanner
+
 scanner = SkillScanner()
-skill_dirs = scanner.scan(extra_paths=["/my/skills"], dcc_name="maya")
 ```
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `scan(extra_paths=None, dcc_name=None, force_refresh=False)` | `List[str]` | Scan paths for skill directories |
+| `clear_cache()` | — | Clear the mtime cache and discovered list |
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `discovered_skills` | `List[str]` | Previously discovered skill directory paths |
+
+### Dunder Methods
+
+| Method | Description |
+|--------|-------------|
+| `__repr__` | `SkillScanner(cached=N, discovered=N)` |
 
 ## Functions
 
@@ -17,43 +39,30 @@ skill_dirs = scanner.scan(extra_paths=["/my/skills"], dcc_name="maya")
 parse_skill_md(skill_dir: str) -> Optional[SkillMetadata]
 ```
 
-Parse a SKILL.md file and return metadata.
+Parse a SKILL.md file from a skill directory. Returns `None` if the file is missing or invalid.
 
-### load_skill
-
-```python
-load_skill(
-    skill_dir: str,
-    registry: ActionRegistry = None,
-    dcc_name: str = None
-) -> List[Type[Action]]
-```
-
-Load a skill directory and register all script actions.
-
-### create_script_action
-
-```python
-create_script_action(
-    skill_name: str,
-    script_path: str,
-    metadata: SkillMetadata,
-    dcc_name: str
-) -> Type[Action]
-```
-
-Create an Action subclass from a script file.
+- Extracts YAML frontmatter between `---` delimiters
+- Enumerates scripts in `scripts/` subdirectory
+- Discovers `.md` files in `metadata/` subdirectory
+- Merges dependencies from `metadata/depends.md`
 
 ### scan_skill_paths
 
 ```python
-scan_skill_paths(extra_paths: List[str] = None) -> List[str]
+scan_skill_paths(extra_paths: Optional[List[str]] = None, dcc_name: Optional[str] = None) -> List[str]
 ```
 
-Convenience function to scan all skill paths.
+Convenience function: creates a fresh `SkillScanner` and scans all paths.
+
+## Search Path Priority
+
+1. `extra_paths` parameter (highest priority)
+2. `DCC_MCP_SKILL_PATHS` environment variable
+3. Platform-specific skills directory (DCC-specific)
+4. Platform-specific skills directory (global)
 
 ## Environment Variables
 
 | Variable | Description |
 |----------|-------------|
-| `DCC_MCP_SKILL_PATHS` | Skill search paths (platform path separator) |
+| `DCC_MCP_SKILL_PATHS` | Skill search paths (`;` on Windows, `:` on Unix) |

--- a/docs/api/transport.md
+++ b/docs/api/transport.md
@@ -1,0 +1,147 @@
+# Transport API
+
+`dcc_mcp_core.TransportManager`
+
+## TransportManager
+
+Python-facing wrapper for the Rust transport layer. Bridges async operations to synchronous calls via an internal Tokio runtime.
+
+### Constructor
+
+```python
+TransportManager(
+    registry_dir: str,
+    max_connections_per_dcc: int = 10,
+    idle_timeout: int = 300,
+    heartbeat_interval: int = 5,
+    connect_timeout: int = 10,
+    reconnect_max_retries: int = 3,
+)
+```
+
+### Service Discovery
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `register_service(dcc_type, host, port, version=None, scene=None, metadata=None)` | `str` | Register a service, returns instance_id (UUID) |
+| `deregister_service(dcc_type, instance_id)` | `bool` | Deregister a service by key |
+| `list_instances(dcc_type)` | `List[dict]` | List all instances for a DCC type |
+| `list_all_services()` | `List[dict]` | List all registered services |
+| `heartbeat(dcc_type, instance_id)` | `bool` | Update heartbeat timestamp |
+
+### Session Management
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `get_or_create_session(dcc_type, instance_id=None)` | `str` | Get/create a session (UUID). If no instance_id, picks first available |
+| `get_session(session_id)` | `dict?` | Get session info dict, or None |
+| `record_success(session_id, latency_ms)` | — | Record successful request |
+| `record_error(session_id, latency_ms, error)` | — | Record failed request |
+| `begin_reconnect(session_id)` | `int` | Begin reconnection, returns backoff in ms |
+| `reconnect_success(session_id)` | — | Mark reconnection as successful |
+| `close_session(session_id)` | `bool` | Close a session |
+| `list_sessions()` | `List[dict]` | List all active sessions |
+| `session_count()` | `int` | Number of active sessions |
+
+### Connection Pool
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `acquire_connection(dcc_type, instance_id=None)` | `str` | Acquire connection (UUID) |
+| `release_connection(dcc_type, instance_id)` | — | Release connection back to pool |
+| `pool_size()` | `int` | Total connections in pool |
+
+### Lifecycle
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `cleanup()` | `(int, int, int)` | Returns (stale_services, closed_sessions, evicted_connections) |
+| `shutdown()` | — | Graceful shutdown |
+| `is_shutdown()` | `bool` | Check if transport is shut down |
+
+### Dunder Methods
+
+| Method | Description |
+|--------|-------------|
+| `__repr__` | `TransportManager(services=N, sessions=N, pool=N)` |
+| `__len__` | Returns session count |
+
+## Rust-Only Types
+
+The following types are available in Rust but not directly exposed to Python:
+
+### TransportConfig
+
+| Field | Type | Default |
+|-------|------|---------|
+| `pool` | `PoolConfig` | — |
+| `session` | `SessionConfig` | — |
+| `connect_timeout` | `Duration` | 10s |
+| `heartbeat_interval` | `Duration` | 5s |
+
+### PoolConfig
+
+| Field | Type | Default |
+|-------|------|---------|
+| `max_connections_per_type` | `usize` | 10 |
+| `max_idle_time` | `Duration` | 300s |
+| `max_lifetime` | `Duration` | 3600s |
+| `acquire_timeout` | `Duration` | 30s |
+
+### SessionConfig
+
+| Field | Type | Default |
+|-------|------|---------|
+| `idle_timeout` | `Duration` | 300s |
+| `reconnect_max_retries` | `u32` | 3 |
+| `reconnect_backoff_base` | `Duration` | 1s |
+| `max_session_lifetime` | `Duration` | 3600s |
+| `heartbeat_interval` | `Duration` | 5s |
+
+### TransportError
+
+| Variant | Description |
+|---------|-------------|
+| `ConnectionFailed` | TCP connection failed |
+| `ConnectionTimeout` | Connection timed out |
+| `PoolExhausted` | All connections in use |
+| `AcquireTimeout` | Timeout waiting for pooled connection |
+| `ServiceNotFound` | Service not in registry |
+| `ServiceAlreadyRegistered` | Duplicate registration |
+| `Serialization` | MessagePack serialization error |
+| `Io` | IO error |
+| `RegistryFile` | Registry file error |
+| `Shutdown` | Transport is shut down |
+| `SessionNotFound` | Session not found |
+| `InvalidSessionState` | Invalid state transition |
+| `ReconnectionFailed` | Max retries exceeded |
+| `Internal` | Generic internal error |
+
+### ServiceStatus
+
+| Value | Description |
+|-------|-------------|
+| `Available` | Accepting connections (default) |
+| `Busy` | Processing a request |
+| `Unreachable` | Health check failed |
+| `ShuttingDown` | Shutting down |
+
+### SessionState
+
+| Value | Description |
+|-------|-------------|
+| `Connected` | Ready for requests |
+| `Idle` | Idle timeout exceeded |
+| `Reconnecting` | Reconnecting after failure |
+| `Closed` | Terminal state |
+
+### Wire Protocol
+
+Messages use MessagePack serialization with a 4-byte big-endian length prefix:
+
+```
+[4-byte length][MessagePack payload]
+```
+
+- **Request**: `{ id: UUID, method: String, params: Vec<u8> }`
+- **Response**: `{ id: UUID, success: bool, payload: Vec<u8>, error: Option<String> }`

--- a/docs/api/utilities.md
+++ b/docs/api/utilities.md
@@ -1,105 +1,88 @@
 # Utilities API
 
-`dcc_mcp_core.utils`
-
-## Decorators
-
-```python
-from dcc_mcp_core.utils.decorators import error_handler, with_context
-
-@error_handler
-def risky_operation(data):
-    # Always returns ActionResultModel, catches all exceptions
-    return {"processed": True}
-
-@with_context()
-def process(data, context):
-    # context defaults to {} if not provided
-    pass
-```
+`dcc_mcp_core.utils` — filesystem, constants, type wrappers, logging.
 
 ## Type Wrappers (RPyC)
 
-```python
-from dcc_mcp_core.utils.type_wrappers import (
-    wrap_value, unwrap_value, wrap_boolean_parameters, unwrap_parameters,
-    BooleanWrapper, IntWrapper, FloatWrapper, StringWrapper,
-)
+Type-safe wrappers for transmitting Python values over RPyC connections.
 
+```python
+from dcc_mcp_core import wrap_value, unwrap_value, unwrap_parameters
+from dcc_mcp_core import BooleanWrapper, IntWrapper, FloatWrapper, StringWrapper
+
+# Wrap native values
 wrapped = wrap_value(True)         # BooleanWrapper(True)
-original = unwrap_value(wrapped)   # True
+wrapped = wrap_value(42)           # IntWrapper(42)
+wrapped = wrap_value(3.14)         # FloatWrapper(3.14)
+wrapped = wrap_value("hello")     # StringWrapper("hello")
 
-params = {"visible": True, "count": 5}
-wrapped_params = wrap_boolean_parameters(params)
-original_params = unwrap_parameters(wrapped_params)
+# Unwrap back to native
+original = unwrap_value(wrapped)   # True, 42, 3.14, or "hello"
+
+# Unwrap all values in a dict
+params = {"visible": BooleanWrapper(True), "count": IntWrapper(5)}
+native = unwrap_parameters(params)  # {"visible": True, "count": 5}
 ```
 
-## Module Loading
+### Wrapper Classes
 
-```python
-from dcc_mcp_core.utils.module_loader import load_module_from_path, append_to_python_path
+| Class | Python Type | Special Methods |
+|-------|-------------|-----------------|
+| `BooleanWrapper(value)` | `bool` | `__bool__`, `__eq__`, `__hash__` |
+| `IntWrapper(value)` | `int` (`i64`) | `__int__`, `__index__`, `__eq__`, `__hash__` |
+| `FloatWrapper(value)` | `float` (`f64`) | `__float__`, `__eq__` (relative tolerance), **not hashable** |
+| `StringWrapper(value)` | `str` | `__str__`, `__eq__`, `__hash__` |
 
-module = load_module_from_path(
-    "/path/to/action.py",
-    dependencies={"cmds": maya_cmds},
-    dcc_name="maya"
-)
-
-with append_to_python_path("/path/to/script.py"):
-    import my_script
-```
+::: warning
+`FloatWrapper` is intentionally not hashable (`__hash__` raises `TypeError`) because `f64` does not implement `Eq`/`Hash` (NaN ≠ NaN). Do not use it as a dict key or in sets.
+:::
 
 ## Filesystem
 
-```python
-from dcc_mcp_core.utils.filesystem import (
-    get_config_dir, get_data_dir, get_log_dir, get_actions_dir,
-    get_skills_dir, get_skill_paths_from_env, get_actions_paths_from_env,
-)
-
-config = get_config_dir()           # Platform-specific config directory
-actions = get_actions_dir("maya")   # .../data/actions/maya/
-skills = get_skills_dir("maya")     # .../data/skills/maya/
-env_paths = get_skill_paths_from_env()  # from DCC_MCP_SKILL_PATHS
-```
-
-## Dependency Injection
+Platform-specific directory resolution using the `dirs` crate.
 
 ```python
-from dcc_mcp_core.utils.dependency_injector import inject_dependencies
-
-inject_dependencies(
-    module,
-    {"cmds": maya_cmds},
-    inject_core_modules=True,
-    dcc_name="maya"
+from dcc_mcp_core import (
+    get_platform_dir, get_config_dir, get_data_dir, get_log_dir,
+    get_actions_dir, get_skills_dir, get_skill_paths_from_env,
 )
-# module.cmds == maya_cmds
-# module.DCC_NAME == "maya"
+
+config = get_config_dir()           # ~/.config/dcc-mcp (Linux)
+data = get_data_dir()               # ~/.local/share/dcc-mcp (Linux)
+log = get_log_dir()                 # ~/.local/share/dcc-mcp/log (Linux)
+actions = get_actions_dir("maya")   # {data}/actions/maya/
+skills = get_skills_dir("maya")     # {data}/skills/maya/
+skills = get_skills_dir()           # {data}/skills/ (global)
+
+# Generic platform dir (config, data, cache, log, documents)
+dir = get_platform_dir("cache")
+
+# From environment variable
+paths = get_skill_paths_from_env()  # splits DCC_MCP_SKILL_PATHS
 ```
+
+::: tip
+All `get_*_dir()` functions create the directory if it doesn't exist (except `get_skills_dir` which only returns the path).
+:::
+
+## Constants
+
+Available as module-level attributes:
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `APP_NAME` | `"dcc-mcp"` | App name for platform dirs |
+| `APP_AUTHOR` | `"dcc-mcp"` | App author |
+| `DEFAULT_DCC` | `"python"` | Default DCC name |
+| `DEFAULT_LOG_LEVEL` | `"DEBUG"` | Default log level |
+| `ENV_LOG_LEVEL` | `"MCP_LOG_LEVEL"` | Env var for log level |
+| `ENV_SKILL_PATHS` | `"DCC_MCP_SKILL_PATHS"` | Env var for skill paths |
+| `SKILL_METADATA_FILE` | `"SKILL.md"` | Skill metadata filename |
+| `SKILL_SCRIPTS_DIR` | `"scripts"` | Scripts subdirectory |
 
 ## Environment Variables
 
 | Variable | Description |
 |----------|-------------|
-| `DCC_MCP_ACTION_PATHS` | Action search paths |
-| `DCC_MCP_ACTION_PATH_{DCC}` | DCC-specific action paths (e.g., `DCC_MCP_ACTION_PATH_MAYA`) |
-| `DCC_MCP_SKILL_PATHS` | Skill search paths |
-| `DCC_MCP_ACTIONS_DIR` | Generic actions directory |
-
-## Exceptions
-
-`dcc_mcp_core.utils.exceptions`
-
-| Exception | Description |
-|-----------|-------------|
-| `MCPError` | Base exception |
-| `ConfigurationError` | Configuration issues |
-| `ConnectionError` | Connection issues |
-| `OperationError` | Operation failures |
-| `ValidationError` | General validation errors |
-| `ParameterValidationError` | Parameter validation errors |
-| `VersionError` | Version compatibility errors |
-| `ActionError` | Base action error (has `action_name`, `action_class`) |
-| `ActionParameterError` | Parameter validation (has `parameter_name`) |
-| `ActionExecutionError` | Execution failure (has `execution_phase`, `traceback`) |
+| `DCC_MCP_SKILL_PATHS` | Skill search paths (`;` on Windows, `:` on Unix) |
+| `MCP_LOG_LEVEL` | Log level override (DEBUG, INFO, WARN, ERROR) |

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -8,7 +8,7 @@
 pip install dcc-mcp-core
 ```
 
-### From Source
+### From Source (requires Rust toolchain)
 
 ```bash
 git clone https://github.com/loonghao/dcc-mcp-core.git
@@ -16,64 +16,89 @@ cd dcc-mcp-core
 pip install -e .
 ```
 
+::: tip
+Building from source requires the Rust toolchain. Install it from [rustup.rs](https://rustup.rs/).
+The build is handled by [maturin](https://www.maturin.rs/) which compiles the Rust core and installs the Python package.
+:::
+
 ## Requirements
 
-- **Python**: >= 3.7 (CI tests 3.11, 3.12, 3.13)
+- **Python**: >= 3.11 (CI tests 3.11, 3.12, 3.13)
+- **Rust**: >= 1.85 (for building from source)
 - **License**: MIT
-- **Dependencies**: Zero for Python 3.8+
+- **Python Dependencies**: Zero — everything is in the compiled Rust extension
 
 ## Quick Start
 
+### Action Registry
+
 ```python
-from dcc_mcp_core import create_action_manager
+from dcc_mcp_core import ActionRegistry
 
-# Create an action manager for a specific DCC
-manager = create_action_manager("maya")
+registry = ActionRegistry()
+registry.register(
+    name="create_sphere",
+    description="Creates a sphere in the scene",
+    category="geometry",
+    tags=["geometry", "creation"],
+    dcc="maya",
+)
 
-# Execute an action
-result = manager.call_action("create_sphere", radius=2.0)
+action = registry.get_action("create_sphere")
+print(action)  # dict with action metadata
 
-# Check the result
-print(result.success, result.message, result.context)
+maya_actions = registry.list_actions(dcc_name="maya")
+```
+
+### Action Results
+
+```python
+from dcc_mcp_core import success_result, error_result
+
+result = success_result("Created 5 spheres", prompt="Use modify next", count=5)
+print(result.success)  # True
+print(result.message)  # "Created 5 spheres"
+print(result.context)  # {"count": 5}
+
+err = error_result("Failed", "File not found", prompt="Check path")
+print(err.success)  # False
+```
+
+### Event Bus
+
+```python
+from dcc_mcp_core import EventBus
+
+bus = EventBus()
+sid = bus.subscribe("scene.changed", lambda: print("Scene updated!"))
+bus.publish("scene.changed")
+bus.unsubscribe("scene.changed", sid)
 ```
 
 ## Development Setup
 
 ```bash
-# Clone the repository
 git clone https://github.com/loonghao/dcc-mcp-core.git
 cd dcc-mcp-core
 
-# Create and activate virtual environment
-python -m venv venv
-source venv/bin/activate  # On Windows: venv\Scripts\activate
-
-# Install development dependencies
-pip install -e .
-pip install pytest pytest-cov pytest-mock pyfakefs
-
-# Or use vx (recommended)
+# Install with vx (recommended)
 vx just install
+
+# Or manual setup
+pip install maturin
+maturin develop
 ```
 
 ## Running Tests
 
 ```bash
-# Run tests with coverage
 vx just test
-
-# Run specific tests
-vx uvx nox -s pytest -- tests/test_action_manager.py -v
-
-# Run linting
 vx just lint
-
-# Run linting with auto-fix
-vx just lint-fix
 ```
 
 ## Next Steps
 
-- Learn about [Actions](/guide/actions) — the core building block
-- Explore the [Action Manager](/guide/action-manager) for lifecycle management
+- Learn about [Actions & Registry](/guide/actions) — the core building block
+- Explore the [Event System](/guide/events) for lifecycle hooks
 - Check out the [Skills System](/guide/skills) for zero-code script registration
+- See the [Transport Layer](/guide/transport) for DCC communication

--- a/docs/guide/transport.md
+++ b/docs/guide/transport.md
@@ -1,0 +1,98 @@
+# Transport Layer
+
+The Transport layer (`dcc-mcp-transport` crate) provides async communication infrastructure for connecting MCP servers to DCC application instances. It includes connection pooling, service discovery, session management, and a wire protocol.
+
+## Overview
+
+```python
+from dcc_mcp_core import TransportManager
+
+transport = TransportManager("/path/to/registry")
+
+# Register a DCC service
+instance_id = transport.register_service("maya", "127.0.0.1", 18812, version="2025.1")
+
+# Create a session
+session_id = transport.get_or_create_session("maya")
+
+# Use the connection
+conn_id = transport.acquire_connection("maya")
+# ... perform operations ...
+transport.release_connection("maya", instance_id)
+
+# Cleanup and shutdown
+transport.cleanup()
+transport.shutdown()
+```
+
+## Service Discovery
+
+The transport layer uses file-based service discovery to track running DCC instances. Each instance registers with a `(dcc_type, instance_id)` key, enabling multiple instances of the same DCC.
+
+```python
+id1 = transport.register_service("maya", "127.0.0.1", 18812)
+id2 = transport.register_service("maya", "127.0.0.1", 18813)
+id3 = transport.register_service("blender", "127.0.0.1", 9090, version="4.0")
+
+maya_instances = transport.list_instances("maya")
+all_services = transport.list_all_services()
+
+transport.heartbeat("maya", id1)
+transport.deregister_service("maya", id1)
+```
+
+## Session Management
+
+Sessions track connections to DCC instances with lifecycle state management and metrics:
+
+```python
+session_id = transport.get_or_create_session("maya", instance_id=id1)
+
+session = transport.get_session(session_id)
+
+transport.record_success(session_id, latency_ms=50)
+transport.record_error(session_id, latency_ms=100, error="timeout")
+
+backoff_ms = transport.begin_reconnect(session_id)
+transport.reconnect_success(session_id)
+
+transport.close_session(session_id)
+```
+
+### Session States
+
+| State | Description |
+|-------|-------------|
+| `connected` | Active and ready for requests |
+| `idle` | Idle timeout exceeded, still valid |
+| `reconnecting` | Reconnecting after failure |
+| `closed` | Terminal state |
+
+## Connection Pool
+
+```python
+conn_id = transport.acquire_connection("maya")
+transport.release_connection("maya", id1)
+transport.pool_size()
+```
+
+## Configuration
+
+```python
+transport = TransportManager(
+    registry_dir="/path/to/registry",
+    max_connections_per_dcc=10,
+    idle_timeout=300,
+    heartbeat_interval=5,
+    connect_timeout=10,
+    reconnect_max_retries=3,
+)
+```
+
+## Lifecycle
+
+```python
+stale, sessions, evicted = transport.cleanup()
+transport.shutdown()
+transport.is_shutdown()
+```

--- a/docs/guide/what-is-dcc-mcp-core.md
+++ b/docs/guide/what-is-dcc-mcp-core.md
@@ -2,75 +2,69 @@
 
 DCC-MCP-Core is an **action management system** designed for Digital Content Creation (DCC) applications, providing a unified interface that allows AI to interact with various DCC software such as Maya, Blender, Houdini, and more.
 
+Built with a **Rust core** exposed to Python via [PyO3](https://pyo3.rs/), it combines the performance and thread safety of Rust with the accessibility of Python.
+
 ## Core Workflow
 
 ```mermaid
 flowchart LR
     AI([AI Assistant]):::aiNode
     MCP{{MCP Server}}:::serverNode
-    DCCMCP{{DCC-MCP}}:::serverNode
-    Actions[(DCC Actions)]:::actionsNode
+    Core{{DCC-MCP-Core}}:::coreNode
     DCC[/DCC Software/]:::dccNode
 
-    AI -->|1. Send Request| MCP
-    MCP -->|2. Forward Request| DCCMCP
-    DCCMCP -->|3. Discover & Load| Actions
-    Actions -->|4. Return Info| DCCMCP
-    DCCMCP -->|5. Structured Data| MCP
-    MCP -->|6. Call Function| DCCMCP
-    DCCMCP -->|7. Execute| DCC
-    DCC -->|8. Operation Result| DCCMCP
-    DCCMCP -->|9. Structured Result| MCP
-    MCP -->|10. Return Result| AI
+    AI -->|1. Request| MCP
+    MCP -->|2. Discover Actions| Core
+    Core -->|3. Execute in DCC| DCC
+    DCC -->|4. Result| Core
+    Core -->|5. Structured Result| MCP
+    MCP -->|6. Response| AI
 
     classDef aiNode fill:#f9d,stroke:#f06,stroke-width:2px,color:#333
     classDef serverNode fill:#bbf,stroke:#66f,stroke-width:2px,color:#333
+    classDef coreNode fill:#fbb,stroke:#f66,stroke-width:2px,color:#333
     classDef dccNode fill:#bfb,stroke:#6b6,stroke-width:2px,color:#333
-    classDef actionsNode fill:#fbb,stroke:#f66,stroke-width:2px,color:#333
 ```
 
 ## Key Features
 
-- **Class-Based Actions** — Define operations using Pydantic models with strong type checking and input validation
-- **ActionManager** — Lifecycle coordinator for action discovery, loading, and execution
-- **Middleware System** — Chain-of-responsibility pattern for logging, performance monitoring, and more
-- **Event System** — Publish/subscribe EventBus for action lifecycle events
+- **ActionRegistry** — Thread-safe, lock-free action registration and lookup via DashMap
+- **EventBus** — Publish/subscribe system for decoupled action lifecycle events
 - **Skills System** — Zero-code registration of scripts as MCP tools via SKILL.md
-- **MCP Protocol Layer** — Full protocol abstractions for Tools, Resources, and Prompts
-- **Zero Dependencies** — Python 3.8+ with no third-party Python dependencies
-- **Rust Core** — Performance-critical modules written in Rust via PyO3
+- **MCP Protocol Types** — Type-safe definitions for Tools, Resources, and Prompts
+- **Transport Layer** — Connection pooling, service discovery, and session management for DCC communication
+- **Type Wrappers** — RPyC-safe wrappers (BooleanWrapper, IntWrapper, FloatWrapper, StringWrapper)
+- **Zero Python Dependencies** — Pure Rust core compiled to a native Python extension
+- **Thread Safety** — All core types use DashMap for lock-free concurrent access
 
-## Project Structure
+## Architecture
+
+DCC-MCP-Core is a Rust workspace with 6 sub-crates, compiled into a single Python extension module via maturin:
 
 ```
-dcc_mcp_core/
-├── __init__.py              # Public API exports
-├── models.py                # ActionResultModel, SkillMetadata
-├── actions/
-│   ├── base.py              # Action base class
-│   ├── manager.py           # ActionManager
-│   ├── registry.py          # ActionRegistry (singleton)
-│   ├── middleware.py         # Middleware system
-│   ├── events.py            # EventBus
-│   ├── function_adapter.py  # Action-to-function adapters
-│   └── generator.py         # Action template generation
-├── skills/
-│   ├── scanner.py           # SkillScanner
-│   ├── loader.py            # SKILL.md parser
-│   └── script_action.py     # ScriptAction factory
-├── protocols/
-│   ├── types.py             # MCP type definitions
-│   ├── base.py              # Resource, Prompt ABCs
-│   ├── server.py            # MCPServerProtocol
-│   └── adapter.py           # MCPAdapter
-└── utils/
-    ├── filesystem.py         # Platform dirs, env paths
-    ├── module_loader.py      # Dynamic module loading
-    ├── decorators.py         # error_handler, with_context
-    ├── dependency_injector.py
-    ├── template.py           # Jinja2 rendering
-    ├── type_wrappers.py      # RPyC-safe type wrappers
-    └── result_factory.py     # Factory functions
+dcc-mcp-core/
+├── src/lib.rs                  # PyO3 module entry point (_core)
+├── crates/
+│   ├── dcc-mcp-actions/        # ActionRegistry, EventBus
+│   ├── dcc-mcp-models/         # ActionResultModel, SkillMetadata
+│   ├── dcc-mcp-protocols/      # MCP type definitions (Tool, Resource, Prompt)
+│   ├── dcc-mcp-skills/         # SKILL.md scanner and loader
+│   ├── dcc-mcp-transport/      # Connection pool, service discovery, sessions
+│   └── dcc-mcp-utils/          # Filesystem, constants, type wrappers, logging
+└── python/
+    └── dcc_mcp_core/
+        └── __init__.py          # Re-exports from _core extension
+```
+
+## Python API Surface
+
+All public APIs are available from the top-level `dcc_mcp_core` package:
+
+```python
+import dcc_mcp_core
+
+# 16 classes, 14 functions, 8 constants
+# See the API Reference for complete documentation
 ```
 
 ## Related Projects

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: DCC-MCP-Core
   text: AI ↔ DCC Bridge
-  tagline: Foundational library for the DCC Model Context Protocol ecosystem. Seamlessly connect AI with Maya, Blender, Houdini, and more.
+  tagline: Rust-powered foundational library for the DCC Model Context Protocol ecosystem. Seamlessly connect AI with Maya, Blender, Houdini, and more.
   image:
     src: /logo.svg
     alt: DCC-MCP-Core
@@ -17,22 +17,22 @@ hero:
       link: https://github.com/loonghao/dcc-mcp-core
 
 features:
+  - icon: 🦀
+    title: Rust-Powered Core
+    details: Performance-critical modules in Rust via PyO3. Thread-safe, lock-free data structures with DashMap. Zero Python dependencies.
   - icon: 🎯
-    title: Class-Based Actions
-    details: Define operations with Pydantic models for strong typing, input validation, and structured output.
-  - icon: ⚡
-    title: Zero Dependencies
-    details: Pure Python 3.8+ with zero third-party dependencies. Rust-powered core via PyO3 for maximum performance.
+    title: Action Registry
+    details: Thread-safe action registration and lookup. Store metadata, JSON schemas, and source paths for each DCC operation.
   - icon: 🔌
     title: Skills System
     details: Register any script (Python, MEL, MaxScript, BAT, Shell) as MCP tools with zero code via SKILL.md.
-  - icon: 🧩
-    title: Middleware & Events
-    details: Chain-of-responsibility middleware and publish/subscribe event system for extensible action processing.
+  - icon: ⚡
+    title: Event Bus
+    details: Publish/subscribe event system for decoupled action lifecycle communication. Panic-safe and thread-safe.
   - icon: 🌐
-    title: MCP Protocol Layer
-    details: Full MCP Server protocol with Tools, Resources, and Prompts abstractions for AI-DCC integration.
+    title: MCP Protocol Types
+    details: Type-safe definitions for MCP Tools, Resources, Prompts, and Annotations following the official specification.
   - icon: 🔄
-    title: Async Support
-    details: Both synchronous and asynchronous action execution with native async override capability.
+    title: Transport Layer
+    details: Connection pooling, file-based service discovery, session management with auto-reconnection for DCC communication.
 ---

--- a/docs/zh/api/transport.md
+++ b/docs/zh/api/transport.md
@@ -1,0 +1,60 @@
+# 传输层 API
+
+`dcc_mcp_core.TransportManager`
+
+## TransportManager
+
+Rust 传输层的 Python 封装。通过内部 Tokio 运行时将异步操作桥接为同步调用。
+
+### 构造函数
+
+```python
+TransportManager(
+    registry_dir: str,
+    max_connections_per_dcc: int = 10,
+    idle_timeout: int = 300,
+    heartbeat_interval: int = 5,
+    connect_timeout: int = 10,
+    reconnect_max_retries: int = 3,
+)
+```
+
+### 服务发现
+
+| 方法 | 返回值 | 说明 |
+|------|--------|------|
+| `register_service(dcc_type, host, port, version=None, scene=None, metadata=None)` | `str` | 注册服务，返回 instance_id (UUID) |
+| `deregister_service(dcc_type, instance_id)` | `bool` | 注销服务 |
+| `list_instances(dcc_type)` | `List[dict]` | 列出某 DCC 类型的所有实例 |
+| `list_all_services()` | `List[dict]` | 列出所有已注册服务 |
+| `heartbeat(dcc_type, instance_id)` | `bool` | 更新心跳时间戳 |
+
+### 会话管理
+
+| 方法 | 返回值 | 说明 |
+|------|--------|------|
+| `get_or_create_session(dcc_type, instance_id=None)` | `str` | 获取/创建会话 (UUID) |
+| `get_session(session_id)` | `dict?` | 获取会话信息 |
+| `record_success(session_id, latency_ms)` | — | 记录成功请求 |
+| `record_error(session_id, latency_ms, error)` | — | 记录失败请求 |
+| `begin_reconnect(session_id)` | `int` | 开始重连，返回退避时间（毫秒） |
+| `reconnect_success(session_id)` | — | 标记重连成功 |
+| `close_session(session_id)` | `bool` | 关闭会话 |
+| `list_sessions()` | `List[dict]` | 列出所有活跃会话 |
+| `session_count()` | `int` | 活跃会话数量 |
+
+### 连接池
+
+| 方法 | 返回值 | 说明 |
+|------|--------|------|
+| `acquire_connection(dcc_type, instance_id=None)` | `str` | 获取连接 (UUID) |
+| `release_connection(dcc_type, instance_id)` | — | 释放连接回池 |
+| `pool_size()` | `int` | 连接池中的总连接数 |
+
+### 生命周期
+
+| 方法 | 返回值 | 说明 |
+|------|--------|------|
+| `cleanup()` | `(int, int, int)` | 返回 (过期服务数, 关闭会话数, 驱逐连接数) |
+| `shutdown()` | — | 优雅关闭 |
+| `is_shutdown()` | `bool` | 检查是否已关闭 |

--- a/docs/zh/guide/transport.md
+++ b/docs/zh/guide/transport.md
@@ -1,0 +1,98 @@
+# 传输层
+
+传输层（`dcc-mcp-transport` crate）为 MCP 服务器与 DCC 应用实例之间的通信提供异步基础设施，包括连接池、服务发现、会话管理和线协议。
+
+## 概览
+
+```python
+from dcc_mcp_core import TransportManager
+
+transport = TransportManager("/path/to/registry")
+
+# 注册 DCC 服务
+instance_id = transport.register_service("maya", "127.0.0.1", 18812, version="2025.1")
+
+# 创建会话
+session_id = transport.get_or_create_session("maya")
+
+# 使用连接
+conn_id = transport.acquire_connection("maya")
+# ... 执行操作 ...
+transport.release_connection("maya", instance_id)
+
+# 清理和关闭
+transport.cleanup()
+transport.shutdown()
+```
+
+## 服务发现
+
+传输层使用基于文件的服务发现来跟踪运行中的 DCC 实例。每个实例使用 `(dcc_type, instance_id)` 作为键注册，支持同一 DCC 类型的多个实例。
+
+```python
+id1 = transport.register_service("maya", "127.0.0.1", 18812)
+id2 = transport.register_service("maya", "127.0.0.1", 18813)
+id3 = transport.register_service("blender", "127.0.0.1", 9090, version="4.0")
+
+maya_instances = transport.list_instances("maya")
+all_services = transport.list_all_services()
+
+transport.heartbeat("maya", id1)
+transport.deregister_service("maya", id1)
+```
+
+## 会话管理
+
+会话跟踪与 DCC 实例的连接，提供生命周期状态管理和指标：
+
+```python
+session_id = transport.get_or_create_session("maya", instance_id=id1)
+
+session = transport.get_session(session_id)
+
+transport.record_success(session_id, latency_ms=50)
+transport.record_error(session_id, latency_ms=100, error="timeout")
+
+backoff_ms = transport.begin_reconnect(session_id)
+transport.reconnect_success(session_id)
+
+transport.close_session(session_id)
+```
+
+### 会话状态
+
+| 状态 | 说明 |
+|------|------|
+| `connected` | 活跃且可接受请求 |
+| `idle` | 超过空闲超时，仍然有效 |
+| `reconnecting` | 失败后正在重连 |
+| `closed` | 终态 |
+
+## 连接池
+
+```python
+conn_id = transport.acquire_connection("maya")
+transport.release_connection("maya", id1)
+transport.pool_size()
+```
+
+## 配置
+
+```python
+transport = TransportManager(
+    registry_dir="/path/to/registry",
+    max_connections_per_dcc=10,   # 每种 DCC 类型的最大连接数
+    idle_timeout=300,             # 会话空闲超时（秒）
+    heartbeat_interval=5,         # 心跳间隔（秒）
+    connect_timeout=10,           # TCP 连接超时（秒）
+    reconnect_max_retries=3,      # 最大重连尝试次数
+)
+```
+
+## 生命周期
+
+```python
+stale, sessions, evicted = transport.cleanup()
+transport.shutdown()
+transport.is_shutdown()
+```

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -27,6 +27,8 @@ from dcc_mcp_core._core import PromptArgument
 from dcc_mcp_core._core import PromptDefinition
 from dcc_mcp_core._core import ResourceDefinition
 from dcc_mcp_core._core import ResourceTemplateDefinition
+from dcc_mcp_core._core import ServiceEntry
+from dcc_mcp_core._core import ServiceStatus
 from dcc_mcp_core._core import SkillMetadata
 from dcc_mcp_core._core import SkillScanner
 from dcc_mcp_core._core import StringWrapper
@@ -75,6 +77,8 @@ __all__ = [
     "PromptDefinition",
     "ResourceDefinition",
     "ResourceTemplateDefinition",
+    "ServiceEntry",
+    "ServiceStatus",
     "SkillMetadata",
     "SkillScanner",
     "StringWrapper",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,12 @@ fn register_skills(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
 #[cfg(feature = "python-bindings")]
 fn register_transport(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    add_classes!(m, dcc_mcp_transport::PyTransportManager);
+    add_classes!(
+        m,
+        dcc_mcp_transport::PyTransportManager,
+        dcc_mcp_transport::PyServiceEntry,
+        dcc_mcp_transport::PyServiceStatus,
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Squashed merge of `auto-improve` branch into `main`, plus CI optimization.

### Changes

**From auto-improve (squashed):**
- **feat(transport):** Add native Python types for `ServiceEntry` and `ServiceStatus`
- **docs:** Fix dead links, add transport docs, update version to v0.12.0

**CI optimization:**
- Remove `ubuntu-20.04` / `py3.8` test matrix entry to reduce CI wait time
  - Python 3.8 reached EOL in Oct 2024
  - `ubuntu-20.04` runners are slower and cause CI delays
  - Minimum supported Python is now 3.9

### Auto-merge
This PR is set to auto-merge once all CI checks pass.