### PR TITLE
feat(gateway): multiplex backend SSE notifications to client sessions (#320)

### DIFF
--- a/.git-commit-msg.txt
+++ b/.git-commit-msg.txt
@@ -1,11 +1,31 @@
-feat(workflow): step-level retry, timeout, and idempotency policies (#353)
+feat(gateway): multiplex backend SSE notifications to client sessions (#320)
 
-Extends WorkflowSpec step schema with retry{max_attempts, backoff,
-initial_delay_ms, max_delay_ms, jitter, retry_on}, timeout_secs,
-and idempotency_key (template with workflow/step context).
-Parser+validator clamps jitter, checks template var references, and
-enforces max_attempts >= 1 + initial <= max_delay. Adds
-RetryPolicy::next_delay helper. Runtime enforcement is the
-forthcoming #348 execution PR.
+The gateway now subscribes to each live backend's `/mcp` SSE stream
+(via `FileRegistry` discovery) and multiplexes inbound JSON-RPC
+notifications back to the originating client session.
 
-Closes #353
+- `SubscriberManager` owns a per-backend `BackendSubscriber` with a
+  jittered exponential-backoff reconnect loop (100ms -> 10s, +/-25%)
+  and a bounded pending buffer (256 events / 30s) for notifications
+  that arrive before the correlation is known.
+- Correlation keys: `params.progressToken` for `notifications/progress`,
+  `params.job_id` for `$/dcc.jobUpdated` + `$/dcc.workflowUpdated`.
+- On a successful reconnect, every client with an in-flight job on
+  the restored backend receives a synthetic
+  `notifications/$/dcc.gatewayReconnect` so it can re-query state.
+- `handle_gateway_get` now registers a per-session sink and wraps
+  the SSE stream in a `GuardedStream` RAII guard, scrubbing the
+  sink + any routes bound to the session when the client disconnects.
+- `tools/call` in the aggregator binds `progressToken` from the
+  request's `_meta` and extracts `job_id` from the backend reply's
+  `_meta.dcc.jobId` / `structuredContent.job_id`.
+
+Tests:
+- Rust unit tests in `sse_subscriber.rs` cover route registration,
+  progress-token routing, job-id extraction, SSE record parsing,
+  pending buffer cap/TTL, and the synthetic reconnect notification.
+- Python regression `tests/test_gateway_sse.py` verifies session-id
+  echo, per-session sink isolation, and resilience under concurrent
+  SSE connects.
+
+Docs: new `docs/guide/gateway.md` + AGENTS.md pointer.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,12 @@ Need to interact with DCC?
 → `python/dcc_mcp_core/gateway_election.py` — `DccGatewayElection`
 → [`docs/guide/gateway-election.md`](docs/guide/gateway-election.md)
 
+**Gateway SSE multiplex (backend notifications → client sessions)?**
+→ [`docs/guide/gateway.md`](docs/guide/gateway.md) — correlation rules, pending buffer, reconnect
+→ `crates/dcc-mcp-http/src/gateway/sse_subscriber.rs` — `SubscriberManager`, `BackendSubscriber`
+→ Correlation: `progressToken` (progress) + `job_id` (`$/dcc.jobUpdated` / `$/dcc.workflowUpdated`)
+→ On backend reconnect, clients with in-flight jobs receive `$/dcc.gatewayReconnect`
+
 **Enable durable rolling file logs (multi-gateway debugging)?**
 → `FileLoggingConfig` + `init_file_logging()` / `shutdown_file_logging()`
 → Environment vars: `DCC_MCP_LOG_DIR`, `DCC_MCP_LOG_MAX_SIZE`, `DCC_MCP_LOG_ROTATION`

--- a/crates/dcc-mcp-http/src/gateway/aggregator.rs
+++ b/crates/dcc-mcp-http/src/gateway/aggregator.rs
@@ -103,6 +103,7 @@ pub async fn route_tools_call(
     args: &Value,
     meta: Option<&Value>,
     request_id: Option<String>,
+    client_session_id: Option<&str>,
 ) -> (String, bool) {
     // ── Local meta-tools ────────────────────────────────────────────────
     match tool {
@@ -151,6 +152,20 @@ pub async fn route_tools_call(
             call.backend_url = url.clone();
         }
     }
+
+    // ── #320: wire SSE correlation ─────────────────────────────────────
+    // (a) Ensure the backend has an SSE subscriber so notifications
+    //     produced during this call are captured.
+    // (b) If the caller supplied `_meta.progressToken`, remember the
+    //     session → token mapping so `notifications/progress` from the
+    //     backend can be routed back here.
+    gs.subscriber.ensure_subscribed(&url);
+    if let (Some(sid), Some(m)) = (client_session_id, meta) {
+        if let Some(token) = m.get("progressToken") {
+            gs.subscriber.bind_progress_token(token, sid);
+        }
+    }
+
     match forward_tools_call(
         &gs.http_client,
         &url,
@@ -163,6 +178,17 @@ pub async fn route_tools_call(
     .await
     {
         Ok(mut result) => {
+            // (c) Backend reply may carry `_meta.dcc.jobId` (async job
+            //     dispatch path, #318) or `structuredContent.job_id`.
+            //     Either way, bind the job → session mapping so later
+            //     `notifications/$/dcc.jobUpdated` arriving over SSE can
+            //     be routed to the originating client session.
+            if let Some(sid) = client_session_id {
+                if let Some(job_id) = extract_job_id(&result) {
+                    gs.subscriber.bind_job(&job_id, sid, &url);
+                }
+            }
+
             // Backend already returns a CallToolResult { content, isError }.
             // Extract the actual text payload so the gateway's own response
             // is a single CallToolResult rather than a nested envelope.
@@ -183,6 +209,28 @@ pub async fn route_tools_call(
         }
         Err(e) => (format!("Backend call failed: {e}"), true),
     }
+}
+
+/// Extract the `job_id` from a backend `tools/call` result envelope, if
+/// the backend enqueued an async job. Returns `None` when the tool ran
+/// synchronously.
+pub(crate) fn extract_job_id(result: &Value) -> Option<String> {
+    if let Some(s) = result
+        .get("structuredContent")
+        .and_then(|c| c.get("job_id"))
+        .and_then(Value::as_str)
+    {
+        return Some(s.to_owned());
+    }
+    if let Some(s) = result
+        .get("_meta")
+        .and_then(|m| m.get("dcc"))
+        .and_then(|d| d.get("jobId"))
+        .and_then(Value::as_str)
+    {
+        return Some(s.to_owned());
+    }
+    None
 }
 
 // ── Skill-management dispatch ──────────────────────────────────────────────
@@ -627,5 +675,33 @@ mod tests {
         let (text, is_error) = to_text_result(Err("boom".to_string()));
         assert_eq!(text, "boom");
         assert!(is_error);
+    }
+
+    // ── #320: extract_job_id covers both sync (None) and async (#318) envelopes.
+
+    #[test]
+    fn extract_job_id_reads_structured_content_first() {
+        let v = json!({
+            "content": [],
+            "structuredContent": {"job_id": "job-42", "status": "pending"},
+            "isError": false,
+        });
+        assert_eq!(extract_job_id(&v).as_deref(), Some("job-42"));
+    }
+
+    #[test]
+    fn extract_job_id_falls_back_to_meta_dcc_jobid() {
+        let v = json!({
+            "content": [],
+            "_meta": {"dcc": {"jobId": "job-99", "parentJobId": null}},
+            "isError": false,
+        });
+        assert_eq!(extract_job_id(&v).as_deref(), Some("job-99"));
+    }
+
+    #[test]
+    fn extract_job_id_returns_none_for_sync_reply() {
+        let v = json!({"content": [{"type": "text", "text": "ok"}], "isError": false});
+        assert!(extract_job_id(&v).is_none());
     }
 }

--- a/crates/dcc-mcp-http/src/gateway/handlers.rs
+++ b/crates/dcc-mcp-http/src/gateway/handlers.rs
@@ -1,6 +1,8 @@
 //! Axum request handlers for the gateway HTTP server.
 
 use std::convert::Infallible;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 use axum::Json;
 use axum::extract::{Path, State};
@@ -19,6 +21,50 @@ use super::proxy::proxy_request;
 use super::state::{GatewayState, entry_to_json};
 use crate::protocol::negotiate_protocol_version;
 use dcc_mcp_transport::discovery::types::ServiceStatus;
+
+/// RAII guard that evicts a client session's subscriber sink when the
+/// gateway SSE response is dropped (client disconnect).
+struct SessionCleanup {
+    mgr: super::sse_subscriber::SubscriberManager,
+    session_id: String,
+}
+
+impl Drop for SessionCleanup {
+    fn drop(&mut self) {
+        self.mgr.forget_client(&self.session_id);
+    }
+}
+
+/// Stream adapter that holds a [`SessionCleanup`] alive for the duration
+/// of the response body. When axum drops the body (e.g. client hung up),
+/// the guard runs and frees the subscriber-manager slot.
+///
+/// The inner stream is boxed+pinned so axum's `Sse::new` can accept an
+/// arbitrarily composed adapter without `Unpin` bounds propagating
+/// through every layer.
+struct GuardedStream {
+    inner: Pin<Box<dyn futures::Stream<Item = Result<Event, Infallible>> + Send>>,
+    _guard: SessionCleanup,
+}
+
+impl GuardedStream {
+    fn new<S>(inner: S, guard: SessionCleanup) -> Self
+    where
+        S: futures::Stream<Item = Result<Event, Infallible>> + Send + 'static,
+    {
+        Self {
+            inner: Box::pin(inner),
+            _guard: guard,
+        }
+    }
+}
+
+impl futures::Stream for GuardedStream {
+    type Item = Result<Event, Infallible>;
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.as_mut().poll_next(cx)
+    }
+}
 
 /// Minimal JSON-RPC 2.0 request shape accepted by the gateway `/mcp` endpoint.
 #[derive(Debug, Deserialize)]
@@ -89,10 +135,13 @@ pub async fn handle_gateway_get(
         .unwrap_or_else(|| format!("gw-{}", uuid::Uuid::new_v4().simple()));
 
     let rx = gs.events_tx.subscribe();
+    // Per-session sink for backend-SSE multiplex (#320). Dropped (via
+    // `forget_client`) when the axum stream is dropped by the client.
+    let per_session_rx = gs.subscriber.register_client(&session_id);
 
     // Convert broadcast receiver into an SSE stream.
     // Lagged messages (receiver too slow) are skipped gracefully.
-    let sse_stream = BroadcastStream::new(rx).filter_map(|result| {
+    let broadcast_stream = BroadcastStream::new(rx).filter_map(|result| {
         let data = match result {
             Ok(s) => s,
             Err(tokio_stream::wrappers::errors::BroadcastStreamRecvError::Lagged(n)) => {
@@ -102,6 +151,34 @@ pub async fn handle_gateway_get(
         };
         Some(Ok::<Event, Infallible>(Event::default().data(data)))
     });
+    // Per-client backend-notification stream.
+    let per_session_stream = BroadcastStream::new(per_session_rx).filter_map(|result| {
+        let data = match result {
+            Ok(s) => s,
+            Err(tokio_stream::wrappers::errors::BroadcastStreamRecvError::Lagged(n)) => {
+                tracing::warn!("Gateway SSE (per-session): client lagged, skipped {n} message(s)");
+                return None;
+            }
+        };
+        // Backend-SSE forwards are already pre-formatted as
+        // "data: <json>\n\n" by `format_sse_event`; strip the framing so
+        // axum's `Event::data` can re-add it cleanly.
+        let payload = data
+            .strip_prefix("data: ")
+            .and_then(|s| s.strip_suffix("\n\n"))
+            .unwrap_or(&data)
+            .to_owned();
+        Some(Ok::<Event, Infallible>(Event::default().data(payload)))
+    });
+    let sse_stream = broadcast_stream.merge(per_session_stream);
+
+    // Track lifetime of the per-session registration: when the axum
+    // response is dropped (client disconnect), this guard evicts the
+    // sink so stale notifications are not buffered forever.
+    let cleanup = SessionCleanup {
+        mgr: gs.subscriber.clone(),
+        session_id: session_id.clone(),
+    };
 
     // Prepend an endpoint-event so MCP clients know where to POST.
     // (Streamable HTTP spec §4.2 requires an initial `endpoint` event.)
@@ -109,7 +186,9 @@ pub async fn handle_gateway_get(
         Ok::<Event, Infallible>(Event::default().event("endpoint").data("/mcp"))
     });
 
-    let mut resp = Sse::new(endpoint_event.chain(sse_stream))
+    let combined = endpoint_event.chain(sse_stream);
+    let guarded = GuardedStream::new(combined, cleanup);
+    let mut resp = Sse::new(guarded)
         .keep_alive(KeepAlive::default())
         .into_response();
     if let Ok(hv) = session_id.parse() {
@@ -523,9 +602,15 @@ async fn dispatch_single_request(
                 );
             }
 
-            let (text, is_error) =
-                aggregator::route_tools_call(gs, tool, &args, meta.as_ref(), Some(id_str.clone()))
-                    .await;
+            let (text, is_error) = aggregator::route_tools_call(
+                gs,
+                tool,
+                &args,
+                meta.as_ref(),
+                Some(id_str.clone()),
+                Some(session_id),
+            )
+            .await;
 
             {
                 let mut pending = gs.pending_calls.write().await;

--- a/crates/dcc-mcp-http/src/gateway/mod.rs
+++ b/crates/dcc-mcp-http/src/gateway/mod.rs
@@ -30,6 +30,7 @@ pub mod handlers;
 pub mod namespace;
 pub mod proxy;
 pub mod router;
+pub mod sse_subscriber;
 pub mod state;
 pub mod tools;
 
@@ -357,6 +358,38 @@ async fn start_gateway_tasks(
         }
     });
 
+    // ── Backend SSE subscriber manager (#320) ─────────────────────────────
+    // Multiplexes per-backend SSE notifications back to originating client
+    // sessions. Each `ensure_subscribed` spawns a reconnecting task.
+    let subscriber = sse_subscriber::SubscriberManager::new(http_client.clone());
+
+    // Periodically ensure every live backend has an active subscription.
+    // The subscriber's internal DashMap makes repeat calls cheap, so we
+    // just poll the instance registry at the same cadence as the
+    // instance-change watcher.
+    let reg_sub = registry.clone();
+    let sub_for_task = subscriber.clone();
+    let backend_sub_handle = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(2));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            interval.tick().await;
+            let urls: Vec<String> = {
+                let r = reg_sub.read().await;
+                r.list_all()
+                    .into_iter()
+                    .filter(|e| {
+                        e.dcc_type != GATEWAY_SENTINEL_DCC_TYPE && !e.is_stale(stale_timeout)
+                    })
+                    .map(|e| format!("http://{}:{}/mcp", e.host, e.port))
+                    .collect()
+            };
+            for url in urls {
+                sub_for_task.ensure_subscribed(&url);
+            }
+        }
+    });
+
     // ── Gateway HTTP server ────────────────────────────────────────────────
     let gw_state = GatewayState {
         registry,
@@ -370,6 +403,7 @@ async fn start_gateway_tasks(
         protocol_version: Arc::new(RwLock::new(None)),
         resource_subscriptions: Arc::new(RwLock::new(HashMap::new())),
         pending_calls: Arc::new(RwLock::new(HashMap::new())),
+        subscriber,
     };
     let gw_router = build_gateway_router(gw_state);
     let actual = listener.local_addr()?;
@@ -401,6 +435,7 @@ async fn start_gateway_tasks(
             cleanup_handle,
             watcher_handle,
             tools_watcher_handle,
+            backend_sub_handle,
             gw_handle
         );
     });

--- a/crates/dcc-mcp-http/src/gateway/sse_subscriber.rs
+++ b/crates/dcc-mcp-http/src/gateway/sse_subscriber.rs
@@ -1,0 +1,824 @@
+//! Backend SSE subscription + multiplexing (#320).
+//!
+//! This module lets the gateway multiplex notifications emitted by each
+//! backend DCC server (`notifications/progress`, `$/dcc.jobUpdated`,
+//! `$/dcc.workflowUpdated`) back to the *originating* client sessions.
+//!
+//! # Architecture
+//!
+//! ```text
+//!   client_session_A ──────┐
+//!                           \     ┌─────────── gateway ─────────────┐
+//!   client_session_B ────────┼──>│ SubscriberManager               │
+//!                           /    │   backends: url → BackendSub     │
+//!   client_session_C ──────┘    │   job_routes: jobId → session     │
+//!                               │   progress_routes: tok → session  │
+//!                               │   inflight: url → {sessions}      │
+//!                               │   client_sinks: session → tx       │
+//!                               └─────┬───────────────┬────────────┘
+//!                                     │ GET /mcp (backend)           │
+//!                                     ▼                              ▼
+//!                                backend-1 SSE               backend-2 SSE
+//! ```
+//!
+//! ## Correlation
+//!
+//! * `notifications/progress` carries `params.progressToken` — resolve against
+//!   `progress_token_routes` (set at outbound `tools/call` time).
+//! * `$/dcc.jobUpdated` / `$/dcc.workflowUpdated` carries `params.job_id` —
+//!   resolve against `job_routes` (set from `_meta.dcc.jobId` on the reply).
+//!
+//! If a notification arrives before either correlation is known it is
+//! buffered for up to 30 s (or 256 events, whichever comes first) and
+//! replayed once the mapping appears; otherwise dropped with a `warn!`.
+//!
+//! ## Reconnect
+//!
+//! Each [`BackendSubscriber`] owns an exponential-backoff retry loop
+//! (start 100 ms → max 10 s, 25 % jitter). When a broken stream is
+//! restored the subscriber emits a synthetic `$/dcc.gatewayReconnect`
+//! notification to every client that had an in-flight job on that
+//! backend (tracked in `backend_inflight`).
+
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use dashmap::{DashMap, DashSet};
+use futures::StreamExt;
+use parking_lot::Mutex;
+use serde_json::{Value, json};
+use tokio::sync::broadcast;
+use tokio::task::JoinHandle;
+
+use crate::protocol::format_sse_event;
+
+/// How long a notification with an unknown target may sit in the pending
+/// buffer before being dropped.
+pub(crate) const PENDING_BUFFER_TTL: Duration = Duration::from_secs(30);
+
+/// Maximum number of notifications with unknown target buffered per backend.
+pub(crate) const PENDING_BUFFER_CAP: usize = 256;
+
+/// Initial reconnect delay after the backend SSE stream dies.
+pub(crate) const RECONNECT_INITIAL: Duration = Duration::from_millis(100);
+
+/// Ceiling on the reconnect delay.
+pub(crate) const RECONNECT_MAX: Duration = Duration::from_secs(10);
+
+/// Jitter multiplier applied to each reconnect delay (±25 %).
+pub(crate) const RECONNECT_JITTER: f32 = 0.25;
+
+/// Request timeout used when opening the backend SSE stream.
+pub(crate) const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Identifier for a client-side MCP session.
+pub type ClientSessionId = String;
+
+/// A notification buffered while its target mapping is still unknown.
+#[derive(Debug, Clone)]
+pub(crate) struct Pending {
+    inserted_at: Instant,
+    value: Value,
+}
+
+/// Per-backend subscription state.
+///
+/// Public fields are `pub(crate)` so the gateway's `start_gateway_tasks`
+/// can spawn / abort the reconnect loop directly.
+pub struct BackendSubscriber {
+    /// Absolute URL of the backend MCP endpoint (`http://host:port/mcp`).
+    #[allow(dead_code)]
+    pub(crate) url: String,
+    /// Reconnect loop JoinHandle. `None` when the subscriber was never
+    /// started or has been aborted.
+    pub(crate) task: Option<JoinHandle<()>>,
+    /// Shared state with the reconnect task.
+    pub(crate) shared: Arc<BackendShared>,
+}
+
+impl BackendSubscriber {
+    /// Abort the reconnect loop. Idempotent.
+    pub fn abort(&mut self) {
+        if let Some(h) = self.task.take() {
+            h.abort();
+        }
+    }
+}
+
+impl Drop for BackendSubscriber {
+    fn drop(&mut self) {
+        self.abort();
+    }
+}
+
+/// Shared state for a single backend's reconnect loop.
+pub(crate) struct BackendShared {
+    /// Backend URL for logging.
+    pub(crate) url: String,
+    /// Per-backend bounded buffer of notifications whose target session
+    /// could not yet be resolved.
+    pub(crate) pending: Mutex<VecDeque<Pending>>,
+    /// Number of consecutive reconnect attempts (reset on a successful
+    /// open of the SSE stream).
+    pub(crate) reconnect_attempts: Mutex<u32>,
+}
+
+impl BackendShared {
+    fn new(url: String) -> Self {
+        Self {
+            url,
+            pending: Mutex::new(VecDeque::with_capacity(PENDING_BUFFER_CAP)),
+            reconnect_attempts: Mutex::new(0),
+        }
+    }
+}
+
+/// Central multiplexer for backend SSE streams.
+///
+/// A single instance is owned by [`crate::gateway::state::GatewayState`] and
+/// shared across every gateway handler. `ensure_subscribed` is the
+/// single entry point callers need — the first request for a given
+/// backend URL spawns a long-lived reconnect task; subsequent requests
+/// are cheap DashMap lookups.
+#[derive(Clone)]
+pub struct SubscriberManager {
+    inner: Arc<SubscriberManagerInner>,
+}
+
+struct SubscriberManagerInner {
+    backends: DashMap<String, BackendSubscriber>,
+    /// `job_id` → owning client session.
+    job_routes: DashMap<String, ClientSessionId>,
+    /// `progressToken` (serialised JSON) → owning client session.
+    progress_token_routes: DashMap<String, ClientSessionId>,
+    /// Backend URL → set of client sessions with in-flight jobs on that
+    /// backend. Used for `$/dcc.gatewayReconnect` fan-out.
+    backend_inflight: DashMap<String, DashSet<ClientSessionId>>,
+    /// Client session → broadcast::Sender used by the GET /mcp handler.
+    client_sinks: DashMap<ClientSessionId, broadcast::Sender<String>>,
+    /// Shared HTTP client with connection pooling.
+    http_client: reqwest::Client,
+}
+
+impl Default for SubscriberManager {
+    fn default() -> Self {
+        Self::new(reqwest::Client::new())
+    }
+}
+
+impl SubscriberManager {
+    pub fn new(http_client: reqwest::Client) -> Self {
+        Self {
+            inner: Arc::new(SubscriberManagerInner {
+                backends: DashMap::new(),
+                job_routes: DashMap::new(),
+                progress_token_routes: DashMap::new(),
+                backend_inflight: DashMap::new(),
+                client_sinks: DashMap::new(),
+                http_client,
+            }),
+        }
+    }
+
+    // ── Client-side API ────────────────────────────────────────────────
+
+    /// Register (or replace) the broadcast::Sender used to deliver SSE
+    /// events to `session_id`. Returns a fresh receiver that the
+    /// GET /mcp handler can forward onto its axum SSE stream.
+    pub fn register_client(&self, session_id: &str) -> broadcast::Receiver<String> {
+        let (tx, rx) = broadcast::channel::<String>(128);
+        self.inner.client_sinks.insert(session_id.to_string(), tx);
+        rx
+    }
+
+    /// Remove a client session and drop its sink. Any future
+    /// notifications destined for this session are dropped silently.
+    pub fn forget_client(&self, session_id: &str) {
+        self.inner.client_sinks.remove(session_id);
+        // Scrub the backend_inflight index so a later reconnect on some
+        // backend does not try to notify this long-gone session.
+        for entry in self.inner.backend_inflight.iter() {
+            entry.value().remove(session_id);
+        }
+        // Scrub routing tables to avoid memory growth. We don't scan
+        // `progress_token_routes` keys eagerly (tokens are short-lived)
+        // but removing job_routes bound to this session is cheap.
+        self.inner
+            .job_routes
+            .retain(|_, sid| sid.as_str() != session_id);
+        self.inner
+            .progress_token_routes
+            .retain(|_, sid| sid.as_str() != session_id);
+    }
+
+    // ── Correlation updates ────────────────────────────────────────────
+
+    /// Associate a `progressToken` seen on the outbound `tools/call`
+    /// with the initiating client session.
+    pub fn bind_progress_token(&self, token: &Value, session_id: &str) {
+        let key = progress_token_key(token);
+        self.inner
+            .progress_token_routes
+            .insert(key, session_id.to_string());
+    }
+
+    /// Associate a `job_id` extracted from a backend reply with its
+    /// owning client session. Also registers the session as having an
+    /// in-flight job on `backend_url` so that a later reconnect on that
+    /// backend can emit `$/dcc.gatewayReconnect`.
+    pub fn bind_job(&self, job_id: &str, session_id: &str, backend_url: &str) {
+        self.inner
+            .job_routes
+            .insert(job_id.to_string(), session_id.to_string());
+        self.inner
+            .backend_inflight
+            .entry(backend_url.to_string())
+            .or_default()
+            .insert(session_id.to_string());
+        self.flush_pending_for_backend(backend_url);
+    }
+
+    /// Forget a `job_id` once the gateway has observed a terminal event
+    /// (caller's responsibility; the subscriber loop does not clean up
+    /// automatically because terminal detection needs JSON-RPC
+    /// semantics).
+    #[allow(dead_code)]
+    pub fn forget_job(&self, job_id: &str) {
+        self.inner.job_routes.remove(job_id);
+    }
+
+    // ── Backend lifecycle ──────────────────────────────────────────────
+
+    /// Ensure a reconnecting SSE subscriber exists for `backend_url`.
+    /// Idempotent — a second call is a cheap DashMap lookup.
+    pub fn ensure_subscribed(&self, backend_url: &str) {
+        if self.inner.backends.contains_key(backend_url) {
+            return;
+        }
+        let shared = Arc::new(BackendShared::new(backend_url.to_string()));
+        let mgr = self.clone();
+        let url = backend_url.to_string();
+        let shared_clone = shared.clone();
+        let task = tokio::spawn(async move {
+            mgr.run_backend_loop(url, shared_clone).await;
+        });
+        self.inner.backends.insert(
+            backend_url.to_string(),
+            BackendSubscriber {
+                url: backend_url.to_string(),
+                task: Some(task),
+                shared,
+            },
+        );
+    }
+
+    // ── Introspection helpers (for tests) ──────────────────────────────
+
+    #[cfg(test)]
+    pub(crate) fn route_for_job(&self, job_id: &str) -> Option<String> {
+        self.inner.job_routes.get(job_id).map(|e| e.value().clone())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn route_for_progress_token(&self, token: &Value) -> Option<String> {
+        self.inner
+            .progress_token_routes
+            .get(&progress_token_key(token))
+            .map(|e| e.value().clone())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pending_count(&self, backend_url: &str) -> usize {
+        self.inner
+            .backends
+            .get(backend_url)
+            .map(|b| b.shared.pending.lock().len())
+            .unwrap_or(0)
+    }
+
+    // ── Delivery ───────────────────────────────────────────────────────
+
+    /// Deliver an MCP notification JSON to the right client session, or
+    /// buffer it if we cannot resolve the target yet.
+    fn deliver(&self, value: Value, backend_shared: &BackendShared) {
+        let session = resolve_target(&self.inner, &value);
+        match session {
+            Some(sid) => {
+                if let Some(sender) = self.inner.client_sinks.get(&sid) {
+                    let event = format_sse_event(&value, None);
+                    // receiver_count() == 0 is fine: push_event in
+                    // SessionManager has the same semantics.
+                    let _ = sender.send(event);
+                } else {
+                    tracing::debug!(
+                        session = %sid,
+                        backend = %backend_shared.url,
+                        "gateway SSE: target session has no live sink — dropping"
+                    );
+                }
+            }
+            None => self.buffer_pending(backend_shared, value),
+        }
+    }
+
+    fn buffer_pending(&self, shared: &BackendShared, value: Value) {
+        let mut buf = shared.pending.lock();
+        // Expire stale entries first.
+        let now = Instant::now();
+        while buf
+            .front()
+            .map(|p| now.duration_since(p.inserted_at) >= PENDING_BUFFER_TTL)
+            .unwrap_or(false)
+        {
+            buf.pop_front();
+        }
+        if buf.len() >= PENDING_BUFFER_CAP {
+            let dropped = buf.pop_front();
+            tracing::warn!(
+                backend = %shared.url,
+                buffered = buf.len() + 1,
+                dropped_method = %dropped
+                    .as_ref()
+                    .and_then(|p| p.value.get("method"))
+                    .and_then(|m| m.as_str())
+                    .unwrap_or(""),
+                "gateway SSE pending buffer full — dropping oldest"
+            );
+        }
+        buf.push_back(Pending {
+            inserted_at: now,
+            value,
+        });
+    }
+
+    /// Re-scan the pending buffer after a new routing mapping appeared.
+    fn flush_pending_for_backend(&self, backend_url: &str) {
+        let Some(backend) = self.inner.backends.get(backend_url) else {
+            return;
+        };
+        let shared = backend.shared.clone();
+        drop(backend); // release DashMap shard lock before taking inner lock
+
+        let drained: Vec<Pending> = {
+            let mut buf = shared.pending.lock();
+            let now = Instant::now();
+            buf.retain(|p| now.duration_since(p.inserted_at) < PENDING_BUFFER_TTL);
+            std::mem::take(&mut *buf).into_iter().collect()
+        };
+        for p in drained {
+            let session = resolve_target(&self.inner, &p.value);
+            match session {
+                Some(sid) => {
+                    if let Some(sender) = self.inner.client_sinks.get(&sid) {
+                        let event = format_sse_event(&p.value, None);
+                        let _ = sender.send(event);
+                    }
+                }
+                None => {
+                    // Still unresolved — re-queue.
+                    shared.pending.lock().push_back(p);
+                }
+            }
+        }
+    }
+
+    /// Fan-out a synthetic `$/dcc.gatewayReconnect` notification to every
+    /// client that had an in-flight job on `backend_url`.
+    fn emit_gateway_reconnect(&self, backend_url: &str) {
+        let Some(sessions) = self.inner.backend_inflight.get(backend_url) else {
+            return;
+        };
+        let notification = json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/$/dcc.gatewayReconnect",
+            "params": {
+                "backend_url": backend_url,
+            },
+        });
+        let event = format_sse_event(&notification, None);
+        for sid in sessions.iter() {
+            if let Some(sender) = self.inner.client_sinks.get(sid.key()) {
+                let _ = sender.send(event.clone());
+            }
+        }
+    }
+
+    // ── Backend reconnect loop ─────────────────────────────────────────
+
+    async fn run_backend_loop(self, url: String, shared: Arc<BackendShared>) {
+        let mut attempt: u32 = 0;
+        loop {
+            match self.open_stream(&url).await {
+                Ok(resp) => {
+                    if attempt > 0 {
+                        tracing::info!(
+                            backend = %url,
+                            attempts = attempt,
+                            "gateway SSE: backend reconnected — emitting gatewayReconnect"
+                        );
+                        self.emit_gateway_reconnect(&url);
+                    }
+                    attempt = 0;
+                    *shared.reconnect_attempts.lock() = 0;
+                    // Pump until the stream closes / errors out.
+                    self.pump_stream(resp, &shared).await;
+                    tracing::info!(backend = %url, "gateway SSE: stream closed — reconnecting");
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        backend = %url,
+                        attempt,
+                        error = %e,
+                        "gateway SSE: connect failed"
+                    );
+                }
+            }
+            attempt = attempt.saturating_add(1);
+            *shared.reconnect_attempts.lock() = attempt;
+            let delay = backoff_delay(attempt);
+            tokio::time::sleep(delay).await;
+        }
+    }
+
+    async fn open_stream(&self, url: &str) -> reqwest::Result<reqwest::Response> {
+        self.inner
+            .http_client
+            .get(url)
+            .timeout(CONNECT_TIMEOUT)
+            .header("accept", "text/event-stream")
+            .send()
+            .await
+            .and_then(|r| r.error_for_status())
+    }
+
+    async fn pump_stream(&self, resp: reqwest::Response, shared: &BackendShared) {
+        let mut stream = resp.bytes_stream();
+        let mut scratch: Vec<u8> = Vec::with_capacity(4096);
+        while let Some(chunk) = stream.next().await {
+            let bytes = match chunk {
+                Ok(b) => b,
+                Err(e) => {
+                    tracing::debug!(backend = %shared.url, error = %e, "gateway SSE: stream error");
+                    break;
+                }
+            };
+            scratch.extend_from_slice(&bytes);
+            // SSE records terminate with "\n\n"; drain complete records
+            // from the head of the scratch buffer.
+            while let Some(pos) = find_record_end(&scratch) {
+                let record = scratch.drain(..pos).collect::<Vec<u8>>();
+                // Discard the trailing delimiter.
+                let _ = scratch.drain(..record_delim_len(&scratch));
+                if let Some(value) = parse_sse_record(&record) {
+                    self.deliver(value, shared);
+                }
+            }
+        }
+    }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+/// Serialise a `progressToken` (may be number or string) into a stable
+/// map key.
+pub(crate) fn progress_token_key(token: &Value) -> String {
+    match token {
+        Value::String(s) => format!("s:{s}"),
+        Value::Number(n) => format!("n:{n}"),
+        other => format!("j:{other}"),
+    }
+}
+
+/// Exponential backoff with ±25 % jitter.
+pub(crate) fn backoff_delay(attempt: u32) -> Duration {
+    let base = RECONNECT_INITIAL.as_millis() as u64;
+    // doubling, capped.
+    let shift = attempt.saturating_sub(1).min(12); // 2^12 headroom
+    let mut delay_ms = base.saturating_mul(1u64 << shift);
+    let cap = RECONNECT_MAX.as_millis() as u64;
+    if delay_ms > cap {
+        delay_ms = cap;
+    }
+    // Pseudo-random jitter derived from attempt & current nanos so
+    // multiple backends don't synchronise retries.
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos() as u64)
+        .unwrap_or(0);
+    let entropy = (nanos.rotate_left(attempt % 64)) % 1024;
+    let jitter_span = (delay_ms as f32 * RECONNECT_JITTER) as i64;
+    let jitter = if jitter_span > 0 {
+        (entropy as i64 % (jitter_span * 2 + 1)) - jitter_span
+    } else {
+        0
+    };
+    let final_ms = (delay_ms as i64).saturating_add(jitter).max(0) as u64;
+    Duration::from_millis(final_ms)
+}
+
+/// Return the byte offset of the end of the next complete SSE record
+/// (double-newline) in `buf`, relative to the buffer start.
+fn find_record_end(buf: &[u8]) -> Option<usize> {
+    // Accept both "\n\n" and "\r\n\r\n" as record terminators.
+    for i in 0..buf.len().saturating_sub(1) {
+        if buf[i] == b'\n' && buf[i + 1] == b'\n' {
+            return Some(i);
+        }
+        if i + 3 < buf.len() && &buf[i..i + 4] == b"\r\n\r\n" {
+            return Some(i);
+        }
+    }
+    None
+}
+
+/// Length of the terminator `find_record_end` matched. Called after a
+/// successful `find_record_end` returns `Some`.
+fn record_delim_len(buf: &[u8]) -> usize {
+    if buf.starts_with(b"\r\n\r\n") {
+        4
+    } else {
+        // Standard case: the drained record already took everything up
+        // to the first delimiter byte. What's left in the buffer starts
+        // with the terminator itself.
+        if buf.starts_with(b"\n\n") { 2 } else { 1 }
+    }
+}
+
+/// Parse a single SSE record (without trailing blank line) into a JSON
+/// value, returning `None` if the record has no `data:` field or the
+/// payload is not valid JSON.
+fn parse_sse_record(record: &[u8]) -> Option<Value> {
+    let text = std::str::from_utf8(record).ok()?;
+    let mut data_lines: Vec<&str> = Vec::new();
+    for line in text.split('\n') {
+        let line = line.trim_end_matches('\r');
+        if let Some(rest) = line.strip_prefix("data:") {
+            // MDN / WHATWG: the single leading space is optional.
+            data_lines.push(rest.strip_prefix(' ').unwrap_or(rest));
+        }
+    }
+    if data_lines.is_empty() {
+        return None;
+    }
+    let joined = data_lines.join("\n");
+    serde_json::from_str::<Value>(&joined).ok()
+}
+
+/// Determine which client session should receive `value`.
+fn resolve_target(inner: &SubscriberManagerInner, value: &Value) -> Option<String> {
+    let method = value.get("method").and_then(|m| m.as_str())?;
+    let params = value.get("params");
+
+    match method {
+        "notifications/progress" => {
+            let token = params.and_then(|p| p.get("progressToken"))?;
+            inner
+                .progress_token_routes
+                .get(&progress_token_key(token))
+                .map(|e| e.value().clone())
+        }
+        "notifications/$/dcc.jobUpdated" | "notifications/$/dcc.workflowUpdated" => {
+            let job_id = params
+                .and_then(|p| p.get("job_id"))
+                .and_then(|j| j.as_str())?;
+            inner.job_routes.get(job_id).map(|e| e.value().clone())
+        }
+        _ => None,
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backoff_delay_starts_near_initial() {
+        let d = backoff_delay(1);
+        // first attempt — base 100 ms ± 25 %
+        assert!(d >= Duration::from_millis(75));
+        assert!(d <= Duration::from_millis(125));
+    }
+
+    #[test]
+    fn backoff_delay_grows_exponentially_and_caps() {
+        // large attempt — must not exceed RECONNECT_MAX + 25 %
+        let cap_with_jitter = (RECONNECT_MAX.as_millis() as f32 * 1.25) as u128;
+        for attempt in 1..30u32 {
+            let d = backoff_delay(attempt).as_millis();
+            assert!(
+                d <= cap_with_jitter,
+                "attempt={attempt} delay={d}ms exceeds cap {cap_with_jitter}ms"
+            );
+        }
+        // At attempt=20 we are definitely saturated near the cap.
+        let d = backoff_delay(20).as_millis();
+        let floor = (RECONNECT_MAX.as_millis() as f32 * 0.75) as u128;
+        assert!(d >= floor, "saturated backoff={d}ms below floor {floor}ms");
+    }
+
+    #[test]
+    fn progress_token_key_distinguishes_string_and_number_tokens() {
+        let s = progress_token_key(&Value::String("abc".into()));
+        let n = progress_token_key(&serde_json::json!(42));
+        let n_str = progress_token_key(&Value::String("42".into()));
+        assert_ne!(s, n);
+        assert_ne!(n, n_str);
+    }
+
+    #[test]
+    fn parse_sse_record_extracts_json_from_data_field() {
+        let rec = b"data: {\"method\":\"notifications/progress\",\"params\":{\"progress\":1}}";
+        let v = parse_sse_record(rec).expect("valid record");
+        assert_eq!(v["method"], "notifications/progress");
+    }
+
+    #[test]
+    fn parse_sse_record_handles_multiline_data_and_id_field() {
+        // Two `data:` lines must be concatenated with '\n' per
+        // WHATWG SSE spec. We check both that the parse does not
+        // panic on a multi-line record and that non-data lines
+        // (`id:`, `event:`) are skipped.
+        let rec = b"id: 7\nevent: message\ndata: {\"a\":1,\ndata: \"b\":2}";
+        let v = parse_sse_record(rec).expect("multi-line data: joins cleanly");
+        assert_eq!(v["a"], 1);
+        assert_eq!(v["b"], 2);
+    }
+
+    #[test]
+    fn parse_sse_record_returns_none_for_record_without_data_field() {
+        let rec = b"event: endpoint\n";
+        assert!(parse_sse_record(rec).is_none());
+    }
+
+    #[test]
+    fn resolve_target_prefers_progress_token_for_progress_notifications() {
+        let inner = SubscriberManagerInner {
+            backends: DashMap::new(),
+            job_routes: DashMap::new(),
+            progress_token_routes: DashMap::new(),
+            backend_inflight: DashMap::new(),
+            client_sinks: DashMap::new(),
+            http_client: reqwest::Client::new(),
+        };
+        inner.progress_token_routes.insert(
+            progress_token_key(&Value::String("tok".into())),
+            "sessA".into(),
+        );
+        let note = serde_json::json!({
+            "method": "notifications/progress",
+            "params": {"progressToken": "tok", "progress": 5, "total": 10}
+        });
+        assert_eq!(resolve_target(&inner, &note).as_deref(), Some("sessA"));
+    }
+
+    #[test]
+    fn resolve_target_uses_job_id_for_job_updated() {
+        let inner = SubscriberManagerInner {
+            backends: DashMap::new(),
+            job_routes: DashMap::new(),
+            progress_token_routes: DashMap::new(),
+            backend_inflight: DashMap::new(),
+            client_sinks: DashMap::new(),
+            http_client: reqwest::Client::new(),
+        };
+        inner.job_routes.insert("jid-42".into(), "sessB".into());
+        let note = serde_json::json!({
+            "method": "notifications/$/dcc.jobUpdated",
+            "params": {"job_id": "jid-42", "status": "running"}
+        });
+        assert_eq!(resolve_target(&inner, &note).as_deref(), Some("sessB"));
+    }
+
+    #[test]
+    fn resolve_target_returns_none_when_unknown() {
+        let inner = SubscriberManagerInner {
+            backends: DashMap::new(),
+            job_routes: DashMap::new(),
+            progress_token_routes: DashMap::new(),
+            backend_inflight: DashMap::new(),
+            client_sinks: DashMap::new(),
+            http_client: reqwest::Client::new(),
+        };
+        let note = serde_json::json!({
+            "method": "notifications/progress",
+            "params": {"progressToken": "no-such-token"}
+        });
+        assert!(resolve_target(&inner, &note).is_none());
+    }
+
+    #[tokio::test]
+    async fn manager_buffers_then_flushes_after_job_binding() {
+        // Stand up a manager, register a client, hand-feed a notification
+        // whose job_id mapping is not yet known, then bind the mapping
+        // and assert the buffered event is delivered.
+        let mgr = SubscriberManager::default();
+        let mut rx = mgr.register_client("sess1");
+        let backend = "http://127.0.0.1:0/mcp".to_string();
+        // Fake a backend entry so buffer operations resolve.
+        let shared = Arc::new(BackendShared::new(backend.clone()));
+        mgr.inner.backends.insert(
+            backend.clone(),
+            BackendSubscriber {
+                url: backend.clone(),
+                task: None,
+                shared: shared.clone(),
+            },
+        );
+
+        let note = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/$/dcc.jobUpdated",
+            "params": {"job_id": "job-1", "status": "running"}
+        });
+        mgr.deliver(note.clone(), &shared);
+        assert_eq!(mgr.pending_count(&backend), 1, "buffered while unresolved");
+        assert!(rx.try_recv().is_err(), "nothing delivered yet");
+
+        mgr.bind_job("job-1", "sess1", &backend);
+        // After bind, the flush is triggered synchronously.
+        assert_eq!(mgr.pending_count(&backend), 0, "buffer drained");
+        let event = rx
+            .try_recv()
+            .expect("event should have been flushed to sink");
+        assert!(event.contains("notifications/$/dcc.jobUpdated"));
+    }
+
+    #[tokio::test]
+    async fn manager_emits_gateway_reconnect_to_inflight_sessions() {
+        let mgr = SubscriberManager::default();
+        let mut rx = mgr.register_client("sess1");
+        let backend = "http://127.0.0.1:0/mcp".to_string();
+        let shared = Arc::new(BackendShared::new(backend.clone()));
+        mgr.inner.backends.insert(
+            backend.clone(),
+            BackendSubscriber {
+                url: backend.clone(),
+                task: None,
+                shared,
+            },
+        );
+        mgr.bind_job("job-x", "sess1", &backend);
+
+        mgr.emit_gateway_reconnect(&backend);
+
+        let event = rx.try_recv().expect("gatewayReconnect should be delivered");
+        assert!(event.contains("notifications/$/dcc.gatewayReconnect"));
+        assert!(event.contains(&backend));
+    }
+
+    #[tokio::test]
+    async fn manager_drops_events_for_forgotten_client() {
+        let mgr = SubscriberManager::default();
+        let _rx = mgr.register_client("sess1");
+        mgr.forget_client("sess1");
+
+        let backend = "http://127.0.0.1:0/mcp".to_string();
+        let shared = Arc::new(BackendShared::new(backend.clone()));
+        mgr.inner.backends.insert(
+            backend.clone(),
+            BackendSubscriber {
+                url: backend.clone(),
+                task: None,
+                shared: shared.clone(),
+            },
+        );
+        mgr.bind_job("job-gone", "sess1", &backend);
+        let note = serde_json::json!({
+            "jsonrpc":"2.0",
+            "method":"notifications/$/dcc.jobUpdated",
+            "params":{"job_id":"job-gone","status":"running"}
+        });
+        // Must not panic; simply drops.
+        mgr.deliver(note, &shared);
+    }
+
+    #[test]
+    fn pending_buffer_evicts_oldest_when_full() {
+        let mgr = SubscriberManager::default();
+        let backend = "http://127.0.0.1:0/mcp".to_string();
+        let shared = Arc::new(BackendShared::new(backend.clone()));
+        mgr.inner.backends.insert(
+            backend.clone(),
+            BackendSubscriber {
+                url: backend.clone(),
+                task: None,
+                shared: shared.clone(),
+            },
+        );
+        for i in 0..(PENDING_BUFFER_CAP + 5) {
+            let note = serde_json::json!({
+                "method":"notifications/$/dcc.jobUpdated",
+                "params":{"job_id": format!("j{i}"), "status":"running"}
+            });
+            mgr.deliver(note, &shared);
+        }
+        assert_eq!(
+            mgr.pending_count(&backend),
+            PENDING_BUFFER_CAP,
+            "buffer is bounded"
+        );
+    }
+}

--- a/crates/dcc-mcp-http/src/gateway/state.rs
+++ b/crates/dcc-mcp-http/src/gateway/state.rs
@@ -65,6 +65,13 @@ pub struct GatewayState {
     /// Key = gateway-side JSON-RPC request `id` (serialised to string).
     /// Value = backend URL + the request id used when talking to that backend.
     pub pending_calls: Arc<RwLock<HashMap<String, PendingCall>>>,
+    /// Backend SSE multiplexer (#320).
+    ///
+    /// Each live backend gets a long-lived SSE subscription; incoming
+    /// `notifications/progress` / `$/dcc.jobUpdated` /
+    /// `$/dcc.workflowUpdated` are routed to the originating client
+    /// session via `progressToken` and `job_id` correlation.
+    pub subscriber: super::sse_subscriber::SubscriberManager,
 }
 
 impl GatewayState {
@@ -143,6 +150,7 @@ mod tests {
             protocol_version: Arc::new(RwLock::new(None)),
             resource_subscriptions: Arc::new(RwLock::new(HashMap::new())),
             pending_calls: Arc::new(RwLock::new(HashMap::new())),
+            subscriber: crate::gateway::sse_subscriber::SubscriberManager::default(),
         }
     }
 

--- a/crates/dcc-mcp-http/src/tests.rs
+++ b/crates/dcc-mcp-http/src/tests.rs
@@ -2914,6 +2914,7 @@ mod gateway_tests {
             protocol_version: Arc::new(RwLock::new(None)),
             resource_subscriptions: Arc::new(RwLock::new(std::collections::HashMap::new())),
             pending_calls: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            subscriber: crate::gateway::sse_subscriber::SubscriberManager::default(),
         }
     }
 

--- a/crates/dcc-mcp-http/tests/backend_timeout.rs
+++ b/crates/dcc-mcp-http/tests/backend_timeout.rs
@@ -58,6 +58,7 @@ async fn make_state(
         protocol_version: Arc::new(RwLock::new(None)),
         resource_subscriptions: Arc::new(RwLock::new(std::collections::HashMap::new())),
         pending_calls: Arc::new(RwLock::new(std::collections::HashMap::new())),
+        subscriber: dcc_mcp_http::gateway::sse_subscriber::SubscriberManager::default(),
     };
     (state, registry, dir)
 }

--- a/docs/guide/gateway.md
+++ b/docs/guide/gateway.md
@@ -1,0 +1,84 @@
+# Gateway
+
+The gateway (`McpHttpConfig::gateway_port > 0`) is a first-wins HTTP
+façade that presents every live DCC instance under one MCP endpoint.
+A single client can talk to Maya, Blender and Houdini through the same
+`/mcp` URL; the gateway discovers live backends via `FileRegistry`,
+aggregates their `tools/list`, routes each `tools/call` to the right
+backend, and multiplexes server-pushed notifications back to the
+originating client session.
+
+## Topology
+
+```
+              ┌──────────────── gateway ────────────────┐
+  client_A ──▶│  POST /mcp  (tools/list, tools/call)    │───▶ backend (maya)
+              │  GET  /mcp  (SSE — MCP 2025-03-26)      │───▶ backend (blender)
+  client_B ──▶│  subscribers: per-client broadcast sink │
+              │  backend SSE sub: one per backend URL   │
+              └────────────────────────────────────────┘
+```
+
+## SSE multiplex (#320)
+
+When the gateway detects a new backend it opens a persistent SSE
+connection to `<backend>/mcp` (the same Streamable HTTP transport the
+client uses against the gateway). Notifications emitted by the backend
+are parsed as JSON-RPC messages and routed to the right client:
+
+| MCP method | Correlation key | Source |
+|------------|-----------------|--------|
+| `notifications/progress` | `params.progressToken` | Set by the gateway when the outbound `tools/call` carried `_meta.progressToken` |
+| `notifications/$/dcc.jobUpdated` | `params.job_id` | Set from the backend reply's `_meta.dcc.jobId` / `structuredContent.job_id` |
+| `notifications/$/dcc.workflowUpdated` | `params.job_id` | Same as above |
+
+### Pending buffer
+
+Notifications that arrive before the correlation is known (race
+between backend SSE push and the `tools/call` HTTP reply) are held in
+a bounded per-backend queue: **256 events** or **30 s**, whichever
+comes first. When the mapping appears the buffer is drained; stale
+entries are dropped with a `warn!` log.
+
+### Reconnect + synthetic `$/dcc.gatewayReconnect`
+
+Each backend subscriber owns a reconnect loop with jittered
+exponential backoff (100 ms → 10 s, ±25% jitter). When a broken
+stream reconnects, the gateway emits a synthetic
+`notifications/$/dcc.gatewayReconnect` notification to every client
+that had an in-flight job on that backend:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/$/dcc.gatewayReconnect",
+  "params": { "backend_url": "http://127.0.0.1:18812/mcp" }
+}
+```
+
+Clients use this to re-query in-flight jobs via `jobs.get_status`.
+
+### Session lifecycle
+
+Per-client SSE sinks are keyed on `Mcp-Session-Id`. A `SessionCleanup`
+RAII guard runs when the `GET /mcp` response body is dropped (client
+disconnect): the client's sink is removed from the subscriber manager
+and any `job_routes` / `progress_token_routes` bound to that session
+are scrubbed. Backend subscriptions stay alive — another client might
+still depend on them.
+
+## Code pointers
+
+| Piece | File |
+|-------|------|
+| Subscriber manager, reconnect loop | `crates/dcc-mcp-http/src/gateway/sse_subscriber.rs` |
+| Per-session SSE plumbing | `crates/dcc-mcp-http/src/gateway/handlers.rs` (`handle_gateway_get`) |
+| `tools/call` correlation hooks | `crates/dcc-mcp-http/src/gateway/aggregator.rs` (`route_tools_call`) |
+| Subscription watcher | `crates/dcc-mcp-http/src/gateway/mod.rs` (`backend_sub_handle`) |
+
+## Non-goals
+
+The SSE multiplexer does **not** forward non-notification response
+bodies — that is tracked under issue #321. Routing-cache improvements
+for cancellation (#322) and HTTP/2 multiplexing tuning are also out of
+scope for #320.

--- a/tests/test_gateway_sse.py
+++ b/tests/test_gateway_sse.py
@@ -1,0 +1,238 @@
+"""Gateway SSE multiplex regression (issue #320).
+
+The gateway subscribes to each backend's SSE stream and forwards
+`notifications/progress`, `$/dcc.jobUpdated`, `$/dcc.workflowUpdated`
+back to the originating client sessions, correlated via
+`progressToken` (for progress) and `job_id` (for the ``$/dcc.*``
+channels).
+
+This test focuses on the HTTP plumbing pieces most likely to regress
+in future refactors. The deep correlation / reconnect backoff /
+pending-buffer logic is covered by the Rust unit tests in
+``crates/dcc-mcp-http/src/gateway/sse_subscriber.rs``.
+
+Invariants verified here:
+
+1. ``GET /mcp`` on the gateway preserves the client-supplied
+   ``Mcp-Session-Id`` and immediately emits the ``endpoint`` SSE
+   event — the per-session ``SessionCleanup`` guard and
+   ``SubscriberManager.register_client`` hook both hang off that
+   session id.
+2. Two concurrent SSE clients with distinct session ids do not
+   share a sink — if they did, a progress notification bound for
+   client A would leak into client B's stream.
+3. The gateway's ``GET /mcp`` handler keeps serving after a brief
+   backend churn: the reconnect loop uses jittered exponential
+   backoff and must never tear down the front-end.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import socket
+import threading
+import time
+import urllib.request
+import uuid
+
+import pytest
+
+from dcc_mcp_core import McpHttpConfig
+from dcc_mcp_core import McpHttpServer
+from dcc_mcp_core import ToolRegistry
+
+SSE_READ_BUDGET_S = 6.0
+
+
+def _pick_free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    try:
+        return s.getsockname()[1]
+    finally:
+        s.close()
+
+
+def _wait_reachable(port: int, budget: float = 5.0) -> bool:
+    deadline = time.time() + budget
+    while time.time() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                return True
+        except (OSError, socket.timeout):
+            time.sleep(0.05)
+    return False
+
+
+class _SseReader(threading.Thread):
+    """Background thread that captures raw SSE records from a URL."""
+
+    def __init__(self, url: str, session_id: str) -> None:
+        super().__init__(daemon=True)
+        self.url = url
+        self.session_id = session_id
+        self.events: list[str] = []
+        self._stop_evt = threading.Event()
+        self._reply_session_id: str | None = None
+        self._err: Exception | None = None
+
+    @property
+    def reply_session_id(self) -> str | None:
+        return self._reply_session_id
+
+    @property
+    def error(self) -> Exception | None:
+        return self._err
+
+    def stop(self) -> None:
+        self._stop_evt.set()
+
+    def run(self) -> None:  # pragma: no cover - thread body
+        try:
+            req = urllib.request.Request(
+                self.url,
+                headers={
+                    "Accept": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    "Mcp-Session-Id": self.session_id,
+                },
+                method="GET",
+            )
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                self._reply_session_id = resp.headers.get("Mcp-Session-Id")
+                # Short socket timeout so ``stop()`` unblocks a pending
+                # ``readline`` within a few hundred milliseconds instead of
+                # hanging until the server closes the connection.
+                with contextlib.suppress(Exception):
+                    resp.fp.raw._sock.settimeout(0.25)
+                pending: list[str] = []
+                while not self._stop_evt.is_set():
+                    try:
+                        line = resp.readline()
+                    except (socket.timeout, TimeoutError):
+                        continue
+                    if not line:
+                        break
+                    text = line.decode("utf-8", "replace").rstrip("\r\n")
+                    if text == "":
+                        if pending:
+                            self.events.append("\n".join(pending))
+                            pending = []
+                        continue
+                    pending.append(text)
+        except Exception as e:
+            self._err = e
+
+
+@pytest.fixture
+def gateway_backend(tmp_path):
+    """Start a single ``McpHttpServer`` that wins the gateway election.
+
+    One process hosting both the plain-instance endpoint and the
+    gateway facade is sufficient for the invariants we check here.
+    """
+    registry_dir = tmp_path / "registry"
+    registry_dir.mkdir()
+
+    gw_port = _pick_free_port()
+
+    reg = ToolRegistry()
+    cfg = McpHttpConfig(port=0, server_name="gateway-sse-test")
+    cfg.gateway_port = gw_port
+    cfg.registry_dir = str(registry_dir)
+    cfg.dcc_type = "python"
+    cfg.heartbeat_secs = 1
+    cfg.stale_timeout_secs = 10
+
+    server = McpHttpServer(reg, cfg)
+    handle = server.start()
+
+    assert _wait_reachable(handle.port), f"instance port {handle.port} unreachable"
+    if not handle.is_gateway:
+        pytest.skip(f"another process is holding gateway port {gw_port}; cannot test gateway SSE")
+    assert _wait_reachable(gw_port), f"gateway port {gw_port} unreachable"
+
+    try:
+        yield {"handle": handle, "gateway_port": gw_port}
+    finally:
+        with contextlib.suppress(Exception):
+            handle.shutdown()
+
+
+def test_gateway_sse_echoes_client_session_id(gateway_backend):
+    """``GET /mcp`` must preserve the client-supplied ``Mcp-Session-Id``."""
+    gw_port = gateway_backend["gateway_port"]
+    sid = f"sess-{uuid.uuid4().hex[:8]}"
+
+    reader = _SseReader(f"http://127.0.0.1:{gw_port}/mcp", session_id=sid)
+    reader.start()
+    try:
+        deadline = time.time() + SSE_READ_BUDGET_S
+        while time.time() < deadline and not reader.events:
+            time.sleep(0.05)
+        assert reader.events, f"no SSE events within {SSE_READ_BUDGET_S}s (err={reader.error})"
+        assert any("endpoint" in e for e in reader.events[:2]), f"expected endpoint event, got: {reader.events[:2]}"
+        assert reader.reply_session_id == sid, f"gateway must echo session id unchanged; got {reader.reply_session_id}"
+    finally:
+        reader.stop()
+        reader.join(timeout=2)
+
+
+def test_gateway_sse_two_clients_have_distinct_sinks(gateway_backend):
+    """Two SSE clients with different session ids must be isolated.
+
+    The ``SubscriberManager`` keeps a per-session ``broadcast::Sender``;
+    cross-talk would mean losing routing for progress notifications.
+    """
+    gw_port = gateway_backend["gateway_port"]
+
+    sid_a = f"sess-a-{uuid.uuid4().hex[:6]}"
+    sid_b = f"sess-b-{uuid.uuid4().hex[:6]}"
+
+    reader_a = _SseReader(f"http://127.0.0.1:{gw_port}/mcp", session_id=sid_a)
+    reader_b = _SseReader(f"http://127.0.0.1:{gw_port}/mcp", session_id=sid_b)
+
+    reader_a.start()
+    reader_b.start()
+    try:
+        deadline = time.time() + SSE_READ_BUDGET_S
+        while time.time() < deadline and not (reader_a.events and reader_b.events):
+            time.sleep(0.05)
+
+        assert reader_a.events, f"A got no events (err={reader_a.error})"
+        assert reader_b.events, f"B got no events (err={reader_b.error})"
+        assert reader_a.reply_session_id == sid_a
+        assert reader_b.reply_session_id == sid_b
+        assert reader_a.reply_session_id != reader_b.reply_session_id, (
+            "session ids must be distinct — subscriber sinks are keyed on them"
+        )
+    finally:
+        reader_a.stop()
+        reader_b.stop()
+        reader_a.join(timeout=2)
+        reader_b.join(timeout=2)
+
+
+def test_gateway_sse_keeps_serving_under_concurrent_connects(gateway_backend):
+    """The gateway must handle overlapping SSE connect attempts without
+    tearing down existing subscribers.
+
+    The SSE multiplexer's reconnect loop uses jittered exponential
+    backoff (100 ms → 10 s); opening several connections in quick
+    succession must not destabilise the supervisor task.
+    """
+    gw_port = gateway_backend["gateway_port"]
+    readers = [_SseReader(f"http://127.0.0.1:{gw_port}/mcp", session_id=f"probe-{i}") for i in range(3)]
+    for r in readers:
+        r.start()
+    try:
+        deadline = time.time() + SSE_READ_BUDGET_S
+        while time.time() < deadline and any(not r.events for r in readers):
+            time.sleep(0.05)
+        for i, r in enumerate(readers):
+            assert r.events, f"reader {i} got no events (err={r.error})"
+    finally:
+        for r in readers:
+            r.stop()
+        for r in readers:
+            r.join(timeout=2)


### PR DESCRIPTION
## Summary

Closes #320. The gateway now subscribes to each live backend's `/mcp`
SSE stream and multiplexes inbound JSON-RPC notifications back to the
originating client session.

- **`SubscriberManager`** — one `BackendSubscriber` per backend URL,
  reconnecting with jittered exponential backoff (100 ms → 10 s, ±25 %).
  A bounded pending buffer (**256 events or 30 s**, whichever comes
  first) absorbs notifications that land before the correlation is known.
- **Correlation** — `params.progressToken` routes
  `notifications/progress`; `params.job_id` routes
  `$/dcc.jobUpdated` and `$/dcc.workflowUpdated`.
- **Reconnect surface** — every client with an in-flight job on a
  restored backend receives a synthetic
  `notifications/$/dcc.gatewayReconnect` so it can re-query state.
- **Session lifecycle** — `handle_gateway_get` registers a per-session
  sink and wraps the SSE stream in a `GuardedStream` RAII guard;
  client disconnect → sink + routes scrubbed. Backend subscriptions
  survive so other clients are unaffected.
- **Hook points** — `aggregator::route_tools_call` binds
  `progressToken` from `_meta` on the way out and extracts `job_id`
  from `_meta.dcc.jobId` / `structuredContent.job_id` on the way back.

See [`docs/guide/gateway.md`](docs/guide/gateway.md) for the full spec.

## Test plan

- [x] `vx just preflight` (cargo check + clippy + fmt + test-rust, all green)
- [x] `vx just dev` rebuilds the wheel with no warnings
- [x] `tests/test_gateway_sse.py` — 3/3 pass (session-id echo,
      per-session sink isolation, concurrent-connects resilience)
- [x] Rust unit tests in `sse_subscriber.rs` cover route registration,
      progress-token routing, SSE record parsing (incl. multi-line
      data + `id:` fields), pending buffer cap/TTL, `extract_job_id`,
      and `$/dcc.gatewayReconnect` emission
- [x] No regression in `crates/dcc-mcp-http/src/tests.rs` or
      `tests/backend_timeout.rs` — both updated for the new
      `GatewayState.subscriber` field
- [ ] 4 pre-existing failures in
      `tests/test_tools_list_pagination.py` and
      `tests/test_on_demand_loading.py` observed on `origin/main` too;
      **not** caused by this PR

## Non-goals

- Forwarding non-notification response bodies → tracked by #321
- Routing-cache for cancellation → #322
- HTTP/2 multiplexing tuning → out of scope
