### PR TITLE
docs(skills): RFC thin-harness skill authoring pattern

### DIFF
--- a/docs/adr/003-thin-harness-skill-pattern.md
+++ b/docs/adr/003-thin-harness-skill-pattern.md
@@ -1,0 +1,71 @@
+# ADR 003 — Thin-Harness Skill Authoring Pattern
+
+**Status**: Accepted
+**Date**: 2026-04-25
+**Relates to**: Issue #425, [The Bitter Lesson of Agent Harnesses](https://sotasync.com/reader/2026-04-24-bitter-lesson-agent-harnesses/)
+
+---
+
+## Context
+
+DCC software APIs (`maya.cmds`, `bpy.ops`, `hou.*`, `pymxs.runtime`) are massively
+represented in LLM training corpora. Downstream adapters (e.g. `dcc-mcp-maya`) have
+historically shipped dozens of wrapper skills, each encoding 2–5 `cmds.*` calls.
+
+These thin wrappers create a **new naming convention + schema** the model must learn,
+instead of leveraging what it already knows. When a wrapper is missing, the agent
+asks for it — rather than writing the native call itself.
+
+Browser Use rewrote their agent harness from thousands of DOM helpers down to ~600
+lines: a thin CDP wrapper and a SKILL.md telling the agent how to use it. The agent
+now reads errors, greps references, and writes the function itself.
+
+---
+
+## Decision
+
+Adopt a **thin-harness skill layer** alongside the existing `infrastructure` / `domain` /
+`example` layers. A thin-harness skill:
+
+1. **Exposes raw script execution** — one `execute_python` (or DCC-equivalent) tool,
+   not a wrapper per API call.
+2. **Ships a `references/RECIPES.md`** sibling file with ~20 copy-pasteable snippets
+   for the most common operations. The agent reads the recipe, not the wrapper.
+3. **Ships a `references/INTROSPECTION.md`** sibling file explaining how to query
+   the live DCC namespace at runtime (`dcc_introspect__signature`, `dir()`, etc.).
+4. **Is the primary fall-through** when no domain skill matches the user's intent.
+
+---
+
+## Rationale
+
+| Approach | Pro | Con |
+|----------|-----|-----|
+| Wrapper per API call | Explicit schema validation | Model learns new names; N wrappers to maintain |
+| Thin harness + recipes | Leverages training corpus; 1 tool to maintain | Less input validation; agent writes raw code |
+| No skill at all | Zero maintenance | No guidance, no recipes, no tool listing |
+
+The thin-harness pattern wins for **well-trained APIs** (anything with Python bindings
+in the model's training set). Domain skills still win for **pipeline-level intent** —
+multi-step operations where explicit state management and error handling matter more
+than raw API flexibility.
+
+---
+
+## Consequences
+
+- **New `thin-harness` layer value** for `metadata.dcc-mcp.layer` in SKILL.md.
+- **New template** at `skills/templates/thin-harness/`.
+- **New routing guidance** in `docs/guide/thin-harness.md`.
+- **Downstream adapters** should elevate their existing `*-scripting` skills to
+  thin-harness layer and add `references/RECIPES.md` + `references/INTROSPECTION.md`.
+- **Domain skills** are unchanged — the thin-harness layer complements, not replaces.
+- **AGENTS.md Do list** updated: "If no domain skill matches, load the thin-harness
+  skill and check `references/RECIPES.md` before inventing a call."
+
+---
+
+## Related ADRs
+
+- ADR 002 — DCC Main-Thread Affinity (the `DeferredExecutor` pattern that
+  thin-harness skills must respect when making scene-mutating calls)

--- a/docs/guide/thin-harness.md
+++ b/docs/guide/thin-harness.md
@@ -1,0 +1,247 @@
+# Thin-Harness Skill Authoring Pattern
+
+> **TL;DR** — When no domain skill covers the user's intent, a thin-harness skill
+> hands the agent a raw script executor plus a recipe book. The agent reads the
+> recipe, writes the native DCC call, and submits it — no wrapper needed.
+> See [ADR 003](../adr/003-thin-harness-skill-pattern.md) for the architectural rationale.
+
+---
+
+## When to Write a Wrapper vs. a Thin Harness
+
+| Signal | Use this |
+|--------|----------|
+| Operation is 2–5 native API calls, well-documented in training data | **Thin harness** — ship `execute_python` + recipes |
+| Operation requires multi-step pipeline logic (render farm, shot export) | **Domain skill** — explicit schema + error handling |
+| Operation needs security validation before execution | **Domain skill** — `ToolValidator` + `SandboxPolicy` |
+| You're wrapping `maya.cmds`, `bpy.ops`, or `hou.*` one-to-one | **Thin harness** — agent already knows these APIs |
+| You need `next-tools` chaining across multiple DCC state changes | **Domain skill** — declare the chain explicitly |
+
+**Rule of thumb**: If the LLM training corpus contains 10,000+ examples of the native
+call, write a thin harness. If the operation is proprietary pipeline logic, write a
+domain skill.
+
+---
+
+## Skill Layer Values
+
+```yaml
+# SKILL.md metadata
+metadata:
+  dcc-mcp:
+    layer: thin-harness   # ← new value alongside infrastructure / domain / example
+```
+
+Routing: agents load thin-harness skills as the **fall-through** after searching
+domain skills. If `search_skills(query)` returns no domain match, the agent loads
+the DCC's thin-harness skill and checks `references/RECIPES.md`.
+
+---
+
+## Thin-Harness Skill Structure
+
+```
+my-dcc-scripting/
+├── SKILL.md                      # short, layer: thin-harness
+├── tools.yaml                    # execute_python + optional group
+├── scripts/
+│   └── execute.py                # raw script runner
+└── references/
+    ├── RECIPES.md                # ~20 copy-pasteable snippets
+    └── INTROSPECTION.md          # how to query the live DCC namespace
+```
+
+### SKILL.md
+
+```yaml
+---
+name: maya-scripting
+description: >-
+  Thin-harness skill — raw Maya Python script execution with recipes.
+  Use when no domain skill covers the operation and the agent knows the
+  maya.cmds / OpenMaya API. Not for pipeline-level intent — use
+  maya-pipeline domain skills for shot export, render farm, etc.
+license: MIT
+metadata:
+  dcc-mcp:
+    dcc: maya
+    layer: thin-harness
+    tools: tools.yaml
+    recipes: references/RECIPES.md
+    introspection: references/INTROSPECTION.md
+---
+
+Execute arbitrary Python inside the live Maya session.
+
+## When to use this skill
+
+- The user wants to call a specific `maya.cmds.*` function directly.
+- No domain skill covers the operation.
+- The user wants to inspect or iterate on raw DCC API calls.
+
+## When NOT to use this skill
+
+- Shot export → use `maya-pipeline__export_shot`
+- Render farm submission → use `maya-render__submit`
+- Any operation with multi-step error recovery → use a domain skill
+
+## Checklist before calling execute_python
+
+1. Check `references/RECIPES.md` for a working snippet.
+2. If no recipe matches, call `dcc_introspect__search` to find the right symbol.
+3. Submit the script. On error, read `_meta.dcc.raw_trace` for the failing call.
+```
+
+### tools.yaml
+
+```yaml
+tools:
+  - name: execute_python
+    description: >-
+      Execute a Python script string inside the live DCC interpreter.
+      When to use: when no domain skill covers the operation and you have
+      a working maya.cmds / bpy / hou snippet. How to use: pass the full
+      script as 'code'; check references/RECIPES.md first.
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: false
+    next-tools:
+      on-failure: [dcc_diagnostics__screenshot, dcc_diagnostics__audit_log]
+```
+
+### scripts/execute.py
+
+```python
+from __future__ import annotations
+
+from dcc_mcp_core import skill_entry, skill_success, skill_error
+
+
+@skill_entry
+def execute_python(code: str, timeout_secs: int = 30) -> dict:
+    """Execute a Python script string in the live DCC interpreter.
+
+    Args:
+        code: Python source to execute.
+        timeout_secs: Execution timeout. Default 30 s.
+
+    Returns:
+        skill_success with 'output' key on success, skill_error on failure.
+    """
+    import traceback
+
+    local_ns: dict = {}
+    try:
+        exec(compile(code, "<execute_python>", "exec"), {}, local_ns)  # noqa: S102
+        output = local_ns.get("result", None)
+        return skill_success("Script executed", output=output)
+    except Exception as exc:  # noqa: BLE001
+        return skill_error(
+            f"Script raised {type(exc).__name__}: {exc}",
+            underlying_call=code[:200],
+            traceback=traceback.format_exc(),
+        )
+```
+
+---
+
+## references/RECIPES.md Contract
+
+A flat Markdown file with anchored `##` sections. Each section:
+- One sentence describing when to use the recipe.
+- A ready-to-run Python snippet (≤15 lines).
+- No boilerplate imports — assume `import maya.cmds as cmds` etc. are in scope.
+
+```markdown
+## create_polygon_cube
+
+Create a named polygon cube at the origin.
+
+\`\`\`python
+cube = cmds.polyCube(name="myCube", w=1, h=1, d=1)[0]
+\`\`\`
+
+## set_world_translation
+
+Set absolute world-space translation (not relative).
+
+\`\`\`python
+cmds.xform("myCube", translation=(1, 2, 3), worldSpace=True)
+\`\`\`
+```
+
+Recipe anchor names become searchable via `recipes__get(skill=..., anchor=...)` once
+issue #428 lands.
+
+---
+
+## references/INTROSPECTION.md Contract
+
+Explains how the agent can discover the live DCC namespace without reading vendor docs.
+
+```markdown
+## List a module's public names
+
+\`\`\`python
+import maya.cmds as cmds
+result = [n for n in dir(cmds) if not n.startswith("_")]
+\`\`\`
+
+## Get a command's flags
+
+\`\`\`python
+help(cmds.polyCube)
+\`\`\`
+
+## Use dcc_introspect__* tools (issue #426)
+
+Once the dcc-introspect built-in skill is loaded:
+- ``dcc_introspect__list_module(module="maya.cmds")``
+- ``dcc_introspect__signature(qualname="maya.cmds.polyCube")``
+- ``dcc_introspect__search(pattern="poly.*", module="maya.cmds")``
+```
+
+---
+
+## Routing in AGENTS.md
+
+Add to `AGENTS.md` Do list (see also ADR 003):
+
+> **If no domain skill matches the user's intent**, load the DCC's `*-scripting`
+> (thin-harness) skill and read `references/RECIPES.md` before inventing a call.
+> Only fall back to raw `execute_python` if no recipe matches.
+
+---
+
+## Error Envelope Integration (issue #427)
+
+When a thin-harness `execute_python` call raises, the `_meta.dcc.raw_trace` block
+(when `McpHttpConfig.enable_error_raw_trace = True`) gives the agent:
+
+```jsonc
+{
+  "_meta": {
+    "dcc.raw_trace": {
+      "underlying_call": "cmds.polySphere(name='mySphere', radius=-1.0)",
+      "traceback": "...",
+      "recipe_hint": "references/RECIPES.md#create_sphere",
+      "introspect_hint": "dcc_introspect__signature(qualname='maya.cmds.polySphere')"
+    }
+  }
+}
+```
+
+The agent reads the trace, corrects the call, and resubmits — without asking for
+a new wrapper tool.
+
+---
+
+## Related
+
+- [ADR 003](../adr/003-thin-harness-skill-pattern.md) — architectural decision
+- [skills/templates/thin-harness/](../../skills/templates/thin-harness/) — starter template
+- [skills/README.md#skill-layering](../../skills/README.md) — layer definitions
+- Issue #426 — `dcc_introspect__*` built-in tools
+- Issue #427 — `_meta.dcc.raw_trace` error envelope
+- Issue #428 — `metadata.dcc-mcp.recipes` formalization

--- a/skills/README.md
+++ b/skills/README.md
@@ -59,15 +59,17 @@ export DCC_MCP_SKILL_PATHS="/path/to/my-skills"
 | [`dcc-specific`](templates/dcc-specific/) | DCC-bound skill (Maya, Blender, etc.) | `dcc:` field, `required_capabilities`, `next-tools` |
 | [`with-groups`](templates/with-groups/) | Progressive exposure via tool groups | `groups:` field, `default-active` toggle |
 | [`domain-skill`](templates/domain-skill/) | Business workflow skill with layering | `dcc-mcp.layer: domain`, negative routing, `depends:`, failure chains |
+| [`thin-harness`](templates/thin-harness/) | Raw script execution + recipe book (no wrappers) | `dcc-mcp.layer: thin-harness`, `recipes:`, `introspection:`, `execute_python` |
 
 ## Skill Layering
 
-Every skill must belong to one of three layers. Set the layer in `metadata`:
+Every skill must belong to one of four layers. Set the layer in `metadata`:
 
 ```yaml
 metadata:
   dcc-mcp.layer: infrastructure   # low-level reusable primitive
   # dcc-mcp.layer: domain         # business workflow, depends on infrastructure
+  # dcc-mcp.layer: thin-harness   # raw script execution + recipes (fall-through)
   # dcc-mcp.layer: example        # authoring reference, never used in production
 ```
 
@@ -77,6 +79,7 @@ metadata:
 |-------|------|---------|
 | **infrastructure** | Low-level, DCC-agnostic primitives. No business context. Stable API. Auto-loaded or shared across all servers. | `dcc-diagnostics`, `workflow`, `usd-tools`, `ffmpeg-media`, `imagemagick-tools`, `git-automation` |
 | **domain** | Business workflows for a specific DCC or task area. Depends on infrastructure skills. Loaded on-demand per DCC. | `maya-geometry`, `maya-pipeline`, `maya-animation`, `blender-rigging` |
+| **thin-harness** | Raw script execution + recipe book. Primary fall-through when no domain skill matches. One `execute_python` tool + `references/RECIPES.md`. See [thin-harness guide](../docs/guide/thin-harness.md). | `maya-scripting`, `blender-scripting`, `houdini-scripting` |
 | **example** | Authoring references and demos only. Never loaded in production environments. | `hello-world`, `multi-script`, `async-render-example`, `cancellable-loop` |
 
 ### Description pattern (required for all skills)

--- a/skills/templates/thin-harness/SKILL.md
+++ b/skills/templates/thin-harness/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: <dcc>-scripting
+description: >-
+  Thin-harness skill — raw <DCC> Python script execution with recipes.
+  Use when no domain skill covers the operation and the agent knows the
+  <dcc> API. Not for pipeline-level intent — use domain skills for
+  multi-step workflows, shot export, render farm, etc.
+license: MIT
+metadata:
+  dcc-mcp:
+    dcc: <dcc>
+    layer: thin-harness
+    tools: tools.yaml
+    recipes: references/RECIPES.md
+    introspection: references/INTROSPECTION.md
+---
+
+Execute arbitrary Python inside the live <DCC> session.
+
+## When to use this skill
+
+- The user wants to call a specific `<dcc>.*` function directly.
+- No domain skill covers the operation.
+- The user wants to inspect or iterate on raw DCC API calls.
+
+## When NOT to use this skill
+
+- Multi-step pipeline operations → use a domain skill
+- Operations requiring explicit error recovery → use a domain skill
+- Any operation where the user's intent maps to a named workflow → use a domain skill
+
+## Checklist before calling execute_python
+
+1. Check `references/RECIPES.md` for a working snippet.
+2. If no recipe matches, use `dcc_introspect__search` or `dir()` to find the right symbol.
+3. Submit the script. On error, read `_meta.dcc.raw_trace` for the failing call.
+4. Correct the call and resubmit — no new wrapper tool needed.

--- a/skills/templates/thin-harness/references/INTROSPECTION.md
+++ b/skills/templates/thin-harness/references/INTROSPECTION.md
@@ -1,0 +1,51 @@
+# Introspection — <DCC> Runtime Namespace
+
+> How to discover the live DCC API without reading vendor docs.
+> Replace `<module>` with the actual DCC Python module (e.g. `maya.cmds`, `bpy.ops`, `hou`).
+
+---
+
+## List a module's public names
+
+```python
+import <module>
+result = [n for n in dir(<module>) if not n.startswith("_")]
+```
+
+## Get a function's signature and docstring
+
+```python
+import <module>
+help(<module>.<function_name>)
+```
+
+## Search for functions matching a pattern
+
+```python
+import <module>, re
+pattern = re.compile(r"poly.*")
+result = [n for n in dir(<module>) if pattern.match(n)]
+```
+
+## Use dcc_introspect__* tools (issue #426)
+
+Once the `dcc-introspect` built-in skill is loaded:
+
+```
+dcc_introspect__list_module(module="<module>")
+  -> {"names": [...], "count": N}
+
+dcc_introspect__signature(qualname="<module>.<function>")
+  -> {"signature": "...", "doc": "...", "flags": {...}}
+
+dcc_introspect__search(pattern="poly.*", module="<module>", limit=20)
+  -> {"hits": [{"qualname": "...", "summary": "..."}, ...]}
+```
+
+## DCC-specific introspection
+
+Replace this section with DCC-specific discovery commands, e.g.:
+
+- **Maya**: `cmds.help("polyCube")` for flag docs, `mel.eval("whatIs polyCube")` for source
+- **Blender**: `bpy.ops.mesh.__dir__()`, `bpy.data.objects.bl_rna.properties`
+- **Houdini**: `hou.nodeTypeCategories()`, `help(hou.Node)`

--- a/skills/templates/thin-harness/references/RECIPES.md
+++ b/skills/templates/thin-harness/references/RECIPES.md
@@ -1,0 +1,61 @@
+# Recipes — <DCC> Scripting
+
+> Copy-pasteable snippets for common operations.
+> Each section is an anchor — use `recipes__get(skill="<dcc>-scripting", anchor="...")`.
+
+---
+
+## example_operation
+
+One sentence describing when to use this recipe.
+
+```python
+# Replace with a real DCC API call
+result = some_module.some_function(arg1, arg2)
+```
+
+---
+
+## list_selected_objects
+
+List the names of currently selected objects.
+
+```python
+# Replace with the DCC-specific selection API
+result = []  # e.g. cmds.ls(selection=True) in Maya
+```
+
+---
+
+## create_primitive
+
+Create a basic geometric primitive at the origin.
+
+```python
+# Replace with the DCC-specific primitive creation call
+result = None  # e.g. cmds.polyCube(name="myCube")[0] in Maya
+```
+
+---
+
+## set_transform
+
+Set the world-space position of an object (absolute, not relative).
+
+```python
+# Replace with the DCC-specific transform API
+# e.g. cmds.xform("myCube", translation=(1, 2, 3), worldSpace=True)
+pass
+```
+
+---
+
+## save_scene
+
+Save the current scene to its current file path.
+
+```python
+# Replace with the DCC-specific save API
+# e.g. cmds.file(save=True) in Maya
+pass
+```

--- a/skills/templates/thin-harness/scripts/execute.py
+++ b/skills/templates/thin-harness/scripts/execute.py
@@ -1,0 +1,39 @@
+"""Thin-harness execute_python skill script — raw DCC Python execution."""
+
+from __future__ import annotations
+
+from dcc_mcp_core import skill_entry
+from dcc_mcp_core import skill_error
+from dcc_mcp_core import skill_success
+
+
+@skill_entry
+def execute_python(code: str, timeout_secs: int = 30) -> dict:
+    """Execute a Python script string in the live DCC interpreter.
+
+    The script runs in an isolated namespace. Set ``result`` in the script
+    to return a value to the caller::
+
+        result = cmds.ls(selection=True)
+
+    Args:
+        code: Python source to execute.
+        timeout_secs: Execution timeout in seconds. Default 30.
+
+    Returns:
+        skill_success with ``output`` key on success, skill_error on failure.
+
+    """
+    import traceback
+
+    local_ns: dict = {}
+    try:
+        exec(compile(code, "<execute_python>", "exec"), {}, local_ns)
+        output = local_ns.get("result")
+        return skill_success("Script executed", output=output)
+    except Exception as exc:
+        return skill_error(
+            f"Script raised {type(exc).__name__}: {exc}",
+            underlying_call=code[:300],
+            traceback=traceback.format_exc(),
+        )

--- a/skills/templates/thin-harness/tools.yaml
+++ b/skills/templates/thin-harness/tools.yaml
@@ -1,0 +1,16 @@
+tools:
+  - name: execute_python
+    description: >-
+      Execute a Python script string inside the live DCC interpreter.
+      When to use: when no domain skill covers the operation and you have
+      a working DCC API snippet. How to use: pass the full script as
+      'code'; check references/RECIPES.md first; read
+      _meta.dcc.raw_trace on error.
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: false
+    next-tools:
+      on-failure:
+        - dcc_diagnostics__screenshot
+        - dcc_diagnostics__audit_log


### PR DESCRIPTION
## Summary

Implements the thin-harness skill authoring pattern from [The Bitter Lesson of Agent Harnesses](https://sotasync.com/reader/2026-04-24-bitter-lesson-agent-harnesses/).

Adds a fourth skill layer (alongside `infrastructure` / `domain` / `example`):

**`thin-harness`** — raw script execution + recipe book. The agent writes native DCC calls using recipe guidance, instead of calling wrapper tools.

## Changes

### New files
- `docs/adr/003-thin-harness-skill-pattern.md` — ADR explaining the wrapper vs thin-harness decision
- `docs/guide/thin-harness.md` — full authoring guide (when to use, structure, SKILL.md contract, tools.yaml, execute.py, RECIPES.md format, error envelope integration)
- `skills/templates/thin-harness/` — ready-to-copy starter template:
  - `SKILL.md` (layer: thin-harness, metadata pointers to sibling files)
  - `tools.yaml` (execute_python with ToolAnnotations + next-tools failure chain)
  - `scripts/execute.py` (raw script runner with skill_entry decorator)
  - `references/RECIPES.md` (anchored snippet format spec)
  - `references/INTROSPECTION.md` (live namespace discovery guide)

### Updated files
- `skills/README.md` — add thin-harness to template table + layer definitions (three → four layers)

## Rationale

LLM training corpora contain tens of thousands of `maya.cmds` / `bpy.ops` / `hou.*` examples. Every wrapper skill adds a new naming convention the model must learn. When a wrapper is missing, the agent asks for it — instead of writing the native call.

The thin-harness pattern: one `execute_python` tool + `references/RECIPES.md` with ~20 copy-pasteable snippets. Agent reads the recipe, writes the call, and resubmits on error — no new wrapper needed.

## Test plan

- [x] ADR explains decision criteria clearly
- [x] Guide documents SKILL.md contract, tools.yaml, execute.py, and RECIPES.md format
- [x] Template is self-contained and can be copied directly
- [x] `skills/README.md` layer table updated

Closes #425