### PR TITLE
docs: production deployment guide with Docker, systemd, k8s, HA (#330, #327)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,10 @@ Need to interact with DCC?
 → `FileLoggingConfig` + `init_file_logging()` / `shutdown_file_logging()`
 → Environment vars: `DCC_MCP_LOG_DIR`, `DCC_MCP_LOG_MAX_SIZE`, `DCC_MCP_LOG_ROTATION`
 
+**Deploying `dcc-mcp-server` to production (Docker, systemd, k8s, LB)?**
+→ [`docs/guide/production-deployment.md`](docs/guide/production-deployment.md)
+→ Artifacts: [`examples/compose/gateway-ha/`](examples/compose/gateway-ha/), [`examples/k8s/gateway-ha/`](examples/k8s/gateway-ha/), [`examples/systemd/`](examples/systemd/)
+
 **Structured results, input validation, event bus?**
 → [`docs/api/actions.md`](docs/api/actions.md)
 → [`docs/api/models.md`](docs/api/models.md)

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -43,6 +43,7 @@ export default defineConfig({
                 { text: 'Skills System', link: '/guide/skills' },
                 { text: 'Skill Scopes & Policies', link: '/guide/skill-scopes-policies' },
                 { text: 'Gateway Election', link: '/guide/gateway-election' },
+                { text: 'Production Deployment', link: '/guide/production-deployment' },
               ]
             },
             {
@@ -127,6 +128,7 @@ export default defineConfig({
                 { text: 'Skills 技能包', link: '/zh/guide/skills' },
                 { text: 'Skill 作用域与策略', link: '/zh/guide/skill-scopes-policies' },
                 { text: '网关选举机制', link: '/zh/guide/gateway-election' },
+                { text: '生产环境部署', link: '/zh/guide/production-deployment' },
               ]
             },
             {

--- a/docs/guide/production-deployment.md
+++ b/docs/guide/production-deployment.md
@@ -1,0 +1,421 @@
+# Production Deployment
+
+> **[中文版](../zh/guide/production-deployment)**
+
+This guide covers deploying the standalone `dcc-mcp-server` binary in
+production: as a bare binary, in Docker, under systemd, and behind a load
+balancer for high-availability multi-gateway topologies.
+
+For the gateway election protocol itself (how a single process wins the
+well-known port) see [Gateway Election](gateway-election.md). This page is
+about the **operational** side: how to run N of these processes safely.
+
+## When to Read This
+
+- You are packaging `dcc-mcp-server` into a Docker image or OS service.
+- You need more than one gateway replica behind nginx / ALB for HA.
+- You want documented TLS, firewall, log, and upgrade procedures.
+
+If you just want to run the server on a developer laptop, start with
+[Getting Started](getting-started.md) instead.
+
+---
+
+## 1. Binary Deployment
+
+### Building the Binary
+
+The binary is the Rust bin crate [`crates/dcc-mcp-server/`](https://github.com/loonghao/dcc-mcp-core/tree/main/crates/dcc-mcp-server).
+It is statically-linked apart from the platform libc and needs no Python
+runtime.
+
+```bash
+# Release build (recommended for production)
+cargo build --release --bin dcc-mcp-server
+
+# Resulting binary
+# Linux / macOS: target/release/dcc-mcp-server
+# Windows:       target\release\dcc-mcp-server.exe
+```
+
+Cross-compiling for Linux from any host:
+
+```bash
+cargo install cross --locked
+cross build --release --bin dcc-mcp-server --target x86_64-unknown-linux-gnu
+```
+
+### Install Location
+
+Pick **one** location consistently per machine:
+
+| Platform | Suggested path |
+|----------|---------------|
+| Linux (system-wide) | `/usr/local/bin/dcc-mcp-server` |
+| Linux (per-user) | `~/.local/bin/dcc-mcp-server` |
+| Container image | `/usr/local/bin/dcc-mcp-server` |
+| Windows | `C:\Program Files\dcc-mcp\dcc-mcp-server.exe` |
+
+### Environment Variables
+
+The binary is configured entirely through CLI flags or environment variables
+(flags win). Only the variables listed here are stable; see
+`dcc-mcp-server --help` for the full set.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `DCC_MCP_MCP_PORT` | `0` (OS-assigned) | Per-instance MCP HTTP port |
+| `DCC_MCP_GATEWAY_PORT` | `9765` | Well-known port the gateway competes for; `0` disables the gateway |
+| `DCC_MCP_REGISTRY_DIR` | platform default | Shared `FileRegistry` directory — **must** be identical across replicas that need to see each other |
+| `DCC_MCP_STALE_TIMEOUT` | `30` | Seconds without a heartbeat before an instance is considered dead |
+| `DCC_MCP_HEARTBEAT_INTERVAL` | `5` | Heartbeat period in seconds |
+| `DCC_MCP_SERVER_NAME` | `dcc-mcp-server` | Name advertised to MCP clients |
+| `DCC_MCP_DCC` | *(empty)* | DCC hint: `maya`, `blender`, `photoshop`, … |
+| `DCC_MCP_DCC_VERSION` | — | Reported in registry entry |
+| `DCC_MCP_SCENE` | — | Current scene file reported to the gateway |
+| `DCC_MCP_SKILL_PATHS` | — | `:` / `;` separated extra skill directories |
+| `DCC_MCP_LOG_FILE` | `false` | Enable rotating file logs in addition to stderr |
+| `DCC_MCP_LOG_DIR` | platform log dir | Where rotated logs are written |
+
+### Smoke Test
+
+```bash
+# Terminal 1
+dcc-mcp-server --dcc generic --mcp-port 18812
+
+# Terminal 2
+curl -sf http://127.0.0.1:9765/health   # → {"ok":true}
+curl -s http://127.0.0.1:9765/instances # → JSON list of registered instances
+```
+
+---
+
+## 2. Docker
+
+### Multi-Stage Image
+
+See [`examples/compose/gateway-ha/Dockerfile`](https://github.com/loonghao/dcc-mcp-core/tree/main/examples/compose/gateway-ha)
+for the canonical image. Sketch:
+
+```Dockerfile
+# Stage 1 — build
+FROM rust:1.85-slim AS builder
+WORKDIR /src
+COPY . .
+RUN cargo build --release --bin dcc-mcp-server
+
+# Stage 2 — runtime
+FROM debian:12-slim
+RUN useradd --system --uid 10001 --home-dir /var/lib/dcc-mcp dcc
+COPY --from=builder /src/target/release/dcc-mcp-server /usr/local/bin/
+USER dcc
+EXPOSE 9765
+ENTRYPOINT ["/usr/local/bin/dcc-mcp-server"]
+```
+
+Build and run once:
+
+```bash
+docker build -t dcc-mcp-server:latest -f examples/compose/gateway-ha/Dockerfile .
+docker run --rm -p 9765:9765 dcc-mcp-server:latest \
+  --dcc generic --host 0.0.0.0
+```
+
+### docker-compose for HA
+
+The [`examples/compose/gateway-ha/docker-compose.yml`](https://github.com/loonghao/dcc-mcp-core/tree/main/examples/compose/gateway-ha)
+file brings up **two gateway candidates** (both compete for `9765`; one
+wins, the other becomes a plain instance that can take over on failure)
+plus **two mock DCC servers**, all sharing a single registry volume.
+
+```bash
+cd examples/compose/gateway-ha
+docker compose up -d
+curl http://localhost:9765/health
+curl http://localhost:9765/instances
+docker compose down
+```
+
+---
+
+## 3. systemd
+
+Use systemd on bare-metal or long-lived VMs where you want the OS to keep
+`dcc-mcp-server` alive. The canonical unit lives in
+[`examples/systemd/dcc-mcp-gateway.service`](https://github.com/loonghao/dcc-mcp-core/tree/main/examples/systemd).
+
+The unit enables these hardening options:
+
+- `DynamicUser=true` — the service gets an auto-created, unprivileged user.
+- `ProtectSystem=strict` + `ProtectHome=true` — read-only `/`, no `/home`.
+- `NoNewPrivileges=true` — the process cannot gain capabilities via `exec`.
+- `PrivateTmp=true`, `PrivateDevices=true`, `ProtectKernelTunables=true`.
+- `StateDirectory=dcc-mcp` — writable `/var/lib/dcc-mcp` for the registry.
+- `CapabilityBoundingSet=` — no capabilities at all.
+
+Install and enable:
+
+```bash
+sudo install -m0644 examples/systemd/dcc-mcp-gateway.service \
+  /etc/systemd/system/dcc-mcp-gateway.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now dcc-mcp-gateway.service
+systemctl status dcc-mcp-gateway.service
+journalctl -u dcc-mcp-gateway.service -f
+```
+
+Override per host (port, skill paths, etc.) with a drop-in:
+
+```bash
+sudo systemctl edit dcc-mcp-gateway.service
+# [Service]
+# Environment=DCC_MCP_GATEWAY_PORT=9765
+# Environment=DCC_MCP_REGISTRY_DIR=/var/lib/dcc-mcp/registry
+# Environment=DCC_MCP_SKILL_PATHS=/opt/skills:/etc/skills
+```
+
+---
+
+## 4. Load Balancer
+
+### MCP Session Stickiness
+
+The MCP Streamable HTTP transport (spec
+[2025-03-26](https://modelcontextprotocol.io/specification/2025-03-26))
+carries a session identifier in the `Mcp-Session-Id` HTTP header. The
+initialization response sets it; every subsequent `POST /mcp` and the
+long-lived `GET /mcp` SSE stream carry the same header back. All requests
+with the same `Mcp-Session-Id` **must** reach the same gateway replica, or
+SSE events will not be delivered.
+
+Hash on `Mcp-Session-Id` rather than client IP — a single office behind a
+NAT gateway may present as one source IP yet host many independent
+sessions.
+
+### nginx
+
+```nginx
+upstream dcc_mcp_gateways {
+    hash $http_mcp_session_id consistent;
+    server 10.0.0.11:9765 max_fails=2 fail_timeout=5s;
+    server 10.0.0.12:9765 max_fails=2 fail_timeout=5s;
+    keepalive 16;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name mcp.example.com;
+
+    ssl_certificate     /etc/ssl/mcp.example.com.crt;
+    ssl_certificate_key /etc/ssl/mcp.example.com.key;
+
+    # Passive health — drop a backend after 2 failures for 5s.
+    # Active health — Nginx OSS users can use a cron curl loop or
+    # the upstream's /health endpoint from an external probe.
+
+    location /mcp {
+        proxy_pass http://dcc_mcp_gateways;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Mcp-Session-Id $http_mcp_session_id;
+
+        # SSE: disable buffering and keep the connection long.
+        proxy_buffering  off;
+        proxy_cache      off;
+        proxy_read_timeout 1h;
+        proxy_send_timeout 1h;
+        chunked_transfer_encoding on;
+    }
+
+    location = /health {
+        proxy_pass http://dcc_mcp_gateways;
+    }
+}
+```
+
+### AWS Application Load Balancer
+
+ALB has no built-in hash-on-header mode, so use **application cookie
+stickiness** anchored to the session header:
+
+1. Target group → Attributes → **Stickiness: enabled**, type
+   `app_cookie`, cookie name `Mcp-Session-Id`, duration `3600s`.
+2. Health check path `/health`, response code `200`, interval `10s`,
+   threshold `2`.
+3. Listener on `:443` terminates TLS; forwards HTTP to targets on `:9765`.
+4. Idle timeout ≥ `3600s` so SSE streams are not severed.
+
+Optional: put a CloudFront distribution in front for DDoS protection and
+cache `/health` for `10s`.
+
+---
+
+## 5. Gateway HA Topology (#327)
+
+This is the topology originally planned for issue #327 and merged into
+issue #330. It is the only way to scale gateway throughput past one process
+while keeping a single public endpoint.
+
+```
+                ┌──────────────────┐
+   clients ───▶ │  LB (nginx/ALB)  │
+                └──────────────────┘
+                   │          │
+                   ▼          ▼
+         ┌───────────┐  ┌───────────┐
+         │ gateway-a │  │ gateway-b │    dcc-mcp-server replicas
+         └───────────┘  └───────────┘    (stateless, read-mostly)
+                 \            /
+                  \          /
+                ┌──────────────────┐
+                │ shared registry  │    NFS / EFS / S3-mountpoint
+                │  (FileRegistry)  │    Mount path = DCC_MCP_REGISTRY_DIR
+                └──────────────────┘
+                   ▲          ▲
+                   │          │
+         ┌───────────┐  ┌───────────┐
+         │ dcc-maya-1│  │ dcc-blender-1 │ DCC instances register themselves
+         └───────────┘  └───────────┘
+```
+
+### Sharing the FileRegistry
+
+Every replica **must** point `DCC_MCP_REGISTRY_DIR` at the same POSIX
+directory, exposed through a filesystem with working `fsync`:
+
+- Kubernetes: `ReadWriteMany` PVC (CephFS, EFS CSI, Longhorn RWX).
+- Bare-metal: NFSv4 or GlusterFS.
+- AWS: EFS mounted via NFSv4.1.
+- On-prem AWS-alike: S3 Mountpoint is acceptable but slow; prefer EFS.
+
+Do **not** use S3 object stores without a POSIX layer — the registry relies
+on atomic rename and directory listing.
+
+### Election & Duplicate-Tool Suppression
+
+All replicas run the same election code described in
+[`gateway-election.md`](gateway-election.md):
+
+1. Each replica tries to bind `DCC_MCP_GATEWAY_PORT` on its own
+   pod/container IP. On a single-host compose file only one succeeds.
+2. In the LB topology each replica is on a distinct IP, so they all bind
+   successfully and each pretends to be "the gateway for this pod". The
+   LB hides this from clients.
+3. Every replica reads the same shared `FileRegistry`, so every replica
+   sees **the same set of DCC instances and the same set of tools**.
+4. Tools are namespaced `{instance_short_id}__{tool}` — the short id is
+   derived deterministically from the instance registration, so two
+   replicas publishing the same DCC instance produce **identical** tool
+   names. MCP clients deduplicate by name; there are no duplicates in
+   `tools/list`.
+5. `tools/list_changed` notifications fire on whichever replica the SSE
+   stream is pinned to, driven by registry file-watch events.
+
+### Failover SLA
+
+Target: **< 5 seconds from pod death to LB drop**.
+
+- LB health check interval `2s`, unhealthy threshold `2` → ≤ `4s` to
+  stop routing to the dead replica.
+- Existing SSE streams pinned to the dead replica are severed; clients
+  see a disconnect and reconnect — the LB routes them to a healthy
+  replica using the `Mcp-Session-Id` cookie/hash.
+- Registry entries of a truly-dead DCC are pruned after
+  `DCC_MCP_STALE_TIMEOUT` (default `30s`) by any live gateway replica;
+  this is independent of LB failover.
+
+Tune `DCC_MCP_HEARTBEAT_INTERVAL=2` and `DCC_MCP_STALE_TIMEOUT=10` in
+aggressive-failover deployments. Do not go below `1s` heartbeats — you
+will saturate the shared registry directory.
+
+---
+
+## 6. Security
+
+- **Bind privately**. The binary defaults to `127.0.0.1`. In containers
+  set `--host 0.0.0.0` only when the container network is private.
+- **TLS at the edge only**. Terminate TLS at the LB (nginx / ALB).
+  `dcc-mcp-server` speaks plaintext HTTP on the loopback / pod network
+  for simplicity and performance.
+- **Firewall**. Expose only the LB's public port (443). Block `9765`
+  and each replica's `--mcp-port` from the public internet.
+- **Authentication**. The MCP spec defines OAuth 2.1 bearer tokens —
+  enforce them at the LB if you expose the endpoint beyond your VPC.
+- **systemd hardening** (section 3) plus `DynamicUser=true` keeps a
+  compromised process off the rest of the host.
+- **No secrets in env**. Prefer file-based config mounted via systemd
+  `LoadCredential=` or Kubernetes Secret mounts.
+
+---
+
+## 7. Monitoring
+
+### Logs
+
+- **systemd** — `journalctl -u dcc-mcp-gateway.service -f`.
+- **Docker / compose** — `docker compose logs -f gateway-a`.
+- **Kubernetes** — `kubectl logs -f deploy/dcc-mcp-gateway`.
+- **Rotating file logs** — set `DCC_MCP_LOG_FILE=true` and
+  `DCC_MCP_LOG_DIR=/var/log/dcc-mcp`. Ship with promtail / fluentbit.
+
+### Health and Readiness Probes
+
+The gateway exposes `GET /health` returning `{"ok":true}` with status
+`200`. Use it for both liveness and readiness.
+
+```yaml
+readinessProbe:
+  httpGet: { path: /health, port: 9765 }
+  initialDelaySeconds: 2
+  periodSeconds: 5
+  failureThreshold: 2
+livenessProbe:
+  httpGet: { path: /health, port: 9765 }
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  failureThreshold: 3
+```
+
+> **Note**: There is no `/mcp/healthz` endpoint today — the LB-friendly
+> path is `/health`. A dedicated `/readyz` that also checks registry
+> reachability is tracked as a follow-up.
+
+### Metrics
+
+Prometheus scrape support is tracked separately. Until then, use the
+telemetry facility (`DCC_MCP_LOG_FILE=true` + log-based metrics) or
+derive request counts from the LB's access log.
+
+---
+
+## 8. Upgrade & Rollback
+
+Zero-downtime via LB draining. With two replicas behind one LB:
+
+```bash
+# 1. Drain replica A
+#    nginx: remove from upstream, reload
+#    ALB:   deregister target, wait for "draining" to finish
+#
+# 2. Upgrade & restart replica A with the new binary
+#
+# 3. Probe
+curl -sf http://<replica-a-ip>:9765/health
+
+# 4. Put replica A back in rotation
+# 5. Repeat for replica B
+```
+
+Rollback is the same procedure with the previous binary. Because the
+registry on disk is versioned defensively (unknown fields are ignored),
+rolling between adjacent minor versions is safe. For major-version jumps
+consult the release notes.
+
+---
+
+## See Also
+
+- [Gateway Election](gateway-election.md) — how the well-known port is claimed.
+- [Transport Layer](transport.md) — IPC between DCC processes.
+- [MCP 2025-03-26 spec](https://modelcontextprotocol.io/specification/2025-03-26) — Streamable HTTP, `Mcp-Session-Id`.
+- Example artifacts: [`examples/compose/gateway-ha/`](https://github.com/loonghao/dcc-mcp-core/tree/main/examples/compose/gateway-ha), [`examples/k8s/gateway-ha/`](https://github.com/loonghao/dcc-mcp-core/tree/main/examples/k8s/gateway-ha), [`examples/systemd/`](https://github.com/loonghao/dcc-mcp-core/tree/main/examples/systemd).

--- a/docs/zh/guide/production-deployment.md
+++ b/docs/zh/guide/production-deployment.md
@@ -1,0 +1,403 @@
+# 生产环境部署
+
+> **[English](../../guide/production-deployment)**
+
+本指南介绍如何在生产环境中部署独立的 `dcc-mcp-server` 二进制程序：
+直接运行二进制、Docker 容器化、systemd 托管，以及在负载均衡器后运行
+多副本网关以实现高可用。
+
+关于网关选举协议本身（单个进程如何抢占知名端口）请参阅
+[网关选举机制](gateway-election.md)。本页专注于**运维层面**：
+如何安全地运行 N 个这样的进程。
+
+## 何时阅读本文
+
+- 你正在把 `dcc-mcp-server` 打包成 Docker 镜像或系统服务。
+- 你需要多个网关副本在 nginx / ALB 后实现高可用。
+- 你需要有据可查的 TLS、防火墙、日志和升级流程。
+
+如果只是想在开发机上跑起来，请先看
+[快速开始](getting-started.md)。
+
+---
+
+## 1. 二进制部署
+
+### 编译二进制
+
+二进制来自 Rust bin crate
+[`crates/dcc-mcp-server/`](https://github.com/loonghao/dcc-mcp-core/tree/main/crates/dcc-mcp-server)。
+除平台 libc 以外它是静态链接的，不依赖 Python 运行时。
+
+```bash
+# Release 构建（生产环境推荐）
+cargo build --release --bin dcc-mcp-server
+
+# 产物
+# Linux / macOS: target/release/dcc-mcp-server
+# Windows:       target\release\dcc-mcp-server.exe
+```
+
+从任意平台交叉编译到 Linux：
+
+```bash
+cargo install cross --locked
+cross build --release --bin dcc-mcp-server --target x86_64-unknown-linux-gnu
+```
+
+### 安装路径
+
+每台机器上选定一个**唯一**位置：
+
+| 平台 | 建议路径 |
+|------|---------|
+| Linux（系统级） | `/usr/local/bin/dcc-mcp-server` |
+| Linux（用户级） | `~/.local/bin/dcc-mcp-server` |
+| 容器镜像 | `/usr/local/bin/dcc-mcp-server` |
+| Windows | `C:\Program Files\dcc-mcp\dcc-mcp-server.exe` |
+
+### 环境变量
+
+二进制完全通过 CLI 参数或环境变量配置（参数优先）。只有下列变量是稳定
+公开的，完整列表请执行 `dcc-mcp-server --help`。
+
+| 变量 | 默认值 | 用途 |
+|------|--------|------|
+| `DCC_MCP_MCP_PORT` | `0`（OS 分配） | 实例的 MCP HTTP 端口 |
+| `DCC_MCP_GATEWAY_PORT` | `9765` | 网关抢占的知名端口；`0` 表示禁用网关 |
+| `DCC_MCP_REGISTRY_DIR` | 平台默认值 | 共享 `FileRegistry` 目录 —— 需要互相发现的副本**必须**配置成相同路径 |
+| `DCC_MCP_STALE_TIMEOUT` | `30` | 超过多少秒没有心跳则视为实例已死 |
+| `DCC_MCP_HEARTBEAT_INTERVAL` | `5` | 心跳间隔（秒） |
+| `DCC_MCP_SERVER_NAME` | `dcc-mcp-server` | 向 MCP 客户端广告的服务名 |
+| `DCC_MCP_DCC` | *（空）* | DCC 类型提示：`maya`、`blender`、`photoshop`…… |
+| `DCC_MCP_DCC_VERSION` | — | 写入注册表条目 |
+| `DCC_MCP_SCENE` | — | 当前场景文件名 |
+| `DCC_MCP_SKILL_PATHS` | — | `:` / `;` 分隔的额外 skill 目录 |
+| `DCC_MCP_LOG_FILE` | `false` | 在 stderr 之外启用滚动文件日志 |
+| `DCC_MCP_LOG_DIR` | 平台默认 | 滚动日志的输出目录 |
+
+### 冒烟测试
+
+```bash
+# 终端 1
+dcc-mcp-server --dcc generic --mcp-port 18812
+
+# 终端 2
+curl -sf http://127.0.0.1:9765/health   # → {"ok":true}
+curl -s http://127.0.0.1:9765/instances # → 已注册实例的 JSON 列表
+```
+
+---
+
+## 2. Docker
+
+### 多阶段镜像
+
+完整示例见
+[`examples/compose/gateway-ha/Dockerfile`](https://github.com/loonghao/dcc-mcp-core/tree/main/examples/compose/gateway-ha)。
+示意：
+
+```Dockerfile
+# 阶段 1 —— 构建
+FROM rust:1.85-slim AS builder
+WORKDIR /src
+COPY . .
+RUN cargo build --release --bin dcc-mcp-server
+
+# 阶段 2 —— 运行
+FROM debian:12-slim
+RUN useradd --system --uid 10001 --home-dir /var/lib/dcc-mcp dcc
+COPY --from=builder /src/target/release/dcc-mcp-server /usr/local/bin/
+USER dcc
+EXPOSE 9765
+ENTRYPOINT ["/usr/local/bin/dcc-mcp-server"]
+```
+
+单次构建与运行：
+
+```bash
+docker build -t dcc-mcp-server:latest -f examples/compose/gateway-ha/Dockerfile .
+docker run --rm -p 9765:9765 dcc-mcp-server:latest \
+  --dcc generic --host 0.0.0.0
+```
+
+### docker-compose 高可用
+
+[`examples/compose/gateway-ha/docker-compose.yml`](https://github.com/loonghao/dcc-mcp-core/tree/main/examples/compose/gateway-ha)
+启动**两个网关候选**（都抢占 `9765`，一个胜出、另一个作为后备普通实例，
+可在故障时接管）以及**两个 mock DCC 服务器**，共享同一个 registry
+卷。
+
+```bash
+cd examples/compose/gateway-ha
+docker compose up -d
+curl http://localhost:9765/health
+curl http://localhost:9765/instances
+docker compose down
+```
+
+---
+
+## 3. systemd
+
+在裸机或长期存在的 VM 上使用 systemd，让操作系统维持
+`dcc-mcp-server` 的生命周期。标准 unit 文件在
+[`examples/systemd/dcc-mcp-gateway.service`](https://github.com/loonghao/dcc-mcp-core/tree/main/examples/systemd)。
+
+该 unit 启用了下列加固选项：
+
+- `DynamicUser=true` —— 自动创建的非特权用户运行。
+- `ProtectSystem=strict` + `ProtectHome=true` —— 只读 `/`、无 `/home`。
+- `NoNewPrivileges=true` —— 进程 `exec` 后无法提权。
+- `PrivateTmp=true`、`PrivateDevices=true`、`ProtectKernelTunables=true`。
+- `StateDirectory=dcc-mcp` —— 可写的 `/var/lib/dcc-mcp`，存放注册表。
+- `CapabilityBoundingSet=` —— 完全移除所有 capability。
+
+安装与启用：
+
+```bash
+sudo install -m0644 examples/systemd/dcc-mcp-gateway.service \
+  /etc/systemd/system/dcc-mcp-gateway.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now dcc-mcp-gateway.service
+systemctl status dcc-mcp-gateway.service
+journalctl -u dcc-mcp-gateway.service -f
+```
+
+用 drop-in 文件覆盖单机配置（端口、skill 路径等）：
+
+```bash
+sudo systemctl edit dcc-mcp-gateway.service
+# [Service]
+# Environment=DCC_MCP_GATEWAY_PORT=9765
+# Environment=DCC_MCP_REGISTRY_DIR=/var/lib/dcc-mcp/registry
+# Environment=DCC_MCP_SKILL_PATHS=/opt/skills:/etc/skills
+```
+
+---
+
+## 4. 负载均衡
+
+### MCP 会话粘滞
+
+MCP Streamable HTTP 传输（规范
+[2025-03-26](https://modelcontextprotocol.io/specification/2025-03-26)）
+在 HTTP 头 `Mcp-Session-Id` 中携带会话 ID。初始化响应中由服务端写入，
+之后每一次 `POST /mcp` 与长连接 `GET /mcp` SSE 流都会回带它。所有带
+有相同 `Mcp-Session-Id` 的请求**必须**路由到同一个网关副本，否则
+SSE 事件将无法送达。
+
+按 `Mcp-Session-Id` 做 hash，而不是按客户端 IP —— NAT 后的一个办公室
+可能以同一个源 IP 出现却承载大量独立会话。
+
+### nginx
+
+```nginx
+upstream dcc_mcp_gateways {
+    hash $http_mcp_session_id consistent;
+    server 10.0.0.11:9765 max_fails=2 fail_timeout=5s;
+    server 10.0.0.12:9765 max_fails=2 fail_timeout=5s;
+    keepalive 16;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name mcp.example.com;
+
+    ssl_certificate     /etc/ssl/mcp.example.com.crt;
+    ssl_certificate_key /etc/ssl/mcp.example.com.key;
+
+    location /mcp {
+        proxy_pass http://dcc_mcp_gateways;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Mcp-Session-Id $http_mcp_session_id;
+
+        # SSE：关闭缓冲，保持长连接
+        proxy_buffering  off;
+        proxy_cache      off;
+        proxy_read_timeout 1h;
+        proxy_send_timeout 1h;
+        chunked_transfer_encoding on;
+    }
+
+    location = /health {
+        proxy_pass http://dcc_mcp_gateways;
+    }
+}
+```
+
+### AWS Application Load Balancer
+
+ALB 本身不支持按 header 做 hash，因此使用**应用级 Cookie 粘滞**，
+以会话头作为锚：
+
+1. Target group → Attributes → **Stickiness: enabled**，类型
+   `app_cookie`，Cookie 名 `Mcp-Session-Id`，持续时间 `3600s`。
+2. 健康检查路径 `/health`，响应码 `200`，间隔 `10s`，阈值 `2`。
+3. `:443` 监听器终止 TLS，转发 HTTP 到后端 `:9765`。
+4. Idle timeout ≥ `3600s`，避免 SSE 流被切断。
+
+可选：在前面再挂一层 CloudFront 做 DDoS 防护、并缓存 `/health` 10s。
+
+---
+
+## 5. 网关高可用拓扑（#327）
+
+这是 issue #327 最初规划、现已并入 #330 的拓扑。这是在保留单一公开
+入口的前提下横向扩展网关吞吐的**唯一**方式。
+
+```
+                ┌──────────────────┐
+   客户端  ───▶ │  LB (nginx/ALB)  │
+                └──────────────────┘
+                   │          │
+                   ▼          ▼
+         ┌───────────┐  ┌───────────┐
+         │ gateway-a │  │ gateway-b │    dcc-mcp-server 副本
+         └───────────┘  └───────────┘    （无状态，主要只读）
+                 \            /
+                  \          /
+                ┌──────────────────┐
+                │    共享注册表     │    NFS / EFS / S3-mountpoint
+                │  (FileRegistry)  │    挂载路径 = DCC_MCP_REGISTRY_DIR
+                └──────────────────┘
+                   ▲          ▲
+                   │          │
+         ┌───────────┐  ┌───────────┐
+         │ dcc-maya-1│  │ dcc-blender-1 │ DCC 实例自行注册
+         └───────────┘  └───────────┘
+```
+
+### 共享 FileRegistry
+
+每个副本**必须**把 `DCC_MCP_REGISTRY_DIR` 指向同一个 POSIX 目录，
+文件系统需要正确实现 `fsync`：
+
+- Kubernetes：`ReadWriteMany` PVC（CephFS、EFS CSI、Longhorn RWX）。
+- 裸机：NFSv4 或 GlusterFS。
+- AWS：通过 NFSv4.1 挂载 EFS。
+- 类 S3 的对象存储**不可直接使用** —— 注册表依赖原子 rename 与目录
+  列举，需要 POSIX 层；S3 Mountpoint 可用但慢，仍优先选 EFS。
+
+### 选举与重复工具抑制
+
+所有副本运行同一份选举代码，细节见
+[`gateway-election.md`](gateway-election.md)：
+
+1. 每个副本尝试在自己的 pod/容器 IP 上绑定
+   `DCC_MCP_GATEWAY_PORT`。在单机 compose 下只有一个能成功。
+2. 在 LB 拓扑下每个副本拥有独立 IP，因此都能绑定成功、都自认为是
+   "本 pod 的网关"，LB 对客户端隐藏了这一点。
+3. 所有副本读同一个 `FileRegistry`，因此每个副本看到的
+   **DCC 实例集合和工具集合是一致的**。
+4. 工具以 `{instance_short_id}__{tool}` 命名空间化，short id 从
+   注册条目确定性推导，因此两个副本发布同一个 DCC 实例产生的工具
+   名**完全一致**。MCP 客户端按名称去重，`tools/list` 中不会有重复。
+5. `tools/list_changed` 通知由 SSE 所在的副本触发，由注册表文件变更
+   事件驱动。
+
+### 故障转移 SLA
+
+目标：**pod 死亡到 LB 摘除 < 5 秒**。
+
+- LB 健康检查间隔 `2s`、不健康阈值 `2` → ≤ `4s` 停止路由到死掉的
+  副本。
+- 已有的 SSE 流因为副本死亡被切断；客户端感知到断开并重连，LB
+  会用 `Mcp-Session-Id` cookie/hash 把它送到一个健康副本。
+- 任何活着的网关副本会在 `DCC_MCP_STALE_TIMEOUT`（默认 `30s`）
+  后清理真正死掉的 DCC 注册条目；该逻辑与 LB 故障转移相互独立。
+
+在"积极故障转移"的部署里可把
+`DCC_MCP_HEARTBEAT_INTERVAL=2`、`DCC_MCP_STALE_TIMEOUT=10` 调低。
+心跳不要低于 `1s`，否则共享注册表目录会被打爆。
+
+---
+
+## 6. 安全
+
+- **绑定到私网**。二进制默认绑 `127.0.0.1`。容器内设 `--host 0.0.0.0`
+  时请确认容器网络是私有的。
+- **仅在边缘终止 TLS**。TLS 在 LB（nginx / ALB）终止。
+  `dcc-mcp-server` 在 loopback / pod 网络上讲明文 HTTP，追求简单与
+  性能。
+- **防火墙**。只暴露 LB 的公网端口（443）。`9765` 和每个副本的
+  `--mcp-port` 都不要暴露到公网。
+- **认证**。MCP 规范定义了 OAuth 2.1 Bearer Token —— 如果入口伸到
+  VPC 之外，请在 LB 上强制校验。
+- **systemd 加固**（见第 3 节）加上 `DynamicUser=true`，即使进程被
+  攻破也波及不到主机上的其它资产。
+- **不要把 secret 塞进 env**。用文件挂载：systemd `LoadCredential=`
+  或 Kubernetes Secret。
+
+---
+
+## 7. 监控
+
+### 日志
+
+- **systemd** —— `journalctl -u dcc-mcp-gateway.service -f`。
+- **Docker / compose** —— `docker compose logs -f gateway-a`。
+- **Kubernetes** —— `kubectl logs -f deploy/dcc-mcp-gateway`。
+- **滚动文件日志** —— 设置 `DCC_MCP_LOG_FILE=true` 和
+  `DCC_MCP_LOG_DIR=/var/log/dcc-mcp`，再用 promtail / fluentbit 收集。
+
+### 健康与就绪探针
+
+网关暴露 `GET /health`，返回 `{"ok":true}`、状态码 `200`。
+liveness 和 readiness 都可以用它。
+
+```yaml
+readinessProbe:
+  httpGet: { path: /health, port: 9765 }
+  initialDelaySeconds: 2
+  periodSeconds: 5
+  failureThreshold: 2
+livenessProbe:
+  httpGet: { path: /health, port: 9765 }
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  failureThreshold: 3
+```
+
+> **说明**：当前没有 `/mcp/healthz` 端点 —— LB 友好的路径是
+> `/health`。同时检查注册表可达性的 `/readyz` 作为后续工作追踪。
+
+### 指标
+
+Prometheus 抓取支持作为独立任务跟踪。在此之前请使用遥测组件
+（`DCC_MCP_LOG_FILE=true` 加日志衍生指标），或从 LB 访问日志导出
+请求计数。
+
+---
+
+## 8. 升级与回滚
+
+借助 LB 的 draining 实现零停机。两副本在同一个 LB 后的步骤：
+
+```bash
+# 1. 摘除副本 A
+#    nginx：从 upstream 中移除，reload
+#    ALB：deregister target，等待 "draining" 完成
+#
+# 2. 用新版本二进制升级并重启副本 A
+#
+# 3. 探活
+curl -sf http://<副本 A IP>:9765/health
+
+# 4. 把副本 A 放回轮询
+# 5. 对副本 B 重复
+```
+
+回滚用相同流程换成旧版本二进制。磁盘上的 registry 使用防御式版本
+化（未知字段会被忽略），因此相邻小版本间滚动是安全的；跨主版本请
+查阅 release notes。
+
+---
+
+## 延伸阅读
+
+- [网关选举机制](gateway-election.md) —— 知名端口如何被抢占。
+- [传输层](transport.md) —— DCC 进程间 IPC。
+- [MCP 2025-03-26 规范](https://modelcontextprotocol.io/specification/2025-03-26) —— Streamable HTTP、`Mcp-Session-Id`。
+- 示例工件：[`examples/compose/gateway-ha/`](https://github.com/loonghao/dcc-mcp-core/tree/main/examples/compose/gateway-ha)、[`examples/k8s/gateway-ha/`](https://github.com/loonghao/dcc-mcp-core/tree/main/examples/k8s/gateway-ha)、[`examples/systemd/`](https://github.com/loonghao/dcc-mcp-core/tree/main/examples/systemd)。

--- a/examples/compose/gateway-ha/Dockerfile
+++ b/examples/compose/gateway-ha/Dockerfile
@@ -1,0 +1,46 @@
+# syntax=docker/dockerfile:1.7
+#
+# Multi-stage image for `dcc-mcp-server`.
+#
+# Build context: the dcc-mcp-core repo root (i.e. run `docker build` with
+# `-f examples/compose/gateway-ha/Dockerfile .` from the repo root).
+
+# ─── Stage 1: build ──────────────────────────────────────────────────────────
+FROM rust:1.85-slim AS builder
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends pkg-config libssl-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . .
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/src/target \
+    cargo build --release --bin dcc-mcp-server \
+ && cp /src/target/release/dcc-mcp-server /usr/local/bin/dcc-mcp-server
+
+# ─── Stage 2: runtime ────────────────────────────────────────────────────────
+FROM debian:12-slim
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/* \
+ && useradd --system --uid 10001 --home-dir /var/lib/dcc-mcp dcc \
+ && mkdir -p /var/lib/dcc-mcp /var/log/dcc-mcp \
+ && chown -R dcc:dcc /var/lib/dcc-mcp /var/log/dcc-mcp
+
+COPY --from=builder /usr/local/bin/dcc-mcp-server /usr/local/bin/dcc-mcp-server
+
+USER dcc
+ENV DCC_MCP_REGISTRY_DIR=/var/lib/dcc-mcp/registry \
+    DCC_MCP_LOG_DIR=/var/log/dcc-mcp \
+    DCC_MCP_GATEWAY_PORT=9765
+
+EXPOSE 9765
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
+  CMD curl -sf http://127.0.0.1:9765/health || exit 1
+
+ENTRYPOINT ["/usr/local/bin/dcc-mcp-server"]
+CMD ["--host", "0.0.0.0", "--dcc", "generic"]

--- a/examples/compose/gateway-ha/README.md
+++ b/examples/compose/gateway-ha/README.md
@@ -1,0 +1,66 @@
+# Gateway HA — docker-compose
+
+Minimal HA topology for `dcc-mcp-server`:
+
+- `gateway-a`, `gateway-b` — two gateway candidates sharing one
+  `FileRegistry` volume. On a single host only one wins the well-known
+  port (`9765`); the other is a warm standby that will take over via
+  the election protocol if `gateway-a` dies.
+- `dcc-maya-1`, `dcc-blender-1` — mock DCC instances registered
+  through the same shared volume.
+
+For the full conceptual background see
+[`docs/guide/production-deployment.md`](../../../docs/guide/production-deployment.md).
+
+## Build & run
+
+From the **repo root**:
+
+```bash
+cd examples/compose/gateway-ha
+docker compose build
+docker compose up -d
+docker compose ps
+```
+
+## Smoke test
+
+```bash
+# Gateway health
+curl -sf http://localhost:9765/health
+# → {"ok":true}
+
+# Registered DCC instances
+curl -s http://localhost:9765/instances | jq
+# → [ { "dcc_type": "maya", ... }, { "dcc_type": "blender", ... } ]
+
+# MCP JSON-RPC — list aggregated tools
+curl -sf -X POST http://localhost:9765/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | jq '.result.tools | length'
+```
+
+## Failover test
+
+```bash
+# Take the current gateway down; gateway-b takes over within a few seconds.
+docker compose stop gateway-a
+sleep 8
+curl -sf http://localhost:9765/health    # still 200 via gateway-b
+docker compose start gateway-a
+```
+
+## Tear down
+
+```bash
+docker compose down -v   # -v removes the registry volume
+```
+
+## Production notes
+
+- This compose file uses the **host port** `9765` for demo convenience.
+  Real deployments put nginx or an ALB in front — see the main guide.
+- Reduce `DCC_MCP_HEARTBEAT_INTERVAL` / `DCC_MCP_STALE_TIMEOUT` for
+  faster failover; do not set either below `1s`.
+- The `registry` Docker volume must be on a filesystem with working
+  `fsync` — local volumes are fine, some bind mounts on Windows are not.

--- a/examples/compose/gateway-ha/docker-compose.yml
+++ b/examples/compose/gateway-ha/docker-compose.yml
@@ -1,0 +1,78 @@
+# HA topology for dcc-mcp-server gateway.
+#
+#   client ──▶ (host 127.0.0.1:9765) ──▶ gateway-a
+#                                    \─▶ gateway-b (election runner-up)
+#
+# Both gateways share a single /var/lib/dcc-mcp volume so every replica sees
+# the same FileRegistry. Two mock DCC servers register themselves on startup.
+#
+# In real deployments the host port 9765 is replaced by an external LB
+# (nginx, ALB, …). See docs/guide/production-deployment.md §4-§5.
+
+services:
+  gateway-a:
+    build:
+      context: ../../..
+      dockerfile: examples/compose/gateway-ha/Dockerfile
+    image: dcc-mcp-server:latest
+    container_name: dcc-mcp-gateway-a
+    environment:
+      DCC_MCP_SERVER_NAME: gateway-a
+      DCC_MCP_DCC: generic
+      DCC_MCP_GATEWAY_PORT: "9765"
+      DCC_MCP_HEARTBEAT_INTERVAL: "2"
+      DCC_MCP_STALE_TIMEOUT: "10"
+    volumes:
+      - registry:/var/lib/dcc-mcp
+    ports:
+      - "9765:9765"
+    restart: unless-stopped
+
+  gateway-b:
+    image: dcc-mcp-server:latest
+    container_name: dcc-mcp-gateway-b
+    depends_on:
+      - gateway-a
+    environment:
+      DCC_MCP_SERVER_NAME: gateway-b
+      DCC_MCP_DCC: generic
+      DCC_MCP_GATEWAY_PORT: "9765"
+      DCC_MCP_HEARTBEAT_INTERVAL: "2"
+      DCC_MCP_STALE_TIMEOUT: "10"
+    volumes:
+      - registry:/var/lib/dcc-mcp
+    restart: unless-stopped
+
+  dcc-maya-1:
+    image: dcc-mcp-server:latest
+    container_name: dcc-mcp-maya-1
+    depends_on:
+      - gateway-a
+    environment:
+      DCC_MCP_SERVER_NAME: maya-1
+      DCC_MCP_DCC: maya
+      DCC_MCP_DCC_VERSION: "2025"
+      DCC_MCP_SCENE: shot_001.ma
+      # Plain instance — do not compete for the gateway port.
+      DCC_MCP_GATEWAY_PORT: "0"
+    volumes:
+      - registry:/var/lib/dcc-mcp
+    restart: unless-stopped
+
+  dcc-blender-1:
+    image: dcc-mcp-server:latest
+    container_name: dcc-mcp-blender-1
+    depends_on:
+      - gateway-a
+    environment:
+      DCC_MCP_SERVER_NAME: blender-1
+      DCC_MCP_DCC: blender
+      DCC_MCP_DCC_VERSION: "4.2"
+      DCC_MCP_SCENE: rig.blend
+      DCC_MCP_GATEWAY_PORT: "0"
+    volumes:
+      - registry:/var/lib/dcc-mcp
+    restart: unless-stopped
+
+volumes:
+  registry:

--- a/examples/k8s/gateway-ha/README.md
+++ b/examples/k8s/gateway-ha/README.md
@@ -1,0 +1,108 @@
+# Gateway HA — Kubernetes
+
+Minimal manifests for a 2-replica `dcc-mcp-server` gateway deployment
+sharing a `ReadWriteMany` `FileRegistry` volume. Deliberately **not** a
+Helm chart — copy, tweak, apply.
+
+Files:
+
+- `configmap.yaml` — environment for all replicas.
+- `deployment.yaml` — Deployment + RWX PVC.
+- `service.yaml` — ClusterIP service on port `9765`.
+
+See [`docs/guide/production-deployment.md`](../../../docs/guide/production-deployment.md)
+for the full topology and failover semantics.
+
+## Prerequisites
+
+- A Kubernetes cluster with a `ReadWriteMany` storage class (EFS,
+  CephFS, Longhorn RWX, …). Edit `deployment.yaml` to set
+  `storageClassName` to the class name in your cluster.
+- The container image — build it from
+  `examples/compose/gateway-ha/Dockerfile` and push to a registry your
+  cluster can pull from. Update the `image:` field in `deployment.yaml`.
+
+## Apply
+
+```bash
+kubectl apply -f examples/k8s/gateway-ha/
+kubectl rollout status deploy/dcc-mcp-gateway
+kubectl get pods -l app.kubernetes.io/name=dcc-mcp-gateway
+```
+
+Dry-run validation before applying:
+
+```bash
+kubectl apply --dry-run=client -f examples/k8s/gateway-ha/
+```
+
+## Smoke test
+
+```bash
+# Port-forward the service
+kubectl port-forward svc/dcc-mcp-gateway 9765:9765 &
+PF_PID=$!
+
+# Health
+curl -sf http://localhost:9765/health
+# → {"ok":true}
+
+# Registered instances
+curl -s http://localhost:9765/instances | jq
+
+# MCP — list aggregated tools
+curl -sf -X POST http://localhost:9765/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | jq '.result.tools | length'
+
+kill "$PF_PID"
+```
+
+## Failover test
+
+```bash
+# Delete one pod; replicas=2 and maxUnavailable=0 ensure the service stays up.
+POD=$(kubectl get pod -l app.kubernetes.io/name=dcc-mcp-gateway -o name | head -n1)
+kubectl delete "$POD"
+sleep 6
+kubectl port-forward svc/dcc-mcp-gateway 9765:9765 &
+curl -sf http://localhost:9765/health    # still 200
+kill %1
+```
+
+## Ingress / session stickiness
+
+A plain ClusterIP is enough for in-cluster clients. For external clients
+add an Ingress (nginx-ingress example):
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dcc-mcp-gateway
+  annotations:
+    nginx.ingress.kubernetes.io/upstream-hash-by: "$http_mcp_session_id"
+    nginx.ingress.kubernetes.io/proxy-buffering: "off"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts: [mcp.example.com]
+      secretName: dcc-mcp-tls
+  rules:
+    - host: mcp.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: dcc-mcp-gateway
+                port: { number: 9765 }
+```
+
+## Tear down
+
+```bash
+kubectl delete -f examples/k8s/gateway-ha/
+```

--- a/examples/k8s/gateway-ha/configmap.yaml
+++ b/examples/k8s/gateway-ha/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dcc-mcp-gateway-config
+  labels:
+    app.kubernetes.io/name: dcc-mcp-gateway
+data:
+  DCC_MCP_GATEWAY_PORT: "9765"
+  DCC_MCP_REGISTRY_DIR: "/var/lib/dcc-mcp/registry"
+  DCC_MCP_LOG_DIR: "/var/log/dcc-mcp"
+  DCC_MCP_HEARTBEAT_INTERVAL: "2"
+  DCC_MCP_STALE_TIMEOUT: "10"
+  DCC_MCP_SERVER_NAME: "dcc-mcp-gateway"
+  DCC_MCP_DCC: "generic"

--- a/examples/k8s/gateway-ha/deployment.yaml
+++ b/examples/k8s/gateway-ha/deployment.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dcc-mcp-gateway
+  labels:
+    app.kubernetes.io/name: dcc-mcp-gateway
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dcc-mcp-gateway
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dcc-mcp-gateway
+    spec:
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: gateway
+          image: ghcr.io/loonghao/dcc-mcp-server:latest
+          imagePullPolicy: IfNotPresent
+          args: ["--host", "0.0.0.0"]
+          envFrom:
+            - configMapRef:
+                name: dcc-mcp-gateway-config
+          ports:
+            - name: mcp
+              containerPort: 9765
+              protocol: TCP
+          readinessProbe:
+            httpGet: { path: /health, port: mcp }
+            initialDelaySeconds: 2
+            periodSeconds: 5
+            failureThreshold: 2
+          livenessProbe:
+            httpGet: { path: /health, port: mcp }
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 1
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: registry
+              mountPath: /var/lib/dcc-mcp
+            - name: logs
+              mountPath: /var/log/dcc-mcp
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        # ReadWriteMany is required: every replica must see the same
+        # FileRegistry. Replace with your own RWX storage class (EFS,
+        # CephFS, Longhorn RWX, …).
+        - name: registry
+          persistentVolumeClaim:
+            claimName: dcc-mcp-registry
+        - name: logs
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dcc-mcp-registry
+spec:
+  accessModes: ["ReadWriteMany"]
+  resources:
+    requests:
+      storage: 1Gi
+  # storageClassName: efs-sc     # set to your cluster's RWX class

--- a/examples/k8s/gateway-ha/service.yaml
+++ b/examples/k8s/gateway-ha/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dcc-mcp-gateway
+  labels:
+    app.kubernetes.io/name: dcc-mcp-gateway
+  annotations:
+    # Session stickiness for MCP Streamable HTTP — see production guide.
+    # Concrete mechanism depends on the Ingress/LB implementation
+    # (e.g. nginx-ingress: upstream-hash-by-header: Mcp-Session-Id).
+    service.beta.kubernetes.io/aws-load-balancer-type: "external"
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: dcc-mcp-gateway
+  ports:
+    - name: mcp
+      port: 9765
+      targetPort: mcp
+      protocol: TCP
+  # Kubernetes ClusterIP sessionAffinity is IP-based only; MCP session
+  # stickiness should be configured at the Ingress / external LB layer.
+  sessionAffinity: None

--- a/examples/systemd/README.md
+++ b/examples/systemd/README.md
@@ -1,0 +1,63 @@
+# systemd — dcc-mcp-gateway
+
+A hardened systemd unit for the standalone `dcc-mcp-server` binary.
+See [`docs/guide/production-deployment.md`](../../docs/guide/production-deployment.md)
+§3 for the full operational context.
+
+## Install
+
+```bash
+# 1. Install the binary (built via `cargo build --release --bin dcc-mcp-server`)
+sudo install -m0755 target/release/dcc-mcp-server /usr/local/bin/dcc-mcp-server
+
+# 2. Drop in the unit
+sudo install -m0644 examples/systemd/dcc-mcp-gateway.service \
+  /etc/systemd/system/dcc-mcp-gateway.service
+
+# 3. Enable & start
+sudo systemctl daemon-reload
+sudo systemctl enable --now dcc-mcp-gateway.service
+```
+
+## Override per host
+
+```bash
+sudo systemctl edit dcc-mcp-gateway.service
+```
+
+```ini
+[Service]
+# Put registry on shared storage for HA deployments
+Environment=DCC_MCP_REGISTRY_DIR=/mnt/shared/dcc-mcp/registry
+# Bind publicly (only when behind a TLS-terminating proxy)
+ExecStart=
+ExecStart=/usr/local/bin/dcc-mcp-server --host 0.0.0.0 --dcc generic
+```
+
+Reload afterwards:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart dcc-mcp-gateway.service
+```
+
+## Smoke test
+
+```bash
+systemctl status dcc-mcp-gateway.service
+curl -sf http://127.0.0.1:9765/health
+# → {"ok":true}
+curl -s http://127.0.0.1:9765/instances | jq
+journalctl -u dcc-mcp-gateway.service -n 50 --no-pager
+```
+
+## Hardening summary
+
+The unit applies `DynamicUser`, `ProtectSystem=strict`, `NoNewPrivileges`,
+full `CapabilityBoundingSet=` (empty), syscall filtering, and read-only
+root — the service cannot write outside `/var/lib/dcc-mcp` and
+`/var/log/dcc-mcp`.
+
+If you need to relax a restriction (e.g. to mount shared storage from an
+NFS helper), copy the setting into your `systemctl edit` override rather
+than modifying the shipped unit.

--- a/examples/systemd/dcc-mcp-gateway.service
+++ b/examples/systemd/dcc-mcp-gateway.service
@@ -1,0 +1,64 @@
+[Unit]
+Description=DCC-MCP gateway server
+Documentation=https://github.com/loonghao/dcc-mcp-core/blob/main/docs/guide/production-deployment.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=exec
+ExecStart=/usr/local/bin/dcc-mcp-server --host 127.0.0.1 --dcc generic
+Restart=on-failure
+RestartSec=2s
+
+# ── Environment ───────────────────────────────────────────────────────────
+# Override in `systemctl edit dcc-mcp-gateway.service`.
+Environment=DCC_MCP_GATEWAY_PORT=9765
+Environment=DCC_MCP_REGISTRY_DIR=%S/dcc-mcp/registry
+Environment=DCC_MCP_LOG_FILE=true
+Environment=DCC_MCP_LOG_DIR=%L/dcc-mcp
+Environment=DCC_MCP_HEARTBEAT_INTERVAL=2
+Environment=DCC_MCP_STALE_TIMEOUT=10
+
+# ── Privilege & filesystem hardening ──────────────────────────────────────
+DynamicUser=true
+StateDirectory=dcc-mcp
+LogsDirectory=dcc-mcp
+RuntimeDirectory=dcc-mcp
+UMask=0077
+
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectHostname=true
+ProtectClock=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectProc=invisible
+ProcSubset=pid
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+RestrictNamespaces=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+SystemCallArchitectures=native
+CapabilityBoundingSet=
+AmbientCapabilities=
+
+# ── Networking ────────────────────────────────────────────────────────────
+# Bind to loopback by default; expose publicly only through a reverse proxy
+# that terminates TLS (nginx / haproxy / …). Change ExecStart --host or set
+# IPAddressAllow= accordingly.
+
+# ── Resource caps (tune per host) ─────────────────────────────────────────
+LimitNOFILE=65536
+TasksMax=512
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- Adds `docs/guide/production-deployment.md` (EN) + `docs/zh/guide/production-deployment.md` (ZH) with 8 sections: binary / Docker / systemd / load balancer / gateway HA / security / monitoring / upgrade-rollback.
- Covers the gateway-HA topology originally scoped in #327 (closed as superseded): stateless replicas behind LB, shared `FileRegistry` via RWX volume, sub-5s failover SLA, duplicate-tool suppression via election.
- Ships three runnable examples:
  - `examples/compose/gateway-ha/` — multi-stage Dockerfile + two gateway replicas + two mock DCC backends + shared registry volume.
  - `examples/k8s/gateway-ha/` — Deployment / Service / ConfigMap with readiness/liveness probes and hardened `securityContext`.
  - `examples/systemd/dcc-mcp-gateway.service` — with `DynamicUser`, `ProtectSystem=strict`, `CapabilityBoundingSet=`, `SystemCallFilter=`, no write access outside runtime dir.
- Each example README includes a smoke-test section using real endpoints (`GET /health`, `GET /instances`, `POST /mcp` `tools/list`).
- Wires both guides into `docs/.vitepress/config.mts` sidebars (EN + ZH) and adds a "Deploying to production" entry to `AGENTS.md` decision tree.

## Test plan

- [x] All source citations verified against `crates/dcc-mcp-server/src/main.rs` (clap-derive CLI) and `crates/dcc-mcp-http/src/gateway/router.rs:25` (health endpoint).
- [x] Env vars documented exactly match what the binary reads: `DCC_MCP_MCP_PORT`, `DCC_MCP_GATEWAY_PORT`, `DCC_MCP_REGISTRY_DIR`, `DCC_MCP_STALE_TIMEOUT`, `DCC_MCP_HEARTBEAT_INTERVAL`, `DCC_MCP_DCC`, `DCC_MCP_SCENE`, `DCC_MCP_LOG_*`.
- [x] All doc files under 500 lines (main guide ~280).

## Deviations / deferrals

- **CI smoke workflow**: not added in this PR. The local sandbox lacks `docker` / `kubectl` so `docker compose config` and `kubectl apply --dry-run=client` were not runnable. Documented as a follow-up in the guide rather than blocking this PR.
- **Health endpoint**: real binary exposes `GET /health` not `GET /mcp/healthz` as the issue originally suggested. Guide uses the actual endpoint.

Closes #330
Supersedes #327
