### PR TITLE
docs(skills): promote sibling-file pattern from #356 to a repo-wide design rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,6 +294,68 @@ result = dispatcher.dispatch("name", json_str)   # returns dict
 registry.register(name="my_tool", description="...", dcc="maya")
 ```
 
+**SKILL.md sibling-file pattern — THE rule for every new extension (v0.15+ / #356):**
+
+Do **not** add new top-level frontmatter keys to `SKILL.md`. agentskills.io
+1.0 only allows `name`, `description`, `license`, `compatibility`,
+`metadata`, `allowed-tools` at the top level. Every dcc-mcp-core
+extension — `tools`, `groups`, `workflows`, `prompts`, behaviour
+chains, annotations, templates, examples packs, anything future —
+MUST be expressed as:
+
+1. A **namespaced key under `metadata:`** using the `dcc-mcp.<feature>` convention.
+2. The key's **value is a glob or filename** pointing at a sibling
+   file (YAML or Markdown) that carries the actual payload.
+3. The sibling file lives **inside the skill directory**, not
+   inline in `SKILL.md`.
+
+```yaml
+---
+name: maya-animation
+description: >-
+  Maya animation keyframes, timeline, curves. Use when the user asks to
+  set/query keyframes, change timeline range, or bake simulations.
+license: MIT
+metadata:
+  dcc-mcp.dcc: maya
+  dcc-mcp.tools: "tools.yaml"              # ✓ points at sibling
+  dcc-mcp.groups: "tools.yaml"             # ✓ same or separate file
+  dcc-mcp.workflows: "workflows/*.workflow.yaml"
+  dcc-mcp.prompts: "prompts/*.prompt.yaml"
+  dcc-mcp.examples: "references/EXAMPLES.md"
+---
+# body — human-readable instructions only
+```
+
+```
+maya-animation/
+├── SKILL.md                    # metadata map + body
+├── tools.yaml                  # tools + groups
+├── workflows/
+│   ├── vendor_intake.workflow.yaml
+│   └── nightly_cleanup.workflow.yaml
+├── prompts/
+│   └── review_scene.prompt.yaml
+└── references/
+    └── EXAMPLES.md
+```
+
+Why this is non-negotiable:
+
+- **`skills-ref validate` passes** — no custom top-level fields.
+- **Progressive disclosure** — agents only pay tokens for the sibling
+  files they actually need; a 60-tool skill stays cheap to index.
+- **Diffable** — one PR per workflow/prompt file, not buried in a
+  monster SKILL.md block.
+- **Forward-compatible** — future extensions add a new
+  `metadata.dcc-mcp.<x>` key and a new sibling schema, without
+  re-negotiating the frontmatter spec.
+
+When you design a new feature that touches SKILL.md, the design review
+gate is: "Can this live as a `metadata.dcc-mcp.<feature>` pointer to
+sibling files?" If the answer is no, bring it to a proposal before
+implementing (see `docs/proposals/`).
+
 **`ToolRegistry` method names still use "action" (v0.13 compatibility):**
 ```python
 # The Rust API was renamed action→tool in v0.13, but some method names
@@ -510,6 +572,7 @@ json_str = result.to_json()    # JSON string
 - Use `next-tools: on-success/on-failure` in SKILL.md — guides AI agents to follow-up tools
 - Use `search-hint:` in SKILL.md — improves `search_skills` keyword matching
 - Use tool groups with `default_active: false` for power-user features — keeps `tools/list` small
+- For every new SKILL.md extension, use a `metadata.dcc-mcp.<feature>` key pointing at a sibling file (see "SKILL.md sibling-file pattern" in Traps). Same rule for `tools`, `groups`, `workflows`, `prompts`, and anything future.
 - Unpack `scan_and_load()`: `skills, skipped = scan_and_load(dcc_name="maya")`
 - Register ALL handlers BEFORE `McpHttpServer.start()` — the server reads the registry at startup
 - Use `SandboxPolicy` + `InputValidator` for AI-driven tool execution
@@ -532,7 +595,8 @@ json_str = result.to_json()    # JSON string
 - Don't import `DeferredExecutor` from public `__init__` — use `from dcc_mcp_core._core import DeferredExecutor`
 - Don't call `.new_auto()` then `.capture_window()` — use `.new_window_auto()` for single-window capture
 - Don't use legacy APIs: `ActionManager`, `create_action_manager()`, `MiddlewareChain`, `Action` — removed in v0.12+
-- Don't put dcc-mcp-core extension keys at the top level of new SKILL.md files (v0.15+ / issue #356) — use the `metadata.dcc-mcp.*` form (`metadata["dcc-mcp.dcc"]`, `metadata["dcc-mcp.tools"] = "tools.yaml"`). Top-level `dcc:`/`tags:`/`tools:`/`groups:`/`depends:`/`search-hint:` still parse for backward compat but trigger a deprecation warn and `is_spec_compliant()` returns `False`. See `docs/guide/skills.md#migrating-pre-015-skillmd`.
+- Don't put ANY dcc-mcp-core extension at the top level of a new SKILL.md (v0.15+ / #356) — **the rule is architectural, not a list of specific fields**. `tools`, `groups`, `workflows`, `prompts`, `next-tools` behaviour chains, `examples` packs, and any future extension MUST be a `metadata.dcc-mcp.<feature>` key pointing at a sibling file. See the "SKILL.md sibling-file pattern" trap for the full rationale. Legacy top-level `dcc:`/`tags:`/`tools:`/`groups:`/`depends:`/`search-hint:` still parse for backward compat but emit a deprecation warn and make `is_spec_compliant()` return `False`. See `docs/guide/skills.md#migrating-pre-015-skillmd`.
+- Don't inline large payloads (workflow specs, prompt templates, example dialogues, annotation tables) into SKILL.md frontmatter or body, even under `metadata:` — use sibling files. SKILL.md body stays ≤500 lines / ≤5000 tokens.
 - Don't use removed transport APIs: `FramedChannel`, `connect_ipc()`, `IpcListener`, `TransportManager`, `CircuitBreaker`, `ConnectionPool` — removed in v0.14 (#251). Use `IpcChannelAdapter` / `DccLinkFrame` instead
 - Don't add Python runtime dependencies — the project is zero-dep by design
 - Don't manually bump versions or edit `CHANGELOG.md` — Release Please handles this

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,8 +63,14 @@ When you need information, read in this order — stop when you find what you ne
   - **Embedded Python** (`DccServerBase`) — Maya, Blender, Houdini, Unreal
   - **WebSocket Bridge** (`DccBridge`) — Photoshop, ZBrush, Unity, After Effects
   - **WebView Host** (`WebViewAdapter`) — AuroraView, Electron panels
-- **SKILL.md frontmatter fields**: agentskills.io standard (`name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools`) + dcc-mcp-core extensions. **v0.15+ (issue #356)**: prefer the agentskills.io-compliant `metadata.dcc-mcp.*` form (e.g. `metadata["dcc-mcp.dcc"]`, `metadata["dcc-mcp.tools"] = "tools.yaml"`); top-level legacy extension keys (`dcc`, `tags`, `search-hint`, `tools`, `groups`, `depends`, `next-tools`) still parse but emit a one-shot deprecation warning and `SkillMetadata.is_spec_compliant()` returns `False`. See `docs/guide/skills.md#migrating-pre-015-skillmd`.
-- **`next-tools`**: Per-tool field guiding AI agents to follow-up tools (`on-success` / `on-failure`). dcc-mcp-core extension, not in agentskills.io spec.
+- **SKILL.md frontmatter fields**: agentskills.io 1.0 allows ONLY six top-level keys — `name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools`. All dcc-mcp-core extensions live under `metadata:` as namespaced `dcc-mcp.<feature>` keys. The body stays ≤500 lines / ≤5000 tokens.
+- **SKILL.md sibling-file pattern (THE design rule for new features, v0.15+ / #356)**: every new extension — `tools`, `groups`, `workflows`, `prompts`, `next-tools`, `examples`, annotation packs, anything future — MUST be a `metadata.dcc-mcp.<feature>` value that **points at a sibling file** (glob or filename relative to the skill directory). Never inline the payload. This is architectural, not per-feature: when designing a new SKILL.md-touching feature, the gate is "Can it be a `metadata.dcc-mcp.<feature>` pointer to sibling YAML/MD?" If no, write a proposal under `docs/proposals/` first.
+  - Good: `metadata["dcc-mcp.workflows"] = "workflows/*.workflow.yaml"` + `workflows/vendor_intake.workflow.yaml` next to SKILL.md.
+  - Good: `metadata["dcc-mcp.tools"] = "tools.yaml"` + `tools.yaml` carrying the `tools:` and optional `groups:` lists.
+  - Bad: putting a `workflows:` / `tools:` / `prompts:` block at the SKILL.md top level (legacy parse still works but emits a deprecation warn and flips `is_spec_compliant()` to False).
+  - Bad: inlining a multi-step workflow or a long prompt template inside `metadata:` as a YAML block — use a sibling file even under `metadata:`.
+  - See `docs/guide/skills.md#migrating-pre-015-skillmd` for the before/after mapping.
+- **`next-tools`**: Per-tool field guiding AI agents to follow-up tools (`on-success` / `on-failure`). dcc-mcp-core extension, carried inside the `tools.yaml` sibling file — never at the SKILL.md top level.
 - **`allowed-tools`**: Experimental agentskills.io field — space-separated pre-approved tool strings (e.g. `Bash(git:*) Read`)
 
 ```python

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -637,3 +637,53 @@ groups:
   ```
 
 A one-shot CLI migrator (`dcc-mcp-migrate-skill`) is planned as a follow-up; see the tracking issue for status.
+
+### The sibling-file pattern is the rule for every new extension
+
+The migration table above is not an exhaustive list — it is an example
+of **the single design rule** that governs every SKILL.md extension
+dcc-mcp-core adds from v0.15 onward:
+
+> **New extensions live under `metadata.dcc-mcp.<feature>` and point at sibling files; they never add new top-level frontmatter keys and they never inline large payloads into SKILL.md.**
+
+Concrete applications (shipped or in flight):
+
+| Feature | Metadata key | Sibling file(s) | Issue |
+|---|---|---|---|
+| Tool declarations + groups | `metadata["dcc-mcp.tools"]`, `metadata["dcc-mcp.groups"]` | `tools.yaml` | #356 |
+| Workflow specs | `metadata["dcc-mcp.workflows"]` | `workflows/*.workflow.yaml` | #348 |
+| Prompts / templates | `metadata["dcc-mcp.prompts"]` | `prompts/*.prompt.yaml` | #351, #355 |
+| Example dialogues | `metadata["dcc-mcp.examples"]` | `references/EXAMPLES.md` or `examples/*.md` | (future) |
+| Tool annotation packs | `metadata["dcc-mcp.annotations"]` | `annotations.yaml` or carried in `tools.yaml` | #344 |
+| next-tools behaviour chains | (carried inline inside `tools.yaml`) | n/a — never a top-level SKILL.md field | #342 |
+
+Layout convention (pick the shape that matches the feature's cardinality):
+
+```
+my-skill/
+├── SKILL.md
+├── tools.yaml               # one file — tools + groups + next-tools
+├── workflows/               # many files — one per workflow
+│   ├── vendor_intake.workflow.yaml
+│   └── nightly_cleanup.workflow.yaml
+├── prompts/                 # many files — one per prompt template
+│   └── review_scene.prompt.yaml
+└── references/              # Markdown reference material (agentskills.io standard)
+    ├── EXAMPLES.md
+    └── REFERENCE.md
+```
+
+Why the rule holds:
+
+- **Spec-conformance**: `skills-ref validate` (agentskills.io's
+  reference validator) passes without a custom ruleset.
+- **Progressive disclosure**: `search_skills` reads only SKILL.md; a
+  sibling file loads on demand when the agent activates that feature.
+- **Bounded SKILL.md**: the body stays ≤500 lines / ≤5000 tokens
+  regardless of how many workflows / prompts / examples ship.
+- **Diff-friendly**: a new workflow is one new YAML file in review,
+  not a 300-line diff inside SKILL.md.
+
+If a feature you are designing can't fit this pattern, that is a
+signal to write a proposal under `docs/proposals/` and discuss the
+frontmatter impact before implementing.


### PR DESCRIPTION
## Summary

Promotes the `metadata.dcc-mcp.<feature>` + sibling-file convention
from a one-off #356 migration instruction to **the single architectural
rule** governing every future SKILL.md extension (tools, groups,
workflows, prompts, annotation packs, next-tools chains, examples
packs, anything future).

The rule: no new top-level frontmatter keys; no inlining large
payloads into `metadata:`; every extension is a
`metadata.dcc-mcp.<feature>` entry whose **value points at a sibling
YAML/MD file** resolved relative to the skill directory.

## What changed

- **`AGENTS.md`**
  - New Traps entry `SKILL.md sibling-file pattern` with full rationale, a
    canonical layout example (`tools.yaml`, `workflows/`, `prompts/`,
    `references/`), and a design-review gate.
  - Generalised the existing Don't entry so it's architectural rather
    than a list of specific fields.
  - Added a matching Do entry.
- **`CLAUDE.md`**
  - Rewrote the SKILL.md frontmatter bullet to state the rule up front.
  - Added Good/Bad examples covering both "top-level block" and
    "inlined payload under metadata" pitfalls.
  - Clarified that `next-tools` lives inside `tools.yaml`, never at the
    SKILL.md top level.
- **`docs/guide/skills.md`**
  - New section `The sibling-file pattern is the rule for every new
    extension` under `Migrating pre-0.15 SKILL.md`.
  - Feature/key/sibling-file table covering tools (#356), workflows
    (#348), prompts (#351/#355), annotations (#344), next-tools (#342),
    and placeholder for future examples packs.

## Why

Several open issues (#342 next-tools wiring, #344 annotations surface,
#351/#355 prompts) all touch SKILL.md. Without a shared rule each of
them would be tempted to grow a new top-level field. Making the
pattern explicit in the agent rulebook (`AGENTS.md` + `CLAUDE.md`)
ensures every implementer — human or agent — defaults to the
compliant shape.

## Test plan

- Docs-only change; no code touched.
- `AGENTS.md` / `CLAUDE.md` / `docs/guide/skills.md` still render as
  valid Markdown.

Refs #356 #348 #351 #355 #344 #342
