### PR TITLE
feat(skill): add skill_error_with_trace for agent self-heal

### DIFF
--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -310,6 +310,7 @@ from dcc_mcp_core.skill import get_bundled_skills_dir
 from dcc_mcp_core.skill import run_main
 from dcc_mcp_core.skill import skill_entry
 from dcc_mcp_core.skill import skill_error
+from dcc_mcp_core.skill import skill_error_with_trace
 from dcc_mcp_core.skill import skill_exception
 from dcc_mcp_core.skill import skill_success
 from dcc_mcp_core.skill import skill_warning
@@ -534,6 +535,7 @@ __all__ = [
     "shutdown_telemetry",
     "skill_entry",
     "skill_error",
+    "skill_error_with_trace",
     "skill_exception",
     "skill_success",
     "skill_success_with_chart",

--- a/python/dcc_mcp_core/skill.py
+++ b/python/dcc_mcp_core/skill.py
@@ -66,6 +66,7 @@ __all__ = [
     "run_main",
     "skill_entry",
     "skill_error",
+    "skill_error_with_trace",
     "skill_exception",
     "skill_success",
     "skill_warning",
@@ -240,6 +241,119 @@ def skill_error(
         "error": error,
         "context": context,
     }
+
+
+def skill_error_with_trace(
+    message: str,
+    error: str,
+    *,
+    underlying_call: str | None = None,
+    recipe_hint: str | None = None,
+    introspect_hint: str | None = None,
+    tb: str | None = None,
+    prompt: str | None = None,
+    possible_solutions: list[str] | None = None,
+    **context: Any,
+) -> ResultDict:
+    """Return a failure result dict enriched with a diagnostic ``_meta.dcc.raw_trace`` block.
+
+    Designed for thin-harness ``execute_python`` skills and any handler that
+    wraps a native DCC API call: the trace block gives the calling agent enough
+    context to self-correct the call without asking for a new wrapper tool.
+
+    The ``_meta.dcc.raw_trace`` block is included only when at least one of
+    ``underlying_call``, ``recipe_hint``, or ``introspect_hint`` is non-empty.
+    When ``McpHttpConfig.enable_error_raw_trace`` is ``False`` (the production
+    default), the gateway strips this block before forwarding the response.
+
+    Parameters
+    ----------
+    message:
+        User-facing description of what went wrong.
+    error:
+        Technical error string (exception repr, error code …).
+    underlying_call:
+        The raw DCC API call that failed (e.g.
+        ``"maya.cmds.polySphere(name='mySphere', radius=-1.0)"``).
+        Truncated to 500 chars automatically.
+    recipe_hint:
+        Path + optional anchor to a recipe that covers this call
+        (e.g. ``"references/RECIPES.md#create_sphere"``).
+    introspect_hint:
+        A ready-to-call ``dcc_introspect__*`` expression that reveals
+        the live API contract
+        (e.g. ``"dcc_introspect__signature(qualname='maya.cmds.polySphere')"``).
+    tb:
+        Full formatted traceback string (``traceback.format_exc()``).
+        Stored in ``_meta.dcc.raw_trace.traceback``.
+    prompt:
+        Optional recovery hint for the agent.
+    possible_solutions:
+        Optional list of actionable suggestions.
+    **context:
+        Additional key/value pairs attached to ``context``.
+
+    Returns
+    -------
+    dict
+        Standard error dict with an additional ``_meta`` key::
+
+            {
+                "success": False,
+                "message": ...,
+                "error": ...,
+                "_meta": {
+                    "dcc.raw_trace": {
+                        "underlying_call": "...",
+                        "traceback": "...",
+                        "recipe_hint": "...",
+                        "introspect_hint": "...",
+                    }
+                }
+            }
+
+    Example
+    -------
+    .. code-block:: python
+
+        import traceback as _tb
+
+        try:
+            result = cmds.polySphere(name="mySphere", radius=radius)
+        except Exception as exc:
+            return skill_error_with_trace(
+                "Failed to create sphere",
+                str(exc),
+                underlying_call=f"maya.cmds.polySphere(name='mySphere', radius={radius})",
+                recipe_hint="references/RECIPES.md#create_sphere",
+                introspect_hint="dcc_introspect__signature(qualname='maya.cmds.polySphere')",
+                tb=_tb.format_exc(),
+            )
+
+    """
+    if possible_solutions:
+        context.setdefault("possible_solutions", possible_solutions)
+
+    raw_trace: dict[str, str] = {}
+    if underlying_call:
+        raw_trace["underlying_call"] = underlying_call[:500]
+    if tb:
+        raw_trace["traceback"] = tb
+    if recipe_hint:
+        raw_trace["recipe_hint"] = recipe_hint
+    if introspect_hint:
+        raw_trace["introspect_hint"] = introspect_hint
+
+    result: ResultDict = {
+        "success": False,
+        "message": message,
+        "prompt": prompt or "Check the error details and try again.",
+        "error": error,
+        "context": context,
+    }
+    if raw_trace:
+        result["_meta"] = {"dcc.raw_trace": raw_trace}
+    return result
 
 
 def skill_warning(

--- a/tests/test_skill_error_with_trace.py
+++ b/tests/test_skill_error_with_trace.py
@@ -1,0 +1,114 @@
+"""Tests for skill_error_with_trace helper (issue #427).
+
+Covers:
+- Basic contract: returns dict with success=False
+- _meta.dcc.raw_trace block is present when trace fields are given
+- _meta block is absent when no trace fields are given
+- underlying_call is truncated to 500 chars
+- All individual trace fields are optional
+- skill_error_with_trace is importable from top-level dcc_mcp_core
+- context kwargs are preserved alongside _meta
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_basic_contract():
+    from dcc_mcp_core import skill_error_with_trace
+
+    result = skill_error_with_trace("Something failed", "RuntimeError: oops")
+    assert result["success"] is False
+    assert result["message"] == "Something failed"
+    assert result["error"] == "RuntimeError: oops"
+
+
+def test_raw_trace_block_present():
+    from dcc_mcp_core import skill_error_with_trace
+
+    result = skill_error_with_trace(
+        "Failed to create sphere",
+        "RuntimeError: radius must be > 0",
+        underlying_call="maya.cmds.polySphere(name='x', radius=-1.0)",
+        recipe_hint="references/RECIPES.md#create_sphere",
+        introspect_hint="dcc_introspect__signature(qualname='maya.cmds.polySphere')",
+        tb="Traceback (most recent call last):\n  ...",
+    )
+    assert "_meta" in result
+    trace = result["_meta"]["dcc.raw_trace"]
+    assert trace["underlying_call"] == "maya.cmds.polySphere(name='x', radius=-1.0)"
+    assert trace["recipe_hint"] == "references/RECIPES.md#create_sphere"
+    assert trace["introspect_hint"] == "dcc_introspect__signature(qualname='maya.cmds.polySphere')"
+    assert "Traceback" in trace["traceback"]
+
+
+def test_meta_absent_when_no_trace_fields():
+    from dcc_mcp_core import skill_error_with_trace
+
+    result = skill_error_with_trace("Failed", "error string")
+    assert "_meta" not in result
+
+
+def test_underlying_call_truncated():
+    from dcc_mcp_core import skill_error_with_trace
+
+    long_call = "x" * 600
+    result = skill_error_with_trace("msg", "err", underlying_call=long_call)
+    assert len(result["_meta"]["dcc.raw_trace"]["underlying_call"]) == 500
+
+
+def test_partial_trace_fields():
+    from dcc_mcp_core import skill_error_with_trace
+
+    result = skill_error_with_trace("msg", "err", recipe_hint="RECIPES.md#foo")
+    trace = result["_meta"]["dcc.raw_trace"]
+    assert "recipe_hint" in trace
+    assert "underlying_call" not in trace
+    assert "traceback" not in trace
+
+
+def test_context_kwargs_preserved():
+    from dcc_mcp_core import skill_error_with_trace
+
+    result = skill_error_with_trace(
+        "msg",
+        "err",
+        underlying_call="some.call()",
+        extra_field="hello",
+        count=42,
+    )
+    assert result["context"]["extra_field"] == "hello"
+    assert result["context"]["count"] == 42
+
+
+def test_possible_solutions_in_context():
+    from dcc_mcp_core import skill_error_with_trace
+
+    result = skill_error_with_trace(
+        "msg",
+        "err",
+        possible_solutions=["Try radius > 0", "Check Maya version"],
+    )
+    assert result["context"]["possible_solutions"] == ["Try radius > 0", "Check Maya version"]
+
+
+def test_importable_from_top_level():
+    import dcc_mcp_core
+
+    assert hasattr(dcc_mcp_core, "skill_error_with_trace")
+    assert callable(dcc_mcp_core.skill_error_with_trace)
+
+
+def test_custom_prompt():
+    from dcc_mcp_core import skill_error_with_trace
+
+    result = skill_error_with_trace("msg", "err", prompt="Custom recovery hint")
+    assert result["prompt"] == "Custom recovery hint"
+
+
+def test_default_prompt_present():
+    from dcc_mcp_core import skill_error_with_trace
+
+    result = skill_error_with_trace("msg", "err")
+    assert result["prompt"]


### PR DESCRIPTION
## Summary

Add `skill_error_with_trace()` — a new result builder that attaches a diagnostic `_meta.dcc.raw_trace` block to the error envelope, giving the calling agent the information needed to self-correct a failed DCC API call without asking for a new wrapper tool.

## Problem

When `execute_python` or a wrapper skill raises, the current error envelope is human-friendly but opaque:

`json
{
  "success": false,
  "message": "Failed to create sphere",
  "error": "RuntimeError: flag 'radius' must be > 0"
}
`

An agent seeing this has no way to know what `maya.cmds` call was attempted, which arguments were wrong, or how to fix it. Its best move is to guess again with the same wrapper, which loops.

## Solution

`python
from dcc_mcp_core import skill_error_with_trace

return skill_error_with_trace(
    "Failed to create sphere",
    str(exc),
    underlying_call=f"maya.cmds.polySphere(name='x', radius={radius})",
    recipe_hint="references/RECIPES.md#create_sphere",
    introspect_hint="dcc_introspect__signature(qualname='maya.cmds.polySphere')",
    tb=traceback.format_exc(),
)
`

Result:
`jsonc
{
  "success": false,
  "message": "Failed to create sphere",
  "_meta": {
    "dcc.raw_trace": {
      "underlying_call": "maya.cmds.polySphere(..., radius=-1.0)",
      "traceback": "...",
      "recipe_hint": "references/RECIPES.md#create_sphere",
      "introspect_hint": "dcc_introspect__signature(qualname='maya.cmds.polySphere')"
    }
  }
}
`

## Changes

- `python/dcc_mcp_core/skill.py` — `skill_error_with_trace()` with full docstring
- `python/dcc_mcp_core/__init__.py` — re-export + add to `__all__`
- `tests/test_skill_error_with_trace.py` — 10 tests covering all branches

## Notes

- Gateway stripping (`McpHttpConfig.enable_error_raw_trace`) is a Rust-side follow-up
- The `_meta` block is omitted when no trace fields are provided (backward compatible)
- `underlying_call` is truncated to 500 chars to avoid bloated responses

Closes #427