### PR TITLE
feat: add metadata.dcc-mcp.recipes sibling-file + recipes__list/get tools

### DIFF
--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -295,6 +295,12 @@ from dcc_mcp_core.plugin_manifest import PluginManifest
 from dcc_mcp_core.plugin_manifest import build_plugin_manifest
 from dcc_mcp_core.plugin_manifest import export_plugin_manifest
 
+# Recipes system: metadata.dcc-mcp.recipes + recipes__list/get tools (issue #428)
+from dcc_mcp_core.recipes import get_recipe_content
+from dcc_mcp_core.recipes import get_recipes_path
+from dcc_mcp_core.recipes import parse_recipe_anchors
+from dcc_mcp_core.recipes import register_recipes_tools
+
 # MCP Apps rich content (issue #409)
 from dcc_mcp_core.rich_content import RichContent
 from dcc_mcp_core.rich_content import RichContentKind
@@ -506,6 +512,8 @@ __all__ = [
     "get_data_dir",
     "get_log_dir",
     "get_platform_dir",
+    "get_recipe_content",
+    "get_recipes_path",
     "get_server_instance",
     "get_skill_paths_from_env",
     "get_skills_dir",
@@ -515,12 +523,14 @@ __all__ = [
     "is_telemetry_initialized",
     "make_start_stop",
     "mpu_to_units",
+    "parse_recipe_anchors",
     "parse_schedules_yaml",
     "parse_skill_md",
     "register_bridge",
     "register_dcc_api_executor",
     "register_diagnostic_handlers",
     "register_diagnostic_mcp_tools",
+    "register_recipes_tools",
     "reset_cancel_token",
     "resolve_dependencies",
     "run_main",

--- a/python/dcc_mcp_core/recipes.py
+++ b/python/dcc_mcp_core/recipes.py
@@ -1,0 +1,365 @@
+"""Recipes system for dcc-mcp-core skills (issue #428).
+
+Formalizes the ``metadata.dcc-mcp.recipes`` sibling-file key per the #356
+sibling-file pattern. A skill recipe file is a flat Markdown file with
+anchored ``##`` sections, each containing a short, copy-pasteable Python
+snippet.
+
+This module provides:
+
+- :func:`get_recipes_path` — extract the recipes file path from a skill's metadata
+- :func:`parse_recipe_anchors` — list anchor names from a RECIPES.md file
+- :func:`get_recipe_content` — fetch content of a specific anchor section
+- :func:`register_recipes_tools` — register ``recipes__list`` and ``recipes__get``
+  as MCP tools on a server
+
+Example SKILL.md metadata::
+
+    metadata:
+      dcc-mcp:
+        layer: thin-harness
+        tools: tools.yaml
+        recipes: references/RECIPES.md
+
+Example RECIPES.md file::
+
+    ## create_polygon_cube
+
+    Create a named polygon cube at the origin.
+
+    ```python
+    cube = cmds.polyCube(name="myCube", w=1, h=1, d=1)[0]
+    ```
+
+    ## set_world_translation
+
+    Set absolute world-space translation.
+
+    ```python
+    cmds.xform("myCube", translation=(1, 2, 3), worldSpace=True)
+    ```
+
+Usage::
+
+    from dcc_mcp_core.recipes import (
+        get_recipes_path,
+        parse_recipe_anchors,
+        get_recipe_content,
+        register_recipes_tools,
+    )
+
+    # Get recipes path from SkillMetadata
+    recipes_path = get_recipes_path(metadata)
+
+    # List all anchors
+    anchors = parse_recipe_anchors(recipes_path)
+    # ["create_polygon_cube", "set_world_translation"]
+
+    # Get content for an anchor
+    content = get_recipe_content(recipes_path, "create_polygon_cube")
+
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_ANCHOR_PATTERN = re.compile(r"^##\s+(\S.+)$", re.MULTILINE)
+
+
+# ── Core parsing utilities ─────────────────────────────────────────────────
+
+
+def get_recipes_path(metadata: Any) -> str | None:
+    """Extract the recipes file path from a ``SkillMetadata`` object.
+
+    Reads ``metadata.dcc-mcp.recipes`` from the skill's metadata dict.
+    Supports both flat (``"dcc-mcp.recipes": "recipes.md"``) and nested
+    (``"dcc-mcp": {"recipes": "recipes.md"}``) forms.
+
+    The returned path is absolute (resolved relative to the skill's
+    ``skill_path`` when that attribute is available and the path is relative).
+
+    Parameters
+    ----------
+    metadata:
+        A ``SkillMetadata`` instance or any object with a ``metadata`` dict
+        and optionally a ``skill_path`` str attribute.
+
+    Returns
+    -------
+    str | None
+        Absolute or relative path string to the recipes file, or ``None``
+        if the skill does not declare a recipes file.
+
+    """
+    meta_dict: dict[str, Any] = getattr(metadata, "metadata", {}) or {}
+
+    # Flat form: "dcc-mcp.recipes": "path"
+    recipes_rel = meta_dict.get("dcc-mcp.recipes")
+
+    # Nested form: {"dcc-mcp": {"recipes": "path"}}
+    if recipes_rel is None:
+        dcc_mcp_nested = meta_dict.get("dcc-mcp")
+        if isinstance(dcc_mcp_nested, dict):
+            recipes_rel = dcc_mcp_nested.get("recipes")
+
+    if not recipes_rel:
+        return None
+
+    # Resolve relative to skill_path if possible
+    skill_path = getattr(metadata, "skill_path", None)
+    if skill_path and not Path(recipes_rel).is_absolute():
+        return str(Path(skill_path) / recipes_rel)
+    return str(recipes_rel)
+
+
+def parse_recipe_anchors(recipes_path: str) -> list[str]:
+    """Return the list of anchor names from a RECIPES.md file.
+
+    Anchors are ``##`` headings. The anchor name is the heading text
+    stripped of leading whitespace and rendered as-is (no slug conversion).
+
+    Parameters
+    ----------
+    recipes_path:
+        Absolute path to the RECIPES.md file.
+
+    Returns
+    -------
+    list[str]
+        Ordered list of anchor names, or ``[]`` if the file does not exist
+        or contains no ``##`` headings.
+
+    """
+    path = Path(recipes_path)
+    if not path.is_file():
+        logger.debug("parse_recipe_anchors: file not found: %s", path)
+        return []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.warning("parse_recipe_anchors: could not read %s: %s", path, exc)
+        return []
+    return [m.group(1).strip() for m in _ANCHOR_PATTERN.finditer(text)]
+
+
+def get_recipe_content(recipes_path: str, anchor: str) -> str | None:
+    """Return the Markdown content of a specific anchor section.
+
+    Returns all text from the ``## <anchor>`` heading up to (but not
+    including) the next ``##`` heading, or to end-of-file.
+
+    Parameters
+    ----------
+    recipes_path:
+        Absolute path to the RECIPES.md file.
+    anchor:
+        The anchor name (as returned by :func:`parse_recipe_anchors`).
+
+    Returns
+    -------
+    str | None
+        Markdown content of the section (including the heading line),
+        or ``None`` if the anchor is not found.
+
+    """
+    path = Path(recipes_path)
+    if not path.is_file():
+        return None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    lines = text.splitlines(keepends=True)
+    start_idx: int | None = None
+
+    for i, line in enumerate(lines):
+        if line.rstrip().startswith("## ") and line.strip()[3:].strip() == anchor:
+            start_idx = i
+            break
+
+    if start_idx is None:
+        return None
+
+    end_idx = len(lines)
+    for i in range(start_idx + 1, len(lines)):
+        if lines[i].startswith("## "):
+            end_idx = i
+            break
+
+    return "".join(lines[start_idx:end_idx]).rstrip()
+
+
+# ── MCP tool registration ─────────────────────────────────────────────────
+
+_LIST_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "skill": {
+            "type": "string",
+            "description": "Skill name to list recipes for.",
+        },
+    },
+    "required": ["skill"],
+    "additionalProperties": False,
+}
+
+_GET_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "skill": {
+            "type": "string",
+            "description": "Skill name.",
+        },
+        "anchor": {
+            "type": "string",
+            "description": "Recipe anchor name (from recipes__list).",
+        },
+    },
+    "required": ["skill", "anchor"],
+    "additionalProperties": False,
+}
+
+_RECIPES_LIST_DESCRIPTION = (
+    "List available recipe anchors for a skill's RECIPES.md file. "
+    "When to use: before calling execute_python — check if a recipe covers "
+    "the operation. "
+    "How to use: pass skill name, then call recipes__get for the matching anchor."
+)
+
+_RECIPES_GET_DESCRIPTION = (
+    "Fetch the Markdown content of a specific recipe anchor from a skill's "
+    "RECIPES.md file. "
+    "When to use: when recipes__list returns an anchor matching your intent. "
+    "How to use: pass skill name and anchor name; copy the code snippet."
+)
+
+
+def register_recipes_tools(
+    server: Any,
+    *,
+    skills: list[Any],
+    dcc_name: str = "dcc",
+) -> None:
+    """Register ``recipes__list`` and ``recipes__get`` MCP tools on *server*.
+
+    The tools operate on the loaded skill list — they look up the skill by
+    name, find the recipes file via :func:`get_recipes_path`, and serve the
+    content.
+
+    Parameters
+    ----------
+    server:
+        An ``McpHttpServer`` compatible object with ``server.registry``
+        and ``server.register_handler(name, handler)``.
+    skills:
+        List of ``SkillMetadata`` objects (e.g. from ``scan_and_load()``).
+    dcc_name:
+        DCC name string for tool metadata.
+
+    Example
+    -------
+    .. code-block:: python
+
+        from dcc_mcp_core import create_skill_server, McpHttpConfig, scan_and_load
+        from dcc_mcp_core.recipes import register_recipes_tools
+
+        loaded, _ = scan_and_load(dcc_name="maya")
+        server = create_skill_server("maya", McpHttpConfig(port=8765))
+        register_recipes_tools(server, skills=loaded, dcc_name="maya")
+        handle = server.start()
+
+    """
+    skill_map: dict[str, Any] = {getattr(s, "name", ""): s for s in skills}
+
+    def _handle_list(params: Any) -> Any:
+        args: dict[str, Any] = json.loads(params) if isinstance(params, str) else (params or {})
+        skill_name = args.get("skill", "")
+        skill_md = skill_map.get(skill_name)
+        if skill_md is None:
+            return {
+                "success": False,
+                "message": f"Skill '{skill_name}' not found.",
+                "context": {"skill": skill_name, "anchors": []},
+            }
+        rp = get_recipes_path(skill_md)
+        if not rp:
+            return {
+                "success": True,
+                "message": f"Skill '{skill_name}' has no recipes file.",
+                "context": {"skill": skill_name, "anchors": [], "path": None},
+            }
+        anchors = parse_recipe_anchors(rp)
+        return {
+            "success": True,
+            "message": f"Found {len(anchors)} recipes.",
+            "context": {"skill": skill_name, "anchors": anchors, "path": rp},
+        }
+
+    def _handle_get(params: Any) -> Any:
+        args: dict[str, Any] = json.loads(params) if isinstance(params, str) else (params or {})
+        skill_name = args.get("skill", "")
+        anchor = args.get("anchor", "")
+        skill_md = skill_map.get(skill_name)
+        if skill_md is None:
+            return {"success": False, "message": f"Skill '{skill_name}' not found."}
+        rp = get_recipes_path(skill_md)
+        if not rp:
+            return {"success": False, "message": f"Skill '{skill_name}' has no recipes file."}
+        content = get_recipe_content(rp, anchor)
+        if content is None:
+            return {
+                "success": False,
+                "message": f"Anchor '{anchor}' not found in {rp}.",
+                "context": {"available_anchors": parse_recipe_anchors(rp)},
+            }
+        return {
+            "success": True,
+            "message": f"Recipe '{anchor}'",
+            "context": {"skill": skill_name, "anchor": anchor, "content": content},
+        }
+
+    try:
+        registry = server.registry
+    except Exception as exc:
+        logger.warning("register_recipes_tools: server.registry unavailable: %s", exc)
+        return
+
+    for name, desc, schema, handler in [
+        ("recipes__list", _RECIPES_LIST_DESCRIPTION, _LIST_SCHEMA, _handle_list),
+        ("recipes__get", _RECIPES_GET_DESCRIPTION, _GET_SCHEMA, _handle_get),
+    ]:
+        try:
+            registry.register(
+                name=name,
+                description=desc,
+                input_schema=json.dumps(schema),
+                dcc=dcc_name,
+                category="recipes",
+                version="1.0.0",
+            )
+        except Exception as exc:
+            logger.warning("register_recipes_tools: register(%s) failed: %s", name, exc)
+            continue
+        try:
+            server.register_handler(name, handler)
+        except Exception as exc:
+            logger.warning("register_recipes_tools: register_handler(%s) failed: %s", name, exc)
+
+
+# ── Public API ─────────────────────────────────────────────────────────────
+
+__all__ = [
+    "get_recipe_content",
+    "get_recipes_path",
+    "parse_recipe_anchors",
+    "register_recipes_tools",
+]

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -1,0 +1,268 @@
+"""Tests for the recipes system (issue #428)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import textwrap
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from dcc_mcp_core.recipes import get_recipe_content
+from dcc_mcp_core.recipes import get_recipes_path
+from dcc_mcp_core.recipes import parse_recipe_anchors
+from dcc_mcp_core.recipes import register_recipes_tools
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def recipes_md(tmp_path: Path) -> Path:
+    """Write a sample RECIPES.md and return its path."""
+    content = textwrap.dedent(
+        """\
+        # Maya Recipes
+
+        ## create_polygon_cube
+
+        Create a named polygon cube at the origin.
+
+        ```python
+        cube = cmds.polyCube(name="myCube", w=1, h=1, d=1)[0]
+        ```
+
+        ## set_world_translation
+
+        Set absolute world-space translation.
+
+        ```python
+        cmds.xform("myCube", translation=(1, 2, 3), worldSpace=True)
+        ```
+
+        ## delete_node
+
+        Delete a named node safely.
+
+        ```python
+        if cmds.objExists("myCube"):
+            cmds.delete("myCube")
+        ```
+        """
+    )
+    p = tmp_path / "RECIPES.md"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _make_metadata(skill_path: str | None, recipes_rel: str | None, *, nested: bool = False) -> MagicMock:
+    """Build a minimal SkillMetadata mock."""
+    md = MagicMock()
+    md.skill_path = skill_path
+    if recipes_rel is None:
+        md.metadata = {}
+    elif nested:
+        md.metadata = {"dcc-mcp": {"recipes": recipes_rel}}
+    else:
+        md.metadata = {"dcc-mcp.recipes": recipes_rel}
+    return md
+
+
+# ── get_recipes_path ──────────────────────────────────────────────────────
+
+
+class TestGetRecipesPath:
+    def test_flat_form_with_skill_path(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir()
+        md = _make_metadata(str(skill_dir), "references/RECIPES.md", nested=False)
+        result = get_recipes_path(md)
+        assert result == str(skill_dir / "references/RECIPES.md")
+
+    def test_nested_form_with_skill_path(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir()
+        md = _make_metadata(str(skill_dir), "RECIPES.md", nested=True)
+        result = get_recipes_path(md)
+        assert result == str(skill_dir / "RECIPES.md")
+
+    def test_no_recipes_key_returns_none(self) -> None:
+        md = _make_metadata("/some/path", None)
+        assert get_recipes_path(md) is None
+
+    def test_absolute_path_not_joined(self, tmp_path: Path) -> None:
+        abs_path = str(tmp_path / "RECIPES.md")
+        md = _make_metadata("/some/skill", abs_path, nested=False)
+        result = get_recipes_path(md)
+        assert result == abs_path
+
+    def test_no_skill_path_returns_relative(self) -> None:
+        md = _make_metadata(None, "references/RECIPES.md", nested=False)
+        result = get_recipes_path(md)
+        assert result == "references/RECIPES.md"
+
+    def test_empty_metadata_returns_none(self) -> None:
+        md = MagicMock()
+        md.metadata = None
+        md.skill_path = None
+        assert get_recipes_path(md) is None
+
+
+# ── parse_recipe_anchors ──────────────────────────────────────────────────
+
+
+class TestParseRecipeAnchors:
+    def test_returns_three_anchors(self, recipes_md: Path) -> None:
+        anchors = parse_recipe_anchors(str(recipes_md))
+        assert anchors == ["create_polygon_cube", "set_world_translation", "delete_node"]
+
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        result = parse_recipe_anchors(str(tmp_path / "nonexistent.md"))
+        assert result == []
+
+    def test_file_with_no_h2_headings(self, tmp_path: Path) -> None:
+        p = tmp_path / "RECIPES.md"
+        p.write_text("# Title\n\nSome text with # hash but no ## heading.\n", encoding="utf-8")
+        assert parse_recipe_anchors(str(p)) == []
+
+    def test_ignores_h1_headings(self, recipes_md: Path) -> None:
+        anchors = parse_recipe_anchors(str(recipes_md))
+        assert "Maya Recipes" not in anchors
+
+    def test_preserves_order(self, tmp_path: Path) -> None:
+        content = "## beta\n\ncontent\n\n## alpha\n\ncontent\n"
+        p = tmp_path / "RECIPES.md"
+        p.write_text(content, encoding="utf-8")
+        assert parse_recipe_anchors(str(p)) == ["beta", "alpha"]
+
+
+# ── get_recipe_content ────────────────────────────────────────────────────
+
+
+class TestGetRecipeContent:
+    def test_returns_first_section(self, recipes_md: Path) -> None:
+        content = get_recipe_content(str(recipes_md), "create_polygon_cube")
+        assert content is not None
+        assert "## create_polygon_cube" in content
+        assert "polyCube" in content
+        assert "## set_world_translation" not in content
+
+    def test_returns_middle_section(self, recipes_md: Path) -> None:
+        content = get_recipe_content(str(recipes_md), "set_world_translation")
+        assert content is not None
+        assert "xform" in content
+        assert "polyCube" not in content
+        assert "cmds.delete" not in content
+
+    def test_returns_last_section(self, recipes_md: Path) -> None:
+        content = get_recipe_content(str(recipes_md), "delete_node")
+        assert content is not None
+        assert "cmds.delete" in content
+
+    def test_unknown_anchor_returns_none(self, recipes_md: Path) -> None:
+        assert get_recipe_content(str(recipes_md), "no_such_anchor") is None
+
+    def test_missing_file_returns_none(self, tmp_path: Path) -> None:
+        assert get_recipe_content(str(tmp_path / "missing.md"), "foo") is None
+
+    def test_content_stripped_of_trailing_whitespace(self, tmp_path: Path) -> None:
+        content = "## foo\n\nsome code\n\n\n"
+        p = tmp_path / "RECIPES.md"
+        p.write_text(content, encoding="utf-8")
+        result = get_recipe_content(str(p), "foo")
+        assert result is not None
+        assert not result.endswith("\n")
+
+
+# ── register_recipes_tools ────────────────────────────────────────────────
+
+
+class TestRegisterRecipesTools:
+    def _make_server(self, skill_metas: list[MagicMock]) -> tuple[MagicMock, dict]:
+        """Return (server_mock, handler_registry)."""
+        server = MagicMock()
+        registry = MagicMock()
+        server.registry = registry
+        handlers: dict = {}
+        server.register_handler.side_effect = lambda name, fn: handlers.__setitem__(name, fn)
+        return server, handlers
+
+    def test_registers_two_tools(self, recipes_md: Path, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "maya-scripting"
+        skill_dir.mkdir()
+        md = _make_metadata(str(skill_dir), str(recipes_md), nested=False)
+        md.name = "maya-scripting"
+        server, _handlers = self._make_server([md])
+        register_recipes_tools(server, skills=[md])
+        calls = [c.kwargs["name"] for c in server.registry.register.call_args_list]
+        assert "recipes__list" in calls
+        assert "recipes__get" in calls
+
+    def test_list_handler_returns_anchors(self, recipes_md: Path, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "maya-scripting"
+        skill_dir.mkdir()
+        md = _make_metadata(str(skill_dir), str(recipes_md), nested=False)
+        md.name = "maya-scripting"
+        server, handlers = self._make_server([md])
+        register_recipes_tools(server, skills=[md])
+
+        result = handlers["recipes__list"](json.dumps({"skill": "maya-scripting"}))
+        assert result["success"] is True
+        assert "create_polygon_cube" in result["context"]["anchors"]
+
+    def test_list_unknown_skill_returns_error(self, tmp_path: Path) -> None:
+        md = _make_metadata(None, None)
+        md.name = "maya-scripting"
+        server, handlers = self._make_server([md])
+        register_recipes_tools(server, skills=[md])
+
+        result = handlers["recipes__list"](json.dumps({"skill": "unknown-skill"}))
+        assert result["success"] is False
+        assert "not found" in result["message"]
+
+    def test_get_handler_returns_content(self, recipes_md: Path, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "maya-scripting"
+        skill_dir.mkdir()
+        md = _make_metadata(str(skill_dir), str(recipes_md), nested=False)
+        md.name = "maya-scripting"
+        server, handlers = self._make_server([md])
+        register_recipes_tools(server, skills=[md])
+
+        result = handlers["recipes__get"](json.dumps({"skill": "maya-scripting", "anchor": "create_polygon_cube"}))
+        assert result["success"] is True
+        assert "polyCube" in result["context"]["content"]
+
+    def test_get_unknown_anchor_returns_error(self, recipes_md: Path, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "maya-scripting"
+        skill_dir.mkdir()
+        md = _make_metadata(str(skill_dir), str(recipes_md), nested=False)
+        md.name = "maya-scripting"
+        server, handlers = self._make_server([md])
+        register_recipes_tools(server, skills=[md])
+
+        result = handlers["recipes__get"](json.dumps({"skill": "maya-scripting", "anchor": "nonexistent"}))
+        assert result["success"] is False
+        assert "available_anchors" in result.get("context", {})
+
+    def test_skill_without_recipes_file(self, tmp_path: Path) -> None:
+        md = _make_metadata(None, None)
+        md.name = "no-recipes-skill"
+        server, handlers = self._make_server([md])
+        register_recipes_tools(server, skills=[md])
+
+        result = handlers["recipes__list"](json.dumps({"skill": "no-recipes-skill"}))
+        assert result["success"] is True
+        assert result["context"]["anchors"] == []
+
+    def test_no_registry_logs_warning(self) -> None:
+        class _BadServer:
+            @property
+            def registry(self):
+                raise AttributeError("no registry")
+
+        import logging
+
+        with patch.object(logging.getLogger("dcc_mcp_core.recipes"), "warning") as mock_warn:
+            register_recipes_tools(_BadServer(), skills=[])
+        mock_warn.assert_called_once()


### PR DESCRIPTION
## Summary

Closes #428.

Implements the `metadata.dcc-mcp.recipes` sibling-file convention per the #356 architectural rule. A skill's SKILL.md can now point at a sibling RECIPES.md (or any path) containing ##-anchored, copy-pasteable code snippets.

New public API (all exported via dcc_mcp_core):

- get_recipes_path(metadata) - Extract recipes file path from SkillMetadata (flat + nested forms)
- parse_recipe_anchors(path) - List ## section headings from a RECIPES.md file
- get_recipe_content(path, anchor) - Fetch one section's Markdown content
- register_recipes_tools(server, skills=...) - Register recipes__list and recipes__get MCP tools on the server

How agents use it:
1. recipes__list {skill: maya-scripting} returns [create_polygon_cube, set_world_translation, ...]
2. recipes__get {skill: maya-scripting, anchor: create_polygon_cube} returns full Markdown with code snippet

## Test plan

- 24 unit tests in tests/test_recipes.py
- Both flat (dcc-mcp.recipes: path) and nested (dcc-mcp: {recipes: path}) metadata forms covered
- Missing file, unknown anchor, skill without recipes, server without registry - all edge cases tested
- ruff passes with zero warnings
- __all__ sorted and verified with ruff --select RUF022