### PR TITLE
fix(gateway): replace SSE total timeout with per-chunk idle timeout

### DIFF
--- a/crates/dcc-mcp-http/src/gateway/sse_subscriber.rs
+++ b/crates/dcc-mcp-http/src/gateway/sse_subscriber.rs
@@ -91,8 +91,19 @@ pub(crate) const RECONNECT_MAX: Duration = Duration::from_secs(10);
 /// Jitter multiplier applied to each reconnect delay (±25 %).
 pub(crate) const RECONNECT_JITTER: f32 = 0.25;
 
-/// Request timeout used when opening the backend SSE stream.
-pub(crate) const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+/// Idle/read timeout applied to the established backend SSE stream.
+///
+/// This caps how long the subscriber waits between consecutive chunks
+/// on the response body — **not** the total request duration. It must
+/// be noticeably larger than the server-side SSE keep-alive interval
+/// (axum's `KeepAlive::default()` emits a heartbeat every 15 s), so we
+/// pick 60 s to tolerate GC pauses and transient network stalls while
+/// still failing fast if the backend goes silent.
+///
+/// Do NOT pass this into `RequestBuilder::timeout()`; that would abort
+/// the long-lived stream after this interval and trigger an endless
+/// reconnect loop.
+pub(crate) const STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Default ceiling on how long a non-terminal `JobRoute` may live in
 /// the gateway's routing cache (`gateway_route_ttl`, issue #322).

--- a/crates/dcc-mcp-http/src/gateway/sse_subscriber/reconnect.rs
+++ b/crates/dcc-mcp-http/src/gateway/sse_subscriber/reconnect.rs
@@ -41,10 +41,23 @@ impl SubscriberManager {
     }
 
     pub(super) async fn open_stream(&self, url: &str) -> reqwest::Result<reqwest::Response> {
+        // NOTE: Intentionally do NOT call `.timeout(..)` here.
+        //
+        // `RequestBuilder::timeout()` in reqwest 0.13 applies to the *entire*
+        // request — including the streaming response body — so for an SSE
+        // subscription it would abort the long-lived stream as soon as the
+        // timeout elapsed, producing a recurring "error decoding response
+        // body" every few seconds (gateway SSE reconnect storm, visible in
+        // the logs as back-to-back `gatewayReconnect` events).
+        //
+        // The idle/heartbeat timeout for the established stream is enforced
+        // by `pump_stream` via `tokio::time::timeout` around each chunk
+        // read (see [`STREAM_IDLE_TIMEOUT`]), so the connect phase here
+        // only needs whatever default the shared `reqwest::Client` was
+        // built with.
         self.inner
             .http_client
             .get(url)
-            .timeout(CONNECT_TIMEOUT)
             .header("accept", "text/event-stream")
             .send()
             .await
@@ -54,7 +67,24 @@ impl SubscriberManager {
     pub(super) async fn pump_stream(&self, resp: reqwest::Response, shared: &BackendShared) {
         let mut stream = resp.bytes_stream();
         let mut scratch: Vec<u8> = Vec::with_capacity(4096);
-        while let Some(chunk) = stream.next().await {
+        loop {
+            // Apply an idle/read timeout *per chunk* rather than to the
+            // whole request — this keeps the long-lived SSE stream alive
+            // as long as the backend emits heartbeats within the window,
+            // while still failing fast if the backend stalls.
+            let chunk = match tokio::time::timeout(STREAM_IDLE_TIMEOUT, stream.next()).await {
+                Ok(Some(item)) => item,
+                // Stream terminated cleanly by the server.
+                Ok(None) => break,
+                Err(_) => {
+                    tracing::debug!(
+                        backend = %shared.url,
+                        idle_secs = STREAM_IDLE_TIMEOUT.as_secs(),
+                        "gateway SSE: read idle timeout — reconnecting"
+                    );
+                    break;
+                }
+            };
             let bytes = match chunk {
                 Ok(b) => b,
                 Err(e) => {

--- a/crates/dcc-mcp-http/src/gateway/sse_subscriber/tests.rs
+++ b/crates/dcc-mcp-http/src/gateway/sse_subscriber/tests.rs
@@ -409,3 +409,35 @@ fn forget_job_cleans_up_reverse_indexes() {
             .is_none_or(|s| !s.contains("j1"))
     );
 }
+
+// ── Regression: gateway SSE reconnect storm ────────────────────────
+//
+// History: `reconnect::open_stream` used to pass a 5 s
+// `CONNECT_TIMEOUT` into `RequestBuilder::timeout()`. reqwest treats
+// that as a *total* request timeout, so the long-lived SSE stream got
+// aborted every 5 s — producing a recurring
+// `error decoding response body` / `gatewayReconnect` loop in the
+// gateway logs while Maya was otherwise idle.
+//
+// The fix replaced the total timeout with a per-chunk idle timeout
+// (`STREAM_IDLE_TIMEOUT`) enforced inside `pump_stream`. This test
+// locks in the invariant that the idle window comfortably exceeds the
+// server-side SSE keep-alive interval so heartbeats cannot trip it.
+
+#[test]
+fn stream_idle_timeout_exceeds_axum_default_keepalive() {
+    // `axum::response::sse::KeepAlive::default()` emits a heartbeat
+    // every 15 s. The subscriber's idle timeout must be strictly
+    // larger than that, with enough slack for GC pauses and transient
+    // network stalls — otherwise an otherwise-healthy backend that
+    // only sends heartbeats (no real events) would be incorrectly
+    // classified as dead every `STREAM_IDLE_TIMEOUT`.
+    const AXUM_DEFAULT_KEEPALIVE_SECS: u64 = 15;
+    assert!(
+        STREAM_IDLE_TIMEOUT.as_secs() > AXUM_DEFAULT_KEEPALIVE_SECS * 2,
+        "STREAM_IDLE_TIMEOUT={}s must be comfortably greater than 2x the \
+         axum default keep-alive ({}s) to avoid spurious reconnects",
+        STREAM_IDLE_TIMEOUT.as_secs(),
+        AXUM_DEFAULT_KEEPALIVE_SECS
+    );
+}


### PR DESCRIPTION
## Problem

The gateway SSE subscriber used a 5-second \CONNECT_TIMEOUT\ via \RequestBuilder::timeout()\ which in reqwest applies to the **entire** request — including the streaming response body. For a long-lived SSE subscription this meant the stream was forcefully aborted every 5 seconds, producing:

- Recurring \rror decoding response body\ in gateway logs
- Back-to-back \gatewayReconnect\ SSE events pushed to clients
- Unnecessary CPU/network overhead from the reconnect storm

## Root Cause

eqwest::RequestBuilder::timeout()\ sets a **total request timeout** that covers the full response body transfer. SSE streams are designed to be long-lived, so applying a 5s total timeout kills the connection every 5 seconds regardless of activity.

## Fix

1. **Remove** the harmful \.timeout(CONNECT_TIMEOUT)\ from \open_stream()2. **Add** \	okio::time::timeout(STREAM_IDLE_TIMEOUT)\ around each chunk read inside \pump_stream()\ — this only fires if the backend goes silent for 60 seconds (well above axum's 15s keep-alive interval)
3. **Add** regression test ensuring \STREAM_IDLE_TIMEOUT > 2x\ axum default keep-alive to prevent future misconfiguration

## Files Changed

- \crates/dcc-mcp-http/src/gateway/sse_subscriber.rs\ — Rename \CONNECT_TIMEOUT\ to \STREAM_IDLE_TIMEOUT\ (60s), update doc comments
- \crates/dcc-mcp-http/src/gateway/sse_subscriber/reconnect.rs\ — Remove \.timeout()\, add per-chunk idle timeout in \pump_stream()- \crates/dcc-mcp-http/src/gateway/sse_subscriber/tests.rs\ — Add regression test

## Testing

- \cargo check\: 0 warnings
- \cargo clippy\: 0 warnings
- \cargo test\: 25 passed, 0 failed (including new regression test)