### PR TITLE
feat(pybridge): scaffold dcc-mcp-pybridge-derive proc-macro crate (#528 M1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,7 +653,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dcc-mcp-actions"
-version = "0.14.15"
+version = "0.14.16"
 dependencies = [
  "dashmap",
  "dcc-mcp-models",
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-artefact"
-version = "0.14.15"
+version = "0.14.16"
 dependencies = [
  "chrono",
  "hex",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-capture"
-version = "0.14.15"
+version = "0.14.16"
 dependencies = [
  "image",
  "libc",
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-core"
-version = "0.14.15"
+version = "0.14.16"
 dependencies = [
  "dcc-mcp-actions",
  "dcc-mcp-artefact",
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-http"
-version = "0.14.15"
+version = "0.14.16"
 dependencies = [
  "axum",
  "axum-test",
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-logging"
-version = "0.14.15"
+version = "0.14.16"
 dependencies = [
  "dcc-mcp-paths",
  "parking_lot",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-models"
-version = "0.14.15"
+version = "0.14.16"
 dependencies = [
  "dcc-mcp-naming",
  "dcc-mcp-pybridge",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-naming"
-version = "0.14.15"
+version = "0.14.16"
 dependencies = [
  "pyo3",
  "pyo3-stub-gen",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-paths"
-version = "0.14.15"
+version = "0.14.16"
 dependencies = [
  "dirs",
  "pyo3",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-process"
-version = "0.14.15"
+version = "0.14.16"
 dependencies = [
  "dcc-mcp-models",
  "ipckit",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-protocols"
-version = "0.14.15"
+version = "0.14.16"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -875,8 +875,9 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-pybridge"
-version = "0.14.15"
+version = "0.14.16"
 dependencies = [
+ "dcc-mcp-pybridge-derive",
  "pyo3",
  "pyo3-stub-gen",
  "pyo3-stub-gen-derive",
@@ -888,8 +889,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dcc-mcp-pybridge-derive"
+version = "0.14.16"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dcc-mcp-sandbox"
-version = "0.14.15"
+version = "0.14.16"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -905,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-scheduler"
-version = "0.14.15"
+version = "0.14.16"
 dependencies = [
  "axum",
  "bytes",
@@ -936,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-server"
-version = "0.14.15"
+version = "0.14.16"
 dependencies = [
  "anyhow",
  "axum",
@@ -963,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-shm"
-version = "0.14.15"
+version = "0.14.16"
 dependencies = [
  "ipckit",
  "libc",
@@ -982,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-skills"
-version = "0.14.15"
+version = "0.14.16"
 dependencies = [
  "dashmap",
  "dcc-mcp-actions",
@@ -1006,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-telemetry"
-version = "0.14.15"
+version = "0.14.16"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -1030,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-transport"
-version = "0.14.15"
+version = "0.14.16"
 dependencies = [
  "criterion",
  "dashmap",
@@ -1056,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-usd"
-version = "0.14.15"
+version = "0.14.16"
 dependencies = [
  "dcc-mcp-protocols",
  "pyo3",
@@ -1072,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-workflow"
-version = "0.14.15"
+version = "0.14.16"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/dcc-mcp-protocols",
     "crates/dcc-mcp-logging",
     "crates/dcc-mcp-pybridge",
+    "crates/dcc-mcp-pybridge-derive",
     "crates/dcc-mcp-paths",
     "crates/dcc-mcp-transport",
     "crates/dcc-mcp-process",
@@ -44,6 +45,7 @@ dcc-mcp-skills = { path = "crates/dcc-mcp-skills" }
 dcc-mcp-protocols = { path = "crates/dcc-mcp-protocols" }
 dcc-mcp-logging = { path = "crates/dcc-mcp-logging" }
 dcc-mcp-pybridge = { path = "crates/dcc-mcp-pybridge" }
+dcc-mcp-pybridge-derive = { path = "crates/dcc-mcp-pybridge-derive" }
 dcc-mcp-paths = { path = "crates/dcc-mcp-paths" }
 dcc-mcp-transport = { path = "crates/dcc-mcp-transport" }
 dcc-mcp-process = { path = "crates/dcc-mcp-process" }

--- a/crates/dcc-mcp-pybridge-derive/Cargo.toml
+++ b/crates/dcc-mcp-pybridge-derive/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "dcc-mcp-pybridge-derive"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Procedural derive macros for the dcc-mcp pybridge wrapper-helper layer (issue #528)"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2", features = ["full", "extra-traits"] }
+quote = "1"
+proc-macro2 = "1"
+
+[dev-dependencies]
+# Smoke-tests live in the consumer crate (`dcc-mcp-pybridge`) so that the
+# macro is exercised in a non-proc-macro build context. See
+# crates/dcc-mcp-pybridge/tests/derive_smoke.rs.

--- a/crates/dcc-mcp-pybridge-derive/src/lib.rs
+++ b/crates/dcc-mcp-pybridge-derive/src/lib.rs
@@ -1,0 +1,55 @@
+//! Procedural derive macros for `dcc-mcp-pybridge` (issue #528).
+//!
+//! This crate is the procedural-macro counterpart of
+//! `dcc-mcp-pybridge::python::wrapper_helpers`: where the helper module
+//! collapses runtime boilerplate (`__repr__` / `to_dict` formatting),
+//! this crate collapses *compile-time* boilerplate \u2014 the dozens of
+//! mechanical `#[getter] fn x(&self) { self.inner.x }` blocks that
+//! every wrapper currently hand-writes.
+//!
+//! ## Status
+//!
+//! M1 (skeleton). The `#[derive(PyWrapper)]` derive currently parses
+//! the input but emits **no code**. Field-level attribute parsing and
+//! code generation land in M2 (PR for issue #528). This skeleton lets
+//! downstream crates start importing the symbol so the M2 PR is a pure
+//! diff inside this crate.
+//!
+//! ## Usage (planned, M2)
+//!
+//! ```ignore
+//! use dcc_mcp_pybridge::derive::PyWrapper;
+//!
+//! #[derive(PyWrapper)]
+//! #[py_wrapper(
+//!     inner = "McpHttpConfig",
+//!     fields(
+//!         port: u16   => [get, set, repr],
+//!         host: String => [get(by_str), repr],
+//!     ),
+//! )]
+//! #[pyclass(name = "McpHttpConfig")]
+//! pub struct PyMcpHttpConfig {
+//!     pub(crate) inner: McpHttpConfig,
+//! }
+//! ```
+//!
+//! See issue #528 for the full design and grammar.
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{DeriveInput, parse_macro_input};
+
+/// Procedural derive that generates `#[pymethods]` accessors from a
+/// `#[py_wrapper(\u2026)]` field declaration table.
+///
+/// **M1 (skeleton)**: parses the input but emits no code. Useful only to
+/// reserve the symbol so downstream crates can wire imports ahead of the
+/// M2 codegen PR. Applying the derive on a struct compiles cleanly and
+/// has zero effect on the resulting binary.
+#[proc_macro_derive(PyWrapper, attributes(py_wrapper))]
+pub fn derive_py_wrapper(input: TokenStream) -> TokenStream {
+    let _input = parse_macro_input!(input as DeriveInput);
+    // M1 stub: no-op codegen. The full implementation lands in M2.
+    quote!().into()
+}

--- a/crates/dcc-mcp-pybridge/Cargo.toml
+++ b/crates/dcc-mcp-pybridge/Cargo.toml
@@ -10,6 +10,10 @@ description = "Python<->Rust bridge helpers for the dcc-mcp ecosystem (PyAny<->s
 [dependencies]
 pyo3 = { workspace = true, optional = true }
 
+# Procedural-derive macros (issue #528). Re-exported through
+# `dcc_mcp_pybridge::derive` so downstream crates only pull `dcc-mcp-pybridge`.
+dcc-mcp-pybridge-derive = { workspace = true }
+
 # Type-stub generation (opt-in via `stub-gen` feature).
 pyo3-stub-gen = { workspace = true, optional = true }
 pyo3-stub-gen-derive = { workspace = true, optional = true }

--- a/crates/dcc-mcp-pybridge/src/lib.rs
+++ b/crates/dcc-mcp-pybridge/src/lib.rs
@@ -31,3 +31,22 @@ pub use python::{json_dumps, json_loads, yaml_dumps, yaml_loads};
 /// ```
 #[cfg(feature = "python-bindings")]
 pub use python::wrapper_helpers;
+
+/// Procedural-derive macros for wrapper boilerplate (issue #528).
+///
+/// Re-exports the [`PyWrapper`](derive::PyWrapper) derive from the
+/// `dcc-mcp-pybridge-derive` crate so downstream wrappers only need a
+/// `dcc-mcp-pybridge` dependency:
+///
+/// ```rust,ignore
+/// use dcc_mcp_pybridge::derive::PyWrapper;
+///
+/// #[derive(PyWrapper)]
+/// #[py_wrapper(\u2026)]
+/// pub struct PyMcpHttpConfig { /* \u2026 */ }
+/// ```
+///
+/// The derive is currently a no-op stub (M1); full codegen lands in M2.
+pub mod derive {
+    pub use dcc_mcp_pybridge_derive::PyWrapper;
+}

--- a/crates/dcc-mcp-pybridge/tests/derive_smoke.rs
+++ b/crates/dcc-mcp-pybridge/tests/derive_smoke.rs
@@ -1,0 +1,66 @@
+//! Smoke test for the `#[derive(PyWrapper)]` re-export (issue #528, M1).
+//!
+//! Verifies that:
+//! 1. The derive macro is reachable via the `dcc_mcp_pybridge::derive` module.
+//! 2. Applying it to a struct compiles cleanly with **no** generated symbols
+//!    (M1 stub semantics) \u2014 i.e. the original struct still has only the
+//!    fields the user wrote, and instantiation through the standard
+//!    field-init syntax still works.
+//!
+//! The full codegen path is exercised by `macrotest` snapshots in M2.
+
+use dcc_mcp_pybridge::derive::PyWrapper;
+
+/// Plain struct that opts into the derive. The `#[py_wrapper(\u2026)]`
+/// attribute is parsed but ignored in M1.
+#[derive(PyWrapper)]
+#[py_wrapper(
+    inner = "InnerCfg",
+    fields(
+        port: u16 => [get, set, repr],
+        host: String => [get, repr],
+    ),
+)]
+pub struct WrapperCfg {
+    pub inner: InnerCfg,
+}
+
+#[derive(Default)]
+pub struct InnerCfg {
+    pub port: u16,
+    pub host: String,
+}
+
+#[test]
+fn derive_compiles_and_struct_remains_constructible() {
+    // If the M1 stub started emitting code that conflicted with the
+    // user's own definitions, this test would fail to compile.
+    let cfg = WrapperCfg {
+        inner: InnerCfg {
+            port: 8765,
+            host: "127.0.0.1".to_string(),
+        },
+    };
+    assert_eq!(cfg.inner.port, 8765);
+    assert_eq!(cfg.inner.host, "127.0.0.1");
+}
+
+/// Direct-pyclass pattern (no `inner` field). Should also compile under
+/// the M1 stub since the macro doesn't emit anything yet.
+#[derive(PyWrapper)]
+#[py_wrapper(
+    fields(
+        name: String => [get, set, repr],
+    ),
+)]
+pub struct DirectStyle {
+    pub name: String,
+}
+
+#[test]
+fn derive_compiles_for_direct_pattern() {
+    let d = DirectStyle {
+        name: "skill".to_string(),
+    };
+    assert_eq!(d.name, "skill");
+}

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -58,24 +58,50 @@ winnow = { version = "1.0.2" }
 zerocopy = { version = "0.8.48", default-features = false, features = ["derive", "simd"] }
 
 [build-dependencies]
+chrono = { version = "0.4.44", features = ["serde"] }
+clap = { version = "4.6.1", features = ["derive", "env"] }
+clap_builder = { version = "4.6.0", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
+crossbeam-utils = { version = "0.8.21" }
+digest = { version = "0.11.2", features = ["alloc", "mac", "oid"] }
 either = { version = "1.15.0", features = ["use_std"] }
+futures-channel = { version = "0.3.32", features = ["sink"] }
+futures-executor = { version = "0.3.32" }
+futures-task = { version = "0.3.32", default-features = false, features = ["std"] }
+futures-util = { version = "0.3.32", features = ["channel", "io", "sink"] }
+hyper = { version = "1.9.0", features = ["client", "http1", "http2", "server"] }
+hyper-util = { version = "0.1.20", features = ["client-legacy", "http1", "server", "service"] }
 log = { version = "0.4.29", default-features = false, features = ["std"] }
 memchr = { version = "2.8.0" }
 num-bigint = { version = "0.4.6" }
+num-complex = { version = "0.4.6" }
 num-integer = { version = "0.1.46", features = ["i128"] }
 num-traits = { version = "0.2.19", features = ["i128", "libm"] }
 phf = { version = "0.11.3", features = ["macros"] }
 phf_shared = { version = "0.11.3" }
 proc-macro2 = { version = "1.0.106" }
 quote = { version = "1.0.45" }
+rand-274715c4dabd11b0 = { package = "rand", version = "0.9.4" }
 rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8.6", features = ["small_rng"] }
 rand_core = { version = "0.6.4", default-features = false, features = ["std"] }
 regex-automata = { version = "0.4.14", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
 regex-syntax = { version = "0.8.10" }
+serde = { version = "1.0.228", features = ["alloc", "derive"] }
 serde_core = { version = "1.0.228", features = ["alloc"] }
+serde_json = { version = "1.0.149", features = ["raw_value"] }
+slab = { version = "0.4.12" }
+smallvec = { version = "1.15.1", default-features = false, features = ["const_new"] }
 syn = { version = "2.0.117", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+sync_wrapper = { version = "1.0.2", default-features = false, features = ["futures"] }
+time = { version = "0.3.47", features = ["formatting", "local-offset", "macros", "parsing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util"] }
+tokio-stream = { version = "0.1.18", features = ["sync"] }
+tokio-util = { version = "0.7.18", features = ["codec", "io", "rt"] }
 toml_datetime = { version = "1.1.1", features = ["serde"] }
 toml_parser = { version = "1.1.2" }
+tower = { version = "0.5.3", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "log"] }
+tracing = { version = "0.1.44", features = ["log"] }
+tracing-core = { version = "0.1.36" }
+tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
 winnow = { version = "1.0.2" }
 zerocopy = { version = "0.8.48", default-features = false, features = ["derive", "simd"] }
 
@@ -90,8 +116,15 @@ tower = { version = "0.5.3", default-features = false, features = ["retry", "tim
 tower-http = { version = "0.6.8", features = ["cors", "follow-redirect", "trace"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
+bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 cc = { version = "1.2.61", default-features = false, features = ["parallel"] }
+getrandom = { version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
+hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
+mio = { version = "1.2.0", features = ["net", "os-ext"] }
+subtle = { version = "2.6.1" }
+tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
+tower-http = { version = "0.6.8", features = ["cors", "follow-redirect", "trace"] }
 
 [target.aarch64-unknown-linux-gnu.dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
@@ -104,8 +137,15 @@ tower = { version = "0.5.3", default-features = false, features = ["retry", "tim
 tower-http = { version = "0.6.8", features = ["cors", "follow-redirect", "trace"] }
 
 [target.aarch64-unknown-linux-gnu.build-dependencies]
+bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 cc = { version = "1.2.61", default-features = false, features = ["parallel"] }
+getrandom = { version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
+hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
+mio = { version = "1.2.0", features = ["net", "os-ext"] }
+subtle = { version = "2.6.1" }
+tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
+tower-http = { version = "0.6.8", features = ["cors", "follow-redirect", "trace"] }
 
 [target.x86_64-apple-darwin.dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
@@ -118,8 +158,15 @@ tower = { version = "0.5.3", default-features = false, features = ["retry", "tim
 tower-http = { version = "0.6.8", features = ["cors", "follow-redirect", "trace"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
+bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 cc = { version = "1.2.61", default-features = false, features = ["parallel"] }
+errno = { version = "0.3.14" }
+getrandom = { version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
+hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
+subtle = { version = "2.6.1" }
+tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
+tower-http = { version = "0.6.8", features = ["cors", "follow-redirect", "trace"] }
 
 [target.aarch64-apple-darwin.dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
@@ -132,8 +179,15 @@ tower = { version = "0.5.3", default-features = false, features = ["retry", "tim
 tower-http = { version = "0.6.8", features = ["cors", "follow-redirect", "trace"] }
 
 [target.aarch64-apple-darwin.build-dependencies]
+bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 cc = { version = "1.2.61", default-features = false, features = ["parallel"] }
+errno = { version = "0.3.14" }
+getrandom = { version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
+hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
+subtle = { version = "2.6.1" }
+tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
+tower-http = { version = "0.6.8", features = ["cors", "follow-redirect", "trace"] }
 
 [target.x86_64-pc-windows-msvc.dependencies]
 getrandom = { version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
@@ -147,5 +201,13 @@ windows-sys = { version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_F
 
 [target.x86_64-pc-windows-msvc.build-dependencies]
 cc = { version = "1.2.61", default-features = false, features = ["parallel"] }
+getrandom = { version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
+hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
+subtle = { version = "2.6.1" }
+tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
+tower-http = { version = "0.6.8", features = ["cors", "follow-redirect", "trace"] }
+winapi = { version = "0.3.9", default-features = false, features = ["cfg", "evntrace", "in6addr", "inaddr", "minwinbase", "ntsecapi", "sysinfoapi", "windef", "winioctl"] }
+windows = { version = "0.62.2", features = ["Wdk_System_SystemInformation", "Wdk_System_SystemServices", "Wdk_System_Threading", "Win32_Graphics_Direct3D", "Win32_Graphics_Direct3D11", "Win32_Graphics_Dxgi_Common", "Win32_Graphics_Gdi", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_NetworkManagement_NetManagement", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_Storage_Xps", "Win32_System_Com", "Win32_System_Diagnostics_Debug", "Win32_System_Diagnostics_ToolHelp", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_Kernel", "Win32_System_Memory", "Win32_System_Ole", "Win32_System_Performance", "Win32_System_Power", "Win32_System_ProcessStatus", "Win32_System_Registry", "Win32_System_RemoteDesktop", "Win32_System_Rpc", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_Variant", "Win32_System_WindowsProgramming", "Win32_System_Wmi", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
+windows-sys = { version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Globalization", "Win32_Networking_WinSock", "Win32_Security_Authorization", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Shell"] }
 
 ### END HAKARI SECTION


### PR DESCRIPTION
## Summary

**M1** of issue #528 — the level-3 follow-up to #490 that aims to eliminate the ~1450 LOC of hand-written PyO3 wrapper boilerplate (`#[getter]` / `#[setter]` / `__repr__` / `to_dict`) currently duplicated across **71 wrapper files**.

This PR adds a new proc-macro crate but **emits no code yet**. The derive is a parse-only stub. The point of an isolated skeleton PR is to land the build-system contract (new workspace member, new dep on syn/quote, hakari sync) and the public re-export path *before* the codegen lands, so M2 is a pure additive diff inside the new crate.

## What's new

### `crates/dcc-mcp-pybridge-derive/`

New crate, `[lib] proc-macro = true`. Dependencies:

- `syn = "2"` with `["full", "extra-traits"]`
- `quote = "1"`
- `proc-macro2 = "1"`

No nightly features. No `pyo3` dep at the macro layer — the *generated* code references `pyo3`, which the consumer crate must already have.

```rust
#[proc_macro_derive(PyWrapper, attributes(py_wrapper))]
pub fn derive_py_wrapper(input: TokenStream) -> TokenStream {
    let _input = parse_macro_input!(input as DeriveInput);
    quote!().into()  // M1 stub: no codegen yet.
}
```

### `dcc-mcp-pybridge::derive`

Unconditional `pub mod derive` that re-exports the macro:

```rust
pub mod derive {
    pub use dcc_mcp_pybridge_derive::PyWrapper;
}
```

Downstream wrapper crates only ever depend on `dcc-mcp-pybridge`; the derive-crate dep is internal. This mirrors the convention that `serde_derive` is re-exported through `serde::Deserialize` rather than imported directly.

### Smoke test

`crates/dcc-mcp-pybridge/tests/derive_smoke.rs` exercises both target patterns:

- **Delegation pattern**: `WrapperCfg { inner: InnerCfg }` with `#[py_wrapper(inner = "InnerCfg", fields(…))]`.
- **Direct pattern**: `DirectStyle { name: String }` with `#[py_wrapper(fields(…))]` (no `inner`).

Both structs construct and read back fields via plain syntax, proving that the M1 stub doesn't emit conflicting symbols.

### Workspace plumbing

- `Cargo.toml`: new `members` entry + new `[workspace.dependencies]` path entry.
- `crates/workspace-hack/Cargo.toml`: regenerated via `cargo hakari generate` (62 lines added — transitive unification for `syn` features).
- `Cargo.lock`: refreshed.

## Why M1 ships zero codegen

The PR breakdown in #528 splits the work three ways:

| PR | Scope | LOC delta |
|---|---|---|
| **M1 (this)** | crate skeleton + re-export + smoke test | +~80 net |
| M2 | full `#[py_wrapper(...)]` parser + codegen + macrotest snapshots + trybuild UI tests | +~600 |
| M3 | adopt at PyMcpHttpConfig + SkillMetadata + ToolDeclaration; LOC delta measurement | -~800 net |

Keeping each PR small enough to review carefully — in particular, M2 will touch zero existing wrapper files and M3 will touch zero macro internals.

## Validation

```
cargo build -p dcc-mcp-pybridge-derive               # clean
cargo test  -p dcc-mcp-pybridge --test derive_smoke  # 2 passed
cargo check --workspace --all-targets                # clean
cargo clippy -p dcc-mcp-pybridge-derive -p dcc-mcp-pybridge \
             --all-targets -- -D warnings            # clean
cargo hakari verify                                  # workspace-hack works correctly
```

## Acceptance criteria touched (#528)

- [x] New crate `dcc-mcp-pybridge-derive` builds on stable Rust, no nightly features.
- [x] `cargo doc --workspace` builds clean for the new crate.
- [ ] `#[derive(PyWrapper)]` works for the **delegation** and **direct** patterns above. — *deferred to M2.*
- [ ] At least 4 modes adopted: `get`, `get(by_str)`, `get(clone)`, `set`. — *deferred to M2.*
- [ ] Generated `__repr__` and `to_dict` byte-identical to current hand-written output for the 3 migration sites. — *deferred to M3.*
- [ ] After adoption at PyMcpHttpConfig + SkillMetadata + ToolDeclaration, **total Python-binding LOC reduced ≥15%**. — *deferred to M3.*

Refs #528