### PR TITLE
docs: enhance AI agent guidance, fix legacy API refs, update llms.txt

### DIFF
--- a/.agents/skills/dcc-mcp-core/SKILL.md
+++ b/.agents/skills/dcc-mcp-core/SKILL.md
@@ -3,7 +3,7 @@ name: dcc-mcp-core
 description: "Foundation library for the DCC Model Context Protocol (MCP) ecosystem. Provides Rust-powered action management, skills system, transport layer, sandbox security, shared memory, screen capture, USD scene support, and telemetry for AI-assisted DCC workflows."
 tools: ["Bash", "Read", "Write", "Edit"]
 tags: ["mcp", "dcc", "rust", "pyo3", "maya", "blender", "houdini", "ai", "skills", "actions"]
-version: "0.12.3"
+version: "0.12.4"
 ---
 
 # dcc-mcp-core — DCC MCP Ecosystem Foundation
@@ -60,7 +60,7 @@ result = dispatcher.call("maya_geometry__create_sphere", radius=2.0)
 if result.success:
     print(f"Created: {result.context.get('object_name')}")
 else:
-    print(f"Error: result.error}")
+    print(f"Error: {result.error}")
 ```
 
 ### Creating a Custom Skill (Zero Python Code)
@@ -115,7 +115,7 @@ print(f'Discovered {len(skills)} skills')
 ┌─────────────────────────────────────────────────────┐
 │                   Python Layer                       │
 │  dcc_mcp_core/__init__.py  →  _core (PyO3 cdyll)   │
-│  ~105 public symbols re-exported from Rust core      │
+│  ~120 public symbols re-exported from Rust core      │
 └──────────────────────┬──────────────────────────────┘
                        │ PyO3 bindings
 ┌──────────────────────▼──────────────────────────────┐
@@ -299,7 +299,7 @@ pytest tests/test_transport.py -v
 ## Learning Resources
 
 - **Full docs site**: https://loonghao.github.io/dcc-mcp-core/
-- **Examples**: See `examples/skills/` for 10 complete skill packages
+- **Examples**: See `examples/skills/` for 9 complete skill packages
 - **Type stubs**: `python/dcc_mcp_core/_core.pyi` (complete API signature reference)
 - **CHANGELOG**: `CHANGELOG.md` for version history
 - **Contributing**: `CONTRIBUTING.md` for development workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,18 +1,19 @@
 # AGENTS.md — dcc-mcp-core AI Agent Guide
 
-> **Purpose**: This file helps AI coding agents (Claude, Copilot, Cursor, Codex, etc.) understand, navigate, and contribute to this project effectively.
+> **Purpose**: This file helps AI coding agents (Claude, Copilot, Cursor, Codex, Gemini, Devin, etc.) understand, navigate, and contribute to this project effectively. Read this before writing any code.
 
 ## Project Overview
 
-**dcc-mcp-core** is the foundational library for the DCC (Digital Content Creation) Model Context Protocol (MCP) ecosystem. It provides a Rust-powered core with Python bindings (PyO3/maturin) that enables AI assistants to interact with DCC software (Maya, Blender, Houdini, etc.).
+**dcc-mcp-core** is the foundational library for the DCC (Digital Content Creation) Model Context Protocol (MCP) ecosystem. It provides a **Rust-powered core with Python bindings (PyO3/maturin)** that enables AI assistants to interact with DCC software (Maya, Blender, Houdini, 3ds Max, etc.).
 
 ### Key Architecture Facts
 
 - **Language**: Rust core (11 crates workspace) + Python bindings via PyO3
 - **Build system**: `cargo` (Rust) + `maturin` (Python wheels)
-- **Python package**: `dcc_mcp_core` with ~105 public symbols re-exported from `_core` native extension
+- **Python package**: `dcc_mcp_core` with ~120 public symbols re-exported from `_core` native extension
 - **Zero runtime Python dependencies** — everything is compiled into the Rust core
 - **Version**: 0.12.x (use Release Please for versioning — never manually bump)
+- **Python support**: 3.7–3.13 (CI tests 3.7–3.13; abi3-py38 wheel for 3.8+)
 
 ## Repository Structure
 
@@ -38,15 +39,17 @@ dcc-mcp-core/
 │   └── dcc-mcp-utils/          # Filesystem, type wrappers, constants, JSON helpers
 │
 ├── python/dcc_mcp_core/
-│   ├── __init__.py             # Public API re-exports (~105 symbols)
-│   ├── _core.pyi               # Type stubs (75 KB, auto-generated-ish)
+│   ├── __init__.py             # Public API re-exports (~120 symbols) — ALWAYS read this first
+│   ├── _core.pyi               # Type stubs (auto-generated-ish) — ground truth for parameter names
 │   └── py.typed                # PEP 561 marker
 │
 ├── tests/                      # Python integration tests (19 files)
-├── examples/skills/            # 10 example SKILL.md packages
+├── examples/skills/            # 9 example SKILL.md packages (hello-world, maya-*, git-*, etc.)
 ├── docs/                       # VitePress documentation site (EN + ZH)
 │   ├── api/                    # API reference per module
 │   └── guide/                  # User guides & tutorials
+├── llms.txt                    # Concise API reference for LLMs
+├── llms-full.txt               # Complete API reference for LLMs
 └── .agents/skills/             # VX toolchain skills (IDE-agnostic)
 ```
 
@@ -55,7 +58,7 @@ dcc-mcp-core/
 ### Prerequisites
 
 ```bash
-# Install vx (recommended): https://github.com/loonghao/vx
+# Install vx (recommended universal tool manager): https://github.com/loonghao/vx
 # Or ensure you have: Rust 1.85+, Python 3.8+, maturin
 ```
 
@@ -85,10 +88,13 @@ dcc-mcp-core/
 
 ```bash
 # Run a single test file
-vx uvx nox -s pytest -- tests/test_skills.py -v
+vx just test -- tests/test_skills.py -v
 
 # Run with coverage for a specific module
-pytest tests/test_actions.py -v --cov=dcc_mcp_core --cov-report=term-missing
+vx just test-cov -- tests/test_actions.py -v
+
+# Run Rust tests for a specific crate
+cargo test -p dcc-mcp-actions --workspace
 ```
 
 ## Code Style & Conventions
@@ -105,7 +111,7 @@ pytest tests/test_actions.py -v --cov=dcc_mcp_core --cov-report=term-missing
 
 - Formatter: `ruff format` (line length: 120, double quotes)
 - Linter: `ruff check` (includes isort via `I` rules)
-- Target: Python 3.8+ (CI tests 3.9–3.13)
+- Target: Python 3.7+ (CI tests 3.7–3.13)
 - Docstrings: Google-style
 - All public APIs must have type annotations
 
@@ -127,90 +133,442 @@ from dcc_mcp_core import ActionResultModel
 
 ## API Reference (What AI Agents Should Know)
 
+> **IMPORTANT**: Always prefer `python/dcc_mcp_core/__init__.py` over guessing imports.
+> That file lists every public symbol. Never import from internal paths like `dcc_mcp_core._core.*` directly.
+
 ### Current Public API (Rust-backed, v0.12+)
 
 The public API is in `python/dcc_mcp_core/__init__.py`. Key domains:
 
 #### Actions System
-- `ActionRegistry` — Register/dispatch/invoke actions
-- `ActionDispatcher` — Typed action dispatch with validation
-- `ActionValidator` — Input parameter validation
-- `EventBus` — Pub/sub event system for action lifecycle
-- `ActionResultModel` / `success_result()` / `error_result()`
+
+```python
+from dcc_mcp_core import (
+    ActionRegistry,       # Thread-safe registry: register/get/list actions
+    ActionDispatcher,     # Typed dispatch with validation
+    ActionValidator,      # Input parameter validation before execution
+    ActionPipeline,       # Middleware-style processing pipeline
+    ActionMetrics,        # Performance/execution metrics
+    ActionRecorder,       # Record/replay action executions
+    EventBus,             # Pub/sub lifecycle events
+    ActionResultModel,    # Structured result model
+    success_result,       # Factory: ActionResultModel(success=True, ...)
+    error_result,         # Factory: ActionResultModel(success=False, ...)
+    from_exception,       # Factory: wrap Python exception as result
+    validate_action_result,  # Normalize dict/str/None → ActionResultModel
+)
+```
+
+**ActionRegistry patterns:**
+
+```python
+reg = ActionRegistry()
+
+# Register an action
+reg.register(
+    name="create_sphere",
+    description="Create a polygon sphere",
+    category="geometry",
+    tags=["geo", "create"],
+    dcc="maya",
+    version="1.0.0",
+    input_schema='{"type": "object", "properties": {"radius": {"type": "number"}}}',
+)
+
+# Look up
+meta = reg.get_action("create_sphere")
+meta = reg.get_action("create_sphere", dcc_name="maya")  # scoped
+names = reg.list_actions_for_dcc("maya")
+all_actions = reg.list_actions()
+dccs = reg.get_all_dccs()
+
+# Version-aware registry
+from dcc_mcp_core import SemVer, VersionedRegistry, VersionConstraint
+vreg = VersionedRegistry()
+vreg.register("my_action", version=SemVer(1, 2, 0), handler=my_fn)
+handler = vreg.get("my_action", constraint=VersionConstraint.parse(">=1.0.0"))
+```
+
+**ActionResultModel fields:**
+
+```python
+result = success_result(
+    message="Sphere created",
+    prompt="Consider adding materials or adjusting UVs",  # AI next-step hint
+    context={"object_name": "sphere1", "position": [0, 0, 0]}
+)
+result.success   # bool
+result.message   # str
+result.prompt    # Optional[str] — guidance for AI's next step
+result.error     # Optional[str] — error details (set when success=False)
+result.context   # dict — arbitrary structured data
+
+# Copy variants
+result.with_error("something failed")   # new result with success=False
+result.with_context(count=5, done=True) # new result with updated context
+result.to_dict()                        # -> dict
+```
 
 #### Skills System
-- `SkillScanner` — Scan directories for `SKILL.md` files
-- `SkillWatcher` — File-watching auto-reload for skills
-- `SkillMetadata` — Parsed skill metadata model
-- `parse_skill_md()` / `scan_skill_paths()` / `scan_and_load()` / `scan_and_load_lenient()`
-- `resolve_dependencies()` / `expand_transitive_dependencies()` / `validate_dependencies()`
+
+```python
+from dcc_mcp_core import (
+    SkillScanner,                    # Discovers SKILL.md directories (mtime-cached)
+    SkillWatcher,                    # File-watching auto-reload for live development
+    SkillMetadata,                   # Parsed skill metadata model
+    parse_skill_md,                  # Parse one skill directory → SkillMetadata
+    scan_skill_paths,                # Scan + return discovered paths
+    scan_and_load,                   # Scan + parse all → List[SkillMetadata]
+    scan_and_load_lenient,           # Same, but silently skip errors
+    resolve_dependencies,            # Resolve skill dependency graph
+    expand_transitive_dependencies,  # Full transitive closure
+    validate_dependencies,           # Validate dependency graph is acyclic
+)
+```
+
+**Full skills pipeline:**
+
+```python
+import os
+os.environ["DCC_MCP_SKILL_PATHS"] = "/path/to/skills"
+
+# Simple one-shot
+skills = scan_and_load(dcc_name="maya")           # raises on error
+skills = scan_and_load_lenient(dcc_name="maya")   # silently skips bad skills
+for s in skills:
+    print(f"{s.name}: {len(s.scripts)} scripts @ {s.skill_path}")
+
+# SkillMetadata fields:
+# s.name, s.description, s.dcc, s.version, s.tags, s.tools,
+# s.scripts (List[str] - absolute paths), s.skill_path, s.depends
+
+# Low-level scanner
+scanner = SkillScanner()
+dirs = scanner.scan(extra_paths=["/my/skills"], dcc_name="maya")
+meta = parse_skill_md(dirs[0])  # -> SkillMetadata or None
+
+# Action naming convention: {skill_name}__{script_stem}
+# e.g. "maya_geometry__create_sphere" for create_sphere.py in maya-geometry skill
+```
 
 #### MCP Protocol Types
-- `ToolDefinition`, `ToolAnnotations` — MCP Tool schema
-- `ResourceDefinition`, `ResourceAnnotations` — MCP Resource schema
-- `PromptDefinition`, `PromptArgument` — MCP Prompt schema
-- `DccInfo`, `DccCapabilities`, `DccError`, `DccErrorCode` — DCC adapter types
+
+```python
+from dcc_mcp_core import (
+    ToolDefinition, ToolAnnotations,
+    ResourceDefinition, ResourceAnnotations, ResourceTemplateDefinition,
+    PromptDefinition, PromptArgument,
+    DccInfo, DccCapabilities, DccError, DccErrorCode,
+)
+
+# Build MCP tool definition
+tool = ToolDefinition(
+    name="create_sphere",
+    description="Create a polygon sphere in the DCC scene",
+    input_schema='{"type": "object", "properties": {"radius": {"type": "number"}}, "required": ["radius"]}',
+    annotations=ToolAnnotations(
+        title="Create Sphere",
+        read_only_hint=False,
+        destructive_hint=False,
+        idempotent_hint=False,
+    ),
+)
+```
 
 #### Transport Layer
-- `TransportManager` — Manage IPC connections
-- `TransportAddress`, `TransportScheme`, `RoutingStrategy` — Addressing
-- `IpcListener`, `ListenerHandle`, `FramedChannel` — IPC primitives
-- `connect_ipc()` — Connect to an IPC server
+
+```python
+from dcc_mcp_core import (
+    TransportManager,    # Connection pool manager
+    TransportAddress, TransportScheme, RoutingStrategy,
+    IpcListener,         # Server-side IPC listener
+    ListenerHandle,      # Handle returned by IpcListener.start()
+    FramedChannel,       # Message-framed IPC channel
+    connect_ipc,         # Client: connect to IPC server
+)
+
+# Server
+listener = IpcListener.new("/tmp/dcc-mcp.sock")
+handle = listener.start(handler_fn=my_handler)
+
+# Client
+channel = connect_ipc("/tmp/dcc-mcp.sock")
+response = channel.call({"method": "ping", "params": {}})
+
+# Production: pooled + circuit breaker
+mgr = TransportManager()
+mgr.configure_pool(min_size=2, max_size=10)
+mgr.set_circuit_breaker(threshold=5, reset_timeout=30)
+```
 
 #### Process Management
-- `PyDccLauncher` — Launch DCC processes
-- `PyProcessMonitor` — Track running processes
-- `PyProcessWatcher` — Auto-restart crashed processes
-- `PyCrashRecoveryPolicy` — Crash recovery configuration
-- `ScriptResult`, `ScriptLanguage` — Script execution results
+
+```python
+from dcc_mcp_core import (
+    PyDccLauncher,           # Launch DCC processes
+    PyProcessMonitor,        # Track running DCC processes
+    PyProcessWatcher,        # Auto-restart on crash
+    PyCrashRecoveryPolicy,   # Crash recovery configuration
+    ScriptResult,            # Result of a script execution
+    ScriptLanguage,          # Enum: Python, MEL, MaxScript, etc.
+)
+
+launcher = PyDccLauncher(dcc_type="maya", version="2025")
+process = launcher.launch(script_path="/startup.py", working_dir="/project")
+
+watcher = PyProcessWatcher(
+    recovery_policy=PyCrashRecoveryPolicy(max_restarts=3, cooldown_sec=10)
+)
+watcher.watch(process)
+```
 
 #### Other Modules
-- **Sandbox**: `SandboxContext`, `SandboxPolicy`, `InputValidator`, `AuditEntry`, `AuditLog`
-- **Shared Memory**: `PyBufferPool`, `PySharedBuffer`, `PySharedSceneBuffer`
-- **Capture**: `Capturer`, `CaptureFrame`, `CaptureResult`
-- **Telemetry**: `TelemetryConfig`, `RecordingGuard`
-- **USD**: `UsdStage`, `UsdPrim`, `SdfPath`, `VtValue`, `scene_info_json_to_stage()`, `stage_to_scene_info_json()`
+
+```python
+# Sandbox security
+from dcc_mcp_core import SandboxContext, SandboxPolicy, InputValidator, AuditEntry, AuditLog
+
+# Shared memory (LZ4 compressed)
+from dcc_mcp_core import PyBufferPool, PySharedBuffer, PySharedSceneBuffer, PySceneDataKind
+
+# Screen capture
+from dcc_mcp_core import Capturer, CaptureFrame, CaptureResult
+
+# Telemetry
+from dcc_mcp_core import TelemetryConfig, RecordingGuard, ActionMetrics, ActionRecorder
+from dcc_mcp_core import is_telemetry_initialized, shutdown_telemetry
+
+# USD bridge
+from dcc_mcp_core import UsdStage, UsdPrim, SdfPath, VtValue, SceneInfo, SceneStatistics
+from dcc_mcp_core import scene_info_json_to_stage, stage_to_scene_info_json
+
+# Type wrappers (for RPyC safe serialization)
+from dcc_mcp_core import wrap_value, unwrap_value, unwrap_parameters
+from dcc_mcp_core import BooleanWrapper, FloatWrapper, IntWrapper, StringWrapper
+
+# Platform utilities
+from dcc_mcp_core import (
+    get_config_dir, get_data_dir, get_log_dir, get_platform_dir,
+    get_actions_dir, get_skills_dir, get_skill_paths_from_env, mpu_to_units, units_to_mpu,
+)
+
+# Service registry
+from dcc_mcp_core import ServiceEntry, ServiceStatus
+```
+
+#### Constants
+
+```python
+from dcc_mcp_core import (
+    APP_NAME,            # "dcc-mcp"
+    APP_AUTHOR,          # "dcc-mcp"
+    DEFAULT_DCC,         # "python"
+    DEFAULT_LOG_LEVEL,   # "DEBUG"
+    DEFAULT_MIME_TYPE,   # "text/plain"
+    DEFAULT_VERSION,     # "1.0.0"
+    ENV_SKILL_PATHS,     # "DCC_MCP_SKILL_PATHS"
+    ENV_LOG_LEVEL,       # "MCP_LOG_LEVEL"
+    SKILL_METADATA_FILE, # "SKILL.md"
+    SKILL_METADATA_DIR,  # "metadata"
+    SKILL_SCRIPTS_DIR,   # "scripts"
+)
+```
 
 ### Legacy APIs (DO NOT USE in new code)
 
-The README still references legacy Python-only APIs that were removed in v0.12+:
+These APIs were removed in v0.12+:
 - ~~`ActionManager`~~ → Use `ActionRegistry` + `ActionDispatcher`
-- ~~`Action` base class~~ → Actions are now registered via `ActionRegistry`
+- ~~`Action` base class~~ → Actions are registered via `ActionRegistry`
 - ~~`Middleware` / `MiddlewareChain`~~ → Use `ActionPipeline` with middleware context
 - ~~`create_action_manager()`~~ → Use `ActionRegistry()` directly
+- ~~`LoggingMiddleware` / `PerformanceMiddleware`~~ → Use `ActionMetrics` + `EventBus`
 
-## Skills System (How It Works)
+## Skills System (Deep Dive)
 
-Skills allow zero-code registration of scripts as MCP tools:
+Skills allow zero-code registration of scripts as MCP tools.
 
-1. Create a directory with `SKILL.md` (YAML frontmatter + markdown body) and `scripts/` folder
-2. Set `DCC_MCP_SKILL_PATHS` env var to point to skill directories
-3. Call `scan_and_load()` or use `ActionRegistry` which auto-loads from env
-4. Each script becomes an invocable action with `{skill_name}__{script_name}` naming
+### Directory Layout
 
-See `examples/skills/` for 10 complete examples covering Python, MEL, Shell, Batch, JavaScript.
+```
+my-skill/
+├── SKILL.md          # Required: YAML frontmatter + markdown description
+├── scripts/          # Required: one file per action
+│   ├── create_sphere.py
+│   ├── batch_rename.mel
+│   └── export_fbx.bat
+└── metadata/         # Optional
+    ├── help.md
+    ├── install.md
+    └── depends.md    # Dependency declarations (YAML list of skill names)
+```
+
+### SKILL.md Format
+
+```yaml
+---
+name: maya-geometry           # Required: unique identifier (used in action names)
+description: "Maya geometry creation and modification tools"
+tools: ["Bash", "Read"]       # OpenClaw tool permissions
+tags: ["maya", "geometry"]    # Classification tags
+dcc: maya                     # Target DCC application
+version: "1.0.0"              # Semantic version
+depends: ["other-skill"]      # Names of required skills
+---
+# Human-readable description (markdown body)
+```
+
+### Action Naming
+
+Each script in `scripts/` becomes an action named `{skill_name}__{script_stem}`:
+- `maya-geometry/scripts/create_sphere.py` → `maya_geometry__create_sphere`
+- `maya-geometry/scripts/batch_rename.mel` → `maya_geometry__batch_rename`
+
+Note: hyphens in skill names are replaced by underscores.
+
+### Environment Variable
+
+```bash
+# Unix/macOS
+export DCC_MCP_SKILL_PATHS="/path/to/skills1:/path/to/skills2"
+
+# Windows
+set DCC_MCP_SKILL_PATHS=C:\path\skills1;C:\path\skills2
+```
+
+### Supported Script Types
+
+| Extension | Type | Execution |
+|-----------|------|-----------|
+| `.py` | Python | `subprocess` with system Python |
+| `.mel` | MEL (Maya) | Via DCC adapter |
+| `.ms` | MaxScript | Via DCC adapter |
+| `.bat`, `.cmd` | Batch | `cmd /c` |
+| `.sh`, `.bash` | Shell | `bash` |
+| `.ps1` | PowerShell | `powershell -File` |
+| `.js`, `.jsx` | JavaScript | `node` |
+
+See `examples/skills/` for **9 complete examples**: hello-world, maya-geometry, maya-pipeline, git-automation, ffmpeg-media, imagemagick-tools, usd-tools, clawhub-compat, multi-script.
+
+## Adding New Python-Accessible Functions/Classes
+
+When adding a new public API (function or class exposed to Python):
+
+1. **Implement in Rust**: Add to the appropriate `crates/dcc-mcp-*/src/` crate
+2. **Add PyO3 bindings**: Create/update the crate's `python.rs` module with `#[pymethods]` / `#[pyclass]`
+3. **Register in entry point**: Add to `src/lib.rs` in the corresponding `register_*()` function
+4. **Re-export in Python**: Add to `python/dcc_mcp_core/__init__.py` and `__all__`
+5. **Update type stubs**: If needed, update `python/dcc_mcp_core/_core.pyi`
+6. **Add tests**: Create/update `tests/test_<module>.py`
+
+Example PyO3 binding pattern:
+
+```rust
+// crates/dcc-mcp-actions/src/python.rs
+use pyo3::prelude::*;
+
+#[pyclass]
+pub struct ActionRegistry { /* ... */ }
+
+#[pymethods]
+impl ActionRegistry {
+    #[new]
+    fn new() -> Self { ActionRegistry { /* ... */ } }
+
+    fn register(&self, name: String, description: String) -> PyResult<()> {
+        // ...
+    }
+}
+
+pub fn register_actions(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<ActionRegistry>()?;
+    Ok(())
+}
+```
 
 ## Commit & PR Guidelines
 
 - Use [Conventional Commits](https://www.conventionalcommits.org/)
 - Prefixes: `feat:`, `fix:`, `docs:`, `chore:`, `ci:`, `refactor:`, `test:`
 - Breaking changes: `feat!:` or add `BREAKING CHANGE:` footer
-- Never manually bump version or edit CHANGELOG.md (Release Please handles this)
+- **Never manually bump version or edit CHANGELOG.md** — Release Please handles this
 - Always run `vx just preflight` before committing
-- PR title format: follow Conventional Commits
+- PR title format: follow Conventional Commits (e.g., `docs: enhance AI agent guidance`)
 
 ## Common Pitfalls for AI Agents
 
-1. **Don't import from internal paths** like `dcc_mcp_core.actions.base` — these don't exist anymore. Use the public API from `dcc_mcp_core`.
-2. **Don't manually edit version numbers** — handled by Release Please.
-3. **Don't add runtime Python dependencies** — this project has zero runtime deps by design.
-4. **Rust changes need Python binding updates** — if you modify a Rust struct that's exposed via PyO3, update the corresponding `python.rs` file and potentially `_core.pyi` stubs.
-5. **Test with `--features python-bindings` when testing Rust-Python integration**.
-6. **Use `vx` prefix for all commands** in this project (e.g., `vx just test` not `pytest`).
+1. **Don't import from internal paths**: `dcc_mcp_core.actions.base`, `dcc_mcp_core._core.*` directly — these are implementation details. Always use the public API from `dcc_mcp_core`.
+
+2. **Don't manually bump version numbers** — handled exclusively by Release Please via `release-please-config.json`.
+
+3. **Don't add runtime Python dependencies** — this project has zero runtime deps by design. Everything is in Rust.
+
+4. **Rust changes need Python binding updates**: If you modify a Rust struct exposed via PyO3, update the crate's `python.rs`, register it in `src/lib.rs`, re-export in `__init__.py`, and update `_core.pyi` stubs.
+
+5. **Test with Python bindings feature flag**: `cargo test --workspace --features python-bindings`
+
+6. **Always use `vx` prefix**: `vx just test` not `pytest`, `vx just lint` not `ruff check`.
+
+7. **Don't use legacy APIs**: `ActionManager`, `Action` base class, `create_action_manager()`, `MiddlewareChain` — all removed in v0.12+.
+
+8. **Skills directory convention**: The env var is `DCC_MCP_SKILL_PATHS` (not `SKILL_PATHS`, not `DCC_SKILL_PATHS`).
+
+9. **Action naming**: When building tools on top of this library, use the `{skill_name}__{script_stem}` naming pattern (double underscore separator).
+
+10. **`_core.pyi` is the authoritative stub**: When unsure of parameter names or types, read `python/dcc_mcp_core/_core.pyi` rather than guessing.
+
+## Debugging & Diagnostics
+
+### Build Issues
+
+```bash
+# Check all crates compile
+vx just check
+
+# Verbose Rust build
+cargo build --workspace --features python-bindings 2>&1 | head -50
+
+# Python import check after build
+vx just dev
+python -c "import dcc_mcp_core; print(dcc_mcp_core.__version__)"
+```
+
+### Test Failures
+
+```bash
+# Verbose test output
+vx just test -- -v -s
+
+# Run a specific test by name
+vx just test -- -k "test_scan_and_load" -v
+
+# Check test coverage gaps
+vx just test-cov
+```
+
+### Type Stub Issues
+
+If Python type checkers report errors about `_core`:
+```bash
+# Stubs are in python/dcc_mcp_core/_core.pyi
+# They're manually maintained — check if your new symbol is listed
+grep "SkillMetadata" python/dcc_mcp_core/_core.pyi
+```
 
 ## CI/CD
 
 - Main branch is protected; all PRs must pass CI
 - CI runs: `preflight` → `install` → `test` → `lint-py`
+- CI matrix: Python 3.7, 3.9, 3.11, 3.13 on Linux/macOS/Windows
 - PyPI publishing uses Trusted Publishing (no tokens needed)
 - Documentation deploys to GitHub Pages via VitePress
+- `.agents/` directory is gitignored — use `git add -f` for skill files there
+
+## External References
+
+- [AGENTS.md specification](https://agents.md/) — open standard for AI agent guidance files
+- [llms.txt specification](https://llmstxt.org/) — AI-optimized documentation format
+- [Model Context Protocol](https://modelcontextprotocol.io/) — the underlying MCP standard
+- [PyO3 documentation](https://pyo3.rs/) — Rust-Python bindings used in this project
+- [maturin documentation](https://www.maturin.rs/) — Python wheel builder used for release
+- [OpenClaw Skills format](https://docs.openclaw.ai/tools) — SKILL.md ecosystem compatibility
+- [vx tool manager](https://github.com/loonghao/vx) — universal dev tool manager used in this project

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,7 @@
-# CLAUDE.md — dcc-mcp-core Instructions for Claude Code
+# CLAUDE.md — dcc-mcp-core Instructions for Claude
 
-> **Purpose**: Claude Code specific instructions. Complements AGENTS.md with Claude-specific guidance.
+> **Purpose**: Claude-specific instructions. Complements AGENTS.md with Claude-specific guidance.
+> Read AGENTS.md first for full project context, then this file.
 
 ## Project Identity
 
@@ -11,8 +12,10 @@ You are working on **dcc-mcp-core**, a Rust-powered MCP (Model Context Protocol)
 ### Before Making Changes
 
 1. Read `AGENTS.md` for full project context
-2. Current branch convention: `feat/`, `fix/`, `docs/`, `refactor/`
-3. Always run commands with `vx` prefix
+2. Read `python/dcc_mcp_core/__init__.py` for the complete public API surface
+3. Read `python/dcc_mcp_core/_core.pyi` for parameter names/types when unsure
+4. Current branch convention: `feat/`, `fix/`, `docs/`, `refactor/`, `chore/`
+5. Always run commands with `vx` prefix
 
 ### Essential Commands
 
@@ -21,39 +24,111 @@ vx just preflight     # Before committing (Rust check + clippy + fmt + test)
 vx just test          # Python tests
 vx just lint          # Full lint (Rust + Python)
 vx just dev           # Build dev wheel (needed before running Python tests)
+vx just lint-fix      # Auto-fix all lint issues
+vx just test-cov      # Coverage report to find gaps
 ```
 
 ### Architecture Summary
 
 - **11 Rust crates** under `crates/`, compiled into `_core` native extension
-- **~105 public Python symbols** exported from `python/dcc_mcp_core/__init__.py`
+- **~120 public Python symbols** exported from `python/dcc_mcp_core/__init__.py`
 - **Zero runtime Python deps** — all logic in Rust
 - Key entry point: `src/lib.rs` (PyO3 `#[pymodule]`)
+- Python 3.7–3.13 supported (CI tests 3.7–3.13)
 
-### When Working With This Codebase
+## Claude-Specific Workflows
 
-**Adding a new Python-accessible function/class:**
+### When Adding a New Python-Accessible Symbol
+
 1. Implement in the appropriate `crates/dcc-mcp-*/src/` Rust crate
-2. Add PyO3 bindings in the crate's `python.rs` module
-3. Register in `src/lib.rs` corresponding `register_*()` function
-4. Re-export in `python/dcc_mcp_core/__init__.py`
-5. Update type stubs if needed (`_core.pyi`)
-6. Add pytest tests in `tests/`
+2. Add PyO3 bindings in the crate's `python.rs` module (`#[pyclass]` / `#[pymethods]`)
+3. Register in `src/lib.rs` in the corresponding `register_*()` function
+4. Re-export in `python/dcc_mcp_core/__init__.py` (both import and `__all__`)
+5. Update `python/dcc_mcp_core/_core.pyi` stubs
+6. Add pytest tests in `tests/test_<module>.py`
 
-**Working with Skills:**
+### When Working With Skills
+
 - Skills are discovered via `SKILL.md` files in directories listed in `DCC_MCP_SKILL_PATHS`
 - Each skill's scripts become automatically registered actions
-- See `examples/skills/` for reference implementations
+- Action naming: `{skill_name}__{script_stem}` (double underscore, hyphens→underscores)
+- Use `scan_and_load()` or `scan_and_load_lenient()` — not the old `scan_and_load_skills()`
+- See `examples/skills/` for 9 reference implementations
 
-**Understanding the Transport layer:**
+### When Understanding the Transport Layer
+
 - Uses IPC (Unix socket / named pipe) for process communication
 - `TransportManager` manages connection pools with `CircuitBreaker` resilience
-- `FramedMessage` protocol for reliable message delivery
+- `FramedChannel` for reliable message delivery with message framing
+- Connect: `connect_ipc(address)` → `FramedChannel`
+- Listen: `IpcListener.new(address).start(handler_fn)` → `ListenerHandle`
+
+### When Exploring Unknown Symbols
+
+```bash
+# Check what's available in the public API
+grep -n "from dcc_mcp_core._core import" python/dcc_mcp_core/__init__.py
+
+# Find parameter signatures
+grep -A5 "class SkillMetadata" python/dcc_mcp_core/_core.pyi
+
+# Find Rust implementation
+grep -rn "SkillMetadata" crates/ --include="*.rs" | grep "pub struct\|pyclass"
+```
+
+### When Debugging Build/Import Issues
+
+```bash
+# Rebuild dev wheel
+vx just dev
+
+# Verify import works
+python -c "import dcc_mcp_core; print(dir(dcc_mcp_core))"
+
+# Check for PyO3 registration gaps (symbol in Rust but missing from Python)
+python -c "import dcc_mcp_core; print(hasattr(dcc_mcp_core, 'MyNewSymbol'))"
+
+# Verbose cargo build
+cargo build --workspace --features python-bindings 2>&1 | grep -E "error|warning" | head -30
+```
+
+### When Writing Tests
+
+```python
+# Import pattern for tests
+from __future__ import annotations
+import pytest
+from dcc_mcp_core import ActionResultModel, success_result, error_result
+
+# Skill tests: use tmp_path fixture + create minimal SKILL.md
+def test_skill_scan(tmp_path):
+    skill_dir = tmp_path / "my-skill"
+    (skill_dir / "scripts").mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: my-skill\ndcc: python\n---\n")
+    (skill_dir / "scripts" / "do_thing.py").write_text("print('hello')")
+
+    from dcc_mcp_core import parse_skill_md
+    meta = parse_skill_md(str(skill_dir))
+    assert meta is not None
+    assert meta.name == "my-skill"
+```
 
 ## Claude-Specific Tips
 
-- Prefer reading `__init__.py` over guessing imports — it has the complete public API surface
-- For large refactors across crates, use `cargo check --workspace` early to catch errors
-- The `justfile` has cross-platform recipes (Windows PowerShell + Unix sh)
-- When debugging Python-Rust binding issues, check `_core.pyi` stubs match actual PyO3 registrations
-- Use `vx just test-cov` to see coverage gaps before adding new features
+- **Prefer reading `__init__.py`** over guessing imports — it has the complete public API surface
+- **`_core.pyi` is the ground truth** for parameter names and types
+- **For large refactors**, use `cargo check --workspace` early to catch errors before building the full wheel
+- **The `justfile` is cross-platform**: recipes work on both Windows PowerShell and Unix sh
+- **When debugging Python-Rust binding issues**: check that the symbol is registered in `src/lib.rs` AND re-exported in `__init__.py` AND listed in `_core.pyi`
+- **Use `vx just test-cov`** to see coverage gaps before adding new features
+- **Don't use legacy APIs**: `ActionManager`, `create_action_manager()`, `MiddlewareChain`, `LoggingMiddleware` — all removed in v0.12+
+- **The project has zero runtime Python dependencies by design** — never add `dependencies = [...]` to `pyproject.toml`
+
+## Key Files to Read First (Priority Order)
+
+1. `python/dcc_mcp_core/__init__.py` — Complete public API (~120 symbols)
+2. `python/dcc_mcp_core/_core.pyi` — Type stubs with parameter names
+3. `AGENTS.md` — Full architecture, commands, pitfalls
+4. `crates/*/src/python.rs` — PyO3 binding implementations
+5. `src/lib.rs` — Module registration entry point
+6. `tests/` — Usage examples in test form

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 [中文文档](README_zh.md) | [English](README.md)
 
-Foundational library for the DCC Model Context Protocol (MCP) ecosystem. It provides a **Rust-powered core with Python bindings (PyO3)** that delivers high-performance action management, skills discovery, transport, sandbox security, shared memory, screen capture, USD support, and telemetry — all with **zero runtime Python dependencies**.
+Foundational library for the DCC Model Context Protocol (MCP) ecosystem. It provides a **Rust-powered core with Python bindings (PyO3)** that delivers high-performance action management, skills discovery, transport, sandbox security, shared memory, screen capture, USD support, and telemetry — all with **zero runtime Python dependencies**. Supports Python 3.7–3.13.
 
 > **Note**: This project is in active development (v0.12+). APIs may evolve; see CHANGELOG.md for version history.
 
@@ -20,7 +20,7 @@ Foundational library for the DCC Model Context Protocol (MCP) ecosystem. It prov
 | Feature | Description |
 |---------|-------------|
 | **Performance** | Rust core with zero-copy serialization via rmp-serde & LZ4 compression |
-| **Type Safety** | Full PyO3 bindings with comprehensive `.pyi` type stubs (~105 public symbols) |
+| **Type Safety** | Full PyO3 bindings with comprehensive `.pyi` type stubs (~120 public symbols) |
 | **Skills System** | Zero-code script registration as MCP tools (SKILL.md + scripts/) |
 | **Resilient Transport** | IPC with connection pooling, circuit breaker, retry policies |
 | **Process Management** | Launch, monitor, auto-recover DCC processes |
@@ -34,7 +34,7 @@ AI-friendly docs: [AGENTS.md](AGENTS.md) | [CLAUDE.md](CLAUDE.md) | [`.agents/sk
 ### Installation
 
 ```bash
-# From PyPI (pre-built wheels for Python 3.8+)
+# From PyPI (pre-built wheels for Python 3.7+)
 pip install dcc-mcp-core
 
 # Or from source (requires Rust toolchain)
@@ -210,7 +210,7 @@ result = registry.call("my_tool__list", some_param="value")
 | `.ps1` | PowerShell | `powershell -File` |
 | `.js`, `.jsx` | JavaScript | `node` |
 
-See `examples/skills/` for **10 complete examples**: hello-world, maya-geometry, maya-pipeline, git-automation, ffmpeg-media, imagemagick-tools, usd-tools, clawhub-compat, multi-script.
+See `examples/skills/` for **9 complete examples**: hello-world, maya-geometry, maya-pipeline, git-automation, ffmpeg-media, imagemagick-tools, usd-tools, clawhub-compat, multi-script.
 
 ## Architecture Overview
 
@@ -243,7 +243,7 @@ dcc-mcp-core is organized as a **Rust workspace of 11 crates**, compiled into a 
 - **Screen capture**: Cross-platform DCC viewport capture for AI visual feedback
 - **USD integration**: Universal Scene Description read/write bridge
 - **Structured telemetry**: Tracing & recording for observability
-- **~105 public Python symbols** with full type stubs (`.pyi`)
+- **~120 public Python symbols** with full type stubs (`.pyi`)
 - **OpenClaw Skills compatible**: Reuse existing ecosystem format
 
 ## Installation
@@ -461,7 +461,9 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 If you're an AI coding agent, also see:
 - **[AGENTS.md](AGENTS.md)** — Comprehensive guide for all AI agents (architecture, commands, API reference, pitfalls)
-- **[CLAUDE.md](CLAUDE.md)** — Claude Code specific instructions
+- **[CLAUDE.md](CLAUDE.md)** — Claude-specific instructions and workflows
 - **[.agents/skills/dcc-mcp-core/SKILL.md](.agents/skills/dcc-mcp-core/SKILL.md)** — Complete API skill definition for learning and using this library
-- **[python/dcc_mcp_core/__init__.py](python/dcc_mcp_core/__init__.py)** — Full public API surface (~105 symbols)
+- **[python/dcc_mcp_core/__init__.py](python/dcc_mcp_core/__init__.py)** — Full public API surface (~120 symbols)
+- **[llms.txt](llms.txt)** — Concise API reference optimized for LLMs
+- **[llms-full.txt](llms-full.txt)** — Complete API reference optimized for LLMs
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** — Development workflow and coding standards

--- a/README_zh.md
+++ b/README_zh.md
@@ -11,7 +11,7 @@
 
 [English](README.md) | [中文文档](README_zh.md)
 
-DCC 模型上下文协议（Model Context Protocol，MCP）生态系统的基础库。它提供 **Rust 核心引擎 + PyO3 Python 绑定**，交付高性能动作管理、技能发现、传输层、沙箱安全、共享内存、屏幕捕获、USD 支持和遥测 —— 所有这些均 **零运行时 Python 依赖**。
+DCC 模型上下文协议（Model Context Protocol，MCP）生态系统的基础库。提供 **Rust 核心引擎 + PyO3 Python 绑定**，交付高性能动作管理、技能发现、传输层、沙箱安全、共享内存、屏幕捕获、USD 支持和遥测 —— 所有这些均 **零运行时 Python 依赖**。
 
 > **注意**：本项目处于积极开发中（v0.12+）。API 可能会演进；版本历史请参阅 CHANGELOG.md。
 
@@ -20,7 +20,7 @@ DCC 模型上下文协议（Model Context Protocol，MCP）生态系统的基础
 | 特性 | 描述 |
 |------|------|
 | **高性能** | Rust 核心，rmp-serde 零拷贝序列化 & LZ4 压缩 |
-| **类型安全** | 完整的 PyO3 绑定 + 全面 `.pyi` 类型存根（约 105 个公共符号） |
+| **类型安全** | 完整的 PyO3 绑定 + 全面 `.pyi` 类型存根（约 120 个公共符号） |
 | **Skills 系统** | 零代码脚本注册为 MCP 工具（SKILL.md + scripts/） |
 | **弹性传输** | IPC + 连接池、熔断器、重试策略 |
 | **进程管理** | 启动/监控/自动恢复 DCC 进程 |
@@ -34,7 +34,7 @@ AI 友好文档：[AGENTS.md](AGENTS.md) | [CLAUDE.md](CLAUDE.md) | [`.agents/sk
 ### 安装
 
 ```bash
-# 从 PyPI 安装（预编译 wheel，支持 Python 3.8+）
+# 从 PyPI 安装（预编译 wheel，支持 Python 3.7+）
 pip install dcc-mcp-core
 
 # 或从源码安装（需要 Rust 工具链）
@@ -79,90 +79,6 @@ else:
     print(f"错误: {result.error}")
 ```
 
-## 包结构
-
-DCC-MCP-Core 组织为几个子包：
-
-- **actions**：动作管理和执行
-  - `base.py`：基础 Action 类定义
-  - `manager.py`：用于动作发现和执行的 ActionManager
-  - `registry.py`：用于注册和检索动作的 ActionRegistry
-  - `middleware.py`：用于横切关注点的中间件
-  - `events.py`：用于动作通信的事件系统
-
-- **models**：MCP 生态系统的数据模型
-  - `action_result.py`：动作的结构化结果模型
-
-- **skills**：Skills 技能包系统，零代码脚本注册
-  - `scanner.py`：SkillScanner 目录扫描，发现 SKILL.md 文件
-  - `loader.py`：SKILL.md 解析器和脚本枚举
-  - `script_action.py`：ScriptAction 工厂，动态生成 Action 子类
-
-- **utils**：实用函数和辅助工具
-  - `module_loader.py`：模块加载工具
-  - `filesystem.py`：文件系统操作
-  - `decorators.py`：用于错误处理的函数装饰器
-  - `dependency_injector.py`：依赖注入工具
-  - `template.py`：模板渲染工具
-  - `platform.py`：平台特定工具
-
-## 中间件系统
-
-DCC-MCP-Core 包含一个中间件系统，用于在动作执行前后插入自定义逻辑：
-
-```python
-from dcc_mcp_core.actions.middleware import LoggingMiddleware, PerformanceMiddleware, MiddlewareChain
-from dcc_mcp_core.actions.manager import ActionManager
-
-# 创建中间件链
-chain = MiddlewareChain()
-
-# 添加中间件（顺序很重要 - 先添加的先执行）
-chain.add(LoggingMiddleware)  # 记录动作执行详情
-chain.add(PerformanceMiddleware, threshold=0.5)  # 监控执行时间
-
-# 使用中间件链创建动作管理器
-manager = ActionManager("maya", middleware=chain.build())
-
-# 通过中间件链执行动作
-result = manager.call_action("create_sphere", radius=2.0)
-
-# 结果中将包含中间件添加的性能数据
-print(f"执行时间：{result.context['performance']['execution_time']:.2f}秒")
-```
-
-### 内置中间件
-
-- **LoggingMiddleware**：记录动作执行详情和计时
-- **PerformanceMiddleware**：监控执行时间并警告慢动作
-
-### 自定义中间件
-
-您可以通过继承 `Middleware` 基类来创建自定义中间件：
-
-```python
-from dcc_mcp_core.actions.middleware import Middleware
-from dcc_mcp_core.actions.base import Action
-from dcc_mcp_core.models import ActionResultModel
-
-class CustomMiddleware(Middleware):
-    def process(self, action: Action, **kwargs) -> ActionResultModel:
-        # 预处理逻辑
-        print(f"执行 {action.name} 之前")
-
-        # 调用链中的下一个中间件（或动作本身）
-        result = super().process(action, **kwargs)
-
-        # 后处理逻辑
-        print(f"执行 {action.name} 之后：{'成功' if result.success else '失败'}")
-
-        # 您可以根据需要修改结果
-        if result.success:
-            result.context["custom_data"] = "由中间件添加"
-
-        return result
-```
-
 ## 核心概念
 
 ### ActionResultModel — AI 友好的结构化结果
@@ -183,6 +99,25 @@ err = error_result(
     message="创建球体失败",
     error="半径必须为正数"
 )
+
+# 直接构造
+result = ActionResultModel(
+    success=True,
+    message="操作完成",
+    context={"key": "value"}
+)
+
+# 字段访问
+result.success   # bool
+result.message   # str
+result.prompt    # Optional[str] — AI 下一步建议
+result.error     # Optional[str] — 错误详情
+result.context   # dict — 任意结构化数据
+
+# 衍生新实例
+result.with_error("something failed")   # 新实例，success=False
+result.with_context(count=5)            # 新实例，带更新后的 context
+result.to_dict()                        # -> dict
 ```
 
 ### ActionRegistry 与调度器 — 动作系统
@@ -190,20 +125,55 @@ err = error_result(
 ```python
 from dcc_mcp_core import (
     ActionRegistry, ActionDispatcher, ActionValidator,
-    EventBus, SemVer
+    EventBus, SemVer, VersionedRegistry, VersionConstraint
 )
 
+# 带版本支持的注册表
 registry = ActionRegistry()
+registry.register(
+    name="my_action",
+    description="执行某操作",
+    dcc="maya",
+    version="1.0.0",
+    input_schema='{"type": "object", "properties": {"param": {"type": "string"}}}',
+)
+
+# 查询
+meta = registry.get_action("my_action")
+meta = registry.get_action("my_action", dcc_name="maya")  # DCC 作用域查找
+names = registry.list_actions_for_dcc("maya")
+all_actions = registry.list_actions()
+dccs = registry.get_all_dccs()
+
+# 带验证的调度器
 dispatcher = ActionDispatcher(registry, ActionValidator())
+result = dispatcher.call("my_action", param="value")
 
 # 事件驱动架构
 bus = EventBus()
-bus.subscribe("action.after_execute", lambda e: print(f"✓ {e.action_name}: {e.result.success}"))
+bus.subscribe("action.before_execute", my_pre_hook)
+bus.subscribe("action.after_execute", my_post_hook)
+bus.publish("action.before_execute", action_name="test")
+
+# 版本感知注册表
+vreg = VersionedRegistry()
+vreg.register("my_action", version=SemVer(1, 2, 0), handler=my_fn)
+handler = vreg.get("my_action", constraint=VersionConstraint.parse(">=1.0.0"))
 ```
 
 ## Skills 技能包系统 — 零代码 MCP 工具注册
 
-**Skills 系统**是 dcc-mcp-core 最独特的功能：让你将任何脚本**零代码**注册为 MCP 可发现工具。复用 [OpenClaw Skills](https://docs.openclaw.ai/tools) 生态格式。
+**Skills 系统**是 dcc-mcp-core 最独特的功能：让你将任何脚本（Python、MEL、MaxScript、BAT、Shell 等）**零代码**注册为 MCP 可发现工具。复用 [OpenClaw Skills](https://docs.openclaw.ai/tools) 生态格式。
+
+### 工作原理
+
+```
+SKILL.md（元数据）+ scripts/ 目录
+       ↓  SkillScanner 发现并解析
+每个技能包的 SkillMetadata（名称、描述、标签、脚本列表）
+       ↓  ScriptAction 工厂生成 Action
+动作注册到 ActionRegistry → AI 通过 MCP 可调用
+```
 
 ### 快速示例
 
@@ -223,20 +193,39 @@ my-tool/
 name: my-tool
 description: "我的自定义 DCC 自动化工具"
 tools: ["Bash"]
-tags: ["automation"]
+tags: ["automation", "custom"]
 dcc: maya
+version: "1.0.0"
 ---
-# 我的工具
+# My Tool
+
+Maya 工作流优化自动化脚本。
 ```
 
-**3. 使用：**
+**3. 设置环境变量并使用：**
 
 ```python
-import os; os.environ["DCC_MCP_SKILL_PATHS"] = "/path/to/my-tool"
-from dcc_mcp_core import scan_and_load
+import os
+os.environ["DCC_MCP_SKILL_PATHS"] = "/path/to/my-tool"
+
+from dcc_mcp_core import scan_and_load, ActionRegistry
+
+registry = ActionRegistry()
 skills = scan_and_load(dcc_name="maya")
-print(f"已加载 {len(skills)} 个技能包")
+for s in skills:
+    print(f"✓ {s.name}: {len(s.scripts)} 个脚本")
+
+# 调用 Skill 动作：{skill_name}__{script_stem}
+result = registry.call("my_tool__list", some_param="value")
 ```
+
+### 动作命名规则
+
+每个 `scripts/` 目录下的脚本成为一个动作，命名为 `{skill_name}__{script_stem}`：
+- `maya-geometry/scripts/create_sphere.py` → `maya_geometry__create_sphere`
+- `maya-geometry/scripts/batch_rename.mel` → `maya_geometry__batch_rename`
+
+注意：技能名称中的连字符会替换为下划线。
 
 ### 支持的脚本类型
 
@@ -250,236 +239,35 @@ print(f"已加载 {len(skills)} 个技能包")
 | `.ps1` | PowerShell | `powershell -File` |
 | `.js`, `.jsx` | JavaScript | `node` |
 
-查看 `examples/skills/` 获取 **10 个完整示例**。
+查看 `examples/skills/` 获取 **9 个完整示例**：hello-world、maya-geometry、maya-pipeline、git-automation、ffmpeg-media、imagemagick-tools、usd-tools、clawhub-compat、multi-script。
 
 ## 架构概览 — 11 个 Rust Crate 工作区
 
+dcc-mcp-core 组织为 **11 个 Rust Crate 工作区**，通过 PyO3/maturin 编译成单个原生 Python 扩展（`_core`）：
+
 | Crate | 职责 | 关键类型 |
-|----------------------|-----------|------------------|
+|-------|------|---------|
 | `dcc-mcp-models` | 数据模型 | `ActionResultModel`, `SkillMetadata` |
-| `dcc-mcp-actions` | 动作生命周期 | `ActionRegistry`, `EventBus`, `ActionDispatcher`, `ActionPipeline` |
+| `dcc-mcp-actions` | 动作生命周期 | `ActionRegistry`, `EventBus`, `ActionDispatcher`, `ActionValidator`, `ActionPipeline` |
 | `dcc-mcp-skills` | 技能发现 | `SkillScanner`, `SkillWatcher`, 依赖解析器 |
-| `dcc-mcp-protocols` | MCP 协议 | `ToolDefinition`, `ResourceDefinition`, `DccAdapter` |
-| `dcc-mcp-transport` | IPC 通信 | `TransportManager`, `ConnectionPool`, `CircuitBreaker`, `FramedChannel` |
+| `dcc-mcp-protocols` | MCP 协议类型 | `ToolDefinition`, `ResourceDefinition`, `DccAdapter` |
+| `dcc-mcp-transport` | IPC 通信 | `TransportManager`, `ConnectionPool`, `IpcListener`, `FramedChannel`, `CircuitBreaker` |
 | `dcc-mcp-process` | 进程管理 | `PyDccLauncher`, `ProcessMonitor`, `CrashRecoveryPolicy` |
 | `dcc-mcp-sandbox` | 安全沙箱 | `SandboxPolicy`, `InputValidator`, `AuditLog` |
 | `dcc-mcp-shm` | 共享内存 | `SharedBuffer`, LZ4 压缩 |
 | `dcc-mcp-capture` | 屏幕捕获 | `Capturer`, 跨平台后端 |
-| `dcc-mcp-telemetry` | 可观测性 | `TelemetryConfig`, tracing |
-| `dcc-mcp-usd` | USD 场景 | `UsdStage`, `UsdPrim` |
+| `dcc-mcp-telemetry` | 可观测性 | `TelemetryConfig`, `ActionMetrics`, tracing |
+| `dcc-mcp-usd` | USD 场景 | `UsdStage`, `UsdPrim`, 场景信息桥接 |
+| `dcc-mcp-utils` | 基础设施 | 文件系统、类型封装、常量、JSON |
 
-```python
-ActionResultModel(
-    success=True,
-    message="成功创建球体",
-    prompt="现在您可以修改球体的属性或添加材质",
-    error=None,
-    context={
-        "object_name": "sphere_1.0",
-        "position": [0, 0, 0]
-    }
-)
-```
-
-### 字段
-
-- **success**：布尔值，表示动作是否成功
-- **message**：人类可读的结果消息
-- **prompt**：关于下一步操作的建议
-- **error**：当 success 为 False 时的错误消息
-- **context**：包含额外上下文数据的字典
-
-### 方法
-
-- **to_dict()**：将模型转换为字典，具有版本无关的兼容性（兼容 Pydantic v1 和 v2）
-- **model_dump()** / **dict()**：原生 Pydantic 序列化方法（版本相关）
-
-### 使用示例
-
-```python
-# 创建结果模型
-result = ActionResultModel(
-    success=True,
-    message="操作完成",
-    prompt="下一步建议",
-    context={"key": "value"}
-)
-
-# 转换为字典（版本无关）
-result_dict = result.to_dict()
-
-# 访问字段
-if result.success:
-    print(f"成功：{result.message}")
-    if result.prompt:
-        print(f"下一步：{result.prompt}")
-    print(f"上下文数据：{result.context}")
-else:
-    print(f"错误：{result.error}")
-```
-
-## 功能特性
-
-- 基于类的 Action 设计，使用 Pydantic 模型
-- 参数验证和类型检查
-- 带有上下文和提示的结构化结果格式
-- 动态动作发现和加载
-- 用于横切关注点的中间件支持
-- 用于动作通信的事件系统
-- 异步动作执行
-- 全面的错误处理
-- **Skills 技能包系统**：零代码将脚本（MEL、MaxScript、BAT、Shell、Python）注册为 MCP 工具
-- **兼容 OpenClaw**：直接复用 OpenClaw Skills 生态格式（SKILL.md + scripts/）
-
-## Skills 技能包系统
-
-Skills 系统允许你将任何脚本（Python、MEL、MaxScript、BAT、Shell 等）零代码注册为 MCP 可发现的工具。直接复用 [OpenClaw Skills](https://docs.openclaw.ai/tools) 生态格式。
-
-### 快速上手
-
-1. **创建 Skill 目录**，包含 `SKILL.md` 和 `scripts/` 文件夹：
-
-```
-maya-geometry/
-├── SKILL.md
-└── scripts/
-    ├── create_sphere.py
-    ├── batch_rename.mel
-    └── export_fbx.bat
-```
-
-2. **编写 SKILL.md**（标准 OpenClaw 格式）：
-
-```yaml
----
-name: maya-geometry
-description: "Maya 几何体创建和修改工具"
-tools: ["Bash", "Read"]
-tags: ["maya", "geometry"]
----
-# Maya Geometry Skill
-
-使用这些工具在 Maya 中创建和修改几何体。
-```
-
-3. **设置环境变量**指向 Skills 目录：
-
-```bash
-# Linux/macOS
-export DCC_MCP_SKILL_PATHS="/path/to/my-skills"
-
-# Windows
-set DCC_MCP_SKILL_PATHS=C:\path\to\my-skills
-
-# 多路径（使用平台路径分隔符）
-export DCC_MCP_SKILL_PATHS="/path/skills1:/path/skills2"
-```
-
-4. **完成！** 脚本自动被发现并注册为 MCP 工具：
-
-```python
-from dcc_mcp_core import create_action_manager
-
-manager = create_action_manager("maya")
-# DCC_MCP_SKILL_PATHS 中的 Skills 自动加载
-
-# 调用 Skill Action
-result = manager.call_action("maya_geometry__create_sphere", radius=2.0)
-```
-
-### 支持的脚本类型
-
-| 扩展名 | 类型 | 执行方式 |
-|--------|------|---------|
-| `.py` | Python | 通过系统 Python `subprocess` 执行 |
-| `.mel` | MEL (Maya) | 通过 context 中的 DCC 适配器执行 |
-| `.ms` | MaxScript | 通过 context 中的 DCC 适配器执行 |
-| `.bat`, `.cmd` | Batch | `cmd /c` |
-| `.sh`, `.bash` | Shell | `bash` |
-| `.ps1` | PowerShell | `powershell -File` |
-| `.js`, `.jsx` | JavaScript | `node` |
-
-### 工作原理
-
-1. **SkillScanner** 扫描目录寻找 `SKILL.md` 文件
-2. **SkillLoader** 解析 YAML frontmatter 并枚举 `scripts/` 目录
-3. **ScriptAction 工厂** 为每个脚本动态生成 Action 子类
-4. Action 注册到现有的 **ActionRegistry**
-5. MCP Server 层可通过 **EventBus** 订阅 `skill.loaded` 事件
-
-## 主要特性
-
-- **Rust 高性能引擎**：rmp-serde 零拷贝序列化、LZ4 共享内存、无锁并发结构
-- **零运行时 Python 依赖**：全部编译进原生扩展
-- **Skills 系统**：零代码 MCP 工具注册（SKILL.md + scripts/）
-- **验证调度**：执行前输入参数验证管道
-- **弹性 IPC**：连接池、熔断器、自动重试
-- **进程管理**：启动/监控/自动恢复 DCC 进程
-- **沙箱安全**：基于策略的访问控制 + 审计日志
-- **屏幕捕获**：跨平台 DCC 视口捕获，AI 视觉反馈
-- **USD 集成**：通用场景描述读写桥接
-- **结构化遥测**：Tracing & 录制可观测性
-- **~105 个 Python 公共符号** + 完整 `.pyi` 类型存根
-- **兼容 OpenClaw Skills**：直接复用生态格式
-
-## 安装
-
-```bash
-# 从 PyPI 安装（预编译 wheel，支持 Python 3.8+）
-pip install dcc-mcp-core
-
-# 或从源码安装（需要 Rust 1.85+ 工具链）
-git clone https://github.com/loonghao/dcc-mcp-core.git
-cd dcc-mcp-core
-pip install -e .
-```
-
-## 开发环境设置
-
-```bash
-# 克隆仓库
-git clone https://github.com/loonghao/dcc-mcp-core.git
-cd dcc-mcp-core
-
-# 推荐：使用 vx（通用开发工具管理器）
-# 安装: https://github.com/loonghao/vx
-vx just install     # 安装所有项目依赖
-vx just dev         # 构建安装开发 wheel
-vx just test       # 运行 Python 测试
-vx just lint       # 全量 lint（Rust + Python）
-```
-
-### 不使用 vx
-
-```bash
-python -m venv venv
-source venv/bin/activate   # Windows: venv\Scripts\activate
-pip install maturin pytest pytest-cov ruff mypy
-maturin develop --features python-bindings,ext-module
-pytest tests/ -v
-ruff check python/ tests/ examples/
-cargo clippy --workspace -- -D warnings
-```
-
-## 运行测试
-
-```bash
-vx just test           # 所有 Python 测试
-vx just test-rust       # 所有 Rust 单元测试
-vx just test-cov        # 带覆盖率报告
-vx just ci              # 完整 CI 流水线
-vx just preflight       # 仅 pre-commit 检查
-```
+## 更多功能
 
 ### 传输层 — IPC 进程通信
-
-dcc-mcp-core 提供生产级 IPC 传输层：
 
 ```python
 from dcc_mcp_core import (
     TransportManager, TransportAddress, TransportScheme,
-    RoutingStrategy, IpcListener, connect_ipc,
-    FramedChannel
+    RoutingStrategy, IpcListener, connect_ipc, FramedChannel
 )
 
 # 服务端：监听连接
@@ -490,7 +278,7 @@ handle = listener.start(handler_fn=my_message_handler)
 channel = connect_ipc("/tmp/dcc-mcp-server.sock")
 response = channel.call({"method": "ping", "params": {}})
 
-# 高级：连接池 + 弹性
+# 高级：连接池 + 弹性熔断
 mgr = TransportManager()
 mgr.configure_pool(min_size=2, max_size=10)
 mgr.set_circuit_breaker(threshold=5, reset_timeout=30)
@@ -515,7 +303,7 @@ process = launcher.launch(
 # 监控健康状态
 monitor = PyProcessMonitor()
 monitor.track(process)
-stats = monitor.stats(process)
+stats = monitor.stats(process)  # CPU、内存、运行时间
 
 # 崩溃后自动重启
 watcher = PyProcessWatcher(
@@ -552,9 +340,73 @@ for entry in audit.entries:
     print(f"{entry.timestamp} [{entry.action}] {entry.decision} → {entry.details}")
 ```
 
+## 主要特性
+
+- **Rust 高性能引擎**：rmp-serde 零拷贝序列化、LZ4 共享内存、无锁并发结构
+- **零运行时 Python 依赖**：全部编译进原生扩展
+- **Skills 系统**：零代码 MCP 工具注册（SKILL.md + scripts/）
+- **验证调度**：执行前输入参数验证管道
+- **弹性 IPC**：连接池、熔断器、自动重试
+- **进程管理**：启动/监控/自动恢复 DCC 进程
+- **沙箱安全**：基于策略的访问控制 + 审计日志
+- **屏幕捕获**：跨平台 DCC 视口捕获，AI 视觉反馈
+- **USD 集成**：通用场景描述读写桥接
+- **结构化遥测**：Tracing & 录制可观测性
+- **~120 个 Python 公共符号** + 完整 `.pyi` 类型存根
+- **兼容 OpenClaw Skills**：直接复用生态格式
+
+## 安装
+
+```bash
+# 从 PyPI 安装（预编译 wheel，支持 Python 3.7+）
+pip install dcc-mcp-core
+
+# 或从源码安装（需要 Rust 1.85+ 工具链）
+git clone https://github.com/loonghao/dcc-mcp-core.git
+cd dcc-mcp-core
+pip install -e .
+```
+
+## 开发环境设置
+
+```bash
+# 克隆仓库
+git clone https://github.com/loonghao/dcc-mcp-core.git
+cd dcc-mcp-core
+
+# 推荐：使用 vx（通用开发工具管理器）
+# 安装: https://github.com/loonghao/vx
+vx just install     # 安装所有项目依赖
+vx just dev         # 构建安装开发 wheel
+vx just test        # 运行 Python 测试
+vx just lint        # 全量 lint（Rust + Python）
+```
+
+### 不使用 vx
+
+```bash
+python -m venv venv
+source venv/bin/activate   # Windows: venv\Scripts\activate
+pip install maturin pytest pytest-cov ruff mypy
+maturin develop --features python-bindings,ext-module
+pytest tests/ -v
+ruff check python/ tests/ examples/
+cargo clippy --workspace -- -D warnings
+```
+
+## 运行测试
+
+```bash
+vx just test           # 所有 Python 测试
+vx just test-rust      # 所有 Rust 单元测试
+vx just test-cov       # 带覆盖率报告
+vx just ci             # 完整 CI 流水线
+vx just preflight      # 仅 pre-commit 检查
+```
+
 ## 更多示例
 
-查看 [`examples/skills/`](examples/skills/) 目录获取 **10 个完整技能包示例**，以及 [VitePress 文档站](https://loonghao.github.io/dcc-mcp-core/) 获取各模块完整指南。
+查看 [`examples/skills/`](examples/skills/) 目录获取 **9 个完整技能包示例**，以及 [VitePress 文档站](https://loonghao.github.io/dcc-mcp-core/) 获取各模块完整指南。
 
 ## 版本发布流程
 
@@ -571,7 +423,7 @@ for entry in audit.entries:
 |------|------|---------|
 | `feat:` | 新功能 | Minor (`0.x.0`) |
 | `fix:` | Bug 修复 | Patch (`0.0.x`) |
-| `feat!:` | 破坏性变更 | Major (`x.0.0`) |
+| `feat!:` 或 `BREAKING CHANGE:` | 破坏性变更 | Major (`x.0.0`) |
 | `docs:` / `chore:` / `ci:` / `refactor:` / `test:` | 不触发发布 |
 
 ## 贡献
@@ -592,7 +444,9 @@ for entry in audit.entries:
 ## AI Agent 资源
 
 如果你是 AI 编码代理，请同时参考：
-- **[AGENTS.md](AGENTS.md)** — 所 AI 代理综合指南（架构、命令、API 参考、陷阱规避）
-- **[CLAUDE.md](CLAUDE.md)** — Claude Code 专用指令
+- **[AGENTS.md](AGENTS.md)** — 所有 AI 代理综合指南（架构、命令、API 参考、陷阱规避）
+- **[CLAUDE.md](CLAUDE.md)** — Claude 专用指令
 - **[.agents/skills/dcc-mcp-core/SKILL.md](.agents/skills/dcc-mcp-core/SKILL.md)** — 完整 API 技能定义，用于学习与使用此库
-- **[python/dcc_mcp_core/__init__.py](python/dcc_mcp_core/__init__.py)** — 完整公共 API 表面（约 105 个符号）
+- **[python/dcc_mcp_core/__init__.py](python/dcc_mcp_core/__init__.py)** — 完整公共 API 表面（约 120 个符号）
+- **[llms.txt](llms.txt)** — 精简 API 参考（LLM 优化格式）
+- **[llms-full.txt](llms-full.txt)** — 完整 API 参考（LLM 优化格式）

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # dcc-mcp-core
 
-> Foundational library for the DCC Model Context Protocol (MCP) ecosystem. Rust-powered core (via PyO3) providing action registry, structured results, event bus, skills/script registration, and MCP protocol type definitions for Digital Content Creation applications (Maya, Blender, Houdini, etc.).
+> Foundational library for the DCC Model Context Protocol (MCP) ecosystem. Rust-powered core (via PyO3) providing action registry, structured results, event bus, skills/script registration, MCP protocol types, IPC transport, process management, sandbox security, shared memory, screen capture, USD bridge, and telemetry for Digital Content Creation applications (Maya, Blender, Houdini, 3ds Max, etc.).
 
 ## Quick Start
 
@@ -13,7 +13,7 @@ reg.register(name="create_sphere", description="Create a sphere", dcc="maya")
 meta = reg.get_action("create_sphere")
 
 # Structured results
-result = dcc_mcp_core.success_result("Created sphere", count=1)
+result = dcc_mcp_core.success_result("Created sphere", prompt="Add materials next", count=1)
 error = dcc_mcp_core.error_result("Failed", "File not found")
 
 # Event bus
@@ -21,75 +21,164 @@ bus = dcc_mcp_core.EventBus()
 bus.subscribe("evt", lambda **kw: print(kw))
 bus.publish("evt", x=1)
 
-# Skill scanning
+# Skill scanning + loading
+skills = dcc_mcp_core.scan_and_load(dcc_name="maya")  # raises on parse errors
+skills = dcc_mcp_core.scan_and_load_lenient(dcc_name="maya")  # silently skips bad skills
+for s in skills:
+    print(f"{s.name}: {len(s.scripts)} scripts")
+
+# Low-level scan
 scanner = dcc_mcp_core.SkillScanner()
 dirs = scanner.scan(extra_paths=["/path/to/skills"], dcc_name="maya")
-meta = dcc_mcp_core.parse_skill_md(dirs[0])
+meta = dcc_mcp_core.parse_skill_md(dirs[0])  # -> SkillMetadata or None
 ```
 
 ## Installation
 
 - PyPI: `pip install dcc-mcp-core`
 - Build from source: `maturin develop --features python-bindings,ext-module`
-- Python: >=3.9 (CI tests 3.9–3.13)
-- Build: maturin (Rust + PyO3)
+- Python: >=3.7 (CI tests 3.7–3.13; abi3-py38 wheel for 3.8+)
+- Build: maturin (Rust 1.85+ + PyO3)
+- Version: 0.12.x
 - License: MIT
 
 ## Architecture
 
-Rust workspace with PyO3 bindings. All logic in Rust sub-crates; Python gets a single `dcc_mcp_core._core` extension module.
+Rust workspace (11 crates) with PyO3 bindings. All logic in Rust sub-crates; Python gets a single `dcc_mcp_core._core` extension module. The `dcc_mcp_core` package re-exports all ~120 public symbols from `_core`.
 
 ```
 crates/
 ├── dcc-mcp-models/      # ActionResultModel, SkillMetadata
-├── dcc-mcp-actions/     # ActionRegistry, EventBus
-├── dcc-mcp-skills/      # SkillScanner, parse_skill_md
-├── dcc-mcp-protocols/   # MCP type definitions (Tool, Resource, Prompt)
-└── dcc-mcp-utils/       # Filesystem, constants, type wrappers, logging
+├── dcc-mcp-actions/     # ActionRegistry, ActionDispatcher, ActionValidator, EventBus, ActionPipeline
+├── dcc-mcp-skills/      # SkillScanner, SkillWatcher, parse_skill_md, dependency resolver
+├── dcc-mcp-protocols/   # MCP type definitions (Tool, Resource, Prompt, DccAdapter)
+├── dcc-mcp-transport/   # IPC transport, ConnectionPool, CircuitBreaker, FramedChannel
+├── dcc-mcp-process/     # PyDccLauncher, ProcessMonitor, ProcessWatcher, CrashRecovery
+├── dcc-mcp-telemetry/   # TelemetryConfig, RecordingGuard, ActionMetrics, ActionRecorder
+├── dcc-mcp-sandbox/     # SandboxPolicy, InputValidator, AuditLog
+├── dcc-mcp-shm/         # PyBufferPool, PySharedBuffer, LZ4 compression
+├── dcc-mcp-capture/     # Capturer, CaptureFrame, CaptureResult
+├── dcc-mcp-usd/         # UsdStage, UsdPrim, SdfPath, scene info bridge
+└── dcc-mcp-utils/       # Filesystem, constants, type wrappers, JSON conversion
 ```
 
 ## Core Concepts
 
-- **ActionRegistry**: Thread-safe registry for action metadata (name, description, dcc, tags, schemas)
-- **ActionResultModel**: Structured result (success, message, prompt, error, context dict)
+- **ActionRegistry**: Thread-safe registry for action metadata (name, description, dcc, tags, schemas, version)
+- **ActionResultModel**: Structured result (success, message, prompt, error, context dict) — AI-friendly with next-step hints
 - **EventBus**: Thread-safe publish/subscribe system with per-event subscriber lists
 - **SkillScanner**: Discovers SKILL.md files in directories with mtime-based caching
-- **SkillMetadata**: Parsed from SKILL.md YAML frontmatter (name, dcc, tags, scripts, depends)
+- **SkillMetadata**: Parsed from SKILL.md YAML frontmatter (name, dcc, tags, scripts, depends, version)
 - **MCP Protocol Types**: ToolDefinition, ResourceDefinition, PromptDefinition, ToolAnnotations
+- **ActionDispatcher**: Typed dispatch with validation via ActionValidator
+- **VersionedRegistry**: SemVer-aware action registry with constraint-based lookup
 
 ## Key APIs
 
 ### Top-level exports (`dcc_mcp_core`)
-- `ActionRegistry` — Thread-safe registry; `.register(name, ...)`, `.get_action(name)`, `.list_actions()`
-- `ActionResultModel` — Structured result: success, message, prompt, error, context
+
+**Actions:**
+- `ActionRegistry` — Thread-safe registry; `.register(name, ...)`, `.get_action(name)`, `.list_actions()`, `.list_actions_for_dcc(dcc)`, `.get_all_dccs()`, `.reset()`
+- `ActionDispatcher` — Validated dispatch; `.call(name, **kwargs) -> ActionResultModel`
+- `ActionValidator` — Input validation before action execution
+- `ActionPipeline` — Middleware-style processing pipeline
+- `ActionMetrics` — Performance and execution metrics collection
+- `ActionRecorder` — Record/replay action executions
+- `EventBus` — `.subscribe(event, callback) -> id`, `.unsubscribe(event, id)`, `.publish(event, **kwargs)`
+- `VersionedRegistry` — SemVer-aware registry with constraint lookup
+- `SemVer(major, minor, patch)` — Semantic version value object
+- `VersionConstraint.parse(">=1.0.0")` — Version constraint expression
+
+**Result Factories:**
 - `success_result(message, prompt=None, **context) -> ActionResultModel`
 - `error_result(message, error, prompt=None, possible_solutions=None, **context) -> ActionResultModel`
-- `from_exception(error_message, message=None, ...) -> ActionResultModel`
-- `validate_action_result(result) -> ActionResultModel`
-- `EventBus` — `.subscribe(event, callback)`, `.unsubscribe(event, id)`, `.publish(event, **kwargs)`
+- `from_exception(error_message, message=None, include_traceback=False, ...) -> ActionResultModel`
+- `validate_action_result(result) -> ActionResultModel` — normalize dict/str/None → ActionResultModel
+
+**ActionResultModel fields:** `.success`, `.message`, `.prompt`, `.error`, `.context`, `.to_dict()`, `.with_error(err)`, `.with_context(**kw)`
+
+**Skills:**
 - `SkillScanner` — `.scan(extra_paths=None, dcc_name=None, force_refresh=False) -> List[str]`
+- `SkillWatcher` — File-watching auto-reload for live development
 - `parse_skill_md(skill_dir) -> Optional[SkillMetadata]`
 - `scan_skill_paths(extra_paths=None, dcc_name=None) -> List[str]`
+- `scan_and_load(dcc_name=None, extra_paths=None) -> List[SkillMetadata]`
+- `scan_and_load_lenient(dcc_name=None, extra_paths=None) -> List[SkillMetadata]`
+- `resolve_dependencies(skills) -> List[SkillMetadata]`
+- `expand_transitive_dependencies(skills) -> List[SkillMetadata]`
+- `validate_dependencies(skills) -> bool`
+
+**SkillMetadata fields:** `.name`, `.description`, `.dcc`, `.version`, `.tags`, `.tools`, `.scripts` (List[str] absolute paths), `.skill_path`, `.depends`, `.metadata_files`
+
+**Action naming**: `{skill_name}__{script_stem}` — hyphens in skill names replaced by underscores
 
 ### MCP Protocol Types (`dcc_mcp_core`)
+
 - `ToolDefinition(name, description, input_schema, output_schema=None, annotations=None)`
-- `ToolAnnotations(title=None, read_only_hint=None, destructive_hint=None, ...)`
+- `ToolAnnotations(title=None, read_only_hint=None, destructive_hint=None, idempotent_hint=None, open_world_hint=None)`
 - `ResourceDefinition(uri, name, description, mime_type="text/plain")`
 - `ResourceTemplateDefinition(uri_template, name, description, mime_type="text/plain")`
 - `PromptDefinition(name, description, arguments=None)`
 - `PromptArgument(name, description, required=False)`
+- `DccInfo`, `DccCapabilities`, `DccError`, `DccErrorCode`
+
+### Transport (`dcc_mcp_core`)
+
+- `IpcListener.new(address)` → `.start(handler_fn) -> ListenerHandle`
+- `connect_ipc(address) -> FramedChannel`
+- `TransportManager` — connection pool + circuit breaker
+- `TransportAddress`, `TransportScheme`, `RoutingStrategy`
+
+### Process Management (`dcc_mcp_core`)
+
+- `PyDccLauncher(dcc_type, version)` → `.launch(script_path, working_dir, env_vars) -> process`
+- `PyProcessMonitor()` → `.track(process)`, `.stats(process)`
+- `PyProcessWatcher(recovery_policy)` → `.watch(process)`
+- `PyCrashRecoveryPolicy(max_restarts, cooldown_sec)`
+- `ScriptResult`, `ScriptLanguage`
+
+### Sandbox (`dcc_mcp_core`)
+
+- `SandboxPolicy.builder().allow_read([...]).allow_write([...]).deny_pattern([...]).build()`
+- `SandboxContext(policy)`, `InputValidator(ctx)`, `AuditLog.load()`, `AuditEntry`
+
+### Telemetry (`dcc_mcp_core`)
+
+- `TelemetryConfig`, `RecordingGuard`, `ActionMetrics`, `ActionRecorder`
+- `is_telemetry_initialized() -> bool`, `shutdown_telemetry()`
+
+### Shared Memory (`dcc_mcp_core`)
+
+- `PyBufferPool`, `PySharedBuffer`, `PySharedSceneBuffer`, `PySceneDataKind`
+
+### Capture (`dcc_mcp_core`)
+
+- `Capturer`, `CaptureFrame`, `CaptureResult`
+
+### USD (`dcc_mcp_core`)
+
+- `UsdStage`, `UsdPrim`, `SdfPath`, `VtValue`, `SceneInfo`, `SceneStatistics`
+- `scene_info_json_to_stage(json_str) -> UsdStage`
+- `stage_to_scene_info_json(stage) -> str`
+- `mpu_to_units(value)`, `units_to_mpu(value)`
+
+### Type Wrappers (`dcc_mcp_core`)
+
+- `wrap_value(v)` / `unwrap_value(v)` — RPyC-safe type wrappers
+- `unwrap_parameters(params_dict)` — unwrap all wrapper values in a dict
+- `BooleanWrapper`, `FloatWrapper`, `IntWrapper`, `StringWrapper`
 
 ### Utility Functions (`dcc_mcp_core`)
+
 - `get_config_dir()`, `get_data_dir()`, `get_log_dir()`, `get_platform_dir(dir_type)`
 - `get_actions_dir(dcc_name)`, `get_skills_dir(dcc_name=None)`
-- `get_skill_paths_from_env() -> List[str]`
-- `wrap_value(value)` / `unwrap_value(value)` — RPyC type safety wrappers
-- `unwrap_parameters(params_dict)` — Unwrap all wrapper values in a dict
+- `get_skill_paths_from_env() -> List[str]` — reads `DCC_MCP_SKILL_PATHS`
 
 ### Constants (`dcc_mcp_core`)
+
 - `APP_NAME = "dcc-mcp"`, `APP_AUTHOR = "dcc-mcp"`
-- `DEFAULT_DCC = "python"`, `DEFAULT_LOG_LEVEL = "DEBUG"`
-- `SKILL_METADATA_FILE = "SKILL.md"`, `SKILL_SCRIPTS_DIR = "scripts"`
+- `DEFAULT_DCC = "python"`, `DEFAULT_LOG_LEVEL = "DEBUG"`, `DEFAULT_MIME_TYPE = "text/plain"`, `DEFAULT_VERSION = "1.0.0"`
+- `SKILL_METADATA_FILE = "SKILL.md"`, `SKILL_SCRIPTS_DIR = "scripts"`, `SKILL_METADATA_DIR = "metadata"`
 - `ENV_SKILL_PATHS = "DCC_MCP_SKILL_PATHS"`, `ENV_LOG_LEVEL = "MCP_LOG_LEVEL"`
 
 ## Skills System
@@ -97,16 +186,36 @@ crates/
 Register scripts as MCP tools with zero Python code via SKILL.md.
 
 ### Directory Structure
+
 ```
 maya-geometry/
 ├── SKILL.md          # YAML frontmatter + description
 ├── scripts/
 │   ├── create_sphere.py
-│   └── batch_rename.py
-└── metadata/         # Optional: help.md, install.md, depends.md
+│   └── batch_rename.mel
+└── metadata/         # Optional
+    ├── help.md
+    ├── install.md
+    └── depends.md    # YAML list of dependency skill names
+```
+
+### SKILL.md Format
+
+```yaml
+---
+name: maya-geometry
+description: "Maya geometry creation tools"
+tools: ["Bash", "Read"]
+tags: ["maya", "geometry"]
+dcc: maya
+version: "1.0.0"
+depends: ["other-skill"]  # optional
+---
+# Markdown description body
 ```
 
 ### Supported Script Types
+
 | Extension | Type |
 |-----------|------|
 | `.py` | Python |
@@ -118,17 +227,21 @@ maya-geometry/
 | `.js`, `.jsx` | JavaScript |
 
 ### Environment Variable
+
 ```bash
 export DCC_MCP_SKILL_PATHS="/path/to/skills1:/path/to/skills2"
+# Windows: set DCC_MCP_SKILL_PATHS=C:\skills1;C:\skills2
 ```
 
 ## Documentation
 
 - [README (English)](https://github.com/loonghao/dcc-mcp-core/blob/main/README.md)
 - [README (中文)](https://github.com/loonghao/dcc-mcp-core/blob/main/README_zh.md)
+- [AI Agent Guide (AGENTS.md)](https://github.com/loonghao/dcc-mcp-core/blob/main/AGENTS.md)
 - [Contributing Guide](https://github.com/loonghao/dcc-mcp-core/blob/main/CONTRIBUTING.md)
 - [Changelog](https://github.com/loonghao/dcc-mcp-core/blob/main/CHANGELOG.md)
 - [Full API Reference](https://github.com/loonghao/dcc-mcp-core/blob/main/llms-full.txt)
+- [VitePress Docs](https://loonghao.github.io/dcc-mcp-core/)
 
 ## Development
 


### PR DESCRIPTION
## Summary

Comprehensive documentation update to improve how AI agents understand and use this project. All changes are documentation-only (no code changes).

## Changes

### `AGENTS.md`
- Add full API code examples for all major domains (Actions, Skills, Transport, Process, Sandbox, Telemetry, USD, Type Wrappers)
- Document new v0.12+ symbols: `ActionMetrics`, `ActionRecorder`, `VersionedRegistry`, `SemVer`, `VersionConstraint`, `ServiceEntry`, `ServiceStatus`, `PySceneDataKind`, `SceneInfo`, `SceneStatistics`
- Add diagnostics guide (build issues, test failures, type stub issues)
- Add external references section (AGENTS.md spec, llms.txt spec, MCP, PyO3, maturin, vx)
- Fix Python version to 3.7–3.13 (was incorrectly 3.8+)
- Fix symbol count to ~120 (was ~105)
- Add action naming convention (`{skill_name}__{script_stem}`)

### `CLAUDE.md`
- Add Claude-specific workflows for exploring unknown symbols, debugging builds, writing tests
- Add priority reading order for key files
- Add cross-platform tips (justfile recipes)
- Clarify `_core.pyi` as ground truth for parameter names

### `llms.txt`
- Comprehensive rewrite with all 11 Rust crates documented
- Add transport, process, sandbox, telemetry, shared memory, capture, USD, type wrappers, constants sections
- Add action naming convention
- Fix Python/version info

### `README.md`
- Fix Python version (3.7+), symbol count (~120), example count (9)
- Add `llms.txt` and `llms-full.txt` to AI Agent Resources section

### `README_zh.md`
- Full rewrite removing all legacy API references (`ActionManager`, `MiddlewareChain`, `LoggingMiddleware`, `create_action_manager()`)
- Align completely with current `README.md` content and v0.12+ API
- Add `VersionedRegistry`, `SemVer`, `VersionConstraint` examples
- Add `llms.txt` and `llms-full.txt` to AI Agent Resources section

### `.agents/skills/dcc-mcp-core/SKILL.md`
- Bump version to 0.12.4
- Fix f-string bug in code example (`print(f"Error: result.error}")`)
- Update symbol count (~120) and example count (9)

## Motivation

The previous `README_zh.md` still referenced removed legacy APIs (`ActionManager`, middleware system) which would confuse AI agents trying to use this library. The `AGENTS.md` and `llms.txt` were missing many new symbols added in v0.12+ and had incorrect Python version information.