### PR TITLE
feat(http): make gateway backend timeout configurable (#314)

### DIFF
--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -142,6 +142,19 @@ pub struct McpHttpConfig {
     /// success. Applied per attempt; up to 5 attempts are made. Set to 0
     /// to disable self-probing (not recommended). Default: 200.
     pub self_probe_timeout_ms: u64,
+
+    /// Per-backend request timeout (milliseconds) used by the gateway when
+    /// fanning out `tools/list` / `tools/call` to live DCC instances.
+    ///
+    /// Default: `10_000` (10 seconds). Increase for DCC workflows that
+    /// routinely produce long-running calls (e.g. heavy scene import,
+    /// simulation bake) so the gateway does not reply with a transport
+    /// timeout error while the backend is still legitimately working.
+    ///
+    /// Only the gateway fan-out uses this value — per-instance servers
+    /// bound to a DCC execute inline and are governed by
+    /// [`Self::request_timeout_ms`] instead. Fixes issue #314.
+    pub backend_timeout_ms: u64,
 }
 
 impl McpHttpConfig {
@@ -168,6 +181,7 @@ impl McpHttpConfig {
             bare_tool_names: true,
             spawn_mode: ServerSpawnMode::Ambient,
             self_probe_timeout_ms: 200,
+            backend_timeout_ms: 10_000,
         }
     }
 
@@ -261,6 +275,17 @@ impl McpHttpConfig {
     /// parent runtime has no active driver thread.
     pub fn with_spawn_mode(mut self, mode: ServerSpawnMode) -> Self {
         self.spawn_mode = mode;
+        self
+    }
+
+    /// Builder: override the per-backend gateway fan-out timeout (issue #314).
+    ///
+    /// Default: `10_000` ms. Raise this for workflows whose backend tools
+    /// legitimately run longer than 10 seconds (scene import, simulation
+    /// bake, large USD composition) so the gateway does not short-circuit
+    /// them with a transport timeout error.
+    pub fn with_backend_timeout_ms(mut self, ms: u64) -> Self {
+        self.backend_timeout_ms = ms;
         self
     }
 }

--- a/crates/dcc-mcp-http/src/gateway/aggregator.rs
+++ b/crates/dcc-mcp-http/src/gateway/aggregator.rs
@@ -28,11 +28,6 @@ use super::tools::{
 use crate::protocol::{TOOLS_LIST_PAGE_SIZE, decode_cursor, encode_cursor};
 use dcc_mcp_transport::discovery::types::ServiceEntry;
 
-/// Per-backend request timeout for fan-out calls.
-///
-/// Kept short so a single unresponsive instance does not stall aggregation.
-const BACKEND_TIMEOUT: Duration = Duration::from_secs(10);
-
 /// Build the unified `tools/list` result by aggregating every live backend.
 ///
 /// Tool order:
@@ -56,9 +51,10 @@ pub async fn aggregate_tools_list(gs: &GatewayState, cursor: Option<&str>) -> Va
     // Tier 3: fan out to every live backend.
     let instances = live_backends(gs).await;
     let client = &gs.http_client;
+    let backend_timeout = gs.backend_timeout;
     let futs = instances.iter().map(|entry| async move {
         let url = format!("http://{}:{}/mcp", entry.host, entry.port);
-        let backend_tools = fetch_tools(client, &url, BACKEND_TIMEOUT).await;
+        let backend_tools = fetch_tools(client, &url, backend_timeout).await;
         (entry.instance_id, entry.dcc_type.clone(), backend_tools)
     });
     let results = join_all(futs).await;
@@ -162,7 +158,7 @@ pub async fn route_tools_call(
         Some(args.clone()),
         meta.cloned(),
         request_id,
-        BACKEND_TIMEOUT,
+        gs.backend_timeout,
     )
     .await
     {
@@ -221,7 +217,7 @@ async fn skill_mgmt_dispatch(gs: &GatewayState, tool: &str, args: &Value) -> (St
                         Some(forward_args),
                         None,
                         None,
-                        BACKEND_TIMEOUT,
+                        gs.backend_timeout,
                     )
                     .await
                     {
@@ -265,6 +261,7 @@ async fn skill_mgmt_dispatch(gs: &GatewayState, tool: &str, args: &Value) -> (St
             }
 
             let client = &gs.http_client;
+            let backend_timeout = gs.backend_timeout;
             let params = json!({"name": tool, "arguments": args});
             let futs = targets.iter().map(|entry| {
                 let url = format!("http://{}:{}/mcp", entry.host, entry.port);
@@ -276,7 +273,7 @@ async fn skill_mgmt_dispatch(gs: &GatewayState, tool: &str, args: &Value) -> (St
                         "tools/call",
                         Some(params),
                         None,
-                        BACKEND_TIMEOUT,
+                        backend_timeout,
                     )
                     .await;
                     (entry.instance_id, entry.dcc_type.clone(), res)
@@ -423,6 +420,7 @@ pub async fn compute_tools_fingerprint(
     >,
     stale_timeout: Duration,
     http_client: &reqwest::Client,
+    backend_timeout: Duration,
 ) -> String {
     let instances: Vec<ServiceEntry> = {
         let reg = registry.read().await;
@@ -442,7 +440,7 @@ pub async fn compute_tools_fingerprint(
 
     let futs = instances.iter().map(|entry| async move {
         let url = format!("http://{}:{}/mcp", entry.host, entry.port);
-        let tools = fetch_tools(http_client, &url, BACKEND_TIMEOUT).await;
+        let tools = fetch_tools(http_client, &url, backend_timeout).await;
         (entry.instance_id, tools)
     });
     let results = join_all(futs).await;

--- a/crates/dcc-mcp-http/src/gateway/mod.rs
+++ b/crates/dcc-mcp-http/src/gateway/mod.rs
@@ -190,6 +190,7 @@ async fn start_gateway_tasks(
     listener: tokio::net::TcpListener,
     registry: Arc<RwLock<FileRegistry>>,
     stale_timeout: Duration,
+    backend_timeout: Duration,
     server_name: String,
     server_version: String,
     sentinel_key: ServiceKey,
@@ -332,6 +333,7 @@ async fn start_gateway_tasks(
                 &reg_tools,
                 stale_timeout,
                 &http_client_tools,
+                backend_timeout,
             )
             .await;
 
@@ -359,6 +361,7 @@ async fn start_gateway_tasks(
     let gw_state = GatewayState {
         registry,
         stale_timeout,
+        backend_timeout,
         server_name,
         server_version,
         http_client,
@@ -494,6 +497,10 @@ pub struct GatewayConfig {
     ///
     /// Default: `120` seconds (12 × 10-second retry intervals).
     pub challenger_timeout_secs: u64,
+    /// Per-backend request timeout (milliseconds) used for fan-out calls
+    /// from the gateway to each live DCC instance. Default: `10_000`.
+    /// Issue #314.
+    pub backend_timeout_ms: u64,
 }
 
 impl Default for GatewayConfig {
@@ -507,6 +514,7 @@ impl Default for GatewayConfig {
             server_version: env!("CARGO_PKG_VERSION").to_string(),
             registry_dir: None,
             challenger_timeout_secs: 120,
+            backend_timeout_ms: 10_000,
         }
     }
 }
@@ -695,6 +703,7 @@ impl GatewayRunner {
         &self,
     ) -> Result<ElectionOutcome, Box<dyn std::error::Error + Send + Sync>> {
         let stale_timeout = Duration::from_secs(self.config.stale_timeout_secs);
+        let backend_timeout = Duration::from_millis(self.config.backend_timeout_ms);
         let own_version = self.config.server_version.clone();
 
         match try_bind_port_opt(&self.config.host, self.config.gateway_port).await {
@@ -720,6 +729,7 @@ impl GatewayRunner {
                     listener,
                     self.registry.clone(),
                     stale_timeout,
+                    backend_timeout,
                     format!("{} (gateway)", self.config.server_name),
                     own_version.clone(),
                     sentinel_key,
@@ -816,6 +826,7 @@ impl GatewayRunner {
         let gw_ver = gw_version.to_owned();
         let registry = self.registry.clone();
         let stale_timeout = Duration::from_secs(self.config.stale_timeout_secs);
+        let backend_timeout = Duration::from_millis(self.config.backend_timeout_ms);
         let server_name = self.config.server_name.clone();
         let timeout_secs = self.config.challenger_timeout_secs;
 
@@ -872,6 +883,7 @@ impl GatewayRunner {
                         listener,
                         registry.clone(),
                         stale_timeout,
+                        backend_timeout,
                         format!("{server_name} (gateway)"),
                         own_ver.clone(),
                         sentinel_key,

--- a/crates/dcc-mcp-http/src/gateway/state.rs
+++ b/crates/dcc-mcp-http/src/gateway/state.rs
@@ -22,6 +22,13 @@ pub struct PendingCall {
 pub struct GatewayState {
     pub registry: Arc<RwLock<FileRegistry>>,
     pub stale_timeout: Duration,
+    /// Per-backend request timeout for gateway fan-out calls (issue #314).
+    ///
+    /// Kept short by default (10s) so a single unresponsive instance does
+    /// not stall aggregation, but configurable via
+    /// [`McpHttpConfig::backend_timeout_ms`] for workflows with legitimately
+    /// long-running backend tools.
+    pub backend_timeout: Duration,
     pub server_name: String,
     /// The version string of this gateway instance (e.g. `"0.12.29"`).
     pub server_version: String,
@@ -127,6 +134,7 @@ mod tests {
         GatewayState {
             registry: reg,
             stale_timeout: Duration::from_secs(30),
+            backend_timeout: Duration::from_secs(10),
             server_name: "test".into(),
             server_version: "0.13.2".into(),
             http_client: reqwest::Client::new(),

--- a/crates/dcc-mcp-http/src/python/mod.rs
+++ b/crates/dcc-mcp-http/src/python/mod.rs
@@ -27,13 +27,14 @@ pub struct PyMcpHttpConfig {
 impl PyMcpHttpConfig {
     /// Create a new config. ``port=0`` binds to any available port.
     #[new]
-    #[pyo3(signature = (port=8765, server_name=None, server_version=None, enable_cors=false, request_timeout_ms=30000))]
+    #[pyo3(signature = (port=8765, server_name=None, server_version=None, enable_cors=false, request_timeout_ms=30000, backend_timeout_ms=10_000))]
     fn new(
         port: u16,
         server_name: Option<String>,
         server_version: Option<String>,
         enable_cors: bool,
         request_timeout_ms: u64,
+        backend_timeout_ms: u64,
     ) -> Self {
         let mut cfg = McpHttpConfig::new(port);
         if let Some(name) = server_name {
@@ -44,6 +45,7 @@ impl PyMcpHttpConfig {
         }
         cfg.enable_cors = enable_cors;
         cfg.request_timeout_ms = request_timeout_ms;
+        cfg.backend_timeout_ms = backend_timeout_ms;
         // Issue #303: PyO3-embedded hosts (Maya on Windows etc.) cannot
         // rely on shared tokio worker threads to drive the accept loop
         // after `block_on` returns. Default to `Dedicated` so the listener
@@ -271,6 +273,22 @@ impl PyMcpHttpConfig {
     #[setter]
     fn set_bare_tool_names(&mut self, enabled: bool) {
         self.inner.bare_tool_names = enabled;
+    }
+
+    /// Per-backend gateway fan-out timeout in milliseconds (issue #314).
+    ///
+    /// Default: ``10_000`` (10 seconds). Raise this for DCC workflows that
+    /// legitimately run backend tools longer than 10 seconds (scene import,
+    /// simulation bake, large USD composition) to avoid spurious transport
+    /// timeout errors on the gateway fan-out path.
+    #[getter]
+    fn backend_timeout_ms(&self) -> u64 {
+        self.inner.backend_timeout_ms
+    }
+
+    #[setter]
+    fn set_backend_timeout_ms(&mut self, ms: u64) {
+        self.inner.backend_timeout_ms = ms;
     }
 
     fn __repr__(&self) -> String {

--- a/crates/dcc-mcp-http/src/server.rs
+++ b/crates/dcc-mcp-http/src/server.rs
@@ -259,6 +259,7 @@ impl McpHttpServer {
                 server_version: self.config.server_version.clone(),
                 registry_dir: self.config.registry_dir.clone(),
                 challenger_timeout_secs: 120,
+                backend_timeout_ms: self.config.backend_timeout_ms,
             };
 
             match GatewayRunner::new(gw_cfg) {

--- a/crates/dcc-mcp-http/src/tests.rs
+++ b/crates/dcc-mcp-http/src/tests.rs
@@ -2523,6 +2523,7 @@ mod gateway_tests {
         GatewayState {
             registry: Arc::new(RwLock::new(registry)),
             stale_timeout: Duration::from_secs(30),
+            backend_timeout: Duration::from_secs(10),
             server_name: "test-gateway".to_string(),
             server_version: "0.1.0".to_string(),
             http_client: reqwest::Client::new(),

--- a/crates/dcc-mcp-http/tests/backend_timeout.rs
+++ b/crates/dcc-mcp-http/tests/backend_timeout.rs
@@ -1,0 +1,222 @@
+//! Regression coverage for issue #314 — configurable gateway backend timeout.
+//!
+//! Before this fix the gateway hard-coded a 10-second per-backend timeout
+//! (`BACKEND_TIMEOUT` in `gateway/aggregator.rs`), which short-circuited any
+//! legitimately long-running DCC tool (scene import, USD composition,
+//! simulation bake) with a transport-level timeout error. The fix promoted
+//! the value to [`McpHttpConfig::backend_timeout_ms`], threaded through
+//! [`GatewayConfig`] → [`GatewayState::backend_timeout`] → every fan-out
+//! helper in the aggregator.
+//!
+//! These tests assert three things:
+//!
+//! 1. The config plumbing actually carries the value end-to-end.
+//! 2. A gateway configured with a *long* backend timeout tolerates a backend
+//!    response that would have tripped the old hard-coded 10-second ceiling.
+//! 3. A gateway configured with a *short* backend timeout still fails fast,
+//!    proving the value is honoured (not silently ignored).
+//!
+//! The slow-backend scenarios use a tiny axum mock that sleeps before
+//! replying, with timeouts scaled to milliseconds so the suite finishes in
+//! well under a second on CI.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use axum::{Json, Router, routing::post};
+use serde_json::{Value, json};
+use tokio::sync::{RwLock, broadcast, watch};
+
+use dcc_mcp_http::config::McpHttpConfig;
+use dcc_mcp_http::gateway::aggregator::{aggregate_tools_list, compute_tools_fingerprint};
+use dcc_mcp_http::gateway::state::GatewayState;
+use dcc_mcp_transport::discovery::file_registry::FileRegistry;
+use dcc_mcp_transport::discovery::types::ServiceEntry;
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/// Build a `GatewayState` with the given backend timeout, using a fresh
+/// empty `FileRegistry`. Returns the state plus the registry handle so the
+/// caller can register mock backends against it.
+async fn make_state(
+    backend_timeout: Duration,
+) -> (GatewayState, Arc<RwLock<FileRegistry>>, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
+    let (yield_tx, _) = watch::channel(false);
+    let (events_tx, _) = broadcast::channel::<String>(16);
+
+    let state = GatewayState {
+        registry: registry.clone(),
+        stale_timeout: Duration::from_secs(30),
+        backend_timeout,
+        server_name: "test".into(),
+        server_version: "0.0.0".into(),
+        http_client: reqwest::Client::new(),
+        yield_tx: Arc::new(yield_tx),
+        events_tx: Arc::new(events_tx),
+        protocol_version: Arc::new(RwLock::new(None)),
+        resource_subscriptions: Arc::new(RwLock::new(std::collections::HashMap::new())),
+        pending_calls: Arc::new(RwLock::new(std::collections::HashMap::new())),
+    };
+    (state, registry, dir)
+}
+
+/// Spawn a minimal MCP-shaped backend on `127.0.0.1:<random>` that sleeps
+/// for `delay` before responding to `tools/list` with a single tool. Returns
+/// the bound port so the caller can register a `ServiceEntry` pointing at it.
+async fn spawn_slow_backend(delay: Duration) -> u16 {
+    async fn handler(
+        axum::extract::State(delay): axum::extract::State<Duration>,
+        Json(req): Json<Value>,
+    ) -> Json<Value> {
+        tokio::time::sleep(delay).await;
+        let id = req.get("id").cloned().unwrap_or(Value::Null);
+        Json(json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": {
+                "tools": [ {
+                    "name": "slow_tool",
+                    "description": "slow",
+                    "inputSchema": { "type": "object" }
+                } ]
+            }
+        }))
+    }
+
+    let app = Router::new().route("/mcp", post(handler)).with_state(delay);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.ok();
+    });
+    // Give the listener a beat to start accepting before the test dials it.
+    tokio::time::sleep(Duration::from_millis(25)).await;
+    port
+}
+
+async fn register_backend(registry: &Arc<RwLock<FileRegistry>>, port: u16) {
+    let reg = registry.read().await;
+    let entry = ServiceEntry::new("maya", "127.0.0.1", port);
+    reg.register(entry).unwrap();
+}
+
+// ── Config plumbing ────────────────────────────────────────────────────────
+
+#[test]
+fn mcp_http_config_default_backend_timeout_is_ten_seconds() {
+    let cfg = McpHttpConfig::new(8765);
+    assert_eq!(
+        cfg.backend_timeout_ms, 10_000,
+        "default backend_timeout_ms must remain 10_000 for backwards compatibility"
+    );
+}
+
+#[test]
+fn mcp_http_config_with_backend_timeout_ms_is_fluent() {
+    let cfg = McpHttpConfig::new(8765).with_backend_timeout_ms(120_000);
+    assert_eq!(cfg.backend_timeout_ms, 120_000);
+}
+
+// ── Runtime behaviour ──────────────────────────────────────────────────────
+
+/// Issue #314 acceptance: a gateway configured with a long backend timeout
+/// must tolerate a backend that takes longer than the legacy 10-second
+/// ceiling to respond. We scale the scenario down by 1000× for test speed
+/// (ms instead of seconds) while preserving the "timeout > backend delay"
+/// invariant the user observes in production.
+#[tokio::test]
+async fn aggregate_tools_list_respects_long_backend_timeout() {
+    // Backend takes ~250ms — would trip any timeout ≤ 200ms, passes at 1s.
+    let port = spawn_slow_backend(Duration::from_millis(250)).await;
+    let (state, registry, _tmp) = make_state(Duration::from_secs(1)).await;
+    register_backend(&registry, port).await;
+
+    let started = Instant::now();
+    let result = aggregate_tools_list(&state, None).await;
+    let elapsed = started.elapsed();
+
+    let tools = result
+        .get("tools")
+        .and_then(Value::as_array)
+        .expect("tools array");
+    // Tier 1 (meta) + Tier 2 (skill mgmt) + 1 backend tool = non-empty, and
+    // at least one tool must come from the backend (encoded name contains `.`).
+    let has_backend_tool = tools.iter().any(|t| {
+        t.get("name")
+            .and_then(Value::as_str)
+            .map(|n| n.contains("slow_tool"))
+            .unwrap_or(false)
+    });
+    assert!(
+        has_backend_tool,
+        "backend tool should be present when backend_timeout > backend delay; got tools={tools:#?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "aggregation should return as soon as the backend replies, not at the timeout (elapsed={elapsed:?})"
+    );
+}
+
+/// Complementary case: a gateway with a *shorter* backend timeout than the
+/// backend's response time must drop the backend's contribution (fetch_tools
+/// swallows the error and returns an empty vec). This proves the timeout
+/// value is actually honoured rather than ignored.
+#[tokio::test]
+async fn aggregate_tools_list_drops_backend_when_timeout_is_exceeded() {
+    let port = spawn_slow_backend(Duration::from_millis(400)).await;
+    let (state, registry, _tmp) = make_state(Duration::from_millis(50)).await;
+    register_backend(&registry, port).await;
+
+    let result = aggregate_tools_list(&state, None).await;
+    let tools = result
+        .get("tools")
+        .and_then(Value::as_array)
+        .expect("tools array");
+    assert!(
+        !tools.iter().any(|t| {
+            t.get("name")
+                .and_then(Value::as_str)
+                .map(|n| n.contains("slow_tool"))
+                .unwrap_or(false)
+        }),
+        "backend tool must not appear when backend_timeout < backend delay; got tools={tools:#?}"
+    );
+}
+
+/// `compute_tools_fingerprint` is the other consumer of the backend timeout
+/// (it drives `tools/list_changed` SSE notifications). Regression-guard the
+/// parameter plumbing so a future refactor cannot silently drop it.
+#[tokio::test]
+async fn compute_tools_fingerprint_honours_backend_timeout() {
+    let port = spawn_slow_backend(Duration::from_millis(250)).await;
+    let (_state, registry, _tmp) = make_state(Duration::from_secs(1)).await;
+    register_backend(&registry, port).await;
+
+    let client = reqwest::Client::new();
+
+    let short = compute_tools_fingerprint(
+        &registry,
+        Duration::from_secs(30),
+        &client,
+        Duration::from_millis(25),
+    )
+    .await;
+    assert!(
+        short.is_empty(),
+        "short timeout should yield empty fingerprint (backend dropped); got {short:?}"
+    );
+
+    let long = compute_tools_fingerprint(
+        &registry,
+        Duration::from_secs(30),
+        &client,
+        Duration::from_secs(1),
+    )
+    .await;
+    assert!(
+        long.contains("slow_tool"),
+        "long timeout should let the backend's tool into the fingerprint; got {long:?}"
+    );
+}

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -534,6 +534,7 @@ async fn main() -> anyhow::Result<()> {
         server_version: env!("CARGO_PKG_VERSION").to_string(),
         registry_dir: registry_dir_path,
         challenger_timeout_secs: 120,
+        backend_timeout_ms: 10_000,
     };
 
     let runner = GatewayRunner::new(gateway_cfg)

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -3669,6 +3669,10 @@ class McpHttpConfig:
         server_version: Version reported in MCP ``initialize`` response.
         enable_cors: Enable CORS headers (for browser clients).
         request_timeout_ms: Request timeout in milliseconds.
+        backend_timeout_ms: Per-backend gateway fan-out timeout in
+            milliseconds. Default: ``10_000``. Raise this for DCC workflows
+            whose backend tools run legitimately longer than 10 s
+            (issue #314).
 
     Example::
 
@@ -3684,6 +3688,7 @@ class McpHttpConfig:
         server_version: str | None = None,
         enable_cors: bool = False,
         request_timeout_ms: int = 30000,
+        backend_timeout_ms: int = 10000,
     ) -> None: ...
     @property
     def port(self) -> int: ...
@@ -3737,6 +3742,16 @@ class McpHttpConfig:
         ...
     @bare_tool_names.setter
     def bare_tool_names(self, enabled: bool) -> None: ...
+    @property
+    def backend_timeout_ms(self) -> int:
+        """Per-backend gateway fan-out timeout in milliseconds (#314).
+
+        Used by the gateway when dispatching ``tools/list`` / ``tools/call``
+        to each live DCC instance. Default: ``10_000`` (10 seconds).
+        """
+        ...
+    @backend_timeout_ms.setter
+    def backend_timeout_ms(self, ms: int) -> None: ...
     def __repr__(self) -> str: ...
 
 class McpServerHandle:

--- a/tests/test_http_config.py
+++ b/tests/test_http_config.py
@@ -1,0 +1,48 @@
+"""Tests for :class:`dcc_mcp_core.McpHttpConfig` Python bindings.
+
+Issue #314 — the gateway's per-backend fan-out timeout must be configurable
+from Python so downstream DCC adapters (Maya/Blender/Houdini…) can extend
+it for workflows that legitimately run longer than the legacy 10-second
+ceiling (scene import, simulation bake, USD composition).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dcc_mcp_core import McpHttpConfig
+
+
+def test_backend_timeout_ms_has_sensible_default() -> None:
+    """The pre-#314 hard-coded value was ``Duration::from_secs(10)``.
+
+    Leaving ``McpHttpConfig(...)`` unconfigured must preserve that behaviour
+    so existing deployments do not silently change after upgrading.
+    """
+    cfg = McpHttpConfig(port=8765)
+    assert cfg.backend_timeout_ms == 10_000
+
+
+def test_backend_timeout_ms_constructor_kwarg() -> None:
+    """Long-running DCC tools (scene import, sim bake) need a larger budget."""
+    cfg = McpHttpConfig(port=8765, backend_timeout_ms=120_000)
+    assert cfg.backend_timeout_ms == 120_000
+
+
+def test_backend_timeout_ms_setter_round_trips() -> None:
+    """The property must be mutable so config objects can be tuned after
+    construction (e.g. from a user-supplied TOML/JSON config file).
+    """
+    cfg = McpHttpConfig(port=8765)
+    cfg.backend_timeout_ms = 45_000
+    assert cfg.backend_timeout_ms == 45_000
+
+
+@pytest.mark.parametrize("value", [0, 1, 10_000, 120_000, 3_600_000])
+def test_backend_timeout_ms_accepts_wide_range(value: int) -> None:
+    """Guard against accidental upper-bound clamps. ``0`` disables the
+    per-request timeout entirely (reqwest semantics); very large values
+    are valid for batch-style backends.
+    """
+    cfg = McpHttpConfig(port=8765, backend_timeout_ms=value)
+    assert cfg.backend_timeout_ms == value


### PR DESCRIPTION
## Summary

- Replaces hard-coded `Duration::from_secs(10)` gateway `BACKEND_TIMEOUT` with a configurable `backend_timeout_ms` field on `McpHttpConfig`.
- Threads the value through `GatewayConfig` → `GatewayState` → `aggregator.rs` (5 call sites including `compute_tools_fingerprint`).
- Exposes `McpHttpConfig(backend_timeout_ms=120000)` in Python with getter/setter property; defaults to `10_000` so behaviour is unchanged when unset.

## Test plan

- [x] `cargo test -p dcc-mcp-http --test backend_timeout` — 5 integration tests (default, builder, long-timeout tolerates slow backend, short-timeout drops backend, fingerprint honours param).
- [x] `cargo test -p dcc-mcp-http --lib` — 152 passed (no regressions).
- [x] `pytest tests/test_http_config.py -v` — 8 passed including a parametrized range `[0, 1, 10_000, 120_000, 3_600_000]`.
- [x] `cargo check --workspace --features python-bindings` clean.
- [x] `cargo clippy -p dcc-mcp-http --no-deps` — no new warnings.
- [x] `cargo fmt --all` applied.

## Notes

Test timing uses scaled real-time (250 ms backend, 1 s / 50 ms timeouts) instead of `tokio::time::pause()` because the network path goes through `reqwest` which is not controlled by tokio's paused clock. This preserves the invariant while keeping tests under 300 ms.

Closes #314
