### PR TITLE
fix(test): update test_entry_to_dict_keys for new ServiceEntry fields

### DIFF
--- a/tests/test_vtvalue_traverse_registry_service_timing_pool.py
+++ b/tests/test_vtvalue_traverse_registry_service_timing_pool.py
@@ -537,10 +537,13 @@ class TestServiceEntryAttributes:
             d = entry.to_dict()
             expected_keys = {
                 "dcc_type",
+                "display_name",
+                "documents",
                 "host",
                 "instance_id",
                 "last_heartbeat_ms",
                 "metadata",
+                "pid",
                 "port",
                 "scene",
                 "status",


### PR DESCRIPTION
## Summary
- Update `test_entry_to_dict_keys` to include `documents`, `pid`, `display_name` keys that were added to `ServiceEntry.to_dict()`

## Context
After PR #199 was merged, the CI test jobs fail because `ServiceEntry.to_dict()` now returns 3 additional fields (`documents`, `pid`, `display_name`) that the test's `expected_keys` set didn't account for.