### PR TITLE
feat(adapters): add JavaScript and TypeScript to ScriptLanguage enum

### DIFF
--- a/crates/dcc-mcp-protocols/src/adapters/tests.rs
+++ b/crates/dcc-mcp-protocols/src/adapters/tests.rs
@@ -55,6 +55,8 @@ fn test_script_language_display() {
     assert_eq!(ScriptLanguage::Lua.to_string(), "lua");
     assert_eq!(ScriptLanguage::CSharp.to_string(), "csharp");
     assert_eq!(ScriptLanguage::Blueprint.to_string(), "blueprint");
+    assert_eq!(ScriptLanguage::JavaScript.to_string(), "javascript");
+    assert_eq!(ScriptLanguage::TypeScript.to_string(), "typescript");
 }
 
 #[test]
@@ -64,6 +66,24 @@ fn test_script_language_serialization_roundtrip() {
     assert_eq!(json, "\"python\"");
     let deserialized: ScriptLanguage = serde_json::from_str(&json).unwrap();
     assert_eq!(deserialized, ScriptLanguage::Python);
+}
+
+#[test]
+fn test_script_language_javascript_serialization_roundtrip() {
+    let lang = ScriptLanguage::JavaScript;
+    let json = serde_json::to_string(&lang).unwrap();
+    assert_eq!(json, "\"javascript\"");
+    let deserialized: ScriptLanguage = serde_json::from_str(&json).unwrap();
+    assert_eq!(deserialized, ScriptLanguage::JavaScript);
+}
+
+#[test]
+fn test_script_language_typescript_serialization_roundtrip() {
+    let lang = ScriptLanguage::TypeScript;
+    let json = serde_json::to_string(&lang).unwrap();
+    assert_eq!(json, "\"typescript\"");
+    let deserialized: ScriptLanguage = serde_json::from_str(&json).unwrap();
+    assert_eq!(deserialized, ScriptLanguage::TypeScript);
 }
 
 #[test]

--- a/crates/dcc-mcp-protocols/src/adapters/types.rs
+++ b/crates/dcc-mcp-protocols/src/adapters/types.rs
@@ -83,6 +83,14 @@ pub enum ScriptLanguage {
     CSharp,
     /// Blueprint/Visual Script (Unreal Engine).
     Blueprint,
+    /// JavaScript — served via CDP `Runtime.evaluate` to WebView-host DCCs
+    /// (auroraview, Photoshop UXP, Figma, embedded CEF/WebView2 panels).
+    #[serde(rename = "javascript")]
+    JavaScript,
+    /// TypeScript — compiled-ahead or evaluated via a TS host
+    /// (Figma plugin runtime, UXP manifests).
+    #[serde(rename = "typescript")]
+    TypeScript,
 }
 
 impl std::fmt::Display for ScriptLanguage {
@@ -96,6 +104,8 @@ impl std::fmt::Display for ScriptLanguage {
             Self::Lua => write!(f, "lua"),
             Self::CSharp => write!(f, "csharp"),
             Self::Blueprint => write!(f, "blueprint"),
+            Self::JavaScript => write!(f, "javascript"),
+            Self::TypeScript => write!(f, "typescript"),
         }
     }
 }

--- a/crates/dcc-mcp-protocols/src/adapters_python/enums.rs
+++ b/crates/dcc-mcp-protocols/src/adapters_python/enums.rs
@@ -38,6 +38,10 @@ pub enum PyScriptLanguage {
     CSharp,
     #[pyo3(name = "BLUEPRINT")]
     Blueprint,
+    #[pyo3(name = "JAVASCRIPT")]
+    JavaScript,
+    #[pyo3(name = "TYPESCRIPT")]
+    TypeScript,
 }
 
 #[cfg(feature = "python-bindings")]
@@ -57,6 +61,8 @@ impl PyScriptLanguage {
             Self::Lua => "LUA",
             Self::CSharp => "CSHARP",
             Self::Blueprint => "BLUEPRINT",
+            Self::JavaScript => "JAVASCRIPT",
+            Self::TypeScript => "TYPESCRIPT",
         }
     }
 }
@@ -73,6 +79,8 @@ impl From<ScriptLanguage> for PyScriptLanguage {
             ScriptLanguage::Lua => PyScriptLanguage::Lua,
             ScriptLanguage::CSharp => PyScriptLanguage::CSharp,
             ScriptLanguage::Blueprint => PyScriptLanguage::Blueprint,
+            ScriptLanguage::JavaScript => PyScriptLanguage::JavaScript,
+            ScriptLanguage::TypeScript => PyScriptLanguage::TypeScript,
         }
     }
 }
@@ -89,6 +97,8 @@ impl From<&PyScriptLanguage> for ScriptLanguage {
             PyScriptLanguage::Lua => ScriptLanguage::Lua,
             PyScriptLanguage::CSharp => ScriptLanguage::CSharp,
             PyScriptLanguage::Blueprint => ScriptLanguage::Blueprint,
+            PyScriptLanguage::JavaScript => ScriptLanguage::JavaScript,
+            PyScriptLanguage::TypeScript => ScriptLanguage::TypeScript,
         }
     }
 }

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -659,6 +659,8 @@ class ScriptLanguage:
     LUA: ScriptLanguage
     CSHARP: ScriptLanguage
     BLUEPRINT: ScriptLanguage
+    JAVASCRIPT: ScriptLanguage
+    TYPESCRIPT: ScriptLanguage
 
     def __repr__(self) -> str: ...
     def __str__(self) -> str: ...

--- a/tests/test_adapters_python.py
+++ b/tests/test_adapters_python.py
@@ -51,6 +51,16 @@ class TestScriptLanguage:
         lang = dcc_mcp_core.ScriptLanguage.BLUEPRINT
         assert str(lang) == "BLUEPRINT"
 
+    def test_javascript_variant(self) -> None:
+        lang = dcc_mcp_core.ScriptLanguage.JAVASCRIPT
+        assert str(lang) == "JAVASCRIPT"
+        assert "JAVASCRIPT" in repr(lang)
+
+    def test_typescript_variant(self) -> None:
+        lang = dcc_mcp_core.ScriptLanguage.TYPESCRIPT
+        assert str(lang) == "TYPESCRIPT"
+        assert "TYPESCRIPT" in repr(lang)
+
     def test_equality(self) -> None:
         assert dcc_mcp_core.ScriptLanguage.PYTHON == dcc_mcp_core.ScriptLanguage.PYTHON
         assert dcc_mcp_core.ScriptLanguage.MEL != dcc_mcp_core.ScriptLanguage.PYTHON


### PR DESCRIPTION
## Summary

- Add `JavaScript` and `TypeScript` variants to `ScriptLanguage` enum for WebView-host DCCs (auroraview, Photoshop UXP, Figma, embedded CEF/WebView2 panels)
- Use explicit `#[serde(rename = "javascript")]` / `#[serde(rename = "typescript")]` to produce clean wire names instead of default `snake_case` (`"java_script"` / `"type_script"`)
- Full PyO3 mirror with `JAVASCRIPT` / `TYPESCRIPT` Python constants, bidirectional `From` impls, and updated type stubs

## Changed files

| File | What |
|------|------|
| `crates/dcc-mcp-protocols/src/adapters/types.rs` | 2 new enum variants + serde overrides + Display arms |
| `crates/dcc-mcp-protocols/src/adapters_python/enums.rs` | PyO3 variants + `__str__` + `From` impls |
| `python/dcc_mcp_core/_core.pyi` | Type stub attributes |
| `crates/dcc-mcp-protocols/src/adapters/tests.rs` | Display + serde roundtrip tests |
| `tests/test_adapters_python.py` | Python variant tests |

## Test plan

- [x] `cargo test -p dcc-mcp-protocols` — 137 passed
- [x] `cargo test --workspace` — no exhaustive match errors
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo fmt --all -- --check` — clean
- [x] `pytest tests/test_adapters_python.py` — 96 passed (incl. new JS/TS tests)

Closes #222, progresses #209