### PR TITLE
refactor: introduce shared DccMcpError + From impls for HttpError, ProcessError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,6 +811,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "uuid",
  "workspace-hack",
 ]
@@ -842,6 +843,7 @@ dependencies = [
 name = "dcc-mcp-process"
 version = "0.14.15"
 dependencies = [
+ "dcc-mcp-models",
  "ipckit",
  "parking_lot",
  "pyo3",

--- a/crates/dcc-mcp-http/src/error.rs
+++ b/crates/dcc-mcp-http/src/error.rs
@@ -1,5 +1,6 @@
 //! Error types for the MCP HTTP server.
 
+use dcc_mcp_models::DccMcpError;
 use thiserror::Error;
 
 pub type HttpResult<T> = Result<T, HttpError>;
@@ -55,5 +56,65 @@ impl HttpError {
             Self::Timeout { .. } => 504,
             _ => 500,
         }
+    }
+}
+
+/// Bubble `HttpError` into the shared `DccMcpError` taxonomy (#488).
+///
+/// Maps each fine-grained variant to the closest cross-crate kind so the
+/// gateway / MCP error-code mapping stays consistent regardless of which
+/// crate produced the error.
+impl From<HttpError> for DccMcpError {
+    fn from(err: HttpError) -> Self {
+        match &err {
+            HttpError::SessionNotFound(_) => DccMcpError::NotFound(err.to_string()),
+            HttpError::InvalidSessionId(_) | HttpError::RateLimit(_) => {
+                DccMcpError::Validation(err.to_string())
+            }
+            HttpError::Json(_) => DccMcpError::Serialization(err.to_string()),
+            HttpError::BindFailed { .. } => DccMcpError::Io(err.to_string()),
+            HttpError::Timeout { ms } => DccMcpError::Timeout { ms: *ms },
+            _ => DccMcpError::Internal(err.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_not_found_maps_to_not_found() {
+        let err: DccMcpError = HttpError::SessionNotFound("abc".into()).into();
+        assert!(matches!(err, DccMcpError::NotFound(_)));
+        assert_eq!(err.code(), "not_found");
+    }
+
+    #[test]
+    fn invalid_session_id_maps_to_validation() {
+        let err: DccMcpError = HttpError::InvalidSessionId("bad".into()).into();
+        assert!(matches!(err, DccMcpError::Validation(_)));
+    }
+
+    #[test]
+    fn timeout_carries_ms() {
+        let err: DccMcpError = HttpError::Timeout { ms: 500 }.into();
+        assert!(matches!(err, DccMcpError::Timeout { ms: 500 }));
+    }
+
+    #[test]
+    fn bind_failed_maps_to_io() {
+        let err: DccMcpError = HttpError::BindFailed {
+            addr: "127.0.0.1:0".into(),
+            source: std::io::Error::new(std::io::ErrorKind::AddrInUse, "addr in use"),
+        }
+        .into();
+        assert!(matches!(err, DccMcpError::Io(_)));
+    }
+
+    #[test]
+    fn already_running_maps_to_internal() {
+        let err: DccMcpError = HttpError::AlreadyRunning.into();
+        assert!(matches!(err, DccMcpError::Internal(_)));
     }
 }

--- a/crates/dcc-mcp-models/Cargo.toml
+++ b/crates/dcc-mcp-models/Cargo.toml
@@ -19,6 +19,7 @@ dcc-mcp-pybridge = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 rmp-serde = { workspace = true }
+thiserror = { workspace = true }
 uuid = { workspace = true }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 

--- a/crates/dcc-mcp-models/src/error.rs
+++ b/crates/dcc-mcp-models/src/error.rs
@@ -1,0 +1,143 @@
+//! Shared `DccMcpError` for cross-crate error bubbling (#488).
+//!
+//! Most crates in the workspace define their own `Error` enum with overlapping
+//! variants (`Io`, `Json`, `Internal`, `NotFound`, `Timeout`). Bubbling an
+//! error through three crates used to require three explicit `Into`
+//! conversions and three serialisation paths at the gateway boundary.
+//!
+//! `DccMcpError` is the *lingua franca* for those crossings. Crate-local
+//! error enums keep their fine-grained variants but gain a single
+//! `impl From<MyCrateError> for DccMcpError`, so a `?` at a crate boundary
+//! is enough to convert. The gateway can then format any error from any
+//! crate through one consistent code-mapping.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Cross-crate error type used at the gateway boundary.
+///
+/// Variants are deliberately coarse — they exist to classify an error for
+/// the gateway / MCP error code mapping, not to replace per-crate
+/// fine-grained errors. Crate-local errors should keep their own typed
+/// enums and convert *into* `DccMcpError` only when bubbling across a
+/// crate boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Error, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "message")]
+pub enum DccMcpError {
+    /// IO failure (file not found, permission denied, broken pipe, …).
+    #[error("io: {0}")]
+    Io(String),
+
+    /// JSON / serialisation failure (malformed input, missing field, …).
+    #[error("serialization: {0}")]
+    Serialization(String),
+
+    /// Caller-side validation failure (bad parameters, schema mismatch, …).
+    #[error("validation: {0}")]
+    Validation(String),
+
+    /// Requested entity does not exist.
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    /// Operation exceeded its time budget.
+    #[error("timeout after {ms}ms")]
+    Timeout {
+        /// How long we waited before giving up.
+        ms: u64,
+    },
+
+    /// Internal failure that does not fit any other variant.
+    #[error("internal: {0}")]
+    Internal(String),
+}
+
+impl DccMcpError {
+    /// Stable string code that the gateway maps to an MCP error code.
+    ///
+    /// Codes are stable across releases — adding a new variant means
+    /// adding a new code, never renaming an existing one.
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::Io(_) => "io",
+            Self::Serialization(_) => "serialization",
+            Self::Validation(_) => "validation",
+            Self::NotFound(_) => "not_found",
+            Self::Timeout { .. } => "timeout",
+            Self::Internal(_) => "internal",
+        }
+    }
+
+    /// Build an [`Internal`](Self::Internal) error from any displayable value.
+    pub fn internal<E: fmt::Display>(err: E) -> Self {
+        Self::Internal(err.to_string())
+    }
+
+    /// Build an [`Io`](Self::Io) error from any displayable value.
+    pub fn io<E: fmt::Display>(err: E) -> Self {
+        Self::Io(err.to_string())
+    }
+
+    /// Build a [`Validation`](Self::Validation) error from any displayable value.
+    pub fn validation<E: fmt::Display>(err: E) -> Self {
+        Self::Validation(err.to_string())
+    }
+
+    /// Build a [`NotFound`](Self::NotFound) error for the named entity.
+    pub fn not_found<S: Into<String>>(what: S) -> Self {
+        Self::NotFound(what.into())
+    }
+}
+
+impl From<std::io::Error> for DccMcpError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e.to_string())
+    }
+}
+
+impl From<serde_json::Error> for DccMcpError {
+    fn from(e: serde_json::Error) -> Self {
+        Self::Serialization(e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn code_is_stable() {
+        assert_eq!(DccMcpError::Io("x".into()).code(), "io");
+        assert_eq!(
+            DccMcpError::Serialization("x".into()).code(),
+            "serialization"
+        );
+        assert_eq!(DccMcpError::Validation("x".into()).code(), "validation");
+        assert_eq!(DccMcpError::NotFound("x".into()).code(), "not_found");
+        assert_eq!(DccMcpError::Timeout { ms: 100 }.code(), "timeout");
+        assert_eq!(DccMcpError::Internal("x".into()).code(), "internal");
+    }
+
+    #[test]
+    fn from_io_error_classifies_as_io() {
+        let io: std::io::Error = std::io::Error::new(std::io::ErrorKind::NotFound, "missing");
+        let err: DccMcpError = io.into();
+        assert!(matches!(err, DccMcpError::Io(_)));
+    }
+
+    #[test]
+    fn display_includes_message() {
+        let err = DccMcpError::Validation("bad input".into());
+        assert_eq!(err.to_string(), "validation: bad input");
+    }
+
+    #[test]
+    fn json_round_trip_preserves_variant() {
+        let err = DccMcpError::Timeout { ms: 250 };
+        let json = serde_json::to_string(&err).unwrap();
+        let back: DccMcpError = serde_json::from_str(&json).unwrap();
+        assert_eq!(err, back);
+    }
+}

--- a/crates/dcc-mcp-models/src/lib.rs
+++ b/crates/dcc-mcp-models/src/lib.rs
@@ -1,6 +1,7 @@
-//! dcc-mcp-models: ActionResultModel, SkillMetadata, SkillScope.
+//! dcc-mcp-models: ActionResultModel, SkillMetadata, SkillScope, DccMcpError.
 
 mod action_result;
+mod error;
 mod skill_metadata;
 pub mod skill_scope;
 
@@ -9,6 +10,7 @@ mod python;
 
 pub use action_result::ActionResultModel as ToolResult;
 pub use action_result::{ActionResultModel, ActionResultModelData, SerializeFormat};
+pub use error::DccMcpError;
 pub use skill_metadata::{
     ExecutionMode, NextTools, SkillDependencies, SkillDependency, SkillDependencyType, SkillGroup,
     SkillMetadata, SkillPolicy, ThreadAffinity, ToolAnnotations, ToolDeclaration,

--- a/crates/dcc-mcp-process/Cargo.toml
+++ b/crates/dcc-mcp-process/Cargo.toml
@@ -21,6 +21,7 @@ pyo3-stub-gen = { workspace = true, optional = true }
 pyo3-stub-gen-derive = { workspace = true, optional = true }
 
 ipckit.workspace = true
+dcc-mcp-models = { path = "../dcc-mcp-models" }
 
 # Cross-platform system/process information
 sysinfo = { workspace = true }

--- a/crates/dcc-mcp-process/src/error.rs
+++ b/crates/dcc-mcp-process/src/error.rs
@@ -1,5 +1,6 @@
 //! Error types for the dcc-mcp-process crate.
 
+use dcc_mcp_models::DccMcpError;
 use thiserror::Error;
 
 /// Errors that can occur during DCC process operations.
@@ -50,6 +51,29 @@ impl ProcessError {
     /// Convenience constructor for `Internal`.
     pub fn internal(msg: impl Into<String>) -> Self {
         Self::Internal(msg.into())
+    }
+}
+
+/// Bubble `ProcessError` into the shared `DccMcpError` taxonomy (#488).
+///
+/// Maps each fine-grained variant to the closest cross-crate kind so the
+/// gateway / MCP error-code mapping stays consistent regardless of which
+/// crate produced the error.
+impl From<ProcessError> for DccMcpError {
+    fn from(err: ProcessError) -> Self {
+        match &err {
+            ProcessError::NotFound { .. } => DccMcpError::NotFound(err.to_string()),
+            ProcessError::LaunchTimeout { timeout_ms, .. } => {
+                DccMcpError::Timeout { ms: *timeout_ms }
+            }
+            ProcessError::Io { .. } => DccMcpError::Io(err.to_string()),
+            ProcessError::SpawnFailed { .. }
+            | ProcessError::TerminateFailed { .. }
+            | ProcessError::MaxRestartsExceeded { .. } => DccMcpError::Validation(err.to_string()),
+            ProcessError::MonitorShutdown | ProcessError::Internal(_) => {
+                DccMcpError::Internal(err.to_string())
+            }
+        }
     }
 }
 
@@ -158,6 +182,43 @@ mod tests {
         fn internal_constructor() {
             let err = ProcessError::internal("bad state");
             assert!(matches!(err, ProcessError::Internal(s) if s == "bad state"));
+        }
+    }
+
+    mod test_into_dcc_mcp_error {
+        use super::*;
+
+        #[test]
+        fn not_found_maps_to_not_found() {
+            let err: DccMcpError = ProcessError::NotFound { pid: 7 }.into();
+            assert!(matches!(err, DccMcpError::NotFound(_)));
+            assert_eq!(err.code(), "not_found");
+        }
+
+        #[test]
+        fn launch_timeout_carries_timeout_ms() {
+            let err: DccMcpError = ProcessError::LaunchTimeout {
+                command: "x".into(),
+                timeout_ms: 1234,
+            }
+            .into();
+            assert!(matches!(err, DccMcpError::Timeout { ms: 1234 }));
+        }
+
+        #[test]
+        fn spawn_failed_maps_to_validation() {
+            let err: DccMcpError = ProcessError::SpawnFailed {
+                command: "x".into(),
+                reason: "y".into(),
+            }
+            .into();
+            assert!(matches!(err, DccMcpError::Validation(_)));
+        }
+
+        #[test]
+        fn monitor_shutdown_maps_to_internal() {
+            let err: DccMcpError = ProcessError::MonitorShutdown.into();
+            assert!(matches!(err, DccMcpError::Internal(_)));
         }
     }
 


### PR DESCRIPTION
## Summary

Most crates in the workspace defined their own `Error` enum with overlapping variants (`Io`, `Json`, `Internal`, `NotFound`, `Timeout`). Bubbling an error across crates required explicit `Into` conversions in three places and three serialisation paths at the gateway boundary (#488).

Introduce `dcc_mcp_models::DccMcpError` as the cross-crate error taxonomy. Variants are deliberately coarse (`Io` / `Serialization` / `Validation` / `NotFound` / `Timeout` / `Internal`) and serialisable; each carries a stable `.code()` string the gateway can map to an MCP error code.

Wire `HttpError → DccMcpError` and `ProcessError → DccMcpError` via `From` impls so a `?` at a crate boundary is enough to convert. Each conversion has unit-test coverage proving the variant mapping is stable.

## Wired conversions

| Source variant | → DccMcpError variant |
| --- | --- |
| `HttpError::SessionNotFound` | `NotFound` |
| `HttpError::InvalidSessionId`, `RateLimit` | `Validation` |
| `HttpError::Json` | `Serialization` |
| `HttpError::BindFailed` | `Io` |
| `HttpError::Timeout { ms }` | `Timeout { ms }` |
| `HttpError::*` (rest) | `Internal` |
| `ProcessError::NotFound` | `NotFound` |
| `ProcessError::LaunchTimeout { timeout_ms }` | `Timeout { ms: timeout_ms }` |
| `ProcessError::Io` | `Io` |
| `ProcessError::SpawnFailed`, `TerminateFailed`, `MaxRestartsExceeded` | `Validation` |
| `ProcessError::MonitorShutdown`, `Internal` | `Internal` |

## Acceptance criteria

- [x] New `dcc_mcp_models::DccMcpError` exposed via `pub use error::DccMcpError`.
- [x] `From<HttpError> for DccMcpError` and `From<ProcessError> for DccMcpError` impls in their respective crates.
- [x] Crate-local enums keep their fine-grained variants — no public-API breakage.
- [x] Each conversion has unit-test coverage (9 new tests).
- [x] Stable `code()` mapping covered by tests.
- [x] All 427 affected tests pass (288 `dcc-mcp-http` + 51 `dcc-mcp-models` + 88 `dcc-mcp-process`).
- [x] `cargo fmt` + `cargo clippy --all-targets -- -D warnings` clean.

## Note on incremental adoption

Further crates (`dcc-mcp-skills`, `dcc-mcp-actions`, `dcc-mcp-workflow`) can adopt `From<TheirError> for DccMcpError` later without breaking compatibility. This PR introduces the shared type and the two highest-traffic conversions; remaining crates can be wired in a follow-up.

Closes #488