### PR TITLE
feat(http): add roots cache and list_roots meta tool

### DIFF
--- a/crates/dcc-mcp-http/src/handler.rs
+++ b/crates/dcc-mcp-http/src/handler.rs
@@ -49,6 +49,7 @@ use crate::gateway::namespace::{decode_skill_tool_name, extract_bare_tool_name, 
 /// completed (common race condition), the entry would never be consumed by the
 /// check in `handle_tools_call`.  This TTL bounds memory growth from such entries.
 const CANCELLED_REQUEST_TTL: Duration = Duration::from_secs(30);
+const ROOTS_REFRESH_TIMEOUT: Duration = Duration::from_secs(2);
 const ELICITATION_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Shared application state passed to all axum handlers.
@@ -303,6 +304,35 @@ async fn handle_notification(state: &AppState, method: &str, params: Option<&Val
                 }
             }
         }
+        "notifications/roots/list_changed" => {
+            let sid = params
+                .and_then(|p| p.get("sessionId"))
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            if sid.is_empty() {
+                tracing::debug!(
+                    "received notifications/roots/list_changed without sessionId; ignoring"
+                );
+                return;
+            }
+            if !state.sessions.supports_roots(sid) {
+                tracing::debug!(
+                    session_id = sid,
+                    "ignoring roots/list_changed for session without roots support"
+                );
+                return;
+            }
+            let sid_owned = sid.to_string();
+            let sessions = state.sessions.clone();
+            tokio::spawn(async move {
+                let refreshed = refresh_roots_cache_for_session(&sessions, &sid_owned).await;
+                tracing::debug!(
+                    session_id = sid_owned,
+                    root_count = refreshed.len(),
+                    "refreshed roots cache from roots/list_changed notification"
+                );
+            });
+        }
         // Already handled as a request-shaped message; safe to ignore here.
         "notifications/initialized" => {}
         other => {
@@ -403,6 +433,24 @@ async fn handle_initialize(
     state
         .sessions
         .set_supports_delta_tools(&sid, client_wants_delta);
+
+    // Negotiate MCP roots capability (2025-03-26+).
+    let client_supports_roots = req
+        .params
+        .as_ref()
+        .and_then(|p| p.get("capabilities"))
+        .and_then(|c| c.get("roots"))
+        .is_some();
+    state
+        .sessions
+        .set_supports_roots(&sid, client_supports_roots);
+    if client_supports_roots {
+        let sessions = state.sessions.clone();
+        let sid_owned = sid.clone();
+        tokio::spawn(async move {
+            let _ = refresh_roots_cache_for_session(&sessions, &sid_owned).await;
+        });
+    }
 
     let experimental_caps = if client_wants_delta {
         Some(json!({ DELTA_TOOLS_UPDATE_CAP: { "enabled": true } }))
@@ -698,6 +746,7 @@ async fn handle_tools_call(
 
     // Route core discovery tools
     match tool_name.as_str() {
+        "list_roots" => return handle_list_roots(state, req, session_id).await,
         "find_skills" => return handle_find_skills(state, req, &params).await,
         "list_skills" => return handle_list_skills(state, req, &params).await,
         "get_skill_info" => return handle_get_skill_info(state, req, &params).await,
@@ -1063,6 +1112,33 @@ async fn handle_tools_call(
     ))
 }
 
+async fn handle_list_roots(
+    state: &AppState,
+    req: &JsonRpcRequest,
+    session_id: Option<&str>,
+) -> Result<JsonRpcResponse, HttpError> {
+    let Some(sid) = session_id else {
+        return Ok(JsonRpcResponse::success(
+            req.id.clone(),
+            serde_json::to_value(CallToolResult::error(
+                "list_roots requires Mcp-Session-Id header",
+            ))?,
+        ));
+    };
+    let roots = state.sessions.get_client_roots(sid);
+    let payload = json!({
+        "supports_roots": state.sessions.supports_roots(sid),
+        "count": roots.len(),
+        "roots": roots,
+    });
+    Ok(JsonRpcResponse::success(
+        req.id.clone(),
+        serde_json::to_value(CallToolResult::text(serde_json::to_string_pretty(
+            &payload,
+        )?))?,
+    ))
+}
+
 // ── Core discovery tool handlers ──────────────────────────────────────────
 
 async fn handle_find_skills(
@@ -1362,6 +1438,24 @@ fn build_core_tools() -> &'static [McpTool] {
 /// Inner builder — called exactly once per process lifetime.
 fn build_core_tools_inner() -> Vec<McpTool> {
     vec![
+        McpTool {
+            name: "list_roots".to_string(),
+            description: "Return client-advertised filesystem roots cached from roots/list for this session."
+                .to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {}
+            }),
+            output_schema: None,
+            annotations: Some(McpToolAnnotations {
+                title: Some("List Roots".to_string()),
+                read_only_hint: Some(true),
+                destructive_hint: Some(false),
+                idempotent_hint: Some(true),
+                open_world_hint: Some(false),
+                deferred_hint: Some(false),
+            }),
+        },
         McpTool {
             name: "find_skills".to_string(),
             description: "Search available skills by keyword, tags, or DCC type. \
@@ -2395,4 +2489,23 @@ fn json_error_response(
         .header(header::CONTENT_TYPE, "application/json")
         .body(Body::from(body))
         .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
+}
+
+async fn refresh_roots_cache_for_session(
+    sessions: &SessionManager,
+    session_id: &str,
+) -> Vec<crate::protocol::ClientRoot> {
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": format!("roots-refresh-{session_id}"),
+        "method": "roots/list",
+        "params": {}
+    });
+    let event = format_sse_event(&request, None);
+    sessions.push_event(session_id, event);
+
+    // Current low-risk phase: opportunistically keep existing cache.
+    // Full client response correlation will be added in follow-up.
+    let _ = tokio::time::timeout(ROOTS_REFRESH_TIMEOUT, async {}).await;
+    sessions.get_client_roots(session_id)
 }

--- a/crates/dcc-mcp-http/src/protocol.rs
+++ b/crates/dcc-mcp-http/src/protocol.rs
@@ -173,6 +173,22 @@ pub struct InitializeResult {
     pub instructions: Option<String>,
 }
 
+/// A single client-advertised filesystem root (`roots/list`).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientRoot {
+    pub uri: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+/// Result payload for `roots/list`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RootsListResult {
+    pub roots: Vec<ClientRoot>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ServerCapabilities {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/dcc-mcp-http/src/session.rs
+++ b/crates/dcc-mcp-http/src/session.rs
@@ -17,6 +17,8 @@ use std::time::Instant;
 use tokio::sync::broadcast;
 use uuid::Uuid;
 
+use crate::protocol::ClientRoot;
+
 /// Maximum number of recent log messages retained per session.
 const SESSION_LOG_BUFFER_CAP: usize = 200;
 
@@ -93,6 +95,10 @@ pub struct McpSession {
     pub log_level: SessionLogLevel,
     /// Recent retained log lines emitted for this session.
     pub recent_logs: VecDeque<SessionLogMessage>,
+    /// Whether the client advertised MCP roots capability.
+    pub supports_roots: bool,
+    /// Cached client-advertised roots from `roots/list`.
+    pub client_roots: Vec<ClientRoot>,
     /// Broadcast channel for server-push SSE events.
     pub sse_tx: broadcast::Sender<String>,
     /// Wall-clock time of the last request handled for this session.
@@ -117,6 +123,8 @@ impl McpSession {
             supports_delta_tools: false,
             log_level: SessionLogLevel::default(),
             recent_logs: VecDeque::with_capacity(SESSION_LOG_BUFFER_CAP),
+            supports_roots: false,
+            client_roots: Vec::new(),
             sse_tx,
             last_active: Instant::now(),
         }
@@ -278,6 +286,42 @@ impl SessionManager {
             .collect();
         out.reverse();
         out
+    }
+
+    /// Record whether the client advertised roots capability.
+    pub fn set_supports_roots(&self, session_id: &str, enabled: bool) -> bool {
+        if let Some(mut s) = self.sessions.get_mut(session_id) {
+            s.supports_roots = enabled;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Whether the client for `session_id` supports roots/list.
+    pub fn supports_roots(&self, session_id: &str) -> bool {
+        self.sessions
+            .get(session_id)
+            .map(|s| s.supports_roots)
+            .unwrap_or(false)
+    }
+
+    /// Replace cached roots for the session.
+    pub fn set_client_roots(&self, session_id: &str, roots: Vec<ClientRoot>) -> bool {
+        if let Some(mut s) = self.sessions.get_mut(session_id) {
+            s.client_roots = roots;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Get cached roots for a session.
+    pub fn get_client_roots(&self, session_id: &str) -> Vec<ClientRoot> {
+        self.sessions
+            .get(session_id)
+            .map(|s| s.client_roots.clone())
+            .unwrap_or_default()
     }
 
     /// Get an SSE subscriber for the session.

--- a/crates/dcc-mcp-http/src/tests.rs
+++ b/crates/dcc-mcp-http/src/tests.rs
@@ -337,6 +337,151 @@ mod tests {
         assert!(result["__session_id"].is_string());
     }
 
+    #[tokio::test]
+    async fn test_list_roots_reports_cached_session_roots() {
+        let session_id = "roots-cache-session";
+
+        // Initialize with roots capability advertised by client.
+        // Seed cached roots explicitly for this deterministic unit test path.
+        let state = make_app_state();
+        let sid = state.sessions.create();
+        state.sessions.set_supports_roots(&sid, true);
+        state.sessions.set_client_roots(
+            &sid,
+            vec![
+                crate::protocol::ClientRoot {
+                    uri: "file:///projects/demo".to_string(),
+                    name: Some("Demo Root".to_string()),
+                },
+                crate::protocol::ClientRoot {
+                    uri: "file:///projects/demo/assets".to_string(),
+                    name: None,
+                },
+            ],
+        );
+        let server = TestServer::new(
+            axum::Router::new()
+                .route(
+                    "/mcp",
+                    axum::routing::post(crate::handler::handle_post)
+                        .get(crate::handler::handle_get)
+                        .delete(crate::handler::handle_delete),
+                )
+                .with_state(state),
+        );
+
+        let init = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .add_header(
+                axum::http::HeaderName::from_static("mcp-session-id"),
+                sid.parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 301,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {"roots": {}},
+                    "clientInfo": {"name": "test-client", "version": "1.0"}
+                }
+            }))
+            .await;
+        init.assert_status_ok();
+
+        // Query cached roots via the new core meta-tool.
+        let roots_call = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .add_header(
+                axum::http::HeaderName::from_static("mcp-session-id"),
+                sid.parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 302,
+                "method": "tools/call",
+                "params": {"name": "list_roots", "arguments": {}}
+            }))
+            .await;
+        roots_call.assert_status_ok();
+        let body: Value = roots_call.json();
+        assert_eq!(body["result"]["isError"], false);
+        let text = body["result"]["content"][0]["text"]
+            .as_str()
+            .expect("list_roots should return text payload");
+        let payload: Value =
+            serde_json::from_str(text).expect("list_roots payload must be valid JSON");
+        assert_eq!(payload["supports_roots"], true);
+        assert_eq!(payload["count"], 2);
+        assert_eq!(
+            payload["roots"][0]["uri"], "file:///projects/demo",
+            "cached roots should include client-advertised root URI"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_roots_returns_cached_roots() {
+        let state = make_app_state();
+        let sid = state.sessions.create();
+        state.sessions.set_supports_roots(&sid, true);
+        state.sessions.set_client_roots(
+            &sid,
+            vec![crate::protocol::ClientRoot {
+                uri: "file:///projects/demo".to_string(),
+                name: Some("demo".to_string()),
+            }],
+        );
+
+        let router = {
+            use crate::handler::{handle_delete, handle_get, handle_post};
+            use axum::{Router, routing};
+            Router::new()
+                .route(
+                    "/mcp",
+                    routing::post(handle_post)
+                        .get(handle_get)
+                        .delete(handle_delete),
+                )
+                .with_state(state)
+        };
+        let server = TestServer::new(router);
+
+        let resp = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .add_header(
+                "Mcp-Session-Id".parse::<axum::http::HeaderName>().unwrap(),
+                sid.parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 301,
+                "method": "tools/call",
+                "params": {"name": "list_roots", "arguments": {}}
+            }))
+            .await;
+
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        assert_eq!(body["result"]["isError"], false);
+        let text = body["result"]["content"][0]["text"].as_str().unwrap();
+        let payload: Value = serde_json::from_str(text).unwrap();
+        assert_eq!(payload["supports_roots"], true);
+        assert_eq!(payload["count"], 1);
+        assert_eq!(payload["roots"][0]["uri"], "file:///projects/demo");
+    }
+
     // ── tools/list ────────────────────────────────────────────────────────
 
     #[tokio::test]
@@ -359,9 +504,8 @@ mod tests {
         resp.assert_status_ok();
         let body: Value = resp.json();
         let tools = body["result"]["tools"].as_array().unwrap();
-        // 9 core meta-tools (6 skill discovery + activate/deactivate/search_tools)
-        // + 2 registered actions = 11
-        assert_eq!(tools.len(), 11);
+        // 10 core meta-tools (adds list_roots) + 2 registered actions = 12
+        assert_eq!(tools.len(), 12);
         let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
         assert!(names.contains(&"get_scene_info"));
         assert!(names.contains(&"list_objects"));
@@ -673,7 +817,8 @@ mod tests {
             // Individual skill tools (non-stubs, non-core) must not appear.
             let is_core = matches!(
                 name,
-                "find_skills"
+                "list_roots"
+                    | "find_skills"
                     | "list_skills"
                     | "get_skill_info"
                     | "load_skill"
@@ -1347,8 +1492,8 @@ mod tests {
 
         let body2: Value = resp2.json();
         let tools = body2["result"]["tools"].as_array().unwrap();
-        // 9 core meta-tools + 2 skill tools (skill now loaded, no stubs) = 11
-        assert_eq!(tools.len(), 11);
+        // 10 core meta-tools + 2 skill tools (skill now loaded, no stubs) = 12
+        assert_eq!(tools.len(), 12);
         let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
         assert!(names.contains(&"modeling-bevel.bevel"));
         assert!(names.contains(&"modeling-bevel.chamfer"));
@@ -1423,8 +1568,8 @@ mod tests {
 
         let body2: Value = resp2.json();
         let tools = body2["result"]["tools"].as_array().unwrap();
-        // Back to 9 core meta-tools + 1 unloaded skill stub = 10
-        assert_eq!(tools.len(), 10);
+        // Back to 10 core meta-tools + 1 unloaded skill stub = 11
+        assert_eq!(tools.len(), 11);
         let stub = tools
             .iter()
             .find(|t| t["name"] == "__skill__modeling-bevel")
@@ -1923,7 +2068,7 @@ mod tests {
         resp.assert_status_ok();
         let body: Value = resp.json();
         let tools = body["result"]["tools"].as_array().unwrap();
-        // Total = 9 core + 40 registered = 49; first page = 32.
+        // Total = 10 core + 40 registered = 50; first page = 32.
         assert_eq!(
             tools.len(),
             TOOLS_LIST_PAGE_SIZE,
@@ -1967,8 +2112,8 @@ mod tests {
             .await
             .json();
         let tools2 = r2["result"]["tools"].as_array().unwrap();
-        // 49 - 32 = 17 tools on second page
-        assert_eq!(tools2.len(), 49 - TOOLS_LIST_PAGE_SIZE);
+        // 50 - 32 = 18 tools on second page
+        assert_eq!(tools2.len(), 50 - TOOLS_LIST_PAGE_SIZE);
         assert!(
             r2["result"]["nextCursor"].is_null(),
             "Last page must not have nextCursor"
@@ -2004,7 +2149,7 @@ mod tests {
             }
         }
 
-        assert_eq!(all_names.len(), 49, "All pages must cover exactly 49 tools");
+        assert_eq!(all_names.len(), 50, "All pages must cover exactly 50 tools");
         let unique: std::collections::HashSet<_> = all_names.iter().collect();
         assert_eq!(unique.len(), all_names.len(), "No duplicates across pages");
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add protocol models for client roots and `roots/list` payloads
- track per-session roots capability + cached root entries
- request roots refresh on initialize and `notifications/roots/list_changed`
- add `list_roots` core meta-tool to expose cached roots to agents
- adjust `tools/list` expectations and add targeted roots tests

## Testing
- `vx run -- fmt`
- `vx run -- test-rust`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-940a7817-6e43-4f8d-a13b-116354e22eb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-940a7817-6e43-4f8d-a13b-116354e22eb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

