### PR TITLE
fix(ci): skip stubgen on Python 3.7 builds, mirror release flow in PR CI

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -77,7 +77,14 @@ runs:
 
     - name: Generate type stubs
       shell: bash
-      run: just stubgen
+      run: |
+        # pyo3-stub-gen v0.22.x unconditionally references PyEncodingWarning,
+        # which only exists in pyo3 when targeting Python >= 3.10.
+        # For Python 3.7 builds we skip regeneration and use the committed stubs.
+        # The abi3 (Python 3.11) build regenerates and commits the authoritative stubs.
+        if [[ "${{ inputs.python-version }}" != "3.7" ]]; then
+          just stubgen
+        fi
 
     - name: Build wheel
       uses: PyO3/maturin-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,12 @@ jobs:
           fail_ci_if_error: false
 
   # ── Python 3.7 build + test (non-abi3 wheel) ──
+  # Uses the same composite action as the release workflow so CI mirrors the
+  # exact environment that caused the windows-py37 failure post-merge.
+  # Previously this job used Python 3.14 as the active interpreter and called
+  # `just build-py37` directly, which hid a pyo3-stub-gen Python<3.10 compat
+  # bug (PyEncodingWarning missing on py37) that only surfaced in the release
+  # build-wheels workflow. Now both paths go through the same composite action.
   # Note: Must use older OS runners where Python 3.7 is still available via setup-python
   build-wheel-py37:
     name: Build wheel (py3.7, ${{ matrix.os }})
@@ -166,42 +172,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/setup-python@v6
+      - uses: ./.github/actions/build-wheel
         with:
-          python-version: "3.14"
-      - uses: loonghao/vx@v0.8.32
-      - name: Install maturin
-        run: pip install maturin
-        shell: bash
-      - name: Build Python 3.7 wheel (non-abi3)
-        # Feature list lives in justfile (WHEEL_FEATURES_PY37).
-        run: vx just build-py37
-        shell: bash
-      - name: Test Python 3.7 wheel
-        shell: bash
-        run: |
-          python -m venv test-env
-          if [ "${{ runner.os }}" = "Windows" ]; then
-            source test-env/Scripts/activate
-          else
-            source test-env/bin/activate
-          fi
-          pip install --no-index --find-links dist dcc-mcp-core --force-reinstall --no-deps
-          python -c "
-          import dcc_mcp_core
-          print(f'Version: {dcc_mcp_core.__version__}')
-          from dcc_mcp_core._core import ToolRegistry, ToolResult, SkillScanner
-          result = ToolResult(success=True, message='Wheel test passed')
-          print(f'Result: {result}')
-          reg = ToolRegistry()
-          print(f'Registry: {reg}')
-          print('All imports OK!')
-          "
-      - uses: actions/upload-artifact@v7
-        with:
-          name: wheel-py37-${{ matrix.os }}
-          path: dist/*.whl
+          target: ${{ matrix.target }}
+          python-version: "3.7"
+          maturin-extra-args: '-i python3.7'
+          test-wheel: 'true'
+          artifact-name: wheel-py37-${{ matrix.os }}
+          use-sccache: 'false'
 
   # ── Lint Python source ──
   lint:


### PR DESCRIPTION
## Summary

- Fix `build-wheels / windows-py37` post-merge failure caused by `pyo3-stub-gen v0.22.1` referencing `PyEncodingWarning` (Python 3.10+) when compiling against Python 3.7
- Close the CI gap that allowed the regression to merge undetected

## Root Cause

`pyo3-stub-gen v0.22.1` unconditionally implements `PyStubType` for `PyEncodingWarning` in `exception.rs:79`, but `EncodingWarning` was added in Python 3.10. When the `stubgen` recipe runs with Python 3.7 as the active interpreter, the crate fails to compile:

```
error[E0412]: cannot find type `PyEncodingWarning` in this scope
   --> pyo3-stub-gen-0.22.1/src/exception.rs:79:27
error: could not compile `pyo3-stub-gen` (lib) due to 1 previous error
error: Recipe `stubgen` failed on line 177 with exit code 1
```

## Why PR CI Didn't Catch It

| | PR CI (`ci.yml`) | Release CI (`build-wheels.yml`) |
|--|--|--|
| Active Python | **3.14** (setup-python 3.14) | **3.7** (composite action sets 3.7 first) |
| `stubgen` result | Python 3.14 → `PyEncodingWarning` exists → ✅ | Python 3.7 → `PyEncodingWarning` missing → ❌ |

The PR CI `build-wheel-py37` job set up Python 3.14, then called `vx just build-py37` directly — `stubgen` ran against 3.14 and passed. The release workflow uses the composite action which sets Python 3.7 **before** running `stubgen`, only surfacing the failure post-merge.

## Fixes

**`.github/actions/build-wheel/action.yml`** — skip `just stubgen` when `python-version == 3.7`. Stubs are version-independent and are generated authoritatively by the abi3 (Python 3.11) build.

**`.github/workflows/ci.yml`** — rewrite `build-wheel-py37` to use the same composite action as the release workflow (`python-version: "3.7"`). PR CI and Release CI now share the same code path, so this class of regression is caught before merge.

## Test Plan
- [ ] `build-wheel (py3.7, windows-2022)` passes in this PR's CI
- [ ] `build-wheel (py3.7, ubuntu-22.04)` passes in this PR's CI
