### PR TITLE
docs: update AI agent guidance for v0.12.9 — MCP 2025-11-05 draft, 12 crates, DeferredExecutor tips

### DIFF
--- a/.agents/skills/dcc-mcp-core/SKILL.md
+++ b/.agents/skills/dcc-mcp-core/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: dcc-mcp-core
-description: "Foundation library for the DCC Model Context Protocol (MCP) ecosystem. Provides Rust-powered action management, skills system, IPC transport, MCP Streamable HTTP server, sandbox security, shared memory, screen capture, USD scene support, and telemetry for AI-assisted DCC workflows. Use when working with Maya, Blender, Houdini, 3ds Max, or any DCC MCP integration."
+description: "Foundation library for the DCC Model Context Protocol (MCP) ecosystem. Provides Rust-powered action management, skills system, IPC transport, MCP Streamable HTTP server (2025-03-26 spec), sandbox security, shared memory, screen capture, USD scene support, and telemetry for AI-assisted DCC workflows. Use when working with Maya, Blender, Houdini, 3ds Max, or any DCC MCP integration."
 allowed-tools: ["Bash", "Read", "Write", "Edit"]
 compatibility: "Python 3.7-3.13; Rust 1.85+ required to build from source; zero runtime Python dependencies"
-version: "0.12.7"
+version: "0.12.9"
 ---
 
 # dcc-mcp-core — DCC MCP Ecosystem Foundation
@@ -28,7 +28,7 @@ The foundational library enabling AI assistants to interact with Digital Content
 | **Action Management** | Register, validate, dispatch, and execute actions with typed inputs/outputs |
 | **Skills System** | Zero-code script registration (Python/MEL/Batch/Shell/JS) as MCP tools via `SKILL.md` |
 | **Transport Layer** | High-performance IPC with connection pooling, circuit breaker, retry policies |
-| **MCP HTTP Server** | MCP Streamable HTTP (2025-03-26 spec) powered by axum/Tokio, runs in background thread |
+| **MCP HTTP Server** | MCP Streamable HTTP (**2025-03-26 spec**) powered by axum/Tokio, runs in background thread. 2025-11-05 draft will add JSON-RPC batching + resource links |
 | **Process Management** | Launch, monitor, auto-recover DCC processes (Maya, Blender, Houdini, etc.) |
 | **Sandbox Security** | Policy-based access control, input validation, audit logging |
 | **Shared Memory** | LZ4-compressed inter-process data exchange for large scenes |
@@ -181,6 +181,30 @@ result = dispatcher.dispatch("create_sphere", json.dumps({"radius": 2.0}))
 # result == {"action": "create_sphere", "output": {"created": True, "r": 2.0}, "validation_skipped": False}
 ```
 
+### Pattern 8: DCC main-thread safety with DeferredExecutor
+
+Most DCC applications (Maya, Blender, Houdini) require scene API calls on their **main thread**.
+McpHttpServer runs on Tokio worker threads — use `DeferredExecutor` to bridge:
+
+```python
+# DeferredExecutor is Rust-backed; import directly until added to public API
+from dcc_mcp_core._core import DeferredExecutor
+from dcc_mcp_core import ActionRegistry, McpHttpServer, McpHttpConfig
+
+executor = DeferredExecutor(queue_depth=64)
+# In DCC main event loop / timer callback:
+def poll():
+    executor.poll_pending()  # runs queued tasks on main thread
+
+# Maya: maya.utils.executeDeferred(poll)
+# Blender: bpy.app.timers.register(poll, persistent=True)
+# Houdini: hou.ui.addEventLoopCallback(poll)
+
+registry = ActionRegistry()
+server = McpHttpServer(registry, McpHttpConfig(port=0, server_name="maya-mcp"))
+handle = server.start()
+```
+
 ## Creating a Custom Skill (Zero Python Code)
 
 ```bash
@@ -274,3 +298,25 @@ print(f'Loaded: {[s.name for s in skills]}')
 
 - [dcc-mcp-rpyc](https://github.com/loonghao/dcc-mcp-rpyc) — RPyC bridge for remote DCC operations
 - [dcc-mcp-maya](https://github.com/loonghao/dcc-mcp-maya) — Maya MCP server implementation
+
+## MCP Specification Roadmap
+
+The library currently implements **MCP 2025-03-26** (Streamable HTTP). The **2025-11-05 draft** introduces:
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| JSON-RPC Batching | Draft | Multiple tool calls per round-trip; reduces latency for bulk ops |
+| Resource Links in Tool Results | Draft | Tools can return resource URIs for dynamic discovery |
+| Event Streams | Draft | Server-initiated push notifications for state changes |
+| Improved Error Taxonomy | Draft | Finer-grained error codes for better client handling |
+
+**AI Agents**: Do NOT implement these features manually. Wait for `dcc-mcp-core` to expose them via `McpHttpServer`. Track progress at the GitHub repository.
+
+## Common Pitfalls
+
+1. `scan_and_load` returns `(List[SkillMetadata], List[str])` — always unpack: `skills, skipped = scan_and_load(...)`
+2. `DeferredExecutor` not in public API yet — use `from dcc_mcp_core._core import DeferredExecutor`
+3. Register ALL actions before `server.start()` — server reads from registry at startup only
+4. Use `FramedChannel.call()` for sync RPC — not `send_request()` + `recv()` (those are for async/multiplex)
+5. `ActionDispatcher(registry)` takes ONE arg — no `validator=` parameter
+6. Action naming: `{skill_name.replace('-','_')}__{script_stem}` (double underscore)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,9 +32,9 @@
 
 - **Language**: Rust core (12 crates workspace) + Python bindings via PyO3
 - **Build system**: `cargo` (Rust) + `maturin` (Python wheels)
-- **Python package**: `dcc_mcp_core` with ~130 public symbols re-exported from `_core` native extension
+- **Python package**: `dcc_mcp_core` with ~130 public symbols re-exported from `_core` native extension (see `python/dcc_mcp_core/__init__.py`)
 - **Zero runtime Python dependencies** — everything is compiled into the Rust core
-- **Version**: 0.12.7 (use Release Please for versioning — never manually bump)
+- **Version**: 0.12.9 (use Release Please for versioning — never manually bump)
 - **Python support**: 3.7–3.13 (CI tests 3.7–3.13; abi3-py38 wheel for 3.8+)
 
 ## Repository Structure
@@ -783,6 +783,10 @@ pub fn register_actions(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
 16. **Do NOT use `dcc-mcp-ipc` in new code**: That project is superseded by `dcc-mcp-core`. All IPC transport, routing, and HTTP serving is provided by this library. New DCC integrations should only depend on `dcc-mcp-core`.
 
+17. **MCP specification version awareness**: `McpHttpServer` implements the 2025-03-26 MCP spec (Streamable HTTP). The 2025-11-05 draft spec introduces JSON-RPC batching, resource links in tool results, and event streams — watch for these capabilities in future `dcc-mcp-core` releases. Do NOT implement these from scratch; wait for API additions to `McpHttpServer`.
+
+18. **`scan_and_load` with `extra_paths`**: When calling `scan_and_load(extra_paths=[...], dcc_name="maya")`, both arguments are keyword-only. Do not pass `extra_paths` as a positional argument — use `extra_paths=["/path"]` explicitly.
+
 ## Debugging & Diagnostics
 
 ### Build Issues
@@ -1052,6 +1056,8 @@ def poll():
 - [AGENTS.md specification](https://agents.md/) — open standard for AI agent guidance files (Linux Foundation / Agentic AI Foundation)
 - [llms.txt specification](https://llmstxt.org/) — AI-optimized documentation format by Answer.AI
 - [Model Context Protocol](https://modelcontextprotocol.io/) — the underlying MCP standard (Anthropic)
+- [MCP Specification 2025-03-26](https://modelcontextprotocol.io/specification/2025-03-26) — current stable spec (Streamable HTTP, OAuth 2.1, Tool Annotations)
+- [MCP Specification 2025-11-05 (draft)](https://modelcontextprotocol.io/specification/draft) — upcoming spec (JSON-RPC batching, resource links in tool results, event streams, improved error taxonomy)
 - [MCP Agent Skills](https://modelcontextprotocol.io/docs/develop/build-with-agent-skills) — SKILL.md ecosystem and agent skills spec
 - [Agent Skills Specification](https://agentskills.io/specification) — official SKILL.md frontmatter format and best practices
 - [PyO3 documentation](https://pyo3.rs/) — Rust-Python bindings used in this project

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,11 +30,12 @@ vx just test-cov      # Coverage report to find gaps
 
 ### Architecture Summary
 
-- **11 Rust crates** under `crates/`, compiled into `_core` native extension
-- **~120 public Python symbols** exported from `python/dcc_mcp_core/__init__.py`
+- **12 Rust crates** under `crates/`, compiled into `_core` native extension
+- **~130 public Python symbols** exported from `python/dcc_mcp_core/__init__.py`
 - **Zero runtime Python deps** — all logic in Rust
 - Key entry point: `src/lib.rs` (PyO3 `#[pymodule]`)
 - Python 3.7–3.13 supported (CI tests 3.7–3.13)
+- Version: **0.12.9** — never manually bump (Release Please manages)
 
 ## Claude-Specific Workflows
 
@@ -188,6 +189,8 @@ def test_skill_scan(tmp_path):
 - **Use `vx just test-cov`** to see coverage gaps before adding new features
 - **Don't use legacy APIs**: `ActionManager`, `create_action_manager()`, `MiddlewareChain`, `Action` base class — all removed in v0.12+. Note: `LoggingMiddleware` IS still available (use via `pipeline.add_logging()`).
 - **The project has zero runtime Python dependencies by design** — never add `dependencies = [...]` to `pyproject.toml`
+- **`DeferredExecutor` is not in public `__init__.py`**: import via `from dcc_mcp_core._core import DeferredExecutor` until it is promoted to the public API
+- **MCP spec**: `McpHttpServer` implements 2025-03-26 spec. The upcoming 2025-11-05 draft adds JSON-RPC batching and resource links in tool results — do not implement these manually
 
 ## Key Files to Read First (Priority Order)
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -30,11 +30,11 @@ vx just lint-fix     # Auto-fix all lint issues
 
 ## Key Architecture Facts
 
-- **11 Rust crates** under `crates/`, compiled into `dcc_mcp_core._core` native extension
+- **12 Rust crates** under `crates/`, compiled into `dcc_mcp_core._core` native extension
 - **~130 public Python symbols** exported from `python/dcc_mcp_core/__init__.py`
 - **Zero runtime Python deps** — all logic in Rust, no `dependencies = [...]` in pyproject.toml
 - Python 3.7–3.13 supported (abi3-py38 wheel; separate non-abi3 wheel for 3.7)
-- Version: **0.12.7** — managed by Release Please, never manually bump
+- Version: **0.12.9** — managed by Release Please, never manually bump
 
 ## Gemini-Specific Workflows
 
@@ -139,6 +139,12 @@ Action naming: `{skill_name}__{script_stem}` (hyphens → underscores, `__` sepa
 16. **`IpcListener.bind(addr)`** creates listener (static method); `.accept()` blocks until client connects. There is no `.new()` or `.start()` method.
 17. **`McpServerHandle` is an alias**: `server.start()` returns `ServerHandle`; it is re-exported as `McpServerHandle` in `__init__.py`. Import as `from dcc_mcp_core import McpServerHandle`.
 18. **`McpHttpServer` registry population**: All actions must be registered in `ActionRegistry` BEFORE calling `server.start()`. The server reads metadata from the registry at startup.
+
+19. **MCP spec version awareness**: `McpHttpServer` implements 2025-03-26 spec. The 2025-11-05 draft adds JSON-RPC batching and resource links in tool results. Do NOT implement these manually — wait for the library to add support.
+
+20. **`scan_and_load` keyword args only**: Both `extra_paths` and `dcc_name` must be passed as keyword arguments: `scan_and_load(dcc_name="maya", extra_paths=["/path"])` — never as positionals.
+
+21. **`DeferredExecutor` import path**: `DeferredExecutor` is Rust-backed and must be imported via `from dcc_mcp_core._core import DeferredExecutor` until it is added to the public `__init__.py` exports. Always check `__init__.py` first.
 
 ## CI/CD Summary
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -38,7 +38,7 @@ dcc-mcp-core is a **Rust workspace** with Python bindings via PyO3. All logic li
 sub-crates; the root crate re-exports everything into a single `dcc_mcp_core._core` Python
 extension module. The Python package `dcc_mcp_core` re-exports all public APIs from `_core`.
 
-**Zero runtime Python dependencies** — install with just `pip install dcc-mcp-core`.
+**12 crates** — **Zero runtime Python dependencies** — install with just `pip install dcc-mcp-core`.
 
 ```
 crates/
@@ -1539,9 +1539,18 @@ channel.send_notify("mesh_ready", data=desc.encode())
 
 ## MCP HTTP Server (`dcc_mcp_core`)
 
-The `dcc-mcp-http` crate provides a **MCP Streamable HTTP server** compliant with the 2025-03-26 MCP
-specification. It uses axum + Tokio and runs in a background thread, making it safe to call from any
+The `dcc-mcp-http` crate provides a **MCP Streamable HTTP server** compliant with the **2025-03-26 MCP
+specification**. It uses axum + Tokio and runs in a background thread, making it safe to call from any
 DCC main thread.
+
+> **MCP Spec Roadmap**: The 2025-11-05 draft spec introduces:
+> - **JSON-RPC Batching** — multiple tool calls in one round-trip
+> - **Resource Links in Tool Results** — tools can return resource links for dynamic discovery
+> - **Event Streams** — server-initiated push notifications
+> - **Improved Error Taxonomy** — finer-grained error codes
+>
+> When these features land in `dcc-mcp-core`, they will be exposed via `McpHttpServer` —
+> do NOT implement these manually.
 
 ### McpHttpConfig
 

--- a/llms.txt
+++ b/llms.txt
@@ -57,12 +57,12 @@ meta = dcc_mcp_core.parse_skill_md(dirs[0])  # -> SkillMetadata or None
 - Build from source: `maturin develop --features python-bindings,ext-module`
 - Python: >=3.7 (CI tests 3.7–3.13; abi3-py38 wheel for 3.8+)
 - Build: maturin (Rust 1.85+ + PyO3)
-- Version: 0.12.7
+- Version: 0.12.9
 - License: MIT
 
 ## Architecture
 
-Rust workspace (11 crates) with PyO3 bindings. All logic in Rust sub-crates; Python gets a single `dcc_mcp_core._core` extension module. The `dcc_mcp_core` package re-exports all ~130 public symbols from `_core`.
+Rust workspace (12 crates) with PyO3 bindings. All logic in Rust sub-crates; Python gets a single `dcc_mcp_core._core` extension module. The `dcc_mcp_core` package re-exports all ~130 public symbols from `_core`.
 
 ```
 crates/
@@ -167,8 +167,9 @@ crates/
 ### MCP HTTP Server (`dcc_mcp_core`)
 
 - `McpHttpConfig(port=8765, server_name=None, server_version=None, enable_cors=False, request_timeout_ms=30000)` — server configuration
-- `McpHttpServer(registry, config=None)` — MCP Streamable HTTP server (2025-03-26 spec), axum/Tokio backend
+- `McpHttpServer(registry, config=None)` — MCP Streamable HTTP server (**2025-03-26 spec**), axum/Tokio backend
   - `.start() -> McpServerHandle` — starts background thread, returns immediately
+  - **Note**: MCP 2025-11-05 draft will add JSON-RPC batching and resource links in tool results — do NOT implement manually
 - `McpServerHandle` (alias for `ServerHandle`) — handle to running server
   - `.mcp_url() -> str` — full MCP endpoint URL (e.g. `"http://127.0.0.1:8765/mcp"`)
   - `.port -> int`, `.bind_addr -> str`


### PR DESCRIPTION
## Summary

Run #6 of daily AI docs optimization automation. Updates all AI agent guidance files to v0.12.9 and adds MCP 2025-11-05 draft spec awareness.

## Changes

### Version Updates
- All files: `0.12.7` → `0.12.9` (the current release)

### Factual Corrections
- **CLAUDE.md**: `11 Rust crates` → `12 Rust crates` (dcc-mcp-http was added in v0.12.7 making it 12)
- **CLAUDE.md**: `~120 public symbols` → `~130 public symbols`
- **GEMINI.md**: `11 Rust crates` → `12 Rust crates`
- **llms.txt**: `11 crates` → `12 crates`

### New Content

#### MCP 2025-11-05 Draft Spec Awareness
The upcoming MCP draft spec introduces:
- **JSON-RPC Batching** — multiple tool calls per round-trip, reduces latency for bulk ops
- **Resource Links in Tool Results** — dynamic resource discovery from tool responses  
- **Event Streams** — server-initiated push notifications
- **Improved Error Taxonomy** — finer-grained error codes

All AI agent files now document these features as *upcoming* and explicitly warn agents NOT to implement them manually — wait for `McpHttpServer` to expose them.

#### New Pitfalls
- **AGENTS.md** Pitfall #17: MCP 2025-11-05 draft spec awareness
- **AGENTS.md** Pitfall #18: `scan_and_load` keyword-only arguments
- **GEMINI.md** Pitfalls #19–21: MCP draft, scan_and_load kwargs, DeferredExecutor import path

#### SKILL.md Enhancements
- **Pattern 8**: DCC main-thread safety with `DeferredExecutor` (Maya/Blender/Houdini)
- **MCP Specification Roadmap** table with feature status
- **Common Pitfalls** section with 6 concise pitfalls

#### External References
- Added direct links to MCP 2025-03-26 and 2025-11-05 draft specifications

#### DeferredExecutor Tips
- **CLAUDE.md** + **GEMINI.md**: Document the current import path (`from dcc_mcp_core._core import DeferredExecutor`) until it is promoted to the public API

## Files Changed

| File | Changes |
|------|---------|
| `AGENTS.md` | v0.12.9, symbol hint, 3 new pitfalls, spec roadmap links |
| `CLAUDE.md` | 12 crates, ~130 symbols, v0.12.9, DeferredExecutor + MCP tips |
| `GEMINI.md` | 12 crates, v0.12.9, 3 new pitfalls |
| `llms.txt` | v0.12.9, 12 crates, McpHttpServer spec note |
| `llms-full.txt` | 12 crates, MCP 2025-11-05 roadmap block |
| `.agents/skills/dcc-mcp-core/SKILL.md` | v0.12.9, Pattern 8, MCP roadmap table, pitfalls |

## CI Expectation

Docs-only changes → Rust rebuild skipped → fast CI path (~5 min)

---
*Generated by automated AI docs optimization (Run #6 — 2026-04-09)*