### PR TITLE
feat: ServiceEntry.extras, capture PNG sugar, WebViewAdapter, IPC tool-rename

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ A Rust-powered MCP (Model Context Protocol) library that lets AI agents interact
 
 **Bind diagnostics tools to a specific DCC instance (multi-instance safe)?**
 → `DccServerBase(..., dcc_pid=pid, dcc_window_title=title, dcc_window_handle=hwnd, resolver=...)`
-→ Registers `diagnostics__screenshot` / `diagnostics__audit_log` / `diagnostics__action_metrics` / `diagnostics__process_status`
+→ Registers `diagnostics__screenshot` / `diagnostics__audit_log` / `diagnostics__tool_metrics` / `diagnostics__process_status`
 → Low-level: `register_diagnostic_mcp_tools(server, dcc_name=..., dcc_pid=...)` BEFORE `server.start()`
 
 **Limit tools surfaced to the LLM client (progressive exposure)?**

--- a/crates/dcc-mcp-actions/src/registry/mod.rs
+++ b/crates/dcc-mcp-actions/src/registry/mod.rs
@@ -56,6 +56,20 @@ pub struct ActionMeta {
     /// actions.
     #[serde(default = "default_enabled")]
     pub enabled: bool,
+    /// Host-DCC capabilities required for this action to be surfaced.
+    ///
+    /// When non-empty, Gateway / adapter implementations **should** hide
+    /// this action from ``tools/list`` on sessions whose host DCC does not
+    /// advertise every listed capability (see
+    /// [``WebViewAdapter.capabilities``](crate::adapters::webview) for the
+    /// pre-defined key set: ``"scene"``, ``"timeline"``, ``"selection"``,
+    /// ``"undo"``, ``"render"``).
+    ///
+    /// The registry itself does **not** perform filtering — filtering is
+    /// the responsibility of the consumer (Gateway, HTTP server, adapter).
+    /// Storing the declaration here avoids a separate side-table lookup.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_capabilities: Vec<String>,
 }
 
 fn default_enabled() -> bool {
@@ -77,6 +91,7 @@ impl Default for ActionMeta {
             skill_name: None,
             group: String::new(),
             enabled: true,
+            required_capabilities: Vec::new(),
         }
     }
 }
@@ -538,6 +553,12 @@ impl ActionRegistry {
                 .flatten()
                 .and_then(|v| v.extract().ok())
                 .unwrap_or(true);
+            let required_capabilities: Vec<String> = dict
+                .get_item("required_capabilities")
+                .ok()
+                .flatten()
+                .and_then(|v| v.extract().ok())
+                .unwrap_or_default();
 
             let input_schema =
                 parse_schema_or_default(input_schema_str.as_deref(), "input_schema", &name);
@@ -557,6 +578,7 @@ impl ActionRegistry {
                 skill_name,
                 group,
                 enabled,
+                required_capabilities,
             });
         }
     }
@@ -584,7 +606,7 @@ impl ActionRegistry {
 
     /// Register an action. Called from Python ActionManager.
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (name, description="".to_string(), category="".to_string(), tags=vec![], dcc=DEFAULT_DCC.to_string(), version=DEFAULT_VERSION.to_string(), input_schema=None, output_schema=None, source_file=None, skill_name=None, group="".to_string(), enabled=true))]
+    #[pyo3(signature = (name, description="".to_string(), category="".to_string(), tags=vec![], dcc=DEFAULT_DCC.to_string(), version=DEFAULT_VERSION.to_string(), input_schema=None, output_schema=None, source_file=None, skill_name=None, group="".to_string(), enabled=true, required_capabilities=None))]
     fn register(
         &self,
         name: String,
@@ -599,6 +621,7 @@ impl ActionRegistry {
         skill_name: Option<String>,
         group: String,
         enabled: bool,
+        required_capabilities: Option<Vec<String>>,
     ) {
         let input_schema = parse_schema_or_default(input_schema.as_deref(), "input_schema", &name);
         let output_schema =
@@ -617,6 +640,7 @@ impl ActionRegistry {
             skill_name,
             group,
             enabled,
+            required_capabilities: required_capabilities.unwrap_or_default(),
         });
     }
 

--- a/crates/dcc-mcp-actions/src/registry/tests.rs
+++ b/crates/dcc-mcp-actions/src/registry/tests.rs
@@ -201,6 +201,7 @@ fn test_action_meta_serde_round_trip() {
         skill_name: None,
         group: String::new(),
         enabled: true,
+        required_capabilities: vec!["scene".into(), "render".into()],
     };
     let json = serde_json::to_string(&meta).unwrap();
     let back: ActionMeta = serde_json::from_str(&json).unwrap();

--- a/crates/dcc-mcp-capture/src/python.rs
+++ b/crates/dcc-mcp-capture/src/python.rs
@@ -303,9 +303,132 @@ impl PyCapturer {
         self.inner.stats().snapshot()
     }
 
+    /// Capture a single window as PNG bytes, looked up by process ID.
+    ///
+    /// This is a sugar wrapper intended for the common "grab a snapshot of a
+    /// DCC window, attach it to a chat message" workflow — no ``Capturer``
+    /// instance needed.  Internally creates a window-auto capturer, captures,
+    /// and returns the PNG-encoded bytes.
+    ///
+    /// Parameters
+    /// ----------
+    /// pid : int
+    ///     OS process ID of the DCC to capture.
+    /// timeout_ms : int, optional
+    ///     Max milliseconds to wait for the frame (default 1000).
+    ///
+    /// Returns
+    /// -------
+    /// bytes | None
+    ///     PNG-encoded bytes on success; ``None`` when the process has no
+    ///     visible top-level window or the backend is unavailable (the
+    ///     function never raises for capture errors — use the instance
+    ///     :py:meth:`capture_window` API when you need exceptions).
+    #[staticmethod]
+    #[pyo3(signature = (pid, *, timeout_ms=1000))]
+    fn capture_window_png(py: Python<'_>, pid: u32, timeout_ms: u64) -> PyResult<Py<PyAny>> {
+        let cfg = CaptureConfig::builder()
+            .format(CaptureFormat::Png)
+            .timeout_ms(timeout_ms)
+            .target(CaptureTarget::ProcessId(pid))
+            .build();
+        let capturer = Capturer::new_window_auto();
+        match capturer.capture(&cfg) {
+            Ok(frame) => Ok(pyo3::types::PyBytes::new(py, &frame.data)
+                .unbind()
+                .into_any()),
+            Err(e) => {
+                tracing::debug!(?pid, error = %e, "capture_window_png returning None");
+                Ok(py.None())
+            }
+        }
+    }
+
+    /// Capture a cropped rectangle of a window as PNG bytes, looked up by PID.
+    ///
+    /// The window is captured first (via the same backend as
+    /// :py:meth:`capture_window_png`) and the ``(x, y, w, h)`` region is
+    /// cropped in CPU before re-encoding.  Coordinates are in window-local
+    /// pixels relative to the top-left of the window rectangle.
+    ///
+    /// Parameters
+    /// ----------
+    /// pid, x, y, w, h : int
+    /// timeout_ms : int, optional (default 1000)
+    ///
+    /// Returns
+    /// -------
+    /// bytes | None
+    ///     PNG-encoded cropped bytes on success; ``None`` on any failure
+    ///     (window not found, crop out of bounds, decode error, ...).
+    #[staticmethod]
+    #[pyo3(signature = (pid, x, y, w, h, *, timeout_ms=1000))]
+    #[allow(clippy::too_many_arguments)]
+    fn capture_region_png(
+        py: Python<'_>,
+        pid: u32,
+        x: u32,
+        y: u32,
+        w: u32,
+        h: u32,
+        timeout_ms: u64,
+    ) -> PyResult<Py<PyAny>> {
+        if w == 0 || h == 0 {
+            return Ok(py.None());
+        }
+        let cfg = CaptureConfig::builder()
+            .format(CaptureFormat::Png)
+            .timeout_ms(timeout_ms)
+            .target(CaptureTarget::ProcessId(pid))
+            .build();
+        let capturer = Capturer::new_window_auto();
+        let frame = match capturer.capture(&cfg) {
+            Ok(f) => f,
+            Err(e) => {
+                tracing::debug!(?pid, error = %e, "capture_region_png capture failed");
+                return Ok(py.None());
+            }
+        };
+        match crop_png_bytes(&frame.data, x, y, w, h) {
+            Ok(bytes) => Ok(pyo3::types::PyBytes::new(py, &bytes).unbind().into_any()),
+            Err(e) => {
+                tracing::debug!(?pid, ?x, ?y, ?w, ?h, error = %e, "capture_region_png crop failed");
+                Ok(py.None())
+            }
+        }
+    }
+
     fn __repr__(&self) -> String {
         format!("Capturer(backend='{}')", self.backend_name())
     }
+}
+
+/// Decode a PNG, crop to ``(x, y, w, h)`` and re-encode as PNG.
+///
+/// Returns the raw PNG bytes on success, or an error string describing the
+/// failure (decode error, crop out of bounds, encode error).
+#[cfg(feature = "python-bindings")]
+fn crop_png_bytes(png: &[u8], x: u32, y: u32, w: u32, h: u32) -> Result<Vec<u8>, String> {
+    use image::ImageFormat;
+    let img = image::load_from_memory_with_format(png, ImageFormat::Png)
+        .map_err(|e| format!("decode: {}", e))?;
+    if x.saturating_add(w) > img.width() || y.saturating_add(h) > img.height() {
+        return Err(format!(
+            "crop ({},{},{},{}) out of bounds {}x{}",
+            x,
+            y,
+            w,
+            h,
+            img.width(),
+            img.height()
+        ));
+    }
+    let cropped = img.crop_imm(x, y, w, h);
+    let mut out = Vec::with_capacity((w * h * 4) as usize);
+    cropped
+        .write_to(&mut std::io::Cursor::new(&mut out), ImageFormat::Png)
+        .map_err(|e| format!("encode: {}", e))?;
+    Ok(out)
 }
 
 // ── PyCaptureTarget ────────────────────────────────────────────────────────

--- a/crates/dcc-mcp-skills/src/catalog/mod.rs
+++ b/crates/dcc-mcp-skills/src/catalog/mod.rs
@@ -363,6 +363,7 @@ impl SkillCatalog {
                 // default-active; default groups (empty group name or an
                 // explicitly default-active group) stay enabled.
                 enabled: group_default_active(&metadata.groups, &tool_decl.group),
+                required_capabilities: Vec::new(),
             };
 
             self.registry.register_action(meta);
@@ -400,6 +401,7 @@ impl SkillCatalog {
                     skill_name: Some(skill_name.to_string()),
                     group: String::new(),
                     enabled: true,
+                    required_capabilities: Vec::new(),
                 };
 
                 self.registry.register_action(meta);

--- a/crates/dcc-mcp-transport/Cargo.toml
+++ b/crates/dcc-mcp-transport/Cargo.toml
@@ -18,6 +18,7 @@ thiserror = { workspace = true }
 uuid = { workspace = true }
 tokio = { workspace = true }
 rmp-serde = { workspace = true }
+dcc-mcp-utils = { workspace = true, optional = true }
 
 [dev-dependencies]
 rstest = "0.26"
@@ -26,4 +27,4 @@ tokio = { workspace = true, features = ["test-util"] }
 
 [features]
 default = []
-python-bindings = ["pyo3"]
+python-bindings = ["pyo3", "dcc-mcp-utils/python-bindings"]

--- a/crates/dcc-mcp-transport/src/discovery/types.rs
+++ b/crates/dcc-mcp-transport/src/discovery/types.rs
@@ -109,6 +109,15 @@ pub struct ServiceEntry {
     /// Arbitrary metadata.
     #[serde(default)]
     pub metadata: HashMap<String, String>,
+    /// Arbitrary DCC-specific extras as JSON-typed values.
+    ///
+    /// Unlike [`metadata`] which is restricted to strings, `extras` allows
+    /// nested objects / arrays / numbers / booleans.  Use for WebView / bridge
+    /// specific fields such as `cdp_port`, `url`, `window_title`, `host_dcc`.
+    ///
+    /// Round-trips losslessly through `services.json` (JSON value preserved).
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub extras: HashMap<String, serde_json::Value>,
     /// When this service was registered.
     pub registered_at: SystemTime,
     /// Last heartbeat timestamp.
@@ -134,6 +143,7 @@ impl ServiceEntry {
             pid: None,
             display_name: None,
             metadata: HashMap::new(),
+            extras: HashMap::new(),
             registered_at: now,
             last_heartbeat: now,
             status: ServiceStatus::Available,
@@ -161,6 +171,7 @@ impl ServiceEntry {
             pid: None,
             display_name: None,
             metadata: HashMap::new(),
+            extras: HashMap::new(),
             registered_at: now,
             last_heartbeat: now,
             status: ServiceStatus::Available,
@@ -234,6 +245,45 @@ mod tests {
         assert!(entry.version.is_none());
         assert!(entry.scene.is_none());
         assert!(entry.transport_address.is_none());
+        assert!(entry.extras.is_empty());
+    }
+
+    #[test]
+    fn test_service_entry_extras_roundtrip() {
+        let mut entry = ServiceEntry::new("webview", "127.0.0.1", 3000);
+        entry
+            .extras
+            .insert("cdp_port".into(), serde_json::json!(9222));
+        entry
+            .extras
+            .insert("url".into(), serde_json::json!("http://localhost:3000"));
+        entry.extras.insert(
+            "capabilities".into(),
+            serde_json::json!({"scene": false, "timeline": true}),
+        );
+
+        let json = serde_json::to_string(&entry).unwrap();
+        let parsed: ServiceEntry = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.extras, entry.extras);
+        assert_eq!(parsed.extras["cdp_port"], serde_json::json!(9222));
+        assert_eq!(
+            parsed.extras["capabilities"]["timeline"],
+            serde_json::json!(true)
+        );
+    }
+
+    #[test]
+    fn test_service_entry_empty_extras_omitted_from_json() {
+        let entry = ServiceEntry::new("maya", "127.0.0.1", 18812);
+        let json = serde_json::to_string(&entry).unwrap();
+        // `skip_serializing_if = "HashMap::is_empty"` keeps services.json small
+        // when no extras were set — preserves backward-compatible file format.
+        assert!(
+            !json.contains("\"extras\""),
+            "empty extras should be omitted, got: {}",
+            json
+        );
     }
 
     #[test]

--- a/crates/dcc-mcp-transport/src/python/helpers.rs
+++ b/crates/dcc-mcp-transport/src/python/helpers.rs
@@ -30,3 +30,13 @@ pub(super) fn session_to_py(py: Python, session: &crate::session::Session) -> Py
     let _ = dict.set_item("reconnect_attempts", session.reconnect_attempts);
     dict.unbind().into_any()
 }
+
+/// Re-export of [`dcc_mcp_utils::py_json::json_value_to_bound_py`] under the
+/// historical transport-crate name used by `PyServiceEntry::extras` getter.
+#[cfg(feature = "python-bindings")]
+pub(crate) use dcc_mcp_utils::py_json::json_value_to_bound_py as json_value_to_py;
+
+/// Re-export of [`dcc_mcp_utils::py_json::py_any_to_json_value`] under the
+/// historical transport-crate name used by `register_service(extras=...)`.
+#[cfg(feature = "python-bindings")]
+pub(crate) use dcc_mcp_utils::py_json::py_any_to_json_value as py_to_json_value;

--- a/crates/dcc-mcp-transport/src/python/manager.rs
+++ b/crates/dcc-mcp-transport/src/python/manager.rs
@@ -158,13 +158,9 @@ impl PyTransportManager {
         if let Some(ex) = extras {
             let mut out = HashMap::with_capacity(ex.len());
             for (k, v) in ex.iter() {
-                let key = k
-                    .extract::<String>()
-                    .map_err(|_| {
-                        pyo3::exceptions::PyTypeError::new_err(
-                            "extras dict keys must be strings",
-                        )
-                    })?;
+                let key = k.extract::<String>().map_err(|_| {
+                    pyo3::exceptions::PyTypeError::new_err("extras dict keys must be strings")
+                })?;
                 out.insert(key, super::helpers::py_to_json_value(&v)?);
             }
             entry.extras = out;

--- a/crates/dcc-mcp-transport/src/python/manager.rs
+++ b/crates/dcc-mcp-transport/src/python/manager.rs
@@ -116,16 +116,19 @@ impl PyTransportManager {
     ///     documents: All open documents for multi-document apps like Photoshop (optional list).
     ///     pid: OS process ID — used to disambiguate instances with the same scene (optional).
     ///     display_name: Human-readable label, e.g. "Maya-Rigging" (optional).
-    ///     metadata: Arbitrary metadata dict (optional).
+    ///     metadata: Arbitrary string metadata dict (optional).
     ///     transport_address: Preferred transport address (optional). When provided,
     ///         enables IPC registration (Named Pipe / Unix Socket) for lower latency.
     ///         Use TransportAddress.default_local(dcc_type, pid) to auto-select the
     ///         optimal IPC transport for the current platform.
+    ///     extras: Arbitrary DCC-specific extras dict with JSON-compatible values
+    ///         (dict / list / int / float / str / bool / None) — useful for
+    ///         WebView / bridge specific fields such as ``cdp_port`` or ``url``.
     ///
     /// Returns:
     ///     The instance_id (UUID string) of the registered service.
     #[pyo3(name = "register_service")]
-    #[pyo3(signature = (dcc_type, host, port, version=None, scene=None, documents=None, pid=None, display_name=None, metadata=None, transport_address=None))]
+    #[pyo3(signature = (dcc_type, host, port, version=None, scene=None, documents=None, pid=None, display_name=None, metadata=None, transport_address=None, extras=None))]
     fn py_register_service(
         &self,
         dcc_type: &str,
@@ -138,6 +141,7 @@ impl PyTransportManager {
         display_name: Option<String>,
         metadata: Option<HashMap<String, String>>,
         transport_address: Option<PyRef<'_, super::types::PyTransportAddress>>,
+        extras: Option<Bound<'_, pyo3::types::PyDict>>,
     ) -> PyResult<String> {
         let mut entry = ServiceEntry::new(dcc_type, host, port);
         entry.version = version;
@@ -150,6 +154,20 @@ impl PyTransportManager {
         }
         if let Some(addr) = transport_address {
             entry.transport_address = Some(addr.inner.clone());
+        }
+        if let Some(ex) = extras {
+            let mut out = HashMap::with_capacity(ex.len());
+            for (k, v) in ex.iter() {
+                let key = k
+                    .extract::<String>()
+                    .map_err(|_| {
+                        pyo3::exceptions::PyTypeError::new_err(
+                            "extras dict keys must be strings",
+                        )
+                    })?;
+                out.insert(key, super::helpers::py_to_json_value(&v)?);
+            }
+            entry.extras = out;
         }
         let instance_id = entry.instance_id.to_string();
         self.inner

--- a/crates/dcc-mcp-transport/src/python/types.rs
+++ b/crates/dcc-mcp-transport/src/python/types.rs
@@ -428,51 +428,69 @@ impl From<&PyTransportScheme> for TransportScheme {
 /// print(entry.status)        # ServiceStatus.AVAILABLE
 /// ```
 #[cfg(feature = "python-bindings")]
-#[pyclass(name = "ServiceEntry", get_all, from_py_object)]
+#[pyclass(name = "ServiceEntry", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct PyServiceEntry {
     /// DCC application type (e.g. "maya", "houdini", "blender").
+    #[pyo3(get)]
     pub dcc_type: String,
     /// Unique instance identifier (UUID string).
+    #[pyo3(get)]
     pub instance_id: String,
     /// Host address.
+    #[pyo3(get)]
     pub host: String,
     /// Port number.
+    #[pyo3(get)]
     pub port: u16,
     /// DCC application version (e.g. "2024.2").
+    #[pyo3(get)]
     pub version: Option<String>,
     /// Currently active scene / document.
     ///
     /// For single-document DCCs this is the open file path.
     /// For multi-document apps (Photoshop) this is the **focused** document.
+    #[pyo3(get)]
     pub scene: Option<String>,
     /// All documents currently open in this instance.
     ///
     /// Empty for DCCs that only support one document at a time.
     /// For multi-document apps each element is a file path.
+    #[pyo3(get)]
     pub documents: Vec<String>,
     /// OS process ID of the DCC process.
     ///
     /// Useful for disambiguating two instances of the same DCC type
     /// that have the same scene open.
+    #[pyo3(get)]
     pub pid: Option<u32>,
     /// Human-readable label for this instance (e.g. `"Maya-Rigging"`).
     ///
     /// Set by the bridge plugin at registration time.  Displayed by the
     /// agent when asking the user to choose between multiple instances.
+    #[pyo3(get)]
     pub display_name: Option<String>,
     /// Arbitrary metadata.
+    #[pyo3(get)]
     pub metadata: HashMap<String, String>,
     /// Current service status.
+    #[pyo3(get)]
     pub status: PyServiceStatus,
     /// Transport address (None = TCP host:port).
+    #[pyo3(get)]
     pub transport_address: Option<PyTransportAddress>,
     /// Last heartbeat timestamp in milliseconds since Unix epoch.
     ///
     /// Useful for `LazySessionPool` implementations to determine if a session
     /// has been idle too long and should be evicted.  Updated by
     /// :meth:`TransportManager.heartbeat`.
+    #[pyo3(get)]
     pub last_heartbeat_ms: u64,
+    /// Arbitrary DCC-specific extras as JSON-typed values.
+    ///
+    /// Exposed to Python via the [`extras`] property getter which returns
+    /// a fresh `dict[str, Any]` with nested JSON values recursively converted.
+    pub(super) extras: HashMap<String, serde_json::Value>,
 }
 
 #[cfg(feature = "python-bindings")]
@@ -521,10 +539,25 @@ impl PyServiceEntry {
         dict.set_item("metadata", &self.metadata)?;
         dict.set_item("status", self.status.__str__())?;
         dict.set_item("last_heartbeat_ms", self.last_heartbeat_ms)?;
+        dict.set_item("extras", self.extras(py)?)?;
         if let Some(addr) = &self.transport_address {
             dict.set_item("transport_address", addr.to_connection_string())?;
         }
         Ok(dict.unbind().into_any())
+    }
+
+    /// Arbitrary DCC-specific extras as a `dict[str, Any]`.
+    ///
+    /// Nested JSON values (objects / arrays / numbers / booleans / nulls) are
+    /// recursively converted into native Python types.  Returns an empty dict
+    /// when no extras were registered.
+    #[getter]
+    fn extras<'py>(&self, py: Python<'py>) -> PyResult<Py<PyDict>> {
+        let dict = PyDict::new(py);
+        for (k, v) in &self.extras {
+            dict.set_item(k, crate::python::helpers::json_value_to_py(py, v)?)?;
+        }
+        Ok(dict.unbind())
     }
 }
 
@@ -553,6 +586,7 @@ impl From<&ServiceEntry> for PyServiceEntry {
                 .as_ref()
                 .map(PyTransportAddress::from),
             last_heartbeat_ms,
+            extras: entry.extras.clone(),
         }
     }
 }

--- a/docs/api/actions.md
+++ b/docs/api/actions.md
@@ -21,7 +21,7 @@ registry = ToolRegistry()
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `register(name, description="", category="", tags=[], dcc="python", version="1.0.0", input_schema=None, output_schema=None, source_file=None)` | — | Register a skill |
+| `register(name, description="", category="", tags=[], dcc="python", version="1.0.0", input_schema=None, output_schema=None, source_file=None, skill_name=None, group="", enabled=True, required_capabilities=None)` | — | Register a skill. `required_capabilities` is an optional `list[str]` of host-DCC capability keys (see [Capability-Based Filtering](#capability-based-filtering)) |
 | `register_batch(actions)` | — | Register multiple tools from a list of dicts (parameter named `actions` for backward compat; each dict uses same keys as `register()`) |
 | `unregister(name, dcc_name=None)` | `bool` | Remove a skill. If `dcc_name=None`, removes globally; otherwise scoped. Returns `True` if found |
 | `get_action(name, dcc_name=None)` | `dict?` | Get skill metadata as dict |
@@ -90,6 +90,36 @@ reg.register_batch([
 removed = reg.unregister("create_sphere")                  # global: True if found
 removed = reg.unregister("create_sphere", dcc_name="maya") # scoped to maya only
 ```
+
+### Capability-Based Filtering
+
+Tools may declare the host-DCC capabilities they rely on at registration time.
+The registry stores the declaration on `ActionMeta.required_capabilities`; the
+Gateway / adapter layer is responsible for hiding the tool from `tools/list`
+when the current session advertises none or a subset of those capabilities.
+
+Built-in keys are exposed through `dcc_mcp_core.CAPABILITY_KEYS`
+(`{"scene", "timeline", "selection", "undo", "render"}`); adapters are free to
+extend the set via `DccCapabilities.extensions`.
+
+```python
+from dcc_mcp_core import ToolRegistry, CAPABILITY_KEYS
+
+reg = ToolRegistry()
+reg.register(
+    "export_playblast",
+    description="Export a timeline playblast",
+    dcc="maya",
+    required_capabilities=["scene", "timeline", "render"],
+)
+
+meta = reg.get_action("export_playblast", dcc_name="maya")
+# Empty lists are elided from the serialized dict; use .get() for safety.
+assert meta.get("required_capabilities", []) == ["scene", "timeline", "render"]
+```
+
+The reference predicate consuming this field lives at
+[`dcc_mcp_core.adapters.WebViewAdapter.matches_requirements`](https://github.com/loonghao/dcc-mcp-core/blob/main/python/dcc_mcp_core/adapters/webview.py).
 
 ## ToolValidator
 

--- a/docs/api/capture.md
+++ b/docs/api/capture.md
@@ -23,6 +23,8 @@ capturer = Capturer.new_auto()
 | `new_auto()` | `Capturer` | Create capturer with best available backend (full-screen / display) |
 | `new_window_auto()` | `Capturer` | Create capturer configured for single-window capture (HWND PrintWindow on Windows; Mock elsewhere) |
 | `new_mock(width=1920, height=1080)` | `Capturer` | Create capturer with mock backend (for testing/CI) |
+| `capture_window_png(pid, *, timeout_ms=1000)` | `bytes \| None` | One-shot helper: resolve the main window of `pid`, capture it, return PNG-encoded bytes. Returns `None` on any failure (window not found, backend error, …) instead of raising |
+| `capture_region_png(pid, x, y, w, h, *, timeout_ms=1000)` | `bytes \| None` | One-shot helper: capture window of `pid` and CPU-crop to the rectangle `(x, y, w, h)` (window-local pixels). Zero-width / zero-height regions short-circuit to `None` without touching the backend |
 
 ### Methods
 
@@ -106,6 +108,24 @@ if info is not None:
 # Enumerate every visible top-level window
 for info in finder.enumerate():
     print(info.handle, info.title)
+```
+
+### One-shot PNG sugar
+
+When a caller only needs PNG bytes for a single window and does not want to
+manage a `Capturer` instance, use the static helpers. They swallow every
+failure mode (window not found, backend error, decode error, out-of-bounds
+crop) and return `None`:
+
+```python
+from dcc_mcp_core import Capturer
+
+png = Capturer.capture_window_png(pid=12345, timeout_ms=1000)
+if png is not None:
+    Path("maya.png").write_bytes(png)
+
+# CPU-crop to a sub-rectangle (window-local coordinates, no backend change)
+thumb = Capturer.capture_region_png(12345, 0, 0, 320, 180, timeout_ms=1000)
 ```
 
 ### `CaptureTarget`

--- a/docs/api/transport.md
+++ b/docs/api/transport.md
@@ -164,7 +164,8 @@ Represents a discovered DCC service instance.
 | `port` | `int` | TCP port |
 | `version` | `str \| None` | DCC version |
 | `scene` | `str \| None` | Currently open scene/file |
-| `metadata` | `dict[str, str]` | Arbitrary metadata |
+| `metadata` | `dict[str, str]` | Arbitrary string-only metadata |
+| `extras` | `dict[str, Any]` | JSON-typed DCC metadata (e.g. `cdp_port`, `pid`, nested config) — empty dict when unset |
 | `status` | `ServiceStatus` | Instance status |
 | `transport_address` | `TransportAddress \| None` | Preferred IPC address |
 | `last_heartbeat_ms` | `int` | Last heartbeat timestamp (Unix ms) |
@@ -215,7 +216,7 @@ mgr = TransportManager(
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `register_service(dcc_type, host, port, version=None, scene=None, metadata=None, transport_address=None)` | `str` | Register a service, returns instance_id (UUID) |
+| `register_service(dcc_type, host, port, version=None, scene=None, metadata=None, transport_address=None, extras=None)` | `str` | Register a service, returns instance_id (UUID). `extras` accepts a `dict[str, Any]` of JSON-typed metadata (nested dicts / lists / numbers allowed) |
 | `deregister_service(dcc_type, instance_id)` | `bool` | Deregister a service by key |
 | `list_instances(dcc_type)` | `list[ServiceEntry]` | List all instances for a DCC type |
 | `list_all_services()` | `list[ServiceEntry]` | List all registered services |
@@ -240,6 +241,30 @@ instance_id = mgr.register_service(
     transport_address=addr,
 )
 ```
+
+#### `register_service` — JSON-typed `extras`
+
+`metadata=` only accepts flat `dict[str, str]`. When the DCC needs to advertise
+numeric ports, nested objects, or typed flags, pass them through `extras=`:
+
+```python
+instance_id = mgr.register_service(
+    "photoshop", "127.0.0.1", 8888,
+    version="2024",
+    extras={
+        "cdp_port": 9222,              # integer survives the round-trip
+        "pid": os.getpid(),
+        "features": {"webview": True}, # nested dict is preserved
+    },
+)
+
+entry = mgr.get_service("photoshop", instance_id)
+assert entry.extras["cdp_port"] == 9222
+assert entry.extras["features"]["webview"] is True
+```
+
+`extras` defaults to `{}` and is omitted from the on-disk `services.json` when
+empty, so legacy registries remain byte-identical.
 
 ### Smart Routing
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -161,7 +161,7 @@ class MayaServer(DccServerBase):
 
 server = MayaServer(pid=12345, window_title="Autodesk Maya 2024")
 handle = server.start()  # exposes diagnostics__screenshot / audit_log /
-                         # action_metrics / process_status tools bound to
+                         # tool_metrics / process_status tools bound to
                          # this Maya instance only
 ```
 

--- a/examples/skills/dcc-diagnostics/SKILL.md
+++ b/examples/skills/dcc-diagnostics/SKILL.md
@@ -63,28 +63,28 @@ tools:
     idempotent: true
     source_file: scripts/audit_log.py
     next-tools:
-      on-success: [dcc_diagnostics__action_metrics]
+      on-success: [dcc_diagnostics__tool_metrics]
       on-failure: []
 
-  - name: action_metrics
-    description: "Show performance metrics for registered actions — invocation counts, success rates, average and P95/P99 latencies. Use to identify slow or failing tools."
+  - name: tool_metrics
+    description: "Show performance metrics for registered tools — invocation counts, success rates, average and P95/P99 latencies. Use to identify slow or failing tools."
     input_schema:
       type: object
       properties:
         action_name:
           type: string
-          description: "If provided, return metrics only for this action. Otherwise return all."
+          description: "If provided, return metrics only for this tool. Otherwise return all."
         sort_by:
           type: string
           description: "Sort results by: 'name', 'invocations' (default), 'avg_ms', 'p95_ms', or 'failure_rate'"
           default: invocations
         limit:
           type: integer
-          description: "Maximum number of actions to return (default 20)."
+          description: "Maximum number of tools to return (default 20)."
           default: 20
     read_only: true
     idempotent: true
-    source_file: scripts/action_metrics.py
+    source_file: scripts/tool_metrics.py
     next-tools:
       on-success: [dcc_diagnostics__process_status]
       on-failure: []
@@ -126,11 +126,11 @@ Backed by the `dcc_mcp_core.Capturer` class which uses:
 ### `dcc_diagnostics__audit_log`
 
 Query the sandbox audit log from `dcc_mcp_core.SandboxContext`.
-Returns recent action invocations with outcome (success/denied) and timestamps.
+Returns recent tool invocations with outcome (success/denied) and timestamps.
 
-### `dcc_diagnostics__action_metrics`
+### `dcc_diagnostics__tool_metrics`
 
-Inspect per-action performance counters from `dcc_mcp_core.ToolRecorder`:
+Inspect per-tool performance counters from `dcc_mcp_core.ToolRecorder`:
 invocation count, success rate, average latency, P95/P99 percentiles.
 
 ### `dcc_diagnostics__process_status`

--- a/examples/skills/dcc-diagnostics/scripts/audit_log.py
+++ b/examples/skills/dcc-diagnostics/scripts/audit_log.py
@@ -144,7 +144,7 @@ def main() -> None:
                 ),
                 "prompt": (
                     "Audit log retrieved. If entries show 'denied' outcomes, check the SandboxPolicy. "
-                    "Use dcc_diagnostics__action_metrics to see performance data, or "
+                    "Use dcc_diagnostics__tool_metrics to see performance data, or "
                     "dcc_diagnostics__screenshot to capture what's currently visible."
                 ),
                 "context": {

--- a/examples/skills/dcc-diagnostics/scripts/screenshot.py
+++ b/examples/skills/dcc-diagnostics/scripts/screenshot.py
@@ -68,7 +68,7 @@ def main() -> None:
                 "prompt": (
                     "Screenshot captured. You can view the image data in the 'image_base64' field. "
                     "If you see an error on screen, use dcc_diagnostics__audit_log to check recent "
-                    "action history, or dcc_diagnostics__action_metrics to find failing tools."
+                    "tool history, or dcc_diagnostics__tool_metrics to find failing tools."
                 ),
                 "context": {
                     "width": frame.width,

--- a/examples/skills/dcc-diagnostics/scripts/tool_metrics.py
+++ b/examples/skills/dcc-diagnostics/scripts/tool_metrics.py
@@ -1,8 +1,8 @@
-"""Inspect per-action performance metrics.
+"""Inspect per-tool performance metrics.
 
 Data source priority:
 1. IPC callback — if DCC_MCP_IPC_ADDRESS is set, connect to the running DCC
-   server and call 'get_action_metrics' to get live recorder data.
+   server and call 'get_tool_metrics' to get live recorder data.
 2. Local ToolRecorder — creates a fresh (empty) recorder as a fallback,
    useful for testing without a running DCC server.
 """
@@ -24,7 +24,7 @@ _SORT_KEYS = {
 
 
 def _fetch_via_ipc(ipc_address: str, action_name: str | None) -> dict | None:
-    """Connect to the DCC server via IPC and call 'get_action_metrics'."""
+    """Connect to the DCC server via IPC and call 'get_tool_metrics'."""
     try:
         from dcc_mcp_core import TransportAddress
         from dcc_mcp_core import connect_ipc
@@ -39,7 +39,7 @@ def _fetch_via_ipc(ipc_address: str, action_name: str | None) -> dict | None:
 
     try:
         params = json.dumps({"action_name": action_name}).encode()
-        result = channel.call("get_action_metrics", params, timeout_ms=10000)
+        result = channel.call("get_tool_metrics", params, timeout_ms=10000)
         channel.shutdown()
 
         if not result.get("success"):
@@ -87,7 +87,6 @@ def _metric_to_dict(metric) -> dict:
 
 
 def main() -> None:
-    """Show action performance metrics and print JSON result to stdout."""
     parser = argparse.ArgumentParser(description="Show action performance metrics.")
     parser.add_argument("--action-name", default=None, dest="action_name")
     parser.add_argument("--sort-by", default="invocations", choices=list(_SORT_KEYS), dest="sort_by")

--- a/examples/skills/workflow/scripts/run_chain.py
+++ b/examples/skills/workflow/scripts/run_chain.py
@@ -2,7 +2,7 @@
 
 Dispatch strategy:
 1. IPC dispatch — if DCC_MCP_IPC_ADDRESS is set, each step is sent to the
-   running DCC server via FramedChannel.call("dispatch_action", ...).
+   running DCC server via FramedChannel.call("dispatch_tool", ...).
    This is the production path (Maya, Blender, Unreal, etc.).
 2. Local ToolDispatcher — fallback for testing without a live DCC server.
    Only actions registered in the local process are available.
@@ -51,7 +51,7 @@ def _build_ipc_dispatcher(ipc_address: str):
         channel = connect_ipc(addr, timeout_ms=5000)
         try:
             payload = json.dumps({"action": action_name, "params": params}).encode()
-            result = channel.call("dispatch_action", payload, timeout_ms=30000)
+            result = channel.call("dispatch_tool", payload, timeout_ms=30000)
             if not result.get("success"):
                 return {"success": False, "message": f"IPC dispatch error: {result.get('error')}"}
             raw = result.get("payload", b"{}")

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1780,7 +1780,7 @@ handle = server.start()
 # Registers the four diagnostics tools bound to this instance:
 #   diagnostics__screenshot
 #   diagnostics__audit_log
-#   diagnostics__action_metrics
+#   diagnostics__tool_metrics   (renamed from diagnostics__action_metrics in 0.14.0)
 #   diagnostics__process_status
 ```
 

--- a/llms.txt
+++ b/llms.txt
@@ -242,7 +242,8 @@ crates/
 ### Instance-Bound Diagnostics (`dcc_mcp_core`)
 
 - `DccServerBase(dcc_name, builtin_skills_dir, *, dcc_pid=None, dcc_window_title=None, dcc_window_handle=None, resolver=None)` — bind an adapter to a specific DCC instance; the four `diagnostics__*` tools target this DCC only
-- `register_diagnostic_mcp_tools(server, *, dcc_name, dcc_pid=None, dcc_window_handle=None, dcc_window_title=None, resolver=None)` — register `diagnostics__screenshot`, `diagnostics__audit_log`, `diagnostics__action_metrics`, `diagnostics__process_status` on an `McpHttpServer` before `.start()`
+- `register_diagnostic_mcp_tools(server, *, dcc_name, dcc_pid=None, dcc_window_handle=None, dcc_window_title=None, resolver=None)` — register `diagnostics__screenshot`, `diagnostics__audit_log`, `diagnostics__tool_metrics`, `diagnostics__process_status` on an `McpHttpServer` before `.start()`
+- IPC handlers (renamed in 0.14.0, no compat aliases): `get_audit_log`, `get_tool_metrics` (was `get_action_metrics`), `dispatch_tool` (was `dispatch_action`), `take_screenshot`
 - `register_diagnostic_handlers(...)` — the IPC-path equivalent (used by `DccServerBase.start()`)
 - Bundled `dcc-diagnostics` skill's `screenshot.py` tries `DCC_MCP_OWNER_IPC` → `channel.call("take_screenshot")` first and falls back to `Capturer.new_auto()` when no owner IPC is set
 

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -201,6 +201,12 @@ from dcc_mcp_core.skill import skill_exception
 from dcc_mcp_core.skill import skill_success
 from dcc_mcp_core.skill import skill_warning
 
+# Adapters (pure-Python, non-DccServerBase)
+from dcc_mcp_core.adapters import CAPABILITY_KEYS
+from dcc_mcp_core.adapters import WEBVIEW_DEFAULT_CAPABILITIES
+from dcc_mcp_core.adapters import WebViewAdapter
+from dcc_mcp_core.adapters import WebViewContext
+
 __version__: str
 try:
     __version__ = _core.__version__  # type: ignore[attr-defined]
@@ -225,6 +231,8 @@ __all__ = [
     "SKILL_METADATA_DIR",
     "SKILL_METADATA_FILE",
     "SKILL_SCRIPTS_DIR",
+    "CAPABILITY_KEYS",
+    "WEBVIEW_DEFAULT_CAPABILITIES",
     "AuditEntry",
     "AuditLog",
     "AuditMiddleware",
@@ -320,6 +328,8 @@ __all__ = [
     "VersionConstraint",
     "VersionedRegistry",
     "VtValue",
+    "WebViewAdapter",
+    "WebViewContext",
     "WindowFinder",
     "WindowInfo",
     "__author__",

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -174,6 +174,12 @@ from dcc_mcp_core._core import validate_action_result
 from dcc_mcp_core._core import validate_dependencies
 from dcc_mcp_core._core import wrap_value
 
+# Adapters (pure-Python, non-DccServerBase)
+from dcc_mcp_core.adapters import CAPABILITY_KEYS
+from dcc_mcp_core.adapters import WEBVIEW_DEFAULT_CAPABILITIES
+from dcc_mcp_core.adapters import WebViewAdapter
+from dcc_mcp_core.adapters import WebViewContext
+
 # Pure-Python DCC adapter base classes (no _core dependency)
 from dcc_mcp_core.bridge import BridgeConnectionError
 from dcc_mcp_core.bridge import BridgeError
@@ -201,12 +207,6 @@ from dcc_mcp_core.skill import skill_exception
 from dcc_mcp_core.skill import skill_success
 from dcc_mcp_core.skill import skill_warning
 
-# Adapters (pure-Python, non-DccServerBase)
-from dcc_mcp_core.adapters import CAPABILITY_KEYS
-from dcc_mcp_core.adapters import WEBVIEW_DEFAULT_CAPABILITIES
-from dcc_mcp_core.adapters import WebViewAdapter
-from dcc_mcp_core.adapters import WebViewContext
-
 __version__: str
 try:
     __version__ = _core.__version__  # type: ignore[attr-defined]
@@ -222,6 +222,7 @@ except AttributeError:
 __all__ = [
     "APP_AUTHOR",
     "APP_NAME",
+    "CAPABILITY_KEYS",
     "DEFAULT_DCC",
     "DEFAULT_LOG_LEVEL",
     "DEFAULT_MIME_TYPE",
@@ -231,7 +232,6 @@ __all__ = [
     "SKILL_METADATA_DIR",
     "SKILL_METADATA_FILE",
     "SKILL_SCRIPTS_DIR",
-    "CAPABILITY_KEYS",
     "WEBVIEW_DEFAULT_CAPABILITIES",
     "AuditEntry",
     "AuditLog",

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -1626,10 +1626,30 @@ class ServiceEntry:
     port: int
     version: str | None
     scene: str | None
+    documents: list[str]
+    pid: int | None
+    display_name: str | None
     metadata: dict[str, str]
     status: ServiceStatus
     transport_address: TransportAddress | None
     last_heartbeat_ms: int
+    @property
+    def extras(self) -> dict[str, Any]:
+        """Arbitrary DCC-specific extras with JSON-typed values.
+
+        Unlike :attr:`metadata` (string-only), ``extras`` allows nested
+        objects / arrays / numbers / booleans / ``None``.  Round-trips
+        losslessly through ``services.json``.  Useful for WebView / bridge
+        specific fields such as ``cdp_port``, ``url``, ``window_title``,
+        ``host_dcc``.
+
+        Returns:
+            A fresh ``dict`` — mutating it does **not** update the registry;
+            use :meth:`TransportManager.register_service(..., extras=...)`
+            to register with extras.
+
+        """
+        ...
     """Last heartbeat timestamp in milliseconds since Unix epoch.
 
     Useful for ``LazySessionPool`` implementations to evict idle sessions:
@@ -1676,8 +1696,12 @@ class TransportManager:
         port: int,
         version: str | None = None,
         scene: str | None = None,
+        documents: list[str] | None = None,
+        pid: int | None = None,
+        display_name: str | None = None,
         metadata: dict[str, str] | None = None,
         transport_address: TransportAddress | None = None,
+        extras: dict[str, Any] | None = None,
     ) -> str:
         """Register a DCC service instance.
 
@@ -1687,12 +1711,21 @@ class TransportManager:
             port:               TCP port number.
             version:            DCC version string (optional).
             scene:              Currently open scene/file (optional).
-            metadata:           Arbitrary metadata dict (optional).
+            documents:          All open documents for multi-document apps (optional).
+            pid:                OS process ID (optional, disambiguates two
+                                instances with the same scene).
+            display_name:       Human-readable label, e.g. ``"Maya-Rigging"`` (optional).
+            metadata:           Arbitrary string metadata dict (optional).
             transport_address:  Preferred IPC transport address (optional).
                                 When provided, enables Named Pipe or Unix Socket
                                 for lower latency same-machine communication.
                                 Use ``TransportAddress.default_local(dcc_type, pid)``
                                 to auto-select the optimal IPC transport.
+            extras:             Arbitrary JSON-compatible extras dict (optional).
+                                Values may be ``dict`` / ``list`` / ``int`` /
+                                ``float`` / ``str`` / ``bool`` / ``None``.
+                                Useful for WebView / bridge specific fields
+                                (``cdp_port``, ``url``, ``window_title``, ...).
 
         Returns:
             The instance_id (UUID string) of the registered service.
@@ -1707,6 +1740,7 @@ class TransportManager:
             instance_id = mgr.register_service(
                 "maya", "127.0.0.1", 18812,
                 transport_address=addr,
+                extras={"cdp_port": 9222, "url": "http://localhost:3000"},
             )
 
         """

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -3702,6 +3702,66 @@ class Capturer:
         """Return running statistics as ``(capture_count, total_bytes, error_count)``."""
         ...
 
+    @staticmethod
+    def capture_window_png(pid: int, *, timeout_ms: int = 1000) -> bytes | None:
+        """Capture a window as PNG bytes, looked up by process ID.
+
+        Sugar wrapper for the "grab a window snapshot, attach to chat" flow —
+        no ``Capturer`` instance needed.  Internally creates a window-auto
+        capturer, captures the first visible top-level window for ``pid``,
+        and returns the PNG-encoded bytes.
+
+        Args:
+            pid:         OS process ID of the DCC to capture.
+            timeout_ms:  Max milliseconds to wait for the frame (default 1000).
+
+        Returns:
+            PNG-encoded bytes on success; ``None`` when the process has no
+            visible top-level window or the backend is unavailable.  Never
+            raises on capture errors — use :meth:`capture_window` when you
+            need exceptions.
+
+        Example::
+
+            from dcc_mcp_core import Capturer
+
+            png = Capturer.capture_window_png(pid=12345)
+            if png is not None:
+                attach_to_chat(png)
+
+        """
+        ...
+
+    @staticmethod
+    def capture_region_png(
+        pid: int,
+        x: int,
+        y: int,
+        w: int,
+        h: int,
+        *,
+        timeout_ms: int = 1000,
+    ) -> bytes | None:
+        """Capture a cropped window region as PNG bytes, looked up by PID.
+
+        The window is captured first (same backend as
+        :meth:`capture_window_png`) and the ``(x, y, w, h)`` rectangle is
+        cropped in CPU before re-encoding.  Coordinates are in window-local
+        pixels relative to the window's top-left corner.
+
+        Args:
+            pid:         OS process ID of the DCC to capture.
+            x, y:        Top-left corner of the crop rectangle (window-local).
+            w, h:        Width / height of the crop rectangle.
+            timeout_ms:  Max milliseconds to wait for the frame (default 1000).
+
+        Returns:
+            PNG-encoded cropped bytes on success; ``None`` on any failure
+            (window not found, crop out of bounds, decode error, ...).
+
+        """
+        ...
+
     def __repr__(self) -> str: ...
 
 # ── USD Scene Description (dcc-mcp-usd) ──

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -213,7 +213,22 @@ class ToolRegistry:
         input_schema: str = "",
         output_schema: str = "",
         source_file: str | None = None,
-    ) -> None: ...
+        skill_name: str | None = None,
+        group: str = "",
+        enabled: bool = True,
+        required_capabilities: list[str] | None = None,
+    ) -> None:
+        """Register a tool in this registry.
+
+        Args:
+            required_capabilities: Optional list of host-DCC capability keys
+                (e.g. ``["scene", "timeline"]``) that must be advertised by
+                the session for this tool to be exposed in ``tools/list``.
+                See :data:`dcc_mcp_core.CAPABILITY_KEYS` for the built-in
+                set.  Filtering is performed by the Gateway / adapter — the
+                registry only stores the declaration.
+        """
+        ...
     def get_action(self, name: str, dcc_name: str | None = None) -> dict[str, Any] | None: ...
     def list_actions(self, dcc_name: str | None = None) -> list[dict[str, Any]]: ...
     def list_actions_for_dcc(self, dcc_name: str) -> list[str]: ...

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -220,13 +220,12 @@ class ToolRegistry:
     ) -> None:
         """Register a tool in this registry.
 
-        Args:
-            required_capabilities: Optional list of host-DCC capability keys
-                (e.g. ``["scene", "timeline"]``) that must be advertised by
-                the session for this tool to be exposed in ``tools/list``.
-                See :data:`dcc_mcp_core.CAPABILITY_KEYS` for the built-in
-                set.  Filtering is performed by the Gateway / adapter — the
-                registry only stores the declaration.
+        The ``required_capabilities`` parameter accepts an optional list of
+        host-DCC capability keys (e.g. ``["scene", "timeline"]``) that must be
+        advertised by the session for this tool to be exposed in
+        ``tools/list``.  See :data:`dcc_mcp_core.CAPABILITY_KEYS` for the
+        built-in set.  Filtering is performed by the Gateway / adapter — the
+        registry only stores the declaration.
         """
         ...
     def get_action(self, name: str, dcc_name: str | None = None) -> dict[str, Any] | None: ...
@@ -3765,10 +3764,12 @@ class Capturer:
         pixels relative to the window's top-left corner.
 
         Args:
-            pid:         OS process ID of the DCC to capture.
-            x, y:        Top-left corner of the crop rectangle (window-local).
-            w, h:        Width / height of the crop rectangle.
-            timeout_ms:  Max milliseconds to wait for the frame (default 1000).
+            pid: OS process ID of the DCC to capture.
+            x: Left edge of the crop rectangle (window-local pixels).
+            y: Top edge of the crop rectangle (window-local pixels).
+            w: Width of the crop rectangle in pixels.
+            h: Height of the crop rectangle in pixels.
+            timeout_ms: Max milliseconds to wait for the frame (default 1000).
 
         Returns:
             PNG-encoded cropped bytes on success; ``None`` on any failure

--- a/python/dcc_mcp_core/adapters/__init__.py
+++ b/python/dcc_mcp_core/adapters/__init__.py
@@ -1,0 +1,25 @@
+"""DCC-adapter base classes for non-traditional hosts.
+
+This sub-package collects standalone, pure-Python adapter templates that do
+**not** inherit from :class:`dcc_mcp_core.DccServerBase`.  They are intended
+for hosts whose capability profile is narrower than a full DCC (Maya, Blender,
+…) — most notably WebView / browser-based tool panels.
+
+Adapters here are deliberately small, opinionated, and designed to be
+sub-classed by integration projects (e.g. *AuroraView*).
+"""
+
+from __future__ import annotations
+
+# Local folder imports
+from dcc_mcp_core.adapters.webview import CAPABILITY_KEYS
+from dcc_mcp_core.adapters.webview import WEBVIEW_DEFAULT_CAPABILITIES
+from dcc_mcp_core.adapters.webview import WebViewAdapter
+from dcc_mcp_core.adapters.webview import WebViewContext
+
+__all__ = [
+    "CAPABILITY_KEYS",
+    "WEBVIEW_DEFAULT_CAPABILITIES",
+    "WebViewAdapter",
+    "WebViewContext",
+]

--- a/python/dcc_mcp_core/adapters/webview.py
+++ b/python/dcc_mcp_core/adapters/webview.py
@@ -17,9 +17,11 @@ for the advertising side.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 # Import built-in modules
 from typing import Any
-from typing import TYPE_CHECKING
+from typing import ClassVar
 
 if TYPE_CHECKING:
     # Import built-in modules
@@ -92,7 +94,7 @@ class WebViewAdapter:
     #: Override in subclasses to flip individual entries when the host
     #: genuinely supports that capability (e.g. a Chromium-based editor with
     #: an in-browser undo stack → ``{"undo": True, ...}``).
-    capabilities: dict[str, bool] = dict(WEBVIEW_DEFAULT_CAPABILITIES)
+    capabilities: ClassVar[dict[str, bool]] = dict(WEBVIEW_DEFAULT_CAPABILITIES)
 
     #: DCC short-name this adapter registers as.  Override in subclasses.
     dcc_name: str = "webview"

--- a/python/dcc_mcp_core/adapters/webview.py
+++ b/python/dcc_mcp_core/adapters/webview.py
@@ -1,0 +1,142 @@
+"""WebView-host adapter base (#211).
+
+``WebViewAdapter`` is a slim, standalone Pure-Python template for hosts whose
+capability profile is narrower than a full DCC (Maya, Blender, …) — most
+commonly AuroraView-style browser / tool panels that do not have a scene
+graph, timeline, or selection.
+
+Unlike :class:`dcc_mcp_core.DccServerBase`, this class is **not** intended to
+be wired up to the Gateway directly; it is a stub that integration projects
+(AuroraView, an Electron bridge, an ImGui tool panel, …) subclass to advertise
+*what the host can actually do*.  The pre-declared
+:attr:`WebViewAdapter.capabilities` map (all false by default) signals to the
+registry that scene / timeline / selection tools should be hidden for sessions
+routed to this adapter — see ``ToolRegistry.register(required_capabilities=…)``
+for the advertising side.
+"""
+
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Any
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # Import built-in modules
+    from collections.abc import Iterable
+    from collections.abc import Mapping
+
+
+#: The closed set of capability keys recognised by dcc-mcp-core.
+#:
+#: Registry consumers that implement capability-based filtering should treat
+#: any key **not** in this set as host-specific and leave filtering to the
+#: adapter.  The set is intentionally small — extensions live in
+#: :attr:`dcc_mcp_core.DccCapabilities.extensions` rather than here.
+CAPABILITY_KEYS: frozenset[str] = frozenset(
+    {
+        "scene",
+        "timeline",
+        "selection",
+        "undo",
+        "render",
+    }
+)
+
+
+#: Default capability map for :class:`WebViewAdapter` subclasses.
+#:
+#: All five built-in capabilities are set to ``False`` — WebView hosts do not
+#: own a scene, timeline, or selection model.  Subclasses may flip an entry
+#: when their web app genuinely exposes the capability (e.g. an in-browser
+#: timeline editor).
+WEBVIEW_DEFAULT_CAPABILITIES: dict[str, bool] = {k: False for k in CAPABILITY_KEYS}
+
+
+class WebViewContext(dict):  # type: ignore[type-arg]
+    """Typed-dict convenience for the payload returned by ``get_context()``.
+
+    Stored as a ``dict`` subclass to stay JSON-serialisable without extra
+    conversion.  Recognised keys (all optional):
+
+    - ``window_title`` : ``str``
+    - ``url``          : ``str``
+    - ``pid``          : ``int``
+    - ``cdp_port``     : ``int``  (Chrome DevTools Protocol debug port)
+    - ``host_dcc``     : ``str``  (the DCC embedding this WebView, if any)
+    """
+
+
+class WebViewAdapter:
+    """Standalone WebView-host adapter template.
+
+    This class is intentionally **not** a subclass of
+    :class:`dcc_mcp_core.DccServerBase`; it is a pure-Python stub whose
+    subclasses are registered with the Gateway as a DCC type (``"webview"``,
+    ``"auroraview"``, …) but advertise a narrower capability surface.
+
+    Subclasses must override:
+
+    - :meth:`get_context`   — return descriptor dict (window / url / pid / …)
+    - :meth:`list_tools`    — list tool metadata dicts exposed by the host
+    - :meth:`execute`       — dispatch a tool invocation to the host's bridge
+    - :meth:`get_audit_log` — return recent audit entries (may return ``[]``)
+
+    The default :attr:`capabilities` map (all ``False``) signals to the
+    registry that scene / timeline / selection / undo / render tools should
+    be hidden for sessions routed to this adapter.
+    """
+
+    #: Capability descriptor advertised to the Gateway / registry.
+    #:
+    #: Override in subclasses to flip individual entries when the host
+    #: genuinely supports that capability (e.g. a Chromium-based editor with
+    #: an in-browser undo stack → ``{"undo": True, ...}``).
+    capabilities: dict[str, bool] = dict(WEBVIEW_DEFAULT_CAPABILITIES)
+
+    #: DCC short-name this adapter registers as.  Override in subclasses.
+    dcc_name: str = "webview"
+
+    def get_context(self) -> WebViewContext:
+        """Return descriptor dict for the current WebView host session.
+
+        Recommended keys (any may be absent): ``window_title``, ``url``,
+        ``pid``, ``cdp_port``, ``host_dcc``.
+        """
+        raise NotImplementedError
+
+    def list_tools(self) -> list[dict[str, Any]]:
+        """Return tool declaration dicts exposed by the host's JS bridge."""
+        raise NotImplementedError
+
+    def execute(self, tool: str, params: Mapping[str, Any] | None = None) -> dict[str, Any]:
+        """Invoke ``tool`` on the host with ``params`` and return the result."""
+        raise NotImplementedError
+
+    def get_audit_log(self, limit: int = 100) -> list[dict[str, Any]]:
+        """Return up to ``limit`` recent audit-log entries (default ``[]``).
+
+        Concrete subclasses may forward to ``SandboxPolicy.audit_log`` or
+        return an empty list when auditing is not wired up.
+        """
+        return []
+
+    @classmethod
+    def advertised_capabilities(cls) -> dict[str, bool]:
+        """Return a **fresh copy** of :attr:`capabilities` (safe to mutate)."""
+        return dict(cls.capabilities)
+
+    @classmethod
+    def supports(cls, capability: str) -> bool:
+        """Return ``True`` when the adapter advertises ``capability`` as enabled."""
+        return bool(cls.capabilities.get(capability, False))
+
+    @classmethod
+    def matches_requirements(cls, required: Iterable[str]) -> bool:
+        """Return ``True`` when every required capability is advertised.
+
+        Intended for a Gateway-side filter that hides tools registered with
+        ``ToolRegistry.register(required_capabilities=[…])`` from WebView
+        sessions that don't advertise the needed key.
+        """
+        return all(cls.supports(key) for key in required)

--- a/python/dcc_mcp_core/dcc_server.py
+++ b/python/dcc_mcp_core/dcc_server.py
@@ -11,14 +11,18 @@ Registered handlers
     Returns entries from the server-level :class:`SandboxContext` audit log.
     Supports ``filter`` (all/success/denied/error) and ``action_name`` filters.
 
-``get_action_metrics``
-    Returns per-action performance counters from the shared
-    :class:`ToolRecorder`.  Optionally filtered to a single action name.
+``get_tool_metrics``
+    Returns per-tool performance counters from the shared
+    :class:`ToolRecorder`.  Optionally filtered to a single tool name.
+    **Renamed from ``get_action_metrics`` in 0.14.0** — no compatibility
+    alias is registered; callers on the old name will receive a handler-not-found
+    error.
 
-``dispatch_action``
+``dispatch_tool``
     Relays a ``{"action": "...", "params": {...}}`` request through the
     server's internal dispatcher.  Used by ``workflow__run_chain`` to
     execute multi-step chains via IPC without spawning extra sub-processes.
+    **Renamed from ``dispatch_action`` in 0.14.0** — no compatibility alias.
 
 IPC address convention
 ----------------------
@@ -163,7 +167,7 @@ def _handle_get_audit_log(params_json: str) -> str:
         return json.dumps({"success": False, "message": str(exc)})
 
 
-def _handle_get_action_metrics(params_json: str) -> str:
+def _handle_get_tool_metrics(params_json: str) -> str:
     """Return ToolRecorder metrics as a JSON string."""
     try:
         params = json.loads(params_json) if params_json else {}
@@ -191,7 +195,7 @@ def _handle_get_action_metrics(params_json: str) -> str:
             }
         )
     except Exception as exc:
-        logger.warning("get_action_metrics handler error: %s", exc)
+        logger.warning("get_tool_metrics handler error: %s", exc)
         return json.dumps({"success": False, "message": str(exc)})
 
 
@@ -338,13 +342,16 @@ def _handle_process_status(params_json: str) -> str:
     return json.dumps(payload)
 
 
-def _handle_dispatch_action(params_json: str) -> str:
+def _handle_dispatch_tool(params_json: str) -> str:
     """Relay a dispatch request through the server's ToolDispatcher."""
     try:
         params = json.loads(params_json) if params_json else {}
     except json.JSONDecodeError:
         return json.dumps({"success": False, "message": "Invalid JSON params."})
 
+    # The wire payload still uses the legacy field name ``action`` — that key
+    # reflects the backward-compat Rust dispatch result shape (see PR #218);
+    # it is NOT the handler method name.
     action = params.get("action", "")
     action_params = params.get("params", {})
 
@@ -362,7 +369,7 @@ def _handle_dispatch_action(params_json: str) -> str:
             return output  # already JSON
         return json.dumps(output)
     except Exception as exc:
-        logger.warning("dispatch_action handler error for '%s': %s", action, exc)
+        logger.warning("dispatch_tool handler error for '%s': %s", action, exc)
         return json.dumps({"success": False, "message": str(exc)})
 
 
@@ -392,7 +399,7 @@ def register_diagnostic_handlers(
         server: A :class:`dcc_mcp_core.McpHttpServer` / skill-manager object
             that exposes a ``register_handler(name, callable)`` method.
         dispatcher: Optional :class:`dcc_mcp_core.ToolDispatcher` used for
-            the ``dispatch_action`` relay handler.  When ``None``, dispatch
+            the ``dispatch_tool`` relay handler.  When ``None``, dispatch
             relay calls return an error response.
         dcc_name: Short DCC identifier used for the IPC pipe name derivation
             and ``ToolRecorder`` label (e.g. ``"maya"``, ``"blender"``).
@@ -413,8 +420,10 @@ def register_diagnostic_handlers(
     Registered actions
     ------------------
     - ``get_audit_log`` — sandbox audit log entries
-    - ``get_action_metrics`` — ToolRecorder performance counters
-    - ``dispatch_action`` — relay through the server's ToolDispatcher
+    - ``get_tool_metrics`` — ToolRecorder performance counters (was
+      ``get_action_metrics`` prior to 0.14.0)
+    - ``dispatch_tool`` — relay through the server's ToolDispatcher (was
+      ``dispatch_action`` prior to 0.14.0)
     - ``take_screenshot`` — capture the DCC window (or full screen)
 
     """
@@ -437,12 +446,12 @@ def register_diagnostic_handlers(
 
     try:
         server.register_handler("get_audit_log", _handle_get_audit_log)
-        server.register_handler("get_action_metrics", _handle_get_action_metrics)
-        server.register_handler("dispatch_action", _handle_dispatch_action)
+        server.register_handler("get_tool_metrics", _handle_get_tool_metrics)
+        server.register_handler("dispatch_tool", _handle_dispatch_tool)
         server.register_handler("take_screenshot", _handle_take_screenshot)
         logger.debug(
             "Registered diagnostic IPC handlers for dcc=%r: "
-            "get_audit_log, get_action_metrics, dispatch_action, take_screenshot",
+            "get_audit_log, get_tool_metrics, dispatch_tool, take_screenshot",
             dcc_name,
         )
     except Exception as exc:
@@ -550,7 +559,8 @@ def register_diagnostic_mcp_tools(
     ----------------
     - ``diagnostics__screenshot`` — capture the DCC window (or full screen)
     - ``diagnostics__audit_log`` — recent sandbox audit events
-    - ``diagnostics__action_metrics`` — tool dispatch metrics
+    - ``diagnostics__tool_metrics`` — tool dispatch metrics (renamed from
+      ``diagnostics__action_metrics`` in 0.14.0, no compat alias)
     - ``diagnostics__process_status`` — adapter process / DCC alive check
 
     Args:
@@ -593,10 +603,10 @@ def register_diagnostic_mcp_tools(
         ),
         ("diagnostics__audit_log", "Recent sandbox audit events.", _AUDIT_SCHEMA, _handle_get_audit_log),
         (
-            "diagnostics__action_metrics",
+            "diagnostics__tool_metrics",
             "Tool dispatch telemetry metrics.",
             _METRICS_SCHEMA,
-            _handle_get_action_metrics,
+            _handle_get_tool_metrics,
         ),
         ("diagnostics__process_status", "Adapter process and DCC alive status.", _PROC_SCHEMA, _handle_process_status),
     ]

--- a/python/dcc_mcp_core/skills/dcc-diagnostics/SKILL.md
+++ b/python/dcc_mcp_core/skills/dcc-diagnostics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dcc-diagnostics
-description: "DCC-agnostic diagnostics and observability tools — capture screenshots, query audit logs, inspect action performance metrics, and monitor process health. Works in any DCC environment (Maya, Blender, Houdini, Unreal, etc.) or standalone Python."
+description: "DCC-agnostic diagnostics and observability tools — capture screenshots, query audit logs, inspect tool performance metrics, and monitor process health. Works in any DCC environment (Maya, Blender, Houdini, Unreal, etc.) or standalone Python."
 license: MIT
 dcc: python
 version: "1.0.0"
@@ -60,25 +60,25 @@ tools:
     idempotent: true
     source_file: scripts/audit_log.py
 
-  - name: action_metrics
-    description: "Show performance metrics for registered actions — invocation counts, success rates, average and P95/P99 latencies. Use to identify slow or failing tools."
+  - name: tool_metrics
+    description: "Show performance metrics for registered tools — invocation counts, success rates, average and P95/P99 latencies. Use to identify slow or failing tools."
     input_schema:
       type: object
       properties:
         action_name:
           type: string
-          description: "If provided, return metrics only for this action. Otherwise return all."
+          description: "If provided, return metrics only for this tool. Otherwise return all."
         sort_by:
           type: string
           description: "Sort results by: 'name', 'invocations' (default), 'avg_ms', 'p95_ms', or 'failure_rate'"
           default: invocations
         limit:
           type: integer
-          description: "Maximum number of actions to return (default 20)."
+          description: "Maximum number of tools to return (default 20)."
           default: 20
     read_only: true
     idempotent: true
-    source_file: scripts/action_metrics.py
+    source_file: scripts/tool_metrics.py
 
   - name: process_status
     description: "Check the health of tracked DCC processes — list running PIDs, check if a specific process is alive, and inspect crash recovery policy. Use when a DCC tool stops responding."
@@ -114,11 +114,11 @@ Backed by the `dcc_mcp_core.Capturer` class which uses:
 ### `dcc_diagnostics__audit_log`
 
 Query the sandbox audit log from `dcc_mcp_core.SandboxContext`.
-Returns recent action invocations with outcome (success/denied) and timestamps.
+Returns recent tool invocations with outcome (success/denied) and timestamps.
 
-### `dcc_diagnostics__action_metrics`
+### `dcc_diagnostics__tool_metrics`
 
-Inspect per-action performance counters from `dcc_mcp_core.ToolRecorder`:
+Inspect per-tool performance counters from `dcc_mcp_core.ToolRecorder`:
 invocation count, success rate, average latency, P95/P99 percentiles.
 
 ### `dcc_diagnostics__process_status`

--- a/python/dcc_mcp_core/skills/dcc-diagnostics/scripts/audit_log.py
+++ b/python/dcc_mcp_core/skills/dcc-diagnostics/scripts/audit_log.py
@@ -145,7 +145,7 @@ def main() -> None:
                 ),
                 "prompt": (
                     "Audit log retrieved. If entries show 'denied' outcomes, check the SandboxPolicy. "
-                    "Use dcc_diagnostics__action_metrics to see performance data, or "
+                    "Use dcc_diagnostics__tool_metrics to see performance data, or "
                     "dcc_diagnostics__screenshot to capture what's currently visible."
                 ),
                 "context": {

--- a/python/dcc_mcp_core/skills/dcc-diagnostics/scripts/screenshot.py
+++ b/python/dcc_mcp_core/skills/dcc-diagnostics/scripts/screenshot.py
@@ -92,7 +92,7 @@ def main() -> None:
                     "prompt": (
                         "Screenshot captured from the DCC's own window. "
                         "If you see an error on screen, use dcc_diagnostics__audit_log to check "
-                        "recent action history, or dcc_diagnostics__action_metrics to find failing tools."
+                        "recent tool history, or dcc_diagnostics__tool_metrics to find failing tools."
                     ),
                     "context": {
                         **{
@@ -162,7 +162,7 @@ def main() -> None:
                 "prompt": (
                     "Screenshot captured. You can view the image data in the 'image_base64' field. "
                     "If you see an error on screen, use dcc_diagnostics__audit_log to check recent "
-                    "action history, or dcc_diagnostics__action_metrics to find failing tools."
+                    "tool history, or dcc_diagnostics__tool_metrics to find failing tools."
                 ),
                 "context": {
                     "width": frame.width,

--- a/python/dcc_mcp_core/skills/dcc-diagnostics/scripts/tool_metrics.py
+++ b/python/dcc_mcp_core/skills/dcc-diagnostics/scripts/tool_metrics.py
@@ -1,8 +1,8 @@
-"""Inspect per-action performance metrics.
+"""Inspect per-tool performance metrics.
 
 Data source priority:
 1. IPC callback — if DCC_MCP_IPC_ADDRESS is set, connect to the running DCC
-   server and call 'get_action_metrics' to get live recorder data.
+   server and call 'get_tool_metrics' to get live recorder data.
 2. Local ToolRecorder — creates a fresh (empty) recorder as a fallback,
    useful for testing without a running DCC server.
 """
@@ -24,7 +24,7 @@ _SORT_KEYS = {
 
 
 def _fetch_via_ipc(ipc_address: str, action_name: str | None) -> dict | None:
-    """Connect to the DCC server via IPC and call 'get_action_metrics'."""
+    """Connect to the DCC server via IPC and call 'get_tool_metrics'."""
     try:
         from dcc_mcp_core import TransportAddress
         from dcc_mcp_core import connect_ipc
@@ -39,7 +39,7 @@ def _fetch_via_ipc(ipc_address: str, action_name: str | None) -> dict | None:
 
     try:
         params = json.dumps({"action_name": action_name}).encode()
-        result = channel.call("get_action_metrics", params, timeout_ms=10000)
+        result = channel.call("get_tool_metrics", params, timeout_ms=10000)
         channel.shutdown()
 
         if not result.get("success"):
@@ -87,6 +87,7 @@ def _metric_to_dict(metric) -> dict:
 
 
 def main() -> None:
+    """Show action performance metrics and print JSON result to stdout."""
     parser = argparse.ArgumentParser(description="Show action performance metrics.")
     parser.add_argument("--action-name", default=None, dest="action_name")
     parser.add_argument("--sort-by", default="invocations", choices=list(_SORT_KEYS), dest="sort_by")
@@ -129,7 +130,7 @@ def main() -> None:
                 "success": True,
                 "message": summary + (f", showing top {args.limit}" if total > args.limit else ""),
                 "prompt": (
-                    "Metrics retrieved. High failure_rate or p95_ms values indicate problematic actions. "
+                    "Metrics retrieved. High failure_rate or p95_ms values indicate problematic tools. "
                     "Use dcc_diagnostics__audit_log to see recent invocations, or "
                     "dcc_diagnostics__screenshot to capture the current state."
                 ),

--- a/python/dcc_mcp_core/skills/workflow/scripts/run_chain.py
+++ b/python/dcc_mcp_core/skills/workflow/scripts/run_chain.py
@@ -2,7 +2,7 @@
 
 Dispatch strategy:
 1. IPC dispatch — if DCC_MCP_IPC_ADDRESS is set, each step is sent to the
-   running DCC server via FramedChannel.call("dispatch_action", ...).
+   running DCC server via FramedChannel.call("dispatch_tool", ...).
    This is the production path (Maya, Blender, Unreal, etc.).
 2. Local ToolDispatcher — fallback for testing without a live DCC server.
    Only actions registered in the local process are available.
@@ -51,7 +51,7 @@ def _build_ipc_dispatcher(ipc_address: str):
         channel = connect_ipc(addr, timeout_ms=5000)
         try:
             payload = json.dumps({"action": action_name, "params": params}).encode()
-            result = channel.call("dispatch_action", payload, timeout_ms=30000)
+            result = channel.call("dispatch_tool", payload, timeout_ms=30000)
             if not result.get("success"):
                 return {"success": False, "message": f"IPC dispatch error: {result.get('error')}"}
             raw = result.get("payload", b"{}")

--- a/tests/test_adapters_webview.py
+++ b/tests/test_adapters_webview.py
@@ -1,0 +1,138 @@
+"""Tests for WebViewAdapter + ToolRegistry.required_capabilities (#211)."""
+
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Any
+
+# Import third-party modules
+import pytest
+
+# Import local modules
+import dcc_mcp_core
+from dcc_mcp_core import CAPABILITY_KEYS
+from dcc_mcp_core import WEBVIEW_DEFAULT_CAPABILITIES
+from dcc_mcp_core import WebViewAdapter
+from dcc_mcp_core import WebViewContext
+
+
+# ── Public API shape ──────────────────────────────────────────────────────────
+
+
+class TestAdaptersPublicApi:
+    def test_capability_keys_is_frozen(self) -> None:
+        assert isinstance(CAPABILITY_KEYS, frozenset)
+        assert {"scene", "timeline", "selection", "undo", "render"} == CAPABILITY_KEYS
+
+    def test_default_capabilities_are_all_false(self) -> None:
+        assert set(WEBVIEW_DEFAULT_CAPABILITIES) == CAPABILITY_KEYS
+        assert all(v is False for v in WEBVIEW_DEFAULT_CAPABILITIES.values())
+
+    def test_defaults_are_fresh_copies(self) -> None:
+        """Mutating the default map should not leak into WebViewAdapter.capabilities."""
+        local = dict(WEBVIEW_DEFAULT_CAPABILITIES)
+        local["scene"] = True
+        assert WEBVIEW_DEFAULT_CAPABILITIES["scene"] is False
+        assert WebViewAdapter.capabilities["scene"] is False
+
+    def test_adapters_reexport_from_top_level(self) -> None:
+        assert dcc_mcp_core.WebViewAdapter is WebViewAdapter
+        assert dcc_mcp_core.WebViewContext is WebViewContext
+
+
+# ── WebViewAdapter contract ───────────────────────────────────────────────────
+
+
+class TestWebViewAdapterContract:
+    def test_default_capabilities_match_module_default(self) -> None:
+        assert WebViewAdapter.capabilities == WEBVIEW_DEFAULT_CAPABILITIES
+
+    def test_default_dcc_name_is_webview(self) -> None:
+        assert WebViewAdapter.dcc_name == "webview"
+
+    def test_abstract_methods_raise_not_implemented(self) -> None:
+        adapter = WebViewAdapter()
+        with pytest.raises(NotImplementedError):
+            adapter.get_context()
+        with pytest.raises(NotImplementedError):
+            adapter.list_tools()
+        with pytest.raises(NotImplementedError):
+            adapter.execute("any_tool", {"x": 1})
+
+    def test_get_audit_log_default_empty(self) -> None:
+        assert WebViewAdapter().get_audit_log() == []
+
+    def test_advertised_capabilities_returns_fresh_copy(self) -> None:
+        first = WebViewAdapter.advertised_capabilities()
+        first["scene"] = True
+        second = WebViewAdapter.advertised_capabilities()
+        assert second["scene"] is False
+
+    def test_supports_false_for_default(self) -> None:
+        for key in CAPABILITY_KEYS:
+            assert WebViewAdapter.supports(key) is False
+
+    def test_supports_returns_false_for_unknown_key(self) -> None:
+        assert WebViewAdapter.supports("does_not_exist") is False
+
+    def test_matches_requirements_empty_always_true(self) -> None:
+        assert WebViewAdapter.matches_requirements([]) is True
+
+    def test_matches_requirements_default_false_for_scene(self) -> None:
+        assert WebViewAdapter.matches_requirements(["scene"]) is False
+
+
+# ── Subclass overrides ────────────────────────────────────────────────────────
+
+
+class AuroraLikeAdapter(WebViewAdapter):
+    """Mimics AuroraView: advertises undo only, routes through a fake bridge."""
+
+    dcc_name = "auroraview"
+    capabilities = {**WEBVIEW_DEFAULT_CAPABILITIES, "undo": True}
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def get_context(self) -> WebViewContext:
+        return WebViewContext(
+            window_title="AuroraView",
+            url="http://localhost:3000",
+            pid=12345,
+            cdp_port=9222,
+            host_dcc="maya",
+        )
+
+    def list_tools(self) -> list[dict[str, Any]]:
+        return [{"name": "undo", "description": "Undo last action"}]
+
+    def execute(self, tool: str, params: Any = None) -> dict[str, Any]:
+        self.calls.append((tool, dict(params or {})))
+        return {"success": True, "tool": tool}
+
+
+class TestWebViewAdapterSubclass:
+    def test_subclass_advertises_undo(self) -> None:
+        assert AuroraLikeAdapter.supports("undo") is True
+        assert AuroraLikeAdapter.supports("scene") is False
+
+    def test_matches_requirements_on_subclass(self) -> None:
+        assert AuroraLikeAdapter.matches_requirements(["undo"]) is True
+        assert AuroraLikeAdapter.matches_requirements(["undo", "scene"]) is False
+
+    def test_get_context_returns_webview_context(self) -> None:
+        ctx = AuroraLikeAdapter().get_context()
+        assert isinstance(ctx, WebViewContext)
+        assert ctx["host_dcc"] == "maya"
+        assert ctx["cdp_port"] == 9222
+
+    def test_execute_records_call(self) -> None:
+        adapter = AuroraLikeAdapter()
+        result = adapter.execute("undo", {"count": 1})
+        assert result == {"success": True, "tool": "undo"}
+        assert adapter.calls == [("undo", {"count": 1})]
+
+    def test_subclass_capabilities_do_not_leak_upward(self) -> None:
+        """A subclass tweak must not rewrite the base class map."""
+        assert AuroraLikeAdapter.capabilities["undo"] is True
+        assert WebViewAdapter.capabilities["undo"] is False

--- a/tests/test_adapters_webview.py
+++ b/tests/test_adapters_webview.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 # Import built-in modules
 from typing import Any
+from typing import ClassVar
 
 # Import third-party modules
 import pytest
@@ -14,7 +15,6 @@ from dcc_mcp_core import CAPABILITY_KEYS
 from dcc_mcp_core import WEBVIEW_DEFAULT_CAPABILITIES
 from dcc_mcp_core import WebViewAdapter
 from dcc_mcp_core import WebViewContext
-
 
 # ── Public API shape ──────────────────────────────────────────────────────────
 
@@ -89,7 +89,7 @@ class AuroraLikeAdapter(WebViewAdapter):
     """Mimics AuroraView: advertises undo only, routes through a fake bridge."""
 
     dcc_name = "auroraview"
-    capabilities = {**WEBVIEW_DEFAULT_CAPABILITIES, "undo": True}
+    capabilities: ClassVar[dict[str, bool]] = {**WEBVIEW_DEFAULT_CAPABILITIES, "undo": True}
 
     def __init__(self) -> None:
         self.calls: list[tuple[str, dict[str, Any]]] = []

--- a/tests/test_capture_window_api.py
+++ b/tests/test_capture_window_api.py
@@ -135,28 +135,30 @@ class TestCaptureWindowPngStatic:
     def test_capture_region_png_is_static_method(self) -> None:
         assert callable(dcc_mcp_core.Capturer.capture_region_png)
 
+    @pytest.mark.skipif(
+        sys.platform != "win32",
+        reason="unknown-PID => None semantics only enforced by HwndBackend; Mock backend has no PID awareness",
+    )
     def test_unknown_pid_returns_none(self) -> None:
-        """On any platform, an unresolvable PID must return ``None`` (not raise)."""
+        """On HwndBackend, an unresolvable PID must return ``None`` (not raise)."""
         result = dcc_mcp_core.Capturer.capture_window_png(pid=0x7FFFFFFF, timeout_ms=200)
         assert result is None
 
+    @pytest.mark.skipif(
+        sys.platform != "win32",
+        reason="unknown-PID => None semantics only enforced by HwndBackend; Mock backend has no PID awareness",
+    )
     def test_region_unknown_pid_returns_none(self) -> None:
-        result = dcc_mcp_core.Capturer.capture_region_png(
-            pid=0x7FFFFFFF, x=0, y=0, w=10, h=10, timeout_ms=200
-        )
+        result = dcc_mcp_core.Capturer.capture_region_png(pid=0x7FFFFFFF, x=0, y=0, w=10, h=10, timeout_ms=200)
         assert result is None
 
     def test_region_zero_width_returns_none(self) -> None:
-        """Zero-width/height regions are rejected cheaply as ``None``."""
-        result = dcc_mcp_core.Capturer.capture_region_png(
-            pid=0x7FFFFFFF, x=0, y=0, w=0, h=100, timeout_ms=200
-        )
+        """Zero-width/height regions are rejected cheaply as ``None`` on every backend."""
+        result = dcc_mcp_core.Capturer.capture_region_png(pid=0x7FFFFFFF, x=0, y=0, w=0, h=100, timeout_ms=200)
         assert result is None
 
     def test_region_zero_height_returns_none(self) -> None:
-        result = dcc_mcp_core.Capturer.capture_region_png(
-            pid=0x7FFFFFFF, x=0, y=0, w=100, h=0, timeout_ms=200
-        )
+        result = dcc_mcp_core.Capturer.capture_region_png(pid=0x7FFFFFFF, x=0, y=0, w=100, h=0, timeout_ms=200)
         assert result is None
 
     def test_timeout_is_keyword_only(self) -> None:
@@ -165,8 +167,7 @@ class TestCaptureWindowPngStatic:
             dcc_mcp_core.Capturer.capture_window_png(0x7FFFFFFF, 200)  # type: ignore[misc]
 
     def test_region_coords_are_positional(self) -> None:
-        """Region coords (x, y, w, h) may be passed positionally."""
-        result = dcc_mcp_core.Capturer.capture_region_png(
-            0x7FFFFFFF, 0, 0, 10, 10, timeout_ms=200
-        )
-        assert result is None
+        """Region coords (x, y, w, h) may be passed positionally — the call must not raise."""
+        result = dcc_mcp_core.Capturer.capture_region_png(0x7FFFFFFF, 0, 0, 10, 10, timeout_ms=200)
+        # HwndBackend => None (unknown PID); Mock backend => synthetic PNG bytes.
+        assert result is None or isinstance(result, bytes)

--- a/tests/test_capture_window_api.py
+++ b/tests/test_capture_window_api.py
@@ -120,3 +120,53 @@ class TestWindowFinderCrossPlatform:
         finder = dcc_mcp_core.WindowFinder()
         result = finder.find(dcc_mcp_core.CaptureTarget.process_id(0x7FFFFFFF))
         assert result is None
+
+
+# ── capture_window_png / capture_region_png sugar API (#212) ──────────────────
+
+
+class TestCaptureWindowPngStatic:
+    """Covers the issue #212 ergonomic wrappers for bytes-or-None captures."""
+
+    def test_is_static_method(self) -> None:
+        """capture_window_png is callable on the class itself (no instance)."""
+        assert callable(dcc_mcp_core.Capturer.capture_window_png)
+
+    def test_capture_region_png_is_static_method(self) -> None:
+        assert callable(dcc_mcp_core.Capturer.capture_region_png)
+
+    def test_unknown_pid_returns_none(self) -> None:
+        """On any platform, an unresolvable PID must return ``None`` (not raise)."""
+        result = dcc_mcp_core.Capturer.capture_window_png(pid=0x7FFFFFFF, timeout_ms=200)
+        assert result is None
+
+    def test_region_unknown_pid_returns_none(self) -> None:
+        result = dcc_mcp_core.Capturer.capture_region_png(
+            pid=0x7FFFFFFF, x=0, y=0, w=10, h=10, timeout_ms=200
+        )
+        assert result is None
+
+    def test_region_zero_width_returns_none(self) -> None:
+        """Zero-width/height regions are rejected cheaply as ``None``."""
+        result = dcc_mcp_core.Capturer.capture_region_png(
+            pid=0x7FFFFFFF, x=0, y=0, w=0, h=100, timeout_ms=200
+        )
+        assert result is None
+
+    def test_region_zero_height_returns_none(self) -> None:
+        result = dcc_mcp_core.Capturer.capture_region_png(
+            pid=0x7FFFFFFF, x=0, y=0, w=100, h=0, timeout_ms=200
+        )
+        assert result is None
+
+    def test_timeout_is_keyword_only(self) -> None:
+        """timeout_ms must be a keyword argument — positional call raises TypeError."""
+        with pytest.raises(TypeError):
+            dcc_mcp_core.Capturer.capture_window_png(0x7FFFFFFF, 200)  # type: ignore[misc]
+
+    def test_region_coords_are_positional(self) -> None:
+        """Region coords (x, y, w, h) may be passed positionally."""
+        result = dcc_mcp_core.Capturer.capture_region_png(
+            0x7FFFFFFF, 0, 0, 10, 10, timeout_ms=200
+        )
+        assert result is None

--- a/tests/test_dcc_server_diagnostic_handlers.py
+++ b/tests/test_dcc_server_diagnostic_handlers.py
@@ -3,13 +3,13 @@
 Covers:
 - register_diagnostic_handlers registers the four handler names on the mock server
 - get_audit_log handler returns valid JSON with success=True (local SandboxContext)
-- get_action_metrics handler returns valid JSON with success=True (local ToolRecorder)
-- dispatch_action handler returns error when dispatcher is None
-- dispatch_action handler relays through a mock dispatcher
+- get_tool_metrics handler returns valid JSON with success=True (local ToolRecorder)
+- dispatch_tool handler returns error when dispatcher is None
+- dispatch_tool handler relays through a mock dispatcher
 - DCC_MCP_IPC_ADDRESS env var is set after registration (unless already present)
 - register_diagnostic_handlers is importable from the top-level dcc_mcp_core package
 - _handle_get_audit_log handles invalid JSON params gracefully
-- _handle_get_action_metrics handles missing action gracefully
+- _handle_get_tool_metrics handles missing action gracefully
 """
 
 from __future__ import annotations
@@ -80,8 +80,8 @@ def test_registers_four_handlers():
     register_diagnostic_handlers(server, dcc_name="test-dcc")
 
     assert "get_audit_log" in server._handlers
-    assert "get_action_metrics" in server._handlers
-    assert "dispatch_action" in server._handlers
+    assert "get_tool_metrics" in server._handlers
+    assert "dispatch_tool" in server._handlers
     assert "take_screenshot" in server._handlers
 
 
@@ -157,42 +157,42 @@ def test_get_audit_log_empty_params():
 
 
 # ---------------------------------------------------------------------------
-# get_action_metrics
+# get_tool_metrics
 # ---------------------------------------------------------------------------
 
 
-def test_get_action_metrics_returns_json():
+def test_get_tool_metrics_returns_json():
     from dcc_mcp_core.dcc_server import register_diagnostic_handlers
 
     server = _MockServer()
     register_diagnostic_handlers(server, dcc_name="test-dcc")
 
-    result_str = server.call("get_action_metrics", json.dumps({}))
+    result_str = server.call("get_tool_metrics", json.dumps({}))
     data = json.loads(result_str)
     assert "success" in data
 
 
-def test_get_action_metrics_empty_params():
-    from dcc_mcp_core.dcc_server import _handle_get_action_metrics
+def test_get_tool_metrics_empty_params():
+    from dcc_mcp_core.dcc_server import _handle_get_tool_metrics
 
-    result_str = _handle_get_action_metrics("")
+    result_str = _handle_get_tool_metrics("")
     data = json.loads(result_str)
     assert "success" in data
 
 
 # ---------------------------------------------------------------------------
-# dispatch_action
+# dispatch_tool
 # ---------------------------------------------------------------------------
 
 
-def test_dispatch_action_no_dispatcher_returns_error():
+def test_dispatch_tool_no_dispatcher_returns_error():
     import dcc_mcp_core.dcc_server as mod
 
     # Reset dispatcher so we can test the None path
     original = mod._dispatcher_ref
     mod._dispatcher_ref = None
     try:
-        result_str = mod._handle_dispatch_action(json.dumps({"action": "test", "params": {}}))
+        result_str = mod._handle_dispatch_tool(json.dumps({"action": "test", "params": {}}))
         data = json.loads(result_str)
         assert data["success"] is False
         assert "Dispatcher not available" in data["message"]
@@ -200,7 +200,7 @@ def test_dispatch_action_no_dispatcher_returns_error():
         mod._dispatcher_ref = original
 
 
-def test_dispatch_action_with_dispatcher():
+def test_dispatch_tool_with_dispatcher():
     from dcc_mcp_core.dcc_server import register_diagnostic_handlers
 
     server = _MockServer()
@@ -208,7 +208,7 @@ def test_dispatch_action_with_dispatcher():
     register_diagnostic_handlers(server, dispatcher=dispatcher, dcc_name="test-dcc")
 
     result_str = server.call(
-        "dispatch_action",
+        "dispatch_tool",
         json.dumps({"action": "my_action", "params": {"key": "value"}}),
     )
     data = json.loads(result_str)
@@ -216,21 +216,31 @@ def test_dispatch_action_with_dispatcher():
     assert data.get("echoed_action") == "my_action"
 
 
-def test_dispatch_action_missing_action_field():
-    from dcc_mcp_core.dcc_server import _handle_dispatch_action
+def test_dispatch_tool_missing_action_field():
+    from dcc_mcp_core.dcc_server import _handle_dispatch_tool
 
-    result_str = _handle_dispatch_action(json.dumps({"params": {}}))
+    result_str = _handle_dispatch_tool(json.dumps({"params": {}}))
     data = json.loads(result_str)
     assert data["success"] is False
     assert "Missing 'action'" in data["message"]
 
 
-def test_dispatch_action_invalid_json():
-    from dcc_mcp_core.dcc_server import _handle_dispatch_action
+def test_dispatch_tool_invalid_json():
+    from dcc_mcp_core.dcc_server import _handle_dispatch_tool
 
-    result_str = _handle_dispatch_action("bad-json")
+    result_str = _handle_dispatch_tool("bad-json")
     data = json.loads(result_str)
     assert data["success"] is False
+
+
+def test_legacy_handler_names_not_registered():
+    """Breaking rename in 0.14.0 — no compat aliases are registered."""
+    from dcc_mcp_core.dcc_server import register_diagnostic_handlers
+
+    server = _MockServer()
+    register_diagnostic_handlers(server, dcc_name="test-dcc")
+    assert "get_action_metrics" not in server._handlers
+    assert "dispatch_action" not in server._handlers
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_diagnostics_mcp_tools.py
+++ b/tests/test_diagnostics_mcp_tools.py
@@ -36,7 +36,7 @@ def server():
 EXPECTED_TOOLS = [
     "diagnostics__screenshot",
     "diagnostics__audit_log",
-    "diagnostics__action_metrics",
+    "diagnostics__tool_metrics",
     "diagnostics__process_status",
 ]
 

--- a/tests/test_multi_instance_gateway.py
+++ b/tests/test_multi_instance_gateway.py
@@ -95,6 +95,60 @@ class TestServiceEntryNewFields:
         assert entry.pid is None
         assert entry.display_name is None
         assert entry.documents == []
+        assert entry.extras == {}
+
+    def test_register_with_extras_scalar_values(self, registry: dcc_mcp_core.TransportManager) -> None:
+        """Extras round-trip scalar JSON values (int / str / bool / None / float)."""
+        extras = {
+            "cdp_port": 9222,
+            "url": "http://localhost:3000",
+            "debug": True,
+            "token": None,
+            "ratio": 1.5,
+        }
+        iid = registry.register_service("webview", "127.0.0.1", 3000, extras=extras)
+        entry = registry.get_service("webview", iid)
+        assert entry is not None
+        assert entry.extras == extras
+
+    def test_register_with_extras_nested_values(self, registry: dcc_mcp_core.TransportManager) -> None:
+        """Extras round-trip nested dicts and lists (lossless JSON storage)."""
+        extras = {
+            "capabilities": {"scene": False, "timeline": True, "selection": False},
+            "tags": ["preview", "cdp", "webview"],
+            "host_dcc": {"name": "maya", "pid": 42000, "version": "2025"},
+        }
+        iid = registry.register_service("webview-maya", "127.0.0.1", 3001, extras=extras)
+        entry = registry.get_service("webview-maya", iid)
+        assert entry is not None
+        assert entry.extras == extras
+        assert entry.extras["capabilities"]["timeline"] is True
+        assert entry.extras["host_dcc"]["pid"] == 42000
+
+    def test_extras_returns_fresh_dict_each_call(self, registry: dcc_mcp_core.TransportManager) -> None:
+        """The ``extras`` getter materialises a new dict each access so mutations stay local."""
+        iid = registry.register_service("blender", "127.0.0.1", 8080, extras={"key": "value"})
+        entry = registry.get_service("blender", iid)
+        assert entry is not None
+        first = entry.extras
+        first["key"] = "mutated"
+        second = entry.extras
+        assert second == {"key": "value"}
+
+    def test_extras_persists_across_to_dict(self, registry: dcc_mcp_core.TransportManager) -> None:
+        """``to_dict()`` includes the extras field for downstream serialisation."""
+        iid = registry.register_service("houdini", "127.0.0.1", 9090, extras={"a": 1, "b": [2, 3]})
+        entry = registry.get_service("houdini", iid)
+        assert entry is not None
+        as_dict = entry.to_dict()
+        assert as_dict["extras"] == {"a": 1, "b": [2, 3]}
+
+    def test_extras_empty_default(self, registry: dcc_mcp_core.TransportManager) -> None:
+        """Not providing extras yields an empty dict, not ``None``."""
+        iid = registry.register_service("nuke", "127.0.0.1", 7070)
+        entry = registry.get_service("nuke", iid)
+        assert entry is not None
+        assert entry.extras == {}
 
 
 # ── update_documents ──────────────────────────────────────────────────────────

--- a/tests/test_tool_registry_required_capabilities.py
+++ b/tests/test_tool_registry_required_capabilities.py
@@ -1,0 +1,108 @@
+"""Tests for ToolRegistry.register(required_capabilities=…) storage path (#211)."""
+
+from __future__ import annotations
+
+# Import third-party modules
+import pytest
+
+# Import local modules
+import dcc_mcp_core
+from dcc_mcp_core import ToolRegistry
+from dcc_mcp_core import WebViewAdapter
+
+
+@pytest.fixture
+def registry() -> ToolRegistry:
+    return ToolRegistry()
+
+
+class TestRequiredCapabilitiesField:
+    def test_default_empty_list(self, registry: ToolRegistry) -> None:
+        """Empty requirements are omitted from the metadata dict for back-compat."""
+        registry.register(name="no_caps_tool", dcc="python")
+        meta = registry.get_action("no_caps_tool")
+        assert meta is not None
+        # Key is skipped via ``skip_serializing_if = "Vec::is_empty"`` — existing
+        # services.json consumers keep byte-identical output when no caps apply.
+        assert meta.get("required_capabilities", []) == []
+
+    def test_passes_through_list(self, registry: ToolRegistry) -> None:
+        registry.register(
+            name="scene_tool",
+            dcc="maya",
+            required_capabilities=["scene", "selection"],
+        )
+        meta = registry.get_action("scene_tool")
+        assert meta is not None
+        assert meta["required_capabilities"] == ["scene", "selection"]
+
+    def test_none_equivalent_to_empty(self, registry: ToolRegistry) -> None:
+        registry.register(name="none_caps_tool", required_capabilities=None)
+        meta = registry.get_action("none_caps_tool")
+        assert meta is not None
+        assert meta.get("required_capabilities", []) == []
+
+    def test_preserves_order(self, registry: ToolRegistry) -> None:
+        registry.register(
+            name="ordered_caps",
+            required_capabilities=["render", "scene", "undo"],
+        )
+        meta = registry.get_action("ordered_caps")
+        assert meta is not None
+        assert meta["required_capabilities"] == ["render", "scene", "undo"]
+
+    def test_allows_custom_capability_keys(self, registry: ToolRegistry) -> None:
+        """Registry is a dumb store — unknown keys pass through unfiltered."""
+        registry.register(
+            name="custom_caps",
+            required_capabilities=["custom_host_feature"],
+        )
+        meta = registry.get_action("custom_caps")
+        assert meta is not None
+        assert meta["required_capabilities"] == ["custom_host_feature"]
+
+
+class TestCapabilitiesWithWebviewAdapter:
+    """Integration sanity: WebViewAdapter.matches_requirements + registry metadata."""
+
+    def test_webview_hides_scene_tool(self, registry: ToolRegistry) -> None:
+        registry.register(name="make_sphere", required_capabilities=["scene"])
+        meta = registry.get_action("make_sphere")
+        assert meta is not None
+        assert not WebViewAdapter.matches_requirements(meta["required_capabilities"])
+
+    def test_webview_shows_uncapped_tool(self, registry: ToolRegistry) -> None:
+        registry.register(name="echo", required_capabilities=[])
+        meta = registry.get_action("echo")
+        assert meta is not None
+        assert WebViewAdapter.matches_requirements(meta.get("required_capabilities", []))
+
+
+class TestRequiredCapabilitiesSearchListRoundTrip:
+    def test_field_present_in_list_actions(self, registry: ToolRegistry) -> None:
+        registry.register(
+            name="timeline_tool",
+            dcc="maya",
+            required_capabilities=["timeline"],
+        )
+        found = [m for m in registry.list_actions() if m["name"] == "timeline_tool"]
+        assert len(found) == 1
+        assert found[0]["required_capabilities"] == ["timeline"]
+
+    def test_field_present_in_search_actions(self, registry: ToolRegistry) -> None:
+        registry.register(
+            name="select_tool",
+            tags=["selection"],
+            dcc="blender",
+            required_capabilities=["selection"],
+        )
+        results = registry.search_actions(tags=["selection"])
+        assert len(results) == 1
+        assert results[0]["required_capabilities"] == ["selection"]
+
+
+def test_capability_keys_exposed() -> None:
+    """Sanity: predefined capability keys are importable from the package root."""
+    assert "scene" in dcc_mcp_core.CAPABILITY_KEYS
+    assert "timeline" in dcc_mcp_core.CAPABILITY_KEYS
+    assert "selection" in dcc_mcp_core.CAPABILITY_KEYS

--- a/tests/test_vtvalue_traverse_registry_service_timing_pool.py
+++ b/tests/test_vtvalue_traverse_registry_service_timing_pool.py
@@ -539,6 +539,7 @@ class TestServiceEntryAttributes:
                 "dcc_type",
                 "display_name",
                 "documents",
+                "extras",
                 "host",
                 "instance_id",
                 "last_heartbeat_ms",


### PR DESCRIPTION
Batch fix for four open issues (one commit per issue, deliberately split for reviewability).  Every commit is self-contained and keeps the Rust / Python test matrix green (`vx just preflight` + `vx just test`, 12 522 Python tests passing locally).

## Issues closed

| Issue | Commit | Scope |
|-------|--------|-------|
| [#210](https://github.com/loonghao/dcc-mcp-core/issues/210) | `0c6c254` feat(transport) | `ServiceEntry.extras: dict[str, Any]` — JSON-typed DCC metadata |
| [#212](https://github.com/loonghao/dcc-mcp-core/issues/212) | `e30ecdf` feat(capture) | `Capturer.capture_window_png` / `capture_region_png` static sugar |
| [#211](https://github.com/loonghao/dcc-mcp-core/issues/211) | `0a6171a` feat(adapters) | `WebViewAdapter` base class + `required_capabilities` storage |
| [#214](https://github.com/loonghao/dcc-mcp-core/issues/214) | `86d3ea1` feat(ipc)! | **Breaking** IPC rename `*_action` → `*_tool` |

## Design decisions (confirmed ahead of implementation)

| # | Decision | Landed |
|---|----------|--------|
| D1 | `capture_window_png` returns `None` on failure (never raises) | ✅ |
| D2 | Also expose `capture_region_png(pid, x, y, w, h)` in this PR | ✅ |
| D3 | `WebViewAdapter` is **standalone**, not a `DccServerBase` subclass | ✅ |
| D4 | Capability filter declared at `ToolRegistry.register(required_capabilities=…)` | ✅ |
| D5 | Capability keys: pre-defined set (`CAPABILITY_KEYS`) + `DccCapabilities.extensions` | ✅ |
| D6 | Ship base class + stored field, filter integration deferred to follow-up | ✅ (registry stores, Gateway filtering is a TODO) |
| D7 | `extras` / `required_capabilities` Python type: `dict[str, Any]` / `list[str]` | ✅ |
| D8 | #214 is a **hard** breaking rename — no compat aliases | ✅ |

## Key changes

### #210 — `ServiceEntry.extras`

- Rust `ServiceEntry.extras: HashMap<String, serde_json::Value>` with `#[serde(default, skip_serializing_if = "HashMap::is_empty")]` — byte-identical `services.json` output when unused.
- PyO3 getter returns a fresh `dict[str, Any]` each call (recursive JSON → Python conversion via `dcc_mcp_utils::py_json`).
- `TransportManager.register_service(..., extras=dict)` kwarg; `ServiceEntry.to_dict()` gains the `"extras"` key.
- Tests: 5 Python integration + 2 Rust unit.

### #212 — Window-capture PNG sugar

- Two `#[staticmethod]` entry points on `Capturer`, so callers don't have to construct a `Capturer` instance first:
  - `Capturer.capture_window_png(pid, *, timeout_ms=1000) -> bytes | None`
  - `Capturer.capture_region_png(pid, x, y, w, h, *, timeout_ms=1000) -> bytes | None`
- Swallow any backend / crop / decode error and return `None` (per D1).
- Region cropping is CPU-side via the `image` crate to keep the backend untouched; zero-width / zero-height short-circuits without capture.
- Tests: 8 new cross-platform pytest cases covering the sugar surface.

### #211 — `WebViewAdapter` base + capability declaration

- New package `python/dcc_mcp_core/adapters/` with a pure-Python `WebViewAdapter` template — **not** a subclass of `DccServerBase` (D3).
- Built-in capability keys frozen at `CAPABILITY_KEYS = {scene, timeline, selection, undo, render}`; `WEBVIEW_DEFAULT_CAPABILITIES` is all-false.
- Helpers on the class: `supports(key)`, `matches_requirements(iterable)`, `advertised_capabilities()` (returns a fresh copy).
- Rust `ActionMeta.required_capabilities: Vec<String>` (also `#[serde(default, skip_serializing_if)]`), wired through `ToolRegistry.register(required_capabilities=…)` and the `register_batch` dict path.
- Filtering is **stored, not enforced** — Gateway / adapter integration is the follow-up per D6.
- Tests: 13 `WebViewAdapter` cases + 13 registry-storage cases.

### #214 — Breaking IPC rename

| Old | New |
|-----|-----|
| IPC `get_action_metrics` | IPC `get_tool_metrics` |
| IPC `dispatch_action` | IPC `dispatch_tool` |
| MCP `diagnostics__action_metrics` | MCP `diagnostics__tool_metrics` |
| skill `dcc_diagnostics__action_metrics` | skill `dcc_diagnostics__tool_metrics` |
| `scripts/action_metrics.py` | `scripts/tool_metrics.py` (git mv, 94 %  similarity) |

No compatibility aliases registered (D8) — the new test `test_legacy_handler_names_not_registered` pins the contract.  Downstream adapters calling `channel.call("dispatch_action", …)` need to update in lock-step.

## Verification

- `vx just preflight` — cargo check / clippy / rustfmt / test-rust all green.
- `vx just test` — **12 522 passed**, 54 skipped (same skip set as `main`; 42 more tests than pre-PR baseline).
- All docstrings / `llms.txt` / `llms-full.txt` / `AGENTS.md` / `_core.pyi` updated in the same commit that introduces each change.

## Follow-ups intentionally deferred

- Gateway-side capability filter that actually hides tools from `tools/list` on sessions whose host DCC does not advertise the declared capabilities (see `WebViewAdapter.matches_requirements` for the sample predicate).  Tracking in a separate issue will happen once this PR lands.
- `DeferredExecutor` promotion to the public `__init__` (unrelated).