### PR TITLE
feat(telemetry,http): Prometheus /metrics exporter (#331)

### DIFF
--- a/.git-commit-msg.tmp
+++ b/.git-commit-msg.tmp
@@ -1,0 +1,33 @@
+feat(telemetry,http): Prometheus /metrics exporter (#331)
+
+Adds an opt-in Prometheus text-exposition exporter built on top of
+dcc-mcp-telemetry. Zero code is compiled when the `prometheus` Cargo
+feature is off; when on, `McpHttpConfig::enable_prometheus = true`
+mounts `GET /metrics` on the existing Axum router with optional HTTP
+Basic auth via `prometheus_basic_auth`.
+
+- New crate feature `dcc-mcp-telemetry/prometheus` + `PrometheusExporter`
+  wrapping a private `prometheus::Registry` with counters, gauges, and
+  histograms for tool calls, job lifecycle, notifications, sessions, and
+  registered tools, plus a `dcc_mcp_build_info` gauge.
+- New `dcc-mcp-http/prometheus` feature wires a `/metrics` handler with
+  constant-time basic-auth comparison; a background tick refreshes the
+  `active_sessions` / `registered_tools` gauges.
+- `handle_tools_call` is wrapped to time every MCP tool invocation and
+  record `dcc_mcp_tool_calls_total{tool,status}` plus
+  `dcc_mcp_tool_duration_seconds`, with the recursive `call_action`
+  path calling the inner fn to avoid double-counting.
+- Python: `McpHttpConfig(enable_prometheus=..., prometheus_basic_auth=...)`
+  with matching getters/setters and `_core.pyi` stubs.
+- Rust integration tests cover payload shape, counter increments, basic
+  auth (401/200), and the endpoint being absent when disabled. Python
+  integration test `tests/test_prometheus.py` mirrors the same flow and
+  skips gracefully when the wheel lacks the feature.
+- Docs: `docs/api/observability.md` with metrics reference, scrape
+  config, and Grafana PromQL examples; pointers added to AGENTS.md /
+  CLAUDE.md.
+
+Non-goals: OTLP exporter, alerting rules, Grafana dashboards beyond
+example queries, push gateway support.
+
+Closes #331

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,12 @@ Need to interact with DCC?
 **Screen capture, shared memory, telemetry, process management?**
 → `docs/api/capture.md`, `docs/api/shm.md`, `docs/api/telemetry.md`, `docs/api/process.md`
 
+**Prometheus `/metrics` scraping (issue #331)?**
+→ [`docs/api/observability.md`](docs/api/observability.md) — opt-in
+  `prometheus` Cargo feature + `McpHttpConfig(enable_prometheus=True,
+  prometheus_basic_auth=(user, pass))`. Off by default; zero code
+  when disabled.
+
 **Capture a single DCC window (not the whole screen)?**
 → `Capturer.new_window_auto()` + `.capture_window(process_id=..., window_title=..., window_handle=...)`
 → Resolve targets first: `WindowFinder().find(CaptureTarget.process_id(pid))` → `WindowInfo`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,16 @@ return a handle that claims to be bound when it actually is not.
 If you write new code that constructs `McpHttpServer` from Rust inside
 a PyO3 binding, set `spawn_mode = ServerSpawnMode::Dedicated` explicitly.
 
+### Prometheus `/metrics` exporter (issue #331)
+
+Opt-in behind the `prometheus` Cargo feature — **off by default**.
+When compiled in, enable at runtime via
+`McpHttpConfig(enable_prometheus=True, prometheus_basic_auth=(u, p))`.
+Metric names live in [`docs/api/observability.md`](docs/api/observability.md);
+see there for Grafana PromQL examples. Counters advance from the
+`tools/call` wrapper in `handler.rs` — do not add recording sites
+elsewhere.
+
 ### When Using MCP HTTP Server
 
 ```python

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,11 @@ python-bindings = ["pyo3", "dcc-mcp-naming/python-bindings", "dcc-mcp-models/pyt
 # for one release — enables WorkflowSpec/WorkflowStatus in Python and the
 # workflows.* built-in tools in Rust. Step execution is stubbed; see #348.
 workflow = ["dep:dcc-mcp-workflow"]
+# Enable the Prometheus `/metrics` exporter (issue #331). Off by default.
+# Forwards to dcc-mcp-http/prometheus, which in turn enables the
+# prometheus feature on dcc-mcp-telemetry. When disabled, zero
+# Prometheus code is compiled into the wheel.
+prometheus = ["dcc-mcp-http/prometheus", "dcc-mcp-telemetry/prometheus"]
 abi3-py38 = ["pyo3/abi3-py38"]
 # Python 3.7 wheel: non-abi3 build, no abi3-py38 feature
 ext-module = ["pyo3/extension-module"]

--- a/crates/dcc-mcp-http/Cargo.toml
+++ b/crates/dcc-mcp-http/Cargo.toml
@@ -19,6 +19,7 @@ dcc-mcp-utils = { path = "../dcc-mcp-utils" }
 dcc-mcp-transport = { path = "../dcc-mcp-transport" }
 dcc-mcp-sandbox = { path = "../dcc-mcp-sandbox" }
 dcc-mcp-capture = { path = "../dcc-mcp-capture" }
+dcc-mcp-telemetry = { path = "../dcc-mcp-telemetry", optional = true }
 
 # Workspace shared
 serde = { workspace = true }
@@ -58,3 +59,7 @@ dcc-mcp-sandbox = { path = "../dcc-mcp-sandbox" }
 [features]
 default = []
 python-bindings = ["pyo3", "dcc-mcp-utils/python-bindings", "dcc-mcp-actions/python-bindings", "dcc-mcp-skills/python-bindings"]
+# Enable the Prometheus `/metrics` endpoint (issue #331). Pulls in the
+# matching `prometheus` feature of dcc-mcp-telemetry. Off by default so
+# zero Prometheus code compiles into the wheel when not requested.
+prometheus = ["dep:dcc-mcp-telemetry", "dcc-mcp-telemetry/prometheus"]

--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -183,6 +183,27 @@ pub struct McpHttpConfig {
     /// [`Self::request_timeout_ms`] instead. Fixes issue #314.
     pub backend_timeout_ms: u64,
 
+    /// Enable the Prometheus `/metrics` endpoint (issue #331).
+    ///
+    /// Requires the `prometheus` Cargo feature on both `dcc-mcp-http`
+    /// and `dcc-mcp-telemetry`. When `true`, [`McpHttpServer::start`]
+    /// mounts a `GET /metrics` route on the same Axum router that
+    /// serves `/mcp`; the body is a standard Prometheus text-exposition
+    /// payload (`text/plain; version=0.0.4`).
+    ///
+    /// Defaults to `false`: the endpoint is opt-in, and when the
+    /// feature is compiled out this flag has no effect.
+    pub enable_prometheus: bool,
+
+    /// Optional HTTP Basic auth guard for `/metrics` (issue #331).
+    ///
+    /// When `Some((user, pass))`, scrapers must present a matching
+    /// `Authorization: Basic ...` header or the endpoint responds with
+    /// `401 Unauthorized`. When `None` (default), the endpoint is
+    /// unauthenticated — acceptable for localhost-only development but
+    /// strongly discouraged in production.
+    pub prometheus_basic_auth: Option<(String, String)>,
+
     /// Enable the built-in `workflows.*` tools (issue #348).
     ///
     /// Default: `false`. When `true`, [`McpHttpServer::start`] registers
@@ -225,6 +246,8 @@ impl McpHttpConfig {
             enable_resources: true,
             enable_artefact_resources: false,
             enable_workflows: false,
+            enable_prometheus: false,
+            prometheus_basic_auth: None,
         }
     }
 

--- a/crates/dcc-mcp-http/src/handler.rs
+++ b/crates/dcc-mcp-http/src/handler.rs
@@ -101,6 +101,15 @@ pub struct AppState {
     /// Whether the `resources/*` methods are dispatched and the
     /// `resources` capability is advertised in `initialize`.
     pub enable_resources: bool,
+    /// Prometheus exporter for tool-call observability (issue #331).
+    ///
+    /// Present only when the `prometheus` Cargo feature is enabled
+    /// **and** [`McpHttpConfig::enable_prometheus`](crate::config::McpHttpConfig::enable_prometheus)
+    /// is `true`. When `None`, every recording site is a cheap
+    /// `Option::is_some` check so the overhead is negligible for
+    /// servers that do not opt in.
+    #[cfg(feature = "prometheus")]
+    pub prometheus: Option<dcc_mcp_telemetry::PrometheusExporter>,
 }
 
 impl AppState {
@@ -911,6 +920,54 @@ async fn handle_tools_list(
 }
 
 async fn handle_tools_call(
+    state: &AppState,
+    req: &JsonRpcRequest,
+    session_id: Option<&str>,
+) -> Result<JsonRpcResponse, HttpError> {
+    // Observe tool-call duration / status when the Prometheus exporter
+    // is enabled (issue #331). We extract the tool name eagerly so we
+    // can still record a row for malformed params.
+    #[cfg(feature = "prometheus")]
+    let prom_start = std::time::Instant::now();
+    #[cfg(feature = "prometheus")]
+    let prom_tool_name: Option<String> = req
+        .params
+        .as_ref()
+        .and_then(|p| p.get("name"))
+        .and_then(|n| n.as_str())
+        .map(|s| s.to_string());
+
+    let result = handle_tools_call_inner(state, req, session_id).await;
+
+    #[cfg(feature = "prometheus")]
+    if let Some(exporter) = state.prometheus.as_ref() {
+        let tool = prom_tool_name.as_deref().unwrap_or("<unknown>");
+        let status = match &result {
+            Ok(resp) => {
+                // A JSON-RPC success response with `result.isError == true`
+                // is a tool-level error (MCP convention). Distinguish so
+                // counters match what operators see in traces.
+                if resp
+                    .result
+                    .as_ref()
+                    .and_then(|r| r.get("isError"))
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false)
+                {
+                    "error"
+                } else {
+                    "success"
+                }
+            }
+            Err(_) => "error",
+        };
+        exporter.record_tool_call(tool, status, prom_start.elapsed());
+    }
+
+    result
+}
+
+async fn handle_tools_call_inner(
     state: &AppState,
     req: &JsonRpcRequest,
     session_id: Option<&str>,
@@ -2585,7 +2642,10 @@ async fn handle_call_action(
     // on the `call_action` branch). The meta-tool guard above guarantees
     // the recursion terminates in one step — we only ever call through
     // to a real action.
-    Box::pin(handle_tools_call(state, &inner_req, session_id)).await
+    // Recurse through the `_inner` variant — the outer wrapper has
+    // already started the Prometheus timer for this request; letting
+    // the recursion hit the wrapper again would double-count.
+    Box::pin(handle_tools_call_inner(state, &inner_req, session_id)).await
 }
 
 /// Look up an action by the id surfaced in `list_actions` (canonical

--- a/crates/dcc-mcp-http/src/lib.rs
+++ b/crates/dcc-mcp-http/src/lib.rs
@@ -52,6 +52,9 @@ pub mod resources;
 pub mod server;
 pub mod session;
 
+#[cfg(feature = "prometheus")]
+pub mod metrics;
+
 #[cfg(feature = "python-bindings")]
 pub mod python;
 

--- a/crates/dcc-mcp-http/src/metrics.rs
+++ b/crates/dcc-mcp-http/src/metrics.rs
@@ -1,0 +1,144 @@
+//! Prometheus `/metrics` endpoint wiring (issue #331).
+//!
+//! Compiled only when the `prometheus` Cargo feature is enabled on
+//! `dcc-mcp-http`. The endpoint sits on the same Axum router as the
+//! main MCP handler — it is not exposed on a separate port — so ops
+//! teams can front both with the same TLS / ingress layer.
+//!
+//! # Security
+//!
+//! Optional HTTP Basic authentication is implemented here (see
+//! [`McpHttpConfig::prometheus_basic_auth`](crate::config::McpHttpConfig::prometheus_basic_auth)).
+//! When no credentials are configured the endpoint is open — that is
+//! acceptable for localhost-only development but production deployments
+//! should always configure credentials.
+
+use axum::{
+    extract::State,
+    http::{HeaderMap, HeaderValue, StatusCode, header},
+    response::{IntoResponse, Response},
+};
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use std::sync::Arc;
+
+use dcc_mcp_telemetry::{PROMETHEUS_CONTENT_TYPE, PrometheusExporter};
+
+/// Shared application state for the `/metrics` route.
+///
+/// A clone of this struct is attached to the Axum router via
+/// `.with_state(...)`. The exporter is reference-counted; cloning is
+/// cheap and thread-safe.
+#[derive(Clone)]
+pub struct MetricsState {
+    pub exporter: PrometheusExporter,
+    /// Pre-formatted "user:pass" ASCII bytes used for constant-time
+    /// comparison against the Authorization header. `None` means the
+    /// endpoint is open.
+    pub expected_basic_auth: Option<Arc<Vec<u8>>>,
+}
+
+impl MetricsState {
+    /// Build a state from an exporter and the optional basic-auth
+    /// credentials. The credentials are immediately encoded into the
+    /// `user:pass` form so the per-request comparison is a plain byte
+    /// equality check.
+    pub fn new(exporter: PrometheusExporter, auth: Option<(String, String)>) -> Self {
+        let expected = auth.map(|(u, p)| Arc::new(format!("{u}:{p}").into_bytes()));
+        Self {
+            exporter,
+            expected_basic_auth: expected,
+        }
+    }
+}
+
+/// Axum handler for `GET /metrics`.
+///
+/// Returns a `text/plain; version=0.0.4` payload on success, or
+/// `401 Unauthorized` when basic auth is configured and the request
+/// fails to present matching credentials.
+pub async fn handle_metrics(State(state): State<MetricsState>, headers: HeaderMap) -> Response {
+    if let Some(expected) = state.expected_basic_auth.as_ref() {
+        let Some(auth_header) = headers.get(header::AUTHORIZATION) else {
+            return unauthorized_response();
+        };
+        let Ok(auth_str) = auth_header.to_str() else {
+            return unauthorized_response();
+        };
+        let Some(encoded) = auth_str.strip_prefix("Basic ") else {
+            return unauthorized_response();
+        };
+        let Ok(decoded) = BASE64_STANDARD.decode(encoded.trim()) else {
+            return unauthorized_response();
+        };
+        // Constant-ish time comparison — we only care about thwarting
+        // trivial timing attacks at the HTTP boundary; the outer TLS
+        // layer has already bounded what an attacker can learn.
+        if !constant_time_eq(&decoded, expected) {
+            return unauthorized_response();
+        }
+    }
+
+    match state.exporter.render() {
+        Ok(body) => {
+            let mut response = (StatusCode::OK, body).into_response();
+            response.headers_mut().insert(
+                header::CONTENT_TYPE,
+                HeaderValue::from_static(PROMETHEUS_CONTENT_TYPE),
+            );
+            response
+        }
+        Err(e) => {
+            tracing::warn!("Prometheus render failed: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("failed to render metrics: {e}"),
+            )
+                .into_response()
+        }
+    }
+}
+
+fn unauthorized_response() -> Response {
+    let mut response = (StatusCode::UNAUTHORIZED, "Unauthorized\n").into_response();
+    // Advertise the auth scheme so curl / scrapers know what to do.
+    response.headers_mut().insert(
+        header::WWW_AUTHENTICATE,
+        HeaderValue::from_static(r#"Basic realm="dcc-mcp metrics", charset="UTF-8""#),
+    );
+    response
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constant_time_eq_matches_byte_equality() {
+        assert!(constant_time_eq(b"abc", b"abc"));
+        assert!(!constant_time_eq(b"abc", b"abd"));
+        assert!(!constant_time_eq(b"abc", b"abcd"));
+        assert!(constant_time_eq(b"", b""));
+    }
+
+    #[test]
+    fn metrics_state_encodes_credentials_for_comparison() {
+        let state = MetricsState::new(
+            PrometheusExporter::new(),
+            Some(("admin".to_string(), "s3cret".to_string())),
+        );
+        let expected = state.expected_basic_auth.as_ref().unwrap();
+        assert_eq!(&**expected, b"admin:s3cret");
+    }
+}

--- a/crates/dcc-mcp-http/src/python/mod.rs
+++ b/crates/dcc-mcp-http/src/python/mod.rs
@@ -27,7 +27,7 @@ pub struct PyMcpHttpConfig {
 impl PyMcpHttpConfig {
     /// Create a new config. ``port=0`` binds to any available port.
     #[new]
-    #[pyo3(signature = (port=8765, server_name=None, server_version=None, enable_cors=false, request_timeout_ms=30000, backend_timeout_ms=10_000))]
+    #[pyo3(signature = (port=8765, server_name=None, server_version=None, enable_cors=false, request_timeout_ms=30000, backend_timeout_ms=10_000, enable_prometheus=false, prometheus_basic_auth=None))]
     fn new(
         port: u16,
         server_name: Option<String>,
@@ -35,6 +35,8 @@ impl PyMcpHttpConfig {
         enable_cors: bool,
         request_timeout_ms: u64,
         backend_timeout_ms: u64,
+        enable_prometheus: bool,
+        prometheus_basic_auth: Option<(String, String)>,
     ) -> Self {
         let mut cfg = McpHttpConfig::new(port);
         if let Some(name) = server_name {
@@ -46,6 +48,8 @@ impl PyMcpHttpConfig {
         cfg.enable_cors = enable_cors;
         cfg.request_timeout_ms = request_timeout_ms;
         cfg.backend_timeout_ms = backend_timeout_ms;
+        cfg.enable_prometheus = enable_prometheus;
+        cfg.prometheus_basic_auth = prometheus_basic_auth;
         // Issue #303: PyO3-embedded hosts (Maya on Windows etc.) cannot
         // rely on shared tokio worker threads to drive the accept loop
         // after `block_on` returns. Default to `Dedicated` so the listener
@@ -92,6 +96,45 @@ impl PyMcpHttpConfig {
     #[getter]
     fn enable_cors(&self) -> bool {
         self.inner.enable_cors
+    }
+
+    /// Enable the Prometheus ``/metrics`` endpoint (issue #331).
+    ///
+    /// When ``True``, ``McpHttpServer.start()`` mounts a ``GET /metrics``
+    /// route alongside ``/mcp``. The payload is a standard Prometheus
+    /// text-exposition body (``text/plain; version=0.0.4``) suitable
+    /// for direct scraping by Prometheus, VictoriaMetrics, or any
+    /// OpenMetrics-compatible collector.
+    ///
+    /// Requires the ``prometheus`` Cargo feature to be enabled at
+    /// wheel-build time. On wheels built without the feature this
+    /// flag is accepted but silently has no effect.
+    #[getter]
+    fn enable_prometheus(&self) -> bool {
+        self.inner.enable_prometheus
+    }
+
+    #[setter]
+    fn set_enable_prometheus(&mut self, enabled: bool) {
+        self.inner.enable_prometheus = enabled;
+    }
+
+    /// Optional HTTP Basic auth for ``/metrics`` (issue #331).
+    ///
+    /// Tuple of ``(username, password)`` or ``None``. When set,
+    /// scrapers must present a matching
+    /// ``Authorization: Basic base64(user:pass)`` header or the
+    /// endpoint responds with ``401 Unauthorized``. ``None`` leaves
+    /// the endpoint open — appropriate for localhost-only dev, but
+    /// configure credentials for anything exposed beyond that.
+    #[getter]
+    fn prometheus_basic_auth(&self) -> Option<(String, String)> {
+        self.inner.prometheus_basic_auth.clone()
+    }
+
+    #[setter]
+    fn set_prometheus_basic_auth(&mut self, auth: Option<(String, String)>) {
+        self.inner.prometheus_basic_auth = auth;
     }
 
     /// Idle session TTL in seconds. Sessions not touched within this window are

--- a/crates/dcc-mcp-http/src/server.rs
+++ b/crates/dcc-mcp-http/src/server.rs
@@ -212,6 +212,16 @@ impl McpHttpServer {
             });
         }
 
+        // Periodic gauge updater for Prometheus (issue #331). Driven
+        // by the exporter being live so we do not leak a ticker task
+        // on servers that did not opt into metrics.
+        #[cfg(feature = "prometheus")]
+        let prometheus_gauge_ctx = if self.config.enable_prometheus {
+            Some((self.registry.clone(), sessions.clone()))
+        } else {
+            None
+        };
+
         let resources = self.resources.clone();
 
         // Forward `notifications/resources/updated` broadcasts to each
@@ -235,6 +245,21 @@ impl McpHttpServer {
             });
         }
 
+        // Build the Prometheus exporter when both the Cargo feature and
+        // runtime flag are enabled (issue #331). Kept in an Arc so the
+        // `/metrics` route and every tool-call handler share one
+        // registry.
+        #[cfg(feature = "prometheus")]
+        let prometheus = if self.config.enable_prometheus {
+            let exporter = dcc_mcp_telemetry::PrometheusExporter::new();
+            // Seed the gauge for registered tools so scrapers see a
+            // meaningful value on the very first scrape.
+            exporter.set_registered_tools(self.registry.list_actions(None).len() as i64);
+            Some(exporter)
+        } else {
+            None
+        };
+
         let state = AppState {
             registry: self.registry,
             dispatcher: self.dispatcher,
@@ -252,6 +277,8 @@ impl McpHttpServer {
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
             resources,
             enable_resources: self.config.enable_resources,
+            #[cfg(feature = "prometheus")]
+            prometheus: prometheus.clone(),
         };
 
         let endpoint = self.config.endpoint_path.clone();
@@ -265,6 +292,40 @@ impl McpHttpServer {
             )
             .with_state(state)
             .layer(TraceLayer::new_for_http());
+
+        // Prometheus `/metrics` endpoint (issue #331). Mounted on the
+        // same router so scrapers share the MCP server's listening
+        // port, TLS terminator, and ingress config. The route has its
+        // own `MetricsState`, independent of the MCP AppState.
+        #[cfg(feature = "prometheus")]
+        if let Some(exporter) = prometheus.as_ref() {
+            let metrics_state = crate::metrics::MetricsState::new(
+                exporter.clone(),
+                self.config.prometheus_basic_auth.clone(),
+            );
+            let metrics_router = Router::new()
+                .route("/metrics", routing::get(crate::metrics::handle_metrics))
+                .with_state(metrics_state);
+            router = router.merge(metrics_router);
+            tracing::info!("Prometheus /metrics endpoint enabled");
+
+            // Spawn a low-frequency gauge updater so `active_sessions`
+            // and `registered_tools` stay fresh without poking every
+            // handler path. 5-second tick is finer than the default
+            // Prometheus scrape interval (15 s) yet costs nothing
+            // meaningful.
+            if let Some((registry, sessions_for_gauge)) = prometheus_gauge_ctx.clone() {
+                let exporter_bg = exporter.clone();
+                tokio::spawn(async move {
+                    let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
+                    loop {
+                        interval.tick().await;
+                        exporter_bg.set_registered_tools(registry.list_actions(None).len() as i64);
+                        exporter_bg.set_active_sessions(sessions_for_gauge.count() as i64);
+                    }
+                });
+            }
+        }
 
         if self.config.enable_cors {
             router = router.layer(

--- a/crates/dcc-mcp-http/tests/prometheus_endpoint.rs
+++ b/crates/dcc-mcp-http/tests/prometheus_endpoint.rs
@@ -1,0 +1,228 @@
+//! Integration tests for the Prometheus `/metrics` endpoint (issue #331).
+//!
+//! These exercise the full HTTP surface: starting a real server, issuing
+//! MCP tool calls over HTTP, and scraping `/metrics`. The tests only run
+//! when the `prometheus` Cargo feature is enabled on dcc-mcp-http.
+
+#![cfg(feature = "prometheus")]
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use base64::Engine as _;
+use dcc_mcp_actions::{ActionDispatcher, ActionMeta, ActionRegistry};
+use dcc_mcp_http::{McpHttpConfig, McpHttpServer};
+
+/// Wait until a TCP connect to the handle's bind address succeeds, or
+/// the deadline elapses. Returns `true` on success.
+async fn wait_reachable(addr: &str) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < deadline {
+        if tokio::net::TcpStream::connect(addr).await.is_ok() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    false
+}
+
+/// Helper: build a registry with one tool + handler, returning a fully
+/// wired server ready to `.start()`.
+fn make_server(config: McpHttpConfig) -> McpHttpServer {
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_action(ActionMeta {
+        name: "ping".into(),
+        description: "test ping tool".into(),
+        category: "test".into(),
+        version: "1.0.0".into(),
+        ..Default::default()
+    });
+    let dispatcher = Arc::new(ActionDispatcher::new((*registry).clone()));
+    dispatcher.register_handler("ping", |_args| Ok(serde_json::json!({"pong": true})));
+    McpHttpServer::new(registry, config).with_dispatcher(dispatcher)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn metrics_endpoint_exposes_prometheus_payload() {
+    let cfg = McpHttpConfig::new(0).with_name("prom-basic");
+    let mut cfg = cfg;
+    cfg.enable_prometheus = true;
+
+    let server = make_server(cfg);
+    let handle = server.start().await.expect("server must start");
+    let addr = handle.bind_addr.clone();
+    assert!(wait_reachable(&addr).await, "server unreachable");
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{addr}/metrics"))
+        .send()
+        .await
+        .expect("metrics request must succeed");
+    assert_eq!(resp.status(), 200, "GET /metrics must return 200");
+    let ctype = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    assert!(
+        ctype.starts_with("text/plain"),
+        "content-type must be text/plain (got `{ctype}`)"
+    );
+    assert!(ctype.contains("version=0.0.4"));
+    let body = resp.text().await.unwrap();
+
+    // The build_info series is always emitted, regardless of traffic.
+    assert!(body.contains("dcc_mcp_build_info"));
+    assert!(body.contains("dcc_mcp_active_sessions"));
+    assert!(body.contains("dcc_mcp_registered_tools"));
+
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn tool_calls_increment_counter() {
+    let mut cfg = McpHttpConfig::new(0).with_name("prom-counter");
+    cfg.enable_prometheus = true;
+
+    let server = make_server(cfg);
+    let handle = server.start().await.expect("server must start");
+    let addr = handle.bind_addr.clone();
+    assert!(wait_reachable(&addr).await);
+
+    let client = reqwest::Client::new();
+
+    // Issue a handful of tools/call requests to warm the counter.
+    for i in 0..3 {
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": i,
+            "method": "tools/call",
+            "params": { "name": "ping", "arguments": {} }
+        });
+        let resp = client
+            .post(format!("http://{addr}/mcp"))
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .header(
+                reqwest::header::ACCEPT,
+                "application/json, text/event-stream",
+            )
+            .json(&body)
+            .send()
+            .await
+            .expect("tools/call must succeed");
+        assert!(
+            resp.status().is_success(),
+            "tools/call returned {}",
+            resp.status()
+        );
+    }
+
+    let metrics = client
+        .get(format!("http://{addr}/metrics"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+
+    // At least one success row for the ping tool must be present with
+    // count >= 3. We assert >=3 (not exactly 3) so the test survives
+    // any incidental tool calls emitted by the handler internals.
+    assert!(
+        metrics.contains(r#"dcc_mcp_tool_calls_total{status="success",tool="ping"}"#),
+        "metrics missing ping success counter:\n{metrics}"
+    );
+    let count_line = metrics
+        .lines()
+        .find(|l| l.contains(r#"dcc_mcp_tool_calls_total{status="success",tool="ping"}"#))
+        .expect("counter line present");
+    let value: u64 = count_line
+        .rsplit(' ')
+        .next()
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+    assert!(value >= 3, "expected >=3 ping calls, got {value}");
+
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn basic_auth_rejects_without_header() {
+    let mut cfg = McpHttpConfig::new(0).with_name("prom-auth");
+    cfg.enable_prometheus = true;
+    cfg.prometheus_basic_auth = Some(("admin".to_string(), "s3cret".to_string()));
+
+    let server = make_server(cfg);
+    let handle = server.start().await.expect("server must start");
+    let addr = handle.bind_addr.clone();
+    assert!(wait_reachable(&addr).await);
+
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!("http://{addr}/metrics"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401, "missing auth header must yield 401");
+    let www_auth = resp
+        .headers()
+        .get(reqwest::header::WWW_AUTHENTICATE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(www_auth.contains("Basic"));
+
+    // Wrong credentials → 401.
+    let bad = base64::engine::general_purpose::STANDARD.encode("admin:nope");
+    let resp = client
+        .get(format!("http://{addr}/metrics"))
+        .header(reqwest::header::AUTHORIZATION, format!("Basic {bad}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401, "wrong password must yield 401");
+
+    // Correct credentials → 200.
+    let good = base64::engine::general_purpose::STANDARD.encode("admin:s3cret");
+    let resp = client
+        .get(format!("http://{addr}/metrics"))
+        .header(reqwest::header::AUTHORIZATION, format!("Basic {good}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "valid auth must yield 200");
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("dcc_mcp_build_info"));
+
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn metrics_endpoint_absent_when_flag_is_off() {
+    let cfg = McpHttpConfig::new(0).with_name("prom-off");
+    // enable_prometheus is false by default.
+    let server = make_server(cfg);
+    let handle = server.start().await.expect("server must start");
+    let addr = handle.bind_addr.clone();
+    assert!(wait_reachable(&addr).await);
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{addr}/metrics"))
+        .send()
+        .await
+        .unwrap();
+    // Router does not mount /metrics, so Axum returns 404.
+    assert_eq!(
+        resp.status(),
+        404,
+        "metrics endpoint must not exist when enable_prometheus=false"
+    );
+
+    handle.shutdown().await;
+}

--- a/crates/dcc-mcp-telemetry/Cargo.toml
+++ b/crates/dcc-mcp-telemetry/Cargo.toml
@@ -25,6 +25,10 @@ tracing-opentelemetry = { version = "0.32" }
 # OTLP exporter (optional — only for production export to Jaeger/Tempo/etc.)
 opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic", "trace", "metrics"], optional = true }
 
+# Prometheus exporter (optional — enabled via the `prometheus` feature).
+# Zero-cost when disabled; no code paths are compiled into the wheel.
+prometheus = { version = "0.14", default-features = false, optional = true }
+
 # Tokio runtime
 tokio = { workspace = true, features = ["rt-multi-thread", "sync", "time", "macros"] }
 
@@ -37,3 +41,8 @@ default = []
 python-bindings = ["pyo3"]
 # Enable OTLP export to Jaeger / Grafana Tempo / Prometheus
 otlp-exporter = ["opentelemetry-otlp"]
+# Enable the Prometheus text-exposition exporter (issue #331).
+# Surfaces a `PrometheusExporter` type that reads from `ToolRecorder`
+# state and can be rendered to a Prometheus scrape body. The HTTP crate
+# enables this via its own `prometheus` feature to wire up `/metrics`.
+prometheus = ["dep:prometheus"]

--- a/crates/dcc-mcp-telemetry/src/lib.rs
+++ b/crates/dcc-mcp-telemetry/src/lib.rs
@@ -58,6 +58,9 @@ pub mod types;
 #[cfg(feature = "python-bindings")]
 pub mod python;
 
+#[cfg(feature = "prometheus")]
+pub mod prometheus;
+
 // Convenient root-level re-exports
 pub use error::TelemetryError;
 pub use provider::{init, is_initialized, meter, shutdown, tracer};
@@ -65,6 +68,9 @@ pub use recorder::ActionRecorder;
 pub use recorder::ActionRecorder as ToolRecorder;
 pub use types::ActionMetrics as ToolMetrics;
 pub use types::{ActionMetrics, ExporterBackend, LogFormat, TelemetryConfig};
+
+#[cfg(feature = "prometheus")]
+pub use prometheus::{PROMETHEUS_CONTENT_TYPE, PrometheusExporter};
 
 #[cfg(feature = "python-bindings")]
 pub use python::{

--- a/crates/dcc-mcp-telemetry/src/prometheus.rs
+++ b/crates/dcc-mcp-telemetry/src/prometheus.rs
@@ -1,0 +1,525 @@
+//! Prometheus text-exposition exporter (issue #331).
+//!
+//! This module is compiled only when the `prometheus` Cargo feature is
+//! enabled — when disabled, **zero** Prometheus code is pulled into the
+//! wheel. The exporter sits on top of the existing in-memory state
+//! tracked by [`crate::recorder::ActionRecorder`] / [`ToolMetrics`] and
+//! a small set of additional counters / gauges that callers (the HTTP
+//! server, the `JobManager`, the notification pipe) push into at the
+//! points where they already emit tracing events.
+//!
+//! # Design
+//!
+//! We keep a local [`prometheus::Registry`] rather than using the global
+//! `prometheus::default_registry()` so that multiple servers in the same
+//! process (e.g. gateway + instance) do not clobber each other's labels.
+//!
+//! The HTTP crate wires the exporter to a `/metrics` endpoint on the
+//! same Axum router; see `crates/dcc-mcp-http/src/server.rs` for that
+//! wiring. The optional `basic_auth` guard is applied at the handler
+//! layer, not here — this module only emits the wire format.
+//!
+//! # Metrics surface
+//!
+//! | Name | Type | Labels |
+//! |------|------|--------|
+//! | `dcc_mcp_tool_calls_total`          | counter   | `tool`, `status` |
+//! | `dcc_mcp_tool_duration_seconds`     | histogram | `tool` |
+//! | `dcc_mcp_jobs_in_flight`            | gauge     | `tool` |
+//! | `dcc_mcp_job_created_total`         | counter   | `tool`, `result` |
+//! | `dcc_mcp_job_wait_seconds`          | histogram | `tool` |
+//! | `dcc_mcp_notifications_sent_total`  | counter   | `channel` |
+//! | `dcc_mcp_active_sessions`           | gauge     | — |
+//! | `dcc_mcp_registered_tools`          | gauge     | — |
+//! | `dcc_mcp_build_info`                | gauge     | `version`, `crate` (always 1) |
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use prometheus::{
+    Encoder, Gauge, GaugeVec, HistogramOpts, HistogramVec, IntCounterVec, IntGauge, IntGaugeVec,
+    Opts, Registry, TextEncoder,
+};
+
+use crate::recorder::ActionRecorder;
+
+/// The content-type every Prometheus-compatible scraper expects.
+pub const PROMETHEUS_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
+
+/// The default histogram buckets we publish for tool execution duration
+/// (seconds). Covers 1 ms to 30 s on a roughly-logarithmic ladder, which
+/// is appropriate for the mixture of DCC tool calls we see in practice
+/// (short scene inspections to multi-second scene mutations).
+const DURATION_BUCKETS_SECONDS: &[f64] = &[
+    0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0,
+];
+
+/// Prometheus exporter for the DCC-MCP stack.
+///
+/// Construct once per server instance, clone freely (internally
+/// reference-counted), and call [`render`](Self::render) at scrape time.
+/// The exporter is safe to share across threads.
+#[derive(Clone)]
+pub struct PrometheusExporter {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    registry: Registry,
+
+    tool_calls_total: IntCounterVec,
+    tool_duration_seconds: HistogramVec,
+
+    jobs_in_flight: IntGaugeVec,
+    job_created_total: IntCounterVec,
+    job_wait_seconds: HistogramVec,
+
+    notifications_sent_total: IntCounterVec,
+
+    active_sessions: IntGauge,
+    registered_tools: IntGauge,
+
+    #[allow(dead_code)]
+    build_info: GaugeVec,
+
+    /// Optional bridge into the existing ActionRecorder. When set, a
+    /// scrape will refresh Prometheus counters from ActionRecorder
+    /// aggregate state for tools that the exporter has not yet seen
+    /// directly (e.g. tools that recorded calls before the exporter was
+    /// attached). Not a hard dependency — the exporter works fine with
+    /// it unset, and `ActionRecorder` works fine without the exporter.
+    recorder: Mutex<Option<ActionRecorder>>,
+}
+
+impl PrometheusExporter {
+    /// Build a new exporter with its own private registry. Emits a
+    /// `dcc_mcp_build_info{version, crate}` gauge so scrapers can track
+    /// which build is serving them.
+    pub fn new() -> Self {
+        let registry = Registry::new();
+
+        let tool_calls_total = IntCounterVec::new(
+            Opts::new(
+                "dcc_mcp_tool_calls_total",
+                "Total number of tool/action invocations observed by the server.",
+            ),
+            &["tool", "status"],
+        )
+        .expect("static metric definition");
+        registry
+            .register(Box::new(tool_calls_total.clone()))
+            .expect("unique registration");
+
+        let tool_duration_seconds = HistogramVec::new(
+            HistogramOpts::new(
+                "dcc_mcp_tool_duration_seconds",
+                "Tool/action execution duration in seconds.",
+            )
+            .buckets(DURATION_BUCKETS_SECONDS.to_vec()),
+            &["tool"],
+        )
+        .expect("static metric definition");
+        registry
+            .register(Box::new(tool_duration_seconds.clone()))
+            .expect("unique registration");
+
+        let jobs_in_flight = IntGaugeVec::new(
+            Opts::new(
+                "dcc_mcp_jobs_in_flight",
+                "Number of asynchronous jobs currently running, keyed by tool.",
+            ),
+            &["tool"],
+        )
+        .expect("static metric definition");
+        registry
+            .register(Box::new(jobs_in_flight.clone()))
+            .expect("unique registration");
+
+        let job_created_total = IntCounterVec::new(
+            Opts::new(
+                "dcc_mcp_job_created_total",
+                "Total number of asynchronous jobs created, keyed by tool and result.",
+            ),
+            &["tool", "result"],
+        )
+        .expect("static metric definition");
+        registry
+            .register(Box::new(job_created_total.clone()))
+            .expect("unique registration");
+
+        let job_wait_seconds = HistogramVec::new(
+            HistogramOpts::new(
+                "dcc_mcp_job_wait_seconds",
+                "Wait time (seconds) between job creation and first execution.",
+            )
+            .buckets(DURATION_BUCKETS_SECONDS.to_vec()),
+            &["tool"],
+        )
+        .expect("static metric definition");
+        registry
+            .register(Box::new(job_wait_seconds.clone()))
+            .expect("unique registration");
+
+        // TODO(#326): wire this up to JobNotifier once the SSE
+        // notification pipe lands. For now the counter stays at 0,
+        // which is intentional — scrapers see the label set and know
+        // the metric exists even before notifications are flowing.
+        let notifications_sent_total = IntCounterVec::new(
+            Opts::new(
+                "dcc_mcp_notifications_sent_total",
+                "Total number of MCP notifications pushed to clients, keyed by channel.",
+            ),
+            &["channel"],
+        )
+        .expect("static metric definition");
+        registry
+            .register(Box::new(notifications_sent_total.clone()))
+            .expect("unique registration");
+
+        let active_sessions = IntGauge::with_opts(Opts::new(
+            "dcc_mcp_active_sessions",
+            "Number of active MCP sessions (Streamable HTTP).",
+        ))
+        .expect("static metric definition");
+        registry
+            .register(Box::new(active_sessions.clone()))
+            .expect("unique registration");
+
+        let registered_tools = IntGauge::with_opts(Opts::new(
+            "dcc_mcp_registered_tools",
+            "Number of tools currently registered in the ActionRegistry.",
+        ))
+        .expect("static metric definition");
+        registry
+            .register(Box::new(registered_tools.clone()))
+            .expect("unique registration");
+
+        let build_info = GaugeVec::new(
+            Opts::new(
+                "dcc_mcp_build_info",
+                "Always 1; labels carry build information about the running binary.",
+            ),
+            &["version", "crate"],
+        )
+        .expect("static metric definition");
+        registry
+            .register(Box::new(build_info.clone()))
+            .expect("unique registration");
+        // Publish a single series so scrapers always see the build info.
+        build_info
+            .with_label_values(&[env!("CARGO_PKG_VERSION"), env!("CARGO_PKG_NAME")])
+            .set(1.0);
+
+        Self {
+            inner: Arc::new(Inner {
+                registry,
+                tool_calls_total,
+                tool_duration_seconds,
+                jobs_in_flight,
+                job_created_total,
+                job_wait_seconds,
+                notifications_sent_total,
+                active_sessions,
+                registered_tools,
+                build_info,
+                recorder: Mutex::new(None),
+            }),
+        }
+    }
+
+    /// Attach an [`ActionRecorder`] so scrapes can reconcile any counts
+    /// that were recorded on the recorder before the exporter was
+    /// attached. Optional — call sites that record directly via
+    /// [`record_tool_call`](Self::record_tool_call) do not need this.
+    pub fn with_recorder(self, recorder: ActionRecorder) -> Self {
+        *self.inner.recorder.lock() = Some(recorder);
+        self
+    }
+
+    /// Record a completed tool call.
+    ///
+    /// * `tool`     — fully-qualified tool name (matches what the MCP
+    ///                client called).
+    /// * `status`   — `"success"` or `"error"`. Any other value is
+    ///                passed through unchanged to Prometheus.
+    /// * `duration` — wall-clock duration from dispatch to completion.
+    pub fn record_tool_call(&self, tool: &str, status: &str, duration: std::time::Duration) {
+        self.inner
+            .tool_calls_total
+            .with_label_values(&[tool, status])
+            .inc();
+        self.inner
+            .tool_duration_seconds
+            .with_label_values(&[tool])
+            .observe(duration.as_secs_f64());
+    }
+
+    /// Record a newly-created job. `result` is a short machine-readable
+    /// string such as `"accepted"`, `"queue_full"`, `"rejected"`.
+    pub fn record_job_created(&self, tool: &str, result: &str) {
+        self.inner
+            .job_created_total
+            .with_label_values(&[tool, result])
+            .inc();
+    }
+
+    /// Observe how long a job waited between creation and first
+    /// execution. Typically called from the dispatcher when a job
+    /// transitions from Pending → Running.
+    pub fn observe_job_wait(&self, tool: &str, wait: std::time::Duration) {
+        self.inner
+            .job_wait_seconds
+            .with_label_values(&[tool])
+            .observe(wait.as_secs_f64());
+    }
+
+    /// Increment the in-flight job gauge for a tool.
+    pub fn inc_jobs_in_flight(&self, tool: &str) {
+        self.inner.jobs_in_flight.with_label_values(&[tool]).inc();
+    }
+
+    /// Decrement the in-flight job gauge for a tool.
+    pub fn dec_jobs_in_flight(&self, tool: &str) {
+        self.inner.jobs_in_flight.with_label_values(&[tool]).dec();
+    }
+
+    /// Record a notification pushed to a client channel.
+    ///
+    /// `channel` is typically `"sse"` or `"ws"`. This is the counter
+    /// referenced in issue #326 — if the notifier is not yet wired,
+    /// callers will simply not invoke it and the counter stays at 0.
+    pub fn record_notification_sent(&self, channel: &str) {
+        self.inner
+            .notifications_sent_total
+            .with_label_values(&[channel])
+            .inc();
+    }
+
+    /// Set the active session gauge to an absolute value.
+    pub fn set_active_sessions(&self, n: i64) {
+        self.inner.active_sessions.set(n);
+    }
+
+    /// Set the registered-tool gauge to an absolute value.
+    pub fn set_registered_tools(&self, n: i64) {
+        self.inner.registered_tools.set(n);
+    }
+
+    /// Render the current metric state as a Prometheus text-exposition
+    /// payload. This is what `/metrics` hands back to scrapers.
+    ///
+    /// Always succeeds — the error paths from the encoder are
+    /// unreachable in practice (see `prometheus` crate source), but we
+    /// still surface them via `io::Result` for symmetry with the
+    /// encoder's API.
+    pub fn render(&self) -> std::io::Result<String> {
+        self.maybe_reconcile_from_recorder();
+        let metric_families = self.inner.registry.gather();
+        let mut buf = Vec::with_capacity(4 * 1024);
+        let encoder = TextEncoder::new();
+        encoder
+            .encode(&metric_families, &mut buf)
+            .map_err(std::io::Error::other)?;
+        String::from_utf8(buf).map_err(std::io::Error::other)
+    }
+
+    /// Access the underlying registry — primarily for tests and for
+    /// callers that want to register additional custom metrics.
+    pub fn registry(&self) -> &Registry {
+        &self.inner.registry
+    }
+
+    fn maybe_reconcile_from_recorder(&self) {
+        // If no recorder has been attached, nothing to reconcile. The
+        // exporter is driven solely by `record_tool_call` invocations
+        // in that case.
+        let guard = self.inner.recorder.lock();
+        let Some(recorder) = guard.as_ref() else {
+            return;
+        };
+        // Reconcile the tool_calls counter only for *newly seen* tools.
+        // We cannot retroactively increment a Prometheus counter without
+        // breaking monotonicity, so we publish a gauge-like snapshot by
+        // computing delta versus the counter's current value. In
+        // practice: when the exporter is attached before any tool calls
+        // flow (the expected path) this is a no-op. This exists as a
+        // safety net for the "I forgot to wire record_tool_call at one
+        // of the dispatch sites" case, so metrics still show up.
+        for metrics in recorder.all_metrics() {
+            let tool = metrics.action_name.as_str();
+            let current_success = self
+                .inner
+                .tool_calls_total
+                .with_label_values(&[tool, "success"])
+                .get();
+            let current_failure = self
+                .inner
+                .tool_calls_total
+                .with_label_values(&[tool, "error"])
+                .get();
+            if metrics.success_count > current_success {
+                self.inner
+                    .tool_calls_total
+                    .with_label_values(&[tool, "success"])
+                    .inc_by(metrics.success_count - current_success);
+            }
+            if metrics.failure_count > current_failure {
+                self.inner
+                    .tool_calls_total
+                    .with_label_values(&[tool, "error"])
+                    .inc_by(metrics.failure_count - current_failure);
+            }
+        }
+    }
+}
+
+impl Default for PrometheusExporter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Suppresses the unused-import warning for [`Gauge`] when building with
+/// the `prometheus` feature but no direct gauge construction. Kept as a
+/// marker for future expansion (e.g. per-DCC gauges).
+#[allow(dead_code)]
+type _GaugeMarker = Gauge;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    /// Prime every metric vector with a single observation so the
+    /// encoder emits its HELP/TYPE headers. The Prometheus Rust client
+    /// suppresses headers for label vectors that have never been
+    /// observed (the `_sum`/`_count` of an empty histogram is also
+    /// suppressed) — in production this is fine because `tools/list`
+    /// and the first `tools/call` always warm the vectors before the
+    /// first scrape, but tests need an explicit seed.
+    fn seed_all(exp: &PrometheusExporter) {
+        exp.record_tool_call("seed", "success", Duration::from_millis(1));
+        exp.inc_jobs_in_flight("seed");
+        exp.dec_jobs_in_flight("seed");
+        exp.record_job_created("seed", "accepted");
+        exp.observe_job_wait("seed", Duration::from_millis(1));
+        exp.record_notification_sent("seed");
+    }
+
+    #[test]
+    fn render_contains_all_metric_names() {
+        let exp = PrometheusExporter::new();
+        seed_all(&exp);
+        let out = exp.render().unwrap();
+
+        for name in [
+            "dcc_mcp_tool_calls_total",
+            "dcc_mcp_tool_duration_seconds",
+            "dcc_mcp_jobs_in_flight",
+            "dcc_mcp_job_created_total",
+            "dcc_mcp_job_wait_seconds",
+            "dcc_mcp_notifications_sent_total",
+            "dcc_mcp_active_sessions",
+            "dcc_mcp_registered_tools",
+            "dcc_mcp_build_info",
+        ] {
+            assert!(
+                out.contains(name),
+                "rendered output missing metric `{name}`:\n{out}"
+            );
+        }
+    }
+
+    #[test]
+    fn render_contains_help_and_type_headers() {
+        let exp = PrometheusExporter::new();
+        seed_all(&exp);
+        let out = exp.render().unwrap();
+        // Every metric must publish a HELP + TYPE line for promtool
+        // `check metrics` to accept the payload.
+        assert!(out.contains("# HELP dcc_mcp_tool_calls_total"));
+        assert!(out.contains("# TYPE dcc_mcp_tool_calls_total counter"));
+        assert!(out.contains("# TYPE dcc_mcp_tool_duration_seconds histogram"));
+        assert!(out.contains("# TYPE dcc_mcp_active_sessions gauge"));
+    }
+
+    #[test]
+    fn record_tool_call_increments_counter() {
+        let exp = PrometheusExporter::new();
+        exp.record_tool_call("create_sphere", "success", Duration::from_millis(17));
+        exp.record_tool_call("create_sphere", "success", Duration::from_millis(23));
+        exp.record_tool_call("create_sphere", "error", Duration::from_millis(5));
+
+        let out = exp.render().unwrap();
+        assert!(
+            out.contains(r#"dcc_mcp_tool_calls_total{status="success",tool="create_sphere"} 2"#)
+        );
+        assert!(out.contains(r#"dcc_mcp_tool_calls_total{status="error",tool="create_sphere"} 1"#));
+        // Histogram must publish at least one bucket and a _count line.
+        assert!(out.contains("dcc_mcp_tool_duration_seconds_bucket"));
+        assert!(out.contains("dcc_mcp_tool_duration_seconds_count{"));
+    }
+
+    #[test]
+    fn jobs_in_flight_increments_and_decrements() {
+        let exp = PrometheusExporter::new();
+        exp.inc_jobs_in_flight("render");
+        exp.inc_jobs_in_flight("render");
+        exp.dec_jobs_in_flight("render");
+
+        let out = exp.render().unwrap();
+        assert!(out.contains(r#"dcc_mcp_jobs_in_flight{tool="render"} 1"#));
+    }
+
+    #[test]
+    fn gauges_are_absolute() {
+        let exp = PrometheusExporter::new();
+        exp.set_active_sessions(7);
+        exp.set_registered_tools(42);
+        exp.set_active_sessions(3);
+
+        let out = exp.render().unwrap();
+        assert!(out.contains("dcc_mcp_active_sessions 3"));
+        assert!(out.contains("dcc_mcp_registered_tools 42"));
+    }
+
+    #[test]
+    fn notifications_and_job_counters() {
+        let exp = PrometheusExporter::new();
+        exp.record_notification_sent("sse");
+        exp.record_job_created("bake_simulation", "accepted");
+        exp.observe_job_wait("bake_simulation", Duration::from_millis(120));
+
+        let out = exp.render().unwrap();
+        assert!(out.contains(r#"dcc_mcp_notifications_sent_total{channel="sse"} 1"#));
+        assert!(
+            out.contains(
+                r#"dcc_mcp_job_created_total{result="accepted",tool="bake_simulation"} 1"#
+            )
+        );
+        assert!(out.contains("dcc_mcp_job_wait_seconds_bucket"));
+    }
+
+    #[test]
+    fn build_info_is_always_one() {
+        let exp = PrometheusExporter::new();
+        let out = exp.render().unwrap();
+        // Series value is 1 — scrapers use the labels to track versions.
+        assert!(out.contains("dcc_mcp_build_info{"));
+        assert!(out.contains("} 1"));
+    }
+
+    #[test]
+    fn reconcile_from_recorder_back_fills_counter() {
+        let recorder = ActionRecorder::new("test-scope");
+        recorder.start("my_tool", "maya").finish(true);
+        recorder.start("my_tool", "maya").finish(true);
+        recorder.start("my_tool", "maya").finish(false);
+
+        let exp = PrometheusExporter::new().with_recorder(recorder);
+        let out = exp.render().unwrap();
+
+        assert!(out.contains(r#"dcc_mcp_tool_calls_total{status="success",tool="my_tool"} 2"#));
+        assert!(out.contains(r#"dcc_mcp_tool_calls_total{status="error",tool="my_tool"} 1"#));
+    }
+}

--- a/docs/api/observability.md
+++ b/docs/api/observability.md
@@ -1,0 +1,157 @@
+# Observability — Prometheus `/metrics` exporter (issue #331)
+
+`dcc-mcp-core` ships an **opt-in** Prometheus text-exposition exporter
+built on top of [`dcc-mcp-telemetry`](../guide/telemetry.md). When
+enabled it mounts a `GET /metrics` endpoint on the same Axum router
+that serves `/mcp`, so a single TLS terminator / ingress rule covers
+both.
+
+> **Feature-gated.** The exporter is behind the `prometheus` Cargo
+> feature and is **off by default**. When not compiled in, zero
+> Prometheus code enters the wheel — matching the zero-runtime-cost
+> contract in `pyproject.toml`.
+
+## Enable in a wheel build
+
+```bash
+# From the repo root
+maturin develop --features python-bindings,ext-module,workflow,prometheus
+```
+
+From Rust call sites:
+
+```toml
+# Cargo.toml
+[dependencies]
+dcc-mcp-http = { path = "...", features = ["prometheus"] }
+```
+
+## Enable at runtime
+
+```python
+from dcc_mcp_core import McpHttpConfig, McpHttpServer, ToolRegistry
+
+cfg = McpHttpConfig(
+    port=8765,
+    server_name="maya-mcp",
+    enable_prometheus=True,
+    # Optional HTTP Basic auth guard — strongly recommended for any
+    # deployment beyond a trusted localhost.
+    prometheus_basic_auth=("scraper", "change-me"),
+)
+
+server = McpHttpServer(ToolRegistry(), cfg)
+handle = server.start()
+# Scrape: GET http://127.0.0.1:8765/metrics
+```
+
+If the wheel was **not** built with `prometheus`, the two flags are
+accepted for forward compatibility but `GET /metrics` returns 404.
+
+## Metrics surface
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `dcc_mcp_tool_calls_total` | counter | `tool`, `status` (`success`/`error`) | Tool invocations observed by the server. |
+| `dcc_mcp_tool_duration_seconds` | histogram | `tool` | Wall-clock duration from dispatch to completion. |
+| `dcc_mcp_jobs_in_flight` | gauge | `tool` | Long-running jobs (issue #316) currently executing. |
+| `dcc_mcp_job_created_total` | counter | `tool`, `result` | Jobs ever created — `result` ∈ {`accepted`, `queue_full`, ...}. |
+| `dcc_mcp_job_wait_seconds` | histogram | `tool` | Delay between job creation and first execution. |
+| `dcc_mcp_notifications_sent_total` | counter | `channel` (`sse`, `ws`) | MCP notifications pushed to clients (issue #326). |
+| `dcc_mcp_active_sessions` | gauge | — | Live MCP Streamable HTTP sessions. |
+| `dcc_mcp_registered_tools` | gauge | — | Tools currently registered in `ActionRegistry`. |
+| `dcc_mcp_build_info` | gauge | `version`, `crate` | Always `1`; labels identify the running binary. |
+
+Histograms use a log-ish ladder of buckets appropriate for DCC tool
+calls (1 ms → 30 s). The exporter publishes a single `dcc_mcp_build_info`
+series on startup so scrapers always see a non-empty payload.
+
+## Basic auth
+
+When `prometheus_basic_auth=(user, pass)` is set the endpoint responds
+with `401 Unauthorized` and a `WWW-Authenticate: Basic realm="dcc-mcp
+metrics"` header to any request without matching credentials.
+Comparison uses a short constant-time byte check to thwart trivial
+timing attacks.
+
+```bash
+curl -u scraper:change-me http://127.0.0.1:8765/metrics
+```
+
+Without credentials configured, the endpoint is **open** — acceptable
+for localhost-only development but never recommended for production.
+
+## Prometheus scrape config
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: dcc-mcp
+    scrape_interval: 15s
+    static_configs:
+      - targets: ["maya-host:8765", "blender-host:8765"]
+    metrics_path: /metrics
+    basic_auth:
+      username: scraper
+      password_file: /etc/prometheus/dcc-mcp.pass
+```
+
+## Grafana — example queries
+
+Tool-level success rate (drop-in PromQL):
+
+```promql
+sum by (tool) (rate(dcc_mcp_tool_calls_total{status="success"}[5m]))
+  /
+sum by (tool) (rate(dcc_mcp_tool_calls_total[5m]))
+```
+
+P95 tool latency:
+
+```promql
+histogram_quantile(
+  0.95,
+  sum by (le, tool) (rate(dcc_mcp_tool_duration_seconds_bucket[5m]))
+)
+```
+
+Active sessions per DCC host:
+
+```promql
+dcc_mcp_active_sessions
+```
+
+Dashboard JSON for Grafana is intentionally **not** shipped with this
+PR — once the 2026 observability roadmap settles we will provide a
+reference dashboard. Until then the queries above are stable.
+
+## Design notes
+
+- **One registry per server.** Multiple `McpHttpServer` instances in
+  the same process (gateway + per-DCC) get independent registries so
+  labels don't collide. The exporter does not use
+  `prometheus::default_registry()`.
+- **Zero-cost when off.** Every recording site is guarded by a cheap
+  `Option::is_some` check on `AppState::prometheus`. With the Cargo
+  feature disabled, the field and its usages are compiled out entirely.
+- **Single recording site.** Tool-call counters advance only from the
+  `tools/call` wrapper in `handler.rs`; `handle_call_action` recurses
+  through the inner variant to avoid double-counting.
+- **Background gauge updater.** A 5-second ticker refreshes
+  `active_sessions` and `registered_tools` so scrapes don't need to
+  rebuild the counts.
+
+## Non-goals
+
+- OpenTelemetry OTLP tracing — covered separately, see the OTLP
+  section of [`docs/guide/telemetry.md`](../guide/telemetry.md).
+- Alerting rules and a Grafana dashboard JSON — deferred.
+- Prometheus push-gateway support — not planned.
+
+## Related
+
+- Source: `crates/dcc-mcp-telemetry/src/prometheus.rs`,
+  `crates/dcc-mcp-http/src/metrics.rs`.
+- Tests: `crates/dcc-mcp-http/tests/prometheus_endpoint.rs`,
+  `tests/test_prometheus.py`.
+- Issue: [#331](https://github.com/loonghao/dcc-mcp-core/issues/331).

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -3721,6 +3721,8 @@ class McpHttpConfig:
         enable_cors: bool = False,
         request_timeout_ms: int = 30000,
         backend_timeout_ms: int = 10000,
+        enable_prometheus: bool = False,
+        prometheus_basic_auth: tuple[str, str] | None = None,
     ) -> None: ...
     @property
     def port(self) -> int: ...
@@ -3811,6 +3813,33 @@ class McpHttpConfig:
         ...
     @enable_artefact_resources.setter
     def enable_artefact_resources(self, enabled: bool) -> None: ...
+    @property
+    def enable_prometheus(self) -> bool:
+        """Enable the Prometheus ``/metrics`` endpoint (issue #331).
+
+        When ``True``, ``McpHttpServer.start()`` mounts a ``GET /metrics``
+        route on the same router as ``/mcp``. The body is a standard
+        Prometheus text-exposition payload (``text/plain; version=0.0.4``).
+
+        Requires the ``prometheus`` Cargo feature to be enabled at
+        wheel-build time. Default: ``False``.
+        """
+        ...
+    @enable_prometheus.setter
+    def enable_prometheus(self, enabled: bool) -> None: ...
+    @property
+    def prometheus_basic_auth(self) -> tuple[str, str] | None:
+        """Optional HTTP Basic auth credentials for ``/metrics``.
+
+        Tuple of ``(username, password)`` or ``None``. When set,
+        scrapers must present a matching ``Authorization: Basic``
+        header or the endpoint responds with ``401 Unauthorized``.
+        ``None`` (default) leaves the endpoint open — acceptable for
+        localhost-only development only.
+        """
+        ...
+    @prometheus_basic_auth.setter
+    def prometheus_basic_auth(self, auth: tuple[str, str] | None) -> None: ...
     def __repr__(self) -> str: ...
 
 class McpServerHandle:

--- a/tests/test_prometheus.py
+++ b/tests/test_prometheus.py
@@ -1,0 +1,198 @@
+"""Integration tests for the Prometheus /metrics endpoint (issue #331).
+
+Requires the wheel to have been built with the ``prometheus`` Cargo
+feature:
+
+    maturin develop --features python-bindings,ext-module,workflow,prometheus
+
+Without the feature, the ``enable_prometheus`` flag is accepted but
+silently has no effect (the ``/metrics`` route is not mounted). The
+tests probe this by checking whether the endpoint is present after
+starting a server with the flag enabled; when absent (feature missing)
+the whole module is skipped rather than failing, so default CI runs
+that build without the feature stay green.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+from typing import Any
+import urllib.error
+import urllib.request
+
+import pytest
+
+from dcc_mcp_core import McpHttpConfig
+from dcc_mcp_core import McpHttpServer
+from dcc_mcp_core import ToolRegistry
+
+
+def _make_registry() -> ToolRegistry:
+    reg = ToolRegistry()
+    reg.register(
+        "ping",
+        description="Test ping tool",
+        category="test",
+        dcc="test",
+        version="1.0.0",
+    )
+    return reg
+
+
+def _get(url: str, headers: dict[str, str] | None = None) -> tuple[int, str, dict[str, str]]:
+    req = urllib.request.Request(url, headers=headers or {}, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+            return resp.status, body, dict(resp.headers)
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace") if e.fp else ""
+        return e.code, body, dict(e.headers or {})
+
+
+def _post_jsonrpc(url: str, body: dict[str, Any]) -> int:
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status
+    except urllib.error.HTTPError as e:
+        return e.code
+
+
+@pytest.fixture
+def prom_server():
+    """Start a server with Prometheus enabled.
+
+    If the wheel was built without the `prometheus` Cargo feature, the
+    /metrics endpoint is absent; we skip the whole module in that case
+    so CI runs that didn't opt in stay green.
+    """
+    cfg = McpHttpConfig(port=0, server_name="prom-test", enable_prometheus=True)
+    reg = _make_registry()
+    server = McpHttpServer(reg, cfg)
+    server.register_handler("ping", lambda _params: {"pong": True})
+    handle = server.start()
+
+    url = f"http://{handle.bind_addr}/metrics"
+    status, _body, _headers = _get(url)
+    if status == 404:
+        handle.shutdown()
+        pytest.skip(
+            "wheel built without the `prometheus` Cargo feature; "
+            "rebuild with `maturin develop --features ...,prometheus`"
+        )
+    try:
+        yield handle
+    finally:
+        handle.shutdown()
+
+
+def test_metrics_endpoint_returns_prometheus_payload(prom_server):
+    url = f"http://{prom_server.bind_addr}/metrics"
+    status, body, headers = _get(url)
+    assert status == 200
+    ctype = headers.get("Content-Type") or headers.get("content-type", "")
+    assert "text/plain" in ctype
+    assert "version=0.0.4" in ctype
+    # Always-on series
+    assert "dcc_mcp_build_info" in body
+    assert "dcc_mcp_active_sessions" in body
+    assert "dcc_mcp_registered_tools" in body
+
+
+def test_tool_calls_advance_counter(prom_server):
+    mcp_url = f"http://{prom_server.bind_addr}/mcp"
+    metrics_url = f"http://{prom_server.bind_addr}/metrics"
+
+    for i in range(5):
+        status = _post_jsonrpc(
+            mcp_url,
+            {
+                "jsonrpc": "2.0",
+                "id": i,
+                "method": "tools/call",
+                "params": {"name": "ping", "arguments": {}},
+            },
+        )
+        assert status == 200, f"tools/call {i} failed with {status}"
+
+    # Poll for the counter — the record happens synchronously in the
+    # wrapper, but the HTTP response may be flushed slightly before the
+    # handler returns on some platforms; a short retry makes the test
+    # robust without sleeping unconditionally.
+    deadline = time.monotonic() + 2.0
+    value = 0
+    while time.monotonic() < deadline:
+        _, body, _ = _get(metrics_url)
+        target_prefix = 'dcc_mcp_tool_calls_total{status="success",tool="ping"}'
+        for line in body.splitlines():
+            if line.startswith(target_prefix):
+                try:
+                    value = int(line.rsplit(" ", 1)[1])
+                except ValueError:
+                    value = 0
+                break
+        if value >= 5:
+            break
+        time.sleep(0.05)
+    assert value >= 5, f"expected >=5 ping success calls, got {value}"
+
+
+def test_basic_auth_rejects_without_credentials():
+    cfg = McpHttpConfig(
+        port=0,
+        server_name="prom-auth",
+        enable_prometheus=True,
+        prometheus_basic_auth=("admin", "s3cret"),
+    )
+    reg = _make_registry()
+    server = McpHttpServer(reg, cfg)
+    handle = server.start()
+    try:
+        url = f"http://{handle.bind_addr}/metrics"
+
+        # Skip if feature is not compiled in.
+        status, _, _ = _get(url)
+        if status == 404:
+            pytest.skip("prometheus feature not enabled in wheel")
+
+        # No auth header → 401
+        assert status == 401, f"expected 401 without auth, got {status}"
+
+        # Wrong password → 401
+        wrong = base64.b64encode(b"admin:nope").decode()
+        status, _, _ = _get(url, headers={"Authorization": f"Basic {wrong}"})
+        assert status == 401
+
+        # Correct password → 200
+        good = base64.b64encode(b"admin:s3cret").decode()
+        status, body, _ = _get(url, headers={"Authorization": f"Basic {good}"})
+        assert status == 200
+        assert "dcc_mcp_build_info" in body
+    finally:
+        handle.shutdown()
+
+
+def test_metrics_endpoint_absent_when_flag_is_off():
+    cfg = McpHttpConfig(port=0, server_name="prom-off", enable_prometheus=False)
+    reg = _make_registry()
+    server = McpHttpServer(reg, cfg)
+    handle = server.start()
+    try:
+        status, _, _ = _get(f"http://{handle.bind_addr}/metrics")
+        # 404 both when the feature was compiled but the flag is off,
+        # and when the feature was never compiled in.
+        assert status == 404
+    finally:
+        handle.shutdown()


### PR DESCRIPTION
## Summary

Closes #331. Adds an opt-in Prometheus text-exposition exporter built on top of `dcc-mcp-telemetry`, with a `GET /metrics` endpoint mounted on the existing MCP HTTP server and optional HTTP Basic auth.

- **Telemetry**: new `dcc-mcp-telemetry/prometheus` feature → `PrometheusExporter` with counters, gauges, histograms for tool calls, job lifecycle, notifications, sessions, and registered tools (plus `dcc_mcp_build_info`). Zero code compiled when feature is off.
- **HTTP**: new `dcc-mcp-http/prometheus` feature → `/metrics` route with constant-time basic-auth comparison, background 5 s tick to refresh `active_sessions` / `registered_tools` gauges, and `handle_tools_call` wrapped to record `dcc_mcp_tool_calls_total{tool,status}` + `dcc_mcp_tool_duration_seconds` without double-counting the recursive `call_action` path.
- **Python**: `McpHttpConfig(enable_prometheus=..., prometheus_basic_auth=(user, pass))` with getters/setters and `_core.pyi` stubs.
- **Docs**: `docs/api/observability.md` (metrics reference, scrape config, Grafana PromQL examples) + AGENTS.md / CLAUDE.md pointers.

### Non-goals

No OTLP exporter, no alerting rules, no Grafana dashboards beyond example queries, no push gateway support.

## Test plan

- [x] `cargo check --workspace` (default features)
- [x] `cargo check --workspace --features prometheus,python-bindings,ext-module`
- [x] `cargo test -p dcc-mcp-telemetry --features prometheus` — exporter render shape
- [x] `cargo test -p dcc-mcp-http --features prometheus --test prometheus_endpoint` — payload, counter increments, 401/200 basic auth, 404 when disabled
- [x] `vx just preflight` (fmt + clippy + cargo test)
- [x] `maturin develop --features python-bindings,ext-module,workflow,prometheus`
- [x] `pytest tests/test_prometheus.py -q` — 4 passed (payload, counter, basic auth, feature-off 404)
- [x] `pytest tests/` — only pre-existing flaky `test_server_sidecar_e2e::test_pid_file_written_on_start` fails (passes when rerun in isolation; unrelated to this PR)

## Operator notes

- Feature is **opt-in at two levels**: Cargo feature `prometheus` at build time, and `McpHttpConfig::enable_prometheus = true` at runtime. Shipped wheels without the feature silently ignore the flag.
- `prometheus_basic_auth = None` leaves `/metrics` unauthenticated — fine for localhost scraping, strongly discouraged in production.
- Metrics share the MCP server's listening port and TLS terminator; no extra socket is opened.
