### PR TITLE
docs: refresh all documentation for v0.12.23

### DIFF
--- a/.agents/skills/dcc-mcp-core/SKILL.md
+++ b/.agents/skills/dcc-mcp-core/SKILL.md
@@ -253,7 +253,7 @@ print(f'Loaded: {[s.name for s in skills]}')
 ┌─────────────────────────────────────────────────────┐
 │                   Python Layer                       │
 │  dcc_mcp_core/__init__.py  →  _core (PyO3 cdyll)   │
-│  ~130 public symbols re-exported from Rust core      │
+│  ~140 public symbols re-exported from Rust core      │
 └──────────────────────┬──────────────────────────────┘
                        │ PyO3 bindings
 ┌──────────────────────▼──────────────────────────────┐

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,9 +34,9 @@
 
 ### Key Architecture Facts
 
-- **Language**: Rust core (12 crates workspace) + Python bindings via PyO3
+- **Language**: Rust core (14 crates workspace) + Python bindings via PyO3
 - **Build system**: `cargo` (Rust) + `maturin` (Python wheels)
-- **Python package**: `dcc_mcp_core` with ~130 public symbols re-exported from `_core` native extension (see `python/dcc_mcp_core/__init__.py`)
+- **Python package**: `dcc_mcp_core` with ~140 public symbols re-exported from `_core` native extension (see `python/dcc_mcp_core/__init__.py`)
 - **Zero runtime Python dependencies** — everything is compiled into the Rust core
 - **Version**: current (use Release Please for versioning — never manually bump)
 - **Python support**: 3.7–3.13 (CI tests 3.7–3.13; abi3-py38 wheel for 3.8+)
@@ -46,32 +46,34 @@
 ```
 dcc-mcp-core/
 ├── src/lib.rs                  # PyO3 entry point (_core module)
-├── Cargo.toml                  # Workspace definition (12 crates)
+├── Cargo.toml                  # Workspace definition (14 crates)
 ├── pyproject.toml              # Python package metadata
 ├── justfile                    # Development commands (use: vx just <recipe>)
 │
 ├── crates/                     # Rust workspace crates
 │   ├── dcc-mcp-models/         # ActionResultModel, SkillMetadata
 │   ├── dcc-mcp-actions/        # ActionRegistry, EventBus, Pipeline, Dispatcher, Validator
-│   ├── dcc-mcp-skills/         # SkillScanner, SkillLoader, SkillWatcher, Resolver
-│   ├── dcc-mcp-protocols/      # MCP types: ToolDefinition, ResourceDefinition, Prompt, DccAdapter
-│   ├── dcc-mcp-transport/      # IPC, ConnectionPool, SessionManager, CircuitBreaker, FramedChannel
+│   ├── dcc-mcp-skills/         # SkillScanner, SkillCatalog, SkillWatcher, Resolver
+│   ├── dcc-mcp-protocols/      # MCP types: ToolDefinition, ResourceDefinition, Prompt, DccAdapter, BridgeKind
+│   ├── dcc-mcp-transport/      # IPC, ConnectionPool, FileRegistry, CircuitBreaker, FramedChannel
 │   ├── dcc-mcp-process/        # PyDccLauncher, ProcessMonitor, ProcessWatcher, CrashRecovery
 │   ├── dcc-mcp-telemetry/      # Tracing/recording infrastructure
 │   ├── dcc-mcp-sandbox/        # Security policy, input validation, audit logging
 │   ├── dcc-mcp-shm/            # Shared memory buffers (LZ4 compressed)
 │   ├── dcc-mcp-capture/        # Screen/window capture backend
 │   ├── dcc-mcp-usd/            # USD scene description bridge
-│   ├── dcc-mcp-http/           # MCP Streamable HTTP server (2025-03-26 spec, McpHttpServer)
+│   ├── dcc-mcp-http/           # MCP Streamable HTTP server (2025-03-26 spec, McpHttpServer, Gateway)
+│   ├── dcc-mcp-server/         # Binary entry point, gateway runner
 │   └── dcc-mcp-utils/          # Filesystem, type wrappers, constants, JSON helpers
 │
 ├── python/dcc_mcp_core/
-│   ├── __init__.py             # Public API re-exports (~120 symbols) — ALWAYS read this first
+│   ├── __init__.py             # Public API re-exports (~140 symbols) — ALWAYS read this first
 │   ├── _core.pyi               # Type stubs (auto-generated-ish) — ground truth for parameter names
+│   ├── skill.py                # Pure-Python skill script helpers (no _core dependency)
 │   └── py.typed                # PEP 561 marker
 │
 ├── tests/                      # Python integration tests (26 files)
-├── examples/skills/            # 9 example SKILL.md packages (hello-world, maya-*, git-*, etc.)
+├── examples/skills/            # 11 example SKILL.md packages (hello-world, maya-*, git-*, etc.)
 ├── docs/                       # VitePress documentation site (EN + ZH)
 │   ├── api/                    # API reference per module
 │   └── guide/                  # User guides & tutorials
@@ -291,56 +293,6 @@ rl.max_calls                              # int
 rl.window_ms                              # int
 ```
 
-**ActionPipeline patterns:**
-
-```python
-from dcc_mcp_core import ActionRegistry, ActionDispatcher, ActionPipeline
-
-reg = ActionRegistry()
-reg.register("create_sphere", description="Create sphere", category="geometry")
-
-dispatcher = ActionDispatcher(reg)
-dispatcher.register_handler("create_sphere", lambda params: {"name": "sphere1"})
-
-pipeline = ActionPipeline(dispatcher)
-
-# Built-in middleware (add in desired order)
-pipeline.add_logging(log_params=True)         # tracing log before/after each action
-timing = pipeline.add_timing()                # measure per-action latency
-audit = pipeline.add_audit(record_params=True) # in-memory audit log
-rl = pipeline.add_rate_limit(max_calls=10, window_ms=1000)  # fixed-window rate limiter
-
-# Python callable hooks (flexible custom middleware)
-pipeline.add_callable(
-    before_fn=lambda action: print(f"before: {action}"),
-    after_fn=lambda action, success: print(f"after: {action} ok={success}"),
-)
-
-# Dispatch
-result = pipeline.dispatch("create_sphere", '{"radius": 1.0}')
-result["output"]          # {"name": "sphere1"}
-result["action"]          # "create_sphere"
-result["validation_skipped"]  # bool
-
-# Register handler directly on pipeline (mirrors ActionDispatcher)
-pipeline.register_handler("delete_sphere", lambda params: True)
-
-# Introspect middleware
-pipeline.middleware_count()   # int
-pipeline.middleware_names()   # ["logging", "timing", "audit", "rate_limit", "python_callable"]
-pipeline.handler_count()      # int
-
-# Query middleware state
-timing.last_elapsed_ms("create_sphere")  # int | None (milliseconds)
-audit.records()                           # list[dict] with action/success/error/timestamp_ms
-audit.records_for_action("create_sphere") # filtered records
-audit.record_count()                      # int
-audit.clear()                             # reset
-rl.call_count("create_sphere")            # int (calls in current window)
-rl.max_calls                              # int
-rl.window_ms                              # int
-```
-
 **ActionResultModel fields:**
 
 ```python
@@ -398,8 +350,7 @@ from dcc_mcp_core import (
 ```python
 # ─────────────────────────────────────────────────────────────
 # Skills-First (recommended): one-call setup
-# Bundled skills (dcc-diagnostics, workflow, git-automation,
-# ffmpeg-media, imagemagick-tools) are loaded automatically.
+# Bundled skills (dcc-diagnostics, workflow) are loaded automatically.
 # ─────────────────────────────────────────────────────────────
 import os
 os.environ["DCC_MCP_MAYA_SKILL_PATHS"] = "/studio/maya-skills"  # or DCC_MCP_SKILL_PATHS
@@ -820,7 +771,7 @@ set DCC_MCP_SKILL_PATHS=C:\path\skills1;C:\path\skills2
 | `.ps1` | PowerShell | `powershell -File` |
 | `.js`, `.jsx` | JavaScript | `node` |
 
-See `examples/skills/` for **9 complete examples**: hello-world, maya-geometry, maya-pipeline, git-automation, ffmpeg-media, imagemagick-tools, usd-tools, clawhub-compat, multi-script.
+See `examples/skills/` for **11 complete examples**: hello-world, maya-geometry, maya-pipeline, git-automation, ffmpeg-media, imagemagick-tools, usd-tools, clawhub-compat, multi-script, dcc-diagnostics, workflow.
 
 ## Adding New Python-Accessible Functions/Classes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,12 +30,12 @@ vx just test-cov      # Coverage report to find gaps
 
 ### Architecture Summary
 
-- **12 Rust crates** under `crates/`, compiled into `_core` native extension
-- **~130 public Python symbols** exported from `python/dcc_mcp_core/__init__.py`
+- **14 Rust crates** under `crates/`, compiled into `_core` native extension
+- **~140 public Python symbols** exported from `python/dcc_mcp_core/__init__.py`
 - **Zero runtime Python deps** — all logic in Rust
 - Key entry point: `src/lib.rs` (PyO3 `#[pymodule]`)
 - Python 3.7–3.13 supported (CI tests 3.7–3.13)
-- Version: **0.12.9** — never manually bump (Release Please manages)
+- Version: **0.12.23** — never manually bump (Release Please manages)
 
 ## Claude-Specific Workflows
 
@@ -55,11 +55,11 @@ vx just test-cov      # Coverage report to find gaps
 - Action naming: `{skill_name}__{script_stem}` (double underscore, hyphens→underscores)
 - Use `scan_and_load()` or `scan_and_load_lenient()` — not the old `scan_and_load_skills()`
 - **`scan_and_load` returns a 2-tuple**: `(List[SkillMetadata], List[str])` — always unpack both
-- See `examples/skills/` for 9 reference implementations
+- See `examples/skills/` for 11 reference implementations
 - **`search-hint` in SKILL.md**: add `search-hint: "keyword1, keyword2"` to improve `search_skills` matching without loading full schemas
 - **On-demand discovery**: `tools/list` returns skill stubs (`__skill__<name>`) for unloaded skills; use `search_skills(query)` then `load_skill(name)` to activate
-- **Bundled skills**: 5 general-purpose skills shipped inside the wheel (`dcc_mcp_core/skills/`):
-  `dcc-diagnostics`, `workflow`, `git-automation`, `ffmpeg-media`, `imagemagick-tools`
+- **Bundled skills**: 2 core skills shipped inside the wheel (`dcc_mcp_core/skills/`):
+  `dcc-diagnostics`, `workflow`
   — use `get_bundled_skills_dir()` / `get_bundled_skill_paths()` to get the path.
   DCC adapters include these by default (`include_bundled=True`).
 
@@ -213,7 +213,7 @@ def test_skill_scan(tmp_path):
 
 ## Key Files to Read First (Priority Order)
 
-1. `python/dcc_mcp_core/__init__.py` — Complete public API (~120 symbols)
+1. `python/dcc_mcp_core/__init__.py` — Complete public API (~140 symbols)
 2. `python/dcc_mcp_core/_core.pyi` — Type stubs with parameter names
 3. `AGENTS.md` — Full architecture, commands, pitfalls
 4. `crates/*/src/python.rs` — PyO3 binding implementations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ vx just test
 
 - **Formatter**: `ruff format` (line length: 120)
 - **Linter**: `ruff check` (includes import sorting via `I` rules)
-- **Target**: Python 3.9+ (CI tests 3.9–3.13)
+- **Target**: Python 3.7+ (CI tests 3.7–3.13)
 - **Quotes**: Double quotes (`"`)
 - **Docstrings**: Google-style
 
@@ -97,19 +97,30 @@ def register_action(self, name: str, **kwargs: Any) -> None:
 ```
 crates/                      # Rust workspace crates (core logic)
 ├── dcc-mcp-models/          # ActionResultModel, SkillMetadata
-├── dcc-mcp-actions/         # ActionRegistry, EventBus
-├── dcc-mcp-skills/          # SkillScanner, SKILL.md loader
-├── dcc-mcp-protocols/       # MCP protocol types (Tool, Resource, Prompt)
-└── dcc-mcp-utils/           # Filesystem, constants, type wrappers, JSON conversion
+├── dcc-mcp-actions/         # ActionRegistry, ActionDispatcher, EventBus, ActionPipeline
+├── dcc-mcp-skills/          # SkillScanner, SkillCatalog, SkillWatcher, dependency resolver
+├── dcc-mcp-protocols/       # MCP protocol types (Tool, Resource, Prompt, DccAdapter, BridgeKind)
+├── dcc-mcp-transport/       # IPC, ConnectionPool, FramedChannel, CircuitBreaker, FileRegistry
+├── dcc-mcp-process/         # PyDccLauncher, ProcessMonitor, CrashRecovery
+├── dcc-mcp-telemetry/       # TelemetryConfig, ActionRecorder, ActionMetrics
+├── dcc-mcp-sandbox/         # SandboxPolicy, InputValidator, AuditLog
+├── dcc-mcp-shm/             # PyBufferPool, PySharedBuffer, LZ4 compression
+├── dcc-mcp-capture/         # Capturer, cross-platform backends
+├── dcc-mcp-usd/             # UsdStage, UsdPrim, scene info bridge
+├── dcc-mcp-http/            # McpHttpServer, McpHttpConfig, Gateway (first-wins competition)
+├── dcc-mcp-server/          # dcc-mcp-server binary, gateway runner
+└── dcc-mcp-utils/           # Filesystem, constants, type wrappers, JSON
 src/
 └── lib.rs                   # PyO3 module entry point (_core)
 python/
 └── dcc_mcp_core/
-    ├── __init__.py           # Public API re-exports from _core
+    ├── __init__.py           # Public API re-exports (~140 symbols) from _core
+    ├── _core.pyi             # Type stubs
+    ├── skill.py              # Pure-Python skill script helpers (no _core dependency)
     └── py.typed              # PEP 561 marker
 tests/                       # Python integration tests
 examples/
-└── skills/                  # Example SKILL.md packages
+└── skills/                  # Example SKILL.md packages (11 examples)
 ```
 
 ## Release Process
@@ -127,7 +138,9 @@ This project uses [Release Please](https://github.com/googleapis/release-please)
 | Command | Description |
 |---------|-------------|
 | `vx just install` | Install project dependencies |
-| `vx just test` | Run tests |
+| `vx just dev` | Build + install dev wheel (maturin develop) |
+| `vx just test` | Run Python tests |
+| `vx just test-rust` | Run Rust unit tests |
 | `vx just test-cov` | Run tests with coverage report |
 | `vx just lint` | Run linter checks (Rust + Python) |
 | `vx just lint-fix` | Auto-fix lint issues |

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -6,7 +6,7 @@
 ## Project Identity
 
 You are working on **dcc-mcp-core**, a Rust-powered MCP (Model Context Protocol) library for DCC
-(Digital Content Creation) applications. Python package: `dcc_mcp_core`. ~120 public symbols,
+(Digital Content Creation) applications. Python package: `dcc_mcp_core`. ~140 public symbols,
 zero runtime Python dependencies (everything compiled into Rust core via PyO3).
 
 ## Priority Reading Order
@@ -30,11 +30,11 @@ vx just lint-fix     # Auto-fix all lint issues
 
 ## Key Architecture Facts
 
-- **12 Rust crates** under `crates/`, compiled into `dcc_mcp_core._core` native extension
-- **~130 public Python symbols** exported from `python/dcc_mcp_core/__init__.py`
+- **14 Rust crates** under `crates/`, compiled into `dcc_mcp_core._core` native extension
+- **~140 public Python symbols** exported from `python/dcc_mcp_core/__init__.py`
 - **Zero runtime Python deps** — all logic in Rust, no `dependencies = [...]` in pyproject.toml
 - Python 3.7–3.13 supported (abi3-py38 wheel; separate non-abi3 wheel for 3.7)
-- Version: **0.12.9** — managed by Release Please, never manually bump
+- Version: **0.12.23** — managed by Release Please, never manually bump
 
 ## Gemini-Specific Workflows
 
@@ -43,7 +43,7 @@ vx just lint-fix     # Auto-fix all lint issues
 ```python
 # What's available?
 import dcc_mcp_core
-print(dir(dcc_mcp_core))  # all ~120 symbols
+print(dir(dcc_mcp_core))  # all ~140 symbols
 
 # Parameter signatures — read _core.pyi
 # grep equivalent:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Foundational library for the DCC Model Context Protocol (MCP) ecosystem. It prov
 | Feature | Description |
 |---------|-------------|
 | **Performance** | Rust core with zero-copy serialization via rmp-serde & LZ4 compression |
-| **Type Safety** | Full PyO3 bindings with comprehensive `.pyi` type stubs (~120 public symbols) |
+| **Type Safety** | Full PyO3 bindings with comprehensive `.pyi` type stubs (~140 public symbols) |
 | **Skills System** | Zero-code script registration as MCP tools (SKILL.md + scripts/) |
 | **Resilient Transport** | IPC with connection pooling, circuit breaker, retry policies |
 | **Process Management** | Launch, monitor, auto-recover DCC processes |
@@ -249,21 +249,23 @@ default. To opt-out: `start_server(include_bundled=False)`.
 
 ## Architecture Overview
 
-dcc-mcp-core is organized as a **Rust workspace of 11 crates**, compiled into a single native Python extension (`_core`) via PyO3/maturin:
+dcc-mcp-core is organized as a **Rust workspace of 14 crates**, compiled into a single native Python extension (`_core`) via PyO3/maturin:
 
 | Crate | Responsibility | Key Types |
 |----------------------|-----------|
 | `dcc-mcp-models` | Data models | `ActionResultModel`, `SkillMetadata` |
 | `dcc-mcp-actions` | Skill execution lifecycle | `ActionRegistry`, `EventBus`, `ActionDispatcher`, `ActionValidator`, `ActionPipeline` |
-| `dcc-mcp-skills` | Skills discovery | `SkillScanner`, `SkillLoader`, `SkillWatcher`, dependency resolver |
-| `dcc-mcp-protocols` | MCP protocol types | `ToolDefinition`, `ResourceDefinition`, `PromptDefinition`, `DccAdapter` types |
-| `dcc-mcp-transport` | IPC communication | `TransportManager`, `ConnectionPool`, `IpcListener`, `FramedChannel`, `CircuitBreaker` |
+| `dcc-mcp-skills` | Skills discovery & loading | `SkillScanner`, `SkillCatalog`, `SkillWatcher`, dependency resolver |
+| `dcc-mcp-protocols` | MCP protocol types | `ToolDefinition`, `ResourceDefinition`, `PromptDefinition`, `DccAdapter`, `BridgeKind` |
+| `dcc-mcp-transport` | IPC communication | `TransportManager`, `ConnectionPool`, `IpcListener`, `FramedChannel`, `CircuitBreaker`, `FileRegistry` |
 | `dcc-mcp-process` | Process management | `PyDccLauncher`, `ProcessMonitor`, `ProcessWatcher`, `CrashRecoveryPolicy` |
 | `dcc-mcp-sandbox` | Security | `SandboxPolicy`, `InputValidator`, `AuditLog` |
 | `dcc-mcp-shm` | Shared memory | `SharedBuffer`, `BufferPool`, LZ4 compression |
 | `dcc-mcp-capture` | Screen capture | `Capturer`, cross-platform backends |
 | `dcc-mcp-telemetry` | Observability | `TelemetryConfig`, `RecordingGuard`, tracing |
 | `dcc-mcp-usd` | USD integration | `UsdStage`, `UsdPrim`, scene info bridge |
+| `dcc-mcp-http` | MCP Streamable HTTP server | `McpHttpServer`, `McpHttpConfig`, `ServerHandle`, Gateway (first-wins competition) |
+| `dcc-mcp-server` | Binary entry point | `dcc-mcp-server` CLI, gateway runner |
 | `dcc-mcp-utils` | Infrastructure | Filesystem helpers, type wrappers, constants, JSON |
 
 ## Key Features
@@ -278,7 +280,7 @@ dcc-mcp-core is organized as a **Rust workspace of 11 crates**, compiled into a 
 - **Screen capture**: Cross-platform DCC viewport capture for AI visual feedback
 - **USD integration**: Universal Scene Description read/write bridge
 - **Structured telemetry**: Tracing & recording for observability
-- **~120 public Python symbols** with full type stubs (`.pyi`)
+- **~140 public Python symbols** with full type stubs (`.pyi`)
 - **OpenClaw Skills compatible**: Reuse existing ecosystem format
 
 ## Installation
@@ -416,7 +418,7 @@ for entry in audit.entries:
 
 ## More Examples
 
-See the [`examples/skills/`](examples/skills/) directory for **9 complete skill packages**, and the [VitePress docs site](https://loonghao.github.io/dcc-mcp-core/) for comprehensive guides per module.
+See the [`examples/skills/`](examples/skills/) directory for **11 complete skill packages**, and the [VitePress docs site](https://loonghao.github.io/dcc-mcp-core/) for comprehensive guides per module.
 
 ## Release Process
 
@@ -499,7 +501,7 @@ If you're an AI coding agent, also see:
 - **[CLAUDE.md](CLAUDE.md)** — Claude-specific instructions and workflows
 - **[GEMINI.md](GEMINI.md)** — Gemini-specific instructions and workflows
 - **[.agents/skills/dcc-mcp-core/SKILL.md](.agents/skills/dcc-mcp-core/SKILL.md)** — Complete API skill definition for learning and using this library
-- **[python/dcc_mcp_core/__init__.py](python/dcc_mcp_core/__init__.py)** — Full public API surface (~120 symbols)
+- **[python/dcc_mcp_core/__init__.py](python/dcc_mcp_core/__init__.py)** — Full public API surface (~140 symbols)
 - **[llms.txt](llms.txt)** — Concise API reference optimized for LLMs
 - **[llms-full.txt](llms-full.txt)** — Complete API reference optimized for LLMs
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** — Development workflow and coding standards

--- a/README_zh.md
+++ b/README_zh.md
@@ -20,7 +20,7 @@ DCC 模型上下文协议（Model Context Protocol，MCP）生态系统的基础
 | 特性 | 描述 |
 |------|------|
 | **高性能** | Rust 核心，rmp-serde 零拷贝序列化 & LZ4 压缩 |
-| **类型安全** | 完整的 PyO3 绑定 + 全面 `.pyi` 类型存根（约 120 个公共符号） |
+| **类型安全** | 完整的 PyO3 绑定 + 全面 `.pyi` 类型存根（约 140 个公共符号） |
 | **Skills 系统** | 零代码脚本注册为 MCP 工具（SKILL.md + scripts/） |
 | **弹性传输** | IPC + 连接池、熔断器、重试策略 |
 | **进程管理** | 启动/监控/自动恢复 DCC 进程 |
@@ -276,23 +276,25 @@ paths = get_bundled_skill_paths(include_bundled=False)  # 按需禁用
 
 DCC 适配器（如 `dcc-mcp-maya`）默认自动加载内置技能包。如需禁用：`start_server(include_bundled=False)`。
 
-## 架构概览 — 11 个 Rust Crate 工作区
+## 架构概览 — 14 个 Rust Crate 工作区
 
-dcc-mcp-core 组织为 **11 个 Rust Crate 工作区**，通过 PyO3/maturin 编译成单个原生 Python 扩展（`_core`）：
+dcc-mcp-core 组织为 **14 个 Rust Crate 工作区**，通过 PyO3/maturin 编译成单个原生 Python 扩展（`_core`）：
 
 | Crate | 职责 | 关键类型 |
 |-------|------|---------|
 | `dcc-mcp-models` | 数据模型 | `ActionResultModel`, `SkillMetadata` |
 | `dcc-mcp-actions` | 技能执行生命周期 | `ActionRegistry`, `EventBus`, `ActionDispatcher`, `ActionValidator`, `ActionPipeline` |
-| `dcc-mcp-skills` | 技能发现 | `SkillScanner`, `SkillWatcher`, 依赖解析器 |
-| `dcc-mcp-protocols` | MCP 协议类型 | `ToolDefinition`, `ResourceDefinition`, `DccAdapter` |
-| `dcc-mcp-transport` | IPC 通信 | `TransportManager`, `ConnectionPool`, `IpcListener`, `FramedChannel`, `CircuitBreaker` |
+| `dcc-mcp-skills` | 技能发现与加载 | `SkillScanner`, `SkillCatalog`, `SkillWatcher`, 依赖解析器 |
+| `dcc-mcp-protocols` | MCP 协议类型 | `ToolDefinition`, `ResourceDefinition`, `DccAdapter`, `BridgeKind` |
+| `dcc-mcp-transport` | IPC 通信 | `TransportManager`, `ConnectionPool`, `IpcListener`, `FramedChannel`, `CircuitBreaker`, `FileRegistry` |
 | `dcc-mcp-process` | 进程管理 | `PyDccLauncher`, `ProcessMonitor`, `CrashRecoveryPolicy` |
 | `dcc-mcp-sandbox` | 安全沙箱 | `SandboxPolicy`, `InputValidator`, `AuditLog` |
 | `dcc-mcp-shm` | 共享内存 | `SharedBuffer`, LZ4 压缩 |
 | `dcc-mcp-capture` | 屏幕捕获 | `Capturer`, 跨平台后端 |
 | `dcc-mcp-telemetry` | 可观测性 | `TelemetryConfig`, `ActionMetrics`, tracing |
 | `dcc-mcp-usd` | USD 场景 | `UsdStage`, `UsdPrim`, 场景信息桥接 |
+| `dcc-mcp-http` | MCP Streamable HTTP 服务器 | `McpHttpServer`, `McpHttpConfig`, `ServerHandle`, Gateway（首个获胜竞争） |
+| `dcc-mcp-server` | 二进制入口点 | `dcc-mcp-server` CLI、Gateway 运行器 |
 | `dcc-mcp-utils` | 基础设施 | 文件系统、类型封装、常量、JSON |
 
 ## 更多功能
@@ -387,7 +389,7 @@ for entry in audit.entries:
 - **屏幕捕获**：跨平台 DCC 视口捕获，AI 视觉反馈
 - **USD 集成**：通用场景描述读写桥接
 - **结构化遥测**：Tracing & 录制可观测性
-- **~120 个 Python 公共符号** + 完整 `.pyi` 类型存根
+- **~140 个 Python 公共符号** + 完整 `.pyi` 类型存根
 - **兼容 OpenClaw Skills**：直接复用生态格式
 
 ## 安装

--- a/docs/api/actions.md
+++ b/docs/api/actions.md
@@ -1,4 +1,4 @@
-# Skills API
+# Actions API
 
 `dcc_mcp_core` — ActionRegistry, EventBus, ActionDispatcher, ActionValidator, SemVer, VersionConstraint, VersionedRegistry.
 

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -33,8 +33,12 @@ cfg = McpHttpConfig(
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `port` | `int` | `8765` | TCP port the server is listening on (`0` = OS-assigned) |
+| `host` | `str` | `"127.0.0.1"` | IP address to bind (localhost only per MCP security spec) |
+| `endpoint_path` | `str` | `"/mcp"` | MCP endpoint path |
 | `server_name` | `str` | `"dcc-mcp"` | Server name in MCP response |
 | `server_version` | `str` | package version | Server version in MCP response |
+| `max_sessions` | `int` | `100` | Maximum concurrent SSE sessions |
+| `session_ttl_secs` | `int` | `3600` | Idle session TTL in seconds (`0` = disable eviction) |
 | `gateway_port` | `int` | `0` | Gateway port to compete for (`0` = disabled). See [Gateway](#gateway) |
 | `registry_dir` | `str \| None` | `None` | Directory for the shared `FileRegistry` JSON (defaults to OS temp dir) |
 | `stale_timeout_secs` | `int` | `30` | Seconds without a heartbeat before an instance is considered stale |
@@ -121,6 +125,7 @@ The server implements the MCP 2025-03-26 spec:
 |----------|--------|-------------|
 | `/mcp` | POST | MCP request (JSON-RPC 2.0) |
 | `/mcp` | GET | SSE-compatible event stream |
+| `/mcp` | DELETE | Terminate MCP session |
 | `/health` | GET | Health check |
 
 ### Request/Response Format

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -94,6 +94,7 @@ Metadata parsed from SKILL.md frontmatter. All fields are readable and writable.
 |-------|------|---------|-------------|
 | `name` | `str` | — | Unique identifier |
 | `description` | `str` | `""` | Human-readable description |
+| `search_hint` | `str` | `""` | Keyword hint for `search_skills` (SKILL.md `search-hint:` field; falls back to `description`) |
 | `tools` | `List[str]` | `[]` | Required tool permissions |
 | `dcc` | `str` | `"python"` | Target DCC application |
 | `tags` | `List[str]` | `[]` | Classification tags |

--- a/docs/api/protocols.md
+++ b/docs/api/protocols.md
@@ -76,7 +76,7 @@ td.read_only, td.destructive, td.idempotent, td.source_file
 `tools:` frontmatter. Each entry maps to one MCP tool. When `tools:` is absent, the Skill
 falls back to auto-discovering scripts in `scripts/`.
 
-
+## ResourceDefinition
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -350,19 +350,59 @@ Feature flags advertising which sub-traits a DCC adapter supports.
 | `transform` | `bool` | `False` | Implements `DccTransform` |
 | `render_capture` | `bool` | `False` | Implements `DccRenderCapture` |
 | `hierarchy` | `bool` | `False` | Implements `DccHierarchy` |
+| `has_embedded_python` | `bool` | `True` | Whether the DCC has an embedded Python interpreter (`False` for bridge-based DCCs) |
+| `bridge_kind` | `str \| None` | `None` | Bridge kind: `"http"`, `"websocket"`, `"named_pipe"`, or custom string |
+| `bridge_endpoint` | `str \| None` | `None` | Bridge endpoint URL or socket path |
 | `extensions` | `dict[str, bool]` | `{}` | Arbitrary extension flags |
 
 ```python
 from dcc_mcp_core import DccCapabilities, ScriptLanguage
 
+# Python-embedded DCC (e.g. Maya, Blender)
 caps = DccCapabilities(
     script_languages=[ScriptLanguage.PYTHON, ScriptLanguage.MEL],
     scene_info=True,
     snapshot=True,
     file_operations=True,
 )
+
+# Bridge-based DCC (e.g. Photoshop via WebSocket)
+caps_bridge = DccCapabilities(
+    scene_info=True,
+    has_embedded_python=False,
+    bridge_kind="websocket",
+    bridge_endpoint="ws://localhost:12345",
+)
 if caps.scene_manager:
     print("scene manager available")
+```
+
+### BridgeKind
+
+`BridgeKind` describes how a non-Python DCC communicates with the MCP server. Bridge-based DCCs
+(e.g. ZBrush via HTTP, Photoshop via WebSocket, 3ds Max via Named Pipe) do not have an embedded
+Python interpreter, so they use a bridge protocol instead.
+
+In Python, `BridgeKind` is exposed as a `str` on `DccCapabilities.bridge_kind`:
+
+| Value | Description | Example DCC |
+|-------|-------------|-------------|
+| `"http"` | HTTP REST bridge | ZBrush 2024+ |
+| `"websocket"` | WebSocket JSON-RPC bridge | Photoshop (UXP) |
+| `"named_pipe"` | Named pipe / COM bridge | 3ds Max |
+| Custom string | Application-specific bridge | — |
+| `None` | Direct Python-embedded (no bridge) | Maya, Blender, Houdini |
+
+```python
+from dcc_mcp_core import DccCapabilities
+
+# Check if a DCC uses a bridge
+if caps.bridge_kind == "websocket":
+    print(f"Connect to bridge at {caps.bridge_endpoint}")
+
+# has_embedded_python is False for bridge-based DCCs
+if not caps.has_embedded_python:
+    print("This DCC requires a bridge connection")
 ```
 
 ### DccError

--- a/docs/api/skills.md
+++ b/docs/api/skills.md
@@ -11,30 +11,33 @@ Progressive skill discovery and loading. Thread-safe (all state stored in DashMa
 When a dispatcher is attached via `with_dispatcher()`, loading a skill also registers a subprocess-based handler for each action — enabling the Skills-First workflow where agents never need to register handlers manually.
 
 ```python
-from dcc_mcp_core import SkillScanner, SkillCatalog
+from dcc_mcp_core import SkillCatalog, ActionRegistry
 
-scanner = SkillScanner()
-catalog = SkillCatalog(scanner)
+registry = ActionRegistry()
+catalog = SkillCatalog(registry)
 ```
 
 ### Constructor
 
 ```python
-SkillCatalog(scanner: SkillScanner) -> SkillCatalog
+SkillCatalog(registry: ActionRegistry) -> SkillCatalog
 ```
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `scanner` | `SkillScanner` | Scanner instance used for discovery |
+| `registry` | `ActionRegistry` | Action registry for registering skill tools |
 
 ### Methods
 
 | Method | Returns | Description |
 |--------|---------|-------------|
 | `with_dispatcher(dispatcher)` | — | Attach an `ActionDispatcher`; enables auto-handler registration on `load_skill()` |
-| `discover(extra_paths=None, dcc_name=None)` | `None` | Scan for skills and populate the catalog |
-| `load_skill(skill_name)` | `bool` | Load a skill; returns `True` on success, `False` if already loaded or not found |
-| `unload_skill(skill_name)` | `bool` | Unload a skill; returns `True` on success, `False` if not loaded |
+| `discover(extra_paths=None, dcc_name=None)` | `int` | Scan for skills and populate the catalog; returns number of newly discovered skills |
+| `load_skill(skill_name)` | `List[str]` | Load a skill; returns list of registered action names. Raises `ValueError` if not found |
+| `load_skills(skill_names)` | `dict[str, Result]` | Batch load multiple skills; returns map of name → result |
+| `unload_skill(skill_name)` | `int` | Unload a skill; returns number of actions removed. Raises `ValueError` if not loaded |
+| `remove_skill(skill_name)` | `bool` | Remove a skill from the catalog entirely (unloads first if loaded) |
+| `clear()` | `None` | Clear all skills from the catalog (unloads first) |
 | `find_skills(query=None, tags=None, dcc=None)` | `List[SkillSummary]` | Search by name/tags/dcc (all filters AND-ed) |
 | `list_skills(status=None)` | `List[SkillSummary]` | List skills. `status`: `"loaded"` or `"unloaded"`, or `None` for all |
 | `get_skill_info(skill_name)` | `SkillMetadata \| None` | Full metadata for a skill, or `None` if not found |
@@ -46,12 +49,12 @@ SkillCatalog(scanner: SkillScanner) -> SkillCatalog
 
 ```python
 import os
-from dcc_mcp_core import SkillScanner, SkillCatalog, ActionRegistry, ActionDispatcher
+from dcc_mcp_core import SkillCatalog, ActionRegistry, ActionDispatcher
 
 os.environ["DCC_MCP_SKILL_PATHS"] = "/path/to/skills"
 
-scanner = SkillScanner()
-catalog = SkillCatalog(scanner)
+registry = ActionRegistry()
+catalog = SkillCatalog(registry)
 
 # Discover skills
 catalog.discover(extra_paths=["/extra/skills"], dcc_name="maya")
@@ -67,13 +70,12 @@ for s in results:
     print(f"  {s.name}: {s.tool_count} tools → {s.tool_names}")
 
 # With dispatcher — enables Skills-First auto-handler registration
-registry = ActionRegistry()
 dispatcher = ActionDispatcher(registry)
 catalog.with_dispatcher(dispatcher)
 
 # Load a skill (actions auto-registered if dispatcher is attached)
-ok = catalog.load_skill("maya-geometry")
-print(f"Loaded: {ok}")
+actions = catalog.load_skill("maya-geometry")
+print(f"Loaded actions: {actions}")
 
 # Get full metadata
 meta = catalog.get_skill_info("maya-geometry")
@@ -84,8 +86,8 @@ if meta:
 print(catalog.loaded_count())
 
 # Unload
-ok = catalog.unload_skill("maya-geometry")
-print(f"Unloaded: {ok}")
+removed = catalog.unload_skill("maya-geometry")
+print(f"Unloaded {removed} actions")
 ```
 
 ---
@@ -100,6 +102,7 @@ Lightweight summary returned by `SkillCatalog.find_skills()` and `list_skills()`
 |----------|------|-------------|
 | `name` | `str` | Skill name |
 | `description` | `str` | Short description |
+| `search_hint` | `str` | Keyword hint for search (from `search-hint:` in SKILL.md; falls back to `description`) |
 | `tags` | `List[str]` | Skill tags |
 | `dcc` | `str` | Target DCC (e.g. `"maya"`) |
 | `version` | `str` | Skill version |

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -4,7 +4,7 @@ DCC-MCP-Core is a Rust workspace with Python bindings via PyO3. The library prov
 
 - **Zero third-party runtime dependencies** in the Rust core
 - **Optional Python bindings** via PyO3 for DCC integration
-- **13 modular crates** for selective dependency usage
+- **14 modular crates** for selective dependency usage
 
 ## Crate Structure
 
@@ -12,16 +12,17 @@ DCC-MCP-Core is a Rust workspace with Python bindings via PyO3. The library prov
 dcc-mcp-core (workspace root)
 ├── dcc-mcp-models       # ActionResultModel, SkillMetadata, DCC types
 ├── dcc-mcp-actions      # ActionRegistry, EventBus, ActionDispatcher, Pipeline
-├── dcc-mcp-skills       # SkillScanner, SkillLoader, SkillWatcher, Resolver
-├── dcc-mcp-protocols    # MCP types: ToolDefinition, ResourceDefinition, Prompt
-├── dcc-mcp-transport    # IPC, ConnectionPool, SessionManager, FramedChannel
+├── dcc-mcp-skills       # SkillScanner, SkillCatalog, SkillWatcher, Resolver
+├── dcc-mcp-protocols    # MCP types: ToolDefinition, ResourceDefinition, Prompt, DccAdapter, BridgeKind
+├── dcc-mcp-transport    # IPC, ConnectionPool, FileRegistry, FramedChannel
 ├── dcc-mcp-process      # PyDccLauncher, ProcessMonitor, ProcessWatcher, CrashRecovery
 ├── dcc-mcp-telemetry    # Tracing/recording: ActionRecorder, TelemetryConfig
 ├── dcc-mcp-sandbox      # Security: SandboxPolicy, SandboxContext, AuditLog
 ├── dcc-mcp-shm          # Shared memory: PySharedBuffer, PyBufferPool
 ├── dcc-mcp-capture      # Screen capture: Capturer, CaptureFrame
 ├── dcc-mcp-usd          # USD scene description: UsdStage, SdfPath, VtValue
-├── dcc-mcp-http         # MCP HTTP server: McpHttpServer, McpHttpConfig
+├── dcc-mcp-http         # MCP HTTP server: McpHttpServer, McpHttpConfig, Gateway
+├── dcc-mcp-server       # Binary entry point: dcc-mcp-server, gateway runner
 └── dcc-mcp-utils       # Filesystem, type wrappers, constants
 ```
 
@@ -38,7 +39,9 @@ dcc-mcp-protocols ← dcc-mcp-models
        ↓
 dcc-mcp-transport ← dcc-mcp-protocols
        ↓
-dcc-mcp-http ← dcc-mcp-transport, dcc-mcp-protocols
+dcc-mcp-http ← dcc-mcp-transport, dcc-mcp-protocols, dcc-mcp-actions, dcc-mcp-skills
+       ↓
+dcc-mcp-server ← dcc-mcp-http
 ```
 
 ## Crate Responsibilities
@@ -78,6 +81,7 @@ dcc-mcp-http ← dcc-mcp-transport, dcc-mcp-protocols
 
 **Key Components**:
 - `SkillScanner` — mtime-cached directory scanner for SKILL.md packages
+- `SkillCatalog` — Progressive skill loading with on-demand discovery (register actions on `load_skill`)
 - `SkillWatcher` — Platform-native filesystem watcher (inotify/FSEvents/ReadDirectoryChangesW)
 - `SkillMetadata` — Parsed metadata from SKILL.md frontmatter
 - Dependency resolution: `resolve_dependencies`, `expand_transitive_dependencies`, `validate_dependencies`
@@ -95,6 +99,7 @@ dcc-mcp-http ← dcc-mcp-transport, dcc-mcp-protocols
 - `ResourceDefinition`, `ResourceTemplateDefinition`, `ResourceAnnotations` — MCP resource schema
 - `PromptDefinition`, `PromptArgument` — MCP prompt schema
 - `DccAdapter` — DCC adapter capability descriptor
+- `BridgeKind` — Bridge type enum (Http, WebSocket, NamedPipe, Custom) for non-Python DCCs
 
 **Dependencies**: `dcc-mcp-models`
 
@@ -198,14 +203,36 @@ dcc-mcp-http ← dcc-mcp-transport, dcc-mcp-protocols
 
 ### dcc-mcp-http
 
-**Purpose**: MCP Streamable HTTP server (2025-03-26 spec) for HTTP-based MCP clients.
+**Purpose**: MCP Streamable HTTP server (2025-03-26 spec) for HTTP-based MCP clients, with optional gateway competition.
 
 **Key Components**:
 - `McpHttpServer` — Background-thread HTTP server (axum/Tokio)
-- `McpHttpConfig` — Server configuration (port, CORS, request timeout)
-- `ServerHandle` — Server handle for URL retrieval and graceful shutdown
+- `McpHttpConfig` — Server configuration (port, CORS, request timeout, gateway fields)
+- `ServerHandle` — Server handle with URL retrieval, `is_gateway` flag, and graceful shutdown
+- `GatewayRunner` — First-wins port competition orchestrator
+- `GatewayConfig` — Gateway configuration (port, stale timeout, heartbeat interval)
+- `GatewayHandle` — Handle indicating whether this process won the gateway port
+- `GatewayState` — Shared gateway state (registry, stale timeout, HTTP client for proxying)
 
-**Dependencies**: `axum`, `tokio`
+**McpHttpConfig Gateway Fields**:
+- `gateway_port` — Port to compete for (0 = disabled, default 0)
+- `registry_dir` — Shared FileRegistry directory
+- `stale_timeout_secs` — Seconds without heartbeat before instance is stale
+- `heartbeat_secs` — Heartbeat interval in seconds
+- `dcc_type` / `dcc_version` / `scene` — Instance metadata for gateway routing
+
+**SSE Support**: `GET /mcp` long-lived SSE stream for server-push events
+
+**Dependencies**: `axum`, `tokio`, `reqwest`, `socket2`, `dcc-mcp-transport`, `dcc-mcp-protocols`, `dcc-mcp-actions`, `dcc-mcp-skills`
+
+### dcc-mcp-server
+
+**Purpose**: Binary entry point (`dcc-mcp-server` CLI) that assembles and runs the full MCP server with gateway support.
+
+**Key Components**:
+- `main.rs` — CLI entry point using `GatewayRunner` and `McpHttpServer` library APIs
+
+**Dependencies**: `dcc-mcp-http`
 
 ### dcc-mcp-utils
 
@@ -257,7 +284,7 @@ If you need custom middleware or fine-grained control, assemble the stack manual
 
 ## Python Bindings
 
-All 13 crates are compiled into a single PyO3 native extension (`dcc_mcp_core._core`) via `maturin`.
+All 14 crates are compiled into a single PyO3 native extension (`dcc_mcp_core._core`) via `maturin`.
 
 ```toml
 # pyproject.toml
@@ -270,7 +297,7 @@ dependencies = []  # Zero runtime dependencies
 
 ```
 python/dcc_mcp_core/
-├── __init__.py     # Public API (re-exports ~130 symbols from _core)
+├── __init__.py     # Public API (re-exports ~140 symbols from _core)
 ├── _core.pyi       # Type stubs (auto-generated from Rust)
 └── py.typed        # PEP 561 marker
 ```

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -20,7 +20,10 @@ DCC-MCP-Core is a foundational Rust library with Python bindings that provides:
 dcc-mcp-core is DCC-agnostic — the core library provides the infrastructure. DCC-specific integrations are separate projects:
 
 - **Maya** — via [dcc-mcp-maya](https://github.com/loonghao/dcc-mcp-maya)
-- **Blender, Houdini, 3ds Max, Unreal** — community/third-party integrations using this library
+- **Unreal Engine** — via [dcc-mcp-unreal](https://github.com/loonghao/dcc-mcp-unreal) (in development, Python embedded)
+- **Photoshop** — via [dcc-mcp-photoshop](https://github.com/loonghao/dcc-mcp-photoshop) (in development, WebSocket bridge)
+- **ZBrush** — via [dcc-mcp-zbrush](https://github.com/loonghao/dcc-mcp-zbrush) (in development, HTTP bridge)
+- **Blender, Houdini, 3ds Max** — community/third-party integrations using this library
 
 The core library works with any Python 3.7+ environment.
 
@@ -260,6 +263,47 @@ print(handle.mcp_url())  # http://127.0.0.1:8765/mcp
 # Connect your AI client to this URL
 handle.shutdown()
 ```
+
+## Gateway
+
+### How do I run multiple DCC instances with a single endpoint?
+
+Use the **Gateway** feature. Set `gateway_port` on `McpHttpConfig` to a well-known port (default: `9765`). The first process to bind that port becomes the gateway; all others register as plain DCC instances:
+
+```python
+from dcc_mcp_core import ActionRegistry, McpHttpServer, McpHttpConfig
+
+registry = ActionRegistry()
+config = McpHttpConfig(port=0, server_name="maya-mcp")
+config.gateway_port = 9765
+config.dcc_type = "maya"
+
+server = McpHttpServer(registry, config)
+handle = server.start()
+print(handle.is_gateway)  # True if this process won the gateway port
+```
+
+Agents always connect to `http://localhost:9765/mcp` and use `list_dcc_instances` / `connect_to_dcc` to discover and route to specific DCC processes.
+
+### What is BridgeKind?
+
+`BridgeKind` describes how a DCC communicates when it does **not** have an embedded Python interpreter:
+- `Http` — HTTP REST bridge (e.g. ZBrush)
+- `WebSocket` — WebSocket JSON-RPC bridge (e.g. Photoshop UXP)
+- `NamedPipe` — Named pipe bridge (e.g. 3ds Max COM)
+
+Set `DccCapabilities(bridge_kind="http", bridge_endpoint="http://localhost:1234", has_embedded_python=False)` for bridge-based DCCs.
+
+## On-Demand Skill Discovery
+
+### How does on-demand skill discovery work?
+
+When `create_skill_manager()` starts, it only **discovers** skills (reads SKILL.md files) — it does **not** load them. The `tools/list` response shows:
+1. 6 core discovery tools (always present)
+2. Loaded skill tools with full schemas
+3. Unloaded skill stubs as `__skill__<name>` (name + one-line description only)
+
+Agents use `search_skills(query="keyword")` to find relevant skills, then `load_skill(skill_name="...")` to activate them. This keeps the initial tool list small and loads schemas only when needed.
 
 ## Troubleshooting
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -132,7 +132,7 @@ server = McpHttpServer(registry, config)
 handle = server.start()
 
 print(f"MCP server running at http://127.0.0.1:8765/mcp")
-# handle.stop() to shut down
+# handle.shutdown() to shut down
 ```
 
 ## Development Setup
@@ -163,4 +163,4 @@ vx just lint
 - Check out the [Skills System](/guide/skills) for zero-code script registration
 - Expose tools with [MCP HTTP Server](/api/http)
 - See the [Transport Layer](/guide/transport) for DCC communication
-- Understand the [Architecture](/guide/architecture) of the 13-crate Rust workspace
+- Understand the [Architecture](/guide/architecture) of the 14-crate Rust workspace

--- a/docs/guide/protocols.md
+++ b/docs/guide/protocols.md
@@ -129,6 +129,10 @@ caps = DccCapabilities(
     progress_reporting=True,
     file_operations=True,
     selection=True,
+    # Bridge fields (for non-Python DCCs like Photoshop, ZBrush)
+    has_embedded_python=True,
+    bridge_kind=None,        # "http", "websocket", "named_pipe", or None
+    bridge_endpoint=None,    # URL or socket path for bridge connection
 )
 
 # DCC error
@@ -166,6 +170,29 @@ scene = SceneInfo(
     statistics=stats,
 )
 ```
+
+### BridgeKind
+
+`BridgeKind` describes how a DCC communicates when it does **not** have an embedded Python interpreter (e.g. Photoshop via UXP WebSocket, ZBrush via HTTP REST):
+
+| Variant | Python string | Description |
+|---------|---------------|-------------|
+| `Http` | `"http"` | HTTP REST bridge (e.g. ZBrush 2024+) |
+| `WebSocket` | `"websocket"` | WebSocket JSON-RPC bridge (e.g. Photoshop UXP) |
+| `NamedPipe` | `"named_pipe"` | Named pipe bridge (e.g. 3ds Max COM) |
+| `Custom(String)` | custom string | Custom bridge protocol |
+
+In Python, `DccCapabilities.bridge_kind` is exposed as `Optional[str]` — use the string values above.
+
+**Factory methods** on `DccCapabilities`:
+- `DccCapabilities()` — Standard Python-embedded DCC (`has_embedded_python=True`)
+- Set `bridge_kind="http"` + `bridge_endpoint=...` for HTTP bridge DCCs
+- Set `bridge_kind="websocket"` + `bridge_endpoint=...` for WebSocket bridge DCCs
+
+**New DCC adapter projects** (in development):
+- [dcc-mcp-unreal](https://github.com/loonghao/dcc-mcp-unreal) — Unreal Engine (Python embedded)
+- [dcc-mcp-photoshop](https://github.com/loonghao/dcc-mcp-photoshop) — Photoshop (WebSocket bridge via UXP)
+- [dcc-mcp-zbrush](https://github.com/loonghao/dcc-mcp-zbrush) — ZBrush (HTTP REST bridge)
 
 ### DccErrorCode Enum
 

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -366,3 +366,62 @@ def create_skill_manager(
 ::: warning script execution
 All scripts run as subprocesses. Input parameters are passed via stdin as JSON. The script should write a JSON result to stdout and exit with code 0 on success.
 :::
+
+## On-Demand Skill Discovery (MCP HTTP)
+
+When using the MCP HTTP server (`McpHttpServer` or `create_skill_manager`), `tools/list` returns a **three-tier** response:
+
+### Three-Tier `tools/list` Response
+
+1. **6 core discovery tools** (always present):
+   - `find_skills` — Search for skills by query, tags, DCC type
+   - `list_skills` — List all skills with optional status filter
+   - `get_skill_info` — Get full metadata for a specific skill
+   - `load_skill` — Load a skill, registering its tools in ActionRegistry
+   - `unload_skill` — Unload a skill, removing its tools
+   - `search_skills` — Keyword search across name, description, search_hint, and tool_names
+
+2. **Loaded skill tools** — Full `input_schema` from the `ActionRegistry` for all currently loaded skills
+
+3. **Unloaded skill stubs** — `__skill__<name>` entries with a one-line description only (no full schema)
+
+### Workflow
+
+```
+1. AI calls tools/list → sees core tools + loaded tools + __skill__ stubs
+2. AI calls search_skills(query="geometry") → finds matching skills
+3. AI calls load_skill(skill_name="maya-geometry") → tools registered
+4. AI calls tools/list again → maya-geometry tools now have full schemas
+5. AI calls maya_geometry__create_sphere → skill script executes
+```
+
+### Skill Stub Behavior
+
+Calling an unloaded skill stub (`__skill__<name>`) returns an error with a hint:
+
+```json
+{
+  "error": "Skill 'maya-geometry' is not loaded. Call load_skill(skill_name=\"maya-geometry\") to register its tools."
+}
+```
+
+### `search_skills` MCP Tool
+
+```json
+{
+  "name": "search_skills",
+  "description": "Search for skills matching a keyword query",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "query": {"type": "string", "description": "Search keyword"},
+      "dcc": {"type": "string", "description": "Filter by DCC type"}
+    },
+    "required": ["query"]
+  }
+}
+```
+
+Searches across: `name`, `description`, `search_hint`, and `tool_names`. The `search_hint` field (from SKILL.md `search-hint:`) improves keyword matching without loading full schemas.
+
+`create_skill_manager()` only calls `discover()` at startup — skills are **not** automatically loaded. This keeps the initial tool list small and lets agents load only what they need.

--- a/docs/guide/what-is-dcc-mcp-core.md
+++ b/docs/guide/what-is-dcc-mcp-core.md
@@ -45,7 +45,7 @@ flowchart LR
 
 ## Architecture
 
-DCC-MCP-Core is a Rust workspace with **13 sub-crates**, compiled into a single Python extension module `dcc_mcp_core._core` via maturin:
+DCC-MCP-Core is a Rust workspace with **14 sub-crates**, compiled into a single Python extension module `dcc_mcp_core._core` via maturin:
 
 ```
 dcc-mcp-core/
@@ -62,17 +62,19 @@ dcc-mcp-core/
 │   ├── dcc-mcp-shm/            # PySharedBuffer, PyBufferPool, PySharedSceneBuffer
 │   ├── dcc-mcp-capture/        # Capturer, CaptureFrame
 │   ├── dcc-mcp-usd/            # UsdStage, UsdPrim, VtValue, SdfPath
-│   ├── dcc-mcp-http/           # McpHttpServer, McpHttpConfig, ServerHandle
+│   ├── dcc-mcp-http/           # McpHttpServer, McpHttpConfig, ServerHandle, Gateway
+│   ├── dcc-mcp-server/         # Binary entry point, gateway runner
 │   └── dcc-mcp-utils/          # Filesystem, constants, type wrappers, JSON helpers
 └── python/
     └── dcc_mcp_core/
-        ├── __init__.py          # Re-exports ~130 public symbols from _core
+        ├── __init__.py          # Re-exports ~140 public symbols from _core
+        ├── skill.py             # Pure-Python skill script helpers
         └── _core.pyi            # Type stubs for all public APIs
 ```
 
 ## Python API Surface
 
-All public APIs are available from the top-level `dcc_mcp_core` package. The library exports ~130 public symbols across 13 domains:
+All public APIs are available from the top-level `dcc_mcp_core` package. The library exports ~140 public symbols across 14 domains:
 
 ```python
 from dcc_mcp_core import (
@@ -118,12 +120,15 @@ See the [API Reference](/api/actions) for complete documentation of every symbol
 
 ## Version & Python Support
 
-- **Current version**: 0.12.12
+- **Current version**: 0.12.23
 - **Python**: 3.7–3.13 (abi3-py38 wheel, tested in CI across all versions)
 - **Rust**: Edition 2024, MSRV 1.85
 - **Build**: maturin + PyO3; zero runtime Python dependencies
 
 ## Related Projects
 
-- [dcc-mcp-rpyc](https://github.com/loonghao/dcc-mcp-rpyc) — RPyC bridge for remote DCC operations
 - [dcc-mcp-maya](https://github.com/loonghao/dcc-mcp-maya) — Maya MCP server implementation
+- [dcc-mcp-unreal](https://github.com/loonghao/dcc-mcp-unreal) — Unreal Engine adapter (in development)
+- [dcc-mcp-photoshop](https://github.com/loonghao/dcc-mcp-photoshop) — Photoshop UXP WebSocket bridge (in development)
+- [dcc-mcp-zbrush](https://github.com/loonghao/dcc-mcp-zbrush) — ZBrush HTTP REST bridge (in development)
+- [dcc-mcp-rpyc](https://github.com/loonghao/dcc-mcp-rpyc) — RPyC bridge for remote DCC operations

--- a/docs/zh/api/actions.md
+++ b/docs/zh/api/actions.md
@@ -1,4 +1,4 @@
-# Skills API
+# Actions API
 
 `dcc_mcp_core` — ActionRegistry、EventBus、ActionDispatcher、ActionValidator、SemVer、VersionConstraint、VersionedRegistry。
 

--- a/docs/zh/api/http.md
+++ b/docs/zh/api/http.md
@@ -30,11 +30,24 @@ cfg = McpHttpConfig(
 
 ### 属性
 
-| 属性 | 类型 | 说明 |
-|------|------|------|
-| `port` | `int` | 服务器监听的 TCP 端口 |
-| `server_name` | `str` | MCP 响应中的服务器名称 |
-| `server_version` | `str` | MCP 响应中的服务器版本 |
+| 属性 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `port` | `int` | `8765` | 服务器监听的 TCP 端口（`0` = OS 分配） |
+| `host` | `str` | `"127.0.0.1"` | 绑定的 IP 地址 |
+| `endpoint_path` | `str` | `"/mcp"` | MCP 端点路径 |
+| `server_name` | `str` | `"dcc-mcp"` | MCP 响应中的服务器名称 |
+| `server_version` | `str` | 包版本 | MCP 响应中的服务器版本 |
+| `max_sessions` | `int` | `100` | 最大并发 SSE 会话数 |
+| `request_timeout_ms` | `int` | `30000` | 每个请求的超时时间（毫秒） |
+| `enable_cors` | `bool` | `False` | 是否启用浏览器客户端的 CORS |
+| `session_ttl_secs` | `int` | `3600` | 空闲会话 TTL 秒数（0 禁用自动清理） |
+| `gateway_port` | `int` | `0` | 竞争的网关端口（`0` = 禁用）。参见[网关](#网关) |
+| `registry_dir` | `str \| None` | `None` | 共享 `FileRegistry` JSON 目录（默认 OS 临时目录） |
+| `stale_timeout_secs` | `int` | `30` | 心跳超时秒数（实例视为过期） |
+| `heartbeat_secs` | `int` | `5` | 心跳间隔秒数（`0` = 禁用） |
+| `dcc_type` | `str \| None` | `None` | 注册表中报告的 DCC 类型（如 `"maya"`、`"blender"`） |
+| `dcc_version` | `str \| None` | `None` | 注册表中报告的 DCC 版本（如 `"2025"`） |
+| `scene` | `str \| None` | `None` | 当前打开的场景文件 — 改善网关路由 |
 
 ## ServerHandle
 
@@ -54,6 +67,7 @@ from dcc_mcp_core import McpServerHandle  # ServerHandle 的别名
 |------|------|------|
 | `port` | `int` | 服务器实际绑定的端口（当 port=0 时有用） |
 | `bind_addr` | `str` | 绑定地址，如 `"127.0.0.1:8765"` |
+| `is_gateway` | `bool` | 若本进程赢得网关端口竞争则为 `True` |
 
 ### 方法
 
@@ -113,6 +127,7 @@ server = McpHttpServer(
 |------|------|------|
 | `/mcp` | POST | MCP 请求（JSON-RPC 2.0） |
 | `/mcp` | GET | SSE 兼容的事件流 |
+| `/mcp` | DELETE | 终止 MCP 会话 |
 | `/health` | GET | 健康检查 |
 
 ### 请求/响应格式
@@ -194,6 +209,81 @@ print(f"Maya MCP 服务器: {handle.mcp_url()}")
 # 输出: Maya MCP 服务器: http://127.0.0.1:18812/mcp
 ```
 
+## 网关
+
+当多个 DCC 实例同时启动时，其中一个会自动成为**网关** — 一个统一的入口点，发现并代理所有运行中的实例。
+
+### 工作原理
+
+- 每个实例在共享的 `FileRegistry`（磁盘上的 JSON 文件）中注册自身，并定期发送心跳。
+- **首个**绑定 `gateway_port`（默认：`9765`）的进程成为网关；其余为普通实例。
+- 互斥使用 `SO_REUSEADDR=false`（通过 `socket2`），确保跨平台（包括 Windows）的首个获胜语义。
+- 网关自动清理过期实例（在 `stale_timeout_secs` 内未收到心跳）。
+- 进程退出时，`ServerHandle` 被 drop，实例自动注销。
+
+### 网关端点
+
+| 端点 | 方法 | 说明 |
+|------|------|------|
+| `/instances` | GET | 所有活跃实例的 JSON 列表 |
+| `/health` | GET | `{"ok": true}` 健康检查 |
+| `/mcp` | POST | 网关自身的 MCP 端点（发现元工具） |
+| `/mcp/{instance_id}` | POST | 透明代理到指定实例 |
+| `/mcp/dcc/{dcc_type}` | POST | 代理到指定 DCC 类型的最佳实例 |
+
+### 网关 MCP 元工具
+
+网关通过自身的 `/mcp` 端点暴露三个发现工具：
+
+| 工具 | 说明 |
+|------|------|
+| `list_dcc_instances` | 列出所有活跃 DCC 服务器（类型、端口、场景、状态） |
+| `get_dcc_instance` | 获取指定实例的信息（按 id 或 `dcc_type+scene`） |
+| `connect_to_dcc` | 返回 DCC 实例的直接 MCP URL |
+
+### Python 示例
+
+```python
+from dcc_mcp_core import ActionRegistry, McpHttpServer, McpHttpConfig
+
+registry = ActionRegistry()
+registry.register("get_scene_info", description="获取场景信息", category="scene", dcc="maya")
+
+config = McpHttpConfig(port=0, server_name="maya-mcp")
+config.gateway_port = 9765    # 加入网关竞争；0 = 禁用
+config.dcc_type = "maya"
+config.dcc_version = "2025"
+config.scene = "/proj/shot01.ma"  # 可选：帮助按场景路由
+
+server = McpHttpServer(registry, config)
+handle = server.start()
+
+print(handle.is_gateway)        # True 表示本进程赢得了网关端口
+print(handle.mcp_url())         # 本实例的直接 MCP URL
+# → 若 is_gateway=True，网关在 http://127.0.0.1:9765/
+# → 实例在 http://127.0.0.1:<port>/mcp
+```
+
+::: tip 多 DCC、单入口
+启动任意数量的 DCC 服务器 — 第一个赢得网关端口。Agent 始终连接 `http://localhost:9765/mcp`，使用 `list_dcc_instances` / `connect_to_dcc` 发现并路由到特定 DCC 进程。
+:::
+
+::: info Skills-First + 网关
+`create_skill_manager()` 默认**不**配置 `gateway_port`。如需参与网关，需在传入的 `McpHttpConfig` 上显式设置：
+
+```python
+import os
+from dcc_mcp_core import create_skill_manager, McpHttpConfig
+
+config = McpHttpConfig(port=0, server_name="maya")
+config.gateway_port = 9765
+config.dcc_type = "maya"
+
+server = create_skill_manager("maya", config)
+handle = server.start()
+```
+:::
+
 ## CORS 配置
 
 为浏览器 MCP 客户端启用 CORS：
@@ -238,3 +328,4 @@ print(handle.mcp_url())
 - 每个调用的请求超时（默认 30 秒）
 - HTTP 层无连接池（每个 POST 无状态）
 - 使用 `TransportManager` 获取与 DCC 的持久 IPC 会话
+- 网关 `FileRegistry` 每次变更都刷新到磁盘 — 多进程安全但不适合高频写入

--- a/docs/zh/api/models.md
+++ b/docs/zh/api/models.md
@@ -94,6 +94,7 @@ validate_action_result("hello")                         # 包装为成功结果
 |------|------|--------|------|
 | `name` | `str` | — | 唯一标识符 |
 | `description` | `str` | `""` | 人类可读描述 |
+| `search_hint` | `str` | `""` | `search_skills` 的关键词提示（SKILL.md `search-hint:` 字段；回退到 `description`） |
 | `tools` | `List[str]` | `[]` | 所需工具权限 |
 | `dcc` | `str` | `"python"` | 目标 DCC 应用 |
 | `tags` | `List[str]` | `[]` | 分类标签 |

--- a/docs/zh/api/protocols.md
+++ b/docs/zh/api/protocols.md
@@ -77,6 +77,8 @@ td.read_only, td.destructive, td.idempotent, td.source_file
 
 
 
+## ResourceDefinition
+
 | 字段 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `uri` | `str` | — | 资源 URI |
@@ -349,20 +351,51 @@ d = info.to_dict()  # 序列化为普通字典
 | `transform` | `bool` | `False` | 是否实现 `DccTransform` |
 | `render_capture` | `bool` | `False` | 是否实现 `DccRenderCapture` |
 | `hierarchy` | `bool` | `False` | 是否实现 `DccHierarchy` |
+| `has_embedded_python` | `bool` | `True` | DCC 是否有内嵌 Python 解释器（`False` 表示桥接型 DCC，如 ZBrush、Photoshop） |
+| `bridge_kind` | `str \| None` | `None` | 桥接类型字符串（`"http"`、`"websocket"`、`"named_pipe"` 或自定义） |
+| `bridge_endpoint` | `str \| None` | `None` | 桥接端点（URL 或 socket 路径） |
 | `extensions` | `dict[str, bool]` | `{}` | 任意扩展功能标志 |
 
 ```python
 from dcc_mcp_core import DccCapabilities, ScriptLanguage
 
+# 内嵌 Python 的 DCC（如 Maya）
 caps = DccCapabilities(
     script_languages=[ScriptLanguage.PYTHON, ScriptLanguage.MEL],
     scene_info=True,
     snapshot=True,
     file_operations=True,
 )
+
+# HTTP 桥接型 DCC（如 ZBrush）
+caps_bridge = DccCapabilities(
+    has_embedded_python=False,
+    bridge_kind="http",
+    bridge_endpoint="http://localhost:8080",
+)
+
+# WebSocket 桥接型 DCC（如 Photoshop）
+caps_ws = DccCapabilities(
+    has_embedded_python=False,
+    bridge_kind="websocket",
+    bridge_endpoint="ws://localhost:12345",
+)
+
 if caps.scene_manager:
     print("场景管理器可用")
 ```
+
+### BridgeKind
+
+DCC 与 MCP 服务器之间的通信桥接类型。在 Python 中以字符串形式暴露：
+
+| 值 | 说明 | 典型应用 |
+|----|------|----------|
+| `"http"` | HTTP REST 桥接 | ZBrush 2024+ |
+| `"websocket"` | WebSocket JSON-RPC 桥接 | Photoshop (UXP) |
+| `"named_pipe"` | 命名管道桥接 | 3ds Max (COM/pipe) |
+| 自定义字符串 | 自定义桥接协议 | 其他 |
+| `None` | 无桥接（内嵌 Python） | Maya, Blender, Houdini |
 
 ### DccError
 

--- a/docs/zh/api/skills.md
+++ b/docs/zh/api/skills.md
@@ -11,30 +11,34 @@
 当通过 `with_dispatcher()` 附加了调度器时，加载 Skill 会自动为每个 Action 注册基于子进程的处理器 — 启用 Skills-First 工作流，Agent 无需手动注册处理器。
 
 ```python
-from dcc_mcp_core import SkillScanner, SkillCatalog
+from dcc_mcp_core import SkillCatalog, ActionRegistry
 
-scanner = SkillScanner()
-catalog = SkillCatalog(scanner)
+registry = ActionRegistry()
+catalog = SkillCatalog(registry)
 ```
 
 ### 构造函数
 
 ```python
-SkillCatalog(scanner: SkillScanner) -> SkillCatalog
+SkillCatalog(registry: ActionRegistry) -> SkillCatalog
 ```
 
 | 参数 | 类型 | 说明 |
 |------|------|------|
-| `scanner` | `SkillScanner` | 用于发现的扫描器实例 |
+| `registry` | `ActionRegistry` | 用于注册/注销工具的 Action 注册表 |
 
 ### 方法
 
 | 方法 | 返回值 | 说明 |
 |------|--------|------|
 | `with_dispatcher(dispatcher)` | — | 附加 `ActionDispatcher`；启用 `load_skill()` 时的自动处理器注册 |
-| `discover(extra_paths=None, dcc_name=None)` | `None` | 扫描并填充目录 |
-| `load_skill(skill_name)` | `bool` | 加载 Skill；成功返回 `True`，已加载或未找到返回 `False` |
-| `unload_skill(skill_name)` | `bool` | 卸载 Skill；成功返回 `True`，未加载返回 `False` |
+| `new_with_dispatcher(registry, dispatcher)` | — | 创建带 dispatcher 的 catalog（构造器式） |
+| `discover(extra_paths=None, dcc_name=None)` | `int` | 扫描并填充目录；返回新发现的 skill 数量 |
+| `load_skill(skill_name)` | `List[str]` | 加载 Skill；返回注册的 action 名称列表，未找到则报错 |
+| `load_skills(skill_names)` | `dict` | 批量加载；返回 `{name: Ok(actions) or Err(msg)}` |
+| `unload_skill(skill_name)` | `int` | 卸载 Skill；返回移除的 action 数量，未加载则报错 |
+| `remove_skill(skill_name)` | `bool` | 从目录中完全移除（已加载则先卸载） |
+| `clear()` | `None` | 清空所有 Skill（已加载的先卸载） |
 | `find_skills(query=None, tags=None, dcc=None)` | `List[SkillSummary]` | 按 name/tags/dcc 搜索（所有过滤器 AND 组合）|
 | `list_skills(status=None)` | `List[SkillSummary]` | 列出 Skill。status：`"loaded"` 或 `"unloaded"`，`None` 为全部 |
 | `get_skill_info(skill_name)` | `SkillMetadata \| None` | 返回完整元数据，未找到返回 `None` |
@@ -46,12 +50,13 @@ SkillCatalog(scanner: SkillScanner) -> SkillCatalog
 
 ```python
 import os
-from dcc_mcp_core import SkillScanner, SkillCatalog, ActionRegistry, ActionDispatcher
+from dcc_mcp_core import SkillCatalog, ActionRegistry, ActionDispatcher
 
 os.environ["DCC_MCP_SKILL_PATHS"] = "/path/to/skills"
 
-scanner = SkillScanner()
-catalog = SkillCatalog(scanner)
+registry = ActionRegistry()
+dispatcher = ActionDispatcher(registry)
+catalog = SkillCatalog.new_with_dispatcher(registry, dispatcher)
 
 # 发现 Skill
 catalog.discover(extra_paths=["/extra/skills"], dcc_name="maya")
@@ -66,14 +71,9 @@ results = catalog.find_skills(query="geometry", tags=["create"])
 for s in results:
     print(f"  {s.name}: {s.tool_count} tools → {s.tool_names}")
 
-# 附加调度器 — 启用 Skills-First 自动处理器注册
-registry = ActionRegistry()
-dispatcher = ActionDispatcher(registry)
-catalog.with_dispatcher(dispatcher)
-
 # 加载 Skill（附加调度器后 Action 自动注册）
-ok = catalog.load_skill("maya-geometry")
-print(f"已加载: {ok}")
+actions = catalog.load_skill("maya-geometry")
+print(f"已注册 actions: {actions}")
 
 # 获取完整元数据
 meta = catalog.get_skill_info("maya-geometry")
@@ -84,8 +84,8 @@ if meta:
 print(catalog.loaded_count())
 
 # 卸载
-ok = catalog.unload_skill("maya-geometry")
-print(f"已卸载: {ok}")
+removed = catalog.unload_skill("maya-geometry")
+print(f"已移除 {removed} 个 action")
 ```
 
 ---
@@ -100,6 +100,7 @@ print(f"已卸载: {ok}")
 |------|------|------|
 | `name` | `str` | Skill 名称 |
 | `description` | `str` | 简短描述 |
+| `search_hint` | `str` | 发现关键词提示（来自 SKILL.md `search-hint:`；回退到 `description`） |
 | `tags` | `List[str]` | Skill 标签 |
 | `dcc` | `str` | 目标 DCC（如 `"maya"`）|
 | `version` | `str` | Skill 版本 |
@@ -185,6 +186,7 @@ SkillMetadata(
     tools: List[str] | None = None,
     dcc: str = "python",
     tags: List[str] | None = None,
+    search_hint: str = "",
     scripts: List[str] | None = None,
     skill_path: str = "",
     version: str = "1.0.0",
@@ -199,6 +201,7 @@ SkillMetadata(
 |------|------|------|
 | `name` | `str` | 唯一 Skill 名称 |
 | `description` | `str` | 简短描述 |
+| `search_hint` | `str` | `search_skills` 的关键词提示（SKILL.md `search-hint:` 字段；回退到 `description`） |
 | `tools` | `List[str]` | frontmatter 中的工具名称 |
 | `dcc` | `str` | 目标 DCC 应用 |
 | `tags` | `List[str]` | 分类标签 |

--- a/docs/zh/guide/architecture.md
+++ b/docs/zh/guide/architecture.md
@@ -1,25 +1,29 @@
 # 架构设计
 
-本文档描述 DCC-MCP-Core 的架构设计。DCC-MCP-Core 是一个 Rust 驱动的 DCC Model Context Protocol 生态系统基础库。
+DCC-MCP-Core 是一个 Rust workspace，通过 PyO3 提供 Python 绑定。核心特点：
 
-## 概述
-
-DCC-MCP-Core 采用 Rust workspace 结构，通过 PyO3 提供 Python 绑定。核心特点：
-
-- **零运行时第三方依赖** - Rust 核心无第三方运行时依赖
-- **可选 Python 绑定** - 通过 PyO3 实现 DCC 集成
-- **模块化 crate 设计** - 按需选择性依赖
+- **零运行时第三方依赖** — Rust 核心无第三方运行时依赖
+- **可选 Python 绑定** — 通过 PyO3 实现 DCC 集成
+- **14 个模块化 crate** — 按需选择性依赖
 
 ## Crate 结构
 
 ```
 dcc-mcp-core (workspace 根目录)
-├── dcc-mcp-models      # 数据模型和类型定义
-├── dcc-mcp-actions     # 动作注册系统
-├── dcc-mcp-skills      # 技能包系统
-├── dcc-mcp-protocols   # MCP 协议类型
-├── dcc-mcp-transport   # IPC 和网络传输
-└── dcc-mcp-utils       # 工具函数
+├── dcc-mcp-models       # ActionResultModel, SkillMetadata, DCC 类型
+├── dcc-mcp-actions      # ActionRegistry, EventBus, ActionDispatcher, Pipeline
+├── dcc-mcp-skills       # SkillScanner, SkillCatalog, SkillWatcher, Resolver
+├── dcc-mcp-protocols    # MCP 类型: ToolDefinition, ResourceDefinition, Prompt, BridgeKind
+├── dcc-mcp-transport    # IPC, ConnectionPool, FileRegistry, FramedChannel
+├── dcc-mcp-process      # PyDccLauncher, ProcessMonitor, ProcessWatcher, CrashRecovery
+├── dcc-mcp-telemetry    # Tracing/recording: ActionRecorder, TelemetryConfig
+├── dcc-mcp-sandbox      # Security: SandboxPolicy, SandboxContext, AuditLog
+├── dcc-mcp-shm          # Shared memory: PySharedBuffer, PyBufferPool
+├── dcc-mcp-capture      # Screen capture: Capturer, CaptureFrame
+├── dcc-mcp-usd          # USD scene description: UsdStage, SdfPath, VtValue
+├── dcc-mcp-http         # MCP HTTP server: McpHttpServer, McpHttpConfig, Gateway
+├── dcc-mcp-server       # 二进制入口点: dcc-mcp-server, gateway runner
+└── dcc-mcp-utils        # Filesystem, type wrappers, constants
 ```
 
 ### 依赖关系图
@@ -27,194 +31,218 @@ dcc-mcp-core (workspace 根目录)
 ```
 dcc-mcp-models (基础类型)
        ↓
-dcc-mcp-actions ← dcc-mcp-models (动作依赖模型)
+dcc-mcp-actions ← dcc-mcp-models
        ↓
 dcc-mcp-skills ← dcc-mcp-actions, dcc-mcp-models
        ↓
-dcc-mcp-protocols ← dcc-mcp-models (协议类型使用模型)
+dcc-mcp-protocols ← dcc-mcp-models
        ↓
-dcc-mcp-transport ← dcc-mcp-protocols (传输层使用协议类型)
+dcc-mcp-transport ← dcc-mcp-protocols
        ↓
-dcc-mcp-utils (共享工具，无内部依赖)
+dcc-mcp-http ← dcc-mcp-transport, dcc-mcp-protocols, dcc-mcp-actions, dcc-mcp-skills
+       ↓
+dcc-mcp-server ← dcc-mcp-http
 ```
 
 ## 各 Crate 职责
 
 ### dcc-mcp-models
 
-**职责**：核心数据模型和类型定义。
+**职责**：核心数据模型和类型定义，所有 crate 共享。
 
 **关键类型**：
-- `ActionResult`：标准化的动作执行结果
-- `SkillMetadata`：技能包元数据
-- `EventData`：事件负载结构
-- `UriTemplate`：URI 模板解析和匹配
+- `ActionResultModel` — 统一的动作执行结果类型
+- `SkillMetadata` — 解析后的技能包元数据
+- `SceneInfo`、`SceneStatistics` — DCC 场景信息
+- `DccInfo`、`DccCapabilities`、`DccError` — DCC 适配器类型
+- `ScriptResult`、`CaptureResult` — 操作结果
 
 **依赖**：无（基础 crate）
 
 ### dcc-mcp-actions
 
-**职责**：集中式动作注册和执行系统。
+**职责**：集中式动作注册、验证、调度和中间件管线系统。
 
 **关键组件**：
-- `ActionRegistry`：全局动作注册和查找
-- `Action`：动作实现的 trait
-- `ActionManager`：DCC 特定的动作管理
+- `ActionRegistry` — 线程安全注册表：register/get/search/list/unregister actions
+- `ActionDispatcher` — 带验证的调度，路由到已注册的 Python 可调用对象
+- `ActionValidator` — 基于 JSON Schema 的参数验证
+- `ActionPipeline` — 中间件管线（日志、计时、审计、限流）
+- `EventBus` — DCC 生命周期事件的发布/订阅系统
+- `VersionedRegistry` — 多版本动作注册表，支持 SemVer 约束解析
 
-**关键函数**：
-- `register_action()`：注册命名动作
-- `call_action()`：执行已注册的动作
-- `list_actions()`：获取所有已注册动作
+**关键特征**：动作是普通的 Python 可调用对象，通过 `ActionDispatcher.register_handler()` 注册
 
 **依赖**：`dcc-mcp-models`
 
 ### dcc-mcp-skills
 
-**职责**：通过 Markdown 文件实现零代码技能包注册。
+**职责**：零代码技能包发现、加载和文件系统热重载。
 
 **关键组件**：
-- `SkillScanner`：扫描目录中的技能包
-- `SkillRegistry`：集中式技能存储
-- `SkillResolver`：解析技能依赖关系
+- `SkillScanner` — 基于 mtime 缓存的目录扫描器，发现 SKILL.md 包
+- `SkillCatalog` — 渐进式技能发现与加载管理（推荐 API）
+- `SkillWatcher` — 平台原生文件系统监听器（inotify/FSEvents/ReadDirectoryChangesW）
+- `SkillMetadata` — 从 SKILL.md frontmatter 解析的元数据
+- 依赖解析：`resolve_dependencies`、`expand_transitive_dependencies`、`validate_dependencies`
 
-**技能包格式**：
-```markdown
----
-name: my-skill
-version: 1.0.0
-description: 一个有用的技能
-author: 作者名称
----
-
-# 技能文档
-
-技能内容和说明...
-```
+**技能包格式**：`SKILL.md` 含 YAML frontmatter（`name`、`version`、`description`、`tools`、`dcc`、`tags`、`depends`、`search-hint`）
 
 **依赖**：`dcc-mcp-actions`、`dcc-mcp-models`
 
 ### dcc-mcp-protocols
 
-**职责**：MCP（Model Context Protocol）类型定义。
+**职责**：MCP（Model Context Protocol）类型定义，遵循 2025-03-26 规范。
 
 **关键类型**：
-- `MCPServerProtocol`：服务端协议实现
-- `MCPClientProtocol`：客户端协议实现
-- `PromptProtocol`：提示词处理
-- `ResourceProtocol`：资源管理
-- `ToolProtocol`：工具执行
-
-**URI 模板**：
-- `{+uri}` - 带片段的 URI
-- `{uri}` - 基础 URI
-- 查询参数提取
+- `ToolDefinition`、`ToolAnnotations` — MCP 工具模式及行为提示
+- `ResourceDefinition`、`ResourceTemplateDefinition`、`ResourceAnnotations` — MCP 资源模式
+- `PromptDefinition`、`PromptArgument` — MCP 提示词模式
+- `DccAdapter` — DCC 适配器能力描述符
+- `BridgeKind` — 桥接类型枚举（Http、WebSocket、NamedPipe、Custom）
 
 **依赖**：`dcc-mcp-models`
 
 ### dcc-mcp-transport
 
-**职责**：IPC 和网络通信层。
+**职责**：IPC 和网络传输层，包含服务发现、会话管理和连接池。
 
 **传输类型**：
-- **IPC**：Unix 套接字 / Windows 命名管道
-- **TCP**：网络套接字
-- **WebSocket**：浏览器兼容
-- **HTTP**：REST 风格通信
+- **IPC**：Unix sockets (Linux/macOS) / Windows 命名管道 — 亚毫秒延迟，PID 唯一
+- **TCP**：网络套接字 — 跨机器或降级使用
 
 **关键组件**：
-- `TransportPool`：连接池
-- `TransportConfig`：配置管理
-- `Session`：连接会话追踪
-- `WireProtocol`：二进制序列化（MessagePack）
+- `TransportManager` — 高层管理器：服务注册、会话池、路由
+- `IpcListener` / `ListenerHandle` — 服务端 IPC 监听器，含连接追踪
+- `FramedChannel` — 全双工帧通道，含后台读取循环
+- `TransportAddress` — 协议无关端点（TCP、命名管道、Unix Socket）
+- `CircuitBreaker` — 故障检测与快速断开
+- `FileRegistry` — 基于文件的服务发现（Gateway 使用）
 
-**Ping/Pong 健康检查**：
-- `ping()` - 发送心跳
-- `ping_with_timeout()` - 超时检查响应
-- 超时自动重连
+**线协议**：MessagePack，4 字节大端长度前缀
 
 **依赖**：`dcc-mcp-protocols`、`tokio`
 
-### dcc-mcp-utils
+### dcc-mcp-process
 
-**职责**：共享工具函数。
+**职责**：跨平台 DCC 进程生命周期管理和崩溃恢复。
 
-**模块**：
-- `filesystem`：文件路径操作
-- `type_wrappers`：Python 类型互操作辅助
-- `constants`：共享常量
+**关键组件**：
+- `PyDccLauncher` — 异步 spawn/terminate/kill DCC 进程
+- `PyProcessMonitor` — 通过 `sysinfo` 进行 CPU/内存监控
+- `PyProcessWatcher` — 后台事件轮询监听器，含心跳/状态追踪
+- `PyCrashRecoveryPolicy` — 指数/固定退避重启策略
+
+**依赖**：`tokio`、`sysinfo`
+
+### dcc-mcp-telemetry
+
+**职责**：分布式追踪和指标收集。
+
+**关键组件**：
+- `ActionRecorder` / `RecordingGuard` — RAII 计时守卫，用于动作执行
+- `ActionMetrics` — 每个动作指标的只读快照（计数、成功率、P95/P99 延迟）
+- `TelemetryConfig` — 全局遥测 provider 构建器（stdout/JSON 导出器）
+
+**依赖**：`tracing`、`metrics`
+
+### dcc-mcp-sandbox
+
+**职责**：安全策略执行、审计日志和输入验证。
+
+**关键组件**：
+- `SandboxPolicy` — API 白名单、路径允许列表、执行约束（超时、最大动作数、只读）
+- `SandboxContext` — 每会话执行上下文，捆绑策略 + 审计日志
+- `AuditLog` / `AuditEntry` — 每次动作调用的结构化审计追踪
+- `InputValidator` — 基于 Schema 的验证，含注入防护模式匹配
 
 **依赖**：无
 
-## Python 绑定
+### dcc-mcp-shm
 
-Python 绑定通过 PyO3 的 `python-bindings` feature 生成：
+**职责**：零拷贝共享内存缓冲区，用于高频 DCC ↔ Agent 数据交换。
 
-```toml
-[features]
-python-bindings = ["pyo3", "dcc-mcp-models/python-bindings", ...]
-```
+**关键组件**：
+- `PySharedBuffer` — 命名内存映射文件缓冲区，支持跨进程传递
+- `PyBufferPool` — 固定容量的可复用缓冲池（在 30fps 下摊销 mmap 开销）
+- `PySharedSceneBuffer` — 高级包装器，含内联 vs 分块存储（>256 MiB 分割）
 
-### Python 包结构
+**压缩**：写入时可选 LZ4；读取时自动解压
 
-```
-python/dcc_mcp_core/
-├── __init__.py      # 公开 API
-├── _core.pyi       # 类型存根
-└── _core.*.so      # 编译的 Rust 扩展
-```
+**依赖**：`lz4`
 
-### 绑定模式
+### dcc-mcp-capture
 
-每个 crate 暴露一个 `python_module!` 宏来生成 Python 模块：
+**职责**：GPU 帧缓冲截图和 DCC 应用视口捕获。
 
-```rust
-#[pymodule]
-fn dcc_mcp_core(_py: Python, m: &PyModule) -> PyResult<()> {
-    dcc_mcp_models::python::register_module(m)?;
-    dcc_mcp_actions::python::register_module(m)?;
-    // ...
-    Ok(())
-}
-```
+**后端**：
+- **Windows**：DXGI Desktop Duplication API — GPU 直接访问，<16ms 每帧
+- **Linux**：X11 XShmGetImage
+- **降级**：Mock 合成后端（CI / headless）
 
-## 设计决策
+**关键组件**：
+- `Capturer` — 自动后端选择入口点（`new_auto()` / `new_mock()`）
+- `CaptureFrame` — 捕获的图像数据，含 PNG/JPEG/raw BGRA 编码
 
-### 1. 零运行时依赖
+**依赖**：平台特定（windows-capture、x11grab 等）
 
-Rust 核心没有第三方运行时依赖。这确保了：
-- 最小的二进制大小
-- 可预测的行为
-- DCC 环境中无依赖版本冲突
+### dcc-mcp-usd
 
-可选依赖（如 `pyo3`）通过 feature 门控。
+**职责**：USD 场景描述数据模型和序列化（纯 Rust，无 OpenUSD C++ 依赖）。
 
-### 2. PyO3 0.28
+**关键组件**：
+- `UsdStage` — 主 Stage 容器，含 prim 管理和元数据
+- `UsdPrim` — Prim，含属性 get/set 和 API Schema 检查
+- `SdfPath` — 场景图路径，含绝对/相对解析
+- `VtValue` — 变体值容器（bool、int、float、string、vec3f、asset、token）
 
-使用 PyO3 0.28，特性：
-- `multiple-pymethods` - 每个 struct 多个 #[pymethods]
-- `abi3-py38` - Python 3.8+ 稳定 ABI
-- `extension-module` - 允许从任意 Python 路径加载
+**序列化**：USDA（可读）和 JSON（紧凑，用于 IPC）
 
-### 3. Rust Edition 2024
+**桥接函数**：`scene_info_json_to_stage`、`stage_to_scene_info_json`、`units_to_mpu`、`mpu_to_units`
 
-Edition 2024 提供：
-- 隐式 `async fn` 在 trait 定义中
-- `async let` 绑定
-- 生命周期子类型改进
+**依赖**：`pxr-usd`（薄包装，无 C++ 运行时）
 
-### 4. Tokio 异步运行时
+### dcc-mcp-http
 
-使用 Tokio 因为：
-- Rust 异步的事实标准
-- 出色的 Windows 支持（命名管道）
-- 与 PyO3 配合良好
+**职责**：MCP Streamable HTTP 服务器（2025-03-26 规范），面向 HTTP 客户端。
 
-### 5. MessagePack 序列化
+**关键组件**：
+- `McpHttpServer` — 后台线程 HTTP 服务器（axum/Tokio）
+- `McpHttpConfig` — 服务器配置（端口、CORS、请求超时、Gateway 字段）
+- `ServerHandle` — 服务器句柄，含 URL 获取和优雅关机；`is_gateway` 标记是否赢得网关竞争
+- `GatewayRunner` / `GatewayConfig` / `GatewayHandle` — 首个获胜端口竞争、实例注册、心跳、代理
+- `GatewayState` — Gateway 运行时状态（实例注册表、路由）
 
-使用 RMP（Rust MessagePack）作为线协议：
-- 紧凑的二进制格式
-- 快速序列化/反序列化
-- 语言无关
+**Gateway 架构**：
+当 `McpHttpConfig.gateway_port > 0` 时，首个绑定该端口的进程成为 Gateway，提供：
+- `/instances` — 所有活跃实例的 JSON 列表
+- `/mcp` — Gateway 自身的 MCP 端点（6 个发现元工具）
+- `/mcp/{instance_id}` — 透明代理到特定实例
+- `/mcp/dcc/{dcc_type}` — 代理到指定 DCC 类型的最佳实例
+
+**依赖**：`axum`、`tokio`、`dcc-mcp-transport`、`dcc-mcp-protocols`、`dcc-mcp-actions`、`dcc-mcp-skills`、`reqwest`、`socket2`
+
+### dcc-mcp-server
+
+**职责**：独立的二进制入口点，提供完整的 MCP 服务器。
+
+**关键组件**：
+- `dcc-mcp-server` CLI — 解析命令行参数，启动 Gateway + MCP HTTP 服务器
+- 使用 `GatewayRunner` 库 API 进行端口竞争和实例注册
+
+**依赖**：`dcc-mcp-http`
+
+### dcc-mcp-utils
+
+**职责**：共享工具函数和常量。
+
+**模块**：
+- `filesystem` — 通过 `dirs` crate 实现平台特定目录
+- `type_wrappers` — RPyC 安全包装器（BooleanWrapper、IntWrapper、FloatWrapper、StringWrapper）
+- `constants` — 应用元数据和环境变量名称
+- `py_json` — Python JSON 互操作辅助
+
+**依赖**：`dirs`
 
 ## Skills-First 架构
 
@@ -243,44 +271,82 @@ print(f"Maya MCP server: {handle.mcp_url()}")
 ```
 
 **技能路径解析顺序**（先找到的优先）：
-1. 应用专属环境变量：`DCC_MCP_{APP}_SKILL_PATHS`（如 `DCC_MCP_MAYA_SKILL_PATHS`）
-2. 全局环境变量：`DCC_MCP_SKILL_PATHS`
+1. `DCC_MCP_{APP}_SKILL_PATHS` — 应用专属环境变量（如 `DCC_MCP_MAYA_SKILL_PATHS`）
+2. `DCC_MCP_SKILL_PATHS` — 全局降级
 3. 平台数据目录：`~/.local/share/dcc-mcp/skills/{app}/`
-4. `extra_paths` 参数传入的额外路径
+4. `extra_paths` 参数
 
 ::: tip 手动组装
 如果需要自定义中间件或更精细的控制，可手动组装：
 `ActionRegistry` → `ActionDispatcher` → `SkillCatalog` → `McpHttpServer`。
 :::
 
+## Python 绑定
+
+全部 14 个 crate 编译为单一 PyO3 原生扩展（`dcc_mcp_core._core`），通过 `maturin` 构建。
+
+```toml
+# pyproject.toml
+[project]
+requires-python = ">=3.7"
+dependencies = []  # 零运行时依赖
+```
+
+### Python 包结构
+
+```
+python/dcc_mcp_core/
+├── __init__.py     # 公开 API（从 _core 重导出约 140 个符号）
+├── _core.pyi       # 类型存根（从 Rust 自动生成）
+├── skill.py        # 纯 Python Skill 脚本辅助（无 _core 依赖）
+└── py.typed        # PEP 561 标记
+```
+
+## 设计决策
+
+### 1. 零运行时 Python 依赖
+
+原生扩展捆绑所有 Rust 代码 — 无需 `pip install` PyO3、tokio 等。这确保了：
+- 与 DCC 内嵌 Python 无版本冲突
+- 在 Maya/Blender/Houdini/3ds Max 中行为可预测
+- 最小导入延迟
+
+### 2. PyO3 0.22+ / Maturin
+
+使用 PyO3，特性：
+- `multiple-pymethods` — 每个 struct 多个 `#[pymethods]`
+- `abi3-py38` — Python 3.8+ 稳定 ABI（CI 测试 3.7–3.13）
+- `extension-module` — 允许从任意 Python 路径加载
+
+### 3. Rust Edition 2024, MSRV 1.85
+
+### 4. Tokio 异步运行时
+
+Rust 异步的事实标准，Windows 命名管道支持出色。
+
+### 5. MessagePack 线协议
+
+紧凑二进制格式，4 字节大端长度前缀 — 语言无关。
+
+### 6. `parking_lot` Mutex
+
+比 `std::sync::Mutex` 更快，且不会在 panic 时中毒。
+
 ## 线程安全
 
 所有内部状态使用：
 - `parking_lot::Mutex` 用于短期临界区
 - `parking_lot::RwLock` 用于读写模式
-- `Arc` 用于共享所有权
-
-不使用 `std::sync::Mutex` — `parking_lot` 更快且不会在 panic 时中毒。
+- 不使用 `std::sync::Mutex` 或 `RwLock`
 
 ## 错误处理
 
-使用 `thiserror` 处理错误类型：
-
-```rust
-#[derive(Error, Debug)]
-pub enum TransportError {
-    #[error("连接超时: {0}")]
-    Timeout(String),
-
-    #[error("连接被拒绝: {0}")]
-    ConnectionRefused(String),
-}
-```
+使用 `thiserror` 处理错误类型，通过 `#[from]` 实现自动转换。
 
 ## 测试策略
 
 - **单元测试**：每个 crate 有内联 `#[cfg(test)]` 模块
-- **集成测试**：`tests/` 目录包含 Python 和 Rust 测试
+- **集成测试**：`tests/` 目录包含 Python + Rust 测试（通过 `cargo test` 和 `pytest`）
 - **覆盖率追踪**：`cargo-llvm-cov` + `pytest --cov`
 
 ## 构建命令

--- a/docs/zh/guide/faq.md
+++ b/docs/zh/guide/faq.md
@@ -20,9 +20,30 @@ DCC-MCP-Core 是一个基础 Rust 库（含 Python 绑定），提供：
 dcc-mcp-core 是 DCC 无关的 — 核心库提供基础设施，DCC 特定集成由独立项目提供：
 
 - **Maya** — 通过 [dcc-mcp-maya](https://github.com/loonghao/dcc-mcp-maya)
-- **Blender、Houdini、3ds Max、Unreal** — 使用本库的社区/第三方集成
+- **Unreal** — 通过 [dcc-mcp-unreal](https://github.com/loonghao/dcc-mcp-unreal)（Python embedded）
+- **Photoshop** — 通过 [dcc-mcp-photoshop](https://github.com/loonghao/dcc-mcp-photoshop)（WebSocket bridge）
+- **ZBrush** — 通过 [dcc-mcp-zbrush](https://github.com/loonghao/dcc-mcp-zbrush)（HTTP bridge）
+- **Blender、Houdini、3ds Max** — 社区/第三方集成
 
 核心库适用于任何 Python 3.7+ 环境。
+
+### 什么是 Gateway 模式？
+
+当多个 DCC 实例同时启动时，可以启用 **Gateway 模式** — 一个统一的入口点，自动发现和代理到所有运行中的实例：
+
+```python
+from dcc_mcp_core import McpHttpConfig
+
+config = McpHttpConfig(port=0)  # 实例自身的端口
+config.gateway_port = 9765      # Gateway 竞争端口（0 = 禁用）
+config.dcc_type = "maya"
+```
+
+- 首个绑定 `gateway_port` 的进程成为 Gateway
+- 其他进程注册为普通 DCC 实例
+- Agent 连接 `http://localhost:9765/mcp` 即可访问所有 DCC
+
+通过 `handle.is_gateway` 检查当前进程是否赢得了 Gateway 竞争。
 
 ### 支持哪些 Python 版本？
 
@@ -181,20 +202,20 @@ tools:
 ### 如何发现并加载 Skill？
 
 ```python
-from dcc_mcp_core import SkillScanner, SkillCatalog
+from dcc_mcp_core import SkillCatalog, ActionRegistry
 import os
 
 os.environ["DCC_MCP_SKILL_PATHS"] = "/path/to/skills"
 
-scanner = SkillScanner()
-catalog = SkillCatalog(scanner)
+registry = ActionRegistry()
+catalog = SkillCatalog(registry)
 
 # 发现 Skill
 catalog.discover(dcc_name="maya")
 
 # 加载 Skill
-ok = catalog.load_skill("maya-geometry")
-print(ok)  # True
+actions = catalog.load_skill("maya-geometry")
+print(actions)  # ["maya_geometry__create_sphere", ...]
 ```
 
 ### Skill 工具的 Action 命名规则是什么？
@@ -260,6 +281,48 @@ print(handle.mcp_url())  # http://127.0.0.1:8765/mcp
 # 将 AI 客户端连接到此 URL
 handle.shutdown()
 ```
+
+
+## 网关（Gateway）
+
+### 如何以单一端点运行多个 DCC 实例？
+
+使用 **Gateway** 功能。在 `McpHttpConfig` 上设置 `gateway_port` 为一个知名端口（默认：`9765`）。第一个绑定该端口的进程成为 Gateway；其他进程注册为普通 DCC 实例：
+
+```python
+from dcc_mcp_core import ActionRegistry, McpHttpServer, McpHttpConfig
+
+registry = ActionRegistry()
+config = McpHttpConfig(port=0, server_name="maya-mcp")
+config.gateway_port = 9765
+config.dcc_type = "maya"
+
+server = McpHttpServer(registry, config)
+handle = server.start()
+print(handle.is_gateway)  # 如果此进程赢得了 Gateway 端口则为 True
+```
+
+Agent 始终连接 `http://localhost:9765/mcp`，使用 `list_dcc_instances` / `connect_to_dcc` 发现并路由到特定 DCC 进程。
+
+### BridgeKind 是什么？
+
+`BridgeKind` 描述非 Python 内嵌 DCC 的桥接通信方式：
+- `Http` — HTTP REST 桥接（如 ZBrush）
+- `WebSocket` — WebSocket JSON-RPC 桥接（如 Photoshop UXP）
+- `NamedPipe` — 命名管道桥接（如 3ds Max COM）
+
+对桥接 DCC 设置 `DccCapabilities(bridge_kind="http", bridge_endpoint="http://localhost:1234", has_embedded_python=False)`。
+
+## 按需 Skill 发现
+
+### 按需 Skill 发现如何工作？
+
+`create_skill_manager()` 启动时只**发现** Skill（读取 SKILL.md 文件）— **不会**加载它们。`tools/list` 响应展示：
+1. 6 个核心发现工具（始终存在）
+2. 已加载 Skill 工具（带完整 schema）
+3. 未加载 Skill Stub，以 `__skill__<name>` 形式出现（仅名称 + 一行描述）
+
+Agent 使用 `search_skills(query="关键词")` 找到相关 Skill，然后 `load_skill(skill_name="...")` 激活它们。这保持了初始工具列表的精简，仅在需要时加载 schema。
 
 ## 故障排查
 

--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -163,4 +163,4 @@ vx just lint
 - 查看 [Skills 技能包](/zh/guide/skills) 的零代码脚本注册
 - 使用 [MCP HTTP 服务器](/zh/api/http) 暴露工具给 AI 客户端
 - 查看 [传输层](/zh/guide/transport) 的 DCC 通信
-- 了解 [架构设计](/zh/guide/architecture) — 13 个 Rust crate 的工作区结构
+- 了解 [架构设计](/zh/guide/architecture) — 14 个 Rust crate 的工作区结构

--- a/docs/zh/guide/protocols.md
+++ b/docs/zh/guide/protocols.md
@@ -194,6 +194,57 @@ scene = SceneInfo(
 | `CSHARP` | C# 脚本 |
 | `BLUEPRINT` | 可视化脚本 |
 
+### BridgeKind 枚举
+
+`BridgeKind` 描述非 Python 内嵌 DCC 的桥接通信方式。在 Python 中通过 `DccCapabilities.bridge_kind` 字符串访问。
+
+| 值 | Python 字符串 | 说明 |
+|----|---------------|------|
+| `Http` | `"http"` | HTTP REST 桥接（如 ZBrush 2024+） |
+| `WebSocket` | `"websocket"` | WebSocket JSON-RPC 桥接（如 Photoshop UXP） |
+| `NamedPipe` | `"named_pipe"` | 命名管道桥接（如 3ds Max COM） |
+| `Custom(String)` | 自定义字符串 | 其他桥接协议 |
+
+### DccCapabilities 桥接字段
+
+`DccCapabilities` 新增三个字段，用于区分内嵌 Python DCC 和桥接 DCC：
+
+| 字段 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `has_embedded_python` | `bool` | `True` | DCC 是否有内嵌 Python 解释器 |
+| `bridge_kind` | `Optional[str]` | `None` | 桥接类型：`"http"` / `"websocket"` / `"named_pipe"` 或自定义 |
+| `bridge_endpoint` | `Optional[str]` | `None` | 桥接端点 URL 或路径 |
+
+```python
+# 内嵌 Python DCC（如 Maya）
+caps = DccCapabilities(
+    script_languages=[ScriptLanguage.PYTHON],
+    has_embedded_python=True,
+)
+
+# HTTP 桥接 DCC（如 ZBrush）
+caps = DccCapabilities(
+    has_embedded_python=False,
+    bridge_kind="http",
+    bridge_endpoint="http://localhost:8080/api",
+)
+
+# WebSocket 桥接 DCC（如 Photoshop）
+caps = DccCapabilities(
+    has_embedded_python=False,
+    bridge_kind="websocket",
+    bridge_endpoint="ws://localhost:12345",
+)
+```
+
+### 新增 DCC 适配器项目
+
+| 项目 | 桥接模式 | 状态 |
+|------|----------|------|
+| [dcc-mcp-unreal](https://github.com/loonghao/dcc-mcp-unreal) | Python embedded（同 Maya） | 占位 |
+| [dcc-mcp-photoshop](https://github.com/loonghao/dcc-mcp-photoshop) | WebSocket bridge (UXP) | 占位 |
+| [dcc-mcp-zbrush](https://github.com/loonghao/dcc-mcp-zbrush) | HTTP bridge (ZBrush 2024+ REST) | 占位 |
+
 ---
 
 ## DCC Adapter Traits

--- a/docs/zh/guide/skills.md
+++ b/docs/zh/guide/skills.md
@@ -24,6 +24,7 @@ description: "Maya 几何体创建和修改工具"
 version: "1.0.0"
 dcc: maya
 tags: ["geometry", "create"]
+search-hint: "polygon modeling, sphere, bevel, extrude, mesh editing"
 tools:
   - name: create_sphere
     description: "根据给定半径创建多边形球体"
@@ -56,27 +57,26 @@ export DCC_MCP_SKILL_PATHS="/path/skills1:/path/skills2"
 推荐使用 `SkillCatalog` 进行完整的渐进式加载，也可使用低级扫描函数进行一次性操作：
 
 ```python
-from dcc_mcp_core import SkillScanner, SkillCatalog, ActionRegistry, ActionDispatcher
+from dcc_mcp_core import SkillCatalog, ActionRegistry, ActionDispatcher
 
-# 创建扫描器和目录
-scanner = SkillScanner()
-catalog = SkillCatalog(scanner)
+# 创建目录（基于 ActionRegistry）
+registry = ActionRegistry()
+catalog = SkillCatalog(registry)
+
+# 可选：附加调度器以启用自动处理器注册
+dispatcher = ActionDispatcher(registry)
+catalog.with_dispatcher(dispatcher)
 
 # 发现 DCC_MCP_SKILL_PATHS 中的所有 Skill
 catalog.discover(dcc_name="maya")
-
-# 可选：附加调度器以启用自动处理器注册
-registry = ActionRegistry()
-dispatcher = ActionDispatcher(registry)
-catalog.with_dispatcher(dispatcher)
 
 # 列出可用 Skill
 for skill in catalog.list_skills():
     print(f"  {skill.name} v{skill.version}: {skill.description} (已加载={skill.loaded})")
 
 # 加载 Skill — 附加调度器后工具自动注册
-ok = catalog.load_skill("maya-geometry")
-print(f"已加载: {ok}")
+actions = catalog.load_skill("maya-geometry")
+print(f"已注册工具: {actions}")
 ```
 
 ## Skill 目录（推荐 API）
@@ -84,12 +84,10 @@ print(f"已加载: {ok}")
 `SkillCatalog` 管理完整生命周期：发现 → 渐进式加载 → 卸载。
 
 ```python
-from dcc_mcp_core import SkillScanner, SkillCatalog, ActionRegistry, ActionDispatcher
-
-scanner = SkillScanner()
-catalog = SkillCatalog(scanner)
+from dcc_mcp_core import SkillCatalog, ActionRegistry, ActionDispatcher
 
 registry = ActionRegistry()
+catalog = SkillCatalog(registry)
 dispatcher = ActionDispatcher(registry)
 catalog.with_dispatcher(dispatcher)
 
@@ -102,9 +100,9 @@ for s in results:
     print(f"{s.name}: {s.tool_count} 个工具 {s.tool_names}")
 
 # 加载/卸载
-ok = catalog.load_skill("maya-geometry")  # 返回 bool
-catalog.is_loaded("maya-geometry")        # True
-ok = catalog.unload_skill("maya-geometry")
+actions = catalog.load_skill("maya-geometry")  # 返回 List[str]
+catalog.is_loaded("maya-geometry")              # True
+removed = catalog.unload_skill("maya-geometry")  # 返回 int
 
 # 状态查询
 catalog.loaded_count()      # int
@@ -125,6 +123,7 @@ info = catalog.get_skill_info("maya-geometry")  # dict 或 None
 |------|------|------|
 | `name` | `str` | Skill 名称 |
 | `description` | `str` | 简短描述 |
+| `search_hint` | `str` | 搜索关键词提示（来自 SKILL.md 的 `search-hint:` 字段；缺失时回退到 `description`） |
 | `tags` | `List[str]` | Skill 标签 |
 | `dcc` | `str` | 目标 DCC（如 `"maya"`）|
 | `version` | `str` | Skill 版本 |
@@ -282,6 +281,7 @@ deps = expand_transitive_dependencies(skills, "maya-animation")
 |------|------|------|
 | `name` | `str` | 唯一 Skill 名称 |
 | `description` | `str` | 简短描述 |
+| `search_hint` | `str` | `search_skills` 的关键词提示（SKILL.md `search-hint:` 字段；缺失时回退到 `description`） |
 | `tools` | `List[str]` | frontmatter 中列出的工具名称 |
 | `dcc` | `str` | 目标 DCC 应用（默认：`"python"`）|
 | `tags` | `List[str]` | 分类标签 |
@@ -360,3 +360,101 @@ def create_skill_manager(
 ::: warning 脚本执行
 所有脚本作为子进程运行。输入参数通过 stdin 以 JSON 格式传入。脚本应将 JSON 结果写入 stdout，成功时退出码为 0。
 :::
+
+## 按需 Skill 发现（MCP HTTP）
+
+使用 MCP HTTP 服务器（`McpHttpServer` 或 `create_skill_manager`）时，`tools/list` 返回**三层**响应：
+
+### 三层 `tools/list` 响应
+
+1. **6 个核心发现工具**（始终存在）：
+   - `find_skills` — 按查询、标签、DCC 类型搜索 Skill
+   - `list_skills` — 列出所有 Skill，可按状态筛选
+   - `get_skill_info` — 获取指定 Skill 的完整元数据
+   - `load_skill` — 加载 Skill，将其工具注册到 ActionRegistry
+   - `unload_skill` — 卸载 Skill，移除其工具
+   - `search_skills` — 跨 name、description、search_hint、tool_names 的关键词搜索
+
+2. **已加载 Skill 工具** — 来自 `ActionRegistry` 的完整 `input_schema`
+
+3. **未加载 Skill Stub** — `__skill__<name>` 条目，仅含一行描述（无完整 schema）
+
+### 工作流
+
+```
+1. AI 调用 tools/list → 看到核心工具 + 已加载工具 + __skill__ stub
+2. AI 调用 search_skills(query="geometry") → 找到匹配的 Skill
+3. AI 调用 load_skill(skill_name="maya-geometry") → 工具已注册
+4. AI 再次调用 tools/list → maya-geometry 工具现在有完整 schema
+5. AI 调用 maya_geometry__create_sphere → Skill 脚本执行
+```
+
+### Skill Stub 行为
+
+调用未加载的 Skill stub（`__skill__<name>`）时返回带提示的错误：
+
+```json
+{
+  "error": "Skill 'maya-geometry' is not loaded. Call load_skill(skill_name=\"maya-geometry\") to register its tools."
+}
+```
+
+### `search_skills` MCP 工具
+
+```json
+{
+  "name": "search_skills",
+  "description": "搜索匹配关键词的 Skill",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "query": {"type": "string", "description": "搜索关键词"},
+      "dcc": {"type": "string", "description": "按 DCC 类型筛选"}
+    },
+    "required": ["query"]
+  }
+}
+```
+
+搜索范围：`name`、`description`、`search_hint`、`tool_names`。`search_hint` 字段（来自 SKILL.md `search-hint:`）无需加载完整 schema 即可改善关键词匹配。
+
+`create_skill_manager()` 启动时只调用 `discover()` — Skills **不会**自动加载。这保持了初始工具列表的精简，让 Agent 按需加载。
+
+## MCP 核心发现工具
+
+通过 MCP HTTP 服务器，`tools/list` 始终返回 6 个核心发现工具：
+
+| 工具 | 说明 |
+|------|------|
+| `find_skills` | 按条件搜索技能（query/tags/dcc） |
+| `list_skills` | 列出技能及加载状态 |
+| `get_skill_info` | 获取技能的完整元数据 |
+| `load_skill` | 加载技能 — 将其工具注册到 ActionRegistry |
+| `unload_skill` | 卸载技能 — 从 ActionRegistry 移除其工具 |
+| `search_skills` | 按关键词搜索技能（紧凑一行摘要） |
+
+## 三层 tools/list 响应
+
+`tools/list` 返回三层内容：
+
+1. **核心发现工具**（6 个，始终完整）— `find_skills`、`list_skills`、`get_skill_info`、`load_skill`、`unload_skill`、`search_skills`
+2. **已加载技能工具** — 来自 ActionRegistry，带完整 `input_schema`
+3. **未加载技能存根** — `__skill__<name>` 格式名称 + 一句话描述，无完整 schema
+
+### 存根调用行为
+
+当调用 `__skill__<name>` 时，返回错误提示：
+
+```
+Call load_skill(skill_name="<name>") to register its tools
+```
+
+### 推荐工作流
+
+```
+1. tools/list          → 看到核心工具 + 已加载工具 + 存根
+2. search_skills(query="modeling") → 找到相关技能
+3. load_skill(skill_name="maya-geometry") → 加载技能
+4. tools/list          → 现在看到 maya-geometry 的完整工具
+5. tools/call          → 直接使用工具
+```

--- a/docs/zh/guide/what-is-dcc-mcp-core.md
+++ b/docs/zh/guide/what-is-dcc-mcp-core.md
@@ -45,7 +45,7 @@ flowchart LR
 
 ## 架构
 
-DCC-MCP-Core 是一个包含 **13 个子 crate** 的 Rust workspace，通过 maturin 编译为单一 Python 扩展模块 `dcc_mcp_core._core`：
+DCC-MCP-Core 是一个包含 **14 个子 crate** 的 Rust workspace，通过 maturin 编译为单一 Python 扩展模块 `dcc_mcp_core._core`：
 
 ```
 dcc-mcp-core/
@@ -62,17 +62,19 @@ dcc-mcp-core/
 │   ├── dcc-mcp-shm/            # PySharedBuffer, PyBufferPool, PySharedSceneBuffer
 │   ├── dcc-mcp-capture/        # Capturer, CaptureFrame
 │   ├── dcc-mcp-usd/            # UsdStage, UsdPrim, VtValue, SdfPath
-│   ├── dcc-mcp-http/           # McpHttpServer, McpHttpConfig, ServerHandle
+│   ├── dcc-mcp-http/           # McpHttpServer, McpHttpConfig, ServerHandle, Gateway
+│   ├── dcc-mcp-server/         # dcc-mcp-server CLI, Gateway runner
 │   └── dcc-mcp-utils/          # 文件系统, 常量, 类型包装器, JSON 工具
 └── python/
     └── dcc_mcp_core/
-        ├── __init__.py          # 从 _core 重导出约 130 个公开符号
+        ├── __init__.py          # 从 _core 重导出约 140 个公开符号
+        ├── skill.py             # 纯 Python Skill 脚本辅助（无 _core 依赖）
         └── _core.pyi            # 所有公开 API 的类型存根
 ```
 
 ## Python API 概览
 
-所有公开 API 均可从顶层包 `dcc_mcp_core` 访问，包含约 130 个公开符号，跨越 13 个领域：
+所有公开 API 均可从顶层包 `dcc_mcp_core` 访问，包含约 140 个公开符号，跨越 14 个领域：
 
 ```python
 from dcc_mcp_core import (
@@ -118,7 +120,7 @@ from dcc_mcp_core import (
 
 ## 版本与 Python 支持
 
-- **当前版本**：0.12.12
+- **当前版本**：0.12.23
 - **Python**：3.7–3.13（abi3-py38 wheel，CI 全版本测试）
 - **Rust**：Edition 2024，MSRV 1.85
 - **构建**：maturin + PyO3；零运行时 Python 依赖


### PR DESCRIPTION
## Summary

This PR comprehensively refreshes all documentation to reflect the current v0.12.23 state of dcc-mcp-core:

- **Version**: Updated all docs from v0.12.9/0.12.12 to v0.12.23
- **Crate Count**: Corrected from 11-13 to 14 crates (added dcc-mcp-http, dcc-mcp-server)
- **Public Symbols**: Updated from ~120-130 to ~140 symbols
- **Gateway Architecture**: Added comprehensive Gateway documentation with competition logic, FileRegistry, service discovery
- **BridgeKind Enum**: Added new bridge types (Http, WebSocket, NamedPipe, Custom) for bridge-based DCCs
- **DccCapabilities**: Documented new bridge-related fields (has_embedded_python, bridge_kind, bridge_endpoint)
- **SkillCatalog API**: Fixed constructor signature and return types (load_skill → List[str], unload_skill → int)
- **On-Demand Skill Discovery**: Documented three-tier tools/list architecture (core tools + loaded + unloaded stubs)
- **New DCC Adapters**: Added documentation for dcc-mcp-unreal, dcc-mcp-photoshop, dcc-mcp-zbrush projects
- **Language Parity**: Synchronized EN and ZH documentation (fixed significant ZH gaps, especially in API docs)

## Files Updated

- **Top-level**: README.md, README_zh.md, AGENTS.md, CLAUDE.md, GEMINI.md, CONTRIBUTING.md
- **EN API docs** (docs/api/): http.md, skills.md, protocols.md, models.md, actions.md
- **EN Guide docs** (docs/guide/): architecture.md, what-is-dcc-mcp-core.md, getting-started.md, protocols.md, skills.md, faq.md
- **ZH API docs** (docs/zh/api/): http.md, skills.md, protocols.md, models.md
- **ZH Guide docs** (docs/zh/guide/): architecture.md, what-is-dcc-mcp-core.md, getting-started.md, protocols.md, skills.md, faq.md

**Total changes**: 29 files (+928/-341 lines)

## Test Plan

- [x] VitePress docs build passes
- [x] Pre-commit hooks passed
- [x] All version references verified against codebase v0.12.23
- [x] Crate count verified: 14 crates confirmed
- [x] API signatures verified against actual Rust code
- [x] EN/ZH documentation consistency cross-checked