### PR TITLE
docs: enhance AI agent guidance with Bridge, Scene Model, Serialization APIs and MCP 2026 roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,9 @@
 | Measure action performance | `ActionRecorder` + `ActionMetrics` |
 | Capture DCC viewport | `Capturer.new_auto().capture()` |
 | Exchange scene as USD | `UsdStage` + `scene_info_json_to_stage()` |
+| Bridge DCC protocols | `BridgeRegistry` + `register_bridge()` / `get_bridge_context()` |
+| Describe scene hierarchy | `SceneNode` + `SceneObject` + `ObjectTransform` + `BoundingBox` |
+| Serialize result for transport | `serialize_result()` / `deserialize_result()` with `SerializeFormat` |
 | Safe RPyC value transport | `wrap_value()` / `unwrap_value()` |
 | Multi-version action lookup | `VersionedRegistry` + `VersionConstraint.parse()` |
 | Expose DCC tools over HTTP/MCP | `create_skill_manager("maya", McpHttpConfig(port=8765))` — one-call Skills-First setup |
@@ -72,7 +75,7 @@ dcc-mcp-core/
 │   ├── skill.py                # Pure-Python skill script helpers (no _core dependency)
 │   └── py.typed                # PEP 561 marker
 │
-├── tests/                      # Python integration tests (26 files)
+├── tests/                      # Python integration tests (120+ files)
 ├── examples/skills/            # 11 example SKILL.md packages (hello-world, maya-*, git-*, etc.)
 ├── docs/                       # VitePress documentation site (EN + ZH)
 │   ├── api/                    # API reference per module
@@ -547,6 +550,47 @@ watcher = PyProcessWatcher(
 watcher.watch(process)
 ```
 
+#### Bridge System (DCC Inter-Protocol Bridging)
+
+```python
+from dcc_mcp_core import BridgeContext, BridgeRegistry, register_bridge, get_bridge_context
+
+# BridgeRegistry manages named protocol bridges (e.g., RPyC ↔ MCP, HTTP ↔ IPC)
+registry = BridgeRegistry()
+register_bridge("rpyc", BridgeContext(name="rpyc", description="RPyC bridge"))
+ctx = get_bridge_context("rpyc")  # retrieve by name
+```
+
+#### Scene Data Model
+
+```python
+from dcc_mcp_core import (
+    BoundingBox,       # Axis-aligned bounding box (min/max corner vectors)
+    FrameRange,        # Animation frame range (start, end, step)
+    ObjectTransform,   # 4x4 transform matrix + decomposition (translate, rotate, scale)
+    SceneNode,         # Hierarchical scene node (path, transform, children)
+    SceneObject,       # Full scene object (mesh, material, transform references)
+    RenderOutput,      # Render result metadata (path, format, resolution)
+)
+
+# BoundingBox usage
+bbox = BoundingBox(min_x=0, min_y=0, min_z=0, max_x=1, max_y=1, max_z=1)
+# FrameRange for animation queries
+frames = FrameRange(start=1, end=24, step=1)
+# ObjectTransform for spatial queries
+xform = ObjectTransform(translate=[0, 5, 0], rotate=[0, 0, 0, 1], scale=[1, 1, 1])
+```
+
+#### Serialization
+
+```python
+from dcc_mcp_core import SerializeFormat, serialize_result, deserialize_result
+
+# Serialize ActionResultModel to bytes/string for transport or storage
+data = serialize_result(result, fmt=SerializeFormat.JSON)
+restored = deserialize_result(data, fmt=SerializeFormat.JSON)
+```
+
 #### Other Modules
 
 ```python
@@ -793,10 +837,13 @@ my-skill/
 │   ├── create_sphere.py
 │   ├── batch_rename.mel
 │   └── export_fbx.bat
-└── metadata/         # Optional
-    ├── help.md
-    ├── install.md
-    └── depends.md    # Dependency declarations (YAML list of skill names)
+├── references/       # Optional: supplementary docs (agentskills.io standard)
+│   ├── REFERENCE.md
+│   └── FORMS.md
+├── assets/           # Optional: templates, images, data files
+│   └── lookup.json
+└── metadata/         # Optional: dependency declarations
+    └── depends.md    # YAML list of dependency skill names
 ```
 
 ### SKILL.md Format
@@ -927,7 +974,7 @@ pub fn register_actions(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
 16. **Do NOT use `dcc-mcp-ipc` in new code**: That project is superseded by `dcc-mcp-core`. All IPC transport, routing, and HTTP serving is provided by this library. New DCC integrations should only depend on `dcc-mcp-core`.
 
-17. **MCP specification version awareness**: `McpHttpServer` implements the 2025-03-26 MCP spec (Streamable HTTP). The 2025-06-18 spec adds **Structured Tool Output**, **Elicitation** (server asks user for info), **Resource Links in tool results**, and **removes JSON-RPC batching**; `MCP-Protocol-Version` header becomes mandatory. The 2025-11-25 spec adds icon metadata, experimental Tasks, Sampling with tool calls, and JSON Schema 2020-12. Do NOT implement these from scratch; wait for API additions to `McpHttpServer`.
+17. **MCP specification version awareness**: `McpHttpServer` implements the 2025-03-26 MCP spec (Streamable HTTP). The 2025-06-18 spec adds **Structured Tool Output**, **Elicitation** (server asks user for info), **Resource Links in tool results**, and **removes JSON-RPC batching**; `MCP-Protocol-Version` header becomes mandatory. The 2025-11-25 spec adds icon metadata, experimental **Tasks** (persistent request tracking), Sampling with tool calls, URL pattern requests, OAuth Client ID Metadata Document, and JSON Schema 2020-12. The 2026 roadmap focuses on transport scalability (stateless horizontal scaling), agent communication (Tasks lifecycle), governance maturation (working groups), and enterprise readiness (extensions). Do NOT implement these from scratch; wait for API additions to `McpHttpServer`.
 
 18. **`scan_and_load` with `extra_paths`**: When calling `scan_and_load(extra_paths=[...], dcc_name="maya")`, both arguments are keyword-only. Do not pass `extra_paths` as a positional argument — use `extra_paths=["/path"]` explicitly.
 
@@ -942,6 +989,16 @@ pub fn register_actions(m: &Bound<'_, PyModule>) -> PyResult<()> {
 23. **MCP 2025-06-18 removes JSON-RPC batching**: If you were planning to use batching, note that it was removed in the 2025-06-18 spec. Also, `MCP-Protocol-Version` header becomes mandatory — handled internally by `McpHttpServer`.
 
 24. **`ActionDispatcher` has new introspection methods**: `has_handler(name)`, `handler_count()`, `handler_names()`, `remove_handler(name)`, and `skip_empty_schema_validation` property. Use these instead of manual bookkeeping.
+
+25. **`BridgeRegistry` and `BridgeContext`** are available for DCC inter-protocol bridging. Use `register_bridge(name, ctx)` to register a named bridge and `get_bridge_context(name)` to retrieve it. Don't build custom bridge registries.
+
+26. **Scene data model types are available**: `BoundingBox`, `FrameRange`, `ObjectTransform`, `SceneNode`, `SceneObject`, `RenderOutput` — use these for structured scene data instead of raw dicts. `BoundingBox` is `Optional` — check for `None` before using.
+
+27. **`serialize_result()` / `deserialize_result()`** for transport-safe ActionResultModel serialization. Use `SerializeFormat.JSON` or `SerializeFormat.MESSAGEPACK` explicitly — don't use `json.dumps()` on ActionResultModel directly.
+
+28. **SKILL.md `references/` directory is now standard** (agentskills.io spec): Place supplementary docs (REFERENCE.md, FORMS.md) in `references/` rather than `metadata/`. The `metadata/` directory is for dependency declarations only. Keep main SKILL.md under 500 lines and move detailed content to `references/`.
+
+29. **MCP 2026 Roadmap**: The MCP project has shifted from version-release milestones to **priority-area working groups**. Four pillars: (1) Transport evolution — stateless horizontal scaling, `.well-known` server discovery; (2) Agent communication — Tasks lifecycle (retry, expiry); (3) Governance maturation — contributor ladder, delegation model; (4) Enterprise readiness — audit, SSO, gateway, config portability (as extensions, not core spec changes). New transport methods are NOT planned — only evolution of existing Streamable HTTP.
 
 ## Debugging & Diagnostics
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ vx just test-cov      # Coverage report to find gaps
 - **Zero runtime Python deps** — all logic in Rust
 - Key entry point: `src/lib.rs` (PyO3 `#[pymodule]`)
 - Python 3.7–3.13 supported (CI tests 3.7–3.13)
-- Version: **0.12.29** — never manually bump (Release Please manages)
+- Version: current — never manually bump (Release Please manages)
 
 ## Claude-Specific Workflows
 
@@ -209,13 +209,16 @@ def test_skill_scan(tmp_path):
 - **Don't use legacy APIs**: `ActionManager`, `create_action_manager()`, `MiddlewareChain`, `Action` base class — all removed in v0.12+. Note: `LoggingMiddleware` IS still available (use via `pipeline.add_logging()`).
 - **The project has zero runtime Python dependencies by design** — never add `dependencies = [...]` to `pyproject.toml`
 - **`DeferredExecutor` is not in public `__init__.py`**: import via `from dcc_mcp_core._core import DeferredExecutor` until it is promoted to the public API
-- **MCP spec**: `McpHttpServer` implements 2025-03-26 spec. The 2025-06-18 version adds Structured Tool Output, Elicitation, Resource Links, and removes JSON-RPC batching. The 2025-11-25 version adds icon metadata, Tasks, Sampling with tools. Do NOT implement these manually — wait for the library to add support.
+- **MCP spec**: `McpHttpServer` implements 2025-03-26 spec. The 2025-06-18 version adds Structured Tool Output, Elicitation, Resource Links, and removes JSON-RPC batching. The 2025-11-25 version adds icon metadata, Tasks (persistent requests), Sampling with tools, URL pattern requests, OAuth Client ID Metadata Document, JSON Schema 2020-12. The 2026 roadmap focuses on transport scalability, agent communication (Tasks lifecycle), governance, and enterprise readiness. Do NOT implement these manually — wait for the library to add support.
+- **Bridge system**: `BridgeRegistry`, `BridgeContext`, `register_bridge()`, `get_bridge_context()` — for inter-protocol bridging (RPyC ↔ MCP etc.). Don't build custom bridge registries.
+- **Scene data model**: `BoundingBox`, `FrameRange`, `ObjectTransform`, `SceneNode`, `SceneObject`, `RenderOutput` — use for structured scene data instead of raw dicts. `BoundingBox` may be `None`.
+- **Serialization**: `serialize_result()` / `deserialize_result()` with `SerializeFormat` enum — for transport-safe ActionResultModel serialization. Don't use `json.dumps()` on ActionResultModel.
 
 ## Key Files to Read First (Priority Order)
 
-1. `python/dcc_mcp_core/__init__.py` — Complete public API (~154 symbols)
+1. `python/dcc_mcp_core/__init__.py` — Complete public API (~154 symbols including BridgeRegistry, BridgeContext, BoundingBox, FrameRange, ObjectTransform, SceneNode, SceneObject, RenderOutput, SerializeFormat)
 2. `python/dcc_mcp_core/_core.pyi` — Type stubs with parameter names
 3. `AGENTS.md` — Full architecture, commands, pitfalls
 4. `crates/*/src/python.rs` — PyO3 binding implementations
 5. `src/lib.rs` — Module registration entry point
-6. `tests/` — Usage examples in test form
+6. `tests/` — Usage examples in test form (120+ files)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -155,7 +155,7 @@ search-hint: "polygon modeling, bevel, extrude, mesh editing"
 17. **`McpServerHandle` is an alias**: `server.start()` returns `ServerHandle`; it is re-exported as `McpServerHandle` in `__init__.py`. Import as `from dcc_mcp_core import McpServerHandle`.
 18. **`McpHttpServer` registry population**: All actions must be registered in `ActionRegistry` BEFORE calling `server.start()`. The server reads metadata from the registry at startup.
 
-19. **MCP spec version awareness**: `McpHttpServer` implements 2025-03-26 spec. The 2025-06-18 version adds Structured Tool Output, Elicitation, Resource Links, and removes JSON-RPC batching. The 2025-11-25 version adds icon metadata, Tasks, Sampling with tools, and JSON Schema 2020-12. Do NOT implement these manually — wait for the library to add support.
+19. **MCP spec version awareness**: `McpHttpServer` implements 2025-03-26 spec. The 2025-06-18 version adds Structured Tool Output, Elicitation, Resource Links, and removes JSON-RPC batching. The 2025-11-25 version adds icon metadata, Tasks (persistent requests), Sampling with tool calls, URL pattern requests, OAuth Client ID Metadata Document, JSON Schema 2020-12. The 2026 roadmap focuses on transport scalability, agent communication (Tasks lifecycle), governance, and enterprise readiness. Do NOT implement these manually — wait for the library to add support.
 
 20. **`scan_and_load` keyword args only**: Both `extra_paths` and `dcc_name` must be passed as keyword arguments: `scan_and_load(dcc_name="maya", extra_paths=["/path"])` — never as positionals.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -26,6 +26,9 @@
 | Share large data between processes | `PySharedSceneBuffer` (LZ4 compressed) |
 | Capture a DCC viewport screenshot | `Capturer.new_auto().capture()` |
 | Exchange scene data via USD format | `UsdStage` + `scene_info_json_to_stage()` |
+| Bridge DCC protocols | `BridgeRegistry` + `register_bridge()` / `get_bridge_context()` |
+| Describe scene hierarchy | `SceneNode` + `SceneObject` + `ObjectTransform` + `BoundingBox` |
+| Serialize result for transport | `serialize_result()` / `deserialize_result()` with `SerializeFormat` |
 | Wrap values for safe RPyC transport | `wrap_value()` / `unwrap_value()` |
 | Handle multiple versions of an action | `VersionedRegistry` + `VersionConstraint` |
 | Expose DCC tools over HTTP/MCP | `create_skill_manager("maya", McpHttpConfig(port=8765))` — Skills-First one-call setup; falls back to `McpHttpServer(registry, config)` for manual registry wiring |
@@ -1756,6 +1759,72 @@ mpu = units_to_mpu("cm")   # -> 0.01 (meters per unit for centimeters)
 mpu = units_to_mpu("m")    # -> 1.0
 units = mpu_to_units(0.01) # -> "cm"
 units = mpu_to_units(1.0)  # -> "m"
+```
+
+---
+
+## Bridge System (`dcc_mcp_core`)
+
+DCC inter-protocol bridging — register named bridges between different transport protocols.
+
+```python
+from dcc_mcp_core import BridgeRegistry, BridgeContext, register_bridge, get_bridge_context
+
+# Register a named bridge
+register_bridge("rpyc", BridgeContext(name="rpyc", description="RPyC ↔ MCP bridge"))
+
+# Retrieve bridge context by name
+ctx = get_bridge_context("rpyc")  # -> BridgeContext or None
+```
+
+---
+
+## Scene Data Model (`dcc_mcp_core`)
+
+Structured scene data types for representing DCC scene hierarchy and geometry.
+
+```python
+from dcc_mcp_core import BoundingBox, FrameRange, ObjectTransform, SceneNode, SceneObject, RenderOutput
+
+# Bounding box (axis-aligned)
+bbox = BoundingBox(min_x=0, min_y=0, min_z=0, max_x=1, max_y=1, max_z=1)
+
+# Animation frame range
+frames = FrameRange(start=1, end=24, step=1)
+
+# Object transform (translate, rotate, scale decomposition)
+xform = ObjectTransform(translate=[0, 5, 0], rotate=[0, 0, 0, 1], scale=[1, 1, 1])
+
+# Scene nodes (hierarchical)
+node = SceneNode(path="/world/geo/sphere1", transform=xform)
+
+# Scene objects (full representation)
+obj = SceneObject(name="sphere1", node_type="mesh", transform=xform)
+
+# Render output metadata
+render = RenderOutput(path="/tmp/render.exr", format="exr", width=1920, height=1080)
+```
+
+> **Note**: `BoundingBox` is an optional import — may be `None` if not available in the compiled extension.
+
+---
+
+## Serialization (`dcc_mcp_core`)
+
+Transport-safe ActionResultModel serialization for IPC, storage, or network transfer.
+
+```python
+from dcc_mcp_core import SerializeFormat, serialize_result, deserialize_result, success_result
+
+result = success_result("Created sphere", prompt="Add materials next", count=1)
+
+# Serialize to bytes
+data = serialize_result(result, fmt=SerializeFormat.JSON)
+
+# Deserialize back
+restored = deserialize_result(data, fmt=SerializeFormat.JSON)
+assert restored.success
+assert restored.message == "Created sphere"
 ```
 
 ---

--- a/llms.txt
+++ b/llms.txt
@@ -59,7 +59,7 @@ meta = dcc_mcp_core.parse_skill_md(dirs[0])  # -> SkillMetadata or None
 - Build from source: `maturin develop --features python-bindings,ext-module`
 - Python: >=3.7 (CI tests 3.7–3.13; abi3-py38 wheel for 3.8+)
 - Build: maturin (Rust 1.85+ + PyO3)
-- Version: 0.12.29
+- Version: 0.12.28+
 - License: MIT
 
 ## Architecture
@@ -233,6 +233,28 @@ crates/
 - `unwrap_parameters(params_dict)` — unwrap all wrapper values in a dict
 - `BooleanWrapper`, `FloatWrapper`, `IntWrapper`, `StringWrapper`
 
+### Bridge System (`dcc_mcp_core`)
+
+- `BridgeRegistry` — manages named protocol bridges (RPyC ↔ MCP, HTTP ↔ IPC)
+- `BridgeContext` — bridge context with name, description, metadata
+- `register_bridge(name, ctx)` — register a named bridge
+- `get_bridge_context(name) -> Optional[BridgeContext]` — retrieve bridge by name
+
+### Scene Data Model (`dcc_mcp_core`)
+
+- `BoundingBox` — axis-aligned bounding box (min/max corner vectors)
+- `FrameRange` — animation frame range (start, end, step)
+- `ObjectTransform` — 4x4 transform + decomposition (translate, rotate, scale)
+- `SceneNode` — hierarchical scene node (path, transform, children)
+- `SceneObject` — full scene object (mesh, material, transform references)
+- `RenderOutput` — render result metadata (path, format, resolution)
+
+### Serialization (`dcc_mcp_core`)
+
+- `SerializeFormat` — enum: JSON, MESSAGEPACK
+- `serialize_result(result, fmt) -> bytes` — ActionResultModel → transport-safe bytes
+- `deserialize_result(data, fmt) -> ActionResultModel` — bytes → ActionResultModel
+
 ### Utility Functions (`dcc_mcp_core`)
 
 - `get_config_dir()`, `get_data_dir()`, `get_log_dir()`, `get_platform_dir(dir_type)`
@@ -258,9 +280,10 @@ maya-geometry/
 ├── scripts/
 │   ├── create_sphere.py
 │   └── batch_rename.mel
-└── metadata/         # Optional
-    ├── help.md
-    ├── install.md
+├── references/       # Optional: supplementary docs (agentskills.io standard)
+│   └── REFERENCE.md
+├── assets/           # Optional: templates, images, data files
+└── metadata/         # Optional: dependency declarations
     └── depends.md    # YAML list of dependency skill names
 ```
 


### PR DESCRIPTION
## Summary

Major update to AI agent guidance files (AGENTS.md, CLAUDE.md, GEMINI.md, llms.txt, llms-full.txt) to improve AI agent understanding and encourage use of provided APIs.

### New API Documentation

- **Bridge System**: `BridgeRegistry`, `BridgeContext`, `register_bridge()`, `get_bridge_context()` — inter-protocol bridging
- **Scene Data Model**: `BoundingBox`, `FrameRange`, `ObjectTransform`, `SceneNode`, `SceneObject`, `RenderOutput` — structured scene data
- **Serialization**: `SerializeFormat`, `serialize_result()`, `deserialize_result()` — transport-safe ActionResultModel serialization

### MCP Spec Updates

- Updated 2025-11-25 spec details: Tasks (persistent requests), URL pattern requests, OAuth Client ID Metadata Document, OIDC Discovery, JSON Schema 2020-12
- Added MCP 2026 Roadmap summary: four priority pillars (transport scalability, agent communication, governance maturation, enterprise readiness)
- Clarified: no new transport methods planned, only evolution of existing Streamable HTTP

### Agent Skills Spec Updates

- Added `references/` directory as official standard (agentskills.io spec)
- Added `assets/` directory for static resources
- Updated SKILL.md directory structure in all docs

### Other Improvements

- Added Quick Decision Guide entries for Bridge, Scene Model, Serialization APIs
- Added pitfalls #25-#29 for new APIs and MCP 2026 roadmap
- Updated test file count (26 → 120+)
- Fixed hardcoded version references to "current"
- Added Agent Skills GitHub repo to External References

### Files Changed

| File | Changes |
|------|---------|
| AGENTS.md | +63 lines: new sections, pitfalls, roadmap, references |
| CLAUDE.md | +7 lines: new APIs, MCP spec update |
| GEMINI.md | +12 lines: new pitfalls, spec updates |
| llms.txt | +27 lines: Bridge, Scene, Serialization APIs |
| llms-full.txt | +69 lines: full API sections with examples |

### Test Plan

- [x] Pre-commit hooks pass (ruff, clippy, fmt, trailing whitespace)
- [ ] CI: Lint + DCC Integration tests pass
- [ ] No Rust code changes — docs-only PR
