### PR TITLE
feat(server_base): add filter_existing param to collect_skill_search_paths

### DIFF
--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -145,6 +145,7 @@ class DccServerBase:
         self,
         extra_paths: list[str] | None = None,
         include_bundled: bool = True,
+        filter_existing: bool = False,
     ) -> list[str]:
         """Build the ordered skill search path list for this DCC.
 
@@ -159,6 +160,10 @@ class DccServerBase:
         Args:
             extra_paths: Additional directories to prepend.
             include_bundled: Include general-purpose skills from dcc-mcp-core.
+            filter_existing: When ``True``, remove paths that do not exist on
+                disk and deduplicate the result.  Pass this when feeding paths
+                to ``McpHttpServer.discover()`` to avoid warnings on missing dirs.
+                Default ``False`` preserves backward-compatible behaviour.
 
         Returns:
             Ordered list of directory paths (strings).
@@ -187,6 +192,15 @@ class DccServerBase:
         default_dir = get_skills_dir()
         if default_dir and default_dir not in paths:
             paths.append(default_dir)
+
+        if filter_existing:
+            seen: set[str] = set()
+            filtered: list[str] = []
+            for p in paths:
+                if p not in seen and Path(p).is_dir():
+                    seen.add(p)
+                    filtered.append(p)
+            return filtered
 
         return paths
 


### PR DESCRIPTION
## Summary

Adds ilter_existing: bool = False parameter to DccServerBase.collect_skill_search_paths().

When ilter_existing=True, only directories that exist on disk are returned and duplicates are removed. This allows DCC adapters to pass the result directly to McpHttpServer.discover() without getting warnings about missing directories.

## Motivation

dcc-mcp-blender's BlenderMcpServer was reimplementing this filtering logic manually:

`python
candidates = self.collect_skill_search_paths(extra_paths=self._extra_skill_paths)
seen: set = set()
result: List[str] = []
for p in candidates:
    if p not in seen and pathlib.Path(p).is_dir():
        seen.add(p)
        result.append(p)
return result
`

Now it can simply call:
`python
return self.collect_skill_search_paths(
    extra_paths=self._extra_skill_paths,
    filter_existing=True,
)
`

## Changes

- python/dcc_mcp_core/server_base.py: add ilter_existing parameter with default False

## Backward Compatibility

Default ilter_existing=False preserves existing behaviour for all existing callers.

## Closes #197