### PR TITLE
docs: enhance AI-agent documentation with progressive disclosure and tool priority guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,17 @@
 > **This file is a navigation map, not a reference manual.**
 > It tells you *where to look*, not *what every API does*.
 > Follow the links; don't read everything upfront.
+>
+> **Document hierarchy** (progressive disclosure — read only what you need):
+>
+> | Layer | File | What it gives you | When to read it |
+> |-------|------|-------------------|-----------------|
+> | 🗺️ Navigation | `AGENTS.md` (this file) | Where to find everything | First contact with the project |
+> | ⚡ AI-friendly index | `llms.txt` | Compressed API reference optimised for token efficiency | When an AI agent needs to *use* the APIs |
+> | 📖 Full index | `llms-full.txt` | Complete API reference with copy-paste examples | When `llms.txt` lacks detail |
+> | 📚 Human docs | `docs/guide/` + `docs/api/` | Conceptual guides and per-module API docs | When building a new adapter or skill |
+> | 🔧 LLM-specific | `CLAUDE.md` / `GEMINI.md` | Agent-specific workflows and tips | When using Claude Code or Gemini CLI |
+> | 🧩 Skill authoring | `skills/README.md` + `examples/skills/` | Templates, examples, SKILL.md format | When creating or modifying skills |
 
 ---
 
@@ -30,6 +41,53 @@ A Rust-powered MCP (Model Context Protocol) library that lets AI agents interact
 1. `python/dcc_mcp_core/__init__.py` — every public symbol, nothing hidden
 2. `python/dcc_mcp_core/_core.pyi` — ground truth for parameter names, types, and signatures
 3. `llms.txt` — compressed version of (1)+(2) optimised for token efficiency
+
+---
+
+## AI Agent Tool Priority — Start Here
+
+When an AI agent needs to interact with DCC software, follow this priority order:
+
+### 1. Skill Discovery (always start here)
+```
+search_skills(query="...") → find relevant skills
+load_skill(skill_name="...") → register tools
+tools/list → see available tools
+```
+
+### 2. Skill-Based Tools (preferred over raw API calls)
+- Use skill tools (e.g. `maya_geometry__create_sphere`) — they have validated schemas, error handling, and `next-tools` guidance
+- Check `ToolAnnotations` for safety hints before calling destructive tools
+- Use `next-tools` from tool results to chain follow-up actions
+
+### 3. Diagnostics Tools (for debugging/verification)
+```
+diagnostics__screenshot → verify visual state
+diagnostics__audit_log → check execution history
+diagnostics__tool_metrics → measure performance
+diagnostics__process_status → check DCC process health
+```
+
+### 4. Direct Registry Access (last resort)
+- Only when no skill tool covers the needed operation
+- Must validate inputs with `ToolValidator` before execution
+- Must use `SandboxPolicy` for AI-initiated calls
+
+### Decision Tree
+```
+Need to interact with DCC?
+├── Know the skill? → load_skill(name) → use tool
+├── Don't know? → search_skills(query) → load_skill → use tool
+├── Need to verify? → diagnostics__screenshot / process_status
+└── No skill exists? → register custom tool with ToolRegistry
+```
+
+### Why Skills First?
+1. **Safety**: Skills declare `ToolAnnotations` — agents can check `destructive_hint`, `read_only_hint`
+2. **Discoverability**: `search_skills` + `search-hint` keywords find the right tool without trial-and-error
+3. **Chainability**: `next-tools` guides follow-up actions, reducing hallucination
+4. **Progressive exposure**: Tool groups keep `tools/list` small — agents activate only what they need
+5. **Validation**: Skill tools have `input_schema` — parameters are validated before execution
 
 ---
 
@@ -399,6 +457,46 @@ json_str = result.to_json()    # JSON string
 
 ---
 
+## Do and Don't — Quick Reference
+
+### Do ✅
+
+- Use `create_skill_server("maya", McpHttpConfig(port=8765))` — the Skills-First entry point since v0.12.12
+- Use `success_result("msg", count=5)` — extra kwargs become `context` dict
+- Use `ToolAnnotations(read_only_hint=True, destructive_hint=False)` — helps AI clients choose safely
+- Use `next-tools: on-success/on-failure` in SKILL.md — guides AI agents to follow-up tools
+- Use `search-hint:` in SKILL.md — improves `search_skills` keyword matching
+- Use tool groups with `default_active: false` for power-user features — keeps `tools/list` small
+- Unpack `scan_and_load()`: `skills, skipped = scan_and_load(dcc_name="maya")`
+- Register ALL handlers BEFORE `McpHttpServer.start()` — the server reads the registry at startup
+- Use `SandboxPolicy` + `InputValidator` for AI-driven tool execution
+- Use `DccServerBase` as the base class for DCC adapters — skill/lifecycle/gateway inherited
+- Use `vx just dev` before `vx just test` — the Rust extension must be compiled first
+- Keep `SKILL.md` body under 500 lines / 5000 tokens — move details to `references/`
+- Use Conventional Commits for PR titles — `feat:`, `fix:`, `docs:`, `refactor:`
+- Use `registry.list_actions()` (shows all) vs `registry.list_actions_enabled()` (active only)
+- Start with `search_skills(query)` when looking for a tool — don't guess tool names
+
+### Don't ❌
+
+- Don't iterate over `scan_and_load()` result directly — it returns `(list, list)`, not skill objects
+- Don't use `success_result("msg", context={"count": 5})` — kwargs go into context automatically
+- Don't call `ToolDispatcher.call()` — method is `.dispatch(name, json_str)`
+- Don't pass positional args to `ToolRegistry.register()` — keyword args only
+- Don't import `SkillScope` or `SkillPolicy` from Python — they are Rust-only types
+- Don't import `DeferredExecutor` from public `__init__` — use `from dcc_mcp_core._core import DeferredExecutor`
+- Don't call `.new_auto()` then `.capture_window()` — use `.new_window_auto()` for single-window capture
+- Don't use legacy APIs: `ActionManager`, `create_action_manager()`, `MiddlewareChain`, `Action` — removed in v0.12+
+- Don't add Python runtime dependencies — the project is zero-dep by design
+- Don't manually bump versions or edit `CHANGELOG.md` — Release Please handles this
+- Don't hardcode API keys, tokens, or passwords — use environment variables
+- Don't use `docs/` prefix in branch names — causes `refs/heads/docs/...` conflicts
+- Don't reference `ActionMeta.enabled` in Python — use `ToolRegistry.set_tool_enabled()` instead
+- Don't use `json.dumps()` on `ToolResult` — use `result.to_json()` or `serialize_result()`
+- Don't guess tool names — use `search_skills(query)` to discover the right tool
+
+---
+
 ## Code Style — Non-Negotiable
 
 **Python:**
@@ -489,19 +587,31 @@ When adding a Rust type/function that needs to be callable from Python:
 > **MCP spec note**: Library implements 2025-03-26 (Streamable HTTP, Tool Annotations, OAuth 2.1).
 > Later specs add: 2025-06-18 (Structured Tool Output, Elicitation, Resource Links, JSON-RPC batching removed);
 > 2025-11-25 (icon metadata, Tasks, Sampling with tools, JSON Schema 2020-12).
+> The 2026 roadmap focuses on four priority areas:
+> **1) Transport scalability** — `.well-known` server capability discovery, stateless session model for horizontal scaling;
+> **2) Agent communication** — Tasks primitive (experimental in 2025-11-25), retry/expiration semantics pending;
+> **3) Governance** — contributor ladder, delegated workgroup model for faster SEP review;
+> **4) Enterprise readiness** — audit trails, SSO integration, gateway behavior, configuration portability (mostly as extensions, not core spec changes).
+> No new official transport types will be added in the 2026 cycle — only evolution of Streamable HTTP.
 > Do NOT implement these manually — wait for library support.
 
 > **agentskills.io note**: The V1.0 specification (stewarded by Anthropic, released 2025-12-18) defines
-> `name` (required), `description` (required), `license`, `compatibility`, `metadata`, and `allowed-tools`
-> (experimental, space-separated) as standard SKILL.md frontmatter fields. dcc-mcp-core extends this with
-> `dcc`, `tags`, `search-hint`, `tools`, `groups`, `depends`, `external_deps`, and `next-tools`.
+> `name` (required, 1-64 chars, lowercase + hyphens, must match directory name),
+> `description` (required, 1-1024 chars, should describe **what** and **when to use**),
+> `license` (optional, SPDX identifier or file reference),
+> `compatibility` (optional, max 500 chars, environment requirements — most skills don't need this),
+> `metadata` (optional, arbitrary string→string key-value map), and
+> `allowed-tools` (experimental, space-separated pre-approved tool strings like `Bash(git:*) Read`)
+> as standard SKILL.md frontmatter fields.
+> dcc-mcp-core extends this with `dcc`, `tags`, `search-hint`, `tools`, `groups`, `depends`, `external_deps`, and `next-tools`.
 > Validation tool: `skills-ref validate ./my-skill` (from [agentskills/agentskills](https://github.com/agentskills/agentskills)).
+> **Progressive disclosure**: Keep `SKILL.md` body < 500 lines / < 5000 tokens; move details to `references/` (loaded on demand).
 
 ---
 
 ## LLM-Specific Guides
 
-- `CLAUDE.md` — Claude Code workflows and tips
-- `GEMINI.md` — Gemini-specific guidance
-- `llms.txt` — token-optimised API reference
-- `llms-full.txt` — complete API reference
+- `CLAUDE.md` — Claude Code workflows and tips (references AGENTS.md for project context)
+- `GEMINI.md` — Gemini-specific guidance (references AGENTS.md for project context)
+- `llms.txt` — token-optimised API reference (for AI agents that need to *use* the APIs)
+- `llms-full.txt` — complete API reference with copy-paste examples

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md — dcc-mcp-core Instructions for Claude
 
-> **Purpose**: Claude-specific instructions. Complements AGENTS.md with Claude-specific guidance.
-> Read AGENTS.md first for full project context, then this file.
+> **Purpose**: Claude-specific instructions. **Read `AGENTS.md` first** for full project context,
+> architecture, commands, and pitfalls. This file adds only Claude-specific guidance.
 
 ## Project Identity
 
@@ -17,35 +17,17 @@ You are working on **dcc-mcp-core**, a Rust-powered MCP (Model Context Protocol)
 - If the user explicitly requests another language for a specific reply,
   follow that request for that turn.
 
-## Quick Reference
+## Document Hierarchy (Progressive Disclosure)
 
-### Before Making Changes
+When you need information, read in this order — stop when you find what you need:
 
-1. Read `AGENTS.md` for full project context
-2. Read `python/dcc_mcp_core/__init__.py` for the complete public API surface
-3. Read `python/dcc_mcp_core/_core.pyi` for parameter names/types when unsure
-4. Current branch convention: `feat/`, `fix/`, `docs/`, `refactor/`, `chore/`
-5. Always run commands with `vx` prefix
-
-### Essential Commands
-
-```bash
-vx just preflight     # Before committing (Rust check + clippy + fmt + test)
-vx just test          # Python tests
-vx just lint          # Full lint (Rust + Python)
-vx just dev           # Build dev wheel (needed before running Python tests)
-vx just lint-fix      # Auto-fix all lint issues
-vx just test-cov      # Coverage report to find gaps
-```
-
-### Architecture Summary
-
-- **14 Rust crates** under `crates/`, compiled into `_core` native extension + pure-Python helpers
-- **~154 public Python symbols** exported from `python/dcc_mcp_core/__init__.py`
-- **Zero runtime Python deps** — all logic in Rust
-- Key entry point: `src/lib.rs` (PyO3 `#[pymodule]`)
-- Python 3.7–3.13 supported (CI tests 3.7–3.13)
-- Version: current — never manually bump (Release Please manages)
+1. **`AGENTS.md`** — Navigation map: where to find everything, traps, Do/Don't
+2. **`llms.txt`** — Compressed API reference for AI agents (token-efficient)
+3. **`python/dcc_mcp_core/__init__.py`** — Complete public API surface (~154 symbols)
+4. **`python/dcc_mcp_core/_core.pyi`** — Parameter names, types, signatures
+5. **`llms-full.txt`** — Complete API reference with examples (when `llms.txt` lacks detail)
+6. **`docs/guide/`** + **`docs/api/`** — Conceptual guides and per-module API docs
+7. **`tests/`** — 120+ usage examples in test form
 
 ## Claude-Specific Workflows
 
@@ -199,27 +181,6 @@ python -c "import dcc_mcp_core; print(hasattr(dcc_mcp_core, 'MyNewSymbol'))"
 cargo build --workspace --features python-bindings 2>&1 | grep -E "error|warning" | head -30
 ```
 
-### When Writing Tests
-
-```python
-# Import pattern for tests
-from __future__ import annotations
-import pytest
-from dcc_mcp_core import ToolResult, success_result, error_result
-
-# Skill tests: use tmp_path fixture + create minimal SKILL.md
-def test_skill_scan(tmp_path):
-    skill_dir = tmp_path / "my-skill"
-    (skill_dir / "scripts").mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text("---\nname: my-skill\ndcc: python\n---\n")
-    (skill_dir / "scripts" / "do_thing.py").write_text("print('hello')")
-
-    from dcc_mcp_core import parse_skill_md
-    meta = parse_skill_md(str(skill_dir))
-    assert meta is not None
-    assert meta.name == "my-skill"
-```
-
 ## Claude-Specific Tips
 
 - **Prefer reading `__init__.py`** over guessing imports — it has the complete public API surface
@@ -233,7 +194,7 @@ def test_skill_scan(tmp_path):
 - **`DeferredExecutor` is not in public `__init__.py`**: import via `from dcc_mcp_core._core import DeferredExecutor` until it is promoted to the public API
 - **`CompatibilityRouter` is not a standalone Python class**: access via `VersionedRegistry.router()` — it borrows the registry for constraint-based version resolution
 - **`external_deps` on SkillMetadata**: a JSON string field for declaring external requirements (MCP servers, env vars, binaries). Set via `md.external_deps = json.dumps(deps)`, read via `json.loads(md.external_deps)`. Returns `None` if not set.
-- **MCP spec**: `McpHttpServer` implements 2025-03-26 spec. The 2025-06-18 version adds Structured Tool Output, Elicitation, Resource Links, and removes JSON-RPC batching. The 2025-11-25 version adds icon metadata, Tasks (persistent requests), Sampling with tools, URL pattern requests, OAuth Client ID Metadata Document, JSON Schema 2020-12. The 2026 roadmap focuses on transport scalability, agent communication (Tasks lifecycle), governance, and enterprise readiness. Do NOT implement these manually — wait for the library to add support.
+- **MCP spec**: `McpHttpServer` implements 2025-03-26 spec. The 2026 roadmap focuses on: (1) transport scalability — `.well-known` capability discovery, stateless session model; (2) agent communication — Tasks lifecycle (experimental), retry/expiration semantics; (3) governance — contributor ladder, delegated workgroups; (4) enterprise readiness — audit, SSO, gateway behavior (mostly extensions, not core spec changes). No new transport types in 2026 — only Streamable HTTP evolution. Do NOT implement these manually — wait for the library to add support.
 - **Bridge system**: `BridgeRegistry`, `BridgeContext`, `register_bridge()`, `get_bridge_context()` — for inter-protocol bridging (RPyC ↔ MCP etc.). Don't build custom bridge registries.
 - **Scene data model**: `BoundingBox`, `FrameRange`, `ObjectTransform`, `SceneNode`, `SceneObject`, `RenderOutput` — use for structured scene data instead of raw dicts. `BoundingBox` may be `None`.
 - **Serialization**: `serialize_result()` / `deserialize_result()` with `SerializeFormat` enum — for transport-safe ToolResult serialization. Don't use `json.dumps()` on ToolResult.
@@ -245,11 +206,13 @@ def test_skill_scan(tmp_path):
 - **Security**: Use `SandboxPolicy` + `SandboxContext` for AI-driven tool execution. Validate inputs with `ToolValidator`. Never hardcode secrets.
 - **Commit messages**: Use Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`, `test:`). Never manually bump versions — Release Please manages this.
 
-## Key Files to Read First (Priority Order)
+## AI Agent Tool Priority
 
-1. `python/dcc_mcp_core/__init__.py` — Complete public API (~154 symbols including BridgeRegistry, BridgeContext, BoundingBox, FrameRange, ObjectTransform, SceneNode, SceneObject, RenderOutput, SerializeFormat, WebViewAdapter, WebViewContext)
-2. `python/dcc_mcp_core/_core.pyi` — Type stubs with parameter names (does NOT include WebViewAdapter — that's Python-only)
-3. `AGENTS.md` — Full architecture, commands, pitfalls
-4. `crates/*/src/python.rs` — PyO3 binding implementations
-5. `src/lib.rs` — Module registration entry point
-6. `tests/` — Usage examples in test form (120+ files)
+When building tools or interacting with DCCs, follow this priority order:
+
+1. **Skill Discovery** (start here): `search_skills(query)` → `load_skill(name)` → use skill tools
+2. **Skill-Based Tools** (preferred): Tools with validated schemas, error handling, `next-tools` guidance, and `ToolAnnotations` safety hints
+3. **Diagnostics Tools** (for verification): `diagnostics__screenshot`, `diagnostics__audit_log`, `diagnostics__process_status`
+4. **Direct Registry Access** (last resort): Only when no skill tool covers the operation; must validate with `ToolValidator` and sandbox with `SandboxPolicy`
+
+**Why skills first?** Safety (annotations), discoverability (search-hint), chainability (next-tools), progressive exposure (tool groups), validation (input_schema).

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,12 +1,12 @@
 # GEMINI.md — dcc-mcp-core Instructions for Gemini
 
-> **Purpose**: Gemini-specific instructions. Complements AGENTS.md with Gemini-specific guidance.
-> Read AGENTS.md first for full project context, then this file.
+> **Purpose**: Gemini-specific instructions. **Read `AGENTS.md` first** for full project context,
+> architecture, commands, and pitfalls. This file adds only Gemini-specific guidance.
 
 ## Project Identity
 
 You are working on **dcc-mcp-core**, a Rust-powered MCP (Model Context Protocol) library for DCC
-(Digital Content Creation) applications. Python package: `dcc_mcp_core`. ~154 public symbols,
+(DDigital Content Creation) applications. Python package: `dcc_mcp_core`. ~154 public symbols,
 zero runtime Python dependencies (everything compiled into Rust core via PyO3), plus pure-Python
 helpers (DccServerBase, DccGatewayElection, DccSkillHotReloader, factory, skill helpers, WebViewAdapter).
 
@@ -20,13 +20,20 @@ helpers (DccServerBase, DccGatewayElection, DccSkillHotReloader, factory, skill 
 - If the user explicitly requests another language for a specific reply,
   follow that request for that turn.
 
-## Priority Reading Order
+## Document Hierarchy (Progressive Disclosure)
 
-1. `python/dcc_mcp_core/__init__.py` — Complete public API (ground truth for imports)
-2. `python/dcc_mcp_core/_core.pyi` — Type stubs (parameter names, signatures, docstrings)
-3. `AGENTS.md` — Architecture, commands, pitfalls, AI integration patterns
-4. `llms-full.txt` — Comprehensive API reference with copy-paste examples
-5. `tests/` — Usage examples in executable test form
+When you need information, read in this order — stop when you find what you need:
+
+1. **`AGENTS.md`** — Navigation map: where to find everything, traps, Do/Don't
+2. **`llms.txt`** — Compressed API reference for AI agents (token-efficient)
+3. **`python/dcc_mcp_core/__init__.py`** — Complete public API (ground truth for imports)
+4. **`python/dcc_mcp_core/_core.pyi`** — Type stubs (parameter names, signatures, docstrings)
+5. **`llms-full.txt`** — Comprehensive API reference with copy-paste examples
+6. **`docs/guide/`** + **`docs/api/`** — Conceptual guides and per-module API docs
+7. **`tests/`** — Usage examples in executable test form
+
+Gemini tip: Use the `llms-full.txt` file as your primary API reference — it has copy-paste examples
+for every API area. The file is structured with a **Quick Decision Guide** table at the top.
 
 ## Essential Commands
 
@@ -60,9 +67,6 @@ print(dir(dcc_mcp_core))  # all ~140 symbols
 # grep equivalent:
 # python/dcc_mcp_core/_core.pyi: has full class/function docstrings + type annotations
 ```
-
-Gemini tip: Use the `llms-full.txt` file as your primary reference — it has copy-paste examples
-for every API area. The file is structured with a **Quick Decision Guide** table at the top.
 
 ### Finding Rust Implementation
 
@@ -183,7 +187,7 @@ search-hint: "polygon modeling, bevel, extrude, mesh editing"
 
 ## Common Pitfalls
 
-1. **Import from public API only**: `from dcc_mcp_core import X` — never `from dcc_mcp_core._core import X`
+1. **Import from public API only**: `from dcc_mcp_core import X` — never `from dcc_mcp_core._core import X` (except `DeferredExecutor`)
 2. **No manual version bumps**: Release Please owns `CHANGELOG.md` and version strings
 3. **No runtime Python deps**: Never add to `dependencies` in `pyproject.toml`
 4. **Rust changes need Python updates**: Modify `python.rs` → `src/lib.rs` → `__init__.py` → `_core.pyi`
@@ -202,7 +206,7 @@ search-hint: "polygon modeling, bevel, extrude, mesh editing"
 17. **`McpServerHandle` is an alias**: `server.start()` returns `McpServerHandle`; it is re-exported as `McpServerHandle` in `__init__.py`. Import as `from dcc_mcp_core import McpServerHandle`.
 18. **`McpHttpServer` registry population**: All actions must be registered in `ToolRegistry` BEFORE calling `server.start()`. The server reads metadata from the registry at startup.
 
-19. **MCP spec version awareness**: `McpHttpServer` implements 2025-03-26 spec (Streamable HTTP, Tool Annotations, OAuth 2.1). The 2025-06-18 version adds Structured Tool Output, Elicitation, Resource Links, and removes JSON-RPC batching. The 2025-11-25 version adds icon metadata, Tasks, Sampling with tools, JSON Schema 2020-12. Do NOT implement these manually — wait for the library to add support.
+19. **MCP spec version awareness**: `McpHttpServer` implements 2025-03-26 spec (Streamable HTTP, Tool Annotations, OAuth 2.1). The 2026 roadmap focuses on: (1) transport scalability — `.well-known` capability discovery, stateless sessions; (2) agent communication — Tasks lifecycle, retry/expiration; (3) governance — contributor ladder, delegated workgroups; (4) enterprise readiness — audit, SSO, gateway behavior (mostly extensions). No new transport types in 2026. Do NOT implement these manually — wait for the library to add support.
 
 20. **`scan_and_load` keyword args only**: Both `extra_paths` and `dcc_name` must be passed as keyword arguments: `scan_and_load(dcc_name="maya", extra_paths=["/path"])` — never as positionals.
 
@@ -212,29 +216,31 @@ search-hint: "polygon modeling, bevel, extrude, mesh editing"
 
 23. **`external_deps` on SkillMetadata**: A JSON string field for declaring external requirements (MCP servers, env vars, binaries). Set via `md.external_deps = json.dumps(deps)`, read via `json.loads(md.external_deps)`. Returns `None` when not set. See `docs/guide/skill-scopes-policies.md` for the schema.
 
-22. **tools/list has 6 core tools** (not 5): `find_skills`, `list_skills`, `get_skill_info`, `load_skill`, `unload_skill`, **`search_skills``. Unloaded skills appear as `__skill__<name>` stubs — calling a stub returns a `load_skill` hint, not an error about missing handlers.
+24. **tools/list has 6 core tools** (not 5): `find_skills`, `list_skills`, `get_skill_info`, `load_skill`, `unload_skill`, **`search_skills``. Unloaded skills appear as `__skill__<name>` stubs — calling a stub returns a `load_skill` hint, not an error about missing handlers.
 
-23. **`search_hint` fallback**: If `search-hint:` is not in SKILL.md, `SkillSummary.search_hint` falls back to `description`. Set `search-hint` explicitly for better keyword matching.
+25. **`search_hint` fallback**: If `search-hint:` is not in SKILL.md, `SkillSummary.search_hint` falls back to `description`. Set `search-hint` explicitly for better keyword matching.
 
-24. **SkillScope & SkillPolicy** (v0.13+): Trust hierarchy `Repo` < `User` < `System` < `Admin`. Higher-scope skills shadow lower-scope ones with the same name. **These are Rust-level types not directly importable from Python.** Configure via SKILL.md frontmatter (`allow_implicit_invocation`, `products`) and access via `SkillMetadata.is_implicit_invocation_allowed()` / `SkillMetadata.matches_product(dcc_name)`.
+26. **SkillScope & SkillPolicy** (v0.13+): Trust hierarchy `Repo` < `User` < `System` < `Admin`. Higher-scope skills shadow lower-scope ones with the same name. **These are Rust-level types not directly importable from Python.** Configure via SKILL.md frontmatter (`allow_implicit_invocation`, `products`) and access via `SkillMetadata.is_implicit_invocation_allowed()` / `SkillMetadata.matches_product(dcc_name)`.
 
-25. **WebViewAdapter** (Python-only): `from dcc_mcp_core import WebViewAdapter, WebViewContext, CAPABILITY_KEYS, WEBVIEW_DEFAULT_CAPABILITIES` — for embedding browser panels in DCC applications. Not in `_core.pyi`.
+27. **WebViewAdapter** (Python-only): `from dcc_mcp_core import WebViewAdapter, WebViewContext, CAPABILITY_KEYS, WEBVIEW_DEFAULT_CAPABILITIES` — for embedding browser panels in DCC applications. Not in `_core.pyi`.
 
-26. **`skill_warning()` / `skill_exception()`**: Pure-Python helpers in `skill.py`. `skill_warning()` returns a partial-success dict with warnings; `skill_exception()` wraps exceptions into error dict format.
+28. **`skill_warning()` / `skill_exception()`**: Pure-Python helpers in `skill.py`. `skill_warning()` returns a partial-success dict with warnings; `skill_exception()` wraps exceptions into error dict format.
 
-27. **Action→Tool compatibility** (v0.13): The project renamed "action" → "tool" conceptually. Method names `get_action`, `list_actions`, `search_actions` remain as compatibility aliases — not bugs.
+29. **Action→Tool compatibility** (v0.13): The project renamed "action" → "tool" conceptually. Method names `get_action`, `list_actions`, `search_actions` remain as compatibility aliases — not bugs.
 
-28. **MCP best practices**: Design tools around user workflows, not API calls. Use `ToolAnnotations` for safety hints (`read_only_hint`, `destructive_hint`, `idempotent_hint`). Return human-readable errors. Use `notifications/tools/list_changed` when the tool set changes.
+30. **MCP best practices**: Design tools around user workflows, not API calls. Use `ToolAnnotations` for safety hints (`read_only_hint`, `destructive_hint`, `idempotent_hint`). Return human-readable errors. Use `notifications/tools/list_changed` when the tool set changes.
 
-29. **`ActionMeta` is Rust-only**: Do not reference `ActionMeta.enabled` or `ActionMeta.group` in Python code. Use `ToolRegistry.set_tool_enabled(name, enabled)` and `ToolRegistry.list_tools_in_group(skill, group)` instead.
+31. **`ActionMeta` is Rust-only**: Do not reference `ActionMeta.enabled` or `ActionMeta.group` in Python code. Use `ToolRegistry.set_tool_enabled(name, enabled)` and `ToolRegistry.list_tools_in_group(skill, group)` instead.
 
-30. **SKILL.md frontmatter fields**: agentskills.io standard (`name` required, `description` required, `license`, `compatibility`, `metadata`, `allowed-tools` experimental) + dcc-mcp-core extensions (`dcc`, `tags`, `search-hint`, `tools`, `groups`, `depends`, `next-tools`). The `allowed-tools` field uses space-separated tool strings like `Bash(git:*) Read`.
+32. **SKILL.md frontmatter fields**: agentskills.io standard (`name` required, `description` required, `license`, `compatibility`, `metadata`, `allowed-tools` experimental) + dcc-mcp-core extensions (`dcc`, `tags`, `search-hint`, `tools`, `groups`, `depends`, `next-tools`). The `allowed-tools` field uses space-separated tool strings like `Bash(git:*) Read`.
 
-31. **`next-tools` field** (dcc-mcp-core extension): Declared per-tool in SKILL.md to guide AI agents to follow-up tools. `on-success` and `on-failure` accept lists of fully-qualified tool names. Not part of agentskills.io spec.
+33. **`next-tools` field** (dcc-mcp-core extension): Declared per-tool in SKILL.md to guide AI agents to follow-up tools. `on-success` and `on-failure` accept lists of fully-qualified tool names. Not part of agentskills.io spec.
 
-32. **Security**: Use `SandboxPolicy` + `SandboxContext` for AI-driven execution. Validate inputs with `ToolValidator`. Never hardcode secrets in code.
+34. **Security**: Use `SandboxPolicy` + `SandboxContext` for AI-driven execution. Validate inputs with `ToolValidator`. Never hardcode secrets in code.
 
-33. **Commit messages**: Use Conventional Commits (`feat:`, `fix:`, `docs:`, etc.). Never manually bump versions.
+35. **Commit messages**: Use Conventional Commits (`feat:`, `fix:`, `docs:`, etc.). Never manually bump versions.
+
+36. **AI Agent Tool Priority**: When interacting with DCCs, prefer: (1) Skill Discovery (`search_skills` → `load_skill`), (2) Skill-based tools (validated schemas + `next-tools` + `ToolAnnotations`), (3) Diagnostics tools (`diagnostics__screenshot` etc.), (4) Direct registry access (last resort, must validate + sandbox). Skills-first approach provides safety, discoverability, chainability, progressive exposure, and validation.
 
 ## CI/CD Summary
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2218,6 +2218,14 @@ DCC main thread.
 > | 2025-06-18 | Structured Tool Output, Elicitation (server asks user for info), Resource Links in tool results, JSON-RPC batching **removed**, `MCP-Protocol-Version` header mandatory | Planned |
 > | 2025-11-25 | Icon metadata, Tasks (experimental), Sampling with tool calls, JSON Schema 2020-12, enhanced OAuth | Planned |
 >
+> **2026 MCP Roadmap** (announced March 2026) — four priority areas:
+> 1. **Transport scalability**: `.well-known` server capability discovery, stateless session model for horizontal scaling
+> 2. **Agent communication**: Tasks primitive lifecycle (experimental in 2025-11-25), retry/expiration semantics pending
+> 3. **Governance**: contributor ladder, delegated workgroup model for faster SEP review
+> 4. **Enterprise readiness**: audit trails, SSO integration, gateway behavior (mostly as extensions, not core spec changes)
+>
+> No new official transport types will be added in the 2026 cycle — only evolution of Streamable HTTP.
+>
 > When these features land in `dcc-mcp-core`, they will be exposed via `McpHttpServer` —
 > do NOT implement these manually.
 
@@ -2373,6 +2381,54 @@ print(f"MCP server ready: {handle.mcp_url()}")
 - Pre-flight: `vx just preflight` (check + clippy + fmt-check + test-rust)
 - Full CI: `vx just ci`
 - Release: [Release Please](https://github.com/googleapis/release-please) with Conventional Commits
+
+## AI Agent Tool Priority Guide
+
+When an AI agent needs to interact with DCC software, follow this priority order:
+
+### 1. Skill Discovery (always start here)
+```python
+# Find relevant skills by keyword
+result = search_skills(query="create sphere maya")
+# Load the skill to register its tools
+load_skill(skill_name="maya-geometry")
+# Now the skill's tools appear in tools/list
+```
+
+### 2. Skill-Based Tools (preferred over raw API calls)
+- Use skill tools (e.g. `maya_geometry__create_sphere`) — they have validated schemas, error handling, and `next-tools` guidance
+- Check `ToolAnnotations` for safety hints before calling destructive tools
+- Use `next-tools` from tool results to chain follow-up actions
+
+### 3. Diagnostics Tools (for debugging/verification)
+```python
+diagnostics__screenshot    # verify visual state
+diagnostics__audit_log     # check execution history
+diagnostics__tool_metrics  # measure performance
+diagnostics__process_status # check DCC process health
+```
+
+### 4. Direct Registry Access (last resort)
+- Only when no skill tool covers the needed operation
+- Must validate inputs with `ToolValidator` before execution
+- Must use `SandboxPolicy` for AI-initiated calls
+
+### Why Skills First?
+1. **Safety**: Skills declare `ToolAnnotations` — agents can check `destructive_hint`, `read_only_hint`
+2. **Discoverability**: `search_skills` + `search-hint` keywords find the right tool without trial-and-error
+3. **Chainability**: `next-tools` guides follow-up actions, reducing hallucination
+4. **Progressive exposure**: Tool groups keep `tools/list` small — agents activate only what they need
+5. **Validation**: Skill tools have `input_schema` — parameters are validated before execution
+
+### SKILL.md Description Quality
+The `description` field (1-1024 chars) should describe **what the skill does AND when to use it**:
+- Bad: `"Helps with geometry."`
+- Good: `"Creates and modifies polygon geometry in Maya. Use when user asks to create spheres, cubes, bevel edges, or extrude faces."`
+
+### Progressive Disclosure
+Keep `SKILL.md` body < 500 lines / < 5000 tokens; move details to `references/` (loaded on demand by agents).
+
+---
 
 ## Related Projects
 

--- a/llms.txt
+++ b/llms.txt
@@ -154,6 +154,8 @@ crates/
 **SkillSummary fields:** `.name`, `.description`, `.search_hint`, `.version`, `.dcc`, `.tags`, `.tool_count`, `.tool_names`, `.loaded`
 
 **SkillMetadata fields:** `.name`, `.description`, `.search_hint`, `.dcc`, `.version`, `.tags`, `.tools`, `.scripts` (List[str] absolute paths), `.skill_path`, `.depends`, `.metadata_files`, `.groups` (List[SkillGroup]), `.license` (str), `.compatibility` (str), `.allowed_tools` (List[str]), `.external_deps` (str|None — JSON string of external dependency declarations; set via `md.external_deps = json.dumps(deps)`, read via `json.loads(md.external_deps)`)
+- **SKILL.md description quality**: The `description` field (1-1024 chars) should describe **what the skill does AND when to use it** — include specific keywords so AI agents can match tasks. Bad: "Helps with geometry." Good: "Creates and modifies polygon geometry in Maya. Use when user asks to create spheres, cubes, bevel edges, or extrude faces."
+- **Progressive disclosure**: Keep `SKILL.md` body < 500 lines / < 5000 tokens; move details to `references/` (loaded on demand by agents)
 
 **SkillGroup fields:** `.name`, `.description`, `.default_active` (bool), `.tools` (List[str]) — declared in SKILL.md `groups:` frontmatter for progressive tool exposure
 
@@ -177,6 +179,8 @@ tools:
 - `on-failure`: debugging/recovery tools on failure
 - Both accept lists of fully-qualified tool names (`skill_name__tool_name` format)
 - This is a dcc-mcp-core extension, not part of the agentskills.io specification
+
+**AI Agent Tool Priority**: When interacting with DCCs, prefer: (1) Skill Discovery (`search_skills` → `load_skill`), (2) Skill-based tools (validated schemas + `next-tools` + `ToolAnnotations` safety hints), (3) Diagnostics tools (`diagnostics__screenshot` etc.), (4) Direct registry access (last resort). Skills-first provides safety, discoverability, chainability, progressive exposure, and input validation.
 
 ### MCP Protocol Types (`dcc_mcp_core`)
 
@@ -216,7 +220,7 @@ tools:
   - `.gateway_port`, `.registry_dir`, `.stale_timeout_secs`, `.heartbeat_secs`, `.dcc_type`, `.dcc_version`, `.scene` — gateway participation config
 - `McpHttpServer(registry, config=None)` — MCP Streamable HTTP server (**2025-03-26 spec**), axum/Tokio backend
   - `.start() -> McpServerHandle` — starts background thread, returns immediately
-  - **Note**: MCP 2025-03-26 implements Streamable HTTP, Tool Annotations, OAuth 2.1. MCP 2025-06-18 adds Structured Tool Output, Elicitation, Resource Links, and removes JSON-RPC batching. MCP 2025-11-25 adds icon metadata, Tasks, Sampling with tools. Do NOT implement manually — wait for library support.
+  - **Note**: MCP 2025-03-26 implements Streamable HTTP, Tool Annotations, OAuth 2.1. MCP 2025-06-18 adds Structured Tool Output, Elicitation, Resource Links, and removes JSON-RPC batching. MCP 2025-11-25 adds icon metadata, Tasks, Sampling with tools. The 2026 roadmap focuses on: (1) transport scalability — `.well-known` capability discovery, stateless sessions; (2) agent communication — Tasks lifecycle, retry/expiration; (3) governance — delegated workgroups; (4) enterprise readiness — audit, SSO (mostly extensions). No new transport types in 2026. Do NOT implement manually — wait for library support.
 - `McpServerHandle` (alias for `McpServerHandle`) — handle to running server
   - `.mcp_url() -> str` — full MCP endpoint URL (e.g. `"http://127.0.0.1:8765/mcp"`)
   - `.port -> int`, `.bind_addr -> str`

--- a/skills/README.md
+++ b/skills/README.md
@@ -54,7 +54,7 @@ my-skill/
 | Field | Required | Description |
 |-------|----------|-------------|
 | `name` | Yes | Unique skill identifier (kebab-case, max 64 chars) |
-| `description` | Yes | What the skill does and when to use it (shown to AI agents, max 1024 chars) |
+| `description` | Yes | What the skill does AND when to use it (shown to AI agents, max 1024 chars). Include specific keywords for discoverability. |
 | `dcc` | No | Target DCC (`maya`, `blender`, `python`, etc.) |
 | `version` | No | Semantic version (default `1.0.0`) |
 | `tags` | No | Discovery tags (`[modeling, geometry, maya]`) |
@@ -67,6 +67,33 @@ my-skill/
 | `tools` | No | Explicit tool declarations with schemas |
 | `metadata` | No | Arbitrary key-value metadata (agentskills.io spec) |
 | `external_deps` | No | External dependency declaration (MCP servers, env vars, binaries) as YAML mapping |
+
+### Description Quality Guide
+
+The `description` field is the **most important field for AI agent discoverability**. It determines whether an agent will find and use your skill via `search_skills()`.
+
+**Good descriptions** tell AI agents **what** the skill does and **when to use it**:
+```yaml
+# ✓ Good — specific keywords + use-case trigger
+description: "Creates and modifies polygon geometry in Maya. Use when user asks to create spheres, cubes, bevel edges, or extrude faces."
+# ✓ Good — clear scope + trigger phrases
+description: "Extracts text and tables from PDF files, fills PDF forms, and merges multiple PDFs. Use when working with PDF documents."
+```
+
+**Bad descriptions** are vague and lack discoverability:
+```yaml
+# ✗ Bad — too vague, no keywords, no use-case
+description: "Helps with geometry."
+# ✗ Bad — no trigger phrase for when to use
+description: "PDF processing utilities."
+```
+
+### Progressive Disclosure
+
+Keep `SKILL.md` body under **500 lines / 5000 tokens**. Move detailed references to `references/`:
+- AI agents load `name` + `description` at startup (~100 tokens)
+- Full SKILL.md body is loaded on `load_skill()` activation
+- `references/` files are loaded only when explicitly needed
 
 ### Tool Declaration Fields
 


### PR DESCRIPTION
## Summary

Enhanced documentation to make AI agents better understand and use the project, with a focus on progressive disclosure architecture and skills-first tool priority.

### Changes

**AGENTS.md** — Navigation map (progressive disclosure):
- Added **Document Hierarchy table** at the top: AGENTS.md → llms.txt → llms-full.txt → docs/ → CLAUDE.md/GEMINI.md
- Added **AI Agent Tool Priority** section with decision tree: Skill Discovery → Skill-Based Tools → Diagnostics → Direct Registry
- Reordered sections: Tool Priority now comes before API Decision Tree
- Added "Start with search_skills" to Do list, "Don't guess tool names" to Don't list

**CLAUDE.md** — Claude-specific (references AGENTS.md):
- Added Document Hierarchy section with progressive disclosure reading order
- Reduced duplication — now references AGENTS.md as primary source
- Added AI Agent Tool Priority section
- Kept Claude-specific tips and workflows

**GEMINI.md** — Gemini-specific (references AGENTS.md):
- Added Document Hierarchy section with progressive disclosure reading order
- Added AI Agent Tool Priority item (pitfall #36)
- Added MCP 2026 roadmap details to spec awareness

**llms.txt** — AI-friendly API index:
- Added MCP 2026 roadmap details (4 priority areas: transport scalability, agent communication, governance, enterprise readiness)
- Added SKILL.md description quality guide (good vs bad examples)
- Added progressive disclosure guidance (keep < 500 lines / 5000 tokens)
- Added AI Agent Tool Priority section

**llms-full.txt** — Complete API reference:
- Added MCP 2026 roadmap details
- Added AI Agent Tool Priority Guide section with skill discovery workflow
- Added SKILL.md description quality guide with examples
- Added progressive disclosure guidance

**skills/README.md** — Skill authoring guide:
- Enhanced description field guidance with concrete good/bad examples
- Added Description Quality Guide section
- Added Progressive Disclosure section with token budget guidance

### Key Design Decisions

1. **AGENTS.md = Navigation map, not reference manual**: Progressive disclosure — tells you *where to look*, not *what everything does*
2. **CLAUDE.md/GEMINI.md reference AGENTS.md**: Avoid duplication, keep agent-specific tips only
3. **Skills-first tool priority**: AI agents should always start with `search_skills()` → `load_skill()` → use skill tools, not guess tool names
4. **MCP 2026 roadmap**: Documents the four priority areas so agents don't implement future features manually
