### PR TITLE
fix(ci): remove pre-installed cargo-clippy on macOS + ignore workspace-hack in Renovate

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -40,6 +40,16 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
+    - name: Remove pre-installed cargo-clippy (macOS aarch64 conflict workaround)
+      # The macos-latest runner (Apple Silicon) pre-installs Rust with cargo-clippy.
+      # When rustup tries to install the pinned toolchain's clippy component it
+      # finds 'bin/cargo-clippy' already present and rolls back the whole install,
+      # causing the "detected conflict: 'bin/cargo-clippy'" error seen in CI.
+      # Removing the stale binary before toolchain setup lets rustup install cleanly.
+      if: runner.os == 'macOS'
+      shell: bash
+      run: rm -f ~/.cargo/bin/cargo-clippy ~/.cargo/bin/cargo-fmt || true
+
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@master
       with:

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,9 @@
   "extends": [
     "config:recommended"
   ],
+  "ignorePaths": [
+    "crates/workspace-hack/Cargo.toml"
+  ],
   "packageRules": [
     {
       "matchManagers": ["cargo"],


### PR DESCRIPTION
## Summary

- Fix macOS clippy conflict: macos-latest runner pre-installs cargo-clippy; added cleanup step in build-wheel action before toolchain setup.
- Prevent Renovate touching workspace-hack: added ignorePaths in renovate.json; closed PR #470 (phf bump broke rand 0.10+small_rng).

Made with [Cursor](https://cursor.com)