### PR TITLE
docs: sync AI-facing docs with latest API surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,10 @@
 | Expose DCC tools over MCP | `DccServerBase` → subclass → `start()` |
 | Zero-code tool registration | `SKILL.md` + `scripts/` ([agentskills.io](https://agentskills.io/specification)) |
 | Structured results | `success_result()` / `error_result()` |
+| Rich error with traceback | `skill_error_with_trace()` |
 | Bridge non-Python DCC | `DccBridge` (WebSocket JSON-RPC 2.0) |
 | IPC | `IpcChannelAdapter` / `SocketServerAdapter` + `DccLinkFrame` |
+| Hand off files between tools | `FileRef` + `artefact_put_file()` / `artefact_get_bytes()` |
 | Multi-DCC gateway | `McpHttpConfig(gateway_port=9765)` |
 | Gateway failover | `DccGatewayElection(dcc_name, server)` — auto-promote on gateway failure |
 | Skill scoping | `SkillScope` (Repo → User → System → Admin) — Rust-only |
@@ -54,10 +56,14 @@
 | In-process skill execution (embedded DCC) | `SkillCatalog.set_in_process_executor(callable)` |
 | Skill scanning | `scan_and_load(dcc_name=...)` → always unpack `(skills, skipped)` tuple |
 | Tolerate broken SKILL.md | `scan_and_load_lenient(...)` instead of `scan_and_load` |
+| Discover team-level skills | `scan_and_load_team()` / `scan_and_load_team_lenient()` |
+| Discover user-level skills | `scan_and_load_user()` / `scan_and_load_user_lenient()` |
+| Disable evolved skills | `ENV_DISABLE_ACCUMULATED_SKILLS` |
 | MCP HTTP (recommended) | `create_skill_server("maya", McpHttpConfig(port=8765))` |
 | MCP HTTP (manual) | `McpHttpServer(registry, McpHttpConfig(port=8765))` |
 | Full-screen capture | `Capturer.new_auto().capture()` |
 | Single-window capture | `Capturer.new_window_auto().capture_window(...)` |
+| Capture DCC output streams | `OutputCapture` — stdout/stderr/script-editor as `output://` resource |
 | Cooperative cancellation | `check_cancelled()` in long-running skill scripts |
 | Checkpoint/resume | `save_checkpoint(job_id, state)` / `get_checkpoint(job_id)` |
 | Agent-facing docs resources | `register_docs_server(server)` → `docs://` MCP resources |

--- a/CODEBUDDY.md
+++ b/CODEBUDDY.md
@@ -33,8 +33,8 @@ When you need information, read in this order — stop when you find what you ne
 2. Add PyO3 bindings in the crate's `python.rs` module (`#[pyclass]` / `#[pymethods]`)
 3. Register in `src/lib.rs` in the corresponding `register_*()` function
 4. Re-export in `python/dcc_mcp_core/__init__.py` (both import and `__all__`)
-5. Update `python/dcc_mcp_core/_core.pyi` stubs
-6. Add pytest tests in `tests/test_<module>.py`
+5. Add pytest tests in `tests/test_<module>.py`
+6. Regenerate type stubs via `vx just stubgen` (produces `_core.pyi`)
 
 ### When Working With Skills
 
@@ -43,6 +43,11 @@ When you need information, read in this order — stop when you find what you ne
 - Action naming: `{skill_name}__{script_stem}` (double underscore, hyphens→underscores)
 - Use `scan_and_load()` or `scan_and_load_lenient()` — not the old `scan_and_load_skills()`
 - **`scan_and_load` returns a 2-tuple**: `(List[SkillMetadata], List[str])` — always unpack both
+- **`search-hint` in SKILL.md**: add `search-hint: "keyword1, keyword2"` to improve `search_skills` matching without loading full schemas
+- **On-demand discovery**: `tools/list` returns skill stubs (`__skill__<name>`) for unloaded skills; use `search_skills(query)` then `load_skill(name)` to activate. As of #340 `search_skills` takes `query`/`tags`/`dcc`/`scope`/`limit` (all optional — empty call browses by trust scope)
+- **Bundled skills**: 2 core skills shipped inside the wheel (`dcc_mcp_core/skills/`): `dcc-diagnostics`, `workflow` — use `get_bundled_skills_dir()` / `get_bundled_skill_paths()` to get the path. DCC adapters include these by default (`include_bundled=True`)
+- **Skill authoring templates**: `skills/templates/` provides three starter templates: `minimal` (1 tool, 1 script), `dcc-specific` (DCC binding + required_capabilities + next-tools chaining), `with-groups` (tool groups for progressive exposure). See `skills/README.md` for quick-start guide
+- **DCC integration architectures**: `skills/integration-guide.md` covers three patterns: Embedded Python (`DccServerBase`) — Maya, Blender, Houdini, Unreal; WebSocket Bridge (`DccBridge`) — Photoshop, ZBrush, Unity, After Effects; WebView Host (`WebViewAdapter`) — AuroraView, Electron panels
 - See `examples/skills/` for 11 reference implementations
 
 ### When Using MCP HTTP Server

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -34,6 +34,13 @@
 | Wrap values for safe RPyC transport | `wrap_value()` / `unwrap_value()` |
 | Handle multiple versions of an action | `VersionedRegistry` + `VersionConstraint` |
 | Expose DCC tools over HTTP/MCP | `create_skill_server("maya", McpHttpConfig(port=8765))` — Skills-First one-call setup; falls back to `McpHttpServer(registry, config)` for manual registry wiring |
+| Discover team-level skills | `scan_and_load_team()` / `scan_and_load_team_lenient()` |
+| Discover user-level skills | `scan_and_load_user()` / `scan_and_load_user_lenient()` |
+| Reference files across tool calls (artefacts) | `FileRef` + `artefact_put_file()` / `artefact_get_bytes()` / `artefact_list()` |
+| Capture DCC stdout/stderr/script-editor output | `OutputCapture` |
+| Rich skill error with traceback | `skill_error_with_trace()` |
+| Skill warning / exception helpers | `skill_warning()` / `skill_exception()` |
+| Disable accumulated/evolved skills | `ENV_DISABLE_ACCUMULATED_SKILLS` |
 
 ---
 
@@ -561,6 +568,79 @@ for s in skills:
     # Action names: f"{s.name.replace('-', '_')}__{stem}" for stem in script stems
 ```
 
+### scan_and_load_team / scan_and_load_team_lenient
+
+```python
+# Discover team-level skills (shared / accumulated / evolved skills)
+skills, skipped = dcc_mcp_core.scan_and_load_team(dcc_name="maya")
+skills, skipped = dcc_mcp_core.scan_and_load_team_lenient(dcc_name="maya")
+# Same return type as scan_and_load: (List[SkillMetadata], List[str])
+# Reads DCC_MCP_TEAM_SKILL_PATHS env var + platform team skills dir
+```
+
+### scan_and_load_user / scan_and_load_user_lenient
+
+```python
+# Discover user-level skills (personal skill directories)
+skills, skipped = dcc_mcp_core.scan_and_load_user(dcc_name="maya")
+skills, skipped = dcc_mcp_core.scan_and_load_user_lenient(dcc_name="maya")
+# Same return type as scan_and_load: (List[SkillMetadata], List[str])
+# Reads DCC_MCP_USER_SKILL_PATHS env var + platform user skills dir
+```
+
+### Skill Feedback
+
+```python
+from dcc_mcp_core import SkillFeedback, get_skill_feedback, record_skill_feedback
+
+# Record feedback for a skill (e.g., from agent or user)
+record_skill_feedback("maya-geometry", "success: created sphere quickly")
+
+# Retrieve feedback history
+entries: list[SkillFeedback] = get_skill_feedback("maya-geometry")
+for entry in entries:
+    print(entry.text)   # str feedback text
+    print(entry.timestamp_ms)
+```
+
+### Skill Version Manifest
+
+```python
+from dcc_mcp_core import SkillVersionEntry, SkillVersionManifest, get_skill_version_manifest
+
+manifest = get_skill_version_manifest("/path/to/skill-dir")
+# manifest.entries: list[SkillVersionEntry]
+# Each entry: version (str), created_at (int ms), description (str), author (str)
+```
+
+### Skill Script Helpers (Rust-level)
+
+```python
+from dcc_mcp_core import skill_error_with_trace, skill_warning, skill_exception
+
+# Error with automatic traceback capture
+result = skill_error_with_trace("Export failed", error="File not found", prompt="Check path")
+
+# Warning-level result (success=True with warning note)
+result = skill_warning("Export completed", prompt="Review normals", warning="Some UVs overlap")
+
+# Exception wrapper (captures current exception info)
+try:
+    risky_op()
+except Exception:
+    result = skill_exception("Operation failed", prompt="Retry with different params")
+```
+
+### run_main
+
+```python
+from dcc_mcp_core import run_main
+
+# Convenience entry point for standalone skill script execution
+# Executes main_fn, serializes result, prints JSON to stdout, exits 0/1
+run_main(skill_dir, params=None) -> dict
+```
+
 ### Dependency Resolution
 
 ```python
@@ -974,6 +1054,28 @@ td.source_file   # str   — relative path within skill's scripts/ dir
 `tools:` array in SKILL.md frontmatter (v0.12+ format). Each entry corresponds to one MCP tool
 that the skill exposes. The `source_file` field links the declaration back to the script that
 implements it.
+
+### ToolSpec
+
+Full tool specification for registry use, including optional output schema and annotations.
+
+```python
+from dcc_mcp_core import ToolSpec
+
+ts = ToolSpec(
+    name="create_sphere",
+    description="Create a polygon sphere",
+    input_schema='{"type": "object", "required": ["radius"], "properties": {"radius": {"type": "number"}}}',
+    output_schema='{"type": "object", "properties": {"name": {"type": "string"}}}',
+    annotations=dcc_mcp_core.ToolAnnotations(
+        title="Create Sphere",
+        read_only_hint=False,
+        destructive_hint=False,
+    ),
+)
+```
+
+**Fields:** `.name`, `.description`, `.input_schema`, `.output_schema` (optional), `.annotations` (optional).
 
 ### ResourceDefinition / ResourceTemplateDefinition
 
@@ -1831,6 +1933,21 @@ to `Capturer.new_auto()` when no owner IPC is configured.
 
 ---
 
+## Output Capture (`dcc_mcp_core`)
+
+Capture DCC stdout, stderr, and script-editor output as an `output://` MCP resource.
+Useful for streaming logs from long-running DCC operations to the agent.
+
+```python
+from dcc_mcp_core import OutputCapture
+
+# OutputCapture is available when the compiled extension supports it.
+# Register on an McpHttpServer before .start() to enable output:// resource serving.
+# The resource URI format: output://<dcc_name>/<channel>  (e.g., output://maya/stdout)
+```
+
+---
+
 ## USD Scene Description (`dcc_mcp_core`)
 
 Lightweight USD-like scene exchange format for DCC interoperability.
@@ -1969,6 +2086,43 @@ ctx = get_bridge_context("rpyc")  # -> BridgeContext or None
 
 ---
 
+## Artefacts (`dcc_mcp_core`)
+
+Cross-tool file hand-off via the artefact store. Files are referenced by `FileRef` objects
+and served as `artefact://` MCP resources when `McpHttpConfig.enable_artefact_resources=True`.
+
+```python
+from dcc_mcp_core import FileRef, artefact_put_file, artefact_put_bytes, artefact_get_bytes, artefact_list
+
+# Store a file from disk
+ref = artefact_put_file("/tmp/render.png", name="frame_001", metadata={"shot": "sh010"})
+# ref.path — original path
+# ref.mime_type — auto-detected or "application/octet-stream"
+# ref.name — "frame_001"
+# ref.metadata — {"shot": "sh010"}
+
+# Store raw bytes
+ref2 = artefact_put_bytes(
+    b"...",
+    name="report.json",
+    mime_type="application/json",
+    metadata={"job_id": "abc"},
+)
+
+# Retrieve bytes by FileRef
+data = artefact_get_bytes(ref2)  # -> bytes
+
+# List all stored artefacts
+refs = artefact_list()  # -> list[FileRef]
+```
+
+**`FileRef` constructor:**
+```python
+FileRef(path, mime_type=None, name=None, metadata=None)
+```
+
+---
+
 ## Scene Data Model (`dcc_mcp_core`)
 
 Structured scene data types for representing DCC scene hierarchy and geometry.
@@ -2076,6 +2230,55 @@ get_app_skill_paths_from_env("maya")   # -> List[str] from DCC_MCP_MAYA_SKILL_PA
 get_app_skill_paths_from_env("blender") # -> List[str] from DCC_MCP_BLENDER_SKILL_PATHS env var
 ```
 
+### Team / User / Bundled Skill Paths
+
+```python
+from dcc_mcp_core import (
+    get_team_skill_paths_from_env, get_user_skill_paths_from_env,
+    get_app_team_skill_paths_from_env, get_app_user_skill_paths_from_env,
+    get_team_skills_dir, get_user_skills_dir,
+    get_bundled_skills_dir, get_bundled_skill_paths,
+    copy_skill_to_team_dir, copy_skill_to_user_dir,
+)
+
+# Env-var readers for team / user skill paths
+get_team_skill_paths_from_env()          # DCC_MCP_TEAM_SKILL_PATHS
+get_user_skill_paths_from_env()          # DCC_MCP_USER_SKILL_PATHS
+get_app_team_skill_paths_from_env("maya")   # DCC_MCP_MAYA_TEAM_SKILL_PATHS
+get_app_user_skill_paths_from_env("maya")   # DCC_MCP_MAYA_USER_SKILL_PATHS
+
+# Platform directories
+get_team_skills_dir()     # -> str  (team-level skills directory)
+get_user_skills_dir()     # -> str  (user-level skills directory)
+get_bundled_skills_dir()  # -> str  (bundled skills directory shipped with package)
+get_bundled_skill_paths() # -> List[str]  (list containing bundled dir when it exists)
+
+# Copy a skill directory into team / user scope
+team_path = copy_skill_to_team_dir("/path/to/my-skill")   # -> str (destination path)
+user_path = copy_skill_to_user_dir("/path/to/my-skill")   # -> str (destination path)
+```
+
+---
+
+## Scheduler (`dcc_mcp_core`)
+
+Declarative scheduling for recurring or event-driven skill execution.
+
+```python
+from dcc_mcp_core import ScheduleSpec, TriggerSpec, parse_schedules_yaml
+
+# Load schedule definitions from a YAML file
+schedules: list[ScheduleSpec] = parse_schedules_yaml("/path/to/schedules.yaml")
+for spec in schedules:
+    print(spec.name, spec.cron, spec.trigger)
+```
+
+**`ScheduleSpec` fields:** `.name`, `.cron` (optional), `.trigger` (`TriggerSpec|None`), `.tool` (str), `.inputs` (dict), `.enabled` (bool).
+
+**`TriggerSpec` fields:** `.event` (str), `.condition` (str|None).
+
+---
+
 ## File Logging (`dcc_mcp_core`)
 
 Rolling file logging for durable, multi-process debugging. Console output (stderr) is unaffected.
@@ -2146,6 +2349,9 @@ shutdown_file_logging()
 | `SKILL_METADATA_DIR` | `"metadata"` | Skill metadata subdirectory name |
 | `ENV_SKILL_PATHS` | `"DCC_MCP_SKILL_PATHS"` | Environment variable for skill search paths |
 | `ENV_LOG_LEVEL` | `"MCP_LOG_LEVEL"` | Environment variable for log level override |
+| `ENV_DISABLE_ACCUMULATED_SKILLS` | `"DCC_MCP_DISABLE_ACCUMULATED_SKILLS"` | Set to `"1"` to disable accumulated/evolved skills discovery |
+| `ENV_TEAM_SKILL_PATHS` | `"DCC_MCP_TEAM_SKILL_PATHS"` | Environment variable for team-level skill paths |
+| `ENV_USER_SKILL_PATHS` | `"DCC_MCP_USER_SKILL_PATHS"` | Environment variable for user-level skill paths |
 
 ---
 
@@ -2599,6 +2805,8 @@ Declarative auth configuration + Bearer-token validation.
 - `CimdDocument(client_name, redirect_uris, grant_types=["authorization_code"], response_types=["code"], token_endpoint_auth_method="none", scope=None, logo_uri=None, client_uri=None, contacts=[])` — `.to_dict()` produces the JSON served from `GET /.well-known/oauth-client-metadata`.
 - `validate_bearer_token(headers, *, expected_token, header_name="Authorization") -> bool` — constant-time compare via `secrets.compare_digest`; case-insensitive header lookup; `expected_token=None` disables auth with a warning.
 - `generate_api_key(length=32) -> str` — URL-safe base64 from `secrets.token_urlsafe`.
+- `hmac_sha256_hex(secret, payload) -> str` — HMAC-SHA256 digest as lowercase hex string.
+- `verify_hub_signature_256(secret, payload, signature) -> bool` — constant-time verification of HMAC-SHA256 signatures (e.g., webhook / hub callbacks).
 - `TokenValidationError` — exception type (reserved; `validate_bearer_token` returns bool).
 
 Status: API key path ships today via `McpHttpConfig.api_key`. OAuth Rust-side enforcement (serving CIMD well-known + enforcing `/mcp` Bearer) tracked in #408.

--- a/llms.txt
+++ b/llms.txt
@@ -42,6 +42,13 @@
 | Singleton DCC server factory | `create_dcc_server(instance_holder, lock, server_class, ...)` / `make_start_stop(ServerClass)` — zero-boilerplate singleton server pattern |
 | Skill validation | `validate_skill(skill_dir)` → `SkillValidationReport` with `SkillValidationIssue` list |
 | Rust-powered JSON/YAML | `json_dumps(obj)` / `json_loads(s)` / `yaml_dumps(obj)` / `yaml_loads(s)` — zero-dependency serialization |
+| Discover team-level skills | `scan_and_load_team()` / `scan_and_load_team_lenient()` |
+| Discover user-level skills | `scan_and_load_user()` / `scan_and_load_user_lenient()` |
+| Reference files across tool calls (artefacts) | `FileRef` + `artefact_put_file()` / `artefact_get_bytes()` / `artefact_list()` |
+| Capture DCC stdout/stderr/script-editor output | `OutputCapture` |
+| Rich skill error with traceback | `skill_error_with_trace()` |
+| Skill warning / exception helpers | `skill_warning()` / `skill_exception()` |
+| Disable accumulated/evolved skills | `ENV_DISABLE_ACCUMULATED_SKILLS` |
 
 ## Quick Start
 
@@ -159,11 +166,25 @@ Pure-Python modules: cancellation, checkpoint, docs_resources, feedback, introsp
 - `scan_skill_paths(extra_paths=None, dcc_name=None) -> List[str]`
 - `scan_and_load(dcc_name=None, extra_paths=None) -> tuple[List[SkillMetadata], List[str]]` — **(skills, skipped_dirs)**
 - `scan_and_load_lenient(dcc_name=None, extra_paths=None) -> tuple[List[SkillMetadata], List[str]]` — same, skips errors
+- `scan_and_load_team(dcc_name=None, extra_paths=None) -> tuple[List[SkillMetadata], List[str]]`
+- `scan_and_load_team_lenient(dcc_name=None, extra_paths=None) -> tuple[List[SkillMetadata], List[str]]`
+- `scan_and_load_user(dcc_name=None, extra_paths=None) -> tuple[List[SkillMetadata], List[str]]`
+- `scan_and_load_user_lenient(dcc_name=None, extra_paths=None) -> tuple[List[SkillMetadata], List[str]]`
 - `resolve_dependencies(skills) -> List[SkillMetadata]`
 - `expand_transitive_dependencies(skills, skill_name) -> List[str]`
 - `validate_dependencies(skills) -> List[str]` — returns error messages
 - `get_skill_paths_from_env() -> List[str]` — reads `DCC_MCP_SKILL_PATHS` env var
 - `get_app_skill_paths_from_env(app_name: str) -> List[str]` — reads `DCC_MCP_{APP}_SKILL_PATHS` env var
+- `skill_error(message, error, prompt=None, possible_solutions=None, **context) -> dict` — zero-boilerplate error result for skill scripts
+- `skill_error_with_trace(message, error=None, prompt=None, **context) -> dict` — same as `skill_error` but includes traceback
+- `skill_warning(message, prompt=None, **context) -> dict` — warning-level result
+- `skill_exception(message, exc_info=None, prompt=None, **context) -> dict` — exception-style result
+- `run_main(skill_dir, params=None) -> dict` — convenience entry point for standalone skill script execution
+- `SkillFeedback` — feedback data model
+- `get_skill_feedback(skill_name) -> List[SkillFeedback]`
+- `record_skill_feedback(skill_name, feedback)`
+- `SkillVersionEntry`, `SkillVersionManifest`
+- `get_skill_version_manifest(skill_dir) -> SkillVersionManifest`
 
 **SkillCatalog** — progressive skill loading with thread-safe state:
 - `SkillCatalog(registry)` — construct with a `ToolRegistry`
@@ -211,6 +232,8 @@ tools:
 ### MCP Protocol Types (`dcc_mcp_core`)
 
 - `ToolDefinition(name, description, input_schema, output_schema=None, annotations=None)`
+- `ToolDeclaration(name, description, input_schema, annotations=None)` — lightweight tool declaration without output schema
+- `ToolSpec(name, description, input_schema, output_schema=None, annotations=None)` — full tool specification for registry use
 - `ToolAnnotations(title=None, read_only_hint=None, destructive_hint=None, idempotent_hint=None, open_world_hint=None, deferred_hint=None)`
 - `ResourceAnnotations(audience=None, priority=None)`
 - `ResourceDefinition(uri, name, description, mime_type="text/plain", annotations=None)`
@@ -322,6 +345,10 @@ tools:
 - `register_diagnostic_handlers(...)` — the IPC-path equivalent (used by `DccServerBase.start()`)
 - Bundled `dcc-diagnostics` skill's `screenshot.py` tries `DCC_MCP_OWNER_IPC` → `channel.call("take_screenshot")` first and falls back to `Capturer.new_auto()` when no owner IPC is set
 
+### Output Capture (`dcc_mcp_core`)
+
+- `OutputCapture` — capture DCC stdout/stderr/script-editor output as `output://` MCP resource (issue #461)
+
 ### USD (`dcc_mcp_core`)
 
 - `UsdStage`, `UsdPrim`, `SdfPath`, `VtValue`, `SceneInfo`, `SceneStatistics`
@@ -341,6 +368,14 @@ tools:
 - `BridgeContext` — bridge context with name, description, metadata
 - `register_bridge(name, ctx)` — register a named bridge
 - `get_bridge_context(name) -> Optional[BridgeContext]` — retrieve bridge by name
+
+### Artefacts (`dcc_mcp_core`)
+
+- `FileRef(path, mime_type=None, name=None, metadata=None)` — reference to a file for cross-tool hand-off
+- `artefact_put_file(path, name=None, metadata=None) -> FileRef`
+- `artefact_put_bytes(data, name, mime_type="application/octet-stream", metadata=None) -> FileRef`
+- `artefact_get_bytes(ref) -> bytes`
+- `artefact_list() -> list[FileRef]`
 
 ### DccBridge — WebSocket Bridge (`dcc_mcp_core.bridge`)
 
@@ -481,6 +516,22 @@ tools:
 - `get_config_dir()`, `get_data_dir()`, `get_log_dir()`, `get_platform_dir(dir_type)`
 - `get_tools_dir(dcc_name)`, `get_skills_dir(dcc_name=None)`
 - `get_skill_paths_from_env() -> List[str]` — reads `DCC_MCP_SKILL_PATHS`
+- `get_team_skill_paths_from_env() -> List[str]` — reads `DCC_MCP_TEAM_SKILL_PATHS`
+- `get_user_skill_paths_from_env() -> List[str]` — reads `DCC_MCP_USER_SKILL_PATHS`
+- `get_app_team_skill_paths_from_env(app_name) -> List[str]` — reads `DCC_MCP_{APP}_TEAM_SKILL_PATHS`
+- `get_app_user_skill_paths_from_env(app_name) -> List[str]` — reads `DCC_MCP_{APP}_USER_SKILL_PATHS`
+- `get_team_skills_dir() -> str` — team-level skills directory
+- `get_user_skills_dir() -> str` — user-level skills directory
+- `get_bundled_skills_dir() -> str` — bundled skills directory shipped with the package
+- `get_bundled_skill_paths() -> List[str]` — list containing the bundled skills directory when it exists
+- `copy_skill_to_team_dir(skill_dir) -> str` — copy a skill to the team directory
+- `copy_skill_to_user_dir(skill_dir) -> str` — copy a skill to the user directory
+
+### Scheduler (`dcc_mcp_core`)
+
+- `ScheduleSpec` — scheduling specification for recurring or delayed tasks
+- `TriggerSpec` — trigger definition for event-driven scheduling
+- `parse_schedules_yaml(path) -> List[ScheduleSpec]` — load and parse schedule definitions from YAML
 
 ### File Logging (`dcc_mcp_core`)
 
@@ -495,7 +546,7 @@ tools:
 - `APP_NAME = "dcc-mcp"`, `APP_AUTHOR = "dcc-mcp"`
 - `DEFAULT_DCC = "python"`, `DEFAULT_LOG_LEVEL = "DEBUG"`, `DEFAULT_MIME_TYPE = "text/plain"`, `DEFAULT_VERSION = "1.0.0"`
 - `SKILL_METADATA_FILE = "SKILL.md"`, `SKILL_SCRIPTS_DIR = "scripts"`, `SKILL_METADATA_DIR = "metadata"`
-- `ENV_SKILL_PATHS = "DCC_MCP_SKILL_PATHS"`, `ENV_LOG_LEVEL = "MCP_LOG_LEVEL"
+- `ENV_SKILL_PATHS = "DCC_MCP_SKILL_PATHS"`, `ENV_LOG_LEVEL = "MCP_LOG_LEVEL"`, `ENV_DISABLE_ACCUMULATED_SKILLS` — set to "1" to disable accumulated/evolved skills discovery, `ENV_TEAM_SKILL_PATHS` / `ENV_USER_SKILL_PATHS` — team-level and user-level skill path env vars
 - `TOOL_NAME_RE` / `ACTION_ID_RE` — SEP-986 regex patterns for tool names and action IDs
 - `MAX_TOOL_NAME_LEN = 48` — maximum tool name length
 
@@ -647,6 +698,10 @@ cimd = oauth.to_cimd_document(redirect_uri="http://localhost:8765/oauth/callback
 
 # Manual validation inside a pure-Python handler
 ok = validate_bearer_token(request_headers, expected_token=os.environ["DCC_MCP_API_KEY"])
+
+# HMAC utilities for webhook / hub signature verification
+signature = hmac_sha256_hex(secret, payload)
+ok = verify_hub_signature_256(secret, payload, signature)
 ```
 
 ### Batch Dispatch (`#406`, `dcc_mcp_core.batch`)


### PR DESCRIPTION
## Summary

Sync AI agent-facing documentation with the latest public API surface:

- **llms.txt / llms-full.txt**: Add 40+ missing symbols including:
  - `scan_and_load_team` / `scan_and_load_user` variants
  - `FileRef` + `artefact_*` helpers (issue #349)
  - `OutputCapture` (issue #461)
  - `skill_error_with_trace` / `skill_warning` / `skill_exception`
  - `SkillFeedback` / `SkillVersionEntry` / `SkillVersionManifest`
  - Team / user / bundled skill path helpers
  - `ScheduleSpec` / `TriggerSpec` / `parse_schedules_yaml`
  - `ToolDeclaration` / `ToolSpec`
  - HMAC utilities (`hmac_sha256_hex`, `verify_hub_signature_256`)
  - `run_main`

- **AGENTS.md**: Expand decision table with 6 new capability rows.

- **CODEBUDDY.md**: Update skill workflows with `search-hint`, on-demand discovery, bundled skills, authoring templates, and DCC integration architectures. Fix `vx just stubgen` step for adding new symbols.

## Test plan

- [x] Verified all missing `__all__` symbols now appear in `llms.txt`
- [x] Verified all missing `__all__` symbols now appear in `llms-full.txt`
- [x] Pre-commit hooks passed locally