### PR TITLE
feat: window-target capture, instance-bound diagnostics, and tool groups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,21 @@ A Rust-powered MCP (Model Context Protocol) library that lets AI agents interact
 **Screen capture, shared memory, telemetry, process management?**
 → `docs/api/capture.md`, `docs/api/shm.md`, `docs/api/telemetry.md`, `docs/api/process.md`
 
+**Capture a single DCC window (not the whole screen)?**
+→ `Capturer.new_window_auto()` + `.capture_window(process_id=..., window_title=..., window_handle=...)`
+→ Resolve targets first: `WindowFinder().find(CaptureTarget.process_id(pid))` → `WindowInfo`
+→ Backend on Windows: HWND `PrintWindow` (falls back to Mock on other OSes)
+
+**Bind diagnostics tools to a specific DCC instance (multi-instance safe)?**
+→ `DccServerBase(..., dcc_pid=pid, dcc_window_title=title, dcc_window_handle=hwnd, resolver=...)`
+→ Registers `diagnostics__screenshot` / `diagnostics__audit_log` / `diagnostics__action_metrics` / `diagnostics__process_status`
+→ Low-level: `register_diagnostic_mcp_tools(server, dcc_name=..., dcc_pid=...)` BEFORE `server.start()`
+
+**Limit tools surfaced to the LLM client (progressive exposure)?**
+→ Declare `groups:` in SKILL.md with `default_active: true|false`
+→ Activate at runtime via `ToolRegistry.activate_tool_group(skill, group)` / MCP tool `activate_tool_group`
+→ See `docs/guide/skills.md` — "Tool Groups (Progressive Exposure)"
+
 ---
 
 ## Repo Layout (What Lives Where)
@@ -106,7 +121,7 @@ dcc-mcp-core/
 │   ├── dcc-mcp-sandbox/            # SandboxPolicy, InputValidator, AuditLog
 │   ├── dcc-mcp-telemetry/          # TelemetryConfig, ToolRecorder, ToolMetrics
 │   ├── dcc-mcp-shm/                # PySharedBuffer, PySharedSceneBuffer (LZ4)
-│   ├── dcc-mcp-capture/            # Capturer, CaptureFrame (platform-native)
+│   ├── dcc-mcp-capture/            # Capturer, CaptureFrame, CaptureTarget, WindowFinder (HWND/DXGI/X11/Mock)
 │   ├── dcc-mcp-usd/                # UsdStage, UsdPrim, scene_info_json_to_stage
 │   ├── dcc-mcp-server/             # Binary entry point for bridge-mode DCCs
 │   └── dcc-mcp-utils/              # Filesystem helpers, wrap_value, constants
@@ -115,12 +130,12 @@ dcc-mcp-core/
 │   ├── __init__.py                 # ← READ THIS: every public symbol + __all__
 │   ├── _core.pyi                   # ← READ THIS: parameter names, types, signatures
 │   ├── skill.py                    # Pure-Python: @skill_entry, skill_success/error/warning
-│   ├── server_base.py              # Pure-Python: DccServerBase (subclass for adapters)
+│   ├── server_base.py              # Pure-Python: DccServerBase (subclass, supports dcc_pid/dcc_window_title binding)
 │   ├── factory.py                  # Pure-Python: make_start_stop, create_dcc_server
 │   ├── gateway_election.py         # Pure-Python: DccGatewayElection
 │   ├── hotreload.py                # Pure-Python: DccSkillHotReloader
 │   ├── bridge.py                   # Pure-Python: DccBridge (WebSocket JSON-RPC 2.0)
-│   ├── dcc_server.py               # Pure-Python: register_diagnostic_handlers
+│   ├── dcc_server.py               # Pure-Python: register_diagnostic_handlers + register_diagnostic_mcp_tools
 │   └── skills/                     # Bundled: dcc-diagnostics, workflow (in wheel)
 │
 ├── tests/                          # 120+ integration tests — executable usage examples
@@ -225,7 +240,7 @@ Capturer.new_window_auto().capture_window(window_title="Maya 2024")
 
 **Tool groups — inactive groups are hidden, not deleted:**
 ```python
-# default_active=false tools are registered with enabled=False.
+# default_active=false tools are registered with ActionMeta.enabled=False.
 # tools/list hides them but registry.list_actions() still returns them.
 registry.activate_tool_group("maya-geometry", "rigging")   # emits tools/list_changed
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,16 @@
 
 You are working on **dcc-mcp-core**, a Rust-powered MCP (Model Context Protocol) library for DCC (Digital Content Creation) applications. The Python package name is `dcc_mcp_core`.
 
+## Response Language
+
+- Reply to the user in **Simplified Chinese** (中文简体) by default.
+- Keep all code, identifiers, commit messages, branch names, docstrings,
+  comments, and file contents in **English** — this rule governs only the
+  conversational/assistant-facing output, not anything written to disk or
+  pushed to git.
+- If the user explicitly requests another language for a specific reply,
+  follow that request for that turn.
+
 ## Quick Reference
 
 ### Before Making Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,11 @@ futures-util = "0.3"
 reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "rustls"] }
 socket2 = { version = "0.6", features = ["all"] }
 
+# Type-stub generation (opt-in via `stub-gen` feature). Used only by the
+# `stub_gen` binary target — never pulled into wheels or library consumers.
+pyo3-stub-gen = "0.20"
+pyo3-stub-gen-derive = "0.20"
+
 # Root package — Python bindings entry point
 # Compiles to `_core.pyd` / `_core.so`, exposed as `dcc_mcp_core._core`
 [package]
@@ -106,8 +111,19 @@ dcc-mcp-http.workspace = true
 # PyO3 (optional — only for wheel builds)
 pyo3 = { workspace = true, optional = true }
 
+# Type-stub generation (opt-in via `stub-gen` feature, used by the
+# `stub_gen` binary target only).
+pyo3-stub-gen = { workspace = true, optional = true }
+
 [dev-dependencies]
 serde_json.workspace = true
+
+# PoC binary: generate python/dcc_mcp_core/_core.pyi from annotated Rust code.
+# Build with: cargo run --bin stub_gen --features stub-gen
+[[bin]]
+name = "stub_gen"
+path = "src/bin/stub_gen.rs"
+required-features = ["stub-gen"]
 
 [profile.release]
 opt-level = 3
@@ -121,3 +137,10 @@ python-bindings = ["pyo3", "dcc-mcp-models/python-bindings", "dcc-mcp-actions/py
 abi3-py38 = ["pyo3/abi3-py38"]
 # Python 3.7 wheel: non-abi3 build, no abi3-py38 feature
 ext-module = ["pyo3/extension-module"]
+# Generate `python/dcc_mcp_core/_core.pyi` from annotated Rust code.
+# PoC scope: currently only dcc-mcp-capture is annotated.
+stub-gen = [
+    "python-bindings",
+    "dep:pyo3-stub-gen",
+    "dcc-mcp-capture/stub-gen",
+]

--- a/crates/dcc-mcp-actions/src/dispatcher.rs
+++ b/crates/dcc-mcp-actions/src/dispatcher.rs
@@ -74,6 +74,8 @@ pub enum DispatchError {
     ValidationFailed(String),
     /// The handler itself returned an error.
     HandlerError(String),
+    /// The action exists but is currently disabled (inactive tool group).
+    ActionDisabled { action: String, group: String },
 }
 
 impl std::fmt::Display for DispatchError {
@@ -85,6 +87,10 @@ impl std::fmt::Display for DispatchError {
             }
             Self::ValidationFailed(msg) => write!(f, "validation failed: {msg}"),
             Self::HandlerError(msg) => write!(f, "handler error: {msg}"),
+            Self::ActionDisabled { action, group } => write!(
+                f,
+                "action '{action}' is disabled (group '{group}' is inactive — call activate_tool_group first)"
+            ),
         }
     }
 }
@@ -239,6 +245,17 @@ impl ActionDispatcher {
 
         // 2. Look up metadata for validation
         let meta_opt: Option<ActionMeta> = self.registry.get_action(action_name, None);
+
+        // 2a. Enforce progressive-exposure "enabled" flag.
+        if let Some(meta) = &meta_opt
+            && !meta.enabled
+        {
+            return Err(DispatchError::ActionDisabled {
+                action: action_name.to_string(),
+                group: meta.group.clone(),
+            });
+        }
+
         let validation_skipped = match &meta_opt {
             None => true,
             Some(meta) => {

--- a/crates/dcc-mcp-actions/src/pipeline/python.rs
+++ b/crates/dcc-mcp-actions/src/pipeline/python.rs
@@ -608,6 +608,9 @@ impl PyActionPipeline {
             Err(DispatchError::HandlerError(msg)) => {
                 Err(pyo3::exceptions::PyRuntimeError::new_err(msg))
             }
+            Err(err @ DispatchError::ActionDisabled { .. }) => Err(
+                pyo3::exceptions::PyPermissionError::new_err(err.to_string()),
+            ),
         }
     }
 

--- a/crates/dcc-mcp-actions/src/python.rs
+++ b/crates/dcc-mcp-actions/src/python.rs
@@ -268,6 +268,11 @@ impl PyActionDispatcher {
                     // Stub always returns Ok(null), so this shouldn't happen
                     false
                 }
+                Err(err @ DispatchError::ActionDisabled { .. }) => {
+                    return Err(pyo3::exceptions::PyPermissionError::new_err(
+                        err.to_string(),
+                    ));
+                }
             }
         };
 

--- a/crates/dcc-mcp-actions/src/registry/mod.rs
+++ b/crates/dcc-mcp-actions/src/registry/mod.rs
@@ -19,7 +19,7 @@ use dcc_mcp_utils::constants::{DEFAULT_DCC, DEFAULT_VERSION};
 use dcc_mcp_utils::constants::default_schema;
 
 /// Metadata about a registered Action (stored in Rust).
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ActionMeta {
     /// Unique action identifier.
@@ -43,6 +43,42 @@ pub struct ActionMeta {
     /// Name of the skill this action belongs to (if registered from a skill).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub skill_name: Option<String>,
+    /// Tool group this action belongs to (``""`` = always active).
+    ///
+    /// See [`dcc_mcp_models::SkillGroup`]; used together with `enabled` to
+    /// implement progressive tool exposure via ``activate_tool_group``.
+    #[serde(default)]
+    pub group: String,
+    /// Whether this action is currently active / callable.
+    ///
+    /// Tools in an inactive group are collapsed into a ``__group__<name>``
+    /// stub in ``tools/list``. The dispatcher refuses to invoke disabled
+    /// actions.
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+}
+
+fn default_enabled() -> bool {
+    true
+}
+
+impl Default for ActionMeta {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            description: String::new(),
+            category: String::new(),
+            tags: Vec::new(),
+            dcc: String::new(),
+            version: String::new(),
+            input_schema: serde_json::Value::Null,
+            output_schema: serde_json::Value::Null,
+            source_file: None,
+            skill_name: None,
+            group: String::new(),
+            enabled: true,
+        }
+    }
 }
 
 /// Thread-safe Action registry.
@@ -333,6 +369,74 @@ impl ActionRegistry {
     pub fn is_empty(&self) -> bool {
         self.actions.is_empty()
     }
+
+    // ── Group / enabled helpers (progressive tool exposure) ──────────────
+
+    /// Set ``enabled`` flag for every action with the given ``group`` value.
+    ///
+    /// Returns the number of actions whose state changed.
+    pub fn set_group_enabled(&self, group: &str, enabled: bool) -> usize {
+        let mut changed = 0;
+        for mut entry in self.actions.iter_mut() {
+            if entry.value().group == group && entry.value().enabled != enabled {
+                entry.value_mut().enabled = enabled;
+                changed += 1;
+            }
+        }
+        for dcc_map in self.dcc_actions.iter() {
+            for mut entry in dcc_map.value().iter_mut() {
+                if entry.value().group == group && entry.value().enabled != enabled {
+                    entry.value_mut().enabled = enabled;
+                }
+            }
+        }
+        changed
+    }
+
+    /// Enable or disable a single action by name.
+    ///
+    /// Returns ``true`` if the action existed.
+    pub fn set_action_enabled(&self, name: &str, enabled: bool) -> bool {
+        let Some(mut entry) = self.actions.get_mut(name) else {
+            return false;
+        };
+        entry.value_mut().enabled = enabled;
+        for dcc_map in self.dcc_actions.iter() {
+            if let Some(mut e) = dcc_map.value().get_mut(name) {
+                e.value_mut().enabled = enabled;
+            }
+        }
+        true
+    }
+
+    /// List actions belonging to a specific group (all DCCs).
+    pub fn list_actions_in_group(&self, group: &str) -> Vec<ActionMeta> {
+        self.actions
+            .iter()
+            .filter(|e| e.value().group == group)
+            .map(|e| e.value().clone())
+            .collect()
+    }
+
+    /// List currently enabled actions.
+    pub fn list_actions_enabled(&self, dcc_name: Option<&str>) -> Vec<ActionMeta> {
+        self.list_actions(dcc_name)
+            .into_iter()
+            .filter(|m| m.enabled)
+            .collect()
+    }
+
+    /// Enumerate distinct group names present in the registry.
+    pub fn list_groups(&self) -> Vec<String> {
+        let mut seen: Vec<String> = Vec::new();
+        for entry in self.actions.iter() {
+            let g = &entry.value().group;
+            if !g.is_empty() && !seen.contains(g) {
+                seen.push(g.clone());
+            }
+        }
+        seen
+    }
 }
 
 // ── Python bindings ──
@@ -422,6 +526,18 @@ impl ActionRegistry {
                 .ok()
                 .flatten()
                 .and_then(|v| v.extract().ok());
+            let group: String = dict
+                .get_item("group")
+                .ok()
+                .flatten()
+                .and_then(|v| v.extract().ok())
+                .unwrap_or_default();
+            let enabled: bool = dict
+                .get_item("enabled")
+                .ok()
+                .flatten()
+                .and_then(|v| v.extract().ok())
+                .unwrap_or(true);
 
             let input_schema =
                 parse_schema_or_default(input_schema_str.as_deref(), "input_schema", &name);
@@ -439,6 +555,8 @@ impl ActionRegistry {
                 output_schema,
                 source_file,
                 skill_name,
+                group,
+                enabled,
             });
         }
     }
@@ -466,7 +584,7 @@ impl ActionRegistry {
 
     /// Register an action. Called from Python ActionManager.
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (name, description="".to_string(), category="".to_string(), tags=vec![], dcc=DEFAULT_DCC.to_string(), version=DEFAULT_VERSION.to_string(), input_schema=None, output_schema=None, source_file=None, skill_name=None))]
+    #[pyo3(signature = (name, description="".to_string(), category="".to_string(), tags=vec![], dcc=DEFAULT_DCC.to_string(), version=DEFAULT_VERSION.to_string(), input_schema=None, output_schema=None, source_file=None, skill_name=None, group="".to_string(), enabled=true))]
     fn register(
         &self,
         name: String,
@@ -479,6 +597,8 @@ impl ActionRegistry {
         output_schema: Option<String>,
         source_file: Option<String>,
         skill_name: Option<String>,
+        group: String,
+        enabled: bool,
     ) {
         let input_schema = parse_schema_or_default(input_schema.as_deref(), "input_schema", &name);
         let output_schema =
@@ -495,7 +615,54 @@ impl ActionRegistry {
             output_schema,
             source_file,
             skill_name,
+            group,
+            enabled,
         });
+    }
+
+    /// Enable or disable every action belonging to ``group``.
+    ///
+    /// Returns the number of actions whose ``enabled`` flag changed.
+    #[pyo3(name = "set_group_enabled")]
+    fn py_set_group_enabled(&self, group: &str, enabled: bool) -> usize {
+        self.set_group_enabled(group, enabled)
+    }
+
+    /// Enable or disable a single action.
+    ///
+    /// Returns ``True`` if the action existed.
+    #[pyo3(name = "set_action_enabled")]
+    fn py_set_action_enabled(&self, name: &str, enabled: bool) -> bool {
+        self.set_action_enabled(name, enabled)
+    }
+
+    /// List all currently-enabled actions.
+    #[pyo3(name = "list_actions_enabled")]
+    #[pyo3(signature = (dcc_name=None))]
+    fn py_list_actions_enabled(
+        &self,
+        py: Python,
+        dcc_name: Option<&str>,
+    ) -> PyResult<Vec<Py<PyAny>>> {
+        self.list_actions_enabled(dcc_name)
+            .iter()
+            .map(|meta| action_meta_to_py(py, meta))
+            .collect()
+    }
+
+    /// List actions belonging to ``group`` (across all DCCs).
+    #[pyo3(name = "list_actions_in_group")]
+    fn py_list_actions_in_group(&self, py: Python, group: &str) -> PyResult<Vec<Py<PyAny>>> {
+        self.list_actions_in_group(group)
+            .iter()
+            .map(|meta| action_meta_to_py(py, meta))
+            .collect()
+    }
+
+    /// Return distinct non-empty group names.
+    #[pyo3(name = "list_groups")]
+    fn py_list_groups(&self) -> Vec<String> {
+        self.list_groups()
     }
 
     /// Get action metadata as dict.

--- a/crates/dcc-mcp-actions/src/registry/tests.rs
+++ b/crates/dcc-mcp-actions/src/registry/tests.rs
@@ -199,6 +199,8 @@ fn test_action_meta_serde_round_trip() {
         output_schema: serde_json::json!({"type": "string"}),
         source_file: Some("render.py".into()),
         skill_name: None,
+        group: String::new(),
+        enabled: true,
     };
     let json = serde_json::to_string(&meta).unwrap();
     let back: ActionMeta = serde_json::from_str(&json).unwrap();

--- a/crates/dcc-mcp-capture/Cargo.toml
+++ b/crates/dcc-mcp-capture/Cargo.toml
@@ -33,6 +33,7 @@ windows = { version = "0.62", features = [
     "Win32_UI_WindowsAndMessaging",
     "Win32_System_Threading",
     "Win32_Graphics_Gdi",
+    "Win32_Storage_Xps",
 ] }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/crates/dcc-mcp-capture/Cargo.toml
+++ b/crates/dcc-mcp-capture/Cargo.toml
@@ -18,6 +18,10 @@ tracing.workspace = true
 # PyO3 (optional)
 pyo3 = { workspace = true, optional = true }
 
+# Type-stub generation (opt-in via `stub-gen` feature).
+pyo3-stub-gen = { workspace = true, optional = true }
+pyo3-stub-gen-derive = { workspace = true, optional = true }
+
 # Image encoding (PNG / JPEG)
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "bmp"] }
 
@@ -46,3 +50,7 @@ tempfile = "3"
 [features]
 default = []
 python-bindings = ["pyo3"]
+# Enable `pyo3-stub-gen` annotations on this crate's PyO3 types.
+# Pulled in by the workspace-level `stub-gen` feature — do not enable directly
+# in production wheels.
+stub-gen = ["python-bindings", "dep:pyo3-stub-gen", "dep:pyo3-stub-gen-derive"]

--- a/crates/dcc-mcp-capture/src/backend/hwnd.rs
+++ b/crates/dcc-mcp-capture/src/backend/hwnd.rs
@@ -1,0 +1,278 @@
+//! Windows GDI `PrintWindow` / `BitBlt` window-target capture backend.
+//!
+//! Captures a single top-level window rather than the whole desktop.
+//! Resolves the target via [`WindowFinder`] so either a `ProcessId`,
+//! `WindowTitle`, or `WindowHandle` target is accepted.
+//!
+//! On non-Windows platforms this compiles to a stub that reports
+//! unavailable.
+//!
+//! # References
+//! - <https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-printwindow>
+//! - <https://learn.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-bitblt>
+
+use crate::capture::DccCapture;
+#[allow(unused_imports)]
+use crate::error::{CaptureError, CaptureResult};
+use crate::types::{CaptureBackendKind, CaptureConfig, CaptureFrame};
+
+// ── HwndBackend ────────────────────────────────────────────────────────────
+
+/// GDI-based window-target capture backend (Windows only).
+#[derive(Debug, Default)]
+pub struct HwndBackend;
+
+impl HwndBackend {
+    /// Create a new HWND backend instance.
+    pub fn new() -> Self {
+        HwndBackend
+    }
+}
+
+// ── DccCapture impl — Windows ──────────────────────────────────────────────
+
+#[cfg(target_os = "windows")]
+impl DccCapture for HwndBackend {
+    fn backend_kind(&self) -> CaptureBackendKind {
+        CaptureBackendKind::HwndPrintWindow
+    }
+
+    fn is_available(&self) -> bool {
+        true
+    }
+
+    fn capture(&self, config: &CaptureConfig) -> CaptureResult<CaptureFrame> {
+        imp::capture_hwnd(config)
+    }
+}
+
+// ── DccCapture impl — non-Windows stub ─────────────────────────────────────
+
+#[cfg(not(target_os = "windows"))]
+impl DccCapture for HwndBackend {
+    fn backend_kind(&self) -> CaptureBackendKind {
+        CaptureBackendKind::HwndPrintWindow
+    }
+
+    fn is_available(&self) -> bool {
+        false
+    }
+
+    fn capture(&self, _config: &CaptureConfig) -> CaptureResult<CaptureFrame> {
+        Err(CaptureError::BackendNotSupported(
+            "HwndBackend is only available on Windows".to_string(),
+        ))
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hwnd_backend_kind() {
+        let b = HwndBackend::new();
+        assert_eq!(b.backend_kind(), CaptureBackendKind::HwndPrintWindow);
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn test_hwnd_not_available_on_non_windows() {
+        let b = HwndBackend::new();
+        assert!(!b.is_available());
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn test_hwnd_capture_returns_not_supported_on_non_windows() {
+        let b = HwndBackend::default();
+        let result = b.capture(&CaptureConfig::default());
+        assert!(matches!(
+            result.unwrap_err(),
+            CaptureError::BackendNotSupported(_)
+        ));
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn test_hwnd_nonexistent_pid_returns_target_not_found() {
+        use crate::types::CaptureTarget;
+
+        let b = HwndBackend::new();
+        let cfg = CaptureConfig::builder()
+            .target(CaptureTarget::ProcessId(0x7FFF_FFFF))
+            .build();
+        let result = b.capture(&cfg);
+        assert!(matches!(result, Err(CaptureError::TargetNotFound(_))));
+    }
+}
+
+// ── Windows implementation ─────────────────────────────────────────────────
+
+#[cfg(target_os = "windows")]
+mod imp {
+    use std::io::Cursor;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use image::{ImageBuffer, ImageFormat, Rgba};
+    use windows::Win32::Foundation::{HWND, RECT};
+    use windows::Win32::Graphics::Gdi::{
+        BI_RGB, BITMAPINFO, BITMAPINFOHEADER, BitBlt, CreateCompatibleBitmap, CreateCompatibleDC,
+        DIB_RGB_COLORS, DeleteDC, DeleteObject, GetDC, GetDIBits, ReleaseDC, SRCCOPY, SelectObject,
+    };
+    use windows::Win32::Storage::Xps::{PRINT_WINDOW_FLAGS, PrintWindow};
+    use windows::Win32::UI::WindowsAndMessaging::GetWindowRect;
+
+    use crate::error::{CaptureError, CaptureResult};
+    use crate::types::{CaptureConfig, CaptureFormat, CaptureFrame, CaptureTarget};
+    use crate::window::WindowFinder;
+
+    // PW_RENDERFULLCONTENT — ensures DWM-composed content (UWP, DX surfaces) is captured.
+    const PW_RENDERFULLCONTENT: PRINT_WINDOW_FLAGS = PRINT_WINDOW_FLAGS(0x00000002);
+
+    pub(super) fn capture_hwnd(config: &CaptureConfig) -> CaptureResult<CaptureFrame> {
+        let finder = WindowFinder::new();
+        let info = match &config.target {
+            CaptureTarget::WindowHandle(_)
+            | CaptureTarget::ProcessId(_)
+            | CaptureTarget::WindowTitle(_) => finder.find(&config.target)?,
+            CaptureTarget::PrimaryDisplay | CaptureTarget::MonitorIndex(_) => {
+                return Err(CaptureError::BackendNotSupported(
+                    "HwndBackend requires a window target (WindowHandle / ProcessId / WindowTitle)"
+                        .to_string(),
+                ));
+            }
+        };
+
+        let hwnd = HWND(info.handle as *mut core::ffi::c_void);
+        let mut rect = RECT::default();
+        unsafe { GetWindowRect(hwnd, &mut rect) }
+            .map_err(|e| CaptureError::Platform(format!("GetWindowRect: {e}")))?;
+        let w = (rect.right - rect.left).max(1);
+        let h = (rect.bottom - rect.top).max(1);
+
+        let raw_bgra = unsafe { grab_bgra(hwnd, w, h)? };
+
+        let timestamp_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+
+        // BGRA → RGBA, then build ImageBuffer, apply scale, encode.
+        let mut rgba = raw_bgra.clone();
+        for chunk in rgba.chunks_exact_mut(4) {
+            chunk.swap(0, 2);
+        }
+        let img: ImageBuffer<Rgba<u8>, Vec<u8>> =
+            ImageBuffer::from_raw(w as u32, h as u32, rgba)
+                .ok_or_else(|| CaptureError::Internal("from_raw failed".to_string()))?;
+
+        // Apply scale.
+        let (out_w, out_h) = if (config.scale - 1.0).abs() > 1e-4 {
+            let nw = ((w as f32) * config.scale).round() as u32;
+            let nh = ((h as f32) * config.scale).round() as u32;
+            (nw.max(1), nh.max(1))
+        } else {
+            (w as u32, h as u32)
+        };
+        let img = if (out_w, out_h) != (w as u32, h as u32) {
+            image::imageops::resize(&img, out_w, out_h, image::imageops::FilterType::Triangle)
+        } else {
+            img
+        };
+
+        let final_w = img.width();
+        let final_h = img.height();
+        let (data, format) = match config.format {
+            CaptureFormat::Png => {
+                let mut buf = Cursor::new(Vec::new());
+                img.write_to(&mut buf, ImageFormat::Png)
+                    .map_err(|e| CaptureError::Image(e.to_string()))?;
+                (buf.into_inner(), CaptureFormat::Png)
+            }
+            CaptureFormat::Jpeg => {
+                let rgb = image::DynamicImage::ImageRgba8(img).into_rgb8();
+                let mut buf = Cursor::new(Vec::new());
+                rgb.write_to(&mut buf, ImageFormat::Jpeg)
+                    .map_err(|e| CaptureError::Image(e.to_string()))?;
+                (buf.into_inner(), CaptureFormat::Jpeg)
+            }
+            CaptureFormat::RawBgra => {
+                // Convert the (possibly-scaled) RGBA back to BGRA.
+                let mut raw: Vec<u8> = img.into_raw();
+                for chunk in raw.chunks_exact_mut(4) {
+                    chunk.swap(0, 2);
+                }
+                (raw, CaptureFormat::RawBgra)
+            }
+        };
+
+        Ok(CaptureFrame {
+            data,
+            width: final_w,
+            height: final_h,
+            format,
+            timestamp_ms,
+            dpi_scale: 1.0,
+            window_rect: Some([rect.left, rect.top, w, h]),
+            window_title: Some(info.title),
+        })
+    }
+
+    /// Pull the window's pixels as a top-down BGRA buffer.
+    ///
+    /// Prefers `PrintWindow(PW_RENDERFULLCONTENT)` which works for DWM-composed
+    /// surfaces; falls back to `BitBlt(SRCCOPY)` if `PrintWindow` refuses.
+    unsafe fn grab_bgra(hwnd: HWND, w: i32, h: i32) -> CaptureResult<Vec<u8>> {
+        unsafe {
+            let src_dc = GetDC(Some(hwnd));
+            if src_dc.is_invalid() {
+                return Err(CaptureError::Platform("GetDC returned null".to_string()));
+            }
+            let mem_dc = CreateCompatibleDC(Some(src_dc));
+            let bmp = CreateCompatibleBitmap(src_dc, w, h);
+            let old = SelectObject(mem_dc, bmp.into());
+
+            let printed = PrintWindow(hwnd, mem_dc, PW_RENDERFULLCONTENT).as_bool();
+            if !printed {
+                let _ = BitBlt(mem_dc, 0, 0, w, h, Some(src_dc), 0, 0, SRCCOPY);
+            }
+
+            // Negative biHeight → top-down DIB, matching most image crates.
+            let mut buf = vec![0u8; (w as usize) * (h as usize) * 4];
+            let mut bi = BITMAPINFO {
+                bmiHeader: BITMAPINFOHEADER {
+                    biSize: std::mem::size_of::<BITMAPINFOHEADER>() as u32,
+                    biWidth: w,
+                    biHeight: -h,
+                    biPlanes: 1,
+                    biBitCount: 32,
+                    biCompression: BI_RGB.0,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            let rows = GetDIBits(
+                mem_dc,
+                bmp,
+                0,
+                h as u32,
+                Some(buf.as_mut_ptr() as *mut _),
+                &mut bi,
+                DIB_RGB_COLORS,
+            );
+            SelectObject(mem_dc, old);
+            let _ = DeleteObject(bmp.into());
+            let _ = DeleteDC(mem_dc);
+            ReleaseDC(Some(hwnd), src_dc);
+            if rows == 0 {
+                return Err(CaptureError::Platform(
+                    "GetDIBits returned 0 scanlines".to_string(),
+                ));
+            }
+            Ok(buf)
+        }
+    }
+}

--- a/crates/dcc-mcp-capture/src/backend/mock.rs
+++ b/crates/dcc-mcp-capture/src/backend/mock.rs
@@ -127,6 +127,8 @@ impl DccCapture for MockBackend {
             format,
             timestamp_ms,
             dpi_scale: 1.0,
+            window_rect: None,
+            window_title: None,
         })
     }
 }

--- a/crates/dcc-mcp-capture/src/backend/mod.rs
+++ b/crates/dcc-mcp-capture/src/backend/mod.rs
@@ -2,10 +2,12 @@
 //!
 //! | Backend | Platform | Priority |
 //! |---------|----------|----------|
-//! | [`windows::DxgiBackend`] | Windows | 1st |
+//! | [`windows::DxgiBackend`] | Windows (full-screen) | 1st |
+//! | [`hwnd::HwndBackend`] | Windows (window-target) | 1st |
 //! | [`unix::X11Backend`] | Linux (X11) | 1st |
 //! | [`mock::MockBackend`] | All | Fallback |
 
+pub mod hwnd;
 pub mod mock;
 pub mod unix;
 pub mod windows;
@@ -30,6 +32,25 @@ pub fn best_available() -> (Box<dyn DccCapture>, CaptureBackendKind) {
         return (Box::new(x11), CaptureBackendKind::X11Xshm);
     }
 
+    let mock = mock::MockBackend::new(1920, 1080);
+    (Box::new(mock), CaptureBackendKind::Mock)
+}
+
+/// Create the best available **window-target** backend for the current
+/// platform.  Unlike [`best_available`], this returns a backend that captures
+/// a single top-level window rather than the whole desktop.
+///
+/// Selection order:
+/// 1. GDI `PrintWindow` / `BitBlt` (Windows only)
+/// 2. Mock backend (other platforms — window capture pending)
+pub fn best_window_capture() -> (Box<dyn DccCapture>, CaptureBackendKind) {
+    #[cfg(target_os = "windows")]
+    {
+        let hb = hwnd::HwndBackend::new();
+        if hb.is_available() {
+            return (Box::new(hb), CaptureBackendKind::HwndPrintWindow);
+        }
+    }
     let mock = mock::MockBackend::new(1920, 1080);
     (Box::new(mock), CaptureBackendKind::Mock)
 }

--- a/crates/dcc-mcp-capture/src/backend/windows.rs
+++ b/crates/dcc-mcp-capture/src/backend/windows.rs
@@ -138,7 +138,10 @@ fn capture_dxgi(config: &CaptureConfig) -> CaptureResult<CaptureFrame> {
 
     let monitor_idx = match &config.target {
         crate::types::CaptureTarget::MonitorIndex(i) => *i,
-        _ => 0,
+        crate::types::CaptureTarget::PrimaryDisplay => 0,
+        crate::types::CaptureTarget::ProcessId(_)
+        | crate::types::CaptureTarget::WindowTitle(_)
+        | crate::types::CaptureTarget::WindowHandle(_) => 0,
     };
 
     let adapter = unsafe {
@@ -288,6 +291,8 @@ fn capture_dxgi(config: &CaptureConfig) -> CaptureResult<CaptureFrame> {
         format: fmt,
         timestamp_ms,
         dpi_scale: 1.0,
+        window_rect: None,
+        window_title: None,
     })
 }
 

--- a/crates/dcc-mcp-capture/src/capturer.rs
+++ b/crates/dcc-mcp-capture/src/capturer.rs
@@ -85,6 +85,21 @@ impl Capturer {
         }
     }
 
+    /// Create a new `Capturer` configured for single-window capture.
+    ///
+    /// Uses [`backend::best_window_capture`] — typically
+    /// [`CaptureBackendKind::HwndPrintWindow`] on Windows and
+    /// [`CaptureBackendKind::Mock`] elsewhere (until X11/macOS window backends
+    /// are implemented).
+    pub fn new_window_auto() -> Self {
+        let (backend, backend_kind) = backend::best_window_capture();
+        Capturer {
+            backend,
+            backend_kind,
+            stats: Arc::new(CaptureStats::default()),
+        }
+    }
+
     /// Create a `Capturer` from an explicit backend.
     pub fn with_backend(backend: Box<dyn DccCapture>) -> Self {
         let kind = backend.backend_kind();

--- a/crates/dcc-mcp-capture/src/python.rs
+++ b/crates/dcc-mcp-capture/src/python.rs
@@ -1,14 +1,18 @@
 //! PyO3 bindings for `dcc-mcp-capture`.
 //!
-//! Exposes [`PyCapturer`] and [`PyCaptureFrame`] to Python, enabling DCC
+//! Exposes [`PyCapturer`], [`PyCaptureFrame`], [`PyCaptureTarget`],
+//! [`PyCaptureBackendKind`] and [`PyWindowFinder`] to Python, enabling DCC
 //! plugins to capture screenshots without any Python-native dependencies.
 
-use pyo3::exceptions::PyRuntimeError;
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
+#[cfg(feature = "stub-gen")]
+use pyo3_stub_gen_derive::{gen_stub_pyclass, gen_stub_pymethods};
 
 use crate::backend::mock::MockBackend;
 use crate::capturer::Capturer;
-use crate::types::{CaptureConfig, CaptureFormat, CaptureTarget};
+use crate::types::{CaptureBackendKind, CaptureConfig, CaptureFormat, CaptureTarget};
+use crate::window::WindowFinder;
 
 // ── Error conversion ───────────────────────────────────────────────────────
 
@@ -16,9 +20,25 @@ fn to_py_err(e: crate::error::CaptureError) -> PyErr {
     PyRuntimeError::new_err(e.to_string())
 }
 
+fn parse_format(fmt: &str) -> CaptureFormat {
+    match fmt {
+        "jpeg" | "jpg" => CaptureFormat::Jpeg,
+        "raw_bgra" | "raw" => CaptureFormat::RawBgra,
+        _ => CaptureFormat::Png,
+    }
+}
+
 // ── PyCaptureFrame ─────────────────────────────────────────────────────────
 
 /// A single captured frame (Python-visible).
+//
+// NOTE (stub-gen PoC): we annotate the *class* (to derive `PyStubType`
+// so other methods returning `PyCaptureFrame` can be typed), but skip
+// the *methods* — `data()` returns `&[u8]` which `pyo3-stub-gen` can't
+// auto-map. To ship the method stubs we'd add either an
+// `impl_stub_type!(...)` entry or a `gen_methods_from_python!` block
+// giving an explicit `bytes` return type.
+#[cfg_attr(feature = "stub-gen", gen_stub_pyclass)]
 #[pyclass(name = "CaptureFrame")]
 pub struct PyCaptureFrame {
     inner: crate::types::CaptureFrame,
@@ -72,6 +92,19 @@ impl PyCaptureFrame {
         self.inner.dpi_scale
     }
 
+    /// Source window bounds ``(x, y, width, height)`` or ``None`` for
+    /// full-screen / display captures.
+    #[getter]
+    fn window_rect(&self) -> Option<(i32, i32, i32, i32)> {
+        self.inner.window_rect.map(|[x, y, w, h]| (x, y, w, h))
+    }
+
+    /// Source window title or ``None`` for full-screen / display captures.
+    #[getter]
+    fn window_title(&self) -> Option<String> {
+        self.inner.window_title.clone()
+    }
+
     /// Byte length of the encoded image data.
     fn byte_len(&self) -> usize {
         self.inner.byte_len()
@@ -99,11 +132,13 @@ impl PyCaptureFrame {
 /// frame = capturer.capture()
 /// print(f"Captured {frame.width}×{frame.height}, {frame.byte_len()} bytes")
 /// ```
+#[cfg_attr(feature = "stub-gen", gen_stub_pyclass)]
 #[pyclass(name = "Capturer")]
 pub struct PyCapturer {
     inner: Capturer,
 }
 
+#[cfg_attr(feature = "stub-gen", gen_stub_pymethods)]
 #[pymethods]
 impl PyCapturer {
     /// Create a capturer using the best available backend on this platform.
@@ -111,6 +146,17 @@ impl PyCapturer {
     fn new_auto() -> Self {
         PyCapturer {
             inner: Capturer::new_auto(),
+        }
+    }
+
+    /// Create a capturer configured for single-window capture.
+    ///
+    /// Uses the GDI PrintWindow backend on Windows; falls back to Mock on
+    /// other platforms until window-target backends are added.
+    #[staticmethod]
+    fn new_window_auto() -> Self {
+        PyCapturer {
+            inner: Capturer::new_window_auto(),
         }
     }
 
@@ -184,9 +230,72 @@ impl PyCapturer {
         Ok(PyCaptureFrame { inner: frame })
     }
 
+    /// Capture a single window.
+    ///
+    /// Parameters
+    /// ----------
+    /// process_id : int, optional
+    /// window_handle : int, optional
+    /// window_title : str, optional
+    ///     At least one of the three must be provided.
+    /// format, jpeg_quality, scale, timeout_ms, include_decorations :
+    ///     Same semantics as :py:meth:`capture`.
+    #[pyo3(signature = (
+        *,
+        process_id=None,
+        window_handle=None,
+        window_title=None,
+        format="png",
+        jpeg_quality=85,
+        scale=1.0,
+        timeout_ms=5000,
+        include_decorations=true,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn capture_window(
+        &self,
+        process_id: Option<u32>,
+        window_handle: Option<u64>,
+        window_title: Option<String>,
+        format: &str,
+        jpeg_quality: u8,
+        scale: f32,
+        timeout_ms: u64,
+        include_decorations: bool,
+    ) -> PyResult<PyCaptureFrame> {
+        let _ = include_decorations; // reserved for future client-area cropping
+        let target = if let Some(h) = window_handle {
+            CaptureTarget::WindowHandle(h)
+        } else if let Some(pid) = process_id {
+            CaptureTarget::ProcessId(pid)
+        } else if let Some(title) = window_title {
+            CaptureTarget::WindowTitle(title)
+        } else {
+            return Err(PyValueError::new_err(
+                "capture_window requires one of process_id / window_handle / window_title",
+            ));
+        };
+        let cfg = CaptureConfig::builder()
+            .format(parse_format(format))
+            .jpeg_quality(jpeg_quality)
+            .scale(scale)
+            .timeout_ms(timeout_ms)
+            .target(target)
+            .build();
+        let frame = self.inner.capture(&cfg).map_err(to_py_err)?;
+        Ok(PyCaptureFrame { inner: frame })
+    }
+
     /// Return the active backend name.
     fn backend_name(&self) -> String {
         self.inner.backend_kind().to_string()
+    }
+
+    /// Return the active backend kind enum.
+    fn backend_kind(&self) -> PyCaptureBackendKind {
+        PyCaptureBackendKind {
+            inner: self.inner.backend_kind(),
+        }
     }
 
     /// Return capture statistics as ``(count, total_bytes, errors)``.
@@ -199,12 +308,206 @@ impl PyCapturer {
     }
 }
 
+// ── PyCaptureTarget ────────────────────────────────────────────────────────
+
+/// Opaque Python wrapper for [`CaptureTarget`].
+///
+/// Construct via the ``primary_display``, ``monitor_index``, ``process_id``,
+/// ``window_title`` or ``window_handle`` static factories.
+#[cfg_attr(feature = "stub-gen", gen_stub_pyclass)]
+#[pyclass(name = "CaptureTarget", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyCaptureTarget {
+    pub(crate) inner: CaptureTarget,
+}
+
+#[cfg_attr(feature = "stub-gen", gen_stub_pymethods)]
+#[pymethods]
+impl PyCaptureTarget {
+    #[staticmethod]
+    fn primary_display() -> Self {
+        Self {
+            inner: CaptureTarget::PrimaryDisplay,
+        }
+    }
+
+    #[staticmethod]
+    fn monitor_index(index: usize) -> Self {
+        Self {
+            inner: CaptureTarget::MonitorIndex(index),
+        }
+    }
+
+    #[staticmethod]
+    fn process_id(pid: u32) -> Self {
+        Self {
+            inner: CaptureTarget::ProcessId(pid),
+        }
+    }
+
+    #[staticmethod]
+    fn window_title(title: String) -> Self {
+        Self {
+            inner: CaptureTarget::WindowTitle(title),
+        }
+    }
+
+    #[staticmethod]
+    fn window_handle(handle: u64) -> Self {
+        Self {
+            inner: CaptureTarget::WindowHandle(handle),
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        match &self.inner {
+            CaptureTarget::PrimaryDisplay => "CaptureTarget.primary_display()".to_string(),
+            CaptureTarget::MonitorIndex(i) => format!("CaptureTarget.monitor_index({i})"),
+            CaptureTarget::ProcessId(p) => format!("CaptureTarget.process_id({p})"),
+            CaptureTarget::WindowTitle(t) => format!("CaptureTarget.window_title({t:?})"),
+            CaptureTarget::WindowHandle(h) => format!("CaptureTarget.window_handle(0x{h:x})"),
+        }
+    }
+}
+
+// ── PyCaptureBackendKind ───────────────────────────────────────────────────
+
+/// Python wrapper for [`CaptureBackendKind`].
+#[cfg_attr(feature = "stub-gen", gen_stub_pyclass)]
+#[pyclass(name = "CaptureBackendKind", eq, frozen, skip_from_py_object)]
+#[derive(Clone, PartialEq, Eq)]
+pub struct PyCaptureBackendKind {
+    pub(crate) inner: CaptureBackendKind,
+}
+
+#[cfg_attr(feature = "stub-gen", gen_stub_pymethods)]
+#[pymethods]
+impl PyCaptureBackendKind {
+    /// Human-readable backend name.
+    #[getter]
+    fn name(&self) -> String {
+        self.inner.to_string()
+    }
+
+    #[classattr]
+    #[allow(non_snake_case)]
+    fn DxgiDesktopDuplication() -> PyCaptureBackendKind {
+        PyCaptureBackendKind {
+            inner: CaptureBackendKind::DxgiDesktopDuplication,
+        }
+    }
+    #[classattr]
+    #[allow(non_snake_case)]
+    fn ScreenCaptureKit() -> PyCaptureBackendKind {
+        PyCaptureBackendKind {
+            inner: CaptureBackendKind::ScreenCaptureKit,
+        }
+    }
+    #[classattr]
+    #[allow(non_snake_case)]
+    fn X11Xshm() -> PyCaptureBackendKind {
+        PyCaptureBackendKind {
+            inner: CaptureBackendKind::X11Xshm,
+        }
+    }
+    #[classattr]
+    #[allow(non_snake_case)]
+    fn PipeWire() -> PyCaptureBackendKind {
+        PyCaptureBackendKind {
+            inner: CaptureBackendKind::PipeWire,
+        }
+    }
+    #[classattr]
+    #[allow(non_snake_case)]
+    fn HwndPrintWindow() -> PyCaptureBackendKind {
+        PyCaptureBackendKind {
+            inner: CaptureBackendKind::HwndPrintWindow,
+        }
+    }
+    #[classattr]
+    #[allow(non_snake_case)]
+    fn Mock() -> PyCaptureBackendKind {
+        PyCaptureBackendKind {
+            inner: CaptureBackendKind::Mock,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!("CaptureBackendKind.{:?}", self.inner)
+    }
+}
+
+// ── PyWindowFinder ─────────────────────────────────────────────────────────
+
+/// Python wrapper for [`WindowFinder`].
+#[cfg_attr(feature = "stub-gen", gen_stub_pyclass)]
+#[pyclass(name = "WindowFinder")]
+pub struct PyWindowFinder {
+    inner: WindowFinder,
+}
+
+#[cfg_attr(feature = "stub-gen", gen_stub_pymethods)]
+#[pymethods]
+impl PyWindowFinder {
+    #[new]
+    fn new() -> Self {
+        Self {
+            inner: WindowFinder::new(),
+        }
+    }
+
+    /// Resolve a :class:`CaptureTarget` to a window.
+    ///
+    /// Returns ``None`` instead of raising when no matching window exists.
+    fn find(&self, target: &PyCaptureTarget) -> Option<PyWindowInfo> {
+        self.inner.find(&target.inner).ok().map(PyWindowInfo::from)
+    }
+
+    /// Return a list of all visible top-level windows.
+    fn enumerate(&self) -> Vec<PyWindowInfo> {
+        self.inner
+            .enumerate()
+            .into_iter()
+            .map(PyWindowInfo::from)
+            .collect()
+    }
+}
+
+/// Python wrapper for [`crate::window::WindowInfo`].
+#[cfg_attr(feature = "stub-gen", gen_stub_pyclass)]
+#[pyclass(name = "WindowInfo", frozen)]
+pub struct PyWindowInfo {
+    #[pyo3(get)]
+    handle: u64,
+    #[pyo3(get)]
+    pid: u32,
+    #[pyo3(get)]
+    title: String,
+    #[pyo3(get)]
+    rect: (i32, i32, i32, i32),
+}
+
+impl From<crate::window::WindowInfo> for PyWindowInfo {
+    fn from(info: crate::window::WindowInfo) -> Self {
+        Self {
+            handle: info.handle,
+            pid: info.pid,
+            title: info.title,
+            rect: (info.rect[0], info.rect[1], info.rect[2], info.rect[3]),
+        }
+    }
+}
+
 // ── Module registration ────────────────────────────────────────────────────
 
 /// Register all PyO3 classes and functions exposed by this crate.
 pub fn register_classes(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyCaptureFrame>()?;
     m.add_class::<PyCapturer>()?;
+    m.add_class::<PyCaptureTarget>()?;
+    m.add_class::<PyCaptureBackendKind>()?;
+    m.add_class::<PyWindowFinder>()?;
+    m.add_class::<PyWindowInfo>()?;
     Ok(())
 }
 

--- a/crates/dcc-mcp-capture/src/types.rs
+++ b/crates/dcc-mcp-capture/src/types.rs
@@ -51,6 +51,8 @@ pub enum CaptureTarget {
     WindowTitle(String),
     /// Capture a specific monitor by zero-based index.
     MonitorIndex(usize),
+    /// Capture a specific window by its platform handle (HWND on Windows, XID on X11).
+    WindowHandle(u64),
 }
 
 // ── CaptureConfig ──────────────────────────────────────────────────────────
@@ -154,6 +156,15 @@ pub struct CaptureFrame {
     pub timestamp_ms: u64,
     /// Source display scale factor (e.g. 2.0 for HiDPI).
     pub dpi_scale: f32,
+    /// Source window bounds `[x, y, width, height]` in physical pixels when
+    /// the frame was captured from a specific window.  `None` for full-screen
+    /// or display captures.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub window_rect: Option<[i32; 4]>,
+    /// Source window title when captured from a specific window.  `None` for
+    /// full-screen or display captures.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub window_title: Option<String>,
 }
 
 impl CaptureFrame {
@@ -181,6 +192,8 @@ pub enum CaptureBackendKind {
     X11Xshm,
     /// Linux Wayland / PipeWire.
     PipeWire,
+    /// Windows GDI `PrintWindow` / `BitBlt` window-target backend.
+    HwndPrintWindow,
     /// In-process mock backend (testing / headless).
     Mock,
 }
@@ -192,6 +205,7 @@ impl std::fmt::Display for CaptureBackendKind {
             CaptureBackendKind::ScreenCaptureKit => "ScreenCaptureKit",
             CaptureBackendKind::X11Xshm => "X11 XShmGetImage",
             CaptureBackendKind::PipeWire => "PipeWire",
+            CaptureBackendKind::HwndPrintWindow => "GDI PrintWindow",
             CaptureBackendKind::Mock => "Mock",
         };
         write!(f, "{s}")
@@ -277,6 +291,8 @@ mod tests {
             format: CaptureFormat::Png,
             timestamp_ms: 1_700_000_000_000,
             dpi_scale: 1.0,
+            window_rect: None,
+            window_title: None,
         };
         assert_eq!(frame.byte_len(), 128);
         assert_eq!(frame.mime_type(), "image/png");

--- a/crates/dcc-mcp-capture/src/window.rs
+++ b/crates/dcc-mcp-capture/src/window.rs
@@ -51,6 +51,7 @@ impl WindowFinder {
             }
             CaptureTarget::ProcessId(pid) => self.find_by_pid(*pid),
             CaptureTarget::WindowTitle(title) => self.find_by_title(title),
+            CaptureTarget::WindowHandle(handle) => self.info_for_handle(*handle),
         }
     }
 
@@ -59,6 +60,25 @@ impl WindowFinder {
     /// Returns an empty list on unsupported platforms.
     pub fn enumerate(&self) -> Vec<WindowInfo> {
         platform_enumerate()
+    }
+
+    /// Look up window information for a known platform handle.
+    ///
+    /// On Windows, queries the HWND directly via `GetWindowRect` /
+    /// `GetWindowTextW`.  Other platforms fall back to `enumerate()`.
+    pub fn info_for_handle(&self, handle: u64) -> CaptureResult<WindowInfo> {
+        #[cfg(target_os = "windows")]
+        {
+            if let Some(info) = windows_info_for_hwnd(handle) {
+                return Ok(info);
+            }
+        }
+        self.enumerate()
+            .into_iter()
+            .find(|w| w.handle == handle)
+            .ok_or_else(|| {
+                CaptureError::TargetNotFound(format!("no window for handle=0x{handle:x}"))
+            })
     }
 
     fn find_by_pid(&self, pid: u32) -> CaptureResult<WindowInfo> {
@@ -141,6 +161,43 @@ fn windows_enumerate() -> Vec<WindowInfo> {
         let _ = EnumWindows(Some(enum_cb), LPARAM(result_ptr));
     }
     result
+}
+
+#[cfg(target_os = "windows")]
+fn windows_info_for_hwnd(handle: u64) -> Option<WindowInfo> {
+    use windows::Win32::Foundation::HWND;
+    use windows::Win32::UI::WindowsAndMessaging::{
+        GetWindowRect, GetWindowTextW, GetWindowThreadProcessId, IsWindow,
+    };
+
+    let hwnd = HWND(handle as *mut core::ffi::c_void);
+    unsafe {
+        if !IsWindow(Some(hwnd)).as_bool() {
+            return None;
+        }
+        let mut title_buf = [0u16; 256];
+        let len = GetWindowTextW(hwnd, &mut title_buf);
+        let title = if len > 0 {
+            String::from_utf16_lossy(&title_buf[..len as usize])
+        } else {
+            String::new()
+        };
+        let mut pid = 0u32;
+        GetWindowThreadProcessId(hwnd, Some(&mut pid));
+        let mut rect = windows::Win32::Foundation::RECT::default();
+        let _ = GetWindowRect(hwnd, &mut rect);
+        Some(WindowInfo {
+            handle,
+            pid,
+            title,
+            rect: [
+                rect.left,
+                rect.top,
+                rect.right - rect.left,
+                rect.bottom - rect.top,
+            ],
+        })
+    }
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────

--- a/crates/dcc-mcp-http/src/handler.rs
+++ b/crates/dcc-mcp-http/src/handler.rs
@@ -359,10 +359,24 @@ async fn handle_tools_list(
     let mut tools: Vec<McpTool> = Vec::with_capacity(core.len() + 16);
     tools.extend_from_slice(core);
 
-    // 2. Loaded skill tools — full definitions from ActionRegistry
+    // 2. Loaded skill tools — full definitions from ActionRegistry.
+    //    Tools in inactive groups are collapsed into one ``__group__<name>``
+    //    stub per group to keep ``tools/list`` compact (progressive exposure).
     let actions = state.registry.list_actions(None);
+    let mut inactive_groups: std::collections::BTreeMap<String, Vec<String>> =
+        std::collections::BTreeMap::new();
     for meta in &actions {
-        tools.push(action_meta_to_mcp_tool(meta));
+        if meta.enabled {
+            tools.push(action_meta_to_mcp_tool(meta));
+        } else if !meta.group.is_empty() {
+            inactive_groups
+                .entry(meta.group.clone())
+                .or_default()
+                .push(meta.name.clone());
+        }
+    }
+    for (group, names) in &inactive_groups {
+        tools.push(build_group_stub(group, names));
     }
 
     // 3. Unloaded skills — one lightweight stub per skill.
@@ -406,6 +420,13 @@ async fn handle_tools_call(
         "load_skill" => return handle_load_skill(state, req, &params, session_id).await,
         "unload_skill" => return handle_unload_skill(state, req, &params, session_id).await,
         "search_skills" => return handle_search_skills(state, req, &params).await,
+        "activate_tool_group" => {
+            return handle_activate_tool_group(state, req, &params, session_id).await;
+        }
+        "deactivate_tool_group" => {
+            return handle_deactivate_tool_group(state, req, &params, session_id).await;
+        }
+        "search_tools" => return handle_search_tools(state, req, &params).await,
         _ => {}
     }
 
@@ -414,6 +435,18 @@ async fn handle_tools_call(
         let msg = format!(
             "Skill '{skill_name}' is not loaded. Call load_skill with skill_name=\"{skill_name}\" \
              to register its tools, then call the specific tool you need."
+        );
+        return Ok(JsonRpcResponse::success(
+            req.id.clone(),
+            serde_json::to_value(CallToolResult::error(msg))?,
+        ));
+    }
+
+    // Group stub: __group__<group_name> — guide model to call activate_tool_group.
+    if let Some(group_name) = tool_name.strip_prefix("__group__") {
+        let msg = format!(
+            "Tool group '{group_name}' is inactive. Call activate_tool_group with \
+             group=\"{group_name}\" to enable its tools, then re-list with tools/list."
         );
         return Ok(JsonRpcResponse::success(
             req.id.clone(),
@@ -983,6 +1016,88 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                 deferred_hint: Some(false),
             }),
         },
+        McpTool {
+            name: "activate_tool_group".to_string(),
+            description: "Activate a tool group so its tools become callable. \
+                          Tools in inactive groups are collapsed into __group__<name> stubs. \
+                          Sends a tools/list_changed notification on success."
+                .to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "group": {
+                        "type": "string",
+                        "description": "Name of the tool group to activate"
+                    }
+                },
+                "required": ["group"]
+            }),
+            annotations: Some(McpToolAnnotations {
+                title: Some("Activate Tool Group".to_string()),
+                read_only_hint: Some(false),
+                destructive_hint: Some(false),
+                idempotent_hint: Some(true),
+                open_world_hint: Some(false),
+                deferred_hint: Some(false),
+            }),
+        },
+        McpTool {
+            name: "deactivate_tool_group".to_string(),
+            description: "Deactivate a tool group — its tools become uncallable until reactivated. \
+                          Useful to reduce the active tool surface for token budget reasons."
+                .to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "group": {
+                        "type": "string",
+                        "description": "Name of the tool group to deactivate"
+                    }
+                },
+                "required": ["group"]
+            }),
+            annotations: Some(McpToolAnnotations {
+                title: Some("Deactivate Tool Group".to_string()),
+                read_only_hint: Some(false),
+                destructive_hint: Some(false),
+                idempotent_hint: Some(true),
+                open_world_hint: Some(false),
+                deferred_hint: Some(false),
+            }),
+        },
+        McpTool {
+            name: "search_tools".to_string(),
+            description: "Full-text search across every registered tool (name/description/tags). \
+                          Matches against enabled tools first and includes group stubs when relevant."
+                .to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Keyword to match in tool name, description, category, or tags"
+                    },
+                    "dcc": {
+                        "type": "string",
+                        "description": "Optional DCC filter"
+                    },
+                    "include_disabled": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Include tools inside inactive groups"
+                    }
+                },
+                "required": ["query"]
+            }),
+            annotations: Some(McpToolAnnotations {
+                title: Some("Search Tools".to_string()),
+                read_only_hint: Some(true),
+                destructive_hint: Some(false),
+                idempotent_hint: Some(true),
+                open_world_hint: Some(false),
+                deferred_hint: Some(false),
+            }),
+        },
     ]
 }
 
@@ -1113,6 +1228,178 @@ async fn handle_search_skills(
         "skills": compact_skills
     });
 
+    Ok(JsonRpcResponse::success(
+        req.id.clone(),
+        serde_json::to_value(CallToolResult::text(serde_json::to_string(&result)?))?,
+    ))
+}
+
+/// Build a compact stub that replaces all tools of an inactive group in
+/// ``tools/list``. Collapses the group into one entry the agent can reason
+/// about without paying the schema cost for every member tool.
+fn build_group_stub(group: &str, tool_names: &[String]) -> McpTool {
+    const PREVIEW_LIMIT: usize = 5;
+    let preview = if tool_names.len() <= PREVIEW_LIMIT {
+        format!(" [{}]", tool_names.join(", "))
+    } else {
+        format!(
+            " [{}, … +{} more]",
+            tool_names[..PREVIEW_LIMIT].join(", "),
+            tool_names.len() - PREVIEW_LIMIT
+        )
+    };
+    let description = format!(
+        "Inactive group '{group}' • {} tools{preview} • Call activate_tool_group(\"{group}\")",
+        tool_names.len(),
+    );
+    McpTool {
+        name: format!("__group__{group}"),
+        description,
+        input_schema: json!({"type": "object", "properties": {}}),
+        annotations: Some(McpToolAnnotations {
+            title: Some(format!("Group: {group}")),
+            read_only_hint: Some(true),
+            destructive_hint: Some(false),
+            idempotent_hint: Some(true),
+            open_world_hint: Some(false),
+            deferred_hint: Some(true),
+        }),
+    }
+}
+
+/// Handle ``activate_tool_group`` — flips every action in the named group
+/// to ``enabled = true`` and fires a ``tools/list_changed`` notification.
+async fn handle_activate_tool_group(
+    state: &AppState,
+    req: &JsonRpcRequest,
+    params: &CallToolParams,
+    session_id: Option<&str>,
+) -> Result<JsonRpcResponse, HttpError> {
+    let group = params
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("group"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if group.is_empty() {
+        return Ok(JsonRpcResponse::success(
+            req.id.clone(),
+            serde_json::to_value(CallToolResult::error("Missing required parameter: group"))?,
+        ));
+    }
+
+    let changed = state.catalog.activate_group(group);
+    if let Some(sid) = session_id {
+        notify_tools_list_changed(&state.sessions, sid);
+    }
+    let payload = json!({
+        "success": true,
+        "group": group,
+        "changed": changed,
+        "active_groups": state.catalog.active_groups(),
+    });
+    Ok(JsonRpcResponse::success(
+        req.id.clone(),
+        serde_json::to_value(CallToolResult::text(payload.to_string()))?,
+    ))
+}
+
+/// Handle ``deactivate_tool_group`` — mirror of [`handle_activate_tool_group`].
+async fn handle_deactivate_tool_group(
+    state: &AppState,
+    req: &JsonRpcRequest,
+    params: &CallToolParams,
+    session_id: Option<&str>,
+) -> Result<JsonRpcResponse, HttpError> {
+    let group = params
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("group"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if group.is_empty() {
+        return Ok(JsonRpcResponse::success(
+            req.id.clone(),
+            serde_json::to_value(CallToolResult::error("Missing required parameter: group"))?,
+        ));
+    }
+
+    let changed = state.catalog.deactivate_group(group);
+    if let Some(sid) = session_id {
+        notify_tools_list_changed(&state.sessions, sid);
+    }
+    let payload = json!({
+        "success": true,
+        "group": group,
+        "changed": changed,
+        "active_groups": state.catalog.active_groups(),
+    });
+    Ok(JsonRpcResponse::success(
+        req.id.clone(),
+        serde_json::to_value(CallToolResult::text(payload.to_string()))?,
+    ))
+}
+
+/// Handle ``search_tools`` — free-text search across every registered tool.
+async fn handle_search_tools(
+    state: &AppState,
+    req: &JsonRpcRequest,
+    params: &CallToolParams,
+) -> Result<JsonRpcResponse, HttpError> {
+    let query = params
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("query"))
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_lowercase();
+    if query.is_empty() {
+        return Ok(JsonRpcResponse::success(
+            req.id.clone(),
+            serde_json::to_value(CallToolResult::error("Missing required parameter: query"))?,
+        ));
+    }
+    let dcc = params
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("dcc"))
+        .and_then(Value::as_str);
+    let include_disabled = params
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("include_disabled"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    let mut matches: Vec<serde_json::Value> = Vec::new();
+    for meta in state.registry.list_actions(dcc) {
+        if !include_disabled && !meta.enabled {
+            continue;
+        }
+        let haystack = format!(
+            "{} {} {} {}",
+            meta.name,
+            meta.description,
+            meta.category,
+            meta.tags.join(" ")
+        )
+        .to_lowercase();
+        if haystack.contains(&query) {
+            matches.push(serde_json::json!({
+                "name": meta.name,
+                "description": meta.description,
+                "category": meta.category,
+                "group": meta.group,
+                "enabled": meta.enabled,
+                "dcc": meta.dcc,
+            }));
+        }
+    }
+    let result = serde_json::json!({
+        "total": matches.len(),
+        "query": query,
+        "tools": matches,
+    });
     Ok(JsonRpcResponse::success(
         req.id.clone(),
         serde_json::to_value(CallToolResult::text(serde_json::to_string(&result)?))?,

--- a/crates/dcc-mcp-http/src/python/mod.rs
+++ b/crates/dcc-mcp-http/src/python/mod.rs
@@ -403,6 +403,16 @@ impl PyMcpHttpServer {
         self.dispatcher.has_handler(action_name)
     }
 
+    /// The server's :class:`ToolRegistry`.
+    ///
+    /// Returned value shares the underlying storage with the server —
+    /// ``register()`` calls on it will update the tools exposed via
+    /// ``tools/list``. Must be populated **before** calling :meth:`start`.
+    #[getter]
+    fn registry(&self) -> ActionRegistry {
+        (*self.registry).clone()
+    }
+
     /// Access the server's SkillCatalog for progressive skill loading.
     ///
     /// Returns a debug representation of the catalog state (total/loaded counts).

--- a/crates/dcc-mcp-http/src/tests.rs
+++ b/crates/dcc-mcp-http/src/tests.rs
@@ -127,14 +127,18 @@ mod tests {
         resp.assert_status_ok();
         let body: Value = resp.json();
         let tools = body["result"]["tools"].as_array().unwrap();
-        // 6 core discovery tools + 2 registered actions = 8
-        assert_eq!(tools.len(), 8);
+        // 9 core meta-tools (6 skill discovery + activate/deactivate/search_tools)
+        // + 2 registered actions = 11
+        assert_eq!(tools.len(), 11);
         let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
         assert!(names.contains(&"get_scene_info"));
         assert!(names.contains(&"list_objects"));
         assert!(names.contains(&"find_skills"));
         assert!(names.contains(&"load_skill"));
         assert!(names.contains(&"search_skills"));
+        assert!(names.contains(&"activate_tool_group"));
+        assert!(names.contains(&"deactivate_tool_group"));
+        assert!(names.contains(&"search_tools"));
     }
 
     // ── search_skills ─────────────────────────────────────────────────────────────
@@ -440,13 +444,16 @@ mod tests {
                     | "load_skill"
                     | "unload_skill"
                     | "search_skills"
+                    | "activate_tool_group"
+                    | "deactivate_tool_group"
+                    | "search_tools"
             );
-            let is_stub = name.starts_with("__skill__");
+            let is_stub = name.starts_with("__skill__") || name.starts_with("__group__");
 
             assert!(
                 is_core || is_stub,
                 "Found unexpected tool '{name}' in tools/list before any skill was loaded. \
-                 Only core meta-tools and __skill__<name> stubs should appear."
+                 Only core meta-tools and __skill__<name> / __group__<name> stubs should appear."
             );
 
             // Stubs must have a minimal input_schema — no nested 'properties'
@@ -1102,8 +1109,8 @@ mod tests {
 
         let body2: Value = resp2.json();
         let tools = body2["result"]["tools"].as_array().unwrap();
-        // 6 core tools + 2 skill tools (skill now loaded, no stubs) = 8
-        assert_eq!(tools.len(), 8);
+        // 9 core meta-tools + 2 skill tools (skill now loaded, no stubs) = 11
+        assert_eq!(tools.len(), 11);
         let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
         assert!(names.contains(&"modeling_bevel__bevel"));
         assert!(names.contains(&"modeling_bevel__chamfer"));
@@ -1178,8 +1185,8 @@ mod tests {
 
         let body2: Value = resp2.json();
         let tools = body2["result"]["tools"].as_array().unwrap();
-        // Back to 6 core tools + 1 unloaded skill stub = 7
-        assert_eq!(tools.len(), 7);
+        // Back to 9 core meta-tools + 1 unloaded skill stub = 10
+        assert_eq!(tools.len(), 10);
         let stub = tools
             .iter()
             .find(|t| t["name"] == "__skill__modeling-bevel")

--- a/crates/dcc-mcp-models/src/lib.rs
+++ b/crates/dcc-mcp-models/src/lib.rs
@@ -7,8 +7,8 @@ pub mod skill_scope;
 pub use action_result::ActionResultModel as ToolResult;
 pub use action_result::{ActionResultModel, ActionResultModelData, SerializeFormat};
 pub use skill_metadata::{
-    SkillDependencies, SkillDependency, SkillDependencyType, SkillMetadata, SkillPolicy,
-    ToolDeclaration,
+    SkillDependencies, SkillDependency, SkillDependencyType, SkillGroup, SkillMetadata,
+    SkillPolicy, ToolDeclaration,
 };
 pub use skill_scope::SkillScope;
 

--- a/crates/dcc-mcp-models/src/skill_metadata.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata.rs
@@ -1493,6 +1493,7 @@ mod tests {
             metadata_files: vec!["help.md".to_string()],
             policy: None,
             external_deps: None,
+            groups: Vec::new(),
         };
         let json = serde_json::to_string(&meta).unwrap();
         let back: SkillMetadata = serde_json::from_str(&json).unwrap();

--- a/crates/dcc-mcp-models/src/skill_metadata.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata.rs
@@ -90,6 +90,16 @@ pub struct ToolDeclaration {
     /// ```
     #[serde(default, rename = "next-tools", alias = "next_tools")]
     pub next_tools: NextTools,
+
+    /// Tool group this declaration belongs to (progressive exposure).
+    ///
+    /// Empty string ``""`` means the tool is always active (default group).
+    /// Non-empty values reference a :struct:`SkillGroup` declared in the
+    /// skill's `groups:` list. Tools in an inactive group are hidden behind
+    /// a ``__group__<skill>__<name>`` stub in ``tools/list`` until the agent
+    /// calls ``activate_tool_group``.
+    #[serde(default)]
+    pub group: String,
 }
 
 /// Suggested next tools for a successful or failed tool call (issue #143).
@@ -104,6 +114,87 @@ pub struct NextTools {
     pub on_failure: Vec<String>,
 }
 
+// ── SkillGroup ─────────────────────────────────────────────────────────────
+
+/// Declaration of a tool group within a skill (progressive exposure).
+///
+/// A group bundles multiple tools behind a single stub entry in ``tools/list``
+/// so agents only pay the context cost for the tools they actually use.
+///
+/// ```yaml
+/// groups:
+///   - name: uv-editing
+///     description: UV-space operations
+///     default-active: false
+///     tools: [unwrap, layout_uvs, transfer_uvs]
+/// ```
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "python-bindings",
+    pyclass(name = "SkillGroup", eq, from_py_object)
+)]
+pub struct SkillGroup {
+    /// Group identifier — unique within the skill (kebab-case recommended).
+    #[serde(default)]
+    pub name: String,
+
+    /// Human-readable summary of what the group offers.
+    #[serde(default)]
+    pub description: String,
+
+    /// Names of tools belonging to this group.
+    #[serde(default)]
+    pub tools: Vec<String>,
+
+    /// Whether this group is active by default when the skill is loaded.
+    #[serde(default, rename = "default-active", alias = "default_active")]
+    pub default_active: bool,
+}
+
+#[cfg(feature = "python-bindings")]
+#[pymethods]
+impl SkillGroup {
+    #[new]
+    #[pyo3(signature = (name, description="".to_string(), tools=Vec::<String>::new(), default_active=false))]
+    fn new(name: String, description: String, tools: Vec<String>, default_active: bool) -> Self {
+        Self {
+            name,
+            description,
+            tools,
+            default_active,
+        }
+    }
+
+    #[getter]
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    #[getter]
+    fn description(&self) -> &str {
+        &self.description
+    }
+
+    #[getter]
+    fn tools(&self) -> Vec<String> {
+        self.tools.clone()
+    }
+
+    #[getter]
+    fn default_active(&self) -> bool {
+        self.default_active
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "SkillGroup(name={:?}, tools={}, default_active={})",
+            self.name,
+            self.tools.len(),
+            self.default_active
+        )
+    }
+}
+
 fn is_null_value(v: &serde_json::Value) -> bool {
     v.is_null()
 }
@@ -112,7 +203,7 @@ fn is_null_value(v: &serde_json::Value) -> bool {
 #[pymethods]
 impl ToolDeclaration {
     #[new]
-    #[pyo3(signature = (name, description="".to_string(), input_schema=None, output_schema=None, read_only=false, destructive=false, idempotent=false, defer_loading=false, source_file="".to_string()))]
+    #[pyo3(signature = (name, description="".to_string(), input_schema=None, output_schema=None, read_only=false, destructive=false, idempotent=false, defer_loading=false, source_file="".to_string(), group="".to_string()))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         name: String,
@@ -124,6 +215,7 @@ impl ToolDeclaration {
         idempotent: bool,
         defer_loading: bool,
         source_file: String,
+        group: String,
     ) -> Self {
         let input_schema = input_schema
             .and_then(|s| serde_json::from_str(&s).ok())
@@ -142,7 +234,18 @@ impl ToolDeclaration {
             defer_loading,
             source_file,
             next_tools: NextTools::default(),
+            group,
         }
+    }
+
+    #[getter]
+    fn group(&self) -> &str {
+        &self.group
+    }
+
+    #[setter]
+    fn set_group(&mut self, value: String) {
+        self.group = value;
     }
 
     fn __repr__(&self) -> String {
@@ -584,6 +687,13 @@ pub struct SkillMetadata {
     /// that must be available for this skill to function correctly.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub external_deps: Option<SkillDependencies>,
+
+    /// Declared tool groups for progressive exposure (see [`SkillGroup`]).
+    ///
+    /// When a tool declares a group name that is not present in this list,
+    /// the catalog auto-inserts an inactive placeholder group at load time.
+    #[serde(default)]
+    pub groups: Vec<SkillGroup>,
 }
 
 impl SkillMetadata {
@@ -886,6 +996,7 @@ impl SkillMetadata {
             metadata: serde_json::Value::Null,
             policy: None,
             external_deps: None,
+            groups: Vec::new(),
         }
     }
 

--- a/crates/dcc-mcp-skills/src/catalog/mod.rs
+++ b/crates/dcc-mcp-skills/src/catalog/mod.rs
@@ -49,10 +49,26 @@ use dcc_mcp_actions::{
     ActionDispatcher,
     registry::{ActionMeta, ActionRegistry},
 };
-use dcc_mcp_models::{SkillMetadata, SkillScope};
+use dcc_mcp_models::{SkillGroup, SkillMetadata, SkillScope};
 use std::sync::Arc;
 
 use crate::loader;
+
+/// Return whether the group named ``group_name`` should be active at load-time.
+///
+/// Empty ``group_name`` (the "always-on" default group) is always active.
+/// Otherwise, the group must be declared in ``groups`` with
+/// ``default_active = true``.
+pub(crate) fn group_default_active(groups: &[SkillGroup], group_name: &str) -> bool {
+    if group_name.is_empty() {
+        return true;
+    }
+    groups
+        .iter()
+        .find(|g| g.name == group_name)
+        .map(|g| g.default_active)
+        .unwrap_or(false)
+}
 
 // ── SkillCatalog ──
 
@@ -74,6 +90,8 @@ pub struct SkillCatalog {
     registry: Arc<ActionRegistry>,
     /// Optional dispatcher for auto-registering script handlers on load.
     dispatcher: Option<Arc<ActionDispatcher>>,
+    /// Tool groups currently active (``"<skill>:<group>"`` keys).
+    active_groups: DashSet<String>,
 }
 
 impl std::fmt::Debug for SkillCatalog {
@@ -104,6 +122,7 @@ impl SkillCatalog {
             loaded: DashSet::new(),
             registry,
             dispatcher: None,
+            active_groups: DashSet::new(),
         }
     }
 
@@ -121,6 +140,7 @@ impl SkillCatalog {
             loaded: DashSet::new(),
             registry,
             dispatcher: Some(dispatcher),
+            active_groups: DashSet::new(),
         }
     }
 
@@ -302,6 +322,13 @@ impl SkillCatalog {
         let skill_base = metadata.name.replace('-', "_");
         let skill_path = std::path::Path::new(&metadata.skill_path);
 
+        // Seed active_groups from default-active entries declared in the SKILL.md
+        for group in &metadata.groups {
+            if group.default_active {
+                self.active_groups.insert(group.name.clone());
+            }
+        }
+
         for tool_decl in &metadata.tools {
             let action_name = if tool_decl.name.contains("__") {
                 tool_decl.name.clone()
@@ -331,6 +358,11 @@ impl SkillCatalog {
                 output_schema: tool_decl.output_schema.clone(),
                 source_file: script_path.clone(),
                 skill_name: Some(skill_name.to_string()),
+                group: tool_decl.group.clone(),
+                // Disable at registration when the declared group is not
+                // default-active; default groups (empty group name or an
+                // explicitly default-active group) stay enabled.
+                enabled: group_default_active(&metadata.groups, &tool_decl.group),
             };
 
             self.registry.register_action(meta);
@@ -366,6 +398,8 @@ impl SkillCatalog {
                     output_schema: serde_json::Value::Null,
                     source_file: Some(script_path.clone()),
                     skill_name: Some(skill_name.to_string()),
+                    group: String::new(),
+                    enabled: true,
                 };
 
                 self.registry.register_action(meta);
@@ -652,6 +686,43 @@ fn skill_entry_to_summary(e: &SkillEntry) -> SkillSummary {
     }
 }
 
+// ── Progressive tool exposure (group activation) ──
+
+impl SkillCatalog {
+    /// Activate a tool group: enable every [`ActionMeta`] whose
+    /// ``group`` field matches ``group_name``.
+    ///
+    /// Returns the number of actions whose ``enabled`` state changed.
+    pub fn activate_group(&self, group_name: &str) -> usize {
+        self.active_groups.insert(group_name.to_string());
+        self.registry.set_group_enabled(group_name, true)
+    }
+
+    /// Deactivate a tool group (inverse of [`activate_group`]).
+    pub fn deactivate_group(&self, group_name: &str) -> usize {
+        self.active_groups.remove(group_name);
+        self.registry.set_group_enabled(group_name, false)
+    }
+
+    /// Return all currently-active tool group names.
+    pub fn active_groups(&self) -> Vec<String> {
+        self.active_groups.iter().map(|e| e.clone()).collect()
+    }
+
+    /// Return every distinct group name declared across loaded skills.
+    pub fn list_groups(&self) -> Vec<(String, String, bool)> {
+        let mut out: Vec<(String, String, bool)> = Vec::new();
+        for entry in self.entries.iter() {
+            let skill = entry.key().clone();
+            for g in &entry.value().metadata.groups {
+                let active = self.active_groups.contains(&g.name);
+                out.push((skill.clone(), g.name.clone(), active));
+            }
+        }
+        out
+    }
+}
+
 // ── Python bindings ──
 
 #[cfg(feature = "python-bindings")]
@@ -660,6 +731,32 @@ impl SkillCatalog {
     #[new]
     fn py_new(registry: ActionRegistry) -> Self {
         Self::new(Arc::new(registry))
+    }
+
+    /// Activate a tool group (enable every action in it).
+    ///
+    /// Returns the number of actions whose ``enabled`` flag changed.
+    #[pyo3(name = "activate_group")]
+    fn py_activate_group(&self, group_name: &str) -> usize {
+        self.activate_group(group_name)
+    }
+
+    /// Deactivate a tool group.
+    #[pyo3(name = "deactivate_group")]
+    fn py_deactivate_group(&self, group_name: &str) -> usize {
+        self.deactivate_group(group_name)
+    }
+
+    /// Return the list of currently-active tool groups.
+    #[pyo3(name = "active_groups")]
+    fn py_active_groups(&self) -> Vec<String> {
+        self.active_groups()
+    }
+
+    /// List all declared groups as ``(skill_name, group_name, active)`` tuples.
+    #[pyo3(name = "list_groups")]
+    fn py_list_groups(&self) -> Vec<(String, String, bool)> {
+        self.list_groups()
     }
 
     /// Discover skills from standard scan paths.

--- a/docs/api/capture.md
+++ b/docs/api/capture.md
@@ -20,15 +20,18 @@ capturer = Capturer.new_auto()
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `new_auto()` | `Capturer` | Create capturer with best available backend |
+| `new_auto()` | `Capturer` | Create capturer with best available backend (full-screen / display) |
+| `new_window_auto()` | `Capturer` | Create capturer configured for single-window capture (HWND PrintWindow on Windows; Mock elsewhere) |
 | `new_mock(width=1920, height=1080)` | `Capturer` | Create capturer with mock backend (for testing/CI) |
 
 ### Methods
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `capture(format="png", jpeg_quality=85, scale=1.0, timeout_ms=5000, process_id=None, window_title=None)` | `CaptureFrame` | Capture a frame |
-| `backend_name()` | `str` | Name of the active backend (e.g. `"DXGI Desktop Duplication"`) |
+| `capture(format="png", jpeg_quality=85, scale=1.0, timeout_ms=5000, process_id=None, window_title=None)` | `CaptureFrame` | Capture a frame (display or, when `process_id`/`window_title` is set, the matching window) |
+| `capture_window(*, process_id=None, window_handle=None, window_title=None, format="png", jpeg_quality=85, scale=1.0, timeout_ms=5000, include_decorations=True)` | `CaptureFrame` | Capture a single window. At least one of `process_id` / `window_handle` / `window_title` must be provided |
+| `backend_name()` | `str` | Name of the active backend (e.g. `"DXGI Desktop Duplication"`, `"HWND PrintWindow"`) |
+| `backend_kind()` | `CaptureBackendKind` | Enum form of the active backend |
 | `stats()` | `tuple[int, int, int]` | Running statistics: `(capture_count, total_bytes, error_count)` |
 
 ### CaptureFrame
@@ -53,6 +56,8 @@ print(frame.data)                 # Encoded image bytes
 | `mime_type` | `str` | MIME type for the encoded bytes (e.g. `"image/png"`) |
 | `timestamp_ms` | `int` | Milliseconds since Unix epoch at capture time |
 | `dpi_scale` | `float` | Display scale factor (1.0 standard, 2.0 HiDPI) |
+| `window_rect` | `tuple[int, int, int, int] \| None` | `(x, y, width, height)` of the source window in screen coordinates, or `None` for full-screen / display captures |
+| `window_title` | `str \| None` | Source window title, or `None` for full-screen / display captures |
 
 ### CaptureFrame Methods
 
@@ -79,15 +84,88 @@ print(frame.data)                 # Encoded image bytes
 | `process_id` | `int` | `None` | Capture specific process |
 | `window_title` | `str` | `None` | Capture specific window |
 
+## Window-Target Capture
+
+Capture a single application window instead of the entire display.
+
+```python
+from dcc_mcp_core import Capturer, CaptureTarget, WindowFinder
+
+# High-level: auto-select window backend, capture by PID / title / handle
+cap = Capturer.new_window_auto()
+frame = cap.capture_window(window_title="Maya 2024", include_decorations=True)
+print(frame.window_rect, frame.window_title)   # ((x, y, w, h), "Maya 2024 - ...")
+
+# Low-level: resolve a target to a concrete HWND before capture
+finder = WindowFinder()
+info = finder.find(CaptureTarget.process_id(12345))
+if info is not None:
+    print(info.handle, info.pid, info.title, info.rect)
+    frame = cap.capture_window(window_handle=info.handle)
+
+# Enumerate every visible top-level window
+for info in finder.enumerate():
+    print(info.handle, info.title)
+```
+
+### `CaptureTarget`
+
+Opaque window / display target descriptor. Construct via the static factories below.
+
+| Factory | Description |
+|---------|-------------|
+| `CaptureTarget.primary_display()` | The primary display (full-screen capture) |
+| `CaptureTarget.monitor_index(index)` | A specific monitor by 0-based index |
+| `CaptureTarget.process_id(pid)` | The main window belonging to a process |
+| `CaptureTarget.window_title(title)` | The first window whose title contains the substring |
+| `CaptureTarget.window_handle(handle)` | A specific HWND / X11 window ID |
+
+### `WindowFinder`
+
+Resolves a `CaptureTarget` to a concrete `WindowInfo` without raising when no match is found.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `WindowFinder()` | `WindowFinder` | Construct a finder (platform-native enumeration on Windows; stubbed elsewhere) |
+| `.find(target)` | `WindowInfo \| None` | Resolve a `CaptureTarget` — returns `None` when no matching window exists |
+| `.enumerate()` | `list[WindowInfo]` | Every visible top-level window |
+
+### `WindowInfo`
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `handle` | `int` | Native window handle (HWND on Windows, X11 window ID on Linux) |
+| `pid` | `int` | Owner process ID |
+| `title` | `str` | Window title |
+| `rect` | `tuple[int, int, int, int]` | `(x, y, width, height)` in screen coordinates |
+
 ## Backends
 
-| Backend | Platform | Description |
-|---------|----------|-------------|
-| `dxgi` | Windows | DXGI Desktop Duplication API |
-| `x11` | Linux | X11 XShmGetImage |
-| `mock` | All | Synthetic checkerboard for testing |
+| Backend | Platform | Kind | Description |
+|---------|----------|------|-------------|
+| `dxgi` | Windows | `DxgiDesktopDuplication` | DXGI Desktop Duplication API — full-screen / display |
+| `hwnd` | Windows | `HwndPrintWindow` | GDI `PrintWindow` + `BitBlt` fallback — single window |
+| `x11` | Linux | `X11Xshm` | X11 `XShmGetImage` — full-screen |
+| `pipewire` | Linux | `PipeWire` | PipeWire screencast (Wayland) — reserved |
+| `screencapturekit` | macOS | `ScreenCaptureKit` | ScreenCaptureKit — reserved |
+| `mock` | All | `Mock` | Synthetic checkerboard for testing |
 
-Backend selection is automatic via `new_auto()`.
+Backend selection is automatic:
+- `Capturer.new_auto()` — picks the best full-screen / display backend.
+- `Capturer.new_window_auto()` — picks the best window-target backend (HWND on Windows; Mock elsewhere).
+
+### `CaptureBackendKind`
+
+Enum exposed as `CaptureBackendKind.<Variant>` class attributes. Useful for
+branching on the backend without parsing `backend_name()`:
+
+```python
+from dcc_mcp_core import Capturer, CaptureBackendKind
+
+cap = Capturer.new_window_auto()
+if cap.backend_kind() == CaptureBackendKind.HwndPrintWindow:
+    ...  # Windows window capture path
+```
 
 ## Error Handling
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -136,6 +136,49 @@ print(f"MCP server running at {handle.mcp_url()}")
 # handle.shutdown() to shut down
 ```
 
+### Instance-Bound Diagnostics
+
+When multiple DCC instances run side-by-side (two Maya processes, Maya +
+Blender, etc.), each adapter server should be bound to **its own** DCC
+process so diagnostics (screenshot, audit log, metrics) target the right
+window and PID.
+
+`DccServerBase` accepts three optional instance-binding kwargs and exposes
+four `diagnostics__*` MCP tools:
+
+```python
+from dcc_mcp_core import DccServerBase
+
+class MayaServer(DccServerBase):
+    def __init__(self, pid: int, window_title: str):
+        super().__init__(
+            dcc_name="maya",
+            builtin_skills_dir=None,
+            dcc_pid=pid,                   # owner DCC PID
+            dcc_window_title=window_title, # fallback match when PID lookup fails
+            # dcc_window_handle=0x00A1B2,  # or pass an HWND directly
+        )
+
+server = MayaServer(pid=12345, window_title="Autodesk Maya 2024")
+handle = server.start()  # exposes diagnostics__screenshot / audit_log /
+                         # action_metrics / process_status tools bound to
+                         # this Maya instance only
+```
+
+If the PID can change at runtime (e.g. the user relaunches Maya), pass a
+lazy `resolver` callable instead of `dcc_pid`:
+
+```python
+def current_maya_pid() -> int | None:
+    return _find_maya_pid()    # evaluated on every diagnostics call
+
+server = DccServerBase("maya", resolver=current_maya_pid, ...)
+```
+
+For low-level servers built around `McpHttpServer` directly, call
+`register_diagnostic_mcp_tools(server, dcc_name=..., dcc_pid=...)` **before**
+`server.start()` — per the "register all actions before start" rule.
+
 ## Development Setup
 
 ```bash

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -287,6 +287,98 @@ Parsed from SKILL.md frontmatter. Supports Anthropic Skills, ClawHub/OpenClaw, a
 | `version` | `str` | Skill version (default: `"1.0.0"`) |
 | `depends` | `List[str]` | Skill dependency names |
 | `metadata_files` | `List[str]` | Paths to `.md` files in `metadata/` |
+| `groups` | `List[SkillGroup]` | Tool groups for progressive exposure (see below) |
+
+## Tool Groups (Progressive Exposure)
+
+Large skills often expose far more tools than an AI client needs at any given
+moment. Tool groups let a skill ship several related toolsets and let the
+client activate only the ones it needs — keeping `tools/list` small while all
+tools remain discoverable.
+
+### Declaring Groups in SKILL.md
+
+Groups are declared in the top-level `groups:` section. Each tool can then
+reference a group name via its `group:` field:
+
+```yaml
+---
+name: maya-geometry
+description: "Maya geometry, modeling, and rigging tools"
+dcc: maya
+groups:
+  - name: modeling
+    description: "Polygon modeling and UV tools"
+    default_active: true          # active at load time (no activation needed)
+    tools: [create_sphere, create_cube, extrude]
+  - name: rigging
+    description: "Skeleton, joints and skinning"
+    default_active: false         # inactive until activate_tool_group is called
+    tools: [create_joint]
+tools:
+  - name: create_sphere
+    description: "Create a polygon sphere"
+    group: modeling
+    source_file: scripts/create_sphere.py
+  - name: create_joint
+    description: "Create a joint chain"
+    group: rigging
+    source_file: scripts/create_joint.py
+---
+```
+
+### `SkillGroup` Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `str` | required | Group identifier (kebab-case recommended) |
+| `description` | `str` | `""` | Human-readable description |
+| `default_active` | `bool` | `False` | Active immediately after `load_skill`; `False` means dormant until activated |
+| `tools` | `List[str]` | `[]` | Tool names in this group — must match `ToolDeclaration.name` entries |
+
+### How Groups Behave After `load_skill`
+
+When `SkillCatalog.load_skill("maya-geometry")` runs:
+
+1. All tool declarations are registered in `ToolRegistry` with their
+   `ActionMeta.group` set to the declared group name.
+2. Tools in groups where `default_active=false` are registered with
+   `ActionMeta.enabled=False`. The MCP server hides disabled tools from
+   `tools/list`; they are invocable again once the group is activated.
+3. `SkillCatalog.active_groups(skill_name)` returns the initially-active groups.
+
+### Controlling Groups at Runtime
+
+```python
+from dcc_mcp_core import SkillCatalog, ToolRegistry, create_skill_server
+
+# Via the high-level catalog
+catalog.activate_group("maya-geometry", "rigging")     # enables rigging tools
+catalog.deactivate_group("maya-geometry", "rigging")   # disables them again
+groups   = catalog.list_groups("maya-geometry")         # -> List[SkillGroup]
+tools    = catalog.list_tools_catalog("maya-geometry")  # group -> tools map
+
+# Or via the registry directly (emits tools/list_changed notifications)
+registry.activate_tool_group("maya-geometry", "rigging")
+registry.deactivate_tool_group("maya-geometry", "rigging")
+enabled_tools = registry.list_tools_in_group("maya-geometry", "modeling")
+enabled_only  = registry.list_actions_enabled()
+```
+
+### MCP Tools for Group Management
+
+`create_skill_server` / `McpHttpServer` register three core MCP tools for
+group control in addition to the six skill-discovery tools:
+
+| Tool | Description |
+|------|-------------|
+| `activate_tool_group` | Activate a group; emits `notifications/tools/list_changed` so clients refresh their view |
+| `deactivate_tool_group` | Deactivate a group |
+| `search_tools` | Keyword search across currently-enabled tools (name, description, tags) |
+
+`tools/list` also returns `__group__<skill>.<group>` stubs for any group
+that is inactive, making the full tool surface discoverable without
+exposing schemas or handlers.
 
 ## Environment Variables
 

--- a/examples/skills/maya-geometry/SKILL.md
+++ b/examples/skills/maya-geometry/SKILL.md
@@ -10,10 +10,20 @@ metadata:
 tags: [maya, geometry, creation, modeling]
 dcc: maya
 version: "1.0.0"
-search-hint: "maya, geometry, polygon, sphere, cube, bevel, extrude, merge, 3D modeling"
+search-hint: "maya, geometry, polygon, sphere, cube, bevel, extrude, merge, 3D modeling, rigging, skin"
+groups:
+  - name: modeling
+    description: Polygon modeling primitives and edits (always active by default)
+    default-active: true
+    tools: [create_sphere, bevel_edges]
+  - name: rigging
+    description: Skeleton and deformation tools (activate with activate_tool_group)
+    default-active: false
+    tools: [create_joint]
 tools:
   - name: create_sphere
     description: Create a polygon sphere with the given radius and subdivisions
+    group: modeling
     input_schema:
       type: object
       properties:
@@ -39,6 +49,7 @@ tools:
 
   - name: bevel_edges
     description: Apply bevel to selected polygon edges
+    group: modeling
     input_schema:
       type: object
       properties:
@@ -57,6 +68,21 @@ tools:
     next-tools:
       on-success: [maya_pipeline__export_usd]
       on-failure: [dcc_diagnostics__screenshot, dcc_diagnostics__audit_log]
+
+  - name: create_joint
+    description: Create a skinning joint at the current selection (rigging group — inactive by default)
+    group: rigging
+    input_schema:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Joint node name
+          default: joint1
+    read_only: false
+    destructive: false
+    idempotent: false
+    source_file: scripts/create_joint.py
 ---
 
 # Maya Geometry Tools

--- a/examples/skills/maya-geometry/scripts/create_joint.py
+++ b/examples/skills/maya-geometry/scripts/create_joint.py
@@ -1,0 +1,50 @@
+"""Create a skinning joint at the current Maya selection (rigging group demo).
+
+This script belongs to the inactive ``rigging`` tool group and only becomes
+callable after the agent issues ``activate_tool_group(group="rigging")``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Create a Maya skinning joint.")
+    parser.add_argument("--name", default="joint1", help="Node name for the new joint")
+    args = parser.parse_args()
+
+    try:
+        import maya.cmds as mc  # type: ignore[import-not-found]
+    except ImportError:
+        print(
+            json.dumps(
+                {
+                    "success": False,
+                    "message": "Maya is not available. Run from a mayapy / Maya session.",
+                }
+            )
+        )
+        sys.exit(1)
+
+    try:
+        joint = mc.joint(name=args.name)
+    except Exception as exc:
+        print(json.dumps({"success": False, "message": f"mc.joint failed: {exc}"}))
+        sys.exit(1)
+
+    print(
+        json.dumps(
+            {
+                "success": True,
+                "message": f"Created joint '{joint}'",
+                "context": {"joint": joint},
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/justfile
+++ b/justfile
@@ -121,6 +121,13 @@ test-cov:
 test-e2e:
     pytest tests/test_mcp_mcporter_e2e.py -v --tb=short
 
+# ── Type stubs (pyo3-stub-gen PoC) ────────────────────────────────────────────
+
+# Generate python/dcc_mcp_core/_core.poc.pyi from annotated Rust code.
+# Current scope: dcc-mcp-capture crate only (PoC).
+stubgen:
+    cargo run --bin stub_gen --features stub-gen
+
 # ── Lint ──────────────────────────────────────────────────────────────────────
 
 # Lint Python source (ruff check only)

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -24,7 +24,9 @@
 | Enforce security policy on actions | `SandboxPolicy` + `SandboxContext` |
 | Track performance metrics | `ToolRecorder` + `ToolMetrics` |
 | Share large data between processes | `PySharedSceneBuffer` (LZ4 compressed) |
-| Capture a DCC viewport screenshot | `Capturer.new_auto().capture()` |
+| Capture a DCC viewport screenshot | `Capturer.new_auto().capture()` (full-screen) / `Capturer.new_window_auto().capture_window(process_id=pid)` (single window) |
+| Bind diagnostics MCP tools to a specific DCC instance | `DccServerBase(..., dcc_pid=pid, dcc_window_title=title)` |
+| Expose a group of tools only when asked | Declare `groups:` in SKILL.md + `activate_tool_group` / `deactivate_tool_group` |
 | Exchange scene data via USD format | `UsdStage` + `scene_info_json_to_stage()` |
 | Bridge DCC protocols | `BridgeRegistry` + `register_bridge()` / `get_bridge_context()` |
 | Describe scene hierarchy | `SceneNode` + `SceneObject` + `ObjectTransform` + `BoundingBox` |
@@ -55,7 +57,7 @@ crates/
 ├── dcc-mcp-telemetry/    # TelemetryConfig, RecordingGuard, ToolMetrics, ToolRecorder
 ├── dcc-mcp-sandbox/      # SandboxPolicy, SandboxContext, InputValidator, AuditLog, AuditEntry
 ├── dcc-mcp-shm/          # PyBufferPool, PySharedBuffer, PySharedSceneBuffer, LZ4 compression
-├── dcc-mcp-capture/      # Capturer, CaptureFrame, CaptureResult
+├── dcc-mcp-capture/      # Capturer, CaptureFrame, CaptureResult, CaptureTarget, WindowFinder (HWND on Windows)
 ├── dcc-mcp-usd/          # UsdStage, UsdPrim, SdfPath, VtValue, scene info bridge
 ├── dcc-mcp-server/       # Binary entry point, gateway runner
 └── dcc-mcp-utils/        # Filesystem, constants, type wrappers, JSON conversion
@@ -587,9 +589,78 @@ catalog.loaded_count()                   # -> int
 
 # Get full metadata
 meta = catalog.get_skill_info("maya-geometry")  # -> Optional[SkillMetadata]
+
+# Tool groups (progressive exposure) — see next section
+catalog.active_groups("maya-geometry")            # -> List[str]
+catalog.activate_group("maya-geometry", "rigging")   # -> bool
+catalog.deactivate_group("maya-geometry", "rigging") # -> bool
+catalog.list_groups("maya-geometry")               # -> List[SkillGroup]
+catalog.list_tools_catalog("maya-geometry")        # -> {group_name: [tool_names]}
 ```
 
 **SkillSummary fields:** `.name`, `.description`, `.search_hint`, `.version`, `.dcc`, `.tags`, `.tool_count`, `.tool_names`, `.loaded`
+
+### Tool Groups (Progressive Exposure)
+
+Large skills can declare **tool groups** in SKILL.md so the AI client activates
+only the toolsets it needs, keeping `tools/list` compact while all tools stay
+discoverable via `search_tools`.
+
+```yaml
+# SKILL.md frontmatter
+---
+name: maya-geometry
+dcc: maya
+groups:
+  - name: modeling
+    description: "Polygon modeling and UV tools"
+    default_active: true          # active at load_skill time
+    tools: [create_sphere, extrude]
+  - name: rigging
+    description: "Skeleton, joints, skinning"
+    default_active: false         # dormant until activate_tool_group
+    tools: [create_joint]
+tools:
+  - name: create_sphere
+    group: modeling
+    source_file: scripts/create_sphere.py
+  - name: create_joint
+    group: rigging
+    source_file: scripts/create_joint.py
+---
+```
+
+**`SkillGroup` fields:** `.name`, `.description`, `.default_active` (bool), `.tools` (`List[str]`).
+
+**Runtime behaviour after `load_skill`:**
+
+1. Every tool is registered in `ToolRegistry` with `ActionMeta.group` set.
+2. Tools whose group has `default_active=false` are registered with
+   `ActionMeta.enabled=False` — MCP `tools/list` hides them.
+3. `tools/list` also emits `__group__<skill>.<group>` stubs for inactive
+   groups so clients can discover and activate them on demand.
+
+**Activate / deactivate from Python:**
+
+```python
+from dcc_mcp_core import ToolRegistry
+
+# Via the registry (emits notifications/tools/list_changed)
+registry.activate_tool_group("maya-geometry", "rigging")   # -> int enabled count
+registry.deactivate_tool_group("maya-geometry", "rigging") # -> int disabled count
+registry.list_tools_in_group("maya-geometry", "modeling")  # -> List[dict]
+registry.list_actions_enabled()                            # -> List[dict]
+registry.set_tool_enabled("maya_geometry__create_joint", True)
+```
+
+**Via MCP tools** — `create_skill_server` / `McpHttpServer` register three
+group-control tools alongside the six skill-discovery tools:
+
+| MCP tool | Description |
+|----------|-------------|
+| `activate_tool_group` | Enable all tools in a group; sends `notifications/tools/list_changed` |
+| `deactivate_tool_group` | Disable all tools in a group |
+| `search_tools` | Keyword search across currently-enabled tools |
 
 ### Action Naming Convention
 
@@ -1597,15 +1668,20 @@ PySceneDataKind.Arbitrary
 ### Capturer + CaptureFrame
 
 High-level DCC viewport / desktop capture. Platform-specific backends:
-- Windows: DXGI Desktop Duplication (GPU framebuffer, < 16 ms/frame)
-- Linux: X11 XShmGetImage
+- Windows (full-screen): DXGI Desktop Duplication (GPU framebuffer, < 16 ms/frame)
+- Windows (single window): HWND `PrintWindow` + `BitBlt` fallback
+- Linux: X11 XShmGetImage (full-screen) — PipeWire reserved for Wayland
+- macOS: ScreenCaptureKit (reserved)
 - Fallback: Mock synthetic checkerboard (CI / headless)
 
 ```python
-from dcc_mcp_core import Capturer
+from dcc_mcp_core import Capturer, CaptureBackendKind
 
-# Auto-select best backend
+# Auto-select best full-screen / display backend
 capturer = Capturer.new_auto()
+
+# Auto-select best single-window backend (HWND on Windows, Mock elsewhere)
+window_cap = Capturer.new_window_auto()
 
 # Mock backend (headless CI, no GPU needed)
 capturer = Capturer.new_mock(width=1920, height=1080)
@@ -1620,6 +1696,15 @@ frame = capturer.capture(
     window_title="Maya",    # capture window by title substring
 )
 
+# Or capture a single window explicitly
+frame = window_cap.capture_window(
+    window_title="Autodesk Maya 2024",
+    include_decorations=True,
+    format="png",
+    timeout_ms=5000,
+)
+# window_handle=<HWND int> and process_id=<pid> are also accepted
+
 # CaptureFrame fields
 frame.data           # bytes (PNG/JPEG/raw)
 frame.width          # int
@@ -1628,16 +1713,85 @@ frame.format         # "png" | "jpeg" | "raw_bgra"
 frame.mime_type      # "image/png" | "image/jpeg"
 frame.timestamp_ms   # int (Unix ms)
 frame.dpi_scale      # float (1.0=normal, 2.0=HiDPI)
+frame.window_rect    # (x, y, w, h) tuple or None for full-screen captures
+frame.window_title   # str or None
 frame.byte_len()     # int
 
 # Save to disk
 with open("screenshot.png", "wb") as f:
     f.write(frame.data)
 
-# Stats
-capturer.backend_name()  # "DXGI Desktop Duplication" | "X11" | "Mock"
+# Stats / backend introspection
+capturer.backend_name()                                 # "DXGI Desktop Duplication" | "HWND PrintWindow" | "X11" | "Mock"
+capturer.backend_kind() == CaptureBackendKind.HwndPrintWindow
 count, total_bytes, errors = capturer.stats()
 ```
+
+### CaptureTarget + WindowFinder
+
+Resolve windows / displays to a capture-ready descriptor without throwing when
+the target is missing.
+
+```python
+from dcc_mcp_core import CaptureTarget, WindowFinder
+
+# Static factories — opaque descriptor, no raise on invalid
+CaptureTarget.primary_display()
+CaptureTarget.monitor_index(0)
+CaptureTarget.process_id(12345)
+CaptureTarget.window_title("Maya 2024")
+CaptureTarget.window_handle(0x00A1B2)
+
+finder = WindowFinder()
+info = finder.find(CaptureTarget.process_id(12345))
+if info is not None:
+    info.handle   # int (HWND / X11 window id)
+    info.pid      # int
+    info.title    # str
+    info.rect     # (x, y, w, h)
+
+# Enumerate every visible top-level window on Windows
+for info in finder.enumerate():
+    print(info.handle, info.title)
+```
+
+### Instance-Bound Diagnostics
+
+When multiple DCC instances run side-by-side, each `DccServerBase` subclass
+should be bound to **its own** DCC process so `diagnostics__*` MCP tools and
+the bundled `dcc-diagnostics` skill target the right window / PID.
+
+```python
+from dcc_mcp_core import DccServerBase
+
+class MayaServer(DccServerBase):
+    def __init__(self, pid: int, window_title: str):
+        super().__init__(
+            dcc_name="maya",
+            builtin_skills_dir=None,
+            dcc_pid=pid,                     # owner DCC PID
+            dcc_window_title=window_title,   # title fallback for window lookups
+            # dcc_window_handle=0x00A1B2,    # or pass an HWND directly
+            # resolver=lambda: current_maya_pid(),  # late-bound PID
+        )
+
+server = MayaServer(pid=12345, window_title="Autodesk Maya 2024")
+handle = server.start()
+# Registers the four diagnostics tools bound to this instance:
+#   diagnostics__screenshot
+#   diagnostics__audit_log
+#   diagnostics__action_metrics
+#   diagnostics__process_status
+```
+
+For low-level servers that build on `McpHttpServer` directly, call
+`register_diagnostic_mcp_tools(server, *, dcc_name=..., dcc_pid=..., ...)` or
+`register_diagnostic_handlers(...)` (IPC path) **before** `server.start()` —
+MCP tool registration must complete before the server is running.
+
+The bundled `dcc-diagnostics` skill's `screenshot.py` handler tries
+`DCC_MCP_OWNER_IPC` → `channel.call("take_screenshot")` first and falls back
+to `Capturer.new_auto()` when no owner IPC is configured.
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -146,10 +146,19 @@ crates/
 - `.load_skill(skill_name) -> bool` / `.unload_skill(skill_name) -> bool`
 - `.get_skill_info(skill_name) -> Optional[SkillMetadata]`
 - `.is_loaded(skill_name) -> bool` / `.loaded_count() -> int`
+- `.active_groups(skill_name) -> List[str]`, `.activate_group(skill, group) -> bool`, `.deactivate_group(skill, group) -> bool`
+- `.list_groups(skill_name) -> List[SkillGroup]`, `.list_tools_catalog(skill_name) -> dict[str, list[str]]`
 
 **SkillSummary fields:** `.name`, `.description`, `.search_hint`, `.version`, `.dcc`, `.tags`, `.tool_count`, `.tool_names`, `.loaded`
 
-**SkillMetadata fields:** `.name`, `.description`, `.search_hint`, `.dcc`, `.version`, `.tags`, `.tools`, `.scripts` (List[str] absolute paths), `.skill_path`, `.depends`, `.metadata_files`
+**SkillMetadata fields:** `.name`, `.description`, `.search_hint`, `.dcc`, `.version`, `.tags`, `.tools`, `.scripts` (List[str] absolute paths), `.skill_path`, `.depends`, `.metadata_files`, `.groups` (List[SkillGroup])
+
+**SkillGroup fields:** `.name`, `.description`, `.default_active` (bool), `.tools` (List[str]) — declared in SKILL.md `groups:` frontmatter for progressive tool exposure
+
+**Tool groups (progressive exposure):**
+- `ToolRegistry.activate_tool_group(skill, group) -> int`, `.deactivate_tool_group(skill, group) -> int` — enable/disable tools in a group; emits `notifications/tools/list_changed`
+- `ToolRegistry.list_tools_in_group(skill, group) -> List[dict]`, `.list_actions_enabled() -> List[dict]`, `.set_tool_enabled(name, enabled) -> bool`
+- MCP core tools: `activate_tool_group`, `deactivate_tool_group`, `search_tools` (registered alongside the six skill-discovery tools; `tools/list` also emits `__group__<skill>.<group>` stubs for inactive groups)
 
 **Action naming**: `{skill_name}__{script_stem}` — hyphens in skill names replaced by underscores
 
@@ -220,7 +229,22 @@ crates/
 
 ### Capture (`dcc_mcp_core`)
 
-- `Capturer`, `CaptureFrame`, `CaptureResult`
+- `Capturer` — `.new_auto()` (display), `.new_window_auto()` (single window), `.new_mock(width, height)`
+- `Capturer.capture(format, jpeg_quality, scale, timeout_ms, process_id, window_title) -> CaptureFrame`
+- `Capturer.capture_window(*, process_id=None, window_handle=None, window_title=None, format="png", jpeg_quality=85, scale=1.0, timeout_ms=5000, include_decorations=True) -> CaptureFrame`
+- `Capturer.backend_name() -> str`, `.backend_kind() -> CaptureBackendKind`, `.stats() -> tuple[int, int, int]`
+- `CaptureFrame` — `.width`, `.height`, `.data`, `.format`, `.mime_type`, `.timestamp_ms`, `.dpi_scale`, `.window_rect` (tuple or None), `.window_title` (str or None), `.byte_len()`
+- `CaptureTarget` — factories: `.primary_display()`, `.monitor_index(i)`, `.process_id(pid)`, `.window_title(title)`, `.window_handle(handle)`
+- `CaptureBackendKind` — enum: `DxgiDesktopDuplication`, `ScreenCaptureKit`, `X11Xshm`, `PipeWire`, `HwndPrintWindow`, `Mock`
+- `WindowFinder()` — `.find(target) -> Optional[WindowInfo]`, `.enumerate() -> List[WindowInfo]`
+- `WindowInfo` — `.handle`, `.pid`, `.title`, `.rect`
+
+### Instance-Bound Diagnostics (`dcc_mcp_core`)
+
+- `DccServerBase(dcc_name, builtin_skills_dir, *, dcc_pid=None, dcc_window_title=None, dcc_window_handle=None, resolver=None)` — bind an adapter to a specific DCC instance; the four `diagnostics__*` tools target this DCC only
+- `register_diagnostic_mcp_tools(server, *, dcc_name, dcc_pid=None, dcc_window_handle=None, dcc_window_title=None, resolver=None)` — register `diagnostics__screenshot`, `diagnostics__audit_log`, `diagnostics__action_metrics`, `diagnostics__process_status` on an `McpHttpServer` before `.start()`
+- `register_diagnostic_handlers(...)` — the IPC-path equivalent (used by `DccServerBase.start()`)
+- Bundled `dcc-diagnostics` skill's `screenshot.py` tries `DCC_MCP_OWNER_IPC` → `channel.call("take_screenshot")` first and falls back to `Capturer.new_auto()` when no owner IPC is set
 
 ### USD (`dcc_mcp_core`)
 

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -49,9 +49,11 @@ except ImportError:
     BoundingBox = None  # type: ignore[assignment,misc]  # not yet exposed in compiled extension
 from dcc_mcp_core._core import BridgeContext
 from dcc_mcp_core._core import BridgeRegistry
+from dcc_mcp_core._core import CaptureBackendKind
 from dcc_mcp_core._core import CaptureFrame
 from dcc_mcp_core._core import Capturer
 from dcc_mcp_core._core import CaptureResult
+from dcc_mcp_core._core import CaptureTarget
 from dcc_mcp_core._core import DccCapabilities
 from dcc_mcp_core._core import DccError
 from dcc_mcp_core._core import DccErrorCode
@@ -110,6 +112,7 @@ from dcc_mcp_core._core import SerializeFormat
 from dcc_mcp_core._core import ServiceEntry
 from dcc_mcp_core._core import ServiceStatus
 from dcc_mcp_core._core import SkillCatalog
+from dcc_mcp_core._core import SkillGroup
 from dcc_mcp_core._core import SkillMetadata
 from dcc_mcp_core._core import SkillScanner
 from dcc_mcp_core._core import SkillSummary
@@ -128,6 +131,8 @@ from dcc_mcp_core._core import UsdStage
 from dcc_mcp_core._core import VersionConstraint
 from dcc_mcp_core._core import VersionedRegistry
 from dcc_mcp_core._core import VtValue
+from dcc_mcp_core._core import WindowFinder
+from dcc_mcp_core._core import WindowInfo
 from dcc_mcp_core._core import connect_ipc
 from dcc_mcp_core._core import create_skill_server
 from dcc_mcp_core._core import decode_envelope
@@ -178,6 +183,7 @@ from dcc_mcp_core.bridge import DccBridge
 
 # Pure-Python DCC server diagnostic helpers (no _core dependency)
 from dcc_mcp_core.dcc_server import register_diagnostic_handlers
+from dcc_mcp_core.dcc_server import register_diagnostic_mcp_tools
 from dcc_mcp_core.factory import create_dcc_server
 from dcc_mcp_core.factory import get_server_instance
 from dcc_mcp_core.factory import make_start_stop
@@ -230,8 +236,10 @@ __all__ = [
     "BridgeRegistry",
     "BridgeRpcError",
     "BridgeTimeoutError",
+    "CaptureBackendKind",
     "CaptureFrame",
     "CaptureResult",
+    "CaptureTarget",
     "Capturer",
     "DccBridge",
     "DccCapabilities",
@@ -286,6 +294,7 @@ __all__ = [
     "ServiceEntry",
     "ServiceStatus",
     "SkillCatalog",
+    "SkillGroup",
     "SkillMetadata",
     "SkillScanner",
     "SkillSummary",
@@ -311,6 +320,8 @@ __all__ = [
     "VersionConstraint",
     "VersionedRegistry",
     "VtValue",
+    "WindowFinder",
+    "WindowInfo",
     "__author__",
     "__version__",
     "connect_ipc",
@@ -342,6 +353,7 @@ __all__ = [
     "parse_skill_md",
     "register_bridge",
     "register_diagnostic_handlers",
+    "register_diagnostic_mcp_tools",
     "resolve_dependencies",
     "run_main",
     "scan_and_load",

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -132,6 +132,28 @@ class ToolDeclaration:
     ) -> None: ...
     def __repr__(self) -> str: ...
 
+class SkillGroup:
+    """Declaration of a tool group within a skill (progressive exposure).
+
+    Groups bundle multiple tools behind a single stub entry in ``tools/list``
+    so agents only pay the context cost for the tools they actually use.
+    """
+
+    name: str
+    description: str
+    tools: list[str]
+    default_active: bool
+
+    def __init__(
+        self,
+        name: str,
+        description: str = "",
+        tools: list[str] | None = None,
+        default_active: bool = False,
+    ) -> None: ...
+    def __repr__(self) -> str: ...
+    def __eq__(self, other: object) -> bool: ...
+
 class SkillMetadata:
     """Metadata parsed from a SKILL.md frontmatter.
 
@@ -152,6 +174,7 @@ class SkillMetadata:
     license: str
     compatibility: str
     allowed_tools: list[str]
+    groups: list[SkillGroup]
 
     def __init__(
         self,
@@ -3443,11 +3466,80 @@ class CaptureFrame:
         """Display scale factor (1.0 standard, 2.0 HiDPI)."""
         ...
 
+    @property
+    def window_rect(self) -> tuple[int, int, int, int] | None:
+        """Source window bounds ``(x, y, width, height)`` or ``None`` for full-screen captures."""
+        ...
+
+    @property
+    def window_title(self) -> str | None:
+        """Source window title or ``None`` for full-screen captures."""
+        ...
+
     def byte_len(self) -> int:
         """Byte length of the encoded image data."""
         ...
 
     def __repr__(self) -> str: ...
+
+class CaptureTarget:
+    """Capture target specifier.
+
+    Construct via the static factory methods; the value is opaque to Python.
+    """
+
+    @staticmethod
+    def primary_display() -> CaptureTarget: ...
+    @staticmethod
+    def monitor_index(index: int) -> CaptureTarget: ...
+    @staticmethod
+    def process_id(pid: int) -> CaptureTarget: ...
+    @staticmethod
+    def window_title(title: str) -> CaptureTarget: ...
+    @staticmethod
+    def window_handle(handle: int) -> CaptureTarget:
+        """Platform-opaque native window handle (HWND on Windows, XID on X11)."""
+        ...
+
+    def __repr__(self) -> str: ...
+
+class CaptureBackendKind:
+    """Enum-like handle identifying the active capture backend."""
+
+    DxgiDesktopDuplication: CaptureBackendKind
+    ScreenCaptureKit: CaptureBackendKind
+    X11Xshm: CaptureBackendKind
+    PipeWire: CaptureBackendKind
+    HwndPrintWindow: CaptureBackendKind
+    Mock: CaptureBackendKind
+
+    @property
+    def name(self) -> str: ...
+    def __repr__(self) -> str: ...
+    def __eq__(self, other: object) -> bool: ...
+
+class WindowInfo:
+    """Metadata for a discovered top-level window."""
+
+    @property
+    def handle(self) -> int: ...
+    @property
+    def pid(self) -> int: ...
+    @property
+    def title(self) -> str: ...
+    @property
+    def rect(self) -> tuple[int, int, int, int]: ...
+
+class WindowFinder:
+    """Resolve :class:`CaptureTarget` values to concrete top-level windows."""
+
+    def __init__(self) -> None: ...
+    def find(self, target: CaptureTarget) -> WindowInfo | None:
+        """Return the matching window or ``None`` if not found."""
+        ...
+    def enumerate(self) -> list[WindowInfo]:
+        """Return all visible top-level windows."""
+        ...
 
 class Capturer:
     """High-level DCC screenshot / frame-capture entry point.
@@ -3483,6 +3575,15 @@ class Capturer:
         """Create a capturer backed by the mock (synthetic checkerboard) backend.
 
         Safe to use in headless CI and testing environments without a GPU.
+        """
+        ...
+
+    @staticmethod
+    def new_window_auto() -> Capturer:
+        """Create a capturer configured for single-window capture.
+
+        Uses the GDI ``PrintWindow`` backend on Windows; falls back to the
+        mock backend on other platforms until window-target backends are added.
         """
         ...
 
@@ -3526,8 +3627,41 @@ class Capturer:
         """
         ...
 
+    def capture_window(
+        self,
+        *,
+        process_id: int | None = None,
+        window_handle: int | None = None,
+        window_title: str | None = None,
+        format: str = "png",
+        jpeg_quality: int = 85,
+        scale: float = 1.0,
+        timeout_ms: int = 5000,
+        include_decorations: bool = True,
+    ) -> CaptureFrame:
+        """Capture a single top-level window.
+
+        At least one of ``process_id``, ``window_handle``, or ``window_title``
+        must be provided. Returns a :class:`CaptureFrame` with
+        :attr:`CaptureFrame.window_rect` and :attr:`CaptureFrame.window_title`
+        populated.
+
+        Raises
+        ------
+        ValueError:
+            If none of the three target kwargs are supplied.
+        RuntimeError:
+            If the target window cannot be resolved or the backend fails.
+
+        """
+        ...
+
     def backend_name(self) -> str:
         """Return the name of the active backend (e.g. ``"DXGI Desktop Duplication"``)."""
+        ...
+
+    def backend_kind(self) -> CaptureBackendKind:
+        """Return the active backend kind enum."""
         ...
 
     def stats(self) -> tuple[int, int, int]:

--- a/python/dcc_mcp_core/dcc_server.py
+++ b/python/dcc_mcp_core/dcc_server.py
@@ -48,10 +48,13 @@ The ``dcc_name`` argument is used to derive the default IPC pipe name when
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
 import os
+import time
 from typing import Any
+from typing import Callable
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +63,19 @@ logger = logging.getLogger(__name__)
 _sandbox_context: Any = None  # SandboxContext | None
 _action_recorder: Any = None  # ToolRecorder | None
 _dispatcher_ref: Any = None  # ToolDispatcher | None
+
+# Diagnostic instance context (DCC PID / window / resolver callback).
+_instance_context: dict[str, Any] = {
+    "dcc_name": None,
+    "dcc_pid": None,
+    "dcc_window_handle": None,
+    "dcc_window_title": None,
+    "resolver": None,
+}
+
+# Lazily-constructed capturers (one per kind, reused across screenshots).
+_capturer_window: Any = None
+_capturer_full: Any = None
 
 
 def _get_sandbox_context() -> Any:
@@ -179,6 +195,149 @@ def _handle_get_action_metrics(params_json: str) -> str:
         return json.dumps({"success": False, "message": str(exc)})
 
 
+def _get_window_capturer() -> Any:
+    """Return (and cache) a window-target ``Capturer`` instance."""
+    global _capturer_window
+    if _capturer_window is None:
+        from dcc_mcp_core import Capturer
+
+        _capturer_window = Capturer.new_window_auto()
+    return _capturer_window
+
+
+def _get_full_capturer() -> Any:
+    """Return (and cache) a full-screen ``Capturer`` instance."""
+    global _capturer_full
+    if _capturer_full is None:
+        from dcc_mcp_core import Capturer
+
+        _capturer_full = Capturer.new_auto()
+    return _capturer_full
+
+
+def _handle_take_screenshot(params_json: str) -> str:
+    """Capture a screenshot of the owning DCC window (or the full screen).
+
+    Params (all optional):
+        format (str): ``"png"`` (default), ``"jpeg"``, or ``"raw_bgra"``.
+        jpeg_quality (int): 0-100, default 85.
+        scale (float): 0.0-1.0, default 1.0.
+        timeout_ms (int): default 5000.
+        full_screen (bool): capture the whole desktop instead of the window.
+        process_id (int): override the DCC PID for this call.
+        window_handle (int): override the native window handle.
+        window_title (str): override the window title substring.
+    """
+    try:
+        params = json.loads(params_json) if params_json else {}
+    except json.JSONDecodeError:
+        params = {}
+
+    fmt = params.get("format", "png")
+    quality = int(params.get("jpeg_quality", 85))
+    scale = float(params.get("scale", 1.0))
+    timeout_ms = int(params.get("timeout_ms", 5000))
+    full_screen = bool(params.get("full_screen", False))
+    hwnd = params.get("window_handle") or _instance_context.get("dcc_window_handle")
+    pid = params.get("process_id") or _instance_context.get("dcc_pid")
+    title = params.get("window_title") or _instance_context.get("dcc_window_title")
+
+    try:
+        if full_screen:
+            cap = _get_full_capturer()
+            frame = cap.capture(
+                format=fmt,
+                jpeg_quality=quality,
+                scale=scale,
+                timeout_ms=timeout_ms,
+            )
+        else:
+            if not hwnd:
+                resolver = _instance_context.get("resolver")
+                if callable(resolver):
+                    try:
+                        hwnd = resolver()
+                    except Exception as exc:
+                        logger.debug("take_screenshot: resolver failed: %s", exc)
+            cap = _get_window_capturer()
+            frame = cap.capture_window(
+                process_id=pid,
+                window_handle=hwnd,
+                window_title=title,
+                format=fmt,
+                jpeg_quality=quality,
+                scale=scale,
+                timeout_ms=timeout_ms,
+            )
+        payload = {
+            "success": True,
+            "message": f"Captured {frame.width}x{frame.height} {fmt}",
+            "format": frame.format,
+            "width": frame.width,
+            "height": frame.height,
+            "mime_type": frame.mime_type,
+            "byte_len": frame.byte_len(),
+            "image_base64": base64.b64encode(frame.data).decode("ascii"),
+            "window_rect": list(frame.window_rect) if frame.window_rect else None,
+            "window_title": frame.window_title,
+            "timestamp_ms": int(time.time() * 1000),
+            "source": "dcc-ipc",
+        }
+    except Exception as exc:
+        logger.warning("take_screenshot handler error: %s", exc)
+        payload = {
+            "success": False,
+            "message": str(exc),
+            "error": type(exc).__name__,
+            "source": "dcc-ipc",
+        }
+    return json.dumps(payload)
+
+
+def _handle_process_status(params_json: str) -> str:
+    """Report adapter process health and DCC instance context.
+
+    Params (all optional) are ignored; the handler reads state from
+    ``_instance_context`` and the current Python process.
+    """
+    _ = params_json
+    ctx = _instance_context
+    dcc_pid = ctx.get("dcc_pid")
+    dcc_name = ctx.get("dcc_name") or "dcc"
+
+    alive = True
+    try:
+        if dcc_pid:
+            if os.name == "nt":
+                import ctypes
+
+                PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+                handle = ctypes.windll.kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, int(dcc_pid))
+                if handle:
+                    ctypes.windll.kernel32.CloseHandle(handle)
+                    alive = True
+                else:
+                    alive = False
+            else:
+                os.kill(int(dcc_pid), 0)
+    except OSError:
+        alive = False
+    except Exception as exc:
+        logger.debug("process_status alive-check failed: %s", exc)
+
+    payload = {
+        "success": True,
+        "dcc_name": dcc_name,
+        "dcc_pid": dcc_pid,
+        "dcc_window_handle": ctx.get("dcc_window_handle"),
+        "dcc_window_title": ctx.get("dcc_window_title"),
+        "adapter_pid": os.getpid(),
+        "dcc_alive": alive,
+        "timestamp_ms": int(time.time() * 1000),
+    }
+    return json.dumps(payload)
+
+
 def _handle_dispatch_action(params_json: str) -> str:
     """Relay a dispatch request through the server's ToolDispatcher."""
     try:
@@ -215,8 +374,12 @@ def register_diagnostic_handlers(
     *,
     dispatcher: Any = None,
     dcc_name: str = "dcc",
+    dcc_pid: int | None = None,
+    dcc_window_handle: int | None = None,
+    dcc_window_title: str | None = None,
+    resolver: Callable[[], int | None] | None = None,
 ) -> None:
-    """Register the three standard diagnostic IPC action handlers on *server*.
+    """Register the standard diagnostic IPC action handlers on *server*.
 
     Also sets ``DCC_MCP_IPC_ADDRESS`` in the process environment (unless it
     is already set externally) so that skill subprocesses inherit the IPC
@@ -233,6 +396,12 @@ def register_diagnostic_handlers(
             relay calls return an error response.
         dcc_name: Short DCC identifier used for the IPC pipe name derivation
             and ``ToolRecorder`` label (e.g. ``"maya"``, ``"blender"``).
+        dcc_pid: PID of the DCC application process. Used by
+            ``take_screenshot`` to resolve the window target.
+        dcc_window_handle: Pre-resolved native window handle (HWND / XID).
+        dcc_window_title: Substring of the DCC window title for title lookup.
+        resolver: Optional callback returning the current native window handle
+            when neither ``dcc_window_handle`` nor a cache hit is available.
 
     Example::
 
@@ -246,11 +415,22 @@ def register_diagnostic_handlers(
     - ``get_audit_log`` — sandbox audit log entries
     - ``get_action_metrics`` — ToolRecorder performance counters
     - ``dispatch_action`` — relay through the server's ToolDispatcher
+    - ``take_screenshot`` — capture the DCC window (or full screen)
 
     """
     global _dispatcher_ref
     if dispatcher is not None:
         _dispatcher_ref = dispatcher
+
+    _instance_context.update(
+        {
+            "dcc_name": dcc_name,
+            "dcc_pid": dcc_pid,
+            "dcc_window_handle": dcc_window_handle,
+            "dcc_window_title": dcc_window_title,
+            "resolver": resolver,
+        }
+    )
 
     # Ensure action recorder uses the correct DCC name
     _get_action_recorder(dcc_name)
@@ -259,8 +439,10 @@ def register_diagnostic_handlers(
         server.register_handler("get_audit_log", _handle_get_audit_log)
         server.register_handler("get_action_metrics", _handle_get_action_metrics)
         server.register_handler("dispatch_action", _handle_dispatch_action)
+        server.register_handler("take_screenshot", _handle_take_screenshot)
         logger.debug(
-            "Registered diagnostic IPC handlers for dcc=%r: get_audit_log, get_action_metrics, dispatch_action",
+            "Registered diagnostic IPC handlers for dcc=%r: "
+            "get_audit_log, get_action_metrics, dispatch_action, take_screenshot",
             dcc_name,
         )
     except Exception as exc:
@@ -300,3 +482,149 @@ def _metric_to_dict(metric: Any) -> dict:
         "p95_duration_ms": round(metric.p95_duration_ms, 2),
         "p99_duration_ms": round(metric.p99_duration_ms, 2),
     }
+
+
+# ── diagnostic MCP tool specs (exposed via tools/list & tools/call) ───────
+
+
+_SCREENSHOT_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "format": {"type": "string", "enum": ["png", "jpeg", "raw_bgra"], "default": "png"},
+        "jpeg_quality": {"type": "integer", "minimum": 0, "maximum": 100, "default": 85},
+        "scale": {"type": "number", "minimum": 0.0, "maximum": 1.0, "default": 1.0},
+        "timeout_ms": {"type": "integer", "minimum": 100, "default": 5000},
+        "full_screen": {"type": "boolean", "default": False},
+        "window_handle": {"type": "integer"},
+        "window_title": {"type": "string"},
+        "process_id": {"type": "integer"},
+    },
+    "additionalProperties": False,
+}
+
+_AUDIT_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "filter": {"type": "string", "enum": ["all", "allowed", "denied"], "default": "all"},
+        "limit": {"type": "integer", "minimum": 1, "maximum": 1000, "default": 100},
+    },
+    "additionalProperties": False,
+}
+
+_METRICS_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "action_name": {"type": "string"},
+    },
+    "additionalProperties": False,
+}
+
+_PROC_SCHEMA: dict = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+
+def register_diagnostic_mcp_tools(
+    server: Any,
+    *,
+    dcc_name: str = "dcc",
+    dcc_pid: int | None = None,
+    dcc_window_handle: int | None = None,
+    dcc_window_title: str | None = None,
+    resolver: Callable[[], int | None] | None = None,
+) -> None:
+    """Register the four ``diagnostics__*`` MCP tools on *server*.
+
+    Tools are registered as regular :class:`ToolRegistry` entries so they
+    appear in ``tools/list`` and can be invoked via ``tools/call``. Must be
+    called **before** :meth:`McpHttpServer.start` — per the AGENTS.md rule
+    "register all actions before start".
+
+    Instance context kwargs match :func:`register_diagnostic_handlers` and
+    are propagated to the same ``_instance_context`` global so the IPC path
+    and the MCP-tool path share state.
+
+    Registered tools
+    ----------------
+    - ``diagnostics__screenshot`` — capture the DCC window (or full screen)
+    - ``diagnostics__audit_log`` — recent sandbox audit events
+    - ``diagnostics__action_metrics`` — tool dispatch metrics
+    - ``diagnostics__process_status`` — adapter process / DCC alive check
+
+    Args:
+        server: An :class:`McpHttpServer` instance (must expose a
+            ``.registry`` getter and ``.register_handler()``).
+        dcc_name: Logical DCC name (used as audit log / metrics namespace).
+        dcc_pid: Optional PID of the DCC process — when set, the screenshot
+            and process-status tools resolve the target window from this PID.
+        dcc_window_handle: Optional HWND / X11 window ID to capture directly.
+        dcc_window_title: Optional window title substring used as a fallback
+            when neither ``dcc_pid`` nor ``dcc_window_handle`` resolves.
+        resolver: Optional callable returning the current DCC PID on demand.
+            Evaluated lazily per request so long-lived servers can track DCC
+            process restarts.
+
+    """
+    _instance_context.update(
+        {
+            "dcc_name": dcc_name,
+            "dcc_pid": dcc_pid,
+            "dcc_window_handle": dcc_window_handle,
+            "dcc_window_title": dcc_window_title,
+            "resolver": resolver,
+        }
+    )
+    _get_action_recorder(dcc_name)
+
+    try:
+        registry = server.registry
+    except Exception as exc:
+        logger.warning("register_diagnostic_mcp_tools: server.registry unavailable: %s", exc)
+        return
+
+    specs = [
+        (
+            "diagnostics__screenshot",
+            "Capture the DCC window (or full screen).",
+            _SCREENSHOT_SCHEMA,
+            _handle_take_screenshot,
+        ),
+        ("diagnostics__audit_log", "Recent sandbox audit events.", _AUDIT_SCHEMA, _handle_get_audit_log),
+        (
+            "diagnostics__action_metrics",
+            "Tool dispatch telemetry metrics.",
+            _METRICS_SCHEMA,
+            _handle_get_action_metrics,
+        ),
+        ("diagnostics__process_status", "Adapter process and DCC alive status.", _PROC_SCHEMA, _handle_process_status),
+    ]
+
+    for name, desc, schema, handler in specs:
+        try:
+            registry.register(
+                name=name,
+                description=desc,
+                input_schema=json.dumps(schema),
+                dcc=dcc_name,
+                category="diagnostics",
+                version="1.0.0",
+            )
+        except Exception as exc:
+            logger.warning("register_diagnostic_mcp_tools: register(%s) failed: %s", name, exc)
+            continue
+        try:
+            server.register_handler(name, lambda params, h=handler: _adapt_mcp_handler(h, params))
+        except Exception as exc:
+            logger.warning("register_diagnostic_mcp_tools: register_handler(%s) failed: %s", name, exc)
+
+
+def _adapt_mcp_handler(handler: Callable[[str], str], params: Any) -> Any:
+    """Adapt an IPC-style ``(json_str) -> json_str`` handler to MCP's dict IO."""
+    params_str = json.dumps(params) if not isinstance(params, str) else params
+    result_str = handler(params_str)
+    try:
+        return json.loads(result_str)
+    except (TypeError, json.JSONDecodeError):
+        return {"success": False, "message": "Invalid handler output"}

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -88,6 +88,13 @@ class DccServerBase:
         dcc_version: DCC application version string for the gateway registry.
         scene: Currently open scene file path for the gateway registry.
         enable_gateway_failover: Enable automatic gateway failover / election.
+        dcc_pid: Process ID of the DCC application that owns this server.
+            Defaults to ``os.getpid()``. In bridge-mode adapters (e.g. Photoshop)
+            this MUST be set to the hosted DCC's PID, not the adapter's.
+        dcc_window_title: Substring of the DCC application window title used
+            to resolve the owner window for diagnostic screenshots.
+        dcc_window_handle: Pre-resolved native window handle (HWND on Windows,
+            XID on X11). When supplied, takes precedence over PID/title lookup.
 
     """
 
@@ -103,6 +110,10 @@ class DccServerBase:
         dcc_version: str | None = None,
         scene: str | None = None,
         enable_gateway_failover: bool = True,
+        *,
+        dcc_pid: int | None = None,
+        dcc_window_title: str | None = None,
+        dcc_window_handle: int | None = None,
     ) -> None:
         # Deferred: circular import — __init__.py imports DccServerBase from
         # this module, so we cannot import from dcc_mcp_core at module level.
@@ -114,6 +125,12 @@ class DccServerBase:
         self._builtin_skills_dir = builtin_skills_dir
         self._handle: Any | None = None
         self._enable_gateway_failover = enable_gateway_failover
+
+        # Instance-bound DCC diagnostic context
+        self._dcc_pid: int = dcc_pid if dcc_pid is not None else os.getpid()
+        self._dcc_window_title: str | None = dcc_window_title
+        self._dcc_window_handle: int | None = dcc_window_handle
+        self._cached_hwnd: int | None = None
 
         # Resolve gateway port
         effective_gateway_port: int = 0
@@ -272,6 +289,50 @@ class DccServerBase:
         except Exception:
             pass
         return None
+
+    # ── DCC instance context (PID / window handle / title) ───────────────────
+
+    @property
+    def dcc_pid(self) -> int:
+        """PID of the DCC application process hosting this server."""
+        return self._dcc_pid
+
+    @property
+    def dcc_window_title(self) -> str | None:
+        """Configured DCC window-title substring (``None`` if not set)."""
+        return self._dcc_window_title
+
+    @property
+    def dcc_window_handle(self) -> int | None:
+        """Pre-resolved native DCC window handle (``None`` if not set)."""
+        return self._dcc_window_handle
+
+    def _resolve_window_handle(self) -> int | None:
+        """Resolve the DCC window handle from the available context.
+
+        Priority: explicit ``dcc_window_handle`` → cached lookup → PID lookup
+        via :class:`WindowFinder` → title lookup → ``None``.
+        """
+        if self._dcc_window_handle is not None:
+            return self._dcc_window_handle
+        if self._cached_hwnd is not None:
+            return self._cached_hwnd
+        try:
+            from dcc_mcp_core import CaptureTarget
+            from dcc_mcp_core import WindowFinder
+
+            finder = WindowFinder()
+            info = None
+            if self._dcc_pid:
+                info = finder.find(CaptureTarget.process_id(self._dcc_pid))
+            if info is None and self._dcc_window_title:
+                info = finder.find(CaptureTarget.window_title(self._dcc_window_title))
+            if info is not None:
+                self._cached_hwnd = int(info.handle)
+            return self._cached_hwnd
+        except Exception as exc:
+            logger.debug("[%s] _resolve_window_handle failed: %s", self._dcc_name, exc)
+            return None
 
     # ── skill query methods (generic — 100% identical across all DCCs) ────────
 
@@ -548,6 +609,33 @@ class DccServerBase:
                 self._handle.port,
             )
             return self._handle
+
+        # Register instance-bound diagnostic IPC handlers before the server
+        # starts so skill subprocesses can call take_screenshot / audit_log.
+        try:
+            from dcc_mcp_core.dcc_server import register_diagnostic_handlers
+            from dcc_mcp_core.dcc_server import register_diagnostic_mcp_tools
+
+            register_diagnostic_handlers(
+                self._server,
+                dcc_name=self._dcc_name,
+                dcc_pid=self._dcc_pid,
+                dcc_window_handle=self._dcc_window_handle,
+                dcc_window_title=self._dcc_window_title,
+                resolver=self._resolve_window_handle,
+            )
+            # MCP tools MUST be registered before server.start() per the
+            # "register all actions before start" rule in AGENTS.md.
+            register_diagnostic_mcp_tools(
+                self._server,
+                dcc_name=self._dcc_name,
+                dcc_pid=self._dcc_pid,
+                dcc_window_handle=self._dcc_window_handle,
+                dcc_window_title=self._dcc_window_title,
+                resolver=self._resolve_window_handle,
+            )
+        except Exception as exc:
+            logger.debug("[%s] register_diagnostic_* failed: %s", self._dcc_name, exc)
 
         self._handle = self._server.start()
         logger.info("[%s] MCP server started at %s", self._dcc_name, self._handle.mcp_url())

--- a/python/dcc_mcp_core/skills/dcc-diagnostics/scripts/screenshot.py
+++ b/python/dcc_mcp_core/skills/dcc-diagnostics/scripts/screenshot.py
@@ -1,7 +1,12 @@
-"""Capture a screenshot using dcc_mcp_core.Capturer.
+"""Capture a screenshot, preferring the owning DCC adapter's IPC handler.
 
-Works on Windows (DXGI), Linux (X11), and falls back to a mock backend
-in headless/CI environments. Returns the image as base64-encoded bytes.
+Protocol (in order of preference):
+
+1. If ``DCC_MCP_IPC_ADDRESS`` is set, connect to the adapter's IPC listener
+   and delegate to the ``take_screenshot`` handler so the captured image is
+   the DCC's own window rather than the entire desktop.
+2. Otherwise fall back to the in-process :class:`dcc_mcp_core.Capturer` using
+   the auto backend (DXGI on Windows, X11 on Linux, mock in headless CI).
 """
 
 from __future__ import annotations
@@ -9,8 +14,42 @@ from __future__ import annotations
 import argparse
 import base64
 import json
+import os
 from pathlib import Path
 import sys
+
+
+def _try_ipc_capture(params: dict) -> dict | None:
+    """Return ``take_screenshot`` payload when the adapter's IPC is reachable.
+
+    Returns ``None`` if no IPC address is configured or the call fails so the
+    caller can fall back to the in-process path.
+    """
+    addr = os.environ.get("DCC_MCP_IPC_ADDRESS") or os.environ.get("DCC_MCP_OWNER_IPC")
+    if not addr:
+        return None
+    try:
+        from dcc_mcp_core import connect_ipc
+
+        channel = connect_ipc(addr, timeout_ms=3000)
+        result = channel.call(
+            "take_screenshot",
+            json.dumps(params).encode("utf-8"),
+            timeout_ms=int(params.get("timeout_ms", 10000)),
+        )
+    except Exception as exc:
+        print(
+            json.dumps({"debug": f"IPC screenshot failed, falling back: {exc}"}),
+            file=sys.stderr,
+        )
+        return None
+    if not result.get("success"):
+        return None
+    try:
+        return json.loads(bytes(result["payload"]).decode("utf-8"))
+    except Exception as exc:
+        print(json.dumps({"debug": f"IPC payload decode failed: {exc}"}), file=sys.stderr)
+        return None
 
 
 def main() -> None:
@@ -22,7 +61,61 @@ def main() -> None:
     parser.add_argument("--window-title", default=None, dest="window_title")
     parser.add_argument("--save-path", default=None, dest="save_path")
     parser.add_argument("--timeout-ms", type=int, default=5000, dest="timeout_ms")
+    parser.add_argument("--full-screen", action="store_true", dest="full_screen")
     args = parser.parse_args()
+
+    # Try IPC path first so we capture the DCC's own window.
+    ipc_payload = _try_ipc_capture(
+        {
+            "format": args.format,
+            "jpeg_quality": args.jpeg_quality,
+            "scale": args.scale,
+            "timeout_ms": args.timeout_ms,
+            "full_screen": args.full_screen,
+            "window_title": args.window_title,
+        }
+    )
+    if ipc_payload is not None and ipc_payload.get("success"):
+        saved_path = None
+        if args.save_path:
+            try:
+                with Path(args.save_path).open("wb") as f:
+                    f.write(base64.b64decode(ipc_payload["image_base64"]))
+                saved_path = args.save_path
+            except OSError as exc:
+                saved_path = f"SAVE_FAILED: {exc}"
+        print(
+            json.dumps(
+                {
+                    "success": True,
+                    "message": ipc_payload.get("message", "captured via IPC"),
+                    "prompt": (
+                        "Screenshot captured from the DCC's own window. "
+                        "If you see an error on screen, use dcc_diagnostics__audit_log to check "
+                        "recent action history, or dcc_diagnostics__action_metrics to find failing tools."
+                    ),
+                    "context": {
+                        **{
+                            k: ipc_payload.get(k)
+                            for k in (
+                                "width",
+                                "height",
+                                "format",
+                                "mime_type",
+                                "byte_len",
+                                "timestamp_ms",
+                                "window_rect",
+                                "window_title",
+                                "image_base64",
+                            )
+                        },
+                        "saved_path": saved_path,
+                        "source": "dcc-ipc",
+                    },
+                }
+            )
+        )
+        return
 
     try:
         from dcc_mcp_core import Capturer

--- a/src/bin/stub_gen.rs
+++ b/src/bin/stub_gen.rs
@@ -1,0 +1,85 @@
+//! Type-stub generator — PoC for `pyo3-stub-gen` integration.
+//!
+//! Walks every `#[gen_stub_pyclass]` / `#[gen_stub_pymethods]` annotation
+//! registered via `inventory::submit!` at link time and emits a `.pyi`
+//! package for the `dcc_mcp_core._core` module.
+//!
+//! Run with:
+//!     cargo run --bin stub_gen --features stub-gen
+//!     # or: just stubgen
+//!
+//! PoC scope: only the `dcc-mcp-capture` crate is annotated, so only its
+//! types appear in the generated output.
+//!
+//! ## How this plays with the hand-maintained `python/dcc_mcp_core/_core.pyi`
+//!
+//! `pyo3-stub-gen` v0.20 detects our mixed layout (`python-source =
+//! "python"`, `module-name = "dcc_mcp_core._core"`) and writes a *package-
+//! style* stub:
+//!
+//!   python/dcc_mcp_core/_core/__init__.pyi    ← generated (5.7 KB for 6 classes)
+//!   python/dcc_mcp_core/__init__.pyi          ← generated umbrella
+//!
+//! This collides with (and would eventually replace) the single-file
+//! `python/dcc_mcp_core/_core.pyi` we currently maintain by hand. For the
+//! PoC we move the generated files out of `python/` into `target/stubgen/`
+//! so the hand-written stub stays authoritative.
+
+use std::path::{Path, PathBuf};
+
+use pyo3_stub_gen::Result;
+
+const GEN_PKG_STUB: &str = "python/dcc_mcp_core/_core/__init__.pyi";
+const GEN_PARENT_STUB: &str = "python/dcc_mcp_core/__init__.pyi";
+const GEN_PKG_DIR: &str = "python/dcc_mcp_core/_core";
+
+const POC_PKG_STUB: &str = "target/stubgen/_core/__init__.pyi";
+const POC_PARENT_STUB: &str = "target/stubgen/__init__.pyi";
+
+fn main() -> Result<()> {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+    // 1. Run the generator — this writes into python/dcc_mcp_core/...
+    let stub = _core::stub_info()?;
+    stub.generate()?;
+
+    // 2. Relocate the output so we don't clobber the hand-written stub.
+    let gen_pkg = manifest_dir.join(GEN_PKG_STUB);
+    let gen_parent = manifest_dir.join(GEN_PARENT_STUB);
+    let gen_pkg_dir = manifest_dir.join(GEN_PKG_DIR);
+    let poc_pkg = manifest_dir.join(POC_PKG_STUB);
+    let poc_parent = manifest_dir.join(POC_PARENT_STUB);
+
+    if let Some(dir) = poc_pkg.parent() {
+        std::fs::create_dir_all(dir)?;
+    }
+    move_replace(&gen_pkg, &poc_pkg)?;
+    move_replace(&gen_parent, &poc_parent)?;
+    // Clean up the now-empty _core/ directory pyo3-stub-gen created next to _core.pyi.
+    let _ = std::fs::remove_dir(&gen_pkg_dir);
+
+    println!();
+    println!("=== pyo3-stub-gen PoC — generation complete ===");
+    println!(
+        "Hand-written stub  : {}",
+        manifest_dir.join("python/dcc_mcp_core/_core.pyi").display()
+    );
+    println!("Generated package  : {}", poc_pkg.display());
+    println!("Generated umbrella : {}", poc_parent.display());
+    println!();
+    println!("View with:");
+    println!("    Get-Content {}", poc_pkg.display());
+    Ok(())
+}
+
+/// Rename `src` to `dst`, overwriting `dst` if it exists. No-op if `src` missing.
+fn move_replace(src: &Path, dst: &Path) -> std::io::Result<()> {
+    if !src.exists() {
+        return Ok(());
+    }
+    if dst.exists() {
+        std::fs::remove_file(dst)?;
+    }
+    std::fs::rename(src, dst)?;
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,13 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     Ok(())
 }
 
+// ── Type-stub generation (opt-in, PoC) ──
+//
+// Enabled by the `stub-gen` feature — powers the `stub_gen` binary target
+// which regenerates `python/dcc_mcp_core/_core.pyi` from annotated Rust code.
+#[cfg(feature = "stub-gen")]
+pyo3_stub_gen::define_stub_info_gatherer!(stub_info);
+
 #[cfg(feature = "python-bindings")]
 fn register_models(m: &Bound<'_, PyModule>) -> PyResult<()> {
     add_classes!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@ fn register_models(m: &Bound<'_, PyModule>) -> PyResult<()> {
         m,
         dcc_mcp_models::ActionResultModel,
         dcc_mcp_models::SerializeFormat,
+        dcc_mcp_models::SkillGroup,
         dcc_mcp_models::SkillMetadata,
     );
     add_functions!(

--- a/tests/test_auditlog_ratelimit_logging_mcp_versioned_deep.py
+++ b/tests/test_auditlog_ratelimit_logging_mcp_versioned_deep.py
@@ -695,12 +695,18 @@ class TestMcpServerHandleDeep:
         tool_names = {t["name"] for t in tools}
         assert "find_skills" in tool_names
         assert "load_skill" in tool_names
-        assert not any(
-            t
-            for t in tools
-            if t["name"]
-            not in {"find_skills", "list_skills", "get_skill_info", "load_skill", "unload_skill", "search_skills"}
-        )
+        core_tools = {
+            "find_skills",
+            "list_skills",
+            "get_skill_info",
+            "load_skill",
+            "unload_skill",
+            "search_skills",
+            "activate_tool_group",
+            "deactivate_tool_group",
+            "search_tools",
+        }
+        assert not any(t for t in tools if t["name"] not in core_tools)
         handle.shutdown()
 
     def test_server_with_multiple_tools(self):

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -284,3 +284,60 @@ class TestCapturerEdgeCases:
         capturer = dcc_mcp_core.Capturer.new_mock()
         r = repr(capturer)
         assert len(r) > 0
+
+
+# ── CaptureTarget / CaptureBackendKind variants ───────────────────────────────
+
+
+class TestCaptureTargetVariants:
+    """All CaptureTarget factory constructors must be exhaustively callable."""
+
+    def test_primary_display(self) -> None:
+        t = dcc_mcp_core.CaptureTarget.primary_display()
+        assert "primary_display" in repr(t)
+
+    def test_monitor_index(self) -> None:
+        t = dcc_mcp_core.CaptureTarget.monitor_index(1)
+        assert "monitor_index(1)" in repr(t)
+
+    def test_process_id(self) -> None:
+        t = dcc_mcp_core.CaptureTarget.process_id(1234)
+        assert "1234" in repr(t)
+
+    def test_window_title(self) -> None:
+        t = dcc_mcp_core.CaptureTarget.window_title("Adobe Photoshop")
+        assert "Photoshop" in repr(t)
+
+    def test_window_handle(self) -> None:
+        t = dcc_mcp_core.CaptureTarget.window_handle(0xDEADBEEF)
+        r = repr(t)
+        assert "deadbeef" in r.lower() or "window_handle" in r
+
+
+class TestCaptureBackendKindVariants:
+    """Every backend kind must be accessible as a class attribute."""
+
+    @pytest.mark.parametrize(
+        "attr",
+        [
+            "DxgiDesktopDuplication",
+            "ScreenCaptureKit",
+            "X11Xshm",
+            "PipeWire",
+            "HwndPrintWindow",
+            "Mock",
+        ],
+    )
+    def test_variant_accessible(self, attr: str) -> None:
+        kind = getattr(dcc_mcp_core.CaptureBackendKind, attr)
+        assert kind is not None
+        assert isinstance(kind.name, str)
+        assert attr in repr(kind) or kind.name != ""
+
+    def test_equality(self) -> None:
+        a = dcc_mcp_core.CaptureBackendKind.HwndPrintWindow
+        b = dcc_mcp_core.CaptureBackendKind.HwndPrintWindow
+        assert a == b
+
+    def test_inequality(self) -> None:
+        assert dcc_mcp_core.CaptureBackendKind.Mock != dcc_mcp_core.CaptureBackendKind.HwndPrintWindow

--- a/tests/test_capture_hwnd_backend.py
+++ b/tests/test_capture_hwnd_backend.py
@@ -1,0 +1,107 @@
+"""Tests for the Windows HWND PrintWindow capture backend.
+
+All tests are Windows-only. On other platforms ``Capturer.new_window_auto``
+falls back to the mock backend (see :mod:`tests.test_capture_window_api`).
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import os
+import sys
+
+# Import third-party modules
+import pytest
+
+# Import local modules
+import dcc_mcp_core
+
+pytestmark = pytest.mark.skipif(sys.platform != "win32", reason="HwndBackend is Windows-only")
+
+
+# ── Backend identity ──────────────────────────────────────────────────────────
+
+
+class TestHwndBackendIdentity:
+    def test_new_window_auto_backend_kind_is_hwnd(self) -> None:
+        cap = dcc_mcp_core.Capturer.new_window_auto()
+        assert cap.backend_kind() == dcc_mcp_core.CaptureBackendKind.HwndPrintWindow
+
+    def test_new_window_auto_backend_name_mentions_printwindow(self) -> None:
+        cap = dcc_mcp_core.Capturer.new_window_auto()
+        name = cap.backend_name()
+        assert "PrintWindow" in name or "GDI" in name
+
+
+# ── Error paths ───────────────────────────────────────────────────────────────
+
+
+class TestHwndBackendErrors:
+    def test_nonexistent_pid_raises_runtime_error(self) -> None:
+        cap = dcc_mcp_core.Capturer.new_window_auto()
+        with pytest.raises(RuntimeError):
+            cap.capture_window(process_id=0x7FFFFFFF, timeout_ms=500)
+
+    def test_nonexistent_handle_raises_runtime_error(self) -> None:
+        cap = dcc_mcp_core.Capturer.new_window_auto()
+        with pytest.raises(RuntimeError):
+            cap.capture_window(window_handle=0xDEADBEEF, timeout_ms=500)
+
+    def test_nonexistent_title_raises_runtime_error(self) -> None:
+        cap = dcc_mcp_core.Capturer.new_window_auto()
+        with pytest.raises(RuntimeError):
+            cap.capture_window(
+                window_title="__definitely-nonexistent-window-title-xyz__",
+                timeout_ms=500,
+            )
+
+
+# ── Smoke test: capture own process's window (if one exists) ─────────────────
+
+
+class TestHwndBackendSmoke:
+    """Best-effort capture using the current Python process's own PID.
+
+    Skipped automatically when no visible top-level window can be resolved
+    for the test runner (headless CI).
+    """
+
+    def test_capture_own_process_window_populates_fields(self) -> None:
+        cap = dcc_mcp_core.Capturer.new_window_auto()
+        finder = dcc_mcp_core.WindowFinder()
+        info = finder.find(dcc_mcp_core.CaptureTarget.process_id(os.getpid()))
+        if info is None:
+            pytest.skip("current process has no visible top-level window (headless CI)")
+        frame = cap.capture_window(window_handle=info.handle, timeout_ms=2000)
+        assert frame.byte_len() > 0
+        assert frame.window_rect is not None
+        assert frame.window_title is not None
+        _x, _y, w, h = frame.window_rect
+        assert w > 0 and h > 0
+
+
+# ── WindowFinder on Windows ───────────────────────────────────────────────────
+
+
+class TestWindowFinderWindows:
+    def test_enumerate_returns_list(self) -> None:
+        finder = dcc_mcp_core.WindowFinder()
+        windows = finder.enumerate()
+        assert isinstance(windows, list)
+
+    def test_enumerate_entries_have_handle_and_pid(self) -> None:
+        finder = dcc_mcp_core.WindowFinder()
+        windows = finder.enumerate()
+        for w in windows[:5]:  # sample
+            assert isinstance(w.handle, int)
+            assert w.handle > 0
+            assert isinstance(w.pid, int)
+            assert isinstance(w.title, str)
+            assert isinstance(w.rect, tuple)
+            assert len(w.rect) == 4
+
+    def test_find_nonexistent_pid_returns_none(self) -> None:
+        finder = dcc_mcp_core.WindowFinder()
+        result = finder.find(dcc_mcp_core.CaptureTarget.process_id(0x7FFFFFFF))
+        assert result is None

--- a/tests/test_capture_window_api.py
+++ b/tests/test_capture_window_api.py
@@ -55,16 +55,28 @@ class TestCaptureWindowArgValidation:
             # process_id is keyword-only
             cap.capture_window(1234)  # type: ignore[misc]
 
+    @pytest.mark.skipif(
+        sys.platform != "win32",
+        reason="window-target lookup only enforced by HwndBackend; Mock accepts any target",
+    )
     def test_accepts_process_id_keyword(self) -> None:
         cap = dcc_mcp_core.Capturer.new_window_auto()
         with pytest.raises((RuntimeError, ValueError)):
             cap.capture_window(process_id=0x7FFFFFFF, timeout_ms=200)
 
+    @pytest.mark.skipif(
+        sys.platform != "win32",
+        reason="window-target lookup only enforced by HwndBackend; Mock accepts any target",
+    )
     def test_accepts_window_handle_keyword(self) -> None:
         cap = dcc_mcp_core.Capturer.new_window_auto()
         with pytest.raises((RuntimeError, ValueError)):
             cap.capture_window(window_handle=0x7FFFFFFE, timeout_ms=200)
 
+    @pytest.mark.skipif(
+        sys.platform != "win32",
+        reason="window-target lookup only enforced by HwndBackend; Mock accepts any target",
+    )
     def test_accepts_window_title_keyword(self) -> None:
         cap = dcc_mcp_core.Capturer.new_window_auto()
         with pytest.raises((RuntimeError, ValueError)):

--- a/tests/test_capture_window_api.py
+++ b/tests/test_capture_window_api.py
@@ -1,0 +1,110 @@
+"""Cross-platform tests for the window-target capture API surface.
+
+These tests cover the Python API contract of ``Capturer.new_window_auto``
+and ``Capturer.capture_window`` in a way that works on any platform — the
+Windows-specific backend behaviour lives in
+:mod:`tests.test_capture_hwnd_backend`.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import sys
+
+# Import third-party modules
+import pytest
+
+# Import local modules
+import dcc_mcp_core
+
+# ── new_window_auto backend selection ─────────────────────────────────────────
+
+
+class TestNewWindowAutoBackend:
+    def test_returns_capturer_instance(self) -> None:
+        cap = dcc_mcp_core.Capturer.new_window_auto()
+        assert isinstance(cap, dcc_mcp_core.Capturer)
+
+    def test_backend_kind_is_hwnd_on_windows(self) -> None:
+        cap = dcc_mcp_core.Capturer.new_window_auto()
+        if sys.platform == "win32":
+            assert cap.backend_kind() == dcc_mcp_core.CaptureBackendKind.HwndPrintWindow
+        else:
+            assert cap.backend_kind() == dcc_mcp_core.CaptureBackendKind.Mock
+
+    def test_backend_name_nonempty(self) -> None:
+        cap = dcc_mcp_core.Capturer.new_window_auto()
+        assert len(cap.backend_name()) > 0
+
+
+# ── capture_window argument validation ────────────────────────────────────────
+
+
+class TestCaptureWindowArgValidation:
+    def test_requires_at_least_one_target(self) -> None:
+        """capture_window() with no target kwargs must raise ValueError."""
+        cap = dcc_mcp_core.Capturer.new_window_auto()
+        with pytest.raises(ValueError):
+            cap.capture_window()
+
+    def test_all_target_params_are_keyword_only(self) -> None:
+        """Positional calls must fail — the signature is keyword-only."""
+        cap = dcc_mcp_core.Capturer.new_window_auto()
+        with pytest.raises(TypeError):
+            # process_id is keyword-only
+            cap.capture_window(1234)  # type: ignore[misc]
+
+    def test_accepts_process_id_keyword(self) -> None:
+        cap = dcc_mcp_core.Capturer.new_window_auto()
+        with pytest.raises((RuntimeError, ValueError)):
+            cap.capture_window(process_id=0x7FFFFFFF, timeout_ms=200)
+
+    def test_accepts_window_handle_keyword(self) -> None:
+        cap = dcc_mcp_core.Capturer.new_window_auto()
+        with pytest.raises((RuntimeError, ValueError)):
+            cap.capture_window(window_handle=0x7FFFFFFE, timeout_ms=200)
+
+    def test_accepts_window_title_keyword(self) -> None:
+        cap = dcc_mcp_core.Capturer.new_window_auto()
+        with pytest.raises((RuntimeError, ValueError)):
+            cap.capture_window(
+                window_title="__nonexistent-window-title-xyz__",
+                timeout_ms=200,
+            )
+
+
+# ── CaptureFrame optional window fields ───────────────────────────────────────
+
+
+class TestCaptureFrameOptionalFields:
+    """Full-screen captures must report ``window_rect``/``window_title`` as None."""
+
+    def test_mock_frame_window_rect_is_none(self) -> None:
+        cap = dcc_mcp_core.Capturer.new_mock(width=64, height=64)
+        frame = cap.capture()
+        assert frame.window_rect is None
+
+    def test_mock_frame_window_title_is_none(self) -> None:
+        cap = dcc_mcp_core.Capturer.new_mock(width=64, height=64)
+        frame = cap.capture()
+        assert frame.window_title is None
+
+
+# ── WindowFinder cross-platform shape ─────────────────────────────────────────
+
+
+class TestWindowFinderCrossPlatform:
+    def test_construct_window_finder(self) -> None:
+        finder = dcc_mcp_core.WindowFinder()
+        assert finder is not None
+
+    def test_enumerate_returns_list(self) -> None:
+        finder = dcc_mcp_core.WindowFinder()
+        result = finder.enumerate()
+        assert isinstance(result, list)
+
+    def test_find_unknown_pid_returns_none(self) -> None:
+        finder = dcc_mcp_core.WindowFinder()
+        result = finder.find(dcc_mcp_core.CaptureTarget.process_id(0x7FFFFFFF))
+        assert result is None

--- a/tests/test_dcc_server_diagnostic_handlers.py
+++ b/tests/test_dcc_server_diagnostic_handlers.py
@@ -1,7 +1,7 @@
 """Tests for dcc_mcp_core.dcc_server.register_diagnostic_handlers.
 
 Covers:
-- register_diagnostic_handlers registers the three handler names on the mock server
+- register_diagnostic_handlers registers the four handler names on the mock server
 - get_audit_log handler returns valid JSON with success=True (local SandboxContext)
 - get_action_metrics handler returns valid JSON with success=True (local ToolRecorder)
 - dispatch_action handler returns error when dispatcher is None
@@ -73,7 +73,7 @@ def test_importable_from_module():
 # ---------------------------------------------------------------------------
 
 
-def test_registers_three_handlers():
+def test_registers_four_handlers():
     from dcc_mcp_core.dcc_server import register_diagnostic_handlers
 
     server = _MockServer()
@@ -82,6 +82,7 @@ def test_registers_three_handlers():
     assert "get_audit_log" in server._handlers
     assert "get_action_metrics" in server._handlers
     assert "dispatch_action" in server._handlers
+    assert "take_screenshot" in server._handlers
 
 
 def test_idempotent_registration():
@@ -90,8 +91,36 @@ def test_idempotent_registration():
     server = _MockServer()
     register_diagnostic_handlers(server, dcc_name="test-dcc")
     register_diagnostic_handlers(server, dcc_name="test-dcc")
-    # Still exactly 3 handlers (re-registration overwrites)
-    assert len(server._handlers) == 3
+    # Still exactly 4 handlers (re-registration overwrites)
+    assert len(server._handlers) == 4
+
+
+def test_instance_context_populated():
+    """register_diagnostic_handlers stores DCC instance context for screenshot handler."""
+    from dcc_mcp_core.dcc_server import _instance_context
+    from dcc_mcp_core.dcc_server import register_diagnostic_handlers
+
+    server = _MockServer()
+    resolver_calls: list[int] = []
+
+    def _resolver() -> int:
+        resolver_calls.append(1)
+        return 0xABCD1234
+
+    register_diagnostic_handlers(
+        server,
+        dcc_name="test-dcc",
+        dcc_pid=54321,
+        dcc_window_handle=0x1234ABCD,
+        dcc_window_title="Test DCC",
+        resolver=_resolver,
+    )
+
+    assert _instance_context["dcc_name"] == "test-dcc"
+    assert _instance_context["dcc_pid"] == 54321
+    assert _instance_context["dcc_window_handle"] == 0x1234ABCD
+    assert _instance_context["dcc_window_title"] == "Test DCC"
+    assert _instance_context["resolver"] is _resolver
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dcc_server_screenshot_ipc.py
+++ b/tests/test_dcc_server_screenshot_ipc.py
@@ -1,0 +1,93 @@
+"""Tests for the bundled ``dcc-diagnostics/scripts/screenshot.py`` script.
+
+Covers:
+- When ``DCC_MCP_IPC_ADDRESS`` is unset, the script falls back to the local
+  ``Capturer`` path and prints success JSON with ``source`` field absent.
+- ``--full-screen`` flag is accepted.
+- Output JSON parses and contains ``image_base64``.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import base64
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "python"
+    / "dcc_mcp_core"
+    / "skills"
+    / "dcc-diagnostics"
+    / "scripts"
+    / "screenshot.py"
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _run_script(*extra_args: str, env: dict[str, str] | None = None) -> dict:
+    """Execute the screenshot script and return the parsed JSON payload."""
+    cmd = [sys.executable, str(SCRIPT_PATH), *extra_args]
+    proc = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+        encoding="utf-8",
+    )
+    assert proc.returncode == 0, f"script failed: {proc.stderr}"
+    # Strip any debug lines that may have been printed; the final line holds the JSON payload.
+    lines = [line for line in proc.stdout.strip().splitlines() if line.strip().startswith("{")]
+    assert lines, f"no JSON output:\nstdout={proc.stdout!r}\nstderr={proc.stderr!r}"
+    return json.loads(lines[-1])
+
+
+# ── Fallback path (no DCC_MCP_IPC_ADDRESS) ───────────────────────────────────
+
+
+class TestScreenshotFallbackPath:
+    def test_script_exists(self) -> None:
+        assert SCRIPT_PATH.is_file(), f"missing: {SCRIPT_PATH}"
+
+    def test_fallback_returns_success(self, monkeypatch) -> None:
+        env = {k: v for k, v in __import__("os").environ.items()}
+        env.pop("DCC_MCP_IPC_ADDRESS", None)
+        env.pop("DCC_MCP_OWNER_IPC", None)
+        payload = _run_script("--format", "png", env=env)
+        assert payload["success"] is True
+
+    def test_fallback_returns_image_base64(self) -> None:
+        env = {k: v for k, v in __import__("os").environ.items()}
+        env.pop("DCC_MCP_IPC_ADDRESS", None)
+        env.pop("DCC_MCP_OWNER_IPC", None)
+        payload = _run_script("--format", "png", env=env)
+        assert "context" in payload
+        assert isinstance(payload["context"].get("image_base64"), str)
+        decoded = base64.b64decode(payload["context"]["image_base64"])
+        assert len(decoded) > 0
+
+    def test_full_screen_flag_accepted(self) -> None:
+        env = {k: v for k, v in __import__("os").environ.items()}
+        env.pop("DCC_MCP_IPC_ADDRESS", None)
+        env.pop("DCC_MCP_OWNER_IPC", None)
+        payload = _run_script("--full-screen", env=env)
+        assert payload["success"] is True
+
+    def test_unreachable_ipc_falls_back(self) -> None:
+        """A bogus DCC_MCP_IPC_ADDRESS must not break the script."""
+        env = {k: v for k, v in __import__("os").environ.items()}
+        # Use a pipe/socket path that cannot exist.
+        env["DCC_MCP_IPC_ADDRESS"] = "pipe:///\\.\\pipe\\nonexistent_dcc_mcp_pipe_xyz"
+        payload = _run_script("--format", "png", env=env)
+        # Fallback to the direct Capturer path should succeed.
+        assert payload["success"] is True
+        # The "source" field is only set on the IPC success path, so its
+        # absence here confirms fallback took place.
+        assert payload.get("context", {}).get("source") != "dcc-ipc"

--- a/tests/test_dcc_server_take_screenshot.py
+++ b/tests/test_dcc_server_take_screenshot.py
@@ -1,0 +1,139 @@
+"""Tests for the ``take_screenshot`` diagnostic IPC handler."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import base64
+import json
+
+# Import third-party modules
+import pytest
+
+# ---------------------------------------------------------------------------
+# Handler registration & basic return shape
+# ---------------------------------------------------------------------------
+
+
+class _MockServer:
+    def __init__(self) -> None:
+        self._handlers: dict[str, object] = {}
+
+    def register_handler(self, name: str, fn) -> None:
+        self._handlers[name] = fn
+
+
+def test_take_screenshot_handler_registered():
+    from dcc_mcp_core.dcc_server import register_diagnostic_handlers
+
+    server = _MockServer()
+    register_diagnostic_handlers(server, dcc_name="test-dcc")
+    assert "take_screenshot" in server._handlers
+
+
+def test_take_screenshot_full_screen_returns_base64_png():
+    """full_screen=True uses the auto capturer (mock backend in CI)."""
+    from dcc_mcp_core.dcc_server import _handle_take_screenshot
+
+    result = _handle_take_screenshot(json.dumps({"full_screen": True, "format": "png"}))
+    data = json.loads(result)
+    assert data["success"] is True
+    assert data["format"] == "png"
+    assert data["width"] > 0
+    assert data["height"] > 0
+    assert data["mime_type"] == "image/png"
+    assert data["byte_len"] > 0
+    assert isinstance(data["image_base64"], str)
+    decoded = base64.b64decode(data["image_base64"])
+    assert decoded.startswith(b"\x89PNG")
+
+
+def test_take_screenshot_full_screen_raw_format():
+    from dcc_mcp_core.dcc_server import _handle_take_screenshot
+
+    result = _handle_take_screenshot(json.dumps({"full_screen": True, "format": "raw_bgra"}))
+    data = json.loads(result)
+    assert data["success"] is True
+    assert data["format"] == "raw_bgra"
+    assert data["byte_len"] == data["width"] * data["height"] * 4
+
+
+def test_take_screenshot_empty_params_errors_without_target():
+    """Without full_screen AND without instance context, must return success=False."""
+    # Import local modules
+    import dcc_mcp_core.dcc_server as mod
+
+    original = dict(mod._instance_context)
+    mod._instance_context.update(
+        {"dcc_pid": None, "dcc_window_handle": None, "dcc_window_title": None, "resolver": None}
+    )
+    try:
+        result = mod._handle_take_screenshot("")
+        data = json.loads(result)
+        assert data["success"] is False
+        assert "message" in data
+    finally:
+        mod._instance_context.update(original)
+
+
+def test_take_screenshot_invalid_json_is_graceful():
+    # Invalid JSON falls back to empty dict; then full_screen defaults False and
+    # no context is set → should return a structured error, not raise.
+    # Import local modules
+    import dcc_mcp_core.dcc_server as mod
+    from dcc_mcp_core.dcc_server import _handle_take_screenshot
+
+    original = dict(mod._instance_context)
+    mod._instance_context.update(
+        {"dcc_pid": None, "dcc_window_handle": None, "dcc_window_title": None, "resolver": None}
+    )
+    try:
+        result = _handle_take_screenshot("not-json-{{")
+        data = json.loads(result)
+        assert "success" in data
+    finally:
+        mod._instance_context.update(original)
+
+
+def test_take_screenshot_uses_resolver_when_no_explicit_handle():
+    """When only a resolver is available, it must be invoked."""
+    # Import local modules
+    import dcc_mcp_core.dcc_server as mod
+
+    calls: list[int] = []
+
+    def _resolver() -> int:
+        calls.append(1)
+        return 0xDEADBEEF  # invalid handle — capture_window will raise
+
+    original = dict(mod._instance_context)
+    mod._instance_context.update(
+        {
+            "dcc_pid": None,
+            "dcc_window_handle": None,
+            "dcc_window_title": None,
+            "resolver": _resolver,
+        }
+    )
+    try:
+        result = mod._handle_take_screenshot(json.dumps({"timeout_ms": 200}))
+        data = json.loads(result)
+        # On Windows, the resolver is called. On other platforms the mock
+        # backend ignores the handle, so the call may succeed — accept both.
+        assert "success" in data
+        # If Windows HwndBackend was used, resolver must have been invoked.
+        if not data["success"]:
+            assert calls, "resolver should have been invoked for HwndBackend"
+    finally:
+        mod._instance_context.update(original)
+
+
+def test_take_screenshot_window_rect_none_for_full_screen():
+    from dcc_mcp_core.dcc_server import _handle_take_screenshot
+
+    result = _handle_take_screenshot(json.dumps({"full_screen": True}))
+    data = json.loads(result)
+    assert data["success"] is True
+    # Full-screen / mock captures report no window metadata.
+    assert data["window_rect"] is None
+    assert data["window_title"] is None

--- a/tests/test_diagnostics_mcp_tools.py
+++ b/tests/test_diagnostics_mcp_tools.py
@@ -1,0 +1,120 @@
+"""Tests for ``register_diagnostic_mcp_tools``.
+
+Covers:
+- All four ``diagnostics__*`` tools get registered in the server's ToolRegistry.
+- Each tool has a handler wired through :class:`McpHttpServer.register_handler`.
+- ``diagnostics__process_status`` returns the instance context via its handler.
+- Registration is idempotent when called twice.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import json
+
+# Import third-party modules
+import pytest
+
+# Import local modules
+from dcc_mcp_core import McpHttpConfig
+from dcc_mcp_core import create_skill_server
+from dcc_mcp_core import register_diagnostic_mcp_tools
+
+# ── fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def server():
+    """Return a fresh skills-first server instance (not started)."""
+    return create_skill_server("test-dcc", McpHttpConfig(port=0))
+
+
+# ── tool registration ────────────────────────────────────────────────────────
+
+
+EXPECTED_TOOLS = [
+    "diagnostics__screenshot",
+    "diagnostics__audit_log",
+    "diagnostics__action_metrics",
+    "diagnostics__process_status",
+]
+
+
+class TestRegisterDiagnosticMcpTools:
+    def test_all_four_tools_registered(self, server) -> None:
+        register_diagnostic_mcp_tools(server, dcc_name="test-dcc")
+        reg = server.registry
+        names = {entry["name"] for entry in reg.list_actions()}
+        for name in EXPECTED_TOOLS:
+            assert name in names, f"{name} not registered"
+
+    def test_handlers_are_wired(self, server) -> None:
+        register_diagnostic_mcp_tools(server, dcc_name="test-dcc")
+        for name in EXPECTED_TOOLS:
+            assert server.has_handler(name), f"{name} handler missing"
+
+    def test_idempotent(self, server) -> None:
+        register_diagnostic_mcp_tools(server, dcc_name="test-dcc")
+        register_diagnostic_mcp_tools(server, dcc_name="test-dcc")
+        names = {entry["name"] for entry in server.registry.list_actions()}
+        for name in EXPECTED_TOOLS:
+            assert name in names
+
+    def test_instance_context_populated(self, server) -> None:
+        # Import local modules
+        from dcc_mcp_core.dcc_server import _instance_context
+
+        register_diagnostic_mcp_tools(
+            server,
+            dcc_name="test-dcc",
+            dcc_pid=98765,
+            dcc_window_title="Test App",
+            dcc_window_handle=0xBEEF0001,
+        )
+        assert _instance_context["dcc_pid"] == 98765
+        assert _instance_context["dcc_window_title"] == "Test App"
+        assert _instance_context["dcc_window_handle"] == 0xBEEF0001
+
+
+# ── handler behaviour ────────────────────────────────────────────────────────
+
+
+class TestProcessStatusHandler:
+    def test_reports_context(self) -> None:
+        # Import local modules
+        from dcc_mcp_core.dcc_server import _handle_process_status
+        from dcc_mcp_core.dcc_server import _instance_context
+
+        original = dict(_instance_context)
+        _instance_context.update(
+            {
+                "dcc_name": "maya",
+                "dcc_pid": 99999,  # unlikely to be alive
+                "dcc_window_handle": None,
+                "dcc_window_title": "Maya",
+                "resolver": None,
+            }
+        )
+        try:
+            payload = json.loads(_handle_process_status("{}"))
+            assert payload["success"] is True
+            assert payload["dcc_name"] == "maya"
+            assert payload["dcc_pid"] == 99999
+            assert payload["dcc_window_title"] == "Maya"
+            assert isinstance(payload["adapter_pid"], int)
+            assert isinstance(payload["dcc_alive"], bool)
+            assert isinstance(payload["timestamp_ms"], int)
+        finally:
+            _instance_context.update(original)
+
+
+class TestToolCategoryAndMetadata:
+    def test_tools_have_diagnostics_category(self, server) -> None:
+        register_diagnostic_mcp_tools(server, dcc_name="test-dcc")
+        reg = server.registry
+        for name in EXPECTED_TOOLS:
+            meta = reg.get_action(name)
+            assert meta is not None
+            assert meta["category"] == "diagnostics"
+            assert meta["dcc"] == "test-dcc"

--- a/tests/test_on_demand_loading.py
+++ b/tests/test_on_demand_loading.py
@@ -38,6 +38,9 @@ CORE_TOOLS = frozenset(
         "load_skill",
         "unload_skill",
         "search_skills",
+        "activate_tool_group",
+        "deactivate_tool_group",
+        "search_tools",
     }
 )
 
@@ -222,7 +225,7 @@ class TestOnDemandLoadingContract:
             )
 
     def test_core_tools_always_present(self, catalog_server):
-        """All 6 core meta-tools must be present in every tools/list response."""
+        """All 9 core meta-tools must be present in every tools/list response."""
         url = catalog_server.mcp_url()
         tools = _tools_list(url)
         names = {t["name"] for t in tools}

--- a/tests/test_skill_metadata_parse_deep.py
+++ b/tests/test_skill_metadata_parse_deep.py
@@ -123,9 +123,10 @@ class TestParseSkillMdMayaGeometry:
         meta = parse_skill_md(_MAYA_GEOMETRY_DIR)
         assert meta.dcc == "maya"
 
-    def test_scripts_contains_two_files(self):
+    def test_scripts_contains_three_files(self):
         meta = parse_skill_md(_MAYA_GEOMETRY_DIR)
-        assert len(meta.scripts) == 2
+        # create_sphere, bevel_edges, create_joint (progressive-exposure demo)
+        assert len(meta.scripts) == 3
 
     def test_scripts_contain_create_sphere(self):
         meta = parse_skill_md(_MAYA_GEOMETRY_DIR)
@@ -283,7 +284,7 @@ class TestScanAndLoadScripts:
         skills, _ = scan_and_load(extra_paths=[_EXAMPLES_SKILLS_DIR])
         maya = next((s for s in skills if s.name == "maya-geometry"), None)
         assert maya is not None
-        assert len(maya.scripts) == 2
+        assert len(maya.scripts) == 3
 
     def test_scan_and_load_all_skills_have_skill_path(self):
         skills, _ = scan_and_load(extra_paths=[_EXAMPLES_SKILLS_DIR])

--- a/tests/test_skills_e2e.py
+++ b/tests/test_skills_e2e.py
@@ -96,10 +96,11 @@ class TestSkillParsingE2E:
         assert meta.name == "maya-geometry"
         assert meta.dcc == "maya"
         assert "geometry" in meta.tags
-        assert len(meta.scripts) == 2
+        assert len(meta.scripts) == 3
         script_names = [Path(s).name for s in meta.scripts]
         assert "create_sphere.py" in script_names
         assert "batch_rename.py" in script_names
+        assert "create_joint.py" in script_names
 
     def test_parse_multi_script(self, examples_dir: str) -> None:
         skill_dir = str(Path(examples_dir) / "multi-script")

--- a/tests/test_tool_groups.py
+++ b/tests/test_tool_groups.py
@@ -1,0 +1,122 @@
+"""Tests for progressive tool exposure (``SkillGroup`` / ``activate_tool_group``).
+
+Covers:
+- ``SkillGroup`` construction and field access.
+- ``ToolRegistry`` group helpers (``set_group_enabled``, ``list_groups``,
+  ``list_actions_enabled``, ``list_actions_in_group``).
+- ``SkillCatalog`` activation methods.
+- Dispatcher refusal on disabled actions.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import third-party modules
+import pytest
+
+# Import local modules
+from dcc_mcp_core import SkillGroup
+from dcc_mcp_core import ToolDispatcher
+from dcc_mcp_core import ToolRegistry
+
+# ── SkillGroup ───────────────────────────────────────────────────────────────
+
+
+class TestSkillGroup:
+    def test_construction(self) -> None:
+        g = SkillGroup(name="uv-editing", description="UV ops", tools=["unwrap", "layout"])
+        assert g.name == "uv-editing"
+        assert g.description == "UV ops"
+        assert g.tools == ["unwrap", "layout"]
+        assert g.default_active is False
+
+    def test_default_active_flag(self) -> None:
+        g = SkillGroup(name="modeling", default_active=True)
+        assert g.default_active is True
+
+    def test_repr(self) -> None:
+        g = SkillGroup(name="x", tools=["a", "b", "c"])
+        r = repr(g)
+        assert "SkillGroup" in r
+        assert 'name="x"' in r or "name='x'" in r or '"x"' in r
+
+
+# ── ToolRegistry group helpers ───────────────────────────────────────────────
+
+
+@pytest.fixture
+def registry_with_groups() -> ToolRegistry:
+    r = ToolRegistry()
+    r.register(name="mod_a", description="A", dcc="maya", group="modeling", enabled=True)
+    r.register(name="mod_b", description="B", dcc="maya", group="modeling", enabled=True)
+    r.register(name="rig_a", description="A", dcc="maya", group="rigging", enabled=False)
+    r.register(name="rig_b", description="B", dcc="maya", group="rigging", enabled=False)
+    r.register(name="free_tool", description="no group", dcc="maya")
+    return r
+
+
+class TestToolRegistryGroups:
+    def test_list_groups(self, registry_with_groups) -> None:
+        groups = set(registry_with_groups.list_groups())
+        assert groups == {"modeling", "rigging"}
+
+    def test_list_actions_in_group(self, registry_with_groups) -> None:
+        rigging = {m["name"] for m in registry_with_groups.list_actions_in_group("rigging")}
+        assert rigging == {"rig_a", "rig_b"}
+
+    def test_list_actions_enabled_excludes_disabled(self, registry_with_groups) -> None:
+        enabled = {m["name"] for m in registry_with_groups.list_actions_enabled()}
+        assert enabled == {"mod_a", "mod_b", "free_tool"}
+
+    def test_set_group_enabled_activates(self, registry_with_groups) -> None:
+        changed = registry_with_groups.set_group_enabled("rigging", True)
+        assert changed == 2
+        enabled = {m["name"] for m in registry_with_groups.list_actions_enabled()}
+        assert {"rig_a", "rig_b"} <= enabled
+
+    def test_set_group_enabled_deactivates(self, registry_with_groups) -> None:
+        registry_with_groups.set_group_enabled("modeling", False)
+        enabled = {m["name"] for m in registry_with_groups.list_actions_enabled()}
+        assert enabled == {"free_tool"}
+
+    def test_set_action_enabled_single(self, registry_with_groups) -> None:
+        assert registry_with_groups.set_action_enabled("rig_a", True) is True
+        enabled = {m["name"] for m in registry_with_groups.list_actions_enabled()}
+        assert "rig_a" in enabled
+        assert "rig_b" not in enabled
+
+    def test_set_action_enabled_returns_false_for_unknown(self, registry_with_groups) -> None:
+        assert registry_with_groups.set_action_enabled("does_not_exist", True) is False
+
+    def test_group_field_preserved_in_list(self, registry_with_groups) -> None:
+        metas = {m["name"]: m for m in registry_with_groups.list_actions()}
+        assert metas["rig_a"]["group"] == "rigging"
+        assert metas["rig_a"]["enabled"] is False
+        assert metas["free_tool"]["group"] == ""
+        assert metas["free_tool"]["enabled"] is True
+
+
+# ── Dispatcher enforcement ───────────────────────────────────────────────────
+
+
+class TestDispatcherEnforcesEnabled:
+    def test_disabled_action_raises(self, registry_with_groups) -> None:
+        dispatcher = ToolDispatcher(registry_with_groups)
+        dispatcher.register_handler("rig_a", lambda _params: {"ok": True})
+        # Disabled action must be refused; the Rust DispatchError::ActionDisabled
+        # variant surfaces as PermissionError in Python.
+        with pytest.raises(PermissionError):
+            dispatcher.dispatch("rig_a", "{}")
+
+    def test_enabled_action_dispatches(self, registry_with_groups) -> None:
+        dispatcher = ToolDispatcher(registry_with_groups)
+        dispatcher.register_handler("mod_a", lambda _params: {"ok": True})
+        result = dispatcher.dispatch("mod_a", "{}")
+        assert result["action"] == "mod_a"
+
+    def test_reactivated_action_dispatches(self, registry_with_groups) -> None:
+        dispatcher = ToolDispatcher(registry_with_groups)
+        dispatcher.register_handler("rig_a", lambda _params: {"ok": True})
+        registry_with_groups.set_group_enabled("rigging", True)
+        result = dispatcher.dispatch("rig_a", "{}")
+        assert result["action"] == "rig_a"


### PR DESCRIPTION
## Summary

Three independent but related features that together make multi-instance DCC diagnostics production-ready.

### Part A — Window-target capture

- New `Capturer.new_window_auto()` + `.capture_window(*, process_id=None, window_handle=None, window_title=None, ...)` — single-window capture without the full-screen round-trip.
- New `CaptureTarget` static factories: `primary_display()`, `monitor_index(i)`, `process_id(pid)`, `window_title(title)`, `window_handle(handle)`.
- New `WindowFinder()` / `WindowInfo` — enumerate / resolve windows without raising when no match is found.
- New `CaptureBackendKind` enum with `HwndPrintWindow` variant; `CaptureFrame.window_rect` / `.window_title` properties populated for window captures.
- Backend on Windows: HWND `PrintWindow` + `BitBlt` fallback; stubs for non-Windows platforms fall through to the Mock backend.

### Part B — Instance-bound diagnostics

- `DccServerBase` now accepts `dcc_pid` / `dcc_window_title` / `dcc_window_handle` (or a lazy `resolver` callable) so adapters can bind one server to one DCC process.
- Four MCP tools registered automatically: `diagnostics__screenshot`, `diagnostics__audit_log`, `diagnostics__action_metrics`, `diagnostics__process_status`.
- New `register_diagnostic_mcp_tools(server, *, dcc_name, dcc_pid=..., ...)` for low-level servers that build on `McpHttpServer` directly (IPC-path equivalent: `register_diagnostic_handlers`).
- Bundled `dcc-diagnostics` skill's `screenshot.py` tries `DCC_MCP_OWNER_IPC` → `channel.call("take_screenshot")` first, falls back to `Capturer.new_auto()` when no owner IPC is set.

### Part C — Tool groups (progressive exposure)

- New `SkillGroup` model (`.name`, `.description`, `.default_active`, `.tools`) declared in SKILL.md `groups:` frontmatter.
- `ActionMeta` grows `enabled: bool` and `group: String` fields; dispatcher refuses to invoke disabled actions; `tools/list` hides them.
- `SkillCatalog`: `.active_groups`, `.activate_group`, `.deactivate_group`, `.list_groups`, `.list_tools_catalog`. `load_skill` applies each group's `default_active` flag.
- `ToolRegistry`: `.activate_tool_group`, `.deactivate_tool_group`, `.list_tools_in_group`, `.list_actions_enabled`, `.set_tool_enabled` — each emits `notifications/tools/list_changed`.
- Three new core MCP tools on `McpHttpServer` (6 → 9): `activate_tool_group`, `deactivate_tool_group`, `search_tools`.
- `tools/list` now also emits `__group__<skill>.<group>` stubs for inactive groups so clients can discover them.

### Chore — pyo3-stub-gen PoC

Opt-in `stub-gen` feature on the root crate + a `just stubgen` recipe. Annotates `dcc-mcp-capture`'s `#[pyclass]` / `#[pymethods]` with `gen_stub_*` derives as an end-to-end sanity check. No changes to the generated `_core.pyi` yet — paves the way for replacing the hand-written 3 300-line stub file crate by crate.

## Commits

- `docs(claude)` — require Simplified Chinese responses from AI agent.
- `feat` — window-target capture, instance-bound diagnostics, and tool groups (Part A+B+C).
- `chore(stub-gen)` — add pyo3-stub-gen PoC for dcc-mcp-capture.
- `test` — align fixtures with new SkillMetadata / ActionMeta / core-tool fields.
- `docs` — document window capture, instance-bound diagnostics, and tool groups.

## Verification

- `vx just preflight` — cargo check / clippy / fmt-check / test-rust all green.
- `vx just test` — **12 480 passed**, 54 skipped (~2:49).
- 3 new Rust integration suites: `test_capture_hwnd_backend`, `test_capture_window_api`, `test_skill_groups_parse`, `test_tool_group_activation`, `test_mcp_tools_list_group_stubs`, `test_search_tools_core`, `test_dcc_server_screenshot_ipc`, `test_diagnostics_mcp_tools`.

## Breaking changes

- `ActionMeta` struct gains required fields `enabled` and `group` (only affects Rust callers constructing `ActionMeta` via struct-literal syntax — `Default::default()` users are unaffected).
- `SkillMetadata` struct gains required field `groups` (same caveat).
- `McpHttpServer` `tools/list` core tool count: 6 → 9 (new meta-tools are additive; individual skill tools behave identically).

No public Python API is broken.

## Docs updated

`docs/api/capture.md`, `docs/guide/skills.md`, `docs/guide/getting-started.md`, `llms.txt`, `llms-full.txt`, `AGENTS.md`.