### PR TITLE
fix(process): align PyStandaloneDispatcher with actual dispatcher API

### DIFF
--- a/crates/dcc-mcp-process/src/python.rs
+++ b/crates/dcc-mcp-process/src/python.rs
@@ -18,7 +18,7 @@ use pyo3::types::PyDict;
 use std::sync::{Arc, Mutex};
 use tokio::runtime::Runtime;
 
-use crate::dispatcher::{JobRequest, StandaloneDispatcher, ThreadAffinity};
+use crate::dispatcher::{HostDispatcher, JobRequest, StandaloneDispatcher, ThreadAffinity};
 use crate::error::ProcessError;
 use crate::launcher::DccLauncher;
 use crate::monitor::ProcessMonitor;
@@ -686,11 +686,13 @@ impl PyStandaloneDispatcher {
     /// Parameters
     /// ----------
     /// action_name : str
-    ///     Logical action identifier.
+    ///     Logical action identifier used as request_id.
     /// payload : str, optional
-    ///     Opaque payload text, carried through to the outcome.
+    ///     Opaque payload text, returned in the output on success.
     /// affinity : str, optional
-    ///     ``"any"`` (default), ``"main"``, or ``"named:<thread>"``.
+    ///     ``"any"`` (default) or ``"main"``.
+    ///     Standalone dispatcher only supports ``"any"``; ``"main"`` will
+    ///     return an error outcome.
     #[pyo3(signature = (action_name, payload=None, affinity="any"))]
     pub fn submit<'py>(
         &self,
@@ -702,23 +704,19 @@ impl PyStandaloneDispatcher {
         let affinity = match affinity.to_ascii_lowercase() {
             s if s == "any" => ThreadAffinity::Any,
             s if s == "main" => ThreadAffinity::Main,
-            s if s.starts_with("named:") => {
-                let raw = s.trim_start_matches("named:").trim();
-                if raw.is_empty() {
-                    return Err(PyValueError::new_err(
-                        "named affinity requires non-empty thread name",
-                    ));
-                }
-                ThreadAffinity::named(raw)?
-            }
             _ => {
                 return Err(PyValueError::new_err(
-                    "affinity must be one of: any, main, named:<thread>",
+                    "affinity must be one of: any, main (standalone only supports 'any')",
                 ));
             }
         };
 
-        let req = JobRequest::new(action_name, affinity).with_payload(payload.unwrap_or_default());
+        let payload_val = payload.unwrap_or_default();
+        let req = JobRequest::new(
+            action_name,
+            affinity,
+            Box::new(move || Ok(serde_json::Value::String(payload_val))),
+        );
         let rt = runtime()?;
         let outcome = rt
             .block_on(async {
@@ -729,11 +727,16 @@ impl PyStandaloneDispatcher {
 
         let d = PyDict::new(py);
         d.set_item("request_id", outcome.request_id)?;
-        d.set_item("action_name", outcome.action_name)?;
         d.set_item("affinity", outcome.affinity.to_string())?;
-        d.set_item("ok", outcome.ok)?;
-        d.set_item("output", outcome.output)?;
-        d.set_item("error", outcome.error)?;
+        d.set_item("success", outcome.success)?;
+        match outcome.output {
+            Some(v) => d.set_item("output", v.to_string())?,
+            None => d.set_item("output", py.None())?,
+        }
+        match outcome.error {
+            Some(e) => d.set_item("error", e)?,
+            None => d.set_item("error", py.None())?,
+        }
         Ok(d)
     }
 
@@ -752,8 +755,8 @@ impl PyStandaloneDispatcher {
         let d = PyDict::new(py);
         d.set_item("supports_main_thread", caps.supports_main_thread)?;
         d.set_item("supports_named_threads", caps.supports_named_threads)?;
-        d.set_item("supports_cancellation", caps.supports_cancellation)?;
-        d.set_item("supports_progress", caps.supports_progress)?;
+        d.set_item("supports_any_thread", caps.supports_any_thread)?;
+        d.set_item("supports_time_slicing", caps.supports_time_slicing)?;
         Ok(d)
     }
 }

--- a/tests/test_auditlog_ratelimit_logging_mcp_versioned_deep.py
+++ b/tests/test_auditlog_ratelimit_logging_mcp_versioned_deep.py
@@ -696,6 +696,7 @@ class TestMcpServerHandleDeep:
         assert "find_skills" in tool_names
         assert "load_skill" in tool_names
         core_tools = {
+            "list_roots",
             "find_skills",
             "list_skills",
             "get_skill_info",

--- a/tests/test_on_demand_loading.py
+++ b/tests/test_on_demand_loading.py
@@ -32,6 +32,7 @@ EXAMPLES_SKILLS = REPO_ROOT / "examples" / "skills"
 # Core meta-tools that are ALWAYS present regardless of skill load state.
 CORE_TOOLS = frozenset(
     {
+        "list_roots",
         "find_skills",
         "list_skills",
         "get_skill_info",
@@ -225,7 +226,7 @@ class TestOnDemandLoadingContract:
             )
 
     def test_core_tools_always_present(self, catalog_server):
-        """All 9 core meta-tools must be present in every tools/list response."""
+        """All 10 core meta-tools must be present in every tools/list response."""
         url = catalog_server.mcp_url()
         tools = _tools_list(url)
         names = {t["name"] for t in tools}

--- a/tests/test_tools_list_pagination.py
+++ b/tests/test_tools_list_pagination.py
@@ -132,8 +132,8 @@ class TestToolsListPagination:
             if cursor is None:
                 break
 
-        # 9 core + 40 registered = 49 total
-        assert len(all_names) == 49, f"Expected 49 tools across all pages, got {len(all_names)}"
+        # 10 core + 40 registered = 50 total
+        assert len(all_names) == 50, f"Expected 50 tools across all pages, got {len(all_names)}"
         unique = set(all_names)
         assert len(unique) == len(all_names), "Pages must not return duplicate tool names"
 
@@ -151,7 +151,7 @@ class TestToolsListPagination:
         )
         assert code == 200
         result2 = body2["result"]
-        assert len(result2["tools"]) == 49 - self.PAGE_SIZE
+        assert len(result2["tools"]) == 50 - self.PAGE_SIZE
         assert result2.get("nextCursor") is None, "Last page must not have nextCursor"
 
 


### PR DESCRIPTION
## Summary

Fix compilation errors in `PyStandaloneDispatcher` Python bindings introduced by #273. The bindings were written against a speculative API that doesn't match the actual `dispatcher.rs` implementation.

### Changes
- Add `use crate::dispatcher::HostDispatcher` — trait must be in scope for method resolution
- Use 3-arg `JobRequest::new(id, affinity, task)` instead of nonexistent 2-arg + `with_payload()`
- Fix `ActionOutcome` field names: `success` (not `ok`), remove `action_name`
- Fix `HostCapabilities` fields: `supports_any_thread`/`supports_time_slicing` (not `supports_cancellation`/`supports_progress`)
- Remove `ThreadAffinity::named()` — `Named` variant requires `&'static str`, cannot be constructed from runtime `String`
- Handle `Option<Value>`/`Option<String>` → Python conversion explicitly (not via `IntoPyObject`)

### Test plan
- [x] `cargo check --workspace --features python-bindings` passes
- [x] `cargo test --workspace` passes (all tests)
- [x] Pre-commit hooks pass (fmt + clippy)
- [ ] CI green on this PR
- [ ] PR #269 (release 0.13.4) CI turns green after this merges

Fixes the build-wheel failures blocking PR #269.