### PR TITLE
docs: update AI agent guidance for v0.12.7 — McpHttpServer, FramedChannel.call(), 12 crates

### DIFF
--- a/.agents/skills/dcc-mcp-core/SKILL.md
+++ b/.agents/skills/dcc-mcp-core/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: dcc-mcp-core
-description: "Foundation library for the DCC Model Context Protocol (MCP) ecosystem. Provides Rust-powered action management, skills system, transport layer, sandbox security, shared memory, screen capture, USD scene support, and telemetry for AI-assisted DCC workflows. Use when working with Maya, Blender, Houdini, 3ds Max, or any DCC MCP integration."
+description: "Foundation library for the DCC Model Context Protocol (MCP) ecosystem. Provides Rust-powered action management, skills system, IPC transport, MCP Streamable HTTP server, sandbox security, shared memory, screen capture, USD scene support, and telemetry for AI-assisted DCC workflows. Use when working with Maya, Blender, Houdini, 3ds Max, or any DCC MCP integration."
 allowed-tools: ["Bash", "Read", "Write", "Edit"]
 compatibility: "Python 3.7-3.13; Rust 1.85+ required to build from source; zero runtime Python dependencies"
-version: "0.12.6"
+version: "0.12.7"
 ---
 
 # dcc-mcp-core — DCC MCP Ecosystem Foundation
@@ -19,6 +19,7 @@ The foundational library enabling AI assistants to interact with Digital Content
 | Validate params | `ActionValidator.from_schema_json()` | isinstance checks |
 | Connect to DCC | `connect_ipc(TransportAddress.default_local(...))` | raw sockets |
 | Define MCP tool | `ToolDefinition` + `ToolAnnotations` | raw JSON |
+| Serve MCP over HTTP | `McpHttpServer(registry, McpHttpConfig(port=8765))` | raw HTTP server |
 
 ## What This Library Does
 
@@ -27,6 +28,7 @@ The foundational library enabling AI assistants to interact with Digital Content
 | **Action Management** | Register, validate, dispatch, and execute actions with typed inputs/outputs |
 | **Skills System** | Zero-code script registration (Python/MEL/Batch/Shell/JS) as MCP tools via `SKILL.md` |
 | **Transport Layer** | High-performance IPC with connection pooling, circuit breaker, retry policies |
+| **MCP HTTP Server** | MCP Streamable HTTP (2025-03-26 spec) powered by axum/Tokio, runs in background thread |
 | **Process Management** | Launch, monitor, auto-recover DCC processes (Maya, Blender, Houdini, etc.) |
 | **Sandbox Security** | Policy-based access control, input validation, audit logging |
 | **Shared Memory** | LZ4-compressed inter-process data exchange for large scenes |
@@ -122,19 +124,35 @@ from dcc_mcp_core import TransportAddress, connect_ipc, success_result, error_re
 addr = TransportAddress.default_local("maya", pid=12345)
 channel = connect_ipc(addr)
 try:
-    # FramedChannel uses send_request() + recv(); there is no .call() method
-    req_id = channel.send_request("execute_python", params=b'import maya.cmds; cmds.sphere()')
-    msg = channel.recv(timeout_ms=10000)  # blocks until response
-    if msg and msg.get("type") == "response":
-        payload = msg.get("payload", b"")
+    # Primary RPC: .call() sends request + waits for correlated response (v0.12.7+)
+    result = channel.call("execute_python", b'import maya.cmds; cmds.sphere()', timeout_ms=10000)
+    if result["success"]:
+        payload = result.get("payload", b"")
         return success_result(payload.decode() if isinstance(payload, bytes) else str(payload))
     else:
-        return error_result("DCC call failed", "No response received")
+        return error_result("DCC call failed", result.get("error", "Unknown error"))
 finally:
     channel.shutdown()
 ```
 
-### Pattern 5: Watch skills for live reload
+### Pattern 5: Expose actions via MCP Streamable HTTP
+
+```python
+from dcc_mcp_core import ActionRegistry, McpHttpServer, McpHttpConfig
+
+registry = ActionRegistry()
+registry.register("get_scene_info", description="Get DCC scene info",
+                  category="scene", dcc="maya", version="1.0.0")
+
+# Runs in background thread — safe to call from DCC main thread
+server = McpHttpServer(registry, McpHttpConfig(port=8765, server_name="maya-mcp"))
+handle = server.start()
+print(f"MCP server: {handle.mcp_url()}")  # http://127.0.0.1:8765/mcp
+# Claude Desktop / MCP host connects to handle.mcp_url()
+# handle.shutdown() when done
+```
+
+### Pattern 6: Watch skills for live reload
 
 ```python
 from dcc_mcp_core import SkillWatcher
@@ -146,7 +164,7 @@ watcher.watch("/my/dev/skills")  # immediate load + start watching
 current_skills = watcher.skills()  # -> List[SkillMetadata]
 ```
 
-### Pattern 6: ActionDispatcher with handlers
+### Pattern 7: ActionDispatcher with handlers
 
 ```python
 import json
@@ -174,7 +192,7 @@ cat > my-tool/SKILL.md << 'EOF'
 ---
 name: my-tool
 description: "My custom DCC automation tools"
-tools: ["Bash"]
+allowed-tools: ["Bash"]
 tags: ["automation", "custom"]
 dcc: maya
 version: "1.0.0"
@@ -211,14 +229,14 @@ print(f'Loaded: {[s.name for s in skills]}')
 ┌─────────────────────────────────────────────────────┐
 │                   Python Layer                       │
 │  dcc_mcp_core/__init__.py  →  _core (PyO3 cdyll)   │
-│  ~120 public symbols re-exported from Rust core      │
+│  ~130 public symbols re-exported from Rust core      │
 └──────────────────────┬──────────────────────────────┘
                        │ PyO3 bindings
 ┌──────────────────────▼──────────────────────────────┐
-│              Rust Core (11 Crates)                   │
+│              Rust Core (12 Crates)                   │
 │                                                      │
 │  models → actions → skills → protocols              │
-│  transport → process → sandbox → telemetry          │
+│  transport → http → process → sandbox → telemetry   │
 │  shm → capture → usd → utils                        │
 └─────────────────────────────────────────────────────┘
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@
 | Exchange scene as USD | `UsdStage` + `scene_info_json_to_stage()` |
 | Safe RPyC value transport | `wrap_value()` / `unwrap_value()` |
 | Multi-version action lookup | `VersionedRegistry` + `VersionConstraint.parse()` |
+| Expose DCC tools over HTTP/MCP | `McpHttpServer(registry, McpHttpConfig(port=8765))` — not a raw HTTP server |
 
 ## Project Overview
 
@@ -29,11 +30,11 @@
 
 ### Key Architecture Facts
 
-- **Language**: Rust core (11 crates workspace) + Python bindings via PyO3
+- **Language**: Rust core (12 crates workspace) + Python bindings via PyO3
 - **Build system**: `cargo` (Rust) + `maturin` (Python wheels)
-- **Python package**: `dcc_mcp_core` with ~120 public symbols re-exported from `_core` native extension
+- **Python package**: `dcc_mcp_core` with ~130 public symbols re-exported from `_core` native extension
 - **Zero runtime Python dependencies** — everything is compiled into the Rust core
-- **Version**: 0.12.6 (use Release Please for versioning — never manually bump)
+- **Version**: 0.12.7 (use Release Please for versioning — never manually bump)
 - **Python support**: 3.7–3.13 (CI tests 3.7–3.13; abi3-py38 wheel for 3.8+)
 
 ## Repository Structure
@@ -41,7 +42,7 @@
 ```
 dcc-mcp-core/
 ├── src/lib.rs                  # PyO3 entry point (_core module)
-├── Cargo.toml                  # Workspace definition (11 crates)
+├── Cargo.toml                  # Workspace definition (12 crates)
 ├── pyproject.toml              # Python package metadata
 ├── justfile                    # Development commands (use: vx just <recipe>)
 │
@@ -57,6 +58,7 @@ dcc-mcp-core/
 │   ├── dcc-mcp-shm/            # Shared memory buffers (LZ4 compressed)
 │   ├── dcc-mcp-capture/        # Screen/window capture backend
 │   ├── dcc-mcp-usd/            # USD scene description bridge
+│   ├── dcc-mcp-http/           # MCP Streamable HTTP server (2025-03-26 spec, McpHttpServer)
 │   └── dcc-mcp-utils/          # Filesystem, type wrappers, constants, JSON helpers
 │
 ├── python/dcc_mcp_core/
@@ -378,23 +380,82 @@ from dcc_mcp_core import (
     TransportManager,    # Connection pool manager
     TransportAddress, TransportScheme, RoutingStrategy,
     IpcListener,         # Server-side IPC listener
-    ListenerHandle,      # Handle returned by IpcListener.start()
+    ListenerHandle,      # Handle returned by IpcListener.into_handle()
     FramedChannel,       # Message-framed IPC channel
     connect_ipc,         # Client: connect to IPC server
 )
 
-# Server
-listener = IpcListener.new("/tmp/dcc-mcp.sock")
-handle = listener.start(handler_fn=my_handler)
+# Server — bind + accept pattern
+addr = TransportAddress.tcp("127.0.0.1", 0)
+listener = IpcListener.bind(addr)
+local_addr = listener.local_address()   # get assigned port
+channel = listener.accept()             # blocks until client connects
 
 # Client
-channel = connect_ipc("/tmp/dcc-mcp.sock")
-response = channel.call({"method": "ping", "params": {}})
+channel = connect_ipc(local_addr, timeout_ms=10000)
 
-# Production: pooled + circuit breaker
-mgr = TransportManager()
-mgr.configure_pool(min_size=2, max_size=10)
-mgr.set_circuit_breaker(threshold=5, reset_timeout=30)
+# FramedChannel RPC — use .call() for synchronous request/reply
+result = channel.call("execute_python", b'cmds.sphere()')
+# result keys: "id", "success" (bool), "payload" (bytes), "error" (str|None)
+if result["success"]:
+    print(result["payload"].decode())
+else:
+    raise RuntimeError(result["error"])
+
+# Low-level: send_request + recv for async/multiplexed patterns
+req_id = channel.send_request("execute_python", params=b'cmds.sphere()')
+msg = channel.recv(timeout_ms=10000)   # {"type": "response", "id": req_id, ...}
+
+# One-way notifications
+channel.send_notify("scene_changed", data=b'{"scene": "shot01.ma"}')
+
+# Heartbeat check
+rtt_ms = channel.ping()                 # round-trip time in ms
+channel.shutdown()                      # graceful close
+
+# Production: pooled + circuit breaker + auto-registration
+mgr = TransportManager("/tmp/dcc-mcp")
+instance_id, listener = mgr.bind_and_register("maya", version="2025")
+entry = mgr.find_best_service("maya")   # best available Maya instance
+session_id = mgr.get_or_create_session("maya", entry.instance_id)
+```
+
+#### MCP HTTP Server
+
+```python
+from dcc_mcp_core import ActionRegistry, McpHttpServer, McpHttpConfig, McpServerHandle
+
+# Build an action registry
+registry = ActionRegistry()
+registry.register(
+    "get_scene_info",
+    description="Get information about the current DCC scene",
+    category="scene", tags=["query"], dcc="maya", version="1.0.0",
+)
+
+# Start MCP Streamable HTTP server (2025-03-26 spec)
+# Runs in background thread — safe to call from DCC main thread
+config = McpHttpConfig(
+    port=8765,              # use 0 for random available port
+    server_name="maya-mcp",
+    server_version="1.0.0",
+    enable_cors=False,      # set True for browser-based MCP clients
+    request_timeout_ms=30000,
+)
+server = McpHttpServer(registry, config)
+handle = server.start()
+
+# MCP host (e.g. Claude Desktop) connects to:
+print(handle.mcp_url())    # "http://127.0.0.1:8765/mcp"
+print(handle.port)         # actual port (useful when port=0)
+print(handle.bind_addr)    # "127.0.0.1:8765"
+
+# Shutdown
+handle.shutdown()          # blocks until stopped
+# handle.signal_shutdown() # non-blocking alternative
+
+# McpServerHandle is an alias for ServerHandle in __init__.py
+from dcc_mcp_core import McpServerHandle  # same type
 ```
 
 #### Process Management
@@ -612,6 +673,14 @@ pub fn register_actions(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
 10. **`_core.pyi` is the authoritative stub**: When unsure of parameter names or types, read `python/dcc_mcp_core/_core.pyi` rather than guessing.
 
+11. **`IpcListener.bind(addr)`** creates the listener (not `.new()`); `.accept()` returns a `FramedChannel`. Use `into_handle()` for `ListenerHandle` with tracking.
+
+12. **`FramedChannel.call()` is the primary RPC helper**: `channel.call(method, params_bytes, timeout_ms)` sends a request and waits for the matching response atomically. Use `send_request()` + `recv()` only for multiplexed async patterns.
+
+13. **`McpServerHandle` vs `ServerHandle`**: `server.start()` returns a `ServerHandle`; it is re-exported as `McpServerHandle` in `__init__.py`. Both refer to the same class.
+
+14. **`McpHttpServer` requires an `ActionRegistry`**: The HTTP server reads tool names/descriptions from the registry. Register all actions before calling `server.start()`.
+
 ## Debugging & Diagnostics
 
 ### Build Issues
@@ -706,11 +775,10 @@ def call_maya_command(pid: int, python_code: str):
     addr = TransportAddress.default_local("maya", pid)
     channel = connect_ipc(addr)
     try:
-        # FramedChannel: use send_request() + recv(); there is no .call() method
-        req_id = channel.send_request("execute_python", params=python_code.encode())
-        msg = channel.recv(timeout_ms=10000)
-        if msg and msg.get("type") == "response":
-            payload = msg.get("payload", b"")
+        # Primary RPC pattern: .call() handles request/response atomically
+        result = channel.call("execute_python", python_code.encode(), timeout_ms=10000)
+        if result["success"]:
+            payload = result.get("payload", b"")
             decoded = payload.decode() if isinstance(payload, bytes) else str(payload)
             return success_result(
                 decoded,
@@ -719,7 +787,7 @@ def call_maya_command(pid: int, python_code: str):
         else:
             return error_result(
                 "DCC script failed",
-                "No response or unexpected message type",
+                result.get("error", "Unknown error"),
                 possible_solutions=["Check Maya is running", "Verify syntax"],
             )
     except Exception as e:
@@ -784,6 +852,53 @@ for entry in ctx.audit_log.entries():
     print(f"{entry.action}: {entry.outcome}")
 ```
 
+### Pattern 6: Expose DCC actions over MCP Streamable HTTP
+
+```python
+import os
+from dcc_mcp_core import (
+    scan_and_load, ActionRegistry, ActionDispatcher,
+    McpHttpServer, McpHttpConfig,
+    success_result, error_result, from_exception,
+)
+from pathlib import Path
+
+# 1. Discover skill scripts and populate registry
+os.environ["DCC_MCP_SKILL_PATHS"] = "/opt/maya-skills"
+skills, skipped = scan_and_load(dcc_name="maya")
+
+registry = ActionRegistry()
+dispatcher = ActionDispatcher(registry)
+
+for skill in skills:
+    for script_path in skill.scripts:
+        stem = Path(script_path).stem
+        action_name = f"{skill.name.replace('-', '_')}__{stem}"
+        registry.register(
+            name=action_name,
+            description=f"[{skill.name}] {skill.description}",
+            dcc=skill.dcc, tags=skill.tags, version=skill.version,
+        )
+        # Bind handler that executes the script
+        def make_handler(sp):
+            def handler(params):
+                import subprocess
+                proc = subprocess.run(["python", sp], capture_output=True, text=True)
+                if proc.returncode == 0:
+                    return success_result(proc.stdout.strip())
+                return error_result("Script failed", proc.stderr.strip())
+            return handler
+        dispatcher.register_handler(action_name, make_handler(script_path))
+
+# 2. Serve via MCP Streamable HTTP (2025-03-26 spec)
+server = McpHttpServer(registry, McpHttpConfig(port=8765, server_name="maya-mcp"))
+handle = server.start()
+print(f"MCP server ready at {handle.mcp_url()}")
+
+# Claude Desktop / MCP host connects to handle.mcp_url()
+# handle.shutdown() when done
+```
+
 ## External References
 
 - [AGENTS.md specification](https://agents.md/) — open standard for AI agent guidance files (Linux Foundation / Agentic AI Foundation)
@@ -827,6 +942,20 @@ result = error_result("Failed", "specific error details")
 # EventBus.subscribe returns an int ID for unsubscribe
 sub_id = bus.subscribe("event_name", handler_fn)
 bus.unsubscribe("event_name", sub_id)
+
+# FramedChannel — .call() is the primary RPC method (added v0.12.7)
+channel = connect_ipc(TransportAddress.default_local("maya", pid))
+result = channel.call("execute_python", b'cmds.sphere()')
+# result: {"id": str, "success": bool, "payload": bytes, "error": str|None}
+# send_request+recv for async/multiplexed:
+req_id = channel.send_request("execute_python", params=b'cmds.sphere()')
+msg = channel.recv(timeout_ms=10000)   # {"type": "response", ...}
+
+# McpHttpServer — expose actions over HTTP/MCP
+server = McpHttpServer(registry, McpHttpConfig(port=8765, server_name="maya-mcp"))
+handle = server.start()          # returns McpServerHandle (alias: McpServerHandle)
+print(handle.mcp_url())          # "http://127.0.0.1:8765/mcp"
+handle.shutdown()                # or handle.signal_shutdown() (non-blocking)
 ```
 
 ## PR Checklist

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,9 +67,28 @@ skills, skipped = scan_and_load(dcc_name="maya")
 - Uses IPC (Unix socket / named pipe) for process communication
 - `TransportManager` manages connection pools with `CircuitBreaker` resilience
 - `FramedChannel` for reliable message delivery with message framing
-- Connect (client): `connect_ipc(address) -> FramedChannel`
-- Listen (server): `IpcListener.new(address)` → `.start(handler_fn) -> ListenerHandle`
-  - Note: `start()` is the method name (not `.bind()` + `.accept()`)
+- Connect (client): `connect_ipc(address, timeout_ms=10000) -> FramedChannel`
+- Listen (server): `IpcListener.bind(address)` → `.accept(timeout_ms=None) -> FramedChannel`
+  - Note: the method is `.bind()` (static) + `.accept()` (blocking) — not `.new()` + `.start()`
+- **`FramedChannel.call(method, params, timeout_ms)` — primary RPC helper** (added v0.12.7):
+  sends a Request and waits for the correlated Response atomically.
+  - `result = channel.call("execute_python", b'cmds.sphere()')` → `{"id", "success", "payload", "error"}`
+  - Use `send_request()` + `recv()` only when you need async/multiplexed patterns
+
+### When Using MCP HTTP Server
+
+```python
+from dcc_mcp_core import ActionRegistry, McpHttpServer, McpHttpConfig, McpServerHandle
+
+registry = ActionRegistry()
+registry.register("get_scene", description="Get scene", category="scene", dcc="maya")
+
+server = McpHttpServer(registry, McpHttpConfig(port=8765, server_name="maya-mcp"))
+handle = server.start()   # returns McpServerHandle (alias for ServerHandle)
+print(handle.mcp_url())   # "http://127.0.0.1:8765/mcp"
+handle.shutdown()
+# Note: register ALL actions BEFORE calling server.start()
+```
 
 ### Quick Lookup: Common Method Signatures
 
@@ -96,6 +115,17 @@ bus.unsubscribe("event_name", sub_id)
 # ActionRegistry.register — takes keyword args, NOT handler=
 registry.register(name="action", description="...", dcc="maya", version="1.0.0")
 # Use dispatcher.register_handler() to attach a Python callable
+
+# FramedChannel.call() — primary RPC helper (v0.12.7+)
+channel = connect_ipc(TransportAddress.default_local("maya", pid))
+result = channel.call("execute_python", b'cmds.sphere()', timeout_ms=30000)
+# result: {"id": str, "success": bool, "payload": bytes, "error": str|None}
+# Alternative (async): req_id = channel.send_request(...); msg = channel.recv(timeout_ms=...)
+
+# McpHttpServer — expose registry over HTTP/MCP
+server = McpHttpServer(registry, McpHttpConfig(port=8765))
+handle = server.start()   # McpServerHandle
+print(handle.mcp_url())   # "http://127.0.0.1:8765/mcp"
 ```
 
 ### When Exploring Unknown Symbols
@@ -156,7 +186,7 @@ def test_skill_scan(tmp_path):
 - **The `justfile` is cross-platform**: recipes work on both Windows PowerShell and Unix sh
 - **When debugging Python-Rust binding issues**: check that the symbol is registered in `src/lib.rs` AND re-exported in `__init__.py` AND listed in `_core.pyi`
 - **Use `vx just test-cov`** to see coverage gaps before adding new features
-- **Don't use legacy APIs**: `ActionManager`, `create_action_manager()`, `MiddlewareChain`, `LoggingMiddleware` — all removed in v0.12+
+- **Don't use legacy APIs**: `ActionManager`, `create_action_manager()`, `MiddlewareChain`, `Action` base class — all removed in v0.12+. Note: `LoggingMiddleware` IS still available (use via `pipeline.add_logging()`).
 - **The project has zero runtime Python dependencies by design** — never add `dependencies = [...]` to `pyproject.toml`
 
 ## Key Files to Read First (Priority Order)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -31,10 +31,10 @@ vx just lint-fix     # Auto-fix all lint issues
 ## Key Architecture Facts
 
 - **11 Rust crates** under `crates/`, compiled into `dcc_mcp_core._core` native extension
-- **~120 public Python symbols** exported from `python/dcc_mcp_core/__init__.py`
+- **~130 public Python symbols** exported from `python/dcc_mcp_core/__init__.py`
 - **Zero runtime Python deps** — all logic in Rust, no `dependencies = [...]` in pyproject.toml
 - Python 3.7–3.13 supported (abi3-py38 wheel; separate non-abi3 wheel for 3.7)
-- Version: **0.12.6** — managed by Release Please, never manually bump
+- Version: **0.12.7** — managed by Release Please, never manually bump
 
 ## Gemini-Specific Workflows
 
@@ -135,6 +135,10 @@ Action naming: `{skill_name}__{script_stem}` (hyphens → underscores, `__` sepa
 12. **`success_result` kwargs → context**: `success_result("msg", count=5)` → `context={"count":5}` — do NOT use `context=` keyword
 13. **`error_result` positional args**: `error_result("msg", "error string")` — not `error_result(message=..., error=...)`
 14. **`EventBus.subscribe` returns int**: Store the return value to unsubscribe later: `sub_id = bus.subscribe(...)`
+15. **`FramedChannel.call()` IS available** (v0.12.7+): Use `channel.call(method, params_bytes, timeout_ms)` for synchronous RPC. Use `send_request()` + `recv()` only for async/multiplexed patterns.
+16. **`IpcListener.bind(addr)`** creates listener (static method); `.accept()` blocks until client connects. There is no `.new()` or `.start()` method.
+17. **`McpServerHandle` is an alias**: `server.start()` returns `ServerHandle`; it is re-exported as `McpServerHandle` in `__init__.py`. Import as `from dcc_mcp_core import McpServerHandle`.
+18. **`McpHttpServer` registry population**: All actions must be registered in `ActionRegistry` BEFORE calling `server.start()`. The server reads metadata from the registry at startup.
 
 ## CI/CD Summary
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -28,6 +28,7 @@
 | Exchange scene data via USD format | `UsdStage` + `scene_info_json_to_stage()` |
 | Wrap values for safe RPyC transport | `wrap_value()` / `unwrap_value()` |
 | Handle multiple versions of an action | `VersionedRegistry` + `VersionConstraint` |
+| Expose DCC tools over HTTP/MCP | `McpHttpServer(registry, McpHttpConfig(port=8765))` |
 
 ---
 
@@ -46,6 +47,7 @@ crates/
 ├── dcc-mcp-skills/       # SkillScanner, SkillWatcher, parse_skill_md, dependency resolver
 ├── dcc-mcp-protocols/    # MCP type definitions (Tool, Resource, Prompt, DccAdapter)
 ├── dcc-mcp-transport/    # IPC transport, TransportManager, ConnectionPool, CircuitBreaker
+├── dcc-mcp-http/         # McpHttpServer, McpHttpConfig, ServerHandle (MCP Streamable HTTP 2025-03-26)
 ├── dcc-mcp-process/      # PyDccLauncher, PyProcessMonitor, PyProcessWatcher, PyCrashRecoveryPolicy
 ├── dcc-mcp-telemetry/    # TelemetryConfig, RecordingGuard, ActionMetrics, ActionRecorder
 ├── dcc-mcp-sandbox/      # SandboxPolicy, SandboxContext, InputValidator, AuditLog, AuditEntry
@@ -1487,15 +1489,14 @@ from dcc_mcp_core import TransportAddress, connect_ipc, success_result, error_re
 addr = TransportAddress.default_local("maya", pid=12345)
 channel = connect_ipc(addr)
 try:
-    # FramedChannel API: send_request() + recv(); there is no .call() method
-    req_id = channel.send_request("execute_python", params=b'import maya.cmds; print(maya.cmds.ls())')
-    msg = channel.recv(timeout_ms=10000)
-    if msg and msg.get("type") == "response":
-        payload = msg.get("payload", b"")
+    # Primary RPC: .call() atomically sends Request + waits for correlated Response (v0.12.7+)
+    result = channel.call("execute_python", b'import maya.cmds; print(maya.cmds.ls())', timeout_ms=10000)
+    if result["success"]:
+        payload = result.get("payload", b"")
         output = payload.decode() if isinstance(payload, bytes) else str(payload)
         r = success_result(output, prompt="Objects listed. You can now select one to modify.")
     else:
-        r = error_result("DCC script failed", "No response or unexpected message type")
+        r = error_result("DCC script failed", result.get("error", "Unknown error"))
 finally:
     channel.shutdown()
 ```
@@ -1532,6 +1533,110 @@ desc = ssb.descriptor_json()
 # Send desc via IPC channel to agent
 channel = connect_ipc(TransportAddress.default_local("maya", os.getpid()))
 channel.send_notify("mesh_ready", data=desc.encode())
+```
+
+---
+
+## MCP HTTP Server (`dcc_mcp_core`)
+
+The `dcc-mcp-http` crate provides a **MCP Streamable HTTP server** compliant with the 2025-03-26 MCP
+specification. It uses axum + Tokio and runs in a background thread, making it safe to call from any
+DCC main thread.
+
+### McpHttpConfig
+
+```python
+from dcc_mcp_core import McpHttpConfig
+
+config = McpHttpConfig(
+    port=8765,              # use 0 for OS-assigned ephemeral port
+    server_name="maya-mcp", # reported in MCP initialize response
+    server_version="1.0.0",
+    enable_cors=False,      # set True for browser-based MCP clients
+    request_timeout_ms=30000,
+)
+print(config.port)          # 8765
+print(config.server_name)   # "maya-mcp"
+print(config.server_version) # "1.0.0"
+```
+
+### McpHttpServer
+
+```python
+from dcc_mcp_core import ActionRegistry, McpHttpServer, McpHttpConfig, McpServerHandle
+
+registry = ActionRegistry()
+registry.register(
+    "get_scene_info",
+    description="Get info about the current scene",
+    category="scene", tags=["query"], dcc="maya", version="1.0.0",
+)
+registry.register(
+    "create_sphere",
+    description="Create a polygon sphere",
+    category="geometry", tags=["create"], dcc="maya", version="1.0.0",
+    input_schema='{"type":"object","required":["radius"],"properties":{"radius":{"type":"number"}}}',
+)
+
+# Start server — returns immediately, server runs in background
+server = McpHttpServer(registry, McpHttpConfig(port=8765, server_name="maya-mcp"))
+handle = server.start()   # -> McpServerHandle (alias for ServerHandle)
+```
+
+### McpServerHandle
+
+```python
+# McpServerHandle is the alias for ServerHandle in __init__.py
+from dcc_mcp_core import McpServerHandle
+
+print(handle.mcp_url())      # "http://127.0.0.1:8765/mcp"  (MCP endpoint URL)
+print(handle.port)           # 8765 (actual port; useful when McpHttpConfig(port=0))
+print(handle.bind_addr)      # "127.0.0.1:8765"
+
+handle.shutdown()            # blocks until server stops
+handle.signal_shutdown()     # non-blocking shutdown signal
+```
+
+### Full Example: Skills → HTTP/MCP Server
+
+```python
+import os
+from pathlib import Path
+from dcc_mcp_core import (
+    scan_and_load, ActionRegistry, ActionDispatcher,
+    McpHttpServer, McpHttpConfig,
+    success_result, error_result,
+)
+
+os.environ["DCC_MCP_SKILL_PATHS"] = "/opt/maya-skills"
+skills, skipped = scan_and_load(dcc_name="maya")
+
+registry = ActionRegistry()
+dispatcher = ActionDispatcher(registry)
+
+for skill in skills:
+    for script_path in skill.scripts:
+        stem = Path(script_path).stem
+        action_name = f"{skill.name.replace('-', '_')}__{stem}"
+        registry.register(
+            name=action_name,
+            description=f"[{skill.name}] {skill.description}",
+            dcc=skill.dcc, tags=skill.tags, version=skill.version,
+        )
+        def make_handler(sp):
+            def handler(params):
+                import subprocess
+                proc = subprocess.run(["python", sp], capture_output=True, text=True, timeout=30)
+                if proc.returncode == 0:
+                    return success_result(proc.stdout.strip(), prompt="Script finished successfully.")
+                return error_result("Script failed", proc.stderr.strip())
+            return handler
+        dispatcher.register_handler(action_name, make_handler(script_path))
+
+server = McpHttpServer(registry, McpHttpConfig(port=0, server_name="maya-mcp"))
+handle = server.start()
+print(f"MCP server ready: {handle.mcp_url()}")
+# Claude Desktop config: {"mcpServers": {"maya": {"url": "<handle.mcp_url()>"}}}
 ```
 
 ---

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # dcc-mcp-core
 
-> Foundational library for the DCC Model Context Protocol (MCP) ecosystem. Rust-powered core (via PyO3) providing action registry, structured results, event bus, skills/script registration, MCP protocol types, IPC transport, process management, sandbox security, shared memory, screen capture, USD bridge, and telemetry for Digital Content Creation applications (Maya, Blender, Houdini, 3ds Max, etc.).
+> Foundational library for the DCC Model Context Protocol (MCP) ecosystem. Rust-powered core (via PyO3) providing action registry, structured results, event bus, skills/script registration, MCP protocol types, IPC transport, MCP Streamable HTTP server, process management, sandbox security, shared memory, screen capture, USD bridge, and telemetry for Digital Content Creation applications (Maya, Blender, Houdini, 3ds Max, etc.).
 
 ## Quick Decision Guide
 
@@ -15,6 +15,7 @@
 | Monitor DCC process | `PyProcessWatcher` + `PyCrashRecoveryPolicy` |
 | Sandbox AI actions | `SandboxPolicy` + `SandboxContext` |
 | Share large data zero-copy | `PySharedSceneBuffer.write()` with LZ4 compression |
+| Expose DCC tools over HTTP/MCP | `McpHttpServer(registry, McpHttpConfig(port=8765))` |
 
 ## Quick Start
 
@@ -56,12 +57,12 @@ meta = dcc_mcp_core.parse_skill_md(dirs[0])  # -> SkillMetadata or None
 - Build from source: `maturin develop --features python-bindings,ext-module`
 - Python: >=3.7 (CI tests 3.7–3.13; abi3-py38 wheel for 3.8+)
 - Build: maturin (Rust 1.85+ + PyO3)
-- Version: 0.12.6
+- Version: 0.12.7
 - License: MIT
 
 ## Architecture
 
-Rust workspace (11 crates) with PyO3 bindings. All logic in Rust sub-crates; Python gets a single `dcc_mcp_core._core` extension module. The `dcc_mcp_core` package re-exports all ~120 public symbols from `_core`.
+Rust workspace (11 crates) with PyO3 bindings. All logic in Rust sub-crates; Python gets a single `dcc_mcp_core._core` extension module. The `dcc_mcp_core` package re-exports all ~130 public symbols from `_core`.
 
 ```
 crates/
@@ -76,6 +77,7 @@ crates/
 ├── dcc-mcp-shm/         # PyBufferPool, PySharedBuffer, LZ4 compression
 ├── dcc-mcp-capture/     # Capturer, CaptureFrame, CaptureResult
 ├── dcc-mcp-usd/         # UsdStage, UsdPrim, SdfPath, scene info bridge
+├── dcc-mcp-http/        # McpHttpServer, McpHttpConfig, ServerHandle (MCP Streamable HTTP 2025-03-26)
 └── dcc-mcp-utils/       # Filesystem, constants, type wrappers, JSON conversion
 ```
 
@@ -96,7 +98,7 @@ crates/
 
 **Actions:**
 - `ActionRegistry` — Thread-safe registry; `.register(name, ...)`, `.register_batch([{...}, ...])`, `.unregister(name, dcc_name=None)`, `.get_action(name)`, `.list_actions()`, `.list_actions_for_dcc(dcc)`, `.get_all_dccs()`, `.search_actions(category, tags, dcc_name)`, `.get_categories()`, `.get_tags()`, `.reset()`
-- `ActionDispatcher` — Validated dispatch; `.call(name, **kwargs) -> ActionResultModel`
+- `ActionDispatcher` — Validated dispatch; `ActionDispatcher(registry)` (ONE arg); `.dispatch(name, json_str) -> dict`; dict keys: `"action"`, `"output"`, `"validation_skipped"`
 - `ActionValidator` — Input validation before action execution
 - `ActionPipeline(dispatcher)` — Middleware-style processing pipeline; `.add_logging(log_params=False)`, `.add_timing() -> TimingMiddleware`, `.add_audit(record_params=True) -> AuditMiddleware`, `.add_rate_limit(max_calls, window_ms) -> RateLimitMiddleware`, `.add_callable(before_fn=None, after_fn=None)`, `.dispatch(action_name, params_json="null") -> dict`, `.register_handler(name, fn)`, `.middleware_count()`, `.middleware_names()`, `.handler_count()`
 - `LoggingMiddleware(log_params=False)` — emits tracing log lines before/after each action
@@ -145,24 +147,48 @@ crates/
 
 ### Transport (`dcc_mcp_core`)
 
-- `IpcListener.bind(address) -> IpcListener` → `.accept() -> FramedChannel` (server-side)
-- `connect_ipc(address) -> FramedChannel` (client-side)
-- `FramedChannel` — `.send_request(method, params=None) -> req_id`, `.recv(timeout_ms=None) -> dict|None`, `.ping() -> int`, `.shutdown()`
-- `TransportManager` — connection pool + circuit breaker
+- `IpcListener.bind(address) -> IpcListener` → `.local_address()`, `.accept(timeout_ms=None) -> FramedChannel` (server-side), `.into_handle() -> ListenerHandle`
+- `connect_ipc(address, timeout_ms=10000) -> FramedChannel` (client-side)
+- `FramedChannel` methods:
+  - `.call(method, params=None, timeout_ms=30000) -> dict` — **primary RPC helper** (v0.12.7+); atomically sends Request + waits for correlated Response; result: `{"id", "success", "payload", "error"}`
+  - `.send_request(method, params=None) -> req_id` — async variant; use with `.recv()` for multiplexed patterns
+  - `.recv(timeout_ms=None) -> dict|None` — returns next Request/Response/Notify envelope
+  - `.send_response(request_id, success, payload=None, error=None)` — server-side reply
+  - `.send_notify(topic, data=None)` — one-way event push
+  - `.ping(timeout_ms=5000) -> int` — heartbeat RTT in ms
+  - `.shutdown()` — graceful close
+- `TransportManager(registry_dir, ...)` — connection pool + circuit breaker + service discovery
+  - `.bind_and_register(dcc_type, version=None) -> (instance_id, IpcListener)` — one-call server setup
+  - `.find_best_service(dcc_type) -> ServiceEntry` — smart routing (IPC > local TCP > remote)
+  - `.rank_services(dcc_type) -> List[ServiceEntry]` — all live instances sorted by preference
 - `TransportAddress`, `TransportScheme`, `RoutingStrategy`
+- Frame encode/decode: `encode_request(method, params)`, `encode_response(id, success, payload, error)`, `encode_notify(topic, data)`, `decode_envelope(data)` — low-level MessagePack framing
+
+### MCP HTTP Server (`dcc_mcp_core`)
+
+- `McpHttpConfig(port=8765, server_name=None, server_version=None, enable_cors=False, request_timeout_ms=30000)` — server configuration
+- `McpHttpServer(registry, config=None)` — MCP Streamable HTTP server (2025-03-26 spec), axum/Tokio backend
+  - `.start() -> McpServerHandle` — starts background thread, returns immediately
+- `McpServerHandle` (alias for `ServerHandle`) — handle to running server
+  - `.mcp_url() -> str` — full MCP endpoint URL (e.g. `"http://127.0.0.1:8765/mcp"`)
+  - `.port -> int`, `.bind_addr -> str`
+  - `.shutdown()` — blocks until stopped; `.signal_shutdown()` — non-blocking
 
 ### Process Management (`dcc_mcp_core`)
 
-- `PyDccLauncher(dcc_type, version)` → `.launch(script_path, working_dir, env_vars) -> process`
-- `PyProcessMonitor()` → `.track(process)`, `.stats(process)`
-- `PyProcessWatcher(recovery_policy)` → `.watch(process)`
-- `PyCrashRecoveryPolicy(max_restarts, cooldown_sec)`
+- `PyDccLauncher()` → `.launch(name, executable, args=None, launch_timeout_ms=30000) -> dict` (dict: `pid`, `name`, `status`), `.terminate(name, timeout_ms=5000)`, `.kill(name)`, `.pid_of(name) -> int|None`, `.running_count() -> int`
+- `PyProcessMonitor()` → `.track(pid, name)`, `.refresh()`, `.query(pid) -> dict|None`, `.list_all() -> list`, `.is_alive(pid) -> bool`
+- `PyProcessWatcher(poll_interval_ms=500)` → `.track(pid, name)`, `.start()`, `.stop()`, `.poll_events() -> list[dict]`
+- `PyCrashRecoveryPolicy(max_restarts=3)` → `.use_exponential_backoff(initial_ms, max_delay_ms)`, `.use_fixed_backoff(delay_ms)`, `.should_restart(status) -> bool`, `.next_delay_ms(name, attempt) -> int`
 - `ScriptResult`, `ScriptLanguage`
 
 ### Sandbox (`dcc_mcp_core`)
 
-- `SandboxPolicy.builder().allow_read([...]).allow_write([...]).deny_pattern([...]).build()`
-- `SandboxContext(policy)`, `InputValidator(ctx)`, `AuditLog.load()`, `AuditEntry`
+- `SandboxPolicy()` → `.allow_actions(list)`, `.deny_actions(list)`, `.allow_paths(list)`, `.set_timeout_ms(ms)`, `.set_max_actions(count)`, `.set_read_only(bool)`, `.is_read_only -> bool`
+- `SandboxContext(policy)` → `.set_actor(actor)`, `.execute_json(action, params_json) -> str`, `.action_count -> int`, `.audit_log -> AuditLog`, `.is_allowed(action) -> bool`, `.is_path_allowed(path) -> bool`
+- `InputValidator()` → `.require_string(field, max_length=None, min_length=None)`, `.require_number(field, min_value=None, max_value=None)`, `.forbid_substrings(field, substrings)`, `.validate(params_json) -> (bool, str|None)`
+- `AuditLog` → `.entries() -> list[AuditEntry]`, `.successes()`, `.denials()`, `.entries_for_action(action)`, `.to_json() -> str`
+- `AuditEntry` → `.timestamp_ms`, `.actor`, `.action`, `.params_json`, `.duration_ms`, `.outcome`, `.outcome_detail`
 
 ### Telemetry (`dcc_mcp_core`)
 


### PR DESCRIPTION
## Summary

Update all AI agent documentation to reflect v0.12.7 changes (new `dcc-mcp-http` crate) and fix accumulated correctness issues across AGENTS.md, CLAUDE.md, GEMINI.md, llms.txt, llms-full.txt, and .agents/skills/dcc-mcp-core/SKILL.md.

## Key Changes

### New API: MCP Streamable HTTP Server
- Document `McpHttpServer`, `McpHttpConfig`, `McpServerHandle` (alias for `ServerHandle`) across all AI docs
- Add Pattern 6 (AGENTS.md), Pattern 5 (SKILL.md) showing full skill → HTTP/MCP pipeline
- Add `McpHttpServer` to Quick Decision Guide tables in all files
- Add complete `## MCP HTTP Server` section to `llms-full.txt` with constructor details and full example
- Add `dcc-mcp-http` crate to architecture diagrams (12 crates total)

### Bug Fixes: Corrected API Documentation
- **`FramedChannel.call()`**: This method **IS** available (v0.12.7+). Previous docs incorrectly stated "there is no .call() method". Fix Pattern 2 in AGENTS.md, SKILL.md, and llms-full.txt to use `.call()` as the primary RPC pattern
- **`IpcListener`**: Fix CLAUDE.md which said `.new()` + `.start()` — correct API is `.bind(addr)` + `.accept()`
- **`ActionDispatcher`** in llms.txt: Fix description from `.call()` to `.dispatch()`
- **`PyDccLauncher`** in llms.txt: Fix incorrect constructor `(dcc_type, version)` → `()`, fix `.launch()` signature
- **`PyProcessWatcher/Monitor`** in llms.txt: Fix `.watch(process)` → `.track(pid, name)` + `.start()` + `.poll_events()`
- **`PyCrashRecoveryPolicy`** in llms.txt: Fix `(max_restarts, cooldown_sec)` → `(max_restarts=3)`
- **`SandboxPolicy`** in llms.txt: Fix builder pattern → direct method calls (`.allow_actions()`, `.deny_actions()`, etc.)
- **`LoggingMiddleware`** in CLAUDE.md: Remove from "removed APIs" list — it IS still available

### Documentation Improvements
- Version: 0.12.6 → 0.12.7 across all docs
- Symbol count: ~120 → ~130 (McpHttpServer, McpHttpConfig, McpServerHandle added)
- AGENTS.md Common Pitfalls: 10 → 14 items (IpcListener.bind, FramedChannel.call, McpServerHandle alias, McpHttpServer registration order)
- GEMINI.md Common Pitfalls: 14 → 18 items
- Quick Lookup sections: add FramedChannel.call() and McpHttpServer signatures
- SKILL.md: Update architecture diagram 11→12 crates, use `allowed-tools:` field

## Files Changed

- `AGENTS.md` — version, crate count, Transport section rewrite, Pattern 2 fix, Pattern 6 add, 14 pitfalls
- `CLAUDE.md` — IpcListener fix, FramedChannel.call() add, McpHttpServer section, Quick Lookup update
- `GEMINI.md` — version, 18 pitfalls
- `llms.txt` — version, 12 crates, MCP HTTP Server section, API corrections
- `llms-full.txt` — Architecture update, Pattern 2 fix, MCP HTTP Server full section
- `.agents/skills/dcc-mcp-core/SKILL.md` — version, McpHttpServer capability, Pattern 4/5 fix/add, 12 crates