### PR TITLE
docs: fix API correctness and enhance AI agent guidance (Run #4)

### DIFF
--- a/.agents/skills/dcc-mcp-core/SKILL.md
+++ b/.agents/skills/dcc-mcp-core/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: dcc-mcp-core
-description: "Foundation library for the DCC Model Context Protocol (MCP) ecosystem. Provides Rust-powered action management, skills system, transport layer, sandbox security, shared memory, screen capture, USD scene support, and telemetry for AI-assisted DCC workflows."
-tools: ["Bash", "Read", "Write", "Edit"]
-tags: ["mcp", "dcc", "rust", "pyo3", "maya", "blender", "houdini", "ai", "skills", "actions"]
-version: "0.12.5"
+description: "Foundation library for the DCC Model Context Protocol (MCP) ecosystem. Provides Rust-powered action management, skills system, transport layer, sandbox security, shared memory, screen capture, USD scene support, and telemetry for AI-assisted DCC workflows. Use when working with Maya, Blender, Houdini, 3ds Max, or any DCC MCP integration."
+allowed-tools: ["Bash", "Read", "Write", "Edit"]
+compatibility: "Python 3.7-3.13; Rust 1.85+ required to build from source; zero runtime Python dependencies"
+version: "0.12.6"
 ---
 
 # dcc-mcp-core — DCC MCP Ecosystem Foundation
@@ -120,13 +120,16 @@ if not ok:
 from dcc_mcp_core import TransportAddress, connect_ipc, success_result, error_result
 
 addr = TransportAddress.default_local("maya", pid=12345)
-channel = connect_ipc(addr, timeout_ms=10000)
+channel = connect_ipc(addr)
 try:
-    result = channel.call("execute_python", params=b'import maya.cmds; cmds.sphere()')
-    if result["success"]:
-        return success_result(result["payload"].decode())
+    # FramedChannel uses send_request() + recv(); there is no .call() method
+    req_id = channel.send_request("execute_python", params=b'import maya.cmds; cmds.sphere()')
+    msg = channel.recv(timeout_ms=10000)  # blocks until response
+    if msg and msg.get("type") == "response":
+        payload = msg.get("payload", b"")
+        return success_result(payload.decode() if isinstance(payload, bytes) else str(payload))
     else:
-        return error_result("DCC call failed", result["error"] or "")
+        return error_result("DCC call failed", "No response received")
 finally:
     channel.shutdown()
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@
 - **Build system**: `cargo` (Rust) + `maturin` (Python wheels)
 - **Python package**: `dcc_mcp_core` with ~120 public symbols re-exported from `_core` native extension
 - **Zero runtime Python dependencies** — everything is compiled into the Rust core
-- **Version**: 0.12.x (use Release Please for versioning — never manually bump)
+- **Version**: 0.12.6 (use Release Please for versioning — never manually bump)
 - **Python support**: 3.7–3.13 (CI tests 3.7–3.13; abi3-py38 wheel for 3.8+)
 
 ## Repository Structure
@@ -64,7 +64,7 @@ dcc-mcp-core/
 │   ├── _core.pyi               # Type stubs (auto-generated-ish) — ground truth for parameter names
 │   └── py.typed                # PEP 561 marker
 │
-├── tests/                      # Python integration tests (19 files)
+├── tests/                      # Python integration tests (26 files)
 ├── examples/skills/            # 9 example SKILL.md packages (hello-world, maya-*, git-*, etc.)
 ├── docs/                       # VitePress documentation site (EN + ZH)
 │   ├── api/                    # API reference per module
@@ -704,18 +704,22 @@ from dcc_mcp_core import (
 
 def call_maya_command(pid: int, python_code: str):
     addr = TransportAddress.default_local("maya", pid)
-    channel = connect_ipc(addr, timeout_ms=10000)
+    channel = connect_ipc(addr)
     try:
-        result = channel.call("execute_python", params=python_code.encode())
-        if result["success"]:
+        # FramedChannel: use send_request() + recv(); there is no .call() method
+        req_id = channel.send_request("execute_python", params=python_code.encode())
+        msg = channel.recv(timeout_ms=10000)
+        if msg and msg.get("type") == "response":
+            payload = msg.get("payload", b"")
+            decoded = payload.decode() if isinstance(payload, bytes) else str(payload)
             return success_result(
-                result["payload"].decode(),
+                decoded,
                 prompt="Command executed. Check result and decide next step.",
             )
         else:
             return error_result(
                 "DCC script failed",
-                result["error"] or "unknown error",
+                "No response or unexpected message type",
                 possible_solutions=["Check Maya is running", "Verify syntax"],
             )
     except Exception as e:
@@ -786,7 +790,54 @@ for entry in ctx.audit_log.entries():
 - [llms.txt specification](https://llmstxt.org/) — AI-optimized documentation format by Answer.AI
 - [Model Context Protocol](https://modelcontextprotocol.io/) — the underlying MCP standard (Anthropic)
 - [MCP Agent Skills](https://modelcontextprotocol.io/docs/develop/build-with-agent-skills) — SKILL.md ecosystem and agent skills spec
+- [Agent Skills Specification](https://agentskills.io/specification) — official SKILL.md frontmatter format and best practices
 - [PyO3 documentation](https://pyo3.rs/) — Rust-Python bindings used in this project
 - [maturin documentation](https://www.maturin.rs/) — Python wheel builder used for release
 - [OpenClaw Skills format](https://docs.openclaw.ai/tools) — SKILL.md ecosystem compatibility
 - [vx tool manager](https://github.com/loonghao/vx) — universal dev tool manager used in this project
+
+## When Stuck
+
+If you are uncertain about how to proceed, follow these steps **in order** — do NOT make large speculative changes:
+
+1. **Read the type stubs first**: `python/dcc_mcp_core/_core.pyi` has authoritative parameter names, types, and docstrings with inline examples.
+2. **Read the public API**: `python/dcc_mcp_core/__init__.py` lists every public symbol — if it's not there, it doesn't exist.
+3. **Check the tests**: `tests/` directory contains executable usage examples for every major API. Run `vx just test -- -k "test_your_keyword" -v` to see a specific example.
+4. **Ask clarifying questions** rather than guessing: e.g., "Does `ActionDispatcher` have a `.call()` method?" — answer: No, use `.dispatch(action_name, params_json)`.
+5. **Run `cargo check --workspace`** early when adding Rust code to catch errors before a full build.
+6. **Do not** hallucinate method names — every public method is documented in `_core.pyi`.
+
+### Quick Lookup: Common Method Signatures
+
+```python
+# ActionDispatcher — only .dispatch(), never .call()
+dispatcher = ActionDispatcher(registry)   # takes ONE arg (no validator)
+result = dispatcher.dispatch("action_name", json.dumps({"key": "value"}))
+
+# scan_and_load — always returns a 2-TUPLE
+skills, skipped = scan_and_load(dcc_name="maya")   # unpack both
+
+# success_result — kwargs become context, NOT "context=" keyword
+result = success_result("message", prompt="hint", count=5, name="sphere1")
+# result.context == {"count": 5, "name": "sphere1"}
+
+# error_result — positional args (message, error), NOT keyword "message=" / "error="
+result = error_result("Failed", "specific error details")
+
+# EventBus.subscribe returns an int ID for unsubscribe
+sub_id = bus.subscribe("event_name", handler_fn)
+bus.unsubscribe("event_name", sub_id)
+```
+
+## PR Checklist
+
+Before opening a PR, verify:
+
+- [ ] `vx just preflight` passes (Rust check + clippy + fmt + test-rust)
+- [ ] `vx just test` passes (all Python tests)
+- [ ] `vx just lint` passes (clippy + fmt-check + ruff)
+- [ ] No new runtime Python dependencies added to `pyproject.toml`
+- [ ] If Rust structs changed: updated `python.rs`, `src/lib.rs`, `__init__.py`, `_core.pyi`
+- [ ] PR title follows Conventional Commits format (`docs:`, `feat:`, `fix:`, etc.)
+- [ ] No manual version bumps (Release Please handles this)
+- [ ] `.agents/` skill files added with `git add -f` (they are gitignored)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,8 +67,36 @@ skills, skipped = scan_and_load(dcc_name="maya")
 - Uses IPC (Unix socket / named pipe) for process communication
 - `TransportManager` manages connection pools with `CircuitBreaker` resilience
 - `FramedChannel` for reliable message delivery with message framing
-- Connect: `connect_ipc(address)` → `FramedChannel`
-- Listen: `IpcListener.new(address).start(handler_fn)` → `ListenerHandle`
+- Connect (client): `connect_ipc(address) -> FramedChannel`
+- Listen (server): `IpcListener.new(address)` → `.start(handler_fn) -> ListenerHandle`
+  - Note: `start()` is the method name (not `.bind()` + `.accept()`)
+
+### Quick Lookup: Common Method Signatures
+
+```python
+# ActionDispatcher — only .dispatch(), never .call()
+dispatcher = ActionDispatcher(registry)   # takes ONE arg; no validator param
+result = dispatcher.dispatch("action_name", json.dumps({"key": "value"}))
+# result keys: "action", "output", "validation_skipped"
+
+# scan_and_load — ALWAYS returns a 2-TUPLE
+skills, skipped = scan_and_load(dcc_name="maya")   # never: skills = scan_and_load(...)
+
+# success_result — extra kwargs go into context, NOT "context=" keyword arg
+result = success_result("message", prompt="hint", count=5)
+# result.context == {"count": 5}
+
+# error_result — positional args
+result = error_result("Failed", "specific error string")
+
+# EventBus.subscribe returns int ID
+sub_id = bus.subscribe("event_name", handler_fn)
+bus.unsubscribe("event_name", sub_id)
+
+# ActionRegistry.register — takes keyword args, NOT handler=
+registry.register(name="action", description="...", dcc="maya", version="1.0.0")
+# Use dispatcher.register_handler() to attach a Python callable
+```
 
 ### When Exploring Unknown Symbols
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -34,7 +34,7 @@ vx just lint-fix     # Auto-fix all lint issues
 - **~120 public Python symbols** exported from `python/dcc_mcp_core/__init__.py`
 - **Zero runtime Python deps** — all logic in Rust, no `dependencies = [...]` in pyproject.toml
 - Python 3.7–3.13 supported (abi3-py38 wheel; separate non-abi3 wheel for 3.7)
-- Version: 0.12.x — managed by Release Please, never manually bump
+- Version: **0.12.6** — managed by Release Please, never manually bump
 
 ## Gemini-Specific Workflows
 
@@ -128,9 +128,13 @@ Action naming: `{skill_name}__{script_stem}` (hyphens → underscores, `__` sepa
 5. **Build before testing**: `vx just dev` before `vx just test`
 6. **Use vx prefix**: `vx just test` not `pytest`, `vx just lint` not `ruff check`
 7. **Legacy APIs removed in v0.12+**: `ActionManager`, `Action` base class, `create_action_manager()`, `MiddlewareChain`
-8. **scan_and_load returns tuple**: `(List[SkillMetadata], List[str])` — unpack both
+8. **scan_and_load returns tuple**: `(List[SkillMetadata], List[str])` — unpack both — `skills = scan_and_load(...)` is WRONG
 9. **`_core.pyi` is authoritative**: When unsure of param names/types, read stubs first
 10. **`.agents/` is gitignored**: Use `git add -f` for files there
+11. **`ActionDispatcher` takes ONE arg**: `ActionDispatcher(registry)` — no `validator=` param; method is `.dispatch(name, json_str)` not `.call()`
+12. **`success_result` kwargs → context**: `success_result("msg", count=5)` → `context={"count":5}` — do NOT use `context=` keyword
+13. **`error_result` positional args**: `error_result("msg", "error string")` — not `error_result(message=..., error=...)`
+14. **`EventBus.subscribe` returns int**: Store the return value to unsubscribe later: `sub_id = bus.subscribe(...)`
 
 ## CI/CD Summary
 

--- a/README.md
+++ b/README.md
@@ -46,37 +46,43 @@ pip install -e .
 ### Basic Usage
 
 ```python
+import json
 from dcc_mcp_core import (
-    ActionRegistry, ActionDispatcher, ActionValidator,
-    EventBus, ActionResultModel, success_result, scan_and_load
+    ActionRegistry, ActionDispatcher,
+    EventBus, success_result, scan_and_load
 )
 
-# 1. Create action registry and load skills from environment
-registry = ActionRegistry()
-skills = scan_and_load(dcc_name="maya")
+# 1. Load skills; scan_and_load returns a 2-tuple (skills, skipped_dirs)
+skills, skipped = scan_and_load(dcc_name="maya")
 print(f"Loaded {len(skills)} skills")
 
-# 2. Set up validated dispatch
-validator = ActionValidator()
-dispatcher = ActionDispatcher(registry, validator)
+# 2. Register actions from discovered skills
+registry = ActionRegistry()
+from pathlib import Path
+for skill in skills:
+    for script_path in skill.scripts:
+        stem = Path(script_path).stem
+        action_name = f"{skill.name.replace('-', '_')}__{stem}"
+        registry.register(name=action_name, description=skill.description, dcc=skill.dcc)
 
-# 3. Subscribe to lifecycle events
-bus = EventBus()
-bus.subscribe("action.after_execute", lambda e: print(f"✓ {e.action_name}: {e.result.success}"))
-
-# 4. Call an action with automatic validation
-result = dispatcher.call(
+# 3. Set up dispatcher and register a handler
+dispatcher = ActionDispatcher(registry)
+dispatcher.register_handler(
     "maya_geometry__create_sphere",
-    radius=2.0,
-    position=[1, 0, 0]
+    lambda params: {"object_name": "pSphere1", "radius": params.get("radius", 1.0)},
 )
 
-if result.success:
-    print(f"Created: {result.context.get('object_name')}")
-    if result.prompt:
-        print(f"Suggestion: {result.prompt}")
-else:
-    print(f"Error: {result.error}")
+# 4. Subscribe to lifecycle events
+bus = EventBus()
+bus.subscribe("action.after_execute", lambda **kw: print(f"event: {kw}"))
+
+# 5. Dispatch an action
+result = dispatcher.dispatch(
+    "maya_geometry__create_sphere",
+    json.dumps({"radius": 2.0}),
+)
+output = result["output"]
+print(f"Created: {output.get('object_name')}")
 ```
 
 ## Core Concepts
@@ -90,14 +96,15 @@ from dcc_mcp_core import ActionResultModel, success_result, error_result
 
 # Factory functions (recommended)
 ok = success_result(
-    message="Sphere created",
+    "Sphere created",
     prompt="Consider adding materials or adjusting UVs",
-    context={"object_name": "sphere1", "position": [0, 1, 0]}
+    object_name="sphere1", position=[0, 1, 0]
 )
+# ok.context == {"object_name": "sphere1", "position": [0, 1, 0]}
 
 err = error_result(
-    message="Failed to create sphere",
-    error="Radius must be positive"
+    "Failed to create sphere",
+    "Radius must be positive"
 )
 
 # Direct construction
@@ -118,24 +125,27 @@ result.context      # dict — arbitrary structured data
 ### ActionRegistry & Dispatcher — The Action System
 
 ```python
+import json
 from dcc_mcp_core import (
     ActionRegistry, ActionDispatcher, ActionValidator,
     EventBus, SemVer, VersionedRegistry
 )
 
-# Registry with version support
+# Registry with search support
 registry = ActionRegistry()
-registry.register("my_action", version=SemVer(0, 1, 0), handler=my_handler)
+registry.register("my_action", description="My action", category="tools", version="1.0.0")
 
-# Validated dispatcher
-dispatcher = ActionDispatcher(registry, ActionValidator())
-result = dispatcher.call("my_action", param1="value")
+# Validated dispatcher (takes only registry; validate separately with ActionValidator)
+dispatcher = ActionDispatcher(registry)
+dispatcher.register_handler("my_action", lambda params: {"done": True})
+result = dispatcher.dispatch("my_action", json.dumps({}))
+# result == {"action": "my_action", "output": {"done": True}, "validation_skipped": True}
 
 # Event-driven architecture
 bus = EventBus()
-bus.subscribe("action.before_execute", my_pre_hook)
-bus.subscribe("action.after_execute", my_post_hook)
+sub_id = bus.subscribe("action.before_execute", lambda **kw: print(f"before: {kw}"))
 bus.publish("action.before_execute", action_name="test")
+bus.unsubscribe("action.before_execute", sub_id)
 ```
 
 ## Skills System — Zero-Code MCP Tool Registration

--- a/README_zh.md
+++ b/README_zh.md
@@ -46,37 +46,43 @@ pip install -e .
 ### 基本用法
 
 ```python
+import json
 from dcc_mcp_core import (
-    ActionRegistry, ActionDispatcher, ActionValidator,
-    EventBus, ActionResultModel, success_result, scan_and_load
+    ActionRegistry, ActionDispatcher,
+    EventBus, success_result, scan_and_load
 )
 
-# 1. 创建动作注册表并从环境变量加载 Skills
-registry = ActionRegistry()
-skills = scan_and_load(dcc_name="maya")
+# 1. 加载 Skills；scan_and_load 返回 2-tuple (skills, skipped_dirs)
+skills, skipped = scan_and_load(dcc_name="maya")
 print(f"已加载 {len(skills)} 个技能包")
 
-# 2. 设置带验证的调度器
-validator = ActionValidator()
-dispatcher = ActionDispatcher(registry, validator)
+# 2. 将发现的 Skills 注册到 ActionRegistry
+registry = ActionRegistry()
+from pathlib import Path
+for skill in skills:
+    for script_path in skill.scripts:
+        stem = Path(script_path).stem
+        action_name = f"{skill.name.replace('-', '_')}__{stem}"
+        registry.register(name=action_name, description=skill.description, dcc=skill.dcc)
 
-# 3. 订阅生命周期事件
-bus = EventBus()
-bus.subscribe("action.after_execute", lambda e: print(f"✓ {e.action_name}: {e.result.success}"))
-
-# 4. 调用动作（自动验证参数）
-result = dispatcher.call(
+# 3. 创建调度器并注册处理函数
+dispatcher = ActionDispatcher(registry)
+dispatcher.register_handler(
     "maya_geometry__create_sphere",
-    radius=2.0,
-    position=[1, 0, 0]
+    lambda params: {"object_name": "pSphere1", "radius": params.get("radius", 1.0)},
 )
 
-if result.success:
-    print(f"已创建: {result.context.get('object_name')}")
-    if result.prompt:
-        print(f"建议: {result.prompt}")
-else:
-    print(f"错误: {result.error}")
+# 4. 订阅生命周期事件
+bus = EventBus()
+bus.subscribe("action.after_execute", lambda **kw: print(f"事件: {kw}"))
+
+# 5. 调度动作
+result = dispatcher.dispatch(
+    "maya_geometry__create_sphere",
+    json.dumps({"radius": 2.0}),
+)
+output = result["output"]
+print(f"已创建: {output.get('object_name')}")
 ```
 
 ## 核心概念
@@ -90,14 +96,15 @@ from dcc_mcp_core import ActionResultModel, success_result, error_result
 
 # 工厂函数（推荐）
 ok = success_result(
-    message="球体已创建",
+    "球体已创建",
     prompt="考虑添加材质或调整 UV",
-    context={"object_name": "sphere1", "position": [0, 1, 0]}
+    object_name="sphere1", position=[0, 1, 0]
 )
+# ok.context == {"object_name": "sphere1", "position": [0, 1, 0]}
 
 err = error_result(
-    message="创建球体失败",
-    error="半径必须为正数"
+    "创建球体失败",
+    "半径必须为正数"
 )
 
 # 直接构造
@@ -123,8 +130,9 @@ result.to_dict()                        # -> dict
 ### ActionRegistry 与调度器 — 动作系统
 
 ```python
+import json
 from dcc_mcp_core import (
-    ActionRegistry, ActionDispatcher, ActionValidator,
+    ActionRegistry, ActionDispatcher,
     EventBus, SemVer, VersionedRegistry, VersionConstraint
 )
 
@@ -145,20 +153,25 @@ names = registry.list_actions_for_dcc("maya")
 all_actions = registry.list_actions()
 dccs = registry.get_all_dccs()
 
-# 带验证的调度器
-dispatcher = ActionDispatcher(registry, ActionValidator())
-result = dispatcher.call("my_action", param="value")
+# 带验证的调度器（ActionDispatcher 只接受 registry）
+dispatcher = ActionDispatcher(registry)
+dispatcher.register_handler("my_action", lambda params: {"done": True, "param": params.get("param")})
+result = dispatcher.dispatch("my_action", json.dumps({"param": "value"}))
+# result == {"action": "my_action", "output": {"done": True, "param": "value"}, "validation_skipped": False}
 
 # 事件驱动架构
 bus = EventBus()
-bus.subscribe("action.before_execute", my_pre_hook)
-bus.subscribe("action.after_execute", my_post_hook)
+sub_id = bus.subscribe("action.before_execute", lambda **kw: print(f"before: {kw}"))
 bus.publish("action.before_execute", action_name="test")
+bus.unsubscribe("action.before_execute", sub_id)
 
 # 版本感知注册表
 vreg = VersionedRegistry()
-vreg.register("my_action", version=SemVer(1, 2, 0), handler=my_fn)
-handler = vreg.get("my_action", constraint=VersionConstraint.parse(">=1.0.0"))
+vreg.register_versioned("my_action", dcc="maya", version="1.2.0")
+vreg.register_versioned("my_action", dcc="maya", version="2.0.0")
+result_v = vreg.resolve("my_action", dcc="maya", constraint=">=1.0.0")   # → version "2.0.0"
+result_v1 = vreg.resolve("my_action", dcc="maya", constraint="^1.0.0")  # → version "1.2.0"
+latest = vreg.latest_version("my_action", dcc="maya")                    # → "2.0.0"
 ```
 
 ## Skills 技能包系统 — 零代码 MCP 工具注册

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1487,12 +1487,15 @@ from dcc_mcp_core import TransportAddress, connect_ipc, success_result, error_re
 addr = TransportAddress.default_local("maya", pid=12345)
 channel = connect_ipc(addr)
 try:
-    result = channel.call("execute_python", params=b'import maya.cmds; print(maya.cmds.ls())')
-    if result["success"]:
-        output = result["payload"].decode()
+    # FramedChannel API: send_request() + recv(); there is no .call() method
+    req_id = channel.send_request("execute_python", params=b'import maya.cmds; print(maya.cmds.ls())')
+    msg = channel.recv(timeout_ms=10000)
+    if msg and msg.get("type") == "response":
+        payload = msg.get("payload", b"")
+        output = payload.decode() if isinstance(payload, bytes) else str(payload)
         r = success_result(output, prompt="Objects listed. You can now select one to modify.")
     else:
-        r = error_result("DCC script failed", result["error"] or "unknown")
+        r = error_result("DCC script failed", "No response or unexpected message type")
 finally:
     channel.shutdown()
 ```

--- a/llms.txt
+++ b/llms.txt
@@ -56,7 +56,7 @@ meta = dcc_mcp_core.parse_skill_md(dirs[0])  # -> SkillMetadata or None
 - Build from source: `maturin develop --features python-bindings,ext-module`
 - Python: >=3.7 (CI tests 3.7–3.13; abi3-py38 wheel for 3.8+)
 - Build: maturin (Rust 1.85+ + PyO3)
-- Version: 0.12.x
+- Version: 0.12.6
 - License: MIT
 
 ## Architecture
@@ -145,8 +145,9 @@ crates/
 
 ### Transport (`dcc_mcp_core`)
 
-- `IpcListener.new(address)` → `.start(handler_fn) -> ListenerHandle`
-- `connect_ipc(address) -> FramedChannel`
+- `IpcListener.bind(address) -> IpcListener` → `.accept() -> FramedChannel` (server-side)
+- `connect_ipc(address) -> FramedChannel` (client-side)
+- `FramedChannel` — `.send_request(method, params=None) -> req_id`, `.recv(timeout_ms=None) -> dict|None`, `.ping() -> int`, `.shutdown()`
 - `TransportManager` — connection pool + circuit breaker
 - `TransportAddress`, `TransportScheme`, `RoutingStrategy`
 


### PR DESCRIPTION
## Summary

This PR fixes multiple **API correctness bugs** in documentation and enhances AI agent guidance based on the official Agent Skills specification and AGENTS.md best practices.

## Bug Fixes (API Correctness)

All of these would cause AI agents to generate broken code:

### `FramedChannel` — no `.call()` method
- **Wrong**: `channel.call("execute_python", params=b"...")`
- **Correct**: `channel.send_request("execute_python", params=b"...")` + `channel.recv(timeout_ms=...)`
- Fixed in: `AGENTS.md` Pattern 2, `llms-full.txt` Pattern 2, `.agents/skills/dcc-mcp-core/SKILL.md` Pattern 4

### `ActionDispatcher` — one arg, no `.call()` method
- **Wrong**: `ActionDispatcher(registry, ActionValidator())` + `dispatcher.call("name", key=val)`
- **Correct**: `ActionDispatcher(registry)` (one arg) + `dispatcher.dispatch("name", json.dumps({...}))`
- Fixed in: `README.md`, `README_zh.md`

### `scan_and_load` — returns 2-tuple
- **Wrong**: `skills = scan_and_load(...)` then `len(skills)`
- **Correct**: `skills, skipped = scan_and_load(...)` then `len(skills)`
- Fixed in: `README.md`, `README_zh.md`

### `success_result` / `error_result` — positional args
- **Wrong**: `success_result(message="...", context={...})`
- **Correct**: `success_result("...", count=5)` (extra kwargs become context)
- Fixed in: `README.md`, `README_zh.md`

## Documentation Enhancements

### AGENTS.md
- Updated version to 0.12.6, test file count to 26
- Added **Agent Skills specification** link to External References
- Added **"When Stuck" section** with step-by-step guidance (per official AGENTS.md best practices)
- Added **PR Checklist** section
- Added **Quick Lookup: Common Method Signatures** to prevent common mistakes

### CLAUDE.md
- Added **Quick Lookup: Common Method Signatures** section
- Fixed IpcListener API description

### GEMINI.md
- Updated version to 0.12.6
- Expanded Common Pitfalls from 10 to 14 items covering `ActionDispatcher.call()`, `success_result` kwargs, `error_result` positional args, `EventBus.subscribe` return value

### `.agents/skills/dcc-mcp-core/SKILL.md`
- Updated `tools:` → `allowed-tools:` per official [Anthropic Agent Skills specification](https://agentskills.io/specification)
- Added `compatibility:` field (Python 3.7-3.13 requirement)
- Updated version to 0.12.6
- Improved `description` to include trigger context ("Use when working with Maya, Blender...")

## Research Sources
- [Agent Skills official specification](https://agentskills.io/specification) — frontmatter fields, `allowed-tools` vs `tools`
- [AGENTS.md best practices](https://agentsmd.io/agents-md-best-practices) — required sections including "When Stuck"
- `python/dcc_mcp_core/_core.pyi` — authoritative source for all API signatures verified