### PR TITLE
fix(workflow): use derive(Default) for BackoffKind to satisfy clippy

### DIFF
--- a/crates/dcc-mcp-workflow/src/policy.rs
+++ b/crates/dcc-mcp-workflow/src/policy.rs
@@ -29,7 +29,7 @@ use crate::error::ValidationError;
 ///
 /// All variants are bounded by [`RetryPolicy::max_delay`] and modulated by
 /// [`RetryPolicy::jitter`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum BackoffKind {
     /// Constant `initial_delay` between attempts.
@@ -37,13 +37,8 @@ pub enum BackoffKind {
     /// `initial_delay * attempt_number` (1-indexed).
     Linear,
     /// `initial_delay * 2^(attempt_number - 1)` (1-indexed).
+    #[default]
     Exponential,
-}
-
-impl Default for BackoffKind {
-    fn default() -> Self {
-        Self::Exponential
-    }
 }
 
 impl BackoffKind {


### PR DESCRIPTION
## Summary

Fixes the Linux CI regression on `main` introduced by #372 (step policies): clippy's `derivable_impls` lint flagged the manual `Default` impl for `BackoffKind`, and CI runs clippy with `-D warnings`, turning it into a hard error.

## Change

Replace the manual impl with `#[derive(Default)]` plus `#[default]` on the `Exponential` variant. Semantics identical.

```rust
#[derive(Default, ...)]
pub enum BackoffKind {
    Fixed,
    Linear,
    #[default]
    Exponential,
}
```

## Test plan

- `cargo clippy -p dcc-mcp-workflow --all-targets -- -D warnings` → No issues found.
- Existing `test_backoff_default` in policy tests still passes (asserts `Exponential` default).
