### PR TITLE
docs: document DCC main-thread affinity and long-running job patterns (#315)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,8 +120,18 @@ Need to interact with DCC?
 → Frame type: `DccLinkFrame(msg_type, seq, body)`
 
 **DCC main-thread safety (Maya cmds, bpy, hou…)?**
-→ [`docs/guide/getting-started.md`](docs/guide/getting-started.md) (DeferredExecutor section)
+→ [`docs/guide/dcc-thread-safety.md`](docs/guide/dcc-thread-safety.md) — full guide (chunking, forbidden patterns, per-DCC defer primitives)
+→ [`docs/adr/002-dcc-main-thread-affinity.md`](docs/adr/002-dcc-main-thread-affinity.md) — architectural rationale
+→ [`docs/guide/getting-started.md`](docs/guide/getting-started.md) (DeferredExecutor section) — minimal example
 → `from dcc_mcp_core._core import DeferredExecutor` (not yet in public `__init__`)
+
+### Thread Safety (quick rules — see `docs/guide/dcc-thread-safety.md`)
+
+- All scene-mutating calls go through `DeferredExecutor` — never call `maya.cmds` / `bpy.ops` / `hou.*` / `pymxs.runtime` from a Tokio worker or `threading.Thread`.
+- Pump the queue via `poll_pending_bounded(max=8)` from the DCC's defer primitive (`maya.utils.executeDeferred`, `bpy.app.timers.register`, `hou.ui.addEventLoopCallback`). Never `poll_pending()` in production — it drains unboundedly and freezes the UI under bursts.
+- Long-running jobs must be chunked into per-tick units with cooperative checkpoints (see #329 `check_cancelled()`, #332 `@chunked_job`).
+- Forbidden inside a `DccTaskFn`: `time.sleep`, spawning OS threads for scene ops, blocking I/O (`requests.get`, sync DB, large file reads). Do I/O on the Tokio worker, then defer only the scene call.
+- Source of truth: `crates/dcc-mcp-http/src/executor.rs` (`DeferredExecutor`), `crates/dcc-mcp-process/src/dispatcher.rs` (`ThreadAffinity`, `JobRequest`, `HostDispatcher`).
 
 **Skills hot-reload during development?**
 → `python/dcc_mcp_core/hotreload.py` — `DccSkillHotReloader`

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -60,6 +60,7 @@ export default defineConfig({
               items: [
                 { text: 'Architecture', link: '/guide/architecture' },
                 { text: 'Custom Skills', link: '/guide/custom-actions' },
+                { text: 'DCC Thread Safety', link: '/guide/dcc-thread-safety' },
                 { text: 'Process Management', link: '/guide/process' },
                 { text: 'Sandbox & Security', link: '/guide/sandbox' },
                 { text: 'Shared Memory', link: '/guide/shm' },
@@ -143,6 +144,7 @@ export default defineConfig({
               items: [
                 { text: '架构设计', link: '/zh/guide/architecture' },
                 { text: '自定义 Skill', link: '/zh/guide/custom-actions' },
+                { text: 'DCC 线程安全', link: '/zh/guide/dcc-thread-safety' },
                 { text: '进程管理', link: '/zh/guide/process' },
                 { text: '沙箱与安全', link: '/zh/guide/sandbox' },
                 { text: '共享内存', link: '/zh/guide/shm' },

--- a/docs/adr/002-dcc-main-thread-affinity.md
+++ b/docs/adr/002-dcc-main-thread-affinity.md
@@ -1,0 +1,139 @@
+# ADR 002 — DCC Main-Thread Affinity
+
+- **Status**: Accepted
+- **Date**: 2026-04-21
+- **Related**: issue #315, #329 (`check_cancelled()`), #332 (`@chunked_job`)
+- **Implements**: [`docs/guide/dcc-thread-safety.md`](../guide/dcc-thread-safety.md)
+
+## Context
+
+`dcc-mcp-core` must expose DCC (Digital Content Creation) scene APIs to
+external AI agents over MCP Streamable HTTP. HTTP requests arrive on Tokio
+worker threads, but every DCC host we target — Maya, Blender, Houdini,
+3ds Max — enforces a hard contract that scene-mutating calls are only legal
+on the host's **main thread**.
+
+The contract is not advisory:
+
+- Maya's `maya.cmds` / `OpenMaya` / PyMel are not thread-safe; the reference
+  guide explicitly directs off-thread code through
+  `maya.utils.executeDeferred`.
+- Blender's `bpy` module asserts main-thread access and crashes the host
+  otherwise; the supported escape hatch is `bpy.app.timers.register`.
+- Houdini's `hou` module requires `hou.ui.addEventLoopCallback` for any
+  scene mutation from a non-main thread.
+- 3ds Max has no deferred primitive at all — all MAXScript / `pymxs` calls
+  must originate on the main thread. Adapters synthesize a deferred
+  primitive via a Qt single-shot timer.
+
+Violating this contract produces one of three failure modes: silent
+no-ops, memory corruption (the crash lands minutes later in unrelated
+code), or hard segfaults. None is acceptable for a library that external
+AI agents drive programmatically.
+
+This ADR is non-negotiable because it is externally imposed by each DCC's
+runtime. Our only design freedom is **how** we bridge worker threads to
+the main thread, not whether we do.
+
+## Decision
+
+Adopt a single canonical bridge for all adapters:
+
+1. **`DeferredExecutor`** owns a bounded `tokio::sync::mpsc::channel` of
+   `DccTaskFn` closures. Source of truth:
+   `crates/dcc-mcp-http/src/executor.rs`.
+2. **Tokio workers submit** tasks via `DccExecutorHandle::execute(fn)` and
+   `await` a `oneshot` reply channel. They never touch the scene API
+   directly.
+3. **The DCC main thread drains** the channel from its event loop by
+   calling `poll_pending_bounded(max=N)` from whatever deferred primitive
+   the host provides (`executeDeferred`, `bpy.app.timers`, etc.).
+4. **Long-running jobs are chunked** into per-tick units. The expected
+   chunking contract will be encoded by the `@chunked_job` decorator
+   (#332) and the `check_cancelled()` primitive (#329).
+
+The public Python surface is `DeferredExecutor(capacity=N)` with
+`.execute(callable)` and `.poll_pending_bounded(max=N)`. `poll_pending()`
+remains available but documented as a footgun (see consequences below).
+
+Job scheduling above this bridge is expressed through
+`crates/dcc-mcp-process/src/dispatcher.rs`:
+
+- `ThreadAffinity::Main` → routed through `DeferredExecutor`.
+- `ThreadAffinity::Any` → executed on Tokio workers directly.
+- `ThreadAffinity::Named(_)` → host-managed worker pool (adapter-specific).
+
+## Consequences
+
+### Positive
+
+- Exactly one thread-safety story across all adapters — easy to audit.
+- Bounded channel provides natural back-pressure when the main thread
+  falls behind.
+- The `DccTaskFn` boundary is a natural sandbox seam: every main-thread
+  call is wrapped and can be instrumented (tracing, telemetry, audit).
+
+### Negative
+
+- **Latency tax.** Every scene call pays at least one channel hop +
+  one tick of event-loop wait time. A `polySphere()` that would be
+  ~1 ms in-process becomes ~16 ms end-to-end at 60 FPS.
+- **Per-DCC callback registration.** Each adapter must wire
+  `poll_pending_bounded` into the host's deferred primitive. There is no
+  universal abstraction; 3ds Max in particular has no native defer
+  primitive and needs a Qt timer shim.
+- **`poll_pending()` is a footgun.** Unbounded drains on a main thread
+  freeze the UI under load. We keep the method because some legitimate
+  teardown paths need it, but the guide directs all production code to
+  `poll_pending_bounded(max=N)`.
+- **Long-running jobs cannot be expressed as a single `DccTaskFn`.**
+  They must be chunked and cooperatively cancellable — which forces
+  skill authors to think about scheduling. This is a feature, not a bug,
+  but it raises the floor for skill authoring.
+
+## Alternatives considered
+
+### A. Native OS threads with scene-API locks
+
+*Rejected.* The DCC scene APIs are not merely unlocked — they are
+affirmatively not thread-safe. Even a global mutex around every scene
+call does not help, because internal DCC state (undo stacks, UI redraw,
+dependency graphs) is keyed on thread-local context that only exists on
+the main thread. Adding locks would give us data races on internal state
+that we do not own and cannot fix.
+
+### B. Pure event-loop polling (no channel)
+
+*Rejected.* A `while True: poll()` loop on the main thread pegs a CPU
+core and still cannot escape the deferred-primitive constraint on hosts
+like Blender and Houdini where the host's own event loop is authoritative.
+It also precludes bounded back-pressure — the Tokio side has no way to
+signal "the main thread is overloaded, slow down."
+
+### C. Coroutine-based scheduler (asyncio on the main thread)
+
+*Rejected.* Maya, Blender, and Houdini do not expose their event loops
+as asyncio-compatible. Embedding a nested asyncio loop that yields to the
+host loop is technically possible but requires bespoke integration per
+DCC (patching `selectors`, forwarding signal handlers, etc.), and none of
+the DCC vendors support that configuration. The interop cost exceeds the
+benefit of the ergonomic gain.
+
+### D. Rendering through a separate out-of-process DCC worker
+
+*Deferred, not rejected.* For truly heavyweight jobs (multi-hour batch
+renders) we may eventually launch a headless DCC subprocess and proxy
+results back. That is a feature of the process layer, not a replacement
+for main-thread affinity in the interactive case, and is out of scope
+for this ADR.
+
+## References
+
+- [`docs/guide/dcc-thread-safety.md`](../guide/dcc-thread-safety.md) —
+  usage guide for adapter and skill authors.
+- `crates/dcc-mcp-http/src/executor.rs` — `DeferredExecutor`
+  implementation.
+- `crates/dcc-mcp-process/src/dispatcher.rs` — `ThreadAffinity`,
+  `JobRequest`, `HostDispatcher` trait.
+- [`skills/integration-guide.md`](https://github.com/loonghao/dcc-mcp-core/blob/main/skills/integration-guide.md)
+  — per-DCC bridge patterns.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,18 @@
+# Architecture Decision Records (ADR)
+
+This directory captures the non-reversible architectural decisions that shape
+`dcc-mcp-core`. Each record is a short document written at the time the
+decision was made, preserved as-is so that future contributors can understand
+the trade-offs that were considered.
+
+Format: [MADR-style](https://adr.github.io/madr/) — Status / Context /
+Decision / Consequences / Alternatives considered.
+
+| #   | Title                                                              | Status   |
+| --- | ------------------------------------------------------------------ | -------- |
+| 001 | *(reserved — not yet written)*                                     | —        |
+| 002 | [DCC Main-Thread Affinity](./002-dcc-main-thread-affinity.md)      | Accepted |
+
+> Numbering is strictly sequential and never reused. ADR 001 is reserved for
+> the first historical record; filling it in is tracked separately from any
+> individual feature PR.

--- a/docs/guide/dcc-thread-safety.md
+++ b/docs/guide/dcc-thread-safety.md
@@ -1,0 +1,225 @@
+# DCC Thread Safety
+
+> **Audience**: adapter authors (`dcc-mcp-maya`, `dcc-mcp-blender`, ...) and
+> skill authors who run long computations inside a DCC host.
+>
+> **TL;DR**: every scene-mutating call must run on the DCC's **main thread**.
+> `DeferredExecutor` is the only supported bridge between Tokio HTTP workers
+> and that main thread. Long-running jobs must be chunked into per-tick units
+> and must use `poll_pending_bounded(max=N)`, never `poll_pending()`.
+
+## Why main-thread affinity exists
+
+Every major DCC host enforces main-thread-only access to its scene-mutating
+API. The runtime does **not** protect you with locks — calling those APIs from
+a worker thread corrupts scene state, segfaults the host, or silently does
+nothing. Each DCC ships a canonical "defer to the main thread" primitive:
+
+| DCC | Main-thread-only API | Canonical defer primitive |
+|------|-----------------------|---------------------------|
+| Maya | `maya.cmds`, `OpenMaya`, `pymel` | `maya.utils.executeDeferred(fn)` / `maya.cmds.evalDeferred("expr")` |
+| Blender | `bpy.ops`, `bpy.data`, `bpy.context` | `bpy.app.timers.register(fn, first_interval=0.0)` |
+| Houdini | `hou.*` (scene graph, SOPs, HDAs) | `hou.ui.addEventLoopCallback(fn)` |
+| 3ds Max | `MaxPlus`, `pymxs.runtime`, MAXScript | `pymxs.runtime.execute("...")` only from main thread (no deferred primitive; use a Qt singleshot timer) |
+
+These primitives all share the same contract:
+
+1. The callable is queued.
+2. The DCC event loop invokes it from the main thread at the next safe tick.
+3. The callable runs to completion **synchronously** and **blocks the UI**.
+
+Point (3) is why this guide exists: the moment your callable takes more than
+~16 ms, the DCC UI stutters; beyond a few hundred ms, the host appears frozen.
+
+## How `DeferredExecutor` bridges Tokio workers to the main thread
+
+`McpHttpServer` accepts HTTP requests on Tokio worker threads. The worker
+must **not** touch the scene API directly — instead it submits a task through
+`DeferredExecutor`, which parks the task on an `mpsc::channel` and returns a
+future. The DCC event loop drains that channel on the main thread.
+
+```text
+   Tokio worker (HTTP handler)                DCC main thread
+   ───────────────────────────                ─────────────────
+   handle.execute(task) ──── mpsc::channel ──► poll_pending_bounded(max=8)
+           │                      (bounded)            │
+           │                                           │ run task_fn()
+           ▼                                           ▼
+   await oneshot ◄──────────── oneshot::channel ── send(result)
+```
+
+The Rust source of truth for this bridge is small enough to read in one sit:
+
+```rust
+// crates/dcc-mcp-http/src/executor.rs (L23-L111)
+use std::sync::Arc;
+use tokio::sync::{mpsc, oneshot};
+
+/// A boxed async-compatible task that runs on the DCC main thread.
+pub type DccTaskFn = Box<dyn FnOnce() -> String + Send + 'static>;
+// ...
+impl DeferredExecutor {
+    pub fn poll_pending(&mut self) -> usize { /* drain all */ }
+    pub fn poll_pending_bounded(&mut self, max: usize) -> usize { /* drain <= max */ }
+}
+```
+
+The job-dispatcher layer that higher-level adapters implement lives in:
+
+```rust
+// crates/dcc-mcp-process/src/dispatcher.rs (L1-L166)
+pub enum ThreadAffinity { Main, Named(&'static str), Any }
+pub struct JobRequest { /* request_id, affinity, timeout_ms, task */ }
+pub trait HostDispatcher {
+    fn submit(&self, req: JobRequest) -> oneshot::Receiver<ActionOutcome>;
+    fn supported(&self) -> &[ThreadAffinity];
+    fn capabilities(&self) -> HostCapabilities;
+}
+```
+
+When a skill tool is marked `ThreadAffinity::Main`, the adapter routes it
+through `DeferredExecutor`; `ThreadAffinity::Any` jobs run on Tokio workers
+directly.
+
+### Python usage
+
+```python
+from dcc_mcp_core._core import DeferredExecutor  # not yet in public __init__
+
+executor = DeferredExecutor(capacity=16)
+
+# From any thread (e.g. MCP HTTP handler):
+executor.execute(lambda: maya.cmds.polySphere(radius=1.0))
+
+# In the DCC idle callback:
+executor.poll_pending_bounded(max=8)  # bounded per tick — see below
+```
+
+## Rules for long-running jobs
+
+A "long-running job" is anything that cannot complete inside one DCC tick
+(~16 ms at 60 FPS, ~33 ms at 30 FPS). Examples: playblast, batch render,
+thousands of scene-graph edits, USD composition, heavy geometry generation.
+
+Three non-negotiable rules:
+
+### 1. Chunk work into per-tick units
+
+Render one frame per timer tick, not all frames in one call. Process
+geometry in batches of N primitives, not the whole mesh. The chunk size
+should leave the DCC at least 50 % of each tick for the UI.
+
+```python
+# Good: one frame per Blender timer tick
+frame_iter = iter(range(1, 241))
+
+def render_next():
+    try:
+        frame = next(frame_iter)
+    except StopIteration:
+        return None  # unregister timer
+    bpy.context.scene.frame_set(frame)
+    bpy.ops.render.render(write_still=True)
+    return 0.0  # reschedule immediately
+
+bpy.app.timers.register(render_next)
+```
+
+### 2. Cooperative checkpoints
+
+Between chunks, check a cancellation flag and yield control back to the
+DCC. See [issue #329 — `check_cancelled()`](https://github.com/loonghao/dcc-mcp-core/issues/329)
+for the planned cooperative-cancellation primitive.
+
+```python
+for batch in chunks(primitives, size=500):
+    if job.check_cancelled():           # #329
+        return skill_error("Cancelled by user")
+    create_primitives(batch)
+    # control returns to DCC between batches
+```
+
+### 3. Use `poll_pending_bounded(max=N)`, never `poll_pending()`
+
+`poll_pending()` drains **every** queued task before returning — if 50 tasks
+arrive simultaneously, the DCC freezes for the sum of their runtimes.
+`poll_pending_bounded(max=N)` caps each pump to `N` tasks so the event loop
+can redraw between batches.
+
+```python
+# ❌ bad — unbounded; a burst of tasks will freeze the UI
+executor.poll_pending()
+
+# ✅ good — bounded; up to 8 tasks per tick, worst-case latency is known
+executor.poll_pending_bounded(max=8)
+```
+
+A reasonable starting value is `max=8` at 60 FPS; tune down if individual
+tasks are expensive.
+
+The chunked-job decorator described in
+[issue #332 — `@chunked_job`](https://github.com/loonghao/dcc-mcp-core/issues/332)
+will encode rules (1) and (2) automatically once it lands.
+
+## Forbidden patterns
+
+### `time.sleep()` inside a `DccTaskFn`
+
+A `DccTaskFn` runs on the DCC main thread. `time.sleep(n)` blocks that
+thread — the host freezes for `n` seconds.
+
+```python
+# ❌ freezes Maya for 5 seconds
+executor.execute(lambda: (time.sleep(5), cmds.polySphere()))
+```
+
+If you need a delay, reschedule via the DCC's own timer primitive
+(`maya.utils.executeDeferred`, `bpy.app.timers.register`, etc.) and return
+control to the event loop.
+
+### Native OS threads from a skill script for scene ops
+
+Spawning `threading.Thread` and calling `maya.cmds` / `bpy.ops` from it
+bypasses the main-thread contract entirely. Even if it appears to work in
+testing, it will segfault or corrupt state under load.
+
+```python
+# ❌ Undefined behaviour — Maya API is not thread-safe
+threading.Thread(target=lambda: cmds.polySphere()).start()
+```
+
+Use `DeferredExecutor.execute(...)` instead — it is the only thread-safe
+path into the scene API.
+
+### Blocking I/O on the main thread
+
+`requests.get(url)`, `urllib.urlopen(...)`, synchronous database calls,
+large file reads — none of these belong in a `DccTaskFn`. They block the
+event loop exactly like `time.sleep`.
+
+```python
+# ❌ blocks the DCC UI for the duration of the HTTP round-trip
+executor.execute(lambda: json.loads(requests.get(url).text))
+```
+
+Perform I/O on the Tokio worker (before submitting), then pass the
+already-resolved payload into the `DccTaskFn`:
+
+```python
+# ✅ I/O on the worker; only the scene call is deferred
+payload = requests.get(url).json()          # Tokio worker
+executor.execute(lambda: apply_to_scene(payload))  # main thread
+```
+
+## See also
+
+- [ADR 002 — DCC Main-Thread Affinity](../adr/002-dcc-main-thread-affinity.md)
+  — the architectural rationale for this design.
+- [Getting Started → DeferredExecutor](./getting-started.md#deferredexecutor-dcc-main-thread-safety)
+  — minimal "hello world" example.
+- [`skills/integration-guide.md`](https://github.com/loonghao/dcc-mcp-core/blob/main/skills/integration-guide.md)
+  — per-DCC bridge patterns (embedded Python / WebSocket / WebView).
+- [Issue #329 — `check_cancelled()`](https://github.com/loonghao/dcc-mcp-core/issues/329)
+  — cooperative cancellation for chunked jobs.
+- [Issue #332 — `@chunked_job`](https://github.com/loonghao/dcc-mcp-core/issues/332)
+  — decorator that encodes the chunking + checkpoint rules.

--- a/docs/zh/guide/dcc-thread-safety.md
+++ b/docs/zh/guide/dcc-thread-safety.md
@@ -1,0 +1,210 @@
+# DCC 线程安全
+
+> **适用对象**：适配器作者（`dcc-mcp-maya`、`dcc-mcp-blender` 等）以及在 DCC 宿主中运行长耗时计算的 skill 作者。
+>
+> **一句话总结**：任何修改场景的调用都必须在 DCC 的**主线程**上执行。
+> `DeferredExecutor` 是 Tokio HTTP 工作线程与主线程之间**唯一被官方支持**的桥梁。
+> 长耗时任务必须被切分为每帧（per-tick）的小块，并且必须使用 `poll_pending_bounded(max=N)`，
+> 不要使用 `poll_pending()`。
+
+## 为什么主线程亲和性是强制的
+
+所有主流 DCC 宿主都要求场景修改 API 只能在主线程上调用。运行时**不会**用锁保护你 ——
+从工作线程调用这些 API 会破坏场景状态、让宿主崩溃，或者静默失败。每个 DCC 都提供了
+一个标准的"派发到主线程"原语：
+
+| DCC | 仅主线程可用的 API | 官方派发原语 |
+|------|-----------------------|---------------------------|
+| Maya | `maya.cmds`、`OpenMaya`、`pymel` | `maya.utils.executeDeferred(fn)` / `maya.cmds.evalDeferred("expr")` |
+| Blender | `bpy.ops`、`bpy.data`、`bpy.context` | `bpy.app.timers.register(fn, first_interval=0.0)` |
+| Houdini | `hou.*`（场景图、SOP、HDA） | `hou.ui.addEventLoopCallback(fn)` |
+| 3ds Max | `MaxPlus`、`pymxs.runtime`、MAXScript | `pymxs.runtime.execute("...")` 只能在主线程调用（无 defer 原语，改用 Qt singleshot timer） |
+
+这些原语共享相同的契约：
+
+1. 可调用对象被入队。
+2. DCC 事件循环在下一个安全时机从主线程调用它。
+3. 可调用对象**同步**运行直到返回，并**阻塞 UI**。
+
+第 (3) 点就是本指南存在的理由：一旦你的回调超过约 16 ms，DCC UI 就会卡顿；超过几百
+毫秒，宿主就会看起来"冻住"。
+
+## `DeferredExecutor` 如何桥接 Tokio 工作线程到主线程
+
+`McpHttpServer` 在 Tokio 工作线程上接收 HTTP 请求。工作线程**不能**直接调用场景 API ——
+它必须通过 `DeferredExecutor` 提交任务；后者把任务塞进一个 `mpsc::channel` 并返回
+一个 future。DCC 事件循环在主线程上消费这个通道。
+
+```text
+   Tokio 工作线程 (HTTP handler)              DCC 主线程
+   ───────────────────────────                ─────────────────
+   handle.execute(task) ──── mpsc::channel ──► poll_pending_bounded(max=8)
+           │                   （有界）                │
+           │                                           │ 运行 task_fn()
+           ▼                                           ▼
+   await oneshot ◄──────────── oneshot::channel ── send(result)
+```
+
+该桥接的 Rust 权威源码简短到可以一次读完：
+
+```rust
+// crates/dcc-mcp-http/src/executor.rs (L23-L111)
+use std::sync::Arc;
+use tokio::sync::{mpsc, oneshot};
+
+/// A boxed async-compatible task that runs on the DCC main thread.
+pub type DccTaskFn = Box<dyn FnOnce() -> String + Send + 'static>;
+// ...
+impl DeferredExecutor {
+    pub fn poll_pending(&mut self) -> usize { /* drain all */ }
+    pub fn poll_pending_bounded(&mut self, max: usize) -> usize { /* drain <= max */ }
+}
+```
+
+上层适配器实现的 job-dispatcher 层位于：
+
+```rust
+// crates/dcc-mcp-process/src/dispatcher.rs (L1-L166)
+pub enum ThreadAffinity { Main, Named(&'static str), Any }
+pub struct JobRequest { /* request_id, affinity, timeout_ms, task */ }
+pub trait HostDispatcher {
+    fn submit(&self, req: JobRequest) -> oneshot::Receiver<ActionOutcome>;
+    fn supported(&self) -> &[ThreadAffinity];
+    fn capabilities(&self) -> HostCapabilities;
+}
+```
+
+当一个 skill 工具被标记为 `ThreadAffinity::Main` 时，适配器会把它路由到
+`DeferredExecutor`；`ThreadAffinity::Any` 的任务则直接在 Tokio 工作线程上执行。
+
+### Python 用法
+
+```python
+from dcc_mcp_core._core import DeferredExecutor  # 暂未进入公共 __init__
+
+executor = DeferredExecutor(capacity=16)
+
+# 从任意线程（例如 MCP HTTP 处理器）：
+executor.execute(lambda: maya.cmds.polySphere(radius=1.0))
+
+# 在 DCC 空闲回调中：
+executor.poll_pending_bounded(max=8)  # 每帧有界 —— 见下文
+```
+
+## 长耗时任务的规则
+
+"长耗时任务"是指无法在单个 DCC tick（60 FPS 约 16 ms，30 FPS 约 33 ms）内完成的
+工作。典型例子：playblast、批量渲染、几千次场景图编辑、USD 合成、复杂几何生成。
+
+三条不可妥协的规则：
+
+### 1. 把工作切分为每帧小块
+
+每个 timer tick 渲染一帧，而不是一次调用里渲染全部帧。每批处理 N 个图元，而不是
+处理整个网格。每块大小应至少给 DCC 留出 50% 的 tick 预算用于 UI。
+
+```python
+# 好：Blender timer 每帧渲染一帧
+frame_iter = iter(range(1, 241))
+
+def render_next():
+    try:
+        frame = next(frame_iter)
+    except StopIteration:
+        return None  # 注销 timer
+    bpy.context.scene.frame_set(frame)
+    bpy.ops.render.render(write_still=True)
+    return 0.0  # 立即重新调度
+
+bpy.app.timers.register(render_next)
+```
+
+### 2. 协作式检查点
+
+在每块之间检查取消标志，并把控制权交还给 DCC。参见
+[issue #329 — `check_cancelled()`](https://github.com/loonghao/dcc-mcp-core/issues/329)
+了解计划中的协作式取消原语。
+
+```python
+for batch in chunks(primitives, size=500):
+    if job.check_cancelled():           # #329
+        return skill_error("被用户取消")
+    create_primitives(batch)
+    # 在 batch 之间控制权会回到 DCC
+```
+
+### 3. 使用 `poll_pending_bounded(max=N)`，不要用 `poll_pending()`
+
+`poll_pending()` 在返回前会排空**所有**已排队任务 —— 如果同时有 50 个任务到达，
+DCC 就会冻结它们运行时长之和的时间。`poll_pending_bounded(max=N)` 限制每次 pump
+最多处理 `N` 个任务，从而让事件循环在批次之间有机会重绘。
+
+```python
+# ❌ 不好 —— 无上限；任务突发会冻结 UI
+executor.poll_pending()
+
+# ✅ 好 —— 有界；每 tick 最多 8 个，最差延迟可控
+executor.poll_pending_bounded(max=8)
+```
+
+60 FPS 下合理的起点是 `max=8`；如果单个任务较重，请调小。
+
+[issue #332 — `@chunked_job`](https://github.com/loonghao/dcc-mcp-core/issues/332)
+中计划的分块任务装饰器落地后，会自动编码规则 (1) 和 (2)。
+
+## 禁止的模式
+
+### 在 `DccTaskFn` 中使用 `time.sleep()`
+
+`DccTaskFn` 运行在 DCC 主线程上。`time.sleep(n)` 会阻塞该线程 —— 宿主会冻结 `n` 秒。
+
+```python
+# ❌ 会让 Maya 冻结 5 秒
+executor.execute(lambda: (time.sleep(5), cmds.polySphere()))
+```
+
+如果需要延迟，使用 DCC 自带的 timer 原语（`maya.utils.executeDeferred`、
+`bpy.app.timers.register` 等）重新调度，并把控制权还给事件循环。
+
+### 从 skill 脚本里启动原生 OS 线程执行场景操作
+
+启动 `threading.Thread` 并在其中调用 `maya.cmds` / `bpy.ops` 会完全绕过主线程契约。
+即使在测试中看起来能工作，在负载下也会段错误或破坏状态。
+
+```python
+# ❌ 未定义行为 —— Maya API 不是线程安全的
+threading.Thread(target=lambda: cmds.polySphere()).start()
+```
+
+请改用 `DeferredExecutor.execute(...)` —— 它是进入场景 API 的唯一线程安全路径。
+
+### 在主线程上做阻塞 I/O
+
+`requests.get(url)`、`urllib.urlopen(...)`、同步数据库调用、大文件读取 —— 都不应
+出现在 `DccTaskFn` 中。它们像 `time.sleep` 一样会阻塞事件循环。
+
+```python
+# ❌ 会让 DCC UI 冻结一整个 HTTP round-trip
+executor.execute(lambda: json.loads(requests.get(url).text))
+```
+
+在工作线程里先做 I/O（提交前），然后把已解析的数据传进 `DccTaskFn`：
+
+```python
+# ✅ 在 worker 里做 I/O；只把场景调用 defer 到主线程
+payload = requests.get(url).json()                   # Tokio worker
+executor.execute(lambda: apply_to_scene(payload))    # 主线程
+```
+
+## 另请参阅
+
+- [ADR 002 — DCC 主线程亲和性](../../adr/002-dcc-main-thread-affinity.md)
+  —— 该设计的架构理由（英文）。
+- [快速开始 → DeferredExecutor](./getting-started.md#deferredexecutor-dcc-main-thread-safety)
+  —— 最小 "hello world" 示例。
+- [`skills/integration-guide.md`](https://github.com/loonghao/dcc-mcp-core/blob/main/skills/integration-guide.md)
+  —— 各 DCC 的桥接模式（嵌入式 Python / WebSocket / WebView）。
+- [Issue #329 — `check_cancelled()`](https://github.com/loonghao/dcc-mcp-core/issues/329)
+  —— 分块任务的协作式取消。
+- [Issue #332 — `@chunked_job`](https://github.com/loonghao/dcc-mcp-core/issues/332)
+  —— 将分块 + 检查点规则封装进的装饰器。


### PR DESCRIPTION
## Summary

- Adds `docs/guide/dcc-thread-safety.md` (EN) and `docs/zh/guide/dcc-thread-safety.md` (ZH) covering Maya / Blender / Houdini / 3ds Max main-thread constraints, `DeferredExecutor` bridging, long-running job chunking, and forbidden patterns.
- Adds `docs/adr/002-dcc-main-thread-affinity.md` (Status / Context / Decision / Consequences / Alternatives) + `docs/adr/README.md` ADR index.
- Adds a new **Thread Safety** subsection to `AGENTS.md`.
- Wires both guides into `docs/.vitepress/config.mts` sidebars (EN + ZH).

## Test plan

- [x] VitePress build: PASS (`build complete in 10.95s`, no dead links, no errors).
- [x] No Rust / Python code changes — docs-only PR, Rust rebuild skipped in CI.
- [x] Source citations reference `crates/dcc-mcp-http/src/executor.rs` (actual location of `DeferredExecutor`) and `crates/dcc-mcp-process/src/dispatcher.rs` (scheduling layer). Both paths verified.

Closes #315
