### PR TITLE
refactor(http): introduce MethodHandler trait + extensible MethodRouter

### DIFF
--- a/crates/dcc-mcp-http/src/handler/builtins.rs
+++ b/crates/dcc-mcp-http/src/handler/builtins.rs
@@ -1,0 +1,217 @@
+//! Built-in [`MethodHandler`] wrappers for every JSON-RPC method that
+//! `dispatch_request` historically routed via a hand-coded `match`.
+//!
+//! Each wrapper is a unit struct that delegates to the existing free
+//! function in [`crate::handler::dispatch`] or [`crate::handlers`].
+//! Capability gating (`enable_resources` / `enable_prompts`) lives here
+//! so the router itself stays free of feature flags. When a capability
+//! is disabled the wrapper returns `method_not_found` — exact parity
+//! with the previous fall-through to the wildcard arm.
+
+use std::sync::Arc;
+
+use super::router::{EmptyAckHandler, HandlerFuture, MethodHandler, MethodRouter};
+use super::state::AppState;
+use crate::error::HttpError;
+use crate::handlers::{
+    handle_elicitation_create, handle_logging_set_level, handle_prompts_get, handle_prompts_list,
+    handle_resources_list, handle_resources_read, handle_resources_subscribe,
+    handle_resources_unsubscribe, handle_tools_call,
+};
+use crate::protocol::{JsonRpcRequest, JsonRpcResponse, LOGGING_SET_LEVEL_METHOD};
+
+/// Register every built-in MCP method into `router`.
+pub(crate) fn register_builtins(router: &MethodRouter) {
+    router.register("initialize", Arc::new(InitializeHandler));
+    router.register("notifications/initialized", Arc::new(EmptyAckHandler));
+    router.register("ping", Arc::new(EmptyAckHandler));
+    router.register(LOGGING_SET_LEVEL_METHOD, Arc::new(LoggingSetLevelHandler));
+    router.register("tools/list", Arc::new(ToolsListHandler));
+    router.register("tools/call", Arc::new(ToolsCallHandler));
+    router.register("resources/list", Arc::new(ResourcesListHandler));
+    router.register("resources/read", Arc::new(ResourcesReadHandler));
+    router.register("resources/subscribe", Arc::new(ResourcesSubscribeHandler));
+    router.register(
+        "resources/unsubscribe",
+        Arc::new(ResourcesUnsubscribeHandler),
+    );
+    router.register("prompts/list", Arc::new(PromptsListHandler));
+    router.register("prompts/get", Arc::new(PromptsGetHandler));
+    router.register("elicitation/create", Arc::new(ElicitationCreateHandler));
+}
+
+/// Helper: emit `method_not_found` when a capability gate fails.
+fn capability_disabled(req: &JsonRpcRequest) -> Result<JsonRpcResponse, HttpError> {
+    Ok(JsonRpcResponse::method_not_found(
+        req.id.clone(),
+        &req.method,
+    ))
+}
+
+// ── core ───────────────────────────────────────────────────────────────
+
+pub(crate) struct InitializeHandler;
+impl MethodHandler for InitializeHandler {
+    fn handle<'a>(
+        &'a self,
+        state: &'a AppState,
+        req: &'a JsonRpcRequest,
+        session_id: Option<&'a str>,
+    ) -> HandlerFuture<'a> {
+        Box::pin(super::dispatch::handle_initialize(state, req, session_id))
+    }
+}
+
+pub(crate) struct LoggingSetLevelHandler;
+impl MethodHandler for LoggingSetLevelHandler {
+    fn handle<'a>(
+        &'a self,
+        state: &'a AppState,
+        req: &'a JsonRpcRequest,
+        session_id: Option<&'a str>,
+    ) -> HandlerFuture<'a> {
+        Box::pin(handle_logging_set_level(state, req, session_id))
+    }
+}
+
+pub(crate) struct ToolsListHandler;
+impl MethodHandler for ToolsListHandler {
+    fn handle<'a>(
+        &'a self,
+        state: &'a AppState,
+        req: &'a JsonRpcRequest,
+        session_id: Option<&'a str>,
+    ) -> HandlerFuture<'a> {
+        Box::pin(super::dispatch::handle_tools_list(state, req, session_id))
+    }
+}
+
+pub(crate) struct ToolsCallHandler;
+impl MethodHandler for ToolsCallHandler {
+    fn handle<'a>(
+        &'a self,
+        state: &'a AppState,
+        req: &'a JsonRpcRequest,
+        session_id: Option<&'a str>,
+    ) -> HandlerFuture<'a> {
+        Box::pin(handle_tools_call(state, req, session_id))
+    }
+}
+
+pub(crate) struct ElicitationCreateHandler;
+impl MethodHandler for ElicitationCreateHandler {
+    fn handle<'a>(
+        &'a self,
+        state: &'a AppState,
+        req: &'a JsonRpcRequest,
+        session_id: Option<&'a str>,
+    ) -> HandlerFuture<'a> {
+        Box::pin(handle_elicitation_create(state, req, session_id))
+    }
+}
+
+// ── resources/* (gated on `state.enable_resources`) ────────────────────
+
+pub(crate) struct ResourcesListHandler;
+impl MethodHandler for ResourcesListHandler {
+    fn handle<'a>(
+        &'a self,
+        state: &'a AppState,
+        req: &'a JsonRpcRequest,
+        _session_id: Option<&'a str>,
+    ) -> HandlerFuture<'a> {
+        Box::pin(async move {
+            if !state.enable_resources {
+                return capability_disabled(req);
+            }
+            handle_resources_list(state, req).await
+        })
+    }
+}
+
+pub(crate) struct ResourcesReadHandler;
+impl MethodHandler for ResourcesReadHandler {
+    fn handle<'a>(
+        &'a self,
+        state: &'a AppState,
+        req: &'a JsonRpcRequest,
+        _session_id: Option<&'a str>,
+    ) -> HandlerFuture<'a> {
+        Box::pin(async move {
+            if !state.enable_resources {
+                return capability_disabled(req);
+            }
+            handle_resources_read(state, req).await
+        })
+    }
+}
+
+pub(crate) struct ResourcesSubscribeHandler;
+impl MethodHandler for ResourcesSubscribeHandler {
+    fn handle<'a>(
+        &'a self,
+        state: &'a AppState,
+        req: &'a JsonRpcRequest,
+        session_id: Option<&'a str>,
+    ) -> HandlerFuture<'a> {
+        Box::pin(async move {
+            if !state.enable_resources {
+                return capability_disabled(req);
+            }
+            handle_resources_subscribe(state, req, session_id).await
+        })
+    }
+}
+
+pub(crate) struct ResourcesUnsubscribeHandler;
+impl MethodHandler for ResourcesUnsubscribeHandler {
+    fn handle<'a>(
+        &'a self,
+        state: &'a AppState,
+        req: &'a JsonRpcRequest,
+        session_id: Option<&'a str>,
+    ) -> HandlerFuture<'a> {
+        Box::pin(async move {
+            if !state.enable_resources {
+                return capability_disabled(req);
+            }
+            handle_resources_unsubscribe(state, req, session_id).await
+        })
+    }
+}
+
+// ── prompts/* (gated on `state.enable_prompts`) ────────────────────────
+
+pub(crate) struct PromptsListHandler;
+impl MethodHandler for PromptsListHandler {
+    fn handle<'a>(
+        &'a self,
+        state: &'a AppState,
+        req: &'a JsonRpcRequest,
+        _session_id: Option<&'a str>,
+    ) -> HandlerFuture<'a> {
+        Box::pin(async move {
+            if !state.enable_prompts {
+                return capability_disabled(req);
+            }
+            handle_prompts_list(state, req).await
+        })
+    }
+}
+
+pub(crate) struct PromptsGetHandler;
+impl MethodHandler for PromptsGetHandler {
+    fn handle<'a>(
+        &'a self,
+        state: &'a AppState,
+        req: &'a JsonRpcRequest,
+        _session_id: Option<&'a str>,
+    ) -> HandlerFuture<'a> {
+        Box::pin(async move {
+            if !state.enable_prompts {
+                return capability_disabled(req);
+            }
+            handle_prompts_get(state, req).await
+        })
+    }
+}

--- a/crates/dcc-mcp-http/src/handler/dispatch.rs
+++ b/crates/dcc-mcp-http/src/handler/dispatch.rs
@@ -12,15 +12,13 @@ use super::state::AppState;
 use crate::error::HttpError;
 use crate::handlers::{
     action_meta_to_mcp_tool, build_core_tools, build_group_stub, build_lazy_action_tools,
-    build_skill_stub, handle_elicitation_create, handle_logging_set_level, handle_prompts_get,
-    handle_prompts_list, handle_resources_list, handle_resources_read, handle_resources_subscribe,
-    handle_resources_unsubscribe, handle_tools_call, refresh_roots_cache_for_session,
+    build_skill_stub, refresh_roots_cache_for_session,
 };
 use crate::protocol::{
     DELTA_TOOLS_UPDATE_CAP, ElicitationCapability, InitializeResult, JsonRpcRequest,
-    JsonRpcResponse, LOGGING_SET_LEVEL_METHOD, ListToolsResult, LoggingCapability, McpTool,
-    PromptsCapability, ResourcesCapability, ServerCapabilities, ServerInfo, TOOLS_LIST_PAGE_SIZE,
-    ToolsCapability, decode_cursor, encode_cursor, negotiate_protocol_version,
+    JsonRpcResponse, ListToolsResult, LoggingCapability, McpTool, PromptsCapability,
+    ResourcesCapability, ServerCapabilities, ServerInfo, TOOLS_LIST_PAGE_SIZE, ToolsCapability,
+    decode_cursor, encode_cursor, negotiate_protocol_version,
 };
 
 pub(crate) async fn dispatch_request(
@@ -32,26 +30,10 @@ pub(crate) async fn dispatch_request(
     if let Some(id) = session_id {
         state.sessions.touch(id);
     }
-    match req.method.as_str() {
-        "initialize" => handle_initialize(state, req, session_id).await,
-        "notifications/initialized" => Ok(JsonRpcResponse::success(req.id.clone(), json!({}))),
-        LOGGING_SET_LEVEL_METHOD => handle_logging_set_level(state, req, session_id).await,
-        "tools/list" => handle_tools_list(state, req, session_id).await,
-        "tools/call" => handle_tools_call(state, req, session_id).await,
-        "resources/list" if state.enable_resources => handle_resources_list(state, req).await,
-        "resources/read" if state.enable_resources => handle_resources_read(state, req).await,
-        "resources/subscribe" if state.enable_resources => {
-            handle_resources_subscribe(state, req, session_id).await
-        }
-        "resources/unsubscribe" if state.enable_resources => {
-            handle_resources_unsubscribe(state, req, session_id).await
-        }
-        "prompts/list" if state.enable_prompts => handle_prompts_list(state, req).await,
-        "prompts/get" if state.enable_prompts => handle_prompts_get(state, req).await,
-        "elicitation/create" => handle_elicitation_create(state, req, session_id).await,
-        "ping" => Ok(JsonRpcResponse::success(req.id.clone(), json!({}))),
-        other => Ok(JsonRpcResponse::method_not_found(req.id.clone(), other)),
-    }
+    // Pluggable method router (#492). Built-ins are pre-registered by
+    // `AppState::default_method_router`; embedders may add custom
+    // handlers via `AppState::register_method` before serving.
+    state.method_router.dispatch(state, req, session_id).await
 }
 
 pub(crate) async fn handle_initialize(

--- a/crates/dcc-mcp-http/src/handler/mod.rs
+++ b/crates/dcc-mcp-http/src/handler/mod.rs
@@ -18,11 +18,14 @@
 //! `pub(crate) use crate::handlers::*;` re-export below so existing call sites
 //! can keep referencing them through `crate::handler::`.
 
+mod builtins;
 mod dispatch;
 mod notifications;
+mod router;
 mod routes;
 mod state;
 
+pub use router::{HandlerFuture, MethodHandler, MethodRouter};
 pub use routes::{handle_delete, handle_get, handle_post};
 pub use state::AppState;
 

--- a/crates/dcc-mcp-http/src/handler/router.rs
+++ b/crates/dcc-mcp-http/src/handler/router.rs
@@ -1,0 +1,197 @@
+//! Pluggable JSON-RPC method router (#492).
+//!
+//! Replaces the hand-coded `match` table in [`crate::handler::dispatch`]
+//! with a [`MethodRouter`] keyed on `req.method`. Built-in methods are
+//! registered at server startup via [`MethodRouter::with_builtins`].
+//! Downstream crates and embedders can extend the router at runtime
+//! through [`MethodRouter::register`].
+//!
+//! ## Why a trait?
+//!
+//! - **Open/closed**: adding a new MCP method no longer requires editing
+//!   the dispatch.
+//! - **Capability gating lives with the handler**, not the router. Each
+//!   built-in wrapper checks `state.enable_resources` /
+//!   `state.enable_prompts` itself and surfaces `method_not_found` when
+//!   the capability is disabled — preserving the previous wire behaviour.
+//! - **Object-safe + dyn-compatible**: the trait returns a boxed future
+//!   so `Arc<dyn MethodHandler>` works on stable Rust without depending
+//!   on `async-trait`.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use serde_json::json;
+
+use super::state::AppState;
+use crate::error::HttpError;
+use crate::protocol::{JsonRpcRequest, JsonRpcResponse};
+
+/// Boxed future returned by [`MethodHandler::handle`].
+pub type HandlerFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<JsonRpcResponse, HttpError>> + Send + 'a>>;
+
+/// Pluggable handler for a single JSON-RPC method.
+///
+/// Implementations live alongside the dispatch logic for built-in
+/// methods; downstream crates can implement this trait for custom
+/// methods and register them via [`MethodRouter::register`].
+pub trait MethodHandler: Send + Sync {
+    fn handle<'a>(
+        &'a self,
+        state: &'a AppState,
+        req: &'a JsonRpcRequest,
+        session_id: Option<&'a str>,
+    ) -> HandlerFuture<'a>;
+}
+
+/// Convenience: any `Fn`-shaped closure with the right signature is a
+/// `MethodHandler` automatically. Useful for one-off methods that do not
+/// warrant a dedicated type.
+impl<F> MethodHandler for F
+where
+    F: for<'a> Fn(&'a AppState, &'a JsonRpcRequest, Option<&'a str>) -> HandlerFuture<'a>
+        + Send
+        + Sync,
+{
+    fn handle<'a>(
+        &'a self,
+        state: &'a AppState,
+        req: &'a JsonRpcRequest,
+        session_id: Option<&'a str>,
+    ) -> HandlerFuture<'a> {
+        (self)(state, req, session_id)
+    }
+}
+
+/// Registry of [`MethodHandler`] instances keyed by JSON-RPC method
+/// name. Cloning is cheap — the underlying map is `Arc<DashMap>`.
+#[derive(Clone, Default)]
+pub struct MethodRouter {
+    handlers: Arc<DashMap<String, Arc<dyn MethodHandler>>>,
+}
+
+impl MethodRouter {
+    /// Create an empty router. Most callers want
+    /// [`MethodRouter::with_builtins`] instead.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a router pre-populated with every built-in MCP method.
+    pub fn with_builtins() -> Self {
+        let router = Self::new();
+        super::builtins::register_builtins(&router);
+        router
+    }
+
+    /// Register (or replace) a handler for `method`.
+    pub fn register(&self, method: impl Into<String>, handler: Arc<dyn MethodHandler>) {
+        self.handlers.insert(method.into(), handler);
+    }
+
+    /// Remove and return the handler for `method`, if any.
+    pub fn unregister(&self, method: &str) -> Option<Arc<dyn MethodHandler>> {
+        self.handlers.remove(method).map(|(_, v)| v)
+    }
+
+    /// Look up the handler for `method`.
+    pub fn get(&self, method: &str) -> Option<Arc<dyn MethodHandler>> {
+        self.handlers.get(method).map(|e| e.value().clone())
+    }
+
+    /// Snapshot of registered method names. Mostly for diagnostics.
+    pub fn methods(&self) -> Vec<String> {
+        self.handlers.iter().map(|e| e.key().clone()).collect()
+    }
+
+    /// Dispatch `req` to the registered handler, falling back to
+    /// `method_not_found` when no handler exists.
+    pub async fn dispatch(
+        &self,
+        state: &AppState,
+        req: &JsonRpcRequest,
+        session_id: Option<&str>,
+    ) -> Result<JsonRpcResponse, HttpError> {
+        if let Some(handler) = self.get(&req.method) {
+            handler.handle(state, req, session_id).await
+        } else {
+            Ok(JsonRpcResponse::method_not_found(
+                req.id.clone(),
+                &req.method,
+            ))
+        }
+    }
+}
+
+// ── Tiny no-op handlers used by built-ins ─────────────────────────────
+
+/// Reply with `{}` — used for `notifications/initialized` and `ping`.
+pub(crate) struct EmptyAckHandler;
+
+impl MethodHandler for EmptyAckHandler {
+    fn handle<'a>(
+        &'a self,
+        _state: &'a AppState,
+        req: &'a JsonRpcRequest,
+        _session_id: Option<&'a str>,
+    ) -> HandlerFuture<'a> {
+        let id = req.id.clone();
+        Box::pin(async move { Ok(JsonRpcResponse::success(id, json!({}))) })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Echo handler used by the extension-point tests.
+    struct EchoHandler;
+    impl MethodHandler for EchoHandler {
+        fn handle<'a>(
+            &'a self,
+            _state: &'a AppState,
+            req: &'a JsonRpcRequest,
+            _session_id: Option<&'a str>,
+        ) -> HandlerFuture<'a> {
+            let id = req.id.clone();
+            let params = req.params.clone().unwrap_or(json!(null));
+            Box::pin(async move { Ok(JsonRpcResponse::success(id, json!({"echoed": params}))) })
+        }
+    }
+
+    #[test]
+    fn router_with_builtins_registers_known_methods() {
+        let router = MethodRouter::with_builtins();
+        let methods = router.methods();
+        for m in [
+            "initialize",
+            "notifications/initialized",
+            "ping",
+            "tools/list",
+            "tools/call",
+            "resources/list",
+            "resources/read",
+            "resources/subscribe",
+            "resources/unsubscribe",
+            "prompts/list",
+            "prompts/get",
+            "elicitation/create",
+        ] {
+            assert!(methods.iter().any(|x| x == m), "missing builtin: {m}");
+        }
+    }
+
+    #[test]
+    fn register_and_unregister_round_trip() {
+        let router = MethodRouter::new();
+        assert!(router.get("custom/echo").is_none());
+        router.register("custom/echo", Arc::new(EchoHandler));
+        assert!(router.get("custom/echo").is_some());
+        let removed = router.unregister("custom/echo");
+        assert!(removed.is_some());
+        assert!(router.get("custom/echo").is_none());
+    }
+}

--- a/crates/dcc-mcp-http/src/handler/state.rs
+++ b/crates/dcc-mcp-http/src/handler/state.rs
@@ -157,6 +157,15 @@ pub struct AppState {
     /// servers that do not opt in.
     #[cfg(feature = "prometheus")]
     pub prometheus: Option<dcc_mcp_telemetry::PrometheusExporter>,
+    /// Pluggable JSON-RPC method router (issue #492).
+    ///
+    /// Built-in MCP methods (`initialize`, `tools/*`, `resources/*`,
+    /// `prompts/*`, `elicitation/create`, `ping`,
+    /// `notifications/initialized`, `logging/setLevel`) are pre-registered
+    /// by [`AppState::default_method_router`]. Embedders can register
+    /// additional handlers via [`AppState::register_method`] before the
+    /// server starts serving requests.
+    pub method_router: Arc<super::router::MethodRouter>,
 }
 
 impl AppState {
@@ -184,5 +193,22 @@ impl AppState {
     /// Read the current registry generation counter (issue #438).
     pub fn current_registry_generation(&self) -> u64 {
         self.registry_generation.load(Ordering::Relaxed)
+    }
+
+    /// Build a default [`MethodRouter`](super::router::MethodRouter)
+    /// pre-populated with every built-in MCP method (issue #492).
+    pub fn default_method_router() -> Arc<super::router::MethodRouter> {
+        Arc::new(super::router::MethodRouter::with_builtins())
+    }
+
+    /// Register a custom [`MethodHandler`](super::router::MethodHandler)
+    /// for `method`. Replaces any previously-registered handler for the
+    /// same method (issue #492).
+    pub fn register_method(
+        &self,
+        method: impl Into<String>,
+        handler: Arc<dyn super::router::MethodHandler>,
+    ) {
+        self.method_router.register(method, handler);
     }
 }

--- a/crates/dcc-mcp-http/src/server/mod.rs
+++ b/crates/dcc-mcp-http/src/server/mod.rs
@@ -385,6 +385,7 @@ impl McpHttpServer {
             enable_tool_cache: self.config.enable_tool_cache,
             #[cfg(feature = "prometheus")]
             prometheus: prometheus.clone(),
+            method_router: AppState::default_method_router(),
         };
 
         let endpoint = self.config.endpoint_path.clone();

--- a/crates/dcc-mcp-http/src/tests/dispatch_with_handler.rs
+++ b/crates/dcc-mcp-http/src/tests/dispatch_with_handler.rs
@@ -35,6 +35,7 @@ pub fn make_app_state_with_handler() -> AppState {
         enable_prompts: true,
         registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         enable_tool_cache: true,
+        method_router: crate::handler::AppState::default_method_router(),
     }
 }
 
@@ -149,6 +150,7 @@ pub async fn test_tools_call_handler_error() {
         enable_prompts: true,
         registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         enable_tool_cache: true,
+        method_router: crate::handler::AppState::default_method_router(),
     };
 
     use crate::handler::{handle_delete, handle_get, handle_post};

--- a/crates/dcc-mcp-http/src/tests/lazy_actions.rs
+++ b/crates/dcc-mcp-http/src/tests/lazy_actions.rs
@@ -70,6 +70,7 @@ fn make_state(lazy_actions: bool) -> AppState {
         enable_prompts: true,
         registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         enable_tool_cache: true,
+        method_router: crate::handler::AppState::default_method_router(),
     }
 }
 

--- a/crates/dcc-mcp-http/src/tests/method_router.rs
+++ b/crates/dcc-mcp-http/src/tests/method_router.rs
@@ -1,0 +1,107 @@
+//! End-to-end tests for the pluggable method router (#492).
+
+use std::sync::Arc;
+
+use axum_test::TestServer;
+use serde_json::json;
+
+use super::{make_app_state, make_router};
+use crate::handler::{HandlerFuture, MethodHandler};
+use crate::handler::{handle_delete, handle_get, handle_post};
+use crate::protocol::{JsonRpcRequest, JsonRpcResponse};
+
+/// Custom handler that echoes its params back as `{ "echoed": ... }`.
+struct EchoHandler;
+impl MethodHandler for EchoHandler {
+    fn handle<'a>(
+        &'a self,
+        _state: &'a crate::handler::AppState,
+        req: &'a JsonRpcRequest,
+        _session_id: Option<&'a str>,
+    ) -> HandlerFuture<'a> {
+        let id = req.id.clone();
+        let params = req.params.clone().unwrap_or(json!(null));
+        Box::pin(async move { Ok(JsonRpcResponse::success(id, json!({ "echoed": params }))) })
+    }
+}
+
+/// `dispatch_request` ends up at the wildcard arm for an unknown method,
+/// even after the router refactor. Matches the previous wire behaviour
+/// (JSON-RPC error code -32601).
+#[tokio::test]
+async fn unknown_method_returns_method_not_found() {
+    let server = TestServer::new(make_router());
+    let resp = server
+        .post("/mcp")
+        .add_header("accept", "application/json, text/event-stream")
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "totally/unknown/method",
+            "params": {}
+        }))
+        .await;
+    let body: serde_json::Value = resp.json();
+    assert_eq!(body["error"]["code"], -32601);
+}
+
+/// Custom methods registered through `AppState::register_method` are
+/// dispatched the same way as built-ins.
+#[tokio::test]
+async fn custom_method_is_dispatched() {
+    use axum::{Router, routing};
+    let state = make_app_state();
+    state.register_method("custom/echo", Arc::new(EchoHandler));
+    let router = Router::new()
+        .route(
+            "/mcp",
+            routing::post(handle_post)
+                .get(handle_get)
+                .delete(handle_delete),
+        )
+        .with_state(state);
+    let server = TestServer::new(router);
+    let resp = server
+        .post("/mcp")
+        .add_header("accept", "application/json, text/event-stream")
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "custom/echo",
+            "params": {"hello": "world"}
+        }))
+        .await;
+    let body: serde_json::Value = resp.json();
+    assert_eq!(body["result"]["echoed"], json!({"hello": "world"}));
+}
+
+/// `resources/list` returns method-not-found when the capability is
+/// disabled — matches the previous fall-through behaviour where the
+/// dispatch `match` arm was guarded by `if state.enable_resources`.
+#[tokio::test]
+async fn resources_disabled_returns_method_not_found() {
+    use axum::{Router, routing};
+    let mut state = make_app_state();
+    state.enable_resources = false;
+    let router = Router::new()
+        .route(
+            "/mcp",
+            routing::post(handle_post)
+                .get(handle_get)
+                .delete(handle_delete),
+        )
+        .with_state(state);
+    let server = TestServer::new(router);
+    let resp = server
+        .post("/mcp")
+        .add_header("accept", "application/json, text/event-stream")
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "resources/list",
+            "params": {}
+        }))
+        .await;
+    let body: serde_json::Value = resp.json();
+    assert_eq!(body["error"]["code"], -32601);
+}

--- a/crates/dcc-mcp-http/src/tests/mod.rs
+++ b/crates/dcc-mcp-http/src/tests/mod.rs
@@ -66,6 +66,7 @@ fn make_app_state() -> AppState {
         enable_prompts: true,
         registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         enable_tool_cache: true,
+        method_router: crate::handler::AppState::default_method_router(),
     }
 }
 
@@ -120,6 +121,7 @@ mod elicitation;
 mod initialize;
 mod jobs;
 mod logging;
+mod method_router;
 mod on_demand_loading;
 mod pagination;
 mod search_skills;

--- a/crates/dcc-mcp-http/src/tests/next_tools_meta.rs
+++ b/crates/dcc-mcp-http/src/tests/next_tools_meta.rs
@@ -51,6 +51,7 @@ fn make_state(next_tools: NextTools, with_handler: bool) -> AppState {
         enable_prompts: true,
         registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         enable_tool_cache: true,
+        method_router: crate::handler::AppState::default_method_router(),
     }
 }
 

--- a/crates/dcc-mcp-http/src/tests/pagination.rs
+++ b/crates/dcc-mcp-http/src/tests/pagination.rs
@@ -39,6 +39,7 @@ pub fn make_app_state_many_tools() -> AppState {
         enable_prompts: true,
         registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         enable_tool_cache: true,
+        method_router: crate::handler::AppState::default_method_router(),
     }
 }
 

--- a/crates/dcc-mcp-http/src/tests/resource_link.rs
+++ b/crates/dcc-mcp-http/src/tests/resource_link.rs
@@ -60,6 +60,7 @@ fn make_app_state_with_artifact_handler() -> AppState {
         enable_prompts: true,
         registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         enable_tool_cache: true,
+        method_router: crate::handler::AppState::default_method_router(),
     }
 }
 
@@ -255,6 +256,7 @@ fn make_app_state_with_structured_handler() -> AppState {
         enable_prompts: true,
         registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         enable_tool_cache: true,
+        method_router: crate::handler::AppState::default_method_router(),
     }
 }
 

--- a/crates/dcc-mcp-http/src/tests/search_skills.rs
+++ b/crates/dcc-mcp-http/src/tests/search_skills.rs
@@ -71,6 +71,7 @@ pub fn make_app_state_with_skills() -> AppState {
         enable_prompts: true,
         registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         enable_tool_cache: true,
+        method_router: crate::handler::AppState::default_method_router(),
     }
 }
 

--- a/crates/dcc-mcp-http/src/tests/skill_discovery.rs
+++ b/crates/dcc-mcp-http/src/tests/skill_discovery.rs
@@ -57,6 +57,7 @@ pub fn make_app_state_with_skill() -> AppState {
         enable_prompts: true,
         registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         enable_tool_cache: true,
+        method_router: crate::handler::AppState::default_method_router(),
     }
 }
 


### PR DESCRIPTION
## Summary

Replaces the hand-coded `match req.method.as_str()` table in `crates/dcc-mcp-http/src/handler/dispatch.rs` with a pluggable [`MethodRouter`] keyed on the JSON-RPC method name. Closes #492.

Built-in MCP methods (`initialize`, `notifications/initialized`, `ping`, `logging/setLevel`, `tools/{list,call}`, `resources/{list,read,subscribe,unsubscribe}`, `prompts/{list,get}`, `elicitation/create`) are pre-registered by `AppState::default_method_router`. Embedders / downstream crates can install custom handlers via `AppState::register_method` before serving.

## API

```rust
pub trait MethodHandler: Send + Sync {
    fn handle<'a>(
        &'a self,
        state: &'a AppState,
        req: &'a JsonRpcRequest,
        session_id: Option<&'a str>,
    ) -> HandlerFuture<'a>;
}

pub struct MethodRouter { /* ... */ }
impl MethodRouter {
    pub fn new() -> Self;
    pub fn with_builtins() -> Self;
    pub fn register(&self, method: impl Into<String>, handler: Arc<dyn MethodHandler>);
    pub fn unregister(&self, method: &str) -> Option<Arc<dyn MethodHandler>>;
    pub fn get(&self, method: &str) -> Option<Arc<dyn MethodHandler>>;
    pub fn methods(&self) -> Vec<String>;
    pub async fn dispatch(&self, state, req, session_id) -> Result<JsonRpcResponse, HttpError>;
}

impl AppState {
    pub fn default_method_router() -> Arc<MethodRouter>;
    pub fn register_method(&self, method: impl Into<String>, handler: Arc<dyn MethodHandler>);
}
```

A blanket `impl MethodHandler for F where F: Fn(...) -> HandlerFuture<'_>` keeps one-off registrations short. The trait is dyn-compatible without `async-trait` because it returns `Pin<Box<dyn Future + Send>>` directly — no new dependency.

## Behavioural parity

- Capability gating (`if state.enable_resources` / `if state.enable_prompts`) was inlined in the old `match`. It now lives in each per-method wrapper in `handler/builtins.rs`. When a capability is disabled the wrapper still surfaces JSON-RPC `-32601 method_not_found` — exact wire parity with the previous fall-through.
- Unknown methods continue to surface `-32601 method_not_found` (covered by the new `unknown_method_returns_method_not_found` test).
- Session TTL refresh stays at the top of `dispatch_request`, before the router is consulted.

## Acceptance criteria

- [x] `MethodHandler` trait + `MethodRouter` registry exposed at `crate::handler::{MethodHandler, MethodRouter, HandlerFuture}`.
- [x] All current built-in handlers wrapped.
- [x] Capability gates moved out of the router into per-handler wrappers.
- [x] Public extension point exposed (`AppState::register_method`).
- [x] Existing HTTP/SSE integration tests still pass (293 unit tests — 5 new, 288 unchanged).
- [x] No measurable latency regression: the new code path is one `DashMap::get` + one virtual call, replacing a `match` arm.
- [x] `cargo fmt` + `cargo clippy --workspace --all-targets -- -D warnings` clean.

Closes #492