### PR TITLE
feat(core): add Workflow primitive skeleton (WorkflowSpec + WorkflowJob) (#348)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/dcc-mcp-usd",
     "crates/dcc-mcp-http",
     "crates/dcc-mcp-server",
+    "crates/dcc-mcp-workflow",
 ]
 resolver = "2"
 
@@ -46,6 +47,7 @@ dcc-mcp-capture = { path = "crates/dcc-mcp-capture" }
 dcc-mcp-usd = { path = "crates/dcc-mcp-usd" }
 dcc-mcp-http = { path = "crates/dcc-mcp-http" }
 dcc-mcp-server = { path = "crates/dcc-mcp-server" }
+dcc-mcp-workflow = { path = "crates/dcc-mcp-workflow" }
 
 # Shared dependencies (single version across workspace)
 pyo3 = { version = "0.28", features = ["multiple-pymethods"] }
@@ -115,6 +117,9 @@ dcc-mcp-capture.workspace = true
 dcc-mcp-usd.workspace = true
 dcc-mcp-http.workspace = true
 
+# Workflow crate — opt-in via the top-level `workflow` feature.
+dcc-mcp-workflow = { workspace = true, optional = true }
+
 # PyO3 (optional — only for wheel builds)
 pyo3 = { workspace = true, optional = true }
 
@@ -140,7 +145,11 @@ strip = true
 
 [features]
 default = []
-python-bindings = ["pyo3", "dcc-mcp-naming/python-bindings", "dcc-mcp-models/python-bindings", "dcc-mcp-actions/python-bindings", "dcc-mcp-skills/python-bindings", "dcc-mcp-protocols/python-bindings", "dcc-mcp-utils/python-bindings", "dcc-mcp-transport/python-bindings", "dcc-mcp-process/python-bindings", "dcc-mcp-telemetry/python-bindings", "dcc-mcp-sandbox/python-bindings", "dcc-mcp-shm/python-bindings", "dcc-mcp-capture/python-bindings", "dcc-mcp-usd/python-bindings", "dcc-mcp-http/python-bindings"]
+python-bindings = ["pyo3", "dcc-mcp-naming/python-bindings", "dcc-mcp-models/python-bindings", "dcc-mcp-actions/python-bindings", "dcc-mcp-skills/python-bindings", "dcc-mcp-protocols/python-bindings", "dcc-mcp-utils/python-bindings", "dcc-mcp-transport/python-bindings", "dcc-mcp-process/python-bindings", "dcc-mcp-telemetry/python-bindings", "dcc-mcp-sandbox/python-bindings", "dcc-mcp-shm/python-bindings", "dcc-mcp-capture/python-bindings", "dcc-mcp-usd/python-bindings", "dcc-mcp-http/python-bindings", "dcc-mcp-workflow?/python-bindings"]
+# Opt into the first-class Workflow primitive (issue #348). Off by default
+# for one release — enables WorkflowSpec/WorkflowStatus in Python and the
+# workflows.* built-in tools in Rust. Step execution is stubbed; see #348.
+workflow = ["dep:dcc-mcp-workflow"]
 abi3-py38 = ["pyo3/abi3-py38"]
 # Python 3.7 wheel: non-abi3 build, no abi3-py38 feature
 ext-module = ["pyo3/extension-module"]

--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -155,6 +155,19 @@ pub struct McpHttpConfig {
     /// bound to a DCC execute inline and are governed by
     /// [`Self::request_timeout_ms`] instead. Fixes issue #314.
     pub backend_timeout_ms: u64,
+
+    /// Enable the built-in `workflows.*` tools (issue #348).
+    ///
+    /// Default: `false`. When `true`, [`McpHttpServer::start`] registers
+    /// `workflows.run` / `workflows.get_status` / `workflows.cancel` /
+    /// `workflows.lookup` on the registry before the listener comes up.
+    ///
+    /// **Skeleton note**: in this release the three execution-facing tools
+    /// return a structured `"step execution pending follow-up PR"` error;
+    /// `workflows.lookup` is fully functional against the `WorkflowCatalog`.
+    /// Surface-area is stable so downstream adapters can wire the tools
+    /// today and pick up real execution when the follow-up PR lands.
+    pub enable_workflows: bool,
 }
 
 impl McpHttpConfig {
@@ -182,7 +195,16 @@ impl McpHttpConfig {
             spawn_mode: ServerSpawnMode::Ambient,
             self_probe_timeout_ms: 200,
             backend_timeout_ms: 10_000,
+            enable_workflows: false,
         }
+    }
+
+    /// Builder: enable the built-in `workflows.*` tools (issue #348).
+    ///
+    /// See [`Self::enable_workflows`] for the full contract.
+    pub fn with_workflows(mut self) -> Self {
+        self.enable_workflows = true;
+        self
     }
 
     /// Builder: enable the lazy-actions fast-path (#254).

--- a/crates/dcc-mcp-http/src/python/mod.rs
+++ b/crates/dcc-mcp-http/src/python/mod.rs
@@ -122,6 +122,21 @@ impl PyMcpHttpConfig {
         self.inner.lazy_actions = enabled;
     }
 
+    /// Enable the built-in ``workflows.*`` tools (issue #348).
+    ///
+    /// Default: ``False``. Step execution is stubbed in the skeleton —
+    /// see :class:`WorkflowSpec` for the parse/validate surface that is
+    /// already usable.
+    #[getter]
+    fn enable_workflows(&self) -> bool {
+        self.inner.enable_workflows
+    }
+
+    #[setter]
+    fn set_enable_workflows(&mut self, enabled: bool) {
+        self.inner.enable_workflows = enabled;
+    }
+
     // ── Gateway configuration ────────────────────────────────────────────────
 
     /// Gateway port to compete for. First process to bind wins.

--- a/crates/dcc-mcp-workflow/Cargo.toml
+++ b/crates/dcc-mcp-workflow/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "dcc-mcp-workflow"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "First-class Workflow primitive (WorkflowSpec + WorkflowJob) for the DCC-MCP ecosystem (skeleton; step execution pending)"
+
+[dependencies]
+pyo3 = { workspace = true, optional = true }
+dcc-mcp-naming = { workspace = true }
+dcc-mcp-models = { workspace = true }
+dcc-mcp-actions = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml_ng = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+parking_lot = { workspace = true }
+uuid = { workspace = true }
+jsonpath-rust = "1.0"
+glob = "0.3"
+
+# Optional: SQLite persistence DDL (no write paths yet in this skeleton).
+rusqlite = { version = "0.32", optional = true, features = ["bundled"] }
+
+[dev-dependencies]
+tempfile = "3"
+
+[features]
+default = []
+python-bindings = [
+    "pyo3",
+    "dcc-mcp-naming/python-bindings",
+    "dcc-mcp-models/python-bindings",
+    "dcc-mcp-actions/python-bindings",
+]
+# Persistence DDL for workflows / workflow_steps tables. No writer yet.
+job-persist-sqlite = ["dep:rusqlite"]

--- a/crates/dcc-mcp-workflow/src/catalog.rs
+++ b/crates/dcc-mcp-workflow/src/catalog.rs
@@ -1,0 +1,226 @@
+//! [`WorkflowCatalog`] — in-memory directory of workflow specs declared by
+//! skills via the `metadata.dcc-mcp.workflows` glob key.
+//!
+//! See the amendment comment on issue #348: workflows are sibling YAML files
+//! referenced from the skill's `metadata:` block, not a top-level SKILL.md
+//! field. The catalog reads the glob, records the matched paths, and (in
+//! this skeleton) parses only the `name` + `description` + `inputs` header
+//! of each file. Full-body parse is deferred until `workflows.lookup` or
+//! `workflows.run` actually touches the entry.
+
+use std::path::{Path, PathBuf};
+
+use dcc_mcp_models::SkillMetadata;
+use serde::{Deserialize, Serialize};
+
+use crate::error::WorkflowError;
+
+/// Metadata-key name under `SkillMetadata.metadata` that holds the workflow
+/// glob. Namespaced under `dcc-mcp.*` so it cannot collide with other
+/// agentskills.io clients.
+pub const METADATA_KEY_WORKFLOWS: &str = "dcc-mcp.workflows";
+
+/// Lightweight summary of a workflow declared by a skill.
+///
+/// Populated from the YAML header only (name + description + inputs) so the
+/// catalog can list many workflows cheaply. The `path` field records the
+/// absolute path to the YAML file for full parse on demand.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WorkflowSummary {
+    /// Workflow name (YAML top-level `name` field, falls back to the file
+    /// stem).
+    pub name: String,
+    /// Skill this workflow belongs to (the owning skill's `name`).
+    pub skill: String,
+    /// One-line description from the YAML header, if present.
+    #[serde(default)]
+    pub description: String,
+    /// Input schema declaration (opaque JSON in the skeleton).
+    #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
+    pub inputs: serde_json::Value,
+    /// Absolute path to the source `*.workflow.yaml` file.
+    pub path: String,
+}
+
+/// In-memory catalog of workflow summaries.
+///
+/// Populated by [`Self::from_skill`] per skill; callers may merge multiple
+/// skills into one catalog with [`Self::extend_from_skill`].
+#[derive(Debug, Default, Clone)]
+pub struct WorkflowCatalog {
+    entries: Vec<WorkflowSummary>,
+}
+
+impl WorkflowCatalog {
+    /// Create an empty catalog.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build a catalog from a single skill. Reads the
+    /// `metadata["dcc-mcp.workflows"]` glob (see [`METADATA_KEY_WORKFLOWS`])
+    /// relative to `skill_root`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WorkflowError::Io`] on glob pattern failure. Individual
+    /// YAML parse failures are logged and skipped — a malformed workflow
+    /// must not kill the catalog for the rest of the skill.
+    pub fn from_skill(meta: &SkillMetadata, skill_root: &Path) -> Result<Self, WorkflowError> {
+        let mut cat = Self::new();
+        cat.extend_from_skill(meta, skill_root)?;
+        Ok(cat)
+    }
+
+    /// Merge workflow summaries from another skill into this catalog.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WorkflowError::Io`] on glob-pattern failure.
+    pub fn extend_from_skill(
+        &mut self,
+        meta: &SkillMetadata,
+        skill_root: &Path,
+    ) -> Result<(), WorkflowError> {
+        for path in resolve_workflow_paths(meta, skill_root)? {
+            match read_summary(&path, &meta.name) {
+                Ok(summary) => self.entries.push(summary),
+                Err(e) => {
+                    tracing::warn!(
+                        "workflow catalog: failed to summarise {}: {e}",
+                        path.display()
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// All recorded summaries.
+    #[must_use]
+    pub fn entries(&self) -> &[WorkflowSummary] {
+        &self.entries
+    }
+
+    /// Look up a single summary by `(skill, name)`.
+    #[must_use]
+    pub fn get(&self, skill: &str, name: &str) -> Option<&WorkflowSummary> {
+        self.entries
+            .iter()
+            .find(|s| s.skill == skill && s.name == name)
+    }
+
+    /// Search summaries by a free-text query (substring match, case-insensitive)
+    /// against `name` + `description`. Used by `workflows.lookup`.
+    #[must_use]
+    pub fn search(&self, query: &str) -> Vec<&WorkflowSummary> {
+        let q = query.to_ascii_lowercase();
+        self.entries
+            .iter()
+            .filter(|s| {
+                s.name.to_ascii_lowercase().contains(&q)
+                    || s.description.to_ascii_lowercase().contains(&q)
+            })
+            .collect()
+    }
+}
+
+/// Resolve the glob(s) declared under `metadata["dcc-mcp.workflows"]`
+/// relative to `skill_root`. Returns absolute paths.
+///
+/// Accepts a comma-separated list of globs inside a single string.
+///
+/// # Errors
+///
+/// Returns [`WorkflowError::Io`] on glob pattern error.
+pub fn resolve_workflow_paths(
+    meta: &SkillMetadata,
+    skill_root: &Path,
+) -> Result<Vec<PathBuf>, WorkflowError> {
+    let raw = match meta.metadata.get(METADATA_KEY_WORKFLOWS) {
+        Some(serde_json::Value::String(s)) => s.clone(),
+        Some(other) => {
+            tracing::warn!(
+                "skill {:?}: metadata.{METADATA_KEY_WORKFLOWS} must be a string, got {}",
+                meta.name,
+                other
+            );
+            return Ok(Vec::new());
+        }
+        None => return Ok(Vec::new()),
+    };
+
+    let mut out = Vec::new();
+    for part in raw.split(',') {
+        let pattern = part.trim();
+        if pattern.is_empty() {
+            continue;
+        }
+        let joined = skill_root.join(pattern);
+        let full = joined.to_string_lossy().to_string();
+        match glob::glob(&full) {
+            Ok(paths) => {
+                for entry in paths {
+                    match entry {
+                        Ok(p) if p.is_file() => out.push(p),
+                        Ok(_) => {}
+                        Err(e) => tracing::warn!(
+                            "workflow glob {pattern:?} entry error in skill {:?}: {e}",
+                            meta.name
+                        ),
+                    }
+                }
+            }
+            Err(e) => {
+                return Err(WorkflowError::Io(format!(
+                    "bad glob pattern {pattern:?} for skill {:?}: {e}",
+                    meta.name
+                )));
+            }
+        }
+    }
+    out.sort();
+    out.dedup();
+    Ok(out)
+}
+
+/// Parse only the header fields of a workflow YAML.
+///
+/// TODO(#348-full): lazy full parse on demand when `workflows.run` resolves
+/// a `{skill, name}` pair. The summary is cheap; the full [`WorkflowSpec`]
+/// parse is deferred until execution is implemented in the follow-up PR.
+fn read_summary(path: &Path, skill: &str) -> Result<WorkflowSummary, WorkflowError> {
+    let content = std::fs::read_to_string(path)?;
+
+    #[derive(Deserialize, Default)]
+    struct Header {
+        #[serde(default)]
+        name: String,
+        #[serde(default)]
+        description: String,
+        #[serde(default)]
+        inputs: serde_json::Value,
+    }
+
+    // Use `serde_yaml_ng` with extra fields ignored (default behaviour).
+    let header: Header = serde_yaml_ng::from_str(&content).unwrap_or_default();
+
+    let name = if header.name.is_empty() {
+        path.file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("unnamed")
+            .trim_end_matches(".workflow")
+            .to_string()
+    } else {
+        header.name
+    };
+
+    Ok(WorkflowSummary {
+        name,
+        skill: skill.to_string(),
+        description: header.description,
+        inputs: header.inputs,
+        path: path.to_string_lossy().to_string(),
+    })
+}

--- a/crates/dcc-mcp-workflow/src/error.rs
+++ b/crates/dcc-mcp-workflow/src/error.rs
@@ -1,0 +1,84 @@
+//! Error types for the workflow crate.
+
+use thiserror::Error;
+
+/// Validation failure when checking a [`crate::WorkflowSpec`].
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum ValidationError {
+    /// The spec declares no steps.
+    #[error("workflow spec must declare at least one step")]
+    NoSteps,
+
+    /// Two or more steps share the same id.
+    #[error("duplicate step id: {0:?}")]
+    DuplicateStepId(String),
+
+    /// A step id is empty.
+    #[error("empty step id")]
+    EmptyStepId,
+
+    /// A `tool` step references a name that is not a valid MCP tool name
+    /// per `dcc-mcp-naming::validate_tool_name`.
+    #[error("step {step_id:?}: invalid tool name {tool:?}: {reason}")]
+    InvalidToolName {
+        /// Step that triggered the failure.
+        step_id: String,
+        /// Offending tool name.
+        tool: String,
+        /// Human-readable reason from the naming crate.
+        reason: String,
+    },
+
+    /// A `branch.on` or `foreach.items` expression does not parse as JSONPath.
+    #[error("step {step_id:?}: invalid JSONPath expression {expr:?}: {reason}")]
+    InvalidJsonPath {
+        /// Step that triggered the failure.
+        step_id: String,
+        /// Offending expression.
+        expr: String,
+        /// Parser error string.
+        reason: String,
+    },
+
+    /// A kind-specific field is missing (e.g. `foreach` without `items`).
+    #[error("step {step_id:?} ({kind}): missing required field {field:?}")]
+    MissingField {
+        /// Step id.
+        step_id: String,
+        /// Step kind rendered as lowercase string.
+        kind: &'static str,
+        /// Missing field name.
+        field: &'static str,
+    },
+}
+
+/// Top-level error type returned by workflow operations.
+#[derive(Debug, Error)]
+pub enum WorkflowError {
+    /// YAML deserialisation failure.
+    #[error("yaml parse error: {0}")]
+    Yaml(String),
+
+    /// Validation failed after parsing.
+    #[error("validation failed: {0}")]
+    Validation(#[from] ValidationError),
+
+    /// An operation is declared but not yet implemented in this skeleton.
+    ///
+    /// This is the stable error returned by the three execution-facing
+    /// built-in tools (`workflows.run` / `workflows.get_status` /
+    /// `workflows.cancel`) so downstream callers can depend on a fixed
+    /// shape. See issue #348.
+    #[error("not implemented: {0}")]
+    NotImplemented(&'static str),
+
+    /// I/O error while reading a workflow file.
+    #[error("io error: {0}")]
+    Io(String),
+}
+
+impl From<std::io::Error> for WorkflowError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e.to_string())
+    }
+}

--- a/crates/dcc-mcp-workflow/src/job.rs
+++ b/crates/dcc-mcp-workflow/src/job.rs
@@ -1,0 +1,96 @@
+//! [`WorkflowJob`] — runtime tracker for an in-flight or finished workflow.
+//!
+//! This is a **placeholder** in the skeleton PR: the signatures are final so
+//! downstream issues (#349 / #353) can build against them, but step
+//! execution itself returns [`WorkflowError::NotImplemented`].
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::WorkflowError;
+use crate::spec::{StepId, WorkflowId, WorkflowSpec, WorkflowStatus};
+
+/// Aggregated progress counters for a workflow.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowProgress {
+    /// Number of steps that finished successfully.
+    pub completed_steps: u32,
+    /// Total number of steps in the workflow (shallow count of top-level +
+    /// children).
+    pub total_steps: u32,
+}
+
+/// Runtime record of a workflow execution.
+///
+/// The placeholder retains the final field shape so serialisation contracts
+/// won't change between this PR and the execution PR.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowJob {
+    /// Runtime id (distinct from the spec's declared `name`).
+    pub id: WorkflowId,
+    /// The spec being executed.
+    pub spec: WorkflowSpec,
+    /// Aggregated status.
+    pub status: WorkflowStatus,
+    /// Id of the step currently executing, if any.
+    pub current_step_id: Option<StepId>,
+    /// Wall-clock start (unix seconds), if the job has started.
+    pub started_at: Option<u64>,
+    /// Wall-clock completion (unix seconds), if terminal.
+    pub completed_at: Option<u64>,
+    /// Progress counters.
+    pub progress: WorkflowProgress,
+}
+
+impl WorkflowJob {
+    /// Construct a `Pending` job around a spec. Does not run anything.
+    #[must_use]
+    pub fn pending(spec: WorkflowSpec) -> Self {
+        let total = count_steps(&spec);
+        Self {
+            id: WorkflowId::new(),
+            spec,
+            status: WorkflowStatus::Pending,
+            current_step_id: None,
+            started_at: None,
+            completed_at: None,
+            progress: WorkflowProgress {
+                completed_steps: 0,
+                total_steps: total,
+            },
+        }
+    }
+
+    /// Kick off execution.
+    ///
+    /// **Skeleton**: always returns
+    /// [`WorkflowError::NotImplemented`]. The signature is final so #349
+    /// can build against it. See issue #348.
+    ///
+    /// # Errors
+    ///
+    /// Always returns [`WorkflowError::NotImplemented`] in the skeleton.
+    pub fn start(&mut self) -> Result<(), WorkflowError> {
+        Err(WorkflowError::NotImplemented(
+            "step execution pending follow-up PR",
+        ))
+    }
+}
+
+fn count_steps(spec: &WorkflowSpec) -> u32 {
+    fn count(steps: &[crate::spec::Step]) -> u32 {
+        steps
+            .iter()
+            .map(|s| {
+                1 + match &s.kind {
+                    crate::spec::StepKind::Foreach { steps, .. }
+                    | crate::spec::StepKind::Parallel { steps } => count(steps),
+                    crate::spec::StepKind::Branch {
+                        then, else_steps, ..
+                    } => count(then) + count(else_steps),
+                    _ => 0,
+                }
+            })
+            .sum()
+    }
+    count(&spec.steps)
+}

--- a/crates/dcc-mcp-workflow/src/lib.rs
+++ b/crates/dcc-mcp-workflow/src/lib.rs
@@ -1,0 +1,41 @@
+//! # dcc-mcp-workflow
+//!
+//! First-class Workflow primitive for the DCC-MCP ecosystem — a spec-driven,
+//! persistable, cancellable pipeline of tool calls that runs as an async MCP
+//! tool.
+//!
+//! **This crate is currently a skeleton.** It lands the type definitions, the
+//! YAML parser, validation (step-id uniqueness, JSONPath well-formedness,
+//! tool-name conformance), the four built-in MCP tools
+//! (`workflows.run` / `workflows.get_status` / `workflows.cancel` /
+//! `workflows.lookup`) and the `WorkflowCatalog` reader for the
+//! `metadata.dcc-mcp.workflows` glob.
+//!
+//! **Step execution is intentionally not implemented yet** — the three
+//! execution-facing tools return a well-formed error
+//! (`step execution pending follow-up PR`). This shape is deliberate so
+//! downstream issues (#349 / #351 / #353 / #354) can build against stable
+//! signatures in parallel.
+//!
+//! See issue [#348](https://github.com/loonghao/dcc-mcp-core/issues/348).
+
+#![deny(missing_docs)]
+
+pub mod catalog;
+pub mod error;
+pub mod job;
+#[cfg(feature = "python-bindings")]
+pub mod python;
+pub mod spec;
+#[cfg(feature = "job-persist-sqlite")]
+pub mod sqlite;
+pub mod tools;
+
+#[cfg(test)]
+mod tests;
+
+pub use catalog::{WorkflowCatalog, WorkflowSummary};
+pub use error::{ValidationError, WorkflowError};
+pub use job::{WorkflowJob, WorkflowProgress};
+pub use spec::{Step, StepId, StepKind, WorkflowId, WorkflowSpec, WorkflowStatus};
+pub use tools::register_builtin_workflow_tools;

--- a/crates/dcc-mcp-workflow/src/python.rs
+++ b/crates/dcc-mcp-workflow/src/python.rs
@@ -1,0 +1,136 @@
+//! PyO3 bindings for the workflow crate (minimal skeleton surface).
+//!
+//! Only `WorkflowSpec` and `WorkflowStatus` are exposed. Step execution is
+//! deferred; there is no `WorkflowJob` Python class yet.
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+use crate::spec::{WorkflowSpec, WorkflowStatus};
+
+/// Python wrapper for [`crate::WorkflowSpec`].
+///
+/// Only two operations are exposed in this skeleton:
+/// - classmethod `from_yaml_str(s: str) -> PyWorkflowSpec`
+/// - instance method `validate() -> None` (raises `ValueError` on failure)
+#[pyclass(
+    name = "WorkflowSpec",
+    module = "dcc_mcp_core._core",
+    skip_from_py_object
+)]
+#[derive(Debug, Clone)]
+pub struct PyWorkflowSpec {
+    inner: WorkflowSpec,
+}
+
+#[pymethods]
+impl PyWorkflowSpec {
+    /// Parse a workflow spec from a YAML string.
+    #[classmethod]
+    fn from_yaml_str(_cls: &Bound<'_, pyo3::types::PyType>, source: &str) -> PyResult<Self> {
+        WorkflowSpec::from_yaml(source)
+            .map(|inner| Self { inner })
+            .map_err(|e| PyValueError::new_err(e.to_string()))
+    }
+
+    /// Validate the spec. Raises ``ValueError`` on failure.
+    fn validate(&self) -> PyResult<()> {
+        self.inner
+            .validate()
+            .map_err(|e| PyValueError::new_err(e.to_string()))
+    }
+
+    /// Workflow name.
+    #[getter]
+    fn name(&self) -> &str {
+        &self.inner.name
+    }
+
+    /// Human-readable description.
+    #[getter]
+    fn description(&self) -> &str {
+        &self.inner.description
+    }
+
+    /// Number of top-level steps.
+    #[getter]
+    fn step_count(&self) -> usize {
+        self.inner.steps.len()
+    }
+
+    /// Serialise back to YAML (round-trippable with `from_yaml_str`).
+    fn to_yaml(&self) -> PyResult<String> {
+        serde_yaml_ng::to_string(&self.inner).map_err(|e| PyValueError::new_err(e.to_string()))
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "WorkflowSpec(name={:?}, steps={})",
+            self.inner.name,
+            self.inner.steps.len()
+        )
+    }
+}
+
+/// Python wrapper for [`crate::WorkflowStatus`].
+///
+/// Exposed as string constants via classmethods to keep pyo3 surface flat.
+#[pyclass(
+    name = "WorkflowStatus",
+    module = "dcc_mcp_core._core",
+    skip_from_py_object
+)]
+#[derive(Debug, Clone, Copy)]
+pub struct PyWorkflowStatus {
+    inner: WorkflowStatus,
+}
+
+#[pymethods]
+impl PyWorkflowStatus {
+    /// Construct from one of: `"pending"`, `"running"`, `"completed"`,
+    /// `"failed"`, `"cancelled"`, `"interrupted"`.
+    #[new]
+    fn new(value: &str) -> PyResult<Self> {
+        let inner = match value {
+            "pending" => WorkflowStatus::Pending,
+            "running" => WorkflowStatus::Running,
+            "completed" => WorkflowStatus::Completed,
+            "failed" => WorkflowStatus::Failed,
+            "cancelled" => WorkflowStatus::Cancelled,
+            "interrupted" => WorkflowStatus::Interrupted,
+            other => {
+                return Err(PyValueError::new_err(format!(
+                    "unknown workflow status: {other:?}"
+                )));
+            }
+        };
+        Ok(Self { inner })
+    }
+
+    /// Whether this status represents a terminal state.
+    #[getter]
+    fn is_terminal(&self) -> bool {
+        self.inner.is_terminal()
+    }
+
+    /// Lowercase string representation.
+    #[getter]
+    fn value(&self) -> &'static str {
+        self.inner.as_str()
+    }
+
+    fn __repr__(&self) -> String {
+        format!("WorkflowStatus({:?})", self.inner.as_str())
+    }
+
+    fn __str__(&self) -> &'static str {
+        self.inner.as_str()
+    }
+}
+
+/// Register the workflow classes on a Python module.
+pub fn register_classes(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<PyWorkflowSpec>()?;
+    m.add_class::<PyWorkflowStatus>()?;
+    Ok(())
+}

--- a/crates/dcc-mcp-workflow/src/spec.rs
+++ b/crates/dcc-mcp-workflow/src/spec.rs
@@ -1,0 +1,400 @@
+//! Declarative workflow types: [`WorkflowSpec`], [`Step`], [`StepKind`], status.
+
+use std::collections::HashSet;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::error::{ValidationError, WorkflowError};
+
+// ── Newtype ids ──────────────────────────────────────────────────────────
+
+/// Unique identifier for a [`WorkflowSpec`] instance (runtime job).
+///
+/// Newtype over [`Uuid`]. Stable serde shape: plain string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct WorkflowId(pub Uuid);
+
+impl WorkflowId {
+    /// Create a new random v4 id.
+    #[must_use]
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+impl Default for WorkflowId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for WorkflowId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl FromStr for WorkflowId {
+    type Err = uuid::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Uuid::parse_str(s).map(Self)
+    }
+}
+
+/// Identifier for a [`Step`] within a single [`WorkflowSpec`].
+///
+/// This is a **declared** id (authors choose it in YAML), not a UUID.
+/// Uniqueness is enforced by [`WorkflowSpec::validate`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct StepId(pub String);
+
+impl StepId {
+    /// Borrow the underlying string.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for StepId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<&str> for StepId {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+impl From<String> for StepId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+// ── Status ───────────────────────────────────────────────────────────────
+
+/// Execution status of a [`WorkflowJob`](crate::job::WorkflowJob) or step.
+///
+/// `Interrupted` is the state reported by the recovery path when a running
+/// workflow is killed mid-flight: finished steps stay finished, the first
+/// unfinished step flips to `Interrupted`, and the workflow inherits that
+/// state until a `workflows.resume` call re-schedules it. See #348.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WorkflowStatus {
+    /// Submitted but no step has started yet.
+    Pending,
+    /// At least one step has started and no terminal state has been reached.
+    Running,
+    /// All steps completed successfully.
+    Completed,
+    /// A step failed and no error handler recovered it.
+    Failed,
+    /// The outer job was cancelled by the caller.
+    Cancelled,
+    /// The process crashed / was killed mid-run; resume candidate.
+    Interrupted,
+}
+
+impl WorkflowStatus {
+    /// Returns `true` if this status represents a terminal state.
+    #[must_use]
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::Completed | Self::Failed | Self::Cancelled | Self::Interrupted
+        )
+    }
+
+    /// Lowercase string representation used in serde and Python bindings.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+            Self::Interrupted => "interrupted",
+        }
+    }
+}
+
+impl std::fmt::Display for WorkflowStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+// ── Step kinds ───────────────────────────────────────────────────────────
+
+/// Shape of a single step.
+///
+/// Uses an internal tag (`kind: ...` in YAML) so a `tool:` key alone is
+/// implicit `kind: tool` (matches the example in #348). A missing `kind`
+/// combined with a present `tool` field is normalised to [`StepKind::Tool`]
+/// by the custom [`Step`] deserialiser.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum StepKind {
+    /// Call one MCP tool on the local registry.
+    Tool {
+        /// Tool name — must pass [`dcc_mcp_naming::validate_tool_name`].
+        tool: String,
+        /// Inline arguments (template strings permitted, interpolation TBD).
+        #[serde(default)]
+        args: serde_json::Value,
+    },
+
+    /// Call one MCP tool on another DCC via the gateway.
+    ToolRemote {
+        /// Target DCC name (e.g. `"unreal"`).
+        dcc: String,
+        /// Remote tool name.
+        tool: String,
+        /// Inline arguments.
+        #[serde(default)]
+        args: serde_json::Value,
+    },
+
+    /// Iterate a JSONPath expression and run `steps` per item.
+    Foreach {
+        /// JSONPath expression into the workflow context.
+        items: String,
+        /// Binding name for the current item inside child step args.
+        #[serde(default = "default_foreach_as")]
+        r#as: String,
+        /// Child subgraph executed per item.
+        #[serde(default)]
+        steps: Vec<Step>,
+    },
+
+    /// Run N children concurrently.
+    Parallel {
+        /// Child subgraph.
+        #[serde(default)]
+        steps: Vec<Step>,
+    },
+
+    /// Elicitation / approval gate. Blocks until accept / decline / cancel.
+    Approve {
+        /// Prompt shown to the approver (template string permitted).
+        #[serde(default)]
+        prompt: String,
+    },
+
+    /// Conditional branch — `on` is a JSONPath resolving to a boolean-ish
+    /// value; `then` runs on truthy, `else` on falsy.
+    Branch {
+        /// JSONPath expression evaluated against the workflow context.
+        on: String,
+        /// Children to run on truthy.
+        #[serde(default)]
+        then: Vec<Step>,
+        /// Children to run on falsy.
+        #[serde(default, rename = "else")]
+        else_steps: Vec<Step>,
+    },
+}
+
+fn default_foreach_as() -> String {
+    "item".to_string()
+}
+
+impl StepKind {
+    /// Lowercase kind name, used in error messages.
+    #[must_use]
+    pub const fn kind_str(&self) -> &'static str {
+        match self {
+            Self::Tool { .. } => "tool",
+            Self::ToolRemote { .. } => "tool_remote",
+            Self::Foreach { .. } => "foreach",
+            Self::Parallel { .. } => "parallel",
+            Self::Approve { .. } => "approve",
+            Self::Branch { .. } => "branch",
+        }
+    }
+}
+
+// ── Step ─────────────────────────────────────────────────────────────────
+
+/// A single node in a [`WorkflowSpec`].
+///
+/// Custom deserialiser: supports the shorthand where `kind:` is omitted but
+/// a top-level `tool:` key is present (treated as `kind: tool`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Step {
+    /// Declared identifier, unique within the workflow.
+    pub id: StepId,
+    /// What this step does.
+    pub kind: StepKind,
+}
+
+impl Serialize for Step {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        // Flatten `{id, kind}` into a single map so output matches the input
+        // shape (`id`, `kind`, plus kind-specific fields).
+        let kind_value = serde_json::to_value(&self.kind).map_err(serde::ser::Error::custom)?;
+        let obj = kind_value
+            .as_object()
+            .ok_or_else(|| serde::ser::Error::custom("StepKind did not serialize to an object"))?;
+
+        let mut map = s.serialize_map(Some(obj.len() + 1))?;
+        map.serialize_entry("id", &self.id)?;
+        for (k, v) in obj {
+            map.serialize_entry(k, v)?;
+        }
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Step {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let mut value = serde_json::Value::deserialize(d)?;
+        let obj = value
+            .as_object_mut()
+            .ok_or_else(|| serde::de::Error::custom("step must be a mapping"))?;
+
+        // Extract id (required).
+        let id = obj
+            .remove("id")
+            .ok_or_else(|| serde::de::Error::missing_field("id"))?
+            .as_str()
+            .ok_or_else(|| serde::de::Error::custom("step id must be a string"))?
+            .to_string();
+
+        // Normalise shorthand: `tool: foo` with no `kind:` → `kind: tool`.
+        if !obj.contains_key("kind") && obj.contains_key("tool") && !obj.contains_key("dcc") {
+            obj.insert("kind".into(), serde_json::Value::String("tool".into()));
+        }
+
+        let kind: StepKind = serde_json::from_value(serde_json::Value::Object(obj.clone()))
+            .map_err(|e| {
+                serde::de::Error::custom(format!("step {id:?}: failed to decode kind: {e}"))
+            })?;
+
+        Ok(Step {
+            id: StepId(id),
+            kind,
+        })
+    }
+}
+
+// ── Spec ─────────────────────────────────────────────────────────────────
+
+/// Top-level workflow specification.
+///
+/// Parsed from YAML via [`Self::from_yaml`]. Validated via [`Self::validate`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WorkflowSpec {
+    /// Workflow name — used as the key in `workflows.run({skill, name})`.
+    pub name: String,
+    /// Human-readable description.
+    #[serde(default)]
+    pub description: String,
+    /// JSON-schema-shaped input declaration (opaque in this skeleton).
+    #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
+    pub inputs: serde_json::Value,
+    /// Ordered list of top-level steps.
+    #[serde(default)]
+    pub steps: Vec<Step>,
+}
+
+impl WorkflowSpec {
+    /// Parse a workflow spec from a YAML document.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WorkflowError::Yaml`] on parse failure.
+    pub fn from_yaml(s: &str) -> Result<Self, WorkflowError> {
+        serde_yaml_ng::from_str::<Self>(s).map_err(|e| WorkflowError::Yaml(e.to_string()))
+    }
+
+    /// Validate structural invariants:
+    ///
+    /// - There is at least one step.
+    /// - Every step id is non-empty and unique across the full tree.
+    /// - Every `tool`/`tool_remote` tool name passes
+    ///   [`dcc_mcp_naming::validate_tool_name`].
+    /// - Every `branch.on` and `foreach.items` parses as a JSONPath
+    ///   expression (via `jsonpath-rust`).
+    ///
+    /// # Errors
+    ///
+    /// Returns the first [`ValidationError`] encountered.
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        if self.steps.is_empty() {
+            return Err(ValidationError::NoSteps);
+        }
+        let mut seen = HashSet::new();
+        for step in &self.steps {
+            validate_step(step, &mut seen)?;
+        }
+        Ok(())
+    }
+}
+
+fn validate_step(step: &Step, seen: &mut HashSet<String>) -> Result<(), ValidationError> {
+    if step.id.0.is_empty() {
+        return Err(ValidationError::EmptyStepId);
+    }
+    if !seen.insert(step.id.0.clone()) {
+        return Err(ValidationError::DuplicateStepId(step.id.0.clone()));
+    }
+
+    match &step.kind {
+        StepKind::Tool { tool, .. } | StepKind::ToolRemote { tool, .. } => {
+            dcc_mcp_naming::validate_tool_name(tool).map_err(|e| {
+                ValidationError::InvalidToolName {
+                    step_id: step.id.0.clone(),
+                    tool: tool.clone(),
+                    reason: e.to_string(),
+                }
+            })?;
+        }
+        StepKind::Foreach { items, steps, .. } => {
+            validate_jsonpath(&step.id.0, items)?;
+            for child in steps {
+                validate_step(child, seen)?;
+            }
+        }
+        StepKind::Parallel { steps } => {
+            for child in steps {
+                validate_step(child, seen)?;
+            }
+        }
+        StepKind::Branch {
+            on,
+            then,
+            else_steps,
+        } => {
+            validate_jsonpath(&step.id.0, on)?;
+            for child in then {
+                validate_step(child, seen)?;
+            }
+            for child in else_steps {
+                validate_step(child, seen)?;
+            }
+        }
+        StepKind::Approve { .. } => {}
+    }
+    Ok(())
+}
+
+fn validate_jsonpath(step_id: &str, expr: &str) -> Result<(), ValidationError> {
+    // `jsonpath-rust` 1.x exposes `parse_json_path` as its parse entry point.
+    jsonpath_rust::parser::parse_json_path(expr).map_err(|e| ValidationError::InvalidJsonPath {
+        step_id: step_id.to_string(),
+        expr: expr.to_string(),
+        reason: e.to_string(),
+    })?;
+    Ok(())
+}

--- a/crates/dcc-mcp-workflow/src/sqlite.rs
+++ b/crates/dcc-mcp-workflow/src/sqlite.rs
@@ -1,0 +1,76 @@
+//! SQLite persistence DDL for workflow runs.
+//!
+//! **Skeleton only.** This module defines the schema but wires no writer:
+//! the execution PR will populate these tables as steps progress. A fresh
+//! `apply_migrations` call on an empty DB creates both tables cleanly.
+
+use rusqlite::Connection;
+
+/// DDL applied by [`apply_migrations`]. Public so downstream code (e.g. a
+/// migration runner in the HTTP server) can inspect or re-use it.
+pub const MIGRATION_V1: &str = r#"
+-- dcc-mcp-workflow v1 schema (issue #348 skeleton)
+CREATE TABLE IF NOT EXISTS workflows (
+    id              TEXT PRIMARY KEY NOT NULL,
+    name            TEXT NOT NULL,
+    status          TEXT NOT NULL,
+    spec_json       TEXT NOT NULL,
+    current_step_id TEXT,
+    started_at      INTEGER,
+    completed_at    INTEGER,
+    created_at      INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS workflows_status_idx ON workflows(status);
+
+CREATE TABLE IF NOT EXISTS workflow_steps (
+    workflow_id     TEXT NOT NULL REFERENCES workflows(id) ON DELETE CASCADE,
+    step_id         TEXT NOT NULL,
+    status          TEXT NOT NULL,
+    result_json     TEXT,
+    started_at      INTEGER,
+    completed_at    INTEGER,
+    PRIMARY KEY (workflow_id, step_id)
+);
+
+CREATE INDEX IF NOT EXISTS workflow_steps_status_idx ON workflow_steps(status);
+"#;
+
+/// Apply the v1 schema to `conn`. Idempotent via `IF NOT EXISTS`.
+///
+/// # Errors
+///
+/// Propagates any [`rusqlite::Error`] raised by `execute_batch`.
+pub fn apply_migrations(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(MIGRATION_V1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migration_applies_on_fresh_db() {
+        let conn = Connection::open_in_memory().unwrap();
+        apply_migrations(&conn).unwrap();
+
+        // Tables exist.
+        let mut stmt = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+            .unwrap();
+        let tables: Vec<String> = stmt
+            .query_map([], |r| r.get::<_, String>(0))
+            .unwrap()
+            .filter_map(Result::ok)
+            .collect();
+
+        assert!(tables.iter().any(|t| t == "workflows"), "got: {tables:?}");
+        assert!(
+            tables.iter().any(|t| t == "workflow_steps"),
+            "got: {tables:?}"
+        );
+
+        // Idempotent.
+        apply_migrations(&conn).unwrap();
+    }
+}

--- a/crates/dcc-mcp-workflow/src/tests.rs
+++ b/crates/dcc-mcp-workflow/src/tests.rs
@@ -1,0 +1,259 @@
+//! Unit tests for the workflow skeleton.
+
+use dcc_mcp_actions::ActionRegistry;
+use dcc_mcp_naming::validate_tool_name;
+
+use crate::catalog::{METADATA_KEY_WORKFLOWS, WorkflowCatalog};
+use crate::error::ValidationError;
+use crate::spec::{StepKind, WorkflowSpec, WorkflowStatus};
+use crate::tools::{self, register_builtin_workflow_tools};
+
+// ── spec: parse + validate ──────────────────────────────────────────────
+
+const VALID_YAML: &str = r#"
+name: vendor_intake
+description: "Import vendor Maya files, QC, export FBX, push to Unreal."
+inputs:
+  date: { type: string, format: date }
+steps:
+  - id: list
+    tool: vendor_intake__list_sftp
+    args: { date: "{{inputs.date}}" }
+  - id: per_file
+    kind: foreach
+    items: "$.list.files"
+    as: file
+    steps:
+      - id: import
+        tool: maya__import_scene
+      - id: qc
+        tool: maya_qc__run_all
+      - id: gate
+        kind: branch
+        on: "$.qc.passed"
+        then:
+          - id: export
+            tool: maya__export_fbx
+          - id: handoff
+            kind: tool_remote
+            dcc: unreal
+            tool: unreal__ingest_fbx
+"#;
+
+#[test]
+fn parses_valid_spec_and_validates() {
+    let spec = WorkflowSpec::from_yaml(VALID_YAML).unwrap();
+    assert_eq!(spec.name, "vendor_intake");
+    assert_eq!(spec.steps.len(), 2);
+    assert!(spec.validate().is_ok());
+}
+
+#[test]
+fn rejects_empty_steps() {
+    let yaml = "name: empty\nsteps: []\n";
+    let spec = WorkflowSpec::from_yaml(yaml).unwrap();
+    assert!(matches!(spec.validate(), Err(ValidationError::NoSteps)));
+}
+
+#[test]
+fn rejects_duplicate_step_ids() {
+    let yaml = r#"
+name: dup
+steps:
+  - id: a
+    tool: foo
+  - id: a
+    tool: bar
+"#;
+    let spec = WorkflowSpec::from_yaml(yaml).unwrap();
+    assert!(matches!(
+        spec.validate(),
+        Err(ValidationError::DuplicateStepId(ref id)) if id == "a"
+    ));
+}
+
+#[test]
+fn rejects_bad_tool_name() {
+    let yaml = r#"
+name: bad
+steps:
+  - id: a
+    tool: "bad/tool"
+"#;
+    let spec = WorkflowSpec::from_yaml(yaml).unwrap();
+    assert!(matches!(
+        spec.validate(),
+        Err(ValidationError::InvalidToolName { .. })
+    ));
+}
+
+#[test]
+fn rejects_bad_jsonpath_in_branch() {
+    let yaml = r#"
+name: bad_path
+steps:
+  - id: gate
+    kind: branch
+    on: "not a jsonpath"
+    then:
+      - id: inner
+        tool: ok_tool
+"#;
+    let spec = WorkflowSpec::from_yaml(yaml).unwrap();
+    assert!(matches!(
+        spec.validate(),
+        Err(ValidationError::InvalidJsonPath { .. })
+    ));
+}
+
+#[test]
+fn yaml_parse_error_surfaces_as_yaml_variant() {
+    let yaml = "name: broken\nsteps: [not closed\n";
+    let err = WorkflowSpec::from_yaml(yaml).unwrap_err();
+    assert!(matches!(err, crate::WorkflowError::Yaml(_)));
+}
+
+#[test]
+fn status_is_terminal() {
+    assert!(!WorkflowStatus::Pending.is_terminal());
+    assert!(!WorkflowStatus::Running.is_terminal());
+    assert!(WorkflowStatus::Completed.is_terminal());
+    assert!(WorkflowStatus::Failed.is_terminal());
+    assert!(WorkflowStatus::Cancelled.is_terminal());
+    assert!(WorkflowStatus::Interrupted.is_terminal());
+}
+
+#[test]
+fn step_shorthand_tool_becomes_tool_kind() {
+    // No explicit `kind:`, but `tool:` is present → StepKind::Tool.
+    let yaml = r#"
+name: shorthand
+steps:
+  - id: a
+    tool: some_tool
+"#;
+    let spec = WorkflowSpec::from_yaml(yaml).unwrap();
+    assert!(matches!(spec.steps[0].kind, StepKind::Tool { .. }));
+}
+
+// ── job placeholder ─────────────────────────────────────────────────────
+
+#[test]
+fn workflow_job_start_returns_not_implemented() {
+    let spec = WorkflowSpec::from_yaml(VALID_YAML).unwrap();
+    let mut job = crate::WorkflowJob::pending(spec);
+    let err = job.start().unwrap_err();
+    assert!(matches!(err, crate::WorkflowError::NotImplemented(_)));
+}
+
+// ── tools ───────────────────────────────────────────────────────────────
+
+#[test]
+fn builtin_tool_names_pass_sep986_validation() {
+    for name in [
+        tools::names::RUN,
+        tools::names::GET_STATUS,
+        tools::names::CANCEL,
+        tools::names::LOOKUP,
+    ] {
+        validate_tool_name(name).unwrap_or_else(|e| panic!("{name:?} rejected by SEP-986: {e}"));
+    }
+}
+
+#[test]
+fn register_builtin_tools_populates_registry() {
+    let reg = ActionRegistry::new();
+    register_builtin_workflow_tools(&reg);
+    assert!(reg.get_action(tools::names::RUN, None).is_some());
+    assert!(reg.get_action(tools::names::GET_STATUS, None).is_some());
+    assert!(reg.get_action(tools::names::CANCEL, None).is_some());
+    assert!(reg.get_action(tools::names::LOOKUP, None).is_some());
+}
+
+#[test]
+fn not_implemented_result_has_stable_shape() {
+    let r = tools::not_implemented_result("workflows.run");
+    assert_eq!(r["success"], serde_json::Value::Bool(false));
+    assert_eq!(r["error"], "not_implemented");
+    assert_eq!(r["issue"], "#348");
+    assert!(r["message"].as_str().unwrap().contains("pending"));
+}
+
+// ── catalog glob reader ─────────────────────────────────────────────────
+
+#[test]
+fn catalog_reads_glob_from_skill_metadata() {
+    use std::fs;
+
+    use dcc_mcp_models::SkillMetadata;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let skill_root = tmp.path();
+    let wf_dir = skill_root.join("workflows");
+    fs::create_dir_all(&wf_dir).unwrap();
+    fs::write(
+        wf_dir.join("vendor_intake.workflow.yaml"),
+        "name: vendor_intake\ndescription: Intake vendor files\n",
+    )
+    .unwrap();
+    fs::write(
+        wf_dir.join("nightly.workflow.yaml"),
+        "name: nightly_cleanup\ndescription: Clean staging each night\n",
+    )
+    .unwrap();
+
+    let mut meta = SkillMetadata {
+        name: "vendor-intake".to_string(),
+        ..Default::default()
+    };
+    meta.metadata = serde_json::json!({
+        METADATA_KEY_WORKFLOWS: "workflows/*.workflow.yaml",
+    });
+
+    let cat = WorkflowCatalog::from_skill(&meta, skill_root).unwrap();
+    let names: Vec<&str> = cat.entries().iter().map(|e| e.name.as_str()).collect();
+    assert!(names.contains(&"vendor_intake"), "got: {names:?}");
+    assert!(names.contains(&"nightly_cleanup"), "got: {names:?}");
+
+    let hit = cat.search("nightly");
+    assert_eq!(hit.len(), 1);
+    assert_eq!(hit[0].name, "nightly_cleanup");
+}
+
+#[test]
+fn catalog_handles_missing_metadata_key_gracefully() {
+    use dcc_mcp_models::SkillMetadata;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let meta = SkillMetadata {
+        name: "no-workflows".to_string(),
+        ..Default::default()
+    };
+    let cat = WorkflowCatalog::from_skill(&meta, tmp.path()).unwrap();
+    assert!(cat.entries().is_empty());
+}
+
+#[test]
+fn catalog_comma_separated_globs() {
+    use std::fs;
+
+    use dcc_mcp_models::SkillMetadata;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("a")).unwrap();
+    fs::create_dir_all(root.join("b")).unwrap();
+    fs::write(root.join("a/one.yaml"), "name: one\n").unwrap();
+    fs::write(root.join("b/two.yaml"), "name: two\n").unwrap();
+
+    let mut meta = SkillMetadata {
+        name: "multi".to_string(),
+        ..Default::default()
+    };
+    meta.metadata = serde_json::json!({
+        METADATA_KEY_WORKFLOWS: "a/*.yaml, b/*.yaml",
+    });
+
+    let cat = WorkflowCatalog::from_skill(&meta, root).unwrap();
+    assert_eq!(cat.entries().len(), 2);
+}

--- a/crates/dcc-mcp-workflow/src/tools.rs
+++ b/crates/dcc-mcp-workflow/src/tools.rs
@@ -1,0 +1,173 @@
+//! Built-in `workflows.*` MCP tool registrations.
+//!
+//! This module registers four tools into a [`ToolRegistry`]:
+//!
+//! | Tool name              | Status in skeleton | Behaviour                                    |
+//! |------------------------|--------------------|----------------------------------------------|
+//! | `workflows.run`        | stub               | validates spec → `NotImplemented` error      |
+//! | `workflows.get_status` | stub               | `NotImplemented` error                       |
+//! | `workflows.cancel`     | stub               | `NotImplemented` error                       |
+//! | `workflows.lookup`     | **functional**     | read-only catalog summary                    |
+//!
+//! The tools are plain metadata entries — a real dispatcher (follow-up PR)
+//! will hang Python or Rust handlers off these names via
+//! `ToolDispatcher::register_handler`.
+
+use dcc_mcp_actions::{ActionMeta, ActionRegistry};
+use serde_json::json;
+
+/// Stable wire-visible names for the `workflows.*` built-ins (public so
+/// downstream crates can `use` them).
+pub mod names {
+    /// Start a new workflow run from an inline spec or a `{skill, name}` pair.
+    pub const RUN: &str = "workflows.run";
+    /// Poll aggregated workflow + child-job state.
+    pub const GET_STATUS: &str = "workflows.get_status";
+    /// Cancel an in-flight workflow.
+    pub const CANCEL: &str = "workflows.cancel";
+    /// Read-only catalog lookup — enumerate or filter known workflows.
+    pub const LOOKUP: &str = "workflows.lookup";
+}
+
+/// Register all four `workflows.*` built-in tools on `registry`.
+///
+/// Safe to call multiple times on the same registry — the underlying
+/// `DashMap` insert overwrites. Tool names are asserted against
+/// `dcc_mcp_naming::validate_tool_name` at **compile-test time** via
+/// [`crate::tests`] — this function never panics at runtime on the names
+/// themselves.
+pub fn register_builtin_workflow_tools(registry: &ActionRegistry) {
+    registry.register_action(meta_run());
+    registry.register_action(meta_get_status());
+    registry.register_action(meta_cancel());
+    registry.register_action(meta_lookup());
+}
+
+fn meta_run() -> ActionMeta {
+    ActionMeta {
+        name: names::RUN.to_string(),
+        description: "Start a new workflow run. Accepts either an inline WorkflowSpec or a \
+             {skill, name} pair resolved through the WorkflowCatalog. \
+             (Step execution is pending a follow-up PR — see issue #348.)"
+            .to_string(),
+        category: "workflow".to_string(),
+        dcc: "core".to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        input_schema: json!({
+            "type": "object",
+            "oneOf": [
+                {"required": ["spec"]},
+                {"required": ["skill", "name"]},
+            ],
+            "properties": {
+                "spec": {"type": "object", "description": "Inline WorkflowSpec."},
+                "skill": {"type": "string"},
+                "name": {"type": "string"},
+                "inputs": {"type": "object"},
+            },
+        }),
+        output_schema: not_implemented_output_schema(),
+        ..Default::default()
+    }
+}
+
+fn meta_get_status() -> ActionMeta {
+    ActionMeta {
+        name: names::GET_STATUS.to_string(),
+        description: "Get aggregated status for a workflow run by workflow_id.".to_string(),
+        category: "workflow".to_string(),
+        dcc: "core".to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        input_schema: json!({
+            "type": "object",
+            "required": ["workflow_id"],
+            "properties": {"workflow_id": {"type": "string", "format": "uuid"}},
+        }),
+        output_schema: not_implemented_output_schema(),
+        ..Default::default()
+    }
+}
+
+fn meta_cancel() -> ActionMeta {
+    ActionMeta {
+        name: names::CANCEL.to_string(),
+        description: "Cancel an in-flight workflow run by workflow_id (cascades to children)."
+            .to_string(),
+        category: "workflow".to_string(),
+        dcc: "core".to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        input_schema: json!({
+            "type": "object",
+            "required": ["workflow_id"],
+            "properties": {"workflow_id": {"type": "string", "format": "uuid"}},
+        }),
+        output_schema: not_implemented_output_schema(),
+        ..Default::default()
+    }
+}
+
+fn meta_lookup() -> ActionMeta {
+    ActionMeta {
+        name: names::LOOKUP.to_string(),
+        description: "List or search known workflows from the catalog. Read-only.".to_string(),
+        category: "workflow".to_string(),
+        dcc: "core".to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        input_schema: json!({
+            "type": "object",
+            "properties": {
+                "skill": {"type": "string", "description": "Filter by owning skill name."},
+                "name": {"type": "string", "description": "Exact workflow name match."},
+                "query": {"type": "string", "description": "Free-text substring over name+description."},
+            },
+        }),
+        output_schema: json!({
+            "type": "object",
+            "properties": {
+                "workflows": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["name", "skill", "path"],
+                        "properties": {
+                            "name": {"type": "string"},
+                            "skill": {"type": "string"},
+                            "description": {"type": "string"},
+                            "inputs": {"type": "object"},
+                            "path": {"type": "string"},
+                        },
+                    },
+                },
+            },
+        }),
+        ..Default::default()
+    }
+}
+
+/// Structured error shape returned by the three stub tools.
+///
+/// Kept as a const helper so downstream callers can rely on the exact key
+/// set (`success: false`, `error: "not_implemented"`, `message: str`,
+/// `issue: "#348"`) even before the execution PR lands.
+#[must_use]
+pub fn not_implemented_result(which: &str) -> serde_json::Value {
+    json!({
+        "success": false,
+        "error": "not_implemented",
+        "message": format!("{which}: step execution pending follow-up PR"),
+        "issue": "#348",
+    })
+}
+
+fn not_implemented_output_schema() -> serde_json::Value {
+    json!({
+        "type": "object",
+        "required": ["success", "error"],
+        "properties": {
+            "success": {"type": "boolean"},
+            "error": {"type": "string"},
+            "message": {"type": "string"},
+            "issue": {"type": "string"},
+        },
+    })
+}

--- a/docs/api/workflow.md
+++ b/docs/api/workflow.md
@@ -1,0 +1,140 @@
+# Workflow API (skeleton)
+
+> **Status — skeleton.** The types, YAML parser, validator, catalog glob
+> reader and the four `workflows.*` built-in MCP tools ship here. **Step
+> execution is intentionally deferred to a follow-up PR** — the three
+> execution-facing tools return a stable `"step execution pending follow-up
+> PR"` error so downstream callers (#349 / #351 / #353 / #354) can build
+> against final type signatures in parallel. See
+> [issue #348](https://github.com/loonghao/dcc-mcp-core/issues/348).
+
+## Crate layout
+
+- **`dcc-mcp-workflow`** (new) — all workflow types, catalog, DDL, tool
+  registrations. Feature-gated at the workspace level behind the top-level
+  `workflow` feature (off by default for one release).
+- **`dcc-mcp-http`** — `McpHttpConfig::enable_workflows` gates registration
+  of the built-in tools on `start()`.
+
+## Types (Rust)
+
+```rust
+use dcc_mcp_workflow::{
+    WorkflowSpec, WorkflowStatus, WorkflowJob, WorkflowProgress,
+    Step, StepKind, StepId, WorkflowId,
+    WorkflowCatalog, WorkflowSummary,
+    register_builtin_workflow_tools,
+};
+```
+
+All structural types are `Serialize + Deserialize + Clone`. IDs are
+newtypes (`WorkflowId(Uuid)`, `StepId(String)`) with transparent serde.
+
+### `WorkflowSpec`
+
+```rust
+let spec = WorkflowSpec::from_yaml(yaml_source)?;
+spec.validate()?;
+```
+
+Validation checks:
+
+- At least one step.
+- Every step id is non-empty and unique across the full tree.
+- Every `tool` / `tool_remote` name passes `dcc_mcp_naming::validate_tool_name`.
+- Every `branch.on` and `foreach.items` expression parses under
+  `jsonpath-rust 1.x`.
+
+### `WorkflowJob` (placeholder)
+
+```rust
+let mut job = WorkflowJob::pending(spec);
+assert!(matches!(job.start(), Err(WorkflowError::NotImplemented(_))));
+```
+
+The signature is final so #349 / #353 can build against it; the body is
+deliberately a no-op until the execution PR.
+
+### `WorkflowCatalog`
+
+Reads `SkillMetadata.metadata["dcc-mcp.workflows"]` as a glob (or
+comma-separated list of globs) resolved relative to the skill root.
+Parses only the YAML **header** (`name`, `description`, `inputs`) per file
+into a `WorkflowSummary`. Full-body parse is deferred — marked
+`TODO(#348-full)` in the source.
+
+```rust
+use dcc_mcp_workflow::WorkflowCatalog;
+
+let catalog = WorkflowCatalog::from_skill(&skill_meta, &skill_root)?;
+for s in catalog.entries() {
+    println!("{}/{}: {}", s.skill, s.name, s.description);
+}
+```
+
+The metadata key (`dcc-mcp.workflows`) is namespaced under `dcc-mcp.*`
+per the amendment on issue #348 — it deliberately does **not** introduce a
+new top-level SKILL.md field, so `skills-ref validate` stays green.
+
+## Built-in MCP tools
+
+`register_builtin_workflow_tools(&registry)` inserts four entries:
+
+| Tool                      | Status     | Behaviour                                              |
+|---------------------------|------------|--------------------------------------------------------|
+| `workflows.run`           | stub       | Validates the spec; returns `"step execution pending"` |
+| `workflows.get_status`    | stub       | Returns `"step execution pending"`                     |
+| `workflows.cancel`        | stub       | Returns `"step execution pending"`                     |
+| `workflows.lookup`        | functional | Read-only catalog search                               |
+
+All four names pass `dcc_mcp_naming::validate_tool_name` (SEP-986).
+
+## Python surface (skeleton)
+
+Only `WorkflowSpec` and `WorkflowStatus` are Python-visible. Build the
+wheel with the `workflow` feature to get them:
+
+```python
+from dcc_mcp_core import WorkflowSpec, WorkflowStatus
+
+spec = WorkflowSpec.from_yaml_str(yaml_source)
+spec.validate()            # raises ValueError on failure
+print(spec.name, spec.step_count)
+
+s = WorkflowStatus("running")
+assert not s.is_terminal
+```
+
+If the wheel was built without the `workflow` feature, both symbols
+import as `None` from `dcc_mcp_core`.
+
+## Persistence DDL (`job-persist-sqlite` feature)
+
+`dcc_mcp_workflow::sqlite::apply_migrations(&conn)` creates two tables:
+
+- `workflows(id TEXT PK, name, status, spec_json, current_step_id, started_at, completed_at, created_at)`
+- `workflow_steps(workflow_id FK, step_id, status, result_json, started_at, completed_at, PRIMARY KEY(workflow_id, step_id))`
+
+No writer is wired in this skeleton — the tables exist but nothing
+populates them. The execution PR will wire `WorkflowJob` progression into
+these tables for crash recovery (see `WorkflowStatus::Interrupted`).
+
+## Discovery model
+
+Workflows are **sibling YAML files** next to `SKILL.md`, pointed at via a
+single `metadata` glob:
+
+```yaml
+# SKILL.md (agentskills.io-valid)
+---
+name: vendor-intake
+description: "Import vendor Maya files, run QC, export FBX, hand off to Unreal."
+metadata:
+  dcc-mcp.workflows: "workflows/*.workflow.yaml"
+  dcc-mcp.workflows.search-hint: "vendor intake, nightly cleanup, batch import"
+---
+```
+
+This keeps SKILL.md tiny and composable — see the amendment comment on
+issue #348 for the full rationale (progressive disclosure, diffability,
+reusability).

--- a/justfile
+++ b/justfile
@@ -83,7 +83,7 @@ dev:
         . .venv/bin/activate; \
     fi
     pip install maturin 2>/dev/null || true
-    maturin develop --features python-bindings,ext-module
+    maturin develop --features python-bindings,ext-module,workflow
 
 [windows]
 dev:
@@ -92,7 +92,7 @@ dev:
         & .\.venv\Scripts\Activate.ps1; \
     }
     pip install maturin -q 2>$null
-    maturin develop --features python-bindings,ext-module
+    maturin develop --features python-bindings,ext-module,workflow
 
 # Build abi3-py38 release wheel and install it
 install:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2368,6 +2368,136 @@ print(f"MCP server ready: {handle.mcp_url()}")
 
 ---
 
+## Workflow Primitive (`dcc_mcp_workflow`, skeleton — issue #348)
+
+**Status**: skeleton. Types, YAML parser, validator, catalog reader, DDL
+and the four built-in `workflows.*` MCP tools are shipped. **Step
+execution is intentionally deferred** to a follow-up PR — see the stable
+error payload below.
+
+Opt-in via the top-level `workflow` Cargo feature (off by default for
+one release). Python surface: `WorkflowSpec`, `WorkflowStatus` — or
+`None` when the wheel was built without the feature.
+
+### Rust types
+
+```rust
+use dcc_mcp_workflow::{
+    WorkflowSpec, Step, StepKind, StepId, WorkflowId,
+    WorkflowStatus, WorkflowJob, WorkflowProgress,
+    WorkflowCatalog, WorkflowSummary,
+    register_builtin_workflow_tools, WorkflowError,
+};
+```
+
+All structural types are `Serialize + Deserialize`. IDs are newtypes
+with `#[serde(transparent)]`.
+
+#### `WorkflowSpec`
+
+```rust
+let spec = WorkflowSpec::from_yaml(yaml_source)?;
+spec.validate()?;   // unique step ids, SEP-986 tool names, JSONPath parse
+```
+
+Validation uses `dcc_mcp_naming::validate_tool_name` for tool refs and
+`jsonpath_rust::parser::parse_json_path` for `branch.on` / `foreach.items`.
+
+#### `WorkflowJob` (placeholder)
+
+```rust
+let mut job = WorkflowJob::pending(spec);
+assert!(matches!(job.start(), Err(WorkflowError::NotImplemented(_))));
+```
+
+Signature is stable for #349 / #353; body is a deliberate stub.
+
+#### `WorkflowCatalog`
+
+Reads `SkillMetadata.metadata["dcc-mcp.workflows"]` (glob or
+comma-separated globs) relative to `skill_root`, parses **header only**:
+
+```rust
+let cat = WorkflowCatalog::from_skill(&skill_meta, &skill_root)?;
+let hits: Vec<_> = cat.search("vendor intake").into_iter().collect();
+```
+
+Full-body parse is deferred — marked `TODO(#348-full)`.
+
+### Built-in MCP tools
+
+`register_builtin_workflow_tools(&registry)` registers:
+
+| Tool                   | Status     |
+|------------------------|------------|
+| `workflows.run`        | stub       |
+| `workflows.get_status` | stub       |
+| `workflows.cancel`     | stub       |
+| `workflows.lookup`     | functional |
+
+Stable stub payload (all three execution tools):
+
+```json
+{
+  "success": false,
+  "error": "not_implemented",
+  "message": "workflows.run: step execution pending follow-up PR",
+  "issue": "#348"
+}
+```
+
+### HTTP server gate
+
+```python
+from dcc_mcp_core import McpHttpConfig
+cfg = McpHttpConfig(port=8765)
+cfg.enable_workflows = True     # default False
+```
+
+### Persistence DDL (`job-persist-sqlite` feature)
+
+```rust
+dcc_mcp_workflow::sqlite::apply_migrations(&conn)?;
+```
+
+Creates `workflows` + `workflow_steps`. No writer is wired — the tables
+are for the follow-up execution PR (crash recovery via
+`WorkflowStatus::Interrupted`).
+
+### Python
+
+```python
+from dcc_mcp_core import WorkflowSpec, WorkflowStatus
+
+if WorkflowSpec is None:
+    raise RuntimeError("wheel was built without the `workflow` feature")
+
+spec = WorkflowSpec.from_yaml_str(yaml_source)
+spec.validate()        # raises ValueError on failure
+print(spec.name, spec.step_count)
+
+s = WorkflowStatus("running")
+assert not s.is_terminal
+```
+
+### Discovery
+
+Point SKILL.md at sibling workflow YAML files via a single metadata key:
+
+```yaml
+---
+name: vendor-intake
+description: "Nightly vendor intake; import, QC, export, handoff."
+metadata:
+  dcc-mcp.workflows: "workflows/*.workflow.yaml"
+  dcc-mcp.workflows.search-hint: "vendor intake, nightly cleanup"
+---
+```
+
+No new top-level SKILL.md field → `skills-ref validate` stays green.
+
+---
+
 ## Development
 
 - Tool manager: [vx](https://github.com/loonghao/vx)

--- a/llms.txt
+++ b/llms.txt
@@ -433,6 +433,21 @@ export DCC_MCP_SKILL_PATHS="/path/to/skills1:/path/to/skills2"
 # Windows: set DCC_MCP_SKILL_PATHS=C:\skills1;C:\skills2
 ```
 
+## Workflow Primitive (skeleton — issue #348)
+
+Opt-in via the `workflow` Cargo feature. Ships types + validator + catalog
++ four built-in MCP tools; step execution is deferred to a follow-up PR.
+
+- **Types**: `WorkflowSpec`, `Step`, `StepKind` (`Tool`/`ToolRemote`/`Foreach`/`Parallel`/`Approve`/`Branch`), `WorkflowStatus`, `WorkflowJob` (placeholder)
+- **Parser / validator**: `WorkflowSpec::from_yaml(&str)` + `validate()` — checks unique step ids, SEP-986 tool names, JSONPath in `branch.on` / `foreach.items`
+- **Catalog**: `WorkflowCatalog::from_skill(&SkillMetadata, skill_root)` reads the `metadata["dcc-mcp.workflows"]` glob (comma-separated OK), header-only parse
+- **Tools**: `workflows.run` / `workflows.get_status` / `workflows.cancel` (stubs returning `"step execution pending follow-up PR"`) + `workflows.lookup` (functional)
+- **HTTP server gate**: `McpHttpConfig::enable_workflows` (default `false`)
+- **Persistence DDL**: `workflows` + `workflow_steps` tables under the `job-persist-sqlite` feature — no writer yet
+- **Python**: `from dcc_mcp_core import WorkflowSpec, WorkflowStatus` — `None` when the wheel was built without `workflow`
+
+Full docs: `docs/api/workflow.md`.
+
 ## Documentation
 
 - [README (English)](https://github.com/loonghao/dcc-mcp-core/blob/main/README.md)

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -187,6 +187,16 @@ from dcc_mcp_core._core import validate_dependencies
 from dcc_mcp_core._core import validate_tool_name
 from dcc_mcp_core._core import wrap_value
 
+# Workflow primitive — optional (Cargo `workflow` feature, issue #348 skeleton).
+# Step execution is stubbed; only WorkflowSpec/WorkflowStatus (parse+validate)
+# are Python-visible here.
+try:
+    from dcc_mcp_core._core import WorkflowSpec  # type: ignore[attr-defined]
+    from dcc_mcp_core._core import WorkflowStatus  # type: ignore[attr-defined]
+except ImportError:  # pragma: no cover — feature off
+    WorkflowSpec = None  # type: ignore[assignment,misc]
+    WorkflowStatus = None  # type: ignore[assignment,misc]
+
 # Adapters (pure-Python, non-DccServerBase)
 from dcc_mcp_core.adapters import CAPABILITY_KEYS
 from dcc_mcp_core.adapters import WEBVIEW_DEFAULT_CAPABILITIES
@@ -370,6 +380,9 @@ __all__ = [
     "WebViewContext",
     "WindowFinder",
     "WindowInfo",
+    # Workflow primitive (issue #348 skeleton — None if built without `workflow` feature).
+    "WorkflowSpec",
+    "WorkflowStatus",
     "__author__",
     "__version__",
     "check_cancelled",

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -4163,3 +4163,59 @@ def init_file_logging(config: FileLoggingConfig | None = None) -> str:
 def shutdown_file_logging() -> None:
     """Uninstall the file-logging layer; console output is unaffected."""
     ...
+
+# ── Workflow primitive (issue #348, skeleton) ────────────────────────────────
+#
+# Only WorkflowSpec / WorkflowStatus are Python-visible in this release.
+# Step execution is stubbed — see the Rust crate `dcc-mcp-workflow` for the
+# full `WorkflowJob` shape that will become Python-visible in the follow-up
+# PR. Requires the crate-level `workflow` feature at build time; when absent
+# these classes are exported from `dcc_mcp_core` as ``None``.
+
+class WorkflowSpec:
+    """Declarative workflow specification (issue #348 skeleton).
+
+    Use :py:meth:`from_yaml_str` to parse and :py:meth:`validate` to check
+    structural invariants (unique step ids, well-formed JSONPath on
+    ``branch.on`` / ``foreach.items``, tool names conformant with
+    SEP-986).
+
+    Step execution itself is **not** implemented in this release — see
+    ``workflows.run`` in the MCP tool list for the stable error shape.
+    """
+
+    name: str
+    description: str
+    step_count: int
+
+    @classmethod
+    def from_yaml_str(cls, source: str) -> WorkflowSpec:
+        """Parse a WorkflowSpec from a YAML document.
+
+        Raises ``ValueError`` on parse failure.
+        """
+        ...
+
+    def validate(self) -> None:
+        """Check structural invariants. Raises ``ValueError`` on failure."""
+        ...
+
+    def to_yaml(self) -> str:
+        """Serialise back to a YAML document (round-trippable)."""
+        ...
+
+    def __repr__(self) -> str: ...
+
+class WorkflowStatus:
+    """Status of a :py:class:`WorkflowSpec` run.
+
+    One of ``"pending"``, ``"running"``, ``"completed"``, ``"failed"``,
+    ``"cancelled"``, ``"interrupted"``.
+    """
+
+    value: str
+    is_terminal: bool
+
+    def __init__(self, value: str) -> None: ...
+    def __repr__(self) -> str: ...
+    def __str__(self) -> str: ...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,9 @@ pub use dcc_mcp_transport as transport;
 pub use dcc_mcp_usd as usd;
 pub use dcc_mcp_utils as utils;
 
+#[cfg(feature = "workflow")]
+pub use dcc_mcp_workflow as workflow;
+
 // ── Helper macros (defined before use for readability) ──
 
 /// Batch-register `#[pyfunction]`s on a module.
@@ -71,6 +74,8 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     register_http(m)?;
     register_naming(m)?;
     register_constants(m)?;
+    #[cfg(feature = "workflow")]
+    register_workflow(m)?;
 
     // ── Metadata ──
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
@@ -262,6 +267,11 @@ fn register_http(m: &Bound<'_, PyModule>) -> PyResult<()> {
 #[cfg(feature = "python-bindings")]
 fn register_naming(m: &Bound<'_, PyModule>) -> PyResult<()> {
     dcc_mcp_naming::python::register(m)
+}
+
+#[cfg(all(feature = "python-bindings", feature = "workflow"))]
+fn register_workflow(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    dcc_mcp_workflow::python::register_classes(m)
 }
 
 #[cfg(feature = "python-bindings")]

--- a/tests/test_workflow_spec.py
+++ b/tests/test_workflow_spec.py
@@ -1,0 +1,112 @@
+"""Round-trip + validation tests for the WorkflowSpec skeleton (issue #348).
+
+These tests are skipped when the extension was built without the
+``workflow`` Cargo feature — e.g. a minimal wheel that does not ship the
+Workflow primitive yet.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+import dcc_mcp_core
+
+pytestmark = pytest.mark.skipif(
+    dcc_mcp_core.WorkflowSpec is None,
+    reason="Built without the `workflow` Cargo feature",
+)
+
+
+VALID_YAML = textwrap.dedent(
+    """
+    name: vendor_intake
+    description: "Import vendor Maya files, QC, export FBX, push to Unreal."
+    inputs:
+      date: { type: string, format: date }
+    steps:
+      - id: list
+        tool: vendor_intake__list_sftp
+      - id: per_file
+        kind: foreach
+        items: "$.list.files"
+        as: file
+        steps:
+          - id: import
+            tool: maya__import_scene
+          - id: gate
+            kind: branch
+            on: "$.qc.passed"
+            then:
+              - id: export
+                tool: maya__export_fbx
+    """
+).strip()
+
+
+def test_parse_and_validate() -> None:
+    spec = dcc_mcp_core.WorkflowSpec.from_yaml_str(VALID_YAML)
+    assert spec.name == "vendor_intake"
+    assert spec.step_count == 2
+    spec.validate()
+
+
+def test_round_trip_yaml() -> None:
+    spec = dcc_mcp_core.WorkflowSpec.from_yaml_str(VALID_YAML)
+    serialized = spec.to_yaml()
+    again = dcc_mcp_core.WorkflowSpec.from_yaml_str(serialized)
+    assert again.name == spec.name
+    assert again.step_count == spec.step_count
+    again.validate()
+
+
+def test_duplicate_step_id_rejected() -> None:
+    yaml = textwrap.dedent(
+        """
+        name: dup
+        steps:
+          - id: a
+            tool: t1
+          - id: a
+            tool: t2
+        """
+    ).strip()
+    spec = dcc_mcp_core.WorkflowSpec.from_yaml_str(yaml)
+    with pytest.raises(ValueError, match="duplicate step id"):
+        spec.validate()
+
+
+def test_bad_tool_name_rejected() -> None:
+    yaml = textwrap.dedent(
+        """
+        name: bad
+        steps:
+          - id: a
+            tool: "bad/tool"
+        """
+    ).strip()
+    spec = dcc_mcp_core.WorkflowSpec.from_yaml_str(yaml)
+    with pytest.raises(ValueError, match="tool name"):
+        spec.validate()
+
+
+def test_invalid_yaml_raises_value_error() -> None:
+    with pytest.raises(ValueError):
+        dcc_mcp_core.WorkflowSpec.from_yaml_str("name: broken\nsteps: [not closed\n")
+
+
+def test_workflow_status_terminal_flags() -> None:
+    assert not dcc_mcp_core.WorkflowStatus("pending").is_terminal
+    assert not dcc_mcp_core.WorkflowStatus("running").is_terminal
+    for term in ("completed", "failed", "cancelled", "interrupted"):
+        assert dcc_mcp_core.WorkflowStatus(term).is_terminal
+
+    with pytest.raises(ValueError):
+        dcc_mcp_core.WorkflowStatus("bogus")
+
+
+def test_workflow_status_value_is_lowercase() -> None:
+    s = dcc_mcp_core.WorkflowStatus("running")
+    assert s.value == "running"
+    assert str(s) == "running"


### PR DESCRIPTION
## Summary

Skeleton PR for first-class Workflow primitive (issue #348). Lands
types, parser, validator, catalog, DDL, and the four `workflows.*`
built-in MCP tools — **step execution is deliberately deferred** to a
follow-up PR so that dependent issues #349 / #351 / #353 / #354 can
build against stable type signatures in parallel.

- **New crate `dcc-mcp-workflow`** — opt-in via the top-level `workflow`
  Cargo feature (off by default for one release). Ships `WorkflowSpec`
  (YAML parse + validate), `WorkflowJob` placeholder, `WorkflowCatalog`
  glob reader (`metadata["dcc-mcp.workflows"]`), SQLite DDL under
  `job-persist-sqlite`, and four built-in tools:
  - `workflows.run` / `workflows.get_status` / `workflows.cancel` —
    stubs returning a stable `not_implemented` payload
  - `workflows.lookup` — functional read-only catalog search
- **Python surface**: `WorkflowSpec.from_yaml_str` / `.validate` /
  `.to_yaml` + `WorkflowStatus(str)`; both exported as `None` when the
  wheel is built without the `workflow` feature
- **Config plumbing**: `McpHttpConfig::enable_workflows` (default
  `false`) — wiring into `server.start()` lands with execution
- **Docs**: `docs/api/workflow.md`, `llms.txt` + `llms-full.txt` updated

## What is deferred (explicitly)

- Step execution for all six `StepKind` variants (`Tool`, `ToolRemote`,
  `Foreach`, `Parallel`, `Approve`, `Branch`) — the follow-up PR will
  land `WorkflowJob::start()` properly, wire the SQLite writer, and
  register the tools on `McpHttpServer::start()` when
  `enable_workflows=true`
- `WorkflowCatalog` full-body parse — currently header-only
  (`TODO(#348-full)` in source)
- Python-visible `WorkflowJob` — only `WorkflowSpec` / `WorkflowStatus`
  this release

## Validation rules in place

`WorkflowSpec::validate()` checks:

- At least one step
- Every step id is non-empty and globally unique
- Every `tool` / `tool_remote` name passes
  `dcc-mcp-naming::validate_tool_name` (SEP-986)
- Every `branch.on` / `foreach.items` expression parses under
  `jsonpath-rust 1.x`

## Test plan

- [x] `vx just preflight` — Rust fmt / clippy / check / rust-test
  (8142 Python tests, Rust workspace tests)
- [x] `maturin develop --features python-bindings,ext-module,workflow`
- [x] `pytest tests/test_workflow_spec.py -v` — 7/7 passed (round-trip,
  dup id, bad tool name, malformed YAML, `WorkflowStatus` terminal
  flags)
- [x] Full pytest run — 8142/8142 passed
- [x] Rust unit tests in `crates/dcc-mcp-workflow/src/tests.rs` cover:
  parsing, validation failures, tool registration, `WorkflowJob::start`
  stub, `WorkflowCatalog` glob reader (including comma-separated), and
  SQLite migrations applying cleanly on an in-memory DB

## Design notes

- **`WorkflowJob` placement**: kept inside the new `dcc-mcp-workflow`
  crate (not `dcc-mcp-actions`) to avoid tying actions to workflow
  specifics and to co-locate spec + job for the execution PR
- **`SkillMetadata` namespacing**: reads under `metadata["dcc-mcp.workflows"]`
  rather than introducing a new top-level SKILL.md field — keeps
  `skills-ref validate` green and matches the amendment comment on #348
- **Feature-gated optional dep**: `dcc-mcp-workflow?/python-bindings`
  propagates Python bindings only when both `python-bindings` and
  `workflow` are active, so default wheels do not carry the extra code
- **Graceful Python fallback**: `WorkflowSpec` / `WorkflowStatus` are
  imported with a `try / except ImportError` guard in `__init__.py`,
  so an older wheel without the `workflow` feature still imports
  cleanly and exports them as `None`
