### PR TITLE
refactor: introduce DccName newtype + typed scanner entry point

### DIFF
--- a/crates/dcc-mcp-models/src/dcc_name.rs
+++ b/crates/dcc-mcp-models/src/dcc_name.rs
@@ -1,0 +1,165 @@
+//! Typed DCC name enum (#491).
+//!
+//! Replaces stringly-typed `&str` / `String` DCC identifiers across the
+//! workspace. Validates and normalises at the API boundary so internal
+//! code can rely on case-stable, exhaustively-matchable variants.
+//!
+//! Unknown DCCs are tolerated via [`DccName::Other`] so the enum can
+//! evolve without breaking external integrations.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+/// Canonical DCC application identifier.
+///
+/// Wire form is the lowercase canonical name (`"maya"`, `"blender"`, …).
+/// Round-trips through serde and `parse` / `to_string` losslessly.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(from = "String", into = "String")]
+pub enum DccName {
+    /// Autodesk Maya
+    Maya,
+    /// Blender Foundation Blender
+    Blender,
+    /// SideFX Houdini
+    Houdini,
+    /// Autodesk 3ds Max
+    ThreedsMax,
+    /// Maxon Cinema 4D
+    Cinema4d,
+    /// Adobe Photoshop
+    Photoshop,
+    /// Foundry Nuke
+    Nuke,
+    /// Any DCC not covered by the canonical variants — preserves the
+    /// caller-supplied lowercase string for forward-compat.
+    Other(String),
+}
+
+impl DccName {
+    /// Parse a DCC name with case-insensitive matching against the
+    /// canonical aliases. Unknown values become [`DccName::Other`] with
+    /// the lowercased input preserved.
+    pub fn parse(s: &str) -> Self {
+        let lower = s.trim().to_ascii_lowercase();
+        match lower.as_str() {
+            "maya" => Self::Maya,
+            "blender" => Self::Blender,
+            "houdini" => Self::Houdini,
+            "3dsmax" | "max" | "threedsmax" => Self::ThreedsMax,
+            "c4d" | "cinema4d" => Self::Cinema4d,
+            "photoshop" | "ps" => Self::Photoshop,
+            "nuke" => Self::Nuke,
+            _ => Self::Other(lower),
+        }
+    }
+
+    /// Canonical wire/string representation (always lowercase, no spaces).
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Maya => "maya",
+            Self::Blender => "blender",
+            Self::Houdini => "houdini",
+            Self::ThreedsMax => "3dsmax",
+            Self::Cinema4d => "c4d",
+            Self::Photoshop => "photoshop",
+            Self::Nuke => "nuke",
+            Self::Other(s) => s.as_str(),
+        }
+    }
+
+    /// `true` if this is one of the canonical (well-known) variants.
+    pub fn is_known(&self) -> bool {
+        !matches!(self, Self::Other(_))
+    }
+}
+
+impl fmt::Display for DccName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for DccName {
+    type Err = std::convert::Infallible;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::parse(s))
+    }
+}
+
+impl From<&str> for DccName {
+    fn from(s: &str) -> Self {
+        Self::parse(s)
+    }
+}
+
+impl From<String> for DccName {
+    fn from(s: String) -> Self {
+        Self::parse(&s)
+    }
+}
+
+impl From<DccName> for String {
+    fn from(d: DccName) -> Self {
+        d.as_str().to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_canonical_lowercase() {
+        assert_eq!(DccName::parse("maya"), DccName::Maya);
+        assert_eq!(DccName::parse("blender"), DccName::Blender);
+        assert_eq!(DccName::parse("houdini"), DccName::Houdini);
+        assert_eq!(DccName::parse("c4d"), DccName::Cinema4d);
+        assert_eq!(DccName::parse("nuke"), DccName::Nuke);
+    }
+
+    #[test]
+    fn parse_is_case_insensitive_and_trims() {
+        assert_eq!(DccName::parse("MAYA"), DccName::Maya);
+        assert_eq!(DccName::parse("  Blender  "), DccName::Blender);
+        assert_eq!(DccName::parse("3DsMax"), DccName::ThreedsMax);
+    }
+
+    #[test]
+    fn unknown_value_becomes_other_with_lowercase() {
+        assert_eq!(DccName::parse("Krita"), DccName::Other("krita".into()));
+        assert!(!DccName::parse("Krita").is_known());
+    }
+
+    #[test]
+    fn round_trip_serde_known_values() {
+        for known in [DccName::Maya, DccName::Blender, DccName::Cinema4d] {
+            let json = serde_json::to_string(&known).unwrap();
+            let back: DccName = serde_json::from_str(&json).unwrap();
+            assert_eq!(known, back);
+            assert_eq!(json, format!("\"{}\"", known.as_str()));
+        }
+    }
+
+    #[test]
+    fn round_trip_serde_other() {
+        let unk = DccName::Other("modo".into());
+        let json = serde_json::to_string(&unk).unwrap();
+        let back: DccName = serde_json::from_str(&json).unwrap();
+        assert_eq!(unk, back);
+    }
+
+    #[test]
+    fn display_uses_as_str() {
+        assert_eq!(DccName::Maya.to_string(), "maya");
+        assert_eq!(DccName::Other("krita".into()).to_string(), "krita");
+    }
+
+    #[test]
+    fn from_str_infallible_returns_other_for_unknown() {
+        let d: DccName = "wibble".parse().unwrap();
+        assert_eq!(d, DccName::Other("wibble".into()));
+    }
+}

--- a/crates/dcc-mcp-models/src/lib.rs
+++ b/crates/dcc-mcp-models/src/lib.rs
@@ -1,6 +1,7 @@
-//! dcc-mcp-models: ActionResultModel, SkillMetadata, SkillScope, DccMcpError.
+//! dcc-mcp-models: ActionResultModel, SkillMetadata, SkillScope, DccMcpError, DccName.
 
 mod action_result;
+mod dcc_name;
 mod error;
 mod skill_metadata;
 pub mod skill_scope;
@@ -10,6 +11,7 @@ mod python;
 
 pub use action_result::ActionResultModel as ToolResult;
 pub use action_result::{ActionResultModel, ActionResultModelData, SerializeFormat};
+pub use dcc_name::DccName;
 pub use error::DccMcpError;
 pub use skill_metadata::{
     ExecutionMode, NextTools, SkillDependencies, SkillDependency, SkillDependencyType, SkillGroup,

--- a/crates/dcc-mcp-skills/src/scanner.rs
+++ b/crates/dcc-mcp-skills/src/scanner.rs
@@ -37,6 +37,23 @@ impl SkillScanner {
         }
     }
 
+    /// Scan all configured paths for Skill packages, taking a typed
+    /// [`dcc_mcp_models::DccName`] (#491).
+    ///
+    /// Thin wrapper around [`Self::scan`] that converts the typed value
+    /// to its canonical lowercase string form before delegating. New
+    /// callers should prefer this entry point so the DCC identifier is
+    /// validated and normalised at the boundary.
+    pub fn scan_for_dcc(
+        &mut self,
+        extra_paths: Option<&[String]>,
+        dcc: Option<&dcc_mcp_models::DccName>,
+        force_refresh: bool,
+    ) -> Vec<String> {
+        let dcc_str = dcc.map(|d| d.as_str());
+        self.scan(extra_paths, dcc_str, force_refresh)
+    }
+
     /// Scan all configured paths for Skill packages.
     pub fn scan(
         &mut self,
@@ -231,6 +248,18 @@ mod tests {
     fn test_scanner_empty() {
         let mut scanner = SkillScanner::new();
         let result = scanner.scan(Some(&["/nonexistent".to_string()]), None, false);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_scan_for_dcc_typed_entry_point() {
+        use dcc_mcp_models::DccName;
+
+        // Typed entry point delegates to scan() with the canonical
+        // lowercase string form (#491).
+        let mut scanner = SkillScanner::new();
+        let dcc = DccName::Maya;
+        let result = scanner.scan_for_dcc(Some(&["/nonexistent".to_string()]), Some(&dcc), false);
         assert!(result.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Replaces stringly-typed `&str` / `String` DCC identifiers with a serde-friendly enum that validates and normalises at the API boundary so internal code can rely on case-stable, exhaustively-matchable variants. Issue #491.

`DccName` covers the seven canonical DCCs (Maya, Blender, Houdini, 3ds Max, Cinema 4D, Photoshop, Nuke) and a forward-compat `Other(String)` variant for anything else. Round-trips through serde and `parse` / `to_string` losslessly. Case-insensitive parsing trims whitespace and lowercases the input.

## First migration target

`SkillScanner` gains a typed entry point:

```rust
pub fn scan_for_dcc(
    &mut self,
    extra_paths: Option<&[String]>,
    dcc: Option<&DccName>,
    force_refresh: bool,
) -> Vec<String>
```

It delegates to the legacy `scan(..., dcc_name: Option<&str>, ...)`. The legacy entry point stays for back-compat (no public-API breakage), but new callers should prefer the typed one so the DCC identifier is validated and normalised at the boundary.

## Acceptance criteria

- [x] New `dcc_mcp_models::DccName` exposed as `pub use dcc_name::DccName`.
- [x] One scanner / catalog entry point migrated to take `DccName` (`SkillScanner::scan_for_dcc`).
- [x] Python-bindings layer still accepts strings unchanged (the typed scanner method is Rust-only; the existing `py_scan_skill_paths` keeps its `Option<String>` signature).
- [x] Round-trip serde test for known + `Other` variants.
- [x] All 60 affected unit tests pass: 7 new on `DccName` (canonical parse, case-insensitive trim, unknown→Other, serde round-trip both shapes, Display, FromStr) + 1 new on the scanner's typed entry point + 52 pre-existing.
- [x] `cargo fmt` + `cargo clippy --all-targets -- -D warnings` clean.

## Note on incremental adoption

`ActionMeta.dcc`, `ToolRegistry::list_actions(dcc_name=)`, and the rest of the workspace still take `&str`. Migrating those touches the wire format and the PyO3 ABI and warrants follow-up PRs. This PR delivers the foundational type plus a clean migration template that future PRs can replicate (rename `_for_dcc` suffix → deprecate string overload → remove string overload one release later).

Closes #491