### PR TITLE
feat(skills): capability declaration + typed workspace path handshake (#354)

### DIFF
--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -262,6 +262,25 @@ pub struct McpHttpConfig {
     ///
     /// Default: `None` (in-memory storage; no persistence).
     pub job_storage_path: Option<PathBuf>,
+
+    /// Capabilities declared by the DCC adapter hosting this server (issue #354).
+    ///
+    /// Each tool may list [`required_capabilities`] in its sibling
+    /// `tools.yaml`; on `tools/call` the server intersects the tool's
+    /// requirements against this declared set. Missing capabilities
+    /// surface as a `-32001 capability_missing` MCP error. Tools with
+    /// unmet capabilities still appear in `tools/list` but carry
+    /// `_meta.dcc.missing_capabilities = [...]` so clients can filter.
+    ///
+    /// The list is freeform — conventionally lowercase dotted identifiers
+    /// like `"usd"`, `"scene.mutate"`, `"filesystem.read"`. Adapters hard-code
+    /// it at construction time; there is no runtime introspection of the DCC.
+    ///
+    /// Default: empty (no capabilities declared — any tool with declared
+    /// requirements will report them as missing).
+    ///
+    /// [`required_capabilities`]: dcc_mcp_models::ToolDeclaration::required_capabilities
+    pub declared_capabilities: Vec<String>,
 }
 
 impl McpHttpConfig {
@@ -297,6 +316,7 @@ impl McpHttpConfig {
             prometheus_basic_auth: None,
             enable_job_notifications: true,
             job_storage_path: None,
+            declared_capabilities: Vec::new(),
         }
     }
 
@@ -308,6 +328,19 @@ impl McpHttpConfig {
     /// with a descriptive error at startup.
     pub fn with_job_storage_path(mut self, path: impl Into<PathBuf>) -> Self {
         self.job_storage_path = Some(path.into());
+        self
+    }
+
+    /// Builder: declare the DCC capabilities this host provides (issue #354).
+    ///
+    /// Replaces any existing capability list. Pass freeform string tags like
+    /// `"usd"`, `"scene.mutate"`, `"filesystem.read"`.
+    pub fn with_declared_capabilities<I, S>(mut self, caps: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.declared_capabilities = caps.into_iter().map(Into::into).collect();
         self
     }
 

--- a/crates/dcc-mcp-http/src/handler.rs
+++ b/crates/dcc-mcp-http/src/handler.rs
@@ -89,6 +89,13 @@ pub struct AppState {
     /// they are unique within the instance. See
     /// [`crate::McpHttpConfig::bare_tool_names`] (#307).
     pub bare_tool_names: bool,
+    /// DCC capabilities advertised by the hosting adapter (issue #354).
+    ///
+    /// Per-tool `required_capabilities` are checked against this set at
+    /// `tools/call` time. Tools with missing capabilities surface
+    /// `_meta.dcc.missing_capabilities` in `tools/list` and fail the call
+    /// with JSON-RPC error `-32001 capability_missing`.
+    pub declared_capabilities: Arc<Vec<String>>,
     /// Registry of async jobs tracked by this server instance (#316).
     ///
     /// Actual dispatch-side wiring lands in #318; #316 only establishes the
@@ -970,6 +977,7 @@ async fn handle_tools_list(
                 meta,
                 include_output_schema,
                 &bare_eligible,
+                state.declared_capabilities.as_ref(),
             ));
         } else if !meta.group.is_empty() {
             inactive_groups
@@ -1217,6 +1225,38 @@ async fn handle_tools_call_inner(
             req.id.clone(),
             serde_json::to_value(CallToolResult::error(envelope.to_json()))?,
         ));
+    }
+
+    // ── Issue #354 — capability gate ──
+    //
+    // Every tool may declare `required_capabilities` in its sibling
+    // `tools.yaml`. If the hosting DCC adapter did not advertise every
+    // requirement via `McpHttpConfig::declared_capabilities`, short-circuit
+    // the call with the `-32001 capability_missing` JSON-RPC error so
+    // clients can react (skip the step, branch to `else`, fail fast).
+    if let Some(meta) = action_meta_snapshot.as_ref() {
+        let missing = missing_capabilities(
+            &meta.required_capabilities,
+            state.declared_capabilities.as_ref(),
+        );
+        if !missing.is_empty() {
+            let msg = format!(
+                "tool {:?} requires capabilities not advertised by this DCC: {}",
+                resolved_name,
+                missing.join(", ")
+            );
+            return Ok(JsonRpcResponse::error_with_data(
+                req.id.clone(),
+                crate::protocol::error_codes::CAPABILITY_MISSING,
+                msg,
+                Some(serde_json::json!({
+                    "tool": resolved_name,
+                    "required_capabilities": meta.required_capabilities,
+                    "declared_capabilities": state.declared_capabilities.as_ref(),
+                    "missing_capabilities": missing,
+                })),
+            ));
+        }
     }
 
     // ── Async dispatch path (#318) ───────────────────────────────────────
@@ -2704,6 +2744,7 @@ fn action_meta_to_mcp_tool(
     meta: &dcc_mcp_actions::registry::ActionMeta,
     include_output_schema: bool,
     bare_eligible: &std::collections::HashSet<(String, String)>,
+    declared_capabilities: &[String],
 ) -> McpTool {
     let input_schema = if meta.input_schema.is_null() {
         json!({"type": "object"})
@@ -2762,7 +2803,7 @@ fn action_meta_to_mcp_tool(
         input_schema,
         output_schema,
         annotations,
-        meta: build_tool_meta(meta),
+        meta: build_tool_meta(meta, declared_capabilities),
     }
 }
 
@@ -2783,6 +2824,7 @@ fn action_meta_to_mcp_tool(
 /// Returns `None` when there is nothing to emit.
 fn build_tool_meta(
     meta: &dcc_mcp_actions::registry::ActionMeta,
+    declared_capabilities: &[String],
 ) -> Option<serde_json::Map<String, serde_json::Value>> {
     let deferred = meta
         .annotations
@@ -2790,7 +2832,12 @@ fn build_tool_meta(
         .unwrap_or_else(|| meta.execution.is_deferred());
 
     let has_timeout = meta.timeout_hint_secs.is_some();
-    if !has_timeout && !deferred {
+    // Issue #354 — surface any capabilities the tool requires that the
+    // hosting DCC adapter did not declare, so clients can filter these
+    // out before asking the user to invoke them.
+    let missing = missing_capabilities(&meta.required_capabilities, declared_capabilities);
+    let has_required_caps = !meta.required_capabilities.is_empty();
+    if !has_timeout && !deferred && !has_required_caps {
         return None;
     }
 
@@ -2801,9 +2848,35 @@ fn build_tool_meta(
     if deferred {
         dcc_meta.insert("deferred_hint".to_string(), serde_json::json!(true));
     }
+    if has_required_caps {
+        dcc_meta.insert(
+            "required_capabilities".to_string(),
+            serde_json::json!(meta.required_capabilities),
+        );
+        if !missing.is_empty() {
+            dcc_meta.insert(
+                "missing_capabilities".to_string(),
+                serde_json::json!(missing),
+            );
+        }
+    }
     let mut out = serde_json::Map::new();
     out.insert("dcc".to_string(), serde_json::Value::Object(dcc_meta));
     Some(out)
+}
+
+/// Return the subset of `required` capabilities that is not present in
+/// `declared`. Preserves declaration order; drops empty tags.
+pub(crate) fn missing_capabilities(required: &[String], declared: &[String]) -> Vec<String> {
+    if required.is_empty() {
+        return Vec::new();
+    }
+    let set: std::collections::HashSet<&str> = declared.iter().map(String::as_str).collect();
+    required
+        .iter()
+        .filter(|c| !c.is_empty() && !set.contains(c.as_str()))
+        .cloned()
+        .collect()
 }
 
 /// Build a lightweight stub McpTool for an unloaded skill.
@@ -3484,7 +3557,12 @@ async fn handle_describe_action(
     // rather than synthesising a bare name that might collide against a
     // peer action the caller didn't ask about.
     let bare_eligible_for_describe = std::collections::HashSet::new();
-    let tool = action_meta_to_mcp_tool(&meta, include_output_schema, &bare_eligible_for_describe);
+    let tool = action_meta_to_mcp_tool(
+        &meta,
+        include_output_schema,
+        &bare_eligible_for_describe,
+        state.declared_capabilities.as_ref(),
+    );
     let payload = serde_json::to_value(tool)?;
 
     Ok(JsonRpcResponse::success(
@@ -3757,7 +3835,7 @@ mod issue_317_tests {
             execution: ExecutionMode::Sync,
             ..Default::default()
         };
-        let tool = action_meta_to_mcp_tool(&meta, false, &empty_eligible());
+        let tool = action_meta_to_mcp_tool(&meta, false, &empty_eligible(), &[]);
         assert!(
             tool.annotations.is_none(),
             "tools without declared annotations must omit the field"
@@ -3776,7 +3854,7 @@ mod issue_317_tests {
             timeout_hint_secs: Some(600),
             ..Default::default()
         };
-        let tool = action_meta_to_mcp_tool(&meta, false, &empty_eligible());
+        let tool = action_meta_to_mcp_tool(&meta, false, &empty_eligible(), &[]);
         let v = serde_json::to_value(&tool).unwrap();
 
         assert_eq!(
@@ -3805,7 +3883,7 @@ mod issue_317_tests {
             timeout_hint_secs: Some(30),
             ..Default::default()
         };
-        let tool = action_meta_to_mcp_tool(&meta, false, &empty_eligible());
+        let tool = action_meta_to_mcp_tool(&meta, false, &empty_eligible(), &[]);
         let m = tool.meta.as_ref().unwrap();
         assert_eq!(
             m.get("dcc")
@@ -3837,7 +3915,7 @@ mod issue_317_tests {
             },
             ..Default::default()
         };
-        let tool = action_meta_to_mcp_tool(&meta, false, &empty_eligible());
+        let tool = action_meta_to_mcp_tool(&meta, false, &empty_eligible(), &[]);
         let v = serde_json::to_value(&tool).unwrap();
 
         assert_eq!(
@@ -3888,7 +3966,7 @@ mod issue_317_tests {
             },
             ..Default::default()
         };
-        let tool = action_meta_to_mcp_tool(&meta, false, &empty_eligible());
+        let tool = action_meta_to_mcp_tool(&meta, false, &empty_eligible(), &[]);
         let v = serde_json::to_value(&tool).unwrap();
         assert_eq!(
             v.pointer("/annotations/readOnlyHint")

--- a/crates/dcc-mcp-http/src/lib.rs
+++ b/crates/dcc-mcp-http/src/lib.rs
@@ -54,6 +54,7 @@ pub mod resource_link;
 pub mod resources;
 pub mod server;
 pub mod session;
+pub mod workspace;
 
 #[cfg(feature = "prometheus")]
 pub mod metrics;
@@ -81,9 +82,10 @@ pub use resources::{
 };
 pub use server::{McpHttpServer, McpServerHandle};
 pub use session::SessionManager;
+pub use workspace::{WorkspaceResolveError, WorkspaceRoots};
 
 #[cfg(feature = "python-bindings")]
-pub use python::{PyMcpHttpConfig, PyMcpHttpServer, PyServerHandle};
+pub use python::{PyMcpHttpConfig, PyMcpHttpServer, PyServerHandle, PyWorkspaceRoots};
 
 #[cfg(test)]
 mod tests;

--- a/crates/dcc-mcp-http/src/protocol.rs
+++ b/crates/dcc-mcp-http/src/protocol.rs
@@ -101,6 +101,17 @@ pub mod error_codes {
     pub const METHOD_NOT_FOUND: i64 = -32601;
     pub const INVALID_PARAMS: i64 = -32602;
     pub const INTERNAL_ERROR: i64 = -32603;
+
+    /// Issue #354 — the target tool declared capabilities that the hosting
+    /// DCC adapter did not advertise at startup. The error `data` payload
+    /// includes the `tool`, `required_capabilities`, `declared_capabilities`
+    /// and `missing_capabilities` fields so clients can react programmatically.
+    pub const CAPABILITY_MISSING: i64 = -32001;
+
+    /// Issue #354 — the client invoked a `workspace://` URI but did not
+    /// advertise any MCP `roots` on this session. The error `data` carries
+    /// the original path.
+    pub const NO_WORKSPACE_ROOTS: i64 = -32602;
 }
 
 impl JsonRpcResponse {
@@ -122,6 +133,28 @@ impl JsonRpcResponse {
                 code,
                 message: message.into(),
                 data: None,
+            }),
+        }
+    }
+
+    /// Like [`Self::error`] but carries a structured `data` payload per
+    /// JSON-RPC 2.0 §5.1. Used by issue #354 for `capability_missing` and
+    /// `no workspace roots` so clients can machine-read the surrounding
+    /// context (missing capabilities, advertised roots, …).
+    pub fn error_with_data(
+        id: Option<Value>,
+        code: i64,
+        message: impl Into<String>,
+        data: Option<Value>,
+    ) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id,
+            result: None,
+            error: Some(JsonRpcError {
+                code,
+                message: message.into(),
+                data,
             }),
         }
     }

--- a/crates/dcc-mcp-http/src/python/mod.rs
+++ b/crates/dcc-mcp-http/src/python/mod.rs
@@ -377,6 +377,28 @@ impl PyMcpHttpConfig {
         self.inner.bare_tool_names = enabled;
     }
 
+    /// DCC capabilities this adapter provides (issue #354).
+    ///
+    /// Freeform string tags (e.g. ``"usd"``, ``"scene.mutate"``,
+    /// ``"filesystem.read"``) consumed by the capability gate in
+    /// ``tools/call``. Tools whose ``required_capabilities`` are not fully
+    /// covered still surface in ``tools/list`` but fail the call with
+    /// JSON-RPC error ``-32001 capability_missing`` and carry
+    /// ``_meta.dcc.missing_capabilities`` in the list response so clients
+    /// can filter them out of the menu.
+    ///
+    /// Defaults to an empty list. Hard-code the capabilities your DCC
+    /// adapter knows it provides; there is no runtime introspection.
+    #[getter]
+    fn declared_capabilities(&self) -> Vec<String> {
+        self.inner.declared_capabilities.clone()
+    }
+
+    #[setter]
+    fn set_declared_capabilities(&mut self, caps: Vec<String>) {
+        self.inner.declared_capabilities = caps;
+    }
+
     /// Per-backend gateway fan-out timeout in milliseconds (issue #314).
     ///
     /// Default: ``10_000`` (10 seconds). Raise this for DCC workflows that
@@ -782,6 +804,81 @@ impl PyMcpHttpServer {
     }
 }
 
+// ── WorkspaceRoots (issue #354) ──────────────────────────────────────────
+
+/// Typed `workspace://` URI resolver built from the client-advertised MCP
+/// roots (issue #354).
+///
+/// Example::
+///
+///     from dcc_mcp_core import WorkspaceRoots
+///     roots = WorkspaceRoots(["/projects/hero"])
+///     assert roots.resolve("workspace://scenes/a.usd").endswith("scenes/a.usd")
+///     assert roots.roots == ["file:///projects/hero"]
+#[pyclass(name = "WorkspaceRoots", skip_from_py_object)]
+#[derive(Clone, Default)]
+pub struct PyWorkspaceRoots {
+    pub(crate) inner: crate::workspace::WorkspaceRoots,
+}
+
+#[pymethods]
+impl PyWorkspaceRoots {
+    /// Build from a list of filesystem roots, URI strings, or a mix.
+    ///
+    /// Each entry that already starts with a scheme (``file://``,
+    /// ``custom://``) is kept verbatim; bare paths are converted into a
+    /// ``file://`` URI.
+    #[new]
+    #[pyo3(signature = (roots = None))]
+    fn new(roots: Option<Vec<String>>) -> Self {
+        let raw = roots.unwrap_or_default();
+        let mut client_roots = Vec::with_capacity(raw.len());
+        for r in raw {
+            let uri = if r.contains("://") {
+                r
+            } else {
+                let normalised = r.replace('\\', "/");
+                if normalised.starts_with('/') {
+                    format!("file://{normalised}")
+                } else {
+                    format!("file:///{normalised}")
+                }
+            };
+            client_roots.push(crate::protocol::ClientRoot { uri, name: None });
+        }
+        Self {
+            inner: crate::workspace::WorkspaceRoots::from_client_roots(&client_roots),
+        }
+    }
+
+    /// All roots (as URI strings) in declaration order.
+    #[getter]
+    fn roots(&self) -> Vec<String> {
+        self.inner.roots().to_vec()
+    }
+
+    /// Resolve a typed path against the workspace.
+    ///
+    /// Rules:
+    ///
+    /// * ``workspace://<rest>`` → joined against the first advertised
+    ///   ``file://`` root. Raises ``ValueError`` (MCP error code
+    ///   ``-32602``) when no roots are advertised.
+    /// * Absolute platform paths are returned unchanged.
+    /// * Relative paths are joined against the first root when one is
+    ///   available; otherwise returned unchanged.
+    fn resolve(&self, path: &str) -> PyResult<String> {
+        match self.inner.resolve(path) {
+            Ok(p) => Ok(p.to_string_lossy().into_owned()),
+            Err(e) => Err(pyo3::exceptions::PyValueError::new_err(e.to_string())),
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!("WorkspaceRoots(roots={:?})", self.inner.roots())
+    }
+}
+
 /// Register all Python classes in this module.
 pub fn register_classes(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyMcpHttpConfig>()?;
@@ -789,6 +886,7 @@ pub fn register_classes(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyServerHandle>()?;
     m.add_class::<PyBridgeContext>()?;
     m.add_class::<PyBridgeRegistry>()?;
+    m.add_class::<PyWorkspaceRoots>()?;
     m.add_function(wrap_pyfunction!(py_create_skill_server, m)?)?;
     m.add_function(wrap_pyfunction!(py_get_bridge_context, m)?)?;
     m.add_function(wrap_pyfunction!(py_register_bridge, m)?)?;

--- a/crates/dcc-mcp-http/src/server.rs
+++ b/crates/dcc-mcp-http/src/server.rs
@@ -344,6 +344,7 @@ impl McpHttpServer {
             pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
             lazy_actions: self.config.lazy_actions,
             bare_tool_names: self.config.bare_tool_names,
+            declared_capabilities: std::sync::Arc::new(self.config.declared_capabilities.clone()),
             jobs,
             job_notifier,
             resources,

--- a/crates/dcc-mcp-http/src/tests.rs
+++ b/crates/dcc-mcp-http/src/tests.rs
@@ -59,6 +59,7 @@ mod tests {
             lazy_actions: false,
 
             bare_tool_names: true,
+            declared_capabilities: std::sync::Arc::new(Vec::new()),
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
             job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
@@ -822,6 +823,7 @@ mod tests {
             lazy_actions: false,
 
             bare_tool_names: true,
+            declared_capabilities: std::sync::Arc::new(Vec::new()),
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
             job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
@@ -1708,6 +1710,7 @@ mod tests {
             lazy_actions: false,
 
             bare_tool_names: true,
+            declared_capabilities: std::sync::Arc::new(Vec::new()),
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
             job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
@@ -2090,6 +2093,7 @@ mod tests {
             lazy_actions: false,
 
             bare_tool_names: true,
+            declared_capabilities: std::sync::Arc::new(Vec::new()),
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
             job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
@@ -2201,6 +2205,7 @@ mod tests {
             lazy_actions: false,
 
             bare_tool_names: true,
+            declared_capabilities: std::sync::Arc::new(Vec::new()),
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
             job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
@@ -2436,6 +2441,7 @@ mod tests {
             lazy_actions: false,
 
             bare_tool_names: true,
+            declared_capabilities: std::sync::Arc::new(Vec::new()),
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
             job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
@@ -3475,6 +3481,7 @@ mod resource_link_integration_tests {
             lazy_actions: false,
 
             bare_tool_names: true,
+            declared_capabilities: std::sync::Arc::new(Vec::new()),
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
             job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
@@ -3667,6 +3674,7 @@ mod resource_link_integration_tests {
             lazy_actions: false,
 
             bare_tool_names: true,
+            declared_capabilities: std::sync::Arc::new(Vec::new()),
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
             job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
@@ -3951,6 +3959,7 @@ mod lazy_actions_tests {
             pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
             lazy_actions,
             bare_tool_names: true,
+            declared_capabilities: std::sync::Arc::new(Vec::new()),
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
             job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),
@@ -4278,6 +4287,7 @@ mod next_tools_meta_tests {
             pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
             lazy_actions: false,
             bare_tool_names: true,
+            declared_capabilities: std::sync::Arc::new(Vec::new()),
             jobs: std::sync::Arc::new(crate::job::JobManager::new()),
             job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
             resources: crate::resources::ResourceRegistry::new(true, false),

--- a/crates/dcc-mcp-http/src/workspace.rs
+++ b/crates/dcc-mcp-http/src/workspace.rs
@@ -1,0 +1,293 @@
+//! Typed workspace-path handshake (issue #354).
+//!
+//! MCP 2025-03-26 defines a `roots` capability: clients advertise the
+//! filesystem roots that represent their active workspace(s) on session
+//! initialization, and the server may later call `roots/list` to refresh
+//! the cache. DCC tools routinely need to resolve paths relative to those
+//! roots — e.g. a workflow step says `workspace://scenes/hero.usd` and the
+//! server picks up the session's first root to produce an absolute path.
+//!
+//! This module provides a small helper that consumes the session-level
+//! `ClientRoot` list and performs the path-resolution rules:
+//!
+//! 1. `workspace://<rest>` — strip the scheme, decode percent-escapes, and
+//!    join against the first advertised root. Empty root list ⇒ error.
+//! 2. Absolute paths (on the current platform) are returned unchanged.
+//! 3. Relative paths (no scheme, not absolute) are joined against the
+//!    first advertised root as a convenience — if no root is advertised
+//!    the path is returned unchanged so callers can still function.
+//!
+//! Roots whose `uri` uses the `file://` scheme are parsed into a local
+//! filesystem path. Other schemes are kept verbatim (the server does not
+//! rewrite them but exposes them via [`WorkspaceRoots::roots`]).
+//!
+//! # Examples
+//!
+//! ```
+//! use dcc_mcp_http::workspace::WorkspaceRoots;
+//! let roots = WorkspaceRoots::from_file_paths(["/projects/hero"]);
+//! let resolved = roots.resolve("workspace://scenes/hero.usd").unwrap();
+//! assert!(resolved.ends_with("scenes/hero.usd") || resolved.ends_with("scenes\\hero.usd"));
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use crate::protocol::ClientRoot;
+
+/// Error produced by [`WorkspaceRoots::resolve`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkspaceResolveError {
+    /// The caller used the `workspace://` scheme but the session has no
+    /// advertised roots. Surface this as JSON-RPC `-32602 no workspace roots`.
+    NoRoots { path: String },
+    /// The input was empty or malformed (e.g. `workspace://` with no path).
+    Invalid { path: String, reason: String },
+}
+
+impl std::fmt::Display for WorkspaceResolveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoRoots { path } => write!(
+                f,
+                "no workspace roots advertised by client; cannot resolve {path:?}"
+            ),
+            Self::Invalid { path, reason } => {
+                write!(f, "invalid workspace path {path:?}: {reason}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for WorkspaceResolveError {}
+
+/// A session's workspace-root set used to resolve `workspace://` URIs.
+///
+/// The struct is cheap to clone; it owns a small `Vec<PathBuf>` of local
+/// filesystem roots derived from the MCP `roots/list` response, plus the
+/// original URIs for any non-`file://` roots (those are surfaced through
+/// [`Self::roots`] but cannot be used as a join base).
+#[derive(Debug, Clone, Default)]
+pub struct WorkspaceRoots {
+    /// Local filesystem roots in declaration order. Empty ⇒ client has
+    /// advertised no `file://` roots.
+    local_roots: Vec<PathBuf>,
+    /// Original `uri` strings as advertised by the client (includes
+    /// non-`file://` schemes). Preserved so [`Self::roots`] can surface
+    /// them verbatim to diagnostic tools.
+    raw_uris: Vec<String>,
+}
+
+impl WorkspaceRoots {
+    /// Build from a client-advertised list (the shape stored by the
+    /// session manager).
+    pub fn from_client_roots(roots: &[ClientRoot]) -> Self {
+        let mut local_roots = Vec::with_capacity(roots.len());
+        let mut raw_uris = Vec::with_capacity(roots.len());
+        for root in roots {
+            raw_uris.push(root.uri.clone());
+            if let Some(p) = uri_to_local_path(&root.uri) {
+                local_roots.push(p);
+            }
+        }
+        Self {
+            local_roots,
+            raw_uris,
+        }
+    }
+
+    /// Convenience constructor for tests / non-MCP callers.
+    pub fn from_file_paths<I, S>(paths: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<Path>,
+    {
+        let mut local_roots = Vec::new();
+        let mut raw_uris = Vec::new();
+        for p in paths {
+            let pb = p.as_ref().to_path_buf();
+            raw_uris.push(path_to_file_uri(&pb));
+            local_roots.push(pb);
+        }
+        Self {
+            local_roots,
+            raw_uris,
+        }
+    }
+
+    /// All roots (as URI strings) in declaration order.
+    pub fn roots(&self) -> &[String] {
+        &self.raw_uris
+    }
+
+    /// Local filesystem roots only (the subset usable as a join base).
+    pub fn local_roots(&self) -> &[PathBuf] {
+        &self.local_roots
+    }
+
+    /// Resolve a typed path string against this workspace.
+    ///
+    /// See the module docs for the full rule list. Returns
+    /// [`WorkspaceResolveError::NoRoots`] when `workspace://` is used but
+    /// the client advertised no `file://` roots.
+    pub fn resolve(&self, path: &str) -> Result<PathBuf, WorkspaceResolveError> {
+        if path.is_empty() {
+            return Err(WorkspaceResolveError::Invalid {
+                path: path.to_string(),
+                reason: "path must not be empty".into(),
+            });
+        }
+
+        if let Some(rest) = path
+            .strip_prefix("workspace://")
+            .or_else(|| path.strip_prefix("workspace:/"))
+        {
+            let trimmed = rest.trim_start_matches('/');
+            if trimmed.is_empty() {
+                return Err(WorkspaceResolveError::Invalid {
+                    path: path.to_string(),
+                    reason: "workspace:// URI is missing a path component".into(),
+                });
+            }
+            let root = self
+                .local_roots
+                .first()
+                .ok_or_else(|| WorkspaceResolveError::NoRoots {
+                    path: path.to_string(),
+                })?;
+            return Ok(join_root(root, trimmed));
+        }
+
+        // Pass-through for absolute paths.
+        let as_path = Path::new(path);
+        if as_path.is_absolute() {
+            return Ok(as_path.to_path_buf());
+        }
+
+        // Relative — join against first root when available, else return
+        // unchanged so callers can still construct a path.
+        match self.local_roots.first() {
+            Some(root) => Ok(join_root(root, path)),
+            None => Ok(as_path.to_path_buf()),
+        }
+    }
+}
+
+/// Parse a `file://` URI into a local path. Returns `None` for other schemes.
+fn uri_to_local_path(uri: &str) -> Option<PathBuf> {
+    let rest = uri.strip_prefix("file://")?;
+    // `file:///C:/foo/bar` → strip one more `/` on Windows-style paths.
+    let stripped = rest.strip_prefix('/').unwrap_or(rest);
+    // If the original started with `file:///`, `rest` begins with `/`; on
+    // POSIX we want to keep that leading `/`, on Windows a drive letter
+    // like `C:` indicates the path is already absolute.
+    if cfg!(windows) {
+        // Prefer the Windows-style (`C:/...`) when present.
+        if looks_like_windows_drive(stripped) {
+            return Some(PathBuf::from(stripped.replace('/', "\\")));
+        }
+        Some(PathBuf::from(rest))
+    } else {
+        // POSIX: preserve the leading slash (`rest` includes it).
+        Some(PathBuf::from(rest))
+    }
+}
+
+fn looks_like_windows_drive(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
+}
+
+fn path_to_file_uri(p: &Path) -> String {
+    let s = p.to_string_lossy().replace('\\', "/");
+    if s.starts_with('/') {
+        format!("file://{s}")
+    } else {
+        // Windows drive-letter path.
+        format!("file:///{s}")
+    }
+}
+
+fn join_root(root: &Path, rel: &str) -> PathBuf {
+    // `Path::join` treats an absolute `rel` as replacing `root`. Since we
+    // already stripped the scheme prefix and trimmed leading `/`, it is
+    // safe to join directly.
+    root.join(rel)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn root(uri: &str) -> ClientRoot {
+        ClientRoot {
+            uri: uri.to_string(),
+            name: None,
+        }
+    }
+
+    #[test]
+    fn resolves_workspace_scheme_against_first_root() {
+        let roots = WorkspaceRoots::from_client_roots(&[root("file:///projects/hero")]);
+        let resolved = roots.resolve("workspace://scenes/a.usd").unwrap();
+        let s = resolved.to_string_lossy().replace('\\', "/");
+        assert!(s.ends_with("/projects/hero/scenes/a.usd"), "{s}");
+    }
+
+    #[test]
+    fn empty_roots_fails_for_workspace_scheme() {
+        let roots = WorkspaceRoots::default();
+        let err = roots.resolve("workspace://scenes/a.usd").unwrap_err();
+        match err {
+            WorkspaceResolveError::NoRoots { path } => {
+                assert_eq!(path, "workspace://scenes/a.usd");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn absolute_paths_pass_through() {
+        let roots = WorkspaceRoots::from_file_paths(["/projects/hero"]);
+        #[cfg(not(windows))]
+        {
+            let resolved = roots.resolve("/tmp/foo.txt").unwrap();
+            assert_eq!(resolved, PathBuf::from("/tmp/foo.txt"));
+        }
+        #[cfg(windows)]
+        {
+            let resolved = roots.resolve(r"C:\tmp\foo.txt").unwrap();
+            assert_eq!(resolved, PathBuf::from(r"C:\tmp\foo.txt"));
+        }
+    }
+
+    #[test]
+    fn relative_paths_join_against_first_root() {
+        let roots = WorkspaceRoots::from_file_paths(["/projects/hero"]);
+        let resolved = roots.resolve("scenes/a.usd").unwrap();
+        let s = resolved.to_string_lossy().replace('\\', "/");
+        assert!(s.ends_with("/projects/hero/scenes/a.usd"), "{s}");
+    }
+
+    #[test]
+    fn relative_paths_returned_unchanged_without_roots() {
+        let roots = WorkspaceRoots::default();
+        let resolved = roots.resolve("scenes/a.usd").unwrap();
+        assert_eq!(resolved, PathBuf::from("scenes/a.usd"));
+    }
+
+    #[test]
+    fn invalid_empty_workspace_uri() {
+        let roots = WorkspaceRoots::from_file_paths(["/projects/hero"]);
+        let err = roots.resolve("workspace://").unwrap_err();
+        assert!(matches!(err, WorkspaceResolveError::Invalid { .. }));
+    }
+
+    #[test]
+    fn roots_getter_preserves_declaration_order() {
+        let roots =
+            WorkspaceRoots::from_client_roots(&[root("file:///a"), root("custom://something")]);
+        assert_eq!(roots.roots(), &["file:///a", "custom://something"]);
+        // Only the file:// root is usable as a join base.
+        assert_eq!(roots.local_roots().len(), 1);
+    }
+}

--- a/crates/dcc-mcp-models/src/skill_metadata.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata.rs
@@ -376,6 +376,32 @@ pub struct ToolDeclaration {
     /// per-field merge).
     #[serde(default, skip_serializing_if = "ToolAnnotations::is_empty")]
     pub annotations: ToolAnnotations,
+
+    /// DCC capabilities required by this tool (issue #354).
+    ///
+    /// Freeform string tags (e.g. `"usd"`, `"scene.mutate"`,
+    /// `"filesystem.read"`). At server startup each DCC adapter advertises
+    /// the capabilities it actually provides via
+    /// `McpHttpConfig::declared_capabilities`; any tool whose requirements
+    /// are not fully covered is still surfaced in `tools/list` but decorated
+    /// with `_meta.dcc.missing_capabilities` and fails `tools/call` with a
+    /// `-32001 capability_missing` JSON-RPC error.
+    ///
+    /// Declared per-tool in the sibling `tools.yaml` (no new top-level
+    /// SKILL.md frontmatter keys, per issue #356):
+    ///
+    /// ```yaml
+    /// tools:
+    ///   - name: import_usd
+    ///     required_capabilities: [usd, scene.mutate, filesystem.read]
+    /// ```
+    #[serde(
+        default,
+        rename = "required_capabilities",
+        alias = "required-capabilities",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub required_capabilities: Vec<String>,
 }
 
 // ── ToolDeclaration custom deserializer (issue #344) ──────────────────────
@@ -463,6 +489,13 @@ impl<'de> serde::Deserialize<'de> for ToolDeclaration {
                 alias = "deferred-hint"
             )]
             deferred_hint: Option<bool>,
+
+            #[serde(
+                default,
+                rename = "required_capabilities",
+                alias = "required-capabilities"
+            )]
+            required_capabilities: Vec<String>,
         }
 
         let w = Wire::deserialize(deserializer)?;
@@ -506,6 +539,7 @@ impl<'de> serde::Deserialize<'de> for ToolDeclaration {
             thread_affinity: w.thread_affinity,
             _deferred_guard: None,
             annotations,
+            required_capabilities: w.required_capabilities,
         })
     }
 }
@@ -665,7 +699,22 @@ impl ToolDeclaration {
             thread_affinity,
             _deferred_guard: None,
             annotations: ToolAnnotations::default(),
+            required_capabilities: Vec::new(),
         })
+    }
+
+    /// Declared DCC capabilities required for this tool (issue #354).
+    ///
+    /// Returns freeform string tags; an empty list means the tool has no
+    /// capability prerequisites beyond what any DCC adapter provides.
+    #[getter]
+    fn required_capabilities(&self) -> Vec<String> {
+        self.required_capabilities.clone()
+    }
+
+    #[setter]
+    fn set_required_capabilities(&mut self, value: Vec<String>) {
+        self.required_capabilities = value;
     }
 
     #[getter]
@@ -1346,6 +1395,33 @@ impl SkillMetadata {
         })
     }
 
+    /// Union of DCC capabilities required by any tool in this skill (issue #354).
+    ///
+    /// Computed lazily from each [`ToolDeclaration::required_capabilities`].
+    /// The result is deduplicated and sorted, so two calls on the same skill
+    /// always produce the same ordering.
+    ///
+    /// ```
+    /// use dcc_mcp_models::{SkillMetadata, ToolDeclaration};
+    /// let mut md = SkillMetadata::default();
+    /// md.tools = vec![
+    ///     ToolDeclaration { name: "a".into(), required_capabilities: vec!["usd".into(), "scene.read".into()], ..Default::default() },
+    ///     ToolDeclaration { name: "b".into(), required_capabilities: vec!["usd".into(), "scene.mutate".into()], ..Default::default() },
+    /// ];
+    /// assert_eq!(md.required_capabilities(), vec!["scene.mutate", "scene.read", "usd"]);
+    /// ```
+    pub fn required_capabilities(&self) -> Vec<String> {
+        let mut set: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        for tool in &self.tools {
+            for cap in &tool.required_capabilities {
+                if !cap.is_empty() {
+                    set.insert(cap.clone());
+                }
+            }
+        }
+        set.into_iter().collect()
+    }
+
     /// Get required environment variables declared by this skill (ClawHub).
     pub fn required_env_vars(&self) -> Vec<&str> {
         self.openclaw_metadata()
@@ -1937,6 +2013,15 @@ impl SkillMetadata {
     fn legacy_extension_fields(&self) -> Vec<String> {
         self.legacy_extension_fields.clone()
     }
+
+    /// Union of DCC capabilities required by any tool in this skill (issue #354).
+    ///
+    /// Returns a deduplicated, sorted list of capability tags aggregated
+    /// from every `ToolDeclaration.required_capabilities` on this skill.
+    #[pyo3(name = "required_capabilities")]
+    fn py_required_capabilities(&self) -> Vec<String> {
+        SkillMetadata::required_capabilities(self)
+    }
 }
 
 impl std::fmt::Display for SkillMetadata {
@@ -1972,6 +2057,61 @@ mod tests {
         assert!(meta.compatibility.is_empty());
         assert!(meta.allowed_tools.is_empty());
         assert!(meta.metadata.is_null());
+    }
+
+    #[test]
+    fn test_required_capabilities_aggregation() {
+        // Issue #354 — per-tool required_capabilities aggregate to a
+        // deduplicated, sorted union on the skill.
+        let mut md = SkillMetadata {
+            name: "usd-tools".into(),
+            description: "USD".into(),
+            ..Default::default()
+        };
+        md.tools = vec![
+            ToolDeclaration {
+                name: "import_usd".into(),
+                required_capabilities: vec![
+                    "usd".into(),
+                    "scene.mutate".into(),
+                    "filesystem.read".into(),
+                ],
+                ..Default::default()
+            },
+            ToolDeclaration {
+                name: "read_stage".into(),
+                required_capabilities: vec!["usd".into(), "scene.read".into()],
+                ..Default::default()
+            },
+            ToolDeclaration {
+                name: "no_caps".into(),
+                required_capabilities: vec![],
+                ..Default::default()
+            },
+        ];
+        assert_eq!(
+            md.required_capabilities(),
+            vec![
+                "filesystem.read".to_string(),
+                "scene.mutate".into(),
+                "scene.read".into(),
+                "usd".into(),
+            ],
+        );
+    }
+
+    #[test]
+    fn test_tool_declaration_parses_required_capabilities() {
+        let json = r#"{
+            "name": "import_usd",
+            "description": "Import a USD file",
+            "required_capabilities": ["usd", "scene.mutate", "filesystem.read"]
+        }"#;
+        let decl: ToolDeclaration = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            decl.required_capabilities,
+            vec!["usd", "scene.mutate", "filesystem.read"]
+        );
     }
 
     #[test]

--- a/crates/dcc-mcp-skills/src/catalog/mod.rs
+++ b/crates/dcc-mcp-skills/src/catalog/mod.rs
@@ -364,7 +364,7 @@ impl SkillCatalog {
                 // default-active; default groups (empty group name or an
                 // explicitly default-active group) stay enabled.
                 enabled: group_default_active(&metadata.groups, &tool_decl.group),
-                required_capabilities: Vec::new(),
+                required_capabilities: tool_decl.required_capabilities.clone(),
                 execution: tool_decl.execution,
                 timeout_hint_secs: tool_decl.timeout_hint_secs,
                 thread_affinity: tool_decl.thread_affinity,

--- a/docs/guide/capabilities.md
+++ b/docs/guide/capabilities.md
@@ -1,0 +1,208 @@
+# Capabilities & Workspace Roots
+
+> **Issue:** [#354](https://github.com/loonghao/dcc-mcp-core/issues/354) — capability declaration + typed workspace path handshake
+>
+> **Status:** Available since v0.15
+
+This guide covers two loosely-coupled features that make DCC tools safer and more
+portable across hosts:
+
+1. **Capability declaration** — tools declare what DCC features they need; adapters
+   declare what the host can provide. The server blocks tool calls whose requirements
+   are not satisfied.
+2. **Typed workspace path handshake** — tools can use the `workspace://` URI scheme
+   and the server resolves it against the MCP client's advertised filesystem roots.
+
+---
+
+## 1. Capability Declaration
+
+### Why
+
+Not every DCC exposes the same feature surface. Maya has USD; 3ds Max does not.
+Some adapters run headless without filesystem access; others have full write
+privileges. Declaring capabilities lets the runtime refuse a tool call **before**
+the Python script runs and return a well-formed MCP error.
+
+### Per-tool: `required_capabilities` in `tools.yaml`
+
+Per **issue #356**, tool declarations live in a sibling `tools.yaml` file referenced
+from `SKILL.md` via `metadata.dcc-mcp.tools`. Add `required_capabilities` to any
+tool that needs a non-trivial host feature:
+
+```yaml
+# tools.yaml
+tools:
+  - name: import_usd
+    description: Import a USD stage into the scene
+    required_capabilities: [usd, scene.mutate, filesystem.read]
+
+  - name: read_stage_metadata
+    description: Read metadata from a USD stage without mutating the scene
+    required_capabilities: [usd, scene.read, filesystem.read]
+
+  - name: ping
+    description: No capabilities required
+```
+
+Capability strings are freeform — treat them as convention between the skill author
+and the adapter author. Common namespaces used by bundled skills:
+
+| Namespace          | Meaning                                              |
+|--------------------|------------------------------------------------------|
+| `usd`              | USD stage / layer manipulation available             |
+| `scene.read`       | Read the current DCC scene graph                     |
+| `scene.mutate`     | Mutate the current DCC scene graph                   |
+| `filesystem.read`  | Read files from disk                                 |
+| `filesystem.write` | Write files to disk                                  |
+| `viewport`         | Render / screenshot the active viewport              |
+
+### Per-skill: aggregated via `SkillMetadata.required_capabilities()`
+
+The loader automatically unions all per-tool capabilities on a skill:
+
+```python
+from dcc_mcp_core import SkillMetadata, scan_and_load
+
+skills, _ = scan_and_load(dcc_name="maya")
+for md in skills:
+    print(md.name, md.required_capabilities)  # sorted deduplicated union
+```
+
+This is useful for `search_skills` filtering and for surfacing to AI agents via
+`SKILL.md` overview.
+
+### Host-side: `McpHttpConfig.declared_capabilities`
+
+The DCC adapter declares what the current host can provide when it starts the
+server:
+
+```python
+from dcc_mcp_core import create_skill_server, McpHttpConfig
+
+cfg = McpHttpConfig(port=8765)
+cfg.declared_capabilities = [
+    "usd",
+    "scene.read",
+    "scene.mutate",
+    "filesystem.read",
+    # filesystem.write deliberately omitted for a read-only session
+]
+server = create_skill_server("maya", cfg)
+handle = server.start()
+```
+
+### Runtime behaviour
+
+**`tools/list`** — every tool is listed regardless of capabilities, but un-satisfied
+tools carry a `_meta` hint so AI clients can skip them:
+
+```jsonc
+{
+  "name": "import_usd",
+  "description": "...",
+  "inputSchema": { "...": "..." },
+  "_meta": {
+    "dcc": {
+      "required_capabilities": ["usd", "scene.mutate", "filesystem.read"],
+      "missing_capabilities": ["filesystem.write"]  // only if non-empty
+    }
+  }
+}
+```
+
+**`tools/call`** — the server refuses the call with a structured JSON-RPC error:
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32001,
+    "message": "capability_missing: tool 'import_usd' requires filesystem.write",
+    "data": {
+      "tool": "import_usd",
+      "required": ["usd", "scene.mutate", "filesystem.write"],
+      "missing": ["filesystem.write"],
+      "declared": ["usd", "scene.read", "scene.mutate", "filesystem.read"]
+    }
+  }
+}
+```
+
+The error code `-32001` is dcc-mcp-core's `CAPABILITY_MISSING`. AI clients should
+treat this as *permanently* failing for the current session rather than retrying.
+
+---
+
+## 2. Typed Workspace Path Handshake
+
+### Why
+
+MCP clients advertise filesystem roots (`file:///home/user/project/...`) via the
+`initialize` request's `roots` capability. Tools that accept paths historically
+had to either:
+
+- Trust the AI to pass absolute paths (risky — escapes the workspace),
+- Or accept raw strings and re-implement root resolution (boilerplate).
+
+The `WorkspaceRoots` helper centralises this. Tools accept the `workspace://`
+URI scheme and the server resolves it against the session's first root.
+
+### Using `WorkspaceRoots` from a tool
+
+`WorkspaceRoots` is exposed as a Python class. When a tool declares a
+`filesystem.*` capability, the server injects a `_workspace_roots` arg into the
+tool context:
+
+```python
+def import_usd(path: str, _workspace_roots=None):
+    if _workspace_roots is None:
+        return error_result("import_usd", "no workspace roots advertised")
+    try:
+        resolved = _workspace_roots.resolve(path)
+    except ValueError as e:
+        return error_result("import_usd", str(e))
+    # ...continue with `resolved` as an absolute PathBuf-equivalent
+```
+
+### Resolution rules
+
+| Input                           | Behaviour                                            |
+|---------------------------------|------------------------------------------------------|
+| `workspace://assets/hero.usd`   | Joined with first advertised root                    |
+| `/abs/path/scene.ma`            | Returned unchanged                                   |
+| `C:\Users\me\scene.max`         | Returned unchanged (Windows absolute)                |
+| `assets/hero.usd` (relative)    | Joined with first root if available; else unchanged  |
+| `workspace://...` with no roots | Raises `no workspace roots` (MCP error `-32602`)     |
+
+### Constructing manually (for tests)
+
+```python
+from dcc_mcp_core import WorkspaceRoots
+
+roots = WorkspaceRoots(["/projects/hero"])
+assert roots.resolve("workspace://char/bob.usd") == "/projects/hero/char/bob.usd"
+assert roots.resolve("/tmp/abs").endswith("abs")
+```
+
+### Rust API
+
+```rust
+use dcc_mcp_http::{WorkspaceRoots, WorkspaceResolveError};
+
+let roots = WorkspaceRoots::from_client_roots(&session.roots());
+let path = roots.resolve("workspace://assets/hero.usd")?;
+// path is an absolute std::path::PathBuf
+```
+
+`WorkspaceResolveError::NoRoots` maps to JSON-RPC error code `-32602`
+(`NO_WORKSPACE_ROOTS`).
+
+---
+
+## See also
+
+- [Skills guide](skills.md) — `tools.yaml` sibling-file pattern (#356)
+- [`docs/guide/naming.md`](naming.md) — SEP-986 tool-name validation
+- MCP roots spec: https://modelcontextprotocol.io/specification/2025-03-26/client/roots

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -149,6 +149,7 @@ from dcc_mcp_core._core import VersionedRegistry
 from dcc_mcp_core._core import VtValue
 from dcc_mcp_core._core import WindowFinder
 from dcc_mcp_core._core import WindowInfo
+from dcc_mcp_core._core import WorkspaceRoots
 from dcc_mcp_core._core import artefact_get_bytes
 from dcc_mcp_core._core import artefact_list
 from dcc_mcp_core._core import artefact_put_bytes
@@ -402,6 +403,7 @@ __all__ = [
     "WorkflowSpec",
     "WorkflowStatus",
     "WorkflowStep",
+    "WorkspaceRoots",
     "__author__",
     "__version__",
     "artefact_get_bytes",

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -3987,6 +3987,45 @@ class McpHttpConfig:
         ...
     @job_storage_path.setter
     def job_storage_path(self, path: str | None) -> None: ...
+    @property
+    def declared_capabilities(self) -> list[str]:
+        """DCC capabilities advertised by the hosting adapter (issue #354).
+
+        Freeform string tags (e.g. ``"usd"``, ``"scene.mutate"``,
+        ``"filesystem.read"``) consumed by the capability gate in
+        ``tools/call``. Tools whose ``required_capabilities`` are not
+        fully covered still surface in ``tools/list`` but fail the call
+        with JSON-RPC error ``-32001 capability_missing``.
+        """
+        ...
+    @declared_capabilities.setter
+    def declared_capabilities(self, caps: list[str]) -> None: ...
+    def __repr__(self) -> str: ...
+
+class WorkspaceRoots:
+    """Typed ``workspace://`` URI resolver built from MCP roots (issue #354).
+
+    Example::
+
+        from dcc_mcp_core import WorkspaceRoots
+        roots = WorkspaceRoots(["/projects/hero"])
+        roots.resolve("workspace://scenes/a.usd")   # → "/projects/hero/scenes/a.usd"
+        roots.resolve("/tmp/abs.txt")               # returned unchanged
+        roots.resolve("relative.txt")               # joined against first root
+    """
+
+    def __init__(self, roots: list[str] | None = None) -> None: ...
+    @property
+    def roots(self) -> list[str]:
+        """All roots (URI strings) in declaration order."""
+        ...
+    def resolve(self, path: str) -> str:
+        """Resolve a typed path against this workspace.
+
+        Raises ``ValueError`` when ``path`` uses the ``workspace://``
+        scheme but the client advertised no roots.
+        """
+        ...
     def __repr__(self) -> str: ...
 
 class McpServerHandle:

--- a/tests/test_capabilities_and_roots.py
+++ b/tests/test_capabilities_and_roots.py
@@ -1,0 +1,268 @@
+"""Tests for issue #354 — capability declaration + workspace path handshake."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from dcc_mcp_core import McpHttpConfig
+from dcc_mcp_core import McpHttpServer
+from dcc_mcp_core import SkillMetadata
+from dcc_mcp_core import ToolDeclaration
+from dcc_mcp_core import ToolRegistry
+from dcc_mcp_core import WorkspaceRoots
+from dcc_mcp_core import scan_and_load
+
+# ── WorkspaceRoots ─────────────────────────────────────────────────────────
+
+
+def test_workspace_roots_resolves_workspace_scheme(tmp_path):
+    roots = WorkspaceRoots([str(tmp_path)])
+    resolved = roots.resolve("workspace://scenes/hero.usd")
+    assert resolved.endswith("scenes/hero.usd") or resolved.endswith("scenes\\hero.usd")
+    assert str(tmp_path).replace("\\", "/") in resolved.replace("\\", "/")
+
+
+def test_workspace_roots_absolute_passthrough(tmp_path):
+    roots = WorkspaceRoots([str(tmp_path)])
+    other = tmp_path / "other.txt"
+    resolved = roots.resolve(str(other))
+    assert resolved == str(other)
+
+
+def test_workspace_roots_relative_joined_against_first_root(tmp_path):
+    roots = WorkspaceRoots([str(tmp_path)])
+    resolved = roots.resolve("scenes/a.usd")
+    norm = resolved.replace("\\", "/")
+    assert norm.endswith("scenes/a.usd")
+    assert str(tmp_path).replace("\\", "/") in norm
+
+
+def test_workspace_roots_no_roots_errors_on_workspace_scheme():
+    roots = WorkspaceRoots()
+    with pytest.raises(ValueError, match="no workspace roots"):
+        roots.resolve("workspace://anything")
+
+
+def test_workspace_roots_empty_init_returns_empty_roots_list():
+    roots = WorkspaceRoots()
+    assert roots.roots == []
+
+
+def test_workspace_roots_uri_and_path_mixed():
+    roots = WorkspaceRoots(["file:///a", "/b", "custom://x"])
+    # All three are preserved verbatim for diagnostics.
+    assert "file:///a" in roots.roots
+    assert "custom://x" in roots.roots
+    # Only file:// entries participate in resolve() (custom scheme is ignored).
+    assert roots.resolve("workspace://rel").replace("\\", "/").startswith("/a/")
+
+
+# ── SkillMetadata aggregation ──────────────────────────────────────────────
+
+
+def test_skill_metadata_aggregates_required_capabilities():
+    md = SkillMetadata("example")
+    t1 = ToolDeclaration("a")
+    t1.required_capabilities = ["usd", "scene.read"]
+    t2 = ToolDeclaration("b")
+    t2.required_capabilities = ["usd", "scene.mutate"]
+    md.tools = [t1, t2]
+    # Deduplicated + sorted.
+    assert md.required_capabilities() == ["scene.mutate", "scene.read", "usd"]
+
+
+def test_skill_metadata_no_caps_returns_empty():
+    md = SkillMetadata("empty")
+    md.tools = [ToolDeclaration("a")]
+    assert md.required_capabilities() == []
+
+
+# ── tools.yaml parsing ─────────────────────────────────────────────────────
+
+
+def test_sibling_tools_yaml_parses_required_capabilities(tmp_path):
+    skill_dir = tmp_path / "cap-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: cap-skill\ndescription: test\nmetadata:\n  dcc-mcp.tools: tools.yaml\n---\n",
+        encoding="utf-8",
+    )
+    (skill_dir / "tools.yaml").write_text(
+        "tools:\n"
+        "  - name: import_usd\n"
+        "    description: Import a USD file\n"
+        "    required_capabilities: [usd, scene.mutate, filesystem.read]\n"
+        "  - name: read_scene\n"
+        "    required_capabilities: [scene.read]\n",
+        encoding="utf-8",
+    )
+
+    skills, skipped = scan_and_load(extra_paths=[str(tmp_path)])
+    assert not skipped
+    cap_skill = next(s for s in skills if s.name == "cap-skill")
+    tool_names = {t.name: t for t in cap_skill.tools}
+    assert tool_names["import_usd"].required_capabilities == [
+        "usd",
+        "scene.mutate",
+        "filesystem.read",
+    ]
+    assert tool_names["read_scene"].required_capabilities == ["scene.read"]
+    # Skill-level aggregation.
+    assert set(cap_skill.required_capabilities()) == {
+        "usd",
+        "scene.mutate",
+        "filesystem.read",
+        "scene.read",
+    }
+
+
+# ── McpHttpConfig.declared_capabilities ────────────────────────────────────
+
+
+def test_mcp_http_config_declared_capabilities_default_empty():
+    cfg = McpHttpConfig(port=0)
+    assert cfg.declared_capabilities == []
+
+
+def test_mcp_http_config_declared_capabilities_setter():
+    cfg = McpHttpConfig(port=0)
+    cfg.declared_capabilities = ["usd", "scene.mutate"]
+    assert cfg.declared_capabilities == ["usd", "scene.mutate"]
+
+
+# ── End-to-end: capability gate blocks tools/call ──────────────────────────
+
+
+def _start_server_with_cap_tool(port: int, declared_caps: list[str], required_caps: list[str]):
+    """Spin up an McpHttpServer exposing a single tool that declares
+    `required_caps`. Returns (server, handle, tool_name).
+    """
+    registry = ToolRegistry()
+    registry.register(
+        name="import_usd",
+        description="Import USD",
+        dcc="test",
+        required_capabilities=required_caps,
+    )
+    cfg = McpHttpConfig(port=port)
+    cfg.declared_capabilities = declared_caps
+    server = McpHttpServer(registry, cfg)
+    handle = server.start()
+    return server, handle, "import_usd"
+
+
+def _mcp_call(handle, method: str, params: dict | None = None) -> dict:
+    import urllib.request
+
+    body = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": method,
+            "params": params or {},
+        }
+    ).encode("utf-8")
+    url = handle.mcp_url()
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        data = resp.read().decode("utf-8")
+    # Strip SSE framing if present.
+    for line in data.splitlines():
+        if line.startswith("data:"):
+            return json.loads(line[5:].strip())
+    return json.loads(data)
+
+
+def test_tools_call_blocks_when_capability_missing():
+    _server, handle, tool_name = _start_server_with_cap_tool(
+        port=0,
+        declared_caps=[],  # nothing declared
+        required_caps=["usd"],
+    )
+    try:
+        # initialize
+        _mcp_call(
+            handle,
+            "initialize",
+            {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "pytest", "version": "0"},
+            },
+        )
+        resp = _mcp_call(
+            handle,
+            "tools/call",
+            {"name": tool_name, "arguments": {}},
+        )
+        assert "error" in resp, resp
+        assert resp["error"]["code"] == -32001
+        data = resp["error"].get("data", {})
+        assert "usd" in data.get("missing_capabilities", [])
+    finally:
+        handle.shutdown()
+
+
+def test_tools_call_succeeds_when_capability_declared():
+    _server, handle, tool_name = _start_server_with_cap_tool(
+        port=0,
+        declared_caps=["usd", "scene.mutate"],
+        required_caps=["usd"],
+    )
+    try:
+        _mcp_call(
+            handle,
+            "initialize",
+            {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "pytest", "version": "0"},
+            },
+        )
+        resp = _mcp_call(
+            handle,
+            "tools/call",
+            {"name": tool_name, "arguments": {}},
+        )
+        # Without a handler the dispatcher returns an error, but NOT the
+        # capability-gate error. Anything that is not -32001 proves the
+        # capability check passed.
+        if "error" in resp:
+            assert resp["error"]["code"] != -32001, resp
+    finally:
+        handle.shutdown()
+
+
+def test_tools_list_meta_includes_missing_capabilities():
+    _server, handle, tool_name = _start_server_with_cap_tool(
+        port=0,
+        declared_caps=["usd"],
+        required_caps=["usd", "fluid"],
+    )
+    try:
+        _mcp_call(
+            handle,
+            "initialize",
+            {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "pytest", "version": "0"},
+            },
+        )
+        resp = _mcp_call(handle, "tools/list", {})
+        tools = resp["result"]["tools"]
+        entry = next(t for t in tools if t["name"] == tool_name)
+        meta = entry.get("_meta", {}).get("dcc", {})
+        assert meta.get("required_capabilities") == ["usd", "fluid"]
+        assert meta.get("missing_capabilities") == ["fluid"]
+    finally:
+        handle.shutdown()


### PR DESCRIPTION
## Summary

Implements **issue #354** — capability declaration + typed workspace path handshake.

### Capability declaration (per-tool)
- `ToolDeclaration.required_capabilities` parsed from `tools.yaml` (sibling-file pattern per #356 — no new top-level `SKILL.md` frontmatter field)
- `SkillMetadata.required_capabilities()` aggregates the deduplicated, sorted union of per-tool capabilities
- `McpHttpConfig.declared_capabilities` for the DCC adapter to declare what the host can provide
- `tools/list` surfaces `_meta.dcc.required_capabilities` + `_meta.dcc.missing_capabilities` (only when non-empty)
- `tools/call` refuses un-capable tools with JSON-RPC error `-32001 capability_missing`, returning `{tool, required, missing, declared}` in `data`

### Typed workspace path handshake
- New `WorkspaceRoots` struct + `resolve()` mapping `workspace://...` URIs to absolute paths via the session's first advertised MCP root
- Absolute paths pass through unchanged; relative paths joined with first root when available
- `workspace://` without any roots returns JSON-RPC error `-32602 no workspace roots`
- Python class: `WorkspaceRoots(roots)`, `.roots`, `.resolve(path)`

### Docs
- New guide: `docs/guide/capabilities.md`

## Test plan

- [x] `cargo test -p dcc-mcp-http --lib workspace` — 7 passed
- [x] `cargo test -p dcc-mcp-http --lib` — 209 passed
- [x] `cargo test -p dcc-mcp-models -p dcc-mcp-skills --lib` — 213 passed
- [x] `pytest tests/test_capabilities_and_roots.py` — 14 passed
- [x] `pytest tests/` — 8226 passed
- [x] `vx just preflight` — green

Closes #354
