### PR TITLE
docs: update outdated workflow docs and translate Chinese placeholders

### DIFF
--- a/docs/api/workflow.md
+++ b/docs/api/workflow.md
@@ -1,18 +1,16 @@
-# Workflow API (skeleton)
+# Workflow API
 
-> **Status — skeleton.** The types, YAML parser, validator, catalog glob
-> reader and the four `workflows.*` built-in MCP tools ship here. **Step
-> execution is intentionally deferred to a follow-up PR** — the three
-> execution-facing tools return a stable `"step execution pending follow-up
-> PR"` error so downstream callers (#349 / #351 / #353 / #354) can build
-> against final type signatures in parallel. See
-> [issue #348](https://github.com/loonghao/dcc-mcp-core/issues/348).
+> **Status**: fully implemented (issue #348). Spec-driven pipeline engine
+> with six step kinds, step-level policies, artefact hand-off,
+> cancellation cascade, and SQLite persistence.
+>
+> For the conceptual guide see [`docs/guide/workflows.md`](../guide/workflows.md).
 
 ## Crate layout
 
-- **`dcc-mcp-workflow`** (new) — all workflow types, catalog, DDL, tool
-  registrations. Feature-gated at the workspace level behind the top-level
-  `workflow` feature (off by default for one release).
+- **`dcc-mcp-workflow`** — all workflow types, catalog, DDL, tool
+  registrations, and the `WorkflowExecutor` engine. Feature-gated at the
+  workspace level behind the top-level `workflow` feature (off by default).
 - **`dcc-mcp-http`** — `McpHttpConfig::enable_workflows` gates registration
   of the built-in tools on `start()`.
 
@@ -23,7 +21,9 @@ use dcc_mcp_workflow::{
     WorkflowSpec, WorkflowStatus, WorkflowJob, WorkflowProgress,
     Step, StepKind, StepId, WorkflowId,
     WorkflowCatalog, WorkflowSummary,
-    register_builtin_workflow_tools,
+    WorkflowExecutor, WorkflowHost, WorkflowRunHandle,
+    register_builtin_workflow_tools, register_workflow_handlers,
+    WorkflowError,
 };
 ```
 
@@ -44,24 +44,80 @@ Validation checks:
 - Every `tool` / `tool_remote` name passes `dcc_mcp_naming::validate_tool_name`.
 - Every `branch.on` and `foreach.items` expression parses under
   `jsonpath-rust 1.x`.
+- Step policies are well-formed (`max_attempts >= 1`,
+  `initial_delay_ms <= max_delay_ms`, `timeout_secs > 0`, etc.).
 
-### `WorkflowJob` (placeholder)
+### `WorkflowExecutor`
+
+```rust
+let handle = WorkflowExecutor::run(spec, inputs, parent_job_id)?;
+```
+
+Execution pipeline:
+
+```text
+WorkflowExecutor::run(spec, inputs, parent)
+   │
+   ├─ validates spec
+   ├─ creates root job + CancellationToken
+   ├─ spawns driver task
+   │     │
+   │     ├─ drive(steps) ── sequential
+   │     │     └─ for each step:
+   │     │           ├─ policy: retry + timeout + idempotency
+   │     │           ├─ dispatch by StepKind
+   │     │           │     ├─ Tool      → ToolCaller::call
+   │     │           │     ├─ ToolRemote→ RemoteCaller::call
+   │     │           │     ├─ Foreach   → drive(body) per item
+   │     │           │     ├─ Parallel  → tokio::join! branches
+   │     │           │     ├─ Approve   → ApprovalGate::wait_handle
+   │     │           │     └─ Branch    → JSONPath → then|else
+   │     │           ├─ artefact handoff (FileRef → ArtefactStore)
+   │     │           ├─ SSE: $/dcc.workflowUpdated enter / exit
+   │     │           └─ sqlite upsert (if feature enabled)
+   │     └─ emit workflow_terminal
+   └─ returns WorkflowRunHandle { workflow_id, root_job_id, cancel_token, join }
+```
+
+### Step kinds
+
+| Kind | Driver | Key policy knobs |
+|------|--------|------------------|
+| `tool` | `ToolCaller::call(name, args)` | timeout, retry, idempotency_key |
+| `tool_remote` | `RemoteCaller::call(dcc, name, args)` | same |
+| `foreach` | JSONPath → body per item, concurrency >= 1 | per-body policy inherited |
+| `parallel` | `tokio::join!` over branches | `on_any_fail: abort \| continue` |
+| `approve` | `ApprovalGate::wait_handle` + timeout | timeout_secs |
+| `branch` | JSONPath condition → `then` or `else` | n/a |
+
+### Cancellation cascade
+
+The root `CancellationToken` is handed to every step driver and every
+caller. On `cancel`:
+
+1. No new steps start.
+2. In-flight `ToolCaller` / `RemoteCaller` receive the token and should
+   honour it cooperatively.
+3. Sleeps (retry backoff, `Approve` timeout) are aborted via
+   `tokio::select!`.
+4. Workflow status becomes `cancelled`; a final `$/dcc.workflowUpdated`
+   fires.
+
+Round-trip from `WorkflowHost::cancel` → every in-flight step observing
+the token is bounded by one cooperative checkpoint (typically < 200 ms).
+
+### `WorkflowJob`
 
 ```rust
 let mut job = WorkflowJob::pending(spec);
-assert!(matches!(job.start(), Err(WorkflowError::NotImplemented(_))));
+job.start()?;   // begins execution via WorkflowExecutor
 ```
-
-The signature is final so #349 / #353 can build against it; the body is
-deliberately a no-op until the execution PR.
 
 ### `WorkflowCatalog`
 
 Reads `SkillMetadata.metadata["dcc-mcp.workflows"]` as a glob (or
 comma-separated list of globs) resolved relative to the skill root.
-Parses only the YAML **header** (`name`, `description`, `inputs`) per file
-into a `WorkflowSummary`. Full-body parse is deferred — marked
-`TODO(#348-full)` in the source.
+Parses the full YAML body into a `WorkflowSummary`.
 
 ```rust
 use dcc_mcp_workflow::WorkflowCatalog;
@@ -76,48 +132,135 @@ The metadata key (`dcc-mcp.workflows`) is namespaced under `dcc-mcp.*`
 per the amendment on issue #348 — it deliberately does **not** introduce a
 new top-level SKILL.md field, so `skills-ref validate` stays green.
 
+## Step policies (issue #353)
+
+Every step may declare an optional `policy` block. All fields are optional;
+omitting the block yields a default `StepPolicy` (no timeout, no retry, no
+idempotency key).
+
+```yaml
+steps:
+  - id: export_fbx
+    tool: maya_animation__export_fbx
+    args: { scene: "{{inputs.scene_id}}" }
+    timeout_secs: 300
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      initial_delay_ms: 500
+      max_delay_ms: 10000
+      jitter: 0.25
+      retry_on: ["transient", "timeout"]
+    idempotency_key: "export_{{scene_id}}_{{frame_range}}"
+    idempotency_scope: workflow
+```
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `timeout_secs` | `u64 > 0` | none | Per-attempt wall-clock deadline. |
+| `retry.max_attempts` | `u32 >= 1` | required if retry present | `1` = no retry. |
+| `retry.backoff` | enum | `exponential` | `fixed` / `linear` / `exponential`. |
+| `retry.initial_delay_ms` | `u64` | `500` | `<= max_delay_ms`. |
+| `retry.max_delay_ms` | `u64` | `10_000` | Upper clamp after shape + jitter. |
+| `retry.jitter` | `f32` | `0.0` | Clamped to `[0.0, 1.0]`. |
+| `retry.retry_on` | `[String]` | all errors | Error-kind allowlist. |
+| `idempotency_key` | string | none | Mustache template rendered before execution. |
+| `idempotency_scope` | enum | `workflow` | `workflow` or `global`. |
+
+Backoff formula: `min(base(attempt), max_delay) * (1 + rand(-jitter, +jitter))`
+where `base` is `initial_delay` (fixed), `initial_delay * (n-1)` (linear),
+or `initial_delay * 2^(n-2)` (exponential).
+
+Attempt numbering is 1-indexed: `attempt_number == 1` is the initial run
+(no pre-delay); `attempt_number == 2` is the first retry.
+
+Cancellation of the enclosing workflow **interrupts the sleep** — retries
+never outlive a `workflows.cancel` call. Each attempt is recorded as a
+separate child job under the workflow's root job (parent-job id from
+issue #318).
+
 ## Built-in MCP tools
 
-`register_builtin_workflow_tools(&registry)` inserts four entries:
+Registered by `register_builtin_workflow_tools(&registry)`. Functional
+handlers are bound by `register_workflow_handlers(&dispatcher, &host)`.
 
-| Tool                      | Status     | Behaviour                                              |
-|---------------------------|------------|--------------------------------------------------------|
-| `workflows.run`           | stub       | Validates the spec; returns `"step execution pending"` |
-| `workflows.get_status`    | stub       | Returns `"step execution pending"`                     |
-| `workflows.cancel`        | stub       | Returns `"step execution pending"`                     |
-| `workflows.lookup`        | functional | Read-only catalog search                               |
+| Tool | Description | ToolAnnotations |
+|------|-------------|-----------------|
+| `workflows.run` | Start a run (YAML or JSON spec + inputs). | `destructive_hint=true, open_world_hint=true` |
+| `workflows.get_status` | Poll terminal status + progress. | `read_only_hint=true, idempotent_hint=true` |
+| `workflows.cancel` | Cancel a run by `workflow_id` (cascade). | `destructive_hint=true, idempotent_hint=true` |
+| `workflows.lookup` | Catalog search (read-only). | `read_only_hint=true` |
 
-All four names pass `dcc_mcp_naming::validate_tool_name` (SEP-986).
-
-## Python surface (skeleton)
-
-Only `WorkflowSpec` and `WorkflowStatus` are Python-visible. Build the
-wheel with the `workflow` feature to get them:
+## Python surface
 
 ```python
-from dcc_mcp_core import WorkflowSpec, WorkflowStatus
+from dcc_mcp_core import (
+    WorkflowSpec, WorkflowStep, StepPolicy,
+    RetryPolicy, BackoffKind, WorkflowStatus,
+)
 
 spec = WorkflowSpec.from_yaml_str(yaml_source)
 spec.validate()            # raises ValueError on failure
-print(spec.name, spec.step_count)
 
-s = WorkflowStatus("running")
-assert not s.is_terminal
+step: WorkflowStep = spec.steps[0]
+policy: StepPolicy = step.policy
+retry: RetryPolicy = policy.retry
+assert retry.next_delay_ms(2) == 500       # first retry delay (unjittered)
 ```
 
-If the wheel was built without the `workflow` feature, both symbols
-import as `None` from `dcc_mcp_core`.
+All policy classes are **frozen** — Python cannot mutate a parsed spec.
+To run workflows, call the MCP tools (`workflows.run` /
+`workflows.get_status` / `workflows.cancel`) from the MCP client side —
+they are registered on any skill server that calls
+`register_builtin_workflow_tools` plus `register_workflow_handlers`.
 
-## Persistence DDL (`job-persist-sqlite` feature)
+## Approval gating
 
-`dcc_mcp_workflow::sqlite::apply_migrations(&conn)` creates two tables:
+```yaml
+steps:
+  - id: human_gate
+    kind: approve
+    prompt: "Proceed with vendor drop?"
+    timeout_secs: 300
+```
 
-- `workflows(id TEXT PK, name, status, spec_json, current_step_id, started_at, completed_at, created_at)`
-- `workflow_steps(workflow_id FK, step_id, status, result_json, started_at, completed_at, PRIMARY KEY(workflow_id, step_id))`
+The executor pauses the workflow and emits a `$/dcc.workflowUpdated`
+with `detail.kind == "approve_requested"` and the prompt. The MCP
+server bridges inbound `notifications/$/dcc.approveResponse` messages
+into `ApprovalGate::resolve`. On timeout the gate resolves with
+`approved=false, reason="timeout"` and the step fails.
 
-No writer is wired in this skeleton — the tables exist but nothing
-populates them. The execution PR will wire `WorkflowJob` progression into
-these tables for crash recovery (see `WorkflowStatus::Interrupted`).
+## Artefact hand-off (issue #349)
+
+A tool whose output contains a `file_refs` array is automatically
+captured via `ArtefactStore::put`; the resulting `FileRef` URIs appear
+in the downstream step context as
+<code v-pre>`{{steps.<id>.file_refs[<i>].uri}}`</code>. The raw JSON output is still
+accessible via <code v-pre>`{{steps.<id>.output.*}}`</code>.
+
+## Persistence (#328)
+
+With the `job-persist-sqlite` feature flag, each workflow run writes to
+two tables:
+
+- `workflows(workflow_id, root_job_id, spec_json, inputs_json, status,
+  current_step_id, step_outputs_json, created_at, completed_at)`
+- `workflow_steps(workflow_id, step_id, status, attempt, result_json,
+  updated_at)` — one row per step per transition.
+
+On startup, `WorkflowExecutor::recover_persisted()` flips every
+non-terminal row to `interrupted` and emits a final
+`$/dcc.workflowUpdated`. Runs are **not** auto-resumed —
+`interrupted` is terminal; clients may implement a resume tool on top
+if desired.
+
+## HTTP server gate
+
+```python
+from dcc_mcp_core import McpHttpConfig
+cfg = McpHttpConfig(port=8765)
+cfg.enable_workflows = True     # default False
+```
 
 ## Discovery model
 

--- a/docs/zh/api/observability.md
+++ b/docs/zh/api/observability.md
@@ -1,3 +1,149 @@
-# observability
+# 可观测性 — Prometheus `/metrics` 导出器 (issue #331)
 
-> 中文翻译尚未完成。请参阅 [英文文档](/api/observability)。
+`dcc-mcp-core` 提供了一个**可选的** Prometheus text-exposition 导出器，
+构建在 [`dcc-mcp-telemetry`](../guide/telemetry.md) 之上。启用时，
+它在服务 `/mcp` 的同一个 Axum 路由器上挂载 `GET /metrics` 端点，
+因此单个 TLS 终止器 / ingress 规则即可覆盖两者。
+
+> **Feature-gated。** 导出器位于 `prometheus` Cargo feature 之后，
+> **默认关闭**。未编译时，零 Prometheus 代码进入 wheel — 匹配
+> `pyproject.toml` 中的零运行时成本约定。
+
+## 在 wheel 构建中启用
+
+```bash
+# 从仓库根目录
+maturin develop --features python-bindings,ext-module,workflow,prometheus
+```
+
+从 Rust 调用点：
+
+```toml
+# Cargo.toml
+[dependencies]
+dcc-mcp-http = { path = "...", features = ["prometheus"] }
+```
+
+## 运行时启用
+
+```python
+from dcc_mcp_core import McpHttpConfig, McpHttpServer, ToolRegistry
+
+cfg = McpHttpConfig(
+    port=8765,
+    server_name="maya-mcp",
+    enable_prometheus=True,
+    # 可选 HTTP Basic auth 守卫 — 强烈建议用于任何超出可信 localhost 的部署。
+    prometheus_basic_auth=("scraper", "change-me"),
+)
+
+server = McpHttpServer(ToolRegistry(), cfg)
+handle = server.start()
+# Scrape: GET http://127.0.0.1:8765/metrics
+```
+
+如果 wheel **没有**使用 `prometheus` 构建，两个标志仍会被接受以保持
+向前兼容，但 `GET /metrics` 返回 404。
+
+## 指标面
+
+| 指标 | 类型 | 标签 | 说明 |
+|------|------|------|------|
+| `dcc_mcp_tool_calls_total` | counter | `tool`, `status` (`success`/`error`) | 服务器观察到的工具调用。 |
+| `dcc_mcp_tool_duration_seconds` | histogram | `tool` | 从分派到完成的 wall-clock 耗时。 |
+| `dcc_mcp_jobs_in_flight` | gauge | `tool` | 当前执行的长时间运行作业 (issue #316)。 |
+| `dcc_mcp_job_created_total` | counter | `tool`, `result` | 曾创建的作业 — `result` ∈ {`accepted`, `queue_full`, ...}。 |
+| `dcc_mcp_job_wait_seconds` | histogram | `tool` | 作业创建到首次执行之间的延迟。 |
+| `dcc_mcp_notifications_sent_total` | counter | `channel` (`sse`, `ws`) | 推送到客户端的 MCP 通知 (issue #326)。 |
+| `dcc_mcp_active_sessions` | gauge | — | 活跃的 MCP Streamable HTTP 会话。 |
+| `dcc_mcp_registered_tools` | gauge | — | 当前在 `ActionRegistry` 中注册的工具。 |
+| `dcc_mcp_build_info` | gauge | `version`, `crate` | 始终为 `1`；标签标识运行中的二进制文件。 |
+
+Histogram 使用适合 DCC 工具调用的对数阶梯 bucket（1 ms → 30 s）。
+导出器在启动时发布单个 `dcc_mcp_build_info` 序列，以便 scraper
+始终看到非空 payload。
+
+## Basic auth
+
+当设置了 `prometheus_basic_auth=(user, pass)` 时，端点对任何没有
+匹配凭证的请求回复 `401 Unauthorized` 和
+`WWW-Authenticate: Basic realm="dcc-mcp metrics"` 头。
+比较使用短常数时间字节检查以防止简单定时攻击。
+
+```bash
+curl -u scraper:change-me http://127.0.0.1:8765/metrics
+```
+
+未配置凭证时，端点是**开放的** — 对仅 localhost 的开发可以接受，
+但绝不建议用于生产环境。
+
+## Prometheus scrape 配置
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: dcc-mcp
+    scrape_interval: 15s
+    static_configs:
+      - targets: ["maya-host:8765", "blender-host:8765"]
+    metrics_path: /metrics
+    basic_auth:
+      username: scraper
+      password_file: /etc/prometheus/dcc-mcp.pass
+```
+
+## Grafana — 示例查询
+
+工具级成功率（直接可用的 PromQL）：
+
+```promql
+sum by (tool) (rate(dcc_mcp_tool_calls_total{status="success"}[5m]))
+  /
+sum by (tool) (rate(dcc_mcp_tool_calls_total[5m]))
+```
+
+P95 工具延迟：
+
+```promql
+histogram_quantile(
+  0.95,
+  sum by (le, tool) (rate(dcc_mcp_tool_duration_seconds_bucket[5m]))
+)
+```
+
+每 DCC 主机的活跃会话：
+
+```promql
+dcc_mcp_active_sessions
+```
+
+本 PR 故意**不**随附 Grafana Dashboard JSON — 一旦 2026 可观测性
+路线图确定，我们将提供一个参考 dashboard。在此之前，
+以上查询是稳定的。
+
+## 设计说明
+
+- **每服务器一个注册表。** 同一进程中的多个 `McpHttpServer` 实例
+ （gateway + 每个 DCC）获得独立的注册表，因此标签不会冲突。
+ 导出器不使用 `prometheus::default_registry()`。
+- **关闭时零成本。** 每个记录点都被 `AppState::prometheus` 上的廉价
+  `Option::is_some` 检查守卫。禁用 Cargo feature 时，字段及其
+  使用会被完全编译掉。
+- **单一记录点。** 工具调用计数器仅从 `handler.rs` 中的 `tools/call`
+ 包装器推进；`handle_call_action` 通过内部变体递归以避免重复计数。
+- **后台 gauge 更新器。** 一个 5 秒 ticker 刷新 `active_sessions` 和
+  `registered_tools`，因此 scrape 不需要重建计数。
+
+## 非目标
+
+- OpenTelemetry OTLP tracing — 单独覆盖，参见 [`docs/guide/telemetry.md`](../guide/telemetry.md) 的 OTLP 部分。
+- 告警规则和 Grafana dashboard JSON — 推迟。
+- Prometheus push-gateway 支持 — 无计划。
+
+## 相关
+
+- 源码: `crates/dcc-mcp-telemetry/src/prometheus.rs`,
+  `crates/dcc-mcp-http/src/metrics.rs`。
+- 测试: `crates/dcc-mcp-http/tests/prometheus_endpoint.rs`,
+  `tests/test_prometheus.py`。
+- Issue: [#331](https://github.com/loonghao/dcc-mcp-core/issues/331)。

--- a/docs/zh/api/resources.md
+++ b/docs/zh/api/resources.md
@@ -1,3 +1,213 @@
-# resources
+# Resources API
 
-> 中文翻译尚未完成。请参阅 [英文文档](/api/resources)。
+`dcc_mcp_core` — 用于实时 DCC 状态的 MCP Resources 原语。
+
+## 概述
+
+Resources 原语使 MCP 客户端（LLM 和主机）能够通过用于工具的
+相同 HTTP 端点读取**实时 DCC 状态**。它实现了
+[MCP 2025-03-26](https://modelcontextprotocol.io/specification/2025-03-26)
+`resources` 能力：
+
+- `resources/list` — 枚举可用 URI
+- `resources/read` — 通过 URI 获取内容（文本或 base64 blob）
+- `resources/subscribe` / `resources/unsubscribe` — 选择加入推送通知
+- `notifications/resources/updated` — 当订阅的 URI 更改时通过 SSE 服务器推送
+
+Resources 在 `initialize` 中通告为：
+
+```json
+{
+  "capabilities": {
+    "resources": { "subscribe": true, "listChanged": true }
+  }
+}
+```
+
+## 内置 Resources
+
+`dcc-mcp-core` 附带四个内置 producer。每个都以 URI scheme 为键。
+
+| URI | MIME | 说明 | 通知 |
+|-----|------|------|------|
+| `scene://current` | `application/json` | 当前 `SceneInfo` 快照（或占位符） | 调用 `set_scene()` 时触发 |
+| `capture://current_window` | `image/png` | 活动 DCC 窗口的 PNG（base64 blob） | 无（按需读取） |
+| `audit://recent?limit=N` | `application/json` | `AuditLog` 的尾部（默认 50，最大 500） | 每次 `AuditLog.record()` 时触发 |
+| `artefact://sha256/<hex>` | 可变 | 内容寻址的制品存储 (#349)；body 以其声明的 MIME 作为 base64 blob 返回。由 `enable_artefact_resources` 门控。 | 无（轮询模型） |
+
+`capture://current_window` 仅在真实窗口捕获后端可用时列出
+（目前为 Windows `HWND PrintWindow`）。在其他平台上它会从
+`resources/list` 中隐藏。
+
+## 启用 / 禁用
+
+```python
+from dcc_mcp_core import McpHttpConfig
+
+cfg = McpHttpConfig(port=8765)
+cfg.enable_resources = True              # 默认: True — 通告能力 + 内置项
+cfg.enable_artefact_resources = False    # 默认: False — 启用前 artefact:// 返回 -32002
+```
+
+当 `enable_resources = False` 时，服务器不通告该能力，所有四个
+`resources/*` 方法返回 `-32601 method not found`。
+
+## 连接外部状态
+
+DCC 适配器通常在调用 `server.start()` **之前**设置场景快照并转发
+审计事件到注册表：
+
+```python
+from dcc_mcp_core import (
+    AuditLog,
+    McpHttpServer,
+    McpHttpConfig,
+    ToolRegistry,
+)
+
+registry = ToolRegistry()
+# ... registry.register(...) ...
+
+server = McpHttpServer(registry, McpHttpConfig(port=8765))
+
+# 1. 每当 DCC 场景变化时推送场景快照:
+server.resources().set_scene({
+    "scene_path": "/projects/shot_010/main.ma",
+    "fps": 24,
+    "frame_range": [1001, 1240],
+    "active_camera": "persp",
+})
+
+# 2. 挂钩 sandbox AuditLog，使 audit://recent 在每次记录时触发通知:
+audit = AuditLog()
+server.resources().wire_audit_log(audit)
+
+handle = server.start()
+```
+
+### 更新场景快照
+
+`set_scene()` 原子性地替换快照并发出一个
+`notifications/resources/updated`，其 `uri = "scene://current"`
+到每个已订阅的会话。
+
+```python
+server.resources().set_scene(new_snapshot_dict)
+```
+
+传递 `None` 以清除快照（读者随后收到一个带有 `status: "no_snapshot"` 的占位符）。
+
+## 示例: 客户端侧
+
+```python
+import json, urllib.request
+
+# Initialize + 获取 session id（此处省略）
+# 列出 resources
+body = {"jsonrpc": "2.0", "id": 1, "method": "resources/list"}
+req = urllib.request.Request(
+    "http://127.0.0.1:8765/mcp",
+    data=json.dumps(body).encode(),
+    headers={"Content-Type": "application/json", "Mcp-Session-Id": session_id},
+    method="POST",
+)
+with urllib.request.urlopen(req) as r:
+    print(json.loads(r.read())["result"]["resources"])
+
+# 读取审计日志
+body = {
+    "jsonrpc": "2.0", "id": 2,
+    "method": "resources/read",
+    "params": {"uri": "audit://recent?limit=10"},
+}
+# ... POST, 将 result.contents[0].text 作为 JSON 解析 ...
+
+# 订阅场景更新
+body = {
+    "jsonrpc": "2.0", "id": 3,
+    "method": "resources/subscribe",
+    "params": {"uri": "scene://current"},
+}
+# ... POST, 然后打开 GET /mcp SSE 流以接收 notifications/resources/updated ...
+```
+
+## 错误码
+
+| 码 | 含义 |
+|----|------|
+| `-32601` | 方法未找到 — resources 已禁用 (`enable_resources = False`) |
+| `-32602` | 无效参数 — 缺失或格式错误的 `uri` |
+| `-32002` | Resource 未启用（scheme 已识别，后端已禁用）— 当 `artefact://` URI 语法有效但未存储时也会复用 |
+| `-32603` | 内部错误 — producer 失败（捕获后端错误等） |
+
+## `artefact://` Scheme (issue #349)
+
+工具和工作流步骤之间的内容寻址制品传递。
+完整指南请参见 [`docs/guide/artefacts.md`](../guide/artefacts.md)。
+快速参考：
+
+- URI 形状: `artefact://sha256/<hex>`。
+- 默认后端: `FilesystemArtefactStore`，锚定在
+  `<registry_dir>/dcc-mcp-artefacts`（或临时目录）。
+- `resources/list` 枚举每个已存储的制品；条目携带声明的 MIME 和
+  sidecar 元数据。
+- `resources/read` 以 base64 blob 返回原始字节。
+- Python 辅助函数: `artefact_put_file`, `artefact_put_bytes`,
+  `artefact_get_bytes`, `artefact_list`。
+- 通过 `McpHttpConfig.enable_artefact_resources = True` 启用。
+
+## 编写自定义 Producer (Rust)
+
+```rust
+use dcc_mcp_http::{ProducerContent, ResourceError, ResourceProducer, ResourceResult};
+use async_trait::async_trait;
+
+struct PlaybackProducer;
+
+#[async_trait]
+impl ResourceProducer for PlaybackProducer {
+    fn scheme(&self) -> &str { "playback" }
+
+    async fn list(&self) -> ResourceResult<Vec<McpResource>> {
+        Ok(vec![McpResource {
+            uri: "playback://current".into(),
+            name: "Playback state".into(),
+            description: Some("Current playback frame and range".into()),
+            mime_type: Some("application/json".into()),
+        }])
+    }
+
+    async fn read(&self, uri: &str) -> ResourceResult<Vec<ProducerContent>> {
+        if uri != "playback://current" {
+            return Err(ResourceError::NotFound(uri.into()));
+        }
+        Ok(vec![ProducerContent::Text {
+            uri: uri.into(),
+            mime_type: Some("application/json".into()),
+            text: r#"{"frame": 42, "range": [1, 100]}"#.into(),
+        }])
+    }
+}
+```
+
+然后在 `start()` 之前将其注册到服务器：
+
+```rust
+server.resources().add_producer(Arc::new(PlaybackProducer));
+```
+
+## 生命周期保证
+
+- 订阅是**每会话**的。当客户端终止会话 (`DELETE /mcp`) 时，
+  其所有订阅自动丢弃。
+- `notifications/resources/updated` 是尽力而为 — 如果 SSE 通道已满
+  或客户端已断开连接，通知会被丢弃（无队列，producer 上无背压）。
+- Producer 必须廉价可调用 — 每次 MCP 客户端重连都会调用 `resources/list`。
+- Blob 内容 (`capture://current_window`) 在 JSON-RPC 响应中 base64 编码；
+  保持 payload 低于约 5 MB 以避免客户端解码问题。
+
+## 参见
+
+- [HTTP API](./http.md) — `McpHttpServer`, `McpHttpConfig`
+- [Sandbox API](./sandbox.md) — `AuditLog` (`audit://recent` 的来源)
+- [Capture API](./capture.md) — `Capturer` (`capture://current_window` 的来源)

--- a/docs/zh/api/workflow.md
+++ b/docs/zh/api/workflow.md
@@ -1,3 +1,273 @@
-# workflow
+# Workflow API
 
-> 中文翻译尚未完成。请参阅 [英文文档](/api/workflow)。
+> **状态**: 完全实现 (issue #348)。基于 spec 的流水线引擎，
+> 包含六种步骤类型、步骤级策略、制品传递、取消级联和 SQLite 持久化。
+>
+> 概念指南请参见 [`docs/guide/workflows.md`](../guide/workflows.md)。
+
+## Crate 布局
+
+- **`dcc-mcp-workflow`** — 所有工作流类型、目录、DDL、工具注册
+  以及 `WorkflowExecutor` 引擎。在工作区级别通过顶层 `workflow`
+  feature 门控（默认关闭）。
+- **`dcc-mcp-http`** — `McpHttpConfig::enable_workflows` 在 `start()` 时
+  门控内置工具的注册。
+
+## 类型 (Rust)
+
+```rust
+use dcc_mcp_workflow::{
+    WorkflowSpec, WorkflowStatus, WorkflowJob, WorkflowProgress,
+    Step, StepKind, StepId, WorkflowId,
+    WorkflowCatalog, WorkflowSummary,
+    WorkflowExecutor, WorkflowHost, WorkflowRunHandle,
+    register_builtin_workflow_tools, register_workflow_handlers,
+    WorkflowError,
+};
+```
+
+所有结构类型都是 `Serialize + Deserialize + Clone`。ID 是 newtype
+(`WorkflowId(Uuid)`, `StepId(String)`)，带有透明 serde。
+
+### `WorkflowSpec`
+
+```rust
+let spec = WorkflowSpec::from_yaml(yaml_source)?;
+spec.validate()?;
+```
+
+验证检查：
+
+- 至少一个步骤。
+- 每个步骤 id 非空且在完整树中唯一。
+- 每个 `tool` / `tool_remote` 名称通过 `dcc_mcp_naming::validate_tool_name`。
+- 每个 `branch.on` 和 `foreach.items` 表达式在 `jsonpath-rust 1.x` 下解析。
+- 步骤策略格式正确 (`max_attempts >= 1`,
+  `initial_delay_ms <= max_delay_ms`, `timeout_secs > 0` 等)。
+
+### `WorkflowExecutor`
+
+```rust
+let handle = WorkflowExecutor::run(spec, inputs, parent_job_id)?;
+```
+
+执行流水线：
+
+```text
+WorkflowExecutor::run(spec, inputs, parent)
+   │
+   ├─ 验证 spec
+   ├─ 创建根作业 + CancellationToken
+   ├─ 生成驱动任务
+   │     │
+   │     ├─ drive(steps) ── 顺序执行
+   │     │     └─ 对每个步骤:
+   │     │           ├─ policy: retry + timeout + idempotency
+   │     │           ├─ 按 StepKind 分发
+   │     │           │     ├─ Tool      → ToolCaller::call
+   │     │           │     ├─ ToolRemote→ RemoteCaller::call
+   │     │           │     ├─ Foreach   → 每项驱动(body)
+   │     │           │     ├─ Parallel  → tokio::join! 分支
+   │     │           │     ├─ Approve   → ApprovalGate::wait_handle
+   │     │           │     └─ Branch    → JSONPath → then|else
+   │     │           ├─ artefact 传递 (FileRef → ArtefactStore)
+   │     │           ├─ SSE: $/dcc.workflowUpdated enter / exit
+   │     │           └─ sqlite upsert (如果启用了 feature)
+   │     └─ 发出 workflow_terminal
+   └─ 返回 WorkflowRunHandle { workflow_id, root_job_id, cancel_token, join }
+```
+
+### 步骤类型
+
+| 类型 | 驱动器 | 关键策略开关 |
+| ---- | ------ | ---------- |
+| `tool` | `ToolCaller::call(name, args)` | timeout, retry, idempotency_key |
+| `tool_remote` | `RemoteCaller::call(dcc, name, args)` | 同上 |
+| `foreach` | JSONPath → 每项 body, 并发 >= 1 | 子 body 继承策略 |
+| `parallel` | `tokio::join!` 分支 | `on_any_fail: abort \| continue` |
+| `approve` | `ApprovalGate::wait_handle` + timeout | timeout_secs |
+| `branch` | JSONPath 条件 → `then` 或 `else` | 无 |
+
+### 取消级联
+
+根 `CancellationToken` 传递给每个步骤驱动器和每个调用器。
+调用 `cancel` 时：
+
+1. 不再启动新步骤。
+2. 进行中的 `ToolCaller` / `RemoteCaller` 收到 token 并应协作地遵守它。
+3. 休眠（重试退避、`Approve` 超时）通过 `tokio::select!` 中止。
+4. 工作流状态变为 `cancelled`；发出最终的 `$/dcc.workflowUpdated`。
+
+从 `WorkflowHost::cancel` → 每个进行中的步骤观察到 token 的往返
+时间被限制在一个协作检查点之内（通常 < 200 ms）。
+
+### `WorkflowJob`
+
+```rust
+let mut job = WorkflowJob::pending(spec);
+job.start()?;   // 通过 WorkflowExecutor 开始执行
+```
+
+### `WorkflowCatalog`
+
+读取 `SkillMetadata.metadata["dcc-mcp.workflows"]` 作为 glob（或
+逗号分隔的 glob 列表），相对于技能根目录解析。
+将完整 YAML body 解析为 `WorkflowSummary`。
+
+```rust
+use dcc_mcp_workflow::WorkflowCatalog;
+
+let catalog = WorkflowCatalog::from_skill(&skill_meta, &skill_root)?;
+for s in catalog.entries() {
+    println!("{}/{}: {}", s.skill, s.name, s.description);
+}
+```
+
+元数据键 (`dcc-mcp.workflows`) 在 issue #348 的修正案下以
+`dcc-mcp.*` 为命名空间 — 它故意**不**引入新的顶级 SKILL.md 字段，
+因此 `skills-ref validate` 保持通过。
+
+## 步骤策略 (issue #353)
+
+每一步都可声明一个可选的 `policy` 块。所有字段都是可选的；
+省略该块则使用默认的 `StepPolicy`（无超时、无重试、无幂等键）。
+
+```yaml
+steps:
+  - id: export_fbx
+    tool: maya_animation__export_fbx
+    args: { scene: "{{inputs.scene_id}}" }
+    timeout_secs: 300
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      initial_delay_ms: 500
+      max_delay_ms: 10000
+      jitter: 0.25
+      retry_on: ["transient", "timeout"]
+    idempotency_key: "export_{{scene_id}}_{{frame_range}}"
+    idempotency_scope: workflow
+```
+
+| 字段 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `timeout_secs` | `u64 > 0` | 无 | 每次尝试的 wall-clock 截止时间。 |
+| `retry.max_attempts` | `u32 >= 1` | 如果存在 retry 则必填 | `1` = 无重试。 |
+| `retry.backoff` | 枚举 | `exponential` | `fixed` / `linear` / `exponential`。 |
+| `retry.initial_delay_ms` | `u64` | `500` | `<= max_delay_ms`。 |
+| `retry.max_delay_ms` | `u64` | `10_000` | shape + jitter 后的上限。 |
+| `retry.jitter` | `f32` | `0.0` | 限制到 `[0.0, 1.0]`。 |
+| `retry.retry_on` | `[String]` | 所有错误 | 错误类型白名单。 |
+| `idempotency_key` | string | 无 | 执行前渲染的 Mustache 模板。 |
+| `idempotency_scope` | 枚举 | `workflow` | `workflow` 或 `global`。 |
+
+退避公式: `min(base(n), max_delay) * (1 + rand(-jitter, +jitter))`
+其中 `base` 对 `fixed` 是 `initial_delay`，对 `linear` 是
+`initial_delay * (n-1)`，对 `exponential` 是
+`initial_delay * 2^(n-2)`。
+
+尝试编号从 1 开始：`attempt_number == 1` 是首次运行
+（无前置延迟）；`attempt_number == 2` 是第一次重试。
+
+工作流的取消会**中断休眠** — 重试永远不会比 `workflows.cancel`
+调用活得更久。每次尝试都被记录为工作流根作业下的一个独立子作业
+（parent-job id 来自 issue #318）。
+
+## 内置 MCP 工具
+
+由 `register_builtin_workflow_tools(&registry)` 注册。功能型 handler
+由 `register_workflow_handlers(&dispatcher, &host)` 绑定。
+
+| 工具 | 说明 | ToolAnnotations |
+|------|------|-----------------|
+| `workflows.run` | 启动运行（YAML 或 JSON spec + inputs）。 | `destructive_hint=true, open_world_hint=true` |
+| `workflows.get_status` | 轮询终止状态 + 进度。 | `read_only_hint=true, idempotent_hint=true` |
+| `workflows.cancel` | 通过 `workflow_id` 取消运行（级联）。 | `destructive_hint=true, idempotent_hint=true` |
+| `workflows.lookup` | 目录搜索（只读）。 | `read_only_hint=true` |
+
+## Python 接口
+
+```python
+from dcc_mcp_core import (
+    WorkflowSpec, WorkflowStep, StepPolicy,
+    RetryPolicy, BackoffKind, WorkflowStatus,
+)
+
+spec = WorkflowSpec.from_yaml_str(yaml_source)
+spec.validate()            # 失败时抛出 ValueError
+
+step: WorkflowStep = spec.steps[0]
+policy: StepPolicy = step.policy
+retry: RetryPolicy = policy.retry
+assert retry.next_delay_ms(2) == 500       # 第一次重试延迟（未加 jitter）
+```
+
+所有策略类都是 **frozen** — Python 无法修改已解析的 spec。
+要运行工作流，请从 MCP 客户端侧调用 MCP 工具
+(`workflows.run` / `workflows.get_status` / `workflows.cancel`) —
+它们注册在任何调用了 `register_builtin_workflow_tools` 加上
+`register_workflow_handlers` 的技能服务器上。
+
+## 审批门控
+
+```yaml
+steps:
+  - id: human_gate
+    kind: approve
+    prompt: "继续执行 vendor drop？"
+    timeout_secs: 300
+```
+
+执行器暂停工作流并发出 `$/dcc.workflowUpdated`，其
+`detail.kind == "approve_requested"` 并附带提示文本。MCP 服务器将
+入站的 `notifications/$/dcc.approveResponse` 消息桥接到
+`ApprovalGate::resolve`。超时时门控以
+`approved=false, reason="timeout"` 解析，步骤失败。
+
+## 制品传递 (issue #349)
+
+输出中包含 `file_refs` 数组的工具会被自动通过
+`ArtefactStore::put` 捕获；生成的 `FileRef` URI 会出现在下游步骤
+上下文中，通过 <code v-pre>`{{steps.<id>.file_refs[<i>].uri}}`</code> 访问。
+原始 JSON 输出仍可通过 <code v-pre>`{{steps.<id>.output.*}}`</code> 访问。
+
+## 持久化 (#328)
+
+在 `job-persist-sqlite` feature flag 下，每次工作流运行写入两张表：
+
+- `workflows(workflow_id, root_job_id, spec_json, inputs_json, status,
+  current_step_id, step_outputs_json, created_at, completed_at)`
+- `workflow_steps(workflow_id, step_id, status, attempt, result_json,
+  updated_at)` — 每次转换一行。
+
+启动时，`WorkflowExecutor::recover_persisted()` 将所有非终止行
+翻转为 `interrupted` 并发出最终的 `$/dcc.workflowUpdated`。
+运行**不会**自动恢复 — `interrupted` 是终止状态；客户端可以
+在其上实现一个恢复工具（如果需要）。
+
+## HTTP 服务器门控
+
+```python
+from dcc_mcp_core import McpHttpConfig
+cfg = McpHttpConfig(port=8765)
+cfg.enable_workflows = True     # 默认 False
+```
+
+## 发现模型
+
+工作流是 `SKILL.md` 旁边的**兄弟 YAML 文件**，通过单个 `metadata` glob
+指向：
+
+```yaml
+# SKILL.md (agentskills.io-valid)
+---
+name: vendor-intake
+description: "导入供应商 Maya 文件、运行 QC、导出 FBX、传递给 Unreal。"
+metadata:
+  dcc-mcp.workflows: "workflows/*.workflow.yaml"
+  dcc-mcp.workflows.search-hint: "vendor intake, nightly cleanup, batch import"
+---
+```
+
+这使 SKILL.md 保持小巧且可组合 — 完整原理参见 issue #348 上的
+修正案注释（渐进式披露、可 diff、可重用）。

--- a/docs/zh/guide/artefacts.md
+++ b/docs/zh/guide/artefacts.md
@@ -1,3 +1,144 @@
-# artefacts
+# 制品传递 (Artefact Hand-Off)
 
-> 中文翻译尚未完成。请参阅 [英文文档](/guide/artefacts)。
+> **Issue**: [#349](https://github.com/loonghao/dcc-mcp-core/issues/349)
+> **Crate**: `dcc-mcp-artefact`
+> **Scheme**: `artefact://sha256/<hex>`
+
+流水线在工具之间以及工作流步骤之间传递*文件*：导入的场景、
+质检报告、暂存的 `.uasset`、烘焙的模拟。内联传递原始字节会
+膨胀 MCP 传输；传递绝对路径会跨机器中断并丢失
+MIME / 大小 / 校验和元数据。
+
+`dcc-mcp-artefact` 提供一个小型值类型（`FileRef`）加上一个
+内容寻址存储后端，并将一个 `artefact://` URI scheme 接入
+MCP Resources 原语，使 MCP 客户端可以通过 URI `resources/read`
+文件传递。
+
+## 概念
+
+- **`FileRef`** — 对已存储文件的可序列化引用：
+  - `uri` — 规范形式，例如 `artefact://sha256/<hex>`
+  - `mime`, `size_bytes`, `digest` (`sha256:<hex>`)
+  - `producer_job_id`（可选，用于工作流步骤输出）
+  - `created_at` (RFC-3339)
+  - `metadata`（工具定义的 JSON — 宽/高、帧号等）
+
+- **`ArtefactStore`** — trait，带有 `put` / `get` / `head` / `delete` /
+  `list`。存储是内容寻址的：提交相同的字节两次会返回相同的 URI。
+
+- **`FilesystemArtefactStore`** — 默认持久化后端。每个制品存放在
+  `<root>/<sha256>.bin` 下，并带有一个携带 `FileRef` 的
+  `<sha256>.json` sidecar。`McpHttpServer` 将其存储锚定在
+  `<registry_dir>/dcc-mcp-artefacts`（或当未配置注册表时的 OS 临时目录）。
+
+- **`InMemoryArtefactStore`** — 非持久化后端，用于测试。
+
+## 启用 Artefact Resources
+
+```python
+from dcc_mcp_core import McpHttpConfig, McpHttpServer, ToolRegistry
+
+cfg = McpHttpConfig(port=8765)
+cfg.enable_artefact_resources = True    # 默认关闭
+server = McpHttpServer(ToolRegistry(), cfg)
+handle = server.start()
+```
+
+一旦启用：
+
+- `resources/list` 将每个已存储的制品作为 `artefact://` URI 包含在内。
+- `resources/read` 以正确的 MIME 类型返回 body，作为 base64 blob。
+- 未知 URI 的 `resources/read` 返回 MCP 错误 `-32002`。
+
+禁用（默认）路径仍然识别该 scheme 并以 `-32002` "not enabled"
+错误响应，因此客户端可以区分 "scheme unknown" 和
+"scheme recognized but backing store off"。
+
+## Python 辅助函数
+
+```python
+from dcc_mcp_core import (
+    FileRef,
+    artefact_put_bytes,
+    artefact_put_file,
+    artefact_get_bytes,
+    artefact_list,
+)
+
+# 将磁盘上的文件放入并获取 FileRef。
+ref = artefact_put_file("/tmp/render.png", mime="image/png")
+print(ref.uri)           # artefact://sha256/<hex>
+print(ref.digest)        # sha256:<hex>
+print(ref.size_bytes)    # 1024
+
+# 往返一个字节缓冲区。
+bref = artefact_put_bytes(b"hello", mime="text/plain")
+assert artefact_get_bytes(bref.uri) == b"hello"
+
+# 清单。
+for entry in artefact_list():
+    print(entry.uri, entry.mime, entry.size_bytes)
+```
+
+辅助函数目标是一个进程级默认存储
+（`<temp_dir>/dcc-mcp-artefacts`）。在服务器进程内部，
+`McpHttpServer` 会自动将辅助函数指向它自己的存储。
+
+## Rust API
+
+```rust
+use dcc_mcp_artefact::{
+    ArtefactBody, ArtefactFilter, ArtefactStore,
+    FilesystemArtefactStore, InMemoryArtefactStore,
+    put_bytes, put_file,
+};
+
+// 持久化存储 — 真实服务器的默认选项。
+let store = FilesystemArtefactStore::new_in("/var/cache/dcc/artefacts")?;
+let fr = put_bytes(&store, b"payload".to_vec(), Some("text/plain".into()))?;
+assert!(fr.uri.starts_with("artefact://sha256/"));
+
+// 通过 URI 查找。
+let body = store.get(&fr.uri)?.unwrap();
+assert_eq!(body.into_bytes()?, b"payload");
+
+// 按生产作业筛选列出制品。
+let refs = store.list(ArtefactFilter {
+    producer_job_id: Some(job_id),
+    ..Default::default()
+})?;
+```
+
+## 工作流集成
+
+工作流运行器通过步骤输出传播 `FileRef`：
+
+1. 一个步骤发出一个 `ToolResult`，其 `context` 包含
+   `{"file_refs": [{"uri": "artefact://sha256/...", "mime": "image/png"}]}`。
+2. 运行器将 `FileRef` 存储在步骤记录上，并将其替换到下一步骤的
+   参数上下文中。
+3. 下游步骤通过 `artefact_get_bytes(uri)` 获取字节 — 或者当从
+   运行器进程外部使用 MCP resources 原语时通过 `resources/read` 获取。
+
+本 PR 落地了类型、存储和 resource 接线。运行器集成超出范围。
+
+## 注意事项
+
+- **重复内容 → 相同 URI。** 不要依赖 URI 的唯一性进行逻辑排序 —
+  改用 `producer_job_id` 和 `metadata`。
+- **`put_file` 会复制。** 源路径保持不动；存储拥有规范副本。
+- **Sidecar 对元数据是权威的。** 手动编辑 JSON sidecar 是支持的；
+  编辑 `.bin` 文件则不支持（digest 会不匹配）。
+- **尚无 GC。** 存储永远不会自动删除。TTL / 引用计数 GC 在一个
+  未来的 issue 中追踪。
+- **尚无远程后端。** S3 / SFTP / HTTP 指针已声明在路线图中但尚未
+  实现 — 一个未来的 issue。
+
+## 参见
+
+- [`docs/api/resources.md`](../api/resources.md) — 承载 `artefact://` 的
+  更广泛的 Resources 原语。
+- Issue [#348](https://github.com/loonghao/dcc-mcp-core/issues/348) —
+  消费 `FileRef` 的工作流运行器。
+- Issue [#350](https://github.com/loonghao/dcc-mcp-core/issues/350) —
+  Resources 原语（已合并）。

--- a/docs/zh/guide/capabilities.md
+++ b/docs/zh/guide/capabilities.md
@@ -1,3 +1,205 @@
-# capabilities
+# 能力与工作区根目录
 
-> 中文翻译尚未完成。请参阅 [英文文档](/guide/capabilities)。
+> **Issue:** [#354](https://github.com/loonghao/dcc-mcp-core/issues/354) —
+> 能力声明 + 类型化工作区路径握手
+>
+> **状态:** 自 v0.15 起可用
+
+本文档涵盖两个松耦合的功能，它们使 DCC 工具更安全、
+跨主机更可移植：
+
+1. **能力声明** — 工具声明需要哪些 DCC 功能；适配器声明
+   主机能提供什么。服务器会阻止未满足要求的工具调用。
+2. **类型化工作区路径握手** — 工具可以使用 `workspace://` URI scheme，
+   服务器会针对 MCP 客户端通告的文件系统根目录解析它。
+
+---
+
+## 1. 能力声明
+
+### 为什么
+
+并非每个 DCC 都暴露相同的功能面。Maya 有 USD；3ds Max 没有。
+某些适配器在无头模式下运行，没有文件系统访问权限；其他则有
+完整的写权限。声明能力让运行时在 Python 脚本运行之前**
+拒绝工具调用并返回格式良好的 MCP 错误。
+
+### 每个工具: `tools.yaml` 中的 `required_capabilities`
+
+根据 **issue #356**，工具声明存放在从 `SKILL.md` 通过
+`metadata.dcc-mcp.tools` 引用的兄弟 `tools.yaml` 文件中。
+向任何需要非平凡主机功能的工具添加 `required_capabilities`：
+
+```yaml
+# tools.yaml
+tools:
+  - name: import_usd
+    description: 将 USD stage 导入场景
+    required_capabilities: [usd, scene.mutate, filesystem.read]
+
+  - name: read_stage_metadata
+    description: 从 USD stage 读取元数据而不修改场景
+    required_capabilities: [usd, scene.read, filesystem.read]
+
+  - name: ping
+    description: 不需要任何能力
+```
+
+能力字符串是自由格式的 — 将其视为技能作者和适配器作者之间的
+约定。捆绑技能使用的常见命名空间：
+
+| 命名空间 | 含义 |
+|----------|------|
+| `usd` | USD stage / layer 操作可用 |
+| `scene.read` | 读取当前 DCC 场景图 |
+| `scene.mutate` | 修改当前 DCC 场景图 |
+| `filesystem.read` | 从磁盘读取文件 |
+| `filesystem.write` | 向磁盘写入文件 |
+| `viewport` | 渲染 / 截图活动视口 |
+
+### 每个技能: 通过 `SkillMetadata.required_capabilities()` 聚合
+
+加载器会自动对技能上所有按工具的能力取并集：
+
+```python
+from dcc_mcp_core import SkillMetadata, scan_and_load
+
+skills, _ = scan_and_load(dcc_name="maya")
+for md in skills:
+    print(md.name, md.required_capabilities)  # 排序去重并集
+```
+
+这对 `search_skills` 过滤以及通过 `SKILL.md` 概览向 AI agent
+展示很有用。
+
+### 主机端: `McpHttpConfig.declared_capabilities`
+
+DCC 适配器在启动服务器时声明当前主机能提供什么：
+
+```python
+from dcc_mcp_core import create_skill_server, McpHttpConfig
+
+cfg = McpHttpConfig(port=8765)
+cfg.declared_capabilities = [
+    "usd",
+    "scene.read",
+    "scene.mutate",
+    "filesystem.read",
+    # 为只读会话故意省略 filesystem.write
+]
+server = create_skill_server("maya", cfg)
+handle = server.start()
+```
+
+### 运行时行为
+
+**`tools/list`** — 每个工具都会被列出，无论能力如何，但未满足的工具
+会携带一个 `_meta` 提示，以便 AI 客户端可以跳过它们：
+
+```jsonc
+{
+  "name": "import_usd",
+  "description": "...",
+  "inputSchema": { "...": "..." },
+  "_meta": {
+    "dcc": {
+      "required_capabilities": ["usd", "scene.mutate", "filesystem.read"],
+      "missing_capabilities": ["filesystem.write"]  // 仅当非空时
+    }
+  }
+}
+```
+
+**`tools/call`** — 服务器会以结构化的 JSON-RPC 错误拒绝调用：
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32001,
+    "message": "capability_missing: tool 'import_usd' requires filesystem.write",
+    "data": {
+      "tool": "import_usd",
+      "required": ["usd", "scene.mutate", "filesystem.write"],
+      "missing": ["filesystem.write"],
+      "declared": ["usd", "scene.read", "scene.mutate", "filesystem.read"]
+    }
+  }
+}
+```
+
+错误码 `-32001` 是 dcc-mcp-core 的 `CAPABILITY_MISSING`。AI 客户端应将
+此视为对当前会话**永久**失败，而不是重试。
+
+---
+
+## 2. 类型化工作区路径握手
+
+### 为什么
+
+MCP 客户端通过 `initialize` 请求的 `roots` 能力通告文件系统根目录
+（`file:///home/user/project/...`）。历史上接受路径的工具必须：
+
+- 信任 AI 传递绝对路径（有风险 — 会逃逸工作区），
+- 或接受原始字符串并重新实现根解析（样板代码）。
+
+`WorkspaceRoots` 辅助类集中处理此问题。工具接受 `workspace://`
+URI scheme，服务器针对会话的第一个根目录解析它。
+
+### 从工具使用 `WorkspaceRoots`
+
+`WorkspaceRoots` 作为 Python 类暴露。当工具声明了 `filesystem.*`
+能力时，服务器会向工具上下文注入一个 `_workspace_roots` 参数：
+
+```python
+def import_usd(path: str, _workspace_roots=None):
+    if _workspace_roots is None:
+        return error_result("import_usd", "no workspace roots advertised")
+    try:
+        resolved = _workspace_roots.resolve(path)
+    except ValueError as e:
+        return error_result("import_usd", str(e))
+    # ...继续使用 `resolved` 作为绝对 PathBuf 等效物
+```
+
+### 解析规则
+
+| 输入 | 行为 |
+|------|------|
+| `workspace://assets/hero.usd` | 与第一个通告的根目录拼接 |
+| `/abs/path/scene.ma` | 原样返回 |
+| `C:\Users\me\scene.max` | 原样返回（Windows 绝对路径） |
+| `assets/hero.usd`（相对） | 如果可用，与第一个根拼接；否则原样返回 |
+| `workspace://...` 但没有根 | 抛出 `no workspace roots`（MCP 错误 `-32602`） |
+
+### 手动构造（用于测试）
+
+```python
+from dcc_mcp_core import WorkspaceRoots
+
+roots = WorkspaceRoots(["/projects/hero"])
+assert roots.resolve("workspace://char/bob.usd") == "/projects/hero/char/bob.usd"
+assert roots.resolve("/tmp/abs").endswith("abs")
+```
+
+### Rust API
+
+```rust
+use dcc_mcp_http::{WorkspaceRoots, WorkspaceResolveError};
+
+let roots = WorkspaceRoots::from_client_roots(&session.roots());
+let path = roots.resolve("workspace://assets/hero.usd")?;
+// path 是绝对 std::path::PathBuf
+```
+
+`WorkspaceResolveError::NoRoots` 映射到 JSON-RPC 错误码 `-32602`
+(`NO_WORKSPACE_ROOTS`)。
+
+---
+
+## 参见
+
+- [Skills guide](skills.md) — `tools.yaml` 兄弟文件模式 (#356)
+- [`docs/guide/naming.md`](naming.md) — SEP-986 工具名验证
+- MCP roots 规范: <https://modelcontextprotocol.io/specification/2025-03-26/client/roots>

--- a/docs/zh/guide/gateway.md
+++ b/docs/zh/guide/gateway.md
@@ -1,3 +1,194 @@
-# gateway
+# Gateway
 
-> 中文翻译尚未完成。请参阅 [英文文档](/guide/gateway)。
+Gateway（`McpHttpConfig::gateway_port > 0`）是一个 first-wins HTTP
+门面，将所有在线的 DCC 实例呈现在一个 MCP 端点下。
+单个客户端可以通过同一个 `/mcp` URL 与 Maya、Blender 和 Houdini
+通信；Gateway 通过 `FileRegistry` 发现在线后端，聚合它们的
+`tools/list`，将每个 `tools/call` 路由到正确的后端，并将
+服务器推送的通知多路复用回原始客户端会话。
+
+## 拓扑
+
+```
+              ┌──────────────── gateway ────────────────┐
+  client_A ──▶│  POST /mcp  (tools/list, tools/call)    │───▶ backend (maya)
+              │  GET  /mcp  (SSE — MCP 2025-03-26)      │───▶ backend (blender)
+  client_B ──▶│  subscribers: per-client broadcast sink │
+              │  backend SSE sub: one per backend URL   │
+              └────────────────────────────────────────┘
+```
+
+## SSE 多路复用 (#320)
+
+当 Gateway 检测到新后端时，它会打开一个持久的 SSE 连接到
+`<backend>/mcp`（客户端对 Gateway 使用的同一个 Streamable HTTP
+传输）。后端发出的通知被解析为 JSON-RPC 消息并路由到正确的客户端：
+
+| MCP 方法 | 关联键 | 来源 |
+|----------|--------|------|
+| `notifications/progress` | `params.progressToken` | 当外发 `tools/call` 携带了 `_meta.progressToken` 时由 Gateway 设置 |
+| `notifications/$/dcc.jobUpdated` | `params.job_id` | 从后端回复的 `_meta.dcc.jobId` / `structuredContent.job_id` 设置 |
+| `notifications/$/dcc.workflowUpdated` | `params.job_id` | 同上 |
+
+### 挂起缓冲区
+
+在关联已知之前到达的通知（后端 SSE 推送与 `tools/call` HTTP
+回复之间的竞争）被保存在一个有界的每后端队列中：**256 个事件**
+或 **30 秒**，以先到者为准。当映射出现时缓冲区被排空；
+过期条目会以 `warn!` 日志丢弃。
+
+### 重连 + 合成 `$/dcc.gatewayReconnect`
+
+每个后端订阅器拥有一个带 jitter 的指数退避重连循环
+（100 ms → 10 s，±25% jitter）。当断开的流重新连接时，
+Gateway 会向每个在该后端上有进行中的作业的客户端发出一个合成的
+`notifications/$/dcc.gatewayReconnect` 通知：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/$/dcc.gatewayReconnect",
+  "params": { "backend_url": "http://127.0.0.1:18812/mcp" }
+}
+```
+
+客户端使用此事件通过 `jobs.get_status` 重新查询进行中的作业。
+
+### 会话生命周期
+
+每客户端 SSE sink 以 `Mcp-Session-Id` 为键。当 `GET /mcp`
+响应体被丢弃时（客户端断开连接），一个 `SessionCleanup` RAII
+守卫会运行：从订阅管理器中移除该客户端的 sink，并清除绑定到
+该会话的任何 `job_routes` / `progress_token_routes`。后端订阅保持
+活动状态 — 另一个客户端可能仍然依赖它们。
+
+## 代码指针
+
+| 组件 | 文件 |
+|------|------|
+| 订阅管理器、重连循环 | `crates/dcc-mcp-http/src/gateway/sse_subscriber.rs` |
+| 每会话 SSE 管道 | `crates/dcc-mcp-http/src/gateway/handlers.rs` (`handle_gateway_get`) |
+| `tools/call` 关联钩子 | `crates/dcc-mcp-http/src/gateway/aggregator.rs` (`route_tools_call`) |
+| 订阅观察者 | `crates/dcc-mcp-http/src/gateway/mod.rs` (`backend_sub_handle`) |
+
+## 从 Gateway 等待终止结果 (#321)
+
+Gateway 对出站 `tools/call` 应用两套独立的请求预算：
+
+| 情况 | 超时 | 来源 |
+|------|------|------|
+| 同步调用（无 `_meta.dcc.async`，无 `progressToken`） | `backend_timeout_ms`（默认 10 s） | `McpHttpConfig` |
+| 异步 opt-in 调用（`_meta.dcc.async=true` 或 `_meta.progressToken`） | `gateway_async_dispatch_timeout_ms`（默认 60 s） | `McpHttpConfig` |
+| 异步 opt-in **并且** `_meta.dcc.wait_for_terminal=true` | `gateway_wait_terminal_timeout_ms`（默认 10 min）用于等待，`gateway_async_dispatch_timeout_ms` 用于初始排队步骤 | `McpHttpConfig` |
+
+**为什么需要两个超时？** 异步分派的工具在作业在后端排队后立即
+回复 `{status:"pending", job_id:"…"}`。在冷启动条件下
+（Maya 重新导入重型模块、Blender 启动新的 Python 解释器）
+即使是这个排队步骤也可能合法地需要 >10 s，因此短的同步超时
+会在后端仍在启动工作时表面一个虚假的传输错误。
+
+### 响应缝合（opt-in）
+
+无法消费 SSE 的客户端（纯 `curl`、批处理脚本、CI runner）
+仍然可以通过在 `_meta.dcc.async = true` 的同时设置
+`_meta.dcc.wait_for_terminal = true` 来在单个 `tools/call`
+响应中获取最终结果：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "maya__bake_simulation",
+    "arguments": {...},
+    "_meta": {
+      "dcc": {"async": true, "wait_for_terminal": true}
+    }
+  }
+}
+```
+
+Gateway 现在：
+
+1. 以更长的 `gateway_async_dispatch_timeout_ms` 预算转发调用到后端。
+2. 接收 `{pending, job_id}` 信封并订阅 SSE 订阅管理器拥有的
+   每作业广播总线。
+3. 阻塞 HTTP 响应，直到通过后端 SSE 流到达一个状态属于
+   `{completed, failed, cancelled, interrupted}` 的
+   `notifications/$/dcc.jobUpdated` 帧，或者直到
+   `gateway_wait_terminal_timeout_ms` 超时。
+4. 将终止状态、`result` 和 `error` 合并到原始 pending 信封的
+   `structuredContent` 中，并返回生成的 `CallToolResult`。
+   任何非 `completed` 状态都会设置 `isError`。
+
+### 超时语义
+
+如果 `gateway_wait_terminal_timeout_ms` 超时前未到达终止事件，
+Gateway 会返回**最后观察到的**作业信封，并标注
+`_meta.dcc.timed_out = true`，同时让作业继续在后端运行。
+调用者可以重新通过 SSE 连接或持续轮询 `jobs.get_status`
+来收集最终结果。
+
+### 后端断开
+
+如果后端 SSE 流在等待者阻塞时断开，Gateway 返回一个
+JSON-RPC `-32000` 错误，标识后端和 `job_id`。作业本身不会被
+取消 — 后端的后续重启可能将其表面为 `interrupted`
+（issue #328），当持久化作业存储重新水合时。
+
+## 作业到后端路由缓存 (#322)
+
+为了将客户端的 `notifications/cancelled { requestId }` 转发到
+实际拥有该作业的后端，Gateway 维护一个小缓存：
+
+```rust
+pub struct JobRoute {
+    pub client_session_id: ClientSessionId,
+    pub backend_id: BackendId,            // 例如 http://127.0.0.1:8001/mcp
+    pub tool: String,                     // 用于日志 + cancel payload
+    pub created_at: DateTime<Utc>,        // GC 锚点
+    pub parent_job_id: Option<String>,    // #318 级联
+}
+// DashMap<Uuid, JobRoute>
+```
+
+在后端对 `tools/call` 的回复携带 `job_id` 时填充。被以下功能消费：
+
+- `notifications/cancelled { requestId }` — Gateway 解析
+  `requestId → job_id → JobRoute` 并向 `backend_id` POST cancel。
+- 父作业级联 — 如果被取消的作业有 `parent_job_id`，或者
+  *它自己就是*父作业，Gateway 会遍历 `children_of` 索引并将
+  cancel 扇出到每个不同的 `backend_id`（这可能与发起后端不同 —
+  `#318` 仅覆盖单服务器级联，Gateway 将其扩展到跨后端）。
+
+### 生命周期
+
+- **插入** — `aggregator::route_tools_call` → `SubscriberManager::bind_job_route`。
+- **自动驱逐** — `deliver()` 在观察到带终止状态（`completed`、`failed`、
+  `cancelled`、`interrupted`）的 `$/dcc.jobUpdated` 时立即移除路由。
+- **TTL GC** — 后台任务每 60 秒扫描一次超过
+  `gateway_route_ttl_secs`（默认 24 小时）的路由，因此一个从未发出
+  终止事件的后端崩溃不会泄漏路由。
+- **每会话上限** — `gateway_max_routes_per_session`（默认 1000）。
+  当会话已持有 `cap` 个活跃路由时，新的分派会被拒绝，返回
+  JSON-RPC `-32005 too_many_in_flight_jobs`。
+
+### Python 配置
+
+```python
+from dcc_mcp_core import McpHttpConfig
+
+cfg = McpHttpConfig(
+    port=0,
+    gateway_route_ttl_secs=3600,              # 1 小时
+    gateway_max_routes_per_session=500,
+)
+```
+
+两个字段在返回的 `McpHttpConfig` 实例上也可作为 getter/setter 访问。
+
+## 非目标
+
+HTTP/2 多路复用调优以及路由缓存的多后端故障转移
+（路由是粘性的）对 #320 / #321 / #322 来说超出范围。

--- a/docs/zh/guide/job-persistence.md
+++ b/docs/zh/guide/job-persistence.md
@@ -1,3 +1,135 @@
-# job-persistence
+# 作业持久化
 
-> 中文翻译尚未完成。请参阅 [英文文档](/guide/job-persistence)。
+`JobManager` 追踪长时间运行的异步工具执行（参见 issues \#316、\#318、
+\#326、\#371）。默认情况下它将所有作业状态保存在进程内，这意味着
+如果服务器崩溃或重启，每个 `Pending` 或 `Running` 行都会丢失。
+
+Issue #328 增加了一个**可选的、feature-gated 的 SQLite 后端**，
+使被追踪的作业能够 survive 重启，并使操作员可以通过内置的 MCP 工具
+清理已完成的历史记录。
+
+## 设计概览
+
+```
+┌──────────────┐      put/get/list/update_status/delete_older_than      ┌─────────────────┐
+│  JobManager  │ ─────────────────────────────────────────────────────▶ │   JobStorage    │
+│  (in-proc)   │                                                        │    (trait)      │
+└──────────────┘                                                        └─────────────────┘
+                                                                                 │
+                                                     ┌───────────────────────────┼─────────────────────────┐
+                                                     ▼                                                     ▼
+                                             InMemoryStorage                                        SqliteStorage
+                                             (default, zero-dep)                                    (feature job-persist-sqlite)
+```
+
+- `JobStorage` 是 `Send + Sync` 且同步的 — 每次作业转换时直写。
+  无后台 flush 任务，无批处理。
+- `InMemoryStorage` 是默认值，随每个 wheel 一起发布。语义与 trait
+  相同，但显然无法 survive 重启。
+- `SqliteStorage` 被 Cargo feature `job-persist-sqlite` 门控，并引入
+  `rusqlite`（带 `bundled`），因此不需要系统 SQLite。
+
+## 启用 SQLite 持久化
+
+### 构建
+
+```bash
+# 默认构建 — 仅内存，不编译 SQLite 代码
+vx just dev
+
+# opt-in — 添加 SqliteStorage 和 rusqlite 依赖
+cargo build --workspace --features job-persist-sqlite,python-bindings,ext-module
+```
+
+### 配置
+
+```python
+from dcc_mcp_core import McpHttpConfig, McpHttpServer, ToolRegistry
+
+config = McpHttpConfig(port=8765)
+config.job_storage_path = "/var/lib/dcc-mcp/jobs.sqlite3"
+
+registry = ToolRegistry()
+# register tools...
+server = McpHttpServer(registry, config)
+handle = server.start()
+```
+
+如果设置了 `job_storage_path` 但 wheel 是**在没有**
+`job-persist-sqlite` 的情况下构建的，`server.start()` 会快速失败并返回
+描述性错误，而不是静默回退到内存存储。
+
+## 启动恢复
+
+当 `JobManager` 以存储后端启动时，它会扫描状态为 `Pending` 或
+`Running` 的行 — 这些是上一个进程退出时正在运行中的作业。
+每一行都会被重写为新的终止状态 `JobStatus::Interrupted`，
+`error = "server restart"` 并带有新的 `updated_at`，同时发出一个
+`$/dcc.jobUpdated` 通知（如果 `JobNotifier` 已连接）。重新连接后
+订阅的客户端因此会看到一个干净的终止转换，而不是一个悬空的
+`Running` 作业。
+
+恢复失败会以 `error` 级别记录日志，并且**不会**中止启动 —
+进程内映射简单地以空开始，进程继续服务新请求。
+
+## `jobs.cleanup` 内置工具
+
+一个符合 SEP-986 规范的内置 MCP 工具，用于修剪终止作业：
+
+```jsonc
+// tools/call
+{
+  "name": "jobs.cleanup",
+  "arguments": { "older_than_hours": 24 }  // 默认值: 24
+}
+// → { "removed": <count>, "older_than_hours": 24 }
+```
+
+- Annotations: `destructive_hint: true`, `idempotent_hint: true`,
+  `read_only_hint: false`。
+- 只有终止状态（`Completed`、`Failed`、`Cancelled`、`Interrupted`）
+  才有资格被移除；无论年龄多大，`Pending` 和 `Running` 行永远不会被移除。
+- 对任一已配置的后端都有效 — 内存或 SQLite。
+
+## 存储 Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS jobs (
+    job_id        TEXT PRIMARY KEY,
+    parent_job_id TEXT,
+    tool          TEXT NOT NULL,
+    status        TEXT NOT NULL,
+    progress_json TEXT,
+    created_at    TEXT NOT NULL,
+    updated_at    TEXT NOT NULL,
+    error         TEXT,
+    result_json   TEXT
+);
+CREATE INDEX IF NOT EXISTS jobs_status_idx  ON jobs(status);
+CREATE INDEX IF NOT EXISTS jobs_parent_idx  ON jobs(parent_job_id);
+CREATE INDEX IF NOT EXISTS jobs_updated_idx ON jobs(updated_at);
+```
+
+时间戳以 RFC 3339 UTC 字符串存储。进度和结果 payload 是 JSON
+序列化的 — 即使内部 `Job` 字段演进，schema 也保持稳定。
+
+## 运维指南
+
+- **备份**: SQLite 文件是单个路径；标准文件级快照即可。
+  跨版本没有 WAL 模式承诺 — 将其视为持久缓存，而非记录系统。
+- **增长**: 按计划调用 `jobs.cleanup`（cron、k8s CronJob 或从编排
+  agent）。默认 24 小时窗口对大多数交互式使用来说足够。
+- **迁移**: 目前没有跨版本迁移。如果未来版本中 schema 改变，
+  删除文件让 `JobManager` 重新创建它 — 该文件旨在 survive 重启，
+  而非升级。
+- **并发**: `SqliteStorage` 通过连接上的 `parking_lot::Mutex` 串行化。
+  对于每个 DCC 的服务器来说足够好；不要将多个 `McpHttpServer` 实例
+  指向同一个文件。
+
+## 相关 issues
+
+- #316 — 带有 `Pending`/`Running`/`Completed` 状态的异步作业执行
+- #318 — `JobManager` 核心
+- #326 — `$/dcc.jobUpdated` 通知
+- #371 — `jobs.get_status` 工具
+- **#328** — 本文档

--- a/docs/zh/guide/prompts.md
+++ b/docs/zh/guide/prompts.md
@@ -1,3 +1,176 @@
-# prompts
+# MCP Prompts 原语
 
-> 中文翻译尚未完成。请参阅 [英文文档](/guide/prompts)。
+> 为 dcc-mcp-core 实现 [MCP 2025-03-26 — Prompts](https://modelcontextprotocol.io/specification/2025-03-26/server/prompts)。
+> Issues [#351](https://github.com/loonghao/dcc-mcp-core/issues/351)
+> 和 [#355](https://github.com/loonghao/dcc-mcp-core/issues/355)。
+
+**Prompts** 原语是 `McpHttpServer` 通告的第三个 MCP 面，
+与 `tools` 和 `resources` 并列。它使 AI 客户端能够发现可重用的
+**提示模板** — 由参数化的自然语言指令组成 — 技能作者可以
+精心制作以从模型中引出正确的行为链。
+
+与 `tools/call`（执行副作用）和 `resources/read`（返回不透明字节）
+不同，`prompts/get` 返回一个**渲染后的消息数组**，客户端可以直接
+拼接到对话中，保留技能作者的意图，而不需要模型猜测正确的措辞。
+
+## 线协议
+
+启用后，服务器在 `initialize` 中通告该原语：
+
+```json
+{
+  "capabilities": {
+    "prompts": { "listChanged": true }
+  }
+}
+```
+
+暴露三个 JSON-RPC 方法：
+
+| 方法 | 目的 |
+|------|------|
+| `prompts/list` | 返回每个已注册的 prompt — 名称、描述、参数 schema。 |
+| `prompts/get` | 通过名称渲染一个 prompt，使用调用者提供的参数。 |
+| `notifications/prompts/list_changed` | 每当技能被加载 / 卸载时服务器推送的 SSE 事件。 |
+
+## 来源: 兄弟 `prompts.yaml`
+
+遵循项目范围的**兄弟文件规则** ([#356](https://github.com/loonghao/dcc-mcp-core/issues/356))，
+提示模板从不内联到 `SKILL.md` 中。技能作者从 `metadata.dcc-mcp`
+命名空间引用一个兄弟文件：
+
+```yaml
+---
+name: maya-geometry
+description: "Maya geometry primitives and editing."
+metadata:
+  dcc-mcp.dcc: maya
+  dcc-mcp.prompts: prompts.yaml     # 单文件，或
+  # dcc-mcp.prompts: prompts/*.prompt.yaml   # glob，每个 prompt 一个文件
+---
+```
+
+`prompts.yaml` 包含两个顶层列表 — 都是可选的：
+
+::: v-pre
+```yaml
+prompts:
+  - name: bevel_all_edges
+    description: "以一致的倒角宽度对每条选中的边进行倒角。"
+    arguments:
+      - name: chamfer_width
+        description: "Maya 单位中的倒角宽度。"
+        required: true
+      - name: segments
+        description: "倒角段数（默认 2）。"
+        required: false
+    template: |
+      使用 `maya_geometry__select_edges` 捕获当前选择，
+      然后调用 `maya_geometry__bevel_edges`，参数为
+      width={{chamfer_width}} 和 segments={{segments}}。
+      在保存前使用 `diagnostics__screenshot` 验证结果。
+
+workflows:
+  - file: workflows/bake_proxies.workflow.yaml
+    prompt_name: bake_proxies_summary      # 可选重命名
+```
+:::
+
+### 显式 prompts
+
+`prompts:` 下的每个条目都是一个 `PromptSpec`：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `name` | string | ✅ | 技能内唯一。作为 MCP 服务时使用完全限定名。 |
+| `description` | string | ✅ | 客户端向用户展示的一行摘要。 |
+| `arguments` | list[ArgumentSpec] | ❌ | 模板的类型化占位符。 |
+| `template` | string | ✅ | <code v-pre>`{{name}}`</code> 占位符针对调用点参数解析。 |
+
+`ArgumentSpec` 字段: `name`, `description`, `required`（默认 `false`）。
+
+### 工作流派生 prompts
+
+`workflows:` 列表为每个引用的工作流自动生成一个摘要 prompt。
+这是一个最小的行为链提示 — "这是工作流按顺序运行的步骤" —
+适合想要在执行前（或代替执行）叙述工作流的 agent：
+
+```yaml
+workflows:
+  - file: workflows/bake_proxies.workflow.yaml
+```
+
+不需要 `template`；注册表将工作流的描述 + 步骤列表汇总为
+一个 user-role 消息。使用 `prompt_name` 覆盖默认自动生成的名称。
+
+### 单文件 vs glob
+
+`metadata.dcc-mcp.prompts` 接受两种形式：
+
+- `prompts.yaml` — 单文件，包含 `prompts:` + `workflows:` 列表。
+- `prompts/*.prompt.yaml` — glob，每个 prompt 一个文件。每个文件的
+  形状与 `prompts:` 中的单个条目相同。
+
+解析是**惰性**的：路径在扫描 / 加载时记录；文件内容仅在服务器
+处理 `prompts/list` 或 `prompts/get` 时才读取。
+
+## 模板引擎
+
+渲染引擎故意保持极简 — 只有一个 token：
+::: v-pre
+`{{placeholder}}`。
+:::
+
+- 大括号内的空白会被修剪：<code v-pre>`{{ foo }}`</code> == <code v-pre>`{{foo}}`</code>。
+- 未声明的 required 参数会抛出
+  `INVALID_PARAMS: missing required argument: <name>`。
+- 不是裸标识符的大括号内容（<code v-pre>`{{ 1 + 1 }}`</code>）会原样保留 —
+  引擎从不求值表达式。
+- 没有匹配 `}}` 的未闭合 <code v-pre>`{{`</code> 会原样输出。
+
+保持模板小而声明式。如果模板需要循环、条件或数据获取，
+请将其编写为**工作流**（issue #348）并从 `workflows:` 列表中引用。
+
+## 服务器配置
+
+该原语**默认启用**。通过 `McpHttpConfig.enable_prompts = false`
+全局禁用：
+
+```python
+from dcc_mcp_core import McpHttpConfig, create_skill_server
+
+cfg = McpHttpConfig(port=8765)
+cfg.enable_prompts = False     # opt out — capability 从 initialize 中消失
+server = create_skill_server("maya", cfg)
+server.start()
+```
+
+禁用时，服务器会省略 `prompts` 能力并以 `Method not found`
+拒绝 `prompts/list` / `prompts/get`。
+
+## `list_changed` 不变式
+
+- `notifications/prompts/list_changed` 在已加载技能集发生变化时触发
+  (`skills/load`, `skills/unload`, 热重载)。
+- 注册表的内部缓存在发出通知的同一个临界区失效 — 客户端可以
+  立即在其后调用 `prompts/list` 并观察到新集合。
+- 通知扇出到每个活跃的 SSE 会话；prompts 没有每会话订阅模型。
+
+## 技能作者指南
+
+1. 保持 `template` 正文**在 50 行以内**。更长的指南应放在 `references/`
+   中，并由工作流层拉取。
+2. 在模板内部优先使用**完全限定工具名**
+   (`maya_geometry__bevel_edges`) — 这样 agent 就不需要猜测。
+3. 如果行为链超过 3-4 个工具调用，将其提取到 `workflow.yaml` 中
+   并让服务器自动生成摘要 prompt。
+4. 不要在模板中放入 secrets 或环境特定路径 — prompts 会原样
+   暴露给模型。
+
+## 相关 issues
+
+- [#351](https://github.com/loonghao/dcc-mcp-core/issues/351) — MCP prompts 原语
+- [#355](https://github.com/loonghao/dcc-mcp-core/issues/355) — 从 SKILL.md 示例 + 工作流派生的 prompts
+- [#348](https://github.com/loonghao/dcc-mcp-core/issues/348) — 工作流 specs（自动派生 prompts 的来源）
+- [#356](https://github.com/loonghao/dcc-mcp-core/issues/356) — 兄弟文件模式
+- [#350](https://github.com/loonghao/dcc-mcp-core/issues/350) — MCP resources 原语（姐妹功能）

--- a/docs/zh/guide/scheduler.md
+++ b/docs/zh/guide/scheduler.md
@@ -1,3 +1,198 @@
-# scheduler
+# 调度器 — cron + webhook 触发的工作流
 
-> 中文翻译尚未完成。请参阅 [英文文档](/guide/scheduler)。
+> Issue [#352](https://github.com/loonghao/dcc-mcp-core/issues/352)。
+> 通过 Cargo `scheduler` feature opt-in。默认关闭。
+
+调度器子系统在两种触发器上触发预注册的工作流
+（来自 [#348](https://github.com/loonghao/dcc-mcp-core/issues/348) 的 `WorkflowSpec`）：
+
+- **Cron** — 基于 `chrono-tz` 时区的下次触发时间循环，可选均匀随机 jitter。
+- **Webhook** — 主 Axum 路由器上的 HTTP POST 端点，可选通过
+  `X-Hub-Signature-256` 进行 HMAC-SHA256 验证。
+
+调度器**本身不执行工作流**。触发时它构建一个 `TriggerFire` 值
+并将其交给调用者提供的 `JobSink`。sink 针对 `WorkflowCatalog`
+解析工作流名称，并通过主机首选的任何分派路径将 `WorkflowJob` 入队。
+
+## 兄弟文件模式 ([#356](https://github.com/loonghao/dcc-mcp-core/issues/356))
+
+调度计划存放在 `SKILL.md` 旁边的 `*.schedules.yaml` 文件中，
+从不内联在 `SKILL.md` frontmatter 本身。技能通过
+`metadata.dcc-mcp.workflow.schedules` 指向它们：
+
+```yaml
+# SKILL.md
+---
+name: scene-maintenance
+description: Maya 场景的夜间清理 + 上传验证。
+metadata:
+  dcc-mcp:
+    workflow:
+      specs: [workflows.yaml]
+      schedules: [schedules.yaml]
+---
+```
+
+::: v-pre
+```yaml
+# schedules.yaml (SKILL.md 的兄弟文件)
+schedules:
+  - id: nightly_cleanup
+    workflow: scene_cleanup          # WorkflowSpec id
+    inputs:
+      scope: all-scenes
+    trigger:
+      kind: cron
+      expression: "0 0 3 * * *"      # 秒 分 时 日 月 星期
+      timezone: UTC
+      jitter_secs: 120
+    enabled: true
+    max_concurrent: 1
+
+  - id: on_upload
+    workflow: validate_upload
+    inputs:
+      path: "{{trigger.payload.file_path}}"
+    trigger:
+      kind: webhook
+      path: /webhooks/upload
+      secret_env: UPLOAD_WEBHOOK_SECRET
+    enabled: true
+```
+:::
+
+### Cron 表达式格式
+
+底层 [`cron`](https://crates.io/crates/cron) crate 期望 6 字段形式
+`sec min hour day_of_month month day_of_week`（**秒是必需的**）。
+经典的 5 字段表达式如 `"0 3 * * *"` 会解析失败 — 使用
+`"0 0 3 * * *"` 表示"每天 03:00"。
+
+### 模板变量
+
+Webhook payload 通过 <code v-pre>`{{trigger.payload.<json-path>}}`</code>
+占位符合并到工作流输入中：
+
+- <code v-pre>`{{trigger.payload.file_path}}`</code> — 点路径查找（对象 + 数字数组索引）。
+- <code v-pre>`{{trigger.schedule_id}}`</code> / <code v-pre>`{{trigger.workflow}}`</code> — 字面量上下文。
+
+作为**整个**字符串的占位符保留底层 JSON 类型（数字保持为数字）。
+更大字符串内部的占位符总是被字符串化。
+
+## HMAC-SHA256 验证
+
+当 webhook 触发器上设置了 `secret_env` 时：
+
+1. 服务器在启动时从命名的环境变量读取 secret。
+2. 每个请求必须携带 `X-Hub-Signature-256: sha256=<hex>`；调度器
+   重新计算 HMAC 并以常数时间比较。
+3. 如果环境变量在启动时设置但在请求时缺失，端点回复
+   `500 webhook_secret_missing`（fail-loud）。
+4. 如果签名错误，端点回复 `401 invalid_signature`。
+
+使用 GitHub 惯例 — 任何现有的 webhook 发送器都无需重新配置即可工作。
+
+## `max_concurrent` — 重叠时跳过
+
+`max_concurrent` 限制每个调度 id 的进行中触发次数。
+- `max_concurrent = 1`（默认）— 如果上一次调用尚未达到终止状态，
+  则跳过触发。
+- `max_concurrent = 0` — 无限制。
+
+主机必须在观察到终止工作流状态时调用
+`SchedulerHandle::mark_terminal(schedule_id)`（通常通过订阅
+`$/dcc.workflowUpdated`）。计数器递减，以便未来的触发再次被允许。
+
+达到并发上限的 webhook 请求会收到 `429 Too Many Requests`，
+以及描述进行中 / 最大值的 JSON body。
+
+## 运行时接口
+
+```rust
+use std::sync::Arc;
+use dcc_mcp_scheduler::{
+    JobSink, SchedulerConfig, SchedulerService, TriggerFire,
+};
+
+struct MySink { /* workflow registry + dispatcher */ }
+impl JobSink for MySink {
+    fn enqueue(&self, fire: TriggerFire) -> Result<(), String> {
+        // 解析 fire.workflow，构建 WorkflowJob，提交。
+        Ok(())
+    }
+}
+
+let cfg = SchedulerConfig::from_dir("./schedules")?;
+let (handle, webhook_router) = SchedulerService::new(cfg, Arc::new(MySink))
+    .start();
+// 将 webhook_router 合并到你的主 Axum app 中:
+//   app = app.merge(webhook_router);
+// 在终止工作流状态时:
+//   handle.mark_terminal("nightly_cleanup");
+// 关闭时:
+//   handle.shutdown();
+```
+
+## `McpHttpConfig` 集成
+
+```python
+from dcc_mcp_core import McpHttpConfig
+
+cfg = McpHttpConfig(port=8765)
+cfg.enable_scheduler = True
+cfg.schedules_dir = "/opt/dcc-mcp/schedules"
+```
+
+或通过 builder：
+
+```rust
+use dcc_mcp_http::config::McpHttpConfig;
+let cfg = McpHttpConfig::new()
+    .with_scheduler("/opt/dcc-mcp/schedules");
+```
+
+配置字段始终存在；当 `dcc-mcp-scheduler` crate 未编译进来时
+它们是 no-op。
+
+## Python 接口
+
+仅暴露**声明式**类型：
+
+```python
+from dcc_mcp_core import (
+    ScheduleSpec, TriggerSpec,
+    parse_schedules_yaml,
+    hmac_sha256_hex, verify_hub_signature_256,
+)
+
+spec = ScheduleSpec(
+    id="nightly_cleanup",
+    workflow="scene_cleanup",
+    trigger=TriggerSpec.cron("0 0 3 * * *", timezone="UTC", jitter_secs=120),
+    inputs='{"scope": "all-scenes"}',
+    max_concurrent=1,
+)
+spec.validate()
+
+# 解析整个文件:
+specs = parse_schedules_yaml(open("./schedules.yaml").read())
+
+# HMAC 辅助函数（例如用于 webhook-sender 测试）:
+sig = hmac_sha256_hex(b"shared-secret", request_body)
+assert verify_hub_signature_256(b"shared-secret", request_body, sig)
+```
+
+调度器运行时本身在 HTTP 服务器内部由 Rust 驱动 —
+Python 目前无法直接构造 `SchedulerService`。
+
+## 非目标
+
+- 分布式调度 / leader 选举（仅单节点）。
+- 调度文件热重载（在服务器重启时加载）。
+- 触发历史 / 上次运行 UI（未来 issue）。
+
+## 参见
+
+- `crates/dcc-mcp-scheduler/src/lib.rs` — crate 级文档和示例。
+- `docs/proposals/workflow-orchestration-gap.md` §G — 设计原理。
+- Issue [#352](https://github.com/loonghao/dcc-mcp-core/issues/352)。

--- a/docs/zh/guide/workflows.md
+++ b/docs/zh/guide/workflows.md
@@ -1,3 +1,264 @@
-# workflows
+# 工作流 (Workflows)
 
-> 中文翻译尚未完成。请参阅 [英文文档](/guide/workflows)。
+> 一等公民、基于 spec 的、可持久化、可取消的 MCP 工具调用流水线。
+> 解析器、验证器以及完整的步骤执行引擎均已随 issue
+> [#348](https://github.com/loonghao/dcc-mcp-core/issues/348) 落地。
+
+## 什么是工作流？
+
+工作流是一个 YAML 文档，声明了一棵有序的**步骤**树。每一步要么是
+`tool` 调用，要么是通过网关的 `tool_remote` 调用，要么是控制流类型
+（`foreach`、`parallel`、`branch`、`approve`）。顶层 spec 由
+[`WorkflowSpec::from_yaml`](../api/workflow) 解析并由
+`WorkflowSpec::validate()` 验证。
+
+::: v-pre
+```yaml
+name: vendor_intake
+description: "导入供应商 Maya 文件、质检、导出 FBX、推送至 Unreal。"
+inputs:
+  date: { type: string, format: date }
+steps:
+  - id: list
+    tool: vendor_intake__list_sftp
+    args: { date: "{{inputs.date}}" }
+  - id: per_file
+    kind: foreach
+    items: "$.list.files"
+    as: file
+    steps:
+      - id: export
+        tool: maya__export_fbx
+```
+:::
+
+完整的端到端示例请见 `examples/workflows/`（随 executor PR 一并添加）。
+
+## 步骤策略 (issue #353)
+
+每一步都可声明一个可选的 **policy** 块来控制执行器如何运行它。
+所有字段都是可选的；省略该块则使用默认的 `StepPolicy`
+（无超时、无重试、无幂等键）。
+
+::: v-pre
+```yaml
+steps:
+  - id: export_fbx
+    tool: maya_animation__export_fbx
+    args: { scene: "{{inputs.scene_id}}" }
+    timeout_secs: 300
+    retry:
+      max_attempts: 3
+      backoff: exponential          # "fixed" | "linear" | "exponential"
+      initial_delay_ms: 500
+      max_delay_ms: 10000
+      jitter: 0.25                  # 相对值，限制在 [0.0, 1.0]
+      retry_on: ["transient", "timeout"]
+    idempotency_key: "export_{{scene_id}}_{{frame_range}}"
+    idempotency_scope: workflow     # 或 "global"（默认值: "workflow"）
+```
+:::
+
+### `timeout_secs`
+
+该步骤**单次尝试**的绝对 wall-clock 截止时间。必须 `> 0`。
+当截止时执行器会取消该步骤，并且（如果设置了 `retry` 且失败类型
+可重试）将其计为一次失败尝试。`None` = 无超时。
+
+### `retry`
+
+| 字段 | 类型 | 默认值 | 说明 |
+| ---- | ---- | ------ | ---- |
+| `max_attempts` | `u32 >= 1` | *必填* | `1` = 不重试。 |
+| `backoff` | 枚举 | `exponential` | `fixed` / `linear` / `exponential`。 |
+| `initial_delay_ms` | `u64` | `500` | 必须 `<= max_delay_ms`。 |
+| `max_delay_ms` | `u64` | `10_000` | 在 shape + jitter 之后应用的上限。 |
+| `jitter` | `f32` | `0.0` | 在解析时限制到 `[0.0, 1.0]`；超出范围会告警。 |
+| `retry_on` | `[String]` | *所有错误* | 错误类型白名单。`None` = 所有错误均可重试。 |
+
+执行器在两次尝试之间休眠
+`min(base(attempt), max_delay) * (1 + rand(-jitter, +jitter))`，
+其中 `base` 由 `backoff` 选择的 shape 决定。Rust 层面的辅助函数
+`RetryPolicy::next_delay(attempt_number)` 返回未加 jitter 的基准值，
+是公式的唯一来源。
+
+尝试编号从 1 开始：`attempt_number == 1` 是首次运行（无前置延迟）；
+`attempt_number == 2` 是第一次重试。
+
+| Backoff | 第 `n >= 2` 次尝试的延迟 |
+| ------- | ------------------------ |
+| `fixed` | `initial_delay` |
+| `linear` | `initial_delay * (n - 1)` |
+| `exponential` | `initial_delay * 2^(n - 2)` |
+
+工作流的取消会**中断休眠** — 重试永远不会比 `workflows.cancel`
+调用活得更久。每次尝试都被记录为工作流根作业下的一个独立子作业
+（parent-job id 来自 issue #318）。
+
+### `idempotency_key`
+
+Mustache 风格的模板，在步骤执行前针对步骤上下文渲染。
+执行器会在 `JobManager` 中查找是否存在已完成的作业，其
+(`step.tool`, `rendered_key`, `scope`) 匹配；如果找到，则直接返回
+之前的结果并跳过该步骤。
+
+- **解析时引用检查。** 每个 <code v-pre>`{{var}}`</code> 的根标识符必须解析为
+  工作流输入、某个已知根（`inputs`、`steps`、`item`、`env`）或树中
+  任意位置声明的步骤 id。未知根会在 `WorkflowSpec::validate` 时产生
+  `ValidationError::UnknownTemplateVar`。
+- **作用域。** 默认 `workflow` — 键在单次工作流调用内唯一。
+  设置 `idempotency_scope: global` 可使键在每次工作流调用之间都唯一
+  （用于针对下游服务如资产追踪 DB 的幂等性）。
+
+跨服务器重启的持久化幂等追踪与 issue #328 的 SQLite 持久化工作
+绑定，对 #353 来说超出范围。
+
+## Python 接口
+
+```python
+from dcc_mcp_core import (
+    BackoffKind,
+    RetryPolicy,
+    StepPolicy,
+    WorkflowSpec,
+    WorkflowStep,
+)
+
+spec = WorkflowSpec.from_yaml_str(yaml_text)
+spec.validate()
+
+step: WorkflowStep = spec.steps[0]
+policy: StepPolicy = step.policy
+assert policy.timeout_secs == 300
+retry: RetryPolicy = policy.retry
+assert retry.max_attempts == 3
+assert retry.backoff == BackoffKind.EXPONENTIAL
+assert retry.next_delay_ms(2) == 500       # 第一次重试延迟
+```
+
+所有策略类都是 **frozen** — Python 无法修改已解析的 spec。
+要更改任何内容，请重新解析 YAML。
+
+## 验证错误
+
+| 错误变体 | 触发条件 |
+| -------- | -------- |
+| `InvalidPolicy` | `max_attempts == 0`、`initial_delay_ms > max_delay_ms`、`timeout_secs == 0`。 |
+| `UnknownTemplateVar` | `idempotency_key` 引用了已知集合之外的标识符。 |
+| `InvalidPolicy` (template parse) | `idempotency_key` 包含格式错误的 <code v-pre>`{{...}}`</code> 段。 |
+
+以上三种在 Python 侧都以 `ValueError` 形式出现，消息中包含出错的步骤 id。
+
+## 执行引擎 (issue #348)
+
+`WorkflowExecutor` 是一个由 Tokio 驱动的引擎，消费一个经过验证的
+`WorkflowSpec` 并端到端运行每一种步骤类型。它与传输层无关：
+本地工具调用通过 `ToolCaller`，远程调用通过 `RemoteCaller`，
+通知通过 `WorkflowNotifier`。
+
+```text
+WorkflowExecutor::run(spec, inputs, parent)
+   │
+   ├─ 验证 spec
+   ├─ 创建根作业 + CancellationToken
+   ├─ 生成驱动任务
+   │     │
+   │     ├─ drive(steps) ── 顺序执行
+   │     │     └─ 对每个步骤:
+   │     │           ├─ policy: retry + timeout + idempotency
+   │     │           ├─ 按 StepKind 分发
+   │     │           │     ├─ Tool      → ToolCaller::call
+   │     │           │     ├─ ToolRemote→ RemoteCaller::call
+   │     │           │     ├─ Foreach   → 每项驱动(body)
+   │     │           │     ├─ Parallel  → tokio::join! 分支
+   │     │           │     ├─ Approve   → ApprovalGate::wait_handle
+   │     │           │     └─ Branch    → JSONPath → then|else
+   │     │           ├─ artefact 传递 (FileRef → ArtefactStore)
+   │     │           ├─ SSE: $/dcc.workflowUpdated enter / exit
+   │     │           └─ sqlite upsert (如果启用了 feature)
+   │     └─ 发出 workflow_terminal
+   └─ 返回 WorkflowRunHandle { workflow_id, root_job_id, cancel_token, join }
+```
+
+### 步骤类型一览
+
+| 类型 | 驱动器 | 关键策略开关 |
+| ---- | ------ | ---------- |
+| `tool` | `ToolCaller::call(name, args)` | timeout, retry, idempotency_key |
+| `tool_remote` | `RemoteCaller::call(dcc, name, args)` | 同上 |
+| `foreach` | JSONPath → 每项 body, 并发>=1 | 子 body 继承策略 |
+| `parallel` | `tokio::join!` 分支 | `on_any_fail: abort \| continue` |
+| `approve` | `ApprovalGate::wait_handle` + timeout | timeout_secs |
+| `branch` | JSONPath 条件 → `then` 或 `else` | 无 |
+
+### 取消级联
+
+根 `CancellationToken` 传递给每个步骤驱动器和每个调用器。
+调用 `cancel` 时：
+
+1. 不再启动新步骤。
+2. 进行中的 `ToolCaller` / `RemoteCaller` 收到 token 并应协作地遵守它。
+3. 休眠（重试退避、`Approve` 超时）通过 `tokio::select!` 中止。
+4. 工作流状态变为 `cancelled`；发出最终的 `$/dcc.workflowUpdated`。
+
+从 `WorkflowHost::cancel` → 每个进行中的步骤观察到 token 的往返
+时间被限制在一个协作检查点之内（通常 < 200 ms）。
+
+### Artefact 传递 (#349)
+
+输出中包含 `file_refs` 数组的工具会被自动通过
+`ArtefactStore::put` 捕获；生成的 `FileRef` URI 会出现在下游步骤
+上下文中，通过 <code v-pre>`{{steps.<id>.file_refs[<i>].uri}}`</code> 访问。
+原始 JSON 输出仍可通过 <code v-pre>`{{steps.<id>.output.*}}`</code> 访问。
+
+### 持久化 (#328)
+
+在 `job-persist-sqlite` feature flag 下，每次工作流运行写入两张表：
+
+- `workflows(workflow_id, root_job_id, spec_json, inputs_json, status,
+  current_step_id, step_outputs_json, created_at, completed_at)`
+- `workflow_steps(workflow_id, step_id, status, attempt, result_json,
+  updated_at)` — 每次转换一行。
+
+启动时，`WorkflowExecutor::recover_persisted()` 将所有非终止行
+翻转为 `interrupted` 并发出最终的 `$/dcc.workflowUpdated`。
+运行**不会**自动恢复 — `interrupted` 是终止状态；如需恢复，
+客户端可以在其上实现一个恢复工具。
+
+### 内置 MCP 工具
+
+由 `register_builtin_workflow_tools(&registry)` 注册。功能型 handler
+由 `register_workflow_handlers(&dispatcher, &host)` 绑定。
+
+| 工具 | 说明 | ToolAnnotations |
+| ---- | ---- | --------------- |
+| `workflows.run` | 启动一次运行（YAML 或 JSON spec + inputs）。 | `destructive_hint=true, open_world_hint=true` |
+| `workflows.get_status` | 轮询终止状态 + 进度。 | `read_only_hint=true, idempotent_hint=true` |
+| `workflows.cancel` | 通过 `workflow_id` 取消运行（级联）。 | `destructive_hint=true, idempotent_hint=true` |
+| `workflows.lookup` | 目录搜索（只读）。 | `read_only_hint=true` |
+
+### 审批门控
+
+```yaml
+steps:
+  - id: human_gate
+    kind: approve
+    prompt: "继续执行 vendor drop？"
+    timeout_secs: 300          # 可选 — 默认无限期
+```
+
+执行器暂停工作流并发出 `$/dcc.workflowUpdated`，其
+`detail.kind == "approve_requested"` 并附带提示文本。MCP 服务器将
+入站的 `notifications/$/dcc.approveResponse` 消息桥接到
+`ApprovalGate::resolve`。超时时门控以
+`approved=false, reason="timeout"` 解析，步骤失败。
+
+### 用于运行的 Python 接口
+
+目前 Python 层仅暴露 spec + policy 查看器。要运行工作流，请从
+MCP 客户端侧调用 MCP 工具（`workflows.run` / `workflows.get_status`
+/ `workflows.cancel`）— 它们注册在任何调用了
+`register_builtin_workflow_tools` 加上
+`register_workflow_handlers` 的技能服务器上。原生的 `WorkflowHost`
+Python 类作为后续跟进追踪；MCP 工具路径是推荐的入口点，
+因为它与 agent 工具链的其余部分组合良好。

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2403,16 +2403,16 @@ print(f"MCP server ready: {handle.mcp_url()}")
 
 ---
 
-## Workflow Primitive (`dcc_mcp_workflow`, skeleton — issue #348)
+## Workflow Primitive (`dcc_mcp_workflow`, issue #348)
 
-**Status**: skeleton. Types, YAML parser, validator, catalog reader, DDL
-and the four built-in `workflows.*` MCP tools are shipped. **Step
-execution is intentionally deferred** to a follow-up PR — see the stable
-error payload below.
+**Status**: fully implemented. Spec-driven pipeline engine with six step
+kinds, step-level policies (retry / timeout / idempotency), artefact
+hand-off, cancellation cascade, and SQLite persistence.
 
-Opt-in via the top-level `workflow` Cargo feature (off by default for
-one release). Python surface: `WorkflowSpec`, `WorkflowStatus` — or
-`None` when the wheel was built without the feature.
+Opt-in via the top-level `workflow` Cargo feature (off by default).
+Python surface: `WorkflowSpec`, `WorkflowStep`, `StepPolicy`,
+`RetryPolicy`, `BackoffKind`, `WorkflowStatus` — or `None` when the wheel
+was built without the feature.
 
 ### Rust types
 
@@ -2421,12 +2421,13 @@ use dcc_mcp_workflow::{
     WorkflowSpec, Step, StepKind, StepId, WorkflowId,
     WorkflowStatus, WorkflowJob, WorkflowProgress,
     WorkflowCatalog, WorkflowSummary,
-    register_builtin_workflow_tools, WorkflowError,
+    register_builtin_workflow_tools, register_workflow_handlers,
+    WorkflowExecutor, WorkflowHost, WorkflowError,
 };
 ```
 
-All structural types are `Serialize + Deserialize`. IDs are newtypes
-with `#[serde(transparent)]`.
+All structural types are `Serialize + Deserialize + Clone`. IDs are
+newtypes with `#[serde(transparent)]`.
 
 #### `WorkflowSpec`
 
@@ -2438,56 +2439,84 @@ spec.validate()?;   // unique step ids, SEP-986 tool names, JSONPath parse
 Validation uses `dcc_mcp_naming::validate_tool_name` for tool refs and
 `jsonpath_rust::parser::parse_json_path` for `branch.on` / `foreach.items`.
 
-#### `WorkflowJob` (placeholder)
+#### `WorkflowExecutor`
 
 ```rust
-let mut job = WorkflowJob::pending(spec);
-assert!(matches!(job.start(), Err(WorkflowError::NotImplemented(_))));
+let handle = WorkflowExecutor::run(spec, inputs, parent_job_id)?;
+// handle: WorkflowRunHandle { workflow_id, root_job_id, cancel_token, join }
 ```
 
-Signature is stable for #349 / #353; body is a deliberate stub.
+Execution pipeline: `spec → validate → spawn driver → drive(steps) →
+per-step policy (retry+timeout+idempotency) → dispatch by kind →
+artefact handoff → SSE $/dcc.workflowUpdated → sqlite upsert → next
+step`.
+
+#### Step kinds
+
+| Kind | Driver | Policy knobs |
+|------|--------|--------------|
+| `tool` | `ToolCaller::call(name, args)` | timeout, retry, idempotency_key |
+| `tool_remote` | `RemoteCaller::call(dcc, name, args)` | same |
+| `foreach` | JSONPath → body per item | per-body policy inherited |
+| `parallel` | `tokio::join!` over branches | `on_any_fail: abort \| continue` |
+| `approve` | `ApprovalGate::wait_handle` + timeout | timeout_secs |
+| `branch` | JSONPath condition → `then` or `else` | n/a |
+
+#### Cancellation cascade
+
+Root `CancellationToken` handed to every step driver. On `cancel`:
+1. No new steps start.
+2. In-flight callers receive the token.
+3. Sleeps (retry backoff, `Approve` timeout) aborted via `tokio::select!`.
+4. Final `$/dcc.workflowUpdated` with `status: cancelled`.
 
 #### `WorkflowCatalog`
 
 Reads `SkillMetadata.metadata["dcc-mcp.workflows"]` (glob or
-comma-separated globs) relative to `skill_root`, parses **header only**:
+comma-separated globs) relative to `skill_root`:
 
 ```rust
 let cat = WorkflowCatalog::from_skill(&skill_meta, &skill_root)?;
 let hits: Vec<_> = cat.search("vendor intake").into_iter().collect();
 ```
 
-Full-body parse is deferred — marked `TODO(#348-full)`.
+### Step policies (issue #353)
+
+Every step may declare an optional `policy` block:
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `timeout_secs` | `u64 > 0` | none | Per-attempt wall-clock deadline. |
+| `retry.max_attempts` | `u32 >= 1` | required if retry present | `1` = no retry. |
+| `retry.backoff` | enum | `exponential` | `fixed` / `linear` / `exponential`. |
+| `retry.initial_delay_ms` | `u64` | `500` | `<= max_delay_ms`. |
+| `retry.max_delay_ms` | `u64` | `10_000` | Upper clamp after shape + jitter. |
+| `retry.jitter` | `f32` | `0.0` | Clamped to `[0.0, 1.0]`. |
+| `retry.retry_on` | `[String]` | all errors | Error-kind allowlist. |
+| `idempotency_key` | string | none | Mustache template rendered before execution. |
+| `idempotency_scope` | enum | `workflow` | `workflow` or `global`. |
+
+Backoff formula: `min(base(n), max_delay) * (1 + rand(-jitter, +jitter))`
+where `base` is `initial_delay` (fixed), `initial_delay * (n-1)` (linear),
+or `initial_delay * 2^(n-2)` (exponential).
 
 ### Built-in MCP tools
 
-`register_builtin_workflow_tools(&registry)` registers:
+Registered by `register_builtin_workflow_tools(&registry)` + bound by
+`register_workflow_handlers(&dispatcher, &host)`:
 
-| Tool                   | Status     |
-|------------------------|------------|
-| `workflows.run`        | stub       |
-| `workflows.get_status` | stub       |
-| `workflows.cancel`     | stub       |
-| `workflows.lookup`     | functional |
+| Tool | Description | ToolAnnotations |
+|------|-------------|-----------------|
+| `workflows.run` | Start a run (YAML or JSON spec + inputs). | `destructive_hint=true, open_world_hint=true` |
+| `workflows.get_status` | Poll terminal status + progress. | `read_only_hint=true, idempotent_hint=true` |
+| `workflows.cancel` | Cancel a run by `workflow_id` (cascade). | `destructive_hint=true, idempotent_hint=true` |
+| `workflows.lookup` | Catalog search (read-only). | `read_only_hint=true` |
 
-Stable stub payload (all three execution tools):
+### Artefact hand-off (issue #349)
 
-```json
-{
-  "success": false,
-  "error": "not_implemented",
-  "message": "workflows.run: step execution pending follow-up PR",
-  "issue": "#348"
-}
-```
-
-### HTTP server gate
-
-```python
-from dcc_mcp_core import McpHttpConfig
-cfg = McpHttpConfig(port=8765)
-cfg.enable_workflows = True     # default False
-```
+A tool whose output contains `file_refs` array is captured to
+`ArtefactStore`. Downstream steps reference via
+`{{steps.<id>.file_refs[<i>].uri}}`.
 
 ### Persistence DDL (`job-persist-sqlite` feature)
 
@@ -2495,24 +2524,37 @@ cfg.enable_workflows = True     # default False
 dcc_mcp_workflow::sqlite::apply_migrations(&conn)?;
 ```
 
-Creates `workflows` + `workflow_steps`. No writer is wired — the tables
-are for the follow-up execution PR (crash recovery via
-`WorkflowStatus::Interrupted`).
+Creates `workflows` + `workflow_steps`. On startup,
+`WorkflowExecutor::recover_persisted()` flips non-terminal rows to
+`Interrupted`. Runs are **not** auto-resumed.
 
 ### Python
 
 ```python
-from dcc_mcp_core import WorkflowSpec, WorkflowStatus
-
-if WorkflowSpec is None:
-    raise RuntimeError("wheel was built without the `workflow` feature")
+from dcc_mcp_core import (
+    WorkflowSpec, WorkflowStep, StepPolicy,
+    RetryPolicy, BackoffKind, WorkflowStatus,
+)
 
 spec = WorkflowSpec.from_yaml_str(yaml_source)
 spec.validate()        # raises ValueError on failure
-print(spec.name, spec.step_count)
 
-s = WorkflowStatus("running")
-assert not s.is_terminal
+step: WorkflowStep = spec.steps[0]
+policy: StepPolicy = step.policy
+retry: RetryPolicy = policy.retry
+assert retry.next_delay_ms(2) == 500   # first retry delay (unjittered)
+```
+
+All policy classes are **frozen**. To run workflows, call the MCP tools
+(`workflows.run` / `workflows.get_status` / `workflows.cancel`) from the
+MCP client side.
+
+### HTTP server gate
+
+```python
+from dcc_mcp_core import McpHttpConfig
+cfg = McpHttpConfig(port=8765)
+cfg.enable_workflows = True     # default False
 ```
 
 ### Discovery

--- a/llms.txt
+++ b/llms.txt
@@ -444,20 +444,25 @@ export DCC_MCP_SKILL_PATHS="/path/to/skills1:/path/to/skills2"
 # Windows: set DCC_MCP_SKILL_PATHS=C:\skills1;C:\skills2
 ```
 
-## Workflow Primitive (skeleton — issue #348)
+## Workflow Primitive (issue #348)
 
-Opt-in via the `workflow` Cargo feature. Ships types + validator + catalog
-+ four built-in MCP tools; step execution is deferred to a follow-up PR.
+Opt-in via the `workflow` Cargo feature. Full spec-driven pipeline engine with six step kinds, step-level policies, artefact hand-off, and persistence.
 
-- **Types**: `WorkflowSpec`, `Step`, `StepKind` (`Tool`/`ToolRemote`/`Foreach`/`Parallel`/`Approve`/`Branch`), `WorkflowStatus`, `WorkflowJob` (placeholder)
-- **Parser / validator**: `WorkflowSpec::from_yaml(&str)` + `validate()` — checks unique step ids, SEP-986 tool names, JSONPath in `branch.on` / `foreach.items`
-- **Catalog**: `WorkflowCatalog::from_skill(&SkillMetadata, skill_root)` reads the `metadata["dcc-mcp.workflows"]` glob (comma-separated OK), header-only parse
-- **Tools**: `workflows.run` / `workflows.get_status` / `workflows.cancel` (stubs returning `"step execution pending follow-up PR"`) + `workflows.lookup` (functional)
-- **HTTP server gate**: `McpHttpConfig::enable_workflows` (default `false`)
-- **Persistence DDL**: `workflows` + `workflow_steps` tables under the `job-persist-sqlite` feature — no writer yet
-- **Python**: `from dcc_mcp_core import WorkflowSpec, WorkflowStatus` — `None` when the wheel was built without `workflow`
+- **Types**: `WorkflowSpec`, `WorkflowStep`, `StepKind` (`Tool`/`ToolRemote`/`Foreach`/`Parallel`/`Approve`/`Branch`), `WorkflowStatus`, `WorkflowJob`, `WorkflowProgress`, `StepPolicy`, `RetryPolicy`, `BackoffKind`
+- **Parser / validator**: `WorkflowSpec::from_yaml_str(&str)` + `.validate()` — checks unique step ids, SEP-986 tool names, JSONPath in `branch.on` / `foreach.items`
+- **Catalog**: `WorkflowCatalog::from_skill(&SkillMetadata, skill_root)` reads the `metadata["dcc-mcp.workflows"]` glob
+- **Execution engine**: `WorkflowExecutor::run(spec, inputs, parent)` — drives steps sequentially, dispatches by kind, applies retry/timeout/idempotency policies, handles cancellation cascade
+- **Tools** (registered via `register_builtin_workflow_tools` + `register_workflow_handlers`):
+  - `workflows.run` — start a run (spec + inputs)
+  - `workflows.get_status` — poll terminal status + progress
+  - `workflows.cancel` — cancel by `workflow_id` (cascade)
+  - `workflows.lookup` — catalog search
+- **Step policies** (per-step): `timeout_secs`, `retry { max_attempts, backoff: fixed|linear|exponential, initial_delay_ms, max_delay_ms, jitter, retry_on }`, `idempotency_key`, `idempotency_scope: workflow|global`
+- **Artefact hand-off**: step outputs with `file_refs` are captured to `ArtefactStore`; downstream steps reference via `{{steps.<id>.file_refs[<i>].uri}}`
+- **Persistence**: `workflows` + `workflow_steps` tables under `job-persist-sqlite`; non-terminal rows flip to `Interrupted` on restart
+- **Python**: `from dcc_mcp_core import WorkflowSpec, WorkflowStep, StepPolicy, RetryPolicy, BackoffKind, WorkflowStatus`
 
-Full docs: `docs/api/workflow.md`.
+Full docs: `docs/guide/workflows.md`.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

This PR updates outdated documentation and fills in missing Chinese translations:

1. **Updated outdated workflow documentation** (was still marked as "skeleton"):
   - `llms.txt` — workflow section now reflects fully implemented status
   - `llms-full.txt` — complete execution engine details, step policies, artefact hand-off
   - `docs/api/workflow.md` — full API reference replacing skeleton content

2. **Translated 10 Chinese documentation placeholders**:
   - `docs/zh/guide/artefacts.md`
   - `docs/zh/guide/capabilities.md`
   - `docs/zh/guide/gateway.md`
   - `docs/zh/guide/job-persistence.md`
   - `docs/zh/guide/prompts.md`
   - `docs/zh/guide/scheduler.md`
   - `docs/zh/guide/workflows.md`
   - `docs/zh/api/observability.md`
   - `docs/zh/api/resources.md`
   - `docs/zh/api/workflow.md`

## Motivation

The workflow feature (#348) has been fully implemented since v0.14.5+, but `llms.txt`, `llms-full.txt`, and `docs/api/workflow.md` were still describing it as a "skeleton" with "step execution pending follow-up PR". This misleads AI agents reading these files.

Additionally, 10 Chinese documentation files were only 3-line placeholders pointing to English docs, creating a poor experience for Chinese-speaking users.