### PR TITLE
fix(server_base): pass port via McpHttpConfig constructor

### DIFF
--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -113,11 +113,12 @@ class DccServerBase:
             if env_val.isdigit():
                 effective_gateway_port = int(env_val)
 
-        # Build McpHttpConfig
-        self._config = McpHttpConfig()
-        self._config.port = port
-        self._config.server_name = server_name or f"{dcc_name}-mcp"
-        self._config.server_version = server_version
+        # Build McpHttpConfig — port must be passed at construction time (read-only after init)
+        self._config = McpHttpConfig(
+            port=port,
+            server_name=server_name or f"{dcc_name}-mcp",
+            server_version=server_version,
+        )
         if effective_gateway_port > 0:
             self._config.gateway_port = effective_gateway_port
         if registry_dir:


### PR DESCRIPTION
McpHttpConfig.port is read-only after construction in the compiled Rust extension. This caused DccServerBase to fail when instantiated via dcc-mcp-maya.

**Root cause**: The `server_base.py` shipped in v0.12.26 used `self._config.port = port` (attribute assignment after construction) but `McpHttpConfig.port` is a read-only PyO3 attribute.

**Fix**: Pass `port`, `server_name`, and `server_version` via the `McpHttpConfig()` constructor instead.