### PR TITLE
fix(tests): add missing uuid import to transport manager tests

### DIFF
--- a/tests/test_dispatcher_validator_launcher_buffer_transport_deep.py
+++ b/tests/test_dispatcher_validator_launcher_buffer_transport_deep.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import gc
 import json
 import tempfile
+import uuid
 
 import pytest
 


### PR DESCRIPTION
## Summary

- One-line fix: adds `import uuid` to `test_dispatcher_validator_launcher_buffer_transport_deep.py`
- `test_instance_id_is_uuid_string` calls `uuid.UUID()` without importing `uuid`
- The `NameError` crashes before `shutdown()`, leaking the IPC socket
- 10 subsequent tests cascade-fail with `Address already in use`
- Total impact: 11 tests × 6 Python versions × 3 OS = **18 CI failures**

## Test plan

- [ ] All 18 previously-failing Python test jobs should pass
- [ ] No other test changes needed

This is the **last CI blocker** before Release Please PR #284 (v0.13.6) can pass.