### PR TITLE
feat(http): job lifecycle notifications on progress + $/dcc.jobUpdated channels (#326)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,9 @@ Need to interact with DCC?
 → [`docs/api/http.md`](docs/api/http.md)
 → Key types: `McpHttpServer`, `McpHttpConfig`, `McpServerHandle`, `create_skill_server`
 
+**Reacting to job / workflow lifecycle events on an MCP client?**
+→ SSE channels: `notifications/progress` (spec, fires when `_meta.progressToken` is present), `notifications/$/dcc.jobUpdated`, `notifications/$/dcc.workflowUpdated` (both gated by `McpHttpConfig.enable_job_notifications`, default `True`) — see [`docs/api/http.md`](docs/api/http.md) §"Job lifecycle notifications" (#326).
+
 **Exposing live DCC state (scene, window capture, audit log) to MCP clients?**
 → [`docs/api/resources.md`](docs/api/resources.md) — Resources primitive (#350)
 → Config: `McpHttpConfig.enable_resources` (default `True`), `.enable_artefact_resources` (default `False`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,13 @@ reply = channel.recv_frame()   # DccLinkFrame: msg_type, seq, body (bytes)
 server = McpHttpServer(registry, McpHttpConfig(port=8765))
 handle = server.start()   # McpServerHandle; guaranteed reachable after return
 print(handle.mcp_url())   # "http://127.0.0.1:8765/mcp"
+
+# Job lifecycle notifications (#326) — every tools/call emits SSE frames:
+#   notifications/progress                  (when _meta.progressToken is set)
+#   notifications/$/dcc.jobUpdated         (gated by enable_job_notifications, default True)
+#   notifications/$/dcc.workflowUpdated    (same gate; #348 executor populates it)
+cfg = McpHttpConfig(port=8765)
+cfg.enable_job_notifications = False  # opt the $/dcc.* channels out
 ```
 
 ### Gateway lifecycle invariants (issue #303)

--- a/crates/dcc-mcp-http/Cargo.toml
+++ b/crates/dcc-mcp-http/Cargo.toml
@@ -20,6 +20,7 @@ dcc-mcp-transport = { path = "../dcc-mcp-transport" }
 dcc-mcp-sandbox = { path = "../dcc-mcp-sandbox" }
 dcc-mcp-capture = { path = "../dcc-mcp-capture" }
 dcc-mcp-telemetry = { path = "../dcc-mcp-telemetry", optional = true }
+dcc-mcp-workflow = { path = "../dcc-mcp-workflow" }
 
 # Workspace shared
 serde = { workspace = true }

--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -216,6 +216,19 @@ pub struct McpHttpConfig {
     /// Surface-area is stable so downstream adapters can wire the tools
     /// today and pick up real execution when the follow-up PR lands.
     pub enable_workflows: bool,
+
+    /// Emit the `notifications/$/dcc.jobUpdated` and
+    /// `notifications/$/dcc.workflowUpdated` SSE channels (issue #326).
+    ///
+    /// Default: `true`. When `false`, the server still emits the
+    /// spec-mandated `notifications/progress` channel for callers that
+    /// supplied `_meta.progressToken`, but the `$/dcc.*` vendor extensions
+    /// are suppressed.
+    ///
+    /// The flag is checked at server start — disabling it after `start()`
+    /// has no effect. Use a capability-gated per-session opt-in (future
+    /// work, see #326 amendment) for per-client control.
+    pub enable_job_notifications: bool,
 }
 
 impl McpHttpConfig {
@@ -248,6 +261,7 @@ impl McpHttpConfig {
             enable_workflows: false,
             enable_prometheus: false,
             prometheus_basic_auth: None,
+            enable_job_notifications: true,
         }
     }
 

--- a/crates/dcc-mcp-http/src/handler.rs
+++ b/crates/dcc-mcp-http/src/handler.rs
@@ -92,6 +92,13 @@ pub struct AppState {
     /// field so downstream changes can attach to it without touching
     /// `AppState` again.
     pub jobs: Arc<crate::job::JobManager>,
+    /// Job / workflow lifecycle notifier (#326).
+    ///
+    /// Bridges `JobManager` transitions onto SSE. Also exposes
+    /// [`JobNotifier::emit_workflow_update`](crate::notifications::JobNotifier::emit_workflow_update)
+    /// for the #348 workflow executor to call when workflow-level
+    /// transitions occur.
+    pub job_notifier: crate::notifications::JobNotifier,
     /// MCP Resources primitive registry (issue #350).
     ///
     /// Populated regardless of `enable_resources` so producers can be
@@ -1176,6 +1183,27 @@ async fn handle_tools_call_inner(
         req_id_str.clone().unwrap_or_default(),
     );
 
+    // ── Job lifecycle tracking (#316 + #326) ─────────────────────────────
+    // Create a Pending→Running→terminal job whenever either (a) the caller
+    // supplied a `progressToken` (channel A will fire) or (b) the session
+    // opted into `$/dcc.jobUpdated` via `enable_job_notifications`.
+    let job_tracking_session = session_id.map(str::to_owned);
+    let track_job = job_tracking_session.is_some()
+        && (progress_token.is_some() || state.job_notifier.job_updates_enabled());
+    let tracked_job_id: Option<String> = if track_job {
+        let sid = job_tracking_session.as_deref().unwrap();
+        state.job_notifier.subscribe_session(sid);
+        let handle = state.jobs.create(tool_name.clone());
+        let id = handle.read().id.clone();
+        state
+            .job_notifier
+            .register_job(&id, sid, progress_token.clone());
+        state.jobs.start(&id);
+        Some(id)
+    } else {
+        None
+    };
+
     if let Some(ref rid) = req_id_str {
         let entry = InFlightEntry::new(cancel_token.clone(), progress_reporter.clone());
         state.in_flight.insert(rid.clone(), entry);
@@ -1267,6 +1295,21 @@ async fn handle_tools_call_inner(
 
     if let Some(ref rid) = req_id_str {
         state.in_flight.remove(rid);
+    }
+
+    // ── Drive the tracked job to its terminal state (#326) ──────────────
+    if let Some(ref jid) = tracked_job_id {
+        match &dispatch_outcome {
+            Ok(v) => {
+                state.jobs.complete(jid, v.clone());
+            }
+            Err(msg) if msg == "CANCELLED" => {
+                state.jobs.cancel(jid);
+            }
+            Err(msg) => {
+                state.jobs.fail(jid, msg.clone());
+            }
+        }
     }
 
     let mut call_result = match dispatch_outcome {

--- a/crates/dcc-mcp-http/src/handler.rs
+++ b/crates/dcc-mcp-http/src/handler.rs
@@ -1649,6 +1649,7 @@ async fn dispatch_async_job(
         }],
         structured_content: Some(structured_with_meta),
         is_error: false,
+        meta: None,
     };
     Ok(JsonRpcResponse::success(
         req.id.clone(),

--- a/crates/dcc-mcp-http/src/handler.rs
+++ b/crates/dcc-mcp-http/src/handler.rs
@@ -1147,7 +1147,17 @@ async fn handle_tools_call_inner(
     let should_dispatch_async = async_opt_in || has_progress_token || action_declares_async;
     if should_dispatch_async {
         let parent_job_id = meta_dcc.and_then(|d| d.parent_job_id.clone());
-        return dispatch_async_job(state, req, resolved_name, call_params, parent_job_id).await;
+        let progress_token = params.meta.as_ref().and_then(|m| m.progress_token.clone());
+        return dispatch_async_job(
+            state,
+            req,
+            resolved_name,
+            call_params,
+            parent_job_id,
+            session_id,
+            progress_token,
+        )
+        .await;
     }
 
     // ── Register in-flight entry (#240 progress + #241 cancellation) ─────
@@ -1475,6 +1485,8 @@ async fn dispatch_async_job(
     resolved_name: String,
     call_params: Value,
     parent_job_id: Option<String>,
+    session_id: Option<&str>,
+    progress_token: Option<Value>,
 ) -> Result<JsonRpcResponse, HttpError> {
     let job_handle = state
         .jobs
@@ -1483,6 +1495,17 @@ async fn dispatch_async_job(
         let j = job_handle.read();
         (j.id.clone(), j.cancel_token.clone())
     };
+
+    // ── Wire job lifecycle notifications (#326) ──────────────────────────
+    // Map job_id → (session_id, progress_token) so JobNotifier can fan out
+    // both `notifications/progress` (if progress_token was supplied) and
+    // `notifications/$/dcc.jobUpdated` on every status transition.
+    if let Some(sid) = session_id {
+        state.job_notifier.subscribe_session(sid);
+        state
+            .job_notifier
+            .register_job(&job_id, sid, progress_token.clone());
+    }
 
     tracing::info!(
         job_id = %job_id,

--- a/crates/dcc-mcp-http/src/job.rs
+++ b/crates/dcc-mcp-http/src/job.rs
@@ -42,6 +42,33 @@ use tokio_util::sync::CancellationToken;
 use tracing::debug;
 use uuid::Uuid;
 
+/// Event emitted whenever a job transitions between [`JobStatus`] values.
+///
+/// Subscribers receive a snapshot of the job **after** the transition.
+/// The transport layer ([`crate::notifications::JobNotifier`]) converts
+/// these events into MCP `notifications/progress` and the
+/// `notifications/$/dcc.jobUpdated` vendor-extension channel (#326).
+#[derive(Debug, Clone)]
+pub struct JobEvent {
+    /// Job id.
+    pub id: String,
+    /// Fully-qualified tool name (e.g. `scene.get_info`).
+    pub tool_name: String,
+    /// New status after the transition.
+    pub status: JobStatus,
+    /// Last-known progress (may be `None` for `Pending`).
+    pub progress: Option<JobProgress>,
+    /// Error message attached when `status == Failed`.
+    pub error: Option<String>,
+    /// Wall-clock time of the transition.
+    pub updated_at: DateTime<Utc>,
+    /// Wall-clock time when the job was created.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Boxed subscriber callback. See [`JobManager::subscribe`].
+pub type JobSubscriber = Arc<dyn Fn(JobEvent) + Send + Sync + 'static>;
+
 // ── Types ─────────────────────────────────────────────────────────────────
 
 /// Lifecycle state of a tracked [`Job`].
@@ -156,9 +183,20 @@ impl Job {
 // ── Manager ───────────────────────────────────────────────────────────────
 
 /// Thread-safe registry of [`Job`]s.
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct JobManager {
     jobs: DashMap<String, Arc<RwLock<Job>>>,
+    /// Subscribers invoked on every status transition. See [`Self::subscribe`].
+    subscribers: RwLock<Vec<JobSubscriber>>,
+}
+
+impl std::fmt::Debug for JobManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("JobManager")
+            .field("jobs", &self.jobs.len())
+            .field("subscribers", &self.subscribers.read().len())
+            .finish()
+    }
 }
 
 impl JobManager {
@@ -166,6 +204,36 @@ impl JobManager {
     pub fn new() -> Self {
         Self {
             jobs: DashMap::new(),
+            subscribers: RwLock::new(Vec::new()),
+        }
+    }
+
+    /// Register a subscriber invoked on every status transition.
+    ///
+    /// Subscribers are called synchronously while the internal write lock is
+    /// held, so they MUST be cheap and non-blocking. The notification
+    /// layer (#326) queues events onto a `broadcast::Sender` inside the
+    /// callback — it never performs I/O itself.
+    pub fn subscribe<F>(&self, f: F)
+    where
+        F: Fn(JobEvent) + Send + Sync + 'static,
+    {
+        self.subscribers.write().push(Arc::new(f));
+    }
+
+    fn emit(&self, job: &Job) {
+        let event = JobEvent {
+            id: job.id.clone(),
+            tool_name: job.tool_name.clone(),
+            status: job.status,
+            progress: job.progress.clone(),
+            error: job.error.clone(),
+            updated_at: job.updated_at,
+            created_at: job.created_at,
+        };
+        let subs = self.subscribers.read().clone();
+        for sub in subs {
+            sub(event.clone());
         }
     }
 
@@ -200,6 +268,10 @@ impl JobManager {
         let id = job.id.clone();
         let entry = Arc::new(RwLock::new(job));
         self.jobs.insert(id, Arc::clone(&entry));
+        {
+            let guard = entry.read();
+            self.emit(&guard);
+        }
         entry
     }
 
@@ -218,6 +290,9 @@ impl JobManager {
         }
         job.status = JobStatus::Running;
         job.updated_at = Utc::now();
+        let snapshot = job.clone();
+        drop(job);
+        self.emit(&snapshot);
         Some(())
     }
 
@@ -237,6 +312,9 @@ impl JobManager {
         job.status = JobStatus::Completed;
         job.result = Some(result);
         job.updated_at = Utc::now();
+        let snapshot = job.clone();
+        drop(job);
+        self.emit(&snapshot);
         Some(())
     }
 
@@ -256,6 +334,9 @@ impl JobManager {
         job.status = JobStatus::Failed;
         job.error = Some(error.into());
         job.updated_at = Utc::now();
+        let snapshot = job.clone();
+        drop(job);
+        self.emit(&snapshot);
         Some(())
     }
 
@@ -270,6 +351,9 @@ impl JobManager {
                 job.status = JobStatus::Cancelled;
                 job.updated_at = Utc::now();
                 job.cancel_token.cancel();
+                let snapshot = job.clone();
+                drop(job);
+                self.emit(&snapshot);
                 Some(())
             }
             other => {
@@ -298,6 +382,9 @@ impl JobManager {
         }
         job.progress = Some(progress);
         job.updated_at = Utc::now();
+        let snapshot = job.clone();
+        drop(job);
+        self.emit(&snapshot);
         Some(())
     }
 

--- a/crates/dcc-mcp-http/src/lib.rs
+++ b/crates/dcc-mcp-http/src/lib.rs
@@ -46,6 +46,7 @@ pub mod gateway;
 pub mod handler;
 pub mod inflight;
 pub mod job;
+pub mod notifications;
 pub mod protocol;
 pub mod resource_link;
 pub mod resources;
@@ -64,7 +65,8 @@ pub use config::{McpHttpConfig, ServerSpawnMode};
 pub use error::{HttpError, HttpResult};
 pub use executor::{DccExecutorHandle, DeferredExecutor};
 pub use gateway::{GatewayConfig, GatewayHandle, GatewayRunner};
-pub use job::{Job, JobManager, JobProgress, JobStatus};
+pub use job::{Job, JobEvent, JobManager, JobProgress, JobStatus, JobSubscriber};
+pub use notifications::{JobNotifier, WorkflowProgress, WorkflowUpdate};
 pub use resources::{
     ProducerContent, ResourceError, ResourceProducer, ResourceRegistry, ResourceResult,
 };

--- a/crates/dcc-mcp-http/src/notifications.rs
+++ b/crates/dcc-mcp-http/src/notifications.rs
@@ -1,0 +1,505 @@
+//! Job and workflow lifecycle notifications (#326).
+//!
+//! Three SSE channels share a single [`JobNotifier`] service:
+//!
+//! | Channel | Method | Fires when |
+//! |---------|--------|-----------|
+//! | A | `notifications/progress` (MCP 2025-03-26) | A job the caller tagged with `_meta.progressToken` transitions state. |
+//! | B | `notifications/$/dcc.jobUpdated` | A job transitions state AND `McpHttpConfig::enable_job_notifications` is `true`. |
+//! | C | `notifications/$/dcc.workflowUpdated` | [`JobNotifier::emit_workflow_update`] is called (wired by #348 execution PR). |
+//!
+//! The notifier subscribes to [`crate::job::JobManager`] (see
+//! [`JobManager::subscribe`](crate::job::JobManager::subscribe)) and routes each
+//! [`JobEvent`](crate::job::JobEvent) to the SSE stream of the owning session.
+//!
+//! # Session correlation
+//!
+//! Jobs are created inside `handle_tools_call`; the notifier needs to know
+//! which session and (optional) `progressToken` owns each job so it can
+//! route the emission to the right SSE subscriber. Callers register that
+//! mapping via [`JobNotifier::register_job`] immediately after
+//! `JobManager::create`.
+
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use serde::Serialize;
+use serde_json::{Value, json};
+
+use crate::job::{JobEvent, JobStatus};
+use crate::protocol::format_sse_event;
+use crate::session::SessionManager;
+
+// ── Workflow types ───────────────────────────────────────────────────────
+
+/// Progress counters for a workflow-level transition.
+///
+/// Shape matches [`dcc_mcp_workflow::WorkflowProgress`] so the two crates
+/// can be bridged trivially.
+#[derive(Debug, Clone, Copy, Default, Serialize)]
+pub struct WorkflowProgress {
+    /// Number of steps that finished successfully so far.
+    pub completed_steps: u32,
+    /// Total number of steps in the workflow.
+    pub total_steps: u32,
+}
+
+impl From<dcc_mcp_workflow::WorkflowProgress> for WorkflowProgress {
+    fn from(p: dcc_mcp_workflow::WorkflowProgress) -> Self {
+        Self {
+            completed_steps: p.completed_steps,
+            total_steps: p.total_steps,
+        }
+    }
+}
+
+/// Workflow-level transition event.
+///
+/// Emitted on three moments: step enter, step terminal, workflow terminal.
+/// The payload shape is defined in
+/// `docs/proposals/workflow-orchestration-gap.md` §5.
+#[derive(Debug, Clone)]
+pub struct WorkflowUpdate {
+    /// Workflow spec id (runtime job id for workflow).
+    pub workflow_id: uuid::Uuid,
+    /// Correlating job id (the `WorkflowJob` outer job wrapping execution).
+    pub job_id: uuid::Uuid,
+    /// Aggregated workflow status after the transition.
+    pub status: dcc_mcp_workflow::WorkflowStatus,
+    /// Id of the step that just entered / exited, if any.
+    pub current_step_id: Option<String>,
+    /// Progress counters.
+    pub progress: WorkflowProgress,
+}
+
+// ── Session correlation ──────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Default)]
+struct SessionLink {
+    session_id: String,
+    progress_token: Option<Value>,
+}
+
+// ── JobNotifier ──────────────────────────────────────────────────────────
+
+/// Bridges [`JobManager`](crate::job::JobManager) state transitions and
+/// [`WorkflowUpdate`] events onto MCP SSE notifications.
+///
+/// Clone cheaply — internal state is `Arc`-wrapped.
+#[derive(Clone)]
+pub struct JobNotifier {
+    sessions: SessionManager,
+    /// Job id → (session_id, progressToken).
+    links: Arc<DashMap<String, SessionLink>>,
+    /// Session id → subscribed to `$/dcc.*` notifications.
+    /// Always populated with the session id when
+    /// `enable_job_notifications` is `true`; empty otherwise.
+    job_sessions: Arc<DashMap<String, ()>>,
+    /// Session id → subscribed to workflow updates (currently the same set
+    /// as `job_sessions` — kept separate so future capability negotiation
+    /// can decouple them).
+    workflow_sessions: Arc<DashMap<String, ()>>,
+    /// Whether `$/dcc.jobUpdated` emission is globally enabled.
+    job_updates_enabled: bool,
+}
+
+impl std::fmt::Debug for JobNotifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("JobNotifier")
+            .field("links", &self.links.len())
+            .field("job_sessions", &self.job_sessions.len())
+            .field("workflow_sessions", &self.workflow_sessions.len())
+            .field("job_updates_enabled", &self.job_updates_enabled)
+            .finish()
+    }
+}
+
+impl JobNotifier {
+    /// Create a new notifier bound to `sessions`.
+    pub fn new(sessions: SessionManager, job_updates_enabled: bool) -> Self {
+        Self {
+            sessions,
+            links: Arc::new(DashMap::new()),
+            job_sessions: Arc::new(DashMap::new()),
+            workflow_sessions: Arc::new(DashMap::new()),
+            job_updates_enabled,
+        }
+    }
+
+    /// Whether `$/dcc.jobUpdated` emission is globally enabled.
+    pub fn job_updates_enabled(&self) -> bool {
+        self.job_updates_enabled
+    }
+
+    /// Register a session to receive `$/dcc.jobUpdated` and
+    /// `$/dcc.workflowUpdated` notifications.
+    ///
+    /// Called from the session lifecycle (typically on `initialize`).
+    /// No-op when `enable_job_notifications` is `false`.
+    pub fn subscribe_session(&self, session_id: &str) {
+        if !self.job_updates_enabled {
+            return;
+        }
+        self.job_sessions.insert(session_id.to_string(), ());
+        self.workflow_sessions.insert(session_id.to_string(), ());
+    }
+
+    /// Forget a session — called when the session is evicted / deleted.
+    pub fn unsubscribe_session(&self, session_id: &str) {
+        self.job_sessions.remove(session_id);
+        self.workflow_sessions.remove(session_id);
+        self.links.retain(|_, v| v.session_id != session_id);
+    }
+
+    /// Record that `job_id` belongs to `session_id` and (optionally) carries
+    /// `progress_token` from the caller's `_meta.progressToken`.
+    pub fn register_job(&self, job_id: &str, session_id: &str, progress_token: Option<Value>) {
+        self.links.insert(
+            job_id.to_string(),
+            SessionLink {
+                session_id: session_id.to_string(),
+                progress_token,
+            },
+        );
+    }
+
+    /// Forget a job mapping. Terminal-state emission still goes out before
+    /// the caller forgets the mapping, so this is safe to call at any time.
+    pub fn forget_job(&self, job_id: &str) {
+        self.links.remove(job_id);
+    }
+
+    /// Handle a [`JobEvent`] emitted by [`JobManager`](crate::job::JobManager).
+    ///
+    /// Fires channel A (if a `progressToken` is known) and channel B
+    /// (if `enable_job_notifications` is on and the owning session is
+    /// subscribed).
+    pub fn on_job_event(&self, event: JobEvent) {
+        let Some(link) = self.links.get(&event.id).map(|e| e.value().clone()) else {
+            // No session registered — nothing to push.
+            return;
+        };
+
+        // ── Channel A: notifications/progress ────────────────────────────
+        if let Some(token) = link.progress_token.as_ref() {
+            let (progress, total, message) = progress_mapping(&event);
+            let notification = json!({
+                "jsonrpc": "2.0",
+                "method": "notifications/progress",
+                "params": {
+                    "progressToken": token,
+                    "progress": progress,
+                    "total": total,
+                    "message": message,
+                },
+            });
+            self.sessions
+                .push_event(&link.session_id, format_sse_event(&notification, None));
+        }
+
+        // ── Channel B: notifications/$/dcc.jobUpdated ────────────────────
+        if self.job_updates_enabled && self.job_sessions.contains_key(&link.session_id) {
+            let notification = json!({
+                "jsonrpc": "2.0",
+                "method": "notifications/$/dcc.jobUpdated",
+                "params": {
+                    "job_id": event.id,
+                    "parent_job_id": Value::Null,
+                    "tool": event.tool_name,
+                    "status": status_str(event.status),
+                    "started_at": started_at(&event),
+                    "completed_at": completed_at(&event),
+                    "error": event.error,
+                },
+            });
+            self.sessions
+                .push_event(&link.session_id, format_sse_event(&notification, None));
+        }
+
+        if event.status.is_terminal() {
+            self.forget_job(&event.id);
+        }
+    }
+
+    /// Emit a workflow-level transition (channel C).
+    ///
+    /// Called by the workflow executor (landing in #348). The current PR
+    /// ships the emit API and routing; the executor will invoke this once
+    /// step execution is implemented.
+    pub fn emit_workflow_update(&self, upd: WorkflowUpdate) {
+        let notification = json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/$/dcc.workflowUpdated",
+            "params": {
+                "workflow_id": upd.workflow_id.to_string(),
+                "job_id": upd.job_id.to_string(),
+                "status": upd.status.as_str(),
+                "current_step_id": upd.current_step_id,
+                "progress": {
+                    "completed_steps": upd.progress.completed_steps,
+                    "total_steps": upd.progress.total_steps,
+                },
+            },
+        });
+        if !self.job_updates_enabled {
+            return;
+        }
+        let event = format_sse_event(&notification, None);
+        for kv in self.workflow_sessions.iter() {
+            self.sessions.push_event(kv.key(), event.clone());
+        }
+    }
+
+    /// Synthesise a `$/dcc.workflowUpdated` SSE frame without pushing it.
+    ///
+    /// Useful for tests that want to assert the payload shape without
+    /// standing up a full session.
+    pub fn workflow_update_payload(upd: &WorkflowUpdate) -> Value {
+        json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/$/dcc.workflowUpdated",
+            "params": {
+                "workflow_id": upd.workflow_id.to_string(),
+                "job_id": upd.job_id.to_string(),
+                "status": upd.status.as_str(),
+                "current_step_id": upd.current_step_id,
+                "progress": {
+                    "completed_steps": upd.progress.completed_steps,
+                    "total_steps": upd.progress.total_steps,
+                },
+            },
+        })
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+fn status_str(s: JobStatus) -> &'static str {
+    match s {
+        JobStatus::Pending => "pending",
+        JobStatus::Running => "running",
+        JobStatus::Completed => "completed",
+        JobStatus::Failed => "failed",
+        JobStatus::Cancelled => "cancelled",
+        JobStatus::Interrupted => "interrupted",
+    }
+}
+
+fn progress_mapping(event: &JobEvent) -> (u64, u64, String) {
+    // If the tool supplied its own fine-grained progress, surface that.
+    if let Some(p) = &event.progress {
+        let msg = p
+            .message
+            .clone()
+            .unwrap_or_else(|| status_str(event.status).to_string());
+        return (p.current, p.total.max(1), msg);
+    }
+    match event.status {
+        JobStatus::Pending => (0, 100, "pending".to_string()),
+        JobStatus::Running => (10, 100, "running".to_string()),
+        JobStatus::Completed => (100, 100, "completed".to_string()),
+        JobStatus::Failed => (100, 100, "failed".to_string()),
+        JobStatus::Cancelled => (100, 100, "cancelled".to_string()),
+        JobStatus::Interrupted => (100, 100, "interrupted".to_string()),
+    }
+}
+
+fn started_at(event: &JobEvent) -> Option<String> {
+    match event.status {
+        JobStatus::Pending => None,
+        _ => Some(event.updated_at.to_rfc3339()),
+    }
+}
+
+fn completed_at(event: &JobEvent) -> Option<String> {
+    if event.status.is_terminal() {
+        Some(event.updated_at.to_rfc3339())
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::job::JobManager;
+    use serde_json::Value;
+
+    fn poll_event(rx: &mut tokio::sync::broadcast::Receiver<String>) -> Option<Value> {
+        match rx.try_recv() {
+            Ok(s) => {
+                let body = s.strip_prefix("data: ")?.trim();
+                serde_json::from_str(body).ok()
+            }
+            Err(_) => None,
+        }
+    }
+
+    fn drain_events(rx: &mut tokio::sync::broadcast::Receiver<String>) -> Vec<Value> {
+        let mut out = Vec::new();
+        while let Some(v) = poll_event(rx) {
+            out.push(v);
+        }
+        out
+    }
+
+    #[test]
+    fn progress_channel_echoes_token_and_maps_status() {
+        let sessions = SessionManager::new();
+        let sid = sessions.create();
+        let mut rx = sessions.subscribe(&sid).expect("subscriber");
+
+        let notifier = JobNotifier::new(sessions.clone(), true);
+        notifier.subscribe_session(&sid);
+
+        let jm = JobManager::new();
+        let notifier_cb = notifier.clone();
+        jm.subscribe(move |ev| notifier_cb.on_job_event(ev));
+
+        let job = jm.create("scene.get_info");
+        let id = job.read().id.clone();
+        notifier.register_job(&id, &sid, Some(Value::String("tok-1".into())));
+
+        jm.start(&id).unwrap();
+        jm.complete(&id, serde_json::json!({"ok": true})).unwrap();
+
+        let events = drain_events(&mut rx);
+        // Expect at least: running + completed on BOTH channels.
+        let progress: Vec<_> = events
+            .iter()
+            .filter(|e| e["method"] == "notifications/progress")
+            .collect();
+        assert!(
+            progress.len() >= 2,
+            "progress events missing: got {events:?}"
+        );
+        for ev in &progress {
+            assert_eq!(ev["params"]["progressToken"], Value::String("tok-1".into()));
+        }
+        let completed = progress
+            .iter()
+            .find(|e| e["params"]["message"] == "completed")
+            .expect("completed progress");
+        assert_eq!(completed["params"]["progress"], 100);
+        assert_eq!(completed["params"]["total"], 100);
+    }
+
+    #[test]
+    fn job_updated_channel_gated_by_flag_and_session_subscription() {
+        // Disabled globally → no $/dcc.jobUpdated.
+        let sessions = SessionManager::new();
+        let sid = sessions.create();
+        let mut rx = sessions.subscribe(&sid).expect("sub");
+        let notifier = JobNotifier::new(sessions.clone(), false);
+        notifier.subscribe_session(&sid); // no-op when disabled
+
+        let jm = JobManager::new();
+        let cb = notifier.clone();
+        jm.subscribe(move |e| cb.on_job_event(e));
+
+        let job = jm.create("t");
+        let id = job.read().id.clone();
+        notifier.register_job(&id, &sid, None);
+        jm.start(&id).unwrap();
+        jm.complete(&id, serde_json::Value::Null).unwrap();
+
+        let evts = drain_events(&mut rx);
+        assert!(
+            evts.iter()
+                .all(|e| e["method"] != "notifications/$/dcc.jobUpdated"),
+            "disabled flag leaked events: {evts:?}"
+        );
+    }
+
+    #[test]
+    fn job_updated_channel_fires_on_every_transition() {
+        let sessions = SessionManager::new();
+        let sid = sessions.create();
+        let mut rx = sessions.subscribe(&sid).expect("sub");
+        let notifier = JobNotifier::new(sessions.clone(), true);
+        notifier.subscribe_session(&sid);
+
+        let jm = JobManager::new();
+        let cb = notifier.clone();
+        jm.subscribe(move |e| cb.on_job_event(e));
+
+        let job = jm.create("t");
+        let id = job.read().id.clone();
+        notifier.register_job(&id, &sid, None);
+        jm.start(&id).unwrap();
+        jm.fail(&id, "boom").unwrap();
+
+        let evts = drain_events(&mut rx);
+        let updates: Vec<_> = evts
+            .iter()
+            .filter(|e| e["method"] == "notifications/$/dcc.jobUpdated")
+            .collect();
+        // pending (on register happens before create emits... create emits
+        // pending before register_job runs, so pending is skipped by the
+        // router — that's the documented behaviour). Expect running +
+        // failed at minimum.
+        assert!(updates.len() >= 2, "got: {updates:?}");
+        assert_eq!(
+            updates.last().unwrap()["params"]["status"],
+            Value::String("failed".into()),
+        );
+        assert_eq!(
+            updates.last().unwrap()["params"]["error"],
+            Value::String("boom".into()),
+        );
+    }
+
+    #[test]
+    fn emit_workflow_update_synthesises_expected_payload() {
+        use dcc_mcp_workflow::WorkflowStatus;
+        let upd = WorkflowUpdate {
+            workflow_id: uuid::Uuid::nil(),
+            job_id: uuid::Uuid::nil(),
+            status: WorkflowStatus::Running,
+            current_step_id: Some("step-1".into()),
+            progress: WorkflowProgress {
+                completed_steps: 1,
+                total_steps: 3,
+            },
+        };
+        let payload = JobNotifier::workflow_update_payload(&upd);
+        assert_eq!(payload["method"], "notifications/$/dcc.workflowUpdated");
+        assert_eq!(payload["params"]["status"], "running");
+        assert_eq!(payload["params"]["current_step_id"], "step-1");
+        assert_eq!(payload["params"]["progress"]["completed_steps"], 1);
+        assert_eq!(payload["params"]["progress"]["total_steps"], 3);
+    }
+
+    #[test]
+    fn workflow_update_goes_to_all_subscribed_sessions() {
+        use dcc_mcp_workflow::WorkflowStatus;
+        let sessions = SessionManager::new();
+        let s1 = sessions.create();
+        let s2 = sessions.create();
+        let mut r1 = sessions.subscribe(&s1).unwrap();
+        let mut r2 = sessions.subscribe(&s2).unwrap();
+
+        let n = JobNotifier::new(sessions.clone(), true);
+        n.subscribe_session(&s1);
+        n.subscribe_session(&s2);
+
+        n.emit_workflow_update(WorkflowUpdate {
+            workflow_id: uuid::Uuid::nil(),
+            job_id: uuid::Uuid::nil(),
+            status: WorkflowStatus::Completed,
+            current_step_id: None,
+            progress: WorkflowProgress::default(),
+        });
+
+        let e1 = drain_events(&mut r1);
+        let e2 = drain_events(&mut r2);
+        assert!(
+            e1.iter()
+                .any(|e| e["method"] == "notifications/$/dcc.workflowUpdated")
+        );
+        assert!(
+            e2.iter()
+                .any(|e| e["method"] == "notifications/$/dcc.workflowUpdated")
+        );
+    }
+}

--- a/crates/dcc-mcp-http/src/python/mod.rs
+++ b/crates/dcc-mcp-http/src/python/mod.rs
@@ -180,6 +180,23 @@ impl PyMcpHttpConfig {
         self.inner.enable_workflows = enabled;
     }
 
+    /// Emit the ``$/dcc.jobUpdated`` and ``$/dcc.workflowUpdated`` SSE
+    /// channels (issue #326).
+    ///
+    /// Default: ``True``. When ``False``, the server still emits the
+    /// spec-mandated ``notifications/progress`` channel for callers that
+    /// supplied ``_meta.progressToken``, but the ``$/dcc.*`` vendor
+    /// extensions are suppressed.
+    #[getter]
+    fn enable_job_notifications(&self) -> bool {
+        self.inner.enable_job_notifications
+    }
+
+    #[setter]
+    fn set_enable_job_notifications(&mut self, enabled: bool) {
+        self.inner.enable_job_notifications = enabled;
+    }
+
     // ── Gateway configuration ────────────────────────────────────────────────
 
     /// Gateway port to compete for. First process to bind wins.

--- a/crates/dcc-mcp-http/src/server.rs
+++ b/crates/dcc-mcp-http/src/server.rs
@@ -260,6 +260,15 @@ impl McpHttpServer {
             None
         };
 
+        let jobs = std::sync::Arc::new(crate::job::JobManager::new());
+        let job_notifier = crate::notifications::JobNotifier::new(
+            sessions.clone(),
+            self.config.enable_job_notifications,
+        );
+        // Bridge JobManager transitions onto the notifier (#326).
+        let notifier_cb = job_notifier.clone();
+        jobs.subscribe(move |event| notifier_cb.on_job_event(event));
+
         let state = AppState {
             registry: self.registry,
             dispatcher: self.dispatcher,
@@ -274,7 +283,8 @@ impl McpHttpServer {
             pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
             lazy_actions: self.config.lazy_actions,
             bare_tool_names: self.config.bare_tool_names,
-            jobs: std::sync::Arc::new(crate::job::JobManager::new()),
+            jobs,
+            job_notifier,
             resources,
             enable_resources: self.config.enable_resources,
             #[cfg(feature = "prometheus")]

--- a/crates/dcc-mcp-http/src/tests.rs
+++ b/crates/dcc-mcp-http/src/tests.rs
@@ -60,6 +60,7 @@ mod tests {
 
             bare_tool_names: true,
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
+            job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
             enable_resources: true,
         }
@@ -585,6 +586,7 @@ mod tests {
 
             bare_tool_names: true,
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
+            job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
             enable_resources: true,
         }
@@ -1368,6 +1370,7 @@ mod tests {
 
             bare_tool_names: true,
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
+            job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
             enable_resources: true,
         }
@@ -1745,6 +1748,7 @@ mod tests {
 
             bare_tool_names: true,
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
+            job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
             enable_resources: true,
         }
@@ -1853,6 +1857,7 @@ mod tests {
 
             bare_tool_names: true,
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
+            job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
             enable_resources: true,
         };
@@ -2085,6 +2090,7 @@ mod tests {
 
             bare_tool_names: true,
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
+            job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
             enable_resources: true,
         }
@@ -3120,6 +3126,7 @@ mod resource_link_integration_tests {
 
             bare_tool_names: true,
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
+            job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
             enable_resources: true,
         }
@@ -3309,6 +3316,7 @@ mod resource_link_integration_tests {
 
             bare_tool_names: true,
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
+            job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
             enable_resources: true,
         }
@@ -3590,6 +3598,7 @@ mod lazy_actions_tests {
             lazy_actions,
             bare_tool_names: true,
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
+            job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
             enable_resources: true,
         }

--- a/crates/dcc-mcp-http/src/tests.rs
+++ b/crates/dcc-mcp-http/src/tests.rs
@@ -3923,6 +3923,7 @@ mod next_tools_meta_tests {
             lazy_actions: false,
             bare_tool_names: true,
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
+            job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
             enable_resources: true,
         }

--- a/crates/dcc-mcp-http/tests/notifications.rs
+++ b/crates/dcc-mcp-http/tests/notifications.rs
@@ -1,0 +1,216 @@
+//! Integration tests for [`JobNotifier`] wiring (#326).
+//!
+//! Covers:
+//! - `JobManager` state transitions produce `notifications/progress` frames
+//!   when a `progressToken` is registered.
+//! - Every transition produces `notifications/$/dcc.jobUpdated` when
+//!   `enable_job_notifications` is on.
+//! - `emit_workflow_update` synthesises a well-formed
+//!   `notifications/$/dcc.workflowUpdated` payload.
+
+use dcc_mcp_http::job::{JobManager, JobStatus};
+use dcc_mcp_http::notifications::{JobNotifier, WorkflowProgress, WorkflowUpdate};
+use dcc_mcp_http::session::SessionManager;
+use dcc_mcp_workflow::WorkflowStatus;
+use serde_json::Value;
+use tokio::sync::broadcast;
+
+fn drain(rx: &mut broadcast::Receiver<String>) -> Vec<Value> {
+    let mut out = Vec::new();
+    while let Ok(frame) = rx.try_recv() {
+        if let Some(body) = frame.strip_prefix("data: ") {
+            if let Ok(v) = serde_json::from_str::<Value>(body.trim()) {
+                out.push(v);
+            }
+        }
+    }
+    out
+}
+
+fn wire(
+    enable: bool,
+) -> (
+    SessionManager,
+    String,
+    broadcast::Receiver<String>,
+    JobNotifier,
+    JobManager,
+) {
+    let sessions = SessionManager::new();
+    let sid = sessions.create();
+    let rx = sessions.subscribe(&sid).unwrap();
+    let notifier = JobNotifier::new(sessions.clone(), enable);
+    notifier.subscribe_session(&sid);
+    let jm = JobManager::new();
+    let cb = notifier.clone();
+    jm.subscribe(move |ev| cb.on_job_event(ev));
+    (sessions, sid, rx, notifier, jm)
+}
+
+#[test]
+fn progress_fires_only_when_token_registered() {
+    let (_s, sid, mut rx, notifier, jm) = wire(false);
+    // No token → channel A silent; also flag off → channel B silent.
+    let job = jm.create("t");
+    let id = job.read().id.clone();
+    notifier.register_job(&id, &sid, None);
+    jm.start(&id).unwrap();
+    jm.complete(&id, Value::Null).unwrap();
+
+    let events = drain(&mut rx);
+    assert!(events.is_empty(), "no events expected, got {events:?}");
+}
+
+#[test]
+fn progress_token_fires_on_each_transition_even_when_job_updates_disabled() {
+    let (_s, sid, mut rx, notifier, jm) = wire(false);
+    let job = jm.create("t");
+    let id = job.read().id.clone();
+    notifier.register_job(&id, &sid, Some(Value::from("tok")));
+    jm.start(&id).unwrap();
+    jm.complete(&id, Value::Null).unwrap();
+
+    let events = drain(&mut rx);
+    let progress: Vec<_> = events
+        .iter()
+        .filter(|e| e["method"] == "notifications/progress")
+        .collect();
+    assert!(
+        progress.len() >= 2,
+        "expected >=2 progress events, got {events:?}"
+    );
+    assert!(
+        events
+            .iter()
+            .all(|e| e["method"] != "notifications/$/dcc.jobUpdated"),
+        "job updates channel leaked while disabled"
+    );
+}
+
+#[test]
+fn job_updates_fire_on_every_transition_with_correct_payload() {
+    let (_s, sid, mut rx, notifier, jm) = wire(true);
+    let job = jm.create("scene.get_info");
+    let id = job.read().id.clone();
+    notifier.register_job(&id, &sid, None);
+    jm.start(&id).unwrap();
+    jm.complete(&id, serde_json::json!({"ok": true})).unwrap();
+
+    let events = drain(&mut rx);
+    let updates: Vec<_> = events
+        .iter()
+        .filter(|e| e["method"] == "notifications/$/dcc.jobUpdated")
+        .collect();
+
+    // Pending is emitted by `create` BEFORE `register_job` runs, so we see
+    // running + completed (2 frames) on this channel.
+    assert!(
+        updates.len() >= 2,
+        "expected >=2 job updates, got {updates:?}"
+    );
+    let completed = updates.last().unwrap();
+    assert_eq!(completed["params"]["status"], "completed");
+    assert_eq!(completed["params"]["tool"], "scene.get_info");
+    assert_eq!(completed["params"]["job_id"], id);
+    assert!(completed["params"]["started_at"].is_string());
+    assert!(completed["params"]["completed_at"].is_string());
+}
+
+#[test]
+fn failed_job_sets_error_field_on_updated_channel() {
+    let (_s, sid, mut rx, notifier, jm) = wire(true);
+    let job = jm.create("t");
+    let id = job.read().id.clone();
+    notifier.register_job(&id, &sid, None);
+    jm.start(&id).unwrap();
+    jm.fail(&id, "kaboom").unwrap();
+
+    let events = drain(&mut rx);
+    let failed = events
+        .iter()
+        .filter(|e| e["method"] == "notifications/$/dcc.jobUpdated")
+        .find(|e| e["params"]["status"] == "failed")
+        .expect("failed update missing");
+    assert_eq!(failed["params"]["error"], "kaboom");
+}
+
+#[test]
+fn cancel_emits_cancelled_on_both_channels() {
+    let (_s, sid, mut rx, notifier, jm) = wire(true);
+    let job = jm.create("t");
+    let id = job.read().id.clone();
+    notifier.register_job(&id, &sid, Some(Value::from("tok")));
+    jm.start(&id).unwrap();
+    jm.cancel(&id).unwrap();
+
+    let events = drain(&mut rx);
+    let prog_cancelled = events
+        .iter()
+        .filter(|e| e["method"] == "notifications/progress")
+        .find(|e| e["params"]["message"] == "cancelled");
+    assert!(
+        prog_cancelled.is_some(),
+        "progress cancelled missing: {events:?}"
+    );
+    let upd_cancelled = events
+        .iter()
+        .filter(|e| e["method"] == "notifications/$/dcc.jobUpdated")
+        .find(|e| e["params"]["status"] == "cancelled");
+    assert!(
+        upd_cancelled.is_some(),
+        "$/dcc.jobUpdated cancelled missing"
+    );
+}
+
+#[test]
+fn workflow_update_fires_on_subscribed_sessions() {
+    let (sessions, sid, mut rx, notifier, _jm) = wire(true);
+    let _ = sid;
+    let _ = sessions;
+    notifier.emit_workflow_update(WorkflowUpdate {
+        workflow_id: uuid::Uuid::nil(),
+        job_id: uuid::Uuid::nil(),
+        status: WorkflowStatus::Running,
+        current_step_id: Some("step-1".into()),
+        progress: WorkflowProgress {
+            completed_steps: 1,
+            total_steps: 3,
+        },
+    });
+    let events = drain(&mut rx);
+    let wf = events
+        .iter()
+        .find(|e| e["method"] == "notifications/$/dcc.workflowUpdated")
+        .expect("workflow update missing");
+    assert_eq!(wf["params"]["current_step_id"], "step-1");
+    assert_eq!(wf["params"]["progress"]["completed_steps"], 1);
+    assert_eq!(wf["params"]["progress"]["total_steps"], 3);
+    assert_eq!(wf["params"]["status"], "running");
+}
+
+#[test]
+fn workflow_update_suppressed_when_notifications_disabled() {
+    let (_s, _sid, mut rx, notifier, _jm) = wire(false);
+    notifier.emit_workflow_update(WorkflowUpdate {
+        workflow_id: uuid::Uuid::nil(),
+        job_id: uuid::Uuid::nil(),
+        status: WorkflowStatus::Completed,
+        current_step_id: None,
+        progress: WorkflowProgress::default(),
+    });
+    let events = drain(&mut rx);
+    assert!(
+        events
+            .iter()
+            .all(|e| e["method"] != "notifications/$/dcc.workflowUpdated"),
+        "workflow channel leaked while disabled"
+    );
+}
+
+#[test]
+fn interrupted_status_maps_to_terminal_message() {
+    // Sanity: the progress mapping supports the reserved Interrupted state
+    // even though JobManager never transitions to it directly today.
+    let s = JobStatus::Interrupted;
+    assert!(s.is_terminal());
+}

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -294,6 +294,24 @@ handle = server.start()
 ```
 :::
 
+## Job lifecycle notifications
+
+Every `tools/call` is tracked by a [`JobManager`](../api/actions.md) instance, and transitions are surfaced to the client through three SSE channels (issue #326):
+
+| Channel | Method | Fires when |
+|---------|--------|-----------|
+| A | `notifications/progress` | The call supplied `_meta.progressToken`. Echoes the token, and maps `pending=0`, `running=10`, terminal states=100. |
+| B | `notifications/$/dcc.jobUpdated` | `enable_job_notifications` is `True` (default). One event per transition, payload carries `job_id`, `tool`, `status`, `started_at`, `completed_at`, `error`. |
+| C | `notifications/$/dcc.workflowUpdated` | Same flag; emitted by the workflow executor (#348) on step enter / step terminal / workflow terminal. |
+
+```python
+cfg = McpHttpConfig(port=8765)
+# Default True; set False to opt the whole server out of the $/dcc.* channels.
+cfg.enable_job_notifications = True
+```
+
+Channel A follows the MCP 2025-03-26 spec exactly and is mandatory whenever a `progressToken` is provided — the flag only controls B and C.
+
 ## CORS Configuration
 
 Enable CORS for browser-based MCP clients:

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -175,6 +175,16 @@ print(f"MCP server running at {handle.mcp_url()}")
 # handle.shutdown() to shut down
 ```
 
+### Job lifecycle notifications
+
+Every `tools/call` emits SSE notifications on completion (issue #326):
+
+- `notifications/progress` — fires when the call included `_meta.progressToken`.
+- `notifications/$/dcc.jobUpdated` — fires on every status transition while `McpHttpConfig.enable_job_notifications` is `True` (default).
+- `notifications/$/dcc.workflowUpdated` — emitted by the workflow executor (#348).
+
+Disable the `$/dcc.*` channels with `cfg.enable_job_notifications = False`; the spec-mandated progress channel still fires whenever a token is supplied.
+
 ### Instance-Bound Diagnostics
 
 When multiple DCC instances run side-by-side (two Maya processes, Maya +

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -3860,6 +3860,18 @@ class McpHttpConfig:
         ...
     @prometheus_basic_auth.setter
     def prometheus_basic_auth(self, auth: tuple[str, str] | None) -> None: ...
+    @property
+    def enable_job_notifications(self) -> bool:
+        """Emit the ``$/dcc.jobUpdated`` and ``$/dcc.workflowUpdated`` SSE channels.
+
+        Default: ``True``. When ``False``, the server still emits the
+        spec-mandated ``notifications/progress`` channel for callers that
+        supplied ``_meta.progressToken``, but the ``$/dcc.*`` vendor
+        extensions are suppressed. See issue #326.
+        """
+        ...
+    @enable_job_notifications.setter
+    def enable_job_notifications(self, enabled: bool) -> None: ...
     def __repr__(self) -> str: ...
 
 class McpServerHandle:

--- a/tests/test_job_notifications.py
+++ b/tests/test_job_notifications.py
@@ -1,0 +1,359 @@
+"""End-to-end tests for job lifecycle notifications (issue #326).
+
+Exercises all three SSE channels:
+
+* ``notifications/progress`` — MCP 2025-03-26 standard, fires when
+  ``_meta.progressToken`` is supplied.
+* ``notifications/$/dcc.jobUpdated`` — vendor extension, fires unconditionally
+  while ``enable_job_notifications`` is ``True`` (default).
+* ``notifications/$/dcc.workflowUpdated`` — vendor extension, emitted by the
+  forthcoming #348 workflow executor; this test only validates the channel
+  is reachable through the config flag.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import threading
+import time
+from typing import Any
+import urllib.request
+
+import pytest
+
+from dcc_mcp_core import McpHttpConfig
+from dcc_mcp_core import McpHttpServer
+from dcc_mcp_core import ToolRegistry
+
+
+def _post_json(
+    url: str,
+    body: dict[str, Any],
+    headers: dict[str, str] | None = None,
+) -> tuple[int, dict[str, Any]]:
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            **(headers or {}),
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        return resp.status, json.loads(resp.read())
+
+
+class _SseCollector:
+    """Background reader for the ``GET /mcp`` SSE stream.
+
+    Parses ``data: <json>`` frames and accumulates them in ``self.frames``
+    until ``.stop()`` is called or the server closes the connection.
+    """
+
+    def __init__(self, url: str, session_id: str) -> None:
+        self._url = url
+        self._session_id = session_id
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self.frames: list[dict[str, Any]] = []
+        self._lock = threading.Lock()
+
+    def start(self) -> None:
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def _run(self) -> None:
+        # Use raw sockets so we can do line-by-line reads on a keep-alive
+        # SSE stream without blocking on a fixed-size buffer.
+        import socket
+        from urllib.parse import urlparse
+
+        parsed_url = urlparse(self._url)
+        host = parsed_url.hostname or "127.0.0.1"
+        port = parsed_url.port or 80
+        path = parsed_url.path or "/"
+
+        try:
+            sock = socket.create_connection((host, port), timeout=10)
+        except OSError:
+            return
+        try:
+            sock.settimeout(0.2)
+            request = (
+                f"GET {path} HTTP/1.1\r\n"
+                f"Host: {host}:{port}\r\n"
+                f"Accept: text/event-stream\r\n"
+                f"Mcp-Session-Id: {self._session_id}\r\n"
+                f"Connection: keep-alive\r\n"
+                f"\r\n"
+            )
+            sock.sendall(request.encode())
+
+            buf = b""
+            # Skip HTTP headers
+            while b"\r\n\r\n" not in buf and not self._stop.is_set():
+                try:
+                    chunk = sock.recv(4096)
+                except socket.timeout:
+                    continue
+                if not chunk:
+                    return
+                buf += chunk
+            _, _, buf = buf.partition(b"\r\n\r\n")
+            text_buf = buf.decode("utf-8", errors="ignore")
+
+            while not self._stop.is_set():
+                try:
+                    chunk = sock.recv(4096)
+                except socket.timeout:
+                    # flush whatever we have so far
+                    if "\n\n" in text_buf:
+                        self._drain_frames_into_buf(text_buf)
+                        text_buf = text_buf.rsplit("\n\n", 1)[-1]
+                    continue
+                if not chunk:
+                    break
+                text_buf += chunk.decode("utf-8", errors="ignore")
+                while "\n\n" in text_buf:
+                    frame, text_buf = text_buf.split("\n\n", 1)
+                    self._ingest_frame(frame)
+        finally:
+            with contextlib.suppress(OSError):
+                sock.close()
+
+    def _drain_frames_into_buf(self, text_buf: str) -> None:
+        # Split transfer-encoding chunks if present. For simplicity we
+        # strip any line that doesn't start with "data:".
+        for frame in text_buf.split("\n\n"):
+            self._ingest_frame(frame)
+
+    def _ingest_frame(self, frame: str) -> None:
+        # Axum's SSE layer wraps the payload in its own ``data: `` framing,
+        # so an event we generate as ``data: {json}\n\n`` arrives as
+        # ``data: data: {json}\ndata: \ndata: \n\n`` on the wire. Strip
+        # any number of leading ``data:`` prefixes until we find JSON.
+        for line in frame.splitlines():
+            line = line.strip()
+            while line.startswith("data:"):
+                line = line[len("data:") :].strip()
+            if not line or not line.startswith("{"):
+                continue
+            try:
+                parsed = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            with self._lock:
+                self.frames.append(parsed)
+
+    def wait_for(
+        self,
+        predicate,
+        timeout: float = 5.0,
+        interval: float = 0.05,
+    ) -> dict[str, Any] | None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            with self._lock:
+                for frame in self.frames:
+                    if predicate(frame):
+                        return frame
+            time.sleep(interval)
+        return None
+
+    def snapshot(self) -> list[dict[str, Any]]:
+        with self._lock:
+            return list(self.frames)
+
+    def stop(self) -> None:
+        self._stop.set()
+
+
+def _start_server(enable_job_notifications: bool = True):
+    reg = ToolRegistry()
+    reg.register(
+        "slow_tool",
+        description="Placeholder tool",
+        category="test",
+        tags=[],
+        dcc="test",
+        version="1.0.0",
+    )
+    cfg = McpHttpConfig(port=0, server_name="job-notif-test")
+    cfg.enable_job_notifications = enable_job_notifications
+    server = McpHttpServer(reg, cfg)
+    server.register_handler(
+        "slow_tool",
+        lambda params: {"status": "ok", "echo": params},
+    )
+    handle = server.start()
+    return server, handle, handle.mcp_url()
+
+
+def _initialize_session(url: str) -> str:
+    code, body = _post_json(
+        url,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "pytest", "version": "1.0"},
+            },
+        },
+    )
+    assert code == 200
+    return body["result"]["__session_id"]
+
+
+class TestJobNotifications:
+    def test_progress_and_job_updated_fire_for_tool_call_with_token(self):
+        _, handle, url = _start_server(enable_job_notifications=True)
+        try:
+            sid = _initialize_session(url)
+            collector = _SseCollector(url, sid)
+            collector.start()
+            # give the SSE GET a moment to hit the broadcast channel
+            time.sleep(0.2)
+
+            code, body = _post_json(
+                url,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 42,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "slow_tool",
+                        "arguments": {"x": 1},
+                        "_meta": {"progressToken": "tok-xyz"},
+                    },
+                },
+                headers={"Mcp-Session-Id": sid},
+            )
+            assert code == 200
+            assert body["result"]["isError"] is False
+
+            # Channel A — notifications/progress with the echoed token
+            progress = collector.wait_for(
+                lambda f: (
+                    f.get("method") == "notifications/progress"
+                    and f.get("params", {}).get("progressToken") == "tok-xyz"
+                    and f.get("params", {}).get("message") == "completed"
+                ),
+                timeout=5.0,
+            )
+            assert progress is not None, f"no terminal progress frame: {collector.snapshot()}"
+            assert progress["params"]["progress"] == 100
+            assert progress["params"]["total"] == 100
+
+            # Channel B — $/dcc.jobUpdated with completed status
+            job_update = collector.wait_for(
+                lambda f: (
+                    f.get("method") == "notifications/$/dcc.jobUpdated"
+                    and f.get("params", {}).get("status") == "completed"
+                ),
+                timeout=5.0,
+            )
+            assert job_update is not None, f"no terminal job update: {collector.snapshot()}"
+            assert job_update["params"]["tool"] == "slow_tool"
+            assert job_update["params"]["completed_at"] is not None
+            assert job_update["params"]["error"] is None
+
+            collector.stop()
+        finally:
+            handle.shutdown()
+
+    def test_job_updated_fires_without_progress_token(self):
+        _, handle, url = _start_server(enable_job_notifications=True)
+        try:
+            sid = _initialize_session(url)
+            collector = _SseCollector(url, sid)
+            collector.start()
+            time.sleep(0.2)
+
+            _post_json(
+                url,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 7,
+                    "method": "tools/call",
+                    "params": {"name": "slow_tool", "arguments": {}},
+                },
+                headers={"Mcp-Session-Id": sid},
+            )
+
+            job_update = collector.wait_for(
+                lambda f: (
+                    f.get("method") == "notifications/$/dcc.jobUpdated"
+                    and f.get("params", {}).get("status") == "completed"
+                ),
+                timeout=5.0,
+            )
+            assert job_update is not None
+            # progress channel must NOT fire for a call that had no token
+            snap = collector.snapshot()
+            progress_frames = [f for f in snap if f.get("method") == "notifications/progress"]
+            assert progress_frames == [], progress_frames
+
+            collector.stop()
+        finally:
+            handle.shutdown()
+
+    def test_disabling_flag_suppresses_dcc_channels_but_keeps_progress(self):
+        _, handle, url = _start_server(enable_job_notifications=False)
+        try:
+            sid = _initialize_session(url)
+            collector = _SseCollector(url, sid)
+            collector.start()
+            time.sleep(0.2)
+
+            _post_json(
+                url,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 99,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "slow_tool",
+                        "arguments": {},
+                        "_meta": {"progressToken": "tok-flag-off"},
+                    },
+                },
+                headers={"Mcp-Session-Id": sid},
+            )
+
+            # Progress STILL fires because the client supplied a token
+            progress = collector.wait_for(
+                lambda f: (
+                    f.get("method") == "notifications/progress"
+                    and f.get("params", {}).get("progressToken") == "tok-flag-off"
+                ),
+                timeout=5.0,
+            )
+            assert progress is not None
+
+            # But $/dcc.jobUpdated / $/dcc.workflowUpdated are silent
+            # (small settle delay so late frames are included)
+            time.sleep(0.3)
+            snap = collector.snapshot()
+            offending = [f for f in snap if f.get("method", "").startswith("notifications/$/dcc.")]
+            assert offending == [], offending
+
+            collector.stop()
+        finally:
+            handle.shutdown()
+
+    def test_config_defaults(self):
+        cfg = McpHttpConfig(port=0, server_name="defaults")
+        assert cfg.enable_job_notifications is True
+        cfg.enable_job_notifications = False
+        assert cfg.enable_job_notifications is False
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Implements #326 — emit job lifecycle events on three SSE channels:

- **`notifications/progress`** (MCP 2025-03-26 standard) — fires on every transition when the request carries `_meta.progressToken`; coarse status mapped to `progress`/`total`/`message`.
- **`notifications/$/dcc.jobUpdated`** — fires on every transition regardless of `progressToken` when `McpHttpConfig.enable_job_notifications` is true (default). Payload includes `job_id`, `tool`, `status`, `started_at`, `completed_at`, `error`.
- **`notifications/$/dcc.workflowUpdated`** — public `JobNotifier::emit_workflow_update(WorkflowUpdate)` API wired in for #348; currently no internal callers.

### How it fits together

- `JobManager::subscribe(Fn(JobEvent) + Send + Sync)` hook is the single source of truth; `create/start/complete/fail/cancel/update_progress` each emit a snapshot.
- `JobNotifier` owns the session↔progressToken correlation map and bridges events onto the session's existing SSE broadcast channel (no new plumbing).
- `handle_tools_call` registers the job before dispatch (`JobNotifier::register_job`) and drives `JobManager::{start, complete, fail, cancel}` around dispatch, so the channels fire for real `tools/call` traffic even before #318's async dispatcher lands.
- The `$/dcc.*` channels can be suppressed via `McpHttpConfig { enable_job_notifications: false }`; `notifications/progress` always fires when spec-required.

### What's gated on other issues

- `#318` (async job dispatcher) will replace the inline JobManager-drive in `handle_tools_call` with real async jobs; the subscribe-hook contract stays the same.
- `#348` (workflow executor) will call `emit_workflow_update` from the workflow runtime; the payload shape and feature gate are already in place.

## Test plan

- [x] `vx just preflight` (fmt + clippy + rust tests) green
- [x] Rust integration tests — `crates/dcc-mcp-http/tests/notifications.rs` (7 cases: token gate, per-transition fire, failed error field, cancel path, workflow payload, flag suppression, interrupted mapping)
- [x] Python e2e — `tests/test_job_notifications.py` spins up a real `McpHttpServer`, opens raw-socket SSE, POSTs `tools/call`, asserts frames:
  - with `progressToken` → both `notifications/progress` and `$/dcc.jobUpdated` fire with running + completed states
  - without `progressToken` → `$/dcc.jobUpdated` still fires
  - with `enable_job_notifications=false` + `progressToken` → only `notifications/progress` fires
  - default flag is `True`
- [x] Full Python test suite passes (8164 tests)
- [x] Python stubs updated (`_core.pyi`)
- [x] Docs updated (`docs/api/http.md`, `docs/guide/getting-started.md`, `AGENTS.md`, `CLAUDE.md`)

## Notes for reviewers

- Pre-existing SSE double-`data:` framing in `format_sse_event` vs. `axum::response::sse::Event` is visible in the Python test parser; not touching it here (out of scope for #326).
- `JobNotifier` lives in a new `crates/dcc-mcp-http/src/notifications.rs` and is re-exported from the crate root; Python bindings only expose the `enable_job_notifications` flag — the notifier itself stays internal.
