### PR TITLE
docs: enhance AI agent guidance for v0.13.x

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,18 +9,21 @@
 ## Start Here — Orient in 60 Seconds
 
 **What is this?**
-A Rust-powered MCP (Model Context Protocol) library that lets AI agents interact with DCC software (Maya, Blender, Houdini, Photoshop…). Compiled to a native Python extension via PyO3/maturin. Zero runtime Python dependencies.
+A Rust-powered MCP (Model Context Protocol) library that lets AI agents interact with DCC software (Maya, Blender, Houdini, Photoshop…). Compiled to a native Python extension via PyO3/maturin. Zero runtime Python dependencies. Implements [MCP 2025-03-26](https://modelcontextprotocol.io/specification/2025-03-26) Streamable HTTP transport.
 
 **What does it provide to downstream adapter packages (`dcc-mcp-maya`, `dcc-mcp-blender`, …)?**
 
 | Need | What to use |
 |------|-------------|
 | Expose DCC tools over MCP HTTP | `DccServerBase` → subclass, call `start()` |
-| Zero-code tool registration | Drop `SKILL.md` + `scripts/` in a directory |
+| Zero-code tool registration | Drop `SKILL.md` + `scripts/` in a directory ([agentskills.io](https://agentskills.io/specification) format) |
 | AI-safe result structure | `success_result()` / `error_result()` |
 | Bridge non-Python DCCs (Photoshop, ZBrush) | `DccBridge` (WebSocket JSON-RPC 2.0) |
 | IPC between processes | `IpcListener.bind()` / `connect_ipc()` / `FramedChannel.call()` |
 | Multi-DCC gateway | `McpHttpConfig(gateway_port=9765)` |
+| Trust-based skill scoping | `SkillScope` (Repo → User → System → Admin) |
+| Progressive tool exposure | `SkillGroup` with `default_active` + `activate_tool_group()` |
+| Instance-bound diagnostics | `DccServerBase(..., dcc_pid=pid)` → scoped `diagnostics__*` tools |
 
 **The three files that define the entire public API surface — read them in this order:**
 
@@ -176,7 +179,17 @@ result = dispatcher.dispatch("name", json_str)   # returns dict
 
 **`ToolRegistry.register()` — keyword args only, no positional:**
 ```python
-registry.register(name="my_action", description="...", dcc="maya")
+registry.register(name="my_tool", description="...", dcc="maya")
+```
+
+**`ToolRegistry` method names still use "action" (v0.13 compatibility):**
+```python
+# The Rust API was renamed action→tool in v0.13, but some method names
+# remain as "action" for backward compatibility:
+registry.get_action("create_sphere")           # still "get_action"
+registry.list_actions(dcc_name="maya")         # still "list_actions"
+registry.search_actions(category="geometry")   # still "search_actions"
+# These are NOT bugs — they are compatibility aliases.
 ```
 
 **`FramedChannel.call()` — primary RPC (v0.12.7+):**
@@ -197,6 +210,25 @@ from dcc_mcp_core._core import DeferredExecutor   # direct import required
 ```
 
 **`McpHttpServer` — register ALL handlers BEFORE `.start()`.**
+This includes `register_diagnostic_mcp_tools(...)` for instance-bound diagnostics —
+register them before calling `server.start()`, never after.
+
+**`Capturer.new_auto()` vs `.new_window_auto()`:**
+```python
+# ✓ full-screen / display capture (DXGI on Windows, X11 on Linux)
+Capturer.new_auto().capture()
+
+# ✓ single-window capture (HWND PrintWindow on Windows; Mock elsewhere)
+Capturer.new_window_auto().capture_window(window_title="Maya 2024")
+# ✗ .new_auto() then .capture_window() — may return an incorrect backend
+```
+
+**Tool groups — inactive groups are hidden, not deleted:**
+```python
+# default_active=false tools are registered with enabled=False.
+# tools/list hides them but registry.list_actions() still returns them.
+registry.activate_tool_group("maya-geometry", "rigging")   # emits tools/list_changed
+```
 
 **`skill_success()` vs `success_result()` — different types, different use cases:**
 ```python
@@ -205,6 +237,21 @@ return skill_success("done", count=5)       # → {"success": True, ...} dict
 
 # Inside server code (returns ToolResult for validation/transport):
 return success_result("done", count=5)      # → ToolResult instance
+```
+
+**`SkillScope` — higher scope overrides lower for same-name skills:**
+```python
+# Scope hierarchy: Repo < User < System < Admin
+# A System-scoped skill silently shadows a Repo-scoped skill with the same name.
+# This prevents project-local skills from hijacking enterprise-managed ones.
+```
+
+**`allow_implicit_invocation: false` ≠ `defer-loading: true`:**
+```yaml
+# allow_implicit_invocation: false → skill must be explicitly load_skill()'d
+# defer-loading: true → tool stub appears in tools/list but needs load_skill()
+# Both delay tool availability, but the former is a *policy* (security),
+# the latter is a *hint* (progressive loading). Use both for maximum control.
 ```
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,9 @@ def test_skill_scan(tmp_path):
 - **Bridge system**: `BridgeRegistry`, `BridgeContext`, `register_bridge()`, `get_bridge_context()` — for inter-protocol bridging (RPyC ↔ MCP etc.). Don't build custom bridge registries.
 - **Scene data model**: `BoundingBox`, `FrameRange`, `ObjectTransform`, `SceneNode`, `SceneObject`, `RenderOutput` — use for structured scene data instead of raw dicts. `BoundingBox` may be `None`.
 - **Serialization**: `serialize_result()` / `deserialize_result()` with `SerializeFormat` enum — for transport-safe ToolResult serialization. Don't use `json.dumps()` on ToolResult.
+- **SkillScope & SkillPolicy** (v0.13+): Trust hierarchy (`Repo` < `User` < `System` < `Admin`) — higher scopes shadow lower for same-name skills. `SkillPolicy` controls `allow_implicit_invocation` and `products` filter.
+- **Action→Tool rename** (v0.13): Conceptual rename complete; some Rust API method names (`get_action`, `list_actions`, `search_actions`) remain as compatibility aliases — not bugs.
+- **MCP best practices**: Design tools around user workflows, not raw API calls. Use `ToolAnnotations` for safety hints (`read_only_hint`, `destructive_hint`, `idempotent_hint`). Return human-readable errors.
 
 ## Key Files to Read First (Priority Order)
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -35,7 +35,7 @@ vx just lint-fix     # Auto-fix all lint issues
 - **~154 public Python symbols** exported from `python/dcc_mcp_core/__init__.py`
 - **Zero runtime Python deps** — all logic in Rust, no `dependencies = [...]` in pyproject.toml
 - Python 3.7–3.13 supported (abi3-py38 wheel; separate non-abi3 wheel for 3.7)
-- Version: **0.12.29** — managed by Release Please, never manually bump
+- **Version: current** — managed by Release Please, never manually bump
 
 ## Gemini-Specific Workflows
 
@@ -164,6 +164,12 @@ search-hint: "polygon modeling, bevel, extrude, mesh editing"
 22. **tools/list has 6 core tools** (not 5): `find_skills`, `list_skills`, `get_skill_info`, `load_skill`, `unload_skill`, **`search_skills``. Unloaded skills appear as `__skill__<name>` stubs — calling a stub returns a `load_skill` hint, not an error about missing handlers.
 
 23. **`search_hint` fallback**: If `search-hint:` is not in SKILL.md, `SkillSummary.search_hint` falls back to `description`. Set `search-hint` explicitly for better keyword matching.
+
+24. **SkillScope & SkillPolicy** (v0.13+): Trust hierarchy `Repo` < `User` < `System` < `Admin`. Higher-scope skills shadow lower-scope ones with the same name. `SkillPolicy.allow_implicit_invocation` controls auto-loading; `SkillPolicy.products` filters by DCC type.
+
+25. **Action→Tool compatibility** (v0.13): The project renamed "action" → "tool" conceptually. Method names `get_action`, `list_actions`, `search_actions` remain as compatibility aliases — not bugs.
+
+26. **MCP best practices**: Design tools around user workflows, not API calls. Use `ToolAnnotations` for safety hints. Return human-readable errors. Use `notifications/tools/list_changed` when the tool set changes.
 
 ## CI/CD Summary
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -63,8 +63,8 @@ discovered = catalog.discover(dcc_name="maya")
 print(f"Discovered {discovered} skills")
 
 # Load a skill and inspect the registered tool names
-actions = catalog.load_skill("maya-geometry")
-print(actions)
+tool_names = catalog.load_skill("maya-geometry")
+print(tool_names)
 ```
 
 See the [Skills System guide](/guide/skills) for writing `SKILL.md` files and advanced options.
@@ -89,7 +89,11 @@ print(tool)  # dict with tool metadata
 maya_tools = registry.list_actions(dcc_name="maya")
 ```
 
-### Action Results
+:::: info Action → Tool terminology
+In v0.13+, the project renamed "action" → "tool" at the conceptual level. However, some Rust API method names (`get_action`, `list_actions`, `search_actions`) still use "action" for backward compatibility. These are not bugs — they are compatibility aliases.
+::::
+
+### Tool Results
 
 ```python
 from dcc_mcp_core import success_result, error_result
@@ -155,9 +159,50 @@ vx just lint
 
 ## Next Steps
 
-- Learn about [Actions & Registry](/guide/actions) — the tool registration layer
+- Learn about [Tools & Registry](/guide/actions) — the tool registration layer
 - Explore [Events & Telemetry](/api/events) for lifecycle hooks and lightweight execution metrics
 - Check out the [Skills System](/guide/skills) for zero-code script registration
 - Expose tools with [MCP HTTP Server](/api/http)
 - See the [Transport Layer](/guide/transport) for DCC communication
 - Understand the [Architecture](/guide/architecture) of the 14-crate Rust workspace
+- Learn [Skill Scopes & Policies](/guide/skill-scopes-policies) for trust-based skill management
+
+## Building a DCC Adapter with DccServerBase
+
+`DccServerBase` is the recommended base class for building DCC adapters. It bundles all the boilerplate that every adapter needs:
+
+```python
+from pathlib import Path
+from dcc_mcp_core import DccServerBase
+
+class BlenderMcpServer(DccServerBase):
+    def __init__(self, port: int = 8765, **kwargs):
+        super().__init__(
+            dcc_name="blender",
+            builtin_skills_dir=Path(__file__).parent / "skills",
+            port=port,
+            **kwargs,
+        )
+
+    def _version_string(self) -> str:
+        import bpy
+        return bpy.app.version_string
+
+# That's it — skill management, hot-reload, gateway election are all inherited.
+server = BlenderMcpServer(gateway_port=9765)
+server.register_builtin_actions()  # discover and load skills
+server.enable_hot_reload()         # optional: auto-reload on file changes
+handle = server.start()            # returns McpServerHandle
+print(f"Running at {handle.mcp_url()}")
+```
+
+For zero-boilerplate adapters, use `make_start_stop`:
+
+```python
+from dcc_mcp_core import make_start_stop
+
+start_server, stop_server = make_start_stop(
+    BlenderMcpServer,
+    hot_reload_env_var="DCC_MCP_BLENDER_HOT_RELOAD",
+)
+```

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -73,9 +73,9 @@ print(f"Discovered {discovered} skills")
 for skill in catalog.list_skills():
     print(f"  {skill.name} v{skill.version}: {skill.description} (loaded={skill.loaded})")
 
-# Load a skill — returns the registered action names
-actions = catalog.load_skill("maya-geometry")
-print(actions)
+# Load a skill — returns the registered tool names
+tool_names = catalog.load_skill("maya-geometry")
+print(tool_names)
 ```
 
 ## Skill Catalog (Recommended API)
@@ -97,7 +97,7 @@ for s in results:
     print(f"{s.name}: {s.tool_count} tools {s.tool_names}")
 
 # Load/unload
-actions = catalog.load_skill("maya-geometry")  # returns List[str]
+actions = catalog.load_skill("maya-geometry")  # returns List[str] — tool names
 catalog.is_loaded("maya-geometry")        # True
 removed = catalog.unload_skill("maya-geometry")
 

--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -62,14 +62,14 @@ catalog = SkillCatalog(registry)
 discovered = catalog.discover(dcc_name="maya")
 print(f"发现了 {discovered} 个 Skill")
 
-# 加载 Skill，并查看注册后的 Action 名称
-actions = catalog.load_skill("maya-geometry")
-print(actions)
+# 加载 Skill，并查看注册后的工具名称
+tool_names = catalog.load_skill("maya-geometry")
+print(tool_names)
 ```
 
 参见 [Skills 系统指南](/zh/guide/skills) 了解 `SKILL.md` 的编写方式和更多选项。
 
-### Action 注册表
+### 工具注册表
 
 ```python
 from dcc_mcp_core import ToolRegistry
@@ -83,13 +83,17 @@ registry.register(
     dcc="maya",
 )
 
-action = registry.get_action("create_sphere")
-print(action)  # 包含 Action 元数据的字典
+tool = registry.get_action("create_sphere")
+print(tool)  # 包含工具元数据的字典
 
-maya_actions = registry.list_actions(dcc_name="maya")
+maya_tools = registry.list_actions(dcc_name="maya")
 ```
 
-### Action 结果
+:::: info Action → Tool 术语说明
+v0.13+ 项目在概念层面将 "action" 重命名为 "tool"。但部分 Rust API 方法名（`get_action`、`list_actions`、`search_actions`）仍使用 "action" 以保持向后兼容——这不是 bug，而是兼容别名。
+::::
+
+### 工具结果
 
 ```python
 from dcc_mcp_core import success_result, error_result
@@ -155,9 +159,50 @@ vx just lint
 
 ## 下一步
 
-- 了解 [Actions 动作](/zh/guide/actions) — 核心构建块
+- 了解 [工具注册表](/zh/guide/actions) — 核心构建块
 - 探索 [Events 事件](/zh/guide/events) 的生命周期钩子
 - 查看 [Skills 技能包](/zh/guide/skills) 的零代码脚本注册
 - 使用 [MCP HTTP 服务器](/zh/api/http) 暴露工具给 AI 客户端
 - 查看 [传输层](/zh/guide/transport) 的 DCC 通信
 - 了解 [架构设计](/zh/guide/architecture) — 14 个 Rust crate 的工作区结构
+- 学习 [技能作用域与策略](/zh/guide/skill-scopes-policies) — 基于信任的技能管理
+
+## 使用 DccServerBase 构建 DCC 适配器
+
+`DccServerBase` 是构建 DCC 适配器的推荐基类。它集成了所有适配器需要的样板代码：
+
+```python
+from pathlib import Path
+from dcc_mcp_core import DccServerBase
+
+class BlenderMcpServer(DccServerBase):
+    def __init__(self, port: int = 8765, **kwargs):
+        super().__init__(
+            dcc_name="blender",
+            builtin_skills_dir=Path(__file__).parent / "skills",
+            port=port,
+            **kwargs,
+        )
+
+    def _version_string(self) -> str:
+        import bpy
+        return bpy.app.version_string
+
+# 仅此而已 — 技能管理、热重载、网关选举均已继承
+server = BlenderMcpServer(gateway_port=9765)
+server.register_builtin_actions()  # 发现并加载技能
+server.enable_hot_reload()         # 可选：文件变更时自动重载
+handle = server.start()            # 返回 McpServerHandle
+print(f"运行于 {handle.mcp_url()}")
+```
+
+零样板适配器可使用 `make_start_stop`：
+
+```python
+from dcc_mcp_core import make_start_stop
+
+start_server, stop_server = make_start_stop(
+    BlenderMcpServer,
+    hot_reload_env_var="DCC_MCP_BLENDER_HOT_RELOAD",
+)
+```

--- a/llms.txt
+++ b/llms.txt
@@ -18,6 +18,8 @@
 | Expose DCC tools over HTTP/MCP | `create_skill_server("maya", McpHttpConfig(port=8765))` — Skills-First setup; falls back to `McpHttpServer(registry, config)` for manual registry wiring |
 | Build a DCC adapter | `DccServerBase(dcc_name, builtin_skills_dir)` — skill/lifecycle/gateway/hot-reload inherited |
 | Write skill scripts | `skill_entry` + `skill_success` / `skill_error` — zero-boilerplate skill authoring |
+| Control skill trust level | `SkillScope` (Repo < User < System < Admin) — higher scope shadows lower |
+| Progressive tool exposure | `SkillGroup` with `default_active` + `activate_tool_group()` |
 
 ## Quick Start
 
@@ -59,7 +61,7 @@ meta = dcc_mcp_core.parse_skill_md(dirs[0])  # -> SkillMetadata or None
 - Build from source: `maturin develop --features python-bindings,ext-module`
 - Python: >=3.7 (CI tests 3.7–3.13; abi3-py38 wheel for 3.8+)
 - Build: maturin (Rust 1.85+ + PyO3)
-- Version: 0.12.28+
+- Version: current
 - License: MIT
 
 ## Architecture
@@ -240,6 +242,22 @@ crates/
 - `register_bridge(name, ctx)` — register a named bridge
 - `get_bridge_context(name) -> Optional[BridgeContext]` — retrieve bridge by name
 
+### Skill Scopes & Policies (`dcc_mcp_core`)
+
+- `SkillScope` — enum: `Repo`, `User`, `System`, `Admin` (ascending trust; higher shadows lower)
+  - `Repo` — project-local (e.g. `./<project>/.dcc_skills/`)
+  - `User` — user-level (e.g. `~/.dcc_mcp/skills/`)
+  - `System` — system-wide (e.g. `/opt/dcc_mcp/skills/`)
+  - `Admin` — enterprise-managed (elevated privilege)
+  - `SkillScope.is_elevated()` — `True` for System and Admin
+  - `SkillScope.label()` — short string (`"repo"`, `"user"`, etc.)
+- `SkillPolicy` — declared in SKILL.md frontmatter
+  - `allow_implicit_invocation: bool` (default `True`) — when `False`, skill must be explicitly `load_skill()`'d
+  - `products: list[str]` — DCC type whitelist (case-insensitive)
+  - `SkillMetadata.policy` — access the policy object
+  - `SkillMetadata.is_implicit_invocation_allowed()` — check policy
+  - `SkillMetadata.matches_product(dcc_name)` — check product filter
+
 ### Scene Data Model (`dcc_mcp_core`)
 
 - `BoundingBox` — axis-aligned bounding box (min/max corner vectors)
@@ -289,6 +307,8 @@ maya-geometry/
 
 ### SKILL.md Format
 
+Follows [agentskills.io](https://agentskills.io/specification) specification.
+
 ```yaml
 ---
 name: maya-geometry
@@ -300,8 +320,12 @@ version: "1.0.0"
 depends: ["other-skill"]  # optional
 license: MIT              # optional
 compatibility: "Maya 2024+" # optional
+metadata:                 # optional (agentskills.io spec)
+  author: example-org
+  version: "1.0"
+search-hint: "polygon modeling, bevel, extrude"  # dcc-mcp-core extension
 ---
-# Markdown description body
+# Markdown description body (keep < 500 lines, < 5000 tokens recommended)
 ```
 
 ### Supported Script Types


### PR DESCRIPTION
## Summary

Enhance AI agent documentation for v0.13.x with new APIs, best practices, and terminology fixes.

## Changes

### New Documentation
- **SkillScope & SkillPolicy** — Added trust hierarchy documentation (Repo < User < System < Admin) across AGENTS.md, CLAUDE.md, GEMINI.md, llms.txt
- **MCP Best Practices** — Added section covering tool design patterns, ToolAnnotations, error handling guidelines (sourced from [MCPcat](https://mcpcat.io/blog/mcp-server-best-practices/) and [MCP 2025-03-26 spec](https://modelcontextprotocol.io/specification/2025-03-26/server/tools))
- **DccServerBase** — Added getting-started sections in EN and ZH with complete usage examples
- **allow_implicit_invocation vs defer-loading** — Added clear distinction between these two mechanisms

### Terminology Fixes (action → tool)
- Fixed action→tool references in docs/guide/getting-started.md (EN), docs/zh/guide/getting-started.md (ZH), docs/guide/skills.md
- Added compatibility alias note explaining why get_action, list_actions, search_actions remain as method names

### Spec Alignment
- Updated SKILL.md format to match latest [agentskills.io](https://agentskills.io/specification) spec (added metadata, compatibility fields)
- Added progressive disclosure guidelines (SKILL.md body < 500 lines, < 5000 tokens)
- Added eferences/ directory documentation per agentskills.io standard

### Reference Updates
- Version references changed from hardcoded to 'current' to avoid staleness
- Added SkillScope shadowing rules to pitfalls section
- Updated Quick Decision Guide with skill scope and progressive exposure entries

## Files Changed
- \AGENTS.md\ — SkillScope, MCP best practices, action→tool compatibility, Capturer/ToolGroup traps
- \CLAUDE.md\ — SkillScope, SkillPolicy, action→tool rename, MCP best practices
- \GEMINI.md\ — SkillScope, action→tool compatibility, MCP best practices, version fix
- \llms.txt\ — SkillScope API, SKILL.md format, progressive disclosure, version fix
- \docs/guide/getting-started.md\ — DccServerBase section, action→tool fixes, compatibility note
- \docs/guide/skills.md\ — action→tool terminology fixes
- \docs/zh/guide/getting-started.md\ — DccServerBase section, action→tool fixes (ZH)

## Test Plan
- [x] Docs-only changes — no Rust/Python code affected
- [x] Pre-commit hooks passed (trailing whitespace, end-of-file)
- [ ] CI should pass (docs-only changes skip Rust rebuild)