### PR TITLE
docs: enhance AI agent guidance and fix documentation inconsistencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ A Rust-powered MCP (Model Context Protocol) library that lets AI agents interact
 | Bridge non-Python DCCs (Photoshop, ZBrush) | `DccBridge` (WebSocket JSON-RPC 2.0) |
 | IPC between processes | `IpcListener.bind()` / `connect_ipc()` / `FramedChannel.call()` |
 | Multi-DCC gateway | `McpHttpConfig(gateway_port=9765)` |
-| Trust-based skill scoping | `SkillScope` (Repo → User → System → Admin) |
+| Trust-based skill scoping | `SkillScope` (Repo → User → System → Admin) — **Rust-only**; Python uses string values via `SkillMetadata` |
 | Progressive tool exposure | `SkillGroup` with `default_active` + `activate_tool_group()` |
 | Instance-bound diagnostics | `DccServerBase(..., dcc_pid=pid)` → scoped `diagnostics__*` tools |
 
@@ -81,6 +81,11 @@ A Rust-powered MCP (Model Context Protocol) library that lets AI agents interact
 **USD scene exchange?**
 → [`docs/api/usd.md`](docs/api/usd.md)
 
+**WebView integration (embedded browser panels)?**
+→ `python/dcc_mcp_core/adapters/webview.py` — `WebViewAdapter`, `WebViewContext`
+→ Constants: `CAPABILITY_KEYS`, `WEBVIEW_DEFAULT_CAPABILITIES`
+→ Note: Currently Python-only, not in `_core.pyi`
+
 **Screen capture, shared memory, telemetry, process management?**
 → `docs/api/capture.md`, `docs/api/shm.md`, `docs/api/telemetry.md`, `docs/api/process.md`
 
@@ -136,6 +141,7 @@ dcc-mcp-core/
 │   ├── hotreload.py                # Pure-Python: DccSkillHotReloader
 │   ├── bridge.py                   # Pure-Python: DccBridge (WebSocket JSON-RPC 2.0)
 │   ├── dcc_server.py               # Pure-Python: register_diagnostic_handlers + register_diagnostic_mcp_tools
+│   ├── adapters/                   # Pure-Python: WebViewAdapter, WebViewContext, capabilities
 │   └── skills/                     # Bundled: dcc-diagnostics, workflow (in wheel)
 │
 ├── tests/                          # 120+ integration tests — executable usage examples
@@ -240,8 +246,8 @@ Capturer.new_window_auto().capture_window(window_title="Maya 2024")
 
 **Tool groups — inactive groups are hidden, not deleted:**
 ```python
-# default_active=false tools are registered with ActionMeta.enabled=False.
-# tools/list hides them but registry.list_actions() still returns them.
+# default_active=false tools are hidden from tools/list but remain in ToolRegistry.
+# Use registry.list_actions() (shows all) vs registry.list_actions_enabled() (active only).
 registry.activate_tool_group("maya-geometry", "rigging")   # emits tools/list_changed
 ```
 
@@ -259,6 +265,11 @@ return success_result("done", count=5)      # → ToolResult instance
 # Scope hierarchy: Repo < User < System < Admin
 # A System-scoped skill silently shadows a Repo-scoped skill with the same name.
 # This prevents project-local skills from hijacking enterprise-managed ones.
+# NOTE: SkillScope/SkillPolicy are Rust-level types not exported to Python.
+# Access scope info via SkillMetadata: metadata.is_implicit_invocation_allowed(),
+# metadata.matches_product(dcc_name). Configure via SKILL.md frontmatter:
+#   allow_implicit_invocation: false
+#   products: ["maya", "blender"]
 ```
 
 **`allow_implicit_invocation: false` ≠ `defer-loading: true`:**
@@ -267,6 +278,28 @@ return success_result("done", count=5)      # → ToolResult instance
 # defer-loading: true → tool stub appears in tools/list but needs load_skill()
 # Both delay tool availability, but the former is a *policy* (security),
 # the latter is a *hint* (progressive loading). Use both for maximum control.
+```
+
+**MCP security — design tools for safe AI interaction:**
+```python
+# Use ToolAnnotations to signal safety properties to AI clients:
+from dcc_mcp_core import ToolAnnotations
+annotations = ToolAnnotations(
+    read_only_hint=True,       # tool only reads data, no side effects
+    destructive_hint=False,    # tool may cause irreversible changes
+    idempotent_hint=True,      # repeated calls produce same result
+)
+# Design tools around user workflows, not raw API calls.
+# Return human-readable errors via error_result("msg", "specific error").
+# Use notifications/tools/list_changed when the tool set changes.
+```
+
+**`skill_warning()` / `skill_exception()` — additional skill helpers:**
+```python
+from dcc_mcp_core import skill_warning, skill_exception
+# skill_warning() — partial success with warnings (success=True but with caveat)
+# skill_exception() — wrap an exception into error dict format
+# Both are pure-Python helpers in python/dcc_mcp_core/skill.py
 ```
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,14 +223,16 @@ def test_skill_scan(tmp_path):
 - **Bridge system**: `BridgeRegistry`, `BridgeContext`, `register_bridge()`, `get_bridge_context()` — for inter-protocol bridging (RPyC ↔ MCP etc.). Don't build custom bridge registries.
 - **Scene data model**: `BoundingBox`, `FrameRange`, `ObjectTransform`, `SceneNode`, `SceneObject`, `RenderOutput` — use for structured scene data instead of raw dicts. `BoundingBox` may be `None`.
 - **Serialization**: `serialize_result()` / `deserialize_result()` with `SerializeFormat` enum — for transport-safe ToolResult serialization. Don't use `json.dumps()` on ToolResult.
-- **SkillScope & SkillPolicy** (v0.13+): Trust hierarchy (`Repo` < `User` < `System` < `Admin`) — higher scopes shadow lower for same-name skills. `SkillPolicy` controls `allow_implicit_invocation` and `products` filter.
+- **SkillScope & SkillPolicy** (v0.13+): Trust hierarchy (`Repo` < `User` < `System` < `Admin`) — higher scopes shadow lower for same-name skills. **These are Rust-level types not directly importable from Python.** Configure via SKILL.md frontmatter (`allow_implicit_invocation`, `products`) and access via `SkillMetadata.is_implicit_invocation_allowed()` / `SkillMetadata.matches_product(dcc_name)`.
+- **WebViewAdapter** (Python-only): `from dcc_mcp_core import WebViewAdapter, WebViewContext, CAPABILITY_KEYS, WEBVIEW_DEFAULT_CAPABILITIES` — for embedding browser panels in DCC applications. Not in `_core.pyi`.
+- **`skill_warning()` / `skill_exception()`**: Pure-Python helpers in `skill.py`. `skill_warning()` returns a partial-success dict with warnings; `skill_exception()` wraps exceptions into error dict format.
 - **Action→Tool rename** (v0.13): Conceptual rename complete; some Rust API method names (`get_action`, `list_actions`, `search_actions`) remain as compatibility aliases — not bugs.
 - **MCP best practices**: Design tools around user workflows, not raw API calls. Use `ToolAnnotations` for safety hints (`read_only_hint`, `destructive_hint`, `idempotent_hint`). Return human-readable errors.
 
 ## Key Files to Read First (Priority Order)
 
-1. `python/dcc_mcp_core/__init__.py` — Complete public API (~154 symbols including BridgeRegistry, BridgeContext, BoundingBox, FrameRange, ObjectTransform, SceneNode, SceneObject, RenderOutput, SerializeFormat)
-2. `python/dcc_mcp_core/_core.pyi` — Type stubs with parameter names
+1. `python/dcc_mcp_core/__init__.py` — Complete public API (~154 symbols including BridgeRegistry, BridgeContext, BoundingBox, FrameRange, ObjectTransform, SceneNode, SceneObject, RenderOutput, SerializeFormat, WebViewAdapter, WebViewContext)
+2. `python/dcc_mcp_core/_core.pyi` — Type stubs with parameter names (does NOT include WebViewAdapter — that's Python-only)
 3. `AGENTS.md` — Full architecture, commands, pitfalls
 4. `crates/*/src/python.rs` — PyO3 binding implementations
 5. `src/lib.rs` — Module registration entry point

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,7 +8,17 @@
 You are working on **dcc-mcp-core**, a Rust-powered MCP (Model Context Protocol) library for DCC
 (Digital Content Creation) applications. Python package: `dcc_mcp_core`. ~154 public symbols,
 zero runtime Python dependencies (everything compiled into Rust core via PyO3), plus pure-Python
-helpers (DccServerBase, DccGatewayElection, DccSkillHotReloader, factory, skill helpers).
+helpers (DccServerBase, DccGatewayElection, DccSkillHotReloader, factory, skill helpers, WebViewAdapter).
+
+## Response Language
+
+- Reply to the user in **Simplified Chinese** (中文简体) by default.
+- Keep all code, identifiers, commit messages, branch names, docstrings,
+  comments, and file contents in **English** — this rule governs only the
+  conversational/assistant-facing output, not anything written to disk or
+  pushed to git.
+- If the user explicitly requests another language for a specific reply,
+  follow that request for that turn.
 
 ## Priority Reading Order
 
@@ -120,6 +130,43 @@ DCC_MCP_SKILL_PATHS env var
 
 Action naming: `{skill_name}__{script_stem}` (hyphens → underscores, `__` separator)
 
+### Quick Lookup: Common Method Signatures
+
+```python
+# ToolDispatcher — only .dispatch(), never .call()
+dispatcher = ToolDispatcher(registry)   # takes ONE arg; no validator param
+result = dispatcher.dispatch("action_name", json.dumps({"key": "value"}))
+# result keys: "action", "output", "validation_skipped"
+
+# scan_and_load — ALWAYS returns a 2-TUPLE
+skills, skipped = scan_and_load(dcc_name="maya")   # never: skills = scan_and_load(...)
+
+# success_result — extra kwargs go into context, NOT "context=" keyword arg
+result = success_result("message", prompt="hint", count=5)
+# result.context == {"count": 5}
+
+# error_result — positional args
+result = error_result("Failed", "specific error string")
+
+# EventBus.subscribe returns int ID
+sub_id = bus.subscribe("event_name", handler_fn)
+bus.unsubscribe("event_name", sub_id)
+
+# ToolRegistry.register — takes keyword args, NOT handler=
+registry.register(name="action", description="...", dcc="maya", version="1.0.0")
+# Use dispatcher.register_handler() to attach a Python callable
+
+# FramedChannel.call() — primary RPC helper (v0.12.7+)
+channel = connect_ipc(TransportAddress.default_local("maya", pid))
+result = channel.call("execute_python", b'cmds.sphere()', timeout_ms=30000)
+# result: {"id": str, "success": bool, "payload": bytes, "error": str|None}
+
+# McpHttpServer — expose registry over HTTP/MCP
+server = McpHttpServer(registry, McpHttpConfig(port=8765))
+handle = server.start()   # McpServerHandle
+print(handle.mcp_url())   # "http://127.0.0.1:8765/mcp"
+```
+
 ### On-Demand Skill Discovery (MCP HTTP)
 
 `tools/list` returns three tiers:
@@ -165,11 +212,17 @@ search-hint: "polygon modeling, bevel, extrude, mesh editing"
 
 23. **`search_hint` fallback**: If `search-hint:` is not in SKILL.md, `SkillSummary.search_hint` falls back to `description`. Set `search-hint` explicitly for better keyword matching.
 
-24. **SkillScope & SkillPolicy** (v0.13+): Trust hierarchy `Repo` < `User` < `System` < `Admin`. Higher-scope skills shadow lower-scope ones with the same name. `SkillPolicy.allow_implicit_invocation` controls auto-loading; `SkillPolicy.products` filters by DCC type.
+24. **SkillScope & SkillPolicy** (v0.13+): Trust hierarchy `Repo` < `User` < `System` < `Admin`. Higher-scope skills shadow lower-scope ones with the same name. **These are Rust-level types not directly importable from Python.** Configure via SKILL.md frontmatter (`allow_implicit_invocation`, `products`) and access via `SkillMetadata.is_implicit_invocation_allowed()` / `SkillMetadata.matches_product(dcc_name)`.
 
-25. **Action→Tool compatibility** (v0.13): The project renamed "action" → "tool" conceptually. Method names `get_action`, `list_actions`, `search_actions` remain as compatibility aliases — not bugs.
+25. **WebViewAdapter** (Python-only): `from dcc_mcp_core import WebViewAdapter, WebViewContext, CAPABILITY_KEYS, WEBVIEW_DEFAULT_CAPABILITIES` — for embedding browser panels in DCC applications. Not in `_core.pyi`.
 
-26. **MCP best practices**: Design tools around user workflows, not API calls. Use `ToolAnnotations` for safety hints. Return human-readable errors. Use `notifications/tools/list_changed` when the tool set changes.
+26. **`skill_warning()` / `skill_exception()`**: Pure-Python helpers in `skill.py`. `skill_warning()` returns a partial-success dict with warnings; `skill_exception()` wraps exceptions into error dict format.
+
+27. **Action→Tool compatibility** (v0.13): The project renamed "action" → "tool" conceptually. Method names `get_action`, `list_actions`, `search_actions` remain as compatibility aliases — not bugs.
+
+28. **MCP best practices**: Design tools around user workflows, not API calls. Use `ToolAnnotations` for safety hints (`read_only_hint`, `destructive_hint`, `idempotent_hint`). Return human-readable errors. Use `notifications/tools/list_changed` when the tool set changes.
+
+29. **`ActionMeta` is Rust-only**: Do not reference `ActionMeta.enabled` or `ActionMeta.group` in Python code. Use `ToolRegistry.set_tool_enabled(name, enabled)` and `ToolRegistry.list_tools_in_group(skill, group)` instead.
 
 ## CI/CD Summary
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -69,6 +69,45 @@ print(tool_names)
 
 See the [Skills System guide](/guide/skills) for writing `SKILL.md` files and advanced options.
 
+### Writing a Minimal SKILL.md
+
+Create a skill in three steps:
+
+```bash
+# 1. Create the skill directory structure
+mkdir -p my-skill/scripts
+
+# 2. Write SKILL.md (follows agentskills.io specification)
+cat > my-skill/SKILL.md << 'EOF'
+---
+name: my-skill
+description: "Does something useful in Maya. Use when user asks to do X."
+dcc: maya
+version: "1.0.0"
+search-hint: "keyword1, keyword2, related task"
+---
+
+# My Skill
+
+Instructions for the AI agent on how to use this skill.
+EOF
+
+# 3. Add a script
+cat > my-skill/scripts/do_thing.py << 'EOF'
+import sys, json
+
+def main():
+    params = json.loads(sys.stdin.read())
+    # ... do work ...
+    print(json.dumps({"success": True, "message": "Done"}))
+
+if __name__ == "__main__":
+    main()
+EOF
+```
+
+Then set `DCC_MCP_SKILL_PATHS` to the parent directory and use `create_skill_server` or `SkillCatalog.discover()`.
+
 ### Tool Registry
 
 ```python
@@ -209,6 +248,33 @@ vx just lint
 - See the [Transport Layer](/guide/transport) for DCC communication
 - Understand the [Architecture](/guide/architecture) of the 14-crate Rust workspace
 - Learn [Skill Scopes & Policies](/guide/skill-scopes-policies) for trust-based skill management
+
+## Troubleshooting
+
+### Build/Import Errors
+
+```bash
+# Symbol in __init__.py but ImportError → rebuild the dev wheel
+vx just dev
+
+# Verify import works
+python -c "import dcc_mcp_core; print(hasattr(dcc_mcp_core, 'MyNewSymbol'))"
+
+# Verbose cargo build to catch errors
+cargo build --workspace --features python-bindings 2>&1 | grep -E "error|warning" | head -30
+```
+
+### Common Mistakes
+
+| Problem | Solution |
+|---------|----------|
+| `scan_and_load` returns wrong results | Always unpack: `skills, skipped = scan_and_load(...)` — it returns a 2-tuple |
+| `success_result` context is empty | Pass kwargs directly: `success_result("msg", count=5)` — NOT `context={"count":5}` |
+| `ToolDispatcher.call()` not found | Use `.dispatch(name, json_str)` — there is no `.call()` method |
+| `McpHttpServer` tools not appearing | Register all tools BEFORE `server.start()` — the server reads the registry at startup |
+| `SkillScope` / `SkillPolicy` ImportError | These are Rust-only types. Use SKILL.md frontmatter and `SkillMetadata` methods instead |
+| `DeferredExecutor` ImportError | Import directly: `from dcc_mcp_core._core import DeferredExecutor` |
+| Skill scripts not discovered | Check `DCC_MCP_SKILL_PATHS` env var and `dcc:` field in SKILL.md matches your filter |
 
 ## Building a DCC Adapter with DccServerBase
 

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -1,6 +1,6 @@
 # Skills System
 
-The Skills system allows you to register any script (Python, MEL, MaxScript, BAT, Shell, etc.) as an MCP-discoverable tool with **zero Python code**. It directly reuses the [OpenClaw Skills](https://docs.openclaw.ai/tools) / Anthropic Skills ecosystem format.
+The Skills system allows you to register any script (Python, MEL, MaxScript, BAT, Shell, etc.) as an MCP-discoverable tool with **zero Python code**. It follows the [agentskills.io](https://agentskills.io/specification) specification for SKILL.md format, with DCC-specific extensions (`dcc`, `search-hint`, `tools`, `groups`, `depends`).
 
 ## Quick Start
 
@@ -270,6 +270,28 @@ deps = expand_transitive_dependencies(skills, "maya-animation")
 # ["maya-geometry"]
 ```
 
+## Skill Directory Structure
+
+Beyond the required `SKILL.md` and `scripts/`, the [agentskills.io](https://agentskills.io/specification) specification defines optional directories:
+
+```
+my-skill/
+├── SKILL.md          # Required: metadata + instructions
+├── scripts/          # Required: executable code
+├── references/       # Optional: supplementary docs loaded on demand
+│   ├── REFERENCE.md  # Detailed technical reference
+│   └── FORMS.md      # Form templates or structured data formats
+├── assets/           # Optional: templates, images, data files
+└── metadata/         # Optional: dcc-mcp-core dependency declarations
+    └── depends.md    # YAML list of dependency skill names
+```
+
+**`references/`** — Additional documentation that agents load on demand. Keep each file focused and small (< 2000 tokens recommended) to minimize context consumption. Reference files from SKILL.md body using relative paths: `See [reference guide](references/REFERENCE.md) for details.`
+
+**`assets/`** — Static resources like document templates, configuration templates, images, or lookup tables. Not automatically loaded; agents access them when needed.
+
+> **Tip**: Keep the main `SKILL.md` body under **500 lines** and **5000 tokens**. Move detailed reference material to `references/` files — agents load them only when needed (progressive disclosure).
+
 ## SkillMetadata Fields
 
 Parsed from SKILL.md frontmatter. Supports Anthropic Skills, ClawHub/OpenClaw, and dcc-mcp-core extensions simultaneously.
@@ -341,10 +363,10 @@ tools:
 When `SkillCatalog.load_skill("maya-geometry")` runs:
 
 1. All tool declarations are registered in `ToolRegistry` with their
-   `ActionMeta.group` set to the declared group name.
-2. Tools in groups where `default_active=false` are registered with
-   `ActionMeta.enabled=False`. The MCP server hides disabled tools from
-   `tools/list`; they are invocable again once the group is activated.
+   group metadata set to the declared group name.
+2. Tools in groups where `default_active=false` are hidden from
+   `tools/list`. They remain in the registry (visible via `list_actions()`)
+   and become active once the group is activated.
 3. `SkillCatalog.active_groups(skill_name)` returns the initially-active groups.
 
 ### Controlling Groups at Runtime

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -634,9 +634,9 @@ tools:
 
 **Runtime behaviour after `load_skill`:**
 
-1. Every tool is registered in `ToolRegistry` with `ActionMeta.group` set.
-2. Tools whose group has `default_active=false` are registered with
-   `ActionMeta.enabled=False` — MCP `tools/list` hides them.
+1. Every tool is registered in `ToolRegistry` with its group metadata set.
+2. Tools whose group has `default_active=false` are hidden from
+   MCP `tools/list` — they remain in the registry and become visible once activated.
 3. `tools/list` also emits `__group__<skill>.<group>` stubs for inactive
    groups so clients can discover and activate them on demand.
 

--- a/llms.txt
+++ b/llms.txt
@@ -158,6 +158,7 @@ crates/
 **Tool groups (progressive exposure):**
 - `ToolRegistry.activate_tool_group(skill, group) -> int`, `.deactivate_tool_group(skill, group) -> int` — enable/disable tools in a group; emits `notifications/tools/list_changed`
 - `ToolRegistry.list_tools_in_group(skill, group) -> List[dict]`, `.list_actions_enabled() -> List[dict]`, `.set_tool_enabled(name, enabled) -> bool`
+- **Note**: `ActionMeta` is a Rust-internal type not accessible from Python. Use the `ToolRegistry` methods above to control tool visibility.
 - MCP core tools: `activate_tool_group`, `deactivate_tool_group`, `search_tools` (registered alongside the six skill-discovery tools; `tools/list` also emits `__group__<skill>.<group>` stubs for inactive groups)
 
 **Action naming**: `{skill_name}__{script_stem}` — hyphens in skill names replaced by underscores
@@ -267,19 +268,24 @@ crates/
 - `register_bridge(name, ctx)` — register a named bridge
 - `get_bridge_context(name) -> Optional[BridgeContext]` — retrieve bridge by name
 
+### WebView System (`dcc_mcp_core`)
+
+- `WebViewAdapter` — Python-only: embed browser panels in DCC applications
+- `WebViewContext` — Python-only: webview context with capabilities and configuration
+- `CAPABILITY_KEYS` — Python-only: available capability key constants
+- `WEBVIEW_DEFAULT_CAPABILITIES` — Python-only: default capability set
+- Note: These are pure-Python helpers, not in `_core.pyi`
+
 ### Skill Scopes & Policies (`dcc_mcp_core`)
 
-- `SkillScope` — enum: `Repo`, `User`, `System`, `Admin` (ascending trust; higher shadows lower)
+- `SkillScope` — enum: `Repo`, `User`, `System`, `Admin` (ascending trust; higher shadows lower). **Rust-only type — not importable from Python.** Configure via SKILL.md frontmatter and access via `SkillMetadata` methods.
   - `Repo` — project-local (e.g. `./<project>/.dcc_skills/`)
   - `User` — user-level (e.g. `~/.dcc_mcp/skills/`)
   - `System` — system-wide (e.g. `/opt/dcc_mcp/skills/`)
   - `Admin` — enterprise-managed (elevated privilege)
-  - `SkillScope.is_elevated()` — `True` for System and Admin
-  - `SkillScope.label()` — short string (`"repo"`, `"user"`, etc.)
-- `SkillPolicy` — declared in SKILL.md frontmatter
+- `SkillPolicy` — declared in SKILL.md frontmatter. **Rust-only type — not importable from Python.** Access via `SkillMetadata`:
   - `allow_implicit_invocation: bool` (default `True`) — when `False`, skill must be explicitly `load_skill()`'d
   - `products: list[str]` — DCC type whitelist (case-insensitive)
-  - `SkillMetadata.policy` — access the policy object
   - `SkillMetadata.is_implicit_invocation_allowed()` — check policy
   - `SkillMetadata.matches_product(dcc_name)` — check product filter
 


### PR DESCRIPTION
Run #13 of the AI documentation automation. Critical fixes: SkillScope/SkillPolicy Rust-only clarification, ActionMeta Python accessibility fix, agentskills.io reference unification. New content: WebViewAdapter docs, MCP security best practices, skill_warning/skill_exception docs, minimal SKILL.md example, troubleshooting section, GEMINI.md parity with CLAUDE.md.