### PR TITLE
fix(gateway): prune dead SSE backends, flush logs in real-time, isolate multi-instance log files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,9 @@ Need to interact with DCC?
 → Timeout path: returns the last-known envelope with `_meta.dcc.timed_out=true` and leaves the job running
 
 **Enable durable rolling file logs (multi-gateway debugging)?**
-→ `FileLoggingConfig` + `init_file_logging()` / `shutdown_file_logging()`
+→ `FileLoggingConfig` + `init_file_logging()` / `shutdown_file_logging()` / `flush_logs()`
+→ `flush_logs()` forces buffered events to disk immediately — use after errors or from a periodic timer (issue #402)
+→ `DccServerBase` writes to `dcc-mcp-<dcc_name>.<pid>.<date>.log` — PID isolates multi-instance files
 → Environment vars: `DCC_MCP_LOG_DIR`, `DCC_MCP_LOG_MAX_SIZE`, `DCC_MCP_LOG_ROTATION`
 
 **Deploying `dcc-mcp-server` to production (Docker, systemd, k8s, LB)?**
@@ -726,7 +728,7 @@ json_str = result.to_json()    # JSON string
 - Use Conventional Commits for PR titles — `feat:`, `fix:`, `docs:`, `refactor:`
 - Use `registry.list_actions()` (shows all) vs `registry.list_actions_enabled()` (active only)
 - Start with `search_skills(query)` when looking for a tool — don't guess tool names. As of #340 `search_skills` also accepts `tags`, `dcc`, `scope`, and `limit`; call it with no arguments to browse by trust scope. `find_skills` is a deprecated alias (removal in v0.17).
-- Use `init_file_logging(FileLoggingConfig(...))` for durable logs in multi-gateway setups
+- Use `init_file_logging(FileLoggingConfig(...))` for durable logs in multi-gateway setups; call `flush_logs()` to force events to disk immediately
 - Rely on bare tool names in `tools/call` — both `execute_python` and `maya-scripting.execute_python` work during the one-release grace window
 
 ### Don't ❌

--- a/crates/dcc-mcp-http/src/gateway/mod.rs
+++ b/crates/dcc-mcp-http/src/gateway/mod.rs
@@ -420,9 +420,14 @@ async fn start_gateway_tasks(
                     .map(|e| format!("http://{}:{}/mcp", e.host, e.port))
                     .collect()
             };
-            for url in urls {
-                sub_for_task.ensure_subscribed(&url);
+            // Add subscriptions for newly-appeared backends.
+            for url in &urls {
+                sub_for_task.ensure_subscribed(url);
             }
+            // Remove subscriptions for backends that have disappeared from the
+            // registry (stale / dead). Without this the reconnect loop runs
+            // indefinitely for ports that no longer exist. Issue #402.
+            sub_for_task.prune_unlisted(&urls);
         }
     });
 

--- a/crates/dcc-mcp-http/src/gateway/sse_subscriber.rs
+++ b/crates/dcc-mcp-http/src/gateway/sse_subscriber.rs
@@ -568,6 +568,43 @@ impl SubscriberManager {
         );
     }
 
+    /// Abort and remove any subscriber whose URL is **not** in `live_urls`.
+    ///
+    /// Called after each `FileRegistry` scan so that dead backends (ports that
+    /// have gone away or become stale) stop burning reconnect-loop cycles and
+    /// log spam. Issue #402.
+    pub fn prune_unlisted(&self, live_urls: &[String]) {
+        let dead: Vec<String> = self
+            .inner
+            .backends
+            .iter()
+            .filter_map(|e| {
+                if !live_urls.contains(e.key()) {
+                    Some(e.key().clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        for url in &dead {
+            if let Some((_, mut sub)) = self.inner.backends.remove(url) {
+                sub.abort();
+                tracing::debug!(
+                    backend = %url,
+                    "gateway SSE: pruned subscriber for dead/stale backend"
+                );
+            }
+        }
+        if !dead.is_empty() {
+            tracing::info!(
+                pruned = dead.len(),
+                "gateway SSE: removed {} dead backend subscriber(s)",
+                dead.len()
+            );
+        }
+    }
+
     // ── Route GC (#322) ────────────────────────────────────────────────
 
     /// Spawn a background task that periodically evicts stale

--- a/crates/dcc-mcp-utils/src/file_logging.rs
+++ b/crates/dcc-mcp-utils/src/file_logging.rs
@@ -505,6 +505,11 @@ fn prune_old(directory: &Path, prefix: &str, max_files: usize) {
 struct FileLoggingHandles {
     guard: WorkerGuard,
     config: FileLoggingConfig,
+    /// Shared `Inner` from the live `RollingFileWriter`. Cloning the writer
+    /// is cheap (it only clones the `Arc`) so we keep a copy here to service
+    /// `flush_logs()` calls from Python / Rust without going through the
+    /// async `tracing_appender` channel (issue #402).
+    writer_inner: Arc<Mutex<Inner>>,
 }
 
 static HANDLES: OnceLock<parking_lot::Mutex<Option<FileLoggingHandles>>> = OnceLock::new();
@@ -528,7 +533,8 @@ pub fn init_file_logging(config: FileLoggingConfig) -> Result<PathBuf, FileLoggi
     crate::log_config::init_logging();
 
     let writer = RollingFileWriter::new(&config)?;
-    let directory = writer.inner.lock().directory.clone();
+    let writer_inner = writer.inner.clone();
+    let directory = writer_inner.lock().directory.clone();
 
     let (non_blocking, guard): (NonBlocking, WorkerGuard) = tracing_appender::non_blocking(writer);
 
@@ -546,9 +552,30 @@ pub fn init_file_logging(config: FileLoggingConfig) -> Result<PathBuf, FileLoggi
     *handles_slot().lock() = Some(FileLoggingHandles {
         guard,
         config: config.clone(),
+        writer_inner,
     });
 
     Ok(directory)
+}
+
+/// Flush any buffered log events to disk immediately.
+///
+/// `tracing_appender::non_blocking` batches writes on a background
+/// thread and only guarantees a flush on rotation or `WorkerGuard` drop.
+/// For long-running DCC sessions (Maya, Blender…) this means the log
+/// file can appear empty or stale until the process exits.
+///
+/// Calling `flush_logs()` forces the underlying `RollingFileWriter` to
+/// flush its OS page-cache buffers, making all events written so far
+/// visible on disk immediately. Issue #402.
+///
+/// Safe to call from any thread. Returns `Ok(())` when no file layer is
+/// installed (no-op).
+pub fn flush_logs() -> std::io::Result<()> {
+    if let Some(handles) = handles_slot().lock().as_ref() {
+        handles.writer_inner.lock().current.flush()?;
+    }
+    Ok(())
 }
 
 /// Uninstall the rolling-file layer (console output is unaffected).
@@ -750,6 +777,21 @@ pub mod python {
     #[pyo3(name = "shutdown_file_logging")]
     pub fn py_shutdown_file_logging() -> PyResult<()> {
         shutdown_file_logging()?;
+        Ok(())
+    }
+
+    /// Flush buffered log events to disk immediately.
+    ///
+    /// `tracing_appender::non_blocking` batches writes on a background thread
+    /// and only guarantees a flush on rotation or process exit. For
+    /// long-running DCC sessions this means the log file can appear empty or
+    /// stale. Call `flush_logs()` to force all buffered events to disk now —
+    /// useful after an error, before opening the log viewer, or from a
+    /// periodic Python timer. Issue #402.
+    #[pyfunction]
+    #[pyo3(name = "flush_logs")]
+    pub fn py_flush_logs() -> PyResult<()> {
+        super::flush_logs().map_err(pyo3::exceptions::PyOSError::new_err)?;
         Ok(())
     }
 

--- a/docs/api/utilities.md
+++ b/docs/api/utilities.md
@@ -279,3 +279,8 @@ shutdown_file_logging()
 |----------|---------|-------------|
 | `init_file_logging(config=None)` | `str` | Install (or swap) the rolling-file layer. Returns resolved log directory. |
 | `shutdown_file_logging()` | `None` | Uninstall the file-logging layer. |
+| `flush_logs()` | `None` | Flush buffered log events to disk immediately. `tracing_appender` batches writes on a background thread — call this after an error, before opening the log viewer, or from a periodic timer to make entries visible before process exit. No-op when file logging is not installed. (issue #402) |
+
+> **Multi-instance isolation**: `DccServerBase` automatically includes the process PID in the log
+> file prefix — `dcc-mcp-<dcc_name>.<pid>.<YYYYMMDD>.log` — so multiple instances of the same
+> DCC application on the same machine write to distinct, non-interleaved files.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2081,7 +2081,7 @@ get_app_skill_paths_from_env("blender") # -> List[str] from DCC_MCP_BLENDER_SKIL
 Rolling file logging for durable, multi-process debugging. Console output (stderr) is unaffected.
 
 ```python
-from dcc_mcp_core import FileLoggingConfig, init_file_logging, shutdown_file_logging
+from dcc_mcp_core import FileLoggingConfig, init_file_logging, shutdown_file_logging, flush_logs
 
 # Quick start — reads DCC_MCP_LOG_* env vars
 log_dir = init_file_logging()   # returns resolved directory
@@ -2098,6 +2098,9 @@ init_file_logging(FileLoggingConfig(
 # Swap at runtime (idempotent)
 init_file_logging(FileLoggingConfig.from_env())
 
+# Flush buffered events to disk immediately (issue #402)
+flush_logs()
+
 # Uninstall; console stays active
 shutdown_file_logging()
 ```
@@ -2110,6 +2113,14 @@ shutdown_file_logging()
 | `max_files` | `int` | `7` | Retention cap for rolled files (current excluded) |
 | `rotation` | `str` | `"both"` | `"size"`, `"daily"`, or `"both"` |
 | `include_console` | `bool` | `True` | Reserved; console always active today |
+
+**Functions:**
+- `init_file_logging(config=None) -> str` — install (or swap) the rolling-file layer. Returns resolved log directory.
+- `shutdown_file_logging()` — uninstall the file-logging layer; console unaffected.
+- `flush_logs()` — flush buffered log events to disk immediately. `tracing_appender` batches writes on a background thread; this bypasses the async channel and forces an OS-level flush. No-op when no file layer is installed. (issue #402)
+
+**Multi-instance isolation**: `DccServerBase` appends the PID to the log file prefix:
+`dcc-mcp-<dcc_name>.<pid>.<YYYYMMDD>.log` — so two Maya processes never share a file.
 
 **Environment variables** (read by `FileLoggingConfig.from_env()`):
 - `DCC_MCP_LOG_DIR` — directory override

--- a/llms.txt
+++ b/llms.txt
@@ -363,6 +363,8 @@ tools:
 - `FileLoggingConfig(directory=None, file_name_prefix="dcc-mcp", max_size_bytes=10485760, max_files=7, rotation="both", include_console=True)` — rolling file logger config. `FileLoggingConfig.from_env()` reads `DCC_MCP_LOG_*` env vars.
 - `init_file_logging(config=None) -> str` — install (or swap) the rolling-file layer. Returns resolved log directory.
 - `shutdown_file_logging()` — uninstall the file-logging layer; console unaffected.
+- `flush_logs()` — flush buffered log events to disk immediately; no-op when file logging is not installed. (issue #402)
+- Note: `DccServerBase` writes to `dcc-mcp-<dcc_name>.<pid>.<YYYYMMDD>.log` — PID is included to isolate multi-instance log files.
 
 ### Constants (`dcc_mcp_core`)
 

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -160,6 +160,7 @@ from dcc_mcp_core._core import create_skill_server
 from dcc_mcp_core._core import deserialize_result
 from dcc_mcp_core._core import error_result
 from dcc_mcp_core._core import expand_transitive_dependencies
+from dcc_mcp_core._core import flush_logs
 from dcc_mcp_core._core import from_exception
 from dcc_mcp_core._core import gc_orphans
 from dcc_mcp_core._core import get_app_skill_paths_from_env
@@ -431,6 +432,7 @@ __all__ = [
     "deserialize_result",
     "error_result",
     "expand_transitive_dependencies",
+    "flush_logs",
     "from_exception",
     "gc_orphans",
     "get_app_skill_paths_from_env",

--- a/python/dcc_mcp_core/_core.pyi
+++ b/python/dcc_mcp_core/_core.pyi
@@ -4614,6 +4614,21 @@ def shutdown_file_logging() -> None:
     """Uninstall the file-logging layer; console output is unaffected."""
     ...
 
+def flush_logs() -> None:
+    """Flush buffered log events to disk immediately.
+
+    ``tracing_appender::non_blocking`` batches writes on a background thread
+    and only guarantees a flush on log rotation or process exit.  For
+    long-running DCC sessions (Maya, Blender, Houdini…) this means the log
+    file can appear empty or stale until the process exits.
+
+    Call ``flush_logs()`` to force all buffered events to disk right now —
+    useful after an error, before opening the log viewer, or from a periodic
+    Python timer.  Safe to call when no file layer is installed (no-op).
+    Issue #402.
+    """
+    ...
+
 # ── Workflow primitive (issue #348, skeleton) ────────────────────────────────
 #
 # Only WorkflowSpec / WorkflowStatus are Python-visible in this release.

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -98,7 +98,7 @@ class DccServerBase:
         enable_file_logging: Automatically initialise rolling file logging on
             construction so that all ``tracing`` events (Rust) and Python
             ``logging`` records are written to
-            ``<log_dir>/dcc-mcp-<dcc_name>.<date>.log``.  Set
+            ``<log_dir>/dcc-mcp-<dcc_name>.<pid>.<date>.log``.  Set
             ``DCC_MCP_DISABLE_FILE_LOGGING=1`` env var to override at runtime.
             Default ``True``.
         enable_job_persistence: Persist tracked jobs to a SQLite database
@@ -217,7 +217,7 @@ class DccServerBase:
         Failures are non-fatal: a ``logger.warning`` is emitted and the
         server continues without file logging.
 
-        Log files are named ``dcc-mcp-<dcc_name>.<YYYYMMDD>.log`` and live in:
+        Log files are named ``dcc-mcp-<dcc_name>.<pid>.<YYYYMMDD>.log`` and live in:
         1. ``DCC_MCP_LOG_DIR`` env var (if set)
         2. ``<platform log dir>/dcc-mcp/`` (macOS: ``~/Library/Logs``,
            Windows: ``%LOCALAPPDATA%``, Linux: ``~/.local/share``)
@@ -230,9 +230,13 @@ class DccServerBase:
             from dcc_mcp_core import init_file_logging
 
             log_dir = os.environ.get("DCC_MCP_LOG_DIR") or get_log_dir()
+            # Include the PID in the prefix so multiple instances of the same
+            # DCC (e.g. two Maya sessions) write to distinct files and never
+            # interleave their log lines. Issue #402.
+            pid = os.getpid()
             cfg = FileLoggingConfig(
                 directory=log_dir,
-                file_name_prefix=f"dcc-mcp-{dcc_name}",
+                file_name_prefix=f"dcc-mcp-{dcc_name}.{pid}",
                 # Keep 14 daily files (two weeks of history)
                 max_files=14,
                 # 20 MiB per file — enough for a busy session without filling disks
@@ -241,10 +245,11 @@ class DccServerBase:
             )
             resolved = init_file_logging(cfg)
             logger.info(
-                "[%s] File logging enabled → %s/dcc-mcp-%s.*.log",
+                "[%s] File logging enabled → %s/dcc-mcp-%s.%s.*.log",
                 dcc_name,
                 resolved,
                 dcc_name,
+                pid,
             )
             return resolved
         except Exception as exc:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,6 +226,7 @@ fn register_utils(m: &Bound<'_, PyModule>) -> PyResult<()> {
         dcc_mcp_utils::type_wrappers::py_wrap_value,
         dcc_mcp_utils::file_logging::python::py_init_file_logging,
         dcc_mcp_utils::file_logging::python::py_shutdown_file_logging,
+        dcc_mcp_utils::file_logging::python::py_flush_logs,
         dcc_mcp_utils::file_logging::python::py_default_settings,
     );
     add_classes!(


### PR DESCRIPTION
## Summary

Fixes three related issues observed during live Maya debugging sessions (closes #402):

- **Gateway SSE subscriber leaks dead backends** — `SubscriberManager::prune_unlisted()` is now called every 2 s after each `FileRegistry` scan; subscriber tasks for stale/dead backends are aborted and removed, stopping the endless reconnect loop and log spam.
- **Logs not flushed in real time** — new `flush_logs()` function (Rust + Python) directly flushes the `RollingFileWriter` file handle, bypassing the `tracing_appender` async channel. Useful after errors or from a periodic Python timer to make log entries visible immediately.
- **Multi-instance log file collision** — `DccServerBase._init_file_logging` now includes the process PID in the file-name prefix (`dcc-mcp-maya.<pid>.<date>.log`), so multiple DCC instances on the same machine write to distinct, non-interleaved files.

## Changes

| File | Change |
|------|--------|
| `crates/dcc-mcp-http/src/gateway/sse_subscriber.rs` | Add `SubscriberManager::prune_unlisted(&[String])` |
| `crates/dcc-mcp-http/src/gateway/mod.rs` | Call `prune_unlisted` after every registry scan in `backend_sub_handle` task |
| `crates/dcc-mcp-utils/src/file_logging.rs` | Hold `writer_inner: Arc<Mutex<Inner>>` in `FileLoggingHandles`; add `flush_logs()` + PyO3 binding `py_flush_logs` |
| `src/lib.rs` | Register `py_flush_logs` in `register_utils` |
| `python/dcc_mcp_core/__init__.py` | Export `flush_logs`; add to `__all__` |
| `python/dcc_mcp_core/_core.pyi` | Add `flush_logs()` type stub |
| `python/dcc_mcp_core/server_base.py` | Append PID to log file prefix |

## Test plan

- [ ] Start two Maya instances; confirm each writes to its own `dcc-mcp-maya.<pid>.<date>.log`
- [ ] Kill a backend DCC process; confirm the gateway stops reconnect attempts within ~4 s (2 registry scan cycles)
- [ ] Call `flush_logs()` from Python; confirm log file is non-empty before process exit
- [ ] Existing gateway + SSE tests pass (`vx just test`)
