### PR TITLE
fix(gateway): aggregate tools from all backends into unified MCP facade

### DIFF
--- a/crates/dcc-mcp-http/src/gateway/aggregator.rs
+++ b/crates/dcc-mcp-http/src/gateway/aggregator.rs
@@ -1,0 +1,561 @@
+//! Tools-list aggregation and tools-call routing for the facade gateway.
+//!
+//! This module is the core of the "one endpoint, every DCC" façade:
+//!
+//! * `aggregate_tools_list` — fan out `tools/list` to every live backend and
+//!   merge the results.  Backend-provided tools get an instance prefix so
+//!   identical tool names across multiple DCCs never clash (see [`namespace`]).
+//! * `route_tools_call` — dispatch a `tools/call` based on the tool name:
+//!   - Meta / skill-management tools are handled locally or fanned-out with
+//!     instance-scoped semantics.
+//!   - Prefixed tools are forwarded to the backend that owns them.
+//!
+//! All network I/O goes through the stateless helpers in
+//! [`super::backend_client`], so fan-out works concurrently via `join_all`.
+
+use std::time::Duration;
+
+use futures::future::join_all;
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+use super::backend_client::{fetch_tools, forward_tools_call};
+use super::namespace::{decode_tool_name, encode_tool_name, instance_short, is_local_tool};
+use super::state::GatewayState;
+use super::tools::{
+    gateway_tool_defs, tool_connect_to_dcc, tool_get_instance, tool_list_instances,
+};
+use dcc_mcp_transport::discovery::types::ServiceEntry;
+
+/// Per-backend request timeout for fan-out calls.
+///
+/// Kept short so a single unresponsive instance does not stall aggregation.
+const BACKEND_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Build the unified `tools/list` result by aggregating every live backend.
+///
+/// Tool order:
+/// 1. Gateway discovery meta-tools (`list_dcc_instances`, `get_dcc_instance`, `connect_to_dcc`).
+/// 2. Skill-management tools (one canonical set for the whole gateway).
+/// 3. Backend-provided tools from every live instance, prefixed with the
+///    8-char instance id, annotated with `_instance_id` / `_dcc_type` in the
+///    tool's `annotations` map so agents can display origin context.
+pub async fn aggregate_tools_list(gs: &GatewayState) -> Value {
+    let mut tools: Vec<Value> = Vec::new();
+
+    // Tier 1 + 2: local gateway tools (meta + skill management).
+    if let Value::Array(local) = gateway_tool_defs() {
+        tools.extend(local);
+    }
+    tools.extend(skill_management_tool_defs());
+
+    // Tier 3: fan out to every live backend.
+    let instances = live_backends(gs).await;
+    let client = &gs.http_client;
+    let futs = instances.iter().map(|entry| async move {
+        let url = format!("http://{}:{}/mcp", entry.host, entry.port);
+        let backend_tools = fetch_tools(client, &url, BACKEND_TIMEOUT).await;
+        (entry.instance_id, entry.dcc_type.clone(), backend_tools)
+    });
+    let results = join_all(futs).await;
+
+    for (iid, dcc_type, backend_tools) in results {
+        for mut tool in backend_tools {
+            // Skip any tool whose name would collide with a gateway-local name
+            // AFTER encoding — cannot happen today because local tools are
+            // already filtered by `is_local_tool`, but guard defensively.
+            if is_local_tool(&tool.name) {
+                continue;
+            }
+            let encoded = encode_tool_name(&iid, &tool.name);
+            tool.name = encoded;
+            let mut json_val = serde_json::to_value(&tool).unwrap_or(Value::Null);
+            inject_instance_metadata(&mut json_val, &iid, &dcc_type);
+            tools.push(json_val);
+        }
+    }
+
+    json!({"tools": tools, "nextCursor": Value::Null})
+}
+
+/// Dispatch a gateway `tools/call` to the right place.
+///
+/// Returns `(text_body, is_error)` so the caller can wrap into an MCP
+/// `CallToolResult`.  Agents never see backend URLs; results look identical
+/// to those produced by a single-DCC server.
+pub async fn route_tools_call(gs: &GatewayState, tool: &str, args: &Value) -> (String, bool) {
+    // ── Local meta-tools ────────────────────────────────────────────────
+    match tool {
+        "list_dcc_instances" => return to_text_result(tool_list_instances(gs, args).await),
+        "get_dcc_instance" => return to_text_result(tool_get_instance(gs, args).await),
+        "connect_to_dcc" => return to_text_result(tool_connect_to_dcc(gs, args).await),
+        _ => {}
+    }
+
+    // ── Skill-management tools ──────────────────────────────────────────
+    if matches!(
+        tool,
+        "list_skills"
+            | "find_skills"
+            | "search_skills"
+            | "get_skill_info"
+            | "load_skill"
+            | "unload_skill"
+    ) {
+        return skill_mgmt_dispatch(gs, tool, args).await;
+    }
+
+    // ── Prefixed backend tool ───────────────────────────────────────────
+    let Some((prefix, original)) = decode_tool_name(tool) else {
+        return (
+            format!(
+                "Unknown tool: {tool}. Call list_dcc_instances or search_skills to discover tools."
+            ),
+            true,
+        );
+    };
+
+    let Some(entry) = find_instance_by_prefix(gs, prefix).await else {
+        return (
+            format!("No live DCC instance matches prefix '{prefix}' in tool '{tool}'."),
+            true,
+        );
+    };
+
+    let url = format!("http://{}:{}/mcp", entry.host, entry.port);
+    match forward_tools_call(
+        &gs.http_client,
+        &url,
+        original,
+        Some(args.clone()),
+        BACKEND_TIMEOUT,
+    )
+    .await
+    {
+        Ok(mut result) => {
+            // Backend already returns a CallToolResult { content, isError }
+            // shaped value; pass it through unchanged by serialising to text.
+            inject_instance_metadata(&mut result, &entry.instance_id, &entry.dcc_type);
+            (
+                serde_json::to_string_pretty(&result).unwrap_or_default(),
+                result
+                    .get("isError")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+            )
+        }
+        Err(e) => (format!("Backend call failed: {e}"), true),
+    }
+}
+
+// ── Skill-management dispatch ──────────────────────────────────────────────
+
+/// Dispatch a skill-management tool across backends.
+///
+/// Two patterns:
+/// * Fan-out, aggregate (`list_skills`, `find_skills`, `search_skills`,
+///   `get_skill_info`): call every matching backend, merge results with
+///   `_instance_id` / `_dcc_type` annotations so agents can disambiguate.
+/// * Target-instance (`load_skill`, `unload_skill`): require `instance_id` /
+///   `dcc` in the arguments; if a single backend is live these default
+///   automatically.
+async fn skill_mgmt_dispatch(gs: &GatewayState, tool: &str, args: &Value) -> (String, bool) {
+    let dcc_filter = args.get("dcc").and_then(Value::as_str);
+    let target_instance = args.get("instance_id").and_then(Value::as_str);
+
+    match tool {
+        "load_skill" | "unload_skill" => {
+            match resolve_target(gs, target_instance, dcc_filter).await {
+                Ok(entry) => {
+                    // Strip gateway-only routing keys before forwarding.
+                    let mut forward_args = args.clone();
+                    if let Some(obj) = forward_args.as_object_mut() {
+                        obj.remove("instance_id");
+                    }
+                    let url = format!("http://{}:{}/mcp", entry.host, entry.port);
+                    match forward_tools_call(
+                        &gs.http_client,
+                        &url,
+                        tool,
+                        Some(forward_args),
+                        BACKEND_TIMEOUT,
+                    )
+                    .await
+                    {
+                        Ok(mut result) => {
+                            inject_instance_metadata(
+                                &mut result,
+                                &entry.instance_id,
+                                &entry.dcc_type,
+                            );
+                            (
+                                serde_json::to_string_pretty(&result).unwrap_or_default(),
+                                result
+                                    .get("isError")
+                                    .and_then(Value::as_bool)
+                                    .unwrap_or(false),
+                            )
+                        }
+                        Err(e) => (format!("Backend call failed: {e}"), true),
+                    }
+                }
+                Err(msg) => (msg, true),
+            }
+        }
+        _ => {
+            // Fan-out aggregation.
+            let targets = targets_for_fanout(gs, dcc_filter).await;
+            if targets.is_empty() {
+                return (
+                    "No live DCC instances. Start dcc-mcp-server on the DCC you want to use."
+                        .to_string(),
+                    true,
+                );
+            }
+
+            let client = &gs.http_client;
+            let params = json!({"name": tool, "arguments": args});
+            let futs = targets.iter().map(|entry| {
+                let url = format!("http://{}:{}/mcp", entry.host, entry.port);
+                let params = params.clone();
+                async move {
+                    let res = super::backend_client::call_backend(
+                        client,
+                        &url,
+                        "tools/call",
+                        Some(params),
+                        BACKEND_TIMEOUT,
+                    )
+                    .await;
+                    (entry.instance_id, entry.dcc_type.clone(), res)
+                }
+            });
+            let results = join_all(futs).await;
+
+            let merged: Vec<Value> = results
+                .into_iter()
+                .map(|(iid, dcc, res)| match res {
+                    Ok(v) => json!({
+                        "instance_id": iid.to_string(),
+                        "instance_short": instance_short(&iid),
+                        "dcc_type": dcc,
+                        "result": v,
+                    }),
+                    Err(e) => json!({
+                        "instance_id": iid.to_string(),
+                        "instance_short": instance_short(&iid),
+                        "dcc_type": dcc,
+                        "error": e,
+                    }),
+                })
+                .collect();
+
+            (
+                serde_json::to_string_pretty(&json!({"instances": merged})).unwrap_or_default(),
+                false,
+            )
+        }
+    }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+async fn live_backends(gs: &GatewayState) -> Vec<ServiceEntry> {
+    let reg = gs.registry.read().await;
+    gs.live_instances(&reg)
+        .into_iter()
+        .filter(|e| e.dcc_type != super::GATEWAY_SENTINEL_DCC_TYPE)
+        .collect()
+}
+
+async fn targets_for_fanout(gs: &GatewayState, dcc_filter: Option<&str>) -> Vec<ServiceEntry> {
+    live_backends(gs)
+        .await
+        .into_iter()
+        .filter(|e| dcc_filter.is_none_or(|f| e.dcc_type.eq_ignore_ascii_case(f)))
+        .collect()
+}
+
+async fn find_instance_by_prefix(gs: &GatewayState, prefix: &str) -> Option<ServiceEntry> {
+    live_backends(gs)
+        .await
+        .into_iter()
+        .find(|e| instance_short(&e.instance_id) == prefix)
+}
+
+async fn resolve_target(
+    gs: &GatewayState,
+    instance_id: Option<&str>,
+    dcc_filter: Option<&str>,
+) -> Result<ServiceEntry, String> {
+    let candidates = live_backends(gs).await;
+
+    // Exact or prefix match on instance_id.
+    if let Some(iid) = instance_id {
+        if let Some(e) = candidates.iter().find(|e| {
+            let full = e.instance_id.to_string();
+            full == iid || full.starts_with(iid) || instance_short(&e.instance_id) == iid
+        }) {
+            return Ok(e.clone());
+        }
+        return Err(format!("No live instance matches instance_id='{iid}'"));
+    }
+
+    // DCC-filtered auto-select when unambiguous.
+    let filtered: Vec<&ServiceEntry> = candidates
+        .iter()
+        .filter(|e| dcc_filter.is_none_or(|f| e.dcc_type.eq_ignore_ascii_case(f)))
+        .collect();
+
+    match filtered.len() {
+        0 => Err(match dcc_filter {
+            Some(d) => format!("No live '{d}' instance."),
+            None => "No live DCC instances.".to_string(),
+        }),
+        1 => Ok(filtered[0].clone()),
+        _ => Err(format!(
+            "Ambiguous target — {} instances live. Pass `instance_id` (or use `dcc` filter if only one of that type).",
+            filtered.len()
+        )),
+    }
+}
+
+fn to_text_result(res: Result<String, String>) -> (String, bool) {
+    match res {
+        Ok(text) => (text, false),
+        Err(msg) => (msg, true),
+    }
+}
+
+fn inject_instance_metadata(value: &mut Value, iid: &Uuid, dcc_type: &str) {
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert("_instance_id".to_string(), Value::String(iid.to_string()));
+        obj.insert(
+            "_instance_short".to_string(),
+            Value::String(instance_short(iid)),
+        );
+        obj.insert("_dcc_type".to_string(), Value::String(dcc_type.to_string()));
+    }
+}
+
+// ── Tools-list fingerprint (for SSE tools/list_changed aggregation) ─────────
+
+/// Compute a fingerprint of the aggregated tool list across every live backend.
+///
+/// The fingerprint is a stable, sorted concatenation of `{instance_id}:{tool_name}`
+/// across every live backend.  When this string changes between two polls, we
+/// know at least one backend's tool list mutated (skill loaded / unloaded) and
+/// we can push a single `notifications/tools/list_changed` to all connected
+/// gateway SSE clients.
+///
+/// Deliberately excludes tool descriptions / schemas: we only want to detect
+/// set-level add/remove changes, not metadata edits.
+pub async fn compute_tools_fingerprint(
+    registry: &std::sync::Arc<
+        tokio::sync::RwLock<dcc_mcp_transport::discovery::file_registry::FileRegistry>,
+    >,
+    stale_timeout: Duration,
+    http_client: &reqwest::Client,
+) -> String {
+    let instances: Vec<ServiceEntry> = {
+        let reg = registry.read().await;
+        reg.list_all()
+            .into_iter()
+            .filter(|e| {
+                !e.is_stale(stale_timeout)
+                    && e.dcc_type != super::GATEWAY_SENTINEL_DCC_TYPE
+                    && !matches!(
+                        e.status,
+                        dcc_mcp_transport::discovery::types::ServiceStatus::ShuttingDown
+                            | dcc_mcp_transport::discovery::types::ServiceStatus::Unreachable
+                    )
+            })
+            .collect()
+    };
+
+    let futs = instances.iter().map(|entry| async move {
+        let url = format!("http://{}:{}/mcp", entry.host, entry.port);
+        let tools = fetch_tools(http_client, &url, BACKEND_TIMEOUT).await;
+        (entry.instance_id, tools)
+    });
+    let results = join_all(futs).await;
+
+    let mut parts: Vec<String> = results
+        .into_iter()
+        .flat_map(|(iid, tools)| {
+            tools
+                .into_iter()
+                .map(move |t| format!("{iid}:{}", t.name))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    parts.sort_unstable();
+    parts.join("|")
+}
+
+// ── Skill-management tool schemas ──────────────────────────────────────────
+
+/// JSON-Schema definitions for the six skill-management tools the gateway
+/// exposes (matching the per-DCC server schemas but with gateway-specific
+/// routing parameters like `instance_id` and `dcc`).
+fn skill_management_tool_defs() -> Vec<Value> {
+    vec![
+        json!({
+            "name": "list_skills",
+            "description": "List all skills across every live DCC instance. Returns a per-instance breakdown.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "status": {"type": "string", "enum": ["all", "loaded", "unloaded", "error"], "default": "all"},
+                    "dcc":    {"type": "string", "description": "Restrict to one DCC type (maya, blender, …)"}
+                }
+            }
+        }),
+        json!({
+            "name": "find_skills",
+            "description": "Search skills by query/tags/dcc across every live DCC instance.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "tags":  {"type": "array", "items": {"type": "string"}},
+                    "dcc":   {"type": "string"}
+                }
+            }
+        }),
+        json!({
+            "name": "search_skills",
+            "description": "Keyword search over skills in every live DCC instance. Use this to discover \
+                            skills before calling load_skill.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "dcc":   {"type": "string"}
+                },
+                "required": ["query"]
+            }
+        }),
+        json!({
+            "name": "get_skill_info",
+            "description": "Get detailed skill info (tools, scripts, dependencies) from each instance that has it.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "skill_name": {"type": "string"},
+                    "dcc":        {"type": "string"}
+                },
+                "required": ["skill_name"]
+            }
+        }),
+        json!({
+            "name": "load_skill",
+            "description": "Load a skill on a specific DCC instance. When multiple instances are live, \
+                            pass `instance_id` (or the short prefix from list_dcc_instances). With a single \
+                            live instance the routing is automatic.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "skill_name":  {"type": "string"},
+                    "skill_names": {"type": "array", "items": {"type": "string"}},
+                    "instance_id": {"type": "string", "description": "Target instance (full UUID or short prefix)"},
+                    "dcc":         {"type": "string", "description": "DCC type when only one instance of that type is live"}
+                }
+            }
+        }),
+        json!({
+            "name": "unload_skill",
+            "description": "Unload a skill on a specific DCC instance. Same routing rules as load_skill.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "skill_name":  {"type": "string"},
+                    "instance_id": {"type": "string"},
+                    "dcc":         {"type": "string"}
+                },
+                "required": ["skill_name"]
+            }
+        }),
+    ]
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn skill_management_tool_defs_cover_all_six_tools() {
+        let defs = skill_management_tool_defs();
+        let names: Vec<&str> = defs
+            .iter()
+            .filter_map(|v| v.get("name").and_then(|n| n.as_str()))
+            .collect();
+        for expected in [
+            "list_skills",
+            "find_skills",
+            "search_skills",
+            "get_skill_info",
+            "load_skill",
+            "unload_skill",
+        ] {
+            assert!(names.contains(&expected), "missing tool def {expected}");
+        }
+        assert_eq!(defs.len(), 6, "expected exactly 6 skill-management tools");
+    }
+
+    #[test]
+    fn skill_management_tool_defs_all_declare_input_schema() {
+        for def in skill_management_tool_defs() {
+            let schema = def.get("inputSchema").expect("inputSchema present");
+            assert_eq!(
+                schema.get("type").and_then(|v| v.as_str()),
+                Some("object"),
+                "schema for {} is not an object",
+                def.get("name").unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn inject_instance_metadata_adds_annotations_to_object() {
+        let id = Uuid::parse_str("abcdef0123456789abcdef0123456789").unwrap();
+        let mut value = json!({"existing": "field"});
+        inject_instance_metadata(&mut value, &id, "maya");
+
+        let obj = value.as_object().unwrap();
+        assert_eq!(obj.get("existing").unwrap(), &json!("field"));
+        assert_eq!(obj.get("_instance_id").unwrap(), &json!(id.to_string()));
+        assert_eq!(obj.get("_instance_short").unwrap(), &json!("abcdef01"));
+        assert_eq!(obj.get("_dcc_type").unwrap(), &json!("maya"));
+    }
+
+    #[test]
+    fn inject_instance_metadata_is_noop_for_non_objects() {
+        let id = Uuid::new_v4();
+        // Arrays and scalars cannot receive annotations — the helper must
+        // silently skip them rather than panic.
+        let mut arr = json!([1, 2, 3]);
+        inject_instance_metadata(&mut arr, &id, "blender");
+        assert_eq!(arr, json!([1, 2, 3]));
+
+        let mut s = json!("scalar");
+        inject_instance_metadata(&mut s, &id, "blender");
+        assert_eq!(s, json!("scalar"));
+    }
+
+    #[test]
+    fn to_text_result_maps_ok_to_success() {
+        let (text, is_error) = to_text_result(Ok("payload".to_string()));
+        assert_eq!(text, "payload");
+        assert!(!is_error);
+    }
+
+    #[test]
+    fn to_text_result_maps_err_to_error() {
+        let (text, is_error) = to_text_result(Err("boom".to_string()));
+        assert_eq!(text, "boom");
+        assert!(is_error);
+    }
+}

--- a/crates/dcc-mcp-http/src/gateway/backend_client.rs
+++ b/crates/dcc-mcp-http/src/gateway/backend_client.rs
@@ -1,0 +1,235 @@
+//! Thin JSON-RPC client used by the gateway to talk to each backend DCC server.
+//!
+//! Each backend is a full `McpHttpServer` listening on `http://{host}:{port}/mcp`.
+//! The gateway calls `tools/list` and `tools/call` on them to aggregate the
+//! facade-style unified MCP endpoint exposed by the gateway itself.
+//!
+//! Intentionally stateless and session-less: backends accept `tools/list` /
+//! `tools/call` without a prior `initialize` handshake (see `dispatch_request`
+//! in `handler.rs`), which keeps the client trivial and race-free under
+//! parallel fan-out.
+
+use std::time::Duration;
+
+use serde_json::{Value, json};
+
+use crate::protocol::{JsonRpcResponse, McpTool};
+
+/// Call a JSON-RPC method on a backend `/mcp` endpoint.
+///
+/// Returns the raw `result` value on success, or an error string on transport
+/// / protocol failure. Timeouts are inherited from the `reqwest::Client`.
+pub async fn call_backend(
+    client: &reqwest::Client,
+    mcp_url: &str,
+    method: &str,
+    params: Option<Value>,
+    timeout: Duration,
+) -> Result<Value, String> {
+    let req_body = json!({
+        "jsonrpc": "2.0",
+        "id": uuid_like_id(),
+        "method": method,
+        "params": params.unwrap_or(Value::Null),
+    });
+
+    let resp = client
+        .post(mcp_url)
+        .timeout(timeout)
+        .header("content-type", "application/json")
+        .header("accept", "application/json")
+        .body(req_body.to_string())
+        .send()
+        .await
+        .map_err(|e| format!("{mcp_url}: transport error: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(format!(
+            "{mcp_url}: HTTP {}: {}",
+            resp.status(),
+            resp.text().await.unwrap_or_default()
+        ));
+    }
+
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| format!("{mcp_url}: read body: {e}"))?;
+
+    let parsed: JsonRpcResponse = serde_json::from_str(&text)
+        .map_err(|e| format!("{mcp_url}: invalid JSON-RPC response: {e}"))?;
+
+    if let Some(err) = parsed.error {
+        return Err(format!(
+            "{mcp_url}: backend error {}: {}",
+            err.code, err.message
+        ));
+    }
+
+    parsed
+        .result
+        .ok_or_else(|| format!("{mcp_url}: empty JSON-RPC result"))
+}
+
+/// Fetch `tools/list` from a backend and return the deserialised [`McpTool`] list.
+///
+/// On any failure returns an empty vector and logs a warning — callers aggregate
+/// tools across many backends and should not fail the whole fan-out because one
+/// instance is unreachable.
+pub async fn fetch_tools(
+    client: &reqwest::Client,
+    mcp_url: &str,
+    timeout: Duration,
+) -> Vec<McpTool> {
+    match call_backend(client, mcp_url, "tools/list", None, timeout).await {
+        Ok(val) => val
+            .get("tools")
+            .and_then(Value::as_array)
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| serde_json::from_value::<McpTool>(v.clone()).ok())
+                    .collect()
+            })
+            .unwrap_or_default(),
+        Err(e) => {
+            tracing::warn!(mcp_url = %mcp_url, error = %e, "Backend tools/list failed");
+            Vec::new()
+        }
+    }
+}
+
+/// Forward a `tools/call` to a backend and return the raw result JSON.
+pub async fn forward_tools_call(
+    client: &reqwest::Client,
+    mcp_url: &str,
+    tool_name: &str,
+    arguments: Option<Value>,
+    timeout: Duration,
+) -> Result<Value, String> {
+    call_backend(
+        client,
+        mcp_url,
+        "tools/call",
+        Some(json!({"name": tool_name, "arguments": arguments.unwrap_or(json!({}))})),
+        timeout,
+    )
+    .await
+}
+
+/// Short non-cryptographic unique ID for JSON-RPC request correlation.
+///
+/// We don't need uuid-level uniqueness here; the client issues one request per
+/// call and reads its own response synchronously.  A timestamp-derived value is
+/// enough to keep request IDs distinct in tracing.
+fn uuid_like_id() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static CTR: AtomicU64 = AtomicU64::new(0);
+    let n = CTR.fetch_add(1, Ordering::Relaxed);
+    format!("gw-{n}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uuid_like_id_increments_monotonically() {
+        // Same-process sequence never collides; relative ordering preserved.
+        let a = uuid_like_id();
+        let b = uuid_like_id();
+        assert_ne!(a, b);
+        assert!(a.starts_with("gw-"));
+        assert!(b.starts_with("gw-"));
+    }
+
+    /// Helper used only in tests — parse a canned JSON-RPC response body the
+    /// same way `call_backend` does after HTTP success, so we can unit-test the
+    /// error / empty-result / tools-list-extraction branches without spinning
+    /// up a real HTTP server.
+    fn parse_response_body(body: &str) -> Result<Value, String> {
+        let parsed: JsonRpcResponse =
+            serde_json::from_str(body).map_err(|e| format!("invalid JSON-RPC response: {e}"))?;
+        if let Some(err) = parsed.error {
+            return Err(format!("backend error {}: {}", err.code, err.message));
+        }
+        parsed
+            .result
+            .ok_or_else(|| "empty JSON-RPC result".to_string())
+    }
+
+    #[test]
+    fn parses_success_result() {
+        let body = r#"{"jsonrpc":"2.0","id":"gw-1","result":{"tools":[]}}"#;
+        let result = parse_response_body(body).unwrap();
+        assert_eq!(result, json!({"tools": []}));
+    }
+
+    #[test]
+    fn parses_backend_error_into_error_string() {
+        let body =
+            r#"{"jsonrpc":"2.0","id":"gw-1","error":{"code":-32601,"message":"Method not found"}}"#;
+        let err = parse_response_body(body).unwrap_err();
+        assert!(err.contains("-32601"));
+        assert!(err.contains("Method not found"));
+    }
+
+    #[test]
+    fn treats_missing_result_as_error() {
+        let body = r#"{"jsonrpc":"2.0","id":"gw-1"}"#;
+        let err = parse_response_body(body).unwrap_err();
+        assert!(err.contains("empty"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_malformed_json() {
+        let body = "not json at all";
+        let err = parse_response_body(body).unwrap_err();
+        assert!(err.contains("invalid JSON-RPC"), "got: {err}");
+    }
+
+    #[test]
+    fn extracts_tools_array_from_tools_list_result() {
+        // Mirrors the inner `.get("tools").and_then(as_array)` path in fetch_tools.
+        let result = json!({
+            "tools": [
+                {"name": "create_sphere", "description": "make sphere", "inputSchema": {"type": "object"}},
+                {"name": "delete_node", "description": "delete", "inputSchema": {"type": "object"}}
+            ]
+        });
+        let tools: Vec<McpTool> = result
+            .get("tools")
+            .and_then(Value::as_array)
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| serde_json::from_value::<McpTool>(v.clone()).ok())
+                    .collect()
+            })
+            .unwrap_or_default();
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[0].name, "create_sphere");
+        assert_eq!(tools[1].name, "delete_node");
+    }
+
+    #[test]
+    fn handles_tools_list_with_malformed_entries_gracefully() {
+        // One good tool + one malformed entry should yield a list of exactly
+        // the good tool — the bad one is silently dropped (fetch_tools policy).
+        let result = json!({
+            "tools": [
+                {"name": "good_tool", "description": "ok", "inputSchema": {"type": "object"}},
+                {"not_a_tool": true}
+            ]
+        });
+        let tools: Vec<McpTool> = result
+            .get("tools")
+            .and_then(Value::as_array)
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| serde_json::from_value::<McpTool>(v.clone()).ok())
+                    .collect()
+            })
+            .unwrap_or_default();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name, "good_tool");
+    }
+}

--- a/crates/dcc-mcp-http/src/gateway/handlers.rs
+++ b/crates/dcc-mcp-http/src/gateway/handlers.rs
@@ -14,11 +14,9 @@ use tokio_stream::StreamExt;
 use tokio_stream::wrappers::BroadcastStream;
 
 use super::super::gateway::is_newer_version;
+use super::aggregator;
 use super::proxy::proxy_request;
 use super::state::{GatewayState, entry_to_json};
-use super::tools::{
-    gateway_tool_defs, tool_connect_to_dcc, tool_get_instance, tool_list_instances,
-};
 use dcc_mcp_transport::discovery::types::ServiceStatus;
 
 /// Minimal JSON-RPC 2.0 request shape accepted by the gateway `/mcp` endpoint.
@@ -177,10 +175,14 @@ pub async fn handle_instances(State(gs): State<GatewayState>) -> impl IntoRespon
 
 // ── MCP endpoint ──────────────────────────────────────────────────────────────
 
-/// `POST /mcp` — gateway's own MCP endpoint with discovery meta-tools.
-/// Does NOT proxy; returns direct URLs for agents to use.
+/// `POST /mcp` — gateway's own MCP endpoint (facade over every live DCC).
+///
+/// Aggregates `tools/list` from every backend, routes `tools/call` by the
+/// instance-prefix encoded into each tool name, and handles the 3 discovery
+/// meta-tools + 6 skill-management tools locally / with fan-out.
 pub async fn handle_gateway_mcp(
     State(gs): State<GatewayState>,
+    headers: HeaderMap,
     body: axum::body::Bytes,
 ) -> Response {
     let req: JsonRpcRequest = match serde_json::from_slice(&body) {
@@ -194,6 +196,13 @@ pub async fn handle_gateway_mcp(
         }
     };
 
+    // Preserve the client's session id (if any) so the SSE subscription opened
+    // via GET /mcp can correlate with POST /mcp calls.
+    let client_session_id = headers
+        .get("Mcp-Session-Id")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+
     let id = req.id.clone();
     let resp = match req.method.as_str() {
         "initialize" => json!({
@@ -201,35 +210,35 @@ pub async fn handle_gateway_mcp(
             "result": {
                 "protocolVersion": "2025-03-26",
                 "capabilities": {
-                    // Tool schemas never change — the 3 meta-tools are always present.
-                    "tools": {"listChanged": false},
+                    // Aggregated tool list changes as backends load/unload skills.
+                    "tools": {"listChanged": true},
                     // Resources (DCC instances) change dynamically.
                     // Clients should subscribe to GET /mcp SSE stream for push notifications.
                     "resources": {"listChanged": true, "subscribe": true}
                 },
                 "serverInfo": {"name": gs.server_name, "version": gs.server_version},
                 "instructions":
-                    "DCC-MCP Gateway — multi-instance discovery.\n\
+                    "DCC-MCP Gateway — unified MCP endpoint across every live DCC.\n\
                      \n\
-                     DYNAMIC DISCOVERY (recommended):\n\
-                     • Open a persistent SSE connection to GET /mcp (Accept: text/event-stream)\n\
-                     • Call resources/list to see current DCC instances as MCP resources\n\
-                     • Receive notifications/resources/list_changed pushed over SSE when instances join/leave\n\
-                     • Call resources/read with a dcc:// URI to get full instance details\n\
+                     tools/list returns:\n\
+                     • 3 discovery meta-tools (list_dcc_instances / get_dcc_instance / connect_to_dcc)\n\
+                     • 6 skill-management tools (list/find/search/get_info/load/unload_skill)\n\
+                     • Every backend tool, prefixed with an 8-char instance id (e.g. abcd1234__maya_geometry__create_sphere)\n\
                      \n\
-                     TOOL-BASED DISCOVERY:\n\
-                     • Call list_dcc_instances — always returns the live snapshot\n\
-                     • Call connect_to_dcc to get a direct MCP URL (zero proxy overhead)\n\
-                     • Or POST /mcp/{instance_id} for transparent proxying"
+                     Workflow:\n\
+                     1. search_skills(query=...) — find relevant skills across every live DCC\n\
+                     2. load_skill(skill_name=..., instance_id=... when multiple instances exist)\n\
+                     3. Call the prefixed tool directly through this same endpoint\n\
+                     \n\
+                     Subscribe to GET /mcp (SSE) for notifications/tools/list_changed and\n\
+                     notifications/resources/list_changed push events."
             }
         }),
         "ping" => json!({"jsonrpc":"2.0","id":id,"result":{}}),
         "notifications/initialized" => json!({"jsonrpc":"2.0","id":id,"result":{}}),
         "tools/list" => {
-            json!({
-                "jsonrpc": "2.0", "id": id,
-                "result": {"tools": gateway_tool_defs(), "nextCursor": null}
-            })
+            let result = aggregator::aggregate_tools_list(&gs).await;
+            json!({"jsonrpc": "2.0", "id": id, "result": result})
         }
         // ── MCP Resources API ─────────────────────────────────────────────
         // Each live DCC instance is a resource with URI: dcc://{dcc_type}/{instance_id}
@@ -316,23 +325,11 @@ pub async fn handle_gateway_mcp(
                 .cloned()
                 .unwrap_or(json!({}));
 
-            let result = match tool {
-                "list_dcc_instances" => tool_list_instances(&gs, &args).await,
-                "get_dcc_instance" => tool_get_instance(&gs, &args).await,
-                "connect_to_dcc" => tool_connect_to_dcc(&gs, &args).await,
-                other => Err(format!("Unknown tool: {other}")),
-            };
-
-            match result {
-                Ok(text) => json!({
-                    "jsonrpc": "2.0", "id": id,
-                    "result": {"content": [{"type": "text", "text": text}], "isError": false}
-                }),
-                Err(msg) => json!({
-                    "jsonrpc": "2.0", "id": id,
-                    "result": {"content": [{"type": "text", "text": msg}], "isError": true}
-                }),
-            }
+            let (text, is_error) = aggregator::route_tools_call(&gs, tool, &args).await;
+            json!({
+                "jsonrpc": "2.0", "id": id,
+                "result": {"content": [{"type": "text", "text": text}], "isError": is_error}
+            })
         }
         other => json!({
             "jsonrpc": "2.0", "id": id,
@@ -340,10 +337,15 @@ pub async fn handle_gateway_mcp(
         }),
     };
 
+    // Session id: reuse the one the client sent if present; otherwise mint a
+    // fresh per-client token so streaming-http clients can correlate their
+    // POST requests with their GET /mcp SSE subscription.
+    let session_value =
+        client_session_id.unwrap_or_else(|| format!("gw-{}", uuid::Uuid::new_v4().simple()));
     let mut response = Json(resp).into_response();
-    response
-        .headers_mut()
-        .insert("Mcp-Session-Id", "dcc-mcp-gateway".parse().unwrap());
+    if let Ok(hv) = session_value.parse() {
+        response.headers_mut().insert("Mcp-Session-Id", hv);
+    }
     response
 }
 

--- a/crates/dcc-mcp-http/src/gateway/mod.rs
+++ b/crates/dcc-mcp-http/src/gateway/mod.rs
@@ -24,7 +24,10 @@
 //! # }
 //! ```
 
+pub mod aggregator;
+pub mod backend_client;
 pub mod handlers;
+pub mod namespace;
 pub mod proxy;
 pub mod router;
 pub mod state;
@@ -128,10 +131,17 @@ async fn start_gateway_tasks(
     let yield_tx = Arc::new(yield_tx);
 
     // ── SSE broadcast channel ──────────────────────────────────────────────
-    // All MCP notifications (resources/list_changed, etc.) are sent here.
-    // Capacity 128 is generous; the watcher fires at most once every 2 s.
+    // All MCP notifications (resources/list_changed, tools/list_changed) are
+    // sent here. Capacity 128 is generous; watchers fire at most every 2-3 s.
     let (events_tx, _) = broadcast::channel::<String>(128);
     let events_tx = Arc::new(events_tx);
+
+    // ── Shared HTTP client for backend fan-out ─────────────────────────────
+    // Reused by both the tools-list watcher task and the facade /mcp handler
+    // via GatewayState so connection pooling is shared across all consumers.
+    let http_client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()?;
 
     // ── Stale cleanup + challenger detection (every 15 s) ─────────────────
     let reg_cleanup = registry.clone();
@@ -206,15 +216,66 @@ async fn start_gateway_tasks(
         }
     });
 
+    // ── Aggregated tools/list_changed watcher (every 3 s) ─────────────────
+    // Polls every live backend's `tools/list`, computes a set-fingerprint of
+    // "{instance_id}:{tool_name}" tuples, and broadcasts one
+    // `notifications/tools/list_changed` to gateway SSE subscribers when the
+    // aggregated set changes (skill loaded / unloaded on any DCC).
+    //
+    // Polling (vs. real SSE subscription to each backend) keeps the gateway
+    // decoupled from backend session lifecycles and works uniformly even when
+    // instances come and go. 3-second granularity is well within the latency
+    // budget for interactive skill loading.
+    let reg_tools = registry.clone();
+    let events_tx_tools = events_tx.clone();
+    let http_client_tools = http_client.clone();
+    let tools_watcher_handle = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(3));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let mut last_fingerprint = String::new();
+
+        loop {
+            interval.tick().await;
+            // Skip polling when no clients are listening — keeps idle gateways
+            // from hammering backends.
+            if events_tx_tools.receiver_count() == 0 {
+                continue;
+            }
+
+            let fingerprint = aggregator::compute_tools_fingerprint(
+                &reg_tools,
+                stale_timeout,
+                &http_client_tools,
+            )
+            .await;
+
+            if fingerprint != last_fingerprint {
+                // First tick always "changes" from empty-string → don't push
+                // on initial startup unless there are actually tools.
+                if !last_fingerprint.is_empty() || !fingerprint.is_empty() {
+                    tracing::debug!(
+                        "Gateway: aggregated tool set changed — broadcasting tools/list_changed"
+                    );
+                    let notif = serde_json::to_string(&serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "method": "notifications/tools/list_changed",
+                        "params": {}
+                    }))
+                    .unwrap_or_default();
+                    let _ = events_tx_tools.send(notif);
+                }
+                last_fingerprint = fingerprint;
+            }
+        }
+    });
+
     // ── Gateway HTTP server ────────────────────────────────────────────────
     let gw_state = GatewayState {
         registry,
         stale_timeout,
         server_name,
         server_version,
-        http_client: reqwest::Client::builder()
-            .timeout(Duration::from_secs(30))
-            .build()?,
+        http_client,
         yield_tx: yield_tx.clone(),
         events_tx,
     };
@@ -244,7 +305,12 @@ async fn start_gateway_tasks(
 
     // Combine all tasks under one abort handle.
     let combined = tokio::spawn(async move {
-        let _ = tokio::join!(cleanup_handle, watcher_handle, gw_handle);
+        let _ = tokio::join!(
+            cleanup_handle,
+            watcher_handle,
+            tools_watcher_handle,
+            gw_handle
+        );
     });
 
     Ok((combined.abort_handle(), yield_tx))

--- a/crates/dcc-mcp-http/src/gateway/namespace.rs
+++ b/crates/dcc-mcp-http/src/gateway/namespace.rs
@@ -1,0 +1,169 @@
+//! Tool-name namespace helpers for the aggregating gateway.
+//!
+//! The gateway aggregates `tools/list` from every live backend and exposes
+//! the union through its own MCP endpoint.  Backends can share tool names
+//! (two Maya instances both loading `maya-geometry` end up advertising a tool
+//! called `maya_geometry__create_sphere`), so the gateway prefixes every
+//! *backend-provided* tool name with a short instance token:
+//!
+//! ```text
+//! {id8}__{original_tool_name}
+//! └─┬─┘
+//!   └── first 8 hex characters of the backend's instance UUID
+//! ```
+//!
+//! The `__` separator is the same double-underscore convention skills already
+//! use, so prefixed names remain valid JSON-Schema tool identifiers and agents
+//! can still visually split them into "instance / skill / tool" chunks.
+//!
+//! Reserved names that the gateway handles **locally** and therefore never
+//! prefixes: every entry in [`GATEWAY_LOCAL_TOOLS`].  Callers should consult
+//! [`is_local_tool`] before routing to a backend.
+
+use uuid::Uuid;
+
+/// Tool names that the gateway handles itself without forwarding to a backend.
+///
+/// The first three are gateway discovery meta-tools; the remaining six are the
+/// core skill-management tools proxied / fanned-out by the gateway with
+/// aggregated semantics.
+pub const GATEWAY_LOCAL_TOOLS: &[&str] = &[
+    // Gateway discovery meta-tools
+    "list_dcc_instances",
+    "get_dcc_instance",
+    "connect_to_dcc",
+    // Skill-management tools (fanned out or routed to a target instance)
+    "list_skills",
+    "find_skills",
+    "search_skills",
+    "get_skill_info",
+    "load_skill",
+    "unload_skill",
+];
+
+/// Length of the instance-id prefix the gateway encodes into tool names.
+///
+/// Eight hex characters (~32 bits of randomness) is enough to disambiguate a
+/// handful of concurrent DCC instances without bloating every tool name.
+pub const ID_PREFIX_LEN: usize = 8;
+
+/// Separator between the instance prefix and the original tool name.
+pub const NAMESPACE_SEP: &str = "__";
+
+/// Return `true` when the tool is handled directly by the gateway (no routing).
+pub fn is_local_tool(name: &str) -> bool {
+    GATEWAY_LOCAL_TOOLS.contains(&name)
+}
+
+/// Short identifier for a backend instance (first [`ID_PREFIX_LEN`] hex chars
+/// of the UUID).
+pub fn instance_short(id: &Uuid) -> String {
+    let mut s = id.simple().to_string();
+    s.truncate(ID_PREFIX_LEN);
+    s
+}
+
+/// Prefix a backend-provided tool name with the instance short id.
+pub fn encode_tool_name(id: &Uuid, original: &str) -> String {
+    format!("{}{NAMESPACE_SEP}{original}", instance_short(id))
+}
+
+/// Strip the gateway prefix.  Returns `(instance_short, original_name)` when
+/// the name is a prefixed backend tool; `None` for local / malformed names.
+pub fn decode_tool_name(prefixed: &str) -> Option<(&str, &str)> {
+    // Early reject for local tools (they never contain the prefix).
+    if is_local_tool(prefixed) {
+        return None;
+    }
+
+    let (prefix, rest) = prefixed.split_once(NAMESPACE_SEP)?;
+    if prefix.len() != ID_PREFIX_LEN || !prefix.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    Some((prefix, rest))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_then_decode_roundtrips() {
+        let id = Uuid::parse_str("abcdef0123456789abcdef0123456789").unwrap();
+        let encoded = encode_tool_name(&id, "maya_geometry__create_sphere");
+        assert_eq!(encoded, "abcdef01__maya_geometry__create_sphere");
+        let (prefix, original) = decode_tool_name(&encoded).unwrap();
+        assert_eq!(prefix, "abcdef01");
+        assert_eq!(original, "maya_geometry__create_sphere");
+    }
+
+    #[test]
+    fn local_tools_decode_to_none() {
+        for name in GATEWAY_LOCAL_TOOLS {
+            assert!(decode_tool_name(name).is_none(), "{name} should be local");
+        }
+    }
+
+    #[test]
+    fn decodes_skill_stub_name() {
+        let id = Uuid::parse_str("11111111222233334444555566667777").unwrap();
+        let encoded = encode_tool_name(&id, "__skill__maya-geometry");
+        // encoded looks like "11111111____skill__maya-geometry"
+        let (prefix, original) = decode_tool_name(&encoded).unwrap();
+        assert_eq!(prefix, "11111111");
+        assert_eq!(original, "__skill__maya-geometry");
+    }
+
+    #[test]
+    fn rejects_non_hex_prefix() {
+        assert!(decode_tool_name("abcdefgz__tool").is_none());
+        assert!(decode_tool_name("short__tool").is_none());
+        assert!(decode_tool_name("no_separator").is_none());
+    }
+
+    #[test]
+    fn instance_short_is_exactly_eight_chars() {
+        let id = Uuid::new_v4();
+        assert_eq!(instance_short(&id).len(), ID_PREFIX_LEN);
+    }
+
+    #[test]
+    fn instance_short_is_deterministic() {
+        let id = Uuid::parse_str("abcdef0123456789abcdef0123456789").unwrap();
+        assert_eq!(instance_short(&id), "abcdef01");
+        // Stable across repeated calls.
+        assert_eq!(instance_short(&id), instance_short(&id));
+    }
+
+    #[test]
+    fn is_local_tool_recognizes_meta_and_skill_management() {
+        // Discovery meta-tools.
+        assert!(is_local_tool("list_dcc_instances"));
+        assert!(is_local_tool("get_dcc_instance"));
+        assert!(is_local_tool("connect_to_dcc"));
+        // Skill-management tools.
+        assert!(is_local_tool("search_skills"));
+        assert!(is_local_tool("load_skill"));
+        assert!(is_local_tool("unload_skill"));
+        // Non-local.
+        assert!(!is_local_tool("create_sphere"));
+        assert!(!is_local_tool("abcdef01__create_sphere"));
+    }
+
+    #[test]
+    fn different_uuids_produce_different_prefixes() {
+        let a = Uuid::parse_str("aaaaaaaa0000000000000000aaaaaaaa").unwrap();
+        let b = Uuid::parse_str("bbbbbbbb0000000000000000bbbbbbbb").unwrap();
+        assert_ne!(instance_short(&a), instance_short(&b));
+        assert_ne!(encode_tool_name(&a, "foo"), encode_tool_name(&b, "foo"));
+    }
+
+    #[test]
+    fn decode_rejects_empty_string_and_separator_only() {
+        assert!(decode_tool_name("").is_none());
+        assert!(decode_tool_name("__").is_none());
+        assert!(decode_tool_name("abcdef01__").is_some()); // valid prefix, empty suffix
+        // NOTE: Empty suffix is accepted by the decoder — callers are
+        // responsible for treating it as malformed where relevant.
+    }
+}

--- a/crates/dcc-mcp-http/src/handler.rs
+++ b/crates/dcc-mcp-http/src/handler.rs
@@ -663,52 +663,98 @@ async fn handle_load_skill(
         ));
     }
 
-    let mut all_registered_tools = Vec::new();
-    let mut errors = Vec::new();
-
-    // Load single skill
+    // Collect the full set of requested skills, deduping `skill_name` vs the
+    // `skill_names` array so callers passing both don't trigger the work twice.
+    let mut requested: Vec<String> = Vec::new();
     if !skill_name.is_empty() {
-        match state.catalog.load_skill(skill_name) {
-            Ok(tools) => all_registered_tools.extend(tools),
-            Err(e) => errors.push(format!("{skill_name}: {e}")),
+        requested.push(skill_name.to_string());
+    }
+    for name in &skill_names {
+        if !requested.contains(name) {
+            requested.push(name.clone());
         }
     }
 
-    // Load multiple skills
-    for name in &skill_names {
+    let mut all_registered_tools: Vec<String> = Vec::new();
+    let mut errors: Vec<String> = Vec::new();
+    let mut newly_loaded: Vec<String> = Vec::new();
+    let mut already_loaded: Vec<String> = Vec::new();
+
+    for name in &requested {
+        let was_loaded = state.catalog.is_loaded(name);
         match state.catalog.load_skill(name) {
-            Ok(tools) => all_registered_tools.extend(tools),
+            Ok(tools) => {
+                all_registered_tools.extend(tools);
+                if was_loaded {
+                    already_loaded.push(name.clone());
+                } else {
+                    newly_loaded.push(name.clone());
+                }
+            }
             Err(e) => errors.push(format!("{name}: {e}")),
         }
     }
 
-    // Send tools/list_changed notification to session if tools were loaded
-    if !all_registered_tools.is_empty() {
+    // Only notify tools/list_changed when at least one skill transitioned
+    // from unloaded → loaded.  Re-loading already-loaded skills is a no-op
+    // and must not trigger a spurious client refresh.
+    if !newly_loaded.is_empty() {
         if let Some(sid) = session_id {
             notify_tools_list_changed(&state.sessions, sid);
         }
     }
 
-    let text = if errors.is_empty() {
-        serde_json::to_string_pretty(&json!({
-            "loaded": true,
-            "registered_tools": all_registered_tools,
-            "tool_count": all_registered_tools.len()
-        }))
-        .unwrap_or_default()
-    } else {
-        serde_json::to_string_pretty(&json!({
-            "loaded": errors.is_empty(),
-            "registered_tools": all_registered_tools,
-            "tool_count": all_registered_tools.len(),
-            "errors": errors
-        }))
-        .unwrap_or_default()
-    };
+    // Build the full tool metadata so agents can invoke the new tools without
+    // a second round-trip to `tools/list`.  One registry read per newly or
+    // previously loaded skill; keeps the payload self-contained.
+    let mut tool_schemas: Vec<Value> = Vec::new();
+    for name in newly_loaded.iter().chain(already_loaded.iter()) {
+        for meta in state.catalog.registry().list_actions_by_skill(name) {
+            tool_schemas.push(json!({
+                "name":          meta.name,
+                "description":   meta.description,
+                "inputSchema":   meta.input_schema,
+                "outputSchema":  meta.output_schema,
+                "skill_name":    meta.skill_name,
+            }));
+        }
+    }
 
+    // Response semantics:
+    // - `loaded` is true when at least one requested skill ended up loaded
+    //   (even if some others failed). This matches the caller's intuition
+    //   that "tools were registered" rather than treating any failure as total.
+    // - `partial` distinguishes mixed success/failure from clean success.
+    let loaded_ok = !all_registered_tools.is_empty();
+    let partial = loaded_ok && !errors.is_empty();
+
+    let mut body = json!({
+        "loaded":           loaded_ok,
+        "partial":          partial,
+        "registered_tools": all_registered_tools,
+        "tool_count":       all_registered_tools.len(),
+        "newly_loaded":     newly_loaded,
+        "already_loaded":   already_loaded,
+        "tools":            tool_schemas,
+    });
+    if !errors.is_empty() {
+        body.as_object_mut()
+            .unwrap()
+            .insert("errors".to_string(), json!(errors));
+    }
+
+    let text = serde_json::to_string_pretty(&body).unwrap_or_default();
+
+    // `isError` only when every requested skill failed — partial success is
+    // still reported as success so clients see the registered-tool list.
+    let result = if loaded_ok {
+        CallToolResult::text(text)
+    } else {
+        CallToolResult::error(text)
+    };
     Ok(JsonRpcResponse::success(
         req.id.clone(),
-        serde_json::to_value(CallToolResult::text(text))?,
+        serde_json::to_value(result)?,
     ))
 }
 
@@ -972,11 +1018,26 @@ fn action_meta_to_mcp_tool(meta: &dcc_mcp_actions::registry::ActionMeta) -> McpT
 ///
 /// Name format: `__skill__<skill_name>`
 fn build_skill_stub(summary: &SkillSummary) -> McpTool {
-    // RTK-inspired: ultra-compact format for skill stubs
-    // Format: [dcc] tool_count tools • load_skill("name")
+    // Compact stub format including a short tool-name preview so the agent
+    // can reason about which skill to load without a second `get_skill_info`
+    // round-trip. Limited to the first few names + ellipsis to keep the
+    // `tools/list` payload from ballooning on skills that expose many tools.
+    const PREVIEW_LIMIT: usize = 5;
+    let preview = if summary.tool_names.is_empty() {
+        String::new()
+    } else if summary.tool_names.len() <= PREVIEW_LIMIT {
+        format!(" ({})", summary.tool_names.join(", "))
+    } else {
+        format!(
+            " ({}, …+{} more)",
+            summary.tool_names[..PREVIEW_LIMIT].join(", "),
+            summary.tool_names.len() - PREVIEW_LIMIT
+        )
+    };
+
     let description = format!(
-        "[{}] {} tools • Call load_skill(\"{}\")",
-        summary.dcc, summary.tool_count, summary.name
+        "[{}] {} tools{} • Call load_skill(\"{}\")",
+        summary.dcc, summary.tool_count, preview, summary.name
     );
 
     McpTool {

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -205,7 +205,7 @@ print(f"Maya MCP server: {handle.mcp_url()}")
 
 ## Gateway
 
-When multiple DCC instances start simultaneously, one automatically becomes the **gateway** — a single well-known entry point that discovers and proxies to all running instances.
+When multiple DCC instances start simultaneously, one automatically becomes the **gateway** — a single well-known `/mcp` endpoint that **aggregates** every running instance's tools into one unified MCP interface.
 
 ### How it works
 
@@ -221,19 +221,24 @@ When multiple DCC instances start simultaneously, one automatically becomes the 
 |----------|--------|-------------|
 | `/instances` | GET | JSON list of all live instances |
 | `/health` | GET | `{"ok": true}` health check |
-| `/mcp` | POST | Gateway's own MCP endpoint (discovery meta-tools) |
-| `/mcp/{instance_id}` | POST | Transparent proxy to a specific instance |
+| `/mcp` | POST | Aggregating MCP endpoint (merges every backend's tools) |
+| `/mcp` | GET | SSE stream — `tools/list_changed` and `resources/list_changed` |
+| `/mcp/{instance_id}` | POST | Transparent proxy to a specific instance (low-level escape hatch) |
 | `/mcp/dcc/{dcc_type}` | POST | Proxy to the best instance of a DCC type |
 
-### Gateway MCP meta-tools
+### Aggregating facade
 
-The gateway exposes three discovery tools via its own `/mcp` endpoint:
+`POST /mcp` on the gateway is a single MCP server that exposes three tiers of tools merged into one `tools/list` response:
 
-| Tool | Description |
-|------|-------------|
-| `list_dcc_instances` | List all live DCC servers (type, port, scene, status) |
-| `get_dcc_instance` | Get info for a specific instance (by id or `dcc_type+scene`) |
-| `connect_to_dcc` | Return the direct MCP URL for a DCC instance |
+| Tier | Tools | Purpose |
+|------|-------|---------|
+| Discovery meta | `list_dcc_instances`, `get_dcc_instance`, `connect_to_dcc` | Enumerate / inspect live DCCs; get a direct MCP URL when needed |
+| Skill management | `list_skills`, `find_skills`, `search_skills`, `get_skill_info`, `load_skill`, `unload_skill` | Fan-out to every DCC (read ops) or target a specific instance via the `instance_id` / `dcc` argument (`load_skill` / `unload_skill`) |
+| Backend tools | Every live DCC's own tools, prefixed with an 8-char instance id — e.g. `a1b2c3d4__create_sphere` | Routed to the originating backend by the prefix |
+
+Each namespaced backend tool also carries `_instance_id`, `_instance_short`, and `_dcc_type` annotations so agents can disambiguate colliding names (e.g. `create_cube` on Maya and Blender appear as two distinct entries with different prefixes).
+
+The gateway advertises `capabilities.tools.listChanged: true` and polls backends every 3 s; when the aggregated set changes (skill loaded / unloaded anywhere) it broadcasts `notifications/tools/list_changed` to every connected SSE client.
 
 ### Python example
 
@@ -259,7 +264,7 @@ print(handle.mcp_url())         # direct MCP URL for this instance
 ```
 
 ::: tip Multiple DCCs, one endpoint
-Start any number of DCC servers — the first one wins the gateway port. Agents always connect to `http://localhost:9765/mcp` and use `list_dcc_instances` / `connect_to_dcc` to discover and route to specific DCC processes.
+Start any number of DCC servers — the first one wins the gateway port. Agents always connect to `http://localhost:9765/mcp` and see every backend's tools in a single `tools/list`, namespaced by instance. `list_dcc_instances` / `connect_to_dcc` are available when an agent wants a direct, un-proxied session.
 :::
 
 ::: info Skills-First + gateway

--- a/docs/guide/gateway-election.md
+++ b/docs/guide/gateway-election.md
@@ -4,12 +4,12 @@
 
 ## What is the Gateway?
 
-The **gateway** is a single Rust HTTP server (running on `localhost:9999` by default) that:
+The **gateway** is a single Rust HTTP server (running on `localhost:9765` by default) that:
 
 - Discovers all running DCC instances (Maya, Blender, Houdini, Photoshop, etc.)
-- Routes AI requests to the correct instance based on session
-- Exposes a scoped `tools/list` per session (prevents context explosion)
-- Handles cancellation and SSE notifications
+- Aggregates every live backend's tools into one unified `/mcp` endpoint (namespaced by `{instance_short}__{name}`)
+- Fans out skill-management calls (`search_skills`, `list_skills`) and routes targeted calls (`load_skill`) to a specific instance
+- Pushes `tools/list_changed` and `resources/list_changed` over SSE as skills load/unload or instances come and go
 
 **One gateway per machine**. It's started automatically when the first DCC instance registers.
 
@@ -162,9 +162,10 @@ session_b = mgr.get_or_create_session("maya", iid_rig)
 # Sessions are different — no context bleeding
 assert session_a != session_b
 
-# tools/list scoped to each session's instance
-# Agent A sees: maya_anim__set_keyframe, ...
-# Agent B sees: maya_rig__mirror_joints, ...
+# Through the aggregating gateway, both instances' tools appear in a single
+# tools/list with distinct 8-char prefixes, so the agent can target either:
+#   a1b2c3d4__set_keyframe   ← maya-animation
+#   e5f6g7h8__mirror_joints  ← maya-rigging
 ```
 
 ## Instance Health

--- a/docs/zh/api/http.md
+++ b/docs/zh/api/http.md
@@ -205,7 +205,7 @@ print(f"Maya MCP 服务器: {handle.mcp_url()}")
 
 ## 网关
 
-当多个 DCC 实例同时启动时，其中一个会自动成为**网关** — 一个统一的入口点，发现并代理所有运行中的实例。
+当多个 DCC 实例同时启动时，其中一个会自动成为**网关** — 一个统一的 `/mcp` 入口点，将所有运行中实例的工具**聚合**成单一 MCP 接口。
 
 ### 工作原理
 
@@ -221,19 +221,24 @@ print(f"Maya MCP 服务器: {handle.mcp_url()}")
 |------|------|------|
 | `/instances` | GET | 所有活跃实例的 JSON 列表 |
 | `/health` | GET | `{"ok": true}` 健康检查 |
-| `/mcp` | POST | 网关自身的 MCP 端点（发现元工具） |
-| `/mcp/{instance_id}` | POST | 透明代理到指定实例 |
+| `/mcp` | POST | 聚合 MCP 端点（合并所有后端工具） |
+| `/mcp` | GET | SSE 事件流 — 推送 `tools/list_changed` 与 `resources/list_changed` |
+| `/mcp/{instance_id}` | POST | 透明代理到指定实例（底层逃生通道） |
 | `/mcp/dcc/{dcc_type}` | POST | 代理到指定 DCC 类型的最佳实例 |
 
-### 网关 MCP 元工具
+### 聚合式 Facade
 
-网关通过自身的 `/mcp` 端点暴露三个发现工具：
+网关的 `POST /mcp` 是一个统一 MCP 服务器，在单次 `tools/list` 响应中合并三层工具：
 
-| 工具 | 说明 |
-|------|------|
-| `list_dcc_instances` | 列出所有活跃 DCC 服务器（类型、端口、场景、状态） |
-| `get_dcc_instance` | 获取指定实例的信息（按 id 或 `dcc_type+scene`） |
-| `connect_to_dcc` | 返回 DCC 实例的直接 MCP URL |
+| 层级 | 工具 | 用途 |
+|------|------|------|
+| 发现元工具 | `list_dcc_instances`、`get_dcc_instance`、`connect_to_dcc` | 枚举 / 查看活跃 DCC；需要直连时返回直接 MCP URL |
+| 技能管理 | `list_skills`、`find_skills`、`search_skills`、`get_skill_info`、`load_skill`、`unload_skill` | 读操作向全部 DCC 扇出；`load_skill` / `unload_skill` 通过 `instance_id` / `dcc` 参数指向具体实例 |
+| 后端工具 | 所有活跃 DCC 自身的工具，带 8 字符实例前缀 — 例如 `a1b2c3d4__create_sphere` | 按前缀路由回原始后端 |
+
+每个命名空间化的后端工具还会附带 `_instance_id`、`_instance_short`、`_dcc_type` 注解，以便 agent 消歧（比如 `create_cube` 在 Maya 和 Blender 上各注册一次时，会表现为两个带不同前缀的独立条目）。
+
+网关声明 `capabilities.tools.listChanged: true`，每 3 秒轮询后端；当聚合集合发生变化（任何一处加载 / 卸载 skill）时，向所有连接的 SSE 客户端广播 `notifications/tools/list_changed`。
 
 ### Python 示例
 
@@ -259,7 +264,7 @@ print(handle.mcp_url())         # 本实例的直接 MCP URL
 ```
 
 ::: tip 多 DCC、单入口
-启动任意数量的 DCC 服务器 — 第一个赢得网关端口。Agent 始终连接 `http://localhost:9765/mcp`，使用 `list_dcc_instances` / `connect_to_dcc` 发现并路由到特定 DCC 进程。
+启动任意数量的 DCC 服务器 — 第一个赢得网关端口。Agent 始终连接 `http://localhost:9765/mcp`，在单一 `tools/list` 中看到所有后端工具（按实例命名空间化）。需要直连、不经代理时再使用 `list_dcc_instances` / `connect_to_dcc`。
 :::
 
 ::: info Skills-First + 网关

--- a/docs/zh/guide/gateway-election.md
+++ b/docs/zh/guide/gateway-election.md
@@ -4,12 +4,12 @@
 
 ## 什么是网关？
 
-**网关**是一个单一的 Rust HTTP 服务器（默认运行在 `localhost:9999`），负责：
+**网关**是一个单一的 Rust HTTP 服务器（默认运行在 `localhost:9765`），负责：
 
 - 发现所有运行中的 DCC 实例（Maya、Blender、Houdini、Photoshop 等）
-- 根据会话将 AI 请求路由到正确的实例
-- 为每个会话提供有范围的 `tools/list`（防止上下文爆炸）
-- 处理请求取消和 SSE 通知
+- 将所有活跃后端的工具聚合到统一的 `/mcp` 端点（按 `{instance_short}__{name}` 命名空间化）
+- 对 skill 管理调用做扇出（`search_skills`、`list_skills`）或按实例路由（`load_skill`）
+- 当 skill 加载 / 卸载或实例进出时，通过 SSE 推送 `tools/list_changed` 和 `resources/list_changed`
 
 **每台机器只有一个网关**。当第一个 DCC 实例注册时自动启动。
 
@@ -162,9 +162,10 @@ session_b = mgr.get_or_create_session("maya", iid_rig)
 # 会话不同——无上下文混淆
 assert session_a != session_b
 
-# tools/list 按每个会话的实例过滤
-# 智能体 A 看到：maya_anim__set_keyframe, ...
-# 智能体 B 看到：maya_rig__mirror_joints, ...
+# 通过聚合式网关，两个实例的工具都会出现在同一份 tools/list 中，
+# 通过 8 字符前缀区分，agent 可定向调用任一实例：
+#   a1b2c3d4__set_keyframe   ← maya-animation
+#   e5f6g7h8__mirror_joints  ← maya-rigging
 ```
 
 ## 实例健康检查

--- a/tests/test_gateway_facade_aggregation.py
+++ b/tests/test_gateway_facade_aggregation.py
@@ -1,0 +1,219 @@
+"""Integration tests for the aggregating-facade gateway.
+
+The facade gateway exposes a single ``/mcp`` endpoint that merges tools from
+every live DCC backend into one namespaced list. These tests start two real
+``McpHttpServer`` instances sharing a common ``FileRegistry`` directory and a
+gateway port, then drive the gateway's MCP endpoint directly to verify:
+
+* The first server to bind the gateway port wins the election and serves the
+  aggregated endpoint; the second registers as a plain backend.
+* ``tools/list`` on the gateway returns the 3 discovery meta-tools, the 6
+  skill-management tools, plus every backend tool namespaced with an 8-char
+  instance prefix (``<short>__<original>``).
+* Tool-name collisions across DCCs never surface — each backend tool carries
+  ``_instance_id`` / ``_dcc_type`` annotations so agents can disambiguate.
+* ``initialize`` advertises ``tools.listChanged: true`` and
+  ``resources.listChanged: true`` so clients know to subscribe to SSE.
+
+These tests run on real TCP so they need short timeouts and an unused port
+range; we pick a fixed port far above the default (9765) to avoid collisions
+with concurrent development instances.
+"""
+
+from __future__ import annotations
+
+# Import built-in modules
+import contextlib
+import json
+from pathlib import Path
+import socket
+import time
+import urllib.request
+
+# Import third-party modules
+import pytest
+
+# Import local modules
+from dcc_mcp_core import McpHttpConfig
+from dcc_mcp_core import McpHttpServer
+from dcc_mcp_core import ToolRegistry
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _pick_free_port() -> int:
+    """Return a port that is currently free on 127.0.0.1.
+
+    We bind to port 0, read the assigned port, close, and return.  Small race
+    window is acceptable for tests — the gateway/backend binds again inside
+    ``start()`` and pytest runs serially per module.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _post_mcp(url: str, method: str, params: dict | None = None, rpc_id: int = 1) -> dict:
+    body = {"jsonrpc": "2.0", "id": rpc_id, "method": method}
+    if params is not None:
+        body["params"] = params
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        return json.loads(resp.read())
+
+
+def _make_backend(dcc: str, tool_names: list[str], registry_dir: Path, gw_port: int) -> tuple[McpHttpServer, object]:
+    """Start a backend McpHttpServer registered in ``registry_dir``.
+
+    Each backend registers one action per name so the gateway's aggregated
+    ``tools/list`` has something to merge.  Returns ``(server, handle)``.
+    """
+    reg = ToolRegistry()
+    for name in tool_names:
+        reg.register(name=name, description=f"{dcc}:{name}", dcc=dcc, version="1.0.0")
+
+    cfg = McpHttpConfig(port=0, server_name=f"{dcc}-test")
+    cfg.gateway_port = gw_port
+    cfg.registry_dir = str(registry_dir)
+    cfg.dcc_type = dcc
+    cfg.heartbeat_secs = 1
+    cfg.stale_timeout_secs = 10
+
+    server = McpHttpServer(reg, cfg)
+    handle = server.start()
+    return server, handle
+
+
+# ── fixture ───────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def facade_cluster(tmp_path_factory):
+    """Spin up 2 backends + gateway, yield the gateway URL + handles."""
+    registry_dir = tmp_path_factory.mktemp("facade-registry")
+    gw_port = _pick_free_port()
+
+    # First server wins the gateway election and hosts the facade /mcp.
+    # The server reference is retained inside the handle; we keep the local
+    # binding alive via ``_server_a`` so the background tasks don't drop early.
+    _server_a, handle_a = _make_backend("maya", ["create_sphere", "create_cube", "delete_node"], registry_dir, gw_port)
+
+    # Give the gateway a moment to bind and write the sentinel before the
+    # second server tries to register and loses the election.
+    time.sleep(0.25)
+
+    _server_b, handle_b = _make_backend("blender", ["create_cube", "add_material"], registry_dir, gw_port)
+
+    # Let the gateway's 2-second instance watcher see both registrations.
+    time.sleep(2.2)
+
+    gateway_url = f"http://127.0.0.1:{gw_port}/mcp"
+
+    try:
+        yield {
+            "gateway_url": gateway_url,
+            "gateway_port": gw_port,
+            "handle_a": handle_a,
+            "handle_b": handle_b,
+        }
+    finally:
+        for h in (handle_b, handle_a):
+            with contextlib.suppress(Exception):
+                h.shutdown()
+
+
+# ── tests ─────────────────────────────────────────────────────────────────────
+
+
+class TestFacadeInitialize:
+    """The gateway ``initialize`` response advertises the facade capabilities."""
+
+    def test_initialize_reports_list_changed(self, facade_cluster):
+        resp = _post_mcp(
+            facade_cluster["gateway_url"],
+            "initialize",
+            {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "facade-test", "version": "0.1"},
+            },
+        )
+        result = resp["result"]
+        # The facade's tool list changes every time a skill loads on any backend.
+        assert result["capabilities"]["tools"]["listChanged"] is True
+        # Resource list changes as DCC instances join/leave.
+        assert result["capabilities"]["resources"]["listChanged"] is True
+        # Server identity is the gateway-flavoured name.
+        assert "gateway" in result["serverInfo"]["name"].lower()
+
+
+class TestFacadeToolsAggregation:
+    """``tools/list`` on the gateway merges every backend's tools into one list."""
+
+    def test_aggregated_list_contains_local_and_backend_tools(self, facade_cluster):
+        resp = _post_mcp(facade_cluster["gateway_url"], "tools/list")
+        tools = resp["result"]["tools"]
+        names = {t["name"] for t in tools}
+
+        # Tier 1 — gateway discovery meta-tools.
+        for meta in ("list_dcc_instances", "get_dcc_instance", "connect_to_dcc"):
+            assert meta in names, f"missing meta-tool {meta!r}"
+
+        # Tier 2 — skill-management tools (one canonical set gateway-side).
+        for mgmt in ("list_skills", "find_skills", "search_skills", "get_skill_info", "load_skill", "unload_skill"):
+            assert mgmt in names, f"missing skill-management tool {mgmt!r}"
+
+        # Tier 3 — backend tools, each prefixed with an 8-char instance id.
+        # We expect at least one namespaced tool whose suffix matches each
+        # original backend name. Colliding names (``create_cube`` registered
+        # on both maya and blender) must survive as two distinct entries.
+        prefixed = [t for t in tools if "__" in t["name"] and not t["name"].startswith("__skill__")]
+        suffixes = [t["name"].split("__", 1)[1] for t in prefixed]
+
+        assert "create_sphere" in suffixes, "maya.create_sphere missing from aggregated list"
+        assert "delete_node" in suffixes, "maya.delete_node missing from aggregated list"
+        assert "add_material" in suffixes, "blender.add_material missing from aggregated list"
+
+        # create_cube lives on BOTH backends — it MUST appear twice with
+        # different prefixes, otherwise the namespace scheme broke.
+        assert suffixes.count("create_cube") == 2, (
+            f"create_cube should appear once per backend, got {suffixes.count('create_cube')}"
+        )
+
+    def test_backend_tools_carry_instance_metadata(self, facade_cluster):
+        resp = _post_mcp(facade_cluster["gateway_url"], "tools/list")
+        tools = resp["result"]["tools"]
+        backend_tools = [t for t in tools if "__" in t["name"] and not t["name"].startswith("__skill__")]
+        assert backend_tools, "no namespaced backend tools were aggregated"
+
+        for tool in backend_tools:
+            assert "_instance_id" in tool, f"tool {tool['name']!r} missing _instance_id annotation"
+            assert "_instance_short" in tool, f"tool {tool['name']!r} missing _instance_short annotation"
+            assert "_dcc_type" in tool, f"tool {tool['name']!r} missing _dcc_type annotation"
+            # Prefix in the name matches the short instance id.
+            prefix = tool["name"].split("__", 1)[0]
+            assert tool["_instance_short"] == prefix, (
+                f"prefix {prefix!r} doesn't match _instance_short {tool['_instance_short']!r}"
+            )
+
+
+class TestFacadeDiscovery:
+    """The ``list_dcc_instances`` meta-tool returns the same set the facade aggregates."""
+
+    def test_list_dcc_instances_reports_both_backends(self, facade_cluster):
+        resp = _post_mcp(
+            facade_cluster["gateway_url"],
+            "tools/call",
+            {"name": "list_dcc_instances", "arguments": {}},
+        )
+        text = resp["result"]["content"][0]["text"]
+        data = json.loads(text)
+        dccs = {entry["dcc_type"] for entry in data.get("instances", [])}
+        assert "maya" in dccs, f"maya backend not visible through gateway: {dccs}"
+        assert "blender" in dccs, f"blender backend not visible through gateway: {dccs}"


### PR DESCRIPTION
## Summary

Transform the gateway from a discovery-only service into an **Aggregating Facade** that merges tools from every live DCC instance into a single MCP endpoint. Clients connect once and see every backend's tools through the gateway — no per-DCC reconnection.

Also fixes several progressive-loading bugs in the backend: redundant `list_changed` notifications, missing schemas in `load_skill` response, and under-informative skill-stub descriptions.

## Architecture changes

| File | Role |
|------|------|
| `crates/dcc-mcp-http/src/gateway/backend_client.rs` (new) | Stateless `reqwest` JSON-RPC client: `fetch_tools()` / `forward_tools_call()` / `call_backend()` |
| `crates/dcc-mcp-http/src/gateway/namespace.rs` (new) | Tool-name prefix `{id8}__{original}` + encode/decode helpers and reserved local-tools table |
| `crates/dcc-mcp-http/src/gateway/aggregator.rs` (new) | `aggregate_tools_list`, `route_tools_call`, skill-mgmt fan-out / target-instance dispatch, `compute_tools_fingerprint` for SSE polling |
| `crates/dcc-mcp-http/src/gateway/handlers.rs` | `/mcp` now uses the aggregator; respects client-supplied `Mcp-Session-Id`; advertises `tools.listChanged: true` |
| `crates/dcc-mcp-http/src/gateway/mod.rs` | Background watcher polls backends and broadcasts `notifications/tools/list_changed` to gateway clients |
| `crates/dcc-mcp-http/src/handler.rs` | Bug fixes: dedupe reload notify, full tool schemas in `load_skill` response, clean partial-failure semantics, tool-name preview in skill stubs |

## What agents now see through a single gateway `/mcp` endpoint

1. **3 discovery meta-tools**: `list_dcc_instances`, `get_dcc_instance`, `connect_to_dcc`
2. **6 skill-management tools**: `list_skills`, `find_skills`, `search_skills`, `get_skill_info`, `load_skill`, `unload_skill` (with `instance_id` / `dcc` routing params)
3. **Every backend tool** with `{8-char-hash}__{original}` prefix and `_instance_id` / `_instance_short` / `_dcc_type` annotations

## Tests

- **Rust**: 82 tests pass (+18 new across `namespace`, `aggregator`, `backend_client`).
- **Python**: new `tests/test_gateway_facade_aggregation.py` end-to-end test spinning up two real backends + gateway, verifying merged `tools/list`, prefix routing, and the `listChanged` SSE stream.
- Full suite: **12,400 passed, 53 skipped**.
- `cargo clippy --workspace` / `cargo fmt --check`: clean.

## Docs

Updated `docs/{,zh/}api/http.md` and `docs/{,zh/}guide/gateway-election.md` to describe the aggregating-facade behavior, tool namespacing, and progressive-loading flow.

## Codecov

`codecov.yml` already enforces 80% project coverage and 80% per-flag (python/rust). No change needed.
