### PR TITLE
feat(skill): add check_cancelled() cooperative cancellation API (#329)

### DIFF
--- a/examples/skills/cancellable-loop/SKILL.md
+++ b/examples/skills/cancellable-loop/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: cancellable-loop
+description: "Demonstrates cooperative cancellation inside a skill script loop using check_cancelled(). Use when showing how long-running skills should respond to notifications/cancelled."
+license: MIT
+compatibility: Python 3.7+
+tags: [example, cancellation, long-running]
+dcc: python
+version: "1.0.0"
+search-hint: "cancellation, cancel, long-running, cooperative, check_cancelled, abort"
+---
+
+# Cancellable Loop
+
+A minimal example that shows how to write a skill script that honours
+`notifications/cancelled` from the MCP client.
+
+The pattern is simple: call `check_cancelled()` at the top of every
+iteration of a long-running loop.  When the dispatcher installs a
+`CancelToken` and the client cancels the request, `check_cancelled()`
+raises `CancelledError` and the script unwinds cleanly.  Outside of a
+request context (REPL, unit tests) `check_cancelled()` is a no-op, so
+the same script remains easy to run in isolation.
+
+## Tools
+
+- `cancellable_loop__count` — Iterate `iterations` times, sleeping
+  `sleep_ms` milliseconds per step, checking for cancellation each
+  iteration.
+
+## Example
+
+```python
+{"name": "cancellable_loop__count", "arguments": {"iterations": 100, "sleep_ms": 50}}
+# → {"success": true, "message": "Completed 100 iterations", "context": {"iterations": 100}}
+```
+
+If the client sends `notifications/cancelled` while the loop is
+running, the next `check_cancelled()` call raises `CancelledError` and
+the `@skill_entry` wrapper converts it into a standard error dict.
+
+## Related
+
+- `dcc_mcp_core.check_cancelled` — the API this skill demonstrates.
+- Issue #329 — cooperative cancellation checkpoints.
+- Issue #318 — async dispatcher integration (wires the CancelToken).

--- a/examples/skills/cancellable-loop/scripts/count.py
+++ b/examples/skills/cancellable-loop/scripts/count.py
@@ -1,0 +1,79 @@
+"""Cancellable-loop skill — iterate while honouring cooperative cancellation.
+
+Reads parameters as JSON from stdin (dcc-mcp-core ``execute_script``
+protocol), runs a loop calling :func:`dcc_mcp_core.check_cancelled`
+once per iteration, and prints a standard skill result dict to stdout.
+
+Parameters
+----------
+    iterations: Number of loop iterations (default ``10``).
+    sleep_ms: Milliseconds to sleep between iterations (default ``100``).
+
+"""
+
+from __future__ import annotations
+
+# Import built-in modules
+import json
+import sys
+import time
+
+# Import local modules
+from dcc_mcp_core import CancelledError
+from dcc_mcp_core import check_cancelled
+from dcc_mcp_core import skill_entry
+from dcc_mcp_core import skill_error
+from dcc_mcp_core import skill_success
+
+
+@skill_entry
+def count(iterations: int = 10, sleep_ms: int = 100, **_: object) -> dict:
+    """Run a cancellation-aware counting loop.
+
+    Args:
+        iterations: How many times to iterate.
+        sleep_ms: Milliseconds to sleep per iteration (simulates work).
+
+    Returns:
+        A standard skill result dict.  On cancellation, returns a
+        failure result carrying the number of iterations completed
+        before the cancel took effect.
+
+    """
+    completed = 0
+    delay = max(0.0, sleep_ms / 1000.0)
+    try:
+        for _ in range(max(0, iterations)):
+            check_cancelled()
+            if delay:
+                time.sleep(delay)
+            completed += 1
+    except CancelledError as exc:
+        return skill_error(
+            f"Cancelled after {completed} iteration(s)",
+            repr(exc),
+            prompt="The client cancelled the request; no cleanup needed.",
+            iterations_completed=completed,
+        )
+    return skill_success(
+        f"Completed {completed} iterations",
+        iterations=completed,
+    )
+
+
+def main() -> dict:
+    """Entry point: read JSON params from stdin, forward to :func:`count`."""
+    params: dict = {}
+    try:
+        if not sys.stdin.isatty():
+            raw = sys.stdin.read()
+            if raw.strip():
+                params = json.loads(raw)
+    except (OSError, ValueError):
+        params = {}
+    return count(**params)
+
+
+if __name__ == "__main__":
+    result = main()
+    print(json.dumps(result, default=str))

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -200,6 +200,14 @@ from dcc_mcp_core.bridge import BridgeRpcError
 from dcc_mcp_core.bridge import BridgeTimeoutError
 from dcc_mcp_core.bridge import DccBridge
 
+# Cooperative cancellation (pure-Python, no _core dependency)
+from dcc_mcp_core.cancellation import CancelledError
+from dcc_mcp_core.cancellation import CancelToken
+from dcc_mcp_core.cancellation import check_cancelled
+from dcc_mcp_core.cancellation import current_cancel_token
+from dcc_mcp_core.cancellation import reset_cancel_token
+from dcc_mcp_core.cancellation import set_cancel_token
+
 # Pure-Python DCC server diagnostic helpers (no _core dependency)
 from dcc_mcp_core.dcc_server import register_diagnostic_handlers
 from dcc_mcp_core.dcc_server import register_diagnostic_mcp_tools
@@ -270,6 +278,8 @@ __all__ = [
     "BridgeRegistry",
     "BridgeRpcError",
     "BridgeTimeoutError",
+    "CancelToken",
+    "CancelledError",
     "CaptureBackendKind",
     "CaptureFrame",
     "CaptureResult",
@@ -362,8 +372,10 @@ __all__ = [
     "WindowInfo",
     "__author__",
     "__version__",
+    "check_cancelled",
     "create_dcc_server",
     "create_skill_server",
+    "current_cancel_token",
     "deserialize_result",
     "error_result",
     "expand_transitive_dependencies",
@@ -389,6 +401,7 @@ __all__ = [
     "register_bridge",
     "register_diagnostic_handlers",
     "register_diagnostic_mcp_tools",
+    "reset_cancel_token",
     "resolve_dependencies",
     "run_main",
     "scan_and_load",
@@ -396,6 +409,7 @@ __all__ = [
     "scan_skill_paths",
     "scene_info_json_to_stage",
     "serialize_result",
+    "set_cancel_token",
     "shutdown_file_logging",
     "shutdown_telemetry",
     "skill_entry",

--- a/python/dcc_mcp_core/cancellation.py
+++ b/python/dcc_mcp_core/cancellation.py
@@ -1,0 +1,192 @@
+"""Cooperative cancellation support for DCC-MCP skill scripts.
+
+Skill scripts executed inside a ``tools/call`` request run as regular
+Python code and therefore cannot be interrupted by the dispatcher the
+way an ``asyncio`` task can.  The MCP spec's ``notifications/cancelled``
+message only helps if the running code checks for cancellation at
+appropriate points.
+
+This module exposes a tiny, dependency-free API that skill authors can
+sprinkle inside long-running loops:
+
+.. code-block:: python
+
+    from dcc_mcp_core import check_cancelled, skill_success
+
+    def run(iterations: int = 100) -> dict:
+        for _ in range(iterations):
+            check_cancelled()  # raises CancelledError when the caller cancels
+            do_one_unit_of_work()
+        return skill_success("done")
+
+The dispatcher is expected to install a :class:`CancelToken` via
+:func:`set_cancel_token` before invoking the skill and to
+:func:`reset_cancel_token` in a ``finally`` block.  When no token is
+installed, :func:`check_cancelled` is a no-op, which keeps the helper
+safe to call from an interactive REPL or from unit tests.
+
+The state is stored in a :mod:`contextvars` ``ContextVar`` so that
+concurrent requests (e.g. under an asyncio dispatcher or in worker
+threads with their own ``contextvars.Context``) do not leak cancel
+flags into one another.
+
+Dispatcher integration inside the Rust ``ToolDispatcher`` / async
+``JobManager`` is deferred to issues #318 and #332; this module only
+provides the Python surface so skill authors can start writing
+cancellation-aware scripts today.
+"""
+
+from __future__ import annotations
+
+# Import built-in modules
+import contextvars
+import threading
+
+__all__ = [
+    "CancelToken",
+    "CancelledError",
+    "check_cancelled",
+    "current_cancel_token",
+    "reset_cancel_token",
+    "set_cancel_token",
+]
+
+
+class CancelledError(Exception):
+    """Raised by :func:`check_cancelled` when the active request was cancelled.
+
+    This is deliberately a plain :class:`Exception` subclass (not
+    :class:`concurrent.futures.CancelledError` or
+    :class:`asyncio.CancelledError`) because skill scripts may run in
+    synchronous contexts that do not import either module.  The
+    ``@skill_entry`` decorator's generic ``except Exception`` branch will
+    convert an unhandled :class:`CancelledError` into a standard skill
+    error dict, so most authors will never need to catch it directly.
+    """
+
+
+class CancelToken:
+    """Thread-safe cancellation flag settable by the request dispatcher.
+
+    Instances are cheap; a new token should be created for every request.
+    :meth:`cancel` may be called from any thread — typically the HTTP
+    listener thread that receives ``notifications/cancelled`` — while
+    the request is still executing on a worker thread.  The underlying
+    flag is guarded by a :class:`threading.Lock` so concurrent
+    ``cancel()`` / ``cancelled`` reads are well-defined.
+
+    Example:
+        >>> token = CancelToken()
+        >>> token.cancelled
+        False
+        >>> token.cancel()
+        >>> token.cancelled
+        True
+
+    """
+
+    __slots__ = ("_cancelled", "_lock")
+
+    def __init__(self) -> None:
+        self._cancelled: bool = False
+        self._lock = threading.Lock()
+
+    def cancel(self) -> None:
+        """Mark the token as cancelled.
+
+        Idempotent — calling :meth:`cancel` multiple times has no
+        additional effect.
+        """
+        with self._lock:
+            self._cancelled = True
+
+    @property
+    def cancelled(self) -> bool:
+        """Whether :meth:`cancel` has been invoked on this token."""
+        with self._lock:
+            return self._cancelled
+
+    def __bool__(self) -> bool:  # pragma: no cover - trivial
+        return self.cancelled
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"CancelToken(cancelled={self.cancelled})"
+
+
+_current_token: contextvars.ContextVar[CancelToken | None] = contextvars.ContextVar(
+    "dcc_mcp_core_cancel_token",
+    default=None,
+)
+
+
+def check_cancelled() -> None:
+    """Raise :class:`CancelledError` if the active request has been cancelled.
+
+    This is a no-op when invoked outside of a request context (for
+    example from an interactive REPL, a unit test, or a DCC host that
+    does not install a cancel token).  Skill authors can therefore
+    sprinkle ``check_cancelled()`` calls inside loops without making
+    the script harder to test in isolation.
+
+    Raises:
+        CancelledError: If a :class:`CancelToken` is installed in the
+            current context and its :attr:`CancelToken.cancelled`
+            property is ``True``.
+
+    """
+    token = _current_token.get()
+    if token is not None and token.cancelled:
+        raise CancelledError("Request cancelled by client")
+
+
+def current_cancel_token() -> CancelToken | None:
+    """Return the :class:`CancelToken` installed in the current context.
+
+    Returns:
+        The active token, or ``None`` when no dispatcher has installed
+        one.  Useful for advanced callers that want to poll the flag
+        without raising (e.g. to flush partial progress before
+        returning).
+
+    """
+    return _current_token.get()
+
+
+def set_cancel_token(token: CancelToken | None) -> contextvars.Token:
+    """Install *token* as the active cancel token for the current context.
+
+    This function is intended for **dispatcher** use only — skill
+    authors should call :func:`check_cancelled` instead.  The return
+    value must be passed to :func:`reset_cancel_token` (typically in a
+    ``finally`` block) so the contextvar is restored to its previous
+    value.
+
+    Args:
+        token: The token to install, or ``None`` to explicitly clear
+            any inherited token for this context.
+
+    Returns:
+        A :class:`contextvars.Token` that records the previous value;
+        pass it to :func:`reset_cancel_token`.
+
+    Example:
+        >>> token = CancelToken()
+        >>> reset = set_cancel_token(token)
+        >>> try:
+        ...     run_skill()
+        ... finally:
+        ...     reset_cancel_token(reset)
+
+    """
+    return _current_token.set(token)
+
+
+def reset_cancel_token(reset: contextvars.Token) -> None:
+    """Restore the cancel-token contextvar to its previous value.
+
+    Args:
+        reset: The token returned by the matching
+            :func:`set_cancel_token` call.
+
+    """
+    _current_token.reset(reset)

--- a/tests/test_cancellation.py
+++ b/tests/test_cancellation.py
@@ -1,0 +1,187 @@
+"""Tests for :mod:`dcc_mcp_core.cancellation`."""
+
+from __future__ import annotations
+
+# Import built-in modules
+import contextvars
+import threading
+import time
+
+# Import third-party modules
+import pytest
+
+# Import local modules
+from dcc_mcp_core import CancelledError
+from dcc_mcp_core import CancelToken
+from dcc_mcp_core import check_cancelled
+from dcc_mcp_core import current_cancel_token
+from dcc_mcp_core import reset_cancel_token
+from dcc_mcp_core import set_cancel_token
+
+
+def test_exports_available() -> None:
+    """All five public symbols must be importable from the top-level package."""
+    # Import local modules
+    import dcc_mcp_core
+
+    for name in (
+        "CancelToken",
+        "CancelledError",
+        "check_cancelled",
+        "current_cancel_token",
+        "reset_cancel_token",
+        "set_cancel_token",
+    ):
+        assert hasattr(dcc_mcp_core, name), name
+        assert name in dcc_mcp_core.__all__
+
+
+def test_no_op_outside_context() -> None:
+    """check_cancelled() must be a no-op when no token is installed."""
+    assert current_cancel_token() is None
+    # Should not raise.
+    check_cancelled()
+    check_cancelled()
+
+
+def test_raises_when_cancelled() -> None:
+    """Setting and cancelling a token causes check_cancelled() to raise."""
+    token = CancelToken()
+    assert token.cancelled is False
+
+    reset = set_cancel_token(token)
+    try:
+        check_cancelled()  # not cancelled yet → no raise
+        token.cancel()
+        assert token.cancelled is True
+        with pytest.raises(CancelledError):
+            check_cancelled()
+    finally:
+        reset_cancel_token(reset)
+
+    assert current_cancel_token() is None
+
+
+def test_cancel_is_idempotent() -> None:
+    """Calling cancel() multiple times has no additional effect."""
+    token = CancelToken()
+    token.cancel()
+    token.cancel()
+    token.cancel()
+    assert token.cancelled is True
+
+
+def test_set_reset_contextvar_restores_previous() -> None:
+    """reset_cancel_token() must restore the prior ContextVar value."""
+    outer = CancelToken()
+    inner = CancelToken()
+
+    outer_reset = set_cancel_token(outer)
+    try:
+        assert current_cancel_token() is outer
+        inner_reset = set_cancel_token(inner)
+        try:
+            assert current_cancel_token() is inner
+        finally:
+            reset_cancel_token(inner_reset)
+        assert current_cancel_token() is outer
+    finally:
+        reset_cancel_token(outer_reset)
+    assert current_cancel_token() is None
+
+
+def test_two_concurrent_contexts_do_not_leak() -> None:
+    """Separate contextvars.Context instances must hold independent tokens."""
+    token_a = CancelToken()
+    token_b = CancelToken()
+
+    ctx_a = contextvars.copy_context()
+    ctx_b = contextvars.copy_context()
+
+    def _install(tok: CancelToken) -> CancelToken | None:
+        set_cancel_token(tok)
+        return current_cancel_token()
+
+    assert ctx_a.run(_install, token_a) is token_a
+    assert ctx_b.run(_install, token_b) is token_b
+
+    # Cancelling token_a must only affect ctx_a.
+    token_a.cancel()
+
+    def _check_raises() -> bool:
+        try:
+            check_cancelled()
+            return False
+        except CancelledError:
+            return True
+
+    assert ctx_a.run(_check_raises) is True
+    assert ctx_b.run(_check_raises) is False
+
+    # The outer/test context never installed a token.
+    assert current_cancel_token() is None
+
+
+def test_thread_cross_signalling() -> None:
+    """A token cancelled from one thread is observed by the worker thread.
+
+    contextvars.Context is per-thread by default, so the worker thread
+    copies the caller's context to inherit the installed token.  The
+    underlying CancelToken flag is lock-protected, so the write from
+    the main thread is visible to the worker.
+    """
+    token = CancelToken()
+    observed: list[bool] = []
+
+    def _worker(ctx: contextvars.Context) -> None:
+        def _run() -> None:
+            # Wait briefly so the main thread has time to cancel.
+            for _ in range(50):
+                if current_cancel_token() is not None and current_cancel_token().cancelled:
+                    observed.append(True)
+                    return
+                time.sleep(0.01)
+            observed.append(False)
+
+        ctx.run(_run)
+
+    reset = set_cancel_token(token)
+    try:
+        ctx = contextvars.copy_context()
+        t = threading.Thread(target=_worker, args=(ctx,))
+        t.start()
+        # Give the worker a chance to start, then cancel.
+        time.sleep(0.05)
+        token.cancel()
+        t.join(timeout=5.0)
+    finally:
+        reset_cancel_token(reset)
+
+    assert observed == [True]
+
+
+def test_explicit_none_clears_inherited_token() -> None:
+    """Passing None to set_cancel_token() clears an inherited token."""
+    token = CancelToken()
+    outer = set_cancel_token(token)
+    try:
+        assert current_cancel_token() is token
+        inner = set_cancel_token(None)
+        try:
+            assert current_cancel_token() is None
+            check_cancelled()  # must not raise — no token installed
+        finally:
+            reset_cancel_token(inner)
+        assert current_cancel_token() is token
+    finally:
+        reset_cancel_token(outer)
+
+
+def test_cancelled_error_is_exception_subclass() -> None:
+    """CancelledError is a plain Exception subclass (not BaseException-only)."""
+    assert issubclass(CancelledError, Exception)
+    # Ensure @skill_entry's `except Exception` branch can catch it.
+    try:
+        raise CancelledError("x")
+    except Exception as exc:
+        assert isinstance(exc, CancelledError)

--- a/tests/test_pipeline_concurrent_skill_launcher_mcphttp_deep.py
+++ b/tests/test_pipeline_concurrent_skill_launcher_mcphttp_deep.py
@@ -647,7 +647,7 @@ class TestSkillScannerCacheClearing:
         # bad-skill should be in skipped (parse_skill_md returns None)
         assert len(skipped) >= 1
 
-    def test_scan_examples_dir_loads_all_11(self):
+    def test_scan_examples_dir_loads_all_example_skills(self):
         """Scan examples/skills and verify every example skill is loaded.
 
         Count scales with the number of skill directories — keep in sync


### PR DESCRIPTION
## Summary

- Adds `dcc_mcp_core.check_cancelled()` — a pure-Python cooperative cancellation API for skill scripts.
- New module `python/dcc_mcp_core/cancellation.py` exports `CancelToken`, `CancelledError`, `check_cancelled`, `current_cancel_token`, `set_cancel_token`, `reset_cancel_token`.
- Uses `contextvars.ContextVar` (not thread-local) for compatibility with the upcoming async `JobManager` dispatcher (#318).
- `CancelToken` read/write guarded by `threading.Lock` so the HTTP listener can cancel work running on a skill-worker thread.
- `CancelledError` inherits from `Exception` (not `BaseException`) so `@skill_entry`'s `except Exception` branch converts unhandled cancellations into standard skill error dicts.
- Example `examples/skills/cancellable-loop/` demonstrates usage inside a loop.
- **No Rust changes** — dispatcher integration deferred to #318 / #332 per the issue scope.

## Test plan

- [x] `pytest tests/test_cancellation.py -v` — 9 passed.

Test coverage:
- no-op outside context
- raises after cancel
- nested context restore
- parallel contexts don't leak
- cross-thread via `copy_context`
- `CancelledError` is `Exception` subclass
- explicit `None` clears inherited token
- `cancel()` idempotent
- all symbols in `__all__`

## Constraints honoured

- Zero new runtime deps (`contextvars` + `threading` are stdlib).
- `from __future__ import annotations` first line of every new module.
- Pure-Python; no PyO3, no Rust bridge (scope of #318 / #332).
- `ruff format` + `ruff check` clean.

Closes #329
