### PR TITLE
fix(http/gateway): replace / tool-name separator with . (#261)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 
 [workspace]
 members = [
+    "crates/dcc-mcp-naming",
     "crates/dcc-mcp-models",
     "crates/dcc-mcp-actions",
     "crates/dcc-mcp-skills",
@@ -30,6 +31,7 @@ repository = "https://github.com/loonghao/dcc-mcp-core"
 
 [workspace.dependencies]
 # Internal crates
+dcc-mcp-naming = { path = "crates/dcc-mcp-naming" }
 dcc-mcp-models = { path = "crates/dcc-mcp-models" }
 dcc-mcp-actions = { path = "crates/dcc-mcp-actions" }
 dcc-mcp-skills = { path = "crates/dcc-mcp-skills" }
@@ -94,6 +96,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 # Internal crates
+dcc-mcp-naming.workspace = true
 dcc-mcp-models.workspace = true
 dcc-mcp-actions.workspace = true
 dcc-mcp-skills.workspace = true
@@ -133,7 +136,7 @@ strip = true
 
 [features]
 default = []
-python-bindings = ["pyo3", "dcc-mcp-models/python-bindings", "dcc-mcp-actions/python-bindings", "dcc-mcp-skills/python-bindings", "dcc-mcp-protocols/python-bindings", "dcc-mcp-utils/python-bindings", "dcc-mcp-transport/python-bindings", "dcc-mcp-process/python-bindings", "dcc-mcp-telemetry/python-bindings", "dcc-mcp-sandbox/python-bindings", "dcc-mcp-shm/python-bindings", "dcc-mcp-capture/python-bindings", "dcc-mcp-usd/python-bindings", "dcc-mcp-http/python-bindings"]
+python-bindings = ["pyo3", "dcc-mcp-naming/python-bindings", "dcc-mcp-models/python-bindings", "dcc-mcp-actions/python-bindings", "dcc-mcp-skills/python-bindings", "dcc-mcp-protocols/python-bindings", "dcc-mcp-utils/python-bindings", "dcc-mcp-transport/python-bindings", "dcc-mcp-process/python-bindings", "dcc-mcp-telemetry/python-bindings", "dcc-mcp-sandbox/python-bindings", "dcc-mcp-shm/python-bindings", "dcc-mcp-capture/python-bindings", "dcc-mcp-usd/python-bindings", "dcc-mcp-http/python-bindings"]
 abi3-py38 = ["pyo3/abi3-py38"]
 # Python 3.7 wheel: non-abi3 build, no abi3-py38 feature
 ext-module = ["pyo3/extension-module"]

--- a/crates/dcc-mcp-http/Cargo.toml
+++ b/crates/dcc-mcp-http/Cargo.toml
@@ -11,6 +11,7 @@ description = "MCP Streamable HTTP server for DCC applications (axum-based, thre
 [dependencies]
 # Internal crates
 dcc-mcp-actions = { path = "../dcc-mcp-actions" }
+dcc-mcp-naming = { path = "../dcc-mcp-naming" }
 dcc-mcp-protocols = { path = "../dcc-mcp-protocols" }
 dcc-mcp-models = { path = "../dcc-mcp-models" }
 dcc-mcp-skills = { path = "../dcc-mcp-skills" }

--- a/crates/dcc-mcp-http/src/gateway/namespace.rs
+++ b/crates/dcc-mcp-http/src/gateway/namespace.rs
@@ -5,6 +5,25 @@
 //! Non-core tools registered from a skill use `<skill-name>.<tool-name>` format
 //! (e.g. `maya-animation.set_keyframe`) so the AI agent immediately sees which
 //! skill a tool belongs to.
+//!
+//! ## Gateway: `<id8>.<tool>` instance prefix (#261)
+//!
+//! The aggregating gateway prepends an 8-hex-char instance id so duplicate
+//! tool names across multiple DCC backends remain addressable. The chosen
+//! separator is **`.` (dot)** because [SEP-986](
+//! https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1603)
+//! restricts MCP tool names to `[A-Za-z0-9_.-]`, 1–128 chars — `/` is **not**
+//! legal. Major LLM clients (Anthropic, OpenAI, Cursor) apply even stricter
+//! regexes and will reject names containing `/` outright.
+//!
+//! Decoder accepts three historical encodings for one-version backward
+//! compatibility (each with a `tracing::warn!` on the legacy forms):
+//!
+//! | Form | Status |
+//! |------|--------|
+//! | `{id8}.{tool}` | **Preferred** — current emitter |
+//! | `{id8}/{tool}` | Deprecated — previous unreleased build, decoded + warned |
+//! | `{id8}__{tool}` | Legacy — pre-#258, decoded + warned |
 
 use uuid::Uuid;
 
@@ -34,8 +53,15 @@ pub const CORE_TOOL_NAMES: &[&str] = &[
 ];
 
 pub const ID_PREFIX_LEN: usize = 8;
-pub const INSTANCE_SEP: &str = "/";
+
+/// Current, SEP-986-compliant gateway instance separator.
+pub const INSTANCE_SEP: &str = ".";
+/// Deprecated separator from an unreleased build — still decoded for
+/// one-version backward compat, never emitted.
+pub const DEPRECATED_SLASH_SEP: &str = "/";
+/// Legacy pre-#258 separator — still decoded for backward compat.
 pub const LEGACY_NAMESPACE_SEP: &str = "__";
+/// Skill→tool separator (unchanged; already SEP-986-compliant).
 pub const SKILL_TOOL_SEP: &str = ".";
 
 pub fn is_local_tool(name: &str) -> bool {
@@ -90,31 +116,89 @@ pub fn skill_tool_name(skill_name: &str, action_name: &str) -> Option<String> {
     Some(format!("{skill_name}{SKILL_TOOL_SEP}{bare}"))
 }
 
+/// Decode a `<skill>.<tool>` pair from a per-DCC tool name.
+///
+/// Rejects gateway-encoded names (`{id8}.<rest>` with an 8-hex prefix) and
+/// skill stubs (`__skill__...`).
 pub fn decode_skill_tool_name(namespaced: &str) -> Option<(&str, &str)> {
     if namespaced.starts_with("__") || namespaced.contains('/') {
         return None;
     }
+    // Reject gateway-encoded form — the gateway prefix owns the first dot.
+    if let Some((head, _)) = namespaced.split_once(SKILL_TOOL_SEP) {
+        if is_instance_prefix(head) {
+            return None;
+        }
+    }
     namespaced.split_once(SKILL_TOOL_SEP)
 }
 
+/// Encode a tool name for gateway aggregation: `{id8}.{original}`.
+///
+/// # Panics (debug builds only)
+///
+/// In debug builds the result is checked against
+/// [`dcc_mcp_naming::validate_tool_name`]; the gateway never emits a name that
+/// fails SEP-986. Release builds skip the check for zero overhead — invalid
+/// names would have been caught at registration time (see
+/// [`assert_gateway_tool_name`]).
 pub fn encode_tool_name(id: &Uuid, original: &str) -> String {
-    format!("{}{INSTANCE_SEP}{original}", instance_short(id))
+    let encoded = format!("{}{INSTANCE_SEP}{original}", instance_short(id));
+    debug_assert!(
+        dcc_mcp_naming::validate_tool_name(&encoded).is_ok(),
+        "gateway emitted tool name {encoded:?} that violates SEP-986"
+    );
+    encoded
 }
 
+/// Validate a tool name the gateway is about to publish.
+///
+/// Used by the registration path as a hard gate: if the composed name would
+/// be rejected by a compliant MCP client, we refuse to register it rather
+/// than ship it and watch the LLM client 400 at runtime.
+///
+/// # Errors
+///
+/// Propagates [`dcc_mcp_naming::NamingError`] unchanged.
+pub fn assert_gateway_tool_name(name: &str) -> Result<(), dcc_mcp_naming::NamingError> {
+    dcc_mcp_naming::validate_tool_name(name)
+}
+
+fn is_instance_prefix(s: &str) -> bool {
+    s.len() == ID_PREFIX_LEN && s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Decode a gateway-encoded tool name into `(id8, original)`.
+///
+/// Accepts the current `.` separator plus two deprecated encodings for
+/// backward compat (`/` and `__`); both emit a `tracing::warn!` so operators
+/// notice leftover clients.
 pub fn decode_tool_name(prefixed: &str) -> Option<(&str, &str)> {
     if is_local_tool(prefixed) {
         return None;
     }
+    // 1. Preferred: `{id8}.{tool}`.
     if let Some((p, r)) = prefixed.split_once(INSTANCE_SEP) {
-        if p.len() == ID_PREFIX_LEN && p.chars().all(|c| c.is_ascii_hexdigit()) {
+        if is_instance_prefix(p) {
             return Some((p, r));
         }
     }
-    if let Some((p, r)) = prefixed.split_once(LEGACY_NAMESPACE_SEP) {
-        if p.len() == ID_PREFIX_LEN && p.chars().all(|c| c.is_ascii_hexdigit()) {
+    // 2. Deprecated: `{id8}/{tool}` — the unreleased format fixed in #261.
+    if let Some((p, r)) = prefixed.split_once(DEPRECATED_SLASH_SEP) {
+        if is_instance_prefix(p) {
             tracing::warn!(
                 tool = prefixed,
-                "Deprecated `__` prefix. Use `{{id8}}/{{tool}}`."
+                "Deprecated `/` gateway separator (pre-#261). Use `{{id8}}.{{tool}}`."
+            );
+            return Some((p, r));
+        }
+    }
+    // 3. Legacy: `{id8}__{tool}` — pre-#258.
+    if let Some((p, r)) = prefixed.split_once(LEGACY_NAMESPACE_SEP) {
+        if is_instance_prefix(p) {
+            tracing::warn!(
+                tool = prefixed,
+                "Deprecated `__` gateway separator (pre-#258). Use `{{id8}}.{{tool}}`."
             );
             return Some((p, r));
         }
@@ -125,32 +209,100 @@ pub fn decode_tool_name(prefixed: &str) -> Option<(&str, &str)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dcc_mcp_naming::validate_tool_name;
+
     #[test]
     fn instance_short_deterministic() {
         let id = Uuid::parse_str("abcdef0123456789abcdef0123456789").unwrap();
         assert_eq!(instance_short(&id), "abcdef01");
     }
+
+    #[test]
+    fn encode_uses_dot_separator() {
+        let id = Uuid::parse_str("abcdef0123456789abcdef0123456789").unwrap();
+        let enc = encode_tool_name(&id, "create_sphere");
+        assert_eq!(enc, "abcdef01.create_sphere");
+    }
+
+    #[test]
+    fn encode_never_contains_slash() {
+        let id = Uuid::parse_str("abcdef0123456789abcdef0123456789").unwrap();
+        for tool in [
+            "create_sphere",
+            "maya-animation.set_keyframe",
+            "CamelCase",
+            "x",
+        ] {
+            let enc = encode_tool_name(&id, tool);
+            assert!(
+                !enc.contains('/'),
+                "gateway encoded {tool:?} -> {enc:?} which contains `/`"
+            );
+        }
+    }
+
+    #[test]
+    fn encode_produces_sep986_compliant_names() {
+        let id = Uuid::parse_str("abcdef0123456789abcdef0123456789").unwrap();
+        for tool in ["create_sphere", "maya-animation.set_keyframe", "CamelCase"] {
+            let enc = encode_tool_name(&id, tool);
+            assert!(
+                validate_tool_name(&enc).is_ok(),
+                "gateway emitted {enc:?} which fails SEP-986 validation"
+            );
+        }
+    }
+
     #[test]
     fn encode_then_decode_roundtrips() {
         let id = Uuid::parse_str("abcdef0123456789abcdef0123456789").unwrap();
         let enc = encode_tool_name(&id, "maya-animation.set_keyframe");
-        assert_eq!(enc, "abcdef01/maya-animation.set_keyframe");
+        assert_eq!(enc, "abcdef01.maya-animation.set_keyframe");
         let (p, o) = decode_tool_name(&enc).unwrap();
         assert_eq!(p, "abcdef01");
         assert_eq!(o, "maya-animation.set_keyframe");
     }
+
     #[test]
-    fn decode_legacy_format() {
+    fn decode_accepts_preferred_dot_form() {
+        let (p, n) = decode_tool_name("abcdef01.create_sphere").unwrap();
+        assert_eq!(p, "abcdef01");
+        assert_eq!(n, "create_sphere");
+    }
+
+    #[test]
+    fn decode_accepts_deprecated_slash_form() {
+        let (p, n) = decode_tool_name("abcdef01/create_sphere").unwrap();
+        assert_eq!(p, "abcdef01");
+        assert_eq!(n, "create_sphere");
+    }
+
+    #[test]
+    fn decode_accepts_legacy_double_underscore_form() {
         let (p, n) = decode_tool_name("abcdef01__maya_geometry__create_sphere").unwrap();
         assert_eq!(p, "abcdef01");
         assert_eq!(n, "maya_geometry__create_sphere");
     }
+
+    #[test]
+    fn decode_rejects_non_hex_prefix() {
+        // 8 chars but not hex → must not be mistaken for an instance prefix.
+        assert!(decode_tool_name("zzzzzzzz.create").is_none());
+    }
+
+    #[test]
+    fn decode_rejects_wrong_length_prefix() {
+        assert!(decode_tool_name("abcdef.create").is_none()); // 6 chars
+        assert!(decode_tool_name("abcdef012.create").is_none()); // 9 chars
+    }
+
     #[test]
     fn local_tools_decode_to_none() {
         for name in GATEWAY_LOCAL_TOOLS {
             assert!(decode_tool_name(name).is_none());
         }
     }
+
     #[test]
     fn extract_bare_name_strips_prefix() {
         assert_eq!(
@@ -162,6 +314,7 @@ mod tests {
             "get_scene_info"
         );
     }
+
     #[test]
     fn skill_tool_name_formats_correctly() {
         assert_eq!(
@@ -170,21 +323,42 @@ mod tests {
         );
         assert_eq!(skill_tool_name("", "set_keyframe"), None);
     }
+
     #[test]
     fn skill_tool_name_none_for_core_tools() {
         for core in CORE_TOOL_NAMES {
             assert_eq!(skill_tool_name("s", &format!("s__{core}")), None);
         }
     }
+
     #[test]
     fn decode_skill_tool_name_round_trips() {
         let (skill, tool) = decode_skill_tool_name("maya-animation.set_keyframe").unwrap();
         assert_eq!(skill, "maya-animation");
         assert_eq!(tool, "set_keyframe");
     }
+
     #[test]
     fn decode_skill_tool_name_rejects_stubs() {
         assert!(decode_skill_tool_name("__skill__maya").is_none());
         assert!(decode_skill_tool_name("abcdef01/tool.name").is_none());
+    }
+
+    #[test]
+    fn decode_skill_tool_name_rejects_gateway_encoded_form() {
+        // `abcdef01.create_sphere` is a gateway-encoded tool, not a skill.tool
+        // pair. `decode_skill_tool_name` must yield None so callers route it
+        // through `decode_tool_name` instead.
+        assert!(decode_skill_tool_name("abcdef01.create_sphere").is_none());
+    }
+
+    #[test]
+    fn assert_gateway_tool_name_accepts_compliant() {
+        assert!(assert_gateway_tool_name("abcdef01.create_sphere").is_ok());
+    }
+
+    #[test]
+    fn assert_gateway_tool_name_rejects_slash() {
+        assert!(assert_gateway_tool_name("abcdef01/create_sphere").is_err());
     }
 }

--- a/crates/dcc-mcp-naming/Cargo.toml
+++ b/crates/dcc-mcp-naming/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "dcc-mcp-naming"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Tool-name and action-id validators for the DCC-MCP ecosystem (SEP-986 single source of truth)"
+
+[dependencies]
+pyo3 = { workspace = true, optional = true }
+thiserror = { workspace = true }
+
+[features]
+default = []
+python-bindings = ["pyo3"]

--- a/crates/dcc-mcp-naming/src/lib.rs
+++ b/crates/dcc-mcp-naming/src/lib.rs
@@ -1,0 +1,416 @@
+//! # dcc-mcp-naming
+//!
+//! Single source of truth for the two naming rules used across the whole
+//! DCC-MCP ecosystem:
+//!
+//! * **Tool name** — the wire-visible string published in MCP `tools/list`.
+//!   Must match [`TOOL_NAME_RE`].
+//! * **Action id** — the internal, stable identifier used by Rust hosts and
+//!   Python bridges to route `tools/call`. Must match [`ACTION_ID_RE`].
+//!
+//! ## Specs
+//!
+//! * [MCP `draft/server/tools#tool-names`](https://modelcontextprotocol.io/specification/draft/server/tools#tool-names)
+//! * [SEP-986](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/986)
+//!   merged in [modelcontextprotocol#1603](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1603)
+//!
+//! The MCP spec allows up to 128 characters for a tool name; this crate caps
+//! at **48** to leave room for namespace prefixes added by gateways (e.g.
+//! `{id8}/` or `{skill}.`).
+//!
+//! Every other crate in this repository — `dcc-mcp-actions`,
+//! `dcc-mcp-skills`, `dcc-mcp-http`, the Python wheel, macros, docs — **must**
+//! go through these validators. Re-inventing the regex in another place is a
+//! bug.
+
+#![deny(missing_docs)]
+
+use thiserror::Error;
+
+#[cfg(feature = "python-bindings")]
+pub mod python;
+
+/// MCP wire-visible tool-name regex.
+///
+/// Syntax (see module docs): starts with ASCII alphanumeric, then up to 47
+/// more ASCII alphanumeric / `_` / `.` / `-` characters, total length ≤ 48.
+///
+/// The trailing character class intentionally excludes `/`, `:`, space, `,`,
+/// `@`, `+` and every other punctuation mark — these are reserved for
+/// transport-layer composition (gateway prefixes, MCP URIs, etc.).
+pub const TOOL_NAME_RE: &str = r"^[A-Za-z0-9](?:[A-Za-z0-9_.\-]{0,47})$";
+
+/// Internal action-id regex.
+///
+/// A `.`-separated chain of lowercase-identifier segments (`[a-z][a-z0-9_]*`).
+/// This is the canonical host-side identifier passed to tool dispatchers.
+///
+/// Examples: `scene.get_info`, `geometry.create_sphere`, `maya.render`.
+pub const ACTION_ID_RE: &str = r"^[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)*$";
+
+/// Maximum length enforced on tool names (MCP spec allows 128, we cap lower
+/// to leave room for gateway prefixes).
+pub const MAX_TOOL_NAME_LEN: usize = 48;
+
+/// Reasons a name can fail validation.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum NamingError {
+    /// Name is the empty string.
+    #[error("name must not be empty")]
+    Empty,
+
+    /// Name exceeds the per-rule length cap.
+    #[error("name is {actual} chars, max is {max}")]
+    TooLong {
+        /// Length observed.
+        actual: usize,
+        /// Cap allowed.
+        max: usize,
+    },
+
+    /// Name contains a non-ASCII character.
+    #[error("name contains non-ASCII character {ch:?} at byte offset {offset}")]
+    NonAscii {
+        /// First offending character.
+        ch: char,
+        /// Byte offset into the input where it was seen.
+        offset: usize,
+    },
+
+    /// Name's first character is not in the allowed leading class.
+    #[error("name must start with an ASCII alphanumeric, got {ch:?}")]
+    BadLeadingChar {
+        /// First character observed.
+        ch: char,
+    },
+
+    /// Name contains a character that is not in the allowed set.
+    #[error("name contains disallowed character {ch:?} at byte offset {offset}")]
+    BadChar {
+        /// Offending character.
+        ch: char,
+        /// Byte offset into the input where it was seen.
+        offset: usize,
+    },
+
+    /// Action-id contains an empty segment (e.g. `foo..bar` or `.foo`).
+    #[error("action id has an empty `.`-separated segment")]
+    EmptySegment,
+}
+
+// ── tool-name ───────────────────────────────────────────────────────────────
+
+/// Validate an MCP tool name against [`TOOL_NAME_RE`] + the 48-char cap.
+///
+/// Runs in `O(n)` and does not allocate. Prefer this over hand-rolled checks.
+///
+/// # Errors
+///
+/// Returns a [`NamingError`] describing the *first* violation found.
+///
+/// # Examples
+///
+/// ```
+/// use dcc_mcp_naming::validate_tool_name;
+/// assert!(validate_tool_name("geometry.create_sphere").is_ok());
+/// assert!(validate_tool_name("hello-world.greet").is_ok());
+/// assert!(validate_tool_name("").is_err());
+/// assert!(validate_tool_name("bad/name").is_err());
+/// assert!(validate_tool_name("_leading").is_err());
+/// ```
+pub fn validate_tool_name(s: &str) -> Result<(), NamingError> {
+    if s.is_empty() {
+        return Err(NamingError::Empty);
+    }
+    if s.len() > MAX_TOOL_NAME_LEN {
+        return Err(NamingError::TooLong {
+            actual: s.len(),
+            max: MAX_TOOL_NAME_LEN,
+        });
+    }
+    let mut chars = s.char_indices();
+    // Leading char: must be ASCII alphanumeric.
+    let (_, first) = chars.next().expect("length checked above");
+    if !first.is_ascii() {
+        return Err(NamingError::NonAscii {
+            ch: first,
+            offset: 0,
+        });
+    }
+    if !first.is_ascii_alphanumeric() {
+        return Err(NamingError::BadLeadingChar { ch: first });
+    }
+    // Remainder: [A-Za-z0-9_.-]
+    for (offset, ch) in chars {
+        if !ch.is_ascii() {
+            return Err(NamingError::NonAscii { ch, offset });
+        }
+        let ok = ch.is_ascii_alphanumeric() || matches!(ch, '_' | '.' | '-');
+        if !ok {
+            return Err(NamingError::BadChar { ch, offset });
+        }
+    }
+    Ok(())
+}
+
+// ── action-id ───────────────────────────────────────────────────────────────
+
+/// Validate an internal action id against [`ACTION_ID_RE`].
+///
+/// Runs in `O(n)` and does not allocate.
+///
+/// # Errors
+///
+/// Returns a [`NamingError`] on the first offending character / segment.
+///
+/// # Examples
+///
+/// ```
+/// use dcc_mcp_naming::validate_action_id;
+/// assert!(validate_action_id("scene.get_info").is_ok());
+/// assert!(validate_action_id("maya.render").is_ok());
+/// assert!(validate_action_id("Scene.Get_Info").is_err()); // uppercase
+/// assert!(validate_action_id("scene..get").is_err()); // empty segment
+/// assert!(validate_action_id("1scene.get").is_err()); // leading digit
+/// ```
+pub fn validate_action_id(s: &str) -> Result<(), NamingError> {
+    if s.is_empty() {
+        return Err(NamingError::Empty);
+    }
+    // Walk segments without allocating.
+    let mut segment_start = 0usize;
+    let mut in_segment = false;
+    for (offset, ch) in s.char_indices() {
+        if !ch.is_ascii() {
+            return Err(NamingError::NonAscii { ch, offset });
+        }
+        if ch == '.' {
+            if !in_segment {
+                return Err(NamingError::EmptySegment);
+            }
+            in_segment = false;
+            segment_start = offset + 1;
+            continue;
+        }
+        if !in_segment {
+            // First char of a segment must be `[a-z]`.
+            if !ch.is_ascii_lowercase() {
+                return Err(NamingError::BadLeadingChar { ch });
+            }
+            in_segment = true;
+            let _ = segment_start; // silence unused warning on non-debug builds
+        } else {
+            // Trailing chars: `[a-z0-9_]`.
+            let ok = ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_';
+            if !ok {
+                return Err(NamingError::BadChar { ch, offset });
+            }
+        }
+    }
+    if !in_segment {
+        // Trailing `.` with no segment after it.
+        return Err(NamingError::EmptySegment);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── tool-name: positive cases ───────────────────────────────────────────
+
+    #[test]
+    fn tool_name_accepts_simple_identifier() {
+        assert!(validate_tool_name("create_sphere").is_ok());
+    }
+
+    #[test]
+    fn tool_name_accepts_dotted() {
+        assert!(validate_tool_name("geometry.create_sphere").is_ok());
+        assert!(validate_tool_name("scene.object.transform").is_ok());
+    }
+
+    #[test]
+    fn tool_name_accepts_hyphens() {
+        assert!(validate_tool_name("hello-world.greet").is_ok());
+    }
+
+    #[test]
+    fn tool_name_accepts_mixed_case() {
+        assert!(validate_tool_name("CamelCaseTool").is_ok());
+    }
+
+    #[test]
+    fn tool_name_accepts_single_char() {
+        assert!(validate_tool_name("a").is_ok());
+        assert!(validate_tool_name("Z").is_ok());
+        assert!(validate_tool_name("0").is_ok());
+    }
+
+    #[test]
+    fn tool_name_accepts_exactly_max_len() {
+        let s: String = std::iter::repeat_n('a', MAX_TOOL_NAME_LEN).collect();
+        assert_eq!(s.len(), MAX_TOOL_NAME_LEN);
+        assert!(validate_tool_name(&s).is_ok());
+    }
+
+    // ── tool-name: negative cases ───────────────────────────────────────────
+
+    #[test]
+    fn tool_name_rejects_empty() {
+        assert_eq!(validate_tool_name(""), Err(NamingError::Empty));
+    }
+
+    #[test]
+    fn tool_name_rejects_over_max_len() {
+        let s: String = std::iter::repeat_n('a', MAX_TOOL_NAME_LEN + 1).collect();
+        assert!(matches!(
+            validate_tool_name(&s),
+            Err(NamingError::TooLong { .. })
+        ));
+    }
+
+    #[test]
+    fn tool_name_rejects_leading_hyphen_dot_underscore() {
+        for bad in ["-tool", ".tool", "_tool"] {
+            assert!(matches!(
+                validate_tool_name(bad),
+                Err(NamingError::BadLeadingChar { .. })
+            ));
+        }
+    }
+
+    #[test]
+    fn tool_name_rejects_forbidden_chars() {
+        for bad in [
+            "tool/call",
+            "ns:tool",
+            "tool name",
+            "tool,other",
+            "tool@host",
+            "tool+v2",
+            "tool?",
+            "tool!",
+            "tool#1",
+        ] {
+            assert!(
+                matches!(validate_tool_name(bad), Err(NamingError::BadChar { .. })),
+                "should reject {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn tool_name_rejects_non_ascii() {
+        assert!(matches!(
+            validate_tool_name("tôol"),
+            Err(NamingError::NonAscii { .. })
+        ));
+        assert!(matches!(
+            validate_tool_name("工具"),
+            Err(NamingError::NonAscii { .. })
+        ));
+    }
+
+    // ── action-id: positive cases ───────────────────────────────────────────
+
+    #[test]
+    fn action_id_accepts_single_segment() {
+        assert!(validate_action_id("scene").is_ok());
+        assert!(validate_action_id("create_sphere").is_ok());
+    }
+
+    #[test]
+    fn action_id_accepts_dotted_segments() {
+        assert!(validate_action_id("scene.get_info").is_ok());
+        assert!(validate_action_id("maya.geometry.create_sphere").is_ok());
+    }
+
+    #[test]
+    fn action_id_accepts_digits_after_leader() {
+        assert!(validate_action_id("v2.create").is_ok());
+        assert!(validate_action_id("scene.frame_3d").is_ok());
+    }
+
+    // ── action-id: negative cases ───────────────────────────────────────────
+
+    #[test]
+    fn action_id_rejects_empty() {
+        assert_eq!(validate_action_id(""), Err(NamingError::Empty));
+    }
+
+    #[test]
+    fn action_id_rejects_uppercase() {
+        assert!(matches!(
+            validate_action_id("Scene.get"),
+            Err(NamingError::BadLeadingChar { .. })
+        ));
+        assert!(matches!(
+            validate_action_id("scene.Get"),
+            Err(NamingError::BadLeadingChar { .. })
+        ));
+        assert!(matches!(
+            validate_action_id("scene.getInfo"),
+            Err(NamingError::BadChar { .. })
+        ));
+    }
+
+    #[test]
+    fn action_id_rejects_leading_digit() {
+        assert!(matches!(
+            validate_action_id("1scene.get"),
+            Err(NamingError::BadLeadingChar { .. })
+        ));
+        assert!(matches!(
+            validate_action_id("scene.1get"),
+            Err(NamingError::BadLeadingChar { .. })
+        ));
+    }
+
+    #[test]
+    fn action_id_rejects_empty_segments() {
+        for bad in [".scene", "scene.", "scene..get"] {
+            assert!(
+                matches!(validate_action_id(bad), Err(NamingError::EmptySegment)),
+                "should reject {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn action_id_rejects_hyphen_and_other_punct() {
+        for bad in ["scene-get", "scene/get", "scene get", "scene@host"] {
+            assert!(
+                matches!(validate_action_id(bad), Err(NamingError::BadChar { .. })),
+                "should reject {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn action_id_rejects_non_ascii() {
+        assert!(matches!(
+            validate_action_id("scene.fü"),
+            Err(NamingError::NonAscii { .. })
+        ));
+    }
+
+    // ── regex constants stay aligned with validators ────────────────────────
+
+    #[test]
+    fn tool_name_regex_constant_is_anchored() {
+        // Smoke-check: the constant is anchored so downstream tooling can
+        // drop it straight into a regex engine without wrapping. The
+        // handwritten validator above IS the authoritative check; this
+        // regex is only surfaced for docs/schema generators.
+        assert!(TOOL_NAME_RE.starts_with('^'));
+        assert!(TOOL_NAME_RE.ends_with('$'));
+    }
+
+    #[test]
+    fn action_id_regex_constant_is_anchored() {
+        assert!(ACTION_ID_RE.starts_with('^'));
+        assert!(ACTION_ID_RE.ends_with('$'));
+    }
+}

--- a/crates/dcc-mcp-naming/src/python.rs
+++ b/crates/dcc-mcp-naming/src/python.rs
@@ -1,0 +1,53 @@
+//! PyO3 bindings for the naming validators.
+//!
+//! Exposes:
+//!
+//! * `validate_tool_name(name: str) -> None`
+//! * `validate_action_id(name: str) -> None`
+//! * `TOOL_NAME_RE: str`
+//! * `ACTION_ID_RE: str`
+//! * `MAX_TOOL_NAME_LEN: int`
+//!
+//! The two `validate_*` functions raise `ValueError` with a human-readable
+//! message on failure; on success they return `None`. This matches the
+//! convention used by the other validators in `dcc_mcp_core` (e.g. the
+//! SandboxPolicy input validator).
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+use crate::{ACTION_ID_RE, MAX_TOOL_NAME_LEN, NamingError, TOOL_NAME_RE};
+
+fn to_py_err(e: NamingError) -> PyErr {
+    PyValueError::new_err(e.to_string())
+}
+
+/// Validate an MCP wire-visible tool name.
+///
+/// Raises ``ValueError`` on any violation; returns ``None`` on success.
+#[pyfunction]
+#[pyo3(name = "validate_tool_name", text_signature = "(name, /)")]
+pub fn py_validate_tool_name(name: &str) -> PyResult<()> {
+    crate::validate_tool_name(name).map_err(to_py_err)
+}
+
+/// Validate an internal action id.
+///
+/// Raises ``ValueError`` on any violation; returns ``None`` on success.
+#[pyfunction]
+#[pyo3(name = "validate_action_id", text_signature = "(name, /)")]
+pub fn py_validate_action_id(name: &str) -> PyResult<()> {
+    crate::validate_action_id(name).map_err(to_py_err)
+}
+
+/// Register naming symbols on a Python module.
+///
+/// Called from the top-level `_core` PyO3 module entrypoint.
+pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(py_validate_tool_name, m)?)?;
+    m.add_function(wrap_pyfunction!(py_validate_action_id, m)?)?;
+    m.add("TOOL_NAME_RE", TOOL_NAME_RE)?;
+    m.add("ACTION_ID_RE", ACTION_ID_RE)?;
+    m.add("MAX_TOOL_NAME_LEN", MAX_TOOL_NAME_LEN)?;
+    Ok(())
+}

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -51,6 +51,7 @@ export default defineConfig({
                 { text: 'Actions & Registry', link: '/guide/actions' },
                 { text: 'Event System', link: '/guide/events' },
                 { text: 'MCP Protocols', link: '/guide/protocols' },
+                { text: 'Naming Actions & Tools', link: '/guide/naming' },
                 { text: 'Transport Layer', link: '/guide/transport' },
               ]
             },

--- a/docs/guide/naming.md
+++ b/docs/guide/naming.md
@@ -1,0 +1,152 @@
+# Naming your actions and tools
+
+> **Status**: mandatory. Every DCC-MCP crate, Python wheel and skill author
+> must pick names that pass the two validators shipped in
+> [`dcc_mcp_core::naming`](https://github.com/loonghao/dcc-mcp-core/tree/main/crates/dcc-mcp-naming).
+> Related spec: [MCP `draft/server/tools#tool-names`](https://modelcontextprotocol.io/specification/draft/server/tools#tool-names),
+> [SEP-986](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/986).
+
+There are **two** naming rules in the ecosystem. Know which one applies to
+the string you are writing before you reach for a keyboard.
+
+| Concept | Purpose | Who sees it | Validator | Regex |
+|---------|---------|-------------|-----------|-------|
+| **Tool name** | MCP wire-visible string published in `tools/list` | The LLM / the MCP client | `validate_tool_name` | `^[A-Za-z0-9](?:[A-Za-z0-9_.\-]{0,47})$` |
+| **Action id** | Internal, stable id used by hosts to route `tools/call` | Rust/Python code, hand-wired registrations | `validate_action_id` | `^[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)*$` |
+
+## Why two rules?
+
+The MCP spec is permissive on tool names: mixed case, hyphens, dots, up to
+128 characters. That's fine for the wire, but it makes a poor internal
+identifier — hyphens collide with Python attribute names, mixed case
+encourages typo-driven bugs, and 128 characters is too long to read.
+
+`dcc-mcp-core` therefore keeps two layers:
+
+1. **Tool names** follow the spec, but are capped at 48 characters to leave
+   room for gateway prefixes (`{id8}/`, `{skill}.`).
+2. **Action ids** are stricter: dotted, lowercase, snake-case segments. You
+   write these by hand in your host code; the library turns them into tool
+   names when publishing.
+
+## Using the validators
+
+### Rust
+
+```rust
+use dcc_mcp_naming::{validate_tool_name, validate_action_id};
+
+validate_tool_name("geometry.create_sphere")?;
+validate_action_id("scene.get_info")?;
+```
+
+Both functions are `O(n)`, allocation-free, and return a structured
+[`NamingError`](https://docs.rs/dcc-mcp-naming) pointing at the first
+violation.
+
+### Python
+
+```python
+from dcc_mcp_core import (
+    TOOL_NAME_RE,
+    ACTION_ID_RE,
+    MAX_TOOL_NAME_LEN,
+    validate_tool_name,
+    validate_action_id,
+)
+
+validate_tool_name("hello-world.greet")        # ok
+validate_action_id("scene.get_info")           # ok
+
+validate_tool_name("bad/name")                 # raises ValueError
+validate_action_id("Scene.Get")                # raises ValueError (uppercase)
+```
+
+The regex constants (`TOOL_NAME_RE`, `ACTION_ID_RE`) are exported for
+downstream tooling — schema generators, lint rules, docs — that need to
+reference the pattern without calling into Rust. **The validator remains the
+authoritative check**: prefer `validate_tool_name()` over re-implementing
+the regex in your own code.
+
+## Cheatsheet
+
+### Valid tool names
+
+```
+create_sphere
+geometry.create_sphere
+scene.object.transform
+hello-world.greet
+CamelCaseTool          # MCP allows mixed case
+0              # single ASCII alphanumeric is legal
+```
+
+### Invalid tool names
+
+| Input | Reason |
+|-------|--------|
+| `""` | empty |
+| `_leading` | leading `_` is not ASCII alphanumeric |
+| `.tool` / `-tool` | leading `.` / `-` |
+| `tool/call` | `/` is reserved for gateway prefixes |
+| `tool name` / `tool,other` / `tool@host` / `tool+v2` | punctuation outside `[_.-]` |
+| `a * 49` | exceeds `MAX_TOOL_NAME_LEN = 48` |
+| `工具` / `tôol` | non-ASCII |
+
+### Valid action ids
+
+```
+scene
+create_sphere
+scene.get_info
+maya.geometry.create_sphere
+v2.create
+```
+
+### Invalid action ids
+
+| Input | Reason |
+|-------|--------|
+| `""` | empty |
+| `Scene.get` / `scene.Get` | uppercase |
+| `1scene.get` | leading digit |
+| `scene..get` / `.scene` / `scene.` | empty `.`-separated segment |
+| `scene-get` | `-` is not allowed in action ids (use `_`) |
+| `scene/get` | `/` is not allowed |
+
+## Caps and rationale
+
+* **`MAX_TOOL_NAME_LEN = 48`** — MCP spec allows 128, we cap at 48 so that
+  a gateway can safely prepend `{id8}/` (9 chars) or a skill can prepend
+  `{skill}.` without blowing past the spec ceiling.
+* **Stricter action-id grammar** — keeps hand-typed identifiers consistent
+  with Python attribute conventions (lowercase, snake_case, dot-separated
+  namespaces) and eliminates ambiguity when action ids are serialised in
+  audit logs, telemetry and IPC payloads.
+
+## When to call the validators
+
+* **Host authors** — call `validate_action_id` **at registration time**,
+  not at dispatch time. A registry that accepts bad ids is a bug magnet.
+* **Server authors** — call `validate_tool_name` before publishing a tool
+  in `tools/list`, including skill-derived tools where the tool name is
+  composed from the skill slug + tool slug.
+* **Skill authors** — no explicit call needed; the library validates your
+  skill's tool names when loading the skill. Invalid names cause the skill
+  to fail loading with a human-readable error.
+
+## Migration from bespoke rules
+
+Earlier code paths occasionally re-invented these rules (substring checks,
+ad-hoc regexes). When you touch such code, replace it with the validator:
+
+```diff
+- if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+-     return Err("bad tool name");
+- }
++ dcc_mcp_naming::validate_tool_name(name)?;
+```
+
+The goal is **one rule, one implementation** — no `name.len() > 100` in
+random files, no "I think it should allow hyphens" disagreement between
+crates.

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -16,6 +16,9 @@ from __future__ import annotations
 
 # Import local modules
 from dcc_mcp_core import _core
+
+# Naming validators (SEP-986)
+from dcc_mcp_core._core import ACTION_ID_RE
 from dcc_mcp_core._core import APP_AUTHOR
 from dcc_mcp_core._core import APP_NAME
 from dcc_mcp_core._core import DEFAULT_DCC
@@ -24,9 +27,11 @@ from dcc_mcp_core._core import DEFAULT_MIME_TYPE
 from dcc_mcp_core._core import DEFAULT_VERSION
 from dcc_mcp_core._core import ENV_LOG_LEVEL
 from dcc_mcp_core._core import ENV_SKILL_PATHS
+from dcc_mcp_core._core import MAX_TOOL_NAME_LEN
 from dcc_mcp_core._core import SKILL_METADATA_DIR
 from dcc_mcp_core._core import SKILL_METADATA_FILE
 from dcc_mcp_core._core import SKILL_SCRIPTS_DIR
+from dcc_mcp_core._core import TOOL_NAME_RE
 
 # Sandbox
 from dcc_mcp_core._core import AuditEntry
@@ -166,8 +171,10 @@ from dcc_mcp_core._core import success_result
 from dcc_mcp_core._core import units_to_mpu
 from dcc_mcp_core._core import unwrap_parameters
 from dcc_mcp_core._core import unwrap_value
+from dcc_mcp_core._core import validate_action_id
 from dcc_mcp_core._core import validate_action_result
 from dcc_mcp_core._core import validate_dependencies
+from dcc_mcp_core._core import validate_tool_name
 from dcc_mcp_core._core import wrap_value
 
 # Adapters (pure-Python, non-DccServerBase)
@@ -216,6 +223,7 @@ except AttributeError:
     __author__ = ""
 
 __all__ = [
+    "ACTION_ID_RE",
     "APP_AUTHOR",
     "APP_NAME",
     "CAPABILITY_KEYS",
@@ -225,9 +233,11 @@ __all__ = [
     "DEFAULT_VERSION",
     "ENV_LOG_LEVEL",
     "ENV_SKILL_PATHS",
+    "MAX_TOOL_NAME_LEN",
     "SKILL_METADATA_DIR",
     "SKILL_METADATA_FILE",
     "SKILL_SCRIPTS_DIR",
+    "TOOL_NAME_RE",
     "WEBVIEW_DEFAULT_CAPABILITIES",
     "AuditEntry",
     "AuditLog",
@@ -378,7 +388,9 @@ __all__ = [
     "units_to_mpu",
     "unwrap_parameters",
     "unwrap_value",
+    "validate_action_id",
     "validate_action_result",
     "validate_dependencies",
+    "validate_tool_name",
     "wrap_value",
 ]

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -27,6 +27,43 @@ SKILL_METADATA_FILE: str
 SKILL_SCRIPTS_DIR: str
 SKILL_METADATA_DIR: str
 
+# Naming (SEP-986)
+TOOL_NAME_RE: str
+"""Regex pattern (anchored) that every MCP wire-visible tool name must match."""
+ACTION_ID_RE: str
+"""Regex pattern (anchored) that every internal action id must match."""
+MAX_TOOL_NAME_LEN: int
+"""Maximum tool-name length enforced by :func:`validate_tool_name` (48 chars).
+
+The MCP spec allows up to 128; the library caps lower to leave room for
+gateway prefixes like ``{id8}/`` or ``{skill}.``.
+"""
+
+def validate_tool_name(name: str) -> None:
+    """Validate an MCP wire-visible tool name (SEP-986).
+
+    Args:
+        name: Candidate tool name.
+
+    Raises:
+        ValueError: If ``name`` is empty, exceeds :data:`MAX_TOOL_NAME_LEN`,
+            contains a non-ASCII or disallowed character, or does not start
+            with an ASCII alphanumeric.
+
+    """
+
+def validate_action_id(name: str) -> None:
+    """Validate an internal action id (dotted lowercase identifier chain).
+
+    Args:
+        name: Candidate action id, e.g. ``"scene.get_info"``.
+
+    Raises:
+        ValueError: If ``name`` is empty, contains uppercase, a leading digit,
+            an empty ``.``-separated segment, or any disallowed character.
+
+    """
+
 # ── Models ──
 
 class ToolResult:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub use dcc_mcp_actions as actions;
 pub use dcc_mcp_capture as capture;
 pub use dcc_mcp_http as http;
 pub use dcc_mcp_models as models;
+pub use dcc_mcp_naming as naming;
 pub use dcc_mcp_process as process;
 pub use dcc_mcp_protocols as protocols;
 pub use dcc_mcp_sandbox as sandbox;
@@ -68,6 +69,7 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     register_usd(m)?;
     register_utils(m)?;
     register_http(m)?;
+    register_naming(m)?;
     register_constants(m)?;
 
     // ── Metadata ──
@@ -260,6 +262,11 @@ fn register_usd(m: &Bound<'_, PyModule>) -> PyResult<()> {
 #[cfg(feature = "python-bindings")]
 fn register_http(m: &Bound<'_, PyModule>) -> PyResult<()> {
     dcc_mcp_http::python::register_classes(m)
+}
+
+#[cfg(feature = "python-bindings")]
+fn register_naming(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    dcc_mcp_naming::python::register(m)
 }
 
 #[cfg(feature = "python-bindings")]

--- a/tests/test_naming_validators.py
+++ b/tests/test_naming_validators.py
@@ -1,0 +1,197 @@
+"""Tests for the SEP-986 naming validators exposed from ``dcc_mcp_core``.
+
+The authoritative Rust unit tests live in ``crates/dcc-mcp-naming/src/lib.rs``.
+These Python-side tests guard the PyO3 binding layer: constants are reachable,
+validators raise ``ValueError`` on bad input, and accept the spec's canonical
+examples. See issue #260 for the full contract.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import ClassVar
+
+import pytest
+
+from dcc_mcp_core import ACTION_ID_RE
+from dcc_mcp_core import MAX_TOOL_NAME_LEN
+from dcc_mcp_core import TOOL_NAME_RE
+from dcc_mcp_core import validate_action_id
+from dcc_mcp_core import validate_tool_name
+
+# ── Constants ───────────────────────────────────────────────────────────────
+
+
+class TestNamingConstants:
+    def test_tool_name_regex_is_anchored(self) -> None:
+        assert TOOL_NAME_RE.startswith("^")
+        assert TOOL_NAME_RE.endswith("$")
+
+    def test_action_id_regex_is_anchored(self) -> None:
+        assert ACTION_ID_RE.startswith("^")
+        assert ACTION_ID_RE.endswith("$")
+
+    def test_max_tool_name_len_is_48(self) -> None:
+        # Capped below MCP spec (128) to leave room for gateway prefixes.
+        assert MAX_TOOL_NAME_LEN == 48
+
+    def test_regexes_compile(self) -> None:
+        re.compile(TOOL_NAME_RE)
+        re.compile(ACTION_ID_RE)
+
+
+# ── validate_tool_name ──────────────────────────────────────────────────────
+
+
+class TestValidateToolName:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "create_sphere",
+            "geometry.create_sphere",
+            "scene.object.transform",
+            "hello-world.greet",
+            "CamelCaseTool",
+            "a",
+            "Z",
+            "0",
+            "a" * MAX_TOOL_NAME_LEN,
+        ],
+    )
+    def test_accepts_valid_names(self, name: str) -> None:
+        validate_tool_name(name)  # does not raise
+
+    def test_rejects_empty(self) -> None:
+        with pytest.raises(ValueError):
+            validate_tool_name("")
+
+    def test_rejects_over_max_length(self) -> None:
+        with pytest.raises(ValueError):
+            validate_tool_name("a" * (MAX_TOOL_NAME_LEN + 1))
+
+    @pytest.mark.parametrize("name", ["-tool", ".tool", "_tool"])
+    def test_rejects_bad_leading_char(self, name: str) -> None:
+        with pytest.raises(ValueError):
+            validate_tool_name(name)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "tool/call",
+            "ns:tool",
+            "tool name",
+            "tool,other",
+            "tool@host",
+            "tool+v2",
+            "tool?",
+            "tool!",
+            "tool#1",
+        ],
+    )
+    def test_rejects_forbidden_chars(self, name: str) -> None:
+        with pytest.raises(ValueError):
+            validate_tool_name(name)
+
+    @pytest.mark.parametrize("name", ["tôol", "工具", "tool\u00e9"])
+    def test_rejects_non_ascii(self, name: str) -> None:
+        with pytest.raises(ValueError):
+            validate_tool_name(name)
+
+    def test_error_message_mentions_char_for_bad_char(self) -> None:
+        with pytest.raises(ValueError, match=r"'/'"):
+            validate_tool_name("bad/name")
+
+
+# ── validate_action_id ──────────────────────────────────────────────────────
+
+
+class TestValidateActionId:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "scene",
+            "create_sphere",
+            "scene.get_info",
+            "maya.geometry.create_sphere",
+            "v2.create",
+            "scene.frame_3d",
+        ],
+    )
+    def test_accepts_valid_ids(self, name: str) -> None:
+        validate_action_id(name)
+
+    def test_rejects_empty(self) -> None:
+        with pytest.raises(ValueError):
+            validate_action_id("")
+
+    @pytest.mark.parametrize(
+        "name",
+        ["Scene.get", "scene.Get", "scene.getInfo"],
+    )
+    def test_rejects_uppercase(self, name: str) -> None:
+        with pytest.raises(ValueError):
+            validate_action_id(name)
+
+    @pytest.mark.parametrize("name", ["1scene.get", "scene.1get"])
+    def test_rejects_leading_digit(self, name: str) -> None:
+        with pytest.raises(ValueError):
+            validate_action_id(name)
+
+    @pytest.mark.parametrize("name", [".scene", "scene.", "scene..get"])
+    def test_rejects_empty_segment(self, name: str) -> None:
+        with pytest.raises(ValueError):
+            validate_action_id(name)
+
+    @pytest.mark.parametrize(
+        "name",
+        ["scene-get", "scene/get", "scene get", "scene@host"],
+    )
+    def test_rejects_punct(self, name: str) -> None:
+        with pytest.raises(ValueError):
+            validate_action_id(name)
+
+    def test_rejects_non_ascii(self) -> None:
+        with pytest.raises(ValueError):
+            validate_action_id("scene.fü")
+
+
+# ── Cross-checks ────────────────────────────────────────────────────────────
+
+
+class TestRegexMatchesValidator:
+    """The exported regex pattern must agree with the validator on a
+    representative sample. We don't chase full equivalence — the validator is
+    the authoritative source of truth — but the regex is published as a
+    contract for downstream tooling (docs, schema generators), so it must at
+    least accept every name the validator accepts and reject everything the
+    validator rejects in the sampled set.
+    """
+
+    SAMPLES_OK: ClassVar[list[str]] = [
+        "geometry.create_sphere",
+        "hello-world.greet",
+        "CamelCase",
+        "a" * MAX_TOOL_NAME_LEN,
+    ]
+    SAMPLES_BAD: ClassVar[list[str]] = [
+        "",
+        "_x",
+        "-x",
+        ".x",
+        "bad/name",
+        "a" * (MAX_TOOL_NAME_LEN + 1),
+        "tôol",
+    ]
+
+    def test_tool_name_regex_accepts_valid_samples(self) -> None:
+        rx = re.compile(TOOL_NAME_RE)
+        for name in self.SAMPLES_OK:
+            assert rx.match(name) is not None, f"regex rejected valid sample {name!r}"
+
+    def test_tool_name_regex_rejects_invalid_samples(self) -> None:
+        rx = re.compile(TOOL_NAME_RE)
+        for name in self.SAMPLES_BAD:
+            # Non-ASCII fails the `[A-Za-z0-9]` class — Python regex on str
+            # treats `\u00f4` as a literal non-matching char. Over-length
+            # matches fail the `{0,47}` quantifier. Empty matches nothing.
+            assert rx.match(name) is None, f"regex accepted invalid sample {name!r}"


### PR DESCRIPTION
## Summary

Closes #261. Stacked on #262 (ships the `dcc_mcp_naming` validators).

The aggregating gateway was emitting tool names of the form `{id8}/{tool}` (PR #258). **`/` is not legal in MCP tool names** per the merged spec ([draft/server/tools#tool-names](https://modelcontextprotocol.io/specification/draft/server/tools#tool-names), [modelcontextprotocol#1603](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1603)) — grammar is `[A-Za-z0-9_.-]{1,128}`. Anthropic Claude, OpenAI Function Calling, Cursor and every SEP-986-compliant SDK will reject these names at runtime.

## Changes

- `INSTANCE_SEP` flips from `"/"` to `"."`.
- `encode_tool_name` now emits `{id8}.{tool}` and hits a `debug_assert!` against `dcc_mcp_naming::validate_tool_name` — in debug builds the gateway is architecturally incapable of emitting a non-compliant name.
- `decode_tool_name` accepts three encodings with targeted `tracing::warn!` on the legacy forms:
  - `{id8}.{tool}` — preferred.
  - `{id8}/{tool}` — deprecated (pre-#261).
  - `{id8}__{tool}` — legacy (pre-#258).
- `decode_skill_tool_name` now rejects gateway-encoded names so the routing layer doesn't mis-classify them as `skill.tool` pairs.
- New `assert_gateway_tool_name` helper surfaces the validator for the registration path.

## Acceptance (from #261)

- [x] No tool name emitted by the gateway contains `/`.
- [x] `dcc_mcp_naming::validate_tool_name` wired into the gateway composition step.
- [x] Legacy decoder list: `{id8}__{tool}`, `{id8}/{tool}`.
- [x] Spec-compliance test scans every emitted form against `TOOL_NAME_RE` via the validator.

## Test plan

- [x] `cargo test -p dcc-mcp-http --lib gateway::namespace` — 19 tests green
- [x] `cargo test -p dcc-mcp-http` — 123 unit + 4 integration green, no regressions
- [x] `cargo fmt -p dcc-mcp-http --check` — clean
- [x] `cargo clippy` — clippy surfaces one pre-existing `module-inception` lint in `tests.rs` that predates this PR and is unrelated
- [ ] CI matrix

## Merge order

Please merge **#262 first** — this PR depends on the `dcc-mcp-naming` crate shipped there. After #262 lands, this PR will rebase cleanly onto `main`.
