### PR TITLE
docs: refresh stale terminology for v0.13.4 codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,18 +106,24 @@ A Rust-powered MCP (Model Context Protocol) library that lets AI agents interact
 → Activate at runtime via `ToolRegistry.activate_tool_group(skill, group)` / MCP tool `activate_tool_group`
 → See `docs/guide/skills.md` — "Tool Groups (Progressive Exposure)"
 
+**Validate tool names or action IDs (SEP-986)?**
+→ [`docs/guide/naming.md`](docs/guide/naming.md)
+→ `validate_tool_name(name)` / `validate_action_id(name)` — raise `ValueError` on invalid names
+→ Constants: `TOOL_NAME_RE`, `ACTION_ID_RE`, `MAX_TOOL_NAME_LEN`
+
 ---
 
 ## Repo Layout (What Lives Where)
 
 ```
 dcc-mcp-core/
-├── src/lib.rs                      # PyO3 entry point — registers all 14 crates into _core
-├── Cargo.toml                      # Workspace: 14 Rust crates
+├── src/lib.rs                      # PyO3 entry point — registers all 15 crates into _core
+├── Cargo.toml                      # Workspace: 15 Rust crates
 ├── pyproject.toml                  # Python package
 ├── justfile                        # Dev commands (always prefix with vx)
 │
 ├── crates/                         # Rust — one crate per concern
+│   ├── dcc-mcp-naming/             # SEP-986 tool-name / action-id validators (TOOL_NAME_RE, validate_tool_name)
 │   ├── dcc-mcp-models/             # ToolResult, SkillMetadata, ToolDeclaration
 │   ├── dcc-mcp-actions/            # ToolRegistry, ToolDispatcher, ToolPipeline, EventBus
 │   ├── dcc-mcp-skills/             # SkillScanner, SkillCatalog, SkillWatcher
@@ -290,6 +296,8 @@ annotations = ToolAnnotations(
     read_only_hint=True,       # tool only reads data, no side effects
     destructive_hint=False,    # tool may cause irreversible changes
     idempotent_hint=True,      # repeated calls produce same result
+    open_world_hint=False,     # tool may interact with external systems
+    deferred_hint=None,        # full schema deferred until load_skill (set by server, not user)
 )
 # Design tools around user workflows, not raw API calls.
 # Return human-readable errors via error_result("msg", "specific error").
@@ -361,6 +369,34 @@ router = vr.router()  # -> CompatibilityRouter (borrows the registry)
 result = vr.resolve("create_sphere", "maya", "^1.0.0")
 ```
 
+**SEP-986 tool naming — validate names before registration:**
+```python
+from dcc_mcp_core import validate_tool_name, validate_action_id, TOOL_NAME_RE
+# Tool names: dot-separated lowercase (e.g. "scene.get_info")
+validate_tool_name("scene.get_info")     # ✓ passes
+validate_tool_name("Scene/GetInfo")      # ✗ raises ValueError
+# Action IDs: dotted lowercase identifier chains
+validate_action_id("maya-geometry.create_sphere")  # ✓
+# Regex constants for custom validation:
+# TOOL_NAME_RE, ACTION_ID_RE, MAX_TOOL_NAME_LEN (48 chars)
+```
+
+**`lazy_actions` — opt-in meta-tool fast-path:**
+```python
+# When enabled, tools/list surfaces only 3 meta-tools:
+# list_actions, describe_action, call_action
+# instead of every registered tool at once.
+config = McpHttpConfig(port=8765)
+config.lazy_actions = True   # opt-in; default is False
+```
+
+**`ToolResult.to_json()` — JSON serialization:**
+```python
+result = success_result("done", count=5)
+json_str = result.to_json()    # JSON string
+# Also: result.to_dict()       # Python dict
+```
+
 ---
 
 ## Code Style — Non-Negotiable
@@ -406,9 +442,9 @@ When adding a Rust type/function that needs to be callable from Python:
 
 - **Sandbox**: Use `SandboxPolicy` + `SandboxContext` for AI-driven tool execution. Never expose unrestricted filesystem or process access.
 - **Input validation**: Always validate AI-provided parameters with `ToolValidator.from_schema_json()` before execution.
-- **ToolAnnotations**: Signal safety properties (`read_only_hint`, `destructive_hint`, `idempotent_hint`) so AI clients make informed choices.
+- **ToolAnnotations**: Signal safety properties (`read_only_hint`, `destructive_hint`, `idempotent_hint`, `open_world_hint`, `deferred_hint`) so AI clients make informed choices.
 - **SkillScope**: Trust hierarchy prevents project-local skills from shadowing enterprise-managed ones.
-- **Audit log**: `AuditLog` / `AuditMiddleware` provide traceability for all AI-initiated actions.
+- **Audit log**: `AuditLog` / `AuditMiddleware` provide traceability for all AI-initiated tool calls.
 - **No secrets in code**: Never hardcode API keys, tokens, or passwords. Use environment variables or config files outside the repo.
 
 ## PR Instructions

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -41,6 +41,7 @@ cfg = McpHttpConfig(
 | `request_timeout_ms` | `int` | `30000` | Per-request timeout in milliseconds |
 | `enable_cors` | `bool` | `False` | Enable CORS headers for browser clients |
 | `session_ttl_secs` | `int` | `3600` | Idle session TTL in seconds (`0` = disable eviction) |
+| `lazy_actions` | `bool` | `False` | Opt-in: surface only 3 meta-tools (`list_actions`, `describe_action`, `call_action`) instead of all tools in `tools/list` |
 | `gateway_port` | `int` | `0` | Gateway port to compete for (`0` = disabled). See [Gateway](#gateway) |
 | `registry_dir` | `str \| None` | `None` | Directory for the shared `FileRegistry` JSON (defaults to OS temp dir) |
 | `stale_timeout_secs` | `int` | `30` | Seconds without a heartbeat before an instance is considered stale |
@@ -54,7 +55,7 @@ cfg = McpHttpConfig(
 Returned by `McpHttpServer.start()`. Use it to get the MCP endpoint URL and shut down gracefully.
 
 ::: tip Alias
-`McpServerHandle` is the preferred public name. `McpServerHandle` remains available as a compatibility alias.
+`McpServerHandle` is the preferred public name. The internal `ServerHandle` remains available as a compatibility alias.
 
 ```python
 from dcc_mcp_core import McpServerHandle  # preferred public handle name
@@ -118,6 +119,13 @@ server = McpHttpServer(
 | `start()` | `McpServerHandle` | Start server in background thread and return handle |
 | `register_handler(tool_name, handler)` | `None` | Register a Python callable that receives decoded params (typically a `dict`) |
 | `has_handler(tool_name)` | `bool` | Check if a handler is registered for a tool |
+| `discover(extra_paths, dcc_name)` | `int` | Scan and populate the skill catalog; returns count of discovered skills |
+| `load_skill(skill_name)` | `list[str]` | Load a skill, registering its tools; returns tool names |
+| `unload_skill(skill_name)` | `bool` | Unload a skill, removing its tools |
+| `find_skills(query, tags, dcc)` | `list[SkillSummary]` | Search skills by query, tags, or DCC type |
+| `list_skills(status)` | `list[SkillSummary]` | List skills with optional status filter (`"loaded"`/`"unloaded"`) |
+| `is_loaded(skill_name)` | `bool` | Check if a skill is currently loaded |
+| `loaded_count()` | `int` | Number of currently loaded skills |
 
 ### MCP Protocol Endpoints
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -246,8 +246,9 @@ vx just lint
 - Check out the [Skills System](/guide/skills) for zero-code script registration
 - Expose tools with [MCP HTTP Server](/api/http)
 - See the [Transport Layer](/guide/transport) for DCC communication
-- Understand the [Architecture](/guide/architecture) of the 14-crate Rust workspace
+- Understand the [Architecture](/guide/architecture) of the 15-crate Rust workspace
 - Learn [Skill Scopes & Policies](/guide/skill-scopes-policies) for trust-based skill management
+- Validate tool names with [SEP-986 Naming Rules](/guide/naming)
 
 ## Troubleshooting
 

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -191,7 +191,7 @@ tools:
 | `on-success` | `List[str]` | Suggested tools after successful execution |
 | `on-failure` | `List[str]` | Debugging/recovery tools on failure |
 
-Both accept lists of fully-qualified tool names in `{skill_name}__{tool_name}` format.
+Both accept lists of fully-qualified tool names in `{skill_name}__{tool_name}` format. SEP-986 dot-namespacing (`skill.tool_name`) is also supported — see [Naming Rules](/guide/naming) for validation.
 
 Unloaded skill stubs returned by `tools/list` also expose `annotations.deferredHint = true` as an explicit progressive-loading signal. Once you call `load_skill(...)`, the real tools replace the stub and return `deferredHint = false`.
 
@@ -323,7 +323,7 @@ Parsed from SKILL.md frontmatter. Supports [agentskills.io](https://agentskills.
 | `name` | `str` | Unique skill name |
 | `description` | `str` | Short description (should describe what the skill does and when to use it) |
 | `search_hint` | `str` | Keyword hint for `search_skills` (SKILL.md `search-hint:` field; falls back to `description`) |
-| `tools` | `List[str]` | Tool names listed in frontmatter |
+| `tools` | `List[ToolDeclaration]` | Tool declarations from frontmatter (use `.name` to get tool names) |
 | `dcc` | `str` | Target DCC application (default: `"python"`) |
 | `tags` | `List[str]` | Classification tags |
 | `scripts` | `List[str]` | Discovered script file paths |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -43,10 +43,11 @@ dcc-mcp-core is a **Rust workspace** with Python bindings via PyO3. All logic li
 sub-crates; the root crate re-exports everything into a single `dcc_mcp_core._core` Python
 extension module. The Python package `dcc_mcp_core` re-exports all public APIs from `_core`.
 
-**14 crates** — **Zero runtime Python dependencies** — install with just `pip install dcc-mcp-core`.
+**15 crates** — **Zero runtime Python dependencies** — install with just `pip install dcc-mcp-core`.
 
 ```
 crates/
+├── dcc-mcp-naming/       # SEP-986 tool-name / action-id validators (TOOL_NAME_RE, validate_tool_name)
 ├── dcc-mcp-models/       # ToolResult, SkillMetadata
 ├── dcc-mcp-actions/      # ToolRegistry, ToolDispatcher, ToolValidator, EventBus, ToolPipeline
 ├── dcc-mcp-skills/       # SkillScanner, SkillWatcher, parse_skill_md, dependency resolver
@@ -94,6 +95,9 @@ ToolResult(success=True, message="", prompt=None, error=None, context=None)
 - `with_error(error: str) -> ToolResult` — Copy with error info (sets success=False)
 - `with_context(**kwargs) -> ToolResult` — Copy with updated context
 - `to_dict() -> dict` — Full dict representation
+- `to_json() -> str` — JSON string representation
+- `keys() -> list[str]` — Dict keys (mapping protocol)
+- `__iter__()` — Iterate over keys (mapping protocol)
 
 **Factory functions (preferred for creation):**
 ```python
@@ -150,7 +154,7 @@ Metadata parsed from SKILL.md frontmatter. All fields are get/set.
 
 ### ToolRegistry
 
-Thread-safe action registry using DashMap (Rust). Each instance is independent (no singleton).
+Thread-safe tool registry using DashMap (Rust). Each instance is independent (no singleton).
 
 ```python
 reg = dcc_mcp_core.ToolRegistry()
@@ -897,6 +901,7 @@ ann = dcc_mcp_core.ToolAnnotations(
     destructive_hint=False,   # True = deletes/overwrites data
     idempotent_hint=True,     # True = safe to call multiple times
     open_world_hint=False,    # True = may affect external/open-ended state
+    deferred_hint=None,        # True = full schema deferred until load_skill (set by server)
 )
 ```
 
@@ -2231,6 +2236,22 @@ config = McpHttpConfig(
 print(config.port)          # 8765
 print(config.server_name)   # "maya-mcp"
 print(config.server_version) # "1.0.0"
+```
+
+```python
+
+# Opt-in: lazy-actions fast-path — tools/list surfaces only 3 meta-tools
+# (list_actions, describe_action, call_action) instead of all tools
+config.lazy_actions = True  # default: False
+
+# Gateway participation
+config.gateway_port = 9765  # 0 = disabled (default)
+config.dcc_type = "maya"
+config.dcc_version = "2025"
+config.scene = "/proj/shot01.ma"  # optional: helps routing by scene
+
+# Session management
+config.session_ttl_secs = 3600  # idle session eviction (0 = disable)
 ```
 
 ### McpHttpServer

--- a/llms.txt
+++ b/llms.txt
@@ -66,10 +66,11 @@ meta = dcc_mcp_core.parse_skill_md(dirs[0])  # -> SkillMetadata or None
 
 ## Architecture
 
-Rust workspace (14 crates) with PyO3 bindings. All logic in Rust sub-crates; Python gets a single `dcc_mcp_core._core` extension module. The `dcc_mcp_core` package re-exports all ~154 public symbols from `_core` plus pure-Python helpers (DccServerBase, DccGatewayElection, DccSkillHotReloader, factory, skill helpers).
+Rust workspace (15 crates) with PyO3 bindings. All logic in Rust sub-crates; Python gets a single `dcc_mcp_core._core` extension module. The `dcc_mcp_core` package re-exports all ~171 public symbols from `_core` plus pure-Python helpers (DccServerBase, DccGatewayElection, DccSkillHotReloader, factory, skill helpers).
 
 ```
 crates/
+├── dcc-mcp-naming/      # SEP-986 tool-name / action-id validators (TOOL_NAME_RE, validate_tool_name)
 ├── dcc-mcp-models/      # ToolResult, SkillMetadata
 ├── dcc-mcp-actions/     # ToolRegistry, ToolDispatcher, ToolValidator, EventBus, ToolPipeline
 ├── dcc-mcp-skills/      # SkillScanner, SkillWatcher, parse_skill_md, dependency resolver
@@ -88,7 +89,7 @@ crates/
 
 ## Core Concepts
 
-- **ToolRegistry**: Thread-safe registry for action metadata (name, description, dcc, tags, schemas, version)
+- **ToolRegistry**: Thread-safe registry for tool metadata (name, description, dcc, tags, schemas, version)
 - **ToolResult**: Structured result (success, message, prompt, error, context dict) — AI-friendly with follow-up hints
 - **EventBus**: Thread-safe publish/subscribe system with per-event subscriber lists
 - **SkillScanner**: Discovers SKILL.md files in directories with mtime-based caching
@@ -102,7 +103,7 @@ crates/
 ### Top-level exports (`dcc_mcp_core`)
 
 **Actions:**
-- `ToolRegistry` — Thread-safe registry; `.register(name, ...)`, `.register_batch([{...}, ...])`, `.unregister(name, dcc_name=None)`, `.get_action(name)`, `.list_actions()`, `.list_actions_for_dcc(dcc)`, `.get_all_dccs()`, `.search_actions(category, tags, dcc_name)`, `.get_categories()`, `.get_tags()`, `.reset()`
+- `ToolRegistry` — Thread-safe registry; `.register(name, ...)`, `.register_batch([{...}, ...])`, `.unregister(name, dcc_name=None)`, `.get_action(name)`, `.list_actions()`, `.list_actions_for_dcc(dcc)`, `.get_all_dccs()`, `.search_actions(category, tags, dcc_name)`, `.count_actions(category, tags, dcc_name)`, `.get_categories()`, `.get_tags()`, `.reset()`
 - `ToolDispatcher` — Validated dispatch; `ToolDispatcher(registry)` (ONE arg); `.dispatch(name, json_str) -> dict`; dict keys: `"action"`, `"output"`, `"validation_skipped"`
 - `ToolValidator` — Input validation before action execution
 - `ToolPipeline(dispatcher)` — Middleware-style processing pipeline; `.add_logging(log_params=False)`, `.add_timing() -> TimingMiddleware`, `.add_audit(record_params=True) -> AuditMiddleware`, `.add_rate_limit(max_calls, window_ms) -> RateLimitMiddleware`, `.add_callable(before_fn=None, after_fn=None)`, `.dispatch(action_name, params_json="null") -> dict`, `.register_handler(name, fn)`, `.middleware_count()`, `.middleware_names()`, `.handler_count()`
@@ -124,7 +125,7 @@ crates/
 - `from_exception(error_message, message=None, include_traceback=False, ...) -> ToolResult`
 - `validate_action_result(result) -> ToolResult` — normalize dict/str/None → ToolResult
 
-**ToolResult fields:** `.success`, `.message`, `.prompt`, `.error`, `.context`, `.to_dict()`, `.with_error(err)`, `.with_context(**kw)`
+**ToolResult fields:** `.success`, `.message`, `.prompt`, `.error`, `.context`, `.to_dict()`, `.to_json()`, `.with_error(err)`, `.with_context(**kw)`
 
 **Skills:**
 - `SkillScanner` — `.scan(extra_paths=None, dcc_name=None, force_refresh=False) -> List[str]`
@@ -162,7 +163,7 @@ crates/
 - **Note**: `ActionMeta` is a Rust-internal type not accessible from Python. Use the `ToolRegistry` methods above to control tool visibility.
 - MCP core tools: `activate_tool_group`, `deactivate_tool_group`, `search_tools` (registered alongside the six skill-discovery tools; `tools/list` also emits `__group__<skill>.<group>` stubs for inactive groups)
 
-**Action naming**: `{skill_name}__{script_stem}` — hyphens in skill names replaced by underscores
+**Action naming**: `{skill_name}__{script_stem}` — hyphens in skill names replaced by underscores. SEP-986 dot-namespacing (`skill.tool_name`) also supported — see `docs/guide/naming.md` for validation rules (`validate_tool_name`, `validate_action_id`)
 
 **`next-tools` (dcc-mcp-core extension):** Declared per-tool in SKILL.md frontmatter to guide AI agents to follow-up tools:
 ```yaml
@@ -180,9 +181,10 @@ tools:
 ### MCP Protocol Types (`dcc_mcp_core`)
 
 - `ToolDefinition(name, description, input_schema, output_schema=None, annotations=None)`
-- `ToolAnnotations(title=None, read_only_hint=None, destructive_hint=None, idempotent_hint=None, open_world_hint=None)`
-- `ResourceDefinition(uri, name, description, mime_type="text/plain")`
-- `ResourceTemplateDefinition(uri_template, name, description, mime_type="text/plain")`
+- `ToolAnnotations(title=None, read_only_hint=None, destructive_hint=None, idempotent_hint=None, open_world_hint=None, deferred_hint=None)`
+- `ResourceAnnotations(audience=None, priority=None)`
+- `ResourceDefinition(uri, name, description, mime_type="text/plain", annotations=None)`
+- `ResourceTemplateDefinition(uri_template, name, description, mime_type="text/plain", annotations=None)`
 - `PromptDefinition(name, description, arguments=None)`
 - `PromptArgument(name, description, required=False)`
 - `DccInfo`, `DccCapabilities`, `DccError`, `DccErrorCode`
@@ -209,6 +211,9 @@ tools:
 ### MCP HTTP Server (`dcc_mcp_core`)
 
 - `McpHttpConfig(port=8765, server_name=None, server_version=None, enable_cors=False, request_timeout_ms=30000)` — server configuration
+  - `.lazy_actions = True` — opt-in: `tools/list` surfaces only 3 meta-tools (`list_actions`, `describe_action`, `call_action`) instead of all tools
+  - `.session_ttl_secs` — idle session eviction (default 3600s)
+  - `.gateway_port`, `.registry_dir`, `.stale_timeout_secs`, `.heartbeat_secs`, `.dcc_type`, `.dcc_version`, `.scene` — gateway participation config
 - `McpHttpServer(registry, config=None)` — MCP Streamable HTTP server (**2025-03-26 spec**), axum/Tokio backend
   - `.start() -> McpServerHandle` — starts background thread, returns immediately
   - **Note**: MCP 2025-03-26 implements Streamable HTTP, Tool Annotations, OAuth 2.1. MCP 2025-06-18 adds Structured Tool Output, Elicitation, Resource Links, and removes JSON-RPC batching. MCP 2025-11-25 adds icon metadata, Tasks, Sampling with tools. Do NOT implement manually — wait for library support.
@@ -329,7 +334,15 @@ tools:
 - `APP_NAME = "dcc-mcp"`, `APP_AUTHOR = "dcc-mcp"`
 - `DEFAULT_DCC = "python"`, `DEFAULT_LOG_LEVEL = "DEBUG"`, `DEFAULT_MIME_TYPE = "text/plain"`, `DEFAULT_VERSION = "1.0.0"`
 - `SKILL_METADATA_FILE = "SKILL.md"`, `SKILL_SCRIPTS_DIR = "scripts"`, `SKILL_METADATA_DIR = "metadata"`
-- `ENV_SKILL_PATHS = "DCC_MCP_SKILL_PATHS"`, `ENV_LOG_LEVEL = "MCP_LOG_LEVEL"`
+- `ENV_SKILL_PATHS = "DCC_MCP_SKILL_PATHS"`, `ENV_LOG_LEVEL = "MCP_LOG_LEVEL"
+- `TOOL_NAME_RE` / `ACTION_ID_RE` — SEP-986 regex patterns for tool names and action IDs
+- `MAX_TOOL_NAME_LEN = 48` — maximum tool name length
+
+### SEP-986 Naming Validators (`dcc_mcp_core`)
+
+- `validate_tool_name(name: str) -> None` — raise `ValueError` if name doesn't match `TOOL_NAME_RE` (dot-separated lowercase, max 48 chars)
+- `validate_action_id(name: str) -> None` — raise `ValueError` if id doesn't match `ACTION_ID_RE` (dotted lowercase identifier chain)
+- See `docs/guide/naming.md` for the full naming rules`
 
 ## Skills System
 


### PR DESCRIPTION
## Summary
- Fix crate count 14 → 15 (`dcc-mcp-naming` added in v0.13.3)
- Add SEP-986 naming validators (`validate_tool_name`, `validate_action_id`, `TOOL_NAME_RE`, `ACTION_ID_RE`, `MAX_TOOL_NAME_LEN`) across AGENTS.md, llms.txt, llms-full.txt, getting-started.md
- Add `lazy_actions` (McpHttpConfig opt-in fast-path) documentation
- Add `ToolAnnotations.deferred_hint` and `open_world_hint` fields
- Add `ToolResult.to_json()` / `keys()` / `__iter__()` documentation
- Add `ResourceAnnotations` class and `annotations` param on `ResourceDefinition`/`ResourceTemplateDefinition`
- Add McpHttpServer skill methods to http.md (`discover`, `load_skill`, etc.)
- Fix `McpServerHandle` alias tip (was referencing same name twice)
- Fix `SkillMetadata.tools` type `List[str]` → `List[ToolDeclaration]`
- Add dot-namespacing reference in skills.md and llms.txt
- Update "AI-initiated actions" → "AI-initiated tool calls"

## Test plan
- [x] Pre-commit hooks pass (ruff, cargo fmt/clippy, trailing whitespace)
- [ ] CI docs-only path (no Rust rebuild needed)
- [ ] Visual review of llms.txt / AGENTS.md for accuracy vs `_core.pyi`