### PR TITLE
fix: resolve issues #464 #465 #466 #467

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,7 +653,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dcc-mcp-actions"
-version = "0.14.13"
+version = "0.14.14"
 dependencies = [
  "dashmap",
  "dcc-mcp-models",
@@ -670,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-artefact"
-version = "0.14.13"
+version = "0.14.14"
 dependencies = [
  "chrono",
  "hex",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-capture"
-version = "0.14.13"
+version = "0.14.14"
 dependencies = [
  "image",
  "libc",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-core"
-version = "0.14.13"
+version = "0.14.14"
 dependencies = [
  "dcc-mcp-actions",
  "dcc-mcp-artefact",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-http"
-version = "0.14.13"
+version = "0.14.14"
 dependencies = [
  "axum",
  "axum-test",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-models"
-version = "0.14.13"
+version = "0.14.14"
 dependencies = [
  "dcc-mcp-utils",
  "pyo3",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-naming"
-version = "0.14.13"
+version = "0.14.14"
 dependencies = [
  "pyo3",
  "pyo3-stub-gen",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-process"
-version = "0.14.13"
+version = "0.14.14"
 dependencies = [
  "ipckit",
  "parking_lot",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-protocols"
-version = "0.14.13"
+version = "0.14.14"
 dependencies = [
  "dcc-mcp-utils",
  "parking_lot",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-sandbox"
-version = "0.14.13"
+version = "0.14.14"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-scheduler"
-version = "0.14.13"
+version = "0.14.14"
 dependencies = [
  "axum",
  "bytes",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-server"
-version = "0.14.13"
+version = "0.14.14"
 dependencies = [
  "anyhow",
  "axum",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-shm"
-version = "0.14.13"
+version = "0.14.14"
 dependencies = [
  "ipckit",
  "libc",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-skills"
-version = "0.14.13"
+version = "0.14.14"
 dependencies = [
  "dashmap",
  "dcc-mcp-actions",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-telemetry"
-version = "0.14.13"
+version = "0.14.14"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-transport"
-version = "0.14.13"
+version = "0.14.14"
 dependencies = [
  "criterion",
  "dashmap",
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-usd"
-version = "0.14.13"
+version = "0.14.14"
 dependencies = [
  "dcc-mcp-protocols",
  "pyo3",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-utils"
-version = "0.14.13"
+version = "0.14.14"
 dependencies = [
  "dirs",
  "parking_lot",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-workflow"
-version = "0.14.13"
+version = "0.14.14"
 dependencies = [
  "base64",
  "chrono",

--- a/crates/dcc-mcp-http/src/python/skill_server.rs
+++ b/crates/dcc-mcp-http/src/python/skill_server.rs
@@ -149,6 +149,76 @@ impl PyMcpHttpServer {
         self.dispatcher.has_handler(action_name)
     }
 
+    /// Register a Python callable as the **in-process** script executor.
+    ///
+    /// This is the recommended way to wire DCC-specific execution into the
+    /// Skills-First workflow (issues #464, #465).  Call this **before** any
+    /// ``load_skill()`` calls so that all skill handlers are registered with
+    /// the in-process path from the start, eliminating the timing race that
+    /// occurred when handlers were overridden one-by-one after loading.
+    ///
+    /// The callable receives two positional arguments:
+    ///
+    /// - ``script_path`` (``str``) — absolute path to the skill's ``.py`` file.
+    /// - ``params`` (``dict``) — tool input parameters.
+    ///
+    /// It must return a JSON-serialisable value (``dict``, ``list``, scalar…).
+    ///
+    /// When called, ``load_skill()`` will register **in-process** handlers for
+    /// every tool in the loaded skill instead of spawning subprocesses.
+    ///
+    /// Example::
+    ///
+    ///     import runpy
+    ///
+    ///     def my_executor(script_path, params):
+    ///         ns = runpy.run_path(script_path, init_globals={"params": params})
+    ///         return ns.get("result", {})
+    ///
+    ///     server = create_skill_server("maya")
+    ///     server.set_in_process_executor(my_executor)
+    ///     server.load_skill("maya-scene")   # handlers: in-process ✓
+    ///
+    /// Raises:
+    ///     TypeError: If ``executor`` is not callable.
+    #[pyo3(signature = (executor))]
+    fn set_in_process_executor(&self, py: Python<'_>, executor: Py<PyAny>) -> PyResult<()> {
+        if !executor.bind(py).is_callable() {
+            return Err(pyo3::exceptions::PyTypeError::new_err(
+                "executor must be callable",
+            ));
+        }
+        let executor_ref = executor.clone_ref(py);
+        self.catalog
+            .set_in_process_executor(move |script_path, params| {
+                Python::attach(|gil| {
+                    use dcc_mcp_utils::py_json::{json_value_to_bound_py, py_any_to_json_value};
+
+                    let py_path = script_path.into_py(gil);
+                    let py_params = json_value_to_bound_py(gil, &params)
+                        .map_err(|e| format!("failed to convert params: {e}"))?;
+                    let raw = executor_ref
+                        .call1(gil, (py_path, py_params))
+                        .map_err(|e| format!("executor error: {e}"))?;
+                    py_any_to_json_value(raw.bind(gil)).map_err(|e| e.to_string())
+                })
+            });
+        tracing::info!(
+            "McpHttpServer: in-process executor registered — \
+             load_skill() will use in-process handlers (issue #464)"
+        );
+        Ok(())
+    }
+
+    /// Remove the in-process executor, reverting future ``load_skill()`` calls
+    /// to subprocess execution.
+    ///
+    /// Already-loaded skills retain their existing handlers; call
+    /// ``unload_skill()`` and ``load_skill()`` again to switch them.
+    fn clear_in_process_executor(&self) {
+        self.catalog.clear_in_process_executor();
+    }
+
     /// The server's :class:`ToolRegistry`.
     ///
     /// Returned value shares the underlying storage with the server —

--- a/crates/dcc-mcp-http/src/python/skill_server.rs
+++ b/crates/dcc-mcp-http/src/python/skill_server.rs
@@ -194,11 +194,10 @@ impl PyMcpHttpServer {
                 Python::attach(|gil| {
                     use dcc_mcp_utils::py_json::{json_value_to_bound_py, py_any_to_json_value};
 
-                    let py_path = script_path.into_py(gil);
                     let py_params = json_value_to_bound_py(gil, &params)
                         .map_err(|e| format!("failed to convert params: {e}"))?;
                     let raw = executor_ref
-                        .call1(gil, (py_path, py_params))
+                        .call1(gil, (script_path, py_params))
                         .map_err(|e| format!("executor error: {e}"))?;
                     py_any_to_json_value(raw.bind(gil)).map_err(|e| e.to_string())
                 })

--- a/crates/dcc-mcp-models/src/skill_metadata/mod.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata/mod.rs
@@ -261,6 +261,29 @@ pub struct SkillMetadata {
     /// rules that govern description prefixes and `search-hint` partitioning.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub layer: Option<String>,
+
+    /// Sibling-file reference for skill recipes (issue #466).
+    ///
+    /// Set from `metadata.dcc-mcp.recipes` in SKILL.md frontmatter. The value
+    /// is a path relative to the skill root pointing to a TOML or YAML file
+    /// that declares pre-composed parameter templates for common workflows.
+    ///
+    /// Parsing is deferred; the path is stored here so callers can load it
+    /// lazily on demand.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recipes_file: Option<String>,
+
+    /// Sibling-file reference for skill introspection metadata (issue #466).
+    ///
+    /// Set from `metadata.dcc-mcp.introspection` in SKILL.md frontmatter.
+    /// The value is a path relative to the skill root pointing to a YAML file
+    /// that describes capability probes, version checks, or runtime-discovery
+    /// hooks used by agents to verify skill compatibility before invocation.
+    ///
+    /// Parsing is deferred; the path is stored here so callers can load it
+    /// lazily on demand.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub introspection_file: Option<String>,
 }
 
 mod execution;

--- a/crates/dcc-mcp-models/src/skill_metadata/python.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata/python.rs
@@ -58,6 +58,8 @@ impl SkillMetadata {
             legacy_extension_fields: Vec::new(),
             prompts_file: None,
             layer: None,
+            recipes_file: None,
+            introspection_file: None,
         }
     }
 

--- a/crates/dcc-mcp-models/src/skill_metadata/tests.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata/tests.rs
@@ -290,6 +290,8 @@ fn test_skill_metadata_serde_round_trip() {
         legacy_extension_fields: Vec::new(),
         prompts_file: None,
         layer: Some("domain".to_string()),
+        recipes_file: None,
+        introspection_file: None,
     };
     let json = serde_json::to_string(&meta).unwrap();
     let back: SkillMetadata = serde_json::from_str(&json).unwrap();

--- a/crates/dcc-mcp-skills/src/catalog/catalog_discovery.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog_discovery.rs
@@ -8,7 +8,7 @@ impl SkillCatalog {
             loaded: DashSet::new(),
             registry,
             dispatcher: None,
-            script_executor: None,
+            script_executor: RwLock::new(None),
             active_groups: DashSet::new(),
         }
     }
@@ -23,7 +23,7 @@ impl SkillCatalog {
             loaded: DashSet::new(),
             registry,
             dispatcher: Some(dispatcher),
-            script_executor: None,
+            script_executor: RwLock::new(None),
             active_groups: DashSet::new(),
         }
     }
@@ -35,31 +35,42 @@ impl SkillCatalog {
     }
 
     /// Register an **in-process** script executor (builder-style).
-    pub fn with_in_process_executor<F>(mut self, executor: F) -> Self
+    pub fn with_in_process_executor<F>(self, executor: F) -> Self
     where
         F: Fn(String, serde_json::Value) -> Result<serde_json::Value, String>
             + Send
             + Sync
             + 'static,
     {
-        self.script_executor = Some(Arc::new(executor));
+        *self.script_executor.write() = Some(Arc::new(executor));
         self
     }
 
     /// Replace the in-process executor after construction.
-    pub fn set_in_process_executor<F>(&mut self, executor: F)
+    ///
+    /// Unlike the builder-style [`with_in_process_executor`](Self::with_in_process_executor),
+    /// this method works on a shared `Arc<SkillCatalog>` (issue #464) — DCC
+    /// adapters can call it between construction and the first `load_skill()`.
+    pub fn set_in_process_executor<F>(&self, executor: F)
     where
         F: Fn(String, serde_json::Value) -> Result<serde_json::Value, String>
             + Send
             + Sync
             + 'static,
     {
-        self.script_executor = Some(Arc::new(executor));
+        *self.script_executor.write() = Some(Arc::new(executor));
+    }
+
+    /// Replace the in-process executor with a pre-boxed `Arc<ScriptExecutorFn>`.
+    ///
+    /// Useful when the executor is already in `Arc` form (e.g. from PyO3 bindings).
+    pub fn set_in_process_executor_arc(&self, executor: Arc<ScriptExecutorFn>) {
+        *self.script_executor.write() = Some(executor);
     }
 
     /// Remove the in-process executor, reverting to subprocess execution.
-    pub fn clear_in_process_executor(&mut self) {
-        self.script_executor = None;
+    pub fn clear_in_process_executor(&self) {
+        *self.script_executor.write() = None;
     }
 
     /// Discover skills from the standard scan paths.

--- a/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
@@ -77,8 +77,8 @@ impl SkillCatalog {
                 let script_path_owned = script_path.clone();
                 let action_name_clone = action_name.clone();
                 let dcc_owned = metadata.dcc.clone();
-                if let Some(executor) = &self.script_executor {
-                    let executor = Arc::clone(executor);
+                let maybe_executor = self.script_executor.read().clone();
+                if let Some(executor) = maybe_executor {
                     dispatcher.register_handler(&action_name_clone, move |params| {
                         executor(script_path_owned.clone(), params)
                     });
@@ -127,8 +127,8 @@ impl SkillCatalog {
                     let script_path_owned = script_path.clone();
                     let action_name_clone = action_name.clone();
                     let dcc_owned = metadata.dcc.clone();
-                    if let Some(executor) = &self.script_executor {
-                        let executor = Arc::clone(executor);
+                    let maybe_executor = self.script_executor.read().clone();
+                    if let Some(executor) = maybe_executor {
                         dispatcher.register_handler(&action_name_clone, move |params| {
                             executor(script_path_owned.clone(), params)
                         });
@@ -149,7 +149,7 @@ impl SkillCatalog {
         }
         self.loaded.insert(skill_name.to_string());
 
-        let handler_mode = match (&self.dispatcher, &self.script_executor) {
+        let handler_mode = match (&self.dispatcher, &*self.script_executor.read()) {
             (Some(_), Some(_)) => "in-process",
             (Some(_), None) => "subprocess",
             (None, _) => "none",

--- a/crates/dcc-mcp-skills/src/catalog/mod.rs
+++ b/crates/dcc-mcp-skills/src/catalog/mod.rs
@@ -53,6 +53,7 @@ use dcc_mcp_actions::{
     registry::{ActionMeta, ActionRegistry},
 };
 use dcc_mcp_models::{SkillGroup, SkillMetadata, SkillScope};
+use parking_lot::RwLock;
 use std::sync::Arc;
 
 use crate::loader;
@@ -103,7 +104,7 @@ pub struct SkillCatalog {
     /// instead of being dispatched to a subprocess.  DCC adapters should
     /// register one of these via [`with_in_process_executor`](Self::with_in_process_executor)
     /// so that `maya.cmds`, `bpy`, `hou`, etc. are available to the scripts.
-    pub(super) script_executor: Option<Arc<ScriptExecutorFn>>,
+    pub(super) script_executor: RwLock<Option<Arc<ScriptExecutorFn>>>,
     /// Tool groups currently active (`"<skill>:<group>"` keys).
     pub(super) active_groups: DashSet<String>,
 }

--- a/crates/dcc-mcp-skills/src/catalog/python.rs
+++ b/crates/dcc-mcp-skills/src/catalog/python.rs
@@ -77,10 +77,10 @@ impl SkillCatalog {
     ///
     /// Pass ``None`` to revert to subprocess execution.
     #[pyo3(name = "set_in_process_executor")]
-    fn py_set_in_process_executor(&mut self, executor: Option<Py<PyAny>>) -> PyResult<()> {
+    fn py_set_in_process_executor(&self, executor: Option<Py<PyAny>>) -> PyResult<()> {
         match executor {
             None => {
-                self.script_executor = None;
+                self.clear_in_process_executor();
             }
             Some(py_fn) => {
                 let executor_fn = move |script_path: String,
@@ -99,7 +99,7 @@ impl SkillCatalog {
                     .ok_or_else(|| "Python interpreter not attached".to_string())
                     .and_then(|r| r)
                 };
-                self.script_executor = Some(Arc::new(executor_fn));
+                self.set_in_process_executor(executor_fn);
             }
         }
         Ok(())

--- a/crates/dcc-mcp-skills/src/loader/mod.rs
+++ b/crates/dcc-mcp-skills/src/loader/mod.rs
@@ -286,6 +286,24 @@ fn apply_dcc_mcp_metadata_overrides(
                     }
                 }
             }
+            "recipes" => {
+                // Sibling-file reference for pre-composed parameter templates
+                // (issue #466). Parsing is deferred; store the path for lazy loading.
+                if let Some(s) = value.as_str() {
+                    if !s.is_empty() {
+                        meta.recipes_file = Some(s.to_string());
+                    }
+                }
+            }
+            "introspection" => {
+                // Sibling-file reference for capability-probe / version-check
+                // metadata (issue #466). Parsing is deferred; store for lazy loading.
+                if let Some(s) = value.as_str() {
+                    if !s.is_empty() {
+                        meta.introspection_file = Some(s.to_string());
+                    }
+                }
+            }
             _ => {
                 tracing::debug!(
                     "skill {}: unknown metadata.dcc-mcp.{} key — ignoring",

--- a/crates/dcc-mcp-telemetry/src/provider.rs
+++ b/crates/dcc-mcp-telemetry/src/provider.rs
@@ -112,6 +112,36 @@ pub fn is_initialized() -> bool {
     HANDLE.get().is_some()
 }
 
+/// Initialise a minimal no-op telemetry provider if one has not been set yet.
+///
+/// This silences the `NoopMeterProvider` / `NoopTracerProvider` warnings that
+/// OpenTelemetry emits when `global::meter()` or `global::tracer()` is called
+/// before any provider has been registered (issue #467).
+///
+/// - If the global provider is already set (by a prior `init()` call or by the
+///   application configuring OTLP / Stdout exporters), this function does
+///   nothing and returns `Ok(())`.
+/// - Otherwise it installs a minimal `SdkMeterProvider` with no exporters so
+///   metrics are silently discarded but the warning is suppressed.
+///
+/// Call this early in your server startup if you don't need full telemetry:
+///
+/// ```no_run
+/// dcc_mcp_telemetry::provider::try_init_default().ok();
+/// ```
+pub fn try_init_default() -> Result<(), TelemetryError> {
+    if HANDLE.get().is_some() {
+        return Ok(());
+    }
+    let cfg = TelemetryConfig {
+        enable_metrics: true,
+        enable_tracing: false,
+        exporter: crate::types::ExporterBackend::Noop,
+        ..TelemetryConfig::default()
+    };
+    init(&cfg)
+}
+
 // ── Named tracer / meter accessors ────────────────────────────────────────────
 
 /// Get a named [`Tracer`] from the global provider.

--- a/crates/dcc-mcp-telemetry/src/python.rs
+++ b/crates/dcc-mcp-telemetry/src/python.rs
@@ -346,6 +346,34 @@ pub fn py_shutdown_telemetry() {
     provider::shutdown();
 }
 
+/// Initialise a minimal no-op telemetry provider if one has not been set yet.
+///
+/// Silences the ``NoopMeterProvider`` warning that OpenTelemetry emits when
+/// ``global::meter()`` is called before any provider has been registered
+/// (issue #467).  Safe to call multiple times — a no-op when already
+/// initialised.
+///
+/// Example::
+///
+///     from dcc_mcp_core import init_default_telemetry
+///
+///     # At server startup, before any MCP tools run:
+///     init_default_telemetry()
+///
+/// Raises:
+///     RuntimeError: If provider initialisation fails for a reason other than
+///         "already initialized".
+#[cfg_attr(feature = "stub-gen", gen_stub_pyfunction)]
+#[pyfunction]
+#[pyo3(name = "init_default_telemetry")]
+pub fn py_init_default_telemetry() -> PyResult<()> {
+    match provider::try_init_default() {
+        Ok(()) => Ok(()),
+        Err(crate::error::TelemetryError::AlreadyInitialized) => Ok(()),
+        Err(e) => Err(PyRuntimeError::new_err(e.to_string())),
+    }
+}
+
 // ── Registration ──────────────────────────────────────────────────────────────
 
 /// Register all telemetry classes and functions on a Python module.
@@ -356,5 +384,6 @@ pub fn register_classes(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyRecordingGuard>()?;
     m.add_function(wrap_pyfunction!(py_is_telemetry_initialized, m)?)?;
     m.add_function(wrap_pyfunction!(py_shutdown_telemetry, m)?)?;
+    m.add_function(wrap_pyfunction!(py_init_default_telemetry, m)?)?;
     Ok(())
 }


### PR DESCRIPTION
## Summary

- **#464/#465 — In-process executor for DCC skill loading**: Wraps SkillCatalog.script_executor in parking_lot::RwLock for interior mutability, adds PyMcpHttpServer.set_in_process_executor(callable) Python API so DCC adapters register their runner before load_skill(). All subsequent load_skill() calls register in-process handlers instead of subprocess handlers.
- **#466 — recipes and introspection metadata keys**: Adds SkillMetadata.recipes_file and SkillMetadata.introspection_file; handles metadata.dcc-mcp.recipes and metadata.dcc-mcp.introspection in SKILL.md loader. No more 'unknown key' warnings.
- **#467 — Avoid NoopMeterProvider warning**: Adds provider::try_init_default() and Python binding init_default_telemetry() that silently installs a noop SdkMeterProvider when no provider has been registered.

## Test plan
- cargo check --workspace passes
- cargo test -p dcc-mcp-models -p dcc-mcp-skills -p dcc-mcp-telemetry all pass (288 tests)
- cargo fmt + cargo clippy pass

Closes #464
Closes #465
Closes #466
Closes #467