### PR TITLE
feat(transport): add DCC-Link ipckit channel and server adapters

### DIFF
--- a/crates/dcc-mcp-transport/Cargo.toml
+++ b/crates/dcc-mcp-transport/Cargo.toml
@@ -20,6 +20,7 @@ tokio = { workspace = true }
 rmp-serde = { workspace = true }
 dcc-mcp-utils = { workspace = true, optional = true }
 sysinfo.workspace = true
+ipckit = { version = "0.1.7", features = ["async", "backend-interprocess"] }
 
 [dev-dependencies]
 rstest = "0.26"

--- a/crates/dcc-mcp-transport/src/connector.rs
+++ b/crates/dcc-mcp-transport/src/connector.rs
@@ -24,6 +24,8 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
+#[cfg(any(unix, windows))]
+use ipckit::AsyncLocalSocketStream;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::TcpStream;
 
@@ -35,6 +37,15 @@ use crate::ipc::TransportAddress;
 /// Frames larger than this are rejected to prevent memory exhaustion.
 pub const MAX_FRAME_SIZE: u32 = 256 * 1024 * 1024;
 
+/// Kind of local IPC endpoint represented by an ipckit local socket.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LocalSocketKind {
+    /// Windows Named Pipe endpoint.
+    NamedPipe,
+    /// Unix Domain Socket endpoint.
+    UnixSocket,
+}
+
 // ── IpcStream ──────────────────────────────────────────────────────────────
 
 /// A unified async I/O stream that wraps platform-specific transports.
@@ -44,33 +55,23 @@ pub enum IpcStream {
     /// TCP socket (all platforms).
     Tcp(TcpStream),
 
-    /// Windows Named Pipe client.
-    #[cfg(windows)]
-    NamedPipe(tokio::net::windows::named_pipe::NamedPipeClient),
-
-    /// Windows Named Pipe server (accepted connection).
-    ///
-    /// Created by [`IpcListener`](crate::listener::IpcListener) when accepting a Named Pipe
-    /// connection. `NamedPipeServer` implements the same `AsyncRead + AsyncWrite` as
-    /// `NamedPipeClient`, so it is fully interchangeable for framed I/O.
-    #[cfg(windows)]
-    NamedPipeServer(tokio::net::windows::named_pipe::NamedPipeServer),
-
-    /// Unix Domain Socket.
-    #[cfg(unix)]
-    UnixSocket(tokio::net::UnixStream),
+    /// Local IPC stream backed by ipckit (Named Pipe / Unix Socket).
+    #[cfg(any(unix, windows))]
+    LocalSocket {
+        stream: AsyncLocalSocketStream,
+        kind: LocalSocketKind,
+    },
 }
 
 impl std::fmt::Debug for IpcStream {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Tcp(_) => f.debug_tuple("IpcStream::Tcp").finish(),
-            #[cfg(windows)]
-            Self::NamedPipe(_) => f.debug_tuple("IpcStream::NamedPipe").finish(),
-            #[cfg(windows)]
-            Self::NamedPipeServer(_) => f.debug_tuple("IpcStream::NamedPipeServer").finish(),
-            #[cfg(unix)]
-            Self::UnixSocket(_) => f.debug_tuple("IpcStream::UnixSocket").finish(),
+            #[cfg(any(unix, windows))]
+            Self::LocalSocket { kind, .. } => f
+                .debug_struct("IpcStream::LocalSocket")
+                .field("kind", kind)
+                .finish(),
         }
     }
 }
@@ -80,10 +81,11 @@ impl IpcStream {
     pub fn transport_name(&self) -> &'static str {
         match self {
             Self::Tcp(_) => "tcp",
-            #[cfg(windows)]
-            Self::NamedPipe(_) | Self::NamedPipeServer(_) => "named_pipe",
-            #[cfg(unix)]
-            Self::UnixSocket(_) => "unix_socket",
+            #[cfg(any(unix, windows))]
+            Self::LocalSocket { kind, .. } => match kind {
+                LocalSocketKind::NamedPipe => "named_pipe",
+                LocalSocketKind::UnixSocket => "unix_socket",
+            },
         }
     }
 
@@ -91,10 +93,8 @@ impl IpcStream {
     pub fn is_ipc(&self) -> bool {
         match self {
             Self::Tcp(_) => false,
-            #[cfg(windows)]
-            Self::NamedPipe(_) | Self::NamedPipeServer(_) => true,
-            #[cfg(unix)]
-            Self::UnixSocket(_) => true,
+            #[cfg(any(unix, windows))]
+            Self::LocalSocket { .. } => true,
         }
     }
 }
@@ -108,12 +108,8 @@ impl AsyncRead for IpcStream {
     ) -> Poll<io::Result<()>> {
         match self.get_mut() {
             Self::Tcp(s) => Pin::new(s).poll_read(cx, buf),
-            #[cfg(windows)]
-            Self::NamedPipe(s) => Pin::new(s).poll_read(cx, buf),
-            #[cfg(windows)]
-            Self::NamedPipeServer(s) => Pin::new(s).poll_read(cx, buf),
-            #[cfg(unix)]
-            Self::UnixSocket(s) => Pin::new(s).poll_read(cx, buf),
+            #[cfg(any(unix, windows))]
+            Self::LocalSocket { stream, .. } => Pin::new(stream).poll_read(cx, buf),
         }
     }
 }
@@ -127,36 +123,24 @@ impl AsyncWrite for IpcStream {
     ) -> Poll<io::Result<usize>> {
         match self.get_mut() {
             Self::Tcp(s) => Pin::new(s).poll_write(cx, buf),
-            #[cfg(windows)]
-            Self::NamedPipe(s) => Pin::new(s).poll_write(cx, buf),
-            #[cfg(windows)]
-            Self::NamedPipeServer(s) => Pin::new(s).poll_write(cx, buf),
-            #[cfg(unix)]
-            Self::UnixSocket(s) => Pin::new(s).poll_write(cx, buf),
+            #[cfg(any(unix, windows))]
+            Self::LocalSocket { stream, .. } => Pin::new(stream).poll_write(cx, buf),
         }
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         match self.get_mut() {
             Self::Tcp(s) => Pin::new(s).poll_flush(cx),
-            #[cfg(windows)]
-            Self::NamedPipe(s) => Pin::new(s).poll_flush(cx),
-            #[cfg(windows)]
-            Self::NamedPipeServer(s) => Pin::new(s).poll_flush(cx),
-            #[cfg(unix)]
-            Self::UnixSocket(s) => Pin::new(s).poll_flush(cx),
+            #[cfg(any(unix, windows))]
+            Self::LocalSocket { stream, .. } => Pin::new(stream).poll_flush(cx),
         }
     }
 
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         match self.get_mut() {
             Self::Tcp(s) => Pin::new(s).poll_shutdown(cx),
-            #[cfg(windows)]
-            Self::NamedPipe(s) => Pin::new(s).poll_shutdown(cx),
-            #[cfg(windows)]
-            Self::NamedPipeServer(s) => Pin::new(s).poll_shutdown(cx),
-            #[cfg(unix)]
-            Self::UnixSocket(s) => Pin::new(s).poll_shutdown(cx),
+            #[cfg(any(unix, windows))]
+            Self::LocalSocket { stream, .. } => Pin::new(stream).poll_shutdown(cx),
         }
     }
 }
@@ -260,30 +244,34 @@ async fn connect_tcp(host: &str, port: u16) -> TransportResult<IpcStream> {
 /// Connect via Windows Named Pipe.
 #[cfg(windows)]
 async fn connect_named_pipe(path: &str) -> TransportResult<IpcStream> {
-    use tokio::net::windows::named_pipe::ClientOptions;
+    let stream = AsyncLocalSocketStream::connect(path).await.map_err(|e| {
+        TransportError::IpcConnectionFailed {
+            address: format!("pipe://{path}"),
+            reason: format!("ipckit connect failed: {e}"),
+        }
+    })?;
 
-    let client =
-        ClientOptions::new()
-            .open(path)
-            .map_err(|e| TransportError::IpcConnectionFailed {
-                address: format!("pipe://{path}"),
-                reason: e.to_string(),
-            })?;
-
-    Ok(IpcStream::NamedPipe(client))
+    Ok(IpcStream::LocalSocket {
+        stream,
+        kind: LocalSocketKind::NamedPipe,
+    })
 }
 
 /// Connect via Unix Domain Socket.
 #[cfg(unix)]
 async fn connect_unix_socket(path: &std::path::Path) -> TransportResult<IpcStream> {
-    let stream = tokio::net::UnixStream::connect(path).await.map_err(|e| {
-        TransportError::IpcConnectionFailed {
+    let path_string = path.display().to_string();
+    let stream = AsyncLocalSocketStream::connect(&path_string)
+        .await
+        .map_err(|e| TransportError::IpcConnectionFailed {
             address: format!("unix://{}", path.display()),
-            reason: e.to_string(),
-        }
-    })?;
+            reason: format!("ipckit connect failed: {e}"),
+        })?;
 
-    Ok(IpcStream::UnixSocket(stream))
+    Ok(IpcStream::LocalSocket {
+        stream,
+        kind: LocalSocketKind::UnixSocket,
+    })
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────

--- a/crates/dcc-mcp-transport/src/dcc_link.rs
+++ b/crates/dcc-mcp-transport/src/dcc_link.rs
@@ -1,0 +1,243 @@
+//! DCC-Link wire frame and ipckit adapters.
+//!
+//! This module introduces an explicit DCC-Link frame format:
+//! `[u32 len][u8 type][u64 seq][msgpack body]`.
+//! It provides:
+//! - `DccLinkFrame` encode/decode helpers
+//! - `IpcChannelAdapter` over `ipckit::IpcChannel<Vec<u8>>`
+//! - `GracefulIpcChannelAdapter` over `ipckit::GracefulIpcChannel<Vec<u8>>`
+//! - `SocketServerAdapter` over `ipckit::SocketServer`
+
+use std::time::Duration;
+
+use ipckit::{GracefulIpcChannel, IpcChannel, SocketServer, SocketServerConfig};
+
+use crate::error::{TransportError, TransportResult};
+
+/// DCC-Link message type tags.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum DccLinkType {
+    Call = 1,
+    Reply = 2,
+    Err = 3,
+    Progress = 4,
+    Cancel = 5,
+    Push = 6,
+    Ping = 7,
+    Pong = 8,
+}
+
+impl TryFrom<u8> for DccLinkType {
+    type Error = TransportError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::Call),
+            2 => Ok(Self::Reply),
+            3 => Ok(Self::Err),
+            4 => Ok(Self::Progress),
+            5 => Ok(Self::Cancel),
+            6 => Ok(Self::Push),
+            7 => Ok(Self::Ping),
+            8 => Ok(Self::Pong),
+            other => Err(TransportError::Serialization(format!(
+                "unknown DccLinkType: {other}"
+            ))),
+        }
+    }
+}
+
+/// A DCC-Link frame.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DccLinkFrame {
+    pub msg_type: DccLinkType,
+    pub seq: u64,
+    pub body: Vec<u8>,
+}
+
+impl DccLinkFrame {
+    const HEADER_LEN: usize = 1 + 8;
+
+    /// Encode to `[len][type][seq][body]` where `len = 1 + 8 + body.len()`.
+    pub fn encode(&self) -> TransportResult<Vec<u8>> {
+        let payload_len = Self::HEADER_LEN + self.body.len();
+        let len_u32 = u32::try_from(payload_len).map_err(|_| TransportError::FrameTooLarge {
+            size: payload_len,
+            max_size: u32::MAX as usize,
+        })?;
+
+        let mut out = Vec::with_capacity(4 + payload_len);
+        out.extend_from_slice(&len_u32.to_be_bytes());
+        out.push(self.msg_type as u8);
+        out.extend_from_slice(&self.seq.to_be_bytes());
+        out.extend_from_slice(&self.body);
+        Ok(out)
+    }
+
+    /// Decode from a full frame buffer including the 4-byte length prefix.
+    pub fn decode(frame: &[u8]) -> TransportResult<Self> {
+        if frame.len() < 4 + Self::HEADER_LEN {
+            return Err(TransportError::Serialization(
+                "dcc-link frame too short".to_string(),
+            ));
+        }
+
+        let declared_len = u32::from_be_bytes([frame[0], frame[1], frame[2], frame[3]]) as usize;
+        let actual_len = frame.len().saturating_sub(4);
+        if declared_len != actual_len {
+            return Err(TransportError::Serialization(format!(
+                "dcc-link frame length mismatch: declared={declared_len}, actual={actual_len}"
+            )));
+        }
+
+        let msg_type = DccLinkType::try_from(frame[4])?;
+        let seq = u64::from_be_bytes([
+            frame[5], frame[6], frame[7], frame[8], frame[9], frame[10], frame[11], frame[12],
+        ]);
+        let body = frame[13..].to_vec();
+
+        Ok(Self {
+            msg_type,
+            seq,
+            body,
+        })
+    }
+}
+
+/// Thin adapter over `ipckit::IpcChannel<Vec<u8>>` using DCC-Link framing.
+pub struct IpcChannelAdapter {
+    inner: IpcChannel<Vec<u8>>,
+}
+
+impl IpcChannelAdapter {
+    pub fn create(name: &str) -> TransportResult<Self> {
+        let inner = IpcChannel::<Vec<u8>>::create(name).map_err(map_ipckit_err)?;
+        Ok(Self { inner })
+    }
+
+    pub fn connect(name: &str) -> TransportResult<Self> {
+        let inner = IpcChannel::<Vec<u8>>::connect(name).map_err(map_ipckit_err)?;
+        Ok(Self { inner })
+    }
+
+    pub fn wait_for_client(&mut self) -> TransportResult<()> {
+        self.inner.wait_for_client().map_err(map_ipckit_err)
+    }
+
+    pub fn send_frame(&mut self, frame: &DccLinkFrame) -> TransportResult<()> {
+        let bytes = frame.encode()?;
+        self.inner.send_bytes(&bytes).map_err(map_ipckit_err)
+    }
+
+    pub fn recv_frame(&mut self) -> TransportResult<DccLinkFrame> {
+        let bytes = self.inner.recv_bytes().map_err(map_ipckit_err)?;
+        DccLinkFrame::decode(&bytes)
+    }
+}
+
+/// Thin adapter over `ipckit::GracefulIpcChannel<Vec<u8>>` using DCC-Link framing.
+pub struct GracefulIpcChannelAdapter {
+    inner: GracefulIpcChannel<Vec<u8>>,
+}
+
+impl GracefulIpcChannelAdapter {
+    pub fn create(name: &str) -> TransportResult<Self> {
+        let inner = GracefulIpcChannel::<Vec<u8>>::create(name).map_err(map_ipckit_err)?;
+        Ok(Self { inner })
+    }
+
+    pub fn connect(name: &str) -> TransportResult<Self> {
+        let inner = GracefulIpcChannel::<Vec<u8>>::connect(name).map_err(map_ipckit_err)?;
+        Ok(Self { inner })
+    }
+
+    pub fn wait_for_client(&mut self) -> TransportResult<()> {
+        self.inner.wait_for_client().map_err(map_ipckit_err)
+    }
+
+    pub fn send_frame(&mut self, frame: &DccLinkFrame) -> TransportResult<()> {
+        let bytes = frame.encode()?;
+        self.inner.send_bytes(&bytes).map_err(map_ipckit_err)
+    }
+
+    pub fn recv_frame(&mut self) -> TransportResult<DccLinkFrame> {
+        let bytes = self.inner.recv_bytes().map_err(map_ipckit_err)?;
+        DccLinkFrame::decode(&bytes)
+    }
+
+    pub fn shutdown(&self) {
+        use ipckit::GracefulChannel;
+        self.inner.shutdown();
+    }
+}
+
+/// Minimal wrapper for `ipckit::SocketServer`.
+pub struct SocketServerAdapter {
+    inner: SocketServer,
+}
+
+impl SocketServerAdapter {
+    pub fn new(
+        path: &str,
+        max_connections: usize,
+        connection_timeout: Duration,
+    ) -> TransportResult<Self> {
+        let config = SocketServerConfig {
+            path: path.to_string(),
+            max_connections,
+            connection_timeout,
+            cleanup_on_start: true,
+            buffer_size: 8192,
+        };
+        let inner = SocketServer::new(config).map_err(map_ipckit_err)?;
+        Ok(Self { inner })
+    }
+
+    pub fn socket_path(&self) -> &str {
+        self.inner.socket_path()
+    }
+
+    pub fn connection_count(&self) -> usize {
+        self.inner.connection_count()
+    }
+}
+
+fn map_ipckit_err(err: ipckit::IpcError) -> TransportError {
+    TransportError::IpcConnectionFailed {
+        address: "ipckit://local".to_string(),
+        reason: err.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dcc_link_frame_roundtrip() {
+        let frame = DccLinkFrame {
+            msg_type: DccLinkType::Call,
+            seq: 42,
+            body: vec![1, 2, 3, 4],
+        };
+        let encoded = frame.encode().unwrap();
+        let decoded = DccLinkFrame::decode(&encoded).unwrap();
+        assert_eq!(decoded, frame);
+    }
+
+    #[test]
+    fn dcc_link_frame_rejects_length_mismatch() {
+        let mut bad = vec![0, 0, 0, 16, DccLinkType::Call as u8];
+        bad.extend_from_slice(&42_u64.to_be_bytes());
+        bad.extend_from_slice(&[1, 2, 3]);
+        let err = DccLinkFrame::decode(&bad).unwrap_err();
+        assert!(err.to_string().contains("length mismatch"));
+    }
+
+    #[test]
+    fn dcc_link_type_rejects_unknown_tag() {
+        let err = DccLinkType::try_from(255).unwrap_err();
+        assert!(err.to_string().contains("unknown DccLinkType"));
+    }
+}

--- a/crates/dcc-mcp-transport/src/lib.rs
+++ b/crates/dcc-mcp-transport/src/lib.rs
@@ -15,6 +15,7 @@ pub mod channel;
 pub mod circuit_breaker;
 pub mod config;
 pub mod connector;
+pub mod dcc_link;
 pub mod discovery;
 pub mod error;
 pub mod framed;
@@ -34,6 +35,9 @@ pub use circuit_breaker::{
 };
 pub use config::{PoolConfig, SessionConfig, TransportConfig};
 pub use connector::{IpcStream, connect};
+pub use dcc_link::{
+    DccLinkFrame, DccLinkType, GracefulIpcChannelAdapter, IpcChannelAdapter, SocketServerAdapter,
+};
 pub use discovery::ServiceRegistry;
 pub use discovery::types::{ServiceEntry, ServiceKey, ServiceStatus};
 pub use error::{TransportError, TransportResult};

--- a/crates/dcc-mcp-transport/src/listener/mod.rs
+++ b/crates/dcc-mcp-transport/src/listener/mod.rs
@@ -39,9 +39,11 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
+#[cfg(any(unix, windows))]
+use ipckit::AsyncLocalSocketListener;
 use tokio::net::TcpListener;
 
-use crate::connector::IpcStream;
+use crate::connector::{IpcStream, LocalSocketKind};
 use crate::error::{TransportError, TransportResult};
 use crate::ipc::TransportAddress;
 
@@ -58,13 +60,12 @@ pub enum IpcListener {
     /// TCP listener (all platforms).
     Tcp(TcpListener),
 
-    /// Windows Named Pipe server.
-    #[cfg(windows)]
-    NamedPipe(NamedPipeListener),
-
-    /// Unix Domain Socket listener.
-    #[cfg(unix)]
-    UnixSocket(tokio::net::UnixListener),
+    /// Local IPC listener backed by ipckit (Named Pipe / Unix Socket).
+    #[cfg(any(unix, windows))]
+    LocalSocket {
+        listener: AsyncLocalSocketListener,
+        kind: LocalSocketKind,
+    },
 }
 
 impl std::fmt::Debug for IpcListener {
@@ -74,15 +75,10 @@ impl std::fmt::Debug for IpcListener {
                 .debug_struct("IpcListener::Tcp")
                 .field("addr", &l.local_addr().ok())
                 .finish(),
-            #[cfg(windows)]
-            Self::NamedPipe(l) => f
-                .debug_struct("IpcListener::NamedPipe")
-                .field("path", &l.path)
-                .finish(),
-            #[cfg(unix)]
-            Self::UnixSocket(l) => f
-                .debug_struct("IpcListener::UnixSocket")
-                .field("addr", &l.local_addr().ok())
+            #[cfg(any(unix, windows))]
+            Self::LocalSocket { kind, .. } => f
+                .debug_struct("IpcListener::LocalSocket")
+                .field("kind", kind)
                 .finish(),
         }
     }
@@ -141,29 +137,23 @@ impl IpcListener {
                 Ok(IpcStream::Tcp(stream))
             }
 
-            #[cfg(windows)]
-            Self::NamedPipe(listener) => listener.accept().await,
-
-            #[cfg(unix)]
-            Self::UnixSocket(listener) => {
-                let (stream, _peer) =
+            #[cfg(any(unix, windows))]
+            Self::LocalSocket { listener, kind } => {
+                let stream =
                     listener
                         .accept()
                         .await
                         .map_err(|e| TransportError::IpcConnectionFailed {
-                            address: format!(
-                                "unix://{}",
-                                listener
-                                    .local_addr()
-                                    .ok()
-                                    .and_then(|a| a.as_pathname().map(|p| p.display().to_string()))
-                                    .unwrap_or_default()
-                            ),
-                            reason: format!("accept failed: {e}"),
+                            address: match kind {
+                                LocalSocketKind::NamedPipe => "pipe://<local-socket>".to_string(),
+                                LocalSocketKind::UnixSocket => "unix://<local-socket>".to_string(),
+                            },
+                            reason: format!("ipckit accept failed: {e}"),
                         })?;
-
-                tracing::debug!("accepted Unix socket connection");
-                Ok(IpcStream::UnixSocket(stream))
+                Ok(IpcStream::LocalSocket {
+                    stream,
+                    kind: *kind,
+                })
             }
         }
     }
@@ -172,10 +162,11 @@ impl IpcListener {
     pub fn transport_name(&self) -> &'static str {
         match self {
             Self::Tcp(_) => "tcp",
-            #[cfg(windows)]
-            Self::NamedPipe(_) => "named_pipe",
-            #[cfg(unix)]
-            Self::UnixSocket(_) => "unix_socket",
+            #[cfg(any(unix, windows))]
+            Self::LocalSocket { kind, .. } => match kind {
+                LocalSocketKind::NamedPipe => "named_pipe",
+                LocalSocketKind::UnixSocket => "unix_socket",
+            },
         }
     }
 
@@ -190,101 +181,17 @@ impl IpcListener {
                     .map_err(|e| TransportError::Internal(e.to_string()))?;
                 Ok(TransportAddress::tcp(addr.ip().to_string(), addr.port()))
             }
-            #[cfg(windows)]
-            Self::NamedPipe(l) => Ok(TransportAddress::named_pipe(&l.path)),
-            #[cfg(unix)]
-            Self::UnixSocket(l) => {
-                let addr = l
-                    .local_addr()
-                    .map_err(|e| TransportError::Internal(e.to_string()))?;
-                let path = addr
-                    .as_pathname()
-                    .ok_or_else(|| {
-                        TransportError::Internal("unix socket has no pathname".to_string())
-                    })?
-                    .to_path_buf();
-                Ok(TransportAddress::UnixSocket { path })
+            #[cfg(any(unix, windows))]
+            Self::LocalSocket { listener, kind } => {
+                let name = listener.name();
+                match kind {
+                    LocalSocketKind::NamedPipe => Ok(TransportAddress::named_pipe(name)),
+                    LocalSocketKind::UnixSocket => Ok(TransportAddress::unix_socket(
+                        std::path::PathBuf::from(name),
+                    )),
+                }
             }
         }
-    }
-}
-
-// ── Windows Named Pipe Listener ────────────────────────────────────────────
-
-/// Named Pipe listener for Windows.
-///
-/// Windows Named Pipes don't have a `listen`/`accept` model like sockets.
-/// Instead, a server creates a pipe instance and waits for a client to connect.
-/// After each connection, a new pipe instance must be created for the next client.
-///
-/// This struct wraps that pattern into a familiar `accept()` loop.
-#[cfg(windows)]
-pub struct NamedPipeListener {
-    /// The pipe path (e.g. `\\.\pipe\dcc-mcp-maya`).
-    path: String,
-    /// Whether the listener has been shut down.
-    shutdown: Arc<AtomicBool>,
-    /// Counter for accepted connections (for logging/metrics).
-    accept_count: AtomicU64,
-}
-
-#[cfg(windows)]
-impl NamedPipeListener {
-    /// Create a new Named Pipe listener.
-    fn new(path: String) -> TransportResult<Self> {
-        // Verify we can create a pipe instance.
-        let _ = Self::create_pipe_instance(&path)?;
-
-        Ok(Self {
-            path,
-            shutdown: Arc::new(AtomicBool::new(false)),
-            accept_count: AtomicU64::new(0),
-        })
-    }
-
-    /// Create a single Named Pipe server instance.
-    fn create_pipe_instance(
-        path: &str,
-    ) -> TransportResult<tokio::net::windows::named_pipe::NamedPipeServer> {
-        use tokio::net::windows::named_pipe::ServerOptions;
-
-        ServerOptions::new()
-            .first_pipe_instance(false)
-            .create(path)
-            .map_err(|e| TransportError::IpcConnectionFailed {
-                address: format!("pipe://{path}"),
-                reason: format!("failed to create pipe server instance: {e}"),
-            })
-    }
-
-    /// Accept the next client connection.
-    async fn accept(&self) -> TransportResult<IpcStream> {
-        if self.shutdown.load(Ordering::SeqCst) {
-            return Err(TransportError::Shutdown);
-        }
-
-        let server = Self::create_pipe_instance(&self.path)?;
-
-        // Wait for a client to connect to this pipe instance.
-        server
-            .connect()
-            .await
-            .map_err(|e| TransportError::IpcConnectionFailed {
-                address: format!("pipe://{}", self.path),
-                reason: format!("client connect wait failed: {e}"),
-            })?;
-
-        self.accept_count.fetch_add(1, Ordering::Relaxed);
-        tracing::debug!(
-            path = %self.path,
-            count = self.accept_count.load(Ordering::Relaxed),
-            "accepted Named Pipe connection"
-        );
-
-        // Convert the connected NamedPipeServer to a NamedPipeClient-like stream.
-        // NamedPipeServer implements AsyncRead + AsyncWrite, same as NamedPipeClient.
-        // We wrap it in IpcStream::NamedPipe via the server type.
-        Ok(IpcStream::NamedPipeServer(server))
     }
 }
 
@@ -296,7 +203,7 @@ async fn bind_inner(addr: &TransportAddress) -> TransportResult<IpcListener> {
         TransportAddress::Tcp { host, port } => bind_tcp(host, *port).await,
 
         #[cfg(windows)]
-        TransportAddress::NamedPipe { path } => bind_named_pipe(path),
+        TransportAddress::NamedPipe { path } => bind_named_pipe(path).await,
 
         #[cfg(not(windows))]
         TransportAddress::NamedPipe { path } => Err(TransportError::IpcNotSupported {
@@ -337,36 +244,38 @@ async fn bind_tcp(host: &str, port: u16) -> TransportResult<IpcListener> {
     Ok(IpcListener::Tcp(listener))
 }
 
-/// Bind a Windows Named Pipe listener.
+/// Bind a Windows Named Pipe listener backed by ipckit local socket.
 #[cfg(windows)]
-fn bind_named_pipe(path: &str) -> TransportResult<IpcListener> {
-    let pipe_path = if path.starts_with(r"\\.\pipe\") {
-        path.to_string()
-    } else {
-        format!(r"\\.\pipe\{path}")
-    };
-
-    let listener = NamedPipeListener::new(pipe_path)?;
-    Ok(IpcListener::NamedPipe(listener))
+async fn bind_named_pipe(path: &str) -> TransportResult<IpcListener> {
+    let listener = AsyncLocalSocketListener::bind(path).await.map_err(|e| {
+        TransportError::IpcConnectionFailed {
+            address: format!("pipe://{path}"),
+            reason: format!("ipckit bind failed: {e}"),
+        }
+    })?;
+    Ok(IpcListener::LocalSocket {
+        listener,
+        kind: LocalSocketKind::NamedPipe,
+    })
 }
 
 /// Bind a Unix Domain Socket listener.
 #[cfg(unix)]
 async fn bind_unix_socket(path: &std::path::Path) -> TransportResult<IpcListener> {
-    // Remove stale socket file if it exists.
-    if path.exists() {
-        let _ = std::fs::remove_file(path);
-    }
-
-    let listener =
-        tokio::net::UnixListener::bind(path).map_err(|e| TransportError::IpcConnectionFailed {
+    let path_string = path.display().to_string();
+    let listener = AsyncLocalSocketListener::bind(&path_string)
+        .await
+        .map_err(|e| TransportError::IpcConnectionFailed {
             address: format!("unix://{}", path.display()),
-            reason: format!("bind failed: {e}"),
+            reason: format!("ipckit bind failed: {e}"),
         })?;
 
-    tracing::debug!(path = %path.display(), "Unix socket listener bound");
+    tracing::debug!(path = %path.display(), "ipckit local socket listener bound");
 
-    Ok(IpcListener::UnixSocket(listener))
+    Ok(IpcListener::LocalSocket {
+        listener,
+        kind: LocalSocketKind::UnixSocket,
+    })
 }
 
 // ── AcceptGuard ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Introduce an explicit DCC-Link wire frame format (`[u32 len][u8 type][u64 seq][msgpack body]`) with `DccLinkFrame` encode/decode helpers in `dcc_link.rs`
- Add `IpcChannelAdapter`, `GracefulIpcChannelAdapter`, and `SocketServerAdapter` over ipckit primitives
- Route local IPC connector and listener through ipckit async sockets, replacing the custom transport implementation
- Align `PyStandaloneDispatcher` with the updated `HostDispatcher` trait and new `JobRequest` constructor signature

## Test plan
- [ ] Verify `vx just preflight` passes (Rust check + clippy + fmt + test)
- [ ] Verify `vx just test` passes (Python tests including updated `test_on_demand_loading`, `test_tools_list_pagination`, `test_auditlog_ratelimit_logging_mcp_versioned_deep`)
- [ ] Confirm DCC-Link frame encode/decode round-trips correctly
- [ ] Confirm IPC channel adapters connect and exchange messages