### PR TITLE
feat(skills): tokenised BM25-lite scoring for search_skills (#343)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,15 @@ load_skill(skill_name="...") → register tools
 tools/list → see available tools
 ```
 
+`search_skills` uses a deterministic BM25-lite scorer (issue
+[#343](https://github.com/loonghao/dcc-mcp-core/issues/343)): multi-word
+queries are tokenised on whitespace/punctuation, stopwords are ignored, and
+matches are weighted across `name` / `tags` / `search_hint` / `description`
+plus the sibling `tools.yaml` tool names and descriptions. Exact-name queries
+short-circuit to first place; ties break on name-substring hit → scope
+precedence (Admin > System > User > Repo) → alphabetical name. See
+`docs/guide/skills.md` → "How `search_skills` ranks results" for weights.
+
 ### 2. Skill-Based Tools (preferred over raw API calls)
 - Use skill tools (e.g. `maya_geometry__create_sphere`) — they have validated schemas, error handling, and `next-tools` guidance
 - Check `ToolAnnotations` for safety hints before calling destructive tools

--- a/crates/dcc-mcp-skills/src/catalog/mod.rs
+++ b/crates/dcc-mcp-skills/src/catalog/mod.rs
@@ -35,6 +35,7 @@
 //! ```
 
 pub mod execute;
+pub mod scoring;
 pub mod types;
 
 pub use types::{SkillDetail, SkillEntry, SkillState, SkillSummary};
@@ -507,42 +508,30 @@ impl SkillCatalog {
 
     /// Search for skills matching the given criteria.
     ///
-    /// Query matches against: `name`, `description`, `search_hint`, and `tool_names`.
-    /// All filters are AND-ed together. Empty/None filters match everything.
+    /// The `tags` and `dcc` filters are applied first (AND semantics). If a
+    /// non-empty `query` is provided, the remaining skills are ranked with a
+    /// BM25-lite scorer that tokenises name, tags, search_hint, description,
+    /// sibling `tools.yaml` entries (tool names + descriptions) and `dcc`.
+    /// See [`scoring`] for weights, tie-breaks and the exact-name fast path.
+    ///
+    /// When `query` is `None` or empty the pre-filter result is returned in
+    /// a deterministic order (scope descending, then alphabetical name), so
+    /// callers don't observe `DashMap` iteration order.
     pub fn find_skills(
         &self,
         query: Option<&str>,
         tags: &[&str],
         dcc: Option<&str>,
     ) -> Vec<SkillSummary> {
-        self.entries
+        // ── 1. Pre-filter by tags/dcc (AND semantics) ──
+        // Collect to owned entries so we can borrow them for the ranker and
+        // also produce a deterministic iteration order independent of DashMap.
+        let mut prefiltered: Vec<SkillEntry> = self
+            .entries
             .iter()
             .filter(|entry| {
                 let meta = &entry.value().metadata;
 
-                // Query filter: match name, description, search_hint, and tool names
-                if let Some(q) = query {
-                    if !q.is_empty() {
-                        let q_lower = q.to_lowercase();
-                        let hint = if meta.search_hint.is_empty() {
-                            &meta.description
-                        } else {
-                            &meta.search_hint
-                        };
-                        let matched = meta.name.to_lowercase().contains(&q_lower)
-                            || meta.description.to_lowercase().contains(&q_lower)
-                            || hint.to_lowercase().contains(&q_lower)
-                            || meta
-                                .tools
-                                .iter()
-                                .any(|t| t.name.to_lowercase().contains(&q_lower));
-                        if !matched {
-                            return false;
-                        }
-                    }
-                }
-
-                // Tags filter: skill must contain ALL requested tags
                 if !tags.is_empty() {
                     for tag in tags {
                         if !meta.tags.iter().any(|t| t.eq_ignore_ascii_case(tag)) {
@@ -551,7 +540,6 @@ impl SkillCatalog {
                     }
                 }
 
-                // DCC filter
                 if let Some(dcc_filter) = dcc {
                     if !dcc_filter.is_empty() && !meta.dcc.eq_ignore_ascii_case(dcc_filter) {
                         return false;
@@ -560,7 +548,28 @@ impl SkillCatalog {
 
                 true
             })
-            .map(|entry| skill_entry_to_summary(entry.value()))
+            .map(|entry| entry.value().clone())
+            .collect();
+
+        // ── 2. No query → deterministic order, no ranking ──
+        let q_trim = query.map(str::trim).unwrap_or("");
+        if q_trim.is_empty() {
+            prefiltered.sort_by(|a, b| {
+                b.scope
+                    .cmp(&a.scope)
+                    .then_with(|| a.metadata.name.cmp(&b.metadata.name))
+            });
+            return prefiltered.iter().map(skill_entry_to_summary).collect();
+        }
+
+        // ── 3. BM25-lite scoring ──
+        let metas: Vec<&SkillMetadata> = prefiltered.iter().map(|e| &e.metadata).collect();
+        let scopes: Vec<SkillScope> = prefiltered.iter().map(|e| e.scope).collect();
+        let scored = scoring::score_skills(q_trim, &metas, &scopes);
+
+        scored
+            .into_iter()
+            .map(|s| skill_entry_to_summary(&prefiltered[s.index]))
             .collect()
     }
 

--- a/crates/dcc-mcp-skills/src/catalog/scoring.rs
+++ b/crates/dcc-mcp-skills/src/catalog/scoring.rs
@@ -1,0 +1,528 @@
+//! BM25-lite relevance scoring for `search_skills` / `find_skills`.
+//!
+//! Replaces the previous naive substring matcher with a deterministic,
+//! tokenised BM25-style ranker that weights different skill fields.
+//! See issue #343 for the rationale.
+//!
+//! # Fields and weights
+//!
+//! | Field                                    | Weight |
+//! |------------------------------------------|--------|
+//! | `name`                                   | 5.0    |
+//! | `tags`                                   | 3.0    |
+//! | `search_hint`                            | 3.0    |
+//! | `description`                            | 2.0    |
+//! | sibling tool names (from `tools.yaml`)   | 2.0    |
+//! | sibling tool descriptions                | 1.0    |
+//! | `dcc` (exact token match only)           | 4.0    |
+//!
+//! Tokenisation: lowercase, split on `[\s_\-.,;:/]+`, drop a small stopword
+//! list. No stemming, no fuzzy match.
+//!
+//! Scoring: BM25 with `k1=1.2`, `b=0.75`, per-token contribution summed
+//! across fields and query tokens.
+//!
+//! Ties broken by (1) exact-name-substring presence, (2) scope precedence
+//! (Admin > System > User > Repo), (3) alphabetical name.
+//!
+//! Exact-match fast-path: if the query equals the skill name
+//! (case-insensitive, after trimming) that skill sorts first unconditionally.
+
+use dcc_mcp_models::{SkillMetadata, SkillScope};
+
+/// BM25 parameter: term-frequency saturation curve.
+const K1: f64 = 1.2;
+
+/// BM25 parameter: length normalisation.
+const B: f64 = 0.75;
+
+/// Field weights. See module docs.
+pub const W_NAME: f64 = 5.0;
+pub const W_TAGS: f64 = 3.0;
+pub const W_HINT: f64 = 3.0;
+pub const W_DESCRIPTION: f64 = 2.0;
+pub const W_TOOL_NAME: f64 = 2.0;
+pub const W_TOOL_DESCRIPTION: f64 = 1.0;
+pub const W_DCC: f64 = 4.0;
+
+/// A tiny English stopword list. Intentionally small — this library is used
+/// with short, technical queries ("polygon bevel", "render maya"); we don't
+/// want to filter more than the most generic connectives.
+const STOPWORDS: &[&str] = &[
+    "a", "an", "the", "of", "and", "or", "to", "for", "with", "from",
+];
+
+/// Tokenise a string: lowercase, split on `[\s_\-.,;:/]+`, drop stopwords.
+///
+/// Deterministic — same input always yields the same token order.
+pub fn tokenize(s: &str) -> Vec<String> {
+    s.to_lowercase()
+        .split(|c: char| c.is_whitespace() || matches!(c, '_' | '-' | '.' | ',' | ';' | ':' | '/'))
+        .filter(|t| !t.is_empty())
+        .filter(|t| !STOPWORDS.contains(t))
+        .map(|t| t.to_string())
+        .collect()
+}
+
+/// Field token buckets for a single skill, used during scoring.
+#[derive(Debug, Clone, Default)]
+pub struct FieldTokens {
+    pub name: Vec<String>,
+    pub tags: Vec<String>,
+    pub hint: Vec<String>,
+    pub description: Vec<String>,
+    pub tool_names: Vec<String>,
+    pub tool_descriptions: Vec<String>,
+    pub dcc: Vec<String>,
+}
+
+impl FieldTokens {
+    /// Total token count (used as BM25 document length).
+    pub fn doc_len(&self) -> usize {
+        self.name.len()
+            + self.tags.len()
+            + self.hint.len()
+            + self.description.len()
+            + self.tool_names.len()
+            + self.tool_descriptions.len()
+            + self.dcc.len()
+    }
+
+    /// Build from a `SkillMetadata`. Includes sibling `tools.yaml` content
+    /// (available via `metadata.tools`) — see #356.
+    pub fn from_metadata(meta: &SkillMetadata) -> Self {
+        let hint_source = if meta.search_hint.is_empty() {
+            meta.description.as_str()
+        } else {
+            meta.search_hint.as_str()
+        };
+
+        let mut tool_names = Vec::new();
+        let mut tool_descriptions = Vec::new();
+        for t in &meta.tools {
+            tool_names.extend(tokenize(&t.name));
+            tool_descriptions.extend(tokenize(&t.description));
+        }
+
+        let mut tag_tokens = Vec::new();
+        for tag in &meta.tags {
+            tag_tokens.extend(tokenize(tag));
+        }
+
+        Self {
+            name: tokenize(&meta.name),
+            tags: tag_tokens,
+            hint: tokenize(hint_source),
+            description: tokenize(&meta.description),
+            tool_names,
+            tool_descriptions,
+            dcc: tokenize(&meta.dcc),
+        }
+    }
+}
+
+fn count_occurrences(field: &[String], token: &str) -> usize {
+    field.iter().filter(|t| t.as_str() == token).count()
+}
+
+/// Inverse document frequency (BM25 form, clamped at 0).
+fn idf(total_docs: usize, df: usize) -> f64 {
+    let n = total_docs as f64;
+    let df_f = df as f64;
+    let v = ((n - df_f + 0.5) / (df_f + 0.5) + 1.0).ln();
+    if v < 0.0 { 0.0 } else { v }
+}
+
+fn field_bm25(f: usize, dl: usize, avgdl: f64) -> f64 {
+    if f == 0 {
+        return 0.0;
+    }
+    let f_f = f as f64;
+    let dl_f = dl as f64;
+    let denom = f_f + K1 * (1.0 - B + B * (dl_f / avgdl.max(1.0)));
+    (f_f * (K1 + 1.0)) / denom
+}
+
+/// Scored skill reference: index into the input slice + score + tie-break
+/// auxiliaries.
+#[derive(Debug, Clone)]
+pub struct Scored {
+    pub index: usize,
+    pub score: f64,
+    /// True if `name` contains the (raw, lowercased) query as a substring —
+    /// primary tie-break after score equality.
+    pub name_substring_hit: bool,
+    /// Scope (for tie-break 2).
+    pub scope: SkillScope,
+    /// Skill name (for alphabetical tie-break 3).
+    pub name: String,
+    /// True if the query equals the skill name case-insensitively — forces
+    /// this result to the top regardless of BM25 output.
+    pub exact_name: bool,
+}
+
+/// Score a collection of skills against a query string.
+///
+/// Returns a `Vec<Scored>` sorted by relevance descending, with the full
+/// tie-break chain applied. Skills with score `0.0` are dropped (unless they
+/// are an exact-name match, which short-circuits to the top).
+///
+/// The `scopes` slice must be the same length as `skills` and provide the
+/// scope for each skill (catalog holds scopes on `SkillEntry`, not on
+/// `SkillMetadata`).
+pub fn score_skills(query: &str, skills: &[&SkillMetadata], scopes: &[SkillScope]) -> Vec<Scored> {
+    assert_eq!(
+        skills.len(),
+        scopes.len(),
+        "skills and scopes slices must be the same length"
+    );
+
+    let tokens = tokenize(query);
+    let q_trim_lower = query.trim().to_lowercase();
+    let q_raw_lower = query.to_lowercase();
+
+    // Pre-compute field tokens and document lengths.
+    let fields: Vec<FieldTokens> = skills
+        .iter()
+        .map(|m| FieldTokens::from_metadata(m))
+        .collect();
+    let doc_lens: Vec<usize> = fields.iter().map(|f| f.doc_len()).collect();
+
+    let total_docs = skills.len();
+    let avgdl: f64 = if total_docs == 0 {
+        1.0
+    } else {
+        doc_lens.iter().sum::<usize>() as f64 / total_docs as f64
+    };
+
+    // For each query token, count document frequency (how many docs contain
+    // the token anywhere across weighted fields). Used for IDF.
+    let df_per_token: Vec<usize> = tokens
+        .iter()
+        .map(|q| {
+            fields
+                .iter()
+                .filter(|f| {
+                    count_occurrences(&f.name, q) > 0
+                        || count_occurrences(&f.tags, q) > 0
+                        || count_occurrences(&f.hint, q) > 0
+                        || count_occurrences(&f.description, q) > 0
+                        || count_occurrences(&f.tool_names, q) > 0
+                        || count_occurrences(&f.tool_descriptions, q) > 0
+                        || count_occurrences(&f.dcc, q) > 0
+                })
+                .count()
+        })
+        .collect();
+
+    let mut scored: Vec<Scored> = Vec::with_capacity(skills.len());
+    for (i, (meta, fields_i)) in skills.iter().zip(fields.iter()).enumerate() {
+        let dl = doc_lens[i];
+        let mut total = 0.0_f64;
+
+        for (q_idx, q) in tokens.iter().enumerate() {
+            let idf_v = idf(total_docs, df_per_token[q_idx]);
+            if idf_v == 0.0 {
+                continue;
+            }
+            let contrib = W_NAME * field_bm25(count_occurrences(&fields_i.name, q), dl, avgdl)
+                + W_TAGS * field_bm25(count_occurrences(&fields_i.tags, q), dl, avgdl)
+                + W_HINT * field_bm25(count_occurrences(&fields_i.hint, q), dl, avgdl)
+                + W_DESCRIPTION
+                    * field_bm25(count_occurrences(&fields_i.description, q), dl, avgdl)
+                + W_TOOL_NAME * field_bm25(count_occurrences(&fields_i.tool_names, q), dl, avgdl)
+                + W_TOOL_DESCRIPTION
+                    * field_bm25(count_occurrences(&fields_i.tool_descriptions, q), dl, avgdl)
+                + W_DCC * field_bm25(count_occurrences(&fields_i.dcc, q), dl, avgdl);
+            total += idf_v * contrib;
+        }
+
+        let name_lower = meta.name.to_lowercase();
+        let exact_name = name_lower == q_trim_lower && !q_trim_lower.is_empty();
+        let name_substring_hit = !q_raw_lower.is_empty() && name_lower.contains(&q_raw_lower);
+
+        if total == 0.0 && !exact_name {
+            continue;
+        }
+
+        scored.push(Scored {
+            index: i,
+            score: total,
+            name_substring_hit,
+            scope: scopes[i],
+            name: meta.name.clone(),
+            exact_name,
+        });
+    }
+
+    // Deterministic sort with full tie-break chain.
+    scored.sort_by(|a, b| {
+        // 0. Exact-name fast-path.
+        match (a.exact_name, b.exact_name) {
+            (true, false) => return std::cmp::Ordering::Less,
+            (false, true) => return std::cmp::Ordering::Greater,
+            _ => {}
+        }
+        // 1. Higher score first.
+        match b
+            .score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+        {
+            std::cmp::Ordering::Equal => {}
+            ord => return ord,
+        }
+        // 2. Exact name-substring hit wins.
+        match (a.name_substring_hit, b.name_substring_hit) {
+            (true, false) => return std::cmp::Ordering::Less,
+            (false, true) => return std::cmp::Ordering::Greater,
+            _ => {}
+        }
+        // 3. Scope precedence: Admin > System > User > Repo.
+        match b.scope.cmp(&a.scope) {
+            std::cmp::Ordering::Equal => {}
+            ord => return ord,
+        }
+        // 4. Alphabetical name.
+        a.name.cmp(&b.name)
+    });
+
+    scored
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dcc_mcp_models::ToolDeclaration;
+
+    fn mk(name: &str) -> SkillMetadata {
+        SkillMetadata {
+            name: name.to_string(),
+            description: String::new(),
+            dcc: String::new(),
+            version: "1.0.0".to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn mk_full(
+        name: &str,
+        desc: &str,
+        hint: &str,
+        tags: &[&str],
+        dcc: &str,
+        tools: &[(&str, &str)],
+    ) -> SkillMetadata {
+        SkillMetadata {
+            name: name.to_string(),
+            description: desc.to_string(),
+            search_hint: hint.to_string(),
+            tags: tags.iter().map(|s| s.to_string()).collect(),
+            dcc: dcc.to_string(),
+            version: "1.0.0".to_string(),
+            tools: tools
+                .iter()
+                .map(|(n, d)| ToolDeclaration {
+                    name: n.to_string(),
+                    description: d.to_string(),
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    // ── tokeniser ──
+
+    #[test]
+    fn test_tokenize_basic() {
+        assert_eq!(
+            tokenize("Polygon Bevel"),
+            vec!["polygon".to_string(), "bevel".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_tokenize_punct_and_separators() {
+        assert_eq!(
+            tokenize("maya-geometry.create_sphere/tool"),
+            vec![
+                "maya".to_string(),
+                "geometry".to_string(),
+                "create".to_string(),
+                "sphere".to_string(),
+                "tool".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_tokenize_stopwords_dropped() {
+        assert_eq!(
+            tokenize("a list of the tools for maya"),
+            vec!["list".to_string(), "tools".to_string(), "maya".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_tokenize_empty_and_stopword_only() {
+        assert!(tokenize("").is_empty());
+        assert!(tokenize("the of and or").is_empty());
+    }
+
+    // ── scorer ──
+
+    #[test]
+    fn test_exact_name_fast_path() {
+        let a = mk_full(
+            "maya-geometry",
+            "Tons of sphere bevel keywords sphere bevel sphere bevel",
+            "sphere bevel sphere bevel",
+            &["sphere", "bevel"],
+            "maya",
+            &[("sphere", "create a sphere"), ("bevel", "bevel edges")],
+        );
+        let b = mk("sphere");
+        let skills = vec![&a, &b];
+        let scopes = vec![SkillScope::Repo, SkillScope::Repo];
+        let out = score_skills("sphere", &skills, &scopes);
+        assert!(!out.is_empty());
+        assert_eq!(out[0].name, "sphere", "exact-name match must rank first");
+    }
+
+    #[test]
+    fn test_prefix_only_no_match() {
+        // BM25 is token-based — "poly" should NOT match "polygon" without stemming.
+        let a = mk_full("polygon-tools", "polygon modelling", "", &[], "maya", &[]);
+        let skills = vec![&a];
+        let scopes = vec![SkillScope::Repo];
+        let out = score_skills("poly", &skills, &scopes);
+        assert!(
+            out.is_empty(),
+            "prefix-only queries must not match without stemming"
+        );
+    }
+
+    #[test]
+    fn test_tag_hit() {
+        let a = mk_full("alpha", "", "", &["rigging"], "maya", &[]);
+        let b = mk_full("beta", "something else entirely", "", &[], "maya", &[]);
+        let skills = vec![&a, &b];
+        let scopes = vec![SkillScope::Repo, SkillScope::Repo];
+        let out = score_skills("rigging", &skills, &scopes);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].name, "alpha");
+    }
+
+    #[test]
+    fn test_description_hit() {
+        let a = mk_full("alpha", "handles character animation", "", &[], "maya", &[]);
+        let b = mk_full("beta", "handles rendering", "", &[], "maya", &[]);
+        let skills = vec![&a, &b];
+        let scopes = vec![SkillScope::Repo, SkillScope::Repo];
+        let out = score_skills("animation", &skills, &scopes);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].name, "alpha");
+    }
+
+    #[test]
+    fn test_sibling_tool_hit() {
+        // Skill whose skill-level fields do NOT mention "turntable" but whose
+        // sibling tools.yaml tool does — must still rank via sibling expansion.
+        let a = mk_full(
+            "scene-utils",
+            "scene helpers",
+            "",
+            &[],
+            "maya",
+            &[("turntable", "create a turntable camera")],
+        );
+        let b = mk_full("other", "unrelated stuff", "", &[], "maya", &[]);
+        let skills = vec![&a, &b];
+        let scopes = vec![SkillScope::Repo, SkillScope::Repo];
+        let out = score_skills("turntable", &skills, &scopes);
+        assert_eq!(out.len(), 1, "sibling tool name must be scorable");
+        assert_eq!(out[0].name, "scene-utils");
+    }
+
+    #[test]
+    fn test_stopword_only_query() {
+        let a = mk_full("alpha", "stuff", "", &[], "maya", &[]);
+        let skills = vec![&a];
+        let scopes = vec![SkillScope::Repo];
+        let out = score_skills("the of and", &skills, &scopes);
+        assert!(out.is_empty(), "stopword-only queries must yield no hits");
+    }
+
+    #[test]
+    fn test_empty_query() {
+        let a = mk("alpha");
+        let skills = vec![&a];
+        let scopes = vec![SkillScope::Repo];
+        let out = score_skills("", &skills, &scopes);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn test_multi_token_query_ordering() {
+        // "polygon bevel" — skill with both tokens should beat skill with one.
+        let both = mk_full(
+            "polygon-bevel",
+            "bevels polygon edges",
+            "polygon bevel",
+            &[],
+            "maya",
+            &[],
+        );
+        let one = mk_full(
+            "polygon-only",
+            "polygon modelling helpers",
+            "",
+            &[],
+            "maya",
+            &[],
+        );
+        let skills = vec![&one, &both];
+        let scopes = vec![SkillScope::Repo, SkillScope::Repo];
+        let out = score_skills("polygon bevel", &skills, &scopes);
+        assert_eq!(out[0].name, "polygon-bevel");
+    }
+
+    #[test]
+    fn test_scope_tiebreak() {
+        // Two skills with identical content — higher scope wins.
+        let a = mk_full("alpha", "renderer thing", "", &[], "maya", &[]);
+        let b = mk_full("beta", "renderer thing", "", &[], "maya", &[]);
+        let skills = vec![&a, &b];
+        let scopes = vec![SkillScope::Repo, SkillScope::Admin];
+        let out = score_skills("renderer", &skills, &scopes);
+        assert_eq!(out.len(), 2);
+        assert_eq!(
+            out[0].name, "beta",
+            "Admin scope must outrank Repo scope at equal score"
+        );
+    }
+
+    #[test]
+    fn test_dcc_exact_token() {
+        // "maya" appears in dcc field of one skill only.
+        let a = mk_full("alpha", "renderer thing", "", &[], "maya", &[]);
+        let b = mk_full("beta", "renderer thing", "", &[], "blender", &[]);
+        let skills = vec![&a, &b];
+        let scopes = vec![SkillScope::Repo, SkillScope::Repo];
+        let out = score_skills("maya", &skills, &scopes);
+        assert_eq!(out[0].name, "alpha", "dcc token boost must apply");
+    }
+
+    #[test]
+    fn test_deterministic_ordering() {
+        // Two fully-equivalent skills — fall through to alphabetical name.
+        let a = mk_full("zzz", "renderer thing", "", &[], "maya", &[]);
+        let b = mk_full("aaa", "renderer thing", "", &[], "maya", &[]);
+        let skills = vec![&a, &b];
+        let scopes = vec![SkillScope::Repo, SkillScope::Repo];
+        let out = score_skills("renderer", &skills, &scopes);
+        assert_eq!(out[0].name, "aaa");
+        assert_eq!(out[1].name, "zzz");
+    }
+}

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -553,7 +553,48 @@ Calling an unloaded skill stub (`__skill__<name>`) returns an error with a hint:
 }
 ```
 
-Searches across: `name`, `description`, `search_hint`, and `tool_names`. The `search_hint` field (from SKILL.md `search-hint:`) improves keyword matching without loading full schemas.
+Searches across: `name`, `description`, `search_hint`, `tags`, `dcc`, and the
+sibling `tools.yaml` entries (`name` + `description`). The `search_hint` field
+(from SKILL.md `search-hint:`) improves keyword matching without loading full
+schemas.
+
+#### How `search_skills` ranks results
+
+Since dcc-mcp-core 0.15 (issue [#343](https://github.com/loonghao/dcc-mcp-core/issues/343))
+the ranker is a tokenised BM25-lite scorer. It is deterministic — the same
+skill set + query always yields the same order.
+
+**Tokeniser** — lowercase, split on `[\s_\-.,;:/]+`, drop a small stopword
+list (`a, an, the, of, and, or, to, for, with, from`). No stemming, no
+fuzzy match.
+
+**Field weights**
+
+| Field | Weight |
+|-------|-------:|
+| `name`                                   | 5.0 |
+| `dcc` (exact token match only)           | 4.0 |
+| `tags`                                   | 3.0 |
+| `search_hint`                            | 3.0 |
+| `description`                            | 2.0 |
+| sibling tool names (from `tools.yaml`)   | 2.0 |
+| sibling tool descriptions                | 1.0 |
+
+**Scoring** — standard BM25 per query token with `k1=1.2`, `b=0.75`, document
+length = total tokens across all weighted fields. The per-field contributions
+are multiplied by the weights above and summed across query tokens.
+
+**Tie-breaks** (in order)
+
+1. **Exact-name fast-path** — if the query equals a skill's name
+   (case-insensitive, after trimming), that skill sorts first unconditionally.
+2. **Name-substring hit** — skills whose `name` contains the query as a
+   raw substring rank above equal-scoring skills that don't.
+3. **Scope precedence** — `Admin > System > User > Repo`.
+4. **Alphabetical name**.
+
+Skills with a total score of `0.0` (and no exact-name match) are dropped.
+The `tags` and `dcc` filter arguments are applied *before* scoring.
 
 `create_skill_server()` only calls `discover()` at startup — skills are **not** automatically loaded. This keeps the initial tool list small and lets agents load only what they need.
 

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -1513,15 +1513,26 @@ class SkillCatalog:
         tags: list[str] | None = None,
         dcc: str | None = None,
     ) -> list[SkillSummary]:
-        """Search the catalog by name, tags, or DCC.
+        """Search the catalog by keyword, tags, or DCC.
+
+        The ``tags`` and ``dcc`` filters are applied first (AND semantics).
+        Remaining skills are then ranked with a tokenised BM25-lite scorer
+        when ``query`` is non-empty, weighting matches across name / tags /
+        search_hint / description / sibling ``tools.yaml`` entries / dcc.
+        An exact (case-insensitive) match on skill name always ranks first.
+
+        When ``query`` is ``None`` or empty, results are returned in a
+        deterministic order (scope descending, then alphabetical name).
 
         Args:
-            query: Case-insensitive substring match on skill name/description.
+            query: Keyword search — tokenised on whitespace/punctuation,
+                   stopwords dropped, no stemming or fuzzy match.
             tags:  Return only skills that have ALL of the given tags.
             dcc:   Return only skills targeting this DCC.
 
         Returns:
-            List of :class:`SkillSummary` matching all supplied filters.
+            List of :class:`SkillSummary` matching all supplied filters,
+            sorted by relevance descending.
 
         """
         ...

--- a/tests/test_mcp_protocols_telemetry_capturer_catalog_deep.py
+++ b/tests/test_mcp_protocols_telemetry_capturer_catalog_deep.py
@@ -1068,7 +1068,9 @@ class TestSkillCatalog:
         reg = m.ToolRegistry()
         cat = m.SkillCatalog(reg)
         cat.discover(extra_paths=[EXAMPLES_SKILLS_DIR])
-        found = cat.find_skills(query="zzz_no_such_skill_zzz")
+        # The tokeniser splits on `_`, so use a single contiguous nonsense
+        # token to confirm truly-unmatched queries return no results.
+        found = cat.find_skills(query="zzznosuchskillzzz")
         assert found == []
 
     def test_info_has_state_key(self):

--- a/tests/test_search_skills_scoring.py
+++ b/tests/test_search_skills_scoring.py
@@ -1,0 +1,171 @@
+"""Integration tests for the BM25-lite ranker powering ``search_skills``.
+
+Issue #343 — `SkillCatalog.find_skills` (the function backing the
+``search_skills`` MCP tool) now tokenises the query, drops stopwords,
+weights matches across skill-level fields AND sibling ``tools.yaml``
+entries, and sorts results deterministically.
+
+These tests exercise a synthetic fixture skill set and assert the
+resulting ORDER of results.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dcc_mcp_core import SkillCatalog
+from dcc_mcp_core import ToolRegistry
+
+# ---------------------------------------------------------------------------
+# Fixture builder
+# ---------------------------------------------------------------------------
+
+
+def _write_skill(
+    root: Path,
+    name: str,
+    *,
+    description: str = "",
+    tags: list[str] | None = None,
+    dcc: str = "maya",
+    search_hint: str = "",
+    tools_yaml: str | None = None,
+) -> None:
+    """Create a SKILL.md directory (with optional sibling tools.yaml)."""
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+
+    tags_block = "tags: []\n" if not tags else "tags:\n" + "".join(f"  - {t}\n" for t in tags)
+    hint_line = f'search-hint: "{search_hint}"\n' if search_hint else ""
+    tools_meta = (
+        "metadata:\n  dcc-mcp.dcc: " + dcc + "\n  dcc-mcp.tools: tools.yaml\n" if tools_yaml is not None else ""
+    )
+    body = (
+        f"---\n"
+        f"name: {name}\n"
+        f"version: 1.0.0\n"
+        f'description: "{description}"\n'
+        f"dcc: {dcc}\n"
+        f"{tags_block}"
+        f"{hint_line}"
+        f"{tools_meta}"
+        f"---\n\n# {name}\n"
+    )
+    (skill_dir / "SKILL.md").write_text(body, encoding="utf-8")
+
+    if tools_yaml is not None:
+        (skill_dir / "tools.yaml").write_text(tools_yaml, encoding="utf-8")
+
+
+@pytest.fixture
+def catalog(tmp_path: Path) -> SkillCatalog:
+    """Build a catalog populated with a deliberately ambiguous skill set.
+
+    Skills are designed so that several naive matchers would produce
+    different orderings; the BM25-lite scorer must still produce the
+    deterministic expected order for the assertions below.
+    """
+    # 1. skill whose NAME is exactly "polygon-bevel" — should win on
+    #    exact-name fast path when queried by its name.
+    _write_skill(
+        tmp_path,
+        "polygon-bevel",
+        description="Bevels polygon edges cleanly.",
+        tags=["modeling", "polygon"],
+        dcc="maya",
+        search_hint="polygon bevel edge chamfer",
+    )
+
+    # 2. description-only mention of polygon, with no tool, no hint.
+    _write_skill(
+        tmp_path,
+        "misc-utils",
+        description="Miscellaneous utilities for polygon cleanup.",
+        tags=["utility"],
+        dcc="maya",
+    )
+
+    # 3. skill whose SKILL.md does NOT mention "turntable" at all, but
+    #    whose sibling tools.yaml declares a `turntable` tool — sibling
+    #    expansion must make it scorable.
+    _write_skill(
+        tmp_path,
+        "camera-helpers",
+        description="Helpers for cinematic shots.",
+        tags=["camera"],
+        dcc="maya",
+        tools_yaml=(
+            "tools:\n"
+            "  - name: turntable\n"
+            "    description: Create a turntable camera rig.\n"
+            "  - name: dolly_in\n"
+            "    description: Animate a simple dolly-in move.\n"
+        ),
+    )
+
+    # 4. blender skill — used to exercise the dcc filter + scope.
+    _write_skill(
+        tmp_path,
+        "render-utils",
+        description="Rendering helpers for Blender.",
+        tags=["render"],
+        dcc="blender",
+    )
+
+    reg = ToolRegistry()
+    cat = SkillCatalog(reg)
+    discovered = cat.discover(extra_paths=[str(tmp_path)])
+    assert discovered >= 4, f"expected >=4 skills, got {discovered}"
+    return cat
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_exact_name_ranks_first(catalog: SkillCatalog) -> None:
+    """Querying the exact skill name places it first, regardless of
+    other skills with more matching fields.
+    """
+    results = catalog.find_skills(query="polygon-bevel")
+    assert results, "expected at least one result"
+    assert results[0].name == "polygon-bevel"
+
+
+def test_sibling_tools_yaml_contributes_to_score(catalog: SkillCatalog) -> None:
+    """A skill whose only mention of the query is in its sibling
+    tools.yaml must still appear in search results (#343 + #356).
+    """
+    results = catalog.find_skills(query="turntable")
+    names = [r.name for r in results]
+    assert "camera-helpers" in names, f"sibling tools.yaml entry must make skill scorable, got {names}"
+    assert results[0].name == "camera-helpers"
+
+
+def test_multi_token_query_prefers_skill_matching_all_tokens(
+    catalog: SkillCatalog,
+) -> None:
+    """A multi-token query favours the skill that hits on more tokens."""
+    results = catalog.find_skills(query="polygon bevel")
+    assert results
+    # `polygon-bevel` has both tokens in name + tags + hint; `misc-utils`
+    # only has `polygon` in description.
+    assert results[0].name == "polygon-bevel"
+
+
+def test_stopword_only_query_returns_nothing(catalog: SkillCatalog) -> None:
+    """`the of and` contains only stopwords — no skill should rank."""
+    results = catalog.find_skills(query="the of and")
+    assert results == [], "stopword-only query must return no results"
+
+
+def test_dcc_filter_applied_before_scoring(catalog: SkillCatalog) -> None:
+    """The `dcc` pre-filter excludes skills for other DCCs before the
+    scorer runs — a maya-only query must not surface blender skills.
+    """
+    results = catalog.find_skills(query="render", dcc="maya")
+    names = [r.name for r in results]
+    assert "render-utils" not in names, f"blender skill must be filtered out, got {names}"


### PR DESCRIPTION
## Summary

Replaces the naive substring matcher in `SkillCatalog::find_skills`
(the function backing the `search_skills` MCP tool) with a deterministic
BM25-lite scorer.

- **Tokenisation**: lowercase, split on `[\s_\-.,;:/]+`, drop a small
  stopword list (`a, an, the, of, and, or, to, for, with, from`). No
  stemming, no fuzzy match — all ordering is deterministic.
- **Field weights**: `name` 5.0 · `dcc` 4.0 · `tags` 3.0 · `search_hint`
  3.0 · `description` 2.0 · sibling tool names 2.0 · sibling tool
  descriptions 1.0.
- **BM25**: `k1=1.2`, `b=0.75`, per-token contributions summed across
  fields and query tokens.
- **Exact-name fast path**: if the query equals a skill's name
  (case-insensitive, trimmed), that skill sorts first unconditionally —
  preserves `find_skills`-style "I know the name" behaviour.
- **Ties** break on (1) name-substring hit → (2) scope precedence
  (Admin > System > User > Repo) → (3) alphabetical name.
- **Sibling `tools.yaml` expansion**: tool `name` + `description` pulled
  from `SkillMetadata.tools` (already cached by the scanner after #356)
  contribute to the score.
- **No public API changes** — `find_skills(query, tags, dcc)` signature
  is preserved so #340's unified `search_skills` can sit cleanly on top.
  The internal ranker change alone fulfils #343.

Closes #343.

## Test plan

- [x] `vx just preflight` — green (workspace cargo check + clippy + fmt
      + rust tests).
- [x] `vx just dev && python -m pytest tests/` — 8186 passed, 0 failed.
- [x] New Rust unit tests in `crates/dcc-mcp-skills/src/catalog/scoring.rs`
      cover: tokeniser (basic, punctuation, stopwords, empty/stopword-only),
      exact-name fast path, prefix-only non-match (no stemming), tag hit,
      description hit, sibling-tool hit, stopword-only query, empty query,
      multi-token ordering, scope tie-break, dcc-token boost, alphabetical
      deterministic fallback. (13 new tests — exceeds the 8-case minimum.)
- [x] New Python integration test `tests/test_search_skills_scoring.py`
      builds a synthetic fixture skill set and asserts result order for
      five representative queries:
      exact-name, sibling-tool-only, multi-token, stopword-only, and
      dcc-pre-filter.
- [x] One pre-existing test
      (`test_find_skills_no_match_empty`) used a token-splittable
      nonsense query (`zzz_no_such_skill_zzz`) that the old substring
      matcher returned empty for; replaced with a single contiguous
      nonsense token (`zzznosuchskillzzz`) that the new tokeniser also
      can't match. This is a deliberate behaviour change — multi-token
      queries now tokenise, which is the whole point of #343.

## Notable decisions

- **No stemming / fuzzy match / synonyms** — issue #343 lists these as
  explicit non-goals. The scorer intentionally does not match `poly` →
  `polygon`; an included unit test (`test_prefix_only_no_match`) locks
  this behaviour in.
- **Scope tie-break via `Reverse`-style compare** — `SkillScope`'s
  existing `Ord` impl places `Repo < User < System < Admin`, so the
  tie-break uses `b.scope.cmp(&a.scope)` to put Admin first.
- **Empty / stopword-only queries short-circuit with a deterministic
  scope/name sort** before reaching the scorer, so `find_skills(None)`
  doesn't surface `DashMap` iteration order.
- **Pre-filter runs before scoring** — tags / dcc exclusions happen in
  a first pass so the BM25 document-frequency counts only reflect the
  eligible skill set.
