### PR TITLE
fix(ci): use ubuntu-22.04 for Python 3.7 and replace setup-just with vx

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -57,7 +57,7 @@ jobs:
   # Users needing Python 3.7 on macOS should install from source distribution
 
   linux-py37:
-    runs-on: ubuntu-24.04  # Ubuntu 24.04 dropped Python 3.7 support; must use 22.04
+    runs-on: ubuntu-22.04  # Python 3.7 not available on Ubuntu 24.04
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/build-wheel
@@ -71,7 +71,7 @@ jobs:
           use-sccache: 'false'
 
   windows-py37:
-    runs-on: windows-2025  # Use Windows 2022 for Python 3.7 availability
+    runs-on: windows-2022  # Python 3.7 not available on newer Windows runners
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/build-wheel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
-      - uses: extractions/setup-just@v4
+      - uses: loonghao/vx@v0.8.25
+        with:
+          tools: just
       - name: Cache Cargo
         uses: actions/cache@v5
         with:
@@ -89,7 +91,9 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-      - uses: extractions/setup-just@v4
+      - uses: loonghao/vx@v0.8.25
+        with:
+          tools: just
       - name: Install maturin
         run: pip install maturin
         shell: bash
@@ -115,7 +119,9 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: extractions/setup-just@v4
+      - uses: loonghao/vx@v0.8.25
+        with:
+          tools: just
       - name: Download wheel
         uses: actions/download-artifact@v8
         with:
@@ -155,7 +161,9 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-      - uses: extractions/setup-just@v4
+      - uses: loonghao/vx@v0.8.25
+        with:
+          tools: just
       - name: Install maturin
         run: pip install maturin
         shell: bash
@@ -194,7 +202,9 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-      - uses: extractions/setup-just@v4
+      - uses: loonghao/vx@v0.8.25
+        with:
+          tools: just
       - name: Install dev deps
         run: just install-dev-deps
       - name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,6 @@ jobs:
         with:
           components: clippy, rustfmt
       - uses: loonghao/vx@v0.8.25
-        with:
-          tools: just
-      - name: Add vx tools to PATH
-        run: echo "$VX_INSTALL_DIR" >> $GITHUB_PATH
-        shell: bash
       - name: Cache Cargo
         uses: actions/cache@v5
         with:
@@ -47,7 +42,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: ${{ runner.os }}-cargo-
       - name: Preflight (check + clippy + fmt + test)
-        run: just preflight
+        run: vx just preflight
 
   # ── Rust code coverage (tarpaulin, Linux only) ──
   rust-coverage:
@@ -58,11 +53,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: loonghao/vx@v0.8.25
-        with:
-          tools: just
-      - name: Add vx tools to PATH
-        run: echo "$VX_INSTALL_DIR" >> $GITHUB_PATH
-        shell: bash
       - name: Cache Cargo
         uses: actions/cache@v5
         with:
@@ -76,7 +66,7 @@ jobs:
       - name: Install cargo-tarpaulin
         run: cargo install cargo-tarpaulin --locked
       - name: Run Rust coverage
-        run: just rust-cov
+        run: vx just rust-cov
       - name: Upload Rust coverage to Codecov
         uses: codecov/codecov-action@v6
         with:
@@ -101,16 +91,11 @@ jobs:
         with:
           python-version: "3.14"
       - uses: loonghao/vx@v0.8.25
-        with:
-          tools: just
-      - name: Add vx tools to PATH
-        run: echo "$VX_INSTALL_DIR" >> $GITHUB_PATH
-        shell: bash
       - name: Install maturin
         run: pip install maturin
         shell: bash
       - name: Build wheel
-        run: just build
+        run: vx just build
       - uses: actions/upload-artifact@v7
         with:
           name: wheel-${{ matrix.os }}
@@ -132,11 +117,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - uses: loonghao/vx@v0.8.25
-        with:
-          tools: just
-      - name: Add vx tools to PATH
-        run: echo "$VX_INSTALL_DIR" >> $GITHUB_PATH
-        shell: bash
       - name: Download wheel
         uses: actions/download-artifact@v8
         with:
@@ -146,7 +126,7 @@ jobs:
         run: pip install --no-index --find-links dist dcc-mcp-core && pip install pytest pytest-cov
         shell: bash
       - name: Test with coverage
-        run: just test-cov
+        run: vx just test-cov
       - name: Upload Python coverage to Codecov
         if: matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v6
@@ -177,11 +157,6 @@ jobs:
         with:
           python-version: "3.14"
       - uses: loonghao/vx@v0.8.25
-        with:
-          tools: just
-      - name: Add vx tools to PATH
-        run: echo "$VX_INSTALL_DIR" >> $GITHUB_PATH
-        shell: bash
       - name: Install maturin
         run: pip install maturin
         shell: bash
@@ -221,15 +196,10 @@ jobs:
         with:
           python-version: "3.14"
       - uses: loonghao/vx@v0.8.25
-        with:
-          tools: just
-      - name: Add vx tools to PATH
-        run: echo "$VX_INSTALL_DIR" >> $GITHUB_PATH
-        shell: bash
       - name: Install dev deps
-        run: just install-dev-deps
+        run: vx just install-dev-deps
       - name: Lint
-        run: just lint-py
+        run: vx just lint-py
 
   # -- mcporter e2e: real MCP client (npx mcporter) vs live McpHttpServer --
   # Exercises the full HTTP stack from outside the process:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - uses: loonghao/vx@v0.8.25
         with:
           tools: just
+      - name: Add vx tools to PATH
+        run: echo "$VX_INSTALL_DIR" >> $GITHUB_PATH
+        shell: bash
       - name: Cache Cargo
         uses: actions/cache@v5
         with:
@@ -54,6 +57,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+      - uses: loonghao/vx@v0.8.25
+        with:
+          tools: just
+      - name: Add vx tools to PATH
+        run: echo "$VX_INSTALL_DIR" >> $GITHUB_PATH
+        shell: bash
       - name: Cache Cargo
         uses: actions/cache@v5
         with:
@@ -94,6 +103,9 @@ jobs:
       - uses: loonghao/vx@v0.8.25
         with:
           tools: just
+      - name: Add vx tools to PATH
+        run: echo "$VX_INSTALL_DIR" >> $GITHUB_PATH
+        shell: bash
       - name: Install maturin
         run: pip install maturin
         shell: bash
@@ -122,6 +134,9 @@ jobs:
       - uses: loonghao/vx@v0.8.25
         with:
           tools: just
+      - name: Add vx tools to PATH
+        run: echo "$VX_INSTALL_DIR" >> $GITHUB_PATH
+        shell: bash
       - name: Download wheel
         uses: actions/download-artifact@v8
         with:
@@ -164,6 +179,9 @@ jobs:
       - uses: loonghao/vx@v0.8.25
         with:
           tools: just
+      - name: Add vx tools to PATH
+        run: echo "$VX_INSTALL_DIR" >> $GITHUB_PATH
+        shell: bash
       - name: Install maturin
         run: pip install maturin
         shell: bash
@@ -205,6 +223,9 @@ jobs:
       - uses: loonghao/vx@v0.8.25
         with:
           tools: just
+      - name: Add vx tools to PATH
+        run: echo "$VX_INSTALL_DIR" >> $GITHUB_PATH
+        shell: bash
       - name: Install dev deps
         run: just install-dev-deps
       - name: Lint

--- a/.github/workflows/dcc-integration.yml
+++ b/.github/workflows/dcc-integration.yml
@@ -47,7 +47,6 @@ jobs:
         run: echo "$VX_INSTALL_DIR" >> $GITHUB_PATH
         shell: bash
       - name: Cache Cargo
-      - name: Cache Cargo
         uses: actions/cache@v5
         with:
           path: |

--- a/.github/workflows/dcc-integration.yml
+++ b/.github/workflows/dcc-integration.yml
@@ -43,6 +43,10 @@ jobs:
       - uses: loonghao/vx@v0.8.25
         with:
           tools: just
+      - name: Add vx tools to PATH
+        run: echo "$VX_INSTALL_DIR" >> $GITHUB_PATH
+        shell: bash
+      - name: Cache Cargo
       - name: Cache Cargo
         uses: actions/cache@v5
         with:

--- a/.github/workflows/dcc-integration.yml
+++ b/.github/workflows/dcc-integration.yml
@@ -40,7 +40,9 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-      - uses: extractions/setup-just@v4
+      - uses: loonghao/vx@v0.8.25
+        with:
+          tools: just
       - name: Cache Cargo
         uses: actions/cache@v5
         with:

--- a/.github/workflows/dcc-integration.yml
+++ b/.github/workflows/dcc-integration.yml
@@ -41,11 +41,6 @@ jobs:
         with:
           python-version: "3.14"
       - uses: loonghao/vx@v0.8.25
-        with:
-          tools: just
-      - name: Add vx tools to PATH
-        run: echo "$VX_INSTALL_DIR" >> $GITHUB_PATH
-        shell: bash
       - name: Cache Cargo
         uses: actions/cache@v5
         with:
@@ -60,7 +55,7 @@ jobs:
         run: pip install maturin
         shell: bash
       - name: Build wheel
-        run: just build
+        run: vx just build
       - uses: actions/upload-artifact@v7
         with:
           name: wheel-dcc-integration

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,11 +63,6 @@ jobs:
           targets: aarch64-apple-darwin  # needed for macOS universal2 lipo
 
       - uses: loonghao/vx@v0.8.25
-        with:
-          tools: just
-      - name: Add vx tools to PATH
-        run: echo "$VX_INSTALL_DIR" >> $GITHUB_PATH
-        shell: bash
 
       - name: Cache Cargo
         uses: actions/cache@v5
@@ -82,11 +77,11 @@ jobs:
 
       - name: Build binary (macOS universal2)
         if: matrix.os == 'macos-latest'
-        run: just build-server-universal
+        run: vx just build-server-universal
 
       - name: Build binary (Linux / Windows)
         if: matrix.os != 'macos-latest'
-        run: just build-server
+        run: vx just build-server
         shell: bash
 
       - name: Stage artifact (Linux / Windows)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,9 @@ jobs:
           toolchain: '1.90.0'
           targets: aarch64-apple-darwin  # needed for macOS universal2 lipo
 
-      - uses: extractions/setup-just@v4
+      - uses: loonghao/vx@v0.8.25
+        with:
+          tools: just
 
       - name: Cache Cargo
         uses: actions/cache@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,9 @@ jobs:
       - uses: loonghao/vx@v0.8.25
         with:
           tools: just
+      - name: Add vx tools to PATH
+        run: echo "$VX_INSTALL_DIR" >> $GITHUB_PATH
+        shell: bash
 
       - name: Cache Cargo
         uses: actions/cache@v5


### PR DESCRIPTION
## Summary

- Fix Python 3.7 "version not found" error: `linux-py37` runner changed from `ubuntu-24.04` → `ubuntu-22.04`, `windows-py37` from `windows-2025` → `windows-2022` (Python 3.7 is unavailable on newer runners)
- Replace `extractions/setup-just@v4` with `loonghao/vx@v0.8.25` across all 4 workflow files (7 occurrences) — resolves "just command not found" in CI

## Test plan

- [ ] CI pipeline passes on this PR (rust-check, build-wheel, python-test, lint)
- [ ] `build-wheels.yml` py37 jobs succeed on ubuntu-22.04 and windows-2022
- [ ] `just` commands execute correctly via vx in all workflow jobs