### PR TITLE
feat(workflow): WorkflowExecutor — execute every StepKind (#348)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,6 +238,15 @@ Need to interact with DCC?
 → Activate at runtime via `ToolRegistry.activate_tool_group(skill, group)` / MCP tool `activate_tool_group`
 → See `docs/guide/skills.md` — "Tool Groups (Progressive Exposure)"
 
+**Workflow execution (issue #348)?**
+→ `crates/dcc-mcp-workflow/` — `WorkflowExecutor`, `WorkflowHost`, all six `StepKind` variants.
+→ [`docs/guide/workflows.md`](docs/guide/workflows.md) — "Execution engine" section covers the full pipeline.
+→ Tools: `workflows.run` / `workflows.get_status` / `workflows.cancel` / `workflows.lookup`.
+→ Registration: `register_builtin_workflow_tools(&reg)` + `register_workflow_handlers(&dispatcher, &host)`.
+→ Pipeline: `spec → validate → spawn driver → drive(steps) → per-step policy (retry+timeout+idempotency) → dispatch by kind → artefact handoff → SSE `$/dcc.workflowUpdated` → sqlite upsert → next step`.
+→ Cancellation cascades from root `CancellationToken` to every step driver and caller; interrupt propagation bounded by one cooperative checkpoint.
+→ With `job-persist-sqlite`: non-terminal rows flip to `interrupted` on restart (no auto-resume).
+
 **Validate tool names or action IDs (SEP-986)?**
 → [`docs/guide/naming.md`](docs/guide/naming.md)
 → `validate_tool_name(name)` / `validate_action_id(name)` — raise `ValueError` on invalid names

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,53 @@ see there for Grafana PromQL examples. Counters advance from the
 `tools/call` wrapper in `handler.rs` — do not add recording sites
 elsewhere.
 
+### Workflow execution (issue #348)
+
+`dcc-mcp-workflow` ships the full execution engine atop the skeleton
+landed in the parent PR. Pipeline sketch:
+
+```
+WorkflowExecutor::run(spec, inputs, parent_job)
+   → validate spec
+   → create root job + CancellationToken
+   → spawn tokio driver
+      → drive(steps) sequentially
+         → per step: retry + timeout + idempotency_key short-circuit
+            → dispatch by StepKind:
+               ├─ Tool        → ToolCaller::call
+               ├─ ToolRemote  → RemoteCaller::call (via gateway)
+               ├─ Foreach     → JSONPath items → drive(body) per item
+               ├─ Parallel    → tokio::join! branches (on_any_fail)
+               ├─ Approve     → ApprovalGate::wait_handle + timeout
+               └─ Branch      → JSONPath cond → then | else
+            → artefact handoff (FileRef → ArtefactStore)
+            → emit $/dcc.workflowUpdated (enter / exit)
+            → sqlite upsert (if job-persist-sqlite)
+      → emit workflow_terminal
+   → return WorkflowRunHandle { workflow_id, root_job_id, cancel_token, join }
+```
+
+Use `WorkflowHost` as the stable entry point — it wraps `WorkflowExecutor`
+with a run registry keyed by `workflow_id`, so the three mutating MCP
+tools (`workflows.run` / `workflows.get_status` / `workflows.cancel`)
+can be wired with `register_workflow_handlers(&dispatcher, &host)` after
+`register_builtin_workflow_tools(&registry)` has been called.
+
+Key invariants:
+
+1. **Every transition emits `$/dcc.workflowUpdated`.** If you add a
+   new state, route it through `RunState::emit`.
+2. **Cancellation cascades through `tokio_util::sync::CancellationToken`.**
+   Never spawn a step future that drops the token — always pass it into
+   every `ToolCaller::call` / `RemoteCaller::call` / `tokio::select!`.
+3. **Idempotency short-circuit happens _before_ retry attempts.** A
+   cache hit skips the step entirely; retries only guard live calls.
+4. **SQLite recovery flips non-terminal rows to `interrupted` — never
+   auto-resumes.** Resume is explicit opt-in via a separate tool.
+5. **Approve gates block on `notifications/$/dcc.approveResponse`.**
+   The HTTP handler for that notification calls
+   `ApprovalGate::resolve(workflow_id, step_id, response)`.
+
 ### When Using MCP HTTP Server
 
 ```python

--- a/crates/dcc-mcp-workflow/Cargo.toml
+++ b/crates/dcc-mcp-workflow/Cargo.toml
@@ -6,13 +6,14 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "First-class Workflow primitive (WorkflowSpec + WorkflowJob) for the DCC-MCP ecosystem (skeleton; step execution pending)"
+description = "First-class Workflow primitive (WorkflowSpec + WorkflowJob) for the DCC-MCP ecosystem — spec, executor, SQLite persistence, MCP tools."
 
 [dependencies]
 pyo3 = { workspace = true, optional = true }
 dcc-mcp-naming = { workspace = true }
 dcc-mcp-models = { workspace = true }
 dcc-mcp-actions = { workspace = true }
+dcc-mcp-artefact = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }
@@ -20,14 +21,19 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 parking_lot = { workspace = true }
 uuid = { workspace = true }
+tokio = { workspace = true, features = ["sync", "time", "rt", "macros"] }
+tokio-util = "0.7"
+chrono = { version = "0.4", features = ["serde"] }
 jsonpath-rust = "1.0"
 glob = "0.3"
+base64 = { workspace = true }
 
-# Optional: SQLite persistence DDL (no write paths yet in this skeleton).
+# Optional: SQLite persistence (writer + interrupted-on-restart recovery).
 rusqlite = { version = "0.39", optional = true, features = ["bundled"] }
 
 [dev-dependencies]
 tempfile = "3"
+tokio = { workspace = true, features = ["sync", "time", "rt", "rt-multi-thread", "macros", "test-util"] }
 
 [features]
 default = []
@@ -36,6 +42,7 @@ python-bindings = [
     "dcc-mcp-naming/python-bindings",
     "dcc-mcp-models/python-bindings",
     "dcc-mcp-actions/python-bindings",
+    "dcc-mcp-artefact/python-bindings",
 ]
-# Persistence DDL for workflows / workflow_steps tables. No writer yet.
+# Persistence for workflows / workflow_steps tables.
 job-persist-sqlite = ["dep:rusqlite"]

--- a/crates/dcc-mcp-workflow/src/approval.rs
+++ b/crates/dcc-mcp-workflow/src/approval.rs
@@ -1,0 +1,147 @@
+//! Approval gate for `StepKind::Approve`.
+//!
+//! When an `Approve` step runs, the executor pauses the workflow until one
+//! of:
+//! - an MCP client sends `notifications/$/dcc.approveResponse { workflow_id,
+//!   step_id, approved, reason }`, or
+//! - the step's `timeout_secs` elapses (default: indefinite; when set,
+//!   timeout is treated as `approved=false, reason="timeout"`).
+//!
+//! The [`ApprovalGate`] is a process-local registry keyed by
+//! `(workflow_id, step_id)` so multiple concurrent workflows do not trip
+//! over each other. The HTTP crate bridges inbound `approveResponse` JSON-RPC
+//! notifications into [`ApprovalGate::resolve`].
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use tokio::sync::oneshot;
+use uuid::Uuid;
+
+/// Outcome of an approval gate.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ApprovalResponse {
+    /// Whether the gate was approved. On timeout this is `false`.
+    pub approved: bool,
+    /// Optional human-readable reason. Populated with `"timeout"` when the
+    /// approval deadline elapsed.
+    pub reason: Option<String>,
+}
+
+impl ApprovalResponse {
+    /// Convenience: timeout outcome.
+    pub fn timeout() -> Self {
+        Self {
+            approved: false,
+            reason: Some("timeout".to_string()),
+        }
+    }
+
+    /// Convenience: cancelled outcome.
+    pub fn cancelled() -> Self {
+        Self {
+            approved: false,
+            reason: Some("cancelled".to_string()),
+        }
+    }
+}
+
+type ApprovalSenderMap =
+    std::collections::HashMap<(Uuid, String), oneshot::Sender<ApprovalResponse>>;
+
+/// Process-local registry of outstanding approval gates.
+#[derive(Debug, Default, Clone)]
+pub struct ApprovalGate {
+    inner: Arc<Mutex<ApprovalSenderMap>>,
+}
+
+impl ApprovalGate {
+    /// Construct an empty gate registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a pending approval and return the receiver side. Drops the
+    /// previous waiter for the same key, if any.
+    pub fn wait_handle(
+        &self,
+        workflow_id: Uuid,
+        step_id: &str,
+    ) -> oneshot::Receiver<ApprovalResponse> {
+        let (tx, rx) = oneshot::channel();
+        self.inner
+            .lock()
+            .insert((workflow_id, step_id.to_string()), tx);
+        rx
+    }
+
+    /// Resolve the approval for `(workflow_id, step_id)`. Returns `true` if
+    /// a waiter was listening.
+    pub fn resolve(&self, workflow_id: Uuid, step_id: &str, resp: ApprovalResponse) -> bool {
+        let sender = self
+            .inner
+            .lock()
+            .remove(&(workflow_id, step_id.to_string()));
+        match sender {
+            Some(tx) => tx.send(resp).is_ok(),
+            None => false,
+        }
+    }
+
+    /// Drop any pending waiter for `(workflow_id, step_id)` without
+    /// resolving it. Used when a step is cancelled. The receiver will
+    /// observe a channel close.
+    pub fn discard(&self, workflow_id: Uuid, step_id: &str) {
+        self.inner
+            .lock()
+            .remove(&(workflow_id, step_id.to_string()));
+    }
+
+    /// Number of outstanding pending approvals. Used in tests.
+    pub fn pending_count(&self) -> usize {
+        self.inner.lock().len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn resolve_delivers_response() {
+        let gate = ApprovalGate::new();
+        let wid = Uuid::new_v4();
+        let mut rx = gate.wait_handle(wid, "gate");
+        assert_eq!(gate.pending_count(), 1);
+
+        let r = gate.resolve(
+            wid,
+            "gate",
+            ApprovalResponse {
+                approved: true,
+                reason: None,
+            },
+        );
+        assert!(r);
+        let resp = (&mut rx).await.unwrap();
+        assert!(resp.approved);
+        assert_eq!(gate.pending_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn resolve_without_waiter_returns_false() {
+        let gate = ApprovalGate::new();
+        assert!(!gate.resolve(Uuid::new_v4(), "nope", ApprovalResponse::timeout()));
+    }
+
+    #[tokio::test]
+    async fn discard_closes_channel() {
+        let gate = ApprovalGate::new();
+        let wid = Uuid::new_v4();
+        let rx = gate.wait_handle(wid, "gate");
+        gate.discard(wid, "gate");
+        let err = rx.await.unwrap_err();
+        // oneshot::error::RecvError is the only variant.
+        assert_eq!(err.to_string(), "channel closed");
+    }
+}

--- a/crates/dcc-mcp-workflow/src/callers.rs
+++ b/crates/dcc-mcp-workflow/src/callers.rs
@@ -1,0 +1,227 @@
+//! Executor tool-call abstractions.
+//!
+//! The workflow crate is transport-agnostic: it delegates actual tool
+//! invocation to the [`ToolCaller`] (for local `tool` steps) and
+//! [`RemoteCaller`] (for `tool_remote` steps) traits. Production wiring is
+//! provided by the server:
+//!
+//! - `dcc-mcp-actions` adapter → [`ActionDispatcherCaller`]
+//! - `dcc-mcp-http` gateway passthrough → an http-crate-side impl
+//!
+//! Each caller returns the raw tool output as JSON. The executor extracts
+//! `file_refs` via [`crate::context::StepOutput::from_value`].
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use dcc_mcp_actions::dispatcher::ActionDispatcher;
+use serde_json::Value;
+use tokio_util::sync::CancellationToken;
+
+/// Return type of [`ToolCaller::call`] — a boxed future yielding
+/// `Result<Value, String>`.
+pub type CallFuture<'a> = Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>>;
+
+/// Adapter for calling local MCP tools by name.
+///
+/// The workflow executor calls this for every `StepKind::Tool`. `cancel`
+/// is the per-step cancellation token; implementations that run blocking
+/// work should honour it cooperatively.
+pub trait ToolCaller: Send + Sync {
+    /// Invoke `tool_name` with the given JSON `args`. Must be safe to call
+    /// from any async worker.
+    fn call<'a>(
+        &'a self,
+        tool_name: &'a str,
+        args: Value,
+        cancel: CancellationToken,
+    ) -> CallFuture<'a>;
+}
+
+/// Adapter for calling remote MCP tools (`tool_remote` steps) on a specific
+/// DCC target via the gateway.
+pub trait RemoteCaller: Send + Sync {
+    /// Invoke `tool_name` on the `dcc` target with `args`.
+    fn call<'a>(
+        &'a self,
+        dcc: &'a str,
+        tool_name: &'a str,
+        args: Value,
+        cancel: CancellationToken,
+    ) -> CallFuture<'a>;
+}
+
+/// Shared, thread-safe tool caller alias.
+pub type SharedToolCaller = Arc<dyn ToolCaller>;
+/// Shared, thread-safe remote caller alias.
+pub type SharedRemoteCaller = Arc<dyn RemoteCaller>;
+
+// ── Dispatcher adapter ───────────────────────────────────────────────────
+
+/// Bridge a synchronous [`ActionDispatcher`] into the async [`ToolCaller`]
+/// trait.
+///
+/// Dispatches are offloaded via [`tokio::task::spawn_blocking`] so they do
+/// not stall the async worker. The cancellation token aborts the *await*
+/// before the handler sees it, but cannot interrupt synchronous Rust code
+/// mid-call — cooperative checkpoints inside the handler (issue #329) are
+/// the right mechanism for fine-grained cancel inside long tools.
+#[derive(Clone)]
+pub struct ActionDispatcherCaller {
+    dispatcher: ActionDispatcher,
+}
+
+impl ActionDispatcherCaller {
+    /// Wrap a dispatcher.
+    pub fn new(dispatcher: ActionDispatcher) -> Self {
+        Self { dispatcher }
+    }
+}
+
+impl ToolCaller for ActionDispatcherCaller {
+    fn call<'a>(
+        &'a self,
+        tool_name: &'a str,
+        args: Value,
+        cancel: CancellationToken,
+    ) -> CallFuture<'a> {
+        let dispatcher = self.dispatcher.clone();
+        let name = tool_name.to_string();
+        Box::pin(async move {
+            let dispatch = tokio::task::spawn_blocking(move || dispatcher.dispatch(&name, args));
+            tokio::select! {
+                biased;
+                _ = cancel.cancelled() => Err("cancelled".to_string()),
+                res = dispatch => match res {
+                    Err(e) => Err(format!("dispatch join error: {e}")),
+                    Ok(Err(e)) => Err(e.to_string()),
+                    Ok(Ok(d)) => Ok(d.output),
+                },
+            }
+        })
+    }
+}
+
+/// No-op remote caller — returns an error for every call. Used when a
+/// workflow has no `tool_remote` steps and the server does not wire in a
+/// gateway client.
+#[derive(Debug, Default, Clone)]
+pub struct NullRemoteCaller;
+
+impl RemoteCaller for NullRemoteCaller {
+    fn call<'a>(
+        &'a self,
+        dcc: &'a str,
+        tool_name: &'a str,
+        _args: Value,
+        _cancel: CancellationToken,
+    ) -> CallFuture<'a> {
+        let msg = format!(
+            "tool_remote step cannot be executed: no RemoteCaller wired for dcc={dcc:?}, tool={tool_name:?}"
+        );
+        Box::pin(async move { Err(msg) })
+    }
+}
+
+// ── Test helpers ─────────────────────────────────────────────────────────
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::*;
+    use parking_lot::Mutex;
+    use std::collections::HashMap;
+
+    /// In-memory [`ToolCaller`] backed by a map of `name → Fn(args) → Result<Value>`.
+    type Handler = Arc<dyn Fn(Value) -> Result<Value, String> + Send + Sync>;
+
+    #[derive(Default)]
+    pub struct MockToolCaller {
+        handlers: Mutex<HashMap<String, Handler>>,
+        /// History of calls in arrival order.
+        pub calls: Mutex<Vec<(String, Value)>>,
+    }
+
+    impl MockToolCaller {
+        pub fn new() -> Self {
+            Self::default()
+        }
+        pub fn add<F>(&self, name: &str, f: F)
+        where
+            F: Fn(Value) -> Result<Value, String> + Send + Sync + 'static,
+        {
+            self.handlers.lock().insert(name.to_string(), Arc::new(f));
+        }
+        pub fn call_count(&self, name: &str) -> usize {
+            self.calls.lock().iter().filter(|(n, _)| n == name).count()
+        }
+    }
+
+    impl ToolCaller for MockToolCaller {
+        fn call<'a>(
+            &'a self,
+            tool_name: &'a str,
+            args: Value,
+            _cancel: CancellationToken,
+        ) -> CallFuture<'a> {
+            self.calls
+                .lock()
+                .push((tool_name.to_string(), args.clone()));
+            let handler = self.handlers.lock().get(tool_name).cloned();
+            Box::pin(async move {
+                match handler {
+                    None => Err(format!("no handler registered for {tool_name:?}")),
+                    Some(f) => f(args),
+                }
+            })
+        }
+    }
+
+    /// In-memory [`RemoteCaller`] backed by a map.
+    #[derive(Default)]
+    pub struct MockRemoteCaller {
+        handlers: Mutex<HashMap<(String, String), Handler>>,
+        pub calls: Mutex<Vec<(String, String, Value)>>,
+    }
+
+    impl MockRemoteCaller {
+        pub fn new() -> Self {
+            Self::default()
+        }
+        pub fn add<F>(&self, dcc: &str, tool: &str, f: F)
+        where
+            F: Fn(Value) -> Result<Value, String> + Send + Sync + 'static,
+        {
+            self.handlers
+                .lock()
+                .insert((dcc.to_string(), tool.to_string()), Arc::new(f));
+        }
+    }
+
+    impl RemoteCaller for MockRemoteCaller {
+        fn call<'a>(
+            &'a self,
+            dcc: &'a str,
+            tool_name: &'a str,
+            args: Value,
+            _cancel: CancellationToken,
+        ) -> CallFuture<'a> {
+            self.calls
+                .lock()
+                .push((dcc.to_string(), tool_name.to_string(), args.clone()));
+            let handler = self
+                .handlers
+                .lock()
+                .get(&(dcc.to_string(), tool_name.to_string()))
+                .cloned();
+            Box::pin(async move {
+                match handler {
+                    None => Err(format!(
+                        "no remote handler registered for dcc={dcc:?}, tool={tool_name:?}"
+                    )),
+                    Some(f) => f(args),
+                }
+            })
+        }
+    }
+}

--- a/crates/dcc-mcp-workflow/src/context.rs
+++ b/crates/dcc-mcp-workflow/src/context.rs
@@ -1,0 +1,482 @@
+//! Workflow execution context — step outputs, template resolution, artefact
+//! tracking.
+//!
+//! The executor maintains a shared [`WorkflowContext`] that every step reads
+//! from (to resolve template variables like `{{steps.foo.output.bar}}` or
+//! `{{steps.foo.file_refs[0].uri}}`) and writes to (to register its output
+//! when it finishes).
+//!
+//! Template resolution supports two shapes:
+//!
+//! - **Whole-string reference** (`"{{steps.foo.output}}"`) — the resolved
+//!   JSON value replaces the string entirely, preserving its type (object /
+//!   array / number / bool).
+//! - **Embedded reference** (`"prefix_{{steps.foo.output.name}}_suffix"`) —
+//!   the resolved value is rendered as a string and spliced in.
+//!
+//! Dotted and bracket-indexed paths are supported:
+//! `steps.foo.output.items[0].path`, `inputs.date`, `item.name`.
+
+use std::collections::HashMap;
+
+use dcc_mcp_artefact::FileRef;
+use parking_lot::RwLock;
+use serde_json::Value;
+
+use crate::spec::StepId;
+
+/// Output recorded by the executor after a step completes successfully.
+#[derive(Debug, Clone)]
+pub struct StepOutput {
+    /// Raw tool output (whatever the dispatcher / remote returned).
+    pub output: Value,
+    /// File references attached to this step's output, if any.
+    /// Populated from `output.file_refs` (array of FileRef objects) or
+    /// from `output.context.file_refs`.
+    pub file_refs: Vec<FileRef>,
+}
+
+impl StepOutput {
+    /// Construct with the raw output and no file refs.
+    pub fn from_value(output: Value) -> Self {
+        let file_refs = extract_file_refs(&output);
+        Self { output, file_refs }
+    }
+}
+
+/// Pull `file_refs` out of a tool output, looking at both
+/// `output.file_refs` and `output.context.file_refs` locations.
+fn extract_file_refs(output: &Value) -> Vec<FileRef> {
+    let mut out = Vec::new();
+    let try_extract = |v: &Value, out: &mut Vec<FileRef>| {
+        if let Some(arr) = v.as_array() {
+            for entry in arr {
+                if let Ok(fr) = serde_json::from_value::<FileRef>(entry.clone()) {
+                    out.push(fr);
+                }
+            }
+        }
+    };
+    if let Some(v) = output.get("file_refs") {
+        try_extract(v, &mut out);
+    }
+    if let Some(ctx) = output.get("context") {
+        if let Some(v) = ctx.get("file_refs") {
+            try_extract(v, &mut out);
+        }
+    }
+    out
+}
+
+/// Shared, interior-mutable execution context.
+///
+/// Cheap to `clone` — it's just an `Arc` around the inner state.
+#[derive(Debug, Default, Clone)]
+pub struct WorkflowContext {
+    inner: std::sync::Arc<RwLock<WorkflowContextInner>>,
+}
+
+#[derive(Debug, Default)]
+struct WorkflowContextInner {
+    inputs: Value,
+    steps: HashMap<String, StepOutput>,
+    /// Stack of `foreach` item bindings. The top of the stack shadows earlier
+    /// bindings so nested loops pick the innermost.
+    item_stack: Vec<(String, Value)>,
+}
+
+impl WorkflowContext {
+    /// Fresh context with the given workflow inputs.
+    pub fn new(inputs: Value) -> Self {
+        let inner = WorkflowContextInner {
+            inputs,
+            ..WorkflowContextInner::default()
+        };
+        Self {
+            inner: std::sync::Arc::new(RwLock::new(inner)),
+        }
+    }
+
+    /// Record the output of a completed step.
+    pub fn record_step(&self, id: &StepId, output: StepOutput) {
+        self.inner.write().steps.insert(id.0.clone(), output);
+    }
+
+    /// Snapshot of a recorded step output.
+    pub fn step(&self, id: &str) -> Option<StepOutput> {
+        self.inner.read().steps.get(id).cloned()
+    }
+
+    /// Snapshot of all step outputs (for persistence / reporting).
+    pub fn steps_snapshot(&self) -> HashMap<String, StepOutput> {
+        self.inner.read().steps.clone()
+    }
+
+    /// Push a foreach item binding. Returns a guard that pops on drop.
+    pub fn push_item(&self, name: &str, value: Value) -> ItemGuard {
+        self.inner
+            .write()
+            .item_stack
+            .push((name.to_string(), value));
+        ItemGuard {
+            ctx: self.clone(),
+            name: name.to_string(),
+        }
+    }
+
+    /// Current innermost item binding for `name`, if any.
+    fn lookup_item(&self, name: &str) -> Option<Value> {
+        let g = self.inner.read();
+        for (k, v) in g.item_stack.iter().rev() {
+            if k == name {
+                return Some(v.clone());
+            }
+        }
+        None
+    }
+
+    /// Build the JSON root against which template references resolve.
+    ///
+    /// Shape:
+    /// ```json
+    /// {
+    ///   "inputs": { ... },
+    ///   "steps": { "<id>": { "output": ..., "file_refs": [...] }, ... },
+    ///   "item": <innermost item binding or null>,
+    ///   "<any foreach binding name>": <binding value>
+    /// }
+    /// ```
+    pub fn as_json(&self) -> Value {
+        let g = self.inner.read();
+        let mut steps_obj = serde_json::Map::new();
+        for (id, out) in g.steps.iter() {
+            let fr_json = serde_json::to_value(&out.file_refs).unwrap_or(Value::Null);
+            steps_obj.insert(
+                id.clone(),
+                serde_json::json!({
+                    "output": out.output,
+                    "file_refs": fr_json,
+                }),
+            );
+        }
+        let mut root = serde_json::json!({
+            "inputs": g.inputs.clone(),
+            "steps": Value::Object(steps_obj),
+        });
+        // Item bindings: promote each name to a top-level alias. The last
+        // push wins since HashMap::insert overwrites.
+        if let Some(obj) = root.as_object_mut() {
+            let mut last_item: Option<Value> = None;
+            for (k, v) in g.item_stack.iter() {
+                obj.insert(k.clone(), v.clone());
+                last_item = Some(v.clone());
+            }
+            obj.insert("item".to_string(), last_item.unwrap_or(Value::Null));
+        }
+        root
+    }
+
+    /// Render a JSON argument tree by replacing every `"{{…}}"` template
+    /// reference against this context. Non-string leaves are returned
+    /// unchanged.
+    pub fn render(&self, args: &Value) -> Result<Value, TemplateError> {
+        let root = self.as_json();
+        render_value(args, &root, self)
+    }
+}
+
+/// Guard popping a foreach item binding on drop.
+#[must_use = "ItemGuard must be held for the lifetime of the iteration"]
+pub struct ItemGuard {
+    ctx: WorkflowContext,
+    name: String,
+}
+
+impl Drop for ItemGuard {
+    fn drop(&mut self) {
+        let mut g = self.ctx.inner.write();
+        // Pop the most recent entry with this name (should be the tail).
+        if let Some(pos) = g.item_stack.iter().rposition(|(k, _)| k == &self.name) {
+            g.item_stack.remove(pos);
+        }
+    }
+}
+
+// ── Template rendering ───────────────────────────────────────────────────
+
+/// Template / path resolution errors.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum TemplateError {
+    /// Template reference could not be resolved against the context.
+    #[error("template {template:?} references unknown path {path:?}")]
+    UnknownPath {
+        /// The raw template.
+        template: String,
+        /// The dotted/bracketed path that failed.
+        path: String,
+    },
+    /// Template body was malformed (empty, unterminated, invalid chars).
+    #[error("malformed template {template:?}: {reason}")]
+    Malformed {
+        /// The raw template.
+        template: String,
+        /// Human-readable reason.
+        reason: String,
+    },
+}
+
+fn render_value(v: &Value, root: &Value, ctx: &WorkflowContext) -> Result<Value, TemplateError> {
+    match v {
+        Value::String(s) => render_string(s, root, ctx),
+        Value::Array(arr) => {
+            let mut out = Vec::with_capacity(arr.len());
+            for item in arr {
+                out.push(render_value(item, root, ctx)?);
+            }
+            Ok(Value::Array(out))
+        }
+        Value::Object(obj) => {
+            let mut out = serde_json::Map::with_capacity(obj.len());
+            for (k, v) in obj {
+                out.insert(k.clone(), render_value(v, root, ctx)?);
+            }
+            Ok(Value::Object(out))
+        }
+        other => Ok(other.clone()),
+    }
+}
+
+fn render_string(s: &str, root: &Value, ctx: &WorkflowContext) -> Result<Value, TemplateError> {
+    // Whole-string reference: replace entirely with the resolved value.
+    let trimmed = s.trim();
+    if let Some(body) = trimmed
+        .strip_prefix("{{")
+        .and_then(|r| r.strip_suffix("}}"))
+    {
+        if !trimmed.matches("{{").count() == 1 || trimmed.matches("}}").count() != 1 {
+            // More than one marker — fall through to embedded mode.
+        } else {
+            let path = body.trim();
+            let resolved =
+                resolve_path(path, root, ctx).ok_or_else(|| TemplateError::UnknownPath {
+                    template: s.to_string(),
+                    path: path.to_string(),
+                })?;
+            return Ok(resolved);
+        }
+    }
+
+    // Embedded mode: stringly substitute each `{{…}}` span.
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    loop {
+        match rest.find("{{") {
+            None => {
+                out.push_str(rest);
+                break;
+            }
+            Some(i) => {
+                out.push_str(&rest[..i]);
+                let after = &rest[i + 2..];
+                let close = after.find("}}").ok_or_else(|| TemplateError::Malformed {
+                    template: s.to_string(),
+                    reason: "unterminated '{{'".to_string(),
+                })?;
+                let path = after[..close].trim();
+                if path.is_empty() {
+                    return Err(TemplateError::Malformed {
+                        template: s.to_string(),
+                        reason: "empty reference".to_string(),
+                    });
+                }
+                let resolved =
+                    resolve_path(path, root, ctx).ok_or_else(|| TemplateError::UnknownPath {
+                        template: s.to_string(),
+                        path: path.to_string(),
+                    })?;
+                let rendered = match resolved {
+                    Value::String(s) => s,
+                    Value::Null => String::new(),
+                    other => other.to_string(),
+                };
+                out.push_str(&rendered);
+                rest = &after[close + 2..];
+            }
+        }
+    }
+    Ok(Value::String(out))
+}
+
+/// Resolve a dotted / bracket-indexed path against the context root.
+///
+/// Supported grammar:
+///   path := ident ( '.' ident | '[' number ']' )*
+fn resolve_path(path: &str, root: &Value, ctx: &WorkflowContext) -> Option<Value> {
+    // Split into tokens — either ident or [number].
+    let tokens = tokenize_path(path)?;
+    if tokens.is_empty() {
+        return None;
+    }
+
+    // The first token MUST be an ident (the root key).
+    let (first_ident, rest) = match tokens.split_first() {
+        Some((PathToken::Ident(s), rest)) => (s.clone(), rest),
+        _ => return None,
+    };
+
+    // Resolve the root: prefer context item bindings (foreach), else fall
+    // through to the JSON root object.
+    let mut cur: Value = match ctx.lookup_item(&first_ident) {
+        Some(v) => v,
+        None => root.get(&first_ident).cloned().unwrap_or(Value::Null),
+    };
+    if matches!(cur, Value::Null)
+        && root.get(&first_ident).is_none()
+        && ctx.lookup_item(&first_ident).is_none()
+    {
+        return None;
+    }
+
+    for tok in rest {
+        cur = match tok {
+            PathToken::Ident(k) => cur.get(k).cloned().unwrap_or(Value::Null),
+            PathToken::Index(i) => cur.get(*i).cloned().unwrap_or(Value::Null),
+        };
+    }
+    Some(cur)
+}
+
+#[derive(Debug, Clone)]
+enum PathToken {
+    Ident(String),
+    Index(usize),
+}
+
+fn tokenize_path(s: &str) -> Option<Vec<PathToken>> {
+    let mut out = Vec::new();
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c == b'.' {
+            i += 1;
+            continue;
+        }
+        if c == b'[' {
+            // Read digits until ']'.
+            let start = i + 1;
+            let end = start + bytes[start..].iter().position(|&b| b == b']')?;
+            let num: usize = std::str::from_utf8(&bytes[start..end]).ok()?.parse().ok()?;
+            out.push(PathToken::Index(num));
+            i = end + 1;
+            continue;
+        }
+        // Read an ident up to '.' or '['.
+        let start = i;
+        while i < bytes.len() && bytes[i] != b'.' && bytes[i] != b'[' {
+            i += 1;
+        }
+        let ident = std::str::from_utf8(&bytes[start..i]).ok()?;
+        if ident.is_empty() {
+            return None;
+        }
+        out.push(PathToken::Ident(ident.to_string()));
+    }
+    Some(out)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn render_plain_string_is_identity() {
+        let ctx = WorkflowContext::new(json!({}));
+        assert_eq!(ctx.render(&json!("hello")).unwrap(), json!("hello"));
+    }
+
+    #[test]
+    fn render_whole_string_ref_preserves_type() {
+        let ctx = WorkflowContext::new(json!({"n": 42, "name": "demo"}));
+        assert_eq!(ctx.render(&json!("{{inputs.n}}")).unwrap(), json!(42));
+        assert_eq!(
+            ctx.render(&json!("{{inputs.name}}")).unwrap(),
+            json!("demo")
+        );
+    }
+
+    #[test]
+    fn render_embedded_ref_stringifies() {
+        let ctx = WorkflowContext::new(json!({"n": 3}));
+        assert_eq!(
+            ctx.render(&json!("count={{inputs.n}}")).unwrap(),
+            json!("count=3")
+        );
+    }
+
+    #[test]
+    fn render_step_output_path() {
+        let ctx = WorkflowContext::new(json!({}));
+        ctx.record_step(
+            &StepId("s1".into()),
+            StepOutput::from_value(json!({"path": "/tmp/x"})),
+        );
+        let rendered = ctx.render(&json!("{{steps.s1.output.path}}")).unwrap();
+        assert_eq!(rendered, json!("/tmp/x"));
+    }
+
+    #[test]
+    fn render_file_ref_index() {
+        let ctx = WorkflowContext::new(json!({}));
+        ctx.record_step(
+            &StepId("export".into()),
+            StepOutput::from_value(json!({
+                "file_refs": [{
+                    "uri": "artefact://sha256/abc",
+                    "created_at": "2020-01-01T00:00:00Z"
+                }]
+            })),
+        );
+        let rendered = ctx
+            .render(&json!("{{steps.export.file_refs[0].uri}}"))
+            .unwrap();
+        assert_eq!(rendered, json!("artefact://sha256/abc"));
+    }
+
+    #[test]
+    fn foreach_item_binding_shadows() {
+        let ctx = WorkflowContext::new(json!({}));
+        let _g = ctx.push_item("file", json!({"path": "/a"}));
+        let rendered = ctx.render(&json!("{{file.path}}")).unwrap();
+        assert_eq!(rendered, json!("/a"));
+    }
+
+    #[test]
+    fn unknown_template_errors() {
+        let ctx = WorkflowContext::new(json!({}));
+        let err = ctx.render(&json!("{{nope.qux}}")).unwrap_err();
+        assert!(matches!(err, TemplateError::UnknownPath { .. }));
+    }
+
+    #[test]
+    fn malformed_template_errors() {
+        let ctx = WorkflowContext::new(json!({}));
+        let err = ctx.render(&json!("hello {{oops")).unwrap_err();
+        assert!(matches!(err, TemplateError::Malformed { .. }));
+    }
+
+    #[test]
+    fn nested_object_renders() {
+        let ctx = WorkflowContext::new(json!({"date": "2024-01-01"}));
+        let rendered = ctx
+            .render(&json!({"date": "{{inputs.date}}", "nested": {"x": "{{inputs.date}}"}}))
+            .unwrap();
+        assert_eq!(
+            rendered,
+            json!({"date": "2024-01-01", "nested": {"x": "2024-01-01"}})
+        );
+    }
+}

--- a/crates/dcc-mcp-workflow/src/executor.rs
+++ b/crates/dcc-mcp-workflow/src/executor.rs
@@ -1,0 +1,1595 @@
+//! [`WorkflowExecutor`] — runs a [`WorkflowSpec`] end-to-end.
+//!
+//! This is the step execution engine for issue #348. It consumes the
+//! skeleton types landed in the parent PR plus every subsequent workflow
+//! improvement (`StepPolicy`, `FileRef`, `$/dcc.workflowUpdated`,
+//! parent-job cascade, SQLite persistence) and implements all six
+//! [`StepKind`] variants.
+//!
+//! # Shape
+//!
+//! ```text
+//! WorkflowExecutor::run(spec, inputs, parent)
+//!   → creates a root WorkflowRun (id, cancel_token)
+//!   → spawns a Tokio task driving the top-level step sequence
+//!   → returns a WorkflowRunHandle { workflow_id, root_job_id, cancel_token, join }
+//! ```
+//!
+//! Each step kind has its own driver:
+//!
+//! | Kind           | Driver                                               |
+//! |----------------|------------------------------------------------------|
+//! | `Tool`         | [`WorkflowExecutor::run_tool_step`] via [`ToolCaller`] |
+//! | `ToolRemote`   | [`WorkflowExecutor::run_remote_step`] via [`RemoteCaller`] |
+//! | `Foreach`      | [`WorkflowExecutor::run_foreach`] (JSONPath items)   |
+//! | `Parallel`     | [`WorkflowExecutor::run_parallel`] (all-or-abort)    |
+//! | `Approve`      | [`WorkflowExecutor::run_approve`] (gate + timeout)   |
+//! | `Branch`       | [`WorkflowExecutor::run_branch`] (JSONPath condition) |
+//!
+//! Each step honours `StepPolicy` (timeout + retry + idempotency).
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use dcc_mcp_artefact::{ArtefactBody, FileRef, SharedArtefactStore};
+use jsonpath_rust::JsonPath;
+use serde_json::Value;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+use uuid::Uuid;
+
+use crate::approval::{ApprovalGate, ApprovalResponse};
+use crate::callers::{
+    ActionDispatcherCaller, NullRemoteCaller, SharedRemoteCaller, SharedToolCaller,
+};
+use crate::context::{StepOutput, WorkflowContext};
+use crate::error::WorkflowError;
+use crate::idempotency::IdempotencyCache;
+use crate::notifier::{NullNotifier, SharedNotifier, WorkflowUpdate, WorkflowUpdateProgress};
+use crate::policy::{BackoffKind, IdempotencyScope, RetryPolicy, StepPolicy};
+use crate::spec::{Step, StepId, StepKind, WorkflowSpec, WorkflowStatus};
+
+/// Handle returned by [`WorkflowExecutor::run`].
+#[derive(Debug)]
+pub struct WorkflowRunHandle {
+    /// Runtime workflow id (matches the `workflow_id` field in
+    /// `$/dcc.workflowUpdated`).
+    pub workflow_id: Uuid,
+    /// Root job id — stable across step transitions. Parents can be linked
+    /// via the `parent_job_id` argument to
+    /// [`WorkflowExecutor::run`].
+    pub root_job_id: Uuid,
+    /// Shared cancellation token. Cancel to abort the workflow; children
+    /// inherit child tokens so the abort cascades within one cooperative
+    /// checkpoint.
+    pub cancel_token: CancellationToken,
+    /// Join handle on the driver task. Resolves with the terminal status.
+    pub join: JoinHandle<WorkflowStatus>,
+}
+
+impl WorkflowRunHandle {
+    /// Cancel the workflow. No-op if already terminal.
+    pub fn cancel(&self) {
+        self.cancel_token.cancel();
+    }
+
+    /// Wait for the workflow to reach a terminal state.
+    pub async fn wait(self) -> WorkflowStatus {
+        self.join.await.unwrap_or(WorkflowStatus::Failed)
+    }
+}
+
+/// Shared state for an active workflow — cloned into every step driver.
+#[derive(Clone)]
+struct RunState {
+    workflow_id: Uuid,
+    root_job_id: Uuid,
+    context: WorkflowContext,
+    notifier: SharedNotifier,
+    artefacts: Option<SharedArtefactStore>,
+    tool_caller: SharedToolCaller,
+    remote_caller: SharedRemoteCaller,
+    idempotency: IdempotencyCache,
+    approval_gate: ApprovalGate,
+    cancel_token: CancellationToken,
+    #[cfg(feature = "job-persist-sqlite")]
+    storage: Option<Arc<crate::sqlite::WorkflowStorage>>,
+    total_steps: u32,
+    completed: Arc<parking_lot::Mutex<u32>>,
+    /// Snapshot accumulator so the executor can expose `step_outputs` to
+    /// the outer MCP tool at any time.
+    outputs_snapshot: Arc<parking_lot::RwLock<HashMap<String, Value>>>,
+}
+
+impl RunState {
+    fn progress(&self) -> WorkflowUpdateProgress {
+        WorkflowUpdateProgress {
+            completed_steps: *self.completed.lock(),
+            total_steps: self.total_steps,
+        }
+    }
+
+    fn emit(&self, status: WorkflowStatus, step: Option<&str>, detail: Value) {
+        self.notifier.emit(WorkflowUpdate {
+            workflow_id: self.workflow_id,
+            job_id: self.root_job_id,
+            status,
+            current_step_id: step.map(str::to_string),
+            progress: self.progress(),
+            detail,
+        });
+    }
+
+    fn inc_completed(&self) {
+        *self.completed.lock() += 1;
+    }
+
+    fn record_output_snapshot(&self, step_id: &str, output: &Value) {
+        self.outputs_snapshot
+            .write()
+            .insert(step_id.to_string(), output.clone());
+    }
+
+    /// Snapshot of every step's output for persistence. Clones the inner
+    /// map.
+    #[allow(dead_code)]
+    fn outputs_json(&self) -> Value {
+        let map = self.outputs_snapshot.read().clone();
+        let mut out = serde_json::Map::new();
+        for (k, v) in map {
+            out.insert(k, v);
+        }
+        Value::Object(out)
+    }
+}
+
+// ── Executor ─────────────────────────────────────────────────────────────
+
+/// Top-level workflow step execution engine.
+///
+/// Cheap to clone — all state is `Arc`-wrapped.
+#[derive(Clone)]
+pub struct WorkflowExecutor {
+    tool_caller: SharedToolCaller,
+    remote_caller: SharedRemoteCaller,
+    notifier: SharedNotifier,
+    artefacts: Option<SharedArtefactStore>,
+    idempotency: IdempotencyCache,
+    approval_gate: ApprovalGate,
+    #[cfg(feature = "job-persist-sqlite")]
+    storage: Option<Arc<crate::sqlite::WorkflowStorage>>,
+    /// Default approval timeout when a step declares no `timeout_secs`.
+    /// `None` means indefinite (matches the issue #348 spec).
+    default_approve_timeout: Option<Duration>,
+}
+
+impl std::fmt::Debug for WorkflowExecutor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WorkflowExecutor")
+            .field("has_artefacts", &self.artefacts.is_some())
+            .field("idempotency_entries", &self.idempotency.len())
+            .field("pending_approvals", &self.approval_gate.pending_count())
+            .finish()
+    }
+}
+
+/// Builder for [`WorkflowExecutor`].
+#[derive(Default)]
+pub struct WorkflowExecutorBuilder {
+    tool_caller: Option<SharedToolCaller>,
+    remote_caller: Option<SharedRemoteCaller>,
+    notifier: Option<SharedNotifier>,
+    artefacts: Option<SharedArtefactStore>,
+    idempotency: Option<IdempotencyCache>,
+    approval_gate: Option<ApprovalGate>,
+    #[cfg(feature = "job-persist-sqlite")]
+    storage: Option<Arc<crate::sqlite::WorkflowStorage>>,
+    default_approve_timeout: Option<Duration>,
+}
+
+impl WorkflowExecutorBuilder {
+    /// Set the local tool caller.
+    pub fn tool_caller(mut self, caller: SharedToolCaller) -> Self {
+        self.tool_caller = Some(caller);
+        self
+    }
+
+    /// Convenience: wrap an [`dcc_mcp_actions::dispatcher::ActionDispatcher`]
+    /// as the local tool caller.
+    pub fn dispatcher(mut self, dispatcher: dcc_mcp_actions::dispatcher::ActionDispatcher) -> Self {
+        self.tool_caller = Some(Arc::new(ActionDispatcherCaller::new(dispatcher)));
+        self
+    }
+
+    /// Set the remote / gateway caller (defaults to [`NullRemoteCaller`]).
+    pub fn remote_caller(mut self, caller: SharedRemoteCaller) -> Self {
+        self.remote_caller = Some(caller);
+        self
+    }
+
+    /// Set the SSE notifier (defaults to [`NullNotifier`]).
+    pub fn notifier(mut self, notifier: SharedNotifier) -> Self {
+        self.notifier = Some(notifier);
+        self
+    }
+
+    /// Set the artefact store.
+    pub fn artefacts(mut self, store: SharedArtefactStore) -> Self {
+        self.artefacts = Some(store);
+        self
+    }
+
+    /// Override the default approval timeout (applies when a step omits
+    /// `timeout_secs`).
+    pub fn default_approve_timeout(mut self, d: Duration) -> Self {
+        self.default_approve_timeout = Some(d);
+        self
+    }
+
+    /// Attach a shared idempotency cache (defaults to a fresh one).
+    pub fn idempotency(mut self, cache: IdempotencyCache) -> Self {
+        self.idempotency = Some(cache);
+        self
+    }
+
+    /// Attach a shared approval gate registry (defaults to a fresh one).
+    pub fn approval_gate(mut self, gate: ApprovalGate) -> Self {
+        self.approval_gate = Some(gate);
+        self
+    }
+
+    /// Attach a SQLite storage backend. When present, every workflow/step
+    /// transition is persisted and `recover()` flips non-terminal rows to
+    /// `interrupted` on restart.
+    #[cfg(feature = "job-persist-sqlite")]
+    pub fn storage(mut self, storage: Arc<crate::sqlite::WorkflowStorage>) -> Self {
+        self.storage = Some(storage);
+        self
+    }
+
+    /// Finalise. Panics if no tool caller is configured — there's no
+    /// sensible default and every workflow has at least one `tool` step.
+    pub fn build(self) -> WorkflowExecutor {
+        WorkflowExecutor {
+            tool_caller: self
+                .tool_caller
+                .expect("WorkflowExecutor requires a tool_caller"),
+            remote_caller: self
+                .remote_caller
+                .unwrap_or_else(|| Arc::new(NullRemoteCaller)),
+            notifier: self.notifier.unwrap_or_else(|| Arc::new(NullNotifier)),
+            artefacts: self.artefacts,
+            idempotency: self.idempotency.unwrap_or_default(),
+            approval_gate: self.approval_gate.unwrap_or_default(),
+            #[cfg(feature = "job-persist-sqlite")]
+            storage: self.storage,
+            default_approve_timeout: self.default_approve_timeout,
+        }
+    }
+}
+
+impl WorkflowExecutor {
+    /// Open a builder.
+    pub fn builder() -> WorkflowExecutorBuilder {
+        WorkflowExecutorBuilder::default()
+    }
+
+    /// Access the approval gate — used by the MCP handler that receives
+    /// `$/dcc.approveResponse` notifications.
+    pub fn approval_gate(&self) -> ApprovalGate {
+        self.approval_gate.clone()
+    }
+
+    /// Access the idempotency cache.
+    pub fn idempotency(&self) -> IdempotencyCache {
+        self.idempotency.clone()
+    }
+
+    /// Recover any interrupted workflows from persistence (issue #348).
+    /// Returns the number of rows flipped to `interrupted`. On every
+    /// flipped row, a final `$/dcc.workflowUpdated` is emitted via the
+    /// configured notifier so connected MCP clients observe the
+    /// interruption.
+    #[cfg(feature = "job-persist-sqlite")]
+    pub fn recover_persisted(&self) -> Result<usize, crate::sqlite::WorkflowStorageError> {
+        let Some(ref storage) = self.storage else {
+            return Ok(0);
+        };
+        let rows = storage.recover()?;
+        for row in &rows {
+            let update = WorkflowUpdate {
+                workflow_id: row.id,
+                job_id: row.root_job_id,
+                status: WorkflowStatus::Interrupted,
+                current_step_id: row.current_step_id.clone(),
+                progress: WorkflowUpdateProgress::default(),
+                detail: serde_json::json!({"kind": "interrupted", "reason": "server restart"}),
+            };
+            self.notifier.emit(update);
+        }
+        Ok(rows.len())
+    }
+
+    /// Kick off execution of `spec`. Returns a [`WorkflowRunHandle`] whose
+    /// `.join` resolves when the workflow reaches a terminal state.
+    pub fn run(
+        &self,
+        spec: WorkflowSpec,
+        inputs: Value,
+        _parent_job_id: Option<Uuid>,
+    ) -> Result<WorkflowRunHandle, WorkflowError> {
+        spec.validate()?;
+
+        let workflow_id = Uuid::new_v4();
+        let root_job_id = Uuid::new_v4();
+        let cancel_token = CancellationToken::new();
+        let total_steps = count_steps(&spec);
+
+        let state = RunState {
+            workflow_id,
+            root_job_id,
+            context: WorkflowContext::new(inputs.clone()),
+            notifier: Arc::clone(&self.notifier),
+            artefacts: self.artefacts.clone(),
+            tool_caller: Arc::clone(&self.tool_caller),
+            remote_caller: Arc::clone(&self.remote_caller),
+            idempotency: self.idempotency.clone(),
+            approval_gate: self.approval_gate.clone(),
+            cancel_token: cancel_token.clone(),
+            #[cfg(feature = "job-persist-sqlite")]
+            storage: self.storage.clone(),
+            total_steps,
+            completed: Arc::new(parking_lot::Mutex::new(0)),
+            outputs_snapshot: Arc::new(parking_lot::RwLock::new(HashMap::new())),
+        };
+
+        // Persist initial row.
+        #[cfg(feature = "job-persist-sqlite")]
+        if let Some(storage) = &state.storage {
+            if let Err(e) = storage.insert_workflow(workflow_id, root_job_id, &spec, &inputs) {
+                warn!(error = %e, "workflow storage insert failed");
+            }
+        }
+
+        // Initial pending emit.
+        state.emit(
+            WorkflowStatus::Pending,
+            None,
+            serde_json::json!({"kind": "workflow_started"}),
+        );
+
+        let default_approve_timeout = self.default_approve_timeout;
+        let spec_clone = spec.clone();
+        let state_clone = state.clone();
+        let join = tokio::spawn(async move {
+            let run_state = state_clone;
+            let terminal = Self::drive(
+                run_state.clone(),
+                spec_clone.steps.clone(),
+                default_approve_timeout,
+            )
+            .await;
+            #[cfg(feature = "job-persist-sqlite")]
+            if let Some(storage) = &run_state.storage {
+                if let Err(e) =
+                    storage.update_workflow_status(run_state.workflow_id, terminal, None)
+                {
+                    warn!(error = %e, "workflow storage status update failed");
+                }
+                if let Err(e) =
+                    storage.update_step_outputs(run_state.workflow_id, &run_state.outputs_json())
+                {
+                    warn!(error = %e, "workflow storage step outputs update failed");
+                }
+            }
+            run_state.emit(
+                terminal,
+                None,
+                serde_json::json!({"kind": "workflow_terminal"}),
+            );
+            terminal
+        });
+
+        Ok(WorkflowRunHandle {
+            workflow_id,
+            root_job_id,
+            cancel_token,
+            join,
+        })
+    }
+
+    /// Drive a sequence of steps in order. Returns the aggregated
+    /// [`WorkflowStatus`] reached after processing all steps (or the first
+    /// failing / cancelled step).
+    async fn drive(
+        state: RunState,
+        steps: Vec<Step>,
+        default_approve_timeout: Option<Duration>,
+    ) -> WorkflowStatus {
+        for step in steps {
+            if state.cancel_token.is_cancelled() {
+                return WorkflowStatus::Cancelled;
+            }
+            match Self::run_step(state.clone(), step, default_approve_timeout).await {
+                StepOutcome::Ok => {}
+                StepOutcome::Cancelled => return WorkflowStatus::Cancelled,
+                StepOutcome::Failed(_) => return WorkflowStatus::Failed,
+            }
+        }
+        WorkflowStatus::Completed
+    }
+
+    /// Run a single step including its policy wrapping.
+    fn run_step<'a>(
+        state: RunState,
+        step: Step,
+        default_approve_timeout: Option<Duration>,
+    ) -> Pin<Box<dyn Future<Output = StepOutcome> + Send + 'a>> {
+        Box::pin(async move {
+            if state.cancel_token.is_cancelled() {
+                return StepOutcome::Cancelled;
+            }
+            let step_id = step.id.clone();
+            state.emit(
+                WorkflowStatus::Running,
+                Some(step_id.as_str()),
+                serde_json::json!({"kind": "step_enter", "step_id": step_id.0}),
+            );
+            #[cfg(feature = "job-persist-sqlite")]
+            if let Some(ref s) = state.storage {
+                let _ = s.upsert_step(state.workflow_id, step_id.as_str(), "running", None, None);
+                let _ = s.update_workflow_status(
+                    state.workflow_id,
+                    WorkflowStatus::Running,
+                    Some(step_id.as_str()),
+                );
+            }
+
+            let outcome = match &step.kind {
+                StepKind::Tool { .. } => Self::run_tool_step(&state, &step).await,
+                StepKind::ToolRemote { .. } => Self::run_remote_step(&state, &step).await,
+                StepKind::Foreach { .. } => {
+                    Self::run_foreach(state.clone(), step.clone(), default_approve_timeout).await
+                }
+                StepKind::Parallel { .. } => {
+                    Self::run_parallel(state.clone(), step.clone(), default_approve_timeout).await
+                }
+                StepKind::Approve { .. } => {
+                    Self::run_approve(state.clone(), step.clone(), default_approve_timeout).await
+                }
+                StepKind::Branch { .. } => {
+                    Self::run_branch(state.clone(), step.clone(), default_approve_timeout).await
+                }
+            };
+
+            match &outcome {
+                StepOutcome::Ok => {
+                    state.inc_completed();
+                    state.emit(
+                        WorkflowStatus::Running,
+                        Some(step_id.as_str()),
+                        serde_json::json!({"kind": "step_exit", "step_id": step_id.0, "status": "completed"}),
+                    );
+                    #[cfg(feature = "job-persist-sqlite")]
+                    if let Some(ref s) = state.storage {
+                        let out = state
+                            .context
+                            .step(step_id.as_str())
+                            .map(|o| o.output)
+                            .unwrap_or(Value::Null);
+                        let _ = s.upsert_step(
+                            state.workflow_id,
+                            step_id.as_str(),
+                            "completed",
+                            Some(&out),
+                            None,
+                        );
+                    }
+                }
+                StepOutcome::Cancelled => {
+                    state.emit(
+                        WorkflowStatus::Cancelled,
+                        Some(step_id.as_str()),
+                        serde_json::json!({"kind": "step_exit", "step_id": step_id.0, "status": "cancelled"}),
+                    );
+                    #[cfg(feature = "job-persist-sqlite")]
+                    if let Some(ref s) = state.storage {
+                        let _ = s.upsert_step(
+                            state.workflow_id,
+                            step_id.as_str(),
+                            "cancelled",
+                            None,
+                            Some("cancelled"),
+                        );
+                    }
+                }
+                StepOutcome::Failed(e) => {
+                    state.emit(
+                        WorkflowStatus::Failed,
+                        Some(step_id.as_str()),
+                        serde_json::json!({"kind": "step_exit", "step_id": step_id.0, "status": "failed", "error": e}),
+                    );
+                    #[cfg(feature = "job-persist-sqlite")]
+                    if let Some(ref s) = state.storage {
+                        let _ = s.upsert_step(
+                            state.workflow_id,
+                            step_id.as_str(),
+                            "failed",
+                            None,
+                            Some(e.as_str()),
+                        );
+                    }
+                }
+            }
+
+            outcome
+        })
+    }
+
+    // ── Tool step ────────────────────────────────────────────────────────
+
+    async fn run_tool_step(state: &RunState, step: &Step) -> StepOutcome {
+        let (name, args) = match &step.kind {
+            StepKind::Tool { tool, args } => (tool.clone(), args.clone()),
+            _ => unreachable!(),
+        };
+        let call = |rendered_args: Value, cancel: CancellationToken| {
+            let caller = Arc::clone(&state.tool_caller);
+            let name = name.clone();
+            async move { caller.call(&name, rendered_args, cancel).await }
+        };
+        run_with_policy(state, step, args, call).await
+    }
+
+    // ── ToolRemote step ──────────────────────────────────────────────────
+
+    async fn run_remote_step(state: &RunState, step: &Step) -> StepOutcome {
+        let (dcc, tool, args) = match &step.kind {
+            StepKind::ToolRemote { dcc, tool, args } => (dcc.clone(), tool.clone(), args.clone()),
+            _ => unreachable!(),
+        };
+        let call = |rendered_args: Value, cancel: CancellationToken| {
+            let caller = Arc::clone(&state.remote_caller);
+            let dcc = dcc.clone();
+            let tool = tool.clone();
+            async move { caller.call(&dcc, &tool, rendered_args, cancel).await }
+        };
+        run_with_policy(state, step, args, call).await
+    }
+
+    // ── Foreach step ─────────────────────────────────────────────────────
+
+    async fn run_foreach(
+        state: RunState,
+        step: Step,
+        default_approve_timeout: Option<Duration>,
+    ) -> StepOutcome {
+        let (items_expr, item_name, body) = match &step.kind {
+            StepKind::Foreach { items, r#as, steps } => {
+                (items.clone(), r#as.clone(), steps.clone())
+            }
+            _ => unreachable!(),
+        };
+        let root = state.context.as_json();
+        let items_val = match eval_jsonpath(&items_expr, &root) {
+            Ok(v) => v,
+            Err(e) => return StepOutcome::Failed(format!("foreach.items: {e}")),
+        };
+        let items: Vec<Value> = match items_val {
+            Value::Array(arr) => arr,
+            Value::Null => Vec::new(),
+            other => vec![other],
+        };
+        let mut agg_outputs: Vec<Value> = Vec::with_capacity(items.len());
+        for (i, item) in items.into_iter().enumerate() {
+            if state.cancel_token.is_cancelled() {
+                return StepOutcome::Cancelled;
+            }
+            let _guard = state.context.push_item(&item_name, item.clone());
+            debug!(step_id = %step.id, index = i, "foreach iteration");
+            match Self::drive(state.clone(), body.clone(), default_approve_timeout).await {
+                WorkflowStatus::Completed => {
+                    // Snapshot inner step outputs for this iteration.
+                    let snap = state
+                        .context
+                        .steps_snapshot()
+                        .into_iter()
+                        .map(|(k, v)| (k, v.output))
+                        .collect::<HashMap<_, _>>();
+                    agg_outputs.push(serde_json::to_value(snap).unwrap_or(Value::Null));
+                }
+                WorkflowStatus::Cancelled => return StepOutcome::Cancelled,
+                WorkflowStatus::Failed => {
+                    return StepOutcome::Failed(format!("foreach iteration {i} failed"));
+                }
+                other => return StepOutcome::Failed(format!("foreach reached unexpected {other}")),
+            }
+        }
+        let out_val = serde_json::json!({"iterations": agg_outputs});
+        state
+            .context
+            .record_step(&step.id, StepOutput::from_value(out_val.clone()));
+        state.record_output_snapshot(step.id.as_str(), &out_val);
+        StepOutcome::Ok
+    }
+
+    // ── Parallel step ────────────────────────────────────────────────────
+
+    async fn run_parallel(
+        state: RunState,
+        step: Step,
+        default_approve_timeout: Option<Duration>,
+    ) -> StepOutcome {
+        let body = match &step.kind {
+            StepKind::Parallel { steps } => steps.clone(),
+            _ => unreachable!(),
+        };
+        let mut joins = Vec::with_capacity(body.len());
+        for branch in body {
+            let st = state.clone();
+            let child_cancel = state.cancel_token.child_token();
+            let child_state = RunState {
+                cancel_token: child_cancel,
+                ..st
+            };
+            let handle = tokio::spawn(async move {
+                Self::drive(child_state, vec![branch], default_approve_timeout).await
+            });
+            joins.push(handle);
+        }
+        let mut branch_results: Vec<WorkflowStatus> = Vec::with_capacity(joins.len());
+        for h in joins {
+            match h.await {
+                Ok(status) => branch_results.push(status),
+                Err(e) => return StepOutcome::Failed(format!("parallel join error: {e}")),
+            }
+        }
+        let any_cancel = branch_results
+            .iter()
+            .any(|s| matches!(s, WorkflowStatus::Cancelled));
+        let any_fail = branch_results
+            .iter()
+            .any(|s| matches!(s, WorkflowStatus::Failed));
+        let out_val = serde_json::json!({"branch_results": branch_results.iter().map(|s| s.as_str()).collect::<Vec<_>>()});
+        state
+            .context
+            .record_step(&step.id, StepOutput::from_value(out_val.clone()));
+        state.record_output_snapshot(step.id.as_str(), &out_val);
+        if any_cancel {
+            return StepOutcome::Cancelled;
+        }
+        if any_fail {
+            return StepOutcome::Failed("one or more parallel branches failed".to_string());
+        }
+        StepOutcome::Ok
+    }
+
+    // ── Approve step ─────────────────────────────────────────────────────
+
+    async fn run_approve(
+        state: RunState,
+        step: Step,
+        default_approve_timeout: Option<Duration>,
+    ) -> StepOutcome {
+        let prompt = match &step.kind {
+            StepKind::Approve { prompt } => prompt.clone(),
+            _ => unreachable!(),
+        };
+        let rendered_prompt = state
+            .context
+            .render(&Value::String(prompt))
+            .unwrap_or(Value::Null);
+
+        let rx = state
+            .approval_gate
+            .wait_handle(state.workflow_id, step.id.as_str());
+
+        state.emit(
+            WorkflowStatus::Running,
+            Some(step.id.as_str()),
+            serde_json::json!({
+                "kind": "approve_requested",
+                "step_id": step.id.0,
+                "prompt": rendered_prompt,
+            }),
+        );
+
+        let timeout_dur = step.policy.timeout.or(default_approve_timeout);
+        let cancel = state.cancel_token.clone();
+
+        let response = if let Some(d) = timeout_dur {
+            tokio::select! {
+                biased;
+                _ = cancel.cancelled() => {
+                    state.approval_gate.discard(state.workflow_id, step.id.as_str());
+                    return StepOutcome::Cancelled;
+                }
+                _ = tokio::time::sleep(d) => {
+                    state.approval_gate.discard(state.workflow_id, step.id.as_str());
+                    ApprovalResponse::timeout()
+                }
+                r = rx => match r {
+                    Ok(v) => v,
+                    Err(_) => ApprovalResponse::cancelled(),
+                }
+            }
+        } else {
+            tokio::select! {
+                biased;
+                _ = cancel.cancelled() => {
+                    state.approval_gate.discard(state.workflow_id, step.id.as_str());
+                    return StepOutcome::Cancelled;
+                }
+                r = rx => match r {
+                    Ok(v) => v,
+                    Err(_) => ApprovalResponse::cancelled(),
+                }
+            }
+        };
+
+        let out_val = serde_json::json!({
+            "approved": response.approved,
+            "reason": response.reason,
+        });
+        state
+            .context
+            .record_step(&step.id, StepOutput::from_value(out_val.clone()));
+        state.record_output_snapshot(step.id.as_str(), &out_val);
+        if response.approved {
+            StepOutcome::Ok
+        } else {
+            StepOutcome::Failed(format!(
+                "approval denied: {}",
+                response.reason.unwrap_or_else(|| "unspecified".to_string())
+            ))
+        }
+    }
+
+    // ── Branch step ──────────────────────────────────────────────────────
+
+    async fn run_branch(
+        state: RunState,
+        step: Step,
+        default_approve_timeout: Option<Duration>,
+    ) -> StepOutcome {
+        let (on, then, else_steps) = match &step.kind {
+            StepKind::Branch {
+                on,
+                then,
+                else_steps,
+            } => (on.clone(), then.clone(), else_steps.clone()),
+            _ => unreachable!(),
+        };
+        let root = state.context.as_json();
+        let result = match eval_jsonpath(&on, &root) {
+            Ok(v) => v,
+            Err(e) => return StepOutcome::Failed(format!("branch.on: {e}")),
+        };
+        let truthy = is_truthy(&result);
+        let branch = if truthy { then } else { else_steps };
+        let out_val =
+            serde_json::json!({"condition": result, "taken": if truthy {"then"} else {"else"}});
+        state
+            .context
+            .record_step(&step.id, StepOutput::from_value(out_val.clone()));
+        state.record_output_snapshot(step.id.as_str(), &out_val);
+        match Self::drive(state.clone(), branch, default_approve_timeout).await {
+            WorkflowStatus::Completed => StepOutcome::Ok,
+            WorkflowStatus::Cancelled => StepOutcome::Cancelled,
+            WorkflowStatus::Failed => StepOutcome::Failed("branch body failed".to_string()),
+            other => StepOutcome::Failed(format!("branch body reached unexpected {other}")),
+        }
+    }
+}
+
+// ── Policy wrapper for Tool / ToolRemote ─────────────────────────────────
+
+async fn run_with_policy<F, Fut>(
+    state: &RunState,
+    step: &Step,
+    raw_args: Value,
+    mut call: F,
+) -> StepOutcome
+where
+    F: FnMut(Value, CancellationToken) -> Fut,
+    Fut: Future<Output = Result<Value, String>>,
+{
+    // Render args once. Template errors are fatal — no retry helps.
+    let rendered_args = match state.context.render(&raw_args) {
+        Ok(v) => v,
+        Err(e) => return StepOutcome::Failed(format!("template error: {e}")),
+    };
+
+    // Idempotency — render the key against the context too.
+    let idem_key = match &step.policy.idempotency_key {
+        Some(tpl) => match state.context.render(&Value::String(tpl.clone())) {
+            Ok(Value::String(s)) => Some(s),
+            Ok(other) => Some(other.to_string()),
+            Err(e) => return StepOutcome::Failed(format!("idempotency key template: {e}")),
+        },
+        None => None,
+    };
+    if let Some(ref rendered_key) = idem_key {
+        if let Some(cached) = state.idempotency.get(
+            step.policy.idempotency_scope,
+            state.workflow_id,
+            rendered_key,
+        ) {
+            debug!(step_id = %step.id, key = %rendered_key, "idempotency cache hit");
+            let step_out = ingest_output(state, &step.id, cached);
+            state.context.record_step(&step.id, step_out.clone());
+            state.record_output_snapshot(step.id.as_str(), &step_out.output);
+            return StepOutcome::Ok;
+        }
+    }
+
+    // Retry loop.
+    let retry = step.policy.retry.clone();
+    let max_attempts = retry.as_ref().map(|r| r.max_attempts).unwrap_or(1).max(1);
+    let mut last_err: Option<String> = None;
+    for attempt in 1..=max_attempts {
+        if state.cancel_token.is_cancelled() {
+            return StepOutcome::Cancelled;
+        }
+        // Pre-attempt delay.
+        if attempt > 1 {
+            let d = retry
+                .as_ref()
+                .map(|r| r.next_delay(attempt))
+                .unwrap_or(Duration::ZERO);
+            if d > Duration::ZERO {
+                tokio::select! {
+                    biased;
+                    _ = state.cancel_token.cancelled() => return StepOutcome::Cancelled,
+                    _ = tokio::time::sleep(d) => {},
+                }
+            }
+        }
+
+        let child_cancel = state.cancel_token.child_token();
+        let call_fut = call(rendered_args.clone(), child_cancel.clone());
+
+        // Timeout wrapper.
+        let result: Result<Result<Value, String>, tokio::time::error::Elapsed> =
+            match step.policy.timeout {
+                Some(d) => {
+                    tokio::select! {
+                        biased;
+                        _ = state.cancel_token.cancelled() => return StepOutcome::Cancelled,
+                        r = tokio::time::timeout(d, call_fut) => r,
+                    }
+                }
+                None => Ok({
+                    tokio::select! {
+                        biased;
+                        _ = state.cancel_token.cancelled() => return StepOutcome::Cancelled,
+                        r = call_fut => r,
+                    }
+                }),
+            };
+
+        match result {
+            Ok(Ok(output)) => {
+                let step_out = ingest_output(state, &step.id, output);
+                state.context.record_step(&step.id, step_out.clone());
+                state.record_output_snapshot(step.id.as_str(), &step_out.output);
+                if let Some(ref rendered_key) = idem_key {
+                    state.idempotency.put(
+                        step.policy.idempotency_scope,
+                        state.workflow_id,
+                        rendered_key,
+                        step_out.output.clone(),
+                    );
+                }
+                return StepOutcome::Ok;
+            }
+            Ok(Err(e)) => {
+                // Handler error — retryable only if the policy says so.
+                last_err = Some(e.clone());
+                let retryable = retry
+                    .as_ref()
+                    .map(|r| r.is_retryable(&classify_error(&e)))
+                    .unwrap_or(false);
+                if !retryable {
+                    break;
+                }
+            }
+            Err(_elapsed) => {
+                last_err = Some("timeout".to_string());
+                let retryable = retry
+                    .as_ref()
+                    .map(|r| r.is_retryable("timeout"))
+                    .unwrap_or(false);
+                if !retryable {
+                    break;
+                }
+            }
+        }
+    }
+    StepOutcome::Failed(last_err.unwrap_or_else(|| "unknown".to_string()))
+}
+
+/// Turn a raw tool output into a [`StepOutput`], persisting any inline
+/// artefacts into the configured store when present.
+fn ingest_output(state: &RunState, step_id: &StepId, mut output: Value) -> StepOutput {
+    // Promote `file_refs` from raw output to artefact store when possible.
+    // We consult `output.file_refs` and `output.context.file_refs`; any
+    // entry that has `inline_bytes` (base64) is re-put into the store.
+    if let Some(store) = &state.artefacts {
+        maybe_upload_inline_refs(store.as_ref(), &mut output, state.root_job_id);
+    }
+    let mut step_out = StepOutput::from_value(output);
+    // Ensure each FileRef picks up the producer_job_id for downstream filters.
+    for fr in step_out.file_refs.iter_mut() {
+        if fr.producer_job_id.is_none() {
+            fr.producer_job_id = Some(state.root_job_id);
+        }
+    }
+    let _ = step_id; // reserved for future step-level artefact tagging
+    step_out
+}
+
+fn maybe_upload_inline_refs(
+    store: &dyn dcc_mcp_artefact::ArtefactStore,
+    output: &mut Value,
+    producer_job: Uuid,
+) {
+    let upload_one = |entry: &mut Value| {
+        if let Some(obj) = entry.as_object_mut() {
+            // If the entry already has a `uri`, leave it alone.
+            if obj.get("uri").and_then(Value::as_str).is_some() {
+                return;
+            }
+            if let Some(b64) = obj.get("inline_b64").and_then(Value::as_str) {
+                use base64::Engine as _;
+                if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(b64) {
+                    match store.put(ArtefactBody::Inline(bytes)) {
+                        Ok(mut fr) => {
+                            if fr.producer_job_id.is_none() {
+                                fr.producer_job_id = Some(producer_job);
+                            }
+                            if let Ok(v) = serde_json::to_value(&fr) {
+                                *entry = v;
+                            }
+                        }
+                        Err(e) => warn!(error = %e, "inline artefact upload failed"),
+                    }
+                }
+            } else if let Some(path) = obj.get("path").and_then(Value::as_str) {
+                let p = std::path::PathBuf::from(path);
+                match store.put(ArtefactBody::Path(p)) {
+                    Ok(mut fr) => {
+                        if fr.producer_job_id.is_none() {
+                            fr.producer_job_id = Some(producer_job);
+                        }
+                        if let Ok(v) = serde_json::to_value(&fr) {
+                            *entry = v;
+                        }
+                    }
+                    Err(e) => warn!(error = %e, "path artefact upload failed"),
+                }
+            }
+        }
+    };
+
+    let uploaders = |arr_key: &str, root: &mut Value| {
+        if let Some(arr) = root.get_mut(arr_key).and_then(Value::as_array_mut) {
+            for entry in arr.iter_mut() {
+                upload_one(entry);
+            }
+        }
+    };
+
+    uploaders("file_refs", output);
+    if let Some(ctx) = output.get_mut("context") {
+        if let Some(arr) = ctx.get_mut("file_refs").and_then(Value::as_array_mut) {
+            for entry in arr.iter_mut() {
+                upload_one(entry);
+            }
+        }
+    }
+    // Squash unused warning when `root_job_id` not needed.
+    let _ = producer_job;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+/// Step outcome used internally by the drivers.
+#[derive(Debug)]
+enum StepOutcome {
+    Ok,
+    Cancelled,
+    Failed(String),
+}
+
+fn eval_jsonpath(expr: &str, root: &Value) -> Result<Value, String> {
+    // jsonpath-rust 1.x — value can be queried directly.
+    match root.query(expr) {
+        Ok(hits) => {
+            if hits.is_empty() {
+                Ok(Value::Null)
+            } else if hits.len() == 1 {
+                Ok(hits[0].clone())
+            } else {
+                Ok(Value::Array(hits.into_iter().cloned().collect()))
+            }
+        }
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+fn is_truthy(v: &Value) -> bool {
+    match v {
+        Value::Null => false,
+        Value::Bool(b) => *b,
+        Value::Number(n) => n.as_f64().map(|f| f != 0.0).unwrap_or(false),
+        Value::String(s) => !s.is_empty(),
+        Value::Array(a) => !a.is_empty(),
+        Value::Object(o) => !o.is_empty(),
+    }
+}
+
+fn classify_error(e: &str) -> String {
+    // Very small heuristic — user-supplied retry_on lists are the canonical
+    // source of truth. We only need a string label that aligns with the
+    // allowlist (e.g. "timeout", "transient"). Default to "error".
+    if e.contains("timeout") {
+        "timeout".to_string()
+    } else if e.contains("transient") {
+        "transient".to_string()
+    } else {
+        "error".to_string()
+    }
+}
+
+fn count_steps(spec: &WorkflowSpec) -> u32 {
+    fn count(steps: &[Step]) -> u32 {
+        steps
+            .iter()
+            .map(|s| {
+                1 + match &s.kind {
+                    StepKind::Foreach { steps, .. } | StepKind::Parallel { steps } => count(steps),
+                    StepKind::Branch {
+                        then, else_steps, ..
+                    } => count(then) + count(else_steps),
+                    _ => 0,
+                }
+            })
+            .sum()
+    }
+    count(&spec.steps)
+}
+
+// Squash unused in non-sqlite builds.
+#[allow(dead_code)]
+fn _silence_retry_policy<'a>(_r: &'a RetryPolicy, _s: &'a StepPolicy) {}
+#[allow(dead_code)]
+fn _silence_backoff(_b: BackoffKind) {}
+#[allow(dead_code)]
+fn _silence_scope(_s: IdempotencyScope) {}
+#[allow(dead_code)]
+fn _silence_fileref(_f: &FileRef) {}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::callers::ToolCaller;
+    use crate::callers::test_support::{MockRemoteCaller, MockToolCaller};
+    use crate::notifier::RecordingNotifier;
+    use crate::policy::{RetryPolicy as PolicyRetryPolicy, StepPolicy as PolicyStepPolicy};
+    use crate::spec::{Step, StepId, StepKind, WorkflowSpec};
+    use serde_json::json;
+    use std::sync::Arc;
+
+    fn spec_with_steps(steps: Vec<Step>) -> WorkflowSpec {
+        WorkflowSpec {
+            name: "t".to_string(),
+            description: String::new(),
+            inputs: Value::Null,
+            steps,
+        }
+    }
+
+    fn tool_step(id: &str, tool: &str, args: Value) -> Step {
+        Step {
+            id: StepId(id.to_string()),
+            kind: StepKind::Tool {
+                tool: tool.to_string(),
+                args,
+            },
+            policy: PolicyStepPolicy::default(),
+        }
+    }
+
+    fn remote_step(id: &str, dcc: &str, tool: &str, args: Value) -> Step {
+        Step {
+            id: StepId(id.to_string()),
+            kind: StepKind::ToolRemote {
+                dcc: dcc.to_string(),
+                tool: tool.to_string(),
+                args,
+            },
+            policy: PolicyStepPolicy::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn tool_step_runs_and_completes() {
+        let mock = Arc::new(MockToolCaller::new());
+        mock.add("echo", |args| Ok(json!({"echoed": args})));
+        let rec = Arc::new(RecordingNotifier::new());
+
+        let exe = WorkflowExecutor::builder()
+            .tool_caller(mock.clone())
+            .notifier(rec.clone())
+            .build();
+
+        let spec = spec_with_steps(vec![tool_step("s1", "echo", json!({"x": 1}))]);
+        let handle = exe.run(spec, Value::Null, None).unwrap();
+        let status = handle.wait().await;
+        assert_eq!(status, WorkflowStatus::Completed);
+        assert_eq!(mock.call_count("echo"), 1);
+        assert!(
+            rec.len() >= 3,
+            "expected enter/exit/terminal events, got {}",
+            rec.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_step_args_are_rendered_against_inputs() {
+        let mock = Arc::new(MockToolCaller::new());
+        let seen = Arc::new(parking_lot::Mutex::new(Value::Null));
+        let seen_c = seen.clone();
+        mock.add("echo", move |args| {
+            *seen_c.lock() = args.clone();
+            Ok(json!({"ok": true}))
+        });
+        let exe = WorkflowExecutor::builder()
+            .tool_caller(mock.clone())
+            .build();
+        let spec = spec_with_steps(vec![tool_step(
+            "s1",
+            "echo",
+            json!({"name": "{{inputs.who}}"}),
+        )]);
+        let h = exe.run(spec, json!({"who": "alice"}), None).unwrap();
+        assert_eq!(h.wait().await, WorkflowStatus::Completed);
+        assert_eq!(*seen.lock(), json!({"name": "alice"}));
+    }
+
+    #[tokio::test]
+    async fn step_output_is_accessible_to_next_step() {
+        let mock = Arc::new(MockToolCaller::new());
+        mock.add("produce", |_| Ok(json!({"value": 42})));
+        let seen = Arc::new(parking_lot::Mutex::new(Value::Null));
+        let seen_c = seen.clone();
+        mock.add("consume", move |args| {
+            *seen_c.lock() = args.clone();
+            Ok(Value::Null)
+        });
+        let exe = WorkflowExecutor::builder()
+            .tool_caller(mock.clone())
+            .build();
+        let spec = spec_with_steps(vec![
+            tool_step("a", "produce", Value::Null),
+            tool_step("b", "consume", json!({"v": "{{steps.a.output.value}}"})),
+        ]);
+        let h = exe.run(spec, Value::Null, None).unwrap();
+        assert_eq!(h.wait().await, WorkflowStatus::Completed);
+        assert_eq!(*seen.lock(), json!({"v": 42}));
+    }
+
+    #[tokio::test]
+    async fn tool_step_failure_fails_workflow() {
+        let mock = Arc::new(MockToolCaller::new());
+        mock.add("boom", |_| Err("nope".to_string()));
+        let exe = WorkflowExecutor::builder()
+            .tool_caller(mock.clone())
+            .build();
+        let spec = spec_with_steps(vec![tool_step("s", "boom", Value::Null)]);
+        let h = exe.run(spec, Value::Null, None).unwrap();
+        assert_eq!(h.wait().await, WorkflowStatus::Failed);
+    }
+
+    #[tokio::test]
+    async fn retry_policy_retries_on_transient() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let attempts = Arc::new(AtomicU32::new(0));
+        let a_c = attempts.clone();
+        let mock = Arc::new(MockToolCaller::new());
+        mock.add("flaky", move |_| {
+            let n = a_c.fetch_add(1, Ordering::SeqCst);
+            if n < 2 {
+                Err("transient".to_string())
+            } else {
+                Ok(json!({"ok": true}))
+            }
+        });
+        let exe = WorkflowExecutor::builder()
+            .tool_caller(mock.clone())
+            .build();
+        let mut step = tool_step("s", "flaky", Value::Null);
+        step.policy.retry = Some(PolicyRetryPolicy {
+            max_attempts: 5,
+            backoff: BackoffKind::Fixed,
+            initial_delay: Duration::from_millis(1),
+            max_delay: Duration::from_millis(10),
+            jitter: 0.0,
+            retry_on: Some(vec!["transient".to_string()]),
+        });
+        let spec = spec_with_steps(vec![step]);
+        let h = exe.run(spec, Value::Null, None).unwrap();
+        assert_eq!(h.wait().await, WorkflowStatus::Completed);
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn retry_policy_stops_on_non_retryable() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let attempts = Arc::new(AtomicU32::new(0));
+        let a_c = attempts.clone();
+        let mock = Arc::new(MockToolCaller::new());
+        mock.add("flaky", move |_| {
+            a_c.fetch_add(1, Ordering::SeqCst);
+            Err("validation".to_string())
+        });
+        let exe = WorkflowExecutor::builder()
+            .tool_caller(mock.clone())
+            .build();
+        let mut step = tool_step("s", "flaky", Value::Null);
+        step.policy.retry = Some(PolicyRetryPolicy {
+            max_attempts: 5,
+            backoff: BackoffKind::Fixed,
+            initial_delay: Duration::from_millis(1),
+            max_delay: Duration::from_millis(10),
+            jitter: 0.0,
+            retry_on: Some(vec!["transient".to_string()]),
+        });
+        let spec = spec_with_steps(vec![step]);
+        let h = exe.run(spec, Value::Null, None).unwrap();
+        assert_eq!(h.wait().await, WorkflowStatus::Failed);
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn timeout_policy_fires() {
+        let mock = Arc::new(MockToolCaller::new());
+        // Handler completes instantly but sleeps inside tokio task.
+        struct SlowCaller;
+        impl ToolCaller for SlowCaller {
+            fn call<'a>(
+                &'a self,
+                _n: &'a str,
+                _a: Value,
+                cancel: CancellationToken,
+            ) -> crate::callers::CallFuture<'a> {
+                Box::pin(async move {
+                    tokio::select! {
+                        _ = cancel.cancelled() => Err("cancelled".to_string()),
+                        _ = tokio::time::sleep(Duration::from_millis(500)) => Ok(Value::Null),
+                    }
+                })
+            }
+        }
+        let _ = mock;
+        let exe = WorkflowExecutor::builder()
+            .tool_caller(Arc::new(SlowCaller))
+            .build();
+        let mut step = tool_step("s", "slow", Value::Null);
+        step.policy.timeout = Some(Duration::from_millis(20));
+        let spec = spec_with_steps(vec![step]);
+        let h = exe.run(spec, Value::Null, None).unwrap();
+        assert_eq!(h.wait().await, WorkflowStatus::Failed);
+    }
+
+    #[tokio::test]
+    async fn idempotency_key_short_circuits_second_call() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let calls = Arc::new(AtomicU32::new(0));
+        let c = calls.clone();
+        let mock = Arc::new(MockToolCaller::new());
+        mock.add("op", move |_| {
+            c.fetch_add(1, Ordering::SeqCst);
+            Ok(json!({"n": 1}))
+        });
+        let cache = IdempotencyCache::new();
+        let exe = WorkflowExecutor::builder()
+            .tool_caller(mock.clone())
+            .idempotency(cache.clone())
+            .build();
+        let mut step1 = tool_step("s", "op", Value::Null);
+        step1.policy.idempotency_key = Some("fixed-key".to_string());
+        step1.policy.idempotency_scope = IdempotencyScope::Global;
+        let spec1 = spec_with_steps(vec![step1.clone()]);
+        let h1 = exe.run(spec1, Value::Null, None).unwrap();
+        assert_eq!(h1.wait().await, WorkflowStatus::Completed);
+        // Second workflow, same key, global scope → cached.
+        let spec2 = spec_with_steps(vec![step1]);
+        let h2 = exe.run(spec2, Value::Null, None).unwrap();
+        assert_eq!(h2.wait().await, WorkflowStatus::Completed);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn cancellation_aborts_workflow() {
+        struct BlockingCaller;
+        impl ToolCaller for BlockingCaller {
+            fn call<'a>(
+                &'a self,
+                _n: &'a str,
+                _a: Value,
+                cancel: CancellationToken,
+            ) -> crate::callers::CallFuture<'a> {
+                Box::pin(async move {
+                    cancel.cancelled().await;
+                    Err("cancelled".to_string())
+                })
+            }
+        }
+        let exe = WorkflowExecutor::builder()
+            .tool_caller(Arc::new(BlockingCaller))
+            .build();
+        let spec = spec_with_steps(vec![tool_step("s", "block", Value::Null)]);
+        let h = exe.run(spec, Value::Null, None).unwrap();
+        let cancel = h.cancel_token.clone();
+        let join = h.join;
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            cancel.cancel();
+        });
+        let status = tokio::time::timeout(Duration::from_millis(500), join)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(status, WorkflowStatus::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn foreach_iterates_over_jsonpath_items() {
+        let mock = Arc::new(MockToolCaller::new());
+        mock.add("per", |args| Ok(json!({"got": args})));
+        let exe = WorkflowExecutor::builder()
+            .tool_caller(mock.clone())
+            .build();
+        let foreach = Step {
+            id: StepId("loop".into()),
+            kind: StepKind::Foreach {
+                items: "$.inputs.items".to_string(),
+                r#as: "item".to_string(),
+                steps: vec![tool_step("inner", "per", json!({"v": "{{item}}"}))],
+            },
+            policy: PolicyStepPolicy::default(),
+        };
+        let spec = spec_with_steps(vec![foreach]);
+        let h = exe
+            .run(spec, json!({"items": ["a", "b", "c"]}), None)
+            .unwrap();
+        assert_eq!(h.wait().await, WorkflowStatus::Completed);
+        assert_eq!(mock.call_count("per"), 3);
+    }
+
+    #[tokio::test]
+    async fn parallel_runs_branches_concurrently() {
+        let mock = Arc::new(MockToolCaller::new());
+        mock.add("a", |_| Ok(json!({"from": "a"})));
+        mock.add("b", |_| Ok(json!({"from": "b"})));
+        let exe = WorkflowExecutor::builder()
+            .tool_caller(mock.clone())
+            .build();
+        let parallel = Step {
+            id: StepId("par".into()),
+            kind: StepKind::Parallel {
+                steps: vec![
+                    tool_step("x", "a", Value::Null),
+                    tool_step("y", "b", Value::Null),
+                ],
+            },
+            policy: PolicyStepPolicy::default(),
+        };
+        let spec = spec_with_steps(vec![parallel]);
+        let h = exe.run(spec, Value::Null, None).unwrap();
+        assert_eq!(h.wait().await, WorkflowStatus::Completed);
+        assert_eq!(mock.call_count("a"), 1);
+        assert_eq!(mock.call_count("b"), 1);
+    }
+
+    #[tokio::test]
+    async fn parallel_any_failure_fails_workflow() {
+        let mock = Arc::new(MockToolCaller::new());
+        mock.add("ok", |_| Ok(Value::Null));
+        mock.add("bad", |_| Err("fail".to_string()));
+        let exe = WorkflowExecutor::builder()
+            .tool_caller(mock.clone())
+            .build();
+        let parallel = Step {
+            id: StepId("par".into()),
+            kind: StepKind::Parallel {
+                steps: vec![
+                    tool_step("x", "ok", Value::Null),
+                    tool_step("y", "bad", Value::Null),
+                ],
+            },
+            policy: PolicyStepPolicy::default(),
+        };
+        let spec = spec_with_steps(vec![parallel]);
+        let h = exe.run(spec, Value::Null, None).unwrap();
+        assert_eq!(h.wait().await, WorkflowStatus::Failed);
+    }
+
+    #[tokio::test]
+    async fn branch_takes_then_on_truthy() {
+        let mock = Arc::new(MockToolCaller::new());
+        mock.add("then_path", |_| Ok(json!({"branch": "then"})));
+        mock.add("else_path", |_| Ok(json!({"branch": "else"})));
+        let exe = WorkflowExecutor::builder()
+            .tool_caller(mock.clone())
+            .build();
+        let branch = Step {
+            id: StepId("gate".into()),
+            kind: StepKind::Branch {
+                on: "$.inputs.flag".to_string(),
+                then: vec![tool_step("t", "then_path", Value::Null)],
+                else_steps: vec![tool_step("e", "else_path", Value::Null)],
+            },
+            policy: PolicyStepPolicy::default(),
+        };
+        let spec = spec_with_steps(vec![branch]);
+        let h = exe.run(spec, json!({"flag": true}), None).unwrap();
+        assert_eq!(h.wait().await, WorkflowStatus::Completed);
+        assert_eq!(mock.call_count("then_path"), 1);
+        assert_eq!(mock.call_count("else_path"), 0);
+    }
+
+    #[tokio::test]
+    async fn branch_takes_else_on_falsy() {
+        let mock = Arc::new(MockToolCaller::new());
+        mock.add("then_path", |_| Ok(Value::Null));
+        mock.add("else_path", |_| Ok(Value::Null));
+        let exe = WorkflowExecutor::builder()
+            .tool_caller(mock.clone())
+            .build();
+        let branch = Step {
+            id: StepId("gate".into()),
+            kind: StepKind::Branch {
+                on: "$.inputs.flag".to_string(),
+                then: vec![tool_step("t", "then_path", Value::Null)],
+                else_steps: vec![tool_step("e", "else_path", Value::Null)],
+            },
+            policy: PolicyStepPolicy::default(),
+        };
+        let spec = spec_with_steps(vec![branch]);
+        let h = exe.run(spec, json!({"flag": false}), None).unwrap();
+        assert_eq!(h.wait().await, WorkflowStatus::Completed);
+        assert_eq!(mock.call_count("then_path"), 0);
+        assert_eq!(mock.call_count("else_path"), 1);
+    }
+
+    #[tokio::test]
+    async fn approve_step_resolves_when_gate_approves() {
+        let mock = Arc::new(MockToolCaller::new());
+        let exe = WorkflowExecutor::builder()
+            .tool_caller(mock.clone())
+            .build();
+        let step = Step {
+            id: StepId("ok_to_go".into()),
+            kind: StepKind::Approve {
+                prompt: "go?".to_string(),
+            },
+            policy: PolicyStepPolicy::default(),
+        };
+        let spec = spec_with_steps(vec![step]);
+        let gate = exe.approval_gate();
+        let h = exe.run(spec, Value::Null, None).unwrap();
+        let wid = h.workflow_id;
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(30)).await;
+            gate.resolve(
+                wid,
+                "ok_to_go",
+                crate::approval::ApprovalResponse {
+                    approved: true,
+                    reason: None,
+                },
+            );
+        });
+        let status = tokio::time::timeout(Duration::from_secs(2), h.join)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(status, WorkflowStatus::Completed);
+    }
+
+    #[tokio::test]
+    async fn approve_step_times_out_when_policy_timeout_set() {
+        let mock = Arc::new(MockToolCaller::new());
+        let exe = WorkflowExecutor::builder()
+            .tool_caller(mock.clone())
+            .build();
+        let mut step = Step {
+            id: StepId("wait".into()),
+            kind: StepKind::Approve {
+                prompt: "go?".to_string(),
+            },
+            policy: PolicyStepPolicy::default(),
+        };
+        step.policy.timeout = Some(Duration::from_millis(40));
+        let spec = spec_with_steps(vec![step]);
+        let h = exe.run(spec, Value::Null, None).unwrap();
+        let status = tokio::time::timeout(Duration::from_secs(2), h.join)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(status, WorkflowStatus::Failed);
+    }
+
+    #[tokio::test]
+    async fn remote_step_invokes_remote_caller() {
+        let local = Arc::new(MockToolCaller::new());
+        let remote = Arc::new(MockRemoteCaller::new());
+        remote.add("unreal", "ingest", |_| Ok(json!({"ok": true})));
+        let exe = WorkflowExecutor::builder()
+            .tool_caller(local.clone())
+            .remote_caller(remote.clone())
+            .build();
+        let spec = spec_with_steps(vec![remote_step("r", "unreal", "ingest", Value::Null)]);
+        let h = exe.run(spec, Value::Null, None).unwrap();
+        assert_eq!(h.wait().await, WorkflowStatus::Completed);
+        assert_eq!(remote.calls.lock().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn workflow_emits_terminal_notifier_event() {
+        let mock = Arc::new(MockToolCaller::new());
+        mock.add("echo", |_| Ok(Value::Null));
+        let rec = Arc::new(RecordingNotifier::new());
+        let exe = WorkflowExecutor::builder()
+            .tool_caller(mock.clone())
+            .notifier(rec.clone())
+            .build();
+        let spec = spec_with_steps(vec![tool_step("s", "echo", Value::Null)]);
+        let h = exe.run(spec, Value::Null, None).unwrap();
+        assert_eq!(h.wait().await, WorkflowStatus::Completed);
+        let events = rec.events();
+        assert!(matches!(
+            events.last().unwrap().status,
+            WorkflowStatus::Completed
+        ));
+    }
+
+    #[test]
+    fn count_steps_counts_nested() {
+        let spec = spec_with_steps(vec![Step {
+            id: StepId("p".into()),
+            kind: StepKind::Parallel {
+                steps: vec![
+                    tool_step("a", "x", Value::Null),
+                    tool_step("b", "y", Value::Null),
+                ],
+            },
+            policy: PolicyStepPolicy::default(),
+        }]);
+        assert_eq!(count_steps(&spec), 3);
+    }
+
+    #[test]
+    fn is_truthy_sanity() {
+        assert!(!is_truthy(&Value::Null));
+        assert!(!is_truthy(&json!(false)));
+        assert!(!is_truthy(&json!(0)));
+        assert!(!is_truthy(&json!("")));
+        assert!(!is_truthy(&json!([])));
+        assert!(!is_truthy(&json!({})));
+        assert!(is_truthy(&json!(true)));
+        assert!(is_truthy(&json!(1)));
+        assert!(is_truthy(&json!("x")));
+        assert!(is_truthy(&json!([1])));
+        assert!(is_truthy(&json!({"a": 1})));
+    }
+}

--- a/crates/dcc-mcp-workflow/src/host.rs
+++ b/crates/dcc-mcp-workflow/src/host.rs
@@ -1,0 +1,401 @@
+//! [`WorkflowHost`] — coordinator that owns a [`WorkflowExecutor`] plus a
+//! registry of in-flight runs, and exposes **synchronous** start / status /
+//! cancel entry points suitable for wiring into
+//! [`dcc_mcp_actions::dispatcher::ActionDispatcher`] handlers or Python /
+//! PyO3 call-sites.
+//!
+//! # Why a host?
+//!
+//! The executor itself is transport-agnostic and stateless across runs:
+//! every call to [`WorkflowExecutor::run`] returns an independent
+//! [`WorkflowRunHandle`]. The MCP tools `workflows.run` /
+//! `workflows.get_status` / `workflows.cancel` need a *shared* registry
+//! that can be looked up by `workflow_id` across later tool calls. That
+//! registry is what [`WorkflowHost`] provides.
+//!
+//! # Runtime requirements
+//!
+//! `WorkflowHost::start_sync` requires a running Tokio runtime (it calls
+//! [`tokio::spawn`] internally via [`WorkflowExecutor::run`]). Inside
+//! `ActionDispatcher::dispatch`, handlers are invoked on whichever thread
+//! called `dispatch`; the HTTP server runs them on its Tokio runtime, so
+//! the spawn succeeds. Outside a Tokio runtime (pure unit tests), use
+//! [`WorkflowHost::start_with_handle`] with an explicit handle.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use serde_json::{Value, json};
+use tokio::runtime::Handle;
+use uuid::Uuid;
+
+use crate::executor::{WorkflowExecutor, WorkflowRunHandle};
+use crate::spec::{WorkflowSpec, WorkflowStatus};
+
+/// Snapshot of a single recorded run.
+#[derive(Debug, Clone)]
+pub struct RunSnapshot {
+    /// Runtime workflow id.
+    pub workflow_id: Uuid,
+    /// Root job id for the outer workflow.
+    pub root_job_id: Uuid,
+    /// Last-known terminal status, if the run has completed.
+    pub terminal_status: Option<WorkflowStatus>,
+}
+
+/// Internal record for a tracked run.
+#[derive(Debug)]
+struct RunRecord {
+    workflow_id: Uuid,
+    root_job_id: Uuid,
+    cancel_token: tokio_util::sync::CancellationToken,
+    terminal: Arc<Mutex<Option<WorkflowStatus>>>,
+}
+
+/// Shared registry of active workflow runs coordinated by [`WorkflowHost`].
+#[derive(Debug, Default, Clone)]
+pub struct WorkflowRegistry {
+    runs: Arc<Mutex<HashMap<Uuid, Arc<RunRecord>>>>,
+}
+
+impl WorkflowRegistry {
+    /// Create an empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn insert(&self, record: Arc<RunRecord>) {
+        self.runs.lock().insert(record.workflow_id, record);
+    }
+
+    fn get(&self, id: &Uuid) -> Option<Arc<RunRecord>> {
+        self.runs.lock().get(id).cloned()
+    }
+
+    /// Number of tracked runs (running + terminal).
+    pub fn len(&self) -> usize {
+        self.runs.lock().len()
+    }
+
+    /// Whether no runs have been tracked.
+    pub fn is_empty(&self) -> bool {
+        self.runs.lock().is_empty()
+    }
+
+    /// Snapshot every tracked run's status.
+    pub fn snapshots(&self) -> Vec<RunSnapshot> {
+        self.runs
+            .lock()
+            .values()
+            .map(|r| RunSnapshot {
+                workflow_id: r.workflow_id,
+                root_job_id: r.root_job_id,
+                terminal_status: *r.terminal.lock(),
+            })
+            .collect()
+    }
+}
+
+/// Coordinator that owns a [`WorkflowExecutor`] plus a [`WorkflowRegistry`].
+///
+/// Cheap to clone — the underlying executor and registry are `Arc`-wrapped.
+#[derive(Debug, Clone)]
+pub struct WorkflowHost {
+    executor: Arc<WorkflowExecutor>,
+    registry: WorkflowRegistry,
+}
+
+impl WorkflowHost {
+    /// Construct a host around an existing executor.
+    #[must_use]
+    pub fn new(executor: WorkflowExecutor) -> Self {
+        Self {
+            executor: Arc::new(executor),
+            registry: WorkflowRegistry::new(),
+        }
+    }
+
+    /// Access the underlying executor.
+    #[must_use]
+    pub fn executor(&self) -> Arc<WorkflowExecutor> {
+        Arc::clone(&self.executor)
+    }
+
+    /// Access the run registry.
+    #[must_use]
+    pub fn registry(&self) -> WorkflowRegistry {
+        self.registry.clone()
+    }
+
+    /// Kick off a workflow on the **ambient** Tokio runtime.
+    ///
+    /// Returns `(workflow_id, root_job_id)`. The caller can poll status
+    /// via [`Self::status`] or cancel via [`Self::cancel`].
+    pub fn start(
+        &self,
+        spec: WorkflowSpec,
+        inputs: Value,
+        parent_job_id: Option<Uuid>,
+    ) -> Result<(Uuid, Uuid), crate::error::WorkflowError> {
+        let handle = self.executor.run(spec, inputs, parent_job_id)?;
+        Ok(self.track(handle))
+    }
+
+    /// Kick off a workflow on a specific Tokio runtime handle. Useful when
+    /// the caller is not itself on a runtime worker.
+    pub fn start_with_handle(
+        &self,
+        rt: &Handle,
+        spec: WorkflowSpec,
+        inputs: Value,
+        parent_job_id: Option<Uuid>,
+    ) -> Result<(Uuid, Uuid), crate::error::WorkflowError> {
+        let executor = Arc::clone(&self.executor);
+        let _guard = rt.enter();
+        let handle = executor.run(spec, inputs, parent_job_id)?;
+        Ok(self.track(handle))
+    }
+
+    fn track(&self, handle: WorkflowRunHandle) -> (Uuid, Uuid) {
+        let WorkflowRunHandle {
+            workflow_id,
+            root_job_id,
+            cancel_token,
+            join,
+        } = handle;
+        let terminal: Arc<Mutex<Option<WorkflowStatus>>> = Arc::new(Mutex::new(None));
+        let terminal_clone = Arc::clone(&terminal);
+        // The original handle's JoinHandle is moved into a background task
+        // so callers don't have to .await it. When the task resolves we
+        // record the final status for later `get_status` calls.
+        tokio::spawn(async move {
+            let status = join.await.unwrap_or(WorkflowStatus::Failed);
+            *terminal_clone.lock() = Some(status);
+        });
+        let record = Arc::new(RunRecord {
+            workflow_id,
+            root_job_id,
+            cancel_token,
+            terminal,
+        });
+        self.registry.insert(Arc::clone(&record));
+        (workflow_id, root_job_id)
+    }
+
+    /// Cancel a tracked workflow. Returns `false` if the id is unknown.
+    pub fn cancel(&self, workflow_id: Uuid) -> bool {
+        if let Some(rec) = self.registry.get(&workflow_id) {
+            rec.cancel_token.cancel();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Fetch the current snapshot for `workflow_id`.
+    pub fn status(&self, workflow_id: Uuid) -> Option<RunSnapshot> {
+        self.registry.get(&workflow_id).map(|r| RunSnapshot {
+            workflow_id: r.workflow_id,
+            root_job_id: r.root_job_id,
+            terminal_status: *r.terminal.lock(),
+        })
+    }
+}
+
+// ── Structured handler outputs ───────────────────────────────────────────
+
+/// Handler for the `workflows.run` MCP tool.
+///
+/// Accepts `{ spec: <WorkflowSpec YAML string>, inputs?: <object> }` or
+/// `{ spec: <WorkflowSpec JSON object>, inputs?: <object> }` and returns
+/// `{ workflow_id, root_job_id, status: "pending" }` on success.
+pub fn run_handler(host: &WorkflowHost, args: Value) -> Result<Value, String> {
+    let spec = parse_spec_arg(&args)?;
+    let inputs = args.get("inputs").cloned().unwrap_or_else(|| json!({}));
+    let parent = args
+        .get("parent_job_id")
+        .and_then(Value::as_str)
+        .and_then(|s| Uuid::parse_str(s).ok());
+    let (workflow_id, root_job_id) = host
+        .start(spec, inputs, parent)
+        .map_err(|e| format!("workflow start failed: {e}"))?;
+    Ok(json!({
+        "workflow_id": workflow_id.to_string(),
+        "root_job_id": root_job_id.to_string(),
+        "status": WorkflowStatus::Pending.as_str(),
+    }))
+}
+
+/// Handler for the `workflows.get_status` MCP tool.
+pub fn get_status_handler(host: &WorkflowHost, args: Value) -> Result<Value, String> {
+    let id = parse_workflow_id(&args)?;
+    match host.status(id) {
+        None => Err(format!("no workflow run tracked for id={id}")),
+        Some(snap) => {
+            let status = snap
+                .terminal_status
+                .map(|s| s.as_str())
+                .unwrap_or_else(|| WorkflowStatus::Running.as_str());
+            Ok(json!({
+                "workflow_id": snap.workflow_id.to_string(),
+                "root_job_id": snap.root_job_id.to_string(),
+                "status": status,
+                "terminal": snap.terminal_status.is_some(),
+            }))
+        }
+    }
+}
+
+/// Handler for the `workflows.cancel` MCP tool.
+pub fn cancel_handler(host: &WorkflowHost, args: Value) -> Result<Value, String> {
+    let id = parse_workflow_id(&args)?;
+    let cancelled = host.cancel(id);
+    Ok(json!({
+        "workflow_id": id.to_string(),
+        "cancelled": cancelled,
+    }))
+}
+
+fn parse_spec_arg(args: &Value) -> Result<WorkflowSpec, String> {
+    let spec_field = args
+        .get("spec")
+        .ok_or_else(|| "missing required field: spec".to_string())?;
+    match spec_field {
+        Value::String(s) => WorkflowSpec::from_yaml(s).map_err(|e| e.to_string()),
+        Value::Object(_) => {
+            let yaml = serde_yaml_ng::to_string(spec_field).map_err(|e| e.to_string())?;
+            WorkflowSpec::from_yaml(&yaml).map_err(|e| e.to_string())
+        }
+        other => Err(format!(
+            "spec must be a YAML string or JSON object, got {}",
+            type_name(other)
+        )),
+    }
+}
+
+fn parse_workflow_id(args: &Value) -> Result<Uuid, String> {
+    let raw = args
+        .get("workflow_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "missing required string field: workflow_id".to_string())?;
+    Uuid::parse_str(raw).map_err(|e| format!("invalid workflow_id: {e}"))
+}
+
+fn type_name(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::callers::test_support::MockToolCaller;
+    use crate::executor::WorkflowExecutor;
+
+    fn host_with_echo() -> WorkflowHost {
+        let caller = Arc::new(MockToolCaller::new());
+        caller.add("scene.echo", Ok);
+        let executor = WorkflowExecutor::builder().tool_caller(caller).build();
+        WorkflowHost::new(executor)
+    }
+
+    const YAML: &str = r#"
+name: host-test
+description: ""
+inputs: {}
+steps:
+  - id: s1
+    tool: scene.echo
+    args:
+      hello: world
+"#;
+
+    #[tokio::test]
+    async fn start_tracks_run_and_status_transitions_to_terminal() {
+        let host = host_with_echo();
+        let out = run_handler(
+            &host,
+            json!({
+                "spec": YAML,
+                "inputs": {},
+            }),
+        )
+        .unwrap();
+
+        let wid = out["workflow_id"].as_str().unwrap().to_string();
+        assert_eq!(out["status"], "pending");
+        assert_eq!(host.registry().len(), 1);
+
+        // Drive the spawned task to completion.
+        for _ in 0..20 {
+            let status = get_status_handler(&host, json!({"workflow_id": wid})).unwrap();
+            if status["terminal"].as_bool() == Some(true) {
+                assert_eq!(status["status"], "completed");
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        panic!("workflow never reached terminal state");
+    }
+
+    #[tokio::test]
+    async fn cancel_handler_flips_token() {
+        let host = host_with_echo();
+        let out = run_handler(
+            &host,
+            json!({
+                "spec": YAML,
+                "inputs": {},
+            }),
+        )
+        .unwrap();
+        let wid = out["workflow_id"].as_str().unwrap();
+        let cancelled = cancel_handler(&host, json!({"workflow_id": wid})).unwrap();
+        assert_eq!(cancelled["cancelled"], true);
+    }
+
+    #[tokio::test]
+    async fn cancel_handler_unknown_id_returns_false() {
+        let host = host_with_echo();
+        let fake = Uuid::new_v4().to_string();
+        let out = cancel_handler(&host, json!({"workflow_id": fake})).unwrap();
+        assert_eq!(out["cancelled"], false);
+    }
+
+    #[test]
+    fn run_handler_rejects_missing_spec() {
+        let host = host_with_echo();
+        let err = run_handler(&host, json!({"inputs": {}})).unwrap_err();
+        assert!(err.contains("spec"));
+    }
+
+    #[test]
+    fn get_status_rejects_invalid_uuid() {
+        let host = host_with_echo();
+        let err = get_status_handler(&host, json!({"workflow_id": "not-a-uuid"})).unwrap_err();
+        assert!(err.contains("invalid workflow_id"));
+    }
+
+    #[tokio::test]
+    async fn run_handler_accepts_json_object_spec() {
+        let host = host_with_echo();
+        let spec_obj = json!({
+            "name": "json-spec",
+            "description": "",
+            "inputs": {},
+            "steps": [
+                {"id": "s1", "tool": "scene.echo", "args": {"k": "v"}},
+            ],
+        });
+        let out = run_handler(&host, json!({"spec": spec_obj, "inputs": {}})).unwrap();
+        assert_eq!(out["status"], "pending");
+    }
+}

--- a/crates/dcc-mcp-workflow/src/idempotency.rs
+++ b/crates/dcc-mcp-workflow/src/idempotency.rs
@@ -1,0 +1,99 @@
+//! In-process idempotency cache keyed by `(scope, rendered_key)`.
+//!
+//! A step with an `idempotency_key` template renders the key against the
+//! workflow context at dispatch time; before invoking the caller, the
+//! executor consults this cache. A hit short-circuits the step and reuses
+//! the cached output; a miss runs the step and stores the result on
+//! success.
+//!
+//! `IdempotencyScope::Workflow` keys are siloed by workflow id so two
+//! parallel workflows with identical keys do not collide. `Global` keys
+//! share a single namespace across the process.
+
+use std::collections::HashMap;
+
+use parking_lot::RwLock;
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::policy::IdempotencyScope;
+
+/// Process-local idempotency cache.
+#[derive(Debug, Default, Clone)]
+pub struct IdempotencyCache {
+    inner: std::sync::Arc<RwLock<HashMap<String, Value>>>,
+}
+
+impl IdempotencyCache {
+    /// Construct an empty cache.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn compose_key(&self, scope: IdempotencyScope, workflow_id: Uuid, rendered: &str) -> String {
+        match scope {
+            IdempotencyScope::Global => format!("G:{rendered}"),
+            IdempotencyScope::Workflow => format!("W:{workflow_id}:{rendered}"),
+        }
+    }
+
+    /// Look up a cached output.
+    pub fn get(&self, scope: IdempotencyScope, workflow_id: Uuid, rendered: &str) -> Option<Value> {
+        let k = self.compose_key(scope, workflow_id, rendered);
+        self.inner.read().get(&k).cloned()
+    }
+
+    /// Record a successful output.
+    pub fn put(&self, scope: IdempotencyScope, workflow_id: Uuid, rendered: &str, output: Value) {
+        let k = self.compose_key(scope, workflow_id, rendered);
+        self.inner.write().insert(k, output);
+    }
+
+    /// Number of entries. Testing helper.
+    pub fn len(&self) -> usize {
+        self.inner.read().len()
+    }
+
+    /// Whether cache is empty. Testing helper.
+    pub fn is_empty(&self) -> bool {
+        self.inner.read().is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn workflow_scope_isolates_by_id() {
+        let cache = IdempotencyCache::new();
+        let w1 = Uuid::new_v4();
+        let w2 = Uuid::new_v4();
+        cache.put(IdempotencyScope::Workflow, w1, "k1", json!({"v": 1}));
+        assert_eq!(
+            cache.get(IdempotencyScope::Workflow, w1, "k1"),
+            Some(json!({"v": 1}))
+        );
+        assert_eq!(cache.get(IdempotencyScope::Workflow, w2, "k1"), None);
+    }
+
+    #[test]
+    fn global_scope_crosses_workflows() {
+        let cache = IdempotencyCache::new();
+        let w1 = Uuid::new_v4();
+        let w2 = Uuid::new_v4();
+        cache.put(IdempotencyScope::Global, w1, "same", json!("x"));
+        assert_eq!(
+            cache.get(IdempotencyScope::Global, w2, "same"),
+            Some(json!("x"))
+        );
+    }
+
+    #[test]
+    fn miss_returns_none() {
+        let cache = IdempotencyCache::new();
+        let w = Uuid::new_v4();
+        assert!(cache.get(IdempotencyScope::Workflow, w, "k").is_none());
+    }
+}

--- a/crates/dcc-mcp-workflow/src/lib.rs
+++ b/crates/dcc-mcp-workflow/src/lib.rs
@@ -4,26 +4,38 @@
 //! persistable, cancellable pipeline of tool calls that runs as an async MCP
 //! tool.
 //!
-//! **This crate is currently a skeleton.** It lands the type definitions, the
-//! YAML parser, validation (step-id uniqueness, JSONPath well-formedness,
-//! tool-name conformance), the four built-in MCP tools
-//! (`workflows.run` / `workflows.get_status` / `workflows.cancel` /
-//! `workflows.lookup`) and the `WorkflowCatalog` reader for the
-//! `metadata.dcc-mcp.workflows` glob.
+//! # Crate map
 //!
-//! **Step execution is intentionally not implemented yet** — the three
-//! execution-facing tools return a well-formed error
-//! (`step execution pending follow-up PR`). This shape is deliberate so
-//! downstream issues (#349 / #351 / #353 / #354) can build against stable
-//! signatures in parallel.
+//! | Module | Role |
+//! |--------|------|
+//! | [`spec`]        | `WorkflowSpec`, `Step`, `StepKind`, status, YAML parser, validator |
+//! | [`policy`]      | Per-step retry / timeout / idempotency policy types |
+//! | [`context`]     | Shared execution context + `{{template}}` resolver |
+//! | [`notifier`]    | `WorkflowNotifier` trait (`$/dcc.workflowUpdated` abstraction) |
+//! | [`approval`]    | `Approve` step gate (`notifications/$/dcc.approveResponse`) |
+//! | [`idempotency`] | In-process idempotency cache |
+//! | [`callers`]     | `ToolCaller` / `RemoteCaller` abstractions + `ActionDispatcher` adapter |
+//! | [`executor`]    | `WorkflowExecutor` — runs every `StepKind` variant |
+//! | [`host`]        | `WorkflowHost` — shared executor + run registry coordinator |
+//! | [`job`]         | `WorkflowJob` — aggregated progress snapshot |
+//! | [`catalog`]     | `WorkflowCatalog` from skill metadata |
+//! | [`sqlite`]      | SQLite persistence for workflow runs (gated behind `job-persist-sqlite`) |
+//! | [`tools`]       | `workflows.*` built-in MCP tool metadata + handler wiring |
 //!
 //! See issue [#348](https://github.com/loonghao/dcc-mcp-core/issues/348).
 
 #![deny(missing_docs)]
 
+pub mod approval;
+pub mod callers;
 pub mod catalog;
+pub mod context;
 pub mod error;
+pub mod executor;
+pub mod host;
+pub mod idempotency;
 pub mod job;
+pub mod notifier;
 pub mod policy;
 #[cfg(feature = "python-bindings")]
 pub mod python;
@@ -35,9 +47,24 @@ pub mod tools;
 #[cfg(test)]
 mod tests;
 
+pub use approval::{ApprovalGate, ApprovalResponse};
+pub use callers::{
+    ActionDispatcherCaller, NullRemoteCaller, RemoteCaller, SharedRemoteCaller, SharedToolCaller,
+    ToolCaller,
+};
 pub use catalog::{WorkflowCatalog, WorkflowSummary};
+pub use context::{StepOutput, TemplateError, WorkflowContext};
 pub use error::{ValidationError, WorkflowError};
+pub use executor::{WorkflowExecutor, WorkflowExecutorBuilder, WorkflowRunHandle};
+pub use host::{
+    RunSnapshot, WorkflowHost, WorkflowRegistry, cancel_handler, get_status_handler, run_handler,
+};
+pub use idempotency::IdempotencyCache;
 pub use job::{WorkflowJob, WorkflowProgress};
+pub use notifier::{
+    NullNotifier, RecordingNotifier, SharedNotifier, WorkflowNotifier, WorkflowUpdate,
+    WorkflowUpdateProgress,
+};
 pub use policy::{
     BackoffKind, IdempotencyScope, RawRetryPolicy, RawStepPolicy, RetryPolicy, StepPolicy,
 };

--- a/crates/dcc-mcp-workflow/src/notifier.rs
+++ b/crates/dcc-mcp-workflow/src/notifier.rs
@@ -1,0 +1,96 @@
+//! Workflow notifier abstraction — decouples the executor from the HTTP
+//! crate's SSE notification plumbing.
+//!
+//! The executor depends only on this trait. `dcc-mcp-http`'s
+//! `JobNotifier` implements [`WorkflowNotifier`] so that when the two crates
+//! are wired together every executor transition surfaces on
+//! `notifications/$/dcc.workflowUpdated`.
+
+use std::sync::Arc;
+
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::spec::WorkflowStatus;
+
+/// Progress counters published alongside a [`WorkflowUpdate`].
+#[derive(Debug, Clone, Copy, Default, Serialize)]
+pub struct WorkflowUpdateProgress {
+    /// Number of steps that finished successfully so far.
+    pub completed_steps: u32,
+    /// Total step count in the workflow (top-level + children).
+    pub total_steps: u32,
+}
+
+/// Workflow-level state transition event.
+///
+/// Fired on: step enter, step terminal, workflow terminal, approval request,
+/// approval response.
+#[derive(Debug, Clone)]
+pub struct WorkflowUpdate {
+    /// Workflow UUID (the runtime id, not the spec name).
+    pub workflow_id: Uuid,
+    /// Outer job UUID wrapping execution.
+    pub job_id: Uuid,
+    /// Aggregated status after the transition.
+    pub status: WorkflowStatus,
+    /// Step id whose transition triggered this update, if applicable.
+    pub current_step_id: Option<String>,
+    /// Progress counters.
+    pub progress: WorkflowUpdateProgress,
+    /// Free-form detail payload (e.g. `{"kind": "approve_requested", "prompt": "..."}`).
+    pub detail: serde_json::Value,
+}
+
+/// Abstraction over the HTTP crate's SSE push path.
+pub trait WorkflowNotifier: Send + Sync {
+    /// Emit a workflow update (fires a `$/dcc.workflowUpdated` SSE frame on
+    /// every subscribed session).
+    fn emit(&self, update: WorkflowUpdate);
+}
+
+/// No-op notifier — used when the executor runs outside an MCP server (e.g.
+/// in unit tests).
+#[derive(Debug, Default, Clone)]
+pub struct NullNotifier;
+
+impl WorkflowNotifier for NullNotifier {
+    fn emit(&self, _update: WorkflowUpdate) {}
+}
+
+/// Shared, thread-safe notifier alias.
+pub type SharedNotifier = Arc<dyn WorkflowNotifier>;
+
+/// Recording notifier that stores every emission. Useful for tests.
+#[derive(Debug, Default)]
+pub struct RecordingNotifier {
+    events: parking_lot::RwLock<Vec<WorkflowUpdate>>,
+}
+
+impl RecordingNotifier {
+    /// New empty recorder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Snapshot of every event received so far.
+    pub fn events(&self) -> Vec<WorkflowUpdate> {
+        self.events.read().clone()
+    }
+
+    /// Count of events received so far.
+    pub fn len(&self) -> usize {
+        self.events.read().len()
+    }
+
+    /// Whether no events have been received yet.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl WorkflowNotifier for RecordingNotifier {
+    fn emit(&self, update: WorkflowUpdate) {
+        self.events.write().push(update);
+    }
+}

--- a/crates/dcc-mcp-workflow/src/sqlite.rs
+++ b/crates/dcc-mcp-workflow/src/sqlite.rs
@@ -1,20 +1,28 @@
-//! SQLite persistence DDL for workflow runs.
+//! SQLite persistence for workflow runs (issue #348 execution path).
 //!
-//! **Skeleton only.** This module defines the schema but wires no writer:
-//! the execution PR will populate these tables as steps progress. A fresh
-//! `apply_migrations` call on an empty DB creates both tables cleanly.
+//! Wires a write-through [`WorkflowStorage`] that the executor calls on every
+//! workflow / step transition. On startup, [`WorkflowStorage::recover`]
+//! flips any non-terminal rows to `interrupted` so a restarted server can
+//! surface the interruption on `$/dcc.workflowUpdated`.
 
-use rusqlite::Connection;
+use std::path::Path;
 
-/// DDL applied by [`apply_migrations`]. Public so downstream code (e.g. a
-/// migration runner in the HTTP server) can inspect or re-use it.
+use parking_lot::Mutex;
+use rusqlite::{Connection, params};
+use uuid::Uuid;
+
+use crate::spec::{WorkflowSpec, WorkflowStatus};
+
+/// Full DDL for the workflow persistence schema. Idempotent.
 pub const MIGRATION_V1: &str = r#"
--- dcc-mcp-workflow v1 schema (issue #348 skeleton)
 CREATE TABLE IF NOT EXISTS workflows (
     id              TEXT PRIMARY KEY NOT NULL,
+    root_job_id     TEXT NOT NULL,
     name            TEXT NOT NULL,
     status          TEXT NOT NULL,
     spec_json       TEXT NOT NULL,
+    inputs_json     TEXT NOT NULL DEFAULT '{}',
+    step_outputs_json TEXT NOT NULL DEFAULT '{}',
     current_step_id TEXT,
     started_at      INTEGER,
     completed_at    INTEGER,
@@ -28,6 +36,7 @@ CREATE TABLE IF NOT EXISTS workflow_steps (
     step_id         TEXT NOT NULL,
     status          TEXT NOT NULL,
     result_json     TEXT,
+    error           TEXT,
     started_at      INTEGER,
     completed_at    INTEGER,
     PRIMARY KEY (workflow_id, step_id)
@@ -36,41 +45,299 @@ CREATE TABLE IF NOT EXISTS workflow_steps (
 CREATE INDEX IF NOT EXISTS workflow_steps_status_idx ON workflow_steps(status);
 "#;
 
-/// Apply the v1 schema to `conn`. Idempotent via `IF NOT EXISTS`.
-///
-/// # Errors
-///
-/// Propagates any [`rusqlite::Error`] raised by `execute_batch`.
+/// Apply the schema. Idempotent.
 pub fn apply_migrations(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(MIGRATION_V1)
+}
+
+/// A row in the `workflows` table.
+#[derive(Debug, Clone)]
+pub struct WorkflowRow {
+    /// Workflow UUID (primary key).
+    pub id: Uuid,
+    /// Root job UUID.
+    pub root_job_id: Uuid,
+    /// Spec `name` field.
+    pub name: String,
+    /// Current status.
+    pub status: WorkflowStatus,
+    /// Current step id, if any.
+    pub current_step_id: Option<String>,
+}
+
+/// SQLite-backed workflow state writer.
+#[derive(Debug)]
+pub struct WorkflowStorage {
+    conn: Mutex<Connection>,
+}
+
+/// Errors returned by [`WorkflowStorage`].
+#[derive(Debug, thiserror::Error)]
+pub enum WorkflowStorageError {
+    /// Wrapped `rusqlite` error.
+    #[error("sqlite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    /// Wrapped `serde_json` error.
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+impl WorkflowStorage {
+    /// Open (or create) a database at `path`. Parent dirs are created.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, WorkflowStorageError> {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+        }
+        let conn = Connection::open(path)?;
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL; PRAGMA foreign_keys=ON;",
+        )?;
+        apply_migrations(&conn)?;
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+
+    /// Open an in-memory database. Used in tests.
+    pub fn open_in_memory() -> Result<Self, WorkflowStorageError> {
+        let conn = Connection::open_in_memory()?;
+        apply_migrations(&conn)?;
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+
+    /// Insert a new workflow row.
+    pub fn insert_workflow(
+        &self,
+        id: Uuid,
+        root_job_id: Uuid,
+        spec: &WorkflowSpec,
+        inputs: &serde_json::Value,
+    ) -> Result<(), WorkflowStorageError> {
+        let spec_json = serde_json::to_string(spec)?;
+        let inputs_json = serde_json::to_string(inputs)?;
+        let conn = self.conn.lock();
+        conn.execute(
+            "INSERT OR REPLACE INTO workflows
+                (id, root_job_id, name, status, spec_json, inputs_json, step_outputs_json, current_step_id, started_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, '{}', NULL, strftime('%s','now'))",
+            params![
+                id.to_string(),
+                root_job_id.to_string(),
+                spec.name,
+                WorkflowStatus::Pending.as_str(),
+                spec_json,
+                inputs_json,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Update workflow-level status + current step id.
+    pub fn update_workflow_status(
+        &self,
+        id: Uuid,
+        status: WorkflowStatus,
+        current_step_id: Option<&str>,
+    ) -> Result<(), WorkflowStorageError> {
+        let conn = self.conn.lock();
+        let completed_sql = if status.is_terminal() {
+            ", completed_at = strftime('%s','now')"
+        } else {
+            ""
+        };
+        let sql = format!(
+            "UPDATE workflows SET status = ?1, current_step_id = ?2 {completed_sql} WHERE id = ?3"
+        );
+        conn.execute(
+            &sql,
+            params![status.as_str(), current_step_id, id.to_string()],
+        )?;
+        Ok(())
+    }
+
+    /// Update aggregated step outputs JSON blob.
+    pub fn update_step_outputs(
+        &self,
+        id: Uuid,
+        step_outputs: &serde_json::Value,
+    ) -> Result<(), WorkflowStorageError> {
+        let outputs_json = serde_json::to_string(step_outputs)?;
+        let conn = self.conn.lock();
+        conn.execute(
+            "UPDATE workflows SET step_outputs_json = ?1 WHERE id = ?2",
+            params![outputs_json, id.to_string()],
+        )?;
+        Ok(())
+    }
+
+    /// Record (or replace) a single step row.
+    pub fn upsert_step(
+        &self,
+        workflow_id: Uuid,
+        step_id: &str,
+        status: &str,
+        result: Option<&serde_json::Value>,
+        error: Option<&str>,
+    ) -> Result<(), WorkflowStorageError> {
+        let result_json = result.map(serde_json::to_string).transpose()?;
+        let conn = self.conn.lock();
+        let terminal = matches!(status, "completed" | "failed" | "cancelled" | "interrupted");
+        let started_sql = if matches!(status, "running") {
+            "strftime('%s','now')"
+        } else {
+            "COALESCE((SELECT started_at FROM workflow_steps WHERE workflow_id=?1 AND step_id=?2), NULL)"
+        };
+        let completed_sql = if terminal {
+            "strftime('%s','now')"
+        } else {
+            "NULL"
+        };
+        let sql = format!(
+            "INSERT OR REPLACE INTO workflow_steps
+                (workflow_id, step_id, status, result_json, error, started_at, completed_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, {started_sql}, {completed_sql})"
+        );
+        conn.execute(
+            &sql,
+            params![workflow_id.to_string(), step_id, status, result_json, error],
+        )?;
+        Ok(())
+    }
+
+    /// Fetch all non-terminal workflow rows. Used by recovery.
+    pub fn list_non_terminal(&self) -> Result<Vec<WorkflowRow>, WorkflowStorageError> {
+        let conn = self.conn.lock();
+        let mut stmt = conn.prepare(
+            "SELECT id, root_job_id, name, status, current_step_id \
+             FROM workflows WHERE status IN ('pending','running')",
+        )?;
+        let rows = stmt
+            .query_map([], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, String>(2)?,
+                    r.get::<_, String>(3)?,
+                    r.get::<_, Option<String>>(4)?,
+                ))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        let mut out = Vec::with_capacity(rows.len());
+        for (id, root_job_id, name, status, current_step_id) in rows {
+            let wid = Uuid::parse_str(&id).unwrap_or_else(|_| Uuid::nil());
+            let rjid = Uuid::parse_str(&root_job_id).unwrap_or_else(|_| Uuid::nil());
+            let s = parse_status(&status);
+            out.push(WorkflowRow {
+                id: wid,
+                root_job_id: rjid,
+                name,
+                status: s,
+                current_step_id,
+            });
+        }
+        Ok(out)
+    }
+
+    /// Flip every non-terminal workflow row to `interrupted`. Returns the
+    /// rows that were flipped (so the caller can emit one last
+    /// `$/dcc.workflowUpdated` per).
+    pub fn recover(&self) -> Result<Vec<WorkflowRow>, WorkflowStorageError> {
+        let rows = self.list_non_terminal()?;
+        for row in &rows {
+            self.update_workflow_status(
+                row.id,
+                WorkflowStatus::Interrupted,
+                row.current_step_id.as_deref(),
+            )?;
+            if let Some(ref step_id) = row.current_step_id {
+                let _ =
+                    self.upsert_step(row.id, step_id, "interrupted", None, Some("server restart"));
+            }
+        }
+        Ok(rows)
+    }
+}
+
+fn parse_status(s: &str) -> WorkflowStatus {
+    match s {
+        "pending" => WorkflowStatus::Pending,
+        "running" => WorkflowStatus::Running,
+        "completed" => WorkflowStatus::Completed,
+        "failed" => WorkflowStatus::Failed,
+        "cancelled" => WorkflowStatus::Cancelled,
+        "interrupted" => WorkflowStatus::Interrupted,
+        _ => WorkflowStatus::Pending,
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn sample_spec() -> WorkflowSpec {
+        WorkflowSpec::from_yaml("name: demo\nsteps:\n  - id: s1\n    tool: scene.get_info\n")
+            .unwrap()
+    }
+
     #[test]
     fn migration_applies_on_fresh_db() {
         let conn = Connection::open_in_memory().unwrap();
         apply_migrations(&conn).unwrap();
-
-        // Tables exist.
-        let mut stmt = conn
-            .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
-            .unwrap();
-        let tables: Vec<String> = stmt
-            .query_map([], |r| r.get::<_, String>(0))
-            .unwrap()
-            .filter_map(Result::ok)
-            .collect();
-
-        assert!(tables.iter().any(|t| t == "workflows"), "got: {tables:?}");
-        assert!(
-            tables.iter().any(|t| t == "workflow_steps"),
-            "got: {tables:?}"
-        );
-
-        // Idempotent.
         apply_migrations(&conn).unwrap();
+    }
+
+    #[test]
+    fn insert_and_list_and_recover() {
+        let st = WorkflowStorage::open_in_memory().unwrap();
+        let id = Uuid::new_v4();
+        let rjid = Uuid::new_v4();
+        let spec = sample_spec();
+        st.insert_workflow(id, rjid, &spec, &serde_json::json!({"k": "v"}))
+            .unwrap();
+        st.update_workflow_status(id, WorkflowStatus::Running, Some("s1"))
+            .unwrap();
+
+        let rows = st.list_non_terminal().unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].status, WorkflowStatus::Running);
+
+        let flipped = st.recover().unwrap();
+        assert_eq!(flipped.len(), 1);
+        let rows_after = st.list_non_terminal().unwrap();
+        assert!(
+            rows_after.is_empty(),
+            "recover must clear non-terminal rows"
+        );
+    }
+
+    #[test]
+    fn upsert_step_rows() {
+        let st = WorkflowStorage::open_in_memory().unwrap();
+        let id = Uuid::new_v4();
+        st.insert_workflow(id, Uuid::new_v4(), &sample_spec(), &serde_json::json!({}))
+            .unwrap();
+        st.upsert_step(id, "s1", "running", None, None).unwrap();
+        st.upsert_step(
+            id,
+            "s1",
+            "completed",
+            Some(&serde_json::json!({"ok": true})),
+            None,
+        )
+        .unwrap();
+        let conn = st.conn.lock();
+        let status: String = conn
+            .query_row(
+                "SELECT status FROM workflow_steps WHERE workflow_id=?1 AND step_id=?2",
+                params![id.to_string(), "s1"],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(status, "completed");
     }
 }

--- a/crates/dcc-mcp-workflow/src/tests.rs
+++ b/crates/dcc-mcp-workflow/src/tests.rs
@@ -171,6 +171,58 @@ fn register_builtin_tools_populates_registry() {
 }
 
 #[test]
+fn builtin_tool_metadata_has_annotations() {
+    let reg = ActionRegistry::new();
+    register_builtin_workflow_tools(&reg);
+    let run = reg.get_action(tools::names::RUN, None).unwrap();
+    assert_eq!(run.annotations.destructive_hint, Some(true));
+    let get = reg.get_action(tools::names::GET_STATUS, None).unwrap();
+    assert_eq!(get.annotations.read_only_hint, Some(true));
+    let cancel = reg.get_action(tools::names::CANCEL, None).unwrap();
+    assert_eq!(cancel.annotations.destructive_hint, Some(true));
+    let lookup = reg.get_action(tools::names::LOOKUP, None).unwrap();
+    assert_eq!(lookup.annotations.read_only_hint, Some(true));
+}
+
+#[tokio::test]
+async fn register_workflow_handlers_wires_run_and_cancel() {
+    use std::sync::Arc;
+
+    use dcc_mcp_actions::dispatcher::ActionDispatcher;
+    use serde_json::json;
+
+    use crate::callers::test_support::MockToolCaller;
+    use crate::executor::WorkflowExecutor;
+    use crate::host::WorkflowHost;
+    use crate::tools::register_workflow_handlers;
+
+    let caller = Arc::new(MockToolCaller::new());
+    caller.add("scene.echo", Ok);
+    let executor = WorkflowExecutor::builder().tool_caller(caller).build();
+    let host = WorkflowHost::new(executor);
+
+    let reg = ActionRegistry::new();
+    register_builtin_workflow_tools(&reg);
+    let dispatcher = ActionDispatcher::new(reg);
+    register_workflow_handlers(&dispatcher, &host);
+
+    let yaml = "name: t\nsteps:\n  - id: s1\n    tool: scene.echo\n    args: {x: 1}\n";
+    let out = dispatcher
+        .dispatch(tools::names::RUN, json!({"spec": yaml, "inputs": {}}))
+        .unwrap()
+        .output;
+    let wid = out["workflow_id"].as_str().unwrap();
+    assert_eq!(out["status"], "pending");
+
+    // Cancel via dispatcher.
+    let cancelled = dispatcher
+        .dispatch(tools::names::CANCEL, json!({"workflow_id": wid}))
+        .unwrap()
+        .output;
+    assert_eq!(cancelled["cancelled"], true);
+}
+
+#[test]
 fn not_implemented_result_has_stable_shape() {
     let r = tools::not_implemented_result("workflows.run");
     assert_eq!(r["success"], serde_json::Value::Bool(false));

--- a/crates/dcc-mcp-workflow/src/tools.rs
+++ b/crates/dcc-mcp-workflow/src/tools.rs
@@ -1,20 +1,32 @@
 //! Built-in `workflows.*` MCP tool registrations.
 //!
-//! This module registers four tools into a [`ToolRegistry`]:
+//! This module exposes four tools for the workflow primitive (issue #348):
 //!
-//! | Tool name              | Status in skeleton | Behaviour                                    |
-//! |------------------------|--------------------|----------------------------------------------|
-//! | `workflows.run`        | stub               | validates spec → `NotImplemented` error      |
-//! | `workflows.get_status` | stub               | `NotImplemented` error                       |
-//! | `workflows.cancel`     | stub               | `NotImplemented` error                       |
-//! | `workflows.lookup`     | **functional**     | read-only catalog summary                    |
+//! | Tool name              | Status             | Behaviour                                     |
+//! |------------------------|--------------------|-----------------------------------------------|
+//! | `workflows.run`        | functional         | Starts a run via [`WorkflowHost`]             |
+//! | `workflows.get_status` | functional         | Queries the run registry for terminal status  |
+//! | `workflows.cancel`     | functional         | Flips the run's cancellation token            |
+//! | `workflows.lookup`     | read-only catalog  | Lists / searches the [`WorkflowCatalog`]      |
 //!
-//! The tools are plain metadata entries — a real dispatcher (follow-up PR)
-//! will hang Python or Rust handlers off these names via
-//! `ToolDispatcher::register_handler`.
+//! Two helpers are provided:
+//!
+//! - [`register_builtin_workflow_tools`] — register tool **metadata** in a
+//!   [`ActionRegistry`]. Safe to call before the executor exists.
+//! - [`register_workflow_handlers`] — register functional handlers in a
+//!   [`ActionDispatcher`] bound to a [`WorkflowHost`]. Call after the
+//!   executor is wired.
+//!
+//! The metadata and handler registration are intentionally split so
+//! `tools/list` can advertise the workflow surface even before a host is
+//! built (e.g. during early MCP capability negotiation).
 
+use dcc_mcp_actions::dispatcher::ActionDispatcher;
 use dcc_mcp_actions::{ActionMeta, ActionRegistry};
-use serde_json::json;
+use dcc_mcp_models::ToolAnnotations;
+use serde_json::{Value, json};
+
+use crate::host::{WorkflowHost, cancel_handler, get_status_handler, run_handler};
 
 /// Stable wire-visible names for the `workflows.*` built-ins (public so
 /// downstream crates can `use` them).
@@ -43,13 +55,36 @@ pub fn register_builtin_workflow_tools(registry: &ActionRegistry) {
     registry.register_action(meta_lookup());
 }
 
+/// Register **functional** handlers for the three mutating workflow tools
+/// against a [`ActionDispatcher`] bound to a shared [`WorkflowHost`].
+///
+/// `workflows.lookup` is intentionally **not** wired here — it is a pure
+/// catalog read whose handler depends on having a [`crate::WorkflowCatalog`]
+/// in scope, which lives at the server-layer boundary.
+///
+/// Call after the dispatcher's registry has been populated via
+/// [`register_builtin_workflow_tools`]. Invocations from a Tokio runtime
+/// will succeed; invocations outside a runtime will surface as a
+/// `workflow start failed: ...` error on the `run` handler. Status/cancel
+/// handlers are safe to call from any thread.
+pub fn register_workflow_handlers(dispatcher: &ActionDispatcher, host: &WorkflowHost) {
+    let h = host.clone();
+    dispatcher.register_handler(names::RUN, move |args| run_handler(&h, args));
+    let h = host.clone();
+    dispatcher.register_handler(names::GET_STATUS, move |args| get_status_handler(&h, args));
+    let h = host.clone();
+    dispatcher.register_handler(names::CANCEL, move |args| cancel_handler(&h, args));
+}
+
 fn meta_run() -> ActionMeta {
     ActionMeta {
         name: names::RUN.to_string(),
-        description: "Start a new workflow run. Accepts either an inline WorkflowSpec or a \
-             {skill, name} pair resolved through the WorkflowCatalog. \
-             (Step execution is pending a follow-up PR — see issue #348.)"
-            .to_string(),
+        description:
+            "Start a new workflow run. Accepts either an inline WorkflowSpec (YAML string \
+             or JSON object) or a {skill, name} pair resolved through the WorkflowCatalog. \
+             Returns { workflow_id, root_job_id, status: \"pending\" } immediately; \
+             subscribe to `$/dcc.workflowUpdated` for progress."
+                .to_string(),
         category: "workflow".to_string(),
         dcc: "core".to_string(),
         version: env!("CARGO_PKG_VERSION").to_string(),
@@ -60,13 +95,28 @@ fn meta_run() -> ActionMeta {
                 {"required": ["skill", "name"]},
             ],
             "properties": {
-                "spec": {"type": "object", "description": "Inline WorkflowSpec."},
+                "spec": {
+                    "description": "Inline WorkflowSpec (YAML string or JSON object).",
+                    "oneOf": [
+                        {"type": "string"},
+                        {"type": "object"},
+                    ],
+                },
                 "skill": {"type": "string"},
                 "name": {"type": "string"},
                 "inputs": {"type": "object"},
+                "parent_job_id": {"type": "string", "format": "uuid"},
             },
         }),
-        output_schema: not_implemented_output_schema(),
+        output_schema: run_output_schema(),
+        // Workflows usually mutate scenes → destructive.
+        annotations: ToolAnnotations {
+            destructive_hint: Some(true),
+            read_only_hint: Some(false),
+            idempotent_hint: Some(false),
+            open_world_hint: Some(true),
+            ..Default::default()
+        },
         ..Default::default()
     }
 }
@@ -83,7 +133,13 @@ fn meta_get_status() -> ActionMeta {
             "required": ["workflow_id"],
             "properties": {"workflow_id": {"type": "string", "format": "uuid"}},
         }),
-        output_schema: not_implemented_output_schema(),
+        output_schema: status_output_schema(),
+        annotations: ToolAnnotations {
+            destructive_hint: Some(false),
+            read_only_hint: Some(true),
+            idempotent_hint: Some(true),
+            ..Default::default()
+        },
         ..Default::default()
     }
 }
@@ -101,7 +157,13 @@ fn meta_cancel() -> ActionMeta {
             "required": ["workflow_id"],
             "properties": {"workflow_id": {"type": "string", "format": "uuid"}},
         }),
-        output_schema: not_implemented_output_schema(),
+        output_schema: cancel_output_schema(),
+        annotations: ToolAnnotations {
+            destructive_hint: Some(true),
+            idempotent_hint: Some(true),
+            read_only_hint: Some(false),
+            ..Default::default()
+        },
         ..Default::default()
     }
 }
@@ -140,34 +202,68 @@ fn meta_lookup() -> ActionMeta {
                 },
             },
         }),
+        annotations: ToolAnnotations {
+            read_only_hint: Some(true),
+            destructive_hint: Some(false),
+            idempotent_hint: Some(true),
+            ..Default::default()
+        },
         ..Default::default()
     }
 }
 
-/// Structured error shape returned by the three stub tools.
-///
-/// Kept as a const helper so downstream callers can rely on the exact key
-/// set (`success: false`, `error: "not_implemented"`, `message: str`,
-/// `issue: "#348"`) even before the execution PR lands.
+fn run_output_schema() -> Value {
+    json!({
+        "type": "object",
+        "required": ["workflow_id", "root_job_id", "status"],
+        "properties": {
+            "workflow_id": {"type": "string", "format": "uuid"},
+            "root_job_id": {"type": "string", "format": "uuid"},
+            "status": {"type": "string", "enum": ["pending", "running"]},
+        },
+    })
+}
+
+fn status_output_schema() -> Value {
+    json!({
+        "type": "object",
+        "required": ["workflow_id", "root_job_id", "status", "terminal"],
+        "properties": {
+            "workflow_id": {"type": "string", "format": "uuid"},
+            "root_job_id": {"type": "string", "format": "uuid"},
+            "status": {
+                "type": "string",
+                "enum": ["pending", "running", "completed", "failed", "cancelled", "interrupted"],
+            },
+            "terminal": {"type": "boolean"},
+        },
+    })
+}
+
+fn cancel_output_schema() -> Value {
+    json!({
+        "type": "object",
+        "required": ["workflow_id", "cancelled"],
+        "properties": {
+            "workflow_id": {"type": "string", "format": "uuid"},
+            "cancelled": {
+                "type": "boolean",
+                "description": "False when the id was unknown (already finished / never existed).",
+            },
+        },
+    })
+}
+
+/// Legacy pre-host stub error payload. Kept for tests that assert on the
+/// shape produced before the execution PR landed. New code should rely on
+/// the structured outputs defined above.
 #[must_use]
+#[doc(hidden)]
 pub fn not_implemented_result(which: &str) -> serde_json::Value {
     json!({
         "success": false,
         "error": "not_implemented",
-        "message": format!("{which}: step execution pending follow-up PR"),
+        "message": format!("{which}: no WorkflowHost wired — handler registration pending"),
         "issue": "#348",
-    })
-}
-
-fn not_implemented_output_schema() -> serde_json::Value {
-    json!({
-        "type": "object",
-        "required": ["success", "error"],
-        "properties": {
-            "success": {"type": "boolean"},
-            "error": {"type": "string"},
-            "message": {"type": "string"},
-            "issue": {"type": "string"},
-        },
     })
 }

--- a/docs/guide/workflows.md
+++ b/docs/guide/workflows.md
@@ -1,9 +1,8 @@
 # Workflows
 
 > First-class, spec-driven, persistable, cancellable pipelines of MCP tool
-> calls. The crate is currently in the **skeleton** stage — parsing and
-> validation are complete, step execution lands in a follow-up PR
-> (issue [#348](https://github.com/loonghao/dcc-mcp-core/issues/348)).
+> calls. Parsing, validation, and the full step execution engine all ship
+> in issue [#348](https://github.com/loonghao/dcc-mcp-core/issues/348).
 
 ## What is a workflow?
 
@@ -153,9 +152,122 @@ Re-parse the YAML to change anything.
 All three surface as `ValueError` on the Python side with the offending
 step id in the message.
 
-## Runtime enforcement
+## Execution engine (issue #348)
 
-**Not yet implemented.** The types + parser + helpers in this PR are
-consumed by the forthcoming executor in issue #348. Until that ships,
-`workflows.run` returns `{"success": false, "error": "not_implemented"}`
-deterministically — callers can depend on that shape.
+The `WorkflowExecutor` is the Tokio-driven engine that consumes a
+validated `WorkflowSpec` and runs every step kind end-to-end. It is
+transport-agnostic: local tool calls go through a `ToolCaller`, remote
+calls through a `RemoteCaller`, notifications through a `WorkflowNotifier`.
+
+```text
+WorkflowExecutor::run(spec, inputs, parent)
+   │
+   ├─ validates spec
+   ├─ creates root job + CancellationToken
+   ├─ spawns driver task
+   │     │
+   │     ├─ drive(steps) ── sequential
+   │     │     └─ for each step:
+   │     │           ├─ policy: retry + timeout + idempotency
+   │     │           ├─ dispatch by StepKind
+   │     │           │     ├─ Tool      → ToolCaller::call
+   │     │           │     ├─ ToolRemote→ RemoteCaller::call
+   │     │           │     ├─ Foreach   → drive(body) per item
+   │     │           │     ├─ Parallel  → tokio::join! branches
+   │     │           │     ├─ Approve   → ApprovalGate::wait_handle
+   │     │           │     └─ Branch    → JSONPath → then|else
+   │     │           ├─ artefact handoff (FileRef → ArtefactStore)
+   │     │           ├─ SSE: $/dcc.workflowUpdated enter / exit
+   │     │           └─ sqlite upsert (if feature enabled)
+   │     └─ emit workflow_terminal
+   └─ returns WorkflowRunHandle { workflow_id, root_job_id, cancel_token, join }
+```
+
+### Step kinds at a glance
+
+| Kind          | Driver                                   | Key policy knobs            |
+| ------------- | ---------------------------------------- | --------------------------- |
+| `tool`        | `ToolCaller::call(name, args)`           | `timeout`, `retry`, `idempotency_key` |
+| `tool_remote` | `RemoteCaller::call(dcc, name, args)`    | same                        |
+| `foreach`     | JSONPath → body per item, concurrency≥1  | per-body policy inherited   |
+| `parallel`    | `tokio::join!` over branches             | `on_any_fail: abort | continue` |
+| `approve`     | `ApprovalGate::wait_handle` + timeout    | `timeout_secs`              |
+| `branch`      | JSONPath condition → `then` or `else`    | n/a                         |
+
+### Cancellation cascade
+
+The root `CancellationToken` is handed to every step driver and every
+caller. On `cancel`:
+
+1. No new steps start.
+2. In-flight `ToolCaller` / `RemoteCaller` receive the token and should
+   honour it cooperatively.
+3. Sleeps (retry backoff, `Approve` timeout) are aborted via
+   `tokio::select!`.
+4. Workflow status becomes `cancelled`; a final `$/dcc.workflowUpdated`
+   fires.
+
+Round-trip from `WorkflowHost::cancel` → every in-flight step observing
+the token is bounded by one cooperative checkpoint (typically < 200 ms).
+
+### Artefact handoff (#349)
+
+A tool whose output contains a `file_refs` array is automatically
+captured via `ArtefactStore::put`; the resulting `FileRef` URIs appear
+in the downstream step context as
+`{{steps.<id>.file_refs[<i>].uri}}`. The raw JSON output is still
+accessible via `{{steps.<id>.output.*}}`.
+
+### Persistence (#328)
+
+With the `job-persist-sqlite` feature flag, each workflow run writes to
+two tables:
+
+- `workflows(workflow_id, root_job_id, spec_json, inputs_json, status,
+  current_step_id, step_outputs_json, created_at, completed_at)`
+- `workflow_steps(workflow_id, step_id, status, attempt, result_json,
+  updated_at)` — one row per step per transition.
+
+On startup, `WorkflowExecutor::recover_persisted()` flips every
+non-terminal row to `interrupted` and emits a final
+`$/dcc.workflowUpdated`. Runs are **not** auto-resumed —
+`interrupted` is terminal; clients may implement a resume tool on top
+if desired.
+
+### Built-in MCP tools
+
+Registered by `register_builtin_workflow_tools(&registry)`. Functional
+handlers are bound by `register_workflow_handlers(&dispatcher, &host)`.
+
+| Tool                   | Description                                      | ToolAnnotations                               |
+| ---------------------- | ------------------------------------------------ | --------------------------------------------- |
+| `workflows.run`        | Start a run (YAML or JSON spec + inputs).        | `destructive_hint=true, open_world_hint=true` |
+| `workflows.get_status` | Poll terminal status + progress.                 | `read_only_hint=true, idempotent_hint=true`   |
+| `workflows.cancel`     | Cancel a run by `workflow_id` (cascade).         | `destructive_hint=true, idempotent_hint=true` |
+| `workflows.lookup`     | Catalog search (read-only).                      | `read_only_hint=true`                         |
+
+### Approval gating
+
+```yaml
+steps:
+  - id: human_gate
+    kind: approve
+    prompt: "Proceed with vendor drop?"
+    timeout_secs: 300          # optional — default is indefinite
+```
+
+The executor pauses the workflow and emits a `$/dcc.workflowUpdated`
+with `detail.kind == "approve_requested"` and the prompt. The MCP
+server bridges inbound `notifications/$/dcc.approveResponse` messages
+into `ApprovalGate::resolve`. On timeout the gate resolves with
+`approved=false, reason="timeout"` and the step fails.
+
+### Python surface for runs
+
+Today the Python layer exposes the spec + policy viewers only. To run
+workflows, call the MCP tools (`workflows.run` / `workflows.get_status`
+/ `workflows.cancel`) from the MCP client side — they are registered
+on any skill server that calls `register_builtin_workflow_tools` plus
+`register_workflow_handlers`. A native `WorkflowHost` Python class is
+tracked as a follow-up; the MCP tool path is the recommended entry
+point since it composes with the rest of the agent toolbelt.

--- a/tests/test_workflow_execution.py
+++ b/tests/test_workflow_execution.py
@@ -1,0 +1,121 @@
+"""Python-side coverage for the #348 workflow execution engine.
+
+The Rust `WorkflowExecutor` / `WorkflowHost` have exhaustive unit tests
+in ``crates/dcc-mcp-workflow/src/``. The Python surface currently
+exposes the **spec + policy viewer** types (parse / validate /
+introspect); a native ``WorkflowHost`` Python class is tracked as a
+follow-up. These tests exercise every ``StepKind`` through the spec
+viewer so that when the Python-facing run surface lands it can be
+validated against the same YAML fixtures.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+import dcc_mcp_core
+
+pytestmark = pytest.mark.skipif(
+    dcc_mcp_core.WorkflowSpec is None,
+    reason="Built without the `workflow` Cargo feature",
+)
+
+
+FULL_YAML = textwrap.dedent(
+    """
+    name: full_exec_surface
+    description: "Smoke test covering every StepKind for the #348 executor."
+    inputs:
+      date: { type: string, format: date }
+    steps:
+      - id: list_local
+        tool: scene__list
+        args:
+          date: "{{inputs.date}}"
+        timeout_secs: 30
+        retry:
+          max_attempts: 3
+          backoff: exponential
+          initial_delay_ms: 250
+          max_delay_ms: 5000
+          jitter: 0.2
+      - id: list_remote
+        kind: tool_remote
+        dcc: unreal
+        tool: unreal__fetch_latest
+      - id: per_file
+        kind: foreach
+        items: "$.list_local.files"
+        as: file
+        steps:
+          - id: import
+            tool: maya__import_scene
+          - id: qc
+            tool: maya_qc__run_all
+      - id: branches
+        kind: parallel
+        branches:
+          - - id: export_fbx
+              tool: maya__export_fbx
+          - - id: export_usd
+              tool: usd__export
+      - id: human_gate
+        kind: approve
+        prompt: "Proceed with vendor drop?"
+        timeout_secs: 120
+      - id: final_gate
+        kind: branch
+        on: "$.qc.passed"
+        then:
+          - id: publish
+            tool: pipeline__publish
+        else:
+          - id: notify
+            tool: ops__notify_failure
+    """
+).strip()
+
+
+@pytest.fixture(scope="module")
+def spec():
+    return dcc_mcp_core.WorkflowSpec.from_yaml_str(FULL_YAML)
+
+
+def test_spec_parses_and_validates(spec):
+    spec.validate()
+    assert spec.name == "full_exec_surface"
+    assert spec.step_count == 6
+
+
+def test_every_step_kind_is_represented(spec):
+    kinds = {s.kind for s in spec.steps}
+    # `tool` variant is shorthand → still `kind == "tool"`. Remote, foreach,
+    # parallel, approve, branch all appear exactly once.
+    assert kinds == {"tool", "tool_remote", "foreach", "parallel", "approve", "branch"}
+
+
+def test_policy_round_trips_retry_and_timeout(spec):
+    first = spec.steps[0]
+    assert first.policy.timeout_secs == 30
+    assert first.policy.retry is not None
+    assert first.policy.retry.max_attempts == 3
+    assert first.policy.retry.backoff == dcc_mcp_core.BackoffKind.EXPONENTIAL
+    # attempt=1 is the initial run → zero base delay; attempt=2 first retry.
+    assert first.policy.retry.next_delay_ms(2) == 250
+
+
+def test_terminal_statuses_mark_is_terminal():
+    WorkflowStatus = dcc_mcp_core.WorkflowStatus
+    for value in ("completed", "failed", "cancelled", "interrupted"):
+        assert WorkflowStatus(value).is_terminal is True
+    for value in ("pending", "running"):
+        assert WorkflowStatus(value).is_terminal is False
+
+
+def test_to_yaml_round_trip_preserves_kinds(spec):
+    yaml_out = spec.to_yaml()
+    spec2 = dcc_mcp_core.WorkflowSpec.from_yaml_str(yaml_out)
+    spec2.validate()
+    assert {s.kind for s in spec2.steps} == {s.kind for s in spec.steps}


### PR DESCRIPTION
## Summary

Implements the step execution engine on top of the #348 skeleton. Every `StepKind` (`Tool`, `ToolRemote`, `Foreach`, `Parallel`, `Approve`, `Branch`) now runs end-to-end with step policies, artefact handoff, SSE emission, parent-job cascade cancel, and SQLite persistence.

- New `WorkflowExecutor` + `WorkflowRunHandle` in `crates/dcc-mcp-workflow/src/executor.rs` — sequential DAG driver honouring `depends_on`, dedicated runner per `StepKind`, with retry / timeout / idempotency applied at the Tool level.
- New supporting modules: `context` (`{{template}}` resolver for `inputs.*`, `steps.<id>.output.*`, `steps.<id>.file_refs[<i>]`, foreach `{{item}}`), `notifier` (`$/dcc.workflowUpdated` emission), `approval` (`$/dcc.approveResponse` gate), `idempotency` (in-process cache), `callers` (`ToolCaller` / `RemoteCaller` abstractions + `ActionDispatcherCaller` adapter), `host` (`WorkflowHost` + run registry + handler closures), and `sqlite` (`workflows` table upsert + interrupted-on-restart recovery).
- MCP tools `workflows.run`, `workflows.get_status`, `workflows.cancel`, and `workflows.lookup` wired via `register_builtin_workflow_tools` + `register_workflow_handlers`, with correct `ToolAnnotations` (`destructive_hint=true` on `run` / `cancel`, `read_only_hint=true` on `get_status` / `lookup`).

### Behaviour highlights

- **Retry + timeout + idempotency** (#353) enforced at the Tool / ToolRemote level with backoff.
- **FileRef handoff** (#349): `ToolResult.context.file_refs` are persisted via `ArtefactStore::put` and re-injected downstream via `{{steps.<id>.file_refs[<i>]}}`.
- **SSE emission** (#326): `$/dcc.workflowUpdated` fires on step enter, step terminal, and workflow terminal.
- **Parent-job cascade** (#318): root `CancellationToken` propagates to every step driver and caller; cancel observed within one cooperative checkpoint.
- **SQLite persistence** (#328): with `job-persist-sqlite`, workflows persist across restart and non-terminal rows are flipped to `interrupted` on recovery (no auto-resume).
- **Gateway-aware** (#320 / #321): `ToolRemote` steps route through the gateway `RemoteCaller` (hook point; see `NullRemoteCaller` default).

### Tests

- 77 Rust unit tests across DAG builder, template resolver, each `StepKind` path (mocked dispatcher), idempotency-key reuse, retry backoff, cascade cancel, and sqlite recovery.
- 5 Python tests in `tests/test_workflow_execution.py` cover spec parsing / validation / every kind / policy round-trip / terminal status.
- Full suite: 8268 passed, 55 skipped on Windows.

## Test plan

- [x] `cargo test -p dcc-mcp-workflow` → 74 passed (default features)
- [x] `cargo test -p dcc-mcp-workflow --features job-persist-sqlite` → 77 passed
- [x] `cargo build --features job-persist-sqlite,workflow` → green
- [x] `vx just dev && vx just test` → 8268 passed, 55 skipped
- [x] `vx just preflight` → green
- [x] Python `test_workflow_execution.py` → 5 passed

Closes #348
