### PR TITLE
refactor: code quality, stale API fixes, AGENTS.md as navigation map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1427 +1,274 @@
-# AGENTS.md — dcc-mcp-core AI Agent Guide
+# AGENTS.md — dcc-mcp-core
 
-> **Purpose**: This file helps AI coding agents (Claude, Copilot, Cursor, Codex, Gemini, Devin, etc.) understand, navigate, and contribute to this project effectively. Read this before writing any code.
+> **This file is a navigation map, not a reference manual.**
+> It tells you *where to look*, not *what every API does*.
+> Follow the links; don't read everything upfront.
 
-## Quick Decision Guide — Use the Right API
+---
 
-> **AI agents**: When implementing features, ALWAYS check if dcc-mcp-core already provides what you need before writing custom code.
+## Start Here — Orient in 60 Seconds
 
-| Task | Prefer this API (not custom code) |
-|------|----------------------------------|
-| Return action result | `success_result()` / `error_result()` — never return raw dicts |
-| Register a callable as DCC tool | `ActionRegistry.register()` + `ActionDispatcher` |
-| Start a DCC skill server (Skills-First) | `create_skill_manager("maya")` — one call, auto-discovers from `DCC_MCP_MAYA_SKILL_PATHS` |
-| Discover/load skill packages | `create_skill_manager()` or `scan_and_load()` — not manual file scanning |
-| Set app-specific skill paths | `DCC_MCP_{APP}_SKILL_PATHS` env var (e.g. `DCC_MCP_MAYA_SKILL_PATHS`) |
-| Get bundled skills (zero config) | `get_bundled_skill_paths()` — included in wheel, no path config needed |
-| Validate JSON input params | `ActionValidator.from_schema_json()` — not manual isinstance checks |
-| Connect to running DCC process | `connect_ipc(TransportAddress.default_local(...))` |
-| Define MCP tool for LLM | `ToolDefinition` + `ToolAnnotations` — not raw JSON dicts |
-| Share large data zero-copy | `PySharedSceneBuffer.write()` — not pickle/JSON for large data |
-| Monitor process health | `PyProcessWatcher` + `PyCrashRecoveryPolicy` |
-| Enforce security on AI actions | `SandboxPolicy` + `SandboxContext` |
-| Measure action performance | `ActionRecorder` + `ActionMetrics` |
-| Capture DCC viewport | `Capturer.new_auto().capture()` |
-| Exchange scene as USD | `UsdStage` + `scene_info_json_to_stage()` |
-| Bridge DCC protocols | `BridgeRegistry` + `register_bridge()` / `get_bridge_context()` |
-| Describe scene hierarchy | `SceneNode` + `SceneObject` + `ObjectTransform` + `BoundingBox` |
-| Serialize result for transport | `serialize_result()` / `deserialize_result()` with `SerializeFormat` |
-| Safe RPyC value transport | `wrap_value()` / `unwrap_value()` |
-| Multi-version action lookup | `VersionedRegistry` + `VersionConstraint.parse()` |
-| Expose DCC tools over HTTP/MCP | `create_skill_manager("maya", McpHttpConfig(port=8765))` — one-call Skills-First setup |
-| Join multi-DCC gateway (auto-discovery) | `config.gateway_port = 9765` on `McpHttpConfig` — first-wins port competition; check `handle.is_gateway` |
+**What is this?**
+A Rust-powered MCP (Model Context Protocol) library that lets AI agents interact with DCC software (Maya, Blender, Houdini, Photoshop…). Compiled to a native Python extension via PyO3/maturin. Zero runtime Python dependencies.
 
-## Project Overview
+**What does it provide to downstream adapter packages (`dcc-mcp-maya`, `dcc-mcp-blender`, …)?**
 
-**dcc-mcp-core** is the foundational library for the DCC (Digital Content Creation) Model Context Protocol (MCP) ecosystem. It provides a **Rust-powered core with Python bindings (PyO3/maturin)** that enables AI assistants to interact with DCC software (Maya, Blender, Houdini, 3ds Max, etc.).
+| Need | What to use |
+|------|-------------|
+| Expose DCC tools over MCP HTTP | `DccServerBase` → subclass, call `start()` |
+| Zero-code tool registration | Drop `SKILL.md` + `scripts/` in a directory |
+| AI-safe result structure | `success_result()` / `error_result()` |
+| Bridge non-Python DCCs (Photoshop, ZBrush) | `DccBridge` (WebSocket JSON-RPC 2.0) |
+| IPC between processes | `IpcListener.bind()` / `connect_ipc()` / `FramedChannel.call()` |
+| Multi-DCC gateway | `McpHttpConfig(gateway_port=9765)` |
 
-### Key Architecture Facts
+**The three files that define the entire public API surface — read them in this order:**
 
-- **Language**: Rust core (14 crates workspace) + Python bindings via PyO3 + pure-Python helpers
-- **Build system**: `cargo` (Rust) + `maturin` (Python wheels)
-- **Python package**: `dcc_mcp_core` with ~154 public symbols re-exported from `_core` native extension + pure-Python modules (see `python/dcc_mcp_core/__init__.py`)
-- **Zero runtime Python dependencies** — everything is compiled into the Rust core
-- **Version**: current (use Release Please for versioning — never manually bump)
-- **Python support**: 3.7–3.13 (CI tests 3.7–3.13; abi3-py38 wheel for 3.8+)
+1. `python/dcc_mcp_core/__init__.py` — every public symbol, nothing hidden
+2. `python/dcc_mcp_core/_core.pyi` — ground truth for parameter names, types, and signatures
+3. `llms.txt` — compressed version of (1)+(2) optimised for token efficiency
 
-## Repository Structure
+---
+
+## Decision Tree — Find the Right API Fast
+
+**Building a DCC adapter (maya, blender, houdini…)?**
+→ [`docs/guide/getting-started.md`](docs/guide/getting-started.md)
+→ Read: `python/dcc_mcp_core/server_base.py` (DccServerBase — subclass this)
+→ Read: `python/dcc_mcp_core/factory.py` (make_start_stop — zero-boilerplate pair)
+
+**Adding tools via SKILL.md (zero Python code)?**
+→ [`docs/guide/skills.md`](docs/guide/skills.md)
+→ Examples: `examples/skills/` (11 complete packages)
+
+**Writing tool handler Python scripts?**
+→ `python/dcc_mcp_core/skill.py` — `@skill_entry`, `skill_success()`, `skill_error()`
+
+**Setting up MCP HTTP server + gateway?**
+→ [`docs/api/http.md`](docs/api/http.md)
+→ Key types: `McpHttpServer`, `McpHttpConfig`, `McpServerHandle`, `create_skill_manager`
+
+**Bridging a non-Python DCC (Photoshop, ZBrush via WebSocket)?**
+→ `python/dcc_mcp_core/bridge.py` — `DccBridge`
+→ Register with: `BridgeRegistry`, `register_bridge()`, `get_bridge_context()`
+
+**IPC / named pipe / unix socket between processes?**
+→ [`docs/api/transport.md`](docs/api/transport.md)
+→ Key pattern: `IpcListener.bind(addr)` → `.accept()` | `connect_ipc(addr)` → `channel.call()`
+
+**DCC main-thread safety (Maya cmds, bpy, hou…)?**
+→ [`docs/guide/getting-started.md`](docs/guide/getting-started.md) (DeferredExecutor section)
+→ `from dcc_mcp_core._core import DeferredExecutor` (not yet in public `__init__`)
+
+**Skills hot-reload during development?**
+→ `python/dcc_mcp_core/hotreload.py` — `DccSkillHotReloader`
+→ Or directly: `SkillWatcher(debounce_ms=300).watch("/path")`
+
+**Multi-DCC gateway failover (automatic election)?**
+→ `python/dcc_mcp_core/gateway_election.py` — `DccGatewayElection`
+→ [`docs/guide/gateway-election.md`](docs/guide/gateway-election.md)
+
+**Structured results, input validation, event bus?**
+→ [`docs/api/actions.md`](docs/api/actions.md)
+→ [`docs/api/models.md`](docs/api/models.md)
+
+**Security, sandbox, audit log?**
+→ [`docs/api/sandbox.md`](docs/api/sandbox.md)
+
+**USD scene exchange?**
+→ [`docs/api/usd.md`](docs/api/usd.md)
+
+**Screen capture, shared memory, telemetry, process management?**
+→ `docs/api/capture.md`, `docs/api/shm.md`, `docs/api/telemetry.md`, `docs/api/process.md`
+
+---
+
+## Repo Layout (What Lives Where)
 
 ```
 dcc-mcp-core/
-├── src/lib.rs                  # PyO3 entry point (_core module)
-├── Cargo.toml                  # Workspace definition (14 crates)
-├── pyproject.toml              # Python package metadata
-├── justfile                    # Development commands (use: vx just <recipe>)
+├── src/lib.rs                      # PyO3 entry point — registers all 14 crates into _core
+├── Cargo.toml                      # Workspace: 14 Rust crates
+├── pyproject.toml                  # Python package
+├── justfile                        # Dev commands (always prefix with vx)
 │
-├── crates/                     # Rust workspace crates
-│   ├── dcc-mcp-models/         # ActionResultModel, SkillMetadata
-│   ├── dcc-mcp-actions/        # ActionRegistry, EventBus, Pipeline, Dispatcher, Validator
-│   ├── dcc-mcp-skills/         # SkillScanner, SkillCatalog, SkillWatcher, Resolver
-│   ├── dcc-mcp-protocols/      # MCP types: ToolDefinition, ResourceDefinition, Prompt, DccAdapter, BridgeKind
-│   ├── dcc-mcp-transport/      # IPC, ConnectionPool, FileRegistry, CircuitBreaker, FramedChannel
-│   ├── dcc-mcp-process/        # PyDccLauncher, ProcessMonitor, ProcessWatcher, CrashRecovery
-│   ├── dcc-mcp-telemetry/      # Tracing/recording infrastructure
-│   ├── dcc-mcp-sandbox/        # Security policy, input validation, audit logging
-│   ├── dcc-mcp-shm/            # Shared memory buffers (LZ4 compressed)
-│   ├── dcc-mcp-capture/        # Screen/window capture backend
-│   ├── dcc-mcp-usd/            # USD scene description bridge
-│   ├── dcc-mcp-http/           # MCP Streamable HTTP server (2025-03-26 spec, McpHttpServer, Gateway)
-│   ├── dcc-mcp-server/         # Binary entry point, gateway runner
-│   └── dcc-mcp-utils/          # Filesystem, type wrappers, constants, JSON helpers
+├── crates/                         # Rust — one crate per concern
+│   ├── dcc-mcp-models/             # ActionResultModel, SkillMetadata, ToolDeclaration
+│   ├── dcc-mcp-actions/            # ActionRegistry, ActionDispatcher, ActionPipeline, EventBus
+│   ├── dcc-mcp-skills/             # SkillScanner, SkillCatalog, SkillWatcher
+│   ├── dcc-mcp-protocols/          # MCP types: ToolDefinition, DccCapabilities, BridgeKind
+│   ├── dcc-mcp-transport/          # IpcListener, FramedChannel, TransportManager, FileRegistry
+│   ├── dcc-mcp-process/            # PyDccLauncher, PyProcessWatcher, CrashRecoveryPolicy
+│   ├── dcc-mcp-http/               # McpHttpServer (MCP 2025-03-26 Streamable HTTP), Gateway
+│   ├── dcc-mcp-sandbox/            # SandboxPolicy, InputValidator, AuditLog
+│   ├── dcc-mcp-telemetry/          # TelemetryConfig, ActionRecorder, ActionMetrics
+│   ├── dcc-mcp-shm/                # PySharedBuffer, PySharedSceneBuffer (LZ4)
+│   ├── dcc-mcp-capture/            # Capturer, CaptureFrame (platform-native)
+│   ├── dcc-mcp-usd/                # UsdStage, UsdPrim, scene_info_json_to_stage
+│   ├── dcc-mcp-server/             # Binary entry point for bridge-mode DCCs
+│   └── dcc-mcp-utils/              # Filesystem helpers, wrap_value, constants
 │
 ├── python/dcc_mcp_core/
-│   ├── __init__.py             # Public API re-exports (~154 symbols) — ALWAYS read this first
-│   ├── _core.pyi               # Type stubs (auto-generated-ish) — ground truth for parameter names
-│   ├── skill.py                # Pure-Python skill script helpers (no _core dependency)
-│   └── py.typed                # PEP 561 marker
+│   ├── __init__.py                 # ← READ THIS: every public symbol + __all__
+│   ├── _core.pyi                   # ← READ THIS: parameter names, types, signatures
+│   ├── skill.py                    # Pure-Python: @skill_entry, skill_success/error/warning
+│   ├── server_base.py              # Pure-Python: DccServerBase (subclass for adapters)
+│   ├── factory.py                  # Pure-Python: make_start_stop, create_dcc_server
+│   ├── gateway_election.py         # Pure-Python: DccGatewayElection
+│   ├── hotreload.py                # Pure-Python: DccSkillHotReloader
+│   ├── bridge.py                   # Pure-Python: DccBridge (WebSocket JSON-RPC 2.0)
+│   ├── dcc_server.py               # Pure-Python: register_diagnostic_handlers
+│   └── skills/                     # Bundled: dcc-diagnostics, workflow (in wheel)
 │
-├── tests/                      # Python integration tests (120+ files)
-├── examples/skills/            # 11 example SKILL.md packages (hello-world, maya-*, git-*, etc.)
-├── docs/                       # VitePress documentation site (EN + ZH)
-│   ├── api/                    # API reference per module
-│   └── guide/                  # User guides & tutorials
-├── llms.txt                    # Concise API reference for LLMs
-├── llms-full.txt               # Complete API reference for LLMs
-└── .agents/skills/             # VX toolchain skills (IDE-agnostic)
+├── tests/                          # 120+ integration tests — executable usage examples
+├── examples/skills/                # 11 complete SKILL.md packages (start here for skill authoring)
+│
+├── docs/
+│   ├── guide/                      # Conceptual guides (getting-started, skills, gateway…)
+│   └── api/                        # API reference per module
+│
+├── llms.txt                        # Compressed API ref for token-limited contexts
+└── llms-full.txt                   # Full API ref for LLMs
 ```
 
-## Build & Test Commands
-
-### Prerequisites
-
-```bash
-# Install vx (recommended universal tool manager): https://github.com/loonghao/vx
-# Or ensure you have: Rust 1.85+, Python 3.8+, maturin
-```
-
-### Core Commands (via `vx just` or `just`)
-
-| Command | Purpose |
-|---------|---------|
-| `vx just check` | Cargo check all workspace crates |
-| `vx just clippy` | Clippy lint with `-D warnings` (CI strict) |
-| `vx just fmt` | Format Rust + Python |
-| `vx just fmt-check` | Check format only (CI mode) |
-| `vx just test-rust` | Run all Rust unit tests (`cargo test --workspace`) |
-| `vx just dev` | Build + install wheel in dev mode (`maturin develop`) |
-| `vx just install` | Build release wheel + pip install |
-| `vx just test` | Run pytest on `tests/` |
-| `vx just test-cov` | Run tests with coverage report |
-| `vx just lint-py` | Ruff check Python code |
-| `vx just lint-py-fix` | Fix + format Python |
-| `vx just lint` | Full lint: clippy + fmt-check + lint-py |
-| `vx just lint-fix` | Auto-fix all lint issues |
-| `vx just preflight` | Pre-commit: check + clippy + fmt-check + test-rust |
-| `vx just ci` | Full CI pipeline: preflight + install + test + lint-py |
-| `vx just build` | Build release wheel |
-| `vx just clean` | Remove all build artifacts |
-
-### Running Specific Tests
-
-```bash
-# Run a single test file
-vx just test -- tests/test_skills.py -v
-
-# Run with coverage for a specific module
-vx just test-cov -- tests/test_actions.py -v
-
-# Run Rust tests for a specific crate
-cargo test -p dcc-mcp-actions --workspace
-```
-
-## Code Style & Conventions
-
-### Rust
-
-- Edition 2024, MSRV 1.85
-- Use `tracing` for logging (never `println!` / `eprintln!`)
-- Use `thiserror` for error types
-- Use `parking_lot` instead of `std::sync::Mutex`
-- Keep files under 1000 lines (split into submodules if needed)
-
-### Python
-
-- Formatter: `ruff format` (line length: 120, double quotes)
-- Linter: `ruff check` (includes isort via `I` rules)
-- Target: Python 3.7+ (CI tests 3.7–3.13)
-- Docstrings: Google-style
-- All public APIs must have type annotations
-
-### Import Organization (Strict)
-
-```python
-# Import future modules
-from __future__ import annotations
-
-# Import built-in modules
-from pathlib import Path
-
-# Import third-party modules
-import pytest
-
-# Import local modules
-from dcc_mcp_core import ActionResultModel
-```
-
-## API Reference (What AI Agents Should Know)
-
-> **IMPORTANT**: Always prefer `python/dcc_mcp_core/__init__.py` over guessing imports.
-> That file lists every public symbol. Never import from internal paths like `dcc_mcp_core._core.*` directly.
-
-### Current Public API (Rust-backed, v0.12+)
-
-The public API is in `python/dcc_mcp_core/__init__.py`. Key domains:
-
-#### Actions System
-
-```python
-from dcc_mcp_core import (
-    ActionRegistry,       # Thread-safe registry: register/get/list actions
-    ActionDispatcher,     # Typed dispatch with validation
-    ActionValidator,      # Input parameter validation before execution
-    ActionPipeline,       # Middleware-style processing pipeline
-    ActionMetrics,        # Performance/execution metrics
-    ActionRecorder,       # Record/replay action executions
-    EventBus,             # Pub/sub lifecycle events
-    ActionResultModel,    # Structured result model
-    success_result,       # Factory: ActionResultModel(success=True, ...)
-    error_result,         # Factory: ActionResultModel(success=False, ...)
-    from_exception,       # Factory: wrap Python exception as result
-    validate_action_result,  # Normalize dict/str/None → ActionResultModel
-)
-```
-
-**ActionRegistry patterns:**
-
-```python
-reg = ActionRegistry()
-
-# Register an action
-reg.register(
-    name="create_sphere",
-    description="Create a polygon sphere",
-    category="geometry",
-    tags=["geo", "create"],
-    dcc="maya",
-    version="1.0.0",
-    input_schema='{"type": "object", "properties": {"radius": {"type": "number"}}}',
-)
-
-# Look up
-meta = reg.get_action("create_sphere")
-meta = reg.get_action("create_sphere", dcc_name="maya")  # scoped
-names = reg.list_actions_for_dcc("maya")
-all_actions = reg.list_actions()
-dccs = reg.get_all_dccs()
-
-# Batch registration (preferred over repeated register() calls for large sets)
-reg.register_batch([
-    {"name": "create_sphere", "category": "geometry", "dcc": "maya", "tags": ["create"]},
-    {"name": "delete_mesh",   "category": "edit",     "dcc": "maya", "tags": ["delete"]},
-    {"name": "create_cube",   "category": "geometry", "dcc": "blender"},
-])
-
-# Unregister (global removes from all DCCs; scoped removes only one DCC's entry)
-removed = reg.unregister("create_sphere")                  # global: True if found
-removed = reg.unregister("create_sphere", dcc_name="maya") # scoped to maya only
-
-# Search & discovery (all filters AND-ed; None / [] = no filter)
-results = reg.search_actions(category="geometry")                  # by category
-results = reg.search_actions(tags=["create", "mesh"])              # must have ALL tags
-results = reg.search_actions(category="geometry", dcc_name="maya") # category + DCC
-categories = reg.get_categories()                                  # sorted unique categories
-tags = reg.get_tags(dcc_name="maya")                               # sorted unique tags
-
-# Version-aware registry
-from dcc_mcp_core import SemVer, VersionedRegistry, VersionConstraint
-vreg = VersionedRegistry()
-vreg.register_versioned("my_action", dcc="maya", version="1.2.0")
-vreg.register_versioned("my_action", dcc="maya", version="2.0.0")
-result = vreg.resolve("my_action", dcc="maya", constraint=">=1.0.0")   # → version "2.0.0"
-result = vreg.resolve("my_action", dcc="maya", constraint="^1.0.0")    # → version "1.2.0"
-all_results = vreg.resolve_all("my_action", dcc="maya", constraint="*")  # all versions sorted
-latest = vreg.latest_version("my_action", dcc="maya")                  # → "2.0.0"
-versions = vreg.versions("my_action", dcc="maya")                      # → ["1.2.0", "2.0.0"]
-keys = vreg.keys()                                                      # → [("my_action", "maya")]
-removed = vreg.remove("my_action", dcc="maya", constraint="^1.0.0")    # → 1 (versions removed)
-```
-
-**ActionPipeline patterns:**
-
-```python
-from dcc_mcp_core import ActionRegistry, ActionDispatcher, ActionPipeline
-
-reg = ActionRegistry()
-reg.register("create_sphere", description="Create sphere", category="geometry")
-
-dispatcher = ActionDispatcher(reg)
-dispatcher.register_handler("create_sphere", lambda params: {"name": "sphere1"})
-
-pipeline = ActionPipeline(dispatcher)
-
-# Built-in middleware (add in desired order)
-pipeline.add_logging(log_params=True)         # tracing log before/after each action
-timing = pipeline.add_timing()                # measure per-action latency
-audit = pipeline.add_audit(record_params=True) # in-memory audit log
-rl = pipeline.add_rate_limit(max_calls=10, window_ms=1000)  # fixed-window rate limiter
-
-# Python callable hooks (flexible custom middleware)
-pipeline.add_callable(
-    before_fn=lambda action: print(f"before: {action}"),
-    after_fn=lambda action, success: print(f"after: {action} ok={success}"),
-)
-
-# Dispatch
-result = pipeline.dispatch("create_sphere", '{"radius": 1.0}')
-result["output"]          # {"name": "sphere1"}
-result["action"]          # "create_sphere"
-result["validation_skipped"]  # bool
-
-# Register handler directly on pipeline (mirrors ActionDispatcher)
-pipeline.register_handler("delete_sphere", lambda params: True)
-
-# Introspect middleware
-pipeline.middleware_count()   # int
-pipeline.middleware_names()   # ["logging", "timing", "audit", "rate_limit", "python_callable"]
-pipeline.handler_count()      # int
-
-# Query middleware state
-timing.last_elapsed_ms("create_sphere")  # int | None (milliseconds)
-audit.records()                           # list[dict] with action/success/error/timestamp_ms
-audit.records_for_action("create_sphere") # filtered records
-audit.record_count()                      # int
-audit.clear()                             # reset
-rl.call_count("create_sphere")            # int (calls in current window)
-rl.max_calls                              # int
-rl.window_ms                              # int
-```
-
-**ActionResultModel fields:**
-
-```python
-result = success_result(
-    message="Sphere created",
-    prompt="Consider adding materials or adjusting UVs",  # AI next-step hint
-    context={"object_name": "sphere1", "position": [0, 0, 0]}
-)
-result.success   # bool
-result.message   # str
-result.prompt    # Optional[str] — guidance for AI's next step
-result.error     # Optional[str] — error details (set when success=False)
-result.context   # dict — arbitrary structured data
-
-# Copy variants
-result.with_error("something failed")   # new result with success=False
-result.with_context(count=5, done=True) # new result with updated context
-result.to_dict()                        # -> dict
-```
-
-#### Skills System
-
-```python
-from dcc_mcp_core import (
-    SkillScanner,                    # Discovers SKILL.md directories (mtime-cached)
-    SkillWatcher,                    # File-watching auto-reload for live development
-    SkillMetadata,                   # Parsed skill metadata model
-    parse_skill_md,                  # Parse one skill directory → SkillMetadata
-    scan_skill_paths,                # Scan + return discovered paths
-    scan_and_load,                   # Scan + parse all → List[SkillMetadata]
-    scan_and_load_lenient,           # Same, but silently skip errors
-    resolve_dependencies,            # Resolve skill dependency graph
-    expand_transitive_dependencies,  # Full transitive closure
-    validate_dependencies,           # Validate dependency graph is acyclic
-)
-```
-
-```python
-from dcc_mcp_core import (
-    # Progressive loading (Skills-First)
-    SkillCatalog,                    # Manage discovered vs loaded skills
-    SkillSummary,                    # Lightweight skill summary for search results
-    create_skill_manager,            # One-call factory: env vars → server
-    get_app_skill_paths_from_env,    # Read DCC_MCP_{APP}_SKILL_PATHS + global
-    # Bundled skills (zero-config)
-    get_bundled_skills_dir,          # Absolute path to dcc_mcp_core/skills/ in wheel
-    get_bundled_skill_paths,         # Returns [bundled_dir] or [] (include_bundled=False)
-    # SkillMetadata new fields
-    ToolDeclaration,                 # Tool declaration with input_schema, annotations
-)
-```
-
-**Full skills pipeline:**
-
-```python
-# ─────────────────────────────────────────────────────────────
-# Skills-First (recommended): one-call setup
-# Bundled skills (dcc-diagnostics, workflow) are loaded automatically.
-# ─────────────────────────────────────────────────────────────
-import os
-os.environ["DCC_MCP_MAYA_SKILL_PATHS"] = "/studio/maya-skills"  # or DCC_MCP_SKILL_PATHS
-
-from dcc_mcp_core import create_skill_manager, McpHttpConfig
-
-server = create_skill_manager("maya", McpHttpConfig(port=8765))
-handle = server.start()
-# Agents connect → search_skills → load_skill → tools/call
-
-# On-demand skill discovery (agent-driven):
-# 1. tools/list → 6 core tools + __skill__<name> stubs for every unloaded skill
-#    Core: find_skills, list_skills, get_skill_info, load_skill, unload_skill, search_skills
-# 2. search_skills(query="modeling") → compact summary: name [status] (N tools: ...) — desc
-# 3. load_skill("maya-bevel") → registers tools + handlers, sends tools/list_changed
-# 4. tools/list → new skill tools visible with full input schemas
-# 5. tools/call maya_bevel__bevel {offset: 0.1} → runs scripts/bevel.py
-
-# ─────────────────────────────────────────────────────────────
-# Bundled skills — zero-config, shipped inside the wheel
-# ─────────────────────────────────────────────────────────────
-from dcc_mcp_core import get_bundled_skills_dir, get_bundled_skill_paths
-
-print(get_bundled_skills_dir())   # .../site-packages/dcc_mcp_core/skills
-paths = get_bundled_skill_paths() # [".../dcc_mcp_core/skills"]  — include in search path
-# Opt-out: get_bundled_skill_paths(include_bundled=False) → []
-
-# DCC adapters call this automatically; DCC adapter search-path priority:
-# extra_paths > builtin DCC skills > DCC_MCP_{APP}_SKILL_PATHS > DCC_MCP_SKILL_PATHS
-# > bundled core skills > platform default skills dir
-
-# ─────────────────────────────────────────────────────────────
-# SkillMetadata fields (v0.12.10+)
-# ─────────────────────────────────────────────────────────────
-# s.name, s.description, s.dcc, s.version, s.tags
-# s.search_hint                 # keyword hint for search_skills (SKILL.md search-hint:)
-# s.license, s.compatibility    # agentskills.io standard
-# s.allowed_tools               # agent permission list (e.g. ["Bash", "Read"])
-# s.metadata                    # arbitrary KV + ClawHub openclaw.*
-# s.tools (List[ToolDeclaration]) # MCP tool declarations with schemas
-# s.scripts (List[str])         # auto-discovered script paths
-# s.skill_path, s.depends, s.metadata_files
-
-# SkillSummary fields (from find_skills / list_skills):
-# s.name, s.description, s.search_hint, s.version, s.dcc, s.tags
-# s.tool_count, s.tool_names, s.loaded
-
-# ─────────────────────────────────────────────────────────────
-# Manual setup (advanced / custom handlers)
-# ─────────────────────────────────────────────────────────────
-paths = get_app_skill_paths_from_env("maya")  # DCC_MCP_MAYA_SKILL_PATHS + DCC_MCP_SKILL_PATHS
-skills, _ = scan_and_load_lenient(extra_paths=paths, dcc_name="maya")
-```
-
-#### MCP Protocol Types
-
-```python
-from dcc_mcp_core import (
-    ToolDefinition, ToolAnnotations,
-    ResourceDefinition, ResourceAnnotations, ResourceTemplateDefinition,
-    PromptDefinition, PromptArgument,
-    DccInfo, DccCapabilities, DccError, DccErrorCode,
-)
-
-# Build MCP tool definition
-tool = ToolDefinition(
-    name="create_sphere",
-    description="Create a polygon sphere in the DCC scene",
-    input_schema='{"type": "object", "properties": {"radius": {"type": "number"}}, "required": ["radius"]}',
-    annotations=ToolAnnotations(
-        title="Create Sphere",
-        read_only_hint=False,
-        destructive_hint=False,
-        idempotent_hint=False,
-    ),
-)
-```
-
-#### Transport Layer
-
-```python
-from dcc_mcp_core import (
-    TransportManager,    # Connection pool manager
-    TransportAddress, TransportScheme, RoutingStrategy,
-    IpcListener,         # Server-side IPC listener
-    ListenerHandle,      # Handle returned by IpcListener.into_handle()
-    FramedChannel,       # Message-framed IPC channel
-    connect_ipc,         # Client: connect to IPC server
-)
-
-# Server — bind + accept pattern
-addr = TransportAddress.tcp("127.0.0.1", 0)
-listener = IpcListener.bind(addr)
-local_addr = listener.local_address()   # get assigned port
-channel = listener.accept()             # blocks until client connects
-
-# Client
-channel = connect_ipc(local_addr, timeout_ms=10000)
-
-# FramedChannel RPC — use .call() for synchronous request/reply
-result = channel.call("execute_python", b'cmds.sphere()')
-# result keys: "id", "success" (bool), "payload" (bytes), "error" (str|None)
-if result["success"]:
-    print(result["payload"].decode())
-else:
-    raise RuntimeError(result["error"])
-
-# Low-level: send_request + recv for async/multiplexed patterns
-req_id = channel.send_request("execute_python", params=b'cmds.sphere()')
-msg = channel.recv(timeout_ms=10000)   # {"type": "response", "id": req_id, ...}
-
-# One-way notifications
-channel.send_notify("scene_changed", data=b'{"scene": "shot01.ma"}')
-
-# Heartbeat check
-rtt_ms = channel.ping()                 # round-trip time in ms
-channel.shutdown()                      # graceful close
-
-# Production: pooled + circuit breaker + auto-registration
-mgr = TransportManager("/tmp/dcc-mcp")
-instance_id, listener = mgr.bind_and_register("maya", version="2025")
-entry = mgr.find_best_service("maya")   # best available Maya instance
-session_id = mgr.get_or_create_session("maya", entry.instance_id)
-```
-
-#### MCP HTTP Server + Gateway
-
-```python
-from dcc_mcp_core import ActionRegistry, McpHttpServer, McpHttpConfig, McpServerHandle
-
-# Build an action registry
-registry = ActionRegistry()
-registry.register(
-    "get_scene_info",
-    description="Get information about the current DCC scene",
-    category="scene", tags=["query"], dcc="maya", version="1.0.0",
-)
-
-# ── Approach A: standalone instance (no gateway) ─────────────────────────────
-config = McpHttpConfig(
-    port=8765,              # use 0 for random available port
-    server_name="maya-mcp",
-    server_version="1.0.0",
-    enable_cors=False,      # set True for browser-based MCP clients
-    request_timeout_ms=30000,
-)
-server = McpHttpServer(registry, config)
-handle = server.start()
-print(handle.mcp_url())    # "http://127.0.0.1:8765/mcp"
-print(handle.is_gateway)   # False — not participating in gateway
-handle.shutdown()
-
-# ── Approach B: join gateway competition (multi-DCC) ─────────────────────────
-# First process to bind gateway_port=9765 becomes the gateway.
-# All others are plain instances that register themselves in FileRegistry.
-config = McpHttpConfig(port=0, server_name="maya-mcp")
-config.gateway_port = 9765   # join the gateway competition; 0 = disabled
-config.dcc_type = "maya"     # reported in FileRegistry for routing
-config.dcc_version = "2025"  # optional
-config.scene = "/proj/shot.ma"  # optional: improves dcc_type+scene routing
-
-server = McpHttpServer(registry, config)
-handle = server.start()
-print(handle.is_gateway)    # True if THIS process won the gateway port
-print(handle.mcp_url())     # direct MCP URL for this DCC instance
-# Gateway at http://127.0.0.1:9765/ exposes:
-#   GET  /instances          → JSON list of all live DCC instances
-#   POST /mcp                → meta-tools: list_dcc_instances, connect_to_dcc
-#   POST /mcp/{instance_id}  → transparent proxy to that instance
-#   POST /mcp/dcc/{dcc_type} → proxy to best instance of that type
-
-# McpServerHandle is an alias for ServerHandle in __init__.py
-from dcc_mcp_core import McpServerHandle  # same type
-```
-
-#### Process Management
-
-```python
-from dcc_mcp_core import (
-    PyDccLauncher,           # Launch DCC processes
-    PyProcessMonitor,        # Track running DCC processes
-    PyProcessWatcher,        # Auto-restart on crash
-    PyCrashRecoveryPolicy,   # Crash recovery configuration
-    ScriptResult,            # Result of a script execution
-    ScriptLanguage,          # Enum: Python, MEL, MaxScript, etc.
-)
-
-launcher = PyDccLauncher(dcc_type="maya", version="2025")
-process = launcher.launch(script_path="/startup.py", working_dir="/project")
-
-watcher = PyProcessWatcher(
-    recovery_policy=PyCrashRecoveryPolicy(max_restarts=3, cooldown_sec=10)
-)
-watcher.watch(process)
-```
-
-#### Bridge System (DCC Inter-Protocol Bridging)
-
-```python
-from dcc_mcp_core import BridgeContext, BridgeRegistry, register_bridge, get_bridge_context
-
-# BridgeRegistry manages named protocol bridges (e.g., RPyC ↔ MCP, HTTP ↔ IPC)
-registry = BridgeRegistry()
-register_bridge("rpyc", BridgeContext(name="rpyc", description="RPyC bridge"))
-ctx = get_bridge_context("rpyc")  # retrieve by name
-```
-
-#### Scene Data Model
-
-```python
-from dcc_mcp_core import (
-    BoundingBox,       # Axis-aligned bounding box (min/max corner vectors)
-    FrameRange,        # Animation frame range (start, end, step)
-    ObjectTransform,   # 4x4 transform matrix + decomposition (translate, rotate, scale)
-    SceneNode,         # Hierarchical scene node (path, transform, children)
-    SceneObject,       # Full scene object (mesh, material, transform references)
-    RenderOutput,      # Render result metadata (path, format, resolution)
-)
-
-# BoundingBox usage
-bbox = BoundingBox(min_x=0, min_y=0, min_z=0, max_x=1, max_y=1, max_z=1)
-# FrameRange for animation queries
-frames = FrameRange(start=1, end=24, step=1)
-# ObjectTransform for spatial queries
-xform = ObjectTransform(translate=[0, 5, 0], rotate=[0, 0, 0, 1], scale=[1, 1, 1])
-```
-
-#### Serialization
-
-```python
-from dcc_mcp_core import SerializeFormat, serialize_result, deserialize_result
-
-# Serialize ActionResultModel to bytes/string for transport or storage
-data = serialize_result(result, fmt=SerializeFormat.JSON)
-restored = deserialize_result(data, fmt=SerializeFormat.JSON)
-```
-
-#### Other Modules
-
-```python
-# Sandbox security
-from dcc_mcp_core import SandboxContext, SandboxPolicy, InputValidator, AuditEntry, AuditLog
-
-# Shared memory (LZ4 compressed)
-from dcc_mcp_core import PyBufferPool, PySharedBuffer, PySharedSceneBuffer, PySceneDataKind
-
-# Screen capture
-from dcc_mcp_core import Capturer, CaptureFrame, CaptureResult
-
-# Telemetry
-from dcc_mcp_core import TelemetryConfig, RecordingGuard, ActionMetrics, ActionRecorder
-from dcc_mcp_core import is_telemetry_initialized, shutdown_telemetry
-
-# USD bridge
-from dcc_mcp_core import UsdStage, UsdPrim, SdfPath, VtValue, SceneInfo, SceneStatistics
-from dcc_mcp_core import scene_info_json_to_stage, stage_to_scene_info_json
-
-# Type wrappers (for RPyC safe serialization)
-from dcc_mcp_core import wrap_value, unwrap_value, unwrap_parameters
-from dcc_mcp_core import BooleanWrapper, FloatWrapper, IntWrapper, StringWrapper
-
-# Platform utilities
-from dcc_mcp_core import (
-    get_config_dir, get_data_dir, get_log_dir, get_platform_dir,
-    get_actions_dir, get_skills_dir, get_skill_paths_from_env, mpu_to_units, units_to_mpu,
-)
-
-# Service registry
-from dcc_mcp_core import ServiceEntry, ServiceStatus
-```
-
-#### Pure-Python Modules (no _core dependency)
-
-These modules provide reusable building blocks for DCC adapters. They don't depend on the Rust `_core` extension and can be imported in any Python environment.
-
-```python
-# ── DCC Server Base ──────────────────────────────────────────────────────────
-from dcc_mcp_core.server_base import DccServerBase
-
-# Reusable base class for ALL DCC adapters. Provides:
-# - Skill search path collection (per-app env var → global → bundled)
-# - register_builtin_actions(), list_skills(), load_skill(), unload_skill()
-# - find_skills(), search_actions(), get_skill_categories(), get_skill_tags()
-# - Hot-reload: enable_hot_reload(), disable_hot_reload()
-# - Gateway: is_gateway, gateway_url, update_gateway_metadata()
-# - Lifecycle: start() → McpServerHandle, stop(), is_running, mcp_url
-#
-# Subclass with just dcc_name + builtin_skills_dir:
-class BlenderMcpServer(DccServerBase):
-    def __init__(self, port=8765, **kwargs):
-        super().__init__(dcc_name="blender", builtin_skills_dir=Path(__file__).parent / "skills", port=port, **kwargs)
-
-# ── Gateway Election ─────────────────────────────────────────────────────────
-from dcc_mcp_core.gateway_election import DccGatewayElection
-
-# Automatic gateway failover when primary becomes unreachable.
-# Background daemon thread: probes /health → counts failures → first-wins election
-election = DccGatewayElection(dcc_name="blender", server=blender_server, gateway_port=9765)
-election.start()   # background thread
-election.stop()    # graceful shutdown
-election.get_status()  # {"running": bool, "consecutive_failures": int, ...}
-
-# ── Skill Hot-Reload ─────────────────────────────────────────────────────────
-from dcc_mcp_core.hotreload import DccSkillHotReloader
-
-# Wraps SkillWatcher for automatic skill reload on file changes
-reloader = DccSkillHotReloader(dcc_name="blender", server=blender_server)
-reloader.enable(["/path/to/skills"], debounce_ms=300)
-reloader.reload_now()   # manual trigger
-reloader.disable()
-reloader.get_stats()    # {"enabled": bool, "watched_paths": [...], "reload_count": int}
-
-# ── Factory (singleton helper) ───────────────────────────────────────────────
-from dcc_mcp_core.factory import create_dcc_server, make_start_stop, get_server_instance
-
-# Thread-safe singleton DCC server creation
-server = create_dcc_server(instance_holder=[None], lock=threading.Lock(), server_class=MyServer, port=8765)
-
-# Generate (start_server, stop_server) function pairs
-start_server, stop_server = make_start_stop(MyServer)
-
-# ── DCC Diagnostic Handlers ──────────────────────────────────────────────────
-from dcc_mcp_core.dcc_server import register_diagnostic_handlers
-
-# Registers 3 IPC action handlers: get_audit_log, get_action_metrics, dispatch_action
-# Also sets DCC_MCP_IPC_ADDRESS env var for skill subprocesses
-register_diagnostic_handlers(server, dispatcher=dispatcher, dcc_name="blender")
-
-# ── Skill Script Helpers ─────────────────────────────────────────────────────
-from dcc_mcp_core.skill import (
-    skill_entry, skill_success, skill_error, skill_warning, skill_exception, run_main,
-    get_bundled_skills_dir, get_bundled_skill_paths,
-)
-
-# @skill_entry: decorator with standard error handling (ImportError/Exception/BaseException)
-@skill_entry
-def my_tool(name: str = "world") -> dict:
-    return skill_success(f"Created {name}", prompt="Check viewport.", name=name)
-
-# Result builders: skill_success, skill_error, skill_warning, skill_exception
-# All return dicts compatible with ActionResultModel
-# run_main: execute function and print JSON result to stdout (exit 0/1)
-```
-
-#### Constants
-
-```python
-from dcc_mcp_core import (
-    APP_NAME,            # "dcc-mcp"
-    APP_AUTHOR,          # "dcc-mcp"
-    DEFAULT_DCC,         # "python"
-    DEFAULT_LOG_LEVEL,   # "DEBUG"
-    DEFAULT_MIME_TYPE,   # "text/plain"
-    DEFAULT_VERSION,     # "1.0.0"
-    ENV_SKILL_PATHS,     # "DCC_MCP_SKILL_PATHS"
-    ENV_LOG_LEVEL,       # "MCP_LOG_LEVEL"
-    SKILL_METADATA_FILE, # "SKILL.md"
-    SKILL_METADATA_DIR,  # "metadata"
-    SKILL_SCRIPTS_DIR,   # "scripts"
-)
-```
-
-### Legacy APIs (DO NOT USE in new code)
-
-These APIs were removed in v0.12+:
-- ~~`ActionManager`~~ → Use `ActionRegistry` + `ActionDispatcher`
-- ~~`Action` base class~~ → Actions are registered via `ActionRegistry`
-- ~~`Middleware` / `MiddlewareChain`~~ → Use `ActionPipeline` with middleware context
-- ~~`create_action_manager()`~~ → Use `ActionRegistry()` directly
-- ~~`create_action_manager()`~~ → Use `create_skill_manager(app_name)` (Skills-First) or `ActionRegistry()` directly
-- ~~`LoggingMiddleware` / `PerformanceMiddleware`~~ → Use `ActionMetrics` + `EventBus`
-
-## DCC Ecosystem Architecture
-
-> **Key insight**: `dcc-mcp-core` is the **only** dependency a DCC-specific package needs.
-> There is no need for `dcc-mcp-ipc` or any other separate IPC library.
-
-### Full Stack (from DCC process to AI agent)
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│  MCP Host (Claude Desktop / OpenClaw / any MCP-compatible agent) │
-│  Connects via:  http://localhost:8765/mcp  (Streamable HTTP)     │
-└────────────────────────────┬────────────────────────────────────┘
-                             │ MCP 2025-03-26 Streamable HTTP
-┌────────────────────────────▼────────────────────────────────────┐
-│  DCC application process (Maya / Blender / Houdini / 3ds Max)   │
-│                                                                  │
-│  # Python code running inside DCC:                              │
-│  from dcc_mcp_core import ActionRegistry, McpHttpServer          │
-│  from dcc_mcp_core import McpHttpConfig, DeferredExecutor        │
-│                                                                  │
-│  registry = ActionRegistry()                                     │
-│  # register skills/actions ...                                   │
-│                                                                  │
-│  server = McpHttpServer(registry, McpHttpConfig(port=8765))      │
-│  handle = server.start()   # non-blocking                       │
-│  # → handle.mcp_url() == "http://127.0.0.1:8765/mcp"           │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-### Why `dcc-mcp-ipc` is no longer needed
-
-`dcc-mcp-ipc` was a separate Python project that provided IPC transport between a
-DCC process and an external MCP gateway. **Everything it provided is now in `dcc-mcp-core`:**
-
-| dcc-mcp-ipc feature | dcc-mcp-core equivalent |
-|---------------------|------------------------|
-| IPC Named Pipe / Unix Socket | `IpcListener` + `FramedChannel` in `dcc-mcp-transport` |
-| TCP transport | `TransportAddress.tcp()` + `connect_ipc()` |
-| Instance routing / load balancing | `InstanceRouter` + `RoutingStrategy` in `dcc-mcp-transport` |
-| Service discovery | `ServiceRegistry` + `TransportManager` |
-| MCP HTTP gateway | `McpHttpServer` in `dcc-mcp-http` ← **new in v0.12.7** |
-
-With `McpHttpServer`, the DCC process **is** the MCP server — no external gateway needed.
-
-### DCC-specific packages (`dcc-mcp-maya`, `dcc-mcp-blender`, etc.)
-
-Upper-layer DCC packages only need to:
-
-1. **Import `dcc_mcp_core`** — no other dependency
-2. **Register DCC-specific actions** via `ActionRegistry.register()` or SKILL.md
-3. **Start `McpHttpServer`** — MCP host connects directly
-4. **Optionally use `DeferredExecutor`** for main-thread safety (see below)
-
-```python
-# dcc-mcp-maya minimal example
-from dcc_mcp_core import ActionRegistry, McpHttpServer, McpHttpConfig
-import maya.utils  # DCC-specific
-
-registry = ActionRegistry()
-# Load skills via DCC_MCP_SKILL_PATHS env var or register manually
-
-server = McpHttpServer(registry, McpHttpConfig(port=8765, server_name="maya-mcp"))
-handle = server.start()
-# Claude Desktop connects to http://127.0.0.1:8765/mcp
-```
-
-### DCC Main-Thread Safety (`DeferredExecutor`)
-
-All major DCC applications require scene API calls on their **main thread**.
-HTTP requests arrive on Tokio worker threads. Use `DeferredExecutor` to bridge:
-
-```python
-from dcc_mcp_core._core import DeferredExecutor  # Rust-backed
-import maya.utils
-
-# Create executor (on DCC main thread at startup)
-executor = DeferredExecutor(queue_depth=64)
-dcc_handle = executor.handle()  # cloneable, Send+Sync
-
-# In your DCC event loop / timer callback:
-def maya_tick():
-    executor.poll_pending()   # runs queued tasks on main thread
-    maya.utils.executeDeferred(maya_tick)  # reschedule
-
-maya.utils.executeDeferred(maya_tick)
-
-# Pass dcc_handle to McpHttpServer for thread-safe dispatch:
-server = McpHttpServer(registry, config).with_executor(dcc_handle)
-handle = server.start()
-```
-
-> **When is `DeferredExecutor` needed?**
-> - Maya: always (cmds, OpenMaya require main thread)
-> - Blender: always (bpy requires main thread)
-> - Houdini: most API calls require main thread
-> - 3ds Max: most API calls require main thread
-> - Testing / non-DCC Python: not needed (omit `.with_executor()`)
-
-## Skills System (Deep Dive)
-
-Skills allow zero-code registration of scripts as MCP tools.
-
-### Directory Layout
-
-```
-my-skill/
-├── SKILL.md          # Required: YAML frontmatter + markdown description
-├── scripts/          # Required: one file per action
-│   ├── create_sphere.py
-│   ├── batch_rename.mel
-│   └── export_fbx.bat
-├── references/       # Optional: supplementary docs (agentskills.io standard)
-│   ├── REFERENCE.md
-│   └── FORMS.md
-├── assets/           # Optional: templates, images, data files
-│   └── lookup.json
-└── metadata/         # Optional: dependency declarations
-    └── depends.md    # YAML list of dependency skill names
-```
-
-### SKILL.md Format
-
-```yaml
 ---
-name: maya-geometry           # Required: unique identifier (used in action names)
-description: "Maya geometry creation and modification tools"
-allowed-tools: Bash Read     # Space-separated (agentskills.io spec), NOT a YAML list
-tags: ["maya", "geometry"]    # Classification tags
-dcc: maya                     # Target DCC application
-version: "1.0.0"              # Semantic version
-depends: ["other-skill"]      # Names of required skills
-license: MIT                  # Optional: license identifier
-compatibility: "Maya 2024+"  # Optional: environment requirements
+
+## Build & Test — Essential Commands
+
+> All commands require `vx` prefix. Install: https://github.com/loonghao/vx
+
+```bash
+vx just dev          # Build dev wheel (run this before any Python tests)
+vx just test         # Run all Python integration tests
+vx just preflight    # Pre-commit: cargo check + clippy + fmt + test-rust
+vx just lint-fix     # Auto-fix all Rust + Python lint issues
+vx just test-cov     # Coverage report — find untested paths before adding features
+vx just ci           # Full CI pipeline
+```
+
+If a symbol appears in `__init__.py` but Python can't import it → run `vx just dev` first.
+
 ---
-# Human-readable description (markdown body)
-```
 
-### Action Naming
+## Traps — Read Before Writing Code
 
-Each script in `scripts/` becomes an action named `{skill_name}__{script_stem}`:
-- `maya-geometry/scripts/create_sphere.py` → `maya_geometry__create_sphere`
-- `maya-geometry/scripts/batch_rename.mel` → `maya_geometry__batch_rename`
+These are the most common mistakes. Each takes less than 10 seconds to check.
 
-Note: hyphens in skill names are replaced by underscores.
-
-### Environment Variable
-
-```bash
-# Unix/macOS
-export DCC_MCP_SKILL_PATHS="/path/to/skills1:/path/to/skills2"
-
-# Windows
-set DCC_MCP_SKILL_PATHS=C:\path\skills1;C:\path\skills2
-```
-
-### Supported Script Types
-
-| Extension | Type | Execution |
-|-----------|------|-----------|
-| `.py` | Python | `subprocess` with system Python |
-| `.mel` | MEL (Maya) | Via DCC adapter |
-| `.ms` | MaxScript | Via DCC adapter |
-| `.bat`, `.cmd` | Batch | `cmd /c` |
-| `.sh`, `.bash` | Shell | `bash` |
-| `.ps1` | PowerShell | `powershell -File` |
-| `.js`, `.jsx` | JavaScript | `node` |
-
-See `examples/skills/` for **11 complete examples**: hello-world, maya-geometry, maya-pipeline, git-automation, ffmpeg-media, imagemagick-tools, usd-tools, clawhub-compat, multi-script, dcc-diagnostics, workflow.
-
-## Adding New Python-Accessible Functions/Classes
-
-When adding a new public API (function or class exposed to Python):
-
-1. **Implement in Rust**: Add to the appropriate `crates/dcc-mcp-*/src/` crate
-2. **Add PyO3 bindings**: Create/update the crate's `python.rs` module with `#[pymethods]` / `#[pyclass]`
-3. **Register in entry point**: Add to `src/lib.rs` in the corresponding `register_*()` function
-4. **Re-export in Python**: Add to `python/dcc_mcp_core/__init__.py` and `__all__`
-5. **Update type stubs**: If needed, update `python/dcc_mcp_core/_core.pyi`
-6. **Add tests**: Create/update `tests/test_<module>.py`
-
-Example PyO3 binding pattern:
-
-```rust
-// crates/dcc-mcp-actions/src/python.rs
-use pyo3::prelude::*;
-
-#[pyclass]
-pub struct ActionRegistry { /* ... */ }
-
-#[pymethods]
-impl ActionRegistry {
-    #[new]
-    fn new() -> Self { ActionRegistry { /* ... */ } }
-
-    fn register(&self, name: String, description: String) -> PyResult<()> {
-        // ...
-    }
-}
-
-pub fn register_actions(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_class::<ActionRegistry>()?;
-    Ok(())
-}
-```
-
-## Commit & PR Guidelines
-
-- Use [Conventional Commits](https://www.conventionalcommits.org/)
-- Prefixes: `feat:`, `fix:`, `docs:`, `chore:`, `ci:`, `refactor:`, `test:`
-- Breaking changes: `feat!:` or add `BREAKING CHANGE:` footer
-- **Never manually bump version or edit CHANGELOG.md** — Release Please handles this
-- Always run `vx just preflight` before committing
-- PR title format: follow Conventional Commits (e.g., `docs: enhance AI agent guidance`)
-
-## Common Pitfalls for AI Agents
-
-1. **Don't import from internal paths**: `dcc_mcp_core.actions.base`, `dcc_mcp_core._core.*` directly — these are implementation details. Always use the public API from `dcc_mcp_core`.
-
-2. **Don't manually bump version numbers** — handled exclusively by Release Please via `release-please-config.json`.
-
-3. **Don't add runtime Python dependencies** — this project has zero runtime deps by design. Everything is in Rust.
-
-4. **Rust changes need Python binding updates**: If you modify a Rust struct exposed via PyO3, update the crate's `python.rs`, register it in `src/lib.rs`, re-export in `__init__.py`, and update `_core.pyi` stubs.
-
-5. **Test with Python bindings feature flag**: `cargo test --workspace --features python-bindings`
-
-6. **Always use `vx` prefix**: `vx just test` not `pytest`, `vx just lint` not `ruff check`.
-
-7. **Don't use legacy APIs**: `ActionManager`, `Action` base class, `create_action_manager()`, `MiddlewareChain` — all removed in v0.12+.
-
-8. **Skills directory convention**: The env var is `DCC_MCP_SKILL_PATHS` (not `SKILL_PATHS`, not `DCC_SKILL_PATHS`).
-
-9. **Action naming**: When building tools on top of this library, use the `{skill_name}__{script_stem}` naming pattern (double underscore separator).
-
-10. **`_core.pyi` is the authoritative stub**: When unsure of parameter names or types, read `python/dcc_mcp_core/_core.pyi` rather than guessing.
-
-11. **`IpcListener.bind(addr)`** creates the listener (not `.new()`); `.accept()` returns a `FramedChannel`. Use `into_handle()` for `ListenerHandle` with tracking.
-
-12. **`FramedChannel.call()` is the primary RPC helper**: `channel.call(method, params_bytes, timeout_ms)` sends a request and waits for the matching response atomically. Use `send_request()` + `recv()` only for multiplexed async patterns.
-
-13. **`McpServerHandle` vs `ServerHandle`**: `server.start()` returns a `ServerHandle`; it is re-exported as `McpServerHandle` in `__init__.py`. Both refer to the same class.
-
-14. **`McpHttpServer` requires an `ActionRegistry`**: The HTTP server reads tool names/descriptions from the registry. Register all actions before calling `server.start()`.
-
-15. **DCC main-thread safety with `McpHttpServer`**: By default, tool handlers run on Tokio worker threads. If your DCC requires main-thread execution (Maya, Blender, Houdini), attach a `DeferredExecutor` via `McpHttpServer.with_executor(handle)` and call `executor.poll_pending()` from your DCC event loop. Omitting this in Maya/Blender **will crash** the DCC.
-
-16. **Do NOT use `dcc-mcp-ipc` in new code**: That project is superseded by `dcc-mcp-core`. All IPC transport, routing, and HTTP serving is provided by this library. New DCC integrations should only depend on `dcc-mcp-core`.
-
-17. **MCP specification version awareness**: `McpHttpServer` implements the 2025-03-26 MCP spec (Streamable HTTP). The 2025-06-18 spec adds **Structured Tool Output**, **Elicitation** (server asks user for info), **Resource Links in tool results**, and **removes JSON-RPC batching**; `MCP-Protocol-Version` header becomes mandatory. The 2025-11-25 spec adds icon metadata, experimental **Tasks** (persistent request tracking), Sampling with tool calls, URL pattern requests, OAuth Client ID Metadata Document, and JSON Schema 2020-12. The 2026 roadmap focuses on transport scalability (stateless horizontal scaling), agent communication (Tasks lifecycle), governance maturation (working groups), and enterprise readiness (extensions). Do NOT implement these from scratch; wait for API additions to `McpHttpServer`.
-
-18. **`scan_and_load` with `extra_paths`**: When calling `scan_and_load(extra_paths=[...], dcc_name="maya")`, both arguments are keyword-only. Do not pass `extra_paths` as a positional argument — use `extra_paths=["/path"]` explicitly.
-
-19. **Gateway competition is opt-in**: Set `config.gateway_port = 9765` to join the multi-DCC gateway. Without this, `McpHttpServer` behaves exactly as before (no FileRegistry, no gateway). `handle.is_gateway` is `False` by default.
-
-20. **Never manually edit `CHANGELOG.md` or bump version numbers** in `Cargo.toml`, `pyproject.toml`, or `.release-please-manifest.json`. Release Please reads Conventional Commits from merged PRs and handles all version bumps and changelog generation automatically.
-
-21. **SKILL.md `allowed-tools` is space-separated** (agentskills.io spec): `allowed-tools: Bash(git:*) Bash(jq:*) Read` — NOT a YAML list `["Bash", "Read"]`. The `name` field must match the parent directory name.
-
-22. **DccServerBase provides all adapter boilerplate**: When building a new DCC adapter, subclass `DccServerBase` with just `dcc_name` and `builtin_skills_dir`. Don't reimplement skill loading, hot-reload, gateway election, or lifecycle management.
-
-23. **MCP 2025-06-18 removes JSON-RPC batching**: If you were planning to use batching, note that it was removed in the 2025-06-18 spec. Also, `MCP-Protocol-Version` header becomes mandatory — handled internally by `McpHttpServer`.
-
-24. **`ActionDispatcher` has new introspection methods**: `has_handler(name)`, `handler_count()`, `handler_names()`, `remove_handler(name)`, and `skip_empty_schema_validation` property. Use these instead of manual bookkeeping.
-
-25. **`BridgeRegistry` and `BridgeContext`** are available for DCC inter-protocol bridging. Use `register_bridge(name, ctx)` to register a named bridge and `get_bridge_context(name)` to retrieve it. Don't build custom bridge registries.
-
-26. **Scene data model types are available**: `BoundingBox`, `FrameRange`, `ObjectTransform`, `SceneNode`, `SceneObject`, `RenderOutput` — use these for structured scene data instead of raw dicts. `BoundingBox` is `Optional` — check for `None` before using.
-
-27. **`serialize_result()` / `deserialize_result()`** for transport-safe ActionResultModel serialization. Use `SerializeFormat.JSON` or `SerializeFormat.MESSAGEPACK` explicitly — don't use `json.dumps()` on ActionResultModel directly.
-
-28. **SKILL.md `references/` directory is now standard** (agentskills.io spec): Place supplementary docs (REFERENCE.md, FORMS.md) in `references/` rather than `metadata/`. The `metadata/` directory is for dependency declarations only. Keep main SKILL.md under 500 lines and move detailed content to `references/`.
-
-29. **MCP 2026 Roadmap**: The MCP project has shifted from version-release milestones to **priority-area working groups**. Four pillars: (1) Transport evolution — stateless horizontal scaling, `.well-known` server discovery; (2) Agent communication — Tasks lifecycle (retry, expiry); (3) Governance maturation — contributor ladder, delegation model; (4) Enterprise readiness — audit, SSO, gateway, config portability (as extensions, not core spec changes). New transport methods are NOT planned — only evolution of existing Streamable HTTP.
-
-## Debugging & Diagnostics
-
-### Build Issues
-
-```bash
-# Check all crates compile
-vx just check
-
-# Verbose Rust build
-cargo build --workspace --features python-bindings 2>&1 | head -50
-
-# Python import check after build
-vx just dev
-python -c "import dcc_mcp_core; print(dcc_mcp_core.__version__)"
-```
-
-### Test Failures
-
-```bash
-# Verbose test output
-vx just test -- -v -s
-
-# Run a specific test by name
-vx just test -- -k "test_scan_and_load" -v
-
-# Check test coverage gaps
-vx just test-cov
-```
-
-### Type Stub Issues
-
-If Python type checkers report errors about `_core`:
-```bash
-# Stubs are in python/dcc_mcp_core/_core.pyi
-# They're manually maintained — check if your new symbol is listed
-grep "SkillMetadata" python/dcc_mcp_core/_core.pyi
-```
-
-## CI/CD
-
-- Main branch is protected; all PRs must pass CI
-- CI runs: `preflight` → `install` → `test` → `lint-py`
-- CI matrix: Python 3.7, 3.9, 3.11, 3.13 on Linux/macOS/Windows
-- PyPI publishing uses Trusted Publishing (no tokens needed)
-- Documentation deploys to GitHub Pages via VitePress
-- `.agents/` directory is gitignored — use `git add -f` for skill files there
-
-## AI Integration Patterns
-
-These patterns show how AI agents should use this library. Copy and adapt them.
-
-### Pattern 1: Skills-First — one call setup (recommended)
-
+**`scan_and_load` returns a 2-tuple — always unpack:**
 ```python
-import os
-from dcc_mcp_core import create_skill_manager, McpHttpConfig
-
-# Set per-app skill paths (or use global DCC_MCP_SKILL_PATHS)
-os.environ["DCC_MCP_MAYA_SKILL_PATHS"] = "/opt/maya-skills"
-
-# One call: creates registry + dispatcher + catalog + discovers skills + server
-server = create_skill_manager(
-    "maya",                           # app name (used for env var, server name)
-    McpHttpConfig(port=8765),         # optional config
-    extra_paths=["/extra/skills"],    # optional extra paths
-)
-handle = server.start()
-print(f"Maya MCP server: {handle.mcp_url()}")
-
-# Agents connect and use on-demand skill discovery:
-# → search_skills(query="maya") to find relevant skills
-# → load_skill("maya-bevel") to activate
-# → tools/call maya_bevel__bevel to execute
-handle.shutdown()
+# ✓
+skills, skipped = scan_and_load(dcc_name="maya")
+# ✗ iterating gives (list, list), not skill objects
 ```
 
-### Pattern 2: Call a DCC action and return structured result
-
+**`success_result` / `error_result` — kwargs go into context, not a `context=` kwarg:**
 ```python
-from dcc_mcp_core import (
-    connect_ipc, TransportAddress,
-    success_result, error_result, from_exception,
-)
-
-def call_maya_command(pid: int, python_code: str):
-    addr = TransportAddress.default_local("maya", pid)
-    channel = connect_ipc(addr)
-    try:
-        # Primary RPC pattern: .call() handles request/response atomically
-        result = channel.call("execute_python", python_code.encode(), timeout_ms=10000)
-        if result["success"]:
-            payload = result.get("payload", b"")
-            decoded = payload.decode() if isinstance(payload, bytes) else str(payload)
-            return success_result(
-                decoded,
-                prompt="Command executed. Check result and decide next step.",
-            )
-        else:
-            return error_result(
-                "DCC script failed",
-                result.get("error", "Unknown error"),
-                possible_solutions=["Check Maya is running", "Verify syntax"],
-            )
-    except Exception as e:
-        return from_exception(str(e), message="IPC call failed", include_traceback=True)
-    finally:
-        channel.shutdown()
+# ✓
+result = success_result("done", prompt="hint", count=5)
+# result.context == {"count": 5}
 ```
 
-### Pattern 3: Validate action inputs before dispatch
-
+**`ActionDispatcher` — only `.dispatch()`, never `.call()`:**
 ```python
-import json
-from dcc_mcp_core import ActionRegistry, ActionValidator, ActionDispatcher, error_result
-
-schema = json.dumps({
-    "type": "object",
-    "required": ["name", "radius"],
-    "properties": {
-        "name": {"type": "string", "maxLength": 64},
-        "radius": {"type": "number", "minimum": 0.001, "maximum": 1000.0},
-    },
-})
-validator = ActionValidator.from_schema_json(schema)
-ok, errors = validator.validate(json.dumps({"name": "sphere1", "radius": 1.0}))
-if not ok:
-    return error_result("Invalid parameters", "; ".join(errors))
+dispatcher = ActionDispatcher(registry)          # one arg only
+result = dispatcher.dispatch("name", json_str)   # returns dict
 ```
 
-### Pattern 4: Watch skills directory for live development
-
+**`ActionRegistry.register()` — keyword args only, no positional:**
 ```python
-from dcc_mcp_core import SkillWatcher
-
-watcher = SkillWatcher(debounce_ms=300)
-watcher.watch("/my/dev/skills")  # immediate load + start watching
-
-# In your main loop or callback:
-current_skills = watcher.skills()  # always up-to-date snapshot
+registry.register(name="my_action", description="...", dcc="maya")
 ```
 
-### Pattern 5: Sandbox AI-generated actions
-
+**`FramedChannel.call()` — primary RPC (v0.12.7+):**
 ```python
-from dcc_mcp_core import SandboxPolicy, SandboxContext, InputValidator
-
-policy = SandboxPolicy()
-policy.allow_actions(["get_scene_info", "list_objects", "create_sphere"])
-policy.deny_actions(["delete_all", "save_to"])
-policy.set_timeout_ms(10000)
-policy.set_max_actions(20)
-
-ctx = SandboxContext(policy)
-ctx.set_actor("ai-assistant")
-
-try:
-    result_json = ctx.execute_json("create_sphere", '{"radius": 1.5}')
-except RuntimeError as e:
-    print(f"Denied: {e}")
-
-# Inspect audit trail
-for entry in ctx.audit_log.entries():
-    print(f"{entry.action}: {entry.outcome}")
-```
-
-### Pattern 6: Multi-DCC gateway — one endpoint for all running instances
-
-```python
-"""
-Gateway pattern: start N DCC servers; the first one wins gateway_port and
-becomes the gateway. Agents connect to one URL regardless of how many DCCs run.
-"""
-import os
-from dcc_mcp_core import create_skill_manager, McpHttpConfig
-
-# maya_plugin.py — run inside Maya
-config = McpHttpConfig(port=0, server_name="maya")
-config.gateway_port = 9765   # compete for the shared gateway port
-config.dcc_type = "maya"
-config.dcc_version = "2025"
-config.scene = cmds.file(q=True, sn=True) or "untitled"
-
-server = create_skill_manager("maya", config)
-handle = server.start()
-if handle.is_gateway:
-    print(f"Gateway at http://127.0.0.1:9765/")
-else:
-    print(f"Instance at {handle.mcp_url()}, registered in gateway")
-
-# Agent workflow (once gateway is up):
-# 1. Connect to http://127.0.0.1:9765/mcp
-# 2. tools/call list_dcc_instances  → see all running DCC servers
-# 3. tools/call connect_to_dcc dcc_type="maya"  → get direct MCP URL
-# 4. Connect directly to the returned URL for zero-proxy-overhead access
-# OR: POST /mcp/dcc/maya  → gateway auto-proxies to best maya instance
-```
-
-### Pattern 6 (cont): Expose DCC actions over MCP Streamable HTTP
-
-```python
-# ── Approach A: Skills-First (recommended) ──────────────────────────────────
-import os
-from dcc_mcp_core import create_skill_manager, McpHttpConfig
-
-os.environ["DCC_MCP_MAYA_SKILL_PATHS"] = "/opt/maya-skills"
-
-server = create_skill_manager("maya", McpHttpConfig(port=8765, server_name="maya-mcp"))
-handle = server.start()
-print(f"MCP server ready at {handle.mcp_url()}")
-# Agents use search_skills/load_skill to discover and activate tools on-demand.
-# handle.shutdown() when done
-
-
-# ── Approach B: Manual setup (custom handlers) ───────────────────────────────
-import os
-from dcc_mcp_core import (
-    ActionRegistry, ActionDispatcher, McpHttpServer, McpHttpConfig,
-    success_result, error_result,
-)
-from pathlib import Path
-
-os.environ["DCC_MCP_SKILL_PATHS"] = "/opt/maya-skills"
-
-registry = ActionRegistry()
-server = McpHttpServer(registry, McpHttpConfig(port=8765, server_name="maya-mcp"))
-
-# Register custom handlers (bypasses script auto-execution)
-registry.register("get_scene_info", description="Return current scene info", dcc="maya")
-server.register_handler("get_scene_info", lambda params: {"scene": "untitled", "objects": 0})
-
-handle = server.start()
-print(f"MCP server ready at {handle.mcp_url()}")
-# handle.shutdown() when done
-```
-
-### Pattern 7: Thread-safe DCC tool execution (Maya / Blender / Houdini)
-
-```python
-"""
-DCC main-thread dispatch pattern.
-
-Applicable when the DCC restricts scene API calls to its main thread.
-McpHttpServer runs on a Tokio worker thread; DeferredExecutor bridges the gap.
-"""
-import threading
-from dcc_mcp_core import ActionRegistry, McpHttpServer, McpHttpConfig
-# DeferredExecutor is a Rust type; import via _core directly for now
-from dcc_mcp_core._core import DeferredExecutor
-
-# ── 1. Create executor on main thread ───────────────────────────────────────
-executor = DeferredExecutor(queue_depth=64)
-dcc_handle = executor.handle()  # cloneable handle for worker threads
-
-# ── 2. Register your DCC actions ───────────────────────────────────────────
-registry = ActionRegistry()
-registry.register(
-    "create_sphere",
-    description="Create a polygon sphere on the active layer",
-    category="geometry", tags=["create", "mesh"],
-    dcc="maya", version="1.0.0",
-    input_schema='{"type":"object","properties":{"radius":{"type":"number"}}}'
-)
-
-# ── 3. Start HTTP server (non-blocking) ────────────────────────────────────
-server = McpHttpServer(registry, McpHttpConfig(port=0, server_name="maya-mcp"))
-# NOTE: .with_executor() is implemented in Rust — available when McpHttpServer
-# gains executor support. Until then, run tools without DCC-specific APIs.
-handle = server.start()
-print(f"MCP server at {handle.mcp_url()}")
-
-# ── 4. Poll executor from DCC main thread ──────────────────────────────────
-# Maya: maya.utils.executeDeferred(poll)
-# Blender: bpy.app.timers.register(poll, persistent=True)
-# Houdini: hou.ui.addEventLoopCallback(poll)
-def poll():
-    executor.poll_pending()
-
-# ── 5. Shutdown ────────────────────────────────────────────────────────────
-# handle.shutdown()
-```
-
-### Pattern 8: Per-app skill path configuration
-
-```python
-import os
-from dcc_mcp_core import get_app_skill_paths_from_env, create_skill_manager, McpHttpConfig
-
-# Set paths per DCC — different studios/users can have different skill sets
-os.environ["DCC_MCP_MAYA_SKILL_PATHS"] = "/studio/maya:/home/user/.skills/maya"
-os.environ["DCC_MCP_BLENDER_SKILL_PATHS"] = "/studio/blender"
-os.environ["DCC_MCP_SKILL_PATHS"] = "/shared/common-skills"  # global fallback
-
-# Query resolved paths for a specific app (per-app + global, deduplicated)
-maya_paths = get_app_skill_paths_from_env("maya")
-# → ["/studio/maya", "/home/user/.skills/maya", "/shared/common-skills"]
-
-# create_skill_manager automatically picks up the right env vars
-maya_server = create_skill_manager("maya", McpHttpConfig(port=8765))
-blender_server = create_skill_manager("blender", McpHttpConfig(port=8766))
-```
-
-### Pattern 9: Build a DCC adapter with DccServerBase
-
-```python
-from pathlib import Path
-from dcc_mcp_core.server_base import DccServerBase
-
-# Subclass DccServerBase — all skill management, hot-reload, gateway logic is inherited
-class BlenderMcpServer(DccServerBase):
-    def __init__(self, port: int = 8765, **kwargs):
-        super().__init__(
-            dcc_name="blender",
-            builtin_skills_dir=Path(__file__).parent / "skills",
-            port=port,
-            **kwargs,
-        )
-
-    def _version_string(self) -> str:
-        import bpy
-        return bpy.app.version_string
-
-# Usage — all skill methods are ready out of the box
-server = BlenderMcpServer(port=8765, gateway_port=9765)
-server.register_builtin_actions()  # discover + load all skills
-server.enable_hot_reload()         # file-watching auto-reload
-handle = server.start()            # start MCP HTTP server + gateway election
-print(f"MCP: {handle.mcp_url()}")
-print(f"Gateway: {server.is_gateway}")
-```
-
-### Pattern 10: Write skill scripts with skill_entry decorator
-
-```python
-from dcc_mcp_core.skill import skill_entry, skill_success, skill_error, skill_exception
-
-@skill_entry
-def create_sphere(radius: float = 1.0, name: str = "sphere") -> dict:
-    """Create a polygon sphere in the active scene."""
-    try:
-        import maya.cmds as cmds
-        obj = cmds.polySphere(r=radius, n=name)[0]
-        return skill_success(
-            f"Created sphere '{obj}' with radius {radius}",
-            prompt="You can now adjust properties or add materials.",
-            object_name=obj,
-            radius=radius,
-        )
-    except ImportError:
-        return skill_error("Maya not available", "maya.cmds not found")
-```
-
-## External References
-
-- [AGENTS.md specification](https://agents.md/) — open standard for AI agent guidance files (Linux Foundation / Agentic AI Foundation)
-- [llms.txt specification](https://llmstxt.org/) — AI-optimized documentation format by Answer.AI
-- [Model Context Protocol](https://modelcontextprotocol.io/) — the underlying MCP standard (Anthropic)
-- [MCP Specification 2025-03-26](https://modelcontextprotocol.io/specification/2025-03-26) — current stable spec implemented by this library (Streamable HTTP, OAuth 2.1, Tool Annotations)
-- [MCP Specification 2025-06-18](https://modelcontextprotocol.io/specification/2025-06-18/changelog) — Structured Tool Output, Elicitation, Resource Links, JSON-RPC batching removed, `MCP-Protocol-Version` header mandatory
-- [MCP Specification 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25/changelog) — Icon metadata, Tasks (experimental), Sampling with tool calls, JSON Schema 2020-12
-- [MCP Agent Skills](https://modelcontextprotocol.io/docs/develop/build-with-agent-skills) — SKILL.md ecosystem and agent skills spec
-- [Agent Skills Specification](https://agentskills.io/specification) — official SKILL.md frontmatter format and best practices
-- [PyO3 documentation](https://pyo3.rs/) — Rust-Python bindings used in this project
-- [maturin documentation](https://www.maturin.rs/) — Python wheel builder used for release
-- [OpenClaw Skills format](https://docs.openclaw.ai/tools) — SKILL.md ecosystem compatibility
-- [vx tool manager](https://github.com/loonghao/vx) — universal dev tool manager used in this project
-
-## When Stuck
-
-If you are uncertain about how to proceed, follow these steps **in order** — do NOT make large speculative changes:
-
-1. **Read the type stubs first**: `python/dcc_mcp_core/_core.pyi` has authoritative parameter names, types, and docstrings with inline examples.
-2. **Read the public API**: `python/dcc_mcp_core/__init__.py` lists every public symbol — if it's not there, it doesn't exist.
-3. **Check the tests**: `tests/` directory contains executable usage examples for every major API. Run `vx just test -- -k "test_your_keyword" -v` to see a specific example.
-4. **Ask clarifying questions** rather than guessing: e.g., "Does `ActionDispatcher` have a `.call()` method?" — answer: No, use `.dispatch(action_name, params_json)`.
-5. **Run `cargo check --workspace`** early when adding Rust code to catch errors before a full build.
-6. **Do not** hallucinate method names — every public method is documented in `_core.pyi`.
-
-### Quick Lookup: Common Method Signatures
-
-```python
-# ActionDispatcher — only .dispatch(), never .call()
-dispatcher = ActionDispatcher(registry)   # takes ONE arg (no validator)
-result = dispatcher.dispatch("action_name", json.dumps({"key": "value"}))
-
-# scan_and_load — always returns a 2-TUPLE
-skills, skipped = scan_and_load(dcc_name="maya")   # unpack both
-
-# success_result — kwargs become context, NOT "context=" keyword
-result = success_result("message", prompt="hint", count=5, name="sphere1")
-# result.context == {"count": 5, "name": "sphere1"}
-
-# error_result — positional args (message, error), NOT keyword "message=" / "error="
-result = error_result("Failed", "specific error details")
-
-# EventBus.subscribe returns an int ID for unsubscribe
-sub_id = bus.subscribe("event_name", handler_fn)
-bus.unsubscribe("event_name", sub_id)
-
-# FramedChannel — .call() is the primary RPC method (added v0.12.7)
-channel = connect_ipc(TransportAddress.default_local("maya", pid))
-result = channel.call("execute_python", b'cmds.sphere()')
+result = channel.call("execute_python", b'cmds.sphere()', timeout_ms=30000)
 # result: {"id": str, "success": bool, "payload": bytes, "error": str|None}
-# send_request+recv for async/multiplexed:
-req_id = channel.send_request("execute_python", params=b'cmds.sphere()')
-msg = channel.recv(timeout_ms=10000)   # {"type": "response", ...}
-
-# McpHttpServer — expose actions over HTTP/MCP
-server = McpHttpServer(registry, McpHttpConfig(port=8765, server_name="maya-mcp"))
-handle = server.start()          # returns McpServerHandle (alias: McpServerHandle)
-print(handle.mcp_url())          # "http://127.0.0.1:8765/mcp"
-handle.shutdown()                # or handle.signal_shutdown() (non-blocking)
 ```
 
-## PR Checklist
+**`IpcListener` — bind then accept, not new+start:**
+```python
+listener = IpcListener.bind(addr)       # ✓
+channel  = listener.accept()            # blocks until client connects
+```
 
-Before opening a PR, verify:
+**`DeferredExecutor` — not in public `__init__`:**
+```python
+from dcc_mcp_core._core import DeferredExecutor   # direct import required
+```
 
-- [ ] `vx just preflight` passes (Rust check + clippy + fmt + test-rust)
-- [ ] `vx just test` passes (all Python tests)
-- [ ] `vx just lint` passes (clippy + fmt-check + ruff)
-- [ ] No new runtime Python dependencies added to `pyproject.toml`
-- [ ] If Rust structs changed: updated `python.rs`, `src/lib.rs`, `__init__.py`, `_core.pyi`
-- [ ] PR title follows Conventional Commits format (`docs:`, `feat:`, `fix:`, etc.)
-- [ ] No manual version bumps (Release Please handles this)
-- [ ] `.agents/` skill files added with `git add -f` (they are gitignored)
+**`McpHttpServer` — register ALL handlers BEFORE `.start()`.**
+
+**`skill_success()` vs `success_result()` — different types, different use cases:**
+```python
+# Inside a skill script (pure Python, returns dict for subprocess capture):
+return skill_success("done", count=5)       # → {"success": True, ...} dict
+
+# Inside server code (returns ActionResultModel for validation/transport):
+return success_result("done", count=5)      # → ActionResultModel instance
+```
+
+---
+
+## Code Style — Non-Negotiable
+
+**Python:**
+- `from __future__ import annotations` — first line of every module
+- Import order: future → stdlib → third-party → local (with section comments)
+- Formatter: `ruff format` (line length 120, double quotes)
+- All public APIs: type annotations + Google-style docstrings
+
+**Rust:**
+- Edition 2024, MSRV 1.85
+- `tracing` for logging (no `println!`)
+- `thiserror` for error types
+- `parking_lot` instead of `std::sync::Mutex`
+
+---
+
+## Adding a New Public Symbol — Checklist
+
+When adding a Rust type/function that needs to be callable from Python:
+
+1. Implement in `crates/dcc-mcp-*/src/`
+2. Add `#[pyclass]` / `#[pymethods]` bindings in the crate's `python.rs`
+3. Register in `src/lib.rs` via the appropriate `register_*()` function
+4. Re-export in `python/dcc_mcp_core/__init__.py` (import + add to `__all__`)
+5. Add stub to `python/dcc_mcp_core/_core.pyi`
+6. Add tests in `tests/test_<module>.py`
+7. Run `vx just dev` to rebuild, then `vx just test`
+
+---
+
+## CI & Release
+
+- PRs must pass: `vx just preflight` + `vx just test` + `vx just lint`
+- CI matrix: Python 3.7, 3.9, 3.11, 3.13 on Linux / macOS / Windows
+- Versioning: Release Please (Conventional Commits) — never manually bump
+- PyPI: Trusted Publishing (no tokens)
+
+---
+
+## External Standards & Specifications
+
+| What | Where |
+|------|-------|
+| MCP spec (implemented: 2025-03-26) | https://modelcontextprotocol.io/specification/2025-03-26 |
+| SKILL.md format | https://agentskills.io/specification |
+| AGENTS.md standard | https://agents.md/ |
+| llms.txt format | https://llmstxt.org/ |
+| PyO3 (Rust→Python bindings) | https://pyo3.rs/ |
+| maturin (wheel builder) | https://www.maturin.rs/ |
+| vx (tool manager) | https://github.com/loonghao/vx |
+
+> MCP spec note: Library implements 2025-03-26. Later specs (2025-06-18, 2025-11-25) add
+> Structured Tool Output, Elicitation, Resource Links, icon metadata, Tasks. Do NOT
+> implement these manually — wait for library support.
+
+---
+
+## LLM-Specific Guides
+
+- `CLAUDE.md` — Claude Code workflows and tips
+- `GEMINI.md` — Gemini-specific guidance
+- `llms.txt` — token-optimised API reference
+- `llms-full.txt` — complete API reference

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ os.environ["DCC_MCP_SKILL_PATHS"] = "/path/to/my-tool"
 
 from dcc_mcp_core import scan_and_load, ActionRegistry
 
-skills = scan_and_load(dcc_name="maya")
+skills, skipped = scan_and_load(dcc_name="maya")
 registry = ActionRegistry()
 
 # Tools are now: maya_cleanup__cleanup, with structured results
@@ -479,18 +479,18 @@ from dcc_mcp_core import (
     FramedChannel
 )
 
-# Server side: listen for connections
-listener = IpcListener.new("/tmp/dcc-mcp-server.sock")
-handle = listener.start(handler_fn=my_message_handler)
+# Server side: bind and accept connections (blocking)
+listener = IpcListener.bind("/tmp/dcc-mcp-server.sock")
+channel = listener.accept(timeout_ms=10000)   # blocks until client connects
 
 # Client side: connect to server
 channel = connect_ipc("/tmp/dcc-mcp-server.sock")
-response = channel.call({"method": "ping", "params": {}})
+# Primary RPC helper (v0.12.7+) — send request and wait for correlated response
+result = channel.call("ping", b"", timeout_ms=5000)
+# result: {"id": str, "success": bool, "payload": bytes, "error": str | None}
 
-# Advanced: connection pooling with resilience
-mgr = TransportManager()
-mgr.configure_pool(min_size=2, max_size=10)
-mgr.set_circuit_breaker(threshold=5, reset_timeout=30)
+# Advanced: service registry + transport manager
+mgr = TransportManager(registry_dir="/tmp/dcc-registry")
 ```
 
 ### Process Management — DCC Lifecycle Control
@@ -526,29 +526,22 @@ watcher.watch(process)
 ```python
 from dcc_mcp_core import SandboxContext, SandboxPolicy, InputValidator, AuditLog
 
-# Define what's allowed
-policy = (
-    SandboxPolicy.builder()
-    .allow_read(["/safe/paths/*"])
-    .allow_write(["/temp/*"])
-    .deny_pattern(["*.critical"])
-    .require_approval_for("delete_*")
-    .build()
-)
-
-ctx = SandboxContext(policy=policy)
+# Define a policy (SandboxPolicy accepts optional config dict)
+policy = SandboxPolicy()
+ctx = SandboxContext(policy)
 validator = InputValidator(ctx)
 
 # Validate before execution
-if not validator.validate_action("delete_all_files"):
-    print("Blocked by policy!")
+allowed, reason = validator.validate("delete_all_files")
+if not allowed:
+    print(f"Blocked by policy: {reason}")
 else:
-    print("Allowed -- executing...")
+    print("Allowed — executing...")
 
 # Review audit trail
-audit = AuditLog.load()
-for entry in audit.entries:
-    print(f"{entry.timestamp} [{entry.action}] {entry.decision} -> {entry.details}")
+audit = ctx.audit_log
+for entry in audit.entries():
+    print(f"{entry.action} -> {entry.outcome}")
 ```
 
 ## More Examples
@@ -612,7 +605,7 @@ Contributions are welcome! Please feel free to submit a Pull Request.
    ```bash
    vx just lint       # Check code style
    vx just test       # Run tests
-   vx just prek-all   # Run all pre-commit hooks
+   vx just preflight  # Run all pre-commit checks
    ```
 5. Commit using [Conventional Commits](https://www.conventionalcommits.org/) format
 6. Push and open a Pull Request against `main`

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -169,10 +169,15 @@ from dcc_mcp_core._core import validate_action_result
 from dcc_mcp_core._core import validate_dependencies
 from dcc_mcp_core._core import wrap_value
 
+# Pure-Python DCC adapter base classes (no _core dependency)
+from dcc_mcp_core.bridge import BridgeConnectionError
+from dcc_mcp_core.bridge import BridgeError
+from dcc_mcp_core.bridge import BridgeRpcError
+from dcc_mcp_core.bridge import BridgeTimeoutError
+from dcc_mcp_core.bridge import DccBridge
+
 # Pure-Python DCC server diagnostic helpers (no _core dependency)
 from dcc_mcp_core.dcc_server import register_diagnostic_handlers
-
-# Pure-Python DCC adapter base classes (no _core dependency)
 from dcc_mcp_core.factory import create_dcc_server
 from dcc_mcp_core.factory import get_server_instance
 from dcc_mcp_core.factory import make_start_stop
@@ -226,11 +231,16 @@ __all__ = [
     "AuditMiddleware",
     "BooleanWrapper",
     "BoundingBox",
+    "BridgeConnectionError",
     "BridgeContext",
+    "BridgeError",
     "BridgeRegistry",
+    "BridgeRpcError",
+    "BridgeTimeoutError",
     "CaptureFrame",
     "CaptureResult",
     "Capturer",
+    "DccBridge",
     "DccCapabilities",
     "DccError",
     "DccErrorCode",

--- a/python/dcc_mcp_core/bridge.py
+++ b/python/dcc_mcp_core/bridge.py
@@ -35,6 +35,20 @@ import threading
 from typing import Any
 import uuid
 
+
+# NOTE: dcc_mcp_core.__version__ is deferred to avoid a potential import-time
+# circular dependency if bridge.py is ever imported before _core is ready.
+# We only need the version string at DccBridge.__init__ call time, not at
+# module import time, so this is safe.
+def _package_version() -> str:
+    try:
+        from dcc_mcp_core import __version__
+
+        return __version__
+    except Exception:
+        return "0.0.0"
+
+
 logger = logging.getLogger(__name__)
 
 # ── Exceptions ────────────────────────────────────────────────────────────────
@@ -105,6 +119,7 @@ class DccBridge:
         Name advertised in the ``hello_ack`` handshake.
     server_version:
         Version advertised in the ``hello_ack`` handshake.
+        Defaults to the installed ``dcc_mcp_core`` package version.
 
     """
 
@@ -114,13 +129,13 @@ class DccBridge:
         port: int = 9001,
         timeout: float = 30.0,
         server_name: str = "dcc-mcp-server",
-        server_version: str = "1.0.0",
+        server_version: str | None = None,
     ) -> None:
         self._host = host
         self._port = port
         self._timeout = timeout
         self._server_name = server_name
-        self._server_version = server_version
+        self._server_version = server_version if server_version is not None else _package_version()
 
         self._loop: asyncio.AbstractEventLoop | None = None
         self._thread: threading.Thread | None = None

--- a/python/dcc_mcp_core/bridge.py
+++ b/python/dcc_mcp_core/bridge.py
@@ -114,7 +114,7 @@ class DccBridge:
         port: int = 9001,
         timeout: float = 30.0,
         server_name: str = "dcc-mcp-server",
-        server_version: str = "0.12.18",
+        server_version: str = "1.0.0",
     ) -> None:
         self._host = host
         self._port = port
@@ -259,7 +259,9 @@ class DccBridge:
     # ── Internal: event loop thread ──────────────────────────────────────────
 
     def _run_event_loop(self) -> None:
-        asyncio.set_event_loop(self._loop)
+        # Do NOT call asyncio.set_event_loop(): it was deprecated in 3.10 and
+        # removed in Python 3.14.  The loop was created in __init__ via
+        # asyncio.new_event_loop() and is fully self-contained in this thread.
         try:
             self._loop.run_until_complete(self._serve())
         except Exception:
@@ -280,7 +282,7 @@ class DccBridge:
             self._server_ready.set()
             logger.debug("DccBridge listening on %s", self.endpoint)
             # Run until stop() is called.
-            await asyncio.get_event_loop().create_future()
+            await asyncio.get_running_loop().create_future()
 
     async def _handle_dcc(self, ws: Any) -> None:
         """Handle a single DCC plugin WebSocket connection."""

--- a/python/dcc_mcp_core/factory.py
+++ b/python/dcc_mcp_core/factory.py
@@ -10,11 +10,7 @@ Usage::
     import threading
     from pathlib import Path
     from dcc_mcp_core.server_base import DccServerBase
-    from dcc_mcp_core.factory import create_dcc_server
-
-    _instance = None
-    _lock = threading.Lock()
-
+    from dcc_mcp_core.factory import create_dcc_server, make_start_stop
 
     class BlenderMcpServer(DccServerBase):
         def __init__(self, port=8765, **kwargs):
@@ -25,30 +21,30 @@ Usage::
                 **kwargs,
             )
 
+    # Recommended: use make_start_stop for zero-boilerplate adapters
+    start_server, stop_server = make_start_stop(
+        BlenderMcpServer,
+        hot_reload_env_var="DCC_MCP_BLENDER_HOT_RELOAD",
+    )
 
-    def start_server(port=8765, register_builtins=True, **kwargs):
-        global _instance
+    # Or manually with a list-based holder:
+    _holder = [None]
+    _lock = threading.Lock()
+
+    def start_server(port=8765, **kwargs):
         return create_dcc_server(
-            instance_ref=lambda: _instance,
-            instance_setter=lambda v: globals().update(_instance=v),
+            instance_holder=_holder,
             lock=_lock,
             server_class=BlenderMcpServer,
             port=port,
-            register_builtins=register_builtins,
             **kwargs,
         )
 
-
     def stop_server():
-        global _instance
         with _lock:
-            if _instance is not None:
-                _instance.stop()
-                _instance = None
-
-The two-argument ``instance_ref`` / ``instance_setter`` pattern avoids
-passing a mutable container just for the reference. Alternatively, you can
-use the simpler list-based variant shown in :func:`create_dcc_server`.
+            if _holder[0] is not None:
+                _holder[0].stop()
+                _holder[0] = None
 """
 
 # Import future modules
@@ -59,6 +55,7 @@ import logging
 import os
 import threading
 from typing import Any
+from typing import Callable
 
 logger = logging.getLogger(__name__)
 
@@ -150,7 +147,7 @@ def create_dcc_server(
 def make_start_stop(
     server_class: type[Any],
     hot_reload_env_var: str | None = None,
-) -> tuple:
+) -> tuple[Callable[..., Any], Callable[[], None]]:
     """Generate a ``(start_server, stop_server)`` function pair for a DCC adapter.
 
     Convenience factory that creates the singleton holder + lock and returns
@@ -219,11 +216,3 @@ def get_server_instance(instance_holder: list[Any | None]) -> Any | None:
 
     """
     return instance_holder[0] if instance_holder else None
-
-
-def _make_env_var_name(dcc_name: str, suffix: str) -> str:
-    """Build a conventional environment variable name.
-
-    ``_make_env_var_name("blender", "HOT_RELOAD")`` → ``"DCC_MCP_BLENDER_HOT_RELOAD"``
-    """
-    return f"DCC_MCP_{dcc_name.upper()}_{suffix}"

--- a/python/dcc_mcp_core/hotreload.py
+++ b/python/dcc_mcp_core/hotreload.py
@@ -35,11 +35,7 @@ from __future__ import annotations
 # Import built-in modules
 import logging
 import threading
-from typing import TYPE_CHECKING
 from typing import Any
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 
@@ -171,11 +167,12 @@ class DccSkillHotReloader:
     def disable(self) -> None:
         """Disable hot-reload and clean up the SkillWatcher."""
         with self._lock:
-            if self._watcher is not None:
-                self._watcher = None
+            was_enabled = self._enabled
+            self._watcher = None
             self._watched_paths.clear()
             self._enabled = False
-        logger.info("[%s] Hot-reload disabled", self._dcc_name)
+        if was_enabled:
+            logger.info("[%s] Hot-reload disabled", self._dcc_name)
 
     def reload_now(self) -> int:
         """Manually trigger a reload of all monitored skills.
@@ -190,37 +187,42 @@ class DccSkillHotReloader:
             logger.warning("[%s] Hot-reload is not enabled", self._dcc_name)
             return 0
 
+        # Snapshot the watcher reference outside the lock before doing I/O.
         with self._lock:
-            try:
-                self._watcher.reload()
-                self._reload_count += 1
-
-                reloaded = 0
-                inner = getattr(self._server, "_server", None)
-                if inner is not None:
-                    try:
-                        for summary in inner.list_skills():
-                            skill_name = summary.name if hasattr(summary, "name") else summary.get("name")
-                            if skill_name:
-                                try:
-                                    inner.load_skill(skill_name)
-                                    reloaded += 1
-                                except Exception as exc:
-                                    logger.debug(
-                                        "[%s] Failed to reload skill %r: %s",
-                                        self._dcc_name,
-                                        skill_name,
-                                        exc,
-                                    )
-                    except Exception as exc:
-                        logger.warning("[%s] Error listing skills during reload: %s", self._dcc_name, exc)
-
-                logger.info("[%s] Manual reload triggered: %d skills reloaded", self._dcc_name, reloaded)
-                return reloaded
-
-            except Exception as exc:
-                logger.error("[%s] Manual reload failed: %s", self._dcc_name, exc)
+            watcher = self._watcher
+            if watcher is None:
                 return 0
+
+        try:
+            watcher.reload()
+            self._reload_count += 1
+
+            reloaded = 0
+            inner = getattr(self._server, "_server", None)
+            if inner is not None:
+                try:
+                    for summary in inner.list_skills():
+                        skill_name = summary.name if hasattr(summary, "name") else summary.get("name")
+                        if skill_name:
+                            try:
+                                inner.load_skill(skill_name)
+                                reloaded += 1
+                            except Exception as exc:
+                                logger.debug(
+                                    "[%s] Failed to reload skill %r: %s",
+                                    self._dcc_name,
+                                    skill_name,
+                                    exc,
+                                )
+                except Exception as exc:
+                    logger.warning("[%s] Error listing skills during reload: %s", self._dcc_name, exc)
+
+            logger.info("[%s] Manual reload triggered: %d skills reloaded", self._dcc_name, reloaded)
+            return reloaded
+
+        except Exception as exc:
+            logger.error("[%s] Manual reload failed: %s", self._dcc_name, exc)
+            return 0
 
     def get_stats(self) -> dict:
         """Return hot-reload statistics.

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -56,6 +56,13 @@ import os
 from pathlib import Path
 from typing import Any
 
+# NOTE: dcc_mcp_core imports (McpHttpConfig, create_skill_manager, get_*,
+# TransportManager, get_bundled_skill_paths) are deferred inside methods to
+# avoid a circular import: __init__.py imports DccServerBase from this module,
+# so this module cannot import from dcc_mcp_core at module level.
+from dcc_mcp_core.gateway_election import DccGatewayElection
+from dcc_mcp_core.hotreload import DccSkillHotReloader
+
 logger = logging.getLogger(__name__)
 
 
@@ -74,6 +81,7 @@ class DccServerBase:
         port: TCP port for the MCP HTTP server. ``0`` → OS picks a free port.
         server_name: Name reported in the MCP ``initialize`` response.
         server_version: Version reported in the MCP ``initialize`` response.
+            Defaults to the installed ``dcc_mcp_core`` package version.
         gateway_port: Port for the multi-DCC first-wins gateway competition.
             ``None`` reads ``DCC_MCP_GATEWAY_PORT`` env var; ``0`` disables gateway.
         registry_dir: Directory for the shared ``FileRegistry`` JSON file.
@@ -89,14 +97,17 @@ class DccServerBase:
         builtin_skills_dir: Path,
         port: int = 8765,
         server_name: str | None = None,
-        server_version: str = "0.1.0",
+        server_version: str | None = None,
         gateway_port: int | None = None,
         registry_dir: str | None = None,
         dcc_version: str | None = None,
         scene: str | None = None,
         enable_gateway_failover: bool = True,
     ) -> None:
+        # Deferred: circular import — __init__.py imports DccServerBase from
+        # this module, so we cannot import from dcc_mcp_core at module level.
         from dcc_mcp_core import McpHttpConfig
+        from dcc_mcp_core import __version__ as _pkg_version
         from dcc_mcp_core import create_skill_manager
 
         self._dcc_name = dcc_name
@@ -117,7 +128,7 @@ class DccServerBase:
         self._config = McpHttpConfig(
             port=port,
             server_name=server_name or f"{dcc_name}-mcp",
-            server_version=server_version,
+            server_version=server_version if server_version is not None else _pkg_version,
         )
         if effective_gateway_port > 0:
             self._config.gateway_port = effective_gateway_port
@@ -494,8 +505,6 @@ class DccServerBase:
             ``True`` on success.
 
         """
-        from dcc_mcp_core.hotreload import DccSkillHotReloader
-
         if self._hot_reloader is None:
             self._hot_reloader = DccSkillHotReloader(dcc_name=self._dcc_name, server=self)
 
@@ -546,8 +555,6 @@ class DccServerBase:
         gateway_port = getattr(self._config, "gateway_port", 0)
         if self._enable_gateway_failover and gateway_port and gateway_port > 0 and self._gateway_election is None:
             try:
-                from dcc_mcp_core.gateway_election import DccGatewayElection
-
                 self._gateway_election = DccGatewayElection(
                     dcc_name=self._dcc_name,
                     server=self,

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -186,8 +186,8 @@ class DccServerBase:
                 from dcc_mcp_core.skill import get_bundled_skill_paths
 
                 paths.extend(get_bundled_skill_paths(include_bundled=True))
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("[%s] Could not load bundled skill paths: %s", self._dcc_name, exc)
 
         default_dir = get_skills_dir()
         if default_dir and default_dir not in paths:
@@ -225,6 +225,7 @@ class DccServerBase:
         skill_paths = self.collect_skill_search_paths(
             extra_paths=extra_skill_paths,
             include_bundled=include_bundled,
+            filter_existing=True,
         )
         logger.debug("[%s] Registering skills from %d path(s)", self._dcc_name, len(skill_paths))
         try:
@@ -254,7 +255,7 @@ class DccServerBase:
             return None
         try:
             port = getattr(self._config, "gateway_port", 0)
-            if port and port > 0 and self.is_gateway:
+            if port > 0 and self.is_gateway:
                 return f"http://127.0.0.1:{port}/mcp"
         except Exception:
             pass
@@ -339,17 +340,22 @@ class DccServerBase:
 
     def search_actions(
         self,
-        query: str,
+        category: str | None = None,
+        tags: list[str] | None = None,
         dcc_name: str | None = None,
     ) -> list[Any]:
-        """Full-text search across action names and descriptions.
+        """Search registered actions by category and/or tags.
+
+        Delegates to :meth:`ActionRegistry.search_actions` which filters by
+        exact category match, all-tags-present, and optional DCC scope.
 
         Args:
-            query: Search term.
+            category: Exact category name to filter by (``None`` = no filter).
+            tags: All listed tags must be present on the action (empty = no filter).
             dcc_name: Override the DCC filter.
 
         Returns:
-            List of matching ``ActionInfo`` objects.
+            List of matching ``ActionInfo`` dicts.
 
         """
         registry = self.registry
@@ -357,7 +363,7 @@ class DccServerBase:
             return []
         effective_dcc = dcc_name if dcc_name is not None else self._dcc_name
         try:
-            return list(registry.search_actions(query, dcc_name=effective_dcc))
+            return list(registry.search_actions(category=category, tags=tags or [], dcc_name=effective_dcc))
         except Exception as exc:
             logger.debug("[%s] search_actions failed: %s", self._dcc_name, exc)
             return []
@@ -493,7 +499,7 @@ class DccServerBase:
         if self._hot_reloader is None:
             self._hot_reloader = DccSkillHotReloader(dcc_name=self._dcc_name, server=self)
 
-        paths = skill_paths or self.collect_skill_search_paths(include_bundled=False)
+        paths = skill_paths or self.collect_skill_search_paths(include_bundled=False, filter_existing=True)
         return self._hot_reloader.enable(paths, debounce_ms=debounce_ms)
 
     def disable_hot_reload(self) -> None:
@@ -613,7 +619,7 @@ class DccServerBase:
             return False
 
         gateway_port = getattr(self._config, "gateway_port", 0)
-        if not gateway_port or gateway_port <= 0:
+        if gateway_port <= 0:
             logger.debug("[%s] Gateway not configured; metadata update skipped", self._dcc_name)
             return False
 

--- a/tests/test_dcc_adapter_base.py
+++ b/tests/test_dcc_adapter_base.py
@@ -333,14 +333,60 @@ class TestDccServerBase:
         server = self._make_server(tmp_path)
         assert server.unload_skill("some-skill") is True
 
-    def test_collect_skill_search_paths_includes_builtin(self, tmp_path):
+    @pytest.fixture()
+    def _patch_skill_env(self):
+        """Patch the three skill-path helpers to return empty / None values.
+
+        server_base.py does ``from dcc_mcp_core import <fn>`` inside
+        ``collect_skill_search_paths``, so we patch the symbols on the
+        ``dcc_mcp_core`` package itself.
+        """
+        with patch("dcc_mcp_core.get_app_skill_paths_from_env", return_value=[]), patch(
+            "dcc_mcp_core.get_skill_paths_from_env", return_value=[]
+        ), patch("dcc_mcp_core.get_skills_dir", return_value=None):
+            yield
+
+    def test_collect_skill_search_paths_includes_builtin(self, tmp_path, _patch_skill_env):
         server = self._make_server(tmp_path)
-        with patch("dcc_mcp_core._core.get_app_skill_paths_from_env", return_value=[], create=True), patch(
-            "dcc_mcp_core._core.get_skill_paths_from_env", return_value=[], create=True
-        ), patch("dcc_mcp_core._core.get_skills_dir", return_value=None, create=True):
-            paths = server.collect_skill_search_paths(include_bundled=False)
+        paths = server.collect_skill_search_paths(include_bundled=False)
         # builtin_skills_dir (tmp_path/skills) should be in the result
         assert any("skills" in p for p in paths)
+
+    def test_collect_skill_search_paths_filter_existing_removes_nonexistent(self, tmp_path, _patch_skill_env):
+        """filter_existing=True removes non-existent paths and deduplicates."""
+        server = self._make_server(tmp_path)
+        # Add extra_paths with a mix of existing and non-existent
+        existing_dir = str(tmp_path / "skills")
+        nonexistent = "/nonexistent/path/xyz"
+        paths = server.collect_skill_search_paths(
+            extra_paths=[existing_dir, nonexistent],
+            include_bundled=False,
+            filter_existing=True,
+        )
+        assert existing_dir in paths
+        assert nonexistent not in paths
+
+    def test_collect_skill_search_paths_filter_existing_deduplicates(self, tmp_path, _patch_skill_env):
+        """filter_existing=True deduplicates identical paths."""
+        server = self._make_server(tmp_path)
+        existing_dir = str(tmp_path / "skills")
+        paths = server.collect_skill_search_paths(
+            extra_paths=[existing_dir, existing_dir],
+            include_bundled=False,
+            filter_existing=True,
+        )
+        assert paths.count(existing_dir) == 1
+
+    def test_collect_skill_search_paths_filter_false_keeps_all(self, tmp_path, _patch_skill_env):
+        """filter_existing=False (default) preserves non-existent paths."""
+        server = self._make_server(tmp_path)
+        nonexistent = "/nonexistent/path/xyz"
+        paths = server.collect_skill_search_paths(
+            extra_paths=[nonexistent],
+            include_bundled=False,
+            filter_existing=False,
+        )
+        assert nonexistent in paths
 
     def test_enable_hot_reload_creates_reloader(self, tmp_path):
         server = self._make_server(tmp_path)


### PR DESCRIPTION
## Summary

- **Refactor pure-Python modules** (`hotreload.py`, `factory.py`, `server_base.py`): remove dead code, fix misleading docs, fix lock-while-doing-IO, fix wrong docstring on `search_actions()`
- **Fix 5 stale/wrong API examples in README.md**: `IpcListener`, `FramedChannel.call()`, `scan_and_load()`, `SandboxPolicy`, wrong command name
- **Expose `DccBridge` publicly**: bridge-mode DCCs (Photoshop, ZBrush) can now `from dcc_mcp_core import DccBridge`
- **Fix Python 3.14 incompatibility** in `bridge.py`: `asyncio.set_event_loop()` removed in 3.14
- **Fix wrong test patch targets** and DRY up 4 duplicate patch context managers
- **Rewrite AGENTS.md**: 1427 lines → 274 lines; navigation map instead of encyclopedia

## Changes by commit

### `refactor: clean up code smells in server-base, hotreload, and factory`
- `hotreload.py`: remove empty `if TYPE_CHECKING: pass`; `disable()` only logs when actually was enabled; move I/O out of lock in `reload_now()` to avoid potential deadlock
- `factory.py`: remove dead `_make_env_var_name()` function; fix module docstring referencing removed `instance_ref`/`instance_setter` API
- `server_base.py`: replace silent `except Exception: pass` with `logger.debug()`; simplify redundant `port and port > 0` to `port > 0`
- `tests/test_dcc_adapter_base.py`: fix patch targets from `dcc_mcp_core._core.*` → `dcc_mcp_core.*`; extract `_patch_skill_env` fixture to eliminate 4 near-identical `with patch` blocks

### `fix: correct stale API examples, expose DccBridge publicly, fix search_actions`
- `README.md`: fix 5 wrong code examples (IpcListener, FramedChannel.call, scan_and_load, SandboxPolicy.builder, preflight command)
- `server_base.py`: fix `search_actions()` — renamed `query→category`, added `tags` param; corrected docstring (it's a category filter, not free-text search)
- `bridge.py`: remove hardcoded stale version `"0.12.18"` → `"1.0.0"`; replace deprecated `asyncio.get_event_loop()` with `asyncio.get_running_loop()`
- `__init__.py`: export `DccBridge`, `BridgeError`, `BridgeConnectionError`, `BridgeTimeoutError`, `BridgeRpcError` at top level
- `factory.py`: tighten `make_start_stop()` return type from bare `tuple` to `tuple[Callable[..., Any], Callable[[], None]]`

### `fix(bridge): remove asyncio.set_event_loop() for Python 3.14 compatibility`
- `asyncio.set_event_loop()` deprecated Python 3.10, **removed Python 3.14** — would crash `DccBridge` on 3.14
- The event loop is already self-contained in the thread; calling `set_event_loop()` was unnecessary

### `docs(agents): rewrite AGENTS.md as navigation map, not encyclopedia`
- Old AGENTS.md duplicated content from `_core.pyi`, `docs/api/`, `docs/guide/` inline → AI agents had to tokenise 1427 lines before writing code
- New design: **map not territory** — Decision Tree pointing to authoritative sources, Repo Layout (file → one-line purpose), essential Traps, minimal build commands
- Full API reference remains authoritative in `_core.pyi`, `docs/api/`, `llms.txt`

## Test plan

- [ ] CI passes on all Python versions (3.7, 3.9, 3.11, 3.13) and platforms
- [ ] `vx just test` — all Python integration tests pass
- [ ] `vx just lint` — ruff + clippy clean
- [ ] No Rust code changed → Rust tests unaffected