### PR TITLE
feat: add Rust-powered json_dumps/json_loads for high-performance JSON serialization

### DIFF
--- a/crates/dcc-mcp-utils/Cargo.toml
+++ b/crates/dcc-mcp-utils/Cargo.toml
@@ -15,6 +15,7 @@ pyo3-stub-gen = { workspace = true, optional = true }
 pyo3-stub-gen-derive = { workspace = true, optional = true }
 
 serde_json = { workspace = true }
+serde_yaml_ng = { workspace = true }
 dirs = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/dcc-mcp-utils/src/lib.rs
+++ b/crates/dcc-mcp-utils/src/lib.rs
@@ -6,4 +6,6 @@ pub mod filesystem;
 pub mod log_config;
 #[cfg(feature = "python-bindings")]
 pub mod py_json;
+#[cfg(feature = "python-bindings")]
+pub mod py_yaml;
 pub mod type_wrappers;

--- a/crates/dcc-mcp-utils/src/py_json.rs
+++ b/crates/dcc-mcp-utils/src/py_json.rs
@@ -2,6 +2,8 @@
 //!
 //! Provides a single source of truth for converting between Python objects and
 //! `serde_json::Value`, eliminating duplicate implementations across crates.
+//! Also exposes high-performance `json_dumps` / `json_loads` pyfunctions that
+//! serve as drop-in replacements for Python's `json.dumps()` / `json.loads()`.
 
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyDict, PyList};
@@ -115,4 +117,146 @@ pub fn py_dict_to_json_map(
     dict: &Bound<'_, PyDict>,
 ) -> PyResult<HashMap<String, serde_json::Value>> {
     Ok(py_dict_to_json_object(dict)?.into_iter().collect())
+}
+
+// ---------------------------------------------------------------------------
+// High-performance Python-accessible JSON functions
+// ---------------------------------------------------------------------------
+
+/// Serialize a Python object to a JSON string using Rust's serde_json.
+///
+/// This is a high-performance drop-in replacement for `json.dumps()`.
+/// Supports dicts, lists, strings, numbers, booleans, and None.
+/// Non-serializable objects are converted to their string representation.
+///
+/// Parameters
+/// ----------
+/// obj : object
+///     The Python object to serialize.
+/// ensure_ascii : bool, optional
+///     If True (default), escape non-ASCII characters. If False, output
+///     raw Unicode characters.
+/// indent : int or None, optional
+///     If given, pretty-print with the specified number of spaces.
+#[pyfunction]
+#[pyo3(signature = (obj, *, ensure_ascii=true, indent=None))]
+pub fn json_dumps(
+    _py: Python,
+    obj: &Bound<'_, PyAny>,
+    ensure_ascii: bool,
+    indent: Option<usize>,
+) -> PyResult<String> {
+    let value = py_any_to_json_value(obj)?;
+    let s = match indent {
+        Some(_) => serde_json::to_string_pretty(&value),
+        None => serde_json::to_string(&value),
+    }
+    .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+
+    if ensure_ascii {
+        Ok(s)
+    } else {
+        // serde_json always escapes non-ASCII; for ensure_ascii=False we
+        // post-process the output to replace \uXXXX escapes with raw chars.
+        Ok(unescape_unicode_json(&s))
+    }
+}
+
+/// Deserialize a JSON string to a Python object using Rust's serde_json.
+///
+/// This is a high-performance drop-in replacement for `json.loads()`.
+/// Returns a Python dict, list, string, number, bool, or None.
+#[pyfunction]
+pub fn json_loads(py: Python, s: &str) -> PyResult<Py<PyAny>> {
+    let value: serde_json::Value = serde_json::from_str(s)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+    json_value_to_pyobject(py, &value)
+}
+
+/// Replace `\uXXXX` escape sequences with their actual Unicode characters
+/// in a JSON string, for `ensure_ascii=False` support.
+fn unescape_unicode_json(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            if chars.peek() == Some(&'u') {
+                chars.next(); // consume 'u'
+                let hex: String = chars.by_ref().take(4).collect();
+                if let Ok(code) = u32::from_str_radix(&hex, 16) {
+                    // Handle surrogate pairs (U+D800..U+DBFF followed by U+DC00..U+DFFF)
+                    if (0xD800..=0xDBFF).contains(&code) {
+                        if chars.peek() == Some(&'\\') {
+                            let mut lookahead = chars.clone();
+                            lookahead.next(); // consume '\'
+                            if lookahead.peek() == Some(&'u') {
+                                chars.next(); // consume '\'
+                                chars.next(); // consume 'u'
+                                let hex2: String = chars.by_ref().take(4).collect();
+                                if let Ok(code2) = u32::from_str_radix(&hex2, 16) {
+                                    if (0xDC00..=0xDFFF).contains(&code2) {
+                                        let combined =
+                                            0x10000 + (code - 0xD800) * 0x400 + (code2 - 0xDC00);
+                                        if let Some(ch) = char::from_u32(combined) {
+                                            result.push(ch);
+                                            continue;
+                                        }
+                                    }
+                                    // Invalid surrogate pair, keep as-is
+                                    result.push_str(&format!("\\u{hex}\\u{hex2}"));
+                                    continue;
+                                }
+                            }
+                        }
+                        // High surrogate without low surrogate, keep as-is
+                        result.push_str(&format!("\\u{hex}"));
+                        continue;
+                    }
+                    // BMP character
+                    if let Some(ch) = char::from_u32(code) {
+                        result.push(ch);
+                        continue;
+                    }
+                    result.push_str(&format!("\\u{hex}"));
+                    continue;
+                }
+                result.push_str(&format!("\\u{hex}"));
+                continue;
+            }
+            result.push('\\');
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unescape_basic() {
+        assert_eq!(unescape_unicode_json(r#""hello""#), r#""hello""#);
+        assert_eq!(unescape_unicode_json(r#""\u4f60\u597d""#), r#""你好""#);
+    }
+
+    #[test]
+    fn test_unescape_no_escapes() {
+        assert_eq!(unescape_unicode_json("abc"), "abc");
+    }
+
+    #[test]
+    fn test_unescape_surrogate_pair() {
+        // U+1F600 = D83D DE00 (surrogate pair)
+        let input = r#""\uD83D\uDE00""#;
+        let output = unescape_unicode_json(input);
+        assert_eq!(output, r#""😀""#);
+    }
+
+    #[test]
+    fn test_json_loads_basic() {
+        let val: serde_json::Value = serde_json::from_str(r#"{"key": "value"}"#).unwrap();
+        assert_eq!(val["key"], "value");
+    }
 }

--- a/crates/dcc-mcp-utils/src/py_yaml.rs
+++ b/crates/dcc-mcp-utils/src/py_yaml.rs
@@ -1,0 +1,152 @@
+//! Rust-powered YAML serialization/deserialization exposed to Python.
+//!
+//! Provides `yaml_loads` and `yaml_dumps` pyfunctions that use `serde_yaml_ng`
+//! as a zero-dependency (from Python's perspective) replacement for PyYAML.
+
+use pyo3::prelude::*;
+
+use crate::py_json::py_any_to_json_value;
+
+/// Deserialize a YAML string to a Python object using Rust's serde_yaml_ng.
+///
+/// This is a high-performance, zero-dependency drop-in replacement for
+/// `yaml.safe_load()`.  Returns a Python dict, list, string, number, bool,
+/// or None.
+///
+/// Parameters
+/// ----------
+/// s : str
+///     The YAML string to deserialize.
+#[pyfunction]
+pub fn yaml_loads(py: Python, s: &str) -> PyResult<Py<PyAny>> {
+    let value: serde_yaml_ng::Value = serde_yaml_ng::from_str(s)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+    let json_value: serde_json::Value = yaml_value_to_json(value);
+    crate::py_json::json_value_to_pyobject(py, &json_value)
+}
+
+/// Serialize a Python object to a YAML string using Rust's serde_yaml_ng.
+///
+/// This is a zero-dependency drop-in replacement for `yaml.safe_dump()` /
+/// `yaml.dump()`.
+///
+/// Parameters
+/// ----------
+/// obj : object
+///     The Python object to serialize.
+#[pyfunction]
+pub fn yaml_dumps(_py: Python, obj: &Bound<'_, PyAny>) -> PyResult<String> {
+    let json_value = py_any_to_json_value(obj)?;
+    let yaml_value = json_value_to_yaml(&json_value);
+    serde_yaml_ng::to_string(&yaml_value)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
+}
+
+/// Convert a `serde_yaml_ng::Value` to a `serde_json::Value`.
+fn yaml_value_to_json(val: serde_yaml_ng::Value) -> serde_json::Value {
+    match val {
+        serde_yaml_ng::Value::Null => serde_json::Value::Null,
+        serde_yaml_ng::Value::Bool(b) => serde_json::Value::Bool(b),
+        serde_yaml_ng::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                serde_json::Value::Number(i.into())
+            } else if let Some(f) = n.as_f64() {
+                serde_json::json!(f)
+            } else {
+                serde_json::Value::Null
+            }
+        }
+        serde_yaml_ng::Value::String(s) => serde_json::Value::String(s),
+        serde_yaml_ng::Value::Sequence(seq) => {
+            serde_json::Value::Array(seq.into_iter().map(yaml_value_to_json).collect())
+        }
+        serde_yaml_ng::Value::Mapping(map) => {
+            let mut obj = serde_json::Map::with_capacity(map.len());
+            for (k, v) in map {
+                let key = match k {
+                    serde_yaml_ng::Value::String(s) => s,
+                    serde_yaml_ng::Value::Number(n) => n.to_string(),
+                    serde_yaml_ng::Value::Bool(b) => b.to_string(),
+                    _ => continue,
+                };
+                obj.insert(key, yaml_value_to_json(v));
+            }
+            serde_json::Value::Object(obj)
+        }
+        serde_yaml_ng::Value::Tagged(tagged) => yaml_value_to_json(tagged.value),
+    }
+}
+
+/// Convert a `serde_json::Value` to a `serde_yaml_ng::Value`.
+fn json_value_to_yaml(val: &serde_json::Value) -> serde_yaml_ng::Value {
+    match val {
+        serde_json::Value::Null => serde_yaml_ng::Value::Null,
+        serde_json::Value::Bool(b) => serde_yaml_ng::Value::Bool(*b),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                serde_yaml_ng::Value::Number(i.into())
+            } else if let Some(f) = n.as_f64() {
+                serde_yaml_ng::Value::Number(f.into())
+            } else {
+                serde_yaml_ng::Value::Null
+            }
+        }
+        serde_json::Value::String(s) => serde_yaml_ng::Value::String(s.clone()),
+        serde_json::Value::Array(arr) => {
+            serde_yaml_ng::Value::Sequence(arr.iter().map(json_value_to_yaml).collect())
+        }
+        serde_json::Value::Object(obj) => {
+            let mut map = serde_yaml_ng::Mapping::with_capacity(obj.len());
+            for (k, v) in obj {
+                map.insert(
+                    serde_yaml_ng::Value::String(k.clone()),
+                    json_value_to_yaml(v),
+                );
+            }
+            serde_yaml_ng::Value::Mapping(map)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_yaml_loads_basic() {
+        let py_json = yaml_value_to_json(serde_yaml_ng::from_str("name: test\nvalue: 42").unwrap());
+        assert_eq!(py_json["name"], "test");
+        assert_eq!(py_json["value"], 42);
+    }
+
+    #[test]
+    fn test_yaml_loads_nested() {
+        let py_json = yaml_value_to_json(
+            serde_yaml_ng::from_str("config:\n  dcc: maya\n  port: 8080").unwrap(),
+        );
+        assert_eq!(py_json["config"]["dcc"], "maya");
+        assert_eq!(py_json["config"]["port"], 8080);
+    }
+
+    #[test]
+    fn test_yaml_loads_list() {
+        let py_json = yaml_value_to_json(
+            serde_yaml_ng::from_str("items:\n  - one\n  - two\n  - three").unwrap(),
+        );
+        assert_eq!(py_json["items"][0], "one");
+        assert_eq!(py_json["items"][2], "three");
+    }
+
+    #[test]
+    fn test_round_trip() {
+        let yaml_str = "name: test\nvalue: 42\n";
+        let value: serde_yaml_ng::Value = serde_yaml_ng::from_str(yaml_str).unwrap();
+        let json_val = yaml_value_to_json(value);
+        let yaml_val = json_value_to_yaml(&json_val);
+        let output = serde_yaml_ng::to_string(&yaml_val).unwrap();
+        let reparsed: serde_yaml_ng::Value = serde_yaml_ng::from_str(&output).unwrap();
+        let json_reparsed = yaml_value_to_json(reparsed);
+        assert_eq!(json_reparsed["name"], "test");
+        assert_eq!(json_reparsed["value"], 42);
+    }
+}

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -174,6 +174,8 @@ from dcc_mcp_core._core import get_skills_dir
 from dcc_mcp_core._core import get_tools_dir
 from dcc_mcp_core._core import init_file_logging
 from dcc_mcp_core._core import is_telemetry_initialized
+from dcc_mcp_core._core import json_dumps
+from dcc_mcp_core._core import json_loads
 from dcc_mcp_core._core import mpu_to_units
 from dcc_mcp_core._core import parse_skill_md
 from dcc_mcp_core._core import register_bridge
@@ -577,6 +579,8 @@ __all__ = [
     "introspect_search",
     "introspect_signature",
     "is_telemetry_initialized",
+    "json_dumps",
+    "json_loads",
     "list_checkpoints",
     "load_workflow_yaml",
     "make_rationale_meta",

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -200,6 +200,8 @@ from dcc_mcp_core._core import validate_dependencies
 from dcc_mcp_core._core import validate_skill
 from dcc_mcp_core._core import validate_tool_name
 from dcc_mcp_core._core import wrap_value
+from dcc_mcp_core._core import yaml_dumps
+from dcc_mcp_core._core import yaml_loads
 
 # Workflow primitive — optional (Cargo `workflow` feature, issue #348 skeleton).
 # Step execution is stubbed; only WorkflowSpec/WorkflowStatus (parse+validate)
@@ -635,4 +637,6 @@ __all__ = [
     "validate_tool_name",
     "verify_hub_signature_256",
     "wrap_value",
+    "yaml_dumps",
+    "yaml_loads",
 ]

--- a/python/dcc_mcp_core/batch.py
+++ b/python/dcc_mcp_core/batch.py
@@ -54,6 +54,8 @@ import json
 import logging
 from typing import Any
 
+from dcc_mcp_core import json_dumps
+
 logger = logging.getLogger(__name__)
 
 __all__ = [
@@ -125,7 +127,7 @@ def batch_dispatch(
 
     for idx, (tool_name, arguments) in enumerate(calls):
         try:
-            result = dispatcher.dispatch(tool_name, json.dumps(arguments))
+            result = dispatcher.dispatch(tool_name, json_dumps(arguments))
             results.append(result)
             output = result.get("output", result)
             if isinstance(output, dict) and output.get("success") is False:
@@ -248,7 +250,7 @@ class EvalContext:
         """Dispatch a single tool call from within an eval script."""
         args = arguments or {}
         try:
-            return self._dispatcher.dispatch(tool_name, json.dumps(args))
+            return self._dispatcher.dispatch(tool_name, json_dumps(args))
         except Exception as exc:
             return {"action": tool_name, "output": {"success": False, "message": str(exc)}}
 

--- a/python/dcc_mcp_core/bridge.py
+++ b/python/dcc_mcp_core/bridge.py
@@ -29,11 +29,13 @@ from __future__ import annotations
 
 import asyncio
 from concurrent.futures import Future
-import json
 import logging
 import threading
 from typing import Any
 import uuid
+
+from dcc_mcp_core import json_dumps
+from dcc_mcp_core import json_loads
 
 
 # NOTE: dcc_mcp_core.__version__ is deferred to avoid a potential import-time
@@ -251,7 +253,7 @@ class DccBridge:
         if params:
             message["params"] = params
 
-        asyncio.run_coroutine_threadsafe(self._send(json.dumps(message)), self._loop)
+        asyncio.run_coroutine_threadsafe(self._send(json_dumps(message)), self._loop)
 
         try:
             result = fut.result(timeout=self._timeout)
@@ -323,10 +325,10 @@ class DccBridge:
     async def _dispatch(self, raw: str) -> None:
         """Parse an incoming message and route it."""
         try:
-            msg = json.loads(raw)
-        except json.JSONDecodeError as exc:
+            msg = json_loads(raw)
+        except ValueError as exc:
             await self._send(
-                json.dumps(
+                json_dumps(
                     {
                         "type": "parse_error",
                         "message": str(exc),
@@ -359,7 +361,7 @@ class DccBridge:
             "version": self._server_version,
             "session_id": str(uuid.uuid4()),
         }
-        await self._send(json.dumps(ack))
+        await self._send(json_dumps(ack))
         self._connected = True
         self._dcc_connected.set()
 

--- a/python/dcc_mcp_core/checkpoint.py
+++ b/python/dcc_mcp_core/checkpoint.py
@@ -38,12 +38,14 @@ Usage in a skill script::
 
 from __future__ import annotations
 
-import json
 import logging
 from pathlib import Path
 import threading
 import time
 from typing import Any
+
+from dcc_mcp_core import json_dumps
+from dcc_mcp_core import json_loads
 
 logger = logging.getLogger(__name__)
 
@@ -76,8 +78,8 @@ class CheckpointStore:
     def _load(self) -> None:
         try:
             raw = self._path.read_text(encoding="utf-8")  # type: ignore[union-attr]
-            self._data = json.loads(raw)
-        except (OSError, json.JSONDecodeError) as exc:
+            self._data = json_loads(raw)
+        except (OSError, ValueError) as exc:
             logger.warning("CheckpointStore: could not load %s: %s", self._path, exc)
             self._data = {}
 
@@ -86,7 +88,7 @@ class CheckpointStore:
             return
         try:
             self._path.parent.mkdir(parents=True, exist_ok=True)
-            self._path.write_text(json.dumps(self._data, indent=2), encoding="utf-8")
+            self._path.write_text(json_dumps(self._data, indent=2), encoding="utf-8")
         except OSError as exc:
             logger.warning("CheckpointStore: could not flush to %s: %s", self._path, exc)
 
@@ -363,7 +365,7 @@ def register_checkpoint_tools(
         return
 
     def _handle_checkpoint_status(params: Any) -> Any:
-        args: dict[str, Any] = json.loads(params) if isinstance(params, str) else (params or {})
+        args: dict[str, Any] = json_loads(params) if isinstance(params, str) else (params or {})
         job_id = args.get("job_id", "")
         cp = _store.get(job_id)
         if cp is None:
@@ -379,7 +381,7 @@ def register_checkpoint_tools(
         }
 
     def _handle_resume_context(params: Any) -> Any:
-        args: dict[str, Any] = json.loads(params) if isinstance(params, str) else (params or {})
+        args: dict[str, Any] = json_loads(params) if isinstance(params, str) else (params or {})
         job_id = args.get("job_id", "")
         cp = _store.get(job_id)
         if cp is None:
@@ -423,7 +425,7 @@ def register_checkpoint_tools(
             registry.register(
                 name=name,
                 description=desc,
-                input_schema=json.dumps(schema),
+                input_schema=json_dumps(schema),
                 dcc=dcc_name,
                 category="jobs",
                 version="1.0.0",

--- a/python/dcc_mcp_core/dcc_api_executor.py
+++ b/python/dcc_mcp_core/dcc_api_executor.py
@@ -61,10 +61,11 @@ Usage
 
 from __future__ import annotations
 
-import json
 import logging
 import re
 from typing import Any
+
+from dcc_mcp_core import json_dumps
 
 logger = logging.getLogger(__name__)
 
@@ -309,7 +310,7 @@ def register_dcc_api_executor(
         f"Scripts are sandboxed and time-limited."
     )
 
-    search_schema = json.dumps(
+    search_schema = json_dumps(
         {
             "type": "object",
             "properties": {
@@ -329,7 +330,7 @@ def register_dcc_api_executor(
         }
     )
 
-    execute_schema = json.dumps(
+    execute_schema = json_dumps(
         {
             "type": "object",
             "properties": {

--- a/python/dcc_mcp_core/dcc_server.py
+++ b/python/dcc_mcp_core/dcc_server.py
@@ -53,12 +53,14 @@ The ``dcc_name`` argument is used to derive the default IPC pipe name when
 from __future__ import annotations
 
 import base64
-import json
 import logging
 import os
 import time
 from typing import Any
 from typing import Callable
+
+from dcc_mcp_core import json_dumps
+from dcc_mcp_core import json_loads
 
 logger = logging.getLogger(__name__)
 
@@ -116,8 +118,8 @@ def _get_action_recorder(dcc_name: str = "dcc") -> Any:
 def _handle_get_audit_log(params_json: str) -> str:
     """Return audit log entries as a JSON string."""
     try:
-        params = json.loads(params_json) if params_json else {}
-    except json.JSONDecodeError:
+        params = json_loads(params_json) if params_json else {}
+    except ValueError:
         params = {}
 
     filter_ = params.get("filter", "all")
@@ -126,7 +128,7 @@ def _handle_get_audit_log(params_json: str) -> str:
 
     ctx = _get_sandbox_context()
     if ctx is None:
-        return json.dumps({"success": False, "message": "SandboxContext not available."})
+        return json_dumps({"success": False, "message": "SandboxContext not available."})
 
     try:
         audit = ctx.audit_log
@@ -154,7 +156,7 @@ def _handle_get_audit_log(params_json: str) -> str:
             except Exception:
                 serialized.append(str(entry))
 
-        return json.dumps(
+        return json_dumps(
             {
                 "success": True,
                 "total_entries": total,
@@ -164,21 +166,21 @@ def _handle_get_audit_log(params_json: str) -> str:
         )
     except Exception as exc:
         logger.warning("get_audit_log handler error: %s", exc)
-        return json.dumps({"success": False, "message": str(exc)})
+        return json_dumps({"success": False, "message": str(exc)})
 
 
 def _handle_get_tool_metrics(params_json: str) -> str:
     """Return ToolRecorder metrics as a JSON string."""
     try:
-        params = json.loads(params_json) if params_json else {}
-    except json.JSONDecodeError:
+        params = json_loads(params_json) if params_json else {}
+    except ValueError:
         params = {}
 
     action_name = params.get("action_name")
 
     recorder = _get_action_recorder()
     if recorder is None:
-        return json.dumps({"success": False, "message": "ToolRecorder not available."})
+        return json_dumps({"success": False, "message": "ToolRecorder not available."})
 
     try:
         if action_name:
@@ -187,7 +189,7 @@ def _handle_get_tool_metrics(params_json: str) -> str:
         else:
             metrics_list = [_metric_to_dict(m) for m in recorder.all_metrics()]
 
-        return json.dumps(
+        return json_dumps(
             {
                 "success": True,
                 "metrics": metrics_list,
@@ -196,7 +198,7 @@ def _handle_get_tool_metrics(params_json: str) -> str:
         )
     except Exception as exc:
         logger.warning("get_tool_metrics handler error: %s", exc)
-        return json.dumps({"success": False, "message": str(exc)})
+        return json_dumps({"success": False, "message": str(exc)})
 
 
 def _get_window_capturer() -> Any:
@@ -233,8 +235,8 @@ def _handle_take_screenshot(params_json: str) -> str:
         window_title (str): override the window title substring.
     """
     try:
-        params = json.loads(params_json) if params_json else {}
-    except json.JSONDecodeError:
+        params = json_loads(params_json) if params_json else {}
+    except ValueError:
         params = {}
 
     fmt = params.get("format", "png")
@@ -295,7 +297,7 @@ def _handle_take_screenshot(params_json: str) -> str:
             "error": type(exc).__name__,
             "source": "dcc-ipc",
         }
-    return json.dumps(payload)
+    return json_dumps(payload)
 
 
 def _handle_process_status(params_json: str) -> str:
@@ -339,15 +341,15 @@ def _handle_process_status(params_json: str) -> str:
         "dcc_alive": alive,
         "timestamp_ms": int(time.time() * 1000),
     }
-    return json.dumps(payload)
+    return json_dumps(payload)
 
 
 def _handle_dispatch_tool(params_json: str) -> str:
     """Relay a dispatch request through the server's ToolDispatcher."""
     try:
-        params = json.loads(params_json) if params_json else {}
-    except json.JSONDecodeError:
-        return json.dumps({"success": False, "message": "Invalid JSON params."})
+        params = json_loads(params_json) if params_json else {}
+    except ValueError:
+        return json_dumps({"success": False, "message": "Invalid JSON params."})
 
     # The wire payload still uses the legacy field name ``action`` — that key
     # reflects the backward-compat Rust dispatch result shape (see PR #218);
@@ -356,21 +358,21 @@ def _handle_dispatch_tool(params_json: str) -> str:
     action_params = params.get("params", {})
 
     if not action:
-        return json.dumps({"success": False, "message": "Missing 'action' field."})
+        return json_dumps({"success": False, "message": "Missing 'action' field."})
 
     dispatcher = _dispatcher_ref
     if dispatcher is None:
-        return json.dumps({"success": False, "message": "Dispatcher not available."})
+        return json_dumps({"success": False, "message": "Dispatcher not available."})
 
     try:
-        result = dispatcher.dispatch(action, json.dumps(action_params))
+        result = dispatcher.dispatch(action, json_dumps(action_params))
         output = result.get("output", "{}")
         if isinstance(output, str):
             return output  # already JSON
-        return json.dumps(output)
+        return json_dumps(output)
     except Exception as exc:
         logger.warning("dispatch_tool handler error for '%s': %s", action, exc)
-        return json.dumps({"success": False, "message": str(exc)})
+        return json_dumps({"success": False, "message": str(exc)})
 
 
 # ── public API ────────────────────────────────────────────────────────────
@@ -616,7 +618,7 @@ def register_diagnostic_mcp_tools(
             registry.register(
                 name=name,
                 description=desc,
-                input_schema=json.dumps(schema),
+                input_schema=json_dumps(schema),
                 dcc=dcc_name,
                 category="diagnostics",
                 version="1.0.0",
@@ -632,9 +634,9 @@ def register_diagnostic_mcp_tools(
 
 def _adapt_mcp_handler(handler: Callable[[str], str], params: Any) -> Any:
     """Adapt an IPC-style ``(json_str) -> json_str`` handler to MCP's dict IO."""
-    params_str = json.dumps(params) if not isinstance(params, str) else params
+    params_str = json_dumps(params) if not isinstance(params, str) else params
     result_str = handler(params_str)
     try:
-        return json.loads(result_str)
-    except (TypeError, json.JSONDecodeError):
+        return json_loads(result_str)
+    except (TypeError, ValueError):
         return {"success": False, "message": "Invalid handler output"}

--- a/python/dcc_mcp_core/feedback.py
+++ b/python/dcc_mcp_core/feedback.py
@@ -52,12 +52,14 @@ Example — feedback tool call::
 
 from __future__ import annotations
 
-import json
 import logging
 import threading
 import time
 from typing import Any
 import uuid
+
+from dcc_mcp_core import json_dumps
+from dcc_mcp_core import json_loads
 
 logger = logging.getLogger(__name__)
 
@@ -150,7 +152,7 @@ def extract_rationale(params: dict[str, Any] | str) -> str | None:
     """
     if isinstance(params, str):
         try:
-            params = json.loads(params)
+            params = json_loads(params)
         except (TypeError, ValueError):
             return None
     if not isinstance(params, dict):
@@ -179,7 +181,6 @@ def make_rationale_meta(rationale: str) -> dict[str, Any]:
     -------
     .. code-block:: python
 
-        import json
         import httpx
 
         meta = make_rationale_meta("User wants a reference sphere for scale.")
@@ -244,9 +245,9 @@ _FEEDBACK_TOOL_DESCRIPTION = (
 def _handle_feedback_report(params: str) -> str:
     """IPC-style handler for ``dcc_feedback__report``."""
     try:
-        args: dict[str, Any] = json.loads(params) if isinstance(params, str) else params
+        args: dict[str, Any] = json_loads(params) if isinstance(params, str) else params
     except (TypeError, ValueError) as exc:
-        return json.dumps({"success": False, "message": f"Invalid params: {exc}"})
+        return json_dumps({"success": False, "message": f"Invalid params: {exc}"})
 
     entry: dict[str, Any] = {
         "id": str(uuid.uuid4()),
@@ -264,7 +265,7 @@ def _handle_feedback_report(params: str) -> str:
         entry["tool_name"],
         entry["severity"],
     )
-    return json.dumps(
+    return json_dumps(
         {
             "success": True,
             "message": "Feedback recorded.",
@@ -317,7 +318,7 @@ def register_feedback_tool(
         registry.register(
             name="dcc_feedback__report",
             description=_FEEDBACK_TOOL_DESCRIPTION,
-            input_schema=json.dumps(_FEEDBACK_SCHEMA),
+            input_schema=json_dumps(_FEEDBACK_SCHEMA),
             dcc=dcc_name,
             category="feedback",
             version="1.0.0",
@@ -327,11 +328,11 @@ def register_feedback_tool(
         return
 
     def _mcp_handler(params: Any) -> Any:
-        params_str = json.dumps(params) if not isinstance(params, str) else params
+        params_str = json_dumps(params) if not isinstance(params, str) else params
         result_str = _handle_feedback_report(params_str)
         try:
-            return json.loads(result_str)
-        except (TypeError, json.JSONDecodeError):
+            return json_loads(result_str)
+        except (TypeError, ValueError):
             return {"success": False, "message": "Invalid handler output"}
 
     try:

--- a/python/dcc_mcp_core/introspect.py
+++ b/python/dcc_mcp_core/introspect.py
@@ -26,19 +26,21 @@ from __future__ import annotations
 import contextlib
 import importlib
 import inspect
-import json
 import logging
 import re
 import traceback
 from typing import Any
 
+from dcc_mcp_core import json_dumps
+from dcc_mcp_core import json_loads
+
 logger = logging.getLogger(__name__)
 
 # Hard output caps
-_MAX_NAMES = 200        # max entries from list_module
-_MAX_HITS = 50          # max hits from search
-_DOC_MAX_CHARS = 800    # max chars for docstring truncation
-_REPR_MAX_CHARS = 500   # max chars for eval repr
+_MAX_NAMES = 200  # max entries from list_module
+_MAX_HITS = 50  # max hits from search
+_DOC_MAX_CHARS = 800  # max chars for docstring truncation
+_REPR_MAX_CHARS = 500  # max chars for eval repr
 
 
 # ── Core introspection helpers ────────────────────────────────────────────
@@ -393,9 +395,11 @@ def register_introspect_tools(
 
     def _handler(fn):
         """Wrap a function to accept JSON string or dict params."""
+
         def wrapper(params: Any) -> Any:
-            args: dict[str, Any] = json.loads(params) if isinstance(params, str) else (params or {})
+            args: dict[str, Any] = json_loads(params) if isinstance(params, str) else (params or {})
             return fn(**args)
+
         return wrapper
 
     tools = [
@@ -430,7 +434,7 @@ def register_introspect_tools(
             registry.register(
                 name=name,
                 description=desc,
-                input_schema=json.dumps(schema),
+                input_schema=json_dumps(schema),
                 dcc=dcc_name,
                 category="introspect",
                 version="1.0.0",

--- a/python/dcc_mcp_core/plugin_manifest.py
+++ b/python/dcc_mcp_core/plugin_manifest.py
@@ -38,10 +38,11 @@ Usage
 from __future__ import annotations
 
 import dataclasses
-import json
 import logging
 from pathlib import Path
 from typing import Any
+
+from dcc_mcp_core import json_dumps
 
 logger = logging.getLogger(__name__)
 
@@ -89,7 +90,7 @@ class PluginManifest:
 
     def to_json(self, indent: int = 2) -> str:
         """Return the manifest as a formatted JSON string."""
-        return json.dumps(self.to_dict(), indent=indent)
+        return json_dumps(self.to_dict(), indent=indent)
 
 
 def build_plugin_manifest(
@@ -197,6 +198,6 @@ def export_plugin_manifest(
     """
     p = Path(path).resolve()
     p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text(json.dumps(manifest, indent=indent), encoding="utf-8")
+    p.write_text(json_dumps(manifest, indent=indent), encoding="utf-8")
     logger.info("export_plugin_manifest: manifest written to %s", p)
     return p

--- a/python/dcc_mcp_core/recipes.py
+++ b/python/dcc_mcp_core/recipes.py
@@ -62,11 +62,13 @@ Usage::
 
 from __future__ import annotations
 
-import json
 import logging
-import re
 from pathlib import Path
+import re
 from typing import Any
+
+from dcc_mcp_core import json_dumps
+from dcc_mcp_core import json_loads
 
 logger = logging.getLogger(__name__)
 
@@ -281,7 +283,7 @@ def register_recipes_tools(
     skill_map: dict[str, Any] = {getattr(s, "name", ""): s for s in skills}
 
     def _handle_list(params: Any) -> Any:
-        args: dict[str, Any] = json.loads(params) if isinstance(params, str) else (params or {})
+        args: dict[str, Any] = json_loads(params) if isinstance(params, str) else (params or {})
         skill_name = args.get("skill", "")
         skill_md = skill_map.get(skill_name)
         if skill_md is None:
@@ -305,7 +307,7 @@ def register_recipes_tools(
         }
 
     def _handle_get(params: Any) -> Any:
-        args: dict[str, Any] = json.loads(params) if isinstance(params, str) else (params or {})
+        args: dict[str, Any] = json_loads(params) if isinstance(params, str) else (params or {})
         skill_name = args.get("skill", "")
         anchor = args.get("anchor", "")
         skill_md = skill_map.get(skill_name)
@@ -341,7 +343,7 @@ def register_recipes_tools(
             registry.register(
                 name=name,
                 description=desc,
-                input_schema=json.dumps(schema),
+                input_schema=json_dumps(schema),
                 dcc=dcc_name,
                 category="recipes",
                 version="1.0.0",

--- a/python/dcc_mcp_core/skill.py
+++ b/python/dcc_mcp_core/skill.py
@@ -51,7 +51,6 @@ You can also call the helpers directly without the decorator:
 from __future__ import annotations
 
 import functools
-import json
 from pathlib import Path
 import sys
 import traceback
@@ -59,6 +58,8 @@ from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import TypeVar
+
+from dcc_mcp_core import json_dumps
 
 __all__ = [
     "get_bundled_skill_paths",
@@ -611,9 +612,9 @@ def _serialize_result(result: ResultDict) -> str:
 
     # Pure-Python fallback: handles any extra keys in context gracefully.
     try:
-        return json.dumps(result, default=str, ensure_ascii=False)
+        return json_dumps(result, ensure_ascii=False)
     except (TypeError, ValueError) as exc:
-        return json.dumps(
+        return json_dumps(
             skill_error("Failed to serialize result", repr(exc)),
             ensure_ascii=False,
         )

--- a/python/dcc_mcp_core/workflow_yaml.py
+++ b/python/dcc_mcp_core/workflow_yaml.py
@@ -60,6 +60,7 @@ from typing import Any
 
 from dcc_mcp_core import json_dumps
 from dcc_mcp_core import json_loads
+from dcc_mcp_core import yaml_loads
 
 logger = logging.getLogger(__name__)
 
@@ -238,17 +239,12 @@ def load_workflow_yaml(path: str | Path) -> WorkflowYaml:
         If the file fails to parse or validate.
 
     """
-    try:
-        import yaml  # type: ignore[import-untyped]
-    except ImportError as exc:
-        raise ImportError("PyYAML is required to load workflow YAML files: pip install pyyaml") from exc
-
     p = Path(path)
     if not p.is_file():
         raise FileNotFoundError(f"Workflow YAML file not found: {p}")
 
     try:
-        raw = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+        raw = yaml_loads(p.read_text(encoding="utf-8")) or {}
     except Exception as exc:
         raise ValueError(f"Failed to parse YAML at {p}: {exc}") from exc
 

--- a/python/dcc_mcp_core/workflow_yaml.py
+++ b/python/dcc_mcp_core/workflow_yaml.py
@@ -53,11 +53,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from dataclasses import field
-import json
 import logging
 from pathlib import Path
 import re
 from typing import Any
+
+from dcc_mcp_core import json_dumps
+from dcc_mcp_core import json_loads
 
 logger = logging.getLogger(__name__)
 
@@ -408,7 +410,7 @@ def register_workflow_yaml_tools(
         }
 
     def _handle_describe(params: Any) -> Any:
-        args: dict[str, Any] = json.loads(params) if isinstance(params, str) else (params or {})
+        args: dict[str, Any] = json_loads(params) if isinstance(params, str) else (params or {})
         name = args.get("name", "")
         wf = workflow_map.get(name)
         if wf is None:
@@ -438,7 +440,7 @@ def register_workflow_yaml_tools(
             registry.register(
                 name=name,
                 description=desc,
-                input_schema=json.dumps(schema),
+                input_schema=json_dumps(schema),
                 dcc=dcc_name,
                 category="workflows",
                 version="1.0.0",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,6 +228,8 @@ fn register_utils(m: &Bound<'_, PyModule>) -> PyResult<()> {
         dcc_mcp_utils::file_logging::python::py_shutdown_file_logging,
         dcc_mcp_utils::file_logging::python::py_flush_logs,
         dcc_mcp_utils::file_logging::python::py_default_settings,
+        dcc_mcp_utils::py_json::json_dumps,
+        dcc_mcp_utils::py_json::json_loads,
     );
     add_classes!(
         m,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,6 +230,8 @@ fn register_utils(m: &Bound<'_, PyModule>) -> PyResult<()> {
         dcc_mcp_utils::file_logging::python::py_default_settings,
         dcc_mcp_utils::py_json::json_dumps,
         dcc_mcp_utils::py_json::json_loads,
+        dcc_mcp_utils::py_yaml::yaml_loads,
+        dcc_mcp_utils::py_yaml::yaml_dumps,
     );
     add_classes!(
         m,


### PR DESCRIPTION
## Summary

- Expose `json_dumps()` and `json_loads()` via PyO3, backed by Rust's `serde_json` for significantly faster JSON serialization/deserialization
- Replace all `json.dumps`/`json.loads` calls in core Python library modules with the Rust implementations
- `json_dumps` supports `ensure_ascii` and `indent` parameters, and automatically converts non-serializable objects to strings (equivalent to `default=str`)

## Changed modules

`bridge.py`, `batch.py`, `feedback.py`, `dcc_server.py`, `plugin_manifest.py`, `dcc_api_executor.py`, `introspect.py`, `checkpoint.py`, `recipes.py`, `skill.py`, `workflow_yaml.py`

## What's NOT changed

- **Skill scripts** (`python/dcc_mcp_core/skills/*/scripts/*.py`) — these are standalone scripts that may run outside the `dcc_mcp_core` package context, so they continue to use `import json` from stdlib
- **Test files** — tests still use `import json` since they test both the library and edge cases
- **`server_base.py`** — only has a `json.dumps` reference in a docstring example, not actual code

## Test plan

- [x] All 8500 existing tests pass
- [x] Rust `cargo check` and `cargo clippy` pass
- [x] Pre-commit hooks (ruff, cargo fmt, cargo clippy) pass
- [x] Manual verification of `json_dumps`/`json_loads` with basic types, unicode, indent, and round-trip