### PR TITLE
chore: fix clippy warnings, remove dead code, and update stale version strings

### DIFF
--- a/.agents/skills/dcc-mcp-core/SKILL.md
+++ b/.agents/skills/dcc-mcp-core/SKILL.md
@@ -3,7 +3,7 @@ name: dcc-mcp-core
 description: "Foundation library for the DCC Model Context Protocol (MCP) ecosystem. Provides Rust-powered action management, skills system, IPC transport, MCP Streamable HTTP server (2025-03-26 spec, with 2025-06-18 and 2025-11-25 awareness), sandbox security, shared memory, screen capture, USD scene support, and telemetry for AI-assisted DCC workflows. Use when working with Maya, Blender, Houdini, 3ds Max, or any DCC MCP integration."
 allowed-tools: Bash Read Write Edit
 compatibility: "Python 3.7-3.13; Rust 1.85+ required to build from source; zero runtime Python dependencies"
-version: "0.14.1"
+version: "0.14.3"  # x-release-please-version
 ---
 
 # dcc-mcp-core — DCC MCP Ecosystem Foundation

--- a/crates/dcc-mcp-http/src/gateway/mod.rs
+++ b/crates/dcc-mcp-http/src/gateway/mod.rs
@@ -142,7 +142,7 @@ async fn try_bind_port_opt(host: &str, port: u16) -> Option<tokio::net::TcpListe
 //
 // Issue #228: the old implementation scanned every DCC instance entry and
 // compared its `version` field (which is the DCC host version — e.g. Maya
-// `"2024"`) against our crate version (e.g. `"0.13.2"`), causing semver
+// `"2024"`) against our crate version (e.g. `"0.14.3"`), causing semver
 // comparison to flag every running DCC as a "newer challenger" and trigger
 // a self-yield within 15 s of startup.
 //

--- a/crates/dcc-mcp-http/src/gateway/sse_subscriber.rs
+++ b/crates/dcc-mcp-http/src/gateway/sse_subscriber.rs
@@ -609,22 +609,6 @@ impl SubscriberManager {
     // ── Introspection helpers (for tests) ──────────────────────────────
 
     #[cfg(test)]
-    pub(crate) fn route_for_job(&self, job_id: &str) -> Option<String> {
-        self.inner
-            .job_routes
-            .get(job_id)
-            .map(|e| e.value().client_session_id.clone())
-    }
-
-    #[cfg(test)]
-    pub(crate) fn route_for_progress_token(&self, token: &Value) -> Option<String> {
-        self.inner
-            .progress_token_routes
-            .get(&progress_token_key(token))
-            .map(|e| e.value().clone())
-    }
-
-    #[cfg(test)]
     pub(crate) fn pending_count(&self, backend_url: &str) -> usize {
         self.inner
             .backends

--- a/crates/dcc-mcp-http/src/gateway/state.rs
+++ b/crates/dcc-mcp-http/src/gateway/state.rs
@@ -151,7 +151,7 @@ mod tests {
             async_dispatch_timeout: Duration::from_secs(60),
             wait_terminal_timeout: Duration::from_secs(600),
             server_name: "test".into(),
-            server_version: "0.13.2".into(),
+            server_version: env!("CARGO_PKG_VERSION").into(),
             http_client: reqwest::Client::new(),
             yield_tx: Arc::new(yield_tx),
             events_tx: Arc::new(events_tx),
@@ -175,7 +175,7 @@ mod tests {
         {
             let r = registry.read().await;
             let mut sentinel = ServiceEntry::new(GATEWAY_SENTINEL_DCC_TYPE, "127.0.0.1", 9765);
-            sentinel.version = Some("0.13.2".into());
+            sentinel.version = Some(env!("CARGO_PKG_VERSION").into());
             r.register(sentinel).unwrap();
 
             let maya = ServiceEntry::new("maya", "127.0.0.1", 18812);

--- a/crates/dcc-mcp-http/src/gateway/tests.rs
+++ b/crates/dcc-mcp-http/src/gateway/tests.rs
@@ -1,6 +1,8 @@
 use super::*;
 use dcc_mcp_transport::discovery::types::ServiceEntry;
 
+const TEST_OWN_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 #[test]
 fn test_parse_semver_basic() {
     assert_eq!(parse_semver("0.12.29"), (0, 12, 29));
@@ -34,7 +36,7 @@ fn test_has_newer_sentinel_ignores_dcc_host_version() {
     reg.register(maya).unwrap();
 
     assert!(
-        !has_newer_sentinel(&reg, "0.13.2", Duration::from_secs(30)),
+        !has_newer_sentinel(&reg, TEST_OWN_VERSION, Duration::from_secs(30)),
         "Maya 2024 host version must not appear as a newer gateway"
     );
 }
@@ -47,11 +49,11 @@ fn test_has_newer_sentinel_detects_newer_gateway() {
     let reg = FileRegistry::new(dir.path()).unwrap();
 
     let mut sentinel = ServiceEntry::new(GATEWAY_SENTINEL_DCC_TYPE, "127.0.0.1", 9765);
-    sentinel.version = Some("0.14.0".to_string());
+    sentinel.version = Some("99.0.0".to_string());
     reg.register(sentinel).unwrap();
 
     assert!(
-        has_newer_sentinel(&reg, "0.13.2", Duration::from_secs(30)),
+        has_newer_sentinel(&reg, TEST_OWN_VERSION, Duration::from_secs(30)),
         "a newer-version sentinel must trigger yield"
     );
 }
@@ -64,11 +66,11 @@ fn test_has_newer_sentinel_ignores_own_version() {
     let reg = FileRegistry::new(dir.path()).unwrap();
 
     let mut sentinel = ServiceEntry::new(GATEWAY_SENTINEL_DCC_TYPE, "127.0.0.1", 9765);
-    sentinel.version = Some("0.13.2".to_string());
+    sentinel.version = Some(TEST_OWN_VERSION.to_string());
     reg.register(sentinel).unwrap();
 
     assert!(
-        !has_newer_sentinel(&reg, "0.13.2", Duration::from_secs(30)),
+        !has_newer_sentinel(&reg, TEST_OWN_VERSION, Duration::from_secs(30)),
         "identical version sentinel must not trigger yield"
     );
 }
@@ -86,7 +88,7 @@ fn test_has_newer_sentinel_ignores_stale_sentinel() {
     reg.register(sentinel).unwrap();
 
     assert!(
-        !has_newer_sentinel(&reg, "0.13.2", Duration::from_secs(30)),
+        !has_newer_sentinel(&reg, TEST_OWN_VERSION, Duration::from_secs(30)),
         "stale sentinel (crashed gateway) must not block newer takeover"
     );
 }
@@ -99,7 +101,7 @@ fn test_gateway_sentinel_heartbeat_advances() {
     let reg = FileRegistry::new(dir.path()).unwrap();
 
     let mut sentinel = ServiceEntry::new(GATEWAY_SENTINEL_DCC_TYPE, "127.0.0.1", 9765);
-    sentinel.version = Some("0.13.2".to_string());
+    sentinel.version = Some(TEST_OWN_VERSION.to_string());
     // Age the heartbeat so the before/after delta is observable.
     sentinel.last_heartbeat = std::time::SystemTime::now() - Duration::from_secs(120);
     let key = sentinel.key();

--- a/crates/dcc-mcp-process/src/pump.rs
+++ b/crates/dcc-mcp-process/src/pump.rs
@@ -320,7 +320,7 @@ mod tests {
         assert_eq!(d.total_processed(), 0);
 
         let req = JobRequest::new("s1", ThreadAffinity::Main, Box::new(|| Ok(json!(1))));
-        let _ = d.submit(req);
+        drop(d.submit(req));
         assert_eq!(d.total_dispatched(), 1);
 
         d.pump();

--- a/crates/dcc-mcp-shm/src/buffer.rs
+++ b/crates/dcc-mcp-shm/src/buffer.rs
@@ -686,23 +686,16 @@ mod tests {
 
         #[test]
         fn test_long_ttl_not_expired() {
-            let buf = SharedBuffer::create_with_ttl(
-                "ttl-long",
-                256,
-                Some(Duration::from_secs(3600)).into(),
-            )
-            .unwrap();
+            let buf =
+                SharedBuffer::create_with_ttl("ttl-long", 256, Some(Duration::from_secs(3600)))
+                    .unwrap();
             assert!(!buf.is_expired().unwrap());
         }
 
         #[test]
         fn test_descriptor_contains_ttl() {
-            let buf = SharedBuffer::create_with_ttl(
-                "ttl-desc",
-                256,
-                Some(Duration::from_secs(30)).into(),
-            )
-            .unwrap();
+            let buf = SharedBuffer::create_with_ttl("ttl-desc", 256, Some(Duration::from_secs(30)))
+                .unwrap();
             let desc = BufferDescriptor::from_buffer(&buf).unwrap();
             assert_eq!(desc.ttl_secs, 30);
         }

--- a/crates/dcc-mcp-transport/benches/dcclink_frame.rs
+++ b/crates/dcc-mcp-transport/benches/dcclink_frame.rs
@@ -1,7 +1,8 @@
 //! Criterion benchmarks for DccLinkFrame encode/decode (pure CPU, no I/O).
 
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use dcc_mcp_transport::{DccLinkFrame, DccLinkType};
+use std::hint::black_box;
 
 fn bench_encode(c: &mut Criterion) {
     let mut group = c.benchmark_group("dcclink_frame/encode");

--- a/crates/dcc-mcp-utils/src/file_logging.rs
+++ b/crates/dcc-mcp-utils/src/file_logging.rs
@@ -814,7 +814,7 @@ mod tests {
         // First write below threshold — no rotation.
         writer.write_all(b"hello\n").unwrap();
         // Second write pushes us past 32 bytes.
-        writer.write_all(&vec![b'x'; 64]).unwrap();
+        writer.write_all(&[b'x'; 64]).unwrap();
         writer.flush().unwrap();
         drop(writer);
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,6 +20,10 @@
           "type": "toml",
           "path": "pyproject.toml",
           "jsonpath": "$.project.version"
+        },
+        {
+          "type": "generic",
+          "path": ".agents/skills/dcc-mcp-core/SKILL.md"
         }
       ]
     }


### PR DESCRIPTION
## Summary

Maintenance cleanup PR targeting stale version strings, clippy warnings, and unused test helper code discovered while auditing the v0.14.3 codebase.

## Changes

- **Clippy warnings fixed (5 crates)**:
  - `dcc-mcp-process`: non-binding `let` on a future in pump.rs test
  - `dcc-mcp-utils`: useless `vec!` in file_logging.rs test
  - `dcc-mcp-shm`: useless `.into()` conversions on `Option<Duration>` in buffer.rs tests
  - `dcc-mcp-transport` benchmarks: replace deprecated `criterion::black_box` with `std::hint::black_box`
  - `dcc-mcp-http`: remove dead test helpers `route_for_job` and `route_for_progress_token`

- **Stale version strings updated**:
  - Gateway tests/state: replace hard-coded `"0.13.2"` with `env!("CARGO_PKG_VERSION")` or `TEST_OWN_VERSION` constant
  - Gateway mod.rs comment: update example version reference to `"0.14.3"`
  - `.agents/skills/dcc-mcp-core/SKILL.md`: bump version from `"0.14.1"` to `"0.14.3"`

## Verification

- [x] `cargo clippy --workspace --all-targets` — zero warnings
- [x] `cargo check --workspace` — clean
- [x] `cargo test -p dcc-mcp-http --lib gateway` — 105 passed
- [x] `cargo test -p dcc-mcp-process --lib pump` — 9 passed
- [x] `cargo test -p dcc-mcp-utils --lib file_logging` — 4 passed
- [x] `cargo test -p dcc-mcp-shm --lib buffer` — 21 passed
- [x] `cargo check --benches -p dcc-mcp-transport` — clean