### PR TITLE
fix(ci): extend cargo-clippy conflict workaround to Linux runners

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -40,13 +40,16 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
-    - name: Remove pre-installed cargo-clippy (macOS aarch64 conflict workaround)
-      # The macos-latest runner (Apple Silicon) pre-installs Rust with cargo-clippy.
-      # When rustup tries to install the pinned toolchain's clippy component it
-      # finds 'bin/cargo-clippy' already present and rolls back the whole install,
-      # causing the "detected conflict: 'bin/cargo-clippy'" error seen in CI.
-      # Removing the stale binary before toolchain setup lets rustup install cleanly.
-      if: runner.os == 'macOS'
+    - name: Remove pre-installed cargo-clippy (conflict workaround)
+      # GitHub-hosted runners (macOS aarch64 AND ubuntu-latest) pre-install Rust
+      # with cargo-clippy. When rustup installs the pinned toolchain (rust-toolchain.toml
+      # requests the clippy component) it finds 'bin/cargo-clippy' already present and
+      # rolls back the whole install with:
+      #   "detected conflict: 'bin/cargo-clippy'"
+      # Removing the stale binaries before toolchain setup lets rustup install cleanly.
+      # Using 'if: runner.os != Windows' keeps the bash-only rm command off Windows;
+      # on Windows cargo-clippy is installed via dtolnay/rust-toolchain without conflict.
+      if: runner.os != 'Windows'
       shell: bash
       run: rm -f ~/.cargo/bin/cargo-clippy ~/.cargo/bin/cargo-fmt || true
 


### PR DESCRIPTION
Same root cause as #472 (merged): ubuntu-latest x86_64 runners also pre-install Rust with cargo-clippy, triggering the same conflict when dtolnay/rust-toolchain installs our pinned 1.90.0 toolchain.

Change guard from runner.os == macOS to runner.os != Windows so the cleanup step runs on both Linux and macOS. Windows is excluded as it does not pre-install cargo-clippy.