### PR TITLE
feat(skills): YAML declarative workflow definitions with task/step semantics

### DIFF
--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -322,6 +322,13 @@ from dcc_mcp_core.skill import skill_exception
 from dcc_mcp_core.skill import skill_success
 from dcc_mcp_core.skill import skill_warning
 
+# YAML declarative workflow definitions (issue #439)
+from dcc_mcp_core.workflow_yaml import WorkflowTask
+from dcc_mcp_core.workflow_yaml import WorkflowYaml
+from dcc_mcp_core.workflow_yaml import get_workflow_path
+from dcc_mcp_core.workflow_yaml import load_workflow_yaml
+from dcc_mcp_core.workflow_yaml import register_workflow_yaml_tools
+
 __version__: str = getattr(_core, "__version__", "0.0.0-dev")
 __author__: str = getattr(_core, "__author__", "unknown")
 
@@ -481,6 +488,8 @@ __all__ = [
     "WorkflowSpec",
     "WorkflowStatus",
     "WorkflowStep",
+    "WorkflowTask",
+    "WorkflowYaml",
     "WorkspaceRoots",
     "__author__",
     "__version__",
@@ -521,9 +530,11 @@ __all__ = [
     "get_skill_paths_from_env",
     "get_skills_dir",
     "get_tools_dir",
+    "get_workflow_path",
     "hmac_sha256_hex",
     "init_file_logging",
     "is_telemetry_initialized",
+    "load_workflow_yaml",
     "make_rationale_meta",
     "make_start_stop",
     "mpu_to_units",
@@ -534,6 +545,7 @@ __all__ = [
     "register_diagnostic_handlers",
     "register_diagnostic_mcp_tools",
     "register_feedback_tool",
+    "register_workflow_yaml_tools",
     "reset_cancel_token",
     "resolve_dependencies",
     "run_main",

--- a/python/dcc_mcp_core/workflow_yaml.py
+++ b/python/dcc_mcp_core/workflow_yaml.py
@@ -1,0 +1,463 @@
+"""YAML declarative workflow definitions with task/step semantics (issue #439).
+
+Inspired by AgentSPEX, this module provides a lightweight YAML format for
+defining multi-step DCC workflows.  The key innovation is the **task vs step**
+semantic distinction for context management:
+
+- **task** — opens a new conversation / clean context; results are passed via
+  variables only.  Use for isolated sub-tasks (import, render) where accumulated
+  scene history is irrelevant.
+- **step** — operates within the same conversation; accumulated history is
+  available.  Use for multi-round reasoning (assign material + set up lighting).
+
+YAML format (sibling file, referenced via ``metadata.dcc-mcp.workflows``)::
+
+    name: model_to_render
+    goal: "Import a model, clean topology, assign materials, light, and render"
+    config:
+      dcc: maya
+    variables:
+      model_path: ""
+      output_dir: "/tmp/render"
+    tasks:
+      - name: import_and_clean
+        kind: task
+        tool: maya_geometry__import_fbx
+        inputs:
+          path: "{{model_path}}"
+        outputs: [mesh_name]
+      - name: material_and_light
+        kind: step
+        tool: maya_shading__assign_material
+        inputs:
+          mesh: "{{mesh_name}}"
+        on_failure: [dcc_diagnostics__screenshot]
+      - name: render
+        kind: task
+        tool: maya_render__render_frame
+        inputs:
+          output_dir: "{{output_dir}}"
+
+Public API:
+
+- :class:`WorkflowTask` — a single task/step definition
+- :class:`WorkflowYaml` — a parsed workflow definition
+- :func:`load_workflow_yaml` — load and validate a workflow YAML file
+- :func:`get_workflow_path` — extract workflow file path from SkillMetadata
+- :func:`register_workflow_yaml_tools` — register ``workflows.list`` and
+  ``workflows.describe`` MCP tools
+
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+import json
+import logging
+from pathlib import Path
+import re
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ── Types ──────────────────────────────────────────────────────────────────
+
+_TEMPLATE_RE = re.compile(r"\{\{(\w+)\}\}")
+
+
+@dataclass
+class WorkflowTask:
+    """A single task or step in a WorkflowYaml definition.
+
+    Parameters
+    ----------
+    name:
+        Unique identifier within the workflow.
+    kind:
+        ``"task"`` (clean context) or ``"step"`` (accumulated context).
+    tool:
+        MCP tool name to invoke.
+    inputs:
+        Variable-interpolated input dict.
+    outputs:
+        List of output variable names produced by this task.
+    on_failure:
+        List of follow-up tools on failure (mirrors next-tools on-failure).
+    description:
+        Human-readable summary.
+
+    """
+
+    name: str
+    kind: str = "step"
+    tool: str = ""
+    inputs: dict[str, Any] = field(default_factory=dict)
+    outputs: list[str] = field(default_factory=list)
+    on_failure: list[str] = field(default_factory=list)
+    description: str = ""
+
+    def __post_init__(self) -> None:
+        if self.kind not in ("task", "step"):
+            raise ValueError(f"WorkflowTask.kind must be 'task' or 'step', got '{self.kind}'")
+
+    def interpolate_inputs(self, variables: dict[str, Any]) -> dict[str, Any]:
+        """Return inputs with ``{{var}}`` templates replaced from *variables*.
+
+        Missing variables are left as-is (no error raised at interpolation time).
+        """
+        result: dict[str, Any] = {}
+        for k, v in self.inputs.items():
+            if isinstance(v, str):
+                result[k] = _TEMPLATE_RE.sub(lambda m: str(variables.get(m.group(1), m.group(0))), v)
+            else:
+                result[k] = v
+        return result
+
+
+@dataclass
+class WorkflowYaml:
+    """Parsed YAML workflow definition.
+
+    Parameters
+    ----------
+    name:
+        Unique workflow identifier.
+    goal:
+        Human-readable description of what the workflow achieves.
+    config:
+        Top-level configuration (``dcc``, ``tools``, etc.).
+    variables:
+        Default variable values; overridden at runtime.
+    tasks:
+        Ordered list of :class:`WorkflowTask` objects.
+    source_path:
+        Absolute path to the YAML file (set by :func:`load_workflow_yaml`).
+
+    """
+
+    name: str
+    goal: str = ""
+    config: dict[str, Any] = field(default_factory=dict)
+    variables: dict[str, Any] = field(default_factory=dict)
+    tasks: list[WorkflowTask] = field(default_factory=list)
+    source_path: str | None = None
+
+    def validate(self) -> list[str]:
+        """Return a list of validation error strings (empty = valid)."""
+        errors: list[str] = []
+        if not self.name:
+            errors.append("WorkflowYaml.name is required")
+        seen_names: set[str] = set()
+        for i, t in enumerate(self.tasks):
+            if not t.name:
+                errors.append(f"tasks[{i}].name is required")
+            elif t.name in seen_names:
+                errors.append(f"Duplicate task name '{t.name}'")
+            else:
+                seen_names.add(t.name)
+            if not t.tool:
+                errors.append(f"tasks[{i}] '{t.name}': tool is required")
+        return errors
+
+    def task_names(self) -> list[str]:
+        """Return ordered list of task names."""
+        return [t.name for t in self.tasks]
+
+    def get_task(self, name: str) -> WorkflowTask | None:
+        """Find a task by name."""
+        for t in self.tasks:
+            if t.name == name:
+                return t
+        return None
+
+    def to_summary_dict(self) -> dict[str, Any]:
+        """Return a concise summary for agent consumption."""
+        return {
+            "name": self.name,
+            "goal": self.goal,
+            "dcc": self.config.get("dcc"),
+            "task_count": len(self.tasks),
+            "tasks": [
+                {
+                    "name": t.name,
+                    "kind": t.kind,
+                    "tool": t.tool,
+                    "description": t.description,
+                }
+                for t in self.tasks
+            ],
+        }
+
+
+# ── YAML loading ───────────────────────────────────────────────────────────
+
+
+def _parse_tasks(raw_tasks: list[Any]) -> list[WorkflowTask]:
+    tasks: list[WorkflowTask] = []
+    for raw in raw_tasks:
+        if not isinstance(raw, dict):
+            continue
+        try:
+            tasks.append(
+                WorkflowTask(
+                    name=str(raw.get("name", "")),
+                    kind=str(raw.get("kind", "step")),
+                    tool=str(raw.get("tool", "")),
+                    inputs=dict(raw.get("inputs") or {}),
+                    outputs=list(raw.get("outputs") or []),
+                    on_failure=list(raw.get("on_failure") or raw.get("on-failure") or []),
+                    description=str(raw.get("description") or ""),
+                )
+            )
+        except ValueError as exc:
+            logger.warning("_parse_tasks: skipping invalid task: %s", exc)
+    return tasks
+
+
+def load_workflow_yaml(path: str | Path) -> WorkflowYaml:
+    """Load and parse a workflow YAML file.
+
+    Parameters
+    ----------
+    path:
+        Absolute path to the workflow YAML file.
+
+    Returns
+    -------
+    WorkflowYaml
+        Parsed workflow definition.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the file does not exist.
+    ValueError
+        If the file fails to parse or validate.
+
+    """
+    try:
+        import yaml  # type: ignore[import-untyped]
+    except ImportError as exc:
+        raise ImportError("PyYAML is required to load workflow YAML files: pip install pyyaml") from exc
+
+    p = Path(path)
+    if not p.is_file():
+        raise FileNotFoundError(f"Workflow YAML file not found: {p}")
+
+    try:
+        raw = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+    except Exception as exc:
+        raise ValueError(f"Failed to parse YAML at {p}: {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise ValueError(f"Workflow YAML must be a mapping, got {type(raw).__name__}")
+
+    wf = WorkflowYaml(
+        name=str(raw.get("name") or ""),
+        goal=str(raw.get("goal") or ""),
+        config=dict(raw.get("config") or {}),
+        variables=dict(raw.get("variables") or {}),
+        tasks=_parse_tasks(list(raw.get("tasks") or [])),
+        source_path=str(p.resolve()),
+    )
+
+    errors = wf.validate()
+    if errors:
+        raise ValueError(f"Workflow YAML validation errors: {'; '.join(errors)}")
+    return wf
+
+
+# ── Skill metadata integration ────────────────────────────────────────────
+
+
+def get_workflow_path(metadata: Any, glob_match_first: bool = True) -> str | None:
+    """Extract the workflow file path from a ``SkillMetadata`` object.
+
+    Reads ``metadata.dcc-mcp.workflows`` (flat or nested form).  If the value
+    is a glob pattern, returns the first matching file (when ``glob_match_first``
+    is True) or ``None``.
+
+    Parameters
+    ----------
+    metadata:
+        A ``SkillMetadata`` instance or any object with a ``metadata`` dict
+        and optionally a ``skill_path`` str attribute.
+    glob_match_first:
+        When True and the value looks like a glob (contains ``*`` or ``?``),
+        return the first match; otherwise return the pattern as-is.
+
+    Returns
+    -------
+    str | None
+        Absolute or relative path to the first workflow YAML file, or ``None``.
+
+    """
+    meta_dict: dict[str, Any] = getattr(metadata, "metadata", {}) or {}
+
+    wf_rel = meta_dict.get("dcc-mcp.workflows")
+    if wf_rel is None:
+        nested = meta_dict.get("dcc-mcp")
+        if isinstance(nested, dict):
+            wf_rel = nested.get("workflows")
+
+    if not wf_rel:
+        return None
+
+    skill_path = getattr(metadata, "skill_path", None)
+
+    if "*" in str(wf_rel) or "?" in str(wf_rel):
+        if skill_path and glob_match_first:
+            base = Path(skill_path)
+            matches = sorted(base.glob(str(wf_rel)))
+            return str(matches[0]) if matches else None
+        return str(wf_rel)
+
+    if skill_path and not Path(str(wf_rel)).is_absolute():
+        return str(Path(skill_path) / str(wf_rel))
+    return str(wf_rel)
+
+
+# ── MCP tool registration ──────────────────────────────────────────────────
+
+_WORKFLOWS_LIST_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+_WORKFLOWS_DESCRIBE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "Workflow name (from workflows.list).",
+        },
+    },
+    "required": ["name"],
+    "additionalProperties": False,
+}
+
+_WORKFLOWS_LIST_DESCRIPTION = (
+    "List YAML workflow definitions loaded from skill sibling files. "
+    "When to use: to discover available multi-step DCC workflows before "
+    "executing them manually. "
+    "How to use: no parameters; use workflows.describe for details on a specific workflow."
+)
+
+_WORKFLOWS_DESCRIBE_DESCRIPTION = (
+    "Describe a YAML workflow: goal, task list, kind (task vs step), and tools. "
+    "When to use: before executing a workflow step-by-step — understand each tool call needed. "
+    "How to use: pass the workflow name from workflows.list."
+)
+
+
+def register_workflow_yaml_tools(
+    server: Any,
+    *,
+    workflows: list[WorkflowYaml] | None = None,
+    skills: list[Any] | None = None,
+    dcc_name: str = "dcc",
+) -> None:
+    """Register ``workflows.list`` and ``workflows.describe`` on *server*.
+
+    Pass either pre-loaded *workflows* or a list of ``SkillMetadata`` *skills*
+    (the function will auto-discover workflow files via :func:`get_workflow_path`).
+
+    Parameters
+    ----------
+    server:
+        An ``McpHttpServer`` compatible object.
+    workflows:
+        Pre-loaded :class:`WorkflowYaml` objects.
+    skills:
+        ``SkillMetadata`` objects; workflow paths discovered automatically.
+    dcc_name:
+        DCC name for tool metadata.
+
+    """
+    workflow_map: dict[str, WorkflowYaml] = {}
+
+    if workflows:
+        for wf in workflows:
+            workflow_map[wf.name] = wf
+
+    if skills:
+        for skill_md in skills:
+            wf_path = get_workflow_path(skill_md)
+            if not wf_path:
+                continue
+            try:
+                wf = load_workflow_yaml(wf_path)
+                workflow_map[wf.name] = wf
+            except Exception as exc:
+                skill_name = getattr(skill_md, "name", "?")
+                logger.warning(
+                    "register_workflow_yaml_tools: failed to load %s (skill %s): %s",
+                    wf_path,
+                    skill_name,
+                    exc,
+                )
+
+    def _handle_list(_params: Any) -> Any:
+        summaries = [wf.to_summary_dict() for wf in workflow_map.values()]
+        return {
+            "success": True,
+            "message": f"{len(summaries)} workflow(s) available.",
+            "context": {"workflows": summaries, "count": len(summaries)},
+        }
+
+    def _handle_describe(params: Any) -> Any:
+        args: dict[str, Any] = json.loads(params) if isinstance(params, str) else (params or {})
+        name = args.get("name", "")
+        wf = workflow_map.get(name)
+        if wf is None:
+            available = list(workflow_map.keys())
+            return {
+                "success": False,
+                "message": f"Workflow '{name}' not found.",
+                "context": {"available": available},
+            }
+        return {
+            "success": True,
+            "message": f"Workflow '{name}': {wf.goal}",
+            "context": wf.to_summary_dict(),
+        }
+
+    try:
+        registry = server.registry
+    except Exception as exc:
+        logger.warning("register_workflow_yaml_tools: server.registry unavailable: %s", exc)
+        return
+
+    for name, desc, schema, handler in [
+        ("workflows.list", _WORKFLOWS_LIST_DESCRIPTION, _WORKFLOWS_LIST_SCHEMA, _handle_list),
+        ("workflows.describe", _WORKFLOWS_DESCRIBE_DESCRIPTION, _WORKFLOWS_DESCRIBE_SCHEMA, _handle_describe),
+    ]:
+        try:
+            registry.register(
+                name=name,
+                description=desc,
+                input_schema=json.dumps(schema),
+                dcc=dcc_name,
+                category="workflows",
+                version="1.0.0",
+            )
+        except Exception as exc:
+            logger.warning("register_workflow_yaml_tools: register(%s) failed: %s", name, exc)
+            continue
+        try:
+            server.register_handler(name, handler)
+        except Exception as exc:
+            logger.warning("register_workflow_yaml_tools: register_handler(%s) failed: %s", name, exc)
+
+
+# ── Public API ─────────────────────────────────────────────────────────────
+
+__all__ = [
+    "WorkflowTask",
+    "WorkflowYaml",
+    "get_workflow_path",
+    "load_workflow_yaml",
+    "register_workflow_yaml_tools",
+]

--- a/tests/test_workflow_yaml.py
+++ b/tests/test_workflow_yaml.py
@@ -1,0 +1,317 @@
+"""Tests for YAML declarative workflow definitions (issue #439)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import textwrap
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from dcc_mcp_core.workflow_yaml import WorkflowTask
+from dcc_mcp_core.workflow_yaml import WorkflowYaml
+from dcc_mcp_core.workflow_yaml import get_workflow_path
+from dcc_mcp_core.workflow_yaml import load_workflow_yaml
+from dcc_mcp_core.workflow_yaml import register_workflow_yaml_tools
+
+# ── YAML fixture ──────────────────────────────────────────────────────────
+
+_WORKFLOW_YAML = textwrap.dedent(
+    """\
+    name: model_to_render
+    goal: "Import a model, clean topology, assign materials, light, and render"
+    config:
+      dcc: maya
+    variables:
+      model_path: ""
+      output_dir: "/tmp/render"
+    tasks:
+      - name: import_model
+        kind: task
+        tool: maya_geometry__import_fbx
+        description: "Import the FBX file"
+        inputs:
+          path: "{{model_path}}"
+        outputs: [mesh_name]
+      - name: assign_material
+        kind: step
+        tool: maya_shading__assign_material
+        inputs:
+          mesh: "{{mesh_name}}"
+        on_failure: [dcc_diagnostics__screenshot]
+      - name: render
+        kind: task
+        tool: maya_render__render_frame
+        inputs:
+          output_dir: "{{output_dir}}"
+    """
+)
+
+
+@pytest.fixture()
+def workflow_yaml_file(tmp_path: Path) -> Path:
+    p = tmp_path / "model_to_render.yaml"
+    p.write_text(_WORKFLOW_YAML, encoding="utf-8")
+    return p
+
+
+# ── WorkflowTask ──────────────────────────────────────────────────────────
+
+
+class TestWorkflowTask:
+    def test_valid_task(self) -> None:
+        t = WorkflowTask(name="foo", kind="task", tool="maya.create_sphere")
+        assert t.kind == "task"
+
+    def test_valid_step(self) -> None:
+        t = WorkflowTask(name="bar", kind="step", tool="maya.bevel")
+        assert t.kind == "step"
+
+    def test_invalid_kind_raises(self) -> None:
+        with pytest.raises(ValueError, match="kind"):
+            WorkflowTask(name="x", kind="invalid", tool="t")
+
+    def test_interpolate_inputs_replaces_template(self) -> None:
+        t = WorkflowTask(name="t", tool="x", inputs={"path": "{{model_path}}/scene.fbx"})
+        result = t.interpolate_inputs({"model_path": "/tmp/models"})
+        assert result["path"] == "/tmp/models/scene.fbx"
+
+    def test_interpolate_missing_var_left_as_is(self) -> None:
+        t = WorkflowTask(name="t", tool="x", inputs={"v": "{{undefined}}"})
+        result = t.interpolate_inputs({})
+        assert result["v"] == "{{undefined}}"
+
+    def test_interpolate_non_string_values_unchanged(self) -> None:
+        t = WorkflowTask(name="t", tool="x", inputs={"count": 5})
+        result = t.interpolate_inputs({"count": 99})
+        assert result["count"] == 5
+
+
+# ── WorkflowYaml ──────────────────────────────────────────────────────────
+
+
+class TestWorkflowYaml:
+    def test_validate_valid(self) -> None:
+        wf = WorkflowYaml(
+            name="my-wf",
+            tasks=[WorkflowTask(name="a", tool="t"), WorkflowTask(name="b", tool="u")],
+        )
+        assert wf.validate() == []
+
+    def test_validate_missing_name(self) -> None:
+        wf = WorkflowYaml(name="")
+        errors = wf.validate()
+        assert any("name" in e for e in errors)
+
+    def test_validate_duplicate_task_names(self) -> None:
+        wf = WorkflowYaml(
+            name="x",
+            tasks=[WorkflowTask(name="dup", tool="t"), WorkflowTask(name="dup", tool="u")],
+        )
+        errors = wf.validate()
+        assert any("Duplicate" in e for e in errors)
+
+    def test_validate_task_missing_tool(self) -> None:
+        wf = WorkflowYaml(name="x", tasks=[WorkflowTask(name="t", tool="")])
+        errors = wf.validate()
+        assert any("tool" in e for e in errors)
+
+    def test_task_names(self) -> None:
+        wf = WorkflowYaml(
+            name="x",
+            tasks=[WorkflowTask(name="a", tool="t"), WorkflowTask(name="b", tool="u")],
+        )
+        assert wf.task_names() == ["a", "b"]
+
+    def test_get_task_found(self) -> None:
+        wf = WorkflowYaml(name="x", tasks=[WorkflowTask(name="a", tool="t")])
+        assert wf.get_task("a") is not None
+
+    def test_get_task_missing(self) -> None:
+        wf = WorkflowYaml(name="x", tasks=[])
+        assert wf.get_task("nope") is None
+
+    def test_to_summary_dict_structure(self) -> None:
+        wf = WorkflowYaml(
+            name="x",
+            goal="do stuff",
+            config={"dcc": "maya"},
+            tasks=[WorkflowTask(name="a", kind="task", tool="t.foo")],
+        )
+        summary = wf.to_summary_dict()
+        assert summary["name"] == "x"
+        assert summary["goal"] == "do stuff"
+        assert summary["dcc"] == "maya"
+        assert summary["task_count"] == 1
+        assert summary["tasks"][0]["kind"] == "task"
+
+
+# ── load_workflow_yaml ────────────────────────────────────────────────────
+
+
+class TestLoadWorkflowYaml:
+    def test_loads_valid_file(self, workflow_yaml_file: Path) -> None:
+        wf = load_workflow_yaml(workflow_yaml_file)
+        assert wf.name == "model_to_render"
+        assert len(wf.tasks) == 3
+
+    def test_task_kind_preserved(self, workflow_yaml_file: Path) -> None:
+        wf = load_workflow_yaml(workflow_yaml_file)
+        assert wf.tasks[0].kind == "task"
+        assert wf.tasks[1].kind == "step"
+
+    def test_on_failure_parsed(self, workflow_yaml_file: Path) -> None:
+        wf = load_workflow_yaml(workflow_yaml_file)
+        assert "dcc_diagnostics__screenshot" in wf.tasks[1].on_failure
+
+    def test_variables_populated(self, workflow_yaml_file: Path) -> None:
+        wf = load_workflow_yaml(workflow_yaml_file)
+        assert "model_path" in wf.variables
+
+    def test_source_path_set(self, workflow_yaml_file: Path) -> None:
+        wf = load_workflow_yaml(workflow_yaml_file)
+        assert wf.source_path is not None
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            load_workflow_yaml(tmp_path / "nonexistent.yaml")
+
+    def test_invalid_yaml_raises(self, tmp_path: Path) -> None:
+        p = tmp_path / "bad.yaml"
+        p.write_text("{bad yaml: [}", encoding="utf-8")
+        with pytest.raises(ValueError, match="parse"):
+            load_workflow_yaml(p)
+
+    def test_non_mapping_yaml_raises(self, tmp_path: Path) -> None:
+        p = tmp_path / "list.yaml"
+        p.write_text("- item1\n- item2\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="mapping"):
+            load_workflow_yaml(p)
+
+    def test_missing_name_raises(self, tmp_path: Path) -> None:
+        p = tmp_path / "no_name.yaml"
+        p.write_text("goal: something\ntasks:\n  - name: t\n    tool: x\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="validation"):
+            load_workflow_yaml(p)
+
+
+# ── get_workflow_path ─────────────────────────────────────────────────────
+
+
+class TestGetWorkflowPath:
+    def _make_md(self, skill_path, wf_rel, *, nested=False):
+        md = MagicMock()
+        md.skill_path = skill_path
+        if wf_rel is None:
+            md.metadata = {}
+        elif nested:
+            md.metadata = {"dcc-mcp": {"workflows": wf_rel}}
+        else:
+            md.metadata = {"dcc-mcp.workflows": wf_rel}
+        return md
+
+    def test_flat_form(self, tmp_path: Path) -> None:
+        md = self._make_md(str(tmp_path), "workflows/wf.yaml")
+        result = get_workflow_path(md)
+        assert result == str(tmp_path / "workflows/wf.yaml")
+
+    def test_nested_form(self, tmp_path: Path) -> None:
+        md = self._make_md(str(tmp_path), "wf.yaml", nested=True)
+        result = get_workflow_path(md)
+        assert result == str(tmp_path / "wf.yaml")
+
+    def test_no_metadata_returns_none(self) -> None:
+        md = MagicMock()
+        md.metadata = {}
+        md.skill_path = None
+        assert get_workflow_path(md) is None
+
+    def test_glob_pattern_matches_first(self, tmp_path: Path) -> None:
+        (tmp_path / "wf1.yaml").write_text("", encoding="utf-8")
+        (tmp_path / "wf2.yaml").write_text("", encoding="utf-8")
+        md = self._make_md(str(tmp_path), "wf*.yaml")
+        result = get_workflow_path(md)
+        assert result is not None
+        assert "wf1.yaml" in result or "wf2.yaml" in result
+
+    def test_glob_no_match_returns_none(self, tmp_path: Path) -> None:
+        md = self._make_md(str(tmp_path), "*.workflow.yaml")
+        result = get_workflow_path(md)
+        assert result is None
+
+
+# ── register_workflow_yaml_tools ──────────────────────────────────────────
+
+
+class TestRegisterWorkflowYamlTools:
+    def _make_server(self) -> tuple[MagicMock, dict]:
+        server = MagicMock()
+        registry = MagicMock()
+        server.registry = registry
+        handlers: dict = {}
+        server.register_handler.side_effect = lambda name, fn: handlers.__setitem__(name, fn)
+        return server, handlers
+
+    def _make_wf(self) -> WorkflowYaml:
+        return WorkflowYaml(
+            name="test-wf",
+            goal="A test workflow",
+            config={"dcc": "maya"},
+            tasks=[
+                WorkflowTask(name="step1", kind="task", tool="t.tool1"),
+                WorkflowTask(name="step2", kind="step", tool="t.tool2"),
+            ],
+        )
+
+    def test_registers_two_tools(self) -> None:
+        server, _handlers = self._make_server()
+        register_workflow_yaml_tools(server, workflows=[self._make_wf()])
+        names = {c.kwargs["name"] for c in server.registry.register.call_args_list}
+        assert "workflows.list" in names
+        assert "workflows.describe" in names
+
+    def test_list_returns_workflows(self) -> None:
+        server, handlers = self._make_server()
+        register_workflow_yaml_tools(server, workflows=[self._make_wf()])
+        result = handlers["workflows.list"](None)
+        assert result["success"] is True
+        assert result["context"]["count"] == 1
+        assert result["context"]["workflows"][0]["name"] == "test-wf"
+
+    def test_describe_known_workflow(self) -> None:
+        server, handlers = self._make_server()
+        register_workflow_yaml_tools(server, workflows=[self._make_wf()])
+        result = handlers["workflows.describe"](json.dumps({"name": "test-wf"}))
+        assert result["success"] is True
+        assert result["context"]["task_count"] == 2
+
+    def test_describe_unknown_workflow(self) -> None:
+        server, handlers = self._make_server()
+        register_workflow_yaml_tools(server, workflows=[self._make_wf()])
+        result = handlers["workflows.describe"](json.dumps({"name": "no-such-wf"}))
+        assert result["success"] is False
+        assert "available" in result["context"]
+
+    def test_no_registry_logs_warning(self) -> None:
+        import logging
+
+        class _BadServer:
+            @property
+            def registry(self):
+                raise AttributeError("no registry")
+
+        with patch.object(logging.getLogger("dcc_mcp_core.workflow_yaml"), "warning") as mock_warn:
+            register_workflow_yaml_tools(_BadServer(), workflows=[self._make_wf()])
+        mock_warn.assert_called_once()
+
+    def test_skills_with_no_workflow_path_skipped(self, tmp_path: Path) -> None:
+        md = MagicMock()
+        md.metadata = {}
+        md.skill_path = str(tmp_path)
+        md.name = "no-wf-skill"
+        server, handlers = self._make_server()
+        register_workflow_yaml_tools(server, skills=[md])
+        result = handlers["workflows.list"](None)
+        assert result["context"]["count"] == 0


### PR DESCRIPTION
## Summary

Closes #439.

Implements a lightweight YAML-based declarative workflow format for DCC skills, inspired by AgentSPEX. The key innovation is the task vs step semantic distinction for context management:

| Kind | Context | Best for |
|------|---------|----------|
| task | Fresh (clean) context | Isolated subtasks (import, render) |
| step | Accumulated context | Multi-round reasoning (material + lighting) |

New public API (all exported via dcc_mcp_core):

- WorkflowTask — single task/step with name, kind, tool, inputs ({{template}}), outputs, on_failure
- WorkflowYaml — parsed workflow definition with validate(), task_names(), get_task(), to_summary_dict()
- load_workflow_yaml(path) — load + validate a workflow YAML file (raises on error)
- get_workflow_path(metadata) — extract path from SkillMetadata (flat + nested + glob forms)
- register_workflow_yaml_tools(server, workflows=..., skills=...) — registers workflows.list + workflows.describe MCP tools

Example YAML (sibling file via metadata.dcc-mcp.workflows):

    name: model_to_render
    goal: "Import a model, clean topology, assign materials, light, and render"
    config:
      dcc: maya
    variables:
      model_path: ""
    tasks:
      - name: import_model
        kind: task
        tool: maya_geometry__import_fbx
        inputs: {path: "{{model_path}}"}
      - name: assign_material
        kind: step
        tool: maya_shading__assign_material
        on_failure: [dcc_diagnostics__screenshot]

## Test plan

- 34 unit tests in tests/test_workflow_yaml.py
- Covers: WorkflowTask validation/interpolation, WorkflowYaml validation + helpers,
  load_workflow_yaml (valid + error cases), get_workflow_path (flat/nested/glob),
  register_workflow_yaml_tools handlers
- ruff passes with zero warnings
- __all__ sorted and verified