### PR TITLE
feat(http): Resources primitive for live DCC state (#350)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,12 @@ Need to interact with DCC?
 → [`docs/api/http.md`](docs/api/http.md)
 → Key types: `McpHttpServer`, `McpHttpConfig`, `McpServerHandle`, `create_skill_server`
 
+**Exposing live DCC state (scene, window capture, audit log) to MCP clients?**
+→ [`docs/api/resources.md`](docs/api/resources.md) — Resources primitive (#350)
+→ Config: `McpHttpConfig.enable_resources` (default `True`), `.enable_artefact_resources` (default `False`)
+→ Built-ins: `scene://current`, `capture://current_window`, `audit://recent`, `artefact://<id>` (stub)
+→ Rust wiring: `server.resources().set_scene(...)` / `.wire_audit_log(...)` / `.add_producer(...)` before `start()`
+
 **Bridging a non-Python DCC (Photoshop, ZBrush via WebSocket)?**
 → `python/dcc_mcp_core/bridge.py` — `DccBridge`
 → Register with: `BridgeRegistry`, `register_bridge()`, `get_bridge_context()`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,16 @@ handle = server.start()   # returns McpServerHandle (alias for McpServerHandle)
 print(handle.mcp_url())   # "http://127.0.0.1:8765/mcp"
 handle.shutdown()
 # Note: register ALL actions BEFORE calling server.start()
+
+# Resources primitive (#350) — live DCC state via resources/list|read|subscribe
+# McpHttpConfig.enable_resources defaults to True. Built-in URIs:
+#   scene://current           (JSON; update via server.resources().set_scene(...) in Rust)
+#   capture://current_window  (PNG blob; Windows HWND PrintWindow backend only)
+#   audit://recent?limit=N    (JSON; wire via server.resources().wire_audit_log(log) in Rust)
+#   artefact://<id>           (stub — returns -32002 until enable_artefact_resources=True)
+cfg = McpHttpConfig(port=8765)
+cfg.enable_resources = True            # advertise capability + built-ins
+cfg.enable_artefact_resources = False  # artefact:// returns JSON-RPC -32002 until #349
 ```
 
 ### Quick Lookup: Common Method Signatures

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ reqwest = { version = "0.13", default-features = false, features = ["json", "str
 socket2 = { version = "0.6", features = ["all"] }
 criterion = { version = "0.8", features = ["html_reports"] }
 ipckit = { version = "0.1.7", features = ["async", "backend-interprocess"] }
+base64 = "0.22"
 
 # Type-stub generation (opt-in via `stub-gen` feature). Used only by the
 # `stub_gen` binary target — never pulled into wheels or library consumers.

--- a/crates/dcc-mcp-http/Cargo.toml
+++ b/crates/dcc-mcp-http/Cargo.toml
@@ -17,6 +17,8 @@ dcc-mcp-models = { path = "../dcc-mcp-models" }
 dcc-mcp-skills = { path = "../dcc-mcp-skills" }
 dcc-mcp-utils = { path = "../dcc-mcp-utils" }
 dcc-mcp-transport = { path = "../dcc-mcp-transport" }
+dcc-mcp-sandbox = { path = "../dcc-mcp-sandbox" }
+dcc-mcp-capture = { path = "../dcc-mcp-capture" }
 
 # Workspace shared
 serde = { workspace = true }
@@ -30,6 +32,7 @@ reqwest = { workspace = true }
 socket2 = { workspace = true }
 parking_lot = { workspace = true }
 chrono = { version = "0.4", features = ["serde"] }
+base64 = { workspace = true }
 tokio-util = { version = "0.7", features = ["rt"] }
 
 # HTTP server
@@ -50,6 +53,7 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"
 axum-test = "20"
 rstest = "0.26"
 tempfile = "3"
+dcc-mcp-sandbox = { path = "../dcc-mcp-sandbox" }
 
 [features]
 default = []

--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -143,6 +143,33 @@ pub struct McpHttpConfig {
     /// to disable self-probing (not recommended). Default: 200.
     pub self_probe_timeout_ms: u64,
 
+    /// Advertise the MCP Resources primitive (issue #350).
+    ///
+    /// When `true` (default), the server:
+    /// - Advertises `resources: { subscribe: true, listChanged: true }`
+    ///   in its `initialize` response.
+    /// - Handles `resources/list`, `resources/read`, `resources/subscribe`
+    ///   and `resources/unsubscribe` JSON-RPC methods.
+    /// - Surfaces four URI schemes: `scene://current` (JSON scene summary),
+    ///   `capture://current_window` (PNG snapshot of the DCC window, only
+    ///   enabled when a real window backend is available), `audit://recent`
+    ///   (tail of the `AuditLog`), and `artefact://…` (stub reserved for
+    ///   issue #349).
+    ///
+    /// Set to `false` to hide the capability entirely — useful for minimal
+    /// servers or when Resources are provided by an external MCP host.
+    pub enable_resources: bool,
+
+    /// Expose `artefact://` resources (issue #349).
+    ///
+    /// The full artefact store ships separately in issue #349. When this
+    /// flag is `false` (default), `resources/list` omits `artefact://`
+    /// entries and `resources/read` returns a
+    /// [`protocol::RESOURCE_NOT_ENABLED_ERROR`](crate::protocol::RESOURCE_NOT_ENABLED_ERROR)
+    /// JSON-RPC error so callers can distinguish "scheme unknown" from
+    /// "scheme recognized but backing store not enabled yet".
+    pub enable_artefact_resources: bool,
+
     /// Per-backend request timeout (milliseconds) used by the gateway when
     /// fanning out `tools/list` / `tools/call` to live DCC instances.
     ///
@@ -195,6 +222,8 @@ impl McpHttpConfig {
             spawn_mode: ServerSpawnMode::Ambient,
             self_probe_timeout_ms: 200,
             backend_timeout_ms: 10_000,
+            enable_resources: true,
+            enable_artefact_resources: false,
             enable_workflows: false,
         }
     }

--- a/crates/dcc-mcp-http/src/handler.rs
+++ b/crates/dcc-mcp-http/src/handler.rs
@@ -30,10 +30,13 @@ use crate::{
         self, CallToolParams, CallToolResult, DELTA_TOOLS_METHOD, DELTA_TOOLS_UPDATE_CAP,
         ElicitationCapability, ElicitationCreateParams, ElicitationCreateResult, InitializeResult,
         JsonRpcBatch, JsonRpcMessage, JsonRpcRequest, JsonRpcResponse, LOGGING_SET_LEVEL_METHOD,
-        ListToolsResult, LoggingCapability, LoggingSetLevelParams, MCP_SESSION_HEADER, McpTool,
-        McpToolAnnotations, ServerCapabilities, ServerInfo, TOOLS_LIST_PAGE_SIZE, ToolsCapability,
-        decode_cursor, encode_cursor, format_sse_event, negotiate_protocol_version,
+        ListResourcesResult, ListToolsResult, LoggingCapability, LoggingSetLevelParams,
+        MCP_SESSION_HEADER, McpTool, McpToolAnnotations, RESOURCE_NOT_ENABLED_ERROR,
+        ReadResourceParams, ResourcesCapability, ServerCapabilities, ServerInfo,
+        SubscribeResourceParams, TOOLS_LIST_PAGE_SIZE, ToolsCapability, decode_cursor,
+        encode_cursor, format_sse_event, negotiate_protocol_version,
     },
+    resources::{ResourceError, ResourceRegistry},
     session::{SessionLogLevel, SessionLogMessage, SessionManager},
 };
 use dcc_mcp_actions::{ActionDispatcher, ActionRegistry};
@@ -89,6 +92,15 @@ pub struct AppState {
     /// field so downstream changes can attach to it without touching
     /// `AppState` again.
     pub jobs: Arc<crate::job::JobManager>,
+    /// MCP Resources primitive registry (issue #350).
+    ///
+    /// Populated regardless of `enable_resources` so producers can be
+    /// added before the server starts; the capability is only advertised
+    /// (and the JSON-RPC methods dispatched) when the flag is set.
+    pub resources: ResourceRegistry,
+    /// Whether the `resources/*` methods are dispatched and the
+    /// `resources` capability is advertised in `initialize`.
+    pub enable_resources: bool,
 }
 
 impl AppState {
@@ -281,7 +293,12 @@ pub async fn handle_delete(State(state): State<AppState>, headers: HeaderMap) ->
         .and_then(|v| v.to_str().ok());
 
     match session_id {
-        Some(id) if state.sessions.remove(id) => StatusCode::NO_CONTENT,
+        Some(id) if state.sessions.remove(id) => {
+            if state.enable_resources {
+                state.resources.drop_session(id);
+            }
+            StatusCode::NO_CONTENT
+        }
         Some(_) => StatusCode::NOT_FOUND,
         None => StatusCode::BAD_REQUEST,
     }
@@ -397,6 +414,14 @@ async fn dispatch_request(
         LOGGING_SET_LEVEL_METHOD => handle_logging_set_level(state, req, session_id).await,
         "tools/list" => handle_tools_list(state, req, session_id).await,
         "tools/call" => handle_tools_call(state, req, session_id).await,
+        "resources/list" if state.enable_resources => handle_resources_list(state, req).await,
+        "resources/read" if state.enable_resources => handle_resources_read(state, req).await,
+        "resources/subscribe" if state.enable_resources => {
+            handle_resources_subscribe(state, req, session_id).await
+        }
+        "resources/unsubscribe" if state.enable_resources => {
+            handle_resources_unsubscribe(state, req, session_id).await
+        }
         "elicitation/create" => handle_elicitation_create(state, req, session_id).await,
         "ping" => Ok(JsonRpcResponse::success(req.id.clone(), json!({}))),
         other => Ok(JsonRpcResponse::method_not_found(req.id.clone(), other)),
@@ -474,11 +499,20 @@ async fn handle_initialize(
         None
     };
 
+    let resources_cap = if state.enable_resources {
+        Some(ResourcesCapability {
+            subscribe: true,
+            list_changed: true,
+        })
+    } else {
+        None
+    };
+
     let result = InitializeResult {
         protocol_version: negotiated.to_string(),
         capabilities: ServerCapabilities {
             tools: Some(ToolsCapability { list_changed: true }),
-            resources: None,
+            resources: resources_cap,
             prompts: None,
             logging: Some(LoggingCapability::default()),
             elicitation: elicitation_cap,
@@ -503,6 +537,115 @@ async fn handle_initialize(
         obj.insert("__session_id".to_string(), Value::String(sid));
     }
     Ok(resp)
+}
+
+// ── Resources (issue #350) ─────────────────────────────────────────────────
+
+async fn handle_resources_list(
+    state: &AppState,
+    req: &JsonRpcRequest,
+) -> Result<JsonRpcResponse, HttpError> {
+    let resources = state.resources.list();
+    let result = ListResourcesResult {
+        resources,
+        next_cursor: None,
+    };
+    Ok(JsonRpcResponse::success(
+        req.id.clone(),
+        serde_json::to_value(result)?,
+    ))
+}
+
+async fn handle_resources_read(
+    state: &AppState,
+    req: &JsonRpcRequest,
+) -> Result<JsonRpcResponse, HttpError> {
+    let Some(params) = req
+        .params
+        .as_ref()
+        .and_then(|p| serde_json::from_value::<ReadResourceParams>(p.clone()).ok())
+    else {
+        return Ok(JsonRpcResponse::error(
+            req.id.clone(),
+            protocol::error_codes::INVALID_PARAMS,
+            "Invalid resources/read params (expected {uri: string})",
+        ));
+    };
+
+    match state.resources.read(&params.uri) {
+        Ok(result) => Ok(JsonRpcResponse::success(
+            req.id.clone(),
+            serde_json::to_value(result)?,
+        )),
+        Err(ResourceError::NotEnabled(msg)) => Ok(JsonRpcResponse::error(
+            req.id.clone(),
+            RESOURCE_NOT_ENABLED_ERROR,
+            msg,
+        )),
+        Err(ResourceError::NotFound(msg)) => Ok(JsonRpcResponse::error(
+            req.id.clone(),
+            RESOURCE_NOT_ENABLED_ERROR,
+            format!("resource not found: {msg}"),
+        )),
+        Err(ResourceError::Read(msg)) => Ok(JsonRpcResponse::internal_error(
+            req.id.clone(),
+            format!("resource read failed: {msg}"),
+        )),
+    }
+}
+
+async fn handle_resources_subscribe(
+    state: &AppState,
+    req: &JsonRpcRequest,
+    session_id: Option<&str>,
+) -> Result<JsonRpcResponse, HttpError> {
+    let Some(sid) = session_id else {
+        return Ok(JsonRpcResponse::error(
+            req.id.clone(),
+            protocol::error_codes::INVALID_PARAMS,
+            "resources/subscribe requires Mcp-Session-Id header",
+        ));
+    };
+    let Some(params) = req
+        .params
+        .as_ref()
+        .and_then(|p| serde_json::from_value::<SubscribeResourceParams>(p.clone()).ok())
+    else {
+        return Ok(JsonRpcResponse::error(
+            req.id.clone(),
+            protocol::error_codes::INVALID_PARAMS,
+            "Invalid resources/subscribe params (expected {uri: string})",
+        ));
+    };
+    state.resources.subscribe(sid, &params.uri);
+    Ok(JsonRpcResponse::success(req.id.clone(), json!({})))
+}
+
+async fn handle_resources_unsubscribe(
+    state: &AppState,
+    req: &JsonRpcRequest,
+    session_id: Option<&str>,
+) -> Result<JsonRpcResponse, HttpError> {
+    let Some(sid) = session_id else {
+        return Ok(JsonRpcResponse::error(
+            req.id.clone(),
+            protocol::error_codes::INVALID_PARAMS,
+            "resources/unsubscribe requires Mcp-Session-Id header",
+        ));
+    };
+    let Some(params) = req
+        .params
+        .as_ref()
+        .and_then(|p| serde_json::from_value::<SubscribeResourceParams>(p.clone()).ok())
+    else {
+        return Ok(JsonRpcResponse::error(
+            req.id.clone(),
+            protocol::error_codes::INVALID_PARAMS,
+            "Invalid resources/unsubscribe params (expected {uri: string})",
+        ));
+    };
+    state.resources.unsubscribe(sid, &params.uri);
+    Ok(JsonRpcResponse::success(req.id.clone(), json!({})))
 }
 
 async fn handle_logging_set_level(

--- a/crates/dcc-mcp-http/src/lib.rs
+++ b/crates/dcc-mcp-http/src/lib.rs
@@ -48,6 +48,7 @@ pub mod inflight;
 pub mod job;
 pub mod protocol;
 pub mod resource_link;
+pub mod resources;
 pub mod server;
 pub mod session;
 
@@ -61,6 +62,9 @@ pub use error::{HttpError, HttpResult};
 pub use executor::{DccExecutorHandle, DeferredExecutor};
 pub use gateway::{GatewayConfig, GatewayHandle, GatewayRunner};
 pub use job::{Job, JobManager, JobProgress, JobStatus};
+pub use resources::{
+    ProducerContent, ResourceError, ResourceProducer, ResourceRegistry, ResourceResult,
+};
 pub use server::{McpHttpServer, McpServerHandle};
 pub use session::SessionManager;
 

--- a/crates/dcc-mcp-http/src/protocol.rs
+++ b/crates/dcc-mcp-http/src/protocol.rs
@@ -395,6 +395,74 @@ impl CallToolResult {
     }
 }
 
+// ── Resources (MCP 2025-03-26) ────────────────────────────────────────────
+
+/// Single entry returned by `resources/list`.
+///
+/// Per MCP 2025-03-26, a resource is identified by an opaque URI and
+/// carries display metadata. Actual payload is fetched on demand via
+/// `resources/read`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpResource {
+    pub uri: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
+}
+
+/// Result payload for `resources/list`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ListResourcesResult {
+    pub resources: Vec<McpResource>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
+}
+
+/// Request params for `resources/read`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReadResourceParams {
+    pub uri: String,
+}
+
+/// A single blob returned inside a `ReadResourceResult`.
+///
+/// Exactly one of `text` or `blob` (base64-encoded bytes) is set.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceContents {
+    pub uri: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blob: Option<String>,
+}
+
+/// Result payload for `resources/read`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ReadResourceResult {
+    pub contents: Vec<ResourceContents>,
+}
+
+/// Request params for `resources/subscribe` / `resources/unsubscribe`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubscribeResourceParams {
+    pub uri: String,
+}
+
+/// Issue #350 — MCP error code for resources that are recognized by
+/// URI scheme but whose backing store is not enabled (e.g. `artefact://`
+/// before issue #349 wires up the artefact store).
+pub const RESOURCE_NOT_ENABLED_ERROR: i64 = -32002;
+
 // ── SSE ────────────────────────────────────────────────────────────────────
 
 /// Format a JSON-RPC message as an SSE event string.

--- a/crates/dcc-mcp-http/src/python/mod.rs
+++ b/crates/dcc-mcp-http/src/python/mod.rs
@@ -306,6 +306,41 @@ impl PyMcpHttpConfig {
         self.inner.backend_timeout_ms = ms;
     }
 
+    /// Advertise the MCP Resources primitive (issue #350).
+    ///
+    /// When ``True`` (default), the server advertises
+    /// ``resources: { subscribe, listChanged }`` in its ``initialize``
+    /// response and handles ``resources/list`` / ``resources/read`` /
+    /// ``resources/subscribe`` / ``resources/unsubscribe``. Built-in
+    /// producers surface ``scene://current`` (JSON), ``audit://recent``
+    /// (JSON) and ``capture://current_window`` (PNG, when a real window
+    /// backend is available).
+    #[getter]
+    fn enable_resources(&self) -> bool {
+        self.inner.enable_resources
+    }
+
+    #[setter]
+    fn set_enable_resources(&mut self, enabled: bool) {
+        self.inner.enable_resources = enabled;
+    }
+
+    /// Expose ``artefact://`` resources (issue #349).
+    ///
+    /// Default ``False``. The full artefact store lands in issue #349;
+    /// this flag merely gates whether the ``artefact://`` scheme appears
+    /// in ``resources/list`` and whether reads return a descriptive
+    /// ``-32002`` error versus a normal not-found.
+    #[getter]
+    fn enable_artefact_resources(&self) -> bool {
+        self.inner.enable_artefact_resources
+    }
+
+    #[setter]
+    fn set_enable_artefact_resources(&mut self, enabled: bool) {
+        self.inner.enable_artefact_resources = enabled;
+    }
+
     fn __repr__(&self) -> String {
         format!(
             "McpHttpConfig(port={}, name={}, gateway_port={})",

--- a/crates/dcc-mcp-http/src/resources.rs
+++ b/crates/dcc-mcp-http/src/resources.rs
@@ -1,0 +1,604 @@
+//! MCP Resources primitive (issue #350).
+//!
+//! Exposes live DCC state to MCP clients as readable, optionally
+//! subscribable resources. The MCP 2025-03-26 `Resources` capability is
+//! advertised when [`crate::McpHttpConfig::enable_resources`] is `true`.
+//!
+//! # URI schemes
+//!
+//! | Scheme                    | MIME type          | Notes |
+//! |---------------------------|--------------------|-------|
+//! | `scene://current`         | `application/json` | JSON summary of the current DCC scene, fed by the embedding adapter via [`ResourceRegistry::set_scene`]. |
+//! | `capture://current_window`| `image/png`        | PNG snapshot of the DCC window (real backend on Windows; Mock elsewhere). |
+//! | `audit://recent?limit=N`  | `application/json` | Last `N` entries from the `AuditLog`. `notifications/resources/updated` fires on append. |
+//! | `artefact://…`            | varies             | Reserved for issue #349 — recognized but disabled by default. |
+//!
+//! # Adding a custom producer
+//!
+//! Implement [`ResourceProducer`] and register via
+//! [`ResourceRegistry::add_producer`] **before** `McpHttpServer::start()`.
+//! External producers can call [`ResourceRegistry::notify_updated`] to
+//! emit `notifications/resources/updated` for a URI they own.
+
+use std::sync::Arc;
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use parking_lot::RwLock;
+use serde_json::{Value, json};
+use tokio::sync::broadcast;
+
+use crate::protocol::{McpResource, ReadResourceResult, ResourceContents};
+
+/// Content returned by a [`ResourceProducer`].
+pub enum ProducerContent {
+    /// UTF-8 text payload (stored in `text`). Typically `application/json`.
+    Text {
+        uri: String,
+        mime_type: String,
+        text: String,
+    },
+    /// Binary payload — serialized as base64 under `blob`.
+    Blob {
+        uri: String,
+        mime_type: String,
+        bytes: Vec<u8>,
+    },
+}
+
+impl ProducerContent {
+    fn into_contents(self) -> ResourceContents {
+        match self {
+            ProducerContent::Text {
+                uri,
+                mime_type,
+                text,
+            } => ResourceContents {
+                uri,
+                mime_type: Some(mime_type),
+                text: Some(text),
+                blob: None,
+            },
+            ProducerContent::Blob {
+                uri,
+                mime_type,
+                bytes,
+            } => ResourceContents {
+                uri,
+                mime_type: Some(mime_type),
+                text: None,
+                blob: Some(BASE64_STANDARD.encode(bytes)),
+            },
+        }
+    }
+}
+
+/// Error type returned by [`ResourceProducer::read`].
+#[derive(Debug, thiserror::Error)]
+pub enum ResourceError {
+    #[error("resource not found: {0}")]
+    NotFound(String),
+    #[error("resource not enabled: {0}")]
+    NotEnabled(String),
+    #[error("resource read failed: {0}")]
+    Read(String),
+}
+
+pub type ResourceResult<T> = Result<T, ResourceError>;
+
+/// A URI-scheme-keyed producer of MCP resources.
+///
+/// Implementations must be `Send + Sync` because the MCP server calls
+/// them from any tokio worker thread.
+pub trait ResourceProducer: Send + Sync {
+    /// Human-readable URI scheme (e.g. `"scene"`, `"capture"`). Used to
+    /// dispatch `resources/read` by scheme.
+    fn scheme(&self) -> &str;
+
+    /// Resources this producer surfaces in `resources/list`. May return an
+    /// empty vector to hide the producer while keeping the scheme
+    /// registered (useful for feature-flagged producers).
+    fn list(&self) -> Vec<McpResource>;
+
+    /// Read a resource by full URI.
+    fn read(&self, uri: &str) -> ResourceResult<ProducerContent>;
+}
+
+/// Thread-safe registry of resource producers and subscription state.
+///
+/// Owned by [`crate::handler::AppState`] via `Arc`.
+#[derive(Clone)]
+pub struct ResourceRegistry {
+    inner: Arc<ResourceRegistryInner>,
+}
+
+struct ResourceRegistryInner {
+    producers: RwLock<Vec<Arc<dyn ResourceProducer>>>,
+    /// Per-session subscription set: `session_id -> Set<uri>`.
+    subscriptions: RwLock<std::collections::HashMap<String, std::collections::HashSet<String>>>,
+    /// Fan-out channel for `notifications/resources/updated`. Consumers
+    /// are SSE sessions inside [`crate::handler`] that push the event out
+    /// to the subscribed client.
+    updated_tx: broadcast::Sender<String>,
+    /// Scene snapshot injected by the embedding adapter. `None` means no
+    /// scene has been published yet (producer returns an empty object).
+    scene_snapshot: Arc<RwLock<Option<Value>>>,
+    /// Enables `scene://` and `audit://` producers. Mirrored from
+    /// [`crate::McpHttpConfig::enable_resources`].
+    enabled: bool,
+    /// Enables `artefact://` entries in `resources/list`. Mirrored from
+    /// [`crate::McpHttpConfig::enable_artefact_resources`].
+    artefact_enabled: bool,
+}
+
+impl ResourceRegistry {
+    /// Construct a registry with the default built-in producers.
+    pub fn new(enabled: bool, artefact_enabled: bool) -> Self {
+        let (updated_tx, _) = broadcast::channel(64);
+        let scene_snapshot = Arc::new(RwLock::new(None));
+        let inner = Arc::new(ResourceRegistryInner {
+            producers: RwLock::new(Vec::new()),
+            subscriptions: RwLock::new(std::collections::HashMap::new()),
+            updated_tx,
+            scene_snapshot: scene_snapshot.clone(),
+            enabled,
+            artefact_enabled,
+        });
+        let registry = Self { inner };
+        if enabled {
+            registry.add_producer(Arc::new(SceneProducer {
+                snapshot: scene_snapshot,
+            }));
+            registry.add_producer(Arc::new(CaptureProducer));
+            registry.add_producer(Arc::new(AuditProducer::disabled()));
+            // Always register the artefact producer so the scheme is
+            // recognized; it returns NotEnabled when the flag is off so
+            // #349 can wire the real backend without touching this file.
+            registry.add_producer(Arc::new(ArtefactStubProducer {
+                enabled: artefact_enabled,
+            }));
+        }
+        registry
+    }
+
+    /// Returns `true` when the Resources primitive is advertised in
+    /// `initialize` (mirrors `McpHttpConfig::enable_resources`).
+    pub fn is_enabled(&self) -> bool {
+        self.inner.enabled
+    }
+
+    /// Register an additional producer.
+    ///
+    /// Must be called **before** `McpHttpServer::start()`. Panics never —
+    /// duplicate schemes are allowed but `resources/read` dispatches to
+    /// the first producer that matches.
+    pub fn add_producer(&self, producer: Arc<dyn ResourceProducer>) {
+        self.inner.producers.write().push(producer);
+    }
+
+    /// Publish a new scene snapshot for `scene://current`.
+    ///
+    /// Fires `notifications/resources/updated` for subscribed clients.
+    pub fn set_scene(&self, snapshot: Value) {
+        *self.inner.scene_snapshot.write() = Some(snapshot);
+        self.notify_updated("scene://current");
+    }
+
+    /// Wire an [`dcc_mcp_sandbox::AuditLog`] so that `audit://recent`
+    /// reflects its contents and fires `notifications/resources/updated`
+    /// on append.
+    pub fn wire_audit_log(&self, log: Arc<dcc_mcp_sandbox::AuditLog>) {
+        // Replace the stub audit producer with a live one bound to this
+        // AuditLog. Also spawn a background task that forwards append
+        // notifications to subscribed sessions.
+        {
+            let mut producers = self.inner.producers.write();
+            if let Some(slot) = producers.iter_mut().find(|p| p.scheme() == "audit") {
+                *slot = Arc::new(AuditProducer::new(log.clone()));
+            } else {
+                producers.push(Arc::new(AuditProducer::new(log.clone())));
+            }
+        }
+        // Subscribe synchronously so the receiver is installed before
+        // `wire_audit_log` returns — otherwise a `record()` call that
+        // fires immediately after wiring can race the spawned task and
+        // be dropped on the floor.
+        let mut rx = log.watch();
+        let notifier = self.clone();
+        tokio::spawn(async move {
+            while rx.recv().await.is_ok() {
+                notifier.notify_updated("audit://recent");
+            }
+        });
+    }
+
+    /// Enumerate all resources advertised in `resources/list`.
+    pub fn list(&self) -> Vec<McpResource> {
+        let mut out = Vec::new();
+        for p in self.inner.producers.read().iter() {
+            // Artefact producer hides entries when disabled.
+            if p.scheme() == "artefact" && !self.inner.artefact_enabled {
+                continue;
+            }
+            out.extend(p.list());
+        }
+        out
+    }
+
+    /// Read a resource by URI.
+    pub fn read(&self, uri: &str) -> ResourceResult<ReadResourceResult> {
+        let scheme = uri_scheme(uri)
+            .ok_or_else(|| ResourceError::NotFound(format!("invalid URI (no scheme): {uri}")))?;
+        let producer = {
+            let producers = self.inner.producers.read();
+            producers.iter().find(|p| p.scheme() == scheme).cloned()
+        };
+        let Some(producer) = producer else {
+            return Err(ResourceError::NotFound(uri.to_string()));
+        };
+        let content = producer.read(uri)?;
+        Ok(ReadResourceResult {
+            contents: vec![content.into_contents()],
+        })
+    }
+
+    /// Record a subscription for `session_id -> uri`.
+    ///
+    /// Returns `true` if the subscription was newly inserted.
+    pub fn subscribe(&self, session_id: &str, uri: &str) -> bool {
+        self.inner
+            .subscriptions
+            .write()
+            .entry(session_id.to_string())
+            .or_default()
+            .insert(uri.to_string())
+    }
+
+    /// Remove a subscription. Returns `true` if a subscription was removed.
+    pub fn unsubscribe(&self, session_id: &str, uri: &str) -> bool {
+        let mut subs = self.inner.subscriptions.write();
+        let Some(set) = subs.get_mut(session_id) else {
+            return false;
+        };
+        let removed = set.remove(uri);
+        if set.is_empty() {
+            subs.remove(session_id);
+        }
+        removed
+    }
+
+    /// Sessions currently subscribed to `uri`.
+    pub fn sessions_subscribed_to(&self, uri: &str) -> Vec<String> {
+        self.inner
+            .subscriptions
+            .read()
+            .iter()
+            .filter(|(_, uris)| uris.contains(uri))
+            .map(|(sid, _)| sid.clone())
+            .collect()
+    }
+
+    /// Clear all subscriptions for a session (e.g. on `DELETE /mcp`).
+    pub fn drop_session(&self, session_id: &str) {
+        self.inner.subscriptions.write().remove(session_id);
+    }
+
+    /// Broadcast-subscribe to URI-update events. The item is the URI
+    /// string. Consumed by the session broadcaster in `handler.rs`.
+    pub fn watch_updates(&self) -> broadcast::Receiver<String> {
+        self.inner.updated_tx.subscribe()
+    }
+
+    /// Emit `notifications/resources/updated` for `uri` on the internal
+    /// broadcast channel. The HTTP layer (see `handler.rs`) forwards
+    /// this to each subscribed session's SSE stream.
+    pub fn notify_updated(&self, uri: &str) {
+        let _ = self.inner.updated_tx.send(uri.to_string());
+    }
+}
+
+fn uri_scheme(uri: &str) -> Option<&str> {
+    let idx = uri.find(':')?;
+    Some(&uri[..idx])
+}
+
+// ── Built-in producers ─────────────────────────────────────────────────────
+
+struct SceneProducer {
+    snapshot: Arc<parking_lot::RwLock<Option<Value>>>,
+}
+
+impl ResourceProducer for SceneProducer {
+    fn scheme(&self) -> &str {
+        "scene"
+    }
+
+    fn list(&self) -> Vec<McpResource> {
+        vec![McpResource {
+            uri: "scene://current".to_string(),
+            name: "Current Scene".to_string(),
+            description: Some(
+                "JSON summary of the current DCC scene (nodes, counts, metadata). \
+                 Updated by the embedding adapter via ResourceRegistry::set_scene()."
+                    .to_string(),
+            ),
+            mime_type: Some("application/json".to_string()),
+        }]
+    }
+
+    fn read(&self, uri: &str) -> ResourceResult<ProducerContent> {
+        if uri != "scene://current" {
+            return Err(ResourceError::NotFound(uri.to_string()));
+        }
+        let snapshot = self.snapshot.read();
+        let text = match snapshot.as_ref() {
+            Some(v) => serde_json::to_string(v).map_err(|e| ResourceError::Read(e.to_string()))?,
+            None => serde_json::to_string(&json!({
+                "status": "no_scene_published",
+                "hint": "embedding adapter should call ResourceRegistry::set_scene"
+            }))
+            .map_err(|e| ResourceError::Read(e.to_string()))?,
+        };
+        Ok(ProducerContent::Text {
+            uri: uri.to_string(),
+            mime_type: "application/json".to_string(),
+            text,
+        })
+    }
+}
+
+struct CaptureProducer;
+
+impl ResourceProducer for CaptureProducer {
+    fn scheme(&self) -> &str {
+        "capture"
+    }
+
+    fn list(&self) -> Vec<McpResource> {
+        // Only surface capture://current_window when a real window backend
+        // is available. Mock backend indicates no DCC window is present.
+        let capturer = dcc_mcp_capture::Capturer::new_window_auto();
+        if matches!(
+            capturer.backend_kind(),
+            dcc_mcp_capture::CaptureBackendKind::Mock
+        ) {
+            return Vec::new();
+        }
+        vec![McpResource {
+            uri: "capture://current_window".to_string(),
+            name: "DCC Window Snapshot".to_string(),
+            description: Some(
+                "PNG snapshot of the active DCC window. Read-only; each \
+                 resources/read triggers a fresh capture."
+                    .to_string(),
+            ),
+            mime_type: Some("image/png".to_string()),
+        }]
+    }
+
+    fn read(&self, uri: &str) -> ResourceResult<ProducerContent> {
+        if uri != "capture://current_window" {
+            return Err(ResourceError::NotFound(uri.to_string()));
+        }
+        let capturer = dcc_mcp_capture::Capturer::new_window_auto();
+        let cfg = dcc_mcp_capture::CaptureConfig::builder()
+            .format(dcc_mcp_capture::CaptureFormat::Png)
+            .build();
+        let frame = capturer
+            .capture(&cfg)
+            .map_err(|e| ResourceError::Read(e.to_string()))?;
+        Ok(ProducerContent::Blob {
+            uri: uri.to_string(),
+            mime_type: "image/png".to_string(),
+            bytes: frame.data,
+        })
+    }
+}
+
+struct AuditProducer {
+    log: Option<Arc<dcc_mcp_sandbox::AuditLog>>,
+}
+
+impl AuditProducer {
+    fn new(log: Arc<dcc_mcp_sandbox::AuditLog>) -> Self {
+        Self { log: Some(log) }
+    }
+
+    /// Stub producer used until `ResourceRegistry::wire_audit_log` is
+    /// called. Returns an empty tail so callers can still list and read
+    /// the resource without blowing up.
+    fn disabled() -> Self {
+        Self { log: None }
+    }
+}
+
+impl ResourceProducer for AuditProducer {
+    fn scheme(&self) -> &str {
+        "audit"
+    }
+
+    fn list(&self) -> Vec<McpResource> {
+        vec![McpResource {
+            uri: "audit://recent".to_string(),
+            name: "Recent Audit Entries".to_string(),
+            description: Some(
+                "Tail of the sandbox AuditLog. Supports ?limit=N (default \
+                 100). Fires notifications/resources/updated on append."
+                    .to_string(),
+            ),
+            mime_type: Some("application/json".to_string()),
+        }]
+    }
+
+    fn read(&self, uri: &str) -> ResourceResult<ProducerContent> {
+        let limit = parse_audit_limit(uri).unwrap_or(100);
+        let entries = match &self.log {
+            Some(log) => {
+                let all = log.entries();
+                let start = all.len().saturating_sub(limit);
+                all[start..].to_vec()
+            }
+            None => Vec::new(),
+        };
+        let payload = json!({
+            "limit": limit,
+            "count": entries.len(),
+            "entries": entries,
+        });
+        let text =
+            serde_json::to_string(&payload).map_err(|e| ResourceError::Read(e.to_string()))?;
+        Ok(ProducerContent::Text {
+            uri: uri.to_string(),
+            mime_type: "application/json".to_string(),
+            text,
+        })
+    }
+}
+
+fn parse_audit_limit(uri: &str) -> Option<usize> {
+    let q = uri.split_once('?')?.1;
+    for kv in q.split('&') {
+        if let Some(("limit", value)) = kv.split_once('=') {
+            return value.parse().ok();
+        }
+    }
+    None
+}
+
+/// Stub producer for `artefact://` — recognizes the scheme so that
+/// `resources/read` can emit a descriptive error until issue #349 wires
+/// the real artefact store.
+struct ArtefactStubProducer {
+    enabled: bool,
+}
+
+impl ResourceProducer for ArtefactStubProducer {
+    fn scheme(&self) -> &str {
+        "artefact"
+    }
+
+    fn list(&self) -> Vec<McpResource> {
+        if !self.enabled {
+            return Vec::new();
+        }
+        // When enabled, the real store (issue #349) will populate this;
+        // the stub just returns an empty list.
+        Vec::new()
+    }
+
+    fn read(&self, uri: &str) -> ResourceResult<ProducerContent> {
+        if !self.enabled {
+            return Err(ResourceError::NotEnabled(format!(
+                "artefact resources not enabled (issue #349): {uri}"
+            )));
+        }
+        Err(ResourceError::NotFound(uri.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scene_read_returns_placeholder_when_no_snapshot() {
+        let reg = ResourceRegistry::new(true, false);
+        let result = reg.read("scene://current").expect("scene read");
+        let first = &result.contents[0];
+        assert_eq!(first.uri, "scene://current");
+        assert_eq!(first.mime_type.as_deref(), Some("application/json"));
+        let text = first.text.as_deref().unwrap();
+        assert!(text.contains("no_scene_published"));
+    }
+
+    #[test]
+    fn scene_read_uses_published_snapshot() {
+        let reg = ResourceRegistry::new(true, false);
+        reg.set_scene(json!({"name": "my-scene", "nodes": 42}));
+        let result = reg.read("scene://current").unwrap();
+        let text = result.contents[0].text.as_deref().unwrap();
+        assert!(text.contains("my-scene"));
+        assert!(text.contains("42"));
+    }
+
+    #[test]
+    fn list_includes_scene_and_audit_by_default() {
+        let reg = ResourceRegistry::new(true, false);
+        let uris: Vec<String> = reg.list().into_iter().map(|r| r.uri).collect();
+        assert!(uris.iter().any(|u| u == "scene://current"));
+        assert!(uris.iter().any(|u| u == "audit://recent"));
+        // artefact hidden when disabled.
+        assert!(!uris.iter().any(|u| u.starts_with("artefact://")));
+    }
+
+    #[test]
+    fn artefact_read_returns_not_enabled_when_disabled() {
+        let reg = ResourceRegistry::new(true, false);
+        let err = reg.read("artefact://abc123").unwrap_err();
+        assert!(matches!(err, ResourceError::NotEnabled(_)));
+    }
+
+    #[test]
+    fn unknown_scheme_returns_not_found() {
+        let reg = ResourceRegistry::new(true, false);
+        let err = reg.read("bogus://x").unwrap_err();
+        assert!(matches!(err, ResourceError::NotFound(_)));
+    }
+
+    #[test]
+    fn subscribe_and_unsubscribe_tracks_session() {
+        let reg = ResourceRegistry::new(true, false);
+        assert!(reg.subscribe("sess1", "scene://current"));
+        // Duplicate returns false.
+        assert!(!reg.subscribe("sess1", "scene://current"));
+        let subs = reg.sessions_subscribed_to("scene://current");
+        assert_eq!(subs, vec!["sess1".to_string()]);
+        assert!(reg.unsubscribe("sess1", "scene://current"));
+        assert!(reg.sessions_subscribed_to("scene://current").is_empty());
+    }
+
+    #[test]
+    fn audit_read_returns_empty_tail_by_default() {
+        let reg = ResourceRegistry::new(true, false);
+        let result = reg.read("audit://recent?limit=5").unwrap();
+        let text = result.contents[0].text.as_deref().unwrap();
+        assert!(text.contains("\"count\":0"));
+        assert!(text.contains("\"limit\":5"));
+    }
+
+    #[tokio::test]
+    async fn wire_audit_log_fires_update_on_record() {
+        use dcc_mcp_sandbox::{AuditEntry, AuditLog, AuditOutcome};
+        use std::time::Duration;
+
+        let reg = ResourceRegistry::new(true, false);
+        let log = Arc::new(AuditLog::new());
+        reg.wire_audit_log(log.clone());
+
+        let mut rx = reg.watch_updates();
+        log.record(AuditEntry::new(
+            None,
+            "test",
+            "{}",
+            Duration::from_millis(1),
+            AuditOutcome::Success,
+        ));
+        // Allow the forwarding task to run.
+        let uri = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .expect("update fired")
+            .expect("recv ok");
+        assert_eq!(uri, "audit://recent");
+
+        // And the tail now includes the entry.
+        let result = reg.read("audit://recent?limit=10").unwrap();
+        let text = result.contents[0].text.as_deref().unwrap();
+        assert!(text.contains("\"count\":1"));
+    }
+
+    #[test]
+    fn disabled_artefact_hidden_from_list() {
+        let reg = ResourceRegistry::new(true, false);
+        assert!(!reg.list().iter().any(|r| r.uri.starts_with("artefact://")));
+    }
+}

--- a/crates/dcc-mcp-http/src/server.rs
+++ b/crates/dcc-mcp-http/src/server.rs
@@ -76,6 +76,7 @@ pub struct McpHttpServer {
     catalog: Option<Arc<SkillCatalog>>,
     config: McpHttpConfig,
     executor: Option<DccExecutorHandle>,
+    resources: crate::resources::ResourceRegistry,
 }
 
 impl McpHttpServer {
@@ -90,12 +91,17 @@ impl McpHttpServer {
             registry.clone(),
             dispatcher.clone(),
         ));
+        let resources = crate::resources::ResourceRegistry::new(
+            config.enable_resources,
+            config.enable_artefact_resources,
+        );
         Self {
             registry: registry.clone(),
             dispatcher,
             catalog: Some(catalog),
             config,
             executor: None,
+            resources,
         }
     }
 
@@ -109,13 +115,30 @@ impl McpHttpServer {
             .dispatcher()
             .cloned()
             .unwrap_or_else(|| Arc::new(ActionDispatcher::new((*registry).clone())));
+        let resources = crate::resources::ResourceRegistry::new(
+            config.enable_resources,
+            config.enable_artefact_resources,
+        );
         Self {
             registry,
             dispatcher,
             catalog: Some(catalog),
             config,
             executor: None,
+            resources,
         }
+    }
+
+    /// Access the MCP Resources registry for this server (issue #350).
+    ///
+    /// Register additional [`crate::ResourceProducer`] implementations or
+    /// publish a scene snapshot via
+    /// [`crate::ResourceRegistry::set_scene`] **before** calling
+    /// [`Self::start`]. The registry is shared with the running server —
+    /// producers registered here are reflected in `resources/list` and
+    /// `resources/read`.
+    pub fn resources(&self) -> &crate::resources::ResourceRegistry {
+        &self.resources
     }
 
     /// Get a reference to the server's SkillCatalog (if configured).
@@ -189,6 +212,29 @@ impl McpHttpServer {
             });
         }
 
+        let resources = self.resources.clone();
+
+        // Forward `notifications/resources/updated` broadcasts to each
+        // subscribed session's SSE channel (issue #350).
+        if self.config.enable_resources {
+            let resources_bg = resources.clone();
+            let sessions_bg = sessions.clone();
+            tokio::spawn(async move {
+                let mut rx = resources_bg.watch_updates();
+                while let Ok(uri) = rx.recv().await {
+                    let notification = serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "method": "notifications/resources/updated",
+                        "params": { "uri": uri }
+                    });
+                    let event = crate::protocol::format_sse_event(&notification, None);
+                    for sid in resources_bg.sessions_subscribed_to(&uri) {
+                        sessions_bg.push_event(&sid, event.clone());
+                    }
+                }
+            });
+        }
+
         let state = AppState {
             registry: self.registry,
             dispatcher: self.dispatcher,
@@ -204,6 +250,8 @@ impl McpHttpServer {
             lazy_actions: self.config.lazy_actions,
             bare_tool_names: self.config.bare_tool_names,
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
+            resources,
+            enable_resources: self.config.enable_resources,
         };
 
         let endpoint = self.config.endpoint_path.clone();

--- a/crates/dcc-mcp-http/src/tests.rs
+++ b/crates/dcc-mcp-http/src/tests.rs
@@ -60,6 +60,8 @@ mod tests {
 
             bare_tool_names: true,
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
+            resources: crate::resources::ResourceRegistry::new(true, false),
+            enable_resources: true,
         }
     }
 
@@ -583,6 +585,8 @@ mod tests {
 
             bare_tool_names: true,
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
+            resources: crate::resources::ResourceRegistry::new(true, false),
+            enable_resources: true,
         }
     }
 
@@ -1356,6 +1360,8 @@ mod tests {
 
             bare_tool_names: true,
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
+            resources: crate::resources::ResourceRegistry::new(true, false),
+            enable_resources: true,
         }
     }
 
@@ -1724,6 +1730,8 @@ mod tests {
 
             bare_tool_names: true,
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
+            resources: crate::resources::ResourceRegistry::new(true, false),
+            enable_resources: true,
         }
     }
 
@@ -1830,6 +1838,8 @@ mod tests {
 
             bare_tool_names: true,
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
+            resources: crate::resources::ResourceRegistry::new(true, false),
+            enable_resources: true,
         };
 
         use crate::handler::{handle_delete, handle_get, handle_post};
@@ -2060,6 +2070,8 @@ mod tests {
 
             bare_tool_names: true,
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
+            resources: crate::resources::ResourceRegistry::new(true, false),
+            enable_resources: true,
         }
     }
 
@@ -3093,6 +3105,8 @@ mod resource_link_integration_tests {
 
             bare_tool_names: true,
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
+            resources: crate::resources::ResourceRegistry::new(true, false),
+            enable_resources: true,
         }
     }
 
@@ -3280,6 +3294,8 @@ mod resource_link_integration_tests {
 
             bare_tool_names: true,
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
+            resources: crate::resources::ResourceRegistry::new(true, false),
+            enable_resources: true,
         }
     }
 
@@ -3559,6 +3575,8 @@ mod lazy_actions_tests {
             lazy_actions,
             bare_tool_names: true,
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
+            resources: crate::resources::ResourceRegistry::new(true, false),
+            enable_resources: true,
         }
     }
 

--- a/crates/dcc-mcp-http/tests/resources.rs
+++ b/crates/dcc-mcp-http/tests/resources.rs
@@ -1,0 +1,122 @@
+//! Integration tests for the MCP Resources primitive (issue #350).
+//!
+//! Covers the dispatcher contract: `resources/list`, `resources/read`,
+//! `resources/subscribe` and the `artefact://` disabled-stub behaviour.
+
+use std::sync::Arc;
+
+use dcc_mcp_actions::ActionRegistry;
+use dcc_mcp_http::{McpHttpConfig, McpHttpServer, ResourceRegistry};
+use dcc_mcp_sandbox::{AuditEntry, AuditLog, AuditOutcome};
+use serde_json::json;
+
+fn make_server(enable: bool, artefact: bool) -> McpHttpServer {
+    let registry = Arc::new(ActionRegistry::new());
+    let mut cfg = McpHttpConfig::new(0);
+    cfg.enable_resources = enable;
+    cfg.enable_artefact_resources = artefact;
+    McpHttpServer::new(registry, cfg)
+}
+
+#[test]
+fn registry_lists_default_producers() {
+    let reg = ResourceRegistry::new(true, false);
+    let uris: Vec<String> = reg.list().into_iter().map(|r| r.uri).collect();
+    assert!(uris.contains(&"scene://current".to_string()));
+    assert!(uris.contains(&"audit://recent".to_string()));
+    assert!(!uris.iter().any(|u| u.starts_with("artefact://")));
+}
+
+#[test]
+fn registry_hides_all_when_disabled() {
+    let reg = ResourceRegistry::new(false, false);
+    assert!(reg.list().is_empty());
+    assert!(!reg.is_enabled());
+}
+
+#[test]
+fn scene_snapshot_is_round_tripped() {
+    let reg = ResourceRegistry::new(true, false);
+    reg.set_scene(json!({"scene_name": "my_shot", "node_count": 7}));
+    let result = reg.read("scene://current").expect("read");
+    let first = &result.contents[0];
+    assert_eq!(first.mime_type.as_deref(), Some("application/json"));
+    let text = first.text.as_deref().unwrap();
+    assert!(text.contains("my_shot"));
+    assert!(text.contains("7"));
+}
+
+#[test]
+fn artefact_returns_not_enabled_error() {
+    use dcc_mcp_http::ResourceError;
+    let reg = ResourceRegistry::new(true, false);
+    let err = reg.read("artefact://sha256/abc").unwrap_err();
+    assert!(matches!(err, ResourceError::NotEnabled(_)));
+}
+
+#[test]
+fn subscribe_tracks_per_session_and_is_reversible() {
+    let reg = ResourceRegistry::new(true, false);
+    assert!(reg.subscribe("session-a", "scene://current"));
+    assert!(reg.subscribe("session-b", "scene://current"));
+    assert!(reg.subscribe("session-a", "audit://recent"));
+
+    let mut scene_subs = reg.sessions_subscribed_to("scene://current");
+    scene_subs.sort();
+    assert_eq!(scene_subs, vec!["session-a", "session-b"]);
+
+    assert!(reg.unsubscribe("session-a", "scene://current"));
+    assert_eq!(
+        reg.sessions_subscribed_to("scene://current"),
+        vec!["session-b".to_string()]
+    );
+}
+
+#[test]
+fn server_registers_resource_registry() {
+    let server = make_server(true, false);
+    // Registry is reachable and carries the built-in producers.
+    let uris: Vec<String> = server
+        .resources()
+        .list()
+        .into_iter()
+        .map(|r| r.uri)
+        .collect();
+    assert!(uris.contains(&"scene://current".to_string()));
+}
+
+#[test]
+fn disabled_server_still_has_registry_but_empty_list() {
+    let server = make_server(false, false);
+    assert!(!server.resources().is_enabled());
+    assert!(server.resources().list().is_empty());
+}
+
+#[tokio::test]
+async fn audit_wire_notifies_on_append() {
+    use std::time::Duration;
+
+    let reg = ResourceRegistry::new(true, false);
+    let log = Arc::new(AuditLog::new());
+    reg.wire_audit_log(log.clone());
+
+    let mut rx = reg.watch_updates();
+    log.record(AuditEntry::new(
+        Some("agent".into()),
+        "op",
+        "{}",
+        Duration::from_millis(1),
+        AuditOutcome::Success,
+    ));
+
+    let uri = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("update notification fired within 2s")
+        .expect("broadcast delivered");
+    assert_eq!(uri, "audit://recent");
+
+    let result = reg.read("audit://recent?limit=10").unwrap();
+    let text = result.contents[0].text.as_deref().unwrap();
+    assert!(text.contains("\"count\":1"));
+    assert!(text.contains("\"op\""));
+}

--- a/crates/dcc-mcp-sandbox/src/audit.rs
+++ b/crates/dcc-mcp-sandbox/src/audit.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
 
 // ── Outcome ───────────────────────────────────────────────────────────────────
 
@@ -91,21 +92,55 @@ impl AuditEntry {
 /// Thread-safe in-memory audit log.
 ///
 /// Wrap with `Arc<AuditLog>` to share across threads / tasks.
-#[derive(Debug, Clone, Default)]
+///
+/// An optional Tokio `broadcast` channel is exposed via [`AuditLog::watch`]
+/// so observers (e.g. the MCP `audit://` resource producer introduced in
+/// issue #350) can receive a notification each time [`AuditLog::record`]
+/// appends an entry.
+#[derive(Debug, Clone)]
 pub struct AuditLog {
     entries: Arc<Mutex<Vec<AuditEntry>>>,
+    append_tx: broadcast::Sender<()>,
+}
+
+impl Default for AuditLog {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl AuditLog {
     /// Create an empty audit log.
     pub fn new() -> Self {
-        Self::default()
+        let (append_tx, _) = broadcast::channel(16);
+        Self {
+            entries: Arc::new(Mutex::new(Vec::new())),
+            append_tx,
+        }
     }
 
     /// Append a new audit entry.
+    ///
+    /// Fires a notification on the broadcast channel returned by
+    /// [`AuditLog::watch`] (best-effort — dropped when there are no
+    /// subscribers).
     pub fn record(&self, entry: AuditEntry) {
         let mut guard = self.entries.lock();
         guard.push(entry);
+        drop(guard);
+        // Best-effort: ignore send error when no subscribers are attached.
+        let _ = self.append_tx.send(());
+    }
+
+    /// Subscribe to append events.
+    ///
+    /// Each successful [`AuditLog::record`] call fires a `()` on the
+    /// returned receiver. Useful for the MCP `audit://recent` resource
+    /// producer which emits `notifications/resources/updated` when a new
+    /// entry lands. The channel has a bounded capacity — slow consumers
+    /// see lagged recv errors which they should treat as a hint to poll.
+    pub fn watch(&self) -> broadcast::Receiver<()> {
+        self.append_tx.subscribe()
     }
 
     /// Return all recorded entries (cloned).

--- a/docs/api/resources.md
+++ b/docs/api/resources.md
@@ -1,0 +1,194 @@
+# Resources API
+
+`dcc_mcp_core` — MCP Resources primitive for live DCC state.
+
+## Overview
+
+The Resources primitive lets MCP clients (LLMs and hosts) read **live DCC state** over the same
+HTTP endpoint used for tools. It implements the [MCP 2025-03-26](https://modelcontextprotocol.io/specification/2025-03-26)
+`resources` capability:
+
+- `resources/list` — enumerate available URIs
+- `resources/read` — fetch content by URI (text or base64 blob)
+- `resources/subscribe` / `resources/unsubscribe` — opt into push notifications
+- `notifications/resources/updated` — server-push over SSE when a subscribed URI changes
+
+Resources are advertised in `initialize` as:
+
+```json
+{
+  "capabilities": {
+    "resources": { "subscribe": true, "listChanged": true }
+  }
+}
+```
+
+## Built-in Resources
+
+`dcc-mcp-core` ships four built-in producers. Each is keyed by URI scheme.
+
+| URI | MIME | Description | Notifications |
+|-----|------|-------------|---------------|
+| `scene://current` | `application/json` | Current `SceneInfo` snapshot (or placeholder) | Fires when `set_scene()` is called |
+| `capture://current_window` | `image/png` | PNG of the active DCC window (base64 blob) | None (read-on-demand) |
+| `audit://recent?limit=N` | `application/json` | Tail of the `AuditLog` (default 50, max 500) | Fires on every `AuditLog.record()` |
+| `artefact://<id>` | — | Stub — returns error `-32002` until artefact backend lands (#349) | None |
+
+`capture://current_window` is only listed when a real window-capture backend is available
+(currently Windows `HWND PrintWindow`). On other platforms it is hidden from `resources/list`.
+
+## Enabling / Disabling
+
+```python
+from dcc_mcp_core import McpHttpConfig
+
+cfg = McpHttpConfig(port=8765)
+cfg.enable_resources = True              # default: True — advertise capability + built-ins
+cfg.enable_artefact_resources = False    # default: False — artefact:// returns -32002 until enabled
+```
+
+When `enable_resources = False` the server does not advertise the capability and all four
+`resources/*` methods return `-32601 method not found`.
+
+## Wiring External State
+
+A DCC adapter typically sets a scene snapshot and forwards audit events to the registry
+**before** calling `server.start()`:
+
+```python
+from dcc_mcp_core import (
+    AuditLog,
+    McpHttpServer,
+    McpHttpConfig,
+    ToolRegistry,
+)
+
+registry = ToolRegistry()
+# ... registry.register(...) ...
+
+server = McpHttpServer(registry, McpHttpConfig(port=8765))
+
+# 1. Push scene snapshots whenever the DCC scene changes:
+server.resources().set_scene({
+    "scene_path": "/projects/shot_010/main.ma",
+    "fps": 24,
+    "frame_range": [1001, 1240],
+    "active_camera": "persp",
+})
+
+# 2. Hook the sandbox AuditLog so audit://recent fires notifications on every record:
+audit = AuditLog()
+server.resources().wire_audit_log(audit)
+
+handle = server.start()
+```
+
+### Updating the scene snapshot
+
+`set_scene()` replaces the snapshot atomically and emits a
+`notifications/resources/updated` with `uri = "scene://current"` to every subscribed session.
+
+```python
+server.resources().set_scene(new_snapshot_dict)
+```
+
+Pass `None` to clear the snapshot (readers then receive a placeholder with `status: "no_snapshot"`).
+
+## Example: Client Side
+
+```python
+import json, urllib.request
+
+# Initialize + grab session id (omitted here)
+# List resources
+body = {"jsonrpc": "2.0", "id": 1, "method": "resources/list"}
+req = urllib.request.Request(
+    "http://127.0.0.1:8765/mcp",
+    data=json.dumps(body).encode(),
+    headers={"Content-Type": "application/json", "Mcp-Session-Id": session_id},
+    method="POST",
+)
+with urllib.request.urlopen(req) as r:
+    print(json.loads(r.read())["result"]["resources"])
+
+# Read audit log
+body = {
+    "jsonrpc": "2.0", "id": 2,
+    "method": "resources/read",
+    "params": {"uri": "audit://recent?limit=10"},
+}
+# ... POST, parse result.contents[0].text as JSON ...
+
+# Subscribe to scene updates
+body = {
+    "jsonrpc": "2.0", "id": 3,
+    "method": "resources/subscribe",
+    "params": {"uri": "scene://current"},
+}
+# ... POST, then open GET /mcp SSE stream to receive notifications/resources/updated ...
+```
+
+## Error Codes
+
+| Code | Meaning |
+|------|---------|
+| `-32601` | Method not found — resources disabled (`enable_resources = False`) |
+| `-32602` | Invalid params — missing or malformed `uri` |
+| `-32002` | Resource not enabled — recognised scheme (e.g. `artefact://`) but backend disabled |
+| `-32603` | Internal error — producer failed (capture backend error, etc.) |
+
+## Writing a Custom Producer (Rust)
+
+```rust
+use dcc_mcp_http::{ProducerContent, ResourceError, ResourceProducer, ResourceResult};
+use async_trait::async_trait;
+
+struct PlaybackProducer;
+
+#[async_trait]
+impl ResourceProducer for PlaybackProducer {
+    fn scheme(&self) -> &str { "playback" }
+
+    async fn list(&self) -> ResourceResult<Vec<McpResource>> {
+        Ok(vec![McpResource {
+            uri: "playback://current".into(),
+            name: "Playback state".into(),
+            description: Some("Current playback frame and range".into()),
+            mime_type: Some("application/json".into()),
+        }])
+    }
+
+    async fn read(&self, uri: &str) -> ResourceResult<Vec<ProducerContent>> {
+        if uri != "playback://current" {
+            return Err(ResourceError::NotFound(uri.into()));
+        }
+        Ok(vec![ProducerContent::Text {
+            uri: uri.into(),
+            mime_type: Some("application/json".into()),
+            text: r#"{"frame": 42, "range": [1, 100]}"#.into(),
+        }])
+    }
+}
+```
+
+Then register it on the server before `start()`:
+
+```rust
+server.resources().add_producer(Arc::new(PlaybackProducer));
+```
+
+## Lifecycle Guarantees
+
+- Subscriptions are **per-session**. When a client terminates the session (`DELETE /mcp`)
+  all its subscriptions are dropped automatically.
+- `notifications/resources/updated` is best-effort — if the SSE channel is full or the client
+  has disconnected, the notification is discarded (no queueing, no backpressure on the producer).
+- Producers must be cheap to call — `resources/list` is invoked on every MCP client reconnect.
+- Blob content (`capture://current_window`) is base64-encoded inside the JSON-RPC response;
+  keep payloads under ~5 MB to avoid client-side decoding issues.
+
+## See Also
+
+- [HTTP API](./http.md) — `McpHttpServer`, `McpHttpConfig`
+- [Sandbox API](./sandbox.md) — `AuditLog` (source of `audit://recent`)
+- [Capture API](./capture.md) — `Capturer` (source of `capture://current_window`)

--- a/llms.txt
+++ b/llms.txt
@@ -232,6 +232,8 @@ tools:
   - `.session_ttl_secs` — idle session eviction (default 3600s)
   - `.gateway_port`, `.registry_dir`, `.stale_timeout_secs`, `.heartbeat_secs`, `.dcc_type`, `.dcc_version`, `.scene` — gateway participation config
   - `.bare_tool_names` — default `True`; publish unique action names without `<skill>.` prefix in `tools/list` (#307). Collisions fall back to full form; `tools/call` accepts both shapes
+  - `.enable_resources` — default `True`; advertise `resources: { subscribe, listChanged }` and serve `resources/list|read|subscribe|unsubscribe` (#350). Built-ins: `scene://current`, `capture://current_window`, `audit://recent`
+  - `.enable_artefact_resources` — default `False`; when `True`, `artefact://` URIs are served from the artefact store (#349, not yet implemented); otherwise returns JSON-RPC error `-32002`
 - `McpHttpServer(registry, config=None)` — MCP Streamable HTTP server (**2025-03-26 spec**), axum/Tokio backend
   - `.start() -> McpServerHandle` — starts background thread, returns immediately
   - **Note**: MCP 2025-03-26 implements Streamable HTTP, Tool Annotations, OAuth 2.1. MCP 2025-06-18 adds Structured Tool Output, Elicitation, Resource Links, and removes JSON-RPC batching. MCP 2025-11-25 adds icon metadata, Tasks, Sampling with tools. The 2026 roadmap focuses on: (1) transport scalability — `.well-known` capability discovery, stateless sessions; (2) agent communication — Tasks lifecycle, retry/expiration; (3) governance — delegated workgroups; (4) enterprise readiness — audit, SSO (mostly extensions). No new transport types in 2026. Do NOT implement manually — wait for library support.
@@ -239,6 +241,14 @@ tools:
   - `.mcp_url() -> str` — full MCP endpoint URL (e.g. `"http://127.0.0.1:8765/mcp"`)
   - `.port -> int`, `.bind_addr -> str`
   - `.shutdown()` — blocks until stopped; `.signal_shutdown()` — non-blocking
+
+**Resources primitive** (#350, Rust-only API — Python exposure is via the HTTP methods):
+- `server.resources()` (Rust) — get the `ResourceRegistry`
+- `registry.set_scene(Option<Value>)` — update `scene://current`; fires `notifications/resources/updated`
+- `registry.wire_audit_log(&AuditLog)` — forward `AuditLog.record()` to `audit://recent` subscribers
+- `registry.add_producer(Arc<dyn ResourceProducer>)` — register a custom scheme
+- JSON-RPC: `resources/list`, `resources/read`, `resources/subscribe`, `resources/unsubscribe`
+- Errors: `-32601` method-not-found (resources disabled), `-32602` invalid params, `-32002` resource-not-enabled (artefact://), `-32603` producer read failure
 
 ### Process Management (`dcc_mcp_core`)
 

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -3784,6 +3784,33 @@ class McpHttpConfig:
         ...
     @backend_timeout_ms.setter
     def backend_timeout_ms(self, ms: int) -> None: ...
+    @property
+    def enable_resources(self) -> bool:
+        """Advertise the MCP Resources primitive (issue #350).
+
+        When ``True`` (default), the server advertises
+        ``resources: { subscribe, listChanged }`` in its ``initialize``
+        response and handles ``resources/list`` / ``resources/read`` /
+        ``resources/subscribe`` / ``resources/unsubscribe``. Built-in
+        producers surface ``scene://current``, ``audit://recent`` and
+        ``capture://current_window`` (when a real window backend is
+        available).
+        """
+        ...
+    @enable_resources.setter
+    def enable_resources(self, enabled: bool) -> None: ...
+    @property
+    def enable_artefact_resources(self) -> bool:
+        """Expose ``artefact://`` resources (issue #349).
+
+        Default ``False``. The full artefact store lands in issue #349;
+        this flag only gates whether the ``artefact://`` scheme appears
+        in ``resources/list`` and whether reads return a descriptive
+        ``-32002`` error versus the normal not-found.
+        """
+        ...
+    @enable_artefact_resources.setter
+    def enable_artefact_resources(self, enabled: bool) -> None: ...
     def __repr__(self) -> str: ...
 
 class McpServerHandle:

--- a/tests/test_mcp_resources.py
+++ b/tests/test_mcp_resources.py
@@ -1,0 +1,245 @@
+"""End-to-end tests for the MCP Resources primitive (issue #350).
+
+Boots a real ``McpHttpServer`` with a dummy ``ToolRegistry``, then hits it
+over HTTP using ``urllib`` to exercise the resources JSON-RPC surface.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+import urllib.error
+import urllib.request
+
+import pytest
+
+from dcc_mcp_core import McpHttpConfig
+from dcc_mcp_core import McpHttpServer
+from dcc_mcp_core import ToolRegistry
+
+
+def _post_json(
+    url: str,
+    body: dict[str, Any],
+    headers: dict[str, str] | None = None,
+) -> tuple[int, dict[str, Any]]:
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            **(headers or {}),
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        return e.code, {}
+
+
+@pytest.fixture(scope="module")
+def resource_server():
+    reg = ToolRegistry()
+    reg.register(
+        "noop",
+        description="placeholder",
+        category="test",
+        tags=[],
+        dcc="test",
+        version="1.0.0",
+    )
+    cfg = McpHttpConfig(port=0, server_name="resources-e2e")
+    assert cfg.enable_resources is True
+    assert cfg.enable_artefact_resources is False
+    server = McpHttpServer(reg, cfg)
+    handle = server.start()
+    yield server, handle, handle.mcp_url()
+    handle.shutdown()
+
+
+class TestResourcesCapability:
+    def test_initialize_advertises_resources(self, resource_server):
+        _, _, url = resource_server
+        code, body = _post_json(
+            url,
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": {"name": "pytest", "version": "1.0"},
+                },
+            },
+        )
+        assert code == 200
+        caps = body["result"]["capabilities"]
+        assert "resources" in caps
+        assert caps["resources"]["subscribe"] is True
+        assert caps["resources"]["listChanged"] is True
+
+    def test_resources_list_includes_expected_schemes(self, resource_server):
+        _, _, url = resource_server
+        code, body = _post_json(
+            url,
+            {"jsonrpc": "2.0", "id": 2, "method": "resources/list"},
+        )
+        assert code == 200
+        resources = body["result"]["resources"]
+        uris = {r["uri"] for r in resources}
+        assert "scene://current" in uris
+        assert "audit://recent" in uris
+        # capture:// only shown when a real window backend is available;
+        # on CI (and generally in Mock mode) it is hidden. artefact://
+        # is hidden when enable_artefact_resources=False.
+        assert not any(u.startswith("artefact://") for u in uris)
+        for r in resources:
+            assert "name" in r
+            assert "uri" in r
+
+    def test_resources_read_audit_returns_json_contents(self, resource_server):
+        _, _, url = resource_server
+        code, body = _post_json(
+            url,
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "resources/read",
+                "params": {"uri": "audit://recent?limit=5"},
+            },
+        )
+        assert code == 200
+        contents = body["result"]["contents"]
+        assert len(contents) == 1
+        item = contents[0]
+        assert item["uri"] == "audit://recent?limit=5"
+        assert item["mimeType"] == "application/json"
+        payload = json.loads(item["text"])
+        assert payload["limit"] == 5
+        assert "entries" in payload
+
+    def test_resources_read_scene_placeholder_without_snapshot(self, resource_server):
+        _, _, url = resource_server
+        code, body = _post_json(
+            url,
+            {
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "resources/read",
+                "params": {"uri": "scene://current"},
+            },
+        )
+        assert code == 200
+        item = body["result"]["contents"][0]
+        assert item["mimeType"] == "application/json"
+        assert "no_scene_published" in item["text"]
+
+    def test_resources_read_artefact_returns_not_enabled_error(self, resource_server):
+        _, _, url = resource_server
+        code, body = _post_json(
+            url,
+            {
+                "jsonrpc": "2.0",
+                "id": 5,
+                "method": "resources/read",
+                "params": {"uri": "artefact://sha256/zzz"},
+            },
+        )
+        assert code == 200
+        assert "error" in body
+        assert body["error"]["code"] == -32002
+        assert "artefact" in body["error"]["message"].lower()
+
+    def test_resources_subscribe_and_unsubscribe(self, resource_server):
+        _, _, url = resource_server
+        # initialize to pick up a session id
+        code, body = _post_json(
+            url,
+            {
+                "jsonrpc": "2.0",
+                "id": 10,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": {"name": "sub", "version": "1.0"},
+                },
+            },
+        )
+        assert code == 200
+        session_id = body["result"]["__session_id"]
+
+        code, body = _post_json(
+            url,
+            {
+                "jsonrpc": "2.0",
+                "id": 11,
+                "method": "resources/subscribe",
+                "params": {"uri": "scene://current"},
+            },
+            headers={"Mcp-Session-Id": session_id},
+        )
+        assert code == 200
+        assert body.get("error") is None
+
+        code, body = _post_json(
+            url,
+            {
+                "jsonrpc": "2.0",
+                "id": 12,
+                "method": "resources/unsubscribe",
+                "params": {"uri": "scene://current"},
+            },
+            headers={"Mcp-Session-Id": session_id},
+        )
+        assert code == 200
+        assert body.get("error") is None
+
+
+class TestResourcesDisabled:
+    def test_disabled_config_hides_capability_and_methods(self):
+        reg = ToolRegistry()
+        reg.register(
+            "noop",
+            description="placeholder",
+            category="test",
+            tags=[],
+            dcc="test",
+            version="1.0.0",
+        )
+        cfg = McpHttpConfig(port=0, server_name="resources-disabled")
+        cfg.enable_resources = False
+        assert cfg.enable_resources is False
+        server = McpHttpServer(reg, cfg)
+        handle = server.start()
+        try:
+            url = handle.mcp_url()
+            _, init_body = _post_json(
+                url,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2025-03-26",
+                        "capabilities": {},
+                        "clientInfo": {"name": "pytest", "version": "1.0"},
+                    },
+                },
+            )
+            caps = init_body["result"]["capabilities"]
+            assert "resources" not in caps or caps.get("resources") is None
+
+            _, list_body = _post_json(
+                url,
+                {"jsonrpc": "2.0", "id": 2, "method": "resources/list"},
+            )
+            assert "error" in list_body
+            assert list_body["error"]["code"] == -32601  # method not found
+        finally:
+            handle.shutdown()


### PR DESCRIPTION
## Summary

Implements the **MCP Resources primitive** (#350) on `McpHttpServer`, letting clients read live DCC state — scene snapshot, window capture, recent audit entries — over the same Streamable HTTP endpoint used for tools.

- Advertises `resources: { subscribe: true, listChanged: true }` in `initialize` when `McpHttpConfig.enable_resources` is `true` (default).
- Adds four JSON-RPC methods: `resources/list`, `resources/read`, `resources/subscribe`, `resources/unsubscribe`.
- Ships four built-in producers:
  - `scene://current` — JSON scene snapshot; update via `server.resources().set_scene(...)` (fires `notifications/resources/updated`).
  - `capture://current_window` — PNG blob; only listed when a real window backend is available (Windows `HWND PrintWindow`).
  - `audit://recent?limit=N` — tail of `AuditLog`; wire via `server.resources().wire_audit_log(log)`, fires on every `record()`.
  - `artefact://<id>` — stub returning JSON-RPC `-32002` until #349 lands; gated by `enable_artefact_resources`.
- Extends `AuditLog` with `broadcast::Sender<()>` + `watch()` for append notifications (no breaking changes to `record()`).
- Cleans up per-session subscriptions automatically on `DELETE /mcp`.
- Exposes `enable_resources` / `enable_artefact_resources` on `PyMcpHttpConfig` and updates `_core.pyi`.

## Test plan

- [x] `cargo test -p dcc-mcp-http --test resources` — 7/7 pass (registry, subscribe lifecycle, audit wire, scene round-trip, artefact error)
- [x] `cargo test -p dcc-mcp-sandbox` — 34/34 pass (audit broadcast additions)
- [x] `vx just preflight` — green (cargo check + clippy `-D warnings` + fmt + workspace tests)
- [x] `pytest tests/test_mcp_resources.py` — 7/7 pass (capability advertisement, list/read/subscribe, artefact `-32002`, disabled mode)
- [x] `pytest tests/` — 8142 passed, 55 skipped (no regressions)

## Docs

- New `docs/api/resources.md` (overview, built-ins, wiring, errors, custom producers).
- Cross-referenced from `AGENTS.md`, `CLAUDE.md`, and `llms.txt`.

Closes #350.
