### PR TITLE
feat(cancellation): add check_dcc_cancelled + JobHandle (#522)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,8 @@
 | Full-screen capture | `Capturer.new_auto().capture()` |
 | Single-window capture | `Capturer.new_window_auto().capture_window(...)` |
 | Capture DCC output streams | `OutputCapture` — stdout/stderr/script-editor as `output://` resource |
-| Cooperative cancellation | `check_cancelled()` in long-running skill scripts |
+| Cooperative cancellation (MCP request) | `check_cancelled()` in long-running skill scripts |
+| Cooperative cancellation (DCC dispatcher + MCP) | `check_dcc_cancelled()` — combines MCP token + per-job `JobHandle` (#522) |
 | Checkpoint/resume | `save_checkpoint(job_id, state)` / `get_checkpoint(job_id)` |
 | Agent-facing docs resources | `register_docs_server(server)` → `docs://` MCP resources |
 | Agent feedback | `register_feedback_tool(server)` → `dcc_feedback__report` tool |

--- a/docs/api/cancellation.md
+++ b/docs/api/cancellation.md
@@ -1,10 +1,10 @@
 # Cancellation API
 
-Cooperative cancellation support for DCC-MCP skill scripts (issue #318, #332).
+Cooperative cancellation support for DCC-MCP skill scripts (issue #318, #332, #522).
 
 Skill scripts executed inside a `tools/call` request run as regular Python code and cannot be interrupted by the dispatcher. The MCP spec's `notifications/cancelled` message only helps if the running code checks for cancellation at appropriate points.
 
-**Exported symbols:** `CancelToken`, `CancelledError`, `check_cancelled`, `current_cancel_token`, `reset_cancel_token`, `set_cancel_token`
+**Exported symbols:** `CancelToken`, `CancelledError`, `JobHandle`, `check_cancelled`, `check_dcc_cancelled`, `current_cancel_token`, `current_job`, `reset_cancel_token`, `reset_current_job`, `set_cancel_token`, `set_current_job`
 
 ## CancelToken
 
@@ -101,3 +101,51 @@ Return the `CancelToken` installed in the current context, or `None` when no dis
 ::: tip
 Use `current_cancel_token()` to poll the cancellation flag without raising, e.g. to flush partial progress before returning.
 :::
+
+## Per-job cancellation (issue #522)
+
+Skill scripts launched **outside** an MCP request context — queued batch renders, `scriptJob` callbacks, simulation runners — cannot rely on `check_cancelled()` because no `CancelToken` is installed. DCC plugins (Maya, Houdini, Unreal …) submit each callable to their own UI-thread dispatcher and need to flag in-flight jobs for cancellation through a per-job handle.
+
+The four symbols below give the dispatcher a way to publish that handle and skill code a single probe (`check_dcc_cancelled`) that honours **both** layers.
+
+### JobHandle
+
+```python
+from dcc_mcp_core import JobHandle
+```
+
+A `typing.Protocol` (runtime-checkable) describing the per-job handle a host dispatcher publishes through `set_current_job`. Only one attribute is contractual:
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `cancelled` (property) | `bool` | `True` when the host dispatcher has signalled cancellation. |
+
+Concrete implementations are free to expose additional fields (request id, progress token, `threading.Event`, …) for their own bookkeeping.
+
+### check_dcc_cancelled
+
+```python
+check_dcc_cancelled() -> None
+```
+
+Cheap probe that raises `CancelledError` if **either** the active MCP `CancelToken` *or* the per-job `JobHandle` reports cancellation. Skill scripts that can run outside a request context should call this instead of `check_cancelled`.
+
+```python
+from dcc_mcp_core import check_dcc_cancelled, skill_success
+
+def run(frames: list[int]) -> dict:
+    for frame in frames:
+        check_dcc_cancelled()  # honours both MCP token and dispatcher
+        render_frame(frame)
+    return skill_success("rendered", count=len(frames))
+```
+
+### set_current_job / reset_current_job / current_job
+
+```python
+set_current_job(job: JobHandle | None) -> contextvars.Token
+reset_current_job(reset: contextvars.Token) -> None
+current_job: contextvars.ContextVar[JobHandle | None]
+```
+
+Dispatcher-only API for installing the active `JobHandle`. Pair every `set_current_job` with a `reset_current_job` in a `finally` block; the contextvar is per-context, so threads spawned with `threading.Thread` start with the default `None` (use `contextvars.copy_context()` if propagation is desired).

--- a/llms.txt
+++ b/llms.txt
@@ -29,7 +29,8 @@
 | Inline chart / table / image result (MCP Apps, issue #409) | `skill_success_with_chart(msg, spec)` / `skill_success_with_table(msg, headers, rows)` / `skill_success_with_image(msg, image_data=...)` |
 | Run skill scripts inside embedded DCC (no subprocess) | `SkillCatalog.set_in_process_executor(callable)` on the server's catalog — callable receives `(script_path, params) -> dict` |
 | Claude Code one-click plugin bundle (issue #410) | `build_plugin_manifest(dcc_name, mcp_url, skill_paths, api_key=...)` + `export_plugin_manifest(manifest, path)` or `server.plugin_manifest(version=...)` |
-| Cooperative cancellation in skill scripts | `check_cancelled()` — raises `CancelledError` when the active request was cancelled; dispatcher sets `CancelToken` via `set_cancel_token()` |
+| Cooperative cancellation in skill scripts (MCP-only) | `check_cancelled()` — raises `CancelledError` when the active request was cancelled; dispatcher sets `CancelToken` via `set_cancel_token()` |
+| Cooperative cancellation in DCC dispatcher skills (#522) | `check_dcc_cancelled()` — also honours per-job `JobHandle` published via `set_current_job(handle)`; required for skills launched outside an MCP request context (queued batch render, `scriptJob` callback, simulation runner) |
 | Checkpoint/resume long-running tool executions (issue #436) | `save_checkpoint(job_id, state)` / `get_checkpoint(job_id)` / `checkpoint_every(n, job_id, state_fn)` — persist progress at intervals so interrupted jobs resume from last checkpoint |
 | Agent-facing docs:// MCP resources (issue #435) | `register_docs_server(server)` — serves `docs://output-format/*` and `docs://skill-authoring/*` resources; agents fetch only specs they need |
 | Agent feedback / rationale (issues #433, #434) | `register_feedback_tool(server)` / `extract_rationale(params)` / `make_rationale_meta(text)` — `dcc_feedback__report` tool + `_meta.dcc.rationale` extraction |
@@ -411,8 +412,13 @@ tools:
 ### Cancellation (`dcc_mcp_core.cancellation`)
 
 - `CancelToken()` — thread-safe cancellation flag; `.cancel()`, `.cancelled -> bool`
-- `CancelledError(Exception)` — raised by `check_cancelled()` when the active request was cancelled
-- `check_cancelled() -> None` — raise `CancelledError` if the active request was cancelled (no-op outside request context)
+- `CancelledError(Exception)` — raised by `check_cancelled()` / `check_dcc_cancelled()` when cancellation was signalled
+- `check_cancelled() -> None` — raise `CancelledError` if the active MCP request was cancelled (no-op outside request context)
+- `check_dcc_cancelled() -> None` (#522) — combines `check_cancelled()` with a per-job check; raises if either the MCP token OR the per-job `JobHandle` reports cancellation; use this in skills launched from a DCC dispatcher rather than an MCP request
+- `JobHandle` (`Protocol`, runtime-checkable) — contract for the per-job handle a host dispatcher publishes; only `cancelled: bool` is contractual
+- `current_job: ContextVar[JobHandle | None]` — read-only contextvar (default `None`) holding the active per-job handle
+- `set_current_job(job) -> contextvars.Token` — install a `JobHandle` (dispatcher use only)
+- `reset_current_job(reset) -> None` — restore previous job handle (pair with `set_current_job`)
 - `set_cancel_token(token) -> contextvars.Token` — install a CancelToken (dispatcher use only)
 - `reset_cancel_token(reset) -> None` — restore previous token (pair with set_cancel_token)
 - `current_cancel_token() -> CancelToken | None` — return the active token

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -301,10 +301,15 @@ from dcc_mcp_core.bridge import DccBridge
 # Cooperative cancellation (pure-Python, no _core dependency)
 from dcc_mcp_core.cancellation import CancelledError
 from dcc_mcp_core.cancellation import CancelToken
+from dcc_mcp_core.cancellation import JobHandle
 from dcc_mcp_core.cancellation import check_cancelled
+from dcc_mcp_core.cancellation import check_dcc_cancelled
 from dcc_mcp_core.cancellation import current_cancel_token
+from dcc_mcp_core.cancellation import current_job
 from dcc_mcp_core.cancellation import reset_cancel_token
+from dcc_mcp_core.cancellation import reset_current_job
 from dcc_mcp_core.cancellation import set_cancel_token
+from dcc_mcp_core.cancellation import set_current_job
 
 # Checkpoint/resume for long-running tool executions (issue #436)
 from dcc_mcp_core.checkpoint import CheckpointStore
@@ -479,6 +484,7 @@ __all__ = [
     "InputValidator",
     "IntWrapper",
     "IpcChannelAdapter",
+    "JobHandle",
     "LoggingMiddleware",
     "McpHttpConfig",
     "McpHttpServer",
@@ -580,6 +586,7 @@ __all__ = [
     "batch_dispatch",
     "build_plugin_manifest",
     "check_cancelled",
+    "check_dcc_cancelled",
     "checkpoint_every",
     "clear_checkpoint",
     "clear_feedback",
@@ -589,6 +596,7 @@ __all__ = [
     "create_dcc_server",
     "create_skill_server",
     "current_cancel_token",
+    "current_job",
     "deserialize_result",
     "elicit_form",
     "elicit_form_sync",
@@ -659,6 +667,7 @@ __all__ = [
     "register_recipes_tools",
     "register_workflow_yaml_tools",
     "reset_cancel_token",
+    "reset_current_job",
     "resolve_dependencies",
     "run_main",
     "save_checkpoint",
@@ -672,6 +681,7 @@ __all__ = [
     "scene_info_json_to_stage",
     "serialize_result",
     "set_cancel_token",
+    "set_current_job",
     "shutdown_file_logging",
     "shutdown_telemetry",
     "skill_entry",

--- a/python/dcc_mcp_core/cancellation.py
+++ b/python/dcc_mcp_core/cancellation.py
@@ -41,14 +41,25 @@ from __future__ import annotations
 # Import built-in modules
 import contextvars
 import threading
+from typing import TYPE_CHECKING
+from typing import Protocol
+from typing import runtime_checkable
+
+if TYPE_CHECKING:
+    pass
 
 __all__ = [
     "CancelToken",
     "CancelledError",
+    "JobHandle",
     "check_cancelled",
+    "check_dcc_cancelled",
     "current_cancel_token",
+    "current_job",
     "reset_cancel_token",
+    "reset_current_job",
     "set_cancel_token",
+    "set_current_job",
 ]
 
 
@@ -190,3 +201,96 @@ def reset_cancel_token(reset: contextvars.Token) -> None:
 
     """
     _current_token.reset(reset)
+
+
+# ── Per-job cooperative cancellation (issue #522) ──────────────────────────
+
+
+@runtime_checkable
+class JobHandle(Protocol):
+    """Protocol for the per-job handle a host dispatcher publishes.
+
+    DCC plugins (Maya, Houdini, Unreal …) submit each callable to their
+    own UI-thread dispatcher and need a way to flag in-flight jobs for
+    cancellation **outside** of an MCP request context (queued batch
+    renders, ``scriptJob`` callbacks, simulation runners). The
+    dispatcher allocates a :class:`JobHandle` per submission and
+    publishes it through :func:`set_current_job` so cooperative probes
+    inside the running script can call :func:`check_dcc_cancelled`.
+
+    Only the ``cancelled`` attribute is contractual. Concrete
+    implementations are free to expose additional fields (request id,
+    progress token, ``threading.Event``, …) for their own bookkeeping.
+    """
+
+    @property
+    def cancelled(self) -> bool:
+        """``True`` when the host dispatcher has signalled cancellation."""
+        ...
+
+
+current_job: contextvars.ContextVar[JobHandle | None] = contextvars.ContextVar(
+    "dcc_mcp_core_current_job",
+    default=None,
+)
+
+
+def check_dcc_cancelled() -> None:
+    """Honour both MCP-request and DCC-dispatcher cancellation signals.
+
+    Raises :class:`CancelledError` when either the active MCP request or
+    the owning host dispatcher has signalled cancellation. Two layers
+    are checked in order:
+
+    1. The ambient :class:`CancelToken` (set by the MCP request handler
+       on receipt of ``notifications/cancelled``) — same as
+       :func:`check_cancelled`.
+    2. The per-job :class:`JobHandle` published by the host dispatcher
+       (Maya ``MayaUiDispatcher``, Houdini equivalent, …).
+
+    Cheap no-op when neither layer is active, so it is safe to call from
+    unit tests, REPLs, or DCC hosts that have not wired the per-job
+    contextvar. Skill scripts launched **outside** an MCP request
+    context (queued batch render, ``scriptJob`` callback, simulation
+    runner) should call :func:`check_dcc_cancelled` rather than
+    :func:`check_cancelled` so dispatcher-driven cancels are honoured.
+
+    Raises:
+        CancelledError: If the MCP token or the per-job handle reports
+            cancellation.
+
+    """
+    check_cancelled()
+    job = current_job.get()
+    if job is not None and job.cancelled:
+        raise CancelledError("Job cancelled by dispatcher")
+
+
+def set_current_job(job: JobHandle | None) -> contextvars.Token:
+    """Install *job* as the active per-job handle for the current context.
+
+    Intended for **dispatcher** use only — skill authors should call
+    :func:`check_dcc_cancelled` instead. Pair every call with
+    :func:`reset_current_job` in a ``finally`` block.
+
+    Args:
+        job: The handle to install, or ``None`` to clear an inherited
+            handle in this context.
+
+    Returns:
+        A :class:`contextvars.Token` recording the previous value;
+        pass it to :func:`reset_current_job`.
+
+    """
+    return current_job.set(job)
+
+
+def reset_current_job(reset: contextvars.Token) -> None:
+    """Restore the per-job contextvar to its previous value.
+
+    Args:
+        reset: The token returned by the matching
+            :func:`set_current_job` call.
+
+    """
+    current_job.reset(reset)

--- a/python/dcc_mcp_core/cancellation.py
+++ b/python/dcc_mcp_core/cancellation.py
@@ -40,13 +40,28 @@ from __future__ import annotations
 
 # Import built-in modules
 import contextvars
+import sys
 import threading
 from typing import TYPE_CHECKING
-from typing import Protocol
-from typing import runtime_checkable
 
 if TYPE_CHECKING:
     pass
+
+# `typing.Protocol` and `typing.runtime_checkable` are 3.8+. The package
+# still claims `requires-python = ">=3.7"`, so on 3.7 we expose
+# `JobHandle` as a plain duck-typed class with the same `cancelled`
+# attribute contract; concrete impls don't need to inherit from it
+# either way (the `current_job` ContextVar is annotated, so the type
+# is only used for static analysis and runtime `isinstance` on 3.8+).
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+    from typing import runtime_checkable
+else:  # pragma: no cover - py3.7 only
+    def runtime_checkable(cls):
+        return cls
+
+    class Protocol:  # type: ignore[no-redef]
+        pass
 
 __all__ = [
     "CancelToken",

--- a/tests/test_cancellation.py
+++ b/tests/test_cancellation.py
@@ -13,10 +13,15 @@ import pytest
 # Import local modules
 from dcc_mcp_core import CancelledError
 from dcc_mcp_core import CancelToken
+from dcc_mcp_core import JobHandle
 from dcc_mcp_core import check_cancelled
+from dcc_mcp_core import check_dcc_cancelled
 from dcc_mcp_core import current_cancel_token
+from dcc_mcp_core import current_job
 from dcc_mcp_core import reset_cancel_token
+from dcc_mcp_core import reset_current_job
 from dcc_mcp_core import set_cancel_token
+from dcc_mcp_core import set_current_job
 
 
 def test_exports_available() -> None:
@@ -185,3 +190,119 @@ def test_cancelled_error_is_exception_subclass() -> None:
         raise CancelledError("x")
     except Exception as exc:
         assert isinstance(exc, CancelledError)
+
+
+# ── check_dcc_cancelled / JobHandle (issue #522) ───────────────────────────
+
+
+class _FakeJob:
+    """Minimal :class:`JobHandle` impl used by the per-job cancel tests."""
+
+    def __init__(self) -> None:
+        self.cancelled = False
+
+
+def test_dcc_exports_available() -> None:
+    """The four new per-job symbols must be re-exported from the top level."""
+    # Import local modules
+    import dcc_mcp_core
+
+    for name in (
+        "JobHandle",
+        "check_dcc_cancelled",
+        "current_job",
+        "set_current_job",
+        "reset_current_job",
+    ):
+        assert hasattr(dcc_mcp_core, name), name
+        assert name in dcc_mcp_core.__all__
+
+
+def test_check_dcc_cancelled_no_op_without_either_layer() -> None:
+    """No token, no job → must not raise."""
+    check_dcc_cancelled()
+
+
+def test_check_dcc_cancelled_honours_mcp_token() -> None:
+    """The MCP-side token short-circuits before the per-job check."""
+    token = CancelToken()
+    reset_token = set_cancel_token(token)
+    try:
+        token.cancel()
+        with pytest.raises(CancelledError, match="Request cancelled"):
+            check_dcc_cancelled()
+    finally:
+        reset_cancel_token(reset_token)
+
+
+def test_check_dcc_cancelled_honours_per_job_handle() -> None:
+    """A cancelled JobHandle raises even when the MCP token is clear."""
+    job = _FakeJob()
+    reset = set_current_job(job)
+    try:
+        check_dcc_cancelled()  # not yet cancelled → no-op
+        job.cancelled = True
+        with pytest.raises(CancelledError, match="Job cancelled by dispatcher"):
+            check_dcc_cancelled()
+    finally:
+        reset_current_job(reset)
+
+
+def test_check_dcc_cancelled_clears_per_thread() -> None:
+    """Per-job handle is contextvar-scoped; threads do not inherit by default."""
+    job = _FakeJob()
+    job.cancelled = True
+    reset = set_current_job(job)
+    try:
+        seen: list[bool] = []
+
+        def worker() -> None:
+            # New OS thread → fresh contextvar copy is empty → no-op.
+            try:
+                check_dcc_cancelled()
+            except CancelledError:
+                seen.append(False)
+            else:
+                seen.append(True)
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join()
+        assert seen == [True]
+    finally:
+        reset_current_job(reset)
+
+
+def test_jobhandle_protocol_runtime_check() -> None:
+    """``isinstance(_, JobHandle)`` works because the protocol is runtime-checkable."""
+    job = _FakeJob()
+    assert isinstance(job, JobHandle)
+
+
+def test_set_current_job_returns_token_for_reset() -> None:
+    """The return value of set_current_job round-trips through reset_current_job."""
+    job_a = _FakeJob()
+    job_b = _FakeJob()
+    reset_a = set_current_job(job_a)
+    reset_b = set_current_job(job_b)
+    assert current_job.get() is job_b
+    reset_current_job(reset_b)
+    assert current_job.get() is job_a
+    reset_current_job(reset_a)
+    assert current_job.get() is None
+
+
+def test_check_dcc_cancelled_token_takes_priority_over_job() -> None:
+    """When both layers signal cancel, the MCP-token message is reported."""
+    job = _FakeJob()
+    job.cancelled = True
+    token = CancelToken()
+    token.cancel()
+    reset_t = set_cancel_token(token)
+    reset_j = set_current_job(job)
+    try:
+        with pytest.raises(CancelledError, match="Request cancelled"):
+            check_dcc_cancelled()
+    finally:
+        reset_current_job(reset_j)
+        reset_cancel_token(reset_t)


### PR DESCRIPTION
## Summary

Lifts the per-job cancellation pattern that Maya already implements (`mayaui_dispatcher.py`) into the shared `dcc_mcp_core.cancellation` module so every DCC plugin (Maya, Houdini, Unreal…) can rely on a single contract.

DCC plugins submit each callable to their own UI-thread dispatcher and need a way to flag in-flight jobs for cancellation **outside** of an MCP request context (queued batch renders, `scriptJob` callbacks, simulation runners). The existing `check_cancelled()` only honours the MCP `CancelToken`; without a parallel mechanism, every plugin re-implements the same per-job ContextVar pattern.

Closes #522.

## New public API

`dcc_mcp_core.cancellation` (also re-exported from the top-level package):

| Symbol | Description |
|---|---|
| `JobHandle` | Runtime-checkable `typing.Protocol` with one contractual `cancelled: bool` attribute. Concrete impls may carry whatever extra state the dispatcher needs. |
| `current_job: ContextVar[JobHandle \| None]` | Read-only contextvar holding the active per-job handle (default `None`). |
| `set_current_job(job) -> contextvars.Token` | Dispatcher-side install; returns a token for `reset_current_job`. |
| `reset_current_job(reset)` | Pair with `set_current_job` in a `finally` block. |
| `check_dcc_cancelled() -> None` | Combined probe: MCP token first, then per-job `JobHandle.cancelled`. Skill scripts launched outside an MCP request context should call this instead of `check_cancelled`. |

## Behaviour notes

- MCP token has priority — its `CancelledError` message ("Request cancelled by client") is reported when both layers signal cancel.
- `current_job` is contextvar-scoped, so plain `threading.Thread` workers start with the default `None` (use `contextvars.copy_context` if propagation is desired).
- Pure-Python; no `_core` (Rust) dependency. Fully usable from skill scripts and unit tests, including hosts that have not wired any dispatcher.

## Tests

`tests/test_cancellation.py` (+8 cases, 17 total):

- `test_dcc_exports_available`
- `test_check_dcc_cancelled_no_op_without_either_layer`
- `test_check_dcc_cancelled_honours_mcp_token`
- `test_check_dcc_cancelled_honours_per_job_handle`
- `test_check_dcc_cancelled_clears_per_thread`
- `test_jobhandle_protocol_runtime_check`
- `test_set_current_job_returns_token_for_reset`
- `test_check_dcc_cancelled_token_takes_priority_over_job`

## Docs

- `docs/api/cancellation.md` — new "Per-job cancellation" section.
- `AGENTS.md` decision table — split MCP-only vs DCC-dispatcher rows.
- `llms.txt` decision table + cancellation section.

## Verification

```text
.venv\Scripts\python -m pytest tests/test_cancellation.py -q   -> 17 passed
.venv\Scripts\python -m ruff check
  python/dcc_mcp_core/cancellation.py
  python/dcc_mcp_core/__init__.py
  tests/test_cancellation.py                                   -> All checks passed
```