### PR TITLE
feat(actions): optional SQLite JobStorage backend (#328)

### DIFF
--- a/.commitmsg.txt
+++ b/.commitmsg.txt
@@ -1,0 +1,10 @@
+feat(actions): optional SQLite JobStorage backend (#328)
+
+Adds a pluggable JobStorage trait with InMemoryStorage (default) and
+SqliteStorage (feature `job-persist-sqlite`). JobManager writes through
+on every state transition. Startup recovery marks any pending/running
+rows as a new Interrupted terminal status with error="server restart".
+Adds jobs.cleanup tool for TTL pruning. Feature-gated — zero sqlite cost
+when disabled.
+
+Closes #328

--- a/.prbody.md
+++ b/.prbody.md
@@ -1,0 +1,22 @@
+## Summary
+
+Implements issue #328 — pluggable job persistence for `JobManager` so tracked async jobs survive a server restart.
+
+- New `JobStorage` trait (`put` / `get` / `list` / `update_status` / `delete_older_than`) with two implementations:
+  - **`InMemoryStorage`** — default, zero-dep, same semantics as before.
+  - **`SqliteStorage`** — gated behind Cargo feature `job-persist-sqlite` (uses `rusqlite` with `bundled`). Write-through, `parking_lot::Mutex` around the connection.
+- `JobManager::with_storage(...)` + `recover_from_storage()`; every mutation (`create_with_parent`, `start`, `complete`, `fail`, `cancel`, `update_progress`, `gc_stale`) persists through the backend.
+- New terminal `JobStatus::Interrupted` — applied on startup to rows previously left as `Pending` / `Running`, with `error = "server restart"` and a `$/dcc.jobUpdated` emission.
+- `McpHttpConfig::job_storage_path: Option<PathBuf>` + builder helper; `PyMcpHttpConfig.job_storage_path` mirror (+ `_core.pyi`). When the path is set but the Cargo feature is absent, `McpHttpServer::start()` fails fast with a descriptive error.
+- New built-in MCP tool **`jobs.cleanup`** (SEP-986 validated) — prunes terminal jobs older than `older_than_hours` (default 24); destructive + idempotent annotations; returns `{removed, older_than_hours}` structured content.
+- Docs: new `docs/guide/job-persistence.md`, additions to `docs/api/http.md`, and one-liners in `AGENTS.md` / `CLAUDE.md`.
+
+## Test plan
+
+- [x] `vx just preflight` (cargo check + clippy + fmt + rust tests)
+- [x] `vx cargo test -p dcc-mcp-http --features job-persist-sqlite` — SQLite CRUD + restart-recovery integration test
+- [x] `vx just dev` + `vx python -m pytest tests/` — 8214 passed / 58 skipped
+- [x] New `tests/test_job_persistence.py` — server restart across SQLite file rewrites pending rows to `interrupted`; `jobs.cleanup` returns expected counts for both backends
+- [x] Updated tool-count assertions in `tests/test_on_demand_loading.py`, `tests/test_tools_list_pagination.py`, `tests/test_auditlog_ratelimit_logging_mcp_versioned_deep.py`, `crates/dcc-mcp-http/src/tests.rs`
+
+Closes #328

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,7 @@ Need to interact with DCC?
 **Reacting to job / workflow lifecycle events on an MCP client?**
 → SSE channels: `notifications/progress` (spec, fires when `_meta.progressToken` is present), `notifications/$/dcc.jobUpdated`, `notifications/$/dcc.workflowUpdated` (both gated by `McpHttpConfig.enable_job_notifications`, default `True`) — see [`docs/api/http.md`](docs/api/http.md) §"Job lifecycle notifications" (#326).
 → Polling alternative: call built-in tool **`jobs.get_status`** (#319) — returns the same envelope (`job_id`, `parent_job_id`, `tool`, `status`, timestamps, `progress`, `error`, optional `result`) via `tools/call`. Always listed in `tools/list`, SEP-986 compliant.
+→ Retention: call built-in tool **`jobs.cleanup`** (#328) with `older_than_hours` to prune terminal jobs. Survives restart when `McpHttpConfig.job_storage_path` + Cargo feature `job-persist-sqlite` are set — pending/running rows on startup are rewritten to the new terminal `Interrupted` status. See [`docs/guide/job-persistence.md`](docs/guide/job-persistence.md).
 
 **Exposing live DCC state (scene, window capture, audit log) to MCP clients?**
 → [`docs/api/resources.md`](docs/api/resources.md) — Resources primitive (#350)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,7 +300,7 @@ When building tools or interacting with DCCs, follow this priority order:
 
 1. **Skill Discovery** (start here): `search_skills(query)` → `load_skill(name)` → use skill tools
 2. **Skill-Based Tools** (preferred): Tools with validated schemas, error handling, `next-tools` guidance, and `ToolAnnotations` safety hints
-3. **Diagnostics Tools** (for verification): `diagnostics__screenshot`, `diagnostics__audit_log`, `diagnostics__process_status`, and — as a polling fallback when you can't subscribe to the `$/dcc.jobUpdated` SSE channel — **`jobs.get_status`** (#319, always registered, returns the full job-state envelope for a given `job_id`).
+3. **Diagnostics Tools** (for verification): `diagnostics__screenshot`, `diagnostics__audit_log`, `diagnostics__process_status`, and — as a polling fallback when you can't subscribe to the `$/dcc.jobUpdated` SSE channel — **`jobs.get_status`** (#319, always registered, returns the full job-state envelope for a given `job_id`). Use **`jobs.cleanup`** (#328) with `older_than_hours` to prune terminal jobs; combine with `McpHttpConfig.job_storage_path` + Cargo feature `job-persist-sqlite` for restart-safe job history (pending/running rows become `Interrupted` on reboot).
 4. **Direct Registry Access** (last resort): Only when no skill tool covers the operation; must validate with `ToolValidator` and sandbox with `SandboxPolicy`
 
 **Why skills first?** Safety (annotations), discoverability (search-hint), chainability (next-tools), progressive exposure (tool groups), validation (input_schema).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,10 @@ socket2 = { version = "0.6", features = ["all"] }
 criterion = { version = "0.8", features = ["html_reports"] }
 ipckit = { version = "0.1.7", features = ["async", "backend-interprocess"] }
 base64 = "0.22"
+# Optional SQLite backend for JobManager persistence (issue #328). Pulled in
+# only when the `job-persist-sqlite` feature is enabled on `dcc-mcp-http`;
+# otherwise zero SQLite code compiles into the wheel.
+rusqlite = { version = "0.39", features = ["bundled"] }
 
 # Type-stub generation (opt-in via `stub-gen` feature). Used only by the
 # `stub_gen` binary target — never pulled into wheels or library consumers.
@@ -156,6 +160,10 @@ workflow = ["dep:dcc-mcp-workflow"]
 # prometheus feature on dcc-mcp-telemetry. When disabled, zero
 # Prometheus code is compiled into the wheel.
 prometheus = ["dcc-mcp-http/prometheus", "dcc-mcp-telemetry/prometheus"]
+# Persist JobManager state in SQLite so tracked jobs survive restarts
+# (issue #328). Forwards to `dcc-mcp-http/job-persist-sqlite`. Off by
+# default — when disabled, zero SQLite code compiles into the wheel.
+job-persist-sqlite = ["dcc-mcp-http/job-persist-sqlite"]
 abi3-py38 = ["pyo3/abi3-py38"]
 # Python 3.7 wheel: non-abi3 build, no abi3-py38 feature
 ext-module = ["pyo3/extension-module"]

--- a/crates/dcc-mcp-http/Cargo.toml
+++ b/crates/dcc-mcp-http/Cargo.toml
@@ -49,6 +49,10 @@ pin-project-lite = "0.2"
 # PyO3 (optional)
 pyo3 = { workspace = true, optional = true }
 
+# Optional SQLite JobStorage backend (issue #328). Gated behind the
+# `job-persist-sqlite` feature so the default build has zero SQLite cost.
+rusqlite = { workspace = true, optional = true }
+
 [dev-dependencies]
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
@@ -64,3 +68,7 @@ python-bindings = ["pyo3", "dcc-mcp-utils/python-bindings", "dcc-mcp-actions/pyt
 # matching `prometheus` feature of dcc-mcp-telemetry. Off by default so
 # zero Prometheus code compiles into the wheel when not requested.
 prometheus = ["dep:dcc-mcp-telemetry", "dcc-mcp-telemetry/prometheus"]
+# Persist tracked Jobs in a SQLite database so they survive a server
+# restart (issue #328). Pulls in the bundled `rusqlite` driver.
+# Off by default — the wheel's default build uses the in-memory store.
+job-persist-sqlite = ["dep:rusqlite"]

--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -229,6 +229,25 @@ pub struct McpHttpConfig {
     /// has no effect. Use a capability-gated per-session opt-in (future
     /// work, see #326 amendment) for per-client control.
     pub enable_job_notifications: bool,
+
+    /// Path to a SQLite database file for persisting tracked jobs
+    /// (issue #328).
+    ///
+    /// When set **and** the `job-persist-sqlite` Cargo feature is
+    /// enabled, [`McpHttpServer::start`] opens the file, runs schema
+    /// migrations, and attaches it to `JobManager` as a write-through
+    /// store. On startup, any pre-existing rows whose status is
+    /// `Pending` or `Running` are rewritten to
+    /// [`JobStatus::Interrupted`](crate::job::JobStatus::Interrupted)
+    /// with `error = "server restart"` so clients never see silently
+    /// "lost" jobs.
+    ///
+    /// When set but the feature is **not** compiled in, `start()`
+    /// returns a descriptive error — the server refuses to silently
+    /// run without the persistence the caller asked for.
+    ///
+    /// Default: `None` (in-memory storage; no persistence).
+    pub job_storage_path: Option<PathBuf>,
 }
 
 impl McpHttpConfig {
@@ -262,7 +281,19 @@ impl McpHttpConfig {
             enable_prometheus: false,
             prometheus_basic_auth: None,
             enable_job_notifications: true,
+            job_storage_path: None,
         }
+    }
+
+    /// Builder: persist tracked jobs in a SQLite database at `path`
+    /// (issue #328).
+    ///
+    /// Requires the `job-persist-sqlite` Cargo feature; otherwise
+    /// [`McpHttpServer::start`](crate::McpHttpServer::start) fails
+    /// with a descriptive error at startup.
+    pub fn with_job_storage_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.job_storage_path = Some(path.into());
+        self
     }
 
     /// Builder: enable the built-in `workflows.*` tools (issue #348).

--- a/crates/dcc-mcp-http/src/handler.rs
+++ b/crates/dcc-mcp-http/src/handler.rs
@@ -1007,6 +1007,8 @@ async fn handle_tools_call_inner(
         // #319 — built-in job polling tool. Always available, regardless of
         // which skills are loaded or whether any jobs exist.
         "jobs.get_status" => return handle_jobs_get_status(state, req, &params).await,
+        // #328 — built-in TTL pruning for tracked jobs.
+        "jobs.cleanup" => return handle_jobs_cleanup(state, req, &params).await,
         // #254 — lazy-actions fast-path (opt-in).
         "list_actions" if state.lazy_actions => {
             return handle_list_actions(state, req, &params).await;
@@ -2403,10 +2405,53 @@ fn build_core_tools_inner() -> Vec<McpTool> {
                     "required": ["job_id"]
                 }),
                 output_schema: None,
+            annotations: Some(McpToolAnnotations {
+                title: Some("Get Job Status".to_string()),
+                read_only_hint: Some(true),
+                destructive_hint: Some(false),
+                idempotent_hint: Some(true),
+                open_world_hint: Some(false),
+                deferred_hint: Some(false),
+            }),
+            meta: None,
+            }
+        },
+        // `jobs.cleanup` — built-in TTL pruning tool (#328). Removes
+        // terminal job rows (and storage-backed rows when a
+        // `job_storage_path` is configured) older than the given
+        // window. Never touches pending / running jobs.
+        {
+            const TOOL_NAME: &str = "jobs.cleanup";
+            if let Err(e) = dcc_mcp_naming::validate_tool_name(TOOL_NAME) {
+                panic!("built-in tool name `{TOOL_NAME}` fails SEP-986 validation: {e}");
+            }
+            McpTool {
+                name: TOOL_NAME.to_string(),
+                description: "Purge terminal (completed/failed/cancelled/interrupted) jobs \
+                              older than `older_than_hours` hours from JobManager and any \
+                              attached storage backend. Non-terminal (pending/running) jobs \
+                              are never removed regardless of age. Returns {removed: <count>} \
+                              as structured content. Idempotent — repeated calls with the \
+                              same window return 0 once the pruning horizon is reached."
+                    .to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "older_than_hours": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "default": 24,
+                            "description": "Prune terminal jobs whose last update is older \
+                                            than this many hours. Default: 24."
+                        }
+                    },
+                    "required": []
+                }),
+                output_schema: None,
                 annotations: Some(McpToolAnnotations {
-                    title: Some("Get Job Status".to_string()),
-                    read_only_hint: Some(true),
-                    destructive_hint: Some(false),
+                    title: Some("Cleanup Completed Jobs".to_string()),
+                    read_only_hint: Some(false),
+                    destructive_hint: Some(true),
                     idempotent_hint: Some(true),
                     open_world_hint: Some(false),
                     deferred_hint: Some(false),
@@ -3131,6 +3176,45 @@ async fn handle_jobs_get_status(
     let tool_result = CallToolResult {
         content: vec![crate::protocol::ToolContent::Text { text }],
         structured_content: Some(envelope_value),
+        is_error: false,
+        meta: None,
+    };
+    Ok(JsonRpcResponse::success(
+        req.id.clone(),
+        serde_json::to_value(tool_result)?,
+    ))
+}
+
+// ── Built-in `jobs.cleanup` (#328) ────────────────────────────────────────
+
+/// Handle ``jobs.cleanup`` — TTL prune terminal jobs from JobManager
+/// and any attached storage backend (issue #328).
+///
+/// Semantics:
+/// * `older_than_hours` defaults to 24. Values of 0 prune every
+///   terminal row that already exists (useful for tests).
+/// * Non-terminal (pending/running) rows are never touched.
+/// * Returns a ``{removed: <count>}`` envelope both as text and
+///   `structuredContent`.
+async fn handle_jobs_cleanup(
+    state: &AppState,
+    req: &JsonRpcRequest,
+    params: &CallToolParams,
+) -> Result<JsonRpcResponse, HttpError> {
+    let args = params.arguments.as_ref();
+    let older_than_hours = args
+        .and_then(|a| a.get("older_than_hours"))
+        .and_then(Value::as_u64)
+        .unwrap_or(24);
+    let removed = state.jobs.cleanup_older_than_hours(older_than_hours);
+    let envelope = serde_json::json!({
+        "removed": removed,
+        "older_than_hours": older_than_hours,
+    });
+    let text = serde_json::to_string(&envelope)?;
+    let tool_result = CallToolResult {
+        content: vec![crate::protocol::ToolContent::Text { text }],
+        structured_content: Some(envelope),
         is_error: false,
         meta: None,
     };

--- a/crates/dcc-mcp-http/src/job.rs
+++ b/crates/dcc-mcp-http/src/job.rs
@@ -188,6 +188,10 @@ pub struct JobManager {
     jobs: DashMap<String, Arc<RwLock<Job>>>,
     /// Subscribers invoked on every status transition. See [`Self::subscribe`].
     subscribers: RwLock<Vec<JobSubscriber>>,
+    /// Optional persistence backend (issue #328). When `Some`, every
+    /// mutation is written through to storage so the next process
+    /// incarnation can see and mark-interrupted any in-flight jobs.
+    storage: Option<Arc<dyn crate::job_storage::JobStorage>>,
 }
 
 impl std::fmt::Debug for JobManager {
@@ -195,16 +199,102 @@ impl std::fmt::Debug for JobManager {
         f.debug_struct("JobManager")
             .field("jobs", &self.jobs.len())
             .field("subscribers", &self.subscribers.read().len())
+            .field("has_storage", &self.storage.is_some())
             .finish()
     }
 }
 
 impl JobManager {
-    /// Create an empty manager.
+    /// Create an empty manager with no persistence backend.
     pub fn new() -> Self {
         Self {
             jobs: DashMap::new(),
             subscribers: RwLock::new(Vec::new()),
+            storage: None,
+        }
+    }
+
+    /// Create a manager that writes every mutation through to `storage`
+    /// (issue #328).
+    ///
+    /// Does NOT perform recovery automatically — call
+    /// [`Self::recover_from_storage`] once after construction if the
+    /// backend may already contain rows from a previous process.
+    pub fn with_storage(storage: Arc<dyn crate::job_storage::JobStorage>) -> Self {
+        Self {
+            jobs: DashMap::new(),
+            subscribers: RwLock::new(Vec::new()),
+            storage: Some(storage),
+        }
+    }
+
+    /// Attach a storage backend to an existing manager. Intended for
+    /// uncommon build-up paths; the primary entry point is
+    /// [`Self::with_storage`].
+    pub fn set_storage(&mut self, storage: Arc<dyn crate::job_storage::JobStorage>) {
+        self.storage = Some(storage);
+    }
+
+    /// Borrow the underlying storage, if any.
+    pub fn storage(&self) -> Option<Arc<dyn crate::job_storage::JobStorage>> {
+        self.storage.clone()
+    }
+
+    /// Recover any in-flight rows left over by a previous process
+    /// (issue #328). Every row whose status is `Pending` or `Running`
+    /// is rewritten to [`JobStatus::Interrupted`] with
+    /// `error = "server restart"` and made visible to subscribers so
+    /// the `$/dcc.jobUpdated` SSE channel surfaces the transition.
+    ///
+    /// Terminal rows are left untouched — they remain queryable via
+    /// `jobs.get_status` / `jobs.cleanup`.
+    ///
+    /// Returns the number of rows that were flipped to `Interrupted`.
+    pub fn recover_from_storage(&self) -> Result<usize, crate::job_storage::JobStorageError> {
+        let storage = match &self.storage {
+            Some(s) => Arc::clone(s),
+            None => return Ok(0),
+        };
+        let all = storage.list(crate::job_storage::JobFilter::default())?;
+        let mut interrupted = 0usize;
+        let now = Utc::now();
+        for mut job in all {
+            let was_inflight = matches!(job.status, JobStatus::Pending | JobStatus::Running);
+            if was_inflight {
+                job.status = JobStatus::Interrupted;
+                job.error = Some("server restart".to_string());
+                job.updated_at = now;
+                // Persist the new terminal state before we hand the row
+                // back out so a second crash does not re-flip it.
+                storage.put(&job)?;
+                interrupted += 1;
+            }
+            // Rehydrate the in-process map so reads and the next
+            // `gc_stale` pass see recovered rows.
+            let id = job.id.clone();
+            let should_emit = was_inflight;
+            let snapshot = job.clone();
+            self.jobs.insert(id, Arc::new(RwLock::new(job)));
+            if should_emit {
+                self.emit(&snapshot);
+            }
+        }
+        Ok(interrupted)
+    }
+
+    fn persist_put(&self, job: &Job) {
+        if let Some(storage) = &self.storage
+            && let Err(e) = storage.put(job)
+        {
+            tracing::warn!(job_id = %job.id, error = %e, "JobStorage.put failed");
+        }
+    }
+
+    fn persist_status(&self, job_id: &str, status: JobStatus, at: DateTime<Utc>) {
+        if let Some(storage) = &self.storage
+            && let Err(e) = storage.update_status(job_id, status, at)
+        {
+            tracing::warn!(job_id = %job_id, error = %e, "JobStorage.update_status failed");
         }
     }
 
@@ -270,6 +360,7 @@ impl JobManager {
         self.jobs.insert(id, Arc::clone(&entry));
         {
             let guard = entry.read();
+            self.persist_put(&guard);
             self.emit(&guard);
         }
         entry
@@ -292,6 +383,7 @@ impl JobManager {
         job.updated_at = Utc::now();
         let snapshot = job.clone();
         drop(job);
+        self.persist_status(&snapshot.id, snapshot.status, snapshot.updated_at);
         self.emit(&snapshot);
         Some(())
     }
@@ -314,6 +406,7 @@ impl JobManager {
         job.updated_at = Utc::now();
         let snapshot = job.clone();
         drop(job);
+        self.persist_put(&snapshot);
         self.emit(&snapshot);
         Some(())
     }
@@ -336,6 +429,7 @@ impl JobManager {
         job.updated_at = Utc::now();
         let snapshot = job.clone();
         drop(job);
+        self.persist_put(&snapshot);
         self.emit(&snapshot);
         Some(())
     }
@@ -353,6 +447,7 @@ impl JobManager {
                 job.cancel_token.cancel();
                 let snapshot = job.clone();
                 drop(job);
+                self.persist_status(&snapshot.id, snapshot.status, snapshot.updated_at);
                 self.emit(&snapshot);
                 Some(())
             }
@@ -384,6 +479,7 @@ impl JobManager {
         job.updated_at = Utc::now();
         let snapshot = job.clone();
         drop(job);
+        self.persist_put(&snapshot);
         self.emit(&snapshot);
         Some(())
     }
@@ -422,7 +518,27 @@ impl JobManager {
                 removed += 1;
             }
         }
+        if removed > 0
+            && let Some(storage) = &self.storage
+            && let Err(e) = storage.delete_older_than(cutoff)
+        {
+            tracing::warn!(error = %e, "JobStorage.delete_older_than failed during gc_stale");
+        }
         removed
+    }
+
+    /// TTL-based cleanup used by the built-in `jobs.cleanup` MCP tool
+    /// (issue #328). Purges terminal rows older than
+    /// `older_than_hours` from both the in-process map and any attached
+    /// [`JobStorage`] backend.
+    ///
+    /// Returns the number of rows removed (from the in-process map —
+    /// the storage delete is authoritative for persisted rows).
+    pub fn cleanup_older_than_hours(&self, older_than_hours: u64) -> usize {
+        // Clamp to i64 to stay inside chrono's range. 1000 years is
+        // more than any real caller should ever pass.
+        let hours = older_than_hours.min(24 * 365 * 1000) as i64;
+        self.gc_stale(Duration::hours(hours))
     }
 }
 

--- a/crates/dcc-mcp-http/src/job_storage/mod.rs
+++ b/crates/dcc-mcp-http/src/job_storage/mod.rs
@@ -1,0 +1,331 @@
+//! Pluggable persistence backend for [`JobManager`](crate::job::JobManager).
+//!
+//! Issue #328 — lets the server choose between the zero-dependency
+//! [`InMemoryStorage`] (default) and the opt-in [`SqliteStorage`] (gated
+//! behind the `job-persist-sqlite` Cargo feature).
+//!
+//! The storage layer is write-through: [`JobManager`] calls
+//! [`JobStorage::put`] / [`JobStorage::update_status`] on every state
+//! transition, so a crashed or restarted server can enumerate
+//! pending/running rows and mark them as
+//! [`JobStatus::Interrupted`](crate::job::JobStatus::Interrupted) — clients
+//! never see a silently "lost" job.
+
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use parking_lot::Mutex;
+use thiserror::Error;
+
+use crate::job::{Job, JobProgress, JobStatus};
+
+#[cfg(feature = "job-persist-sqlite")]
+pub mod sqlite;
+
+#[cfg(feature = "job-persist-sqlite")]
+pub use sqlite::SqliteStorage;
+
+/// Error returned by every [`JobStorage`] operation.
+#[derive(Debug, Error)]
+pub enum JobStorageError {
+    /// Lower-level I/O or backend error (SQLite, filesystem, …).
+    #[error("job storage backend error: {0}")]
+    Backend(String),
+    /// Row data failed to deserialize back into a [`Job`].
+    #[error("failed to decode persisted job: {0}")]
+    Decode(String),
+    /// Config asked for a feature that is not compiled in.
+    #[error(
+        "job_storage_path is set but the `job-persist-sqlite` Cargo feature is \
+         not enabled — rebuild dcc-mcp-core with `--features job-persist-sqlite` \
+         or clear job_storage_path"
+    )]
+    FeatureDisabled,
+}
+
+/// Subset filter applied by [`JobStorage::list`].
+///
+/// All fields are additive — `None` means "no constraint on this axis".
+#[derive(Debug, Clone, Default)]
+pub struct JobFilter {
+    /// Limit to a single status.
+    pub status: Option<JobStatus>,
+    /// Limit to children of a specific parent job.
+    pub parent_job_id: Option<String>,
+    /// Soft cap; `None` means unbounded.
+    pub limit: Option<usize>,
+}
+
+impl JobFilter {
+    /// Convenience: filter by status only.
+    pub fn by_status(status: JobStatus) -> Self {
+        Self {
+            status: Some(status),
+            ..Self::default()
+        }
+    }
+}
+
+/// Persistence interface for [`Job`] state.
+///
+/// Every implementation MUST be safe to share between Tokio worker
+/// threads (`Send + Sync`) and MUST be write-through — readers of a
+/// freshly restarted server depend on [`Self::list`] returning rows that
+/// were `put` by the previous incarnation.
+pub trait JobStorage: Send + Sync + std::fmt::Debug {
+    /// Insert-or-update the full job row.
+    fn put(&self, job: &Job) -> Result<(), JobStorageError>;
+
+    /// Fetch a single job by id, if present.
+    fn get(&self, job_id: &str) -> Result<Option<Job>, JobStorageError>;
+
+    /// Enumerate jobs matching `filter`. Order is
+    /// implementation-defined; callers must not rely on it.
+    fn list(&self, filter: JobFilter) -> Result<Vec<Job>, JobStorageError>;
+
+    /// Narrow write path for status transitions — more efficient than a
+    /// full [`Self::put`] when the caller only touched `status` /
+    /// `updated_at`. Implementations MAY fall back to a full put.
+    fn update_status(
+        &self,
+        job_id: &str,
+        status: JobStatus,
+        at: DateTime<Utc>,
+    ) -> Result<(), JobStorageError>;
+
+    /// Delete terminal jobs whose `updated_at` is older than `cutoff`.
+    /// Non-terminal jobs are never deleted. Returns the number of rows
+    /// removed.
+    fn delete_older_than(&self, cutoff: DateTime<Utc>) -> Result<u64, JobStorageError>;
+}
+
+// ── In-memory implementation ─────────────────────────────────────────────
+
+/// Zero-dependency default backend — keeps every row in a
+/// `Mutex<HashMap>`. Used when `McpHttpConfig::job_storage_path` is
+/// `None`.
+///
+/// The in-memory store has no restart-recovery story (the process dies
+/// and the map is gone) — that is deliberate: the whole point of the
+/// SQLite feature is to provide persistence only for deployments that
+/// actually need it.
+#[derive(Debug, Default)]
+pub struct InMemoryStorage {
+    // Store serialisable snapshot so `list` round-trips identically to
+    // the SQLite backend (no sharing of `CancellationToken` here; the
+    // consumer is always `JobManager::recover_from_storage` which
+    // re-wraps rows into fresh `Interrupted` terminal-state snapshots).
+    rows: Mutex<std::collections::HashMap<String, PersistedJob>>,
+}
+
+impl InMemoryStorage {
+    /// Create an empty in-memory store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Convenience wrapper used by [`JobManager::with_default_storage`](crate::job::JobManager::with_default_storage).
+    pub fn shared() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+}
+
+impl JobStorage for InMemoryStorage {
+    fn put(&self, job: &Job) -> Result<(), JobStorageError> {
+        let row = PersistedJob::from_job(job);
+        self.rows.lock().insert(job.id.clone(), row);
+        Ok(())
+    }
+
+    fn get(&self, job_id: &str) -> Result<Option<Job>, JobStorageError> {
+        Ok(self.rows.lock().get(job_id).map(PersistedJob::to_job))
+    }
+
+    fn list(&self, filter: JobFilter) -> Result<Vec<Job>, JobStorageError> {
+        let rows = self.rows.lock();
+        let mut out: Vec<Job> = rows
+            .values()
+            .filter(|r| {
+                filter.status.map(|s| r.status == s).unwrap_or(true)
+                    && filter
+                        .parent_job_id
+                        .as_deref()
+                        .map(|p| r.parent_job_id.as_deref() == Some(p))
+                        .unwrap_or(true)
+            })
+            .map(PersistedJob::to_job)
+            .collect();
+        if let Some(limit) = filter.limit {
+            out.truncate(limit);
+        }
+        Ok(out)
+    }
+
+    fn update_status(
+        &self,
+        job_id: &str,
+        status: JobStatus,
+        at: DateTime<Utc>,
+    ) -> Result<(), JobStorageError> {
+        let mut rows = self.rows.lock();
+        if let Some(row) = rows.get_mut(job_id) {
+            row.status = status;
+            row.updated_at = at;
+        }
+        Ok(())
+    }
+
+    fn delete_older_than(&self, cutoff: DateTime<Utc>) -> Result<u64, JobStorageError> {
+        let mut rows = self.rows.lock();
+        let mut removed = 0u64;
+        rows.retain(|_, r| {
+            let should_delete = r.status.is_terminal() && r.updated_at < cutoff;
+            if should_delete {
+                removed += 1;
+            }
+            !should_delete
+        });
+        Ok(removed)
+    }
+}
+
+// ── Wire-format helper ──────────────────────────────────────────────────
+
+/// Serialisable snapshot of a [`Job`] used by every backend.
+///
+/// Deliberately flat + `Clone` so both [`InMemoryStorage`] and the
+/// SQLite backend produce the same JSON for introspection.
+#[derive(Debug, Clone)]
+pub struct PersistedJob {
+    pub id: String,
+    pub parent_job_id: Option<String>,
+    pub tool_name: String,
+    pub status: JobStatus,
+    pub progress: Option<JobProgress>,
+    pub result: Option<serde_json::Value>,
+    pub error: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl PersistedJob {
+    pub fn from_job(job: &Job) -> Self {
+        Self {
+            id: job.id.clone(),
+            parent_job_id: job.parent_job_id.clone(),
+            tool_name: job.tool_name.clone(),
+            status: job.status,
+            progress: job.progress.clone(),
+            result: job.result.clone(),
+            error: job.error.clone(),
+            created_at: job.created_at,
+            updated_at: job.updated_at,
+        }
+    }
+
+    /// Rehydrate a [`Job`] from persisted state. Since
+    /// `CancellationToken` is not serialisable we attach a fresh
+    /// (already-cancelled on terminal rows) token — consumers only use
+    /// recovered rows for read-only reporting.
+    pub fn to_job(&self) -> Job {
+        let cancel_token = tokio_util::sync::CancellationToken::new();
+        if self.status.is_terminal() {
+            cancel_token.cancel();
+        }
+        Job {
+            id: self.id.clone(),
+            tool_name: self.tool_name.clone(),
+            status: self.status,
+            parent_job_id: self.parent_job_id.clone(),
+            progress: self.progress.clone(),
+            result: self.result.clone(),
+            error: self.error.clone(),
+            created_at: self.created_at,
+            updated_at: self.updated_at,
+            cancel_token,
+        }
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::job::JobManager;
+    use serde_json::json;
+
+    fn sample_job(mgr: &JobManager, tool: &str) -> String {
+        mgr.create(tool).read().id.clone()
+    }
+
+    #[test]
+    fn inmemory_put_get_roundtrip() {
+        let store = InMemoryStorage::new();
+        let mgr = JobManager::new();
+        let id = sample_job(&mgr, "scene.get_info");
+        let job = mgr.get(&id).unwrap();
+        let snap = job.read().clone();
+        store.put(&snap).unwrap();
+
+        let got = store.get(&id).unwrap().unwrap();
+        assert_eq!(got.id, id);
+        assert_eq!(got.tool_name, "scene.get_info");
+        assert_eq!(got.status, JobStatus::Pending);
+    }
+
+    #[test]
+    fn inmemory_update_status_and_list_filter() {
+        let store = InMemoryStorage::new();
+        let mgr = JobManager::new();
+        let a = sample_job(&mgr, "a");
+        let b = sample_job(&mgr, "b");
+        for id in [&a, &b] {
+            store.put(&mgr.get(id).unwrap().read()).unwrap();
+        }
+        store
+            .update_status(&a, JobStatus::Running, Utc::now())
+            .unwrap();
+        let running = store
+            .list(JobFilter::by_status(JobStatus::Running))
+            .unwrap();
+        assert_eq!(running.len(), 1);
+        assert_eq!(running[0].id, a);
+
+        let pending = store
+            .list(JobFilter::by_status(JobStatus::Pending))
+            .unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].id, b);
+    }
+
+    #[test]
+    fn inmemory_delete_older_than_skips_non_terminal() {
+        let store = InMemoryStorage::new();
+        let mgr = JobManager::new();
+        let done_id = sample_job(&mgr, "done");
+        let running_id = sample_job(&mgr, "running");
+
+        {
+            let handle = mgr.get(&done_id).unwrap();
+            let mut job = handle.write();
+            job.status = JobStatus::Completed;
+            job.result = Some(json!({"ok": true}));
+            job.updated_at = Utc::now() - chrono::Duration::hours(24);
+            store.put(&job).unwrap();
+        }
+        {
+            let handle = mgr.get(&running_id).unwrap();
+            let mut job = handle.write();
+            job.status = JobStatus::Running;
+            job.updated_at = Utc::now() - chrono::Duration::hours(24);
+            store.put(&job).unwrap();
+        }
+
+        let cutoff = Utc::now() - chrono::Duration::hours(1);
+        let removed = store.delete_older_than(cutoff).unwrap();
+        assert_eq!(removed, 1);
+        assert!(store.get(&done_id).unwrap().is_none());
+        assert!(store.get(&running_id).unwrap().is_some());
+    }
+}

--- a/crates/dcc-mcp-http/src/job_storage/sqlite.rs
+++ b/crates/dcc-mcp-http/src/job_storage/sqlite.rs
@@ -1,0 +1,418 @@
+//! SQLite [`JobStorage`] implementation — issue #328.
+//!
+//! Gated behind the `job-persist-sqlite` Cargo feature so the default
+//! build has zero SQLite cost. Uses the bundled `rusqlite` driver so
+//! downstream wheels do not need a system libsqlite.
+//!
+//! Synchronous write-through — every mutation runs a parameterised
+//! `INSERT OR REPLACE` / `UPDATE` under a short `Mutex`. The connection
+//! is not shared across threads directly (rusqlite `Connection` is not
+//! `Sync`), so we serialise writes behind `parking_lot::Mutex` which is
+//! the same locking strategy used elsewhere in the workspace.
+
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+use parking_lot::Mutex;
+use rusqlite::{Connection, OptionalExtension, params};
+
+use crate::job::{Job, JobProgress, JobStatus};
+use crate::job_storage::{JobFilter, JobStorage, JobStorageError, PersistedJob};
+
+const SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS jobs (
+    job_id TEXT PRIMARY KEY,
+    parent_job_id TEXT,
+    tool TEXT NOT NULL,
+    status TEXT NOT NULL,
+    progress_json TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    error TEXT,
+    result_json TEXT
+);
+CREATE INDEX IF NOT EXISTS jobs_status_idx ON jobs(status);
+CREATE INDEX IF NOT EXISTS jobs_parent_idx ON jobs(parent_job_id);
+CREATE INDEX IF NOT EXISTS jobs_updated_idx ON jobs(updated_at);
+"#;
+
+/// SQLite-backed [`JobStorage`].
+#[derive(Debug)]
+pub struct SqliteStorage {
+    conn: Mutex<Connection>,
+}
+
+impl SqliteStorage {
+    /// Open (or create) a SQLite database at `path` and run schema
+    /// migrations. Parent directories are created as needed.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, JobStorageError> {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                JobStorageError::Backend(format!(
+                    "failed to create parent directory for job storage: {e}"
+                ))
+            })?;
+        }
+        let conn = Connection::open(path).map_err(map_err)?;
+        // Pragmas: WAL for concurrent reads, NORMAL sync is a good
+        // durability/perf tradeoff for a side-car status store.
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL; \
+             PRAGMA synchronous=NORMAL; \
+             PRAGMA foreign_keys=ON;",
+        )
+        .map_err(map_err)?;
+        conn.execute_batch(SCHEMA).map_err(map_err)?;
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+
+    /// Open an in-memory database — used by tests that want the real
+    /// SQLite code path without touching the filesystem.
+    pub fn open_in_memory() -> Result<Self, JobStorageError> {
+        let conn = Connection::open_in_memory().map_err(map_err)?;
+        conn.execute_batch(SCHEMA).map_err(map_err)?;
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+}
+
+impl JobStorage for SqliteStorage {
+    fn put(&self, job: &Job) -> Result<(), JobStorageError> {
+        let row = PersistedJob::from_job(job);
+        let progress_json = row
+            .progress
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .map_err(|e| JobStorageError::Decode(e.to_string()))?;
+        let result_json = row
+            .result
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .map_err(|e| JobStorageError::Decode(e.to_string()))?;
+        let status = status_to_str(row.status);
+
+        let conn = self.conn.lock();
+        conn.execute(
+            "INSERT INTO jobs (job_id, parent_job_id, tool, status, \
+                progress_json, created_at, updated_at, error, result_json) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9) \
+             ON CONFLICT(job_id) DO UPDATE SET \
+                parent_job_id=excluded.parent_job_id, \
+                tool=excluded.tool, \
+                status=excluded.status, \
+                progress_json=excluded.progress_json, \
+                updated_at=excluded.updated_at, \
+                error=excluded.error, \
+                result_json=excluded.result_json",
+            params![
+                row.id,
+                row.parent_job_id,
+                row.tool_name,
+                status,
+                progress_json,
+                row.created_at.to_rfc3339(),
+                row.updated_at.to_rfc3339(),
+                row.error,
+                result_json,
+            ],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    fn get(&self, job_id: &str) -> Result<Option<Job>, JobStorageError> {
+        let conn = self.conn.lock();
+        let row = conn
+            .query_row(
+                "SELECT job_id, parent_job_id, tool, status, progress_json, \
+                        created_at, updated_at, error, result_json \
+                 FROM jobs WHERE job_id = ?1",
+                params![job_id],
+                row_to_persisted,
+            )
+            .optional()
+            .map_err(map_err)?;
+        Ok(row.map(|r| r.to_job()))
+    }
+
+    fn list(&self, filter: JobFilter) -> Result<Vec<Job>, JobStorageError> {
+        let mut sql = String::from(
+            "SELECT job_id, parent_job_id, tool, status, progress_json, \
+                    created_at, updated_at, error, result_json \
+             FROM jobs WHERE 1=1",
+        );
+        let mut bound: Vec<String> = Vec::new();
+        if let Some(status) = filter.status {
+            sql.push_str(" AND status = ?");
+            bound.push(status_to_str(status).to_string());
+        }
+        if let Some(parent) = filter.parent_job_id.as_deref() {
+            sql.push_str(" AND parent_job_id = ?");
+            bound.push(parent.to_string());
+        }
+        sql.push_str(" ORDER BY created_at ASC");
+        if let Some(limit) = filter.limit {
+            sql.push_str(&format!(" LIMIT {limit}"));
+        }
+
+        let conn = self.conn.lock();
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let params_dyn: Vec<&dyn rusqlite::ToSql> =
+            bound.iter().map(|s| s as &dyn rusqlite::ToSql).collect();
+        let rows = stmt
+            .query_map(params_dyn.as_slice(), row_to_persisted)
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?.to_job());
+        }
+        Ok(out)
+    }
+
+    fn update_status(
+        &self,
+        job_id: &str,
+        status: JobStatus,
+        at: DateTime<Utc>,
+    ) -> Result<(), JobStorageError> {
+        let conn = self.conn.lock();
+        conn.execute(
+            "UPDATE jobs SET status = ?1, updated_at = ?2 WHERE job_id = ?3",
+            params![status_to_str(status), at.to_rfc3339(), job_id],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    fn delete_older_than(&self, cutoff: DateTime<Utc>) -> Result<u64, JobStorageError> {
+        let conn = self.conn.lock();
+        // Only terminal jobs are eligible — mirror InMemoryStorage.
+        let terminal = [
+            status_to_str(JobStatus::Completed),
+            status_to_str(JobStatus::Failed),
+            status_to_str(JobStatus::Cancelled),
+            status_to_str(JobStatus::Interrupted),
+        ];
+        let removed = conn
+            .execute(
+                "DELETE FROM jobs WHERE updated_at < ?1 AND status IN (?2, ?3, ?4, ?5)",
+                params![
+                    cutoff.to_rfc3339(),
+                    terminal[0],
+                    terminal[1],
+                    terminal[2],
+                    terminal[3],
+                ],
+            )
+            .map_err(map_err)?;
+        Ok(removed as u64)
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+fn map_err(e: rusqlite::Error) -> JobStorageError {
+    JobStorageError::Backend(e.to_string())
+}
+
+fn status_to_str(s: JobStatus) -> &'static str {
+    match s {
+        JobStatus::Pending => "pending",
+        JobStatus::Running => "running",
+        JobStatus::Completed => "completed",
+        JobStatus::Failed => "failed",
+        JobStatus::Cancelled => "cancelled",
+        JobStatus::Interrupted => "interrupted",
+    }
+}
+
+fn str_to_status(s: &str) -> Result<JobStatus, JobStorageError> {
+    Ok(match s {
+        "pending" => JobStatus::Pending,
+        "running" => JobStatus::Running,
+        "completed" => JobStatus::Completed,
+        "failed" => JobStatus::Failed,
+        "cancelled" => JobStatus::Cancelled,
+        "interrupted" => JobStatus::Interrupted,
+        other => {
+            return Err(JobStorageError::Decode(format!(
+                "unknown job status in storage: {other}"
+            )));
+        }
+    })
+}
+
+fn parse_rfc3339(s: &str) -> Result<DateTime<Utc>, JobStorageError> {
+    DateTime::parse_from_rfc3339(s)
+        .map(|d| d.with_timezone(&Utc))
+        .map_err(|e| JobStorageError::Decode(format!("invalid rfc3339 timestamp `{s}`: {e}")))
+}
+
+fn row_to_persisted(row: &rusqlite::Row<'_>) -> rusqlite::Result<PersistedJob> {
+    let id: String = row.get(0)?;
+    let parent_job_id: Option<String> = row.get(1)?;
+    let tool_name: String = row.get(2)?;
+    let status_str: String = row.get(3)?;
+    let progress_json: Option<String> = row.get(4)?;
+    let created_at_str: String = row.get(5)?;
+    let updated_at_str: String = row.get(6)?;
+    let error: Option<String> = row.get(7)?;
+    let result_json: Option<String> = row.get(8)?;
+
+    // Map JobStorageError into rusqlite::Error so query_map's Result type
+    // is satisfied; the wrapper at the top of each backend method
+    // translates back to JobStorageError.
+    let status = str_to_status(&status_str).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(3, rusqlite::types::Type::Text, e.into())
+    })?;
+    let progress: Option<JobProgress> = match progress_json {
+        Some(s) => Some(serde_json::from_str(&s).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(4, rusqlite::types::Type::Text, e.into())
+        })?),
+        None => None,
+    };
+    let result: Option<serde_json::Value> = match result_json {
+        Some(s) => Some(serde_json::from_str(&s).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(8, rusqlite::types::Type::Text, e.into())
+        })?),
+        None => None,
+    };
+    let created_at = parse_rfc3339(&created_at_str).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(5, rusqlite::types::Type::Text, e.into())
+    })?;
+    let updated_at = parse_rfc3339(&updated_at_str).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(6, rusqlite::types::Type::Text, e.into())
+    })?;
+
+    Ok(PersistedJob {
+        id,
+        parent_job_id,
+        tool_name,
+        status,
+        progress,
+        result,
+        error,
+        created_at,
+        updated_at,
+    })
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::job::JobManager;
+    use serde_json::json;
+
+    #[test]
+    fn sqlite_put_get_roundtrip() {
+        let store = SqliteStorage::open_in_memory().unwrap();
+        let mgr = JobManager::new();
+        let handle = mgr.create("scene.get_info");
+        let id = handle.read().id.clone();
+        store.put(&handle.read()).unwrap();
+
+        let got = store.get(&id).unwrap().unwrap();
+        assert_eq!(got.id, id);
+        assert_eq!(got.tool_name, "scene.get_info");
+        assert_eq!(got.status, JobStatus::Pending);
+    }
+
+    #[test]
+    fn sqlite_list_filter_by_status_and_parent() {
+        let store = SqliteStorage::open_in_memory().unwrap();
+        let mgr = JobManager::new();
+
+        let parent = mgr.create("parent");
+        let parent_id = parent.read().id.clone();
+        store.put(&parent.read()).unwrap();
+
+        let child = mgr.create_with_parent("child", Some(parent_id.clone()));
+        let child_id = child.read().id.clone();
+        store.put(&child.read()).unwrap();
+
+        let standalone = mgr.create("lonely");
+        store.put(&standalone.read()).unwrap();
+
+        let children = store
+            .list(JobFilter {
+                parent_job_id: Some(parent_id.clone()),
+                ..JobFilter::default()
+            })
+            .unwrap();
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0].id, child_id);
+
+        let pending = store
+            .list(JobFilter::by_status(JobStatus::Pending))
+            .unwrap();
+        assert_eq!(pending.len(), 3);
+    }
+
+    #[test]
+    fn sqlite_update_status_and_crud() {
+        let store = SqliteStorage::open_in_memory().unwrap();
+        let mgr = JobManager::new();
+        let handle = mgr.create("t");
+        let id = handle.read().id.clone();
+        store.put(&handle.read()).unwrap();
+
+        store
+            .update_status(&id, JobStatus::Running, Utc::now())
+            .unwrap();
+        let got = store.get(&id).unwrap().unwrap();
+        assert_eq!(got.status, JobStatus::Running);
+
+        // full put with a result field exercises the ON CONFLICT path
+        {
+            let mut job = handle.write();
+            job.status = JobStatus::Completed;
+            job.result = Some(json!({"ok": true}));
+            job.updated_at = Utc::now();
+        }
+        store.put(&handle.read()).unwrap();
+        let got = store.get(&id).unwrap().unwrap();
+        assert_eq!(got.status, JobStatus::Completed);
+        assert_eq!(got.result.as_ref().unwrap(), &json!({"ok": true}));
+    }
+
+    #[test]
+    fn sqlite_delete_older_than_skips_non_terminal() {
+        let store = SqliteStorage::open_in_memory().unwrap();
+        let mgr = JobManager::new();
+
+        let done = mgr.create("done");
+        {
+            let mut j = done.write();
+            j.status = JobStatus::Completed;
+            j.updated_at = Utc::now() - chrono::Duration::hours(24);
+        }
+        let done_id = done.read().id.clone();
+        store.put(&done.read()).unwrap();
+
+        let running = mgr.create("running");
+        {
+            let mut j = running.write();
+            j.status = JobStatus::Running;
+            j.updated_at = Utc::now() - chrono::Duration::hours(24);
+        }
+        let running_id = running.read().id.clone();
+        store.put(&running.read()).unwrap();
+
+        let removed = store
+            .delete_older_than(Utc::now() - chrono::Duration::hours(1))
+            .unwrap();
+        assert_eq!(removed, 1);
+        assert!(store.get(&done_id).unwrap().is_none());
+        assert!(store.get(&running_id).unwrap().is_some());
+    }
+}

--- a/crates/dcc-mcp-http/src/lib.rs
+++ b/crates/dcc-mcp-http/src/lib.rs
@@ -46,6 +46,7 @@ pub mod gateway;
 pub mod handler;
 pub mod inflight;
 pub mod job;
+pub mod job_storage;
 pub mod notifications;
 pub mod protocol;
 pub mod resource_link;
@@ -66,6 +67,9 @@ pub use error::{HttpError, HttpResult};
 pub use executor::{DccExecutorHandle, DeferredExecutor};
 pub use gateway::{GatewayConfig, GatewayHandle, GatewayRunner};
 pub use job::{Job, JobEvent, JobManager, JobProgress, JobStatus, JobSubscriber};
+#[cfg(feature = "job-persist-sqlite")]
+pub use job_storage::SqliteStorage;
+pub use job_storage::{InMemoryStorage, JobFilter, JobStorage, JobStorageError};
 pub use notifications::{JobNotifier, WorkflowProgress, WorkflowUpdate};
 pub use resources::{
     ProducerContent, ResourceError, ResourceProducer, ResourceRegistry, ResourceResult,

--- a/crates/dcc-mcp-http/src/python/mod.rs
+++ b/crates/dcc-mcp-http/src/python/mod.rs
@@ -197,6 +197,33 @@ impl PyMcpHttpConfig {
         self.inner.enable_job_notifications = enabled;
     }
 
+    /// Optional filesystem path to a SQLite database used to persist
+    /// tracked jobs across server restarts (issue #328).
+    ///
+    /// When set, ``McpHttpServer.start()`` opens (or creates) the file
+    /// and attaches a write-through storage backend to the
+    /// ``JobManager``; any pre-existing ``pending``/``running`` rows
+    /// are rewritten to a terminal ``interrupted`` status on startup
+    /// so clients never see silently "lost" jobs.
+    ///
+    /// Requires the ``job-persist-sqlite`` Cargo feature; when the
+    /// wheel was built without that feature, setting this path
+    /// causes ``server.start()`` to raise a descriptive error.
+    ///
+    /// Default: ``None`` (in-memory only, no persistence).
+    #[getter]
+    fn job_storage_path(&self) -> Option<String> {
+        self.inner
+            .job_storage_path
+            .as_ref()
+            .map(|p| p.to_string_lossy().to_string())
+    }
+
+    #[setter]
+    fn set_job_storage_path(&mut self, path: Option<String>) {
+        self.inner.job_storage_path = path.map(std::path::PathBuf::from);
+    }
+
     // ── Gateway configuration ────────────────────────────────────────────────
 
     /// Gateway port to compete for. First process to bind wins.

--- a/crates/dcc-mcp-http/src/server.rs
+++ b/crates/dcc-mcp-http/src/server.rs
@@ -260,7 +260,7 @@ impl McpHttpServer {
             None
         };
 
-        let jobs = std::sync::Arc::new(crate::job::JobManager::new());
+        let jobs = build_job_manager(&self.config)?;
         let job_notifier = crate::notifications::JobNotifier::new(
             sessions.clone(),
             self.config.enable_job_notifications,
@@ -268,6 +268,23 @@ impl McpHttpServer {
         // Bridge JobManager transitions onto the notifier (#326).
         let notifier_cb = job_notifier.clone();
         jobs.subscribe(move |event| notifier_cb.on_job_event(event));
+        // Issue #328: recover any in-flight rows from a prior run and
+        // mark them Interrupted. Emits `$/dcc.jobUpdated` through the
+        // just-wired notifier. Errors are logged but not fatal — the
+        // server continues with an empty in-process map.
+        if jobs.storage().is_some() {
+            match jobs.recover_from_storage() {
+                Ok(n) if n > 0 => tracing::info!(
+                    interrupted_jobs = n,
+                    "JobManager recovered pending/running rows from storage and marked them Interrupted"
+                ),
+                Ok(_) => tracing::debug!("JobManager storage recovery found no in-flight rows"),
+                Err(e) => tracing::error!(
+                    error = %e,
+                    "JobManager storage recovery failed — in-process map stays empty"
+                ),
+            }
+        }
 
         let state = AppState {
             registry: self.registry,
@@ -628,4 +645,47 @@ pub fn start_in_runtime(
     config: McpHttpConfig,
 ) -> HttpResult<McpServerHandle> {
     runtime.block_on(async { McpHttpServer::new(registry, config).start().await })
+}
+
+/// Build the [`JobManager`](crate::job::JobManager) for this server,
+/// attaching a SQLite-backed [`JobStorage`](crate::job_storage::JobStorage)
+/// when `config.job_storage_path` is set.
+///
+/// Fails fast with [`HttpError::Internal`] when the caller asked for
+/// persistence but the `job-persist-sqlite` Cargo feature is not
+/// compiled in (issue #328) — we must not silently run without the
+/// persistence the deployment expected.
+fn build_job_manager(config: &McpHttpConfig) -> HttpResult<Arc<crate::job::JobManager>> {
+    match &config.job_storage_path {
+        Some(path) => {
+            #[cfg(feature = "job-persist-sqlite")]
+            {
+                let storage = crate::job_storage::SqliteStorage::open(path).map_err(|e| {
+                    tracing::error!(error = %e, path = %path.display(), "failed to open SQLite JobStorage");
+                    HttpError::Internal(format!(
+                        "failed to open SQLite job storage at {}: {e}",
+                        path.display()
+                    ))
+                })?;
+                Ok(Arc::new(crate::job::JobManager::with_storage(Arc::new(
+                    storage,
+                ))))
+            }
+            #[cfg(not(feature = "job-persist-sqlite"))]
+            {
+                tracing::error!(
+                    path = %path.display(),
+                    "McpHttpConfig.job_storage_path is set but the `job-persist-sqlite` \
+                     Cargo feature is not enabled"
+                );
+                Err(HttpError::Internal(format!(
+                    "job_storage_path={} requires the `job-persist-sqlite` Cargo feature; \
+                     rebuild dcc-mcp-core with --features job-persist-sqlite or clear \
+                     job_storage_path",
+                    path.display()
+                )))
+            }
+        }
+        None => Ok(Arc::new(crate::job::JobManager::new())),
+    }
 }

--- a/crates/dcc-mcp-http/src/tests.rs
+++ b/crates/dcc-mcp-http/src/tests.rs
@@ -510,8 +510,9 @@ mod tests {
         resp.assert_status_ok();
         let body: Value = resp.json();
         let tools = body["result"]["tools"].as_array().unwrap();
-        // 11 core meta-tools (10 + jobs.get_status #319) + 2 registered actions = 13
-        assert_eq!(tools.len(), 13);
+        // 12 core meta-tools (10 + jobs.get_status #319 + jobs.cleanup #328)
+        // + 2 registered actions = 14
+        assert_eq!(tools.len(), 14);
         let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
         assert!(names.contains(&"get_scene_info"));
         assert!(names.contains(&"list_objects"));
@@ -1172,6 +1173,7 @@ mod tests {
                     | "deactivate_tool_group"
                     | "search_tools"
                     | "jobs.get_status"
+                    | "jobs.cleanup"
             );
             let is_stub = name.starts_with("__skill__") || name.starts_with("__group__");
 
@@ -1857,8 +1859,9 @@ mod tests {
 
         let body2: Value = resp2.json();
         let tools = body2["result"]["tools"].as_array().unwrap();
-        // 11 core meta-tools (incl. jobs.get_status #319) + 2 skill tools = 13
-        assert_eq!(tools.len(), 13);
+        // 12 core meta-tools (incl. jobs.get_status #319 + jobs.cleanup #328)
+        // + 2 skill tools = 14
+        assert_eq!(tools.len(), 14);
         let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
         // #307: bare names when unique within the instance.
         assert!(names.contains(&"bevel"));
@@ -1938,8 +1941,9 @@ mod tests {
 
         let body2: Value = resp2.json();
         let tools = body2["result"]["tools"].as_array().unwrap();
-        // Back to 11 core meta-tools (incl. jobs.get_status #319) + 1 unloaded skill stub = 12
-        assert_eq!(tools.len(), 12);
+        // Back to 12 core meta-tools (incl. jobs.get_status #319 + jobs.cleanup
+        // #328) + 1 unloaded skill stub = 13
+        assert_eq!(tools.len(), 13);
         let stub = tools
             .iter()
             .find(|t| t["name"] == "__skill__modeling-bevel")
@@ -2458,7 +2462,7 @@ mod tests {
         resp.assert_status_ok();
         let body: Value = resp.json();
         let tools = body["result"]["tools"].as_array().unwrap();
-        // Total = 11 core (incl. jobs.get_status #319) + 40 registered = 51; first page = 32.
+        // Total = 12 core (incl. jobs.get_status #319 + jobs.cleanup #328) + 40 registered = 52; first page = 32.
         assert_eq!(
             tools.len(),
             TOOLS_LIST_PAGE_SIZE,
@@ -2502,8 +2506,8 @@ mod tests {
             .await
             .json();
         let tools2 = r2["result"]["tools"].as_array().unwrap();
-        // 51 - 32 = 19 tools on second page
-        assert_eq!(tools2.len(), 51 - TOOLS_LIST_PAGE_SIZE);
+        // 52 - 32 = 20 tools on second page
+        assert_eq!(tools2.len(), 52 - TOOLS_LIST_PAGE_SIZE);
         assert!(
             r2["result"]["nextCursor"].is_null(),
             "Last page must not have nextCursor"
@@ -2539,7 +2543,7 @@ mod tests {
             }
         }
 
-        assert_eq!(all_names.len(), 51, "All pages must cover exactly 51 tools");
+        assert_eq!(all_names.len(), 52, "All pages must cover exactly 52 tools");
         let unique: std::collections::HashSet<_> = all_names.iter().collect();
         assert_eq!(unique.len(), all_names.len(), "No duplicates across pages");
     }

--- a/crates/dcc-mcp-http/tests/job_persistence.rs
+++ b/crates/dcc-mcp-http/tests/job_persistence.rs
@@ -1,0 +1,116 @@
+//! Integration tests for the optional SQLite `JobStorage` backend
+//! (issue #328).
+//!
+//! These tests are compiled only when the `job-persist-sqlite` feature
+//! is enabled; the default build silently skips them so CI matrices
+//! that do not opt in stay green.
+
+#![cfg(feature = "job-persist-sqlite")]
+
+use std::sync::Arc;
+
+use dcc_mcp_http::job::{JobManager, JobStatus};
+use dcc_mcp_http::job_storage::{JobFilter, JobStorage, SqliteStorage};
+use serde_json::json;
+use tempfile::tempdir;
+
+fn open_store(path: &std::path::Path) -> Arc<SqliteStorage> {
+    Arc::new(SqliteStorage::open(path).expect("open SQLite storage"))
+}
+
+#[test]
+fn restart_flips_inflight_jobs_to_interrupted() {
+    let dir = tempdir().unwrap();
+    let db = dir.path().join("jobs.sqlite3");
+
+    // First "incarnation": create one pending, one running, one terminal row.
+    let pending_id;
+    let running_id;
+    let done_id;
+    {
+        let storage = open_store(&db);
+        let mgr = JobManager::with_storage(storage.clone());
+
+        let pending = mgr.create("pending.tool");
+        pending_id = pending.read().id.clone();
+
+        let running = mgr.create("running.tool");
+        running_id = running.read().id.clone();
+        mgr.start(&running_id).unwrap();
+
+        let done = mgr.create("done.tool");
+        done_id = done.read().id.clone();
+        mgr.start(&done_id).unwrap();
+        mgr.complete(&done_id, json!({"ok": true})).unwrap();
+
+        // Storage should now contain three rows with the expected statuses.
+        let all = storage.list(JobFilter::default()).unwrap();
+        assert_eq!(all.len(), 3);
+    }
+
+    // Second incarnation: open the same file and recover.
+    {
+        let storage = open_store(&db);
+        let mgr = JobManager::with_storage(storage.clone());
+        let flipped = mgr.recover_from_storage().unwrap();
+        assert_eq!(flipped, 2, "pending + running should both flip");
+
+        // Pending → Interrupted.
+        let row = mgr.get(&pending_id).unwrap();
+        let row = row.read();
+        assert_eq!(row.status, JobStatus::Interrupted);
+        assert_eq!(row.error.as_deref(), Some("server restart"));
+        drop(row);
+
+        // Running → Interrupted.
+        let row = mgr.get(&running_id).unwrap();
+        let row = row.read();
+        assert_eq!(row.status, JobStatus::Interrupted);
+        drop(row);
+
+        // Completed stays Completed.
+        let row = mgr.get(&done_id).unwrap();
+        let row = row.read();
+        assert_eq!(row.status, JobStatus::Completed);
+    }
+
+    // Third incarnation: re-recovering must be idempotent — nothing is
+    // in-flight anymore so `flipped` should be zero.
+    {
+        let storage = open_store(&db);
+        let mgr = JobManager::with_storage(storage);
+        let flipped = mgr.recover_from_storage().unwrap();
+        assert_eq!(flipped, 0);
+    }
+}
+
+#[test]
+fn cleanup_older_than_hours_prunes_storage_rows() {
+    let dir = tempdir().unwrap();
+    let db = dir.path().join("jobs.sqlite3");
+    let storage = open_store(&db);
+    let mgr = JobManager::with_storage(storage.clone());
+
+    // A completed job backdated 48 hours.
+    let done = mgr.create("old.done");
+    let done_id = done.read().id.clone();
+    mgr.start(&done_id).unwrap();
+    mgr.complete(&done_id, json!(null)).unwrap();
+    {
+        let mut j = done.write();
+        j.updated_at = chrono::Utc::now() - chrono::Duration::hours(48);
+    }
+    storage.put(&done.read()).unwrap();
+
+    // A fresh running job — must NOT be pruned.
+    let running = mgr.create("fresh.running");
+    let running_id = running.read().id.clone();
+    mgr.start(&running_id).unwrap();
+
+    let removed = mgr.cleanup_older_than_hours(24);
+    assert_eq!(removed, 1);
+    assert!(mgr.get(&done_id).is_none());
+    assert!(mgr.get(&running_id).is_some());
+    assert!(storage.get(&done_id).unwrap().is_none());
+    assert!(storage.get(&running_id).unwrap().is_some());
+}

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -409,6 +409,39 @@ if env["status"] in {"completed", "failed", "cancelled", "interrupted"}:
     print("final:", env.get("result"))
 ```
 
+### Built-in tools: `jobs.cleanup`
+
+Prune terminal jobs from `JobManager` (and any attached `JobStorage` backend) once they age out. Complements [`jobs.get_status`](#built-in-tools-jobsget_status) and the optional SQLite persistence backend (see [`docs/guide/job-persistence.md`](../guide/job-persistence.md), issue #328).
+
+- **Name**: `jobs.cleanup` — SEP-986 compliant, validated at server startup.
+- **Visibility**: always surfaced in `tools/list`, independent of which skills are loaded.
+- **Annotations**: `readOnlyHint=false`, `destructiveHint=true`, `idempotentHint=true`, `openWorldHint=false`.
+
+Input schema:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `older_than_hours` | `integer ≥ 0` | `24` | Remove terminal jobs whose last `updated_at` is older than this many hours. Set to `0` to purge all terminal rows. |
+
+Only terminal statuses (`completed`, `failed`, `cancelled`, `interrupted`) are eligible — `pending` and `running` rows are never removed regardless of age.
+
+Success envelope (`CallToolResult.structuredContent`):
+
+```json
+{ "removed": 42, "older_than_hours": 24 }
+```
+
+## Optional SQLite job persistence
+
+Set `McpHttpConfig.job_storage_path` to persist `JobManager` state so in-flight jobs survive a restart (issue #328). Requires the `job-persist-sqlite` Cargo feature; when the feature is absent but the path is set, `McpHttpServer.start()` returns a descriptive error rather than silently falling back to the in-memory store.
+
+```python
+cfg = McpHttpConfig(port=8765)
+cfg.job_storage_path = "/var/lib/dcc-mcp/jobs.sqlite3"
+```
+
+On startup, any `pending` / `running` rows from a previous run are rewritten to the new terminal `interrupted` status with `error = "server restart"` and surfaced via `$/dcc.jobUpdated`. Full design and operational guidance: [`docs/guide/job-persistence.md`](../guide/job-persistence.md).
+
 ## CORS Configuration
 
 Enable CORS for browser-based MCP clients:

--- a/docs/guide/job-persistence.md
+++ b/docs/guide/job-persistence.md
@@ -1,0 +1,138 @@
+# Job Persistence
+
+`JobManager` tracks long-running async tool executions (see issues #316, #318,
+#326, #371). By default it keeps all job state in-process, which means every
+`Pending` or `Running` row is lost if the server crashes or restarts.
+
+Issue #328 adds an **optional, feature-gated SQLite backend** so tracked jobs
+survive a restart and so operators can prune completed history with a built-in
+MCP tool.
+
+## Design at a glance
+
+```
+┌──────────────┐      put/get/list/update_status/delete_older_than      ┌─────────────────┐
+│  JobManager  │ ─────────────────────────────────────────────────────▶ │   JobStorage    │
+│  (in-proc)   │                                                        │    (trait)      │
+└──────────────┘                                                        └─────────────────┘
+                                                                                 │
+                                                     ┌───────────────────────────┼─────────────────────────┐
+                                                     ▼                                                     ▼
+                                             InMemoryStorage                                        SqliteStorage
+                                             (default, zero-dep)                                    (feature job-persist-sqlite)
+```
+
+- `JobStorage` is `Send + Sync` and synchronous — write-through on every job
+  transition. No background flush task, no batching.
+- `InMemoryStorage` is the default and ships in every wheel. Same semantics as
+  the trait, but obviously does not survive a restart.
+- `SqliteStorage` is gated behind the Cargo feature `job-persist-sqlite` and
+  pulls in `rusqlite` with `bundled` so no system SQLite is required.
+
+## Enabling SQLite persistence
+
+### Build
+
+```bash
+# default build — in-memory only, no SQLite code compiled in
+vx just dev
+
+# opt-in — adds SqliteStorage and the rusqlite dependency
+cargo build --workspace --features job-persist-sqlite,python-bindings,ext-module
+```
+
+### Configure
+
+```python
+from dcc_mcp_core import McpHttpConfig, McpHttpServer, ToolRegistry
+
+config = McpHttpConfig(port=8765)
+config.job_storage_path = "/var/lib/dcc-mcp/jobs.sqlite3"
+
+registry = ToolRegistry()
+# register tools...
+server = McpHttpServer(registry, config)
+handle = server.start()
+```
+
+If `job_storage_path` is set but the wheel was built **without**
+`job-persist-sqlite`, `server.start()` fails fast with a descriptive error
+rather than silently falling back to the in-memory store.
+
+## Startup recovery
+
+When `JobManager` boots with a storage backend, it scans for rows whose status
+is `Pending` or `Running` — those are jobs that were in flight when the
+previous process exited. Each one is rewritten to the new terminal
+`JobStatus::Interrupted` variant with `error = "server restart"` and a fresh
+`updated_at`, and a `$/dcc.jobUpdated` notification is emitted (if the
+`JobNotifier` is wired). Clients that re-subscribe after reconnect therefore
+see a clean terminal transition instead of a dangling `Running` job.
+
+Recovery failures are logged at `error` level and do **not** abort startup — the
+in-process map simply starts empty and the process continues to serve new
+requests.
+
+## `jobs.cleanup` built-in tool
+
+A SEP-986-compliant built-in MCP tool prunes terminal jobs:
+
+```jsonc
+// tools/call
+{
+  "name": "jobs.cleanup",
+  "arguments": { "older_than_hours": 24 }  // default: 24
+}
+// → { "removed": <count>, "older_than_hours": 24 }
+```
+
+- Annotations: `destructive_hint: true`, `idempotent_hint: true`,
+  `read_only_hint: false`.
+- Only terminal statuses (`Completed`, `Failed`, `Cancelled`, `Interrupted`)
+  are eligible; `Pending` and `Running` rows are never removed regardless of
+  age.
+- Works against whichever backend is configured — in-memory or SQLite.
+
+## Storage schema
+
+```sql
+CREATE TABLE IF NOT EXISTS jobs (
+    job_id        TEXT PRIMARY KEY,
+    parent_job_id TEXT,
+    tool          TEXT NOT NULL,
+    status        TEXT NOT NULL,
+    progress_json TEXT,
+    created_at    TEXT NOT NULL,
+    updated_at    TEXT NOT NULL,
+    error         TEXT,
+    result_json   TEXT
+);
+CREATE INDEX IF NOT EXISTS jobs_status_idx  ON jobs(status);
+CREATE INDEX IF NOT EXISTS jobs_parent_idx  ON jobs(parent_job_id);
+CREATE INDEX IF NOT EXISTS jobs_updated_idx ON jobs(updated_at);
+```
+
+Timestamps are stored as RFC 3339 UTC strings. Progress and result payloads are
+JSON-serialized — the schema stays stable even if internal `Job` fields evolve.
+
+## Operational guidance
+
+- **Backup**: the SQLite file is a single path; standard file-level snapshotting
+  works. There is no WAL-mode promise across versions — treat it as a durable
+  cache, not a system of record.
+- **Growth**: call `jobs.cleanup` on a schedule (cron, k8s CronJob, or from an
+  orchestrator agent). Default 24h window works for most interactive use.
+- **Migration**: there is no cross-version migration today. If the schema
+  changes in a future release, delete the file and let `JobManager` recreate
+  it — the file is meant to survive restarts, not upgrades.
+- **Concurrency**: `SqliteStorage` serializes through a `parking_lot::Mutex` on
+  the connection. Good enough for per-DCC servers; do not point multiple
+  `McpHttpServer` instances at the same file.
+
+## Related issues
+
+- #316 — Async job execution with `Pending`/`Running`/`Completed` states
+- #318 — `JobManager` core
+- #326 — `$/dcc.jobUpdated` notifications
+- #371 — `jobs.get_status` tool
+- **#328** — this document

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -3913,6 +3913,25 @@ class McpHttpConfig:
         ...
     @enable_job_notifications.setter
     def enable_job_notifications(self, enabled: bool) -> None: ...
+    @property
+    def job_storage_path(self) -> str | None:
+        """Optional SQLite database path for persisting tracked jobs (issue #328).
+
+        When set, ``McpHttpServer.start()`` opens (or creates) the file
+        and attaches a write-through storage backend to the
+        ``JobManager``; any pre-existing ``pending``/``running`` rows
+        are rewritten to a terminal ``interrupted`` status on startup
+        so clients never see silently "lost" jobs.
+
+        Requires the ``job-persist-sqlite`` Cargo feature; when the
+        wheel was built without that feature, setting this path causes
+        ``server.start()`` to raise a descriptive error.
+
+        Default: ``None`` (in-memory only, no persistence).
+        """
+        ...
+    @job_storage_path.setter
+    def job_storage_path(self, path: str | None) -> None: ...
     def __repr__(self) -> str: ...
 
 class McpServerHandle:

--- a/tests/test_auditlog_ratelimit_logging_mcp_versioned_deep.py
+++ b/tests/test_auditlog_ratelimit_logging_mcp_versioned_deep.py
@@ -707,6 +707,7 @@ class TestMcpServerHandleDeep:
             "deactivate_tool_group",
             "search_tools",
             "jobs.get_status",
+            "jobs.cleanup",
         }
         assert not any(t for t in tools if t["name"] not in core_tools)
         handle.shutdown()

--- a/tests/test_job_persistence.py
+++ b/tests/test_job_persistence.py
@@ -1,0 +1,283 @@
+"""End-to-end test for the optional SQLite JobStorage backend (issue #328).
+
+Verifies the full restart-recovery contract from Python:
+
+1. Dispatch an async tool while the server has ``job_storage_path`` set
+   to a fresh SQLite file — SQLite is created with the expected schema
+   and the job row is persisted.
+2. Stop the server before the async job completes (by starting a second
+   server against the same file before the first finishes).
+3. On the second incarnation, any row left in ``pending`` / ``running``
+   is visible as ``interrupted`` via ``jobs.get_status``.
+
+The test is skipped at module level when the wheel was not built with
+the ``job-persist-sqlite`` Cargo feature — detected by trying to set
+``job_storage_path`` on a config and asserting the server accepts it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sqlite3
+import tempfile
+import time
+from typing import Any
+import urllib.request
+
+import pytest
+
+from dcc_mcp_core import McpHttpConfig
+from dcc_mcp_core import McpHttpServer
+from dcc_mcp_core import ToolRegistry
+
+
+def _feature_enabled() -> bool:
+    """Return ``True`` when the wheel was built with job-persist-sqlite.
+
+    The property is always exposed (for stable stub shape) but calling
+    ``server.start()`` with a path raises when the feature is absent.
+    So we use the roundtrip to tell: construct a config, start a
+    minimal server and observe the outcome.
+    """
+    cfg = McpHttpConfig(port=0, server_name="sqlite-probe")
+    # On Windows the SQLite WAL/SHM side-files keep the directory
+    # locked for a brief moment after shutdown, so we use
+    # ``ignore_cleanup_errors=True`` to avoid a spurious collection
+    # failure here.
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as d:
+        cfg.job_storage_path = str(Path(d) / "probe.sqlite3")
+        reg = ToolRegistry()
+        server = McpHttpServer(reg, cfg)
+        try:
+            handle = server.start()
+        except Exception as exc:  # pragma: no cover - pure env detection
+            msg = str(exc).lower()
+            if "job-persist-sqlite" in msg or "feature" in msg:
+                return False
+            raise
+        try:
+            return True
+        finally:
+            handle.shutdown()
+
+
+_FEATURE = _feature_enabled()
+pytestmark = pytest.mark.skipif(
+    not _FEATURE,
+    reason="dcc-mcp-core wheel was built without the job-persist-sqlite feature",
+)
+
+
+def _post(url: str, body: dict[str, Any], sid: str | None = None) -> dict[str, Any]:
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    if sid is not None:
+        headers["Mcp-Session-Id"] = sid
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode(),
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        return json.loads(resp.read())
+
+
+def _initialize_session(url: str) -> str:
+    body = _post(
+        url,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "pytest-328", "version": "1.0"},
+            },
+        },
+    )
+    return body["result"]["__session_id"]
+
+
+def _make_server(db_path: str, handler):
+    reg = ToolRegistry()
+    reg.register(
+        "slow_echo",
+        description="Slow echo — sleeps so the async job stays 'running' long enough to be interrupted.",
+        category="test",
+        tags=[],
+        dcc="test",
+        version="1.0.0",
+    )
+    cfg = McpHttpConfig(port=0, server_name="jobs-persist-test")
+    cfg.enable_job_notifications = True
+    cfg.job_storage_path = db_path
+    server = McpHttpServer(reg, cfg)
+    server.register_handler("slow_echo", handler)
+    handle = server.start()
+    return server, handle, handle.mcp_url()
+
+
+def test_sqlite_storage_persists_rows_across_restart():
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as d:
+        db = str(Path(d) / "jobs.sqlite3")
+
+        # First incarnation — dispatch an async tool; shut the server
+        # down before the handler returns so the row stays "running".
+        def slow_handler(params):
+            time.sleep(2.0)
+            return {"echoed": params, "ok": True}
+
+        job_id: str
+        _server, handle, url = _make_server(db, slow_handler)
+        try:
+            sid = _initialize_session(url)
+            dispatch = _post(
+                url,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "slow_echo",
+                        "arguments": {"hello": "world"},
+                        "_meta": {"dcc": {"async": True}},
+                    },
+                },
+                sid=sid,
+            )
+            assert dispatch["result"]["isError"] is False, dispatch
+            sc = dispatch["result"].get("structuredContent") or json.loads(dispatch["result"]["content"][0]["text"])
+            job_id = sc["job_id"]
+            assert isinstance(job_id, str) and job_id
+            # Give the dispatcher a moment to flip Pending → Running
+            # before we tear the server down.
+            time.sleep(0.1)
+        finally:
+            handle.shutdown()
+
+        # SQLite file must exist and contain the `jobs` table.
+        assert Path(db).exists(), "SQLite database file should have been created"
+        with sqlite3.connect(db) as conn:
+            rows = conn.execute(
+                "SELECT job_id, tool, status FROM jobs WHERE job_id = ?",
+                (job_id,),
+            ).fetchall()
+        assert len(rows) == 1, f"expected one persisted row, got {rows}"
+        assert rows[0][1] == "slow_echo"
+        # The status will be either 'pending' or 'running' — either is
+        # recoverable. Terminal values would mean the handler completed
+        # before we tore down, which is a timing failure.
+        assert rows[0][2] in {"pending", "running"}, rows
+
+        # Second incarnation against the SAME database file.
+        _server, handle, url = _make_server(db, slow_handler)
+        try:
+            sid = _initialize_session(url)
+            status = _post(
+                url,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "jobs.get_status",
+                        "arguments": {"job_id": job_id},
+                    },
+                },
+                sid=sid,
+            )
+            assert status["result"]["isError"] is False, status
+            env = status["result"]["structuredContent"]
+            assert env["job_id"] == job_id
+            assert env["status"] == "interrupted", env
+            assert env["error"] == "server restart", env
+        finally:
+            handle.shutdown()
+
+
+def test_jobs_cleanup_tool_roundtrip_with_sqlite_storage():
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as d:
+        db = str(Path(d) / "jobs.sqlite3")
+
+        def fast_handler(params):
+            return {"echoed": params}
+
+        _server, handle, url = _make_server(db, fast_handler)
+        try:
+            sid = _initialize_session(url)
+            # Complete a job so there's something terminal to prune.
+            dispatch = _post(
+                url,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 4,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "slow_echo",
+                        "arguments": {"x": 1},
+                        "_meta": {"dcc": {"async": True}},
+                    },
+                },
+                sid=sid,
+            )
+            sc = dispatch["result"].get("structuredContent") or json.loads(dispatch["result"]["content"][0]["text"])
+            job_id = sc["job_id"]
+
+            # Poll until terminal (or bail).
+            deadline = time.monotonic() + 3.0
+            while time.monotonic() < deadline:
+                status = _post(
+                    url,
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 5,
+                        "method": "tools/call",
+                        "params": {
+                            "name": "jobs.get_status",
+                            "arguments": {"job_id": job_id},
+                        },
+                    },
+                    sid=sid,
+                )
+                env = status["result"]["structuredContent"]
+                if env["status"] in {"completed", "failed", "cancelled", "interrupted"}:
+                    break
+                time.sleep(0.05)
+
+            # older_than_hours=0 means "prune everything terminal that exists".
+            cleanup = _post(
+                url,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 6,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "jobs.cleanup",
+                        "arguments": {"older_than_hours": 0},
+                    },
+                },
+                sid=sid,
+            )
+            assert cleanup["result"]["isError"] is False, cleanup
+            env = cleanup["result"]["structuredContent"]
+            assert env["removed"] >= 1, env
+
+            # jobs.get_status for the pruned id now reports unknown.
+            follow = _post(
+                url,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 7,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "jobs.get_status",
+                        "arguments": {"job_id": job_id},
+                    },
+                },
+                sid=sid,
+            )
+            assert follow["result"]["isError"] is True
+        finally:
+            handle.shutdown()

--- a/tests/test_on_demand_loading.py
+++ b/tests/test_on_demand_loading.py
@@ -43,6 +43,7 @@ CORE_TOOLS = frozenset(
         "deactivate_tool_group",
         "search_tools",
         "jobs.get_status",
+        "jobs.cleanup",
     }
 )
 
@@ -227,7 +228,7 @@ class TestOnDemandLoadingContract:
             )
 
     def test_core_tools_always_present(self, catalog_server):
-        """All 10 core meta-tools must be present in every tools/list response."""
+        """All core meta-tools must be present in every tools/list response."""
         url = catalog_server.mcp_url()
         tools = _tools_list(url)
         names = {t["name"] for t in tools}

--- a/tests/test_tools_list_pagination.py
+++ b/tests/test_tools_list_pagination.py
@@ -132,8 +132,8 @@ class TestToolsListPagination:
             if cursor is None:
                 break
 
-        # 11 core (incl. jobs.get_status #319) + 40 registered = 51 total
-        assert len(all_names) == 51, f"Expected 51 tools across all pages, got {len(all_names)}"
+        # 12 core (incl. jobs.get_status #319 + jobs.cleanup #328) + 40 registered = 52 total
+        assert len(all_names) == 52, f"Expected 52 tools across all pages, got {len(all_names)}"
         unique = set(all_names)
         assert len(unique) == len(all_names), "Pages must not return duplicate tool names"
 
@@ -151,7 +151,7 @@ class TestToolsListPagination:
         )
         assert code == 200
         result2 = body2["result"]
-        assert len(result2["tools"]) == 51 - self.PAGE_SIZE
+        assert len(result2["tools"]) == 52 - self.PAGE_SIZE
         assert result2.get("nextCursor") is None, "Last page must not have nextCursor"
 
 


### PR DESCRIPTION
## Summary

Implements issue #328 — pluggable job persistence for `JobManager` so tracked async jobs survive a server restart.

- New `JobStorage` trait (`put` / `get` / `list` / `update_status` / `delete_older_than`) with two implementations:
  - **`InMemoryStorage`** — default, zero-dep, same semantics as before.
  - **`SqliteStorage`** — gated behind Cargo feature `job-persist-sqlite` (uses `rusqlite` with `bundled`). Write-through, `parking_lot::Mutex` around the connection.
- `JobManager::with_storage(...)` + `recover_from_storage()`; every mutation (`create_with_parent`, `start`, `complete`, `fail`, `cancel`, `update_progress`, `gc_stale`) persists through the backend.
- New terminal `JobStatus::Interrupted` — applied on startup to rows previously left as `Pending` / `Running`, with `error = "server restart"` and a `$/dcc.jobUpdated` emission.
- `McpHttpConfig::job_storage_path: Option<PathBuf>` + builder helper; `PyMcpHttpConfig.job_storage_path` mirror (+ `_core.pyi`). When the path is set but the Cargo feature is absent, `McpHttpServer::start()` fails fast with a descriptive error.
- New built-in MCP tool **`jobs.cleanup`** (SEP-986 validated) — prunes terminal jobs older than `older_than_hours` (default 24); destructive + idempotent annotations; returns `{removed, older_than_hours}` structured content.
- Docs: new `docs/guide/job-persistence.md`, additions to `docs/api/http.md`, and one-liners in `AGENTS.md` / `CLAUDE.md`.

## Test plan

- [x] `vx just preflight` (cargo check + clippy + fmt + rust tests)
- [x] `vx cargo test -p dcc-mcp-http --features job-persist-sqlite` — SQLite CRUD + restart-recovery integration test
- [x] `vx just dev` + `vx python -m pytest tests/` — 8214 passed / 58 skipped
- [x] New `tests/test_job_persistence.py` — server restart across SQLite file rewrites pending rows to `interrupted`; `jobs.cleanup` returns expected counts for both backends
- [x] Updated tool-count assertions in `tests/test_on_demand_loading.py`, `tests/test_tools_list_pagination.py`, `tests/test_auditlog_ratelimit_logging_mcp_versioned_deep.py`, `crates/dcc-mcp-http/src/tests.rs`

Closes #328
