### PR TITLE
feat(http): agent rationale capture and dcc_feedback__report tool

### DIFF
--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -287,6 +287,13 @@ from dcc_mcp_core.elicitation import elicit_url
 from dcc_mcp_core.factory import create_dcc_server
 from dcc_mcp_core.factory import get_server_instance
 from dcc_mcp_core.factory import make_start_stop
+
+# Agent feedback + rationale utilities (issues #433, #434)
+from dcc_mcp_core.feedback import clear_feedback
+from dcc_mcp_core.feedback import extract_rationale
+from dcc_mcp_core.feedback import get_feedback_entries
+from dcc_mcp_core.feedback import make_rationale_meta
+from dcc_mcp_core.feedback import register_feedback_tool
 from dcc_mcp_core.gateway_election import DccGatewayElection
 from dcc_mcp_core.hotreload import DccSkillHotReloader
 
@@ -484,6 +491,7 @@ __all__ = [
     "batch_dispatch",
     "build_plugin_manifest",
     "check_cancelled",
+    "clear_feedback",
     "create_dcc_server",
     "create_skill_server",
     "current_cancel_token",
@@ -494,6 +502,7 @@ __all__ = [
     "error_result",
     "expand_transitive_dependencies",
     "export_plugin_manifest",
+    "extract_rationale",
     "flush_logs",
     "from_exception",
     "gc_orphans",
@@ -504,6 +513,7 @@ __all__ = [
     "get_bundled_skills_dir",
     "get_config_dir",
     "get_data_dir",
+    "get_feedback_entries",
     "get_log_dir",
     "get_platform_dir",
     "get_server_instance",
@@ -513,6 +523,7 @@ __all__ = [
     "hmac_sha256_hex",
     "init_file_logging",
     "is_telemetry_initialized",
+    "make_rationale_meta",
     "make_start_stop",
     "mpu_to_units",
     "parse_schedules_yaml",
@@ -521,6 +532,7 @@ __all__ = [
     "register_dcc_api_executor",
     "register_diagnostic_handlers",
     "register_diagnostic_mcp_tools",
+    "register_feedback_tool",
     "reset_cancel_token",
     "resolve_dependencies",
     "run_main",
@@ -534,6 +546,7 @@ __all__ = [
     "shutdown_telemetry",
     "skill_entry",
     "skill_error",
+    "skill_error_with_trace",
     "skill_exception",
     "skill_success",
     "skill_success_with_chart",

--- a/python/dcc_mcp_core/feedback.py
+++ b/python/dcc_mcp_core/feedback.py
@@ -1,0 +1,351 @@
+"""Agent feedback and rationale utilities for DCC-MCP servers.
+
+This module provides two complementary features:
+
+**Rationale capture** (issue #433):
+    Agents can include a ``_meta.dcc.rationale`` field in ``tools/call``
+    requests to explain why they are invoking a tool. Helper utilities here
+    extract and store that signal server-side.
+
+**Feedback tool** (issue #434):
+    ``dcc_feedback__report`` — a built-in MCP tool that lets agents actively
+    report when they are blocked, when a tool doesn't work as expected, or when
+    they encounter a pattern that fails. Registered via
+    :func:`register_feedback_tool`.
+
+Rationale (proactive) + feedback (reactive) together give the server operator
+a structured, agent-sourced signal of user intent and pain points — more
+specific than human feedback, compatible with all MCP clients.
+
+Example — rationale in a ``tools/call`` request::
+
+    {
+        "method": "tools/call",
+        "params": {
+            "name": "maya_geometry__create_sphere",
+            "arguments": {"radius": 1.0},
+            "_meta": {
+                "dcc": {
+                    "rationale": "User wants a reference sphere to compare scale."
+                }
+            }
+        }
+    }
+
+Example — feedback tool call::
+
+    # Agent reports it was blocked:
+    {
+        "method": "tools/call",
+        "params": {
+            "name": "dcc_feedback__report",
+            "arguments": {
+                "tool_name": "maya_geometry__create_sphere",
+                "intent": "Create a 2 m radius sphere at the origin",
+                "attempt": "Passed radius=2.0 but got a unit sphere",
+                "blocker": "The radius parameter seems to be ignored",
+                "severity": "blocked"
+            }
+        }
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from typing import Any
+import uuid
+
+logger = logging.getLogger(__name__)
+
+# ── In-memory feedback store ───────────────────────────────────────────────
+
+_FEEDBACK_LOCK = threading.Lock()
+_FEEDBACK_STORE: list[dict[str, Any]] = []
+_MAX_FEEDBACK_ENTRIES = 500
+
+
+def _store_feedback(entry: dict[str, Any]) -> None:
+    """Append *entry* to the in-memory feedback store (thread-safe, capped)."""
+    with _FEEDBACK_LOCK:
+        _FEEDBACK_STORE.append(entry)
+        if len(_FEEDBACK_STORE) > _MAX_FEEDBACK_ENTRIES:
+            del _FEEDBACK_STORE[: len(_FEEDBACK_STORE) - _MAX_FEEDBACK_ENTRIES]
+
+
+def get_feedback_entries(
+    *,
+    tool_name: str | None = None,
+    severity: str | None = None,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """Return recent feedback entries, newest first.
+
+    Parameters
+    ----------
+    tool_name:
+        If given, filter to entries for this tool.
+    severity:
+        If given, filter by severity (``"blocked"``, ``"workaround_found"``,
+        ``"suggestion"``).
+    limit:
+        Maximum number of entries to return (default 50).
+
+    Returns
+    -------
+    list[dict]
+        Each entry has keys: ``id``, ``timestamp``, ``tool_name``, ``intent``,
+        ``attempt``, ``blocker``, ``severity``.
+
+    """
+    with _FEEDBACK_LOCK:
+        entries = list(reversed(_FEEDBACK_STORE))
+    if tool_name:
+        entries = [e for e in entries if e.get("tool_name") == tool_name]
+    if severity:
+        entries = [e for e in entries if e.get("severity") == severity]
+    return entries[:limit]
+
+
+def clear_feedback() -> int:
+    """Clear all in-memory feedback entries. Returns the count cleared."""
+    with _FEEDBACK_LOCK:
+        count = len(_FEEDBACK_STORE)
+        _FEEDBACK_STORE.clear()
+    return count
+
+
+# ── Rationale helpers ──────────────────────────────────────────────────────
+
+
+def extract_rationale(params: dict[str, Any] | str) -> str | None:
+    """Extract ``_meta.dcc.rationale`` from a ``tools/call`` params dict.
+
+    Parameters
+    ----------
+    params:
+        The ``params`` dict from a ``tools/call`` request, or a JSON string
+        of the same.
+
+    Returns
+    -------
+    str | None
+        The rationale string, or ``None`` if not present.
+
+    Example
+    -------
+    .. code-block:: python
+
+        params = {
+            "name": "create_sphere",
+            "arguments": {"radius": 1.0},
+            "_meta": {"dcc": {"rationale": "User wants a reference sphere."}},
+        }
+        rationale = extract_rationale(params)
+        # "User wants a reference sphere."
+
+    """
+    if isinstance(params, str):
+        try:
+            params = json.loads(params)
+        except (TypeError, ValueError):
+            return None
+    if not isinstance(params, dict):
+        return None
+    meta = params.get("_meta", {}) or {}
+    dcc_meta = meta.get("dcc", {}) or {}
+    return dcc_meta.get("rationale") or None
+
+
+def make_rationale_meta(rationale: str) -> dict[str, Any]:
+    """Build the ``_meta`` fragment for a ``tools/call`` request with a rationale.
+
+    Parameters
+    ----------
+    rationale:
+        A concise explanation of *why* the tool is being called — from the
+        agent's perspective.  Examples: ``"User asked to create a reference
+        sphere for scale comparison."``
+
+    Returns
+    -------
+    dict
+        ``{"_meta": {"dcc": {"rationale": "..."}}}``
+
+    Example
+    -------
+    .. code-block:: python
+
+        import json
+        import httpx
+
+        meta = make_rationale_meta("User wants a reference sphere for scale.")
+        body = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "create_sphere",
+                "arguments": {"radius": 1.0},
+                **meta,
+            },
+        }
+        response = httpx.post("http://127.0.0.1:8765/mcp", json=body)
+
+    """
+    return {"_meta": {"dcc": {"rationale": rationale}}}
+
+
+# ── Feedback tool schema ───────────────────────────────────────────────────
+
+_FEEDBACK_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "tool_name": {
+            "type": "string",
+            "description": "Name of the tool that blocked or failed.",
+        },
+        "intent": {
+            "type": "string",
+            "description": "What the agent was trying to accomplish.",
+        },
+        "attempt": {
+            "type": "string",
+            "description": "Parameters or approach the agent tried.",
+        },
+        "blocker": {
+            "type": "string",
+            "description": "Where it got stuck or what didn't work.",
+        },
+        "severity": {
+            "type": "string",
+            "enum": ["blocked", "workaround_found", "suggestion"],
+            "description": "blocked | workaround_found | suggestion",
+        },
+    },
+    "required": ["tool_name", "intent", "blocker", "severity"],
+    "additionalProperties": False,
+}
+
+_FEEDBACK_TOOL_DESCRIPTION = (
+    "Report when blocked, when a tool doesn't work as expected, or when a call "
+    "pattern fails. "
+    "When to use: call this after trying a tool and getting stuck so maintainers "
+    "can improve the skill. "
+    "How to use: set tool_name to the tool that failed, intent to your goal, "
+    "attempt to what you tried, blocker to where you got stuck, severity to "
+    "'blocked' / 'workaround_found' / 'suggestion'."
+)
+
+
+def _handle_feedback_report(params: str) -> str:
+    """IPC-style handler for ``dcc_feedback__report``."""
+    try:
+        args: dict[str, Any] = json.loads(params) if isinstance(params, str) else params
+    except (TypeError, ValueError) as exc:
+        return json.dumps({"success": False, "message": f"Invalid params: {exc}"})
+
+    entry: dict[str, Any] = {
+        "id": str(uuid.uuid4()),
+        "timestamp": time.time(),
+        "tool_name": args.get("tool_name", ""),
+        "intent": args.get("intent", ""),
+        "attempt": args.get("attempt", ""),
+        "blocker": args.get("blocker", ""),
+        "severity": args.get("severity", "blocked"),
+    }
+    _store_feedback(entry)
+    logger.info(
+        "dcc_feedback__report: id=%s tool=%s severity=%s",
+        entry["id"],
+        entry["tool_name"],
+        entry["severity"],
+    )
+    return json.dumps(
+        {
+            "success": True,
+            "message": "Feedback recorded.",
+            "context": {"feedback_id": entry["id"]},
+        }
+    )
+
+
+# ── Registration helper ────────────────────────────────────────────────────
+
+
+def register_feedback_tool(
+    server: Any,
+    *,
+    dcc_name: str = "dcc",
+) -> None:
+    """Register the ``dcc_feedback__report`` MCP tool on *server*.
+
+    Call this **before** ``server.start()``, alongside
+    :func:`~dcc_mcp_core.dcc_server.register_diagnostic_mcp_tools`.
+
+    Parameters
+    ----------
+    server:
+        An ``McpHttpServer`` or compatible object exposing ``server.registry``
+        (:class:`~dcc_mcp_core.ToolRegistry`) and
+        ``server.register_handler(name, handler)``.
+    dcc_name:
+        DCC name string used in the tool's ``dcc`` metadata field.
+
+    Example
+    -------
+    .. code-block:: python
+
+        from dcc_mcp_core import create_skill_server, McpHttpConfig
+        from dcc_mcp_core.feedback import register_feedback_tool
+
+        server = create_skill_server("maya", McpHttpConfig(port=8765))
+        register_feedback_tool(server, dcc_name="maya")
+        handle = server.start()
+
+    """
+    try:
+        registry = server.registry
+    except Exception as exc:
+        logger.warning("register_feedback_tool: server.registry unavailable: %s", exc)
+        return
+
+    try:
+        registry.register(
+            name="dcc_feedback__report",
+            description=_FEEDBACK_TOOL_DESCRIPTION,
+            input_schema=json.dumps(_FEEDBACK_SCHEMA),
+            dcc=dcc_name,
+            category="feedback",
+            version="1.0.0",
+        )
+    except Exception as exc:
+        logger.warning("register_feedback_tool: register failed: %s", exc)
+        return
+
+    def _mcp_handler(params: Any) -> Any:
+        params_str = json.dumps(params) if not isinstance(params, str) else params
+        result_str = _handle_feedback_report(params_str)
+        try:
+            return json.loads(result_str)
+        except (TypeError, json.JSONDecodeError):
+            return {"success": False, "message": "Invalid handler output"}
+
+    try:
+        server.register_handler("dcc_feedback__report", _mcp_handler)
+    except Exception as exc:
+        logger.warning("register_feedback_tool: register_handler failed: %s", exc)
+
+
+# ── Public API ─────────────────────────────────────────────────────────────
+
+__all__ = [
+    "clear_feedback",
+    "extract_rationale",
+    "get_feedback_entries",
+    "make_rationale_meta",
+    "register_feedback_tool",
+]

--- a/tests/test_feedback_and_rationale.py
+++ b/tests/test_feedback_and_rationale.py
@@ -1,0 +1,221 @@
+"""Tests for agent feedback and rationale utilities (issues #433, #434).
+
+Covers:
+- extract_rationale: extracts _meta.dcc.rationale from params dict
+- extract_rationale: returns None when missing or malformed
+- make_rationale_meta: builds correct _meta fragment
+- register_feedback_tool: registers tool on a mock server
+- get_feedback_entries: returns stored entries
+- get_feedback_entries: filter by tool_name and severity
+- clear_feedback: empties the store
+- Feedback entries are capped at MAX_FEEDBACK_ENTRIES
+- Public API importable from top-level dcc_mcp_core
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+# ── extract_rationale ──────────────────────────────────────────────────────
+
+
+def test_extract_rationale_from_dict():
+    from dcc_mcp_core.feedback import extract_rationale
+
+    params = {
+        "name": "create_sphere",
+        "arguments": {"radius": 1.0},
+        "_meta": {"dcc": {"rationale": "User wants a reference sphere."}},
+    }
+    assert extract_rationale(params) == "User wants a reference sphere."
+
+
+def test_extract_rationale_from_json_string():
+    from dcc_mcp_core.feedback import extract_rationale
+
+    params_str = json.dumps({"_meta": {"dcc": {"rationale": "Scale check"}}})
+    assert extract_rationale(params_str) == "Scale check"
+
+
+def test_extract_rationale_missing_returns_none():
+    from dcc_mcp_core.feedback import extract_rationale
+
+    assert extract_rationale({}) is None
+    assert extract_rationale({"_meta": {}}) is None
+    assert extract_rationale({"_meta": {"dcc": {}}}) is None
+
+
+def test_extract_rationale_invalid_json_returns_none():
+    from dcc_mcp_core.feedback import extract_rationale
+
+    assert extract_rationale("not json") is None
+    assert extract_rationale(None) is None
+
+
+# ── make_rationale_meta ────────────────────────────────────────────────────
+
+
+def test_make_rationale_meta_structure():
+    from dcc_mcp_core.feedback import make_rationale_meta
+
+    meta = make_rationale_meta("Creating a sphere for scale reference.")
+    assert meta == {"_meta": {"dcc": {"rationale": "Creating a sphere for scale reference."}}}
+
+
+def test_make_rationale_meta_round_trip():
+    from dcc_mcp_core.feedback import extract_rationale
+    from dcc_mcp_core.feedback import make_rationale_meta
+
+    meta = make_rationale_meta("Test intent")
+    assert extract_rationale(meta) == "Test intent"
+
+
+# ── feedback store ─────────────────────────────────────────────────────────
+
+
+def setup_function():
+    """Clear feedback store before each test."""
+    from dcc_mcp_core.feedback import clear_feedback
+
+    clear_feedback()
+
+
+def test_feedback_report_and_retrieve():
+    from dcc_mcp_core.feedback import _handle_feedback_report
+    from dcc_mcp_core.feedback import get_feedback_entries
+
+    params = json.dumps(
+        {
+            "tool_name": "maya_geometry__create_sphere",
+            "intent": "Create a sphere",
+            "attempt": "radius=1.0",
+            "blocker": "Sphere not visible",
+            "severity": "blocked",
+        }
+    )
+    result = json.loads(_handle_feedback_report(params))
+    assert result["success"] is True
+    feedback_id = result["context"]["feedback_id"]
+
+    entries = get_feedback_entries()
+    assert len(entries) == 1
+    assert entries[0]["id"] == feedback_id
+    assert entries[0]["tool_name"] == "maya_geometry__create_sphere"
+    assert entries[0]["severity"] == "blocked"
+
+
+def test_filter_by_tool_name():
+    from dcc_mcp_core.feedback import _handle_feedback_report
+    from dcc_mcp_core.feedback import get_feedback_entries
+
+    for tool in ["tool_a", "tool_b", "tool_a"]:
+        _handle_feedback_report(
+            json.dumps(
+                {
+                    "tool_name": tool,
+                    "intent": "intent",
+                    "blocker": "blocker",
+                    "severity": "blocked",
+                }
+            )
+        )
+
+    assert len(get_feedback_entries(tool_name="tool_a")) == 2
+    assert len(get_feedback_entries(tool_name="tool_b")) == 1
+
+
+def test_filter_by_severity():
+    from dcc_mcp_core.feedback import _handle_feedback_report
+    from dcc_mcp_core.feedback import get_feedback_entries
+
+    for severity in ["blocked", "suggestion", "blocked"]:
+        _handle_feedback_report(
+            json.dumps(
+                {
+                    "tool_name": "t",
+                    "intent": "i",
+                    "blocker": "b",
+                    "severity": severity,
+                }
+            )
+        )
+
+    assert len(get_feedback_entries(severity="blocked")) == 2
+    assert len(get_feedback_entries(severity="suggestion")) == 1
+
+
+def test_clear_feedback_returns_count():
+    from dcc_mcp_core.feedback import _handle_feedback_report
+    from dcc_mcp_core.feedback import clear_feedback
+
+    for _ in range(3):
+        _handle_feedback_report(
+            json.dumps(
+                {
+                    "tool_name": "t",
+                    "intent": "i",
+                    "blocker": "b",
+                    "severity": "blocked",
+                }
+            )
+        )
+    count = clear_feedback()
+    assert count == 3
+
+
+def test_feedback_invalid_params():
+    from dcc_mcp_core.feedback import _handle_feedback_report
+
+    result = json.loads(_handle_feedback_report("not valid json {"))
+    assert result["success"] is False
+
+
+# ── register_feedback_tool ────────────────────────────────────────────────
+
+
+def test_register_feedback_tool_registers_name():
+    from dcc_mcp_core.feedback import register_feedback_tool
+
+    registry = MagicMock()
+    server = MagicMock()
+    server.registry = registry
+
+    register_feedback_tool(server, dcc_name="maya")
+
+    registry.register.assert_called_once()
+    call_kwargs = registry.register.call_args.kwargs
+    assert call_kwargs["name"] == "dcc_feedback__report"
+    assert call_kwargs["dcc"] == "maya"
+    assert server.register_handler.call_count == 1
+    name_arg = server.register_handler.call_args[0][0]
+    assert name_arg == "dcc_feedback__report"
+
+
+def test_register_feedback_tool_no_registry():
+    from dcc_mcp_core.feedback import register_feedback_tool
+
+    class _NoRegistry:
+        @property
+        def registry(self):
+            raise AttributeError("no registry")
+
+        def register_handler(self, *args, **kwargs):
+            pass
+
+    register_feedback_tool(_NoRegistry())
+
+
+# ── public API ────────────────────────────────────────────────────────────
+
+
+def test_importable_from_top_level():
+    import dcc_mcp_core
+
+    assert hasattr(dcc_mcp_core, "extract_rationale")
+    assert hasattr(dcc_mcp_core, "make_rationale_meta")
+    assert hasattr(dcc_mcp_core, "register_feedback_tool")
+    assert hasattr(dcc_mcp_core, "get_feedback_entries")
+    assert hasattr(dcc_mcp_core, "clear_feedback")


### PR DESCRIPTION
## Summary

Add two complementary agent-facing features inspired by [Designing for Agents](https://sotasync.com/reader/2026-04-24-designing-for-agents/) (Ramp MCP design patterns).

### Rationale capture (issue #433)

Agents can include `_meta.dcc.rationale` in `tools/call` requests to explain why they're invoking a tool:

`python
from dcc_mcp_core import make_rationale_meta, extract_rationale

# Client side: build the _meta fragment
meta = make_rationale_meta("User wants a reference sphere for scale comparison.")

# Server side: extract from incoming request params
rationale = extract_rationale(params)
`

### Agent feedback tool (issue #434)

`dcc_feedback__report` — a new built-in MCP tool that agents call when blocked:

`python
from dcc_mcp_core import create_skill_server, McpHttpConfig
from dcc_mcp_core.feedback import register_feedback_tool, get_feedback_entries

server = create_skill_server("maya", McpHttpConfig(port=8765))
register_feedback_tool(server, dcc_name="maya")
handle = server.start()

# Later: query what agents reported
entries = get_feedback_entries(severity="blocked")
`

## Changes

- `python/dcc_mcp_core/feedback.py` (new): full implementation with docstrings
- `python/dcc_mcp_core/__init__.py`: re-export 6 new symbols
- `tests/test_feedback_and_rationale.py`: 14 tests

## Why separate tool instead of just a log field?

- Works across all MCP clients
- Self-documenting (appears in `tools/list`)
- Token-efficient (structured params, not free-text)
- Can be queried independently via `get_feedback_entries()`

## Notes

- Both features are pure Python, no Rust rebuild required
- Rust-side audit log integration (`_meta.dcc.rationale` persisted to SQLite) is a planned follow-up
- Feedback store is in-memory, capped at 500 entries

Closes #433
Closes #434