### PR TITLE
fix(skills): fix skill discovery, execution param passing, and script compatibility

### DIFF
--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -131,28 +131,29 @@ async fn main() -> anyhow::Result<()> {
         dispatcher.clone(),
     ));
 
-    // Scan for skills.
-    if !skill_paths.is_empty() {
-        use dcc_mcp_skills::SkillScanner;
-        let mut scanner = SkillScanner::new();
-        let skill_dirs: Vec<String> = skill_paths
-            .iter()
-            .filter(|p| p.exists())
-            .map(|p| p.display().to_string())
-            .collect();
-        if !skill_dirs.is_empty() {
-            let dcc_hint = if args.dcc.is_empty() {
-                None
-            } else {
-                Some(args.dcc.as_str())
-            };
-            let discovered = scanner.scan(Some(&skill_dirs), dcc_hint, false);
-            tracing::info!("Found {} skill path(s)", discovered.len());
-            for s in &discovered {
-                tracing::debug!("  skill dir: {}", s);
-            }
-        }
-    }
+    // Discover skills into the catalog so they appear as stubs in tools/list.
+    // catalog.discover() scans for SKILL.md files and registers each skill as
+    // SkillState::Discovered (unloaded).  Tools from discovered skills show up
+    // as lightweight __skill__<name> stubs in tools/list, enabling agents to
+    // find and load them on demand without pre-loading all schemas.
+    let dcc_hint = if args.dcc.is_empty() {
+        None
+    } else {
+        Some(args.dcc.as_str())
+    };
+    let extra_dirs: Option<Vec<String>> = if skill_paths.is_empty() {
+        None
+    } else {
+        Some(
+            skill_paths
+                .iter()
+                .filter(|p| p.exists())
+                .map(|p| p.display().to_string())
+                .collect(),
+        )
+    };
+    let n = catalog.discover(extra_dirs.as_deref(), dcc_hint);
+    tracing::info!("Discovered {} skill(s) in catalog", n);
 
     // ── Start MCP HTTP server ────────────────────────────────────────────────
 

--- a/crates/dcc-mcp-skills/src/catalog/execute.rs
+++ b/crates/dcc-mcp-skills/src/catalog/execute.rs
@@ -68,12 +68,21 @@ pub(crate) fn resolve_tool_script(
     None
 }
 
-/// Execute a skill script as a subprocess, passing params as JSON via stdin.
+/// Execute a skill script as a subprocess.
 ///
-/// The script is expected to:
-/// - Read JSON params from stdin (or use sys.argv for simple cases)
-/// - Write a JSON result to stdout
-/// - Exit with code 0 on success, non-zero on failure
+/// Parameters are passed in **two complementary ways** so that scripts can use
+/// whichever convention they prefer:
+///
+/// 1. **stdin (preferred)** — the full params JSON object is written to the
+///    child's stdin.  Scripts read it with `json.load(sys.stdin)`.
+///
+/// 2. **CLI flags (argparse-compatible)** — each top-level string/number/bool
+///    key in `params` is also appended as `--<key> <value>` so that scripts
+///    that use `argparse` work without any modification.
+///
+/// The script is expected to write a JSON result to stdout and exit 0 on
+/// success, or exit non-zero on failure (stderr is captured for the error
+/// message).
 ///
 /// Returns `Ok(Value)` on success, `Err(String)` on failure.
 pub(crate) fn execute_script(
@@ -103,8 +112,35 @@ pub(crate) fn execute_script(
     // to run before the script, e.g. "import maya.standalone; maya.standalone.initialize(name='python')"
     let init_snippet = std::env::var("DCC_MCP_PYTHON_INIT_SNIPPET").ok();
 
-    // Choose interpreter based on extension
-    let (program, args): (String, Vec<String>) = match ext.as_str() {
+    // Build CLI args that argparse-based scripts can consume.
+    // Only scalar values (string, number, bool) are expanded; objects/arrays
+    // are left for the stdin JSON path.
+    let mut cli_extra: Vec<String> = Vec::new();
+    if let Some(obj) = params.as_object() {
+        for (key, val) in obj {
+            let flag = format!("--{}", key.replace('_', "-"));
+            match val {
+                serde_json::Value::String(s) => {
+                    cli_extra.push(flag);
+                    cli_extra.push(s.clone());
+                }
+                serde_json::Value::Number(n) => {
+                    cli_extra.push(flag);
+                    cli_extra.push(n.to_string());
+                }
+                serde_json::Value::Bool(b) => {
+                    // Boolean flags: --flag true / --flag false
+                    cli_extra.push(flag);
+                    cli_extra.push(b.to_string());
+                }
+                // Skip null / object / array — too complex for CLI args
+                _ => {}
+            }
+        }
+    }
+
+    // Choose interpreter based on extension, appending the CLI extra args
+    let (program, mut args): (String, Vec<String>) = match ext.as_str() {
         "py" => {
             if let Some(ref snippet) = init_snippet {
                 // Wrap: python -c "exec(open(...).read())" with init prepended
@@ -126,6 +162,8 @@ pub(crate) fn execute_script(
         "mel" | "lua" | "hscript" | "maxscript" => (python_exe, vec![script_path.to_string()]),
         _ => (python_exe, vec![script_path.to_string()]),
     };
+    // Append CLI flags after the script path (or after the -c "..." snippet)
+    args.extend(cli_extra);
 
     let mut child = Command::new(&program)
         .args(&args)
@@ -135,7 +173,7 @@ pub(crate) fn execute_script(
         .spawn()
         .map_err(|e| format!("Failed to spawn '{script_path}': {e}"))?;
 
-    // Write params to stdin
+    // Write full params JSON to stdin so scripts can also do json.load(sys.stdin)
     if let Some(mut stdin) = child.stdin.take() {
         let _ = stdin.write_all(params_json.as_bytes());
         // stdin closes when dropped, signalling EOF to the script

--- a/examples/skills/hello-world/scripts/greet.py
+++ b/examples/skills/hello-world/scripts/greet.py
@@ -1,7 +1,9 @@
 """Hello World skill script — prints a greeting message.
 
-Reads JSON parameters from stdin (preferred) or falls back to sys.argv
-for backwards-compatible invocation.
+Parameter resolution order:
+1. stdin JSON: {"name": "..."} — used by dcc-mcp-core execute_script
+2. CLI positional arg: greet.py <name> — used by direct invocation / tests
+3. Default: "World"
 """
 
 from __future__ import annotations
@@ -12,14 +14,21 @@ import sys
 
 def main() -> None:
     """Entry point for the greet action."""
-    # Primary: read JSON params from stdin (dcc-mcp-core execute_script protocol)
-    try:
-        raw = sys.stdin.read()
-        params = json.loads(raw) if raw.strip() else {}
-    except Exception:
-        params = {}
+    name = "World"
 
-    name = params.get("name", "World")
+    # 1. Try stdin JSON (dcc-mcp-core execute_script protocol)
+    try:
+        if not sys.stdin.isatty():
+            raw = sys.stdin.read()
+            if raw.strip():
+                params = json.loads(raw)
+                name = params.get("name", name)
+    except Exception:
+        pass
+
+    # 2. Fallback: positional CLI arg (legacy / direct invocation)
+    if name == "World" and len(sys.argv) > 1:
+        name = sys.argv[1]
 
     result = {
         "success": True,

--- a/examples/skills/hello-world/scripts/greet.py
+++ b/examples/skills/hello-world/scripts/greet.py
@@ -1,4 +1,8 @@
-"""Hello World skill script — prints a greeting message."""
+"""Hello World skill script — prints a greeting message.
+
+Reads JSON parameters from stdin (preferred) or falls back to sys.argv
+for backwards-compatible invocation.
+"""
 
 from __future__ import annotations
 
@@ -8,9 +12,14 @@ import sys
 
 def main() -> None:
     """Entry point for the greet action."""
-    name = "World"
-    if len(sys.argv) > 1:
-        name = sys.argv[1]
+    # Primary: read JSON params from stdin (dcc-mcp-core execute_script protocol)
+    try:
+        raw = sys.stdin.read()
+        params = json.loads(raw) if raw.strip() else {}
+    except Exception:
+        params = {}
+
+    name = params.get("name", "World")
 
     result = {
         "success": True,

--- a/examples/skills/multi-script/scripts/action_python.py
+++ b/examples/skills/multi-script/scripts/action_python.py
@@ -1,13 +1,24 @@
-"""Python action script example."""
+"""Python action script example.
+
+Reads JSON parameters from stdin (dcc-mcp-core execute_script protocol).
+"""
 
 from __future__ import annotations
 
 import json
+import sys
 
 
 def main() -> None:
     """Execute the Python action."""
-    print(json.dumps({"success": True, "message": "Executed Python action"}))
+    try:
+        raw = sys.stdin.read()
+        params = json.loads(raw) if raw.strip() else {}
+    except Exception:
+        params = {}
+
+    message = params.get("message", "hello")
+    print(json.dumps({"success": True, "message": f"Python says: {message}"}))
 
 
 if __name__ == "__main__":

--- a/examples/skills/workflow/scripts/run_chain.py
+++ b/examples/skills/workflow/scripts/run_chain.py
@@ -88,13 +88,26 @@ def _build_local_dispatcher():
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run a sequence of actions as a chain.")
-    parser.add_argument("--steps", required=True, help="JSON array of step definitions.")
-    parser.add_argument("--context", default="{}", help="JSON object with initial context values.")
+    parser.add_argument("--steps", default=None, help="JSON array of step definitions.")
+    parser.add_argument("--context", default=None, help="JSON object with initial context values.")
     args = parser.parse_args()
 
+    # Prefer CLI args; fall back to reading the full params JSON from stdin.
+    if args.steps is None:
+        try:
+            raw = sys.stdin.read()
+            stdin_params = json.loads(raw) if raw.strip() else {}
+        except Exception:
+            stdin_params = {}
+        steps_str = json.dumps(stdin_params.get("steps", []))
+        context_str = json.dumps(stdin_params.get("context", {}))
+    else:
+        steps_str = args.steps
+        context_str = args.context or "{}"
+
     try:
-        steps = json.loads(args.steps)
-        context: dict = json.loads(args.context)
+        steps = json.loads(steps_str)
+        context: dict = json.loads(context_str)
     except json.JSONDecodeError as exc:
         print(json.dumps({"success": False, "message": f"Invalid JSON input: {exc}"}))
         sys.exit(1)

--- a/python/dcc_mcp_core/skills/workflow/scripts/run_chain.py
+++ b/python/dcc_mcp_core/skills/workflow/scripts/run_chain.py
@@ -89,13 +89,28 @@ def _build_local_dispatcher():
 def main() -> None:
     """Run a sequence of actions as a chain and print JSON result to stdout."""
     parser = argparse.ArgumentParser(description="Run a sequence of actions as a chain.")
-    parser.add_argument("--steps", required=True, help="JSON array of step definitions.")
-    parser.add_argument("--context", default="{}", help="JSON object with initial context values.")
+    parser.add_argument("--steps", default=None, help="JSON array of step definitions.")
+    parser.add_argument("--context", default=None, help="JSON object with initial context values.")
     args = parser.parse_args()
 
+    # Prefer CLI args; fall back to reading the full params JSON from stdin.
+    # dcc-mcp-core execute_script writes params JSON to stdin alongside CLI flags,
+    # so complex values (arrays, nested objects) arrive via stdin.
+    if args.steps is None:
+        try:
+            raw = sys.stdin.read()
+            stdin_params = json.loads(raw) if raw.strip() else {}
+        except Exception:
+            stdin_params = {}
+        steps_str = json.dumps(stdin_params.get("steps", []))
+        context_str = json.dumps(stdin_params.get("context", {}))
+    else:
+        steps_str = args.steps
+        context_str = args.context or "{}"
+
     try:
-        steps = json.loads(args.steps)
-        context: dict = json.loads(args.context)
+        steps = json.loads(steps_str)
+        context: dict = json.loads(context_str)
     except json.JSONDecodeError as exc:
         print(json.dumps({"success": False, "message": f"Invalid JSON input: {exc}"}))
         sys.exit(1)


### PR DESCRIPTION
## Summary

Fixes three interconnected bugs that caused skills to be invisible in `tools/list` and tool calls to silently fail.

### Bug 1 — `dcc-mcp-server`: skill scan result not wired to catalog

`main.rs` called `SkillScanner.scan()` and discarded the result without passing it to `SkillCatalog`. The catalog was always empty, so:
- `tools/list` showed zero `__skill__<name>` stubs
- `load_skill` / `find_skills` found nothing

**Fix**: Replace `SkillScanner.scan()` with `catalog.discover(extra_paths, dcc_hint)` which populates the catalog correctly.

### Bug 2 — `execute_script`: params only sent to stdin, breaking argparse scripts

`execute_script()` wrote the params JSON to stdin only. Nearly all example skills use `argparse` and parse CLI flags — they never received any parameters, so every tool call silently used default values or failed.

**Fix**: In addition to writing JSON to stdin, also expand top-level scalar params as `--key value` CLI flags. Both conventions now work simultaneously:
- `argparse` scripts receive `--format png --scale 2.0` etc. ✅
- `json.load(sys.stdin)` scripts receive the full JSON object ✅

### Bug 3 — Script implementation mismatches

| File | Problem | Fix |
|------|---------|-----|
| `hello-world/greet.py` | Read `sys.argv[1]` instead of stdin JSON | Changed to `json.load(sys.stdin)` |
| `multi-script/action_python.py` | Ignored params entirely | Added stdin JSON read, echoes `message` param |
| `workflow/run_chain.py` (×2) | `--steps required=True` but arrays can't be passed as CLI flags | Made `--steps` optional; falls back to reading full params from stdin |

## Test plan

- [x] `cargo check -p dcc-mcp-skills -p dcc-mcp-server` — clean
- [x] `cargo test -p dcc-mcp-skills -p dcc-mcp-http` — 116 passed, 0 failed
- [x] pre-commit hooks (ruff, cargo fmt, cargo clippy) — all passed
- [ ] CI: mcporter e2e `test_call_skill_tool_after_load` and `test_full_progressive_loading_cycle` should now pass
- [ ] CI: `test_list_skills_returns_discovered_skills` should now find skills in catalog