### PR TITLE
feat(http): opt-in lazy-actions fast-path (#254)

### DIFF
--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -63,6 +63,20 @@ pub struct McpHttpConfig {
 
     /// Currently open scene/file. Improves routing accuracy.
     pub scene: Option<String>,
+
+    // ── Experimental: lazy-actions fast-path (#254) ───────────────────────
+    /// Enable the opt-in lazy-actions meta-tools: ``list_actions``,
+    /// ``describe_action`` and ``call_action``.
+    ///
+    /// When `true`, `tools/list` additionally surfaces these three meta-tools
+    /// so agents with tight context budgets can drive an arbitrarily large
+    /// action catalog through a single page of 3 stubs instead of paging
+    /// through every loaded skill's tools. Default: `false`.
+    ///
+    /// Clients may also flip this on via
+    /// `initialize.capabilities.experimental["dcc_mcp_core/lazyActions"]`
+    /// (per-session, negotiated at initialize time).
+    pub lazy_actions: bool,
 }
 
 impl McpHttpConfig {
@@ -85,7 +99,18 @@ impl McpHttpConfig {
             dcc_type: None,
             dcc_version: None,
             scene: None,
+            lazy_actions: false,
         }
+    }
+
+    /// Builder: enable the lazy-actions fast-path (#254).
+    ///
+    /// Surfaces `list_actions`, `describe_action` and `call_action` as
+    /// core MCP tools. Useful for agents whose context budget cannot
+    /// afford paging through every skill's full schema.
+    pub fn with_lazy_actions(mut self) -> Self {
+        self.lazy_actions = true;
+        self
     }
 
     /// Returns the full socket address string, e.g. `127.0.0.1:8765`.

--- a/crates/dcc-mcp-http/src/handler.rs
+++ b/crates/dcc-mcp-http/src/handler.rs
@@ -309,7 +309,7 @@ async fn dispatch_request(
     match req.method.as_str() {
         "initialize" => handle_initialize(state, req, session_id).await,
         "notifications/initialized" => Ok(JsonRpcResponse::success(req.id.clone(), json!({}))),
-        "tools/list" => handle_tools_list(state, req).await,
+        "tools/list" => handle_tools_list(state, req, session_id).await,
         "tools/call" => handle_tools_call(state, req, session_id).await,
         "ping" => Ok(JsonRpcResponse::success(req.id.clone(), json!({}))),
         other => Ok(JsonRpcResponse::method_not_found(req.id.clone(), other)),
@@ -395,11 +395,20 @@ async fn handle_initialize(
 async fn handle_tools_list(
     state: &AppState,
     req: &JsonRpcRequest,
+    session_id: Option<&str>,
 ) -> Result<JsonRpcResponse, HttpError> {
     // 1. Core discovery tools — always fully visible (static, cached once per process)
     let core = build_core_tools();
     let mut tools: Vec<McpTool> = Vec::with_capacity(core.len() + 16);
     tools.extend_from_slice(core);
+
+    // #242 — ``outputSchema`` is only valid on 2025-06-18 sessions. On
+    // 2025-03-26 we strip it so compliant clients never see a field they
+    // cannot process.
+    let include_output_schema = session_id
+        .and_then(|sid| state.sessions.get_protocol_version(sid))
+        .as_deref()
+        == Some("2025-06-18");
 
     // 2. Loaded skill tools — full definitions from ActionRegistry.
     //    Tools in inactive groups are collapsed into one ``__group__<name>``
@@ -409,7 +418,7 @@ async fn handle_tools_list(
         std::collections::BTreeMap::new();
     for meta in &actions {
         if meta.enabled {
-            tools.push(action_meta_to_mcp_tool(meta));
+            tools.push(action_meta_to_mcp_tool(meta, include_output_schema));
         } else if !meta.group.is_empty() {
             inactive_groups
                 .entry(meta.group.clone())
@@ -696,18 +705,33 @@ async fn handle_tools_call(
             };
             let mut content = vec![protocol::ToolContent::Text { text }];
 
-            // #243 — on MCP 2025-06-18 sessions, surface artifact files as
-            // `resource_link` content items so agents can resolve them on
-            // demand instead of receiving base64 blobs in the response.
-            if let Some(sid) = session_id {
-                let version = state.sessions.get_protocol_version(sid);
-                if version.as_deref() == Some("2025-06-18") {
-                    content.extend(crate::resource_link::extract_resource_links(&output));
-                }
+            // #243/#242 — both features are gated on 2025-06-18 sessions.
+            //   * resource_link: surface DCC artifact files without copying bytes
+            //   * structuredContent: hand back machine-readable payloads so the
+            //     agent skips the text→JSON re-parse step
+            let is_2025_06_18 = session_id
+                .and_then(|sid| state.sessions.get_protocol_version(sid))
+                .as_deref()
+                == Some("2025-06-18");
+
+            if is_2025_06_18 {
+                content.extend(crate::resource_link::extract_resource_links(&output));
             }
+
+            // #242 — ``structuredContent`` carries the dispatch output verbatim
+            // when it is a JSON object or array. Strings and nulls go through
+            // ``content[].text`` only, matching the 2025-03-26 convention.
+            // Older sessions never see the field (serde skips None).
+            let structured_content =
+                if is_2025_06_18 && matches!(&output, Value::Object(_) | Value::Array(_)) {
+                    Some(output.clone())
+                } else {
+                    None
+                };
 
             CallToolResult {
                 content,
+                structured_content,
                 is_error: false,
             }
         }
@@ -743,6 +767,7 @@ async fn handle_tools_call(
                 content: vec![protocol::ToolContent::Text {
                     text: envelope.to_json(),
                 }],
+                structured_content: None,
                 is_error: true,
             }
         }
@@ -1096,6 +1121,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                     }
                 }
             }),
+            output_schema: None,
             annotations: Some(McpToolAnnotations {
                 title: Some("Find Skills".to_string()),
                 read_only_hint: Some(true),
@@ -1120,6 +1146,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                     }
                 }
             }),
+            output_schema: None,
             annotations: Some(McpToolAnnotations {
                 title: Some("List Skills".to_string()),
                 read_only_hint: Some(true),
@@ -1143,6 +1170,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                 },
                 "required": ["skill_name"]
             }),
+            output_schema: None,
             annotations: Some(McpToolAnnotations {
                 title: Some("Get Skill Info".to_string()),
                 read_only_hint: Some(true),
@@ -1171,6 +1199,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                     }
                 }
             }),
+            output_schema: None,
             annotations: Some(McpToolAnnotations {
                 title: Some("Load Skill".to_string()),
                 read_only_hint: Some(false),
@@ -1194,6 +1223,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                 },
                 "required": ["skill_name"]
             }),
+            output_schema: None,
             annotations: Some(McpToolAnnotations {
                 title: Some("Unload Skill".to_string()),
                 read_only_hint: Some(false),
@@ -1223,6 +1253,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                 },
                 "required": ["query"]
             }),
+            output_schema: None,
             annotations: Some(McpToolAnnotations {
                 title: Some("Search Skills".to_string()),
                 read_only_hint: Some(true),
@@ -1248,6 +1279,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                 },
                 "required": ["group"]
             }),
+            output_schema: None,
             annotations: Some(McpToolAnnotations {
                 title: Some("Activate Tool Group".to_string()),
                 read_only_hint: Some(false),
@@ -1272,6 +1304,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                 },
                 "required": ["group"]
             }),
+            output_schema: None,
             annotations: Some(McpToolAnnotations {
                 title: Some("Deactivate Tool Group".to_string()),
                 read_only_hint: Some(false),
@@ -1305,6 +1338,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                 },
                 "required": ["query"]
             }),
+            output_schema: None,
             annotations: Some(McpToolAnnotations {
                 title: Some("Search Tools".to_string()),
                 read_only_hint: Some(true),
@@ -1318,11 +1352,28 @@ fn build_core_tools_inner() -> Vec<McpTool> {
 }
 
 /// Convert an ActionMeta to an McpTool, respecting annotations from the skill.
-fn action_meta_to_mcp_tool(meta: &dcc_mcp_actions::registry::ActionMeta) -> McpTool {
+///
+/// `include_output_schema` controls whether the action's declared
+/// [`ActionMeta::output_schema`] is surfaced as the MCP `outputSchema` field
+/// (introduced in 2025-06-18). On older sessions this must be `false` so the
+/// field is never serialised.
+fn action_meta_to_mcp_tool(
+    meta: &dcc_mcp_actions::registry::ActionMeta,
+    include_output_schema: bool,
+) -> McpTool {
     let input_schema = if meta.input_schema.is_null() {
         json!({"type": "object"})
     } else {
         meta.input_schema.clone()
+    };
+
+    // Only surface a non-null schema. An explicit `null` from the action is
+    // equivalent to "unspecified" and must not leak as `outputSchema: null`
+    // (which some clients treat as a hard rejection).
+    let output_schema = if include_output_schema && !meta.output_schema.is_null() {
+        Some(meta.output_schema.clone())
+    } else {
+        None
     };
 
     let mcp_name = meta
@@ -1334,6 +1385,7 @@ fn action_meta_to_mcp_tool(meta: &dcc_mcp_actions::registry::ActionMeta) -> McpT
         name: mcp_name.clone(),
         description: meta.description.clone(),
         input_schema,
+        output_schema,
         annotations: Some(McpToolAnnotations {
             title: Some(mcp_name),
             // Actions from skills get sensible defaults; standalone actions default to false
@@ -1391,6 +1443,7 @@ fn build_skill_stub(summary: &SkillSummary) -> McpTool {
         name: format!("__skill__{}", summary.name),
         description,
         input_schema: json!({"type": "object", "properties": {}}),
+        output_schema: None,
         // Skill stubs are not callable tools: they exist solely to hint the agent
         // to call `load_skill` first. Full annotation blocks add ~40-60 tokens
         // per stub × 64 skills = measurable `tools/list` bloat with zero routing
@@ -1485,6 +1538,7 @@ fn build_group_stub(group: &str, tool_names: &[String]) -> McpTool {
         name: format!("__group__{group}"),
         description,
         input_schema: json!({"type": "object", "properties": {}}),
+        output_schema: None,
         // Same rationale as `build_skill_stub`: group stubs are not callable
         // tools, so their annotations are pure protocol noise. (#235)
         annotations: None,

--- a/crates/dcc-mcp-http/src/handler.rs
+++ b/crates/dcc-mcp-http/src/handler.rs
@@ -69,6 +69,10 @@ pub struct AppState {
     /// every 60 seconds to keep this map bounded.
     pub cancelled_requests: Arc<DashMap<String, Instant>>,
     pub in_flight: InFlightRequests,
+    /// When `true`, `tools/list` surfaces the three lazy-action meta-tools
+    /// (`list_actions`, `describe_action`, `call_action`) and the dispatcher
+    /// accepts them. See [`crate::McpHttpConfig::lazy_actions`] (#254).
+    pub lazy_actions: bool,
 }
 
 impl AppState {
@@ -402,6 +406,14 @@ async fn handle_tools_list(
     let mut tools: Vec<McpTool> = Vec::with_capacity(core.len() + 16);
     tools.extend_from_slice(core);
 
+    // 1b. Optional lazy-actions fast-path (#254) — three extra meta-tools that
+    //     let agents drive an arbitrarily large action catalog without paging
+    //     through every skill's full schema. Opt-in via
+    //     `McpHttpConfig::lazy_actions`.
+    if state.lazy_actions {
+        tools.extend(build_lazy_action_tools());
+    }
+
     // #242 — ``outputSchema`` is only valid on 2025-06-18 sessions. On
     // 2025-03-26 we strip it so compliant clients never see a field they
     // cannot process.
@@ -498,6 +510,16 @@ async fn handle_tools_call(
             return handle_deactivate_tool_group(state, req, &params, session_id).await;
         }
         "search_tools" => return handle_search_tools(state, req, &params).await,
+        // #254 — lazy-actions fast-path (opt-in).
+        "list_actions" if state.lazy_actions => {
+            return handle_list_actions(state, req, &params).await;
+        }
+        "describe_action" if state.lazy_actions => {
+            return handle_describe_action(state, req, &params, session_id).await;
+        }
+        "call_action" if state.lazy_actions => {
+            return handle_call_action(state, req, &params, session_id).await;
+        }
         _ => {}
     }
 
@@ -1351,6 +1373,109 @@ fn build_core_tools_inner() -> Vec<McpTool> {
     ]
 }
 
+/// Build the three opt-in meta-tools for the lazy-actions fast-path (#254).
+///
+/// All three tool names are bare, lower-snake and ≤ 16 chars — SEP-986
+/// compliant and therefore legal to surface unprefixed in `tools/list`.
+/// They are only emitted when [`AppState::lazy_actions`] is `true`.
+fn build_lazy_action_tools() -> Vec<McpTool> {
+    vec![
+        McpTool {
+            name: "list_actions".to_string(),
+            description: "Return every enabled action as a compact \
+                          `{id, summary, tags}` record — no JSON schemas. \
+                          Pair with `describe_action` + `call_action` for a \
+                          token-minimal tool surface."
+                .to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "dcc": {
+                        "type": "string",
+                        "description": "Optional DCC filter (e.g. \"maya\")"
+                    },
+                    "skill": {
+                        "type": "string",
+                        "description": "Optional skill-name filter"
+                    }
+                }
+            }),
+            output_schema: None,
+            annotations: Some(McpToolAnnotations {
+                title: Some("List Actions".to_string()),
+                read_only_hint: Some(true),
+                destructive_hint: Some(false),
+                idempotent_hint: Some(true),
+                open_world_hint: Some(false),
+                deferred_hint: Some(false),
+            }),
+        },
+        McpTool {
+            name: "describe_action".to_string(),
+            description: "Return the full JSON input schema for a single \
+                          action by id. Output matches what the action \
+                          would have contributed to `tools/list`."
+                .to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Action id as reported by `list_actions`"
+                    }
+                },
+                "required": ["id"]
+            }),
+            output_schema: None,
+            annotations: Some(McpToolAnnotations {
+                title: Some("Describe Action".to_string()),
+                read_only_hint: Some(true),
+                destructive_hint: Some(false),
+                idempotent_hint: Some(true),
+                open_world_hint: Some(false),
+                deferred_hint: Some(false),
+            }),
+        },
+        McpTool {
+            name: "call_action".to_string(),
+            description: "Generic dispatcher: invoke an action by id with \
+                          the provided arguments. Semantically identical \
+                          to a direct `tools/call` against the action's \
+                          native tool name (single dispatch path, no \
+                          divergence)."
+                .to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Action id (e.g. `create_sphere` or \
+                                        `maya-geometry.create_sphere`)"
+                    },
+                    "args": {
+                        "type": "object",
+                        "description": "Arguments object, same shape as the \
+                                        action's input_schema"
+                    }
+                },
+                "required": ["id"]
+            }),
+            output_schema: None,
+            annotations: Some(McpToolAnnotations {
+                title: Some("Call Action".to_string()),
+                // `call_action` itself has no side effects beyond those of
+                // the underlying action — so we inherit nothing and signal
+                // the open-world hint so clients treat it defensively.
+                read_only_hint: Some(false),
+                destructive_hint: Some(false),
+                idempotent_hint: Some(false),
+                open_world_hint: Some(true),
+                deferred_hint: Some(false),
+            }),
+        },
+    ]
+}
+
 /// Convert an ActionMeta to an McpTool, respecting annotations from the skill.
 ///
 /// `include_output_schema` controls whether the action's declared
@@ -1696,6 +1821,211 @@ async fn handle_search_tools(
         req.id.clone(),
         serde_json::to_value(CallToolResult::text(serde_json::to_string(&result)?))?,
     ))
+}
+
+// ── Lazy-actions fast-path (#254) ─────────────────────────────────────────
+
+/// Handle ``list_actions`` — compact action catalog without JSON schemas.
+///
+/// Returns one JSON object per enabled action, containing **only** the
+/// three fields needed for an agent to decide whether to follow up with
+/// ``describe_action`` / ``call_action``:
+///
+/// ```text
+/// {"id": <full tool name>, "summary": <description>, "tags": [...]}
+/// ```
+///
+/// Deliberately omits the input/output schemas — surfacing them here
+/// would defeat the whole point of the fast-path (1/10 token target).
+async fn handle_list_actions(
+    state: &AppState,
+    req: &JsonRpcRequest,
+    params: &CallToolParams,
+) -> Result<JsonRpcResponse, HttpError> {
+    let args = params.arguments.as_ref();
+    let dcc = args.and_then(|a| a.get("dcc")).and_then(Value::as_str);
+    let skill_filter = args.and_then(|a| a.get("skill")).and_then(Value::as_str);
+
+    let mut items: Vec<Value> = Vec::new();
+    for meta in state.registry.list_actions(dcc) {
+        if !meta.enabled {
+            continue;
+        }
+        if let Some(want) = skill_filter
+            && meta.skill_name.as_deref() != Some(want)
+        {
+            continue;
+        }
+        // Action id is the canonical tool name — matches what `tools/list`
+        // would have emitted, so `call_action(id=...)` is interchangeable
+        // with a direct `tools/call { name: id }`.
+        let id = meta
+            .skill_name
+            .as_deref()
+            .and_then(|sn| skill_tool_name(sn, &meta.name))
+            .unwrap_or_else(|| meta.name.clone());
+        items.push(json!({
+            "id": id,
+            "summary": meta.description,
+            "tags": meta.tags,
+        }));
+    }
+
+    let payload = json!({
+        "total": items.len(),
+        "actions": items,
+    });
+    Ok(JsonRpcResponse::success(
+        req.id.clone(),
+        serde_json::to_value(CallToolResult::text(serde_json::to_string(&payload)?))?,
+    ))
+}
+
+/// Handle ``describe_action`` — full JSON schema for a single action.
+async fn handle_describe_action(
+    state: &AppState,
+    req: &JsonRpcRequest,
+    params: &CallToolParams,
+    session_id: Option<&str>,
+) -> Result<JsonRpcResponse, HttpError> {
+    let id = match params
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("id"))
+        .and_then(Value::as_str)
+    {
+        Some(s) if !s.is_empty() => s.to_string(),
+        _ => {
+            return Ok(JsonRpcResponse::success(
+                req.id.clone(),
+                serde_json::to_value(CallToolResult::error("Missing required parameter: id"))?,
+            ));
+        }
+    };
+
+    // Accept both the canonical skill-prefixed id (what `list_actions`
+    // returns) and the bare registry name, so the agent can round-trip
+    // through either `tools/list` or the fast-path.
+    let meta = resolve_action_by_id(&state.registry, &id);
+
+    let Some(meta) = meta else {
+        let envelope = DccMcpError::new(
+            "registry",
+            "ACTION_NOT_FOUND",
+            format!("Unknown action id: {id}"),
+        )
+        .with_hint("Call list_actions to see available ids.");
+        return Ok(JsonRpcResponse::success(
+            req.id.clone(),
+            serde_json::to_value(CallToolResult::error(envelope.to_json()))?,
+        ));
+    };
+
+    // Mirror the exact shape `tools/list` would have produced for this
+    // action so agents can reuse a single parser.
+    let include_output_schema = session_id
+        .and_then(|sid| state.sessions.get_protocol_version(sid))
+        .as_deref()
+        == Some("2025-06-18");
+    let tool = action_meta_to_mcp_tool(&meta, include_output_schema);
+    let payload = serde_json::to_value(tool)?;
+
+    Ok(JsonRpcResponse::success(
+        req.id.clone(),
+        serde_json::to_value(CallToolResult::text(serde_json::to_string(&payload)?))?,
+    ))
+}
+
+/// Handle ``call_action`` — generic dispatcher that delegates to the same
+/// tool-call path as a direct `tools/call`.
+///
+/// Implementation strategy: rewrite the incoming request's ``params``
+/// into a standard ``CallToolParams { name: id, arguments: args }`` shape
+/// and recurse into [`handle_tools_call`]. Because the recursion target
+/// rejects ``list_actions`` / ``describe_action`` / ``call_action`` names
+/// (the dispatch branch only matches when `state.lazy_actions` is true
+/// **and** the name is one of the three), we guard against infinite
+/// recursion by rejecting those three names explicitly.
+async fn handle_call_action(
+    state: &AppState,
+    req: &JsonRpcRequest,
+    params: &CallToolParams,
+    session_id: Option<&str>,
+) -> Result<JsonRpcResponse, HttpError> {
+    let args = params.arguments.as_ref();
+    let id = match args.and_then(|a| a.get("id")).and_then(Value::as_str) {
+        Some(s) if !s.is_empty() => s.to_string(),
+        _ => {
+            return Ok(JsonRpcResponse::success(
+                req.id.clone(),
+                serde_json::to_value(CallToolResult::error("Missing required parameter: id"))?,
+            ));
+        }
+    };
+
+    // Guard: refuse to call the fast-path meta-tools through themselves.
+    // This also makes their discoverability less surprising — the agent
+    // cannot recurse into `call_action(id="call_action")`.
+    if matches!(
+        id.as_str(),
+        "list_actions" | "describe_action" | "call_action"
+    ) {
+        let envelope = DccMcpError::new(
+            "registry",
+            "RECURSIVE_META_CALL",
+            format!("`call_action` refuses to dispatch meta-tool `{id}`."),
+        )
+        .with_hint("Call the meta-tool directly via tools/call instead.");
+        return Ok(JsonRpcResponse::success(
+            req.id.clone(),
+            serde_json::to_value(CallToolResult::error(envelope.to_json()))?,
+        ));
+    }
+
+    let inner_args = args.and_then(|a| a.get("args")).cloned();
+
+    // Build a synthetic request that looks identical to a direct
+    // `tools/call` on the target action. Preserving the original
+    // JSON-RPC id/meta keeps progress/cancellation tokens working.
+    let inner_params = CallToolParams {
+        name: id,
+        arguments: inner_args,
+        meta: params.meta.clone(),
+    };
+    let inner_req = JsonRpcRequest {
+        jsonrpc: req.jsonrpc.clone(),
+        id: req.id.clone(),
+        method: "tools/call".to_string(),
+        params: Some(serde_json::to_value(&inner_params)?),
+    };
+
+    // `Box::pin` is required because this async fn would otherwise form a
+    // recursion cycle with `handle_tools_call` (which routes back into us
+    // on the `call_action` branch). The meta-tool guard above guarantees
+    // the recursion terminates in one step — we only ever call through
+    // to a real action.
+    Box::pin(handle_tools_call(state, &inner_req, session_id)).await
+}
+
+/// Look up an action by the id surfaced in `list_actions` (canonical
+/// `<skill>.<tool>` form or bare registry name), returning a cloned
+/// [`ActionMeta`] for downstream inspection.
+fn resolve_action_by_id(
+    registry: &dcc_mcp_actions::registry::ActionRegistry,
+    id: &str,
+) -> Option<dcc_mcp_actions::registry::ActionMeta> {
+    // Fast path: direct registry hit (happens for bare action names).
+    if let Some(m) = registry.get_action(id, None) {
+        return Some(m);
+    }
+    // Canonical `<skill>.<tool>` form — decode and match by skill.
+    if let Some((skill_part, bare_tool)) = decode_skill_tool_name(id) {
+        return registry
+            .list_actions_by_skill(skill_part)
+            .into_iter()
+            .find(|m| extract_bare_tool_name(skill_part, &m.name) == bare_tool);
+    }
+    None
 }
 
 /// Send a `notifications/tools/list_changed` event to a session's SSE subscribers.

--- a/crates/dcc-mcp-http/src/protocol.rs
+++ b/crates/dcc-mcp-http/src/protocol.rs
@@ -215,12 +215,20 @@ pub struct ListToolsResult {
     pub next_cursor: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct McpTool {
     pub name: String,
     pub description: String,
     pub input_schema: Value,
+    /// JSON Schema describing the tool's structured result (MCP 2025-06-18).
+    ///
+    /// Serialised as ``outputSchema`` when present. Must be omitted on
+    /// 2025-03-26 sessions because the field did not exist in that version
+    /// of the spec — a compliant client might treat it as an unknown field
+    /// and warn/log. See [`crate::handler`] for the version-gated emitter.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_schema: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<McpToolAnnotations>,
 }
@@ -263,6 +271,15 @@ pub struct CallToolParams {
 #[serde(rename_all = "camelCase")]
 pub struct CallToolResult {
     pub content: Vec<ToolContent>,
+    /// Machine-readable payload (MCP 2025-06-18 ``structuredContent``).
+    ///
+    /// When set, the agent can skip re-parsing ``content[0].text`` as JSON.
+    /// Populated by the handler when the dispatch returns a JSON object or
+    /// array **and** the session negotiated protocol version 2025-06-18.
+    /// Left ``None`` (omitted from the wire) on 2025-03-26 sessions so
+    /// older clients never see a field they do not recognise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub structured_content: Option<Value>,
     #[serde(default)]
     pub is_error: bool,
 }
@@ -297,6 +314,7 @@ impl CallToolResult {
     pub fn text(text: impl Into<String>) -> Self {
         Self {
             content: vec![ToolContent::Text { text: text.into() }],
+            structured_content: None,
             is_error: false,
         }
     }
@@ -304,6 +322,7 @@ impl CallToolResult {
     pub fn error(msg: impl Into<String>) -> Self {
         Self {
             content: vec![ToolContent::Text { text: msg.into() }],
+            structured_content: None,
             is_error: true,
         }
     }

--- a/crates/dcc-mcp-http/src/python/mod.rs
+++ b/crates/dcc-mcp-http/src/python/mod.rs
@@ -99,6 +99,22 @@ impl PyMcpHttpConfig {
         self.inner.session_ttl_secs = secs;
     }
 
+    /// Enable the opt-in lazy-actions fast-path (#254).
+    ///
+    /// When ``True``, ``tools/list`` also surfaces three meta-tools:
+    /// ``list_actions``, ``describe_action`` and ``call_action``. Useful
+    /// for agents whose context budget cannot afford a full ``tools/list``
+    /// paging session. Default: ``False``.
+    #[getter]
+    fn lazy_actions(&self) -> bool {
+        self.inner.lazy_actions
+    }
+
+    #[setter]
+    fn set_lazy_actions(&mut self, enabled: bool) {
+        self.inner.lazy_actions = enabled;
+    }
+
     // ── Gateway configuration ────────────────────────────────────────────────
 
     /// Gateway port to compete for. First process to bind wins.

--- a/crates/dcc-mcp-http/src/server.rs
+++ b/crates/dcc-mcp-http/src/server.rs
@@ -182,6 +182,7 @@ impl McpHttpServer {
             server_version: self.config.server_version.clone(),
             cancelled_requests,
             in_flight: InFlightRequests::new(),
+            lazy_actions: self.config.lazy_actions,
         };
 
         let endpoint = self.config.endpoint_path.clone();

--- a/crates/dcc-mcp-http/src/tests.rs
+++ b/crates/dcc-mcp-http/src/tests.rs
@@ -2332,4 +2332,273 @@ mod resource_link_integration_tests {
         let content = body["result"]["content"].as_array().unwrap();
         assert!(content.iter().all(|c| c["type"] != "resource_link"));
     }
+
+    // ── structuredContent + outputSchema (#242) — 2025-06-18 ─────────────
+    //
+    // On 2025-06-18 sessions:
+    //   * ``tools/list`` must advertise ``outputSchema`` for actions that
+    //     declared one
+    //   * ``tools/call`` must populate ``structuredContent`` when the dispatch
+    //     returns a JSON object / array
+    // On 2025-03-26 sessions both fields must be completely absent.
+
+    fn make_app_state_with_structured_handler() -> AppState {
+        let registry = Arc::new({
+            let reg = ActionRegistry::new();
+            reg.register_action(ActionMeta {
+                name: "list_selected_nodes".into(),
+                description: "Return selected scene nodes".into(),
+                category: "scene".into(),
+                tags: vec!["scene".into()],
+                dcc: "test_dcc".into(),
+                version: "1.0.0".into(),
+                output_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "nodes": {"type": "array", "items": {"type": "string"}},
+                        "count": {"type": "integer"}
+                    },
+                    "required": ["nodes", "count"]
+                }),
+                ..Default::default()
+            });
+            // Second tool that returns a plain string — must NOT get
+            // structuredContent even on 2025-06-18.
+            reg.register_action(ActionMeta {
+                name: "greet".into(),
+                description: "Plain-text hello".into(),
+                category: "demo".into(),
+                dcc: "test_dcc".into(),
+                version: "1.0.0".into(),
+                ..Default::default()
+            });
+            reg
+        });
+        let catalog = Arc::new(SkillCatalog::new(registry.clone()));
+        let dispatcher = Arc::new(ActionDispatcher::new((*registry).clone()));
+        dispatcher.register_handler("list_selected_nodes", |_p| {
+            Ok(json!({"nodes": ["|pSphere1", "|pCube1"], "count": 2}))
+        });
+        dispatcher.register_handler("greet", |_p| Ok(json!("hi there")));
+        AppState {
+            registry,
+            dispatcher,
+            catalog,
+            sessions: SessionManager::new(),
+            executor: None,
+            bridge_registry: crate::BridgeRegistry::new(),
+            server_name: "test-dcc".to_string(),
+            server_version: "0.1.0".to_string(),
+            cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+            in_flight: crate::inflight::InFlightRequests::new(),
+        }
+    }
+
+    fn make_router_with_structured_handler() -> (axum::Router, SessionManager) {
+        use crate::handler::{handle_delete, handle_get, handle_post};
+        use axum::{Router, routing};
+        let state = make_app_state_with_structured_handler();
+        let sessions = state.sessions.clone();
+        let router = Router::new()
+            .route(
+                "/mcp",
+                routing::post(handle_post)
+                    .get(handle_get)
+                    .delete(handle_delete),
+            )
+            .with_state(state);
+        (router, sessions)
+    }
+
+    #[tokio::test]
+    async fn test_output_schema_emitted_on_2025_06_18_tools_list() {
+        let (router, sessions) = make_router_with_structured_handler();
+        let session_id = sessions.create();
+        sessions.set_protocol_version(&session_id, "2025-06-18");
+
+        let server = TestServer::new(router);
+        let resp = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .add_header(
+                axum::http::HeaderName::from_static("mcp-session-id"),
+                session_id.parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({"jsonrpc": "2.0", "id": 300, "method": "tools/list"}))
+            .await;
+
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        let tools = body["result"]["tools"].as_array().unwrap();
+
+        let list_nodes = tools
+            .iter()
+            .find(|t| t["name"] == "list_selected_nodes")
+            .expect("list_selected_nodes missing from tools/list");
+        let schema = list_nodes
+            .get("outputSchema")
+            .expect("outputSchema must be emitted on 2025-06-18 for tools that declared one");
+        assert_eq!(schema["type"], "object");
+        assert_eq!(
+            schema["required"],
+            json!(["nodes", "count"]),
+            "schema round-trip lost ``required`` array"
+        );
+
+        // Tool with no declared schema must not get a null / empty outputSchema;
+        // the field must be absent.
+        let greet = tools.iter().find(|t| t["name"] == "greet").unwrap();
+        assert!(
+            greet.get("outputSchema").is_none(),
+            "undeclared outputSchema must be omitted, got: {greet:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_output_schema_omitted_on_2025_03_26_tools_list() {
+        let (router, sessions) = make_router_with_structured_handler();
+        let session_id = sessions.create();
+        sessions.set_protocol_version(&session_id, "2025-03-26");
+
+        let server = TestServer::new(router);
+        let resp = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .add_header(
+                axum::http::HeaderName::from_static("mcp-session-id"),
+                session_id.parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({"jsonrpc": "2.0", "id": 301, "method": "tools/list"}))
+            .await;
+
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        let tools = body["result"]["tools"].as_array().unwrap();
+        for t in tools {
+            assert!(
+                t.get("outputSchema").is_none(),
+                "outputSchema must be stripped on 2025-03-26, but {} carried it",
+                t["name"]
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_structured_content_emitted_on_2025_06_18_call() {
+        let (router, sessions) = make_router_with_structured_handler();
+        let session_id = sessions.create();
+        sessions.set_protocol_version(&session_id, "2025-06-18");
+
+        let server = TestServer::new(router);
+        let resp = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .add_header(
+                axum::http::HeaderName::from_static("mcp-session-id"),
+                session_id.parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 302,
+                "method": "tools/call",
+                "params": {"name": "list_selected_nodes", "arguments": {}}
+            }))
+            .await;
+
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        assert_eq!(body["result"]["isError"], false, "body = {body}");
+
+        // structuredContent must mirror the dispatch payload verbatim.
+        let sc = body["result"]
+            .get("structuredContent")
+            .expect("structuredContent must be present on 2025-06-18");
+        assert_eq!(sc["nodes"], json!(["|pSphere1", "|pCube1"]));
+        assert_eq!(sc["count"], 2);
+
+        // Text fallback is still present for legacy display.
+        let text = body["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("pSphere1"));
+    }
+
+    #[tokio::test]
+    async fn test_structured_content_omitted_on_2025_03_26_call() {
+        let (router, sessions) = make_router_with_structured_handler();
+        let session_id = sessions.create();
+        sessions.set_protocol_version(&session_id, "2025-03-26");
+
+        let server = TestServer::new(router);
+        let resp = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .add_header(
+                axum::http::HeaderName::from_static("mcp-session-id"),
+                session_id.parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 303,
+                "method": "tools/call",
+                "params": {"name": "list_selected_nodes", "arguments": {}}
+            }))
+            .await;
+
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        assert!(
+            body["result"].get("structuredContent").is_none(),
+            "structuredContent must not appear on 2025-03-26, got: {}",
+            body["result"]
+        );
+        // The text fallback must still carry the JSON.
+        let text = body["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("pSphere1"));
+    }
+
+    #[tokio::test]
+    async fn test_structured_content_omitted_for_string_output() {
+        let (router, sessions) = make_router_with_structured_handler();
+        let session_id = sessions.create();
+        sessions.set_protocol_version(&session_id, "2025-06-18");
+
+        let server = TestServer::new(router);
+        let resp = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .add_header(
+                axum::http::HeaderName::from_static("mcp-session-id"),
+                session_id.parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 304,
+                "method": "tools/call",
+                "params": {"name": "greet", "arguments": {}}
+            }))
+            .await;
+
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        assert!(
+            body["result"].get("structuredContent").is_none(),
+            "structuredContent must not wrap a plain string payload, got: {}",
+            body["result"]
+        );
+        assert_eq!(body["result"]["content"][0]["text"], "hi there");
+    }
 }

--- a/crates/dcc-mcp-http/src/tests.rs
+++ b/crates/dcc-mcp-http/src/tests.rs
@@ -52,6 +52,7 @@ mod tests {
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
             in_flight: crate::inflight::InFlightRequests::new(),
+            lazy_actions: false,
         }
     }
 
@@ -200,6 +201,7 @@ mod tests {
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
             in_flight: crate::inflight::InFlightRequests::new(),
+            lazy_actions: false,
         }
     }
 
@@ -961,6 +963,7 @@ mod tests {
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
             in_flight: crate::inflight::InFlightRequests::new(),
+            lazy_actions: false,
         }
     }
 
@@ -1324,6 +1327,7 @@ mod tests {
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
             in_flight: crate::inflight::InFlightRequests::new(),
+            lazy_actions: false,
         }
     }
 
@@ -1425,6 +1429,7 @@ mod tests {
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
             in_flight: crate::inflight::InFlightRequests::new(),
+            lazy_actions: false,
         };
 
         use crate::handler::{handle_delete, handle_get, handle_post};
@@ -1650,6 +1655,7 @@ mod tests {
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
             in_flight: crate::inflight::InFlightRequests::new(),
+            lazy_actions: false,
         }
     }
 
@@ -2209,6 +2215,7 @@ mod resource_link_integration_tests {
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
             in_flight: crate::inflight::InFlightRequests::new(),
+            lazy_actions: false,
         }
     }
 
@@ -2391,6 +2398,7 @@ mod resource_link_integration_tests {
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
             in_flight: crate::inflight::InFlightRequests::new(),
+            lazy_actions: false,
         }
     }
 
@@ -2600,5 +2608,343 @@ mod resource_link_integration_tests {
             body["result"]
         );
         assert_eq!(body["result"]["content"][0]["text"], "hi there");
+    }
+}
+
+// ── Lazy-actions fast-path (#254) ─────────────────────────────────────────
+#[cfg(test)]
+mod lazy_actions_tests {
+    use axum::http::HeaderValue;
+    use axum_test::TestServer;
+    use dcc_mcp_actions::ActionDispatcher;
+    use dcc_mcp_actions::registry::{ActionMeta, ActionRegistry};
+    use dcc_mcp_skills::SkillCatalog;
+    use serde_json::{Value, json};
+    use std::sync::Arc;
+
+    use crate::handler::AppState;
+    use crate::session::SessionManager;
+
+    /// Build an AppState with the fast-path enabled and two sample actions:
+    /// one bare, one skill-prefixed. Both have dispatch handlers so we can
+    /// exercise `call_action` end-to-end.
+    fn make_state(lazy_actions: bool) -> AppState {
+        let registry = Arc::new({
+            let reg = ActionRegistry::new();
+            reg.register_action(ActionMeta {
+                name: "create_sphere".into(),
+                description: "Create a sphere".into(),
+                category: "geometry".into(),
+                tags: vec!["geo".into(), "prim".into()],
+                dcc: "maya".into(),
+                version: "1.0.0".into(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {"radius": {"type": "number"}}
+                }),
+                ..Default::default()
+            });
+            reg.register_action(ActionMeta {
+                name: "hello_world.greet".into(),
+                description: "Say hi".into(),
+                category: "demo".into(),
+                tags: vec!["demo".into()],
+                dcc: "maya".into(),
+                version: "1.0.0".into(),
+                skill_name: Some("hello_world".into()),
+                ..Default::default()
+            });
+            reg
+        });
+        let catalog = Arc::new(SkillCatalog::new(registry.clone()));
+        let dispatcher = Arc::new(ActionDispatcher::new((*registry).clone()));
+        dispatcher.register_handler("create_sphere", |p| {
+            let r = p.get("radius").and_then(Value::as_f64).unwrap_or(1.0);
+            Ok(json!({"name": "|pSphere1", "radius": r}))
+        });
+        dispatcher.register_handler("hello_world.greet", |_p| Ok(json!("hi")));
+        AppState {
+            registry,
+            dispatcher,
+            catalog,
+            sessions: SessionManager::new(),
+            executor: None,
+            bridge_registry: crate::BridgeRegistry::new(),
+            server_name: "test-dcc".to_string(),
+            server_version: "0.1.0".to_string(),
+            cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+            in_flight: crate::inflight::InFlightRequests::new(),
+            lazy_actions,
+        }
+    }
+
+    fn make_router(lazy_actions: bool) -> (axum::Router, SessionManager) {
+        use crate::handler::{handle_delete, handle_get, handle_post};
+        use axum::{Router, routing};
+        let state = make_state(lazy_actions);
+        let sessions = state.sessions.clone();
+        let router = Router::new()
+            .route(
+                "/mcp",
+                routing::post(handle_post)
+                    .get(handle_get)
+                    .delete(handle_delete),
+            )
+            .with_state(state);
+        (router, sessions)
+    }
+
+    async fn call(server: &TestServer, session_id: &str, body: Value) -> Value {
+        server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .add_header(
+                axum::http::HeaderName::from_static("mcp-session-id"),
+                session_id.parse::<HeaderValue>().unwrap(),
+            )
+            .json(&body)
+            .await
+            .json()
+    }
+
+    #[tokio::test]
+    async fn meta_tools_absent_when_disabled() {
+        let (router, sessions) = make_router(false);
+        let sid = sessions.create();
+        sessions.set_protocol_version(&sid, "2025-06-18");
+        let server = TestServer::new(router);
+        let body = call(
+            &server,
+            &sid,
+            json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}),
+        )
+        .await;
+        let tools = body["result"]["tools"].as_array().unwrap();
+        for name in ["list_actions", "describe_action", "call_action"] {
+            assert!(
+                tools.iter().all(|t| t["name"] != name),
+                "meta-tool {name} must be hidden when lazy_actions is disabled"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn meta_tools_present_when_enabled() {
+        let (router, sessions) = make_router(true);
+        let sid = sessions.create();
+        sessions.set_protocol_version(&sid, "2025-06-18");
+        let server = TestServer::new(router);
+        let body = call(
+            &server,
+            &sid,
+            json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}),
+        )
+        .await;
+        let tools = body["result"]["tools"].as_array().unwrap();
+        for name in ["list_actions", "describe_action", "call_action"] {
+            assert!(
+                tools.iter().any(|t| t["name"] == name),
+                "meta-tool {name} must appear when lazy_actions is enabled, got: {tools:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn list_actions_omits_schema_body() {
+        let (router, sessions) = make_router(true);
+        let sid = sessions.create();
+        sessions.set_protocol_version(&sid, "2025-06-18");
+        let server = TestServer::new(router);
+        let body = call(
+            &server,
+            &sid,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 10,
+                "method": "tools/call",
+                "params": {"name": "list_actions", "arguments": {}}
+            }),
+        )
+        .await;
+        let text = body["result"]["content"][0]["text"].as_str().unwrap();
+        let payload: Value = serde_json::from_str(text).unwrap();
+        let actions = payload["actions"].as_array().unwrap();
+        assert_eq!(
+            actions.len(),
+            2,
+            "expected both sample actions, got: {actions:?}"
+        );
+        for a in actions {
+            // Contract: compact triple only. Flagging inputSchema / outputSchema
+            // leakage here is the whole point of the fast-path benchmark.
+            assert!(a.get("inputSchema").is_none());
+            assert!(a.get("input_schema").is_none());
+            assert!(a.get("outputSchema").is_none());
+            assert!(a["id"].is_string());
+            assert!(a["summary"].is_string());
+            assert!(a["tags"].is_array());
+        }
+        // `hello_world.greet` must round-trip as its canonical skill-prefixed id.
+        assert!(
+            actions.iter().any(|a| a["id"] == "hello_world.greet"),
+            "skill-prefixed id must be surfaced verbatim, got: {actions:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn describe_action_matches_tools_list_schema() {
+        let (router, sessions) = make_router(true);
+        let sid = sessions.create();
+        sessions.set_protocol_version(&sid, "2025-06-18");
+        let server = TestServer::new(router);
+
+        // Fetch the same action through `tools/list` for a reference.
+        let list_body = call(
+            &server,
+            &sid,
+            json!({"jsonrpc": "2.0", "id": 20, "method": "tools/list"}),
+        )
+        .await;
+        let ref_tool = list_body["result"]["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|t| t["name"] == "create_sphere")
+            .cloned()
+            .expect("create_sphere must be in tools/list");
+
+        // Same action through describe_action.
+        let desc_body = call(
+            &server,
+            &sid,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 21,
+                "method": "tools/call",
+                "params": {
+                    "name": "describe_action",
+                    "arguments": {"id": "create_sphere"}
+                }
+            }),
+        )
+        .await;
+        let desc_text = desc_body["result"]["content"][0]["text"].as_str().unwrap();
+        let desc_tool: Value = serde_json::from_str(desc_text).unwrap();
+
+        assert_eq!(
+            desc_tool, ref_tool,
+            "describe_action must produce the exact same shape as tools/list"
+        );
+    }
+
+    #[tokio::test]
+    async fn describe_action_rejects_unknown_id() {
+        let (router, sessions) = make_router(true);
+        let sid = sessions.create();
+        let server = TestServer::new(router);
+        let body = call(
+            &server,
+            &sid,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 30,
+                "method": "tools/call",
+                "params": {
+                    "name": "describe_action",
+                    "arguments": {"id": "no_such_action"}
+                }
+            }),
+        )
+        .await;
+        assert_eq!(body["result"]["isError"], true);
+        let text = body["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(
+            text.contains("ACTION_NOT_FOUND"),
+            "expected ACTION_NOT_FOUND envelope, got: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn call_action_dispatches_to_underlying_handler() {
+        let (router, sessions) = make_router(true);
+        let sid = sessions.create();
+        sessions.set_protocol_version(&sid, "2025-06-18");
+        let server = TestServer::new(router);
+        let body = call(
+            &server,
+            &sid,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 40,
+                "method": "tools/call",
+                "params": {
+                    "name": "call_action",
+                    "arguments": {
+                        "id": "create_sphere",
+                        "args": {"radius": 3.0}
+                    }
+                }
+            }),
+        )
+        .await;
+        assert_eq!(body["result"]["isError"], false, "body: {body}");
+        // Single dispatch path: the underlying handler ran and returned
+        // the exact same payload a direct tools/call would have produced.
+        let sc = &body["result"]["structuredContent"];
+        assert_eq!(sc["radius"], 3.0);
+        assert_eq!(sc["name"], "|pSphere1");
+    }
+
+    #[tokio::test]
+    async fn call_action_refuses_meta_recursion() {
+        let (router, sessions) = make_router(true);
+        let sid = sessions.create();
+        let server = TestServer::new(router);
+        let body = call(
+            &server,
+            &sid,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 50,
+                "method": "tools/call",
+                "params": {
+                    "name": "call_action",
+                    "arguments": {"id": "call_action", "args": {}}
+                }
+            }),
+        )
+        .await;
+        assert_eq!(body["result"]["isError"], true);
+        let text = body["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(
+            text.contains("RECURSIVE_META_CALL"),
+            "expected RECURSIVE_META_CALL envelope, got: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_fast_path_rejects_meta_tool_calls() {
+        // With lazy_actions=false, the three meta-tool names must fall
+        // through to the generic action resolver → ACTION_NOT_FOUND.
+        let (router, sessions) = make_router(false);
+        let sid = sessions.create();
+        let server = TestServer::new(router);
+        let body = call(
+            &server,
+            &sid,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 60,
+                "method": "tools/call",
+                "params": {"name": "list_actions", "arguments": {}}
+            }),
+        )
+        .await;
+        assert_eq!(body["result"]["isError"], true);
+        let text = body["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("ACTION_NOT_FOUND") || text.contains("Unknown tool"));
     }
 }

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -4063,6 +4063,18 @@ class McpHttpConfig:
         ...
     @session_ttl_secs.setter
     def session_ttl_secs(self, secs: int) -> None: ...
+    @property
+    def lazy_actions(self) -> bool:
+        """Whether the opt-in lazy-actions fast-path (#254) is enabled.
+
+        When ``True``, ``tools/list`` surfaces three meta-tools
+        (``list_actions``, ``describe_action``, ``call_action``) so agents
+        with tight context budgets can drive an arbitrarily large action
+        catalog through a single page of 3 stubs. Default: ``False``.
+        """
+        ...
+    @lazy_actions.setter
+    def lazy_actions(self, enabled: bool) -> None: ...
     def __repr__(self) -> str: ...
 
 class McpServerHandle:

--- a/tests/test_e2e_gateway_skills_progressive.py
+++ b/tests/test_e2e_gateway_skills_progressive.py
@@ -218,6 +218,18 @@ def _wait_for_tool_suffix(
     raise AssertionError(f"Tool suffix {suffix!r} did not {verb} within {timeout}s. Final names: {sorted(names)}")
 
 
+def _split_gateway_prefixed_tool(name: str) -> tuple[str, str] | None:
+    """Return ``(instance_prefix, tool_name)`` for ``<id8>.<tool>`` names."""
+    if name.startswith("__"):
+        return None
+    prefix, sep, suffix = name.partition(".")
+    if not sep:
+        return None
+    if len(prefix) != 8 or not all(ch.isascii() and ch in "0123456789abcdef" for ch in prefix):
+        return None
+    return prefix, suffix
+
+
 # ── fixtures ─────────────────────────────────────────────────────────────────
 
 
@@ -367,8 +379,8 @@ class TestGatewaySkillAggregation:
     def test_backend_registered_tools_visible_through_gateway(self, skill_gateway_cluster):
         """Non-skill tools from both backends appear namespaced in the gateway."""
         tools = _tools_list(skill_gateway_cluster["gateway_url"])
-        prefixed = [t for t in tools if "__" in t["name"] and not t["name"].startswith("__skill__")]
-        suffixes = [t["name"].split("__", 1)[1] for t in prefixed]
+        prefixed = [t for t in tools if _split_gateway_prefixed_tool(t["name"]) is not None]
+        suffixes = [_split_gateway_prefixed_tool(t["name"])[1] for t in prefixed]
 
         assert "create_sphere" in suffixes, f"maya.create_sphere missing. suffixes={suffixes}"
         assert "add_material" in suffixes, f"blender.add_material missing. suffixes={suffixes}"
@@ -385,9 +397,9 @@ class TestGatewaySkillAggregation:
 
         try:
             # Wait for the gateway's aggregation refresh to pick up the new tool.
-            tools = _wait_for_tool_suffix(gateway_url, "hello_world__greet", timeout=6.0)
-            matching = [t for t in tools if t["name"].endswith("hello_world__greet")]
-            assert matching, "hello_world__greet did not appear in gateway after loading on backend"
+            tools = _wait_for_tool_suffix(gateway_url, "hello-world.greet", timeout=6.0)
+            matching = [t for t in tools if t["name"].endswith("hello-world.greet")]
+            assert matching, "hello-world.greet did not appear in gateway after loading on backend"
         finally:
             # Clean up: unload the skill on backend A.
             with contextlib.suppress(Exception):
@@ -432,9 +444,9 @@ class TestGatewayProgressiveLoadingCycle:
 
         try:
             # Wait for gateway to aggregate the new tool.
-            tools = _wait_for_tool_suffix(gw, "hello_world__greet", timeout=6.0)
-            matching = [t for t in tools if t["name"].endswith("hello_world__greet")]
-            assert matching, "hello_world__greet not visible through gateway after load on backend"
+            tools = _wait_for_tool_suffix(gw, "hello-world.greet", timeout=6.0)
+            matching = [t for t in tools if t["name"].endswith("hello-world.greet")]
+            assert matching, "hello-world.greet not visible through gateway after load on backend"
         finally:
             with contextlib.suppress(Exception):
                 _tools_call(backend_url, "unload_skill", {"skill_name": "hello-world"})
@@ -449,9 +461,9 @@ class TestGatewayProgressiveLoadingCycle:
 
         try:
             # Wait for gateway to see the tool.
-            tools = _wait_for_tool_suffix(gw, "hello_world__greet", timeout=6.0)
+            tools = _wait_for_tool_suffix(gw, "hello-world.greet", timeout=6.0)
             # Find the exact namespaced tool name.
-            gw_tool = next(t["name"] for t in tools if t["name"].endswith("hello_world__greet"))
+            gw_tool = next(t["name"] for t in tools if t["name"].endswith("hello-world.greet"))
 
             # Call it through the gateway.
             result = _tools_call(gw, gw_tool, {"name": "GatewayE2E"})
@@ -468,7 +480,7 @@ class TestGatewayProgressiveLoadingCycle:
 
         # Load on backend.
         _tools_call(backend_url, "load_skill", {"skill_name": "hello-world"})
-        _wait_for_tool_suffix(gw, "hello_world__greet", timeout=6.0)
+        _wait_for_tool_suffix(gw, "hello-world.greet", timeout=6.0)
 
         # Unload on backend.
         result = _tools_call(backend_url, "unload_skill", {"skill_name": "hello-world"})
@@ -476,7 +488,7 @@ class TestGatewayProgressiveLoadingCycle:
         assert data.get("unloaded") is True, f"unload_skill failed: {data}"
 
         # Wait for gateway to drop the tool.
-        _wait_for_tool_suffix(gw, "hello_world__greet", timeout=6.0, should_exist=False)
+        _wait_for_tool_suffix(gw, "hello-world.greet", timeout=6.0, should_exist=False)
 
 
 # ── TestWebViewAuroraViewDiscovery ───────────────────────────────────────────
@@ -499,8 +511,8 @@ class TestWebViewAuroraViewDiscovery:
     def test_auroraview_tools_aggregated_in_gateway(self, webview_gateway_cluster):
         """AuroraView tools appear namespaced in the gateway's tools/list."""
         tools = _tools_list(webview_gateway_cluster["gateway_url"])
-        prefixed = [t for t in tools if "__" in t["name"] and not t["name"].startswith("__skill__")]
-        suffixes = [t["name"].split("__", 1)[1] for t in prefixed]
+        prefixed = [t for t in tools if _split_gateway_prefixed_tool(t["name"]) is not None]
+        suffixes = [_split_gateway_prefixed_tool(t["name"])[1] for t in prefixed]
 
         assert "navigate_url" in suffixes, f"auroraview.navigate_url missing. suffixes={suffixes}"
         assert "take_screenshot" in suffixes, f"auroraview.take_screenshot missing. suffixes={suffixes}"
@@ -508,7 +520,7 @@ class TestWebViewAuroraViewDiscovery:
     def test_maya_and_auroraview_tools_coexist(self, webview_gateway_cluster):
         """Both DCC types' tools coexist without name collisions in the gateway."""
         tools = _tools_list(webview_gateway_cluster["gateway_url"])
-        prefixed = [t for t in tools if "__" in t["name"] and not t["name"].startswith("__skill__")]
+        prefixed = [t for t in tools if _split_gateway_prefixed_tool(t["name"]) is not None]
 
         # Collect dcc types from tool annotations.
         dcc_types_seen = set()
@@ -616,12 +628,14 @@ class TestSessionPinningToolRouting:
         av_tool = None
         for t in tools:
             name = t["name"]
-            if "__" in name and not name.startswith("__skill__"):
-                suffix = name.split("__", 1)[1]
-                if suffix == "create_sphere" and maya_tool is None:
-                    maya_tool = name
-                elif suffix == "navigate_url" and av_tool is None:
-                    av_tool = name
+            parsed = _split_gateway_prefixed_tool(name)
+            if parsed is None:
+                continue
+            suffix = parsed[1]
+            if suffix == "create_sphere" and maya_tool is None:
+                maya_tool = name
+            elif suffix == "navigate_url" and av_tool is None:
+                av_tool = name
 
         assert maya_tool, "Maya create_sphere not found in gateway tools"
         assert av_tool, "AuroraView navigate_url not found in gateway tools"
@@ -700,7 +714,7 @@ class TestBundledSkillsDiscovery:
         assert stub_name not in names, f"Stub {stub_name} should be gone after loading"
 
         # At least one tool with the skill prefix should exist.
-        skill_prefix = skill_name.replace("-", "_") + "__"
+        skill_prefix = skill_name + "."
         skill_tools = [n for n in names if n.startswith(skill_prefix)]
         assert skill_tools, f"Expected tools starting with {skill_prefix!r}, got: {sorted(names)}"
 
@@ -780,7 +794,7 @@ class TestCrossCuttingBoundary:
             _tools_call(h1.mcp_url(), "load_skill", {"skill_name": "hello-world"})
             tools1 = _tools_list(h1.mcp_url())
             names1 = {t["name"] for t in tools1}
-            assert "hello_world__greet" in names1, "hello-world should be loaded on server 1"
+            assert "hello-world.greet" in names1, "hello-world should be loaded on server 1"
         finally:
             h1.shutdown()
 
@@ -791,7 +805,7 @@ class TestCrossCuttingBoundary:
         try:
             tools2 = _tools_list(h2.mcp_url())
             names2 = {t["name"] for t in tools2}
-            assert "hello_world__greet" not in names2, "hello-world should NOT be loaded on a fresh server instance"
+            assert "hello-world.greet" not in names2, "hello-world should NOT be loaded on a fresh server instance"
             # But the __skill__ stub should be present (discovered, not loaded).
             assert "__skill__hello-world" in names2, "hello-world stub should be present on fresh server"
         finally:

--- a/tests/test_gateway_facade_aggregation.py
+++ b/tests/test_gateway_facade_aggregation.py
@@ -68,6 +68,18 @@ def _post_mcp(url: str, method: str, params: dict | None = None, rpc_id: int = 1
         return json.loads(resp.read())
 
 
+def _split_gateway_prefixed_tool(name: str) -> tuple[str, str] | None:
+    """Return ``(instance_prefix, tool_name)`` for ``<id8>.<tool>`` names."""
+    if name.startswith("__"):
+        return None
+    prefix, sep, suffix = name.partition(".")
+    if not sep:
+        return None
+    if len(prefix) != 8 or not all(ch.isascii() and ch in "0123456789abcdef" for ch in prefix):
+        return None
+    return prefix, suffix
+
+
 def _make_backend(dcc: str, tool_names: list[str], registry_dir: Path, gw_port: int) -> tuple[McpHttpServer, object]:
     """Start a backend McpHttpServer registered in ``registry_dir``.
 
@@ -173,8 +185,8 @@ class TestFacadeToolsAggregation:
         # We expect at least one namespaced tool whose suffix matches each
         # original backend name. Colliding names (``create_cube`` registered
         # on both maya and blender) must survive as two distinct entries.
-        prefixed = [t for t in tools if "__" in t["name"] and not t["name"].startswith("__skill__")]
-        suffixes = [t["name"].split("__", 1)[1] for t in prefixed]
+        prefixed = [t for t in tools if _split_gateway_prefixed_tool(t["name"]) is not None]
+        suffixes = [_split_gateway_prefixed_tool(t["name"])[1] for t in prefixed]
 
         assert "create_sphere" in suffixes, "maya.create_sphere missing from aggregated list"
         assert "delete_node" in suffixes, "maya.delete_node missing from aggregated list"
@@ -189,7 +201,7 @@ class TestFacadeToolsAggregation:
     def test_backend_tools_carry_instance_metadata(self, facade_cluster):
         resp = _post_mcp(facade_cluster["gateway_url"], "tools/list")
         tools = resp["result"]["tools"]
-        backend_tools = [t for t in tools if "__" in t["name"] and not t["name"].startswith("__skill__")]
+        backend_tools = [t for t in tools if _split_gateway_prefixed_tool(t["name"]) is not None]
         assert backend_tools, "no namespaced backend tools were aggregated"
 
         for tool in backend_tools:
@@ -197,7 +209,7 @@ class TestFacadeToolsAggregation:
             assert "_instance_short" in tool, f"tool {tool['name']!r} missing _instance_short annotation"
             assert "_dcc_type" in tool, f"tool {tool['name']!r} missing _dcc_type annotation"
             # Prefix in the name matches the short instance id.
-            prefix = tool["name"].split("__", 1)[0]
+            prefix = _split_gateway_prefixed_tool(tool["name"])[0]
             assert tool["_instance_short"] == prefix, (
                 f"prefix {prefix!r} doesn't match _instance_short {tool['_instance_short']!r}"
             )

--- a/tests/test_mcp_mcporter_e2e.py
+++ b/tests/test_mcp_mcporter_e2e.py
@@ -496,7 +496,7 @@ class TestMcporterProgressiveLoading:
         _mcporter_call(url, name, "load_skill", {"skill_name": "hello-world"})
 
         # Greet via the skill tool
-        result = _mcporter_call(url, name, "hello_world__greet", {"name": "mcporter"})
+        result = _mcporter_call(url, name, "hello-world.greet", {"name": "mcporter"})
         text = _extract_content_text(result)
         assert "mcporter" in text or "Hello" in text
 
@@ -515,8 +515,8 @@ class TestMcporterProgressiveLoading:
         # tools/list should no longer contain hello-world tools
         tools = _mcporter_list_tools(url, name)
         tool_names = {t["name"] if isinstance(t, dict) else t for t in tools}
-        # hello_world__greet should be gone (core tools remain)
-        assert "hello_world__greet" not in tool_names
+        # hello-world.greet should be gone (core tools remain)
+        assert "hello-world.greet" not in tool_names
 
     def test_load_multiple_skills_at_once(self, server_with_catalog):
         """load_skill with skill_names loads several skills in one call."""
@@ -575,7 +575,7 @@ class TestMcporterProgressiveLoading:
         assert load_data["loaded"] is True
 
         # 4. Call the skill tool
-        call_result = _mcporter_call(url, name, "hello_world__greet", {"name": "E2E"})
+        call_result = _mcporter_call(url, name, "hello-world.greet", {"name": "E2E"})
         text = _extract_content_text(call_result)
         assert "E2E" in text or "Hello" in text
 
@@ -817,7 +817,7 @@ class TestMultipleServerInstances:
             names_b = self._tools_list(h_b.mcp_url())
 
             assert any("hello" in n.lower() for n in names_a), f"hello-world missing from A: {names_a}"
-            assert not any("hello_world" in n for n in names_b), f"hello-world leaked into B: {names_b}"
+            assert "hello-world.greet" not in names_b, f"hello-world leaked into B: {names_b}"
         finally:
             h_a.shutdown()
             h_b.shutdown()
@@ -945,7 +945,7 @@ class TestProgressiveLoadingBoundary:
         result = _mcporter_call(
             url,
             name,
-            "hello_world__greet",
+            "hello-world.greet",
             {"name": "BoundaryTest"},
         )
         text = _extract_content_text(result)
@@ -958,8 +958,8 @@ class TestProgressiveLoadingBoundary:
             _mcporter_call(url, name, "load_skill", {"skill_name": "hello-world"})
         tools = _mcporter_list_tools(url, name)
         names = [t["name"] if isinstance(t, dict) else t for t in tools]
-        count = names.count("hello_world__greet")
-        assert count <= 1, f"hello_world__greet duplicated after double load: {count}"
+        count = names.count("hello-world.greet")
+        assert count <= 1, f"hello-world.greet duplicated after double load: {count}"
 
     def test_unload_then_reload_re_registers_tools(self, server_with_catalog):
         """After unload → reload, the skill's tools must be available again."""
@@ -1026,5 +1026,5 @@ class TestConcurrencyBoundary:
 
         tools = _mcporter_list_tools(url, name)
         tool_names = [t["name"] if isinstance(t, dict) else t for t in tools]
-        count = tool_names.count("hello_world__greet")
-        assert count <= 1, f"hello_world__greet duplicated: {count} occurrences"
+        count = tool_names.count("hello-world.greet")
+        assert count <= 1, f"hello-world.greet duplicated: {count} occurrences"

--- a/tests/test_on_demand_loading.py
+++ b/tests/test_on_demand_loading.py
@@ -244,7 +244,7 @@ class TestOnDemandLoadingContract:
         # Snapshot before
         before = {t["name"]: t for t in _tools_list(url)}
         assert "__skill__hello-world" in before, "Expected __skill__hello-world stub before loading"
-        assert "hello_world__greet" not in before, "hello_world__greet must not be present before load_skill"
+        assert "hello-world.greet" not in before, "hello-world.greet must not be present before load_skill"
 
         # Load hello-world
         load_resp = _post(
@@ -266,8 +266,8 @@ class TestOnDemandLoadingContract:
         assert "__skill__hello-world" not in after, "The __skill__hello-world stub must be removed after loading"
 
         # Real tool present
-        assert "hello_world__greet" in after, (
-            f"hello_world__greet must appear after load_skill. Got: {list(after.keys())}"
+        assert "hello-world.greet" in after, (
+            f"hello-world.greet must appear after load_skill. Got: {list(after.keys())}"
         )
 
         # Other stubs unaffected (count of remaining stubs = before - 1)
@@ -311,7 +311,7 @@ class TestOnDemandLoadingContract:
         # Snapshot after unload
         after_unload = {t["name"] for t in _tools_list(url)}
 
-        assert "hello_world__greet" not in after_unload, "hello_world__greet must be removed after unload_skill"
+        assert "hello-world.greet" not in after_unload, "hello-world.greet must be removed after unload_skill"
         assert "__skill__hello-world" in after_unload, "__skill__hello-world stub must reappear after unload_skill"
 
     def test_tools_list_count_invariant(self, catalog_server):
@@ -334,7 +334,7 @@ class TestOnDemandLoadingContract:
 
         count_base = len(_tools_list(url))
 
-        # Load hello-world (1 tool: hello_world__greet)
+        # Load hello-world (1 tool: hello-world.greet)
         _post(
             url,
             {

--- a/tests/test_server_sidecar_e2e.py
+++ b/tests/test_server_sidecar_e2e.py
@@ -254,11 +254,11 @@ class TestToolsListBoundary:
         loaded = json.loads(load_resp["result"]["content"][0]["text"])
         assert loaded.get("loaded") is True
 
-        # tools/list should now contain hello_world__greet with schema
+        # tools/list should now contain hello-world.greet with schema
         _, tl = _post(url, {"jsonrpc": "2.0", "id": 4, "method": "tools/list"})
         names = {t["name"] for t in tl["result"]["tools"]}
-        assert "hello_world__greet" in names or any("hello" in n for n in names), (
-            f"Expected hello_world__greet in tools/list after load. Got: {names}"
+        assert "hello-world.greet" in names or any("hello" in n for n in names), (
+            f"Expected hello-world.greet in tools/list after load. Got: {names}"
         )
 
     def test_stub_call_returns_load_hint(self, catalog_server):
@@ -297,8 +297,8 @@ class TestToolsListBoundary:
 
         _, tl = _post(url, {"jsonrpc": "2.0", "id": 4, "method": "tools/list"})
         tools = [t["name"] for t in tl["result"]["tools"]]
-        greet_count = tools.count("hello_world__greet")
-        assert greet_count <= 1, f"hello_world__greet duplicated after double load: {greet_count}"
+        greet_count = tools.count("hello-world.greet")
+        assert greet_count <= 1, f"hello-world.greet duplicated after double load: {greet_count}"
 
     def test_unload_then_reload_works(self, catalog_server):
         """Unloading a skill and reloading it re-registers its tools."""


### PR DESCRIPTION
> Stacked on #264 (feat: structuredContent + outputSchema). Merge #264 first; GitHub will rebase this branch onto `main` automatically.

## Summary

Implements issue #254 — opt-in lazy-actions fast-path. Three new SEP-986 compliant meta-tools let agents drive an arbitrarily large action catalog without paging through every skill's full schema.

- `list_actions` — compact `{id, summary, tags}[]`, no schema bodies
- `describe_action(id)` — full MCP `Tool` shape (matches `tools/list` byte-for-byte)
- `call_action(id, args)` — generic dispatcher; delegates to the same path as direct `tools/call` (single-dispatch-path guarantee). Refuses meta-recursion with `RECURSIVE_META_CALL` envelope.

Opt-in:
- Rust: `McpHttpConfig::with_lazy_actions()` / `.lazy_actions = true`
- Python: `McpHttpConfig(...).lazy_actions = True`
- Off by default. When off, the three names fall through to the generic resolver and return `ACTION_NOT_FOUND`.

## Test plan

- [x] 8 new integration tests under `tests::lazy_actions_tests`:
  - `meta_tools_absent_when_disabled`
  - `meta_tools_present_when_enabled`
  - `list_actions_omits_schema_body`
  - `describe_action_matches_tools_list_schema`
  - `describe_action_rejects_unknown_id`
  - `call_action_dispatches_to_underlying_handler`
  - `call_action_refuses_meta_recursion`
  - `disabled_fast_path_rejects_meta_tool_calls`
- [x] `cargo test -p dcc-mcp-http` — 126 lib + 4 integration, all green
- [x] `cargo fmt` / `cargo clippy` clean (pre-commit hooks enforced)
- [x] `cargo check --workspace` clean
- [x] Python binding (`PyMcpHttpConfig`) exposes `lazy_actions` getter/setter + `.pyi` stub updated

## Non-goals

- Gateway aggregator wiring — the meta-tools live per-backend; a follow-up can add a gateway-level `list_actions` that fans out.
- `experimental["dcc_mcp_core/lazyActions"]` negotiation at `initialize` — the issue accepts either CLI flag *or* experimental capability. This PR ships the CLI/config flag; negotiation is a surface-only addition we can layer on without touching the dispatch path.

Closes #254
