### PR TITLE
docs: fix action->tool terminology, add DccGatewayElection API, sync ZH docs

### DIFF
--- a/docs/api/actions.md
+++ b/docs/api/actions.md
@@ -1,6 +1,10 @@
-# Actions API
+# Tools API
 
 `dcc_mcp_core` — ToolRegistry, EventBus, ToolDispatcher, ToolValidator, SemVer, VersionConstraint, VersionedRegistry.
+
+:::: info Action → Tool terminology
+In v0.13+, the project renamed "action" → "tool" at the conceptual level. However, some Rust API method names (`get_action`, `list_actions`, `search_actions`, `count_actions`, `register_batch(actions)`) still use "action" for backward compatibility. These are NOT bugs — they are compatibility aliases.
+::::
 
 ## ToolRegistry
 
@@ -18,7 +22,7 @@ registry = ToolRegistry()
 | Method | Returns | Description |
 |--------|---------|-------------|
 | `register(name, description="", category="", tags=[], dcc="python", version="1.0.0", input_schema=None, output_schema=None, source_file=None)` | — | Register a skill |
-| `register_batch(actions)` | — | Register multiple skills from a list of dicts (each dict uses same keys as `register()`; entries without `name` are skipped) |
+| `register_batch(actions)` | — | Register multiple tools from a list of dicts (parameter named `actions` for backward compat; each dict uses same keys as `register()`) |
 | `unregister(name, dcc_name=None)` | `bool` | Remove a skill. If `dcc_name=None`, removes globally; otherwise scoped. Returns `True` if found |
 | `get_action(name, dcc_name=None)` | `dict?` | Get skill metadata as dict |
 | `list_actions(dcc_name=None)` | `List[dict]` | List all skills as metadata dicts |
@@ -27,7 +31,7 @@ registry = ToolRegistry()
 | `search_actions(category=None, tags=[], dcc_name=None)` | `List[dict]` | Search with AND-ed filters |
 | `get_categories(dcc_name=None)` | `List[str]` | Sorted unique categories |
 | `get_tags(dcc_name=None)` | `List[str]` | Sorted unique tags |
-| `count_actions(category=None, tags=[], dcc_name=None)` | `int` | Count matching skills |
+| `count_actions(category=None, tags=[], dcc_name=None)` | `int` | Count matching tools (method named `count_actions` for backward compat) |
 | `reset()` | — | Clear all registered skills |
 
 ### Dunder Methods
@@ -40,7 +44,7 @@ registry = ToolRegistry()
 
 ### Skill Metadata Dict
 
-When retrieved via `get_action()`, `list_actions()`, or `search_actions()`, each skill is a dict:
+When retrieved via `get_action()`, `list_actions()`, or `search_actions()` (method names use "action" for backward compat), each tool is a dict:
 
 ```python
 {
@@ -106,7 +110,7 @@ validator = ToolValidator.from_schema_json(
 from dcc_mcp_core import ToolRegistry
 reg = ToolRegistry()
 reg.register("create_sphere", input_schema='{"type": "object", "properties": {"radius": {"type": "number"}}}')
-validator = ToolValidator.from_action_registry(reg, "create_sphere")
+validator = ToolValidator.from_action_registry(reg, "create_sphere")  # method name uses "action" for backward compat
 ```
 
 ### Validating Input
@@ -171,6 +175,7 @@ import json
 
 result = dispatcher.dispatch("create_sphere", json.dumps({"radius": 2.0}))
 # result = {"action": "create_sphere", "output": {"created": True, "radius": 2.0}, "validation_skipped": False}
+# Note: the dict key "action" in the result reflects backward-compat naming in the Rust wire format
 print(result["output"]["created"])  # True
 ```
 
@@ -186,7 +191,7 @@ def handler(params: dict) -> Any:
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `register_handler(action_name, handler)` | — | Register a Python callable for a skill |
+| `register_handler(action_name, handler)` | — | Register a Python callable for a tool (parameter named `action_name` for backward compat) |
 | `remove_handler(action_name)` | `bool` | Remove handler, return True if existed |
 | `has_handler(action_name)` | `bool` | Check if handler is registered |
 | `handler_count()` | `int` | Number of registered handlers |
@@ -407,7 +412,7 @@ pipeline = ToolPipeline(dispatcher)
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `dispatch(action, params_json)` | `dict` | Dispatch skill through all middleware layers |
+| `dispatch(action, params_json)` | `dict` | Dispatch tool through all middleware layers |
 | `register_handler(name, fn)` | — | Register a Python handler (mirrors `ToolDispatcher`) |
 | `add_logging(log_params=False)` | — | Add trace logging middleware |
 | `add_timing()` | `TimingMiddleware` | Add latency tracking; returns handle |
@@ -424,7 +429,7 @@ pipeline = ToolPipeline(dispatcher)
 
 | Key | Type | Description |
 |-----|------|-------------|
-| `action` | `str` | Skill name |
+| `action` | `str` | Tool name (dict key uses "action" for backward compat) |
 | `output` | `Any` | Handler return value |
 | `success` | `bool` | `True` if no exception |
 | `error` | `str?` | Error message if failed |
@@ -451,12 +456,12 @@ count = audit.record_count()                     # int
 audit.clear()
 ```
 
-Each record dict: `action` (str, the skill name), `success` (bool), `error` (str | None), `timestamp_ms` (int).
+Each record dict: `action` (str, the tool name — key uses "action" for backward compat), `success` (bool), `error` (str | None), `timestamp_ms` (int).
 
 | Method | Returns | Description |
 |--------|---------|-------------|
 | `records()` | `List[dict]` | All audit records |
-| `records_for_action(name)` | `List[dict]` | Records for a specific action |
+| `records_for_action(name)` | `List[dict]` | Records for a specific tool (method named `records_for_action` for backward compat) |
 | `record_count()` | `int` | Total record count |
 | `clear()` | — | Remove all records |
 

--- a/docs/guide/gateway-election.md
+++ b/docs/guide/gateway-election.md
@@ -185,3 +185,104 @@ mgr.deregister_service("maya", iid)
 ## Backward Compatibility
 
 Older DCC versions that don't support `/gateway/yield` return 404 — that's OK. The challenger enters a polling retry loop and waits until the port is naturally freed (when old DCC exits or crashes). No hard failures; graceful degradation.
+
+## DccGatewayElection (Python API)
+
+`DccGatewayElection` is a pure-Python class that provides **automatic gateway failover** for non-gateway DCC instances. When the current gateway becomes unreachable, the election thread automatically attempts to take over.
+
+### How It Works
+
+1. A background daemon thread periodically probes the gateway's `/health` endpoint
+2. Counts consecutive probe failures
+3. When failures exceed the threshold, attempts a first-wins TCP port check
+4. If the port is free, signals the server to upgrade to gateway mode
+
+### Constructor
+
+```python
+from dcc_mcp_core import DccGatewayElection
+
+election = DccGatewayElection(
+    dcc_name="blender",           # Short DCC identifier for logs
+    server=blender_server,        # DCC server instance (must expose is_gateway, is_running, _handle)
+    gateway_host="127.0.0.1",     # Gateway bind address
+    gateway_port=9765,            # Gateway port to compete for
+    probe_interval=5,             # Seconds between health probes
+    probe_timeout=2.0,            # Timeout per probe in seconds
+    probe_failures=3,             # Consecutive failures before election attempt
+    on_promote=None,              # Optional callable: () -> bool, overrides server._upgrade_to_gateway()
+)
+```
+
+### Configuration via Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DCC_MCP_GATEWAY_PROBE_INTERVAL` | `5` | Seconds between health probes |
+| `DCC_MCP_GATEWAY_PROBE_TIMEOUT` | `2` | Timeout per probe in seconds |
+| `DCC_MCP_GATEWAY_PROBE_FAILURES` | `3` | Consecutive failures before election |
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `is_running` | `bool` | Whether the election thread is active |
+| `consecutive_failures` | `int` | Current consecutive gateway probe failure count |
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `start()` | `None` | Start the background election thread (idempotent) |
+| `stop()` | `None` | Gracefully stop the thread (waits up to 5s) |
+| `get_status()` | `dict` | Returns `{running, consecutive_failures, gateway_host, gateway_port}` |
+
+### Promotion Path
+
+When the election wins (port is free), it resolves the promotion path in order:
+
+1. The `on_promote` callable passed to `__init__` (if any)
+2. `server._upgrade_to_gateway()` method on the bound server (if it exposes one)
+3. Fallback: logs a warning and returns `False`
+
+### Usage with DccServerBase
+
+`DccServerBase` integrates `DccGatewayElection` automatically:
+
+```python
+from dcc_mcp_core import DccServerBase
+
+class BlenderMcpServer(DccServerBase):
+    def __init__(self, **kwargs):
+        super().__init__(dcc_name="blender", builtin_skills_dir=..., **kwargs)
+
+server = BlenderMcpServer(gateway_port=9765)
+server.register_builtin_actions()
+handle = server.start()        # election thread starts automatically
+print(server._election.get_status())  # inspect election state
+```
+
+### Standalone Usage
+
+```python
+from dcc_mcp_core import DccGatewayElection
+
+# With a custom promotion callback
+def promote():
+    # Restart the MCP server with gateway port
+    return True
+
+election = DccGatewayElection(
+    dcc_name="blender",
+    server=my_server,
+    gateway_port=9765,
+    on_promote=promote,
+)
+election.start()
+
+# Later...
+status = election.get_status()
+# {"running": True, "consecutive_failures": 0, "gateway_host": "127.0.0.1", "gateway_port": 9765}
+
+election.stop()
+```

--- a/docs/zh/api/actions.md
+++ b/docs/zh/api/actions.md
@@ -1,6 +1,10 @@
-# Actions API
+# Tools API（工具 API）
 
 `dcc_mcp_core` — ToolRegistry、EventBus、ToolDispatcher、ToolValidator、SemVer、VersionConstraint、VersionedRegistry。
+
+:::: info Action → Tool 术语说明
+v0.13+ 项目在概念层面将 "action" 重命名为 "tool"。但部分 Rust API 方法名（`get_action`、`list_actions`、`search_actions`、`count_actions`、`register_batch(actions)`）仍使用 "action" 以保持向后兼容——这不是 bug，而是兼容别名。
+::::
 
 ## ToolRegistry
 
@@ -18,7 +22,7 @@ registry = ToolRegistry()
 | 方法 | 返回值 | 说明 |
 |------|--------|------|
 | `register(name, description="", category="", tags=[], dcc="python", version="1.0.0", input_schema=None, output_schema=None, source_file=None)` | — | 注册一个 Skill |
-| `register_batch(actions)` | — | 批量注册，传入字典列表（每个字典使用与 `register()` 相同的键；缺少 `name` 的条目被跳过）|
+| `register_batch(actions)` | — | 批量注册工具，传入字典列表（参数名 `actions` 为向后兼容；每个字典使用与 `register()` 相同的键）|
 | `unregister(name, dcc_name=None)` | `bool` | 移除 Skill。`dcc_name=None` 时全局移除；否则作用域限定。找到返回 `True` |
 | `get_action(name, dcc_name=None)` | `dict?` | 获取 Skill 元数据字典 |
 | `list_actions(dcc_name=None)` | `List[dict]` | 列出所有 Skill 的元数据字典 |
@@ -40,7 +44,7 @@ registry = ToolRegistry()
 
 ### Skill 元数据字典
 
-通过 `get_action()`、`list_actions()` 或 `search_actions()` 获取时，每个 Skill 是一个字典：
+通过 `get_action()`、`list_actions()` 或 `search_actions()` 获取时（方法名使用 "action" 以保持向后兼容），每个工具是一个字典：
 
 ```python
 {
@@ -186,7 +190,7 @@ def handler(params: dict) -> Any:
 
 | 方法 | 返回值 | 说明 |
 |------|--------|------|
-| `register_handler(action_name, handler)` | — | 注册一个 Python 可调用对象 |
+| `register_handler(action_name, handler)` | — | 注册一个 Python 可调用对象（参数名 `action_name` 为向后兼容） |
 | `remove_handler(action_name)` | `bool` | 移除处理器，存在返回 True |
 | `has_handler(action_name)` | `bool` | 检查处理器是否已注册 |
 | `handler_count()` | `int` | 已注册处理器数量 |
@@ -407,7 +411,7 @@ pipeline = ToolPipeline(dispatcher)
 
 | 方法 | 返回值 | 说明 |
 |------|--------|------|
-| `dispatch(action, params_json)` | `dict` | 通过所有中间件层进行调度 |
+| `dispatch(action, params_json)` | `dict` | 通过所有中间件层调度工具 |
 | `register_handler(name, fn)` | — | 注册 Python 处理器（与 `ToolDispatcher` 一致）|
 | `add_logging(log_params=False)` | — | 添加 trace 日志中间件 |
 | `add_timing()` | `TimingMiddleware` | 添加延迟统计；返回句柄 |
@@ -424,7 +428,7 @@ pipeline = ToolPipeline(dispatcher)
 
 | 键 | 类型 | 说明 |
 |----|------|------|
-| `action` | `str` | Skill 名称 |
+| `action` | `str` | 工具名称（字典键使用 "action" 以保持向后兼容） |
 | `output` | `Any` | 处理器返回值 |
 | `success` | `bool` | 无异常时为 `True` |
 | `error` | `str?` | 失败时的错误信息 |
@@ -451,12 +455,12 @@ count = audit.record_count()                     # int
 audit.clear()
 ```
 
-每条记录包含：`action`（str）、`success`（bool）、`error`（str | None）、`timestamp_ms`（int）。
+每条记录包含：`action`（str，工具名称——键名使用 "action" 以保持向后兼容）、`success`（bool）、`error`（str | None）、`timestamp_ms`（int）。
 
 | 方法 | 返回值 | 说明 |
 |------|--------|------|
 | `records()` | `List[dict]` | 所有审计记录 |
-| `records_for_action(name)` | `List[dict]` | 指定 Action 的记录 |
+| `records_for_action(name)` | `List[dict]` | 指定工具的记录（方法名使用 "action" 以保持向后兼容） |
 | `record_count()` | `int` | 总记录数 |
 | `clear()` | — | 清空所有记录 |
 

--- a/docs/zh/api/capture.md
+++ b/docs/zh/api/capture.md
@@ -13,15 +13,35 @@
 ```python
 from dcc_mcp_core import Capturer
 
+# 自动选择最佳后端
 capturer = Capturer.new_auto()
+
+# 单窗口捕获
+capturer = Capturer.new_window_auto()
+
+# 无头环境 / CI 测试
+capturer = Capturer.new_mock(width=1920, height=1080)
+print(f"Backend: {capturer.backend_name()}")
+count, total_bytes, errors = capturer.stats()
 ```
 
-### 方法
+### 静态方法
 
 | 方法 | 返回 | 描述 |
 |------|------|------|
-| `new_auto()` | `Capturer` | 使用最佳可用后端创建捕获器 |
-| `capture(format="png", jpeg_quality=85, scale=1.0, timeout_ms=5000, process_id=None, window_title=None)` | `CaptureFrame` | 捕获一帧 |
+| `new_auto()` | `Capturer` | 使用最佳可用后端创建捕获器（Windows: DXGI, Linux: X11, 其他: Mock） |
+| `new_window_auto()` | `Capturer` | 创建配置为单窗口捕获的捕获器（Windows: HWND PrintWindow；其他平台回退到 Mock） |
+| `new_mock(width=1920, height=1080)` | `Capturer` | 创建使用 Mock 合成后端的捕获器（用于 CI/无头环境） |
+
+### 实例方法
+
+| 方法 | 返回 | 描述 |
+|------|------|------|
+| `capture(format="png", jpeg_quality=85, scale=1.0, timeout_ms=5000, process_id=None, window_title=None)` | `CaptureFrame` | 捕获一帧（全屏，或当设置 `process_id`/`window_title` 时捕获匹配窗口） |
+| `capture_window(*, process_id=None, window_handle=None, window_title=None, format="png", jpeg_quality=85, scale=1.0, timeout_ms=5000, include_decorations=True)` | `CaptureFrame` | 捕获单个窗口。必须提供 `process_id`/`window_handle`/`window_title` 中的至少一个 |
+| `backend_name()` | `str` | 当前后端名称（如 `"DXGI Desktop Duplication"`、`"HWND PrintWindow"`） |
+| `backend_kind()` | `CaptureBackendKind` | 当前后端的枚举形式 |
+| `stats()` | `tuple[int, int, int]` | 运行统计：`(capture_count, total_bytes, error_count)` |
 
 ### CaptureFrame
 

--- a/docs/zh/api/http.md
+++ b/docs/zh/api/http.md
@@ -173,7 +173,7 @@ MCP 请求使用 JSON-RPC 2.0：
 ```python
 from dcc_mcp_core import ToolRegistry, McpHttpServer, McpHttpConfig
 
-# 构建 Action 注册表
+# 构建工具注册表
 registry = ToolRegistry()
 registry.register(
     "get_scene_info",

--- a/docs/zh/guide/gateway-election.md
+++ b/docs/zh/guide/gateway-election.md
@@ -185,3 +185,104 @@ mgr.deregister_service("maya", iid)
 ## 向后兼容性
 
 不支持 `/gateway/yield` 的旧版 DCC 会返回 404——这没问题。挑战者进入轮询重试循环，等待端口自然释放（当旧 DCC 退出或崩溃时）。无硬性失败，优雅降级。
+
+## DccGatewayElection（Python API）
+
+`DccGatewayElection` 是一个纯 Python 类，为非网关 DCC 实例提供**自动网关故障转移**。当当前网关不可达时，选举线程会自动尝试接管。
+
+### 工作原理
+
+1. 后台守护线程定期探测网关的 `/health` 端点
+2. 统计连续探测失败次数
+3. 当失败次数超过阈值时，尝试首次获胜的 TCP 端口检查
+4. 如果端口空闲，通知服务器升级为网关模式
+
+### 构造函数
+
+```python
+from dcc_mcp_core import DccGatewayElection
+
+election = DccGatewayElection(
+    dcc_name="blender",           # 日志中的 DCC 标识
+    server=blender_server,        # DCC 服务器实例（需暴露 is_gateway、is_running、_handle）
+    gateway_host="127.0.0.1",     # 网关绑定地址
+    gateway_port=9765,            # 竞争的网关端口
+    probe_interval=5,             # 健康探测间隔（秒）
+    probe_timeout=2.0,            # 每次探测超时（秒）
+    probe_failures=3,             # 触发选举前的连续失败次数
+    on_promote=None,              # 可选回调：() -> bool，覆盖 server._upgrade_to_gateway()
+)
+```
+
+### 环境变量配置
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `DCC_MCP_GATEWAY_PROBE_INTERVAL` | `5` | 健康探测间隔（秒） |
+| `DCC_MCP_GATEWAY_PROBE_TIMEOUT` | `2` | 每次探测超时（秒） |
+| `DCC_MCP_GATEWAY_PROBE_FAILURES` | `3` | 触发选举前的连续失败次数 |
+
+### 属性
+
+| 属性 | 类型 | 说明 |
+|------|------|------|
+| `is_running` | `bool` | 选举线程是否活跃 |
+| `consecutive_failures` | `int` | 当前连续网关探测失败次数 |
+
+### 方法
+
+| 方法 | 返回值 | 说明 |
+|------|--------|------|
+| `start()` | `None` | 启动后台选举线程（幂等） |
+| `stop()` | `None` | 优雅停止线程（最多等待 5 秒） |
+| `get_status()` | `dict` | 返回 `{running, consecutive_failures, gateway_host, gateway_port}` |
+
+### 提升路径
+
+选举获胜（端口空闲）时，按以下顺序解析提升路径：
+
+1. 传给 `__init__` 的 `on_promote` 可调用对象（如有）
+2. 绑定服务器上的 `server._upgrade_to_gateway()` 方法（如有）
+3. 回退：记录警告并返回 `False`
+
+### 与 DccServerBase 配合使用
+
+`DccServerBase` 已自动集成 `DccGatewayElection`：
+
+```python
+from dcc_mcp_core import DccServerBase
+
+class BlenderMcpServer(DccServerBase):
+    def __init__(self, **kwargs):
+        super().__init__(dcc_name="blender", builtin_skills_dir=..., **kwargs)
+
+server = BlenderMcpServer(gateway_port=9765)
+server.register_builtin_actions()
+handle = server.start()        # 选举线程自动启动
+print(server._election.get_status())  # 检查选举状态
+```
+
+### 独立使用
+
+```python
+from dcc_mcp_core import DccGatewayElection
+
+# 使用自定义提升回调
+def promote():
+    # 用网关端口重启 MCP 服务器
+    return True
+
+election = DccGatewayElection(
+    dcc_name="blender",
+    server=my_server,
+    gateway_port=9765,
+    on_promote=promote,
+)
+election.start()
+
+# 稍后...
+status = election.get_status()
+# {"running": True, "consecutive_failures": 0, "gateway_host": "127.0.0.1", "gateway_port": 9765}
+
+election.stop()
+```


### PR DESCRIPTION
## Summary

Fix outdated terminology and fill documentation gaps identified in a comprehensive audit of EN+ZH docs.

## Changes

### Terminology Fixes (action to tool)
- `docs/api/actions.md` (EN): Renamed title to "Tools API", added backward-compatibility note
- `docs/zh/api/actions.md` (ZH): Same terminology fixes as EN
- `docs/zh/api/http.md` (ZH): Fixed 7 places - handler params, MCP descriptions, error codes

### Missing API Documentation
- `docs/guide/gateway-election.md` (EN): Added DccGatewayElection Python API section
- `docs/zh/guide/gateway-election.md` (ZH): Same DccGatewayElection documentation in Chinese
- `docs/zh/api/capture.md` (ZH): Added new_window_auto(), capture_window(), new_mock(), backend_name(), backend_kind(), stats()

## Test Plan
- [x] Docs-only changes
- [x] Pre-commit hooks passed
- [ ] CI should pass
