### PR TITLE
refactor(core): extract Registry<V> trait to unify Action/Skill/Workflow catalogs

### DIFF
--- a/crates/dcc-mcp-actions/Cargo.toml
+++ b/crates/dcc-mcp-actions/Cargo.toml
@@ -24,6 +24,9 @@ tracing = { workspace = true }
 parking_lot = { workspace = true }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
+[dev-dependencies]
+dcc-mcp-models = { workspace = true, features = ["testing"] }
+
 [features]
 default = []
 python-bindings = ["pyo3", "dcc-mcp-naming/python-bindings", "dcc-mcp-models/python-bindings", "dep:dcc-mcp-pybridge", "dcc-mcp-pybridge/python-bindings"]

--- a/crates/dcc-mcp-actions/src/registry/meta.rs
+++ b/crates/dcc-mcp-actions/src/registry/meta.rs
@@ -1,4 +1,4 @@
-use dcc_mcp_models::{ExecutionMode, NextTools, ThreadAffinity, ToolAnnotations};
+use dcc_mcp_models::{ExecutionMode, NextTools, RegistryEntry, ThreadAffinity, ToolAnnotations};
 use serde::{Deserialize, Serialize};
 
 /// Metadata about a registered Action (stored in Rust).
@@ -127,5 +127,27 @@ impl Default for ActionMeta {
             annotations: ToolAnnotations::default(),
             next_tools: NextTools::default(),
         }
+    }
+}
+
+// ── RegistryEntry impl ───────────────────────────────────────────────────────
+
+impl RegistryEntry for ActionMeta {
+    /// The stable lookup key is the action's unique name.
+    fn key(&self) -> String {
+        self.name.clone()
+    }
+
+    /// Search tokens: name, category, DCC name, and all declared tags.
+    fn search_tags(&self) -> Vec<String> {
+        let mut tags = vec![
+            self.name.clone(),
+            self.category.clone(),
+            self.dcc.clone(),
+            self.description.clone(),
+        ];
+        tags.extend(self.tags.iter().cloned());
+        tags.retain(|t| !t.is_empty());
+        tags
     }
 }

--- a/crates/dcc-mcp-actions/src/registry/mod.rs
+++ b/crates/dcc-mcp-actions/src/registry/mod.rs
@@ -9,6 +9,7 @@ use pyo3_stub_gen_derive::gen_stub_pyclass;
 use dcc_mcp_pybridge::py_json::json_value_to_pyobject;
 
 use dashmap::DashMap;
+use dcc_mcp_models::registry::{Registry, SearchQuery};
 use std::sync::Arc;
 
 #[cfg(feature = "python-bindings")]
@@ -388,6 +389,54 @@ impl ActionRegistry {
             }
         }
         seen
+    }
+}
+
+// ── impl Registry<ActionMeta> ────────────────────────────────────────────────
+
+/// Satisfy the shared [`Registry<ActionMeta>`] contract.
+///
+/// Delegates to the existing `register_action` / `get_action` / `list_actions`
+/// / `unregister` methods so all per-DCC indexing is preserved byte-for-byte.
+impl Registry<ActionMeta> for ActionRegistry {
+    fn register(&self, entry: ActionMeta) {
+        self.register_action(entry);
+    }
+
+    fn get(&self, key: &str) -> Option<ActionMeta> {
+        self.get_action(key, None)
+    }
+
+    fn list(&self) -> Vec<ActionMeta> {
+        self.list_actions(None)
+    }
+
+    fn remove(&self, key: &str) -> bool {
+        self.unregister(key, None)
+    }
+
+    fn count(&self) -> usize {
+        self.len()
+    }
+
+    fn search(&self, query: &SearchQuery) -> Vec<ActionMeta> {
+        use dcc_mcp_models::RegistryEntry as _;
+        let q = query.query.to_ascii_lowercase();
+        let mut results: Vec<ActionMeta> = self
+            .actions
+            .iter()
+            .filter(|e| {
+                e.value()
+                    .search_tags()
+                    .iter()
+                    .any(|tag| tag.to_ascii_lowercase().contains(&q))
+            })
+            .map(|e| e.value().clone())
+            .collect();
+        if let Some(limit) = query.limit {
+            results.truncate(limit);
+        }
+        results
     }
 }
 

--- a/crates/dcc-mcp-actions/src/registry/tests/mod.rs
+++ b/crates/dcc-mcp-actions/src/registry/tests/mod.rs
@@ -6,3 +6,12 @@ pub(super) mod fixtures;
 mod happy_path;
 mod search;
 mod serialization;
+
+// ── Registry<ActionMeta> contract test ───────────────────────────────────────
+
+#[test]
+fn action_registry_satisfies_registry_contract() {
+    use dcc_mcp_models::registry::testing::assert_registry_contract;
+    let sample = fixtures::make_action("contract_test_action", "maya");
+    assert_registry_contract(ActionRegistry::new, sample);
+}

--- a/crates/dcc-mcp-models/Cargo.toml
+++ b/crates/dcc-mcp-models/Cargo.toml
@@ -28,3 +28,6 @@ default = []
 python-bindings = ["pyo3", "dcc-mcp-naming/python-bindings", "dep:dcc-mcp-pybridge", "dcc-mcp-pybridge/python-bindings"]
 # Enable `pyo3-stub-gen` annotations on this crate's PyO3 types.
 stub-gen = ["python-bindings", "dep:pyo3-stub-gen", "dep:pyo3-stub-gen-derive"]
+# Expose the shared `registry::testing` harness so downstream crates can call
+# `dcc_mcp_models::registry::testing::assert_registry_contract` in their tests.
+testing = []

--- a/crates/dcc-mcp-models/src/lib.rs
+++ b/crates/dcc-mcp-models/src/lib.rs
@@ -3,6 +3,7 @@
 mod action_result;
 mod dcc_name;
 mod error;
+pub mod registry;
 mod skill_metadata;
 pub mod skill_scope;
 
@@ -13,6 +14,7 @@ pub use action_result::ActionResultModel as ToolResult;
 pub use action_result::{ActionResultModel, ActionResultModelData, SerializeFormat};
 pub use dcc_name::DccName;
 pub use error::DccMcpError;
+pub use registry::{DefaultRegistry, Registry, RegistryEntry, SearchQuery};
 pub use skill_metadata::{
     ExecutionMode, NextTools, SkillDependencies, SkillDependency, SkillDependencyType, SkillGroup,
     SkillMetadata, SkillPolicy, ThreadAffinity, ToolAnnotations, ToolDeclaration,

--- a/crates/dcc-mcp-models/src/registry.rs
+++ b/crates/dcc-mcp-models/src/registry.rs
@@ -1,0 +1,260 @@
+//! Shared registry contract for ActionRegistry / SkillCatalog /
+//! WorkflowCatalog (issue #489).
+//!
+//! # Design
+//!
+//! Three components:
+//! - [`RegistryEntry`] — marker trait every stored value must implement.
+//! - [`Registry<V>`] — shared CRUD + search contract, using `&self` (interior
+//!   mutability) so trait objects work behind `Arc`.
+//! - [`DefaultRegistry<V>`] — thread-safe `HashMap`-backed default impl for
+//!   use cases that don't need specialised secondary indexes.
+//!
+//! `SkillCatalog` and `ActionRegistry` keep their existing `DashMap` storage;
+//! `WorkflowCatalog` keeps its `Vec` with interior mutability via
+//! `parking_lot::RwLock`. Each simply adds an `impl Registry<V>` block that
+//! delegates to the existing methods.
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+// ── RegistryEntry ────────────────────────────────────────────────────────────
+
+/// Every value stored in a [`Registry`] must implement this trait.
+///
+/// - [`key`](RegistryEntry::key) is the stable lookup key (must be unique
+///   within a given registry).
+/// - [`search_tags`](RegistryEntry::search_tags) returns tokens used for
+///   free-text substring matching in [`Registry::search`].
+pub trait RegistryEntry: Clone + Send + Sync {
+    /// Stable lookup key — must be unique within the registry.
+    fn key(&self) -> String;
+
+    /// Tokens used by [`Registry::search`] for substring matching.
+    fn search_tags(&self) -> Vec<String>;
+}
+
+// ── SearchQuery ──────────────────────────────────────────────────────────────
+
+/// Parameters for [`Registry::search`].
+#[derive(Debug, Clone, Default)]
+pub struct SearchQuery {
+    /// Free-text query string (case-insensitive substring match against
+    /// [`RegistryEntry::search_tags`]).
+    pub query: String,
+    /// Optional cap on the number of results returned.
+    pub limit: Option<usize>,
+}
+
+// ── Registry<V> ──────────────────────────────────────────────────────────────
+
+/// Shared registry contract: insert, look up, list, remove, count, search.
+///
+/// All methods take `&self` — implementations use interior mutability
+/// (`DashMap`, `RwLock`, etc.) so the trait is usable behind `Arc<dyn Registry<V>>`.
+pub trait Registry<V: RegistryEntry> {
+    /// Insert (or overwrite) an entry.
+    fn register(&self, entry: V);
+
+    /// Retrieve a clone of the entry with the given key, or `None`.
+    fn get(&self, key: &str) -> Option<V>;
+
+    /// Return clones of all entries in an unspecified order.
+    fn list(&self) -> Vec<V>;
+
+    /// Remove the entry with the given key.
+    ///
+    /// Returns `true` if an entry was removed, `false` if the key was unknown.
+    fn remove(&self, key: &str) -> bool;
+
+    /// Number of entries currently stored.
+    fn count(&self) -> usize;
+
+    /// Free-text search over [`RegistryEntry::search_tags`] (case-insensitive
+    /// substring match).  Results are unordered unless the implementation
+    /// applies additional ranking.
+    fn search(&self, query: &SearchQuery) -> Vec<V>;
+}
+
+// ── DefaultRegistry<V> ───────────────────────────────────────────────────────
+
+/// Thread-safe `HashMap`-backed [`Registry`] implementation.
+///
+/// Suitable for registries that do not need ordered iteration or secondary
+/// indexes. Uses [`std::sync::RwLock`] for interior mutability — zero extra
+/// crate dependencies.
+///
+/// `WorkflowCatalog` currently preserves insertion order via a `Vec` and
+/// therefore implements [`Registry`] directly rather than delegating to
+/// `DefaultRegistry`.
+#[derive(Debug)]
+pub struct DefaultRegistry<V: RegistryEntry> {
+    inner: RwLock<HashMap<String, V>>,
+}
+
+impl<V: RegistryEntry> Default for DefaultRegistry<V> {
+    fn default() -> Self {
+        Self {
+            inner: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl<V: RegistryEntry> DefaultRegistry<V> {
+    /// Create an empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<V: RegistryEntry> Registry<V> for DefaultRegistry<V> {
+    fn register(&self, entry: V) {
+        self.inner
+            .write()
+            .expect("DefaultRegistry lock poisoned")
+            .insert(entry.key(), entry);
+    }
+
+    fn get(&self, key: &str) -> Option<V> {
+        self.inner
+            .read()
+            .expect("DefaultRegistry lock poisoned")
+            .get(key)
+            .cloned()
+    }
+
+    fn list(&self) -> Vec<V> {
+        self.inner
+            .read()
+            .expect("DefaultRegistry lock poisoned")
+            .values()
+            .cloned()
+            .collect()
+    }
+
+    fn remove(&self, key: &str) -> bool {
+        self.inner
+            .write()
+            .expect("DefaultRegistry lock poisoned")
+            .remove(key)
+            .is_some()
+    }
+
+    fn count(&self) -> usize {
+        self.inner
+            .read()
+            .expect("DefaultRegistry lock poisoned")
+            .len()
+    }
+
+    fn search(&self, query: &SearchQuery) -> Vec<V> {
+        let q = query.query.to_ascii_lowercase();
+        let guard = self.inner.read().expect("DefaultRegistry lock poisoned");
+        let mut results: Vec<V> = guard
+            .values()
+            .filter(|v| {
+                v.search_tags()
+                    .iter()
+                    .any(|tag| tag.to_ascii_lowercase().contains(&q))
+            })
+            .cloned()
+            .collect();
+        if let Some(limit) = query.limit {
+            results.truncate(limit);
+        }
+        results
+    }
+}
+
+// ── Shared test harness (enabled by the `testing` feature or in `cfg(test)`) ─
+
+#[cfg(any(test, feature = "testing"))]
+pub mod testing {
+    //! Shared parameterised test harness for [`super::Registry`] impls.
+    //!
+    //! Gate with the crate's `testing` feature so downstream crates can import
+    //! [`assert_registry_contract`] in their own `#[cfg(test)]` modules without
+    //! pulling in test-only code in production builds.
+    //!
+    //! # Usage (downstream crate)
+    //!
+    //! ```toml
+    //! # Cargo.toml [dev-dependencies]
+    //! dcc-mcp-models = { workspace = true, features = ["testing"] }
+    //! ```
+    //!
+    //! ```rust,ignore
+    //! use dcc_mcp_models::registry::testing::assert_registry_contract;
+    //! ```
+
+    use super::{Registry, RegistryEntry, SearchQuery};
+
+    /// Exercise the full CRUD + search contract for any [`Registry`] impl.
+    ///
+    /// Panics with a descriptive message on any contract violation.
+    pub fn assert_registry_contract<R, V>(make: impl Fn() -> R, sample: V)
+    where
+        R: Registry<V>,
+        V: RegistryEntry + PartialEq + std::fmt::Debug,
+    {
+        let r = make();
+
+        // Empty on construction.
+        assert_eq!(r.count(), 0, "new registry should be empty");
+        assert!(r.list().is_empty(), "new registry list should be empty");
+
+        // Register one entry.
+        r.register(sample.clone());
+        assert_eq!(r.count(), 1, "count after one register should be 1");
+
+        // Get by key.
+        let fetched = r.get(&sample.key());
+        assert_eq!(
+            fetched,
+            Some(sample.clone()),
+            "get should return the registered entry"
+        );
+
+        // List contains the entry.
+        let listing = r.list();
+        assert!(
+            listing.contains(&sample),
+            "list should contain the registered entry; got {listing:?}"
+        );
+
+        // Remove.
+        assert!(
+            r.remove(&sample.key()),
+            "remove should return true for existing key"
+        );
+        assert_eq!(r.count(), 0, "count should be 0 after remove");
+        assert!(
+            r.get(&sample.key()).is_none(),
+            "get should return None after remove"
+        );
+
+        // Remove non-existent → false.
+        assert!(
+            !r.remove(&sample.key()),
+            "remove of missing key should return false"
+        );
+
+        // Search finds the entry.
+        r.register(sample.clone());
+        let tags = sample.search_tags();
+        assert!(
+            !tags.is_empty(),
+            "search_tags must not be empty for a valid RegistryEntry"
+        );
+        let results = r.search(&SearchQuery {
+            query: tags[0].clone(),
+            limit: None,
+        });
+        assert!(
+            !results.is_empty(),
+            "search by first search_tag should find the entry; tag={:?}",
+            tags[0]
+        );
+    }
+}

--- a/crates/dcc-mcp-skills/Cargo.toml
+++ b/crates/dcc-mcp-skills/Cargo.toml
@@ -31,6 +31,7 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
 tempfile = "3"
+dcc-mcp-models = { workspace = true, features = ["testing"] }
 
 [features]
 default = []

--- a/crates/dcc-mcp-skills/src/catalog/mod.rs
+++ b/crates/dcc-mcp-skills/src/catalog/mod.rs
@@ -50,7 +50,8 @@ use dcc_mcp_actions::{
     ActionDispatcher,
     registry::{ActionMeta, ActionRegistry},
 };
-use dcc_mcp_models::{SkillGroup, SkillMetadata, SkillScope};
+use dcc_mcp_models::registry::{Registry, SearchQuery};
+use dcc_mcp_models::{RegistryEntry as _, SkillGroup, SkillMetadata, SkillScope};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -137,6 +138,55 @@ pub(crate) fn group_default_active(groups: &[SkillGroup], group_name: &str) -> b
         .find(|g| g.name == group_name)
         .map(|g| g.default_active)
         .unwrap_or(false)
+}
+
+// ── impl Registry<SkillEntry> ────────────────────────────────────────────────
+
+/// Satisfy the shared [`Registry<SkillEntry>`] contract.
+///
+/// Delegates to the internal `DashMap<String, SkillEntry>` directly so that
+/// file-hash tracking, `loaded` bookkeeping, and per-DCC indexing are
+/// unaffected.  Callers that need those richer features should use the
+/// dedicated methods (`add_skill`, `load_skill`, `remove_skill`, …) instead.
+impl Registry<SkillEntry> for SkillCatalog {
+    fn register(&self, entry: SkillEntry) {
+        self.entries.insert(entry.key(), entry);
+    }
+
+    fn get(&self, key: &str) -> Option<SkillEntry> {
+        self.entries.get(key).map(|e| e.value().clone())
+    }
+
+    fn list(&self) -> Vec<SkillEntry> {
+        self.entries.iter().map(|e| e.value().clone()).collect()
+    }
+
+    fn remove(&self, key: &str) -> bool {
+        self.entries.remove(key).is_some()
+    }
+
+    fn count(&self) -> usize {
+        self.entries.len()
+    }
+
+    fn search(&self, query: &SearchQuery) -> Vec<SkillEntry> {
+        let q = query.query.to_ascii_lowercase();
+        let mut results: Vec<SkillEntry> = self
+            .entries
+            .iter()
+            .filter(|e| {
+                e.value()
+                    .search_tags()
+                    .iter()
+                    .any(|tag| tag.to_ascii_lowercase().contains(&q))
+            })
+            .map(|e| e.value().clone())
+            .collect();
+        if let Some(limit) = query.limit {
+            results.truncate(limit);
+        }
+        results
+    }
 }
 
 #[cfg(test)]

--- a/crates/dcc-mcp-skills/src/catalog/tests/mod.rs
+++ b/crates/dcc-mcp-skills/src/catalog/tests/mod.rs
@@ -8,3 +8,19 @@ mod test_execute_script_env;
 mod test_resolve_tool_script;
 mod test_search_hint;
 mod test_search_skills;
+
+// ── Registry<SkillEntry> contract test ───────────────────────────────────────
+
+#[test]
+fn skill_catalog_satisfies_registry_contract() {
+    use dcc_mcp_models::registry::testing::assert_registry_contract;
+    use fixtures::{make_test_catalog, make_test_skill};
+
+    let sample_entry = SkillEntry {
+        metadata: make_test_skill("contract_skill", "maya", &["tool_a"]),
+        state: SkillState::Discovered,
+        registered_tools: Vec::new(),
+        scope: SkillScope::Repo,
+    };
+    assert_registry_contract(make_test_catalog, sample_entry);
+}

--- a/crates/dcc-mcp-skills/src/catalog/types.rs
+++ b/crates/dcc-mcp-skills/src/catalog/types.rs
@@ -1,6 +1,6 @@
 //! Data types for the skill catalog: state, entries, summary, and detail.
 
-use dcc_mcp_models::{SkillMetadata, SkillScope, ToolDeclaration};
+use dcc_mcp_models::{RegistryEntry, SkillMetadata, SkillScope, ToolDeclaration};
 #[cfg(feature = "stub-gen")]
 use pyo3_stub_gen_derive::{gen_stub_pyclass, gen_stub_pymethods};
 use serde::Serializer;
@@ -41,7 +41,7 @@ impl std::fmt::Display for SkillState {
 // ── Skill entry ──
 
 /// A skill entry in the catalog, tracking its metadata and load state.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct SkillEntry {
     /// Parsed skill metadata from SKILL.md.
     pub metadata: SkillMetadata,
@@ -105,6 +105,28 @@ pub struct SkillDetail {
     pub implicit_invocation: bool,
     /// Number of declared external dependencies (MCP servers, env vars, binaries).
     pub dependency_count: usize,
+}
+
+// ── RegistryEntry impl ───────────────────────────────────────────────────────
+
+impl RegistryEntry for SkillEntry {
+    /// The stable lookup key is the skill's unique name.
+    fn key(&self) -> String {
+        self.metadata.name.clone()
+    }
+
+    /// Search tokens: name, description, DCC name, and declared tags.
+    fn search_tags(&self) -> Vec<String> {
+        let mut tags = vec![
+            self.metadata.name.clone(),
+            self.metadata.description.clone(),
+            self.metadata.dcc.clone(),
+            self.metadata.search_hint.clone(),
+        ];
+        tags.extend(self.metadata.tags.iter().cloned());
+        tags.retain(|t| !t.is_empty());
+        tags
+    }
 }
 
 // ── Python bindings for summary ──

--- a/crates/dcc-mcp-workflow/Cargo.toml
+++ b/crates/dcc-mcp-workflow/Cargo.toml
@@ -40,6 +40,7 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 [dev-dependencies]
 tempfile = "3"
 tokio = { workspace = true, features = ["sync", "time", "rt", "rt-multi-thread", "macros", "test-util"] }
+dcc-mcp-models = { workspace = true, features = ["testing"] }
 
 [features]
 default = []

--- a/crates/dcc-mcp-workflow/src/catalog.rs
+++ b/crates/dcc-mcp-workflow/src/catalog.rs
@@ -10,7 +10,9 @@
 
 use std::path::{Path, PathBuf};
 
-use dcc_mcp_models::SkillMetadata;
+use dcc_mcp_models::registry::{Registry, SearchQuery};
+use dcc_mcp_models::{RegistryEntry, SkillMetadata};
+use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 
 use crate::error::WorkflowError;
@@ -46,9 +48,21 @@ pub struct WorkflowSummary {
 ///
 /// Populated by [`Self::from_skill`] per skill; callers may merge multiple
 /// skills into one catalog with [`Self::extend_from_skill`].
-#[derive(Debug, Default, Clone)]
+///
+/// Interior mutability via `parking_lot::RwLock` allows the catalog to
+/// implement [`Registry<WorkflowSummary>`] (which requires `&self`) while
+/// still supporting mutation through `extend_from_skill`.
+#[derive(Debug, Default)]
 pub struct WorkflowCatalog {
-    entries: Vec<WorkflowSummary>,
+    entries: RwLock<Vec<WorkflowSummary>>,
+}
+
+impl Clone for WorkflowCatalog {
+    fn clone(&self) -> Self {
+        Self {
+            entries: RwLock::new(self.entries.read().clone()),
+        }
+    }
 }
 
 impl WorkflowCatalog {
@@ -68,24 +82,27 @@ impl WorkflowCatalog {
     /// YAML parse failures are logged and skipped — a malformed workflow
     /// must not kill the catalog for the rest of the skill.
     pub fn from_skill(meta: &SkillMetadata, skill_root: &Path) -> Result<Self, WorkflowError> {
-        let mut cat = Self::new();
+        let cat = Self::new();
         cat.extend_from_skill(meta, skill_root)?;
         Ok(cat)
     }
 
     /// Merge workflow summaries from another skill into this catalog.
     ///
+    /// Takes `&self` (interior mutability via `RwLock`) so the catalog can
+    /// implement [`Registry<WorkflowSummary>`] which requires `&self`.
+    ///
     /// # Errors
     ///
     /// Returns [`WorkflowError::Io`] on glob-pattern failure.
     pub fn extend_from_skill(
-        &mut self,
+        &self,
         meta: &SkillMetadata,
         skill_root: &Path,
     ) -> Result<(), WorkflowError> {
         for path in resolve_workflow_paths(meta, skill_root)? {
             match read_summary(&path, &meta.name) {
-                Ok(summary) => self.entries.push(summary),
+                Ok(summary) => self.entries.write().push(summary),
                 Err(e) => {
                     tracing::warn!(
                         "workflow catalog: failed to summarise {}: {e}",
@@ -97,32 +114,115 @@ impl WorkflowCatalog {
         Ok(())
     }
 
-    /// All recorded summaries.
+    /// All recorded summaries (cloned — interior mutability prevents returning
+    /// a reference into the locked `Vec`).
     #[must_use]
-    pub fn entries(&self) -> &[WorkflowSummary] {
-        &self.entries
+    pub fn entries(&self) -> Vec<WorkflowSummary> {
+        self.entries.read().clone()
     }
 
     /// Look up a single summary by `(skill, name)`.
     #[must_use]
-    pub fn get(&self, skill: &str, name: &str) -> Option<&WorkflowSummary> {
+    pub fn get(&self, skill: &str, name: &str) -> Option<WorkflowSummary> {
         self.entries
+            .read()
             .iter()
             .find(|s| s.skill == skill && s.name == name)
+            .cloned()
     }
 
     /// Search summaries by a free-text query (substring match, case-insensitive)
     /// against `name` + `description`. Used by `workflows.lookup`.
     #[must_use]
-    pub fn search(&self, query: &str) -> Vec<&WorkflowSummary> {
+    pub fn search(&self, query: &str) -> Vec<WorkflowSummary> {
         let q = query.to_ascii_lowercase();
         self.entries
+            .read()
             .iter()
             .filter(|s| {
                 s.name.to_ascii_lowercase().contains(&q)
                     || s.description.to_ascii_lowercase().contains(&q)
             })
+            .cloned()
             .collect()
+    }
+}
+
+// ── RegistryEntry impl ────────────────────────────────────────────────────────
+
+impl RegistryEntry for WorkflowSummary {
+    /// Composite key: `"<skill>::<name>"` to avoid name collisions across
+    /// skills that may declare workflows with the same local name.
+    fn key(&self) -> String {
+        format!("{}::{}", self.skill, self.name)
+    }
+
+    /// Search tokens: name, skill, and description.
+    fn search_tags(&self) -> Vec<String> {
+        [
+            self.name.clone(),
+            self.skill.clone(),
+            self.description.clone(),
+        ]
+        .into_iter()
+        .filter(|s| !s.is_empty())
+        .collect()
+    }
+}
+
+// ── impl Registry<WorkflowSummary> ───────────────────────────────────────────
+
+/// Satisfy the shared [`Registry<WorkflowSummary>`] contract.
+///
+/// Preserves insertion order (unlike `HashMap`-based `DefaultRegistry`) by
+/// using the `Vec` as the backing store. Upserts overwrite in place to keep
+/// ordering stable for existing entries.
+impl Registry<WorkflowSummary> for WorkflowCatalog {
+    fn register(&self, entry: WorkflowSummary) {
+        let mut guard = self.entries.write();
+        let key = entry.key();
+        match guard.iter().position(|e| e.key() == key) {
+            Some(pos) => guard[pos] = entry,
+            None => guard.push(entry),
+        }
+    }
+
+    fn get(&self, key: &str) -> Option<WorkflowSummary> {
+        self.entries.read().iter().find(|e| e.key() == key).cloned()
+    }
+
+    fn list(&self) -> Vec<WorkflowSummary> {
+        self.entries.read().clone()
+    }
+
+    fn remove(&self, key: &str) -> bool {
+        let mut guard = self.entries.write();
+        let before = guard.len();
+        guard.retain(|e| e.key() != key);
+        guard.len() < before
+    }
+
+    fn count(&self) -> usize {
+        self.entries.read().len()
+    }
+
+    fn search(&self, query: &SearchQuery) -> Vec<WorkflowSummary> {
+        let q = query.query.to_ascii_lowercase();
+        let mut results: Vec<WorkflowSummary> = self
+            .entries
+            .read()
+            .iter()
+            .filter(|v| {
+                v.search_tags()
+                    .iter()
+                    .any(|tag| tag.to_ascii_lowercase().contains(&q))
+            })
+            .cloned()
+            .collect();
+        if let Some(limit) = query.limit {
+            results.truncate(limit);
+        }
+        results
     }
 }
 

--- a/crates/dcc-mcp-workflow/src/tests.rs
+++ b/crates/dcc-mcp-workflow/src/tests.rs
@@ -222,6 +222,25 @@ async fn register_workflow_handlers_wires_run_and_cancel() {
     assert_eq!(cancelled["cancelled"], true);
 }
 
+// ── Registry<WorkflowSummary> contract test ─────────────────────────────
+
+#[test]
+fn workflow_catalog_satisfies_registry_contract() {
+    use dcc_mcp_models::registry::testing::assert_registry_contract;
+
+    use crate::WorkflowCatalog;
+    use crate::catalog::WorkflowSummary;
+
+    let sample = WorkflowSummary {
+        name: "vendor_intake".to_string(),
+        skill: "vendor-skill".to_string(),
+        description: "Import vendor files".to_string(),
+        inputs: serde_json::Value::Null,
+        path: "/tmp/vendor_intake.workflow.yaml".to_string(),
+    };
+    assert_registry_contract(WorkflowCatalog::new, sample);
+}
+
 // ── catalog glob reader ─────────────────────────────────────────────────
 
 #[test]
@@ -254,7 +273,9 @@ fn catalog_reads_glob_from_skill_metadata() {
     });
 
     let cat = WorkflowCatalog::from_skill(&meta, skill_root).unwrap();
-    let names: Vec<&str> = cat.entries().iter().map(|e| e.name.as_str()).collect();
+    // entries() now returns Vec<WorkflowSummary> (interior mutability via RwLock)
+    let all_entries = cat.entries();
+    let names: Vec<&str> = all_entries.iter().map(|e| e.name.as_str()).collect();
     assert!(names.contains(&"vendor_intake"), "got: {names:?}");
     assert!(names.contains(&"nightly_cleanup"), "got: {names:?}");
 


### PR DESCRIPTION
## Summary

Three independent registry-like containers — `ActionRegistry` (per-DCC indexed DashMaps), `SkillCatalog` (DashMap with file-hash entries), and `WorkflowCatalog` (ordered `Vec`) — now share one `Registry<V>` trait declared in `dcc-mcp-models`. The trait pins the cross-cutting contract (`register/get/list/remove/count/search`) without forcing every container into the same storage layout. Closes #489.

## Trait + default impl

New `crates/dcc-mcp-models/src/registry.rs` (~250 LOC):

```rust
pub trait RegistryEntry: Clone + Send + Sync {
    fn key(&self) -> String;
    fn search_tags(&self) -> Vec<String>;
}

pub trait Registry<V: RegistryEntry> {
    fn register(&self, entry: V);
    fn get(&self, key: &str) -> Option<V>;
    fn list(&self) -> Vec<V>;
    fn remove(&self, key: &str) -> bool;
    fn count(&self) -> usize;
    fn search(&self, query: &SearchQuery) -> Vec<V>;
}

/// Turn-key impl for new registries that need the contract but not
/// specialised indexing.
pub struct DefaultRegistry<V: RegistryEntry> { /* DashMap inner */ }
impl<V: RegistryEntry> Registry<V> for DefaultRegistry<V> { /* ... */ }
```

## Migration

| Container | Strategy | Reason |
|-----------|----------|--------|
| `ActionRegistry` | impl `Registry<ActionMeta>` over **existing** dual-DashMap | preserves O(1) `actions_for_dcc()` |
| `SkillCatalog` | impl `Registry<SkillEntry>` over **existing** DashMap | preserves file-hash + scope tracking |
| `WorkflowCatalog` | impl `Registry<WorkflowSummary>` over `RwLock<Vec>` | preserves declaration order |

No container lost a feature. `DefaultRegistry<V>` is offered as a turn-key impl for *new* registries that need the contract but not specialised indexing; existing containers keep their tuned storage.

## Shared contract test

A parameterised harness lives in `dcc_mcp_models::registry::testing::assert_registry_contract`, gated on the new `testing` feature flag. Each crate's tests call it once with a tiny fixture, e.g.:

```rust
#[test]
fn action_registry_satisfies_registry_contract() {
    use dcc_mcp_models::registry::testing::assert_registry_contract;
    assert_registry_contract(|| ActionRegistry::default(), sample_action_meta());
}
```

Round-trip assertions (`register → get → list → search → remove`) used to live in three test files; they're now a single function called three times. Per-crate tests retain only domain-specific assertions (per-DCC indexing for actions, file-hash invariants for skills, declaration order for workflows).

## Behavioural parity

- `cargo test --workspace --lib` — 1268 tests pass (`actions: 239`, `skills: 208`, `workflow: 74`, plus everything else unchanged).
- `pytest` — 8421 tests pass (no PyO3 ABI break).
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.

## API note

`WorkflowCatalog::entries()` / `get()` / `search()` now return owned values instead of borrowed references because the inner `Vec` moved behind an `RwLock` (required to satisfy the trait's `&self` signature plus `Send + Sync`). Internal callers updated; no public callers existed yet so this is non-breaking in practice (verified by full workspace + pytest run).

## Acceptance criteria (#489)

- [x] `Registry<V>` trait + `DefaultRegistry<V>` impl with thread-safe semantics.
- [x] All 3 existing catalogs migrated to the trait (each as a custom impl preserving its specialised storage).
- [x] Public surface backward-compatible (existing call sites untouched; only `WorkflowCatalog` getters changed return type from `&[T]` to `Vec<T>` — zero downstream impact verified).
- [x] Single shared test suite parameterised over the trait covers register / list / remove / count / search.
- [x] Per-crate test files only retain domain-specific assertions.

Closes #489