### PR TITLE
feat(gateway): job-to-backend routing cache with cancel cascade (#322)

### DIFF
--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -233,6 +233,31 @@ pub struct McpHttpConfig {
     /// Default: `600_000` (10 minutes).
     pub gateway_wait_terminal_timeout_ms: u64,
 
+    /// TTL (seconds) for the gateway's per-job routing cache (issue
+    /// #322). Controls how long a `JobRoute` may live without seeing a
+    /// terminal notification before a background GC task evicts it.
+    ///
+    /// The routing cache maps `job_id → backend_id` so client-initiated
+    /// `notifications/cancelled` can be forwarded to the correct
+    /// backend. Terminal notifications (`completed`, `failed`,
+    /// `cancelled`, `interrupted`) auto-evict routes; this TTL is the
+    /// safety net for jobs whose terminal event is never delivered
+    /// (backend crash, SSE drop that never recovers, …).
+    ///
+    /// Default: `86_400` (24 hours).
+    pub gateway_route_ttl_secs: u64,
+
+    /// Per-session ceiling on concurrent live routes in the gateway
+    /// routing cache (issue #322). `0` disables the cap.
+    ///
+    /// When a client session is already holding `cap` live routes, a
+    /// new async `tools/call` is rejected with JSON-RPC error code
+    /// `-32005 too_many_in_flight_jobs`. This prevents a runaway agent
+    /// from causing unbounded memory growth in the gateway.
+    ///
+    /// Default: `1_000`.
+    pub gateway_max_routes_per_session: u64,
+
     /// Enable the Prometheus `/metrics` endpoint (issue #331).
     ///
     /// Requires the `prometheus` Cargo feature on both `dcc-mcp-http`
@@ -366,6 +391,8 @@ impl McpHttpConfig {
             backend_timeout_ms: 10_000,
             gateway_async_dispatch_timeout_ms: 60_000,
             gateway_wait_terminal_timeout_ms: 600_000,
+            gateway_route_ttl_secs: 60 * 60 * 24,
+            gateway_max_routes_per_session: 1_000,
             enable_resources: true,
             enable_artefact_resources: false,
             enable_prompts: true,
@@ -537,6 +564,22 @@ impl McpHttpConfig {
     /// See [`Self::gateway_wait_terminal_timeout_ms`] for the full contract.
     pub fn with_gateway_wait_terminal_timeout_ms(mut self, ms: u64) -> Self {
         self.gateway_wait_terminal_timeout_ms = ms;
+        self
+    }
+
+    /// Builder: override the gateway's routing-cache TTL (issue #322).
+    ///
+    /// See [`Self::gateway_route_ttl_secs`] for the full contract.
+    pub fn with_gateway_route_ttl_secs(mut self, secs: u64) -> Self {
+        self.gateway_route_ttl_secs = secs;
+        self
+    }
+
+    /// Builder: override the gateway's per-session route cap (issue #322).
+    ///
+    /// See [`Self::gateway_max_routes_per_session`] for the full contract.
+    pub fn with_gateway_max_routes_per_session(mut self, cap: u64) -> Self {
+        self.gateway_max_routes_per_session = cap;
         self
     }
 }

--- a/crates/dcc-mcp-http/src/gateway/aggregator.rs
+++ b/crates/dcc-mcp-http/src/gateway/aggregator.rs
@@ -196,7 +196,7 @@ pub async fn route_tools_call(
         original,
         Some(args.clone()),
         forwarded_meta,
-        request_id,
+        request_id.clone(),
         dispatch_timeout,
     )
     .await;
@@ -210,7 +210,46 @@ pub async fn route_tools_call(
             //     be routed to the originating client session.
             let job_id = extract_job_id(&result);
             if let (Some(sid), Some(jid)) = (client_session_id, job_id.as_deref()) {
-                gs.subscriber.bind_job(jid, sid, &url);
+                // #322: record the full JobRoute so `notifications/cancelled`
+                // can later forward to this backend. `parent_job_id` comes
+                // from the inbound `_meta.dcc.parentJobId` so workflow
+                // cancellations can cascade across backends.
+                let parent = meta
+                    .and_then(|m| m.get("dcc"))
+                    .and_then(|d| d.get("parentJobId"))
+                    .and_then(|p| p.as_str());
+                if let Err(e) = gs
+                    .subscriber
+                    .bind_job_route(jid, sid, &url, original, parent)
+                {
+                    tracing::warn!(
+                        session = %sid,
+                        job = %jid,
+                        backend = %url,
+                        error = %e,
+                        "gateway: refusing to bind route — per-session cap reached"
+                    );
+                    let payload = json!({
+                        "error": {
+                            "code": -32005,
+                            "message": format!("{e}"),
+                            "data": {
+                                "instance_id": entry.instance_id.to_string(),
+                                "dcc_type": entry.dcc_type,
+                            }
+                        }
+                    });
+                    return (
+                        serde_json::to_string_pretty(&payload).unwrap_or_default(),
+                        true,
+                    );
+                }
+                // Correlate the originating JSON-RPC requestId with the
+                // dispatched job_id so a later `notifications/cancelled`
+                // can resolve to the JobRoute.
+                if let Some(ref rid) = request_id {
+                    gs.subscriber.bind_request_to_job(rid, jid);
+                }
             }
 
             // ── #321: wait-for-terminal passthrough ────────────────────

--- a/crates/dcc-mcp-http/src/gateway/handlers.rs
+++ b/crates/dcc-mcp-http/src/gateway/handlers.rs
@@ -394,22 +394,71 @@ async fn handle_notification(gs: &GatewayState, req: &JsonRpcRequest, _session_i
                 .cloned();
             if let Some(rid) = request_id {
                 let rid_str = serde_json::to_string(&rid).unwrap_or_default();
-                let pending = gs.pending_calls.read().await;
-                if let Some(call) = pending.get(&rid_str) {
-                    if !call.backend_url.is_empty() {
-                        let cancel_body = json!({
-                            "jsonrpc": "2.0",
-                            "method": "notifications/cancelled",
-                            "params": {"requestId": rid}
-                        });
-                        let _ = gs
-                            .http_client
-                            .post(&call.backend_url)
-                            .header("content-type", "application/json")
-                            .body(cancel_body.to_string())
-                            .timeout(std::time::Duration::from_secs(5))
-                            .send()
-                            .await;
+
+                // #322: prefer the JobRoute cache — it knows the exact
+                // backend that owns the job and unlocks the
+                // parent-job cascade across backends. Fall back to
+                // `pending_calls` only when no route is cached (e.g.
+                // for synchronous `tools/call` that never produced a
+                // job_id, or after the route has been GC'd).
+                let mut forwarded_to: std::collections::HashSet<String> =
+                    std::collections::HashSet::new();
+
+                let job_id = gs.subscriber.job_id_for_request(&rid_str);
+                let route = job_id.as_deref().and_then(|j| gs.subscriber.job_route(j));
+
+                if let Some(route) = route.clone() {
+                    forward_cancel(gs, &route.backend_id, &rid, &route.tool).await;
+                    forwarded_to.insert(route.backend_id.clone());
+
+                    // Parent-job cascade: if THIS job has a parent, we
+                    // also cancel every sibling routed via this gateway
+                    // (issue #318 inside a single server, here extended
+                    // across backends). This matches the semantics
+                    // users expect: cancelling any node in a workflow
+                    // cancels the workflow.
+                    if let Some(parent) = route.parent_job_id.as_deref() {
+                        for (child_jid, child) in gs.subscriber.children_of(parent) {
+                            if forwarded_to.insert(child.backend_id.clone()) {
+                                tracing::debug!(
+                                    parent = parent,
+                                    child = %child_jid,
+                                    backend = %child.backend_id,
+                                    "gateway: cascading cancel to child job"
+                                );
+                                forward_cancel(gs, &child.backend_id, &rid, &child.tool).await;
+                            }
+                        }
+                    }
+                }
+
+                // #322 cascade (parent-side): if the cancelled request
+                // itself targets a *parent* job_id — meaning no specific
+                // child route is cached under this requestId — walk the
+                // children index directly.
+                if let Some(jid) = job_id.as_deref() {
+                    for (child_jid, child) in gs.subscriber.children_of(jid) {
+                        if forwarded_to.insert(child.backend_id.clone()) {
+                            tracing::debug!(
+                                parent = jid,
+                                child = %child_jid,
+                                backend = %child.backend_id,
+                                "gateway: cascading cancel from parent"
+                            );
+                            forward_cancel(gs, &child.backend_id, &rid, &child.tool).await;
+                        }
+                    }
+                }
+
+                // Fallback: if we never resolved via JobRoute, honour
+                // the legacy `pending_calls` path so synchronous /
+                // pre-#322 callers are still covered.
+                if forwarded_to.is_empty() {
+                    let pending = gs.pending_calls.read().await;
+                    if let Some(call) = pending.get(&rid_str) {
+                        if !call.backend_url.is_empty() {
+                            forward_cancel(gs, &call.backend_url, &rid, "").await;
+                        }
                     }
                 }
             }
@@ -417,6 +466,38 @@ async fn handle_notification(gs: &GatewayState, req: &JsonRpcRequest, _session_i
         other => {
             tracing::debug!(method = other, "Gateway received unknown MCP notification");
         }
+    }
+}
+
+/// POST `notifications/cancelled { requestId }` to `backend_url`. Fire-
+/// and-forget with a short timeout — the backend's own cancel handler
+/// is responsible for racing this against the in-flight job. A best-
+/// effort debug log records failures but does not surface them to the
+/// client (MCP notifications have no reply channel).
+async fn forward_cancel(gs: &GatewayState, backend_url: &str, request_id: &Value, tool: &str) {
+    if backend_url.is_empty() {
+        return;
+    }
+    let body = json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/cancelled",
+        "params": {"requestId": request_id.clone()}
+    });
+    if let Err(e) = gs
+        .http_client
+        .post(backend_url)
+        .header("content-type", "application/json")
+        .body(body.to_string())
+        .timeout(std::time::Duration::from_secs(5))
+        .send()
+        .await
+    {
+        tracing::debug!(
+            backend = backend_url,
+            tool = tool,
+            error = %e,
+            "gateway: notifications/cancelled forward failed"
+        );
     }
 }
 

--- a/crates/dcc-mcp-http/src/gateway/mod.rs
+++ b/crates/dcc-mcp-http/src/gateway/mod.rs
@@ -195,6 +195,8 @@ async fn start_gateway_tasks(
     backend_timeout: Duration,
     async_dispatch_timeout: Duration,
     wait_terminal_timeout: Duration,
+    route_ttl: Duration,
+    max_routes_per_session: usize,
     server_name: String,
     server_version: String,
     sentinel_key: ServiceKey,
@@ -364,7 +366,14 @@ async fn start_gateway_tasks(
     // ── Backend SSE subscriber manager (#320) ─────────────────────────────
     // Multiplexes per-backend SSE notifications back to originating client
     // sessions. Each `ensure_subscribed` spawns a reconnecting task.
-    let subscriber = sse_subscriber::SubscriberManager::new(http_client.clone());
+    let subscriber = sse_subscriber::SubscriberManager::with_limits(
+        http_client.clone(),
+        route_ttl,
+        max_routes_per_session,
+    );
+    // #322: GC loop — evicts stale (non-terminal) routes that outlive
+    // their TTL. Terminal jobs are auto-evicted in `deliver`.
+    let route_gc_handle = subscriber.spawn_route_gc();
 
     // Periodically ensure every live backend has an active subscription.
     // The subscriber's internal DashMap makes repeat calls cheap, so we
@@ -441,6 +450,7 @@ async fn start_gateway_tasks(
             watcher_handle,
             tools_watcher_handle,
             backend_sub_handle,
+            route_gc_handle,
             gw_handle
         );
     });
@@ -547,6 +557,16 @@ pub struct GatewayConfig {
     /// Gateway wait-for-terminal passthrough timeout (issue #321).
     /// Default: `600_000` (10 minutes).
     pub wait_terminal_timeout_ms: u64,
+    /// TTL (seconds) for cached [`JobRoute`] entries in the gateway
+    /// routing cache (issue #322). Routes older than this are evicted
+    /// by a background GC task even if no terminal event was observed.
+    /// Default: `86_400` (24 hours).
+    ///
+    /// [`JobRoute`]: sse_subscriber::JobRoute
+    pub route_ttl_secs: u64,
+    /// Per-session ceiling on concurrent live routes (issue #322). `0`
+    /// disables the cap. Default: `1_000`.
+    pub max_routes_per_session: u64,
 }
 
 impl Default for GatewayConfig {
@@ -563,6 +583,8 @@ impl Default for GatewayConfig {
             backend_timeout_ms: 10_000,
             async_dispatch_timeout_ms: 60_000,
             wait_terminal_timeout_ms: 600_000,
+            route_ttl_secs: 60 * 60 * 24,
+            max_routes_per_session: 1_000,
         }
     }
 }
@@ -754,6 +776,8 @@ impl GatewayRunner {
         let backend_timeout = Duration::from_millis(self.config.backend_timeout_ms);
         let async_dispatch_timeout = Duration::from_millis(self.config.async_dispatch_timeout_ms);
         let wait_terminal_timeout = Duration::from_millis(self.config.wait_terminal_timeout_ms);
+        let route_ttl = Duration::from_secs(self.config.route_ttl_secs);
+        let max_routes_per_session = self.config.max_routes_per_session as usize;
         let own_version = self.config.server_version.clone();
 
         match try_bind_port_opt(&self.config.host, self.config.gateway_port).await {
@@ -782,6 +806,8 @@ impl GatewayRunner {
                     backend_timeout,
                     async_dispatch_timeout,
                     wait_terminal_timeout,
+                    route_ttl,
+                    max_routes_per_session,
                     format!("{} (gateway)", self.config.server_name),
                     own_version.clone(),
                     sentinel_key,
@@ -881,6 +907,8 @@ impl GatewayRunner {
         let backend_timeout = Duration::from_millis(self.config.backend_timeout_ms);
         let async_dispatch_timeout = Duration::from_millis(self.config.async_dispatch_timeout_ms);
         let wait_terminal_timeout = Duration::from_millis(self.config.wait_terminal_timeout_ms);
+        let route_ttl = Duration::from_secs(self.config.route_ttl_secs);
+        let max_routes_per_session = self.config.max_routes_per_session as usize;
         let server_name = self.config.server_name.clone();
         let timeout_secs = self.config.challenger_timeout_secs;
 
@@ -940,6 +968,8 @@ impl GatewayRunner {
                         backend_timeout,
                         async_dispatch_timeout,
                         wait_terminal_timeout,
+                        route_ttl,
+                        max_routes_per_session,
                         format!("{server_name} (gateway)"),
                         own_ver.clone(),
                         sentinel_key,

--- a/crates/dcc-mcp-http/src/gateway/sse_subscriber.rs
+++ b/crates/dcc-mcp-http/src/gateway/sse_subscriber.rs
@@ -44,6 +44,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use chrono::{DateTime, Utc};
 use dashmap::{DashMap, DashSet};
 use futures::StreamExt;
 use parking_lot::Mutex;
@@ -74,6 +75,78 @@ pub(crate) const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Identifier for a client-side MCP session.
 pub type ClientSessionId = String;
+
+/// Identifier for a backend DCC server. Conventionally the backend's
+/// MCP URL (`http://host:port/mcp`) — stable for the life of the
+/// instance and sufficient for cancel forwarding.
+pub type BackendId = String;
+
+/// Default ceiling on how long a non-terminal `JobRoute` may live in
+/// the gateway's routing cache (`gateway_route_ttl`, issue #322).
+pub(crate) const DEFAULT_ROUTE_TTL: Duration = Duration::from_secs(60 * 60 * 24);
+
+/// Default ceiling on concurrent live routes per client session
+/// (`gateway_max_routes_per_session`, issue #322).
+pub(crate) const DEFAULT_MAX_ROUTES_PER_SESSION: usize = 1_000;
+
+/// Cadence of the background GC that evicts stale `JobRoute`s.
+pub(crate) const ROUTE_GC_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Gateway-owned routing entry for a single async job (issue #322).
+///
+/// Populated when the gateway forwards a `tools/call` and the backend
+/// replies with a `job_id`; consulted on `notifications/cancelled` so
+/// the cancel can be propagated to the exact backend that owns the
+/// job. The `parent_job_id` link lets the gateway fan a cancel out
+/// across backends when a workflow parent is cancelled (#318 cascade).
+#[derive(Debug, Clone)]
+pub struct JobRoute {
+    /// Owning client session — used to route backend SSE notifications
+    /// back to the originator (the pre-#322 behaviour).
+    pub client_session_id: ClientSessionId,
+    /// Backend that runs this job (stable for the job's lifetime —
+    /// routes are sticky, no multi-backend failover, per #322).
+    pub backend_id: BackendId,
+    /// Tool name reported on dispatch, kept for cancel-payload logs.
+    pub tool: String,
+    /// Wall-clock time the route was created — drives TTL GC.
+    pub created_at: DateTime<Utc>,
+    /// Parent job id when this job was dispatched under a workflow
+    /// (`_meta.dcc.parentJobId`). A cancel on the parent cascades to
+    /// every child route, even across backends.
+    pub parent_job_id: Option<String>,
+}
+
+/// Error returned when a new route cannot be admitted to the gateway
+/// routing cache (issue #322).
+#[derive(Debug, Clone)]
+pub enum BindJobError {
+    /// The owning session already holds `cap` live routes. The gateway
+    /// surfaces this as a JSON-RPC `-32005 too_many_in_flight_jobs`
+    /// error so AI clients can back off or cancel in-flight jobs.
+    TooManyInFlight {
+        session_id: ClientSessionId,
+        live: usize,
+        cap: usize,
+    },
+}
+
+impl std::fmt::Display for BindJobError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BindJobError::TooManyInFlight {
+                session_id,
+                live,
+                cap,
+            } => write!(
+                f,
+                "too_many_in_flight_jobs: session {session_id} holds {live} live routes (cap {cap})"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for BindJobError {}
 
 /// A notification buffered while its target mapping is still unknown.
 #[derive(Debug, Clone)]
@@ -148,8 +221,21 @@ pub struct SubscriberManager {
 
 struct SubscriberManagerInner {
     backends: DashMap<String, BackendSubscriber>,
-    /// `job_id` → owning client session.
-    job_routes: DashMap<String, ClientSessionId>,
+    /// `job_id` → full [`JobRoute`] (issue #322).
+    ///
+    /// Before v0.15 this was `DashMap<String, ClientSessionId>`; callers
+    /// that only need the session id now read `route.client_session_id`.
+    job_routes: DashMap<String, JobRoute>,
+    /// Reverse index: `client_session_id` → set of live `job_id`s. Used
+    /// to enforce the per-session cap without walking the whole
+    /// `job_routes` map on every insert.
+    session_jobs: DashMap<ClientSessionId, DashSet<String>>,
+    /// Reverse index: gateway JSON-RPC `requestId` (stringified) →
+    /// dispatched `job_id`. Populated at dispatch time for async jobs
+    /// so `notifications/cancelled { requestId }` can resolve to a
+    /// `JobRoute` even after the original RPC has already returned
+    /// (issue #322).
+    request_to_job: DashMap<String, String>,
     /// `progressToken` (serialised JSON) → owning client session.
     progress_token_routes: DashMap<String, ClientSessionId>,
     /// Backend URL → set of client sessions with in-flight jobs on that
@@ -167,6 +253,12 @@ struct SubscriberManagerInner {
     job_event_buses: DashMap<String, broadcast::Sender<Value>>,
     /// Shared HTTP client with connection pooling.
     http_client: reqwest::Client,
+    /// TTL beyond which a non-terminal route is evicted by the GC task
+    /// (issue #322).
+    route_ttl: Duration,
+    /// Per-session ceiling on concurrent live routes (issue #322). `0`
+    /// disables the cap.
+    max_routes_per_session: usize,
 }
 
 impl Default for SubscriberManager {
@@ -177,15 +269,34 @@ impl Default for SubscriberManager {
 
 impl SubscriberManager {
     pub fn new(http_client: reqwest::Client) -> Self {
+        Self::with_limits(
+            http_client,
+            DEFAULT_ROUTE_TTL,
+            DEFAULT_MAX_ROUTES_PER_SESSION,
+        )
+    }
+
+    /// Construct with explicit routing-cache limits (issue #322). A
+    /// `max_routes_per_session` of `0` is treated as unlimited — caps
+    /// are opt-in by configuration.
+    pub fn with_limits(
+        http_client: reqwest::Client,
+        route_ttl: Duration,
+        max_routes_per_session: usize,
+    ) -> Self {
         Self {
             inner: Arc::new(SubscriberManagerInner {
                 backends: DashMap::new(),
                 job_routes: DashMap::new(),
+                session_jobs: DashMap::new(),
+                request_to_job: DashMap::new(),
                 progress_token_routes: DashMap::new(),
                 backend_inflight: DashMap::new(),
                 client_sinks: DashMap::new(),
                 job_event_buses: DashMap::new(),
                 http_client,
+                route_ttl,
+                max_routes_per_session,
             }),
         }
     }
@@ -213,9 +324,24 @@ impl SubscriberManager {
         // Scrub routing tables to avoid memory growth. We don't scan
         // `progress_token_routes` keys eagerly (tokens are short-lived)
         // but removing job_routes bound to this session is cheap.
+        let mut dropped_jobs: Vec<String> = Vec::new();
+        self.inner.job_routes.retain(|job_id, route| {
+            let keep = route.client_session_id.as_str() != session_id;
+            if !keep {
+                dropped_jobs.push(job_id.clone());
+            }
+            keep
+        });
+        for jid in &dropped_jobs {
+            self.inner.job_event_buses.remove(jid);
+        }
+        // The reverse index for this session is now redundant.
+        self.inner.session_jobs.remove(session_id);
+        // Orphaned request_to_job entries would be cheap to keep, but
+        // may as well scrub them.
         self.inner
-            .job_routes
-            .retain(|_, sid| sid.as_str() != session_id);
+            .request_to_job
+            .retain(|_, jid| !dropped_jobs.iter().any(|d| d == jid));
         self.inner
             .progress_token_routes
             .retain(|_, sid| sid.as_str() != session_id);
@@ -233,29 +359,131 @@ impl SubscriberManager {
     }
 
     /// Associate a `job_id` extracted from a backend reply with its
-    /// owning client session. Also registers the session as having an
-    /// in-flight job on `backend_url` so that a later reconnect on that
-    /// backend can emit `$/dcc.gatewayReconnect`.
-    pub fn bind_job(&self, job_id: &str, session_id: &str, backend_url: &str) {
+    /// owning client session, backend, and tool name (issue #322). Also
+    /// registers the session as having an in-flight job on `backend_url`
+    /// so that a later reconnect on that backend can emit
+    /// `$/dcc.gatewayReconnect`.
+    ///
+    /// Returns [`BindJobError::TooManyInFlight`] when the session has
+    /// reached `gateway_max_routes_per_session`; the gateway translates
+    /// this into a JSON-RPC `-32005` error so clients can back off or
+    /// cancel in-flight jobs.
+    pub fn bind_job_route(
+        &self,
+        job_id: &str,
+        session_id: &str,
+        backend_url: &str,
+        tool: &str,
+        parent_job_id: Option<&str>,
+    ) -> Result<(), BindJobError> {
+        if self.inner.max_routes_per_session > 0 {
+            let live = self
+                .inner
+                .session_jobs
+                .get(session_id)
+                .map(|e| e.value().len())
+                .unwrap_or(0);
+            if live >= self.inner.max_routes_per_session {
+                return Err(BindJobError::TooManyInFlight {
+                    session_id: session_id.to_string(),
+                    live,
+                    cap: self.inner.max_routes_per_session,
+                });
+            }
+        }
+        let route = JobRoute {
+            client_session_id: session_id.to_string(),
+            backend_id: backend_url.to_string(),
+            tool: tool.to_string(),
+            created_at: Utc::now(),
+            parent_job_id: parent_job_id.map(str::to_owned),
+        };
+        self.inner.job_routes.insert(job_id.to_string(), route);
         self.inner
-            .job_routes
-            .insert(job_id.to_string(), session_id.to_string());
+            .session_jobs
+            .entry(session_id.to_string())
+            .or_default()
+            .insert(job_id.to_string());
         self.inner
             .backend_inflight
             .entry(backend_url.to_string())
             .or_default()
             .insert(session_id.to_string());
         self.flush_pending_for_backend(backend_url);
+        Ok(())
+    }
+
+    /// Back-compat shim for the pre-#322 signature. Still used by a few
+    /// tests; new code should prefer [`bind_job_route`].
+    #[cfg(test)]
+    pub fn bind_job(&self, job_id: &str, session_id: &str, backend_url: &str) {
+        let _ = self.bind_job_route(job_id, session_id, backend_url, "", None);
+    }
+
+    /// Associate a gateway `requestId` with the `job_id` produced for
+    /// that async dispatch (issue #322). `notifications/cancelled`
+    /// carries only the `requestId`, so this reverse index lets the
+    /// gateway resolve back to a [`JobRoute`] even after the original
+    /// RPC has returned.
+    pub fn bind_request_to_job(&self, request_id: &str, job_id: &str) {
+        self.inner
+            .request_to_job
+            .insert(request_id.to_string(), job_id.to_string());
+    }
+
+    /// Lookup helper for the cancel path.
+    pub fn job_id_for_request(&self, request_id: &str) -> Option<String> {
+        self.inner
+            .request_to_job
+            .get(request_id)
+            .map(|e| e.value().clone())
+    }
+
+    /// Drop the `request_id → job_id` mapping (e.g. when the dispatch
+    /// is resolved client-side and cannot be cancelled any more).
+    #[allow(dead_code)]
+    pub fn forget_request(&self, request_id: &str) {
+        self.inner.request_to_job.remove(request_id);
+    }
+
+    /// Fetch a cloned [`JobRoute`] for `job_id`, if any.
+    pub fn job_route(&self, job_id: &str) -> Option<JobRoute> {
+        self.inner.job_routes.get(job_id).map(|e| e.value().clone())
+    }
+
+    /// Return every route whose `parent_job_id == parent` (issue #322
+    /// cross-backend cascade).
+    pub fn children_of(&self, parent: &str) -> Vec<(String, JobRoute)> {
+        self.inner
+            .job_routes
+            .iter()
+            .filter_map(|e| match &e.value().parent_job_id {
+                Some(p) if p == parent => Some((e.key().clone(), e.value().clone())),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Total number of live routes (introspection for tests + metrics).
+    pub fn route_count(&self) -> usize {
+        self.inner.job_routes.len()
     }
 
     /// Forget a `job_id` once the gateway has observed a terminal event
-    /// (caller's responsibility; the subscriber loop does not clean up
-    /// automatically because terminal detection needs JSON-RPC
-    /// semantics).
-    #[allow(dead_code)]
+    /// (the subscriber loop does this automatically on `$/dcc.jobUpdated`
+    /// with a terminal status — callers typically don't need to invoke
+    /// it themselves).
     pub fn forget_job(&self, job_id: &str) {
-        self.inner.job_routes.remove(job_id);
+        let removed = self.inner.job_routes.remove(job_id);
         self.inner.job_event_buses.remove(job_id);
+        if let Some((_, route)) = removed {
+            if let Some(set) = self.inner.session_jobs.get(&route.client_session_id) {
+                set.value().remove(job_id);
+            }
+        }
+        self.inner
+            .request_to_job
+            .retain(|_, jid| jid.as_str() != job_id);
     }
 
     // ── Job event bus (#321 wait-for-terminal) ─────────────────────────
@@ -326,11 +554,52 @@ impl SubscriberManager {
         );
     }
 
+    // ── Route GC (#322) ────────────────────────────────────────────────
+
+    /// Spawn a background task that periodically evicts stale
+    /// [`JobRoute`]s older than `route_ttl`. Returns the `JoinHandle`
+    /// so the gateway supervisor can cancel it on shutdown.
+    pub fn spawn_route_gc(&self) -> JoinHandle<()> {
+        let mgr = self.clone();
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(ROUTE_GC_INTERVAL);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                ticker.tick().await;
+                mgr.run_route_gc_once();
+            }
+        })
+    }
+
+    /// One GC pass — exposed separately so tests can drive it
+    /// synchronously without waiting a real interval.
+    pub fn run_route_gc_once(&self) -> usize {
+        let ttl = self.inner.route_ttl;
+        if ttl.is_zero() {
+            return 0;
+        }
+        let cutoff = Utc::now() - chrono::Duration::from_std(ttl).unwrap_or_default();
+        let stale: Vec<String> = self
+            .inner
+            .job_routes
+            .iter()
+            .filter(|e| e.value().created_at < cutoff)
+            .map(|e| e.key().clone())
+            .collect();
+        for jid in &stale {
+            self.forget_job(jid);
+        }
+        stale.len()
+    }
+
     // ── Introspection helpers (for tests) ──────────────────────────────
 
     #[cfg(test)]
     pub(crate) fn route_for_job(&self, job_id: &str) -> Option<String> {
-        self.inner.job_routes.get(job_id).map(|e| e.value().clone())
+        self.inner
+            .job_routes
+            .get(job_id)
+            .map(|e| e.value().client_session_id.clone())
     }
 
     #[cfg(test)]
@@ -362,6 +631,11 @@ impl SubscriberManager {
         // any GET /mcp stream open at all.
         if let Some(jid) = job_id_for_job_notification(&value) {
             self.publish_job_event(&jid, &value);
+        }
+        // #322: auto-evict the JobRoute once a terminal status arrives,
+        // so the cache doesn't grow with completed jobs.
+        if let Some(jid) = terminal_job_id(&value) {
+            self.forget_job(&jid);
         }
         let session = resolve_target(&self.inner, &value);
         match session {
@@ -645,6 +919,29 @@ fn job_id_for_job_notification(value: &Value) -> Option<String> {
         .map(str::to_owned)
 }
 
+/// Extract the `job_id` from a `$/dcc.jobUpdated` / `workflowUpdated`
+/// notification only when it carries a terminal status (issue #322
+/// auto-eviction). Terminal statuses follow #318: `completed`,
+/// `failed`, `cancelled`, `interrupted`.
+fn terminal_job_id(value: &Value) -> Option<String> {
+    let method = value.get("method").and_then(|m| m.as_str())?;
+    if !matches!(
+        method,
+        "notifications/$/dcc.jobUpdated" | "notifications/$/dcc.workflowUpdated"
+    ) {
+        return None;
+    }
+    let params = value.get("params")?;
+    let status = params.get("status").and_then(|s| s.as_str())?;
+    if !matches!(status, "completed" | "failed" | "cancelled" | "interrupted") {
+        return None;
+    }
+    params
+        .get("job_id")
+        .and_then(|j| j.as_str())
+        .map(str::to_owned)
+}
+
 /// Determine which client session should receive `value`.
 fn resolve_target(inner: &SubscriberManagerInner, value: &Value) -> Option<String> {
     let method = value.get("method").and_then(|m| m.as_str())?;
@@ -662,7 +959,10 @@ fn resolve_target(inner: &SubscriberManagerInner, value: &Value) -> Option<Strin
             let job_id = params
                 .and_then(|p| p.get("job_id"))
                 .and_then(|j| j.as_str())?;
-            inner.job_routes.get(job_id).map(|e| e.value().clone())
+            inner
+                .job_routes
+                .get(job_id)
+                .map(|e| e.value().client_session_id.clone())
         }
         _ => None,
     }
@@ -737,11 +1037,25 @@ mod tests {
         SubscriberManagerInner {
             backends: DashMap::new(),
             job_routes: DashMap::new(),
+            session_jobs: DashMap::new(),
+            request_to_job: DashMap::new(),
             progress_token_routes: DashMap::new(),
             backend_inflight: DashMap::new(),
             client_sinks: DashMap::new(),
             job_event_buses: DashMap::new(),
             http_client: reqwest::Client::new(),
+            route_ttl: DEFAULT_ROUTE_TTL,
+            max_routes_per_session: DEFAULT_MAX_ROUTES_PER_SESSION,
+        }
+    }
+
+    fn test_route(sid: &str) -> JobRoute {
+        JobRoute {
+            client_session_id: sid.to_string(),
+            backend_id: "http://backend/mcp".into(),
+            tool: "test_tool".into(),
+            created_at: Utc::now(),
+            parent_job_id: None,
         }
     }
 
@@ -762,7 +1076,9 @@ mod tests {
     #[test]
     fn resolve_target_uses_job_id_for_job_updated() {
         let inner = empty_inner();
-        inner.job_routes.insert("jid-42".into(), "sessB".into());
+        inner
+            .job_routes
+            .insert("jid-42".into(), test_route("sessB"));
         let note = serde_json::json!({
             "method": "notifications/$/dcc.jobUpdated",
             "params": {"job_id": "jid-42", "status": "running"}
@@ -955,6 +1271,118 @@ mod tests {
             mgr.pending_count(&backend),
             PENDING_BUFFER_CAP,
             "buffer is bounded"
+        );
+    }
+
+    // ── #322 JobRoute store ─────────────────────────────────────────────
+
+    #[test]
+    fn bind_job_route_populates_all_fields() {
+        let mgr = SubscriberManager::default();
+        mgr.bind_job_route("j1", "sessA", "http://back/mcp", "my_tool", Some("parent"))
+            .unwrap();
+        let route = mgr.job_route("j1").expect("route present");
+        assert_eq!(route.client_session_id, "sessA");
+        assert_eq!(route.backend_id, "http://back/mcp");
+        assert_eq!(route.tool, "my_tool");
+        assert_eq!(route.parent_job_id.as_deref(), Some("parent"));
+    }
+
+    #[test]
+    fn bind_request_to_job_resolves_back_to_route() {
+        let mgr = SubscriberManager::default();
+        mgr.bind_job_route("j1", "sessA", "http://back/mcp", "t", None)
+            .unwrap();
+        mgr.bind_request_to_job("\"req-7\"", "j1");
+        let jid = mgr.job_id_for_request("\"req-7\"").expect("mapping");
+        assert_eq!(jid, "j1");
+        let route = mgr.job_route(&jid).unwrap();
+        assert_eq!(route.backend_id, "http://back/mcp");
+    }
+
+    #[test]
+    fn children_of_returns_every_child_of_parent() {
+        let mgr = SubscriberManager::default();
+        mgr.bind_job_route("c1", "s", "http://a/mcp", "t", Some("P"))
+            .unwrap();
+        mgr.bind_job_route("c2", "s", "http://b/mcp", "t", Some("P"))
+            .unwrap();
+        mgr.bind_job_route("other", "s", "http://c/mcp", "t", Some("Q"))
+            .unwrap();
+        let mut kids: Vec<String> = mgr.children_of("P").into_iter().map(|(j, _)| j).collect();
+        kids.sort();
+        assert_eq!(kids, vec!["c1".to_string(), "c2".to_string()]);
+    }
+
+    #[test]
+    fn per_session_cap_rejects_overflow() {
+        let mgr =
+            SubscriberManager::with_limits(reqwest::Client::new(), Duration::from_secs(60), 2);
+        assert!(
+            mgr.bind_job_route("j1", "sess", "http://b/mcp", "t", None)
+                .is_ok()
+        );
+        assert!(
+            mgr.bind_job_route("j2", "sess", "http://b/mcp", "t", None)
+                .is_ok()
+        );
+        let err = mgr
+            .bind_job_route("j3", "sess", "http://b/mcp", "t", None)
+            .expect_err("cap should reject");
+        matches!(err, BindJobError::TooManyInFlight { .. });
+    }
+
+    #[test]
+    fn terminal_status_auto_evicts_route() {
+        let mgr = SubscriberManager::default();
+        let backend = "http://127.0.0.1:0/mcp".to_string();
+        let shared = Arc::new(BackendShared::new(backend.clone()));
+        mgr.bind_job_route("jT", "sess", &backend, "t", None)
+            .unwrap();
+        assert!(mgr.job_route("jT").is_some());
+        let note = serde_json::json!({
+            "method": "notifications/$/dcc.jobUpdated",
+            "params": {"job_id": "jT", "status": "completed"}
+        });
+        mgr.deliver(note, &shared);
+        assert!(
+            mgr.job_route("jT").is_none(),
+            "route should be auto-evicted on completion"
+        );
+    }
+
+    #[test]
+    fn run_route_gc_once_evicts_stale_routes() {
+        // TTL=0 disables GC (per spec); use 1 ms so routes older than
+        // 1 ms are stale.
+        let mgr =
+            SubscriberManager::with_limits(reqwest::Client::new(), Duration::from_millis(1), 0);
+        mgr.bind_job_route("old", "s", "http://b/mcp", "t", None)
+            .unwrap();
+        // Force the created_at far into the past.
+        if let Some(mut e) = mgr.inner.job_routes.get_mut("old") {
+            e.value_mut().created_at = Utc::now() - chrono::Duration::seconds(10);
+        }
+        let evicted = mgr.run_route_gc_once();
+        assert_eq!(evicted, 1);
+        assert!(mgr.job_route("old").is_none());
+    }
+
+    #[test]
+    fn forget_job_cleans_up_reverse_indexes() {
+        let mgr = SubscriberManager::default();
+        mgr.bind_job_route("j1", "sess", "http://b/mcp", "t", None)
+            .unwrap();
+        mgr.bind_request_to_job("\"rid\"", "j1");
+        assert!(mgr.job_route("j1").is_some());
+        mgr.forget_job("j1");
+        assert!(mgr.job_route("j1").is_none());
+        assert!(mgr.job_id_for_request("\"rid\"").is_none());
+        assert!(
+            mgr.inner
+                .session_jobs
+                .get("sess")
+                .is_none_or(|s| !s.contains("j1"))
         );
     }
 }

--- a/crates/dcc-mcp-http/src/python/mod.rs
+++ b/crates/dcc-mcp-http/src/python/mod.rs
@@ -27,7 +27,7 @@ pub struct PyMcpHttpConfig {
 impl PyMcpHttpConfig {
     /// Create a new config. ``port=0`` binds to any available port.
     #[new]
-    #[pyo3(signature = (port=8765, server_name=None, server_version=None, enable_cors=false, request_timeout_ms=30000, backend_timeout_ms=10_000, enable_prometheus=false, prometheus_basic_auth=None, gateway_async_dispatch_timeout_ms=60_000, gateway_wait_terminal_timeout_ms=600_000))]
+    #[pyo3(signature = (port=8765, server_name=None, server_version=None, enable_cors=false, request_timeout_ms=30000, backend_timeout_ms=10_000, enable_prometheus=false, prometheus_basic_auth=None, gateway_async_dispatch_timeout_ms=60_000, gateway_wait_terminal_timeout_ms=600_000, gateway_route_ttl_secs=86_400, gateway_max_routes_per_session=1_000))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         port: u16,
@@ -40,6 +40,8 @@ impl PyMcpHttpConfig {
         prometheus_basic_auth: Option<(String, String)>,
         gateway_async_dispatch_timeout_ms: u64,
         gateway_wait_terminal_timeout_ms: u64,
+        gateway_route_ttl_secs: u64,
+        gateway_max_routes_per_session: u64,
     ) -> Self {
         let mut cfg = McpHttpConfig::new(port);
         if let Some(name) = server_name {
@@ -55,6 +57,8 @@ impl PyMcpHttpConfig {
         cfg.prometheus_basic_auth = prometheus_basic_auth;
         cfg.gateway_async_dispatch_timeout_ms = gateway_async_dispatch_timeout_ms;
         cfg.gateway_wait_terminal_timeout_ms = gateway_wait_terminal_timeout_ms;
+        cfg.gateway_route_ttl_secs = gateway_route_ttl_secs;
+        cfg.gateway_max_routes_per_session = gateway_max_routes_per_session;
         // Issue #303: PyO3-embedded hosts (Maya on Windows etc.) cannot
         // rely on shared tokio worker threads to drive the accept loop
         // after `block_on` returns. Default to `Dedicated` so the listener
@@ -455,6 +459,38 @@ impl PyMcpHttpConfig {
     #[setter]
     fn set_gateway_wait_terminal_timeout_ms(&mut self, ms: u64) {
         self.inner.gateway_wait_terminal_timeout_ms = ms;
+    }
+
+    /// Gateway routing-cache TTL (seconds) for `JobRoute` entries
+    /// (issue #322). Default: ``86_400`` (24 hours).
+    ///
+    /// Routes that don't see a terminal notification within this window
+    /// are evicted by a background GC task so the cache cannot grow
+    /// without bound under pathological agents or crashed backends.
+    #[getter]
+    fn gateway_route_ttl_secs(&self) -> u64 {
+        self.inner.gateway_route_ttl_secs
+    }
+
+    #[setter]
+    fn set_gateway_route_ttl_secs(&mut self, secs: u64) {
+        self.inner.gateway_route_ttl_secs = secs;
+    }
+
+    /// Per-session ceiling on concurrent live gateway routes (issue
+    /// #322). ``0`` disables the cap. Default: ``1_000``.
+    ///
+    /// When a client session is already holding this many live routes,
+    /// new async ``tools/call`` requests are rejected with JSON-RPC
+    /// ``-32005 too_many_in_flight_jobs``.
+    #[getter]
+    fn gateway_max_routes_per_session(&self) -> u64 {
+        self.inner.gateway_max_routes_per_session
+    }
+
+    #[setter]
+    fn set_gateway_max_routes_per_session(&mut self, cap: u64) {
+        self.inner.gateway_max_routes_per_session = cap;
     }
 
     /// Advertise the MCP Resources primitive (issue #350).

--- a/crates/dcc-mcp-http/src/server.rs
+++ b/crates/dcc-mcp-http/src/server.rs
@@ -445,6 +445,8 @@ impl McpHttpServer {
                 backend_timeout_ms: self.config.backend_timeout_ms,
                 async_dispatch_timeout_ms: self.config.gateway_async_dispatch_timeout_ms,
                 wait_terminal_timeout_ms: self.config.gateway_wait_terminal_timeout_ms,
+                route_ttl_secs: self.config.gateway_route_ttl_secs,
+                max_routes_per_session: self.config.gateway_max_routes_per_session,
             };
 
             match GatewayRunner::new(gw_cfg) {

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -537,6 +537,8 @@ async fn main() -> anyhow::Result<()> {
         backend_timeout_ms: 10_000,
         async_dispatch_timeout_ms: 60_000,
         wait_terminal_timeout_ms: 600_000,
+        route_ttl_secs: 60 * 60 * 24,
+        max_routes_per_session: 1_000,
     };
 
     let runner = GatewayRunner::new(gateway_cfg)

--- a/docs/guide/gateway.md
+++ b/docs/guide/gateway.md
@@ -146,7 +146,62 @@ returns a JSON-RPC `-32000` error identifying the backend and the
 the backend may surface it as `interrupted` (issue #328) when the
 persisted job store rehydrates.
 
+## Job-to-backend routing cache (#322)
+
+To forward a `notifications/cancelled { requestId }` from the client to
+the backend that actually owns the job, the gateway keeps a small cache:
+
+```rust
+pub struct JobRoute {
+    pub client_session_id: ClientSessionId,
+    pub backend_id: BackendId,            // e.g. http://127.0.0.1:8001/mcp
+    pub tool: String,                     // for logs + cancel payload
+    pub created_at: DateTime<Utc>,        // GC anchor
+    pub parent_job_id: Option<String>,    // #318 cascade
+}
+// DashMap<Uuid, JobRoute>
+```
+
+Populated when the backend reply to a `tools/call` carries a `job_id`.
+Consumed by:
+
+- `notifications/cancelled { requestId }` — the gateway resolves
+  `requestId → job_id → JobRoute` and POSTs a cancel to `backend_id`.
+- Parent-job cascade — if the cancelled job has a `parent_job_id`, or
+  *is itself* a parent, the gateway walks the `children_of` index and
+  fans the cancel out to every distinct `backend_id` (which may differ
+  from the originating backend — `#318` only covered single-server
+  cascade, the gateway extends this across backends).
+
+### Lifecycle
+
+- **Insert** — `aggregator::route_tools_call` → `SubscriberManager::bind_job_route`.
+- **Auto-evict** — `deliver()` removes the route as soon as a
+  `$/dcc.jobUpdated` with a terminal status (`completed`, `failed`,
+  `cancelled`, `interrupted`) is observed.
+- **TTL GC** — a background task sweeps routes older than
+  `gateway_route_ttl_secs` (default 24 h) every 60 s, so a backend
+  crash that never emits a terminal event doesn't leak the route.
+- **Per-session cap** — `gateway_max_routes_per_session` (default
+  1 000). When a session is already holding `cap` live routes a new
+  dispatch is rejected with JSON-RPC `-32005 too_many_in_flight_jobs`.
+
+### Python configuration
+
+```python
+from dcc_mcp_core import McpHttpConfig
+
+cfg = McpHttpConfig(
+    port=0,
+    gateway_route_ttl_secs=3600,              # 1 hour
+    gateway_max_routes_per_session=500,
+)
+```
+
+Both fields are also accessible as getters/setters on the returned
+`McpHttpConfig` instance.
+
 ## Non-goals
 
-Routing-cache improvements for cancellation (#322) and HTTP/2
-multiplexing tuning are out of scope for both #320 and #321.
+HTTP/2 multiplexing tuning and multi-backend failover for the routing
+cache (routes are sticky) are out of scope for #320 / #321 / #322.

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -3836,6 +3836,16 @@ class McpHttpConfig:
             the gateway returns the last-known job envelope annotated
             with ``_meta.dcc.timed_out=true`` and leaves the job
             running on the backend (issue #321).
+        gateway_route_ttl_secs: TTL (seconds) for the gateway's
+            ``job_id → backend_id`` routing cache. Default: ``86_400``
+            (24 hours). Routes that don't see a terminal notification
+            within this window are evicted by a background GC task
+            (issue #322).
+        gateway_max_routes_per_session: Per-session ceiling on
+            concurrent live routes in the gateway routing cache. ``0``
+            disables the cap. Default: ``1_000``. Exceeding the cap
+            rejects new async ``tools/call`` with JSON-RPC
+            ``-32005 too_many_in_flight_jobs`` (issue #322).
 
     Example::
 
@@ -3856,6 +3866,8 @@ class McpHttpConfig:
         prometheus_basic_auth: tuple[str, str] | None = None,
         gateway_async_dispatch_timeout_ms: int = 60_000,
         gateway_wait_terminal_timeout_ms: int = 600_000,
+        gateway_route_ttl_secs: int = 86_400,
+        gateway_max_routes_per_session: int = 1_000,
     ) -> None: ...
     @property
     def port(self) -> int: ...
@@ -3946,6 +3958,32 @@ class McpHttpConfig:
         ...
     @gateway_wait_terminal_timeout_ms.setter
     def gateway_wait_terminal_timeout_ms(self, ms: int) -> None: ...
+    @property
+    def gateway_route_ttl_secs(self) -> int:
+        """Gateway routing-cache TTL in seconds (#322).
+
+        Controls how long a cached ``JobRoute`` (``job_id → backend_id``)
+        may live without seeing a terminal ``$/dcc.jobUpdated`` before a
+        background GC task evicts it. Terminal notifications auto-evict
+        routes; this TTL is the safety net for jobs whose terminal event
+        is never delivered (backend crash, SSE drop that never recovers,
+        …). Default: ``86_400`` (24 hours).
+        """
+        ...
+    @gateway_route_ttl_secs.setter
+    def gateway_route_ttl_secs(self, secs: int) -> None: ...
+    @property
+    def gateway_max_routes_per_session(self) -> int:
+        """Per-session cap on concurrent live gateway routes (#322).
+
+        ``0`` disables the cap. When a client session is already holding
+        this many live routes, new async ``tools/call`` requests are
+        rejected with JSON-RPC ``-32005 too_many_in_flight_jobs``.
+        Default: ``1_000``.
+        """
+        ...
+    @gateway_max_routes_per_session.setter
+    def gateway_max_routes_per_session(self, cap: int) -> None: ...
     @property
     def enable_resources(self) -> bool:
         """Advertise the MCP Resources primitive (issue #350).

--- a/tests/test_gateway_routing_cache.py
+++ b/tests/test_gateway_routing_cache.py
@@ -1,0 +1,116 @@
+"""Gateway job-to-backend routing cache (issue #322).
+
+End-to-end verification of the cancel-forward + cross-backend cascade
+path is covered by the Rust integration tests in
+``crates/dcc-mcp-http/src/gateway/sse_subscriber.rs`` (``JobRoute`` unit
+tests) and can be exercised against a real two-backend cluster via the
+``gateway_cross_process`` harness. From Python we pin the public surface:
+
+1. The two new ``McpHttpConfig`` fields (``gateway_route_ttl_secs`` and
+   ``gateway_max_routes_per_session``) accept defaults, constructor
+   kwargs, and setter round-trips.
+2. A gateway that is configured with those fields still elects
+   successfully and its listener passes the self-probe (issue #303
+   regression guard).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import socket
+import time
+
+import pytest
+
+from dcc_mcp_core import McpHttpConfig
+from dcc_mcp_core import McpHttpServer
+from dcc_mcp_core import ToolRegistry
+
+# ── Config surface ────────────────────────────────────────────────────────
+
+
+def test_mcp_http_config_defaults_match_issue_322():
+    """Defaults: 24 h TTL and 1000 live routes per session."""
+    cfg = McpHttpConfig(port=8765)
+    assert cfg.gateway_route_ttl_secs == 86_400
+    assert cfg.gateway_max_routes_per_session == 1_000
+
+
+def test_mcp_http_config_accepts_routing_fields_via_constructor():
+    cfg = McpHttpConfig(
+        port=8765,
+        gateway_route_ttl_secs=600,
+        gateway_max_routes_per_session=16,
+    )
+    assert cfg.gateway_route_ttl_secs == 600
+    assert cfg.gateway_max_routes_per_session == 16
+
+
+def test_mcp_http_config_setters_round_trip():
+    cfg = McpHttpConfig(port=0)
+    cfg.gateway_route_ttl_secs = 300
+    cfg.gateway_max_routes_per_session = 4
+    assert cfg.gateway_route_ttl_secs == 300
+    assert cfg.gateway_max_routes_per_session == 4
+    # 0 disables the cap — sanity check the type accepts it.
+    cfg.gateway_max_routes_per_session = 0
+    assert cfg.gateway_max_routes_per_session == 0
+
+
+# ── Gateway startup does not regress under custom routing limits ─────────
+
+
+def _pick_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_reachable(port: int, budget: float = 5.0) -> bool:
+    deadline = time.time() + budget
+    while time.time() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                return True
+        except (OSError, socket.timeout):
+            time.sleep(0.05)
+    return False
+
+
+def test_gateway_starts_with_custom_routing_cache_limits(tmp_path):
+    """Regression: tight TTL + small per-session cap must not break election.
+
+    If the GC task or the per-session cap were wired incorrectly, the
+    self-probe inside ``start_gateway_tasks`` would time out and
+    ``is_gateway`` would fall back to ``False``.
+    """
+    registry_dir = tmp_path / "registry"
+    registry_dir.mkdir()
+    gw_port = _pick_free_port()
+
+    reg = ToolRegistry()
+    cfg = McpHttpConfig(
+        port=0,
+        server_name="gateway-routing-cache-test",
+        gateway_route_ttl_secs=2,  # aggressive TTL — GC loops every 60 s
+        gateway_max_routes_per_session=4,
+    )
+    cfg.gateway_port = gw_port
+    cfg.registry_dir = str(registry_dir)
+    cfg.dcc_type = "python"
+    cfg.heartbeat_secs = 1
+    cfg.stale_timeout_secs = 10
+
+    server = McpHttpServer(reg, cfg)
+    handle = server.start()
+    try:
+        assert _wait_reachable(handle.port), "instance port must be reachable"
+        if not handle.is_gateway:
+            pytest.skip(f"another process holds gateway port {gw_port} — cannot verify gateway startup invariants here")
+        assert _wait_reachable(gw_port), "gateway port must be reachable"
+        # The config the server ran with reflects the overrides.
+        assert cfg.gateway_route_ttl_secs == 2
+        assert cfg.gateway_max_routes_per_session == 4
+    finally:
+        with contextlib.suppress(Exception):
+            handle.shutdown()


### PR DESCRIPTION
## Summary

Closes #322. Extends the gateway's in-memory job routing state so
`notifications/cancelled` can be forwarded to the backend that owns
the job, and parent-job cancellation cascades across backends.

- New `JobRoute { client_session_id, backend_id, tool, created_at, parent_job_id }`
  replaces the pre-existing `DashMap<Uuid, ClientSessionId>`. All
  callers (`aggregator::route_tools_call`, `handlers::handle_notification`,
  `resolve_target`, reconnect fan-out) updated.
- `notifications/cancelled { requestId }` now resolves
  `requestId → job_id → JobRoute` (new `request_to_job` reverse index)
  and POSTs the cancel to `route.backend_id`. When the cancelled job
  is part of a workflow (`_meta.dcc.parentJobId`), the gateway walks
  `children_of(parent)` and fans the cancel out to every distinct
  child backend — extending the single-server cascade added in #318.
- Terminal `$/dcc.jobUpdated` statuses (`completed`, `failed`,
  `cancelled`, `interrupted`) auto-evict routes in `deliver()`. A
  background GC task sweeps stale routes older than
  `gateway_route_ttl_secs` (default 24 h) once per minute so crashed
  backends don't leak entries.
- Per-session cap `gateway_max_routes_per_session` (default 1 000) —
  exceeding it rejects the dispatch with JSON-RPC
  `-32005 too_many_in_flight_jobs`. `0` disables.
- New Python config fields `McpHttpConfig.gateway_route_ttl_secs` and
  `McpHttpConfig.gateway_max_routes_per_session`, plumbed through
  `GatewayConfig`, the server binary defaults, and `_core.pyi`.
- Docs updated in `docs/guide/gateway.md`.

Non-goals (unchanged from the issue): no multi-backend failover
(routes are sticky), no load-based routing.

## Test plan

- [x] `vx cargo test -p dcc-mcp-http --lib gateway::sse_subscriber` —
      24 tests including 6 new #322 cases (`bind_job_route_populates_all_fields`,
      `bind_request_to_job_resolves_back_to_route`,
      `children_of_returns_every_child_of_parent`,
      `per_session_cap_rejects_overflow`,
      `terminal_status_auto_evicts_route`,
      `run_route_gc_once_evicts_stale_routes`,
      `forget_job_cleans_up_reverse_indexes`).
- [x] `vx just preflight` — clippy + fmt + full workspace `cargo test`
      green.
- [x] `vx just dev && pytest tests/test_gateway_routing_cache.py
      tests/test_gateway_passthrough.py tests/test_gateway_sse.py` — 11
      passed, 0 failed. Python test covers the new config surface
      (defaults, constructor kwargs, setter round-trip) and that
      gateway election + self-probe still succeed under a tight TTL
      and a small per-session cap.
