### PR TITLE
docs: document remote-server extensions from issues #404-#411

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,11 @@ A Rust-powered MCP (Model Context Protocol) library that lets AI agents interact
 | Trust-based skill scoping | `SkillScope` (Repo → User → System → Admin) — **Rust-only**; Python uses string values via `SkillMetadata` |
 | Progressive tool exposure | `SkillGroup` with `default_active` + `activate_tool_group()` |
 | Instance-bound diagnostics | `DccServerBase(..., dcc_pid=pid)` → scoped `diagnostics__*` tools |
+| Remote-server auth (API key / OAuth / CIMD) | `ApiKeyConfig`, `OAuthConfig`, `validate_bearer_token`, `McpHttpConfig.api_key` |
+| Batch tool calls / sandboxed script orchestration | `batch_dispatch()`, `EvalContext`, `DccApiExecutor` (2-tool Cloudflare pattern) |
+| Mid-call user input (confirm destructive, fill missing param, OAuth) | `elicit_form()`, `elicit_url()`, `elicit_form_sync()` |
+| Inline chart / table / image tool results (MCP Apps) | `skill_success_with_chart/table/image`, `RichContent`, `attach_rich_content()` |
+| Claude Code one-click plugin bundle | `build_plugin_manifest()`, `DccServerBase.plugin_manifest()` |
 
 **The three files that define the entire public API surface — read them in this order:**
 
@@ -268,6 +273,30 @@ Need to interact with DCC?
 → Pipeline: `spec → validate → spawn driver → drive(steps) → per-step policy (retry+timeout+idempotency) → dispatch by kind → artefact handoff → SSE `$/dcc.workflowUpdated` → sqlite upsert → next step`.
 → Cancellation cascades from root `CancellationToken` to every step driver and caller; interrupt propagation bounded by one cooperative checkpoint.
 → With `job-persist-sqlite`: non-terminal rows flip to `interrupted` on restart (no auto-resume).
+
+**Expose an MCP server to cloud-hosted agents (Claude.ai, Cursor, ChatGPT, VS Code)?**
+→ [`docs/guide/remote-server.md`](docs/guide/remote-server.md) — `host="0.0.0.0"`, CORS, API key / OAuth, Docker + reverse-proxy TLS recipes
+→ Example: [`examples/remote-server/`](examples/remote-server/) — minimal deployable server + hello-world skill + Dockerfile + docker-compose
+→ Auth: `ApiKeyConfig` / `OAuthConfig` / `CimdDocument` / `validate_bearer_token` / `generate_api_key` — see [`docs/api/auth.md`](docs/api/auth.md)
+
+**Reduce tool-call round-trips by batching or code-orchestration (issues #406, #411)?**
+→ [`docs/api/batch.md`](docs/api/batch.md) — `batch_dispatch()` (sequential N-call summary) and `EvalContext` (sandboxed script with `dispatch()`)
+→ [`docs/api/dcc-api-executor.md`](docs/api/dcc-api-executor.md) — `DccApiCatalog` + `DccApiExecutor` + `register_dcc_api_executor()` — the 2-tool "Cloudflare pattern" that covers 2000+ DCC commands in ~500 tokens
+→ Python helpers ship now; Rust-level `tools/batch` + `dcc_mcp_core__eval` + `dcc_search` / `dcc_execute` built-ins land in follow-up PRs
+
+**Pause a tool call to ask the user for input (issue #407)?**
+→ [`docs/api/elicitation.md`](docs/api/elicitation.md) — `elicit_form` (async), `elicit_form_sync` (DCC main-thread), `elicit_url` (OAuth / payment / credential flows)
+→ Types: `ElicitationMode`, `ElicitationRequest`, `ElicitationResponse`, `FormElicitation`, `UrlElicitation`
+→ Status: stubs return `accepted=False, message="elicitation_not_supported"` until Rust transport support lands — design handlers now, upgrade automatically
+
+**Return rich inline UI (chart / form / image / table / dashboard) — MCP Apps (issue #409)?**
+→ [`docs/api/rich-content.md`](docs/api/rich-content.md) — `RichContent.{chart,form,image,table,dashboard}`, `attach_rich_content()`
+→ Skill-script helpers: `skill_success_with_chart()` / `skill_success_with_table()` / `skill_success_with_image()`
+→ Stored today under `result.context["__rich__"]`; Rust-side MCP Apps envelope wiring tracked in #409
+
+**Bundle your server as a Claude Code one-click plugin (issue #410)?**
+→ [`docs/api/plugin-manifest.md`](docs/api/plugin-manifest.md) — `PluginManifest`, `build_plugin_manifest()`, `export_plugin_manifest()`
+→ Recommended: `DccServerBase.plugin_manifest(version=...)` — auto-fills `mcp_url` + `skill_paths` from the running server
 
 **Validate tool names or action IDs (SEP-986)?**
 → [`docs/guide/naming.md`](docs/guide/naming.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,14 @@ Need to interact with DCC?
 → `crates/dcc-mcp-http/src/gateway/sse_subscriber.rs` — `SubscriberManager`, `BackendSubscriber`
 → Correlation: `progressToken` (progress) + `job_id` (`$/dcc.jobUpdated` / `$/dcc.workflowUpdated`)
 → On backend reconnect, clients with in-flight jobs receive `$/dcc.gatewayReconnect`
+→ **Self-loop guard (#419)**: when a DCC process wins gateway election
+ the facade filters its own `(host, port)` out of fan-out targets —
+ see `is_own_instance` in `crates/dcc-mcp-http/src/gateway/sentinel.rs`
+ and `GatewayState::live_instances` in `state.rs`.
+→ **Pre-subscribe hygiene (#419)**: `start_gateway_tasks` runs a
+ synchronous `prune_dead_pids` + `cleanup_stale` pass **before**
+ spawning the backend SSE loop, so the first two-second tick does not
+ waste reconnect budget on ghost rows left behind by a previous crash.
 
 **Gateway async-dispatch timeout + wait-for-terminal passthrough (#321)?**
 → [`docs/guide/gateway.md`](docs/guide/gateway.md) — "Waiting for terminal results from the gateway"

--- a/crates/dcc-mcp-http/src/gateway/aggregator.rs
+++ b/crates/dcc-mcp-http/src/gateway/aggregator.rs
@@ -24,6 +24,7 @@ mod wait_terminal;
 
 pub use call::route_tools_call;
 pub use fingerprint::compute_tools_fingerprint;
+pub(crate) use fingerprint::compute_tools_fingerprint_with_own;
 pub(crate) use helpers::{
     envelope_to_text_result, extract_job_id, find_instance_by_prefix, inject_instance_metadata,
     live_backends, meta_signals_async_dispatch, meta_wants_wait_for_terminal, resolve_target,

--- a/crates/dcc-mcp-http/src/gateway/aggregator/fingerprint.rs
+++ b/crates/dcc-mcp-http/src/gateway/aggregator/fingerprint.rs
@@ -10,6 +10,11 @@ use super::*;
 ///
 /// Deliberately excludes tool descriptions / schemas: we only want to detect
 /// set-level add/remove changes, not metadata edits.
+///
+/// `own_host` / `own_port` identify the gateway's own facade so its own
+/// plain-instance row (present when a DCC process wins gateway election)
+/// is skipped — see issue #419. Pass `None`/`0` to disable the filter;
+/// tests that do not care about self-exclusion use this form.
 pub async fn compute_tools_fingerprint(
     registry: &std::sync::Arc<
         tokio::sync::RwLock<dcc_mcp_transport::discovery::file_registry::FileRegistry>,
@@ -17,6 +22,29 @@ pub async fn compute_tools_fingerprint(
     stale_timeout: Duration,
     http_client: &reqwest::Client,
     backend_timeout: Duration,
+) -> String {
+    compute_tools_fingerprint_with_own(
+        registry,
+        stale_timeout,
+        http_client,
+        backend_timeout,
+        None,
+        0,
+    )
+    .await
+}
+
+/// Same as [`compute_tools_fingerprint`] but also filters out the gateway's
+/// own plain-instance row (issue #419).
+pub(crate) async fn compute_tools_fingerprint_with_own(
+    registry: &std::sync::Arc<
+        tokio::sync::RwLock<dcc_mcp_transport::discovery::file_registry::FileRegistry>,
+    >,
+    stale_timeout: Duration,
+    http_client: &reqwest::Client,
+    backend_timeout: Duration,
+    own_host: Option<&str>,
+    own_port: u16,
 ) -> String {
     let instances: Vec<ServiceEntry> = {
         let reg = registry.read().await;
@@ -30,6 +58,10 @@ pub async fn compute_tools_fingerprint(
                         dcc_mcp_transport::discovery::types::ServiceStatus::ShuttingDown
                             | dcc_mcp_transport::discovery::types::ServiceStatus::Unreachable
                     )
+                    && match own_host {
+                        Some(h) => !super::super::is_own_instance(e, h, own_port),
+                        None => true,
+                    }
             })
             .collect()
     };

--- a/crates/dcc-mcp-http/src/gateway/mod.rs
+++ b/crates/dcc-mcp-http/src/gateway/mod.rs
@@ -85,7 +85,7 @@ pub use config::GatewayConfig;
 pub(crate) use handle::ElectionOutcome;
 pub use handle::GatewayHandle;
 pub use runner::GatewayRunner;
-pub(crate) use sentinel::has_newer_sentinel;
+pub(crate) use sentinel::{has_newer_sentinel, is_own_instance};
 pub(crate) use tasks::start_gateway_tasks;
 pub(crate) use version::is_newer_version;
 

--- a/crates/dcc-mcp-http/src/gateway/runner.rs
+++ b/crates/dcc-mcp-http/src/gateway/runner.rs
@@ -181,6 +181,8 @@ impl GatewayRunner {
                     format!("{} (gateway)", self.config.server_name),
                     own_version.clone(),
                     sentinel_key,
+                    self.config.host.clone(),
+                    self.config.gateway_port,
                 )
                 .await
                 {
@@ -343,6 +345,8 @@ impl GatewayRunner {
                         format!("{server_name} (gateway)"),
                         own_ver.clone(),
                         sentinel_key,
+                        host.clone(),
+                        port,
                     )
                     .await
                     {

--- a/crates/dcc-mcp-http/src/gateway/sentinel.rs
+++ b/crates/dcc-mcp-http/src/gateway/sentinel.rs
@@ -2,6 +2,41 @@ use super::*;
 
 use dcc_mcp_transport::discovery::file_registry::FileRegistry;
 
+/// Normalise a host string to a canonical form so that `127.0.0.1`,
+/// `localhost`, and `::1` compare equal when we ask "is this entry my own
+/// address?".
+///
+/// We can't rely on full DNS resolution here — the gateway runs in embedded
+/// hosts (mayapy, Blender's Python) where blocking DNS lookups are a very
+/// bad idea — so we do a cheap textual normalisation instead. This is
+/// sufficient because every real binding in `GatewayConfig` is an IP
+/// literal or the string `"localhost"` (see `GatewayConfig::default`).
+fn normalise_host(host: &str) -> &str {
+    match host {
+        "localhost" | "::1" | "0.0.0.0" | "[::]" | "[::0]" => "127.0.0.1",
+        other => other,
+    }
+}
+
+/// Is `entry` the gateway's own advertised (host, port) pair?
+///
+/// Issue #419: when a DCC process (Maya/Blender/Houdini) wins the gateway
+/// election it keeps its plain-instance `ServiceEntry` in `FileRegistry`
+/// alongside the `__gateway__` sentinel. Without this filter the gateway's
+/// backend-SSE subscriber would open a connection to its own `/mcp` endpoint
+/// — a classic self-loop that wastes a socket and floods the reconnect logs
+/// whenever the facade blips.
+///
+/// The sentinel row is filtered elsewhere via `GATEWAY_SENTINEL_DCC_TYPE`;
+/// this helper is for the plain DCC row.
+pub(crate) fn is_own_instance(
+    entry: &dcc_mcp_transport::discovery::types::ServiceEntry,
+    own_host: &str,
+    own_port: u16,
+) -> bool {
+    entry.port == own_port && normalise_host(&entry.host) == normalise_host(own_host)
+}
+
 /// Helper: does the sentinel advertise a newer gateway version than us?
 ///
 /// Issue #228: the old implementation scanned every DCC instance entry and
@@ -29,4 +64,39 @@ pub(crate) fn has_newer_sentinel(
                     .map(|v| is_newer_version(v, own_version))
                     .unwrap_or(false)
         })
+}
+
+#[cfg(test)]
+mod own_instance_tests {
+    use super::*;
+    use dcc_mcp_transport::discovery::types::ServiceEntry;
+
+    #[test]
+    fn exact_host_and_port_match() {
+        let e = ServiceEntry::new("maya", "127.0.0.1", 9765);
+        assert!(is_own_instance(&e, "127.0.0.1", 9765));
+    }
+
+    #[test]
+    fn port_mismatch_is_not_self() {
+        let e = ServiceEntry::new("maya", "127.0.0.1", 18812);
+        assert!(!is_own_instance(&e, "127.0.0.1", 9765));
+    }
+
+    #[test]
+    fn localhost_aliases_collapse_to_loopback() {
+        for alias in ["localhost", "::1", "0.0.0.0", "[::]"] {
+            let e = ServiceEntry::new("maya", alias, 9765);
+            assert!(
+                is_own_instance(&e, "127.0.0.1", 9765),
+                "alias {alias} must match 127.0.0.1"
+            );
+        }
+    }
+
+    #[test]
+    fn distinct_remote_host_is_not_self() {
+        let e = ServiceEntry::new("maya", "10.0.0.5", 9765);
+        assert!(!is_own_instance(&e, "127.0.0.1", 9765));
+    }
 }

--- a/crates/dcc-mcp-http/src/gateway/state.rs
+++ b/crates/dcc-mcp-http/src/gateway/state.rs
@@ -38,6 +38,16 @@ pub struct GatewayState {
     pub server_name: String,
     /// The version string of this gateway instance (e.g. `"0.12.29"`).
     pub server_version: String,
+    /// Host the gateway is bound to (issue #419).
+    ///
+    /// Used together with [`Self::own_port`] to filter this gateway's own
+    /// plain-instance row out of fan-out targets — without the filter, a
+    /// DCC that wins gateway election would subscribe to its own `/mcp`
+    /// endpoint via [`super::sse_subscriber::SubscriberManager`] and every
+    /// `tools/list` / `tools/call` fan-out would recurse back into itself.
+    pub own_host: String,
+    /// Port the gateway's facade listens on (issue #419).
+    pub own_port: u16,
     pub http_client: reqwest::Client,
     /// Sending side of the voluntary-yield channel.
     ///
@@ -88,6 +98,11 @@ impl GatewayState {
     /// user-facing tool output (`list_dcc_instances`, `get_dcc_instance`,
     /// `connect_to_dcc`) would confuse agents and break the `mcp_url` contract
     /// (the sentinel's host:port points at the gateway facade, not a real DCC).
+    ///
+    /// The gateway's **own plain-instance row** is also excluded (issue #419).
+    /// When a DCC process (e.g. Maya) wins gateway election it keeps both the
+    /// sentinel and a regular `"maya"` row; exposing its own row here would
+    /// cause the facade to fan `tools/list` / `tools/call` back into itself.
     pub fn live_instances(&self, registry: &FileRegistry) -> Vec<ServiceEntry> {
         registry
             .list_all()
@@ -99,6 +114,7 @@ impl GatewayState {
                         e.status,
                         ServiceStatus::ShuttingDown | ServiceStatus::Unreachable
                     )
+                    && !super::is_own_instance(e, &self.own_host, self.own_port)
             })
             .collect()
     }
@@ -142,6 +158,14 @@ mod tests {
     use tokio::sync::{RwLock, broadcast, watch};
 
     fn test_gateway_state(reg: Arc<RwLock<FileRegistry>>) -> GatewayState {
+        test_gateway_state_with_own(reg, "127.0.0.1", 9765)
+    }
+
+    fn test_gateway_state_with_own(
+        reg: Arc<RwLock<FileRegistry>>,
+        own_host: &str,
+        own_port: u16,
+    ) -> GatewayState {
         let (yield_tx, _) = watch::channel(false);
         let (events_tx, _) = broadcast::channel::<String>(8);
         GatewayState {
@@ -152,6 +176,8 @@ mod tests {
             wait_terminal_timeout: Duration::from_secs(600),
             server_name: "test".into(),
             server_version: env!("CARGO_PKG_VERSION").into(),
+            own_host: own_host.to_string(),
+            own_port,
             http_client: reqwest::Client::new(),
             yield_tx: Arc::new(yield_tx),
             events_tx: Arc::new(events_tx),
@@ -189,6 +215,66 @@ mod tests {
         assert!(
             !live.iter().any(|e| e.dcc_type == GATEWAY_SENTINEL_DCC_TYPE),
             "gateway sentinel must never appear in user-facing listings"
+        );
+    }
+
+    /// Regression test for issue #419: when the gateway process is also a
+    /// DCC instance (e.g. Maya that won the gateway election), its own
+    /// plain-instance row must be hidden from `live_instances` so the
+    /// facade does not fan `tools/list` / `tools/call` back into itself.
+    #[tokio::test]
+    async fn test_live_instances_excludes_gateway_self_row() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
+
+        {
+            let r = registry.read().await;
+            // The sentinel + the gateway's own DCC row share host/port.
+            let mut sentinel = ServiceEntry::new(GATEWAY_SENTINEL_DCC_TYPE, "127.0.0.1", 9765);
+            sentinel.version = Some(env!("CARGO_PKG_VERSION").into());
+            r.register(sentinel).unwrap();
+
+            // Self DCC row — same host/port as the gateway facade.
+            let maya_self = ServiceEntry::new("maya", "127.0.0.1", 9765);
+            r.register(maya_self).unwrap();
+
+            // A second Maya instance on a different port — must survive.
+            let maya_other = ServiceEntry::new("maya", "127.0.0.1", 18812);
+            r.register(maya_other).unwrap();
+        }
+
+        let gs = test_gateway_state_with_own(registry.clone(), "127.0.0.1", 9765);
+        let live = gs.live_instances(&*registry.read().await);
+        assert_eq!(
+            live.len(),
+            1,
+            "only the non-self maya row should remain; got {live:#?}"
+        );
+        assert_eq!(live[0].port, 18812);
+    }
+
+    /// Regression test for issue #419: `localhost` / `::1` / `0.0.0.0` must
+    /// all normalise to the same address so that a gateway bound on
+    /// `127.0.0.1` still filters out a self-row advertised as `localhost`
+    /// (DCC adapters vary in how they populate `ServiceEntry::host`).
+    #[tokio::test]
+    async fn test_live_instances_self_row_localhost_aliases() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
+
+        {
+            let r = registry.read().await;
+            // Self row advertised as "localhost" — must still be filtered
+            // when the gateway is bound to 127.0.0.1.
+            let maya_self = ServiceEntry::new("maya", "localhost", 9765);
+            r.register(maya_self).unwrap();
+        }
+
+        let gs = test_gateway_state_with_own(registry.clone(), "127.0.0.1", 9765);
+        let live = gs.live_instances(&*registry.read().await);
+        assert!(
+            live.is_empty(),
+            "self row with localhost alias must be filtered; got {live:#?}"
         );
     }
 }

--- a/crates/dcc-mcp-http/src/gateway/tasks.rs
+++ b/crates/dcc-mcp-http/src/gateway/tasks.rs
@@ -35,6 +35,8 @@ pub(crate) async fn start_gateway_tasks(
     server_name: String,
     server_version: String,
     sentinel_key: ServiceKey,
+    own_host: String,
+    own_port: u16,
 ) -> Result<GatewayTasks, Box<dyn std::error::Error + Send + Sync>> {
     // ── Yield channel ─────────────────────────────────────────────────────
     let (yield_tx, mut yield_rx) = watch::channel(false);
@@ -103,6 +105,8 @@ pub(crate) async fn start_gateway_tasks(
     // `notifications/resources/list_changed` to all connected SSE clients.
     let reg_watch = registry.clone();
     let events_tx_watch = events_tx.clone();
+    let watch_own_host = own_host.clone();
+    let watch_own_port = own_port;
     let watcher_handle = tokio::spawn(async move {
         let mut interval = tokio::time::interval(Duration::from_secs(2));
         // Fingerprint = sorted "dcc_type:instance_id" strings of live instances.
@@ -117,7 +121,9 @@ pub(crate) async fn start_gateway_tasks(
                     .list_all()
                     .into_iter()
                     .filter(|e| {
-                        e.dcc_type != GATEWAY_SENTINEL_DCC_TYPE && !e.is_stale(stale_timeout)
+                        e.dcc_type != GATEWAY_SENTINEL_DCC_TYPE
+                            && !e.is_stale(stale_timeout)
+                            && !is_own_instance(e, &watch_own_host, watch_own_port)
                     })
                     .map(|e| format!("{}:{}", e.dcc_type, e.instance_id))
                     .collect();
@@ -157,6 +163,8 @@ pub(crate) async fn start_gateway_tasks(
     let reg_tools = registry.clone();
     let events_tx_tools = events_tx.clone();
     let http_client_tools = http_client.clone();
+    let tools_own_host = own_host.clone();
+    let tools_own_port = own_port;
     let tools_watcher_handle = tokio::spawn(async move {
         let mut interval = tokio::time::interval(Duration::from_secs(3));
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -170,11 +178,13 @@ pub(crate) async fn start_gateway_tasks(
                 continue;
             }
 
-            let fingerprint = aggregator::compute_tools_fingerprint(
+            let fingerprint = aggregator::compute_tools_fingerprint_with_own(
                 &reg_tools,
                 stale_timeout,
                 &http_client_tools,
                 backend_timeout,
+                Some(tools_own_host.as_str()),
+                tools_own_port,
             )
             .await;
 
@@ -210,12 +220,47 @@ pub(crate) async fn start_gateway_tasks(
     // their TTL. Terminal jobs are auto-evicted in `deliver`.
     let route_gc_handle = subscriber.spawn_route_gc();
 
+    // ── Pre-subscribe registry hygiene (issue #419) ───────────────────────
+    //
+    // Before the backend subscriber loop starts fanning SSE connections at
+    // everything in the registry, do a one-shot synchronous cleanup so we
+    // don't waste reconnect budget on ghost rows left behind by a previous
+    // crash. The periodic `cleanup_handle` above runs on a 15-second
+    // cadence; without this synchronous pass, the subscriber would see
+    // stale / dead-PID entries during the first ~15 s and pay the full
+    // exponential-backoff retry cost trying to reach them.
+    {
+        let r = registry.read().await;
+        match r.prune_dead_pids() {
+            Ok(n) if n > 0 => {
+                tracing::info!(
+                    reaped = n,
+                    "Gateway: pre-subscribe dead-PID sweep reaped ghost entry/entries"
+                );
+            }
+            Err(e) => tracing::warn!("Gateway: pre-subscribe dead-PID sweep error: {e}"),
+            _ => {}
+        }
+        match r.cleanup_stale(stale_timeout) {
+            Ok(n) if n > 0 => {
+                tracing::info!(
+                    evicted = n,
+                    "Gateway: pre-subscribe stale sweep evicted instance(s)"
+                );
+            }
+            Err(e) => tracing::warn!("Gateway: pre-subscribe stale sweep error: {e}"),
+            _ => {}
+        }
+    }
+
     // Periodically ensure every live backend has an active subscription.
     // The subscriber's internal DashMap makes repeat calls cheap, so we
     // just poll the instance registry at the same cadence as the
     // instance-change watcher.
     let reg_sub = registry.clone();
     let sub_for_task = subscriber.clone();
+    let sub_own_host = own_host.clone();
+    let sub_own_port = own_port;
     let backend_sub_handle = tokio::spawn(async move {
         let mut interval = tokio::time::interval(Duration::from_secs(2));
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -226,7 +271,9 @@ pub(crate) async fn start_gateway_tasks(
                 r.list_all()
                     .into_iter()
                     .filter(|e| {
-                        e.dcc_type != GATEWAY_SENTINEL_DCC_TYPE && !e.is_stale(stale_timeout)
+                        e.dcc_type != GATEWAY_SENTINEL_DCC_TYPE
+                            && !e.is_stale(stale_timeout)
+                            && !is_own_instance(e, &sub_own_host, sub_own_port)
                     })
                     .map(|e| format!("http://{}:{}/mcp", e.host, e.port))
                     .collect()
@@ -251,6 +298,8 @@ pub(crate) async fn start_gateway_tasks(
         wait_terminal_timeout,
         server_name,
         server_version,
+        own_host,
+        own_port,
         http_client,
         yield_tx: yield_tx.clone(),
         events_tx,

--- a/crates/dcc-mcp-http/src/tests/gateway.rs
+++ b/crates/dcc-mcp-http/src/tests/gateway.rs
@@ -24,6 +24,8 @@ fn make_gateway_state() -> GatewayState {
         wait_terminal_timeout: Duration::from_secs(600),
         server_name: "test-gateway".to_string(),
         server_version: "0.1.0".to_string(),
+        own_host: "127.0.0.1".to_string(),
+        own_port: 0,
         http_client: reqwest::Client::new(),
         yield_tx: Arc::new(yield_tx),
         events_tx: Arc::new(events_tx),

--- a/crates/dcc-mcp-http/tests/backend_timeout.rs
+++ b/crates/dcc-mcp-http/tests/backend_timeout.rs
@@ -54,6 +54,8 @@ async fn make_state(
         wait_terminal_timeout: Duration::from_secs(600),
         server_name: "test".into(),
         server_version: "0.0.0".into(),
+        own_host: "127.0.0.1".into(),
+        own_port: 0,
         http_client: reqwest::Client::new(),
         yield_tx: Arc::new(yield_tx),
         events_tx: Arc::new(events_tx),

--- a/crates/dcc-mcp-http/tests/gateway_passthrough.rs
+++ b/crates/dcc-mcp-http/tests/gateway_passthrough.rs
@@ -52,6 +52,8 @@ async fn make_state(
         wait_terminal_timeout,
         server_name: "test".into(),
         server_version: "0.0.0".into(),
+        own_host: "127.0.0.1".into(),
+        own_port: 0,
         http_client: reqwest::Client::new(),
         yield_tx: Arc::new(yield_tx),
         events_tx: Arc::new(events_tx),

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -20,7 +20,7 @@ export default defineConfig({
           { text: 'Guide', link: '/guide/what-is-dcc-mcp-core' },
           { text: 'API', link: '/api/models' },
           {
-            text: 'v0.14.6',
+            text: 'v0.14.9',
             items: [
               { text: 'Changelog', link: 'https://github.com/loonghao/dcc-mcp-core/blob/main/CHANGELOG.md' },
               { text: 'PyPI', link: 'https://pypi.org/project/dcc-mcp-core/' },
@@ -44,6 +44,7 @@ export default defineConfig({
                 { text: 'Skill Scopes & Policies', link: '/guide/skill-scopes-policies' },
                 { text: 'Gateway Election', link: '/guide/gateway-election' },
                 { text: 'Gateway', link: '/guide/gateway' },
+                { text: 'Remote Server', link: '/guide/remote-server' },
                 { text: 'Production Deployment', link: '/guide/production-deployment' },
               ]
             },
@@ -101,6 +102,17 @@ export default defineConfig({
                 { text: 'Resources', link: '/api/resources' },
                 { text: 'Workflow', link: '/api/workflow' },
               ]
+            },
+            {
+              text: 'Remote-Server Extensions',
+              items: [
+                { text: 'Auth (API Key + OAuth/CIMD)', link: '/api/auth' },
+                { text: 'Batch Dispatch', link: '/api/batch' },
+                { text: 'Elicitation', link: '/api/elicitation' },
+                { text: 'Plugin Manifest', link: '/api/plugin-manifest' },
+                { text: 'Rich Content (MCP Apps)', link: '/api/rich-content' },
+                { text: 'DCC API Executor', link: '/api/dcc-api-executor' },
+              ]
             }
           ]
         },
@@ -115,7 +127,7 @@ export default defineConfig({
           { text: '指南', link: '/zh/guide/what-is-dcc-mcp-core' },
           { text: 'API', link: '/zh/api/models' },
           {
-            text: 'v0.14.6',
+            text: 'v0.14.9',
             items: [
               { text: '更新日志', link: 'https://github.com/loonghao/dcc-mcp-core/blob/main/CHANGELOG.md' },
               { text: 'PyPI', link: 'https://pypi.org/project/dcc-mcp-core/' },
@@ -139,6 +151,7 @@ export default defineConfig({
                 { text: 'Skill 作用域与策略', link: '/zh/guide/skill-scopes-policies' },
                 { text: '网关选举机制', link: '/zh/guide/gateway-election' },
                 { text: 'Gateway', link: '/zh/guide/gateway' },
+                { text: '远程服务器', link: '/zh/guide/remote-server' },
                 { text: '生产环境部署', link: '/zh/guide/production-deployment' },
               ]
             },
@@ -195,6 +208,17 @@ export default defineConfig({
                 { text: '可观测性', link: '/zh/api/observability' },
                 { text: 'Resources', link: '/zh/api/resources' },
                 { text: 'Workflow', link: '/zh/api/workflow' },
+              ]
+            },
+            {
+              text: '远程服务器扩展',
+              items: [
+                { text: '认证 (API Key + OAuth/CIMD)', link: '/zh/api/auth' },
+                { text: '批量分发', link: '/zh/api/batch' },
+                { text: 'Elicitation 用户交互', link: '/zh/api/elicitation' },
+                { text: '插件清单', link: '/zh/api/plugin-manifest' },
+                { text: 'Rich Content (MCP Apps)', link: '/zh/api/rich-content' },
+                { text: 'DCC API Executor', link: '/zh/api/dcc-api-executor' },
               ]
             }
           ]

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -20,7 +20,7 @@ export default defineConfig({
           { text: 'Guide', link: '/guide/what-is-dcc-mcp-core' },
           { text: 'API', link: '/api/models' },
           {
-            text: 'v0.14.9',
+            text: 'v0.14.9', // x-release-please-version
             items: [
               { text: 'Changelog', link: 'https://github.com/loonghao/dcc-mcp-core/blob/main/CHANGELOG.md' },
               { text: 'PyPI', link: 'https://pypi.org/project/dcc-mcp-core/' },
@@ -127,7 +127,7 @@ export default defineConfig({
           { text: '指南', link: '/zh/guide/what-is-dcc-mcp-core' },
           { text: 'API', link: '/zh/api/models' },
           {
-            text: 'v0.14.9',
+            text: 'v0.14.9', // x-release-please-version
             items: [
               { text: '更新日志', link: 'https://github.com/loonghao/dcc-mcp-core/blob/main/CHANGELOG.md' },
               { text: 'PyPI', link: 'https://pypi.org/project/dcc-mcp-core/' },

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -1,0 +1,135 @@
+# Auth — API Key and OAuth 2.1 / CIMD
+
+> Source: [`python/dcc_mcp_core/auth.py`](https://github.com/loonghao/dcc-mcp-core/blob/main/python/dcc_mcp_core/auth.py) · Issue [#408](https://github.com/loonghao/dcc-mcp-core/issues/408)
+>
+> **[中文版](../zh/api/auth.md)**
+
+Declarative authentication configuration for remote MCP servers. Provides
+Bearer-token ("API key") auth for studio environments and OAuth 2.1 +
+[CIMD (Client ID Metadata Documents)](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#client-id-metadata-documents)
+for production cloud deployments.
+
+**When to use**
+
+- **API Key** — studio / internal network, single shared secret, no identity provider.
+- **OAuth / CIMD** — public SaaS, per-user identity, automatic client registration, token refresh via [Managed Agents Vaults](https://www.anthropic.com/news/claude-code-vaults).
+
+## Imports
+
+```python
+from dcc_mcp_core import (
+    ApiKeyConfig,
+    OAuthConfig,
+    CimdDocument,
+    TokenValidationError,
+    generate_api_key,
+    validate_bearer_token,
+)
+```
+
+## `ApiKeyConfig`
+
+Configuration dataclass for Bearer-token auth.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api_key` | `str \| None` | `None` | Literal token — overrides `env_var` when set |
+| `env_var` | `str` | `"DCC_MCP_API_KEY"` | Env var read at `.resolve()` time |
+| `header_name` | `str` | `"Authorization"` | HTTP header (`Bearer <key>` expected) |
+
+```python
+cfg = ApiKeyConfig(env_var="MY_MCP_SECRET")
+token = cfg.resolve()   # field → env var → None
+mcp_cfg.api_key = token
+```
+
+## `OAuthConfig`
+
+Declarative OAuth 2.1 configuration. Produces a [`CimdDocument`](#cimddocument)
+suitable for serving from `GET /.well-known/oauth-client-metadata`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `provider_url` | `str` | — | Base URL of the OAuth provider |
+| `client_id` | `str \| None` | `None` | Pre-registered client ID (leave `None` for CIMD dynamic registration) |
+| `scopes` | `list[str]` | `[]` | Requested OAuth scopes |
+| `client_name` | `str` | `"dcc-mcp-server"` | Human-readable server name shown in auth dialog |
+| `redirect_uri` | `str \| None` | `None` | Default redirect URI for CIMD |
+
+**Derived URLs** (read-only properties):
+
+- `authorization_endpoint` → `<provider>/authorize`
+- `token_endpoint` → `<provider>/token`
+- `well_known_url` → `<provider>/.well-known/oauth-client-metadata`
+
+```python
+oauth = OAuthConfig(
+    provider_url="https://auth.shotgrid.example.com",
+    scopes=["scene:read", "render:write"],
+    client_name="Maya MCP Server",
+)
+doc = oauth.to_cimd_document(redirect_uri="http://localhost:8765/oauth/callback")
+```
+
+## `CimdDocument`
+
+[Client ID Metadata Document](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#client-id-metadata-documents)
+for dynamic client registration. Serialise with `.to_dict()` and serve JSON
+from `/.well-known/oauth-client-metadata`.
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `client_name` | `str` | — | Shown in consent dialog |
+| `redirect_uris` | `list[str]` | — | Must include every callback used |
+| `grant_types` | `list[str]` | `["authorization_code"]` | |
+| `response_types` | `list[str]` | `["code"]` | |
+| `token_endpoint_auth_method` | `str` | `"none"` | PKCE-only public client |
+| `scope` | `str \| None` | `None` | Space-separated |
+| `logo_uri`, `client_uri`, `contacts` | optional | — | Cosmetics for consent screen |
+
+## `validate_bearer_token(headers, *, expected_token, header_name="Authorization") -> bool`
+
+Constant-time Bearer-token check for use inside pure-Python tool handlers.
+
+- Returns `True` when `expected_token is None` (auth disabled, logs a warning).
+- Returns `True` when the header equals `Bearer <expected_token>`.
+- Returns `False` on missing header, wrong scheme, or mismatch.
+- Uses [`secrets.compare_digest`](https://docs.python.org/3/library/secrets.html#secrets.compare_digest) to prevent timing attacks.
+- Case-insensitive header lookup.
+
+```python
+from dcc_mcp_core import validate_bearer_token
+
+def secure_handler(params, *, request_headers=None):
+    if not validate_bearer_token(request_headers or {}, expected_token=os.environ["DCC_MCP_API_KEY"]):
+        return {"success": False, "message": "Unauthorized"}
+    ...
+```
+
+## `generate_api_key(length: int = 32) -> str`
+
+Cryptographically secure URL-safe base64 token (`secrets.token_urlsafe`).
+`length=32` produces a 43-character string.
+
+```python
+from dcc_mcp_core import generate_api_key
+token = generate_api_key()            # "xZ3qB2..." — use as DCC_MCP_API_KEY
+```
+
+## Integration path
+
+Today these types are **declarative configuration objects** consumed either
+by (a) Python tool handlers calling `validate_bearer_token` directly, or
+(b) the `McpHttpConfig.api_key` field (Bearer-token path, supported now).
+
+Full Rust-side enforcement of the `/.well-known/oauth-client-metadata`
+endpoint and the `/mcp` Bearer check is tracked in issue
+[#408](https://github.com/loonghao/dcc-mcp-core/issues/408). API keys work
+today; OAuth is opt-in via `McpHttpConfig(enable_oauth=True)` once the
+Rust layer lands.
+
+## See also
+
+- [Remote Server guide](../guide/remote-server.md) — end-to-end deployment
+- [`McpHttpConfig.api_key`](./http.md) — how the server consumes the token
+- [MCP authorization spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)

--- a/docs/api/batch.md
+++ b/docs/api/batch.md
@@ -1,0 +1,139 @@
+# Batch Dispatch — 批量工具调用与 Eval 沙箱
+
+> 源码：[`python/dcc_mcp_core/batch.py`](https://github.com/loonghao/dcc-mcp-core/blob/main/python/dcc_mcp_core/batch.py) · Issue [#406](https://github.com/loonghao/dcc-mcp-core/issues/406)
+>
+> **[English](../zh/api/batch.md)**（中文本页）
+
+Server-side batch execution for reducing agent round-trips and token usage.
+Intermediate results never enter the model context — only the final
+aggregated value is returned.
+
+**When to use**
+
+- **`batch_dispatch`** — N tool calls you already know up-front; you only
+  want the combined summary, not each step's chatter.
+- **`EvalContext`** — the agent writes a short Python script that conditionally
+  chooses tools based on intermediate results ("the Cloudflare pattern").
+  Pairs with [`DccApiExecutor`](./dcc-api-executor.md) for large DCC APIs.
+
+Both are **pure-Python** — they work with any `ToolDispatcher` even before
+the Rust-level `tools/batch` MCP endpoint lands.
+
+## Imports
+
+```python
+from dcc_mcp_core import batch_dispatch, EvalContext
+```
+
+## `batch_dispatch(dispatcher, calls, *, aggregate="list", stop_on_error=False) -> dict`
+
+Execute `(tool_name, arguments_dict)` pairs sequentially against a
+`ToolDispatcher` and return a single aggregated summary.
+
+**Parameters**
+
+| Name | Type | Default | Notes |
+|------|------|---------|-------|
+| `dispatcher` | `ToolDispatcher` | — | Must expose `.dispatch(name, json_str) -> dict` |
+| `calls` | `list[tuple[str, dict]]` | — | Ordered list of `(tool_name, args)` |
+| `aggregate` | `"list" \| "merge" \| "last"` | `"list"` | See below |
+| `stop_on_error` | `bool` | `False` | Abort on first failure when `True` |
+
+**Aggregation modes**
+
+| Mode | Resulting key | Shape |
+|------|---------------|-------|
+| `"list"` | `"results"` | List of individual `dispatch` return dicts |
+| `"merge"` | `"merged"` | Each result's `output` dict merged (later keys win) |
+| `"last"` | `"last"` | Only the final result dict |
+
+**Return value** — always includes:
+
+- `"total"` — number of calls attempted
+- `"succeeded"` — number with `output.success != False`
+- `"errors"` — list of `{index, tool, error}` for failing calls
+- plus one of `results` / `merged` / `last` depending on `aggregate`
+
+**Example**
+
+```python
+from dcc_mcp_core import ToolRegistry, ToolDispatcher, batch_dispatch
+
+registry = ToolRegistry()
+# ... register tools ...
+dispatcher = ToolDispatcher(registry)
+
+summary = batch_dispatch(
+    dispatcher,
+    [
+        ("get_scene_objects", {}),
+        ("get_render_stats", {"layer": "beauty"}),
+        ("get_render_stats", {"layer": "specular"}),
+    ],
+    aggregate="merge",
+)
+print(summary["total"], summary["succeeded"])
+print(summary["merged"])   # combined output dict
+```
+
+## `EvalContext(dispatcher, *, sandbox=True, timeout_secs=30)`
+
+Sandboxed script-execution context with access to `dispatch(name, args)`.
+
+Mirrors the planned `dcc_mcp_core__eval` MCP built-in tool — hands the
+agent a restricted Python interpreter that can orchestrate dozens of
+tool calls in a loop without each intermediate value reaching the model.
+
+**Constructor**
+
+| Arg | Type | Default | Notes |
+|-----|------|---------|-------|
+| `dispatcher` | `ToolDispatcher` | — | |
+| `sandbox` | `bool` | `True` | Strips `open`, `exec`, `eval`, `__import__`, `compile`, `getattr`, `setattr`, `delattr`, `vars`, `dir`, `globals`, `locals` from `__builtins__` |
+| `timeout_secs` | `int \| None` | `30` | POSIX-only (`signal.SIGALRM`); silently ignored on Windows |
+
+**Method: `.run(script: str) -> Any`**
+
+- Wraps the script in a function body so top-level `return <expr>` works.
+- The last expression is **not** implicitly returned (unlike a REPL).
+- Raises `TimeoutError` when the budget is exceeded (POSIX only).
+- Raises `RuntimeError` on any other script exception.
+- Inside the script, `dispatch(tool_name, args_dict)` is available.
+
+**Example**
+
+```python
+ctx = EvalContext(dispatcher)
+keyframes = ctx.run("""
+frames = []
+for i in range(1, 11):
+    r = dispatch("get_frame_data", {"frame": i})
+    if r.get("output", {}).get("has_keyframe"):
+        frames.append(i)
+return frames
+""")
+# Only the final list reaches the agent — 10 tool calls cost 1 token-worth of output.
+```
+
+## Security considerations
+
+- The `sandbox=True` restriction is **best-effort** — it hides dangerous
+  builtins but does not provide OS-level isolation. Treat scripts as
+  semi-trusted code from your own agent, not arbitrary user input.
+- For untrusted input, combine `EvalContext` with
+  [`SandboxPolicy`](./sandbox.md) and run inside a subprocess / container.
+- Failing tool calls do **not** raise inside a script — they return a
+  standard error dict, so scripts handle them idiomatically.
+
+## Integration path
+
+The Python helpers ship today. The Rust-level `tools/batch` and
+`dcc_mcp_core__eval` built-in MCP tools are tracked in issue
+[#406](https://github.com/loonghao/dcc-mcp-core/issues/406) and will call
+through this same logic once implemented.
+
+## See also
+
+- [`DccApiExecutor`](./dcc-api-executor.md) — the 2-tool "search + execute" wrapper that uses `EvalContext`
+- [Remote Server guide](../guide/remote-server.md)
+- [Sandbox & Security](./sandbox.md)

--- a/docs/api/dcc-api-executor.md
+++ b/docs/api/dcc-api-executor.md
@@ -1,0 +1,165 @@
+# DCC API Executor — Code-Orchestration for Huge APIs
+
+> Source: [`python/dcc_mcp_core/dcc_api_executor.py`](https://github.com/loonghao/dcc-mcp-core/blob/main/python/dcc_mcp_core/dcc_api_executor.py) · Issue [#411](https://github.com/loonghao/dcc-mcp-core/issues/411)
+>
+> **[中文版](../zh/api/dcc-api-executor.md)**
+
+Implements the "Cloudflare pattern" for enormous DCC APIs: expose just
+**two tools** — `dcc_search` and `dcc_execute` — that together cover the
+entire DCC Python API in ~500 tokens, instead of listing each of 1500+
+commands individually.
+
+**Why this matters for DCCs**
+
+| DCC | Approximate API surface |
+|-----|-------------------------|
+| Maya | 2000+ MEL / Python commands |
+| Houdini | 1500+ `hou` methods |
+| Blender | 800+ `bpy` operators |
+| 3ds Max | 1000+ `pymxs` commands |
+
+Registering each as its own MCP tool bloats `tools/list` past agent
+context budgets. Code orchestration keeps the surface constant: **2 tools,
+any DCC, any size**.
+
+> Reference: Anthropic — *"Building agents that reach production systems with
+> MCP"* (Apr 22, 2026): "Design for code orchestration when your surface
+> is large. Cloudflare's MCP server is the reference example — two tools
+> (search and execute) cover ~2,500 endpoints in roughly 1K tokens."
+
+## Imports
+
+```python
+from dcc_mcp_core import (
+    DccApiCatalog,
+    DccApiExecutor,
+    register_dcc_api_executor,
+)
+```
+
+## `DccApiCatalog(dcc_name, commands=None, catalog_text=None)`
+
+Searchable catalog of DCC API command signatures and descriptions.
+
+**Construction sources**
+
+1. `commands` — explicit list of dicts: `[{"name": "polyCube", "signature": "polyCube(...)", "description": "Create a cube mesh."}, ...]`
+2. `catalog_text` — plain-text catalog, one command per line as `name - description`. Blank lines and `#` comments are ignored.
+3. `add_command(name, *, signature="", description="")` — append at runtime.
+
+**Search** — `search(query: str, *, limit: int = 10) -> list[dict]`
+
+- Tokenises on whitespace/punctuation
+- Drops stopwords (`the`, `a`, `an`, `in`, `for`, `of`)
+- Scores by token-overlap count across `name + description + signature`
+- Returns top-`limit` by score, then alphabetical by name
+- Never surfaces zero-score results
+
+`len(catalog)` returns the number of commands.
+
+## `DccApiExecutor(dcc_name, catalog=None, dispatcher=None)`
+
+The two-tool wrapper.
+
+| Arg | Type | Default | Notes |
+|-----|------|---------|-------|
+| `dcc_name` | `str` | — | DCC identifier |
+| `catalog` | `DccApiCatalog \| None` | new empty catalog | Used by `dcc_search` |
+| `dispatcher` | `ToolDispatcher \| None` | `None` | When provided, `dcc_execute` exposes `dispatch(name, args)` inside the script |
+
+### `.search(query, *, limit=10) -> dict`
+
+Handles `dcc_search` calls. Returns:
+
+```json
+{
+  "success": true,
+  "message": "Found 3 command(s) matching 'create sphere'.",
+  "results": [
+    {"name": "polySphere", "signature": "...", "description": "..."}
+  ]
+}
+```
+
+No hits → `"results": []` and a `"hint"` suggesting `search_skills`.
+
+### `.execute(code, *, timeout_secs=30) -> dict`
+
+Handles `dcc_execute` calls. Runs the snippet through
+[`EvalContext`](./batch.md) with `sandbox=True`. When a `ToolDispatcher`
+was passed to the constructor, `dispatch()` is available inside the
+script.
+
+Returns one of:
+
+- `{"success": True, "output": <script return value>, "message": "..."}`
+- `{"success": False, "error": "...", "message": "Script timed out ..."}`
+- `{"success": False, "error": "...", "message": "Script failed ..."}`
+
+`output` is the value returned by the script via a top-level `return`
+statement (the last expression is not implicitly returned).
+
+## `register_dcc_api_executor(server, executor, *, search_tool_name="dcc_search", execute_tool_name="dcc_execute") -> None`
+
+Register both tools on a `McpHttpServer` *before* `server.start()`. Tool
+names are overridable for disambiguation in multi-DCC gateways
+(`maya_search`, `blender_search`, …).
+
+## End-to-end example
+
+```python
+from dcc_mcp_core import (
+    ToolRegistry, ToolDispatcher,
+    McpHttpServer, McpHttpConfig,
+    DccApiCatalog, DccApiExecutor, register_dcc_api_executor,
+)
+
+registry = ToolRegistry()
+dispatcher = ToolDispatcher(registry)
+
+catalog = DccApiCatalog(
+    "maya",
+    catalog_text="""
+polyCube - Create a cube polygon mesh
+polySphere - Create a sphere polygon mesh
+select - Select nodes in the scene
+render - Render the current frame
+""",
+)
+
+executor = DccApiExecutor("maya", catalog=catalog, dispatcher=dispatcher)
+
+server = McpHttpServer(registry, McpHttpConfig(port=8765))
+register_dcc_api_executor(server, executor)
+handle = server.start()
+# tools/list now contains exactly 2 entries: dcc_search, dcc_execute
+```
+
+## Agent usage pattern
+
+```text
+User  : "Create 5 spheres arranged on a line"
+Agent : dcc_search({"query": "create sphere"})         → finds polySphere
+Agent : dcc_execute({"code": "..."} )
+        for i in range(5):
+            dispatch("polySphere", {"position": [i, 0, 0]})
+        return {"created": 5}
+Server: { "output": {"created": 5}, "success": true }
+```
+
+Only the final script return value reaches the model — the 5 intermediate
+dispatches never consume tokens.
+
+## Current status
+
+Python helpers ship today. The Rust-level MCP built-in `dcc_search` /
+`dcc_execute` tools are tracked in issue
+[#411](https://github.com/loonghao/dcc-mcp-core/issues/411). Until they
+land, register via `register_dcc_api_executor(server, executor)` — the
+Python handlers behave identically.
+
+## See also
+
+- [`EvalContext` / `batch_dispatch`](./batch.md) — the sandboxed executor under the hood
+- [Skills System](../guide/skills.md) — how `search-hint` populates catalog entries from SKILL.md
+- [Remote Server guide](../guide/remote-server.md)

--- a/docs/api/elicitation.md
+++ b/docs/api/elicitation.md
@@ -1,0 +1,125 @@
+# Elicitation — Mid-tool-call User Input
+
+> Source: [`python/dcc_mcp_core/elicitation.py`](https://github.com/loonghao/dcc-mcp-core/blob/main/python/dcc_mcp_core/elicitation.py) · Issue [#407](https://github.com/loonghao/dcc-mcp-core/issues/407) · [MCP 2025-11-25 Elicitation spec](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation)
+>
+> **[中文版](../zh/api/elicitation.md)**
+
+Elicitation lets a tool handler **pause** mid-execution to ask the end user
+for input — either a form rendered from JSON Schema, or a browser URL
+flow (OAuth, payment, credential collection).
+
+**When to use**
+
+- **Destructive confirmations** — "Delete 127 shot cameras? This cannot be undone."
+- **Missing required parameter** — Agent invoked without `render_layer`; pop a dropdown.
+- **Auth flows** — Send the user to `/oauth/authorize` and wait for callback.
+
+Without elicitation these scenarios require bouncing through the agent
+again — costing tokens and often breaking flow.
+
+## Imports
+
+```python
+from dcc_mcp_core import (
+    ElicitationMode,
+    ElicitationRequest,
+    ElicitationResponse,
+    FormElicitation,
+    UrlElicitation,
+    elicit_form,
+    elicit_form_sync,
+    elicit_url,
+)
+```
+
+## Types
+
+### `ElicitationMode` (enum)
+
+| Value | Meaning |
+|-------|---------|
+| `ElicitationMode.FORM` | Client renders a JSON-Schema form |
+| `ElicitationMode.URL` | Client opens a browser URL and awaits completion |
+
+### `FormElicitation`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `message` | `str` | Prompt above the form |
+| `schema` | `dict` | JSON Schema (`type: object`, `properties`, `required`) |
+| `title` | `str \| None` | Optional dialog title |
+
+### `UrlElicitation`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `message` | `str` | Short description |
+| `url` | `str` | Browser URL |
+| `description` | `str \| None` | Longer explanation |
+
+### `ElicitationRequest`
+
+Wraps `mode` + a `FormElicitation` or `UrlElicitation`.
+
+### `ElicitationResponse`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `accepted` | `bool` | `True` on submit, `False` on cancel / unsupported client |
+| `data` | `dict \| None` | User-supplied values (form mode only) |
+| `message` | `str \| None` | Status / error message |
+
+## Helpers
+
+### `await elicit_form(message, schema, *, title=None) -> ElicitationResponse`
+
+Async form elicitation for `async def` skill handlers.
+
+```python
+async def delete_objects(objects: list[str], **kwargs):
+    resp = await elicit_form(
+        message=f"Delete {len(objects)} objects? This cannot be undone.",
+        schema={
+            "type": "object",
+            "properties": {"confirm": {"type": "boolean", "title": "Confirm deletion"}},
+            "required": ["confirm"],
+        },
+    )
+    if not resp.accepted or not resp.data.get("confirm"):
+        return {"success": False, "message": "Cancelled by user"}
+    # ... proceed ...
+```
+
+### `await elicit_url(message, url, *, description=None) -> ElicitationResponse`
+
+Async URL elicitation (OAuth, payment, credential flow). Opens the URL
+in the user's browser and waits for the client to report completion.
+
+### `elicit_form_sync(message, schema, *, title=None, fallback_values=None) -> ElicitationResponse`
+
+Blocking variant for DCC main-thread handlers that cannot be `async`
+(Maya, Houdini, …). When the Rust transport supports elicitation this
+blocks the calling thread; without it, `fallback_values` (if provided)
+is returned with `accepted=True, message="fallback_values_used"`.
+
+## Current status — stub + graceful fallback
+
+The Rust-level MCP HTTP layer support for forwarding
+`notifications/elicitation/request` and awaiting
+`notifications/elicitation/response` is planned in issue
+[#407](https://github.com/loonghao/dcc-mcp-core/issues/407). Until that
+lands, all three helpers:
+
+- log a warning (`"MCP Elicitation is not yet wired to the HTTP transport"`),
+- return `ElicitationResponse(accepted=False, message="elicitation_not_supported")`.
+
+Skill handlers written against this API **today** will automatically gain
+real elicitation behaviour once the Rust layer is released — no code
+changes required. Design your destructive tools now to call `elicit_form`
+and rely on the `accepted=False` fallback path meanwhile.
+
+## See also
+
+- [Remote Server guide](../guide/remote-server.md)
+- [`ToolAnnotations.destructive_hint`](./actions.md) — pair every `destructive_hint=True` tool with an elicitation gate
+- [MCP spec 2025-11-25 § Elicitation](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation)

--- a/docs/api/plugin-manifest.md
+++ b/docs/api/plugin-manifest.md
@@ -1,0 +1,123 @@
+# Plugin Manifest — One-click Install for Claude Code
+
+> Source: [`python/dcc_mcp_core/plugin_manifest.py`](https://github.com/loonghao/dcc-mcp-core/blob/main/python/dcc_mcp_core/plugin_manifest.py) · Issue [#410](https://github.com/loonghao/dcc-mcp-core/issues/410) · [Claude Code plugin reference](https://code.claude.com/docs/en/plugins-reference#plugin-components-reference)
+>
+> **[中文版](../zh/api/plugin-manifest.md)**
+
+Bundle an MCP server URL, skill paths, and optional sub-agents into a
+single JSON manifest that users install into Claude Code with one click.
+
+**When to use**
+
+- Ship a pre-configured DCC integration (`maya-mcp`, `blender-mcp`, …) to
+  users without forcing them to edit `claude_desktop_config.json`.
+- Distribute a curated skill bundle alongside your server URL.
+- Prepare for the upstream MCP
+  [`experimental-ext-skills`](https://github.com/modelcontextprotocol/experimental-ext-skills)
+  extension that delivers skills directly from servers.
+
+## Imports
+
+```python
+from dcc_mcp_core import (
+    PluginManifest,
+    build_plugin_manifest,
+    export_plugin_manifest,
+)
+```
+
+## `PluginManifest` (dataclass)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | `str` | Plugin name (e.g. `"maya-mcp"`) |
+| `version` | `str` | Plugin version string |
+| `description` | `str` | Shown in the Claude Code UI |
+| `mcp_servers` | `list[dict]` | Each entry has `"url"` and optional `"headers"` |
+| `skills` | `list[str]` | Absolute paths to skill directories |
+| `sub_agents` | `list[dict]` | Optional sub-agent definitions (default `[]`) |
+
+Methods:
+
+- `.to_dict() -> dict` — JSON-serialisable dict
+- `.to_json(indent=2) -> str` — formatted JSON string
+
+## `build_plugin_manifest(dcc_name, mcp_url, skill_paths=None, *, version="0.1.0", description=None, api_key=None, extra_mcp_servers=None, sub_agents=None) -> dict`
+
+Assemble a plugin manifest dict.
+
+| Arg | Type | Default | Notes |
+|-----|------|---------|-------|
+| `dcc_name` | `str` | — | Short DCC identifier; becomes `<dcc>-mcp` as the plugin `name` |
+| `mcp_url` | `str \| None` | — | Full MCP endpoint (`http://host:8765/mcp`). `None` → skills-only bundle |
+| `skill_paths` | `list[str] \| None` | `None` | Directories to include. Non-existent paths are dropped with a debug log |
+| `version` | `str` | `"0.1.0"` | Plugin version |
+| `description` | `str \| None` | auto | Auto-generated from `dcc_name` when `None` |
+| `api_key` | `str \| None` | `None` | Injected into `mcp_servers[0].headers.Authorization` as `Bearer <key>` |
+| `extra_mcp_servers` | `list[dict] \| None` | `None` | Additional server entries beyond the primary |
+| `sub_agents` | `list[dict] \| None` | `None` | Sub-agent definitions |
+
+**Returns** a JSON-serialisable dict matching the Claude Code plugin
+schema. Log message at INFO level summarises how many servers / skills
+were included.
+
+**Example**
+
+```python
+from dcc_mcp_core import build_plugin_manifest, export_plugin_manifest
+
+manifest = build_plugin_manifest(
+    dcc_name="maya",
+    mcp_url="https://mcp.example.com/mcp",
+    skill_paths=["/opt/skills/maya-geometry", "/opt/skills/maya-render"],
+    version="1.2.0",
+    api_key="s3cret-studio-token",
+)
+export_plugin_manifest(manifest, "dist/maya-mcp.plugin.json")
+```
+
+## `export_plugin_manifest(manifest, path, *, indent=2) -> Path`
+
+Write a manifest dict to disk. Creates parent directories as needed.
+Returns the resolved `pathlib.Path`.
+
+## Recommended pattern — `DccServerBase.plugin_manifest()`
+
+When building on `DccServerBase`, use the convenience method added in #410
+that auto-fills `mcp_url` and `skill_paths` from the running server:
+
+```python
+class MayaServer(DccServerBase):
+    def __init__(self):
+        super().__init__(dcc_name="maya", http_config=McpHttpConfig(port=8765))
+
+server = MayaServer()
+handle = server.start()
+manifest = server.plugin_manifest(version="1.2.0")   # dict
+```
+
+## Manifest shape
+
+```json
+{
+  "name": "maya-mcp",
+  "version": "1.2.0",
+  "description": "MCP plugin for Maya — provides AI-accessible tools via dcc-mcp-core.",
+  "mcp_servers": [
+    {
+      "url": "https://mcp.example.com/mcp",
+      "headers": { "Authorization": "Bearer s3cret-studio-token" }
+    }
+  ],
+  "skills": [
+    "/opt/skills/maya-geometry",
+    "/opt/skills/maya-render"
+  ]
+}
+```
+
+## See also
+
+- [Remote Server guide](../guide/remote-server.md)
+- [Skills System](../guide/skills.md) — SKILL.md discovery & `DCC_MCP_SKILL_PATHS`
+- [Claude Code plugin components reference](https://code.claude.com/docs/en/plugins-reference#plugin-components-reference)

--- a/docs/api/rich-content.md
+++ b/docs/api/rich-content.md
@@ -1,0 +1,167 @@
+# Rich Content — MCP Apps Inline UI
+
+> Source: [`python/dcc_mcp_core/rich_content.py`](https://github.com/loonghao/dcc-mcp-core/blob/main/python/dcc_mcp_core/rich_content.py) · Issue [#409](https://github.com/loonghao/dcc-mcp-core/issues/409) · [MCP Apps overview](https://modelcontextprotocol.io/extensions/apps/overview)
+>
+> **[中文版](../zh/api/rich-content.md)**
+
+MCP Apps is the first official MCP protocol extension. A tool can return
+an interactive interface — chart, form, dashboard, image, table —
+rendered inline in the chat interface, **without hitting the model
+context**. Servers that return rich content see meaningfully higher
+adoption than text-only servers.
+
+**When rich content pays off for DCC tools**
+
+| Tool | Rich return | Value |
+|------|-------------|-------|
+| `render_frames` | Thumbnail gallery + stats table | Visual verification without leaving chat |
+| `get_scene_hierarchy` | Interactive tree | Browse 10k-node scene |
+| `diagnostics__screenshot` | Inline screenshot | More useful than a file path |
+| `analyze_keyframes` | Vega-Lite curve chart | Visual timing debug |
+| `get_render_stats` | Bar chart per layer | Faster than raw JSON |
+| `list_materials` | Material swatch grid | Visual selection |
+
+## Imports
+
+```python
+from dcc_mcp_core import (
+    RichContent,
+    RichContentKind,
+    attach_rich_content,
+    skill_success_with_chart,
+    skill_success_with_image,
+    skill_success_with_table,
+)
+```
+
+## `RichContentKind` (enum)
+
+| Value | Rendered as |
+|-------|-------------|
+| `"chart"` | Vega-Lite / Chart.js spec |
+| `"form"` | Interactive JSON-Schema form |
+| `"dashboard"` | Composite layout of multiple components |
+| `"image"` | Inline PNG / JPEG / WebP (base64) |
+| `"table"` | Headers + rows grid |
+
+## `RichContent` (dataclass)
+
+Prefer the class-method constructors over the raw dataclass.
+
+### `RichContent.chart(spec) -> RichContent`
+
+Vega-Lite v5 or Chart.js specification dict.
+
+```python
+RichContent.chart({
+    "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+    "data": {"values": [{"x": 1, "y": 2}]},
+    "mark": "line",
+    "encoding": {"x": {"field": "x"}, "y": {"field": "y"}},
+})
+```
+
+### `RichContent.form(schema, *, title=None) -> RichContent`
+
+Interactive form rendered from a JSON Schema. Distinct from
+[Elicitation](./elicitation.md) — this `form` is part of the **tool
+result** (one-shot display), whereas elicitation *pauses* the tool call
+for user input.
+
+### `RichContent.image(data, mime="image/png", *, alt=None) -> RichContent`
+
+Raw image bytes encoded to base64.
+
+### `RichContent.image_from_file(path, mime=None, *, alt=None) -> RichContent`
+
+Convenience loader. MIME type auto-detected from extension (`.png`,
+`.jpg`, `.jpeg`, `.webp`, `.gif`).
+
+### `RichContent.table(headers, rows, *, title=None) -> RichContent`
+
+Grid with `headers: list[str]` and `rows: list[list]`. Every inner row
+list must have the same length as `headers`.
+
+### `RichContent.dashboard(components) -> RichContent`
+
+Composite layout containing an ordered list of other `RichContent`
+items.
+
+### `.to_dict() -> dict`
+
+Flattens to `{"kind": <value>, **payload}` — safe for JSON
+serialization.
+
+## `attach_rich_content(result, content) -> dict`
+
+Stash a `RichContent` on an existing skill result dict. Stored under
+`result["context"]["__rich__"]` — MCP-Apps-aware clients render it;
+plain clients ignore it gracefully (backward-compatible).
+
+```python
+result = skill_success("Render complete", total_frames=250)
+return attach_rich_content(result, RichContent.chart({...}))
+```
+
+## Skill-script helpers
+
+These return ready-to-use skill result dicts. Additional keyword
+arguments are forwarded into the `context` dict.
+
+### `skill_success_with_chart(message, chart_spec, **context) -> dict`
+
+```python
+return skill_success_with_chart(
+    "Render complete",
+    chart_spec={
+        "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+        "data": {"values": render_stats},
+        "mark": "bar",
+        "encoding": {
+            "x": {"field": "layer"},
+            "y": {"field": "time_secs"},
+        },
+    },
+    total_frames=250,
+)
+```
+
+### `skill_success_with_table(message, headers, rows, *, title=None, **context) -> dict`
+
+```python
+return skill_success_with_table(
+    "Scene objects",
+    headers=["Name", "Type", "Vertices"],
+    rows=[["pCube1", "mesh", 8], ["nurbsSphere1", "nurbs", 0]],
+)
+```
+
+### `skill_success_with_image(message, image_data=None, image_path=None, mime="image/png", *, alt=None, **context) -> dict`
+
+Provide either `image_data` (raw bytes) or `image_path` (file). Raises
+`ValueError` if neither is given.
+
+```python
+return skill_success_with_image(
+    "Viewport captured",
+    image_data=capture_viewport(),
+    alt="Maya viewport",
+)
+```
+
+## Current status — context-side storage, Rust-side wiring pending
+
+Rich content is stored today in `result.context["__rich__"]` as a
+JSON-serialisable dict. Full wiring into `tools/call` responses using
+the MCP Apps canonical envelope is tracked in issue
+[#409](https://github.com/loonghao/dcc-mcp-core/issues/409).
+
+Skills written against these helpers today will automatically surface
+rich content to MCP-Apps clients once the Rust layer ships.
+
+## See also
+
+- [Remote Server guide](../guide/remote-server.md)
+- [Elicitation](./elicitation.md) — *pauses* a tool for input; this doc covers *one-shot* display
+- [Vega-Lite v5 docs](https://vega.github.io/vega-lite/) — chart schema reference
+- [MCP Apps extension](https://modelcontextprotocol.io/extensions/apps/overview)

--- a/docs/guide/gateway.md
+++ b/docs/guide/gateway.md
@@ -67,6 +67,33 @@ and any `job_routes` / `progress_token_routes` bound to that session
 are scrubbed. Backend subscriptions stay alive — another client might
 still depend on them.
 
+### Self-loop guard + pre-subscribe hygiene (#419)
+
+When a DCC process (Maya, Blender, Houdini…) wins gateway election it
+keeps *two* rows in `FileRegistry`: the `__gateway__` sentinel **and**
+its own plain `"maya"` / `"blender"` / … row. Without filtering, the
+backend SSE subscriber would open a connection to its own `/mcp`
+endpoint — a self-loop that wastes a socket and floods the reconnect
+logs whenever the facade blips.
+
+Two invariants prevent this:
+
+1. **Self-exclusion in every fan-out path.** `GatewayState::live_instances`
+   skips rows whose `(host, port)` matches the gateway's own binding,
+   using `is_own_instance` from `crates/dcc-mcp-http/src/gateway/sentinel.rs`.
+   The helper normalises localhost aliases (`localhost`, `::1`,
+   `0.0.0.0`, `[::]`) to `127.0.0.1` so an adapter that advertises its
+   host as `"localhost"` is still filtered when the gateway is bound
+   to `127.0.0.1`. The `backend_sub_handle` subscription loop and the
+   `compute_tools_fingerprint_with_own` watcher apply the same filter.
+2. **Synchronous hygiene before the subscriber loop starts.** Inside
+   `start_gateway_tasks`, a one-shot `prune_dead_pids()` +
+   `cleanup_stale()` pass runs **before** `backend_sub_handle` is
+   spawned. The periodic cleanup task only ticks every 15 s; without
+   the synchronous pre-pass, ghost rows left behind by a previous
+   crash would eat the full exponential-backoff retry budget during
+   the first ~15 s of gateway lifetime.
+
 ## Code pointers
 
 | Piece | File |

--- a/docs/zh/api/auth.md
+++ b/docs/zh/api/auth.md
@@ -1,0 +1,117 @@
+# Auth — API Key 与 OAuth 2.1 / CIMD
+
+> 源码：[`python/dcc_mcp_core/auth.py`](https://github.com/loonghao/dcc-mcp-core/blob/main/python/dcc_mcp_core/auth.py) · Issue [#408](https://github.com/loonghao/dcc-mcp-core/issues/408)
+>
+> **[English](../../api/auth.md)**
+
+远程 MCP 服务器的声明式认证配置。提供面向工作室/内网的 Bearer-token（API Key）认证，以及面向公网 SaaS 部署的 OAuth 2.1 + [CIMD（Client ID Metadata Documents）](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#client-id-metadata-documents) 动态客户端注册。
+
+**如何选择**
+
+- **API Key** — 工作室/内网，单一共享密钥，无外部身份提供方。
+- **OAuth / CIMD** — 公网 SaaS，按用户身份鉴权，自动客户端注册，可通过 [Managed Agents Vaults](https://www.anthropic.com/news/claude-code-vaults) 刷新 Token。
+
+## 导入
+
+```python
+from dcc_mcp_core import (
+    ApiKeyConfig,
+    OAuthConfig,
+    CimdDocument,
+    TokenValidationError,
+    generate_api_key,
+    validate_bearer_token,
+)
+```
+
+## `ApiKeyConfig`
+
+Bearer Token 认证配置数据类。
+
+| 字段 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `api_key` | `str \| None` | `None` | 直接传入密钥；设置后会覆盖 `env_var` |
+| `env_var` | `str` | `"DCC_MCP_API_KEY"` | 调用 `.resolve()` 时读取的环境变量名 |
+| `header_name` | `str` | `"Authorization"` | 期望 `Bearer <key>` 形式的 HTTP 头 |
+
+```python
+cfg = ApiKeyConfig(env_var="MY_MCP_SECRET")
+token = cfg.resolve()   # 字段 → 环境变量 → None
+mcp_cfg.api_key = token
+```
+
+## `OAuthConfig`
+
+OAuth 2.1 声明式配置。可生成 [`CimdDocument`](#cimddocument)，用于从 `GET /.well-known/oauth-client-metadata` 提供服务。
+
+| 字段 | 类型 | 默认 | 说明 |
+|------|------|------|------|
+| `provider_url` | `str` | — | OAuth 服务商基础 URL |
+| `client_id` | `str \| None` | `None` | 预注册 client ID；`None` 时走 CIMD 动态注册 |
+| `scopes` | `list[str]` | `[]` | 申请的 OAuth scope |
+| `client_name` | `str` | `"dcc-mcp-server"` | 授权对话框中显示的名称 |
+| `redirect_uri` | `str \| None` | `None` | CIMD 默认回调 URI |
+
+**派生只读属性**
+
+- `authorization_endpoint` → `<provider>/authorize`
+- `token_endpoint` → `<provider>/token`
+- `well_known_url` → `<provider>/.well-known/oauth-client-metadata`
+
+```python
+oauth = OAuthConfig(
+    provider_url="https://auth.shotgrid.example.com",
+    scopes=["scene:read", "render:write"],
+    client_name="Maya MCP Server",
+)
+doc = oauth.to_cimd_document(redirect_uri="http://localhost:8765/oauth/callback")
+```
+
+## `CimdDocument`
+
+[Client ID Metadata Document](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#client-id-metadata-documents) — 动态客户端注册元数据。调用 `.to_dict()` 序列化为 JSON，通过 `/.well-known/oauth-client-metadata` 提供。
+
+| 字段 | 类型 | 默认 | 说明 |
+|------|------|------|------|
+| `client_name` | `str` | — | 授权对话框显示名 |
+| `redirect_uris` | `list[str]` | — | 所有可能用到的回调 URI |
+| `grant_types` | `list[str]` | `["authorization_code"]` | |
+| `response_types` | `list[str]` | `["code"]` | |
+| `token_endpoint_auth_method` | `str` | `"none"` | 仅 PKCE 的 public client |
+| `scope` | `str \| None` | `None` | 空格分隔 |
+| `logo_uri` / `client_uri` / `contacts` | 可选 | — | 授权页装饰 |
+
+## `validate_bearer_token(headers, *, expected_token, header_name="Authorization") -> bool`
+
+纯 Python 工具处理器中可直接使用的 Bearer Token 校验器，防时序攻击。
+
+- `expected_token is None` 时返回 `True`（鉴权关闭，记录警告）。
+- 头部等于 `Bearer <expected_token>` 时返回 `True`。
+- 头部缺失/方案错误/不匹配时返回 `False`。
+- 使用 [`secrets.compare_digest`](https://docs.python.org/3/library/secrets.html#secrets.compare_digest) 做定长比较。
+- 请求头名称大小写不敏感。
+
+```python
+from dcc_mcp_core import validate_bearer_token
+
+def secure_handler(params, *, request_headers=None):
+    if not validate_bearer_token(request_headers or {}, expected_token=os.environ["DCC_MCP_API_KEY"]):
+        return {"success": False, "message": "Unauthorized"}
+    ...
+```
+
+## `generate_api_key(length: int = 32) -> str`
+
+基于 `secrets.token_urlsafe` 的强随机 URL-safe base64 字符串。`length=32` 产出 43 字符。
+
+## 落地现状
+
+目前这些类型是**声明式配置对象**，服务于：(a) Python 工具处理器直接调用 `validate_bearer_token`；(b) `McpHttpConfig.api_key` 字段（Bearer Token 路径，当前已可用）。
+
+Rust 侧对 `/.well-known/oauth-client-metadata` 端点以及 `/mcp` 请求 Bearer 检查的完整支持，跟踪于 issue [#408](https://github.com/loonghao/dcc-mcp-core/issues/408)。API Key 路径立即可用；OAuth 路径在 Rust 层落地后通过 `McpHttpConfig(enable_oauth=True)` 开启。
+
+## 参见
+
+- [远程服务器指南](../guide/remote-server.md)
+- [`McpHttpConfig.api_key`](./http.md)
+- [MCP 认证规范](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)

--- a/docs/zh/api/batch.md
+++ b/docs/zh/api/batch.md
@@ -1,0 +1,103 @@
+# Batch Dispatch — 批量工具调用与 Eval 沙箱
+
+> 源码：[`python/dcc_mcp_core/batch.py`](https://github.com/loonghao/dcc-mcp-core/blob/main/python/dcc_mcp_core/batch.py) · Issue [#406](https://github.com/loonghao/dcc-mcp-core/issues/406)
+>
+> **[English](../../api/batch.md)**
+
+服务端批量执行工具调用，减少 Agent 往返和 Token 消耗。中间结果**不会**进入模型上下文——只有最终聚合值返回。
+
+**何时使用**
+
+- **`batch_dispatch`** — 已知要连续调用的 N 个工具；只关心合并后的汇总，不希望逐步响应进入上下文。
+- **`EvalContext`** — Agent 写一段短 Python 脚本，根据中间结果条件选择工具（"Cloudflare 模式"）。配合 [`DccApiExecutor`](./dcc-api-executor.md) 覆盖大型 DCC API。
+
+两者均为**纯 Python**，在 Rust 级 `tools/batch` MCP 端点落地前即可使用任意 `ToolDispatcher`。
+
+## 导入
+
+```python
+from dcc_mcp_core import batch_dispatch, EvalContext
+```
+
+## `batch_dispatch(dispatcher, calls, *, aggregate="list", stop_on_error=False) -> dict`
+
+按顺序执行 `(tool_name, arguments_dict)` 列表，返回单一聚合汇总。
+
+**参数**
+
+| 名称 | 类型 | 默认 | 说明 |
+|------|------|------|------|
+| `dispatcher` | `ToolDispatcher` | — | 需暴露 `.dispatch(name, json_str) -> dict` |
+| `calls` | `list[tuple[str, dict]]` | — | 有序 `(tool_name, args)` 列表 |
+| `aggregate` | `"list" \| "merge" \| "last"` | `"list"` | 详见下表 |
+| `stop_on_error` | `bool` | `False` | 为 `True` 时首次失败即中止 |
+
+**聚合模式**
+
+| 模式 | 结果键 | 形态 |
+|------|--------|------|
+| `"list"` | `"results"` | 单次调用返回值列表 |
+| `"merge"` | `"merged"` | 合并每次的 `output` 字典（后者覆盖前者） |
+| `"last"` | `"last"` | 仅最后一次结果 |
+
+**返回值**始终包含 `total`、`succeeded`、`errors`，以及按 `aggregate` 附加的 `results` / `merged` / `last` 之一。
+
+```python
+summary = batch_dispatch(
+    dispatcher,
+    [
+        ("get_scene_objects", {}),
+        ("get_render_stats", {"layer": "beauty"}),
+        ("get_render_stats", {"layer": "specular"}),
+    ],
+    aggregate="merge",
+)
+print(summary["total"], summary["succeeded"])
+print(summary["merged"])
+```
+
+## `EvalContext(dispatcher, *, sandbox=True, timeout_secs=30)`
+
+带 `dispatch(name, args)` 的沙箱脚本执行环境——对应规划中的 `dcc_mcp_core__eval` MCP 内建工具。交给 Agent 一个受限的 Python 解释器，在循环中编排几十次工具调用，而不让中间值进入上下文。
+
+| 参数 | 类型 | 默认 | 说明 |
+|------|------|------|------|
+| `dispatcher` | `ToolDispatcher` | — | |
+| `sandbox` | `bool` | `True` | 从 `__builtins__` 中剥离 `open`、`exec`、`eval`、`__import__`、`compile`、`getattr/setattr/delattr`、`vars/dir`、`globals/locals` |
+| `timeout_secs` | `int \| None` | `30` | 仅 POSIX（`signal.SIGALRM`）；Windows 下自动跳过 |
+
+**方法 `.run(script: str) -> Any`**
+
+- 会把脚本包装成函数体，使顶层 `return <expr>` 生效。
+- 最后一行表达式不会隐式返回（与 REPL 不同）。
+- 超时抛 `TimeoutError`（仅 POSIX），其他异常抛 `RuntimeError`。
+- 脚本内可使用 `dispatch(tool_name, args_dict)` 调用任意已注册工具。
+
+```python
+ctx = EvalContext(dispatcher)
+keyframes = ctx.run("""
+frames = []
+for i in range(1, 11):
+    r = dispatch("get_frame_data", {"frame": i})
+    if r.get("output", {}).get("has_keyframe"):
+        frames.append(i)
+return frames
+""")
+# 仅最终列表回到 Agent——10 次调用只消耗 1 次返回的 Token 量。
+```
+
+## 安全注意
+
+- `sandbox=True` 是**尽力而为**——隐藏了危险 builtin 但不是 OS 级隔离。可信度视作"自家 Agent 生成的半可信代码"，而非任意用户输入。
+- 处理不可信输入时请配合 [`SandboxPolicy`](./sandbox.md) 并运行于子进程/容器。
+- 脚本里工具调用失败不会抛异常——返回标准错误字典，便于脚本按惯用方式处理。
+
+## 落地现状
+
+Python 助手已可用。Rust 级 `tools/batch` 与 `dcc_mcp_core__eval` 内建 MCP 工具跟踪于 issue [#406](https://github.com/loonghao/dcc-mcp-core/issues/406)，将复用本模块逻辑。
+
+## 参见
+
+- [`DccApiExecutor`](./dcc-api-executor.md) — 使用 `EvalContext` 的 2 工具包装
+- [远程服务器指南](../guide/remote-server.md)
+- [沙箱与安全](./sandbox.md)

--- a/docs/zh/api/dcc-api-executor.md
+++ b/docs/zh/api/dcc-api-executor.md
@@ -1,0 +1,146 @@
+# DCC API Executor — 面向巨型 API 的代码编排模式
+
+> 源码：[`python/dcc_mcp_core/dcc_api_executor.py`](https://github.com/loonghao/dcc-mcp-core/blob/main/python/dcc_mcp_core/dcc_api_executor.py) · Issue [#411](https://github.com/loonghao/dcc-mcp-core/issues/411)
+>
+> **[English](../../api/dcc-api-executor.md)**
+
+把 "Cloudflare 模式" 引入 DCC：只暴露**两个工具**——`dcc_search` 和 `dcc_execute`——二者合计约 500 token，即可覆盖整个 DCC Python API，而不必为 1500+ 个命令各注册一个 MCP 工具。
+
+**为什么 DCC 尤其需要这种模式**
+
+| DCC | 大致 API 规模 |
+|-----|---------------|
+| Maya | 2000+ MEL / Python 命令 |
+| Houdini | 1500+ `hou` 方法 |
+| Blender | 800+ `bpy` 操作符 |
+| 3ds Max | 1000+ `pymxs` 命令 |
+
+逐个注册会把 `tools/list` 撑爆 Agent 上下文。代码编排把工具面恒定在：**2 个工具，任意 DCC，任意规模**。
+
+> 参考：Anthropic《Building agents that reach production systems with MCP》（2026-04-22）——"当工具面很大时要按代码编排设计。Cloudflare 的 MCP server 是参考范例：两个工具（search/execute）在大约 1K token 内覆盖 2500 个端点。"
+
+## 导入
+
+```python
+from dcc_mcp_core import (
+    DccApiCatalog,
+    DccApiExecutor,
+    register_dcc_api_executor,
+)
+```
+
+## `DccApiCatalog(dcc_name, commands=None, catalog_text=None)`
+
+可搜索的 DCC 命令目录，用于 `dcc_search`。
+
+**来源**
+
+1. `commands` — 显式列表：`[{"name": "polyCube", "signature": "...", "description": "..."}]`
+2. `catalog_text` — 纯文本目录，一行一条：`name - description`。空行与 `#` 注释自动忽略。
+3. `add_command(name, *, signature="", description="")` — 运行期追加。
+
+**搜索 `search(query: str, *, limit: int = 10) -> list[dict]`**
+
+- 按空白/标点切词
+- 丢弃停用词（`the`、`a`、`an`、`in`、`for`、`of`）
+- 按 `name + description + signature` 命中计数打分
+- Top-`limit`，分数同则按名称字典序
+- 零分项不返回
+
+`len(catalog)` 返回命令条数。
+
+## `DccApiExecutor(dcc_name, catalog=None, dispatcher=None)`
+
+2 工具包装器。
+
+| 参数 | 类型 | 默认 | 说明 |
+|------|------|------|------|
+| `dcc_name` | `str` | — | DCC 标识 |
+| `catalog` | `DccApiCatalog \| None` | 空目录 | `dcc_search` 使用 |
+| `dispatcher` | `ToolDispatcher \| None` | `None` | 提供时 `dcc_execute` 脚本内可用 `dispatch(name, args)` |
+
+### `.search(query, *, limit=10) -> dict`
+
+处理 `dcc_search` 调用：
+
+```json
+{
+  "success": true,
+  "message": "Found 3 command(s) matching 'create sphere'.",
+  "results": [
+    {"name": "polySphere", "signature": "...", "description": "..."}
+  ]
+}
+```
+
+无匹配时返回 `"results": []` 并附带建议使用 `search_skills` 的 `"hint"`。
+
+### `.execute(code, *, timeout_secs=30) -> dict`
+
+处理 `dcc_execute` 调用。脚本在 [`EvalContext`](./batch.md) 中以 `sandbox=True` 执行；构造时传入 `ToolDispatcher` 后脚本可使用 `dispatch()`。
+
+可能返回：
+
+- `{"success": True, "output": <脚本 return 值>, "message": "..."}`
+- `{"success": False, "error": "...", "message": "Script timed out ..."}`
+- `{"success": False, "error": "...", "message": "Script failed ..."}`
+
+`output` 为脚本顶层 `return` 返回的值（最后一行表达式不会隐式返回）。
+
+## `register_dcc_api_executor(server, executor, *, search_tool_name="dcc_search", execute_tool_name="dcc_execute") -> None`
+
+在 `server.start()` **之前**在 `McpHttpServer` 上注册这两个工具。工具名可覆盖，用于多 DCC gateway 消歧（`maya_search`、`blender_search`）。
+
+## 端到端示例
+
+```python
+from dcc_mcp_core import (
+    ToolRegistry, ToolDispatcher,
+    McpHttpServer, McpHttpConfig,
+    DccApiCatalog, DccApiExecutor, register_dcc_api_executor,
+)
+
+registry = ToolRegistry()
+dispatcher = ToolDispatcher(registry)
+
+catalog = DccApiCatalog(
+    "maya",
+    catalog_text="""
+polyCube - Create a cube polygon mesh
+polySphere - Create a sphere polygon mesh
+select - Select nodes in the scene
+render - Render the current frame
+""",
+)
+
+executor = DccApiExecutor("maya", catalog=catalog, dispatcher=dispatcher)
+
+server = McpHttpServer(registry, McpHttpConfig(port=8765))
+register_dcc_api_executor(server, executor)
+handle = server.start()
+# tools/list 现在恰好包含 2 个条目：dcc_search、dcc_execute
+```
+
+## Agent 典型使用流
+
+```text
+User  : "创建 5 个球体排成一行"
+Agent : dcc_search({"query": "create sphere"})         → 命中 polySphere
+Agent : dcc_execute({"code": "..."} )
+        for i in range(5):
+            dispatch("polySphere", {"position": [i, 0, 0]})
+        return {"created": 5}
+Server: { "output": {"created": 5}, "success": true }
+```
+
+只有最终脚本返回值进入模型——5 次中间 dispatch 不消耗 Token。
+
+## 当前状态
+
+Python 助手已可用。Rust 级 `dcc_search` / `dcc_execute` 内建 MCP 工具跟踪于 issue [#411](https://github.com/loonghao/dcc-mcp-core/issues/411)。之前通过 `register_dcc_api_executor(server, executor)` 注册——Python 处理器行为完全一致。
+
+## 参见
+
+- [`EvalContext` / `batch_dispatch`](./batch.md) — 底层沙箱执行器
+- [Skills 技能包](../guide/skills.md) — `search-hint` 如何从 SKILL.md 填充目录
+- [远程服务器指南](../guide/remote-server.md)

--- a/docs/zh/api/elicitation.md
+++ b/docs/zh/api/elicitation.md
@@ -1,0 +1,111 @@
+# Elicitation — 工具执行期间向用户请求输入
+
+> 源码：[`python/dcc_mcp_core/elicitation.py`](https://github.com/loonghao/dcc-mcp-core/blob/main/python/dcc_mcp_core/elicitation.py) · Issue [#407](https://github.com/loonghao/dcc-mcp-core/issues/407) · [MCP 2025-11-25 Elicitation 规范](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation)
+>
+> **[English](../../api/elicitation.md)**
+
+Elicitation 允许工具处理器在执行过程中**暂停**，向终端用户索取输入——可以是基于 JSON Schema 渲染的表单，也可以是浏览器 URL 流（OAuth、支付、凭据采集）。
+
+**典型场景**
+
+- **破坏性操作确认** — "删除 127 个镜头相机？此操作不可撤销。"
+- **缺失必填参数** — Agent 调用时遗漏 `render_layer`，弹出下拉选择。
+- **认证流程** — 把用户引导到 `/oauth/authorize` 并等待回调。
+
+没有 elicitation 就需要把场景弹回 Agent——浪费 Token 且常常打断交互流。
+
+## 导入
+
+```python
+from dcc_mcp_core import (
+    ElicitationMode,
+    ElicitationRequest,
+    ElicitationResponse,
+    FormElicitation,
+    UrlElicitation,
+    elicit_form,
+    elicit_form_sync,
+    elicit_url,
+)
+```
+
+## 类型
+
+### `ElicitationMode`（枚举）
+
+| 值 | 含义 |
+|----|------|
+| `ElicitationMode.FORM` | 客户端渲染 JSON-Schema 表单 |
+| `ElicitationMode.URL` | 客户端打开浏览器 URL 并等待完成 |
+
+### `FormElicitation`
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `message` | `str` | 表单上方的提示词 |
+| `schema` | `dict` | JSON Schema（`type: object`、`properties`、`required`） |
+| `title` | `str \| None` | 可选对话框标题 |
+
+### `UrlElicitation`
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `message` | `str` | 简短描述 |
+| `url` | `str` | 浏览器 URL |
+| `description` | `str \| None` | 长描述 |
+
+### `ElicitationRequest`
+
+组合 `mode` 与 `FormElicitation` 或 `UrlElicitation`。
+
+### `ElicitationResponse`
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `accepted` | `bool` | 提交为 `True`，取消/不支持为 `False` |
+| `data` | `dict \| None` | 用户填写的值（仅 form 模式） |
+| `message` | `str \| None` | 状态或错误信息 |
+
+## 辅助函数
+
+### `await elicit_form(message, schema, *, title=None) -> ElicitationResponse`
+
+`async def` 技能处理器使用的异步表单请求。
+
+```python
+async def delete_objects(objects: list[str], **kwargs):
+    resp = await elicit_form(
+        message=f"删除 {len(objects)} 个对象？此操作不可撤销。",
+        schema={
+            "type": "object",
+            "properties": {"confirm": {"type": "boolean", "title": "确认删除"}},
+            "required": ["confirm"],
+        },
+    )
+    if not resp.accepted or not resp.data.get("confirm"):
+        return {"success": False, "message": "用户取消"}
+    # ... 继续删除 ...
+```
+
+### `await elicit_url(message, url, *, description=None) -> ElicitationResponse`
+
+异步 URL 请求（OAuth、支付、凭据流）。
+
+### `elicit_form_sync(message, schema, *, title=None, fallback_values=None) -> ElicitationResponse`
+
+DCC 主线程处理器（Maya、Houdini）中无法使用 `async` 的阻塞变体。Rust 传输支持 elicitation 后会阻塞直到用户响应；在此之前若提供 `fallback_values`，则返回 `accepted=True, message="fallback_values_used"`。
+
+## 当前状态——桩实现 + 优雅降级
+
+Rust 级 MCP HTTP 层对 `notifications/elicitation/request` 转发与 `notifications/elicitation/response` 回调的支持跟踪于 issue [#407](https://github.com/loonghao/dcc-mcp-core/issues/407)。在此之前，三个 helper 均会：
+
+- 记录警告日志（`"MCP Elicitation is not yet wired to the HTTP transport"`）；
+- 返回 `ElicitationResponse(accepted=False, message="elicitation_not_supported")`。
+
+**今天**按此 API 编写的处理器，在 Rust 层落地后会自动获得真实的 elicitation 行为——无需改代码。请立刻为所有破坏性工具接入 `elicit_form`，并在 `accepted=False` 分支做降级处理。
+
+## 参见
+
+- [远程服务器指南](../guide/remote-server.md)
+- [`ToolAnnotations.destructive_hint`](./actions.md) — 每个 `destructive_hint=True` 的工具都应该搭配 elicitation 确认
+- [MCP 规范 2025-11-25 § Elicitation](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation)

--- a/docs/zh/api/plugin-manifest.md
+++ b/docs/zh/api/plugin-manifest.md
@@ -1,0 +1,113 @@
+# Plugin Manifest — 为 Claude Code 打包一键安装包
+
+> 源码：[`python/dcc_mcp_core/plugin_manifest.py`](https://github.com/loonghao/dcc-mcp-core/blob/main/python/dcc_mcp_core/plugin_manifest.py) · Issue [#410](https://github.com/loonghao/dcc-mcp-core/issues/410) · [Claude Code 插件参考](https://code.claude.com/docs/en/plugins-reference#plugin-components-reference)
+>
+> **[English](../../api/plugin-manifest.md)**
+
+将 MCP 服务器 URL、技能路径、可选 sub-agent 打包成单个 JSON 清单，Claude Code 用户一键安装即可使用。
+
+**使用场景**
+
+- 向用户交付预配置好的 DCC 集成（`maya-mcp`、`blender-mcp`），无需手工编辑 `claude_desktop_config.json`。
+- 和服务器 URL 一起分发精选技能包。
+- 对齐上游 MCP [`experimental-ext-skills`](https://github.com/modelcontextprotocol/experimental-ext-skills) 扩展——支持直接由服务器分发技能。
+
+## 导入
+
+```python
+from dcc_mcp_core import (
+    PluginManifest,
+    build_plugin_manifest,
+    export_plugin_manifest,
+)
+```
+
+## `PluginManifest`（dataclass）
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `name` | `str` | 插件名（如 `"maya-mcp"`） |
+| `version` | `str` | 插件版本 |
+| `description` | `str` | Claude Code UI 中显示 |
+| `mcp_servers` | `list[dict]` | 每项含 `"url"` 和可选 `"headers"` |
+| `skills` | `list[str]` | 技能目录绝对路径 |
+| `sub_agents` | `list[dict]` | 可选 sub-agent 定义（默认 `[]`） |
+
+方法：
+
+- `.to_dict() -> dict` — JSON 可序列化字典
+- `.to_json(indent=2) -> str` — 格式化 JSON 字符串
+
+## `build_plugin_manifest(dcc_name, mcp_url, skill_paths=None, *, version="0.1.0", description=None, api_key=None, extra_mcp_servers=None, sub_agents=None) -> dict`
+
+组装清单字典。
+
+| 参数 | 类型 | 默认 | 说明 |
+|------|------|------|------|
+| `dcc_name` | `str` | — | DCC 标识，用作插件名 `<dcc>-mcp` |
+| `mcp_url` | `str \| None` | — | MCP 端点 URL；`None` 生成仅技能的包 |
+| `skill_paths` | `list[str] \| None` | `None` | 纳入的目录；不存在的会被 DEBUG 过滤 |
+| `version` | `str` | `"0.1.0"` | 插件版本 |
+| `description` | `str \| None` | 自动 | `None` 时根据 `dcc_name` 生成 |
+| `api_key` | `str \| None` | `None` | 注入首个 server 的 `headers.Authorization` 为 `Bearer <key>` |
+| `extra_mcp_servers` | `list[dict] \| None` | `None` | 额外 MCP server 条目 |
+| `sub_agents` | `list[dict] \| None` | `None` | sub-agent 定义 |
+
+返回符合 Claude Code 插件 Schema 的 JSON 可序列化字典。INFO 级日志汇总写入服务器/技能数量。
+
+```python
+from dcc_mcp_core import build_plugin_manifest, export_plugin_manifest
+
+manifest = build_plugin_manifest(
+    dcc_name="maya",
+    mcp_url="https://mcp.example.com/mcp",
+    skill_paths=["/opt/skills/maya-geometry", "/opt/skills/maya-render"],
+    version="1.2.0",
+    api_key="s3cret-studio-token",
+)
+export_plugin_manifest(manifest, "dist/maya-mcp.plugin.json")
+```
+
+## `export_plugin_manifest(manifest, path, *, indent=2) -> Path`
+
+把清单字典写入磁盘，父目录自动创建，返回解析后的 `pathlib.Path`。
+
+## 推荐用法 — `DccServerBase.plugin_manifest()`
+
+基于 `DccServerBase` 构建时，使用 #410 新增的便捷方法自动从运行中的服务器取回 `mcp_url` 与 `skill_paths`：
+
+```python
+class MayaServer(DccServerBase):
+    def __init__(self):
+        super().__init__(dcc_name="maya", http_config=McpHttpConfig(port=8765))
+
+server = MayaServer()
+handle = server.start()
+manifest = server.plugin_manifest(version="1.2.0")   # dict
+```
+
+## 清单结构
+
+```json
+{
+  "name": "maya-mcp",
+  "version": "1.2.0",
+  "description": "MCP plugin for Maya — provides AI-accessible tools via dcc-mcp-core.",
+  "mcp_servers": [
+    {
+      "url": "https://mcp.example.com/mcp",
+      "headers": { "Authorization": "Bearer s3cret-studio-token" }
+    }
+  ],
+  "skills": [
+    "/opt/skills/maya-geometry",
+    "/opt/skills/maya-render"
+  ]
+}
+```
+
+## 参见
+
+- [远程服务器指南](../guide/remote-server.md)
+- [Skills 技能包](../guide/skills.md) — SKILL.md 发现机制与 `DCC_MCP_SKILL_PATHS`
+- [Claude Code 插件组件参考](https://code.claude.com/docs/en/plugins-reference#plugin-components-reference)

--- a/docs/zh/api/rich-content.md
+++ b/docs/zh/api/rich-content.md
@@ -1,0 +1,119 @@
+# Rich Content — MCP Apps 内联 UI
+
+> 源码：[`python/dcc_mcp_core/rich_content.py`](https://github.com/loonghao/dcc-mcp-core/blob/main/python/dcc_mcp_core/rich_content.py) · Issue [#409](https://github.com/loonghao/dcc-mcp-core/issues/409) · [MCP Apps 总览](https://modelcontextprotocol.io/extensions/apps/overview)
+>
+> **[English](../../api/rich-content.md)**
+
+MCP Apps 是 MCP 协议首个官方扩展。工具可以返回交互式界面——图表、表单、仪表盘、图像、表格——直接在对话窗口内联渲染，**完全不占用模型上下文**。返回富内容的服务器比纯文本服务器有明显更高的接受度。
+
+**DCC 工具中富内容的典型收益**
+
+| 工具 | 富内容 | 价值 |
+|------|--------|------|
+| `render_frames` | 缩略图画廊 + 统计表 | 不离开对话即可可视化验证 |
+| `get_scene_hierarchy` | 交互式树视图 | 浏览 1 万节点的场景 |
+| `diagnostics__screenshot` | 内联截图 | 比文件路径好用得多 |
+| `analyze_keyframes` | 动画曲线图 | 可视化时序调试 |
+| `get_render_stats` | 各层柱状图 | 比原始 JSON 数组更快 |
+| `list_materials` | 材质色板网格 | 可视化选择 |
+
+## 导入
+
+```python
+from dcc_mcp_core import (
+    RichContent,
+    RichContentKind,
+    attach_rich_content,
+    skill_success_with_chart,
+    skill_success_with_image,
+    skill_success_with_table,
+)
+```
+
+## `RichContentKind`（枚举）
+
+| 值 | 渲染方式 |
+|----|----------|
+| `"chart"` | Vega-Lite / Chart.js 规范 |
+| `"form"` | 交互式 JSON-Schema 表单 |
+| `"dashboard"` | 多个组件的组合布局 |
+| `"image"` | 内联 PNG / JPEG / WebP（base64） |
+| `"table"` | 表头 + 行的网格 |
+
+## `RichContent`（dataclass）
+
+推荐使用类方法构造器而非原始构造函数。
+
+### `RichContent.chart(spec) -> RichContent`
+
+Vega-Lite v5 或 Chart.js 规范字典。
+
+```python
+RichContent.chart({
+    "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+    "data": {"values": [{"x": 1, "y": 2}]},
+    "mark": "line",
+    "encoding": {"x": {"field": "x"}, "y": {"field": "y"}},
+})
+```
+
+### `RichContent.form(schema, *, title=None) -> RichContent`
+
+从 JSON Schema 渲染的交互表单。注意和 [Elicitation](./elicitation.md) 的区别：这里的 `form` 是**工具结果的一部分**（一次性展示），而 elicitation 会**暂停**工具调用等待用户输入。
+
+### `RichContent.image(data, mime="image/png", *, alt=None) -> RichContent`
+
+原始图像字节（内部 base64 编码）。
+
+### `RichContent.image_from_file(path, mime=None, *, alt=None) -> RichContent`
+
+便捷读取器。根据扩展名自动推断 MIME（`.png`、`.jpg/.jpeg`、`.webp`、`.gif`）。
+
+### `RichContent.table(headers, rows, *, title=None) -> RichContent`
+
+`headers: list[str]` 与 `rows: list[list]`。每行长度必须与 `headers` 一致。
+
+### `RichContent.dashboard(components) -> RichContent`
+
+有序的 `RichContent` 组合布局。
+
+### `.to_dict() -> dict`
+
+扁平化为 `{"kind": <value>, **payload}`，可 JSON 序列化。
+
+## `attach_rich_content(result, content) -> dict`
+
+将 `RichContent` 附到已存在的技能结果字典上。存储于 `result["context"]["__rich__"]`——支持 MCP Apps 的客户端会渲染；纯客户端优雅忽略。
+
+## 技能脚本辅助函数
+
+返回可直接使用的技能结果字典。附加关键字参数进入 `context` 字典。
+
+### `skill_success_with_chart(message, chart_spec, **context) -> dict`
+
+### `skill_success_with_table(message, headers, rows, *, title=None, **context) -> dict`
+
+### `skill_success_with_image(message, image_data=None, image_path=None, mime="image/png", *, alt=None, **context) -> dict`
+
+必须提供 `image_data` 或 `image_path` 之一，否则抛 `ValueError`。
+
+```python
+return skill_success_with_image(
+    "视口已捕获",
+    image_data=capture_viewport(),
+    alt="Maya viewport",
+)
+```
+
+## 当前状态——上下文存储就绪，Rust 层对接中
+
+目前富内容以 JSON 可序列化字典形式存储在 `result.context["__rich__"]`。完整对接到 `tools/call` 响应的 MCP Apps 标准信封跟踪于 issue [#409](https://github.com/loonghao/dcc-mcp-core/issues/409)。
+
+**今天**基于这些 helper 编写的技能，在 Rust 层落地后会自动向支持 MCP Apps 的客户端暴露富内容。
+
+## 参见
+
+- [远程服务器指南](../guide/remote-server.md)
+- [Elicitation](./elicitation.md) — *暂停*工具等待输入；本文档讲的是*一次性*展示
+- [Vega-Lite v5 文档](https://vega.github.io/vega-lite/)
+- [MCP Apps 扩展](https://modelcontextprotocol.io/extensions/apps/overview)

--- a/docs/zh/guide/gateway.md
+++ b/docs/zh/guide/gateway.md
@@ -62,6 +62,31 @@ Gateway 会向每个在该后端上有进行中的作业的客户端发出一个
 该会话的任何 `job_routes` / `progress_token_routes`。后端订阅保持
 活动状态 — 另一个客户端可能仍然依赖它们。
 
+### 自环防护与订阅前卫生检查（#419）
+
+当一个 DCC 进程（Maya、Blender、Houdini…）赢得 Gateway 选举时，
+`FileRegistry` 中会同时保留 *两行*：`__gateway__` 哨兵行以及它
+自身的普通 `"maya"` / `"blender"` / … 行。如果不做过滤，后端 SSE
+订阅器会连接到自己的 `/mcp` 端点 —— 这是一个经典的自环，每次
+facade 抖动都会浪费 socket 并塞满重连日志。
+
+两条不变量防止这种情况：
+
+1. **所有 fan-out 路径都排除自身。** `GatewayState::live_instances`
+   会跳过 `(host, port)` 等于 Gateway 自身绑定地址的行，使用
+   `crates/dcc-mcp-http/src/gateway/sentinel.rs` 中的
+   `is_own_instance` 辅助函数。该函数将 localhost 别名
+   （`localhost` / `::1` / `0.0.0.0` / `[::]`）规范化为
+   `127.0.0.1`，这样即便适配器把 host 写成 `"localhost"`，当
+   Gateway 绑定到 `127.0.0.1` 时也能被正确过滤。
+   `backend_sub_handle` 订阅循环和 `compute_tools_fingerprint_with_own`
+   监听器都复用同一过滤规则。
+2. **启动订阅循环前执行同步卫生检查。** 在 `start_gateway_tasks`
+   内部，`backend_sub_handle` spawn **之前**会同步执行一次
+   `prune_dead_pids()` + `cleanup_stale()`。周期性清理任务每 15
+   秒才触发一次；没有这次同步前置扫描的话，上一次崩溃残留的幽灵
+   行会在 Gateway 启动后的前 ~15 秒内耗尽完整的指数退避重连预算。
+
 ## 代码指针
 
 | 组件 | 文件 |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2586,6 +2586,127 @@ No new top-level SKILL.md field → `skills-ref validate` stays green.
 
 ---
 
+## Remote-Server Extensions (issues #404–#411)
+
+Pure-Python modules that extend the MCP HTTP server towards cloud-hosted agents (Claude.ai, Cursor, ChatGPT, VS Code). All symbols re-exported from `dcc_mcp_core`. Per-module API reference lives in `docs/api/{auth,batch,elicitation,rich-content,plugin-manifest,dcc-api-executor}.md`; end-to-end deployment guide in `docs/guide/remote-server.md`.
+
+### `dcc_mcp_core.auth` (issue #408)
+
+Declarative auth configuration + Bearer-token validation.
+
+- `ApiKeyConfig(api_key=None, env_var="DCC_MCP_API_KEY", header_name="Authorization")` — dataclass; `.resolve()` returns field → env var → None.
+- `OAuthConfig(provider_url, client_id=None, scopes=[], client_name="dcc-mcp-server", redirect_uri=None)` — derived `.authorization_endpoint`, `.token_endpoint`, `.well_known_url`; `.to_cimd_document(redirect_uri=...)` builds `CimdDocument`.
+- `CimdDocument(client_name, redirect_uris, grant_types=["authorization_code"], response_types=["code"], token_endpoint_auth_method="none", scope=None, logo_uri=None, client_uri=None, contacts=[])` — `.to_dict()` produces the JSON served from `GET /.well-known/oauth-client-metadata`.
+- `validate_bearer_token(headers, *, expected_token, header_name="Authorization") -> bool` — constant-time compare via `secrets.compare_digest`; case-insensitive header lookup; `expected_token=None` disables auth with a warning.
+- `generate_api_key(length=32) -> str` — URL-safe base64 from `secrets.token_urlsafe`.
+- `TokenValidationError` — exception type (reserved; `validate_bearer_token` returns bool).
+
+Status: API key path ships today via `McpHttpConfig.api_key`. OAuth Rust-side enforcement (serving CIMD well-known + enforcing `/mcp` Bearer) tracked in #408.
+
+### `dcc_mcp_core.batch` (issue #406)
+
+Server-side batch + sandboxed eval — intermediate results never enter model context.
+
+- `batch_dispatch(dispatcher, calls, *, aggregate="list", stop_on_error=False) -> dict`
+  - `calls`: `list[tuple[str, dict]]`
+  - `aggregate`: `"list"` / `"merge"` / `"last"` — added result key matches the mode
+  - Returns always-present `total`, `succeeded`, `errors` plus the mode-specific payload
+  - Failed calls produce `{"index": i, "tool": name, "error": str}` records; when `stop_on_error=True` the batch halts on the first failure
+- `EvalContext(dispatcher, *, sandbox=True, timeout_secs=30)`
+  - `.run(script: str)` wraps in a function body so top-level `return` works; last-expression is NOT implicitly returned
+  - Sandbox strips `open`, `exec`, `eval`, `__import__`, `compile`, `getattr`, `setattr`, `delattr`, `vars`, `dir`, `globals`, `locals` from `__builtins__`
+  - POSIX-only `SIGALRM` timeout; silently skipped on Windows
+  - Inside script: `dispatch(tool_name, args_dict) -> dict` is available; `json` module pre-imported
+
+Rust-level `tools/batch` + `dcc_mcp_core__eval` built-in MCP tools tracked in #406 — they will call through these same helpers.
+
+### `dcc_mcp_core.elicitation` (issue #407)
+
+Pause a tool mid-call to ask the user for input (MCP 2025-11-25 Elicitation spec).
+
+- `ElicitationMode` enum: `FORM`, `URL`
+- `FormElicitation(message, schema, title=None)` / `UrlElicitation(message, url, description=None)` — parameter dataclasses
+- `ElicitationRequest(mode, params)` — wraps a mode + params pair
+- `ElicitationResponse(accepted, data=None, message=None)` — returned by the helpers
+- `await elicit_form(message, schema, *, title=None) -> ElicitationResponse` — async form
+- `await elicit_url(message, url, *, description=None) -> ElicitationResponse` — async URL flow
+- `elicit_form_sync(message, schema, *, title=None, fallback_values=None) -> ElicitationResponse` — blocking wrapper for DCC main-thread handlers; `fallback_values` (if provided) returns `accepted=True, message="fallback_values_used"`
+
+Status: Rust-side `notifications/elicitation/request` + `notifications/elicitation/response` wiring tracked in #407. Until then, helpers log a warning and return `accepted=False, message="elicitation_not_supported"` — safe fallback lets handlers written today upgrade automatically.
+
+### `dcc_mcp_core.rich_content` (issue #409, MCP Apps)
+
+Inline chart / form / dashboard / image / table results rendered by MCP-Apps-aware clients.
+
+- `RichContentKind` enum: `CHART`, `FORM`, `DASHBOARD`, `IMAGE`, `TABLE`
+- `RichContent(kind, payload)` dataclass + class-method constructors:
+  - `.chart(spec)` — Vega-Lite v5 / Chart.js spec dict
+  - `.form(schema, *, title=None)` — JSON-Schema form (one-shot display; distinct from `elicit_form`)
+  - `.image(data, mime="image/png", *, alt=None)` — base64-encodes raw bytes
+  - `.image_from_file(path, mime=None, *, alt=None)` — auto-detects MIME from extension
+  - `.table(headers, rows, *, title=None)` — grid
+  - `.dashboard(components)` — composite layout of other `RichContent`
+  - `.to_dict() -> dict` — flattens to `{"kind": value, **payload}`
+- `attach_rich_content(result, content) -> dict` — sets `result["context"]["__rich__"] = content.to_dict()`; backward-compatible with plain clients
+- Skill-script helpers (return ready-to-use skill dicts):
+  - `skill_success_with_chart(message, chart_spec, **context) -> dict`
+  - `skill_success_with_table(message, headers, rows, *, title=None, **context) -> dict`
+  - `skill_success_with_image(message, image_data=None, image_path=None, mime="image/png", *, alt=None, **context) -> dict` — raises `ValueError` if both `image_data` and `image_path` are `None`
+
+Rust-side MCP Apps envelope wiring tracked in #409. Today's `context.__rich__` placement is ignored by plain clients.
+
+### `dcc_mcp_core.plugin_manifest` (issue #410)
+
+Claude Code one-click plugin bundles.
+
+- `PluginManifest(name, version, description, mcp_servers, skills, sub_agents=[])` dataclass
+  - `.to_dict()` / `.to_json(indent=2)`
+- `build_plugin_manifest(dcc_name, mcp_url, skill_paths=None, *, version="0.1.0", description=None, api_key=None, extra_mcp_servers=None, sub_agents=None) -> dict`
+  - Plugin name auto-derives as `<dcc_name>-mcp`; description auto-generates when `None`
+  - `api_key` → injected into `mcp_servers[0].headers.Authorization` as `Bearer <key>`
+  - Non-existent `skill_paths` entries are dropped with a debug log
+- `export_plugin_manifest(manifest, path, *, indent=2) -> Path` — writes JSON, creates parent dirs, returns resolved path
+- Convenience: `DccServerBase.plugin_manifest(version="...")` auto-fills `mcp_url` + `skill_paths` from the running server
+
+### `dcc_mcp_core.dcc_api_executor` (issue #411)
+
+Two-tool Cloudflare-pattern wrapper — covers 1500+ DCC commands in ~500 tokens.
+
+- `DccApiCatalog(dcc_name, commands=None, catalog_text=None)`
+  - `commands`: `list[{name, signature, description}]`
+  - `catalog_text`: plain-text `name - description` per line; `#` comments + blank lines ignored
+  - `.add_command(name, *, signature="", description="")` — runtime append
+  - `.search(query, *, limit=10)` — tokenised BM25-lite over `name + description + signature`; stopwords dropped (`the`, `a`, `an`, `in`, `for`, `of`); score-sorted then alphabetical
+  - `len(catalog)` returns command count
+- `DccApiExecutor(dcc_name, catalog=None, dispatcher=None)`
+  - `.search(query, *, limit=10) -> dict` — `dcc_search` handler; zero-hit path returns `"results": []` + `"hint"`
+  - `.execute(code, *, timeout_secs=30) -> dict` — `dcc_execute` handler; runs code via `EvalContext(sandbox=True)`, `dispatch()` available when dispatcher passed; handles `TimeoutError` + `RuntimeError` into structured error dicts
+  - `.catalog` property exposes the underlying `DccApiCatalog`
+- `register_dcc_api_executor(server, executor, *, search_tool_name="dcc_search", execute_tool_name="dcc_execute") -> None` — register both tools on `McpHttpServer` BEFORE `server.start()`
+
+Typical agent flow: `dcc_search({"query": ...})` → narrow down commands → `dcc_execute({"code": "for i in range(5): dispatch('polySphere', {'position': [i,0,0]}); return {'created': 5}"})`. Only the final return value reaches the model.
+
+Rust-level built-in `dcc_search` / `dcc_execute` tools tracked in #411 — they will call through these same handlers.
+
+### Minimum `McpHttpConfig` for remote access
+
+```python
+cfg = McpHttpConfig(
+    port=8765,
+    host="0.0.0.0",              # bind to all interfaces (default "127.0.0.1")
+    enable_cors=True,            # required for browser / Claude.ai / Cursor
+    allowed_origins=["https://claude.ai", "https://cursor.sh"],
+    spawn_mode="dedicated",      # always for PyO3-embedded DCC hosts
+)
+cfg.api_key = os.environ["DCC_MCP_API_KEY"]   # Bearer token
+server = create_skill_server("maya", cfg)
+handle = server.start()
+```
+
+See `docs/guide/remote-server.md` for the Docker / systemd / k8s / reverse-proxy TLS recipes and the `examples/remote-server/` deployable reference.
+
+---
+
 ## Development
 
 - Tool manager: [vx](https://github.com/loonghao/vx)

--- a/llms.txt
+++ b/llms.txt
@@ -20,6 +20,14 @@
 | Write skill scripts | `skill_entry` + `skill_success` / `skill_error` — zero-boilerplate skill authoring |
 | Control skill trust level | `SkillScope` (Repo < User < System < Admin) — higher scope shadows lower |
 | Progressive tool exposure | `SkillGroup` with `default_active` + `activate_tool_group()` |
+| Remote-accessible MCP server (cloud agents) | `create_skill_server("maya", McpHttpConfig(host="0.0.0.0", port=8765, enable_cors=True))` — bind `0.0.0.0`, CORS on, Bearer auth via `cfg.api_key` |
+| Bearer-token / OAuth auth | `ApiKeyConfig`, `OAuthConfig`, `CimdDocument`, `validate_bearer_token(headers, expected_token=...)`, `generate_api_key()` |
+| Batch multiple tool calls server-side (issue #406) | `batch_dispatch(dispatcher, calls, aggregate="merge")` — returns `{total, succeeded, errors, merged}` |
+| Sandboxed script orchestration (issue #406) | `EvalContext(dispatcher, sandbox=True).run("...")` — script uses `dispatch(name, args)` |
+| Thin 2-tool surface for huge DCC APIs (issue #411) | `DccApiExecutor("maya", catalog, dispatcher)` + `register_dcc_api_executor(server, executor)` → `dcc_search`, `dcc_execute` |
+| Mid-call user input (issue #407) | `await elicit_form(message, schema)` / `elicit_form_sync(...)` / `await elicit_url(message, url)` — returns `ElicitationResponse` |
+| Inline chart / table / image result (MCP Apps, issue #409) | `skill_success_with_chart(msg, spec)` / `skill_success_with_table(msg, headers, rows)` / `skill_success_with_image(msg, image_data=...)` |
+| Claude Code one-click plugin bundle (issue #410) | `build_plugin_manifest(dcc_name, mcp_url, skill_paths, api_key=...)` + `export_plugin_manifest(manifest, path)` or `server.plugin_manifest(version=...)` |
 
 ## Quick Start
 
@@ -465,6 +473,159 @@ Opt-in via the `workflow` Cargo feature. Full spec-driven pipeline engine with s
 - **Python**: `from dcc_mcp_core import WorkflowSpec, WorkflowStep, StepPolicy, RetryPolicy, BackoffKind, WorkflowStatus`
 
 Full docs: `docs/guide/workflows.md`.
+
+## Remote-Server Extensions (issues #404–#411)
+
+Pure-Python helpers that enable cloud-hosted MCP agents (Claude.ai, Cursor, ChatGPT, VS Code) to reach your DCC server. All symbols are re-exported from `dcc_mcp_core`.
+
+### Auth (`#408`, `dcc_mcp_core.auth`)
+
+```python
+from dcc_mcp_core import (
+    ApiKeyConfig, OAuthConfig, CimdDocument,
+    validate_bearer_token, generate_api_key, TokenValidationError,
+)
+
+# API key — simplest: read from env, attach to McpHttpConfig
+cfg = McpHttpConfig(port=8765, host="0.0.0.0", enable_cors=True)
+cfg.api_key = ApiKeyConfig(env_var="DCC_MCP_API_KEY").resolve()
+
+# OAuth 2.1 + CIMD — serve /.well-known/oauth-client-metadata
+oauth = OAuthConfig(
+    provider_url="https://auth.example.com",
+    scopes=["scene:read", "render:write"],
+    client_name="Maya MCP Server",
+)
+cimd = oauth.to_cimd_document(redirect_uri="http://localhost:8765/oauth/callback")
+
+# Manual validation inside a pure-Python handler
+ok = validate_bearer_token(request_headers, expected_token=os.environ["DCC_MCP_API_KEY"])
+```
+
+### Batch Dispatch (`#406`, `dcc_mcp_core.batch`)
+
+```python
+from dcc_mcp_core import batch_dispatch, EvalContext
+
+# Sequential N calls → single aggregated summary; intermediate results never hit the model
+summary = batch_dispatch(
+    dispatcher,
+    [("get_scene_objects", {}), ("get_render_stats", {"layer": "beauty"})],
+    aggregate="merge",   # "list" | "merge" | "last"
+)
+summary["total"], summary["succeeded"], summary["errors"], summary["merged"]
+
+# Sandboxed script with access to dispatch() — the Cloudflare orchestration pattern
+ctx = EvalContext(dispatcher, sandbox=True, timeout_secs=30)
+keyframes = ctx.run("""
+frames = []
+for i in range(1, 11):
+    r = dispatch("get_frame_data", {"frame": i})
+    if r.get("output", {}).get("has_keyframe"):
+        frames.append(i)
+return frames
+""")
+```
+
+### Elicitation (`#407`, `dcc_mcp_core.elicitation`)
+
+```python
+from dcc_mcp_core import (
+    ElicitationMode, ElicitationRequest, ElicitationResponse,
+    FormElicitation, UrlElicitation,
+    elicit_form, elicit_form_sync, elicit_url,
+)
+
+# Async form (async def handlers)
+resp = await elicit_form(
+    message=f"Delete {n} objects? This cannot be undone.",
+    schema={"type": "object", "properties": {"confirm": {"type": "boolean"}}, "required": ["confirm"]},
+)
+if not resp.accepted or not resp.data.get("confirm"):
+    return {"success": False, "message": "Cancelled by user"}
+
+# Sync variant for DCC main-thread handlers; optional fallback_values for unsupported clients
+resp = elicit_form_sync(message="...", schema={...}, fallback_values={"confirm": True})
+
+# URL mode (OAuth / payment / credential collection)
+resp = await elicit_url(message="Authorize Shotgrid access", url="https://.../oauth/authorize?...")
+```
+
+Status: stubs return `accepted=False, message="elicitation_not_supported"` until Rust transport wires `notifications/elicitation/request`. Design handlers today — they upgrade automatically.
+
+### Rich Content / MCP Apps (`#409`, `dcc_mcp_core.rich_content`)
+
+```python
+from dcc_mcp_core import (
+    RichContent, RichContentKind, attach_rich_content,
+    skill_success_with_chart, skill_success_with_table, skill_success_with_image,
+)
+
+# Inline Vega-Lite chart from a skill script
+return skill_success_with_chart(
+    "Render complete",
+    chart_spec={
+        "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+        "data": {"values": stats},
+        "mark": "bar",
+        "encoding": {"x": {"field": "layer"}, "y": {"field": "time_secs"}},
+    },
+    total_frames=250,
+)
+
+# Table / image
+return skill_success_with_table("Scene objects", headers=["Name", "Type"], rows=[["pCube1", "mesh"]])
+return skill_success_with_image("Viewport captured", image_data=png_bytes, alt="Maya viewport")
+
+# Low-level: attach any RichContent to an existing result dict
+result = skill_success("Render complete", total_frames=250)
+return attach_rich_content(result, RichContent.dashboard([RichContent.chart({...}), RichContent.table(...)]))
+```
+
+Today rich content lives under `result.context["__rich__"]`; MCP-Apps-aware clients render it, others ignore gracefully. Full `tools/call` envelope wiring tracked in #409.
+
+### Plugin Manifest (`#410`, `dcc_mcp_core.plugin_manifest`)
+
+```python
+from dcc_mcp_core import PluginManifest, build_plugin_manifest, export_plugin_manifest
+
+manifest = build_plugin_manifest(
+    dcc_name="maya",
+    mcp_url="https://mcp.example.com/mcp",
+    skill_paths=["/opt/skills/maya-geometry"],
+    version="1.2.0",
+    api_key="studio-token",     # → headers.Authorization: Bearer …
+)
+export_plugin_manifest(manifest, "dist/maya-mcp.plugin.json")
+
+# Recommended on DccServerBase:
+manifest = server.plugin_manifest(version="1.2.0")
+```
+
+### DCC API Executor (`#411`, `dcc_mcp_core.dcc_api_executor`)
+
+Covers 2000+ DCC commands in a 2-tool surface (~500 tokens) — the "Cloudflare pattern" for DCC APIs.
+
+```python
+from dcc_mcp_core import DccApiCatalog, DccApiExecutor, register_dcc_api_executor
+
+catalog = DccApiCatalog("maya", catalog_text="""
+polyCube - Create a cube polygon mesh
+polySphere - Create a sphere polygon mesh
+select - Select nodes in the scene
+""")
+catalog.add_command("render", signature="render(frame)", description="Render the current frame")
+
+executor = DccApiExecutor("maya", catalog=catalog, dispatcher=dispatcher)
+register_dcc_api_executor(server, executor)   # before server.start()
+# tools/list now contains only: dcc_search, dcc_execute
+
+# Agent workflow:
+# dcc_search({"query": "create sphere"}) → finds polySphere
+# dcc_execute({"code": "dispatch('polySphere', {...}); return {'ok': True}"})
+```
+
+Full guide: `docs/guide/remote-server.md`. Per-module API: `docs/api/{auth,batch,elicitation,rich-content,plugin-manifest,dcc-api-executor}.md`.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

Backfill docs for the remote-server extensions landed in commit `66288af` (issues #404–#411). No runtime code changes — pure documentation + navigation + AI-index updates so agents can discover and use the new Python helpers.

**What changed**

- **VitePress sidebar** (`docs/.vitepress/config.mts`):
  - Add *Remote Server* link under **MCP + Skills System**.
  - New **Remote-Server Extensions** API group (6 pages) in both EN and ZH sidebars.
  - Bump version label `v0.14.6` → `v0.14.9`.
- **Six new API reference pages** (EN + ZH):
  - `api/auth.md` — `ApiKeyConfig`, `OAuthConfig`, `CimdDocument`, `validate_bearer_token`, `generate_api_key` (#408)
  - `api/batch.md` — `batch_dispatch`, `EvalContext` (#406)
  - `api/elicitation.md` — `elicit_form`, `elicit_form_sync`, `elicit_url` + dataclasses (#407)
  - `api/rich-content.md` — `RichContent`, `skill_success_with_{chart,table,image}`, `attach_rich_content` (#409)
  - `api/plugin-manifest.md` — `PluginManifest`, `build_plugin_manifest`, `export_plugin_manifest`, `DccServerBase.plugin_manifest()` (#410)
  - `api/dcc-api-executor.md` — `DccApiCatalog`, `DccApiExecutor`, `register_dcc_api_executor`, the Cloudflare 2-tool pattern (#411)
- **`AGENTS.md`**: five new decision-tree entries + summary-table rows so the navigation map reflects the new surface.
- **`llms.txt`** / **`llms-full.txt`**: new *Remote-Server Extensions* sections with compact usage snippets per module + extended Quick Decision Guide.

Every new page explains the current status vs the pending Rust-layer wiring, so skill authors can adopt the API today and upgrade automatically when the Rust PRs land.

## Test plan

- [ ] CI green (VitePress build, link check, lint)
- [ ] Confirm all 6 new `api/*.md` pages resolve from the sidebar (EN + ZH)
- [ ] Confirm AGENTS.md decision-tree links resolve
