### PR TITLE
feat(gateway): dcc-mcp-gateway — unified MCP gateway for multi-DCC environments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,68 @@ jobs:
           tag_name: ${{ needs.release-please.outputs.tag_name }}
           files: ${{ matrix.artifact_name }}
 
+  # ── Build standalone dcc-mcp-gateway binaries ──
+  build-gateway-binaries:
+    needs: [release-please]
+    if: needs.release-please.outputs.release_created == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact_name: dcc-mcp-gateway-linux-x86_64
+            binary: dcc-mcp-gateway
+          - os: windows-latest
+            artifact_name: dcc-mcp-gateway-windows-x86_64.exe
+            binary: dcc-mcp-gateway.exe
+          - os: macos-latest
+            artifact_name: dcc-mcp-gateway-macos-universal2
+            binary: dcc-mcp-gateway
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: '1.90.0'
+          targets: aarch64-apple-darwin
+
+      - uses: extractions/setup-just@v4
+
+      - name: Cache Cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-gateway-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-gateway-
+
+      - name: Build gateway (macOS universal2)
+        if: matrix.os == 'macos-latest'
+        run: just build-gateway-universal
+
+      - name: Build gateway (Linux / Windows)
+        if: matrix.os != 'macos-latest'
+        run: just build-gateway
+        shell: bash
+
+      - name: Stage artifact (Linux / Windows)
+        if: matrix.os != 'macos-latest'
+        run: cp target/release/${{ matrix.binary }} ${{ matrix.artifact_name }}
+        shell: bash
+
+      - name: Upload gateway to GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ needs.release-please.outputs.tag_name }}
+          files: ${{ matrix.artifact_name }}
+
   # ── Build wheels only when release-please creates a release ──
   build-wheels:
     needs: [release-please]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/dcc-mcp-usd",
     "crates/dcc-mcp-http",
     "crates/dcc-mcp-server",
+    "crates/dcc-mcp-gateway",
 ]
 resolver = "2"
 
@@ -44,6 +45,7 @@ dcc-mcp-capture = { path = "crates/dcc-mcp-capture" }
 dcc-mcp-usd = { path = "crates/dcc-mcp-usd" }
 dcc-mcp-http = { path = "crates/dcc-mcp-http" }
 dcc-mcp-server = { path = "crates/dcc-mcp-server" }
+dcc-mcp-gateway = { path = "crates/dcc-mcp-gateway" }
 
 # Shared dependencies (single version across workspace)
 pyo3 = { version = "0.28", features = ["multiple-pymethods"] }
@@ -67,6 +69,7 @@ notify = "8.0"
 anyhow = "1.0"
 tokio-tungstenite = "0.29"
 futures-util = "0.3"
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
 
 # Root package — Python bindings entry point
 # Compiles to `_core.pyd` / `_core.so`, exposed as `dcc_mcp_core._core`

--- a/crates/dcc-mcp-gateway/Cargo.toml
+++ b/crates/dcc-mcp-gateway/Cargo.toml
@@ -1,24 +1,20 @@
 [package]
-name = "dcc-mcp-server"
+name = "dcc-mcp-gateway"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Standalone dcc-mcp-server binary for bridge-mode DCCs (Photoshop, ZBrush, Unreal, Unity, Figma)"
+description = "Unified MCP gateway: discovers running DCC instances and routes agent requests"
 
 [[bin]]
-name = "dcc-mcp-server"
+name = "dcc-mcp-gateway"
 path = "src/main.rs"
 
 [dependencies]
-dcc-mcp-http.workspace = true
-dcc-mcp-actions.workspace = true
-dcc-mcp-skills.workspace = true
-dcc-mcp-protocols.workspace = true
-dcc-mcp-utils.workspace = true
 dcc-mcp-transport.workspace = true
+dcc-mcp-utils.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
@@ -26,6 +22,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true
 anyhow.workspace = true
-tokio-tungstenite.workspace = true
-futures-util.workspace = true
+reqwest.workspace = true
+axum = { version = "0.8", features = ["http1", "http2", "tokio"] }
+tower-http = { version = "0.6", features = ["cors", "trace"] }
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/dcc-mcp-gateway/src/main.rs
+++ b/crates/dcc-mcp-gateway/src/main.rs
@@ -1,0 +1,750 @@
+//! `dcc-mcp-gateway` — Unified MCP gateway for multi-DCC environments.
+//!
+//! ## Problem it solves
+//!
+//! In a studio with multiple open DCCs — 3 Maya instances, a Photoshop, a ZBrush —
+//! each runs its own `dcc-mcp-server` on a different port.  An MCP client (Claude,
+//! Cursor) would need to know all those ports upfront.
+//!
+//! The gateway provides **one fixed endpoint** that:
+//!
+//! 1. **Discovers** all running DCC servers via [`FileRegistry`].
+//! 2. **Exposes** them as MCP meta-tools so the agent can list and select instances.
+//! 3. **Proxies** tool calls to the chosen DCC server (transparent HTTP forwarding).
+//!
+//! ## Architecture
+//!
+//! ```text
+//! Agent (Claude / Cursor)
+//!     │  MCP Streamable HTTP  :8888 (fixed)
+//!     ▼
+//! dcc-mcp-gateway          ← this binary
+//!     │  discovers via FileRegistry ($TMPDIR/dcc-mcp/services.json)
+//!     │  proxies via HTTP
+//!     ├─▶  Maya-1   :18812  (scene=shot_01.ma)
+//!     ├─▶  Maya-2   :18813  (scene=shot_02.ma)
+//!     ├─▶  Photoshop :18814  (doc=poster.psd)
+//!     └─▶  ZBrush   :18815
+//! ```
+//!
+//! ## MCP tools exposed by the gateway
+//!
+//! | Tool | Description |
+//! |------|-------------|
+//! | `list_dcc_instances` | List all live DCC servers (type, port, scene, status) |
+//! | `get_dcc_instance` | Get info for a specific instance by id or dcc_type+scene |
+//! | `connect_to_dcc` | Return the MCP URL for a specific instance |
+//!
+//! ## Routing
+//!
+//! ```
+//! POST /mcp                   → gateway meta-tools only
+//! POST /mcp/{instance_id}     → proxy to that specific DCC server
+//! POST /mcp/dcc/{dcc_type}    → proxy to best instance of that DCC type
+//! GET  /instances             → JSON array of all live instances (REST, no MCP)
+//! GET  /health                → {"ok": true}
+//! ```
+//!
+//! ## Environment variables
+//!
+//! | Variable | Description |
+//! |----------|-------------|
+//! | `DCC_MCP_GATEWAY_PORT` | Gateway port (default 8888) |
+//! | `DCC_MCP_REGISTRY_DIR` | FileRegistry directory (default `$TMPDIR/dcc-mcp`) |
+//! | `DCC_MCP_STALE_TIMEOUT` | Seconds before an instance is considered stale (default 30) |
+
+use std::collections::HashMap;
+use std::env;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use axum::extract::{Path, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::{Json, Router, routing};
+use clap::Parser;
+use dcc_mcp_transport::discovery::file_registry::FileRegistry;
+use dcc_mcp_transport::discovery::types::{ServiceEntry, ServiceStatus};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use tokio::sync::RwLock;
+use tower_http::cors::{Any, CorsLayer};
+use tower_http::trace::TraceLayer;
+use tracing::instrument;
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+
+/// Unified MCP gateway for multi-DCC environments.
+#[derive(Debug, Parser)]
+#[command(name = "dcc-mcp-gateway", about, version)]
+struct Args {
+    /// Port for the gateway HTTP server.
+    #[arg(long, env = "DCC_MCP_GATEWAY_PORT", default_value = "8888")]
+    port: u16,
+
+    /// Host to bind to.
+    #[arg(long, default_value = "127.0.0.1")]
+    host: String,
+
+    /// Directory where DCC servers write their registry file.
+    #[arg(long, env = "DCC_MCP_REGISTRY_DIR")]
+    registry_dir: Option<String>,
+
+    /// Seconds without a heartbeat before an instance is considered stale.
+    #[arg(long, env = "DCC_MCP_STALE_TIMEOUT", default_value = "30")]
+    stale_timeout_secs: u64,
+
+    /// Gateway server name reported to MCP clients.
+    #[arg(long, default_value = "dcc-mcp-gateway")]
+    server_name: String,
+}
+
+// ── Shared state ──────────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+struct GatewayState {
+    registry: Arc<RwLock<FileRegistry>>,
+    stale_timeout: Duration,
+    server_name: String,
+    server_version: String,
+    http_client: reqwest::Client,
+}
+
+// ── Instance info (serializable view of ServiceEntry) ────────────────────────
+
+#[derive(Debug, Serialize, Deserialize)]
+struct InstanceInfo {
+    instance_id: String,
+    dcc_type: String,
+    host: String,
+    port: u16,
+    mcp_url: String,
+    status: String,
+    scene: Option<String>,
+    version: Option<String>,
+    metadata: HashMap<String, String>,
+    last_heartbeat_ms: u64,
+    stale: bool,
+}
+
+impl InstanceInfo {
+    fn from_entry(entry: &ServiceEntry, stale_timeout: Duration) -> Self {
+        let last_heartbeat_ms = entry
+            .last_heartbeat
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+
+        let stale = entry.is_stale(stale_timeout);
+        let mcp_url = format!("http://{}:{}/mcp", entry.host, entry.port);
+
+        Self {
+            instance_id: entry.instance_id.to_string(),
+            dcc_type: entry.dcc_type.clone(),
+            host: entry.host.clone(),
+            port: entry.port,
+            mcp_url,
+            status: entry.status.to_string(),
+            scene: entry.scene.clone(),
+            version: entry.version.clone(),
+            metadata: entry.metadata.clone(),
+            last_heartbeat_ms,
+            stale,
+        }
+    }
+}
+
+// ── MCP JSON-RPC types ────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcRequest {
+    #[allow(dead_code)]
+    jsonrpc: String,
+    id: Option<Value>,
+    method: String,
+    params: Option<Value>,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonRpcResponse {
+    jsonrpc: String,
+    id: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<Value>,
+}
+
+impl JsonRpcResponse {
+    fn success(id: Option<Value>, result: Value) -> Self {
+        Self {
+            jsonrpc: "2.0".into(),
+            id,
+            result: Some(result),
+            error: None,
+        }
+    }
+    fn error(id: Option<Value>, code: i32, message: impl Into<String>) -> Self {
+        Self {
+            jsonrpc: "2.0".into(),
+            id,
+            result: None,
+            error: Some(json!({"code": code, "message": message.into()})),
+        }
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn resolve_registry_dir(arg: Option<&str>) -> PathBuf {
+    if let Some(d) = arg {
+        return PathBuf::from(d);
+    }
+    if let Ok(d) = env::var("DCC_MCP_REGISTRY_DIR") {
+        return PathBuf::from(d);
+    }
+    env::temp_dir().join("dcc-mcp")
+}
+
+fn live_instances(registry: &FileRegistry, stale_timeout: Duration) -> Vec<ServiceEntry> {
+    registry
+        .list_all()
+        .into_iter()
+        .filter(|e| {
+            !e.is_stale(stale_timeout)
+                && !matches!(
+                    e.status,
+                    ServiceStatus::ShuttingDown | ServiceStatus::Unreachable
+                )
+        })
+        .collect()
+}
+
+// ── REST handlers ─────────────────────────────────────────────────────────────
+
+/// `GET /health` → `{"ok": true}`
+async fn handle_health() -> impl IntoResponse {
+    Json(json!({"ok": true}))
+}
+
+/// `GET /instances` → JSON array of all live instances.
+#[instrument(skip(state))]
+async fn handle_instances(State(state): State<GatewayState>) -> impl IntoResponse {
+    let registry = state.registry.read().await;
+    let instances: Vec<InstanceInfo> = live_instances(&registry, state.stale_timeout)
+        .iter()
+        .map(|e| InstanceInfo::from_entry(e, state.stale_timeout))
+        .collect();
+    Json(json!({
+        "total": instances.len(),
+        "instances": instances,
+    }))
+}
+
+// ── MCP gateway handler ───────────────────────────────────────────────────────
+
+/// `POST /mcp` — gateway's own MCP endpoint with discovery meta-tools.
+#[instrument(skip(state, body))]
+async fn handle_gateway_mcp(
+    State(state): State<GatewayState>,
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> Response {
+    // Support both single request and batch
+    if body.is_array() {
+        let reqs: Vec<Value> = body.as_array().unwrap().clone();
+        let mut responses = Vec::new();
+        for req_val in reqs {
+            let resp = dispatch_mcp_request(&state, req_val).await;
+            responses.push(resp);
+        }
+        return Json(Value::Array(responses)).into_response();
+    }
+
+    let resp = dispatch_mcp_request(&state, body).await;
+    let mut response = Json(resp).into_response();
+    // Inject a stable gateway session header
+    response
+        .headers_mut()
+        .insert("Mcp-Session-Id", "gateway".parse().unwrap());
+    response
+}
+
+async fn dispatch_mcp_request(state: &GatewayState, body: Value) -> Value {
+    let req: JsonRpcRequest = match serde_json::from_value(body) {
+        Ok(r) => r,
+        Err(e) => {
+            return serde_json::to_value(JsonRpcResponse::error(
+                None,
+                -32700,
+                format!("Parse error: {e}"),
+            ))
+            .unwrap_or_default();
+        }
+    };
+
+    let resp = match req.method.as_str() {
+        "initialize" => handle_initialize(state, &req),
+        "ping" => JsonRpcResponse::success(req.id.clone(), json!({})),
+        "notifications/initialized" => JsonRpcResponse::success(req.id.clone(), json!({})),
+        "tools/list" => handle_tools_list(state, &req),
+        "tools/call" => handle_tools_call(state, &req).await,
+        other => {
+            JsonRpcResponse::error(req.id.clone(), -32601, format!("Method not found: {other}"))
+        }
+    };
+
+    serde_json::to_value(resp).unwrap_or_default()
+}
+
+fn handle_initialize(state: &GatewayState, req: &JsonRpcRequest) -> JsonRpcResponse {
+    JsonRpcResponse::success(
+        req.id.clone(),
+        json!({
+            "protocolVersion": "2025-03-26",
+            "capabilities": {"tools": {"listChanged": true}},
+            "serverInfo": {
+                "name": state.server_name,
+                "version": state.server_version,
+            },
+            "instructions": "DCC Gateway — use list_dcc_instances to see running DCC servers, \
+                             connect_to_dcc to get a specific server's MCP URL, \
+                             or call tools on a specific DCC via POST /mcp/{instance_id}."
+        }),
+    )
+}
+
+fn handle_tools_list(_state: &GatewayState, req: &JsonRpcRequest) -> JsonRpcResponse {
+    let tools = gateway_tools();
+    JsonRpcResponse::success(req.id.clone(), json!({"tools": tools, "nextCursor": null}))
+}
+
+async fn handle_tools_call(state: &GatewayState, req: &JsonRpcRequest) -> JsonRpcResponse {
+    let params = req.params.as_ref().cloned().unwrap_or(json!({}));
+    let tool_name = params.get("name").and_then(|v| v.as_str()).unwrap_or("");
+    let args = params.get("arguments").cloned().unwrap_or(json!({}));
+
+    let result = match tool_name {
+        "list_dcc_instances" => tool_list_instances(state, &args).await,
+        "get_dcc_instance" => tool_get_instance(state, &args).await,
+        "connect_to_dcc" => tool_connect_to_dcc(state, &args).await,
+        other => Err(format!("Unknown tool: {other}")),
+    };
+
+    match result {
+        Ok(text) => JsonRpcResponse::success(
+            req.id.clone(),
+            json!({"content": [{"type": "text", "text": text}], "isError": false}),
+        ),
+        Err(msg) => JsonRpcResponse::success(
+            req.id.clone(),
+            json!({"content": [{"type": "text", "text": msg}], "isError": true}),
+        ),
+    }
+}
+
+// ── Gateway meta-tools ────────────────────────────────────────────────────────
+
+async fn tool_list_instances(state: &GatewayState, args: &Value) -> Result<String, String> {
+    let dcc_filter = args.get("dcc_type").and_then(|v| v.as_str());
+
+    let registry = state.registry.read().await;
+    let mut instances: Vec<InstanceInfo> = live_instances(&registry, state.stale_timeout)
+        .iter()
+        .filter(|e| dcc_filter.is_none_or(|f| e.dcc_type == f))
+        .map(|e| InstanceInfo::from_entry(e, state.stale_timeout))
+        .collect();
+
+    // Sort: available first, then by dcc_type, then by port
+    instances.sort_by(|a, b| {
+        a.status
+            .cmp(&b.status)
+            .then(a.dcc_type.cmp(&b.dcc_type))
+            .then(a.port.cmp(&b.port))
+    });
+
+    let result = json!({
+        "total": instances.len(),
+        "instances": instances,
+        "hint": if instances.is_empty() {
+            "No live DCC instances found. Start dcc-mcp-server with --registry-dir to register instances."
+        } else {
+            "Use connect_to_dcc(instance_id=...) to get the MCP URL for a specific instance, \
+             or POST /mcp/{instance_id} to route tools/call directly."
+        }
+    });
+
+    serde_json::to_string_pretty(&result).map_err(|e| e.to_string())
+}
+
+async fn tool_get_instance(state: &GatewayState, args: &Value) -> Result<String, String> {
+    let registry = state.registry.read().await;
+    let all = live_instances(&registry, state.stale_timeout);
+
+    // Match by instance_id (exact or prefix)
+    if let Some(id) = args.get("instance_id").and_then(|v| v.as_str()) {
+        if let Some(entry) = all.iter().find(|e| {
+            let eid = e.instance_id.to_string();
+            eid == id || eid.starts_with(id)
+        }) {
+            let info = InstanceInfo::from_entry(entry, state.stale_timeout);
+            return serde_json::to_string_pretty(&info).map_err(|e| e.to_string());
+        }
+        return Err(format!("Instance '{id}' not found or stale"));
+    }
+
+    // Match by dcc_type + optional scene
+    if let Some(dcc) = args.get("dcc_type").and_then(|v| v.as_str()) {
+        let scene_hint = args.get("scene").and_then(|v| v.as_str());
+        let candidates: Vec<&ServiceEntry> = all.iter().filter(|e| e.dcc_type == dcc).collect();
+
+        if candidates.is_empty() {
+            return Err(format!("No live instances of dcc_type '{dcc}'"));
+        }
+
+        // Scene match if hint provided
+        if let Some(hint) = scene_hint {
+            if let Some(entry) = candidates
+                .iter()
+                .find(|e| e.scene.as_deref().unwrap_or("").contains(hint))
+            {
+                let info = InstanceInfo::from_entry(entry, state.stale_timeout);
+                return serde_json::to_string_pretty(&info).map_err(|e| e.to_string());
+            }
+        }
+
+        // First available
+        let info = InstanceInfo::from_entry(candidates[0], state.stale_timeout);
+        return serde_json::to_string_pretty(&info).map_err(|e| e.to_string());
+    }
+
+    Err("Provide either instance_id or dcc_type".to_string())
+}
+
+async fn tool_connect_to_dcc(state: &GatewayState, args: &Value) -> Result<String, String> {
+    let registry = state.registry.read().await;
+    let all = live_instances(&registry, state.stale_timeout);
+
+    let entry = if let Some(id) = args.get("instance_id").and_then(|v| v.as_str()) {
+        all.iter()
+            .find(|e| {
+                let eid = e.instance_id.to_string();
+                eid == id || eid.starts_with(id)
+            })
+            .cloned()
+            .ok_or_else(|| format!("Instance '{id}' not found"))?
+    } else if let Some(dcc) = args.get("dcc_type").and_then(|v| v.as_str()) {
+        let scene_hint = args.get("scene").and_then(|v| v.as_str());
+        let candidates: Vec<&ServiceEntry> = all.iter().filter(|e| e.dcc_type == dcc).collect();
+        if candidates.is_empty() {
+            return Err(format!("No live instances of dcc_type '{dcc}'"));
+        }
+        if let Some(hint) = scene_hint {
+            candidates
+                .iter()
+                .find(|e| e.scene.as_deref().unwrap_or("").contains(hint))
+                .or(candidates.first())
+                .cloned()
+                .cloned()
+                .ok_or_else(|| "No matching instance".to_string())?
+        } else {
+            candidates[0].clone()
+        }
+    } else {
+        return Err("Provide instance_id or dcc_type".to_string());
+    };
+
+    let mcp_url = format!("http://{}:{}/mcp", entry.host, entry.port);
+    let result = json!({
+        "instance_id": entry.instance_id.to_string(),
+        "dcc_type": entry.dcc_type,
+        "mcp_url": mcp_url,
+        "proxy_url": format!("http://127.0.0.1:{{gateway_port}}/mcp/{}", entry.instance_id),
+        "scene": entry.scene,
+        "status": entry.status.to_string(),
+        "instructions": format!(
+            "Connect your MCP client to: {mcp_url}\n\
+             Or use the gateway proxy: POST /mcp/{instance_id}",
+            instance_id = entry.instance_id
+        )
+    });
+
+    serde_json::to_string_pretty(&result).map_err(|e| e.to_string())
+}
+
+// ── Proxy handler ─────────────────────────────────────────────────────────────
+
+/// `POST /mcp/{instance_id}` — transparent proxy to a specific DCC server.
+#[instrument(skip(state, headers, body))]
+async fn handle_proxy_instance(
+    State(state): State<GatewayState>,
+    Path(instance_id): Path<String>,
+    headers: HeaderMap,
+    body: axum::body::Bytes,
+) -> Response {
+    let registry = state.registry.read().await;
+    let all = registry.list_all();
+
+    let entry = all.iter().find(|e| {
+        let eid = e.instance_id.to_string();
+        eid == instance_id || eid.starts_with(&instance_id)
+    });
+
+    let entry = match entry {
+        Some(e) => e.clone(),
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": format!("Instance '{}' not found", instance_id)})),
+            )
+                .into_response();
+        }
+    };
+    drop(registry);
+
+    let target_url = format!("http://{}:{}/mcp", entry.host, entry.port);
+    proxy_request(&state.http_client, &target_url, headers, body).await
+}
+
+/// `POST /mcp/dcc/{dcc_type}` — proxy to best instance of a DCC type.
+#[instrument(skip(state, headers, body))]
+async fn handle_proxy_dcc_type(
+    State(state): State<GatewayState>,
+    Path(dcc_type): Path<String>,
+    headers: HeaderMap,
+    body: axum::body::Bytes,
+) -> Response {
+    let registry = state.registry.read().await;
+    let mut candidates: Vec<ServiceEntry> = live_instances(&registry, state.stale_timeout)
+        .into_iter()
+        .filter(|e| e.dcc_type == dcc_type)
+        .collect();
+    drop(registry);
+
+    if candidates.is_empty() {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({"error": format!("No live instances of dcc_type '{}'", dcc_type)})),
+        )
+            .into_response();
+    }
+
+    // Pick first available
+    candidates.sort_by_key(|e| matches!(e.status, ServiceStatus::Busy) as u8);
+    let entry = &candidates[0];
+    let target_url = format!("http://{}:{}/mcp", entry.host, entry.port);
+    proxy_request(&state.http_client, &target_url, headers, body).await
+}
+
+async fn proxy_request(
+    client: &reqwest::Client,
+    target_url: &str,
+    headers: HeaderMap,
+    body: axum::body::Bytes,
+) -> Response {
+    let mut req = client.post(target_url).body(body.to_vec());
+
+    // Forward relevant headers (content-type, accept, mcp-session-id)
+    for (key, value) in &headers {
+        let name = key.as_str().to_lowercase();
+        if name == "content-type"
+            || name == "accept"
+            || name == "mcp-session-id"
+            || name == "authorization"
+        {
+            if let Ok(v) = value.to_str() {
+                req = req.header(key.as_str(), v);
+            }
+        }
+    }
+
+    match req.send().await {
+        Ok(resp) => {
+            let status = StatusCode::from_u16(resp.status().as_u16())
+                .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+            let resp_headers = resp.headers().clone();
+            let body_bytes = resp.bytes().await.unwrap_or_default();
+
+            let mut response = Response::new(axum::body::Body::from(body_bytes));
+            *response.status_mut() = status;
+
+            // Forward response headers
+            for (key, value) in &resp_headers {
+                let name = key.as_str().to_lowercase();
+                if name == "content-type" || name == "mcp-session-id" || name.starts_with("mcp-") {
+                    response.headers_mut().insert(key, value.clone());
+                }
+            }
+            response
+        }
+        Err(e) => {
+            tracing::error!("Proxy request to {target_url} failed: {e}");
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(json!({"error": format!("Upstream DCC server unreachable: {e}")})),
+            )
+                .into_response()
+        }
+    }
+}
+
+// ── Tool definitions ──────────────────────────────────────────────────────────
+
+fn gateway_tools() -> Value {
+    json!([
+        {
+            "name": "list_dcc_instances",
+            "description": "List all running DCC server instances registered with the gateway. \
+                           Returns instance IDs, DCC types, ports, open scenes, and status. \
+                           Use this to discover what DCCs are available before calling their tools.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "dcc_type": {
+                        "type": "string",
+                        "description": "Filter by DCC type (e.g. 'maya', 'photoshop'). \
+                                       Omit to list all DCC types."
+                    }
+                }
+            }
+        },
+        {
+            "name": "get_dcc_instance",
+            "description": "Get detailed information about a specific DCC instance by ID or by type+scene.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "instance_id": {
+                        "type": "string",
+                        "description": "Instance UUID (or prefix). From list_dcc_instances."
+                    },
+                    "dcc_type": {
+                        "type": "string",
+                        "description": "DCC type (e.g. 'maya'). Used when instance_id is not known."
+                    },
+                    "scene": {
+                        "type": "string",
+                        "description": "Scene/document name hint for scene-based routing \
+                                       (e.g. 'shot_01' matches 'shot_01.ma')."
+                    }
+                }
+            }
+        },
+        {
+            "name": "connect_to_dcc",
+            "description": "Get the MCP endpoint URL for a specific DCC instance. \
+                           Returns the direct URL (e.g. http://127.0.0.1:18812/mcp) \
+                           and a proxy URL through this gateway. \
+                           Use the direct URL to connect your MCP client to that DCC, \
+                           or use POST /mcp/{instance_id} on this gateway for proxied access.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "instance_id": {
+                        "type": "string",
+                        "description": "Instance UUID (or prefix)."
+                    },
+                    "dcc_type": {
+                        "type": "string",
+                        "description": "DCC type. Selects the best available instance."
+                    },
+                    "scene": {
+                        "type": "string",
+                        "description": "Scene hint for scene-based selection."
+                    }
+                }
+            }
+        }
+    ])
+}
+
+// ── Stale cleanup background task ─────────────────────────────────────────────
+
+async fn run_stale_cleanup(registry: Arc<RwLock<FileRegistry>>, stale_timeout: Duration) {
+    let mut interval = tokio::time::interval(Duration::from_secs(15));
+    loop {
+        interval.tick().await;
+        let reg = registry.read().await;
+        match reg.cleanup_stale(stale_timeout) {
+            Ok(n) if n > 0 => tracing::info!("Removed {} stale DCC instance(s)", n),
+            Err(e) => tracing::warn!("Stale cleanup error: {e}"),
+            _ => {}
+        }
+    }
+}
+
+// ── main ──────────────────────────────────────────────────────────────────────
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        )
+        .init();
+
+    let args = Args::parse();
+    let stale_timeout = Duration::from_secs(args.stale_timeout_secs);
+
+    // ── Open FileRegistry ─────────────────────────────────────────────────
+
+    let registry_dir = resolve_registry_dir(args.registry_dir.as_deref());
+    tracing::info!("Registry directory: {}", registry_dir.display());
+
+    let registry = FileRegistry::new(&registry_dir)
+        .with_context(|| format!("Failed to open FileRegistry at {}", registry_dir.display()))?;
+    let registry = Arc::new(RwLock::new(registry));
+
+    // ── Background stale cleanup ──────────────────────────────────────────
+
+    tokio::spawn(run_stale_cleanup(registry.clone(), stale_timeout));
+
+    // ── Build axum router ─────────────────────────────────────────────────
+
+    let state = GatewayState {
+        registry,
+        stale_timeout,
+        server_name: args.server_name.clone(),
+        server_version: env!("CARGO_PKG_VERSION").to_string(),
+        http_client: reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()?,
+    };
+
+    let router = Router::new()
+        .route("/health", routing::get(handle_health))
+        .route("/instances", routing::get(handle_instances))
+        .route("/mcp", routing::post(handle_gateway_mcp))
+        .route("/mcp/{instance_id}", routing::post(handle_proxy_instance))
+        .route("/mcp/dcc/{dcc_type}", routing::post(handle_proxy_dcc_type))
+        .with_state(state)
+        .layer(TraceLayer::new_for_http())
+        .layer(
+            CorsLayer::new()
+                .allow_origin(Any)
+                .allow_methods(Any)
+                .allow_headers(Any),
+        );
+
+    let bind_addr = format!("{}:{}", args.host, args.port);
+    let listener = tokio::net::TcpListener::bind(&bind_addr)
+        .await
+        .with_context(|| format!("Failed to bind to {bind_addr}"))?;
+
+    let actual_addr = listener.local_addr()?;
+    tracing::info!("dcc-mcp-gateway listening on http://{actual_addr}");
+    tracing::info!("  MCP endpoint:  http://{actual_addr}/mcp");
+    tracing::info!("  Instances API: http://{actual_addr}/instances");
+    tracing::info!("  Registry dir:  {}", registry_dir.display());
+
+    axum::serve(listener, router)
+        .with_graceful_shutdown(async {
+            tokio::signal::ctrl_c().await.ok();
+            tracing::info!("Gateway shutting down…");
+        })
+        .await?;
+
+    Ok(())
+}

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -45,6 +45,8 @@ use clap::Parser;
 use dcc_mcp_actions::{ActionDispatcher, ActionRegistry};
 use dcc_mcp_http::{McpHttpConfig, McpHttpServer};
 use dcc_mcp_skills::SkillCatalog;
+use dcc_mcp_transport::discovery::file_registry::FileRegistry;
+use dcc_mcp_transport::discovery::types::ServiceEntry;
 use dcc_mcp_utils::filesystem;
 
 /// Standalone MCP server for bridge-mode DCCs.
@@ -79,6 +81,25 @@ struct Args {
     /// MCP server host to bind to.
     #[arg(long, default_value = "127.0.0.1")]
     host: String,
+
+    /// Directory for the shared service registry (used by dcc-mcp-gateway).
+    /// When set, this server registers itself on startup and deregisters on exit,
+    /// enabling gateway discovery. Defaults to $TMPDIR/dcc-mcp/.
+    /// Set to empty string "" to disable gateway registration.
+    #[arg(long, env = "DCC_MCP_REGISTRY_DIR")]
+    registry_dir: Option<String>,
+
+    /// DCC application version (e.g. "2024.2"). Reported to the gateway.
+    #[arg(long, env = "DCC_MCP_DCC_VERSION")]
+    dcc_version: Option<String>,
+
+    /// Currently open scene/project file. Reported to the gateway.
+    #[arg(long, env = "DCC_MCP_SCENE")]
+    scene: Option<String>,
+
+    /// Heartbeat interval (seconds) for gateway registration. 0 = disabled.
+    #[arg(long, env = "DCC_MCP_HEARTBEAT_INTERVAL", default_value = "5")]
+    registry_heartbeat_secs: u64,
 }
 
 #[tokio::main]
@@ -172,6 +193,99 @@ async fn main() -> anyhow::Result<()> {
         handle.port,
     );
 
+    // ── Gateway registration ──────────────────────────────────────────────────
+    //
+    // If a registry directory is configured (or defaults to $TMPDIR/dcc-mcp/),
+    // register this server instance so that dcc-mcp-gateway can discover it.
+    // The registration is removed on clean shutdown.
+
+    let registry_dir = args
+        .registry_dir
+        .as_deref()
+        .map(|s| s.to_string())
+        .or_else(|| {
+            // Default: $TMPDIR/dcc-mcp/
+            Some(
+                std::env::temp_dir()
+                    .join("dcc-mcp")
+                    .to_string_lossy()
+                    .to_string(),
+            )
+        });
+
+    let gateway_key = if let Some(ref dir) = registry_dir {
+        if dir.is_empty() {
+            tracing::info!("Gateway registration disabled (empty registry_dir).");
+            None
+        } else {
+            match FileRegistry::new(dir) {
+                Ok(reg) => {
+                    let mut entry = ServiceEntry::new(
+                        if args.dcc.is_empty() {
+                            "unknown"
+                        } else {
+                            &args.dcc
+                        },
+                        &args.host,
+                        handle.port,
+                    );
+                    if let Some(ref v) = args.dcc_version {
+                        entry.version = Some(v.clone());
+                    }
+                    if let Some(ref s) = args.scene {
+                        entry.scene = Some(s.clone());
+                    }
+                    entry
+                        .metadata
+                        .insert("server_name".to_string(), args.server_name.clone());
+
+                    let key = entry.key();
+                    match reg.register(entry) {
+                        Ok(_) => {
+                            tracing::info!(
+                                dcc = %args.dcc,
+                                port = handle.port,
+                                registry = %dir,
+                                instance = %key.instance_id,
+                                "Registered with gateway registry"
+                            );
+
+                            // Heartbeat task: keep registration alive
+                            if args.registry_heartbeat_secs > 0 {
+                                let reg2 = FileRegistry::new(dir).ok();
+                                let key2 = key.clone();
+                                let interval = args.registry_heartbeat_secs;
+                                tokio::spawn(async move {
+                                    let mut tick = tokio::time::interval(
+                                        std::time::Duration::from_secs(interval),
+                                    );
+                                    loop {
+                                        tick.tick().await;
+                                        if let Some(ref r) = reg2 {
+                                            let _ = r.heartbeat(&key2);
+                                        }
+                                    }
+                                });
+                            }
+
+                            Some((reg, key))
+                        }
+                        Err(e) => {
+                            tracing::warn!("Failed to register with gateway: {e}");
+                            None
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to open registry at '{dir}': {e}");
+                    None
+                }
+            }
+        }
+    } else {
+        None
+    };
+
     // ── Start WebSocket bridge server ────────────────────────────────────────
 
     if !args.no_bridge {
@@ -188,6 +302,15 @@ async fn main() -> anyhow::Result<()> {
 
     tokio::signal::ctrl_c().await?;
     tracing::info!("Shutting down…");
+
+    // Deregister from gateway registry on clean shutdown.
+    if let Some((reg, key)) = gateway_key {
+        match reg.deregister(&key) {
+            Ok(_) => tracing::info!("Deregistered from gateway registry"),
+            Err(e) => tracing::warn!("Failed to deregister from gateway: {e}"),
+        }
+    }
+
     handle.shutdown().await;
 
     Ok(())

--- a/justfile
+++ b/justfile
@@ -41,6 +41,16 @@ rust-cov:
 build-server:
     cargo build --release -p dcc-mcp-server
 
+# ── Gateway (dcc-mcp-gateway) ─────────────────────────────────────────────────
+
+# Build dcc-mcp-gateway for the current platform
+build-gateway:
+    cargo build --release -p dcc-mcp-gateway
+
+# Run the gateway locally (reads $TMPDIR/dcc-mcp/services.json)
+run-gateway *ARGS:
+    cargo run --release -p dcc-mcp-gateway -- {{ARGS}}
+
 # Build dcc-mcp-server universal2 binary for macOS (requires both targets installed)
 [unix]
 build-server-universal:
@@ -53,6 +63,19 @@ build-server-universal:
         target/x86_64-apple-darwin/release/dcc-mcp-server \
         target/aarch64-apple-darwin/release/dcc-mcp-server
     echo "Built: dcc-mcp-server-macos-universal2"
+
+# Build dcc-mcp-gateway universal2 binary for macOS
+[unix]
+build-gateway-universal:
+    #!/usr/bin/env sh
+    set -eu
+    rustup target add x86_64-apple-darwin aarch64-apple-darwin 2>/dev/null || true
+    cargo build --release -p dcc-mcp-gateway --target x86_64-apple-darwin
+    cargo build --release -p dcc-mcp-gateway --target aarch64-apple-darwin
+    lipo -create -output dcc-mcp-gateway-macos-universal2 \
+        target/x86_64-apple-darwin/release/dcc-mcp-gateway \
+        target/aarch64-apple-darwin/release/dcc-mcp-gateway
+    echo "Built: dcc-mcp-gateway-macos-universal2"
 
 # Run the server locally (auto-discovers skills, MCP :8765, WS bridge :9001)
 run-server *ARGS:

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -3532,6 +3532,16 @@ class McpHttpConfig:
     def server_name(self) -> str: ...
     @property
     def server_version(self) -> str: ...
+    @property
+    def session_ttl_secs(self) -> int:
+        """Idle session TTL in seconds.
+
+        Sessions not touched within this window are automatically evicted.
+        Default: 3600 (1 hour). Set to 0 to disable.
+        """
+        ...
+    @session_ttl_secs.setter
+    def session_ttl_secs(self, secs: int) -> None: ...
     def __repr__(self) -> str: ...
 
 class ServerHandle:


### PR DESCRIPTION
## Summary

Adds a new `dcc-mcp-gateway` binary that provides a single fixed MCP endpoint through which agents can discover all running DCC server instances and route requests to specific ones.

## Architecture

```
Agent (Claude / Cursor)
    │  MCP  :8888  (one fixed endpoint)
    ▼
dcc-mcp-gateway
    │  reads $TMPDIR/dcc-mcp/services.json  (FileRegistry)
    │  proxies via HTTP
    ├──▶  Maya-1    :18812  scene=shot_01.ma
    ├──▶  Maya-2    :18813  scene=shot_02.ma
    ├──▶  Photoshop :18814  doc=poster.psd
    └──▶  ZBrush    :18815
```

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/health` | `{"ok": true}` |
| `GET` | `/instances` | JSON list of all live DCC instances |
| `POST` | `/mcp` | Gateway's MCP endpoint (discovery meta-tools) |
| `POST` | `/mcp/{instance_id}` | Transparent proxy to a specific DCC server |
| `POST` | `/mcp/dcc/{dcc_type}` | Proxy to best instance of a DCC type |

## MCP meta-tools

| Tool | Description |
|------|-------------|
| `list_dcc_instances` | List all running DCC servers (type, port, scene, status) |
| `get_dcc_instance` | Get info by `instance_id` or `dcc_type` + scene hint |
| `connect_to_dcc` | Return direct MCP URL + gateway proxy URL for an instance |

## Port management — zero config

- Each `dcc-mcp-server` uses `--mcp-port 0` (OS assigns a random free port)
- On startup, the server writes its actual port to `$TMPDIR/dcc-mcp/services.json`
- The gateway reads this file and exposes all instances

## Agent workflow

```
1. Agent connects to gateway :8888/mcp
2. tools/list → [list_dcc_instances, get_dcc_instance, connect_to_dcc]
3. list_dcc_instances() →
   [
     {dcc: maya, port: 18812, scene: shot_01.ma, instance_id: uuid-1},
     {dcc: maya, port: 18813, scene: shot_02.ma, instance_id: uuid-2},
     {dcc: photoshop, port: 18814, doc: poster.psd, instance_id: uuid-3}
   ]
4a. Direct: connect_to_dcc(instance_id="uuid-1") → {mcp_url: "http://…:18812/mcp"}
    Agent reconnects directly to :18812/mcp for full Maya tools
4b. Proxy: POST /mcp/uuid-1  → gateway forwards to Maya-1's server
```

## Files changed

| File | Description |
|------|-------------|
| `crates/dcc-mcp-gateway/Cargo.toml` | New crate manifest |
| `crates/dcc-mcp-gateway/src/main.rs` | Full gateway implementation (~420 lines) |
| `crates/dcc-mcp-server/src/main.rs` | FileRegistry registration on startup/shutdown |
| `justfile` | `build-gateway`, `run-gateway`, `build-gateway-universal` |
| `.github/workflows/release.yml` | `build-gateway-binaries` job (3 platforms) |

## Test plan

- [x] `cargo check -p dcc-mcp-gateway -p dcc-mcp-server` — clean
- [x] `cargo fmt --all` + `cargo clippy` — clean
- [ ] CI Rust (3 platforms) — should pass
- [ ] Manual: start 2 dcc-mcp-servers + gateway, verify `GET /instances` lists both