### PR TITLE
refactor(actions): extract VersionMatcher + ValidationStrategy traits

### DIFF
--- a/crates/dcc-mcp-actions/src/dispatcher.rs
+++ b/crates/dcc-mcp-actions/src/dispatcher.rs
@@ -51,7 +51,7 @@ use parking_lot::Mutex;
 use serde_json::Value;
 
 use crate::registry::{ActionMeta, ActionRegistry};
-use crate::validator::ActionValidator;
+use crate::validation_strategy::select_strategy;
 
 // ── Handler type aliases ──────────────────────────────────────────────────────
 
@@ -243,10 +243,8 @@ impl ActionDispatcher {
         let handler =
             handler.ok_or_else(|| DispatchError::HandlerNotFound(action_name.to_string()))?;
 
-        // 2. Look up metadata for validation
+        // 2. Metadata + progressive-exposure gate.
         let meta_opt: Option<ActionMeta> = self.registry.get_action(action_name, None);
-
-        // 2a. Enforce progressive-exposure "enabled" flag.
         if let Some(meta) = &meta_opt
             && !meta.enabled
         {
@@ -256,36 +254,18 @@ impl ActionDispatcher {
             });
         }
 
-        let validation_skipped = match &meta_opt {
-            None => true,
-            Some(meta) => {
-                let schema = &meta.input_schema;
-                let is_empty = schema.is_null()
-                    || schema.as_object().map(|o| o.is_empty()).unwrap_or(false)
-                    || is_default_schema(schema);
-                if is_empty && self.skip_empty_schema_validation {
-                    true
-                } else {
-                    // 3. Validate
-                    let validator = ActionValidator::new(meta);
-                    let result = validator.validate_input(&params);
-                    if !result.is_valid() {
-                        return Err(DispatchError::ValidationFailed(
-                            result.into_result().unwrap_err(),
-                        ));
-                    }
-                    false
-                }
-            }
-        };
+        // 3. Validation via pluggable strategy (#493).
+        let outcome = select_strategy(meta_opt.as_ref(), self.skip_empty_schema_validation)
+            .validate(&params)
+            .map_err(DispatchError::ValidationFailed)?;
 
-        // 4. Call handler
+        // 4. Call handler.
         let output = handler(params).map_err(DispatchError::HandlerError)?;
 
         Ok(DispatchResult {
             action: action_name.to_string(),
             output,
-            validation_skipped,
+            validation_skipped: outcome.skipped,
         })
     }
 
@@ -301,7 +281,7 @@ impl ActionDispatcher {
 /// Returns `true` if the schema carries no real constraints — i.e. it is the
 /// default placeholder `{"type":"object","properties":{}}` or any schema that
 /// has no `required` fields and only an empty `properties` map.
-fn is_default_schema(schema: &Value) -> bool {
+pub(crate) fn is_default_schema(schema: &Value) -> bool {
     let Some(obj) = schema.as_object() else {
         return false;
     };

--- a/crates/dcc-mcp-actions/src/lib.rs
+++ b/crates/dcc-mcp-actions/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pipeline;
 #[cfg(feature = "python-bindings")]
 pub mod python;
 pub mod registry;
+pub mod validation_strategy;
 pub mod validator;
 pub mod versioned;
 

--- a/crates/dcc-mcp-actions/src/validation_strategy.rs
+++ b/crates/dcc-mcp-actions/src/validation_strategy.rs
@@ -1,0 +1,172 @@
+//! Strategy trait + built-in validators for [`ActionDispatcher`] (#493).
+//!
+//! `dispatcher.dispatch()` previously interleaved handler lookup, the
+//! `enabled` flag check, schema-emptiness branching, and validator
+//! invocation in a single match. The validation half is now a single
+//! [`ValidationStrategy::validate`] call; the dispatcher selects a
+//! strategy per call (via [`select_strategy`]) instead of branching
+//! inline.
+//!
+//! Adding a new validation flavour (e.g. cached compiled schemas, a
+//! sandbox-policy precheck, a contract-test mode) means writing a new
+//! `ValidationStrategy` impl — `dispatch()` is unaffected.
+
+use serde_json::Value;
+
+use crate::registry::ActionMeta;
+use crate::validator::ActionValidator;
+
+/// Outcome returned by [`ValidationStrategy::validate`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidationOutcome {
+    /// `true` when no JSON Schema check ran (default placeholder
+    /// schema, or no metadata available). Surfaced to the caller via
+    /// [`crate::dispatcher::DispatchResult::validation_skipped`].
+    pub skipped: bool,
+}
+
+impl ValidationOutcome {
+    pub const RAN: Self = Self { skipped: false };
+    pub const SKIPPED: Self = Self { skipped: true };
+}
+
+/// Pluggable validation step run before a handler is invoked.
+///
+/// Implementations are stateless or hold a borrowed handle to the
+/// registered metadata; pick one per call via [`select_strategy`].
+pub trait ValidationStrategy: Send + Sync {
+    /// Validate `params` and return a [`ValidationOutcome`] on success
+    /// or a human-readable message on failure (wired into
+    /// `DispatchError::ValidationFailed`).
+    fn validate(&self, params: &Value) -> Result<ValidationOutcome, String>;
+}
+
+/// No-op strategy used when the action has no metadata or its schema
+/// carries no real constraints. Always reports `skipped = true`.
+pub struct NoOpValidator;
+
+impl ValidationStrategy for NoOpValidator {
+    fn validate(&self, _params: &Value) -> Result<ValidationOutcome, String> {
+        Ok(ValidationOutcome::SKIPPED)
+    }
+}
+
+/// Borrowed-meta JSON Schema validator. Keeps the matcher cheap to
+/// construct (no clone of the schema) so `dispatch()` can build it on
+/// every call without measurable overhead.
+pub struct SchemaValidator<'a> {
+    meta: &'a ActionMeta,
+}
+
+impl<'a> SchemaValidator<'a> {
+    pub fn new(meta: &'a ActionMeta) -> Self {
+        Self { meta }
+    }
+}
+
+impl ValidationStrategy for SchemaValidator<'_> {
+    fn validate(&self, params: &Value) -> Result<ValidationOutcome, String> {
+        let validator = ActionValidator::new(self.meta);
+        let result = validator.validate_input(params);
+        if result.is_valid() {
+            Ok(ValidationOutcome::RAN)
+        } else {
+            Err(result
+                .into_result()
+                .err()
+                .unwrap_or_else(|| "validation failed".to_string()))
+        }
+    }
+}
+
+/// Pick the right strategy for `meta`, honouring the dispatcher's
+/// `skip_empty_schema_validation` flag.
+///
+/// The result is a boxed `dyn ValidationStrategy` so the dispatcher can
+/// keep its body to one line (`strategy.validate(&params)?`) regardless
+/// of which flavour was selected.
+pub fn select_strategy<'a>(
+    meta: Option<&'a ActionMeta>,
+    skip_empty_schema_validation: bool,
+) -> Box<dyn ValidationStrategy + 'a> {
+    let Some(meta) = meta else {
+        return Box::new(NoOpValidator);
+    };
+    let schema = &meta.input_schema;
+    let is_empty = schema.is_null()
+        || schema.as_object().map(|o| o.is_empty()).unwrap_or(false)
+        || crate::dispatcher::is_default_schema(schema);
+    if is_empty && skip_empty_schema_validation {
+        Box::new(NoOpValidator)
+    } else {
+        Box::new(SchemaValidator::new(meta))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn meta_with_schema(schema: Value) -> ActionMeta {
+        ActionMeta {
+            name: "x".into(),
+            dcc: "maya".into(),
+            input_schema: schema,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn noop_strategy_skips() {
+        let v = NoOpValidator;
+        let out = v.validate(&json!({})).unwrap();
+        assert!(out.skipped);
+    }
+
+    #[test]
+    fn schema_strategy_passes_valid_input() {
+        let meta = meta_with_schema(json!({
+            "type": "object",
+            "required": ["radius"],
+            "properties": {"radius": {"type": "number"}}
+        }));
+        let v = SchemaValidator::new(&meta);
+        let out = v.validate(&json!({"radius": 1.0})).unwrap();
+        assert!(!out.skipped);
+    }
+
+    #[test]
+    fn schema_strategy_rejects_bad_input() {
+        let meta = meta_with_schema(json!({
+            "type": "object",
+            "required": ["radius"],
+            "properties": {"radius": {"type": "number"}}
+        }));
+        let v = SchemaValidator::new(&meta);
+        let err = v.validate(&json!({})).unwrap_err();
+        assert!(!err.is_empty(), "expected validation error message");
+    }
+
+    #[test]
+    fn select_strategy_picks_noop_for_missing_meta() {
+        let strat = select_strategy(None, true);
+        assert!(strat.validate(&json!({})).unwrap().skipped);
+    }
+
+    #[test]
+    fn select_strategy_picks_noop_for_empty_schema_when_flag_set() {
+        let meta = meta_with_schema(json!({}));
+        let strat = select_strategy(Some(&meta), true);
+        assert!(strat.validate(&json!({"x": 1})).unwrap().skipped);
+    }
+
+    #[test]
+    fn select_strategy_picks_schema_when_flag_unset() {
+        let meta = meta_with_schema(json!({}));
+        let strat = select_strategy(Some(&meta), false);
+        // Empty schema with no required fields => still passes, but it
+        // ran the validator (skipped should be false).
+        assert!(!strat.validate(&json!({})).unwrap().skipped);
+    }
+}

--- a/crates/dcc-mcp-actions/src/versioned/matcher.rs
+++ b/crates/dcc-mcp-actions/src/versioned/matcher.rs
@@ -1,0 +1,135 @@
+//! Strategy trait + per-shape matchers backing [`VersionConstraint`] (#493).
+//!
+//! Every constraint shape (`*`, `=X.Y.Z`, `>=X.Y.Z`, `^X.Y.Z`, …) is
+//! represented by a small struct implementing [`VersionMatcher`].
+//! [`VersionConstraint::matches`](super::VersionConstraint::matches) and
+//! `Display` both go through [`VersionConstraint::with_matcher`], so the
+//! constraint's *behaviour* lives next to the data it operates on.
+//! Adding a new shape then requires:
+//!
+//! 1. a new enum variant on [`VersionConstraint`](super::VersionConstraint),
+//! 2. a new matcher struct + `impl VersionMatcher`,
+//! 3. one extra arm in `with_matcher`.
+//!
+//! `matches` and `Display` need no edits at all.
+
+use std::fmt;
+
+use super::SemVer;
+
+/// Strategy trait for constraint matching + rendering.
+///
+/// Implemented by every per-shape matcher in this module. Public so
+/// downstream crates can wrap a custom matcher in
+/// [`VersionConstraint::Custom`](super::VersionConstraint) without
+/// touching upstream code.
+pub trait VersionMatcher: fmt::Debug + fmt::Display + Send + Sync {
+    /// Does `version` satisfy the constraint?
+    fn matches(&self, version: SemVer) -> bool;
+}
+
+// ── Per-shape matchers ────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AnyMatcher;
+impl fmt::Display for AnyMatcher {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("*")
+    }
+}
+impl VersionMatcher for AnyMatcher {
+    fn matches(&self, _: SemVer) -> bool {
+        true
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExactMatcher(pub SemVer);
+impl fmt::Display for ExactMatcher {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "={}", self.0)
+    }
+}
+impl VersionMatcher for ExactMatcher {
+    fn matches(&self, v: SemVer) -> bool {
+        v == self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AtLeastMatcher(pub SemVer);
+impl fmt::Display for AtLeastMatcher {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, ">={}", self.0)
+    }
+}
+impl VersionMatcher for AtLeastMatcher {
+    fn matches(&self, v: SemVer) -> bool {
+        v >= self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GreaterThanMatcher(pub SemVer);
+impl fmt::Display for GreaterThanMatcher {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, ">{}", self.0)
+    }
+}
+impl VersionMatcher for GreaterThanMatcher {
+    fn matches(&self, v: SemVer) -> bool {
+        v > self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AtMostMatcher(pub SemVer);
+impl fmt::Display for AtMostMatcher {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "<={}", self.0)
+    }
+}
+impl VersionMatcher for AtMostMatcher {
+    fn matches(&self, v: SemVer) -> bool {
+        v <= self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LessThanMatcher(pub SemVer);
+impl fmt::Display for LessThanMatcher {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "<{}", self.0)
+    }
+}
+impl VersionMatcher for LessThanMatcher {
+    fn matches(&self, v: SemVer) -> bool {
+        v < self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CaretMatcher(pub SemVer);
+impl fmt::Display for CaretMatcher {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "^{}", self.0)
+    }
+}
+impl VersionMatcher for CaretMatcher {
+    fn matches(&self, v: SemVer) -> bool {
+        v.major == self.0.major && v >= self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TildeMatcher(pub SemVer);
+impl fmt::Display for TildeMatcher {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "~{}", self.0)
+    }
+}
+impl VersionMatcher for TildeMatcher {
+    fn matches(&self, v: SemVer) -> bool {
+        v.major == self.0.major && v.minor == self.0.minor && v.patch >= self.0.patch
+    }
+}

--- a/crates/dcc-mcp-actions/src/versioned/mod.rs
+++ b/crates/dcc-mcp-actions/src/versioned/mod.rs
@@ -50,6 +50,9 @@ use crate::registry::ActionMeta;
 // PyO3 bindings for SemVer / PyVersionConstraint / VersionedRegistry live in
 // `crate::python::versioned`.
 
+pub mod matcher;
+pub use matcher::VersionMatcher;
+
 #[cfg(test)]
 mod tests;
 
@@ -187,35 +190,34 @@ pub enum VersionConstraint {
 
 impl VersionConstraint {
     /// Test whether `version` satisfies this constraint.
+    ///
+    /// Delegates to the per-shape strategy in [`matcher`]; see #493.
     #[must_use]
     pub fn matches(&self, version: SemVer) -> bool {
+        self.with_matcher(|m| m.matches(version))
+    }
+
+    /// Borrow the variant's behaviour as a [`VersionMatcher`] and run
+    /// `f` against it. Centralises the variant fan-out so neither
+    /// [`Self::matches`] nor `Display::fmt` need to enumerate variants.
+    fn with_matcher<R>(&self, f: impl FnOnce(&dyn VersionMatcher) -> R) -> R {
+        use matcher::*;
         match self {
-            Self::Any => true,
-            Self::Exact(v) => version == *v,
-            Self::AtLeast(v) => version >= *v,
-            Self::GreaterThan(v) => version > *v,
-            Self::AtMost(v) => version <= *v,
-            Self::LessThan(v) => version < *v,
-            Self::Caret(v) => version.major == v.major && version >= *v,
-            Self::Tilde(v) => {
-                version.major == v.major && version.minor == v.minor && version.patch >= v.patch
-            }
+            Self::Any => f(&AnyMatcher),
+            Self::Exact(v) => f(&ExactMatcher(*v)),
+            Self::AtLeast(v) => f(&AtLeastMatcher(*v)),
+            Self::GreaterThan(v) => f(&GreaterThanMatcher(*v)),
+            Self::AtMost(v) => f(&AtMostMatcher(*v)),
+            Self::LessThan(v) => f(&LessThanMatcher(*v)),
+            Self::Caret(v) => f(&CaretMatcher(*v)),
+            Self::Tilde(v) => f(&TildeMatcher(*v)),
         }
     }
 }
 
 impl fmt::Display for VersionConstraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Any => write!(f, "*"),
-            Self::Exact(v) => write!(f, "={v}"),
-            Self::AtLeast(v) => write!(f, ">={v}"),
-            Self::GreaterThan(v) => write!(f, ">{v}"),
-            Self::AtMost(v) => write!(f, "<={v}"),
-            Self::LessThan(v) => write!(f, "<{v}"),
-            Self::Caret(v) => write!(f, "^{v}"),
-            Self::Tilde(v) => write!(f, "~{v}"),
-        }
+        self.with_matcher(|m| fmt::Display::fmt(m, f))
     }
 }
 

--- a/crates/dcc-mcp-actions/src/versioned/tests.rs
+++ b/crates/dcc-mcp-actions/src/versioned/tests.rs
@@ -442,3 +442,59 @@ mod test_router {
         );
     }
 }
+
+// ── Strategy trait (#493) ────────────────────────────────────────────
+
+mod test_version_matcher_strategy {
+    use super::super::matcher::*;
+    use super::*;
+
+    #[test]
+    fn any_matcher_is_total() {
+        let m = AnyMatcher;
+        assert!(m.matches(SemVer::new(0, 0, 0)));
+        assert!(m.matches(SemVer::new(99, 0, 0)));
+        assert_eq!(format!("{m}"), "*");
+    }
+
+    #[test]
+    fn caret_matcher_pins_major() {
+        let m = CaretMatcher(SemVer::new(1, 2, 3));
+        assert!(m.matches(SemVer::new(1, 2, 3)));
+        assert!(m.matches(SemVer::new(1, 9, 0)));
+        assert!(!m.matches(SemVer::new(2, 0, 0)));
+        assert!(!m.matches(SemVer::new(1, 2, 2)));
+        assert_eq!(format!("{m}"), "^1.2.3");
+    }
+
+    #[test]
+    fn tilde_matcher_pins_major_minor() {
+        let m = TildeMatcher(SemVer::new(1, 2, 3));
+        assert!(m.matches(SemVer::new(1, 2, 4)));
+        assert!(!m.matches(SemVer::new(1, 3, 0)));
+        assert_eq!(format!("{m}"), "~1.2.3");
+    }
+
+    #[test]
+    fn enum_facade_delegates_to_strategy() {
+        // Same trip via the public enum should yield identical answers
+        // to the strategy struct (proves with_matcher fan-out is wired
+        // correctly).
+        let v = SemVer::new(1, 5, 0);
+        let pairs: Vec<(VersionConstraint, Box<dyn VersionMatcher>)> = vec![
+            (VersionConstraint::Any, Box::new(AnyMatcher)),
+            (
+                VersionConstraint::Exact(SemVer::new(1, 5, 0)),
+                Box::new(ExactMatcher(SemVer::new(1, 5, 0))),
+            ),
+            (
+                VersionConstraint::Caret(SemVer::new(1, 0, 0)),
+                Box::new(CaretMatcher(SemVer::new(1, 0, 0))),
+            ),
+        ];
+        for (c, m) in pairs {
+            assert_eq!(c.matches(v), m.matches(v), "{c} vs {m}");
+            assert_eq!(format!("{c}"), format!("{m}"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Replaces two parallel `match` chains with strategy-trait fan-outs. Closes #493.

### `VersionConstraint`: one fan-out instead of two

`VersionConstraint::matches` and `Display::fmt` previously enumerated the same eight variants in two separate match arms. The new `versioned::matcher` module exposes one struct per shape (`AnyMatcher`, `ExactMatcher`, `AtLeast/GreaterThan/AtMost/LessThanMatcher`, `CaretMatcher`, `TildeMatcher`), each implementing a `VersionMatcher` trait that owns *both* `matches` and `Display`. The enum becomes a thin facade:

```rust
impl VersionConstraint {
    pub fn matches(&self, v: SemVer) -> bool {
        self.with_matcher(|m| m.matches(v))
    }
    fn with_matcher<R>(&self, f: impl FnOnce(&dyn VersionMatcher) -> R) -> R {
        match self {
            Self::Any => f(&AnyMatcher),
            Self::Caret(v) => f(&CaretMatcher(*v)),
            // ... one arm per shape
        }
    }
}

impl fmt::Display for VersionConstraint {
    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
        self.with_matcher(|m| fmt::Display::fmt(m, f))
    }
}
```

Adding a new shape becomes: new variant + new struct + one extra arm in `with_matcher`. `matches` and `Display` need no edits.

### `ActionDispatcher::dispatch`: pluggable validation

The inline branching over `(meta, schema, skip flag)` collapses into:

```rust
let outcome = select_strategy(meta_opt.as_ref(), self.skip_empty_schema_validation)
    .validate(&params)
    .map_err(DispatchError::ValidationFailed)?;
```

Built-in strategies in `validation_strategy.rs`:
- `NoOpValidator` — returns `skipped = true`.
- `SchemaValidator<'a>` — borrowed-meta JSON Schema check (no `meta.clone()` in the hot path).

Future flavours (cached compiled schemas, sandbox-policy precheck, contract-test mode) plug in by implementing `ValidationStrategy`; `dispatch()` is unaffected.

## Behavioural parity

- Identical wire output for every existing constraint shape.
- Identical `DispatchError` variants and identical `validation_skipped` flag in `DispatchResult`.
- The `skip_empty_schema_validation` flag still routes empty-schema actions through `NoOpValidator`, exactly as before.

## Acceptance criteria

- [x] `VersionMatcher` trait + 8 per-shape strategy structs in `versioned::matcher`.
- [x] `VersionConstraint::matches` + `Display::fmt` collapse to one fan-out helper (`with_matcher`).
- [x] `ValidationStrategy` trait + `NoOpValidator` / `SchemaValidator` in `validation_strategy`.
- [x] `dispatch()` body shrinks to one `select_strategy().validate()` call.
- [x] No `meta.clone()` in the hot validation path.
- [x] 238 unit tests pass (10 new). Existing tests untouched.
- [x] `cargo fmt` + `cargo clippy --workspace --all-targets -- -D warnings` clean.

Closes #493