### PR TITLE
feat(http): add 2025-06-18 elicitation create flow

### DIFF
--- a/crates/dcc-mcp-http/src/handler.rs
+++ b/crates/dcc-mcp-http/src/handler.rs
@@ -17,6 +17,7 @@ use serde_json::{Value, json};
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 use tokio::sync::broadcast;
+use tokio::sync::oneshot;
 use tokio_stream::StreamExt;
 use tokio_stream::wrappers::BroadcastStream;
 
@@ -27,10 +28,11 @@ use crate::{
     inflight::{CancelToken, InFlightEntry, InFlightRequests, ProgressReporter},
     protocol::{
         self, CallToolParams, CallToolResult, DELTA_TOOLS_METHOD, DELTA_TOOLS_UPDATE_CAP,
-        InitializeResult, JsonRpcBatch, JsonRpcMessage, JsonRpcRequest, JsonRpcResponse,
-        ListToolsResult, MCP_SESSION_HEADER, McpTool, McpToolAnnotations, ServerCapabilities,
-        ServerInfo, TOOLS_LIST_PAGE_SIZE, ToolsCapability, decode_cursor, encode_cursor,
-        format_sse_event, negotiate_protocol_version,
+        ElicitationCapability, ElicitationCreateParams, ElicitationCreateResult, InitializeResult,
+        JsonRpcBatch, JsonRpcMessage, JsonRpcRequest, JsonRpcResponse, ListToolsResult,
+        MCP_SESSION_HEADER, McpTool, McpToolAnnotations, ServerCapabilities, ServerInfo,
+        TOOLS_LIST_PAGE_SIZE, ToolsCapability, decode_cursor, encode_cursor, format_sse_event,
+        negotiate_protocol_version,
     },
     session::SessionManager,
 };
@@ -47,6 +49,7 @@ use crate::gateway::namespace::{decode_skill_tool_name, extract_bare_tool_name, 
 /// completed (common race condition), the entry would never be consumed by the
 /// check in `handle_tools_call`.  This TTL bounds memory growth from such entries.
 const CANCELLED_REQUEST_TTL: Duration = Duration::from_secs(30);
+const ELICITATION_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Shared application state passed to all axum handlers.
 #[derive(Clone)]
@@ -69,6 +72,8 @@ pub struct AppState {
     /// every 60 seconds to keep this map bounded.
     pub cancelled_requests: Arc<DashMap<String, Instant>>,
     pub in_flight: InFlightRequests,
+    /// Pending `elicitation/create` requests keyed by the elicitation request id.
+    pub pending_elicitations: Arc<DashMap<String, oneshot::Sender<ElicitationCreateResult>>>,
     /// When `true`, `tools/list` surfaces the three lazy-action meta-tools
     /// (`list_actions`, `describe_action`, `call_action`) and the dispatcher
     /// accepts them. See [`crate::McpHttpConfig::lazy_actions`] (#254).
@@ -132,6 +137,13 @@ pub async fn handle_post(
     for msg in &messages {
         if let JsonRpcMessage::Notification(notif) = msg {
             handle_notification(&state, &notif.method, notif.params.as_ref()).await;
+        }
+    }
+    // Client responses to server-initiated elicitation requests arrive as
+    // JSON-RPC responses. Correlate and wake the waiting oneshot channel.
+    for msg in &messages {
+        if let JsonRpcMessage::Response(resp) = msg {
+            handle_response_message(&state, resp);
         }
     }
 
@@ -299,6 +311,35 @@ async fn handle_notification(state: &AppState, method: &str, params: Option<&Val
     }
 }
 
+fn handle_response_message(state: &AppState, resp: &JsonRpcResponse) {
+    let id = match &resp.id {
+        Some(Value::String(s)) => s.clone(),
+        Some(Value::Number(n)) => n.to_string(),
+        Some(other) => serde_json::to_string(other).unwrap_or_default(),
+        None => return,
+    };
+    if id.is_empty() {
+        return;
+    }
+    let Some((_, tx)) = state.pending_elicitations.remove(&id) else {
+        return;
+    };
+    let resolved = if let Some(result) = resp.result.clone() {
+        serde_json::from_value::<ElicitationCreateResult>(result).unwrap_or(
+            ElicitationCreateResult {
+                action: "decline".to_string(),
+                content: None,
+            },
+        )
+    } else {
+        ElicitationCreateResult {
+            action: "decline".to_string(),
+            content: None,
+        }
+    };
+    let _ = tx.send(resolved);
+}
+
 // ── Method dispatch ───────────────────────────────────────────────────────
 
 async fn dispatch_request(
@@ -315,6 +356,7 @@ async fn dispatch_request(
         "notifications/initialized" => Ok(JsonRpcResponse::success(req.id.clone(), json!({}))),
         "tools/list" => handle_tools_list(state, req, session_id).await,
         "tools/call" => handle_tools_call(state, req, session_id).await,
+        "elicitation/create" => handle_elicitation_create(state, req, session_id).await,
         "ping" => Ok(JsonRpcResponse::success(req.id.clone(), json!({}))),
         other => Ok(JsonRpcResponse::method_not_found(req.id.clone(), other)),
     }
@@ -367,12 +409,19 @@ async fn handle_initialize(
         None
     };
 
+    let elicitation_cap = if negotiated == "2025-06-18" {
+        Some(ElicitationCapability::default())
+    } else {
+        None
+    };
+
     let result = InitializeResult {
         protocol_version: negotiated.to_string(),
         capabilities: ServerCapabilities {
             tools: Some(ToolsCapability { list_changed: true }),
             resources: None,
             prompts: None,
+            elicitation: elicitation_cap,
             experimental: experimental_caps,
         },
         server_info: ServerInfo {
@@ -394,6 +443,97 @@ async fn handle_initialize(
         obj.insert("__session_id".to_string(), Value::String(sid));
     }
     Ok(resp)
+}
+
+async fn handle_elicitation_create(
+    state: &AppState,
+    req: &JsonRpcRequest,
+    session_id: Option<&str>,
+) -> Result<JsonRpcResponse, HttpError> {
+    // Spec gate: only exposed on 2025-06-18 sessions.
+    let is_2025_06_18 = session_id
+        .and_then(|sid| state.sessions.get_protocol_version(sid))
+        .as_deref()
+        == Some("2025-06-18");
+    if !is_2025_06_18 {
+        return Ok(JsonRpcResponse::method_not_found(
+            req.id.clone(),
+            "elicitation/create",
+        ));
+    }
+    let sid = match session_id {
+        Some(s) => s,
+        None => {
+            return Err(HttpError::Internal(
+                "elicitation/create requires Mcp-Session-Id".to_string(),
+            ));
+        }
+    };
+    let elicit_id = req.id.clone().ok_or_else(|| {
+        HttpError::Internal("elicitation/create requires a JSON-RPC request id".to_string())
+    })?;
+    let req_id = match &elicit_id {
+        Value::String(s) => s.clone(),
+        Value::Number(n) => n.to_string(),
+        other => serde_json::to_string(other).unwrap_or_default(),
+    };
+    if req_id.is_empty() {
+        return Err(HttpError::Internal(
+            "elicitation/create request id cannot be empty".to_string(),
+        ));
+    }
+
+    let params: ElicitationCreateParams = req
+        .params
+        .as_ref()
+        .and_then(|p| serde_json::from_value(p.clone()).ok())
+        .ok_or_else(|| HttpError::Internal("invalid elicitation/create params".to_string()))?;
+
+    let (tx, rx) = oneshot::channel::<ElicitationCreateResult>();
+    state.pending_elicitations.insert(req_id.clone(), tx);
+
+    let notification = json!({
+        "jsonrpc": "2.0",
+        "method": "elicitation/create",
+        "params": {
+            "id": elicit_id,
+            "message": params.message,
+            "requestedSchema": params.requested_schema,
+        }
+    });
+    let event = format_sse_event(&notification, None);
+    state.sessions.push_event(sid, event);
+
+    let waited = tokio::time::timeout(ELICITATION_TIMEOUT, rx).await;
+    state.pending_elicitations.remove(&req_id);
+
+    let result = match waited {
+        Ok(Ok(value)) => value,
+        Ok(Err(_)) => ElicitationCreateResult {
+            action: "decline".to_string(),
+            content: None,
+        },
+        Err(_) => {
+            let envelope = DccMcpError::new(
+                "dcc",
+                "ELICITATION_TIMEOUT",
+                format!(
+                    "Client did not answer elicitation request {req_id} within {} seconds.",
+                    ELICITATION_TIMEOUT.as_secs()
+                ),
+            )
+            .with_hint("Ask the user again or proceed with a conservative default.");
+            return Ok(JsonRpcResponse::success(
+                req.id.clone(),
+                serde_json::to_value(CallToolResult::error(envelope.to_json()))?,
+            ));
+        }
+    };
+
+    Ok(JsonRpcResponse::success(
+        req.id.clone(),
+        serde_json::to_value(result)?,
+    ))
 }
 
 async fn handle_tools_list(

--- a/crates/dcc-mcp-http/src/protocol.rs
+++ b/crates/dcc-mcp-http/src/protocol.rs
@@ -36,6 +36,9 @@ pub const DELTA_TOOLS_UPDATE_CAP: &str = "dcc_mcp_core/deltaToolsUpdate";
 /// Method name for vendored delta tools update notifications.
 pub const DELTA_TOOLS_METHOD: &str = "notifications/tools/delta";
 
+/// Method name for server-initiated user elicitation.
+pub const ELICITATION_CREATE_METHOD: &str = "elicitation/create";
+
 /// Number of tools returned per `tools/list` page.
 pub const TOOLS_LIST_PAGE_SIZE: usize = 32;
 
@@ -175,6 +178,11 @@ pub struct ServerCapabilities {
     pub resources: Option<ResourcesCapability>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prompts: Option<PromptsCapability>,
+    /// Client-side elicitation support (MCP 2025-06-18).
+    ///
+    /// The server includes this field only on 2025-06-18 sessions.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub elicitation: Option<ElicitationCapability>,
     /// Vendor-extension capabilities echoed back to the client.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub experimental: Option<Value>,
@@ -197,6 +205,26 @@ pub struct ResourcesCapability {
 #[serde(rename_all = "camelCase")]
 pub struct PromptsCapability {
     pub list_changed: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ElicitationCapability {}
+
+/// Request params for `elicitation/create`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ElicitationCreateParams {
+    pub message: String,
+    pub requested_schema: Value,
+}
+
+/// Result payload returned by client for `elicitation/create`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ElicitationCreateResult {
+    pub action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/dcc-mcp-http/src/server.rs
+++ b/crates/dcc-mcp-http/src/server.rs
@@ -182,6 +182,7 @@ impl McpHttpServer {
             server_version: self.config.server_version.clone(),
             cancelled_requests,
             in_flight: InFlightRequests::new(),
+            pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
             lazy_actions: self.config.lazy_actions,
         };
 

--- a/crates/dcc-mcp-http/src/tests.rs
+++ b/crates/dcc-mcp-http/src/tests.rs
@@ -52,6 +52,7 @@ mod tests {
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
             in_flight: crate::inflight::InFlightRequests::new(),
+            pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
             lazy_actions: false,
         }
     }
@@ -72,6 +73,207 @@ mod tests {
     }
 
     // ── initialize ────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_initialize_advertises_elicitation_for_2025_06_18_only() {
+        let server = TestServer::new(make_router());
+
+        let init_2025_06_18 = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 101,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test-client", "version": "1.0"}
+                }
+            }))
+            .await;
+        init_2025_06_18.assert_status_ok();
+        let body_2025_06_18: Value = init_2025_06_18.json();
+        assert!(
+            body_2025_06_18["result"]["capabilities"]["elicitation"].is_object(),
+            "2025-06-18 initialize must advertise elicitation capability"
+        );
+
+        let init_2025_03_26 = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 102,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test-client", "version": "1.0"}
+                }
+            }))
+            .await;
+        init_2025_03_26.assert_status_ok();
+        let body_2025_03_26: Value = init_2025_03_26.json();
+        assert!(
+            body_2025_03_26["result"]["capabilities"]
+                .get("elicitation")
+                .is_none(),
+            "2025-03-26 initialize must not advertise elicitation capability"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_elicitation_create_requires_2025_06_18() {
+        let server = TestServer::new(make_router());
+        let session_id = "elicitation-gate-session";
+
+        // Negotiate 2025-03-26 first.
+        let init = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .add_header(
+                axum::http::HeaderName::from_static("mcp-session-id"),
+                session_id.parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 201,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test-client", "version": "1.0"}
+                }
+            }))
+            .await;
+        init.assert_status_ok();
+
+        let resp = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .add_header(
+                axum::http::HeaderName::from_static("mcp-session-id"),
+                session_id.parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 202,
+                "method": "elicitation/create",
+                "params": {
+                    "message": "confirm destructive action?",
+                    "requestedSchema": {
+                        "type": "object",
+                        "properties": {
+                            "confirm": {"type": "boolean"}
+                        },
+                        "required": ["confirm"]
+                    }
+                }
+            }))
+            .await;
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        let err = body["error"]
+            .as_object()
+            .expect("must return method-not-found error");
+        assert_eq!(err["code"], -32601);
+    }
+
+    #[tokio::test]
+    async fn test_elicitation_create_roundtrip_via_sse_response() {
+        let registry = Arc::new(make_registry());
+        let config = McpHttpConfig::new(0);
+        let server = McpHttpServer::new(registry, config);
+        let handle = server.start().await.unwrap();
+        let mcp_url = format!("http://{}{}/", handle.bind_addr, "/mcp");
+        let mcp_url = mcp_url.trim_end_matches('/').to_string();
+        let client = reqwest::Client::new();
+
+        let init_resp = client
+            .post(&mcp_url)
+            .header("Accept", "application/json")
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 201,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test-client", "version": "1.0"}
+                }
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert!(init_resp.status().is_success());
+        let init_body: Value = init_resp.json().await.unwrap();
+        let session_id = init_body["result"]["__session_id"]
+            .as_str()
+            .map(str::to_owned)
+            .expect("initialize must return __session_id");
+
+        let responder_client = client.clone();
+        let responder_url = mcp_url.clone();
+        let sid_clone = session_id.clone();
+        let responder = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            let _ = responder_client
+                .post(&responder_url)
+                .header("Accept", "application/json")
+                .header("Mcp-Session-Id", sid_clone)
+                .json(&json!({
+                    "jsonrpc": "2.0",
+                    "id": 9001,
+                    "result": {
+                        "action": "accept",
+                        "content": {"confirmed": true}
+                    }
+                }))
+                .send()
+                .await;
+        });
+
+        let call_resp = client
+            .post(&mcp_url)
+            .header("Accept", "application/json")
+            .header("Mcp-Session-Id", session_id)
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 9001,
+                "method": "elicitation/create",
+                "params": {
+                    "message": "Proceed with destructive operation?",
+                    "requestedSchema": {
+                        "type": "object",
+                        "properties": {"confirmed": {"type": "boolean"}},
+                        "required": ["confirmed"]
+                    }
+                }
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert!(call_resp.status().is_success());
+        let body: Value = call_resp.json().await.unwrap();
+        assert_eq!(body["result"]["action"], "accept");
+        assert_eq!(body["result"]["content"]["confirmed"], true);
+
+        responder.await.unwrap();
+        handle.shutdown().await;
+    }
 
     #[tokio::test]
     async fn test_initialize() {
@@ -201,6 +403,7 @@ mod tests {
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
             in_flight: crate::inflight::InFlightRequests::new(),
+            pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
             lazy_actions: false,
         }
     }
@@ -963,6 +1166,7 @@ mod tests {
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
             in_flight: crate::inflight::InFlightRequests::new(),
+            pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
             lazy_actions: false,
         }
     }
@@ -1327,6 +1531,7 @@ mod tests {
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
             in_flight: crate::inflight::InFlightRequests::new(),
+            pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
             lazy_actions: false,
         }
     }
@@ -1429,6 +1634,7 @@ mod tests {
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
             in_flight: crate::inflight::InFlightRequests::new(),
+            pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
             lazy_actions: false,
         };
 
@@ -1655,6 +1861,7 @@ mod tests {
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
             in_flight: crate::inflight::InFlightRequests::new(),
+            pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
             lazy_actions: false,
         }
     }
@@ -2215,6 +2422,7 @@ mod resource_link_integration_tests {
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
             in_flight: crate::inflight::InFlightRequests::new(),
+            pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
             lazy_actions: false,
         }
     }
@@ -2398,6 +2606,7 @@ mod resource_link_integration_tests {
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
             in_flight: crate::inflight::InFlightRequests::new(),
+            pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
             lazy_actions: false,
         }
     }
@@ -2674,6 +2883,7 @@ mod lazy_actions_tests {
             server_version: "0.1.0".to_string(),
             cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
             in_flight: crate::inflight::InFlightRequests::new(),
+            pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
             lazy_actions,
         }
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add MCP protocol structs for `elicitation/create` and server capability negotiation
- extend HTTP app state with pending elicitation request tracking
- handle `elicitation/create` requests with protocol/version gating and timeout behavior
- correlate client JSON-RPC responses back to pending elicitation requests
- add tests for capability advertisement, method gating, and end-to-end roundtrip behavior

## Testing
- `vx run -- fmt`
- `vx run -- test-rust`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-940a7817-6e43-4f8d-a13b-116354e22eb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-940a7817-6e43-4f8d-a13b-116354e22eb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

