### PR TITLE
feat(actions,skills): add execution and timeout_hint_secs to Action and SKILL.md (#317)

### DIFF
--- a/crates/dcc-mcp-actions/Cargo.toml
+++ b/crates/dcc-mcp-actions/Cargo.toml
@@ -10,6 +10,7 @@ description = "Action registry and event system for the DCC-MCP ecosystem"
 [dependencies]
 pyo3 = { workspace = true, optional = true }
 dcc-mcp-utils = { workspace = true }
+dcc-mcp-models = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 dashmap = { workspace = true }
@@ -18,4 +19,4 @@ parking_lot = { workspace = true }
 
 [features]
 default = []
-python-bindings = ["pyo3", "dcc-mcp-utils/python-bindings"]
+python-bindings = ["pyo3", "dcc-mcp-utils/python-bindings", "dcc-mcp-models/python-bindings"]

--- a/crates/dcc-mcp-actions/src/registry/mod.rs
+++ b/crates/dcc-mcp-actions/src/registry/mod.rs
@@ -7,6 +7,7 @@ use pyo3::prelude::*;
 use dcc_mcp_utils::py_json::json_value_to_pyobject;
 
 use dashmap::DashMap;
+use dcc_mcp_models::ExecutionMode;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -68,6 +69,18 @@ pub struct ActionMeta {
     /// Storing the declaration here avoids a separate side-table lookup.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub required_capabilities: Vec<String>,
+    /// Execution mode declared by the skill author (issue #317).
+    ///
+    /// `Sync` (default) or `Async`. Drives the server-derived MCP
+    /// `deferredHint` annotation emitted by `tools/list`.
+    #[serde(default)]
+    pub execution: ExecutionMode,
+    /// Optional hint about typical execution time in seconds (issue #317).
+    ///
+    /// Surfaces under `_meta.dcc.timeoutHintSecs` on the tool definition —
+    /// never inside `annotations`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_hint_secs: Option<u32>,
 }
 
 fn default_enabled() -> bool {
@@ -90,6 +103,8 @@ impl Default for ActionMeta {
             group: String::new(),
             enabled: true,
             required_capabilities: Vec::new(),
+            execution: ExecutionMode::Sync,
+            timeout_hint_secs: None,
         }
     }
 }
@@ -556,6 +571,26 @@ impl ActionRegistry {
                 .flatten()
                 .and_then(|v| v.extract().ok())
                 .unwrap_or_default();
+            let execution_str: Option<String> = dict
+                .get_item("execution")
+                .ok()
+                .flatten()
+                .and_then(|v| v.extract().ok());
+            let execution = match execution_str.as_deref() {
+                None | Some("sync") => ExecutionMode::Sync,
+                Some("async") => ExecutionMode::Async,
+                Some(other) => {
+                    tracing::warn!(
+                        "Invalid execution mode {other:?} for '{name}' — defaulting to sync"
+                    );
+                    ExecutionMode::Sync
+                }
+            };
+            let timeout_hint_secs: Option<u32> = dict
+                .get_item("timeout_hint_secs")
+                .ok()
+                .flatten()
+                .and_then(|v| v.extract().ok());
 
             let input_schema =
                 parse_schema_or_default(input_schema_str.as_deref(), "input_schema", &name);
@@ -576,6 +611,8 @@ impl ActionRegistry {
                 group,
                 enabled,
                 required_capabilities,
+                execution,
+                timeout_hint_secs,
             });
         }
     }
@@ -603,7 +640,7 @@ impl ActionRegistry {
 
     /// Register an action.
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (name, description="".to_string(), category="".to_string(), tags=vec![], dcc=DEFAULT_DCC.to_string(), version=DEFAULT_VERSION.to_string(), input_schema=None, output_schema=None, source_file=None, skill_name=None, group="".to_string(), enabled=true, required_capabilities=None))]
+    #[pyo3(signature = (name, description="".to_string(), category="".to_string(), tags=vec![], dcc=DEFAULT_DCC.to_string(), version=DEFAULT_VERSION.to_string(), input_schema=None, output_schema=None, source_file=None, skill_name=None, group="".to_string(), enabled=true, required_capabilities=None, execution="sync".to_string(), timeout_hint_secs=None))]
     fn register(
         &self,
         name: String,
@@ -619,10 +656,21 @@ impl ActionRegistry {
         group: String,
         enabled: bool,
         required_capabilities: Option<Vec<String>>,
-    ) {
+        execution: String,
+        timeout_hint_secs: Option<u32>,
+    ) -> pyo3::PyResult<()> {
         let input_schema = parse_schema_or_default(input_schema.as_deref(), "input_schema", &name);
         let output_schema =
             parse_schema_or_default(output_schema.as_deref(), "output_schema", &name);
+        let execution = match execution.as_str() {
+            "sync" => ExecutionMode::Sync,
+            "async" => ExecutionMode::Async,
+            other => {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "execution must be 'sync' or 'async' (got {other:?})",
+                )));
+            }
+        };
 
         self.register_action(ActionMeta {
             name,
@@ -638,7 +686,10 @@ impl ActionRegistry {
             group,
             enabled,
             required_capabilities: required_capabilities.unwrap_or_default(),
+            execution,
+            timeout_hint_secs,
         });
+        Ok(())
     }
 
     /// Enable or disable every action belonging to ``group``.

--- a/crates/dcc-mcp-actions/src/registry/tests.rs
+++ b/crates/dcc-mcp-actions/src/registry/tests.rs
@@ -202,10 +202,33 @@ fn test_action_meta_serde_round_trip() {
         group: String::new(),
         enabled: true,
         required_capabilities: vec!["scene".into(), "render".into()],
+        execution: dcc_mcp_models::ExecutionMode::Async,
+        timeout_hint_secs: Some(900),
     };
     let json = serde_json::to_string(&meta).unwrap();
     let back: ActionMeta = serde_json::from_str(&json).unwrap();
     assert_eq!(meta, back);
+}
+
+#[test]
+fn test_action_meta_execution_defaults_to_sync() {
+    let meta = ActionMeta::default();
+    assert_eq!(meta.execution, dcc_mcp_models::ExecutionMode::Sync);
+    assert_eq!(meta.timeout_hint_secs, None);
+}
+
+#[test]
+fn test_action_meta_execution_and_timeout_serde() {
+    // Issue #317 — new fields must round-trip and be recognised on input.
+    let json = r#"{
+        "name": "render",
+        "description": "Render",
+        "execution": "async",
+        "timeout_hint_secs": 600
+    }"#;
+    let meta: ActionMeta = serde_json::from_str(json).unwrap();
+    assert_eq!(meta.execution, dcc_mcp_models::ExecutionMode::Async);
+    assert_eq!(meta.timeout_hint_secs, Some(600));
 }
 
 #[test]

--- a/crates/dcc-mcp-http/src/handler.rs
+++ b/crates/dcc-mcp-http/src/handler.rs
@@ -1506,6 +1506,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                 open_world_hint: Some(false),
                 deferred_hint: Some(false),
             }),
+            meta: None,
         },
         McpTool {
             name: "find_skills".to_string(),
@@ -1539,6 +1540,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                 open_world_hint: Some(false),
                 deferred_hint: Some(false),
             }),
+            meta: None,
         },
         McpTool {
             name: "list_skills".to_string(),
@@ -1564,6 +1566,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                 open_world_hint: Some(false),
                 deferred_hint: Some(false),
             }),
+            meta: None,
         },
         McpTool {
             name: "get_skill_info".to_string(),
@@ -1588,6 +1591,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                 open_world_hint: Some(false),
                 deferred_hint: Some(false),
             }),
+            meta: None,
         },
         McpTool {
             name: "load_skill".to_string(),
@@ -1617,6 +1621,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                 open_world_hint: Some(false),
                 deferred_hint: Some(false),
             }),
+            meta: None,
         },
         McpTool {
             name: "unload_skill".to_string(),
@@ -1641,6 +1646,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                 open_world_hint: Some(false),
                 deferred_hint: Some(false),
             }),
+            meta: None,
         },
         McpTool {
             name: "search_skills".to_string(),
@@ -1671,6 +1677,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                 open_world_hint: Some(false),
                 deferred_hint: Some(false),
             }),
+            meta: None,
         },
         McpTool {
             name: "activate_tool_group".to_string(),
@@ -1697,6 +1704,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                 open_world_hint: Some(false),
                 deferred_hint: Some(false),
             }),
+            meta: None,
         },
         McpTool {
             name: "deactivate_tool_group".to_string(),
@@ -1722,6 +1730,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                 open_world_hint: Some(false),
                 deferred_hint: Some(false),
             }),
+            meta: None,
         },
         McpTool {
             name: "search_tools".to_string(),
@@ -1756,6 +1765,7 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                 open_world_hint: Some(false),
                 deferred_hint: Some(false),
             }),
+            meta: None,
         },
     ]
 }
@@ -1796,6 +1806,7 @@ fn build_lazy_action_tools() -> Vec<McpTool> {
                 open_world_hint: Some(false),
                 deferred_hint: Some(false),
             }),
+            meta: None,
         },
         McpTool {
             name: "describe_action".to_string(),
@@ -1822,6 +1833,7 @@ fn build_lazy_action_tools() -> Vec<McpTool> {
                 open_world_hint: Some(false),
                 deferred_hint: Some(false),
             }),
+            meta: None,
         },
         McpTool {
             name: "call_action".to_string(),
@@ -1859,6 +1871,7 @@ fn build_lazy_action_tools() -> Vec<McpTool> {
                 open_world_hint: Some(true),
                 deferred_hint: Some(false),
             }),
+            meta: None,
         },
     ]
 }
@@ -1916,9 +1929,29 @@ fn action_meta_to_mcp_tool(
             destructive_hint: Some(false),
             idempotent_hint: Some(false),
             open_world_hint: Some(false),
-            deferred_hint: Some(false),
+            // `deferredHint` is server-set per MCP 2025-03-26 — derived
+            // from the skill-author-declared `execution` mode (issue #317).
+            deferred_hint: Some(meta.execution.is_deferred()),
         }),
+        meta: build_tool_meta(meta),
     }
+}
+
+/// Build the MCP `_meta` map for a tool definition (issue #317).
+///
+/// Emits the dcc-mcp-core-specific `dcc.timeoutHintSecs` hint when the
+/// skill author declared `timeout_hint_secs`. The hint lives under a
+/// vendor-scoped `dcc.*` key so future additions don't collide with
+/// spec-defined fields. Returns `None` when there is nothing to emit.
+fn build_tool_meta(
+    meta: &dcc_mcp_actions::registry::ActionMeta,
+) -> Option<serde_json::Map<String, serde_json::Value>> {
+    let timeout = meta.timeout_hint_secs?;
+    let mut dcc_meta = serde_json::Map::new();
+    dcc_meta.insert("timeoutHintSecs".to_string(), serde_json::json!(timeout));
+    let mut out = serde_json::Map::new();
+    out.insert("dcc".to_string(), serde_json::Value::Object(dcc_meta));
+    Some(out)
 }
 
 /// Build a lightweight stub McpTool for an unloaded skill.
@@ -1972,6 +2005,7 @@ fn build_skill_stub(summary: &SkillSummary) -> McpTool {
         // per stub × 64 skills = measurable `tools/list` bloat with zero routing
         // value for the model. (#235)
         annotations: None,
+        meta: None,
     }
 }
 
@@ -2065,6 +2099,7 @@ fn build_group_stub(group: &str, tool_names: &[String]) -> McpTool {
         // Same rationale as `build_skill_stub`: group stubs are not callable
         // tools, so their annotations are pure protocol noise. (#235)
         annotations: None,
+        meta: None,
     }
 }
 
@@ -2575,4 +2610,105 @@ async fn refresh_roots_cache_for_session(
     // Full client response correlation will be added in follow-up.
     let _ = tokio::time::timeout(ROOTS_REFRESH_TIMEOUT, async {}).await;
     sessions.get_client_roots(session_id)
+}
+
+#[cfg(test)]
+mod issue_317_tests {
+    //! Issue #317 — `execution` / `timeout_hint_secs` plumbing.
+    use super::*;
+    use dcc_mcp_actions::registry::ActionMeta;
+    use dcc_mcp_models::ExecutionMode;
+
+    fn empty_eligible() -> std::collections::HashSet<(String, String)> {
+        std::collections::HashSet::new()
+    }
+
+    #[test]
+    fn deferred_hint_false_for_sync_action() {
+        let meta = ActionMeta {
+            name: "quick".into(),
+            description: "Fast".into(),
+            execution: ExecutionMode::Sync,
+            ..Default::default()
+        };
+        let tool = action_meta_to_mcp_tool(&meta, false, &empty_eligible());
+        let ann = tool.annotations.as_ref().unwrap();
+        assert_eq!(ann.deferred_hint, Some(false));
+        assert!(tool.meta.is_none(), "no timeout hint → no _meta");
+    }
+
+    #[test]
+    fn deferred_hint_true_for_async_action() {
+        let meta = ActionMeta {
+            name: "render".into(),
+            description: "Render".into(),
+            execution: ExecutionMode::Async,
+            timeout_hint_secs: Some(600),
+            ..Default::default()
+        };
+        let tool = action_meta_to_mcp_tool(&meta, false, &empty_eligible());
+        let ann = tool.annotations.as_ref().unwrap();
+        assert_eq!(ann.deferred_hint, Some(true));
+
+        // _meta.dcc.timeoutHintSecs must be set — NEVER inside annotations.
+        let m = tool
+            .meta
+            .as_ref()
+            .expect("timeout hint should surface _meta");
+        let dcc_meta = m.get("dcc").and_then(|v| v.as_object()).unwrap();
+        assert_eq!(
+            dcc_meta.get("timeoutHintSecs").and_then(|v| v.as_u64()),
+            Some(600),
+        );
+    }
+
+    #[test]
+    fn timeout_hint_emitted_even_when_sync() {
+        let meta = ActionMeta {
+            name: "measured".into(),
+            description: "Sync with timeout hint".into(),
+            execution: ExecutionMode::Sync,
+            timeout_hint_secs: Some(30),
+            ..Default::default()
+        };
+        let tool = action_meta_to_mcp_tool(&meta, false, &empty_eligible());
+        assert_eq!(
+            tool.annotations.as_ref().unwrap().deferred_hint,
+            Some(false)
+        );
+        let m = tool.meta.as_ref().unwrap();
+        assert_eq!(
+            m.get("dcc")
+                .and_then(|v| v.get("timeoutHintSecs"))
+                .and_then(|v| v.as_u64()),
+            Some(30),
+        );
+    }
+
+    #[test]
+    fn tools_list_serialization_places_timeout_under_meta_not_annotations() {
+        let meta = ActionMeta {
+            name: "render".into(),
+            description: "Render".into(),
+            execution: ExecutionMode::Async,
+            timeout_hint_secs: Some(600),
+            ..Default::default()
+        };
+        let tool = action_meta_to_mcp_tool(&meta, false, &empty_eligible());
+        let v = serde_json::to_value(&tool).unwrap();
+        assert_eq!(
+            v.pointer("/_meta/dcc/timeoutHintSecs")
+                .and_then(|x| x.as_u64()),
+            Some(600),
+        );
+        assert!(
+            v.pointer("/annotations/timeoutHintSecs").is_none(),
+            "timeoutHintSecs must never appear under annotations",
+        );
+        assert_eq!(
+            v.pointer("/annotations/deferredHint")
+                .and_then(|x| x.as_bool()),
+            Some(true),
+        );
+    }
 }

--- a/crates/dcc-mcp-http/src/protocol.rs
+++ b/crates/dcc-mcp-http/src/protocol.rs
@@ -291,6 +291,13 @@ pub struct McpTool {
     pub output_schema: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<McpToolAnnotations>,
+    /// MCP `_meta` — free-form server-scoped metadata (issue #317).
+    ///
+    /// dcc-mcp-core surfaces implementation-specific hints (e.g.
+    /// `dcc.timeoutHintSecs`) here rather than in `annotations`, which is
+    /// reserved for spec-defined tool hints.
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    pub meta: Option<serde_json::Map<String, Value>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/crates/dcc-mcp-models/src/lib.rs
+++ b/crates/dcc-mcp-models/src/lib.rs
@@ -7,8 +7,8 @@ pub mod skill_scope;
 pub use action_result::ActionResultModel as ToolResult;
 pub use action_result::{ActionResultModel, ActionResultModelData, SerializeFormat};
 pub use skill_metadata::{
-    SkillDependencies, SkillDependency, SkillDependencyType, SkillGroup, SkillMetadata,
-    SkillPolicy, ToolDeclaration,
+    ExecutionMode, SkillDependencies, SkillDependency, SkillDependencyType, SkillGroup,
+    SkillMetadata, SkillPolicy, ToolDeclaration,
 };
 pub use skill_scope::SkillScope;
 

--- a/crates/dcc-mcp-models/src/skill_metadata.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata.rs
@@ -17,6 +17,40 @@ use dcc_mcp_utils::constants::{DEFAULT_DCC, DEFAULT_VERSION};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+// ── ExecutionMode ─────────────────────────────────────────────────────────
+
+/// How a tool is expected to execute with respect to request/response latency.
+///
+/// Authors declare `execution` in SKILL.md. The MCP server derives the
+/// `deferredHint` annotation from this value (per MCP 2025-03-26 the hint
+/// is server-set — end users should not set it directly). See issue #317.
+///
+/// ```yaml
+/// tools:
+///   - name: render_frames
+///     execution: async          # sync | async ; default sync
+///     timeout_hint_secs: 600    # optional u32
+/// ```
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ExecutionMode {
+    /// Returns quickly — callers expect a synchronous reply.
+    #[default]
+    Sync,
+    /// May take long enough that clients should treat the call as deferred.
+    /// Surfaces as `deferredHint: true` on the MCP tool annotation.
+    Async,
+}
+
+impl ExecutionMode {
+    /// Whether this mode should surface as a deferred hint in MCP tool
+    /// annotations.
+    #[must_use]
+    pub fn is_deferred(self) -> bool {
+        matches!(self, Self::Async)
+    }
+}
+
 // ── ToolDeclaration ───────────────────────────────────────────────────────
 
 /// Declaration of a tool provided by a skill, parsed from SKILL.md frontmatter.
@@ -100,6 +134,39 @@ pub struct ToolDeclaration {
     /// calls ``activate_tool_group``.
     #[serde(default)]
     pub group: String,
+
+    /// Execution mode — `sync` (default) or `async`.
+    ///
+    /// Drives the server-derived `deferredHint` annotation on the MCP tool
+    /// definition. See [`ExecutionMode`] and issue #317.
+    #[serde(default)]
+    pub execution: ExecutionMode,
+
+    /// Optional hint about typical execution time in seconds.
+    ///
+    /// When set, surfaces under the tool's `_meta.dcc.timeoutHintSecs` in
+    /// `tools/list` (never inside `annotations`). Clients may use this to
+    /// size their own request timeouts.
+    #[serde(
+        default,
+        rename = "timeout_hint_secs",
+        alias = "timeout-hint-secs",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub timeout_hint_secs: Option<u32>,
+
+    /// Reject the legacy user-level `deferred: true` flag with a clear error.
+    ///
+    /// `deferredHint` is server-set per MCP 2025-03-26; skill authors must
+    /// use `execution: async` instead. Always deserialises to `None`; the
+    /// presence of the key triggers a custom-deserialiser error.
+    #[serde(
+        default,
+        skip_serializing,
+        rename = "deferred",
+        deserialize_with = "reject_deferred_field"
+    )]
+    pub _deferred_guard: Option<()>,
 }
 
 /// Suggested next tools for a successful or failed tool call (issue #143).
@@ -203,7 +270,7 @@ fn is_null_value(v: &serde_json::Value) -> bool {
 #[pymethods]
 impl ToolDeclaration {
     #[new]
-    #[pyo3(signature = (name, description="".to_string(), input_schema=None, output_schema=None, read_only=false, destructive=false, idempotent=false, defer_loading=false, source_file="".to_string(), group="".to_string()))]
+    #[pyo3(signature = (name, description="".to_string(), input_schema=None, output_schema=None, read_only=false, destructive=false, idempotent=false, defer_loading=false, source_file="".to_string(), group="".to_string(), execution="sync".to_string(), timeout_hint_secs=None))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         name: String,
@@ -216,14 +283,25 @@ impl ToolDeclaration {
         defer_loading: bool,
         source_file: String,
         group: String,
-    ) -> Self {
+        execution: String,
+        timeout_hint_secs: Option<u32>,
+    ) -> pyo3::PyResult<Self> {
         let input_schema = input_schema
             .and_then(|s| serde_json::from_str(&s).ok())
             .unwrap_or(serde_json::json!({"type": "object"}));
         let output_schema = output_schema
             .and_then(|s| serde_json::from_str(&s).ok())
             .unwrap_or(serde_json::Value::Null);
-        Self {
+        let execution = match execution.as_str() {
+            "sync" => ExecutionMode::Sync,
+            "async" => ExecutionMode::Async,
+            other => {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "execution must be 'sync' or 'async' (got {other:?})",
+                )));
+            }
+        };
+        Ok(Self {
             name,
             description,
             input_schema,
@@ -235,7 +313,42 @@ impl ToolDeclaration {
             source_file,
             next_tools: NextTools::default(),
             group,
+            execution,
+            timeout_hint_secs,
+            _deferred_guard: None,
+        })
+    }
+
+    #[getter]
+    fn execution(&self) -> &'static str {
+        match self.execution {
+            ExecutionMode::Sync => "sync",
+            ExecutionMode::Async => "async",
         }
+    }
+
+    #[setter]
+    fn set_execution(&mut self, value: String) -> pyo3::PyResult<()> {
+        self.execution = match value.as_str() {
+            "sync" => ExecutionMode::Sync,
+            "async" => ExecutionMode::Async,
+            other => {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "execution must be 'sync' or 'async' (got {other:?})",
+                )));
+            }
+        };
+        Ok(())
+    }
+
+    #[getter]
+    fn timeout_hint_secs(&self) -> Option<u32> {
+        self.timeout_hint_secs
+    }
+
+    #[setter]
+    fn set_timeout_hint_secs(&mut self, value: Option<u32>) {
+        self.timeout_hint_secs = value;
     }
 
     #[getter]
@@ -931,6 +1044,21 @@ where
     deserializer.deserialize_seq(ToolDeclarationsVisitor)
 }
 
+/// Custom deserializer used by [`ToolDeclaration`] to reject the legacy
+/// `deferred:` user-level field with a clear, actionable error.
+///
+/// `deferredHint` is server-set per MCP 2025-03-26 — authors must declare
+/// `execution: sync|async` instead. See issue #317.
+fn reject_deferred_field<'de, D>(_deserializer: D) -> Result<Option<()>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Err(serde::de::Error::custom(
+        "`deferred` is not a user-level SKILL.md field — it is server-derived per \
+         MCP 2025-03-26. Declare `execution: async` instead (see issue #317).",
+    ))
+}
+
 fn default_dcc() -> String {
     DEFAULT_DCC.to_string()
 }
@@ -1569,6 +1697,67 @@ mod tests {
         let meta: SkillMetadata = serde_json::from_str(json).unwrap();
         assert_eq!(meta.tools[0].next_tools.on_success, vec!["tool_a"]);
         assert_eq!(meta.tools[0].next_tools.on_failure, vec!["tool_b"]);
+    }
+
+    // ── ExecutionMode (issue #317) ──────────────────────────────────────
+
+    #[test]
+    fn test_execution_mode_default_is_sync() {
+        assert_eq!(ExecutionMode::default(), ExecutionMode::Sync);
+        assert!(!ExecutionMode::default().is_deferred());
+    }
+
+    #[test]
+    fn test_execution_mode_is_deferred() {
+        assert!(!ExecutionMode::Sync.is_deferred());
+        assert!(ExecutionMode::Async.is_deferred());
+    }
+
+    #[test]
+    fn test_execution_mode_serde_round_trip() {
+        let s = serde_json::to_string(&ExecutionMode::Sync).unwrap();
+        assert_eq!(s, "\"sync\"");
+        let a = serde_json::to_string(&ExecutionMode::Async).unwrap();
+        assert_eq!(a, "\"async\"");
+        let back: ExecutionMode = serde_json::from_str("\"async\"").unwrap();
+        assert_eq!(back, ExecutionMode::Async);
+    }
+
+    #[test]
+    fn test_tool_declaration_execution_async() {
+        let json = r#"{"name": "s", "tools": [
+            {"name": "render", "execution": "async", "timeout_hint_secs": 600}
+        ]}"#;
+        let meta: SkillMetadata = serde_json::from_str(json).unwrap();
+        assert_eq!(meta.tools[0].execution, ExecutionMode::Async);
+        assert_eq!(meta.tools[0].timeout_hint_secs, Some(600));
+    }
+
+    #[test]
+    fn test_tool_declaration_execution_default_sync() {
+        // Absence of `execution` → Sync, timeout_hint_secs → None.
+        let json = r#"{"name": "s", "tools": [{"name": "quick"}]}"#;
+        let meta: SkillMetadata = serde_json::from_str(json).unwrap();
+        assert_eq!(meta.tools[0].execution, ExecutionMode::Sync);
+        assert_eq!(meta.tools[0].timeout_hint_secs, None);
+    }
+
+    #[test]
+    fn test_tool_declaration_rejects_deferred_field() {
+        let json = r#"{"name": "s", "tools": [{"name": "t", "deferred": true}]}"#;
+        let err = serde_json::from_str::<SkillMetadata>(json).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("execution: async") || msg.contains("deferred"),
+            "error must point to execution: async — got: {msg}",
+        );
+    }
+
+    #[test]
+    fn test_tool_declaration_rejects_unknown_execution() {
+        let json = r#"{"name": "s", "tools": [{"name": "t", "execution": "background"}]}"#;
+        let err = serde_json::from_str::<SkillMetadata>(json).unwrap_err();
+        assert!(err.to_string().contains("background") || err.to_string().contains("execution"));
     }
 
     #[test]

--- a/crates/dcc-mcp-skills/src/catalog/mod.rs
+++ b/crates/dcc-mcp-skills/src/catalog/mod.rs
@@ -364,6 +364,8 @@ impl SkillCatalog {
                 // explicitly default-active group) stay enabled.
                 enabled: group_default_active(&metadata.groups, &tool_decl.group),
                 required_capabilities: Vec::new(),
+                execution: tool_decl.execution,
+                timeout_hint_secs: tool_decl.timeout_hint_secs,
             };
 
             self.registry.register_action(meta);
@@ -404,6 +406,8 @@ impl SkillCatalog {
                     group: String::new(),
                     enabled: true,
                     required_capabilities: Vec::new(),
+                    execution: dcc_mcp_models::ExecutionMode::Sync,
+                    timeout_hint_secs: None,
                 };
 
                 self.registry.register_action(meta);

--- a/crates/dcc-mcp-skills/src/loader/tests.rs
+++ b/crates/dcc-mcp-skills/src/loader/tests.rs
@@ -287,6 +287,69 @@ mod test_parse_skill_md {
     }
 
     #[test]
+    fn parse_skill_with_tool_execution_async() {
+        // Issue #317 — `execution: async` and `timeout_hint_secs` round-trip.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join(SKILL_METADATA_FILE),
+            "---\nname: render-farm\ndcc: python\ntools:\n  - name: render_frames\n    execution: async\n    timeout_hint_secs: 600\n  - name: quick_check\n---\n# Render\n",
+        )
+        .unwrap();
+
+        let meta = parse_skill_md(tmp.path()).unwrap();
+        assert_eq!(meta.tools.len(), 2);
+        assert_eq!(
+            meta.tools[0].execution,
+            dcc_mcp_models::ExecutionMode::Async,
+        );
+        assert_eq!(meta.tools[0].timeout_hint_secs, Some(600));
+        // Absence defaults to Sync / None.
+        assert_eq!(meta.tools[1].execution, dcc_mcp_models::ExecutionMode::Sync,);
+        assert_eq!(meta.tools[1].timeout_hint_secs, None);
+    }
+
+    #[test]
+    fn parse_skill_rejects_user_level_deferred_flag() {
+        // Issue #317 — `deferred: true` at the user level must be rejected,
+        // parse_skill_md logs and returns None.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join(SKILL_METADATA_FILE),
+            "---\nname: bad\ndcc: python\ntools:\n  - name: x\n    deferred: true\n---\n# Bad\n",
+        )
+        .unwrap();
+        assert!(parse_skill_md(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn parse_skill_rejects_unknown_execution_value() {
+        // Issue #317 — unknown execution value fails at load time.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join(SKILL_METADATA_FILE),
+            "---\nname: bad\ndcc: python\ntools:\n  - name: x\n    execution: background\n---\n# Bad\n",
+        )
+        .unwrap();
+        assert!(parse_skill_md(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn parse_skill_backward_compat_without_execution() {
+        // Issue #317 — existing pre-change SKILL.md files (no `execution` key)
+        // must continue to load and default to Sync / None.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join(SKILL_METADATA_FILE),
+            "---\nname: legacy\ndcc: python\ntools:\n  - name: do_thing\n    description: does a thing\n---\n# Legacy\n",
+        )
+        .unwrap();
+        let meta = parse_skill_md(tmp.path()).unwrap();
+        assert_eq!(meta.tools.len(), 1);
+        assert_eq!(meta.tools[0].execution, dcc_mcp_models::ExecutionMode::Sync,);
+        assert_eq!(meta.tools[0].timeout_hint_secs, None);
+    }
+
+    #[test]
     fn parse_returns_none_for_missing_skill_md() {
         let tmp = tempfile::tempdir().unwrap();
         // No SKILL.md file

--- a/examples/skills/async-render-example/SKILL.md
+++ b/examples/skills/async-render-example/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: async-render-example
+description: "Example skill demonstrating async execution affinity. Use when you want to see how long-running tools surface as deferredHint=true in MCP tools/list."
+license: MIT
+compatibility: Python 3.7+
+tags: [example, async, render]
+dcc: python
+version: "1.0.0"
+search-hint: "async, long-running, render, deferred, timeout hint"
+tools:
+  - name: render_frames
+    description: "Pretend to render a frame range. Long-running; the server surfaces `deferredHint: true` and `_meta.dcc.timeoutHintSecs`."
+    execution: async
+    timeout_hint_secs: 600
+  - name: quick_status
+    description: "Return the current (fake) render status. Fast, sync."
+    execution: sync
+---
+
+# Async Render Example (issue #317)
+
+This skill demonstrates the `execution` and `timeout_hint_secs` fields added
+for issue #317. Tools are declared with either `execution: sync` (default)
+or `execution: async`; the MCP server derives the `deferredHint` annotation
+from this value and surfaces `timeout_hint_secs` under
+`_meta.dcc.timeoutHintSecs` on the tool definition (never inside
+`annotations`).
+
+## Behaviour
+
+- `render_frames` → `execution: async` + `timeout_hint_secs: 600`
+  → `tools/list` entry gets `"annotations": { "deferredHint": true, ... }`
+  and `"_meta": { "dcc": { "timeoutHintSecs": 600 } }`.
+- `quick_status` → no `execution` field → default `Sync`
+  → `"annotations": { "deferredHint": false, ... }` and no `_meta`.
+
+## Script convention
+
+Each script reads JSON parameters from stdin and writes a JSON result to
+stdout — the standard dcc-mcp-core skill script contract.

--- a/examples/skills/async-render-example/scripts/quick_status.py
+++ b/examples/skills/async-render-example/scripts/quick_status.py
@@ -1,0 +1,15 @@
+"""Return fake render status — sync demo tool for issue #317."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+def main() -> None:
+    _ = json.load(sys.stdin)
+    json.dump({"success": True, "status": "idle", "queued": 0}, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/skills/async-render-example/scripts/render_frames.py
+++ b/examples/skills/async-render-example/scripts/render_frames.py
@@ -1,0 +1,26 @@
+"""Pretend to render a frame range (issue #317 async-execution demo)."""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+
+
+def main() -> None:
+    params = json.load(sys.stdin)
+    start = int(params.get("start", 1))
+    end = int(params.get("end", 1))
+    # In a real skill this would dispatch to the DCC renderer. We sleep a
+    # tiny amount so the demo feels plausible without blocking test runs.
+    time.sleep(0.05)
+    result = {
+        "success": True,
+        "message": f"rendered frames {start}-{end}",
+        "frames": end - start + 1,
+    }
+    json.dump(result, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -164,6 +164,10 @@ class ToolDeclaration:
     idempotent: bool
     defer_loading: bool
     source_file: str
+    execution: str
+    """Execution mode — ``"sync"`` or ``"async"`` (issue #317)."""
+    timeout_hint_secs: int | None
+    """Optional hint in seconds; surfaces under ``_meta.dcc.timeoutHintSecs``."""
 
     def __init__(
         self,
@@ -176,6 +180,9 @@ class ToolDeclaration:
         idempotent: bool = False,
         defer_loading: bool = False,
         source_file: str = "",
+        group: str = "",
+        execution: str = "sync",
+        timeout_hint_secs: int | None = None,
     ) -> None: ...
     def __repr__(self) -> str: ...
 
@@ -264,8 +271,16 @@ class ToolRegistry:
         group: str = "",
         enabled: bool = True,
         required_capabilities: list[str] | None = None,
+        execution: str = "sync",
+        timeout_hint_secs: int | None = None,
     ) -> None:
         """Register a tool in this registry.
+
+        ``execution`` is ``"sync"`` (default) or ``"async"``. When ``"async"``,
+        the MCP server surfaces ``deferredHint: true`` on the tool annotation.
+        ``timeout_hint_secs`` surfaces under ``_meta.dcc.timeoutHintSecs`` on
+        the tool definition — never inside ``annotations`` (issue #317).
+
 
         The ``required_capabilities`` parameter accepts an optional list of
         host-DCC capability keys (e.g. ``["scene", "timeline"]``) that must be

--- a/tests/test_execution_affinity.py
+++ b/tests/test_execution_affinity.py
@@ -1,0 +1,154 @@
+"""Issue #317 — execution / timeout_hint_secs on ToolDeclaration & Action.
+
+Covers:
+- SKILL.md with `execution: async` parses into ToolDeclaration.execution == "async"
+- Absence of `execution` defaults to "sync"
+- SKILL.md with `deferred: true` at the user level is rejected
+- Unknown `execution` values are rejected
+- ActionRegistry.register accepts `execution` / `timeout_hint_secs`
+- Backward compat: pre-change SKILL.md files still load
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import dcc_mcp_core
+
+
+def _write_skill(base: Path, name: str, frontmatter_body: str) -> Path:
+    """Write a SKILL.md with the given frontmatter body under base/name."""
+    skill_dir = base / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    content = f"---\nname: {name}\ndcc: python\n{frontmatter_body}---\n# {name}\n"
+    (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+    return skill_dir
+
+
+class TestSkillMdExecution:
+    def test_execution_async_parses(self, tmp_path: Path) -> None:
+        skill_dir = _write_skill(
+            tmp_path,
+            "render-farm",
+            "tools:\n  - name: render_frames\n    execution: async\n    timeout_hint_secs: 600\n",
+        )
+        meta = dcc_mcp_core.parse_skill_md(str(skill_dir))
+        assert meta is not None
+        assert len(meta.tools) == 1
+        assert meta.tools[0].execution == "async"
+        assert meta.tools[0].timeout_hint_secs == 600
+
+    def test_execution_defaults_to_sync(self, tmp_path: Path) -> None:
+        skill_dir = _write_skill(
+            tmp_path,
+            "quick-skill",
+            "tools:\n  - name: do_thing\n",
+        )
+        meta = dcc_mcp_core.parse_skill_md(str(skill_dir))
+        assert meta is not None
+        assert meta.tools[0].execution == "sync"
+        assert meta.tools[0].timeout_hint_secs is None
+
+    def test_deferred_user_flag_rejected(self, tmp_path: Path) -> None:
+        """`deferred: true` at the user level must be rejected (server-set only)."""
+        skill_dir = _write_skill(
+            tmp_path,
+            "bad-skill",
+            "tools:\n  - name: x\n    deferred: true\n",
+        )
+        # parse_skill_md swallows YAML errors and returns None — the point
+        # is that the skill does NOT load with a silent success.
+        meta = dcc_mcp_core.parse_skill_md(str(skill_dir))
+        assert meta is None, "deferred: true must cause a load failure"
+
+    def test_unknown_execution_value_rejected(self, tmp_path: Path) -> None:
+        skill_dir = _write_skill(
+            tmp_path,
+            "bad-skill",
+            "tools:\n  - name: x\n    execution: background\n",
+        )
+        meta = dcc_mcp_core.parse_skill_md(str(skill_dir))
+        assert meta is None
+
+    def test_backward_compat_pre_change_skill_md(self, tmp_path: Path) -> None:
+        """Existing SKILL.md files (no `execution` field) still load."""
+        skill_dir = _write_skill(
+            tmp_path,
+            "legacy-skill",
+            "tools:\n  - name: legacy_tool\n    description: old style\n",
+        )
+        meta = dcc_mcp_core.parse_skill_md(str(skill_dir))
+        assert meta is not None
+        assert meta.tools[0].execution == "sync"
+        assert meta.tools[0].timeout_hint_secs is None
+
+
+class TestToolDeclarationPython:
+    def test_python_constructor_accepts_execution(self) -> None:
+        td = dcc_mcp_core.ToolDeclaration(
+            name="render",
+            execution="async",
+            timeout_hint_secs=120,
+        )
+        assert td.execution == "async"
+        assert td.timeout_hint_secs == 120
+
+    def test_python_constructor_rejects_bad_execution(self) -> None:
+        with pytest.raises(ValueError, match=r"sync.*async"):
+            dcc_mcp_core.ToolDeclaration(name="bad", execution="maybe")
+
+    def test_setter_validates(self) -> None:
+        td = dcc_mcp_core.ToolDeclaration(name="t")
+        td.execution = "async"
+        assert td.execution == "async"
+        with pytest.raises(ValueError):
+            td.execution = "background"
+
+
+class TestToolRegistryExecution:
+    def test_register_accepts_execution(self) -> None:
+        reg = dcc_mcp_core.ToolRegistry()
+        reg.register(
+            name="render_frames",
+            description="Async render",
+            execution="async",
+            timeout_hint_secs=600,
+        )
+        action = reg.get_action("render_frames")
+        assert action is not None
+        assert action["execution"] == "async"
+        assert action["timeout_hint_secs"] == 600
+
+    def test_register_defaults(self) -> None:
+        reg = dcc_mcp_core.ToolRegistry()
+        reg.register(name="quick")
+        action = reg.get_action("quick")
+        assert action is not None
+        assert action["execution"] == "sync"
+        # timeout_hint_secs omitted when None (serde skip_serializing_if)
+        assert action.get("timeout_hint_secs") in (None, 0, False)
+
+    def test_register_rejects_bad_execution(self) -> None:
+        reg = dcc_mcp_core.ToolRegistry()
+        with pytest.raises(ValueError):
+            reg.register(name="bad", execution="background")
+
+
+class TestAsyncRenderExampleSkill:
+    """The bundled example skill under examples/skills/async-render-example/
+    must declare execution: async + timeout_hint_secs and parse cleanly.
+    """
+
+    def test_example_skill_loads(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        skill_dir = root / "examples" / "skills" / "async-render-example"
+        assert skill_dir.is_dir(), f"example skill missing: {skill_dir}"
+        meta = dcc_mcp_core.parse_skill_md(str(skill_dir))
+        assert meta is not None
+        by_name = {t.name: t for t in meta.tools}
+        assert "render_frames" in by_name
+        assert by_name["render_frames"].execution == "async"
+        assert by_name["render_frames"].timeout_hint_secs == 600
+        assert by_name["quick_status"].execution == "sync"

--- a/tests/test_pipeline_concurrent_skill_launcher_mcphttp_deep.py
+++ b/tests/test_pipeline_concurrent_skill_launcher_mcphttp_deep.py
@@ -540,7 +540,14 @@ class TestSkillWatcherMultiPath:
         examples = str(Path(__file__).parent / ".." / "examples" / "skills")
         watcher = SkillWatcher()
         watcher.watch(examples)
-        assert watcher.skill_count() == 11
+        # Count scales with the number of directories under examples/skills.
+        # Keep in sync when adding/removing example skills.
+        expected = sum(
+            1
+            for p in (Path(__file__).parent / ".." / "examples" / "skills").iterdir()
+            if p.is_dir() and (p / "SKILL.md").is_file()
+        )
+        assert watcher.skill_count() == expected
 
     def test_watcher_with_invalid_path_does_not_crash(self):
         """Watching a non-existent path should not raise an exception."""
@@ -641,10 +648,16 @@ class TestSkillScannerCacheClearing:
         assert len(skipped) >= 1
 
     def test_scan_examples_dir_loads_all_11(self):
-        """Scan examples/skills and verify all 11 skills are loaded."""
-        examples = str(Path(__file__).parent / ".." / "examples" / "skills")
+        """Scan examples/skills and verify every example skill is loaded.
+
+        Count scales with the number of skill directories — keep in sync
+        when adding/removing example skills.
+        """
+        examples_path = Path(__file__).parent / ".." / "examples" / "skills"
+        examples = str(examples_path)
+        expected = sum(1 for p in examples_path.iterdir() if p.is_dir() and (p / "SKILL.md").is_file())
         skills, skipped = scan_and_load([examples])
-        assert len(skills) == 11
+        assert len(skills) == expected
         assert skipped == []
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -421,7 +421,7 @@ toml = [
 
 [[package]]
 name = "dcc-mcp-core"
-version = "0.12.28"
+version = "0.14.2"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- Adds `ExecutionMode { Sync, Async }` to `dcc-mcp-models`; `ActionMeta` and `ToolDeclaration` carry `execution` + `timeout_hint_secs`.
- `tools/list` handler now **derives** `annotations.deferredHint` from `execution` — no more hard-coded `Some(false)`.
- `timeout_hint_secs` is emitted under `_meta.dcc.timeoutHintSecs`, **never** inside `annotations` (MCP 2025-03-26 compliant — `deferredHint` is a server-set signal).
- SKILL.md parser accepts `execution: async` + `timeout_hint_secs: 600`; rejects the legacy user-facing `deferred: true` with a clear error pointing to `execution:`; rejects unknown `execution` values.
- Backward compat: existing SKILL.md files without `execution` still load (default `sync`).
- Example skill `examples/skills/async-render-example/` demonstrates `execution: async`.
- Python stubs in `_core.pyi` updated; `ToolDeclaration(execution=...)` constructor kwarg validated.

## Test plan

- [x] 12 new pytest cases in `tests/test_execution_affinity.py`.
- [x] 2 legacy tests updated from hardcoded skill counts to dynamic counts so new bundled example does not break them.
- [x] `cargo test -p dcc-mcp-models -p dcc-mcp-actions -p dcc-mcp-skills -p dcc-mcp-http` — 561 Rust tests passed.
- [x] `cargo check --workspace --features python-bindings` clean.
- [x] `ruff format` + `ruff check --fix` applied.

## Notes on protocol correctness

Per MCP 2025-03-26, `deferredHint` is a *server-set* signal, not a user-authored field. This PR keeps that invariant: skill authors declare *execution semantics* (`sync` / `async`) and the server derives the hint. `timeout_hint_secs` is not in the MCP spec so it lives in vendor `_meta`, not `annotations`.

Closes #317
