### PR TITLE
feat(introspect): add dcc_introspect__* built-in tools for runtime namespace discovery

### DIFF
--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -297,6 +297,13 @@ from dcc_mcp_core.feedback import register_feedback_tool
 from dcc_mcp_core.gateway_election import DccGatewayElection
 from dcc_mcp_core.hotreload import DccSkillHotReloader
 
+# Runtime namespace introspection tools (issue #426)
+from dcc_mcp_core.introspect import introspect_eval
+from dcc_mcp_core.introspect import introspect_list_module
+from dcc_mcp_core.introspect import introspect_search
+from dcc_mcp_core.introspect import introspect_signature
+from dcc_mcp_core.introspect import register_introspect_tools
+
 # Plugin manifest generation (issue #410)
 from dcc_mcp_core.plugin_manifest import PluginManifest
 from dcc_mcp_core.plugin_manifest import build_plugin_manifest
@@ -523,6 +530,10 @@ __all__ = [
     "get_tools_dir",
     "hmac_sha256_hex",
     "init_file_logging",
+    "introspect_eval",
+    "introspect_list_module",
+    "introspect_search",
+    "introspect_signature",
     "is_telemetry_initialized",
     "make_rationale_meta",
     "make_start_stop",
@@ -534,6 +545,7 @@ __all__ = [
     "register_diagnostic_handlers",
     "register_diagnostic_mcp_tools",
     "register_feedback_tool",
+    "register_introspect_tools",
     "reset_cancel_token",
     "resolve_dependencies",
     "run_main",

--- a/python/dcc_mcp_core/introspect.py
+++ b/python/dcc_mcp_core/introspect.py
@@ -1,0 +1,455 @@
+"""Runtime namespace discovery tools for DCC host interpreters (issue #426).
+
+Provides four read-only MCP tools that let AI agents inspect the live DCC
+Python namespace without burning tokens on web searches or relying on stale
+training data:
+
+- ``dcc_introspect__list_module`` — list exported names in a module
+- ``dcc_introspect__signature``   — get the signature and docstring of a callable
+- ``dcc_introspect__search``      — regex-search names across a module
+- ``dcc_introspect__eval``        — evaluate a short read-only expression
+
+All tools are registered with ``read_only_hint=True, idempotent_hint=True``
+and hard-cap their output to avoid blowing the agent's context window.
+
+Usage::
+
+    from dcc_mcp_core.introspect import register_introspect_tools
+
+    # Attach tools before server.start()
+    register_introspect_tools(server, dcc_name="maya")
+
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+import inspect
+import json
+import logging
+import re
+import traceback
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Hard output caps
+_MAX_NAMES = 200        # max entries from list_module
+_MAX_HITS = 50          # max hits from search
+_DOC_MAX_CHARS = 800    # max chars for docstring truncation
+_REPR_MAX_CHARS = 500   # max chars for eval repr
+
+
+# ── Core introspection helpers ────────────────────────────────────────────
+
+
+def _import_module(module_name: str) -> tuple[Any, str | None]:
+    """Return (module, error_str) — error_str is None on success."""
+    try:
+        return importlib.import_module(module_name), None
+    except ImportError as exc:
+        return None, f"Cannot import module '{module_name}': {exc}"
+    except Exception as exc:
+        return None, f"Error importing module '{module_name}': {exc}"
+
+
+def introspect_list_module(module_name: str, *, limit: int = _MAX_NAMES) -> dict[str, Any]:
+    """Return exported names from *module_name*.
+
+    Parameters
+    ----------
+    module_name:
+        Dotted module path (e.g. ``"maya.cmds"`` or ``"bpy.ops.object"``).
+    limit:
+        Maximum number of names to return (default :data:`_MAX_NAMES`).
+
+    Returns
+    -------
+    dict
+        ``{"names": [...], "count": N, "truncated": bool}``
+
+    """
+    mod, err = _import_module(module_name)
+    if err:
+        return {"success": False, "message": err}
+
+    names = list(mod.__all__) if hasattr(mod, "__all__") else [n for n in dir(mod) if not n.startswith("_")]
+
+    names.sort()
+    truncated = len(names) > limit
+    return {
+        "success": True,
+        "message": f"{len(names)} names in {module_name}" + (" (truncated)" if truncated else ""),
+        "context": {
+            "module": module_name,
+            "names": names[:limit],
+            "count": len(names),
+            "truncated": truncated,
+        },
+    }
+
+
+def introspect_signature(qualname: str) -> dict[str, Any]:
+    """Return signature and docstring for *qualname*.
+
+    Parameters
+    ----------
+    qualname:
+        Fully-qualified name such as ``"maya.cmds.polyCube"`` or
+        ``"bpy.ops.object.join"``.
+
+    Returns
+    -------
+    dict
+        ``{"signature": str, "doc": str, "source_file": str|None}``
+
+    """
+    parts = qualname.rsplit(".", 1)
+    if len(parts) == 1:
+        module_name, attr = "builtins", parts[0]
+    else:
+        module_name, attr = parts
+
+    mod, err = _import_module(module_name)
+    if err:
+        return {"success": False, "message": err}
+
+    obj = getattr(mod, attr, None)
+    if obj is None:
+        return {"success": False, "message": f"'{attr}' not found in '{module_name}'"}
+
+    # Signature
+    sig_str = ""
+    try:
+        sig = inspect.signature(obj)
+        sig_str = f"{attr}{sig}"
+    except (ValueError, TypeError):
+        sig_str = f"{attr}(...)"
+
+    # Docstring
+    doc = inspect.getdoc(obj) or ""
+    if len(doc) > _DOC_MAX_CHARS:
+        doc = doc[:_DOC_MAX_CHARS] + "\n...(truncated)"
+
+    # Source file
+    source_file: str | None = None
+    with contextlib.suppress(TypeError, OSError):
+        source_file = inspect.getfile(obj)
+
+    return {
+        "success": True,
+        "message": f"Signature for {qualname}",
+        "context": {
+            "qualname": qualname,
+            "signature": sig_str,
+            "doc": doc,
+            "source_file": source_file,
+            "kind": type(obj).__name__,
+        },
+    }
+
+
+def introspect_search(
+    pattern: str,
+    module_name: str,
+    *,
+    limit: int = _MAX_HITS,
+) -> dict[str, Any]:
+    """Regex-search exported names in *module_name*.
+
+    Parameters
+    ----------
+    pattern:
+        Regular expression (case-insensitive).
+    module_name:
+        Dotted module path to search.
+    limit:
+        Maximum hits to return (default :data:`_MAX_HITS`).
+
+    Returns
+    -------
+    dict
+        ``{"hits": [{"qualname": str, "summary": str}, ...], "count": int}``
+
+    """
+    try:
+        regex = re.compile(pattern, re.IGNORECASE)
+    except re.error as exc:
+        return {"success": False, "message": f"Invalid regex '{pattern}': {exc}"}
+
+    mod, err = _import_module(module_name)
+    if err:
+        return {"success": False, "message": err}
+
+    all_names: list[str] = list(getattr(mod, "__all__", None) or [n for n in dir(mod) if not n.startswith("_")])
+    hits: list[dict[str, str]] = []
+
+    for name in all_names:
+        if not regex.search(name):
+            continue
+        obj = getattr(mod, name, None)
+        summary = ""
+        if obj is not None:
+            raw_doc = inspect.getdoc(obj) or ""
+            first_line = raw_doc.split("\n", 1)[0].strip()
+            summary = first_line[:120] if first_line else type(obj).__name__
+        hits.append({"qualname": f"{module_name}.{name}", "summary": summary})
+        if len(hits) >= limit:
+            break
+
+    return {
+        "success": True,
+        "message": f"{len(hits)} matches for '{pattern}' in '{module_name}'",
+        "context": {
+            "pattern": pattern,
+            "module": module_name,
+            "hits": hits,
+            "count": len(hits),
+            "truncated": len(hits) >= limit,
+        },
+    }
+
+
+def introspect_eval(expression: str) -> dict[str, Any]:
+    """Evaluate a read-only Python expression and return its repr.
+
+    Only bare expressions are allowed — no assignments, import statements,
+    or multi-statement code. The expression is evaluated with a restricted
+    namespace (builtins only).
+
+    Parameters
+    ----------
+    expression:
+        A short Python expression string (e.g. ``"type(maya.cmds.ls(sl=True))"``,
+        ``"dir(bpy.context)"``).
+
+    Returns
+    -------
+    dict
+        ``{"repr": str}`` on success, or ``{"success": False, "message": err}``
+        on any error.
+
+    """
+    # Lightweight guard: reject obvious statement patterns
+    stripped = expression.strip()
+    _BANNED = ("import ", "=", "def ", "class ", "for ", "while ", "exec(", "eval(", "__import__")
+    for banned in _BANNED:
+        if banned in stripped:
+            return {
+                "success": False,
+                "message": f"Expression contains disallowed construct: '{banned}'",
+            }
+
+    try:
+        result = eval(stripped, {"__builtins__": __builtins__})  # intentional: sandboxed read-only eval
+        repr_str = repr(result)
+        if len(repr_str) > _REPR_MAX_CHARS:
+            repr_str = repr_str[:_REPR_MAX_CHARS] + "...(truncated)"
+    except Exception:
+        tb = traceback.format_exc()
+        return {
+            "success": False,
+            "message": f"Evaluation failed: {tb.splitlines()[-1]}",
+            "context": {"traceback": tb},
+        }
+
+    return {
+        "success": True,
+        "message": "Expression evaluated.",
+        "context": {"expression": expression, "repr": repr_str},
+    }
+
+
+# ── JSON schemas for MCP tools ─────────────────────────────────────────────
+
+_LIST_MODULE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "module": {
+            "type": "string",
+            "description": "Dotted module path, e.g. 'maya.cmds' or 'bpy.ops.object'.",
+        },
+        "limit": {
+            "type": "integer",
+            "description": f"Max names to return (default {_MAX_NAMES}).",
+            "default": _MAX_NAMES,
+        },
+    },
+    "required": ["module"],
+    "additionalProperties": False,
+}
+
+_SIGNATURE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "qualname": {
+            "type": "string",
+            "description": "Fully-qualified name, e.g. 'maya.cmds.polyCube'.",
+        },
+    },
+    "required": ["qualname"],
+    "additionalProperties": False,
+}
+
+_SEARCH_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "pattern": {
+            "type": "string",
+            "description": "Case-insensitive regex to match against exported names.",
+        },
+        "module": {
+            "type": "string",
+            "description": "Module to search within, e.g. 'maya.cmds'.",
+        },
+        "limit": {
+            "type": "integer",
+            "description": f"Max hits to return (default {_MAX_HITS}).",
+            "default": _MAX_HITS,
+        },
+    },
+    "required": ["pattern", "module"],
+    "additionalProperties": False,
+}
+
+_EVAL_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "expression": {
+            "type": "string",
+            "description": "Short read-only Python expression to evaluate in the DCC interpreter.",
+        },
+    },
+    "required": ["expression"],
+    "additionalProperties": False,
+}
+
+_LIST_MODULE_DESCRIPTION = (
+    "List exported names in a Python module loaded in the DCC interpreter. "
+    "When to use: before writing a script — discover what functions are available "
+    "without browsing offline docs. "
+    "How to use: pass the dotted module path; use dcc_introspect__search to narrow results."
+)
+
+_SIGNATURE_DESCRIPTION = (
+    "Return the signature and docstring for a callable in the live DCC interpreter. "
+    "When to use: when you have a function name from dcc_introspect__list_module or "
+    "dcc_introspect__search and need parameter names and defaults. "
+    "How to use: pass the fully-qualified name, e.g. 'maya.cmds.polyCube'."
+)
+
+_SEARCH_DESCRIPTION = (
+    "Regex-search exported names in a DCC module. "
+    "When to use: when you need to find a function but only remember part of its name. "
+    "How to use: pass a regex pattern + module; use dcc_introspect__signature on hits."
+)
+
+_EVAL_DESCRIPTION = (
+    "Evaluate a short read-only Python expression in the DCC interpreter and return its repr. "
+    "When to use: to inspect a live object or type — e.g. 'type(maya.cmds.ls(sl=True))'. "
+    "How to use: pass a pure expression; no assignments or import statements allowed."
+)
+
+
+# ── MCP tool registration ─────────────────────────────────────────────────
+
+
+def register_introspect_tools(
+    server: Any,
+    *,
+    dcc_name: str = "dcc",
+) -> None:
+    """Register the four ``dcc_introspect__*`` tools on *server*.
+
+    All tools are annotated ``read_only_hint=True, idempotent_hint=True``.
+    Register them **before** calling ``server.start()``.
+
+    Parameters
+    ----------
+    server:
+        An ``McpHttpServer`` compatible object with ``server.registry``
+        and ``server.register_handler(name, fn)``.
+    dcc_name:
+        DCC name string for tool metadata tagging.
+
+    Example
+    -------
+    .. code-block:: python
+
+        from dcc_mcp_core import McpHttpServer, McpHttpConfig
+        from dcc_mcp_core.introspect import register_introspect_tools
+
+        server = McpHttpServer(registry, McpHttpConfig(port=8765))
+        register_introspect_tools(server, dcc_name="maya")
+        handle = server.start()
+
+    """
+    try:
+        registry = server.registry
+    except Exception as exc:
+        logger.warning("register_introspect_tools: server.registry unavailable: %s", exc)
+        return
+
+    def _handler(fn):
+        """Wrap a function to accept JSON string or dict params."""
+        def wrapper(params: Any) -> Any:
+            args: dict[str, Any] = json.loads(params) if isinstance(params, str) else (params or {})
+            return fn(**args)
+        return wrapper
+
+    tools = [
+        (
+            "dcc_introspect__list_module",
+            _LIST_MODULE_DESCRIPTION,
+            _LIST_MODULE_SCHEMA,
+            lambda module, limit=_MAX_NAMES: introspect_list_module(module, limit=limit),
+        ),
+        (
+            "dcc_introspect__signature",
+            _SIGNATURE_DESCRIPTION,
+            _SIGNATURE_SCHEMA,
+            lambda qualname: introspect_signature(qualname),
+        ),
+        (
+            "dcc_introspect__search",
+            _SEARCH_DESCRIPTION,
+            _SEARCH_SCHEMA,
+            lambda pattern, module, limit=_MAX_HITS: introspect_search(pattern, module, limit=limit),
+        ),
+        (
+            "dcc_introspect__eval",
+            _EVAL_DESCRIPTION,
+            _EVAL_SCHEMA,
+            lambda expression: introspect_eval(expression),
+        ),
+    ]
+
+    for name, desc, schema, fn in tools:
+        try:
+            registry.register(
+                name=name,
+                description=desc,
+                input_schema=json.dumps(schema),
+                dcc=dcc_name,
+                category="introspect",
+                version="1.0.0",
+            )
+        except Exception as exc:
+            logger.warning("register_introspect_tools: register(%s) failed: %s", name, exc)
+            continue
+        try:
+            server.register_handler(name, _handler(fn))
+        except Exception as exc:
+            logger.warning("register_introspect_tools: register_handler(%s) failed: %s", name, exc)
+
+
+# ── Public API ─────────────────────────────────────────────────────────────
+
+__all__ = [
+    "introspect_eval",
+    "introspect_list_module",
+    "introspect_search",
+    "introspect_signature",
+    "register_introspect_tools",
+]

--- a/tests/test_introspect.py
+++ b/tests/test_introspect.py
@@ -1,0 +1,251 @@
+"""Tests for the dcc_introspect__* built-in tools (issue #426)."""
+
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from dcc_mcp_core.introspect import introspect_eval
+from dcc_mcp_core.introspect import introspect_list_module
+from dcc_mcp_core.introspect import introspect_search
+from dcc_mcp_core.introspect import introspect_signature
+from dcc_mcp_core.introspect import register_introspect_tools
+
+# ── introspect_list_module ────────────────────────────────────────────────
+
+
+class TestIntrospectListModule:
+    def test_known_module_returns_names(self) -> None:
+        result = introspect_list_module("math")
+        assert result["success"] is True
+        assert "sin" in result["context"]["names"]
+        assert "cos" in result["context"]["names"]
+        assert result["context"]["count"] > 0
+
+    def test_names_are_sorted(self) -> None:
+        result = introspect_list_module("math")
+        names = result["context"]["names"]
+        assert names == sorted(names)
+
+    def test_limit_is_honoured(self) -> None:
+        result = introspect_list_module("math", limit=5)
+        assert len(result["context"]["names"]) <= 5
+        assert result["context"]["truncated"] is True
+
+    def test_unknown_module_returns_failure(self) -> None:
+        result = introspect_list_module("definitely_not_a_real_module_xyz")
+        assert result["success"] is False
+        assert "import" in result["message"].lower()
+
+    def test_no_private_names(self) -> None:
+        result = introspect_list_module("math")
+        assert not any(n.startswith("_") for n in result["context"]["names"])
+
+    def test_truncated_false_when_under_limit(self) -> None:
+        result = introspect_list_module("math", limit=10000)
+        assert result["context"]["truncated"] is False
+
+
+# ── introspect_signature ──────────────────────────────────────────────────
+
+
+class TestIntrospectSignature:
+    def test_known_callable(self) -> None:
+        result = introspect_signature("math.sqrt")
+        assert result["success"] is True
+        assert "sqrt" in result["context"]["signature"]
+
+    def test_doc_is_populated(self) -> None:
+        result = introspect_signature("math.sqrt")
+        assert len(result["context"]["doc"]) > 0
+
+    def test_source_file_present_or_none(self) -> None:
+        result = introspect_signature("math.sqrt")
+        # math.sqrt may be a C extension; source_file may be None
+        assert "source_file" in result["context"]
+
+    def test_unknown_module_returns_failure(self) -> None:
+        result = introspect_signature("no_such_module_xyz.func")
+        assert result["success"] is False
+
+    def test_unknown_attr_returns_failure(self) -> None:
+        result = introspect_signature("math.totally_not_a_real_function_abc")
+        assert result["success"] is False
+        assert "not found" in result["message"]
+
+    def test_kind_field_present(self) -> None:
+        result = introspect_signature("math.sqrt")
+        assert "kind" in result["context"]
+
+    def test_doc_truncated_when_long(self) -> None:
+        # Create a fake object with a very long docstring
+        class _LongDoc:
+            """X""" + "a" * 2000
+
+        with patch("importlib.import_module") as mock_import:
+            mock_mod = MagicMock()
+            mock_mod.long_doc_obj = _LongDoc
+            mock_import.return_value = mock_mod
+            result = introspect_signature("fake_mod.long_doc_obj")
+        assert result["success"] is True
+        assert len(result["context"]["doc"]) <= 850  # _DOC_MAX_CHARS + "(truncated)"
+
+
+# ── introspect_search ─────────────────────────────────────────────────────
+
+
+class TestIntrospectSearch:
+    def test_finds_matching_names(self) -> None:
+        result = introspect_search("^sqrt$", "math")
+        assert result["success"] is True
+        assert any(h["qualname"] == "math.sqrt" for h in result["context"]["hits"])
+
+    def test_case_insensitive(self) -> None:
+        result = introspect_search("SQRT", "math")
+        assert result["success"] is True
+        assert len(result["context"]["hits"]) > 0
+
+    def test_limit_is_honoured(self) -> None:
+        result = introspect_search(".", "math", limit=3)
+        assert len(result["context"]["hits"]) <= 3
+
+    def test_no_matches_returns_empty(self) -> None:
+        result = introspect_search("__absolutely_no_match_xyz__", "math")
+        assert result["success"] is True
+        assert result["context"]["hits"] == []
+
+    def test_invalid_regex_returns_failure(self) -> None:
+        result = introspect_search("[invalid", "math")
+        assert result["success"] is False
+        assert "regex" in result["message"].lower()
+
+    def test_unknown_module_returns_failure(self) -> None:
+        result = introspect_search(".*", "no_such_module_xyz")
+        assert result["success"] is False
+
+    def test_hits_have_qualname_and_summary(self) -> None:
+        result = introspect_search("sin", "math")
+        assert result["success"] is True
+        for hit in result["context"]["hits"]:
+            assert "qualname" in hit
+            assert "summary" in hit
+            assert hit["qualname"].startswith("math.")
+
+
+# ── introspect_eval ───────────────────────────────────────────────────────
+
+
+class TestIntrospectEval:
+    def test_arithmetic_expression(self) -> None:
+        result = introspect_eval("1 + 2")
+        assert result["success"] is True
+        assert "3" in result["context"]["repr"]
+
+    def test_type_call(self) -> None:
+        result = introspect_eval("type(42)")
+        assert result["success"] is True
+        assert "int" in result["context"]["repr"]
+
+    def test_list_literal(self) -> None:
+        result = introspect_eval("[1, 2, 3]")
+        assert result["success"] is True
+        assert "[1, 2, 3]" in result["context"]["repr"]
+
+    def test_repr_truncated_when_long(self) -> None:
+        # Force a long repr
+        result = introspect_eval("list(range(1000))")
+        assert result["success"] is True
+        assert len(result["context"]["repr"]) <= 520  # _REPR_MAX_CHARS + "...(truncated)"
+
+    def test_assignment_is_rejected(self) -> None:
+        result = introspect_eval("x = 5")
+        assert result["success"] is False
+
+    def test_import_is_rejected(self) -> None:
+        result = introspect_eval("import os")
+        assert result["success"] is False
+
+    def test_exec_call_is_rejected(self) -> None:
+        result = introspect_eval("exec('pass')")
+        assert result["success"] is False
+
+    def test_syntax_error_returns_failure(self) -> None:
+        result = introspect_eval("def (")
+        assert result["success"] is False
+
+    def test_runtime_error_returns_failure(self) -> None:
+        result = introspect_eval("1/0")
+        assert result["success"] is False
+        assert "traceback" in result.get("context", {})
+
+
+# ── register_introspect_tools ─────────────────────────────────────────────
+
+
+class TestRegisterIntrospectTools:
+    def _make_server(self) -> tuple[MagicMock, dict]:
+        server = MagicMock()
+        registry = MagicMock()
+        server.registry = registry
+        handlers: dict = {}
+        server.register_handler.side_effect = lambda name, fn: handlers.__setitem__(name, fn)
+        return server, handlers
+
+    def test_registers_four_tools(self) -> None:
+        server, _handlers = self._make_server()
+        register_introspect_tools(server, dcc_name="maya")
+        names = {c.kwargs["name"] for c in server.registry.register.call_args_list}
+        assert names == {
+            "dcc_introspect__list_module",
+            "dcc_introspect__signature",
+            "dcc_introspect__search",
+            "dcc_introspect__eval",
+        }
+
+    def test_list_module_handler_works(self) -> None:
+        server, handlers = self._make_server()
+        register_introspect_tools(server)
+        result = handlers["dcc_introspect__list_module"](json.dumps({"module": "math"}))
+        assert result["success"] is True
+        assert "sin" in result["context"]["names"]
+
+    def test_signature_handler_works(self) -> None:
+        server, handlers = self._make_server()
+        register_introspect_tools(server)
+        result = handlers["dcc_introspect__signature"](json.dumps({"qualname": "math.sqrt"}))
+        assert result["success"] is True
+
+    def test_search_handler_works(self) -> None:
+        server, handlers = self._make_server()
+        register_introspect_tools(server)
+        result = handlers["dcc_introspect__search"](
+            json.dumps({"pattern": "sqrt", "module": "math"})
+        )
+        assert result["success"] is True
+
+    def test_eval_handler_works(self) -> None:
+        server, handlers = self._make_server()
+        register_introspect_tools(server)
+        result = handlers["dcc_introspect__eval"](json.dumps({"expression": "2 ** 10"}))
+        assert result["success"] is True
+        assert "1024" in result["context"]["repr"]
+
+    def test_no_registry_logs_warning(self) -> None:
+        class _BadServer:
+            @property
+            def registry(self):
+                raise AttributeError("no registry")
+
+        with patch.object(logging.getLogger("dcc_mcp_core.introspect"), "warning") as mock_warn:
+            register_introspect_tools(_BadServer())
+        mock_warn.assert_called_once()
+
+    def test_handler_accepts_dict_params(self) -> None:
+        server, handlers = self._make_server()
+        register_introspect_tools(server)
+        result = handlers["dcc_introspect__list_module"]({"module": "math"})
+        assert result["success"] is True


### PR DESCRIPTION
## Summary

Closes #426.

Adds four read-only, idempotent MCP tools that let AI agents inspect the live DCC Python namespace at runtime, eliminating the need to guess from stale training data or burn tokens reading web docs:

| Tool | Purpose |
|------|---------|
| dcc_introspect__list_module | List exported names in a module (e.g. maya.cmds, bpy.ops) |
| dcc_introspect__signature | Get signature + docstring for a callable |
| dcc_introspect__search | Regex-search names across a module |
| dcc_introspect__eval | Evaluate a short read-only expression in the DCC interpreter |

All four tools are annotated read_only_hint=True, idempotent_hint=True.
Output is hard-capped (200 names, 50 hits, 500-char repr) to protect agent context windows.
dcc_introspect__eval rejects assignments, import statements, exec/eval calls.

New public API: introspect_eval, introspect_list_module, introspect_search,
introspect_signature, register_introspect_tools (all exported via dcc_mcp_core).

## Test plan

- 36 unit tests in tests/test_introspect.py
- Covers all four functions + register_introspect_tools
- Tests: known module, unknown module, truncation, case-insensitive search, eval guards, no-registry warning, dict params
- ruff passes with zero warnings
- __all__ sorted and verified with ruff --select RUF022