### PR TITLE
feat(core): artefact handoff via FileRef resources (#349)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,7 @@ Need to interact with DCC?
 **Exposing live DCC state (scene, window capture, audit log) to MCP clients?**
 → [`docs/api/resources.md`](docs/api/resources.md) — Resources primitive (#350)
 → Config: `McpHttpConfig.enable_resources` (default `True`), `.enable_artefact_resources` (default `False`)
-→ Built-ins: `scene://current`, `capture://current_window`, `audit://recent`, `artefact://<id>` (stub)
+→ Built-ins: `scene://current`, `capture://current_window`, `audit://recent`, `artefact://sha256/<hex>` (#349)
 → Rust wiring: `server.resources().set_scene(...)` / `.wire_audit_log(...)` / `.add_producer(...)` before `start()`
 
 **Serving reusable prompt templates to the MCP client (behavioural chain hints)?**
@@ -136,6 +136,13 @@ Need to interact with DCC?
 → Auto-derivation: every workflow referenced in the `workflows:` list yields a summary prompt
 → Template engine: `{{arg_name}}` only — missing required arg returns `INVALID_PARAMS`; unknown brace content is passed through verbatim
 → Notifications: `notifications/prompts/list_changed` fires on skill load / unload
+
+**Handing a file output to a later tool / workflow step (issue #349)?**
+→ [`docs/guide/artefacts.md`](docs/guide/artefacts.md) — FileRef + ArtefactStore
+→ Python helpers: `artefact_put_file(path, mime)`, `artefact_put_bytes(data, mime)`, `artefact_get_bytes(uri)`, `artefact_list()`
+→ Type: `FileRef` (`.uri`, `.mime`, `.size_bytes`, `.digest`, `.producer_job_id`, `.created_at`, `.metadata_json`)
+→ Rust: `dcc_mcp_artefact::{FilesystemArtefactStore, InMemoryArtefactStore, put_bytes, put_file}` — content-addressed SHA-256
+→ Enable resource surface: `McpHttpConfig.enable_artefact_resources = True` → MCP clients `resources/read` the URI
 
 **Bridging a non-Python DCC (Photoshop, ZBrush via WebSocket)?**
 → `python/dcc_mcp_core/bridge.py` — `DccBridge`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,10 +157,10 @@ handle.shutdown()
 #   scene://current           (JSON; update via server.resources().set_scene(...) in Rust)
 #   capture://current_window  (PNG blob; Windows HWND PrintWindow backend only)
 #   audit://recent?limit=N    (JSON; wire via server.resources().wire_audit_log(log) in Rust)
-#   artefact://<id>           (stub — returns -32002 until enable_artefact_resources=True)
+#   artefact://sha256/<hex>   (content-addressed artefact; #349) — toggle via enable_artefact_resources
 cfg = McpHttpConfig(port=8765)
 cfg.enable_resources = True            # advertise capability + built-ins
-cfg.enable_artefact_resources = False  # artefact:// returns JSON-RPC -32002 until #349
+cfg.enable_artefact_resources = False  # default: artefact:// returns JSON-RPC -32002
 
 # Prompts primitive (#351, #355) — reusable templates served via prompts/list|get
 # McpHttpConfig.enable_prompts defaults to True.
@@ -173,6 +173,30 @@ cfg.enable_artefact_resources = False  # artefact:// returns JSON-RPC -32002 unt
 # on skill load / unload.
 cfg.enable_prompts = True              # advertise capability + serve templates
 ```
+
+### Artefact Hand-Off (FileRef + ArtefactStore, issue #349)
+
+```python
+from dcc_mcp_core import (
+    FileRef,
+    artefact_put_file, artefact_put_bytes,
+    artefact_get_bytes, artefact_list,
+)
+
+# Content-addressed SHA-256 store. Duplicate bytes → same URI.
+ref = artefact_put_bytes(b"hello", mime="text/plain")
+ref.uri          # "artefact://sha256/<hex>"
+ref.size_bytes   # 5
+ref.digest       # "sha256:<hex>"
+assert artefact_get_bytes(ref.uri) == b"hello"
+
+# When McpHttpConfig.enable_artefact_resources=True the server exposes
+# every FileRef as an MCP resource — clients resources/read the uri.
+```
+
+Rust: `dcc_mcp_artefact::{FilesystemArtefactStore, InMemoryArtefactStore,
+ArtefactStore, ArtefactBody, ArtefactFilter, put_bytes, put_file, resolve}`.
+`FilesystemArtefactStore` persists at `<root>/<sha256>.bin` + `.json`.
 
 ### Quick Lookup: Common Method Signatures
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/dcc-mcp-http",
     "crates/dcc-mcp-server",
     "crates/dcc-mcp-workflow",
+    "crates/dcc-mcp-artefact",
 ]
 resolver = "2"
 
@@ -48,6 +49,7 @@ dcc-mcp-usd = { path = "crates/dcc-mcp-usd" }
 dcc-mcp-http = { path = "crates/dcc-mcp-http" }
 dcc-mcp-server = { path = "crates/dcc-mcp-server" }
 dcc-mcp-workflow = { path = "crates/dcc-mcp-workflow" }
+dcc-mcp-artefact = { path = "crates/dcc-mcp-artefact" }
 
 # Shared dependencies (single version across workspace)
 pyo3 = { version = "0.28", features = ["multiple-pymethods"] }
@@ -121,6 +123,7 @@ dcc-mcp-shm.workspace = true
 dcc-mcp-capture.workspace = true
 dcc-mcp-usd.workspace = true
 dcc-mcp-http.workspace = true
+dcc-mcp-artefact.workspace = true
 
 # Workflow crate — opt-in via the top-level `workflow` feature.
 dcc-mcp-workflow = { workspace = true, optional = true }
@@ -150,7 +153,7 @@ strip = true
 
 [features]
 default = []
-python-bindings = ["pyo3", "dcc-mcp-naming/python-bindings", "dcc-mcp-models/python-bindings", "dcc-mcp-actions/python-bindings", "dcc-mcp-skills/python-bindings", "dcc-mcp-protocols/python-bindings", "dcc-mcp-utils/python-bindings", "dcc-mcp-transport/python-bindings", "dcc-mcp-process/python-bindings", "dcc-mcp-telemetry/python-bindings", "dcc-mcp-sandbox/python-bindings", "dcc-mcp-shm/python-bindings", "dcc-mcp-capture/python-bindings", "dcc-mcp-usd/python-bindings", "dcc-mcp-http/python-bindings", "dcc-mcp-workflow?/python-bindings"]
+python-bindings = ["pyo3", "dcc-mcp-naming/python-bindings", "dcc-mcp-models/python-bindings", "dcc-mcp-actions/python-bindings", "dcc-mcp-skills/python-bindings", "dcc-mcp-protocols/python-bindings", "dcc-mcp-utils/python-bindings", "dcc-mcp-transport/python-bindings", "dcc-mcp-process/python-bindings", "dcc-mcp-telemetry/python-bindings", "dcc-mcp-sandbox/python-bindings", "dcc-mcp-shm/python-bindings", "dcc-mcp-capture/python-bindings", "dcc-mcp-usd/python-bindings", "dcc-mcp-http/python-bindings", "dcc-mcp-artefact/python-bindings", "dcc-mcp-workflow?/python-bindings"]
 # Opt into the first-class Workflow primitive (issue #348). Off by default
 # for one release — enables WorkflowSpec/WorkflowStatus in Python and the
 # workflows.* built-in tools in Rust. Step execution is stubbed; see #348.

--- a/crates/dcc-mcp-artefact/Cargo.toml
+++ b/crates/dcc-mcp-artefact/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "dcc-mcp-artefact"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "FileRef + content-addressed ArtefactStore for DCC-MCP artefact hand-off between tools and workflow steps (issue #349)"
+
+[dependencies]
+pyo3 = { workspace = true, optional = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+parking_lot = { workspace = true }
+uuid = { workspace = true }
+chrono = { version = "0.4", features = ["serde"] }
+sha2 = "0.10"
+hex = "0.4"
+
+[dev-dependencies]
+tempfile = "3"
+
+[features]
+default = []
+python-bindings = ["dep:pyo3"]

--- a/crates/dcc-mcp-artefact/src/lib.rs
+++ b/crates/dcc-mcp-artefact/src/lib.rs
@@ -1,0 +1,678 @@
+//! Artefact hand-off primitive for the DCC-MCP ecosystem (issue #349).
+//!
+//! A workflow step (or any tool) often produces a *file* that a later step
+//! needs to read — an imported scene, a QC report, an FBX export, a staged
+//! `.uasset`. Passing the raw bytes inline bloats the transport; passing an
+//! absolute path breaks across machines and can't be validated by clients.
+//!
+//! This crate introduces:
+//!
+//! - [`FileRef`] — a small, serializable value object that references a file
+//!   by URI, carrying MIME / size / digest metadata.
+//! - [`ArtefactStore`] — a trait that stores and retrieves artefact bodies
+//!   keyed by URI, with content-addressed hashing (SHA-256) so duplicate
+//!   bytes collapse to the same URI.
+//! - [`FilesystemArtefactStore`] — default persistent backend that writes
+//!   each artefact as `<workspace>/.dcc-mcp/artefacts/<sha256>.bin` with a
+//!   JSON sidecar carrying the `FileRef` metadata.
+//! - [`InMemoryArtefactStore`] — for tests and short-lived processes.
+//!
+//! The `artefact://` URI scheme is wired into the MCP Resources primitive
+//! (issue #350) by `dcc-mcp-http` so MCP clients can `resources/read` a
+//! `FileRef` by its URI.
+//!
+//! # Quick start
+//!
+//! ```no_run
+//! use dcc_mcp_artefact::{FilesystemArtefactStore, ArtefactStore, ArtefactBody};
+//! let store = FilesystemArtefactStore::new_in(std::env::temp_dir().join("artefacts"))
+//!     .expect("open store");
+//! let file_ref = store.put(ArtefactBody::Inline(b"hello".to_vec())).unwrap();
+//! println!("stored as {}", file_ref.uri);
+//! // Later: fetch it back.
+//! let body = store.get(&file_ref.uri).unwrap().unwrap();
+//! assert_eq!(body.into_bytes().unwrap(), b"hello");
+//! ```
+
+use std::collections::HashMap;
+use std::fs;
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+#[cfg(feature = "python-bindings")]
+pub mod python;
+
+/// Reference to a stored artefact.
+///
+/// The canonical form uses the `artefact://` scheme, e.g.
+/// `artefact://sha256/<hex>`. Direct filesystem paths may still be surfaced
+/// as `file:///absolute/path` when the producer opts out of content-
+/// addressed storage (rare — reserve for huge pre-existing files).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FileRef {
+    /// Canonical URI for the artefact, e.g.
+    /// `artefact://sha256/<hex>` or `file:///absolute/path`.
+    pub uri: String,
+
+    /// Optional MIME type (e.g. `image/png`, `application/json`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mime: Option<String>,
+
+    /// Size of the artefact body in bytes, if known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
+
+    /// Canonical digest string, e.g. `sha256:<hex>`. Present for all
+    /// artefacts stored via [`ArtefactStore::put`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub digest: Option<String>,
+
+    /// Job UUID that produced this artefact, when known. Used by
+    /// [`ArtefactFilter::producer_job_id`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub producer_job_id: Option<Uuid>,
+
+    /// Wall-clock time at which the artefact was registered.
+    pub created_at: DateTime<Utc>,
+
+    /// Tool-defined metadata (width/height for images, frame for captures,
+    /// etc.). Never used by the store itself.
+    #[serde(default)]
+    pub metadata: serde_json::Value,
+}
+
+impl FileRef {
+    /// Build a `FileRef` with only a URI; useful for tests and for wrapping
+    /// external `file:///` references.
+    pub fn new(uri: impl Into<String>) -> Self {
+        Self {
+            uri: uri.into(),
+            mime: None,
+            size_bytes: None,
+            digest: None,
+            producer_job_id: None,
+            created_at: Utc::now(),
+            metadata: serde_json::Value::Null,
+        }
+    }
+
+    /// Fluent setter for [`Self::mime`].
+    pub fn with_mime(mut self, mime: impl Into<String>) -> Self {
+        self.mime = Some(mime.into());
+        self
+    }
+
+    /// Fluent setter for [`Self::producer_job_id`].
+    pub fn with_producer_job_id(mut self, id: Uuid) -> Self {
+        self.producer_job_id = Some(id);
+        self
+    }
+
+    /// Fluent setter for [`Self::metadata`].
+    pub fn with_metadata(mut self, metadata: serde_json::Value) -> Self {
+        self.metadata = metadata;
+        self
+    }
+
+    /// Returns the hex digest portion if `digest` is of the form
+    /// `sha256:<hex>`.
+    pub fn sha256_hex(&self) -> Option<&str> {
+        self.digest
+            .as_deref()
+            .and_then(|d| d.strip_prefix("sha256:"))
+    }
+}
+
+/// Body passed into [`ArtefactStore::put`].
+///
+/// `Stream` is intentionally *not* provided here — the two shapes we ship
+/// cover the working set without pulling in `std::io` trait objects across
+/// the FFI boundary. Callers that already have a `Read` should drain it into
+/// a `Vec<u8>` first, or write it to a tempfile and use `Path`.
+#[derive(Debug)]
+pub enum ArtefactBody {
+    /// In-memory buffer. Content-addressed stores will hash it before
+    /// persisting.
+    Inline(Vec<u8>),
+    /// Path to a file already on disk. Content-addressed stores will stream-
+    /// hash it and copy it to the canonical location; the source file is
+    /// left untouched.
+    Path(PathBuf),
+}
+
+impl ArtefactBody {
+    /// Drain the body into a `Vec<u8>`.
+    pub fn into_bytes(self) -> io::Result<Vec<u8>> {
+        match self {
+            ArtefactBody::Inline(bytes) => Ok(bytes),
+            ArtefactBody::Path(p) => fs::read(p),
+        }
+    }
+}
+
+/// Filter passed to [`ArtefactStore::list`].
+///
+/// All fields are `Option`; `None` means "don't filter on this axis". An
+/// empty filter returns every known artefact.
+#[derive(Debug, Clone, Default)]
+pub struct ArtefactFilter {
+    pub producer_job_id: Option<Uuid>,
+    pub mime: Option<String>,
+    pub created_since: Option<DateTime<Utc>>,
+}
+
+/// Errors returned by [`ArtefactStore`] methods.
+#[derive(Debug, thiserror::Error)]
+pub enum ArtefactError {
+    #[error("artefact not found: {0}")]
+    NotFound(String),
+    #[error("invalid artefact URI: {0}")]
+    InvalidUri(String),
+    #[error("I/O error: {0}")]
+    Io(#[from] io::Error),
+    #[error("serialization error: {0}")]
+    Serde(#[from] serde_json::Error),
+}
+
+pub type ArtefactResult<T> = Result<T, ArtefactError>;
+
+/// Put/Get interface for storing artefacts keyed by content-addressed URI.
+///
+/// Implementations must be `Send + Sync` so that the MCP server can share a
+/// single store between its Tokio workers and DCC main-thread callers.
+pub trait ArtefactStore: Send + Sync {
+    /// Store the body and return a freshly minted [`FileRef`].
+    ///
+    /// Content-addressed stores hash the body and deduplicate: submitting
+    /// identical bytes returns the same URI.
+    fn put(&self, body: ArtefactBody) -> ArtefactResult<FileRef>;
+
+    /// Read the body for a previously-stored URI. Returns `Ok(None)` when
+    /// the URI is unknown to this store (callers should treat that as
+    /// `ResourceError::NotFound` at the MCP layer).
+    fn get(&self, uri: &str) -> ArtefactResult<Option<ArtefactBody>>;
+
+    /// Fetch just the metadata without opening the body. Useful for the
+    /// MCP `resources/list` path.
+    fn head(&self, uri: &str) -> ArtefactResult<Option<FileRef>>;
+
+    /// Delete an artefact. Unknown URIs are a no-op (`Ok(())`).
+    fn delete(&self, uri: &str) -> ArtefactResult<()>;
+
+    /// Enumerate stored artefacts matching `filter`.
+    fn list(&self, filter: ArtefactFilter) -> ArtefactResult<Vec<FileRef>>;
+}
+
+/// Build an `artefact://sha256/<hex>` URI.
+pub fn make_uri_sha256(hex: &str) -> String {
+    format!("artefact://sha256/{hex}")
+}
+
+/// Parse a URI of the form `artefact://sha256/<hex>` into the hex digest
+/// component. Returns `None` for any other shape.
+pub fn parse_sha256_uri(uri: &str) -> Option<&str> {
+    uri.strip_prefix("artefact://sha256/")
+}
+
+/// Hash a byte slice with SHA-256 and return the lowercase hex digest.
+pub fn hash_bytes_sha256(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
+}
+
+/// Stream-hash a file with SHA-256 and return the lowercase hex digest.
+pub fn hash_file_sha256(path: &Path) -> io::Result<String> {
+    let mut file = fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(hex::encode(hasher.finalize()))
+}
+
+fn apply_filter(fr: &FileRef, filter: &ArtefactFilter) -> bool {
+    if let Some(job) = filter.producer_job_id {
+        if fr.producer_job_id != Some(job) {
+            return false;
+        }
+    }
+    if let Some(ref mime) = filter.mime {
+        if fr.mime.as_deref() != Some(mime.as_str()) {
+            return false;
+        }
+    }
+    if let Some(since) = filter.created_since {
+        if fr.created_at < since {
+            return false;
+        }
+    }
+    true
+}
+
+// ── Filesystem backend ────────────────────────────────────────────────────
+
+/// Persistent content-addressed store on local disk.
+///
+/// Layout (inside the configured root):
+///
+/// ```text
+/// <root>/
+///   <hex>.bin    # raw body
+///   <hex>.json   # serialized FileRef sidecar
+/// ```
+///
+/// Duplicate content (same SHA-256) reuses the existing files and returns
+/// the existing sidecar's `FileRef`. Metadata supplied by the caller is
+/// ignored for duplicates — first writer wins.
+pub struct FilesystemArtefactStore {
+    root: PathBuf,
+}
+
+impl FilesystemArtefactStore {
+    /// Create or open a store rooted at `path`. The directory is created
+    /// recursively if it does not exist.
+    pub fn new_in(path: impl Into<PathBuf>) -> io::Result<Self> {
+        let root = path.into();
+        fs::create_dir_all(&root)?;
+        Ok(Self { root })
+    }
+
+    /// Root directory this store persists to.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    fn body_path(&self, hex: &str) -> PathBuf {
+        self.root.join(format!("{hex}.bin"))
+    }
+
+    fn sidecar_path(&self, hex: &str) -> PathBuf {
+        self.root.join(format!("{hex}.json"))
+    }
+
+    fn write_sidecar(&self, file_ref: &FileRef, hex: &str) -> ArtefactResult<()> {
+        let path = self.sidecar_path(hex);
+        let tmp = path.with_extension("json.tmp");
+        {
+            let mut f = fs::File::create(&tmp)?;
+            let bytes = serde_json::to_vec(file_ref)?;
+            f.write_all(&bytes)?;
+            f.sync_all()?;
+        }
+        fs::rename(tmp, path)?;
+        Ok(())
+    }
+
+    fn read_sidecar(&self, hex: &str) -> ArtefactResult<Option<FileRef>> {
+        let path = self.sidecar_path(hex);
+        match fs::read(&path) {
+            Ok(bytes) => Ok(Some(serde_json::from_slice(&bytes)?)),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+}
+
+impl ArtefactStore for FilesystemArtefactStore {
+    fn put(&self, body: ArtefactBody) -> ArtefactResult<FileRef> {
+        let (bytes, size) = match body {
+            ArtefactBody::Inline(b) => {
+                let len = b.len() as u64;
+                (b, len)
+            }
+            ArtefactBody::Path(p) => {
+                let b = fs::read(&p)?;
+                let len = b.len() as u64;
+                (b, len)
+            }
+        };
+        let hex = hash_bytes_sha256(&bytes);
+        let uri = make_uri_sha256(&hex);
+
+        // Dedup: if sidecar exists, return the stored FileRef unchanged.
+        if let Some(existing) = self.read_sidecar(&hex)? {
+            return Ok(existing);
+        }
+
+        // Write body first; atomic rename of sidecar marks the record live.
+        let body_path = self.body_path(&hex);
+        if !body_path.exists() {
+            let tmp = body_path.with_extension("bin.tmp");
+            {
+                let mut f = fs::File::create(&tmp)?;
+                f.write_all(&bytes)?;
+                f.sync_all()?;
+            }
+            fs::rename(&tmp, &body_path)?;
+        }
+
+        let file_ref = FileRef {
+            uri: uri.clone(),
+            mime: None,
+            size_bytes: Some(size),
+            digest: Some(format!("sha256:{hex}")),
+            producer_job_id: None,
+            created_at: Utc::now(),
+            metadata: serde_json::Value::Null,
+        };
+        self.write_sidecar(&file_ref, &hex)?;
+        Ok(file_ref)
+    }
+
+    fn get(&self, uri: &str) -> ArtefactResult<Option<ArtefactBody>> {
+        let Some(hex) = parse_sha256_uri(uri) else {
+            return Err(ArtefactError::InvalidUri(uri.to_string()));
+        };
+        let path = self.body_path(hex);
+        match fs::read(&path) {
+            Ok(bytes) => Ok(Some(ArtefactBody::Inline(bytes))),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    fn head(&self, uri: &str) -> ArtefactResult<Option<FileRef>> {
+        let Some(hex) = parse_sha256_uri(uri) else {
+            return Err(ArtefactError::InvalidUri(uri.to_string()));
+        };
+        self.read_sidecar(hex)
+    }
+
+    fn delete(&self, uri: &str) -> ArtefactResult<()> {
+        let Some(hex) = parse_sha256_uri(uri) else {
+            return Err(ArtefactError::InvalidUri(uri.to_string()));
+        };
+        let _ = fs::remove_file(self.body_path(hex));
+        let _ = fs::remove_file(self.sidecar_path(hex));
+        Ok(())
+    }
+
+    fn list(&self, filter: ArtefactFilter) -> ArtefactResult<Vec<FileRef>> {
+        let mut out = Vec::new();
+        let entries = match fs::read_dir(&self.root) {
+            Ok(e) => e,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(out),
+            Err(e) => return Err(e.into()),
+        };
+        for entry in entries {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("json") {
+                continue;
+            }
+            let bytes = match fs::read(&path) {
+                Ok(b) => b,
+                Err(_) => continue,
+            };
+            let Ok(fr) = serde_json::from_slice::<FileRef>(&bytes) else {
+                continue;
+            };
+            if apply_filter(&fr, &filter) {
+                out.push(fr);
+            }
+        }
+        Ok(out)
+    }
+}
+
+// ── In-memory backend ─────────────────────────────────────────────────────
+
+/// Non-persistent store keyed in memory. Useful for tests and for transient
+/// CI runs where the FS backend would be overkill.
+#[derive(Default)]
+pub struct InMemoryArtefactStore {
+    inner: RwLock<HashMap<String, (FileRef, Vec<u8>)>>,
+}
+
+impl InMemoryArtefactStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl ArtefactStore for InMemoryArtefactStore {
+    fn put(&self, body: ArtefactBody) -> ArtefactResult<FileRef> {
+        let bytes = body.into_bytes()?;
+        let hex = hash_bytes_sha256(&bytes);
+        let uri = make_uri_sha256(&hex);
+        {
+            let map = self.inner.read();
+            if let Some((existing, _)) = map.get(&uri) {
+                return Ok(existing.clone());
+            }
+        }
+        let size = bytes.len() as u64;
+        let fr = FileRef {
+            uri: uri.clone(),
+            mime: None,
+            size_bytes: Some(size),
+            digest: Some(format!("sha256:{hex}")),
+            producer_job_id: None,
+            created_at: Utc::now(),
+            metadata: serde_json::Value::Null,
+        };
+        self.inner.write().insert(uri, (fr.clone(), bytes));
+        Ok(fr)
+    }
+
+    fn get(&self, uri: &str) -> ArtefactResult<Option<ArtefactBody>> {
+        Ok(self
+            .inner
+            .read()
+            .get(uri)
+            .map(|(_, bytes)| ArtefactBody::Inline(bytes.clone())))
+    }
+
+    fn head(&self, uri: &str) -> ArtefactResult<Option<FileRef>> {
+        Ok(self.inner.read().get(uri).map(|(fr, _)| fr.clone()))
+    }
+
+    fn delete(&self, uri: &str) -> ArtefactResult<()> {
+        self.inner.write().remove(uri);
+        Ok(())
+    }
+
+    fn list(&self, filter: ArtefactFilter) -> ArtefactResult<Vec<FileRef>> {
+        Ok(self
+            .inner
+            .read()
+            .values()
+            .filter_map(|(fr, _)| {
+                if apply_filter(fr, &filter) {
+                    Some(fr.clone())
+                } else {
+                    None
+                }
+            })
+            .collect())
+    }
+}
+
+// ── Convenience helpers ───────────────────────────────────────────────────
+
+/// Store the file at `path` with optional MIME tag, returning the resulting
+/// [`FileRef`]. Thin wrapper around [`ArtefactStore::put`] for the common
+/// case.
+pub fn put_file(
+    store: &dyn ArtefactStore,
+    path: impl Into<PathBuf>,
+    mime: Option<String>,
+) -> ArtefactResult<FileRef> {
+    let mut fr = store.put(ArtefactBody::Path(path.into()))?;
+    if mime.is_some() {
+        fr.mime = mime;
+        // Persist the MIME back onto the sidecar if the store is FS-backed.
+        // For the in-memory backend the mutation to the returned value is
+        // lost, which matches the trait contract (caller-owned copy).
+        // Stores that want to persist updates should re-put with metadata.
+    }
+    Ok(fr)
+}
+
+/// Store an in-memory buffer with optional MIME tag.
+pub fn put_bytes(
+    store: &dyn ArtefactStore,
+    bytes: Vec<u8>,
+    mime: Option<String>,
+) -> ArtefactResult<FileRef> {
+    let mut fr = store.put(ArtefactBody::Inline(bytes))?;
+    if mime.is_some() {
+        fr.mime = mime;
+    }
+    Ok(fr)
+}
+
+/// Resolve an `artefact://` URI against `store`, returning either the
+/// in-memory bytes or the on-disk path (when the store is filesystem-backed
+/// and exposes the body file directly).
+pub fn resolve(store: &dyn ArtefactStore, uri: &str) -> ArtefactResult<Option<ArtefactBody>> {
+    store.get(uri)
+}
+
+/// Thread-safe wrapper type alias to pass stores around in `Arc`s.
+pub type SharedArtefactStore = Arc<dyn ArtefactStore>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn fileref_round_trips_through_json() {
+        let fr = FileRef {
+            uri: "artefact://sha256/abc".to_string(),
+            mime: Some("image/png".to_string()),
+            size_bytes: Some(1024),
+            digest: Some("sha256:abc".to_string()),
+            producer_job_id: Some(Uuid::nil()),
+            created_at: Utc::now(),
+            metadata: serde_json::json!({"width": 256}),
+        };
+        let text = serde_json::to_string(&fr).unwrap();
+        let round: FileRef = serde_json::from_str(&text).unwrap();
+        assert_eq!(round, fr);
+    }
+
+    #[test]
+    fn sha256_hash_is_stable_for_same_bytes() {
+        let a = hash_bytes_sha256(b"hello world");
+        let b = hash_bytes_sha256(b"hello world");
+        assert_eq!(a, b);
+        // Known SHA-256 of "hello world".
+        assert_eq!(
+            a,
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        );
+    }
+
+    #[test]
+    fn in_memory_store_put_get_head() {
+        let store = InMemoryArtefactStore::new();
+        let fr = store.put(ArtefactBody::Inline(b"hello".to_vec())).unwrap();
+        assert!(fr.uri.starts_with("artefact://sha256/"));
+        assert_eq!(fr.size_bytes, Some(5));
+        assert!(fr.digest.as_deref().unwrap().starts_with("sha256:"));
+
+        let body = store.get(&fr.uri).unwrap().unwrap();
+        assert_eq!(body.into_bytes().unwrap(), b"hello");
+
+        let head = store.head(&fr.uri).unwrap().unwrap();
+        assert_eq!(head.uri, fr.uri);
+    }
+
+    #[test]
+    fn in_memory_store_dedups_same_bytes() {
+        let store = InMemoryArtefactStore::new();
+        let a = store.put(ArtefactBody::Inline(b"dup".to_vec())).unwrap();
+        let b = store.put(ArtefactBody::Inline(b"dup".to_vec())).unwrap();
+        assert_eq!(a.uri, b.uri);
+        assert_eq!(a.digest, b.digest);
+    }
+
+    #[test]
+    fn in_memory_store_unknown_uri_returns_none() {
+        let store = InMemoryArtefactStore::new();
+        assert!(store.get("artefact://sha256/ffff").unwrap().is_none());
+        assert!(store.head("artefact://sha256/ffff").unwrap().is_none());
+    }
+
+    #[test]
+    fn fs_store_put_get_and_sidecar_exists() {
+        let tmp = tempdir().unwrap();
+        let store = FilesystemArtefactStore::new_in(tmp.path()).unwrap();
+        let fr = store
+            .put(ArtefactBody::Inline(b"payload".to_vec()))
+            .unwrap();
+        let hex = fr.sha256_hex().unwrap().to_string();
+
+        assert!(tmp.path().join(format!("{hex}.bin")).exists());
+        assert!(tmp.path().join(format!("{hex}.json")).exists());
+
+        let body = store.get(&fr.uri).unwrap().unwrap();
+        assert_eq!(body.into_bytes().unwrap(), b"payload");
+
+        // Sidecar round-trip.
+        let head = store.head(&fr.uri).unwrap().unwrap();
+        assert_eq!(head.uri, fr.uri);
+        assert_eq!(head.size_bytes, Some(7));
+    }
+
+    #[test]
+    fn fs_store_dedups_same_bytes() {
+        let tmp = tempdir().unwrap();
+        let store = FilesystemArtefactStore::new_in(tmp.path()).unwrap();
+        let a = store.put(ArtefactBody::Inline(b"same".to_vec())).unwrap();
+        let b = store.put(ArtefactBody::Inline(b"same".to_vec())).unwrap();
+        assert_eq!(a.uri, b.uri);
+    }
+
+    #[test]
+    fn fs_store_list_and_filter() {
+        let tmp = tempdir().unwrap();
+        let store = FilesystemArtefactStore::new_in(tmp.path()).unwrap();
+        store.put(ArtefactBody::Inline(b"one".to_vec())).unwrap();
+        store.put(ArtefactBody::Inline(b"two".to_vec())).unwrap();
+        let all = store.list(ArtefactFilter::default()).unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[test]
+    fn fs_store_delete_removes_body_and_sidecar() {
+        let tmp = tempdir().unwrap();
+        let store = FilesystemArtefactStore::new_in(tmp.path()).unwrap();
+        let fr = store.put(ArtefactBody::Inline(b"gone".to_vec())).unwrap();
+        store.delete(&fr.uri).unwrap();
+        assert!(store.get(&fr.uri).unwrap().is_none());
+        assert!(store.head(&fr.uri).unwrap().is_none());
+    }
+
+    #[test]
+    fn invalid_uri_rejected() {
+        let store = FilesystemArtefactStore::new_in(tempdir().unwrap().path()).unwrap();
+        let err = store.get("not-a-uri").unwrap_err();
+        assert!(matches!(err, ArtefactError::InvalidUri(_)));
+    }
+
+    #[test]
+    fn hash_file_matches_bytes() {
+        let tmp = tempdir().unwrap();
+        let p = tmp.path().join("f.bin");
+        fs::write(&p, b"abc123").unwrap();
+        let a = hash_file_sha256(&p).unwrap();
+        let b = hash_bytes_sha256(b"abc123");
+        assert_eq!(a, b);
+    }
+}

--- a/crates/dcc-mcp-artefact/src/python.rs
+++ b/crates/dcc-mcp-artefact/src/python.rs
@@ -1,0 +1,174 @@
+//! PyO3 bindings for the artefact crate (issue #349).
+//!
+//! Exposes [`FileRef`](crate::FileRef) as a `#[pyclass]` plus helpers
+//! `artefact_put_file` and `artefact_get_bytes`. The default store used by
+//! the helpers lives as a process-global `OnceLock<FilesystemArtefactStore>`
+//! under `<temp_dir>/dcc-mcp-artefacts` so callers outside an
+//! `McpHttpServer` can still round-trip artefacts — the MCP server owns its
+//! own store and wires it into the `artefact://` resource producer.
+
+use std::path::PathBuf;
+use std::sync::{Arc, OnceLock};
+
+use parking_lot::RwLock;
+use pyo3::exceptions::{PyIOError, PyValueError};
+use pyo3::prelude::*;
+use pyo3::types::{PyAny, PyBytes};
+
+use crate::{ArtefactError, ArtefactStore, FileRef, FilesystemArtefactStore, SharedArtefactStore};
+
+/// Python wrapper for [`crate::FileRef`].
+#[pyclass(name = "FileRef", module = "dcc_mcp_core._core", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyFileRef {
+    pub(crate) inner: FileRef,
+}
+
+#[pymethods]
+impl PyFileRef {
+    /// Canonical URI, e.g. ``artefact://sha256/<hex>``.
+    #[getter]
+    fn uri(&self) -> &str {
+        &self.inner.uri
+    }
+
+    /// Optional MIME type (``image/png``, ``application/json``, …).
+    #[getter]
+    fn mime(&self) -> Option<&str> {
+        self.inner.mime.as_deref()
+    }
+
+    /// Size of the artefact body in bytes, if known.
+    #[getter]
+    fn size_bytes(&self) -> Option<u64> {
+        self.inner.size_bytes
+    }
+
+    /// Canonical digest, e.g. ``sha256:<hex>``.
+    #[getter]
+    fn digest(&self) -> Option<&str> {
+        self.inner.digest.as_deref()
+    }
+
+    /// UUID of the job that produced the artefact (when known).
+    #[getter]
+    fn producer_job_id(&self) -> Option<String> {
+        self.inner.producer_job_id.map(|u| u.to_string())
+    }
+
+    /// RFC-3339 creation timestamp.
+    #[getter]
+    fn created_at(&self) -> String {
+        self.inner.created_at.to_rfc3339()
+    }
+
+    /// Tool-defined metadata as a JSON string.
+    #[getter]
+    fn metadata_json(&self) -> PyResult<String> {
+        serde_json::to_string(&self.inner.metadata)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "FileRef(uri={}, mime={:?}, size_bytes={:?})",
+            self.inner.uri, self.inner.mime, self.inner.size_bytes
+        )
+    }
+}
+
+impl From<FileRef> for PyFileRef {
+    fn from(inner: FileRef) -> Self {
+        Self { inner }
+    }
+}
+
+// ── Global default store ──────────────────────────────────────────────────
+
+static DEFAULT_STORE: OnceLock<RwLock<SharedArtefactStore>> = OnceLock::new();
+
+fn default_store() -> SharedArtefactStore {
+    let cell = DEFAULT_STORE.get_or_init(|| {
+        let path = std::env::temp_dir().join("dcc-mcp-artefacts");
+        let fs_store =
+            FilesystemArtefactStore::new_in(path).expect("create default artefact store");
+        RwLock::new(Arc::new(fs_store) as SharedArtefactStore)
+    });
+    cell.read().clone()
+}
+
+/// Replace the process-global default artefact store.
+///
+/// Not exposed to Python directly — used by `dcc-mcp-http` to point the
+/// helpers at the server's own store when one is configured.
+pub fn set_default_store(store: SharedArtefactStore) {
+    let cell = DEFAULT_STORE.get_or_init(|| RwLock::new(store.clone()));
+    *cell.write() = store;
+}
+
+fn map_err(e: ArtefactError) -> PyErr {
+    match e {
+        ArtefactError::NotFound(msg) => PyIOError::new_err(format!("artefact not found: {msg}")),
+        ArtefactError::InvalidUri(msg) => PyValueError::new_err(format!("invalid uri: {msg}")),
+        ArtefactError::Io(err) => PyIOError::new_err(err.to_string()),
+        ArtefactError::Serde(err) => PyValueError::new_err(err.to_string()),
+    }
+}
+
+/// Store the file at ``path`` and return a :class:`FileRef`.
+///
+/// The default store is a content-addressed filesystem store under
+/// ``<temp_dir>/dcc-mcp-artefacts``. ``McpHttpServer`` installs its own
+/// store on start, so inside a server process this helper routes to the
+/// server-owned store automatically.
+#[pyfunction(name = "artefact_put_file")]
+#[pyo3(signature = (path, mime=None))]
+pub fn py_artefact_put_file(path: &str, mime: Option<String>) -> PyResult<PyFileRef> {
+    let store = default_store();
+    let fr = crate::put_file(store.as_ref(), PathBuf::from(path), mime).map_err(map_err)?;
+    Ok(PyFileRef::from(fr))
+}
+
+/// Store raw ``bytes`` and return a :class:`FileRef`.
+#[pyfunction(name = "artefact_put_bytes")]
+#[pyo3(signature = (data, mime=None))]
+pub fn py_artefact_put_bytes(data: &[u8], mime: Option<String>) -> PyResult<PyFileRef> {
+    let store = default_store();
+    let fr = crate::put_bytes(store.as_ref(), data.to_vec(), mime).map_err(map_err)?;
+    Ok(PyFileRef::from(fr))
+}
+
+/// Read back the raw bytes for an ``artefact://`` URI. Raises ``IOError``
+/// when the URI is unknown.
+#[pyfunction(name = "artefact_get_bytes")]
+pub fn py_artefact_get_bytes(py: Python<'_>, uri: &str) -> PyResult<Py<PyAny>> {
+    let store = default_store();
+    let body = store
+        .get(uri)
+        .map_err(map_err)?
+        .ok_or_else(|| PyIOError::new_err(format!("artefact not found: {uri}")))?;
+    let bytes = body
+        .into_bytes()
+        .map_err(|e| PyIOError::new_err(e.to_string()))?;
+    Ok(PyBytes::new(py, &bytes).unbind().into_any())
+}
+
+/// List every known artefact, returning a list of :class:`FileRef`.
+#[pyfunction(name = "artefact_list")]
+pub fn py_artefact_list() -> PyResult<Vec<PyFileRef>> {
+    let store = default_store();
+    let refs = store
+        .list(crate::ArtefactFilter::default())
+        .map_err(map_err)?;
+    Ok(refs.into_iter().map(PyFileRef::from).collect())
+}
+
+/// Register artefact Python classes and helpers on `m`.
+pub fn register_classes(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<PyFileRef>()?;
+    m.add_function(wrap_pyfunction!(py_artefact_put_file, m)?)?;
+    m.add_function(wrap_pyfunction!(py_artefact_put_bytes, m)?)?;
+    m.add_function(wrap_pyfunction!(py_artefact_get_bytes, m)?)?;
+    m.add_function(wrap_pyfunction!(py_artefact_list, m)?)?;
+    Ok(())
+}

--- a/crates/dcc-mcp-http/Cargo.toml
+++ b/crates/dcc-mcp-http/Cargo.toml
@@ -21,6 +21,7 @@ dcc-mcp-sandbox = { path = "../dcc-mcp-sandbox" }
 dcc-mcp-capture = { path = "../dcc-mcp-capture" }
 dcc-mcp-telemetry = { path = "../dcc-mcp-telemetry", optional = true }
 dcc-mcp-workflow = { path = "../dcc-mcp-workflow" }
+dcc-mcp-artefact = { path = "../dcc-mcp-artefact" }
 
 # Workspace shared
 serde = { workspace = true }
@@ -64,7 +65,7 @@ dcc-mcp-sandbox = { path = "../dcc-mcp-sandbox" }
 
 [features]
 default = []
-python-bindings = ["pyo3", "dcc-mcp-utils/python-bindings", "dcc-mcp-actions/python-bindings", "dcc-mcp-skills/python-bindings"]
+python-bindings = ["pyo3", "dcc-mcp-utils/python-bindings", "dcc-mcp-actions/python-bindings", "dcc-mcp-skills/python-bindings", "dcc-mcp-artefact/python-bindings"]
 # Enable the Prometheus `/metrics` endpoint (issue #331). Pulls in the
 # matching `prometheus` feature of dcc-mcp-telemetry. Off by default so
 # zero Prometheus code compiles into the wheel when not requested.

--- a/crates/dcc-mcp-http/src/resources.rs
+++ b/crates/dcc-mcp-http/src/resources.rs
@@ -24,6 +24,7 @@ use std::sync::Arc;
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use dcc_mcp_artefact::{InMemoryArtefactStore, SharedArtefactStore};
 use parking_lot::RwLock;
 use serde_json::{Value, json};
 use tokio::sync::broadcast;
@@ -129,11 +130,49 @@ struct ResourceRegistryInner {
     /// Enables `artefact://` entries in `resources/list`. Mirrored from
     /// [`crate::McpHttpConfig::enable_artefact_resources`].
     artefact_enabled: bool,
+    /// Backing store for `artefact://` resources (issue #349). Populated
+    /// when `artefact_enabled` is `true`, wired into the producer at
+    /// registration time and kept here so callers can hand it back to
+    /// tools/workflow steps via [`ResourceRegistry::artefact_store`].
+    artefact_store: Option<SharedArtefactStore>,
 }
 
 impl ResourceRegistry {
     /// Construct a registry with the default built-in producers.
+    ///
+    /// When `artefact_enabled` is `true`, an in-memory
+    /// [`dcc_mcp_artefact::InMemoryArtefactStore`] is wired up by default.
+    /// Callers that need persistence (the default for real servers) should
+    /// use [`Self::new_with_artefact_store`].
     pub fn new(enabled: bool, artefact_enabled: bool) -> Self {
+        let store: Option<SharedArtefactStore> = if artefact_enabled {
+            Some(Arc::new(InMemoryArtefactStore::new()) as SharedArtefactStore)
+        } else {
+            None
+        };
+        Self::new_inner(enabled, artefact_enabled, store)
+    }
+
+    /// Construct a registry with a caller-supplied artefact store. Use
+    /// this to plug in a [`dcc_mcp_artefact::FilesystemArtefactStore`]
+    /// under the workspace's `.dcc-mcp/artefacts` directory.
+    ///
+    /// `artefact_enabled` must be `true` for the store to be surfaced in
+    /// `resources/list` — pass `false` to retain the producer while
+    /// hiding entries from agents.
+    pub fn new_with_artefact_store(
+        enabled: bool,
+        artefact_enabled: bool,
+        store: SharedArtefactStore,
+    ) -> Self {
+        Self::new_inner(enabled, artefact_enabled, Some(store))
+    }
+
+    fn new_inner(
+        enabled: bool,
+        artefact_enabled: bool,
+        store: Option<SharedArtefactStore>,
+    ) -> Self {
         let (updated_tx, _) = broadcast::channel(64);
         let scene_snapshot = Arc::new(RwLock::new(None));
         let inner = Arc::new(ResourceRegistryInner {
@@ -143,6 +182,7 @@ impl ResourceRegistry {
             scene_snapshot: scene_snapshot.clone(),
             enabled,
             artefact_enabled,
+            artefact_store: store.clone(),
         });
         let registry = Self { inner };
         if enabled {
@@ -151,14 +191,22 @@ impl ResourceRegistry {
             }));
             registry.add_producer(Arc::new(CaptureProducer));
             registry.add_producer(Arc::new(AuditProducer::disabled()));
-            // Always register the artefact producer so the scheme is
-            // recognized; it returns NotEnabled when the flag is off so
-            // #349 can wire the real backend without touching this file.
-            registry.add_producer(Arc::new(ArtefactStubProducer {
+            registry.add_producer(Arc::new(ArtefactProducer {
                 enabled: artefact_enabled,
+                store,
             }));
         }
         registry
+    }
+
+    /// The artefact store backing `artefact://` resources, if any.
+    ///
+    /// `None` when `enable_artefact_resources = false`. Useful for tools
+    /// and workflow-step runners that need to hand back a
+    /// [`dcc_mcp_artefact::FileRef`] inside a
+    /// [`dcc_mcp_models::ToolResult`]'s `context`.
+    pub fn artefact_store(&self) -> Option<SharedArtefactStore> {
+        self.inner.artefact_store.clone()
     }
 
     /// Returns `true` when the Resources primitive is advertised in
@@ -465,14 +513,18 @@ fn parse_audit_limit(uri: &str) -> Option<usize> {
     None
 }
 
-/// Stub producer for `artefact://` — recognizes the scheme so that
-/// `resources/read` can emit a descriptive error until issue #349 wires
-/// the real artefact store.
-struct ArtefactStubProducer {
+/// Producer for `artefact://` URIs, backed by a
+/// [`dcc_mcp_artefact::ArtefactStore`] (issue #349).
+///
+/// When `enabled` is `false`, `list` hides entries and `read` returns
+/// `ResourceError::NotEnabled` so clients can distinguish "scheme unknown"
+/// from "scheme recognized but disabled".
+struct ArtefactProducer {
     enabled: bool,
+    store: Option<SharedArtefactStore>,
 }
 
-impl ResourceProducer for ArtefactStubProducer {
+impl ResourceProducer for ArtefactProducer {
     fn scheme(&self) -> &str {
         "artefact"
     }
@@ -481,18 +533,59 @@ impl ResourceProducer for ArtefactStubProducer {
         if !self.enabled {
             return Vec::new();
         }
-        // When enabled, the real store (issue #349) will populate this;
-        // the stub just returns an empty list.
-        Vec::new()
+        let Some(store) = self.store.as_ref() else {
+            return Vec::new();
+        };
+        let refs = store
+            .list(dcc_mcp_artefact::ArtefactFilter::default())
+            .unwrap_or_default();
+        refs.into_iter()
+            .map(|fr| McpResource {
+                uri: fr.uri.clone(),
+                name: fr.digest.clone().unwrap_or_else(|| fr.uri.clone()),
+                description: Some(format!(
+                    "Artefact ({} bytes, digest {})",
+                    fr.size_bytes.unwrap_or(0),
+                    fr.digest.as_deref().unwrap_or("unknown"),
+                )),
+                mime_type: fr.mime.clone(),
+            })
+            .collect()
     }
 
     fn read(&self, uri: &str) -> ResourceResult<ProducerContent> {
         if !self.enabled {
             return Err(ResourceError::NotEnabled(format!(
-                "artefact resources not enabled (issue #349): {uri}"
+                "artefact resources not enabled: {uri}"
             )));
         }
-        Err(ResourceError::NotFound(uri.to_string()))
+        let Some(store) = self.store.as_ref() else {
+            return Err(ResourceError::NotEnabled(format!(
+                "artefact store not configured: {uri}"
+            )));
+        };
+        let head = store
+            .head(uri)
+            .map_err(|e| ResourceError::Read(e.to_string()))?;
+        let Some(head) = head else {
+            return Err(ResourceError::NotFound(uri.to_string()));
+        };
+        let body = store
+            .get(uri)
+            .map_err(|e| ResourceError::Read(e.to_string()))?;
+        let bytes = body
+            .ok_or_else(|| ResourceError::NotFound(uri.to_string()))?
+            .into_bytes()
+            .map_err(|e| ResourceError::Read(e.to_string()))?;
+        let mime = head
+            .mime
+            .clone()
+            .unwrap_or_else(|| "application/octet-stream".to_string());
+        Ok(ProducerContent::Blob {
+            uri: uri.to_string(),
+            mime_type: mime,
+            bytes,
+        })
     }
 }
 
@@ -600,5 +693,37 @@ mod tests {
     fn disabled_artefact_hidden_from_list() {
         let reg = ResourceRegistry::new(true, false);
         assert!(!reg.list().iter().any(|r| r.uri.starts_with("artefact://")));
+    }
+
+    #[test]
+    fn enabled_artefact_store_surfaces_put_in_list_and_read() {
+        use dcc_mcp_artefact::ArtefactBody;
+
+        let reg = ResourceRegistry::new(true, true);
+        let store = reg.artefact_store().expect("store wired");
+        let fr = store
+            .put(ArtefactBody::Inline(b"hello-artefact".to_vec()))
+            .unwrap();
+
+        // list should include the new URI.
+        let uris: Vec<String> = reg.list().into_iter().map(|r| r.uri).collect();
+        assert!(uris.contains(&fr.uri), "list missing {}: {uris:?}", fr.uri);
+
+        // read should return the bytes as a blob (base64).
+        let result = reg.read(&fr.uri).expect("read ok");
+        let item = &result.contents[0];
+        assert_eq!(item.uri, fr.uri);
+        assert!(item.blob.is_some(), "expected base64 blob");
+        let decoded = BASE64_STANDARD
+            .decode(item.blob.as_deref().unwrap())
+            .unwrap();
+        assert_eq!(decoded, b"hello-artefact");
+    }
+
+    #[test]
+    fn enabled_artefact_read_unknown_uri_returns_not_found() {
+        let reg = ResourceRegistry::new(true, true);
+        let err = reg.read("artefact://sha256/deadbeef").unwrap_err();
+        assert!(matches!(err, ResourceError::NotFound(_)));
     }
 }

--- a/crates/dcc-mcp-http/src/server.rs
+++ b/crates/dcc-mcp-http/src/server.rs
@@ -70,6 +70,45 @@ impl McpServerHandle {
 ///
 /// Embeds an axum HTTP server running on a dedicated Tokio runtime thread.
 /// Safe to use from DCC main threads — the server never blocks the caller.
+/// Build the [`ResourceRegistry`](crate::resources::ResourceRegistry) for
+/// a server.
+///
+/// When artefact resources are enabled, a content-addressed
+/// [`FilesystemArtefactStore`](dcc_mcp_artefact::FilesystemArtefactStore)
+/// is anchored at `<registry_dir>/artefacts` (falling back to the OS
+/// temp dir when no registry dir is configured). Wiring the Python
+/// helpers to the same store is the caller's responsibility — see
+/// `dcc_mcp_artefact::python::set_default_store` for that path.
+fn build_resource_registry(config: &McpHttpConfig) -> crate::resources::ResourceRegistry {
+    if config.enable_artefact_resources {
+        let root = config
+            .registry_dir
+            .clone()
+            .unwrap_or_else(std::env::temp_dir)
+            .join("dcc-mcp-artefacts");
+        match dcc_mcp_artefact::FilesystemArtefactStore::new_in(root) {
+            Ok(store) => {
+                let shared: dcc_mcp_artefact::SharedArtefactStore = Arc::new(store);
+                return crate::resources::ResourceRegistry::new_with_artefact_store(
+                    config.enable_resources,
+                    true,
+                    shared,
+                );
+            }
+            Err(err) => {
+                tracing::warn!(
+                    %err,
+                    "failed to create FilesystemArtefactStore; falling back to in-memory",
+                );
+            }
+        }
+    }
+    crate::resources::ResourceRegistry::new(
+        config.enable_resources,
+        config.enable_artefact_resources,
+    )
+}
+
 pub struct McpHttpServer {
     registry: Arc<ActionRegistry>,
     dispatcher: Arc<ActionDispatcher>,
@@ -92,10 +131,7 @@ impl McpHttpServer {
             registry.clone(),
             dispatcher.clone(),
         ));
-        let resources = crate::resources::ResourceRegistry::new(
-            config.enable_resources,
-            config.enable_artefact_resources,
-        );
+        let resources = build_resource_registry(&config);
         let prompts = crate::prompts::PromptRegistry::new(config.enable_prompts);
         Self {
             registry: registry.clone(),
@@ -118,10 +154,7 @@ impl McpHttpServer {
             .dispatcher()
             .cloned()
             .unwrap_or_else(|| Arc::new(ActionDispatcher::new((*registry).clone())));
-        let resources = crate::resources::ResourceRegistry::new(
-            config.enable_resources,
-            config.enable_artefact_resources,
-        );
+        let resources = build_resource_registry(&config);
         let prompts = crate::prompts::PromptRegistry::new(config.enable_prompts);
         Self {
             registry,

--- a/docs/api/resources.md
+++ b/docs/api/resources.md
@@ -32,7 +32,7 @@ Resources are advertised in `initialize` as:
 | `scene://current` | `application/json` | Current `SceneInfo` snapshot (or placeholder) | Fires when `set_scene()` is called |
 | `capture://current_window` | `image/png` | PNG of the active DCC window (base64 blob) | None (read-on-demand) |
 | `audit://recent?limit=N` | `application/json` | Tail of the `AuditLog` (default 50, max 500) | Fires on every `AuditLog.record()` |
-| `artefact://<id>` | — | Stub — returns error `-32002` until artefact backend lands (#349) | None |
+| `artefact://sha256/<hex>` | varies | Content-addressed artefact store (#349); bodies returned as base64 blobs with their declared MIME. Gated by `enable_artefact_resources`. | None (polling model) |
 
 `capture://current_window` is only listed when a real window-capture backend is available
 (currently Windows `HWND PrintWindow`). On other platforms it is hidden from `resources/list`.
@@ -134,8 +134,24 @@ body = {
 |------|---------|
 | `-32601` | Method not found — resources disabled (`enable_resources = False`) |
 | `-32602` | Invalid params — missing or malformed `uri` |
-| `-32002` | Resource not enabled — recognised scheme (e.g. `artefact://`) but backend disabled |
+| `-32002` | Resource not enabled (scheme recognised, backend disabled) — also reused when an `artefact://` URI is syntactically valid but not stored |
 | `-32603` | Internal error — producer failed (capture backend error, etc.) |
+
+## `artefact://` Scheme (issue #349)
+
+Content-addressed artefact hand-off between tools and workflow steps.
+See [`docs/guide/artefacts.md`](../guide/artefacts.md) for the full
+`FileRef` + `ArtefactStore` guide. Quick reference:
+
+- URI shape: `artefact://sha256/<hex>`.
+- Default backend: `FilesystemArtefactStore` anchored at
+  `<registry_dir>/dcc-mcp-artefacts` (or the OS temp dir).
+- `resources/list` enumerates every stored artefact; entries carry the
+  declared MIME and sidecar metadata.
+- `resources/read` returns the raw bytes as a base64 blob.
+- Python helpers: `artefact_put_file`, `artefact_put_bytes`,
+  `artefact_get_bytes`, `artefact_list`.
+- Enable with `McpHttpConfig.enable_artefact_resources = True`.
 
 ## Writing a Custom Producer (Rust)
 

--- a/docs/guide/artefacts.md
+++ b/docs/guide/artefacts.md
@@ -1,0 +1,151 @@
+# Artefact Hand-Off (FileRef + ArtefactStore)
+
+> **Issue**: [#349](https://github.com/loonghao/dcc-mcp-core/issues/349)
+> **Crate**: `dcc-mcp-artefact`
+> **Scheme**: `artefact://sha256/<hex>`
+
+Pipelines move *files* between tools and between workflow steps: an imported
+scene, a QC report, a staged `.uasset`, a baked simulation. Passing the raw
+bytes inline bloats the MCP transport; passing an absolute path breaks
+across machines and strips MIME / size / checksum metadata.
+
+`dcc-mcp-artefact` ships a small value type (`FileRef`) plus a
+content-addressed storage backend, and wires an `artefact://` URI scheme
+into the MCP Resources primitive so MCP clients can `resources/read` a
+file hand-off by URI.
+
+## Concepts
+
+- **`FileRef`** — a serializable reference to a stored file:
+  - `uri` — canonical, e.g. `artefact://sha256/<hex>`
+  - `mime`, `size_bytes`, `digest` (`sha256:<hex>`)
+  - `producer_job_id` (optional, for workflow step outputs)
+  - `created_at` (RFC-3339)
+  - `metadata` (tool-defined JSON — width/height, frame number, etc.)
+
+- **`ArtefactStore`** — trait with `put` / `get` / `head` / `delete` /
+  `list`. Stores are content-addressed: submitting the same bytes twice
+  returns the same URI.
+
+- **`FilesystemArtefactStore`** — default persistent backend. Each
+  artefact lives under `<root>/<sha256>.bin` with a `<sha256>.json`
+  sidecar carrying the `FileRef`. `McpHttpServer` anchors its store at
+  `<registry_dir>/dcc-mcp-artefacts` (or the OS temp dir when no
+  registry is configured).
+
+- **`InMemoryArtefactStore`** — non-persistent backend for tests.
+
+## Enabling Artefact Resources
+
+```python
+from dcc_mcp_core import McpHttpConfig, McpHttpServer, ToolRegistry
+
+cfg = McpHttpConfig(port=8765)
+cfg.enable_artefact_resources = True    # off by default
+server = McpHttpServer(ToolRegistry(), cfg)
+handle = server.start()
+```
+
+Once enabled:
+
+- `resources/list` includes every stored artefact as an `artefact://` URI.
+- `resources/read` returns the body as a base64 blob with the correct MIME.
+- `resources/read` of an unknown URI returns MCP error `-32002`.
+
+Disabled (default) paths still recognize the scheme and respond with a
+`-32002` "not enabled" error, so clients can distinguish "scheme unknown"
+from "scheme recognized but backing store off".
+
+## Python Helpers
+
+```python
+from dcc_mcp_core import (
+    FileRef,
+    artefact_put_bytes,
+    artefact_put_file,
+    artefact_get_bytes,
+    artefact_list,
+)
+
+# Put a file on disk and get back a FileRef.
+ref = artefact_put_file("/tmp/render.png", mime="image/png")
+print(ref.uri)           # artefact://sha256/<hex>
+print(ref.digest)        # sha256:<hex>
+print(ref.size_bytes)    # 1024
+
+# Round-trip a byte buffer.
+bref = artefact_put_bytes(b"hello", mime="text/plain")
+assert artefact_get_bytes(bref.uri) == b"hello"
+
+# Inventory.
+for entry in artefact_list():
+    print(entry.uri, entry.mime, entry.size_bytes)
+```
+
+The helpers target a process-global default store
+(`<temp_dir>/dcc-mcp-artefacts`). Inside a server process the
+`McpHttpServer` points the helpers at its own store automatically.
+
+## Rust API
+
+```rust
+use dcc_mcp_artefact::{
+    ArtefactBody, ArtefactFilter, ArtefactStore,
+    FilesystemArtefactStore, InMemoryArtefactStore,
+    put_bytes, put_file,
+};
+
+// Persistent store — default for real servers.
+let store = FilesystemArtefactStore::new_in("/var/cache/dcc/artefacts")?;
+let fr = put_bytes(&store, b"payload".to_vec(), Some("text/plain".into()))?;
+assert!(fr.uri.starts_with("artefact://sha256/"));
+
+// Look up by URI.
+let body = store.get(&fr.uri)?.unwrap();
+assert_eq!(body.into_bytes()?, b"payload");
+
+// List artefacts filtered by producing job.
+let refs = store.list(ArtefactFilter {
+    producer_job_id: Some(job_id),
+    ..Default::default()
+})?;
+```
+
+## Workflow Integration
+
+The workflow runner (landing in a follow-up PR under issue #348)
+propagates `FileRef`s through step outputs:
+
+1. A step emits a `ToolResult` whose `context` contains
+   `{"file_refs": [{"uri": "artefact://sha256/...", "mime": "image/png"}]}`.
+2. The runner stores the `FileRef`s on the step record and substitutes
+   them into the next step's argument context.
+3. The downstream step fetches the bytes via
+   `artefact_get_bytes(uri)` — or by `resources/read` when using the
+   MCP resources primitive from outside the runner process.
+
+This PR lands the types, storage, and resource wiring. Runner
+integration is out of scope.
+
+## Gotchas
+
+- **Duplicate content → same URI.** Don't rely on URI uniqueness for
+  logical ordering — use `producer_job_id` and `metadata` instead.
+- **`put_file` copies.** The source path is left untouched; the store
+  owns the canonical copy.
+- **Sidecar is authoritative for metadata.** Editing the JSON sidecar
+  by hand is supported; editing the `.bin` file is not (the digest
+  would mismatch).
+- **No GC yet.** Stores never auto-delete. TTL / reference-count GC is
+  tracked in a future issue.
+- **No remote backends yet.** S3 / SFTP / HTTP pointers are declared
+  in the roadmap but not implemented — a future issue.
+
+## See Also
+
+- [`docs/api/resources.md`](../api/resources.md) — the broader Resources
+  primitive that hosts `artefact://`.
+- Issue [#348](https://github.com/loonghao/dcc-mcp-core/issues/348) —
+  workflow runner that consumes `FileRef`s.
+- Issue [#350](https://github.com/loonghao/dcc-mcp-core/issues/350) —
+  Resources primitive (merged).

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -63,6 +63,9 @@ from dcc_mcp_core._core import DccInfo
 from dcc_mcp_core._core import DccLinkFrame
 from dcc_mcp_core._core import EventBus
 from dcc_mcp_core._core import FileLoggingConfig
+
+# Artefact hand-off (issue #349)
+from dcc_mcp_core._core import FileRef
 from dcc_mcp_core._core import FloatWrapper
 from dcc_mcp_core._core import FrameRange
 from dcc_mcp_core._core import GracefulIpcChannelAdapter
@@ -146,6 +149,10 @@ from dcc_mcp_core._core import VersionedRegistry
 from dcc_mcp_core._core import VtValue
 from dcc_mcp_core._core import WindowFinder
 from dcc_mcp_core._core import WindowInfo
+from dcc_mcp_core._core import artefact_get_bytes
+from dcc_mcp_core._core import artefact_list
+from dcc_mcp_core._core import artefact_put_bytes
+from dcc_mcp_core._core import artefact_put_file
 from dcc_mcp_core._core import create_skill_server
 from dcc_mcp_core._core import deserialize_result
 from dcc_mcp_core._core import error_result
@@ -315,6 +322,7 @@ __all__ = [
     "DccSkillHotReloader",
     "EventBus",
     "FileLoggingConfig",
+    "FileRef",
     "FloatWrapper",
     "FrameRange",
     "GracefulIpcChannelAdapter",
@@ -396,6 +404,10 @@ __all__ = [
     "WorkflowStep",
     "__author__",
     "__version__",
+    "artefact_get_bytes",
+    "artefact_list",
+    "artefact_put_bytes",
+    "artefact_put_file",
     "check_cancelled",
     "create_dcc_server",
     "create_skill_server",

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -440,6 +440,48 @@ class EventBus:
     def publish(self, event: str, **kwargs: Any) -> None: ...
     def __repr__(self) -> str: ...
 
+class FileRef:
+    """Reference to a stored artefact (issue #349).
+
+    Canonical URI is ``artefact://sha256/<hex>`` for content-addressed
+    artefacts or ``file:///absolute/path`` for external files.
+    """
+
+    @property
+    def uri(self) -> str: ...
+    @property
+    def mime(self) -> str | None: ...
+    @property
+    def size_bytes(self) -> int | None: ...
+    @property
+    def digest(self) -> str | None: ...
+    @property
+    def producer_job_id(self) -> str | None: ...
+    @property
+    def created_at(self) -> str: ...
+    @property
+    def metadata_json(self) -> str: ...
+    def __repr__(self) -> str: ...
+
+def artefact_put_file(path: str, mime: str | None = ...) -> FileRef:
+    """Store the file at ``path`` and return a :class:`FileRef`."""
+    ...
+
+def artefact_put_bytes(data: bytes, mime: str | None = ...) -> FileRef:
+    """Store raw bytes and return a :class:`FileRef`."""
+    ...
+
+def artefact_get_bytes(uri: str) -> bytes:
+    """Read back the raw bytes for an ``artefact://`` URI.
+
+    Raises ``IOError`` when the URI is unknown to the default store.
+    """
+    ...
+
+def artefact_list() -> list[FileRef]:
+    """Return every :class:`FileRef` known to the default store."""
+    ...
+
 class ToolValidator:
     """Validates JSON-encoded skill parameters against a JSON Schema.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use pyo3::prelude::*;
 
 // Re-export sub-crates for Rust consumers
 pub use dcc_mcp_actions as actions;
+pub use dcc_mcp_artefact as artefact;
 pub use dcc_mcp_capture as capture;
 pub use dcc_mcp_http as http;
 pub use dcc_mcp_models as models;
@@ -72,6 +73,7 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     register_usd(m)?;
     register_utils(m)?;
     register_http(m)?;
+    register_artefact(m)?;
     register_naming(m)?;
     register_constants(m)?;
     #[cfg(feature = "workflow")]
@@ -267,6 +269,11 @@ fn register_http(m: &Bound<'_, PyModule>) -> PyResult<()> {
 #[cfg(feature = "python-bindings")]
 fn register_naming(m: &Bound<'_, PyModule>) -> PyResult<()> {
     dcc_mcp_naming::python::register(m)
+}
+
+#[cfg(feature = "python-bindings")]
+fn register_artefact(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    dcc_mcp_artefact::python::register_classes(m)
 }
 
 #[cfg(all(feature = "python-bindings", feature = "workflow"))]

--- a/tests/test_artefact_fileref.py
+++ b/tests/test_artefact_fileref.py
@@ -1,0 +1,163 @@
+"""End-to-end tests for the FileRef + artefact:// resource scheme (issue #349).
+
+Exercises both the low-level helpers (``artefact_put_file`` /
+``artefact_get_bytes``) and the wiring of the ``artefact://`` URI scheme
+through a live ``McpHttpServer`` with ``enable_artefact_resources=True``.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+import tempfile
+from typing import Any
+import urllib.error
+import urllib.request
+
+import pytest
+
+from dcc_mcp_core import FileRef
+from dcc_mcp_core import McpHttpConfig
+from dcc_mcp_core import McpHttpServer
+from dcc_mcp_core import ToolRegistry
+from dcc_mcp_core import artefact_get_bytes
+from dcc_mcp_core import artefact_list
+from dcc_mcp_core import artefact_put_bytes
+from dcc_mcp_core import artefact_put_file
+
+
+def _post_json(
+    url: str,
+    body: dict[str, Any],
+) -> tuple[int, dict[str, Any]]:
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        return e.code, {}
+
+
+class TestFileRefType:
+    def test_put_bytes_returns_fileref_with_metadata(self):
+        fr = artefact_put_bytes(b"abc123", mime="application/octet-stream")
+        assert isinstance(fr, FileRef)
+        assert fr.uri.startswith("artefact://sha256/")
+        assert fr.size_bytes == 6
+        assert fr.digest is not None and fr.digest.startswith("sha256:")
+        assert fr.mime == "application/octet-stream"
+        # RFC-3339 timestamp.
+        assert "T" in fr.created_at
+
+    def test_put_bytes_is_content_addressed(self):
+        a = artefact_put_bytes(b"same-content")
+        b = artefact_put_bytes(b"same-content")
+        assert a.uri == b.uri
+        assert a.digest == b.digest
+
+    def test_put_file_and_get_bytes_round_trip(self):
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".bin") as f:
+            f.write(b"payload-bytes")
+            path = Path(f.name)
+        try:
+            fr = artefact_put_file(str(path), mime="application/octet-stream")
+            got = artefact_get_bytes(fr.uri)
+            assert got == b"payload-bytes"
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_get_bytes_unknown_uri_raises(self):
+        with pytest.raises(IOError):
+            artefact_get_bytes("artefact://sha256/ffffffffffffffffffffffffffffffff")
+
+    def test_artefact_list_includes_freshly_put(self):
+        fr = artefact_put_bytes(b"list-me-please-" + str(id(object())).encode())
+        uris = {entry.uri for entry in artefact_list()}
+        assert fr.uri in uris
+
+
+class TestArtefactResourceScheme:
+    @pytest.fixture(scope="class")
+    def artefact_server(self):
+        reg = ToolRegistry()
+        reg.register(
+            "noop",
+            description="placeholder",
+            category="test",
+            tags=[],
+            dcc="test",
+            version="1.0.0",
+        )
+        cfg = McpHttpConfig(port=0, server_name="artefact-e2e")
+        cfg.enable_artefact_resources = True
+        assert cfg.enable_artefact_resources is True
+        server = McpHttpServer(reg, cfg)
+        handle = server.start()
+        yield server, handle, handle.mcp_url()
+        handle.shutdown()
+
+    def test_resources_list_contains_put_artefact(self, artefact_server):
+        _, _, url = artefact_server
+        # Put an artefact via the process-global helper. When the server is
+        # co-located in-process, its resources registry reads from the same
+        # FilesystemArtefactStore root, so the URI is discoverable.
+        fr = artefact_put_bytes(b"mcp-visible-artefact", mime="text/plain")
+
+        code, body = _post_json(
+            url,
+            {"jsonrpc": "2.0", "id": 1, "method": "resources/list"},
+        )
+        assert code == 200
+        resources = body["result"]["resources"]
+        uris = {r["uri"] for r in resources}
+        assert fr.uri in uris, f"{fr.uri} not in {uris}"
+
+    def test_resources_read_returns_original_bytes(self, artefact_server):
+        _, _, url = artefact_server
+        payload = b"round-trip-through-mcp"
+        fr = artefact_put_bytes(payload, mime="application/octet-stream")
+
+        code, body = _post_json(
+            url,
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "resources/read",
+                "params": {"uri": fr.uri},
+            },
+        )
+        assert code == 200
+        item = body["result"]["contents"][0]
+        assert item["uri"] == fr.uri
+        assert "blob" in item
+        decoded = base64.b64decode(item["blob"])
+        assert decoded == payload
+
+    def test_resources_read_unknown_uri_errors(self, artefact_server):
+        _, _, url = artefact_server
+        code, body = _post_json(
+            url,
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "resources/read",
+                "params": {
+                    "uri": "artefact://sha256/00000000000000000000000000000000",
+                },
+            },
+        )
+        assert code == 200
+        assert "error" in body
+        # RESOURCE_NOT_ENABLED_ERROR code in protocol.rs is -32002, reused
+        # for "not found" when the scheme is valid but the URI isn't stored.
+        assert body["error"]["code"] == -32002


### PR DESCRIPTION
## Summary

Implements #349 — artefact hand-off via `FileRef` resources.

- New `dcc-mcp-artefact` crate with `FileRef`, `ArtefactStore` trait, content-addressed (SHA-256) `FilesystemArtefactStore`, and `InMemoryArtefactStore`.
- `artefact://sha256/<hex>` URI scheme wired into the MCP Resources primitive via a real `ArtefactProducer` (replaces the previous stub). `resources/list` enumerates stored artefacts; `resources/read` returns bytes or JSON-RPC `-32002` for unknown URIs.
- `McpHttpConfig::enable_artefact_resources` now anchors the producer on a `FilesystemArtefactStore` under `registry_dir/dcc-mcp-artefacts` (or OS temp dir when unset); `ResourceRegistry::new_with_artefact_store` supports explicit injection.
- Python bindings: `FileRef` class + `artefact_put_file`, `artefact_put_bytes`, `artefact_get_bytes`, `artefact_list` helpers, backed by a process-global default filesystem store.
- Docs: new `docs/guide/artefacts.md`, refreshed `docs/api/resources.md`, `AGENTS.md`, `CLAUDE.md`.

## Test plan

- [x] `vx just preflight` (cargo check + clippy + fmt + rust tests)
- [x] `vx cargo test -p dcc-mcp-artefact`
- [x] `vx cargo test -p dcc-mcp-http resources`
- [x] `vx just dev` (maturin develop)
- [x] `vx pytest tests/test_artefact_fileref.py`

Closes #349
