### PR TITLE
docs: fix outdated references and add missing guide pages

### DIFF
--- a/.agents/skills/dcc-mcp-core/SKILL.md
+++ b/.agents/skills/dcc-mcp-core/SKILL.md
@@ -3,7 +3,7 @@ name: dcc-mcp-core
 description: "Foundation library for the DCC Model Context Protocol (MCP) ecosystem. Provides Rust-powered action management, skills system, IPC transport, MCP Streamable HTTP server (2025-03-26 spec, with 2025-06-18 and 2025-11-25 awareness), sandbox security, shared memory, screen capture, USD scene support, and telemetry for AI-assisted DCC workflows. Use when working with Maya, Blender, Houdini, 3ds Max, or any DCC MCP integration."
 allowed-tools: Bash Read Write Edit
 compatibility: "Python 3.7-3.13; Rust 1.85+ required to build from source; zero runtime Python dependencies"
-version: "0.12.29"
+version: "0.13.5"
 ---
 
 # dcc-mcp-core — DCC MCP Ecosystem Foundation
@@ -16,8 +16,8 @@ The foundational library enabling AI assistants to interact with Digital Content
 |------|----------|----------|
 | Return action result | `success_result()` / `error_result()` | raw dicts |
 | Load skills | `scan_and_load()` → `(skills, skipped)` | manual file scanning |
-| One-call MCP server | `create_skill_manager("maya", McpHttpConfig(port=8765))` | manual wiring |
-| Validate params | `ActionValidator.from_schema_json()` | isinstance checks |
+| One-call MCP server | `create_skill_server("maya", McpHttpConfig(port=8765))` | manual wiring |
+| Validate params | `ToolValidator.from_schema_json()` | isinstance checks |
 | Connect to DCC | `connect_ipc(TransportAddress.default_local(...))` | raw sockets |
 | Define MCP tool | `ToolDefinition` + `ToolAnnotations` | raw JSON |
 | Serve MCP over HTTP | `McpHttpServer(registry, McpHttpConfig(port=8765))` | raw HTTP server |
@@ -58,12 +58,12 @@ pip install dcc-mcp-core
 
 ```python
 import os
-from dcc_mcp_core import create_skill_manager, McpHttpConfig
+from dcc_mcp_core import create_skill_server, McpHttpConfig
 
 os.environ["DCC_MCP_MAYA_SKILL_PATHS"] = "/opt/my-skills"
 
 # One call: creates registry + dispatcher + catalog + discovers skills + server
-server = create_skill_manager("maya", McpHttpConfig(port=8765))
+server = create_skill_server("maya", McpHttpConfig(port=8765))
 handle = server.start()
 print(f"Maya MCP server: {handle.mcp_url()}")
 
@@ -96,7 +96,7 @@ def my_action(params):
 
 ```python
 import json
-from dcc_mcp_core import ActionValidator, error_result
+from dcc_mcp_core import ToolValidator, error_result
 
 schema = json.dumps({
     "type": "object",
@@ -106,7 +106,7 @@ schema = json.dumps({
         "radius": {"type": "number", "minimum": 0.001},
     },
 })
-validator = ActionValidator.from_schema_json(schema)
+validator = ToolValidator.from_schema_json(schema)
 ok, errors = validator.validate(json.dumps(params))
 if not ok:
     return error_result("Invalid parameters", "; ".join(errors))
@@ -173,14 +173,14 @@ current_skills = watcher.skills()  # -> List[SkillMetadata]
 
 ```python
 import json
-from dcc_mcp_core import ActionRegistry, ActionDispatcher
+from dcc_mcp_core import ToolRegistry, ToolDispatcher
 
-reg = ActionRegistry()
+reg = ToolRegistry()
 reg.register("create_sphere",
     input_schema=json.dumps({"type": "object", "required": ["radius"],
                               "properties": {"radius": {"type": "number", "minimum": 0.0}}}))
 
-dispatcher = ActionDispatcher(reg)
+dispatcher = ToolDispatcher(reg)
 dispatcher.register_handler("create_sphere", lambda params: {"created": True, "r": params["radius"]})
 
 # Introspect handlers
@@ -212,7 +212,7 @@ def poll():
 # Blender: bpy.app.timers.register(poll, persistent=True)
 # Houdini: hou.ui.addEventLoopCallback(poll)
 
-registry = ActionRegistry()
+registry = ToolRegistry()
 server = McpHttpServer(registry, McpHttpConfig(port=0, server_name="maya-mcp"))
 handle = server.start()
 ```
@@ -281,13 +281,13 @@ print(f'Loaded: {[s.name for s in skills]}')
 ┌─────────────────────────────────────────────────────┐
 │                   Python Layer                       │
 │  dcc_mcp_core/__init__.py  →  _core (PyO3 cdyll)   │
-│  ~154 public symbols re-exported from Rust core      │
+│  ~177 public symbols re-exported from Rust core      │
 │  + Pure-Python: DccServerBase, DccGatewayElection,  │
 │    DccSkillHotReloader, factory, skill helpers       │
 └──────────────────────┬──────────────────────────────┘
                        │ PyO3 bindings
 ┌──────────────────────▼──────────────────────────────┐
-│              Rust Core (14 Crates)                   │
+│              Rust Core (15 Crates)                   │
 │                                                      │
 │  models → actions → skills → protocols              │
 │  transport → http → process → sandbox → telemetry   │
@@ -318,7 +318,7 @@ print(f'Loaded: {[s.name for s in skills]}')
 | `GEMINI.md` | Gemini-specific workflows and tips |
 | `llms.txt` | Concise API reference for LLMs |
 | `llms-full.txt` | Comprehensive API reference with all examples |
-| `python/dcc_mcp_core/__init__.py` | Complete public API (~154 symbols, ground truth for imports) |
+| `python/dcc_mcp_core/__init__.py` | Complete public API (~177 symbols, ground truth for imports) |
 | `python/dcc_mcp_core/_core.pyi` | Type stubs — authoritative parameter names |
 | `examples/skills/` | 11 complete skill package examples |
 | `tests/` | Python integration tests (executable usage examples) |
@@ -354,7 +354,7 @@ The library currently implements **MCP 2025-03-26** (Streamable HTTP). The ecosy
 2. `DeferredExecutor` not in public API yet — use `from dcc_mcp_core._core import DeferredExecutor`
 3. Register ALL actions before `server.start()` — server reads from registry at startup only
 4. Use `FramedChannel.call()` for sync RPC — not `send_request()` + `recv()` (those are for async/multiplex)
-5. `ActionDispatcher(registry)` takes ONE arg — no `validator=` parameter
+5. `ToolDispatcher(registry)` takes ONE arg — no `validator=` parameter
 6. Action naming: `{skill_name.replace('-','_')}__{script_stem}` (double underscore)
 7. SKILL.md `name` must match parent directory name (agentskills.io spec)
 8. `allowed-tools` in SKILL.md is space-separated string, not a list (agentskills.io spec)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@
 > | ⚡ AI-friendly index | `llms.txt` | Compressed API reference optimised for token efficiency | When an AI agent needs to *use* the APIs |
 > | 📖 Full index | `llms-full.txt` | Complete API reference with copy-paste examples | When `llms.txt` lacks detail |
 > | 📚 Human docs | `docs/guide/` + `docs/api/` | Conceptual guides and per-module API docs | When building a new adapter or skill |
-> | 🔧 LLM-specific | `CLAUDE.md` / `GEMINI.md` | Agent-specific workflows and tips | When using Claude Code or Gemini CLI |
+> | 🔧 LLM-specific | `CLAUDE.md` / `GEMINI.md` / `CODEBUDDY.md` | Agent-specific workflows and tips | When using Claude Code, Gemini CLI, or CodeBuddy Code |
 > | 🧩 Skill authoring | `skills/README.md` + `examples/skills/` | Templates, examples, SKILL.md format | When creating or modifying skills |
 
 ---
@@ -613,5 +613,6 @@ When adding a Rust type/function that needs to be callable from Python:
 
 - `CLAUDE.md` — Claude Code workflows and tips (references AGENTS.md for project context)
 - `GEMINI.md` — Gemini-specific guidance (references AGENTS.md for project context)
+- `CODEBUDDY.md` — CodeBuddy Code-specific guidance (references AGENTS.md for project context)
 - `llms.txt` — token-optimised API reference (for AI agents that need to *use* the APIs)
 - `llms-full.txt` — complete API reference with copy-paste examples

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ When you need information, read in this order — stop when you find what you ne
 
 1. **`AGENTS.md`** — Navigation map: where to find everything, traps, Do/Don't
 2. **`llms.txt`** — Compressed API reference for AI agents (token-efficient)
-3. **`python/dcc_mcp_core/__init__.py`** — Complete public API surface (~154 symbols)
+3. **`python/dcc_mcp_core/__init__.py`** — Complete public API surface (~177 symbols)
 4. **`python/dcc_mcp_core/_core.pyi`** — Parameter names, types, signatures
 5. **`llms-full.txt`** — Complete API reference with examples (when `llms.txt` lacks detail)
 6. **`docs/guide/`** + **`docs/api/`** — Conceptual guides and per-module API docs

--- a/CODEBUDDY.md
+++ b/CODEBUDDY.md
@@ -1,0 +1,97 @@
+# CODEBUDDY.md — dcc-mcp-core Instructions for CodeBuddy Code
+
+> **Purpose**: CodeBuddy Code-specific instructions. **Read `AGENTS.md` first** for full project context,
+> architecture, commands, and pitfalls. This file adds only CodeBuddy-specific guidance.
+
+## Project Identity
+
+You are working on **dcc-mcp-core**, a Rust-powered MCP (Model Context Protocol) library for DCC (Digital Content Creation) applications. The Python package name is `dcc_mcp_core`.
+
+## Response Language
+
+- Reply to the user in **Simplified Chinese** (中文简体) by default.
+- Keep all code, identifiers, commit messages, branch names, docstrings, comments, and file contents in **English** — this rule governs only the conversational/assistant-facing output, not anything written to disk or pushed to git.
+- If the user explicitly requests another language for a specific reply, follow that request for that turn.
+
+## Document Hierarchy (Progressive Disclosure)
+
+When you need information, read in this order — stop when you find what you need:
+
+1. **`AGENTS.md`** — Navigation map: where to find everything, traps, Do/Don't
+2. **`llms.txt`** — Compressed API reference for AI agents (token-efficient)
+3. **`python/dcc_mcp_core/__init__.py`** — Complete public API surface (~177 symbols)
+4. **`python/dcc_mcp_core/_core.pyi`** — Parameter names, types, signatures
+5. **`llms-full.txt`** — Complete API reference with examples (when `llms.txt` lacks detail)
+6. **`docs/guide/`** + **`docs/api/`** — Conceptual guides and per-module API docs
+7. **`tests/`** — 120+ usage examples in test form
+
+## CodeBuddy-Specific Workflows
+
+### When Adding a New Python-Accessible Symbol
+
+1. Implement in the appropriate `crates/dcc-mcp-*/src/` Rust crate
+2. Add PyO3 bindings in the crate's `python.rs` module (`#[pyclass]` / `#[pymethods]`)
+3. Register in `src/lib.rs` in the corresponding `register_*()` function
+4. Re-export in `python/dcc_mcp_core/__init__.py` (both import and `__all__`)
+5. Update `python/dcc_mcp_core/_core.pyi` stubs
+6. Add pytest tests in `tests/test_<module>.py`
+
+### When Working With Skills
+
+- Skills are discovered via `SKILL.md` files in directories listed in `DCC_MCP_SKILL_PATHS`
+- Each skill's scripts become automatically registered actions
+- Action naming: `{skill_name}__{script_stem}` (double underscore, hyphens→underscores)
+- Use `scan_and_load()` or `scan_and_load_lenient()` — not the old `scan_and_load_skills()`
+- **`scan_and_load` returns a 2-tuple**: `(List[SkillMetadata], List[str])` — always unpack both
+- See `examples/skills/` for 11 reference implementations
+
+### When Using MCP HTTP Server
+
+```python
+# Skills-First (recommended)
+from dcc_mcp_core import create_skill_server, McpHttpConfig
+server = create_skill_server("maya", McpHttpConfig(port=8765))
+handle = server.start()
+print(handle.mcp_url())  # "http://127.0.0.1:8765/mcp"
+
+# Manual registry wiring (low-level)
+from dcc_mcp_core import ToolRegistry, McpHttpServer, McpHttpConfig
+registry = ToolRegistry()
+registry.register("get_scene", description="Get scene", category="scene", dcc="maya")
+server = McpHttpServer(registry, McpHttpConfig(port=8765, server_name="maya-mcp"))
+handle = server.start()
+# Note: register ALL actions BEFORE calling server.start()
+```
+
+### When Debugging Build/Import Issues
+
+```bash
+# Rebuild dev wheel
+vx just dev
+
+# Verify import works
+python -c "import dcc_mcp_core; print(dir(dcc_mcp_core))"
+
+# Verbose cargo build
+cargo build --workspace --features python-bindings 2>&1 | grep -E "error|warning" | head -30
+```
+
+## CodeBuddy-Specific Tips
+
+- **Prefer reading `__init__.py`** over guessing imports — it has the complete public API surface
+- **`_core.pyi` is the ground truth** for parameter names and types
+- **For large refactors**, use `cargo check --workspace` early to catch errors before building the full wheel
+- **Use `vx just dev`** before running any Python tests — the Rust extension must be compiled first
+- **Don't use legacy APIs**: `ActionManager`, `create_action_manager()`, `MiddlewareChain`, `Action` base class — all removed in v0.12+. Note: `LoggingMiddleware` IS still available.
+- **The project has zero runtime Python dependencies by design** — never add `dependencies = [...]` to `pyproject.toml`
+- **`DeferredExecutor` is not in public `__init__.py`**: import via `from dcc_mcp_core._core import DeferredExecutor`
+- **Commit messages**: Use Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`, `test:`). Never manually bump versions.
+
+## AI Agent Tool Priority
+
+When building tools or interacting with DCCs, follow this priority order:
+
+1. **Skill Discovery** (start here): `search_skills(query)` → `load_skill(name)` → use skill tools
+2. **Skill-Based Tools** (preferred): Tools with validated schemas, error handling, `next-tools` guidance, and `ToolAnnotations` safety hints
+3. **Diagnostics Tools** (for verification): `diagnostics__screenshot`, `diagnostics__audit_log`, `diagnostics__process_status`
+4. **Direct Registry Access** (last resort): Only when no skill tool covers the operation; must validate with `ToolValidator` and sandbox with `SandboxPolicy`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,7 @@ src/
 └── lib.rs                   # PyO3 module entry point (_core)
 python/
 └── dcc_mcp_core/
-    ├── __init__.py           # Public API re-exports (~140 symbols) from _core
+    ├── __init__.py           # Public API re-exports (~177 symbols) from _core
     ├── _core.pyi             # Type stubs
     ├── skill.py              # Pure-Python skill script helpers (no _core dependency)
     └── py.typed              # PEP 561 marker

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -5,8 +5,7 @@
 
 ## Project Identity
 
-You are working on **dcc-mcp-core**, a Rust-powered MCP (Model Context Protocol) library for DCC
-(DDigital Content Creation) applications. Python package: `dcc_mcp_core`. ~154 public symbols,
+You are working on **dcc-mcp-core**, a Rust-powered MCP (Model Context Protocol) library for DCC (Digital Content Creation) applications. Python package: `dcc_mcp_core`. ~177 public symbols,
 zero runtime Python dependencies (everything compiled into Rust core via PyO3), plus pure-Python
 helpers (DccServerBase, DccGatewayElection, DccSkillHotReloader, factory, skill helpers, WebViewAdapter).
 
@@ -48,8 +47,8 @@ vx just lint-fix     # Auto-fix all lint issues
 
 ## Key Architecture Facts
 
-- **14 Rust crates** under `crates/`, compiled into `dcc_mcp_core._core` native extension + pure-Python helpers
-- **~154 public Python symbols** exported from `python/dcc_mcp_core/__init__.py`
+- **15 Rust crates** under `crates/`, compiled into `dcc_mcp_core._core` native extension + pure-Python helpers
+- **~177 public Python symbols** exported from `python/dcc_mcp_core/__init__.py`
 - **Zero runtime Python deps** — all logic in Rust, no `dependencies = [...]` in pyproject.toml
 - Python 3.7–3.13 supported (abi3-py38 wheel; separate non-abi3 wheel for 3.7)
 - **Version: current** — managed by Release Please, never manually bump

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This isn't reinventing MCP — it's **solving MCP's blind spots for desktop auto
 | **Security** | Sandbox + audit log | Manual | Manual | None |
 | **Cross-Platform** | Windows/macOS/Linux | Yes | Limited | Browser only |
 
-AI-friendly docs: [AGENTS.md](AGENTS.md) | [CLAUDE.md](CLAUDE.md) | [GEMINI.md](GEMINI.md) | [`.agents/skills/dcc-mcp-core/SKILL.md`](.agents/skills/dcc-mcp-core/SKILL.md)
+AI-friendly docs: [AGENTS.md](AGENTS.md) | [CLAUDE.md](CLAUDE.md) | [GEMINI.md](GEMINI.md) | [CODEBUDDY.md](CODEBUDDY.md) | [`.agents/skills/dcc-mcp-core/SKILL.md`](.agents/skills/dcc-mcp-core/SKILL.md)
 
 ## Architecture: The Three-Layer Stack
 
@@ -383,12 +383,13 @@ This is **session-bound tool discovery** — not a hack, but a fundamental rethi
 
 ---
 
-## Architecture Overview — 14 Rust Crates
+## Architecture Overview — 15 Rust Crates
 
-dcc-mcp-core is organized as a **Rust workspace of 14 crates**, compiled into a single native Python extension (`_core`) via PyO3/maturin:
+dcc-mcp-core is organized as a **Rust workspace of 15 crates**, compiled into a single native Python extension (`_core`) via PyO3/maturin:
 
 | Crate | Responsibility | Key Types |
 |----------------------|-----------|
+| `dcc-mcp-naming` | SEP-986 naming validators | `validate_tool_name`, `validate_action_id`, `TOOL_NAME_RE` |
 | `dcc-mcp-models` | Data models | `ToolResult`, `SkillMetadata` |
 | `dcc-mcp-actions` | Tool execution lifecycle | `ToolRegistry`, `EventBus`, `ToolDispatcher`, `ToolValidator`, `ToolPipeline` |
 | `dcc-mcp-skills` | Skills discovery & loading | `SkillScanner`, `SkillCatalog`, `SkillWatcher`, dependency resolver |
@@ -416,7 +417,7 @@ dcc-mcp-core is organized as a **Rust workspace of 14 crates**, compiled into a 
 - **Screen capture**: Cross-platform DCC viewport capture for AI visual feedback
 - **USD integration**: Universal Scene Description read/write bridge
 - **Structured telemetry**: Tracing & recording for observability
-- **~154 public Python symbols** with full type stubs (`.pyi`)
+- **~177 public Python symbols** with full type stubs (`.pyi`)
 - **OpenClaw Skills compatible**: Reuse existing ecosystem format
 
 ## Installation
@@ -629,8 +630,9 @@ If you're an AI coding agent, also see:
 - **[AGENTS.md](AGENTS.md)** — Comprehensive guide for all AI agents (architecture, commands, API reference, pitfalls)
 - **[CLAUDE.md](CLAUDE.md)** — Claude-specific instructions and workflows
 - **[GEMINI.md](GEMINI.md)** — Gemini-specific instructions and workflows
+- **[CODEBUDDY.md](CODEBUDDY.md)** — CodeBuddy Code-specific instructions and workflows
 - **[.agents/skills/dcc-mcp-core/SKILL.md](.agents/skills/dcc-mcp-core/SKILL.md)** — Complete API skill definition for learning and using this library
-- **[python/dcc_mcp_core/__init__.py](python/dcc_mcp_core/__init__.py)** — Full public API surface (~140 symbols)
+- **[python/dcc_mcp_core/__init__.py](python/dcc_mcp_core/__init__.py)** — Full public API surface (~177 symbols)
 - **[llms.txt](llms.txt)** — Concise API reference optimized for LLMs
 - **[llms-full.txt](llms-full.txt)** — Complete API reference optimized for LLMs
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** — Development workflow and coding standards

--- a/README_zh.md
+++ b/README_zh.md
@@ -60,7 +60,7 @@ English | [中文](README_zh.md)
 | **安全性** | 沙箱 + 审计日志 | 手动 | 手动 | 无 |
 | **跨平台** | Windows/macOS/Linux | 是 | 有限 | 仅浏览器 |
 
-AI 友好文档：[AGENTS.md](AGENTS.md) | [CLAUDE.md](CLAUDE.md) | [GEMINI.md](GEMINI.md) | [`.agents/skills/dcc-mcp-core/SKILL.md`](.agents/skills/dcc-mcp-core/SKILL.md)
+AI 友好文档：[AGENTS.md](AGENTS.md) | [CLAUDE.md](CLAUDE.md) | [GEMINI.md](GEMINI.md) | [CODEBUDDY.md](CODEBUDDY.md) | [`.agents/skills/dcc-mcp-core/SKILL.md`](.agents/skills/dcc-mcp-core/SKILL.md)
 
 ## 架构：三层体系
 
@@ -413,9 +413,9 @@ paths = get_bundled_skill_paths(include_bundled=False)  # 按需禁用
 
 DCC 适配器（如 `dcc-mcp-maya`）默认自动加载内置技能包。如需禁用：`start_server(include_bundled=False)`。
 
-## 架构概览 — 14 个 Rust Crate 工作区
+## 架构概览 — 15 个 Rust Crate 工作区
 
-dcc-mcp-core 组织为 **14 个 Rust Crate 工作区**，通过 PyO3/maturin 编译成单个原生 Python 扩展（`_core`）：
+dcc-mcp-core 组织为 **15 个 Rust Crate 工作区**，通过 PyO3/maturin 编译成单个原生 Python 扩展（`_core`）：
 
 | Crate | 职责 | 关键类型 |
 |-------|------|---------|
@@ -445,7 +445,7 @@ from dcc_mcp_core import (
 )
 
 # 服务端：监听连接
-listener = IpcListener.new("/tmp/dcc-mcp-server.sock")
+listener = IpcListener.bind("/tmp/dcc-mcp-server.sock")
 handle = listener.start(handler_fn=my_message_handler)
 
 # 客户端：连接服务器
@@ -621,7 +621,8 @@ vx just preflight      # 仅 pre-commit 检查
 - **[AGENTS.md](AGENTS.md)** — 所有 AI 代理综合指南（架构、命令、API 参考、陷阱规避）
 - **[CLAUDE.md](CLAUDE.md)** — Claude 专用指令与工作流
 - **[GEMINI.md](GEMINI.md)** — Gemini 专用指令与工作流
+- **[CODEBUDDY.md](CODEBUDDY.md)** — CodeBuddy Code 专用指令与工作流
 - **[.agents/skills/dcc-mcp-core/SKILL.md](.agents/skills/dcc-mcp-core/SKILL.md)** — 完整 API 技能定义，用于学习与使用此库
-- **[python/dcc_mcp_core/__init__.py](python/dcc_mcp_core/__init__.py)** — 完整公共 API 表面（约 140 个符号）
+- **[python/dcc_mcp_core/__init__.py](python/dcc_mcp_core/__init__.py)** — 完整公共 API 表面（约 177 个符号）
 - **[llms.txt](llms.txt)** — 精简 API 参考（LLM 优化格式）
 - **[llms-full.txt](llms-full.txt)** — 完整 API 参考（LLM 优化格式）

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -20,7 +20,7 @@ export default defineConfig({
           { text: 'Guide', link: '/guide/what-is-dcc-mcp-core' },
           { text: 'API', link: '/api/models' },
           {
-            text: 'v0.12.28',
+            text: 'v0.13.5',
             items: [
               { text: 'Changelog', link: 'https://github.com/loonghao/dcc-mcp-core/blob/main/CHANGELOG.md' },
               { text: 'PyPI', link: 'https://pypi.org/project/dcc-mcp-core/' },
@@ -103,7 +103,7 @@ export default defineConfig({
           { text: '指南', link: '/zh/guide/what-is-dcc-mcp-core' },
           { text: 'API', link: '/zh/api/models' },
           {
-            text: 'v0.12.28',
+              text: 'v0.13.5',
             items: [
               { text: '更新日志', link: 'https://github.com/loonghao/dcc-mcp-core/blob/main/CHANGELOG.md' },
               { text: 'PyPI', link: 'https://pypi.org/project/dcc-mcp-core/' },
@@ -134,6 +134,7 @@ export default defineConfig({
                 { text: 'Actions 动作', link: '/zh/guide/actions' },
                 { text: '事件系统', link: '/zh/guide/events' },
                 { text: 'MCP 协议', link: '/zh/guide/protocols' },
+                { text: '命名 Actions 与 Tools', link: '/zh/guide/naming' },
                 { text: '传输层', link: '/zh/guide/transport' },
               ]
             },

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -43,7 +43,7 @@ DCC-MCP-Core is a Rust workspace with Python bindings via PyO3. It provides:
 
 - **Zero third-party runtime dependencies** in the Rust core
 - **Optional Python bindings** via PyO3 for DCC integration
-- **14 modular crates** for selective dependency usage
+- **15 modular crates** for selective dependency usage
 
 ## Crate Structure
 
@@ -323,7 +323,7 @@ If you need custom middleware or fine-grained control, assemble the stack manual
 
 ## Python Bindings
 
-All 14 crates are compiled into a single PyO3 native extension (`dcc_mcp_core._core`) via `maturin`.
+All 15 crates are compiled into a single PyO3 native extension (`dcc_mcp_core._core`) via `maturin`.
 
 ```toml
 # pyproject.toml
@@ -336,7 +336,7 @@ dependencies = []  # Zero runtime dependencies
 
 ```
 python/dcc_mcp_core/
-├── __init__.py     # Public API (re-exports ~140 symbols from _core)
+├── __init__.py     # Public API (re-exports ~177 symbols from _core)
 ├── _core.pyi       # Type stubs (auto-generated from Rust)
 └── py.typed        # PEP 561 marker
 ```

--- a/docs/guide/custom-actions.md
+++ b/docs/guide/custom-actions.md
@@ -1,0 +1,240 @@
+# Custom Skills
+
+Learn how to build custom Skills for DCC applications — from the recommended Skills-First approach to the low-level registry API.
+
+## Recommended: Skills-First Approach
+
+The Skills-First approach discovers `SKILL.md` packages via environment variables and is the recommended way to build DCC tools:
+
+- **Zero boilerplate** — no manual handler registration, tools are auto-discovered
+- **Auto-exposed as MCP tools** — the skill manager exposes each tool to AI via the MCP protocol
+- **Hot-reload** — changes to `SKILL.md` take effect without restart
+
+### Step 1: Create a SKILL.md Package
+
+```markdown
+---
+name: maya-geometry
+description: Maya geometry creation tools
+version: 1.0.0
+dcc: maya
+tags: [geometry, create]
+tools:
+  - name: create_sphere
+    description: Create a polygon sphere
+    input_schema: |
+      {
+        "type": "object",
+        "required": ["radius"],
+        "properties": {
+          "radius": {"type": "number", "minimum": 0.1},
+          "name": {"type": "string"}
+        }
+      }
+scripts:
+  - create_sphere.py
+---
+
+# Maya Geometry Tools
+
+A toolset for creating and editing geometry in Maya.
+```
+
+### Step 2: Implement the Script
+
+`create_sphere.py`:
+
+```python
+import maya.cmds as cmds
+from dcc_mcp_core import success_result, error_result
+
+
+def create_sphere(radius: float = 1.0, name: str | None = None):
+    try:
+        sphere = cmds.polySphere(r=radius, n=name)[0]
+        return success_result(
+            message=f"Created sphere: {sphere}",
+            context={"object_name": sphere, "radius": radius}
+        )
+    except Exception as e:
+        return error_result(str(e))
+```
+
+### Step 3: Register via Environment Variable and Start
+
+```python
+import os
+from dcc_mcp_core import create_skill_server
+
+os.environ["DCC_MCP_MAYA_SKILL_PATHS"] = "/path/to/my/skills"
+
+# One line: auto-discovers skills, starts MCP HTTP server
+server = create_skill_server("maya", McpHttpConfig(port=8765))
+```
+
+::: tip Skills-First is the recommended pattern
+All new DCC tools should use `SKILL.md` packages first. Only fall back to the registry API when you need runtime dynamic control over handler logic.
+:::
+
+---
+
+## Low-Level Registry API
+
+When you need programmatic control over handler registration at runtime, use the `ToolRegistry` + `ToolDispatcher` API.
+
+### Full Example
+
+```python
+import json
+from dcc_mcp_core import ToolRegistry, ToolDispatcher
+
+# 1. Register action metadata with JSON Schema
+reg = ToolRegistry()
+reg.register(
+    name="create_sphere",
+    description="Create a polygon sphere in Maya",
+    category="geometry",
+    tags=["geo", "create", "mesh"],
+    dcc="maya",
+    version="1.0.0",
+    input_schema=json.dumps({
+        "type": "object",
+        "required": ["radius"],
+        "properties": {
+            "radius": {
+                "type": "number",
+                "minimum": 0.1,
+                "description": "Sphere radius"
+            },
+            "segments": {
+                "type": "integer",
+                "minimum": 4,
+                "default": 16,
+                "description": "Subdivision segments"
+            },
+            "name": {
+                "type": "string",
+                "description": "Optional sphere name"
+            }
+        }
+    }),
+)
+
+# 2. Create dispatcher and register handler
+dispatcher = ToolDispatcher(reg)
+
+def handle_create_sphere(params):
+    radius = params.get("radius", 1.0)
+    segments = params.get("segments", 16)
+    name = params.get("name")
+
+    # Call Maya API (example using maya.cmds)
+    import maya.cmds as cmds
+    sphere_name = cmds.polySphere(r=radius, sx=segments, sy=segments, n=name)[0]
+
+    return {
+        "created": True,
+        "object_name": sphere_name,
+        "radius": radius,
+        "segments": segments,
+    }
+
+dispatcher.register_handler("create_sphere", handle_create_sphere)
+
+# 3. Dispatch using JSON (wire format)
+import json
+result = dispatcher.dispatch("create_sphere", json.dumps({"radius": 2.0, "segments": 32}))
+print(result["output"]["object_name"])  # "pSphere1"
+```
+
+## Key Takeaways
+
+1. **Use `ToolRegistry.register()`** — pass name, description, tags, DCC, version, and JSON Schema
+2. **Implement a handler function** — receives `params: dict`, returns a result dictionary
+3. **Use `ToolDispatcher` to register handlers** — connects an action name to a Python callable
+4. **Use JSON Schema for validation** — `ToolDispatcher` validates JSON input before calling the handler
+5. **Dispatch with JSON strings** — the wire format uses JSON, not Python dicts
+
+## Handler Function Signature
+
+```python
+def my_handler(params: dict) -> Any:
+    """
+    Args:
+        params: Validated parameters (parsed from JSON input)
+    Returns:
+        A dictionary to be used as the action result (serializable to JSON)
+    """
+    pass
+```
+
+## Validation with ToolValidator
+
+Validate inputs before dispatching:
+
+```python
+from dcc_mcp_core import ToolValidator
+
+validator = ToolValidator.from_action_registry(reg, "create_sphere", dcc_name="maya")
+ok, errors = validator.validate('{"radius": 1.5}')
+if not ok:
+    print(f"Validation failed: {errors}")
+    # Handle error
+```
+
+## Versioned Actions
+
+Use `VersionedRegistry` for backward compatibility:
+
+```python
+from dcc_mcp_core import VersionedRegistry
+
+vr = VersionedRegistry()
+
+# v1: basic sphere
+vr.register_versioned(
+    "create_sphere", dcc="maya", version="1.0.0",
+    description="Basic sphere creation",
+)
+
+# v2: add subdivision parameter
+vr.register_versioned(
+    "create_sphere", dcc="maya", version="2.0.0",
+    description="Sphere with subdivision control",
+)
+
+# Automatically resolve the best version
+result = vr.resolve("create_sphere", "maya", "^1.0.0")
+print(result["version"])  # "2.0.0"
+```
+
+## JSON Schema Tips
+
+- Use `$ref` for reusable schemas (ToolValidator does not support this — inline all definitions)
+- `"default"` fields set defaults when keys are missing from input
+- Use `"minimum"`/`"maximum"` for numeric constraints
+- Use `"minLength"`/`"maxLength"` for string length constraints
+- Use `"enum"` to restrict string choices
+
+```python
+input_schema = json.dumps({
+    "type": "object",
+    "required": ["radius"],
+    "properties": {
+        "radius": {
+            "type": "number",
+            "minimum": 0.1,
+            "maximum": 1000.0,
+        },
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64,
+        },
+        "align_to_world": {
+            "type": "boolean",
+            "default": False,
+        }
+    }
+})
+```

--- a/docs/guide/telemetry.md
+++ b/docs/guide/telemetry.md
@@ -1,0 +1,241 @@
+# Telemetry Guide
+
+Operation performance recording and optional OpenTelemetry tracing/metrics.
+
+## Overview
+
+Provides:
+
+- **Operation recording** — `ToolRecorder` records execution time and success/failure counts for each operation
+- **Metrics** — `ToolMetrics` snapshots with latency percentiles (p95/p99) and success rates
+- **Optional OpenTelemetry** — stdout exporter, JSON/text logs, resource attributes (optional)
+
+## ToolRecorder
+
+Records execution time and results for any operation.
+
+### Quick Start
+
+```python
+from dcc_mcp_core import ToolRecorder
+
+recorder = ToolRecorder("my-service")
+
+# Record with guard
+guard = recorder.start("create_sphere", "maya")
+# ... do work ...
+guard.finish(success=True)
+```
+
+### Guard Pattern (Recommended)
+
+The guard returned by `start()` is an RAII context manager:
+
+```python
+# Automatically success=True unless an exception is raised
+with recorder.start("create_sphere", "maya") as guard:
+    # ... do work ...
+    pass
+# guard.finish(success=True) is called automatically
+```
+
+Manual finish when you need explicit control:
+
+```python
+guard = recorder.start("delete_mesh", "houdini")
+try:
+    delete_mesh("Cube")
+    guard.finish(success=True)
+except Exception:
+    guard.finish(success=False)
+    raise
+```
+
+### Querying Metrics
+
+```python
+# Get metrics for a specific operation
+metrics = recorder.metrics("create_sphere")
+if metrics:
+    print(f"Operation: {metrics.action_name}")
+    print(f"Invocations: {metrics.invocation_count}")
+    print(f"Success rate: {metrics.success_rate():.2%}")
+    print(f"Avg duration: {metrics.avg_duration_ms:.2f}ms")
+    print(f"P95: {metrics.p95_duration_ms:.2f}ms")
+    print(f"P99: {metrics.p99_duration_ms:.2f}ms")
+```
+
+### All Metrics
+
+```python
+# Get metrics for all recorded operations
+all_metrics = recorder.all_metrics()
+
+for m in all_metrics:
+    print(f"{m.action_name}: {m.invocation_count} calls, {m.success_rate():.1%} success")
+```
+
+### Reset
+
+```python
+recorder.reset()  # Clear all in-memory statistics
+```
+
+## TelemetryConfig
+
+Optional OpenTelemetry configuration. Not needed when using `ToolRecorder` alone.
+
+### Basic Setup
+
+```python
+from dcc_mcp_core import TelemetryConfig
+
+cfg = TelemetryConfig("my-dcc-service")
+cfg.init()
+```
+
+### Console Exporter
+
+```python
+cfg = TelemetryConfig("my-dcc-service")
+cfg.with_stdout_exporter()
+cfg.init()
+```
+
+### JSON Logs (Production)
+
+```python
+cfg = TelemetryConfig("my-dcc-service")
+cfg.with_stdout_exporter()
+cfg.with_json_logs()
+cfg.with_service_version("1.0.0")
+cfg.init()
+```
+
+### Text Logs (Default)
+
+```python
+cfg = TelemetryConfig("my-dcc-service")
+cfg.with_stdout_exporter()
+cfg.with_text_logs()
+cfg.init()
+```
+
+### No-op Exporter (Testing)
+
+```python
+cfg = TelemetryConfig("my-dcc-service")
+cfg.with_noop_exporter()
+cfg.init()
+```
+
+### Custom Attributes
+
+```python
+cfg = TelemetryConfig("my-dcc-service")
+cfg.with_stdout_exporter()
+cfg.with_attribute("dcc.name", "maya")
+cfg.with_attribute("dcc.version", "2025")
+cfg.init()
+```
+
+### Enable/Disable Features
+
+```python
+cfg = TelemetryConfig("my-dcc-service")
+cfg.with_stdout_exporter()
+cfg.set_enable_metrics(False)   # Disable metrics collection
+cfg.set_enable_tracing(False)   # Disable distributed tracing
+cfg.init()
+```
+
+### Check Initialization
+
+```python
+from dcc_mcp_core import is_telemetry_initialized
+
+if is_telemetry_initialized():
+    print("Telemetry is active")
+```
+
+## Maya Integration
+
+```python
+from dcc_mcp_core import ToolRecorder
+import maya.cmds as cmds
+
+recorder = ToolRecorder("maya")
+
+def traced_create_sphere(radius=1.0, name=None):
+    with recorder.start("create_sphere", "maya") as guard:
+        sphere = cmds.polySphere(r=radius, n=name)[0]
+        guard.finish(success=True)
+        return sphere
+
+def traced_delete(object_name):
+    with recorder.start("delete_object", "maya") as guard:
+        cmds.delete(object_name)
+        guard.finish(success=True)
+```
+
+## Blender Integration
+
+```python
+from dcc_mcp_core import ToolRecorder
+import bpy
+
+recorder = ToolRecorder("blender")
+
+def traced_blender_operation(operation_name, func):
+    with recorder.start(operation_name, "blender") as guard:
+        result = func()
+        guard.finish(success=True)
+        return result
+```
+
+## Multi-DCC Tracing
+
+```python
+# One recorder per DCC
+maya_recorder = ToolRecorder("maya")
+blender_recorder = ToolRecorder("blender")
+houdini_recorder = ToolRecorder("houdini")
+
+# Each maintains independent metrics
+```
+
+## Best Practices
+
+### 1. Use Context Managers
+
+```python
+with recorder.start("my_action", "maya") as guard:
+    perform_action()
+# Success/failure is recorded automatically
+```
+
+### 2. Explicitly Catch Exceptions
+
+```python
+with recorder.start("risky_action", "maya") as guard:
+    try:
+        risky_operation()
+        guard.finish(success=True)
+    except Exception:
+        guard.finish(success=False)
+        raise
+```
+
+### 3. Query Metrics After Batch Operations
+
+```python
+# Run many operations
+for i in range(100):
+    with recorder.start("batch_op", "maya"):
+        do_work(i)
+
+# Check aggregate metrics
+metrics = recorder.metrics("batch_op")
+if metrics:
+    print(f"P99 latency: {metrics.p99_duration_ms}ms")
+```

--- a/docs/zh/guide/naming.md
+++ b/docs/zh/guide/naming.md
@@ -1,0 +1,128 @@
+# 命名你的 Actions 和 Tools
+
+> **状态**：强制规范。每个 DCC-MCP crate、Python wheel 和 skill 作者
+> 必须选择能通过
+> [`dcc_mcp_core::naming`](https://github.com/loonghao/dcc-mcp-core/tree/main/crates/dcc-mcp-naming)
+> 中两个验证器的名称。
+> 相关规范：[MCP `draft/server/tools#tool-names`](https://modelcontextprotocol.io/specification/draft/server/tools#tool-names)、
+> [SEP-986](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/986)。
+
+生态系统中存在**两套**命名规则。在动手之前，先搞清楚你写的字符串适用哪一套。
+
+| 概念 | 用途 | 谁看到 | 验证器 | 正则 |
+|------|------|--------|--------|------|
+| **Tool name** | MCP 线上可见字符串，发布在 `tools/list` 中 | LLM / MCP 客户端 | `validate_tool_name` | `^[A-Za-z0-9](?:[A-Za-z0-9_.\-]{0,47})$` |
+| **Action id** | 内部稳定标识符，宿主用来路由 `tools/call` | Rust/Python 代码，手写注册 | `validate_action_id` | `^[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)*$` |
+
+## 为什么有两套规则？
+
+MCP 规范对 tool name 很宽松：混合大小写、连字符、点号、最长 128 字符。线上传输没问题，但作为内部标识符很糟糕——连字符与 Python 属性名冲突，混合大小写助长拼写错误，128 字符太长不便阅读。
+
+因此 `dcc-mcp-core` 保持两层：
+
+1. **Tool names** 遵循规范，但上限 48 字符，为网关前缀（`{id8}/`、`{skill}.`）留出空间。
+2. **Action ids** 更严格：点分、小写、snake_case 段。你手写这些 ID；库在发布时将它们转换为 tool names。
+
+## 使用验证器
+
+### Rust
+
+```rust
+use dcc_mcp_naming::{validate_tool_name, validate_action_id};
+
+validate_tool_name("geometry.create_sphere")?;
+validate_action_id("scene.get_info")?;
+```
+
+两个函数均为 `O(n)`、无内存分配，返回结构化的
+[`NamingError`](https://docs.rs/dcc-mcp-naming)，指向第一个违规位置。
+
+### Python
+
+```python
+from dcc_mcp_core import (
+    TOOL_NAME_RE,
+    ACTION_ID_RE,
+    MAX_TOOL_NAME_LEN,
+    validate_tool_name,
+    validate_action_id,
+)
+
+validate_tool_name("hello-world.greet")        # 通过
+validate_action_id("scene.get_info")           # 通过
+
+validate_tool_name("bad/name")                 # 抛出 ValueError
+validate_action_id("Scene.Get")                # 抛出 ValueError（大写）
+```
+
+正则常量（`TOOL_NAME_RE`、`ACTION_ID_RE`）导出供下游工具使用——schema 生成器、lint 规则、文档——它们需要引用模式而不调用 Rust。**验证器仍然是权威检查**：优先使用 `validate_tool_name()` 而不是在你的代码中重新实现正则。
+
+## 速查表
+
+### 合法的 tool names
+
+```
+create_sphere
+geometry.create_sphere
+scene.object.transform
+hello-world.greet
+CamelCaseTool          # MCP 允许混合大小写
+0              # 单个 ASCII 字母数字也合法
+```
+
+### 非法的 tool names
+
+| 输入 | 原因 |
+|------|------|
+| `""` | 空字符串 |
+| `_leading` | 前导 `_` 不是 ASCII 字母数字 |
+| `.tool` / `-tool` | 前导 `.` / `-` |
+| `tool/call` | `/` 保留给网关前缀 |
+| `tool name` / `tool,other` / `tool@host` / `tool+v2` | `[_.-]` 之外的标点 |
+| `a * 49` | 超过 `MAX_TOOL_NAME_LEN = 48` |
+| `工具` / `tôol` | 非 ASCII |
+
+### 合法的 action ids
+
+```
+scene
+create_sphere
+scene.get_info
+maya.geometry.create_sphere
+v2.create
+```
+
+### 非法的 action ids
+
+| 输入 | 原因 |
+|------|------|
+| `""` | 空字符串 |
+| `Scene.get` / `scene.Get` | 大写 |
+| `1scene.get` | 前导数字 |
+| `scene..get` / `.scene` / `scene.` | 空的 `.` 分隔段 |
+| `scene-get` | action id 中不允许 `-`（用 `_`） |
+| `scene/get` | 不允许 `/` |
+
+## 上限与理由
+
+* **`MAX_TOOL_NAME_LEN = 48`** — MCP 规范允许 128，我们限制在 48，这样网关可以安全地前置 `{id8}/`（9 字符）或 skill 可以前置 `{skill}.` 而不会超出规范上限。
+* **更严格的 action-id 语法** — 保持手写标识符与 Python 属性约定一致（小写、snake_case、点分命名空间），消除在审计日志、遥测和 IPC 负载中序列化 action id 时的歧义。
+
+## 何时调用验证器
+
+* **宿主作者** — 在**注册时**调用 `validate_action_id`，而不是在调度时。接受错误 id 的注册是 bug 温床。
+* **服务器作者** — 在 `tools/list` 中发布 tool 之前调用 `validate_tool_name`，包括 skill 派生的 tool（其名称由 skill slug + tool slug 组成）。
+* **Skill 作者** — 无需显式调用；库在加载 skill 时验证你的 tool name。无效名称会导致 skill 加载失败并显示可读的错误信息。
+
+## 从自定义规则迁移
+
+早期代码路径偶尔重新发明了这些规则（子串检查、临时正则）。当你修改此类代码时，替换为验证器：
+
+```diff
+- if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+-     return Err("bad tool name");
+- }
++ dcc_mcp_naming::validate_tool_name(name)?;
+```
+
+目标是**一条规则，一个实现**——不要在随机文件中写 `name.len() > 100`，不要在 crate 之间出现"我觉得应该允许连字符"的分歧。

--- a/llms.txt
+++ b/llms.txt
@@ -66,7 +66,7 @@ meta = dcc_mcp_core.parse_skill_md(dirs[0])  # -> SkillMetadata or None
 
 ## Architecture
 
-Rust workspace (15 crates) with PyO3 bindings. All logic in Rust sub-crates; Python gets a single `dcc_mcp_core._core` extension module. The `dcc_mcp_core` package re-exports all ~171 public symbols from `_core` plus pure-Python helpers (DccServerBase, DccGatewayElection, DccSkillHotReloader, factory, skill helpers).
+Rust workspace (15 crates) with PyO3 bindings. All logic in Rust sub-crates; Python gets a single `dcc_mcp_core._core` extension module. The `dcc_mcp_core` package re-exports all ~177 public symbols from `_core` plus pure-Python helpers (DccServerBase, DccGatewayElection, DccSkillHotReloader, factory, skill helpers).
 
 ```
 crates/
@@ -420,6 +420,7 @@ export DCC_MCP_SKILL_PATHS="/path/to/skills1:/path/to/skills2"
 - [AI Agent Guide (AGENTS.md)](https://github.com/loonghao/dcc-mcp-core/blob/main/AGENTS.md)
 - [Claude Guide (CLAUDE.md)](https://github.com/loonghao/dcc-mcp-core/blob/main/CLAUDE.md)
 - [Gemini Guide (GEMINI.md)](https://github.com/loonghao/dcc-mcp-core/blob/main/GEMINI.md)
+- [CodeBuddy Guide (CODEBUDDY.md)](https://github.com/loonghao/dcc-mcp-core/blob/main/CODEBUDDY.md)
 - [Contributing Guide](https://github.com/loonghao/dcc-mcp-core/blob/main/CONTRIBUTING.md)
 - [Changelog](https://github.com/loonghao/dcc-mcp-core/blob/main/CHANGELOG.md)
 - [Full API Reference](https://github.com/loonghao/dcc-mcp-core/blob/main/llms-full.txt)


### PR DESCRIPTION
## Summary

- Fix crate count 14→15 across all docs (dcc-mcp-naming was missing from counts)
- Fix symbol count ~140/~154/~171→~177 to match current `__all__`
- Fix outdated API names: `create_skill_manager`→`create_skill_server`, `ActionValidator`→`ToolValidator`, `ActionRegistry`→`ToolRegistry`, `ActionDispatcher`→`ToolDispatcher`, `IpcListener.new`→`IpcListener.bind`
- Fix GEMINI.md typo "DDigital"→"Digital"
- Update VitePress version stamp v0.12.28→v0.13.5
- Add missing English guide pages: `custom-actions.md`, `telemetry.md`
- Add missing Chinese guide page: `naming.md`
- Add Chinese sidebar entry for naming.md in VitePress config
- Add `CODEBUDDY.md` for CodeBuddy Code agent instructions (with references in AGENTS.md, README.md, README_zh.md, llms.txt)
- Update `.agents/skills/dcc-mcp-core/SKILL.md` version to 0.13.5 and fix stale API names
- Add `dcc-mcp-naming` crate row to README.md architecture table

## Test plan

- [ ] Verify VitePress site builds without broken links (custom-actions, telemetry, naming pages now exist)
- [ ] Verify all API references match current `__init__.py` exports
- [ ] Verify crate count is 15 (matches `ls crates/`)