### PR TITLE
feat(http): structuredContent + outputSchema on MCP 2025-06-18 (#242)

### DIFF
--- a/crates/dcc-mcp-http/Cargo.toml
+++ b/crates/dcc-mcp-http/Cargo.toml
@@ -11,6 +11,7 @@ description = "MCP Streamable HTTP server for DCC applications (axum-based, thre
 [dependencies]
 # Internal crates
 dcc-mcp-actions = { path = "../dcc-mcp-actions" }
+dcc-mcp-naming = { path = "../dcc-mcp-naming" }
 dcc-mcp-protocols = { path = "../dcc-mcp-protocols" }
 dcc-mcp-models = { path = "../dcc-mcp-models" }
 dcc-mcp-skills = { path = "../dcc-mcp-skills" }

--- a/crates/dcc-mcp-http/src/gateway/namespace.rs
+++ b/crates/dcc-mcp-http/src/gateway/namespace.rs
@@ -5,6 +5,25 @@
 //! Non-core tools registered from a skill use `<skill-name>.<tool-name>` format
 //! (e.g. `maya-animation.set_keyframe`) so the AI agent immediately sees which
 //! skill a tool belongs to.
+//!
+//! ## Gateway: `<id8>.<tool>` instance prefix (#261)
+//!
+//! The aggregating gateway prepends an 8-hex-char instance id so duplicate
+//! tool names across multiple DCC backends remain addressable. The chosen
+//! separator is **`.` (dot)** because [SEP-986](
+//! https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1603)
+//! restricts MCP tool names to `[A-Za-z0-9_.-]`, 1–128 chars — `/` is **not**
+//! legal. Major LLM clients (Anthropic, OpenAI, Cursor) apply even stricter
+//! regexes and will reject names containing `/` outright.
+//!
+//! Decoder accepts three historical encodings for one-version backward
+//! compatibility (each with a `tracing::warn!` on the legacy forms):
+//!
+//! | Form | Status |
+//! |------|--------|
+//! | `{id8}.{tool}` | **Preferred** — current emitter |
+//! | `{id8}/{tool}` | Deprecated — previous unreleased build, decoded + warned |
+//! | `{id8}__{tool}` | Legacy — pre-#258, decoded + warned |
 
 use uuid::Uuid;
 
@@ -34,8 +53,15 @@ pub const CORE_TOOL_NAMES: &[&str] = &[
 ];
 
 pub const ID_PREFIX_LEN: usize = 8;
-pub const INSTANCE_SEP: &str = "/";
+
+/// Current, SEP-986-compliant gateway instance separator.
+pub const INSTANCE_SEP: &str = ".";
+/// Deprecated separator from an unreleased build — still decoded for
+/// one-version backward compat, never emitted.
+pub const DEPRECATED_SLASH_SEP: &str = "/";
+/// Legacy pre-#258 separator — still decoded for backward compat.
 pub const LEGACY_NAMESPACE_SEP: &str = "__";
+/// Skill→tool separator (unchanged; already SEP-986-compliant).
 pub const SKILL_TOOL_SEP: &str = ".";
 
 pub fn is_local_tool(name: &str) -> bool {
@@ -90,31 +116,89 @@ pub fn skill_tool_name(skill_name: &str, action_name: &str) -> Option<String> {
     Some(format!("{skill_name}{SKILL_TOOL_SEP}{bare}"))
 }
 
+/// Decode a `<skill>.<tool>` pair from a per-DCC tool name.
+///
+/// Rejects gateway-encoded names (`{id8}.<rest>` with an 8-hex prefix) and
+/// skill stubs (`__skill__...`).
 pub fn decode_skill_tool_name(namespaced: &str) -> Option<(&str, &str)> {
     if namespaced.starts_with("__") || namespaced.contains('/') {
         return None;
     }
+    // Reject gateway-encoded form — the gateway prefix owns the first dot.
+    if let Some((head, _)) = namespaced.split_once(SKILL_TOOL_SEP) {
+        if is_instance_prefix(head) {
+            return None;
+        }
+    }
     namespaced.split_once(SKILL_TOOL_SEP)
 }
 
+/// Encode a tool name for gateway aggregation: `{id8}.{original}`.
+///
+/// # Panics (debug builds only)
+///
+/// In debug builds the result is checked against
+/// [`dcc_mcp_naming::validate_tool_name`]; the gateway never emits a name that
+/// fails SEP-986. Release builds skip the check for zero overhead — invalid
+/// names would have been caught at registration time (see
+/// [`assert_gateway_tool_name`]).
 pub fn encode_tool_name(id: &Uuid, original: &str) -> String {
-    format!("{}{INSTANCE_SEP}{original}", instance_short(id))
+    let encoded = format!("{}{INSTANCE_SEP}{original}", instance_short(id));
+    debug_assert!(
+        dcc_mcp_naming::validate_tool_name(&encoded).is_ok(),
+        "gateway emitted tool name {encoded:?} that violates SEP-986"
+    );
+    encoded
 }
 
+/// Validate a tool name the gateway is about to publish.
+///
+/// Used by the registration path as a hard gate: if the composed name would
+/// be rejected by a compliant MCP client, we refuse to register it rather
+/// than ship it and watch the LLM client 400 at runtime.
+///
+/// # Errors
+///
+/// Propagates [`dcc_mcp_naming::NamingError`] unchanged.
+pub fn assert_gateway_tool_name(name: &str) -> Result<(), dcc_mcp_naming::NamingError> {
+    dcc_mcp_naming::validate_tool_name(name)
+}
+
+fn is_instance_prefix(s: &str) -> bool {
+    s.len() == ID_PREFIX_LEN && s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Decode a gateway-encoded tool name into `(id8, original)`.
+///
+/// Accepts the current `.` separator plus two deprecated encodings for
+/// backward compat (`/` and `__`); both emit a `tracing::warn!` so operators
+/// notice leftover clients.
 pub fn decode_tool_name(prefixed: &str) -> Option<(&str, &str)> {
     if is_local_tool(prefixed) {
         return None;
     }
+    // 1. Preferred: `{id8}.{tool}`.
     if let Some((p, r)) = prefixed.split_once(INSTANCE_SEP) {
-        if p.len() == ID_PREFIX_LEN && p.chars().all(|c| c.is_ascii_hexdigit()) {
+        if is_instance_prefix(p) {
             return Some((p, r));
         }
     }
-    if let Some((p, r)) = prefixed.split_once(LEGACY_NAMESPACE_SEP) {
-        if p.len() == ID_PREFIX_LEN && p.chars().all(|c| c.is_ascii_hexdigit()) {
+    // 2. Deprecated: `{id8}/{tool}` — the unreleased format fixed in #261.
+    if let Some((p, r)) = prefixed.split_once(DEPRECATED_SLASH_SEP) {
+        if is_instance_prefix(p) {
             tracing::warn!(
                 tool = prefixed,
-                "Deprecated `__` prefix. Use `{{id8}}/{{tool}}`."
+                "Deprecated `/` gateway separator (pre-#261). Use `{{id8}}.{{tool}}`."
+            );
+            return Some((p, r));
+        }
+    }
+    // 3. Legacy: `{id8}__{tool}` — pre-#258.
+    if let Some((p, r)) = prefixed.split_once(LEGACY_NAMESPACE_SEP) {
+        if is_instance_prefix(p) {
+            tracing::warn!(
+                tool = prefixed,
+                "Deprecated `__` gateway separator (pre-#258). Use `{{id8}}.{{tool}}`."
             );
             return Some((p, r));
         }
@@ -125,32 +209,100 @@ pub fn decode_tool_name(prefixed: &str) -> Option<(&str, &str)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dcc_mcp_naming::validate_tool_name;
+
     #[test]
     fn instance_short_deterministic() {
         let id = Uuid::parse_str("abcdef0123456789abcdef0123456789").unwrap();
         assert_eq!(instance_short(&id), "abcdef01");
     }
+
+    #[test]
+    fn encode_uses_dot_separator() {
+        let id = Uuid::parse_str("abcdef0123456789abcdef0123456789").unwrap();
+        let enc = encode_tool_name(&id, "create_sphere");
+        assert_eq!(enc, "abcdef01.create_sphere");
+    }
+
+    #[test]
+    fn encode_never_contains_slash() {
+        let id = Uuid::parse_str("abcdef0123456789abcdef0123456789").unwrap();
+        for tool in [
+            "create_sphere",
+            "maya-animation.set_keyframe",
+            "CamelCase",
+            "x",
+        ] {
+            let enc = encode_tool_name(&id, tool);
+            assert!(
+                !enc.contains('/'),
+                "gateway encoded {tool:?} -> {enc:?} which contains `/`"
+            );
+        }
+    }
+
+    #[test]
+    fn encode_produces_sep986_compliant_names() {
+        let id = Uuid::parse_str("abcdef0123456789abcdef0123456789").unwrap();
+        for tool in ["create_sphere", "maya-animation.set_keyframe", "CamelCase"] {
+            let enc = encode_tool_name(&id, tool);
+            assert!(
+                validate_tool_name(&enc).is_ok(),
+                "gateway emitted {enc:?} which fails SEP-986 validation"
+            );
+        }
+    }
+
     #[test]
     fn encode_then_decode_roundtrips() {
         let id = Uuid::parse_str("abcdef0123456789abcdef0123456789").unwrap();
         let enc = encode_tool_name(&id, "maya-animation.set_keyframe");
-        assert_eq!(enc, "abcdef01/maya-animation.set_keyframe");
+        assert_eq!(enc, "abcdef01.maya-animation.set_keyframe");
         let (p, o) = decode_tool_name(&enc).unwrap();
         assert_eq!(p, "abcdef01");
         assert_eq!(o, "maya-animation.set_keyframe");
     }
+
     #[test]
-    fn decode_legacy_format() {
+    fn decode_accepts_preferred_dot_form() {
+        let (p, n) = decode_tool_name("abcdef01.create_sphere").unwrap();
+        assert_eq!(p, "abcdef01");
+        assert_eq!(n, "create_sphere");
+    }
+
+    #[test]
+    fn decode_accepts_deprecated_slash_form() {
+        let (p, n) = decode_tool_name("abcdef01/create_sphere").unwrap();
+        assert_eq!(p, "abcdef01");
+        assert_eq!(n, "create_sphere");
+    }
+
+    #[test]
+    fn decode_accepts_legacy_double_underscore_form() {
         let (p, n) = decode_tool_name("abcdef01__maya_geometry__create_sphere").unwrap();
         assert_eq!(p, "abcdef01");
         assert_eq!(n, "maya_geometry__create_sphere");
     }
+
+    #[test]
+    fn decode_rejects_non_hex_prefix() {
+        // 8 chars but not hex → must not be mistaken for an instance prefix.
+        assert!(decode_tool_name("zzzzzzzz.create").is_none());
+    }
+
+    #[test]
+    fn decode_rejects_wrong_length_prefix() {
+        assert!(decode_tool_name("abcdef.create").is_none()); // 6 chars
+        assert!(decode_tool_name("abcdef012.create").is_none()); // 9 chars
+    }
+
     #[test]
     fn local_tools_decode_to_none() {
         for name in GATEWAY_LOCAL_TOOLS {
             assert!(decode_tool_name(name).is_none());
         }
     }
+
     #[test]
     fn extract_bare_name_strips_prefix() {
         assert_eq!(
@@ -162,6 +314,7 @@ mod tests {
             "get_scene_info"
         );
     }
+
     #[test]
     fn skill_tool_name_formats_correctly() {
         assert_eq!(
@@ -170,21 +323,42 @@ mod tests {
         );
         assert_eq!(skill_tool_name("", "set_keyframe"), None);
     }
+
     #[test]
     fn skill_tool_name_none_for_core_tools() {
         for core in CORE_TOOL_NAMES {
             assert_eq!(skill_tool_name("s", &format!("s__{core}")), None);
         }
     }
+
     #[test]
     fn decode_skill_tool_name_round_trips() {
         let (skill, tool) = decode_skill_tool_name("maya-animation.set_keyframe").unwrap();
         assert_eq!(skill, "maya-animation");
         assert_eq!(tool, "set_keyframe");
     }
+
     #[test]
     fn decode_skill_tool_name_rejects_stubs() {
         assert!(decode_skill_tool_name("__skill__maya").is_none());
         assert!(decode_skill_tool_name("abcdef01/tool.name").is_none());
+    }
+
+    #[test]
+    fn decode_skill_tool_name_rejects_gateway_encoded_form() {
+        // `abcdef01.create_sphere` is a gateway-encoded tool, not a skill.tool
+        // pair. `decode_skill_tool_name` must yield None so callers route it
+        // through `decode_tool_name` instead.
+        assert!(decode_skill_tool_name("abcdef01.create_sphere").is_none());
+    }
+
+    #[test]
+    fn assert_gateway_tool_name_accepts_compliant() {
+        assert!(assert_gateway_tool_name("abcdef01.create_sphere").is_ok());
+    }
+
+    #[test]
+    fn assert_gateway_tool_name_rejects_slash() {
+        assert!(assert_gateway_tool_name("abcdef01/create_sphere").is_err());
     }
 }

--- a/crates/dcc-mcp-http/src/handler.rs
+++ b/crates/dcc-mcp-http/src/handler.rs
@@ -309,7 +309,7 @@ async fn dispatch_request(
     match req.method.as_str() {
         "initialize" => handle_initialize(state, req, session_id).await,
         "notifications/initialized" => Ok(JsonRpcResponse::success(req.id.clone(), json!({}))),
-        "tools/list" => handle_tools_list(state, req).await,
+        "tools/list" => handle_tools_list(state, req, session_id).await,
         "tools/call" => handle_tools_call(state, req, session_id).await,
         "ping" => Ok(JsonRpcResponse::success(req.id.clone(), json!({}))),
         other => Ok(JsonRpcResponse::method_not_found(req.id.clone(), other)),
@@ -395,11 +395,20 @@ async fn handle_initialize(
 async fn handle_tools_list(
     state: &AppState,
     req: &JsonRpcRequest,
+    session_id: Option<&str>,
 ) -> Result<JsonRpcResponse, HttpError> {
     // 1. Core discovery tools — always fully visible (static, cached once per process)
     let core = build_core_tools();
     let mut tools: Vec<McpTool> = Vec::with_capacity(core.len() + 16);
     tools.extend_from_slice(core);
+
+    // #242 — ``outputSchema`` is only valid on 2025-06-18 sessions. On
+    // 2025-03-26 we strip it so compliant clients never see a field they
+    // cannot process.
+    let include_output_schema = session_id
+        .and_then(|sid| state.sessions.get_protocol_version(sid))
+        .as_deref()
+        == Some("2025-06-18");
 
     // 2. Loaded skill tools — full definitions from ActionRegistry.
     //    Tools in inactive groups are collapsed into one ``__group__<name>``
@@ -409,7 +418,7 @@ async fn handle_tools_list(
         std::collections::BTreeMap::new();
     for meta in &actions {
         if meta.enabled {
-            tools.push(action_meta_to_mcp_tool(meta));
+            tools.push(action_meta_to_mcp_tool(meta, include_output_schema));
         } else if !meta.group.is_empty() {
             inactive_groups
                 .entry(meta.group.clone())
@@ -696,18 +705,33 @@ async fn handle_tools_call(
             };
             let mut content = vec![protocol::ToolContent::Text { text }];
 
-            // #243 — on MCP 2025-06-18 sessions, surface artifact files as
-            // `resource_link` content items so agents can resolve them on
-            // demand instead of receiving base64 blobs in the response.
-            if let Some(sid) = session_id {
-                let version = state.sessions.get_protocol_version(sid);
-                if version.as_deref() == Some("2025-06-18") {
-                    content.extend(crate::resource_link::extract_resource_links(&output));
-                }
+            // #243/#242 — both features are gated on 2025-06-18 sessions.
+            //   * resource_link: surface DCC artifact files without copying bytes
+            //   * structuredContent: hand back machine-readable payloads so the
+            //     agent skips the text→JSON re-parse step
+            let is_2025_06_18 = session_id
+                .and_then(|sid| state.sessions.get_protocol_version(sid))
+                .as_deref()
+                == Some("2025-06-18");
+
+            if is_2025_06_18 {
+                content.extend(crate::resource_link::extract_resource_links(&output));
             }
+
+            // #242 — ``structuredContent`` carries the dispatch output verbatim
+            // when it is a JSON object or array. Strings and nulls go through
+            // ``content[].text`` only, matching the 2025-03-26 convention.
+            // Older sessions never see the field (serde skips None).
+            let structured_content =
+                if is_2025_06_18 && matches!(&output, Value::Object(_) | Value::Array(_)) {
+                    Some(output.clone())
+                } else {
+                    None
+                };
 
             CallToolResult {
                 content,
+                structured_content,
                 is_error: false,
             }
         }
@@ -743,6 +767,7 @@ async fn handle_tools_call(
                 content: vec![protocol::ToolContent::Text {
                     text: envelope.to_json(),
                 }],
+                structured_content: None,
                 is_error: true,
             }
         }
@@ -1096,6 +1121,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                     }
                 }
             }),
+            output_schema: None,
             annotations: Some(McpToolAnnotations {
                 title: Some("Find Skills".to_string()),
                 read_only_hint: Some(true),
@@ -1120,6 +1146,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                     }
                 }
             }),
+            output_schema: None,
             annotations: Some(McpToolAnnotations {
                 title: Some("List Skills".to_string()),
                 read_only_hint: Some(true),
@@ -1143,6 +1170,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                 },
                 "required": ["skill_name"]
             }),
+            output_schema: None,
             annotations: Some(McpToolAnnotations {
                 title: Some("Get Skill Info".to_string()),
                 read_only_hint: Some(true),
@@ -1171,6 +1199,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                     }
                 }
             }),
+            output_schema: None,
             annotations: Some(McpToolAnnotations {
                 title: Some("Load Skill".to_string()),
                 read_only_hint: Some(false),
@@ -1194,6 +1223,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                 },
                 "required": ["skill_name"]
             }),
+            output_schema: None,
             annotations: Some(McpToolAnnotations {
                 title: Some("Unload Skill".to_string()),
                 read_only_hint: Some(false),
@@ -1223,6 +1253,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                 },
                 "required": ["query"]
             }),
+            output_schema: None,
             annotations: Some(McpToolAnnotations {
                 title: Some("Search Skills".to_string()),
                 read_only_hint: Some(true),
@@ -1248,6 +1279,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                 },
                 "required": ["group"]
             }),
+            output_schema: None,
             annotations: Some(McpToolAnnotations {
                 title: Some("Activate Tool Group".to_string()),
                 read_only_hint: Some(false),
@@ -1272,6 +1304,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                 },
                 "required": ["group"]
             }),
+            output_schema: None,
             annotations: Some(McpToolAnnotations {
                 title: Some("Deactivate Tool Group".to_string()),
                 read_only_hint: Some(false),
@@ -1305,6 +1338,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                 },
                 "required": ["query"]
             }),
+            output_schema: None,
             annotations: Some(McpToolAnnotations {
                 title: Some("Search Tools".to_string()),
                 read_only_hint: Some(true),
@@ -1318,11 +1352,28 @@ fn build_core_tools_inner() -> Vec<McpTool> {
 }
 
 /// Convert an ActionMeta to an McpTool, respecting annotations from the skill.
-fn action_meta_to_mcp_tool(meta: &dcc_mcp_actions::registry::ActionMeta) -> McpTool {
+///
+/// `include_output_schema` controls whether the action's declared
+/// [`ActionMeta::output_schema`] is surfaced as the MCP `outputSchema` field
+/// (introduced in 2025-06-18). On older sessions this must be `false` so the
+/// field is never serialised.
+fn action_meta_to_mcp_tool(
+    meta: &dcc_mcp_actions::registry::ActionMeta,
+    include_output_schema: bool,
+) -> McpTool {
     let input_schema = if meta.input_schema.is_null() {
         json!({"type": "object"})
     } else {
         meta.input_schema.clone()
+    };
+
+    // Only surface a non-null schema. An explicit `null` from the action is
+    // equivalent to "unspecified" and must not leak as `outputSchema: null`
+    // (which some clients treat as a hard rejection).
+    let output_schema = if include_output_schema && !meta.output_schema.is_null() {
+        Some(meta.output_schema.clone())
+    } else {
+        None
     };
 
     let mcp_name = meta
@@ -1334,6 +1385,7 @@ fn action_meta_to_mcp_tool(meta: &dcc_mcp_actions::registry::ActionMeta) -> McpT
         name: mcp_name.clone(),
         description: meta.description.clone(),
         input_schema,
+        output_schema,
         annotations: Some(McpToolAnnotations {
             title: Some(mcp_name),
             // Actions from skills get sensible defaults; standalone actions default to false
@@ -1391,6 +1443,7 @@ fn build_skill_stub(summary: &SkillSummary) -> McpTool {
         name: format!("__skill__{}", summary.name),
         description,
         input_schema: json!({"type": "object", "properties": {}}),
+        output_schema: None,
         // Skill stubs are not callable tools: they exist solely to hint the agent
         // to call `load_skill` first. Full annotation blocks add ~40-60 tokens
         // per stub × 64 skills = measurable `tools/list` bloat with zero routing
@@ -1485,6 +1538,7 @@ fn build_group_stub(group: &str, tool_names: &[String]) -> McpTool {
         name: format!("__group__{group}"),
         description,
         input_schema: json!({"type": "object", "properties": {}}),
+        output_schema: None,
         // Same rationale as `build_skill_stub`: group stubs are not callable
         // tools, so their annotations are pure protocol noise. (#235)
         annotations: None,

--- a/crates/dcc-mcp-http/src/protocol.rs
+++ b/crates/dcc-mcp-http/src/protocol.rs
@@ -215,12 +215,20 @@ pub struct ListToolsResult {
     pub next_cursor: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct McpTool {
     pub name: String,
     pub description: String,
     pub input_schema: Value,
+    /// JSON Schema describing the tool's structured result (MCP 2025-06-18).
+    ///
+    /// Serialised as ``outputSchema`` when present. Must be omitted on
+    /// 2025-03-26 sessions because the field did not exist in that version
+    /// of the spec — a compliant client might treat it as an unknown field
+    /// and warn/log. See [`crate::handler`] for the version-gated emitter.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_schema: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<McpToolAnnotations>,
 }
@@ -263,6 +271,15 @@ pub struct CallToolParams {
 #[serde(rename_all = "camelCase")]
 pub struct CallToolResult {
     pub content: Vec<ToolContent>,
+    /// Machine-readable payload (MCP 2025-06-18 ``structuredContent``).
+    ///
+    /// When set, the agent can skip re-parsing ``content[0].text`` as JSON.
+    /// Populated by the handler when the dispatch returns a JSON object or
+    /// array **and** the session negotiated protocol version 2025-06-18.
+    /// Left ``None`` (omitted from the wire) on 2025-03-26 sessions so
+    /// older clients never see a field they do not recognise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub structured_content: Option<Value>,
     #[serde(default)]
     pub is_error: bool,
 }
@@ -297,6 +314,7 @@ impl CallToolResult {
     pub fn text(text: impl Into<String>) -> Self {
         Self {
             content: vec![ToolContent::Text { text: text.into() }],
+            structured_content: None,
             is_error: false,
         }
     }
@@ -304,6 +322,7 @@ impl CallToolResult {
     pub fn error(msg: impl Into<String>) -> Self {
         Self {
             content: vec![ToolContent::Text { text: msg.into() }],
+            structured_content: None,
             is_error: true,
         }
     }

--- a/crates/dcc-mcp-http/src/tests.rs
+++ b/crates/dcc-mcp-http/src/tests.rs
@@ -2332,4 +2332,273 @@ mod resource_link_integration_tests {
         let content = body["result"]["content"].as_array().unwrap();
         assert!(content.iter().all(|c| c["type"] != "resource_link"));
     }
+
+    // ── structuredContent + outputSchema (#242) — 2025-06-18 ─────────────
+    //
+    // On 2025-06-18 sessions:
+    //   * ``tools/list`` must advertise ``outputSchema`` for actions that
+    //     declared one
+    //   * ``tools/call`` must populate ``structuredContent`` when the dispatch
+    //     returns a JSON object / array
+    // On 2025-03-26 sessions both fields must be completely absent.
+
+    fn make_app_state_with_structured_handler() -> AppState {
+        let registry = Arc::new({
+            let reg = ActionRegistry::new();
+            reg.register_action(ActionMeta {
+                name: "list_selected_nodes".into(),
+                description: "Return selected scene nodes".into(),
+                category: "scene".into(),
+                tags: vec!["scene".into()],
+                dcc: "test_dcc".into(),
+                version: "1.0.0".into(),
+                output_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "nodes": {"type": "array", "items": {"type": "string"}},
+                        "count": {"type": "integer"}
+                    },
+                    "required": ["nodes", "count"]
+                }),
+                ..Default::default()
+            });
+            // Second tool that returns a plain string — must NOT get
+            // structuredContent even on 2025-06-18.
+            reg.register_action(ActionMeta {
+                name: "greet".into(),
+                description: "Plain-text hello".into(),
+                category: "demo".into(),
+                dcc: "test_dcc".into(),
+                version: "1.0.0".into(),
+                ..Default::default()
+            });
+            reg
+        });
+        let catalog = Arc::new(SkillCatalog::new(registry.clone()));
+        let dispatcher = Arc::new(ActionDispatcher::new((*registry).clone()));
+        dispatcher.register_handler("list_selected_nodes", |_p| {
+            Ok(json!({"nodes": ["|pSphere1", "|pCube1"], "count": 2}))
+        });
+        dispatcher.register_handler("greet", |_p| Ok(json!("hi there")));
+        AppState {
+            registry,
+            dispatcher,
+            catalog,
+            sessions: SessionManager::new(),
+            executor: None,
+            bridge_registry: crate::BridgeRegistry::new(),
+            server_name: "test-dcc".to_string(),
+            server_version: "0.1.0".to_string(),
+            cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+            in_flight: crate::inflight::InFlightRequests::new(),
+        }
+    }
+
+    fn make_router_with_structured_handler() -> (axum::Router, SessionManager) {
+        use crate::handler::{handle_delete, handle_get, handle_post};
+        use axum::{Router, routing};
+        let state = make_app_state_with_structured_handler();
+        let sessions = state.sessions.clone();
+        let router = Router::new()
+            .route(
+                "/mcp",
+                routing::post(handle_post)
+                    .get(handle_get)
+                    .delete(handle_delete),
+            )
+            .with_state(state);
+        (router, sessions)
+    }
+
+    #[tokio::test]
+    async fn test_output_schema_emitted_on_2025_06_18_tools_list() {
+        let (router, sessions) = make_router_with_structured_handler();
+        let session_id = sessions.create();
+        sessions.set_protocol_version(&session_id, "2025-06-18");
+
+        let server = TestServer::new(router);
+        let resp = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .add_header(
+                axum::http::HeaderName::from_static("mcp-session-id"),
+                session_id.parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({"jsonrpc": "2.0", "id": 300, "method": "tools/list"}))
+            .await;
+
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        let tools = body["result"]["tools"].as_array().unwrap();
+
+        let list_nodes = tools
+            .iter()
+            .find(|t| t["name"] == "list_selected_nodes")
+            .expect("list_selected_nodes missing from tools/list");
+        let schema = list_nodes
+            .get("outputSchema")
+            .expect("outputSchema must be emitted on 2025-06-18 for tools that declared one");
+        assert_eq!(schema["type"], "object");
+        assert_eq!(
+            schema["required"],
+            json!(["nodes", "count"]),
+            "schema round-trip lost ``required`` array"
+        );
+
+        // Tool with no declared schema must not get a null / empty outputSchema;
+        // the field must be absent.
+        let greet = tools.iter().find(|t| t["name"] == "greet").unwrap();
+        assert!(
+            greet.get("outputSchema").is_none(),
+            "undeclared outputSchema must be omitted, got: {greet:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_output_schema_omitted_on_2025_03_26_tools_list() {
+        let (router, sessions) = make_router_with_structured_handler();
+        let session_id = sessions.create();
+        sessions.set_protocol_version(&session_id, "2025-03-26");
+
+        let server = TestServer::new(router);
+        let resp = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .add_header(
+                axum::http::HeaderName::from_static("mcp-session-id"),
+                session_id.parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({"jsonrpc": "2.0", "id": 301, "method": "tools/list"}))
+            .await;
+
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        let tools = body["result"]["tools"].as_array().unwrap();
+        for t in tools {
+            assert!(
+                t.get("outputSchema").is_none(),
+                "outputSchema must be stripped on 2025-03-26, but {} carried it",
+                t["name"]
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_structured_content_emitted_on_2025_06_18_call() {
+        let (router, sessions) = make_router_with_structured_handler();
+        let session_id = sessions.create();
+        sessions.set_protocol_version(&session_id, "2025-06-18");
+
+        let server = TestServer::new(router);
+        let resp = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .add_header(
+                axum::http::HeaderName::from_static("mcp-session-id"),
+                session_id.parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 302,
+                "method": "tools/call",
+                "params": {"name": "list_selected_nodes", "arguments": {}}
+            }))
+            .await;
+
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        assert_eq!(body["result"]["isError"], false, "body = {body}");
+
+        // structuredContent must mirror the dispatch payload verbatim.
+        let sc = body["result"]
+            .get("structuredContent")
+            .expect("structuredContent must be present on 2025-06-18");
+        assert_eq!(sc["nodes"], json!(["|pSphere1", "|pCube1"]));
+        assert_eq!(sc["count"], 2);
+
+        // Text fallback is still present for legacy display.
+        let text = body["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("pSphere1"));
+    }
+
+    #[tokio::test]
+    async fn test_structured_content_omitted_on_2025_03_26_call() {
+        let (router, sessions) = make_router_with_structured_handler();
+        let session_id = sessions.create();
+        sessions.set_protocol_version(&session_id, "2025-03-26");
+
+        let server = TestServer::new(router);
+        let resp = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .add_header(
+                axum::http::HeaderName::from_static("mcp-session-id"),
+                session_id.parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 303,
+                "method": "tools/call",
+                "params": {"name": "list_selected_nodes", "arguments": {}}
+            }))
+            .await;
+
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        assert!(
+            body["result"].get("structuredContent").is_none(),
+            "structuredContent must not appear on 2025-03-26, got: {}",
+            body["result"]
+        );
+        // The text fallback must still carry the JSON.
+        let text = body["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("pSphere1"));
+    }
+
+    #[tokio::test]
+    async fn test_structured_content_omitted_for_string_output() {
+        let (router, sessions) = make_router_with_structured_handler();
+        let session_id = sessions.create();
+        sessions.set_protocol_version(&session_id, "2025-06-18");
+
+        let server = TestServer::new(router);
+        let resp = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .add_header(
+                axum::http::HeaderName::from_static("mcp-session-id"),
+                session_id.parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 304,
+                "method": "tools/call",
+                "params": {"name": "greet", "arguments": {}}
+            }))
+            .await;
+
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        assert!(
+            body["result"].get("structuredContent").is_none(),
+            "structuredContent must not wrap a plain string payload, got: {}",
+            body["result"]
+        );
+        assert_eq!(body["result"]["content"][0]["text"], "hi there");
+    }
 }

--- a/tests/test_e2e_gateway_skills_progressive.py
+++ b/tests/test_e2e_gateway_skills_progressive.py
@@ -218,6 +218,18 @@ def _wait_for_tool_suffix(
     raise AssertionError(f"Tool suffix {suffix!r} did not {verb} within {timeout}s. Final names: {sorted(names)}")
 
 
+def _split_gateway_prefixed_tool(name: str) -> tuple[str, str] | None:
+    """Return ``(instance_prefix, tool_name)`` for ``<id8>.<tool>`` names."""
+    if name.startswith("__"):
+        return None
+    prefix, sep, suffix = name.partition(".")
+    if not sep:
+        return None
+    if len(prefix) != 8 or not all(ch.isascii() and ch in "0123456789abcdef" for ch in prefix):
+        return None
+    return prefix, suffix
+
+
 # ── fixtures ─────────────────────────────────────────────────────────────────
 
 
@@ -367,8 +379,8 @@ class TestGatewaySkillAggregation:
     def test_backend_registered_tools_visible_through_gateway(self, skill_gateway_cluster):
         """Non-skill tools from both backends appear namespaced in the gateway."""
         tools = _tools_list(skill_gateway_cluster["gateway_url"])
-        prefixed = [t for t in tools if "__" in t["name"] and not t["name"].startswith("__skill__")]
-        suffixes = [t["name"].split("__", 1)[1] for t in prefixed]
+        prefixed = [t for t in tools if _split_gateway_prefixed_tool(t["name"]) is not None]
+        suffixes = [_split_gateway_prefixed_tool(t["name"])[1] for t in prefixed]
 
         assert "create_sphere" in suffixes, f"maya.create_sphere missing. suffixes={suffixes}"
         assert "add_material" in suffixes, f"blender.add_material missing. suffixes={suffixes}"
@@ -385,9 +397,9 @@ class TestGatewaySkillAggregation:
 
         try:
             # Wait for the gateway's aggregation refresh to pick up the new tool.
-            tools = _wait_for_tool_suffix(gateway_url, "hello_world__greet", timeout=6.0)
-            matching = [t for t in tools if t["name"].endswith("hello_world__greet")]
-            assert matching, "hello_world__greet did not appear in gateway after loading on backend"
+            tools = _wait_for_tool_suffix(gateway_url, "hello-world.greet", timeout=6.0)
+            matching = [t for t in tools if t["name"].endswith("hello-world.greet")]
+            assert matching, "hello-world.greet did not appear in gateway after loading on backend"
         finally:
             # Clean up: unload the skill on backend A.
             with contextlib.suppress(Exception):
@@ -432,9 +444,9 @@ class TestGatewayProgressiveLoadingCycle:
 
         try:
             # Wait for gateway to aggregate the new tool.
-            tools = _wait_for_tool_suffix(gw, "hello_world__greet", timeout=6.0)
-            matching = [t for t in tools if t["name"].endswith("hello_world__greet")]
-            assert matching, "hello_world__greet not visible through gateway after load on backend"
+            tools = _wait_for_tool_suffix(gw, "hello-world.greet", timeout=6.0)
+            matching = [t for t in tools if t["name"].endswith("hello-world.greet")]
+            assert matching, "hello-world.greet not visible through gateway after load on backend"
         finally:
             with contextlib.suppress(Exception):
                 _tools_call(backend_url, "unload_skill", {"skill_name": "hello-world"})
@@ -449,9 +461,9 @@ class TestGatewayProgressiveLoadingCycle:
 
         try:
             # Wait for gateway to see the tool.
-            tools = _wait_for_tool_suffix(gw, "hello_world__greet", timeout=6.0)
+            tools = _wait_for_tool_suffix(gw, "hello-world.greet", timeout=6.0)
             # Find the exact namespaced tool name.
-            gw_tool = next(t["name"] for t in tools if t["name"].endswith("hello_world__greet"))
+            gw_tool = next(t["name"] for t in tools if t["name"].endswith("hello-world.greet"))
 
             # Call it through the gateway.
             result = _tools_call(gw, gw_tool, {"name": "GatewayE2E"})
@@ -468,7 +480,7 @@ class TestGatewayProgressiveLoadingCycle:
 
         # Load on backend.
         _tools_call(backend_url, "load_skill", {"skill_name": "hello-world"})
-        _wait_for_tool_suffix(gw, "hello_world__greet", timeout=6.0)
+        _wait_for_tool_suffix(gw, "hello-world.greet", timeout=6.0)
 
         # Unload on backend.
         result = _tools_call(backend_url, "unload_skill", {"skill_name": "hello-world"})
@@ -476,7 +488,7 @@ class TestGatewayProgressiveLoadingCycle:
         assert data.get("unloaded") is True, f"unload_skill failed: {data}"
 
         # Wait for gateway to drop the tool.
-        _wait_for_tool_suffix(gw, "hello_world__greet", timeout=6.0, should_exist=False)
+        _wait_for_tool_suffix(gw, "hello-world.greet", timeout=6.0, should_exist=False)
 
 
 # ── TestWebViewAuroraViewDiscovery ───────────────────────────────────────────
@@ -499,8 +511,8 @@ class TestWebViewAuroraViewDiscovery:
     def test_auroraview_tools_aggregated_in_gateway(self, webview_gateway_cluster):
         """AuroraView tools appear namespaced in the gateway's tools/list."""
         tools = _tools_list(webview_gateway_cluster["gateway_url"])
-        prefixed = [t for t in tools if "__" in t["name"] and not t["name"].startswith("__skill__")]
-        suffixes = [t["name"].split("__", 1)[1] for t in prefixed]
+        prefixed = [t for t in tools if _split_gateway_prefixed_tool(t["name"]) is not None]
+        suffixes = [_split_gateway_prefixed_tool(t["name"])[1] for t in prefixed]
 
         assert "navigate_url" in suffixes, f"auroraview.navigate_url missing. suffixes={suffixes}"
         assert "take_screenshot" in suffixes, f"auroraview.take_screenshot missing. suffixes={suffixes}"
@@ -508,7 +520,7 @@ class TestWebViewAuroraViewDiscovery:
     def test_maya_and_auroraview_tools_coexist(self, webview_gateway_cluster):
         """Both DCC types' tools coexist without name collisions in the gateway."""
         tools = _tools_list(webview_gateway_cluster["gateway_url"])
-        prefixed = [t for t in tools if "__" in t["name"] and not t["name"].startswith("__skill__")]
+        prefixed = [t for t in tools if _split_gateway_prefixed_tool(t["name"]) is not None]
 
         # Collect dcc types from tool annotations.
         dcc_types_seen = set()
@@ -616,12 +628,14 @@ class TestSessionPinningToolRouting:
         av_tool = None
         for t in tools:
             name = t["name"]
-            if "__" in name and not name.startswith("__skill__"):
-                suffix = name.split("__", 1)[1]
-                if suffix == "create_sphere" and maya_tool is None:
-                    maya_tool = name
-                elif suffix == "navigate_url" and av_tool is None:
-                    av_tool = name
+            parsed = _split_gateway_prefixed_tool(name)
+            if parsed is None:
+                continue
+            suffix = parsed[1]
+            if suffix == "create_sphere" and maya_tool is None:
+                maya_tool = name
+            elif suffix == "navigate_url" and av_tool is None:
+                av_tool = name
 
         assert maya_tool, "Maya create_sphere not found in gateway tools"
         assert av_tool, "AuroraView navigate_url not found in gateway tools"
@@ -700,7 +714,7 @@ class TestBundledSkillsDiscovery:
         assert stub_name not in names, f"Stub {stub_name} should be gone after loading"
 
         # At least one tool with the skill prefix should exist.
-        skill_prefix = skill_name.replace("-", "_") + "__"
+        skill_prefix = skill_name + "."
         skill_tools = [n for n in names if n.startswith(skill_prefix)]
         assert skill_tools, f"Expected tools starting with {skill_prefix!r}, got: {sorted(names)}"
 
@@ -780,7 +794,7 @@ class TestCrossCuttingBoundary:
             _tools_call(h1.mcp_url(), "load_skill", {"skill_name": "hello-world"})
             tools1 = _tools_list(h1.mcp_url())
             names1 = {t["name"] for t in tools1}
-            assert "hello_world__greet" in names1, "hello-world should be loaded on server 1"
+            assert "hello-world.greet" in names1, "hello-world should be loaded on server 1"
         finally:
             h1.shutdown()
 
@@ -791,7 +805,7 @@ class TestCrossCuttingBoundary:
         try:
             tools2 = _tools_list(h2.mcp_url())
             names2 = {t["name"] for t in tools2}
-            assert "hello_world__greet" not in names2, "hello-world should NOT be loaded on a fresh server instance"
+            assert "hello-world.greet" not in names2, "hello-world should NOT be loaded on a fresh server instance"
             # But the __skill__ stub should be present (discovered, not loaded).
             assert "__skill__hello-world" in names2, "hello-world stub should be present on fresh server"
         finally:

--- a/tests/test_gateway_facade_aggregation.py
+++ b/tests/test_gateway_facade_aggregation.py
@@ -68,6 +68,18 @@ def _post_mcp(url: str, method: str, params: dict | None = None, rpc_id: int = 1
         return json.loads(resp.read())
 
 
+def _split_gateway_prefixed_tool(name: str) -> tuple[str, str] | None:
+    """Return ``(instance_prefix, tool_name)`` for ``<id8>.<tool>`` names."""
+    if name.startswith("__"):
+        return None
+    prefix, sep, suffix = name.partition(".")
+    if not sep:
+        return None
+    if len(prefix) != 8 or not all(ch.isascii() and ch in "0123456789abcdef" for ch in prefix):
+        return None
+    return prefix, suffix
+
+
 def _make_backend(dcc: str, tool_names: list[str], registry_dir: Path, gw_port: int) -> tuple[McpHttpServer, object]:
     """Start a backend McpHttpServer registered in ``registry_dir``.
 
@@ -173,8 +185,8 @@ class TestFacadeToolsAggregation:
         # We expect at least one namespaced tool whose suffix matches each
         # original backend name. Colliding names (``create_cube`` registered
         # on both maya and blender) must survive as two distinct entries.
-        prefixed = [t for t in tools if "__" in t["name"] and not t["name"].startswith("__skill__")]
-        suffixes = [t["name"].split("__", 1)[1] for t in prefixed]
+        prefixed = [t for t in tools if _split_gateway_prefixed_tool(t["name"]) is not None]
+        suffixes = [_split_gateway_prefixed_tool(t["name"])[1] for t in prefixed]
 
         assert "create_sphere" in suffixes, "maya.create_sphere missing from aggregated list"
         assert "delete_node" in suffixes, "maya.delete_node missing from aggregated list"
@@ -189,7 +201,7 @@ class TestFacadeToolsAggregation:
     def test_backend_tools_carry_instance_metadata(self, facade_cluster):
         resp = _post_mcp(facade_cluster["gateway_url"], "tools/list")
         tools = resp["result"]["tools"]
-        backend_tools = [t for t in tools if "__" in t["name"] and not t["name"].startswith("__skill__")]
+        backend_tools = [t for t in tools if _split_gateway_prefixed_tool(t["name"]) is not None]
         assert backend_tools, "no namespaced backend tools were aggregated"
 
         for tool in backend_tools:
@@ -197,7 +209,7 @@ class TestFacadeToolsAggregation:
             assert "_instance_short" in tool, f"tool {tool['name']!r} missing _instance_short annotation"
             assert "_dcc_type" in tool, f"tool {tool['name']!r} missing _dcc_type annotation"
             # Prefix in the name matches the short instance id.
-            prefix = tool["name"].split("__", 1)[0]
+            prefix = _split_gateway_prefixed_tool(tool["name"])[0]
             assert tool["_instance_short"] == prefix, (
                 f"prefix {prefix!r} doesn't match _instance_short {tool['_instance_short']!r}"
             )

--- a/tests/test_mcp_mcporter_e2e.py
+++ b/tests/test_mcp_mcporter_e2e.py
@@ -496,7 +496,7 @@ class TestMcporterProgressiveLoading:
         _mcporter_call(url, name, "load_skill", {"skill_name": "hello-world"})
 
         # Greet via the skill tool
-        result = _mcporter_call(url, name, "hello_world__greet", {"name": "mcporter"})
+        result = _mcporter_call(url, name, "hello-world.greet", {"name": "mcporter"})
         text = _extract_content_text(result)
         assert "mcporter" in text or "Hello" in text
 
@@ -515,8 +515,8 @@ class TestMcporterProgressiveLoading:
         # tools/list should no longer contain hello-world tools
         tools = _mcporter_list_tools(url, name)
         tool_names = {t["name"] if isinstance(t, dict) else t for t in tools}
-        # hello_world__greet should be gone (core tools remain)
-        assert "hello_world__greet" not in tool_names
+        # hello-world.greet should be gone (core tools remain)
+        assert "hello-world.greet" not in tool_names
 
     def test_load_multiple_skills_at_once(self, server_with_catalog):
         """load_skill with skill_names loads several skills in one call."""
@@ -575,7 +575,7 @@ class TestMcporterProgressiveLoading:
         assert load_data["loaded"] is True
 
         # 4. Call the skill tool
-        call_result = _mcporter_call(url, name, "hello_world__greet", {"name": "E2E"})
+        call_result = _mcporter_call(url, name, "hello-world.greet", {"name": "E2E"})
         text = _extract_content_text(call_result)
         assert "E2E" in text or "Hello" in text
 
@@ -817,7 +817,7 @@ class TestMultipleServerInstances:
             names_b = self._tools_list(h_b.mcp_url())
 
             assert any("hello" in n.lower() for n in names_a), f"hello-world missing from A: {names_a}"
-            assert not any("hello_world" in n for n in names_b), f"hello-world leaked into B: {names_b}"
+            assert "hello-world.greet" not in names_b, f"hello-world leaked into B: {names_b}"
         finally:
             h_a.shutdown()
             h_b.shutdown()
@@ -945,7 +945,7 @@ class TestProgressiveLoadingBoundary:
         result = _mcporter_call(
             url,
             name,
-            "hello_world__greet",
+            "hello-world.greet",
             {"name": "BoundaryTest"},
         )
         text = _extract_content_text(result)
@@ -958,8 +958,8 @@ class TestProgressiveLoadingBoundary:
             _mcporter_call(url, name, "load_skill", {"skill_name": "hello-world"})
         tools = _mcporter_list_tools(url, name)
         names = [t["name"] if isinstance(t, dict) else t for t in tools]
-        count = names.count("hello_world__greet")
-        assert count <= 1, f"hello_world__greet duplicated after double load: {count}"
+        count = names.count("hello-world.greet")
+        assert count <= 1, f"hello-world.greet duplicated after double load: {count}"
 
     def test_unload_then_reload_re_registers_tools(self, server_with_catalog):
         """After unload → reload, the skill's tools must be available again."""
@@ -1026,5 +1026,5 @@ class TestConcurrencyBoundary:
 
         tools = _mcporter_list_tools(url, name)
         tool_names = [t["name"] if isinstance(t, dict) else t for t in tools]
-        count = tool_names.count("hello_world__greet")
-        assert count <= 1, f"hello_world__greet duplicated: {count} occurrences"
+        count = tool_names.count("hello-world.greet")
+        assert count <= 1, f"hello-world.greet duplicated: {count} occurrences"

--- a/tests/test_on_demand_loading.py
+++ b/tests/test_on_demand_loading.py
@@ -244,7 +244,7 @@ class TestOnDemandLoadingContract:
         # Snapshot before
         before = {t["name"]: t for t in _tools_list(url)}
         assert "__skill__hello-world" in before, "Expected __skill__hello-world stub before loading"
-        assert "hello_world__greet" not in before, "hello_world__greet must not be present before load_skill"
+        assert "hello-world.greet" not in before, "hello-world.greet must not be present before load_skill"
 
         # Load hello-world
         load_resp = _post(
@@ -266,8 +266,8 @@ class TestOnDemandLoadingContract:
         assert "__skill__hello-world" not in after, "The __skill__hello-world stub must be removed after loading"
 
         # Real tool present
-        assert "hello_world__greet" in after, (
-            f"hello_world__greet must appear after load_skill. Got: {list(after.keys())}"
+        assert "hello-world.greet" in after, (
+            f"hello-world.greet must appear after load_skill. Got: {list(after.keys())}"
         )
 
         # Other stubs unaffected (count of remaining stubs = before - 1)
@@ -311,7 +311,7 @@ class TestOnDemandLoadingContract:
         # Snapshot after unload
         after_unload = {t["name"] for t in _tools_list(url)}
 
-        assert "hello_world__greet" not in after_unload, "hello_world__greet must be removed after unload_skill"
+        assert "hello-world.greet" not in after_unload, "hello-world.greet must be removed after unload_skill"
         assert "__skill__hello-world" in after_unload, "__skill__hello-world stub must reappear after unload_skill"
 
     def test_tools_list_count_invariant(self, catalog_server):
@@ -334,7 +334,7 @@ class TestOnDemandLoadingContract:
 
         count_base = len(_tools_list(url))
 
-        # Load hello-world (1 tool: hello_world__greet)
+        # Load hello-world (1 tool: hello-world.greet)
         _post(
             url,
             {

--- a/tests/test_server_sidecar_e2e.py
+++ b/tests/test_server_sidecar_e2e.py
@@ -254,11 +254,11 @@ class TestToolsListBoundary:
         loaded = json.loads(load_resp["result"]["content"][0]["text"])
         assert loaded.get("loaded") is True
 
-        # tools/list should now contain hello_world__greet with schema
+        # tools/list should now contain hello-world.greet with schema
         _, tl = _post(url, {"jsonrpc": "2.0", "id": 4, "method": "tools/list"})
         names = {t["name"] for t in tl["result"]["tools"]}
-        assert "hello_world__greet" in names or any("hello" in n for n in names), (
-            f"Expected hello_world__greet in tools/list after load. Got: {names}"
+        assert "hello-world.greet" in names or any("hello" in n for n in names), (
+            f"Expected hello-world.greet in tools/list after load. Got: {names}"
         )
 
     def test_stub_call_returns_load_hint(self, catalog_server):
@@ -297,8 +297,8 @@ class TestToolsListBoundary:
 
         _, tl = _post(url, {"jsonrpc": "2.0", "id": 4, "method": "tools/list"})
         tools = [t["name"] for t in tl["result"]["tools"]]
-        greet_count = tools.count("hello_world__greet")
-        assert greet_count <= 1, f"hello_world__greet duplicated after double load: {greet_count}"
+        greet_count = tools.count("hello-world.greet")
+        assert greet_count <= 1, f"hello-world.greet duplicated after double load: {greet_count}"
 
     def test_unload_then_reload_works(self, catalog_server):
         """Unloading a skill and reloading it re-registers its tools."""


### PR DESCRIPTION
## Summary

Implements issue #242 — tools on MCP **2025-06-18** sessions now advertise
`outputSchema` and return `structuredContent` alongside the legacy text
fallback. Both fields are stripped entirely on 2025-03-26 sessions so older
clients never see fields they do not recognise.

- `McpTool.output_schema: Option<Value>` → serialised as `outputSchema`
- `CallToolResult.structured_content: Option<Value>` → serialised as `structuredContent`
- `handle_tools_list` now takes the session id and version-gates the schema emission
- `handle_tools_call` sets `structuredContent` only when the dispatch payload is a JSON object / array (strings and nulls still go through `content[0].text`)
- `action_meta_to_mcp_tool(meta, include_output_schema)` — explicit `null` schema is treated as "unspecified" and omitted

## Test plan

- [x] `cargo test -p dcc-mcp-http` — lib tests + integration tests pass
- [x] 5 new integration tests in `tests::resource_link_integration_tests`:
  - `test_output_schema_emitted_on_2025_06_18_tools_list`
  - `test_output_schema_omitted_on_2025_03_26_tools_list`
  - `test_structured_content_emitted_on_2025_06_18_call`
  - `test_structured_content_omitted_on_2025_03_26_call`
  - `test_structured_content_omitted_for_string_output`
- [x] `cargo fmt` / `cargo clippy` clean for the diff (pre-commit hooks enforced)
- [x] `cargo check --workspace` clean

## Non-goals

- Gateway aggregator forwarding — backends return `outputSchema` / `structuredContent` verbatim today; a follow-up pass will verify end-to-end behaviour through the multi-DCC gateway.
- Migrating Maya/Blender first-class actions to structured output — belongs to the adapter repos.

Closes #242
