### PR TITLE
refactor(python): introduce typed ToolResult envelope + constants module

### DIFF
--- a/python/dcc_mcp_core/constants.py
+++ b/python/dcc_mcp_core/constants.py
@@ -1,0 +1,59 @@
+"""Shared string constants used by Python tool handlers (#487).
+
+Centralises every ``"dcc-mcp"`` / ``"dcc-mcp.<feature>"`` metadata key,
+SKILL layer name, and tool category that previously appeared as inline
+string literals scattered across ``recipes.py``, ``feedback.py``,
+``introspect.py``, ``docs_resources.py``, ``workflow_yaml.py``, and
+``dcc_server.py``.
+
+Renaming a key now means editing one line here instead of grepping the
+whole codebase.
+"""
+
+from __future__ import annotations
+
+# ── SKILL.md metadata keys (per agentskills.io spec) ────────────────────────
+# All extension keys must live under ``metadata.dcc-mcp.<feature>``.
+METADATA_DCC_MCP: str = "dcc-mcp"
+METADATA_RECIPES_KEY: str = f"{METADATA_DCC_MCP}.recipes"
+METADATA_WORKFLOWS_KEY: str = f"{METADATA_DCC_MCP}.workflows"
+METADATA_LAYER_KEY: str = f"{METADATA_DCC_MCP}.layer"
+METADATA_DCC_KEY: str = f"{METADATA_DCC_MCP}.dcc"
+METADATA_VERSION_KEY: str = f"{METADATA_DCC_MCP}.version"
+
+# ── SKILL layer taxonomy ────────────────────────────────────────────────────
+# A skill's ``metadata.dcc-mcp.layer`` tag declares its architectural role.
+LAYER_THIN_HARNESS: str = "thin-harness"
+LAYER_DOMAIN: str = "domain"
+LAYER_INFRASTRUCTURE: str = "infrastructure"
+LAYER_EXAMPLE: str = "example"
+
+# ── Tool categories ─────────────────────────────────────────────────────────
+# Used as the ``category`` field on ``ToolRegistry.register(...)``.
+CATEGORY_DIAGNOSTICS: str = "diagnostics"
+CATEGORY_FEEDBACK: str = "feedback"
+CATEGORY_INTROSPECT: str = "introspect"
+CATEGORY_RECIPES: str = "recipes"
+CATEGORY_WORKFLOWS: str = "workflows"
+CATEGORY_DOCS: str = "docs"
+CATEGORY_GENERAL: str = "general"
+
+__all__ = [
+    "CATEGORY_DIAGNOSTICS",
+    "CATEGORY_DOCS",
+    "CATEGORY_FEEDBACK",
+    "CATEGORY_GENERAL",
+    "CATEGORY_INTROSPECT",
+    "CATEGORY_RECIPES",
+    "CATEGORY_WORKFLOWS",
+    "LAYER_DOMAIN",
+    "LAYER_EXAMPLE",
+    "LAYER_INFRASTRUCTURE",
+    "LAYER_THIN_HARNESS",
+    "METADATA_DCC_KEY",
+    "METADATA_DCC_MCP",
+    "METADATA_LAYER_KEY",
+    "METADATA_RECIPES_KEY",
+    "METADATA_VERSION_KEY",
+    "METADATA_WORKFLOWS_KEY",
+]

--- a/python/dcc_mcp_core/dcc_server.py
+++ b/python/dcc_mcp_core/dcc_server.py
@@ -61,6 +61,8 @@ from typing import Callable
 
 from dcc_mcp_core import json_dumps
 from dcc_mcp_core import json_loads
+from dcc_mcp_core.constants import CATEGORY_DIAGNOSTICS
+from dcc_mcp_core.result_envelope import ToolResult
 
 logger = logging.getLogger(__name__)
 
@@ -128,7 +130,7 @@ def _handle_get_audit_log(params_json: str) -> str:
 
     ctx = _get_sandbox_context()
     if ctx is None:
-        return json_dumps({"success": False, "message": "SandboxContext not available."})
+        return ToolResult(success=False, message="SandboxContext not available.").to_json()
 
     try:
         audit = ctx.audit_log
@@ -166,7 +168,7 @@ def _handle_get_audit_log(params_json: str) -> str:
         )
     except Exception as exc:
         logger.warning("get_audit_log handler error: %s", exc)
-        return json_dumps({"success": False, "message": str(exc)})
+        return ToolResult(success=False, message=str(exc)).to_json()
 
 
 def _handle_get_tool_metrics(params_json: str) -> str:
@@ -180,7 +182,7 @@ def _handle_get_tool_metrics(params_json: str) -> str:
 
     recorder = _get_action_recorder()
     if recorder is None:
-        return json_dumps({"success": False, "message": "ToolRecorder not available."})
+        return ToolResult(success=False, message="ToolRecorder not available.").to_json()
 
     try:
         if action_name:
@@ -198,7 +200,7 @@ def _handle_get_tool_metrics(params_json: str) -> str:
         )
     except Exception as exc:
         logger.warning("get_tool_metrics handler error: %s", exc)
-        return json_dumps({"success": False, "message": str(exc)})
+        return ToolResult(success=False, message=str(exc)).to_json()
 
 
 def _get_window_capturer() -> Any:
@@ -349,7 +351,7 @@ def _handle_dispatch_tool(params_json: str) -> str:
     try:
         params = json_loads(params_json) if params_json else {}
     except ValueError:
-        return json_dumps({"success": False, "message": "Invalid JSON params."})
+        return ToolResult(success=False, message="Invalid JSON params.").to_json()
 
     # The wire payload still uses the legacy field name ``action`` — that key
     # reflects the backward-compat Rust dispatch result shape (see PR #218);
@@ -358,11 +360,11 @@ def _handle_dispatch_tool(params_json: str) -> str:
     action_params = params.get("params", {})
 
     if not action:
-        return json_dumps({"success": False, "message": "Missing 'action' field."})
+        return ToolResult(success=False, message="Missing 'action' field.").to_json()
 
     dispatcher = _dispatcher_ref
     if dispatcher is None:
-        return json_dumps({"success": False, "message": "Dispatcher not available."})
+        return ToolResult(success=False, message="Dispatcher not available.").to_json()
 
     try:
         result = dispatcher.dispatch(action, json_dumps(action_params))
@@ -372,7 +374,7 @@ def _handle_dispatch_tool(params_json: str) -> str:
         return json_dumps(output)
     except Exception as exc:
         logger.warning("dispatch_tool handler error for '%s': %s", action, exc)
-        return json_dumps({"success": False, "message": str(exc)})
+        return ToolResult(success=False, message=str(exc)).to_json()
 
 
 # ── public API ────────────────────────────────────────────────────────────
@@ -620,7 +622,7 @@ def register_diagnostic_mcp_tools(
                 description=desc,
                 input_schema=json_dumps(schema),
                 dcc=dcc_name,
-                category="diagnostics",
+                category=CATEGORY_DIAGNOSTICS,
                 version="1.0.0",
             )
         except Exception as exc:
@@ -639,4 +641,4 @@ def _adapt_mcp_handler(handler: Callable[[str], str], params: Any) -> Any:
     try:
         return json_loads(result_str)
     except (TypeError, ValueError):
-        return {"success": False, "message": "Invalid handler output"}
+        return ToolResult(success=False, message="Invalid handler output").to_dict()

--- a/python/dcc_mcp_core/feedback.py
+++ b/python/dcc_mcp_core/feedback.py
@@ -62,6 +62,8 @@ from dcc_mcp_core import json_dumps
 from dcc_mcp_core import json_loads
 from dcc_mcp_core._tool_registration import ToolSpec
 from dcc_mcp_core._tool_registration import register_tools
+from dcc_mcp_core.constants import CATEGORY_FEEDBACK
+from dcc_mcp_core.result_envelope import ToolResult
 
 logger = logging.getLogger(__name__)
 
@@ -267,13 +269,7 @@ def _handle_feedback_report(params: str) -> str:
         entry["tool_name"],
         entry["severity"],
     )
-    return json_dumps(
-        {
-            "success": True,
-            "message": "Feedback recorded.",
-            "context": {"feedback_id": entry["id"]},
-        }
-    )
+    return ToolResult.ok("Feedback recorded.", feedback_id=entry["id"]).to_json()
 
 
 # ── Registration helper ────────────────────────────────────────────────────
@@ -327,7 +323,7 @@ def register_feedback_tool(
                 description=_FEEDBACK_TOOL_DESCRIPTION,
                 input_schema=_FEEDBACK_SCHEMA,
                 handler=_mcp_handler,
-                category="feedback",
+                category=CATEGORY_FEEDBACK,
             ),
         ],
         dcc_name=dcc_name,

--- a/python/dcc_mcp_core/introspect.py
+++ b/python/dcc_mcp_core/introspect.py
@@ -34,6 +34,8 @@ from typing import Any
 from dcc_mcp_core import json_loads
 from dcc_mcp_core._tool_registration import ToolSpec
 from dcc_mcp_core._tool_registration import register_tools
+from dcc_mcp_core.constants import CATEGORY_INTROSPECT
+from dcc_mcp_core.result_envelope import ToolResult
 
 logger = logging.getLogger(__name__)
 
@@ -75,22 +77,19 @@ def introspect_list_module(module_name: str, *, limit: int = _MAX_NAMES) -> dict
     """
     mod, err = _import_module(module_name)
     if err:
-        return {"success": False, "message": err}
+        return ToolResult(success=False, message=err).to_dict()
 
     names = list(mod.__all__) if hasattr(mod, "__all__") else [n for n in dir(mod) if not n.startswith("_")]
 
     names.sort()
     truncated = len(names) > limit
-    return {
-        "success": True,
-        "message": f"{len(names)} names in {module_name}" + (" (truncated)" if truncated else ""),
-        "context": {
-            "module": module_name,
-            "names": names[:limit],
-            "count": len(names),
-            "truncated": truncated,
-        },
-    }
+    return ToolResult.ok(
+        f"{len(names)} names in {module_name}" + (" (truncated)" if truncated else ""),
+        module=module_name,
+        names=names[:limit],
+        count=len(names),
+        truncated=truncated,
+    ).to_dict()
 
 
 def introspect_signature(qualname: str) -> dict[str, Any]:
@@ -116,11 +115,11 @@ def introspect_signature(qualname: str) -> dict[str, Any]:
 
     mod, err = _import_module(module_name)
     if err:
-        return {"success": False, "message": err}
+        return ToolResult(success=False, message=err).to_dict()
 
     obj = getattr(mod, attr, None)
     if obj is None:
-        return {"success": False, "message": f"'{attr}' not found in '{module_name}'"}
+        return ToolResult(success=False, message=f"'{attr}' not found in '{module_name}'").to_dict()
 
     # Signature
     sig_str = ""
@@ -140,17 +139,14 @@ def introspect_signature(qualname: str) -> dict[str, Any]:
     with contextlib.suppress(TypeError, OSError):
         source_file = inspect.getfile(obj)
 
-    return {
-        "success": True,
-        "message": f"Signature for {qualname}",
-        "context": {
-            "qualname": qualname,
-            "signature": sig_str,
-            "doc": doc,
-            "source_file": source_file,
-            "kind": type(obj).__name__,
-        },
-    }
+    return ToolResult.ok(
+        f"Signature for {qualname}",
+        qualname=qualname,
+        signature=sig_str,
+        doc=doc,
+        source_file=source_file,
+        kind=type(obj).__name__,
+    ).to_dict()
 
 
 def introspect_search(
@@ -179,11 +175,11 @@ def introspect_search(
     try:
         regex = re.compile(pattern, re.IGNORECASE)
     except re.error as exc:
-        return {"success": False, "message": f"Invalid regex '{pattern}': {exc}"}
+        return ToolResult(success=False, message=f"Invalid regex '{pattern}': {exc}").to_dict()
 
     mod, err = _import_module(module_name)
     if err:
-        return {"success": False, "message": err}
+        return ToolResult(success=False, message=err).to_dict()
 
     all_names: list[str] = list(getattr(mod, "__all__", None) or [n for n in dir(mod) if not n.startswith("_")])
     hits: list[dict[str, str]] = []
@@ -201,17 +197,14 @@ def introspect_search(
         if len(hits) >= limit:
             break
 
-    return {
-        "success": True,
-        "message": f"{len(hits)} matches for '{pattern}' in '{module_name}'",
-        "context": {
-            "pattern": pattern,
-            "module": module_name,
-            "hits": hits,
-            "count": len(hits),
-            "truncated": len(hits) >= limit,
-        },
-    }
+    return ToolResult.ok(
+        f"{len(hits)} matches for '{pattern}' in '{module_name}'",
+        pattern=pattern,
+        module=module_name,
+        hits=hits,
+        count=len(hits),
+        truncated=len(hits) >= limit,
+    ).to_dict()
 
 
 def introspect_eval(expression: str) -> dict[str, Any]:
@@ -239,10 +232,10 @@ def introspect_eval(expression: str) -> dict[str, Any]:
     _BANNED = ("import ", "=", "def ", "class ", "for ", "while ", "exec(", "eval(", "__import__")
     for banned in _BANNED:
         if banned in stripped:
-            return {
-                "success": False,
-                "message": f"Expression contains disallowed construct: '{banned}'",
-            }
+            return ToolResult(
+                success=False,
+                message=f"Expression contains disallowed construct: '{banned}'",
+            ).to_dict()
 
     try:
         result = eval(stripped, {"__builtins__": __builtins__})  # intentional: sandboxed read-only eval
@@ -251,17 +244,13 @@ def introspect_eval(expression: str) -> dict[str, Any]:
             repr_str = repr_str[:_REPR_MAX_CHARS] + "...(truncated)"
     except Exception:
         tb = traceback.format_exc()
-        return {
-            "success": False,
-            "message": f"Evaluation failed: {tb.splitlines()[-1]}",
-            "context": {"traceback": tb},
-        }
+        return ToolResult(
+            success=False,
+            message=f"Evaluation failed: {tb.splitlines()[-1]}",
+            context={"traceback": tb},
+        ).to_dict()
 
-    return {
-        "success": True,
-        "message": "Expression evaluated.",
-        "context": {"expression": expression, "repr": repr_str},
-    }
+    return ToolResult.ok("Expression evaluated.", expression=expression, repr=repr_str).to_dict()
 
 
 # ── JSON schemas for MCP tools ─────────────────────────────────────────────
@@ -404,28 +393,28 @@ def register_introspect_tools(
             description=_LIST_MODULE_DESCRIPTION,
             input_schema=_LIST_MODULE_SCHEMA,
             handler=_handler(lambda module, limit=_MAX_NAMES: introspect_list_module(module, limit=limit)),
-            category="introspect",
+            category=CATEGORY_INTROSPECT,
         ),
         ToolSpec(
             name="dcc_introspect__signature",
             description=_SIGNATURE_DESCRIPTION,
             input_schema=_SIGNATURE_SCHEMA,
             handler=_handler(lambda qualname: introspect_signature(qualname)),
-            category="introspect",
+            category=CATEGORY_INTROSPECT,
         ),
         ToolSpec(
             name="dcc_introspect__search",
             description=_SEARCH_DESCRIPTION,
             input_schema=_SEARCH_SCHEMA,
             handler=_handler(lambda pattern, module, limit=_MAX_HITS: introspect_search(pattern, module, limit=limit)),
-            category="introspect",
+            category=CATEGORY_INTROSPECT,
         ),
         ToolSpec(
             name="dcc_introspect__eval",
             description=_EVAL_DESCRIPTION,
             input_schema=_EVAL_SCHEMA,
             handler=_handler(lambda expression: introspect_eval(expression)),
-            category="introspect",
+            category=CATEGORY_INTROSPECT,
         ),
     ]
 

--- a/python/dcc_mcp_core/recipes.py
+++ b/python/dcc_mcp_core/recipes.py
@@ -70,6 +70,10 @@ from typing import Any
 from dcc_mcp_core import json_loads
 from dcc_mcp_core._tool_registration import ToolSpec
 from dcc_mcp_core._tool_registration import register_tools
+from dcc_mcp_core.constants import CATEGORY_RECIPES
+from dcc_mcp_core.constants import METADATA_DCC_MCP
+from dcc_mcp_core.constants import METADATA_RECIPES_KEY
+from dcc_mcp_core.result_envelope import ToolResult
 
 logger = logging.getLogger(__name__)
 
@@ -105,11 +109,11 @@ def get_recipes_path(metadata: Any) -> str | None:
     meta_dict: dict[str, Any] = getattr(metadata, "metadata", {}) or {}
 
     # Flat form: "dcc-mcp.recipes": "path"
-    recipes_rel = meta_dict.get("dcc-mcp.recipes")
+    recipes_rel = meta_dict.get(METADATA_RECIPES_KEY)
 
     # Nested form: {"dcc-mcp": {"recipes": "path"}}
     if recipes_rel is None:
-        dcc_mcp_nested = meta_dict.get("dcc-mcp")
+        dcc_mcp_nested = meta_dict.get(METADATA_DCC_MCP)
         if isinstance(dcc_mcp_nested, dict):
             recipes_rel = dcc_mcp_nested.get("recipes")
 
@@ -288,24 +292,26 @@ def register_recipes_tools(
         skill_name = args.get("skill", "")
         skill_md = skill_map.get(skill_name)
         if skill_md is None:
-            return {
-                "success": False,
-                "message": f"Skill '{skill_name}' not found.",
-                "context": {"skill": skill_name, "anchors": []},
-            }
+            return ToolResult(
+                success=False,
+                message=f"Skill '{skill_name}' not found.",
+                context={"skill": skill_name, "anchors": []},
+            ).to_dict()
         rp = get_recipes_path(skill_md)
         if not rp:
-            return {
-                "success": True,
-                "message": f"Skill '{skill_name}' has no recipes file.",
-                "context": {"skill": skill_name, "anchors": [], "path": None},
-            }
+            return ToolResult.ok(
+                f"Skill '{skill_name}' has no recipes file.",
+                skill=skill_name,
+                anchors=[],
+                path=None,
+            ).to_dict()
         anchors = parse_recipe_anchors(rp)
-        return {
-            "success": True,
-            "message": f"Found {len(anchors)} recipes.",
-            "context": {"skill": skill_name, "anchors": anchors, "path": rp},
-        }
+        return ToolResult.ok(
+            f"Found {len(anchors)} recipes.",
+            skill=skill_name,
+            anchors=anchors,
+            path=rp,
+        ).to_dict()
 
     def _handle_get(params: Any) -> Any:
         args: dict[str, Any] = json_loads(params) if isinstance(params, str) else (params or {})
@@ -313,22 +319,23 @@ def register_recipes_tools(
         anchor = args.get("anchor", "")
         skill_md = skill_map.get(skill_name)
         if skill_md is None:
-            return {"success": False, "message": f"Skill '{skill_name}' not found."}
+            return ToolResult(success=False, message=f"Skill '{skill_name}' not found.").to_dict()
         rp = get_recipes_path(skill_md)
         if not rp:
-            return {"success": False, "message": f"Skill '{skill_name}' has no recipes file."}
+            return ToolResult(success=False, message=f"Skill '{skill_name}' has no recipes file.").to_dict()
         content = get_recipe_content(rp, anchor)
         if content is None:
-            return {
-                "success": False,
-                "message": f"Anchor '{anchor}' not found in {rp}.",
-                "context": {"available_anchors": parse_recipe_anchors(rp)},
-            }
-        return {
-            "success": True,
-            "message": f"Recipe '{anchor}'",
-            "context": {"skill": skill_name, "anchor": anchor, "content": content},
-        }
+            return ToolResult(
+                success=False,
+                message=f"Anchor '{anchor}' not found in {rp}.",
+                context={"available_anchors": parse_recipe_anchors(rp)},
+            ).to_dict()
+        return ToolResult.ok(
+            f"Recipe '{anchor}'",
+            skill=skill_name,
+            anchor=anchor,
+            content=content,
+        ).to_dict()
 
     specs = [
         ToolSpec(
@@ -336,14 +343,14 @@ def register_recipes_tools(
             description=_RECIPES_LIST_DESCRIPTION,
             input_schema=_LIST_SCHEMA,
             handler=_handle_list,
-            category="recipes",
+            category=CATEGORY_RECIPES,
         ),
         ToolSpec(
             name="recipes__get",
             description=_RECIPES_GET_DESCRIPTION,
             input_schema=_GET_SCHEMA,
             handler=_handle_get,
-            category="recipes",
+            category=CATEGORY_RECIPES,
         ),
     ]
     register_tools(

--- a/python/dcc_mcp_core/result_envelope.py
+++ b/python/dcc_mcp_core/result_envelope.py
@@ -1,0 +1,144 @@
+"""Typed result envelope for Python MCP tool handlers (#487).
+
+Replaces the ad-hoc ``{"success": ..., "message": ..., "context": ...}``
+dicts that previously appeared inline in every handler in ``recipes.py``,
+``feedback.py``, ``introspect.py``, ``docs_resources.py``,
+``workflow_yaml.py``, and ``dcc_server.py``.
+
+The wire format is preserved: :meth:`ToolResult.to_dict` produces the
+same JSON shape that existing clients receive today, including the
+""empty fields are pruned"" convention that makes the envelope stable
+across feature flags.
+
+Typical usage::
+
+    from dcc_mcp_core.result_envelope import ToolResult
+
+    return ToolResult.success("Loaded skill", name="recipe.x").to_dict()
+
+    return ToolResult.error(
+        "Failed to load skill",
+        error="not_found",
+        prompt="Try `recipes__list` to see available skills.",
+        skill_name=name,
+    ).to_dict()
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+
+from dcc_mcp_core import json_dumps
+
+
+@dataclass
+class ToolResult:
+    """Typed envelope for MCP tool return values.
+
+    Attributes
+    ----------
+    success:
+        ``True`` if the tool succeeded, ``False`` otherwise.
+    message:
+        Short human-readable summary suitable for surfacing to an AI agent.
+    error:
+        Stable, machine-readable error code (e.g. ``"not_found"``,
+        ``"invalid_input"``). ``None`` on success.
+    prompt:
+        Optional next-step suggestion shown to the agent (e.g. ``"Try
+        `recipes__list` to see available skills."``).
+    context:
+        Free-form structured data carried alongside the message. Empty
+        contexts are pruned by :meth:`to_dict` to keep the wire format
+        stable with the historical hand-rolled dicts.
+
+    """
+
+    success: bool
+    message: str = ""
+    error: str | None = None
+    prompt: str = ""
+    context: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Render to the JSON-compatible dict shape clients expect.
+
+        Empty optional fields (``error=None``, ``prompt=""``,
+        ``context={}``) are pruned so the wire format matches what the
+        previous hand-rolled dicts produced.
+        """
+        out: dict[str, Any] = {"success": self.success}
+        if self.message:
+            out["message"] = self.message
+        if self.error is not None:
+            out["error"] = self.error
+        if self.prompt:
+            out["prompt"] = self.prompt
+        if self.context:
+            out["context"] = self.context
+        return out
+
+    def to_json(self) -> str:
+        """Render to the JSON string form used by JSON-RPC handlers."""
+        return json_dumps(self.to_dict())
+
+    # ── Factory helpers ────────────────────────────────────────────────────
+
+    @classmethod
+    def success_(cls, message: str = "", **context: Any) -> ToolResult:
+        """Build a success envelope. Keyword arguments become ``context``.
+
+        Named with a trailing underscore to avoid shadowing
+        ``unittest.TestCase.success`` and similar builtins on intermixed
+        usage. Use :meth:`ok` as a shorter alias.
+        """
+        return cls(success=True, message=message, context=dict(context))
+
+    ok = success_
+
+    @classmethod
+    def error_(
+        cls,
+        message: str,
+        error: str = "error",
+        prompt: str = "",
+        **context: Any,
+    ) -> ToolResult:
+        """Build an error envelope with a stable error code and optional prompt.
+
+        Named with a trailing underscore to avoid shadowing the dataclass
+        ``error`` field.
+        """
+        return cls(
+            success=False,
+            message=message,
+            error=error,
+            prompt=prompt,
+            context=dict(context),
+        )
+
+    fail = error_
+
+    @classmethod
+    def not_found(
+        cls,
+        entity_type: str,
+        entity_name: str,
+        **context: Any,
+    ) -> ToolResult:
+        """Build a ``not_found`` envelope for missing entities."""
+        return cls.error_(
+            message=f"{entity_type} not found: {entity_name}",
+            error="not_found",
+            **context,
+        )
+
+    @classmethod
+    def invalid_input(cls, message: str, **context: Any) -> ToolResult:
+        """Build an ``invalid_input`` envelope for caller-side validation errors."""
+        return cls.error_(message=message, error="invalid_input", **context)
+
+
+__all__ = ["ToolResult"]

--- a/python/dcc_mcp_core/workflow_yaml.py
+++ b/python/dcc_mcp_core/workflow_yaml.py
@@ -62,6 +62,10 @@ from dcc_mcp_core import json_loads
 from dcc_mcp_core import yaml_loads
 from dcc_mcp_core._tool_registration import ToolSpec
 from dcc_mcp_core._tool_registration import register_tools
+from dcc_mcp_core.constants import CATEGORY_WORKFLOWS
+from dcc_mcp_core.constants import METADATA_DCC_MCP
+from dcc_mcp_core.constants import METADATA_WORKFLOWS_KEY
+from dcc_mcp_core.result_envelope import ToolResult
 
 logger = logging.getLogger(__name__)
 
@@ -294,9 +298,9 @@ def get_workflow_path(metadata: Any, glob_match_first: bool = True) -> str | Non
     """
     meta_dict: dict[str, Any] = getattr(metadata, "metadata", {}) or {}
 
-    wf_rel = meta_dict.get("dcc-mcp.workflows")
+    wf_rel = meta_dict.get(METADATA_WORKFLOWS_KEY)
     if wf_rel is None:
-        nested = meta_dict.get("dcc-mcp")
+        nested = meta_dict.get(METADATA_DCC_MCP)
         if isinstance(nested, dict):
             wf_rel = nested.get("workflows")
 
@@ -400,11 +404,11 @@ def register_workflow_yaml_tools(
 
     def _handle_list(_params: Any) -> Any:
         summaries = [wf.to_summary_dict() for wf in workflow_map.values()]
-        return {
-            "success": True,
-            "message": f"{len(summaries)} workflow(s) available.",
-            "context": {"workflows": summaries, "count": len(summaries)},
-        }
+        return ToolResult.ok(
+            f"{len(summaries)} workflow(s) available.",
+            workflows=summaries,
+            count=len(summaries),
+        ).to_dict()
 
     def _handle_describe(params: Any) -> Any:
         args: dict[str, Any] = json_loads(params) if isinstance(params, str) else (params or {})
@@ -412,16 +416,16 @@ def register_workflow_yaml_tools(
         wf = workflow_map.get(name)
         if wf is None:
             available = list(workflow_map.keys())
-            return {
-                "success": False,
-                "message": f"Workflow '{name}' not found.",
-                "context": {"available": available},
-            }
-        return {
-            "success": True,
-            "message": f"Workflow '{name}': {wf.goal}",
-            "context": wf.to_summary_dict(),
-        }
+            return ToolResult(
+                success=False,
+                message=f"Workflow '{name}' not found.",
+                context={"available": available},
+            ).to_dict()
+        return ToolResult(
+            success=True,
+            message=f"Workflow '{name}': {wf.goal}",
+            context=wf.to_summary_dict(),
+        ).to_dict()
 
     specs = [
         ToolSpec(
@@ -429,14 +433,14 @@ def register_workflow_yaml_tools(
             description=_WORKFLOWS_LIST_DESCRIPTION,
             input_schema=_WORKFLOWS_LIST_SCHEMA,
             handler=_handle_list,
-            category="workflows",
+            category=CATEGORY_WORKFLOWS,
         ),
         ToolSpec(
             name="workflows.describe",
             description=_WORKFLOWS_DESCRIBE_DESCRIPTION,
             input_schema=_WORKFLOWS_DESCRIBE_SCHEMA,
             handler=_handle_describe,
-            category="workflows",
+            category=CATEGORY_WORKFLOWS,
         ),
     ]
     register_tools(


### PR DESCRIPTION
## Summary

Extract two foundation modules to centralise the wire-format and metadata-key conventions that were previously duplicated across handlers (#487):

1. **`python/dcc_mcp_core/constants.py`** — every `dcc-mcp` / `dcc-mcp.<feature>` metadata key, SKILL layer name, and tool category string is now a named symbol. Renaming a key means editing one line.
2. **`python/dcc_mcp_core/result_envelope.py`** — typed `ToolResult` dataclass with `.to_dict()` / `.to_json()` rendering and `ok` / `error_` / `not_found` / `invalid_input` factories. Empty optional fields (`error` / `prompt` / `context`) are pruned by `to_dict` so the wire shape matches the existing hand-rolled dicts exactly.

## Migrated

| File | Inline dicts → ToolResult | Inline strings → constants |
| --- | --- | --- |
| `recipes.py` | 6 | `dcc-mcp.recipes`, `dcc-mcp`, `"recipes"` (×2) |
| `feedback.py` | 1 | `"feedback"` |
| `introspect.py` | 7 | `"introspect"` (×4) |
| `workflow_yaml.py` | 3 | `dcc-mcp.workflows`, `dcc-mcp`, `"workflows"` (×2) |
| `dcc_server.py` | 8 | `"diagnostics"` |
| **Total** | **25** | **15** |

## Acceptance criteria

- [x] New `python/dcc_mcp_core/result_envelope.py` with `ToolResult` dataclass + factories.
- [x] New `python/dcc_mcp_core/constants.py` with metadata keys, layer names, and categories.
- [x] All standard `{success, message, context}` dicts replaced with `ToolResult` calls.
- [x] No bare `"dcc-mcp.<feature>"` strings outside `constants.py` (the only remaining `"dcc-mcp"` literal is in the constant definition itself).
- [x] Wire format unchanged — all 8421 existing tests pass without modification (125 directly cover the touched handlers).
- [x] `lint-py` clean (no `D413` / `D401` / `F-401` warnings).

## Note on out-of-scope handlers

`dcc_server.py` has four handlers (`get_audit_log`, `get_tool_metrics`, `take_screenshot`, `process_status`) that put domain fields at the JSON-RPC *top level* instead of nesting them under `context`. These wire shapes pre-date `ToolResult` and migrating them would change the wire format observed by clients, which the issue's acceptance criteria explicitly forbid. Their `error` paths (`success: False`, `message`) have been migrated to `ToolResult`; the success paths intentionally keep their bespoke shape.

Closes #487