### PR TITLE
feat(http): progress notifications and cooperative cancellation (#240, #241)

### DIFF
--- a/crates/dcc-mcp-http/src/handler.rs
+++ b/crates/dcc-mcp-http/src/handler.rs
@@ -24,6 +24,7 @@ use crate::{
     bridge_registry::BridgeRegistry,
     error::HttpError,
     executor::DccExecutorHandle,
+    inflight::{CancelToken, InFlightEntry, InFlightRequests, ProgressReporter},
     protocol::{
         self, CallToolParams, CallToolResult, InitializeResult, JsonRpcBatch, JsonRpcMessage,
         JsonRpcRequest, JsonRpcResponse, ListToolsResult, MCP_SESSION_HEADER, McpTool,
@@ -64,6 +65,7 @@ pub struct AppState {
     /// task in `McpHttpServer::start()` runs `purge_expired_cancellations()`
     /// every 60 seconds to keep this map bounded.
     pub cancelled_requests: Arc<DashMap<String, Instant>>,
+    pub in_flight: InFlightRequests,
 }
 
 impl AppState {
@@ -275,7 +277,10 @@ async fn handle_notification(state: &AppState, method: &str, params: Option<&Val
             if let Some(id) = id_str {
                 if !id.is_empty() {
                     tracing::info!(request_id = %id, "MCP request cancelled by client");
-                    state.cancelled_requests.insert(id, Instant::now());
+                    state.cancelled_requests.insert(id.clone(), Instant::now());
+                    if state.in_flight.request_cancel(&id) {
+                        tracing::debug!(request_id = %id, "cancel flag set on in-flight request");
+                    }
                 }
             }
         }
@@ -497,20 +502,72 @@ async fn handle_tools_call(
         ));
     }
 
-    // Dispatch via ActionDispatcher
+    // ── Register in-flight entry (#240 progress + #241 cancellation) ─────
+    let req_id_str: Option<String> = req.id.as_ref().map(|id| match id {
+        Value::String(s) => s.clone(),
+        Value::Number(n) => n.to_string(),
+        other => serde_json::to_string(other).unwrap_or_default(),
+    });
+
+    let progress_token = params.meta.as_ref().and_then(|m| m.progress_token.clone());
+    let cancel_token = CancelToken::new();
+    let progress_reporter = ProgressReporter::new(
+        progress_token.clone(),
+        session_id.map(str::to_owned),
+        state.sessions.clone(),
+        req_id_str.clone().unwrap_or_default(),
+    );
+
+    if let Some(ref rid) = req_id_str {
+        let entry = InFlightEntry::new(cancel_token.clone(), progress_reporter.clone());
+        state.in_flight.insert(rid.clone(), entry);
+        tracing::debug!(
+            request_id = %rid,
+            has_progress_token = progress_token.is_some(),
+            "registered in-flight request"
+        );
+    }
+
+    // ── Pre-dispatch early-cancel check ───────────────────────────────────
+    if let Some(ref rid) = req_id_str {
+        let already_cancelled = state
+            .cancelled_requests
+            .get(rid)
+            .is_some_and(|ts| ts.elapsed() < CANCELLED_REQUEST_TTL);
+        if already_cancelled {
+            state.in_flight.remove(rid);
+            state.cancelled_requests.remove(rid);
+            tracing::info!(request_id = %rid, "request cancelled before dispatch");
+            let envelope = DccMcpError::new(
+                "registry",
+                "CANCELLED",
+                format!("Request {rid} was cancelled before dispatch."),
+            )
+            .with_hint("Re-send the request if you still need the result.");
+            return Ok(JsonRpcResponse::success(
+                req.id.clone(),
+                serde_json::to_value(CallToolResult::error(envelope.to_json()))?,
+            ));
+        }
+    }
+
+    // Dispatch — cancel token is checked before entering the action.
+    let cancel_token_for_dispatch = cancel_token.clone();
     let dispatch_outcome = if let Some(exec) = &state.executor {
-        // DCC main-thread path: run synchronous dispatch inside DeferredExecutor
+        // DCC main-thread path
         let dispatcher = state.dispatcher.clone();
         let name = tool_name.clone();
         let p = call_params.clone();
+        let ct = cancel_token_for_dispatch;
         exec.execute(Box::new(move || {
+            if ct.is_cancelled() {
+                return serde_json::to_string(&json!({"__dispatch_error": "CANCELLED"}))
+                    .unwrap_or_default();
+            }
             match dispatcher.dispatch(&name, p) {
                 Ok(r) => serde_json::to_string(&r.output).unwrap_or_else(|_| "null".to_string()),
-                Err(e) => {
-                    // Encode error in a sentinel JSON object
-                    let err_obj = json!({"__dispatch_error": e.to_string()});
-                    serde_json::to_string(&err_obj).unwrap_or_default()
-                }
+                Err(e) => serde_json::to_string(&json!({"__dispatch_error": e.to_string()}))
+                    .unwrap_or_default(),
             }
         }))
         .await
@@ -524,17 +581,36 @@ async fn handle_tools_call(
         })
         .unwrap_or_else(|e| Err(e.to_string()))
     } else {
-        // Non-DCC path: use spawn_blocking so we don't block the async runtime
+        // Non-DCC path: spawn_blocking with cooperative cancel monitor.
         let dispatcher = state.dispatcher.clone();
         let name = tool_name.clone();
         let p = call_params.clone();
-        tokio::task::spawn_blocking(move || dispatcher.dispatch(&name, p))
-            .await
-            .map_err(|e| e.to_string())
-            .and_then(|r| r.map(|d| d.output).map_err(|e| e.to_string()))
+        let ct_for_block = cancel_token_for_dispatch.clone();
+        let dispatch_fut = tokio::task::spawn_blocking(move || {
+            if ct_for_block.is_cancelled() {
+                return Err("CANCELLED".to_string());
+            }
+            dispatcher
+                .dispatch(&name, p)
+                .map(|r| r.output)
+                .map_err(|e| e.to_string())
+        });
+        tokio::select! {
+            result = dispatch_fut => { result.map_err(|e| e.to_string()).and_then(|r| r) }
+            _ = async {
+                let deadline = tokio::time::Instant::now() + crate::inflight::CANCEL_GRACE_PERIOD;
+                loop {
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                    if cancel_token_for_dispatch.is_cancelled() || tokio::time::Instant::now() >= deadline { break; }
+                }
+            } => { Err("CANCELLED".to_string()) }
+        }
     };
 
-    // Build MCP CallToolResult from dispatch outcome
+    if let Some(ref rid) = req_id_str {
+        state.in_flight.remove(rid);
+    }
+
     let call_result = match dispatch_outcome {
         Ok(output) => {
             let text = match &output {
@@ -547,10 +623,25 @@ async fn handle_tools_call(
                 is_error: false,
             }
         }
+        Err(err_msg) if err_msg == "CANCELLED" => {
+            let rid = req_id_str.as_deref().unwrap_or("unknown");
+            tracing::info!(request_id = %rid, "tool call cancelled cooperatively");
+            if let Some(ref r) = req_id_str {
+                state.cancelled_requests.remove(r);
+            }
+            let envelope = DccMcpError::new(
+                "registry",
+                "CANCELLED",
+                format!("Request {rid} was cancelled by the client."),
+            )
+            .with_hint("Re-send the request if you still need the result.");
+            return Ok(JsonRpcResponse::success(
+                req.id.clone(),
+                serde_json::to_value(CallToolResult::error(envelope.to_json()))?,
+            ));
+        }
         Err(err_msg) => {
-            // Build a structured error envelope for dispatch failures.
             let envelope = if err_msg.contains("no handler registered") {
-                // Tool exists in registry but has no callable handler.
                 DccMcpError::new(
                     "instance",
                     "NO_HANDLER",
@@ -569,16 +660,7 @@ async fn handle_tools_call(
         }
     };
 
-    // ── Cancellation check ────────────────────────────────────────────
-    // If the client sent `notifications/cancelled` for this request while
-    // the tool was executing, suppress the result and return a short error.
-    let req_id_str = req.id.as_ref().map(|id| match id {
-        Value::String(s) => s.clone(),
-        Value::Number(n) => n.to_string(),
-        other => serde_json::to_string(other).unwrap_or_default(),
-    });
     if let Some(ref rid) = req_id_str {
-        // Only suppress if the cancellation was recorded within the TTL window.
         let cancelled = state
             .cancelled_requests
             .remove(rid)

--- a/crates/dcc-mcp-http/src/inflight.rs
+++ b/crates/dcc-mcp-http/src/inflight.rs
@@ -1,0 +1,248 @@
+//! In-flight request tracking: progress notifications and cooperative cancellation.
+//!
+//! # Design
+//!
+//! Each `tools/call` request that is currently being dispatched has a
+//! corresponding [`InFlightEntry`] stored in the [`InFlightRequests`] map.
+//! The entry carries two shared objects:
+//!
+//! - [`CancelToken`]  — set by the notification handler when the client sends
+//!   `notifications/cancelled`.  The executing action checks this flag and
+//!   aborts early when set.
+//! - [`ProgressReporter`] — used by the action handler (or wrappers around it)
+//!   to emit `notifications/progress` events back to the client via SSE.
+//!
+//! ## Grace period (cancellation)
+//!
+//! Once [`CancelToken::cancel`] is called, the caller in `handle_tools_call`
+//! waits up to [`CANCEL_GRACE_PERIOD`] for the dispatch future to complete
+//! naturally (cooperative cancel).  If the future doesn't resolve within the
+//! grace period, a `CANCELLED` error envelope is returned.
+
+use dashmap::DashMap;
+use serde_json::Value;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+
+use crate::protocol::format_sse_event;
+use crate::session::SessionManager;
+
+/// Grace period before an in-flight tool call is hard-cancelled.
+///
+/// After [`CancelToken::cancel`] is called the `handle_tools_call` task waits
+/// up to this duration for the dispatch future to return before giving up and
+/// returning a `CANCELLED` error to the client.
+pub const CANCEL_GRACE_PERIOD: std::time::Duration = std::time::Duration::from_secs(10);
+
+// ── CancelToken ──────────────────────────────────────────────────────────────
+
+/// A cooperative cancellation token shared between the HTTP handler and the
+/// executing action.
+///
+/// # Usage
+///
+/// ```rust,ignore
+/// // Handler: poll in the action loop
+/// if cancel_token.is_cancelled() {
+///     return Err("cancelled".to_string());
+/// }
+///
+/// // Notification handler: signal cancellation
+/// cancel_token.cancel();
+/// ```
+#[derive(Clone, Default)]
+pub struct CancelToken(Arc<AtomicBool>);
+
+impl CancelToken {
+    /// Create a new token (initially not cancelled).
+    pub fn new() -> Self {
+        Self(Arc::new(AtomicBool::new(false)))
+    }
+
+    /// Signal that the associated request has been cancelled by the client.
+    pub fn cancel(&self) {
+        self.0.store(true, Ordering::Release);
+    }
+
+    /// Return `true` if cancellation has been requested.
+    pub fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::Acquire)
+    }
+}
+
+// ── ProgressReporter ─────────────────────────────────────────────────────────
+
+/// Sends `notifications/progress` events to the client via the session SSE
+/// channel.
+///
+/// The reporter is a no-op when no `progressToken` was supplied by the client.
+///
+/// # MCP specification
+///
+/// ```json
+/// {
+///   "jsonrpc": "2.0",
+///   "method": "notifications/progress",
+///   "params": {
+///     "progressToken": "<token from _meta>",
+///     "progress": 42,
+///     "total": 100,
+///     "message": "optional human-readable status"
+///   }
+/// }
+/// ```
+#[derive(Clone)]
+pub struct ProgressReporter {
+    /// Echo-back of the client's `progressToken`. `None` means no-op.
+    token: Option<Value>,
+    /// MCP session ID for SSE push.
+    session_id: Option<String>,
+    /// Shared session manager — used to push events.
+    sessions: SessionManager,
+    /// Request ID used for logging.
+    request_id: String,
+}
+
+impl ProgressReporter {
+    /// Create a new reporter.
+    ///
+    /// If `token` is `None`, all `report()` calls are no-ops (backward compat).
+    pub fn new(
+        token: Option<Value>,
+        session_id: Option<String>,
+        sessions: SessionManager,
+        request_id: String,
+    ) -> Self {
+        Self {
+            token,
+            session_id,
+            sessions,
+            request_id,
+        }
+    }
+
+    /// Emit a progress event to the client.
+    ///
+    /// - `progress`: current work units completed (monotonically increasing).
+    /// - `total`: total work units, or `None` if unknown.
+    /// - `message`: optional human-readable status string.
+    ///
+    /// No-op when no `progressToken` was provided or session has no SSE stream.
+    pub fn report(&self, progress: f64, total: Option<f64>, message: Option<&str>) {
+        let (Some(token), Some(sid)) = (self.token.as_ref(), self.session_id.as_ref()) else {
+            return;
+        };
+
+        let mut params = serde_json::json!({
+            "progressToken": token,
+            "progress": progress,
+        });
+
+        if let Some(t) = total {
+            params["total"] = serde_json::json!(t);
+        }
+        if let Some(m) = message {
+            params["message"] = serde_json::json!(m);
+        }
+
+        let notification = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/progress",
+            "params": params,
+        });
+
+        let event = format_sse_event(&notification, None);
+        self.sessions.push_event(sid, event);
+
+        tracing::debug!(
+            request_id = %self.request_id,
+            progress = progress,
+            total = ?total,
+            "progress notification sent"
+        );
+    }
+
+    /// Convenience: report with percentage (0.0–100.0).
+    pub fn report_pct(&self, pct: f64, message: Option<&str>) {
+        self.report(pct, Some(100.0), message);
+    }
+}
+
+// ── InFlightEntry ─────────────────────────────────────────────────────────────
+
+/// State record for a single in-flight `tools/call`.
+pub struct InFlightEntry {
+    /// Cancellation token — set externally by the notification handler.
+    pub cancel_token: CancelToken,
+    /// Progress reporter — caller uses this to emit progress events.
+    pub progress: ProgressReporter,
+    /// Wall-clock time when the request started (for TTL / metrics).
+    pub started_at: std::time::Instant,
+}
+
+impl InFlightEntry {
+    pub fn new(cancel_token: CancelToken, progress: ProgressReporter) -> Self {
+        Self {
+            cancel_token,
+            progress,
+            started_at: std::time::Instant::now(),
+        }
+    }
+}
+
+// ── InFlightRequests ─────────────────────────────────────────────────────────
+
+/// Thread-safe map from request-id → [`InFlightEntry`].
+///
+/// Entries are inserted before dispatch and removed on completion.
+#[derive(Clone, Default)]
+pub struct InFlightRequests {
+    map: Arc<DashMap<String, InFlightEntry>>,
+}
+
+impl InFlightRequests {
+    pub fn new() -> Self {
+        Self {
+            map: Arc::new(DashMap::new()),
+        }
+    }
+
+    /// Register a new in-flight request.
+    pub fn insert(&self, request_id: String, entry: InFlightEntry) {
+        self.map.insert(request_id, entry);
+    }
+
+    /// Remove a completed request and return its entry.
+    pub fn remove(&self, request_id: &str) -> Option<(String, InFlightEntry)> {
+        self.map.remove(request_id)
+    }
+
+    /// Set the cancel flag for an in-flight request.
+    ///
+    /// Returns `true` if the request was found and the flag was set.
+    pub fn request_cancel(&self, request_id: &str) -> bool {
+        if let Some(entry) = self.map.get(request_id) {
+            entry.cancel_token.cancel();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Purge entries that have been running longer than `max_age`.
+    pub fn purge_stale(&self, max_age: std::time::Duration) {
+        self.map.retain(|_, e| e.started_at.elapsed() < max_age);
+    }
+
+    /// Current count of in-flight requests.
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    /// `true` when there are no in-flight requests.
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+}

--- a/crates/dcc-mcp-http/src/lib.rs
+++ b/crates/dcc-mcp-http/src/lib.rs
@@ -44,6 +44,7 @@ pub mod error;
 pub mod executor;
 pub mod gateway;
 pub mod handler;
+pub mod inflight;
 pub mod protocol;
 pub mod server;
 pub mod session;

--- a/crates/dcc-mcp-http/src/protocol.rs
+++ b/crates/dcc-mcp-http/src/protocol.rs
@@ -230,11 +230,21 @@ pub struct McpToolAnnotations {
     pub deferred_hint: Option<bool>,
 }
 
+/// `_meta` field carried in a `tools/call` request.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct CallToolMeta {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub progress_token: Option<Value>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CallToolParams {
     pub name: String,
     #[serde(default)]
     pub arguments: Option<Value>,
+    #[serde(rename = "_meta", default)]
+    pub meta: Option<CallToolMeta>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/dcc-mcp-http/src/server.rs
+++ b/crates/dcc-mcp-http/src/server.rs
@@ -12,6 +12,7 @@ use crate::{
     executor::DccExecutorHandle,
     gateway::{GatewayConfig, GatewayRunner},
     handler::{AppState, handle_delete, handle_get, handle_post},
+    inflight::InFlightRequests,
     session::SessionManager,
 };
 use dcc_mcp_actions::{ActionDispatcher, ActionRegistry};
@@ -180,6 +181,7 @@ impl McpHttpServer {
             server_name: self.config.server_name.clone(),
             server_version: self.config.server_version.clone(),
             cancelled_requests,
+            in_flight: InFlightRequests::new(),
         };
 
         let endpoint = self.config.endpoint_path.clone();

--- a/crates/dcc-mcp-http/src/tests.rs
+++ b/crates/dcc-mcp-http/src/tests.rs
@@ -8,7 +8,8 @@ mod tests {
     use std::sync::Arc;
 
     use crate::{
-        config::McpHttpConfig, handler::AppState, server::McpHttpServer, session::SessionManager,
+        config::McpHttpConfig, handler::AppState, inflight::InFlightRequests,
+        server::McpHttpServer, session::SessionManager,
     };
     use dcc_mcp_actions::{ActionDispatcher, ActionMeta, ActionRegistry};
     use dcc_mcp_models::{SkillMetadata, ToolDeclaration};
@@ -51,6 +52,7 @@ mod tests {
             server_name: "test-dcc".to_string(),
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+            in_flight: InFlightRequests::new(),
         }
     }
 
@@ -198,6 +200,7 @@ mod tests {
             server_name: "test-dcc".to_string(),
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+            in_flight: InFlightRequests::new(),
         }
     }
 
@@ -958,6 +961,7 @@ mod tests {
             server_name: "test-dcc".to_string(),
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+            in_flight: InFlightRequests::new(),
         }
     }
 
@@ -1241,6 +1245,7 @@ mod tests {
             server_name: "test-dcc".to_string(),
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+            in_flight: InFlightRequests::new(),
         }
     }
 
@@ -1341,6 +1346,7 @@ mod tests {
             server_name: "test-dcc".to_string(),
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+            in_flight: InFlightRequests::new(),
         };
 
         use crate::handler::{handle_delete, handle_get, handle_post};
@@ -1538,6 +1544,197 @@ mod tests {
         let handle = server.start().await.unwrap();
         assert!(handle.port > 0);
         handle.shutdown().await;
+    }
+
+    // ── Progress notifications (#240) ─────────────────────────────────────
+
+    /// `_meta.progressToken` is deserialized correctly from `tools/call` params.
+    #[test]
+    fn test_progress_token_extracted_from_meta() {
+        use crate::protocol::CallToolParams;
+        let raw = json!({
+            "name": "my_tool",
+            "arguments": {"key": "val"},
+            "_meta": { "progressToken": "tok-abc" }
+        });
+        let params: CallToolParams = serde_json::from_value(raw).unwrap();
+        let token = params
+            .meta
+            .as_ref()
+            .and_then(|m| m.progress_token.as_ref())
+            .and_then(|v| v.as_str());
+        assert_eq!(token, Some("tok-abc"));
+    }
+
+    /// No `_meta` → `progress_token` is `None` (backward compat).
+    #[test]
+    fn test_progress_token_absent_when_no_meta() {
+        use crate::protocol::CallToolParams;
+        let raw = json!({"name": "my_tool", "arguments": {}});
+        let params: CallToolParams = serde_json::from_value(raw).unwrap();
+        assert!(params.meta.is_none());
+    }
+
+    /// Integer `progressToken` is also accepted (MCP spec allows int or string).
+    #[test]
+    fn test_progress_token_integer_accepted() {
+        use crate::protocol::CallToolParams;
+        let raw = json!({"name": "my_tool", "_meta": { "progressToken": 42 }});
+        let params: CallToolParams = serde_json::from_value(raw).unwrap();
+        let token = params.meta.as_ref().and_then(|m| m.progress_token.as_ref());
+        assert!(token.is_some());
+        assert_eq!(token.unwrap().as_i64(), Some(42));
+    }
+
+    /// ProgressReporter with a token pushes `notifications/progress` to SSE.
+    #[test]
+    fn test_progress_reporter_sends_event_to_session() {
+        use crate::inflight::ProgressReporter;
+        let sessions = SessionManager::new();
+        let sid = sessions.create();
+        let mut rx = sessions.subscribe(&sid).unwrap();
+        let reporter = ProgressReporter::new(
+            Some(serde_json::json!("tok-abc")),
+            Some(sid.clone()),
+            sessions.clone(),
+            "req-1".to_string(),
+        );
+        reporter.report(25.0, Some(100.0), Some("working"));
+        let event = rx.try_recv().expect("expected a progress SSE event");
+        assert!(event.contains("notifications/progress"), "event: {event}");
+        assert!(event.contains("tok-abc"), "event: {event}");
+        assert!(event.contains("25"), "event: {event}");
+        assert!(event.contains("100"), "event: {event}");
+        assert!(event.contains("working"), "event: {event}");
+    }
+
+    /// ProgressReporter without a token is a no-op.
+    #[test]
+    fn test_progress_reporter_noop_without_token() {
+        use crate::inflight::ProgressReporter;
+        let sessions = SessionManager::new();
+        let sid = sessions.create();
+        let mut rx = sessions.subscribe(&sid).unwrap();
+        let reporter = ProgressReporter::new(None, Some(sid), sessions, "req-2".to_string());
+        reporter.report(50.0, None, None);
+        assert!(
+            rx.try_recv().is_err(),
+            "no events when progressToken is absent"
+        );
+    }
+
+    // ── Cooperative cancellation (#241) ───────────────────────────────────
+
+    #[test]
+    fn test_cancel_token_lifecycle() {
+        use crate::inflight::CancelToken;
+        let token = CancelToken::new();
+        assert!(!token.is_cancelled());
+        token.cancel();
+        assert!(token.is_cancelled());
+    }
+
+    #[test]
+    fn test_cancel_token_clone_shares_state() {
+        use crate::inflight::CancelToken;
+        let token = CancelToken::new();
+        let clone = token.clone();
+        assert!(!clone.is_cancelled());
+        token.cancel();
+        assert!(
+            clone.is_cancelled(),
+            "clone must see cancellation from original"
+        );
+    }
+
+    /// `notifications/cancelled` for an unknown request is silently accepted.
+    #[tokio::test]
+    async fn test_cancel_notification_for_unknown_request_is_noop() {
+        let server = TestServer::new(make_router());
+        let resp = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "method": "notifications/cancelled",
+                "params": { "requestId": "nonexistent-req-99" }
+            }))
+            .await;
+        resp.assert_status(axum::http::StatusCode::ACCEPTED);
+    }
+
+    /// After cancelling a completed request, a subsequent call must still succeed.
+    #[tokio::test]
+    async fn test_cancel_completed_request_does_not_affect_future_calls() {
+        let server = TestServer::new(make_router_with_handler());
+
+        // First call succeeds.
+        let resp1 = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({"jsonrpc": "2.0", "id": 100, "method": "tools/call",
+                "params": {"name": "get_scene_info", "arguments": {}}}))
+            .await;
+        resp1.assert_status_ok();
+        assert_eq!(resp1.json::<Value>()["result"]["isError"], false);
+
+        // Send a stale cancellation for the completed request.
+        let _ = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .json(
+                &json!({"jsonrpc": "2.0", "method": "notifications/cancelled",
+                "params": {"requestId": "100"}}),
+            )
+            .await;
+
+        // Second call must succeed regardless.
+        let resp2 = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({"jsonrpc": "2.0", "id": 101, "method": "tools/call",
+                "params": {"name": "get_scene_info", "arguments": {}}}))
+            .await;
+        resp2.assert_status_ok();
+        assert_eq!(
+            resp2.json::<Value>()["result"]["isError"],
+            false,
+            "subsequent call must succeed even after stale cancellation"
+        );
+    }
+
+    /// A `tools/call` with `_meta.progressToken` completes normally.
+    #[tokio::test]
+    async fn test_tools_call_with_progress_token_succeeds() {
+        let server = TestServer::new(make_router_with_handler());
+        let resp = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({"jsonrpc": "2.0", "id": 200, "method": "tools/call",
+                "params": {"name": "get_scene_info", "arguments": {},
+                           "_meta": { "progressToken": "pt-xyz" }}}))
+            .await;
+        resp.assert_status_ok();
+        assert_eq!(
+            resp.json::<Value>()["result"]["isError"],
+            false,
+            "tools/call with progressToken must return success"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

- **#240 Progress notifications**: extracts `_meta.progressToken` from `tools/call` params and streams `notifications/progress` events back to the client over SSE during long-running DCC actions. No-op when token is absent (backward compatible).
- **#241 Cooperative cancellation**: routes `notifications/cancelled` to a per-request `CancelToken` via the new `InFlightRequests` map. The dispatch path polls the flag before entering the action body; the non-DCC `spawn_blocking` path uses a `tokio::select!` with a 10-second grace period, returning `{ layer: "registry", code: "CANCELLED" }` on timeout. Does not kill worker processes.
- New `crates/dcc-mcp-http/src/inflight.rs` module: `CancelToken`, `ProgressReporter`, `InFlightEntry`, `InFlightRequests`.
- 10 new Rust unit tests covering both features.

## Test plan

- [ ] `vx just preflight` — all 29 test suites pass (100 tests in `dcc-mcp-http` including 10 new ones)
- [ ] `test_progress_token_extracted_from_meta` — string token deserialized correctly
- [ ] `test_progress_token_integer_accepted` — integer token accepted per MCP spec
- [ ] `test_progress_reporter_sends_event_to_session` — SSE event emitted with correct fields
- [ ] `test_progress_reporter_noop_without_token` — no SSE push when token absent
- [ ] `test_cancel_token_lifecycle` — cancel flag transitions correctly
- [ ] `test_cancel_token_clone_shares_state` — all clones observe same atomic state
- [ ] `test_cancel_notification_for_unknown_request_is_noop` — 202 returned, no panic
- [ ] `test_cancel_completed_request_does_not_affect_future_calls` — subsequent calls succeed
- [ ] `test_tools_call_with_progress_token_succeeds` — normal result returned even with progressToken

Closes #240, #241