### PR TITLE
docs: enhance AI agent guidance for v0.12.29

### DIFF
--- a/.agents/skills/dcc-mcp-core/SKILL.md
+++ b/.agents/skills/dcc-mcp-core/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: dcc-mcp-core
-description: "Foundation library for the DCC Model Context Protocol (MCP) ecosystem. Provides Rust-powered action management, skills system, IPC transport, MCP Streamable HTTP server (2025-03-26 spec), sandbox security, shared memory, screen capture, USD scene support, and telemetry for AI-assisted DCC workflows. Use when working with Maya, Blender, Houdini, 3ds Max, or any DCC MCP integration."
-allowed-tools: ["Bash", "Read", "Write", "Edit"]
+description: "Foundation library for the DCC Model Context Protocol (MCP) ecosystem. Provides Rust-powered action management, skills system, IPC transport, MCP Streamable HTTP server (2025-03-26 spec, with 2025-06-18 and 2025-11-25 awareness), sandbox security, shared memory, screen capture, USD scene support, and telemetry for AI-assisted DCC workflows. Use when working with Maya, Blender, Houdini, 3ds Max, or any DCC MCP integration."
+allowed-tools: Bash Read Write Edit
 compatibility: "Python 3.7-3.13; Rust 1.85+ required to build from source; zero runtime Python dependencies"
-version: "0.12.9"
+version: "0.12.29"
 ---
 
 # dcc-mcp-core — DCC MCP Ecosystem Foundation
@@ -16,10 +16,15 @@ The foundational library enabling AI assistants to interact with Digital Content
 |------|----------|----------|
 | Return action result | `success_result()` / `error_result()` | raw dicts |
 | Load skills | `scan_and_load()` → `(skills, skipped)` | manual file scanning |
+| One-call MCP server | `create_skill_manager("maya", McpHttpConfig(port=8765))` | manual wiring |
 | Validate params | `ActionValidator.from_schema_json()` | isinstance checks |
 | Connect to DCC | `connect_ipc(TransportAddress.default_local(...))` | raw sockets |
 | Define MCP tool | `ToolDefinition` + `ToolAnnotations` | raw JSON |
 | Serve MCP over HTTP | `McpHttpServer(registry, McpHttpConfig(port=8765))` | raw HTTP server |
+| Build DCC adapter | `DccServerBase(dcc_name, builtin_skills_dir)` | copy-paste boilerplate |
+| Enable skill hot-reload | `DccSkillHotReloader(dcc_name, server)` | custom file watchers |
+| Gateway failover | `DccGatewayElection(dcc_name, server)` | manual election logic |
+| Write skill scripts | `skill_entry` + `skill_success` / `skill_error` | manual JSON output |
 
 ## What This Library Does
 
@@ -28,7 +33,7 @@ The foundational library enabling AI assistants to interact with Digital Content
 | **Action Management** | Register, validate, dispatch, and execute actions with typed inputs/outputs |
 | **Skills System** | Zero-code script registration (Python/MEL/Batch/Shell/JS) as MCP tools via `SKILL.md` |
 | **Transport Layer** | High-performance IPC with connection pooling, circuit breaker, retry policies |
-| **MCP HTTP Server** | MCP Streamable HTTP (**2025-03-26 spec**) powered by axum/Tokio, runs in background thread. 2025-11-05 draft will add JSON-RPC batching + resource links |
+| **MCP HTTP Server** | MCP Streamable HTTP (**2025-03-26 spec**) powered by axum/Tokio, runs in background thread |
 | **Process Management** | Launch, monitor, auto-recover DCC processes (Maya, Blender, Houdini, etc.) |
 | **Sandbox Security** | Policy-based access control, input validation, audit logging |
 | **Shared Memory** | LZ4-compressed inter-process data exchange for large scenes |
@@ -36,6 +41,9 @@ The foundational library enabling AI assistants to interact with Digital Content
 | **USD Support** | Read/write Universal Scene Description for pipeline integration |
 | **Telemetry** | Structured tracing and recording for observability |
 | **MCP Protocol Types** | Complete Tool/Resource/Prompt schema implementations |
+| **DCC Server Base** | Reusable base class for DCC adapters (hot-reload, gateway election, lifecycle) |
+| **Gateway Failover** | Automatic gateway election when primary gateway becomes unreachable |
+| **Skill Hot-Reload** | File-watching auto-reload for live skill development |
 
 ## Installation
 
@@ -46,36 +54,24 @@ pip install dcc-mcp-core
 
 ## Core Patterns
 
-### Pattern 1: Skills → MCP tools
+### Pattern 1: Skills-First — one-call MCP server (recommended)
 
 ```python
 import os
-from dcc_mcp_core import scan_and_load, ActionRegistry, ToolDefinition, ToolAnnotations
-from pathlib import Path
+from dcc_mcp_core import create_skill_manager, McpHttpConfig
 
-os.environ["DCC_MCP_SKILL_PATHS"] = "/opt/my-skills"
+os.environ["DCC_MCP_MAYA_SKILL_PATHS"] = "/opt/my-skills"
 
-# IMPORTANT: scan_and_load returns a 2-tuple
-skills, skipped = scan_and_load(dcc_name="maya")
+# One call: creates registry + dispatcher + catalog + discovers skills + server
+server = create_skill_manager("maya", McpHttpConfig(port=8765))
+handle = server.start()
+print(f"Maya MCP server: {handle.mcp_url()}")
 
-registry = ActionRegistry()
-tools = []
-for skill in skills:
-    for script_path in skill.scripts:
-        stem = Path(script_path).stem
-        action_name = f"{skill.name.replace('-', '_')}__{stem}"
-        registry.register(
-            name=action_name,
-            description=skill.description,
-            dcc=skill.dcc,
-            tags=skill.tags,
-        )
-        tools.append(ToolDefinition(
-            name=action_name,
-            description=skill.description,
-            input_schema='{"type": "object"}',
-            annotations=ToolAnnotations(read_only_hint=False),
-        ))
+# Agents connect and use on-demand skill discovery:
+# → search_skills(query="modeling") to find relevant skills
+# → load_skill("maya-bevel") to activate
+# → tools/call maya_bevel__bevel to execute
+handle.shutdown()
 ```
 
 ### Pattern 2: Return structured results (always use factories)
@@ -135,21 +131,30 @@ finally:
     channel.shutdown()
 ```
 
-### Pattern 5: Expose actions via MCP Streamable HTTP
+### Pattern 5: Build a DCC adapter with DccServerBase
 
 ```python
-from dcc_mcp_core import ActionRegistry, McpHttpServer, McpHttpConfig
+from pathlib import Path
+from dcc_mcp_core.server_base import DccServerBase
 
-registry = ActionRegistry()
-registry.register("get_scene_info", description="Get DCC scene info",
-                  category="scene", dcc="maya", version="1.0.0")
+class BlenderMcpServer(DccServerBase):
+    def __init__(self, port: int = 8765, **kwargs):
+        super().__init__(
+            dcc_name="blender",
+            builtin_skills_dir=Path(__file__).parent / "skills",
+            port=port,
+            **kwargs,
+        )
 
-# Runs in background thread — safe to call from DCC main thread
-server = McpHttpServer(registry, McpHttpConfig(port=8765, server_name="maya-mcp"))
+    def _version_string(self) -> str:
+        import bpy
+        return bpy.app.version_string
+
+# All skill methods, hot-reload, gateway are ready:
+server = BlenderMcpServer(port=8765)
+server.register_builtin_actions()
 handle = server.start()
-print(f"MCP server: {handle.mcp_url()}")  # http://127.0.0.1:8765/mcp
-# Claude Desktop / MCP host connects to handle.mcp_url()
-# handle.shutdown() when done
+print(f"MCP: {handle.mcp_url()}")
 ```
 
 ### Pattern 6: Watch skills for live reload
@@ -177,6 +182,13 @@ reg.register("create_sphere",
 
 dispatcher = ActionDispatcher(reg)
 dispatcher.register_handler("create_sphere", lambda params: {"created": True, "r": params["radius"]})
+
+# Introspect handlers
+dispatcher.has_handler("create_sphere")  # True
+dispatcher.handler_count()               # 1
+dispatcher.handler_names()               # ["create_sphere"]
+dispatcher.remove_handler("create_sphere")  # True
+
 result = dispatcher.dispatch("create_sphere", json.dumps({"radius": 2.0}))
 # result == {"action": "create_sphere", "output": {"created": True, "r": 2.0}, "validation_skipped": False}
 ```
@@ -205,18 +217,34 @@ server = McpHttpServer(registry, McpHttpConfig(port=0, server_name="maya-mcp"))
 handle = server.start()
 ```
 
+### Pattern 9: Write skill scripts with skill_entry
+
+```python
+from dcc_mcp_core.skill import skill_entry, skill_success, skill_error, skill_exception
+
+@skill_entry
+def create_sphere(radius: float = 1.0, name: str = "sphere") -> dict:
+    import maya.cmds as cmds
+    obj = cmds.polySphere(r=radius, n=name)[0]
+    return skill_success(
+        f"Created sphere '{obj}' with radius {radius}",
+        prompt="You can now adjust properties or add materials.",
+        object_name=obj,
+        radius=radius,
+    )
+```
+
 ## Creating a Custom Skill (Zero Python Code)
 
 ```bash
 # 1. Create directory structure
 mkdir -p my-tool/scripts/
 
-# 2. Write SKILL.md (name and dcc are required fields)
+# 2. Write SKILL.md (name is required, follows agentskills.io spec)
 cat > my-tool/SKILL.md << 'EOF'
 ---
 name: my-tool
-description: "My custom DCC automation tools"
-allowed-tools: ["Bash"]
+description: "My custom DCC automation tools. Use when automating scene setup or batch operations."
 tags: ["automation", "custom"]
 dcc: maya
 version: "1.0.0"
@@ -253,15 +281,17 @@ print(f'Loaded: {[s.name for s in skills]}')
 ┌─────────────────────────────────────────────────────┐
 │                   Python Layer                       │
 │  dcc_mcp_core/__init__.py  →  _core (PyO3 cdyll)   │
-│  ~140 public symbols re-exported from Rust core      │
+│  ~154 public symbols re-exported from Rust core      │
+│  + Pure-Python: DccServerBase, DccGatewayElection,  │
+│    DccSkillHotReloader, factory, skill helpers       │
 └──────────────────────┬──────────────────────────────┘
                        │ PyO3 bindings
 ┌──────────────────────▼──────────────────────────────┐
-│              Rust Core (12 Crates)                   │
+│              Rust Core (14 Crates)                   │
 │                                                      │
 │  models → actions → skills → protocols              │
 │  transport → http → process → sandbox → telemetry   │
-│  shm → capture → usd → utils                        │
+│  shm → capture → usd → server → utils               │
 └─────────────────────────────────────────────────────┘
 ```
 
@@ -270,7 +300,14 @@ print(f'Loaded: {[s.name for s in skills]}')
 | Variable | Purpose |
 |----------|---------|
 | `DCC_MCP_SKILL_PATHS` | Colon/semicolon-separated paths to scan for `SKILL.md` dirs |
+| `DCC_MCP_{APP}_SKILL_PATHS` | Per-app skill paths (e.g. `DCC_MCP_MAYA_SKILL_PATHS`) |
+| `DCC_MCP_GATEWAY_PORT` | Gateway port for multi-DCC setup |
+| `DCC_MCP_REGISTRY_DIR` | Directory for FileRegistry JSON |
 | `MCP_LOG_LEVEL` | Log level override (`DEBUG`, `INFO`, `WARN`) |
+| `DCC_MCP_IPC_ADDRESS` | IPC endpoint address (auto-set by register_diagnostic_handlers) |
+| `DCC_MCP_GATEWAY_PROBE_INTERVAL` | Seconds between gateway health probes (default 5) |
+| `DCC_MCP_GATEWAY_PROBE_TIMEOUT` | Timeout per probe in seconds (default 2) |
+| `DCC_MCP_GATEWAY_PROBE_FAILURES` | Consecutive failures before election (default 3) |
 
 ## Key Files in This Repository
 
@@ -281,9 +318,9 @@ print(f'Loaded: {[s.name for s in skills]}')
 | `GEMINI.md` | Gemini-specific workflows and tips |
 | `llms.txt` | Concise API reference for LLMs |
 | `llms-full.txt` | Comprehensive API reference with all examples |
-| `python/dcc_mcp_core/__init__.py` | Complete public API (ground truth for imports) |
+| `python/dcc_mcp_core/__init__.py` | Complete public API (~154 symbols, ground truth for imports) |
 | `python/dcc_mcp_core/_core.pyi` | Type stubs — authoritative parameter names |
-| `examples/skills/` | 9 complete skill package examples |
+| `examples/skills/` | 11 complete skill package examples |
 | `tests/` | Python integration tests (executable usage examples) |
 
 ## Supported DCC Software
@@ -301,16 +338,15 @@ print(f'Loaded: {[s.name for s in skills]}')
 
 ## MCP Specification Roadmap
 
-The library currently implements **MCP 2025-03-26** (Streamable HTTP). The **2025-11-05 draft** introduces:
+The library currently implements **MCP 2025-03-26** (Streamable HTTP). The ecosystem has since released:
 
-| Feature | Status | Notes |
-|---------|--------|-------|
-| JSON-RPC Batching | Draft | Multiple tool calls per round-trip; reduces latency for bulk ops |
-| Resource Links in Tool Results | Draft | Tools can return resource URIs for dynamic discovery |
-| Event Streams | Draft | Server-initiated push notifications for state changes |
-| Improved Error Taxonomy | Draft | Finer-grained error codes for better client handling |
+| Version | Key Features | Status in dcc-mcp-core |
+|---------|-------------|----------------------|
+| 2025-03-26 | Streamable HTTP, Tool Annotations, OAuth 2.1 | **Implemented** |
+| 2025-06-18 | Structured Tool Output, Elicitation, Resource Links, JSON-RPC batching removed, `MCP-Protocol-Version` header mandatory | Planned |
+| 2025-11-25 | Icon metadata, Tasks (experimental), Sampling with tool calls, JSON Schema 2020-12, enhanced OAuth | Planned |
 
-**AI Agents**: Do NOT implement these features manually. Wait for `dcc-mcp-core` to expose them via `McpHttpServer`. Track progress at the GitHub repository.
+**AI Agents**: Do NOT implement draft features manually. Wait for `dcc-mcp-core` to expose them via `McpHttpServer`. Track progress at the GitHub repository.
 
 ## Common Pitfalls
 
@@ -320,3 +356,8 @@ The library currently implements **MCP 2025-03-26** (Streamable HTTP). The **202
 4. Use `FramedChannel.call()` for sync RPC — not `send_request()` + `recv()` (those are for async/multiplex)
 5. `ActionDispatcher(registry)` takes ONE arg — no `validator=` parameter
 6. Action naming: `{skill_name.replace('-','_')}__{script_stem}` (double underscore)
+7. SKILL.md `name` must match parent directory name (agentskills.io spec)
+8. `allowed-tools` in SKILL.md is space-separated string, not a list (agentskills.io spec)
+9. `DccServerBase` provides all skill/lifecycle/gateway/hot-reload methods — don't reimplement
+10. MCP 2025-06-18 removes JSON-RPC batching — do not implement batch calls manually
+11. `MCP-Protocol-Version` header is mandatory in 2025-06-18 — handled by McpHttpServer internally

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,9 +34,9 @@
 
 ### Key Architecture Facts
 
-- **Language**: Rust core (14 crates workspace) + Python bindings via PyO3
+- **Language**: Rust core (14 crates workspace) + Python bindings via PyO3 + pure-Python helpers
 - **Build system**: `cargo` (Rust) + `maturin` (Python wheels)
-- **Python package**: `dcc_mcp_core` with ~140 public symbols re-exported from `_core` native extension (see `python/dcc_mcp_core/__init__.py`)
+- **Python package**: `dcc_mcp_core` with ~154 public symbols re-exported from `_core` native extension + pure-Python modules (see `python/dcc_mcp_core/__init__.py`)
 - **Zero runtime Python dependencies** — everything is compiled into the Rust core
 - **Version**: current (use Release Please for versioning — never manually bump)
 - **Python support**: 3.7–3.13 (CI tests 3.7–3.13; abi3-py38 wheel for 3.8+)
@@ -67,7 +67,7 @@ dcc-mcp-core/
 │   └── dcc-mcp-utils/          # Filesystem, type wrappers, constants, JSON helpers
 │
 ├── python/dcc_mcp_core/
-│   ├── __init__.py             # Public API re-exports (~140 symbols) — ALWAYS read this first
+│   ├── __init__.py             # Public API re-exports (~154 symbols) — ALWAYS read this first
 │   ├── _core.pyi               # Type stubs (auto-generated-ish) — ground truth for parameter names
 │   ├── skill.py                # Pure-Python skill script helpers (no _core dependency)
 │   └── py.typed                # PEP 561 marker
@@ -581,6 +581,79 @@ from dcc_mcp_core import (
 from dcc_mcp_core import ServiceEntry, ServiceStatus
 ```
 
+#### Pure-Python Modules (no _core dependency)
+
+These modules provide reusable building blocks for DCC adapters. They don't depend on the Rust `_core` extension and can be imported in any Python environment.
+
+```python
+# ── DCC Server Base ──────────────────────────────────────────────────────────
+from dcc_mcp_core.server_base import DccServerBase
+
+# Reusable base class for ALL DCC adapters. Provides:
+# - Skill search path collection (per-app env var → global → bundled)
+# - register_builtin_actions(), list_skills(), load_skill(), unload_skill()
+# - find_skills(), search_actions(), get_skill_categories(), get_skill_tags()
+# - Hot-reload: enable_hot_reload(), disable_hot_reload()
+# - Gateway: is_gateway, gateway_url, update_gateway_metadata()
+# - Lifecycle: start() → McpServerHandle, stop(), is_running, mcp_url
+#
+# Subclass with just dcc_name + builtin_skills_dir:
+class BlenderMcpServer(DccServerBase):
+    def __init__(self, port=8765, **kwargs):
+        super().__init__(dcc_name="blender", builtin_skills_dir=Path(__file__).parent / "skills", port=port, **kwargs)
+
+# ── Gateway Election ─────────────────────────────────────────────────────────
+from dcc_mcp_core.gateway_election import DccGatewayElection
+
+# Automatic gateway failover when primary becomes unreachable.
+# Background daemon thread: probes /health → counts failures → first-wins election
+election = DccGatewayElection(dcc_name="blender", server=blender_server, gateway_port=9765)
+election.start()   # background thread
+election.stop()    # graceful shutdown
+election.get_status()  # {"running": bool, "consecutive_failures": int, ...}
+
+# ── Skill Hot-Reload ─────────────────────────────────────────────────────────
+from dcc_mcp_core.hotreload import DccSkillHotReloader
+
+# Wraps SkillWatcher for automatic skill reload on file changes
+reloader = DccSkillHotReloader(dcc_name="blender", server=blender_server)
+reloader.enable(["/path/to/skills"], debounce_ms=300)
+reloader.reload_now()   # manual trigger
+reloader.disable()
+reloader.get_stats()    # {"enabled": bool, "watched_paths": [...], "reload_count": int}
+
+# ── Factory (singleton helper) ───────────────────────────────────────────────
+from dcc_mcp_core.factory import create_dcc_server, make_start_stop, get_server_instance
+
+# Thread-safe singleton DCC server creation
+server = create_dcc_server(instance_holder=[None], lock=threading.Lock(), server_class=MyServer, port=8765)
+
+# Generate (start_server, stop_server) function pairs
+start_server, stop_server = make_start_stop(MyServer)
+
+# ── DCC Diagnostic Handlers ──────────────────────────────────────────────────
+from dcc_mcp_core.dcc_server import register_diagnostic_handlers
+
+# Registers 3 IPC action handlers: get_audit_log, get_action_metrics, dispatch_action
+# Also sets DCC_MCP_IPC_ADDRESS env var for skill subprocesses
+register_diagnostic_handlers(server, dispatcher=dispatcher, dcc_name="blender")
+
+# ── Skill Script Helpers ─────────────────────────────────────────────────────
+from dcc_mcp_core.skill import (
+    skill_entry, skill_success, skill_error, skill_warning, skill_exception, run_main,
+    get_bundled_skills_dir, get_bundled_skill_paths,
+)
+
+# @skill_entry: decorator with standard error handling (ImportError/Exception/BaseException)
+@skill_entry
+def my_tool(name: str = "world") -> dict:
+    return skill_success(f"Created {name}", prompt="Check viewport.", name=name)
+
+# Result builders: skill_success, skill_error, skill_warning, skill_exception
+# All return dicts compatible with ActionResultModel
+# run_main: execute function and print JSON result to stdout (exit 0/1)
+```
+
 #### Constants
 
 ```python
@@ -732,11 +805,13 @@ my-skill/
 ---
 name: maya-geometry           # Required: unique identifier (used in action names)
 description: "Maya geometry creation and modification tools"
-tools: ["Bash", "Read"]       # OpenClaw tool permissions
+allowed-tools: Bash Read     # Space-separated (agentskills.io spec), NOT a YAML list
 tags: ["maya", "geometry"]    # Classification tags
 dcc: maya                     # Target DCC application
 version: "1.0.0"              # Semantic version
 depends: ["other-skill"]      # Names of required skills
+license: MIT                  # Optional: license identifier
+compatibility: "Maya 2024+"  # Optional: environment requirements
 ---
 # Human-readable description (markdown body)
 ```
@@ -852,13 +927,21 @@ pub fn register_actions(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
 16. **Do NOT use `dcc-mcp-ipc` in new code**: That project is superseded by `dcc-mcp-core`. All IPC transport, routing, and HTTP serving is provided by this library. New DCC integrations should only depend on `dcc-mcp-core`.
 
-17. **MCP specification version awareness**: `McpHttpServer` implements the 2025-03-26 MCP spec (Streamable HTTP). The 2025-11-05 draft spec introduces JSON-RPC batching, resource links in tool results, and event streams — watch for these capabilities in future `dcc-mcp-core` releases. Do NOT implement these from scratch; wait for API additions to `McpHttpServer`.
+17. **MCP specification version awareness**: `McpHttpServer` implements the 2025-03-26 MCP spec (Streamable HTTP). The 2025-06-18 spec adds **Structured Tool Output**, **Elicitation** (server asks user for info), **Resource Links in tool results**, and **removes JSON-RPC batching**; `MCP-Protocol-Version` header becomes mandatory. The 2025-11-25 spec adds icon metadata, experimental Tasks, Sampling with tool calls, and JSON Schema 2020-12. Do NOT implement these from scratch; wait for API additions to `McpHttpServer`.
 
 18. **`scan_and_load` with `extra_paths`**: When calling `scan_and_load(extra_paths=[...], dcc_name="maya")`, both arguments are keyword-only. Do not pass `extra_paths` as a positional argument — use `extra_paths=["/path"]` explicitly.
 
 19. **Gateway competition is opt-in**: Set `config.gateway_port = 9765` to join the multi-DCC gateway. Without this, `McpHttpServer` behaves exactly as before (no FileRegistry, no gateway). `handle.is_gateway` is `False` by default.
 
 20. **Never manually edit `CHANGELOG.md` or bump version numbers** in `Cargo.toml`, `pyproject.toml`, or `.release-please-manifest.json`. Release Please reads Conventional Commits from merged PRs and handles all version bumps and changelog generation automatically.
+
+21. **SKILL.md `allowed-tools` is space-separated** (agentskills.io spec): `allowed-tools: Bash(git:*) Bash(jq:*) Read` — NOT a YAML list `["Bash", "Read"]`. The `name` field must match the parent directory name.
+
+22. **DccServerBase provides all adapter boilerplate**: When building a new DCC adapter, subclass `DccServerBase` with just `dcc_name` and `builtin_skills_dir`. Don't reimplement skill loading, hot-reload, gateway election, or lifecycle management.
+
+23. **MCP 2025-06-18 removes JSON-RPC batching**: If you were planning to use batching, note that it was removed in the 2025-06-18 spec. Also, `MCP-Protocol-Version` header becomes mandatory — handled internally by `McpHttpServer`.
+
+24. **`ActionDispatcher` has new introspection methods**: `has_handler(name)`, `handler_count()`, `handler_names()`, `remove_handler(name)`, and `skip_empty_schema_validation` property. Use these instead of manual bookkeeping.
 
 ## Debugging & Diagnostics
 
@@ -1161,13 +1244,64 @@ maya_server = create_skill_manager("maya", McpHttpConfig(port=8765))
 blender_server = create_skill_manager("blender", McpHttpConfig(port=8766))
 ```
 
+### Pattern 9: Build a DCC adapter with DccServerBase
+
+```python
+from pathlib import Path
+from dcc_mcp_core.server_base import DccServerBase
+
+# Subclass DccServerBase — all skill management, hot-reload, gateway logic is inherited
+class BlenderMcpServer(DccServerBase):
+    def __init__(self, port: int = 8765, **kwargs):
+        super().__init__(
+            dcc_name="blender",
+            builtin_skills_dir=Path(__file__).parent / "skills",
+            port=port,
+            **kwargs,
+        )
+
+    def _version_string(self) -> str:
+        import bpy
+        return bpy.app.version_string
+
+# Usage — all skill methods are ready out of the box
+server = BlenderMcpServer(port=8765, gateway_port=9765)
+server.register_builtin_actions()  # discover + load all skills
+server.enable_hot_reload()         # file-watching auto-reload
+handle = server.start()            # start MCP HTTP server + gateway election
+print(f"MCP: {handle.mcp_url()}")
+print(f"Gateway: {server.is_gateway}")
+```
+
+### Pattern 10: Write skill scripts with skill_entry decorator
+
+```python
+from dcc_mcp_core.skill import skill_entry, skill_success, skill_error, skill_exception
+
+@skill_entry
+def create_sphere(radius: float = 1.0, name: str = "sphere") -> dict:
+    """Create a polygon sphere in the active scene."""
+    try:
+        import maya.cmds as cmds
+        obj = cmds.polySphere(r=radius, n=name)[0]
+        return skill_success(
+            f"Created sphere '{obj}' with radius {radius}",
+            prompt="You can now adjust properties or add materials.",
+            object_name=obj,
+            radius=radius,
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds not found")
+```
+
 ## External References
 
 - [AGENTS.md specification](https://agents.md/) — open standard for AI agent guidance files (Linux Foundation / Agentic AI Foundation)
 - [llms.txt specification](https://llmstxt.org/) — AI-optimized documentation format by Answer.AI
 - [Model Context Protocol](https://modelcontextprotocol.io/) — the underlying MCP standard (Anthropic)
-- [MCP Specification 2025-03-26](https://modelcontextprotocol.io/specification/2025-03-26) — current stable spec (Streamable HTTP, OAuth 2.1, Tool Annotations)
-- [MCP Specification 2025-11-05 (draft)](https://modelcontextprotocol.io/specification/draft) — upcoming spec (JSON-RPC batching, resource links in tool results, event streams, improved error taxonomy)
+- [MCP Specification 2025-03-26](https://modelcontextprotocol.io/specification/2025-03-26) — current stable spec implemented by this library (Streamable HTTP, OAuth 2.1, Tool Annotations)
+- [MCP Specification 2025-06-18](https://modelcontextprotocol.io/specification/2025-06-18/changelog) — Structured Tool Output, Elicitation, Resource Links, JSON-RPC batching removed, `MCP-Protocol-Version` header mandatory
+- [MCP Specification 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25/changelog) — Icon metadata, Tasks (experimental), Sampling with tool calls, JSON Schema 2020-12
 - [MCP Agent Skills](https://modelcontextprotocol.io/docs/develop/build-with-agent-skills) — SKILL.md ecosystem and agent skills spec
 - [Agent Skills Specification](https://agentskills.io/specification) — official SKILL.md frontmatter format and best practices
 - [PyO3 documentation](https://pyo3.rs/) — Rust-Python bindings used in this project

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,12 +30,12 @@ vx just test-cov      # Coverage report to find gaps
 
 ### Architecture Summary
 
-- **14 Rust crates** under `crates/`, compiled into `_core` native extension
-- **~140 public Python symbols** exported from `python/dcc_mcp_core/__init__.py`
+- **14 Rust crates** under `crates/`, compiled into `_core` native extension + pure-Python helpers
+- **~154 public Python symbols** exported from `python/dcc_mcp_core/__init__.py`
 - **Zero runtime Python deps** — all logic in Rust
 - Key entry point: `src/lib.rs` (PyO3 `#[pymodule]`)
 - Python 3.7–3.13 supported (CI tests 3.7–3.13)
-- Version: **0.12.23** — never manually bump (Release Please manages)
+- Version: **0.12.29** — never manually bump (Release Please manages)
 
 ## Claude-Specific Workflows
 
@@ -209,11 +209,11 @@ def test_skill_scan(tmp_path):
 - **Don't use legacy APIs**: `ActionManager`, `create_action_manager()`, `MiddlewareChain`, `Action` base class — all removed in v0.12+. Note: `LoggingMiddleware` IS still available (use via `pipeline.add_logging()`).
 - **The project has zero runtime Python dependencies by design** — never add `dependencies = [...]` to `pyproject.toml`
 - **`DeferredExecutor` is not in public `__init__.py`**: import via `from dcc_mcp_core._core import DeferredExecutor` until it is promoted to the public API
-- **MCP spec**: `McpHttpServer` implements 2025-03-26 spec. The upcoming 2025-11-05 draft adds JSON-RPC batching and resource links in tool results — do not implement these manually
+- **MCP spec**: `McpHttpServer` implements 2025-03-26 spec. The 2025-06-18 version adds Structured Tool Output, Elicitation, Resource Links, and removes JSON-RPC batching. The 2025-11-25 version adds icon metadata, Tasks, Sampling with tools. Do NOT implement these manually — wait for the library to add support.
 
 ## Key Files to Read First (Priority Order)
 
-1. `python/dcc_mcp_core/__init__.py` — Complete public API (~140 symbols)
+1. `python/dcc_mcp_core/__init__.py` — Complete public API (~154 symbols)
 2. `python/dcc_mcp_core/_core.pyi` — Type stubs with parameter names
 3. `AGENTS.md` — Full architecture, commands, pitfalls
 4. `crates/*/src/python.rs` — PyO3 binding implementations

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -6,8 +6,9 @@
 ## Project Identity
 
 You are working on **dcc-mcp-core**, a Rust-powered MCP (Model Context Protocol) library for DCC
-(Digital Content Creation) applications. Python package: `dcc_mcp_core`. ~140 public symbols,
-zero runtime Python dependencies (everything compiled into Rust core via PyO3).
+(Digital Content Creation) applications. Python package: `dcc_mcp_core`. ~154 public symbols,
+zero runtime Python dependencies (everything compiled into Rust core via PyO3), plus pure-Python
+helpers (DccServerBase, DccGatewayElection, DccSkillHotReloader, factory, skill helpers).
 
 ## Priority Reading Order
 
@@ -30,11 +31,11 @@ vx just lint-fix     # Auto-fix all lint issues
 
 ## Key Architecture Facts
 
-- **14 Rust crates** under `crates/`, compiled into `dcc_mcp_core._core` native extension
-- **~140 public Python symbols** exported from `python/dcc_mcp_core/__init__.py`
+- **14 Rust crates** under `crates/`, compiled into `dcc_mcp_core._core` native extension + pure-Python helpers
+- **~154 public Python symbols** exported from `python/dcc_mcp_core/__init__.py`
 - **Zero runtime Python deps** — all logic in Rust, no `dependencies = [...]` in pyproject.toml
 - Python 3.7–3.13 supported (abi3-py38 wheel; separate non-abi3 wheel for 3.7)
-- Version: **0.12.23** — managed by Release Please, never manually bump
+- Version: **0.12.29** — managed by Release Please, never manually bump
 
 ## Gemini-Specific Workflows
 
@@ -154,7 +155,7 @@ search-hint: "polygon modeling, bevel, extrude, mesh editing"
 17. **`McpServerHandle` is an alias**: `server.start()` returns `ServerHandle`; it is re-exported as `McpServerHandle` in `__init__.py`. Import as `from dcc_mcp_core import McpServerHandle`.
 18. **`McpHttpServer` registry population**: All actions must be registered in `ActionRegistry` BEFORE calling `server.start()`. The server reads metadata from the registry at startup.
 
-19. **MCP spec version awareness**: `McpHttpServer` implements 2025-03-26 spec. The 2025-11-05 draft adds JSON-RPC batching and resource links in tool results. Do NOT implement these manually — wait for the library to add support.
+19. **MCP spec version awareness**: `McpHttpServer` implements 2025-03-26 spec. The 2025-06-18 version adds Structured Tool Output, Elicitation, Resource Links, and removes JSON-RPC batching. The 2025-11-25 version adds icon metadata, Tasks, Sampling with tools, and JSON Schema 2020-12. Do NOT implement these manually — wait for the library to add support.
 
 20. **`scan_and_load` keyword args only**: Both `extra_paths` and `dcc_name` must be passed as keyword arguments: `scan_and_load(dcc_name="maya", extra_paths=["/path"])` — never as positionals.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -38,7 +38,7 @@ dcc-mcp-core is a **Rust workspace** with Python bindings via PyO3. All logic li
 sub-crates; the root crate re-exports everything into a single `dcc_mcp_core._core` Python
 extension module. The Python package `dcc_mcp_core` re-exports all public APIs from `_core`.
 
-**12 crates** — **Zero runtime Python dependencies** — install with just `pip install dcc-mcp-core`.
+**14 crates** — **Zero runtime Python dependencies** — install with just `pip install dcc-mcp-core`.
 
 ```
 crates/
@@ -54,6 +54,7 @@ crates/
 ├── dcc-mcp-shm/          # PyBufferPool, PySharedBuffer, PySharedSceneBuffer, LZ4 compression
 ├── dcc-mcp-capture/      # Capturer, CaptureFrame, CaptureResult
 ├── dcc-mcp-usd/          # UsdStage, UsdPrim, SdfPath, VtValue, scene info bridge
+├── dcc-mcp-server/       # Binary entry point, gateway runner
 └── dcc-mcp-utils/        # Filesystem, constants, type wrappers, JSON conversion
 ```
 
@@ -1933,11 +1934,13 @@ The `dcc-mcp-http` crate provides a **MCP Streamable HTTP server** compliant wit
 specification**. It uses axum + Tokio and runs in a background thread, making it safe to call from any
 DCC main thread.
 
-> **MCP Spec Roadmap**: The 2025-11-05 draft spec introduces:
-> - **JSON-RPC Batching** — multiple tool calls in one round-trip
-> - **Resource Links in Tool Results** — tools can return resource links for dynamic discovery
-> - **Event Streams** — server-initiated push notifications
-> - **Improved Error Taxonomy** — finer-grained error codes
+> **MCP Spec Roadmap**: The MCP specification has evolved significantly since the 2025-03-26 version this library implements:
+>
+> | Version | Key Changes | Status |
+> |---------|-------------|--------|
+> | 2025-03-26 | Streamable HTTP, Tool Annotations, OAuth 2.1 | **Implemented** |
+> | 2025-06-18 | Structured Tool Output, Elicitation (server asks user for info), Resource Links in tool results, JSON-RPC batching **removed**, `MCP-Protocol-Version` header mandatory | Planned |
+> | 2025-11-25 | Icon metadata, Tasks (experimental), Sampling with tool calls, JSON Schema 2020-12, enhanced OAuth | Planned |
 >
 > When these features land in `dcc-mcp-core`, they will be exposed via `McpHttpServer` —
 > do NOT implement these manually.

--- a/llms.txt
+++ b/llms.txt
@@ -16,6 +16,8 @@
 | Sandbox AI actions | `SandboxPolicy` + `SandboxContext` |
 | Share large data zero-copy | `PySharedSceneBuffer.write()` with LZ4 compression |
 | Expose DCC tools over HTTP/MCP | `create_skill_manager("maya", McpHttpConfig(port=8765))` — Skills-First setup; falls back to `McpHttpServer(registry, config)` for manual registry wiring |
+| Build a DCC adapter | `DccServerBase(dcc_name, builtin_skills_dir)` — skill/lifecycle/gateway/hot-reload inherited |
+| Write skill scripts | `skill_entry` + `skill_success` / `skill_error` — zero-boilerplate skill authoring |
 
 ## Quick Start
 
@@ -57,12 +59,12 @@ meta = dcc_mcp_core.parse_skill_md(dirs[0])  # -> SkillMetadata or None
 - Build from source: `maturin develop --features python-bindings,ext-module`
 - Python: >=3.7 (CI tests 3.7–3.13; abi3-py38 wheel for 3.8+)
 - Build: maturin (Rust 1.85+ + PyO3)
-- Version: 0.12.9
+- Version: 0.12.29
 - License: MIT
 
 ## Architecture
 
-Rust workspace (12 crates) with PyO3 bindings. All logic in Rust sub-crates; Python gets a single `dcc_mcp_core._core` extension module. The `dcc_mcp_core` package re-exports all ~130 public symbols from `_core`.
+Rust workspace (14 crates) with PyO3 bindings. All logic in Rust sub-crates; Python gets a single `dcc_mcp_core._core` extension module. The `dcc_mcp_core` package re-exports all ~154 public symbols from `_core` plus pure-Python helpers (DccServerBase, DccGatewayElection, DccSkillHotReloader, factory, skill helpers).
 
 ```
 crates/
@@ -78,6 +80,7 @@ crates/
 ├── dcc-mcp-capture/     # Capturer, CaptureFrame, CaptureResult
 ├── dcc-mcp-usd/         # UsdStage, UsdPrim, SdfPath, scene info bridge
 ├── dcc-mcp-http/        # McpHttpServer, McpHttpConfig, ServerHandle (MCP Streamable HTTP 2025-03-26)
+├── dcc-mcp-server/      # Binary entry point, gateway runner
 └── dcc-mcp-utils/       # Filesystem, constants, type wrappers, JSON conversion
 ```
 
@@ -182,7 +185,7 @@ crates/
 - `McpHttpConfig(port=8765, server_name=None, server_version=None, enable_cors=False, request_timeout_ms=30000)` — server configuration
 - `McpHttpServer(registry, config=None)` — MCP Streamable HTTP server (**2025-03-26 spec**), axum/Tokio backend
   - `.start() -> McpServerHandle` — starts background thread, returns immediately
-  - **Note**: MCP 2025-11-05 draft will add JSON-RPC batching and resource links in tool results — do NOT implement manually
+  - **Note**: MCP 2025-06-18 adds Structured Tool Output, Elicitation, Resource Links, and removes JSON-RPC batching. MCP 2025-11-25 adds icon metadata, Tasks, Sampling with tools. Do NOT implement manually — wait for library support.
 - `McpServerHandle` (alias for `ServerHandle`) — handle to running server
   - `.mcp_url() -> str` — full MCP endpoint URL (e.g. `"http://127.0.0.1:8765/mcp"`)
   - `.port -> int`, `.bind_addr -> str`
@@ -245,7 +248,7 @@ crates/
 
 ## Skills System
 
-Register scripts as MCP tools with zero Python code via SKILL.md.
+Register scripts as MCP tools with zero Python code via SKILL.md. Follows [agentskills.io](https://agentskills.io/specification) specification for SKILL.md format.
 
 ### Directory Structure
 
@@ -267,11 +270,13 @@ maya-geometry/
 ---
 name: maya-geometry
 description: "Maya geometry creation tools"
-allowed-tools: ["Bash", "Read"]
+allowed-tools: Bash Read  # space-separated (agentskills.io spec), NOT a YAML list
 tags: ["maya", "geometry"]
 dcc: maya
 version: "1.0.0"
 depends: ["other-skill"]  # optional
+license: MIT              # optional
+compatibility: "Maya 2024+" # optional
 ---
 # Markdown description body
 ```


### PR DESCRIPTION
## Summary

Comprehensive update of all AI agent documentation to reflect dcc-mcp-core v0.12.29.

## Changes

### Version and Metrics
- Version 0.12.9/0.12.23 to 0.12.29 across all AI docs
- Public symbols ~140 to ~154
- Crate count 12 to 14 (added dcc-mcp-server)

### MCP Specification Roadmap
- 2025-03-26: Implemented
- 2025-06-18: Planned (Structured Tool Output, Elicitation, Resource Links, JSON-RPC batching removed)
- 2025-11-25: Planned (Icon metadata, Tasks, Sampling with tools, JSON Schema 2020-12)

### Pure-Python Modules Documentation
Added docs for: DccServerBase, DccGatewayElection, DccSkillHotReloader, factory, dcc_server, skill helpers

### New Patterns
- Pattern 9: Build DCC adapter with DccServerBase
- Pattern 10: Write skill scripts with skill_entry decorator

### SKILL.md Spec Compliance
- Fixed allowed-tools format to space-separated string per agentskills.io spec
- Added license and compatibility optional fields

### New Pitfalls #21-#24
- SKILL.md allowed-tools format
- DccServerBase reuse
- JSON-RPC batching removal in 2025-06-18
- ActionDispatcher introspection methods

### Files Modified
- .agents/skills/dcc-mcp-core/SKILL.md
- AGENTS.md
- CLAUDE.md
- GEMINI.md
- llms.txt
- llms-full.txt