### PR TITLE
docs: update all documentation for v0.14 DccLink transport API

### DIFF
--- a/.agents/skills/dcc-mcp-core/SKILL.md
+++ b/.agents/skills/dcc-mcp-core/SKILL.md
@@ -3,7 +3,7 @@ name: dcc-mcp-core
 description: "Foundation library for the DCC Model Context Protocol (MCP) ecosystem. Provides Rust-powered action management, skills system, IPC transport, MCP Streamable HTTP server (2025-03-26 spec, with 2025-06-18 and 2025-11-25 awareness), sandbox security, shared memory, screen capture, USD scene support, and telemetry for AI-assisted DCC workflows. Use when working with Maya, Blender, Houdini, 3ds Max, or any DCC MCP integration."
 allowed-tools: Bash Read Write Edit
 compatibility: "Python 3.7-3.13; Rust 1.85+ required to build from source; zero runtime Python dependencies"
-version: "0.13.5"
+version: "0.14.1"
 ---
 
 # dcc-mcp-core — DCC MCP Ecosystem Foundation
@@ -18,7 +18,7 @@ The foundational library enabling AI assistants to interact with Digital Content
 | Load skills | `scan_and_load()` → `(skills, skipped)` | manual file scanning |
 | One-call MCP server | `create_skill_server("maya", McpHttpConfig(port=8765))` | manual wiring |
 | Validate params | `ToolValidator.from_schema_json()` | isinstance checks |
-| Connect to DCC | `connect_ipc(TransportAddress.default_local(...))` | raw sockets |
+| Connect to DCC | `IpcChannelAdapter.connect(name)` or `SocketServerAdapter(path)` | raw sockets |
 | Define MCP tool | `ToolDefinition` + `ToolAnnotations` | raw JSON |
 | Serve MCP over HTTP | `McpHttpServer(registry, McpHttpConfig(port=8765))` | raw HTTP server |
 | Build DCC adapter | `DccServerBase(dcc_name, builtin_skills_dir)` | copy-paste boilerplate |
@@ -32,7 +32,7 @@ The foundational library enabling AI assistants to interact with Digital Content
 |------------|-------------|
 | **Action Management** | Register, validate, dispatch, and execute actions with typed inputs/outputs |
 | **Skills System** | Zero-code script registration (Python/MEL/Batch/Shell/JS) as MCP tools via `SKILL.md` |
-| **Transport Layer** | High-performance IPC with connection pooling, circuit breaker, retry policies |
+| **Transport Layer** | High-performance IPC via ipckit with DccLink framing (IpcChannelAdapter, SocketServerAdapter) |
 | **MCP HTTP Server** | MCP Streamable HTTP (**2025-03-26 spec**) powered by axum/Tokio, runs in background thread |
 | **Process Management** | Launch, monitor, auto-recover DCC processes (Maya, Blender, Houdini, etc.) |
 | **Sandbox Security** | Policy-based access control, input validation, audit logging |
@@ -112,23 +112,23 @@ if not ok:
     return error_result("Invalid parameters", "; ".join(errors))
 ```
 
-### Pattern 4: Connect to a running DCC and call it
+### Pattern 4: Connect to a running DCC via IPC
 
 ```python
-from dcc_mcp_core import TransportAddress, connect_ipc, success_result, error_result
+from dcc_mcp_core import DccLinkFrame, IpcChannelAdapter, success_result, error_result
 
-addr = TransportAddress.default_local("maya", pid=12345)
-channel = connect_ipc(addr)
+# Connect to a DCC process via named pipe / Unix domain socket
+channel = IpcChannelAdapter.connect("dcc-mcp-maya-12345")
 try:
-    # Primary RPC: .call() sends request + waits for correlated response (v0.12.7+)
-    result = channel.call("execute_python", b'import maya.cmds; cmds.sphere()', timeout_ms=10000)
-    if result["success"]:
-        payload = result.get("payload", b"")
-        return success_result(payload.decode() if isinstance(payload, bytes) else str(payload))
+    # Send a Call frame and receive the reply
+    channel.send_frame(DccLinkFrame(msg_type=1, seq=1, body=b'{"method":"execute_python","params":"cmds.sphere()"}'))
+    reply = channel.recv_frame()  # DccLinkFrame
+    if reply.msg_type == 2:  # Reply
+        return success_result(reply.body.decode())
     else:
-        return error_result("DCC call failed", result.get("error", "Unknown error"))
+        return error_result("DCC call failed", reply.body.decode())
 finally:
-    channel.shutdown()
+    channel.shutdown() if hasattr(channel, 'shutdown') else None
 ```
 
 ### Pattern 5: Build a DCC adapter with DccServerBase
@@ -201,7 +201,7 @@ McpHttpServer runs on Tokio worker threads — use `DeferredExecutor` to bridge:
 ```python
 # DeferredExecutor is Rust-backed; import directly until added to public API
 from dcc_mcp_core._core import DeferredExecutor
-from dcc_mcp_core import ActionRegistry, McpHttpServer, McpHttpConfig
+from dcc_mcp_core import ToolRegistry, McpHttpServer, McpHttpConfig
 
 executor = DeferredExecutor(queue_depth=64)
 # In DCC main event loop / timer callback:
@@ -281,7 +281,7 @@ print(f'Loaded: {[s.name for s in skills]}')
 ┌─────────────────────────────────────────────────────┐
 │                   Python Layer                       │
 │  dcc_mcp_core/__init__.py  →  _core (PyO3 cdyll)   │
-│  ~177 public symbols re-exported from Rust core      │
+│  ~180 public symbols re-exported from Rust core      │
 │  + Pure-Python: DccServerBase, DccGatewayElection,  │
 │    DccSkillHotReloader, factory, skill helpers       │
 └──────────────────────┬──────────────────────────────┘
@@ -318,7 +318,7 @@ print(f'Loaded: {[s.name for s in skills]}')
 | `GEMINI.md` | Gemini-specific workflows and tips |
 | `llms.txt` | Concise API reference for LLMs |
 | `llms-full.txt` | Comprehensive API reference with all examples |
-| `python/dcc_mcp_core/__init__.py` | Complete public API (~177 symbols, ground truth for imports) |
+| `python/dcc_mcp_core/__init__.py` | Complete public API (~180 symbols, ground truth for imports) |
 | `python/dcc_mcp_core/_core.pyi` | Type stubs — authoritative parameter names |
 | `examples/skills/` | 11 complete skill package examples |
 | `tests/` | Python integration tests (executable usage examples) |
@@ -353,7 +353,7 @@ The library currently implements **MCP 2025-03-26** (Streamable HTTP). The ecosy
 1. `scan_and_load` returns `(List[SkillMetadata], List[str])` — always unpack: `skills, skipped = scan_and_load(...)`
 2. `DeferredExecutor` not in public API yet — use `from dcc_mcp_core._core import DeferredExecutor`
 3. Register ALL actions before `server.start()` — server reads from registry at startup only
-4. Use `FramedChannel.call()` for sync RPC — not `send_request()` + `recv()` (those are for async/multiplex)
+4. Use `IpcChannelAdapter` + `DccLinkFrame` for IPC (v0.14+) — `FramedChannel`/`connect_ipc` were removed in #251
 5. `ToolDispatcher(registry)` takes ONE arg — no `validator=` parameter
 6. Action naming: `{skill_name.replace('-','_')}__{script_stem}` (double underscore)
 7. SKILL.md `name` must match parent directory name (agentskills.io spec)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,8 @@ Need to interact with DCC?
 
 **IPC / named pipe / unix socket between processes?**
 → [`docs/api/transport.md`](docs/api/transport.md)
-→ Key pattern: `IpcListener.bind(addr)` → `.accept()` | `connect_ipc(addr)` → `channel.call()`
+→ Key pattern: `IpcChannelAdapter.create(name)` → `.wait_for_client()` | `IpcChannelAdapter.connect(name)` → `.send_frame()` / `.recv_frame()`
+→ Frame type: `DccLinkFrame(msg_type, seq, body)`
 
 **DCC main-thread safety (Maya cmds, bpy, hou…)?**
 → [`docs/guide/getting-started.md`](docs/guide/getting-started.md) (DeferredExecutor section)
@@ -491,6 +492,7 @@ json_str = result.to_json()    # JSON string
 - Don't import `DeferredExecutor` from public `__init__` — use `from dcc_mcp_core._core import DeferredExecutor`
 - Don't call `.new_auto()` then `.capture_window()` — use `.new_window_auto()` for single-window capture
 - Don't use legacy APIs: `ActionManager`, `create_action_manager()`, `MiddlewareChain`, `Action` — removed in v0.12+
+- Don't use removed transport APIs: `FramedChannel`, `connect_ipc()`, `IpcListener`, `TransportManager`, `CircuitBreaker`, `ConnectionPool` — removed in v0.14 (#251). Use `IpcChannelAdapter` / `DccLinkFrame` instead
 - Don't add Python runtime dependencies — the project is zero-dep by design
 - Don't manually bump versions or edit `CHANGELOG.md` — Release Please handles this
 - Don't hardcode API keys, tokens, or passwords — use environment variables

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ When you need information, read in this order — stop when you find what you ne
 
 1. **`AGENTS.md`** — Navigation map: where to find everything, traps, Do/Don't
 2. **`llms.txt`** — Compressed API reference for AI agents (token-efficient)
-3. **`python/dcc_mcp_core/__init__.py`** — Complete public API surface (~177 symbols)
+3. **`python/dcc_mcp_core/__init__.py`** — Complete public API surface (~180 symbols)
 4. **`python/dcc_mcp_core/_core.pyi`** — Parameter names, types, signatures
 5. **`llms-full.txt`** — Complete API reference with examples (when `llms.txt` lacks detail)
 6. **`docs/guide/`** + **`docs/api/`** — Conceptual guides and per-module API docs

--- a/CODEBUDDY.md
+++ b/CODEBUDDY.md
@@ -19,7 +19,7 @@ When you need information, read in this order — stop when you find what you ne
 
 1. **`AGENTS.md`** — Navigation map: where to find everything, traps, Do/Don't
 2. **`llms.txt`** — Compressed API reference for AI agents (token-efficient)
-3. **`python/dcc_mcp_core/__init__.py`** — Complete public API surface (~177 symbols)
+3. **`python/dcc_mcp_core/__init__.py`** — Complete public API surface (~180 symbols)
 4. **`python/dcc_mcp_core/_core.pyi`** — Parameter names, types, signatures
 5. **`llms-full.txt`** — Complete API reference with examples (when `llms.txt` lacks detail)
 6. **`docs/guide/`** + **`docs/api/`** — Conceptual guides and per-module API docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ crates/                      # Rust workspace crates (core logic)
 ├── dcc-mcp-actions/         # ToolRegistry, ToolDispatcher, EventBus, ToolPipeline
 ├── dcc-mcp-skills/          # SkillScanner, SkillCatalog, SkillWatcher, dependency resolver
 ├── dcc-mcp-protocols/       # MCP protocol types (Tool, Resource, Prompt, DccAdapter, BridgeKind)
-├── dcc-mcp-transport/       # IPC, ConnectionPool, FramedChannel, CircuitBreaker, FileRegistry
+├── dcc-mcp-transport/       # IPC (ipckit), DccLinkFrame, IpcChannelAdapter, SocketServerAdapter
 ├── dcc-mcp-process/         # PyDccLauncher, ProcessMonitor, CrashRecovery
 ├── dcc-mcp-telemetry/       # TelemetryConfig, ToolRecorder, ToolMetrics
 ├── dcc-mcp-sandbox/         # SandboxPolicy, InputValidator, AuditLog

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -5,7 +5,7 @@
 
 ## Project Identity
 
-You are working on **dcc-mcp-core**, a Rust-powered MCP (Model Context Protocol) library for DCC (Digital Content Creation) applications. Python package: `dcc_mcp_core`. ~177 public symbols,
+You are working on **dcc-mcp-core**, a Rust-powered MCP (Model Context Protocol) library for DCC (Digital Content Creation) applications. Python package: `dcc_mcp_core`. ~180 public symbols,
 zero runtime Python dependencies (everything compiled into Rust core via PyO3), plus pure-Python
 helpers (DccServerBase, DccGatewayElection, DccSkillHotReloader, factory, skill helpers, WebViewAdapter).
 
@@ -48,7 +48,7 @@ vx just lint-fix     # Auto-fix all lint issues
 ## Key Architecture Facts
 
 - **15 Rust crates** under `crates/`, compiled into `dcc_mcp_core._core` native extension + pure-Python helpers
-- **~177 public Python symbols** exported from `python/dcc_mcp_core/__init__.py`
+- **~180 public Python symbols** exported from `python/dcc_mcp_core/__init__.py`
 - **Zero runtime Python deps** — all logic in Rust, no `dependencies = [...]` in pyproject.toml
 - Python 3.7–3.13 supported (abi3-py38 wheel; separate non-abi3 wheel for 3.7)
 - **Version: current** — managed by Release Please, never manually bump
@@ -159,10 +159,12 @@ bus.unsubscribe("event_name", sub_id)
 registry.register(name="action", description="...", dcc="maya", version="1.0.0")
 # Use dispatcher.register_handler() to attach a Python callable
 
-# FramedChannel.call() — primary RPC helper (v0.12.7+)
-channel = connect_ipc(TransportAddress.default_local("maya", pid))
-result = channel.call("execute_python", b'cmds.sphere()', timeout_ms=30000)
-# result: {"id": str, "success": bool, "payload": bytes, "error": str|None}
+# IpcChannelAdapter — IPC via DccLink frames (v0.14+)
+from dcc_mcp_core import DccLinkFrame, IpcChannelAdapter
+channel = IpcChannelAdapter.connect("dcc-mcp-maya-12345")
+channel.send_frame(DccLinkFrame(msg_type=1, seq=1, body=b'{...}'))
+reply = channel.recv_frame()  # DccLinkFrame
+# Legacy FramedChannel/connect_ipc REMOVED in v0.14 (#251)
 
 # McpHttpServer — expose registry over HTTP/MCP
 server = McpHttpServer(registry, McpHttpConfig(port=8765))
@@ -200,8 +202,8 @@ search-hint: "polygon modeling, bevel, extrude, mesh editing"
 12. **`success_result` kwargs → context**: `success_result("msg", count=5)` → `context={"count":5}` — do NOT use `context=` keyword
 13. **`error_result` positional args**: `error_result("msg", "error string")` — not `error_result(message=..., error=...)`
 14. **`EventBus.subscribe` returns int**: Store the return value to unsubscribe later: `sub_id = bus.subscribe(...)`
-15. **`FramedChannel.call()` IS available** (v0.12.7+): Use `channel.call(method, params_bytes, timeout_ms)` for synchronous RPC. Use `send_request()` + `recv()` only for async/multiplexed patterns.
-16. **`IpcListener.bind(addr)`** creates listener (static method); `.accept()` blocks until client connects. There is no `.new()` or `.start()` method.
+15. **`IpcChannelAdapter` replaces `FramedChannel`** (v0.14+): Use `IpcChannelAdapter.connect(name)` + `send_frame(DccLinkFrame(...))` + `recv_frame()`. Legacy `FramedChannel`, `connect_ipc`, `IpcListener` were removed in #251.
+16. **`IpcChannelAdapter.create(name)`** creates server-side channel; `.connect(name)` connects as client. Use `GracefulIpcChannelAdapter` for channels that need `.shutdown()` and thread affinity.
 17. **`McpServerHandle` is an alias**: `server.start()` returns `McpServerHandle`; it is re-exported as `McpServerHandle` in `__init__.py`. Import as `from dcc_mcp_core import McpServerHandle`.
 18. **`McpHttpServer` registry population**: All actions must be registered in `ToolRegistry` BEFORE calling `server.start()`. The server reads metadata from the registry at startup.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **Production-grade foundation for AI-assisted DCC workflows** combining the **Model Context Protocol (MCP)** and a **zero-code Skills system**. Provides a **Rust-powered core with Python bindings (PyO3)** delivering enterprise-grade performance, security, and scalability — all with **zero runtime Python dependencies**. Supports Python 3.7–3.13.
 
-> **Note**: This project is in active development (v0.13+). APIs may evolve; see CHANGELOG.md for version history.
+> **Note**: This project is in active development (v0.14+). APIs may evolve; see CHANGELOG.md for version history.
 
 ---
 
@@ -394,7 +394,7 @@ dcc-mcp-core is organized as a **Rust workspace of 15 crates**, compiled into a 
 | `dcc-mcp-actions` | Tool execution lifecycle | `ToolRegistry`, `EventBus`, `ToolDispatcher`, `ToolValidator`, `ToolPipeline` |
 | `dcc-mcp-skills` | Skills discovery & loading | `SkillScanner`, `SkillCatalog`, `SkillWatcher`, dependency resolver |
 | `dcc-mcp-protocols` | MCP protocol types | `ToolDefinition`, `ResourceDefinition`, `PromptDefinition`, `DccAdapter`, `BridgeKind` |
-| `dcc-mcp-transport` | IPC communication | `TransportManager`, `ConnectionPool`, `IpcListener`, `FramedChannel`, `CircuitBreaker`, `FileRegistry` |
+| `dcc-mcp-transport` | IPC communication | `DccLinkFrame`, `IpcChannelAdapter`, `GracefulIpcChannelAdapter`, `SocketServerAdapter`, `TransportAddress` |
 | `dcc-mcp-process` | Process management | `PyDccLauncher`, `ProcessMonitor`, `ProcessWatcher`, `CrashRecoveryPolicy` |
 | `dcc-mcp-sandbox` | Security | `SandboxPolicy`, `InputValidator`, `AuditLog` |
 | `dcc-mcp-shm` | Shared memory | `SharedBuffer`, `BufferPool`, LZ4 compression |
@@ -411,13 +411,13 @@ dcc-mcp-core is organized as a **Rust workspace of 15 crates**, compiled into a 
 - **Zero runtime Python deps**: Everything compiled into native extension
 - **Skills system**: Zero-code MCP tool registration via SKILL.md + scripts/
 - **Validated dispatch**: Input validation pipeline before execution
-- **Resilient IPC**: Connection pooling, circuit breaker, automatic retry
+- **Resilient IPC**: DccLink framing via ipckit (IpcChannelAdapter, SocketServerAdapter)
 - **Process management**: Launch, monitor, auto-recover DCC processes
 - **Sandbox security**: Policy-based access control with audit logging
 - **Screen capture**: Cross-platform DCC viewport capture for AI visual feedback
 - **USD integration**: Universal Scene Description read/write bridge
 - **Structured telemetry**: Tracing & recording for observability
-- **~177 public Python symbols** with full type stubs (`.pyi`)
+- **~180 public Python symbols** with full type stubs (`.pyi`)
 - **OpenClaw Skills compatible**: Reuse existing ecosystem format
 
 ## Installation
@@ -472,27 +472,22 @@ vx just preflight       # Pre-commit checks only
 
 ### Transport Layer — Inter-Process Communication
 
-dcc-mcp-core provides a production-ready IPC transport layer:
+dcc-mcp-core provides IPC via DccLink framing (ipckit-based, v0.14+):
 
 ```python
-from dcc_mcp_core import (
-    TransportManager, TransportAddress, TransportScheme,
-    RoutingStrategy, IpcListener, connect_ipc,
-    FramedChannel
-)
+from dcc_mcp_core import DccLinkFrame, IpcChannelAdapter, GracefulIpcChannelAdapter, SocketServerAdapter
 
-# Server side: bind and accept connections (blocking)
-listener = IpcListener.bind("/tmp/dcc-mcp-server.sock")
-channel = listener.accept(timeout_ms=10000)   # blocks until client connects
+# Server side: create channel and wait for client
+server = IpcChannelAdapter.create("dcc-mcp-maya")
+server.wait_for_client()  # blocks until client connects
 
 # Client side: connect to server
-channel = connect_ipc("/tmp/dcc-mcp-server.sock")
-# Primary RPC helper (v0.12.7+) — send request and wait for correlated response
-result = channel.call("ping", b"", timeout_ms=5000)
-# result: {"id": str, "success": bool, "payload": bytes, "error": str | None}
+client = IpcChannelAdapter.connect("dcc-mcp-maya")
+client.send_frame(DccLinkFrame(msg_type=1, seq=1, body=b'{"method":"ping"}'))
+reply = client.recv_frame()  # DccLinkFrame
 
-# Advanced: service registry + transport manager
-mgr = TransportManager(registry_dir="/tmp/dcc-registry")
+# Multi-client socket server
+sock_server = SocketServerAdapter("/tmp/dcc-mcp.sock", max_connections=10)
 ```
 
 ### Process Management — DCC Lifecycle Control
@@ -632,7 +627,7 @@ If you're an AI coding agent, also see:
 - **[GEMINI.md](GEMINI.md)** — Gemini-specific instructions and workflows
 - **[CODEBUDDY.md](CODEBUDDY.md)** — CodeBuddy Code-specific instructions and workflows
 - **[.agents/skills/dcc-mcp-core/SKILL.md](.agents/skills/dcc-mcp-core/SKILL.md)** — Complete API skill definition for learning and using this library
-- **[python/dcc_mcp_core/__init__.py](python/dcc_mcp_core/__init__.py)** — Full public API surface (~177 symbols)
+- **[python/dcc_mcp_core/__init__.py](python/dcc_mcp_core/__init__.py)** — Full public API surface (~180 symbols)
 - **[llms.txt](llms.txt)** — Concise API reference optimized for LLMs
 - **[llms-full.txt](llms-full.txt)** — Complete API reference optimized for LLMs
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** — Development workflow and coding standards

--- a/README_zh.md
+++ b/README_zh.md
@@ -13,7 +13,7 @@ English | [中文](README_zh.md)
 
 **面向 AI 辅助 DCC 工作流的生产级基础库**，结合了 **模型上下文协议（MCP）** 与 **零代码 Skills 系统**。提供 **Rust 驱动核心 + PyO3 Python 绑定**，交付企业级性能、安全性和可扩展性——所有这些均**零运行时 Python 依赖**。支持 Python 3.7–3.13。
 
-> **注意**：本项目处于积极开发中（v0.13+）。API 可能会演进；版本历史请参阅 CHANGELOG.md。
+> **注意**：本项目处于积极开发中（v0.14+）。API 可能会演进；版本历史请参阅 CHANGELOG.md。
 
 ---
 
@@ -423,7 +423,7 @@ dcc-mcp-core 组织为 **15 个 Rust Crate 工作区**，通过 PyO3/maturin 编
 | `dcc-mcp-actions` | 技能执行生命周期 | `ToolRegistry`, `EventBus`, `ToolDispatcher`, `ToolValidator`, `ToolPipeline` |
 | `dcc-mcp-skills` | 技能发现与加载 | `SkillScanner`, `SkillCatalog`, `SkillWatcher`, 依赖解析器 |
 | `dcc-mcp-protocols` | MCP 协议类型 | `ToolDefinition`, `ResourceDefinition`, `DccAdapter`, `BridgeKind` |
-| `dcc-mcp-transport` | IPC 通信 | `TransportManager`, `ConnectionPool`, `IpcListener`, `FramedChannel`, `CircuitBreaker`, `FileRegistry` |
+| `dcc-mcp-transport` | IPC 通信 | `DccLinkFrame`, `IpcChannelAdapter`, `GracefulIpcChannelAdapter`, `SocketServerAdapter`, `TransportAddress` |
 | `dcc-mcp-process` | 进程管理 | `PyDccLauncher`, `ProcessMonitor`, `CrashRecoveryPolicy` |
 | `dcc-mcp-sandbox` | 安全沙箱 | `SandboxPolicy`, `InputValidator`, `AuditLog` |
 | `dcc-mcp-shm` | 共享内存 | `SharedBuffer`, LZ4 压缩 |
@@ -436,26 +436,30 @@ dcc-mcp-core 组织为 **15 个 Rust Crate 工作区**，通过 PyO3/maturin 编
 
 ## 更多功能
 
-### 传输层 — IPC 进程通信
+### 传输层 — DccLink IPC 进程通信
 
 ```python
 from dcc_mcp_core import (
-    TransportManager, TransportAddress, TransportScheme,
-    RoutingStrategy, IpcListener, connect_ipc, FramedChannel
+    DccLinkFrame, IpcChannelAdapter, GracefulIpcChannelAdapter,
+    SocketServerAdapter, TransportAddress
 )
 
-# 服务端：监听连接
-listener = IpcListener.bind("/tmp/dcc-mcp-server.sock")
-handle = listener.start(handler_fn=my_message_handler)
+# 服务端：创建 IPC 端点并等待客户端
+server = IpcChannelAdapter.create("my-dcc-server")
+server.wait_for_client()
+frame = server.recv_frame()
+response = DccLinkFrame(msg_type=2, seq=frame.seq, body=b'result')
+server.send_frame(response)
 
-# 客户端：连接服务器
-channel = connect_ipc("/tmp/dcc-mcp-server.sock")
-response = channel.call({"method": "ping", "params": {}})
+# 客户端：连接到服务端
+client = IpcChannelAdapter.connect("my-dcc-server")
+request = DccLinkFrame(msg_type=1, seq=0, body=b'ping')
+client.send_frame(request)
+reply = client.recv_frame()
 
-# 高级：连接池 + 弹性熔断
-mgr = TransportManager()
-mgr.configure_pool(min_size=2, max_size=10)
-mgr.set_circuit_breaker(threshold=5, reset_timeout=30)
+# TCP 服务器（跨机器通信）
+tcp_server = SocketServerAdapter("/tmp/dcc-mcp.sock")
+print(tcp_server.socket_path)
 ```
 
 ### 进程管理 — DCC 生命周期控制

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -20,7 +20,7 @@ export default defineConfig({
           { text: 'Guide', link: '/guide/what-is-dcc-mcp-core' },
           { text: 'API', link: '/api/models' },
           {
-            text: 'v0.13.5',
+            text: 'v0.14.1',
             items: [
               { text: 'Changelog', link: 'https://github.com/loonghao/dcc-mcp-core/blob/main/CHANGELOG.md' },
               { text: 'PyPI', link: 'https://pypi.org/project/dcc-mcp-core/' },
@@ -103,7 +103,7 @@ export default defineConfig({
           { text: '指南', link: '/zh/guide/what-is-dcc-mcp-core' },
           { text: 'API', link: '/zh/api/models' },
           {
-              text: 'v0.13.5',
+              text: 'v0.14.1',
             items: [
               { text: '更新日志', link: 'https://github.com/loonghao/dcc-mcp-core/blob/main/CHANGELOG.md' },
               { text: 'PyPI', link: 'https://pypi.org/project/dcc-mcp-core/' },

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -334,5 +334,5 @@ Common error codes:
 - Server runs in background Tokio thread — no DCC main thread blocking
 - Request timeout applies per-call (default 30s)
 - No connection pooling on the HTTP layer (each POST is stateless)
-- Use `TransportManager` for persistent IPC sessions with DCC
+- Use `IpcChannelAdapter` for persistent IPC sessions with DCC
 - Gateway `FileRegistry` flushes to disk on every mutation — safe for multi-process but not high-frequency writes

--- a/docs/api/transport.md
+++ b/docs/api/transport.md
@@ -1,53 +1,207 @@
 # Transport API
 
-`dcc_mcp_core` — TransportManager, TransportAddress, TransportScheme, RoutingStrategy, ServiceStatus, ServiceEntry, IpcListener, ListenerHandle, FramedChannel, connect_ipc.
+`dcc_mcp_core` — DccLinkFrame, IpcChannelAdapter, GracefulIpcChannelAdapter, SocketServerAdapter, TransportAddress, TransportScheme, ServiceEntry, ServiceStatus.
 
 ## Overview
 
-The transport module provides **cross-platform IPC and TCP communication** between AI agents and DCC applications. Key design decisions:
+The transport module provides **DccLink-based IPC communication** between AI agents and DCC applications. Key design decisions:
 
 - **Named Pipes** (Windows) and **Unix Domain Sockets** (macOS/Linux) are preferred for same-machine connections — sub-millisecond latency, zero configuration.
-- **TCP** is the fallback for cross-machine or when IPC is unavailable.
-- `TransportAddress.default_local(dcc_type, pid)` auto-selects the optimal transport for the current platform.
-- `TransportManager.bind_and_register()` is the recommended one-call setup for DCC plugin authors.
+- DccLink adapters wrap `ipckit` channels with a binary wire format: `[u32 len][u8 type][u64 seq][msgpack body]`.
+- `IpcChannelAdapter.create(name)` + `wait_for_client()` is the recommended server setup.
+- `IpcChannelAdapter.connect(name)` is the client-side entry point.
+- `GracefulIpcChannelAdapter` adds graceful shutdown and DCC main-thread integration.
+- `SocketServerAdapter` provides multi-client connections with a bounded connection pool.
 
-## TransportAddress
+## DccLinkFrame
 
-Protocol-agnostic transport endpoint. Supports TCP, Named Pipes (Windows), and Unix Domain Sockets (macOS/Linux).
+A DCC-Link frame with `msg_type`, `seq`, and `body` fields.
 
-### Factory Methods
+Wire format: `[u32 len][u8 type][u64 seq][msgpack body]`.
+
+Message type tags: 1=Call, 2=Reply, 3=Err, 4=Progress, 5=Cancel, 6=Push, 7=Ping, 8=Pong.
+
+### Constructor
 
 ```python
-from dcc_mcp_core import TransportAddress
+from dcc_mcp_core import DccLinkFrame
 
-# TCP
-addr = TransportAddress.tcp("127.0.0.1", 18812)
-
-# Named Pipe (Windows)
-addr = TransportAddress.named_pipe("dcc-maya-12345")
-
-# Unix Domain Socket (macOS/Linux)
-addr = TransportAddress.unix_socket("/tmp/dcc-maya-12345.sock")
-
-# Auto-select optimal local transport for current platform
-addr = TransportAddress.default_local("maya", pid=os.getpid())
-
-# Parse from URI string
-addr = TransportAddress.parse("tcp://127.0.0.1:18812")
-addr = TransportAddress.parse("pipe://dcc-maya-12345")
-addr = TransportAddress.parse("unix:///tmp/dcc-maya.sock")
+frame = DccLinkFrame(msg_type=1, seq=0, body=b"hello")
 ```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `msg_type` | `int` | — | Message type tag (1-8). Raises `ValueError` if invalid. |
+| `seq` | `int` | — | Sequence number. |
+| `body` | `bytes \| None` | `None` | Payload bytes. |
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `msg_type` | `int` | Message type tag (1=Call, 2=Reply, 3=Err, 4=Progress, 5=Cancel, 6=Push, 7=Ping, 8=Pong) |
+| `seq` | `int` | Sequence number |
+| `body` | `bytes` | Payload bytes |
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `encode()` | `bytes` | Encode the frame to `[len][type][seq][body]` bytes |
+| `decode(data)` | `DccLinkFrame` | Decode a frame from bytes including the 4-byte length prefix (static). Raises `RuntimeError` if malformed. |
+
+### Example
+
+```python
+frame = DccLinkFrame(msg_type=1, seq=0, body=b"payload")
+encoded = frame.encode()
+decoded = DccLinkFrame.decode(encoded)
+assert decoded.msg_type == frame.msg_type
+assert decoded.seq == frame.seq
+assert decoded.body == frame.body
+```
+
+## IpcChannelAdapter
+
+Thin adapter over `ipckit::IpcChannel` using DCC-Link framing. Provides 1:1 framed IPC connections via Named Pipes (Windows) or Unix Domain Sockets (macOS/Linux).
 
 ### Static Methods
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `tcp(host, port)` | `TransportAddress` | Create TCP address |
-| `named_pipe(name)` | `TransportAddress` | Create Named Pipe address (Windows) |
-| `unix_socket(path)` | `TransportAddress` | Create Unix Socket address |
-| `default_local(dcc_type, pid)` | `TransportAddress` | Auto-select optimal local transport |
-| `default_pipe_name(dcc_type, pid)` | `TransportAddress` | Named Pipe for DCC instance |
-| `default_unix_socket(dcc_type, pid)` | `TransportAddress` | Unix Socket for DCC instance |
+| `create(name)` | `IpcChannelAdapter` | Create a server-side IPC channel. Raises `RuntimeError` if creation fails. |
+| `connect(name)` | `IpcChannelAdapter` | Connect to an existing IPC channel. Raises `RuntimeError` if connection fails. |
+
+### Instance Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `wait_for_client()` | `None` | Wait for a client to connect (server-side only). Raises `RuntimeError` if the wait fails. |
+| `send_frame(frame)` | `None` | Send a `DccLinkFrame` to the peer. Raises `RuntimeError` if the send fails. |
+| `recv_frame()` | `DccLinkFrame \| None` | Receive a DCC-Link frame (blocking). Returns `None` if the channel is closed. Raises `RuntimeError` on unexpected errors. |
+
+### Example: Server
+
+```python
+from dcc_mcp_core import IpcChannelAdapter, DccLinkFrame
+
+server = IpcChannelAdapter.create("my-dcc")
+server.wait_for_client()
+
+frame = server.recv_frame()
+if frame is not None:
+    reply = DccLinkFrame(msg_type=2, seq=frame.seq, body=b"result")
+    server.send_frame(reply)
+```
+
+### Example: Client
+
+```python
+from dcc_mcp_core import IpcChannelAdapter, DccLinkFrame
+
+client = IpcChannelAdapter.connect("my-dcc")
+call = DccLinkFrame(msg_type=1, seq=0, body=b"request")
+client.send_frame(call)
+
+reply = client.recv_frame()
+if reply is not None:
+    print(reply.body)
+```
+
+## GracefulIpcChannelAdapter
+
+Graceful IPC channel adapter with shutdown and affinity-pump support. Extends `IpcChannelAdapter` with graceful shutdown and `bind_affinity_thread` / `pump_pending` for integrating with DCC main-thread idle callbacks.
+
+For reentrancy-safe Python dispatch, prefer `DeferredExecutor` from `dcc_mcp_core._core` instead of `submit()`.
+
+### Static Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `create(name)` | `GracefulIpcChannelAdapter` | Create a server-side graceful IPC channel. Raises `RuntimeError` if creation fails. |
+| `connect(name)` | `GracefulIpcChannelAdapter` | Connect to an existing graceful IPC channel. Raises `RuntimeError` if connection fails. |
+
+### Instance Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `wait_for_client()` | `None` | Wait for a client to connect (server-side only). Raises `RuntimeError` if the wait fails. |
+| `send_frame(frame)` | `None` | Send a `DccLinkFrame` to the peer. Raises `RuntimeError` if the send fails. |
+| `recv_frame()` | `DccLinkFrame \| None` | Receive a DCC-Link frame (blocking). Returns `None` if the channel is closed. Raises `RuntimeError` on unexpected errors. |
+| `shutdown()` | `None` | Signal the channel to shut down gracefully. |
+| `bind_affinity_thread()` | `None` | Bind the current thread as the affinity thread for reentrancy-safe dispatch. Call **once** on the DCC main thread. |
+| `pump_pending(budget_ms=100)` | `int` | Drain pending work items on the affinity thread within the budget. Call from DCC host idle callback. Returns number of items processed. |
+
+### Example
+
+```python
+from dcc_mcp_core import GracefulIpcChannelAdapter, DccLinkFrame
+
+server = GracefulIpcChannelAdapter.create("my-dcc")
+server.bind_affinity_thread()
+server.wait_for_client()
+
+# In DCC idle callback:
+# processed = server.pump_pending(budget_ms=50)
+
+frame = server.recv_frame()
+if frame is not None:
+    reply = DccLinkFrame(msg_type=2, seq=frame.seq, body=b"ok")
+    server.send_frame(reply)
+
+server.shutdown()
+```
+
+## SocketServerAdapter
+
+Minimal wrapper for `ipckit::SocketServer` (multi-client Unix socket / named pipe). Supports a bounded connection pool.
+
+### Constructor
+
+```python
+from dcc_mcp_core import SocketServerAdapter
+
+server = SocketServerAdapter(
+    path="/tmp/my-dcc.sock",
+    max_connections=10,
+    connection_timeout_ms=30000,
+)
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `path` | `str` | — | Socket path (Unix) or pipe name (Windows). Raises `RuntimeError` if creation fails. |
+| `max_connections` | `int` | `10` | Maximum concurrent connections. |
+| `connection_timeout_ms` | `int` | `30000` | Connection timeout in milliseconds. |
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `socket_path` | `str` | The socket path this server is listening on. |
+| `connection_count` | `int` | Number of currently connected clients. |
+
+### Instance Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `shutdown()` | `None` | Gracefully shut down the server (blocks until stopped). |
+| `signal_shutdown()` | `None` | Signal shutdown without blocking. |
+
+## TransportAddress
+
+Protocol-agnostic transport endpoint for DCC communication. Supports TCP, Named Pipes (Windows), and Unix Domain Sockets (macOS/Linux).
+
+### Static Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `tcp(host, port)` | `TransportAddress` | Create a TCP transport address |
+| `named_pipe(name)` | `TransportAddress` | Create a Named Pipe transport address (Windows) |
+| `unix_socket(path)` | `TransportAddress` | Create a Unix Domain Socket transport address |
+| `default_local(dcc_type, pid)` | `TransportAddress` | Generate optimal local transport for the current platform |
+| `default_pipe_name(dcc_type, pid)` | `TransportAddress` | Generate a default Named Pipe name for a DCC instance |
+| `default_unix_socket(dcc_type, pid)` | `TransportAddress` | Generate a default Unix Socket path for a DCC instance |
 | `parse(s)` | `TransportAddress` | Parse URI string (`tcp://`, `pipe://`, `unix://`) |
 
 ### Properties
@@ -72,22 +226,20 @@ addr = TransportAddress.parse("unix:///tmp/dcc-maya.sock")
 import os
 from dcc_mcp_core import TransportAddress
 
-# Optimal local transport (IPC on all platforms)
 addr = TransportAddress.default_local("maya", os.getpid())
 print(addr.scheme)   # "pipe" on Windows, "unix" on macOS/Linux
 print(addr.is_local) # True
-print(addr)          # e.g. "pipe://dcc-maya-12345"
 ```
 
 ## TransportScheme
 
-Strategy for choosing the optimal communication channel.
+Transport selection strategy for choosing the optimal communication channel.
 
 ### Constants
 
 | Constant | Description |
 |----------|-------------|
-| `AUTO` | Auto-select best transport |
+| `AUTO` | Auto-select best transport (Named Pipe on Windows, Unix Socket on *nix) |
 | `TCP_ONLY` | Always use TCP |
 | `PREFER_NAMED_PIPE` | Prefer Named Pipe, fall back to TCP |
 | `PREFER_UNIX_SOCKET` | Prefer Unix Socket, fall back to TCP |
@@ -97,7 +249,7 @@ Strategy for choosing the optimal communication channel.
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `select_address(dcc_type, host, port, pid=None)` | `TransportAddress` | Select optimal address |
+| `select_address(dcc_type, host, port, pid=None)` | `TransportAddress` | Select optimal transport address |
 
 ```python
 from dcc_mcp_core import TransportScheme
@@ -105,30 +257,40 @@ from dcc_mcp_core import TransportScheme
 addr = TransportScheme.AUTO.select_address("maya", "127.0.0.1", 18812, pid=12345)
 ```
 
-## RoutingStrategy
+## ServiceEntry
 
-Strategy for selecting among multiple DCC instances.
+Represents a discovered DCC service instance.
 
-### Constants
+### Attributes
 
-| Constant | Description |
-|----------|-------------|
-| `FIRST_AVAILABLE` | Use first available instance |
-| `ROUND_ROBIN` | Rotate across all available instances |
-| `LEAST_BUSY` | Prefer instances with lowest load |
-| `SPECIFIC` | Target a specific instance by ID |
-| `SCENE_MATCH` | Prefer instance with matching open scene |
-| `RANDOM` | Random selection |
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `dcc_type` | `str` | DCC application type (e.g. `"maya"`) |
+| `instance_id` | `str` | UUID string |
+| `host` | `str` | Host address |
+| `port` | `int` | TCP port |
+| `version` | `str \| None` | DCC version |
+| `scene` | `str \| None` | Currently open scene/file |
+| `documents` | `list[str]` | Open documents |
+| `pid` | `int \| None` | Process ID |
+| `display_name` | `str \| None` | Display name |
+| `metadata` | `dict[str, str]` | Arbitrary string-only metadata |
+| `status` | `ServiceStatus` | Instance status |
+| `transport_address` | `TransportAddress \| None` | Preferred IPC address |
+| `last_heartbeat_ms` | `int` | Last heartbeat timestamp (Unix ms) |
 
-```python
-from dcc_mcp_core import RoutingStrategy, TransportManager
+### Properties
 
-mgr = TransportManager("/tmp/dcc-mcp")
-session_id = mgr.get_or_create_session_routed(
-    "maya",
-    strategy=RoutingStrategy.ROUND_ROBIN,
-)
-```
+| Property | Type | Description |
+|----------|------|-------------|
+| `extras` | `dict[str, Any]` | Arbitrary DCC-specific extras with JSON-typed values. Unlike `metadata` (string-only), `extras` allows nested objects / arrays / numbers / booleans. Returns a fresh dict — mutating it does not update the registry. |
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `effective_address()` | `TransportAddress` | IPC address or TCP fallback |
+| `to_dict()` | `dict` | Serialize to dict |
 
 ## ServiceStatus
 
@@ -143,509 +305,28 @@ Enum for DCC service instance status.
 | `UNREACHABLE` | Health check failed |
 | `SHUTTING_DOWN` | Shutting down |
 
-```python
-from dcc_mcp_core import ServiceStatus, TransportManager
+## Wire Protocol
 
-mgr = TransportManager("/tmp/dcc-mcp")
-mgr.update_service_status("maya", instance_id, ServiceStatus.BUSY)
-```
-
-## ServiceEntry
-
-Represents a discovered DCC service instance.
-
-### Properties
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `dcc_type` | `str` | DCC application type (e.g. `"maya"`) |
-| `instance_id` | `str` | UUID string |
-| `host` | `str` | Host address |
-| `port` | `int` | TCP port |
-| `version` | `str \| None` | DCC version |
-| `scene` | `str \| None` | Currently open scene/file |
-| `metadata` | `dict[str, str]` | Arbitrary string-only metadata |
-| `extras` | `dict[str, Any]` | JSON-typed DCC metadata (e.g. `cdp_port`, `pid`, nested config) — empty dict when unset |
-| `status` | `ServiceStatus` | Instance status |
-| `transport_address` | `TransportAddress \| None` | Preferred IPC address |
-| `last_heartbeat_ms` | `int` | Last heartbeat timestamp (Unix ms) |
-| `is_ipc` | `bool` | Whether using IPC transport |
-
-### Methods
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `effective_address()` | `TransportAddress` | IPC address or TCP fallback |
-| `to_dict()` | `dict` | Serialize to dict |
-
-### Example
-
-```python
-entry = mgr.find_best_service("maya")
-print(entry.dcc_type)         # "maya"
-print(entry.status)           # ServiceStatus.AVAILABLE
-print(entry.effective_address())  # e.g. TransportAddress("pipe://dcc-maya-12345")
-
-# Check idle time
-import time
-idle_sec = (time.time() * 1000 - entry.last_heartbeat_ms) / 1000
-if idle_sec > 300:
-    mgr.deregister_service("maya", entry.instance_id)
-```
-
-## TransportManager
-
-Transport layer manager with service discovery, smart routing, sessions, and connection pooling.
-
-### Constructor
-
-```python
-from dcc_mcp_core import TransportManager
-
-mgr = TransportManager(
-    registry_dir="/tmp/dcc-mcp",
-    max_connections_per_dcc=10,
-    idle_timeout=300,
-    heartbeat_interval=5,
-    connect_timeout=10,
-    reconnect_max_retries=3,
-)
-```
-
-### Service Discovery
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `register_service(dcc_type, host, port, version=None, scene=None, metadata=None, transport_address=None, extras=None)` | `str` | Register a service, returns instance_id (UUID). `extras` accepts a `dict[str, Any]` of JSON-typed metadata (nested dicts / lists / numbers allowed) |
-| `deregister_service(dcc_type, instance_id)` | `bool` | Deregister a service by key |
-| `list_instances(dcc_type)` | `list[ServiceEntry]` | List all instances for a DCC type |
-| `list_all_services()` | `list[ServiceEntry]` | List all registered services |
-| `list_all_instances()` | `list[ServiceEntry]` | Alias for `list_all_services()` |
-| `get_service(dcc_type, instance_id)` | `ServiceEntry \| None` | Get a specific instance |
-| `heartbeat(dcc_type, instance_id)` | `bool` | Update heartbeat timestamp |
-| `update_service_status(dcc_type, instance_id, status)` | `bool` | Set instance status |
-
-#### `register_service` — IPC transport parameter
-
-Pass `transport_address` to enable Named Pipe / Unix Socket for lower-latency same-machine connections:
-
-```python
-import os
-from dcc_mcp_core import TransportManager, TransportAddress
-
-mgr = TransportManager("/tmp/dcc-mcp")
-addr = TransportAddress.default_local("maya", os.getpid())
-instance_id = mgr.register_service(
-    "maya", "127.0.0.1", 18812,
-    version="2025",
-    transport_address=addr,
-)
-```
-
-#### `register_service` — JSON-typed `extras`
-
-`metadata=` only accepts flat `dict[str, str]`. When the DCC needs to advertise
-numeric ports, nested objects, or typed flags, pass them through `extras=`:
-
-```python
-instance_id = mgr.register_service(
-    "photoshop", "127.0.0.1", 8888,
-    version="2024",
-    extras={
-        "cdp_port": 9222,              # integer survives the round-trip
-        "pid": os.getpid(),
-        "features": {"webview": True}, # nested dict is preserved
-    },
-)
-
-entry = mgr.get_service("photoshop", instance_id)
-assert entry.extras["cdp_port"] == 9222
-assert entry.extras["features"]["webview"] is True
-```
-
-`extras` defaults to `{}` and is omitted from the on-disk `services.json` when
-empty, so legacy registries remain byte-identical.
-
-### Smart Routing
-
-#### `find_best_service()`
-
-Returns the highest-priority live `ServiceEntry`. Priority: local IPC > local TCP > remote TCP. Within the same tier, `AVAILABLE` beats `BUSY`. Across equal-priority instances, round-robin load balancing is applied automatically.
-
-```python
-entry = mgr.find_best_service("maya")
-session_id = mgr.get_or_create_session("maya", entry.instance_id)
-```
-
-#### `rank_services()`
-
-Returns all live instances sorted by preference (lowest-score = best):
-
-| Score | Tier |
-|-------|------|
-| 0 | Local IPC, AVAILABLE |
-| 1 | Local IPC, BUSY |
-| 2 | Local TCP, AVAILABLE |
-| 3 | Local TCP, BUSY |
-| 4 | Remote TCP, AVAILABLE |
-| 5 | Remote TCP, BUSY |
-
-`UNREACHABLE` and `SHUTTING_DOWN` instances are excluded.
-
-```python
-for entry in mgr.rank_services("maya"):
-    print(entry.instance_id, entry.status, entry.effective_address())
-    sid = mgr.get_or_create_session("maya", entry.instance_id)
-    # dispatch work to this instance via session sid
-```
-
-#### `bind_and_register()`
-
-One-call setup for DCC plugin authors. Binds a listener on the optimal transport and registers this DCC instance in one step:
-
-```python
-from dcc_mcp_core import TransportManager
-
-mgr = TransportManager("/tmp/dcc-mcp")
-instance_id, listener = mgr.bind_and_register("maya", version="2025")
-local_addr = listener.local_address()
-print(f"Listening on {local_addr}")  # e.g. unix:///tmp/dcc-mcp-maya-12345.sock
-
-# Hand the listener to a serve loop (DCC plugin thread)
-channel = listener.accept()
-```
-
-Transport selection priority: Named Pipe (Windows) / Unix Socket (macOS/Linux) → TCP on ephemeral port.
-
-### Session Management
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `get_or_create_session(dcc_type, instance_id=None)` | `str` | Get/create a session (UUID). Picks first available if no instance_id |
-| `get_or_create_session_routed(dcc_type, strategy=None, hint=None)` | `str` | Get/create session with routing strategy |
-| `get_session(session_id)` | `dict \| None` | Get session info dict |
-| `record_success(session_id, latency_ms)` | — | Record successful request |
-| `record_error(session_id, latency_ms, error)` | — | Record failed request |
-| `begin_reconnect(session_id)` | `int` | Begin reconnection, returns backoff ms |
-| `reconnect_success(session_id)` | — | Mark reconnection as successful |
-| `close_session(session_id)` | `bool` | Close a session |
-| `list_sessions()` | `list[dict]` | List all active sessions |
-| `list_sessions_for_dcc(dcc_type)` | `list[dict]` | List sessions for a specific DCC |
-| `session_count()` | `int` | Number of active sessions |
-
-### Connection Pool
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `acquire_connection(dcc_type, instance_id=None)` | `str` | Acquire connection (UUID) |
-| `release_connection(dcc_type, instance_id)` | — | Release connection back to pool |
-| `pool_size()` | `int` | Total connections in pool |
-| `pool_count_for_dcc(dcc_type)` | `int` | Pool size for a specific DCC |
-
-### Lifecycle
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `cleanup()` | `tuple[int, int, int]` | Returns (stale_services, closed_sessions, evicted_connections) |
-| `shutdown()` | — | Graceful shutdown |
-| `is_shutdown()` | `bool` | Check if transport is shut down |
-
-### Dunder Methods
-
-| Method | Description |
-|--------|-------------|
-| `__repr__` | `TransportManager(services=N, sessions=N, pool=N)` |
-| `__len__` | Returns session count |
-
-## IpcListener
-
-Async IPC listener for DCC server-side applications. Supports TCP, Windows Named Pipes, and Unix Domain Sockets.
-
-### Static Factory
-
-```python
-from dcc_mcp_core import IpcListener, TransportAddress
-
-addr = TransportAddress.tcp("127.0.0.1", 0)  # port 0 = OS assigns free port
-listener = IpcListener.bind(addr)
-print(listener.local_address())  # e.g. "tcp://127.0.0.1:54321"
-```
-
-### Methods
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `IpcListener.bind(addr)` | `IpcListener` | Bind to transport address |
-| `local_address()` | `TransportAddress` | Get bound local address |
-| `accept(timeout_ms=None)` | `FramedChannel` | Accept next connection (blocking) |
-| `into_handle()` | `ListenerHandle` | Wrap for connection tracking (consumes listener) |
-
-### Properties
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `transport_name` | `str` | Transport type: `"tcp"`, `"named_pipe"`, or `"unix_socket"` |
-
-::: tip
-`IpcListener.bind()` with port `0` lets the OS assign a free port. Call `local_address()` after binding to discover the actual port.
-:::
-
-## ListenerHandle
-
-IPC listener handle with connection tracking and shutdown control.
-
-### Properties
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `accept_count` | `int` | Number of connections accepted |
-| `is_shutdown` | `bool` | Whether shutdown has been requested |
-| `transport_name` | `str` | Transport type string |
-
-### Methods
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `local_address()` | `TransportAddress` | Get bound local address |
-| `shutdown()` | — | Request stop (idempotent) |
-
-### Example
-
-```python
-addr = TransportAddress.tcp("127.0.0.1", 0)
-listener = IpcListener.bind(addr)
-handle = listener.into_handle()
-
-print(handle.accept_count)   # 0
-print(handle.is_shutdown)    # False
-
-# ... accept connections in another thread ...
-
-handle.shutdown()
-```
-
-## FramedChannel
-
-Channel-based full-duplex framed communication for DCC connections. Wraps TCP/IPC with automatic Ping/Pong heartbeats and message buffering.
-
-### Obtaining Instances
-
-```python
-from dcc_mcp_core import connect_ipc, IpcListener, TransportAddress
-
-# Server side: accept from IpcListener
-addr = TransportAddress.tcp("127.0.0.1", 0)
-listener = IpcListener.bind(addr)
-channel = listener.accept()
-
-# Client side: connect to running DCC
-addr = TransportAddress.tcp("127.0.0.1", 18812)
-channel = connect_ipc(addr)
-```
-
-### Properties
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `is_running` | `bool` | Whether background reader task is running |
-
-### Methods
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `call(method, params=None, timeout_ms=30000)` | `dict` | Send request, wait for response (RPC) |
-| `recv(timeout_ms=None)` | `dict \| None` | Receive next data message (blocking) |
-| `try_recv()` | `dict \| None` | Receive without blocking |
-| `ping(timeout_ms=5000)` | `int` | Send heartbeat, returns RTT ms |
-| `send_request(method, params=None)` | `str` | Send request, returns request_id UUID |
-| `send_response(request_id, success, payload=None, error=None)` | — | Send response |
-| `send_notify(topic, data=None)` | — | Send one-way notification |
-| `shutdown()` | — | Graceful shutdown (idempotent) |
-
-### `call()` — Recommended RPC Pattern
-
-The primary way to invoke DCC commands. Sends a `Request` and waits for the correlated `Response`:
-
-```python
-result = channel.call("execute_python", b'print("hello")', timeout_ms=10000)
-if result["success"]:
-    print(result["payload"])   # bytes
-else:
-    raise RuntimeError(result["error"])
-```
-
-`call()` return dict keys:
-
-| Key | Type | Description |
-|-----|------|-------------|
-| `id` | `str` | UUID of the correlated request |
-| `success` | `bool` | Whether the DCC executed successfully |
-| `payload` | `bytes` | Serialized result data |
-| `error` | `str \| None` | Error message when `success` is `False` |
-
-::: tip
-Unrelated messages (Notifications, other Responses) that arrive while `call()` is waiting are **not lost** — they remain available via `recv()`.
-:::
-
-### `recv()` — Event Loop Pattern
-
-For server-side DCC plugins that need to handle multiple message types:
-
-```python
-while True:
-    msg = channel.recv(timeout_ms=100)
-    if msg is None:
-        continue  # timeout or closed
-
-    if msg["type"] == "request":
-        handle_request(channel, msg)
-    elif msg["type"] == "notify":
-        handle_notification(msg)
-    elif msg["type"] == "response":
-        handle_response(msg)
-```
-
-### Ping / Health Check
-
-```python
-rtt_ms = channel.ping(timeout_ms=5000)
-print(f"DCC ping: {rtt_ms}ms")
-```
-
-## connect_ipc()
-
-Top-level function to create a client-side `FramedChannel` to a running DCC server.
-
-```python
-from dcc_mcp_core import connect_ipc, TransportAddress
-
-addr = TransportAddress.default_local("maya", pid=12345)
-channel = connect_ipc(addr)
-
-rtt = channel.ping()
-print(f"Connected, RTT: {rtt}ms")
-
-result = channel.call("get_scene_info")
-channel.shutdown()
-```
-
-## Full Integration Example
-
-```python
-import os
-import time
-from dcc_mcp_core import TransportManager, TransportAddress, RoutingStrategy
-
-# --- DCC Plugin side (runs inside Maya/Blender) ---
-def start_dcc_server(dcc_type: str):
-    mgr = TransportManager("/tmp/dcc-mcp")
-    instance_id, listener = mgr.bind_and_register(dcc_type, version="2025")
-    print(f"DCC server bound to: {listener.local_address()}")
-
-    # Accept client connections in a loop
-    while True:
-        channel = listener.accept(timeout_ms=1000)
-        if channel:
-            msg = channel.recv()
-            if msg and msg["type"] == "request":
-                channel.send_response(
-                    msg["id"],
-                    success=True,
-                    payload=b'{"status": "ok"}',
-                )
-
-
-# --- Agent side (AI tool, external script) ---
-def connect_to_maya():
-    mgr = TransportManager("/tmp/dcc-mcp")
-
-    # Find best Maya instance (IPC-first, then TCP)
-    entry = mgr.find_best_service("maya")
-    print(f"Connecting to {entry.effective_address()}")
-
-    # Round-robin across instances for load distribution
-    for entry in mgr.rank_services("maya")[:3]:
-        sid = mgr.get_or_create_session_routed(
-            "maya",
-            strategy=RoutingStrategy.ROUND_ROBIN,
-        )
-```
-
-## Wire Protocol Notes
-
-Messages use MessagePack serialization with a 4-byte big-endian length prefix:
+DccLink frames use the following binary wire format:
 
 ```
-[4-byte length][MessagePack payload]
+[u32 len][u8 type][u64 seq][msgpack body]
 ```
 
-- **Request**: `{ id: UUID, method: String, params: Vec<u8> }`
-- **Response**: `{ id: UUID, success: bool, payload: Vec<u8>, error: Option<String> }`
-- **Notify**: `{ topic: String, data: Vec<u8> }`
-- **Ping/Pong**: handled automatically by `FramedChannel`
+- `len` — 4-byte big-endian total frame length (including type + seq + body)
+- `type` — 1-byte message type tag (1-8)
+- `seq` — 8-byte big-endian sequence number
+- `body` — MessagePack-encoded payload
 
-## Low-Level Frame Encoding
+Message types:
 
-For advanced use cases where you need to encode/decode raw frames (e.g. implementing a custom transport or testing):
-
-### `encode_request()`
-
-```python
-from dcc_mcp_core import encode_request
-
-frame = encode_request("execute_python", b'cmds.sphere()')
-# bytes: [4-byte BE length][MessagePack payload]
-```
-
-### `encode_response()`
-
-```python
-from dcc_mcp_core import encode_response
-
-frame = encode_response(
-    request_id="550e8400-e29b-41d4-a716-446655440000",
-    success=True,
-    payload=b'{"result": "pSphere1"}',
-)
-
-# Error response
-frame = encode_response(
-    request_id="550e8400-e29b-41d4-a716-446655440000",
-    success=False,
-    error="Action failed: object not found",
-)
-```
-
-### `encode_notify()`
-
-```python
-from dcc_mcp_core import encode_notify
-
-frame = encode_notify("scene_changed", b'{"change": "object_added"}')
-frame = encode_notify("render_complete")  # data optional
-```
-
-### `decode_envelope()`
-
-Decode a raw MessagePack payload (length prefix already stripped) into a message dict:
-
-```python
-from dcc_mcp_core import encode_request, decode_envelope
-
-frame = encode_request("ping", b"")
-msg = decode_envelope(frame[4:])  # strip 4-byte length prefix
-
-print(msg["type"])    # "request"
-print(msg["method"]) # "ping"
-```
-
-Returned dict structure by `"type"`:
-
-| Type | Fields |
-|------|--------|
-| `"request"` | `id` (str), `method` (str), `params` (bytes) |
-| `"response"` | `id` (str), `success` (bool), `payload` (bytes), `error` (str\|None) |
-| `"notify"` | `id` (str\|None), `topic` (str), `data` (bytes) |
-| `"ping"` | `id` (str), `timestamp_ms` (int) |
-| `"pong"` | `id` (str), `timestamp_ms` (int) |
-| `"shutdown"` | `reason` (str\|None) |
+| Tag | Type | Direction | Description |
+|-----|------|-----------|-------------|
+| 1 | Call | Client → Server | Request invocation |
+| 2 | Reply | Server → Client | Successful response |
+| 3 | Err | Server → Client | Error response |
+| 4 | Progress | Server → Client | Progress update |
+| 5 | Cancel | Client → Server | Cancellation signal |
+| 6 | Push | Server → Client | Server-pushed message |
+| 7 | Ping | Either | Heartbeat request |
+| 8 | Pong | Either | Heartbeat response |

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -53,7 +53,7 @@ dcc-mcp-core (workspace root)
 ├── dcc-mcp-actions      # ToolRegistry, EventBus, ToolDispatcher, Pipeline
 ├── dcc-mcp-skills       # SkillScanner, SkillCatalog, SkillWatcher, Resolver
 ├── dcc-mcp-protocols    # MCP types: ToolDefinition, ResourceDefinition, Prompt, DccAdapter, BridgeKind
-├── dcc-mcp-transport    # IPC, ConnectionPool, FileRegistry, FramedChannel
+├── dcc-mcp-transport    # IPC (ipckit), DccLinkFrame, IpcChannelAdapter, SocketServerAdapter
 ├── dcc-mcp-process      # PyDccLauncher, ProcessMonitor, ProcessWatcher, CrashRecovery
 ├── dcc-mcp-telemetry    # Tracing/recording: ToolRecorder, TelemetryConfig
 ├── dcc-mcp-sandbox      # Security: SandboxPolicy, SandboxContext, AuditLog
@@ -151,11 +151,10 @@ dcc-mcp-server ← dcc-mcp-http
 - **TCP**: Network sockets — cross-machine or fallback
 
 **Key Components**:
-- `TransportManager` — High-level manager: service registry, session pool, routing
-- `IpcListener` / `ListenerHandle` — Server-side IPC listener with connection tracking
-- `FramedChannel` — Full-duplex framed channel with background reader loop
+- `IpcChannelAdapter` — Client/server IPC adapter using DccLink frames over ipckit
+- `SocketServerAdapter` — Multi-client TCP/UDS listener for server-side IPC
+- `DccLinkFrame` — Binary frame type (msg_type, seq, body) for DccLink wire protocol
 - `TransportAddress` — Protocol-agnostic endpoint (TCP, named pipe, unix socket)
-- `CircuitBreaker` — Failure detection and fast-drop
 
 **Wire Protocol**: MessagePack with 4-byte big-endian length prefix
 

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -229,22 +229,22 @@ Use `TransportAddress.default_local(dcc_type, pid)` to automatically select the 
 
 **DCC-side (server):**
 ```python
-import os
-from dcc_mcp_core import TransportManager, IpcListener, TransportAddress
+from dcc_mcp_core import IpcChannelAdapter, DccLinkFrame
 
-mgr = TransportManager("/tmp/dcc-mcp")
-instance_id, listener = mgr.bind_and_register("maya", version="2025")
-channel = listener.accept()  # wait for agent to connect
+# Server: create named IPC endpoint and wait for client
+server = IpcChannelAdapter.create("maya-2025")
+server.wait_for_client()
 ```
 
 **Agent-side (client):**
 ```python
-from dcc_mcp_core import TransportManager, connect_ipc
+from dcc_mcp_core import IpcChannelAdapter, DccLinkFrame
 
-mgr = TransportManager("/tmp/dcc-mcp")
-entry = mgr.find_best_service("maya")
-channel = connect_ipc(entry.effective_address())
-rtt = channel.ping()
+# Client: connect to the DCC's IPC endpoint
+client = IpcChannelAdapter.connect("maya-2025")
+request = DccLinkFrame(msg_type=1, seq=0, body=b'{"method":"ping"}')
+client.send_frame(request)
+reply = client.recv_frame()
 ```
 
 ## MCP HTTP Server

--- a/docs/guide/mcp-skills-integration.md
+++ b/docs/guide/mcp-skills-integration.md
@@ -74,25 +74,11 @@ DCC Bridge Plugin
 ### ServiceEntry — What Each DCC Registers
 
 ```python
-from dcc_mcp_core import TransportManager
+from dcc_mcp_core import create_skill_server, McpHttpConfig
 
-mgr = TransportManager(registry_dir="/tmp/dcc-mcp")
-
-# Maya bridge plugin calls this on startup:
-instance_id, listener = mgr.bind_and_register(
-    dcc_type="maya",
-    version="2025",
-)
-
-# Or with rich metadata for smart routing:
-iid = mgr.register_service(
-    "maya", "127.0.0.1", 18812,
-    pid=os.getpid(),
-    display_name="Maya-Production",
-    scene="character.ma",
-    documents=["character.ma", "rig.ma"],
-    version="2025",
-)
+# Gateway auto-registers the DCC instance
+server = create_skill_server("maya", McpHttpConfig(port=8765))
+handle = server.start()
 ```
 
 The gateway reads this to know:
@@ -103,11 +89,9 @@ The gateway reads this to know:
 ### Session Isolation
 
 ```python
-# Pin session to specific Maya instance
-session_id = mgr.get_or_create_session("maya", instance_id)
-
-# tools/list filtered to this Maya instance's skills only
-# AI agent sees 150 tools, not 750
+# Session pinning is handled automatically by the gateway
+# based on dcc_type, dcc_version, and scene metadata
+# set on McpHttpConfig
 ```
 
 ### Skills System

--- a/docs/guide/transport.md
+++ b/docs/guide/transport.md
@@ -1,135 +1,261 @@
 # Transport Layer
 
-> **🚨 v0.14 removed the legacy transport stack (issue #251).**
+> **v0.14 replaced the legacy transport stack (issue #251).**
 >
-> The classes described below — `TransportManager`, `FramedChannel`,
-> `FramedIo`, `IpcListener` (Python), `ListenerHandle`, `RoutingStrategy`,
+> The old classes — `TransportManager`, `FramedChannel`, `FramedIo`,
+> `IpcListener` (Python), `ListenerHandle`, `RoutingStrategy`,
 > `ConnectionPool`, `InstanceRouter`, `CircuitBreaker`, `MessageEnvelope`,
 > `encode_request` / `encode_response` / `encode_notify` / `decode_envelope`,
-> `connect_ipc` — are **gone**. New code should use the DccLink adapters
-> built on `ipckit`:
->
-> - `IpcChannelAdapter.connect(name)` / `.create(name)` — per-connection
->   framed channel for Named Pipes (Windows) or Unix Sockets (*nix).
-> - `SocketServerAdapter` — multi-client IPC server with a bounded
->   connection pool.
-> - `GracefulIpcChannelAdapter` — adds graceful shutdown + reentrancy-safe
->   dispatch for DCC main-thread integration.
-> - `DccLinkFrame` / `DccLinkType` — `[u32 len][u8 type][u64 seq][msgpack body]`
->   wire frame with eight message kinds (Call, Reply, Err, Progress,
->   Cancel, Push, Ping, Pong).
-> - `ServiceEntry` + `FileRegistry` — service discovery (unchanged).
->
-> The gateway HTTP API (`GET /instances`, `POST /mcp`, …) is the public
-> surface for discovery across processes.
+> `connect_ipc` — have been removed. Use the DccLink adapters built on
+> `ipckit` documented below.
 
-The Transport layer (`dcc-mcp-transport` crate) provides async communication infrastructure for connecting MCP servers to DCC application instances. It includes connection pooling, service discovery, session management, and a wire protocol.
+The Transport layer (`dcc-mcp-transport` crate) provides IPC communication between MCP servers and DCC application instances using DccLink framing over Named Pipes (Windows) or Unix Domain Sockets (macOS/Linux).
 
 ## Overview
 
+The new transport API is built around **DccLink adapters** — thin wrappers over `ipckit` IPC channels that use a binary wire format (`[u32 len][u8 type][u64 seq][msgpack body]`) for efficient framed communication.
+
 ```python
-from dcc_mcp_core import TransportManager
+from dcc_mcp_core import IpcChannelAdapter, DccLinkFrame
 
-transport = TransportManager("/path/to/registry")
+# Server side: create a named channel and wait for a client
+server = IpcChannelAdapter.create("my-dcc")
+server.wait_for_client()
 
-# Register a DCC service
-instance_id = transport.register_service("maya", "127.0.0.1", 18812, version="2025.1")
+# Client side: connect to the server
+client = IpcChannelAdapter.connect("my-dcc")
 
-# Create a session
-session_id = transport.get_or_create_session("maya")
+# Send a frame
+frame = DccLinkFrame(msg_type=1, seq=0, body=b"hello")
+client.send_frame(frame)
 
-# Use the connection
-conn_id = transport.acquire_connection("maya")
-# ... perform operations ...
-transport.release_connection("maya", instance_id)
-
-# Cleanup and shutdown
-transport.cleanup()
-transport.shutdown()
+# Receive a frame
+received = server.recv_frame()
+print(received.body)  # b"hello"
 ```
 
-## Service Discovery
+## DccLinkFrame
 
-The transport layer uses file-based service discovery to track running DCC instances. Each instance registers with a `(dcc_type, instance_id)` key, enabling multiple instances of the same DCC.
+Binary wire frame for DCC-Link protocol. Wire format: `[u32 len][u8 type][u64 seq][msgpack body]`.
+
+### Message Types
+
+| Tag | Type | Description |
+|-----|------|-------------|
+| 1 | Call | Request invocation |
+| 2 | Reply | Successful response |
+| 3 | Err | Error response |
+| 4 | Progress | Progress update |
+| 5 | Cancel | Cancellation signal |
+| 6 | Push | Server-pushed message |
+| 7 | Ping | Heartbeat request |
+| 8 | Pong | Heartbeat response |
+
+### Constructor
 
 ```python
-id1 = transport.register_service("maya", "127.0.0.1", 18812)
-id2 = transport.register_service("maya", "127.0.0.1", 18813)
-id3 = transport.register_service("blender", "127.0.0.1", 9090, version="4.0")
+from dcc_mcp_core import DccLinkFrame
 
-maya_instances = transport.list_instances("maya")
-all_services = transport.list_all_services()
-
-transport.heartbeat("maya", id1)
-transport.deregister_service("maya", id1)
+frame = DccLinkFrame(msg_type=1, seq=0, body=b"hello")
 ```
 
-## Session Management
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `msg_type` | `int` | Message type tag (1-8) |
+| `seq` | `int` | Sequence number |
+| `body` | `bytes \| None` | Payload bytes (defaults to `b""`) |
 
-Sessions track connections to DCC instances with lifecycle state management and metrics:
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `msg_type` | `int` | Message type tag (1=Call, 2=Reply, 3=Err, 4=Progress, 5=Cancel, 6=Push, 7=Ping, 8=Pong) |
+| `seq` | `int` | Sequence number |
+| `body` | `bytes` | Payload bytes |
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `encode()` | `bytes` | Encode the frame to `[len][type][seq][body]` bytes |
+| `decode(data)` | `DccLinkFrame` | Decode a frame from bytes including the 4-byte length prefix (static) |
 
 ```python
-session_id = transport.get_or_create_session("maya", id1)
-
-session = transport.get_session(session_id)
-# session is a dict with keys: id, dcc_type, instance_id, state, request_count, error_count, last_error, created_at, last_request_at
-
-transport.record_success(session_id, 50)
-transport.record_error(session_id, 100, "timeout")
-
-backoff_ms = transport.begin_reconnect(session_id)
-transport.reconnect_success(session_id)
-
-transport.close_session(session_id)
+frame = DccLinkFrame(msg_type=1, seq=0, body=b"payload")
+encoded = frame.encode()
+decoded = DccLinkFrame.decode(encoded)
+assert decoded.msg_type == frame.msg_type
+assert decoded.seq == frame.seq
+assert decoded.body == frame.body
 ```
 
-### Session States
+## IpcChannelAdapter
 
-| State | Description |
-|-------|-------------|
-| `connected` | Active and ready for requests |
-| `idle` | Idle timeout exceeded, still valid |
-| `reconnecting` | Reconnecting after failure |
-| `closed` | Terminal state |
+Thin adapter over `ipckit::IpcChannel` using DCC-Link framing. Supports 1:1 connections over Named Pipes (Windows) or Unix Domain Sockets (macOS/Linux).
 
-## Connection Pool
+### Creating a Server
 
 ```python
-conn_id = transport.acquire_connection("maya")
-transport.release_connection("maya", id1)
-transport.pool_size()
+from dcc_mcp_core import IpcChannelAdapter
+
+server = IpcChannelAdapter.create("my-dcc")
+server.wait_for_client()  # blocks until a client connects
 ```
 
-## Configuration
+### Connecting as a Client
 
 ```python
-transport = TransportManager(
-    registry_dir="/path/to/registry",
-    max_connections_per_dcc=10,
-    idle_timeout=300,
-    heartbeat_interval=5,
-    connect_timeout=10,
-    reconnect_max_retries=3,
+from dcc_mcp_core import IpcChannelAdapter
+
+client = IpcChannelAdapter.connect("my-dcc")
+```
+
+### Sending and Receiving Frames
+
+```python
+from dcc_mcp_core import IpcChannelAdapter, DccLinkFrame
+
+# Server side
+server = IpcChannelAdapter.create("my-dcc")
+server.wait_for_client()
+
+# Client side
+client = IpcChannelAdapter.connect("my-dcc")
+
+# Client sends a Call frame
+call_frame = DccLinkFrame(msg_type=1, seq=0, body=b"execute_python")
+client.send_frame(call_frame)
+
+# Server receives the frame
+received = server.recv_frame()  # blocking; returns None if channel closed
+if received is not None:
+    print(received.msg_type)  # 1
+    print(received.body)      # b"execute_python"
+
+    # Server sends a Reply frame
+    reply = DccLinkFrame(msg_type=2, seq=0, body=b"ok")
+    server.send_frame(reply)
+
+# Client receives the reply
+response = client.recv_frame()
+```
+
+### Static Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `create(name)` | `IpcChannelAdapter` | Create a server-side IPC channel |
+| `connect(name)` | `IpcChannelAdapter` | Connect to an existing IPC channel |
+
+### Instance Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `wait_for_client()` | `None` | Wait for a client to connect (server-side only) |
+| `send_frame(frame)` | `None` | Send a `DccLinkFrame` to the peer |
+| `recv_frame()` | `DccLinkFrame \| None` | Receive a frame (blocking). Returns `None` if channel closed |
+
+## GracefulIpcChannelAdapter
+
+Extends `IpcChannelAdapter` with graceful shutdown and DCC main-thread integration. Use this in DCC plugins that need to process IPC messages on the main thread without blocking.
+
+### Creating a Graceful Server
+
+```python
+from dcc_mcp_core import GracefulIpcChannelAdapter
+
+server = GracefulIpcChannelAdapter.create("my-dcc")
+server.bind_affinity_thread()  # call once on the DCC main thread
+server.wait_for_client()
+```
+
+### Pumping Messages on the Main Thread
+
+In DCC applications, IPC messages must often be processed on the main thread. Use `pump_pending()` from an idle callback:
+
+```python
+# Maya example: use scriptJob idleEvent
+import maya.cmds as cmds
+
+def on_idle():
+    processed = server.pump_pending(budget_ms=50)
+    # returns number of items processed
+
+cmds.scriptJob(idleEvent="python(\"on_idle()\")")
+```
+
+### Graceful Shutdown
+
+```python
+server.shutdown()  # signals the channel to shut down gracefully
+```
+
+### Static Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `create(name)` | `GracefulIpcChannelAdapter` | Create a server-side graceful IPC channel |
+| `connect(name)` | `GracefulIpcChannelAdapter` | Connect to an existing graceful IPC channel |
+
+### Instance Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `wait_for_client()` | `None` | Wait for a client to connect (server-side only) |
+| `send_frame(frame)` | `None` | Send a `DccLinkFrame` to the peer |
+| `recv_frame()` | `DccLinkFrame \| None` | Receive a frame (blocking). Returns `None` if channel closed |
+| `shutdown()` | `None` | Signal the channel to shut down gracefully |
+| `bind_affinity_thread()` | `None` | Bind the current thread as the affinity thread. Call **once** on the DCC main thread |
+| `pump_pending(budget_ms=100)` | `int` | Drain pending work items on the affinity thread within the budget. Returns items processed |
+
+## SocketServerAdapter
+
+Multi-client IPC server using Unix Domain Sockets (macOS/Linux) or Named Pipes (Windows). Supports a bounded connection pool.
+
+### Creating a Socket Server
+
+```python
+from dcc_mcp_core import SocketServerAdapter
+
+server = SocketServerAdapter(
+    path="/tmp/my-dcc.sock",  # Unix socket path or Windows pipe name
+    max_connections=10,        # maximum concurrent connections
+    connection_timeout_ms=30000,  # connection timeout in ms
 )
+
+print(server.socket_path)      # the path this server is listening on
+print(server.connection_count) # number of currently connected clients
+
+server.shutdown()  # gracefully shut down
 ```
 
-## Lifecycle
+### Constructor
 
-```python
-stale, sessions, evicted = transport.cleanup()
-transport.shutdown()
-transport.is_shutdown()
-```
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `path` | `str` | — | Socket path (Unix) or pipe name (Windows) |
+| `max_connections` | `int` | `10` | Maximum concurrent connections |
+| `connection_timeout_ms` | `int` | `30000` | Connection timeout in milliseconds |
 
----
+### Properties
 
-## Low-Level IPC API
+| Property | Type | Description |
+|----------|------|-------------|
+| `socket_path` | `str` | The socket path this server is listening on |
+| `connection_count` | `int` | Number of currently connected clients |
 
-For DCC plugins that need to act as a server or communicate directly over IPC (bypassing `TransportManager`), use the low-level classes.
+### Instance Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `shutdown()` | `None` | Gracefully shut down the server (blocks until stopped) |
+| `signal_shutdown()` | `None` | Signal shutdown without blocking |
+
+## Transport Helpers
 
 ### TransportAddress
 
-Protocol-agnostic endpoint descriptor. Supports TCP, Windows Named Pipes, and Unix Domain Sockets.
+Protocol-agnostic transport endpoint. Supports TCP, Named Pipes (Windows), and Unix Domain Sockets (macOS/Linux).
 
 ```python
 from dcc_mcp_core import TransportAddress
@@ -157,155 +283,46 @@ addr = TransportAddress.parse("tcp://127.0.0.1:18812")
 
 ### TransportScheme
 
-Strategy enum for selecting the optimal transport type for a connection:
+Strategy for choosing the optimal communication channel:
 
-| Variant | Description |
-|---------|-------------|
-| `TransportScheme.AUTO` | Platform-optimal: Named Pipe on Windows, Unix Socket on Linux/macOS |
-| `TransportScheme.TCP_ONLY` | Always use TCP |
-| `TransportScheme.PREFER_NAMED_PIPE` | Named Pipe if same machine, TCP otherwise |
-| `TransportScheme.PREFER_UNIX_SOCKET` | Unix socket if same machine, TCP otherwise |
-| `TransportScheme.PREFER_IPC` | Any local IPC transport |
-
-```python
-from dcc_mcp_core import TransportScheme, TransportAddress
-
-scheme = TransportScheme.AUTO
-addr = scheme.select_address("maya", "127.0.0.1", 18812, pid=12345)
-```
-
-### IpcListener
-
-Server-side listener. Used inside DCC plugins to accept incoming connections.
+| Constant | Description |
+|----------|-------------|
+| `AUTO` | Auto-select best transport (Named Pipe on Windows, Unix Socket on *nix) |
+| `TCP_ONLY` | Always use TCP |
+| `PREFER_NAMED_PIPE` | Prefer Named Pipe, fall back to TCP |
+| `PREFER_UNIX_SOCKET` | Prefer Unix Socket, fall back to TCP |
+| `PREFER_IPC` | Prefer any IPC, fall back to TCP |
 
 ```python
-from dcc_mcp_core import IpcListener, TransportAddress
+from dcc_mcp_core import TransportScheme
 
-# Bind to a transport address (port 0 = OS-assigned)
-addr = TransportAddress.tcp("127.0.0.1", 0)
-listener = IpcListener.bind(addr)
-
-# Get the actual bound address (useful when port=0)
-local_addr = listener.local_address()
-print(f"Listening on {local_addr}")   # tcp://127.0.0.1:54321
-
-# Accept a connection (blocking)
-channel = listener.accept(timeout_ms=5000)  # → FramedChannel
-
-# Or convert to a handle for connection tracking
-handle = listener.into_handle()   # consumes listener; can only call once
+addr = TransportScheme.AUTO.select_address("maya", "127.0.0.1", 18812, pid=12345)
 ```
 
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `IpcListener.bind(addr)` | `IpcListener` | Bind to address. Raises `RuntimeError` if port in use |
-| `local_address()` | `TransportAddress` | Actual bound address |
-| `transport_name` | `str` | `"tcp"`, `"named_pipe"`, or `"unix_socket"` |
-| `accept(timeout_ms=None)` | `FramedChannel` | Accept next connection. Blocks until client connects |
-| `into_handle()` | `ListenerHandle` | Wrap in a handle with connection tracking (consumes `self`) |
+### ServiceEntry
 
-### ListenerHandle
+Represents a discovered DCC service instance.
 
-Wraps `IpcListener` with connection tracking and shutdown control.
-
-```python
-from dcc_mcp_core import IpcListener, TransportAddress
-
-addr = TransportAddress.default_local("maya", pid=12345)
-listener = IpcListener.bind(addr)
-handle = listener.into_handle()
-
-print(handle.accept_count)   # 0
-print(handle.is_shutdown)    # False
-
-# Request shutdown (stop accepting new connections)
-handle.shutdown()
-```
-
-| Property/Method | Returns | Description |
-|-----------------|---------|-------------|
-| `accept_count` | `int` | Connections accepted so far |
-| `is_shutdown` | `bool` | Whether shutdown has been requested |
-| `transport_name` | `str` | Transport type name |
-| `local_address()` | `TransportAddress` | Bound address |
-| `shutdown()` | `None` | Stop accepting new connections (idempotent) |
-
-### FramedChannel
-
-Full-duplex framed channel with a background reader loop. Handles Ping/Pong heartbeats automatically. Obtain via `IpcListener.accept()` (server) or `connect_ipc()` (client).
-
-```python
-from dcc_mcp_core import connect_ipc, TransportAddress
-
-# Client-side: connect to a running DCC server
-addr = TransportAddress.tcp("127.0.0.1", 18812)
-channel = connect_ipc(addr, timeout_ms=10000)
-
-# Liveness check
-rtt_ms = channel.ping()          # int, round-trip time in ms
-
-# Receive (blocking)
-msg = channel.recv(timeout_ms=5000)
-# msg: dict with "type" field → "request", "response", or "notify"
-
-# Non-blocking receive
-msg = channel.try_recv()         # None if buffer empty
-
-# Send
-req_id = channel.send_request("execute_python", params=b'{"code":"..."}')
-channel.send_response(req_id, success=True, payload=b'{"result":1}')
-channel.send_notify("scene_changed", data=b'{"scene":"untitled"}')
-
-# Shutdown
-channel.shutdown()
-print(channel.is_running)        # False
-```
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `recv(timeout_ms=None)` | `dict \| None` | Blocking receive. Returns `None` on timeout or close |
-| `try_recv()` | `dict \| None` | Non-blocking receive. Returns `None` if buffer empty |
-| `ping(timeout_ms=5000)` | `int` | Heartbeat ping; returns RTT ms. Data messages not lost |
-| `send_request(method, params=None)` | `str` | Send request; returns UUID request ID |
-| `send_response(request_id, success, payload=None, error=None)` | `None` | Send response for a request |
-| `send_notify(topic, data=None)` | `None` | Send a one-way notification |
-| `shutdown()` | `None` | Graceful shutdown (idempotent) |
-| `is_running` | `bool` | Whether the background reader is still running |
-
-### connect_ipc
-
-Client-side connection factory:
-
-```python
-from dcc_mcp_core import connect_ipc, TransportAddress
-
-channel = connect_ipc(
-    addr=TransportAddress.tcp("127.0.0.1", 18812),
-    timeout_ms=10000,    # default: 10000 ms
-)
-```
-
-Raises `RuntimeError` if the connection cannot be established within the timeout.
-
-### RoutingStrategy
-
-Strategy for selecting a DCC instance when multiple are registered:
-
-| Variant | Description |
-|---------|-------------|
-| `FIRST_AVAILABLE` | Pick the first reachable instance |
-| `ROUND_ROBIN` | Cycle through instances |
-| `LEAST_BUSY` | Instance with lowest session request count |
-| `SPECIFIC` | Requires an explicit `instance_id` |
-| `SCENE_MATCH` | Match by open scene name |
-| `RANDOM` | Random instance selection |
+| Property | Type | Description |
+|----------|------|-------------|
+| `dcc_type` | `str` | DCC application type (e.g. `"maya"`) |
+| `instance_id` | `str` | UUID string |
+| `host` | `str` | Host address |
+| `port` | `int` | TCP port |
+| `version` | `str \| None` | DCC version |
+| `scene` | `str \| None` | Currently open scene/file |
+| `metadata` | `dict[str, str]` | Arbitrary string-only metadata |
+| `extras` | `dict[str, Any]` | JSON-typed DCC metadata |
+| `status` | `ServiceStatus` | Instance status |
+| `transport_address` | `TransportAddress \| None` | Preferred IPC address |
+| `last_heartbeat_ms` | `int` | Last heartbeat timestamp (Unix ms) |
 
 ### ServiceStatus
 
-Enum for DCC service health:
+DCC service health status:
 
-| Variant | Meaning |
-|---------|---------|
+| Constant | Description |
+|----------|-------------|
 | `AVAILABLE` | Ready to accept requests |
 | `BUSY` | Processing; may accept more |
 | `UNREACHABLE` | Not responding to heartbeats |
@@ -313,40 +330,48 @@ Enum for DCC service health:
 
 ---
 
-## End-to-End Example: DCC Plugin Server
+## End-to-End Example
+
+### DCC Plugin (Server)
 
 ```python
-# Inside a Maya plugin (server side)
-import maya.cmds as cmds
-from dcc_mcp_core import IpcListener, TransportAddress
-import threading, os
+# Inside a Maya plugin
+from dcc_mcp_core import GracefulIpcChannelAdapter, DccLinkFrame
 
-addr = TransportAddress.default_local("maya", os.getpid())
-listener = IpcListener.bind(addr)
-print(f"Maya IPC server: {listener.local_address()}")
+server = GracefulIpcChannelAdapter.create("maya-ipc")
+server.bind_affinity_thread()  # call once on main thread
+server.wait_for_client()
 
-def serve():
-    channel = listener.accept()
-    while True:
-        msg = channel.recv(timeout_ms=1000)
-        if msg is None:
-            break
-        if msg["type"] == "request":
-            result = cmds.ls()
-            channel.send_response(msg["id"], success=True,
-                                  payload=str(result).encode())
+# In Maya idle callback:
+def on_idle():
+    processed = server.pump_pending(budget_ms=50)
 
-threading.Thread(target=serve, daemon=True).start()
+# Main message loop
+while True:
+    frame = server.recv_frame()
+    if frame is None:
+        break  # channel closed
+    if frame.msg_type == 1:  # Call
+        # Process the request...
+        reply = DccLinkFrame(msg_type=2, seq=frame.seq, body=b"ok")
+        server.send_frame(reply)
+
+server.shutdown()
 ```
 
-```python
-# Client side (MCP agent)
-from dcc_mcp_core import connect_ipc, TransportAddress
+### MCP Agent (Client)
 
-addr = TransportAddress.default_local("maya", pid=12345)
-channel = connect_ipc(addr)
-req_id = channel.send_request("ls")
-response = channel.recv()
-# response["type"] == "response", response["payload"] == b"[...]"
-channel.shutdown()
+```python
+from dcc_mcp_core import IpcChannelAdapter, DccLinkFrame
+
+client = IpcChannelAdapter.connect("maya-ipc")
+
+# Send a Call frame
+call = DccLinkFrame(msg_type=1, seq=0, body=b"get_scene_info")
+client.send_frame(call)
+
+# Receive the Reply
+reply = client.recv_frame()
+if reply and reply.msg_type == 2:
+    print(f"Result: {reply.body}")
 ```

--- a/docs/guide/what-is-dcc-mcp-core.md
+++ b/docs/guide/what-is-dcc-mcp-core.md
@@ -55,7 +55,7 @@ dcc-mcp-core/
 │   ├── dcc-mcp-actions/        # ToolRegistry, EventBus, Pipeline, Dispatcher, Validator
 │   ├── dcc-mcp-skills/         # SkillScanner, SkillCatalog, SkillWatcher, Resolver
 │   ├── dcc-mcp-protocols/      # MCP types: ToolDefinition, ResourceDefinition, Prompt, DccAdapter
-│   ├── dcc-mcp-transport/      # IPC, ConnectionPool, SessionManager, FramedChannel
+│   ├── dcc-mcp-transport/      # IPC (ipckit), DccLinkFrame, IpcChannelAdapter, SocketServerAdapter
 │   ├── dcc-mcp-process/        # PyDccLauncher, ProcessMonitor, CrashRecovery
 │   ├── dcc-mcp-telemetry/      # ToolRecorder, ToolMetrics, TelemetryConfig
 │   ├── dcc-mcp-sandbox/        # SandboxPolicy, SandboxContext, AuditLog, InputValidator
@@ -91,7 +91,7 @@ from dcc_mcp_core import (
     McpHttpServer, McpHttpConfig,
 
     # Transport
-    TransportManager, TransportAddress, IpcListener, FramedChannel, connect_ipc,
+    IpcChannelAdapter, GracefulIpcChannelAdapter, SocketServerAdapter, DccLinkFrame,
 
     # Protocols
     ToolDefinition, ToolAnnotations, ResourceDefinition, PromptDefinition,

--- a/docs/zh/api/http.md
+++ b/docs/zh/api/http.md
@@ -326,5 +326,5 @@ print(handle.mcp_url())
 - 服务器在后台 Tokio 线程运行 — 不会阻塞 DCC 主线程
 - 每个调用的请求超时（默认 30 秒）
 - HTTP 层无连接池（每个 POST 无状态）
-- 使用 `TransportManager` 获取与 DCC 的持久 IPC 会话
+- 使用 `IpcChannelAdapter` 获取与 DCC 的持久 IPC 会话
 - 网关 `FileRegistry` 每次变更都刷新到磁盘 — 多进程安全但不适合高频写入

--- a/docs/zh/api/transport.md
+++ b/docs/zh/api/transport.md
@@ -1,53 +1,207 @@
 # 传输层 API
 
-`dcc_mcp_core` — TransportManager, TransportAddress, TransportScheme, RoutingStrategy, ServiceStatus, ServiceEntry, IpcListener, ListenerHandle, FramedChannel, connect_ipc.
+`dcc_mcp_core` — DccLinkFrame, IpcChannelAdapter, GracefulIpcChannelAdapter, SocketServerAdapter, TransportAddress, TransportScheme, ServiceEntry, ServiceStatus.
 
 ## 概述
 
-传输层模块提供 AI 智能体与 DCC 应用之间的**跨平台 IPC 和 TCP 通信**。核心设计：
+传输模块提供 AI 智能体与 DCC 应用之间的 **基于 DccLink 的 IPC 通信**。核心设计：
 
 - 同机连接优先使用 **Named Pipe**（Windows）/ **Unix Domain Socket**（macOS/Linux），亚毫秒延迟，零配置。
-- 跨机或 IPC 不可用时自动降级为 **TCP**。
-- `TransportAddress.default_local(dcc_type, pid)` 自动选择当前平台的最优传输方式。
-- `TransportManager.bind_and_register()` 是 DCC 插件开发者的一键启动推荐入口。
+- DccLink 适配器封装 `ipckit` 通道，使用二进制线格式：`[u32 len][u8 type][u64 seq][msgpack body]`。
+- `IpcChannelAdapter.create(name)` + `wait_for_client()` 是推荐的服务端启动方式。
+- `IpcChannelAdapter.connect(name)` 是客户端连接入口。
+- `GracefulIpcChannelAdapter` 增加优雅关闭和 DCC 主线程集成。
+- `SocketServerAdapter` 提供带连接池的多客户端连接。
 
-## TransportAddress
+## DccLinkFrame
 
-与协议无关的传输端点。支持 TCP、Named Pipe（Windows）和 Unix Domain Socket（macOS/Linux）。
+DCC-Link 帧，包含 `msg_type`、`seq` 和 `body` 字段。
 
-### 工厂方法
+线格式：`[u32 len][u8 type][u64 seq][msgpack body]`。
+
+消息类型标签：1=Call, 2=Reply, 3=Err, 4=Progress, 5=Cancel, 6=Push, 7=Ping, 8=Pong。
+
+### 构造函数
 
 ```python
-from dcc_mcp_core import TransportAddress
+from dcc_mcp_core import DccLinkFrame
 
-# TCP
-addr = TransportAddress.tcp("127.0.0.1", 18812)
-
-# Named Pipe（Windows）
-addr = TransportAddress.named_pipe("dcc-maya-12345")
-
-# Unix Domain Socket（macOS/Linux）
-addr = TransportAddress.unix_socket("/tmp/dcc-maya-12345.sock")
-
-# 当前平台最优本地传输
-addr = TransportAddress.default_local("maya", pid=os.getpid())
-
-# 从 URI 字符串解析
-addr = TransportAddress.parse("tcp://127.0.0.1:18812")
-addr = TransportAddress.parse("pipe://dcc-maya-12345")
-addr = TransportAddress.parse("unix:///tmp/dcc-maya.sock")
+frame = DccLinkFrame(msg_type=1, seq=0, body=b"hello")
 ```
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `msg_type` | `int` | — | 消息类型标签（1-8）。无效时抛出 `ValueError`。|
+| `seq` | `int` | — | 序列号。|
+| `body` | `bytes \| None` | `None` | 载荷字节。|
+
+### 属性
+
+| 属性 | 类型 | 说明 |
+|------|------|------|
+| `msg_type` | `int` | 消息类型标签（1=Call, 2=Reply, 3=Err, 4=Progress, 5=Cancel, 6=Push, 7=Ping, 8=Pong）|
+| `seq` | `int` | 序列号 |
+| `body` | `bytes` | 载荷字节 |
+
+### 方法
+
+| 方法 | 返回值 | 说明 |
+|------|--------|------|
+| `encode()` | `bytes` | 将帧编码为 `[len][type][seq][body]` 字节 |
+| `decode(data)` | `DccLinkFrame` | 从包含 4 字节长度前缀的字节中解码帧（静态方法）。格式错误时抛出 `RuntimeError`。|
+
+### 示例
+
+```python
+frame = DccLinkFrame(msg_type=1, seq=0, body=b"payload")
+encoded = frame.encode()
+decoded = DccLinkFrame.decode(encoded)
+assert decoded.msg_type == frame.msg_type
+assert decoded.seq == frame.seq
+assert decoded.body == frame.body
+```
+
+## IpcChannelAdapter
+
+基于 `ipckit::IpcChannel` 的轻量适配器，使用 DCC-Link 帧格式。通过 Named Pipe（Windows）或 Unix Domain Socket（macOS/Linux）提供 1:1 帧化 IPC 连接。
 
 ### 静态方法
 
 | 方法 | 返回值 | 说明 |
 |------|--------|------|
-| `tcp(host, port)` | `TransportAddress` | 创建 TCP 地址 |
-| `named_pipe(name)` | `TransportAddress` | 创建 Named Pipe 地址（Windows）|
-| `unix_socket(path)` | `TransportAddress` | 创建 Unix Socket 地址 |
-| `default_local(dcc_type, pid)` | `TransportAddress` | 自动选择最优本地传输 |
-| `default_pipe_name(dcc_type, pid)` | `TransportAddress` | 为 DCC 实例生成 Named Pipe |
-| `default_unix_socket(dcc_type, pid)` | `TransportAddress` | 为 DCC 实例生成 Unix Socket |
+| `create(name)` | `IpcChannelAdapter` | 创建服务端 IPC 通道。创建失败时抛出 `RuntimeError`。|
+| `connect(name)` | `IpcChannelAdapter` | 连接到已有的 IPC 通道。连接失败时抛出 `RuntimeError`。|
+
+### 实例方法
+
+| 方法 | 返回值 | 说明 |
+|------|--------|------|
+| `wait_for_client()` | `None` | 等待客户端连接（仅服务端）。等待失败时抛出 `RuntimeError`。|
+| `send_frame(frame)` | `None` | 向对端发送 `DccLinkFrame`。发送失败时抛出 `RuntimeError`。|
+| `recv_frame()` | `DccLinkFrame \| None` | 接收 DCC-Link 帧（阻塞）。通道关闭时返回 `None`。意外错误时抛出 `RuntimeError`。|
+
+### 示例：服务端
+
+```python
+from dcc_mcp_core import IpcChannelAdapter, DccLinkFrame
+
+server = IpcChannelAdapter.create("my-dcc")
+server.wait_for_client()
+
+frame = server.recv_frame()
+if frame is not None:
+    reply = DccLinkFrame(msg_type=2, seq=frame.seq, body=b"result")
+    server.send_frame(reply)
+```
+
+### 示例：客户端
+
+```python
+from dcc_mcp_core import IpcChannelAdapter, DccLinkFrame
+
+client = IpcChannelAdapter.connect("my-dcc")
+call = DccLinkFrame(msg_type=1, seq=0, body=b"request")
+client.send_frame(call)
+
+reply = client.recv_frame()
+if reply is not None:
+    print(reply.body)
+```
+
+## GracefulIpcChannelAdapter
+
+带优雅关闭和亲和线程支持的 IPC 通道适配器。在 `IpcChannelAdapter` 基础上增加了优雅关闭和 `bind_affinity_thread` / `pump_pending`，用于集成 DCC 主线程空闲回调。
+
+对于需要重入安全 Python 派发的场景，推荐使用 `dcc_mcp_core._core` 中的 `DeferredExecutor` 而非 `submit()`。
+
+### 静态方法
+
+| 方法 | 返回值 | 说明 |
+|------|--------|------|
+| `create(name)` | `GracefulIpcChannelAdapter` | 创建服务端优雅 IPC 通道。创建失败时抛出 `RuntimeError`。|
+| `connect(name)` | `GracefulIpcChannelAdapter` | 连接到已有的优雅 IPC 通道。连接失败时抛出 `RuntimeError`。|
+
+### 实例方法
+
+| 方法 | 返回值 | 说明 |
+|------|--------|------|
+| `wait_for_client()` | `None` | 等待客户端连接（仅服务端）。等待失败时抛出 `RuntimeError`。|
+| `send_frame(frame)` | `None` | 向对端发送 `DccLinkFrame`。发送失败时抛出 `RuntimeError`。|
+| `recv_frame()` | `DccLinkFrame \| None` | 接收 DCC-Link 帧（阻塞）。通道关闭时返回 `None`。意外错误时抛出 `RuntimeError`。|
+| `shutdown()` | `None` | 信号通道优雅关闭。|
+| `bind_affinity_thread()` | `None` | 将当前线程绑定为亲和线程以实现重入安全派发。在 DCC 主线程上调用**一次**。|
+| `pump_pending(budget_ms=100)` | `int` | 在亲和线程上按预算排空待处理工作项。从 DCC 宿主空闲回调中调用。返回已处理条目数。|
+
+### 示例
+
+```python
+from dcc_mcp_core import GracefulIpcChannelAdapter, DccLinkFrame
+
+server = GracefulIpcChannelAdapter.create("my-dcc")
+server.bind_affinity_thread()
+server.wait_for_client()
+
+# 在 DCC 空闲回调中：
+# processed = server.pump_pending(budget_ms=50)
+
+frame = server.recv_frame()
+if frame is not None:
+    reply = DccLinkFrame(msg_type=2, seq=frame.seq, body=b"ok")
+    server.send_frame(reply)
+
+server.shutdown()
+```
+
+## SocketServerAdapter
+
+`ipckit::SocketServer` 的最小封装（多客户端 Unix socket / named pipe）。支持有界连接池。
+
+### 构造函数
+
+```python
+from dcc_mcp_core import SocketServerAdapter
+
+server = SocketServerAdapter(
+    path="/tmp/my-dcc.sock",
+    max_connections=10,
+    connection_timeout_ms=30000,
+)
+```
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `path` | `str` | — | Socket 路径（Unix）或管道名（Windows）。创建失败时抛出 `RuntimeError`。|
+| `max_connections` | `int` | `10` | 最大并发连接数。|
+| `connection_timeout_ms` | `int` | `30000` | 连接超时（毫秒）。|
+
+### 属性
+
+| 属性 | 类型 | 说明 |
+|------|------|------|
+| `socket_path` | `str` | 服务端监听的 socket 路径。|
+| `connection_count` | `int` | 当前连接的客户端数。|
+
+### 实例方法
+
+| 方法 | 返回值 | 说明 |
+|------|--------|------|
+| `shutdown()` | `None` | 优雅关闭服务端（阻塞直到停止）。|
+| `signal_shutdown()` | `None` | 发出关闭信号但不阻塞。|
+
+## TransportAddress
+
+与协议无关的 DCC 通信传输端点。支持 TCP、Named Pipe（Windows）和 Unix Domain Socket（macOS/Linux）。
+
+### 静态方法
+
+| 方法 | 返回值 | 说明 |
+|------|--------|------|
+| `tcp(host, port)` | `TransportAddress` | 创建 TCP 传输地址 |
+| `named_pipe(name)` | `TransportAddress` | 创建 Named Pipe 传输地址（Windows）|
+| `unix_socket(path)` | `TransportAddress` | 创建 Unix Domain Socket 传输地址 |
+| `default_local(dcc_type, pid)` | `TransportAddress` | 生成当前平台最优本地传输 |
+| `default_pipe_name(dcc_type, pid)` | `TransportAddress` | 为 DCC 实例生成默认 Named Pipe 名称 |
+| `default_unix_socket(dcc_type, pid)` | `TransportAddress` | 为 DCC 实例生成默认 Unix Socket 路径 |
 | `parse(s)` | `TransportAddress` | 解析 URI 字符串（`tcp://`、`pipe://`、`unix://`）|
 
 ### 属性
@@ -79,13 +233,13 @@ print(addr.is_local) # True
 
 ## TransportScheme
 
-选择最优通信通道的策略。
+选择最优通信通道的传输策略。
 
 ### 常量
 
 | 常量 | 说明 |
 |------|------|
-| `AUTO` | 自动选择最优传输 |
+| `AUTO` | 自动选择最优传输（Windows 用 Named Pipe，*nix 用 Unix Socket）|
 | `TCP_ONLY` | 始终使用 TCP |
 | `PREFER_NAMED_PIPE` | 优先 Named Pipe，降级到 TCP |
 | `PREFER_UNIX_SOCKET` | 优先 Unix Socket，降级到 TCP |
@@ -95,51 +249,12 @@ print(addr.is_local) # True
 
 | 方法 | 返回值 | 说明 |
 |------|--------|------|
-| `select_address(dcc_type, host, port, pid=None)` | `TransportAddress` | 选择最优地址 |
-
-## RoutingStrategy
-
-多 DCC 实例时的选择策略。
-
-### 常量
-
-| 常量 | 说明 |
-|------|------|
-| `FIRST_AVAILABLE` | 使用第一个可用实例 |
-| `ROUND_ROBIN` | 轮询所有可用实例 |
-| `LEAST_BUSY` | 优先最低负载的实例 |
-| `SPECIFIC` | 按 ID 指定实例 |
-| `SCENE_MATCH` | 优先打开匹配场景的实例 |
-| `RANDOM` | 随机选择 |
+| `select_address(dcc_type, host, port, pid=None)` | `TransportAddress` | 选择最优传输地址 |
 
 ```python
-from dcc_mcp_core import RoutingStrategy, TransportManager
+from dcc_mcp_core import TransportScheme
 
-mgr = TransportManager("/tmp/dcc-mcp")
-session_id = mgr.get_or_create_session_routed(
-    "maya",
-    strategy=RoutingStrategy.ROUND_ROBIN,
-)
-```
-
-## ServiceStatus
-
-DCC 服务实例状态枚举。
-
-### 常量
-
-| 常量 | 说明 |
-|------|------|
-| `AVAILABLE` | 接受连接（默认）|
-| `BUSY` | 正在处理请求 |
-| `UNREACHABLE` | 健康检查失败 |
-| `SHUTTING_DOWN` | 正在关闭 |
-
-```python
-from dcc_mcp_core import ServiceStatus, TransportManager
-
-mgr = TransportManager("/tmp/dcc-mcp")
-mgr.update_service_status("maya", instance_id, ServiceStatus.BUSY)
+addr = TransportScheme.AUTO.select_address("maya", "127.0.0.1", 18812, pid=12345)
 ```
 
 ## ServiceEntry
@@ -156,11 +271,19 @@ mgr.update_service_status("maya", instance_id, ServiceStatus.BUSY)
 | `port` | `int` | TCP 端口 |
 | `version` | `str \| None` | DCC 版本 |
 | `scene` | `str \| None` | 当前打开的场景/文件 |
-| `metadata` | `dict[str, str]` | 自定义元数据 |
+| `documents` | `list[str]` | 打开的文档列表 |
+| `pid` | `int \| None` | 进程 ID |
+| `display_name` | `str \| None` | 显示名称 |
+| `metadata` | `dict[str, str]` | 自定义字符串元数据 |
 | `status` | `ServiceStatus` | 实例状态 |
 | `transport_address` | `TransportAddress \| None` | 首选 IPC 地址 |
 | `last_heartbeat_ms` | `int` | 最后心跳时间戳（Unix 毫秒）|
-| `is_ipc` | `bool` | 是否使用 IPC 传输 |
+
+### Properties
+
+| Property | 类型 | 说明 |
+|----------|------|------|
+| `extras` | `dict[str, Any]` | 任意 JSON 类型的 DCC 扩展字段。与 `metadata`（仅字符串）不同，`extras` 支持嵌套对象/数组/数字/布尔值。返回新字典——修改不影响注册表。|
 
 ### 方法
 
@@ -169,421 +292,41 @@ mgr.update_service_status("maya", instance_id, ServiceStatus.BUSY)
 | `effective_address()` | `TransportAddress` | IPC 地址或 TCP 降级地址 |
 | `to_dict()` | `dict` | 序列化为字典 |
 
-### 示例
+## ServiceStatus
 
-```python
-entry = mgr.find_best_service("maya")
-print(entry.dcc_type)             # "maya"
-print(entry.status)               # ServiceStatus.AVAILABLE
-print(entry.effective_address())  # 如 "pipe://dcc-maya-12345"
+DCC 服务实例状态枚举。
 
-# 检查空闲时间
-import time
-idle_sec = (time.time() * 1000 - entry.last_heartbeat_ms) / 1000
-if idle_sec > 300:
-    mgr.deregister_service("maya", entry.instance_id)
-```
+### 常量
 
-## TransportManager
-
-带有服务发现、智能路由、会话管理和连接池的传输层管理器。
-
-### 构造函数
-
-```python
-from dcc_mcp_core import TransportManager
-
-mgr = TransportManager(
-    registry_dir="/tmp/dcc-mcp",
-    max_connections_per_dcc=10,
-    idle_timeout=300,
-    heartbeat_interval=5,
-    connect_timeout=10,
-    reconnect_max_retries=3,
-)
-```
-
-### 服务发现
-
-| 方法 | 返回值 | 说明 |
-|------|--------|------|
-| `register_service(dcc_type, host, port, version=None, scene=None, metadata=None, transport_address=None)` | `str` | 注册服务，返回 instance_id |
-| `deregister_service(dcc_type, instance_id)` | `bool` | 注销服务 |
-| `list_instances(dcc_type)` | `list[ServiceEntry]` | 列出某 DCC 类型的所有实例 |
-| `list_all_services()` | `list[ServiceEntry]` | 列出所有已注册服务 |
-| `list_all_instances()` | `list[ServiceEntry]` | `list_all_services()` 的别名 |
-| `get_service(dcc_type, instance_id)` | `ServiceEntry \| None` | 获取特定实例 |
-| `heartbeat(dcc_type, instance_id)` | `bool` | 更新心跳时间戳 |
-| `update_service_status(dcc_type, instance_id, status)` | `bool` | 设置实例状态 |
-
-#### `register_service` — IPC 传输参数
-
-传入 `transport_address` 以启用 Named Pipe / Unix Socket 进行低延迟同机通信：
-
-```python
-import os
-from dcc_mcp_core import TransportManager, TransportAddress
-
-mgr = TransportManager("/tmp/dcc-mcp")
-addr = TransportAddress.default_local("maya", os.getpid())
-instance_id = mgr.register_service(
-    "maya", "127.0.0.1", 18812,
-    version="2025",
-    transport_address=addr,
-)
-```
-
-### 智能路由
-
-#### `find_best_service()`
-
-返回优先级最高的活跃 `ServiceEntry`。优先级：本地 IPC > 本地 TCP > 远程 TCP。同层内 `AVAILABLE` 优先于 `BUSY`，同优先级实例自动轮询。
-
-```python
-entry = mgr.find_best_service("maya")
-session_id = mgr.get_or_create_session("maya", entry.instance_id)
-```
-
-#### `rank_services()`
-
-返回按优先级排序的所有活跃实例（分数越低越优先）：
-
-| 分数 | 层级 |
+| 常量 | 说明 |
 |------|------|
-| 0 | 本地 IPC，AVAILABLE |
-| 1 | 本地 IPC，BUSY |
-| 2 | 本地 TCP，AVAILABLE |
-| 3 | 本地 TCP，BUSY |
-| 4 | 远程 TCP，AVAILABLE |
-| 5 | 远程 TCP，BUSY |
+| `AVAILABLE` | 接受连接（默认）|
+| `BUSY` | 正在处理请求 |
+| `UNREACHABLE` | 健康检查失败 |
+| `SHUTTING_DOWN` | 正在关闭 |
 
-`UNREACHABLE` 和 `SHUTTING_DOWN` 实例会被排除。
+## 线协议
 
-```python
-for entry in mgr.rank_services("maya"):
-    print(entry.instance_id, entry.status, entry.effective_address())
-```
-
-#### `bind_and_register()`
-
-DCC 插件开发者的一键启动接口。自动绑定最优传输并注册服务：
-
-```python
-from dcc_mcp_core import TransportManager
-
-mgr = TransportManager("/tmp/dcc-mcp")
-instance_id, listener = mgr.bind_and_register("maya", version="2025")
-local_addr = listener.local_address()
-print(f"监听地址：{local_addr}")
-
-# 在 DCC 插件线程中接受连接
-channel = listener.accept()
-```
-
-传输选择优先级：Named Pipe（Windows）/ Unix Socket（macOS/Linux）→ TCP 随机端口。
-
-### 会话管理
-
-| 方法 | 返回值 | 说明 |
-|------|--------|------|
-| `get_or_create_session(dcc_type, instance_id=None)` | `str` | 获取/创建会话（UUID）|
-| `get_or_create_session_routed(dcc_type, strategy=None, hint=None)` | `str` | 使用路由策略获取/创建会话 |
-| `get_session(session_id)` | `dict \| None` | 获取会话信息 |
-| `record_success(session_id, latency_ms)` | — | 记录成功请求 |
-| `record_error(session_id, latency_ms, error)` | — | 记录失败请求 |
-| `begin_reconnect(session_id)` | `int` | 开始重连，返回退避时间（毫秒）|
-| `reconnect_success(session_id)` | — | 标记重连成功 |
-| `close_session(session_id)` | `bool` | 关闭会话 |
-| `list_sessions()` | `list[dict]` | 列出所有活跃会话 |
-| `list_sessions_for_dcc(dcc_type)` | `list[dict]` | 列出某 DCC 的所有会话 |
-| `session_count()` | `int` | 活跃会话数量 |
-
-### 连接池
-
-| 方法 | 返回值 | 说明 |
-|------|--------|------|
-| `acquire_connection(dcc_type, instance_id=None)` | `str` | 获取连接（UUID）|
-| `release_connection(dcc_type, instance_id)` | — | 释放连接回池 |
-| `pool_size()` | `int` | 连接池总连接数 |
-| `pool_count_for_dcc(dcc_type)` | `int` | 指定 DCC 的池大小 |
-
-### 生命周期
-
-| 方法 | 返回值 | 说明 |
-|------|--------|------|
-| `cleanup()` | `tuple[int, int, int]` | 返回 (过期服务数, 关闭会话数, 驱逐连接数) |
-| `shutdown()` | — | 优雅关闭 |
-| `is_shutdown()` | `bool` | 是否已关闭 |
-
-### Dunder 方法
-
-| 方法 | 说明 |
-|------|------|
-| `__repr__` | `TransportManager(services=N, sessions=N, pool=N)` |
-| `__len__` | 返回会话数量 |
-
-## IpcListener
-
-DCC 服务端 IPC 监听器。支持 TCP、Windows Named Pipe 和 Unix Domain Socket。
-
-### 创建
-
-```python
-from dcc_mcp_core import IpcListener, TransportAddress
-
-addr = TransportAddress.tcp("127.0.0.1", 0)  # port 0 = 系统分配空闲端口
-listener = IpcListener.bind(addr)
-print(listener.local_address())  # 如 "tcp://127.0.0.1:54321"
-```
-
-### 方法
-
-| 方法 | 返回值 | 说明 |
-|------|--------|------|
-| `IpcListener.bind(addr)` | `IpcListener` | 绑定到传输地址 |
-| `local_address()` | `TransportAddress` | 获取已绑定的本地地址 |
-| `accept(timeout_ms=None)` | `FramedChannel` | 接受下一个连接（阻塞）|
-| `into_handle()` | `ListenerHandle` | 包装为 ListenerHandle（消耗 listener）|
-
-### 属性
-
-| 属性 | 类型 | 说明 |
-|------|------|------|
-| `transport_name` | `str` | 传输类型：`"tcp"`、`"named_pipe"` 或 `"unix_socket"` |
-
-::: tip
-使用端口 `0` 绑定，系统会自动分配空闲端口。绑定后调用 `local_address()` 获取实际端口。
-:::
-
-## ListenerHandle
-
-带连接计数和关闭控制的 IPC 监听器句柄。
-
-### 属性
-
-| 属性 | 类型 | 说明 |
-|------|------|------|
-| `accept_count` | `int` | 已接受的连接数 |
-| `is_shutdown` | `bool` | 是否已请求关闭 |
-| `transport_name` | `str` | 传输类型字符串 |
-
-### 方法
-
-| 方法 | 返回值 | 说明 |
-|------|--------|------|
-| `local_address()` | `TransportAddress` | 获取本地地址 |
-| `shutdown()` | — | 请求停止接受新连接（幂等）|
-
-## FramedChannel
-
-用于 DCC 连接的全双工帧通信信道。封装 TCP/IPC，自动处理 Ping/Pong 心跳和消息缓冲。
-
-### 获取实例
-
-```python
-from dcc_mcp_core import connect_ipc, IpcListener, TransportAddress
-
-# 服务端：从 IpcListener 接受连接
-addr = TransportAddress.tcp("127.0.0.1", 0)
-listener = IpcListener.bind(addr)
-channel = listener.accept()
-
-# 客户端：连接到运行中的 DCC
-addr = TransportAddress.tcp("127.0.0.1", 18812)
-channel = connect_ipc(addr)
-```
-
-### 属性
-
-| 属性 | 类型 | 说明 |
-|------|------|------|
-| `is_running` | `bool` | 后台读取任务是否仍在运行 |
-
-### 方法
-
-| 方法 | 返回值 | 说明 |
-|------|--------|------|
-| `call(method, params=None, timeout_ms=30000)` | `dict` | 发送请求并等待响应（RPC）|
-| `recv(timeout_ms=None)` | `dict \| None` | 接收下一条数据消息（阻塞）|
-| `try_recv()` | `dict \| None` | 非阻塞接收 |
-| `ping(timeout_ms=5000)` | `int` | 发送心跳，返回 RTT 毫秒数 |
-| `send_request(method, params=None)` | `str` | 发送请求，返回 request_id UUID |
-| `send_response(request_id, success, payload=None, error=None)` | — | 发送响应 |
-| `send_notify(topic, data=None)` | — | 发送单向通知 |
-| `shutdown()` | — | 优雅关闭（幂等）|
-
-### `call()` — 推荐 RPC 模式
-
-调用 DCC 命令的首选方式。发送 `Request` 并等待对应 `Response`：
-
-```python
-result = channel.call("execute_python", b'print("hello")', timeout_ms=10000)
-if result["success"]:
-    print(result["payload"])   # bytes
-else:
-    raise RuntimeError(result["error"])
-```
-
-`call()` 返回字典键：
-
-| 键 | 类型 | 说明 |
-|----|------|------|
-| `id` | `str` | 对应请求的 UUID |
-| `success` | `bool` | DCC 是否执行成功 |
-| `payload` | `bytes` | 序列化的结果数据 |
-| `error` | `str \| None` | 失败时的错误消息 |
-
-::: tip
-`call()` 等待期间收到的其他消息（通知、其他响应）**不会丢失**，仍可通过 `recv()` 获取。
-:::
-
-### `recv()` — 事件循环模式
-
-适用于需要处理多种消息类型的 DCC 插件服务端：
-
-```python
-while True:
-    msg = channel.recv(timeout_ms=100)
-    if msg is None:
-        continue  # 超时或连接已关闭
-
-    if msg["type"] == "request":
-        handle_request(channel, msg)
-    elif msg["type"] == "notify":
-        handle_notification(msg)
-```
-
-## connect_ipc()
-
-顶层函数，用于创建客户端 `FramedChannel` 连接到运行中的 DCC 服务。
-
-```python
-from dcc_mcp_core import connect_ipc, TransportAddress
-
-addr = TransportAddress.default_local("maya", pid=12345)
-channel = connect_ipc(addr)
-
-rtt = channel.ping()
-print(f"已连接，RTT: {rtt}ms")
-
-result = channel.call("get_scene_info")
-channel.shutdown()
-```
-
-## 完整集成示例
-
-```python
-import os
-from dcc_mcp_core import TransportManager, TransportAddress, RoutingStrategy
-
-# --- DCC 插件端（在 Maya/Blender 内运行）---
-def start_dcc_server(dcc_type: str):
-    mgr = TransportManager("/tmp/dcc-mcp")
-    instance_id, listener = mgr.bind_and_register(dcc_type, version="2025")
-    print(f"DCC 服务已绑定到：{listener.local_address()}")
-
-    while True:
-        channel = listener.accept(timeout_ms=1000)
-        if channel:
-            msg = channel.recv()
-            if msg and msg["type"] == "request":
-                channel.send_response(
-                    msg["id"],
-                    success=True,
-                    payload=b'{"status": "ok"}',
-                )
-
-
-# --- 智能体端（AI 工具或外部脚本）---
-def connect_to_maya():
-    mgr = TransportManager("/tmp/dcc-mcp")
-
-    # 找到最优 Maya 实例（IPC 优先，再 TCP）
-    entry = mgr.find_best_service("maya")
-    print(f"连接到 {entry.effective_address()}")
-
-    # 轮询多实例实现负载均衡
-    session_id = mgr.get_or_create_session_routed(
-        "maya",
-        strategy=RoutingStrategy.ROUND_ROBIN,
-    )
-```
-
-## 线协议说明
-
-消息使用 MessagePack 序列化，带 4 字节大端序长度前缀：
+DccLink 帧使用以下二进制线格式：
 
 ```
-[4 字节长度][MessagePack 载荷]
+[u32 len][u8 type][u64 seq][msgpack body]
 ```
 
-- **Request**: `{ id: UUID, method: String, params: Vec<u8> }`
-- **Response**: `{ id: UUID, success: bool, payload: Vec<u8>, error: Option<String> }`
-- **Notify**: `{ topic: String, data: Vec<u8> }`
-- **Ping/Pong**：由 `FramedChannel` 自动处理
+- `len` — 4 字节大端序总帧长度（包含 type + seq + body）
+- `type` — 1 字节消息类型标签（1-8）
+- `seq` — 8 字节大端序序列号
+- `body` — MessagePack 编码的载荷
 
-## 低级帧编码函数
+消息类型：
 
-用于高级场景（如自定义传输实现或测试）的原始帧编码/解码函数：
-
-### `encode_request()`
-
-```python
-from dcc_mcp_core import encode_request
-
-frame = encode_request("execute_python", b'cmds.sphere()')
-# bytes: [4 字节大端序长度][MessagePack 载荷]
-```
-
-### `encode_response()`
-
-```python
-from dcc_mcp_core import encode_response
-
-frame = encode_response(
-    request_id="550e8400-e29b-41d4-a716-446655440000",
-    success=True,
-    payload=b'{"result": "pSphere1"}',
-)
-
-# 失败响应
-frame = encode_response(
-    request_id="550e8400-e29b-41d4-a716-446655440000",
-    success=False,
-    error="操作失败：对象未找到",
-)
-```
-
-### `encode_notify()`
-
-```python
-from dcc_mcp_core import encode_notify
-
-frame = encode_notify("scene_changed", b'{"change": "object_added"}')
-frame = encode_notify("render_complete")  # data 可选
-```
-
-### `decode_envelope()`
-
-将原始 MessagePack 载荷（已去除长度前缀）解码为消息字典：
-
-```python
-from dcc_mcp_core import encode_request, decode_envelope
-
-frame = encode_request("ping", b"")
-msg = decode_envelope(frame[4:])  # 去掉 4 字节长度前缀
-
-print(msg["type"])    # "request"
-print(msg["method"]) # "ping"
-```
-
-不同 `"type"` 的返回字典字段：
-
-| 类型 | 字段 |
-|------|------|
-| `"request"` | `id` (str)、`method` (str)、`params` (bytes) |
-| `"response"` | `id` (str)、`success` (bool)、`payload` (bytes)、`error` (str\|None) |
-| `"notify"` | `id` (str\|None)、`topic` (str)、`data` (bytes) |
-| `"ping"` | `id` (str)、`timestamp_ms` (int) |
-| `"pong"` | `id` (str)、`timestamp_ms` (int) |
-| `"shutdown"` | `reason` (str\|None) |
+| 标签 | 类型 | 方向 | 说明 |
+|------|------|------|------|
+| 1 | Call | 客户端 → 服务端 | 请求调用 |
+| 2 | Reply | 服务端 → 客户端 | 成功响应 |
+| 3 | Err | 服务端 → 客户端 | 错误响应 |
+| 4 | Progress | 服务端 → 客户端 | 进度更新 |
+| 5 | Cancel | 客户端 → 服务端 | 取消信号 |
+| 6 | Push | 服务端 → 客户端 | 服务端推送消息 |
+| 7 | Ping | 双向 | 心跳请求 |
+| 8 | Pong | 双向 | 心跳响应 |

--- a/docs/zh/guide/architecture.md
+++ b/docs/zh/guide/architecture.md
@@ -14,7 +14,7 @@ dcc-mcp-core (workspace 根目录)
 ├── dcc-mcp-actions      # ToolRegistry, EventBus, ToolDispatcher, Pipeline
 ├── dcc-mcp-skills       # SkillScanner, SkillCatalog, SkillWatcher, Resolver
 ├── dcc-mcp-protocols    # MCP 类型: ToolDefinition, ResourceDefinition, Prompt, BridgeKind
-├── dcc-mcp-transport    # IPC, ConnectionPool, FileRegistry, FramedChannel
+├── dcc-mcp-transport    # IPC (ipckit), DccLinkFrame, IpcChannelAdapter, SocketServerAdapter
 ├── dcc-mcp-process      # PyDccLauncher, ProcessMonitor, ProcessWatcher, CrashRecovery
 ├── dcc-mcp-telemetry    # Tracing/recording: ToolRecorder, TelemetryConfig
 ├── dcc-mcp-sandbox      # Security: SandboxPolicy, SandboxContext, AuditLog
@@ -105,18 +105,17 @@ dcc-mcp-server ← dcc-mcp-http
 
 ### dcc-mcp-transport
 
-**职责**：IPC 和网络传输层，包含服务发现、会话管理和连接池。
+**职责**：IPC 和网络传输层，基于 ipckit 提供帧级通信。
 
 **传输类型**：
 - **IPC**：Unix sockets (Linux/macOS) / Windows 命名管道 — 亚毫秒延迟，PID 唯一
 - **TCP**：网络套接字 — 跨机器或降级使用
 
 **关键组件**：
-- `TransportManager` — 高层管理器：服务注册、会话池、路由
-- `IpcListener` / `ListenerHandle` — 服务端 IPC 监听器，含连接追踪
-- `FramedChannel` — 全双工帧通道，含后台读取循环
+- `IpcChannelAdapter` — 基于 ipckit 的客户端/服务端 IPC 适配器，使用 DccLink 帧
+- `SocketServerAdapter` — 多客户端 TCP/UDS 监听器，用于服务端 IPC
+- `DccLinkFrame` — DccLink 线协议二进制帧类型（msg_type, seq, body）
 - `TransportAddress` — 协议无关端点（TCP、命名管道、Unix Socket）
-- `CircuitBreaker` — 故障检测与快速断开
 - `FileRegistry` — 基于文件的服务发现（Gateway 使用）
 
 **线协议**：MessagePack，4 字节大端长度前缀

--- a/docs/zh/guide/faq.md
+++ b/docs/zh/guide/faq.md
@@ -247,22 +247,22 @@ for skill in skills:
 
 **DCC 端（服务器）：**
 ```python
-import os
-from dcc_mcp_core import TransportManager, IpcListener, TransportAddress
+from dcc_mcp_core import IpcChannelAdapter, DccLinkFrame
 
-mgr = TransportManager("/tmp/dcc-mcp")
-instance_id, listener = mgr.bind_and_register("maya", version="2025")
-channel = listener.accept()  # 等待 Agent 连接
+# 服务端：创建命名 IPC 端点并等待客户端
+server = IpcChannelAdapter.create("maya-2025")
+server.wait_for_client()
 ```
 
 **Agent 端（客户端）：**
 ```python
-from dcc_mcp_core import TransportManager, connect_ipc
+from dcc_mcp_core import IpcChannelAdapter, DccLinkFrame
 
-mgr = TransportManager("/tmp/dcc-mcp")
-entry = mgr.find_best_service("maya")
-channel = connect_ipc(entry.effective_address())
-rtt = channel.ping()
+# 客户端：连接到 DCC 的 IPC 端点
+client = IpcChannelAdapter.connect("maya-2025")
+request = DccLinkFrame(msg_type=1, seq=0, body=b'{"method":"ping"}')
+client.send_frame(request)
+reply = client.recv_frame()
 ```
 
 ## MCP HTTP 服务器

--- a/docs/zh/guide/gateway-election.md
+++ b/docs/zh/guide/gateway-election.md
@@ -86,108 +86,43 @@ Maya v0.12.6（网关）              Maya v0.12.29（新实例）
 > PyO3 嵌入式宿主（Maya 等）下的监听器生命周期变化见后文 spawn_mode 与 issue #303 说明。
 
 ```python
-from dcc_mcp_core import TransportManager
-import os
+from dcc_mcp_core import create_skill_server, McpHttpConfig
 
-mgr = TransportManager("/tmp/dcc-mcp")
-
-# Maya #1：动画工作
-iid_anim = mgr.register_service(
-    "maya", "127.0.0.1", 18812,
-    pid=os.getpid(),
-    display_name="Maya-Animation",
-    scene="shot_001.ma",
-    documents=["shot_001.ma", "shot_002.ma"],
-    version="2025",
-)
-
-# Maya #2：绑定工作
-iid_rig = mgr.register_service(
-    "maya", "127.0.0.1", 18813,
-    pid=12345,
-    display_name="Maya-Rigging",
-    scene="character_rig.ma",
-    documents=["character_rig.ma"],
-    version="2025",
-)
-
-# 列出所有 Maya 实例
-instances = mgr.list_instances("maya")
-# → [Maya-Animation, Maya-Rigging]
-
-# 查找最佳实例（AVAILABLE > BUSY；IPC > TCP）
-best = mgr.find_best_service("maya")
-
-# 按优先级排列所有实例
-ranked = mgr.rank_services("maya")
+# 启动带 Gateway 的服务器（自动注册）
+server = create_skill_server("maya", McpHttpConfig(port=8765))
+handle = server.start()
 ```
 
 ## 文档追踪
 
-对于多文档 DCC（Photoshop、After Effects），追踪所有打开的文件：
+对于多文档 DCC（Photoshop、After Effects），网关通过 `McpHttpConfig.scene` 追踪活跃文档：
 
 ```python
-# Photoshop 以初始文档注册
-iid = mgr.register_service(
-    "photoshop", "127.0.0.1", 18820,
-    pid=55001,
-    display_name="PS-Marketing",
-    scene="logo.psd",
-    documents=["logo.psd", "banner.psd"],
-)
+from dcc_mcp_core import create_skill_server, McpHttpConfig
 
-# 用户打开新文档
-mgr.update_documents(
-    "photoshop", iid,
-    active_document="icon.psd",
-    documents=["logo.psd", "banner.psd", "icon.psd"],
-)
+config = McpHttpConfig(port=0, server_name="photoshop")
+config.gateway_port = 9765
+config.dcc_type = "photoshop"
+config.scene = "logo.psd"  # 当前活跃文档
 
-# 用户切换活跃文档
-mgr.update_documents(
-    "photoshop", iid,
-    active_document="banner.psd",
-    documents=["logo.psd", "banner.psd", "icon.psd"],
-)
-
-entry = mgr.get_service("photoshop", iid)
-print(entry.scene)      # "banner.psd"（活跃文档）
-print(entry.documents)  # ["logo.psd", "banner.psd", "icon.psd"]
+server = create_skill_server("photoshop", config)
+handle = server.start()
 ```
+
+文档切换时更新 `config.scene` 即可反映到网关路由中。
 
 ## 会话隔离
 
-每个 AI 会话**绑定到一个实例**：
+每个 AI 会话**绑定到一个实例**。通过聚合式网关，多个实例的工具都会出现在同一份 `tools/list` 中，通过 8 字符前缀区分，agent 可定向调用任一实例：
 
-```python
-# AI 智能体 A 只与 Maya-Animation 通信
-session_a = mgr.get_or_create_session("maya", iid_anim)
-
-# AI 智能体 B 只与 Maya-Rigging 通信
-session_b = mgr.get_or_create_session("maya", iid_rig)
-
-# 会话不同——无上下文混淆
-assert session_a != session_b
-
-# 通过聚合式网关，两个实例的工具都会出现在同一份 tools/list 中，
-# 通过 8 字符前缀区分，agent 可定向调用任一实例：
-#   a1b2c3d4__set_keyframe   ← maya-animation
-#   e5f6g7h8__mirror_joints  ← maya-rigging
+```
+a1b2c3d4__set_keyframe   ← maya-animation
+e5f6g7h8__mirror_joints  ← maya-rigging
 ```
 
 ## 实例健康检查
 
-```python
-# 通过心跳保持实例存活
-mgr.heartbeat("maya", iid)  # → True 表示存活，False 表示未找到
-
-# 更新实例状态
-from dcc_mcp_core import ServiceStatus
-mgr.update_service_status("maya", iid, ServiceStatus.BUSY)
-
-# DCC 退出时清理
-mgr.deregister_service("maya", iid)
-```
+网关通过心跳自动检测实例健康状态（`stale_timeout_secs` 和 `heartbeat_secs` 在 `McpHttpConfig` 中配置）。实例退出时 `McpServerHandle` 被 drop，自动从网关注销。
 
 ## 向后兼容性
 

--- a/docs/zh/guide/mcp-skills-integration.md
+++ b/docs/zh/guide/mcp-skills-integration.md
@@ -74,20 +74,11 @@ DCC 桥接插件
 ### ServiceEntry — 每个 DCC 注册的信息
 
 ```python
-from dcc_mcp_core import TransportManager
-import os
+from dcc_mcp_core import create_skill_server, McpHttpConfig
 
-mgr = TransportManager(registry_dir="/tmp/dcc-mcp")
-
-# Maya 桥接插件在启动时调用：
-iid = mgr.register_service(
-    "maya", "127.0.0.1", 18812,
-    pid=os.getpid(),
-    display_name="Maya-Production",
-    scene="character.ma",
-    documents=["character.ma", "rig.ma"],
-    version="2025",
-)
+# Gateway 自动注册 DCC 实例
+server = create_skill_server("maya", McpHttpConfig(port=8765))
+handle = server.start()
 ```
 
 网关通过这些信息了解：

--- a/docs/zh/guide/transport.md
+++ b/docs/zh/guide/transport.md
@@ -1,130 +1,260 @@
 # 传输层
 
-> **🚨 v0.14 已移除遗留传输栈（issue #251）。**
+> **v0.14 已替换遗留传输栈（issue #251）。**
 >
-> 下文描述的 `TransportManager`、`FramedChannel`、`FramedIo`、
+> 旧版类 — `TransportManager`、`FramedChannel`、`FramedIo`、
 > `IpcListener`（Python 版）、`ListenerHandle`、`RoutingStrategy`、
 > `ConnectionPool`、`InstanceRouter`、`CircuitBreaker`、`MessageEnvelope`、
 > `encode_request` / `encode_response` / `encode_notify` / `decode_envelope`、
-> `connect_ipc` 等都**已被删除**。新代码请改用基于 `ipckit` 的 DccLink 适配器：
->
-> - `IpcChannelAdapter.connect(name)` / `.create(name)` — 单连接的带帧通道，
->   对接 Windows Named Pipe 或 *nix Unix Socket。
-> - `SocketServerAdapter` — 支持连接上限的多客户端 IPC 服务器。
-> - `GracefulIpcChannelAdapter` — 额外提供优雅关闭和 DCC 主线程友好的重入派发。
-> - `DccLinkFrame` / `DccLinkType` — `[u32 len][u8 type][u64 seq][msgpack body]`
->   线格式，共 8 种消息（Call、Reply、Err、Progress、Cancel、Push、Ping、Pong）。
-> - `ServiceEntry` + `FileRegistry` — 服务发现（保留未变）。
->
-> 跨进程实例发现的对外接口为 gateway HTTP API（`GET /instances`、`POST /mcp` 等）。
+> `connect_ipc` — 均已移除。请使用下方基于 `ipckit` 的 DccLink 适配器。
 
-传输层（`dcc-mcp-transport` crate）为 MCP 服务器与 DCC 应用实例之间的通信提供异步基础设施，包括连接池、服务发现、会话管理和线协议。
+传输层（`dcc-mcp-transport` crate）提供 MCP 服务器与 DCC 应用实例之间的 IPC 通信，使用 DccLink 帧格式通过 Named Pipe（Windows）或 Unix Domain Socket（macOS/Linux）传输。
 
 ## 概览
 
+新传输 API 围绕 **DccLink 适配器** 构建 —— 这是对 `ipckit` IPC 通道的轻量封装，使用二进制线格式（`[u32 len][u8 type][u64 seq][msgpack body]`）实现高效帧通信。
+
 ```python
-from dcc_mcp_core import TransportManager
+from dcc_mcp_core import IpcChannelAdapter, DccLinkFrame
 
-transport = TransportManager("/path/to/registry")
+# 服务端：创建命名通道并等待客户端
+server = IpcChannelAdapter.create("my-dcc")
+server.wait_for_client()
 
-# 注册 DCC 服务
-instance_id = transport.register_service("maya", "127.0.0.1", 18812, version="2025.1")
+# 客户端：连接到服务端
+client = IpcChannelAdapter.connect("my-dcc")
 
-# 创建会话
-session_id = transport.get_or_create_session("maya")
+# 发送帧
+frame = DccLinkFrame(msg_type=1, seq=0, body=b"hello")
+client.send_frame(frame)
 
-# 使用连接
-conn_id = transport.acquire_connection("maya")
-# ... 执行操作 ...
-transport.release_connection("maya", instance_id)
-
-# 清理和关闭
-transport.cleanup()
-transport.shutdown()
+# 接收帧
+received = server.recv_frame()
+print(received.body)  # b"hello"
 ```
 
-## 服务发现
+## DccLinkFrame
 
-传输层使用基于文件的服务发现来跟踪运行中的 DCC 实例。每个实例使用 `(dcc_type, instance_id)` 作为键注册，支持同一 DCC 类型的多个实例。
+DCC-Link 协议的二进制线帧。线格式：`[u32 len][u8 type][u64 seq][msgpack body]`。
+
+### 消息类型
+
+| 标签 | 类型 | 说明 |
+|------|------|------|
+| 1 | Call | 请求调用 |
+| 2 | Reply | 成功响应 |
+| 3 | Err | 错误响应 |
+| 4 | Progress | 进度更新 |
+| 5 | Cancel | 取消信号 |
+| 6 | Push | 服务端推送消息 |
+| 7 | Ping | 心跳请求 |
+| 8 | Pong | 心跳响应 |
+
+### 构造函数
 
 ```python
-id1 = transport.register_service("maya", "127.0.0.1", 18812)
-id2 = transport.register_service("maya", "127.0.0.1", 18813)
-id3 = transport.register_service("blender", "127.0.0.1", 9090, version="4.0")
+from dcc_mcp_core import DccLinkFrame
 
-maya_instances = transport.list_instances("maya")
-all_services = transport.list_all_services()
-
-transport.heartbeat("maya", id1)
-transport.deregister_service("maya", id1)
+frame = DccLinkFrame(msg_type=1, seq=0, body=b"hello")
 ```
 
-## 会话管理
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| `msg_type` | `int` | 消息类型标签（1-8）|
+| `seq` | `int` | 序列号 |
+| `body` | `bytes \| None` | 载荷字节（默认 `b""`）|
 
-会话跟踪与 DCC 实例的连接，提供生命周期状态管理和指标：
+### 属性
+
+| 属性 | 类型 | 说明 |
+|------|------|------|
+| `msg_type` | `int` | 消息类型标签（1=Call, 2=Reply, 3=Err, 4=Progress, 5=Cancel, 6=Push, 7=Ping, 8=Pong）|
+| `seq` | `int` | 序列号 |
+| `body` | `bytes` | 载荷字节 |
+
+### 方法
+
+| 方法 | 返回值 | 说明 |
+|------|--------|------|
+| `encode()` | `bytes` | 将帧编码为 `[len][type][seq][body]` 字节 |
+| `decode(data)` | `DccLinkFrame` | 从包含 4 字节长度前缀的字节中解码帧（静态方法）|
 
 ```python
-session_id = transport.get_or_create_session("maya", id1)
-
-session = transport.get_session(session_id)
-# session 是一个字典，包含键: id, dcc_type, instance_id, state, request_count, error_count, last_error, created_at, last_request_at
-
-transport.record_success(session_id, 50)
-transport.record_error(session_id, 100, "timeout")
-
-backoff_ms = transport.begin_reconnect(session_id)
-transport.reconnect_success(session_id)
-
-transport.close_session(session_id)
+frame = DccLinkFrame(msg_type=1, seq=0, body=b"payload")
+encoded = frame.encode()
+decoded = DccLinkFrame.decode(encoded)
+assert decoded.msg_type == frame.msg_type
+assert decoded.seq == frame.seq
+assert decoded.body == frame.body
 ```
 
-### 会话状态
+## IpcChannelAdapter
 
-| 状态 | 说明 |
-|------|------|
-| `connected` | 活跃且可接受请求 |
-| `idle` | 超过空闲超时，仍然有效 |
-| `reconnecting` | 失败后正在重连 |
-| `closed` | 终态 |
+基于 `ipckit::IpcChannel` 的轻量适配器，使用 DCC-Link 帧格式。支持通过 Named Pipe（Windows）或 Unix Domain Socket（macOS/Linux）的 1:1 连接。
 
-## 连接池
+### 创建服务端
 
 ```python
-conn_id = transport.acquire_connection("maya")
-transport.release_connection("maya", id1)
-transport.pool_size()
+from dcc_mcp_core import IpcChannelAdapter
+
+server = IpcChannelAdapter.create("my-dcc")
+server.wait_for_client()  # 阻塞等待客户端连接
 ```
 
-## 配置
+### 作为客户端连接
 
 ```python
-transport = TransportManager(
-    registry_dir="/path/to/registry",
-    max_connections_per_dcc=10,   # 每种 DCC 类型的最大连接数
-    idle_timeout=300,             # 会话空闲超时（秒）
-    heartbeat_interval=5,         # 心跳间隔（秒）
-    connect_timeout=10,           # TCP 连接超时（秒）
-    reconnect_max_retries=3,      # 最大重连尝试次数
+from dcc_mcp_core import IpcChannelAdapter
+
+client = IpcChannelAdapter.connect("my-dcc")
+```
+
+### 发送和接收帧
+
+```python
+from dcc_mcp_core import IpcChannelAdapter, DccLinkFrame
+
+# 服务端
+server = IpcChannelAdapter.create("my-dcc")
+server.wait_for_client()
+
+# 客户端
+client = IpcChannelAdapter.connect("my-dcc")
+
+# 客户端发送 Call 帧
+call_frame = DccLinkFrame(msg_type=1, seq=0, body=b"execute_python")
+client.send_frame(call_frame)
+
+# 服务端接收帧
+received = server.recv_frame()  # 阻塞；通道关闭时返回 None
+if received is not None:
+    print(received.msg_type)  # 1
+    print(received.body)      # b"execute_python"
+
+    # 服务端发送 Reply 帧
+    reply = DccLinkFrame(msg_type=2, seq=0, body=b"ok")
+    server.send_frame(reply)
+
+# 客户端接收回复
+response = client.recv_frame()
+```
+
+### 静态方法
+
+| 方法 | 返回值 | 说明 |
+|------|--------|------|
+| `create(name)` | `IpcChannelAdapter` | 创建服务端 IPC 通道 |
+| `connect(name)` | `IpcChannelAdapter` | 连接到已有的 IPC 通道 |
+
+### 实例方法
+
+| 方法 | 返回值 | 说明 |
+|------|--------|------|
+| `wait_for_client()` | `None` | 等待客户端连接（仅服务端）|
+| `send_frame(frame)` | `None` | 向对端发送 `DccLinkFrame` |
+| `recv_frame()` | `DccLinkFrame \| None` | 接收帧（阻塞）。通道关闭时返回 `None` |
+
+## GracefulIpcChannelAdapter
+
+在 `IpcChannelAdapter` 基础上增加了优雅关闭和 DCC 主线程集成。适用于需要在主线程处理 IPC 消息而不阻塞的 DCC 插件。
+
+### 创建优雅服务端
+
+```python
+from dcc_mcp_core import GracefulIpcChannelAdapter
+
+server = GracefulIpcChannelAdapter.create("my-dcc")
+server.bind_affinity_thread()  # 在 DCC 主线程上调用一次
+server.wait_for_client()
+```
+
+### 在主线程上处理消息
+
+在 DCC 应用中，IPC 消息通常需要在主线程上处理。在空闲回调中使用 `pump_pending()`：
+
+```python
+# Maya 示例：使用 scriptJob idleEvent
+import maya.cmds as cmds
+
+def on_idle():
+    processed = server.pump_pending(budget_ms=50)
+    # 返回已处理的条目数
+
+cmds.scriptJob(idleEvent="python(\"on_idle()\")")
+```
+
+### 优雅关闭
+
+```python
+server.shutdown()  # 信号通道优雅关闭
+```
+
+### 静态方法
+
+| 方法 | 返回值 | 说明 |
+|------|--------|------|
+| `create(name)` | `GracefulIpcChannelAdapter` | 创建服务端优雅 IPC 通道 |
+| `connect(name)` | `GracefulIpcChannelAdapter` | 连接到已有的优雅 IPC 通道 |
+
+### 实例方法
+
+| 方法 | 返回值 | 说明 |
+|------|--------|------|
+| `wait_for_client()` | `None` | 等待客户端连接（仅服务端）|
+| `send_frame(frame)` | `None` | 向对端发送 `DccLinkFrame` |
+| `recv_frame()` | `DccLinkFrame \| None` | 接收帧（阻塞）。通道关闭时返回 `None` |
+| `shutdown()` | `None` | 信号通道优雅关闭 |
+| `bind_affinity_thread()` | `None` | 将当前线程绑定为亲和线程。在 DCC 主线程上调用**一次** |
+| `pump_pending(budget_ms=100)` | `int` | 在亲和线程上按预算排空待处理工作项。返回已处理条目数 |
+
+## SocketServerAdapter
+
+基于 Unix Domain Socket（macOS/Linux）或 Named Pipe（Windows）的多客户端 IPC 服务器。支持有界连接池。
+
+### 创建 Socket 服务器
+
+```python
+from dcc_mcp_core import SocketServerAdapter
+
+server = SocketServerAdapter(
+    path="/tmp/my-dcc.sock",  # Unix socket 路径或 Windows 管道名
+    max_connections=10,        # 最大并发连接数
+    connection_timeout_ms=30000,  # 连接超时（毫秒）
 )
+
+print(server.socket_path)      # 服务端监听路径
+print(server.connection_count) # 当前连接的客户端数
+
+server.shutdown()  # 优雅关闭
 ```
 
-## 生命周期
+### 构造函数
 
-```python
-stale, sessions, evicted = transport.cleanup()
-transport.shutdown()
-transport.is_shutdown()
-```
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `path` | `str` | — | Socket 路径（Unix）或管道名（Windows）|
+| `max_connections` | `int` | `10` | 最大并发连接数 |
+| `connection_timeout_ms` | `int` | `30000` | 连接超时（毫秒）|
 
----
+### 属性
 
-## 低级 IPC API
+| 属性 | 类型 | 说明 |
+|------|------|------|
+| `socket_path` | `str` | 服务端监听的 socket 路径 |
+| `connection_count` | `int` | 当前连接的客户端数 |
 
-对于需要充当服务端或直接通过 IPC 通信（绕过 `TransportManager`）的 DCC 插件，可使用低级类。
+### 实例方法
+
+| 方法 | 返回值 | 说明 |
+|------|--------|------|
+| `shutdown()` | `None` | 优雅关闭服务端（阻塞直到停止）|
+| `signal_shutdown()` | `None` | 发出关闭信号但不阻塞 |
+
+## 传输辅助类
 
 ### TransportAddress
 
-协议无关的端点描述符，支持 TCP、Windows 命名管道和 Unix Domain Socket。
+协议无关的传输端点。支持 TCP、Named Pipe（Windows）和 Unix Domain Socket（macOS/Linux）。
 
 ```python
 from dcc_mcp_core import TransportAddress
@@ -146,160 +276,51 @@ addr = TransportAddress.parse("tcp://127.0.0.1:18812")
 | `scheme` | `str` | `"tcp"`、`"pipe"` 或 `"unix"` |
 | `is_local` | `bool` | 是否为本机传输 |
 | `is_tcp` | `bool` | 是否为 TCP |
-| `is_named_pipe` | `bool` | 是否为命名管道 |
+| `is_named_pipe` | `bool` | 是否为 Named Pipe |
 | `is_unix_socket` | `bool` | 是否为 Unix Socket |
 | `to_connection_string()` | `str` | URI 字符串，如 `"tcp://127.0.0.1:18812"` |
 
 ### TransportScheme
 
-选择最优传输类型的策略枚举：
+选择最优通信通道的策略：
 
-| 变体 | 说明 |
+| 常量 | 说明 |
 |------|------|
-| `TransportScheme.AUTO` | 平台最优：Windows 用命名管道，Linux/macOS 用 Unix Socket |
-| `TransportScheme.TCP_ONLY` | 始终使用 TCP |
-| `TransportScheme.PREFER_NAMED_PIPE` | 同机用命名管道，否则用 TCP |
-| `TransportScheme.PREFER_UNIX_SOCKET` | 同机用 Unix Socket，否则用 TCP |
-| `TransportScheme.PREFER_IPC` | 任意本地 IPC 传输 |
+| `AUTO` | 自动选择最优传输（Windows 用 Named Pipe，*nix 用 Unix Socket）|
+| `TCP_ONLY` | 始终使用 TCP |
+| `PREFER_NAMED_PIPE` | 优先 Named Pipe，降级到 TCP |
+| `PREFER_UNIX_SOCKET` | 优先 Unix Socket，降级到 TCP |
+| `PREFER_IPC` | 优先任意 IPC，降级到 TCP |
 
 ```python
-from dcc_mcp_core import TransportScheme, TransportAddress
+from dcc_mcp_core import TransportScheme
 
-scheme = TransportScheme.AUTO
-addr = scheme.select_address("maya", "127.0.0.1", 18812, pid=12345)
+addr = TransportScheme.AUTO.select_address("maya", "127.0.0.1", 18812, pid=12345)
 ```
 
-### IpcListener
+### ServiceEntry
 
-服务端监听器，用于 DCC 插件内部接受传入连接。
+已注册 DCC 服务实例的描述对象。
 
-```python
-from dcc_mcp_core import IpcListener, TransportAddress
-
-# 绑定到传输地址（port=0 表示 OS 自动分配端口）
-addr = TransportAddress.tcp("127.0.0.1", 0)
-listener = IpcListener.bind(addr)
-
-# 获取实际绑定地址（port=0 时尤为有用）
-local_addr = listener.local_address()
-print(f"监听地址: {local_addr}")   # tcp://127.0.0.1:54321
-
-# 接受连接（阻塞）
-channel = listener.accept(timeout_ms=5000)  # → FramedChannel
-
-# 或转换为 ListenerHandle 以追踪连接数
-handle = listener.into_handle()   # 消费 listener，只能调用一次
-```
-
-| 方法 | 返回值 | 说明 |
-|------|--------|------|
-| `IpcListener.bind(addr)` | `IpcListener` | 绑定地址，端口占用时抛出 `RuntimeError` |
-| `local_address()` | `TransportAddress` | 实际绑定地址 |
-| `transport_name` | `str` | `"tcp"`、`"named_pipe"` 或 `"unix_socket"` |
-| `accept(timeout_ms=None)` | `FramedChannel` | 接受下一个连接，阻塞直到客户端连入 |
-| `into_handle()` | `ListenerHandle` | 包装为带连接追踪的 handle（消费 `self`） |
-
-### ListenerHandle
-
-包装 `IpcListener`，提供连接计数和关闭控制。
-
-```python
-from dcc_mcp_core import IpcListener, TransportAddress
-
-addr = TransportAddress.default_local("maya", pid=12345)
-listener = IpcListener.bind(addr)
-handle = listener.into_handle()
-
-print(handle.accept_count)   # 0
-print(handle.is_shutdown)    # False
-
-# 请求停止接受新连接
-handle.shutdown()
-```
-
-| 属性/方法 | 返回值 | 说明 |
-|-----------|--------|------|
-| `accept_count` | `int` | 已接受的连接数 |
-| `is_shutdown` | `bool` | 是否已请求关闭 |
-| `transport_name` | `str` | 传输类型名称 |
-| `local_address()` | `TransportAddress` | 绑定地址 |
-| `shutdown()` | `None` | 停止接受新连接（幂等） |
-
-### FramedChannel
-
-全双工帧通道，后台读取循环自动处理 Ping/Pong 心跳。通过 `IpcListener.accept()`（服务端）或 `connect_ipc()`（客户端）获取。
-
-```python
-from dcc_mcp_core import connect_ipc, TransportAddress
-
-# 客户端：连接到运行中的 DCC 服务器
-addr = TransportAddress.tcp("127.0.0.1", 18812)
-channel = connect_ipc(addr, timeout_ms=10000)
-
-# 存活检测
-rtt_ms = channel.ping()          # int，往返时间（毫秒）
-
-# 阻塞接收
-msg = channel.recv(timeout_ms=5000)
-# msg: 含 "type" 字段的字典 → "request"、"response" 或 "notify"
-
-# 非阻塞接收
-msg = channel.try_recv()         # 缓冲区为空时返回 None
-
-# 发送
-req_id = channel.send_request("execute_python", params=b'{"code":"..."}')
-channel.send_response(req_id, success=True, payload=b'{"result":1}')
-channel.send_notify("scene_changed", data=b'{"scene":"untitled"}')
-
-# 关闭
-channel.shutdown()
-print(channel.is_running)        # False
-```
-
-| 方法 | 返回值 | 说明 |
-|------|--------|------|
-| `recv(timeout_ms=None)` | `dict \| None` | 阻塞接收，超时或连接关闭时返回 `None` |
-| `try_recv()` | `dict \| None` | 非阻塞接收，缓冲区为空时返回 `None` |
-| `ping(timeout_ms=5000)` | `int` | 心跳 ping，返回 RTT 毫秒数；数据消息不会丢失 |
-| `send_request(method, params=None)` | `str` | 发送请求，返回 UUID 请求 ID |
-| `send_response(request_id, success, payload=None, error=None)` | `None` | 发送请求的响应 |
-| `send_notify(topic, data=None)` | `None` | 发送单向通知 |
-| `shutdown()` | `None` | 优雅关闭（幂等） |
-| `is_running` | `bool` | 后台读取器是否仍在运行 |
-
-### connect_ipc
-
-客户端连接工厂函数：
-
-```python
-from dcc_mcp_core import connect_ipc, TransportAddress
-
-channel = connect_ipc(
-    addr=TransportAddress.tcp("127.0.0.1", 18812),
-    timeout_ms=10000,    # 默认 10000 毫秒
-)
-```
-
-无法在超时时间内建立连接时抛出 `RuntimeError`。
-
-### RoutingStrategy
-
-选择 DCC 实例的策略（有多个实例注册时）：
-
-| 变体 | 说明 |
-|------|------|
-| `FIRST_AVAILABLE` | 选择第一个可达实例 |
-| `ROUND_ROBIN` | 轮询所有实例 |
-| `LEAST_BUSY` | 会话请求数最少的实例 |
-| `SPECIFIC` | 需要显式指定 `instance_id` |
-| `SCENE_MATCH` | 按打开的场景名称匹配 |
-| `RANDOM` | 随机选择实例 |
+| 属性 | 类型 | 说明 |
+|------|------|------|
+| `dcc_type` | `str` | DCC 类型，如 `"maya"` |
+| `instance_id` | `str` | UUID 字符串 |
+| `host` | `str` | 主机地址 |
+| `port` | `int` | TCP 端口 |
+| `version` | `str \| None` | DCC 版本 |
+| `scene` | `str \| None` | 当前打开的场景/文件 |
+| `metadata` | `dict[str, str]` | 自定义字符串元数据 |
+| `extras` | `dict[str, Any]` | JSON 类型的 DCC 元数据 |
+| `status` | `ServiceStatus` | 实例状态 |
+| `transport_address` | `TransportAddress \| None` | 首选 IPC 地址 |
+| `last_heartbeat_ms` | `int` | 最后心跳时间戳（Unix 毫秒）|
 
 ### ServiceStatus
 
 DCC 服务健康状态枚举：
 
-| 变体 | 含义 |
+| 常量 | 说明 |
 |------|------|
 | `AVAILABLE` | 就绪，可接受请求 |
 | `BUSY` | 处理中，可能接受更多请求 |
@@ -308,40 +329,48 @@ DCC 服务健康状态枚举：
 
 ---
 
-## 端到端示例：DCC 插件服务端
+## 端到端示例
+
+### DCC 插件（服务端）
 
 ```python
-# Maya 插件内部（服务端）
-import maya.cmds as cmds
-from dcc_mcp_core import IpcListener, TransportAddress
-import threading, os
+# Maya 插件内部
+from dcc_mcp_core import GracefulIpcChannelAdapter, DccLinkFrame
 
-addr = TransportAddress.default_local("maya", os.getpid())
-listener = IpcListener.bind(addr)
-print(f"Maya IPC 服务器: {listener.local_address()}")
+server = GracefulIpcChannelAdapter.create("maya-ipc")
+server.bind_affinity_thread()  # 在主线程调用一次
+server.wait_for_client()
 
-def serve():
-    channel = listener.accept()
-    while True:
-        msg = channel.recv(timeout_ms=1000)
-        if msg is None:
-            break
-        if msg["type"] == "request":
-            result = cmds.ls()
-            channel.send_response(msg["id"], success=True,
-                                  payload=str(result).encode())
+# Maya 空闲回调：
+def on_idle():
+    processed = server.pump_pending(budget_ms=50)
 
-threading.Thread(target=serve, daemon=True).start()
+# 主消息循环
+while True:
+    frame = server.recv_frame()
+    if frame is None:
+        break  # 通道已关闭
+    if frame.msg_type == 1:  # Call
+        # 处理请求...
+        reply = DccLinkFrame(msg_type=2, seq=frame.seq, body=b"ok")
+        server.send_frame(reply)
+
+server.shutdown()
 ```
 
-```python
-# 客户端（MCP Agent）
-from dcc_mcp_core import connect_ipc, TransportAddress
+### MCP Agent（客户端）
 
-addr = TransportAddress.default_local("maya", pid=12345)
-channel = connect_ipc(addr)
-req_id = channel.send_request("ls")
-response = channel.recv()
-# response["type"] == "response", response["payload"] == b"[...]"
-channel.shutdown()
+```python
+from dcc_mcp_core import IpcChannelAdapter, DccLinkFrame
+
+client = IpcChannelAdapter.connect("maya-ipc")
+
+# 发送 Call 帧
+call = DccLinkFrame(msg_type=1, seq=0, body=b"get_scene_info")
+client.send_frame(call)
+
+# 接收 Reply
+reply = client.recv_frame()
+if reply and reply.msg_type == 2:
+    print(f"结果: {reply.body}")
 ```

--- a/docs/zh/guide/what-is-dcc-mcp-core.md
+++ b/docs/zh/guide/what-is-dcc-mcp-core.md
@@ -55,7 +55,7 @@ dcc-mcp-core/
 │   ├── dcc-mcp-actions/        # ToolRegistry, EventBus, Pipeline, Dispatcher, Validator
 │   ├── dcc-mcp-skills/         # SkillScanner, SkillCatalog, SkillWatcher, Resolver
 │   ├── dcc-mcp-protocols/      # MCP 类型：ToolDefinition, ResourceDefinition, Prompt, DccAdapter
-│   ├── dcc-mcp-transport/      # IPC, ConnectionPool, SessionManager, FramedChannel
+│   ├── dcc-mcp-transport/      # IPC (ipckit), DccLinkFrame, IpcChannelAdapter, SocketServerAdapter
 │   ├── dcc-mcp-process/        # PyDccLauncher, ProcessMonitor, CrashRecovery
 │   ├── dcc-mcp-telemetry/      # ToolRecorder, ToolMetrics, TelemetryConfig
 │   ├── dcc-mcp-sandbox/        # SandboxPolicy, SandboxContext, AuditLog, InputValidator
@@ -91,7 +91,7 @@ from dcc_mcp_core import (
     McpHttpServer, McpHttpConfig,
 
     # 传输层
-    TransportManager, TransportAddress, IpcListener, FramedChannel, connect_ipc,
+    IpcChannelAdapter, GracefulIpcChannelAdapter, SocketServerAdapter, DccLinkFrame,
 
     # 协议类型
     ToolDefinition, ToolAnnotations, ResourceDefinition, PromptDefinition,

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -18,7 +18,7 @@
 | Validate action input parameters | `ToolValidator` / `InputValidator` |
 | Route action calls to Python handlers | `ToolDispatcher` |
 | Define an MCP Tool for the LLM | `ToolDefinition` + `ToolAnnotations` |
-| Connect to a running DCC process | `connect_ipc(TransportAddress)` |
+| Connect to a running DCC process | `IpcChannelAdapter.connect(name)` / `GracefulIpcChannelAdapter.connect(name)` |
 | Launch a new DCC process | `PyDccLauncher` |
 | Monitor DCC process health | `PyProcessWatcher` / `PyProcessMonitor` |
 | Enforce security policy on actions | `SandboxPolicy` + `SandboxContext` |
@@ -52,7 +52,7 @@ crates/
 ├── dcc-mcp-actions/      # ToolRegistry, ToolDispatcher, ToolValidator, EventBus, ToolPipeline
 ├── dcc-mcp-skills/       # SkillScanner, SkillWatcher, parse_skill_md, dependency resolver
 ├── dcc-mcp-protocols/    # MCP type definitions (Tool, Resource, Prompt, DccAdapter)
-├── dcc-mcp-transport/    # IPC transport, TransportManager, ConnectionPool, CircuitBreaker
+├── dcc-mcp-transport/    # DccLink IPC adapters (IpcChannelAdapter, GracefulIpcChannelAdapter, SocketServerAdapter)
 ├── dcc-mcp-http/         # McpHttpServer, McpHttpConfig, McpServerHandle (MCP Streamable HTTP 2025-03-26)
 ├── dcc-mcp-process/      # PyDccLauncher, PyProcessMonitor, PyProcessWatcher, PyCrashRecoveryPolicy
 ├── dcc-mcp-telemetry/    # TelemetryConfig, RecordingGuard, ToolMetrics, ToolRecorder
@@ -1040,6 +1040,109 @@ dcc_mcp_core.DccErrorCode.INTERNAL
 
 ## Transport Layer (`dcc_mcp_core`)
 
+### DccLinkFrame
+
+Binary frame for DccLink protocol. Each frame carries a message type, sequence number, and body.
+
+```python
+from dcc_mcp_core import DccLinkFrame
+
+# Create a frame
+frame = DccLinkFrame(msg_type=1, seq=0, body=b'{"method": "execute_python", "params": {}}')
+frame.msg_type   # int — message type
+frame.seq        # int — sequence number
+frame.body       # bytes — payload
+
+# Encode / decode for wire transfer
+encoded: bytes = frame.encode()           # serialize to binary
+restored = DccLinkFrame.decode(encoded)   # deserialize from binary
+
+# Message types
+# 1 = Call      — request that expects a reply
+# 2 = Reply     — response to a Call
+# 3 = Err       — error response to a Call
+# 4 = Progress  — intermediate progress update
+# 5 = Cancel    — cancel a pending Call
+# 6 = Push      — server-initiated notification
+# 7 = Ping      — keep-alive / latency probe
+# 8 = Pong      — response to Ping
+```
+
+### IpcChannelAdapter
+
+Named IPC channel adapter using the DccLink framing protocol. Supports both server (create)
+and client (connect) modes over OS-native named pipes / Unix domain sockets.
+
+```python
+from dcc_mcp_core import IpcChannelAdapter, DccLinkFrame
+
+# Server mode: create a named channel
+server = IpcChannelAdapter.create("maya-ipc")
+server.wait_for_client()   # blocks until a client connects
+
+# Client mode: connect to a named channel
+client = IpcChannelAdapter.connect("maya-ipc")
+
+# Send a frame
+call_frame = DccLinkFrame(msg_type=1, seq=0, body=b'{"method": "execute_python", "params": {}}')
+client.send_frame(call_frame)
+
+# Receive a frame (blocking)
+reply_frame = server.recv_frame()   # -> DccLinkFrame
+print(reply_frame.msg_type)         # 2 (Reply) or 3 (Err)
+print(reply_frame.body)             # response payload bytes
+
+# Round-trip example
+server.send_frame(DccLinkFrame(msg_type=2, seq=reply_frame.seq, body=b'result'))
+client_reply = client.recv_frame()
+```
+
+### GracefulIpcChannelAdapter
+
+Extended `IpcChannelAdapter` with graceful shutdown and thread-affinity support.
+Use this in DCC main-thread scenarios where cleanup must be orderly.
+
+```python
+from dcc_mcp_core import GracefulIpcChannelAdapter, DccLinkFrame
+
+# Server mode
+server = GracefulIpcChannelAdapter.create("maya-graceful")
+server.wait_for_client()
+
+# Client mode
+client = GracefulIpcChannelAdapter.connect("maya-graceful")
+
+# Same send_frame / recv_frame as IpcChannelAdapter
+client.send_frame(DccLinkFrame(msg_type=1, seq=0, body=b'request'))
+reply = server.recv_frame()
+
+# Graceful shutdown (waits for in-flight frames)
+server.shutdown()
+client.shutdown()
+
+# Thread affinity: bind IPC processing to a specific thread
+# Required for DCCs that restrict API calls to the main thread
+server.bind_affinity_thread()   # binds to current thread
+```
+
+### SocketServerAdapter
+
+TCP socket server adapter for DccLink protocol. Accepts multiple client connections.
+
+```python
+from dcc_mcp_core import SocketServerAdapter
+
+# Create a TCP server on a Unix domain socket or named pipe path
+server = SocketServerAdapter(
+    path="/tmp/dcc-mcp.sock",       # socket path
+    max_connections=10,              # max concurrent clients (default: 10)
+    connection_timeout_ms=30000,     # per-connection idle timeout (default: 30000)
+)
+
+server.socket_path        # str — the socket path
+server.connection_count   # int — current active connections
+```
+
 ### TransportAddress
 
 Protocol-agnostic endpoint. Supports TCP, Windows Named Pipes, Unix Domain Sockets.
@@ -1082,164 +1185,6 @@ addr = scheme.select_address(dcc_type="maya", host="127.0.0.1", port=18812, pid=
 # -> TransportAddress (Named Pipe on Windows, Unix Socket on Linux/macOS, TCP fallback)
 ```
 
-### IpcListener + ListenerHandle
-
-Server-side: bind a listener and accept connections.
-
-```python
-from dcc_mcp_core import IpcListener, TransportAddress
-
-# Bind
-addr = TransportAddress.tcp("127.0.0.1", 0)   # port 0 = OS assigns
-listener = IpcListener.bind(addr)
-local_addr = listener.local_address()          # get assigned port
-print(f"Listening on {local_addr.to_connection_string()}")
-
-# Accept one connection (blocking)
-channel = listener.accept(timeout_ms=10000)   # -> FramedChannel
-
-# Or convert to handle for connection tracking
-handle = listener.into_handle()  # consumes listener
-print(handle.accept_count)       # 0 initially
-print(handle.is_shutdown)        # False
-handle.shutdown()                # request stop
-```
-
-### connect_ipc (client)
-
-```python
-from dcc_mcp_core import connect_ipc, TransportAddress
-
-addr = TransportAddress.tcp("127.0.0.1", 18812)
-channel = connect_ipc(addr, timeout_ms=10000)  # -> FramedChannel
-```
-
-### FramedChannel
-
-Full-duplex message-framed channel. Handles Ping/Pong heartbeats automatically.
-
-```python
-# Ping (round-trip latency check)
-rtt_ms = channel.ping(timeout_ms=5000)  # -> int
-
-# RPC-style call (send Request, wait for matching Response)
-result = channel.call(
-    "execute_python",
-    params=b'import maya.cmds as cmds; cmds.sphere()',
-    timeout_ms=30000,
-)
-# result: {"id": "...", "success": bool, "payload": bytes, "error": str|None}
-if result["success"]:
-    output = result["payload"]
-else:
-    raise RuntimeError(result["error"])
-
-# Low-level send/recv
-req_id = channel.send_request("execute_mel", params=b'sphere -r 1;')
-channel.send_notify("scene_changed", data=b'{"file": "scene.mb"}')
-msg = channel.recv(timeout_ms=5000)   # -> dict|None (blocks)
-msg = channel.try_recv()              # -> dict|None (non-blocking)
-
-# Shutdown
-channel.shutdown()       # graceful, idempotent
-channel.is_running       # bool
-
-# Message dict structure from recv():
-# Request:  {"type": "request",  "id": str, "method": str, "params": bytes|None}
-# Response: {"type": "response", "id": str, "success": bool, "payload": bytes|None, "error": str|None}
-# Notify:   {"type": "notify",   "topic": str, "data": bytes|None}
-```
-
-### TransportManager
-
-Full-featured manager with service discovery, session management, and connection pooling.
-
-```python
-from dcc_mcp_core import TransportManager, ServiceStatus, RoutingStrategy
-
-mgr = TransportManager(
-    registry_dir="/tmp/dcc-mcp-registry",
-    max_connections_per_dcc=10,
-    idle_timeout=300,           # seconds
-    heartbeat_interval=5,       # seconds
-    connect_timeout=10,         # seconds
-    reconnect_max_retries=3,
-)
-
-# Service discovery
-instance_id = mgr.register_service(
-    dcc_type="maya",
-    host="127.0.0.1",
-    port=18812,
-    version="2025",
-    scene="/project/scene.mb",
-    metadata={"user": "artist1"},
-)
-mgr.deregister_service("maya", instance_id)
-instances = mgr.list_instances("maya")           # -> List[ServiceEntry]
-all_services = mgr.list_all_services()            # -> List[ServiceEntry]
-all_services = mgr.list_all_instances()           # alias for list_all_services()
-entry = mgr.get_service("maya", instance_id)      # -> ServiceEntry|None
-
-# Heartbeat + status
-mgr.heartbeat("maya", instance_id)  # -> bool (False if not found)
-mgr.update_service_status("maya", instance_id, ServiceStatus.BUSY)
-
-# One-call server registration (v0.12+) — bind listener + register in one step
-instance_id, listener = mgr.bind_and_register(
-    "maya",
-    version="2025",
-    metadata={"artist": "user1"},
-)
-# Transport auto-selected: Named Pipe on Windows, Unix Socket on Linux/macOS, TCP fallback
-local_addr = listener.local_address()
-channel = listener.accept()   # wait for first client connection
-
-# Smart service discovery (v0.12+)
-best = mgr.find_best_service("maya")      # best available instance (raises if none)
-ranked = mgr.rank_services("maya")        # all live instances sorted by preference
-# Preference order: Local IPC AVAILABLE → Local IPC BUSY → Local TCP AVAIL → Remote TCP ...
-for entry in ranked:
-    print(entry.instance_id, entry.status, entry.effective_address())
-
-# Session management (automatic connection routing)
-session_id = mgr.get_or_create_session("maya", instance_id)
-session_id = mgr.get_or_create_session_routed(
-    "maya",
-    strategy=RoutingStrategy.LEAST_BUSY,
-)
-session = mgr.get_session(session_id)      # -> dict|None
-mgr.record_success(session_id, latency_ms=42)
-mgr.record_error(session_id, latency_ms=500, error="timeout")
-mgr.close_session(session_id)              # -> bool
-
-# Connection pool
-conn_id = mgr.acquire_connection("maya", instance_id)
-mgr.release_connection("maya", instance_id)
-mgr.pool_size()                 # -> int
-mgr.pool_count_for_dcc("maya")  # -> int
-
-# Lifecycle
-stats = mgr.cleanup()   # -> (expired_sessions, idle_conns, errors) tuple
-mgr.shutdown()
-mgr.is_shutdown()       # -> bool
-len(mgr)                # total managed connections
-
-# ServiceStatus values
-ServiceStatus.AVAILABLE
-ServiceStatus.BUSY
-ServiceStatus.UNREACHABLE
-ServiceStatus.SHUTTING_DOWN
-
-# RoutingStrategy values
-RoutingStrategy.FIRST_AVAILABLE
-RoutingStrategy.ROUND_ROBIN
-RoutingStrategy.LEAST_BUSY
-RoutingStrategy.SPECIFIC
-RoutingStrategy.SCENE_MATCH
-RoutingStrategy.RANDOM
-```
-
 ### ServiceEntry
 
 ```python
@@ -1251,16 +1196,19 @@ entry.scene              # str|None (current open scene path)
 entry.metadata           # dict[str,str]
 entry.status             # ServiceStatus
 entry.transport_address  # TransportAddress|None
-entry.last_heartbeat_ms  # int (Unix ms; updated by TransportManager.heartbeat())
+entry.last_heartbeat_ms  # int (Unix ms)
 entry.is_ipc             # bool
 entry.effective_address()  # -> TransportAddress (transport_address or TCP fallback)
 entry.to_dict()
+```
 
-# Check staleness
-import time
-idle_sec = (time.time() * 1000 - entry.last_heartbeat_ms) / 1000
-if idle_sec > 300:
-    mgr.deregister_service(entry.dcc_type, entry.instance_id)
+### ServiceStatus
+
+```python
+ServiceStatus.AVAILABLE
+ServiceStatus.BUSY
+ServiceStatus.UNREACHABLE
+ServiceStatus.SHUTTING_DOWN
 ```
 
 ---
@@ -1699,7 +1647,7 @@ ssb = PySharedSceneBuffer.write(
 desc_json = ssb.descriptor_json()  # send this to consumer via IPC channel
 
 # Read (consumer agent side) — reconstruct from descriptor is not exposed;
-# pass ssb itself if in-process, or use FramedChannel to send desc_json
+# pass ssb itself if in-process, or use IpcChannelAdapter to send desc_json
 recovered = ssb.read()  # -> bytes (decompresses automatically)
 
 ssb.id            # str
@@ -1843,7 +1791,7 @@ For low-level servers that build on `McpHttpServer` directly, call
 MCP tool registration must complete before the server is running.
 
 The bundled `dcc-diagnostics` skill's `screenshot.py` handler tries
-`DCC_MCP_OWNER_IPC` → `channel.call("take_screenshot")` first and falls back
+`DCC_MCP_OWNER_IPC` → IPC frame with take_screenshot request first and falls back
 to `Capturer.new_auto()` when no owner IPC is configured.
 
 ---
@@ -2147,25 +2095,26 @@ for skill in skills:
         ))
 ```
 
-### Pattern 2: Full RPC call to a running DCC
+### Pattern 2: IPC call to a running DCC via DccLink
 
 ```python
 import json
-from dcc_mcp_core import TransportAddress, connect_ipc, success_result, error_result
+from dcc_mcp_core import IpcChannelAdapter, DccLinkFrame, success_result, error_result
 
-addr = TransportAddress.default_local("maya", pid=12345)
-channel = connect_ipc(addr)
+# Connect to a DCC process via named IPC channel
+client = IpcChannelAdapter.connect("maya-ipc")
 try:
-    # Primary RPC: .call() atomically sends Request + waits for correlated Response (v0.12.7+)
-    result = channel.call("execute_python", b'import maya.cmds; print(maya.cmds.ls())', timeout_ms=10000)
-    if result["success"]:
-        payload = result.get("payload", b"")
-        output = payload.decode() if isinstance(payload, bytes) else str(payload)
+    # Send a Call frame and wait for a Reply
+    req = DccLinkFrame(msg_type=1, seq=0, body=json.dumps({"method": "execute_python", "params": "import maya.cmds; print(maya.cmds.ls())"}).encode())
+    client.send_frame(req)
+    reply = client.recv_frame()
+    if reply.msg_type == 2:  # Reply
+        output = reply.body.decode()
         r = success_result(output, prompt="Objects listed. You can now select one to modify.")
-    else:
-        r = error_result("DCC script failed", result.get("error", "Unknown error"))
+    else:  # Err (msg_type=3)
+        r = error_result("DCC script failed", reply.body.decode())
 finally:
-    channel.shutdown()
+    client.shutdown()
 ```
 
 ### Pattern 3: Sandbox AI-generated code execution
@@ -2191,15 +2140,16 @@ for entry in ctx.audit_log.entries():
 ### Pattern 4: Zero-copy scene data transfer
 
 ```python
-from dcc_mcp_core import PySharedSceneBuffer, PySceneDataKind, TransportAddress, connect_ipc
+import json
+from dcc_mcp_core import PySharedSceneBuffer, PySceneDataKind, IpcChannelAdapter, DccLinkFrame
 
 # In DCC (producer)
 mesh_bytes = get_mesh_data_as_bytes()
 ssb = PySharedSceneBuffer.write(mesh_bytes, kind=PySceneDataKind.Geometry, use_compression=True)
 desc = ssb.descriptor_json()
 # Send desc via IPC channel to agent
-channel = connect_ipc(TransportAddress.default_local("maya", os.getpid()))
-channel.send_notify("mesh_ready", data=desc.encode())
+client = IpcChannelAdapter.connect("maya-ipc")
+client.send_frame(DccLinkFrame(msg_type=6, seq=0, body=json.dumps({"topic": "mesh_ready", "desc": desc}).encode()))
 ```
 
 ---

--- a/llms.txt
+++ b/llms.txt
@@ -10,7 +10,7 @@
 | Register scripts as MCP tools | `ToolRegistry.register()` |
 | Discover skills from directories | `scan_and_load()` → returns `(skills, skipped)` tuple |
 | Validate tool params | `ToolValidator.from_schema_json()` |
-| Connect to running DCC | `connect_ipc(TransportAddress.default_local(...))` |
+| Connect to running DCC | `IpcChannelAdapter.connect(name)` or `SocketServerAdapter(path)` |
 | Define MCP tool for LLM | `ToolDefinition` + `ToolAnnotations` |
 | Monitor DCC process | `PyProcessWatcher` + `PyCrashRecoveryPolicy` |
 | Sandbox AI actions | `SandboxPolicy` + `SandboxContext` |
@@ -66,7 +66,7 @@ meta = dcc_mcp_core.parse_skill_md(dirs[0])  # -> SkillMetadata or None
 
 ## Architecture
 
-Rust workspace (15 crates) with PyO3 bindings. All logic in Rust sub-crates; Python gets a single `dcc_mcp_core._core` extension module. The `dcc_mcp_core` package re-exports all ~177 public symbols from `_core` plus pure-Python helpers (DccServerBase, DccGatewayElection, DccSkillHotReloader, factory, skill helpers).
+Rust workspace (15 crates) with PyO3 bindings. All logic in Rust sub-crates; Python gets a single `dcc_mcp_core._core` extension module. The `dcc_mcp_core` package re-exports all ~180 public symbols from `_core` plus pure-Python helpers (DccServerBase, DccGatewayElection, DccSkillHotReloader, factory, skill helpers).
 
 ```
 crates/
@@ -75,7 +75,7 @@ crates/
 ├── dcc-mcp-actions/     # ToolRegistry, ToolDispatcher, ToolValidator, EventBus, ToolPipeline
 ├── dcc-mcp-skills/      # SkillScanner, SkillWatcher, parse_skill_md, dependency resolver
 ├── dcc-mcp-protocols/   # MCP type definitions (Tool, Resource, Prompt, DccAdapter)
-├── dcc-mcp-transport/   # IPC transport, ConnectionPool, CircuitBreaker, FramedChannel
+├── dcc-mcp-transport/   # IPC transport (ipckit), DccLinkFrame, IpcChannelAdapter, SocketServerAdapter
 ├── dcc-mcp-process/     # PyDccLauncher, ProcessMonitor, ProcessWatcher, CrashRecovery
 ├── dcc-mcp-telemetry/   # TelemetryConfig, RecordingGuard, ToolMetrics, ToolRecorder
 ├── dcc-mcp-sandbox/     # SandboxPolicy, InputValidator, AuditLog
@@ -195,22 +195,35 @@ tools:
 
 ### Transport (`dcc_mcp_core`)
 
-- `IpcListener.bind(address) -> IpcListener` → `.local_address()`, `.accept(timeout_ms=None) -> FramedChannel` (server-side), `.into_handle() -> ListenerHandle`
-- `connect_ipc(address, timeout_ms=10000) -> FramedChannel` (client-side)
-- `FramedChannel` methods:
-  - `.call(method, params=None, timeout_ms=30000) -> dict` — **primary RPC helper** (v0.12.7+); atomically sends Request + waits for correlated Response; result: `{"id", "success", "payload", "error"}`
-  - `.send_request(method, params=None) -> req_id` — async variant; use with `.recv()` for multiplexed patterns
-  - `.recv(timeout_ms=None) -> dict|None` — returns next Request/Response/Notify envelope
-  - `.send_response(request_id, success, payload=None, error=None)` — server-side reply
-  - `.send_notify(topic, data=None)` — one-way event push
-  - `.ping(timeout_ms=5000) -> int` — heartbeat RTT in ms
-  - `.shutdown()` — graceful close
-- `TransportManager(registry_dir, ...)` — connection pool + circuit breaker + service discovery
-  - `.bind_and_register(dcc_type, version=None) -> (instance_id, IpcListener)` — one-call server setup
-  - `.find_best_service(dcc_type) -> ServiceEntry` — smart routing (IPC > local TCP > remote)
-  - `.rank_services(dcc_type) -> List[ServiceEntry]` — all live instances sorted by preference
-- `TransportAddress`, `TransportScheme`, `RoutingStrategy`
-- Frame encode/decode: `encode_request(method, params)`, `encode_response(id, success, payload, error)`, `encode_notify(topic, data)`, `decode_envelope(data)` — low-level MessagePack framing
+**DccLinkFrame** — framed message for IPC transport:
+- `DccLinkFrame(msg_type, seq, body)` — construct a frame
+  - `.msg_type` — message type (int): 1=Call, 2=Reply, 3=Err, 4=Progress, 5=Cancel, 6=Push, 7=Ping, 8=Pong
+  - `.seq` — sequence number (u32)
+  - `.body` — payload bytes
+  - `.encode() -> bytes` — serialize frame to wire format
+  - `.decode(data) -> DccLinkFrame` — deserialize from wire format (static)
+
+**IpcChannelAdapter** — named-pipe IPC channel:
+- `IpcChannelAdapter.create(name) -> IpcChannelAdapter` — create server-side endpoint
+- `IpcChannelAdapter.connect(name) -> IpcChannelAdapter` — connect client-side endpoint
+- `.wait_for_client()` — block until a client connects (server-side)
+- `.send_frame(frame)` — send a DccLinkFrame
+- `.recv_frame() -> DccLinkFrame` — receive next frame
+
+**GracefulIpcChannelAdapter** — IPC channel with graceful shutdown and thread affinity:
+- Same methods as `IpcChannelAdapter` plus:
+- `.shutdown()` — graceful close
+- `.bind_affinity_thread()` — bind to current thread for thread-safe access
+
+**SocketServerAdapter** — Unix domain socket / named pipe server:
+- `SocketServerAdapter(path, max_connections=1, connection_timeout_ms=30000)` — create socket server
+- `.socket_path` — the socket path (read-only)
+- `.connection_count` — current active connections (read-only)
+
+**Service Discovery** (still available):
+- `TransportAddress`, `TransportScheme` — address types for service discovery
+- `ServiceEntry` — discovered service metadata
+- `ServiceStatus` — service health status
 
 ### MCP HTTP Server (`dcc_mcp_core`)
 

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -288,7 +288,6 @@ __all__ = [
     "FileLoggingConfig",
     "FloatWrapper",
     "FrameRange",
-    "FrameRange",
     "GracefulIpcChannelAdapter",
     "InputValidator",
     "IntWrapper",

--- a/skills/integration-guide.md
+++ b/skills/integration-guide.md
@@ -467,24 +467,16 @@ class AuroraViewAdapter(WebViewAdapter):
 WebView hosts register with extra metadata so the Gateway can identify them:
 
 ```python
-from dcc_mcp_core import TransportManager
+from dcc_mcp_core import create_skill_server, McpHttpConfig
 
-mgr = TransportManager(registry_dir="/tmp/dcc-mcp")
-instance_id = mgr.register_service(
-    "auroraview",
-    "127.0.0.1",
-    8765,
-    extras={
-        "cdp_port": 9222,
-        "url": "http://localhost:3000",
-        "window_title": "AuroraView Panel",
-        "host_dcc": "maya",           # embedded inside Maya
-    },
-)
-
-# AI agents discover it via the Gateway:
-# tools/call list_dcc_instances → shows auroraview with all extras
+# The gateway auto-registers the DCC instance
+server = create_skill_server("auroraview", McpHttpConfig(port=8765))
+handle = server.start()
 ```
+
+To include WebView-specific extras (CDP port, host DCC, etc.), pass them via
+`McpHttpConfig` fields or environment variables — the Gateway picks them up
+automatically during registration.
 
 ---
 
@@ -673,7 +665,7 @@ public class DccMcpBridge
 | **Capabilities** | Full (scene, timeline, ...) | Full (via bridge calls) | Narrow (configurable) |
 | **Base class** | `DccServerBase` | `DccServerBase` + `DccBridge` | `WebViewAdapter` |
 | **Main thread safety** | DCC-specific (deferred exec) | Always safe (separate process) | N/A |
-| **Gateway registration** | Automatic (via `McpHttpConfig`) | Automatic | Manual (`TransportManager`) |
+| **Gateway registration** | Automatic (via `McpHttpConfig`) | Automatic | Manual (`ServiceEntry` + `IpcChannelAdapter`) |
 
 ---
 
@@ -699,7 +691,7 @@ handle = server.start()
 | `DCC_MCP_SKILL_PATHS` | Global skill search paths |
 | `DCC_MCP_{DCC}_SKILL_PATHS` | Per-DCC skill search paths (e.g. `DCC_MCP_MAYA_SKILL_PATHS`) |
 | `DCC_MCP_GATEWAY_PORT` | Gateway election port (default 9765) |
-| `DCC_MCP_REGISTRY_DIR` | Shared FileRegistry directory |
+| `DCC_MCP_REGISTRY_DIR` | Shared service registry directory |
 | `DCC_MCP_{DCC}_HOT_RELOAD=1` | Enable skill hot-reload |
 
 ### Multiple DCC instances


### PR DESCRIPTION
## Summary

- Rewrite transport guide & API docs (EN + ZH) for DccLinkFrame, IpcChannelAdapter, GracefulIpcChannelAdapter, SocketServerAdapter
- Update all markdown files (AGENTS.md, CLAUDE.md, GEMINI.md, CODEBUDDY.md, README, CONTRIBUTING, etc.) to remove stale references to removed v0.14 transport APIs (TransportManager, FramedChannel, IpcListener, connect_ipc, CircuitBreaker, ConnectionPool, RoutingStrategy, ListenerHandle)
- Update llms.txt / llms-full.txt with new transport API reference and code patterns
- Fix architecture.md, faq.md, what-is-dcc-mcp-core.md, mcp-skills-integration.md, gateway-election.md (EN + ZH)
- Update SKILL.md, integration-guide.md
- Fix duplicate FrameRange in `__init__.py` `__all__`
- Bump VitePress version stamp to v0.14.1

## Test plan

- [ ] Verify `llms.txt` and `llms-full.txt` have no references to removed symbols (TransportManager, FramedChannel, etc.)
- [ ] Verify transport guide and API docs show correct DccLink API
- [ ] Verify README code examples are runnable
- [ ] Verify no stale `~177 symbols` references remain (should be `~180`)
- [ ] CI passes