### PR TITLE
feat(gateway): async-aware dispatch timeout + wait-for-terminal response (#321)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,14 @@ Need to interact with DCC?
 → Correlation: `progressToken` (progress) + `job_id` (`$/dcc.jobUpdated` / `$/dcc.workflowUpdated`)
 → On backend reconnect, clients with in-flight jobs receive `$/dcc.gatewayReconnect`
 
+**Gateway async-dispatch timeout + wait-for-terminal passthrough (#321)?**
+→ [`docs/guide/gateway.md`](docs/guide/gateway.md) — "Waiting for terminal results from the gateway"
+→ Config: `McpHttpConfig.gateway_async_dispatch_timeout_ms` (default 60 s),
+  `McpHttpConfig.gateway_wait_terminal_timeout_ms` (default 10 min)
+→ Opt-in: send `_meta.dcc.async=true` (or `_meta.progressToken`) to pick up the longer queuing timeout;
+  add `_meta.dcc.wait_for_terminal=true` for single-shot response stitching (no SSE client needed)
+→ Timeout path: returns the last-known envelope with `_meta.dcc.timed_out=true` and leaves the job running
+
 **Enable durable rolling file logs (multi-gateway debugging)?**
 → `FileLoggingConfig` + `init_file_logging()` / `shutdown_file_logging()`
 → Environment vars: `DCC_MCP_LOG_DIR`, `DCC_MCP_LOG_MAX_SIZE`, `DCC_MCP_LOG_ROTATION`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,6 +285,62 @@ These hold after v0.14 and MUST NOT regress:
    also coerces `Ambient` → `Dedicated`. Do not revert to Ambient inside
    Python bindings.
 
+### Gateway async-dispatch + wait-for-terminal (issue #321)
+
+The gateway now uses three per-request timeouts instead of one:
+
+- **Sync call** (no `_meta.dcc.async`, no `progressToken`): governed by
+  `McpHttpConfig.backend_timeout_ms` (default 10 s, #314).
+- **Async opt-in** (`_meta.dcc.async=true` *or* `_meta.progressToken`
+  present): governed by
+  `McpHttpConfig.gateway_async_dispatch_timeout_ms` (default 60 s).
+  Only the **queuing** step spends this budget — the backend replies
+  with `{status:"pending", job_id:"…"}` once the job is enqueued.
+- **Wait-for-terminal** (`_meta.dcc.wait_for_terminal=true` *and* an
+  async opt-in): the gateway blocks the `tools/call` response until
+  `$/dcc.jobUpdated` reports a terminal status (`completed` / `failed`
+  / `cancelled` / `interrupted`). Governed by
+  `McpHttpConfig.gateway_wait_terminal_timeout_ms` (default 10 min).
+  On timeout, the response is the last-known envelope annotated with
+  `_meta.dcc.timed_out = true`; the job keeps running on the backend.
+
+```python
+from dcc_mcp_core import McpHttpConfig
+cfg = McpHttpConfig(
+    port=8765,
+    gateway_async_dispatch_timeout_ms=60_000,   # queuing budget
+    gateway_wait_terminal_timeout_ms=600_000,   # wait-for-terminal budget
+)
+```
+
+Wire-level contract:
+
+```jsonc
+// POST /mcp — client request
+{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{
+  "name":"maya__bake_simulation","arguments":{...},
+  "_meta":{"dcc":{"async":true,"wait_for_terminal":true}}
+}}
+// Gateway blocks the response until $/dcc.jobUpdated status=terminal;
+// wait_for_terminal is STRIPPED before forwarding to the backend so
+// the backend contract remains unchanged.
+```
+
+Implementation notes for maintainers:
+
+- Detection helpers live in `crates/dcc-mcp-http/src/gateway/aggregator.rs`
+  (`meta_signals_async_dispatch`, `meta_wants_wait_for_terminal`,
+  `strip_gateway_meta_flags`).
+- The per-job broadcast bus is owned by `SubscriberManager`
+  (`job_event_buses`, `job_event_channel`, `publish_job_event`,
+  `forget_job_bus`). The bus is created **before** the outbound
+  `tools/call` so terminal events arriving in the tiny window between
+  the backend reply and the waiter installing its subscription are
+  not lost.
+- Backend disconnect during a wait surfaces as `-32000 backend
+  disconnected` and the job stays in whatever state on the backend
+  (may later become `interrupted` per #328).
+
 ### When Exploring Unknown Symbols
 
 ```bash

--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -197,6 +197,42 @@ pub struct McpHttpConfig {
     /// [`Self::request_timeout_ms`] instead. Fixes issue #314.
     pub backend_timeout_ms: u64,
 
+    /// Per-backend request timeout (milliseconds) applied by the gateway
+    /// when the client has opted into **async dispatch** (issue #321).
+    ///
+    /// Triggered when any of the following signals are present on the
+    /// outbound `tools/call`:
+    ///
+    /// * `_meta.dcc.async == true` (explicit client opt-in).
+    /// * `_meta.progressToken` is set (MCP 2025-03-26 long-running hint).
+    /// * The target tool declares `execution: async` or a non-zero
+    ///   `timeout_hint_secs` in its [`dcc_mcp_models::ActionMeta`].
+    ///
+    /// The async dispatch path only has to **queue** the job on the
+    /// backend (reply is `{status:"pending", job_id:"..."}`), but cold
+    /// starts or heavy imports can still legitimately push the queuing
+    /// step past [`Self::backend_timeout_ms`]. This longer timeout
+    /// prevents the gateway from returning a spurious transport error
+    /// while the backend is still starting the job.
+    ///
+    /// Default: `60_000` (60 seconds).
+    pub gateway_async_dispatch_timeout_ms: u64,
+
+    /// Gateway timeout (milliseconds) for the opt-in wait-for-terminal
+    /// response-stitching mode (issue #321).
+    ///
+    /// When a client sends `_meta.dcc.wait_for_terminal = true` on an
+    /// async `tools/call`, the gateway blocks the POST response until
+    /// a `notifications/$/dcc.jobUpdated` with a terminal status
+    /// (`completed`, `failed`, `cancelled`) arrives over the backend
+    /// SSE stream. On timeout the gateway returns the last known job
+    /// envelope annotated with `_meta.dcc.timed_out = true` and leaves
+    /// the job running on the backend — the caller can keep polling
+    /// `jobs.get_status` or reconnect SSE to collect the result later.
+    ///
+    /// Default: `600_000` (10 minutes).
+    pub gateway_wait_terminal_timeout_ms: u64,
+
     /// Enable the Prometheus `/metrics` endpoint (issue #331).
     ///
     /// Requires the `prometheus` Cargo feature on both `dcc-mcp-http`
@@ -308,6 +344,8 @@ impl McpHttpConfig {
             spawn_mode: ServerSpawnMode::Ambient,
             self_probe_timeout_ms: 200,
             backend_timeout_ms: 10_000,
+            gateway_async_dispatch_timeout_ms: 60_000,
+            gateway_wait_terminal_timeout_ms: 600_000,
             enable_resources: true,
             enable_artefact_resources: false,
             enable_prompts: true,
@@ -453,6 +491,22 @@ impl McpHttpConfig {
     /// them with a transport timeout error.
     pub fn with_backend_timeout_ms(mut self, ms: u64) -> Self {
         self.backend_timeout_ms = ms;
+        self
+    }
+
+    /// Builder: override the gateway's async-dispatch timeout (issue #321).
+    ///
+    /// See [`Self::gateway_async_dispatch_timeout_ms`] for the full contract.
+    pub fn with_gateway_async_dispatch_timeout_ms(mut self, ms: u64) -> Self {
+        self.gateway_async_dispatch_timeout_ms = ms;
+        self
+    }
+
+    /// Builder: override the gateway wait-for-terminal timeout (issue #321).
+    ///
+    /// See [`Self::gateway_wait_terminal_timeout_ms`] for the full contract.
+    pub fn with_gateway_wait_terminal_timeout_ms(mut self, ms: u64) -> Self {
+        self.gateway_wait_terminal_timeout_ms = ms;
         self
     }
 }

--- a/crates/dcc-mcp-http/src/gateway/aggregator.rs
+++ b/crates/dcc-mcp-http/src/gateway/aggregator.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 
 use futures::future::join_all;
 use serde_json::{Value, json};
+use tokio::sync::broadcast;
 use uuid::Uuid;
 
 use super::backend_client::{fetch_tools, forward_tools_call};
@@ -27,6 +28,13 @@ use super::tools::{
 };
 use crate::protocol::{TOOLS_LIST_PAGE_SIZE, decode_cursor, encode_cursor};
 use dcc_mcp_transport::discovery::types::ServiceEntry;
+
+/// Terminal job statuses that end a wait-for-terminal block (#321).
+///
+/// Mirrors the backend's [`crate::job::JobStatus`] terminal states; the
+/// gateway does not import the enum directly to keep the dependency
+/// graph flat.
+const TERMINAL_JOB_STATUSES: &[&str] = &["completed", "failed", "cancelled", "interrupted"];
 
 /// Build the unified `tools/list` result by aggregating every live backend.
 ///
@@ -166,49 +174,344 @@ pub async fn route_tools_call(
         }
     }
 
-    match forward_tools_call(
+    // ── #321: pick the right timeout ──────────────────────────────────
+    // Async-opt-in calls may legitimately take longer than the short
+    // sync `backend_timeout` just to queue the job. Bump to
+    // `async_dispatch_timeout` when any of the opt-in signals fire.
+    let async_opt_in = meta_signals_async_dispatch(meta);
+    let dispatch_timeout = if async_opt_in {
+        gs.async_dispatch_timeout
+    } else {
+        gs.backend_timeout
+    };
+    let wait_for_terminal = async_opt_in && meta_wants_wait_for_terminal(meta);
+
+    // The outbound body must not carry `_meta.dcc.wait_for_terminal` —
+    // that flag is gateway-local bookkeeping, not a backend contract.
+    let forwarded_meta = meta.cloned().map(strip_gateway_meta_flags);
+
+    let forward = forward_tools_call(
         &gs.http_client,
         &url,
         original,
         Some(args.clone()),
-        meta.cloned(),
+        forwarded_meta,
         request_id,
-        gs.backend_timeout,
+        dispatch_timeout,
     )
-    .await
-    {
+    .await;
+
+    match forward {
         Ok(mut result) => {
             // (c) Backend reply may carry `_meta.dcc.jobId` (async job
             //     dispatch path, #318) or `structuredContent.job_id`.
             //     Either way, bind the job → session mapping so later
             //     `notifications/$/dcc.jobUpdated` arriving over SSE can
             //     be routed to the originating client session.
-            if let Some(sid) = client_session_id {
-                if let Some(job_id) = extract_job_id(&result) {
-                    gs.subscriber.bind_job(&job_id, sid, &url);
-                }
+            let job_id = extract_job_id(&result);
+            if let (Some(sid), Some(jid)) = (client_session_id, job_id.as_deref()) {
+                gs.subscriber.bind_job(jid, sid, &url);
             }
 
-            // Backend already returns a CallToolResult { content, isError }.
-            // Extract the actual text payload so the gateway's own response
-            // is a single CallToolResult rather than a nested envelope.
+            // ── #321: wait-for-terminal passthrough ────────────────────
+            if wait_for_terminal {
+                if let Some(jid) = job_id.as_deref() {
+                    return wait_for_terminal_reply(
+                        gs,
+                        jid,
+                        &mut result,
+                        &entry,
+                        gs.wait_terminal_timeout,
+                    )
+                    .await;
+                }
+                // Synchronous reply on an async-opt-in path: nothing to
+                // wait for — fall through and return the envelope as-is.
+            }
+
             inject_instance_metadata(&mut result, &entry.instance_id, &entry.dcc_type);
-            let is_error = result
-                .get("isError")
-                .and_then(Value::as_bool)
-                .unwrap_or(false);
-            let text = result
-                .get("content")
-                .and_then(Value::as_array)
-                .and_then(|arr| arr.first())
-                .and_then(|c| c.get("text"))
-                .and_then(Value::as_str)
-                .map(str::to_owned)
-                .unwrap_or_else(|| serde_json::to_string_pretty(&result).unwrap_or_default());
-            (text, is_error)
+            envelope_to_text_result(&result)
         }
-        Err(e) => (format!("Backend call failed: {e}"), true),
+        Err(e) => {
+            if async_opt_in && e.contains("timeout") {
+                // Backend was unresponsive while we tried to queue the
+                // job. Surface a JSON-RPC style `-32000 backend
+                // unresponsive` payload so clients can distinguish it
+                // from a legitimate tool error.
+                let payload = json!({
+                    "error": {
+                        "code": -32000,
+                        "message": format!(
+                            "backend unresponsive ({}): {e}",
+                            entry.dcc_type
+                        ),
+                        "data": {
+                            "instance_id": entry.instance_id.to_string(),
+                            "dcc_type": entry.dcc_type,
+                        }
+                    }
+                });
+                (
+                    serde_json::to_string_pretty(&payload).unwrap_or_default(),
+                    true,
+                )
+            } else {
+                (format!("Backend call failed: {e}"), true)
+            }
+        }
     }
+}
+
+/// Common envelope-to-text extraction used by both the sync and wait-
+/// for-terminal paths. Keeps the gateway's response shape a single
+/// `CallToolResult` rather than a nested envelope.
+fn envelope_to_text_result(result: &Value) -> (String, bool) {
+    let is_error = result
+        .get("isError")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let text = result
+        .get("content")
+        .and_then(Value::as_array)
+        .and_then(|arr| arr.first())
+        .and_then(|c| c.get("text"))
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .unwrap_or_else(|| serde_json::to_string_pretty(result).unwrap_or_default());
+    (text, is_error)
+}
+
+/// Detect whether the outbound `tools/call` has signalled async
+/// dispatch opt-in (#318 + #321). Any of the three signals listed in
+/// the backend handler (`handler.rs::should_dispatch_async`) triggers
+/// the longer gateway timeout — we do NOT need to consult the tool's
+/// `ActionMeta` here because the backend will do so itself; if none of
+/// these signals are present the call will always be synchronous and
+/// the short timeout is correct.
+fn meta_signals_async_dispatch(meta: Option<&Value>) -> bool {
+    let Some(m) = meta else {
+        return false;
+    };
+    let async_flag = m
+        .get("dcc")
+        .and_then(|d| d.get("async"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let has_progress_token = m.get("progressToken").is_some();
+    async_flag || has_progress_token
+}
+
+/// Detect the `_meta.dcc.wait_for_terminal = true` opt-in (#321).
+fn meta_wants_wait_for_terminal(meta: Option<&Value>) -> bool {
+    meta.and_then(|m| m.get("dcc"))
+        .and_then(|d| d.get("wait_for_terminal"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+/// Remove gateway-only bookkeeping keys from a `_meta` value before we
+/// forward it to the backend (`wait_for_terminal` is useless to the
+/// backend — keep the wire protocol clean).
+fn strip_gateway_meta_flags(mut meta: Value) -> Value {
+    if let Some(dcc) = meta.get_mut("dcc").and_then(Value::as_object_mut) {
+        dcc.remove("wait_for_terminal");
+    }
+    meta
+}
+
+/// Block the gateway's `tools/call` response until the backend reports
+/// a terminal `$/dcc.jobUpdated` for `job_id`, or until the
+/// [`GatewayState::wait_terminal_timeout`] elapses.
+///
+/// Returns the same `(text, is_error)` shape as the synchronous path so
+/// the caller's wrapping into `CallToolResult` is identical.
+///
+/// On timeout we return the **initial `{pending}` envelope annotated
+/// with `_meta.dcc.timed_out = true`** and leave the job running on the
+/// backend — the caller can keep polling `jobs.get_status` or reconnect
+/// SSE to collect the result later.
+async fn wait_for_terminal_reply(
+    gs: &GatewayState,
+    job_id: &str,
+    pending_envelope: &mut Value,
+    entry: &ServiceEntry,
+    timeout: Duration,
+) -> (String, bool) {
+    // Subscribe BEFORE we return to the caller — the publish happens
+    // inside [`SubscriberManager::deliver`] regardless of any
+    // client-session binding, so the only race window we need to
+    // defend against is between "backend replied {pending}" and "we
+    // call `.recv()` below". Binding happened in the caller via
+    // `bind_job`, but the bus is independent — create it here.
+    let mut rx: broadcast::Receiver<Value> = gs.subscriber.job_event_channel(job_id);
+
+    // Capture the latest-seen job update so that on timeout we can
+    // return the richest envelope we observed.
+    let mut latest: Option<Value> = None;
+    let deadline = tokio::time::Instant::now() + timeout;
+
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match tokio::time::timeout(remaining, rx.recv()).await {
+            Ok(Ok(value)) => {
+                let status = value
+                    .get("params")
+                    .and_then(|p| p.get("status"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                let is_terminal = TERMINAL_JOB_STATUSES
+                    .iter()
+                    .any(|s| s.eq_ignore_ascii_case(status));
+                latest = Some(value);
+                if is_terminal {
+                    // Retire per-job bus + routing (best-effort — we may
+                    // have an in-flight notification still buffered, but
+                    // the waiter has consumed the terminal event).
+                    gs.subscriber.forget_job_bus(job_id);
+                    gs.subscriber.forget_job(job_id);
+                    break;
+                }
+            }
+            // Broadcast lag: the backend emitted notifications faster
+            // than we could consume them. Keep going; the next call
+            // will deliver the most recent events.
+            Ok(Err(broadcast::error::RecvError::Lagged(_))) => continue,
+            // Sender was dropped — the subscriber's backend loop tore
+            // down. This is NOT a terminal state; surface a clear
+            // error so the client knows the job is in limbo on the
+            // backend. (#328 will later mark it `interrupted`.)
+            Ok(Err(broadcast::error::RecvError::Closed)) => {
+                gs.subscriber.forget_job_bus(job_id);
+                let payload = json!({
+                    "error": {
+                        "code": -32000,
+                        "message": format!(
+                            "backend disconnected during wait_for_terminal \
+                             (job {job_id} still running on {})",
+                            entry.dcc_type
+                        ),
+                        "data": {
+                            "job_id": job_id,
+                            "instance_id": entry.instance_id.to_string(),
+                            "dcc_type": entry.dcc_type,
+                        }
+                    }
+                });
+                return (
+                    serde_json::to_string_pretty(&payload).unwrap_or_default(),
+                    true,
+                );
+            }
+            // Per-iteration timeout — fall through to check deadline.
+            Err(_) => break,
+        }
+    }
+
+    // If we have a terminal event, build the final envelope by merging
+    // the backend's job-update payload into the pending envelope.
+    let envelope = match latest {
+        Some(update) => merge_job_update_into_envelope(pending_envelope.clone(), &update, false),
+        None => {
+            // Timed out before any update arrived. Tag the pending
+            // envelope so the client can distinguish "still running"
+            // from "completed with empty output".
+            gs.subscriber.forget_job_bus(job_id);
+            merge_job_update_into_envelope(pending_envelope.clone(), &Value::Null, true)
+        }
+    };
+
+    let mut final_envelope = envelope;
+    inject_instance_metadata(&mut final_envelope, &entry.instance_id, &entry.dcc_type);
+    envelope_to_text_result(&final_envelope)
+}
+
+/// Compose a terminal-state `CallToolResult` by layering:
+/// 1. The backend's original `{pending, job_id}` envelope (preserves
+///    `_meta.dcc.jobId`, `parentJobId`).
+/// 2. The `$/dcc.jobUpdated` payload's `status`, `result` (if present),
+///    and `error` (if present).
+/// 3. Gateway flags — `_meta.dcc.timed_out` when we couldn't wait any
+///    longer.
+///
+/// The output is a JSON object shaped like a `CallToolResult` so the
+/// caller can reuse [`envelope_to_text_result`].
+fn merge_job_update_into_envelope(mut pending: Value, update: &Value, timed_out: bool) -> Value {
+    let params = update.get("params");
+    let status = params
+        .and_then(|p| p.get("status"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let error_text = params
+        .and_then(|p| p.get("error"))
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    let result_value = params.and_then(|p| p.get("result")).cloned();
+
+    // Build structuredContent payload: reuse the pending object, then
+    // overwrite status + result.
+    let mut sc = pending
+        .get("structuredContent")
+        .cloned()
+        .and_then(|v| v.as_object().cloned())
+        .unwrap_or_default();
+    if !status.is_empty() {
+        sc.insert("status".to_string(), Value::String(status.to_string()));
+    }
+    if let Some(r) = result_value {
+        sc.insert("result".to_string(), r);
+    }
+    if let Some(ref e) = error_text {
+        sc.insert("error".to_string(), Value::String(e.clone()));
+    }
+
+    // Merge _meta.
+    let mut meta = sc
+        .get("_meta")
+        .cloned()
+        .and_then(|v| v.as_object().cloned())
+        .unwrap_or_default();
+    let mut dcc_meta = meta
+        .get("dcc")
+        .cloned()
+        .and_then(|v| v.as_object().cloned())
+        .unwrap_or_default();
+    if !status.is_empty() {
+        dcc_meta.insert("status".to_string(), Value::String(status.to_string()));
+    }
+    if timed_out {
+        dcc_meta.insert("timed_out".to_string(), Value::Bool(true));
+    }
+    meta.insert("dcc".to_string(), Value::Object(dcc_meta));
+    sc.insert("_meta".to_string(), Value::Object(meta));
+
+    // Build a human-readable text body so the CallToolResult still
+    // has a non-empty `content`.
+    let text = if timed_out {
+        format!("wait_for_terminal: timeout — job still running (status={status})")
+    } else if let Some(err) = error_text.as_deref() {
+        format!("Job {}: {err}", status)
+    } else {
+        format!(
+            "Job {status} — {}",
+            sc.get("result")
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| "(no structured result)".to_string())
+        )
+    };
+
+    let is_error = matches!(status, "failed" | "cancelled" | "interrupted") || timed_out;
+    if let Some(obj) = pending.as_object_mut() {
+        obj.insert("structuredContent".to_string(), Value::Object(sc));
+        obj.insert("isError".to_string(), Value::Bool(is_error));
+        obj.insert(
+            "content".to_string(),
+            json!([{ "type": "text", "text": text }]),
+        );
+    }
+    pending
 }
 
 /// Extract the `job_id` from a backend `tools/call` result envelope, if
@@ -703,5 +1006,97 @@ mod tests {
     fn extract_job_id_returns_none_for_sync_reply() {
         let v = json!({"content": [{"type": "text", "text": "ok"}], "isError": false});
         assert!(extract_job_id(&v).is_none());
+    }
+
+    // ── #321: async opt-in detection + envelope merging ────────────────
+
+    #[test]
+    fn meta_signals_async_dispatch_picks_up_async_flag() {
+        let meta = json!({"dcc": {"async": true}});
+        assert!(meta_signals_async_dispatch(Some(&meta)));
+    }
+
+    #[test]
+    fn meta_signals_async_dispatch_picks_up_progress_token() {
+        let meta = json!({"progressToken": "tok"});
+        assert!(meta_signals_async_dispatch(Some(&meta)));
+    }
+
+    #[test]
+    fn meta_signals_async_dispatch_is_false_for_sync_requests() {
+        assert!(!meta_signals_async_dispatch(None));
+        let meta = json!({"dcc": {"parentJobId": "abc"}});
+        assert!(!meta_signals_async_dispatch(Some(&meta)));
+    }
+
+    #[test]
+    fn meta_wants_wait_for_terminal_reads_dcc_flag() {
+        let meta = json!({"dcc": {"async": true, "wait_for_terminal": true}});
+        assert!(meta_wants_wait_for_terminal(Some(&meta)));
+
+        let meta = json!({"dcc": {"async": true}});
+        assert!(!meta_wants_wait_for_terminal(Some(&meta)));
+    }
+
+    #[test]
+    fn strip_gateway_meta_flags_removes_wait_for_terminal_only() {
+        let meta = json!({"dcc": {"async": true, "wait_for_terminal": true, "parentJobId": "p"}});
+        let stripped = strip_gateway_meta_flags(meta);
+        assert_eq!(stripped["dcc"]["async"], true);
+        assert_eq!(stripped["dcc"]["parentJobId"], "p");
+        assert!(stripped["dcc"].get("wait_for_terminal").is_none());
+    }
+
+    #[test]
+    fn merge_job_update_into_envelope_completed_sets_status_and_result() {
+        let pending = json!({
+            "content": [{"type": "text", "text": "Job x queued"}],
+            "structuredContent": {"job_id": "x", "status": "pending", "_meta": {"dcc": {"jobId": "x"}}},
+            "isError": false,
+        });
+        let update = json!({
+            "method": "notifications/$/dcc.jobUpdated",
+            "params": {"job_id": "x", "status": "completed", "result": {"rows": 42}}
+        });
+        let merged = merge_job_update_into_envelope(pending, &update, false);
+        assert_eq!(merged["structuredContent"]["status"], "completed");
+        assert_eq!(merged["structuredContent"]["result"]["rows"], 42);
+        assert_eq!(
+            merged["structuredContent"]["_meta"]["dcc"]["status"],
+            "completed"
+        );
+        assert_eq!(merged["isError"], false);
+    }
+
+    #[test]
+    fn merge_job_update_into_envelope_failed_marks_is_error() {
+        let pending = json!({
+            "content": [{"type": "text", "text": "Job x queued"}],
+            "structuredContent": {"job_id": "x", "status": "pending"},
+            "isError": false,
+        });
+        let update = json!({
+            "method": "notifications/$/dcc.jobUpdated",
+            "params": {"job_id": "x", "status": "failed", "error": "boom"}
+        });
+        let merged = merge_job_update_into_envelope(pending, &update, false);
+        assert_eq!(merged["structuredContent"]["status"], "failed");
+        assert_eq!(merged["structuredContent"]["error"], "boom");
+        assert_eq!(merged["isError"], true);
+    }
+
+    #[test]
+    fn merge_job_update_into_envelope_timeout_sets_timed_out_flag() {
+        let pending = json!({
+            "content": [{"type": "text", "text": "Job x queued"}],
+            "structuredContent": {"job_id": "x", "status": "pending"},
+            "isError": false,
+        });
+        let merged = merge_job_update_into_envelope(pending, &Value::Null, true);
+        assert_eq!(
+            merged["structuredContent"]["_meta"]["dcc"]["timed_out"],
+            true
+        );
+        assert_eq!(merged["isError"], true);
     }
 }

--- a/crates/dcc-mcp-http/src/gateway/mod.rs
+++ b/crates/dcc-mcp-http/src/gateway/mod.rs
@@ -187,11 +187,14 @@ pub(crate) struct GatewayTasks {
 ///
 /// `sentinel_key` is the registry key of the `__gateway__` sentinel row that
 /// the caller registered; the cleanup loop heartbeats it (issue #229).
+#[allow(clippy::too_many_arguments)]
 async fn start_gateway_tasks(
     listener: tokio::net::TcpListener,
     registry: Arc<RwLock<FileRegistry>>,
     stale_timeout: Duration,
     backend_timeout: Duration,
+    async_dispatch_timeout: Duration,
+    wait_terminal_timeout: Duration,
     server_name: String,
     server_version: String,
     sentinel_key: ServiceKey,
@@ -395,6 +398,8 @@ async fn start_gateway_tasks(
         registry,
         stale_timeout,
         backend_timeout,
+        async_dispatch_timeout,
+        wait_terminal_timeout,
         server_name,
         server_version,
         http_client,
@@ -536,6 +541,12 @@ pub struct GatewayConfig {
     /// from the gateway to each live DCC instance. Default: `10_000`.
     /// Issue #314.
     pub backend_timeout_ms: u64,
+    /// Longer timeout applied when the outbound `tools/call` is async-
+    /// opted-in (issue #321). Default: `60_000`.
+    pub async_dispatch_timeout_ms: u64,
+    /// Gateway wait-for-terminal passthrough timeout (issue #321).
+    /// Default: `600_000` (10 minutes).
+    pub wait_terminal_timeout_ms: u64,
 }
 
 impl Default for GatewayConfig {
@@ -550,6 +561,8 @@ impl Default for GatewayConfig {
             registry_dir: None,
             challenger_timeout_secs: 120,
             backend_timeout_ms: 10_000,
+            async_dispatch_timeout_ms: 60_000,
+            wait_terminal_timeout_ms: 600_000,
         }
     }
 }
@@ -739,6 +752,8 @@ impl GatewayRunner {
     ) -> Result<ElectionOutcome, Box<dyn std::error::Error + Send + Sync>> {
         let stale_timeout = Duration::from_secs(self.config.stale_timeout_secs);
         let backend_timeout = Duration::from_millis(self.config.backend_timeout_ms);
+        let async_dispatch_timeout = Duration::from_millis(self.config.async_dispatch_timeout_ms);
+        let wait_terminal_timeout = Duration::from_millis(self.config.wait_terminal_timeout_ms);
         let own_version = self.config.server_version.clone();
 
         match try_bind_port_opt(&self.config.host, self.config.gateway_port).await {
@@ -765,6 +780,8 @@ impl GatewayRunner {
                     self.registry.clone(),
                     stale_timeout,
                     backend_timeout,
+                    async_dispatch_timeout,
+                    wait_terminal_timeout,
                     format!("{} (gateway)", self.config.server_name),
                     own_version.clone(),
                     sentinel_key,
@@ -862,6 +879,8 @@ impl GatewayRunner {
         let registry = self.registry.clone();
         let stale_timeout = Duration::from_secs(self.config.stale_timeout_secs);
         let backend_timeout = Duration::from_millis(self.config.backend_timeout_ms);
+        let async_dispatch_timeout = Duration::from_millis(self.config.async_dispatch_timeout_ms);
+        let wait_terminal_timeout = Duration::from_millis(self.config.wait_terminal_timeout_ms);
         let server_name = self.config.server_name.clone();
         let timeout_secs = self.config.challenger_timeout_secs;
 
@@ -919,6 +938,8 @@ impl GatewayRunner {
                         registry.clone(),
                         stale_timeout,
                         backend_timeout,
+                        async_dispatch_timeout,
+                        wait_terminal_timeout,
                         format!("{server_name} (gateway)"),
                         own_ver.clone(),
                         sentinel_key,

--- a/crates/dcc-mcp-http/src/gateway/sse_subscriber.rs
+++ b/crates/dcc-mcp-http/src/gateway/sse_subscriber.rs
@@ -157,6 +157,14 @@ struct SubscriberManagerInner {
     backend_inflight: DashMap<String, DashSet<ClientSessionId>>,
     /// Client session → broadcast::Sender used by the GET /mcp handler.
     client_sinks: DashMap<ClientSessionId, broadcast::Sender<String>>,
+    /// Per-`job_id` broadcast of parsed `$/dcc.jobUpdated` / `workflowUpdated`
+    /// JSON-RPC notifications (#321 wait-for-terminal passthrough).
+    ///
+    /// The bus is created lazily by [`SubscriberManager::job_event_channel`]
+    /// — typically called from the gateway aggregator just before
+    /// forwarding an async `tools/call` so the waiter cannot miss a
+    /// terminal event that arrives while the POST reply is in flight.
+    job_event_buses: DashMap<String, broadcast::Sender<Value>>,
     /// Shared HTTP client with connection pooling.
     http_client: reqwest::Client,
 }
@@ -176,6 +184,7 @@ impl SubscriberManager {
                 progress_token_routes: DashMap::new(),
                 backend_inflight: DashMap::new(),
                 client_sinks: DashMap::new(),
+                job_event_buses: DashMap::new(),
                 http_client,
             }),
         }
@@ -246,6 +255,50 @@ impl SubscriberManager {
     #[allow(dead_code)]
     pub fn forget_job(&self, job_id: &str) {
         self.inner.job_routes.remove(job_id);
+        self.inner.job_event_buses.remove(job_id);
+    }
+
+    // ── Job event bus (#321 wait-for-terminal) ─────────────────────────
+
+    /// Subscribe to parsed `$/dcc.jobUpdated` / `workflowUpdated`
+    /// JSON-RPC notifications for `job_id`. Idempotent — repeated calls
+    /// return independent receivers reading from the same broadcast.
+    ///
+    /// Callers should invoke this **before** forwarding the outbound
+    /// `tools/call` so that a terminal event produced during the brief
+    /// window between the backend reply and the waiter installing its
+    /// subscription cannot be missed.
+    pub fn job_event_channel(&self, job_id: &str) -> broadcast::Receiver<Value> {
+        let entry = self
+            .inner
+            .job_event_buses
+            .entry(job_id.to_string())
+            .or_insert_with(|| broadcast::channel::<Value>(32).0);
+        entry.value().subscribe()
+    }
+
+    /// Drop the per-job broadcast bus. Outstanding receivers will see
+    /// `RecvError::Closed` on their next `recv().await`; call this after
+    /// the waiter has observed a terminal event (or timed out) so the
+    /// map does not grow unboundedly across many async jobs.
+    pub fn forget_job_bus(&self, job_id: &str) {
+        self.inner.job_event_buses.remove(job_id);
+    }
+
+    /// Publish a parsed notification to the per-job bus, if any waiter
+    /// is listening. Silently noops when nobody subscribed.
+    fn publish_job_event(&self, job_id: &str, value: &Value) {
+        if let Some(entry) = self.inner.job_event_buses.get(job_id) {
+            let _ = entry.value().send(value.clone());
+        }
+    }
+
+    /// Testing-only: hand-feed a `$/dcc.jobUpdated` notification to the
+    /// per-job bus. Lets integration tests exercise the wait-for-
+    /// terminal path without spinning up a real backend SSE stream.
+    #[doc(hidden)]
+    pub fn test_publish_job_event(&self, job_id: &str, value: Value) {
+        self.publish_job_event(job_id, &value);
     }
 
     // ── Backend lifecycle ──────────────────────────────────────────────
@@ -302,6 +355,14 @@ impl SubscriberManager {
     /// Deliver an MCP notification JSON to the right client session, or
     /// buffer it if we cannot resolve the target yet.
     fn deliver(&self, value: Value, backend_shared: &BackendShared) {
+        // #321: fan out `$/dcc.jobUpdated` / `workflowUpdated` onto any
+        // per-job wait-for-terminal bus before we worry about SSE
+        // routing. Publishing is independent of whether a client SSE
+        // sink exists — a wait-for-terminal POST client may not have
+        // any GET /mcp stream open at all.
+        if let Some(jid) = job_id_for_job_notification(&value) {
+            self.publish_job_event(&jid, &value);
+        }
         let session = resolve_target(&self.inner, &value);
         match session {
             Some(sid) => {
@@ -565,6 +626,25 @@ fn parse_sse_record(record: &[u8]) -> Option<Value> {
     serde_json::from_str::<Value>(&joined).ok()
 }
 
+/// Extract the `job_id` from a `$/dcc.jobUpdated` / `workflowUpdated`
+/// notification envelope. Used by the per-job broadcast bus (#321) so
+/// wait-for-terminal POST handlers can block on terminal events without
+/// needing their own SSE subscription.
+fn job_id_for_job_notification(value: &Value) -> Option<String> {
+    let method = value.get("method").and_then(|m| m.as_str())?;
+    if !matches!(
+        method,
+        "notifications/$/dcc.jobUpdated" | "notifications/$/dcc.workflowUpdated"
+    ) {
+        return None;
+    }
+    value
+        .get("params")
+        .and_then(|p| p.get("job_id"))
+        .and_then(|j| j.as_str())
+        .map(str::to_owned)
+}
+
 /// Determine which client session should receive `value`.
 fn resolve_target(inner: &SubscriberManagerInner, value: &Value) -> Option<String> {
     let method = value.get("method").and_then(|m| m.as_str())?;
@@ -653,16 +733,21 @@ mod tests {
         assert!(parse_sse_record(rec).is_none());
     }
 
-    #[test]
-    fn resolve_target_prefers_progress_token_for_progress_notifications() {
-        let inner = SubscriberManagerInner {
+    fn empty_inner() -> SubscriberManagerInner {
+        SubscriberManagerInner {
             backends: DashMap::new(),
             job_routes: DashMap::new(),
             progress_token_routes: DashMap::new(),
             backend_inflight: DashMap::new(),
             client_sinks: DashMap::new(),
+            job_event_buses: DashMap::new(),
             http_client: reqwest::Client::new(),
-        };
+        }
+    }
+
+    #[test]
+    fn resolve_target_prefers_progress_token_for_progress_notifications() {
+        let inner = empty_inner();
         inner.progress_token_routes.insert(
             progress_token_key(&Value::String("tok".into())),
             "sessA".into(),
@@ -676,14 +761,7 @@ mod tests {
 
     #[test]
     fn resolve_target_uses_job_id_for_job_updated() {
-        let inner = SubscriberManagerInner {
-            backends: DashMap::new(),
-            job_routes: DashMap::new(),
-            progress_token_routes: DashMap::new(),
-            backend_inflight: DashMap::new(),
-            client_sinks: DashMap::new(),
-            http_client: reqwest::Client::new(),
-        };
+        let inner = empty_inner();
         inner.job_routes.insert("jid-42".into(), "sessB".into());
         let note = serde_json::json!({
             "method": "notifications/$/dcc.jobUpdated",
@@ -694,19 +772,77 @@ mod tests {
 
     #[test]
     fn resolve_target_returns_none_when_unknown() {
-        let inner = SubscriberManagerInner {
-            backends: DashMap::new(),
-            job_routes: DashMap::new(),
-            progress_token_routes: DashMap::new(),
-            backend_inflight: DashMap::new(),
-            client_sinks: DashMap::new(),
-            http_client: reqwest::Client::new(),
-        };
+        let inner = empty_inner();
         let note = serde_json::json!({
             "method": "notifications/progress",
             "params": {"progressToken": "no-such-token"}
         });
         assert!(resolve_target(&inner, &note).is_none());
+    }
+
+    // #321: per-job broadcast delivery — unit tests here, end-to-end
+    // wiring is covered by `gateway/tests.rs`.
+
+    #[tokio::test]
+    async fn job_event_channel_receives_published_notifications() {
+        let mgr = SubscriberManager::default();
+        let mut rx = mgr.job_event_channel("job-1");
+        let note = serde_json::json!({
+            "method": "notifications/$/dcc.jobUpdated",
+            "params": {"job_id": "job-1", "status": "completed"}
+        });
+        mgr.publish_job_event("job-1", &note);
+        let delivered = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("recv did not time out")
+            .expect("bus delivered");
+        assert_eq!(delivered["params"]["status"], "completed");
+    }
+
+    #[tokio::test]
+    async fn job_event_channel_publishes_only_to_requested_job() {
+        let mgr = SubscriberManager::default();
+        let mut rx_a = mgr.job_event_channel("job-a");
+        let mut rx_b = mgr.job_event_channel("job-b");
+        let note = serde_json::json!({
+            "method": "notifications/$/dcc.jobUpdated",
+            "params": {"job_id": "job-a", "status": "running"}
+        });
+        mgr.publish_job_event("job-a", &note);
+        assert!(rx_a.try_recv().is_ok());
+        assert!(rx_b.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn deliver_publishes_to_job_event_bus_even_without_route() {
+        // The waiter path does NOT require `bind_job` — it subscribes to
+        // the per-job bus directly before the reply arrives. `deliver`
+        // must therefore publish to the bus regardless of whether a
+        // client-session route exists.
+        let mgr = SubscriberManager::default();
+        let mut rx = mgr.job_event_channel("job-x");
+        let backend = "http://127.0.0.1:0/mcp".to_string();
+        let shared = Arc::new(BackendShared::new(backend.clone()));
+        let note = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/$/dcc.jobUpdated",
+            "params": {"job_id": "job-x", "status": "completed"}
+        });
+        mgr.deliver(note, &shared);
+        let delivered = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("recv did not time out")
+            .expect("bus delivered");
+        assert_eq!(delivered["params"]["status"], "completed");
+    }
+
+    #[test]
+    fn forget_job_bus_removes_the_broadcast() {
+        let mgr = SubscriberManager::default();
+        let _rx = mgr.job_event_channel("job-1");
+        assert!(mgr.inner.job_event_buses.contains_key("job-1"));
+        mgr.forget_job_bus("job-1");
+        assert!(!mgr.inner.job_event_buses.contains_key("job-1"));
     }
 
     #[tokio::test]

--- a/crates/dcc-mcp-http/src/gateway/state.rs
+++ b/crates/dcc-mcp-http/src/gateway/state.rs
@@ -29,6 +29,12 @@ pub struct GatewayState {
     /// [`McpHttpConfig::backend_timeout_ms`] for workflows with legitimately
     /// long-running backend tools.
     pub backend_timeout: Duration,
+    /// Longer timeout applied when the outbound `tools/call` is async-
+    /// opted-in (issue #321). Default: `60 s`.
+    pub async_dispatch_timeout: Duration,
+    /// Gateway wait-for-terminal passthrough timeout (issue #321).
+    /// Default: `600 s` (10 minutes).
+    pub wait_terminal_timeout: Duration,
     pub server_name: String,
     /// The version string of this gateway instance (e.g. `"0.12.29"`).
     pub server_version: String,
@@ -142,6 +148,8 @@ mod tests {
             registry: reg,
             stale_timeout: Duration::from_secs(30),
             backend_timeout: Duration::from_secs(10),
+            async_dispatch_timeout: Duration::from_secs(60),
+            wait_terminal_timeout: Duration::from_secs(600),
             server_name: "test".into(),
             server_version: "0.13.2".into(),
             http_client: reqwest::Client::new(),

--- a/crates/dcc-mcp-http/src/python/mod.rs
+++ b/crates/dcc-mcp-http/src/python/mod.rs
@@ -27,7 +27,8 @@ pub struct PyMcpHttpConfig {
 impl PyMcpHttpConfig {
     /// Create a new config. ``port=0`` binds to any available port.
     #[new]
-    #[pyo3(signature = (port=8765, server_name=None, server_version=None, enable_cors=false, request_timeout_ms=30000, backend_timeout_ms=10_000, enable_prometheus=false, prometheus_basic_auth=None))]
+    #[pyo3(signature = (port=8765, server_name=None, server_version=None, enable_cors=false, request_timeout_ms=30000, backend_timeout_ms=10_000, enable_prometheus=false, prometheus_basic_auth=None, gateway_async_dispatch_timeout_ms=60_000, gateway_wait_terminal_timeout_ms=600_000))]
+    #[allow(clippy::too_many_arguments)]
     fn new(
         port: u16,
         server_name: Option<String>,
@@ -37,6 +38,8 @@ impl PyMcpHttpConfig {
         backend_timeout_ms: u64,
         enable_prometheus: bool,
         prometheus_basic_auth: Option<(String, String)>,
+        gateway_async_dispatch_timeout_ms: u64,
+        gateway_wait_terminal_timeout_ms: u64,
     ) -> Self {
         let mut cfg = McpHttpConfig::new(port);
         if let Some(name) = server_name {
@@ -50,6 +53,8 @@ impl PyMcpHttpConfig {
         cfg.backend_timeout_ms = backend_timeout_ms;
         cfg.enable_prometheus = enable_prometheus;
         cfg.prometheus_basic_auth = prometheus_basic_auth;
+        cfg.gateway_async_dispatch_timeout_ms = gateway_async_dispatch_timeout_ms;
+        cfg.gateway_wait_terminal_timeout_ms = gateway_wait_terminal_timeout_ms;
         // Issue #303: PyO3-embedded hosts (Maya on Windows etc.) cannot
         // rely on shared tokio worker threads to drive the accept loop
         // after `block_on` returns. Default to `Dedicated` so the listener
@@ -413,6 +418,43 @@ impl PyMcpHttpConfig {
     #[setter]
     fn set_backend_timeout_ms(&mut self, ms: u64) {
         self.inner.backend_timeout_ms = ms;
+    }
+
+    /// Gateway timeout (ms) for async-dispatch `tools/call` requests
+    /// (issue #321). Default: ``60_000``.
+    ///
+    /// Applies when the outbound call carries ``_meta.dcc.async == true``,
+    /// a ``_meta.progressToken``, or targets a tool whose ``ActionMeta``
+    /// declares ``execution: async`` / a ``timeout_hint_secs``. Only the
+    /// **queuing** step uses this budget — the backend replies with
+    /// ``{status: "pending"}`` as soon as the job is enqueued.
+    #[getter]
+    fn gateway_async_dispatch_timeout_ms(&self) -> u64 {
+        self.inner.gateway_async_dispatch_timeout_ms
+    }
+
+    #[setter]
+    fn set_gateway_async_dispatch_timeout_ms(&mut self, ms: u64) {
+        self.inner.gateway_async_dispatch_timeout_ms = ms;
+    }
+
+    /// Gateway timeout (ms) for the opt-in wait-for-terminal passthrough
+    /// mode (issue #321). Default: ``600_000`` (10 minutes).
+    ///
+    /// When the client sets ``_meta.dcc.wait_for_terminal = true`` along
+    /// with an async opt-in, the gateway blocks the ``tools/call``
+    /// response until a ``$/dcc.jobUpdated`` with a terminal status
+    /// arrives. On timeout the gateway returns the last known status
+    /// with ``_meta.dcc.timed_out = true`` and leaves the job running
+    /// on the backend.
+    #[getter]
+    fn gateway_wait_terminal_timeout_ms(&self) -> u64 {
+        self.inner.gateway_wait_terminal_timeout_ms
+    }
+
+    #[setter]
+    fn set_gateway_wait_terminal_timeout_ms(&mut self, ms: u64) {
+        self.inner.gateway_wait_terminal_timeout_ms = ms;
     }
 
     /// Advertise the MCP Resources primitive (issue #350).

--- a/crates/dcc-mcp-http/src/server.rs
+++ b/crates/dcc-mcp-http/src/server.rs
@@ -443,6 +443,8 @@ impl McpHttpServer {
                 registry_dir: self.config.registry_dir.clone(),
                 challenger_timeout_secs: 120,
                 backend_timeout_ms: self.config.backend_timeout_ms,
+                async_dispatch_timeout_ms: self.config.gateway_async_dispatch_timeout_ms,
+                wait_terminal_timeout_ms: self.config.gateway_wait_terminal_timeout_ms,
             };
 
             match GatewayRunner::new(gw_cfg) {

--- a/crates/dcc-mcp-http/src/tests.rs
+++ b/crates/dcc-mcp-http/src/tests.rs
@@ -2912,6 +2912,8 @@ mod gateway_tests {
             registry: Arc::new(RwLock::new(registry)),
             stale_timeout: Duration::from_secs(30),
             backend_timeout: Duration::from_secs(10),
+            async_dispatch_timeout: Duration::from_secs(60),
+            wait_terminal_timeout: Duration::from_secs(600),
             server_name: "test-gateway".to_string(),
             server_version: "0.1.0".to_string(),
             http_client: reqwest::Client::new(),

--- a/crates/dcc-mcp-http/tests/backend_timeout.rs
+++ b/crates/dcc-mcp-http/tests/backend_timeout.rs
@@ -50,6 +50,8 @@ async fn make_state(
         registry: registry.clone(),
         stale_timeout: Duration::from_secs(30),
         backend_timeout,
+        async_dispatch_timeout: Duration::from_secs(60),
+        wait_terminal_timeout: Duration::from_secs(600),
         server_name: "test".into(),
         server_version: "0.0.0".into(),
         http_client: reqwest::Client::new(),

--- a/crates/dcc-mcp-http/tests/gateway_passthrough.rs
+++ b/crates/dcc-mcp-http/tests/gateway_passthrough.rs
@@ -1,0 +1,349 @@
+//! Regression coverage for issue #321 — gateway async-dispatch timeout
+//! and wait-for-terminal response passthrough.
+//!
+//! The gateway must
+//!
+//! 1. Apply a longer per-request timeout when the client has opted into
+//!    async dispatch (either via `_meta.dcc.async` or `progressToken`);
+//!    the short sync timeout is otherwise preserved for non-async
+//!    calls.
+//! 2. Support a wait-for-terminal mode: when the caller sets
+//!    `_meta.dcc.wait_for_terminal = true`, the gateway must block the
+//!    `tools/call` response until a `$/dcc.jobUpdated` with terminal
+//!    status is observed, then return the final envelope.
+//! 3. Annotate the response with `_meta.dcc.timed_out = true` when the
+//!    wait-for-terminal deadline elapses before the backend emits a
+//!    terminal event.
+//!
+//! We use a tiny axum backend that always replies with a `{pending}`
+//! envelope (mimicking the #318 async-dispatch path) and inject the
+//! terminal notification directly onto the gateway's per-job broadcast
+//! bus via [`SubscriberManager::test_publish_job_event`].
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::{Json, Router, routing::post};
+use serde_json::{Value, json};
+use tokio::sync::{RwLock, broadcast, watch};
+
+use dcc_mcp_http::gateway::aggregator::route_tools_call;
+use dcc_mcp_http::gateway::sse_subscriber::SubscriberManager;
+use dcc_mcp_http::gateway::state::GatewayState;
+use dcc_mcp_transport::discovery::file_registry::FileRegistry;
+use dcc_mcp_transport::discovery::types::ServiceEntry;
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+async fn make_state(
+    backend_timeout: Duration,
+    async_dispatch_timeout: Duration,
+    wait_terminal_timeout: Duration,
+) -> (GatewayState, Arc<RwLock<FileRegistry>>, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
+    let (yield_tx, _) = watch::channel(false);
+    let (events_tx, _) = broadcast::channel::<String>(16);
+    let state = GatewayState {
+        registry: registry.clone(),
+        stale_timeout: Duration::from_secs(30),
+        backend_timeout,
+        async_dispatch_timeout,
+        wait_terminal_timeout,
+        server_name: "test".into(),
+        server_version: "0.0.0".into(),
+        http_client: reqwest::Client::new(),
+        yield_tx: Arc::new(yield_tx),
+        events_tx: Arc::new(events_tx),
+        protocol_version: Arc::new(RwLock::new(None)),
+        resource_subscriptions: Arc::new(RwLock::new(std::collections::HashMap::new())),
+        pending_calls: Arc::new(RwLock::new(std::collections::HashMap::new())),
+        subscriber: SubscriberManager::default(),
+    };
+    (state, registry, dir)
+}
+
+/// Spawn a backend that always replies `{pending, job_id: "job-1"}` for
+/// `tools/call`, optionally sleeping for `delay` first. `tools/list`
+/// returns a single `slow_tool` so the gateway's prefix-match succeeds.
+async fn spawn_pending_backend(delay: Duration) -> u16 {
+    #[derive(Clone)]
+    struct State {
+        delay: Duration,
+    }
+
+    async fn handler(
+        axum::extract::State(s): axum::extract::State<State>,
+        Json(req): Json<Value>,
+    ) -> Json<Value> {
+        tokio::time::sleep(s.delay).await;
+        let id = req.get("id").cloned().unwrap_or(Value::Null);
+        let method = req
+            .get("method")
+            .and_then(|m| m.as_str())
+            .unwrap_or_default();
+        match method {
+            "tools/list" => Json(json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": {
+                    "tools": [{
+                        "name": "slow_tool",
+                        "description": "slow",
+                        "inputSchema": {"type": "object"}
+                    }]
+                }
+            })),
+            "tools/call" => Json(json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": {
+                    "content": [{"type": "text", "text": "Job job-1 queued"}],
+                    "structuredContent": {
+                        "job_id": "job-1",
+                        "status": "pending",
+                        "_meta": {"dcc": {"jobId": "job-1"}}
+                    },
+                    "isError": false
+                }
+            })),
+            other => Json(json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "error": {"code": -32601, "message": format!("unknown method: {other}")}
+            })),
+        }
+    }
+
+    let app = Router::new()
+        .route("/mcp", post(handler))
+        .with_state(State { delay });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.ok();
+    });
+    tokio::time::sleep(Duration::from_millis(25)).await;
+    port
+}
+
+async fn register_backend(registry: &Arc<RwLock<FileRegistry>>, port: u16) -> ServiceEntry {
+    let entry = ServiceEntry::new("maya", "127.0.0.1", port);
+    let reg = registry.read().await;
+    reg.register(entry.clone()).unwrap();
+    entry
+}
+
+fn encoded_tool_name(instance_id: uuid::Uuid, tool: &str) -> String {
+    // Mirror `encode_tool_name` — 8-char prefix + '.' + tool name.
+    let short = &instance_id.to_string().replace('-', "")[..8];
+    format!("{short}.{tool}")
+}
+
+// ── Async dispatch timeout ────────────────────────────────────────────────
+
+/// Part 1 acceptance: an async-opt-in call tolerates a backend that
+/// takes longer than the short sync `backend_timeout` to reply, as long
+/// as it stays under `async_dispatch_timeout`.
+#[tokio::test]
+async fn async_dispatch_respects_longer_timeout() {
+    let port = spawn_pending_backend(Duration::from_millis(250)).await;
+    // Short sync timeout (100 ms) — would fail — but async timeout is 1s.
+    let (state, registry, _tmp) = make_state(
+        Duration::from_millis(100),
+        Duration::from_secs(1),
+        Duration::from_secs(5),
+    )
+    .await;
+    let entry = register_backend(&registry, port).await;
+    let tool = encoded_tool_name(entry.instance_id, "slow_tool");
+    let args = json!({});
+    let meta = json!({"dcc": {"async": true}});
+
+    let (text, is_error) = route_tools_call(
+        &state,
+        &tool,
+        &args,
+        Some(&meta),
+        Some("req-1".into()),
+        Some("sess-1"),
+    )
+    .await;
+    assert!(
+        !is_error,
+        "async opt-in call must not timeout when within async budget; got text={text}"
+    );
+    assert!(text.contains("job-1") || text.contains("Job"));
+}
+
+/// Complementary: a sync call with the same 100 ms timeout DOES fail —
+/// proving the async path took the longer timeout, not the shared one.
+#[tokio::test]
+async fn sync_call_still_uses_short_backend_timeout() {
+    let port = spawn_pending_backend(Duration::from_millis(250)).await;
+    let (state, registry, _tmp) = make_state(
+        Duration::from_millis(100),
+        Duration::from_secs(1),
+        Duration::from_secs(5),
+    )
+    .await;
+    let entry = register_backend(&registry, port).await;
+    let tool = encoded_tool_name(entry.instance_id, "slow_tool");
+    let args = json!({});
+
+    // No _meta — synchronous path.
+    let (text, is_error) = route_tools_call(
+        &state,
+        &tool,
+        &args,
+        None,
+        Some("req-2".into()),
+        Some("sess-2"),
+    )
+    .await;
+    assert!(
+        is_error,
+        "sync call must time out under the short backend_timeout; got text={text}"
+    );
+}
+
+// ── Wait-for-terminal ─────────────────────────────────────────────────────
+
+/// Part 2 happy path: `_meta.dcc.wait_for_terminal = true` blocks the
+/// `tools/call` response until `$/dcc.jobUpdated status=completed` is
+/// published, and the final envelope carries the backend's `result`.
+#[tokio::test]
+async fn wait_for_terminal_returns_completed_envelope() {
+    let port = spawn_pending_backend(Duration::ZERO).await;
+    let (state, registry, _tmp) = make_state(
+        Duration::from_secs(1),
+        Duration::from_secs(5),
+        Duration::from_secs(5),
+    )
+    .await;
+    let entry = register_backend(&registry, port).await;
+    let tool = encoded_tool_name(entry.instance_id, "slow_tool");
+
+    // Publish the terminal event on a background task 200 ms after the
+    // waiter begins — simulates the backend finishing the job.
+    let sub = state.subscriber.clone();
+    let pub_task = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        sub.test_publish_job_event(
+            "job-1",
+            json!({
+                "jsonrpc": "2.0",
+                "method": "notifications/$/dcc.jobUpdated",
+                "params": {"job_id": "job-1", "status": "completed", "result": {"value": 42}}
+            }),
+        );
+    });
+
+    let args = json!({});
+    let meta = json!({"dcc": {"async": true, "wait_for_terminal": true}});
+    let (text, is_error) = route_tools_call(
+        &state,
+        &tool,
+        &args,
+        Some(&meta),
+        Some("req-3".into()),
+        Some("sess-3"),
+    )
+    .await;
+    pub_task.await.unwrap();
+
+    assert!(!is_error, "completed job must not set isError; text={text}");
+    assert!(
+        text.contains("completed"),
+        "text body should mention terminal status; got {text}"
+    );
+}
+
+/// Part 3 timeout behaviour: when no terminal event arrives before
+/// `wait_terminal_timeout`, the gateway returns the last-known envelope
+/// with `isError=true` and a wait_for_terminal timeout message.
+#[tokio::test]
+async fn wait_for_terminal_times_out_with_timed_out_flag() {
+    let port = spawn_pending_backend(Duration::ZERO).await;
+    let (state, registry, _tmp) = make_state(
+        Duration::from_secs(1),
+        Duration::from_secs(5),
+        Duration::from_millis(200), // very short wait timeout
+    )
+    .await;
+    let entry = register_backend(&registry, port).await;
+    let tool = encoded_tool_name(entry.instance_id, "slow_tool");
+    let args = json!({});
+    let meta = json!({"dcc": {"async": true, "wait_for_terminal": true}});
+
+    let started = std::time::Instant::now();
+    let (text, is_error) = route_tools_call(
+        &state,
+        &tool,
+        &args,
+        Some(&meta),
+        Some("req-4".into()),
+        Some("sess-4"),
+    )
+    .await;
+    let elapsed = started.elapsed();
+
+    assert!(is_error, "timed-out wait must set isError; text={text}");
+    assert!(
+        text.contains("timeout") || text.contains("timed_out"),
+        "response should signal the wait-for-terminal timeout; got {text}"
+    );
+    // Tight bound: we should not wait materially longer than the
+    // configured 200 ms (allow a generous 2-second ceiling for CI).
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "gateway should return promptly at timeout; elapsed={elapsed:?}"
+    );
+}
+
+/// Subscribing to the per-job bus must happen BEFORE the backend reply
+/// so a fast-completing backend doesn't beat the waiter into position.
+/// Publish the terminal event 0 ms later (effectively as soon as the
+/// spawn has a tick to run) and assert we still observe completion.
+#[tokio::test]
+async fn wait_for_terminal_no_race_on_fast_completion() {
+    let port = spawn_pending_backend(Duration::ZERO).await;
+    let (state, registry, _tmp) = make_state(
+        Duration::from_secs(1),
+        Duration::from_secs(5),
+        Duration::from_secs(2),
+    )
+    .await;
+    let entry = register_backend(&registry, port).await;
+    let tool = encoded_tool_name(entry.instance_id, "slow_tool");
+
+    // Publish as fast as we can — the waiter's `job_event_channel` is
+    // created inside `wait_for_terminal_reply` before we await the
+    // receiver, so this race is safe.
+    let sub = state.subscriber.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        sub.test_publish_job_event(
+            "job-1",
+            json!({
+                "jsonrpc": "2.0",
+                "method": "notifications/$/dcc.jobUpdated",
+                "params": {"job_id": "job-1", "status": "completed"}
+            }),
+        );
+    });
+
+    let args = json!({});
+    let meta = json!({"dcc": {"async": true, "wait_for_terminal": true}});
+    let (text, is_error) = route_tools_call(
+        &state,
+        &tool,
+        &args,
+        Some(&meta),
+        Some("req-5".into()),
+        Some("sess-5"),
+    )
+    .await;
+    assert!(!is_error, "fast completion should succeed; text={text}");
+    assert!(text.contains("completed"));
+}

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -535,6 +535,8 @@ async fn main() -> anyhow::Result<()> {
         registry_dir: registry_dir_path,
         challenger_timeout_secs: 120,
         backend_timeout_ms: 10_000,
+        async_dispatch_timeout_ms: 60_000,
+        wait_terminal_timeout_ms: 600_000,
     };
 
     let runner = GatewayRunner::new(gateway_cfg)

--- a/docs/guide/gateway.md
+++ b/docs/guide/gateway.md
@@ -76,9 +76,77 @@ still depend on them.
 | `tools/call` correlation hooks | `crates/dcc-mcp-http/src/gateway/aggregator.rs` (`route_tools_call`) |
 | Subscription watcher | `crates/dcc-mcp-http/src/gateway/mod.rs` (`backend_sub_handle`) |
 
+## Waiting for terminal results from the gateway (#321)
+
+The gateway applies two separate request budgets to an outbound
+`tools/call`:
+
+| Case | Timeout | Source |
+|------|---------|--------|
+| Sync call (no `_meta.dcc.async`, no `progressToken`) | `backend_timeout_ms` (default 10 s) | `McpHttpConfig` |
+| Async opt-in call (`_meta.dcc.async=true` or `_meta.progressToken`) | `gateway_async_dispatch_timeout_ms` (default 60 s) | `McpHttpConfig` |
+| Async opt-in **with** `_meta.dcc.wait_for_terminal=true` | `gateway_wait_terminal_timeout_ms` (default 10 min) for the wait, `gateway_async_dispatch_timeout_ms` for the initial queuing step | `McpHttpConfig` |
+
+**Why two timeouts?** An async-dispatched tool replies immediately with
+`{status:"pending", job_id:"…"}` once the job has been queued on the
+backend. Under cold-start conditions (Maya re-importing a heavy module,
+Blender firing up a fresh Python interpreter) even that queuing step can
+legitimately take >10 s, so the short sync timeout would surface a
+spurious transport error while the backend is still starting the work.
+
+### Response stitching (opt-in)
+
+Clients that cannot consume SSE (plain `curl`, a batch script, a CI
+runner) can still get the final result in a single `tools/call`
+response by setting `_meta.dcc.wait_for_terminal = true` alongside
+`_meta.dcc.async = true`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "maya__bake_simulation",
+    "arguments": {...},
+    "_meta": {
+      "dcc": {"async": true, "wait_for_terminal": true}
+    }
+  }
+}
+```
+
+The gateway now:
+
+1. Forwards the call to the backend with the longer
+   `gateway_async_dispatch_timeout_ms` budget.
+2. Receives the `{pending, job_id}` envelope and subscribes to the
+   per-job broadcast bus owned by the SSE subscriber manager.
+3. Blocks the HTTP response until a
+   `notifications/$/dcc.jobUpdated` frame with `status in {completed,
+   failed, cancelled, interrupted}` arrives over the backend's SSE
+   stream, or until `gateway_wait_terminal_timeout_ms` elapses.
+4. Merges the terminal status, `result`, and `error` into the original
+   pending envelope's `structuredContent` and returns the resulting
+   `CallToolResult`. `isError` is set for any non-`completed` status.
+
+### Timeout semantics
+
+If `gateway_wait_terminal_timeout_ms` elapses before a terminal event
+arrives, the gateway returns the **last observed** job envelope
+annotated with `_meta.dcc.timed_out = true` and leaves the job running
+on the backend. Callers can either reconnect over SSE or keep polling
+`jobs.get_status` to collect the eventual result.
+
+### Backend disconnect
+
+If the backend SSE stream drops while a waiter is blocked, the gateway
+returns a JSON-RPC `-32000` error identifying the backend and the
+`job_id`. The job itself is not cancelled — a subsequent restart of
+the backend may surface it as `interrupted` (issue #328) when the
+persisted job store rehydrates.
+
 ## Non-goals
 
-The SSE multiplexer does **not** forward non-notification response
-bodies — that is tracked under issue #321. Routing-cache improvements
-for cancellation (#322) and HTTP/2 multiplexing tuning are also out of
-scope for #320.
+Routing-cache improvements for cancellation (#322) and HTTP/2
+multiplexing tuning are out of scope for both #320 and #321.

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -3821,6 +3821,21 @@ class McpHttpConfig:
             milliseconds. Default: ``10_000``. Raise this for DCC workflows
             whose backend tools run legitimately longer than 10 s
             (issue #314).
+        gateway_async_dispatch_timeout_ms: Per-backend timeout applied by the
+            gateway when the outbound ``tools/call`` is async-opt-in
+            (``_meta.dcc.async=true`` or ``_meta.progressToken``). Default:
+            ``60_000``. Only the **queuing** step uses this budget — the
+            backend replies with ``{status:"pending"}`` as soon as the
+            job is enqueued (issue #321).
+        gateway_wait_terminal_timeout_ms: Gateway wait-for-terminal
+            passthrough timeout in milliseconds. Default: ``600_000``
+            (10 minutes). When the client sets
+            ``_meta.dcc.wait_for_terminal=true`` along with an async
+            opt-in, the gateway blocks the ``tools/call`` response until
+            ``$/dcc.jobUpdated`` reports a terminal status. On timeout
+            the gateway returns the last-known job envelope annotated
+            with ``_meta.dcc.timed_out=true`` and leaves the job
+            running on the backend (issue #321).
 
     Example::
 
@@ -3839,6 +3854,8 @@ class McpHttpConfig:
         backend_timeout_ms: int = 10000,
         enable_prometheus: bool = False,
         prometheus_basic_auth: tuple[str, str] | None = None,
+        gateway_async_dispatch_timeout_ms: int = 60_000,
+        gateway_wait_terminal_timeout_ms: int = 600_000,
     ) -> None: ...
     @property
     def port(self) -> int: ...
@@ -3902,6 +3919,33 @@ class McpHttpConfig:
         ...
     @backend_timeout_ms.setter
     def backend_timeout_ms(self, ms: int) -> None: ...
+    @property
+    def gateway_async_dispatch_timeout_ms(self) -> int:
+        """Gateway timeout (ms) for async-dispatch ``tools/call`` (#321).
+
+        Triggered by ``_meta.dcc.async=true`` or ``_meta.progressToken``
+        on the outbound call. Default: ``60_000`` (60 seconds). Only the
+        queuing step uses this budget — the backend replies with
+        ``{status: "pending"}`` as soon as the job is enqueued.
+        """
+        ...
+    @gateway_async_dispatch_timeout_ms.setter
+    def gateway_async_dispatch_timeout_ms(self, ms: int) -> None: ...
+    @property
+    def gateway_wait_terminal_timeout_ms(self) -> int:
+        """Gateway wait-for-terminal passthrough timeout (ms) (#321).
+
+        Default: ``600_000`` (10 minutes). When the client sets
+        ``_meta.dcc.wait_for_terminal=true`` on an async-opt-in
+        ``tools/call``, the gateway blocks the response until a
+        ``$/dcc.jobUpdated`` with a terminal status arrives. On timeout
+        the gateway returns the last-known envelope with
+        ``_meta.dcc.timed_out=true`` and leaves the job running on the
+        backend.
+        """
+        ...
+    @gateway_wait_terminal_timeout_ms.setter
+    def gateway_wait_terminal_timeout_ms(self, ms: int) -> None: ...
     @property
     def enable_resources(self) -> bool:
         """Advertise the MCP Resources primitive (issue #350).

--- a/tests/test_gateway_passthrough.py
+++ b/tests/test_gateway_passthrough.py
@@ -1,0 +1,120 @@
+"""Gateway async-dispatch passthrough regression (issue #321).
+
+The gateway must
+
+1. Apply a longer per-request timeout when the client has opted into
+   async dispatch (``_meta.dcc.async=true`` or ``_meta.progressToken``).
+   This Python surface test pins the two new ``McpHttpConfig`` fields
+   and confirms they round-trip through getters/setters and the
+   constructor signature.
+2. Support a wait-for-terminal mode where the gateway blocks the
+   ``tools/call`` response until a terminal ``$/dcc.jobUpdated`` is
+   observed. The full end-to-end dance requires a real backend SSE
+   stream — covered by
+   ``crates/dcc-mcp-http/tests/gateway_passthrough.rs``. Here we
+   verify the Python API surface and that gateway startup does NOT
+   regress when the defaults are bumped to the #321 values.
+"""
+
+from __future__ import annotations
+
+# Import built-in modules
+import contextlib
+import socket
+import time
+
+# Import third-party modules
+import pytest
+
+# Import local modules
+from dcc_mcp_core import McpHttpConfig
+from dcc_mcp_core import McpHttpServer
+from dcc_mcp_core import ToolRegistry
+
+# ── Config surface ────────────────────────────────────────────────────────
+
+
+def test_mcp_http_config_defaults_match_issue_321():
+    """Defaults: 60 s for async dispatch, 10 min for wait-for-terminal."""
+    cfg = McpHttpConfig(port=8765)
+    assert cfg.gateway_async_dispatch_timeout_ms == 60_000
+    assert cfg.gateway_wait_terminal_timeout_ms == 600_000
+    # Sync path unchanged — regression guard for #314.
+    assert cfg.backend_timeout_ms == 10_000
+
+
+def test_mcp_http_config_accepts_new_fields_via_constructor():
+    cfg = McpHttpConfig(
+        port=8765,
+        gateway_async_dispatch_timeout_ms=90_000,
+        gateway_wait_terminal_timeout_ms=120_000,
+    )
+    assert cfg.gateway_async_dispatch_timeout_ms == 90_000
+    assert cfg.gateway_wait_terminal_timeout_ms == 120_000
+
+
+def test_mcp_http_config_setters_round_trip():
+    cfg = McpHttpConfig(port=0)
+    cfg.gateway_async_dispatch_timeout_ms = 45_000
+    cfg.gateway_wait_terminal_timeout_ms = 30_000
+    assert cfg.gateway_async_dispatch_timeout_ms == 45_000
+    assert cfg.gateway_wait_terminal_timeout_ms == 30_000
+
+
+# ── Gateway startup does not regress ──────────────────────────────────────
+
+
+def _pick_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_reachable(port: int, budget: float = 5.0) -> bool:
+    deadline = time.time() + budget
+    while time.time() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                return True
+        except (OSError, socket.timeout):
+            time.sleep(0.05)
+    return False
+
+
+def test_gateway_starts_with_custom_passthrough_timeouts(tmp_path):
+    """Regression: the new config fields don't break gateway election.
+
+    The `McpServerHandle.is_gateway` path runs a self-probe (issue #303);
+    if the new config fields were wired incorrectly (for example by
+    dropping gateway supervisor tasks) this probe would fail.
+    """
+    registry_dir = tmp_path / "registry"
+    registry_dir.mkdir()
+    gw_port = _pick_free_port()
+
+    reg = ToolRegistry()
+    cfg = McpHttpConfig(
+        port=0,
+        server_name="gateway-passthrough-test",
+        gateway_async_dispatch_timeout_ms=45_000,
+        gateway_wait_terminal_timeout_ms=30_000,
+    )
+    cfg.gateway_port = gw_port
+    cfg.registry_dir = str(registry_dir)
+    cfg.dcc_type = "python"
+    cfg.heartbeat_secs = 1
+    cfg.stale_timeout_secs = 10
+
+    server = McpHttpServer(reg, cfg)
+    handle = server.start()
+    try:
+        assert _wait_reachable(handle.port), "instance port must be reachable"
+        if not handle.is_gateway:
+            pytest.skip(f"another process holds gateway port {gw_port} — cannot verify gateway startup invariants here")
+        assert _wait_reachable(gw_port), "gateway port must be reachable"
+        # Sanity: the config the server ran with reflects the overrides.
+        assert cfg.gateway_async_dispatch_timeout_ms == 45_000
+        assert cfg.gateway_wait_terminal_timeout_ms == 30_000
+    finally:
+        with contextlib.suppress(Exception):
+            handle.shutdown()


### PR DESCRIPTION
## Summary

Fixes #321 — the gateway now distinguishes sync, async-opt-in, and
wait-for-terminal `tools/call` requests and applies the appropriate
timeout to each path.

- **Async dispatch timeout** — when the outbound `tools/call` carries
  `_meta.dcc.async = true` or `_meta.progressToken`, the gateway uses
  `McpHttpConfig.gateway_async_dispatch_timeout_ms` (default 60 s)
  instead of the short sync `backend_timeout_ms` (10 s). Only the
  queuing step spends this budget; the backend replies with
  `{status:"pending", job_id:"…"}` as soon as the job is enqueued.
  Backend unresponsive while queuing surfaces as a JSON-RPC
  `-32000 backend unresponsive` error naming the DCC type.
- **Wait-for-terminal response stitching** — when the client adds
  `_meta.dcc.wait_for_terminal = true` on an async-opt-in call, the
  gateway blocks the `tools/call` response until a
  `$/dcc.jobUpdated` with terminal status (`completed` / `failed` /
  `cancelled` / `interrupted`) arrives over the backend's SSE stream,
  then returns the final envelope with the tool's
  `structuredContent`. On timeout
  (`McpHttpConfig.gateway_wait_terminal_timeout_ms`, default 10 min)
  the gateway returns the last-known envelope annotated with
  `_meta.dcc.timed_out = true` and leaves the job running on the
  backend. Backend disconnect during the wait surfaces a clear
  `-32000 backend disconnected` error.
- **Correlation bus** — `SubscriberManager` grows a per-`job_id`
  `tokio::sync::broadcast` so wait-for-terminal POST handlers can
  subscribe before forwarding the call (no race window between the
  pending reply and the waiter installing its subscription). The
  new bus is GC'd on terminal event or timeout.

## Config surface

Two new fields on `McpHttpConfig` (also exposed on Python
`McpHttpConfig` with getters/setters and a keyword constructor
argument):

- `gateway_async_dispatch_timeout_ms: u64` (default 60 000)
- `gateway_wait_terminal_timeout_ms: u64` (default 600 000)

## Testing

- **Rust**: `crates/dcc-mcp-http/tests/gateway_passthrough.rs` — 5
  tests covering (a) async opt-in picks up the longer timeout,
  (b) sync calls still honour the short `backend_timeout`,
  (c) happy-path wait-for-terminal returns the completed envelope,
  (d) wait-for-terminal times out with the `timed_out` flag,
  (e) no-race check when the backend completes almost instantly.
- **Rust unit tests** inside `aggregator.rs` (async opt-in detection,
  meta flag stripping, envelope merging) and `sse_subscriber.rs`
  (per-job bus publish/subscribe/forget, and `deliver()` publishing
  without requiring a session binding).
- **Python**: `tests/test_gateway_passthrough.py` pins the new
  `McpHttpConfig` fields (defaults, constructor, setters) and
  confirms gateway startup does not regress when the new fields
  are overridden.
- Full suite: `vx just preflight` + `vx cargo test -p dcc-mcp-http
  --test gateway_passthrough` (5/5) + `pytest tests/` (8258 /
  8258 green on this worktree).

## Docs

- New "Waiting for terminal results from the gateway" section in
  `docs/guide/gateway.md` covering the three timeouts, the opt-in
  wire protocol, and the timeout / disconnect semantics.
- `AGENTS.md` + `CLAUDE.md` quick-lookup extended with the new
  config fields and links to the guide section.

## Non-goals

- No retry on backend timeout (client concern).
- No fan-out — one `tools/call` still maps to one job.

Closes #321.
