### PR TITLE
feat(http): jobs.get_status built-in tool (#319)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,7 @@ Need to interact with DCC?
 
 **Reacting to job / workflow lifecycle events on an MCP client?**
 → SSE channels: `notifications/progress` (spec, fires when `_meta.progressToken` is present), `notifications/$/dcc.jobUpdated`, `notifications/$/dcc.workflowUpdated` (both gated by `McpHttpConfig.enable_job_notifications`, default `True`) — see [`docs/api/http.md`](docs/api/http.md) §"Job lifecycle notifications" (#326).
+→ Polling alternative: call built-in tool **`jobs.get_status`** (#319) — returns the same envelope (`job_id`, `parent_job_id`, `tool`, `status`, timestamps, `progress`, `error`, optional `result`) via `tools/call`. Always listed in `tools/list`, SEP-986 compliant.
 
 **Exposing live DCC state (scene, window capture, audit log) to MCP clients?**
 → [`docs/api/resources.md`](docs/api/resources.md) — Resources primitive (#350)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,7 +299,7 @@ When building tools or interacting with DCCs, follow this priority order:
 
 1. **Skill Discovery** (start here): `search_skills(query)` → `load_skill(name)` → use skill tools
 2. **Skill-Based Tools** (preferred): Tools with validated schemas, error handling, `next-tools` guidance, and `ToolAnnotations` safety hints
-3. **Diagnostics Tools** (for verification): `diagnostics__screenshot`, `diagnostics__audit_log`, `diagnostics__process_status`
+3. **Diagnostics Tools** (for verification): `diagnostics__screenshot`, `diagnostics__audit_log`, `diagnostics__process_status`, and — as a polling fallback when you can't subscribe to the `$/dcc.jobUpdated` SSE channel — **`jobs.get_status`** (#319, always registered, returns the full job-state envelope for a given `job_id`).
 4. **Direct Registry Access** (last resort): Only when no skill tool covers the operation; must validate with `ToolValidator` and sandbox with `SandboxPolicy`
 
 **Why skills first?** Safety (annotations), discoverability (search-hint), chainability (next-tools), progressive exposure (tool groups), validation (input_schema).

--- a/_commit_msg_319.txt
+++ b/_commit_msg_319.txt
@@ -1,0 +1,31 @@
+feat(http): add jobs.get_status built-in tool for job polling (#319)
+
+SEP-986-compliant built-in tool (validated via `validate_tool_name` at
+build time — panics early if the naming regex ever stops accepting the
+name) exposing the JobManager lifecycle envelope over `tools/call`.
+Returns `job_id`, `parent_job_id`, `tool`, `status`, timestamps,
+`progress`, `error`, and — when the job is terminal and
+`include_result=true` — the final ToolResult. Marked
+`read_only_hint=true` + `idempotent_hint=true` via ToolAnnotations.
+
+Complements the `$/dcc.jobUpdated` SSE channel from #326 for clients
+that prefer polling. Always present in `tools/list`, regardless of
+loaded skills. Unknown job ids produce a `CallToolResult { isError:
+true, content: [...] }` — never a JSON-RPC transport error — naming
+the missing id.
+
+`include_logs=true` is accepted for forward compatibility but is
+currently a no-op (JobManager does not capture stdout/stderr); a
+`tracing::debug!` breadcrumb documents the reality.
+
+Tests:
+- `crates/dcc-mcp-http/tests/jobs_get_status.rs` — SEP-986 name check,
+  envelope shape, all six JobStatus serde variants.
+- `crates/dcc-mcp-http/src/tests.rs` — tools/list visibility, unknown
+  id error envelope, missing-param error, running/terminal envelope
+  with/without result.
+- `tests/test_jobs_get_status.py` — end-to-end: tools/list visibility,
+  unknown id, async dispatch -> poll -> completed with result, and
+  include_result=false omission.
+
+Closes #319

--- a/crates/dcc-mcp-http/src/handler.rs
+++ b/crates/dcc-mcp-http/src/handler.rs
@@ -1003,6 +1003,9 @@ async fn handle_tools_call_inner(
             return handle_deactivate_tool_group(state, req, &params, session_id).await;
         }
         "search_tools" => return handle_search_tools(state, req, &params).await,
+        // #319 — built-in job polling tool. Always available, regardless of
+        // which skills are loaded or whether any jobs exist.
+        "jobs.get_status" => return handle_jobs_get_status(state, req, &params).await,
         // #254 — lazy-actions fast-path (opt-in).
         "list_actions" if state.lazy_actions => {
             return handle_list_actions(state, req, &params).await;
@@ -2290,6 +2293,66 @@ fn build_core_tools_inner() -> Vec<McpTool> {
             }),
             meta: None,
         },
+        // `jobs.get_status` — built-in job-polling tool (#319).
+        //
+        // Complements the `$/dcc.jobUpdated` SSE channel (#326) for clients
+        // that prefer request/response polling over a long-lived stream.
+        // SEP-986 compliant: the dot-separated `jobs.*` namespace is the
+        // reserved built-in prefix (see `docs/guide/naming.md`). We panic
+        // at first build if the regex or the length cap ever rejects this
+        // name — that would be a dcc-mcp-naming regression and we want to
+        // catch it loudly.
+        {
+            const TOOL_NAME: &str = "jobs.get_status";
+            if let Err(e) = dcc_mcp_naming::validate_tool_name(TOOL_NAME) {
+                panic!("built-in tool name `{TOOL_NAME}` fails SEP-986 validation: {e}");
+            }
+            McpTool {
+                name: TOOL_NAME.to_string(),
+                description: "Poll the status of an async tool-call job tracked by JobManager. \
+                              Returns a JSON envelope with job_id, parent_job_id, tool, status \
+                              (pending|running|completed|failed|cancelled|interrupted), timestamps, \
+                              progress, error, and optionally the final ToolResult once the job \
+                              is terminal. Complements the `$/dcc.jobUpdated` SSE channel (#326) \
+                              for polling-based clients. Returns isError=true with a human-readable \
+                              message when the job id is unknown (never a JSON-RPC transport error)."
+                    .to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "job_id": {
+                            "type": "string",
+                            "description": "UUID of the job to query"
+                        },
+                        "include_logs": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Include captured stdout/stderr if any. \
+                                            Currently a no-op — JobManager does not capture logs; \
+                                            the flag is accepted for forward compatibility."
+                        },
+                        "include_result": {
+                            "type": "boolean",
+                            "default": true,
+                            "description": "Include the job's final ToolResult when the job is \
+                                            in a terminal state (completed/failed). Ignored for \
+                                            pending/running jobs since no result exists yet."
+                        }
+                    },
+                    "required": ["job_id"]
+                }),
+                output_schema: None,
+                annotations: Some(McpToolAnnotations {
+                    title: Some("Get Job Status".to_string()),
+                    read_only_hint: Some(true),
+                    destructive_hint: Some(false),
+                    idempotent_hint: Some(true),
+                    open_world_hint: Some(false),
+                    deferred_hint: Some(false),
+                }),
+                meta: None,
+            }
+        },
     ]
 }
 
@@ -2811,6 +2874,168 @@ async fn handle_search_tools(
         req.id.clone(),
         serde_json::to_value(CallToolResult::text(serde_json::to_string(&result)?))?,
     ))
+}
+
+// ── Built-in `jobs.get_status` (#319) ─────────────────────────────────────
+
+/// Handle ``jobs.get_status`` — poll a tracked job's lifecycle state.
+///
+/// Returns the standard status envelope — ``{job_id, parent_job_id, tool,
+/// status, created_at, started_at, completed_at, progress, error, result}``
+/// — mirroring the field names emitted on the ``$/dcc.jobUpdated`` SSE
+/// channel (#326) so clients can mix polling and streaming freely.
+///
+/// Semantics:
+///
+/// * Missing / empty ``job_id`` → ``isError=true`` with a human-readable
+///   message (still a valid ``CallToolResult``, never a JSON-RPC error).
+/// * Unknown ``job_id`` → ``isError=true`` naming the bad id.
+/// * ``include_result=false`` or job not terminal → ``result`` is omitted.
+/// * ``include_logs=true`` is accepted for forward compatibility —
+///   ``JobManager`` does not currently capture per-job stdout/stderr, so
+///   the flag is a no-op and a ``tracing::debug!`` breadcrumb is emitted.
+async fn handle_jobs_get_status(
+    state: &AppState,
+    req: &JsonRpcRequest,
+    params: &CallToolParams,
+) -> Result<JsonRpcResponse, HttpError> {
+    let args = params.arguments.as_ref();
+    let job_id = args
+        .and_then(|a| a.get("job_id"))
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim();
+    if job_id.is_empty() {
+        return Ok(JsonRpcResponse::success(
+            req.id.clone(),
+            serde_json::to_value(CallToolResult::error(
+                "Missing required parameter: job_id".to_string(),
+            ))?,
+        ));
+    }
+    let include_logs = args
+        .and_then(|a| a.get("include_logs"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let include_result = args
+        .and_then(|a| a.get("include_result"))
+        .and_then(Value::as_bool)
+        .unwrap_or(true);
+
+    if include_logs {
+        // #319: accepted for forward-compat. JobManager does not capture
+        // stdout/stderr today; document the reality instead of silently
+        // pretending to honour the flag.
+        tracing::debug!(
+            job_id = %job_id,
+            "jobs.get_status received include_logs=true — no-op, JobManager does not capture logs"
+        );
+    }
+
+    let Some(entry) = state.jobs.get(job_id) else {
+        return Ok(JsonRpcResponse::success(
+            req.id.clone(),
+            serde_json::to_value(CallToolResult::error(format!(
+                "No job found with id '{job_id}'"
+            )))?,
+        ));
+    };
+    let job = entry.read();
+
+    // Build the envelope. Field order / names mirror `$/dcc.jobUpdated`
+    // (see `notifications.rs`) so polling clients see the same shape as
+    // streaming subscribers.
+    let (started_at, completed_at) = compute_job_timestamps(&job);
+    let mut envelope = serde_json::Map::new();
+    envelope.insert("job_id".into(), Value::String(job.id.clone()));
+    envelope.insert(
+        "parent_job_id".into(),
+        match &job.parent_job_id {
+            Some(p) => Value::String(p.clone()),
+            None => Value::Null,
+        },
+    );
+    envelope.insert("tool".into(), Value::String(job.tool_name.clone()));
+    envelope.insert(
+        "status".into(),
+        serde_json::to_value(job.status).unwrap_or(Value::Null),
+    );
+    envelope.insert(
+        "created_at".into(),
+        Value::String(job.created_at.to_rfc3339()),
+    );
+    envelope.insert(
+        "started_at".into(),
+        started_at
+            .map(|t| Value::String(t.to_rfc3339()))
+            .unwrap_or(Value::Null),
+    );
+    envelope.insert(
+        "completed_at".into(),
+        completed_at
+            .map(|t| Value::String(t.to_rfc3339()))
+            .unwrap_or(Value::Null),
+    );
+    envelope.insert(
+        "updated_at".into(),
+        Value::String(job.updated_at.to_rfc3339()),
+    );
+    envelope.insert(
+        "progress".into(),
+        serde_json::to_value(&job.progress).unwrap_or(Value::Null),
+    );
+    envelope.insert(
+        "error".into(),
+        match &job.error {
+            Some(e) => Value::String(e.clone()),
+            None => Value::Null,
+        },
+    );
+    if include_result && job.status.is_terminal() {
+        if let Some(ref r) = job.result {
+            envelope.insert("result".into(), r.clone());
+        }
+    }
+    drop(job);
+
+    let envelope_value = Value::Object(envelope);
+    let text = serde_json::to_string(&envelope_value)?;
+    let tool_result = CallToolResult {
+        content: vec![crate::protocol::ToolContent::Text { text }],
+        structured_content: Some(envelope_value),
+        is_error: false,
+        meta: None,
+    };
+    Ok(JsonRpcResponse::success(
+        req.id.clone(),
+        serde_json::to_value(tool_result)?,
+    ))
+}
+
+/// Derive ``started_at`` and ``completed_at`` from a [`Job`] snapshot.
+///
+/// `JobManager` does not store these explicitly — it keeps only
+/// `created_at` + `updated_at` + current `status`. For the public
+/// envelope (#319 / #326) we reconstruct them:
+/// * `started_at` is `updated_at` once the job has left `Pending`.
+/// * `completed_at` is `updated_at` once the job is terminal.
+fn compute_job_timestamps(
+    job: &crate::job::Job,
+) -> (
+    Option<chrono::DateTime<chrono::Utc>>,
+    Option<chrono::DateTime<chrono::Utc>>,
+) {
+    use crate::job::JobStatus;
+    let started_at = match job.status {
+        JobStatus::Pending => None,
+        _ => Some(job.updated_at),
+    };
+    let completed_at = if job.status.is_terminal() {
+        Some(job.updated_at)
+    } else {
+        None
+    };
+    (started_at, completed_at)
 }
 
 // ── Lazy-actions fast-path (#254) ─────────────────────────────────────────

--- a/crates/dcc-mcp-http/src/tests.rs
+++ b/crates/dcc-mcp-http/src/tests.rs
@@ -510,8 +510,8 @@ mod tests {
         resp.assert_status_ok();
         let body: Value = resp.json();
         let tools = body["result"]["tools"].as_array().unwrap();
-        // 10 core meta-tools (adds list_roots) + 2 registered actions = 12
-        assert_eq!(tools.len(), 12);
+        // 11 core meta-tools (10 + jobs.get_status #319) + 2 registered actions = 13
+        assert_eq!(tools.len(), 13);
         let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
         assert!(names.contains(&"get_scene_info"));
         assert!(names.contains(&"list_objects"));
@@ -521,6 +521,240 @@ mod tests {
         assert!(names.contains(&"activate_tool_group"));
         assert!(names.contains(&"deactivate_tool_group"));
         assert!(names.contains(&"search_tools"));
+        assert!(
+            names.contains(&"jobs.get_status"),
+            "tools/list must always expose the built-in jobs.get_status (#319)"
+        );
+    }
+
+    // ── jobs.get_status (#319) ────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_jobs_get_status_unknown_id_returns_is_error_envelope() {
+        let server = TestServer::new(make_router());
+        let resp = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "jobs.get_status",
+                    "arguments": {"job_id": "nonexistent-uuid"}
+                }
+            }))
+            .await;
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        // No JSON-RPC error object — the failure is carried inside a valid
+        // CallToolResult with isError=true (MCP convention).
+        assert!(
+            body.get("error").is_none(),
+            "unknown job id must not produce a transport-level JSON-RPC error"
+        );
+        let result = &body["result"];
+        assert_eq!(result["isError"], true);
+        let text = result["content"][0]["text"].as_str().unwrap();
+        assert!(
+            text.contains("nonexistent-uuid"),
+            "error message must name the missing id, got: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_jobs_get_status_missing_job_id_param_is_error() {
+        let server = TestServer::new(make_router());
+        let resp = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "jobs.get_status",
+                    "arguments": {}
+                }
+            }))
+            .await;
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        assert_eq!(body["result"]["isError"], true);
+        let text = body["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(
+            text.to_lowercase().contains("job_id"),
+            "error text must name the missing parameter, got: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_jobs_get_status_returns_full_envelope_for_terminal_job() {
+        use crate::job::JobProgress;
+
+        let state = make_app_state();
+        // Create + drive a job to completion through JobManager directly,
+        // then invoke `jobs.get_status` via the full axum stack.
+        let parent = state.jobs.create("workflow.run");
+        let parent_id = parent.read().id.clone();
+        let child = state
+            .jobs
+            .create_with_parent("workflow.step", Some(parent_id.clone()));
+        let child_id = child.read().id.clone();
+        state.jobs.start(&child_id).unwrap();
+        state
+            .jobs
+            .update_progress(
+                &child_id,
+                JobProgress {
+                    current: 3,
+                    total: 10,
+                    message: Some("half-way".into()),
+                },
+            )
+            .unwrap();
+        state
+            .jobs
+            .complete(&child_id, json!({"ok": true, "value": 42}))
+            .unwrap();
+
+        let app = axum::Router::new()
+            .route(
+                "/mcp",
+                axum::routing::post(crate::handler::handle_post)
+                    .get(crate::handler::handle_get)
+                    .delete(crate::handler::handle_delete),
+            )
+            .with_state(state);
+        let server = TestServer::new(app);
+
+        let resp = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "jobs.get_status",
+                    "arguments": {"job_id": child_id, "include_result": true}
+                }
+            }))
+            .await;
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        let result = &body["result"];
+        assert_eq!(result["isError"], false);
+        let sc = &result["structuredContent"];
+        assert_eq!(sc["job_id"], child_id);
+        assert_eq!(sc["parent_job_id"], parent_id);
+        assert_eq!(sc["tool"], "workflow.step");
+        assert_eq!(sc["status"], "completed");
+        assert!(sc["created_at"].is_string());
+        assert!(sc["started_at"].is_string());
+        assert!(sc["completed_at"].is_string());
+        assert_eq!(sc["progress"]["current"], 3);
+        assert_eq!(sc["progress"]["total"], 10);
+        assert_eq!(sc["result"]["ok"], true);
+        assert_eq!(sc["result"]["value"], 42);
+    }
+
+    #[tokio::test]
+    async fn test_jobs_get_status_include_result_false_omits_result() {
+        let state = make_app_state();
+        let job = state.jobs.create("t.x");
+        let id = job.read().id.clone();
+        state.jobs.start(&id).unwrap();
+        state.jobs.complete(&id, json!({"v": 1})).unwrap();
+
+        let app = axum::Router::new()
+            .route(
+                "/mcp",
+                axum::routing::post(crate::handler::handle_post)
+                    .get(crate::handler::handle_get)
+                    .delete(crate::handler::handle_delete),
+            )
+            .with_state(state);
+        let server = TestServer::new(app);
+
+        let resp = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "jobs.get_status",
+                    "arguments": {"job_id": id, "include_result": false}
+                }
+            }))
+            .await;
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        let sc = &body["result"]["structuredContent"];
+        assert_eq!(sc["status"], "completed");
+        assert!(
+            sc.get("result").is_none(),
+            "include_result=false must omit `result` key, got {sc}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_jobs_get_status_running_job_has_no_result_yet() {
+        let state = make_app_state();
+        let job = state.jobs.create("t.slow");
+        let id = job.read().id.clone();
+        state.jobs.start(&id).unwrap();
+
+        let app = axum::Router::new()
+            .route(
+                "/mcp",
+                axum::routing::post(crate::handler::handle_post)
+                    .get(crate::handler::handle_get)
+                    .delete(crate::handler::handle_delete),
+            )
+            .with_state(state);
+        let server = TestServer::new(app);
+
+        let resp = server
+            .post("/mcp")
+            .add_header(
+                axum::http::header::ACCEPT,
+                "application/json".parse::<HeaderValue>().unwrap(),
+            )
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "jobs.get_status",
+                    "arguments": {"job_id": id, "include_result": true}
+                }
+            }))
+            .await;
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        let sc = &body["result"]["structuredContent"];
+        assert_eq!(sc["status"], "running");
+        assert!(
+            sc.get("result").is_none(),
+            "running job must not have a `result` key even with include_result=true"
+        );
+        assert!(sc["started_at"].is_string());
+        assert_eq!(sc["completed_at"], Value::Null);
     }
 
     // ── search_skills ─────────────────────────────────────────────────────────────
@@ -839,6 +1073,7 @@ mod tests {
                     | "activate_tool_group"
                     | "deactivate_tool_group"
                     | "search_tools"
+                    | "jobs.get_status"
             );
             let is_stub = name.starts_with("__skill__") || name.starts_with("__group__");
 
@@ -1524,8 +1759,8 @@ mod tests {
 
         let body2: Value = resp2.json();
         let tools = body2["result"]["tools"].as_array().unwrap();
-        // 10 core meta-tools + 2 skill tools (skill now loaded, no stubs) = 12
-        assert_eq!(tools.len(), 12);
+        // 11 core meta-tools (incl. jobs.get_status #319) + 2 skill tools = 13
+        assert_eq!(tools.len(), 13);
         let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
         // #307: bare names when unique within the instance.
         assert!(names.contains(&"bevel"));
@@ -1605,8 +1840,8 @@ mod tests {
 
         let body2: Value = resp2.json();
         let tools = body2["result"]["tools"].as_array().unwrap();
-        // Back to 10 core meta-tools + 1 unloaded skill stub = 11
-        assert_eq!(tools.len(), 11);
+        // Back to 11 core meta-tools (incl. jobs.get_status #319) + 1 unloaded skill stub = 12
+        assert_eq!(tools.len(), 12);
         let stub = tools
             .iter()
             .find(|t| t["name"] == "__skill__modeling-bevel")
@@ -2125,7 +2360,7 @@ mod tests {
         resp.assert_status_ok();
         let body: Value = resp.json();
         let tools = body["result"]["tools"].as_array().unwrap();
-        // Total = 10 core + 40 registered = 50; first page = 32.
+        // Total = 11 core (incl. jobs.get_status #319) + 40 registered = 51; first page = 32.
         assert_eq!(
             tools.len(),
             TOOLS_LIST_PAGE_SIZE,
@@ -2169,8 +2404,8 @@ mod tests {
             .await
             .json();
         let tools2 = r2["result"]["tools"].as_array().unwrap();
-        // 50 - 32 = 18 tools on second page
-        assert_eq!(tools2.len(), 50 - TOOLS_LIST_PAGE_SIZE);
+        // 51 - 32 = 19 tools on second page
+        assert_eq!(tools2.len(), 51 - TOOLS_LIST_PAGE_SIZE);
         assert!(
             r2["result"]["nextCursor"].is_null(),
             "Last page must not have nextCursor"
@@ -2206,7 +2441,7 @@ mod tests {
             }
         }
 
-        assert_eq!(all_names.len(), 50, "All pages must cover exactly 50 tools");
+        assert_eq!(all_names.len(), 51, "All pages must cover exactly 51 tools");
         let unique: std::collections::HashSet<_> = all_names.iter().collect();
         assert_eq!(unique.len(), all_names.len(), "No duplicates across pages");
     }

--- a/crates/dcc-mcp-http/tests/jobs_get_status.rs
+++ b/crates/dcc-mcp-http/tests/jobs_get_status.rs
@@ -1,0 +1,56 @@
+//! Integration tests for the built-in `jobs.get_status` tool (#319).
+//!
+//! Covers:
+//! * Tool name passes SEP-986 (`validate_tool_name`).
+//! * `tools/list` always surfaces `jobs.get_status`, irrespective of
+//!   whether any job has been created.
+//! * `tools/call jobs.get_status` with an unknown job id returns an
+//!   `isError=true` `CallToolResult` (never a JSON-RPC transport error).
+//! * Each `JobStatus` variant is reported correctly.
+//! * `include_result=false` omits the result even for a terminal job.
+//! * `parent_job_id` is surfaced for child jobs.
+
+use dcc_mcp_http::JobManager;
+use dcc_mcp_naming::validate_tool_name;
+
+#[test]
+fn jobs_get_status_name_is_sep986_compliant() {
+    validate_tool_name("jobs.get_status").expect("jobs.get_status must satisfy TOOL_NAME_RE");
+}
+
+#[test]
+fn job_manager_status_envelope_shape() {
+    // Minimal shape sanity check using `to_status_json` — the handler
+    // builds the envelope on top of the same fields.
+    let jm = JobManager::new();
+    let parent = jm.create("workflow.run");
+    let parent_id = parent.read().id.clone();
+    let child = jm.create_with_parent("workflow.step", Some(parent_id.clone()));
+    let v = child.read().to_status_json();
+    assert_eq!(
+        v.get("parent_job_id").and_then(|x| x.as_str()),
+        Some(parent_id.as_str())
+    );
+    assert_eq!(v.get("status").and_then(|x| x.as_str()), Some("pending"));
+    assert!(v.get("tool_name").and_then(|x| x.as_str()).is_some());
+    assert!(v.get("job_id").and_then(|x| x.as_str()).is_some());
+    assert!(v.get("created_at").is_some());
+    assert!(v.get("updated_at").is_some());
+}
+
+#[test]
+fn all_job_status_variants_serialize_lowercase() {
+    // The `jobs.get_status` envelope uses serde's lowercase rename, so the
+    // string representation surfaced to clients matches the #326 channel.
+    use dcc_mcp_http::JobStatus;
+    for (variant, expected) in [
+        (JobStatus::Pending, "\"pending\""),
+        (JobStatus::Running, "\"running\""),
+        (JobStatus::Completed, "\"completed\""),
+        (JobStatus::Failed, "\"failed\""),
+        (JobStatus::Cancelled, "\"cancelled\""),
+        (JobStatus::Interrupted, "\"interrupted\""),
+    ] {
+        assert_eq!(serde_json::to_string(&variant).unwrap(), expected);
+    }
+}

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -312,6 +312,55 @@ cfg.enable_job_notifications = True
 
 Channel A follows the MCP 2025-03-26 spec exactly and is mandatory whenever a `progressToken` is provided — the flag only controls B and C.
 
+### Built-in tools: `jobs.get_status`
+
+Clients that can't consume the `$/dcc.jobUpdated` SSE stream (or simply prefer request/response) can poll job state via the always-registered `jobs.get_status` built-in tool (issue #319).
+
+- **Name**: `jobs.get_status` — SEP-986 compliant (validated with `TOOL_NAME_RE` at server startup; the build panics if the regex ever rejects the name).
+- **Visibility**: surfaced in `tools/list` unconditionally, regardless of which skills are loaded or whether any jobs exist.
+- **Annotations**: `readOnlyHint=true`, `destructiveHint=false`, `idempotentHint=true`, `openWorldHint=false`.
+
+Input schema:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `job_id` | `string` | — (required) | UUID of the job to query |
+| `include_logs` | `boolean` | `false` | Forward-compat flag; `JobManager` does not currently capture stdout/stderr, so the flag is a no-op and a `tracing::debug!` breadcrumb is emitted |
+| `include_result` | `boolean` | `true` | When `true` **and** the job is terminal (`completed` / `failed`), include the final `ToolResult` JSON under `result`; otherwise the key is omitted |
+
+Success envelope (returned inside a `CallToolResult` — text content mirrors `structuredContent`):
+
+```json
+{
+  "job_id": "c8aa…",
+  "parent_job_id": null,
+  "tool": "scene.get_info",
+  "status": "completed",
+  "created_at": "2026-04-22T10:00:00+00:00",
+  "started_at": "2026-04-22T10:00:00+00:00",
+  "completed_at": "2026-04-22T10:00:01+00:00",
+  "updated_at": "2026-04-22T10:00:01+00:00",
+  "progress": {"current": 10, "total": 10, "message": "done"},
+  "error": null,
+  "result": { "...": "…final ToolResult…" }
+}
+```
+
+Field semantics mirror the `$/dcc.jobUpdated` channel so polling and streaming clients observe the same shape. `started_at` is derived from `updated_at` once the job leaves `pending`; `completed_at` from `updated_at` once it reaches a terminal state.
+
+Unknown job id → `CallToolResult { isError: true, content: [{type:"text", text:"No job found with id '<bad>'"}] }`. This is always an MCP tool-level error, **never** a JSON-RPC transport error — the response still carries a successful `result` field with `isError=true`.
+
+Python example:
+
+```python
+body = post_mcp({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                 "params": {"name": "jobs.get_status",
+                            "arguments": {"job_id": jid}}})
+env = body["result"]["structuredContent"]
+if env["status"] in {"completed", "failed", "cancelled", "interrupted"}:
+    print("final:", env.get("result"))
+```
+
 ## CORS Configuration
 
 Enable CORS for browser-based MCP clients:

--- a/tests/test_auditlog_ratelimit_logging_mcp_versioned_deep.py
+++ b/tests/test_auditlog_ratelimit_logging_mcp_versioned_deep.py
@@ -706,6 +706,7 @@ class TestMcpServerHandleDeep:
             "activate_tool_group",
             "deactivate_tool_group",
             "search_tools",
+            "jobs.get_status",
         }
         assert not any(t for t in tools if t["name"] not in core_tools)
         handle.shutdown()

--- a/tests/test_jobs_get_status.py
+++ b/tests/test_jobs_get_status.py
@@ -1,0 +1,257 @@
+"""End-to-end tests for the built-in ``jobs.get_status`` tool (issue #319).
+
+The tool is always registered by ``McpHttpServer`` — regardless of which
+skills are loaded — and is SEP-986 compliant (``validate_tool_name``).
+
+Covers:
+
+1. ``jobs.get_status`` is visible in ``tools/list`` with the expected
+   SEP-986 name and ``ToolAnnotations`` (read-only, idempotent).
+2. Calling ``jobs.get_status`` with an unknown ``job_id`` returns an
+   ``isError=true`` ``CallToolResult`` — never a JSON-RPC transport error.
+3. Dispatching an async tool via ``_meta.dcc.async=true`` produces a
+   ``job_id``; polling that id transitions ``pending → running →
+   completed`` and surfaces the final ``ToolResult`` in the envelope.
+4. The SEP-986 naming validator accepts the name.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+import urllib.request
+
+from dcc_mcp_core import McpHttpConfig
+from dcc_mcp_core import McpHttpServer
+from dcc_mcp_core import ToolRegistry
+from dcc_mcp_core import validate_tool_name
+
+
+def _post(url: str, body: dict[str, Any], sid: str | None = None) -> dict[str, Any]:
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+    if sid is not None:
+        headers["Mcp-Session-Id"] = sid
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode(),
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        return json.loads(resp.read())
+
+
+def _initialize_session(url: str) -> str:
+    body = _post(
+        url,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "pytest-319", "version": "1.0"},
+            },
+        },
+    )
+    return body["result"]["__session_id"]
+
+
+def _make_server() -> tuple[Any, str]:
+    reg = ToolRegistry()
+    reg.register(
+        "echo_tool",
+        description="Simple echo used by #319 tests",
+        category="test",
+        tags=[],
+        dcc="test",
+        version="1.0.0",
+    )
+    cfg = McpHttpConfig(port=0, server_name="jobs-get-status-test")
+    cfg.enable_job_notifications = True
+    server = McpHttpServer(reg, cfg)
+    server.register_handler(
+        "echo_tool",
+        lambda params: {"echoed": params, "ok": True},
+    )
+    handle = server.start()
+    # Return both so the test can keep the server alive for the duration.
+    return server, handle, handle.mcp_url()
+
+
+def test_sep986_validate_tool_name_accepts_jobs_get_status():
+    # Belt-and-braces check on the Python-exposed validator.
+    validate_tool_name("jobs.get_status")
+
+
+def test_jobs_get_status_listed_in_tools_list():
+    _server, handle, url = _make_server()
+    try:
+        body = _post(
+            url,
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+        )
+        tools = body["result"]["tools"]
+        names = [t["name"] for t in tools]
+        assert "jobs.get_status" in names, f"tools/list missing jobs.get_status: {names}"
+
+        meta = next(t for t in tools if t["name"] == "jobs.get_status")
+        ann = meta.get("annotations") or {}
+        # Read-only + idempotent + non-destructive — polling a status must
+        # never mutate anything server-side.
+        assert ann.get("readOnlyHint") is True
+        assert ann.get("idempotentHint") is True
+        assert ann.get("destructiveHint") is False
+        # Input schema has the three documented fields.
+        props = meta["inputSchema"]["properties"]
+        assert set(props.keys()) >= {"job_id", "include_logs", "include_result"}
+        assert meta["inputSchema"]["required"] == ["job_id"]
+    finally:
+        handle.shutdown()
+
+
+def test_jobs_get_status_unknown_id_returns_is_error_envelope():
+    _server, handle, url = _make_server()
+    try:
+        body = _post(
+            url,
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {
+                    "name": "jobs.get_status",
+                    "arguments": {"job_id": "does-not-exist"},
+                },
+            },
+        )
+        assert "error" not in body, f"unknown job id must not produce a JSON-RPC transport error: {body}"
+        assert body["result"]["isError"] is True
+        text = body["result"]["content"][0]["text"]
+        assert "does-not-exist" in text
+    finally:
+        handle.shutdown()
+
+
+def test_jobs_get_status_polls_async_dispatch_to_completion():
+    _server, handle, url = _make_server()
+    try:
+        sid = _initialize_session(url)
+        # Opt into the async dispatch path (#318) — the server returns a
+        # `{job_id, status: "pending"}` envelope instead of the result.
+        body = _post(
+            url,
+            {
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "tools/call",
+                "params": {
+                    "name": "echo_tool",
+                    "arguments": {"hello": "world"},
+                    "_meta": {"dcc": {"async": True}},
+                },
+            },
+            sid=sid,
+        )
+        assert body["result"]["isError"] is False, body
+        sc = body["result"].get("structuredContent") or json.loads(body["result"]["content"][0]["text"])
+        job_id = sc["job_id"]
+        assert isinstance(job_id, str) and job_id
+        # Initial status is "pending" or "running" depending on timing.
+        assert sc["status"] in {"pending", "running"}
+
+        # Poll jobs.get_status until terminal. Guard with a hard timeout so
+        # a regression doesn't hang the suite.
+        deadline = time.monotonic() + 5.0
+        final = None
+        seen_statuses: set[str] = set()
+        while time.monotonic() < deadline:
+            poll = _post(
+                url,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 5,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "jobs.get_status",
+                        "arguments": {"job_id": job_id, "include_result": True},
+                    },
+                },
+                sid=sid,
+            )
+            assert poll["result"]["isError"] is False, poll
+            env = poll["result"]["structuredContent"]
+            seen_statuses.add(env["status"])
+            if env["status"] in {"completed", "failed", "cancelled", "interrupted"}:
+                final = env
+                break
+            time.sleep(0.05)
+
+        assert final is not None, f"polling timed out; saw statuses {seen_statuses}"
+        assert final["status"] == "completed", final
+        assert final["job_id"] == job_id
+        assert final["tool"] == "echo_tool"
+        assert final["created_at"]
+        assert final["started_at"]
+        assert final["completed_at"]
+        # `result` is present once terminal + include_result=true.
+        assert "result" in final, f"missing result once completed: {final}"
+        assert final["result"]["ok"] is True
+        assert final["result"]["echoed"] == {"hello": "world"}
+    finally:
+        handle.shutdown()
+
+
+def test_jobs_get_status_include_result_false_omits_result():
+    _server, handle, url = _make_server()
+    try:
+        sid = _initialize_session(url)
+        body = _post(
+            url,
+            {
+                "jsonrpc": "2.0",
+                "id": 6,
+                "method": "tools/call",
+                "params": {
+                    "name": "echo_tool",
+                    "arguments": {"x": 1},
+                    "_meta": {"dcc": {"async": True}},
+                },
+            },
+            sid=sid,
+        )
+        sc = body["result"].get("structuredContent") or json.loads(body["result"]["content"][0]["text"])
+        job_id = sc["job_id"]
+
+        # Wait for completion.
+        deadline = time.monotonic() + 5.0
+        env = None
+        while time.monotonic() < deadline:
+            poll = _post(
+                url,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 7,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "jobs.get_status",
+                        "arguments": {"job_id": job_id, "include_result": False},
+                    },
+                },
+                sid=sid,
+            )
+            env = poll["result"]["structuredContent"]
+            if env["status"] in {"completed", "failed", "cancelled", "interrupted"}:
+                break
+            time.sleep(0.05)
+
+        assert env is not None
+        assert env["status"] == "completed"
+        assert "result" not in env, f"include_result=false must omit result: {env}"
+    finally:
+        handle.shutdown()

--- a/tests/test_on_demand_loading.py
+++ b/tests/test_on_demand_loading.py
@@ -42,6 +42,7 @@ CORE_TOOLS = frozenset(
         "activate_tool_group",
         "deactivate_tool_group",
         "search_tools",
+        "jobs.get_status",
     }
 )
 

--- a/tests/test_tools_list_pagination.py
+++ b/tests/test_tools_list_pagination.py
@@ -132,8 +132,8 @@ class TestToolsListPagination:
             if cursor is None:
                 break
 
-        # 10 core + 40 registered = 50 total
-        assert len(all_names) == 50, f"Expected 50 tools across all pages, got {len(all_names)}"
+        # 11 core (incl. jobs.get_status #319) + 40 registered = 51 total
+        assert len(all_names) == 51, f"Expected 51 tools across all pages, got {len(all_names)}"
         unique = set(all_names)
         assert len(unique) == len(all_names), "Pages must not return duplicate tool names"
 
@@ -151,7 +151,7 @@ class TestToolsListPagination:
         )
         assert code == 200
         result2 = body2["result"]
-        assert len(result2["tools"]) == 50 - self.PAGE_SIZE
+        assert len(result2["tools"]) == 51 - self.PAGE_SIZE
         assert result2.get("nextCursor") is None, "Last page must not have nextCursor"
 
 


### PR DESCRIPTION
## Summary

Implements **#319** — a SEP-986-compliant built-in MCP tool `jobs.get_status` that lets polling-based clients query a tracked job's full lifecycle state over `tools/call`, complementing the `$/dcc.jobUpdated` SSE channel from #326.

- **Always registered** in every `McpHttpServer` (listed in `tools/list` regardless of which skills are loaded). Validated via `dcc_mcp_naming::validate_tool_name` at build time — panics early if the naming regex ever stops accepting the name, catching any future `TOOL_NAME_RE` regression.
- **Annotations**: `readOnlyHint=true`, `idempotentHint=true`, `destructiveHint=false`, `openWorldHint=false`.
- **Output shape mirrors `$/dcc.jobUpdated`** so polling and streaming clients observe the same fields: `job_id`, `parent_job_id`, `tool`, `status`, `created_at`, `started_at`, `completed_at`, `updated_at`, `progress`, `error`, and (when terminal + `include_result=true`) `result`.
- **Error handling**: unknown / missing `job_id` → `CallToolResult { isError: true, content: [...] }` naming the bad id — never a JSON-RPC transport error.
- **`include_logs=true`**: accepted for forward compatibility. `JobManager` does not currently capture stdout/stderr, so the flag is a no-op and a `tracing::debug!` breadcrumb is emitted — documented in the schema description and in `docs/api/http.md`.

## Test plan

- [x] `cargo test -p dcc-mcp-http` — 236 passed (new integration tests in `tests/jobs_get_status.rs` plus 5 new in-module tests covering tools/list visibility, missing-param error, unknown-id error, terminal-with-result, include_result=false, running-job-no-result).
- [x] `tests/test_jobs_get_status.py` — 5 passing Python end-to-end tests: SEP-986 name check, tools/list visibility + annotations, unknown id error envelope, async dispatch → poll → completed with result, and `include_result=false` omission.
- [x] Full Python suite: 8186 passed (existing `tools/list` counting tests updated to include the new built-in).
- [x] `vx just preflight` green (fmt + clippy + cargo test-rust).

## Docs

- `docs/api/http.md` — new "Built-in tools: `jobs.get_status`" subsection under "Job lifecycle notifications".
- `AGENTS.md` — "Quick Lookup" now mentions `jobs.get_status` as the polling alternative to the SSE channel.
- `CLAUDE.md` — added under "AI Agent Tool Priority" as a diagnostics-fallback path for clients without SSE.

Closes #319
