### PR TITLE
feat(http): MCP prompts primitive derived from SKILL.md examples + workflows + behavioural chain guidance

### DIFF
--- a/.commit-msg.tmp
+++ b/.commit-msg.tmp
@@ -1,0 +1,28 @@
+feat(http): add MCP prompts primitive with sibling-file + workflow-derived sources (#351, #355)
+
+Implements the MCP 2025-03-26 prompts primitive end-to-end, sourced from
+each loaded skill's sibling `prompts.yaml` (or `prompts/*.prompt.yaml`
+glob) referenced by `metadata.dcc-mcp.prompts` in SKILL.md. Workflows
+listed in the same spec auto-generate summary prompts that narrate the
+tool chain, giving AI agents a behavioural-chain hint without the skill
+author having to write one by hand.
+
+* Wire: `initialize` now advertises `prompts: { listChanged: true }`
+  when enabled; `prompts/list` and `prompts/get` dispatch through a new
+  `PromptRegistry` with a lazy, loaded-skill-scoped cache.
+* Templating: minimal `{{var}}` engine — whitespace-tolerant, missing
+  required args return `INVALID_PARAMS`, non-placeholder brace content
+  is passed through verbatim.
+* Notifications: `notifications/prompts/list_changed` fans out to every
+  active SSE session on skill load / unload; cache invalidation happens
+  in the same critical section.
+* Config: `McpHttpConfig::enable_prompts` (default `true`) toggles the
+  primitive; Python `McpHttpConfig.enable_prompts` getter + setter.
+* Tests: 11 new Rust unit tests cover the templating engine, registry
+  lifecycle, and YAML parsing; 3 Python tests cover the config surface.
+* Docs: new `docs/guide/prompts.md` (full spec walk-through), sibling-
+  file table row in `docs/guide/skills.md`, and orientation entries in
+  `AGENTS.md` + `CLAUDE.md`.
+
+Closes #351
+Closes #355

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,14 @@ Need to interact with DCC?
 → Built-ins: `scene://current`, `capture://current_window`, `audit://recent`, `artefact://<id>` (stub)
 → Rust wiring: `server.resources().set_scene(...)` / `.wire_audit_log(...)` / `.add_producer(...)` before `start()`
 
+**Serving reusable prompt templates to the MCP client (behavioural chain hints)?**
+→ [`docs/guide/prompts.md`](docs/guide/prompts.md) — Prompts primitive (#351, #355)
+→ Config: `McpHttpConfig.enable_prompts` (default `True`)
+→ SKILL.md: point `metadata.dcc-mcp.prompts` at sibling `prompts.yaml` (single file, `prompts:` + `workflows:` lists) or `prompts/*.prompt.yaml` (glob, one file per prompt)
+→ Auto-derivation: every workflow referenced in the `workflows:` list yields a summary prompt
+→ Template engine: `{{arg_name}}` only — missing required arg returns `INVALID_PARAMS`; unknown brace content is passed through verbatim
+→ Notifications: `notifications/prompts/list_changed` fires on skill load / unload
+
 **Bridging a non-Python DCC (Photoshop, ZBrush via WebSocket)?**
 → `python/dcc_mcp_core/bridge.py` — `DccBridge`
 → Register with: `BridgeRegistry`, `register_bridge()`, `get_bridge_context()`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,17 @@ handle.shutdown()
 cfg = McpHttpConfig(port=8765)
 cfg.enable_resources = True            # advertise capability + built-ins
 cfg.enable_artefact_resources = False  # artefact:// returns JSON-RPC -32002 until #349
+
+# Prompts primitive (#351, #355) — reusable templates served via prompts/list|get
+# McpHttpConfig.enable_prompts defaults to True.
+# Prompts come from each loaded skill's sibling file referenced by
+# metadata["dcc-mcp.prompts"] in SKILL.md — either a single `prompts.yaml`
+# (top-level `prompts:` + `workflows:` lists) or a `prompts/*.prompt.yaml` glob.
+# Workflows referenced by the spec auto-generate a summary prompt.
+# Template engine is minimal: only {{arg_name}} substitution, missing required
+# args return JSON-RPC INVALID_PARAMS. notifications/prompts/list_changed fires
+# on skill load / unload.
+cfg.enable_prompts = True              # advertise capability + serve templates
 ```
 
 ### Quick Lookup: Common Method Signatures

--- a/crates/dcc-mcp-http/Cargo.toml
+++ b/crates/dcc-mcp-http/Cargo.toml
@@ -35,6 +35,7 @@ socket2 = { workspace = true }
 parking_lot = { workspace = true }
 chrono = { version = "0.4", features = ["serde"] }
 base64 = { workspace = true }
+serde_yaml_ng = { workspace = true }
 tokio-util = { version = "0.7", features = ["rt"] }
 
 # HTTP server

--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -160,6 +160,20 @@ pub struct McpHttpConfig {
     /// servers or when Resources are provided by an external MCP host.
     pub enable_resources: bool,
 
+    /// Advertise the MCP Prompts primitive (issues #351, #355).
+    ///
+    /// When `true` (default), the server:
+    /// - Advertises `prompts: { listChanged: true }` in `initialize`.
+    /// - Handles `prompts/list` and `prompts/get` JSON-RPC methods.
+    /// - Parses the sibling `prompts.yaml` file referenced by
+    ///   `metadata.dcc-mcp.prompts` on each loaded skill and merges its
+    ///   `prompts:` and workflow-derived entries into `prompts/list`.
+    /// - Emits `notifications/prompts/list_changed` on skill load/unload.
+    ///
+    /// Set to `false` to hide the capability — appropriate for minimal
+    /// servers, or when prompts are provided by an external MCP host.
+    pub enable_prompts: bool,
+
     /// Expose `artefact://` resources (issue #349).
     ///
     /// The full artefact store ships separately in issue #349. When this
@@ -258,6 +272,7 @@ impl McpHttpConfig {
             backend_timeout_ms: 10_000,
             enable_resources: true,
             enable_artefact_resources: false,
+            enable_prompts: true,
             enable_workflows: false,
             enable_prometheus: false,
             prometheus_basic_auth: None,

--- a/crates/dcc-mcp-http/src/handler.rs
+++ b/crates/dcc-mcp-http/src/handler.rs
@@ -26,15 +26,17 @@ use crate::{
     error::HttpError,
     executor::DccExecutorHandle,
     inflight::{CancelToken, InFlightEntry, InFlightRequests, ProgressReporter},
+    prompts::{PromptError, PromptRegistry},
     protocol::{
         self, CallToolParams, CallToolResult, DELTA_TOOLS_METHOD, DELTA_TOOLS_UPDATE_CAP,
-        ElicitationCapability, ElicitationCreateParams, ElicitationCreateResult, InitializeResult,
-        JsonRpcBatch, JsonRpcMessage, JsonRpcRequest, JsonRpcResponse, LOGGING_SET_LEVEL_METHOD,
-        ListResourcesResult, ListToolsResult, LoggingCapability, LoggingSetLevelParams,
-        MCP_SESSION_HEADER, McpTool, McpToolAnnotations, RESOURCE_NOT_ENABLED_ERROR,
-        ReadResourceParams, ResourcesCapability, ServerCapabilities, ServerInfo,
-        SubscribeResourceParams, TOOLS_LIST_PAGE_SIZE, ToolsCapability, decode_cursor,
-        encode_cursor, format_sse_event, negotiate_protocol_version,
+        ElicitationCapability, ElicitationCreateParams, ElicitationCreateResult, GetPromptParams,
+        InitializeResult, JsonRpcBatch, JsonRpcMessage, JsonRpcRequest, JsonRpcResponse,
+        LOGGING_SET_LEVEL_METHOD, ListPromptsResult, ListResourcesResult, ListToolsResult,
+        LoggingCapability, LoggingSetLevelParams, MCP_SESSION_HEADER, McpTool, McpToolAnnotations,
+        PromptsCapability, RESOURCE_NOT_ENABLED_ERROR, ReadResourceParams, ResourcesCapability,
+        ServerCapabilities, ServerInfo, SubscribeResourceParams, TOOLS_LIST_PAGE_SIZE,
+        ToolsCapability, decode_cursor, encode_cursor, format_sse_event,
+        negotiate_protocol_version,
     },
     resources::{ResourceError, ResourceRegistry},
     session::{SessionLogLevel, SessionLogMessage, SessionManager},
@@ -109,6 +111,13 @@ pub struct AppState {
     /// Whether the `resources/*` methods are dispatched and the
     /// `resources` capability is advertised in `initialize`.
     pub enable_resources: bool,
+    /// MCP Prompts primitive registry (issues #351, #355).
+    ///
+    /// Always populated but only queried when `enable_prompts` is set.
+    pub prompts: PromptRegistry,
+    /// Whether the `prompts/*` methods are dispatched and the
+    /// `prompts` capability is advertised in `initialize`.
+    pub enable_prompts: bool,
     /// Prometheus exporter for tool-call observability (issue #331).
     ///
     /// Present only when the `prometheus` Cargo feature is enabled
@@ -439,6 +448,8 @@ async fn dispatch_request(
         "resources/unsubscribe" if state.enable_resources => {
             handle_resources_unsubscribe(state, req, session_id).await
         }
+        "prompts/list" if state.enable_prompts => handle_prompts_list(state, req).await,
+        "prompts/get" if state.enable_prompts => handle_prompts_get(state, req).await,
         "elicitation/create" => handle_elicitation_create(state, req, session_id).await,
         "ping" => Ok(JsonRpcResponse::success(req.id.clone(), json!({}))),
         other => Ok(JsonRpcResponse::method_not_found(req.id.clone(), other)),
@@ -525,12 +536,18 @@ async fn handle_initialize(
         None
     };
 
+    let prompts_cap = if state.enable_prompts {
+        Some(PromptsCapability { list_changed: true })
+    } else {
+        None
+    };
+
     let result = InitializeResult {
         protocol_version: negotiated.to_string(),
         capabilities: ServerCapabilities {
             tools: Some(ToolsCapability { list_changed: true }),
             resources: resources_cap,
-            prompts: None,
+            prompts: prompts_cap,
             logging: Some(LoggingCapability::default()),
             elicitation: elicitation_cap,
             experimental: experimental_caps,
@@ -663,6 +680,84 @@ async fn handle_resources_unsubscribe(
     };
     state.resources.unsubscribe(sid, &params.uri);
     Ok(JsonRpcResponse::success(req.id.clone(), json!({})))
+}
+
+// ── Prompts (issues #351, #355) ────────────────────────────────────────────
+
+async fn handle_prompts_list(
+    state: &AppState,
+    req: &JsonRpcRequest,
+) -> Result<JsonRpcResponse, HttpError> {
+    let catalog = state.catalog.clone();
+    let prompts = state.prompts.list(|visit| {
+        catalog.for_each_loaded_metadata(|md| visit(md));
+    });
+    let result = ListPromptsResult {
+        prompts,
+        next_cursor: None,
+    };
+    Ok(JsonRpcResponse::success(
+        req.id.clone(),
+        serde_json::to_value(result)?,
+    ))
+}
+
+async fn handle_prompts_get(
+    state: &AppState,
+    req: &JsonRpcRequest,
+) -> Result<JsonRpcResponse, HttpError> {
+    let Some(params) = req
+        .params
+        .as_ref()
+        .and_then(|p| serde_json::from_value::<GetPromptParams>(p.clone()).ok())
+    else {
+        return Ok(JsonRpcResponse::error(
+            req.id.clone(),
+            protocol::error_codes::INVALID_PARAMS,
+            "Invalid prompts/get params (expected {name: string, arguments?: object})",
+        ));
+    };
+    let catalog = state.catalog.clone();
+    let lookup = state.prompts.get(&params.name, &params.arguments, |visit| {
+        catalog.for_each_loaded_metadata(|md| visit(md));
+    });
+    match lookup {
+        Ok(result) => Ok(JsonRpcResponse::success(
+            req.id.clone(),
+            serde_json::to_value(result)?,
+        )),
+        Err(PromptError::NotFound(name)) => Ok(JsonRpcResponse::error(
+            req.id.clone(),
+            protocol::error_codes::INVALID_PARAMS,
+            format!("prompt not found: {name}"),
+        )),
+        Err(PromptError::MissingArg(arg)) => Ok(JsonRpcResponse::error(
+            req.id.clone(),
+            protocol::error_codes::INVALID_PARAMS,
+            format!("missing required argument: {arg}"),
+        )),
+        Err(PromptError::Load(msg)) => Ok(JsonRpcResponse::internal_error(
+            req.id.clone(),
+            format!("prompts/get load failure: {msg}"),
+        )),
+    }
+}
+
+/// Emit `notifications/prompts/list_changed` to every session whose SSE
+/// stream is live. Called from skill load / unload paths.
+pub(crate) fn notify_prompts_list_changed_all(state: &AppState) {
+    if !state.enable_prompts {
+        return;
+    }
+    let notification = json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/prompts/list_changed",
+        "params": {}
+    });
+    let event = format_sse_event(&notification, None);
+    for sid in state.sessions.all_ids() {
+        state.sessions.push_event(&sid, event.clone());
+    }
 }
 
 async fn handle_logging_set_level(
@@ -1900,6 +1995,11 @@ async fn handle_load_skill(
                 .collect();
             notify_tools_changed(&state.sessions, sid, &added, &removed);
         }
+        // Skill content changed — invalidate the prompt cache and
+        // broadcast `notifications/prompts/list_changed` (issues
+        // #351, #355).
+        state.prompts.invalidate();
+        notify_prompts_list_changed_all(state);
     }
 
     // Build the full tool metadata so agents can invoke the new tools without
@@ -1990,6 +2090,10 @@ async fn handle_unload_skill(
                 let added = vec![format!("__skill__{skill_name}")];
                 notify_tools_changed(&state.sessions, sid, &added, &removed);
             }
+            // Invalidate prompt cache and fire
+            // `notifications/prompts/list_changed` (issues #351, #355).
+            state.prompts.invalidate();
+            notify_prompts_list_changed_all(state);
 
             let text = serde_json::to_string_pretty(&json!({
                 "unloaded": true,

--- a/crates/dcc-mcp-http/src/lib.rs
+++ b/crates/dcc-mcp-http/src/lib.rs
@@ -47,6 +47,7 @@ pub mod handler;
 pub mod inflight;
 pub mod job;
 pub mod notifications;
+pub mod prompts;
 pub mod protocol;
 pub mod resource_link;
 pub mod resources;
@@ -67,6 +68,10 @@ pub use executor::{DccExecutorHandle, DeferredExecutor};
 pub use gateway::{GatewayConfig, GatewayHandle, GatewayRunner};
 pub use job::{Job, JobEvent, JobManager, JobProgress, JobStatus, JobSubscriber};
 pub use notifications::{JobNotifier, WorkflowProgress, WorkflowUpdate};
+pub use prompts::{
+    PromptArgumentSpec, PromptEntry, PromptError, PromptRegistry, PromptResult, PromptSource,
+    PromptSpec, PromptsSpec, WorkflowPromptRef, render_template,
+};
 pub use resources::{
     ProducerContent, ResourceError, ResourceProducer, ResourceRegistry, ResourceResult,
 };

--- a/crates/dcc-mcp-http/src/prompts.rs
+++ b/crates/dcc-mcp-http/src/prompts.rs
@@ -1,0 +1,636 @@
+//! MCP Prompts primitive (issues #351, #355).
+//!
+//! Exposes skill-authored prompt templates and workflow-derived prompts over
+//! the MCP 2025-03-26 `prompts/list` + `prompts/get` JSON-RPC methods. The
+//! capability is advertised only when [`crate::McpHttpConfig::enable_prompts`]
+//! is `true`.
+//!
+//! # Sibling-file pattern (issue #356)
+//!
+//! Prompts live **outside** `SKILL.md`. A skill opts in by setting
+//! `metadata.dcc-mcp.prompts: prompts.yaml` in its SKILL.md frontmatter;
+//! `prompts.yaml` is a sibling file describing zero or more prompts and,
+//! optionally, a list of workflows whose execution summary should be
+//! rendered as an auto-generated prompt.
+//!
+//! ```yaml
+//! # my-skill/prompts.yaml
+//! prompts:
+//!   - name: bake_and_export_animation
+//!     description: Guide for baking a rig and exporting FBX
+//!     arguments:
+//!       - name: frame_range
+//!         required: true
+//!       - name: output_path
+//!         required: true
+//!     template: |
+//!       Please bake the animation on the selected rig across frames
+//!       {{frame_range}}. Then export to FBX at {{output_path}}.
+//! workflows:
+//!   - file: workflows/bake_and_export.yaml
+//!     prompt_name: bake_and_export_workflow
+//! ```
+//!
+//! # Template engine
+//!
+//! A minimal `{{name}}` substitutor (see [`render_template`]). Missing
+//! arguments raise [`PromptError::MissingArg`] so `prompts/get` can
+//! surface a descriptive JSON-RPC error naming the offending parameter.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+
+use crate::protocol::{
+    GetPromptResult, McpPrompt, McpPromptArgument, McpPromptContent, McpPromptMessage,
+};
+
+// ── Errors ──────────────────────────────────────────────────────────────────
+
+/// Error type surfaced by [`PromptRegistry::get`].
+#[derive(Debug, thiserror::Error)]
+pub enum PromptError {
+    #[error("prompt not found: {0}")]
+    NotFound(String),
+    #[error("missing required argument: {0}")]
+    MissingArg(String),
+    #[error("failed to load prompt source: {0}")]
+    Load(String),
+}
+
+pub type PromptResult<T> = Result<T, PromptError>;
+
+// ── Spec types (parsed from sibling YAML) ───────────────────────────────────
+
+/// Declared argument for a hand-authored prompt.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PromptArgumentSpec {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub required: bool,
+}
+
+/// Single prompt entry inside a sibling `prompts.yaml`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PromptSpec {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub arguments: Vec<PromptArgumentSpec>,
+    pub template: String,
+}
+
+/// Reference to a workflow that should be surfaced as an auto-generated prompt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowPromptRef {
+    /// Path to the workflow YAML (relative to the skill root).
+    pub file: String,
+    /// Public prompt name. When omitted, `{skill}.{workflow.name}` is used.
+    #[serde(default)]
+    pub prompt_name: Option<String>,
+}
+
+/// Parsed contents of a skill's `prompts.yaml`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PromptsSpec {
+    #[serde(default)]
+    pub prompts: Vec<PromptSpec>,
+    #[serde(default)]
+    pub workflows: Vec<WorkflowPromptRef>,
+}
+
+impl PromptsSpec {
+    /// Parse a YAML document into a [`PromptsSpec`].
+    pub fn from_yaml(s: &str) -> Result<Self, String> {
+        serde_yaml_ng::from_str(s).map_err(|e| e.to_string())
+    }
+}
+
+// ── Template engine ────────────────────────────────────────────────────────
+
+/// Render a `{{name}}` template against an argument map.
+///
+/// Substitution rules:
+///
+/// - `{{name}}` → value from `args[name]`; missing → [`PromptError::MissingArg`].
+/// - Whitespace inside the placeholder is tolerated: `{{ name }}`.
+/// - Literal `{{` or `}}` outside a placeholder are preserved verbatim.
+/// - The engine does NOT support `{{{raw}}}`, filters, blocks, or
+///   conditionals (Handlebars-style). Keep templates simple.
+///
+/// # Errors
+///
+/// Returns the first missing-argument name encountered.
+pub fn render_template(template: &str, args: &HashMap<String, String>) -> PromptResult<String> {
+    let bytes = template.as_bytes();
+    let mut out = String::with_capacity(template.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        // Look for `{{`
+        if i + 1 < bytes.len() && bytes[i] == b'{' && bytes[i + 1] == b'{' {
+            if let Some(end_rel) = template[i + 2..].find("}}") {
+                let raw = &template[i + 2..i + 2 + end_rel];
+                let name = raw.trim();
+                if !name.is_empty() && is_valid_placeholder(name) {
+                    match args.get(name) {
+                        Some(v) => out.push_str(v),
+                        None => return Err(PromptError::MissingArg(name.to_string())),
+                    }
+                    i = i + 2 + end_rel + 2;
+                    continue;
+                }
+                // Not a valid placeholder — emit `{{` literally and advance by 1.
+                out.push_str("{{");
+                i += 2;
+                continue;
+            }
+        }
+        // Regular char — UTF-8 safe advance.
+        let ch_end = next_char_boundary(template, i);
+        out.push_str(&template[i..ch_end]);
+        i = ch_end;
+    }
+    Ok(out)
+}
+
+fn is_valid_placeholder(s: &str) -> bool {
+    s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.')
+}
+
+fn next_char_boundary(s: &str, start: usize) -> usize {
+    // Walk forward to the next UTF-8 char boundary.
+    let mut j = start + 1;
+    while j < s.len() && !s.is_char_boundary(j) {
+        j += 1;
+    }
+    j
+}
+
+// ── Registry ────────────────────────────────────────────────────────────────
+
+/// How a prompt was sourced — surfaced to downstream consumers for
+/// diagnostics / client hints. Never emitted on the wire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PromptSource {
+    /// From a `*.prompt.yaml` / `prompts.yaml` sibling file.
+    Explicit,
+    /// Derived from a workflow referenced in the sibling `workflows:` section.
+    WorkflowDerived,
+}
+
+/// A single entry in the prompt registry — pre-rendered list metadata plus
+/// the raw template used by `prompts/get`.
+#[derive(Debug, Clone)]
+pub struct PromptEntry {
+    pub name: String,
+    pub description: Option<String>,
+    pub arguments: Vec<PromptArgumentSpec>,
+    pub template: String,
+    pub source: PromptSource,
+    /// Fully-qualified skill name this prompt belongs to.
+    pub skill: String,
+}
+
+impl PromptEntry {
+    fn to_mcp(&self) -> McpPrompt {
+        McpPrompt {
+            name: self.name.clone(),
+            description: self.description.clone(),
+            arguments: self
+                .arguments
+                .iter()
+                .map(|a| McpPromptArgument {
+                    name: a.name.clone(),
+                    description: a.description.clone(),
+                    required: a.required,
+                })
+                .collect(),
+        }
+    }
+}
+
+/// Thread-safe registry of prompts, rebuilt lazily on demand.
+///
+/// Owned by [`crate::handler::AppState`] via `Arc`. The registry caches the
+/// set of loaded skills it last saw; when `prompts/list` or `prompts/get` is
+/// called it rescans the [`dcc_mcp_skills::SkillCatalog`] (the heavy work —
+/// actually opening and parsing sibling YAML files — happens once per skill
+/// per cache invalidation).
+#[derive(Clone, Default)]
+pub struct PromptRegistry {
+    inner: Arc<RwLock<PromptRegistryInner>>,
+}
+
+#[derive(Default)]
+struct PromptRegistryInner {
+    /// Prompts keyed by (skill_name, prompt_name) so duplicate names across
+    /// skills don't collide.
+    entries: BTreeMap<(String, String), PromptEntry>,
+    /// Names of the loaded skills this cache was built from. Used to
+    /// short-circuit rebuilds — swapping this out atomically invalidates.
+    loaded_skills: HashSet<String>,
+    enabled: bool,
+}
+
+impl PromptRegistry {
+    /// Create an empty registry.
+    ///
+    /// Pass `enabled = false` to disable the whole primitive — `list()` will
+    /// always return an empty `Vec` and `get()` will return
+    /// [`PromptError::NotFound`] for every name.
+    pub fn new(enabled: bool) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(PromptRegistryInner {
+                enabled,
+                ..Default::default()
+            })),
+        }
+    }
+
+    /// Returns `true` when the Prompts primitive is advertised in
+    /// `initialize` (mirrors `McpHttpConfig::enable_prompts`).
+    pub fn is_enabled(&self) -> bool {
+        self.inner.read().enabled
+    }
+
+    /// Force a rebuild on next `list` / `get`.
+    ///
+    /// Called by the server when a skill is loaded or unloaded — the cached
+    /// entry set is cleared so the next request rescans all loaded skills.
+    pub fn invalidate(&self) {
+        let mut g = self.inner.write();
+        g.entries.clear();
+        g.loaded_skills.clear();
+    }
+
+    /// List every prompt known to the registry.
+    pub fn list<F>(&self, walk_loaded: F) -> Vec<McpPrompt>
+    where
+        F: FnOnce(&mut dyn FnMut(&dcc_mcp_models::SkillMetadata)),
+    {
+        if !self.is_enabled() {
+            return Vec::new();
+        }
+        self.refresh_if_needed(walk_loaded);
+        self.inner
+            .read()
+            .entries
+            .values()
+            .map(PromptEntry::to_mcp)
+            .collect()
+    }
+
+    /// Look up + render a single prompt.
+    pub fn get<F>(
+        &self,
+        name: &str,
+        args: &HashMap<String, String>,
+        walk_loaded: F,
+    ) -> PromptResult<GetPromptResult>
+    where
+        F: FnOnce(&mut dyn FnMut(&dcc_mcp_models::SkillMetadata)),
+    {
+        if !self.is_enabled() {
+            return Err(PromptError::NotFound(name.to_string()));
+        }
+        self.refresh_if_needed(walk_loaded);
+        // Validate required args present before rendering so we fail fast
+        // with a named-parameter error.
+        let entry = {
+            let g = self.inner.read();
+            g.entries
+                .values()
+                .find(|e| e.name == name)
+                .cloned()
+                .ok_or_else(|| PromptError::NotFound(name.to_string()))?
+        };
+        for arg in &entry.arguments {
+            if arg.required && !args.contains_key(&arg.name) {
+                return Err(PromptError::MissingArg(arg.name.clone()));
+            }
+        }
+        let rendered = render_template(&entry.template, args)?;
+        Ok(GetPromptResult {
+            description: entry.description.clone(),
+            messages: vec![McpPromptMessage {
+                role: "user".to_string(),
+                content: McpPromptContent::text(rendered),
+            }],
+        })
+    }
+
+    fn refresh_if_needed<F>(&self, walk_loaded: F)
+    where
+        F: FnOnce(&mut dyn FnMut(&dcc_mcp_models::SkillMetadata)),
+    {
+        // Collect loaded skills.
+        let mut loaded_now: HashSet<String> = HashSet::new();
+        let mut metadatas: Vec<dcc_mcp_models::SkillMetadata> = Vec::new();
+        let mut cb = |md: &dcc_mcp_models::SkillMetadata| {
+            loaded_now.insert(md.name.clone());
+            metadatas.push(md.clone());
+        };
+        walk_loaded(&mut cb);
+
+        // Fast path — loaded skill set unchanged and cache populated.
+        {
+            let g = self.inner.read();
+            if g.loaded_skills == loaded_now && !g.entries.is_empty() {
+                return;
+            }
+            // Empty cache + empty loaded set → still fine, mark set.
+            if g.loaded_skills == loaded_now && loaded_now.is_empty() {
+                return;
+            }
+        }
+
+        // Slow path — rebuild.
+        let mut new_entries: BTreeMap<(String, String), PromptEntry> = BTreeMap::new();
+        for md in &metadatas {
+            if let Some(rel) = md.prompts_file.as_deref() {
+                let skill_path = PathBuf::from(&md.skill_path);
+                for entry in load_prompts_from_reference(&skill_path, rel, &md.name) {
+                    new_entries.insert((md.name.clone(), entry.name.clone()), entry);
+                }
+            }
+        }
+        let mut g = self.inner.write();
+        g.entries = new_entries;
+        g.loaded_skills = loaded_now;
+    }
+}
+
+/// Resolve `reference` (relative to `skill_root`) and return every prompt
+/// entry it produces. `reference` may point at a single YAML file or at a
+/// glob (`prompts/*.prompt.yaml`).
+fn load_prompts_from_reference(
+    skill_root: &Path,
+    reference: &str,
+    skill_name: &str,
+) -> Vec<PromptEntry> {
+    let mut out = Vec::new();
+
+    if reference.contains('*') || reference.contains('?') {
+        // Glob — treat each matching file as a standalone PromptSpec.
+        let pattern_root = match reference.split_once('/') {
+            Some((dir, _)) if !dir.contains('*') && !dir.contains('?') => skill_root.join(dir),
+            _ => skill_root.to_path_buf(),
+        };
+        if let Ok(rd) = std::fs::read_dir(&pattern_root) {
+            for ent in rd.flatten() {
+                let p = ent.path();
+                if p.extension()
+                    .and_then(|e| e.to_str())
+                    .map(|e| matches!(e, "yaml" | "yml"))
+                    .unwrap_or(false)
+                {
+                    let Ok(text) = std::fs::read_to_string(&p) else {
+                        continue;
+                    };
+                    if let Ok(spec) = serde_yaml_ng::from_str::<PromptSpec>(&text) {
+                        out.push(entry_from_spec(spec, skill_name));
+                    } else if let Ok(spec) = serde_yaml_ng::from_str::<PromptsSpec>(&text) {
+                        out.extend(entries_from_promptsspec(spec, skill_root, skill_name));
+                    }
+                }
+            }
+        }
+        return out;
+    }
+
+    // Single file — expected to contain a PromptsSpec with prompts+workflows.
+    let path = skill_root.join(reference);
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        tracing::warn!(
+            "prompts sibling file {} missing or unreadable; skipping",
+            path.display()
+        );
+        return out;
+    };
+    match PromptsSpec::from_yaml(&text) {
+        Ok(spec) => {
+            out.extend(entries_from_promptsspec(spec, skill_root, skill_name));
+        }
+        Err(e) => {
+            tracing::warn!("failed to parse {}: {e}", path.display());
+        }
+    }
+    out
+}
+
+fn entry_from_spec(spec: PromptSpec, skill_name: &str) -> PromptEntry {
+    PromptEntry {
+        name: spec.name,
+        description: spec.description,
+        arguments: spec.arguments,
+        template: spec.template,
+        source: PromptSource::Explicit,
+        skill: skill_name.to_string(),
+    }
+}
+
+fn entries_from_promptsspec(
+    spec: PromptsSpec,
+    skill_root: &Path,
+    skill_name: &str,
+) -> Vec<PromptEntry> {
+    let mut out: Vec<PromptEntry> = spec
+        .prompts
+        .into_iter()
+        .map(|p| entry_from_spec(p, skill_name))
+        .collect();
+
+    for wf_ref in spec.workflows {
+        if let Some(entry) = workflow_to_prompt(skill_root, skill_name, &wf_ref) {
+            out.push(entry);
+        }
+    }
+    out
+}
+
+/// Load a workflow YAML and render a prompt entry that summarises its
+/// purpose + step chain.
+fn workflow_to_prompt(
+    skill_root: &Path,
+    skill_name: &str,
+    wf_ref: &WorkflowPromptRef,
+) -> Option<PromptEntry> {
+    let path = skill_root.join(&wf_ref.file);
+    let text = std::fs::read_to_string(&path)
+        .map_err(|e| {
+            tracing::warn!(
+                "workflow-derived prompt: failed to read {}: {e}",
+                path.display()
+            )
+        })
+        .ok()?;
+    let spec = dcc_mcp_workflow::WorkflowSpec::from_yaml(&text)
+        .map_err(|e| {
+            tracing::warn!(
+                "workflow-derived prompt: failed to parse {}: {e}",
+                path.display()
+            )
+        })
+        .ok()?;
+
+    let name = wf_ref
+        .prompt_name
+        .clone()
+        .unwrap_or_else(|| format!("{skill_name}.{}", spec.name));
+
+    let mut steps_text = String::new();
+    for (i, step) in spec.steps.iter().enumerate() {
+        let (tool, kind) = match &step.kind {
+            dcc_mcp_workflow::StepKind::Tool { tool, .. } => (tool.as_str(), "tool"),
+            dcc_mcp_workflow::StepKind::ToolRemote { tool, .. } => (tool.as_str(), "tool_remote"),
+            other => ("", other.kind_str()),
+        };
+        if tool.is_empty() {
+            steps_text.push_str(&format!("  {}. [{}] {}\n", i + 1, kind, step.id));
+        } else {
+            steps_text.push_str(&format!("  {}. {}\n", i + 1, tool));
+        }
+    }
+
+    let template = format!(
+        "Workflow: {description}\n\nThis workflow runs these steps in order:\n{steps}\n\
+         Call `workflows.run` with name = {wf_name:?} to execute, or invoke the tools \
+         manually in the order above.\n",
+        description = if spec.description.is_empty() {
+            spec.name.clone()
+        } else {
+            spec.description.clone()
+        },
+        steps = steps_text,
+        wf_name = spec.name,
+    );
+
+    Some(PromptEntry {
+        name,
+        description: Some(format!(
+            "Auto-generated prompt describing the {} workflow.",
+            spec.name
+        )),
+        arguments: Vec::new(),
+        template,
+        source: PromptSource::WorkflowDerived,
+        skill: skill_name.to_string(),
+    })
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn argmap(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn render_basic() {
+        let t = "hello {{name}}";
+        let out = render_template(t, &argmap(&[("name", "world")])).unwrap();
+        assert_eq!(out, "hello world");
+    }
+
+    #[test]
+    fn render_no_args() {
+        let out = render_template("plain string", &HashMap::new()).unwrap();
+        assert_eq!(out, "plain string");
+    }
+
+    #[test]
+    fn render_multi_arg() {
+        let t = "{{a}}+{{b}}={{c}}";
+        let out = render_template(t, &argmap(&[("a", "1"), ("b", "2"), ("c", "3")])).unwrap();
+        assert_eq!(out, "1+2=3");
+    }
+
+    #[test]
+    fn render_missing_arg_errors() {
+        let t = "hi {{who}}";
+        let err = render_template(t, &HashMap::new()).unwrap_err();
+        assert!(matches!(err, PromptError::MissingArg(ref s) if s == "who"));
+    }
+
+    #[test]
+    fn render_duplicate_arg() {
+        let t = "{{x}}-{{x}}-{{x}}";
+        let out = render_template(t, &argmap(&[("x", "42")])).unwrap();
+        assert_eq!(out, "42-42-42");
+    }
+
+    #[test]
+    fn render_tolerates_whitespace_inside_braces() {
+        let t = "v={{  k  }}";
+        let out = render_template(t, &argmap(&[("k", "ok")])).unwrap();
+        assert_eq!(out, "v=ok");
+    }
+
+    #[test]
+    fn render_preserves_unmatched_open_braces() {
+        // Dangling `{{` with no closing `}}` is kept verbatim.
+        let t = "weird {{ no close";
+        let out = render_template(t, &HashMap::new()).unwrap();
+        assert_eq!(out, "weird {{ no close");
+    }
+
+    #[test]
+    fn render_preserves_non_placeholder_brace_content() {
+        // `{{ }}` containing invalid placeholder chars is left intact.
+        let t = "code: {{ 1 + 1 }} done";
+        let out = render_template(t, &HashMap::new()).unwrap();
+        assert_eq!(out, "code: {{ 1 + 1 }} done");
+    }
+
+    #[test]
+    fn render_empty_template() {
+        let out = render_template("", &HashMap::new()).unwrap();
+        assert_eq!(out, "");
+    }
+
+    #[test]
+    fn registry_disabled_returns_empty() {
+        let reg = PromptRegistry::new(false);
+        let list = reg.list(|_| {});
+        assert!(list.is_empty());
+        let err = reg.get("foo", &HashMap::new(), |_| {}).unwrap_err();
+        assert!(matches!(err, PromptError::NotFound(_)));
+    }
+
+    #[test]
+    fn promptsspec_from_yaml_parses_both_sections() {
+        let yaml = r#"
+prompts:
+  - name: one
+    description: first
+    arguments:
+      - name: x
+        required: true
+    template: "x is {{x}}"
+workflows:
+  - file: wf/bake.yaml
+    prompt_name: bake_summary
+"#;
+        let spec = PromptsSpec::from_yaml(yaml).unwrap();
+        assert_eq!(spec.prompts.len(), 1);
+        assert_eq!(spec.workflows.len(), 1);
+        assert_eq!(spec.prompts[0].name, "one");
+        assert_eq!(
+            spec.workflows[0].prompt_name.as_deref(),
+            Some("bake_summary")
+        );
+    }
+}

--- a/crates/dcc-mcp-http/src/protocol.rs
+++ b/crates/dcc-mcp-http/src/protocol.rs
@@ -496,6 +496,75 @@ pub struct SubscribeResourceParams {
 /// before issue #349 wires up the artefact store).
 pub const RESOURCE_NOT_ENABLED_ERROR: i64 = -32002;
 
+// ── Prompts (MCP 2025-03-26, issues #351, #355) ──────────────────────────
+
+/// Single prompt template entry returned by `prompts/list`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpPrompt {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub arguments: Vec<McpPromptArgument>,
+}
+
+/// Declared argument for a prompt (surfaced through `prompts/list`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpPromptArgument {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub required: bool,
+}
+
+/// Result payload for `prompts/list`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ListPromptsResult {
+    pub prompts: Vec<McpPrompt>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
+}
+
+/// Request params for `prompts/get`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetPromptParams {
+    pub name: String,
+    #[serde(default)]
+    pub arguments: std::collections::HashMap<String, String>,
+}
+
+/// Single message inside a rendered prompt (MCP `PromptMessage`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpPromptMessage {
+    pub role: String,
+    pub content: McpPromptContent,
+}
+
+/// Prompt message content. Only text is emitted by this library —
+/// binary content is forwarded as-is on the wire for forward compat.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum McpPromptContent {
+    #[serde(rename = "text")]
+    Text { text: String },
+}
+
+impl McpPromptContent {
+    pub fn text(t: impl Into<String>) -> Self {
+        Self::Text { text: t.into() }
+    }
+}
+
+/// Result payload for `prompts/get`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GetPromptResult {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub messages: Vec<McpPromptMessage>,
+}
+
 // ── SSE ────────────────────────────────────────────────────────────────────
 
 /// Format a JSON-RPC message as an SSE event string.

--- a/crates/dcc-mcp-http/src/python/mod.rs
+++ b/crates/dcc-mcp-http/src/python/mod.rs
@@ -401,6 +401,24 @@ impl PyMcpHttpConfig {
         self.inner.enable_artefact_resources = enabled;
     }
 
+    /// Advertise the MCP Prompts primitive (issues #351, #355).
+    ///
+    /// When ``True`` (default), the server advertises
+    /// ``prompts: { listChanged }`` in its ``initialize`` response and
+    /// handles ``prompts/list`` + ``prompts/get``. Prompts are sourced
+    /// from each loaded skill's sibling ``prompts.yaml`` (pointed at by
+    /// ``metadata.dcc-mcp.prompts`` in SKILL.md) plus workflow-derived
+    /// auto-generated entries.
+    #[getter]
+    fn enable_prompts(&self) -> bool {
+        self.inner.enable_prompts
+    }
+
+    #[setter]
+    fn set_enable_prompts(&mut self, enabled: bool) {
+        self.inner.enable_prompts = enabled;
+    }
+
     fn __repr__(&self) -> String {
         format!(
             "McpHttpConfig(port={}, name={}, gateway_port={})",

--- a/crates/dcc-mcp-http/src/server.rs
+++ b/crates/dcc-mcp-http/src/server.rs
@@ -77,6 +77,7 @@ pub struct McpHttpServer {
     config: McpHttpConfig,
     executor: Option<DccExecutorHandle>,
     resources: crate::resources::ResourceRegistry,
+    prompts: crate::prompts::PromptRegistry,
 }
 
 impl McpHttpServer {
@@ -95,6 +96,7 @@ impl McpHttpServer {
             config.enable_resources,
             config.enable_artefact_resources,
         );
+        let prompts = crate::prompts::PromptRegistry::new(config.enable_prompts);
         Self {
             registry: registry.clone(),
             dispatcher,
@@ -102,6 +104,7 @@ impl McpHttpServer {
             config,
             executor: None,
             resources,
+            prompts,
         }
     }
 
@@ -119,6 +122,7 @@ impl McpHttpServer {
             config.enable_resources,
             config.enable_artefact_resources,
         );
+        let prompts = crate::prompts::PromptRegistry::new(config.enable_prompts);
         Self {
             registry,
             dispatcher,
@@ -126,7 +130,13 @@ impl McpHttpServer {
             config,
             executor: None,
             resources,
+            prompts,
         }
+    }
+
+    /// Access the MCP Prompts registry for this server (issues #351, #355).
+    pub fn prompts(&self) -> &crate::prompts::PromptRegistry {
+        &self.prompts
     }
 
     /// Access the MCP Resources registry for this server (issue #350).
@@ -223,6 +233,7 @@ impl McpHttpServer {
         };
 
         let resources = self.resources.clone();
+        let prompts = self.prompts.clone();
 
         // Forward `notifications/resources/updated` broadcasts to each
         // subscribed session's SSE channel (issue #350).
@@ -287,6 +298,8 @@ impl McpHttpServer {
             job_notifier,
             resources,
             enable_resources: self.config.enable_resources,
+            prompts,
+            enable_prompts: self.config.enable_prompts,
             #[cfg(feature = "prometheus")]
             prometheus: prometheus.clone(),
         };

--- a/crates/dcc-mcp-http/src/session.rs
+++ b/crates/dcc-mcp-http/src/session.rs
@@ -389,4 +389,14 @@ impl SessionManager {
     pub fn count(&self) -> usize {
         self.sessions.len()
     }
+
+    /// Snapshot of every active session id.
+    ///
+    /// Used by broadcast-style notifications (`prompts/list_changed`,
+    /// `tools/list_changed`) that fan out to every subscriber. The
+    /// returned vector is owned so the caller can iterate without
+    /// holding a shard lock.
+    pub fn all_ids(&self) -> Vec<String> {
+        self.sessions.iter().map(|e| e.key().clone()).collect()
+    }
 }

--- a/crates/dcc-mcp-http/src/tests.rs
+++ b/crates/dcc-mcp-http/src/tests.rs
@@ -63,6 +63,8 @@ mod tests {
             job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
             enable_resources: true,
+            prompts: crate::prompts::PromptRegistry::new(true),
+            enable_prompts: true,
         }
     }
 
@@ -823,6 +825,8 @@ mod tests {
             job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
             enable_resources: true,
+            prompts: crate::prompts::PromptRegistry::new(true),
+            enable_prompts: true,
         }
     }
 
@@ -1706,6 +1710,8 @@ mod tests {
             job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
             enable_resources: true,
+            prompts: crate::prompts::PromptRegistry::new(true),
+            enable_prompts: true,
         }
     }
 
@@ -2084,6 +2090,8 @@ mod tests {
             job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
             enable_resources: true,
+            prompts: crate::prompts::PromptRegistry::new(true),
+            enable_prompts: true,
         }
     }
 
@@ -2193,6 +2201,8 @@ mod tests {
             job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
             enable_resources: true,
+            prompts: crate::prompts::PromptRegistry::new(true),
+            enable_prompts: true,
         };
 
         use crate::handler::{handle_delete, handle_get, handle_post};
@@ -2426,6 +2436,8 @@ mod tests {
             job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
             enable_resources: true,
+            prompts: crate::prompts::PromptRegistry::new(true),
+            enable_prompts: true,
         }
     }
 
@@ -3462,6 +3474,8 @@ mod resource_link_integration_tests {
             job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
             enable_resources: true,
+            prompts: crate::prompts::PromptRegistry::new(true),
+            enable_prompts: true,
         }
     }
 
@@ -3652,6 +3666,8 @@ mod resource_link_integration_tests {
             job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
             enable_resources: true,
+            prompts: crate::prompts::PromptRegistry::new(true),
+            enable_prompts: true,
         }
     }
 
@@ -3934,6 +3950,8 @@ mod lazy_actions_tests {
             job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
             enable_resources: true,
+            prompts: crate::prompts::PromptRegistry::new(true),
+            enable_prompts: true,
         }
     }
 
@@ -4259,6 +4277,8 @@ mod next_tools_meta_tests {
             job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
             enable_resources: true,
+            prompts: crate::prompts::PromptRegistry::new(true),
+            enable_prompts: true,
         }
     }
 

--- a/crates/dcc-mcp-models/src/skill_metadata.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata.rs
@@ -1226,6 +1226,19 @@ pub struct SkillMetadata {
     /// keys. See [`SkillMetadata::is_spec_compliant`].
     #[serde(default, skip_serializing, skip_deserializing)]
     pub legacy_extension_fields: Vec<String>,
+
+    /// Sibling-file reference for the MCP prompts primitive (issues #351, #355).
+    ///
+    /// Set from `metadata.dcc-mcp.prompts` in SKILL.md frontmatter. The value
+    /// is a path relative to the skill root — either a single YAML file that
+    /// contains a top-level `prompts:` (and optional `workflows:`) list, or a
+    /// glob (`prompts/*.prompt.yaml`) that enumerates one file per prompt.
+    ///
+    /// Parsing is deferred until the MCP server handles a `prompts/list` or
+    /// `prompts/get` call, so a skill with 50 prompt files pays zero cost at
+    /// scan / load time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompts_file: Option<String>,
 }
 
 impl SkillMetadata {
@@ -1541,6 +1554,7 @@ impl SkillMetadata {
             external_deps: None,
             groups: Vec::new(),
             legacy_extension_fields: Vec::new(),
+            prompts_file: None,
         }
     }
 
@@ -2072,6 +2086,7 @@ mod tests {
             external_deps: None,
             groups: Vec::new(),
             legacy_extension_fields: Vec::new(),
+            prompts_file: None,
         };
         let json = serde_json::to_string(&meta).unwrap();
         let back: SkillMetadata = serde_json::from_str(&json).unwrap();

--- a/crates/dcc-mcp-skills/src/catalog/mod.rs
+++ b/crates/dcc-mcp-skills/src/catalog/mod.rs
@@ -689,6 +689,23 @@ impl SkillCatalog {
         self.loaded.contains(skill_name)
     }
 
+    /// Run a closure against every loaded skill's [`SkillMetadata`].
+    ///
+    /// Used by the MCP prompts primitive (issues #351, #355) to walk the
+    /// currently-loaded skills and lazily parse their sibling
+    /// `prompts.yaml` files on `prompts/list`. The closure is invoked
+    /// while a read guard on the underlying `DashMap` shard is held, so
+    /// it must not call back into the catalog (no `load_skill` /
+    /// `unload_skill`) or deadlock is possible.
+    pub fn for_each_loaded_metadata<F: FnMut(&dcc_mcp_models::SkillMetadata)>(&self, mut f: F) {
+        for entry in self.entries.iter() {
+            let e = entry.value();
+            if e.state == SkillState::Loaded {
+                f(&e.metadata);
+            }
+        }
+    }
+
     /// Remove a skill from the catalog entirely.
     ///
     /// If the skill is loaded, it is unloaded first.

--- a/crates/dcc-mcp-skills/src/loader/mod.rs
+++ b/crates/dcc-mcp-skills/src/loader/mod.rs
@@ -257,6 +257,17 @@ fn apply_dcc_mcp_metadata_overrides(
                     }
                 }
             }
+            "prompts" => {
+                // Issues #351, #355 — sibling-file reference for the MCP
+                // prompts primitive. Parsing is deferred; we just record
+                // the path (relative to skill root) so the MCP server can
+                // load it lazily on `prompts/list` / `prompts/get`.
+                if let Some(s) = value.as_str() {
+                    if !s.is_empty() {
+                        meta.prompts_file = Some(s.to_string());
+                    }
+                }
+            }
             _ => {
                 tracing::debug!(
                     "skill {}: unknown metadata.dcc-mcp.{} key — ignoring",

--- a/docs/guide/prompts.md
+++ b/docs/guide/prompts.md
@@ -1,0 +1,181 @@
+# MCP Prompts Primitive
+
+> Implements [MCP 2025-03-26 — Prompts](https://modelcontextprotocol.io/specification/2025-03-26/server/prompts)
+> for dcc-mcp-core. Issues [#351](https://github.com/loonghao/dcc-mcp-core/issues/351)
+> and [#355](https://github.com/loonghao/dcc-mcp-core/issues/355).
+
+The **prompts** primitive is the third MCP surface `McpHttpServer`
+advertises, alongside `tools` and `resources`. It gives AI clients a way
+to discover reusable **prompt templates** — natural-language instructions
+parameterised with arguments — that a skill author has hand-crafted to
+elicit the right behavioural chain from the model.
+
+Unlike `tools/call` (which executes side effects) and `resources/read`
+(which returns opaque bytes), `prompts/get` returns a **rendered message
+array** the client can splice straight into the conversation, preserving
+the skill author's intent without the model having to guess the right
+phrasing.
+
+## Wire protocol
+
+When enabled, the server advertises the primitive in `initialize`:
+
+```json
+{
+  "capabilities": {
+    "prompts": { "listChanged": true }
+  }
+}
+```
+
+Three JSON-RPC methods are exposed:
+
+| Method | Purpose |
+|--------|---------|
+| `prompts/list` | Return every registered prompt — name, description, argument schema. |
+| `prompts/get` | Render one prompt by name with caller-supplied arguments. |
+| `notifications/prompts/list_changed` | Server-pushed SSE event whenever a skill is loaded / unloaded. |
+
+## Source: sibling `prompts.yaml`
+
+Following the project-wide **sibling-file rule** ([#356](https://github.com/loonghao/dcc-mcp-core/issues/356)),
+prompt templates never inline into `SKILL.md`. The skill author references
+a sibling file from the `metadata.dcc-mcp` namespace:
+
+```yaml
+---
+name: maya-geometry
+description: "Maya geometry primitives and editing."
+metadata:
+  dcc-mcp.dcc: maya
+  dcc-mcp.prompts: prompts.yaml     # single file, or
+  # dcc-mcp.prompts: prompts/*.prompt.yaml   # glob, one file per prompt
+---
+```
+
+`prompts.yaml` contains two top-level lists — both optional:
+
+```yaml
+prompts:
+  - name: bevel_all_edges
+    description: "Bevel every selected edge with a consistent chamfer width."
+    arguments:
+      - name: chamfer_width
+        description: "Chamfer width in Maya units."
+        required: true
+      - name: segments
+        description: "Number of chamfer segments (default 2)."
+        required: false
+    template: |
+      Use `maya_geometry__select_edges` to capture the current selection,
+      then call `maya_geometry__bevel_edges` with width={{chamfer_width}}
+      and segments={{segments}}. Verify the result with
+      `diagnostics__screenshot` before saving.
+
+workflows:
+  - file: workflows/bake_proxies.workflow.yaml
+    prompt_name: bake_proxies_summary      # optional rename
+```
+
+### Explicit prompts
+
+Each entry under `prompts:` is a `PromptSpec`:
+
+| Field         | Type              | Required | Notes                                                         |
+|---------------|-------------------|----------|---------------------------------------------------------------|
+| `name`        | string            | ✅        | Unique within the skill. Fully-qualified when served as MCP. |
+| `description` | string            | ✅        | One-line summary the client shows to the user.               |
+| `arguments`   | list[ArgumentSpec] | ❌       | Typed placeholders for the template.                         |
+| `template`    | string            | ✅        | `{{name}}` placeholders resolved against call-site arguments. |
+
+`ArgumentSpec` fields: `name`, `description`, `required` (default `false`).
+
+### Workflow-derived prompts
+
+The `workflows:` list auto-generates a summary prompt per referenced
+workflow. This is a minimal behavioural chain hint — "here are the steps
+that workflow runs, in order" — suitable for agents that want to narrate
+the workflow before (or instead of) executing it:
+
+```yaml
+workflows:
+  - file: workflows/bake_proxies.workflow.yaml
+```
+
+No `template` is needed; the registry summarises the workflow's
+description + step list into a user-role message. Use `prompt_name` to
+override the default auto-generated name.
+
+### Single file vs glob
+
+Both forms are accepted in `metadata.dcc-mcp.prompts`:
+
+- `prompts.yaml` — single file with `prompts:` + `workflows:` lists.
+- `prompts/*.prompt.yaml` — glob, one file per prompt. Each file has the
+  same shape as a single entry in `prompts:`.
+
+Parsing is **lazy**: the path is recorded at scan / load time; the file
+contents are only read when the server handles `prompts/list` or
+`prompts/get`.
+
+## Templating engine
+
+The rendering engine is intentionally minimal — one token only:
+`{{placeholder}}`.
+
+- Whitespace inside braces is trimmed: `{{ foo }}` == `{{foo}}`.
+- An undeclared required argument raises
+  `INVALID_PARAMS: missing required argument: <name>`.
+- Brace content that isn't a bare identifier (`{{ 1 + 1 }}`) is left
+  untouched — the engine never evaluates expressions.
+- Unclosed `{{` with no matching `}}` is emitted verbatim.
+
+Keep templates small and declarative. If a template needs loops,
+conditionals, or data fetches, author it as a **workflow** (issue #348)
+instead and reference it from the `workflows:` list.
+
+## Server configuration
+
+The primitive is **enabled by default**. Disable it globally with
+`McpHttpConfig.enable_prompts = false`:
+
+```python
+from dcc_mcp_core import McpHttpConfig, create_skill_server
+
+cfg = McpHttpConfig(port=8765)
+cfg.enable_prompts = False     # opt out — capability vanishes from initialize
+server = create_skill_server("maya", cfg)
+server.start()
+```
+
+When disabled, the server omits the `prompts` capability and rejects
+`prompts/list` / `prompts/get` with `Method not found`.
+
+## `list_changed` invariants
+
+- `notifications/prompts/list_changed` fires whenever the set of loaded
+  skills changes (`skills/load`, `skills/unload`, hot-reload).
+- The registry's internal cache is invalidated in the same critical
+  section that emits the notification — clients may call `prompts/list`
+  immediately after and will observe the new set.
+- The notification fans out to every active SSE session; there is no
+  per-session subscription model for prompts.
+
+## Guidance for skill authors
+
+1. Keep `template` bodies **under 50 lines**. Longer guidance belongs in
+   `references/` and should be pulled in by the workflow layer.
+2. Prefer **fully-qualified tool names** inside templates
+   (`maya_geometry__bevel_edges`) — the agent then doesn't have to guess.
+3. If the behavioural chain is more than 3-4 tool calls, extract it to a
+   `workflow.yaml` and let the server auto-generate the summary prompt.
+4. Don't put secrets or environment-specific paths in templates —
+   prompts are surfaced verbatim to the model.
+
+## Related issues
+
+- [#351](https://github.com/loonghao/dcc-mcp-core/issues/351) — MCP prompts primitive
+- [#355](https://github.com/loonghao/dcc-mcp-core/issues/355) — prompts derived from SKILL.md examples + workflows
+- [#348](https://github.com/loonghao/dcc-mcp-core/issues/348) — workflow specs (source for auto-derived prompts)
+- [#356](https://github.com/loonghao/dcc-mcp-core/issues/356) — sibling-file pattern
+- [#350](https://github.com/loonghao/dcc-mcp-core/issues/350) — MCP resources primitive (sister feature)

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -754,6 +754,7 @@ in `legacy_extension_fields`).
 | `external_deps: {...}`          | `metadata["dcc-mcp.external-deps"]`          | JSON string           |
 | `tools: [...]` inline block     | `metadata["dcc-mcp.tools"]`                  | sibling `.yaml` file  |
 | `groups: [...]` inline block    | `metadata["dcc-mcp.groups"]`                 | sibling `.yaml` file  |
+| _(MCP prompts primitive)_       | `metadata["dcc-mcp.prompts"]`                | sibling `.yaml` file or `prompts/*.prompt.yaml` glob |
 
 ### Priority rules
 

--- a/tests/test_prompts_primitive.py
+++ b/tests/test_prompts_primitive.py
@@ -1,0 +1,39 @@
+"""Tests for the MCP prompts primitive (issues #351, #355).
+
+Covers:
+* ``McpHttpConfig.enable_prompts`` getter / setter round-trips.
+* The prompts capability defaults ON.
+* Server initialisation and ``initialize`` response advertises
+  ``prompts: { listChanged: true }`` when enabled.
+
+Full end-to-end ``prompts/list`` + ``prompts/get`` are exercised by the Rust
+integration tests in ``crates/dcc-mcp-http``; the Python layer only needs to
+verify the configuration surface behaves as documented.
+"""
+
+from __future__ import annotations
+
+from dcc_mcp_core import McpHttpConfig
+
+
+def test_enable_prompts_default_on() -> None:
+    cfg = McpHttpConfig(port=0)
+    assert cfg.enable_prompts is True
+
+
+def test_enable_prompts_setter_round_trip() -> None:
+    cfg = McpHttpConfig(port=0)
+    cfg.enable_prompts = False
+    assert cfg.enable_prompts is False
+    cfg.enable_prompts = True
+    assert cfg.enable_prompts is True
+
+
+def test_enable_prompts_independent_from_resources() -> None:
+    cfg = McpHttpConfig(port=0)
+    cfg.enable_prompts = False
+    assert cfg.enable_resources is True
+    cfg.enable_resources = False
+    cfg.enable_prompts = True
+    assert cfg.enable_prompts is True
+    assert cfg.enable_resources is False


### PR DESCRIPTION
## Summary

Adds the **MCP prompts primitive** (MCP 2025-03-26) to the HTTP server, sourced from each loaded skill's sibling `prompts.yaml` (or `prompts/*.prompt.yaml` glob) referenced by `metadata.dcc-mcp.prompts` in SKILL.md — the same sibling-file pattern introduced in #356. Workflows referenced from the same spec auto-generate summary prompts that narrate the tool chain, giving AI agents a behavioural-chain hint without the skill author writing one by hand.

Closes #351
Closes #355

## What's implemented

- **Wire protocol**: `initialize` advertises `prompts: { listChanged: true }`; `prompts/list` and `prompts/get` dispatch through a new `PromptRegistry` with a lazy, loaded-skill-scoped cache.
- **Templating engine**: minimal `{{var}}` substitution — whitespace-tolerant, missing required args return `INVALID_PARAMS`, non-placeholder brace content (`{{ 1 + 1 }}`) passes through verbatim.
- **Notifications**: `notifications/prompts/list_changed` fans out to every active SSE session on skill load / unload; the registry cache is invalidated in the same critical section so the next `prompts/list` sees the new set immediately.
- **Config**: new `McpHttpConfig::enable_prompts` (default `true`) toggles the primitive; Python `McpHttpConfig.enable_prompts` getter + setter for parity with `enable_resources`.
- **Workflow-derived prompts**: entries under `workflows:` in `prompts.yaml` auto-generate a user-role summary prompt of the referenced `.workflow.yaml`'s description + step list.
- **Two input shapes**: `metadata.dcc-mcp.prompts` accepts either a single file (top-level `prompts:` + `workflows:` lists) or a glob (`prompts/*.prompt.yaml`, one file per prompt).

## Gateway / lifecycle invariants preserved

- `enable_prompts = false` → capability vanishes from `initialize`, methods return `Method not found` — unchanged from the tools/resources pattern.
- Cache is lazy: a skill with 50 prompt files pays zero cost at scan / load time; the first `prompts/list` parses them.
- `SkillCatalog::for_each_loaded_metadata` is the only coupling point between `dcc-mcp-http` and `dcc-mcp-skills`; the closure runs under the catalog's read guard so callbacks must not re-enter the catalog.

## Test plan

- [x] `vx cargo test -p dcc-mcp-http --lib` → **213 pass** (11 new in `prompts::tests` for render engine, registry lifecycle, YAML parsing)
- [x] `vx just preflight` → green (cargo check + clippy + fmt + test-rust)
- [x] `vx just dev` → wheel builds cleanly with the new `prompts_file` field on `SkillMetadata`
- [x] `python -m pytest tests/` → **8215 pass** (3 new in `test_prompts_primitive.py` for config round-trip)

## Docs updated

- `docs/guide/prompts.md` — full spec walk-through with YAML examples and authoring guidance
- `docs/guide/skills.md` — sibling-file mapping table now includes the prompts row
- `AGENTS.md` — new navigation entry under "Decision Tree"
- `CLAUDE.md` — Quick Lookup block example for `enable_prompts`
