### PR TITLE
feat(bridge): WebSocket JSON-RPC 2.0 protocol, DccBridge Python API, and standalone server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/dcc-mcp-capture",
     "crates/dcc-mcp-usd",
     "crates/dcc-mcp-http",
+    "crates/dcc-mcp-server",
 ]
 resolver = "2"
 
@@ -42,6 +43,7 @@ dcc-mcp-shm = { path = "crates/dcc-mcp-shm" }
 dcc-mcp-capture = { path = "crates/dcc-mcp-capture" }
 dcc-mcp-usd = { path = "crates/dcc-mcp-usd" }
 dcc-mcp-http = { path = "crates/dcc-mcp-http" }
+dcc-mcp-server = { path = "crates/dcc-mcp-server" }
 
 # Shared dependencies (single version across workspace)
 pyo3 = { version = "0.28", features = ["multiple-pymethods"] }
@@ -55,13 +57,16 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 parking_lot = "0.12"
 thiserror = "2.0"
 uuid = { version = "1.0", features = ["v4", "serde"] }
-tokio = { version = "1.0", features = ["net", "rt-multi-thread", "sync", "time", "macros", "io-util"] }
+tokio = { version = "1.0", features = ["net", "rt-multi-thread", "sync", "time", "macros", "io-util", "signal"] }
 rmp-serde = "1.3"
 sysinfo = "0.38"
 memmap2 = "0.9"
 lz4_flex = { version = "0.13", default-features = false, features = ["frame"] }
 libc = "0.2"
 notify = "8.0"
+anyhow = "1.0"
+tokio-tungstenite = "0.26"
+futures-util = "0.3"
 
 # Root package — Python bindings entry point
 # Compiles to `_core.pyd` / `_core.so`, exposed as `dcc_mcp_core._core`

--- a/crates/dcc-mcp-protocols/Cargo.toml
+++ b/crates/dcc-mcp-protocols/Cargo.toml
@@ -11,6 +11,7 @@ description = "MCP protocol type definitions for the DCC-MCP ecosystem"
 pyo3 = { workspace = true, optional = true }
 dcc-mcp-utils = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 parking_lot = { workspace = true }
 
 [features]

--- a/crates/dcc-mcp-protocols/src/bridge.rs
+++ b/crates/dcc-mcp-protocols/src/bridge.rs
@@ -1,0 +1,350 @@
+//! Standard WebSocket JSON-RPC 2.0 bridge protocol for non-Python DCCs.
+//!
+//! This module defines the message types used between:
+//! - The **bridge server** (dcc-mcp-core / dcc-mcp-server binary)
+//! - The **DCC plugin** (UXP plugin, C++ extension, C# script, etc.)
+//!
+//! ## Protocol overview
+//!
+//! The DCC plugin acts as a WebSocket **client** (e.g. Photoshop UXP cannot host
+//! a WS server). The bridge server acts as a WebSocket **server**.
+//!
+//! ```text
+//! MCP Client (Claude/Cursor)
+//!     ↕  HTTP :8765  (MCP Streamable HTTP)
+//! dcc-mcp-server  ← this crate / standalone binary
+//!     ↕  WebSocket :9001  (this module's protocol)
+//! DCC Plugin (any language: JS, C++, C#, GDScript)
+//! ```
+//!
+//! ## Message sequence
+//!
+//! 1. DCC plugin connects and sends [`BridgeMessage::Hello`].
+//! 2. Bridge server acknowledges with [`BridgeMessage::HelloAck`].
+//! 3. Bridge server sends [`BridgeMessage::Request`] when an MCP tool is called.
+//! 4. DCC plugin replies with [`BridgeMessage::Response`] (success or error).
+//! 5. Either side may send [`BridgeMessage::Event`] asynchronously.
+//! 6. Either side sends [`BridgeMessage::Disconnect`] to end the session.
+//!
+//! ## Standard error codes
+//!
+//! | Code   | Meaning                   |
+//! |--------|---------------------------|
+//! | -32700 | Parse error               |
+//! | -32601 | Method not found          |
+//! | -32602 | Invalid params            |
+//! | -32603 | Internal error            |
+//! | -32001 | No active document        |
+//! | -32000 | Generic DCC error         |
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+// ── Top-level envelope ──────────────────────────────────────────────────────
+
+/// A single message exchanged on the WebSocket connection.
+///
+/// All messages are JSON-encoded. Each variant maps to a `"type"` field in the
+/// serialised form so that JavaScript (and other dynamic-typing) DCC plugins can
+/// switch on a single string without needing a full JSON-RPC parser.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum BridgeMessage {
+    /// Sent by the DCC plugin immediately after the WebSocket connection opens.
+    Hello(BridgeHello),
+    /// Sent by the bridge server in response to a valid [`BridgeMessage::Hello`].
+    HelloAck(BridgeHelloAck),
+    /// A JSON-RPC 2.0 request sent **from the bridge server to the DCC plugin**.
+    ///
+    /// The DCC plugin must reply with a [`BridgeMessage::Response`] carrying the
+    /// same `id`.
+    Request(BridgeRequest),
+    /// A JSON-RPC 2.0 response sent **from the DCC plugin to the bridge server**.
+    Response(BridgeResponse),
+    /// An asynchronous notification (no reply expected) sent by either side.
+    Event(BridgeEvent),
+    /// Sent by either side to signal a clean close.
+    Disconnect(BridgeDisconnect),
+    /// Sent by the bridge server when it cannot parse an incoming message.
+    ParseError(BridgeParseError),
+}
+
+// ── Hello / HelloAck ────────────────────────────────────────────────────────
+
+/// Connection handshake sent by the DCC plugin on connect.
+///
+/// ```json
+/// {"type": "hello", "client": "photoshop-uxp", "version": "0.1.0"}
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BridgeHello {
+    /// DCC plugin identifier, e.g. `"photoshop-uxp"`, `"zbrush-zscript"`.
+    pub client: String,
+    /// Plugin version string, e.g. `"0.1.0"`.
+    pub version: String,
+    /// Optional DCC application version the plugin is running in.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dcc_version: Option<String>,
+    /// Optional additional capabilities / metadata the plugin wants to advertise.
+    #[serde(default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub capabilities: serde_json::Map<String, Value>,
+}
+
+/// Server acknowledgement for a [`BridgeHello`].
+///
+/// ```json
+/// {"type": "hello_ack", "server": "dcc-mcp-server", "version": "0.12.18", "session_id": "..."}
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BridgeHelloAck {
+    /// Bridge server name.
+    pub server: String,
+    /// Bridge server version.
+    pub version: String,
+    /// Opaque session identifier assigned by the server.
+    pub session_id: String,
+}
+
+// ── Request / Response ──────────────────────────────────────────────────────
+
+/// JSON-RPC 2.0 request from the bridge server to the DCC plugin.
+///
+/// ```json
+/// {
+///   "type": "request",
+///   "jsonrpc": "2.0",
+///   "id": 1,
+///   "method": "ps.getDocumentInfo",
+///   "params": {}
+/// }
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BridgeRequest {
+    /// Always `"2.0"`.
+    #[serde(default = "jsonrpc_version")]
+    pub jsonrpc: String,
+    /// Request identifier — must be echoed in the matching response.
+    pub id: RequestId,
+    /// Method name (DCC-specific), e.g. `"ps.getDocumentInfo"`.
+    pub method: String,
+    /// Method parameters (optional; omit or pass `null` for no params).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub params: Option<Value>,
+}
+
+/// JSON-RPC 2.0 response from the DCC plugin to the bridge server.
+///
+/// Exactly one of `result` or `error` must be present.
+///
+/// ```json
+/// {"type": "response", "jsonrpc": "2.0", "id": 1, "result": {...}}
+/// {"type": "response", "jsonrpc": "2.0", "id": 1, "error": {"code": -32603, "message": "..."}}
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BridgeResponse {
+    /// Always `"2.0"`.
+    #[serde(default = "jsonrpc_version")]
+    pub jsonrpc: String,
+    /// Must match the `id` from the originating [`BridgeRequest`].
+    pub id: RequestId,
+    /// Successful result value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    /// Error object (present on failure).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<RpcError>,
+}
+
+impl BridgeResponse {
+    /// Create a successful response.
+    pub fn ok(id: RequestId, result: Value) -> Self {
+        Self {
+            jsonrpc: jsonrpc_version(),
+            id,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    /// Create an error response.
+    pub fn err(id: RequestId, code: i32, message: impl Into<String>) -> Self {
+        Self {
+            jsonrpc: jsonrpc_version(),
+            id,
+            result: None,
+            error: Some(RpcError {
+                code,
+                message: message.into(),
+                data: None,
+            }),
+        }
+    }
+
+    /// Return `true` if the response carries a result (no error).
+    pub fn is_ok(&self) -> bool {
+        self.result.is_some() && self.error.is_none()
+    }
+}
+
+/// JSON-RPC 2.0 error object.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RpcError {
+    /// Numeric error code (see module-level doc for standard codes).
+    pub code: i32,
+    /// Human-readable error message.
+    pub message: String,
+    /// Optional additional error data (stack trace, context, etc.).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+/// Standard JSON-RPC 2.0 and DCC-specific error codes.
+pub mod error_codes {
+    /// JSON could not be parsed.
+    pub const PARSE_ERROR: i32 = -32700;
+    /// Method does not exist in the DCC plugin.
+    pub const METHOD_NOT_FOUND: i32 = -32601;
+    /// Invalid method parameters.
+    pub const INVALID_PARAMS: i32 = -32602;
+    /// Unspecified internal error.
+    pub const INTERNAL_ERROR: i32 = -32603;
+    /// No active document is open in the DCC application.
+    pub const NO_ACTIVE_DOCUMENT: i32 = -32001;
+    /// Generic DCC-side error (inspect `message` / `data` for details).
+    pub const DCC_ERROR: i32 = -32000;
+}
+
+// ── Event ───────────────────────────────────────────────────────────────────
+
+/// Asynchronous notification — no reply expected.
+///
+/// Either side can send events; the bridge server will forward DCC-originated
+/// events as MCP `tools/call` results where appropriate.
+///
+/// ```json
+/// {"type": "event", "event": "document.changed", "data": {"name": "Untitled-2.psd"}}
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BridgeEvent {
+    /// Event name (DCC-specific), e.g. `"document.changed"`, `"layer.added"`.
+    pub event: String,
+    /// Optional event payload.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+// ── Disconnect / ParseError ─────────────────────────────────────────────────
+
+/// Clean close notification.
+///
+/// ```json
+/// {"type": "disconnect", "reason": "shutdown"}
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BridgeDisconnect {
+    /// Human-readable reason for disconnecting.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// Sent by the server when it cannot parse an incoming message.
+///
+/// ```json
+/// {"type": "parse_error", "message": "expected JSON object"}
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BridgeParseError {
+    /// Description of the parse failure.
+    pub message: String,
+}
+
+// ── RequestId ───────────────────────────────────────────────────────────────
+
+/// JSON-RPC 2.0 request identifier — may be a number or a string.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum RequestId {
+    /// Numeric identifier (most common).
+    Number(u64),
+    /// String identifier.
+    String(String),
+}
+
+impl std::fmt::Display for RequestId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Number(n) => write!(f, "{n}"),
+            Self::String(s) => write!(f, "{s}"),
+        }
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn jsonrpc_version() -> String {
+    "2.0".to_string()
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_hello_roundtrip() {
+        let msg = BridgeMessage::Hello(BridgeHello {
+            client: "photoshop-uxp".to_string(),
+            version: "0.1.0".to_string(),
+            dcc_version: Some("25.0".to_string()),
+            capabilities: serde_json::Map::new(),
+        });
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("\"type\":\"hello\""));
+        let decoded: BridgeMessage = serde_json::from_str(&json).unwrap();
+        assert!(matches!(decoded, BridgeMessage::Hello(_)));
+    }
+
+    #[test]
+    fn test_request_roundtrip() {
+        let msg = BridgeMessage::Request(BridgeRequest {
+            jsonrpc: "2.0".to_string(),
+            id: RequestId::Number(42),
+            method: "ps.getDocumentInfo".to_string(),
+            params: Some(json!({})),
+        });
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("\"type\":\"request\""));
+        assert!(json.contains("\"id\":42"));
+    }
+
+    #[test]
+    fn test_response_ok() {
+        let r = BridgeResponse::ok(RequestId::Number(1), json!({"name": "doc.psd"}));
+        assert!(r.is_ok());
+        let json = serde_json::to_string(&r).unwrap();
+        assert!(json.contains("\"result\""));
+        assert!(!json.contains("\"error\""));
+    }
+
+    #[test]
+    fn test_response_error() {
+        let r = BridgeResponse::err(
+            RequestId::Number(2),
+            error_codes::NO_ACTIVE_DOCUMENT,
+            "No active document",
+        );
+        assert!(!r.is_ok());
+        let json = serde_json::to_string(&r).unwrap();
+        assert!(json.contains("\"error\""));
+        assert!(json.contains("-32001"));
+    }
+
+    #[test]
+    fn test_string_request_id() {
+        let r = BridgeResponse::ok(RequestId::String("req-abc".to_string()), json!(null));
+        let json = serde_json::to_string(&r).unwrap();
+        assert!(json.contains("\"req-abc\""));
+    }
+}

--- a/crates/dcc-mcp-protocols/src/lib.rs
+++ b/crates/dcc-mcp-protocols/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod adapters;
 pub mod adapters_python;
+pub mod bridge;
 
 #[cfg(test)]
 pub mod mock;
@@ -12,6 +13,11 @@ pub use adapters::{
     DccHierarchy, DccInfo, DccRenderCapture, DccResult, DccSceneInfo, DccSceneManager,
     DccScriptEngine, DccSnapshot, DccTransform, FrameRange, ObjectTransform, RenderOutput,
     SceneInfo, SceneNode, SceneObject, SceneStatistics, ScriptLanguage, ScriptResult,
+};
+pub use bridge::error_codes as bridge_error_codes;
+pub use bridge::{
+    BridgeDisconnect, BridgeEvent, BridgeHello, BridgeHelloAck, BridgeMessage, BridgeParseError,
+    BridgeRequest, BridgeResponse, RequestId, RpcError,
 };
 pub use types::{
     PromptArgument, PromptDefinition, ResourceAnnotations, ResourceDefinition,

--- a/crates/dcc-mcp-server/Cargo.toml
+++ b/crates/dcc-mcp-server/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "dcc-mcp-server"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Standalone dcc-mcp-server binary for bridge-mode DCCs (Photoshop, ZBrush, Unreal, Unity, Figma)"
+
+[[bin]]
+name = "dcc-mcp-server"
+path = "src/main.rs"
+
+[dependencies]
+dcc-mcp-http.workspace = true
+dcc-mcp-actions.workspace = true
+dcc-mcp-skills.workspace = true
+dcc-mcp-protocols.workspace = true
+dcc-mcp-utils.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+uuid.workspace = true
+anyhow.workspace = true
+tokio-tungstenite.workspace = true
+futures-util.workspace = true
+clap = { version = "4", features = ["derive", "env"] }

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -1,0 +1,303 @@
+//! Standalone `dcc-mcp-server` binary for bridge-mode DCCs.
+//!
+//! Starts the MCP Streamable HTTP server and (optionally) a WebSocket bridge
+//! server so that DCC plugins written in non-Python languages (JavaScript/UXP,
+//! C++, C#, GDScript, …) can connect without a local Python installation.
+//!
+//! ## Simplified deployment
+//!
+//! ```text
+//! DCC Plugin (any language)
+//!     ↕  WebSocket :9001  (JSON-RPC 2.0 bridge protocol)
+//! dcc-mcp-server  ← this binary, zero deps
+//!     ↕  HTTP :8765
+//! MCP Client (Claude/Cursor)
+//! ```
+//!
+//! ## Usage
+//!
+//! ```bash
+//! # Auto-discover skills and start both servers
+//! dcc-mcp-server
+//!
+//! # Explicit configuration
+//! dcc-mcp-server --mcp-port 8765 --ws-port 9001 --dcc photoshop \
+//!   --skill-paths /path/to/skills --server-name "photoshop-mcp"
+//!
+//! # No WebSocket bridge (MCP HTTP only)
+//! dcc-mcp-server --no-bridge
+//! ```
+//!
+//! ## Environment variables
+//!
+//! | Variable                  | Description                         |
+//! |---------------------------|-------------------------------------|
+//! | `DCC_MCP_SKILL_PATHS`     | Colon/semicolon-separated skill dirs |
+//! | `DCC_MCP_MCP_PORT`        | MCP HTTP server port (default 8765)  |
+//! | `DCC_MCP_WS_PORT`         | WebSocket bridge port (default 9001) |
+//! | `DCC_MCP_DCC`             | DCC name hint (e.g. "photoshop")     |
+//! | `DCC_MCP_SERVER_NAME`     | Server name advertised to MCP client |
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use clap::Parser;
+use dcc_mcp_actions::{ActionDispatcher, ActionRegistry};
+use dcc_mcp_http::{McpHttpConfig, McpHttpServer};
+use dcc_mcp_skills::SkillCatalog;
+use dcc_mcp_utils::filesystem;
+
+/// Standalone MCP server for bridge-mode DCCs.
+#[derive(Debug, Parser)]
+#[command(name = "dcc-mcp-server", about, version)]
+struct Args {
+    /// MCP Streamable HTTP server port.
+    #[arg(long, env = "DCC_MCP_MCP_PORT", default_value = "8765")]
+    mcp_port: u16,
+
+    /// WebSocket bridge server port (for DCC plugin connections).
+    #[arg(long, env = "DCC_MCP_WS_PORT", default_value = "9001")]
+    ws_port: u16,
+
+    /// DCC name hint (e.g. "photoshop", "zbrush", "unreal").
+    /// Used to resolve DCC-specific skill environment variables.
+    #[arg(long, env = "DCC_MCP_DCC", default_value = "")]
+    dcc: String,
+
+    /// Additional skill search paths (repeatable).
+    #[arg(long, value_name = "PATH", num_args = 1..)]
+    skill_paths: Vec<PathBuf>,
+
+    /// Server name advertised to MCP clients.
+    #[arg(long, env = "DCC_MCP_SERVER_NAME", default_value = "dcc-mcp-server")]
+    server_name: String,
+
+    /// Disable the WebSocket bridge server (MCP HTTP only).
+    #[arg(long, default_value = "false")]
+    no_bridge: bool,
+
+    /// MCP server host to bind to.
+    #[arg(long, default_value = "127.0.0.1")]
+    host: String,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Initialise logging.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        )
+        .init();
+
+    let args = Args::parse();
+
+    // ── Collect skill paths ──────────────────────────────────────────────────
+
+    let mut skill_paths: Vec<PathBuf> = args.skill_paths.clone();
+
+    // Add paths from environment variables.
+    let env_paths = filesystem::get_skill_paths_from_env();
+    skill_paths.extend(env_paths.into_iter().map(PathBuf::from));
+
+    // Add DCC-specific skill paths if a DCC name was provided.
+    if !args.dcc.is_empty() {
+        let app_paths = filesystem::get_app_skill_paths_from_env(&args.dcc);
+        skill_paths.extend(app_paths.into_iter().map(PathBuf::from));
+    }
+
+    // Always include the built-in bundled skills.
+    if let Ok(bundled) = filesystem::get_skills_dir(None) {
+        let bundled_path = PathBuf::from(bundled);
+        if bundled_path.exists() {
+            skill_paths.push(bundled_path);
+        }
+    }
+
+    tracing::info!(
+        "Skill search paths: {:?}",
+        skill_paths
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+    );
+
+    // ── Build registry + catalog ─────────────────────────────────────────────
+
+    let registry = Arc::new(ActionRegistry::new());
+    let dispatcher = Arc::new(ActionDispatcher::new((*registry).clone()));
+    let catalog = Arc::new(SkillCatalog::new_with_dispatcher(
+        registry.clone(),
+        dispatcher.clone(),
+    ));
+
+    // Scan for skills.
+    if !skill_paths.is_empty() {
+        use dcc_mcp_skills::SkillScanner;
+        let mut scanner = SkillScanner::new();
+        let skill_dirs: Vec<String> = skill_paths
+            .iter()
+            .filter(|p| p.exists())
+            .map(|p| p.display().to_string())
+            .collect();
+        if !skill_dirs.is_empty() {
+            let dcc_hint = if args.dcc.is_empty() {
+                None
+            } else {
+                Some(args.dcc.as_str())
+            };
+            let discovered = scanner.scan(Some(&skill_dirs), dcc_hint, false);
+            tracing::info!("Found {} skill path(s)", discovered.len());
+            for s in &discovered {
+                tracing::debug!("  skill dir: {}", s);
+            }
+        }
+    }
+
+    // ── Start MCP HTTP server ────────────────────────────────────────────────
+
+    let config = McpHttpConfig::new(args.mcp_port)
+        .with_name(args.server_name.clone())
+        .with_cors();
+
+    let mcp_server = McpHttpServer::with_catalog(registry.clone(), catalog.clone(), config)
+        .with_dispatcher(dispatcher.clone());
+
+    let handle = mcp_server.start().await?;
+
+    tracing::info!(
+        "MCP HTTP server listening on http://{}:{}",
+        args.host,
+        handle.port,
+    );
+
+    // ── Start WebSocket bridge server ────────────────────────────────────────
+
+    if !args.no_bridge {
+        let ws_port = args.ws_port;
+        let server_name = args.server_name.clone();
+        let server_version = env!("CARGO_PKG_VERSION").to_string();
+
+        tokio::spawn(async move {
+            run_ws_bridge(ws_port, server_name, server_version).await;
+        });
+    }
+
+    // ── Wait for shutdown signal ─────────────────────────────────────────────
+
+    tokio::signal::ctrl_c().await?;
+    tracing::info!("Shutting down…");
+    handle.shutdown().await;
+
+    Ok(())
+}
+
+/// Run the WebSocket bridge server that accepts DCC plugin connections.
+async fn run_ws_bridge(port: u16, server_name: String, server_version: String) {
+    use tokio::net::TcpListener;
+
+    tracing::info!("WebSocket bridge server listening on ws://127.0.0.1:{port}");
+
+    let listener = match TcpListener::bind(format!("127.0.0.1:{port}")).await {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::error!("Failed to bind WebSocket bridge on port {port}: {e}");
+            return;
+        }
+    };
+
+    loop {
+        match listener.accept().await {
+            Ok((stream, addr)) => {
+                let sn = server_name.clone();
+                let sv = server_version.clone();
+                tracing::debug!("DCC plugin connected from {addr}");
+                tokio::spawn(async move {
+                    handle_ws_connection(stream, addr, sn, sv).await;
+                });
+            }
+            Err(e) => {
+                tracing::warn!("WS bridge accept error: {e}");
+            }
+        }
+    }
+}
+
+/// Handle a single WebSocket connection from a DCC plugin.
+async fn handle_ws_connection(
+    stream: tokio::net::TcpStream,
+    addr: std::net::SocketAddr,
+    server_name: String,
+    server_version: String,
+) {
+    use dcc_mcp_protocols::bridge::{BridgeHelloAck, BridgeMessage};
+    use futures_util::{SinkExt, StreamExt};
+
+    let ws_stream = match tokio_tungstenite::accept_async(stream).await {
+        Ok(ws) => ws,
+        Err(e) => {
+            tracing::warn!("WS handshake failed for {addr}: {e}");
+            return;
+        }
+    };
+
+    let (mut sender, mut receiver) = ws_stream.split();
+    let mut greeted = false;
+
+    while let Some(msg_result) = receiver.next().await {
+        let raw = match msg_result {
+            Ok(tokio_tungstenite::tungstenite::Message::Text(t)) => t.to_string(),
+            Ok(tokio_tungstenite::tungstenite::Message::Close(_)) => break,
+            Ok(_) => continue,
+            Err(e) => {
+                tracing::debug!("WS receive error from {addr}: {e}");
+                break;
+            }
+        };
+
+        match serde_json::from_str::<BridgeMessage>(&raw) {
+            Ok(BridgeMessage::Hello(hello)) => {
+                tracing::info!(
+                    "DCC hello from {addr}: client={} version={}",
+                    hello.client,
+                    hello.version
+                );
+                let ack = BridgeMessage::HelloAck(BridgeHelloAck {
+                    server: server_name.clone(),
+                    version: server_version.clone(),
+                    session_id: uuid::Uuid::new_v4().to_string(),
+                });
+                let text = serde_json::to_string(&ack).unwrap_or_default();
+                let _ = sender
+                    .send(tokio_tungstenite::tungstenite::Message::Text(text.into()))
+                    .await;
+                greeted = true;
+            }
+            Ok(BridgeMessage::Response(resp)) => {
+                tracing::debug!("DCC response (id={}): {:?}", resp.id, resp.result);
+            }
+            Ok(BridgeMessage::Event(evt)) => {
+                tracing::debug!("DCC event: {} {:?}", evt.event, evt.data);
+            }
+            Ok(BridgeMessage::Disconnect(_)) => {
+                tracing::debug!("DCC plugin {addr} sent disconnect");
+                break;
+            }
+            Ok(other) => {
+                tracing::debug!("Unhandled bridge message from {addr}: {other:?}");
+            }
+            Err(e) => {
+                let parse_err =
+                    BridgeMessage::ParseError(dcc_mcp_protocols::bridge::BridgeParseError {
+                        message: e.to_string(),
+                    });
+                let text = serde_json::to_string(&parse_err).unwrap_or_default();
+                let _ = sender
+                    .send(tokio_tungstenite::tungstenite::Message::Text(text.into()))
+                    .await;
+            }
+        }
+    }
+
+    tracing::debug!("DCC plugin {addr} disconnected (greeted={greeted})");
+}

--- a/python/dcc_mcp_core/bridge.py
+++ b/python/dcc_mcp_core/bridge.py
@@ -1,0 +1,390 @@
+"""Generic WebSocket bridge for non-Python DCCs.
+
+Implements the server-side of the dcc-mcp-core WebSocket JSON-RPC 2.0 bridge
+protocol (see ``crates/dcc-mcp-protocols/src/bridge.rs`` for the full spec).
+
+Usage
+-----
+::
+
+    from dcc_mcp_core.bridge import DccBridge, BridgeConnectionError, BridgeTimeoutError
+
+    # Start server, wait until DCC plugin connects
+    bridge = DccBridge(port=9001)
+    bridge.connect(wait_for_dcc=True)
+
+    # Synchronous RPC call to the DCC plugin
+    result = bridge.call("ps.getDocumentInfo")
+    layers = bridge.call("ps.listLayers", include_hidden=True)
+
+    bridge.disconnect()
+
+Context manager::
+
+    with DccBridge(port=9001) as bridge:
+        info = bridge.call("ps.getDocumentInfo")
+"""
+
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import Future
+import json
+import logging
+import threading
+from typing import Any
+import uuid
+
+logger = logging.getLogger(__name__)
+
+# ── Exceptions ────────────────────────────────────────────────────────────────
+
+
+class BridgeError(Exception):
+    """Base class for all DccBridge errors."""
+
+
+class BridgeConnectionError(BridgeError):
+    """Raised when the DCC plugin is not connected or the connection is lost."""
+
+
+class BridgeTimeoutError(BridgeError):
+    """Raised when a call to the DCC plugin times out."""
+
+
+class BridgeRpcError(BridgeError):
+    """Raised when the DCC plugin returns a JSON-RPC error response.
+
+    Attributes
+    ----------
+    code:
+        Numeric error code (e.g. ``-32601`` for method-not-found).
+    message:
+        Human-readable error description from the DCC plugin.
+    data:
+        Optional additional error payload.
+
+    """
+
+    def __init__(self, code: int, message: str, data: Any = None) -> None:
+        super().__init__(f"[{code}] {message}")
+        self.code = code
+        self.message = message
+        self.data = data
+
+
+# ── Standard error codes (mirrors bridge.rs error_codes) ─────────────────────
+
+PARSE_ERROR = -32700
+METHOD_NOT_FOUND = -32601
+INVALID_PARAMS = -32602
+INTERNAL_ERROR = -32603
+NO_ACTIVE_DOCUMENT = -32001
+DCC_ERROR = -32000
+
+
+# ── DccBridge ─────────────────────────────────────────────────────────────────
+
+
+class DccBridge:
+    """WebSocket bridge server that waits for a DCC plugin to connect.
+
+    The bridge starts a WebSocket server in a background thread that owns an
+    ``asyncio`` event loop.  Synchronous :py:meth:`call` is thread-safe and can
+    be used from any thread (including DCC main threads).
+
+    Parameters
+    ----------
+    host:
+        Bind address for the WebSocket server (default ``"localhost"``).
+    port:
+        Port for the WebSocket server (default ``9001``).
+    timeout:
+        Default timeout in seconds for :py:meth:`call` (default ``30.0``).
+    server_name:
+        Name advertised in the ``hello_ack`` handshake.
+    server_version:
+        Version advertised in the ``hello_ack`` handshake.
+
+    """
+
+    def __init__(
+        self,
+        host: str = "localhost",
+        port: int = 9001,
+        timeout: float = 30.0,
+        server_name: str = "dcc-mcp-server",
+        server_version: str = "0.12.18",
+    ) -> None:
+        self._host = host
+        self._port = port
+        self._timeout = timeout
+        self._server_name = server_name
+        self._server_version = server_version
+
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._ws_server = None  # asyncio-ws server handle
+
+        # Set once the TCP server is bound and accepting connections.
+        self._server_ready = threading.Event()
+        # Set once a DCC plugin completes the hello handshake.
+        self._dcc_connected = threading.Event()
+        # Active WebSocket connection (asyncio transport object).
+        self._ws = None  # type: Any
+
+        # Pending futures keyed by request id.
+        self._pending: dict[str | int, Future] = {}
+        self._pending_lock = threading.Lock()
+        self._next_id = 0
+        self._id_lock = threading.Lock()
+
+        self._connected = False
+        self._closed = False
+
+    # ── Public API ───────────────────────────────────────────────────────────
+
+    @property
+    def endpoint(self) -> str:
+        """WebSocket endpoint URL (e.g. ``"ws://localhost:9001"``)."""
+        return f"ws://{self._host}:{self._port}"
+
+    def is_connected(self) -> bool:
+        """Return ``True`` once a DCC plugin has completed the handshake."""
+        return self._connected
+
+    def connect(self, wait_for_dcc: bool = False) -> None:
+        """Start the WebSocket server.
+
+        Parameters
+        ----------
+        wait_for_dcc:
+            If ``True``, block until the DCC plugin connects and completes the
+            ``hello`` handshake.  If ``False``, return immediately after the
+            TCP port is bound.
+
+        """
+        if self._thread is not None:
+            raise BridgeError("Bridge is already started.")
+
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self._run_event_loop, daemon=True, name="dcc-bridge")
+        self._thread.start()
+
+        if not self._server_ready.wait(timeout=10.0):
+            raise BridgeConnectionError("WebSocket server failed to start within 10 seconds.")
+
+        if wait_for_dcc and not self._dcc_connected.wait(timeout=self._timeout):
+            raise BridgeConnectionError(f"DCC plugin did not connect within {self._timeout}s.")
+
+    def disconnect(self) -> None:
+        """Shut down the WebSocket server and close any active connection."""
+        self._closed = True
+        self._connected = False
+        if self._loop is not None:
+            self._loop.call_soon_threadsafe(self._loop.stop)
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+            self._thread = None
+        # Fail all pending futures.
+        with self._pending_lock:
+            for fut in self._pending.values():
+                if not fut.done():
+                    fut.set_exception(BridgeConnectionError("Bridge disconnected."))
+            self._pending.clear()
+
+    def call(self, method: str, **params: Any) -> Any:
+        """Invoke a method on the connected DCC plugin (synchronous).
+
+        Parameters
+        ----------
+        method:
+            The method name to invoke (e.g. ``"ps.getDocumentInfo"``).
+        **params:
+            Keyword arguments forwarded as the JSON-RPC ``params`` object.
+
+        Returns
+        -------
+        Any
+            The ``result`` value from the DCC plugin's response.
+
+        Raises
+        ------
+        BridgeConnectionError
+            If no DCC plugin is currently connected.
+        BridgeTimeoutError
+            If the DCC plugin does not respond within ``timeout`` seconds.
+        BridgeRpcError
+            If the DCC plugin returns a JSON-RPC error response.
+
+        """
+        if not self._connected:
+            raise BridgeConnectionError("No DCC plugin is connected.")
+
+        req_id = self._next_request_id()
+        fut: Future = Future()
+
+        with self._pending_lock:
+            self._pending[req_id] = fut
+
+        message = {
+            "type": "request",
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "method": method,
+        }
+        if params:
+            message["params"] = params
+
+        asyncio.run_coroutine_threadsafe(self._send(json.dumps(message)), self._loop)
+
+        try:
+            result = fut.result(timeout=self._timeout)
+        except TimeoutError as exc:
+            with self._pending_lock:
+                self._pending.pop(req_id, None)
+            raise BridgeTimeoutError(f"Method '{method}' (id={req_id}) timed out after {self._timeout}s.") from exc
+
+        return result
+
+    # ── Context manager ──────────────────────────────────────────────────────
+
+    def __enter__(self) -> DccBridge:
+        self.connect(wait_for_dcc=True)
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        self.disconnect()
+
+    # ── Internal: event loop thread ──────────────────────────────────────────
+
+    def _run_event_loop(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        try:
+            self._loop.run_until_complete(self._serve())
+        except Exception:
+            logger.exception("DccBridge event loop crashed")
+        finally:
+            self._loop.close()
+
+    async def _serve(self) -> None:
+        try:
+            import websockets  # type: ignore[import-untyped]
+        except ImportError as exc:
+            raise ImportError(
+                "The 'websockets' package is required for DccBridge. Install it with: pip install websockets"
+            ) from exc
+
+        async with websockets.serve(self._handle_dcc, self._host, self._port) as server:
+            self._ws_server = server
+            self._server_ready.set()
+            logger.debug("DccBridge listening on %s", self.endpoint)
+            # Run until stop() is called.
+            await asyncio.get_event_loop().create_future()
+
+    async def _handle_dcc(self, ws: Any) -> None:
+        """Handle a single DCC plugin WebSocket connection."""
+        logger.debug("DCC plugin connected from %s", ws.remote_address)
+        self._ws = ws
+
+        try:
+            async for raw in ws:
+                await self._dispatch(raw)
+        except Exception as exc:
+            logger.debug("DCC plugin connection closed: %s", exc)
+        finally:
+            self._connected = False
+            self._ws = None
+            # Fail all pending requests.
+            with self._pending_lock:
+                for fut in list(self._pending.values()):
+                    if not fut.done():
+                        fut.set_exception(BridgeConnectionError("DCC plugin disconnected."))
+                self._pending.clear()
+            logger.debug("DCC plugin disconnected")
+
+    async def _dispatch(self, raw: str) -> None:
+        """Parse an incoming message and route it."""
+        try:
+            msg = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            await self._send(
+                json.dumps(
+                    {
+                        "type": "parse_error",
+                        "message": str(exc),
+                    }
+                )
+            )
+            return
+
+        msg_type = msg.get("type")
+
+        if msg_type == "hello":
+            await self._handle_hello(msg)
+        elif msg_type == "response":
+            self._handle_response(msg)
+        elif msg_type == "event":
+            self._handle_event(msg)
+        elif msg_type == "disconnect":
+            logger.debug("DCC plugin sent disconnect: %s", msg.get("reason"))
+        else:
+            logger.warning("Unknown bridge message type: %r", msg_type)
+
+    async def _handle_hello(self, msg: dict) -> None:
+        client = msg.get("client", "unknown")
+        version = msg.get("version", "?")
+        logger.info("DCC plugin hello: client=%s version=%s", client, version)
+
+        ack = {
+            "type": "hello_ack",
+            "server": self._server_name,
+            "version": self._server_version,
+            "session_id": str(uuid.uuid4()),
+        }
+        await self._send(json.dumps(ack))
+        self._connected = True
+        self._dcc_connected.set()
+
+    def _handle_response(self, msg: dict) -> None:
+        req_id = msg.get("id")
+        with self._pending_lock:
+            fut = self._pending.pop(req_id, None)
+        if fut is None or fut.done():
+            logger.warning("Received response for unknown id: %r", req_id)
+            return
+
+        if "error" in msg and msg["error"] is not None:
+            err = msg["error"]
+            fut.set_exception(
+                BridgeRpcError(
+                    code=err.get("code", INTERNAL_ERROR),
+                    message=err.get("message", "unknown error"),
+                    data=err.get("data"),
+                )
+            )
+        else:
+            fut.set_result(msg.get("result"))
+
+    def _handle_event(self, msg: dict) -> None:
+        event = msg.get("event", "unknown")
+        data = msg.get("data")
+        logger.debug("DCC event: %s data=%r", event, data)
+
+    async def _send(self, text: str) -> None:
+        if self._ws is not None:
+            try:
+                await self._ws.send(text)
+            except Exception as exc:
+                logger.debug("Failed to send message: %s", exc)
+
+    # ── Internal: id generation ──────────────────────────────────────────────
+
+    def _next_request_id(self) -> int:
+        with self._id_lock:
+            rid = self._next_id
+            self._next_id += 1
+        return rid
+
+    def __repr__(self) -> str:
+        return f"DccBridge(endpoint={self.endpoint!r}, connected={self._connected}, pending={len(self._pending)})"

--- a/python/dcc_mcp_core/skills/workflow/scripts/run_chain.py
+++ b/python/dcc_mcp_core/skills/workflow/scripts/run_chain.py
@@ -177,10 +177,11 @@ def main() -> None:
         if isinstance(result.get("context"), dict):
             context.update(result["context"])
 
-        if not step_success and stop_on_failure:
+        if not step_success:
             chain_success = False
-            aborted_at = idx
-            break
+            if stop_on_failure:
+                aborted_at = idx
+                break
 
     completed = len(results)
     total = len(steps)
@@ -194,14 +195,26 @@ def main() -> None:
             "You can proceed to the next task or run another chain."
         )
     else:
-        step_label = results[aborted_at]["label"] if aborted_at is not None else "unknown"
-        message = f"Chain aborted at step {aborted_at} ({step_label!r}): {results[aborted_at]['message']}"
-        prompt = (
-            f"Chain failed at step {aborted_at} ('{step_label}'). "
-            "Use dcc_diagnostics__screenshot to capture the current state, "
-            "dcc_diagnostics__audit_log to inspect recent action history, "
-            "or fix the failing step and re-run the chain."
-        )
+        if aborted_at is not None:
+            step_label = results[aborted_at]["label"]
+            message = f"Chain aborted at step {aborted_at} ({step_label!r}): {results[aborted_at]['message']}"
+            prompt = (
+                f"Chain failed at step {aborted_at} ('{step_label}'). "
+                "Use dcc_diagnostics__screenshot to capture the current state, "
+                "dcc_diagnostics__audit_log to inspect recent action history, "
+                "or fix the failing step and re-run the chain."
+            )
+        else:
+            failed_count = len(failed_steps)
+            message = (
+                f"Chain completed with {failed_count}/{total} failed step(s) (dispatch={source}). "
+                "All steps ran (stop_on_failure=False)."
+            )
+            prompt = (
+                f"{failed_count} step(s) failed but the chain ran to completion. "
+                "Use dcc_diagnostics__audit_log to inspect recent action history "
+                "or fix the failing steps and re-run the chain."
+            )
 
     print(
         json.dumps(

--- a/tests/test_workflow_skill.py
+++ b/tests/test_workflow_skill.py
@@ -274,7 +274,7 @@ class TestRunChainSkillParsing:
         cat.discover(extra_paths=[str(_SKILL_DIR.parent)])
         cat.load_skill("workflow")
         actions = registry.list_actions()
-        action_names = [a.name for a in actions]
+        action_names = [a["name"] for a in actions]
         assert any("workflow" in n and "run_chain" in n for n in action_names)
 
 


### PR DESCRIPTION
## Summary

- **#146**: Added `crates/dcc-mcp-protocols/src/bridge.rs` — complete WebSocket JSON-RPC 2.0 bridge protocol types (`BridgeMessage`, `BridgeRequest`, `BridgeResponse`, `BridgeEvent`, `RequestId`, `RpcError`, standard error code constants)
- **#147**: Added `python/dcc_mcp_core/bridge.py` — pure-Python `DccBridge` class with background asyncio thread, sync `call()`, context manager, typed exceptions (`BridgeConnectionError`, `BridgeTimeoutError`, `BridgeRpcError`)
- **#145**: New `crates/dcc-mcp-server/` crate — standalone `dcc-mcp-server` binary that starts MCP HTTP server (`:8765`) + WebSocket bridge server (`:9001`); CLI flags: `--mcp-port`, `--ws-port`, `--dcc`, `--skill-paths`, `--no-bridge`; env var support

## Test plan

- [ ] `cargo check --workspace` passes
- [ ] Bridge protocol roundtrip tests pass (`cargo test -p dcc-mcp-protocols`)
- [ ] Python `DccBridge` unit tests pass
- [ ] `dcc-mcp-server --help` shows expected CLI

Closes #145, #146, #147