### PR TITLE
feat(skills): accept agentskills.io-compliant metadata.dcc-mcp.* keys

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -526,6 +526,7 @@ json_str = result.to_json()    # JSON string
 - Don't import `DeferredExecutor` from public `__init__` — use `from dcc_mcp_core._core import DeferredExecutor`
 - Don't call `.new_auto()` then `.capture_window()` — use `.new_window_auto()` for single-window capture
 - Don't use legacy APIs: `ActionManager`, `create_action_manager()`, `MiddlewareChain`, `Action` — removed in v0.12+
+- Don't put dcc-mcp-core extension keys at the top level of new SKILL.md files (v0.15+ / issue #356) — use the `metadata.dcc-mcp.*` form (`metadata["dcc-mcp.dcc"]`, `metadata["dcc-mcp.tools"] = "tools.yaml"`). Top-level `dcc:`/`tags:`/`tools:`/`groups:`/`depends:`/`search-hint:` still parse for backward compat but trigger a deprecation warn and `is_spec_compliant()` returns `False`. See `docs/guide/skills.md#migrating-pre-015-skillmd`.
 - Don't use removed transport APIs: `FramedChannel`, `connect_ipc()`, `IpcListener`, `TransportManager`, `CircuitBreaker`, `ConnectionPool` — removed in v0.14 (#251). Use `IpcChannelAdapter` / `DccLinkFrame` instead
 - Don't add Python runtime dependencies — the project is zero-dep by design
 - Don't manually bump versions or edit `CHANGELOG.md` — Release Please handles this

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ When you need information, read in this order — stop when you find what you ne
   - **Embedded Python** (`DccServerBase`) — Maya, Blender, Houdini, Unreal
   - **WebSocket Bridge** (`DccBridge`) — Photoshop, ZBrush, Unity, After Effects
   - **WebView Host** (`WebViewAdapter`) — AuroraView, Electron panels
-- **SKILL.md frontmatter fields**: agentskills.io standard (`name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools`) + dcc-mcp-core extensions (`dcc`, `tags`, `search-hint`, `tools`, `groups`, `depends`, `next-tools`)
+- **SKILL.md frontmatter fields**: agentskills.io standard (`name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools`) + dcc-mcp-core extensions. **v0.15+ (issue #356)**: prefer the agentskills.io-compliant `metadata.dcc-mcp.*` form (e.g. `metadata["dcc-mcp.dcc"]`, `metadata["dcc-mcp.tools"] = "tools.yaml"`); top-level legacy extension keys (`dcc`, `tags`, `search-hint`, `tools`, `groups`, `depends`, `next-tools`) still parse but emit a one-shot deprecation warning and `SkillMetadata.is_spec_compliant()` returns `False`. See `docs/guide/skills.md#migrating-pre-015-skillmd`.
 - **`next-tools`**: Per-tool field guiding AI agents to follow-up tools (`on-success` / `on-failure`). dcc-mcp-core extension, not in agentskills.io spec.
 - **`allowed-tools`**: Experimental agentskills.io field — space-separated pre-approved tool strings (e.g. `Bash(git:*) Read`)
 

--- a/crates/dcc-mcp-models/src/skill_metadata.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata.rs
@@ -807,6 +807,16 @@ pub struct SkillMetadata {
     /// the catalog auto-inserts an inactive placeholder group at load time.
     #[serde(default)]
     pub groups: Vec<SkillGroup>,
+
+    /// Names of legacy top-level extension fields detected while parsing
+    /// this skill's SKILL.md (issue #356).
+    ///
+    /// Populated by the loader, not by serde. When empty the skill uses the
+    /// agentskills.io-compliant `metadata.dcc-mcp.*` form exclusively; when
+    /// non-empty the skill still relies on deprecated top-level extension
+    /// keys. See [`SkillMetadata::is_spec_compliant`].
+    #[serde(default, skip_serializing, skip_deserializing)]
+    pub legacy_extension_fields: Vec<String>,
 }
 
 impl SkillMetadata {
@@ -891,6 +901,17 @@ impl SkillMetadata {
                     .collect()
             })
             .unwrap_or_default()
+    }
+
+    /// Returns `true` iff no legacy top-level extension fields were used
+    /// when this skill's SKILL.md was parsed.
+    ///
+    /// Spec-compliant skills declare all dcc-mcp-specific keys under the
+    /// `metadata.dcc-mcp.*` namespace (agentskills.io v1.0). Legacy skills
+    /// declared them as top-level YAML fields (`dcc`, `tags`, `tools`, …).
+    /// See issue #356.
+    pub fn is_spec_compliant(&self) -> bool {
+        self.legacy_extension_fields.is_empty()
     }
 
     /// Returns true if this skill has any validation warnings.
@@ -1125,6 +1146,7 @@ impl SkillMetadata {
             policy: None,
             external_deps: None,
             groups: Vec::new(),
+            legacy_extension_fields: Vec::new(),
         }
     }
 
@@ -1215,6 +1237,15 @@ impl SkillMetadata {
     }
 
     #[getter]
+    fn search_hint(&self) -> &str {
+        &self.search_hint
+    }
+    #[setter]
+    fn set_search_hint(&mut self, v: String) {
+        self.search_hint = v;
+    }
+
+    #[getter]
     fn scripts(&self) -> Vec<String> {
         self.scripts.clone()
     }
@@ -1257,6 +1288,15 @@ impl SkillMetadata {
     #[setter]
     fn set_tools(&mut self, v: Vec<ToolDeclaration>) {
         self.tools = v;
+    }
+
+    #[getter]
+    fn groups(&self) -> Vec<SkillGroup> {
+        self.groups.clone()
+    }
+    #[setter]
+    fn set_groups(&mut self, v: Vec<SkillGroup>) {
+        self.groups = v;
     }
 
     // ── metadata field: JSON value exposed as Python dict ──────────────
@@ -1376,6 +1416,21 @@ impl SkillMetadata {
     #[pyo3(name = "validate")]
     fn py_validate(&self) -> Vec<String> {
         SkillMetadata::validate(self)
+    }
+
+    /// Returns ``True`` iff this skill uses the agentskills.io-compliant
+    /// ``metadata.dcc-mcp.*`` form exclusively (no legacy top-level
+    /// extension keys).  See issue #356.
+    #[pyo3(name = "is_spec_compliant")]
+    fn py_is_spec_compliant(&self) -> bool {
+        SkillMetadata::is_spec_compliant(self)
+    }
+
+    /// Names of legacy top-level extension fields that were observed when
+    /// parsing this skill's SKILL.md.  Empty list ⇒ spec-compliant.
+    #[getter]
+    fn legacy_extension_fields(&self) -> Vec<String> {
+        self.legacy_extension_fields.clone()
     }
 }
 
@@ -1622,6 +1677,7 @@ mod tests {
             policy: None,
             external_deps: None,
             groups: Vec::new(),
+            legacy_extension_fields: Vec::new(),
         };
         let json = serde_json::to_string(&meta).unwrap();
         let back: SkillMetadata = serde_json::from_str(&json).unwrap();

--- a/crates/dcc-mcp-skills/src/loader/mod.rs
+++ b/crates/dcc-mcp-skills/src/loader/mod.rs
@@ -9,12 +9,50 @@
 #[cfg(feature = "python-bindings")]
 use pyo3::prelude::*;
 
-use dcc_mcp_models::SkillMetadata;
+use dcc_mcp_models::{SkillGroup, SkillMetadata, ToolDeclaration};
 use dcc_mcp_utils::constants::{
     DEPENDS_FILE, SKILL_METADATA_DIR, SKILL_METADATA_FILE, SKILL_SCRIPTS_DIR,
 };
 use dcc_mcp_utils::filesystem::path_to_string;
 use std::path::Path;
+
+/// Namespace prefix for agentskills.io-compliant dcc-mcp-core metadata keys
+/// (issue #356). Keys under `metadata.dcc-mcp.*` take priority over the
+/// legacy top-level form.
+const DCC_MCP_PREFIX: &str = "dcc-mcp.";
+
+/// Top-level YAML keys allowed by the agentskills.io 1.0 spec; any other
+/// extension key observed at the frontmatter root is considered legacy
+/// (see issue #356).
+const AGENTSKILLS_SPEC_KEYS: &[&str] = &[
+    "name",
+    "description",
+    "license",
+    "compatibility",
+    "metadata",
+    "allowed-tools",
+    "allowed_tools",
+];
+
+/// Legacy top-level extension keys we still dual-read for backward
+/// compatibility. Collected into `SkillMetadata::legacy_extension_fields`
+/// so callers can surface a deprecation warning. See issue #356.
+const LEGACY_EXTENSION_KEYS: &[&str] = &[
+    "dcc",
+    "version",
+    "tags",
+    "search-hint",
+    "search_hint",
+    "depends",
+    "tools",
+    "groups",
+    "policy",
+    "external_deps",
+    "external-deps",
+    "products",
+    "allow_implicit_invocation",
+    "allow-implicit-invocation",
+];
 
 use crate::resolver::{self, ResolveError};
 use crate::scanner::SkillScanner;
@@ -41,8 +79,22 @@ pub fn parse_skill_md(skill_dir: &Path) -> Option<SkillMetadata> {
     // Extract YAML frontmatter between --- delimiters
     let frontmatter = extract_frontmatter(&content)?;
 
-    // Parse YAML
-    let mut meta: SkillMetadata = match serde_yaml_ng::from_str(frontmatter) {
+    // Parse once into a raw YAML value so we can inspect which top-level
+    // keys the author declared; this drives the legacy/spec-compliant
+    // detection in issue #356 without breaking the existing deserializer.
+    let raw_value: serde_yaml_ng::Value = match serde_yaml_ng::from_str(frontmatter) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                "Error parsing frontmatter in {}: {}",
+                skill_md_path.display(),
+                e
+            );
+            return None;
+        }
+    };
+
+    let mut meta: SkillMetadata = match serde_yaml_ng::from_value(raw_value.clone()) {
         Ok(m) => m,
         Err(e) => {
             tracing::warn!(
@@ -62,6 +114,33 @@ pub fn parse_skill_md(skill_dir: &Path) -> Option<SkillMetadata> {
             .unwrap_or_default();
     }
 
+    // serde_yaml_ng cannot deserialize directly into `serde_json::Value`
+    // for arbitrary YAML mappings — do the conversion manually so callers
+    // that rely on `SkillMetadata::metadata` (flat_metadata, openclaw, …)
+    // continue to work.
+    if let Some(raw_metadata) = raw_value
+        .as_mapping()
+        .and_then(|m| m.get(serde_yaml_ng::Value::String("metadata".into())))
+    {
+        if let Some(j) = yaml_to_json(raw_metadata) {
+            meta.metadata = j;
+        }
+    }
+
+    // Apply the agentskills.io-compliant `metadata.dcc-mcp.*` overrides
+    // and collect any legacy top-level extension keys that were used.
+    let legacy_fields = detect_legacy_extension_fields(&raw_value);
+    apply_dcc_mcp_metadata_overrides(skill_dir, &raw_value, &mut meta);
+    if !legacy_fields.is_empty() {
+        tracing::warn!(
+            "skill {name}: legacy top-level field(s) {legacy:?}; use metadata.dcc-mcp.* instead \
+             (see docs/guide/skills.md#migrating-pre-015-skillmd)",
+            name = meta.name,
+            legacy = legacy_fields,
+        );
+    }
+    meta.legacy_extension_fields = legacy_fields;
+
     // Enumerate scripts
     meta.scripts = enumerate_scripts(skill_dir);
     meta.skill_path = path_to_string(skill_dir);
@@ -73,6 +152,381 @@ pub fn parse_skill_md(skill_dir: &Path) -> Option<SkillMetadata> {
     merge_depends_from_metadata(skill_dir, &mut meta);
 
     Some(meta)
+}
+
+// ── Issue #356: agentskills.io-compliant metadata.dcc-mcp.* support ──
+
+/// Collect the names of legacy top-level extension keys that were
+/// declared in the raw YAML frontmatter.  Returns an empty vec when the
+/// skill already uses the `metadata.dcc-mcp.*` form exclusively.
+fn detect_legacy_extension_fields(root: &serde_yaml_ng::Value) -> Vec<String> {
+    let Some(map) = root.as_mapping() else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for (key, _) in map.iter() {
+        let Some(k) = key.as_str() else { continue };
+        if AGENTSKILLS_SPEC_KEYS.contains(&k) {
+            continue;
+        }
+        if LEGACY_EXTENSION_KEYS.contains(&k) {
+            let normalized = k.to_string();
+            if !out.iter().any(|x: &String| x == &normalized) {
+                out.push(normalized);
+            }
+        }
+    }
+    out
+}
+
+/// Apply `metadata.dcc-mcp.*` overrides onto `meta`.
+///
+/// Priority: a value present under `metadata.dcc-mcp.<field>` wins over
+/// the legacy top-level form.  Missing keys leave the existing value
+/// untouched so the legacy path remains functional.  Sibling-file
+/// references for `tools` / `groups` are resolved relative to
+/// `skill_dir`.
+fn apply_dcc_mcp_metadata_overrides(
+    skill_dir: &Path,
+    raw: &serde_yaml_ng::Value,
+    meta: &mut SkillMetadata,
+) {
+    let overrides = collect_dcc_mcp_overrides(raw);
+    if overrides.is_empty() {
+        return;
+    }
+
+    for (key, value) in overrides {
+        match key.as_str() {
+            "dcc" => {
+                if let Some(s) = value.as_str() {
+                    meta.dcc = s.to_string();
+                }
+            }
+            "version" => {
+                if let Some(s) = yaml_scalar_as_string(&value) {
+                    meta.version = s;
+                }
+            }
+            "tags" => {
+                meta.tags = parse_csv_or_list(&value);
+            }
+            "search-hint" | "search_hint" => {
+                if let Some(s) = value.as_str() {
+                    meta.search_hint = s.to_string();
+                }
+            }
+            "depends" => {
+                meta.depends = parse_csv_or_list(&value);
+            }
+            "products" => {
+                let products = parse_csv_or_list(&value);
+                let policy = meta.policy.get_or_insert_with(Default::default);
+                policy.products = products;
+            }
+            "allow-implicit-invocation" | "allow_implicit_invocation" => {
+                if let Some(b) = parse_bool_yaml(&value) {
+                    let policy = meta.policy.get_or_insert_with(Default::default);
+                    policy.allow_implicit_invocation = Some(b);
+                }
+            }
+            "external-deps" | "external_deps" => {
+                if let Some(deps) = parse_external_deps_yaml(&value) {
+                    meta.external_deps = Some(deps);
+                }
+            }
+            "tools" => {
+                if let Some(s) = value.as_str() {
+                    if let Some((tools, groups)) = load_sibling_tools_file(skill_dir, s) {
+                        meta.tools = tools;
+                        if let Some(g) = groups {
+                            meta.groups = g;
+                        }
+                    }
+                }
+            }
+            "groups" => {
+                if let Some(s) = value.as_str() {
+                    if let Some(groups) = load_sibling_groups_file(skill_dir, s) {
+                        meta.groups = groups;
+                    }
+                }
+            }
+            _ => {
+                tracing::debug!(
+                    "skill {}: unknown metadata.dcc-mcp.{} key — ignoring",
+                    meta.name,
+                    key
+                );
+            }
+        }
+    }
+}
+
+/// Extract `metadata.dcc-mcp.*` overrides from the raw YAML frontmatter.
+///
+/// The prefix strip is applied to keys; returns pairs of
+/// `(field_suffix, raw_value)` so callers can interpret each override in
+/// the correct type.
+fn collect_dcc_mcp_overrides(raw: &serde_yaml_ng::Value) -> Vec<(String, serde_yaml_ng::Value)> {
+    let mut out = Vec::new();
+    let Some(map) = raw.as_mapping() else {
+        return out;
+    };
+    let Some(meta_node) = map.get(serde_yaml_ng::Value::String("metadata".into())) else {
+        return out;
+    };
+    let Some(meta_map) = meta_node.as_mapping() else {
+        return out;
+    };
+    for (k, v) in meta_map.iter() {
+        let Some(ks) = k.as_str() else { continue };
+        if let Some(rest) = ks.strip_prefix(DCC_MCP_PREFIX) {
+            out.push((rest.to_string(), v.clone()));
+        }
+    }
+    out
+}
+
+/// Accept either a comma-separated string (`"a, b, c"`) or a YAML list.
+/// Empty / invalid inputs yield an empty vec.
+fn parse_csv_or_list(v: &serde_yaml_ng::Value) -> Vec<String> {
+    if let Some(s) = v.as_str() {
+        return s
+            .split(',')
+            .map(|t| t.trim().to_string())
+            .filter(|t| !t.is_empty())
+            .collect();
+    }
+    if let Some(seq) = v.as_sequence() {
+        return seq
+            .iter()
+            .filter_map(|x| x.as_str().map(String::from))
+            .collect();
+    }
+    Vec::new()
+}
+
+/// Parse a boolean from a native YAML bool or a `"true"`/`"false"`
+/// string (case-insensitive).  Everything else → `None`.
+fn parse_bool_yaml(v: &serde_yaml_ng::Value) -> Option<bool> {
+    if let Some(b) = v.as_bool() {
+        return Some(b);
+    }
+    if let Some(s) = v.as_str() {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "true" | "yes" | "1" => return Some(true),
+            "false" | "no" | "0" => return Some(false),
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Coerce a YAML scalar to its string representation. Handles both
+/// `"1.0.0"` and unquoted `1.0.0` (YAML may parse the latter as a
+/// float / string depending on lexer quirks).
+fn yaml_scalar_as_string(v: &serde_yaml_ng::Value) -> Option<String> {
+    if let Some(s) = v.as_str() {
+        return Some(s.to_string());
+    }
+    if let Some(i) = v.as_i64() {
+        return Some(i.to_string());
+    }
+    if let Some(f) = v.as_f64() {
+        return Some(f.to_string());
+    }
+    None
+}
+
+/// Parse a JSON-encoded string (per issue #356) or an inline YAML object
+/// into a [`SkillDependencies`].  Returns `None` when the value is
+/// unusable.
+fn parse_external_deps_yaml(v: &serde_yaml_ng::Value) -> Option<dcc_mcp_models::SkillDependencies> {
+    if let Some(s) = v.as_str() {
+        return serde_json::from_str(s).ok();
+    }
+    serde_yaml_ng::from_value(v.clone()).ok()
+}
+
+/// Recursively convert a `serde_yaml_ng::Value` into a
+/// `serde_json::Value`. Non-string mapping keys are coerced with
+/// `to_string()` so the result always round-trips through a JSON
+/// object.
+fn yaml_to_json(v: &serde_yaml_ng::Value) -> Option<serde_json::Value> {
+    use serde_json::Value as J;
+    Some(match v {
+        serde_yaml_ng::Value::Null => J::Null,
+        serde_yaml_ng::Value::Bool(b) => J::Bool(*b),
+        serde_yaml_ng::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                J::Number(i.into())
+            } else if let Some(u) = n.as_u64() {
+                J::Number(u.into())
+            } else if let Some(f) = n.as_f64() {
+                serde_json::Number::from_f64(f)
+                    .map(J::Number)
+                    .unwrap_or(J::Null)
+            } else {
+                J::Null
+            }
+        }
+        serde_yaml_ng::Value::String(s) => J::String(s.clone()),
+        serde_yaml_ng::Value::Sequence(seq) => {
+            J::Array(seq.iter().filter_map(yaml_to_json).collect())
+        }
+        serde_yaml_ng::Value::Mapping(map) => {
+            let mut obj = serde_json::Map::new();
+            for (k, val) in map.iter() {
+                let key = match k {
+                    serde_yaml_ng::Value::String(s) => s.clone(),
+                    other => {
+                        // Best-effort: stringify non-string keys.
+                        serde_yaml_ng::to_string(other)
+                            .unwrap_or_default()
+                            .trim()
+                            .to_string()
+                    }
+                };
+                if let Some(jv) = yaml_to_json(val) {
+                    obj.insert(key, jv);
+                }
+            }
+            J::Object(obj)
+        }
+        serde_yaml_ng::Value::Tagged(t) => return yaml_to_json(&t.value),
+    })
+}
+
+/// Load a sibling YAML file referenced by `metadata.dcc-mcp.tools`.
+///
+/// The file must be a YAML mapping with a top-level `tools:` key and an
+/// optional `groups:` key, e.g.:
+///
+/// ```yaml
+/// tools:
+///   - name: create_sphere
+///     description: ...
+/// groups:
+///   - name: advanced
+///     default-active: false
+/// ```
+fn load_sibling_tools_file(
+    skill_dir: &Path,
+    rel: &str,
+) -> Option<(Vec<ToolDeclaration>, Option<Vec<SkillGroup>>)> {
+    if !has_yaml_extension(rel) {
+        tracing::warn!(
+            "metadata.dcc-mcp.tools references {rel:?} which is not a .yaml/.yml file; ignoring"
+        );
+        return None;
+    }
+    let path = skill_dir.join(rel);
+    let text = match std::fs::read_to_string(&path) {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::warn!("failed to read sibling tools file {}: {e}", path.display());
+            return None;
+        }
+    };
+
+    #[derive(serde::Deserialize, Default)]
+    struct Sidecar {
+        #[serde(default)]
+        tools: Option<serde_yaml_ng::Value>,
+        #[serde(default)]
+        groups: Option<Vec<SkillGroup>>,
+    }
+
+    let side: Sidecar = match serde_yaml_ng::from_str(&text) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!("failed to parse sibling tools file {}: {e}", path.display());
+            return None;
+        }
+    };
+
+    let tools = match side.tools {
+        Some(v) => deserialize_tools_value(v)?,
+        None => Vec::new(),
+    };
+    Some((tools, side.groups))
+}
+
+/// Load a sibling YAML file referenced by `metadata.dcc-mcp.groups`.
+///
+/// The file must be a YAML mapping whose top-level `groups:` key is a
+/// list of [`SkillGroup`] declarations.
+fn load_sibling_groups_file(skill_dir: &Path, rel: &str) -> Option<Vec<SkillGroup>> {
+    if !has_yaml_extension(rel) {
+        tracing::warn!(
+            "metadata.dcc-mcp.groups references {rel:?} which is not a .yaml/.yml file; ignoring"
+        );
+        return None;
+    }
+    let path = skill_dir.join(rel);
+    let text = match std::fs::read_to_string(&path) {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::warn!("failed to read sibling groups file {}: {e}", path.display());
+            return None;
+        }
+    };
+
+    #[derive(serde::Deserialize, Default)]
+    struct Sidecar {
+        #[serde(default)]
+        groups: Option<Vec<SkillGroup>>,
+    }
+
+    match serde_yaml_ng::from_str::<Sidecar>(&text) {
+        Ok(s) => s.groups,
+        Err(e) => {
+            tracing::warn!(
+                "failed to parse sibling groups file {}: {e}",
+                path.display()
+            );
+            None
+        }
+    }
+}
+
+fn has_yaml_extension(path: &str) -> bool {
+    let lower = path.to_ascii_lowercase();
+    lower.ends_with(".yaml") || lower.ends_with(".yml")
+}
+
+/// Deserialize a YAML value into the same `Vec<ToolDeclaration>` shape
+/// accepted by the main SKILL.md `tools:` key (plain names or full
+/// declaration objects).
+fn deserialize_tools_value(value: serde_yaml_ng::Value) -> Option<Vec<ToolDeclaration>> {
+    let Some(seq) = value.as_sequence() else {
+        tracing::warn!("sibling tools file: `tools:` must be a list");
+        return None;
+    };
+    let mut out = Vec::with_capacity(seq.len());
+    for item in seq {
+        match item {
+            serde_yaml_ng::Value::String(s) => out.push(ToolDeclaration {
+                name: s.clone(),
+                ..Default::default()
+            }),
+            serde_yaml_ng::Value::Mapping(_) => {
+                match serde_yaml_ng::from_value::<ToolDeclaration>(item.clone()) {
+                    Ok(t) => out.push(t),
+                    Err(e) => {
+                        tracing::warn!("sibling tools file: invalid tool entry: {e}");
+                        return None;
+                    }
+                }
+            }
+            _ => {
+                tracing::warn!("sibling tools file: each tool must be a string or mapping");
+                return None;
+            }
+        }
+    }
+    Some(out)
 }
 
 // ── Full pipeline: scan → load → resolve ──

--- a/crates/dcc-mcp-skills/src/loader/tests.rs
+++ b/crates/dcc-mcp-skills/src/loader/tests.rs
@@ -611,3 +611,161 @@ mod test_load_all_skills {
         assert_eq!(skipped.len(), 1);
     }
 }
+
+// ── Issue #356: metadata.dcc-mcp.* compat ──
+
+mod test_metadata_compat {
+    use super::*;
+
+    fn write_skill(skill_dir: &Path, body: &str) {
+        std::fs::create_dir_all(skill_dir).unwrap();
+        std::fs::write(skill_dir.join(SKILL_METADATA_FILE), body).unwrap();
+    }
+
+    #[test]
+    fn legacy_form_flags_non_compliant() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("legacy");
+        write_skill(
+            &dir,
+            "---\nname: legacy\ndcc: maya\nversion: \"2.0.0\"\ntags: [a, b]\n---\n# body\n",
+        );
+        let meta = parse_skill_md(&dir).expect("parsed");
+        assert_eq!(meta.dcc, "maya");
+        assert_eq!(meta.version, "2.0.0");
+        assert_eq!(meta.tags, vec!["a".to_string(), "b".to_string()]);
+        assert!(!meta.is_spec_compliant());
+        assert!(meta.legacy_extension_fields.iter().any(|s| s == "dcc"));
+    }
+
+    #[test]
+    fn new_form_is_spec_compliant() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("new");
+        let body = r#"---
+name: new
+description: new-form skill
+metadata:
+  dcc-mcp.dcc: maya
+  dcc-mcp.version: "2.0.0"
+  dcc-mcp.tags: "a, b"
+  dcc-mcp.search-hint: "hint words"
+  dcc-mcp.depends: "other-skill"
+---
+# body
+"#;
+        write_skill(&dir, body);
+        let meta = parse_skill_md(&dir).expect("parsed");
+        assert!(meta.is_spec_compliant(), "expected spec compliant");
+        assert_eq!(meta.dcc, "maya");
+        assert_eq!(meta.version, "2.0.0");
+        assert_eq!(meta.tags, vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(meta.search_hint, "hint words");
+        assert_eq!(meta.depends, vec!["other-skill".to_string()]);
+    }
+
+    #[test]
+    fn new_form_overrides_legacy_when_both_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("both");
+        let body = r#"---
+name: both
+dcc: blender
+metadata:
+  dcc-mcp.dcc: maya
+---
+# body
+"#;
+        write_skill(&dir, body);
+        let meta = parse_skill_md(&dir).expect("parsed");
+        assert_eq!(meta.dcc, "maya", "metadata.dcc-mcp.dcc must win");
+        // still marked legacy because top-level dcc was present
+        assert!(!meta.is_spec_compliant());
+    }
+
+    #[test]
+    fn new_form_sibling_tools_yaml_resolves() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("sidecar");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("tools.yaml"),
+            "tools:\n  - name: create_sphere\n    description: make a sphere\n  - ping\ngroups:\n  - name: advanced\n    default-active: false\n    tools: [create_sphere]\n",
+        )
+        .unwrap();
+        let body = r#"---
+name: sidecar
+metadata:
+  dcc-mcp.dcc: maya
+  dcc-mcp.tools: tools.yaml
+---
+# body
+"#;
+        std::fs::write(dir.join(SKILL_METADATA_FILE), body).unwrap();
+        let meta = parse_skill_md(&dir).expect("parsed");
+        assert!(meta.is_spec_compliant());
+        assert_eq!(meta.tools.len(), 2);
+        assert_eq!(meta.tools[0].name, "create_sphere");
+        assert_eq!(meta.tools[0].description, "make a sphere");
+        assert_eq!(meta.tools[1].name, "ping");
+        assert_eq!(meta.groups.len(), 1);
+        assert_eq!(meta.groups[0].name, "advanced");
+        assert!(!meta.groups[0].default_active);
+    }
+
+    #[test]
+    fn new_form_products_and_implicit_invocation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("policy");
+        let body = r#"---
+name: policy
+metadata:
+  dcc-mcp.products: "maya, houdini"
+  dcc-mcp.allow-implicit-invocation: "false"
+---
+# body
+"#;
+        write_skill(&dir, body);
+        let meta = parse_skill_md(&dir).expect("parsed");
+        let policy = meta.policy.expect("policy must be set");
+        assert_eq!(
+            policy.products,
+            vec!["maya".to_string(), "houdini".to_string()]
+        );
+        assert_eq!(policy.allow_implicit_invocation, Some(false));
+    }
+
+    #[test]
+    fn both_forms_produce_same_values() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let legacy_dir = tmp.path().join("legacy");
+        write_skill(
+            &legacy_dir,
+            "---\nname: same\ndcc: maya\nversion: \"1.2.3\"\ntags: [x, y]\nsearch-hint: hello\n---\n",
+        );
+        let legacy = parse_skill_md(&legacy_dir).expect("parsed");
+
+        let new_dir = tmp.path().join("new");
+        write_skill(
+            &new_dir,
+            r#"---
+name: same
+metadata:
+  dcc-mcp.dcc: maya
+  dcc-mcp.version: "1.2.3"
+  dcc-mcp.tags: "x, y"
+  dcc-mcp.search-hint: hello
+---
+"#,
+        );
+        let newf = parse_skill_md(&new_dir).expect("parsed");
+
+        assert_eq!(legacy.dcc, newf.dcc);
+        assert_eq!(legacy.version, newf.version);
+        assert_eq!(legacy.tags, newf.tags);
+        assert_eq!(legacy.search_hint, newf.search_hint);
+        assert!(!legacy.is_spec_compliant());
+        assert!(newf.is_spec_compliant());
+    }
+}

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -556,3 +556,84 @@ Calling an unloaded skill stub (`__skill__<name>`) returns an error with a hint:
 Searches across: `name`, `description`, `search_hint`, and `tool_names`. The `search_hint` field (from SKILL.md `search-hint:`) improves keyword matching without loading full schemas.
 
 `create_skill_server()` only calls `discover()` at startup — skills are **not** automatically loaded. This keeps the initial tool list small and lets agents load only what they need.
+
+## Migrating pre-0.15 SKILL.md
+
+Starting with dcc-mcp-core 0.15 (issue [#356](https://github.com/loonghao/dcc-mcp-core/issues/356)), dcc-mcp-core-specific extension keys (`dcc`, `version`, `tags`, `tools`, …) should live under the agentskills.io-compliant `metadata.dcc-mcp.*` namespace rather than at the top level of SKILL.md frontmatter. Top-level extension keys continue to parse but emit a one-shot deprecation warning per skill, and `SkillMetadata.is_spec_compliant()` returns `False` for them.
+
+### Before (pre-0.15, legacy — still works, now deprecated)
+
+```yaml
+---
+name: maya-geometry
+description: "Maya geometry creation and modification tools"
+dcc: maya
+version: "1.0.0"
+tags: [geometry, create]
+search-hint: "polygon modeling, sphere, bevel, extrude"
+tools:
+  - name: create_sphere
+    description: "Create a polygon sphere"
+    source_file: scripts/create_sphere.py
+---
+```
+
+### After (0.15+, agentskills.io 1.0 compliant)
+
+```yaml
+---
+name: maya-geometry
+description: "Maya geometry creation and modification tools"
+license: MIT
+metadata:
+  dcc-mcp.dcc: maya
+  dcc-mcp.version: "1.0.0"
+  dcc-mcp.tags: "geometry, create"
+  dcc-mcp.search-hint: "polygon modeling, sphere, bevel, extrude"
+  dcc-mcp.tools: tools.yaml     # sibling file (relative to SKILL.md)
+---
+```
+
+Then put the MCP tool declarations in a sibling `tools.yaml`:
+
+```yaml
+# tools.yaml — same schema as the inline tools: block
+tools:
+  - name: create_sphere
+    description: "Create a polygon sphere"
+    source_file: scripts/create_sphere.py
+groups:
+  - name: advanced
+    default-active: false
+    tools: [create_sphere]
+```
+
+### Metadata key reference
+
+| Legacy top-level                | Spec-compliant `metadata` key                | Value type            |
+| ------------------------------- | -------------------------------------------- | --------------------- |
+| `dcc: maya`                     | `metadata["dcc-mcp.dcc"]`                    | string                |
+| `version: 1.0.0`                | `metadata["dcc-mcp.version"]`                | string                |
+| `tags: [a, b]`                  | `metadata["dcc-mcp.tags"]`                   | comma-separated string |
+| `search-hint: "…"`              | `metadata["dcc-mcp.search-hint"]`            | string                |
+| `depends: [x, y]`               | `metadata["dcc-mcp.depends"]`                | comma-separated string |
+| `products: [maya]`              | `metadata["dcc-mcp.products"]`               | comma-separated string |
+| `allow_implicit_invocation`     | `metadata["dcc-mcp.allow-implicit-invocation"]` | `"true"` / `"false"` |
+| `external_deps: {...}`          | `metadata["dcc-mcp.external-deps"]`          | JSON string           |
+| `tools: [...]` inline block     | `metadata["dcc-mcp.tools"]`                  | sibling `.yaml` file  |
+| `groups: [...]` inline block    | `metadata["dcc-mcp.groups"]`                 | sibling `.yaml` file  |
+
+### Priority rules
+
+- When both forms are present, the `metadata.dcc-mcp.*` value wins.
+- If only the legacy top-level field is present, it is still read (backward compatibility) and the loader emits a single `tracing::warn!` per skill.
+- Checking compliance programmatically:
+
+  ```python
+  skills, _skipped = dcc_mcp_core.scan_and_load(dcc_name="maya")
+  for s in skills:
+      if not s.is_spec_compliant():
+          print(f"{s.name}: legacy fields={s.legacy_extension_fields}")
+  ```
+
+A one-shot CLI migrator (`dcc-mcp-migrate-skill`) is planned as a follow-up; see the tracking issue for status.

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -229,6 +229,7 @@ class SkillMetadata:
     compatibility: str
     allowed_tools: list[str]
     groups: list[SkillGroup]
+    search_hint: str
 
     def __init__(
         self,
@@ -249,6 +250,22 @@ class SkillMetadata:
     def __repr__(self) -> str: ...
     def __str__(self) -> str: ...
     def __eq__(self, other: object) -> bool: ...
+    @property
+    def legacy_extension_fields(self) -> list[str]:
+        """Names of legacy top-level extension fields observed when parsing.
+
+        Populated by the SKILL.md loader. Empty ⇒ spec-compliant.
+        """
+        ...
+
+    def is_spec_compliant(self) -> bool:
+        """Return ``True`` iff this skill uses ``metadata.dcc-mcp.*`` exclusively.
+
+        A skill is spec-compliant (per agentskills.io 1.0) when no legacy
+        top-level extension fields (``dcc``, ``tags``, ``tools``, …) were
+        found in its SKILL.md frontmatter. See issue #356.
+        """
+        ...
 
 # ── Skills ──
 

--- a/python/dcc_mcp_core/skills/dcc-diagnostics/SKILL.md
+++ b/python/dcc_mcp_core/skills/dcc-diagnostics/SKILL.md
@@ -2,95 +2,13 @@
 name: dcc-diagnostics
 description: "DCC-agnostic diagnostics and observability tools — capture screenshots, query audit logs, inspect tool performance metrics, and monitor process health. Works in any DCC environment (Maya, Blender, Houdini, Unreal, etc.) or standalone Python."
 license: MIT
-dcc: python
-version: "1.0.0"
-search-hint: "screenshot, capture, audit log, metrics, performance, process monitor, diagnostics, debug, health check"
-tags: [diagnostics, observability, screenshot, audit, metrics, debug]
 metadata:
   category: diagnostics
-tools:
-  - name: screenshot
-    description: "Capture a screenshot of the current display or a specific window. Returns the image as a base64-encoded PNG. Useful for visual debugging — capture what's visible on screen when an error occurs."
-    input_schema:
-      type: object
-      properties:
-        format:
-          type: string
-          description: "Image format: 'png' (default), 'jpeg', or 'raw_bgra'"
-          default: png
-        scale:
-          type: number
-          description: "Scale factor 0.0-1.0 (default 1.0 = native resolution). Use 0.5 to halve the size."
-          default: 1.0
-        jpeg_quality:
-          type: integer
-          description: "JPEG quality 0-100 (default 85). Only used when format is 'jpeg'."
-          default: 85
-        window_title:
-          type: string
-          description: "Capture only the window whose title contains this substring. If omitted, captures the full screen."
-        save_path:
-          type: string
-          description: "If provided, save the image to this file path in addition to returning base64."
-        timeout_ms:
-          type: integer
-          description: "Maximum milliseconds to wait for a frame (default 5000)."
-          default: 5000
-    read_only: true
-    idempotent: false
-    source_file: scripts/screenshot.py
-
-  - name: audit_log
-    description: "Query the dcc-mcp-core sandbox audit log — list recent action invocations, filter by outcome (success/denied), or search by action name. Helps diagnose why an action was blocked or what the agent did recently."
-    input_schema:
-      type: object
-      properties:
-        filter:
-          type: string
-          description: "Filter entries: 'all' (default), 'success', 'denied', or 'error'"
-          default: all
-        action_name:
-          type: string
-          description: "Only return entries for this specific action name."
-        limit:
-          type: integer
-          description: "Maximum number of entries to return (default 50)."
-          default: 50
-    read_only: true
-    idempotent: true
-    source_file: scripts/audit_log.py
-
-  - name: tool_metrics
-    description: "Show performance metrics for registered tools — invocation counts, success rates, average and P95/P99 latencies. Use to identify slow or failing tools."
-    input_schema:
-      type: object
-      properties:
-        action_name:
-          type: string
-          description: "If provided, return metrics only for this tool. Otherwise return all."
-        sort_by:
-          type: string
-          description: "Sort results by: 'name', 'invocations' (default), 'avg_ms', 'p95_ms', or 'failure_rate'"
-          default: invocations
-        limit:
-          type: integer
-          description: "Maximum number of tools to return (default 20)."
-          default: 20
-    read_only: true
-    idempotent: true
-    source_file: scripts/tool_metrics.py
-
-  - name: process_status
-    description: "Check the health of tracked DCC processes — list running PIDs, check if a specific process is alive, and inspect crash recovery policy. Use when a DCC tool stops responding."
-    input_schema:
-      type: object
-      properties:
-        pid:
-          type: integer
-          description: "Check status of a specific process ID. If omitted, returns summary of all tracked processes."
-    read_only: true
-    idempotent: true
-    source_file: scripts/process_status.py
+  dcc-mcp.dcc: python
+  dcc-mcp.version: "1.0.0"
+  dcc-mcp.search-hint: "screenshot, capture, audit log, metrics, performance, process monitor, diagnostics, debug, health check"
+  dcc-mcp.tags: "diagnostics, observability, screenshot, audit, metrics, debug"
+  dcc-mcp.tools: tools.yaml
 ---
 
 # DCC Diagnostics

--- a/python/dcc_mcp_core/skills/dcc-diagnostics/tools.yaml
+++ b/python/dcc_mcp_core/skills/dcc-diagnostics/tools.yaml
@@ -1,0 +1,83 @@
+tools:
+  - name: screenshot
+    description: "Capture a screenshot of the current display or a specific window. Returns the image as a base64-encoded PNG. Useful for visual debugging — capture what's visible on screen when an error occurs."
+    input_schema:
+      type: object
+      properties:
+        format:
+          type: string
+          description: "Image format: 'png' (default), 'jpeg', or 'raw_bgra'"
+          default: png
+        scale:
+          type: number
+          description: "Scale factor 0.0-1.0 (default 1.0 = native resolution). Use 0.5 to halve the size."
+          default: 1.0
+        jpeg_quality:
+          type: integer
+          description: "JPEG quality 0-100 (default 85). Only used when format is 'jpeg'."
+          default: 85
+        window_title:
+          type: string
+          description: "Capture only the window whose title contains this substring. If omitted, captures the full screen."
+        save_path:
+          type: string
+          description: "If provided, save the image to this file path in addition to returning base64."
+        timeout_ms:
+          type: integer
+          description: "Maximum milliseconds to wait for a frame (default 5000)."
+          default: 5000
+    read_only: true
+    idempotent: false
+    source_file: scripts/screenshot.py
+
+  - name: audit_log
+    description: "Query the dcc-mcp-core sandbox audit log — list recent action invocations, filter by outcome (success/denied), or search by action name. Helps diagnose why an action was blocked or what the agent did recently."
+    input_schema:
+      type: object
+      properties:
+        filter:
+          type: string
+          description: "Filter entries: 'all' (default), 'success', 'denied', or 'error'"
+          default: all
+        action_name:
+          type: string
+          description: "Only return entries for this specific action name."
+        limit:
+          type: integer
+          description: "Maximum number of entries to return (default 50)."
+          default: 50
+    read_only: true
+    idempotent: true
+    source_file: scripts/audit_log.py
+
+  - name: tool_metrics
+    description: "Show performance metrics for registered tools — invocation counts, success rates, average and P95/P99 latencies. Use to identify slow or failing tools."
+    input_schema:
+      type: object
+      properties:
+        action_name:
+          type: string
+          description: "If provided, return metrics only for this tool. Otherwise return all."
+        sort_by:
+          type: string
+          description: "Sort results by: 'name', 'invocations' (default), 'avg_ms', 'p95_ms', or 'failure_rate'"
+          default: invocations
+        limit:
+          type: integer
+          description: "Maximum number of tools to return (default 20)."
+          default: 20
+    read_only: true
+    idempotent: true
+    source_file: scripts/tool_metrics.py
+
+  - name: process_status
+    description: "Check the health of tracked DCC processes — list running PIDs, check if a specific process is alive, and inspect crash recovery policy. Use when a DCC tool stops responding."
+    input_schema:
+      type: object
+      properties:
+        pid:
+          type: integer
+          description: "Check status of a specific process ID. If omitted, returns summary of all tracked processes."
+    read_only: true
+    idempotent: true
+    source_file: scripts/process_status.py

--- a/python/dcc_mcp_core/skills/workflow/SKILL.md
+++ b/python/dcc_mcp_core/skills/workflow/SKILL.md
@@ -2,47 +2,13 @@
 name: workflow
 description: "Multi-step action orchestration — run a sequence of MCP tools in order, passing results between steps. Enables agents to chain complex operations (select → rename → validate → export) without custom code."
 license: MIT
-dcc: python
-version: "1.0.0"
-search-hint: "chain, sequence, pipeline, multi-step, orchestration, workflow, batch, run steps"
-tags: [workflow, orchestration, chain, pipeline, automation]
 metadata:
   category: workflow
-tools:
-  - name: run_chain
-    description: "Execute a sequence of actions in order via the dcc-mcp-core ToolDispatcher. Each step's output context is merged into the next step's parameters. On failure, the chain stops and reports which step failed and why."
-    input_schema:
-      type: object
-      required: [steps]
-      properties:
-        steps:
-          type: array
-          description: "Ordered list of steps to execute."
-          items:
-            type: object
-            required: [action]
-            properties:
-              action:
-                type: string
-                description: "Action name (e.g. 'maya_scene__list_objects')."
-              params:
-                type: object
-                description: "Parameters to pass to this action. Values from previous step context can be referenced using '{key}' syntax."
-                default: {}
-              stop_on_failure:
-                type: boolean
-                description: "If true (default), abort the chain when this step fails."
-                default: true
-              label:
-                type: string
-                description: "Human-readable label for this step (shown in results)."
-        context:
-          type: object
-          description: "Initial context values available to all steps via '{key}' interpolation."
-          default: {}
-    read_only: false
-    idempotent: false
-    source_file: scripts/run_chain.py
+  dcc-mcp.dcc: python
+  dcc-mcp.version: "1.0.0"
+  dcc-mcp.search-hint: "chain, sequence, pipeline, multi-step, orchestration, workflow, batch, run steps"
+  dcc-mcp.tags: "workflow, orchestration, chain, pipeline, automation"
+  dcc-mcp.tools: tools.yaml
 ---
 
 # Workflow Orchestration

--- a/python/dcc_mcp_core/skills/workflow/tools.yaml
+++ b/python/dcc_mcp_core/skills/workflow/tools.yaml
@@ -1,0 +1,35 @@
+tools:
+  - name: run_chain
+    description: "Execute a sequence of actions in order via the dcc-mcp-core ToolDispatcher. Each step's output context is merged into the next step's parameters. On failure, the chain stops and reports which step failed and why."
+    input_schema:
+      type: object
+      required: [steps]
+      properties:
+        steps:
+          type: array
+          description: "Ordered list of steps to execute."
+          items:
+            type: object
+            required: [action]
+            properties:
+              action:
+                type: string
+                description: "Action name (e.g. 'maya_scene__list_objects')."
+              params:
+                type: object
+                description: "Parameters to pass to this action. Values from previous step context can be referenced using '{key}' syntax."
+                default: {}
+              stop_on_failure:
+                type: boolean
+                description: "If true (default), abort the chain when this step fails."
+                default: true
+              label:
+                type: string
+                description: "Human-readable label for this step (shown in results)."
+        context:
+          type: object
+          description: "Initial context values available to all steps via '{key}' interpolation."
+          default: {}
+    read_only: false
+    idempotent: false
+    source_file: scripts/run_chain.py

--- a/tests/fixtures/skills/legacy-form-skill/SKILL.md
+++ b/tests/fixtures/skills/legacy-form-skill/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: legacy-form-skill
+description: Pre-0.15 legacy SKILL.md fixture (issue #356) — exercises the backward-compatible dual-read path. Same semantics as new-form-skill but with all dcc-mcp-core extensions at top level.
+license: MIT
+dcc: maya
+version: "1.2.3"
+tags: [modeling, polygon, bevel]
+search-hint: "bevel edges mesh polygon modeling"
+tools:
+  - name: bevel
+    description: Apply a bevel to the selected edges.
+    read_only: false
+    destructive: true
+    idempotent: false
+    source_file: scripts/bevel.py
+  - name: measure
+groups:
+  - name: advanced
+    description: Advanced modeling tools not needed for most workflows.
+    default-active: false
+    tools: [bevel]
+---
+
+# Legacy-form skill
+
+This fixture declares all dcc-mcp-core extensions at the YAML top level,
+the way skills were authored before v0.15. The loader still accepts this
+form but emits a deprecation warning and `is_spec_compliant()` returns
+`False`.

--- a/tests/fixtures/skills/legacy-form-skill/scripts/bevel.py
+++ b/tests/fixtures/skills/legacy-form-skill/scripts/bevel.py
@@ -1,0 +1,7 @@
+"""Placeholder script for the legacy-form-skill fixture (issue #356)."""
+
+from __future__ import annotations
+
+
+def bevel(width: float = 0.1) -> dict[str, object]:
+    return {"success": True, "width": width}

--- a/tests/fixtures/skills/new-form-skill/SKILL.md
+++ b/tests/fixtures/skills/new-form-skill/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: new-form-skill
+description: agentskills.io 1.0 compliant fixture for issue #356 — exercises metadata.dcc-mcp.* overrides and sibling tools.yaml resolution.
+license: MIT
+metadata:
+  dcc-mcp.dcc: maya
+  dcc-mcp.version: "1.2.3"
+  dcc-mcp.tags: "modeling, polygon, bevel"
+  dcc-mcp.search-hint: "bevel edges mesh polygon modeling"
+  dcc-mcp.products: "maya, houdini"
+  dcc-mcp.allow-implicit-invocation: "false"
+  dcc-mcp.tools: tools.yaml
+---
+
+# New-form skill
+
+This fixture uses the agentskills.io 1.0 compliant metadata form.
+All dcc-mcp-core-specific fields live under `metadata.dcc-mcp.*`.

--- a/tests/fixtures/skills/new-form-skill/scripts/bevel.py
+++ b/tests/fixtures/skills/new-form-skill/scripts/bevel.py
@@ -1,0 +1,7 @@
+"""Placeholder script for the new-form-skill fixture (issue #356)."""
+
+from __future__ import annotations
+
+
+def bevel(width: float = 0.1) -> dict[str, object]:
+    return {"success": True, "width": width}

--- a/tests/fixtures/skills/new-form-skill/tools.yaml
+++ b/tests/fixtures/skills/new-form-skill/tools.yaml
@@ -1,0 +1,14 @@
+tools:
+  - name: bevel
+    description: Apply a bevel to the selected edges.
+    read_only: false
+    destructive: true
+    idempotent: false
+    source_file: scripts/bevel.py
+  - name: measure
+
+groups:
+  - name: advanced
+    description: Advanced modeling tools not needed for most workflows.
+    default-active: false
+    tools: [bevel]

--- a/tests/test_skill_metadata_compat.py
+++ b/tests/test_skill_metadata_compat.py
@@ -1,0 +1,144 @@
+"""Tests for agentskills.io-compliant ``metadata.dcc-mcp.*`` parsing.
+
+Covers issue #356: the SKILL.md loader dual-reads the new, spec-compliant
+``metadata.dcc-mcp.*`` keys and the legacy top-level extension fields,
+surfacing a ``is_spec_compliant()`` flag so callers can drive
+deprecation warnings.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import dcc_mcp_core
+
+FIXTURES = Path(__file__).parent / "fixtures" / "skills"
+NEW_FORM = FIXTURES / "new-form-skill"
+LEGACY_FORM = FIXTURES / "legacy-form-skill"
+
+
+def _parse(skill_dir: Path):
+    meta = dcc_mcp_core.parse_skill_md(str(skill_dir))
+    assert meta is not None, f"parse_skill_md returned None for {skill_dir}"
+    return meta
+
+
+class TestLegacyForm:
+    """Pre-0.15 SKILL.md with top-level extensions must still parse."""
+
+    def test_parses(self) -> None:
+        meta = _parse(LEGACY_FORM)
+        assert meta.name == "legacy-form-skill"
+
+    def test_is_not_spec_compliant(self) -> None:
+        meta = _parse(LEGACY_FORM)
+        assert meta.is_spec_compliant() is False
+        # The loader must have flagged at least the `dcc` / `tools` keys.
+        legacy = meta.legacy_extension_fields
+        assert isinstance(legacy, list)
+        assert "dcc" in legacy
+        assert "tools" in legacy
+
+    def test_values_populated(self) -> None:
+        meta = _parse(LEGACY_FORM)
+        assert meta.dcc == "maya"
+        assert meta.version == "1.2.3"
+        assert meta.tags == ["modeling", "polygon", "bevel"]
+        assert meta.search_hint == "bevel edges mesh polygon modeling"
+        names = [t.name for t in meta.tools]
+        assert names == ["bevel", "measure"]
+
+
+class TestNewForm:
+    """Spec-compliant SKILL.md uses only metadata.dcc-mcp.* keys."""
+
+    def test_parses(self) -> None:
+        meta = _parse(NEW_FORM)
+        assert meta.name == "new-form-skill"
+
+    def test_is_spec_compliant(self) -> None:
+        meta = _parse(NEW_FORM)
+        assert meta.is_spec_compliant() is True
+        assert meta.legacy_extension_fields == []
+
+    def test_values_populated(self) -> None:
+        meta = _parse(NEW_FORM)
+        assert meta.dcc == "maya"
+        assert meta.version == "1.2.3"
+        assert meta.tags == ["modeling", "polygon", "bevel"]
+        assert meta.search_hint == "bevel edges mesh polygon modeling"
+
+    def test_sibling_tools_yaml_resolved(self) -> None:
+        meta = _parse(NEW_FORM)
+        names = [t.name for t in meta.tools]
+        assert names == ["bevel", "measure"]
+        bevel = meta.tools[0]
+        assert bevel.description == "Apply a bevel to the selected edges."
+        assert bevel.destructive is True
+        # groups sidecar from tools.yaml
+        assert [g.name for g in meta.groups] == ["advanced"]
+        assert meta.groups[0].default_active is False
+
+    def test_policy_overrides(self) -> None:
+        meta = _parse(NEW_FORM)
+        # `products` and `allow-implicit-invocation` from metadata.dcc-mcp.*
+        # must feed into the SkillPolicy surface.
+        assert meta.is_implicit_invocation_allowed() is False
+        assert meta.matches_product("maya") is True
+        assert meta.matches_product("blender") is False
+        policy_json = meta.policy
+        assert policy_json is not None
+        policy = json.loads(policy_json)
+        assert sorted(policy["products"]) == ["houdini", "maya"]
+        assert policy["allow_implicit_invocation"] is False
+
+
+class TestParity:
+    """Both SKILL.md forms must yield identical field values."""
+
+    FIELDS = ("dcc", "version", "tags", "search_hint")
+
+    def test_parity(self) -> None:
+        old = _parse(LEGACY_FORM)
+        new = _parse(NEW_FORM)
+        for field in self.FIELDS:
+            assert getattr(old, field) == getattr(new, field), (
+                f"field {field!r} differs: old={getattr(old, field)!r} new={getattr(new, field)!r}"
+            )
+        # Tool names match.
+        assert [t.name for t in old.tools] == [t.name for t in new.tools]
+
+
+class TestInlineNewForm:
+    """Smoke-test an inline new-form SKILL.md written at runtime."""
+
+    def test_inline(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "inline"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            (
+                "---\n"
+                "name: inline\n"
+                "description: inline new-form skill\n"
+                "metadata:\n"
+                "  dcc-mcp.dcc: houdini\n"
+                '  dcc-mcp.version: "0.1.0"\n'
+                '  dcc-mcp.tags: "a, b"\n'
+                "---\n"
+                "# body\n"
+            ),
+            encoding="utf-8",
+        )
+        meta = _parse(skill_dir)
+        assert meta.is_spec_compliant() is True
+        assert meta.dcc == "houdini"
+        assert meta.version == "0.1.0"
+        assert meta.tags == ["a", "b"]
+
+
+def test_is_spec_compliant_signature_is_a_method() -> None:
+    """`is_spec_compliant` must be callable, not a property (issue #356 AC 4)."""
+    meta = dcc_mcp_core.SkillMetadata(name="smoke")
+    assert callable(meta.is_spec_compliant)
+    assert meta.is_spec_compliant() is True


### PR DESCRIPTION
## Summary

- Parser dual-reads `metadata.dcc-mcp.*` (spec-compliant) and legacy top-level extensions.
- One-shot deprecation warning per skill on legacy usage.
- New `SkillMetadata.is_spec_compliant()`.
- Sibling `tools.yaml` resolution via `metadata.dcc-mcp.tools`.
- Bundled skills migrated.

## Test plan

- [x] `vx just preflight`
- [x] `vx just test`
- [x] New fixtures for both legacy and new forms

Migration CLI (`dcc-mcp-migrate-skill`) is tracked as a follow-up issue; not in this PR.

Closes #356
