### PR TITLE
feat(skills,http): add explicit deferred tool hints

### DIFF
--- a/crates/dcc-mcp-http/src/handler.rs
+++ b/crates/dcc-mcp-http/src/handler.rs
@@ -693,10 +693,11 @@ fn build_core_tools() -> Vec<McpTool> {
             }),
             annotations: Some(McpToolAnnotations {
                 title: Some("Find Skills".to_string()),
-                read_only_hint: true,
-                destructive_hint: false,
-                idempotent_hint: true,
-                open_world_hint: false,
+                read_only_hint: Some(true),
+                destructive_hint: Some(false),
+                idempotent_hint: Some(true),
+                open_world_hint: Some(false),
+                deferred_hint: Some(false),
             }),
         },
         McpTool {
@@ -716,10 +717,11 @@ fn build_core_tools() -> Vec<McpTool> {
             }),
             annotations: Some(McpToolAnnotations {
                 title: Some("List Skills".to_string()),
-                read_only_hint: true,
-                destructive_hint: false,
-                idempotent_hint: true,
-                open_world_hint: false,
+                read_only_hint: Some(true),
+                destructive_hint: Some(false),
+                idempotent_hint: Some(true),
+                open_world_hint: Some(false),
+                deferred_hint: Some(false),
             }),
         },
         McpTool {
@@ -738,10 +740,11 @@ fn build_core_tools() -> Vec<McpTool> {
             }),
             annotations: Some(McpToolAnnotations {
                 title: Some("Get Skill Info".to_string()),
-                read_only_hint: true,
-                destructive_hint: false,
-                idempotent_hint: true,
-                open_world_hint: false,
+                read_only_hint: Some(true),
+                destructive_hint: Some(false),
+                idempotent_hint: Some(true),
+                open_world_hint: Some(false),
+                deferred_hint: Some(false),
             }),
         },
         McpTool {
@@ -765,10 +768,11 @@ fn build_core_tools() -> Vec<McpTool> {
             }),
             annotations: Some(McpToolAnnotations {
                 title: Some("Load Skill".to_string()),
-                read_only_hint: false,
-                destructive_hint: false,
-                idempotent_hint: true,
-                open_world_hint: false,
+                read_only_hint: Some(false),
+                destructive_hint: Some(false),
+                idempotent_hint: Some(true),
+                open_world_hint: Some(false),
+                deferred_hint: Some(false),
             }),
         },
         McpTool {
@@ -787,10 +791,11 @@ fn build_core_tools() -> Vec<McpTool> {
             }),
             annotations: Some(McpToolAnnotations {
                 title: Some("Unload Skill".to_string()),
-                read_only_hint: false,
-                destructive_hint: false,
-                idempotent_hint: true,
-                open_world_hint: false,
+                read_only_hint: Some(false),
+                destructive_hint: Some(false),
+                idempotent_hint: Some(true),
+                open_world_hint: Some(false),
+                deferred_hint: Some(false),
             }),
         },
         McpTool {
@@ -815,10 +820,11 @@ fn build_core_tools() -> Vec<McpTool> {
             }),
             annotations: Some(McpToolAnnotations {
                 title: Some("Search Skills".to_string()),
-                read_only_hint: true,
-                destructive_hint: false,
-                idempotent_hint: true,
-                open_world_hint: false,
+                read_only_hint: Some(true),
+                destructive_hint: Some(false),
+                idempotent_hint: Some(true),
+                open_world_hint: Some(false),
+                deferred_hint: Some(false),
             }),
         },
     ]
@@ -839,10 +845,11 @@ fn action_meta_to_mcp_tool(meta: &dcc_mcp_actions::registry::ActionMeta) -> McpT
         annotations: Some(McpToolAnnotations {
             title: Some(meta.name.clone()),
             // Actions from skills get sensible defaults; standalone actions default to false
-            read_only_hint: false,
-            destructive_hint: false,
-            idempotent_hint: false,
-            open_world_hint: false,
+            read_only_hint: Some(false),
+            destructive_hint: Some(false),
+            idempotent_hint: Some(false),
+            open_world_hint: Some(false),
+            deferred_hint: Some(false),
         }),
     }
 }
@@ -883,10 +890,11 @@ fn build_skill_stub(summary: &SkillSummary) -> McpTool {
         input_schema: json!({"type": "object", "properties": {}}),
         annotations: Some(McpToolAnnotations {
             title: Some(format!("Skill: {}", summary.name)),
-            read_only_hint: true,
-            destructive_hint: false,
-            idempotent_hint: true,
-            open_world_hint: false,
+            read_only_hint: Some(true),
+            destructive_hint: Some(false),
+            idempotent_hint: Some(true),
+            open_world_hint: Some(false),
+            deferred_hint: Some(true),
         }),
     }
 }

--- a/crates/dcc-mcp-http/src/protocol.rs
+++ b/crates/dcc-mcp-http/src/protocol.rs
@@ -199,10 +199,16 @@ pub struct McpTool {
 pub struct McpToolAnnotations {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
-    pub read_only_hint: bool,
-    pub destructive_hint: bool,
-    pub idempotent_hint: bool,
-    pub open_world_hint: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub read_only_hint: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub destructive_hint: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub idempotent_hint: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub open_world_hint: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deferred_hint: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/dcc-mcp-http/src/tests.rs
+++ b/crates/dcc-mcp-http/src/tests.rs
@@ -386,6 +386,12 @@ mod tests {
             names.contains(&"__skill__git-tools"),
             "Expected stub __skill__git-tools, got: {names:?}"
         );
+
+        let maya_stub = tools
+            .iter()
+            .find(|t| t["name"] == "__skill__maya-bevel")
+            .unwrap();
+        assert_eq!(maya_stub["annotations"]["deferredHint"], true);
     }
 
     // ── On-demand loading invariants ──────────────────────────────────────
@@ -557,6 +563,13 @@ mod tests {
             !bevel_tool["inputSchema"].is_null(),
             "Loaded tool must have an inputSchema"
         );
+        assert_eq!(bevel_tool["annotations"]["deferredHint"], false);
+
+        let git_stub = tools
+            .iter()
+            .find(|t| t["name"] == "__skill__git-tools")
+            .unwrap();
+        assert_eq!(git_stub["annotations"]["deferredHint"], true);
 
         let _ = state; // suppress unused warning
     }
@@ -1088,6 +1101,12 @@ mod tests {
         let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
         assert!(names.contains(&"modeling_bevel__bevel"));
         assert!(names.contains(&"modeling_bevel__chamfer"));
+
+        let bevel_tool = tools
+            .iter()
+            .find(|t| t["name"] == "modeling_bevel__bevel")
+            .unwrap();
+        assert_eq!(bevel_tool["annotations"]["deferredHint"], false);
     }
 
     #[tokio::test]
@@ -1155,6 +1174,11 @@ mod tests {
         let tools = body2["result"]["tools"].as_array().unwrap();
         // Back to 6 core tools + 1 unloaded skill stub = 7
         assert_eq!(tools.len(), 7);
+        let stub = tools
+            .iter()
+            .find(|t| t["name"] == "__skill__modeling-bevel")
+            .unwrap();
+        assert_eq!(stub["annotations"]["deferredHint"], true);
     }
 
     #[tokio::test]

--- a/crates/dcc-mcp-models/src/skill_metadata.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata.rs
@@ -58,6 +58,12 @@ pub struct ToolDeclaration {
     #[serde(default)]
     pub idempotent: bool,
 
+    /// Whether this declaration should be surfaced as deferred in discovery-oriented UIs.
+    ///
+    /// Supports both `defer-loading` and `defer_loading` in SKILL.md frontmatter.
+    #[serde(default, rename = "defer-loading", alias = "defer_loading")]
+    pub defer_loading: bool,
+
     /// Explicit path to the script that implements this tool.
     ///
     /// If empty, the catalog will try to find a matching script by name.
@@ -106,7 +112,7 @@ fn is_null_value(v: &serde_json::Value) -> bool {
 #[pymethods]
 impl ToolDeclaration {
     #[new]
-    #[pyo3(signature = (name, description="".to_string(), input_schema=None, output_schema=None, read_only=false, destructive=false, idempotent=false, source_file="".to_string()))]
+    #[pyo3(signature = (name, description="".to_string(), input_schema=None, output_schema=None, read_only=false, destructive=false, idempotent=false, defer_loading=false, source_file="".to_string()))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         name: String,
@@ -116,6 +122,7 @@ impl ToolDeclaration {
         read_only: bool,
         destructive: bool,
         idempotent: bool,
+        defer_loading: bool,
         source_file: String,
     ) -> Self {
         let input_schema = input_schema
@@ -132,6 +139,7 @@ impl ToolDeclaration {
             read_only,
             destructive,
             idempotent,
+            defer_loading,
             source_file,
             next_tools: NextTools::default(),
         }
@@ -222,6 +230,16 @@ impl ToolDeclaration {
     #[setter]
     fn set_idempotent(&mut self, value: bool) {
         self.idempotent = value;
+    }
+
+    #[getter]
+    fn defer_loading(&self) -> bool {
+        self.defer_loading
+    }
+
+    #[setter]
+    fn set_defer_loading(&mut self, value: bool) {
+        self.defer_loading = value;
     }
 
     #[getter]

--- a/crates/dcc-mcp-protocols/src/types.rs
+++ b/crates/dcc-mcp-protocols/src/types.rs
@@ -30,19 +30,22 @@ pub struct ToolAnnotations {
     pub idempotent_hint: Option<bool>,
     #[serde(rename = "openWorldHint")]
     pub open_world_hint: Option<bool>,
+    #[serde(rename = "deferredHint")]
+    pub deferred_hint: Option<bool>,
 }
 
 #[cfg(feature = "python-bindings")]
 #[pymethods]
 impl ToolAnnotations {
     #[new]
-    #[pyo3(signature = (title=None, read_only_hint=None, destructive_hint=None, idempotent_hint=None, open_world_hint=None))]
+    #[pyo3(signature = (title=None, read_only_hint=None, destructive_hint=None, idempotent_hint=None, open_world_hint=None, deferred_hint=None))]
     fn new(
         title: Option<String>,
         read_only_hint: Option<bool>,
         destructive_hint: Option<bool>,
         idempotent_hint: Option<bool>,
         open_world_hint: Option<bool>,
+        deferred_hint: Option<bool>,
     ) -> Self {
         Self {
             title,
@@ -50,17 +53,19 @@ impl ToolAnnotations {
             destructive_hint,
             idempotent_hint,
             open_world_hint,
+            deferred_hint,
         }
     }
 
     fn __repr__(&self) -> String {
         format!(
-            "ToolAnnotations(title={:?}, read_only={:?}, destructive={:?}, idempotent={:?}, open_world={:?})",
+            "ToolAnnotations(title={:?}, read_only={:?}, destructive={:?}, idempotent={:?}, open_world={:?}, deferred={:?})",
             self.title,
             self.read_only_hint,
             self.destructive_hint,
             self.idempotent_hint,
-            self.open_world_hint
+            self.open_world_hint,
+            self.deferred_hint
         )
     }
 }
@@ -380,11 +385,13 @@ mod tests {
                 destructive_hint: Some(true),
                 idempotent_hint: Some(true),
                 open_world_hint: None,
+                deferred_hint: Some(true),
             }),
         };
         let json = serde_json::to_string(&td).unwrap();
         assert!(json.contains("\"annotations\""));
         assert!(json.contains("\"destructiveHint\":true"));
+        assert!(json.contains("\"deferredHint\":true"));
     }
 
     #[test]
@@ -400,6 +407,7 @@ mod tests {
                 destructive_hint: None,
                 idempotent_hint: None,
                 open_world_hint: None,
+                deferred_hint: None,
             }),
         };
         let json = serde_json::to_string(&td).unwrap();

--- a/crates/dcc-mcp-skills/src/loader/tests.rs
+++ b/crates/dcc-mcp-skills/src/loader/tests.rs
@@ -272,6 +272,21 @@ mod test_parse_skill_md {
     }
 
     #[test]
+    fn parse_skill_with_tool_defer_loading_aliases() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join(SKILL_METADATA_FILE),
+            "---\nname: deferred-skill\ndcc: python\ntools:\n  - name: slow_tool\n    defer-loading: true\n  - name: alias_tool\n    defer_loading: true\n---\n# Deferred\n",
+        )
+        .unwrap();
+
+        let meta = parse_skill_md(tmp.path()).unwrap();
+        assert_eq!(meta.tools.len(), 2);
+        assert!(meta.tools[0].defer_loading);
+        assert!(meta.tools[1].defer_loading);
+    }
+
+    #[test]
     fn parse_returns_none_for_missing_skill_md() {
         let tmp = tempfile::tempdir().unwrap();
         // No SKILL.md file

--- a/docs/api/skills.md
+++ b/docs/api/skills.md
@@ -129,6 +129,7 @@ decl = ToolDeclaration(
     read_only=False,
     destructive=False,
     idempotent=False,
+    defer_loading=True,
     source_file="scripts/create_sphere.py",
 )
 ```
@@ -144,6 +145,7 @@ ToolDeclaration(
     read_only: bool = False,
     destructive: bool = False,
     idempotent: bool = False,
+    defer_loading: bool = False,
     source_file: str = "",
 ) -> ToolDeclaration
 ```
@@ -157,10 +159,15 @@ ToolDeclaration(
 | `read_only` | `bool` | `False` | True if this tool only reads data (no side effects) |
 | `destructive` | `bool` | `False` | True if this tool may cause destructive changes |
 | `idempotent` | `bool` | `False` | True if same args always produce the same result |
+| `defer_loading` | `bool` | `False` | Parse `defer-loading:` / `defer_loading:` from SKILL.md for discovery-oriented UIs |
 | `source_file` | `str` | `""` | Explicit path to the script file |
 
 ::: tip input_schema and output_schema
 These are stored internally as JSON values, not strings. When constructing from Python, pass a JSON string and it will be parsed automatically.
+:::
+
+::: tip Progressive loading signal
+Unloaded skill stubs surfaced via `tools/list` now include `annotations.deferredHint = true`. After `load_skill(...)`, the real tools appear with `deferredHint = false`.
 :::
 
 ---

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -149,6 +149,7 @@ tools:
     read_only: false
     destructive: false
     idempotent: false
+    defer-loading: true
     source_file: scripts/create_sphere.py
 ```
 
@@ -162,6 +163,7 @@ decl = ToolDeclaration(
     read_only=False,
     destructive=False,
     idempotent=False,
+    defer_loading=True,
     source_file="scripts/create_sphere.py",
 )
 ```
@@ -175,7 +177,10 @@ decl = ToolDeclaration(
 | `read_only` | `bool` | `False` | Whether this tool only reads data |
 | `destructive` | `bool` | `False` | Whether this tool may cause destructive changes |
 | `idempotent` | `bool` | `False` | Whether calling with same args always produces same result |
+| `defer_loading` | `bool` | `False` | Accepts `defer-loading` / `defer_loading` in SKILL.md and marks the declaration as discovery-oriented |
 | `source_file` | `str` | `""` | Explicit path to the script (relative to skill dir) |
+
+Unloaded skill stubs returned by `tools/list` also expose `annotations.deferredHint = true` as an explicit progressive-loading signal. Once you call `load_skill(...)`, the real tools replace the stub and return `deferredHint = false`.
 
 ## Script Lookup Priority
 

--- a/docs/zh/api/skills.md
+++ b/docs/zh/api/skills.md
@@ -129,6 +129,7 @@ decl = ToolDeclaration(
     read_only=False,
     destructive=False,
     idempotent=False,
+    defer_loading=True,
     source_file="scripts/create_sphere.py",
 )
 ```
@@ -144,6 +145,7 @@ ToolDeclaration(
     read_only: bool = False,
     destructive: bool = False,
     idempotent: bool = False,
+    defer_loading: bool = False,
     source_file: str = "",
 ) -> ToolDeclaration
 ```
@@ -157,10 +159,15 @@ ToolDeclaration(
 | `read_only` | `bool` | `False` | 仅读取数据（无副作用）|
 | `destructive` | `bool` | `False` | 可能导致破坏性更改 |
 | `idempotent` | `bool` | `False` | 相同参数始终产生相同结果 |
+| `defer_loading` | `bool` | `False` | 解析 SKILL.md 中的 `defer-loading:` / `defer_loading:`，供发现型 UI 使用 |
 | `source_file` | `str` | `""` | 脚本文件的显式路径 |
 
 ::: tip input_schema 和 output_schema
 内部以 JSON 值存储，非字符串。从 Python 构造时传入 JSON 字符串，会自动解析。
+:::
+
+::: tip 渐进式加载信号
+`tools/list` 返回的未加载 skill stub 现在会带 `annotations.deferredHint = true`。调用 `load_skill(...)` 后，真实工具会以 `deferredHint = false` 暴露。
 :::
 
 ---

--- a/docs/zh/guide/skills.md
+++ b/docs/zh/guide/skills.md
@@ -144,6 +144,7 @@ tools:
     read_only: false
     destructive: false
     idempotent: false
+    defer-loading: true
     source_file: scripts/create_sphere.py
 ```
 
@@ -157,6 +158,7 @@ decl = ToolDeclaration(
     read_only=False,
     destructive=False,
     idempotent=False,
+    defer_loading=True,
     source_file="scripts/create_sphere.py",
 )
 ```
@@ -170,7 +172,10 @@ decl = ToolDeclaration(
 | `read_only` | `bool` | `False` | 仅读取数据（无副作用）|
 | `destructive` | `bool` | `False` | 可能导致破坏性修改 |
 | `idempotent` | `bool` | `False` | 相同参数始终产生相同结果 |
+| `defer_loading` | `bool` | `False` | 接受 `defer-loading` / `defer_loading`，用于标记发现阶段的声明 |
 | `source_file` | `str` | `""` | 脚本的显式路径（相对于 Skill 目录）|
+
+`tools/list` 返回的未加载 skill stub 还会显式带上 `annotations.deferredHint = true`。调用 `load_skill(...)` 后，stub 会被真实工具替换，且这些工具返回 `deferredHint = false`。
 
 ## 脚本查找优先级
 

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -115,6 +115,7 @@ class ToolDeclaration:
     read_only: bool
     destructive: bool
     idempotent: bool
+    defer_loading: bool
     source_file: str
 
     def __init__(
@@ -126,6 +127,7 @@ class ToolDeclaration:
         read_only: bool = False,
         destructive: bool = False,
         idempotent: bool = False,
+        defer_loading: bool = False,
         source_file: str = "",
     ) -> None: ...
     def __repr__(self) -> str: ...
@@ -1044,6 +1046,7 @@ class ToolAnnotations:
     destructive_hint: bool | None
     idempotent_hint: bool | None
     open_world_hint: bool | None
+    deferred_hint: bool | None
 
     def __init__(
         self,
@@ -1052,6 +1055,7 @@ class ToolAnnotations:
         destructive_hint: bool | None = None,
         idempotent_hint: bool | None = None,
         open_world_hint: bool | None = None,
+        deferred_hint: bool | None = None,
     ) -> None: ...
     def __repr__(self) -> str: ...
     def __eq__(self, other: object) -> bool: ...

--- a/tests/test_mcp_protocols_telemetry_capturer_catalog_deep.py
+++ b/tests/test_mcp_protocols_telemetry_capturer_catalog_deep.py
@@ -301,6 +301,7 @@ class TestToolAnnotations:
         assert ta.destructive_hint is None
         assert ta.idempotent_hint is None
         assert ta.open_world_hint is None
+        assert ta.deferred_hint is None
 
     def test_title_set(self):
         ta = m.ToolAnnotations(title="Create Sphere")
@@ -333,12 +334,14 @@ class TestToolAnnotations:
             destructive_hint=False,
             idempotent_hint=True,
             open_world_hint=False,
+            deferred_hint=True,
         )
         assert ta.title == "My Tool"
         assert ta.read_only_hint is True
         assert ta.destructive_hint is False
         assert ta.idempotent_hint is True
         assert ta.open_world_hint is False
+        assert ta.deferred_hint is True
 
     def test_repr_contains_title(self):
         ta = m.ToolAnnotations(title="TestTool")
@@ -352,7 +355,14 @@ class TestToolAnnotations:
     def test_attrs_complete(self):
         ta = m.ToolAnnotations()
         attrs = [a for a in dir(ta) if not a.startswith("_")]
-        for attr in ["title", "read_only_hint", "destructive_hint", "idempotent_hint", "open_world_hint"]:
+        for attr in [
+            "title",
+            "read_only_hint",
+            "destructive_hint",
+            "idempotent_hint",
+            "open_world_hint",
+            "deferred_hint",
+        ]:
             assert attr in attrs
 
 
@@ -464,6 +474,14 @@ class TestToolDeclaration:
         tdecl = m.ToolDeclaration("tool", idempotent=True)
         assert tdecl.idempotent is True
 
+    def test_defer_loading_default_false(self):
+        tdecl = m.ToolDeclaration("tool")
+        assert tdecl.defer_loading is False
+
+    def test_defer_loading_true(self):
+        tdecl = m.ToolDeclaration("tool", defer_loading=True)
+        assert tdecl.defer_loading is True
+
     def test_input_schema_default_is_object_schema(self):
         tdecl = m.ToolDeclaration("tool")
         # Rust default is {"type":"object"} — always returns a JSON string
@@ -491,7 +509,16 @@ class TestToolDeclaration:
     def test_attrs_complete(self):
         tdecl = m.ToolDeclaration("t")
         attrs = [a for a in dir(tdecl) if not a.startswith("_")]
-        for attr in ["name", "description", "read_only", "destructive", "idempotent", "input_schema", "output_schema"]:
+        for attr in [
+            "name",
+            "description",
+            "read_only",
+            "destructive",
+            "idempotent",
+            "defer_loading",
+            "input_schema",
+            "output_schema",
+        ]:
             assert attr in attrs
 
     def test_all_flags_true(self):


### PR DESCRIPTION
## Summary
- add explicit `annotations.deferredHint` to MCP tool metadata so unloaded skill stubs can be distinguished from loaded tools in `tools/list`
- extend shared protocol/model bindings with `deferred_hint` and `defer_loading`, including `defer-loading` / `defer_loading` parsing from `SKILL.md`
- update Rust tests, Python type stubs, and EN/ZH skills docs to describe the progressive-loading signal

## Test plan
- [x] `cargo test -p dcc-mcp-http -p dcc-mcp-protocols -p dcc-mcp-models -p dcc-mcp-skills`
- [x] `cargo test --features python-bindings -p dcc-mcp-models -p dcc-mcp-protocols`
- [x] `cargo test --features python-bindings --no-run`