### PR TITLE
docs: refresh agent-facing docs after EPIC #495

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,20 @@
 | Singleton server factory | `make_start_stop(ServerClass)` → `(start_fn, stop_fn)` |
 | Skill validation | `validate_skill(skill_dir)` → `SkillValidationReport` |
 | Zero-dep JSON/YAML | `json_dumps/loads` / `yaml_dumps/loads` (Rust-powered) |
+| Typed handler return envelope | `ToolResult.ok("msg", **ctx).to_dict()` / `ToolResult.fail("msg", error="code").to_dict()` from `dcc_mcp_core.result_envelope` — note the underscored aliases `success_`/`error_`; `success`/`error` are dataclass fields, **not** factories (#487) |
+| Centralised metadata keys | `from dcc_mcp_core.constants import METADATA_*, LAYER_*, CATEGORY_*` — never inline `"dcc-mcp.recipes"` etc. (#487) |
+| Custom JSON-RPC method (Rust) | `MethodRouter::register(method, Arc::new(handler))` — implement `MethodHandler` trait (#492) |
+| Custom action validation (Rust) | implement `ValidationStrategy` and return it from `select_strategy(...)` (#493) |
+| Custom version constraint shape (Rust) | implement `VersionMatcher` + wrap in `VersionConstraint::Custom` (#493) |
+| Build a registry-like container (Rust) | implement `Registry<V>` over your storage, or use `DefaultRegistry<V>` (#489) |
+| Build a JSON-RPC notification (Rust) | `NotificationBuilder::new("notifications/...").with_params(json).as_sse_event()` (#484) |
+| Typed DCC name (Rust) | `DccName::parse("Maya")` → `DccName::Maya`; canonicalises + hashes safely (#491) |
 
+### Skill layer taxonomy (`metadata.dcc-mcp.layer`)
+
+| Layer | Purpose |
+|-------|---------|
+| `thin-harness` | One Python script + minimal SKILL.md — agents wrap a single CLI/API |
 | `infrastructure` | Safety, diagnostics, introspection |
 | `domain` | Pipeline-level intent (shot export, render farm) |
 | `example` | Authoring reference only |
@@ -123,13 +136,15 @@
 
 ---
 
-## Top 5 Traps — Memorize These
+## Top Traps — Memorize These
 
 1. **`scan_and_load` returns a 2-tuple** → `skills, skipped = scan_and_load(...)` — never iterate directly
 2. **`success_result` kwargs → context** → `success_result("msg", count=5)` — do NOT use `context=`
 3. **`ToolDispatcher` uses `.dispatch()`** → never `.call()`
 4. **Register ALL handlers BEFORE `server.start()`** — server reads registry at startup
 5. **SKILL.md extensions use `metadata.dcc-mcp.<feature>`** → sibling files, never top-level keys (v0.15+ / #356)
+6. **Use `dcc_mcp_core.constants.*` for metadata strings** → no inline `"dcc-mcp.recipes"` / `"thin-harness"` literals (#487)
+7. **Return `ToolResult` from Python tool handlers** → `ToolResult.ok("...", **ctx).to_dict()` (or `success_(...)`); `success`/`error` are dataclass *fields*, the factories are `success_`/`error_` / `ok`/`fail` (#487)
 
 Full trap list + code examples → [`docs/guide/agents-reference.md`](docs/guide/agents-reference.md)
 
@@ -144,11 +159,14 @@ Full trap list + code examples → [`docs/guide/agents-reference.md`](docs/guide
 ## Repo Layout (What Lives Where)
 
 ```
-crates/          # Rust — 15 crates
+crates/          # Rust — 21 crates
 python/dcc_mcp_core/__init__.py  # ← every public symbol
 python/dcc_mcp_core/_core.pyi   # ← parameter names & types
+python/dcc_mcp_core/result_envelope.py  # ← typed ToolResult dataclass (#487)
+python/dcc_mcp_core/constants.py        # ← metadata key / layer / category constants (#487)
+python/dcc_mcp_core/_server/            # ← DccServerBase collaborators (observability, skill_query, window_resolver) (#486)
 tests/           # 120+ integration tests
-examples/skills/ # 11 complete SKILL.md packages
+examples/skills/ # 13 complete SKILL.md packages
 docs/            # guides + API reference
 ```
 
@@ -159,11 +177,15 @@ docs/            # guides + API reference
 ### Do ✅
 - Use `create_skill_server()` — Skills-First entry point
 - Use `success_result("msg", count=5)` — kwargs become context
+- Use `ToolResult.ok("...", **ctx).to_dict()` (or `.success_(...)`) from `result_envelope`; `.fail(msg, error="...")` for errors; `.not_found("Skill", name)` / `.invalid_input(msg)` for the common error codes (#487)
+- Import metadata strings from `dcc_mcp_core.constants` (`METADATA_*`, `LAYER_*`, `CATEGORY_*`) (#487)
 - Use `ToolAnnotations` — safety hints for AI clients
 - Use `search_skills(query)` — don't guess tool names
 - Use `metadata.dcc-mcp.<feature>` keys + sibling files for all SKILL.md extensions
 - Tag every skill with `metadata.dcc-mcp.layer`
 - Unpack `scan_and_load()`: `skills, skipped = scan_and_load(...)`
+- Use `DccName::parse(s)` at Rust API boundaries instead of `&str` (#491)
+- Use `MethodRouter::with_builtins()` then `.register(...)` to add custom JSON-RPC methods (#492)
 - Use Conventional Commits: `feat:`, `fix:`, `docs:`, `refactor:`
 - Use `vx just dev` before `vx just test`
 
@@ -172,6 +194,12 @@ docs/            # guides + API reference
 - Don't use `context=` kwarg in `success_result()` → **pass kwargs directly**
 - Don't call `ToolDispatcher.call()` → **use `.dispatch(name, json_str)`**
 - Don't put SKILL.md extensions at top level → **use `metadata.dcc-mcp.<feature>` + sibling file**
+- Don't hand-roll `{"success": ..., "context": ...}` dicts in handlers → **return `ToolResult.ok(...).to_dict()`** (the factory is `ok`/`success_`, NOT `success`) (#487)
+- Don't write inline `"dcc-mcp.recipes"` / `"thin-harness"` literals → **import from `constants.py`** (#487)
+- Don't pass raw `&str` DCC names through Rust APIs → **`DccName::parse(s)` at the boundary** (#491)
+- Don't extend the JSON-RPC `match` arm in `dispatch.rs` → **register a `MethodHandler` on `MethodRouter`** (#492)
+- Don't hand-roll JSON-RPC envelopes → **`NotificationBuilder` / `JsonRpcRequestBuilder`** (#484)
+- Don't add per-crate `*Error` enums → **return `DccMcpError` via `From` impls** (#488)
 - Don't add Python runtime deps → **zero-dep by design**
 - Don't manually bump versions → **Release Please handles this**
 - Don't import `SkillScope` from Python → **it's Rust-only; use `SkillMetadata` methods**

--- a/docs/guide/agents-reference.md
+++ b/docs/guide/agents-reference.md
@@ -175,6 +175,46 @@ from dcc_mcp_core._core import DeferredExecutor   # direct import required
 This includes `register_diagnostic_mcp_tools(...)` for instance-bound diagnostics —
 register them before calling `server.start()`, never after.
 
+**Return `ToolResult` from Python tool handlers (#487) — never hand-roll the dict:**
+```python
+from dcc_mcp_core.result_envelope import ToolResult
+
+# ✓ typed envelope; serialises to the same wire shape clients already see.
+# Factory methods are `success_` / `error_` (trailing underscore avoids
+# shadowing the dataclass fields), with shorter aliases `ok` / `fail`.
+return ToolResult.ok("Loaded skill", name=name).to_dict()
+return ToolResult.fail("Skill missing", error="not_found",
+                       prompt="Try `recipes__list`.").to_dict()
+# `ToolResult.not_found("Skill", name)` and `ToolResult.invalid_input(msg)`
+# are convenience constructors for the two most common error codes.
+
+# ✗ ad-hoc dict — no field validation, drifts when the wire shape evolves
+return {"success": True, "message": "...", "context": {"name": name}}
+```
+The dataclass mirrors the Rust `ToolResult` model; empty fields are pruned
+by `.to_dict()` so feature-flag toggles do not perturb the JSON envelope.
+
+> **Trap (#487):** there is no `ToolResult.success(...)` / `ToolResult.error(...)`
+> classmethod — `success` and `error` are *dataclass fields*, so the factories
+> are spelled `success_` / `error_` (or the cleaner aliases `ok` / `fail`).
+> Calling `ToolResult.success("...")` raises
+> `AttributeError: type object 'ToolResult' has no attribute 'success'`.
+
+**Import metadata key strings from `constants.py` (#487):**
+```python
+from dcc_mcp_core.constants import (
+    METADATA_RECIPES_KEY,    # "dcc-mcp.recipes"
+    METADATA_LAYER_KEY,      # "dcc-mcp.layer"
+    LAYER_THIN_HARNESS,      # "thin-harness"
+    CATEGORY_RECIPES,        # "recipes"
+)
+# ✗ never inline literals — renaming a key now means editing one file
+```
+Every `"dcc-mcp.<feature>"` metadata key, every `metadata.dcc-mcp.layer` value,
+and every `category` tag on `ToolRegistry.register(...)` lives in
+`dcc_mcp_core.constants`. Adding a new key? Add it to `constants.py` first,
+import it everywhere it appears.
+
 **Connection-scoped tool cache (issue #438):**
 `tools/list` caches a per-session snapshot by default (`enable_tool_cache=True`).
 The cache is invalidated automatically on skill load/unload and group
@@ -889,3 +929,136 @@ Metric names live in [`docs/api/observability.md`](../api/observability.md);
 see there for Grafana PromQL examples. Counters advance from the
 `tools/call` wrapper in `handler.rs` — do not add recording sites
 elsewhere.
+
+---
+
+## Rust Extension Points (post-EPIC #495)
+
+Five trait-shaped extension points landed during the EPIC #495 architecture
+audit. Each follows the same recipe: **"add a behaviour without editing the
+upstream `match` table."** All are Rust-only; they live below the PyO3 layer.
+
+### `MethodHandler` + `MethodRouter` — custom JSON-RPC methods (#492)
+
+Crate: `dcc-mcp-http`, module `handler::router`.
+
+```rust
+use std::sync::Arc;
+use dcc_mcp_http::handler::{MethodRouter, MethodHandler, HandlerFuture};
+use dcc_mcp_http::handler::state::AppState;
+use dcc_mcp_http::protocol::{JsonRpcRequest, JsonRpcResponse};
+use dcc_mcp_http::error::HttpError;
+
+struct PingHandler;
+impl MethodHandler for PingHandler {
+    fn handle<'a>(
+        &'a self,
+        _state: &'a AppState,
+        req: &'a JsonRpcRequest,
+        _session: Option<&'a str>,
+    ) -> HandlerFuture<'a> {
+        Box::pin(async move {
+            Ok(JsonRpcResponse::success(req.id.clone(), serde_json::json!("pong")))
+        })
+    }
+}
+
+let router = MethodRouter::with_builtins();   // initializes, prompts, ...
+router.register("ping", Arc::new(PingHandler));
+// hand `router` to `AppState::with_method_router(...)`
+```
+
+Capability gating (`enable_resources`, `enable_prompts`) lives in the handler
+itself — return `HttpError::method_not_found(...)` when a feature is off, never
+add another arm to the dispatcher. Closures that match the
+`Fn(&AppState, &JsonRpcRequest, Option<&str>) -> HandlerFuture` shape implement
+`MethodHandler` automatically; reach for a struct only when you need state.
+
+### `Registry<V>` + `RegistryEntry` — registry-shaped containers (#489)
+
+Crate: `dcc-mcp-models`, module `registry`.
+
+`ActionRegistry`, `SkillCatalog`, and `WorkflowCatalog` all `impl Registry<V>`
+over their existing storage (per-DCC `DashMap`, file-hash `DashMap`, ordered
+`RwLock<Vec>`). New registries that need only the contract — not specialised
+indexes — can use `DefaultRegistry<V>` directly.
+
+The shared contract test lives in `dcc_mcp_models::registry::testing::assert_registry_contract`
+behind the `testing` feature flag; every implementor calls it once with a
+fixture so register / get / list / remove / count / search semantics stay in
+lockstep.
+
+### `ValidationStrategy` + `select_strategy` — pluggable action validation (#493)
+
+Crate: `dcc-mcp-actions`, module `validation_strategy`.
+
+Built-ins: `NoOpValidator` (no metadata / empty schema) and
+`SchemaValidator<'_>` (borrowed-meta JSON Schema check). `ActionDispatcher::dispatch`
+calls `select_strategy(meta, skip_empty_schema_validation)` to pick one per call;
+adding a new flavour (cached compiled schemas, sandbox precheck, contract-test
+mode) means a new `impl ValidationStrategy` and one extra arm in
+`select_strategy` — `dispatch()` is unaffected. The trait returns
+`ValidationOutcome { skipped: bool }` so the dispatcher can record metrics
+without re-deriving "did this actually run?".
+
+### `VersionMatcher` — pluggable version-constraint shapes (#493)
+
+Crate: `dcc-mcp-actions`, module `versioned::matcher`.
+
+Built-in matchers (one per `VersionConstraint` variant): `AnyMatcher`,
+`ExactMatcher`, `AtLeastMatcher`, `GreaterThanMatcher`, `AtMostMatcher`,
+`LessThanMatcher`, `CaretMatcher`, `TildeMatcher`. Both
+`VersionConstraint::matches(version)` and `Display::fmt` route through
+`VersionConstraint::with_matcher(...)`, so adding a new constraint shape
+takes exactly three edits, none of them in caller code:
+
+1. one new `VersionConstraint` enum variant in `versioned/mod.rs`,
+2. a new matcher struct + `impl VersionMatcher` in `versioned/matcher.rs`,
+3. one extra arm in `with_matcher`.
+
+`matches()` and `Display::fmt` need no edits at all.
+
+### `NotificationBuilder` + `JsonRpcRequestBuilder` — JSON-RPC envelope construction (#484)
+
+Crate: `dcc-mcp-http`, module `protocol::notification_builder`.
+
+Six call sites previously hand-rolled
+`json!({"jsonrpc":"2.0","method":..,"params":..})`. The builders are now the
+single source of truth for that wire shape:
+
+```rust
+use dcc_mcp_http::protocol::NotificationBuilder;
+
+let sse_frame = NotificationBuilder::new("notifications/tools/list_changed")
+    .with_params(serde_json::json!({}))
+    .as_sse_event();   // ready to push onto the per-session stream
+```
+
+`.build()` returns a typed `JsonRpcNotification`; `.to_value()` returns the raw
+`serde_json::Value`. `JsonRpcRequestBuilder` is the symmetric helper for
+*requests* (gateway backend client) — it owns the `id` field.
+
+### `DccName` — typed DCC identifier (#491)
+
+Crate: `dcc-mcp-models`.
+
+`DccName::parse("Maya")` → `DccName::Maya`; case-insensitive aliases (`"3dsmax"`,
+`"max"`, `"threedsmax"` all map to `ThreedsMax`). Round-trips through
+`serde_json::to_value(...)` ↔ `serde_json::from_value(...)` losslessly via the
+`#[serde(from = "String", into = "String")]` annotation. Unknown values become
+`DccName::Other(String)` so the enum can grow without breaking external
+callers. Aliases live in `DccName::parse(...)` itself: `"3dsmax"`, `"max"`,
+and `"threedsmax"` all map to `DccName::ThreedsMax`; `"c4d"` and `"cinema4d"`
+to `DccName::Cinema4d`; `"photoshop"` and `"ps"` to `DccName::Photoshop`.
+Use the type at every new Rust API boundary that previously would have taken
+`&str`; existing call sites such as `ActionRegistry::list_actions_for_dcc(&str)`
+remain `&str` for backward compat and can be migrated lazily.
+
+### `DccMcpError` — unified workspace error (#488)
+
+Crate: `dcc-mcp-models`.
+
+A single error enum with `From<HttpError>`, `From<ProcessError>`, … impls.
+Crates keep their domain-specific enums (`HttpError`, `ProcessError`, …) and
+convert to `DccMcpError` at the public boundary. New top-level helpers should
+return `Result<T, DccMcpError>` rather than introducing yet another error type.

--- a/llms.txt
+++ b/llms.txt
@@ -49,6 +49,15 @@
 | Rich skill error with traceback | `skill_error_with_trace()` |
 | Skill warning / exception helpers | `skill_warning()` / `skill_exception()` |
 | Disable accumulated/evolved skills | `ENV_DISABLE_ACCUMULATED_SKILLS` |
+| Typed Python tool handler return | `from dcc_mcp_core.result_envelope import ToolResult` → `ToolResult.ok("msg", **ctx).to_dict()` / `ToolResult.fail("msg", error="code").to_dict()` (also `success_`/`error_`, plus `not_found(entity_type, name)` / `invalid_input(msg)` shortcuts). **Note**: `success`/`error` are dataclass fields, not factories; calling `ToolResult.success(...)` raises `AttributeError` (#487) |
+| Centralised metadata key constants | `from dcc_mcp_core.constants import METADATA_RECIPES_KEY, METADATA_LAYER_KEY, LAYER_THIN_HARNESS, CATEGORY_DIAGNOSTICS, ...` — every `"dcc-mcp.<feature>"` string lives here (#487) |
+| Custom JSON-RPC method (Rust) | `dcc_mcp_http::handler::{MethodRouter, MethodHandler, HandlerFuture}` — `router.register("ping", Arc::new(handler))`; capability gating lives in the handler, not the router (#492) |
+| Custom action validation (Rust) | `dcc_mcp_actions::validation_strategy::{ValidationStrategy, ValidationOutcome, NoOpValidator, SchemaValidator, select_strategy}` — adding a flavour does not touch `dispatch()` (#493) |
+| Custom version constraint shape (Rust) | `dcc_mcp_actions::versioned::matcher::{VersionMatcher, AnyMatcher, ExactMatcher, AtLeastMatcher, GreaterThanMatcher, AtMostMatcher, LessThanMatcher, CaretMatcher, TildeMatcher}` — adding a shape = enum variant + matcher impl + `with_matcher` arm; `matches()` / `Display` untouched (#493) |
+| Build a registry-like container (Rust) | `dcc_mcp_models::registry::{Registry, RegistryEntry, DefaultRegistry, SearchQuery}` — `ActionRegistry`, `SkillCatalog`, `WorkflowCatalog` all `impl Registry<V>`; shared contract test in `registry::testing` (feature `testing`) (#489) |
+| Build a JSON-RPC notification (Rust) | `dcc_mcp_http::protocol::{NotificationBuilder, JsonRpcRequestBuilder}` — single source for the `{"jsonrpc":"2.0","method":..,"params":..}` shape; `.as_sse_event()` for SSE frames (#484) |
+| Typed DCC name (Rust) | `dcc_mcp_models::DccName` — canonical enum + `parse(s)` (case-insensitive aliases) + `as_str()` round-trip; `DccName::Other(String)` preserves unknown values (#491) |
+| Unified workspace error (Rust) | `dcc_mcp_models::DccMcpError` — single error enum with `From<HttpError>` / `From<ProcessError>` impls; per-crate enums are `From`-converted at the boundary (#488) |
 
 ## Quick Start
 
@@ -95,14 +104,16 @@ meta = dcc_mcp_core.parse_skill_md(dirs[0])  # -> SkillMetadata or None
 
 ## Architecture
 
-Rust workspace (15 crates) with PyO3 bindings. All logic in Rust sub-crates; Python gets a single `dcc_mcp_core._core` extension module. The `dcc_mcp_core` package re-exports all ~275 public symbols from `_core` plus pure-Python helpers (DccServerBase, DccGatewayElection, DccSkillHotReloader, factory, skill helpers).
+Rust workspace (21 crates, including `workspace-hack`) with PyO3 bindings. All logic in Rust sub-crates; Python gets a single `dcc_mcp_core._core` extension module. The `dcc_mcp_core` package re-exports all ~275 public symbols from `_core` plus pure-Python helpers (DccServerBase, DccGatewayElection, DccSkillHotReloader, factory, skill helpers, ToolResult dataclass, constants).
 
 ```
 crates/
 ├── dcc-mcp-naming/      # SEP-986 tool-name / action-id validators (TOOL_NAME_RE, validate_tool_name)
-├── dcc-mcp-models/      # ToolResult, SkillMetadata
-├── dcc-mcp-actions/     # ToolRegistry, ToolDispatcher, ToolValidator, EventBus, ToolPipeline
-├── dcc-mcp-skills/      # SkillScanner, SkillWatcher, parse_skill_md, dependency resolver
+├── dcc-mcp-models/      # SkillMetadata, ToolResult, DccName (#491), DccMcpError (#488), Registry<V> trait (#489)
+├── dcc-mcp-actions/     # ToolRegistry, ToolDispatcher, ToolValidator, EventBus, ToolPipeline,
+│                        # ValidationStrategy (#493), VersionMatcher (#493)
+├── dcc-mcp-skills/      # SkillScanner, SkillWatcher (in watcher/ submodule #483), parse_skill_md,
+│                        # validator/ submodule (#482), dependency resolver
 ├── dcc-mcp-protocols/   # MCP type definitions (Tool, Resource, Prompt, DccAdapter)
 ├── dcc-mcp-transport/   # IPC transport (ipckit), DccLinkFrame, IpcChannelAdapter, SocketServerAdapter
 ├── dcc-mcp-process/     # PyDccLauncher, ProcessMonitor, ProcessWatcher, CrashRecovery
@@ -111,12 +122,19 @@ crates/
 ├── dcc-mcp-shm/         # PyBufferPool, PySharedBuffer, LZ4 compression
 ├── dcc-mcp-capture/     # Capturer, CaptureFrame, CaptureResult
 ├── dcc-mcp-usd/         # UsdStage, UsdPrim, SdfPath, scene info bridge
-├── dcc-mcp-http/        # McpHttpServer, McpHttpConfig, McpServerHandle (MCP Streamable HTTP 2025-03-26)
+├── dcc-mcp-http/        # McpHttpServer, McpHttpConfig, McpServerHandle, MethodRouter (#492),
+│                        # NotificationBuilder (#484) — MCP Streamable HTTP 2025-03-26
 ├── dcc-mcp-server/      # Binary entry point, gateway runner
-└── dcc-mcp-utils/       # Filesystem, constants, type wrappers, JSON conversion
+├── dcc-mcp-scheduler/   # ScheduleSpec, TriggerSpec, SchedulerService (cron + webhook HMAC)
+├── dcc-mcp-workflow/    # WorkflowCatalog, YAML workflow loader
+├── dcc-mcp-artefact/    # FilesystemArtefactStore, FileRef, content-addressed handoff
+├── dcc-mcp-logging/     # File logging + LOG_* constants (former dcc-mcp-utils logging slice)
+├── dcc-mcp-paths/       # Path helpers (former dcc-mcp-utils path slice)
+└── dcc-mcp-pybridge/    # PyO3 helpers — repr_pairs! / to_dict_pairs! macros (#490),
+                         # py_json / py_yaml; reduces wrapper boilerplate across crates
 ```
 
-Pure-Python modules: cancellation, checkpoint, docs_resources, feedback, introspect, recipes, workflow_yaml, bridge, gateway_election, hotreload, factory, dcc_server, server_base, adapters, auth, batch, elicitation, rich_content, plugin_manifest, dcc_api_executor, skill, workflow_yaml
+Pure-Python modules: cancellation, checkpoint, constants (#487), result_envelope (#487), _server/{observability,skill_query,window_resolver} (#486), _tool_registration (#481), docs_resources, feedback, introspect, recipes, workflow_yaml, bridge, gateway_election, hotreload, factory, dcc_server, server_base, adapters, auth, batch, elicitation, rich_content, plugin_manifest, dcc_api_executor, skill
 
 ## Core Concepts
 


### PR DESCRIPTION
## Summary

Documentation-only PR that closes the gap between EPIC #495's new public surface and the agent-facing docs (`llms.txt`, `AGENTS.md`, `docs/guide/agents-reference.md`). Every entry was verified against the actual API on disk before being written down (one real bug surfaced and got documented as a trap, see below).

## What changed

### `AGENTS.md`
- Added 9 new rows to the **Decision Tables**: `ToolResult` envelope, centralised metadata constants, custom JSON-RPC method, custom action validation, custom version constraint, custom registry, JSON-RPC notification builder, typed `DccName`, unified `DccMcpError`.
- Restored the orphan **Skill layer taxonomy** table fragment that lost its header and added the missing `thin-harness` row.
- Bumped **Top Traps** from 5 to 7: trap #6 = use `constants.py` for metadata strings; trap #7 = `ToolResult` factories are spelled `success_` / `ok` (the `success` name is taken by the dataclass field).
- **Repo Layout**: corrected `15 crates` → `21 crates`, `11 SKILL.md packages` → `13`, and listed the new Python modules (`constants.py`, `result_envelope.py`, `_server/`).
- **Do / Don't**: added concrete entries pointing at the new APIs (use `ToolResult.ok(...)`, use `MethodRouter::with_builtins()`, use `DccName::parse(s)` at boundaries; don't extend `dispatch.rs` `match` arm, don't add per-crate `*Error` enums, don't hand-roll JSON-RPC envelopes).

### `llms.txt`
- Added 10 new rows to the **decision table** mirroring the AGENTS.md additions but with module paths suitable for direct `use` statements.
- **Architecture section**: corrected crate count to 21, listed the 6 crates that were missing (`scheduler`, `workflow`, `artefact`, `logging`, `paths`, `pybridge`), and tagged each crate with the EPIC #495 issues that touched it (#491, #488, #489, #482, #483, #492, #493, #484, #490).
- Listed the new pure-Python modules with their issue references.

### `docs/guide/agents-reference.md`
- New **Trap section** for `ToolResult`: documents that `success_` / `error_` (and the cleaner aliases `ok` / `fail` / `not_found` / `invalid_input`) are the factories, with a worked code sample.
- New **Trap section** for `constants.py`: lists the four most-used keys and explains the "add to constants first, import everywhere" workflow.
- New end-of-file section **Rust Extension Points (post-EPIC #495)** — short, code-shaped reference for each of the 7 new traits / types: `MethodHandler`, `Registry<V>`, `ValidationStrategy`, `VersionMatcher`, `NotificationBuilder` / `JsonRpcRequestBuilder`, `DccName`, `DccMcpError`. Each subsection shows the *exact* signature an extension author has to implement and the *exact* call site they tap into, so the docs don't have to be re-read every time.

## Accuracy verification

Every code snippet in this PR was checked against the live source before being written down. One real bug surfaced during verification and is now a trap:

```python
>>> ToolResult.success("hi")
AttributeError: type object 'ToolResult' has no attribute 'success'.
               Did you mean: 'success_'?
```

Reason: `success` and `error` are *dataclass fields*, so the factory methods carry an underscore suffix. The cleaner aliases `ok` / `fail` exist precisely for this. Documented in all three files.

## Why now

1. The 14 sub-issues of EPIC #495 introduced trait-shaped extension points that are non-obvious to discover from `lib.rs` alone (`MethodHandler`, `Registry<V>`, `ValidationStrategy`, `VersionMatcher`).
2. The Python `ToolResult` / `constants.py` modules were introduced in #487 but never made it into the agent-facing decision tables, so agents continued to hand-roll dicts and inline `"dcc-mcp.recipes"` literals.
3. The orphan Skill-layer taxonomy table fragment in `AGENTS.md` had been broken since at least the v0.15 SKILL.md spec migration.

## Validation

- All Python imports referenced in the new docs were exercised end-to-end (`from dcc_mcp_core.result_envelope import ToolResult`, `from dcc_mcp_core.constants import METADATA_RECIPES_KEY, ...`, `from dcc_mcp_core._server import observability, skill_query, window_resolver`, `from dcc_mcp_core._tool_registration import ToolSpec, register_tools`).
- `ToolResult.ok(...).to_dict()` and `ToolResult.fail(...).to_dict()` smoke-tested at the REPL.
- All Rust API references (`MethodRouter::with_builtins`, `select_strategy`, `NotificationBuilder::as_sse_event`, `DccName::parse`, `VersionConstraint::with_matcher`) cross-checked against `cargo doc` source.
- `pre-commit run --files AGENTS.md docs/guide/agents-reference.md llms.txt` clean (end-of-file, trim-trailing-whitespace passed; the language hooks all skipped because no source changed).

No runtime code touched.