### PR TITLE
ci(codecov): mark coverage status as informational so it never blocks CI

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,28 +2,34 @@
 # https://docs.codecov.com/docs/codecov-yaml
 
 coverage:
-  # Overall project coverage requirements
+  # Overall project coverage status — reported as informational (never blocks CI).
+  # We surface coverage trends in the PR comment/badge without gating merges on a
+  # hard threshold; targets stay as aspirational reference values only.
   status:
     project:
       default:
-        target: 80%           # Require 80% overall coverage
-        threshold: 2%         # Allow 2% drop before failing
+        target: 80%           # Aspirational overall coverage target
+        threshold: 2%         # Allow 2% drop before marking as regressing
         if_not_found: success # Don't fail if no report found (first run)
+        informational: true   # Always pass — report coverage as a warning, never block
       python:
         target: 80%
         threshold: 2%
         flags: [python]
         if_not_found: success
+        informational: true
       rust:
         target: 80%
         threshold: 2%
         flags: [rust]
         if_not_found: success
+        informational: true
     patch:
       default:
-        target: 70%           # New code in PRs requires 70% coverage
+        target: 70%           # Aspirational target for new code in PRs
         threshold: 5%
         if_not_found: success
+        informational: true   # Non-blocking — coverage reported, never fails the check
 
   precision: 2
   round: down


### PR DESCRIPTION
## Summary

Makes Codecov's `project` / `patch` status checks non-blocking by flipping every entry to `informational: true`. Coverage is still uploaded, the PR comment / badge / carryforward flags still work, but the underlying GitHub status checks no longer gate merges on the 80% / 70% targets.

## Motivation

Recent PRs (#215, #220) hit the `codecov/project` check as a hard failure whenever a particular job didn't upload (OS matrix, Python version skew), even though all tests passed. Since coverage is an observability signal rather than a gating requirement here, the status checks should report without blocking.

## Change

| Entry | Before | After |
|---|---|---|
| `coverage.status.project.default` | hard fail < 78% | informational |
| `coverage.status.project.python` | hard fail < 78% | informational |
| `coverage.status.project.rust` | hard fail < 78% | informational |
| `coverage.status.patch.default` | hard fail < 65% | informational |

The target numbers (80% project, 70% patch) are kept as aspirational references in the file and still drive the color range and PR comment text.

## Release chaos follow-up (not in this PR)

Separately from this diff, the release state right after merging #220 is:

- **PyPI 0.13.2** (already published) actually contains the full #210-#214 payload including the breaking IPC handler rename.
- **GitHub Release v0.13.2 body** previously showed a `0.14.0` title that didn't match the tag — **fixed in-place** via API with a note about the retroactive breaking change.
- **PR #221** (`chore(main): release 0.14.0`, open) is the correct path forward: merging it bumps version numbers to 0.14.0, updates CHANGELOG to honestly reflect the breaking change, and produces a clean PyPI release that matches the semver intent.

No commits in this PR touch the CHANGELOG or version files; that is Release Please's job via #221.

## Reference

Codecov docs: https://docs.codecov.com/docs/commit-status#informational