### PR TITLE
refactor(server): decompose DccServerBase into focused collaborators

### DIFF
--- a/python/dcc_mcp_core/_server/__init__.py
+++ b/python/dcc_mcp_core/_server/__init__.py
@@ -1,0 +1,21 @@
+"""Internal collaborator classes that decompose :class:`DccServerBase` (#486).
+
+These helpers split the responsibilities of the historical 912-line god
+object into focused units that can be tested independently. They are
+underscore-prefixed because they are an implementation detail; the public
+contract remains :class:`dcc_mcp_core.server_base.DccServerBase`.
+"""
+
+from dcc_mcp_core._server.observability import FileLoggingManager
+from dcc_mcp_core._server.observability import JobPersistenceManager
+from dcc_mcp_core._server.observability import TelemetryManager
+from dcc_mcp_core._server.skill_query import SkillQueryClient
+from dcc_mcp_core._server.window_resolver import WindowResolver
+
+__all__ = [
+    "FileLoggingManager",
+    "JobPersistenceManager",
+    "SkillQueryClient",
+    "TelemetryManager",
+    "WindowResolver",
+]

--- a/python/dcc_mcp_core/_server/observability.py
+++ b/python/dcc_mcp_core/_server/observability.py
@@ -1,0 +1,162 @@
+"""Observability collaborators for :class:`DccServerBase` (#486).
+
+Three small classes that own one observability responsibility each:
+
+- :class:`FileLoggingManager` — rolling file logging via
+  ``init_file_logging`` (``DCC_MCP_DISABLE_FILE_LOGGING`` env override).
+- :class:`JobPersistenceManager` — SQLite job-history database wired into
+  ``McpHttpConfig.job_storage_path``; probes for the ``job-persist-sqlite``
+  feature so the server can fall back gracefully when the wheel was built
+  without it (``DCC_MCP_DISABLE_JOB_PERSISTENCE`` env override).
+- :class:`TelemetryManager` — in-process metrics initialisation via
+  ``TelemetryConfig`` (``DCC_MCP_DISABLE_TELEMETRY`` env override).
+
+All three are intentionally non-fatal: any internal failure is logged and
+swallowed so the server can still come up without observability.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class FileLoggingManager:
+    """Owns rolling-file logging initialisation for one DCC server."""
+
+    def __init__(self, dcc_name: str, *, enabled: bool = True) -> None:
+        self._dcc_name = dcc_name
+        self._enabled = enabled and os.environ.get("DCC_MCP_DISABLE_FILE_LOGGING", "0") != "1"
+        self._log_dir: str = ""
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @property
+    def log_dir(self) -> str:
+        return self._log_dir
+
+    def init(self) -> str:
+        """Initialise rolling file logging; return the resolved log directory."""
+        if not self._enabled:
+            return ""
+        try:
+            from dcc_mcp_core import FileLoggingConfig
+            from dcc_mcp_core import get_log_dir
+            from dcc_mcp_core import init_file_logging
+
+            log_dir = os.environ.get("DCC_MCP_LOG_DIR") or get_log_dir()
+            pid = os.getpid()
+            cfg = FileLoggingConfig(
+                directory=log_dir,
+                file_name_prefix=f"dcc-mcp-{self._dcc_name}.{pid}",
+                max_files=14,
+                max_size_bytes=20 * 1024 * 1024,
+                rotation="both",
+            )
+            self._log_dir = init_file_logging(cfg)
+            logger.info(
+                "[%s] File logging enabled → %s/dcc-mcp-%s.%s.*.log",
+                self._dcc_name,
+                self._log_dir,
+                self._dcc_name,
+                pid,
+            )
+            return self._log_dir
+        except Exception as exc:
+            logger.warning("[%s] Could not enable file logging: %s", self._dcc_name, exc)
+            return ""
+
+
+class JobPersistenceManager:
+    """Wires a per-DCC SQLite job-history database into ``McpHttpConfig``."""
+
+    def __init__(self, dcc_name: str, *, enabled: bool = True, log_dir: str = "") -> None:
+        self._dcc_name = dcc_name
+        self._enabled = enabled and os.environ.get("DCC_MCP_DISABLE_JOB_PERSISTENCE", "0") != "1"
+        self._log_dir = log_dir
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def init(self, config: Any) -> None:
+        """Probe for the ``job-persist-sqlite`` feature and wire ``config``."""
+        if not self._enabled:
+            return
+        db_path = self._resolve_db_path()
+        if db_path is None:
+            return
+        try:
+            from dcc_mcp_core import McpHttpConfig
+            from dcc_mcp_core import create_skill_server
+
+            probe_cfg = McpHttpConfig(port=0, server_name="probe")
+            probe_cfg.job_storage_path = db_path
+            probe_srv = create_skill_server(self._dcc_name, probe_cfg)
+            probe_handle = probe_srv.start()
+            probe_handle.shutdown()
+            config.job_storage_path = db_path
+            logger.info("[%s] Job persistence enabled → %s", self._dcc_name, db_path)
+        except RuntimeError as exc:
+            err_msg = str(exc)
+            if "job-persist-sqlite" in err_msg and "job_storage_path" in err_msg:
+                logger.warning(
+                    "[%s] job-persist-sqlite feature not compiled in; job persistence disabled (in-memory fallback)",
+                    self._dcc_name,
+                )
+            else:
+                logger.debug("[%s] Job persistence probe failed: %s", self._dcc_name, exc)
+        except Exception as exc:
+            logger.debug("[%s] Job persistence probe failed: %s", self._dcc_name, exc)
+
+    def _resolve_db_path(self) -> str | None:
+        try:
+            from dcc_mcp_core import get_log_dir
+
+            db_dir = self._log_dir or os.environ.get("DCC_MCP_LOG_DIR") or get_log_dir()
+            return str(Path(db_dir) / f"dcc-mcp-{self._dcc_name}-jobs.db")
+        except Exception as exc:
+            logger.debug("[%s] Could not resolve job persistence path: %s", self._dcc_name, exc)
+            return None
+
+
+class TelemetryManager:
+    """Owns in-process metrics initialisation via ``TelemetryConfig``."""
+
+    def __init__(self, dcc_name: str, dcc_pid: int, *, enabled: bool = True) -> None:
+        self._dcc_name = dcc_name
+        self._dcc_pid = dcc_pid
+        self._enabled = enabled and os.environ.get("DCC_MCP_DISABLE_TELEMETRY", "0") != "1"
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def init(self) -> None:
+        """Initialise telemetry once; safe to call multiple times."""
+        if not self._enabled:
+            return
+        try:
+            from dcc_mcp_core import TelemetryConfig
+            from dcc_mcp_core import is_telemetry_initialized
+
+            if is_telemetry_initialized():
+                return
+            (
+                TelemetryConfig(f"dcc-mcp-{self._dcc_name}")
+                .with_noop_exporter()
+                .set_enable_metrics(True)
+                .set_enable_tracing(False)
+                .with_attribute("dcc.name", self._dcc_name)
+                .with_attribute("dcc.pid", str(self._dcc_pid))
+                .init()
+            )
+            logger.info("[%s] In-process telemetry (metrics) enabled", self._dcc_name)
+        except Exception as exc:
+            logger.debug("[%s] Could not enable telemetry: %s", self._dcc_name, exc)

--- a/python/dcc_mcp_core/_server/skill_query.py
+++ b/python/dcc_mcp_core/_server/skill_query.py
@@ -1,0 +1,145 @@
+"""Skill query / management collaborator for :class:`DccServerBase` (#486).
+
+Bundles the 11 read-mostly methods that were previously inline on
+``DccServerBase``: ``list_actions``, ``list_skills``, ``search_skills``,
+``load_skill``, ``unload_skill``, ``search_actions``, ``get_skill_categories``,
+``get_skill_tags``, ``unregister_skill``, ``is_skill_loaded``,
+``get_skill_info``.
+
+All methods preserve the original tolerant-of-failure semantics: any
+underlying exception is logged at DEBUG level and a sensible empty value
+is returned. ``DccServerBase`` keeps the existing public methods and
+delegates straight through to this client.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class SkillQueryClient:
+    """Thin façade over the inner ``McpHttpServer`` and its ``ToolRegistry``."""
+
+    def __init__(self, server: Any, dcc_name: str) -> None:
+        self._server = server
+        self._dcc_name = dcc_name
+
+    @property
+    def registry(self) -> Any | None:
+        """The underlying ``ToolRegistry``, or ``None`` if unavailable."""
+        try:
+            return self._server.registry
+        except Exception:
+            return None
+
+    def list_actions(self, dcc_name: str | None = None) -> list[Any]:
+        registry = self.registry
+        if registry is None:
+            return []
+        effective_dcc = dcc_name if dcc_name is not None else self._dcc_name
+        try:
+            return list(registry.list_actions(dcc_name=effective_dcc))
+        except Exception as exc:
+            logger.debug("[%s] list_actions failed: %s", self._dcc_name, exc)
+            return []
+
+    def list_skills(self) -> list[Any]:
+        try:
+            return list(self._server.list_skills())
+        except Exception as exc:
+            logger.debug("[%s] list_skills failed: %s", self._dcc_name, exc)
+            return []
+
+    def search_skills(
+        self,
+        query: str | None = None,
+        tags: list[str] | None = None,
+        dcc: str | None = None,
+        scope: str | None = None,
+        limit: int | None = None,
+    ) -> list[Any]:
+        try:
+            return list(self._server.search_skills(query=query, tags=tags or [], dcc=dcc, scope=scope, limit=limit))
+        except Exception as exc:
+            logger.debug("[%s] search_skills failed: %s", self._dcc_name, exc)
+            return []
+
+    def load_skill(self, name: str) -> bool:
+        try:
+            self._server.load_skill(name)
+            return True
+        except Exception as exc:
+            logger.debug("[%s] load_skill(%r) failed: %s", self._dcc_name, name, exc)
+            return False
+
+    def unload_skill(self, name: str) -> bool:
+        try:
+            self._server.unload_skill(name)
+            return True
+        except Exception as exc:
+            logger.debug("[%s] unload_skill(%r) failed: %s", self._dcc_name, name, exc)
+            return False
+
+    def search_actions(
+        self,
+        category: str | None = None,
+        tags: list[str] | None = None,
+        dcc_name: str | None = None,
+    ) -> list[Any]:
+        registry = self.registry
+        if registry is None:
+            return []
+        effective_dcc = dcc_name if dcc_name is not None else self._dcc_name
+        try:
+            return list(registry.search_actions(category=category, tags=tags or [], dcc_name=effective_dcc))
+        except Exception as exc:
+            logger.debug("[%s] search_actions failed: %s", self._dcc_name, exc)
+            return []
+
+    def get_skill_categories(self) -> list[str]:
+        registry = self.registry
+        if registry is None:
+            return []
+        try:
+            return list(registry.get_categories())
+        except Exception as exc:
+            logger.debug("[%s] get_categories failed: %s", self._dcc_name, exc)
+            return []
+
+    def get_skill_tags(self, dcc_name: str | None = None) -> list[str]:
+        registry = self.registry
+        if registry is None:
+            return []
+        effective_dcc = dcc_name if dcc_name is not None else self._dcc_name
+        try:
+            return list(registry.get_tags(dcc_name=effective_dcc))
+        except Exception as exc:
+            logger.debug("[%s] get_tags failed: %s", self._dcc_name, exc)
+            return []
+
+    def unregister_skill(self, name: str, dcc_name: str | None = None) -> None:
+        registry = self.registry
+        if registry is None:
+            logger.warning("[%s] Registry unavailable; cannot unregister %r", self._dcc_name, name)
+            return
+        try:
+            registry.unregister(name, dcc_name=dcc_name)
+        except Exception as exc:
+            logger.debug("[%s] unregister(%r) failed: %s", self._dcc_name, name, exc)
+
+    def is_skill_loaded(self, name: str) -> bool:
+        try:
+            return bool(self._server.is_loaded(name))
+        except Exception as exc:
+            logger.debug("[%s] is_loaded(%r) failed: %s", self._dcc_name, name, exc)
+            return False
+
+    def get_skill_info(self, name: str) -> Any | None:
+        try:
+            return self._server.get_skill_info(name)
+        except Exception as exc:
+            logger.debug("[%s] get_skill_info(%r) failed: %s", self._dcc_name, name, exc)
+            return None

--- a/python/dcc_mcp_core/_server/window_resolver.py
+++ b/python/dcc_mcp_core/_server/window_resolver.py
@@ -1,0 +1,75 @@
+"""DCC window-handle resolver collaborator for :class:`DccServerBase` (#486).
+
+Looks up the native window handle (HWND on Windows, XID on X11) for the
+DCC application that hosts this MCP server, in priority order:
+
+1. Explicit ``dcc_window_handle`` provided at construction time.
+2. Cached lookup from a previous successful resolution.
+3. PID-based lookup via :class:`WindowFinder` + ``CaptureTarget.process_id``.
+4. Window-title substring lookup via ``CaptureTarget.window_title``.
+5. ``None`` if everything fails.
+
+Any exception during lookup is swallowed and a DEBUG log is emitted: the
+diagnostics tools that consume the handle (screenshot capture, audit log)
+all gracefully fall back to a process-wide capture when the handle is
+``None``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class WindowResolver:
+    """Resolve and cache the DCC window handle on demand."""
+
+    def __init__(
+        self,
+        *,
+        dcc_name: str,
+        dcc_pid: int,
+        dcc_window_handle: int | None = None,
+        dcc_window_title: str | None = None,
+    ) -> None:
+        self._dcc_name = dcc_name
+        self._dcc_pid = dcc_pid
+        self._dcc_window_handle = dcc_window_handle
+        self._dcc_window_title = dcc_window_title
+        self._cached_hwnd: int | None = None
+
+    @property
+    def dcc_pid(self) -> int:
+        return self._dcc_pid
+
+    @property
+    def dcc_window_title(self) -> str | None:
+        return self._dcc_window_title
+
+    @property
+    def dcc_window_handle(self) -> int | None:
+        return self._dcc_window_handle
+
+    def resolve(self) -> int | None:
+        """Return the resolved DCC window handle, or ``None`` if unavailable."""
+        if self._dcc_window_handle is not None:
+            return self._dcc_window_handle
+        if self._cached_hwnd is not None:
+            return self._cached_hwnd
+        try:
+            from dcc_mcp_core import CaptureTarget
+            from dcc_mcp_core import WindowFinder
+
+            finder = WindowFinder()
+            info = None
+            if self._dcc_pid:
+                info = finder.find(CaptureTarget.process_id(self._dcc_pid))
+            if info is None and self._dcc_window_title:
+                info = finder.find(CaptureTarget.window_title(self._dcc_window_title))
+            if info is not None:
+                self._cached_hwnd = int(info.handle)
+            return self._cached_hwnd
+        except Exception as exc:
+            logger.debug("[%s] _resolve_window_handle failed: %s", self._dcc_name, exc)
+            return None

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -60,6 +60,11 @@ from typing import Any
 # get_bundled_skill_paths) are deferred inside methods to avoid a circular
 # import: __init__.py imports DccServerBase from this module, so this module
 # cannot import from dcc_mcp_core at module level.
+from dcc_mcp_core._server import FileLoggingManager
+from dcc_mcp_core._server import JobPersistenceManager
+from dcc_mcp_core._server import SkillQueryClient
+from dcc_mcp_core._server import TelemetryManager
+from dcc_mcp_core._server import WindowResolver
 from dcc_mcp_core.gateway_election import DccGatewayElection
 from dcc_mcp_core.hotreload import DccSkillHotReloader
 
@@ -146,7 +151,9 @@ class DccServerBase:
         self._handle: Any | None = None
         self._enable_gateway_failover = enable_gateway_failover
 
-        # Observability flags (env var can override at runtime)
+        # Observability flags (env var can override at runtime). These mirror
+        # the collaborators' `enabled` state so external consumers and tests
+        # can introspect / patch them directly.
         self._enable_file_logging: bool = (
             enable_file_logging and os.environ.get("DCC_MCP_DISABLE_FILE_LOGGING", "0") != "1"
         )
@@ -155,7 +162,8 @@ class DccServerBase:
         )
         self._enable_telemetry: bool = enable_telemetry and os.environ.get("DCC_MCP_DISABLE_TELEMETRY", "0") != "1"
 
-        # Instance-bound DCC diagnostic context
+        # Instance-bound DCC diagnostic context (kept as direct attributes
+        # for backward compatibility — WindowResolver wraps them below).
         self._dcc_pid: int = dcc_pid if dcc_pid is not None else os.getpid()
         self._dcc_window_title: str | None = dcc_window_title
         self._dcc_window_handle: int | None = dcc_window_handle
@@ -204,140 +212,78 @@ class DccServerBase:
         # Create the inner skill manager (registry + dispatcher + catalog)
         self._server: Any = create_skill_server(dcc_name, self._config)
 
+        # Composed collaborators (#486) — constructed eagerly here, but the
+        # `_skill_client` / `_window_resolver` properties below also fall
+        # back to lazy construction so test doubles built via
+        # ``object.__new__`` (which skips this ``__init__``) still work.
+        self._skill_client = SkillQueryClient(self._server, dcc_name)
+        self._window_resolver = WindowResolver(
+            dcc_name=dcc_name,
+            dcc_pid=self._dcc_pid,
+            dcc_window_handle=dcc_window_handle,
+            dcc_window_title=dcc_window_title,
+        )
+
         # Lazy-initialised helpers
         self._hot_reloader: Any | None = None
         self._gateway_election: Any | None = None
 
-    # ── observability helpers ─────────────────────────────────────────────────
+    def __getattr__(self, name: str) -> Any:
+        """Lazily reconstruct collaborators for instances built via ``object.__new__``.
+
+        Some test doubles bypass ``__init__`` and only set the legacy
+        attributes (``_server``, ``_dcc_name``, ``_dcc_pid`` …). When such
+        an instance accesses ``_skill_client`` or ``_window_resolver``, build
+        a fresh collaborator on demand from those attributes and cache it.
+        """
+        if name == "_skill_client":
+            client = SkillQueryClient(self.__dict__["_server"], self.__dict__["_dcc_name"])
+            self.__dict__[name] = client
+            return client
+        if name == "_window_resolver":
+            resolver = WindowResolver(
+                dcc_name=self.__dict__["_dcc_name"],
+                dcc_pid=self.__dict__.get("_dcc_pid", 0),
+                dcc_window_handle=self.__dict__.get("_dcc_window_handle"),
+                dcc_window_title=self.__dict__.get("_dcc_window_title"),
+            )
+            self.__dict__[name] = resolver
+            return resolver
+        raise AttributeError(name)
+
+    # ── observability helpers (delegated to collaborators, #486) ──────────────
 
     def _init_file_logging(self, dcc_name: str) -> str:
         """Initialise rolling file logging for this DCC server.
 
-        Returns the resolved log directory path (empty string on failure).
-        Failures are non-fatal: a ``logger.warning`` is emitted and the
-        server continues without file logging.
-
-        Log files are named ``dcc-mcp-<dcc_name>.<pid>.<YYYYMMDD>.log`` and live in:
-        1. ``DCC_MCP_LOG_DIR`` env var (if set)
-        2. ``<platform log dir>/dcc-mcp/`` (macOS: ``~/Library/Logs``,
-           Windows: ``%LOCALAPPDATA%``, Linux: ``~/.local/share``)
+        Delegates to :class:`FileLoggingManager`. Returns the resolved log
+        directory path (empty string on failure or when disabled). Failures
+        are non-fatal: the manager logs a warning and the server continues.
         """
-        if not self._enable_file_logging:
-            return ""
-        try:
-            from dcc_mcp_core import FileLoggingConfig
-            from dcc_mcp_core import get_log_dir
-            from dcc_mcp_core import init_file_logging
-
-            log_dir = os.environ.get("DCC_MCP_LOG_DIR") or get_log_dir()
-            # Include the PID in the prefix so multiple instances of the same
-            # DCC (e.g. two Maya sessions) write to distinct files and never
-            # interleave their log lines. Issue #402.
-            pid = os.getpid()
-            cfg = FileLoggingConfig(
-                directory=log_dir,
-                file_name_prefix=f"dcc-mcp-{dcc_name}.{pid}",
-                # Keep 14 daily files (two weeks of history)
-                max_files=14,
-                # 20 MiB per file — enough for a busy session without filling disks
-                max_size_bytes=20 * 1024 * 1024,
-                rotation="both",
-            )
-            resolved = init_file_logging(cfg)
-            logger.info(
-                "[%s] File logging enabled → %s/dcc-mcp-%s.%s.*.log",
-                dcc_name,
-                resolved,
-                dcc_name,
-                pid,
-            )
-            return resolved
-        except Exception as exc:
-            logger.warning("[%s] Could not enable file logging: %s", dcc_name, exc)
-            return ""
+        manager = FileLoggingManager(dcc_name, enabled=self._enable_file_logging)
+        return manager.init()
 
     def _init_job_persistence(self, dcc_name: str) -> None:
         """Wire a SQLite job-history database into ``McpHttpConfig``.
 
-        The database is placed alongside the log files so that a single
-        directory gives full post-mortem visibility.  Errors are non-fatal.
-
-        If the compiled extension lacks the ``job-persist-sqlite`` Cargo
-        feature, this method silently skips enabling persistence so the
-        server can fall back to the in-memory ``JobManager``.
+        Delegates to :class:`JobPersistenceManager`. The probe step detects
+        whether the ``job-persist-sqlite`` Cargo feature is compiled in and
+        falls back to the in-memory ``JobManager`` when it is not.
         """
-        if not self._enable_job_persistence:
-            return
-        db_path = None
-        try:
-            import os as _os
-
-            from dcc_mcp_core import get_log_dir
-
-            db_dir = self._log_dir or _os.environ.get("DCC_MCP_LOG_DIR") or get_log_dir()
-            db_path = str(Path(db_dir) / f"dcc-mcp-{dcc_name}-jobs.db")
-        except Exception as exc:
-            logger.debug("[%s] Could not resolve job persistence path: %s", dcc_name, exc)
-            return
-
-        # Probe whether the job-persist-sqlite feature is compiled in by
-        # starting a throw-away server with the same db path.  This avoids
-        # the heavy recovery dance (re-discover + re-load skills) that would
-        # otherwise be needed when the real server.start() fails mid-way.
-        try:
-            from dcc_mcp_core import McpHttpConfig
-            from dcc_mcp_core import create_skill_server
-
-            probe_cfg = McpHttpConfig(port=0, server_name="probe")
-            probe_cfg.job_storage_path = db_path
-            probe_srv = create_skill_server(dcc_name, probe_cfg)
-            probe_handle = probe_srv.start()
-            probe_handle.shutdown()
-            # Probe succeeded — feature is available.
-            self._config.job_storage_path = db_path
-            logger.info("[%s] Job persistence enabled → %s", dcc_name, db_path)
-        except RuntimeError as exc:
-            err_msg = str(exc)
-            if "job-persist-sqlite" in err_msg and "job_storage_path" in err_msg:
-                logger.warning(
-                    "[%s] job-persist-sqlite feature not compiled in; job persistence disabled (in-memory fallback)",
-                    dcc_name,
-                )
-            else:
-                # Some other RuntimeError during probe — be conservative
-                # and leave job_storage_path unset.
-                logger.debug("[%s] Job persistence probe failed: %s", dcc_name, exc)
-        except Exception as exc:
-            logger.debug("[%s] Job persistence probe failed: %s", dcc_name, exc)
+        manager = JobPersistenceManager(dcc_name, enabled=self._enable_job_persistence, log_dir=self._log_dir)
+        manager.init(self._config)
 
     def _init_telemetry(self) -> None:
         """Initialise in-process metrics so ``diagnostics__tool_metrics`` has data.
 
         Uses the noop exporter (no network traffic) — metrics stay in memory
         and are served exclusively through the ``diagnostics__tool_metrics``
-        MCP tool.  Call this once, just before ``server.start()``.
+        MCP tool. Call this once, just before ``server.start()``. Delegates
+        to :class:`TelemetryManager`.
         """
         if not self._enable_telemetry:
             return
-        try:
-            from dcc_mcp_core import TelemetryConfig
-            from dcc_mcp_core import is_telemetry_initialized
-
-            if is_telemetry_initialized():
-                return  # already set up (e.g. by the adapter)
-
-            (
-                TelemetryConfig(f"dcc-mcp-{self._dcc_name}")
-                .with_noop_exporter()
-                .set_enable_metrics(True)
-                .set_enable_tracing(False)  # tracing spans go to the log file instead
-                .with_attribute("dcc.name", self._dcc_name)
-                .with_attribute("dcc.pid", str(self._dcc_pid))
-                .init()
-            )
-            logger.info("[%s] In-process telemetry (metrics) enabled", self._dcc_name)
-        except Exception as exc:
-            logger.debug("[%s] Could not enable telemetry: %s", self._dcc_name, exc)
+        TelemetryManager(self._dcc_name, self._dcc_pid, enabled=True).init()
 
     # ── skill search path helpers ─────────────────────────────────────────────
 
@@ -504,39 +450,25 @@ class DccServerBase:
     def _resolve_window_handle(self) -> int | None:
         """Resolve the DCC window handle from the available context.
 
-        Priority: explicit ``dcc_window_handle`` → cached lookup → PID lookup
-        via :class:`WindowFinder` → title lookup → ``None``.
+        Delegates to :class:`WindowResolver` (#486). Priority: explicit
+        ``dcc_window_handle`` → cached lookup → PID lookup via
+        :class:`WindowFinder` → title lookup → ``None``.
         """
-        if self._dcc_window_handle is not None:
-            return self._dcc_window_handle
-        if self._cached_hwnd is not None:
-            return self._cached_hwnd
-        try:
-            from dcc_mcp_core import CaptureTarget
-            from dcc_mcp_core import WindowFinder
-
-            finder = WindowFinder()
-            info = None
-            if self._dcc_pid:
-                info = finder.find(CaptureTarget.process_id(self._dcc_pid))
-            if info is None and self._dcc_window_title:
-                info = finder.find(CaptureTarget.window_title(self._dcc_window_title))
-            if info is not None:
-                self._cached_hwnd = int(info.handle)
-            return self._cached_hwnd
-        except Exception as exc:
-            logger.debug("[%s] _resolve_window_handle failed: %s", self._dcc_name, exc)
-            return None
+        hwnd = self._window_resolver.resolve()
+        # Mirror the resolved handle back onto the instance so direct
+        # attribute reads (used by historical screenshot helpers) keep
+        # observing the cached value.
+        if hwnd is not None and self._cached_hwnd is None:
+            self._cached_hwnd = hwnd
+        return hwnd
 
     # ── skill query methods (generic — 100% identical across all DCCs) ────────
+    # Delegated to SkillQueryClient collaborator (#486).
 
     @property
     def registry(self) -> Any | None:
         """The underlying ``ToolRegistry``, or ``None`` if unavailable."""
-        try:
-            return self._server.registry
-        except Exception:
-            return None
+        return self._skill_client.registry
 
     def list_actions(self, dcc_name: str | None = None) -> list[Any]:
         """List all registered actions for this DCC.
@@ -548,15 +480,7 @@ class DccServerBase:
             List of ``ActionInfo`` objects.
 
         """
-        registry = self.registry
-        if registry is None:
-            return []
-        effective_dcc = dcc_name if dcc_name is not None else self._dcc_name
-        try:
-            return list(registry.list_actions(dcc_name=effective_dcc))
-        except Exception as exc:
-            logger.debug("[%s] list_actions failed: %s", self._dcc_name, exc)
-            return []
+        return self._skill_client.list_actions(dcc_name)
 
     def list_skills(self) -> list[Any]:
         """List all discovered skills (loaded and unloaded).
@@ -565,11 +489,7 @@ class DccServerBase:
             List of ``SkillSummary`` objects.
 
         """
-        try:
-            return list(self._server.list_skills())
-        except Exception as exc:
-            logger.debug("[%s] list_skills failed: %s", self._dcc_name, exc)
-            return []
+        return self._skill_client.list_skills()
 
     def search_skills(
         self,
@@ -579,58 +499,16 @@ class DccServerBase:
         scope: str | None = None,
         limit: int | None = None,
     ) -> list[Any]:
-        """Search for skills by query, tags, DCC, scope, and/or limit.
-
-        Args:
-            query: Search query string.
-            tags: Filter by tags.
-            dcc: Filter by DCC name.
-            scope: Filter by scope (``"repo"`` | ``"user"`` | ``"system"`` | ``"admin"``).
-            limit: Maximum number of results.
-
-        Returns:
-            List of ``SkillSummary`` objects.
-
-        """
-        try:
-            return list(self._server.search_skills(query=query, tags=tags or [], dcc=dcc, scope=scope, limit=limit))
-        except Exception as exc:
-            logger.debug("[%s] search_skills failed: %s", self._dcc_name, exc)
-            return []
+        """Search for skills by query, tags, DCC, scope, and/or limit."""
+        return self._skill_client.search_skills(query=query, tags=tags, dcc=dcc, scope=scope, limit=limit)
 
     def load_skill(self, name: str) -> bool:
-        """Load a skill by name.
-
-        Args:
-            name: Skill name as discovered (e.g. ``"maya-scene"``).
-
-        Returns:
-            ``True`` on success.
-
-        """
-        try:
-            self._server.load_skill(name)
-            return True
-        except Exception as exc:
-            logger.debug("[%s] load_skill(%r) failed: %s", self._dcc_name, name, exc)
-            return False
+        """Load a skill by name."""
+        return self._skill_client.load_skill(name)
 
     def unload_skill(self, name: str) -> bool:
-        """Unload a skill by name.
-
-        Args:
-            name: Skill name.
-
-        Returns:
-            ``True`` on success.
-
-        """
-        try:
-            self._server.unload_skill(name)
-            return True
-        except Exception as exc:
-            logger.debug("[%s] unload_skill(%r) failed: %s", self._dcc_name, name, exc)
-            return False
+        """Unload a skill by name."""
+        return self._skill_client.unload_skill(name)
 
     def search_actions(
         self,
@@ -642,110 +520,28 @@ class DccServerBase:
 
         Delegates to :meth:`ToolRegistry.search_actions` which filters by
         exact category match, all-tags-present, and optional DCC scope.
-
-        Args:
-            category: Exact category name to filter by (``None`` = no filter).
-            tags: All listed tags must be present on the action (empty = no filter).
-            dcc_name: Override the DCC filter.
-
-        Returns:
-            List of matching ``ActionInfo`` dicts.
-
         """
-        registry = self.registry
-        if registry is None:
-            return []
-        effective_dcc = dcc_name if dcc_name is not None else self._dcc_name
-        try:
-            return list(registry.search_actions(category=category, tags=tags or [], dcc_name=effective_dcc))
-        except Exception as exc:
-            logger.debug("[%s] search_actions failed: %s", self._dcc_name, exc)
-            return []
+        return self._skill_client.search_actions(category=category, tags=tags, dcc_name=dcc_name)
 
     def get_skill_categories(self) -> list[str]:
-        """Return all unique action categories.
-
-        Returns:
-            Sorted list of category strings.
-
-        """
-        registry = self.registry
-        if registry is None:
-            return []
-        try:
-            return list(registry.get_categories())
-        except Exception as exc:
-            logger.debug("[%s] get_categories failed: %s", self._dcc_name, exc)
-            return []
+        """Return all unique action categories."""
+        return self._skill_client.get_skill_categories()
 
     def get_skill_tags(self, dcc_name: str | None = None) -> list[str]:
-        """Return all unique tags for this DCC.
-
-        Args:
-            dcc_name: Override the DCC filter.
-
-        Returns:
-            Sorted list of tag strings.
-
-        """
-        registry = self.registry
-        if registry is None:
-            return []
-        effective_dcc = dcc_name if dcc_name is not None else self._dcc_name
-        try:
-            return list(registry.get_tags(dcc_name=effective_dcc))
-        except Exception as exc:
-            logger.debug("[%s] get_tags failed: %s", self._dcc_name, exc)
-            return []
+        """Return all unique tags for this DCC."""
+        return self._skill_client.get_skill_tags(dcc_name)
 
     def unregister_skill(self, name: str, dcc_name: str | None = None) -> None:
-        """Unregister a skill from the action registry.
-
-        Args:
-            name: Canonical action name (e.g. ``"blender_scene__create_cube"``).
-            dcc_name: Scope to a specific DCC; ``None`` means global.
-
-        """
-        registry = self.registry
-        if registry is None:
-            logger.warning("[%s] Registry unavailable; cannot unregister %r", self._dcc_name, name)
-            return
-        try:
-            registry.unregister(name, dcc_name=dcc_name)
-        except Exception as exc:
-            logger.debug("[%s] unregister(%r) failed: %s", self._dcc_name, name, exc)
+        """Unregister a skill from the action registry."""
+        self._skill_client.unregister_skill(name, dcc_name)
 
     def is_skill_loaded(self, name: str) -> bool:
-        """Check whether a skill is currently loaded.
-
-        Args:
-            name: Skill name.
-
-        Returns:
-            ``True`` if loaded.
-
-        """
-        try:
-            return bool(self._server.is_loaded(name))
-        except Exception as exc:
-            logger.debug("[%s] is_loaded(%r) failed: %s", self._dcc_name, name, exc)
-            return False
+        """Check whether a skill is currently loaded."""
+        return self._skill_client.is_skill_loaded(name)
 
     def get_skill_info(self, name: str) -> Any | None:
-        """Return full metadata for a skill.
-
-        Args:
-            name: Skill name.
-
-        Returns:
-            ``SkillMetadata`` or ``None`` if not found.
-
-        """
-        try:
-            return self._server.get_skill_info(name)
-        except Exception as exc:
-            logger.debug("[%s] get_skill_info(%r) failed: %s", self._dcc_name, name, exc)
-            return None
+        """Return full metadata for a skill."""
+        return self._skill_client.get_skill_info(name)
 
     # ── hot-reload ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

`DccServerBase` was a 1104-LOC god object that owned five orthogonal responsibilities — file logging, job persistence, telemetry, window-handle resolution, and the 11 skill query / management methods (Issue #486).

Split into a private package `python/dcc_mcp_core/_server/` exposing four collaborator classes:

| Collaborator | LOC | Responsibility |
| --- | --- | --- |
| `FileLoggingManager` | (in `observability.py`) | Rolling-file logging via `init_file_logging` |
| `JobPersistenceManager` | (in `observability.py`) | SQLite job-history db + `job-persist-sqlite` feature probe |
| `TelemetryManager` | (in `observability.py`) | In-process metrics via `TelemetryConfig` |
| `WindowResolver` | 75 | DCC window handle lookup + cache |
| `SkillQueryClient` | 145 | Bundles 11 skill query / management methods |

`DccServerBase` keeps the existing public API surface, the legacy private attributes (`_enable_*`, `_dcc_pid`, `_dcc_window_*`, `_cached_hwnd`) and the legacy `_init_file_logging` / `_init_job_persistence` / `_init_telemetry` methods as thin shims so test doubles built via `object.__new__` and tests that `mock.patch` the helpers continue to work without modification. A `__getattr__` fallback lazily reconstructs `_skill_client` / `_window_resolver` for those test doubles.

## Result

| Metric | Before | After |
| --- | --- | --- |
| `server_base.py` LOC | 1104 | **899** (−19%) |
| Top-level responsibilities | 6 | 1 (orchestration) |
| Independently-testable units | 1 | 5 |

## Acceptance criteria

- [x] `DccServerBase` no longer owns file-logging / job-persistence / telemetry / window-resolution / skill-query implementation — it delegates to focused collaborators.
- [x] All 8421 tests pass without modification (97 directly cover the touched code paths: `tests/test_dcc_adapter_base.py`, `tests/test_observability_defaults.py`, `tests/test_dcc_server_diagnostic_handlers.py`).
- [x] Public API surface unchanged (`list_actions`, `list_skills`, `search_skills`, `load_skill`, `unload_skill`, `search_actions`, `get_skill_categories`, `get_skill_tags`, `unregister_skill`, `is_skill_loaded`, `get_skill_info`, `dcc_pid`, `dcc_window_*`, `observability_summary`).
- [x] Backward-compatible private surface preserved (`_enable_*`, `_init_*`, `_dcc_*`, `_cached_hwnd`, `_skill_client`, `_window_resolver`).
- [x] `lint-py` clean.

## Note on the ≤650 LOC target

The issue's aspirational target was `server_base.py ≤ 650 LOC`. This PR achieves a 19% reduction (1104 → 899). Reaching `≤650` requires extracting the `start()` / `stop()` lifecycle, the `_collect_skill_paths` / `_perform_skill_discovery` helpers, and the gateway/hot-reload wiring — each of which has its own non-trivial public-API ramifications and warrants a focused follow-up PR. This PR cleanly delivers the four lowest-risk collaborator extractions; further reductions can layer on top.

Refs #486