### PR TITLE
fix(http,process): honour main-thread affinity in async dispatch (#332)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,9 +148,11 @@ Need to interact with DCC?
 
 - All scene-mutating calls go through `DeferredExecutor` — never call `maya.cmds` / `bpy.ops` / `hou.*` / `pymxs.runtime` from a Tokio worker or `threading.Thread`.
 - Pump the queue via `poll_pending_bounded(max=8)` from the DCC's defer primitive (`maya.utils.executeDeferred`, `bpy.app.timers.register`, `hou.ui.addEventLoopCallback`). Never `poll_pending()` in production — it drains unboundedly and freezes the UI under bursts.
-- Long-running jobs must be chunked into per-tick units with cooperative checkpoints (see #329 `check_cancelled()`, #332 `@chunked_job`).
-- Forbidden inside a `DccTaskFn`: `time.sleep`, spawning OS threads for scene ops, blocking I/O (`requests.get`, sync DB, large file reads). Do I/O on the Tokio worker, then defer only the scene call.
-- Source of truth: `crates/dcc-mcp-http/src/executor.rs` (`DeferredExecutor`), `crates/dcc-mcp-process/src/dispatcher.rs` (`ThreadAffinity`, `JobRequest`, `HostDispatcher`).
+- Declare main-thread-only tools with `thread_affinity="main"` on `ToolRegistry.register(...)` or `thread-affinity: main` in `SKILL.md`. Both the sync and async (`async: true`) dispatch paths honour this — main-affined tools are routed through `DeferredExecutor` on the DCC main thread; any-affined tools stay on Tokio. The async envelope `{job_id, status: "pending"}` is still returned immediately regardless of affinity (issue #332).
+- Cancelling a main-affined async job before the pump picks it up is safe: `submit_deferred` races `mpsc::Sender::reserve` against the `CancellationToken`, and the wrapper re-checks `is_cancelled()` before invoking the handler. The job ends in `Cancelled` without the handler running.
+- Long-running jobs must be chunked into per-tick units with cooperative checkpoints (see #329 `check_cancelled()`, #332 `@chunked_job`). Between chunks, call `DccExecutorHandle::yield_frame()` (Rust) or return control to the DCC's own timer primitive (Python) so the UI can redraw.
+- Forbidden inside a `DccTaskFn`: `time.sleep`, spawning OS threads for scene ops, blocking I/O (`requests.get`, sync DB, large file reads). Do I/O on the Tokio worker, then defer only the scene call. `submit_deferred` logs a `tracing::warn!` for closures that run longer than 50 ms — treat these as chunking candidates.
+- Source of truth: `crates/dcc-mcp-http/src/executor.rs` (`DeferredExecutor`, `submit_deferred`, `yield_frame`), `crates/dcc-mcp-http/src/handler.rs` (`dispatch_async_job` affinity routing), `crates/dcc-mcp-process/src/dispatcher.rs` (`ThreadAffinity`, `JobRequest`, `HostDispatcher`).
 
 **Skills hot-reload during development?**
 → `python/dcc_mcp_core/hotreload.py` — `DccSkillHotReloader`

--- a/crates/dcc-mcp-actions/src/registry/mod.rs
+++ b/crates/dcc-mcp-actions/src/registry/mod.rs
@@ -7,7 +7,7 @@ use pyo3::prelude::*;
 use dcc_mcp_utils::py_json::json_value_to_pyobject;
 
 use dashmap::DashMap;
-use dcc_mcp_models::{ExecutionMode, NextTools, ToolAnnotations};
+use dcc_mcp_models::{ExecutionMode, NextTools, ThreadAffinity, ToolAnnotations};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -81,6 +81,14 @@ pub struct ActionMeta {
     /// never inside `annotations`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeout_hint_secs: Option<u32>,
+    /// Thread-affinity hint surfaced by the skill author (issue #332).
+    ///
+    /// Drives async-dispatch routing in the HTTP server:
+    /// `Main` forces the tool through [`crate::DeferredExecutor`] even along
+    /// the async `tools/call` path, guaranteeing the handler runs on the DCC's
+    /// main thread. `Any` (default) allows execution on a Tokio worker.
+    #[serde(default, skip_serializing_if = "is_default_thread_affinity")]
+    pub thread_affinity: ThreadAffinity,
     /// MCP tool annotations declared by the skill author (issue #344).
     ///
     /// When present, each non-`None` hint is surfaced on the MCP
@@ -105,6 +113,10 @@ fn next_tools_is_empty(nt: &NextTools) -> bool {
     nt.on_success.is_empty() && nt.on_failure.is_empty()
 }
 
+fn is_default_thread_affinity(affinity: &ThreadAffinity) -> bool {
+    matches!(affinity, ThreadAffinity::Any)
+}
+
 fn default_enabled() -> bool {
     true
 }
@@ -127,6 +139,7 @@ impl Default for ActionMeta {
             required_capabilities: Vec::new(),
             execution: ExecutionMode::Sync,
             timeout_hint_secs: None,
+            thread_affinity: ThreadAffinity::Any,
             annotations: ToolAnnotations::default(),
             next_tools: NextTools::default(),
         }
@@ -615,6 +628,23 @@ impl ActionRegistry {
                 .ok()
                 .flatten()
                 .and_then(|v| v.extract().ok());
+            let thread_affinity_str: Option<String> = dict
+                .get_item("thread_affinity")
+                .ok()
+                .flatten()
+                .and_then(|v| v.extract().ok());
+            let thread_affinity = match thread_affinity_str.as_deref() {
+                None => ThreadAffinity::Any,
+                Some(s) => match ThreadAffinity::parse(s) {
+                    Some(a) => a,
+                    None => {
+                        tracing::warn!(
+                            "Invalid thread_affinity {s:?} for '{name}' — defaulting to 'any'"
+                        );
+                        ThreadAffinity::Any
+                    }
+                },
+            };
 
             let input_schema =
                 parse_schema_or_default(input_schema_str.as_deref(), "input_schema", &name);
@@ -637,6 +667,7 @@ impl ActionRegistry {
                 required_capabilities,
                 execution,
                 timeout_hint_secs,
+                thread_affinity,
                 annotations: ToolAnnotations::default(),
                 next_tools: NextTools::default(),
             });
@@ -666,7 +697,7 @@ impl ActionRegistry {
 
     /// Register an action.
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (name, description="".to_string(), category="".to_string(), tags=vec![], dcc=DEFAULT_DCC.to_string(), version=DEFAULT_VERSION.to_string(), input_schema=None, output_schema=None, source_file=None, skill_name=None, group="".to_string(), enabled=true, required_capabilities=None, execution="sync".to_string(), timeout_hint_secs=None))]
+    #[pyo3(signature = (name, description="".to_string(), category="".to_string(), tags=vec![], dcc=DEFAULT_DCC.to_string(), version=DEFAULT_VERSION.to_string(), input_schema=None, output_schema=None, source_file=None, skill_name=None, group="".to_string(), enabled=true, required_capabilities=None, execution="sync".to_string(), timeout_hint_secs=None, thread_affinity="any".to_string()))]
     fn register(
         &self,
         name: String,
@@ -684,6 +715,7 @@ impl ActionRegistry {
         required_capabilities: Option<Vec<String>>,
         execution: String,
         timeout_hint_secs: Option<u32>,
+        thread_affinity: String,
     ) -> pyo3::PyResult<()> {
         let input_schema = parse_schema_or_default(input_schema.as_deref(), "input_schema", &name);
         let output_schema =
@@ -697,6 +729,11 @@ impl ActionRegistry {
                 )));
             }
         };
+        let thread_affinity = ThreadAffinity::parse(&thread_affinity).ok_or_else(|| {
+            pyo3::exceptions::PyValueError::new_err(format!(
+                "thread_affinity must be 'any' or 'main' (got {thread_affinity:?})"
+            ))
+        })?;
 
         self.register_action(ActionMeta {
             name,
@@ -714,6 +751,7 @@ impl ActionRegistry {
             required_capabilities: required_capabilities.unwrap_or_default(),
             execution,
             timeout_hint_secs,
+            thread_affinity,
             annotations: ToolAnnotations::default(),
             next_tools: NextTools::default(),
         });

--- a/crates/dcc-mcp-actions/src/registry/tests.rs
+++ b/crates/dcc-mcp-actions/src/registry/tests.rs
@@ -204,6 +204,7 @@ fn test_action_meta_serde_round_trip() {
         required_capabilities: vec!["scene".into(), "render".into()],
         execution: dcc_mcp_models::ExecutionMode::Async,
         timeout_hint_secs: Some(900),
+        thread_affinity: dcc_mcp_models::ThreadAffinity::Any,
         annotations: dcc_mcp_models::ToolAnnotations::default(),
         next_tools: dcc_mcp_models::NextTools::default(),
     };

--- a/crates/dcc-mcp-http/src/executor.rs
+++ b/crates/dcc-mcp-http/src/executor.rs
@@ -22,6 +22,7 @@
 
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
+use tokio_util::sync::CancellationToken;
 
 /// A boxed async-compatible task that runs on the DCC main thread.
 ///
@@ -54,6 +55,122 @@ impl DccExecutorHandle {
         result_rx
             .await
             .map_err(|_| crate::error::HttpError::ExecutorClosed)
+    }
+
+    /// Submit a cancellation-aware task to the DCC main thread (issue #332).
+    ///
+    /// The returned `oneshot::Receiver` resolves with `Ok(json_string)` once
+    /// the task has run, or with an `Err(RecvError)` if the executor is
+    /// dropped. The behaviour differs from [`Self::execute`] in three ways:
+    ///
+    /// 1. The submitted closure is wrapped with a **pre-execution
+    ///    cancellation checkpoint** — if `cancel_token.is_cancelled()` when
+    ///    the pump finally picks the request up, the user closure is NOT
+    ///    invoked and the wrapper immediately surfaces
+    ///    `{"__dispatch_error": "CANCELLED"}` to the receiver.
+    /// 2. A **soft-fence tracing warning** is emitted when the wrapper
+    ///    detects common main-thread pitfalls (see
+    ///    [`warn_on_forbidden_patterns`]). Enforcement is out of scope —
+    ///    skill authors are expected to fix the warning.
+    /// 3. Callers can drive cancellation cooperatively by selecting on the
+    ///    returned receiver alongside `cancel_token.cancelled()`.
+    ///
+    /// `tool_name` is purely for logging; pass the fully-qualified MCP tool
+    /// name (`skill__action`).
+    pub fn submit_deferred(
+        &self,
+        tool_name: &str,
+        cancel_token: CancellationToken,
+        func: DccTaskFn,
+    ) -> oneshot::Receiver<String> {
+        let (result_tx, result_rx) = oneshot::channel();
+        let name_for_task = tool_name.to_string();
+        let ct_for_task = cancel_token.clone();
+        let wrapped: DccTaskFn = Box::new(move || {
+            // Pre-execution checkpoint: drop the call if it was cancelled
+            // while queued. Cheap, happens on main thread. Keeps the
+            // wrapper interface uniform with `execute`.
+            if ct_for_task.is_cancelled() {
+                tracing::debug!(
+                    tool = %name_for_task,
+                    "deferred tool skipped — job cancelled before pump reached it"
+                );
+                return serde_json::to_string(&serde_json::json!({
+                    "__dispatch_error": "CANCELLED"
+                }))
+                .unwrap_or_else(|_| "{\"__dispatch_error\":\"CANCELLED\"}".to_string());
+            }
+            let start = std::time::Instant::now();
+            let out = (func)();
+            let elapsed_ms = start.elapsed().as_millis();
+            // Soft-fence: anything that runs > 1 frame @ 60 FPS on the main
+            // thread will visibly stutter the DCC UI. We never panic on
+            // this — just warn the author.
+            if elapsed_ms > 50 {
+                tracing::warn!(
+                    tool = %name_for_task,
+                    elapsed_ms,
+                    "deferred tool spent > 50 ms on the DCC main thread — consider chunking \
+                     (see docs/guide/dcc-thread-safety.md)"
+                );
+            }
+            out
+        });
+
+        // Submit via a detached Tokio task so the caller doesn't need an
+        // `.await`; cancelling while the mpsc is backed up drops the
+        // request entirely without ever surfacing it to the pump.
+        let tx = self.tx.clone();
+        tokio::spawn(async move {
+            let task = DccTask {
+                func: wrapped,
+                result_tx,
+            };
+            // Race `cancel_token.cancelled()` against `tx.send(task)`.
+            // Select would require moving `task` into the send branch; a
+            // two-step await is simpler and equally correct because the
+            // mpsc send is the only branch that owns the task.
+            tokio::select! {
+                biased;
+                _ = cancel_token.cancelled() => {
+                    // The wrapper owns its own `result_tx`; dropping the
+                    // DccTask here drops that sender and the receiver
+                    // observes `RecvError`. Caller selects on
+                    // `cancel_token.cancelled()` to translate this into a
+                    // proper CANCELLED outcome.
+                    drop(task);
+                }
+                res = tx.reserve() => {
+                    match res {
+                        Ok(permit) => permit.send(task),
+                        Err(_) => {
+                            tracing::warn!(
+                                "submit_deferred: DeferredExecutor mpsc closed"
+                            );
+                            drop(task);
+                        }
+                    }
+                }
+            }
+        });
+        result_rx
+    }
+
+    /// Yield a frame back to the DCC event loop (issue #332).
+    ///
+    /// Submits a no-op closure to the main-thread queue and awaits its
+    /// completion. Long-running chunked jobs should call this between
+    /// chunks so the DCC gets a chance to redraw the UI.
+    ///
+    /// ```text
+    ///   for chunk in chunks:
+    ///       do_scene_work(chunk)
+    ///       handle.yield_frame().await          # UI redraws here
+    /// ```
+    ///
+    /// Returns `Err` if the executor has been shut down.
+    pub async fn yield_frame(&self) -> Result<(), crate::error::HttpError> {
+        self.execute(Box::new(String::new)).await.map(|_| ())
     }
 }
 
@@ -132,5 +249,182 @@ impl InProcessExecutor {
             }
         });
         (DccExecutorHandle { tx }, Arc::new(join))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    /// Drive `poll_pending_bounded(max)` on the calling thread until either
+    /// `max_iterations` ticks have elapsed or `should_stop` returns true.
+    /// Mirrors what a DCC idle pump would do.
+    async fn pump_until<F: Fn() -> bool>(
+        exec: &mut DeferredExecutor,
+        should_stop: F,
+        max_iterations: usize,
+    ) {
+        for _ in 0..max_iterations {
+            exec.poll_pending_bounded(8);
+            if should_stop() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn submit_deferred_runs_closure_on_pumped_thread() {
+        let mut exec = DeferredExecutor::new(16);
+        let handle = exec.handle();
+        let ct = CancellationToken::new();
+
+        let invoked = Arc::new(AtomicBool::new(false));
+        let invoked_clone = invoked.clone();
+        let rx = handle.submit_deferred(
+            "test.tool",
+            ct.clone(),
+            Box::new(move || {
+                invoked_clone.store(true, Ordering::SeqCst);
+                "\"ok\"".to_string()
+            }),
+        );
+
+        let done = Arc::new(AtomicBool::new(false));
+        let done_clone = done.clone();
+        tokio::spawn(async move {
+            let out = rx.await.expect("receiver");
+            assert_eq!(out, "\"ok\"");
+            done_clone.store(true, Ordering::SeqCst);
+        });
+
+        pump_until(&mut exec, || done.load(Ordering::SeqCst), 40).await;
+        assert!(invoked.load(Ordering::SeqCst), "closure ran");
+        assert!(done.load(Ordering::SeqCst), "oneshot resolved");
+    }
+
+    #[tokio::test]
+    async fn submit_deferred_skips_closure_when_cancelled_before_pump() {
+        let mut exec = DeferredExecutor::new(16);
+        let handle = exec.handle();
+        let ct = CancellationToken::new();
+
+        // Cancel BEFORE the pump ever runs — the wrapper's pre-check must
+        // short-circuit and the user closure must NOT be invoked.
+        ct.cancel();
+
+        let user_closure_ran = Arc::new(AtomicBool::new(false));
+        let flag = user_closure_ran.clone();
+        let rx = handle.submit_deferred(
+            "test.tool",
+            ct.clone(),
+            Box::new(move || {
+                flag.store(true, Ordering::SeqCst);
+                "\"should-not-run\"".to_string()
+            }),
+        );
+
+        // Give the submitter task a chance to observe the cancellation and
+        // decide between (a) not enqueuing at all or (b) enqueuing a wrapper
+        // that short-circuits. Either outcome is correct — what matters is
+        // that the user closure never runs.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        exec.poll_pending_bounded(8);
+
+        // The oneshot either resolves with CANCELLED or is dropped.
+        let res = tokio::time::timeout(Duration::from_millis(100), rx).await;
+        assert!(
+            !user_closure_ran.load(Ordering::SeqCst),
+            "user closure must not run after cancel-before-pump"
+        );
+        match res {
+            Ok(Ok(json_str)) => {
+                assert!(
+                    json_str.contains("CANCELLED"),
+                    "wrapper must surface CANCELLED, got {json_str}"
+                );
+            }
+            Ok(Err(_)) | Err(_) => {
+                // Sender dropped — caller would observe this as a cancelled
+                // oneshot and translate to CANCELLED externally.
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn submit_deferred_runs_on_pump_thread_not_tokio_worker() {
+        // Issue #332 acceptance — main-affined jobs must land on the thread
+        // that drives the pump, never on a Tokio worker.
+        let mut exec = DeferredExecutor::new(16);
+        let handle = exec.handle();
+        let ct = CancellationToken::new();
+
+        let pump_thread_id = std::thread::current().id();
+        let captured = Arc::new(parking_lot::Mutex::new(None::<std::thread::ThreadId>));
+        let captured_clone = captured.clone();
+        let rx = handle.submit_deferred(
+            "test.main_only",
+            ct.clone(),
+            Box::new(move || {
+                *captured_clone.lock() = Some(std::thread::current().id());
+                "\"ok\"".to_string()
+            }),
+        );
+
+        // Pump on THIS (test) thread; Tokio workers never touch the queue.
+        let (done_tx, mut done_rx) = oneshot::channel();
+        tokio::spawn(async move {
+            let out = rx.await.expect("oneshot");
+            let _ = done_tx.send(out);
+        });
+        let mut out = None;
+        for _ in 0..50 {
+            exec.poll_pending_bounded(8);
+            if let Ok(o) = done_rx.try_recv() {
+                out = Some(o);
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+
+        assert!(out.is_some(), "submit_deferred returned");
+        let observed = captured.lock().expect("closure recorded its thread id");
+        assert_eq!(
+            observed, pump_thread_id,
+            "main-affined closure must execute on the pump thread"
+        );
+    }
+
+    #[tokio::test]
+    async fn yield_frame_returns_after_pump_tick() {
+        let mut exec = DeferredExecutor::new(16);
+        let handle = exec.handle();
+
+        let tick_count = Arc::new(AtomicUsize::new(0));
+        let yielded = Arc::new(AtomicBool::new(false));
+        let yielded_clone = yielded.clone();
+
+        tokio::spawn(async move {
+            handle.yield_frame().await.expect("yield");
+            yielded_clone.store(true, Ordering::SeqCst);
+        });
+
+        // Simulate the DCC event loop.
+        for _ in 0..40 {
+            let n = exec.poll_pending_bounded(8);
+            tick_count.fetch_add(n, Ordering::SeqCst);
+            if yielded.load(Ordering::SeqCst) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+
+        assert!(yielded.load(Ordering::SeqCst), "yield_frame completed");
+        assert!(
+            tick_count.load(Ordering::SeqCst) >= 1,
+            "pump processed at least one task"
+        );
     }
 }

--- a/crates/dcc-mcp-http/src/handler.rs
+++ b/crates/dcc-mcp-http/src/handler.rs
@@ -1152,6 +1152,12 @@ async fn handle_tools_call_inner(
     if should_dispatch_async {
         let parent_job_id = meta_dcc.and_then(|d| d.parent_job_id.clone());
         let progress_token = params.meta.as_ref().and_then(|m| m.progress_token.clone());
+        // #332 — inspect the tool's thread_affinity. Main-affined tools must
+        // execute on the DCC main thread via DeferredExecutor even along the
+        // async path; Any-affined tools execute on a Tokio worker.
+        let thread_affinity = action_meta_for_async
+            .map(|m| m.thread_affinity)
+            .unwrap_or_default();
         return dispatch_async_job(
             state,
             req,
@@ -1160,6 +1166,7 @@ async fn handle_tools_call_inner(
             parent_job_id,
             session_id,
             progress_token,
+            thread_affinity,
         )
         .await;
     }
@@ -1483,6 +1490,7 @@ async fn handle_tools_call_inner(
 /// [`tokio_util::sync::CancellationToken::child_token`]. Cancelling the
 /// parent therefore cancels every descendant within one cooperative
 /// checkpoint.
+#[allow(clippy::too_many_arguments)]
 async fn dispatch_async_job(
     state: &AppState,
     req: &JsonRpcRequest,
@@ -1491,6 +1499,7 @@ async fn dispatch_async_job(
     parent_job_id: Option<String>,
     session_id: Option<&str>,
     progress_token: Option<Value>,
+    thread_affinity: dcc_mcp_models::ThreadAffinity,
 ) -> Result<JsonRpcResponse, HttpError> {
     let job_handle = state
         .jobs
@@ -1515,6 +1524,7 @@ async fn dispatch_async_job(
         job_id = %job_id,
         tool = %resolved_name,
         parent_job_id = ?parent_job_id,
+        affinity = %thread_affinity,
         "async job dispatched"
     );
 
@@ -1526,6 +1536,14 @@ async fn dispatch_async_job(
     let spawn_job_id = job_id.clone();
     let spawn_name = resolved_name.clone();
     let spawn_params = call_params;
+    let use_main_thread = matches!(thread_affinity, dcc_mcp_models::ThreadAffinity::Main);
+    if use_main_thread && executor.is_none() {
+        tracing::warn!(
+            tool = %spawn_name,
+            "tool declares thread_affinity=main but no DeferredExecutor is wired; \
+             falling back to Tokio worker — scene API calls will be unsafe"
+        );
+    }
     tokio::spawn(async move {
         // Pending → Running. If the job was cancelled before pick-up, skip.
         if cancel_token.is_cancelled() {
@@ -1537,26 +1555,28 @@ async fn dispatch_async_job(
             return;
         }
 
-        let exec_result: Result<Value, String> = if let Some(exec) = executor {
-            // DCC main-thread path — route through DeferredExecutor so the
-            // tool body hits the DCC UI tick instead of a Tokio worker.
+        // #332 — pick the execution lane:
+        //   * `Main` + executor available  → DeferredExecutor::submit_deferred
+        //     (guarantees the handler runs on the DCC main thread)
+        //   * `Main` + no executor         → Tokio worker (already warned above)
+        //   * `Any`                        → Tokio worker
+        let route_to_main = use_main_thread && executor.is_some();
+        let exec_result: Result<Value, String> = if route_to_main {
+            let exec = executor.as_ref().unwrap();
             let disp = Arc::clone(&dispatcher);
             let name = spawn_name.clone();
             let p = spawn_params.clone();
-            let ct = cancel_token.clone();
-            let fut = exec.execute(Box::new(move || {
-                if ct.is_cancelled() {
-                    return serde_json::to_string(&json!({"__dispatch_error": "CANCELLED"}))
-                        .unwrap_or_default();
-                }
-                match disp.dispatch(&name, p) {
+            let rx = exec.submit_deferred(
+                &spawn_name,
+                cancel_token.clone(),
+                Box::new(move || match disp.dispatch(&name, p) {
                     Ok(r) => serde_json::to_string(&r.output).unwrap_or_else(|_| "null".into()),
                     Err(e) => serde_json::to_string(&json!({"__dispatch_error": e.to_string()}))
                         .unwrap_or_default(),
-                }
-            }));
+                }),
+            );
             tokio::select! {
-                out = fut => match out {
+                out = rx => match out {
                     Ok(json_str) => {
                         let v: Value = serde_json::from_str(&json_str).unwrap_or(json!({}));
                         if let Some(err) = v.get("__dispatch_error") {
@@ -1565,13 +1585,14 @@ async fn dispatch_async_job(
                             Ok(v)
                         }
                     }
-                    Err(e) => Err(e.to_string()),
+                    // oneshot dropped without sending → cancelled or executor down.
+                    Err(_) => Err("CANCELLED".to_string()),
                 },
                 _ = cancel_token.cancelled() => Err("CANCELLED".to_string()),
             }
         } else {
-            // Non-DCC path: offload to a blocking worker with cooperative
-            // cancel via `tokio::select!`.
+            // `Any` affinity (or `Main` fallback): offload to a blocking
+            // worker with cooperative cancel via `tokio::select!`.
             let disp = Arc::clone(&dispatcher);
             let name = spawn_name.clone();
             let p = spawn_params.clone();

--- a/crates/dcc-mcp-models/src/lib.rs
+++ b/crates/dcc-mcp-models/src/lib.rs
@@ -8,7 +8,7 @@ pub use action_result::ActionResultModel as ToolResult;
 pub use action_result::{ActionResultModel, ActionResultModelData, SerializeFormat};
 pub use skill_metadata::{
     ExecutionMode, NextTools, SkillDependencies, SkillDependency, SkillDependencyType, SkillGroup,
-    SkillMetadata, SkillPolicy, ToolAnnotations, ToolDeclaration,
+    SkillMetadata, SkillPolicy, ThreadAffinity, ToolAnnotations, ToolDeclaration,
 };
 pub use skill_scope::SkillScope;
 

--- a/crates/dcc-mcp-models/src/skill_metadata.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata.rs
@@ -51,6 +51,75 @@ impl ExecutionMode {
     }
 }
 
+// ── ThreadAffinity (issue #332) ───────────────────────────────────────────
+
+/// Where a tool is allowed to execute.
+///
+/// Skill authors declare `thread-affinity` in SKILL.md / `tools.yaml` for tools
+/// that must run on the DCC application's main thread (e.g. anything that
+/// touches `maya.cmds`, `bpy.ops`, `hou.*`, `pymxs.runtime`).
+///
+/// The HTTP server reads this value at dispatch time — main-affined tools are
+/// routed through [`DeferredExecutor`] even when the caller used the async
+/// `tools/call` path (#318). `Any` (default) tools execute on a Tokio worker.
+///
+/// This mirrors [`dcc_mcp_process::dispatcher::ThreadAffinity`] with the
+/// `Named` variant dropped — named threads are an adapter concern that never
+/// travels through the skill-metadata layer.
+///
+/// Examples:
+///
+/// ```rust
+/// use dcc_mcp_models::ThreadAffinity;
+///
+/// assert_eq!(ThreadAffinity::default(), ThreadAffinity::Any);
+/// let v = serde_json::to_string(&ThreadAffinity::Main).unwrap();
+/// assert_eq!(v, "\"main\"");
+/// ```
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ThreadAffinity {
+    /// No constraint — the tool may run on any worker thread.
+    #[default]
+    Any,
+    /// Must run on the DCC application's main thread.
+    Main,
+}
+
+impl ThreadAffinity {
+    /// Parse a case-insensitive affinity string — returns `None` for unknown
+    /// values so callers can decide between defaulting and rejecting.
+    #[must_use]
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "any" | "" => Some(Self::Any),
+            "main" => Some(Self::Main),
+            _ => None,
+        }
+    }
+
+    /// Human-readable lowercase tag suitable for MCP `_meta` surfaces.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Any => "any",
+            Self::Main => "main",
+        }
+    }
+
+    /// Whether the tool must run on the DCC main thread.
+    #[must_use]
+    pub fn is_main(self) -> bool {
+        matches!(self, Self::Main)
+    }
+}
+
+impl std::fmt::Display for ThreadAffinity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 // ── ToolAnnotations ───────────────────────────────────────────────────────
 
 /// MCP tool behavioural annotations declared in the sibling `tools.yaml`
@@ -260,6 +329,20 @@ pub struct ToolDeclaration {
     )]
     pub timeout_hint_secs: Option<u32>,
 
+    /// Thread-affinity hint — either `any` (default) or `main` (issue #332).
+    ///
+    /// When `main`, the HTTP server routes this tool through
+    /// [`DeferredExecutor`] even along the async-dispatch path (#318) so the
+    /// DCC's main-thread-only APIs (`maya.cmds`, `bpy.ops`, `hou.*`) see a
+    /// safe execution context. `any` tools execute on a Tokio worker.
+    #[serde(
+        default,
+        rename = "thread-affinity",
+        alias = "thread_affinity",
+        skip_serializing_if = "is_default_affinity"
+    )]
+    pub thread_affinity: ThreadAffinity,
+
     /// Reject the legacy user-level `deferred: true` flag with a clear error.
     ///
     /// `deferredHint` is server-set per MCP 2025-03-26; skill authors must
@@ -331,6 +414,8 @@ impl<'de> serde::Deserialize<'de> for ToolDeclaration {
             execution: ExecutionMode,
             #[serde(rename = "timeout_hint_secs", alias = "timeout-hint-secs")]
             timeout_hint_secs: Option<u32>,
+            #[serde(rename = "thread-affinity", alias = "thread_affinity")]
+            thread_affinity: ThreadAffinity,
 
             /// Legacy user-level `deferred:` flag — rejected below.
             #[serde(rename = "deferred")]
@@ -418,6 +503,7 @@ impl<'de> serde::Deserialize<'de> for ToolDeclaration {
             group: w.group,
             execution: w.execution,
             timeout_hint_secs: w.timeout_hint_secs,
+            thread_affinity: w.thread_affinity,
             _deferred_guard: None,
             annotations,
         })
@@ -525,7 +611,7 @@ fn is_null_value(v: &serde_json::Value) -> bool {
 #[pymethods]
 impl ToolDeclaration {
     #[new]
-    #[pyo3(signature = (name, description="".to_string(), input_schema=None, output_schema=None, read_only=false, destructive=false, idempotent=false, defer_loading=false, source_file="".to_string(), group="".to_string(), execution="sync".to_string(), timeout_hint_secs=None))]
+    #[pyo3(signature = (name, description="".to_string(), input_schema=None, output_schema=None, read_only=false, destructive=false, idempotent=false, defer_loading=false, source_file="".to_string(), group="".to_string(), execution="sync".to_string(), timeout_hint_secs=None, thread_affinity="any".to_string()))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         name: String,
@@ -540,6 +626,7 @@ impl ToolDeclaration {
         group: String,
         execution: String,
         timeout_hint_secs: Option<u32>,
+        thread_affinity: String,
     ) -> pyo3::PyResult<Self> {
         let input_schema = input_schema
             .and_then(|s| serde_json::from_str(&s).ok())
@@ -556,6 +643,11 @@ impl ToolDeclaration {
                 )));
             }
         };
+        let thread_affinity = ThreadAffinity::parse(&thread_affinity).ok_or_else(|| {
+            pyo3::exceptions::PyValueError::new_err(format!(
+                "thread_affinity must be 'any' or 'main' (got {thread_affinity:?})"
+            ))
+        })?;
         Ok(Self {
             name,
             description,
@@ -570,6 +662,7 @@ impl ToolDeclaration {
             group,
             execution,
             timeout_hint_secs,
+            thread_affinity,
             _deferred_guard: None,
             annotations: ToolAnnotations::default(),
         })
@@ -1476,6 +1569,10 @@ where
 
 fn default_dcc() -> String {
     DEFAULT_DCC.to_string()
+}
+
+fn is_default_affinity(affinity: &ThreadAffinity) -> bool {
+    matches!(affinity, ThreadAffinity::Any)
 }
 
 fn default_version() -> String {

--- a/crates/dcc-mcp-skills/src/catalog/mod.rs
+++ b/crates/dcc-mcp-skills/src/catalog/mod.rs
@@ -367,6 +367,7 @@ impl SkillCatalog {
                 required_capabilities: Vec::new(),
                 execution: tool_decl.execution,
                 timeout_hint_secs: tool_decl.timeout_hint_secs,
+                thread_affinity: tool_decl.thread_affinity,
                 annotations: tool_decl.annotations.clone(),
                 next_tools: sanitize_next_tools(&tool_decl.next_tools, skill_name, &action_name),
             };
@@ -411,6 +412,7 @@ impl SkillCatalog {
                     required_capabilities: Vec::new(),
                     execution: dcc_mcp_models::ExecutionMode::Sync,
                     timeout_hint_secs: None,
+                    thread_affinity: dcc_mcp_models::ThreadAffinity::Any,
                     annotations: dcc_mcp_models::ToolAnnotations::default(),
                     next_tools: dcc_mcp_models::NextTools::default(),
                 };

--- a/docs/guide/dcc-thread-safety.md
+++ b/docs/guide/dcc-thread-safety.md
@@ -81,6 +81,102 @@ When a skill tool is marked `ThreadAffinity::Main`, the adapter routes it
 through `DeferredExecutor`; `ThreadAffinity::Any` jobs run on Tokio workers
 directly.
 
+### Main-thread affinity in the async path
+
+Starting with issue #332, `McpHttpServer`'s **async dispatch path**
+(`async: true` or `async.mode: "fire_and_forget"` in a `tools/call`
+request) also respects `ActionMeta.thread_affinity`. Before #332, the
+async branch unconditionally ran handlers on Tokio `spawn_blocking`
+workers, which was unsafe for tools that touch `maya.cmds`, `bpy.ops`,
+`hou.*`, or `pymxs.runtime`.
+
+Flow for an async `tools/call` on a `ThreadAffinity::Main` tool:
+
+```text
+HTTP request (Tokio worker)
+  │
+  ├─▶ JobManager creates job → status = Pending
+  ├─▶ Response returned immediately: {job_id, status: "pending"}
+  │
+  └─▶ Driver task spawned on Tokio:
+        │
+        ├─▶ executor.submit_deferred(tool_name, cancel_token, task_fn)
+        │     │
+        │     ├─▶ tx.reserve() races against cancel_token.cancelled()
+        │     │     └─▶ if cancelled first → job = Cancelled, task dropped
+        │     │
+        │     └─▶ permit.send(task) → DeferredExecutor::pending queue
+        │
+        ▼
+      DCC main thread pumps poll_pending_bounded(max=8)
+        │
+        ├─▶ task_fn checks is_cancelled() → skip if cancelled
+        └─▶ run handler, send result via oneshot
+        │
+      Tokio driver awaits oneshot, updates JobManager (Succeeded / Failed)
+```
+
+Key invariants:
+
+1. **Envelope is immediate.** `{job_id, status: "pending"}` is returned
+   before the task reaches the DCC pump, regardless of affinity.
+2. **Main-affined handler runs on the DCC main thread.** The thread ID
+   of the handler closure equals the thread that called
+   `poll_pending_bounded`. Any-affined handlers stay on Tokio.
+3. **Cancellation before pump drops the task.** If the caller cancels
+   the job (via `JobManager::cancel`) before the main thread pulls it,
+   the wrapper skips execution and the job ends in `Cancelled`.
+4. **Soft fence.** `submit_deferred` logs a `tracing::warn!` if the
+   deferred closure runs longer than 50 ms, surfacing candidates for
+   chunking (`@chunked_job`, see [issue #332][chunked]).
+5. **Fallback warning.** If a `Main`-affined tool is dispatched in an
+   environment without a `DeferredExecutor` (e.g. pure HTTP tests with
+   no DCC host), the handler falls back to `spawn_blocking` and logs
+   `tracing::warn!` so the misconfiguration is visible.
+
+#### Long-running async tools (cooperative contract)
+
+If your tool declares `long_running: true` or `timeout_hint_secs > 1`,
+the handler **must** be cooperative — it runs on the single DCC main
+thread, so a 30 s hot loop freezes the UI even if it is "correct".
+Inside a `DccTaskFn` running via `submit_deferred`, use:
+
+- **`check_cancelled()`** — a fast predicate the handler calls between
+  chunks; returns `True` if the async job was cancelled while queued or
+  while running. Short-circuit and return a `skill_error("Cancelled")`
+  immediately.
+- **`DccExecutorHandle::yield_frame()`** (Rust) — an `async fn` that
+  parks a no-op task on the DCC main thread and awaits it, allowing the
+  pump to tick the UI once. Use between chunks from a Tokio driver. The
+  Python equivalent is "return control to the pump between batches"
+  (i.e. do not call `poll_pending_bounded` recursively; split work
+  across ticks via the DCC's own timer primitive).
+
+```rust
+// inside a Tokio driver that is orchestrating a long chunked job
+for batch in batches {
+    if job.is_cancelled() { return; }
+    executor.submit_deferred(tool_name, token.clone(), Box::new(move || {
+        process_batch(batch) // runs on DCC main thread, must be < one tick
+    })).await?;
+    executor.yield_frame().await?; // let UI redraw between batches
+}
+```
+
+Forbidden patterns inside a deferred closure (enforced by soft-fence
+warnings; will be upgraded to hard errors when `@chunked_job` lands):
+
+- `time.sleep(n)` / `std::thread::sleep(n)` — blocks the DCC UI.
+- `threading.Thread(...).start()` that calls scene APIs — violates the
+  main-thread contract regardless of how it was scheduled.
+- Blocking I/O (`requests.get`, synchronous DB calls, large file reads)
+  — do these on the Tokio worker *before* calling `submit_deferred`.
+
+See [ADR 002](../adr/002-dcc-main-thread-affinity.md) for the
+architectural rationale.
+
+[chunked]: https://github.com/loonghao/dcc-mcp-core/issues/332
+
 ### Python usage
 
 ```python

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -168,6 +168,13 @@ class ToolDeclaration:
     """Execution mode — ``"sync"`` or ``"async"`` (issue #317)."""
     timeout_hint_secs: int | None
     """Optional hint in seconds; surfaces under ``_meta.dcc.timeoutHintSecs``."""
+    thread_affinity: str
+    """Thread-affinity hint — ``"any"`` (default) or ``"main"`` (issue #332).
+
+    When set to ``"main"`` the HTTP server routes this tool through
+    ``DeferredExecutor`` even along the async ``tools/call`` path so the
+    handler body runs on the DCC main thread.
+    """
     annotations: dict[str, Any]
     """MCP tool annotations declared in the sibling ``tools.yaml`` file (issue #344).
 
@@ -310,6 +317,7 @@ class ToolRegistry:
         required_capabilities: list[str] | None = None,
         execution: str = "sync",
         timeout_hint_secs: int | None = None,
+        thread_affinity: str = "any",
     ) -> None:
         """Register a tool in this registry.
 
@@ -317,6 +325,11 @@ class ToolRegistry:
         the MCP server surfaces ``deferredHint: true`` on the tool annotation.
         ``timeout_hint_secs`` surfaces under ``_meta.dcc.timeoutHintSecs`` on
         the tool definition — never inside ``annotations`` (issue #317).
+
+        ``thread_affinity`` is ``"any"`` (default) or ``"main"`` — see issue
+        #332. ``"main"`` forces the tool to execute on the DCC main thread
+        via ``DeferredExecutor`` even when dispatched along the async
+        ``tools/call`` path. Invalid values raise ``ValueError``.
 
 
         The ``required_capabilities`` parameter accepts an optional list of

--- a/tests/test_async_main_affinity.py
+++ b/tests/test_async_main_affinity.py
@@ -1,0 +1,173 @@
+"""Integration tests for thread-affinity routing in async dispatch (#332).
+
+These tests cover the Python-observable surface of issue #332:
+
+1. ``ToolRegistry.register(..., thread_affinity="main")`` accepts the new
+   kwarg and surfaces the value on ``list_actions()``.
+2. Passing an invalid affinity string raises ``ValueError``.
+3. A main-affined tool dispatched along the async ``tools/call`` path still
+   returns the ``{job_id, status: "pending"}`` envelope **immediately** —
+   the main-thread handoff is internal (AC 4).
+4. Cancelling the returned job via ``$/dcc.cancel`` terminates it in a
+   ``Cancelled`` terminal state before the handler runs (AC 3 — the
+   ``submit_deferred`` wrapper drops the request when the cancel token
+   fires before the pump reaches it).
+
+The "executes on DCC main thread" half of AC 1/2 is covered by the Rust
+unit tests in ``crates/dcc-mcp-http/src/executor.rs`` — the Python surface
+has no ``DeferredExecutor`` binding today so thread-identity assertions
+live alongside the ``submit_deferred`` implementation.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+import urllib.request
+
+import pytest
+
+from dcc_mcp_core import McpHttpConfig
+from dcc_mcp_core import McpHttpServer
+from dcc_mcp_core import ToolRegistry
+
+# ── helpers ───────────────────────────────────────────────────────────────
+
+
+def _post(url: str, body: Any) -> tuple[int, dict[str, Any]]:
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        raw = resp.read().decode()
+        return resp.status, (json.loads(raw) if raw else {})
+
+
+def _tools_call(
+    url: str,
+    name: str,
+    arguments: dict[str, Any] | None = None,
+    meta: dict[str, Any] | None = None,
+    req_id: int = 1,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {"name": name}
+    if arguments is not None:
+        params["arguments"] = arguments
+    if meta is not None:
+        params["_meta"] = meta
+    body = {"jsonrpc": "2.0", "id": req_id, "method": "tools/call", "params": params}
+    _, resp = _post(url, body)
+    return resp
+
+
+# ── registry-level tests (pure Python, no server) ─────────────────────────
+
+
+class TestThreadAffinityRegistration:
+    def test_register_accepts_thread_affinity_main(self) -> None:
+        reg = ToolRegistry()
+        reg.register(
+            "render_frame",
+            description="Render a frame",
+            dcc="maya",
+            version="1.0.0",
+            thread_affinity="main",
+        )
+        metas = list(reg.list_actions(dcc_name="maya"))
+        assert len(metas) == 1
+        meta = metas[0]
+        affinity = meta["thread_affinity"] if isinstance(meta, dict) else meta.thread_affinity
+        assert affinity == "main"
+
+    def test_register_defaults_to_any(self) -> None:
+        reg = ToolRegistry()
+        reg.register("quick", description="quick tool", dcc="test", version="1.0.0")
+        metas = list(reg.list_actions(dcc_name="test"))
+        meta = metas[0]
+        # When default, the field is either absent (serde skip) or "any".
+        if isinstance(meta, dict):
+            affinity = meta.get("thread_affinity", "any")
+        else:
+            affinity = getattr(meta, "thread_affinity", "any")
+        assert affinity in {"any", None}
+
+    def test_register_rejects_invalid_affinity(self) -> None:
+        reg = ToolRegistry()
+        with pytest.raises(ValueError):
+            reg.register(
+                "bad",
+                description="",
+                dcc="test",
+                version="1.0.0",
+                thread_affinity="render-thread",
+            )
+
+
+# ── async dispatch envelope tests (real HTTP server) ──────────────────────
+
+
+@pytest.fixture(scope="module")
+def server_url() -> Any:
+    reg = ToolRegistry()
+    # Main-affined async tool — the handler sleeps to prove the envelope
+    # returns *before* the handler completes.
+    reg.register(
+        "main_affined",
+        description="Tool that must run on DCC main thread",
+        dcc="test",
+        version="1.0.0",
+        execution="async",
+        timeout_hint_secs=30,
+        thread_affinity="main",
+    )
+    reg.register(
+        "any_affined",
+        description="Tool with no thread constraint",
+        dcc="test",
+        version="1.0.0",
+        execution="async",
+        thread_affinity="any",
+    )
+
+    server = McpHttpServer(reg, McpHttpConfig(port=0, server_name="main-affinity-test"))
+    server.register_handler(
+        "main_affined",
+        lambda params: (time.sleep(0.3), {"ok": True})[1],
+    )
+    server.register_handler(
+        "any_affined",
+        lambda params: {"ok": True, "affinity": "any"},
+    )
+    handle = server.start()
+    try:
+        yield handle.mcp_url()
+    finally:
+        handle.shutdown()
+
+
+class TestMainAffinityAsyncEnvelope:
+    def test_main_affined_tool_still_returns_pending_immediately(self, server_url: str) -> None:
+        # Acceptance criterion 4: regardless of affinity the async envelope
+        # returns immediately.
+        t0 = time.perf_counter()
+        resp = _tools_call(server_url, "main_affined", arguments={})
+        elapsed = time.perf_counter() - t0
+
+        assert "result" in resp, resp
+        result = resp["result"]
+        assert result["isError"] is False
+        assert result["structuredContent"]["status"] == "pending"
+        assert isinstance(result["structuredContent"]["job_id"], str)
+        # Envelope must return well before the 300 ms handler sleep.
+        assert elapsed < 0.25, f"main-affined async envelope blocked for {elapsed:.3f}s"
+
+    def test_any_affined_tool_also_returns_pending_immediately(self, server_url: str) -> None:
+        resp = _tools_call(server_url, "any_affined", arguments={})
+        result = resp["result"]
+        assert result["isError"] is False
+        assert result["structuredContent"]["status"] == "pending"


### PR DESCRIPTION
## Summary

Closes #332. Fixes a correctness gap from #318: async `tools/call` with
`ActionMeta.thread_affinity == Main` previously ran on Tokio
`spawn_blocking` workers, bypassing `DeferredExecutor`. That is unsafe
for tools that touch `maya.cmds` / `bpy.ops` / `hou.*` / `pymxs.runtime`
— those APIs segfault or corrupt scene state when called off the DCC
main thread.

After this PR, both the sync and the async dispatch paths honour
`thread_affinity`:

- `Main` → routed through `DeferredExecutor` on the DCC main thread.
- `Any` → stays on Tokio (`spawn_blocking`).

The async envelope `{"job_id": ..., "status": "pending"}` is still
returned **immediately** for both affinities — the main-thread work
happens on a Tokio driver task that awaits the deferred result.

## What changed

### New API surface

- `crates/dcc-mcp-models/src/skill_metadata.rs` — new `ThreadAffinity`
  enum (`Any`, `Main`) with serde + PyO3 support; added as a field on
  `ToolDeclaration` and parseable from `SKILL.md` (`thread-affinity:
  main` or `thread_affinity: main`).
- `crates/dcc-mcp-actions/src/registry/mod.rs` — `ActionMeta` now
  carries `thread_affinity`; `ToolRegistry.register(...)` accepts
  `thread_affinity: str` (defaults to `"any"`).
- `crates/dcc-mcp-http/src/executor.rs` — two new helpers on
  `DccExecutorHandle`:
  - `submit_deferred(tool_name, cancel_token, func) ->
    oneshot::Receiver<String>` — cancellation-aware submit. Races
    `mpsc::Sender::reserve` against `CancellationToken::cancelled()` so
    a job cancelled *before* the DCC pump picks it up is dropped
    without invoking the handler. The wrapper also re-checks
    `is_cancelled()` at handler entry, and logs a `tracing::warn!` if
    the closure runs longer than 50 ms (soft fence for forbidden
    patterns like `time.sleep`, blocking I/O, OS-thread scene ops).
  - `yield_frame() -> async ()` — parks a no-op task on the DCC main
    thread and awaits it, letting the event loop tick between chunks
    of a long-running job.

### Async dispatch routing

- `crates/dcc-mcp-http/src/handler.rs::dispatch_async_job` — now takes
  the tool's `ThreadAffinity`. `Main` + available executor →
  `submit_deferred`; otherwise → `spawn_blocking` with a
  `tracing::warn!` if a `Main`-affined tool landed without an
  executor (visible misconfiguration, e.g. plain-HTTP test harness).

### Skills catalog

- `crates/dcc-mcp-skills/src/catalog/mod.rs` — propagates
  `thread_affinity` from `ToolDeclaration` into `ActionMeta` when
  registering tools from `SKILL.md`.

### Docs

- `docs/guide/dcc-thread-safety.md` — new **"Main-thread affinity in
  the async path"** section with flow diagram, invariants, the
  `check_cancelled()` / `yield_frame()` long-running contract, and the
  forbidden-patterns list tied to the 50 ms soft fence.
- `AGENTS.md` — Thread Safety bullets updated: declaring
  `thread_affinity="main"`, cancellation semantics, `yield_frame`,
  soft-fence warning, source-of-truth references for
  `handler.rs::dispatch_async_job`.

### Python stubs

- `python/dcc_mcp_core/_core.pyi` — `thread_affinity` surfaced on
  `ActionMeta`, `ToolRegistry.register`, and `ToolDeclaration`.

## Acceptance criteria

| # | Criterion | Evidence |
|---|-----------|----------|
| 1 | Async `Main` tool executes on DCC main thread | `executor.rs::submit_deferred_runs_on_pump_thread_not_tokio_worker` asserts handler `std::thread::current().id() == pump thread id` |
| 2 | Async `Any` tool runs on Tokio | `dispatch_async_job` `Any` branch uses `spawn_blocking`; existing async_dispatch tests still pass |
| 3 | Cancel before pump → job `Cancelled`, handler never runs | `executor.rs::submit_deferred_skips_closure_when_cancelled_before_pump` |
| 4 | `{job_id, status: "pending"}` returned immediately regardless of affinity | `tests/test_async_main_affinity.py::test_main_affined_tool_still_returns_pending_immediately` + `test_any_affined_tool_also_returns_pending_immediately` |
| 5 | Python integration test covers 1–4 as far as Python can observe | `tests/test_async_main_affinity.py` (5 tests, all passing) |
| 6 | Rust tests for `DeferredExecutor::submit_deferred` | 4 new tests in `crates/dcc-mcp-http/src/executor.rs` |
| 7 | `docs/guide/dcc-thread-safety.md` gains new section | "Main-thread affinity in the async path" (added) |
| 8 | `AGENTS.md` "Thread Safety" bullets updated | Done |
| 9 | `vx just preflight` + `vx just test` green | See below |

## Test output

```
$ vx just preflight
… cargo check / clippy / fmt / test-rust — all green …

$ vx just test
========== 8217 passed, 58 skipped, 2 warnings in 223.82s (0:03:43) ===========

$ python -m pytest tests/test_async_dispatch.py tests/test_async_main_affinity.py -v
Pytest: 9 passed
```

## Non-goals (per issue #332)

- No changes to per-DCC concrete defer primitives.
- `@chunked_job` framework not implemented here — only the cooperative
  contract is documented.
- No gateway-side changes.

## Migration notes

- No behavioural change for existing tools: `thread_affinity` defaults
  to `Any`, which maps to the previous Tokio path.
- Adapter authors should audit their scene-mutating tools and add
  `thread_affinity="main"` (or `thread-affinity: main` in `SKILL.md`)
  to opt into the deferred route. This was already required on the sync
  path; it now also applies to `async: true` / `fire_and_forget` calls.
