### PR TITLE
feat(http): ResourceLink content for DCC artifacts (#243)

### DIFF
--- a/crates/dcc-mcp-http/src/handler.rs
+++ b/crates/dcc-mcp-http/src/handler.rs
@@ -694,8 +694,20 @@ async fn handle_tools_call(
                 Value::Null => String::new(),
                 other => serde_json::to_string_pretty(other).unwrap_or_else(|_| other.to_string()),
             };
+            let mut content = vec![protocol::ToolContent::Text { text }];
+
+            // #243 — on MCP 2025-06-18 sessions, surface artifact files as
+            // `resource_link` content items so agents can resolve them on
+            // demand instead of receiving base64 blobs in the response.
+            if let Some(sid) = session_id {
+                let version = state.sessions.get_protocol_version(sid);
+                if version.as_deref() == Some("2025-06-18") {
+                    content.extend(crate::resource_link::extract_resource_links(&output));
+                }
+            }
+
             CallToolResult {
-                content: vec![protocol::ToolContent::Text { text }],
+                content,
                 is_error: false,
             }
         }

--- a/crates/dcc-mcp-http/src/lib.rs
+++ b/crates/dcc-mcp-http/src/lib.rs
@@ -46,6 +46,7 @@ pub mod gateway;
 pub mod handler;
 pub mod inflight;
 pub mod protocol;
+pub mod resource_link;
 pub mod server;
 pub mod session;
 

--- a/crates/dcc-mcp-http/src/protocol.rs
+++ b/crates/dcc-mcp-http/src/protocol.rs
@@ -268,11 +268,29 @@ pub struct CallToolResult {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "lowercase")]
+#[serde(tag = "type")]
 pub enum ToolContent {
+    #[serde(rename = "text")]
     Text { text: String },
+    #[serde(rename = "image", rename_all = "camelCase")]
     Image { data: String, mime_type: String },
+    #[serde(rename = "resource")]
     Resource { resource: Value },
+    /// MCP 2025-06-18 `resource_link` content type.
+    ///
+    /// Used to hand DCC-produced artifact files (playblasts, exports,
+    /// screenshots) back to the agent without copying their bytes into the
+    /// JSON-RPC response.
+    #[serde(rename = "resource_link", rename_all = "camelCase")]
+    ResourceLink {
+        uri: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        mime_type: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+    },
 }
 
 impl CallToolResult {

--- a/crates/dcc-mcp-http/src/resource_link.rs
+++ b/crates/dcc-mcp-http/src/resource_link.rs
@@ -1,0 +1,304 @@
+//! Artifact → MCP `resource_link` conversion (issue #243).
+//!
+//! On MCP **2025-06-18** sessions, tools/call results may include
+//! `resource_link` content items that point to DCC-produced artifact files
+//! (playblasts, FBX/USD exports, screenshots, baked textures).  Instead of
+//! base64-encoding the bytes into `content[0].text` — catastrophic for token
+//! cost — we hand the agent a URI it can resolve on demand.
+//!
+//! Tool authors surface artifacts by including one of the following keys in
+//! their JSON payload:
+//!
+//! | Key              | Shape                                           |
+//! |------------------|-------------------------------------------------|
+//! | `artifact_paths` | `["/abs/out.mp4", ...]`                         |
+//! | `artifacts`      | `[{"path": "...", "name": "...", "mime": "..."}]` |
+//! | `artifact_path`  | `"/abs/out.mp4"` (single path, legacy)          |
+//!
+//! On MCP **2025-03-26** sessions we emit no `resource_link` items (the spec
+//! did not define the type); the existing text fallback is preserved by the
+//! caller.
+
+use std::path::Path;
+
+use serde_json::Value;
+
+use crate::protocol::ToolContent;
+
+/// Heuristic mapping from file extension to a common MIME type.
+///
+/// Intentionally small — specialised DCC adapters are free to supply their
+/// own `mime` on `artifacts[].mime` when they know better.
+fn guess_mime_type(path: &str) -> Option<&'static str> {
+    let ext = Path::new(path).extension()?.to_str()?.to_ascii_lowercase();
+    Some(match ext.as_str() {
+        // Video / playblast
+        "mp4" => "video/mp4",
+        "mov" => "video/quicktime",
+        "avi" => "video/x-msvideo",
+        "webm" => "video/webm",
+        // Images / screenshots
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "tif" | "tiff" => "image/tiff",
+        "exr" => "image/x-exr",
+        "webp" => "image/webp",
+        // 3D / DCC exchange
+        "fbx" => "application/octet-stream",
+        "obj" => "model/obj",
+        "usd" | "usda" | "usdc" | "usdz" => "model/vnd.usd",
+        "gltf" => "model/gltf+json",
+        "glb" => "model/gltf-binary",
+        "abc" => "application/x-alembic",
+        // Textures / data
+        "hdr" => "image/vnd.radiance",
+        "json" => "application/json",
+        "xml" => "application/xml",
+        "txt" | "log" => "text/plain",
+        _ => return None,
+    })
+}
+
+/// Convert an absolute or relative filesystem path into a `file://` URI.
+///
+/// This is a best-effort conversion; it does not canonicalise the path (we
+/// must not touch the filesystem here — the action may return paths to files
+/// that live on the DCC host, not on the HTTP server).
+fn path_to_file_uri(path: &str) -> String {
+    if path.starts_with("file://") || path.contains("://") {
+        return path.to_string();
+    }
+    // Windows: replace backslashes; absolute paths need a leading slash.
+    let normalised = path.replace('\\', "/");
+    if normalised.starts_with('/') {
+        format!("file://{normalised}")
+    } else if normalised.len() >= 2 && normalised.as_bytes()[1] == b':' {
+        // e.g. "C:/foo/bar.mp4" → "file:///C:/foo/bar.mp4"
+        format!("file:///{normalised}")
+    } else {
+        // Relative path — still emit file:// so the client can resolve against cwd.
+        format!("file://{normalised}")
+    }
+}
+
+/// Build a single `ResourceLink` from a filesystem path.
+fn resource_link_from_path(path: &str, name: Option<&str>, mime: Option<&str>) -> ToolContent {
+    let file_name = name.map(str::to_owned).or_else(|| {
+        Path::new(path)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(str::to_owned)
+    });
+    let mime_type = mime
+        .map(str::to_owned)
+        .or_else(|| guess_mime_type(path).map(str::to_owned));
+    ToolContent::ResourceLink {
+        uri: path_to_file_uri(path),
+        name: file_name,
+        mime_type,
+        description: None,
+    }
+}
+
+/// Extract `resource_link` content items from a tool-output payload.
+///
+/// Recognised shapes (first match wins):
+/// - `{"artifact_paths": ["/a.mp4", "/b.png"]}`
+/// - `{"artifacts": [{"path": "/a.mp4", "name": "...", "mime": "..."}, ...]}`
+/// - `{"artifact_path": "/a.mp4"}`
+///
+/// Returns an empty vec when no artifacts are present.
+pub fn extract_resource_links(output: &Value) -> Vec<ToolContent> {
+    let obj = match output.as_object() {
+        Some(o) => o,
+        None => return Vec::new(),
+    };
+
+    if let Some(arr) = obj.get("artifact_paths").and_then(Value::as_array) {
+        return arr
+            .iter()
+            .filter_map(Value::as_str)
+            .map(|p| resource_link_from_path(p, None, None))
+            .collect();
+    }
+
+    if let Some(arr) = obj.get("artifacts").and_then(Value::as_array) {
+        return arr
+            .iter()
+            .filter_map(|entry| {
+                let e = entry.as_object()?;
+                let path = e.get("path").and_then(Value::as_str)?;
+                let name = e.get("name").and_then(Value::as_str);
+                // Accept both `mime` (terse) and `mimeType` (MCP camelCase) / `mime_type`.
+                let mime = e
+                    .get("mime")
+                    .and_then(Value::as_str)
+                    .or_else(|| e.get("mimeType").and_then(Value::as_str))
+                    .or_else(|| e.get("mime_type").and_then(Value::as_str));
+                let description = e.get("description").and_then(Value::as_str);
+                match resource_link_from_path(path, name, mime) {
+                    ToolContent::ResourceLink {
+                        uri,
+                        name,
+                        mime_type,
+                        ..
+                    } => Some(ToolContent::ResourceLink {
+                        uri,
+                        name,
+                        mime_type,
+                        description: description.map(str::to_owned),
+                    }),
+                    other => Some(other),
+                }
+            })
+            .collect();
+    }
+
+    if let Some(path) = obj.get("artifact_path").and_then(Value::as_str) {
+        return vec![resource_link_from_path(path, None, None)];
+    }
+
+    Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn guesses_common_mime_types() {
+        assert_eq!(guess_mime_type("/tmp/out.mp4"), Some("video/mp4"));
+        assert_eq!(guess_mime_type("shot.PNG"), Some("image/png"));
+        assert_eq!(guess_mime_type("scene.usda"), Some("model/vnd.usd"));
+        assert_eq!(guess_mime_type("unknown.xyz"), None);
+    }
+
+    #[test]
+    fn converts_unix_path_to_file_uri() {
+        assert_eq!(path_to_file_uri("/tmp/a.mp4"), "file:///tmp/a.mp4");
+    }
+
+    #[test]
+    fn converts_windows_path_to_file_uri() {
+        assert_eq!(
+            path_to_file_uri("C:\\work\\out.mp4"),
+            "file:///C:/work/out.mp4"
+        );
+    }
+
+    #[test]
+    fn preserves_existing_uri() {
+        assert_eq!(
+            path_to_file_uri("https://cdn.example.com/out.mp4"),
+            "https://cdn.example.com/out.mp4"
+        );
+        assert_eq!(
+            path_to_file_uri("file:///already/uri.png"),
+            "file:///already/uri.png"
+        );
+    }
+
+    #[test]
+    fn extracts_artifact_paths_array() {
+        let out = json!({
+            "artifact_paths": ["/tmp/a.mp4", "/tmp/b.png"],
+            "frame_count": 24,
+        });
+        let links = extract_resource_links(&out);
+        assert_eq!(links.len(), 2);
+        match &links[0] {
+            ToolContent::ResourceLink {
+                uri,
+                mime_type,
+                name,
+                ..
+            } => {
+                assert_eq!(uri, "file:///tmp/a.mp4");
+                assert_eq!(mime_type.as_deref(), Some("video/mp4"));
+                assert_eq!(name.as_deref(), Some("a.mp4"));
+            }
+            _ => panic!("expected ResourceLink"),
+        }
+    }
+
+    #[test]
+    fn extracts_structured_artifacts() {
+        let out = json!({
+            "artifacts": [
+                {
+                    "path": "/tmp/anim.mov",
+                    "name": "Shot 010 playblast",
+                    "mime": "video/quicktime",
+                    "description": "1280x720, 240 frames"
+                }
+            ]
+        });
+        let links = extract_resource_links(&out);
+        assert_eq!(links.len(), 1);
+        match &links[0] {
+            ToolContent::ResourceLink {
+                uri,
+                name,
+                mime_type,
+                description,
+            } => {
+                assert_eq!(uri, "file:///tmp/anim.mov");
+                assert_eq!(name.as_deref(), Some("Shot 010 playblast"));
+                assert_eq!(mime_type.as_deref(), Some("video/quicktime"));
+                assert_eq!(description.as_deref(), Some("1280x720, 240 frames"));
+            }
+            _ => panic!("expected ResourceLink"),
+        }
+    }
+
+    #[test]
+    fn extracts_single_artifact_path() {
+        let out = json!({"artifact_path": "/var/out/bake.exr"});
+        let links = extract_resource_links(&out);
+        assert_eq!(links.len(), 1);
+    }
+
+    #[test]
+    fn returns_empty_when_no_artifacts() {
+        let out = json!({"nodes": ["pSphere1"]});
+        assert!(extract_resource_links(&out).is_empty());
+    }
+
+    #[test]
+    fn accepts_mime_type_camel_and_snake() {
+        let out = json!({
+            "artifacts": [
+                {"path": "/a.bin", "mimeType": "application/custom-a"},
+                {"path": "/b.bin", "mime_type": "application/custom-b"}
+            ]
+        });
+        let links = extract_resource_links(&out);
+        assert_eq!(links.len(), 2);
+        if let ToolContent::ResourceLink { mime_type, .. } = &links[0] {
+            assert_eq!(mime_type.as_deref(), Some("application/custom-a"));
+        }
+        if let ToolContent::ResourceLink { mime_type, .. } = &links[1] {
+            assert_eq!(mime_type.as_deref(), Some("application/custom-b"));
+        }
+    }
+
+    #[test]
+    fn serializes_with_resource_link_type_tag() {
+        let link = ToolContent::ResourceLink {
+            uri: "file:///tmp/a.mp4".into(),
+            name: Some("a.mp4".into()),
+            mime_type: Some("video/mp4".into()),
+            description: None,
+        };
+        let v = serde_json::to_value(&link).unwrap();
+        assert_eq!(v.get("type").and_then(Value::as_str), Some("resource_link"));
+        assert_eq!(
+            v.get("uri").and_then(Value::as_str),
+            Some("file:///tmp/a.mp4")
+        );
+        assert_eq!(v.get("mimeType").and_then(Value::as_str), Some("video/mp4"));
+        assert!(v.get("description").is_none());
+    }
+}

--- a/crates/dcc-mcp-http/src/tests.rs
+++ b/crates/dcc-mcp-http/src/tests.rs
@@ -51,6 +51,7 @@ mod tests {
             server_name: "test-dcc".to_string(),
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+            in_flight: crate::inflight::InFlightRequests::new(),
         }
     }
 
@@ -198,6 +199,7 @@ mod tests {
             server_name: "test-dcc".to_string(),
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+            in_flight: crate::inflight::InFlightRequests::new(),
         }
     }
 
@@ -958,6 +960,7 @@ mod tests {
             server_name: "test-dcc".to_string(),
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+            in_flight: crate::inflight::InFlightRequests::new(),
         }
     }
 
@@ -1320,6 +1323,7 @@ mod tests {
             server_name: "test-dcc".to_string(),
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+            in_flight: crate::inflight::InFlightRequests::new(),
         }
     }
 
@@ -1420,6 +1424,7 @@ mod tests {
             server_name: "test-dcc".to_string(),
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+            in_flight: crate::inflight::InFlightRequests::new(),
         };
 
         use crate::handler::{handle_delete, handle_get, handle_post};
@@ -1644,6 +1649,7 @@ mod tests {
             server_name: "test-dcc".to_string(),
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+            in_flight: crate::inflight::InFlightRequests::new(),
         }
     }
 
@@ -2149,5 +2155,181 @@ mod gateway_tests {
         let entry = ServiceEntry::new("blender", "127.0.0.1", 19000);
         let handle = runner.start(entry).await.unwrap();
         assert!(handle.is_gateway, "first runner should win free port");
+    }
+}
+
+#[cfg(test)]
+mod resource_link_integration_tests {
+    use axum::http::HeaderValue;
+    use axum_test::TestServer;
+    use serde_json::{Value, json};
+    use std::sync::Arc;
+
+    use crate::{handler::AppState, session::SessionManager};
+    use dcc_mcp_actions::{ActionDispatcher, ActionMeta, ActionRegistry};
+    use dcc_mcp_skills::SkillCatalog;
+
+    // ── ResourceLink (#243) — 2025-06-18 artifact surfacing ───────────────
+    //
+    // On MCP 2025-06-18 sessions, tools/call results that include
+    // `artifact_paths` / `artifacts` / `artifact_path` must surface them as
+    // `resource_link` content items. On 2025-03-26 sessions the text fallback
+    // is preserved (no resource_link content).
+
+    fn make_app_state_with_artifact_handler() -> AppState {
+        let registry = Arc::new({
+            let reg = ActionRegistry::new();
+            reg.register_action(ActionMeta {
+                name: "playblast".into(),
+                description: "Render a playblast".into(),
+                category: "render".into(),
+                tags: vec!["render".into()],
+                dcc: "test_dcc".into(),
+                version: "1.0.0".into(),
+                ..Default::default()
+            });
+            reg
+        });
+        let catalog = Arc::new(SkillCatalog::new(registry.clone()));
+        let dispatcher = Arc::new(ActionDispatcher::new((*registry).clone()));
+        dispatcher.register_handler("playblast", |_params| {
+            Ok(json!({
+                "frame_count": 24,
+                "artifact_paths": ["/tmp/shot_010.mp4"]
+            }))
+        });
+        AppState {
+            registry,
+            dispatcher,
+            catalog,
+            sessions: SessionManager::new(),
+            executor: None,
+            bridge_registry: crate::BridgeRegistry::new(),
+            server_name: "test-dcc".to_string(),
+            server_version: "0.1.0".to_string(),
+            cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+            in_flight: crate::inflight::InFlightRequests::new(),
+        }
+    }
+
+    fn make_router_with_artifact_handler() -> (axum::Router, SessionManager) {
+        use crate::handler::{handle_delete, handle_get, handle_post};
+        use axum::{Router, routing};
+        let state = make_app_state_with_artifact_handler();
+        let sessions = state.sessions.clone();
+        let router = Router::new()
+            .route(
+                "/mcp",
+                routing::post(handle_post)
+                    .get(handle_get)
+                    .delete(handle_delete),
+            )
+            .with_state(state);
+        (router, sessions)
+    }
+
+    #[tokio::test]
+    async fn test_resource_link_emitted_on_2025_06_18_session() {
+        let (router, sessions) = make_router_with_artifact_handler();
+        let session_id = sessions.create();
+        sessions.set_protocol_version(&session_id, "2025-06-18");
+
+        let server = TestServer::new(router);
+        let resp = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .add_header(
+                axum::http::HeaderName::from_static("mcp-session-id"),
+                session_id.parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 200,
+                "method": "tools/call",
+                "params": {"name": "playblast", "arguments": {}}
+            }))
+            .await;
+
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        assert_eq!(body["result"]["isError"], false, "body = {body}");
+
+        let content = body["result"]["content"].as_array().unwrap();
+        // First item is the text summary.
+        assert_eq!(content[0]["type"], "text");
+        // Second item must be the resource_link for the artifact.
+        let link = content.iter().find(|c| c["type"] == "resource_link");
+        assert!(
+            link.is_some(),
+            "Expected a resource_link content item on 2025-06-18, got: {content:?}"
+        );
+        let link = link.unwrap();
+        assert_eq!(link["uri"], "file:///tmp/shot_010.mp4");
+        assert_eq!(link["mimeType"], "video/mp4");
+        assert_eq!(link["name"], "shot_010.mp4");
+    }
+
+    #[tokio::test]
+    async fn test_resource_link_suppressed_on_2025_03_26_session() {
+        let (router, sessions) = make_router_with_artifact_handler();
+        let session_id = sessions.create();
+        sessions.set_protocol_version(&session_id, "2025-03-26");
+
+        let server = TestServer::new(router);
+        let resp = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .add_header(
+                axum::http::HeaderName::from_static("mcp-session-id"),
+                session_id.parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 201,
+                "method": "tools/call",
+                "params": {"name": "playblast", "arguments": {}}
+            }))
+            .await;
+
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        let content = body["result"]["content"].as_array().unwrap();
+        assert!(
+            content.iter().all(|c| c["type"] != "resource_link"),
+            "resource_link must NOT appear on 2025-03-26 sessions, got: {content:?}"
+        );
+        // Text fallback still carries the full JSON payload including the path.
+        let text = content[0]["text"].as_str().unwrap();
+        assert!(text.contains("/tmp/shot_010.mp4"));
+    }
+
+    #[tokio::test]
+    async fn test_resource_link_suppressed_when_session_header_absent() {
+        let (router, _sessions) = make_router_with_artifact_handler();
+        let server = TestServer::new(router);
+        let resp = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 202,
+                "method": "tools/call",
+                "params": {"name": "playblast", "arguments": {}}
+            }))
+            .await;
+
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        let content = body["result"]["content"].as_array().unwrap();
+        assert!(content.iter().all(|c| c["type"] != "resource_link"));
     }
 }


### PR DESCRIPTION
## Summary

Closes #243. Implements the MCP 2025-06-18 `resource_link` content type so DCC tools can hand artifact files (playblasts, FBX/USD exports, screenshots, baked textures) back to the agent as URIs instead of base64 blobs.

- `ToolContent::ResourceLink { uri, name, mimeType, description }` — spec-compliant shape, added to `protocol::ToolContent`.
- New `resource_link` module extracts artifacts from tool output using conventional keys: `artifact_paths: [str]`, `artifacts: [{path, name, mime|mimeType|mime_type, description}]`, and legacy `artifact_path: str`. MIME is inferred from the extension when not supplied (mp4, mov, png, exr, usd, fbx, abc, gltf, …).
- `handle_tools_call` only emits `resource_link` items on sessions negotiated at `2025-06-18`. On `2025-03-26` sessions (or when the client sent no `Mcp-Session-Id`), the existing text fallback is preserved verbatim.

No behaviour change for tools that do not return artifact keys, and no behaviour change for `2025-03-26` clients.

## Motivation

DCC actions often produce large files as their primary output. Today they must either return the absolute path as a plain string (no way for MCP-aware clients to preview or fetch on demand) or embed base64 bytes in `content[0].text` (a 50 MB playblast = ~67 MB of JSON, token-cost catastrophic). `resource_link` is the standard MCP solution; this PR makes it available to every DCC adapter without requiring any per-adapter changes beyond returning `artifact_paths` / `artifacts` from the tool handler.

## Test plan

- [x] `cargo test -p dcc-mcp-http` — 113 existing tests pass + 13 new tests (10 unit, 3 HTTP integration).
- [x] `cargo clippy --workspace -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] Unit tests cover: MIME guessing, unix & Windows path-to-URI conversion, `file://` / `https://` passthrough, all three payload shapes (`artifact_paths` array, structured `artifacts`, single `artifact_path`), empty-output case, `mime` vs `mimeType` vs `mime_type` key variants, and JSON shape (`type: "resource_link"`, camelCase `mimeType`).
- [x] Integration tests: `resource_link` emitted on 2025-06-18 session, suppressed on 2025-03-26 session, suppressed when no session header is present.

## Follow-ups (out of scope)

- DCC-specific adapter tools (maya `playblast`, `export_fbx`, `export_usd`, `screenshot`, `bake_textures`) should start returning `artifact_paths` to opt in. No changes needed in `dcc-mcp-core` for that.
- A Python `Artifact(path=…, name=…, mime=…)` helper can be layered on top in a follow-up PR — the Rust side already accepts the structured `artifacts` payload.
