### PR TITLE
feat(skills): introduce layered skill architecture with explicit routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,11 @@ Need to interact with DCC?
 → [`docs/guide/skills.md`](docs/guide/skills.md)
 → Examples: `examples/skills/` (11 complete packages)
 
+**Choosing the right skill layer (infrastructure vs domain vs example)?**
+→ [`skills/README.md#skill-layering`](skills/README.md#skill-layering) — layer definitions, description pattern, search-hint partitioning
+→ [`docs/guide/skills.md#layered-skill-architecture`](docs/guide/skills.md#layered-skill-architecture) — checklist + failure chain wiring
+→ Template: `skills/templates/domain-skill/` — ready-to-copy domain skill with correct layering
+
 **Writing tool handler Python scripts?**
 → `python/dcc_mcp_core/skill.py` — `@skill_entry`, `skill_success()`, `skill_error()`
 
@@ -706,6 +711,11 @@ json_str = result.to_json()    # JSON string
 - Use `next-tools: on-success/on-failure` in SKILL.md — guides AI agents to follow-up tools
 - Use `search-hint:` in SKILL.md — improves `search_skills` keyword matching
 - Use tool groups with `default_active: false` for power-user features — keeps `tools/list` small
+- **Tag every skill with `metadata.dcc-mcp.layer`** — `infrastructure`, `domain`, or `example`. See `skills/README.md#skill-layering`.
+- **Start every skill `description` with the layer prefix** (`Infrastructure skill —` / `Domain skill —` / `Example skill —`) followed by a "Not for X — use Y" negative routing sentence
+- **Keep `search-hint` non-overlapping across layers** — infrastructure: mechanism-oriented; domain: intent-oriented; example: append "authoring reference"
+- **Wire every domain skill tool `on-failure`** to `[dcc_diagnostics__screenshot, dcc_diagnostics__audit_log]`
+- **Declare `depends: [dcc-diagnostics]`** in every domain skill that uses `on-failure` chains
 - For every new SKILL.md extension, use a `metadata.dcc-mcp.<feature>` key pointing at a sibling file (see "SKILL.md sibling-file pattern" in Traps). Same rule for `tools`, `groups`, `workflows`, `prompts`, and anything future.
 - Unpack `scan_and_load()`: `skills, skipped = scan_and_load(dcc_name="maya")`
 - Register ALL handlers BEFORE `McpHttpServer.start()` — the server reads the registry at startup
@@ -731,6 +741,9 @@ json_str = result.to_json()    # JSON string
 - Don't use legacy APIs: `ActionManager`, `create_action_manager()`, `MiddlewareChain`, `Action` — removed in v0.12+
 - Don't put ANY dcc-mcp-core extension at the top level of a new SKILL.md (v0.15+ / #356) — **the rule is architectural, not a list of specific fields**. `tools`, `groups`, `workflows`, `prompts`, `next-tools` behaviour chains, `examples` packs, and any future extension MUST be a `metadata.dcc-mcp.<feature>` key pointing at a sibling file. See the "SKILL.md sibling-file pattern" trap for the full rationale. Legacy top-level `dcc:`/`tags:`/`tools:`/`groups:`/`depends:`/`search-hint:` still parse for backward compat but emit a deprecation warn and make `is_spec_compliant()` return `False`. See `docs/guide/skills.md#migrating-pre-015-skillmd`.
 - Don't inline large payloads (workflow specs, prompt templates, example dialogues, annotation tables) into SKILL.md frontmatter or body, even under `metadata:` — use sibling files. SKILL.md body stays ≤500 lines / ≤5000 tokens.
+- **Don't create a skill without `metadata.dcc-mcp.layer`** — untagged skills cause routing ambiguity as the catalog grows
+- **Don't write a domain skill `description` without a "Not for X" sentence** — agents need explicit counter-examples to avoid picking the wrong skill
+- **Don't overlap `search-hint` keywords between infrastructure and domain skills** — overlapping keywords make `search_skills()` return ambiguous results
 - Don't use removed transport APIs: `FramedChannel`, `connect_ipc()`, `IpcListener`, `TransportManager`, `CircuitBreaker`, `ConnectionPool` — removed in v0.14 (#251). Use `IpcChannelAdapter` / `DccLinkFrame` instead
 - Don't add Python runtime dependencies — the project is zero-dep by design
 - Don't manually bump versions or edit `CHANGELOG.md` — Release Please handles this

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -261,6 +261,117 @@ watcher.unwatch("/path/to/skills")
 paths = watcher.watched_paths()    # List[str]
 ```
 
+## Layered Skill Architecture
+
+### Why layers matter
+
+As a DCC adapter's skill set grows, AI agents can encounter routing ambiguity: two
+skills share overlapping keywords and the agent picks the wrong one. The layered
+architecture solves this by making each skill's scope and counter-examples explicit
+in its `description`, and by tagging every skill with a `dcc-mcp.layer` metadata key
+that partitions discovery.
+
+### The three layers
+
+| Layer | Role | `dcc-mcp.layer` value |
+|-------|------|----------------------|
+| **infrastructure** | Low-level, DCC-agnostic primitives. Stable API. Auto-loaded or shared. | `infrastructure` |
+| **domain** | Business workflows for a specific DCC or task. Depends on infrastructure. | `domain` |
+| **example** | Authoring references and demos. Never loaded in production. | `example` |
+
+**Infrastructure skills** (e.g. `dcc-diagnostics`, `workflow`, `usd-tools`) are the
+fallback and recovery layer. Every domain skill chains to them via `next-tools.on-failure`.
+
+**Domain skills** (e.g. `maya-geometry`, `maya-pipeline`) implement a specific DCC
+workflow. They declare `depends:` on the infrastructure skills they chain to, and their
+tool descriptions guide agents toward other domain skills when the requested operation
+is out of scope.
+
+### Description pattern: explicit negative routing
+
+The `description` field must follow a 3-part structure that tells agents both
+when to use and when **not** to use the skill:
+
+```
+<Layer> skill — <one-sentence what + scope keywords>. Use when <trigger>.
+Not for <counter-example> — use <other-skill> for that.
+```
+
+```yaml
+# Infrastructure skill
+description: >-
+  Infrastructure skill — low-level OpenUSD scene inspection and validation:
+  read layer stacks, traverse prims, validate schemas. Use when working
+  directly with raw USD files. Not for Maya-specific USD export — use
+  maya-pipeline__export_usd for that.
+
+# Domain skill
+description: >-
+  Domain skill — Maya geometry primitives: create spheres, cubes, cylinders;
+  bevel and extrude polygon components. Use for individual geometry operations
+  in Maya. Not for full asset export pipelines — use maya-pipeline for that.
+  Not for raw USD file inspection — use usd-tools for that.
+```
+
+### Metadata layer tag
+
+Tag every skill with its layer so `search_skills` can filter by layer:
+
+```yaml
+metadata:
+  dcc-mcp.layer: infrastructure   # or: domain | example
+```
+
+```python
+# Browse only infrastructure skills
+infra = catalog.find_skills(tags=["infrastructure"])
+
+# Browse only domain skills for maya
+domain = catalog.find_skills(tags=["domain"], dcc="maya")
+```
+
+### search-hint partitioning
+
+Keep `search-hint` keywords non-overlapping across layers so `search_skills()`
+returns the most relevant skill:
+
+```yaml
+# ✓ Infrastructure — mechanism-oriented (describes the tool/API itself)
+dcc-mcp.search-hint: "usd stage, prim, schema validation, usdcat, usdchecker"
+
+# ✓ Domain — intent-oriented (describes the user's goal)
+dcc-mcp.search-hint: "export Maya scene to USD, asset pipeline, project setup"
+
+# ✓ Example — append "authoring reference" to avoid production matches
+dcc-mcp.search-hint: "async tool, deferred hint, authoring reference"
+```
+
+### Failure chain wiring
+
+Every **domain skill tool** must wire `on-failure` to infrastructure diagnostics.
+This gives the agent a consistent recovery path regardless of which domain skill failed:
+
+```yaml
+tools:
+  - name: export_usd
+    source_file: scripts/export_usd.py
+    next-tools:
+      on-success: [usd_tools__validate]
+      on-failure: [dcc_diagnostics__screenshot, dcc_diagnostics__audit_log]
+```
+
+Infrastructure skills do not need `on-failure` chains — they are the fallback.
+
+### Checklist for a new domain skill
+
+Before opening a PR for a new domain skill, verify:
+
+- [ ] `metadata.dcc-mcp.layer: domain` is set
+- [ ] `description` starts with `Domain skill —` and ends with at least one `Not for … — use … for that.` sentence
+- [ ] `search-hint` uses intent-oriented keywords that do not overlap with infrastructure skills
+- [ ] `depends:` lists every infrastructure skill referenced in `next-tools.on-failure`
+- [ ] Every tool has `on-failure: [dcc_diagnostics__screenshot, dcc_diagnostics__audit_log]`
+
 ## Dependency Resolution
 
 Skills can declare dependencies on other skills using the `depends:` field in SKILL.md:

--- a/examples/skills/async-render-example/SKILL.md
+++ b/examples/skills/async-render-example/SKILL.md
@@ -1,12 +1,18 @@
 ---
 name: async-render-example
-description: "Example skill demonstrating async execution affinity. Use when you want to see how long-running tools surface as deferredHint=true in MCP tools/list."
+description: >-
+  Example skill — demonstrates async execution affinity: long-running tools
+  surface as deferredHint=true in MCP tools/list. Use as a reference when
+  writing domain skills with render or simulation tools. Not intended for
+  production use.
 license: MIT
 compatibility: Python 3.7+
-tags: [example, async, render]
-dcc: python
-version: "1.0.0"
-search-hint: "async, long-running, render, deferred, timeout hint"
+metadata:
+  dcc-mcp.dcc: python
+  dcc-mcp.version: "1.0.0"
+  dcc-mcp.layer: example
+  dcc-mcp.search-hint: "async tool, long-running, deferred hint, timeout hint, render async, authoring reference"
+  dcc-mcp.tags: "example, async, render, deferred"
 tools:
   - name: render_frames
     description: "Pretend to render a frame range. Long-running; the server surfaces `deferredHint: true` and `_meta.dcc.timeoutHintSecs`."

--- a/examples/skills/cancellable-loop/SKILL.md
+++ b/examples/skills/cancellable-loop/SKILL.md
@@ -1,12 +1,18 @@
 ---
 name: cancellable-loop
-description: "Demonstrates cooperative cancellation inside a skill script loop using check_cancelled(). Use when showing how long-running skills should respond to notifications/cancelled."
+description: >-
+  Example skill — demonstrates cooperative cancellation inside a skill script
+  loop using check_cancelled(). Use as a reference when writing long-running
+  domain skills that must respond to notifications/cancelled. Not intended for
+  production use.
 license: MIT
 compatibility: Python 3.7+
-tags: [example, cancellation, long-running]
-dcc: python
-version: "1.0.0"
-search-hint: "cancellation, cancel, long-running, cooperative, check_cancelled, abort"
+metadata:
+  dcc-mcp.dcc: python
+  dcc-mcp.version: "1.0.0"
+  dcc-mcp.layer: example
+  dcc-mcp.search-hint: "cancellation, cancel, long-running, cooperative, check_cancelled, abort, authoring reference"
+  dcc-mcp.tags: "example, cancellation, long-running"
 ---
 
 # Cancellable Loop

--- a/examples/skills/clawhub-compat/SKILL.md
+++ b/examples/skills/clawhub-compat/SKILL.md
@@ -1,11 +1,18 @@
 ---
 name: clawhub-compat
-description: "Demonstrates full compatibility with the ClawHub/OpenClaw skill format. Use as a reference when creating skills for both the dcc-mcp-core ecosystem and ClawHub marketplace."
+description: >-
+  Example skill — demonstrates full compatibility with the ClawHub/OpenClaw
+  skill format. Use as a reference when creating skills for both the
+  dcc-mcp-core ecosystem and ClawHub marketplace. Not intended for production
+  use — this is an authoring reference only.
 license: MIT
 compatibility: Requires curl binary on PATH
 allowed-tools: Bash Read
 metadata:
-  category: example
+  dcc-mcp.dcc: python
+  dcc-mcp.layer: example
+  dcc-mcp.search-hint: "clawhub, openclaw, marketplace, skill format, compatibility reference"
+  dcc-mcp.tags: "example, clawhub, openclaw, compatibility"
   openclaw:
     requires:
       env:

--- a/examples/skills/dcc-diagnostics/SKILL.md
+++ b/examples/skills/dcc-diagnostics/SKILL.md
@@ -1,13 +1,19 @@
 ---
 name: dcc-diagnostics
-description: "DCC-agnostic diagnostics and observability tools — capture screenshots, query audit logs, inspect action performance metrics, and monitor process health. Works in any DCC environment (Maya, Blender, Houdini, Unreal, etc.) or standalone Python."
+description: >-
+  Infrastructure skill — DCC-agnostic observability primitives: capture
+  screenshots, query audit logs, inspect tool performance metrics, and monitor
+  process health. Works in any DCC environment (Maya, Blender, Houdini, Unreal,
+  etc.) or standalone Python. Use for debugging any skill failure or verifying
+  DCC state. Not for primary task execution — use a domain skill for actual DCC
+  operations.
 license: MIT
-dcc: python
-version: "1.0.0"
-search-hint: "screenshot, capture, audit log, metrics, performance, process monitor, diagnostics, debug, health check"
-tags: [diagnostics, observability, screenshot, audit, metrics, debug]
 metadata:
-  category: diagnostics
+  dcc-mcp.dcc: python
+  dcc-mcp.version: "1.0.0"
+  dcc-mcp.layer: infrastructure
+  dcc-mcp.search-hint: "screenshot, capture, audit log, metrics, performance, process monitor, diagnostics, debug, health check, observability"
+  dcc-mcp.tags: "diagnostics, observability, screenshot, audit, metrics, debug, infrastructure"
 tools:
   - name: screenshot
     description: "Capture a screenshot of the current display or a specific window. Returns the image as a base64-encoded PNG. Useful for visual debugging — capture what's visible on screen when an error occurs."

--- a/examples/skills/ffmpeg-media/SKILL.md
+++ b/examples/skills/ffmpeg-media/SKILL.md
@@ -1,11 +1,19 @@
 ---
 name: ffmpeg-media
-description: "Media conversion and processing powered by FFmpeg — convert video/audio formats, extract frames, resize, and transcode. Use when working with video, audio, or image sequences."
+description: >-
+  Infrastructure skill — media conversion and processing via FFmpeg: convert
+  video/audio formats, extract frames, resize, and transcode. Use when
+  manipulating raw media files (mp4, mov, wav, image sequences) regardless of
+  DCC context. Not for DCC-specific render output handling — use a domain
+  pipeline skill for post-render processing tied to a specific DCC.
 license: MIT
 compatibility: Requires ffmpeg and ffprobe binaries on PATH
 allowed-tools: Bash Read Write
 metadata:
-  category: media
+  dcc-mcp.dcc: python
+  dcc-mcp.layer: infrastructure
+  dcc-mcp.search-hint: "ffmpeg, video transcode, audio convert, extract frames, resize video, image sequence, media processing"
+  dcc-mcp.tags: "media, video, audio, ffmpeg, conversion, infrastructure"
   openclaw:
     requires:
       bins:
@@ -17,7 +25,6 @@ metadata:
         bins: [ffmpeg, ffprobe]
     emoji: "🎬"
     homepage: https://ffmpeg.org
-tags: [media, video, audio, ffmpeg, conversion]
 dcc: python
 version: "1.0.0"
 search-hint: "ffmpeg, video, audio, media conversion, transcode, extract frames, resize"

--- a/examples/skills/git-automation/SKILL.md
+++ b/examples/skills/git-automation/SKILL.md
@@ -1,21 +1,26 @@
 ---
 name: git-automation
-description: "Git repository analysis and automation — inspect commits, branches, diffs, and file history. Use when analysing a codebase, reviewing changes, or automating version control workflows."
+description: >-
+  Infrastructure skill — Git repository analysis and automation: inspect
+  commits, branches, diffs, and file history. Use when analysing a codebase,
+  reviewing changes, or automating version control workflows independent of any
+  DCC. Not for DCC asset versioning or Perforce operations — use a domain skill
+  bound to the specific VCS for those.
 license: MIT
 compatibility: Requires git on PATH
 allowed-tools: Bash Read
 metadata:
-  category: devops
+  dcc-mcp.dcc: python
+  dcc-mcp.version: "1.0.0"
+  dcc-mcp.layer: infrastructure
+  dcc-mcp.search-hint: "git commit, git diff, git branch, git log, version control, codebase analysis, git history"
+  dcc-mcp.tags: "git, vcs, automation, devops, infrastructure"
   openclaw:
     requires:
       bins:
         - git
     emoji: "🔀"
     homepage: https://git-scm.com
-tags: [git, vcs, automation, devops]
-dcc: python
-version: "1.0.0"
-search-hint: "git, commit history, diff, branch, version control, log, vcs"
 tools:
   - name: log
     description: Show recent commit history

--- a/examples/skills/hello-world/SKILL.md
+++ b/examples/skills/hello-world/SKILL.md
@@ -1,13 +1,18 @@
 ---
 name: hello-world
-description: "A minimal example skill that prints a greeting message. Use when demonstrating the dcc-mcp-core skill system or testing a new skill installation."
+description: >-
+  Example skill — minimal greeting tool demonstrating the dcc-mcp-core skill
+  system. Use only when testing a new skill installation or onboarding to the
+  skill authoring workflow. Not intended for production use.
 license: MIT
 compatibility: Python 3.7+
 allowed-tools: Bash Read
-tags: [example, beginner]
-dcc: python
-version: "1.0.0"
-search-hint: "greeting, hello, example, demo, test skill"
+metadata:
+  dcc-mcp.dcc: python
+  dcc-mcp.version: "1.0.0"
+  dcc-mcp.layer: example
+  dcc-mcp.search-hint: "greeting, hello, example, demo, test skill, starter"
+  dcc-mcp.tags: "example, beginner, demo"
 ---
 
 # Hello World

--- a/examples/skills/imagemagick-tools/SKILL.md
+++ b/examples/skills/imagemagick-tools/SKILL.md
@@ -1,11 +1,19 @@
 ---
 name: imagemagick-tools
-description: "Image processing and manipulation powered by ImageMagick — resize, composite, convert formats, add watermarks. Use when batch-processing textures, thumbnails, or rendered images in DCC pipelines."
+description: >-
+  Infrastructure skill — image processing and manipulation via ImageMagick:
+  resize, composite, convert formats, add watermarks. Use when batch-processing
+  textures, thumbnails, or rendered images at the file level. Not for
+  in-DCC texture or material editing — use a domain skill bound to the specific
+  DCC for that.
 license: MIT
 compatibility: Requires ImageMagick (magick binary) on PATH
 allowed-tools: Bash Read Write
 metadata:
-  category: image
+  dcc-mcp.dcc: python
+  dcc-mcp.layer: infrastructure
+  dcc-mcp.search-hint: "imagemagick, resize image, convert texture, composite, watermark, batch image, thumbnail"
+  dcc-mcp.tags: "image, processing, imagemagick, texture, compositing, infrastructure"
   openclaw:
     requires:
       bins:
@@ -16,8 +24,6 @@ metadata:
         bins: [magick]
     emoji: "🖼️"
     homepage: https://imagemagick.org
-tags: [image, processing, imagemagick, texture, compositing]
-dcc: python
 version: "1.0.0"
 search-hint: "imagemagick, image processing, resize, convert, watermark, texture, thumbnail"
 tools:

--- a/examples/skills/maya-geometry/SKILL.md
+++ b/examples/skills/maya-geometry/SKILL.md
@@ -1,16 +1,22 @@
 ---
 name: maya-geometry
-description: "Maya geometry creation and modification tools — create spheres, cubes, cylinders; bevel, extrude, and merge polygon components. Use when working with 3D geometry in Maya scenes."
+description: >-
+  Domain skill — Maya geometry primitives: create spheres, cubes, cylinders;
+  bevel, extrude, and merge polygon components. Use for individual geometry
+  creation or editing operations inside Maya. Not for full asset export
+  pipelines — use maya-pipeline for that. Not for USD scene inspection — use
+  usd-tools for that.
 license: MIT
 compatibility: Maya 2022+, Python 3.7+
 allowed-tools: Bash Read Write
 metadata:
+  dcc-mcp.dcc: maya
+  dcc-mcp.version: "1.0.0"
+  dcc-mcp.layer: domain
+  dcc-mcp.search-hint: "create sphere, create cube, bevel edges, extrude faces, polygon modeling, Maya mesh, 3D primitives, rigging joint"
+  dcc-mcp.tags: "maya, geometry, modeling, polygon, domain"
   category: modeling
   dcc_vendor: Autodesk
-tags: [maya, geometry, creation, modeling]
-dcc: maya
-version: "1.0.0"
-search-hint: "maya, geometry, polygon, sphere, cube, bevel, extrude, merge, 3D modeling, rigging, skin"
 groups:
   - name: modeling
     description: Polygon modeling primitives and edits (always active by default)

--- a/examples/skills/maya-pipeline/SKILL.md
+++ b/examples/skills/maya-pipeline/SKILL.md
@@ -1,16 +1,22 @@
 ---
 name: maya-pipeline
-description: "Advanced Maya pipeline skill — set up project structures, export scenes to USD, and orchestrate multi-step DCC workflows. Use when initialising a Maya project or exporting assets for a pipeline."
+description: >-
+  Domain skill — Maya asset pipeline orchestration: set up project directory
+  structures, export scenes to USD, and coordinate multi-step DCC workflows.
+  Use when initialising a Maya project or exporting assets for a downstream
+  pipeline. Not for raw geometry editing — use maya-geometry for that. Not for
+  low-level USD file inspection — use usd-tools for that.
 license: MIT
 compatibility: Maya 2022+, Python 3.7+, requires usd-tools and maya-geometry skills
 allowed-tools: Bash Read Write
 metadata:
+  dcc-mcp.dcc: maya
+  dcc-mcp.version: "2.0.0"
+  dcc-mcp.layer: domain
+  dcc-mcp.search-hint: "Maya project setup, export scene USD, asset pipeline, Maya export workflow, DCC pipeline orchestration"
+  dcc-mcp.tags: "maya, pipeline, export, project setup, domain"
   category: pipeline
   author: dcc-mcp-core
-tags: [maya, pipeline, advanced, composable]
-dcc: maya
-version: "2.0.0"
-search-hint: "maya, pipeline, USD, export, project setup, scene, asset, DCC workflow"
 depends:
   - maya-geometry
   - usd-tools

--- a/examples/skills/multi-script/SKILL.md
+++ b/examples/skills/multi-script/SKILL.md
@@ -1,16 +1,19 @@
 ---
 name: multi-script
-description: "Demonstrates a skill with multiple script types — Python, Shell, and Batch. Use as a reference when writing cross-platform skills that run different script languages."
+description: >-
+  Example skill — demonstrates a skill with multiple script types (Python,
+  Shell, Batch). Use as a reference when writing cross-platform skills. Not
+  intended for production use — this is an authoring reference only.
 license: MIT
 compatibility: Python 3.7+; bash required on Linux/macOS; cmd on Windows
 allowed-tools: Bash Read
 metadata:
-  category: example
+  dcc-mcp.dcc: python
+  dcc-mcp.version: "1.0.0"
+  dcc-mcp.layer: example
+  dcc-mcp.search-hint: "multi-script, cross-platform, python shell batch, script types, authoring reference"
+  dcc-mcp.tags: "example, multi-language, cross-platform"
   author: dcc-mcp-core
-tags: [example, multi-language, cross-platform]
-dcc: python
-version: "1.0.0"
-search-hint: "multi-script, cross-platform, python, shell, batch, script types, example"
 tools:
   - name: action_python
     description: Runs the Python implementation of the action

--- a/examples/skills/usd-tools/SKILL.md
+++ b/examples/skills/usd-tools/SKILL.md
@@ -1,11 +1,20 @@
 ---
 name: usd-tools
-description: "OpenUSD scene inspection and validation tools — read layer stacks, traverse prims, validate USD files. Use when working with USD assets, pipelines, or scene description."
+description: >-
+  Infrastructure skill — low-level OpenUSD scene inspection and validation:
+  read layer stacks, traverse prims, validate USD schemas. Use when working
+  directly with raw USD files (usda, usdc, usdz) or verifying USD compliance.
+  Not for Maya-specific USD export — use maya-pipeline__export_usd for that.
+  Not for full DCC pipeline workflows — use a domain pipeline skill instead.
 license: Apache-2.0
 compatibility: Requires usdcat and usdchecker from the OpenUSD distribution
 allowed-tools: Bash Read
 metadata:
-  category: pipeline
+  dcc-mcp.dcc: python
+  dcc-mcp.version: "1.0.0"
+  dcc-mcp.layer: infrastructure
+  dcc-mcp.search-hint: "USD stage, prim, schema validation, layer stack, usda, usdc, usdz, usdchecker, usdcat, raw USD file"
+  dcc-mcp.tags: "usd, openusd, scene inspection, validation, infrastructure"
   openclaw:
     requires:
       bins:
@@ -13,10 +22,6 @@ metadata:
         - usdchecker
     emoji: "🎬"
     homepage: https://openusd.org
-tags: [usd, openusd, pipeline, scene, validation]
-dcc: python
-version: "1.0.0"
-search-hint: "USD, OpenUSD, scene inspection, validation, layer stack, prims, assets"
 tools:
   - name: inspect
     description: Print the contents of a USD file in human-readable form

--- a/examples/skills/workflow/SKILL.md
+++ b/examples/skills/workflow/SKILL.md
@@ -1,13 +1,18 @@
 ---
 name: workflow
-description: "Multi-step action orchestration — run a sequence of MCP tools in order, passing results between steps. Enables agents to chain complex operations (select → rename → validate → export) without custom code."
+description: >-
+  Infrastructure skill — multi-step action orchestration: run a sequence of MCP
+  tools in order, passing results between steps. Use when chaining two or more
+  tools into a repeatable pipeline (select → rename → validate → export). Not
+  for single-tool operations or DCC-specific business logic — use a domain skill
+  for those.
 license: MIT
-dcc: python
-version: "1.0.0"
-search-hint: "chain, sequence, pipeline, multi-step, orchestration, workflow, batch, run steps"
-tags: [workflow, orchestration, chain, pipeline, automation]
 metadata:
-  category: workflow
+  dcc-mcp.dcc: python
+  dcc-mcp.version: "1.0.0"
+  dcc-mcp.layer: infrastructure
+  dcc-mcp.search-hint: "chain, sequence, pipeline, multi-step, orchestration, workflow, batch, run steps, automate"
+  dcc-mcp.tags: "workflow, orchestration, chain, pipeline, automation, infrastructure"
 tools:
   - name: run_chain
     description: "Execute a sequence of actions in order via the dcc-mcp-core ToolDispatcher. Each step's output context is merged into the next step's parameters. On failure, the chain stops and reports which step failed and why."

--- a/python/dcc_mcp_core/skills/dcc-diagnostics/SKILL.md
+++ b/python/dcc_mcp_core/skills/dcc-diagnostics/SKILL.md
@@ -1,13 +1,19 @@
 ---
 name: dcc-diagnostics
-description: "DCC-agnostic diagnostics and observability tools — capture screenshots, query audit logs, inspect tool performance metrics, and monitor process health. Works in any DCC environment (Maya, Blender, Houdini, Unreal, etc.) or standalone Python."
+description: >-
+  Infrastructure skill — DCC-agnostic observability primitives: capture
+  screenshots, query audit logs, inspect tool performance metrics, and monitor
+  process health. Works in any DCC environment (Maya, Blender, Houdini, Unreal,
+  etc.) or standalone Python. Use for debugging any skill failure or verifying
+  DCC state. Not for primary task execution — use a domain skill for actual DCC
+  operations.
 license: MIT
 metadata:
-  category: diagnostics
   dcc-mcp.dcc: python
   dcc-mcp.version: "1.0.0"
-  dcc-mcp.search-hint: "screenshot, capture, audit log, metrics, performance, process monitor, diagnostics, debug, health check"
-  dcc-mcp.tags: "diagnostics, observability, screenshot, audit, metrics, debug"
+  dcc-mcp.layer: infrastructure
+  dcc-mcp.search-hint: "screenshot, capture, audit log, metrics, performance, process monitor, diagnostics, debug, health check, observability"
+  dcc-mcp.tags: "diagnostics, observability, screenshot, audit, metrics, debug, infrastructure"
   dcc-mcp.tools: tools.yaml
 ---
 

--- a/python/dcc_mcp_core/skills/workflow/SKILL.md
+++ b/python/dcc_mcp_core/skills/workflow/SKILL.md
@@ -1,13 +1,18 @@
 ---
 name: workflow
-description: "Multi-step action orchestration — run a sequence of MCP tools in order, passing results between steps. Enables agents to chain complex operations (select → rename → validate → export) without custom code."
+description: >-
+  Infrastructure skill — multi-step action orchestration: run a sequence of MCP
+  tools in order, passing results between steps. Use when chaining two or more
+  tools into a repeatable pipeline (select → rename → validate → export). Not
+  for single-tool operations or DCC-specific business logic — use a domain skill
+  for those.
 license: MIT
 metadata:
-  category: workflow
   dcc-mcp.dcc: python
   dcc-mcp.version: "1.0.0"
-  dcc-mcp.search-hint: "chain, sequence, pipeline, multi-step, orchestration, workflow, batch, run steps"
-  dcc-mcp.tags: "workflow, orchestration, chain, pipeline, automation"
+  dcc-mcp.layer: infrastructure
+  dcc-mcp.search-hint: "chain, sequence, pipeline, multi-step, orchestration, workflow, batch, run steps, automate"
+  dcc-mcp.tags: "workflow, orchestration, chain, pipeline, automation, infrastructure"
   dcc-mcp.tools: tools.yaml
 ---
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -58,16 +58,106 @@ export DCC_MCP_SKILL_PATHS="/path/to/my-skills"
 | [`minimal`](templates/minimal/) | Simplest possible skill | 1 tool, 1 script, no groups |
 | [`dcc-specific`](templates/dcc-specific/) | DCC-bound skill (Maya, Blender, etc.) | `dcc:` field, `required_capabilities`, `next-tools` |
 | [`with-groups`](templates/with-groups/) | Progressive exposure via tool groups | `groups:` field, `default-active` toggle |
+| [`domain-skill`](templates/domain-skill/) | Business workflow skill with layering | `dcc-mcp.layer: domain`, negative routing, `depends:`, failure chains |
+
+## Skill Layering
+
+Every skill must belong to one of three layers. Set the layer in `metadata`:
+
+```yaml
+metadata:
+  dcc-mcp.layer: infrastructure   # low-level reusable primitive
+  # dcc-mcp.layer: domain         # business workflow, depends on infrastructure
+  # dcc-mcp.layer: example        # authoring reference, never used in production
+```
+
+### Layer definitions
+
+| Layer | Role | Examples |
+|-------|------|---------|
+| **infrastructure** | Low-level, DCC-agnostic primitives. No business context. Stable API. Auto-loaded or shared across all servers. | `dcc-diagnostics`, `workflow`, `usd-tools`, `ffmpeg-media`, `imagemagick-tools`, `git-automation` |
+| **domain** | Business workflows for a specific DCC or task area. Depends on infrastructure skills. Loaded on-demand per DCC. | `maya-geometry`, `maya-pipeline`, `maya-animation`, `blender-rigging` |
+| **example** | Authoring references and demos only. Never loaded in production environments. | `hello-world`, `multi-script`, `async-render-example`, `cancellable-loop` |
+
+### Description pattern (required for all skills)
+
+Every skill `description` must follow this 3-part structure (max 1024 chars total):
+
+```
+<Layer> skill — <one-sentence what + scope keywords>. Use when <trigger>.
+Not for <counter-example> — use <other-skill> for that.
+```
+
+**Infrastructure example:**
+```yaml
+description: >-
+  Infrastructure skill — low-level OpenUSD scene inspection and validation:
+  read layer stacks, traverse prims, validate schemas. Use when working
+  directly with raw USD files. Not for Maya-specific USD export — use
+  maya-pipeline__export_usd for that.
+```
+
+**Domain example:**
+```yaml
+description: >-
+  Domain skill — Maya geometry primitives: create spheres, cubes, cylinders;
+  bevel and extrude polygon components. Use for individual geometry operations
+  in Maya. Not for full asset export pipelines — use maya-pipeline for that.
+  Not for raw USD file inspection — use usd-tools for that.
+```
+
+**Example/demo:**
+```yaml
+description: >-
+  Example skill — demonstrates <feature>. Use as a reference when authoring
+  new skills. Not intended for production use.
+```
+
+### search-hint partitioning
+
+Keep `search-hint` keywords **non-overlapping** across layers so `search_skills()`
+returns the most relevant skill without ambiguity:
+
+- **Infrastructure**: mechanism-oriented — describe the underlying tool/API
+  (`"usd stage, prim, schema validation, usdcat"`)
+- **Domain**: intent-oriented — describe the user's goal
+  (`"export Maya scene to USD, asset pipeline, project setup"`)
+- **Example**: append `"authoring reference"` to prevent accidental production matches
+
+### next-tools failure chains
+
+Every domain skill tool **must** include `on-failure` pointing to infrastructure diagnostics:
+
+```yaml
+next-tools:
+  on-success: [next_logical_tool]
+  on-failure: [dcc_diagnostics__screenshot, dcc_diagnostics__audit_log]
+```
+
+Infrastructure skills do not require `on-failure` chains (they ARE the fallback).
+
+### depends declaration
+
+Domain skills **must** declare `depends:` for every infrastructure skill they chain to via
+`next-tools.on-failure`. This ensures the infrastructure skill is loaded before the domain
+skill is activated:
+
+```yaml
+depends:
+  - dcc-diagnostics   # required for on-failure chains
+  - usd-tools         # required if any tool exports/validates USD
+```
 
 ## Skill Anatomy
 
 ```
 my-skill/
-  SKILL.md          # Frontmatter (name, dcc, tags, tools) + body docs
+  SKILL.md          # Frontmatter (name, dcc, metadata, tools) + body docs
   scripts/           # One file per tool (*.py, *.sh, *.bat, *.js, *.ts)
     tool_a.py
     tool_b.sh
-  metadata/          # Optional: help.md, install.md, depends.md
+  references/        # Optional: per-topic knowledge loaded on demand
+    guide.md
 ```
 
 ### SKILL.md Frontmatter Fields
@@ -76,37 +166,44 @@ my-skill/
 |-------|----------|-------------|
 | `name` | Yes | Unique skill identifier (kebab-case, max 64 chars) |
 | `description` | Yes | What the skill does AND when to use it (shown to AI agents, max 1024 chars). Include specific keywords for discoverability. |
-| `dcc` | No | Target DCC (`maya`, `blender`, `python`, etc.) |
-| `version` | No | Semantic version (default `1.0.0`) |
-| `tags` | No | Discovery tags (`[modeling, geometry, maya]`) |
-| `search-hint` | No | Extra keywords for `search_skills()` matching |
 | `license` | No | License identifier (agentskills.io spec, e.g. `MIT`, `Apache-2.0`) |
 | `compatibility` | No | Environment requirements, max 500 chars (agentskills.io spec, e.g. `"Maya 2024+, Python 3.7+"`) |
 | `allowed-tools` | No | Pre-approved tools, space-separated (agentskills.io spec, **experimental**, e.g. `Bash(git:*) Read`) |
 | `depends` | No | List of skill names this skill requires |
-| `groups` | No | Tool groups for progressive exposure |
-| `tools` | No | Explicit tool declarations with schemas |
-| `metadata` | No | Arbitrary key-value metadata (agentskills.io spec) |
-| `external_deps` | No | External dependency declaration (MCP servers, env vars, binaries) as YAML mapping |
+| `metadata` | No | Namespaced key-value metadata (agentskills.io spec). Use `dcc-mcp.*` keys for dcc-mcp-core extensions. |
+| `metadata.dcc-mcp.dcc` | No | Target DCC (`maya`, `blender`, `python`, etc.) |
+| `metadata.dcc-mcp.version` | No | Semantic version (default `1.0.0`) |
+| `metadata.dcc-mcp.layer` | **Yes** | Skill layer: `infrastructure`, `domain`, or `example` |
+| `metadata.dcc-mcp.search-hint` | No | Extra keywords for `search_skills()` matching |
+| `metadata.dcc-mcp.tags` | No | Comma-separated discovery tags |
+| `metadata.dcc-mcp.tools` | No | Sibling file path for tool declarations (e.g. `tools.yaml`) |
 
 ### Description Quality Guide
 
-The `description` field is the **most important field for AI agent discoverability**. It determines whether an agent will find and use your skill via `search_skills()`.
+The `description` field is the **most important field for AI agent discoverability**. It
+determines whether an agent will find and use your skill via `search_skills()`.
 
-**Good descriptions** tell AI agents **what** the skill does and **when to use it**:
+**Good descriptions** tell AI agents **what**, **when to use**, and **when NOT to use**:
 ```yaml
-# ✓ Good — specific keywords + use-case trigger
-description: "Creates and modifies polygon geometry in Maya. Use when user asks to create spheres, cubes, bevel edges, or extrude faces."
-# ✓ Good — clear scope + trigger phrases
-description: "Extracts text and tables from PDF files, fills PDF forms, and merges multiple PDFs. Use when working with PDF documents."
+# ✓ Infrastructure — mechanism + negative routing
+description: >-
+  Infrastructure skill — raw USD file inspection via usdcat/usdchecker.
+  Use when validating or reading a .usd file directly. Not for Maya USD
+  export — use maya-pipeline__export_usd for that.
+
+# ✓ Domain — intent + explicit scope + counter-examples
+description: >-
+  Domain skill — Maya polygon geometry: create, bevel, extrude. Use when
+  the user asks to build or modify 3D meshes in Maya. Not for export
+  pipelines — use maya-pipeline for that.
 ```
 
-**Bad descriptions** are vague and lack discoverability:
+**Bad descriptions** are vague, lack layer prefix, or have no counter-examples:
 ```yaml
-# ✗ Bad — too vague, no keywords, no use-case
+# ✗ Bad — no layer, no trigger, no counter-examples
 description: "Helps with geometry."
-# ✗ Bad — no trigger phrase for when to use
-description: "PDF processing utilities."
+# ✗ Bad — no when-to-use, no negative routing
+description: "USD processing utilities."
 ```
 
 ### Progressive Disclosure
@@ -133,13 +230,13 @@ tools:
     group: basic                 # Tool group name (if using groups)
     next-tools:                  # dcc-mcp-core extension: follow-up tools
       on-success: [other_skill__tool]
-      on-failure: [dcc_diagnostics__screenshot]
+      on-failure: [dcc_diagnostics__screenshot, dcc_diagnostics__audit_log]
 ```
 
 **`next-tools`** is a dcc-mcp-core extension (not in agentskills.io spec). It guides AI agents
 to chain tool calls:
 - `on-success`: suggested tools after successful execution
-- `on-failure`: debugging/recovery tools on failure
+- `on-failure`: debugging/recovery tools on failure — **always point to `dcc_diagnostics__*`**
 - Both accept lists of fully-qualified tool names (`skill_name__tool_name` format)
 
 ## Existing Examples
@@ -147,24 +244,27 @@ to chain tool calls:
 See [`examples-index.md`](examples-index.md) for a full index of the 11 example
 skills shipped in `examples/skills/`, or browse them directly:
 
-| Skill | DCC | Category | Key Feature |
-|-------|-----|----------|-------------|
-| [hello-world](../examples/skills/hello-world/) | python | example | Minimal starter |
-| [maya-geometry](../examples/skills/maya-geometry/) | maya | modeling | Tool groups |
-| [maya-pipeline](../examples/skills/maya-pipeline/) | maya | pipeline | Dependencies + metadata/ |
-| [git-automation](../examples/skills/git-automation/) | python | devops | OpenClaw format |
-| [ffmpeg-media](../examples/skills/ffmpeg-media/) | python | media | External binary deps |
-| [imagemagick-tools](../examples/skills/imagemagick-tools/) | python | image | OpenClaw install |
-| [usd-tools](../examples/skills/usd-tools/) | python | pipeline | Read-only tools |
-| [multi-script](../examples/skills/multi-script/) | python | example | .py + .sh + .bat |
-| [clawhub-compat](../examples/skills/clawhub-compat/) | python | example | Full OpenClaw |
-| [dcc-diagnostics](../examples/skills/dcc-diagnostics/) | python | diagnostics | Also bundled |
-| [workflow](../examples/skills/workflow/) | python | workflow | Also bundled |
+| Skill | Layer | DCC | Key Feature |
+|-------|-------|-----|-------------|
+| [hello-world](../examples/skills/hello-world/) | example | python | Minimal starter |
+| [multi-script](../examples/skills/multi-script/) | example | python | .py + .sh + .bat |
+| [async-render-example](../examples/skills/async-render-example/) | example | python | Async/deferred tools |
+| [cancellable-loop](../examples/skills/cancellable-loop/) | example | python | Cooperative cancellation |
+| [clawhub-compat](../examples/skills/clawhub-compat/) | example | python | Full OpenClaw format |
+| [dcc-diagnostics](../examples/skills/dcc-diagnostics/) | infrastructure | python | Also bundled |
+| [workflow](../examples/skills/workflow/) | infrastructure | python | Also bundled |
+| [usd-tools](../examples/skills/usd-tools/) | infrastructure | python | Read-only USD tools |
+| [ffmpeg-media](../examples/skills/ffmpeg-media/) | infrastructure | python | External binary deps |
+| [imagemagick-tools](../examples/skills/imagemagick-tools/) | infrastructure | python | OpenClaw install |
+| [git-automation](../examples/skills/git-automation/) | infrastructure | python | OpenClaw format |
+| [maya-geometry](../examples/skills/maya-geometry/) | domain | maya | Tool groups |
+| [maya-pipeline](../examples/skills/maya-pipeline/) | domain | maya | Dependencies + metadata/ |
 
 ## Bundled Skills
 
 Two skills ship inside the `dcc-mcp-core` wheel and are available immediately
-after `pip install dcc-mcp-core` (no `DCC_MCP_SKILL_PATHS` needed):
+after `pip install dcc-mcp-core` (no `DCC_MCP_SKILL_PATHS` needed).
+Both are **infrastructure** skills:
 
 - **dcc-diagnostics** — screenshot, audit_log, tool_metrics, process_status
 - **workflow** — run_chain (multi-step orchestration)

--- a/skills/templates/domain-skill/SKILL.md
+++ b/skills/templates/domain-skill/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: my-domain-skill
+description: >-
+  Domain skill — <one-sentence what this skill does and its scope keywords>.
+  Use when <trigger phrase — user intent or task keywords>.
+  Not for <counter-example A> — use <infrastructure-or-other-skill> for that.
+  Not for <counter-example B> — use <other-skill> for that.
+license: MIT
+compatibility: <DCC> <version>+, Python 3.7+
+metadata:
+  dcc-mcp.dcc: maya
+  dcc-mcp.version: "1.0.0"
+  dcc-mcp.layer: domain
+  # Intent-oriented keywords — describe the user's goal, not the mechanism.
+  # Do NOT duplicate keywords that belong to an infrastructure skill
+  # (e.g. "usd stage", "ffmpeg", "git commit").
+  dcc-mcp.search-hint: "intent keyword 1, intent keyword 2, task phrase 3"
+  dcc-mcp.tags: "maya, your-category, domain"
+# Declare infrastructure skills this domain skill depends on.
+# Load them before loading this skill.
+depends:
+  - dcc-diagnostics   # always required for on-failure chains
+  # - usd-tools       # uncomment if tools export USD
+tools:
+  - name: primary_action
+    description: >-
+      <What this tool does in one sentence>. <When to call it>.
+      Returns <what the output looks like>.
+    input_schema:
+      type: object
+      required: [required_param]
+      properties:
+        required_param:
+          type: string
+          description: "<≤100 chars description>"
+        optional_param:
+          type: number
+          description: "<≤100 chars description>"
+          default: 1.0
+    read_only: false
+    destructive: false
+    idempotent: false
+    source_file: scripts/primary_action.py
+    next-tools:
+      # Point to the next logical step on success.
+      on-success: []
+      # Always point to diagnostics on failure so the agent can recover.
+      on-failure: [dcc_diagnostics__screenshot, dcc_diagnostics__audit_log]
+
+  - name: read_only_query
+    description: >-
+      <What this tool queries>. Returns <structured output>.
+      Safe to call without side effects.
+    input_schema:
+      type: object
+      properties:
+        filter:
+          type: string
+          description: "Optional filter string"
+    read_only: true
+    idempotent: true
+    source_file: scripts/read_only_query.py
+    next-tools:
+      on-success: [my_domain_skill__primary_action]
+      on-failure: [dcc_diagnostics__audit_log]
+---
+
+# my-domain-skill
+
+> **Layer**: Domain — depends on `dcc-diagnostics` (infrastructure).
+
+Replace this body with documentation about your domain skill.
+Keep it under 500 lines / 5000 tokens.
+
+## When to Use This Skill
+
+- <Trigger scenario 1 — specific user intent or task>
+- <Trigger scenario 2>
+
+## When NOT to Use This Skill
+
+- **<Counter-example A>** → use `<other-skill>` instead
+- **<Counter-example B>** → use `<other-skill>` instead
+
+## Tools
+
+### `my_domain_skill__primary_action`
+
+<Describe what the tool does, its inputs, and expected output.>
+
+### `my_domain_skill__read_only_query`
+
+<Describe what the tool queries and the shape of its output.>
+
+## Prerequisites
+
+- <DCC> <version> or later
+- `dcc-diagnostics` skill loaded (for failure recovery chains)
+
+## Failure Recovery
+
+All tools chain to `dcc_diagnostics__screenshot` and
+`dcc_diagnostics__audit_log` on failure via `next-tools.on-failure`.

--- a/skills/templates/domain-skill/scripts/primary_action.py
+++ b/skills/templates/domain-skill/scripts/primary_action.py
@@ -1,0 +1,38 @@
+"""primary_action — replace with your domain skill logic.
+
+This script is the entry point for the `primary_action` tool declared in SKILL.md.
+The dispatcher calls `main(**kwargs)` and captures the return value as the tool result.
+"""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+from dcc_mcp_core.skill import skill_error
+from dcc_mcp_core.skill import skill_success
+
+
+@skill_entry
+def primary_action(required_param: str = "", optional_param: float = 1.0, **kwargs) -> dict:
+    """Execute the primary domain action.
+
+    Replace this implementation with your actual DCC logic.
+    Import DCC-specific modules (maya.cmds, bpy, hou, etc.) inside the
+    function body so the skill loads in non-DCC environments too.
+    """
+    if not required_param:
+        return skill_error("required_param is missing", "Provide a non-empty required_param value.")
+
+    # ---- your DCC logic here ----
+    # try:
+    #     import maya.cmds as cmds
+    #     result = cmds.something(required_param)
+    # except ImportError:
+    #     return skill_error("DCC not available", "This tool requires Maya.")
+
+    return skill_success(
+        f"primary_action completed for {required_param!r}",
+        # Extra kwargs become the tool's context output and are available
+        # to downstream tools via next-tools chaining.
+        required_param=required_param,
+        optional_param=optional_param,
+    )

--- a/skills/templates/domain-skill/scripts/read_only_query.py
+++ b/skills/templates/domain-skill/scripts/read_only_query.py
@@ -1,0 +1,32 @@
+"""read_only_query — replace with your domain skill query logic.
+
+Read-only tools should never modify DCC state.
+Mark them with read_only: true and idempotent: true in SKILL.md.
+"""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+from dcc_mcp_core.skill import skill_success
+
+
+@skill_entry
+def read_only_query(filter: str = "", **kwargs) -> dict:
+    """Query DCC state without modifying it.
+
+    Replace this implementation with your actual read-only query.
+    """
+    # ---- your DCC query here ----
+    # try:
+    #     import maya.cmds as cmds
+    #     items = cmds.ls(filter or "*", type="transform")
+    # except ImportError:
+    #     return skill_error("DCC not available", "This tool requires Maya.")
+
+    items: list = []  # replace with actual query result
+
+    return skill_success(
+        f"Query returned {len(items)} items",
+        items=items,
+        filter=filter,
+    )


### PR DESCRIPTION
## Summary

- Introduce a three-layer skill taxonomy (`infrastructure` / `domain` / `example`) via the `metadata.dcc-mcp.layer` tag
- Rewrite all skill `description` fields with a layer prefix and explicit "Not for X — use Y" negative routing sentences, eliminating AI agent routing ambiguity as the skill catalog grows
- Partition `search-hint` keywords by layer (mechanism-oriented for infrastructure, intent-oriented for domain) so `search_skills()` returns unambiguous results
- Add new `skills/templates/domain-skill/` template for downstream adapter authors
- Document the full layering convention in `skills/README.md`, `docs/guide/skills.md`, and `AGENTS.md`

## Changed files

| File | What changed |
|------|-------------|
| `python/dcc_mcp_core/skills/dcc-diagnostics/SKILL.md` | Layer tag + negative routing in description |
| `python/dcc_mcp_core/skills/workflow/SKILL.md` | Layer tag + negative routing in description |
| `examples/skills/*/SKILL.md` (11 files) | Layer tags, description rewrite, metadata migration to `dcc-mcp.*` namespace |
| `skills/templates/domain-skill/` (new) | Ready-to-copy template: SKILL.md + primary_action.py + read_only_query.py |
| `skills/README.md` | New "Skill Layering" section: definitions, description pattern, search-hint rules, failure chain wiring, depends declaration |
| `docs/guide/skills.md` | New "Layered Skill Architecture" chapter: why layers, checklist for new domain skills |
| `AGENTS.md` | Do/Don't rules + decision-tree entry for skill layer selection |

## Downstream impact

Adapter repos (`dcc-mcp-maya`, `dcc-mcp-blender`, …) should follow the pattern documented in this PR:

- All skills need `metadata.dcc-mcp.layer` tagged
- All skill descriptions need layer prefix + negative routing sentence
- Domain skill tools need `on-failure: [dcc_diagnostics__screenshot, dcc_diagnostics__audit_log]`

Tracked in: https://github.com/loonghao/dcc-mcp-maya/issues/100

## Test plan

- [ ] `search_skills("geometry")` returns `maya-geometry` (domain), not `usd-tools` or `dcc-diagnostics`
- [ ] `search_skills(tags=["infrastructure"])` returns only infrastructure-layer skills
- [ ] `search_skills(tags=["domain"], dcc="maya")` returns only Maya domain skills
- [ ] All updated SKILL.md files pass `validate_skill()` (no spec violations)
- [ ] `domain-skill` template loads cleanly: `scan_and_load_lenient()` returns it without errors
