### PR TITLE
refactor(dcc-mcp-http): introduce NotificationBuilder for JSON-RPC envelopes

### DIFF
--- a/crates/dcc-mcp-http/src/gateway/backend_client.rs
+++ b/crates/dcc-mcp-http/src/gateway/backend_client.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 
 use serde_json::{Value, json};
 
-use crate::protocol::{JsonRpcResponse, McpTool};
+use crate::protocol::{JsonRpcRequestBuilder, JsonRpcResponse, McpTool};
 
 /// Call a JSON-RPC method on a backend `/mcp` endpoint.
 ///
@@ -33,20 +33,9 @@ pub async fn call_backend(
     timeout: Duration,
 ) -> Result<Value, String> {
     let id = request_id.unwrap_or_else(uuid_like_id);
-    let req_body = if let Some(p) = params {
-        json!({
-            "jsonrpc": "2.0",
-            "id": id,
-            "method": method,
-            "params": p,
-        })
-    } else {
-        json!({
-            "jsonrpc": "2.0",
-            "id": id,
-            "method": method,
-        })
-    };
+    let req_body = JsonRpcRequestBuilder::new(id, method)
+        .with_optional_params(params)
+        .to_value();
 
     let resp = client
         .post(mcp_url)

--- a/crates/dcc-mcp-http/src/handlers/lazy_actions.rs
+++ b/crates/dcc-mcp-http/src/handlers/lazy_actions.rs
@@ -206,12 +206,9 @@ pub fn resolve_action_by_id(
 
 /// Send a `notifications/tools/list_changed` event to a session's SSE subscribers.
 pub fn notify_tools_list_changed(sessions: &SessionManager, session_id: &str) {
-    let notification = json!({
-        "jsonrpc": "2.0",
-        "method": "notifications/tools/list_changed",
-        "params": {}
-    });
-    let event = format_sse_event(&notification, None);
+    let event = NotificationBuilder::new("notifications/tools/list_changed")
+        .with_empty_params()
+        .as_sse_event();
     sessions.push_event(session_id, event);
     tracing::debug!("Sent tools/list_changed notification to session {session_id}");
 }
@@ -224,12 +221,9 @@ pub fn notify_tools_changed(
     removed: &[String],
 ) {
     if sessions.supports_delta_tools(session_id) {
-        let notification = json!({
-            "jsonrpc": "2.0",
-            "method": DELTA_TOOLS_METHOD,
-            "params": { "added": added, "removed": removed }
-        });
-        let event = format_sse_event(&notification, None);
+        let event = NotificationBuilder::new(DELTA_TOOLS_METHOD)
+            .with_params(json!({ "added": added, "removed": removed }))
+            .as_sse_event();
         sessions.push_event(session_id, event);
         tracing::debug!(
             session_id,
@@ -256,16 +250,13 @@ pub fn notify_message(sessions: &SessionManager, session_id: &str, entry: Sessio
         return;
     }
 
-    let notification = json!({
-        "jsonrpc": "2.0",
-        "method": "notifications/message",
-        "params": {
+    let event = NotificationBuilder::new("notifications/message")
+        .with_params(json!({
             "level": emit_level.as_str(),
             "logger": logger.clone(),
             "data": data,
-        },
-    });
-    let event = format_sse_event(&notification, None);
+        }))
+        .as_sse_event();
     sessions.push_event(session_id, event);
     tracing::debug!(
         session_id,
@@ -335,13 +326,9 @@ pub async fn refresh_roots_cache_for_session(
     sessions: &SessionManager,
     session_id: &str,
 ) -> Vec<crate::protocol::ClientRoot> {
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": format!("roots-refresh-{session_id}"),
-        "method": "roots/list",
-        "params": {}
-    });
-    let event = format_sse_event(&request, None);
+    let event = JsonRpcRequestBuilder::new(format!("roots-refresh-{session_id}"), "roots/list")
+        .with_params(json!({}))
+        .as_sse_event();
     sessions.push_event(session_id, event);
 
     // Current low-risk phase: opportunistically keep existing cache.

--- a/crates/dcc-mcp-http/src/handlers/mod.rs
+++ b/crates/dcc-mcp-http/src/handlers/mod.rs
@@ -21,9 +21,9 @@ pub(crate) use crate::{
     protocol::{
         self, CallToolParams, CallToolResult, DELTA_TOOLS_METHOD, ElicitationCreateParams,
         ElicitationCreateResult, GetPromptParams, JsonRpcBatch, JsonRpcMessage, JsonRpcRequest,
-        JsonRpcResponse, ListPromptsResult, ListResourcesResult, LoggingSetLevelParams, McpTool,
-        McpToolAnnotations, RESOURCE_NOT_ENABLED_ERROR, ReadResourceParams,
-        SubscribeResourceParams, format_sse_event,
+        JsonRpcRequestBuilder, JsonRpcResponse, ListPromptsResult, ListResourcesResult,
+        LoggingSetLevelParams, McpTool, McpToolAnnotations, NotificationBuilder,
+        RESOURCE_NOT_ENABLED_ERROR, ReadResourceParams, SubscribeResourceParams,
     },
     resources::ResourceError,
     session::{SessionLogLevel, SessionLogMessage, SessionManager},

--- a/crates/dcc-mcp-http/src/handlers/resources_prompts.rs
+++ b/crates/dcc-mcp-http/src/handlers/resources_prompts.rs
@@ -176,12 +176,9 @@ pub(crate) fn notify_prompts_list_changed_all(state: &AppState) {
     if !state.enable_prompts {
         return;
     }
-    let notification = json!({
-        "jsonrpc": "2.0",
-        "method": "notifications/prompts/list_changed",
-        "params": {}
-    });
-    let event = format_sse_event(&notification, None);
+    let event = NotificationBuilder::new("notifications/prompts/list_changed")
+        .with_empty_params()
+        .as_sse_event();
     for sid in state.sessions.all_ids() {
         state.sessions.push_event(&sid, event.clone());
     }
@@ -293,16 +290,13 @@ pub async fn handle_elicitation_create(
     let (tx, rx) = oneshot::channel::<ElicitationCreateResult>();
     state.pending_elicitations.insert(req_id.clone(), tx);
 
-    let notification = json!({
-        "jsonrpc": "2.0",
-        "method": "elicitation/create",
-        "params": {
+    let event = NotificationBuilder::new("elicitation/create")
+        .with_params(json!({
             "id": elicit_id,
             "message": params.message,
             "requestedSchema": params.requested_schema,
-        }
-    });
-    let event = format_sse_event(&notification, None);
+        }))
+        .as_sse_event();
     state.sessions.push_event(sid, event);
 
     let waited = tokio::time::timeout(ELICITATION_TIMEOUT, rx).await;

--- a/crates/dcc-mcp-http/src/notifications.rs
+++ b/crates/dcc-mcp-http/src/notifications.rs
@@ -27,7 +27,7 @@ use serde::Serialize;
 use serde_json::{Value, json};
 
 use crate::job::{JobEvent, JobStatus};
-use crate::protocol::format_sse_event;
+use crate::protocol::NotificationBuilder;
 use crate::session::SessionManager;
 
 // ── Workflow types ───────────────────────────────────────────────────────
@@ -183,26 +183,21 @@ impl JobNotifier {
         // ── Channel A: notifications/progress ────────────────────────────
         if let Some(token) = link.progress_token.as_ref() {
             let (progress, total, message) = progress_mapping(&event);
-            let notification = json!({
-                "jsonrpc": "2.0",
-                "method": "notifications/progress",
-                "params": {
+            let frame = NotificationBuilder::new("notifications/progress")
+                .with_params(json!({
                     "progressToken": token,
                     "progress": progress,
                     "total": total,
                     "message": message,
-                },
-            });
-            self.sessions
-                .push_event(&link.session_id, format_sse_event(&notification, None));
+                }))
+                .as_sse_event();
+            self.sessions.push_event(&link.session_id, frame);
         }
 
         // ── Channel B: notifications/$/dcc.jobUpdated ────────────────────
         if self.job_updates_enabled && self.job_sessions.contains_key(&link.session_id) {
-            let notification = json!({
-                "jsonrpc": "2.0",
-                "method": "notifications/$/dcc.jobUpdated",
-                "params": {
+            let frame = NotificationBuilder::new("notifications/$/dcc.jobUpdated")
+                .with_params(json!({
                     "job_id": event.id,
                     "parent_job_id": Value::Null,
                     "tool": event.tool_name,
@@ -210,10 +205,9 @@ impl JobNotifier {
                     "started_at": started_at(&event),
                     "completed_at": completed_at(&event),
                     "error": event.error,
-                },
-            });
-            self.sessions
-                .push_event(&link.session_id, format_sse_event(&notification, None));
+                }))
+                .as_sse_event();
+            self.sessions.push_event(&link.session_id, frame);
         }
 
         if event.status.is_terminal() {
@@ -227,24 +221,12 @@ impl JobNotifier {
     /// ships the emit API and routing; the executor will invoke this once
     /// step execution is implemented.
     pub fn emit_workflow_update(&self, upd: WorkflowUpdate) {
-        let notification = json!({
-            "jsonrpc": "2.0",
-            "method": "notifications/$/dcc.workflowUpdated",
-            "params": {
-                "workflow_id": upd.workflow_id.to_string(),
-                "job_id": upd.job_id.to_string(),
-                "status": upd.status.as_str(),
-                "current_step_id": upd.current_step_id,
-                "progress": {
-                    "completed_steps": upd.progress.completed_steps,
-                    "total_steps": upd.progress.total_steps,
-                },
-            },
-        });
         if !self.job_updates_enabled {
             return;
         }
-        let event = format_sse_event(&notification, None);
+        let event = NotificationBuilder::new("notifications/$/dcc.workflowUpdated")
+            .with_params(workflow_update_params(&upd))
+            .as_sse_event();
         for kv in self.workflow_sessions.iter() {
             self.sessions.push_event(kv.key(), event.clone());
         }
@@ -255,21 +237,23 @@ impl JobNotifier {
     /// Useful for tests that want to assert the payload shape without
     /// standing up a full session.
     pub fn workflow_update_payload(upd: &WorkflowUpdate) -> Value {
-        json!({
-            "jsonrpc": "2.0",
-            "method": "notifications/$/dcc.workflowUpdated",
-            "params": {
-                "workflow_id": upd.workflow_id.to_string(),
-                "job_id": upd.job_id.to_string(),
-                "status": upd.status.as_str(),
-                "current_step_id": upd.current_step_id,
-                "progress": {
-                    "completed_steps": upd.progress.completed_steps,
-                    "total_steps": upd.progress.total_steps,
-                },
-            },
-        })
+        NotificationBuilder::new("notifications/$/dcc.workflowUpdated")
+            .with_params(workflow_update_params(upd))
+            .to_value()
     }
+}
+
+fn workflow_update_params(upd: &WorkflowUpdate) -> Value {
+    json!({
+        "workflow_id": upd.workflow_id.to_string(),
+        "job_id": upd.job_id.to_string(),
+        "status": upd.status.as_str(),
+        "current_step_id": upd.current_step_id,
+        "progress": {
+            "completed_steps": upd.progress.completed_steps,
+            "total_steps": upd.progress.total_steps,
+        },
+    })
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────

--- a/crates/dcc-mcp-http/src/protocol/mod.rs
+++ b/crates/dcc-mcp-http/src/protocol/mod.rs
@@ -18,9 +18,11 @@
 //! | `protocol_resources.rs` | `McpResource` / `ListResourcesResult` / `ReadResource*` / `ResourceContents` / `SubscribeResourceParams` + `RESOURCE_NOT_ENABLED_ERROR` |
 //! | `protocol_prompts.rs`   | `McpPrompt` / `McpPromptArgument` / `ListPromptsResult` / `GetPrompt*` / `McpPromptMessage` / `McpPromptContent` |
 //! | `protocol_sse.rs`       | `format_sse_event` + `encode_cursor` / `decode_cursor` pagination helpers |
+//! | `notification_builder.rs` | `NotificationBuilder` / `JsonRpcRequestBuilder` — fluent envelope construction (#484) |
 
 mod jsonrpc;
 mod lifecycle;
+mod notification_builder;
 mod prompts;
 mod resources;
 mod sse;
@@ -36,6 +38,7 @@ pub use lifecycle::{
     LoggingSetLevelParams, PromptsCapability, ResourcesCapability, RootsListResult,
     ServerCapabilities, ServerInfo, ToolsCapability,
 };
+pub use notification_builder::{JsonRpcRequestBuilder, NotificationBuilder};
 pub use prompts::{
     GetPromptParams, GetPromptResult, ListPromptsResult, McpPrompt, McpPromptArgument,
     McpPromptContent, McpPromptMessage,

--- a/crates/dcc-mcp-http/src/protocol/notification_builder.rs
+++ b/crates/dcc-mcp-http/src/protocol/notification_builder.rs
@@ -1,0 +1,147 @@
+//! Builders for JSON-RPC 2.0 notification and request envelopes (#484).
+//!
+//! Six+ call sites previously hand-rolled
+//! `json!({"jsonrpc":"2.0","method":"…","params":{…}})` envelopes. Drift in
+//! that shape (a new top-level field, a protocol version bump, …) used to
+//! require touching every site.
+//!
+//! These builders consolidate envelope construction so the *only* place
+//! that knows the wire shape is this module:
+//!
+//! ```ignore
+//! use crate::protocol::NotificationBuilder;
+//!
+//! let sse_frame = NotificationBuilder::new("notifications/tools/list_changed")
+//!     .with_params(serde_json::json!({}))
+//!     .as_sse_event();
+//! ```
+//!
+//! `JsonRpcRequestBuilder` is the symmetric helper used by the gateway
+//! backend client to build *requests* (with an `id`) instead of fire-and-
+//! forget notifications.
+
+use serde_json::Value;
+
+use super::JsonRpcNotification;
+use super::format_sse_event;
+
+/// Fluent builder for a [`JsonRpcNotification`] envelope.
+///
+/// Use [`Self::build`] to obtain the typed notification, [`Self::to_value`]
+/// to obtain the raw JSON value, or [`Self::as_sse_event`] to obtain a
+/// fully-formatted SSE frame ready to push onto a session's event stream.
+#[derive(Debug, Clone)]
+pub struct NotificationBuilder {
+    method: String,
+    params: Option<Value>,
+}
+
+impl NotificationBuilder {
+    /// Create a new notification with the given JSON-RPC `method`.
+    pub fn new(method: impl Into<String>) -> Self {
+        Self {
+            method: method.into(),
+            params: None,
+        }
+    }
+
+    /// Attach a `params` payload to the notification.
+    #[must_use]
+    pub fn with_params(mut self, params: Value) -> Self {
+        self.params = Some(params);
+        self
+    }
+
+    /// Attach an empty (`{}`) `params` object.
+    ///
+    /// Required by MCP for `notifications/{tools,prompts,resources}/list_changed`
+    /// which the spec defines with an empty params object rather than no
+    /// `params` field at all.
+    #[must_use]
+    pub fn with_empty_params(mut self) -> Self {
+        self.params = Some(Value::Object(serde_json::Map::new()));
+        self
+    }
+
+    /// Consume the builder and return a typed [`JsonRpcNotification`].
+    pub fn build(self) -> JsonRpcNotification {
+        JsonRpcNotification {
+            jsonrpc: "2.0".to_string(),
+            method: self.method,
+            params: self.params,
+        }
+    }
+
+    /// Consume the builder and return the raw JSON value of the envelope.
+    ///
+    /// Equivalent to `serde_json::to_value(&self.build()).unwrap()`, kept
+    /// as a dedicated helper because most call sites only need the value
+    /// to feed into [`format_sse_event`].
+    pub fn to_value(self) -> Value {
+        serde_json::to_value(self.build()).unwrap_or(Value::Null)
+    }
+
+    /// Consume the builder and return an SSE frame string ready to push
+    /// onto a session's event stream.
+    ///
+    /// The SSE event has no `id:` line — channel-specific event ids are
+    /// not used by any current notification site.
+    pub fn as_sse_event(self) -> String {
+        format_sse_event(&self.build(), None)
+    }
+}
+
+/// Fluent builder for a JSON-RPC 2.0 *request* envelope (with `id`).
+///
+/// Used by the gateway backend client to construct outgoing requests
+/// without re-spelling the envelope shape inline.
+#[derive(Debug, Clone)]
+pub struct JsonRpcRequestBuilder {
+    id: Value,
+    method: String,
+    params: Option<Value>,
+}
+
+impl JsonRpcRequestBuilder {
+    /// Create a new request with the given `id` and JSON-RPC `method`.
+    pub fn new(id: impl Into<Value>, method: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            method: method.into(),
+            params: None,
+        }
+    }
+
+    /// Attach a `params` payload to the request.
+    #[must_use]
+    pub fn with_params(mut self, params: Value) -> Self {
+        self.params = Some(params);
+        self
+    }
+
+    /// Attach an *optional* `params` payload — convenience for callers
+    /// that already carry an `Option<Value>` and want to forward it.
+    #[must_use]
+    pub fn with_optional_params(mut self, params: Option<Value>) -> Self {
+        self.params = params;
+        self
+    }
+
+    /// Consume the builder and return the raw JSON value of the envelope.
+    pub fn to_value(self) -> Value {
+        let mut obj = serde_json::Map::with_capacity(4);
+        obj.insert("jsonrpc".to_string(), Value::String("2.0".to_string()));
+        obj.insert("id".to_string(), self.id);
+        obj.insert("method".to_string(), Value::String(self.method));
+        if let Some(p) = self.params {
+            obj.insert("params".to_string(), p);
+        }
+        Value::Object(obj)
+    }
+
+    /// Consume the builder and return an SSE frame string ready to push
+    /// onto a session's event stream.
+    pub fn as_sse_event(self) -> String {
+        format_sse_event(&self.to_value(), None)
+    }
+}


### PR DESCRIPTION
## Summary

Nine call sites across `dcc-mcp-http` hand-rolled `json!({"jsonrpc":"2.0", "method":"…", "params":"…"})` envelopes for SSE notifications, plus two more for JSON-RPC requests. Drift in that shape (a new top-level field, a protocol version bump, an `id` style change) used to require touching every site.

Introduce two fluent builders in `protocol/notification_builder.rs`:

- `NotificationBuilder` — for fire-and-forget notifications. Methods: `new(method)`, `with_params(value)`, `with_empty_params()`, `build()` → `JsonRpcNotification`, `to_value()` → raw `Value`, `as_sse_event()` → SSE frame string.
- `JsonRpcRequestBuilder` — symmetric helper for outgoing requests carrying an `id`. Used by the gateway backend client and the `roots/list` SSE re-fetch path.

Each call site shrinks from 6–10 lines of `json!` macro + `format_sse_event` to a 3–5 line builder chain. The only place that knows the wire shape is now the builder module.

## Migrated emitters

| File | Method |
| --- | --- |
| `notifications.rs` | `notifications/progress` |
| `notifications.rs` | `notifications/$/dcc.jobUpdated` |
| `notifications.rs` | `notifications/$/dcc.workflowUpdated` (×2, unified through `workflow_update_params` helper) |
| `handlers/lazy_actions.rs` | `notifications/tools/list_changed` |
| `handlers/lazy_actions.rs` | `DELTA_TOOLS_METHOD` |
| `handlers/lazy_actions.rs` | `notifications/message` |
| `handlers/lazy_actions.rs` | `roots/list` request (SSE) |
| `handlers/resources_prompts.rs` | `notifications/prompts/list_changed` |
| `handlers/resources_prompts.rs` | `elicitation/create` |
| `gateway/backend_client.rs` | generic backend JSON-RPC request |

## Acceptance criteria

- [x] New `protocol/notification_builder.rs` module with `NotificationBuilder` + `JsonRpcRequestBuilder`
- [x] All 10 hand-rolled `json!` envelope sites migrated
- [x] Public API surface unchanged (`emit_workflow_update`, `notify_tools_changed`, `notify_message`, `call_backend`, etc.)
- [x] All existing tests pass without modification (283 lib + 37 + 7 integration = 327 in `dcc-mcp-http`)
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean

Closes #484