### PR TITLE
feat(core): cron + webhook workflow triggers (#352)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,6 +225,13 @@ Need to interact with DCC?
 → Key types: `StepPolicy { timeout, retry, idempotency_key, idempotency_scope }`, `RetryPolicy::next_delay(n)` helper
 → Executor enforcement is the #348 follow-up PR; this PR (#353) lands types + parser + helpers only
 
+**Scheduled workflow triggers (cron + webhook)?**
+→ [`docs/guide/scheduler.md`](docs/guide/scheduler.md) — sibling `schedules.yaml` schema, HMAC, `max_concurrent` semantics
+→ Opt in with the Cargo `scheduler` feature + `McpHttpConfig(enable_scheduler=True, schedules_dir="…")`
+→ `from dcc_mcp_core import ScheduleSpec, TriggerSpec, parse_schedules_yaml, hmac_sha256_hex, verify_hub_signature_256`
+→ Rust runtime: `dcc_mcp_scheduler::{SchedulerService, SchedulerConfig, SchedulerHandle, JobSink, TriggerFire}` (issue #352)
+→ Call `handle.mark_terminal(id)` on terminal workflow status to release `max_concurrent` gate
+
 **Prometheus `/metrics` scraping (issue #331)?**
 → [`docs/api/observability.md`](docs/api/observability.md) — opt-in
   `prometheus` Cargo feature + `McpHttpConfig(enable_prometheus=True,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,6 +262,22 @@ policy.retry.backoff                     # BackoffKind.{FIXED,LINEAR,EXPONENTIAL
 policy.retry.next_delay_ms(2)            # first-retry base delay, no jitter
 policy.idempotency_scope                 # "workflow" (default) | "global"
 # Executor enforcement is #348 follow-up; this release lands types+parser only.
+
+# Scheduler (#352) — opt in with Cargo feature `scheduler`
+from dcc_mcp_core import (
+    ScheduleSpec, TriggerSpec, parse_schedules_yaml,
+    hmac_sha256_hex, verify_hub_signature_256,
+)
+cfg = McpHttpConfig(port=8765)
+cfg.enable_scheduler = True
+cfg.schedules_dir = "/opt/dcc-mcp/schedules"   # loads *.schedules.yaml
+# ScheduleSpec/TriggerSpec are declarative; the SchedulerService runtime is
+# driven from Rust. Schedules live in sibling schedules.yaml files (never
+# embedded in SKILL.md frontmatter — follow the #356 sibling-file pattern).
+# Cron format is 6-field: "sec min hour day month weekday".
+# Webhook HMAC-SHA256 via X-Hub-Signature-256; secret read from secret_env
+# at startup. On terminal workflow status, host calls
+# SchedulerHandle::mark_terminal(schedule_id) to release max_concurrent.
 ```
 
 ### Gateway lifecycle invariants (issue #303)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/dcc-mcp-http",
     "crates/dcc-mcp-server",
     "crates/dcc-mcp-workflow",
+    "crates/dcc-mcp-scheduler",
     "crates/dcc-mcp-artefact",
 ]
 resolver = "2"
@@ -49,6 +50,7 @@ dcc-mcp-usd = { path = "crates/dcc-mcp-usd" }
 dcc-mcp-http = { path = "crates/dcc-mcp-http" }
 dcc-mcp-server = { path = "crates/dcc-mcp-server" }
 dcc-mcp-workflow = { path = "crates/dcc-mcp-workflow" }
+dcc-mcp-scheduler = { path = "crates/dcc-mcp-scheduler" }
 dcc-mcp-artefact = { path = "crates/dcc-mcp-artefact" }
 
 # Shared dependencies (single version across workspace)
@@ -128,6 +130,9 @@ dcc-mcp-artefact.workspace = true
 # Workflow crate — opt-in via the top-level `workflow` feature.
 dcc-mcp-workflow = { workspace = true, optional = true }
 
+# Scheduler crate — opt-in via the top-level `scheduler` feature (issue #352).
+dcc-mcp-scheduler = { workspace = true, optional = true }
+
 # PyO3 (optional — only for wheel builds)
 pyo3 = { workspace = true, optional = true }
 
@@ -153,11 +158,15 @@ strip = true
 
 [features]
 default = []
-python-bindings = ["pyo3", "dcc-mcp-naming/python-bindings", "dcc-mcp-models/python-bindings", "dcc-mcp-actions/python-bindings", "dcc-mcp-skills/python-bindings", "dcc-mcp-protocols/python-bindings", "dcc-mcp-utils/python-bindings", "dcc-mcp-transport/python-bindings", "dcc-mcp-process/python-bindings", "dcc-mcp-telemetry/python-bindings", "dcc-mcp-sandbox/python-bindings", "dcc-mcp-shm/python-bindings", "dcc-mcp-capture/python-bindings", "dcc-mcp-usd/python-bindings", "dcc-mcp-http/python-bindings", "dcc-mcp-artefact/python-bindings", "dcc-mcp-workflow?/python-bindings"]
+python-bindings = ["pyo3", "dcc-mcp-naming/python-bindings", "dcc-mcp-models/python-bindings", "dcc-mcp-actions/python-bindings", "dcc-mcp-skills/python-bindings", "dcc-mcp-protocols/python-bindings", "dcc-mcp-utils/python-bindings", "dcc-mcp-transport/python-bindings", "dcc-mcp-process/python-bindings", "dcc-mcp-telemetry/python-bindings", "dcc-mcp-sandbox/python-bindings", "dcc-mcp-shm/python-bindings", "dcc-mcp-capture/python-bindings", "dcc-mcp-usd/python-bindings", "dcc-mcp-http/python-bindings", "dcc-mcp-artefact/python-bindings", "dcc-mcp-workflow?/python-bindings", "dcc-mcp-scheduler?/python-bindings"]
 # Opt into the first-class Workflow primitive (issue #348). Off by default
 # for one release — enables WorkflowSpec/WorkflowStatus in Python and the
 # workflows.* built-in tools in Rust. Step execution is stubbed; see #348.
 workflow = ["dep:dcc-mcp-workflow"]
+# Opt into the scheduler subsystem (issue #352). Off by default — enables
+# the cron + webhook-triggered workflow scheduler and exposes
+# ScheduleSpec / TriggerSpec in Python. Requires the `workflow` feature.
+scheduler = ["dep:dcc-mcp-scheduler", "workflow"]
 # Enable the Prometheus `/metrics` exporter (issue #331). Off by default.
 # Forwards to dcc-mcp-http/prometheus, which in turn enables the
 # prometheus feature on dcc-mcp-telemetry. When disabled, zero

--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -317,6 +317,26 @@ pub struct McpHttpConfig {
     ///
     /// [`required_capabilities`]: dcc_mcp_models::ToolDeclaration::required_capabilities
     pub declared_capabilities: Vec<String>,
+
+    /// Enable the cron + webhook scheduler subsystem (issue #352).
+    ///
+    /// Default: `false`. When `true`, the server loads every
+    /// `*.schedules.yaml` file in [`Self::schedules_dir`] at startup,
+    /// spawns one Tokio task per enabled cron schedule, and mounts each
+    /// declared webhook route on the main Axum router.
+    ///
+    /// The scheduler is provided by the optional `dcc-mcp-scheduler`
+    /// crate (feature-gated at the workspace root). When the crate is not
+    /// compiled in, this flag has no effect.
+    pub enable_scheduler: bool,
+
+    /// Directory holding `*.schedules.yaml` files for the scheduler
+    /// subsystem (issue #352).
+    ///
+    /// Only consulted when [`Self::enable_scheduler`] is `true`. Paths
+    /// are loaded non-recursively. A `None` value pairs with
+    /// `enable_scheduler = true` as a no-op (empty schedule set).
+    pub schedules_dir: Option<PathBuf>,
 }
 
 impl McpHttpConfig {
@@ -355,7 +375,17 @@ impl McpHttpConfig {
             enable_job_notifications: true,
             job_storage_path: None,
             declared_capabilities: Vec::new(),
+            enable_scheduler: false,
+            schedules_dir: None,
         }
+    }
+
+    /// Builder: enable the scheduler subsystem and point at a directory
+    /// of `*.schedules.yaml` files (issue #352).
+    pub fn with_scheduler(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.enable_scheduler = true;
+        self.schedules_dir = Some(dir.into());
+        self
     }
 
     /// Builder: persist tracked jobs in a SQLite database at `path`

--- a/crates/dcc-mcp-scheduler/Cargo.toml
+++ b/crates/dcc-mcp-scheduler/Cargo.toml
@@ -1,0 +1,52 @@
+[package]
+name = "dcc-mcp-scheduler"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Cron + webhook-triggered workflow scheduler for the DCC-MCP ecosystem (feature-gated)"
+
+[dependencies]
+pyo3 = { workspace = true, optional = true }
+dcc-mcp-workflow = { workspace = true }
+
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml_ng = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+parking_lot = { workspace = true }
+dashmap = { workspace = true }
+tokio = { workspace = true }
+uuid = { workspace = true }
+
+# Cron parsing + timezone-aware scheduling
+cron = "0.15"
+chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.10"
+
+# HMAC-SHA256 webhook validation
+hmac = "0.12"
+sha2 = "0.10"
+subtle = "2.6"
+hex = "0.4"
+
+# Axum router for webhook endpoints
+axum = { version = "0.8", features = ["http1", "tokio"] }
+bytes = "1"
+
+# Seedable PRNG for jitter testing
+rand = "0.9"
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
+
+[features]
+default = []
+python-bindings = [
+    "pyo3",
+    "dcc-mcp-workflow/python-bindings",
+]

--- a/crates/dcc-mcp-scheduler/src/error.rs
+++ b/crates/dcc-mcp-scheduler/src/error.rs
@@ -1,0 +1,50 @@
+//! Error types for the scheduler crate.
+
+use thiserror::Error;
+
+/// Errors returned by the scheduler.
+#[derive(Debug, Error)]
+pub enum SchedulerError {
+    /// YAML parse / IO failure while loading a `*.schedules.yaml` file.
+    #[error("failed to load schedules from {path}: {message}")]
+    Load {
+        /// Offending path.
+        path: String,
+        /// Underlying error message.
+        message: String,
+    },
+
+    /// A cron expression failed to parse.
+    #[error("invalid cron expression {expression:?}: {message}")]
+    InvalidCron {
+        /// The raw cron string.
+        expression: String,
+        /// Underlying parser message.
+        message: String,
+    },
+
+    /// Unknown `chrono_tz` timezone name.
+    #[error("unknown timezone {timezone:?}")]
+    InvalidTimezone {
+        /// The raw timezone name.
+        timezone: String,
+    },
+
+    /// A duplicate schedule id was declared across the loaded files.
+    #[error("duplicate schedule id {id:?}")]
+    DuplicateId {
+        /// The offending id.
+        id: String,
+    },
+
+    /// A webhook secret env var is referenced but not set.
+    #[error("webhook secret env var {var:?} not set")]
+    MissingSecretEnv {
+        /// Env var name.
+        var: String,
+    },
+
+    /// Validation against the schema failed.
+    #[error("invalid schedule spec: {0}")]
+    Validation(String),
+}

--- a/crates/dcc-mcp-scheduler/src/lib.rs
+++ b/crates/dcc-mcp-scheduler/src/lib.rs
@@ -1,0 +1,74 @@
+//! # dcc-mcp-scheduler
+//!
+//! Scheduler subsystem for the DCC-MCP ecosystem — fires pre-registered
+//! workflows on cron schedules or HTTP webhook events without a human
+//! tool call.
+//!
+//! See issue [#352](https://github.com/loonghao/dcc-mcp-core/issues/352).
+//!
+//! ## Design summary
+//!
+//! * Schedules live in sibling `*.schedules.yaml` files — never embedded in
+//!   `SKILL.md`. A skill points at them via
+//!   `metadata.dcc-mcp.workflow.schedules` (mirrors the #356 sibling-file
+//!   pattern used for workflows).
+//! * [`SchedulerService::start`] consumes a directory of schedule files,
+//!   spawns one Tokio task per cron schedule, and returns an
+//!   [`axum::Router`] holding every declared webhook route.
+//! * On fire, the scheduler builds a [`TriggerFire`] and hands it to the
+//!   caller-supplied [`JobSink`]. The sink is responsible for actually
+//!   enqueueing a `WorkflowJob` via whatever dispatch path exists (see
+//!   `dcc_mcp_workflow::WorkflowJob`). The scheduler does **not** execute
+//!   workflows itself.
+//! * `max_concurrent` is enforced by an in-memory counter the caller
+//!   decrements through [`SchedulerHandle::mark_terminal`] when it observes
+//!   a terminal workflow status (e.g. via `$/dcc.workflowUpdated`).
+//! * Webhook HMAC-SHA256 validation uses the `X-Hub-Signature-256` header
+//!   convention and a constant-time comparison.
+//!
+//! ## Non-goals
+//!
+//! * Distributed scheduling / leader election (single-node only).
+//! * Hot-reload of schedules (pick up on server restart).
+//! * Fire-history UI.
+//!
+//! ## Example
+//!
+//! ```no_run
+//! use std::sync::Arc;
+//! use dcc_mcp_scheduler::{
+//!     JobSink, SchedulerConfig, SchedulerService, TriggerFire,
+//! };
+//!
+//! struct Printer;
+//! impl JobSink for Printer {
+//!     fn enqueue(&self, fire: TriggerFire) -> Result<(), String> {
+//!         println!("fire: schedule={} workflow={}", fire.schedule_id, fire.workflow);
+//!         Ok(())
+//!     }
+//! }
+//!
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! let cfg = SchedulerConfig::from_dir("./schedules")?;
+//! let (handle, router) = SchedulerService::new(cfg, Arc::new(Printer)).start();
+//! // mount `router` on your axum server, keep `handle` alive to keep tasks running
+//! # Ok(()) }
+//! ```
+
+#![deny(missing_docs)]
+
+pub mod error;
+pub mod service;
+pub mod sink;
+pub mod spec;
+pub mod template;
+pub mod webhook;
+
+#[cfg(feature = "python-bindings")]
+pub mod python;
+
+pub use error::SchedulerError;
+pub use service::{SchedulerConfig, SchedulerHandle, SchedulerService};
+pub use sink::{JobSink, TriggerFire};
+pub use spec::{ScheduleSpec, TriggerSpec};
+pub use webhook::{HMAC_HEADER, verify_hub_signature_256};

--- a/crates/dcc-mcp-scheduler/src/python.rs
+++ b/crates/dcc-mcp-scheduler/src/python.rs
@@ -1,0 +1,271 @@
+//! PyO3 bindings for the scheduler crate.
+//!
+//! Only the declarative types are exposed — the runtime
+//! ([`SchedulerService`](crate::SchedulerService)) is driven from Rust
+//! inside the McpHttpServer. Python code can:
+//!
+//! * Parse and validate a `*.schedules.yaml` file (via [`PyScheduleFile`]).
+//! * Build / inspect individual [`PyScheduleSpec`] / [`PyTriggerSpec`] entries.
+//! * Compute and verify HMAC signatures for webhook testing.
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::types::PyType;
+
+use crate::spec::{ScheduleFile, ScheduleSpec, TriggerSpec};
+use crate::webhook::{compute_signature, verify_hub_signature_256};
+
+/// Python wrapper for [`TriggerSpec`].
+#[pyclass(name = "TriggerSpec", module = "dcc_mcp_core._core", from_py_object)]
+#[derive(Debug, Clone)]
+pub struct PyTriggerSpec {
+    inner: TriggerSpec,
+}
+
+#[pymethods]
+impl PyTriggerSpec {
+    /// Build a cron trigger.
+    #[classmethod]
+    #[pyo3(signature = (expression, timezone="UTC", jitter_secs=0))]
+    fn cron(
+        _cls: &Bound<'_, PyType>,
+        expression: &str,
+        timezone: &str,
+        jitter_secs: u32,
+    ) -> PyResult<Self> {
+        crate::service::parse_cron(expression).map_err(|e| PyValueError::new_err(e.to_string()))?;
+        crate::service::parse_timezone(timezone)
+            .map_err(|e| PyValueError::new_err(e.to_string()))?;
+        Ok(Self {
+            inner: TriggerSpec::Cron {
+                expression: expression.to_string(),
+                timezone: timezone.to_string(),
+                jitter_secs,
+            },
+        })
+    }
+
+    /// Build a webhook trigger.
+    #[classmethod]
+    #[pyo3(signature = (path, secret_env=None))]
+    fn webhook(_cls: &Bound<'_, PyType>, path: &str, secret_env: Option<String>) -> PyResult<Self> {
+        if !path.starts_with('/') {
+            return Err(PyValueError::new_err("webhook path must start with '/'"));
+        }
+        Ok(Self {
+            inner: TriggerSpec::Webhook {
+                path: path.to_string(),
+                secret_env,
+            },
+        })
+    }
+
+    /// Trigger kind — `"cron"` or `"webhook"`.
+    #[getter]
+    fn kind(&self) -> &'static str {
+        match self.inner {
+            TriggerSpec::Cron { .. } => "cron",
+            TriggerSpec::Webhook { .. } => "webhook",
+        }
+    }
+
+    /// Cron expression (None for webhook triggers).
+    #[getter]
+    fn expression(&self) -> Option<String> {
+        match &self.inner {
+            TriggerSpec::Cron { expression, .. } => Some(expression.clone()),
+            _ => None,
+        }
+    }
+
+    /// Timezone name (None for webhook triggers).
+    #[getter]
+    fn timezone(&self) -> Option<String> {
+        match &self.inner {
+            TriggerSpec::Cron { timezone, .. } => Some(timezone.clone()),
+            _ => None,
+        }
+    }
+
+    /// Jitter (seconds, 0 for webhook).
+    #[getter]
+    fn jitter_secs(&self) -> u32 {
+        match &self.inner {
+            TriggerSpec::Cron { jitter_secs, .. } => *jitter_secs,
+            _ => 0,
+        }
+    }
+
+    /// Webhook path (None for cron triggers).
+    #[getter]
+    fn path(&self) -> Option<String> {
+        match &self.inner {
+            TriggerSpec::Webhook { path, .. } => Some(path.clone()),
+            _ => None,
+        }
+    }
+
+    /// Webhook secret env var name (None for cron triggers or no-secret webhooks).
+    #[getter]
+    fn secret_env(&self) -> Option<String> {
+        match &self.inner {
+            TriggerSpec::Webhook { secret_env, .. } => secret_env.clone(),
+            _ => None,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!("TriggerSpec(kind={:?})", self.kind())
+    }
+}
+
+/// Python wrapper for [`ScheduleSpec`].
+#[pyclass(
+    name = "ScheduleSpec",
+    module = "dcc_mcp_core._core",
+    skip_from_py_object
+)]
+#[derive(Debug, Clone)]
+pub struct PyScheduleSpec {
+    inner: ScheduleSpec,
+}
+
+#[pymethods]
+impl PyScheduleSpec {
+    /// Construct a schedule spec directly.
+    #[new]
+    #[pyo3(signature = (id, workflow, trigger, inputs=None, enabled=true, max_concurrent=1))]
+    fn new(
+        id: String,
+        workflow: String,
+        trigger: PyTriggerSpec,
+        inputs: Option<&str>,
+        enabled: bool,
+        max_concurrent: u32,
+    ) -> PyResult<Self> {
+        let inputs_val = match inputs {
+            Some(s) => serde_json::from_str(s)
+                .map_err(|e| PyValueError::new_err(format!("invalid JSON for inputs: {e}")))?,
+            None => serde_json::Value::Null,
+        };
+        let spec = ScheduleSpec {
+            id,
+            workflow,
+            inputs: inputs_val,
+            trigger: trigger.inner,
+            enabled,
+            max_concurrent,
+        };
+        spec.validate()
+            .map_err(|e| PyValueError::new_err(e.to_string()))?;
+        Ok(Self { inner: spec })
+    }
+
+    /// Validate the spec (raises `ValueError` on failure).
+    fn validate(&self) -> PyResult<()> {
+        self.inner
+            .validate()
+            .map_err(|e| PyValueError::new_err(e.to_string()))
+    }
+
+    /// Schedule id.
+    #[getter]
+    fn id(&self) -> &str {
+        &self.inner.id
+    }
+
+    /// Workflow name.
+    #[getter]
+    fn workflow(&self) -> &str {
+        &self.inner.workflow
+    }
+
+    /// Workflow inputs rendered as a JSON string (before placeholder substitution).
+    #[getter]
+    fn inputs_json(&self) -> String {
+        self.inner.inputs.to_string()
+    }
+
+    /// Schedule trigger.
+    #[getter]
+    fn trigger(&self) -> PyTriggerSpec {
+        PyTriggerSpec {
+            inner: self.inner.trigger.clone(),
+        }
+    }
+
+    /// Whether the schedule is currently enabled.
+    #[getter]
+    fn enabled(&self) -> bool {
+        self.inner.enabled
+    }
+
+    /// Maximum concurrent in-flight fires (0 = unlimited).
+    #[getter]
+    fn max_concurrent(&self) -> u32 {
+        self.inner.max_concurrent
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "ScheduleSpec(id={:?}, workflow={:?}, trigger_kind={:?})",
+            self.inner.id,
+            self.inner.workflow,
+            match self.inner.trigger {
+                TriggerSpec::Cron { .. } => "cron",
+                TriggerSpec::Webhook { .. } => "webhook",
+            }
+        )
+    }
+}
+
+/// Parse a `*.schedules.yaml` document. Returns a list of
+/// [`PyScheduleSpec`].
+///
+/// # Errors
+///
+/// Raises `ValueError` on parse or validation failure.
+#[pyfunction]
+#[pyo3(name = "parse_schedules_yaml", signature = (source, path_hint="<string>".to_string()))]
+pub fn py_parse_schedules_yaml(source: &str, path_hint: String) -> PyResult<Vec<PyScheduleSpec>> {
+    let file = ScheduleFile::from_yaml_str(source, &path_hint)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+    for s in &file.schedules {
+        s.validate()
+            .map_err(|e| PyValueError::new_err(e.to_string()))?;
+    }
+    Ok(file
+        .schedules
+        .into_iter()
+        .map(|s| PyScheduleSpec { inner: s })
+        .collect())
+}
+
+/// Compute the canonical `sha256=<hex>` HMAC signature for `body` under
+/// `secret`. Exposed for webhook-sender testing.
+#[pyfunction]
+#[pyo3(name = "hmac_sha256_hex")]
+pub fn py_hmac_sha256_hex(secret: &[u8], body: &[u8]) -> String {
+    compute_signature(secret, body)
+}
+
+/// Verify a `X-Hub-Signature-256` header value.
+#[pyfunction]
+#[pyo3(name = "verify_hub_signature_256", signature = (secret, body, header_value))]
+pub fn py_verify_hub_signature_256(secret: &[u8], body: &[u8], header_value: Option<&str>) -> bool {
+    verify_hub_signature_256(secret, body, header_value)
+}
+
+/// Register the scheduler Python classes on the extension module.
+///
+/// # Errors
+///
+/// Propagates PyO3 registration failures.
+pub fn register_classes(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<PyScheduleSpec>()?;
+    m.add_class::<PyTriggerSpec>()?;
+    m.add_function(wrap_pyfunction!(py_parse_schedules_yaml, m)?)?;
+    m.add_function(wrap_pyfunction!(py_hmac_sha256_hex, m)?)?;
+    m.add_function(wrap_pyfunction!(py_verify_hub_signature_256, m)?)?;
+    Ok(())
+}

--- a/crates/dcc-mcp-scheduler/src/service.rs
+++ b/crates/dcc-mcp-scheduler/src/service.rs
@@ -1,0 +1,700 @@
+//! [`SchedulerService`] — the runtime that owns cron tasks and webhook
+//! routes.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use axum::{
+    Json, Router,
+    body::Bytes,
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    response::IntoResponse,
+    routing::post,
+};
+use chrono::{DateTime, Utc};
+use chrono_tz::Tz;
+use cron::Schedule as CronSchedule;
+use dashmap::DashMap;
+use parking_lot::Mutex;
+use serde_json::json;
+use tokio::sync::Notify;
+use tokio::task::JoinHandle;
+
+use crate::error::SchedulerError;
+use crate::sink::{SharedJobSink, TriggerFire, TriggerKind};
+use crate::spec::{ScheduleFile, ScheduleSpec, TriggerSpec};
+use crate::template::{RenderCtx, render_value};
+use crate::webhook::{HMAC_HEADER, verify_hub_signature_256};
+
+/// Parse a cron expression, returning a structural [`CronSchedule`].
+///
+/// # Errors
+///
+/// Returns [`SchedulerError::InvalidCron`] on parse failure.
+pub fn parse_cron(expression: &str) -> Result<CronSchedule, SchedulerError> {
+    expression
+        .parse::<CronSchedule>()
+        .map_err(|e| SchedulerError::InvalidCron {
+            expression: expression.to_string(),
+            message: e.to_string(),
+        })
+}
+
+/// Parse a `chrono_tz` timezone name.
+///
+/// # Errors
+///
+/// Returns [`SchedulerError::InvalidTimezone`] on parse failure.
+pub fn parse_timezone(name: &str) -> Result<Tz, SchedulerError> {
+    name.parse::<Tz>()
+        .map_err(|_| SchedulerError::InvalidTimezone {
+            timezone: name.to_string(),
+        })
+}
+
+// ── Configuration ───────────────────────────────────────────────────────
+
+/// Configuration loaded from a directory of `*.schedules.yaml` files.
+#[derive(Debug, Clone, Default)]
+pub struct SchedulerConfig {
+    /// Parsed, validated schedules.
+    pub schedules: Vec<ScheduleSpec>,
+}
+
+impl SchedulerConfig {
+    /// Collect schedules from every `*.schedules.yaml` file in `dir`
+    /// (non-recursive).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SchedulerError::Load`] on IO or parse failure,
+    /// [`SchedulerError::DuplicateId`] when two schedules share an id,
+    /// or [`SchedulerError::Validation`] on structural problems.
+    pub fn from_dir(dir: impl AsRef<Path>) -> Result<Self, SchedulerError> {
+        let dir = dir.as_ref();
+        let entries = std::fs::read_dir(dir).map_err(|e| SchedulerError::Load {
+            path: dir.display().to_string(),
+            message: e.to_string(),
+        })?;
+        let mut paths: Vec<PathBuf> = Vec::new();
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.is_file()
+                && p.file_name().and_then(|n| n.to_str()).is_some_and(|n| {
+                    n.ends_with(".schedules.yaml") || n.ends_with(".schedules.yml")
+                })
+            {
+                paths.push(p);
+            }
+        }
+        paths.sort();
+        Self::from_paths(&paths)
+    }
+
+    /// Build a [`SchedulerConfig`] from explicit paths.
+    ///
+    /// # Errors
+    ///
+    /// See [`Self::from_dir`].
+    pub fn from_paths(paths: &[PathBuf]) -> Result<Self, SchedulerError> {
+        let mut all: Vec<ScheduleSpec> = Vec::new();
+        for p in paths {
+            let file = ScheduleFile::load(p)?;
+            all.extend(file.schedules);
+        }
+        Self::from_specs(all)
+    }
+
+    /// Validate + deduplicate a raw list of schedules.
+    ///
+    /// # Errors
+    ///
+    /// See [`Self::from_dir`].
+    pub fn from_specs(schedules: Vec<ScheduleSpec>) -> Result<Self, SchedulerError> {
+        let mut seen: std::collections::HashSet<String> =
+            std::collections::HashSet::with_capacity(schedules.len());
+        for s in &schedules {
+            s.validate()?;
+            if !seen.insert(s.id.clone()) {
+                return Err(SchedulerError::DuplicateId { id: s.id.clone() });
+            }
+        }
+        Ok(Self { schedules })
+    }
+}
+
+// ── Concurrency tracking ────────────────────────────────────────────────
+
+#[derive(Debug, Default)]
+struct ConcurrencyTracker {
+    // schedule id -> currently in-flight count
+    counts: DashMap<String, u32>,
+}
+
+impl ConcurrencyTracker {
+    fn try_acquire(&self, id: &str, max: u32) -> bool {
+        if max == 0 {
+            // Unlimited — still record for visibility.
+            *self.counts.entry(id.to_string()).or_insert(0) += 1;
+            return true;
+        }
+        let mut entry = self.counts.entry(id.to_string()).or_insert(0);
+        if *entry >= max {
+            return false;
+        }
+        *entry += 1;
+        true
+    }
+
+    fn release(&self, id: &str) {
+        if let Some(mut entry) = self.counts.get_mut(id) {
+            *entry = entry.saturating_sub(1);
+        }
+    }
+
+    fn in_flight(&self, id: &str) -> u32 {
+        self.counts.get(id).map_or(0, |e| *e)
+    }
+}
+
+// ── Handle ──────────────────────────────────────────────────────────────
+
+/// Opaque handle returned by [`SchedulerService::start`].
+///
+/// Dropping the handle cancels every cron task (via [`Notify`]) and frees
+/// the concurrency tracker; the webhook routes die with the `Router`
+/// they are attached to.
+#[derive(Clone)]
+pub struct SchedulerHandle {
+    inner: Arc<SchedulerInner>,
+}
+
+struct SchedulerInner {
+    tracker: ConcurrencyTracker,
+    shutdown: Notify,
+    tasks: Mutex<Vec<JoinHandle<()>>>,
+    specs_by_id: DashMap<String, ScheduleSpec>,
+}
+
+impl std::fmt::Debug for SchedulerHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SchedulerHandle")
+            .field("schedules", &self.inner.specs_by_id.len())
+            .finish()
+    }
+}
+
+impl SchedulerHandle {
+    /// Called by the host when it observes a terminal workflow status for
+    /// a fire that was enqueued by this schedule id. Decrements the
+    /// in-flight counter so `max_concurrent` admits future fires.
+    pub fn mark_terminal(&self, schedule_id: &str) {
+        self.inner.tracker.release(schedule_id);
+    }
+
+    /// Current in-flight count for a schedule.
+    #[must_use]
+    pub fn in_flight(&self, schedule_id: &str) -> u32 {
+        self.inner.tracker.in_flight(schedule_id)
+    }
+
+    /// Signal cron tasks to stop. Running tasks observe the notification
+    /// at their next wake-up.
+    pub fn shutdown(&self) {
+        self.inner.shutdown.notify_waiters();
+        let mut tasks = self.inner.tasks.lock();
+        for t in tasks.drain(..) {
+            t.abort();
+        }
+    }
+
+    /// Number of registered schedules.
+    #[must_use]
+    pub fn schedule_count(&self) -> usize {
+        self.inner.specs_by_id.len()
+    }
+}
+
+impl Drop for SchedulerInner {
+    fn drop(&mut self) {
+        self.shutdown.notify_waiters();
+        let mut tasks = self.tasks.lock();
+        for t in tasks.drain(..) {
+            t.abort();
+        }
+    }
+}
+
+// ── Service ─────────────────────────────────────────────────────────────
+
+/// Runtime that owns cron tasks and produces the webhook router.
+pub struct SchedulerService {
+    config: SchedulerConfig,
+    sink: SharedJobSink,
+    // seed for jitter; None → real rng. Exposed for tests.
+    jitter_seed: Option<u64>,
+}
+
+impl SchedulerService {
+    /// Create a service over a prepared config and sink.
+    #[must_use]
+    pub fn new(config: SchedulerConfig, sink: SharedJobSink) -> Self {
+        Self {
+            config,
+            sink,
+            jitter_seed: None,
+        }
+    }
+
+    /// Seed the jitter PRNG (tests only — for deterministic behaviour).
+    #[must_use]
+    pub fn with_jitter_seed(mut self, seed: u64) -> Self {
+        self.jitter_seed = Some(seed);
+        self
+    }
+
+    /// Spawn cron tasks and return `(handle, webhook_router)`.
+    ///
+    /// The router carries routes for every enabled webhook schedule;
+    /// callers merge it into their axum app with `Router::merge`.
+    pub fn start(self) -> (SchedulerHandle, Router) {
+        let inner = Arc::new(SchedulerInner {
+            tracker: ConcurrencyTracker::default(),
+            shutdown: Notify::new(),
+            tasks: Mutex::new(Vec::new()),
+            specs_by_id: DashMap::new(),
+        });
+        let handle = SchedulerHandle {
+            inner: inner.clone(),
+        };
+
+        for spec in &self.config.schedules {
+            inner.specs_by_id.insert(spec.id.clone(), spec.clone());
+        }
+
+        // Spawn cron drivers.
+        for spec in self.config.schedules.iter().cloned() {
+            if !spec.enabled {
+                continue;
+            }
+            if let TriggerSpec::Cron { .. } = spec.trigger {
+                let task =
+                    spawn_cron_task(spec, inner.clone(), self.sink.clone(), self.jitter_seed);
+                inner.tasks.lock().push(task);
+            }
+        }
+
+        // Build webhook router.
+        let router = build_webhook_router(&self.config, self.sink.clone(), inner.clone());
+
+        (handle, router)
+    }
+}
+
+// ── Cron driver ─────────────────────────────────────────────────────────
+
+fn spawn_cron_task(
+    spec: ScheduleSpec,
+    inner: Arc<SchedulerInner>,
+    sink: SharedJobSink,
+    jitter_seed: Option<u64>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let (expression, tz_name, jitter) = match &spec.trigger {
+            TriggerSpec::Cron {
+                expression,
+                timezone,
+                jitter_secs,
+            } => (expression.clone(), timezone.clone(), *jitter_secs),
+            _ => return,
+        };
+        let schedule = match parse_cron(&expression) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!("scheduler[{}]: {e}", spec.id);
+                return;
+            }
+        };
+        let tz = parse_timezone(&tz_name).unwrap_or(chrono_tz::UTC);
+
+        loop {
+            let now_tz = Utc::now().with_timezone(&tz);
+            let next = match schedule.upcoming(tz).next() {
+                Some(t) => t,
+                None => {
+                    tracing::warn!(
+                        "scheduler[{}]: cron expression {:?} produced no upcoming times",
+                        spec.id,
+                        expression
+                    );
+                    return;
+                }
+            };
+            let mut delay = (next - now_tz).to_std().unwrap_or(Duration::from_millis(0));
+            if jitter > 0 {
+                let extra = jitter_duration(jitter, jitter_seed, &spec.id, next);
+                delay += extra;
+            }
+            // Minimum 1ms sleep to avoid tight loops if delay collapses.
+            if delay.is_zero() {
+                delay = Duration::from_millis(1);
+            }
+            tokio::select! {
+                _ = tokio::time::sleep(delay) => {}
+                _ = inner.shutdown.notified() => {
+                    tracing::debug!("scheduler[{}]: shutdown", spec.id);
+                    return;
+                }
+            }
+
+            // Fire (unless concurrency gate rejects).
+            if !inner.tracker.try_acquire(&spec.id, spec.max_concurrent) {
+                tracing::info!(
+                    "scheduler[{}]: skipped (in-flight={}, max_concurrent={})",
+                    spec.id,
+                    inner.tracker.in_flight(&spec.id),
+                    spec.max_concurrent
+                );
+                // Busy-wait: poll the cron schedule for its *next* fire time
+                // rather than immediately retrying. We simply loop — the
+                // next iteration picks up a fresh `upcoming`.
+                // Prevent a tight loop if next is immediate by a brief
+                // grace period.
+                tokio::select! {
+                    _ = tokio::time::sleep(Duration::from_millis(500)) => {}
+                    _ = inner.shutdown.notified() => return,
+                }
+                continue;
+            }
+
+            let fired_at = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            let payload = serde_json::Value::Object(serde_json::Map::new());
+            let ctx = RenderCtx {
+                payload: &payload,
+                schedule_id: &spec.id,
+                workflow: &spec.workflow,
+            };
+            let inputs = render_value(&spec.inputs, &ctx);
+            let fire = TriggerFire {
+                kind: TriggerKind::Cron,
+                schedule_id: spec.id.clone(),
+                workflow: spec.workflow.clone(),
+                inputs,
+                payload,
+                fired_at,
+            };
+
+            if let Err(err) = sink.enqueue(fire) {
+                tracing::warn!("scheduler[{}]: sink error: {err}", spec.id);
+                inner.tracker.release(&spec.id);
+            }
+        }
+    })
+}
+
+fn jitter_duration(
+    max_secs: u32,
+    seed: Option<u64>,
+    schedule_id: &str,
+    next: DateTime<Tz>,
+) -> Duration {
+    use rand::{Rng, SeedableRng};
+    if max_secs == 0 {
+        return Duration::ZERO;
+    }
+    let max_ms = (u64::from(max_secs)).saturating_mul(1000);
+    let secs = match seed {
+        Some(s) => {
+            // Mix in schedule id + next fire time so each fire gets a
+            // different draw while remaining deterministic for a given
+            // (seed, schedule, fire-time) triple.
+            let mix = s ^ hash64(schedule_id) ^ (next.timestamp() as u64);
+            rand::rngs::StdRng::seed_from_u64(mix).random_range(0..=max_ms)
+        }
+        None => rand::rng().random_range(0..=max_ms),
+    };
+    Duration::from_millis(secs)
+}
+
+fn hash64(s: &str) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    s.hash(&mut h);
+    h.finish()
+}
+
+// ── Webhook router ──────────────────────────────────────────────────────
+
+#[derive(Clone)]
+struct WebhookState {
+    spec: ScheduleSpec,
+    sink: SharedJobSink,
+    inner: Arc<SchedulerInner>,
+    secret: Option<Vec<u8>>,
+}
+
+fn build_webhook_router(
+    cfg: &SchedulerConfig,
+    sink: SharedJobSink,
+    inner: Arc<SchedulerInner>,
+) -> Router {
+    let mut router = Router::new();
+    for spec in &cfg.schedules {
+        if !spec.enabled {
+            continue;
+        }
+        let (path, secret_env) = match &spec.trigger {
+            TriggerSpec::Webhook { path, secret_env } => (path.clone(), secret_env.clone()),
+            _ => continue,
+        };
+        let secret = match secret_env.as_deref() {
+            Some(var) => match std::env::var(var) {
+                Ok(v) => Some(v.into_bytes()),
+                Err(_) => {
+                    tracing::warn!(
+                        "scheduler[{}]: webhook secret env var {:?} not set at startup",
+                        spec.id,
+                        var
+                    );
+                    // Keep the env name so we can fail-loud on request.
+                    None
+                }
+            },
+            None => None,
+        };
+        let state = WebhookState {
+            spec: spec.clone(),
+            sink: sink.clone(),
+            inner: inner.clone(),
+            secret,
+        };
+        router = router.route(&path, post(handle_webhook).with_state(state));
+    }
+    router
+}
+
+async fn handle_webhook(
+    State(state): State<WebhookState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> axum::response::Response {
+    let WebhookState {
+        spec,
+        sink,
+        inner,
+        secret,
+    } = state;
+
+    // HMAC validation.
+    if let TriggerSpec::Webhook {
+        secret_env: Some(var),
+        ..
+    } = &spec.trigger
+    {
+        let Some(key) = secret.as_deref() else {
+            tracing::error!(
+                "scheduler[{}]: refusing request, secret env {:?} not set",
+                spec.id,
+                var
+            );
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "webhook_secret_missing", "env": var})),
+            )
+                .into_response();
+        };
+        let header_val = headers.get(HMAC_HEADER).and_then(|h| h.to_str().ok());
+        if !verify_hub_signature_256(key, body.as_ref(), header_val) {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({"error": "invalid_signature"})),
+            )
+                .into_response();
+        }
+    }
+
+    let payload: serde_json::Value = if body.is_empty() {
+        serde_json::Value::Object(serde_json::Map::new())
+    } else {
+        match serde_json::from_slice(&body) {
+            Ok(v) => v,
+            Err(e) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({"error": "invalid_json", "message": e.to_string()})),
+                )
+                    .into_response();
+            }
+        }
+    };
+
+    if !inner.tracker.try_acquire(&spec.id, spec.max_concurrent) {
+        return (
+            StatusCode::TOO_MANY_REQUESTS,
+            Json(json!({
+                "error": "max_concurrent_exceeded",
+                "schedule_id": spec.id,
+                "in_flight": inner.tracker.in_flight(&spec.id),
+                "max_concurrent": spec.max_concurrent,
+            })),
+        )
+            .into_response();
+    }
+
+    let fired_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let ctx = RenderCtx {
+        payload: &payload,
+        schedule_id: &spec.id,
+        workflow: &spec.workflow,
+    };
+    let inputs = render_value(&spec.inputs, &ctx);
+    let fire = TriggerFire {
+        kind: TriggerKind::Webhook,
+        schedule_id: spec.id.clone(),
+        workflow: spec.workflow.clone(),
+        inputs: inputs.clone(),
+        payload,
+        fired_at,
+    };
+
+    match sink.enqueue(fire) {
+        Ok(()) => (
+            StatusCode::ACCEPTED,
+            Json(json!({
+                "status": "enqueued",
+                "schedule_id": spec.id,
+                "workflow": spec.workflow,
+                "inputs": inputs,
+            })),
+        )
+            .into_response(),
+        Err(err) => {
+            inner.tracker.release(&spec.id);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "sink_failed", "message": err})),
+            )
+                .into_response()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sink::RecordingSink;
+    use chrono::TimeZone;
+    use std::sync::Arc;
+
+    fn cron_spec(id: &str, expr: &str) -> ScheduleSpec {
+        ScheduleSpec {
+            id: id.into(),
+            workflow: "w".into(),
+            inputs: serde_json::Value::Null,
+            trigger: TriggerSpec::Cron {
+                expression: expr.into(),
+                timezone: "UTC".into(),
+                jitter_secs: 0,
+            },
+            enabled: true,
+            max_concurrent: 1,
+        }
+    }
+
+    #[test]
+    fn rejects_duplicate_ids() {
+        let a = cron_spec("same", "* * * * * *");
+        let b = cron_spec("same", "*/5 * * * * *");
+        let err = SchedulerConfig::from_specs(vec![a, b]).unwrap_err();
+        assert!(matches!(err, SchedulerError::DuplicateId { .. }));
+    }
+
+    #[test]
+    fn accepts_six_field_cron() {
+        let s = cron_spec("every_sec", "* * * * * *");
+        SchedulerConfig::from_specs(vec![s]).unwrap();
+    }
+
+    #[test]
+    fn concurrency_tracker_respects_max() {
+        let t = ConcurrencyTracker::default();
+        assert!(t.try_acquire("s", 2));
+        assert!(t.try_acquire("s", 2));
+        assert!(!t.try_acquire("s", 2));
+        t.release("s");
+        assert!(t.try_acquire("s", 2));
+    }
+
+    #[test]
+    fn concurrency_tracker_unlimited_when_zero() {
+        let t = ConcurrencyTracker::default();
+        for _ in 0..10 {
+            assert!(t.try_acquire("s", 0));
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cron_every_second_fires_multiple_times() {
+        let cfg = SchedulerConfig::from_specs(vec![cron_spec("tick", "* * * * * *")]).unwrap();
+        let sink = Arc::new(RecordingSink::new());
+        let (handle, _router) = SchedulerService::new(cfg, sink.clone()).start();
+        // Release the concurrency gate each time — the schedule has
+        // max_concurrent=1 so we need to mark_terminal to allow subsequent fires.
+        let handle_clone = handle.clone();
+        let releaser = tokio::spawn(async move {
+            for _ in 0..6 {
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                handle_clone.mark_terminal("tick");
+            }
+        });
+        tokio::time::sleep(Duration::from_millis(2500)).await;
+        handle.shutdown();
+        let _ = releaser.await;
+        let n = sink.len();
+        assert!(n >= 2, "expected at least 2 fires in 2.5s window, got {n}");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn max_concurrent_skips_when_not_released() {
+        let cfg = SchedulerConfig::from_specs(vec![cron_spec("hold", "* * * * * *")]).unwrap();
+        let sink = Arc::new(RecordingSink::new());
+        let (handle, _router) = SchedulerService::new(cfg, sink.clone()).start();
+        // Do NOT call mark_terminal — in-flight stays at 1 so subsequent
+        // fires are skipped.
+        tokio::time::sleep(Duration::from_millis(3500)).await;
+        handle.shutdown();
+        let n = sink.len();
+        assert_eq!(n, 1, "expected exactly 1 fire with no release, got {n}");
+    }
+
+    #[test]
+    fn jitter_seeded_is_deterministic() {
+        let tz_date = chrono_tz::UTC
+            .with_ymd_and_hms(2030, 1, 1, 0, 0, 0)
+            .unwrap();
+        let a = jitter_duration(120, Some(42), "id", tz_date);
+        let b = jitter_duration(120, Some(42), "id", tz_date);
+        assert_eq!(a, b);
+        let c = jitter_duration(120, Some(43), "id", tz_date);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn jitter_within_bounds() {
+        let tz_date = chrono_tz::UTC
+            .with_ymd_and_hms(2030, 1, 1, 0, 0, 0)
+            .unwrap();
+        for i in 0..20 {
+            let d = jitter_duration(5, Some(i), "id", tz_date);
+            assert!(d <= Duration::from_secs(5));
+        }
+    }
+}

--- a/crates/dcc-mcp-scheduler/src/sink.rs
+++ b/crates/dcc-mcp-scheduler/src/sink.rs
@@ -1,0 +1,105 @@
+//! Trait that receives fired schedules and hands them off to a real
+//! workflow dispatcher.
+//!
+//! The scheduler crate is deliberately agnostic about how workflows are
+//! executed: it only decides **when** to fire. Downstream callers wire a
+//! [`JobSink`] that resolves the workflow name against their
+//! `WorkflowCatalog` and enqueues a `WorkflowJob`.
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+/// Origin of a fire event, passed to the [`JobSink`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TriggerKind {
+    /// Fired by a cron next-fire-time calculation.
+    Cron,
+    /// Fired by an HTTP POST to a registered webhook path.
+    Webhook,
+}
+
+/// A single fire event.
+///
+/// Produced by [`SchedulerService`](crate::SchedulerService) and consumed by
+/// [`JobSink::enqueue`]. The `inputs` field has already had any
+/// `{{trigger.payload.<jsonpath>}}` placeholders rendered against
+/// `payload`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TriggerFire {
+    /// Origin of the fire.
+    pub kind: TriggerKind,
+    /// Id of the [`ScheduleSpec`](crate::ScheduleSpec) that fired.
+    pub schedule_id: String,
+    /// Workflow name the schedule is bound to.
+    pub workflow: String,
+    /// Rendered workflow inputs.
+    pub inputs: serde_json::Value,
+    /// Raw webhook payload (empty JSON object for cron fires).
+    pub payload: serde_json::Value,
+    /// UNIX seconds at fire time.
+    pub fired_at: u64,
+}
+
+/// Callback trait implemented by the host to actually enqueue a workflow.
+///
+/// Implementations are expected to:
+/// 1. Resolve `fire.workflow` against their `WorkflowCatalog`.
+/// 2. Build a `WorkflowJob` (skeleton in `dcc_mcp_workflow`) from
+///    `fire.inputs`.
+/// 3. Submit it to their dispatch path (once #348 execution lands).
+///
+/// The scheduler does not retry on sink failure — it logs the error and
+/// moves on. Idempotency / retry is the caller's responsibility, typically
+/// via `StepPolicy::retry` at the workflow level.
+pub trait JobSink: Send + Sync + 'static {
+    /// Enqueue one fired trigger. Return `Err` only if the host is in an
+    /// unrecoverable state; transient failures should be absorbed inside
+    /// the implementation.
+    fn enqueue(&self, fire: TriggerFire) -> Result<(), String>;
+}
+
+/// Type-erased handle to a [`JobSink`], used internally by the scheduler.
+pub type SharedJobSink = Arc<dyn JobSink>;
+
+/// Sink that records every fire in a `Vec` — useful for tests and demos.
+///
+/// Not intended for production: memory grows without bound.
+#[derive(Debug, Default)]
+pub struct RecordingSink {
+    fires: parking_lot::Mutex<Vec<TriggerFire>>,
+}
+
+impl RecordingSink {
+    /// New empty recorder.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Snapshot every fire seen so far.
+    #[must_use]
+    pub fn fires(&self) -> Vec<TriggerFire> {
+        self.fires.lock().clone()
+    }
+
+    /// Number of fires recorded.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.fires.lock().len()
+    }
+
+    /// `true` when no fires have been recorded.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.fires.lock().is_empty()
+    }
+}
+
+impl JobSink for RecordingSink {
+    fn enqueue(&self, fire: TriggerFire) -> Result<(), String> {
+        self.fires.lock().push(fire);
+        Ok(())
+    }
+}

--- a/crates/dcc-mcp-scheduler/src/spec.rs
+++ b/crates/dcc-mcp-scheduler/src/spec.rs
@@ -1,0 +1,300 @@
+//! [`ScheduleSpec`] and [`TriggerSpec`] — the sibling-file schema.
+//!
+//! Schedule files live alongside a skill's `SKILL.md`, for example:
+//!
+//! ```yaml
+//! schedules:
+//!   - id: nightly_cleanup
+//!     workflow: scene_cleanup
+//!     inputs:
+//!       scope: all-scenes
+//!     trigger:
+//!       kind: cron
+//!       # 6-field cron: sec min hour day month weekday
+//!       expression: "0 0 3 * * *"
+//!       timezone: "UTC"
+//!       jitter_secs: 120
+//!     enabled: true
+//!     max_concurrent: 1
+//!
+//!   - id: on_upload
+//!     workflow: validate_upload
+//!     inputs:
+//!       path: "{{trigger.payload.file_path}}"
+//!     trigger:
+//!       kind: webhook
+//!       path: "/webhooks/upload"
+//!       secret_env: UPLOAD_WEBHOOK_SECRET
+//!     enabled: true
+//! ```
+//!
+//! The sibling-file pattern (issue #356) keeps `SKILL.md` small; the skill
+//! points at one or more `*.schedules.yaml` files via
+//! `metadata.dcc-mcp.workflow.schedules`.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::SchedulerError;
+
+/// A single registered schedule.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ScheduleSpec {
+    /// Stable id, unique across all schedule files loaded by the scheduler.
+    pub id: String,
+    /// Name of the `WorkflowSpec` to fire (looked up in the
+    /// `WorkflowCatalog` by the [`JobSink`](crate::JobSink)).
+    pub workflow: String,
+    /// Static inputs passed to the workflow. May contain template
+    /// placeholders like `{{trigger.payload.<jsonpath>}}` that are rendered
+    /// from the trigger payload at fire time.
+    #[serde(default)]
+    pub inputs: serde_json::Value,
+    /// Trigger configuration.
+    pub trigger: TriggerSpec,
+    /// If `false`, this schedule is ignored at load time.
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+    /// Maximum number of concurrent in-flight invocations. A fire is
+    /// skipped (logged) when the counter would exceed this value.
+    /// `0` means unlimited.
+    #[serde(default = "default_max_concurrent")]
+    pub max_concurrent: u32,
+}
+
+const fn default_enabled() -> bool {
+    true
+}
+
+const fn default_max_concurrent() -> u32 {
+    1
+}
+
+/// How a schedule is triggered.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum TriggerSpec {
+    /// Fire on a cron schedule.
+    Cron {
+        /// Cron expression in the 6- or 7-field form understood by the
+        /// [`cron`](https://crates.io/crates/cron) crate:
+        /// `sec min hour day_of_month month day_of_week [year]`. The
+        /// seconds field is **required** — a classic 5-field expression
+        /// like `"0 3 * * *"` will fail to parse; use
+        /// `"0 0 3 * * *"` for "every day at 03:00".
+        expression: String,
+        /// `chrono_tz` timezone name. Defaults to `"UTC"`.
+        #[serde(default = "default_timezone")]
+        timezone: String,
+        /// Random jitter in seconds, added to each fire time. `0`
+        /// disables jitter. Defaults to `0`.
+        #[serde(default)]
+        jitter_secs: u32,
+    },
+    /// Fire on an HTTP POST webhook.
+    Webhook {
+        /// Absolute URL path, e.g. `"/webhooks/upload"`.
+        path: String,
+        /// Optional env var name holding the HMAC-SHA256 shared secret.
+        /// When set, the webhook verifies `X-Hub-Signature-256` with
+        /// constant-time comparison; mismatch returns 401.
+        #[serde(default)]
+        secret_env: Option<String>,
+    },
+}
+
+fn default_timezone() -> String {
+    "UTC".to_string()
+}
+
+/// Top-level YAML schema: a `schedules:` list.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ScheduleFile {
+    /// Schedules declared in this file.
+    #[serde(default)]
+    pub schedules: Vec<ScheduleSpec>,
+}
+
+impl ScheduleFile {
+    /// Parse a YAML document into a [`ScheduleFile`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SchedulerError::Load`] on parse failure.
+    pub fn from_yaml_str(source: &str, path_hint: &str) -> Result<Self, SchedulerError> {
+        serde_yaml_ng::from_str(source).map_err(|e| SchedulerError::Load {
+            path: path_hint.to_string(),
+            message: e.to_string(),
+        })
+    }
+
+    /// Load a schedule file from disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SchedulerError::Load`] on IO or parse failure.
+    pub fn load(path: &Path) -> Result<Self, SchedulerError> {
+        let source = std::fs::read_to_string(path).map_err(|e| SchedulerError::Load {
+            path: path.display().to_string(),
+            message: e.to_string(),
+        })?;
+        Self::from_yaml_str(&source, &path.display().to_string())
+    }
+}
+
+impl ScheduleSpec {
+    /// Structural validation — checks the cron expression parses, the
+    /// timezone resolves, and webhook paths are non-empty.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`SchedulerError`] variant describing the first problem
+    /// encountered.
+    pub fn validate(&self) -> Result<(), SchedulerError> {
+        if self.id.trim().is_empty() {
+            return Err(SchedulerError::Validation("schedule id is empty".into()));
+        }
+        if self.workflow.trim().is_empty() {
+            return Err(SchedulerError::Validation(format!(
+                "schedule {:?}: workflow name is empty",
+                self.id
+            )));
+        }
+        match &self.trigger {
+            TriggerSpec::Cron {
+                expression,
+                timezone,
+                ..
+            } => {
+                crate::service::parse_cron(expression)?;
+                crate::service::parse_timezone(timezone)?;
+            }
+            TriggerSpec::Webhook { path, .. } => {
+                if path.trim().is_empty() || !path.starts_with('/') {
+                    return Err(SchedulerError::Validation(format!(
+                        "schedule {:?}: webhook path must start with '/'",
+                        self.id
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_minimal_cron_schedule() {
+        let yaml = r#"
+schedules:
+  - id: nightly
+    workflow: cleanup
+    trigger:
+      kind: cron
+      expression: "0 3 * * *"
+"#;
+        let file = ScheduleFile::from_yaml_str(yaml, "test.yaml").unwrap();
+        assert_eq!(file.schedules.len(), 1);
+        let s = &file.schedules[0];
+        assert_eq!(s.id, "nightly");
+        assert!(s.enabled);
+        assert_eq!(s.max_concurrent, 1);
+        match &s.trigger {
+            TriggerSpec::Cron {
+                expression,
+                timezone,
+                jitter_secs,
+            } => {
+                assert_eq!(expression, "0 3 * * *");
+                assert_eq!(timezone, "UTC");
+                assert_eq!(*jitter_secs, 0);
+            }
+            _ => panic!("wrong trigger kind"),
+        }
+    }
+
+    #[test]
+    fn parses_webhook_schedule() {
+        let yaml = r#"
+schedules:
+  - id: on_upload
+    workflow: validate_upload
+    inputs:
+      path: "{{trigger.payload.file_path}}"
+    trigger:
+      kind: webhook
+      path: /webhooks/upload
+      secret_env: UPLOAD_WEBHOOK_SECRET
+"#;
+        let file = ScheduleFile::from_yaml_str(yaml, "t").unwrap();
+        let s = &file.schedules[0];
+        match &s.trigger {
+            TriggerSpec::Webhook { path, secret_env } => {
+                assert_eq!(path, "/webhooks/upload");
+                assert_eq!(secret_env.as_deref(), Some("UPLOAD_WEBHOOK_SECRET"));
+            }
+            _ => panic!("wrong trigger kind"),
+        }
+    }
+
+    #[test]
+    fn rejects_empty_workflow() {
+        let s = ScheduleSpec {
+            id: "x".into(),
+            workflow: " ".into(),
+            inputs: serde_json::Value::Null,
+            trigger: TriggerSpec::Cron {
+                expression: "* * * * * *".into(),
+                timezone: "UTC".into(),
+                jitter_secs: 0,
+            },
+            enabled: true,
+            max_concurrent: 1,
+        };
+        assert!(s.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_bad_cron_expression() {
+        let s = ScheduleSpec {
+            id: "x".into(),
+            workflow: "w".into(),
+            inputs: serde_json::Value::Null,
+            trigger: TriggerSpec::Cron {
+                expression: "not a cron".into(),
+                timezone: "UTC".into(),
+                jitter_secs: 0,
+            },
+            enabled: true,
+            max_concurrent: 1,
+        };
+        assert!(matches!(
+            s.validate(),
+            Err(SchedulerError::InvalidCron { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_bad_timezone() {
+        let s = ScheduleSpec {
+            id: "x".into(),
+            workflow: "w".into(),
+            inputs: serde_json::Value::Null,
+            trigger: TriggerSpec::Cron {
+                expression: "* * * * * *".into(),
+                timezone: "Mars/Olympus".into(),
+                jitter_secs: 0,
+            },
+            enabled: true,
+            max_concurrent: 1,
+        };
+        assert!(matches!(
+            s.validate(),
+            Err(SchedulerError::InvalidTimezone { .. })
+        ));
+    }
+}

--- a/crates/dcc-mcp-scheduler/src/template.rs
+++ b/crates/dcc-mcp-scheduler/src/template.rs
@@ -1,0 +1,191 @@
+//! Minimal template engine for `{{trigger.payload.<path>}}` placeholders.
+//!
+//! A full Handlebars / Tera dependency would be overkill — we only need
+//! dotted-path lookup into a JSON value, with the original string
+//! returned unchanged when nothing matches.
+//!
+//! Supported syntax:
+//!
+//! * `{{trigger.payload.path}}` — dotted JSON path into `payload`.
+//! * `{{trigger.schedule_id}}` — literal context field.
+//! * `{{trigger.workflow}}` — literal context field.
+//!
+//! Anything else is left as-is. Placeholders that resolve to `null` are
+//! rendered as the JSON null literal `null` rather than the string
+//! `"null"` — this is what callers actually want when feeding the result
+//! back into workflow inputs.
+
+use serde_json::Value;
+
+/// Context available to placeholder lookups.
+#[derive(Debug, Clone)]
+pub struct RenderCtx<'a> {
+    /// Payload body (webhook JSON body or empty object for cron).
+    pub payload: &'a Value,
+    /// Id of the firing schedule.
+    pub schedule_id: &'a str,
+    /// Workflow name of the firing schedule.
+    pub workflow: &'a str,
+}
+
+/// Render placeholders within a JSON value (recursive).
+///
+/// Strings that are **exactly** a single placeholder are replaced with
+/// the underlying JSON value (preserving type). Strings that embed
+/// placeholders as a substring are rendered as string interpolation.
+#[must_use]
+pub fn render_value(input: &Value, ctx: &RenderCtx<'_>) -> Value {
+    match input {
+        Value::String(s) => render_string(s, ctx),
+        Value::Array(arr) => Value::Array(arr.iter().map(|v| render_value(v, ctx)).collect()),
+        Value::Object(map) => {
+            let mut out = serde_json::Map::with_capacity(map.len());
+            for (k, v) in map {
+                out.insert(k.clone(), render_value(v, ctx));
+            }
+            Value::Object(out)
+        }
+        other => other.clone(),
+    }
+}
+
+fn render_string(s: &str, ctx: &RenderCtx<'_>) -> Value {
+    // Fast-path: whole-string placeholder → preserve value type.
+    if let Some(path) = whole_placeholder(s) {
+        return resolve(path, ctx).unwrap_or_else(|| Value::String(s.to_string()));
+    }
+    // Slow-path: substring interpolation → always yields a string.
+    Value::String(interpolate(s, ctx))
+}
+
+fn whole_placeholder(s: &str) -> Option<&str> {
+    let trimmed = s.trim();
+    let inner = trimmed.strip_prefix("{{")?.strip_suffix("}}")?;
+    // Disallow nested braces — treat as interpolation instead.
+    if inner.contains("{{") || inner.contains("}}") {
+        return None;
+    }
+    Some(inner.trim())
+}
+
+fn interpolate(s: &str, ctx: &RenderCtx<'_>) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(open) = rest.find("{{") {
+        out.push_str(&rest[..open]);
+        let after = &rest[open + 2..];
+        let Some(close) = after.find("}}") else {
+            // Unterminated — emit the rest verbatim and stop.
+            out.push_str(&rest[open..]);
+            return out;
+        };
+        let path = after[..close].trim();
+        let replacement = resolve(path, ctx)
+            .map(|v| match v {
+                Value::String(s) => s,
+                other => other.to_string(),
+            })
+            .unwrap_or_else(|| format!("{{{{{path}}}}}"));
+        out.push_str(&replacement);
+        rest = &after[close + 2..];
+    }
+    out.push_str(rest);
+    out
+}
+
+fn resolve(path: &str, ctx: &RenderCtx<'_>) -> Option<Value> {
+    let path = path.trim();
+    if let Some(rest) = path.strip_prefix("trigger.payload") {
+        let json_path = rest.strip_prefix('.').unwrap_or("");
+        return lookup_json(ctx.payload, json_path);
+    }
+    if path == "trigger.schedule_id" {
+        return Some(Value::String(ctx.schedule_id.to_string()));
+    }
+    if path == "trigger.workflow" {
+        return Some(Value::String(ctx.workflow.to_string()));
+    }
+    None
+}
+
+fn lookup_json(root: &Value, path: &str) -> Option<Value> {
+    if path.is_empty() {
+        return Some(root.clone());
+    }
+    let mut cur = root;
+    for seg in path.split('.') {
+        if seg.is_empty() {
+            return None;
+        }
+        // Support numeric array indices (e.g. `items.0.name`).
+        if let Ok(idx) = seg.parse::<usize>() {
+            cur = cur.as_array().and_then(|a| a.get(idx))?;
+        } else {
+            cur = cur.as_object().and_then(|m| m.get(seg))?;
+        }
+    }
+    Some(cur.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn ctx<'a>(payload: &'a Value) -> RenderCtx<'a> {
+        RenderCtx {
+            payload,
+            schedule_id: "sid",
+            workflow: "wf",
+        }
+    }
+
+    #[test]
+    fn whole_string_preserves_type() {
+        let payload = json!({"count": 5});
+        let ctx = ctx(&payload);
+        let out = render_value(&json!("{{trigger.payload.count}}"), &ctx);
+        assert_eq!(out, json!(5));
+    }
+
+    #[test]
+    fn substring_interpolates() {
+        let payload = json!({"file": "a.ma"});
+        let ctx = ctx(&payload);
+        let out = render_value(&json!("uploaded: {{trigger.payload.file}}"), &ctx);
+        assert_eq!(out, json!("uploaded: a.ma"));
+    }
+
+    #[test]
+    fn unknown_placeholder_passthrough() {
+        let payload = json!({});
+        let ctx = ctx(&payload);
+        let out = render_value(&json!("{{trigger.payload.missing}}"), &ctx);
+        assert_eq!(out, json!("{{trigger.payload.missing}}"));
+    }
+
+    #[test]
+    fn nested_object_render() {
+        let payload = json!({"user": {"name": "alice"}});
+        let ctx = ctx(&payload);
+        let input = json!({"args": {"who": "{{trigger.payload.user.name}}"}});
+        let out = render_value(&input, &ctx);
+        assert_eq!(out, json!({"args": {"who": "alice"}}));
+    }
+
+    #[test]
+    fn schedule_id_resolves() {
+        let payload = json!({});
+        let ctx = ctx(&payload);
+        let out = render_value(&json!("{{trigger.schedule_id}}"), &ctx);
+        assert_eq!(out, json!("sid"));
+    }
+
+    #[test]
+    fn array_index_lookup() {
+        let payload = json!({"items": [{"n": "a"}, {"n": "b"}]});
+        let ctx = ctx(&payload);
+        let out = render_value(&json!("{{trigger.payload.items.1.n}}"), &ctx);
+        assert_eq!(out, json!("b"));
+    }
+}

--- a/crates/dcc-mcp-scheduler/src/webhook.rs
+++ b/crates/dcc-mcp-scheduler/src/webhook.rs
@@ -1,0 +1,101 @@
+//! HMAC-SHA256 webhook validation.
+//!
+//! Uses the GitHub-style `X-Hub-Signature-256: sha256=<hex>` header
+//! convention and a constant-time comparison via the `subtle` crate.
+
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use subtle::ConstantTimeEq;
+
+/// Header name used for HMAC signatures. Matches the GitHub / X-Hub
+/// convention so existing webhook senders work without reconfiguration.
+pub const HMAC_HEADER: &str = "x-hub-signature-256";
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Compute the canonical `sha256=<hex>` header value for `body` under
+/// the given `secret`.
+#[must_use]
+pub fn compute_signature(secret: &[u8], body: &[u8]) -> String {
+    let mut mac =
+        HmacSha256::new_from_slice(secret).expect("HMAC-SHA256 accepts keys of any length");
+    mac.update(body);
+    let tag = mac.finalize().into_bytes();
+    format!("sha256={}", hex::encode(tag))
+}
+
+/// Verify a header value against the expected signature, using a
+/// constant-time comparison.
+///
+/// Returns `true` when the header exists and matches the computed
+/// signature. Case-insensitive on the `sha256=` prefix; otherwise
+/// byte-for-byte.
+#[must_use]
+pub fn verify_hub_signature_256(secret: &[u8], body: &[u8], header_value: Option<&str>) -> bool {
+    let Some(header) = header_value else {
+        return false;
+    };
+    let expected = compute_signature(secret, body);
+    constant_time_eq_ignore_prefix_case(&expected, header)
+}
+
+fn constant_time_eq_ignore_prefix_case(expected: &str, got: &str) -> bool {
+    let (a_prefix, a_hex) = match expected.split_once('=') {
+        Some(p) => p,
+        None => return false,
+    };
+    let (b_prefix, b_hex) = match got.split_once('=') {
+        Some(p) => p,
+        None => return false,
+    };
+    if !a_prefix.eq_ignore_ascii_case(b_prefix) {
+        return false;
+    }
+    let a_bytes = a_hex.as_bytes();
+    let b_bytes = b_hex.as_bytes();
+    if a_bytes.len() != b_bytes.len() {
+        return false;
+    }
+    a_bytes.ct_eq(b_bytes).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_known_signature() {
+        let secret = b"top-secret";
+        let body = b"{\"hello\":\"world\"}";
+        let sig = compute_signature(secret, body);
+        assert!(verify_hub_signature_256(secret, body, Some(&sig)));
+    }
+
+    #[test]
+    fn rejects_tampered_body() {
+        let secret = b"top-secret";
+        let sig = compute_signature(secret, b"a");
+        assert!(!verify_hub_signature_256(secret, b"b", Some(&sig)));
+    }
+
+    #[test]
+    fn rejects_missing_header() {
+        assert!(!verify_hub_signature_256(b"x", b"a", None));
+    }
+
+    #[test]
+    fn rejects_missing_prefix() {
+        let secret = b"top-secret";
+        let tag = compute_signature(secret, b"a");
+        let hex_only = tag.trim_start_matches("sha256=");
+        assert!(!verify_hub_signature_256(secret, b"a", Some(hex_only)));
+    }
+
+    #[test]
+    fn accepts_case_insensitive_prefix() {
+        let secret = b"top-secret";
+        let sig = compute_signature(secret, b"a");
+        let upper = sig.replacen("sha256", "SHA256", 1);
+        assert!(verify_hub_signature_256(secret, b"a", Some(&upper)));
+    }
+}

--- a/docs/guide/scheduler.md
+++ b/docs/guide/scheduler.md
@@ -1,0 +1,203 @@
+# Scheduler — cron + webhook-triggered workflows
+
+> Issue [#352](https://github.com/loonghao/dcc-mcp-core/issues/352).
+> Opt-in via the Cargo `scheduler` feature. Off by default.
+
+The scheduler subsystem fires pre-registered workflows (`WorkflowSpec` from
+[#348](https://github.com/loonghao/dcc-mcp-core/issues/348)) on two kinds of
+triggers:
+
+- **Cron** — a next-fire-time loop on a `chrono-tz` timezone, optional
+  uniform random jitter.
+- **Webhook** — an HTTP POST endpoint on the main Axum router, optional
+  HMAC-SHA256 validation via `X-Hub-Signature-256`.
+
+The scheduler **does not execute workflows itself**. On fire it builds a
+`TriggerFire` value and hands it to a caller-supplied `JobSink`. The sink
+resolves the workflow name against the `WorkflowCatalog` and enqueues a
+`WorkflowJob` through whatever dispatch path the host prefers.
+
+## Sibling-file pattern ([#356](https://github.com/loonghao/dcc-mcp-core/issues/356))
+
+Schedules live in `*.schedules.yaml` files alongside `SKILL.md`, never
+embedded in the `SKILL.md` frontmatter itself. A skill points at them via
+`metadata.dcc-mcp.workflow.schedules`:
+
+```yaml
+# SKILL.md
+---
+name: scene-maintenance
+description: Nightly cleanup + upload validation for Maya scenes.
+metadata:
+  dcc-mcp:
+    workflow:
+      specs: [workflows.yaml]
+      schedules: [schedules.yaml]
+---
+```
+
+```yaml
+# schedules.yaml (sibling of SKILL.md)
+schedules:
+  - id: nightly_cleanup
+    workflow: scene_cleanup          # WorkflowSpec id
+    inputs:
+      scope: all-scenes
+    trigger:
+      kind: cron
+      expression: "0 0 3 * * *"      # sec min hour day month weekday
+      timezone: UTC
+      jitter_secs: 120
+    enabled: true
+    max_concurrent: 1
+
+  - id: on_upload
+    workflow: validate_upload
+    inputs:
+      path: "{{trigger.payload.file_path}}"
+    trigger:
+      kind: webhook
+      path: /webhooks/upload
+      secret_env: UPLOAD_WEBHOOK_SECRET
+    enabled: true
+```
+
+### Cron expression format
+
+The underlying [`cron`](https://crates.io/crates/cron) crate expects the
+6-field form `sec min hour day_of_month month day_of_week` (seconds are
+**required**). A classic 5-field expression like `"0 3 * * *"` will fail
+to parse — use `"0 0 3 * * *"` for "every day at 03:00".
+
+### Template variables
+
+Webhook payloads are merged into workflow inputs via
+`{{trigger.payload.<json-path>}}` placeholders:
+
+- `{{trigger.payload.file_path}}` — dotted-path lookup (objects + numeric
+  array indices).
+- `{{trigger.schedule_id}}` / `{{trigger.workflow}}` — literal context.
+
+A placeholder that is the **entire** string preserves the underlying
+JSON type (number stays a number). Placeholders inside a larger string
+are always stringified.
+
+## HMAC-SHA256 validation
+
+When `secret_env` is set on a webhook trigger:
+
+1. The server reads the secret from the named env var **at startup**.
+2. Each request must carry `X-Hub-Signature-256: sha256=<hex>`; the
+   scheduler recomputes the HMAC and compares in constant time.
+3. If the env var is set at startup but missing at request time, the
+   endpoint replies `500 webhook_secret_missing` (fail-loud).
+4. If the signature is wrong, the endpoint replies `401 invalid_signature`.
+
+Use the GitHub convention — any existing webhook sender works without
+reconfiguration.
+
+## `max_concurrent` — skip-on-overlap
+
+`max_concurrent` caps the number of in-flight fires per schedule id.
+- `max_concurrent = 1` (default) — a fire is skipped if the previous
+  invocation has not yet reached a terminal status.
+- `max_concurrent = 0` — unlimited.
+
+The host must call `SchedulerHandle::mark_terminal(schedule_id)` when it
+observes a terminal workflow status (typically via a subscription to
+`$/dcc.workflowUpdated`). The counter is decremented so future fires are
+admitted again.
+
+Webhook requests that hit the concurrency cap receive `429 Too Many
+Requests` with a JSON body describing the in-flight / max values.
+
+## Runtime surface
+
+```rust
+use std::sync::Arc;
+use dcc_mcp_scheduler::{
+    JobSink, SchedulerConfig, SchedulerService, TriggerFire,
+};
+
+struct MySink { /* workflow registry + dispatcher */ }
+impl JobSink for MySink {
+    fn enqueue(&self, fire: TriggerFire) -> Result<(), String> {
+        // resolve fire.workflow, build a WorkflowJob, submit it.
+        Ok(())
+    }
+}
+
+let cfg = SchedulerConfig::from_dir("./schedules")?;
+let (handle, webhook_router) = SchedulerService::new(cfg, Arc::new(MySink))
+    .start();
+// Merge webhook_router into your main Axum app:
+//   app = app.merge(webhook_router);
+// On terminal workflow status:
+//   handle.mark_terminal("nightly_cleanup");
+// On shutdown:
+//   handle.shutdown();
+```
+
+## `McpHttpConfig` integration
+
+```python
+from dcc_mcp_core import McpHttpConfig
+
+cfg = McpHttpConfig(port=8765)
+cfg.enable_scheduler = True
+cfg.schedules_dir = "/opt/dcc-mcp/schedules"
+```
+
+Or via builder:
+
+```rust
+use dcc_mcp_http::config::McpHttpConfig;
+let cfg = McpHttpConfig::new()
+    .with_scheduler("/opt/dcc-mcp/schedules");
+```
+
+The config fields are always present; they are no-ops when the
+`dcc-mcp-scheduler` crate is not compiled in.
+
+## Python surface
+
+Only the **declarative** types are exposed:
+
+```python
+from dcc_mcp_core import (
+    ScheduleSpec, TriggerSpec,
+    parse_schedules_yaml,
+    hmac_sha256_hex, verify_hub_signature_256,
+)
+
+spec = ScheduleSpec(
+    id="nightly_cleanup",
+    workflow="scene_cleanup",
+    trigger=TriggerSpec.cron("0 0 3 * * *", timezone="UTC", jitter_secs=120),
+    inputs='{"scope": "all-scenes"}',
+    max_concurrent=1,
+)
+spec.validate()
+
+# Parse a whole file:
+specs = parse_schedules_yaml(open("./schedules.yaml").read())
+
+# HMAC helpers (e.g. for webhook-sender tests):
+sig = hmac_sha256_hex(b"shared-secret", request_body)
+assert verify_hub_signature_256(b"shared-secret", request_body, sig)
+```
+
+The scheduler runtime itself is driven from Rust inside the HTTP server —
+Python cannot currently construct a `SchedulerService` directly.
+
+## Non-goals
+
+- Distributed scheduling / leader election (single-node only).
+- Hot-reload of schedule files (pick up on server restart).
+- Fire-history / last-run UI (future issue).
+
+## See also
+
+- `crates/dcc-mcp-scheduler/src/lib.rs` — crate-level docs and example.
+- `docs/proposals/workflow-orchestration-gap.md` §G — design rationale.
+- Issue [#352](https://github.com/loonghao/dcc-mcp-core/issues/352).

--- a/justfile
+++ b/justfile
@@ -83,7 +83,7 @@ dev:
         . .venv/bin/activate; \
     fi
     pip install maturin 2>/dev/null || true
-    maturin develop --features python-bindings,ext-module,workflow
+    maturin develop --features python-bindings,ext-module,workflow,scheduler
 
 [windows]
 dev:
@@ -92,7 +92,7 @@ dev:
         & .\.venv\Scripts\Activate.ps1; \
     }
     pip install maturin -q 2>$null
-    maturin develop --features python-bindings,ext-module,workflow
+    maturin develop --features python-bindings,ext-module,workflow,scheduler
 
 # Build abi3-py38 release wheel and install it
 install:

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -213,6 +213,22 @@ except ImportError:  # pragma: no cover — feature off
     WorkflowStatus = None  # type: ignore[assignment,misc]
     WorkflowStep = None  # type: ignore[assignment,misc]
 
+# Scheduler subsystem — optional (Cargo `scheduler` feature, issue #352).
+# Only declarative types are Python-visible; the runtime service is
+# constructed from Rust inside the McpHttpServer.
+try:
+    from dcc_mcp_core._core import ScheduleSpec  # type: ignore[attr-defined]
+    from dcc_mcp_core._core import TriggerSpec  # type: ignore[attr-defined]
+    from dcc_mcp_core._core import hmac_sha256_hex  # type: ignore[attr-defined]
+    from dcc_mcp_core._core import parse_schedules_yaml  # type: ignore[attr-defined]
+    from dcc_mcp_core._core import verify_hub_signature_256  # type: ignore[attr-defined]
+except ImportError:  # pragma: no cover — feature off
+    ScheduleSpec = None  # type: ignore[assignment,misc]
+    TriggerSpec = None  # type: ignore[assignment,misc]
+    parse_schedules_yaml = None  # type: ignore[assignment,misc]
+    hmac_sha256_hex = None  # type: ignore[assignment,misc]
+    verify_hub_signature_256 = None  # type: ignore[assignment,misc]
+
 # Adapters (pure-Python, non-DccServerBase)
 from dcc_mcp_core.adapters import CAPABILITY_KEYS
 from dcc_mcp_core.adapters import WEBVIEW_DEFAULT_CAPABILITIES
@@ -360,6 +376,7 @@ __all__ = [
     "SceneNode",
     "SceneObject",
     "SceneStatistics",
+    "ScheduleSpec",
     "ScriptLanguage",
     "ScriptResult",
     "SdfPath",
@@ -391,6 +408,7 @@ __all__ = [
     "ToolValidator",
     "TransportAddress",
     "TransportScheme",
+    "TriggerSpec",
     "UsdPrim",
     "UsdStage",
     "VersionConstraint",
@@ -431,10 +449,12 @@ __all__ = [
     "get_skill_paths_from_env",
     "get_skills_dir",
     "get_tools_dir",
+    "hmac_sha256_hex",
     "init_file_logging",
     "is_telemetry_initialized",
     "make_start_stop",
     "mpu_to_units",
+    "parse_schedules_yaml",
     "parse_skill_md",
     "register_bridge",
     "register_diagnostic_handlers",
@@ -464,5 +484,6 @@ __all__ = [
     "validate_action_result",
     "validate_dependencies",
     "validate_tool_name",
+    "verify_hub_signature_256",
     "wrap_value",
 ]

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -4623,3 +4623,114 @@ class WorkflowStatus:
     def __init__(self, value: str) -> None: ...
     def __repr__(self) -> str: ...
     def __str__(self) -> str: ...
+
+# ── Scheduler (issue #352) ────────────────────────────────────────────────────
+#
+# Requires the crate-level ``scheduler`` feature at build time; when absent,
+# these classes are exported from ``dcc_mcp_core`` as ``None``.
+
+class TriggerSpec:
+    """Declarative trigger for a :py:class:`ScheduleSpec` (issue #352).
+
+    Construct via the ``cron`` / ``webhook`` classmethods — do not
+    instantiate directly.
+    """
+
+    @classmethod
+    def cron(
+        cls,
+        expression: str,
+        timezone: str = "UTC",
+        jitter_secs: int = 0,
+    ) -> TriggerSpec:
+        """Build a cron trigger.
+
+        Raises ``ValueError`` on an invalid expression or unknown timezone.
+        """
+        ...
+
+    @classmethod
+    def webhook(cls, path: str, secret_env: str | None = None) -> TriggerSpec:
+        """Build an HTTP-POST webhook trigger.
+
+        ``path`` must start with ``/``. ``secret_env``, when set, names an
+        environment variable that holds the HMAC-SHA256 shared secret used
+        to validate ``X-Hub-Signature-256`` headers.
+        """
+        ...
+
+    @property
+    def kind(self) -> str:
+        """``"cron"`` or ``"webhook"``."""
+        ...
+
+    @property
+    def expression(self) -> str | None: ...
+    @property
+    def timezone(self) -> str | None: ...
+    @property
+    def jitter_secs(self) -> int: ...
+    @property
+    def path(self) -> str | None: ...
+    @property
+    def secret_env(self) -> str | None: ...
+    def __repr__(self) -> str: ...
+
+class ScheduleSpec:
+    """A single cron- or webhook-triggered schedule (issue #352).
+
+    Example:
+    -------
+    .. code-block:: python
+
+        from dcc_mcp_core import ScheduleSpec, TriggerSpec
+
+        s = ScheduleSpec(
+            id="nightly_cleanup",
+            workflow="scene_cleanup",
+            trigger=TriggerSpec.cron("0 3 * * *", timezone="UTC"),
+            inputs='{"scope": "all-scenes"}',
+            max_concurrent=1,
+        )
+        s.validate()
+
+    """
+
+    def __init__(
+        self,
+        id: str,
+        workflow: str,
+        trigger: TriggerSpec,
+        inputs: str | None = None,
+        enabled: bool = True,
+        max_concurrent: int = 1,
+    ) -> None:
+        """Construct and validate a schedule. Raises ``ValueError`` on failure."""
+        ...
+
+    def validate(self) -> None: ...
+    @property
+    def id(self) -> str: ...
+    @property
+    def workflow(self) -> str: ...
+    @property
+    def inputs_json(self) -> str: ...
+    @property
+    def trigger(self) -> TriggerSpec: ...
+    @property
+    def enabled(self) -> bool: ...
+    @property
+    def max_concurrent(self) -> int: ...
+    def __repr__(self) -> str: ...
+
+def parse_schedules_yaml(source: str, path_hint: str = "<string>") -> list[ScheduleSpec]:
+    """Parse a ``*.schedules.yaml`` document. Raises ``ValueError``."""
+    ...
+
+def hmac_sha256_hex(secret: bytes, body: bytes) -> str:
+    """Compute the canonical ``sha256=<hex>`` HMAC for a webhook body."""
+    ...
+
+def verify_hub_signature_256(secret: bytes, body: bytes, header_value: str | None) -> bool:
+    """Constant-time verify an ``X-Hub-Signature-256`` header value."""
+    ...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,9 @@ pub use dcc_mcp_utils as utils;
 #[cfg(feature = "workflow")]
 pub use dcc_mcp_workflow as workflow;
 
+#[cfg(feature = "scheduler")]
+pub use dcc_mcp_scheduler as scheduler;
+
 // ── Helper macros (defined before use for readability) ──
 
 /// Batch-register `#[pyfunction]`s on a module.
@@ -78,6 +81,8 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     register_constants(m)?;
     #[cfg(feature = "workflow")]
     register_workflow(m)?;
+    #[cfg(feature = "scheduler")]
+    register_scheduler(m)?;
 
     // ── Metadata ──
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
@@ -279,6 +284,11 @@ fn register_artefact(m: &Bound<'_, PyModule>) -> PyResult<()> {
 #[cfg(all(feature = "python-bindings", feature = "workflow"))]
 fn register_workflow(m: &Bound<'_, PyModule>) -> PyResult<()> {
     dcc_mcp_workflow::python::register_classes(m)
+}
+
+#[cfg(all(feature = "python-bindings", feature = "scheduler"))]
+fn register_scheduler(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    dcc_mcp_scheduler::python::register_classes(m)
 }
 
 #[cfg(feature = "python-bindings")]

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,145 @@
+"""Python-facing tests for the scheduler subsystem (issue #352).
+
+These tests are skipped when the extension was built without the
+``scheduler`` Cargo feature.
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+
+import pytest
+
+import dcc_mcp_core
+
+pytestmark = pytest.mark.skipif(
+    getattr(dcc_mcp_core, "ScheduleSpec", None) is None,
+    reason="Built without the `scheduler` Cargo feature",
+)
+
+
+CRON_DAILY_3AM = "0 0 3 * * *"  # sec min hour day month weekday
+
+
+def test_trigger_spec_cron_valid() -> None:
+    t = dcc_mcp_core.TriggerSpec.cron(CRON_DAILY_3AM, timezone="UTC", jitter_secs=120)
+    assert t.kind == "cron"
+    assert t.expression == CRON_DAILY_3AM
+    assert t.timezone == "UTC"
+    assert t.jitter_secs == 120
+    assert t.path is None
+
+
+def test_trigger_spec_cron_invalid_expression() -> None:
+    with pytest.raises(ValueError):
+        dcc_mcp_core.TriggerSpec.cron("not-a-cron")
+
+
+def test_trigger_spec_cron_invalid_timezone() -> None:
+    with pytest.raises(ValueError):
+        dcc_mcp_core.TriggerSpec.cron(CRON_DAILY_3AM, timezone="Mars/Olympus")
+
+
+def test_trigger_spec_webhook_rejects_relative_path() -> None:
+    with pytest.raises(ValueError):
+        dcc_mcp_core.TriggerSpec.webhook("no-slash")
+
+
+def test_trigger_spec_webhook_with_secret() -> None:
+    t = dcc_mcp_core.TriggerSpec.webhook("/webhooks/upload", secret_env="UPLOAD_WEBHOOK_SECRET")
+    assert t.kind == "webhook"
+    assert t.path == "/webhooks/upload"
+    assert t.secret_env == "UPLOAD_WEBHOOK_SECRET"
+
+
+def test_schedule_spec_build_and_validate() -> None:
+    trigger = dcc_mcp_core.TriggerSpec.cron(CRON_DAILY_3AM)
+    spec = dcc_mcp_core.ScheduleSpec(
+        id="nightly_cleanup",
+        workflow="scene_cleanup",
+        trigger=trigger,
+        inputs='{"scope": "all-scenes"}',
+        enabled=True,
+        max_concurrent=1,
+    )
+    assert spec.id == "nightly_cleanup"
+    assert spec.workflow == "scene_cleanup"
+    assert spec.max_concurrent == 1
+    assert spec.enabled is True
+    assert json.loads(spec.inputs_json) == {"scope": "all-scenes"}
+
+
+def test_schedule_spec_rejects_empty_workflow() -> None:
+    trigger = dcc_mcp_core.TriggerSpec.cron(CRON_DAILY_3AM)
+    with pytest.raises(ValueError):
+        dcc_mcp_core.ScheduleSpec(id="x", workflow=" ", trigger=trigger)
+
+
+def test_parse_schedules_yaml_minimal() -> None:
+    yaml = textwrap.dedent(
+        """
+        schedules:
+          - id: nightly_cleanup
+            workflow: scene_cleanup
+            inputs:
+              scope: all-scenes
+            trigger:
+              kind: cron
+              expression: "0 0 3 * * *"
+              timezone: UTC
+              jitter_secs: 120
+            enabled: true
+            max_concurrent: 1
+
+          - id: on_upload
+            workflow: validate_upload
+            inputs:
+              path: "{{trigger.payload.file_path}}"
+            trigger:
+              kind: webhook
+              path: /webhooks/upload
+              secret_env: UPLOAD_WEBHOOK_SECRET
+        """
+    )
+    specs = dcc_mcp_core.parse_schedules_yaml(yaml)
+    assert len(specs) == 2
+    nightly, on_upload = specs
+    assert nightly.id == "nightly_cleanup"
+    assert nightly.trigger.kind == "cron"
+    assert nightly.trigger.jitter_secs == 120
+    assert on_upload.trigger.kind == "webhook"
+    assert on_upload.trigger.secret_env == "UPLOAD_WEBHOOK_SECRET"
+
+
+def test_parse_schedules_yaml_reports_invalid_cron() -> None:
+    yaml = textwrap.dedent(
+        """
+        schedules:
+          - id: broken
+            workflow: w
+            trigger:
+              kind: cron
+              expression: "this is not a cron"
+        """
+    )
+    with pytest.raises(ValueError):
+        dcc_mcp_core.parse_schedules_yaml(yaml)
+
+
+def test_hmac_round_trip() -> None:
+    secret = b"top-secret"
+    body = b'{"hello":"world"}'
+    sig = dcc_mcp_core.hmac_sha256_hex(secret, body)
+    assert sig.startswith("sha256=")
+    assert dcc_mcp_core.verify_hub_signature_256(secret, body, sig)
+
+
+def test_hmac_rejects_tampered_body() -> None:
+    secret = b"top-secret"
+    sig = dcc_mcp_core.hmac_sha256_hex(secret, b"a")
+    assert not dcc_mcp_core.verify_hub_signature_256(secret, b"b", sig)
+
+
+def test_hmac_rejects_missing_header() -> None:
+    assert not dcc_mcp_core.verify_hub_signature_256(b"s", b"body", None)


### PR DESCRIPTION
## Summary

Adds a cron + webhook workflow scheduler behind the Cargo `scheduler` feature (off by default, per-issue request). Fires `WorkflowJob`s without a human tool call; the scheduler itself is transport-agnostic and hands fires to a caller-supplied `JobSink`.

- **New crate `dcc-mcp-scheduler`** — `ScheduleSpec` / `TriggerSpec`, sibling-file `*.schedules.yaml` loader, Tokio-driven cron tasks with `chrono-tz` timezones + seedable jitter, Axum webhook router with HMAC-SHA256 (`X-Hub-Signature-256`) validation, DashMap concurrency tracker released via `SchedulerHandle::mark_terminal`, minimal `{{trigger.payload.*}}` template renderer.
- **Sibling-file pattern (#356 style)** — schedules live next to `SKILL.md`, never as top-level frontmatter; `metadata.dcc-mcp.workflow.schedules` points at one or more `*.schedules.yaml` files.
- **Config** — `McpHttpConfig::enable_scheduler` + `McpHttpConfig::schedules_dir` (always present, no-op when the crate is not compiled in). Builder helper `with_scheduler(dir)`.
- **Python surface** — `ScheduleSpec`, `TriggerSpec`, `parse_schedules_yaml`, `hmac_sha256_hex`, `verify_hub_signature_256` (only declarative types; the runtime is driven from Rust). `_core.pyi` stubs included.
- **Docs** — new `docs/guide/scheduler.md` + quick-lookup entries in `AGENTS.md` / `CLAUDE.md`.

## Feature gating

`scheduler = ["dep:dcc-mcp-scheduler", "workflow"]`. Default build does not pull in `cron`, `chrono-tz`, `hmac`, or `sha2`. Python tests are skipped on default builds.

## Test plan

- [x] `cargo build --workspace` (default, no scheduler) — green
- [x] `cargo build --workspace --features scheduler` — green
- [x] `cargo test -p dcc-mcp-scheduler` — 25/25 passing (spec, webhook, template, service — cron-every-second fires ≥2 in 2.5s window, `max_concurrent=1` skips without release, jitter-seeded determinism, HMAC round-trip + tampered body + missing header)
- [x] `cargo clippy --workspace -- -D warnings` and `--features scheduler` — clean
- [x] `vx just preflight` — green (fmt + clippy + workspace check + rust tests)
- [x] `pytest tests/test_scheduler.py` — 12/12 passing (cron trigger valid/invalid expression/timezone, webhook path + secret, `ScheduleSpec` validation, `parse_schedules_yaml` for two-schedule YAML, HMAC round-trip / tampered / missing)
- [x] `pytest tests/` full — 8279 passed, 55 skipped

## Acceptance criteria coverage

1. Cron fires at the right time — `cron_every_second_fires_multiple_times` test asserts ≥ 2 fires in 2.5 s.
2. Jitter within bounds — `jitter_within_bounds` + `jitter_seeded_is_deterministic`.
3. `max_concurrent=1` skip-on-overlap — `max_concurrent_skips_when_not_released` (no `mark_terminal` → exactly 1 fire over 3.5 s).
4. Webhook HMAC — `matches_known_signature`, `rejects_tampered_body`, `rejects_missing_header`, `rejects_missing_prefix`, `accepts_case_insensitive_prefix`.
5. Webhook payload → workflow inputs — `render_value` / `interpolate` tests cover whole-string type preservation, substring interpolation, unknown-placeholder passthrough, array-index lookup.
6. Enable/disable without rebuild — `McpHttpConfig::{enable_scheduler, schedules_dir}` present on all builds.
7. Python test module skips when feature off — `pytest.mark.skipif(getattr(dcc_mcp_core, "ScheduleSpec", None) is None)`.
8. Rust tests — covered above.
9. Docs — `docs/guide/scheduler.md` + `AGENTS.md` + `CLAUDE.md`.
10. Both default + `--features scheduler` build + test matrices green; Python tests pass on default (skipped) and scheduler-enabled (12 passed) builds.

## Non-goals (per issue)

- Distributed scheduler / leader election — single-node only.
- Hot-reload of schedule files — pick up on server restart.
- Fire-history UI — future issue.

Closes #352
