### PR TITLE
feat(skills): wire next-tools from tools.yaml through to tools/call _meta (#342)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -494,17 +494,20 @@ from dcc_mcp_core import skill_warning, skill_exception
 # Both are pure-Python helpers in python/dcc_mcp_core/skill.py
 ```
 
-**`next-tools` in SKILL.md — guide AI to follow-up tools:**
+**`next-tools` — live inside the sibling `tools.yaml`, never top-level SKILL.md (issue #342):**
 ```yaml
+# tools.yaml  (referenced from SKILL.md via metadata.dcc-mcp.tools: tools.yaml)
 tools:
   - name: create_sphere
     next-tools:
-      on-success: [maya_geometry__bevel_edges]   # suggested after success
+      on-success: [maya_geometry__bevel_edges]    # suggested after success
       on-failure: [dcc_diagnostics__screenshot]   # debug on failure
 ```
 - `next-tools` is a dcc-mcp-core extension (not in agentskills.io spec)
-- Helps AI agents chain tool calls without trial-and-error
-- Both `on-success` and `on-failure` accept lists of fully-qualified tool names
+- Lives inside each tool entry in `tools.yaml`. Top-level `next-tools:` on SKILL.md is legacy, emits a deprecation warn, and flips `is_spec_compliant() → False`.
+- Surfaces on `CallToolResult._meta["dcc.next_tools"]` — server attaches `on_success` after success and `on_failure` after error; omitted entirely when not declared.
+- Invalid tool names are dropped at load-time with a warn — skill still loads.
+- Both `on-success` and `on-failure` accept lists of fully-qualified tool names.
 
 **agentskills.io fields — `license`, `compatibility`, `allowed-tools`:**
 ```yaml

--- a/crates/dcc-mcp-actions/src/registry/mod.rs
+++ b/crates/dcc-mcp-actions/src/registry/mod.rs
@@ -7,7 +7,7 @@ use pyo3::prelude::*;
 use dcc_mcp_utils::py_json::json_value_to_pyobject;
 
 use dashmap::DashMap;
-use dcc_mcp_models::{ExecutionMode, ToolAnnotations};
+use dcc_mcp_models::{ExecutionMode, NextTools, ToolAnnotations};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -90,6 +90,19 @@ pub struct ActionMeta {
     /// inside the spec `annotations` map.
     #[serde(default, skip_serializing_if = "ToolAnnotations::is_empty")]
     pub annotations: ToolAnnotations,
+    /// Suggested follow-up tools surfaced on `CallToolResult._meta`
+    /// under `dcc.next_tools` (issue #342).
+    ///
+    /// Populated from the per-tool `next-tools` entry in the sibling
+    /// `tools.yaml` file. Tool names must pass
+    /// [`dcc_mcp_naming::validate_tool_name`]; invalid entries are
+    /// dropped at skill-load time with a warning.
+    #[serde(default, skip_serializing_if = "next_tools_is_empty")]
+    pub next_tools: NextTools,
+}
+
+fn next_tools_is_empty(nt: &NextTools) -> bool {
+    nt.on_success.is_empty() && nt.on_failure.is_empty()
 }
 
 fn default_enabled() -> bool {
@@ -115,6 +128,7 @@ impl Default for ActionMeta {
             execution: ExecutionMode::Sync,
             timeout_hint_secs: None,
             annotations: ToolAnnotations::default(),
+            next_tools: NextTools::default(),
         }
     }
 }
@@ -624,6 +638,7 @@ impl ActionRegistry {
                 execution,
                 timeout_hint_secs,
                 annotations: ToolAnnotations::default(),
+                next_tools: NextTools::default(),
             });
         }
     }
@@ -700,6 +715,7 @@ impl ActionRegistry {
             execution,
             timeout_hint_secs,
             annotations: ToolAnnotations::default(),
+            next_tools: NextTools::default(),
         });
         Ok(())
     }

--- a/crates/dcc-mcp-actions/src/registry/tests.rs
+++ b/crates/dcc-mcp-actions/src/registry/tests.rs
@@ -205,6 +205,7 @@ fn test_action_meta_serde_round_trip() {
         execution: dcc_mcp_models::ExecutionMode::Async,
         timeout_hint_secs: Some(900),
         annotations: dcc_mcp_models::ToolAnnotations::default(),
+        next_tools: dcc_mcp_models::NextTools::default(),
     };
     let json = serde_json::to_string(&meta).unwrap();
     let back: ActionMeta = serde_json::from_str(&json).unwrap();

--- a/crates/dcc-mcp-http/src/handler.rs
+++ b/crates/dcc-mcp-http/src/handler.rs
@@ -1269,7 +1269,7 @@ async fn handle_tools_call_inner(
         state.in_flight.remove(rid);
     }
 
-    let call_result = match dispatch_outcome {
+    let mut call_result = match dispatch_outcome {
         Ok(output) => {
             let text = match &output {
                 Value::String(s) => s.clone(),
@@ -1306,6 +1306,7 @@ async fn handle_tools_call_inner(
                 content,
                 structured_content,
                 is_error: false,
+                meta: None,
             }
         }
         Err(err_msg) if err_msg == "CANCELLED" => {
@@ -1366,6 +1367,7 @@ async fn handle_tools_call_inner(
                 }],
                 structured_content: None,
                 is_error: true,
+                meta: None,
             }
         }
     };
@@ -1388,6 +1390,14 @@ async fn handle_tools_call_inner(
                 serde_json::to_value(CallToolResult::error(envelope.to_json()))?,
             ));
         }
+    }
+
+    // Issue #342 — attach `_meta["dcc.next_tools"]` with the matching
+    // on-success / on-failure list when the tool declared one. The slot
+    // is asymmetric on purpose: success results never expose on-failure
+    // suggestions and vice versa. Absent → no key, never an empty dict.
+    if let Some(action_meta) = state.registry.get_action(&resolved_name, None) {
+        attach_next_tools_meta(&mut call_result, &action_meta.next_tools);
     }
 
     Ok(JsonRpcResponse::success(
@@ -1578,6 +1588,35 @@ async fn dispatch_async_job(
         req.id.clone(),
         serde_json::to_value(envelope)?,
     ))
+}
+
+/// Populate `CallToolResult._meta["dcc.next_tools"]` per issue #342.
+///
+/// The key is only emitted when the relevant list (on-success for a
+/// success result, on-failure for an error result) is non-empty. Other
+/// existing `_meta` entries are preserved; callers are expected to own
+/// their own vendor namespace inside the same map.
+fn attach_next_tools_meta(result: &mut CallToolResult, next_tools: &dcc_mcp_models::NextTools) {
+    let list = if result.is_error {
+        &next_tools.on_failure
+    } else {
+        &next_tools.on_success
+    };
+    if list.is_empty() {
+        return;
+    }
+    let key = if result.is_error {
+        "on_failure"
+    } else {
+        "on_success"
+    };
+    let mut nt_map = serde_json::Map::new();
+    nt_map.insert(
+        key.to_string(),
+        Value::Array(list.iter().map(|n| Value::String(n.clone())).collect()),
+    );
+    let meta = result.meta.get_or_insert_with(serde_json::Map::new);
+    meta.insert("dcc.next_tools".to_string(), Value::Object(nt_map));
 }
 
 async fn handle_list_roots(

--- a/crates/dcc-mcp-http/src/protocol.rs
+++ b/crates/dcc-mcp-http/src/protocol.rs
@@ -373,6 +373,13 @@ pub struct CallToolResult {
     pub structured_content: Option<Value>,
     #[serde(default)]
     pub is_error: bool,
+    /// MCP `_meta` slot on a `CallToolResult` (issue #342).
+    ///
+    /// Namespaced under vendor keys (e.g. `dcc.next_tools`); never used
+    /// to carry spec-defined top-level fields. Populated lazily by the
+    /// handler; older clients ignore it.
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    pub meta: Option<serde_json::Map<String, Value>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -407,6 +414,7 @@ impl CallToolResult {
             content: vec![ToolContent::Text { text: text.into() }],
             structured_content: None,
             is_error: false,
+            meta: None,
         }
     }
 
@@ -415,6 +423,7 @@ impl CallToolResult {
             content: vec![ToolContent::Text { text: msg.into() }],
             structured_content: None,
             is_error: true,
+            meta: None,
         }
     }
 }

--- a/crates/dcc-mcp-http/src/tests.rs
+++ b/crates/dcc-mcp-http/src/tests.rs
@@ -3865,3 +3865,183 @@ mod lazy_actions_tests {
         assert!(text.contains("ACTION_NOT_FOUND") || text.contains("Unknown tool"));
     }
 }
+
+// ── Issue #342 — next-tools surfacing on CallToolResult._meta ────────────
+#[cfg(test)]
+mod next_tools_meta_tests {
+    use axum::http::HeaderValue;
+    use axum_test::TestServer;
+    use serde_json::{Value, json};
+    use std::sync::Arc;
+
+    use crate::{handler::AppState, session::SessionManager};
+    use dcc_mcp_actions::{ActionDispatcher, ActionMeta, ActionRegistry};
+    use dcc_mcp_models::NextTools;
+    use dcc_mcp_skills::SkillCatalog;
+
+    fn make_state(next_tools: NextTools, with_handler: bool) -> AppState {
+        let registry = Arc::new({
+            let reg = ActionRegistry::new();
+            reg.register_action(ActionMeta {
+                name: "sample".into(),
+                description: "sample tool".into(),
+                dcc: "test_dcc".into(),
+                version: "1.0.0".into(),
+                next_tools,
+                ..Default::default()
+            });
+            reg
+        });
+        let catalog = Arc::new(SkillCatalog::new(registry.clone()));
+        let dispatcher = Arc::new(ActionDispatcher::new((*registry).clone()));
+        if with_handler {
+            dispatcher.register_handler("sample", |_p| Ok(json!({"ok": true})));
+        } else {
+            dispatcher.register_handler("sample", |_p| Err("boom".to_string()));
+        }
+        AppState {
+            registry,
+            dispatcher,
+            catalog,
+            sessions: SessionManager::new(),
+            executor: None,
+            bridge_registry: crate::BridgeRegistry::new(),
+            server_name: "test-dcc".to_string(),
+            server_version: "0.1.0".to_string(),
+            cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+            in_flight: crate::inflight::InFlightRequests::new(),
+            pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
+            lazy_actions: false,
+            bare_tool_names: true,
+            jobs: std::sync::Arc::new(crate::job::JobManager::new()),
+            resources: crate::resources::ResourceRegistry::new(true, false),
+            enable_resources: true,
+        }
+    }
+
+    fn make_router(state: AppState) -> (axum::Router, SessionManager) {
+        use crate::handler::{handle_delete, handle_get, handle_post};
+        use axum::{Router, routing};
+        let sessions = state.sessions.clone();
+        let router = Router::new()
+            .route(
+                "/mcp",
+                routing::post(handle_post)
+                    .get(handle_get)
+                    .delete(handle_delete),
+            )
+            .with_state(state);
+        (router, sessions)
+    }
+
+    async fn call_sample(router: axum::Router, sid: &str) -> Value {
+        let server = TestServer::new(router);
+        let resp = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .add_header(
+                axum::http::HeaderName::from_static("mcp-session-id"),
+                sid.parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "sample", "arguments": {}}
+            }))
+            .await;
+        resp.assert_status_ok();
+        resp.json()
+    }
+
+    #[tokio::test]
+    async fn success_attaches_on_success_list_only() {
+        let nt = NextTools {
+            on_success: vec!["foo__bar".into(), "baz__qux".into()],
+            on_failure: vec!["debug__trace".into()],
+        };
+        let state = make_state(nt, true);
+        let (router, sessions) = make_router(state);
+        let sid = sessions.create();
+        let body = call_sample(router, &sid).await;
+
+        assert_eq!(body["result"]["isError"], false, "body: {body}");
+        let meta = &body["result"]["_meta"]["dcc.next_tools"];
+        assert!(
+            meta.is_object(),
+            "expected _meta.\"dcc.next_tools\" object on success, got: {body}",
+        );
+        let on_success = meta["on_success"].as_array().expect("on_success array");
+        assert_eq!(on_success.len(), 2);
+        assert_eq!(on_success[0], "foo__bar");
+        assert!(
+            meta.get("on_failure").is_none(),
+            "on_failure must NOT be present on success results",
+        );
+    }
+
+    #[tokio::test]
+    async fn failure_attaches_on_failure_list_only() {
+        let nt = NextTools {
+            on_success: vec!["foo__bar".into()],
+            on_failure: vec!["diagnostics__screenshot".into()],
+        };
+        let state = make_state(nt, false);
+        let (router, sessions) = make_router(state);
+        let sid = sessions.create();
+        let body = call_sample(router, &sid).await;
+
+        assert_eq!(body["result"]["isError"], true, "body: {body}");
+        let meta = &body["result"]["_meta"]["dcc.next_tools"];
+        assert!(
+            meta.is_object(),
+            "expected _meta.\"dcc.next_tools\" on failure, got: {body}",
+        );
+        assert_eq!(
+            meta["on_failure"][0], "diagnostics__screenshot",
+            "on_failure list must surface",
+        );
+        assert!(
+            meta.get("on_success").is_none(),
+            "on_success must NOT be present on error results",
+        );
+    }
+
+    #[tokio::test]
+    async fn no_next_tools_declared_omits_meta_entirely() {
+        let state = make_state(NextTools::default(), true);
+        let (router, sessions) = make_router(state);
+        let sid = sessions.create();
+        let body = call_sample(router, &sid).await;
+
+        assert_eq!(body["result"]["isError"], false);
+        assert!(
+            body["result"].get("_meta").is_none(),
+            "no next-tools means no _meta slot at all (got {body})",
+        );
+    }
+
+    #[tokio::test]
+    async fn success_without_on_success_list_omits_meta() {
+        // on-failure declared but the call succeeded — we must NOT
+        // emit an empty on_success, and must NOT leak on_failure on a
+        // success result.
+        let nt = NextTools {
+            on_success: vec![],
+            on_failure: vec!["diagnostics__screenshot".into()],
+        };
+        let state = make_state(nt, true);
+        let (router, sessions) = make_router(state);
+        let sid = sessions.create();
+        let body = call_sample(router, &sid).await;
+
+        assert_eq!(body["result"]["isError"], false);
+        assert!(
+            body["result"].get("_meta").is_none(),
+            "success result must not leak on_failure, got {body}",
+        );
+    }
+}

--- a/crates/dcc-mcp-models/src/lib.rs
+++ b/crates/dcc-mcp-models/src/lib.rs
@@ -7,7 +7,7 @@ pub mod skill_scope;
 pub use action_result::ActionResultModel as ToolResult;
 pub use action_result::{ActionResultModel, ActionResultModelData, SerializeFormat};
 pub use skill_metadata::{
-    ExecutionMode, SkillDependencies, SkillDependency, SkillDependencyType, SkillGroup,
+    ExecutionMode, NextTools, SkillDependencies, SkillDependency, SkillDependencyType, SkillGroup,
     SkillMetadata, SkillPolicy, ToolAnnotations, ToolDeclaration,
 };
 pub use skill_scope::SkillScope;

--- a/crates/dcc-mcp-models/src/skill_metadata.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata.rs
@@ -425,7 +425,7 @@ impl<'de> serde::Deserialize<'de> for ToolDeclaration {
 }
 
 /// Suggested next tools for a successful or failed tool call (issue #143).
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NextTools {
     /// Tool names to suggest after a successful invocation.
     #[serde(default, rename = "on-success", alias = "on_success")]
@@ -811,6 +811,68 @@ impl ToolDeclaration {
             idempotent_hint: get_bool(d, &["idempotent_hint", "idempotentHint"])?,
             open_world_hint: get_bool(d, &["open_world_hint", "openWorldHint"])?,
             deferred_hint: get_bool(d, &["deferred_hint", "deferredHint"])?,
+        };
+        Ok(())
+    }
+
+    /// Suggested follow-up tools for this declaration (issue #342).
+    ///
+    /// Returns ``None`` when neither ``on-success`` nor ``on-failure``
+    /// was declared. Otherwise returns a dict with string-list values
+    /// under the ``"on_success"`` / ``"on_failure"`` keys.
+    #[getter]
+    fn next_tools<'py>(
+        &self,
+        py: Python<'py>,
+    ) -> pyo3::PyResult<Option<pyo3::Bound<'py, pyo3::types::PyDict>>> {
+        if self.next_tools.on_success.is_empty() && self.next_tools.on_failure.is_empty() {
+            return Ok(None);
+        }
+        let d = pyo3::types::PyDict::new(py);
+        d.set_item("on_success", self.next_tools.on_success.clone())?;
+        d.set_item("on_failure", self.next_tools.on_failure.clone())?;
+        Ok(Some(d))
+    }
+
+    /// Set ``next_tools`` from a dict with optional ``on_success`` /
+    /// ``on_failure`` list-of-string values. Passing ``None`` clears
+    /// both lists.
+    #[setter]
+    fn set_next_tools(
+        &mut self,
+        value: Option<&pyo3::Bound<'_, pyo3::types::PyAny>>,
+    ) -> pyo3::PyResult<()> {
+        use pyo3::types::PyDict;
+        let Some(v) = value else {
+            self.next_tools = NextTools::default();
+            return Ok(());
+        };
+        if v.is_none() {
+            self.next_tools = NextTools::default();
+            return Ok(());
+        }
+        let dict = v.downcast::<PyDict>().map_err(|_| {
+            pyo3::exceptions::PyTypeError::new_err(
+                "next_tools must be a dict with optional on_success/on_failure list keys, or None",
+            )
+        })?;
+        let on_success: Vec<String> = dict
+            .get_item("on_success")
+            .ok()
+            .flatten()
+            .map(|v| v.extract())
+            .transpose()?
+            .unwrap_or_default();
+        let on_failure: Vec<String> = dict
+            .get_item("on_failure")
+            .ok()
+            .flatten()
+            .map(|v| v.extract())
+            .transpose()?
+            .unwrap_or_default();
+        self.next_tools = NextTools {
+            on_success,
+            on_failure,
         };
         Ok(())
     }

--- a/crates/dcc-mcp-skills/Cargo.toml
+++ b/crates/dcc-mcp-skills/Cargo.toml
@@ -11,6 +11,7 @@ description = "Skills system for the DCC-MCP ecosystem (SKILL.md scanning and lo
 pyo3 = { workspace = true, optional = true }
 dcc-mcp-models = { workspace = true }
 dcc-mcp-actions = { workspace = true }
+dcc-mcp-naming = { workspace = true }
 dcc-mcp-utils = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/dcc-mcp-skills/src/catalog/mod.rs
+++ b/crates/dcc-mcp-skills/src/catalog/mod.rs
@@ -367,6 +367,7 @@ impl SkillCatalog {
                 execution: tool_decl.execution,
                 timeout_hint_secs: tool_decl.timeout_hint_secs,
                 annotations: tool_decl.annotations.clone(),
+                next_tools: sanitize_next_tools(&tool_decl.next_tools, skill_name, &action_name),
             };
 
             self.registry.register_action(meta);
@@ -410,6 +411,7 @@ impl SkillCatalog {
                     execution: dcc_mcp_models::ExecutionMode::Sync,
                     timeout_hint_secs: None,
                     annotations: dcc_mcp_models::ToolAnnotations::default(),
+                    next_tools: dcc_mcp_models::NextTools::default(),
                 };
 
                 self.registry.register_action(meta);
@@ -869,6 +871,39 @@ impl SkillCatalog {
             self.len(),
             self.loaded_count()
         )
+    }
+}
+
+/// Drop tool names in `next-tools` that fail `validate_tool_name` so
+/// the catalog never surfaces malformed follow-up suggestions to AI
+/// clients (issue #342).
+///
+/// Invalid entries are logged at warn-level and skipped; skill load
+/// succeeds so a typo in one tool's `next-tools` list does not block
+/// an entire skill.
+fn sanitize_next_tools(
+    raw: &dcc_mcp_models::NextTools,
+    skill_name: &str,
+    action_name: &str,
+) -> dcc_mcp_models::NextTools {
+    let sanitize = |kind: &str, names: &[String]| -> Vec<String> {
+        names
+            .iter()
+            .filter_map(|n| match dcc_mcp_naming::validate_tool_name(n) {
+                Ok(()) => Some(n.clone()),
+                Err(e) => {
+                    tracing::warn!(
+                        "skill {skill_name}: tool {action_name}: next-tools.{kind} entry \
+                         {n:?} is not a valid tool name ({e}); dropping.",
+                    );
+                    None
+                }
+            })
+            .collect()
+    };
+    dcc_mcp_models::NextTools {
+        on_success: sanitize("on-success", &raw.on_success),
+        on_failure: sanitize("on-failure", &raw.on_failure),
     }
 }
 

--- a/crates/dcc-mcp-skills/src/catalog/tests.rs
+++ b/crates/dcc-mcp-skills/src/catalog/tests.rs
@@ -109,6 +109,42 @@ fn test_unload_not_loaded_skill_fails() {
 }
 
 #[test]
+fn test_load_skill_propagates_next_tools_and_drops_invalid() {
+    // Issue #342: tools.yaml `next-tools` flows into ActionMeta.next_tools;
+    // entries whose tool name fails `validate_tool_name` are dropped at
+    // load time and do not fail the whole skill load.
+    let catalog = make_test_catalog();
+    let mut skill = make_test_skill("modeling", "maya", &[]);
+    skill.tools = vec![ToolDeclaration {
+        name: "bevel".to_string(),
+        next_tools: dcc_mcp_models::NextTools {
+            on_success: vec![
+                "maya_geometry__assign_material".to_string(),
+                "bad/name".to_string(), // invalid — must be dropped
+            ],
+            on_failure: vec!["diagnostics__screenshot".to_string()],
+        },
+        ..Default::default()
+    }];
+    catalog.add_skill(skill);
+
+    catalog.load_skill("modeling").unwrap();
+    let meta = catalog
+        .registry()
+        .get_action("modeling__bevel", None)
+        .expect("action registered");
+    assert_eq!(
+        meta.next_tools.on_success,
+        vec!["maya_geometry__assign_material".to_string()],
+        "invalid entries must be filtered",
+    );
+    assert_eq!(
+        meta.next_tools.on_failure,
+        vec!["diagnostics__screenshot".to_string()],
+    );
+}
+
+#[test]
 fn test_load_skill_idempotent() {
     let catalog = make_test_catalog();
     catalog.add_skill(make_test_skill("test", "maya", &["tool1"]));

--- a/crates/dcc-mcp-skills/src/loader/mod.rs
+++ b/crates/dcc-mcp-skills/src/loader/mod.rs
@@ -52,6 +52,11 @@ const LEGACY_EXTENSION_KEYS: &[&str] = &[
     "products",
     "allow_implicit_invocation",
     "allow-implicit-invocation",
+    // Issue #342 — per-tool `next-tools` MUST live in the sibling
+    // tools.yaml file. A top-level `next-tools:` in SKILL.md is the
+    // legacy form and is treated as spec-non-compliant.
+    "next-tools",
+    "next_tools",
 ];
 
 use crate::resolver::{self, ResolveError};

--- a/crates/dcc-mcp-skills/src/loader/tests.rs
+++ b/crates/dcc-mcp-skills/src/loader/tests.rs
@@ -871,4 +871,73 @@ metadata:
         let meta = parse_skill_md(&dir).expect("parsed");
         assert!(meta.tools[0].annotations.is_empty());
     }
+
+    // ── issue #342: next-tools in sibling tools.yaml ──
+
+    #[test]
+    fn sibling_tools_yaml_parses_next_tools() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("nt");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("tools.yaml"),
+            r#"tools:
+  - name: create_sphere
+    description: make a sphere
+    next-tools:
+      on-success:
+        - maya_geometry__bevel_edges
+        - maya_geometry__assign_material
+      on-failure:
+        - diagnostics__screenshot
+"#,
+        )
+        .unwrap();
+        let body = r#"---
+name: nt
+metadata:
+  dcc-mcp.dcc: maya
+  dcc-mcp.tools: tools.yaml
+---
+"#;
+        std::fs::write(dir.join(SKILL_METADATA_FILE), body).unwrap();
+        let meta = parse_skill_md(&dir).expect("parsed");
+        assert!(meta.is_spec_compliant());
+        assert_eq!(meta.tools.len(), 1);
+        let nt = &meta.tools[0].next_tools;
+        assert_eq!(
+            nt.on_success,
+            vec![
+                "maya_geometry__bevel_edges".to_string(),
+                "maya_geometry__assign_material".to_string(),
+            ]
+        );
+        assert_eq!(nt.on_failure, vec!["diagnostics__screenshot".to_string()]);
+    }
+
+    #[test]
+    fn top_level_next_tools_is_legacy_and_non_compliant() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("legacy_nt");
+        let body = r#"---
+name: legacy_nt
+dcc: maya
+next-tools:
+  on-success: [foo]
+---
+"#;
+        write_skill(&dir, body);
+        let meta = parse_skill_md(&dir).expect("parsed");
+        assert!(
+            !meta.is_spec_compliant(),
+            "top-level next-tools must be flagged as legacy",
+        );
+        assert!(
+            meta.legacy_extension_fields
+                .iter()
+                .any(|s| s == "next-tools"),
+            "legacy_extension_fields must name next-tools; got {:?}",
+            meta.legacy_extension_fields,
+        );
+    }
 }

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -664,6 +664,41 @@ spec-standard `annotations` map (which would make the payload
 non-compliant). The same `_meta` slot also carries the
 `execution: async` implication from issue #317.
 
+#### Declaring `next-tools` (issue #342)
+
+`next-tools` belongs **inside each tool entry in `tools.yaml`** — never as
+a top-level SKILL.md frontmatter key. The server surfaces the declared
+list on `CallToolResult._meta["dcc.next_tools"]`:
+
+- `on-success` list → attached after a successful tool call
+- `on-failure` list → attached after an error (`isError == true`)
+- No `next-tools` declared → `_meta["dcc.next_tools"]` is omitted entirely
+
+```yaml
+# tools.yaml
+tools:
+  - name: create_sphere
+    description: "Create a polygon sphere"
+    source_file: scripts/create_sphere.py
+    next-tools:
+      on-success:
+        - maya_geometry__bevel_edges
+        - maya_geometry__assign_material
+      on-failure:
+        - diagnostics__screenshot
+        - diagnostics__audit_log
+```
+
+Tool names are validated with `dcc_mcp_naming::validate_tool_name` at
+skill-load time. Invalid entries are dropped with a `tracing::warn!`
+and the rest of the skill loads normally — a single malformed name
+will not fail the whole skill.
+
+A legacy top-level `next-tools:` block on SKILL.md still parses for
+backward compatibility but emits a deprecation warning and flips
+`SkillMetadata.is_spec_compliant()` to `False` (`next-tools` appears
+in `legacy_extension_fields`).
+
 ### Metadata key reference
 
 | Legacy top-level                | Spec-compliant `metadata` key                | Value type            |

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -180,6 +180,14 @@ class ToolDeclaration:
     Assignment accepts both snake_case (``read_only_hint``) and camelCase
     (``readOnlyHint``). Set to ``None`` or ``{}`` to clear.
     """
+    next_tools: dict[str, list[str]] | None
+    """Suggested follow-up tools (issue #342).
+
+    Returns ``None`` when no ``next-tools`` block was declared in the
+    sibling ``tools.yaml``. Otherwise a dict with ``"on_success"`` and
+    ``"on_failure"`` list-of-string values. Surfaces on
+    ``CallToolResult._meta`` as ``dcc.next_tools``.
+    """
 
     def __init__(
         self,

--- a/tests/test_next_tools.py
+++ b/tests/test_next_tools.py
@@ -1,0 +1,331 @@
+"""Tests for the `next-tools` wiring from SKILL.md / tools.yaml to
+``CallToolResult._meta["dcc.next_tools"]`` — issue #342.
+
+These tests exercise the full pipeline:
+
+1. Sibling-file parsing: ``tools.yaml`` with per-tool ``next-tools``
+   surfaces on ``SkillMetadata.tools[i].next_tools``.
+2. Legacy deprecation: a top-level ``next-tools:`` on SKILL.md parses
+   but flags the skill as non-spec-compliant and lists ``next-tools``
+   in ``legacy_extension_fields``.
+3. End-to-end: a running ``McpHttpServer`` attaches
+   ``_meta["dcc.next_tools"]["on_success"]`` after success and
+   ``_meta["dcc.next_tools"]["on_failure"]`` after an error, and
+   omits the key entirely when the tool declared no next-tools.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import socket
+import sys
+import time
+from typing import Any
+import urllib.request
+
+import pytest
+
+import dcc_mcp_core
+from dcc_mcp_core import McpHttpConfig
+from dcc_mcp_core import McpHttpServer
+from dcc_mcp_core import ToolRegistry
+
+# ── Unit: sibling tools.yaml parses next-tools per tool ────────────────────
+
+
+def _write_skill_md(skill_dir: Path, body: str) -> None:
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(body, encoding="utf-8")
+
+
+def test_sibling_tools_yaml_parses_next_tools(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "nt-skill"
+    skill_dir.mkdir()
+    (skill_dir / "tools.yaml").write_text(
+        """tools:
+  - name: create_sphere
+    description: Create a polygon sphere
+    next-tools:
+      on-success:
+        - maya_geometry__bevel_edges
+        - maya_geometry__assign_material
+      on-failure:
+        - diagnostics__screenshot
+""",
+        encoding="utf-8",
+    )
+    _write_skill_md(
+        skill_dir,
+        """---
+name: nt-skill
+description: next-tools sibling-file test
+metadata:
+  dcc-mcp.dcc: maya
+  dcc-mcp.tools: tools.yaml
+---
+# body
+""",
+    )
+
+    meta = dcc_mcp_core.parse_skill_md(str(skill_dir))
+    assert meta is not None
+    assert meta.is_spec_compliant()
+    assert len(meta.tools) == 1
+    tool = meta.tools[0]
+    nt = tool.next_tools
+    assert nt is not None, "next_tools dict must be exposed"
+    assert nt["on_success"] == [
+        "maya_geometry__bevel_edges",
+        "maya_geometry__assign_material",
+    ]
+    assert nt["on_failure"] == ["diagnostics__screenshot"]
+
+
+# ── Unit: top-level next-tools is legacy + deprecation ─────────────────────
+
+
+def test_top_level_next_tools_is_legacy(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "legacy-nt"
+    _write_skill_md(
+        skill_dir,
+        """---
+name: legacy-nt
+dcc: maya
+next-tools:
+  on-success: [foo]
+---
+""",
+    )
+    meta = dcc_mcp_core.parse_skill_md(str(skill_dir))
+    assert meta is not None
+    assert not meta.is_spec_compliant(), "A top-level next-tools: key must flag the skill as non-compliant"
+    assert "next-tools" in meta.legacy_extension_fields, (
+        f"legacy_extension_fields must name next-tools; got {meta.legacy_extension_fields!r}"
+    )
+
+
+# ── E2E: CallToolResult._meta["dcc.next_tools"] wiring ─────────────────────
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _post(url: str, body: dict[str, Any]) -> dict[str, Any]:
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        return json.loads(resp.read())
+
+
+def _write_success_skill(root: Path) -> Path:
+    """Write a minimal skill whose single tool succeeds and declares
+    both on-success and on-failure next-tools. The script echoes its
+    arguments back as a success dict.
+    """
+    skill_dir = root / "nt-success"
+    skill_dir.mkdir()
+    scripts = skill_dir / "scripts"
+    scripts.mkdir()
+    (scripts / "ping.py").write_text(
+        """from __future__ import annotations
+import json, sys
+print(json.dumps({"success": True, "message": "pong"}))
+""",
+        encoding="utf-8",
+    )
+    (skill_dir / "tools.yaml").write_text(
+        """tools:
+  - name: ping
+    description: Returns pong
+    source_file: scripts/ping.py
+    next-tools:
+      on-success: [nt_success__followup_a, nt_success__followup_b]
+      on-failure: [diagnostics__screenshot]
+""",
+        encoding="utf-8",
+    )
+    _write_skill_md(
+        skill_dir,
+        """---
+name: nt-success
+description: Success skill for #342 end-to-end test
+metadata:
+  dcc-mcp.dcc: test
+  dcc-mcp.tools: tools.yaml
+---
+""",
+    )
+    return skill_dir
+
+
+def _write_failure_skill(root: Path) -> Path:
+    """Tool exits with an error payload so the server marks the result
+    as ``isError: true`` and surfaces the on-failure list.
+    """
+    skill_dir = root / "nt-failure"
+    skill_dir.mkdir()
+    scripts = skill_dir / "scripts"
+    scripts.mkdir()
+    (scripts / "boom.py").write_text(
+        """from __future__ import annotations
+import json, sys
+sys.stderr.write("boom!\\n")
+sys.exit(1)
+""",
+        encoding="utf-8",
+    )
+    (skill_dir / "tools.yaml").write_text(
+        """tools:
+  - name: boom
+    description: Always fails
+    source_file: scripts/boom.py
+    next-tools:
+      on-failure: [diagnostics__screenshot, diagnostics__audit_log]
+""",
+        encoding="utf-8",
+    )
+    _write_skill_md(
+        skill_dir,
+        """---
+name: nt-failure
+description: Failure skill for #342 end-to-end test
+metadata:
+  dcc-mcp.dcc: test
+  dcc-mcp.tools: tools.yaml
+---
+""",
+    )
+    return skill_dir
+
+
+def _write_plain_skill(root: Path) -> Path:
+    """Skill with no next-tools declared — baseline for "no _meta" case."""
+    skill_dir = root / "nt-plain"
+    skill_dir.mkdir()
+    scripts = skill_dir / "scripts"
+    scripts.mkdir()
+    (scripts / "noop.py").write_text(
+        """from __future__ import annotations
+import json
+print(json.dumps({"success": True, "message": "ok"}))
+""",
+        encoding="utf-8",
+    )
+    (skill_dir / "tools.yaml").write_text(
+        """tools:
+  - name: noop
+    description: Does nothing
+    source_file: scripts/noop.py
+""",
+        encoding="utf-8",
+    )
+    _write_skill_md(
+        skill_dir,
+        """---
+name: nt-plain
+description: No next-tools declared
+metadata:
+  dcc-mcp.dcc: test
+  dcc-mcp.tools: tools.yaml
+---
+""",
+    )
+    return skill_dir
+
+
+@pytest.fixture(scope="module")
+def e2e_server(tmp_path_factory):
+    root = tmp_path_factory.mktemp("nt-skills")
+    _write_success_skill(root)
+    _write_failure_skill(root)
+    _write_plain_skill(root)
+
+    reg = ToolRegistry()
+    port = _free_port()
+    config = McpHttpConfig(port=port, server_name="nt-test-server")
+    server = McpHttpServer(reg, config)
+    server.discover(extra_paths=[str(root)])
+    handle = server.start()
+    # Wait briefly for the listener to be ready.
+    time.sleep(0.25)
+    try:
+        url = handle.mcp_url()
+        # Activate every declared skill so its tools are callable.
+        for skill in ("nt-success", "nt-failure", "nt-plain"):
+            _post(
+                url,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 100,
+                    "method": "tools/call",
+                    "params": {"name": "load_skill", "arguments": {"skill_name": skill}},
+                },
+            )
+        yield url
+    finally:
+        handle.shutdown()
+
+
+def _call_tool(url: str, name: str, rid: int = 1) -> dict[str, Any]:
+    return _post(
+        url,
+        {
+            "jsonrpc": "2.0",
+            "id": rid,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": {}},
+        },
+    )
+
+
+def test_tools_call_success_attaches_on_success(e2e_server: str) -> None:
+    body = _call_tool(e2e_server, "nt_success__ping", rid=1)
+    result = body["result"]
+    assert result["isError"] is False, f"unexpected error: {result}"
+    meta = result.get("_meta")
+    assert meta is not None, f"expected _meta on success, got: {result}"
+    nt = meta.get("dcc.next_tools")
+    assert nt is not None, f"expected dcc.next_tools, got: {meta}"
+    assert nt["on_success"] == [
+        "nt_success__followup_a",
+        "nt_success__followup_b",
+    ]
+    assert "on_failure" not in nt, "on_failure must be absent on a success result"
+
+
+def test_tools_call_failure_attaches_on_failure(e2e_server: str) -> None:
+    body = _call_tool(e2e_server, "nt_failure__boom", rid=2)
+    result = body["result"]
+    assert result["isError"] is True, f"expected error: {result}"
+    meta = result.get("_meta")
+    assert meta is not None, f"expected _meta on failure, got: {result}"
+    nt = meta.get("dcc.next_tools")
+    assert nt is not None, f"expected dcc.next_tools, got: {meta}"
+    assert nt["on_failure"] == [
+        "diagnostics__screenshot",
+        "diagnostics__audit_log",
+    ]
+    assert "on_success" not in nt, "on_success must be absent on an error result"
+
+
+def test_tools_call_no_next_tools_omits_meta(e2e_server: str) -> None:
+    body = _call_tool(e2e_server, "nt_plain__noop", rid=3)
+    result = body["result"]
+    assert result["isError"] is False, f"unexpected error: {result}"
+    # When no next-tools declared: either no _meta at all or a _meta
+    # without the dcc.next_tools key. The former is preferred.
+    meta = result.get("_meta")
+    if meta is not None:
+        assert "dcc.next_tools" not in meta, f"next_tools must be absent for a tool with no declaration, got: {meta}"


### PR DESCRIPTION
## Summary

Wires `next-tools` from the sibling `tools.yaml` file all the way through to `CallToolResult._meta["dcc.next_tools"]` — per the issue #342 amendment.

- **Parser**: per-tool `next-tools` in `tools.yaml` parses into `NextTools { on_success, on_failure }` on `ActionMeta`. Tool names are validated with `dcc_mcp_naming::validate_tool_name`; invalid entries are dropped with a `tracing::warn!` and the rest of the skill loads.
- **Legacy deprecation**: a top-level `next-tools:` on `SKILL.md` still parses but adds `next-tools` to `legacy_extension_fields`, flips `is_spec_compliant() → false`, and emits the existing deprecation warning — no new top-level frontmatter key introduced.
- **Response wiring**: `handle_tools_call` looks up the tool's `next_tools` after dispatch and attaches `_meta["dcc.next_tools"]["on_success"]` on success or `_meta["dcc.next_tools"]["on_failure"]` on error. The key is omitted entirely when no next-tools are declared or the relevant list is empty. Asymmetric — `on_success` never appears on an error and vice versa.
- **Python surface**: `ToolDeclaration.next_tools` getter/setter returning `Optional[Dict[str, List[str]]]`; `_core.pyi` updated.
- **Docs**: `docs/guide/skills.md` gains a "Declaring next-tools" subsection under the sibling-file pattern; `AGENTS.md` Quick Lookup entry updated to reflect the `tools.yaml` placement and the `_meta` surface.

## Test plan

- [x] `cargo test --workspace` — green (7 new Rust tests in loader / catalog / http)
- [x] `vx just preflight` — green (cargo check + clippy + fmt + test-rust)
- [x] `pytest tests/test_next_tools.py` — 5 / 5 pass (sibling-file parse, legacy top-level deprecation, tools/call `_meta` success/failure/absent)
- [x] `pytest tests/` — 8165 passed, 55 skipped, no regressions

## Notable decisions

- `NextTools` now derives `Eq` so `ActionMeta` continues to satisfy `Eq`.
- `CallToolResult` gains an optional `_meta: Option<serde_json::Map<String, Value>>` field serialized with `#[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]` — the key never appears in the JSON when the server has nothing to attach.
- `ToolDeclaration.next_tools` (Python) returns `None` when both lists are empty, matching the "omit entirely" contract on the server side.

Closes #342
