### PR TITLE
ci(release): build and publish dcc-mcp-server standalone binaries on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install cargo-tarpaulin
         run: cargo install cargo-tarpaulin --locked
       - name: Run Rust coverage
-        run: cargo tarpaulin --workspace --out Xml --output-dir coverage/ --timeout 300
+        run: just rust-cov
       - name: Upload Rust coverage to Codecov
         uses: codecov/codecov-action@v6
         with:
@@ -195,8 +195,8 @@ jobs:
         with:
           python-version: "3.13"
       - uses: extractions/setup-just@v4
-      - name: Install ruff
-        run: pip install ruff
+      - name: Install dev deps
+        run: just install-dev-deps
       - name: Lint
         run: just lint-py
 
@@ -241,5 +241,5 @@ jobs:
         shell: bash
 
       - name: Run mcporter e2e tests
-        run: pytest tests/test_mcp_mcporter_e2e.py -v --tb=short
+        run: just test-e2e
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,8 @@ jobs:
           toolchain: '1.90.0'
           targets: aarch64-apple-darwin  # needed for macOS universal2 lipo
 
+      - uses: extractions/setup-just@v4
+
       - name: Cache Cargo
         uses: actions/cache@v5
         with:
@@ -75,16 +77,11 @@ jobs:
 
       - name: Build binary (macOS universal2)
         if: matrix.os == 'macos-latest'
-        run: |
-          cargo build --release -p dcc-mcp-server --target x86_64-apple-darwin
-          cargo build --release -p dcc-mcp-server --target aarch64-apple-darwin
-          lipo -create -output ${{ matrix.artifact_name }} \
-            target/x86_64-apple-darwin/release/dcc-mcp-server \
-            target/aarch64-apple-darwin/release/dcc-mcp-server
+        run: just build-server-universal
 
       - name: Build binary (Linux / Windows)
         if: matrix.os != 'macos-latest'
-        run: cargo build --release -p dcc-mcp-server
+        run: just build-server
         shell: bash
 
       - name: Stage artifact (Linux / Windows)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,71 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+  # ── Build standalone dcc-mcp-server binaries ──
+  build-binaries:
+    needs: [release-please]
+    if: needs.release-please.outputs.release_created == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact_name: dcc-mcp-server-linux-x86_64
+            binary: dcc-mcp-server
+          - os: windows-latest
+            artifact_name: dcc-mcp-server-windows-x86_64.exe
+            binary: dcc-mcp-server.exe
+          - os: macos-latest
+            artifact_name: dcc-mcp-server-macos-universal2
+            binary: dcc-mcp-server
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: '1.90.0'
+          targets: aarch64-apple-darwin  # needed for macOS universal2 lipo
+
+      - name: Cache Cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-binary-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-binary-
+
+      - name: Build binary (macOS universal2)
+        if: matrix.os == 'macos-latest'
+        run: |
+          cargo build --release -p dcc-mcp-server --target x86_64-apple-darwin
+          cargo build --release -p dcc-mcp-server --target aarch64-apple-darwin
+          lipo -create -output ${{ matrix.artifact_name }} \
+            target/x86_64-apple-darwin/release/dcc-mcp-server \
+            target/aarch64-apple-darwin/release/dcc-mcp-server
+
+      - name: Build binary (Linux / Windows)
+        if: matrix.os != 'macos-latest'
+        run: cargo build --release -p dcc-mcp-server
+        shell: bash
+
+      - name: Stage artifact (Linux / Windows)
+        if: matrix.os != 'macos-latest'
+        run: cp target/release/${{ matrix.binary }} ${{ matrix.artifact_name }}
+        shell: bash
+
+      - name: Upload binary to GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ needs.release-please.outputs.tag_name }}
+          files: ${{ matrix.artifact_name }}
+
   # ── Build wheels only when release-please creates a release ──
   build-wheels:
     needs: [release-please]

--- a/justfile
+++ b/justfile
@@ -1,5 +1,7 @@
-﻿# dcc-mcp-core development commands
-# Usage: just <recipe>  (or: vx just <recipe>)
+# dcc-mcp-core development commands
+# Usage: just <recipe>  (or: just --list)
+#
+# All CI jobs use these recipes — local and CI are identical.
 
 set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
 set shell := ["sh", "-cu"]
@@ -7,31 +9,58 @@ set shell := ["sh", "-cu"]
 default:
     @just --list
 
-# ── Rust ──
+# ── Rust ──────────────────────────────────────────────────────────────────────
 
-# Check all Rust crates
+# Check all crates compile
 check:
     cargo check --workspace
 
-# Run clippy with CI-identical flags
+# Run clippy (same flags as CI)
 clippy:
     cargo clippy --workspace -- -D warnings
 
-# Format Rust code
+# Format Rust source
 fmt:
     cargo fmt --all
 
-# Format check (CI mode)
+# Check Rust formatting (CI mode — no writes)
 fmt-check:
     cargo fmt --all -- --check
 
-# Run Rust tests
+# Run Rust unit/integration tests
 test-rust:
     cargo test --workspace
 
-# ── Python ──
+# Rust test coverage via cargo-tarpaulin (install: cargo install cargo-tarpaulin)
+rust-cov:
+    cargo tarpaulin --workspace --out Html --out Xml --output-dir coverage/ --timeout 300
 
-# Build and install wheel in dev mode (requires virtualenv or CI env)
+# ── Standalone binary (dcc-mcp-server) ───────────────────────────────────────
+
+# Build dcc-mcp-server for the current platform
+build-server:
+    cargo build --release -p dcc-mcp-server
+
+# Build dcc-mcp-server universal2 binary for macOS (requires both targets installed)
+[unix]
+build-server-universal:
+    #!/usr/bin/env sh
+    set -eu
+    rustup target add x86_64-apple-darwin aarch64-apple-darwin 2>/dev/null || true
+    cargo build --release -p dcc-mcp-server --target x86_64-apple-darwin
+    cargo build --release -p dcc-mcp-server --target aarch64-apple-darwin
+    lipo -create -output dcc-mcp-server-macos-universal2 \
+        target/x86_64-apple-darwin/release/dcc-mcp-server \
+        target/aarch64-apple-darwin/release/dcc-mcp-server
+    echo "Built: dcc-mcp-server-macos-universal2"
+
+# Run the server locally (auto-discovers skills, MCP :8765, WS bridge :9001)
+run-server *ARGS:
+    cargo run --release -p dcc-mcp-server -- {{ARGS}}
+
+# ── Python ────────────────────────────────────────────────────────────────────
+
+# Build and install wheel in dev/editable mode
 [unix]
 dev:
     #!/usr/bin/env sh
@@ -52,51 +81,63 @@ dev:
     pip install maturin -q 2>$null
     maturin develop --features python-bindings,ext-module
 
-# Build wheel + pip install (CI-friendly, no virtualenv required)
+# Build abi3-py38 release wheel and install it
 install:
     maturin build --release --out dist --features python-bindings,ext-module,abi3-py38
     pip install --force-reinstall --no-index --find-links dist dcc-mcp-core
 
-# Run Python tests (requires `just dev` or `just install` first)
+# Build abi3-py38 release wheel (dist/ only, no install)
+build:
+    maturin build --release --features python-bindings,ext-module,abi3-py38
+
+# Build Python 3.7 wheel (non-abi3, for py37-specific CI jobs)
+build-py37:
+    maturin build --release --out dist --features python-bindings,ext-module
+
+# Install dev/test dependencies
+install-dev-deps:
+    pip install maturin pytest pytest-cov anyio ruff
+
+# ── Python tests ──────────────────────────────────────────────────────────────
+
+# Run Python test suite
 test:
     pytest tests/ -v --tb=short
 
-# Run Python tests with coverage
+# Run Python tests with coverage report
 test-cov:
     pytest tests/ -v --cov=dcc_mcp_core --cov-report=term --cov-report=xml:coverage.xml
 
-# Run Rust tests with coverage (requires cargo-tarpaulin)
-rust-cov:
-    cargo tarpaulin --workspace --out Html --out Xml --output-dir coverage/ --timeout 300
+# Run mcporter MCP end-to-end tests (requires: npm install -g mcporter)
+test-e2e:
+    pytest tests/test_mcp_mcporter_e2e.py -v --tb=short
 
-# Lint Python code
+# ── Lint ──────────────────────────────────────────────────────────────────────
+
+# Lint Python source (ruff check only)
 lint-py:
     ruff check python/dcc_mcp_core/ tests/ examples/
 
-# Fix Python lint issues
+# Auto-fix Python lint issues and format
 lint-py-fix:
     ruff check --fix python/dcc_mcp_core/ tests/ examples/
     ruff format python/dcc_mcp_core/ tests/ examples/
 
-# ── Unified commands (CI + local) ──
-
-# Lint all (Rust + Python) — same checks as CI
+# Lint everything: Rust (clippy + fmt-check) + Python (ruff)
 lint: clippy fmt-check lint-py
 
-# Fix all lint issues
+# Fix all fixable lint issues (Rust fmt + Python ruff)
 lint-fix: fmt lint-py-fix
 
-# Pre-flight check — run before committing (same as CI)
+# ── Aggregate targets (CI + local) ────────────────────────────────────────────
+
+# Pre-flight: Rust check + clippy + fmt + tests — run before every commit
 preflight: check clippy fmt-check test-rust
 
-# Full CI pipeline (Rust + Python)
+# Full local CI pipeline: preflight → build wheel → Python tests → lint
 ci: preflight install test lint-py
 
-# Build release wheel
-build:
-    maturin build --release --features python-bindings,ext-module,abi3-py38
-
-# ── Clean ──
+# ── Clean ─────────────────────────────────────────────────────────────────────
 
 [unix]
 clean:


### PR DESCRIPTION
## Summary

- Adds `build-binaries` job to `release.yml` triggered when release-please creates a new release
- Builds `dcc-mcp-server` for 3 platforms in parallel:
  - **Linux**: `dcc-mcp-server-linux-x86_64`
  - **Windows**: `dcc-mcp-server-windows-x86_64.exe`
  - **macOS**: `dcc-mcp-server-macos-universal2` (x86_64 + arm64 merged via `lipo`)
- Each binary is uploaded directly to GitHub Release assets upon completion
- Uses `fail-fast: false` so one platform failure does not cancel others
- Independent of the `publish` (PyPI) job — binaries ship even if PyPI upload fails

## Motivation

The `dcc-mcp-server` binary was added in #145 as a zero-dependency standalone server for bridge-mode DCCs (Photoshop UXP, ZBrush, Unreal, Unity, etc.). Without a pre-built binary, DCC plugin developers need a full Rust toolchain to use it, which is a significant barrier.

## Test plan

- [ ] Verify CI passes on this PR (pre-commit hooks, yaml lint)
- [ ] On next release, confirm GitHub Release assets include all 3 binaries
- [ ] Manually test: `./dcc-mcp-server --help` on each platform