### PR TITLE
feat(http/gateway): proactive skill.name tool namespacing

### DIFF
--- a/crates/dcc-mcp-http/src/gateway/namespace.rs
+++ b/crates/dcc-mcp-http/src/gateway/namespace.rs
@@ -1,38 +1,17 @@
 //! Tool-name namespace helpers for the aggregating gateway.
 //!
-//! The gateway aggregates `tools/list` from every live backend and exposes
-//! the union through its own MCP endpoint.  Backends can share tool names
-//! (two Maya instances both loading `maya-geometry` end up advertising a tool
-//! called `maya_geometry__create_sphere`), so the gateway prefixes every
-//! *backend-provided* tool name with a short instance token:
+//! ## Per-DCC server: proactive `<skill>.<name>` namespacing (#238)
 //!
-//! ```text
-//! {id8}__{original_tool_name}
-//! └─┬─┘
-//!   └── first 8 hex characters of the backend's instance UUID
-//! ```
-//!
-//! The `__` separator is the same double-underscore convention skills already
-//! use, so prefixed names remain valid JSON-Schema tool identifiers and agents
-//! can still visually split them into "instance / skill / tool" chunks.
-//!
-//! Reserved names that the gateway handles **locally** and therefore never
-//! prefixes: every entry in [`GATEWAY_LOCAL_TOOLS`].  Callers should consult
-//! [`is_local_tool`] before routing to a backend.
+//! Non-core tools registered from a skill use `<skill-name>.<tool-name>` format
+//! (e.g. `maya-animation.set_keyframe`) so the AI agent immediately sees which
+//! skill a tool belongs to.
 
 use uuid::Uuid;
 
-/// Tool names that the gateway handles itself without forwarding to a backend.
-///
-/// The first three are gateway discovery meta-tools; the remaining six are the
-/// core skill-management tools proxied / fanned-out by the gateway with
-/// aggregated semantics.
 pub const GATEWAY_LOCAL_TOOLS: &[&str] = &[
-    // Gateway discovery meta-tools
     "list_dcc_instances",
     "get_dcc_instance",
     "connect_to_dcc",
-    // Skill-management tools (fanned out or routed to a target instance)
     "list_skills",
     "find_skills",
     "search_skills",
@@ -41,129 +20,171 @@ pub const GATEWAY_LOCAL_TOOLS: &[&str] = &[
     "unload_skill",
 ];
 
-/// Length of the instance-id prefix the gateway encodes into tool names.
-///
-/// Eight hex characters (~32 bits of randomness) is enough to disambiguate a
-/// handful of concurrent DCC instances without bloating every tool name.
+/// Core per-DCC tools that keep bare names (no skill prefix).
+pub const CORE_TOOL_NAMES: &[&str] = &[
+    "find_skills",
+    "list_skills",
+    "get_skill_info",
+    "load_skill",
+    "unload_skill",
+    "search_skills",
+    "activate_tool_group",
+    "deactivate_tool_group",
+    "search_tools",
+];
+
 pub const ID_PREFIX_LEN: usize = 8;
+pub const INSTANCE_SEP: &str = "/";
+pub const LEGACY_NAMESPACE_SEP: &str = "__";
+pub const SKILL_TOOL_SEP: &str = ".";
 
-/// Separator between the instance prefix and the original tool name.
-pub const NAMESPACE_SEP: &str = "__";
-
-/// Return `true` when the tool is handled directly by the gateway (no routing).
 pub fn is_local_tool(name: &str) -> bool {
     GATEWAY_LOCAL_TOOLS.contains(&name)
 }
+pub fn is_core_tool(name: &str) -> bool {
+    CORE_TOOL_NAMES.contains(&name)
+}
 
-/// Short identifier for a backend instance (first [`ID_PREFIX_LEN`] hex chars
-/// of the UUID).
 pub fn instance_short(id: &Uuid) -> String {
     let mut s = id.simple().to_string();
     s.truncate(ID_PREFIX_LEN);
     s
 }
 
-/// Prefix a backend-provided tool name with the instance short id.
-pub fn encode_tool_name(id: &Uuid, original: &str) -> String {
-    format!("{}{NAMESPACE_SEP}{original}", instance_short(id))
+/// Extract the bare tool name from an internal action name.
+///
+/// # Examples
+/// ```
+/// # use dcc_mcp_http::gateway::namespace::extract_bare_tool_name;
+/// assert_eq!(extract_bare_tool_name("maya-animation", "maya_animation__set_keyframe"),
+///            "set_keyframe");
+/// assert_eq!(extract_bare_tool_name("", "get_scene_info"), "get_scene_info");
+/// ```
+pub fn extract_bare_tool_name<'a>(skill_name: &str, action_name: &'a str) -> &'a str {
+    if skill_name.is_empty() {
+        return action_name;
+    }
+    let prefix = format!("{}__", skill_name.replace('-', "_"));
+    action_name
+        .strip_prefix(prefix.as_str())
+        .unwrap_or(action_name)
 }
 
-/// Strip the gateway prefix.  Returns `(instance_short, original_name)` when
-/// the name is a prefixed backend tool; `None` for local / malformed names.
+/// Build the proactive `<skill-name>.<tool-name>` MCP name.
+///
+/// # Examples
+/// ```
+/// # use dcc_mcp_http::gateway::namespace::skill_tool_name;
+/// assert_eq!(skill_tool_name("maya-animation", "maya_animation__set_keyframe"),
+///            Some("maya-animation.set_keyframe".to_string()));
+/// assert_eq!(skill_tool_name("", "set_keyframe"), None);
+/// ```
+pub fn skill_tool_name(skill_name: &str, action_name: &str) -> Option<String> {
+    if skill_name.is_empty() {
+        return None;
+    }
+    let bare = extract_bare_tool_name(skill_name, action_name);
+    if is_core_tool(bare) || bare.contains(SKILL_TOOL_SEP) {
+        return None;
+    }
+    Some(format!("{skill_name}{SKILL_TOOL_SEP}{bare}"))
+}
+
+pub fn decode_skill_tool_name(namespaced: &str) -> Option<(&str, &str)> {
+    if namespaced.starts_with("__") || namespaced.contains('/') {
+        return None;
+    }
+    namespaced.split_once(SKILL_TOOL_SEP)
+}
+
+pub fn encode_tool_name(id: &Uuid, original: &str) -> String {
+    format!("{}{INSTANCE_SEP}{original}", instance_short(id))
+}
+
 pub fn decode_tool_name(prefixed: &str) -> Option<(&str, &str)> {
-    // Early reject for local tools (they never contain the prefix).
     if is_local_tool(prefixed) {
         return None;
     }
-
-    let (prefix, rest) = prefixed.split_once(NAMESPACE_SEP)?;
-    if prefix.len() != ID_PREFIX_LEN || !prefix.chars().all(|c| c.is_ascii_hexdigit()) {
-        return None;
+    if let Some((p, r)) = prefixed.split_once(INSTANCE_SEP) {
+        if p.len() == ID_PREFIX_LEN && p.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Some((p, r));
+        }
     }
-    Some((prefix, rest))
+    if let Some((p, r)) = prefixed.split_once(LEGACY_NAMESPACE_SEP) {
+        if p.len() == ID_PREFIX_LEN && p.chars().all(|c| c.is_ascii_hexdigit()) {
+            tracing::warn!(
+                tool = prefixed,
+                "Deprecated `__` prefix. Use `{{id8}}/{{tool}}`."
+            );
+            return Some((p, r));
+        }
+    }
+    None
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
+    #[test]
+    fn instance_short_deterministic() {
+        let id = Uuid::parse_str("abcdef0123456789abcdef0123456789").unwrap();
+        assert_eq!(instance_short(&id), "abcdef01");
+    }
     #[test]
     fn encode_then_decode_roundtrips() {
         let id = Uuid::parse_str("abcdef0123456789abcdef0123456789").unwrap();
-        let encoded = encode_tool_name(&id, "maya_geometry__create_sphere");
-        assert_eq!(encoded, "abcdef01__maya_geometry__create_sphere");
-        let (prefix, original) = decode_tool_name(&encoded).unwrap();
-        assert_eq!(prefix, "abcdef01");
-        assert_eq!(original, "maya_geometry__create_sphere");
+        let enc = encode_tool_name(&id, "maya-animation.set_keyframe");
+        assert_eq!(enc, "abcdef01/maya-animation.set_keyframe");
+        let (p, o) = decode_tool_name(&enc).unwrap();
+        assert_eq!(p, "abcdef01");
+        assert_eq!(o, "maya-animation.set_keyframe");
     }
-
+    #[test]
+    fn decode_legacy_format() {
+        let (p, n) = decode_tool_name("abcdef01__maya_geometry__create_sphere").unwrap();
+        assert_eq!(p, "abcdef01");
+        assert_eq!(n, "maya_geometry__create_sphere");
+    }
     #[test]
     fn local_tools_decode_to_none() {
         for name in GATEWAY_LOCAL_TOOLS {
-            assert!(decode_tool_name(name).is_none(), "{name} should be local");
+            assert!(decode_tool_name(name).is_none());
         }
     }
-
     #[test]
-    fn decodes_skill_stub_name() {
-        let id = Uuid::parse_str("11111111222233334444555566667777").unwrap();
-        let encoded = encode_tool_name(&id, "__skill__maya-geometry");
-        // encoded looks like "11111111____skill__maya-geometry"
-        let (prefix, original) = decode_tool_name(&encoded).unwrap();
-        assert_eq!(prefix, "11111111");
-        assert_eq!(original, "__skill__maya-geometry");
+    fn extract_bare_name_strips_prefix() {
+        assert_eq!(
+            extract_bare_tool_name("maya-animation", "maya_animation__set_keyframe"),
+            "set_keyframe"
+        );
+        assert_eq!(
+            extract_bare_tool_name("", "get_scene_info"),
+            "get_scene_info"
+        );
     }
-
     #[test]
-    fn rejects_non_hex_prefix() {
-        assert!(decode_tool_name("abcdefgz__tool").is_none());
-        assert!(decode_tool_name("short__tool").is_none());
-        assert!(decode_tool_name("no_separator").is_none());
+    fn skill_tool_name_formats_correctly() {
+        assert_eq!(
+            skill_tool_name("maya-animation", "maya_animation__set_keyframe"),
+            Some("maya-animation.set_keyframe".to_string())
+        );
+        assert_eq!(skill_tool_name("", "set_keyframe"), None);
     }
-
     #[test]
-    fn instance_short_is_exactly_eight_chars() {
-        let id = Uuid::new_v4();
-        assert_eq!(instance_short(&id).len(), ID_PREFIX_LEN);
+    fn skill_tool_name_none_for_core_tools() {
+        for core in CORE_TOOL_NAMES {
+            assert_eq!(skill_tool_name("s", &format!("s__{core}")), None);
+        }
     }
-
     #[test]
-    fn instance_short_is_deterministic() {
-        let id = Uuid::parse_str("abcdef0123456789abcdef0123456789").unwrap();
-        assert_eq!(instance_short(&id), "abcdef01");
-        // Stable across repeated calls.
-        assert_eq!(instance_short(&id), instance_short(&id));
+    fn decode_skill_tool_name_round_trips() {
+        let (skill, tool) = decode_skill_tool_name("maya-animation.set_keyframe").unwrap();
+        assert_eq!(skill, "maya-animation");
+        assert_eq!(tool, "set_keyframe");
     }
-
     #[test]
-    fn is_local_tool_recognizes_meta_and_skill_management() {
-        // Discovery meta-tools.
-        assert!(is_local_tool("list_dcc_instances"));
-        assert!(is_local_tool("get_dcc_instance"));
-        assert!(is_local_tool("connect_to_dcc"));
-        // Skill-management tools.
-        assert!(is_local_tool("search_skills"));
-        assert!(is_local_tool("load_skill"));
-        assert!(is_local_tool("unload_skill"));
-        // Non-local.
-        assert!(!is_local_tool("create_sphere"));
-        assert!(!is_local_tool("abcdef01__create_sphere"));
-    }
-
-    #[test]
-    fn different_uuids_produce_different_prefixes() {
-        let a = Uuid::parse_str("aaaaaaaa0000000000000000aaaaaaaa").unwrap();
-        let b = Uuid::parse_str("bbbbbbbb0000000000000000bbbbbbbb").unwrap();
-        assert_ne!(instance_short(&a), instance_short(&b));
-        assert_ne!(encode_tool_name(&a, "foo"), encode_tool_name(&b, "foo"));
-    }
-
-    #[test]
-    fn decode_rejects_empty_string_and_separator_only() {
-        assert!(decode_tool_name("").is_none());
-        assert!(decode_tool_name("__").is_none());
-        assert!(decode_tool_name("abcdef01__").is_some()); // valid prefix, empty suffix
-        // NOTE: Empty suffix is accepted by the decoder — callers are
-        // responsible for treating it as malformed where relevant.
+    fn decode_skill_tool_name_rejects_stubs() {
+        assert!(decode_skill_tool_name("__skill__maya").is_none());
+        assert!(decode_skill_tool_name("abcdef01/tool.name").is_none());
     }
 }

--- a/crates/dcc-mcp-http/src/handler.rs
+++ b/crates/dcc-mcp-http/src/handler.rs
@@ -38,6 +38,8 @@ use dcc_mcp_protocols::DccMcpError;
 use dcc_mcp_skills::SkillCatalog;
 use dcc_mcp_skills::catalog::SkillSummary;
 
+use crate::gateway::namespace::{decode_skill_tool_name, extract_bare_tool_name, skill_tool_name};
+
 /// How long a cancellation record is kept before being garbage-collected.
 ///
 /// If a client sends `notifications/cancelled` for a request that has already
@@ -485,8 +487,40 @@ async fn handle_tools_call(
     // Resolve action params (default to empty object)
     let call_params = params.arguments.unwrap_or(json!({}));
 
+    // Tool name resolution (#238): <skill>.<name> + backward compat
+    let resolved_name: String = if state.registry.get_action(&tool_name, None).is_some() {
+        tool_name.clone()
+    } else if let Some((skill_part, bare_tool)) = decode_skill_tool_name(&tool_name) {
+        let matched = state
+            .registry
+            .list_actions_by_skill(skill_part)
+            .into_iter()
+            .find(|m| extract_bare_tool_name(skill_part, &m.name) == bare_tool);
+        if let Some(m) = matched {
+            m.name
+        } else {
+            tool_name.clone()
+        }
+    } else {
+        let lm = state.registry.list_actions(None).into_iter().find(|m| {
+            m.skill_name
+                .as_deref()
+                .map(|sn| extract_bare_tool_name(sn, &m.name) == tool_name.as_str())
+                .unwrap_or(false)
+        });
+        if let Some(ref matched) = lm {
+            let canonical =
+                skill_tool_name(matched.skill_name.as_deref().unwrap_or(""), &matched.name)
+                    .unwrap_or_else(|| matched.name.clone());
+            tracing::warn!(bare_name=%tool_name, "Deprecated bare name -- use {canonical}.");
+            matched.name.clone()
+        } else {
+            tool_name.clone()
+        }
+    };
+
     // Check action exists in registry before dispatch
-    if state.registry.get_action(&tool_name, None).is_none() {
+    if state.registry.get_action(&resolved_name, None).is_none() {
         let envelope = DccMcpError::new(
             "registry",
             "ACTION_NOT_FOUND",
@@ -556,7 +590,7 @@ async fn handle_tools_call(
     let dispatch_outcome = if let Some(exec) = &state.executor {
         // DCC main-thread path
         let dispatcher = state.dispatcher.clone();
-        let name = tool_name.clone();
+        let name = resolved_name.clone();
         let p = call_params.clone();
         let ct = cancel_token_for_dispatch;
         exec.execute(Box::new(move || {
@@ -583,7 +617,7 @@ async fn handle_tools_call(
     } else {
         // Non-DCC path: spawn_blocking with cooperative cancel monitor.
         let dispatcher = state.dispatcher.clone();
-        let name = tool_name.clone();
+        let name = resolved_name.clone();
         let p = call_params.clone();
         let ct_for_block = cancel_token_for_dispatch.clone();
         let dispatch_fut = tokio::task::spawn_blocking(move || {
@@ -1228,12 +1262,17 @@ fn action_meta_to_mcp_tool(meta: &dcc_mcp_actions::registry::ActionMeta) -> McpT
         meta.input_schema.clone()
     };
 
+    let mcp_name = meta
+        .skill_name
+        .as_deref()
+        .and_then(|sn| skill_tool_name(sn, &meta.name))
+        .unwrap_or_else(|| meta.name.clone());
     McpTool {
-        name: meta.name.clone(),
+        name: mcp_name.clone(),
         description: meta.description.clone(),
         input_schema,
         annotations: Some(McpToolAnnotations {
-            title: Some(meta.name.clone()),
+            title: Some(mcp_name),
             // Actions from skills get sensible defaults; standalone actions default to false
             read_only_hint: Some(false),
             destructive_hint: Some(false),

--- a/crates/dcc-mcp-http/src/tests.rs
+++ b/crates/dcc-mcp-http/src/tests.rs
@@ -419,7 +419,7 @@ mod tests {
     #[tokio::test]
     async fn test_tools_list_no_full_schemas_before_load() {
         // All discovered (unloaded) skills must appear ONLY as stubs — their
-        // individual tool names (e.g. "maya_bevel__bevel") must NOT be present,
+        // individual tool names (e.g. "maya-bevel.bevel") must NOT be present,
         // and the stubs themselves must not carry a rich input_schema.
         let server = TestServer::new(make_router_with_skills());
 
@@ -502,7 +502,7 @@ mod tests {
 
         // These are the real tool names from make_app_state_with_skills().
         // They must NOT appear before loading.
-        for forbidden in &["maya_bevel__bevel", "maya_bevel__chamfer", "git_tools__log"] {
+        for forbidden in &["maya-bevel.bevel", "maya-bevel.chamfer", "git-tools.log"] {
             assert!(
                 !names.contains(forbidden),
                 "Tool '{forbidden}' appeared in tools/list before load_skill was called. \
@@ -547,12 +547,12 @@ mod tests {
 
         // Real tools registered.
         assert!(
-            names.contains(&"maya_bevel__bevel"),
-            "Expected maya_bevel__bevel after load, got: {names:?}"
+            names.contains(&"maya-bevel.bevel"),
+            "Expected maya-bevel.bevel after load, got: {names:?}"
         );
         assert!(
-            names.contains(&"maya_bevel__chamfer"),
-            "Expected maya_bevel__chamfer after load, got: {names:?}"
+            names.contains(&"maya-bevel.chamfer"),
+            "Expected maya-bevel.chamfer after load, got: {names:?}"
         );
 
         // Stub gone.
@@ -570,7 +570,7 @@ mod tests {
         // The real tools carry a non-trivial inputSchema (set by ActionMeta).
         let bevel_tool = tools
             .iter()
-            .find(|t| t["name"] == "maya_bevel__bevel")
+            .find(|t| t["name"] == "maya-bevel.bevel")
             .unwrap();
         // inputSchema must be at least `{"type": "object"}` — not null/absent.
         assert!(
@@ -1116,12 +1116,12 @@ mod tests {
         // 9 core meta-tools + 2 skill tools (skill now loaded, no stubs) = 11
         assert_eq!(tools.len(), 11);
         let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
-        assert!(names.contains(&"modeling_bevel__bevel"));
-        assert!(names.contains(&"modeling_bevel__chamfer"));
+        assert!(names.contains(&"modeling-bevel.bevel"));
+        assert!(names.contains(&"modeling-bevel.chamfer"));
 
         let bevel_tool = tools
             .iter()
-            .find(|t| t["name"] == "modeling_bevel__bevel")
+            .find(|t| t["name"] == "modeling-bevel.bevel")
             .unwrap();
         assert_eq!(bevel_tool["annotations"]["deferredHint"], false);
     }
@@ -1198,6 +1198,85 @@ mod tests {
         assert_eq!(stub["annotations"], serde_json::Value::Null);
     }
 
+    // Tool namespacing tests (#238)
+    #[tokio::test]
+    async fn test_loaded_tools_have_namespaced_names() {
+        let server = TestServer::new(make_router_with_skill());
+        server.post("/mcp")
+            .add_header(axum::http::header::ACCEPT, "application/json".parse::<HeaderValue>().unwrap())
+            .json(&json!({"jsonrpc":"2.0","id":100,"method":"tools/call","params":{"name":"load_skill","arguments":{"skill_name":"modeling-bevel"}}}))
+            .await;
+        let resp = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({"jsonrpc":"2.0","id":101,"method":"tools/list"}))
+            .await;
+        let body: Value = resp.json();
+        let tools = body["result"]["tools"].as_array().unwrap();
+        let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+        assert!(
+            names.contains(&"modeling-bevel.bevel"),
+            "Expected modeling-bevel.bevel, got: {names:?}"
+        );
+        assert!(
+            names.contains(&"modeling-bevel.chamfer"),
+            "Expected modeling-bevel.chamfer, got: {names:?}"
+        );
+        assert!(
+            !names.contains(&"modeling_bevel__bevel"),
+            "Old __ name must not appear: {names:?}"
+        );
+    }
+    #[tokio::test]
+    async fn test_core_tools_keep_bare_names() {
+        let server = TestServer::new(make_router_with_skill());
+        let resp = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({"jsonrpc":"2.0","id":120,"method":"tools/list"}))
+            .await;
+        let body: Value = resp.json();
+        let tools = body["result"]["tools"].as_array().unwrap();
+        let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+        for core in &[
+            "find_skills",
+            "list_skills",
+            "get_skill_info",
+            "load_skill",
+            "unload_skill",
+            "search_skills",
+            "activate_tool_group",
+            "deactivate_tool_group",
+            "search_tools",
+        ] {
+            assert!(
+                names.contains(core),
+                "Core '{core}' must be bare, got: {names:?}"
+            );
+        }
+    }
+    #[tokio::test]
+    async fn test_unknown_tool_returns_not_found() {
+        let server = TestServer::new(make_router_with_skill());
+        let resp = server.post("/mcp")
+            .add_header(axum::http::header::ACCEPT, "application/json".parse::<HeaderValue>().unwrap())
+            .json(&json!({"jsonrpc":"2.0","id":130,"method":"tools/call","params":{"name":"totally_unknown_xyzzy","arguments":{}}}))
+            .await;
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        assert_eq!(body["result"]["isError"], true);
+        let text = body["result"]["content"][0]["text"].as_str().unwrap_or("");
+        assert!(
+            text.contains("Unknown tool") || text.contains("ACTION_NOT_FOUND"),
+            "Expected Unknown: {text}"
+        );
+    }
     #[tokio::test]
     async fn test_initialize_reports_list_changed_true() {
         let server = TestServer::new(make_router());


### PR DESCRIPTION
## Summary

- **Proactive `<skill-name>.<tool-name>` MCP tool namespacing**: Non-core tools registered from a skill now use `skill.tool` format (e.g. `maya-animation.set_keyframe`) instead of the internal registry name (`maya_animation__set_keyframe`). The AI agent immediately sees skill ownership without loading every skill.
- **Core tools keep bare names**: `load_skill`, `search_skills`, `find_skills`, etc. remain unchanged — only skill-registered tools get namespaced.
- **Backward-compatible dispatch**: `handle_tools_call` resolves names in three paths: (1) direct registry hit, (2) decode `<skill>.<tool>` via `extract_bare_tool_name`, (3) bare legacy name scan with deprecation warning logged.
- **Gateway layer updated**: New `{id8}/{tool}` prefix format (slash separator); legacy `{id8}__{tool}` still decoded for one-version backward compat with a deprecation `tracing::warn!`.

Closes #238

## Test plan

- [x] `cargo test -p dcc-mcp-http` — 93 Rust tests pass
- [x] `vx just preflight` — Rust check + clippy + fmt + all unit tests pass
- [x] `test_loaded_tools_have_namespaced_names` — verifies tools/list emits `modeling-bevel.bevel` format after load_skill
- [x] `test_core_tools_keep_bare_names` — core meta-tools never receive skill prefix
- [x] `test_unknown_tool_returns_not_found` — regression for unknown tool error path
- [x] Existing tests updated from old `maya_bevel__bevel` format to new `maya-bevel.bevel`