### PR TITLE
feat(pybridge-derive): add get(to_string) field mode (#528 M3.1)

### DIFF
--- a/crates/dcc-mcp-pybridge-derive/src/codegen.rs
+++ b/crates/dcc-mcp-pybridge-derive/src/codegen.rs
@@ -77,6 +77,10 @@ fn emit_accessor(field: &FieldDecl, mode: FieldMode, base: &TokenStream2) -> Opt
             #[getter]
             fn #name(&self) -> #ty { #base #name .clone() }
         },
+        FieldMode::GetToString => quote! {
+            #[getter]
+            fn #name(&self) -> #ty { #base #name .to_string() }
+        },
         FieldMode::Set => {
             let setter = format_ident!("set_{}", name);
             quote! {

--- a/crates/dcc-mcp-pybridge-derive/src/parse.rs
+++ b/crates/dcc-mcp-pybridge-derive/src/parse.rs
@@ -12,8 +12,9 @@
 //! )
 //! ```
 //!
-//! `<mode>` is one of: `get` | `get(by_str)` | `get(clone)` | `set` |
-//! `repr` | `dict`. See [`FieldMode`] for semantics.
+//! `<mode>` is one of: `get` | `get(by_str)` | `get(clone)` |
+//! `get(to_string)` | `set` | `repr` | `dict`. See [`FieldMode`] for
+//! semantics.
 
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
@@ -29,6 +30,10 @@ pub enum FieldMode {
     GetByStr,
     /// `#[getter] fn x(&self) -> T { self.<base>.x.clone() }` for owned types.
     GetClone,
+    /// `#[getter] fn x(&self) -> T { self.<base>.x.to_string() }` for
+    /// types whose `Display` impl is the canonical Python serialisation
+    /// (e.g. `Url`, `IpAddr`, `PathBuf`).
+    GetToString,
     /// `#[setter] fn set_x(&mut self, value: T) { self.<base>.x = value; }`.
     Set,
     /// Field appears in the auto-generated `__repr__` body via `{:?}`.
@@ -131,11 +136,12 @@ impl Parse for FieldMode {
                     match variant.to_string().as_str() {
                         "by_str" => FieldMode::GetByStr,
                         "clone" => FieldMode::GetClone,
+                        "to_string" => FieldMode::GetToString,
                         other => {
                             return Err(syn::Error::new(
                                 variant.span(),
                                 format!(
-                                    "unknown get variant `{other}`; expected `by_str` or `clone`"
+                                    "unknown get variant `{other}`; expected `by_str`, `clone`, or `to_string`"
                                 ),
                             ));
                         }
@@ -211,6 +217,12 @@ mod tests {
     fn rejects_unknown_get_variant() {
         let err = parse(r#"fields(x: u8 => [get(weird)])"#).unwrap_err();
         assert!(err.to_string().contains("unknown get variant"));
+    }
+
+    #[test]
+    fn parses_get_to_string() {
+        let attr = parse(r#"fields(host: String => [get(to_string)])"#).unwrap();
+        assert_eq!(attr.fields[0].modes, vec![FieldMode::GetToString]);
     }
 
     #[test]

--- a/crates/dcc-mcp-pybridge/tests/derive_smoke.rs
+++ b/crates/dcc-mcp-pybridge/tests/derive_smoke.rs
@@ -86,3 +86,52 @@ impl DirectStyle {
 fn direct_pattern_compiles() {
     let _ = std::mem::size_of::<DirectStyle>();
 }
+
+// --------------------------------------------------------- get(to_string) mode
+
+/// A type whose canonical Python serialisation is `Display`. Mimics the
+/// real-world pattern in `PyMcpHttpConfig::host()` where the inner field
+/// is a non-`String` type (e.g. `IpAddr`, `Url`) but Python sees a plain
+/// `str` produced via `to_string()`.
+#[derive(Default)]
+pub struct DisplayHolder {
+    pub label: u32,
+}
+
+impl std::fmt::Display for DisplayHolder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "label-{}", self.label)
+    }
+}
+
+#[derive(Default)]
+pub struct InnerToString {
+    pub label: DisplayHolder,
+}
+
+#[pyclass(name = "ToStringWrapper")]
+#[derive(PyWrapper)]
+#[py_wrapper(
+    inner = "InnerToString",
+    fields(
+        label: String => [get(to_string)],
+    ),
+)]
+pub struct ToStringWrapper {
+    pub inner: InnerToString,
+}
+
+#[pymethods]
+impl ToStringWrapper {
+    #[new]
+    fn new() -> Self {
+        Self {
+            inner: InnerToString::default(),
+        }
+    }
+}
+
+#[test]
+fn to_string_mode_compiles() {
+    let _ = std::mem::size_of::<ToStringWrapper>();
+}


### PR DESCRIPTION
## Summary

M3.1 of issue #528. Extends the `#[derive(PyWrapper)]` field-mode grammar with `get(to_string)`, emitting `self.<base>.<field>.to_string()` for fields whose canonical Python representation is `Display`. Required by the M3.2 adoption pass on `PyMcpHttpConfig` (`host()`, `endpoint_path()` style accessors that wrap `IpAddr`, `Url`, `PathBuf`, or other `Display`-only types).

## Why

The audit comment on #528 identified `host: self.inner.host.to_string()` as a pattern not covered by the existing `get` / `get(by_str)` / `get(clone)` modes. Without this mode, ~37 accessors in `PyMcpHttpConfig` alone would still need to be hand-written.

## Changes

| File | Change |
|---|---|
| `crates/dcc-mcp-pybridge-derive/src/parse.rs` | New `FieldMode::GetToString` variant; `get(to_string)` recognised inside `[…]`; updated error message lists all three accepted variants. |
| `crates/dcc-mcp-pybridge-derive/src/codegen.rs` | Emits `#[getter] fn x(&self) -> T { self.<base>.x.to_string() }`. |
| `crates/dcc-mcp-pybridge-derive/src/parse.rs` (tests) | Added `parses_get_to_string` unit test. |
| `crates/dcc-mcp-pybridge/tests/derive_smoke.rs` | New `to_string_mode_compiles` integration test using a custom `Display`-only inner type. |

## Verification

```text
cargo test -p dcc-mcp-pybridge-derive --lib              -> 8 / 8 passed
cargo test -p dcc-mcp-pybridge --features python-bindings
           --test derive_smoke                          -> 3 / 3 passed
cargo clippy -p dcc-mcp-pybridge-derive
             -p dcc-mcp-pybridge
             --all-targets --all-features -- -D warnings  -> clean
cargo fmt --all -- --check                                -> clean
```

## Refs

- #528 (M3 wave-based migration plan)
- #490 (original level-3 acceptance)