### PR TITLE
docs(tests): note e2e test files are CI-active, not to be --ignored

### DIFF
--- a/tests/test_e2e_gateway_skill_load_sse.py
+++ b/tests/test_e2e_gateway_skill_load_sse.py
@@ -1,5 +1,10 @@
 """E2E regression test: gateway SSE → load_skill → tools/list_changed.
 
+CI status: this file is part of the standard ``pytest tests/`` run on every
+matrix cell (ubuntu/windows/macos x py3.8-3.13) and completes in ~10 s. Do
+**not** add it to local ``--ignore`` lists in CI workflows or shared scripts;
+the e2e SSE invariant guarded here regressed once already (#303).
+
 This test replaces the coverage gap left by the removal of
 ``tests/test_e2e_gateway_skills_progressive.py`` in the
 ``fix(http,transport)!: gateway lifecycle`` commit. It does **not** re-add

--- a/tests/test_mcp_mcporter_e2e.py
+++ b/tests/test_mcp_mcporter_e2e.py
@@ -17,6 +17,14 @@ Requirements:
     dcc_mcp_core Python package installed (Rust wheel)
 
 The tests are skipped automatically when ``npx`` is not found.
+
+CI status: this file runs in the dedicated ``mcporter-e2e`` job
+(``.github/workflows/ci.yml``) which installs ``mcporter`` globally via
+``npm install -g mcporter`` and executes ``pytest tests/test_mcp_mcporter_e2e.py``
+against a Linux wheel built earlier in the run. It also auto-skips inside the
+standard ``pytest tests/`` matrix cells because ``npx`` is absent there. Do
+**not** add this file to local ``--ignore`` lists in CI workflows or shared
+scripts.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Docstring-only update to two e2e test files. **No runtime behaviour changes.**

During the EPIC #495 sub-PRs, both files were repeatedly invoked through:

```
pytest tests/ -q --ignore=tests/test_e2e_gateway_skill_load_sse.py \
                --ignore=tests/test_mcp_mcporter_e2e.py
```

…as a local convenience to keep iteration cycles under 30 s. Audit confirmed both modules are already part of CI — the `--ignore` flags only ever lived in shell history. The pattern looked suspicious enough in PR review notes that it deserves a paper trail in the files themselves so it doesn’t get re-introduced.

## What changed

### `tests/test_e2e_gateway_skill_load_sse.py`

Added a 4-line note to the module docstring documenting:
- runs in the standard `pytest tests/` matrix on every CI cell,
- ~10 s per cell,
- guards the SSE invariant from #303,
- not to be `--ignore`d in CI workflows.

### `tests/test_mcp_mcporter_e2e.py`

Added a 7-line note to the module docstring documenting:
- dedicated `mcporter-e2e` CI job with `npm install -g mcporter`,
- auto-skips inside the standard `pytest tests/` matrix because `npx` is absent there,
- not to be `--ignore`d in CI workflows.

## Validation

- `pre-commit run --files tests/test_e2e_gateway_skill_load_sse.py tests/test_mcp_mcporter_e2e.py` clean (one en-dash → hyphen tweak applied to satisfy ruff's `RUF002`).
- Locally re-ran both e2e modules to confirm pass:
  - `test_e2e_gateway_skill_load_sse.py`: 4 passed in 9.6 s.
  - `test_mcp_mcporter_e2e.py`: 38 passed in ~68 s (npx via mcporter).

Closes #526