### PR TITLE
refactor(shm): migrate from memmap2 to ipckit SharedMemory with TTL support

### DIFF
--- a/crates/dcc-mcp-shm/Cargo.toml
+++ b/crates/dcc-mcp-shm/Cargo.toml
@@ -16,17 +16,17 @@ thiserror.workspace = true
 tracing.workspace = true
 uuid.workspace = true
 parking_lot.workspace = true
-memmap2.workspace = true
+ipckit.workspace = true
 lz4_flex.workspace = true
 
 # PyO3 (optional)
 pyo3 = { workspace = true, optional = true }
 
+# libc needed for shm_unlink in gc_orphans (Unix only)
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
 
 [dev-dependencies]
-tempfile = "3"
 serde_json.workspace = true
 
 [features]

--- a/crates/dcc-mcp-shm/src/buffer.rs
+++ b/crates/dcc-mcp-shm/src/buffer.rs
@@ -1,36 +1,63 @@
 //! `SharedBuffer` — a named, fixed-size region of memory visible to multiple
-//! OS processes via an anonymous memory-mapped file.
+//! OS processes via ipckit's OS-native shared memory.
 //!
 //! # Design
-//! We back each buffer with a temporary file so that:
-//!  1. The same `SharedBuffer` can be passed to another process by sending the
-//!     file descriptor / file path.
+//! We back each buffer with an ipckit `SharedMemory` region (POSIX `shm_open`
+//! on Unix, `CreateFileMappingW` on Windows) so that:
+//!  1. The same `SharedBuffer` can be opened by another process using the
+//!     segment name.
 //!  2. The OS reclaims the memory when the last handle is dropped (RAII).
+//!  3. On Windows the kernel reference-counts named file-mappings; on Unix
+//!     the owner's Drop calls `shm_unlink`.
 //!
-//! For same-process zero-copy we expose `as_slice` / `as_slice_mut`.
+//! # Header layout
+//! ```text
+//! Offset  Size  Content
+//! 0       8     magic (0xDCC0_0000_5348_4D01)
+//! 8       8     data_len (logical data length)
+//! 16      8     capacity (max data bytes, excluding header)
+//! 24      8     created_at_secs (UNIX timestamp)
+//! 32      8     ttl_secs (0 = no TTL)
+//! 40      1     compressed flag
+//! 41      7     reserved / alignment padding
+//! 48      ..    User data (up to `capacity` bytes)
+//! ```
+//!
+//! # Orphan GC
+//! DCC applications can crash at any time, leaving shared memory segments
+//! behind.  Call [`gc_orphans`] at startup (and optionally in an idle loop)
+//! to scan for and remove stale segments whose TTL has expired.
 
 use std::fmt;
-use std::fs::OpenOptions;
-use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use memmap2::MmapMut;
+use ipckit::SharedMemory;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::error::{ShmError, ShmResult};
 
-// ── Header stored at byte 0 of the mapped region ────────────────────────────
+// ── Header stored at byte 0 of the shared region ────────────────────────────
 
-/// Fixed-size header written at the start of every mapped region.
+/// Fixed-size header written at the start of every shared region.
+///
+/// Total size: 48 bytes.
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub(crate) struct RegionHeader {
-    /// Magic marker to detect corruption.
+    /// Magic marker to detect corruption (0xDCC0_0000_5348_4D01).
     pub magic: u64,
     /// Logical data length (may be < capacity).
     pub data_len: u64,
+    /// Capacity in bytes (excludes header) — stored so `open` can recover
+    /// the original value even when the OS rounds up the mapping size.
+    pub capacity: u64,
+    /// Creation timestamp (seconds since UNIX epoch).
+    pub created_at_secs: u64,
+    /// Time-to-live in seconds (0 = no TTL / never expires).
+    pub ttl_secs: u64,
     /// Whether the content is lz4-compressed.
     pub compressed: u8,
     /// Alignment padding.
@@ -40,34 +67,30 @@ pub(crate) struct RegionHeader {
 pub(crate) const HEADER_MAGIC: u64 = 0xDCC0_0000_5348_4D01;
 pub(crate) const HEADER_SIZE: usize = std::mem::size_of::<RegionHeader>();
 
+/// Prefix used for all ipckit segment names created by dcc-mcp-shm.
+const SEGMENT_PREFIX: &str = "dcc_shm_";
+
 // ── BufferHandle — the Arc-backed inner state ────────────────────────────────
 
 struct BufferInner {
-    /// The path of the backing temp file (kept alive for the buffer lifetime).
-    path: PathBuf,
+    /// The ipckit shared memory region.
+    shm: Mutex<SharedMemory>,
     /// Capacity in bytes (does NOT include the header).
     capacity: usize,
-    /// The memory-mapped view.
-    mmap: Mutex<MmapMut>,
 }
 
-impl Drop for BufferInner {
-    fn drop(&mut self) {
-        // Best-effort removal; ignore errors (e.g. already cleaned up).
-        let _ = std::fs::remove_file(&self.path);
-    }
-}
+// No custom Drop needed — ipckit::SharedMemory handles OS cleanup on Drop.
 
 // ── Public API ───────────────────────────────────────────────────────────────
 
-/// A fixed-capacity shared memory buffer backed by a memory-mapped file.
+/// A fixed-capacity shared memory buffer backed by an ipckit shared segment.
 ///
-/// Multiple `SharedBuffer` handles can map the same file by calling
+/// Multiple `SharedBuffer` handles can map the same segment by calling
 /// [`SharedBuffer::open`].
 #[derive(Clone)]
 pub struct SharedBuffer {
     inner: Arc<BufferInner>,
-    /// Human-readable name / ID (not the file path).
+    /// Human-readable name / ID (also part of the ipckit segment name).
     pub id: String,
 }
 
@@ -81,16 +104,29 @@ impl fmt::Debug for SharedBuffer {
 }
 
 impl SharedBuffer {
-    /// Create a new buffer backed by an anonymous temp file.
+    /// Create a new buffer backed by an ipckit shared memory segment.
     ///
     /// `capacity` is the maximum number of *data* bytes (header is added
     /// automatically).
     pub fn create(capacity: usize) -> ShmResult<Self> {
-        Self::create_with_id(Uuid::new_v4().to_string(), capacity)
+        Self::create_with_ttl(Uuid::new_v4().to_string(), capacity, None)
     }
 
-    /// Create a buffer with an explicit string id (useful for tests).
+    /// Create a buffer with an explicit string id (used as the ipckit segment name).
     pub fn create_with_id(id: impl Into<String>, capacity: usize) -> ShmResult<Self> {
+        Self::create_with_ttl(id, capacity, None)
+    }
+
+    /// Create a buffer with an optional time-to-live.
+    ///
+    /// When `ttl` is `Some`, the segment header stores the creation timestamp
+    /// and TTL so that [`gc_orphans`] can detect and remove stale segments
+    /// left behind by crashed DCC processes.
+    pub fn create_with_ttl(
+        id: impl Into<String>,
+        capacity: usize,
+        ttl: Option<Duration>,
+    ) -> ShmResult<Self> {
         if capacity == 0 {
             return Err(ShmError::InvalidArgument(
                 "capacity must be greater than 0".into(),
@@ -100,77 +136,85 @@ impl SharedBuffer {
         let id = id.into();
         let total = HEADER_SIZE + capacity;
 
-        // Create a temp file for the backing store.
-        let tmp_dir = std::env::temp_dir().join("dcc_mcp_shm");
-        std::fs::create_dir_all(&tmp_dir)?;
-        let path = tmp_dir.join(format!("{}.shm", id));
+        let segment_name = format!("{SEGMENT_PREFIX}{id}");
 
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create_new(true)
-            .open(&path)
-            .map_err(|e| {
-                if e.kind() == std::io::ErrorKind::AlreadyExists {
-                    ShmError::AlreadyExists { name: id.clone() }
-                } else {
-                    ShmError::Io(e)
-                }
-            })?;
+        let mut shm = SharedMemory::create(&segment_name, total).map_err(|e| {
+            let msg = e.to_string();
+            if msg.contains("already exists") || msg.contains("AlreadyExists") {
+                ShmError::AlreadyExists { name: id.clone() }
+            } else {
+                ShmError::Internal(format!("SharedMemory::create failed: {msg}"))
+            }
+        })?;
 
-        // Pre-allocate.
-        file.set_len(total as u64)?;
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
 
-        // SAFETY: the file is valid and sized; we hold the file handle.
-        let mut mmap =
-            unsafe { MmapMut::map_mut(&file) }.map_err(|e| ShmError::Mmap(e.to_string()))?;
-
-        // Write initial header.
         let header = RegionHeader {
             magic: HEADER_MAGIC,
             data_len: 0,
+            capacity: capacity as u64,
+            created_at_secs: now,
+            ttl_secs: ttl.map(|d| d.as_secs()).unwrap_or(0),
             compressed: 0,
             _pad: [0u8; 7],
         };
-        mmap[..HEADER_SIZE].copy_from_slice(unsafe {
+        let header_bytes = unsafe {
             std::slice::from_raw_parts(&header as *const RegionHeader as *const u8, HEADER_SIZE)
-        });
-        mmap.flush()?;
+        };
+        shm.write(0, header_bytes)
+            .map_err(|e| ShmError::Internal(format!("header write failed: {e}")))?;
 
-        tracing::debug!(id = %id, capacity, "SharedBuffer created");
+        tracing::debug!(id = %id, capacity, ttl_secs = header.ttl_secs, "SharedBuffer created");
 
         Ok(Self {
             inner: Arc::new(BufferInner {
-                path,
+                shm: Mutex::new(shm),
                 capacity,
-                mmap: Mutex::new(mmap),
             }),
             id,
         })
     }
 
-    /// Open an existing buffer by file path (for cross-process use).
-    pub fn open(path: impl AsRef<Path>, id: impl Into<String>) -> ShmResult<Self> {
-        let path = path.as_ref().to_path_buf();
+    /// Open an existing buffer by its ipckit segment name (for cross-process use).
+    pub fn open(name: impl AsRef<str>, id: impl Into<String>) -> ShmResult<Self> {
+        let name = name.as_ref().to_string();
         let id = id.into();
 
-        let file = OpenOptions::new().read(true).write(true).open(&path)?;
+        let shm = SharedMemory::open(&name).map_err(|e| {
+            let msg = e.to_string();
+            if msg.contains("not found") || msg.contains("NotFound") {
+                ShmError::NotFound { name: name.clone() }
+            } else {
+                ShmError::Internal(format!("SharedMemory::open failed: {msg}"))
+            }
+        })?;
 
-        let file_len = file.metadata()?.len() as usize;
-        if file_len < HEADER_SIZE {
+        let total = shm.size();
+        if total < HEADER_SIZE {
             return Err(ShmError::InvalidArgument(
-                "file too small to be a SharedBuffer".into(),
+                "segment too small to be a SharedBuffer".into(),
             ));
         }
-        let capacity = file_len - HEADER_SIZE;
 
-        let mmap = unsafe { MmapMut::map_mut(&file) }.map_err(|e| ShmError::Mmap(e.to_string()))?;
+        // Read capacity from the header rather than computing from OS mapping
+        // size (which may be page-aligned and larger than the original request).
+        let header_bytes = shm
+            .read(0, HEADER_SIZE)
+            .map_err(|e| ShmError::Internal(format!("header read failed: {e}")))?;
+        let header: RegionHeader =
+            unsafe { std::ptr::read_unaligned(header_bytes.as_ptr() as *const RegionHeader) };
+        if header.magic != HEADER_MAGIC {
+            return Err(ShmError::Internal("invalid magic bytes in header".into()));
+        }
+        let capacity = header.capacity as usize;
 
         Ok(Self {
             inner: Arc::new(BufferInner {
-                path,
+                shm: Mutex::new(shm),
                 capacity,
-                mmap: Mutex::new(mmap),
             }),
             id,
         })
@@ -182,9 +226,18 @@ impl SharedBuffer {
         self.inner.capacity
     }
 
-    /// Backing file path (used for cross-process handoff).
-    pub fn path(&self) -> &Path {
-        &self.inner.path
+    /// Segment name used for cross-process handoff (ipckit name).
+    pub fn name(&self) -> String {
+        format!("{SEGMENT_PREFIX}{}", self.id)
+    }
+
+    /// Returns `true` if this buffer's TTL has expired.
+    ///
+    /// Buffers without a TTL (`ttl_secs == 0`) never expire.
+    pub fn is_expired(&self) -> ShmResult<bool> {
+        let shm = self.inner.shm.lock();
+        let header = self.read_header(&shm)?;
+        Ok(is_header_expired(&header))
     }
 
     /// Write `data` into the buffer.
@@ -198,23 +251,29 @@ impl SharedBuffer {
             });
         }
 
-        let mut mmap = self.inner.mmap.lock();
+        let mut shm = self.inner.shm.lock();
         let len = data.len();
 
-        // Update header.
+        // Read existing header to preserve TTL fields.
+        let existing = self.read_header_unlocked(&shm)?;
         let header = RegionHeader {
             magic: HEADER_MAGIC,
             data_len: len as u64,
+            capacity: self.inner.capacity as u64,
+            created_at_secs: existing.created_at_secs,
+            ttl_secs: existing.ttl_secs,
             compressed: 0,
             _pad: [0u8; 7],
         };
-        mmap[..HEADER_SIZE].copy_from_slice(unsafe {
+        let header_bytes = unsafe {
             std::slice::from_raw_parts(&header as *const RegionHeader as *const u8, HEADER_SIZE)
-        });
+        };
+        shm.write(0, header_bytes)
+            .map_err(|e| ShmError::Internal(format!("header write failed: {e}")))?;
 
         // Copy data.
-        mmap[HEADER_SIZE..HEADER_SIZE + len].copy_from_slice(data);
-        mmap.flush()?;
+        shm.write(HEADER_SIZE, data)
+            .map_err(|e| ShmError::Internal(format!("data write failed: {e}")))?;
 
         tracing::trace!(id = %self.id, bytes = len, "SharedBuffer written");
         Ok(len)
@@ -224,59 +283,205 @@ impl SharedBuffer {
     ///
     /// Returns a `Vec<u8>` copy (safe to hold across lock boundaries).
     pub fn read(&self) -> ShmResult<Vec<u8>> {
-        let mmap = self.inner.mmap.lock();
-        let header = self.read_header(&mmap)?;
+        let shm = self.inner.shm.lock();
+        let header = self.read_header(&shm)?;
 
         let len = header.data_len as usize;
         if len == 0 {
             return Ok(vec![]);
         }
-        if HEADER_SIZE + len > mmap.len() {
+        if HEADER_SIZE + len > shm.size() {
             return Err(ShmError::Internal(
-                "header data_len exceeds mmap size".into(),
+                "header data_len exceeds shm size".into(),
             ));
         }
 
-        Ok(mmap[HEADER_SIZE..HEADER_SIZE + len].to_vec())
+        shm.read(HEADER_SIZE, len)
+            .map_err(|e| ShmError::Internal(format!("data read failed: {e}")))
     }
 
     /// Returns the number of bytes currently stored (from header).
     pub fn data_len(&self) -> ShmResult<usize> {
-        let mmap = self.inner.mmap.lock();
-        let header = self.read_header(&mmap)?;
+        let shm = self.inner.shm.lock();
+        let header = self.read_header(&shm)?;
         Ok(header.data_len as usize)
     }
 
     /// Zero out the data region and reset `data_len` to 0.
     pub fn clear(&self) -> ShmResult<()> {
-        let mut mmap = self.inner.mmap.lock();
+        let mut shm = self.inner.shm.lock();
+        let existing = self.read_header_unlocked(&shm)?;
         let header = RegionHeader {
             magic: HEADER_MAGIC,
             data_len: 0,
+            capacity: self.inner.capacity as u64,
+            created_at_secs: existing.created_at_secs,
+            ttl_secs: existing.ttl_secs,
             compressed: 0,
             _pad: [0u8; 7],
         };
-        mmap[..HEADER_SIZE].copy_from_slice(unsafe {
+        let header_bytes = unsafe {
             std::slice::from_raw_parts(&header as *const RegionHeader as *const u8, HEADER_SIZE)
-        });
-        mmap.flush()?;
+        };
+        shm.write(0, header_bytes)
+            .map_err(|e| ShmError::Internal(format!("clear header write failed: {e}")))?;
         Ok(())
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────
 
-    fn read_header(&self, mmap: &MmapMut) -> ShmResult<RegionHeader> {
-        if mmap.len() < HEADER_SIZE {
-            return Err(ShmError::Internal("mmap too small for header".into()));
+    fn read_header(&self, shm: &SharedMemory) -> ShmResult<RegionHeader> {
+        Self::read_header_from(shm)
+    }
+
+    fn read_header_unlocked(&self, shm: &SharedMemory) -> ShmResult<RegionHeader> {
+        Self::read_header_from(shm)
+    }
+
+    fn read_header_from(shm: &SharedMemory) -> ShmResult<RegionHeader> {
+        if shm.size() < HEADER_SIZE {
+            return Err(ShmError::Internal("shm too small for header".into()));
         }
+        let bytes = shm
+            .read(0, HEADER_SIZE)
+            .map_err(|e| ShmError::Internal(format!("header read failed: {e}")))?;
         // SAFETY: the region has been sized to hold the header at construction.
         let header: RegionHeader =
-            unsafe { std::ptr::read_unaligned(mmap.as_ptr() as *const RegionHeader) };
+            unsafe { std::ptr::read_unaligned(bytes.as_ptr() as *const RegionHeader) };
         if header.magic != HEADER_MAGIC {
             return Err(ShmError::Internal("invalid magic bytes in header".into()));
         }
         Ok(header)
     }
+}
+
+// ── TTL helper ──────────────────────────────────────────────────────────────
+
+fn is_header_expired(header: &RegionHeader) -> bool {
+    if header.ttl_secs == 0 {
+        return false;
+    }
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    now.saturating_sub(header.created_at_secs) > header.ttl_secs
+}
+
+// ── Orphan GC ───────────────────────────────────────────────────────────────
+
+/// Scan the OS shared-memory namespace for `dcc_shm_*` segments whose TTL
+/// has expired and remove them.
+///
+/// Returns the number of segments removed.
+///
+/// # Platform note
+/// On **Unix**, the scan enumerates `/dev/shm` (Linux) or `/tmp` (macOS);
+/// on **Windows** the kernel reference-counts named file-mappings — they
+/// vanish when all handles close, so GC is a no-op.
+///
+/// Call this at startup and optionally in an idle timer.
+pub fn gc_orphans(max_age: Duration) -> usize {
+    #[cfg(target_os = "linux")]
+    {
+        gc_orphans_scan("/dev/shm", max_age)
+    }
+    #[cfg(target_os = "macos")]
+    {
+        gc_orphans_scan("/tmp", max_age)
+    }
+    #[cfg(windows)]
+    {
+        let _ = max_age;
+        0
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+    {
+        let _ = max_age;
+        0
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn gc_orphans_scan(shm_dir: &str, max_age: Duration) -> usize {
+    use std::ffi::CString;
+
+    let dir = match std::fs::read_dir(shm_dir) {
+        Ok(d) => d,
+        Err(_) => return 0,
+    };
+
+    let now = SystemTime::now();
+    let max_age_secs = max_age.as_secs();
+    let mut removed = 0;
+
+    for entry in dir.flatten() {
+        let fname = match entry.file_name().to_str() {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+
+        // Only inspect segments that look like ours.
+        if !fname.starts_with(SEGMENT_PREFIX) {
+            continue;
+        }
+
+        let shm = match SharedMemory::open(&fname) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+
+        // Read and validate header.
+        if shm.size() < HEADER_SIZE {
+            continue;
+        }
+        let bytes = match shm.read(0, HEADER_SIZE) {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        let header: RegionHeader =
+            unsafe { std::ptr::read_unaligned(bytes.as_ptr() as *const RegionHeader) };
+        if header.magic != HEADER_MAGIC {
+            continue;
+        }
+
+        // Check if expired via TTL.
+        let expired_by_ttl = is_header_expired(&header);
+
+        // Also check max_age: if the segment is older than max_age and has
+        // no active holders (the OS refcount would keep us from opening it
+        // if the owner were still alive on some platforms, but we use
+        // creation-time as a heuristic).
+        let age = now
+            .duration_since(UNIX_EPOCH + Duration::from_secs(header.created_at_secs))
+            .unwrap_or_default();
+
+        let expired_by_age = header.ttl_secs == 0 && age.as_secs() > max_age_secs;
+
+        if !expired_by_ttl && !expired_by_age {
+            continue;
+        }
+
+        // Unlink
+        #[cfg(unix)]
+        {
+            let link_name = if fname.starts_with('/') {
+                fname.clone()
+            } else {
+                format!("/{fname}")
+            };
+            let c_name = match CString::new(link_name) {
+                Ok(n) => n,
+                Err(_) => continue,
+            };
+            unsafe {
+                libc::shm_unlink(c_name.as_ptr());
+            }
+            removed += 1;
+        }
+    }
+
+    removed
 }
 
 // ── Serialisable descriptor for cross-process handoff ───────────────────────
@@ -287,20 +492,26 @@ impl SharedBuffer {
 pub struct BufferDescriptor {
     /// Human-readable id.
     pub id: String,
-    /// Absolute path to the backing file.
-    pub path: String,
+    /// ipckit segment name (used by `SharedBuffer::open`).
+    pub name: String,
     /// Capacity in bytes.
     pub capacity: usize,
+    /// Optional TTL in seconds (0 = no TTL).
+    #[serde(default)]
+    pub ttl_secs: u64,
 }
 
 impl BufferDescriptor {
     /// Build a descriptor from an existing [`SharedBuffer`].
-    pub fn from_buffer(buf: &SharedBuffer) -> Self {
-        Self {
+    pub fn from_buffer(buf: &SharedBuffer) -> ShmResult<Self> {
+        let shm = buf.inner.shm.lock();
+        let header = buf.read_header(&shm)?;
+        Ok(Self {
             id: buf.id.clone(),
-            path: buf.path().to_string_lossy().into_owned(),
+            name: buf.name(),
             capacity: buf.capacity(),
-        }
+            ttl_secs: header.ttl_secs,
+        })
     }
 
     /// Serialise to JSON.
@@ -401,7 +612,7 @@ mod tests {
         #[test]
         fn test_descriptor_roundtrip_json() {
             let buf = SharedBuffer::create(2048).unwrap();
-            let desc = BufferDescriptor::from_buffer(&buf);
+            let desc = BufferDescriptor::from_buffer(&buf).unwrap();
             let json = desc.to_json().unwrap();
             let desc2 = BufferDescriptor::from_json(&json).unwrap();
             assert_eq!(desc2.capacity, 2048);
@@ -412,8 +623,8 @@ mod tests {
         fn test_open_via_descriptor() {
             let buf = SharedBuffer::create(1024).unwrap();
             buf.write(b"cross-process").unwrap();
-            let desc = BufferDescriptor::from_buffer(&buf);
-            let buf2 = SharedBuffer::open(&desc.path, &desc.id).unwrap();
+            let desc = BufferDescriptor::from_buffer(&buf).unwrap();
+            let buf2 = SharedBuffer::open(&desc.name, &desc.id).unwrap();
             let out = buf2.read().unwrap();
             assert_eq!(out, b"cross-process");
         }
@@ -438,6 +649,56 @@ mod tests {
             buf2.write(b"written by clone").unwrap();
             let out = buf.read().unwrap();
             assert_eq!(out, b"written by clone");
+        }
+    }
+
+    mod test_ttl {
+        use super::*;
+
+        #[test]
+        fn test_no_ttl_never_expired() {
+            let buf = SharedBuffer::create(256).unwrap();
+            assert!(!buf.is_expired().unwrap());
+        }
+
+        #[test]
+        fn test_long_ttl_not_expired() {
+            let buf = SharedBuffer::create_with_ttl(
+                "ttl-long",
+                256,
+                Some(Duration::from_secs(3600)).into(),
+            )
+            .unwrap();
+            assert!(!buf.is_expired().unwrap());
+        }
+
+        #[test]
+        fn test_descriptor_contains_ttl() {
+            let buf = SharedBuffer::create_with_ttl(
+                "ttl-desc",
+                256,
+                Some(Duration::from_secs(30)).into(),
+            )
+            .unwrap();
+            let desc = BufferDescriptor::from_buffer(&buf).unwrap();
+            assert_eq!(desc.ttl_secs, 30);
+        }
+
+        #[test]
+        fn test_descriptor_zero_ttl_when_none() {
+            let buf = SharedBuffer::create(256).unwrap();
+            let desc = BufferDescriptor::from_buffer(&buf).unwrap();
+            assert_eq!(desc.ttl_secs, 0);
+        }
+    }
+
+    mod test_gc {
+        use super::*;
+
+        #[test]
+        fn test_gc_orphans_returns_usize() {
+            // Just ensure the function compiles and returns without panic.
+            let _ = gc_orphans(Duration::from_secs(60));
         }
     }
 }

--- a/crates/dcc-mcp-shm/src/chunked.rs
+++ b/crates/dcc-mcp-shm/src/chunked.rs
@@ -98,7 +98,7 @@ pub fn write_chunked(
         let buf = SharedBuffer::create(stored_len.max(1))?;
         buf.write(&to_write)?;
 
-        let descriptor = BufferDescriptor::from_buffer(&buf);
+        let descriptor = BufferDescriptor::from_buffer(&buf)?;
         chunk_infos.push(ChunkInfo {
             index,
             descriptor,
@@ -141,7 +141,7 @@ pub fn read_chunked(manifest: &ChunkManifest) -> ShmResult<Vec<u8>> {
             });
         }
 
-        let buf = SharedBuffer::open(&chunk_info.descriptor.path, &chunk_info.descriptor.id)?;
+        let buf = SharedBuffer::open(&chunk_info.descriptor.name, &chunk_info.descriptor.id)?;
         let raw = buf.read()?;
 
         if chunk_info.compressed {

--- a/crates/dcc-mcp-shm/src/lib.rs
+++ b/crates/dcc-mcp-shm/src/lib.rs
@@ -6,13 +6,13 @@
 //! serialising and sending over TCP, which can take 10-30 s for a 1 GB scene.
 //!
 //! `dcc-mcp-shm` provides a **zero-copy** alternative: the DCC side writes
-//! data directly into a memory-mapped file; the consumer reads from the same
+//! data directly into an ipckit shared memory segment; the consumer reads from the same
 //! mapped region without any copying or serialisation.
 //!
 //! # Modules
 //! | Module | Purpose |
 //! |--------|---------|
-//! | [`buffer`] | `SharedBuffer` — single named region backed by a temp mmap file |
+//! | [`buffer`] | `SharedBuffer` — single named region backed by ipckit shared memory |
 //! | [`compress`] | LZ4 frame compression/decompression helpers |
 //! | [`pool`] | `BufferPool` — reusable pool of pre-allocated buffers |
 //! | [`chunked`] | Chunked transfer for data > 256 MiB |
@@ -54,7 +54,7 @@ pub mod scene;
 pub mod python;
 
 // Re-export most-used types at crate root.
-pub use buffer::{BufferDescriptor, SharedBuffer};
+pub use buffer::{BufferDescriptor, SharedBuffer, gc_orphans};
 pub use chunked::{ChunkManifest, DEFAULT_CHUNK_SIZE};
 pub use error::{ShmError, ShmResult};
 pub use pool::BufferPool;

--- a/crates/dcc-mcp-shm/src/pool.rs
+++ b/crates/dcc-mcp-shm/src/pool.rs
@@ -1,8 +1,8 @@
 //! `BufferPool` — a fixed-capacity pool of pre-allocated [`SharedBuffer`]s.
 //!
 //! # Purpose
-//! Allocating a new shared-memory region involves creating a temp file, an
-//! mmap syscall, and zeroing the header.  For high-frequency use-cases (e.g.
+//! Allocating a new shared-memory region involves creating an ipckit segment
+//! and writing the header.  For high-frequency use-cases (e.g.
 //! 30 fps scene snapshots) repeated allocation is expensive.  A pool amortises
 //! this cost by recycling buffers.
 //!

--- a/crates/dcc-mcp-shm/src/python.rs
+++ b/crates/dcc-mcp-shm/src/python.rs
@@ -1,18 +1,22 @@
 //! PyO3 Python bindings for dcc-mcp-shm.
 //!
 //! Exposes:
-//!  - `PySharedBuffer`   — wraps [`SharedBuffer`]
+//!  - `PySharedBuffer`   — wraps [`SharedBuffer`] (with TTL support)
+//!  - `gc_orphans`        — module-level function to clean up stale segments
 //!  - `PyBufferPool`     — wraps [`BufferPool`]
 //!  - `PySceneDataKind`  — enum mirror of [`SceneDataKind`]
 //!  - `PySharedSceneBuffer` — wraps [`SharedSceneBuffer`]
 
+use std::time::Duration;
+
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 
-use crate::buffer::{BufferDescriptor, SharedBuffer};
+use crate::buffer::{BufferDescriptor, SharedBuffer, gc_orphans};
 use crate::error::ShmError;
 use crate::pool::{BufferPool, PooledBuffer};
 use crate::scene::{SceneDataKind, SharedSceneBuffer};
+use uuid::Uuid;
 
 // ── Error conversion ─────────────────────────────────────────────────────────
 
@@ -22,8 +26,8 @@ fn to_py(e: ShmError) -> PyErr {
 
 // ── PySharedBuffer ────────────────────────────────────────────────────────────
 
-/// A named, fixed-capacity shared memory buffer backed by a memory-mapped
-/// file.
+/// A named, fixed-capacity shared memory buffer backed by an ipckit
+/// shared memory segment.
 ///
 /// Usage::
 ///
@@ -32,6 +36,11 @@ fn to_py(e: ShmError) -> PyErr {
 ///     buf = PySharedBuffer.create(capacity=1024 * 1024)  # 1 MiB
 ///     buf.write(b"vertex data")
 ///     data = buf.read()
+///
+///     # With TTL (auto-expire after 60 seconds)
+///     buf = PySharedBuffer.create(capacity=1024, ttl_secs=60)
+///     if buf.is_expired():
+///         print("buffer has expired")
 #[pyclass(name = "PySharedBuffer")]
 pub struct PySharedBuffer {
     inner: SharedBuffer,
@@ -42,9 +51,19 @@ pub struct PySharedBuffer {
 #[pymethods]
 impl PySharedBuffer {
     /// Create a new buffer with the given capacity (bytes).
+    ///
+    /// If ``ttl_secs`` is > 0 the buffer will be considered expired after
+    /// that many seconds since creation, enabling automatic cleanup via
+    /// :func:`gc_orphans`.
     #[staticmethod]
-    fn create(capacity: usize) -> PyResult<Self> {
-        SharedBuffer::create(capacity)
+    #[pyo3(signature = (capacity, ttl_secs=0))]
+    fn create(capacity: usize, ttl_secs: u64) -> PyResult<Self> {
+        let ttl = if ttl_secs > 0 {
+            Some(Duration::from_secs(ttl_secs))
+        } else {
+            None
+        };
+        SharedBuffer::create_with_ttl(Uuid::new_v4().to_string(), capacity, ttl)
             .map(|inner| Self {
                 inner,
                 _pool_guard: None,
@@ -99,18 +118,27 @@ impl PySharedBuffer {
         self.inner.name()
     }
 
+    /// Returns True if this buffer's TTL has expired.
+    ///
+    /// Buffers without a TTL (``ttl_secs == 0``) never expire.
+    fn is_expired(&self) -> PyResult<bool> {
+        self.inner.is_expired().map_err(to_py)
+    }
+
     /// Return a JSON descriptor string for cross-process handoff.
     fn descriptor_json(&self) -> PyResult<String> {
-        BufferDescriptor::from_buffer(&self.inner)?
+        BufferDescriptor::from_buffer(&self.inner)
+            .map_err(to_py)?
             .to_json()
             .map_err(to_py)
     }
 
     fn __repr__(&self) -> String {
         format!(
-            "PySharedBuffer(id={:?}, capacity={})",
+            "PySharedBuffer(id={:?}, capacity={}, ttl={})",
             self.inner.id,
-            self.inner.capacity()
+            self.inner.capacity(),
+            "?" // TTL is behind a lock; skip in repr for speed
         )
     }
 }
@@ -295,12 +323,33 @@ impl PySharedSceneBuffer {
 
 // ── Module registration ───────────────────────────────────────────────────────
 
+/// Scan for and remove stale ``dcc_shm_*`` shared memory segments.
+///
+/// On Linux this scans ``/dev/shm``; on macOS it scans ``/tmp``;
+/// on Windows it is a no-op (the OS reclaims named file-mappings on
+/// last close).
+///
+/// Returns the number of segments removed.
+///
+/// Parameters
+/// ----------
+/// max_age_secs : float
+///     Minimum age (in seconds) for a segment to be considered stale.
+///     Segments whose TTL has expired **or** whose creation time is older
+///     than ``max_age_secs`` are removed.
+#[pyfunction]
+#[pyo3(signature = (max_age_secs,), name = "gc_orphans")]
+fn py_gc_orphans(max_age_secs: f64) -> usize {
+    gc_orphans(Duration::from_secs_f64(max_age_secs))
+}
+
 /// Register all PyO3 classes from this crate into `m`.
 pub fn register_classes(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PySharedBuffer>()?;
     m.add_class::<PyBufferPool>()?;
     m.add_class::<PySceneDataKind>()?;
     m.add_class::<PySharedSceneBuffer>()?;
+    m.add_function(wrap_pyfunction!(py_gc_orphans, m)?)?;
     Ok(())
 }
 

--- a/crates/dcc-mcp-shm/src/python.rs
+++ b/crates/dcc-mcp-shm/src/python.rs
@@ -52,10 +52,10 @@ impl PySharedBuffer {
             .map_err(to_py)
     }
 
-    /// Open an existing buffer from a file path and id.
+    /// Open an existing buffer from an ipckit segment name and id.
     #[staticmethod]
-    fn open(path: &str, id: &str) -> PyResult<Self> {
-        SharedBuffer::open(path, id)
+    fn open(name: &str, id: &str) -> PyResult<Self> {
+        SharedBuffer::open(name, id)
             .map(|inner| Self {
                 inner,
                 _pool_guard: None,
@@ -94,14 +94,14 @@ impl PySharedBuffer {
         &self.inner.id
     }
 
-    /// File path of the backing memory-mapped file.
-    fn path(&self) -> String {
-        self.inner.path().to_string_lossy().into_owned()
+    /// ipckit segment name of the backing shared memory.
+    fn name(&self) -> String {
+        self.inner.name()
     }
 
     /// Return a JSON descriptor string for cross-process handoff.
     fn descriptor_json(&self) -> PyResult<String> {
-        BufferDescriptor::from_buffer(&self.inner)
+        BufferDescriptor::from_buffer(&self.inner)?
             .to_json()
             .map_err(to_py)
     }

--- a/crates/dcc-mcp-shm/src/scene.rs
+++ b/crates/dcc-mcp-shm/src/scene.rs
@@ -105,7 +105,7 @@ impl SharedSceneBuffer {
 
             let buf = SharedBuffer::create(to_write.len().max(1))?;
             buf.write(&to_write)?;
-            let desc = BufferDescriptor::from_buffer(&buf);
+            let desc = BufferDescriptor::from_buffer(&buf)?;
 
             // Store compression flag in descriptor path comment — we embed it
             // in the metadata JSON instead via the `compressed` field.
@@ -147,7 +147,7 @@ impl SharedSceneBuffer {
     pub fn read(&self) -> ShmResult<Vec<u8>> {
         match &self.storage {
             StorageKind::Inline(desc) => {
-                let buf = SharedBuffer::open(&desc.path, &desc.id)?;
+                let buf = SharedBuffer::open(&desc.name, &desc.id)?;
                 let raw = buf.read()?;
                 // Try decompression; if it fails fall back to raw (not
                 // compressed).

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -150,6 +150,7 @@ from dcc_mcp_core._core import encode_response
 from dcc_mcp_core._core import error_result
 from dcc_mcp_core._core import expand_transitive_dependencies
 from dcc_mcp_core._core import from_exception
+from dcc_mcp_core._core import gc_orphans
 from dcc_mcp_core._core import get_app_skill_paths_from_env
 from dcc_mcp_core._core import get_bridge_context
 from dcc_mcp_core._core import get_config_dir
@@ -273,6 +274,7 @@ __all__ = [
     "EventBus",
     "FloatWrapper",
     "FrameRange",
+    "FrameRange",
     "FramedChannel",
     "GracefulIpcChannelAdapter",
     "InputValidator",
@@ -363,6 +365,7 @@ __all__ = [
     "error_result",
     "expand_transitive_dependencies",
     "from_exception",
+    "gc_orphans",
     "get_app_skill_paths_from_env",
     "get_bridge_context",
     "get_bundled_skill_paths",

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -3703,8 +3703,16 @@ class PySharedBuffer:
     """
 
     @staticmethod
-    def create(capacity: int) -> PySharedBuffer:
-        """Create a new buffer with the given capacity in bytes."""
+    def create(capacity: int, ttl_secs: int = 0) -> PySharedBuffer:
+        """Create a new buffer with the given capacity in bytes.
+
+        Args:
+            capacity: Maximum data bytes (header is added automatically).
+            ttl_secs: Time-to-live in seconds (0 = no TTL, never expires).
+                When > 0, the buffer is considered expired after this many
+                seconds since creation.
+
+        """
         ...
     @staticmethod
     def open(name: str, id: str) -> PySharedBuffer:
@@ -3736,6 +3744,13 @@ class PySharedBuffer:
         ...
     def name(self) -> str:
         """Ipckit segment name of the backing shared memory."""
+        ...
+    def is_expired(self) -> bool:
+        """Return True if this buffer's TTL has expired.
+
+        Buffers without a TTL (``ttl_secs == 0``) never expire.
+
+        """
         ...
     def descriptor_json(self) -> str:
         """Return a JSON descriptor string for cross-process handoff."""
@@ -3855,6 +3870,22 @@ class PySharedSceneBuffer:
         """JSON descriptor for cross-process handoff."""
         ...
     def __repr__(self) -> str: ...
+
+def gc_orphans(max_age_secs: float) -> int:
+    """Scan for and remove stale dcc_shm_* shared memory segments.
+
+    On Linux scans /dev/shm; on macOS scans /tmp; on Windows this is a no-op.
+
+    Args:
+        max_age_secs: Minimum age in seconds for a segment to be considered
+            stale.  Segments whose TTL has expired **or** whose creation time
+            is older than ``max_age_secs`` are removed.
+
+    Returns:
+        Number of segments removed.
+
+    """
+    ...
 
 # ── GPU Capture (dcc-mcp-capture) ──
 

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -3682,9 +3682,9 @@ class InputValidator:
 # ── Shared Memory (dcc-mcp-shm) ──
 
 class PySharedBuffer:
-    """A named, fixed-capacity shared memory buffer backed by a memory-mapped file.
+    """A named, fixed-capacity shared memory buffer backed by an ipckit shared memory segment.
 
-    Zero-copy: the DCC side writes data directly into the mapped region; the
+    Zero-copy: the DCC side writes data directly into the shared region; the
     consumer reads from the same mapping without any copying or serialisation.
 
     Example::
@@ -3697,7 +3697,7 @@ class PySharedBuffer:
         # Cross-process handoff
         desc_json = buf.descriptor_json()
         # ... send desc_json to consumer via IPC ...
-        buf2 = PySharedBuffer.open(path=buf.path(), id=buf.id)
+        buf2 = PySharedBuffer.open(name=buf.name(), id=buf.id)
         assert buf2.read() == b"vertex data"
 
     """
@@ -3707,8 +3707,8 @@ class PySharedBuffer:
         """Create a new buffer with the given capacity in bytes."""
         ...
     @staticmethod
-    def open(path: str, id: str) -> PySharedBuffer:
-        """Open an existing buffer from a file path and id."""
+    def open(name: str, id: str) -> PySharedBuffer:
+        """Open an existing buffer from an ipckit segment name and id."""
         ...
     def write(self, data: bytes) -> int:
         """Write bytes into the buffer. Returns the number of bytes written.
@@ -3734,8 +3734,8 @@ class PySharedBuffer:
     def id(self) -> str:
         """Buffer id (string)."""
         ...
-    def path(self) -> str:
-        """File path of the backing memory-mapped file."""
+    def name(self) -> str:
+        """Ipckit segment name of the backing shared memory."""
         ...
     def descriptor_json(self) -> str:
         """Return a JSON descriptor string for cross-process handoff."""

--- a/tests/test_buffer_pool_telemetry_crash.py
+++ b/tests/test_buffer_pool_telemetry_crash.py
@@ -2,7 +2,7 @@
 
 Covers:
 - PyBufferPool: acquire/release cycle, available count, exhaustion RuntimeError
-- PySharedBuffer: id/capacity()/data_len()/path()/write/read/clear/descriptor_json
+- PySharedBuffer: id/capacity()/data_len()/name()/write/read/clear/descriptor_json
 - TelemetryConfig: builder chain methods, property access
 - PyCrashRecoveryPolicy: use_exponential_backoff, use_fixed_backoff,
   next_delay_ms, should_restart, max_restarts, boundary conditions
@@ -102,9 +102,9 @@ class TestPySharedBuffer:
         _, buf = self._make_pool_and_buf()
         assert buf.data_len() == 0
 
-    def test_path_is_string(self) -> None:
+    def test_name_is_string(self) -> None:
         _, buf = self._make_pool_and_buf()
-        p = buf.path()
+        p = buf.name()
         assert isinstance(p, str)
         assert len(p) > 0
 
@@ -160,10 +160,10 @@ class TestPySharedBuffer:
         assert "id" in desc
         assert desc["id"] == buf.id
 
-    def test_descriptor_json_contains_path(self) -> None:
+    def test_descriptor_json_contains_name(self) -> None:
         _, buf = self._make_pool_and_buf()
         desc = json.loads(buf.descriptor_json())
-        assert "path" in desc
+        assert "name" in desc
 
     def test_unique_ids_from_same_pool(self) -> None:
         pool = dcc_mcp_core.PyBufferPool(2, 256)

--- a/tests/test_captureframe_prompt_sandbox_versioned.py
+++ b/tests/test_captureframe_prompt_sandbox_versioned.py
@@ -210,35 +210,35 @@ class TestPySharedBufferClearAndOpen:
         buf = PySharedBuffer.create(capacity=1024)
         payload = b"cross instance hello"
         buf.write(payload)
-        p = buf.path()
+        p = buf.name()
         i = buf.id
-        buf2 = PySharedBuffer.open(path=p, id=i)
+        buf2 = PySharedBuffer.open(name=p, id=i)
         assert buf2.read() == payload
 
     def test_open_cross_instance_id_matches(self):
         buf = PySharedBuffer.create(capacity=512)
         buf.write(b"test")
-        buf2 = PySharedBuffer.open(path=buf.path(), id=buf.id)
+        buf2 = PySharedBuffer.open(name=buf.name(), id=buf.id)
         assert buf2.id == buf.id
 
     def test_open_cross_instance_capacity_matches(self):
         buf = PySharedBuffer.create(capacity=2048)
         buf.write(b"data")
-        buf2 = PySharedBuffer.open(path=buf.path(), id=buf.id)
+        buf2 = PySharedBuffer.open(name=buf.name(), id=buf.id)
         assert buf2.capacity() == buf.capacity()
 
     def test_open_cross_instance_clear_visible(self):
         buf = PySharedBuffer.create(capacity=256)
         buf.write(b"before clear")
-        buf2 = PySharedBuffer.open(path=buf.path(), id=buf.id)
+        buf2 = PySharedBuffer.open(name=buf.name(), id=buf.id)
         buf2.clear()
         assert buf2.data_len() == 0
 
     def test_open_cross_instance_write_then_read(self):
         buf = PySharedBuffer.create(capacity=256)
         buf.write(b"initial")
-        p, i = buf.path(), buf.id
-        buf2 = PySharedBuffer.open(path=p, id=i)
+        p, i = buf.name(), buf.id
+        buf2 = PySharedBuffer.open(name=p, id=i)
         assert buf2.read() == b"initial"
         buf2.clear()
         buf2.write(b"updated")
@@ -249,12 +249,12 @@ class TestPySharedBufferClearAndOpen:
         desc = buf.descriptor_json()
         assert buf.id in desc
 
-    def test_descriptor_json_contains_path(self):
+    def test_descriptor_json_contains_name(self):
         buf = PySharedBuffer.create(capacity=256)
         desc = buf.descriptor_json()
         # descriptor_json JSON-escapes backslashes on Windows; verify via id instead
         assert buf.id in desc
-        assert "path" in desc
+        assert "name" in desc
 
 
 # ─────────────────── ToolRegistry.search_actions combination filters ───────────────────

--- a/tests/test_dispatcher_validator_launcher_buffer_transport_deep.py
+++ b/tests/test_dispatcher_validator_launcher_buffer_transport_deep.py
@@ -564,9 +564,9 @@ class TestPySharedBufferOperations:
         # Pool buffer IDs are pool-<uuid>-<index> format
         assert buf.id.startswith("pool-")
 
-    def test_path_is_string(self) -> None:
+    def test_name_is_string(self) -> None:
         buf = self.pool.acquire()
-        assert isinstance(buf.path(), str)
+        assert isinstance(buf.name(), str)
 
     def test_capacity_matches_pool_buffer_size(self) -> None:
         buf = self.pool.acquire()

--- a/tests/test_pipeline_callable_encode_decode_shm_registry_monitor.py
+++ b/tests/test_pipeline_callable_encode_decode_shm_registry_monitor.py
@@ -326,25 +326,25 @@ class TestPySharedBufferDescriptorJson:
     def test_open_reads_same_data(self):
         buf = PySharedBuffer.create(capacity=1024)
         buf.write(b"hello shared memory")
-        buf2 = PySharedBuffer.open(path=buf.path(), id=buf.id)
+        buf2 = PySharedBuffer.open(name=buf.name(), id=buf.id)
         assert buf2.read() == b"hello shared memory"
 
     def test_open_capacity_matches(self):
         buf = PySharedBuffer.create(capacity=4096)
-        buf2 = PySharedBuffer.open(path=buf.path(), id=buf.id)
+        buf2 = PySharedBuffer.open(name=buf.name(), id=buf.id)
         assert buf2.capacity() == buf.capacity()
 
     def test_open_data_len_matches(self):
         buf = PySharedBuffer.create(capacity=1024)
         data = b"some data"
         buf.write(data)
-        buf2 = PySharedBuffer.open(path=buf.path(), id=buf.id)
+        buf2 = PySharedBuffer.open(name=buf.name(), id=buf.id)
         assert buf2.data_len() == len(data)
 
     def test_write_visible_across_instances(self):
         buf = PySharedBuffer.create(capacity=1024)
         buf.write(b"cross-process data")
-        buf2 = PySharedBuffer.open(path=buf.path(), id=buf.id)
+        buf2 = PySharedBuffer.open(name=buf.name(), id=buf.id)
         assert buf2.read() == b"cross-process data"
 
     def test_clear_resets_data_len(self):
@@ -369,11 +369,11 @@ class TestPySharedBufferDescriptorJson:
         assert isinstance(buf.id, str)
         assert len(buf.id) > 0
 
-    def test_buf_path_is_string(self):
+    def test_buf_name_is_string(self):
         buf = PySharedBuffer.create(capacity=512)
-        path = buf.path()
-        assert isinstance(path, str)
-        assert len(path) > 0
+        name = buf.name()
+        assert isinstance(name, str)
+        assert len(name) > 0
 
     def test_repr_is_string(self):
         buf = PySharedBuffer.create(capacity=512)

--- a/tests/test_pipeline_shm_transport_edge.py
+++ b/tests/test_pipeline_shm_transport_edge.py
@@ -744,8 +744,8 @@ class TestPySharedSceneBufferDescriptor:
     def test_descriptor_json_storage_has_path(self):
         buf = PySharedSceneBuffer.write(b"path test")
         desc = json.loads(buf.descriptor_json())
-        assert "path" in desc["storage"]
-        assert isinstance(desc["storage"]["path"], str)
+        assert "name" in desc["storage"]
+        assert isinstance(desc["storage"]["name"], str)
 
     def test_large_data_read_roundtrip(self):
         large = bytes(range(256)) * 4000  # ~1MB
@@ -844,10 +844,10 @@ class TestPyBufferPoolLifecycle:
         buf.write(b"second")
         assert buf.read() == b"second"
 
-    def test_pool_path_returns_string(self):
+    def test_pool_name_returns_string(self):
         pool = PyBufferPool(capacity=2, buffer_size=256)
         buf = pool.acquire()
-        p = buf.path()
+        p = buf.name()
         assert isinstance(p, str)
         assert len(p) > 0
 

--- a/tests/test_shared_scene_buffer_deep.py
+++ b/tests/test_shared_scene_buffer_deep.py
@@ -280,7 +280,7 @@ class TestPySharedSceneBufferDescriptorJson:
     def test_storage_has_path(self):
         buf = PySharedSceneBuffer.write(b"test")
         dj = json.loads(buf.descriptor_json())
-        assert "path" in dj["storage"]
+        assert "name" in dj["storage"]
 
     def test_storage_has_capacity(self):
         buf = PySharedSceneBuffer.write(b"test")

--- a/tests/test_shm.py
+++ b/tests/test_shm.py
@@ -54,11 +54,11 @@ class TestPySharedBuffer:
         assert isinstance(buf.id, str)
         assert len(buf.id) > 0
 
-    def test_path_is_nonempty_string(self) -> None:
+    def test_name_is_nonempty_string(self) -> None:
         buf = dcc_mcp_core.PySharedBuffer.create(capacity=256)
-        path = buf.path()
-        assert isinstance(path, str)
-        assert len(path) > 0
+        name = buf.name()
+        assert isinstance(name, str)
+        assert len(name) > 0
 
     def test_descriptor_json_is_valid(self) -> None:
         import json
@@ -93,30 +93,30 @@ class TestPySharedBuffer:
         assert buf.read() == binary
 
     def test_open_reads_written_data(self) -> None:
-        """PySharedBuffer.open opens an existing buffer by path+id and reads data."""
+        """PySharedBuffer.open opens an existing buffer by name+id and reads data."""
         buf1 = dcc_mcp_core.PySharedBuffer.create(capacity=1024)
         payload = b"shared memory cross read"
         buf1.write(payload)
-        buf2 = dcc_mcp_core.PySharedBuffer.open(buf1.path(), buf1.id)
+        buf2 = dcc_mcp_core.PySharedBuffer.open(buf1.name(), buf1.id)
         assert buf2.read() == payload
 
     def test_open_capacity_matches_original(self) -> None:
         """Opened buffer reports the same capacity as the creator."""
         buf1 = dcc_mcp_core.PySharedBuffer.create(capacity=2048)
-        buf2 = dcc_mcp_core.PySharedBuffer.open(buf1.path(), buf1.id)
+        buf2 = dcc_mcp_core.PySharedBuffer.open(buf1.name(), buf1.id)
         assert buf2.capacity() == buf1.capacity()
 
     def test_open_data_len_matches_after_write(self) -> None:
         """Opened buffer sees the correct data_len written by creator."""
         buf1 = dcc_mcp_core.PySharedBuffer.create(capacity=512)
         buf1.write(b"hello")
-        buf2 = dcc_mcp_core.PySharedBuffer.open(buf1.path(), buf1.id)
+        buf2 = dcc_mcp_core.PySharedBuffer.open(buf1.name(), buf1.id)
         assert buf2.data_len() == 5
 
     def test_open_empty_buffer(self) -> None:
         """Opening a buffer that has not been written yet returns empty bytes."""
         buf1 = dcc_mcp_core.PySharedBuffer.create(capacity=256)
-        buf2 = dcc_mcp_core.PySharedBuffer.open(buf1.path(), buf1.id)
+        buf2 = dcc_mcp_core.PySharedBuffer.open(buf1.name(), buf1.id)
         assert buf2.data_len() == 0
         assert buf2.read() == b""
 
@@ -125,7 +125,7 @@ class TestPySharedBuffer:
         buf1 = dcc_mcp_core.PySharedBuffer.create(capacity=4096)
         payload = bytes(range(256))
         buf1.write(payload)
-        buf2 = dcc_mcp_core.PySharedBuffer.open(buf1.path(), buf1.id)
+        buf2 = dcc_mcp_core.PySharedBuffer.open(buf1.name(), buf1.id)
         assert buf2.read() == payload
 
     def test_descriptor_json_contains_id_field(self) -> None:
@@ -137,14 +137,14 @@ class TestPySharedBuffer:
         assert "id" in parsed
         assert parsed["id"] == buf.id
 
-    def test_descriptor_json_contains_path_field(self) -> None:
-        """descriptor_json dict contains a 'path' key."""
+    def test_descriptor_json_contains_name_field(self) -> None:
+        """descriptor_json dict contains a 'name' key."""
         import json
 
         buf = dcc_mcp_core.PySharedBuffer.create(capacity=512)
         parsed = json.loads(buf.descriptor_json())
-        assert "path" in parsed
-        assert len(parsed["path"]) > 0
+        assert "name" in parsed
+        assert len(parsed["name"]) > 0
 
     def test_descriptor_json_contains_capacity_field(self) -> None:
         """descriptor_json dict contains a 'capacity' key matching the buffer capacity."""

--- a/tests/test_shm_capture_process_wrappers_deep.py
+++ b/tests/test_shm_capture_process_wrappers_deep.py
@@ -202,10 +202,10 @@ class TestPySharedBufferCreate:
         assert isinstance(buf.id, str)
         assert len(buf.id) > 0
 
-    def test_path_is_nonempty_string(self):
+    def test_name_is_nonempty_string(self):
         buf = PySharedBuffer.create(512)
-        assert isinstance(buf.path(), str)
-        assert len(buf.path()) > 0
+        assert isinstance(buf.name(), str)
+        assert len(buf.name()) > 0
 
     def test_write_and_read_roundtrip(self):
         buf = PySharedBuffer.create(1024)
@@ -247,29 +247,29 @@ class TestPySharedBufferCreate:
         assert "id" in d
         assert d["id"] == buf.id
 
-    def test_descriptor_json_has_path(self):
+    def test_descriptor_json_has_name(self):
         buf = PySharedBuffer.create(1024)
         d = json.loads(buf.descriptor_json())
-        assert "path" in d
+        assert "name" in d
 
 
 class TestPySharedBufferOpen:
-    """Opening an existing buffer by path + id."""
+    """Opening an existing buffer by name + id."""
 
     def test_open_returns_same_capacity(self):
         buf = PySharedBuffer.create(512)
-        buf2 = PySharedBuffer.open(buf.path(), buf.id)
+        buf2 = PySharedBuffer.open(buf.name(), buf.id)
         assert buf2.capacity() == 512
 
     def test_open_can_read_written_data(self):
         buf = PySharedBuffer.create(512)
         buf.write(b"shared content")
-        buf2 = PySharedBuffer.open(buf.path(), buf.id)
+        buf2 = PySharedBuffer.open(buf.name(), buf.id)
         assert buf2.read() == b"shared content"
 
     def test_open_repr_contains_id(self):
         buf = PySharedBuffer.create(512)
-        buf2 = PySharedBuffer.open(buf.path(), buf.id)
+        buf2 = PySharedBuffer.open(buf.name(), buf.id)
         assert buf.id in repr(buf2)
 
 

--- a/tests/test_shm_recovery_registry_usd_deep.py
+++ b/tests/test_shm_recovery_registry_usd_deep.py
@@ -31,10 +31,10 @@ class TestPySharedBufferCreate:
         parts = buf.id.split("-")
         assert len(parts) == 5
 
-    def test_path_is_string(self):
+    def test_name_is_string(self):
         buf = dcc_mcp_core.PySharedBuffer.create(capacity=512)
-        assert isinstance(buf.path(), str)
-        assert len(buf.path()) > 0
+        assert isinstance(buf.name(), str)
+        assert len(buf.name()) > 0
 
     def test_capacity_matches(self):
         buf = dcc_mcp_core.PySharedBuffer.create(capacity=4096)
@@ -110,11 +110,11 @@ class TestPySharedBufferDescriptorAndOpen:
         assert "id" in parsed
         assert parsed["id"] == buf.id
 
-    def test_descriptor_json_has_path(self):
+    def test_descriptor_json_has_name(self):
         buf = dcc_mcp_core.PySharedBuffer.create(capacity=1024)
         parsed = json.loads(buf.descriptor_json())
-        assert "path" in parsed
-        assert parsed["path"] == buf.path()
+        assert "name" in parsed
+        assert parsed["name"] == buf.name()
 
     def test_descriptor_json_has_capacity(self):
         buf = dcc_mcp_core.PySharedBuffer.create(capacity=2048)
@@ -125,23 +125,23 @@ class TestPySharedBufferDescriptorAndOpen:
     def test_open_from_path_and_id(self):
         buf = dcc_mcp_core.PySharedBuffer.create(capacity=1024)
         buf.write(b"cross-process data")
-        buf2 = dcc_mcp_core.PySharedBuffer.open(path=buf.path(), id=buf.id)
+        buf2 = dcc_mcp_core.PySharedBuffer.open(name=buf.name(), id=buf.id)
         assert buf2.read() == b"cross-process data"
 
     def test_open_same_id(self):
         buf = dcc_mcp_core.PySharedBuffer.create(capacity=1024)
-        buf2 = dcc_mcp_core.PySharedBuffer.open(path=buf.path(), id=buf.id)
+        buf2 = dcc_mcp_core.PySharedBuffer.open(name=buf.name(), id=buf.id)
         assert buf2.id == buf.id
 
     def test_open_same_capacity(self):
         buf = dcc_mcp_core.PySharedBuffer.create(capacity=4096)
-        buf2 = dcc_mcp_core.PySharedBuffer.open(path=buf.path(), id=buf.id)
+        buf2 = dcc_mcp_core.PySharedBuffer.open(name=buf.name(), id=buf.id)
         assert buf2.capacity() == 4096
 
     def test_open_reads_updated_data(self):
         buf = dcc_mcp_core.PySharedBuffer.create(capacity=1024)
         buf.write(b"first write")
-        buf2 = dcc_mcp_core.PySharedBuffer.open(path=buf.path(), id=buf.id)
+        buf2 = dcc_mcp_core.PySharedBuffer.open(name=buf.name(), id=buf.id)
         # Write again via original handle
         buf.clear()
         buf.write(b"second write")
@@ -151,7 +151,7 @@ class TestPySharedBufferDescriptorAndOpen:
         buf = dcc_mcp_core.PySharedBuffer.create(capacity=1024)
         buf.write(b"descriptor roundtrip")
         desc = json.loads(buf.descriptor_json())
-        buf2 = dcc_mcp_core.PySharedBuffer.open(path=desc["path"], id=desc["id"])
+        buf2 = dcc_mcp_core.PySharedBuffer.open(name=desc["name"], id=desc["id"])
         assert buf2.read() == b"descriptor roundtrip"
 
 

--- a/tests/test_shm_sandbox_capture_deep.py
+++ b/tests/test_shm_sandbox_capture_deep.py
@@ -60,10 +60,10 @@ class TestPySharedBufferCreate:
         assert isinstance(buf.id, str)
         assert len(buf.id) > 0
 
-    def test_path_is_string(self):
+    def test_name_is_string(self):
         buf = PySharedBuffer.create(capacity=128)
-        assert isinstance(buf.path(), str)
-        assert len(buf.path()) > 0
+        assert isinstance(buf.name(), str)
+        assert len(buf.name()) > 0
 
     def test_descriptor_json_is_string(self):
         buf = PySharedBuffer.create(capacity=128)
@@ -152,30 +152,30 @@ class TestPySharedBufferOpen:
     def test_open_reads_same_data(self):
         buf = PySharedBuffer.create(capacity=256)
         buf.write(b"cross-process data")
-        buf2 = PySharedBuffer.open(path=buf.path(), id=buf.id)
+        buf2 = PySharedBuffer.open(name=buf.name(), id=buf.id)
         assert buf2.read() == b"cross-process data"
 
     def test_open_has_same_id(self):
         buf = PySharedBuffer.create(capacity=256)
-        buf2 = PySharedBuffer.open(path=buf.path(), id=buf.id)
+        buf2 = PySharedBuffer.open(name=buf.name(), id=buf.id)
         assert buf2.id == buf.id
 
     def test_open_has_same_capacity(self):
         buf = PySharedBuffer.create(capacity=512)
-        buf2 = PySharedBuffer.open(path=buf.path(), id=buf.id)
+        buf2 = PySharedBuffer.open(name=buf.name(), id=buf.id)
         assert buf2.capacity() == 512
 
     def test_open_sees_updated_data(self):
         buf = PySharedBuffer.create(capacity=256)
         buf.write(b"v1")
-        buf2 = PySharedBuffer.open(path=buf.path(), id=buf.id)
+        buf2 = PySharedBuffer.open(name=buf.name(), id=buf.id)
         buf.write(b"v2")
         assert buf2.read() == b"v2"
 
     def test_descriptor_json_contains_id_and_path(self):
         buf = PySharedBuffer.create(capacity=256)
         desc = json.loads(buf.descriptor_json())
-        assert "id" in desc or "path" in desc
+        assert "id" in desc or "name" in desc
 
 
 # ===========================================================================

--- a/tests/test_shm_usd_deep.py
+++ b/tests/test_shm_usd_deep.py
@@ -156,8 +156,8 @@ class TestSharedSceneBufferDescriptorJson:
     def test_descriptor_json_storage_has_path(self) -> None:
         buf = self._make_buf()
         desc = json.loads(buf.descriptor_json())
-        assert "path" in desc["storage"]
-        assert len(desc["storage"]["path"]) > 0
+        assert "name" in desc["storage"]
+        assert len(desc["storage"]["name"]) > 0
 
     def test_descriptor_json_meta_has_created_at(self) -> None:
         buf = self._make_buf()

--- a/tests/test_shm_versioned_registry_result_deep.py
+++ b/tests/test_shm_versioned_registry_result_deep.py
@@ -172,9 +172,9 @@ class TestPySharedBuffer:
         assert isinstance(buf.id, str)
         assert len(buf.id) > 0
 
-    def test_path_is_string(self):
+    def test_name_is_string(self):
         buf = PySharedBuffer.create(capacity=256)
-        assert isinstance(buf.path(), str)
+        assert isinstance(buf.name(), str)
 
     def test_initial_data_len_is_zero(self):
         buf = PySharedBuffer.create(capacity=512)

--- a/tests/test_transport_heartbeat_audit_scanner_usd_shm.py
+++ b/tests/test_transport_heartbeat_audit_scanner_usd_shm.py
@@ -799,7 +799,7 @@ class TestUsdPrimAttributesSummary:
 def _open_from_desc(desc_json: str) -> PySharedBuffer:
     """Open a PySharedBuffer from its descriptor_json string."""
     d = json.loads(desc_json)
-    return PySharedBuffer.open(d["path"], d["id"])
+    return PySharedBuffer.open(d["name"], d["id"])
 
 
 class TestPySharedBufferCrossInstance:
@@ -832,12 +832,12 @@ class TestPySharedBufferCrossInstance:
         d = json.loads(buf.descriptor_json())
         assert d["id"] == buf.id
 
-    def test_descriptor_json_contains_path(self):
-        """descriptor_json() JSON contains 'path' field."""
+    def test_descriptor_json_contains_name(self):
+        """descriptor_json() JSON contains 'name' field."""
         buf = PySharedBuffer.create(1024)
         d = json.loads(buf.descriptor_json())
-        assert "path" in d
-        assert len(d["path"]) > 0
+        assert "name" in d
+        assert len(d["name"]) > 0
 
     def test_write_and_read_roundtrip(self):
         """write() + read() roundtrip returns the exact same bytes."""
@@ -847,7 +847,7 @@ class TestPySharedBufferCrossInstance:
         assert buf.read() == data
 
     def test_open_from_descriptor_returns_buffer(self):
-        """PySharedBuffer.open(path, id) returns a PySharedBuffer object."""
+        """PySharedBuffer.open(name, id) returns a PySharedBuffer object."""
         buf1 = PySharedBuffer.create(1024)
         buf2 = _open_from_desc(buf1.descriptor_json())
         assert buf2 is not None

--- a/tests/test_transport_process_shm_deep.py
+++ b/tests/test_transport_process_shm_deep.py
@@ -6,7 +6,7 @@ Coverage targets (this iteration):
 - PyProcessWatcher: track/watch/start/stop/poll_events/aliases
 - PyDccLauncher: empty init/running_count/pid_of/restart_count
 - PyCrashRecoveryPolicy: should_restart/next_delay_ms/fixed/exponential
-- PySharedBuffer: create/write/read/clear/capacity/data_len/path/descriptor_json/open
+- PySharedBuffer: create/write/read/clear/capacity/data_len/name/descriptor_json/open
 - PySharedSceneBuffer: write/read/id/is_chunked/is_inline/descriptor_json/compression
 - PyBufferPool: capacity/buffer_size/available/acquire/release-on-gc
 """
@@ -778,9 +778,9 @@ class TestPySharedBufferCreate:
         assert isinstance(buf.id, str)
         assert len(buf.id) > 0
 
-    def test_path_is_str(self):
+    def test_name_is_str(self):
         buf = PySharedBuffer.create(capacity=1024)
-        p = buf.path()
+        p = buf.name()
         assert isinstance(p, str)
         assert len(p) > 0
 
@@ -857,7 +857,7 @@ class TestPySharedBufferDescriptorAndOpen:
     def test_open_existing_buffer(self):
         buf = PySharedBuffer.create(capacity=512)
         buf.write(b"test data")
-        buf2 = PySharedBuffer.open(buf.path(), buf.id)
+        buf2 = PySharedBuffer.open(buf.name(), buf.id)
         assert buf2.read() == b"test data"
 
 


### PR DESCRIPTION
## Summary

- Migrate `dcc-mcp-shm` from `memmap2`+`tempfile` to `ipckit::SharedMemory` for cross-process shared buffers, using OS-native named segments (`shm_open` on Unix, `CreateFileMappingW` on Windows)
- Add TTL (time-to-live) and orphan GC to `RegionHeader` — new `created_at_secs` and `ttl_secs` fields enable automatic expiry detection; `gc_orphans()` scans for and removes stale segments left by crashed DCC processes
- Expose Python bindings for TTL: `PySharedBuffer.create(capacity, ttl_secs=0)`, `.is_expired()`, `gc_orphans(max_age_secs)`

## Key changes

| Area | Before | After |
|------|--------|-------|
| Backend | `memmap2::MmapMut` + temp file | `ipckit::SharedMemory` (RAII) |
| RegionHeader | 24B (magic + data_len + compressed) | 48B (+ capacity + created_at_secs + ttl_secs) |
| Cross-process handoff | `SharedBuffer.open(path, id)` | `SharedBuffer.open(name, id)` |
| `BufferDescriptor` | `.path` field, `from_buffer() → BufferDescriptor` | `.name` field, `ttl_secs`, `from_buffer() → ShmResult<BufferDescriptor>` |
| Cleanup | Manual `fs::remove_file` on Drop | ipckit RAII + `gc_orphans()` for crash recovery |
| Dependencies | memmap2, tempfile | ipckit (workspace dep); libc (Unix only, for gc_orphans) |

## New APIs

- `SharedBuffer::create_with_ttl(id, capacity, ttl: Option<Duration>)` — create with optional TTL
- `SharedBuffer::is_expired()` — check if TTL has expired
- `gc_orphans(max_age: Duration) → usize` — scan and remove stale `dcc_shm_*` segments
- Python: `PySharedBuffer.create(capacity, ttl_secs=0)`, `.is_expired()`, `gc_orphans(max_age_secs)`

## Design decision

We chose NOT to use `ipckit::ResourceLink` because its `write_payload()` always writes from offset 0 of the payload area, which would conflict with our `RegionHeader` stored at the beginning. Instead, we implement TTL/GC directly in our own header layout for full control.

## Test plan

- [x] 61 Rust unit tests pass (`cargo test -p dcc-mcp-shm`)
- [x] 46 Python shm tests pass (`pytest tests/test_shm.py`)
- [x] Full workspace `cargo check --all` passes
- [x] 5 new TTL/GC-specific tests: `test_no_ttl_never_expired`, `test_long_ttl_not_expired`, `test_descriptor_contains_ttl`, `test_descriptor_zero_ttl_when_none`, `test_gc_orphans_returns_usize`
- [x] 14 Python test files updated for `path→name` migration

Closes #286