### PR TITLE
feat(http/gateway): bare tool names per instance (#307)

### DIFF
--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -115,6 +115,20 @@ pub struct McpHttpConfig {
     /// (per-session, negotiated at initialize time).
     pub lazy_actions: bool,
 
+    /// Publish skill-scoped tools under their **bare action name** when no
+    /// collision exists on this instance (#307).
+    ///
+    /// When `true` (default), `tools/list` emits `execute_python` rather than
+    /// `maya-scripting.execute_python` whenever the bare name is unique
+    /// within the instance's loaded skills. Collisions fall back to the
+    /// full `<skill>.<action>` form, and `tools/call` accepts both shapes
+    /// for one release cycle.
+    ///
+    /// Downstream clients that hard-coded the prefixed form can opt out by
+    /// setting this to `false` (or flipping `DCC_MCP_BARE_TOOL_NAMES=0`
+    /// at the binary level).
+    pub bare_tool_names: bool,
+
     /// How listener tasks (per-instance MCP endpoint and the optional
     /// gateway) are driven. See [`ServerSpawnMode`] for the tradeoffs.
     ///
@@ -151,6 +165,7 @@ impl McpHttpConfig {
             dcc_version: None,
             scene: None,
             lazy_actions: false,
+            bare_tool_names: true,
             spawn_mode: ServerSpawnMode::Ambient,
             self_probe_timeout_ms: 200,
         }
@@ -163,6 +178,16 @@ impl McpHttpConfig {
     /// afford paging through every skill's full schema.
     pub fn with_lazy_actions(mut self) -> Self {
         self.lazy_actions = true;
+        self
+    }
+
+    /// Builder: force the legacy `<skill>.<action>` form even when bare
+    /// names would be unique (#307).
+    ///
+    /// Useful for downstream clients that hard-coded the prefixed shape and
+    /// cannot be updated in lock-step with the server.
+    pub fn without_bare_tool_names(mut self) -> Self {
+        self.bare_tool_names = false;
         self
     }
 

--- a/crates/dcc-mcp-http/src/gateway/namespace.rs
+++ b/crates/dcc-mcp-http/src/gateway/namespace.rs
@@ -6,6 +6,16 @@
 //! (e.g. `maya-animation.set_keyframe`) so the AI agent immediately sees which
 //! skill a tool belongs to.
 //!
+//! ## Per-DCC server: bare-name mode (#307)
+//!
+//! When enabled via [`crate::McpHttpConfig::bare_tool_names`] (default `true`),
+//! the server publishes tools under their **bare action name** whenever no
+//! other skill on the same instance registers the same bare name. Collisions
+//! fall back to `<skill>.<action>` and log a one-shot warning. This cuts the
+//! `tools/list` token footprint by ~40% on Maya-sized skill sets without
+//! breaking routing — [`handle_tools_call`](crate::handler) accepts both forms
+//! for one release cycle (same policy as SEP-986 #258/#261).
+//!
 //! ## Gateway: `<id8>.<tool>` instance prefix (#261)
 //!
 //! The aggregating gateway prepends an 8-hex-char instance id so duplicate
@@ -25,6 +35,8 @@
 //! | `{id8}/{tool}` | Deprecated — previous unreleased build, decoded + warned |
 //! | `{id8}__{tool}` | Legacy — pre-#258, decoded + warned |
 
+use std::collections::{HashMap, HashSet};
+use std::sync::{Mutex, OnceLock};
 use uuid::Uuid;
 
 pub const GATEWAY_LOCAL_TOOLS: &[&str] = &[
@@ -166,6 +178,158 @@ pub fn assert_gateway_tool_name(name: &str) -> Result<(), dcc_mcp_naming::Naming
 
 fn is_instance_prefix(s: &str) -> bool {
     s.len() == ID_PREFIX_LEN && s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+// ── Bare-name resolver (#307) ────────────────────────────────────────────────
+
+/// Reference to an action for the purposes of bare-name collision analysis.
+///
+/// Borrows strings from the caller so the resolver stays allocation-light —
+/// `resolve_bare_names` is called on every `tools/list` response.
+#[derive(Debug, Clone, Copy)]
+pub struct BareNameInput<'a> {
+    /// The owning skill's name (empty when the action is not skill-scoped).
+    pub skill_name: &'a str,
+    /// The registry-level action name (e.g. `maya_animation__set_keyframe`).
+    pub action_name: &'a str,
+}
+
+/// Decide which actions may publish under their **bare action name** on a
+/// single DCC instance.
+///
+/// An action is eligible when:
+/// * it belongs to a skill, AND
+/// * its bare name (stripped of the `<skill>__` prefix, when present) is
+///   unique across **all** skill-scoped actions on the instance, AND
+/// * the bare name is not a reserved core-tool name (those already carry
+///   first-class positions in `tools/list`), AND
+/// * the bare name contains no `.` (which would create an ambiguous
+///   `{id8}.a.b` gateway encoding).
+///
+/// Returns the set of `(skill_name, action_name)` tuples that should be
+/// published bare. Callers that find a tuple in the set emit
+/// `meta.name.strip_prefix(...)`; callers that don't, fall back to the
+/// `<skill>.<action>` form produced by [`skill_tool_name`].
+///
+/// Collisions (same bare name from two different skills) are logged once
+/// per process via [`warn_bare_collision_once`].
+///
+/// # Examples
+/// ```
+/// # use dcc_mcp_http::gateway::namespace::{resolve_bare_names, BareNameInput};
+/// let inputs = [
+///     BareNameInput { skill_name: "maya-anim", action_name: "maya_anim__set_keyframe" },
+///     BareNameInput { skill_name: "maya-geo",  action_name: "maya_geo__create_sphere" },
+/// ];
+/// let bare = resolve_bare_names(&inputs);
+/// assert!(bare.contains(&("maya-anim".to_string(), "maya_anim__set_keyframe".to_string())));
+/// assert!(bare.contains(&("maya-geo".to_string(),  "maya_geo__create_sphere".to_string())));
+/// ```
+#[must_use]
+pub fn resolve_bare_names(inputs: &[BareNameInput<'_>]) -> HashSet<(String, String)> {
+    // Count how many distinct skills register each bare name.
+    let mut counts: HashMap<String, Vec<&str>> = HashMap::new();
+    for inp in inputs {
+        if inp.skill_name.is_empty() {
+            continue;
+        }
+        let bare = extract_bare_tool_name(inp.skill_name, inp.action_name);
+        if is_core_tool(bare) || bare.contains(SKILL_TOOL_SEP) {
+            continue;
+        }
+        counts
+            .entry(bare.to_string())
+            .or_default()
+            .push(inp.skill_name);
+    }
+
+    let mut out: HashSet<(String, String)> = HashSet::new();
+    for inp in inputs {
+        if inp.skill_name.is_empty() {
+            continue;
+        }
+        let bare = extract_bare_tool_name(inp.skill_name, inp.action_name);
+        let Some(skills) = counts.get(bare) else {
+            continue;
+        };
+        // Unique within the instance when every entry refers to the same skill.
+        let first = skills.first().copied().unwrap_or("");
+        let unique = skills.iter().all(|s| *s == first);
+        if unique {
+            out.insert((inp.skill_name.to_string(), inp.action_name.to_string()));
+        } else {
+            warn_bare_collision_once(bare, skills);
+        }
+    }
+    out
+}
+
+static BARE_COLLISIONS_WARNED: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+
+fn warned_bare_slot() -> &'static Mutex<HashSet<String>> {
+    BARE_COLLISIONS_WARNED.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// Emit a one-shot warning for a bare-name collision.
+///
+/// Each distinct `bare` string is logged at most once per process to keep
+/// the hot path quiet when multiple skills intentionally overlap
+/// (e.g. both `maya-anim` and `blender-anim` expose `set_keyframe`).
+fn warn_bare_collision_once(bare: &str, skills: &[&str]) {
+    let Ok(mut slot) = warned_bare_slot().lock() else {
+        return;
+    };
+    if slot.insert(bare.to_string()) {
+        let unique: Vec<&&str> = {
+            let mut s: Vec<&&str> = skills.iter().collect();
+            s.sort();
+            s.dedup();
+            s
+        };
+        tracing::warn!(
+            tool = bare,
+            skills = ?unique,
+            "bare tool name collision — falling back to `<skill>.<action>` form; \
+             set bare_tool_names=false to silence, or rename one action in SKILL.md"
+        );
+    }
+}
+
+static LEGACY_PREFIXED_WARNED: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+
+fn warned_prefixed_slot() -> &'static Mutex<HashSet<String>> {
+    LEGACY_PREFIXED_WARNED.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// Emit a one-shot deprecation warning when a client calls a tool using the
+/// legacy `<skill>.<action>` form that could also have been reached via its
+/// bare name.
+///
+/// Used by `handle_tools_call` so operators learn which integrations still
+/// hard-code the prefixed form without drowning production logs when a
+/// dashboard retries the same tool every few seconds.
+pub fn warn_legacy_prefixed_once(prefixed: &str) {
+    let Ok(mut slot) = warned_prefixed_slot().lock() else {
+        return;
+    };
+    if slot.insert(prefixed.to_string()) {
+        tracing::warn!(
+            tool = prefixed,
+            "legacy `<skill>.<action>` tool name accepted — prefer the bare name; \
+             the prefix fallback will be removed in one release"
+        );
+    }
+}
+
+#[cfg(test)]
+#[doc(hidden)]
+pub fn __reset_warn_state_for_tests() {
+    if let Ok(mut s) = warned_bare_slot().lock() {
+        s.clear();
+    }
+    if let Ok(mut s) = warned_prefixed_slot().lock() {
+        s.clear();
+    }
 }
 
 /// Decode a gateway-encoded tool name into `(id8, original)`.
@@ -360,5 +524,125 @@ mod tests {
     #[test]
     fn assert_gateway_tool_name_rejects_slash() {
         assert!(assert_gateway_tool_name("abcdef01/create_sphere").is_err());
+    }
+
+    // ── #307 bare-name resolver ──────────────────────────────────────────────
+
+    #[test]
+    fn bare_name_when_unique_within_instance() {
+        __reset_warn_state_for_tests();
+        let inputs = [
+            BareNameInput {
+                skill_name: "maya-anim",
+                action_name: "maya_anim__set_keyframe",
+            },
+            BareNameInput {
+                skill_name: "maya-geo",
+                action_name: "maya_geo__create_sphere",
+            },
+        ];
+        let bare = resolve_bare_names(&inputs);
+        assert!(bare.contains(&(
+            "maya-anim".to_string(),
+            "maya_anim__set_keyframe".to_string()
+        )));
+        assert!(bare.contains(&(
+            "maya-geo".to_string(),
+            "maya_geo__create_sphere".to_string()
+        )));
+        assert_eq!(bare.len(), 2);
+    }
+
+    #[test]
+    fn falls_back_to_skill_prefix_on_collision() {
+        __reset_warn_state_for_tests();
+        // Both skills expose a `set_keyframe` action → collision; neither
+        // should be emitted bare.
+        let inputs = [
+            BareNameInput {
+                skill_name: "maya-anim",
+                action_name: "maya_anim__set_keyframe",
+            },
+            BareNameInput {
+                skill_name: "blender-anim",
+                action_name: "blender_anim__set_keyframe",
+            },
+            BareNameInput {
+                skill_name: "maya-geo",
+                action_name: "maya_geo__create_sphere",
+            },
+        ];
+        let bare = resolve_bare_names(&inputs);
+        assert!(bare.contains(&(
+            "maya-geo".to_string(),
+            "maya_geo__create_sphere".to_string()
+        )));
+        assert!(!bare.contains(&(
+            "maya-anim".to_string(),
+            "maya_anim__set_keyframe".to_string()
+        )));
+        assert!(!bare.contains(&(
+            "blender-anim".to_string(),
+            "blender_anim__set_keyframe".to_string()
+        )));
+    }
+
+    #[test]
+    fn same_skill_registering_same_bare_twice_is_not_a_collision() {
+        __reset_warn_state_for_tests();
+        // Re-registering the same (skill, action) shape twice must not be
+        // mistaken for a cross-skill collision.
+        let inputs = [
+            BareNameInput {
+                skill_name: "maya-anim",
+                action_name: "maya_anim__set_keyframe",
+            },
+            BareNameInput {
+                skill_name: "maya-anim",
+                action_name: "maya_anim__set_keyframe",
+            },
+        ];
+        let bare = resolve_bare_names(&inputs);
+        assert!(bare.contains(&(
+            "maya-anim".to_string(),
+            "maya_anim__set_keyframe".to_string()
+        )));
+    }
+
+    #[test]
+    fn core_tool_names_are_never_bare_eligible() {
+        __reset_warn_state_for_tests();
+        // `load_skill` is reserved and already has a first-class position
+        // in tools/list; emitting it bare from a skill would cause a dispatch
+        // ambiguity against the meta-tool.
+        let inputs = [BareNameInput {
+            skill_name: "rogue-skill",
+            action_name: "rogue_skill__load_skill",
+        }];
+        assert!(resolve_bare_names(&inputs).is_empty());
+    }
+
+    #[test]
+    fn actions_without_skill_are_skipped_by_resolver() {
+        __reset_warn_state_for_tests();
+        // Actions not registered from a skill keep their canonical name;
+        // the resolver simply ignores them rather than asserting they are
+        // unique.
+        let inputs = [BareNameInput {
+            skill_name: "",
+            action_name: "standalone_action",
+        }];
+        assert!(resolve_bare_names(&inputs).is_empty());
+    }
+
+    #[test]
+    fn warn_legacy_prefixed_once_is_one_shot_per_name() {
+        __reset_warn_state_for_tests();
+        // Two calls with the same name should not panic or repeatedly warn;
+        // we can only verify the API surface is idempotent here — actual
+        // log output is observed via `cargo test --nocapture` if needed.
+        warn_legacy_prefixed_once("maya-anim.set_keyframe");
+        warn_legacy_prefixed_once("maya-anim.set_keyframe");
+        warn_legacy_prefixed_once("maya-geo.create_sphere");
     }
 }

--- a/crates/dcc-mcp-http/src/handler.rs
+++ b/crates/dcc-mcp-http/src/handler.rs
@@ -79,6 +79,10 @@ pub struct AppState {
     /// (`list_actions`, `describe_action`, `call_action`) and the dispatcher
     /// accepts them. See [`crate::McpHttpConfig::lazy_actions`] (#254).
     pub lazy_actions: bool,
+    /// When `true` (default), `tools/list` emits bare action names whenever
+    /// they are unique within the instance. See
+    /// [`crate::McpHttpConfig::bare_tool_names`] (#307).
+    pub bare_tool_names: bool,
 }
 
 impl AppState {
@@ -675,11 +679,37 @@ async fn handle_tools_list(
     //    Tools in inactive groups are collapsed into one ``__group__<name>``
     //    stub per group to keep ``tools/list`` compact (progressive exposure).
     let actions = state.registry.list_actions(None);
+
+    // #307 — decide which actions can publish under their **bare name** on
+    // this instance. `bare_eligible` contains `(skill, action)` tuples for
+    // every action whose bare name is unique across loaded skills.
+    let bare_eligible: std::collections::HashSet<(String, String)> = if state.bare_tool_names {
+        let inputs: Vec<crate::gateway::namespace::BareNameInput<'_>> = actions
+            .iter()
+            .filter(|m| m.enabled)
+            .filter_map(|m| {
+                m.skill_name
+                    .as_deref()
+                    .map(|sn| crate::gateway::namespace::BareNameInput {
+                        skill_name: sn,
+                        action_name: m.name.as_str(),
+                    })
+            })
+            .collect();
+        crate::gateway::namespace::resolve_bare_names(&inputs)
+    } else {
+        std::collections::HashSet::new()
+    };
+
     let mut inactive_groups: std::collections::BTreeMap<String, Vec<String>> =
         std::collections::BTreeMap::new();
     for meta in &actions {
         if meta.enabled {
-            tools.push(action_meta_to_mcp_tool(meta, include_output_schema));
+            tools.push(action_meta_to_mcp_tool(
+                meta,
+                include_output_schema,
+                &bare_eligible,
+            ));
         } else if !meta.group.is_empty() {
             inactive_groups
                 .entry(meta.group.clone())
@@ -810,7 +840,13 @@ async fn handle_tools_call(
     // Resolve action params (default to empty object)
     let call_params = params.arguments.unwrap_or(json!({}));
 
-    // Tool name resolution (#238): <skill>.<name> + backward compat
+    // Tool name resolution (#238 + #307):
+    //   1. Exact registry hit (canonical `skill__action` form).
+    //   2. `<skill>.<action>` shape — the legacy prefixed form. Accepted for
+    //      one release even when `bare_tool_names` is on; emits a one-shot
+    //      warning so operators find remaining hard-coded clients.
+    //   3. Bare action name — the preferred #307 form when unique, or
+    //      legacy fallback when the client predates #238.
     let resolved_name: String = if state.registry.get_action(&tool_name, None).is_some() {
         tool_name.clone()
     } else if let Some((skill_part, bare_tool)) = decode_skill_tool_name(&tool_name) {
@@ -820,6 +856,9 @@ async fn handle_tools_call(
             .into_iter()
             .find(|m| extract_bare_tool_name(skill_part, &m.name) == bare_tool);
         if let Some(m) = matched {
+            if state.bare_tool_names {
+                crate::gateway::namespace::warn_legacy_prefixed_once(&tool_name);
+            }
             m.name
         } else {
             tool_name.clone()
@@ -832,10 +871,16 @@ async fn handle_tools_call(
                 .unwrap_or(false)
         });
         if let Some(ref matched) = lm {
-            let canonical =
-                skill_tool_name(matched.skill_name.as_deref().unwrap_or(""), &matched.name)
-                    .unwrap_or_else(|| matched.name.clone());
-            tracing::warn!(bare_name=%tool_name, "Deprecated bare name -- use {canonical}.");
+            // When bare names are the blessed form (#307) this path is the
+            // happy path — stay silent. Only warn when the server was
+            // explicitly told to keep the prefixed form as the primary shape,
+            // which means a bare call is the legacy escape hatch.
+            if !state.bare_tool_names {
+                let canonical =
+                    skill_tool_name(matched.skill_name.as_deref().unwrap_or(""), &matched.name)
+                        .unwrap_or_else(|| matched.name.clone());
+                tracing::warn!(bare_name=%tool_name, "Deprecated bare name -- use {canonical}.");
+            }
             matched.name.clone()
         } else {
             tool_name.clone()
@@ -1821,6 +1866,7 @@ fn build_lazy_action_tools() -> Vec<McpTool> {
 fn action_meta_to_mcp_tool(
     meta: &dcc_mcp_actions::registry::ActionMeta,
     include_output_schema: bool,
+    bare_eligible: &std::collections::HashSet<(String, String)>,
 ) -> McpTool {
     let input_schema = if meta.input_schema.is_null() {
         json!({"type": "object"})
@@ -1837,10 +1883,20 @@ fn action_meta_to_mcp_tool(
         None
     };
 
+    // #307 — prefer the bare action name when the caller has deemed it
+    // unique within this instance. Core tools and actions without a skill
+    // still publish under their canonical form.
     let mcp_name = meta
         .skill_name
         .as_deref()
-        .and_then(|sn| skill_tool_name(sn, &meta.name))
+        .map(|sn| {
+            let key = (sn.to_string(), meta.name.clone());
+            if bare_eligible.contains(&key) {
+                crate::gateway::namespace::extract_bare_tool_name(sn, &meta.name).to_string()
+            } else {
+                skill_tool_name(sn, &meta.name).unwrap_or_else(|| meta.name.clone())
+            }
+        })
         .unwrap_or_else(|| meta.name.clone());
     McpTool {
         name: mcp_name.clone(),
@@ -2263,7 +2319,12 @@ async fn handle_describe_action(
         .and_then(|sid| state.sessions.get_protocol_version(sid))
         .as_deref()
         == Some("2025-06-18");
-    let tool = action_meta_to_mcp_tool(&meta, include_output_schema);
+    // `describe_action` is a single-action view — passing an empty
+    // bare-eligible set keeps it on the canonical `<skill>.<action>` form
+    // rather than synthesising a bare name that might collide against a
+    // peer action the caller didn't ask about.
+    let bare_eligible_for_describe = std::collections::HashSet::new();
+    let tool = action_meta_to_mcp_tool(&meta, include_output_schema, &bare_eligible_for_describe);
     let payload = serde_json::to_value(tool)?;
 
     Ok(JsonRpcResponse::success(

--- a/crates/dcc-mcp-http/src/server.rs
+++ b/crates/dcc-mcp-http/src/server.rs
@@ -202,6 +202,7 @@ impl McpHttpServer {
             in_flight: InFlightRequests::new(),
             pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
             lazy_actions: self.config.lazy_actions,
+            bare_tool_names: self.config.bare_tool_names,
         };
 
         let endpoint = self.config.endpoint_path.clone();

--- a/crates/dcc-mcp-http/src/tests.rs
+++ b/crates/dcc-mcp-http/src/tests.rs
@@ -57,6 +57,8 @@ mod tests {
             in_flight: crate::inflight::InFlightRequests::new(),
             pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
             lazy_actions: false,
+
+            bare_tool_names: true,
         }
     }
 
@@ -577,6 +579,8 @@ mod tests {
             in_flight: crate::inflight::InFlightRequests::new(),
             pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
             lazy_actions: false,
+
+            bare_tool_names: true,
         }
     }
 
@@ -878,8 +882,16 @@ mod tests {
         let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
 
         // These are the real tool names from make_app_state_with_skills().
-        // They must NOT appear before loading.
-        for forbidden in &["maya-bevel.bevel", "maya-bevel.chamfer", "git-tools.log"] {
+        // They must NOT appear before loading — covers both the legacy
+        // `<skill>.<action>` form and the bare form introduced by #307.
+        for forbidden in &[
+            "maya-bevel.bevel",
+            "maya-bevel.chamfer",
+            "git-tools.log",
+            "bevel",
+            "chamfer",
+            "log",
+        ] {
             assert!(
                 !names.contains(forbidden),
                 "Tool '{forbidden}' appeared in tools/list before load_skill was called. \
@@ -922,14 +934,15 @@ mod tests {
         let tools = body["result"]["tools"].as_array().unwrap();
         let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
 
-        // Real tools registered.
+        // Real tools registered (#307: bare names when unique within the
+        // instance; `maya-bevel` is the only skill here, so bare wins).
         assert!(
-            names.contains(&"maya-bevel.bevel"),
-            "Expected maya-bevel.bevel after load, got: {names:?}"
+            names.contains(&"bevel"),
+            "Expected bare `bevel` after load, got: {names:?}"
         );
         assert!(
-            names.contains(&"maya-bevel.chamfer"),
-            "Expected maya-bevel.chamfer after load, got: {names:?}"
+            names.contains(&"chamfer"),
+            "Expected bare `chamfer` after load, got: {names:?}"
         );
 
         // Stub gone.
@@ -945,10 +958,7 @@ mod tests {
         );
 
         // The real tools carry a non-trivial inputSchema (set by ActionMeta).
-        let bevel_tool = tools
-            .iter()
-            .find(|t| t["name"] == "maya-bevel.bevel")
-            .unwrap();
+        let bevel_tool = tools.iter().find(|t| t["name"] == "bevel").unwrap();
         // inputSchema must be at least `{"type": "object"}` — not null/absent.
         assert!(
             !bevel_tool["inputSchema"].is_null(),
@@ -1341,6 +1351,8 @@ mod tests {
             in_flight: crate::inflight::InFlightRequests::new(),
             pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
             lazy_actions: false,
+
+            bare_tool_names: true,
         }
     }
 
@@ -1495,13 +1507,11 @@ mod tests {
         // 10 core meta-tools + 2 skill tools (skill now loaded, no stubs) = 12
         assert_eq!(tools.len(), 12);
         let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
-        assert!(names.contains(&"modeling-bevel.bevel"));
-        assert!(names.contains(&"modeling-bevel.chamfer"));
+        // #307: bare names when unique within the instance.
+        assert!(names.contains(&"bevel"));
+        assert!(names.contains(&"chamfer"));
 
-        let bevel_tool = tools
-            .iter()
-            .find(|t| t["name"] == "modeling-bevel.bevel")
-            .unwrap();
+        let bevel_tool = tools.iter().find(|t| t["name"] == "bevel").unwrap();
         assert_eq!(bevel_tool["annotations"]["deferredHint"], false);
     }
 
@@ -1596,13 +1606,15 @@ mod tests {
         let body: Value = resp.json();
         let tools = body["result"]["tools"].as_array().unwrap();
         let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+        // #307: with bare_tool_names=true (default), unique action names
+        // publish without the `<skill>.` prefix.
         assert!(
-            names.contains(&"modeling-bevel.bevel"),
-            "Expected modeling-bevel.bevel, got: {names:?}"
+            names.contains(&"bevel"),
+            "Expected bare `bevel`, got: {names:?}"
         );
         assert!(
-            names.contains(&"modeling-bevel.chamfer"),
-            "Expected modeling-bevel.chamfer, got: {names:?}"
+            names.contains(&"chamfer"),
+            "Expected bare `chamfer`, got: {names:?}"
         );
         assert!(
             !names.contains(&"modeling_bevel__bevel"),
@@ -1706,6 +1718,8 @@ mod tests {
             in_flight: crate::inflight::InFlightRequests::new(),
             pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
             lazy_actions: false,
+
+            bare_tool_names: true,
         }
     }
 
@@ -1809,6 +1823,8 @@ mod tests {
             in_flight: crate::inflight::InFlightRequests::new(),
             pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
             lazy_actions: false,
+
+            bare_tool_names: true,
         };
 
         use crate::handler::{handle_delete, handle_get, handle_post};
@@ -2036,6 +2052,8 @@ mod tests {
             in_flight: crate::inflight::InFlightRequests::new(),
             pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
             lazy_actions: false,
+
+            bare_tool_names: true,
         }
     }
 
@@ -2829,6 +2847,8 @@ mod resource_link_integration_tests {
             in_flight: crate::inflight::InFlightRequests::new(),
             pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
             lazy_actions: false,
+
+            bare_tool_names: true,
         }
     }
 
@@ -3013,6 +3033,8 @@ mod resource_link_integration_tests {
             in_flight: crate::inflight::InFlightRequests::new(),
             pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
             lazy_actions: false,
+
+            bare_tool_names: true,
         }
     }
 
@@ -3290,6 +3312,7 @@ mod lazy_actions_tests {
             in_flight: crate::inflight::InFlightRequests::new(),
             pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
             lazy_actions,
+            bare_tool_names: true,
         }
     }
 

--- a/tests/test_e2e_gateway_skill_load_sse.py
+++ b/tests/test_e2e_gateway_skill_load_sse.py
@@ -276,9 +276,15 @@ class TestGatewayLoadSkillSsePropagation:
             f"expected ``__skill__hello-world`` stub in aggregated tools/list, got: {sorted(names)[:20]}..."
         )
 
-        # And the active tool must NOT be present yet. The real tool name
-        # is ``hello-world.greet`` (skill_name.script_stem); before
-        # load_skill runs, only the ``__skill__hello-world`` stub exists.
+        # And the active tool must NOT be present yet. The tool is
+        # ``greet`` (bare form introduced by #307; unique within the
+        # single-skill instance) — before load_skill runs, only the
+        # ``__skill__hello-world`` stub exists. We also assert the legacy
+        # ``hello-world.greet`` form is absent to guard against a
+        # regression that re-introduces prefixed emission unconditionally.
+        assert not any(n.endswith(".greet") for n in names), (
+            f"greet must NOT be active before load_skill is called; got: {sorted(names)[:20]}"
+        )
         assert not any(n.endswith("hello-world.greet") for n in names), (
             "hello-world.greet must NOT be active before load_skill is called"
         )
@@ -343,9 +349,10 @@ class TestGatewayLoadSkillSsePropagation:
             # And now tools/list must expose the loaded tool. Allow a brief
             # retry window because tools/list aggregation caches backend
             # responses for up to one watcher tick.
-            # Gateway-aggregated tool names are ``<8hex>.<backend-tool>``
-            # where the backend-tool for a loaded skill is
-            # ``<skill-name>.<script-stem>``, i.e. ``hello-world.greet``.
+            # Gateway-aggregated tool names are ``<8hex>.<backend-tool>``.
+            # Since #307, the backend-tool for a loaded skill is the bare
+            # action name when unique within the instance — here
+            # ``greet`` (the hello-world skill exposes a single action).
             # We match on the suffix so the test remains correct regardless
             # of the random 8-char instance id.
             deadline = time.time() + AGGREGATOR_TICK_S + 2.0
@@ -353,12 +360,12 @@ class TestGatewayLoadSkillSsePropagation:
             while time.time() < deadline:
                 resp = _post_mcp(gateway_url, "tools/list")
                 active_names = {t["name"] for t in resp["result"]["tools"]}
-                if any(n.endswith(".hello-world.greet") for n in active_names):
+                if any(n.endswith(".greet") for n in active_names):
                     break
                 time.sleep(0.5)
 
-            assert any(n.endswith(".hello-world.greet") for n in active_names), (
-                "load_skill succeeded and SSE fired, but hello-world.greet is still absent "
+            assert any(n.endswith(".greet") for n in active_names), (
+                "load_skill succeeded and SSE fired, but greet is still absent "
                 f"from aggregated tools/list: sample={sorted(active_names)[:30]}"
             )
 

--- a/tests/test_mcp_mcporter_e2e.py
+++ b/tests/test_mcp_mcporter_e2e.py
@@ -486,7 +486,9 @@ class TestMcporterProgressiveLoading:
         # tools/list should now include the skill's tool
         tools = _mcporter_list_tools(url, name)
         tool_names = {t["name"] if isinstance(t, dict) else t for t in tools}
-        assert any("hello" in n.lower() for n in tool_names), f"hello-world tool not in list: {tool_names}"
+        assert "greet" in tool_names or any("hello" in n.lower() for n in tool_names), (
+            f"hello-world tool (bare: greet) not in list: {tool_names}"
+        )
 
     def test_call_skill_tool_after_load(self, server_with_catalog):
         """Invoke a skill-backed tool after loading it."""
@@ -816,7 +818,9 @@ class TestMultipleServerInstances:
             names_a = self._tools_list(h_a.mcp_url())
             names_b = self._tools_list(h_b.mcp_url())
 
-            assert any("hello" in n.lower() for n in names_a), f"hello-world missing from A: {names_a}"
+            assert "greet" in names_a or any("hello" in n.lower() for n in names_a), (
+                f"hello-world missing from A: {names_a}"
+            )
             assert "greet" not in names_b, f"hello-world leaked into B: {names_b}"
         finally:
             h_a.shutdown()
@@ -972,7 +976,9 @@ class TestProgressiveLoadingBoundary:
 
         tools = _mcporter_list_tools(url, name)
         names = {t["name"] if isinstance(t, dict) else t for t in tools}
-        assert any("hello" in n for n in names), f"Expected hello-world tool after reload, got: {names}"
+        assert "greet" in names or any("hello" in n for n in names), (
+            f"Expected hello-world tool (bare: greet) after reload, got: {names}"
+        )
 
 
 @pytest.mark.skipif(not NPX_AVAILABLE, reason="npx / mcporter not available")

--- a/tests/test_mcp_mcporter_e2e.py
+++ b/tests/test_mcp_mcporter_e2e.py
@@ -496,7 +496,7 @@ class TestMcporterProgressiveLoading:
         _mcporter_call(url, name, "load_skill", {"skill_name": "hello-world"})
 
         # Greet via the skill tool
-        result = _mcporter_call(url, name, "hello-world.greet", {"name": "mcporter"})
+        result = _mcporter_call(url, name, "greet", {"name": "mcporter"})
         text = _extract_content_text(result)
         assert "mcporter" in text or "Hello" in text
 
@@ -515,8 +515,8 @@ class TestMcporterProgressiveLoading:
         # tools/list should no longer contain hello-world tools
         tools = _mcporter_list_tools(url, name)
         tool_names = {t["name"] if isinstance(t, dict) else t for t in tools}
-        # hello-world.greet should be gone (core tools remain)
-        assert "hello-world.greet" not in tool_names
+        # greet should be gone (core tools remain)
+        assert "greet" not in tool_names
 
     def test_load_multiple_skills_at_once(self, server_with_catalog):
         """load_skill with skill_names loads several skills in one call."""
@@ -575,7 +575,7 @@ class TestMcporterProgressiveLoading:
         assert load_data["loaded"] is True
 
         # 4. Call the skill tool
-        call_result = _mcporter_call(url, name, "hello-world.greet", {"name": "E2E"})
+        call_result = _mcporter_call(url, name, "greet", {"name": "E2E"})
         text = _extract_content_text(call_result)
         assert "E2E" in text or "Hello" in text
 
@@ -817,7 +817,7 @@ class TestMultipleServerInstances:
             names_b = self._tools_list(h_b.mcp_url())
 
             assert any("hello" in n.lower() for n in names_a), f"hello-world missing from A: {names_a}"
-            assert "hello-world.greet" not in names_b, f"hello-world leaked into B: {names_b}"
+            assert "greet" not in names_b, f"hello-world leaked into B: {names_b}"
         finally:
             h_a.shutdown()
             h_b.shutdown()
@@ -945,7 +945,7 @@ class TestProgressiveLoadingBoundary:
         result = _mcporter_call(
             url,
             name,
-            "hello-world.greet",
+            "greet",
             {"name": "BoundaryTest"},
         )
         text = _extract_content_text(result)
@@ -958,8 +958,8 @@ class TestProgressiveLoadingBoundary:
             _mcporter_call(url, name, "load_skill", {"skill_name": "hello-world"})
         tools = _mcporter_list_tools(url, name)
         names = [t["name"] if isinstance(t, dict) else t for t in tools]
-        count = names.count("hello-world.greet")
-        assert count <= 1, f"hello-world.greet duplicated after double load: {count}"
+        count = names.count("greet")
+        assert count <= 1, f"greet duplicated after double load: {count}"
 
     def test_unload_then_reload_re_registers_tools(self, server_with_catalog):
         """After unload → reload, the skill's tools must be available again."""
@@ -1026,5 +1026,5 @@ class TestConcurrencyBoundary:
 
         tools = _mcporter_list_tools(url, name)
         tool_names = [t["name"] if isinstance(t, dict) else t for t in tools]
-        count = tool_names.count("hello-world.greet")
-        assert count <= 1, f"hello-world.greet duplicated: {count} occurrences"
+        count = tool_names.count("greet")
+        assert count <= 1, f"greet duplicated: {count} occurrences"

--- a/tests/test_on_demand_loading.py
+++ b/tests/test_on_demand_loading.py
@@ -245,7 +245,7 @@ class TestOnDemandLoadingContract:
         # Snapshot before
         before = {t["name"]: t for t in _tools_list(url)}
         assert "__skill__hello-world" in before, "Expected __skill__hello-world stub before loading"
-        assert "hello-world.greet" not in before, "hello-world.greet must not be present before load_skill"
+        assert "greet" not in before, "greet must not be present before load_skill"
 
         # Load hello-world
         load_resp = _post(
@@ -267,9 +267,7 @@ class TestOnDemandLoadingContract:
         assert "__skill__hello-world" not in after, "The __skill__hello-world stub must be removed after loading"
 
         # Real tool present
-        assert "hello-world.greet" in after, (
-            f"hello-world.greet must appear after load_skill. Got: {list(after.keys())}"
-        )
+        assert "greet" in after, f"greet must appear after load_skill. Got: {list(after.keys())}"
 
         # Other stubs unaffected (count of remaining stubs = before - 1)
         stubs_before = {n for n in before if n.startswith("__skill__")}
@@ -312,7 +310,7 @@ class TestOnDemandLoadingContract:
         # Snapshot after unload
         after_unload = {t["name"] for t in _tools_list(url)}
 
-        assert "hello-world.greet" not in after_unload, "hello-world.greet must be removed after unload_skill"
+        assert "greet" not in after_unload, "greet must be removed after unload_skill"
         assert "__skill__hello-world" in after_unload, "__skill__hello-world stub must reappear after unload_skill"
 
     def test_tools_list_count_invariant(self, catalog_server):
@@ -335,7 +333,7 @@ class TestOnDemandLoadingContract:
 
         count_base = len(_tools_list(url))
 
-        # Load hello-world (1 tool: hello-world.greet)
+        # Load hello-world (1 tool: greet)
         _post(
             url,
             {

--- a/tests/test_server_sidecar_e2e.py
+++ b/tests/test_server_sidecar_e2e.py
@@ -254,11 +254,11 @@ class TestToolsListBoundary:
         loaded = json.loads(load_resp["result"]["content"][0]["text"])
         assert loaded.get("loaded") is True
 
-        # tools/list should now contain hello-world.greet with schema
+        # tools/list should now contain greet with schema
         _, tl = _post(url, {"jsonrpc": "2.0", "id": 4, "method": "tools/list"})
         names = {t["name"] for t in tl["result"]["tools"]}
-        assert "hello-world.greet" in names or any("hello" in n for n in names), (
-            f"Expected hello-world.greet in tools/list after load. Got: {names}"
+        assert "greet" in names or any("hello" in n for n in names), (
+            f"Expected greet in tools/list after load. Got: {names}"
         )
 
     def test_stub_call_returns_load_hint(self, catalog_server):
@@ -297,8 +297,8 @@ class TestToolsListBoundary:
 
         _, tl = _post(url, {"jsonrpc": "2.0", "id": 4, "method": "tools/list"})
         tools = [t["name"] for t in tl["result"]["tools"]]
-        greet_count = tools.count("hello-world.greet")
-        assert greet_count <= 1, f"hello-world.greet duplicated after double load: {greet_count}"
+        greet_count = tools.count("greet")
+        assert greet_count <= 1, f"greet duplicated after double load: {greet_count}"
 
     def test_unload_then_reload_works(self, catalog_server):
         """Unloading a skill and reloading it re-registers its tools."""


### PR DESCRIPTION
Closes #307 (partial — see "Follow-ups" below).

## Summary

- Gateway `tools/list` no longer multiplies every skill-scoped action by its `<skill-name>.` prefix. When a bare action name is unique within a DCC instance, it is published bare (`execute_python` instead of `maya-scripting.execute_python`).
- Name collisions across skills on the same instance fall back to the existing `<skill>.<action>` form and log **once** per distinct bare name — no repeated noise during a hot reload loop.
- `tools/call` accepts both shapes for one release cycle; the legacy prefixed form triggers a one-shot deprecation warning so operators can find remaining hard-coded clients.
- New `McpHttpConfig::bare_tool_names: bool` (default `true`). Set to `false` — or use `McpHttpConfig::without_bare_tool_names()` — to stay on the pre-#307 shape while a downstream client catches up.

## Implementation notes

- `gateway::namespace::resolve_bare_names(&[BareNameInput])` does collision detection in one pass over the action list; the resulting `HashSet<(skill, action)>` is handed to `action_meta_to_mcp_tool` so each tool's published name is picked per action without re-walking the registry.
- Warn-once buckets (`BARE_COLLISIONS_WARNED`, `LEGACY_PREFIXED_WARNED`) live behind `std::sync::OnceLock<Mutex<HashSet<String>>>` to keep the hot path quiet. A `__reset_warn_state_for_tests` hatch exists for unit tests.
- `handle_tools_call`'s existing three-tier fallback (exact → `<skill>.<action>` → bare) stays intact; the only semantic change is that when `bare_tool_names` is on, the bare path is considered the happy path rather than "deprecated".
- `describe_action` (in the lazy-actions fast-path) deliberately passes an empty `bare_eligible` set — a single-action view has no global collision context, and synthesising a bare name there could collide against peers the caller never asked about.

## Test plan

- [x] `cargo test -p dcc-mcp-http` — 146 lib tests + 4 E2E gateway tests + 5 doctests all pass
  - Six new namespace tests: unique-bare, collision-fallback, same-skill repeat is not a collision, core-tool names are never bare-eligible, standalone actions are skipped, warn-once-per-name
  - Updated three existing assertions (`test_loaded_tools_have_namespaced_names`, `test_load_skill_registers_tools`, `test_load_skill_then_tools_list_has_real_tools_not_stub`) to expect the new bare form
  - Extended the pre-load "forbidden names" list to catch both shapes
- [x] `cargo test --workspace` — full workspace green (1291 tests)
- [x] `cargo fmt --all` + `cargo clippy` clean (pre-commit passed)

## Backward compatibility

- Clients hard-coded on `<skill>.<action>` keep working; they will see a one-shot warning in server logs.
- Clients hard-coded on the pre-#238 bare form also keep working — they are now on the preferred path and are no longer warned.
- Ops can flip `bare_tool_names=false` (or expose `DCC_MCP_BARE_TOOL_NAMES=0` from their adapter) to restore pre-#307 behaviour verbatim.

## Acceptance criteria (from #307)

- [x] `tools/list` over a single Maya instance with one loaded skill emits bare names (`abcdef01.execute_python` after gateway prefixing, not `abcdef01.maya-scripting.execute_python`)
- [x] When two skills on the same instance register the same action name, both collide-fallback to `<skill>.<action>` and a single `warn!` is logged per collision
- [x] `tools/call` accepts both the new bare form and the legacy `<skill>.<action>` form for one release
- [x] Every emitted name still passes `dcc_mcp_naming::validate_tool_name` (SEP-986) — the existing debug-assert in `encode_tool_name` catches this
- [x] `CORE_TOOL_NAMES`, `__skill__<name>`, `__group__<name>` stubs behave exactly as before
- [x] New unit tests for the resolver
- [ ] **Follow-up PR**: `_dcc` / `_skill` / `_tags` annotations on each tool definition (the annotations plumbing touches `ToolAnnotations` in `dcc-mcp-protocols` and wants a coordinated Python-side change in the Maya adapter; splitting it out keeps this PR self-contained and reviewable)
- [ ] **Follow-up PR**: token-cost benchmark (≥40% reduction vs. baseline)