### PR TITLE
feat(transport): add FileRegistry::read_alive auto-eviction (#523)

### DIFF
--- a/crates/dcc-mcp-transport/src/discovery/file_registry.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry.rs
@@ -400,6 +400,49 @@ impl FileRegistry {
         Ok(count)
     }
 
+    /// Read all live entries, evicting any whose owning OS process is dead.
+    ///
+    /// Combines the reload-if-stale + [`Self::prune_dead_pids`] + [`Self::list_all`]
+    /// dance into a single call so external readers (gateway aggregator,
+    /// gateway election (#523), `dcc-mcp-cli`, third-party tools) get
+    /// auto-eviction at read time without re-implementing the pattern.
+    ///
+    /// Returns `(live_entries, evicted_count)`. `evicted_count` is `0` on the
+    /// happy path, so callers can fall back to a simple `read_alive()?.0` if
+    /// they only care about the rows. The atomic temp+rename rewrite of
+    /// `services.json` happens automatically inside `prune_dead_pids` whenever
+    /// at least one entry is evicted.
+    ///
+    /// Closes loonghao/dcc-mcp-maya#126.
+    pub fn read_alive(&self) -> TransportResult<(Vec<ServiceEntry>, usize)> {
+        let evicted = self.prune_dead_pids()?;
+        Ok((self.list_all(), evicted))
+    }
+
+    /// [`Self::read_alive`] + a `tracing::warn!` whenever the eviction count
+    /// crosses `warn_threshold`.
+    ///
+    /// Intended for the gateway's startup audit and any background reaper
+    /// task that wants visibility on chronic ghost-row accumulation. The
+    /// default threshold for callers that don't care about precision is
+    /// `10` — small enough to surface real problems, large enough to absorb
+    /// a single noisy crash on startup without spamming the log.
+    pub fn read_alive_with_log(
+        &self,
+        warn_threshold: usize,
+    ) -> TransportResult<(Vec<ServiceEntry>, usize)> {
+        let (entries, evicted) = self.read_alive()?;
+        if evicted >= warn_threshold {
+            tracing::warn!(
+                evicted,
+                warn_threshold,
+                kept = entries.len(),
+                "FileRegistry::read_alive evicted ghost entries above warn threshold"
+            );
+        }
+        Ok((entries, evicted))
+    }
+
     /// Get the number of registered services.
     pub fn len(&self) -> usize {
         self.services.len()

--- a/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
@@ -295,3 +295,100 @@ fn test_file_registry_update_metadata() {
             .unwrap()
     );
 }
+
+// ── read_alive auto-eviction (issue #523) ─────────────────────────────────
+
+#[test]
+fn test_read_alive_evicts_ghost_and_returns_live() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = FileRegistry::new(dir.path()).unwrap();
+
+    // Live entry (auto-populated pid == our own process id).
+    let live = ServiceEntry::new("maya", "127.0.0.1", 18812);
+    let live_key = live.key();
+    registry.register(live).unwrap();
+
+    // Ghost entry with a clearly-dead PID.
+    let ghost = ServiceEntry::new("maya", "127.0.0.1", 18813).with_pid(u32::MAX);
+    let ghost_key = ghost.key();
+    registry.register(ghost).unwrap();
+
+    let (entries, evicted) = registry.read_alive().unwrap();
+    assert_eq!(evicted, 1, "exactly one ghost row must be evicted");
+    assert_eq!(entries.len(), 1, "only the live row must remain");
+    assert!(registry.get(&live_key).is_some());
+    assert!(registry.get(&ghost_key).is_none());
+}
+
+#[test]
+fn test_read_alive_returns_zero_evicted_when_all_live() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = FileRegistry::new(dir.path()).unwrap();
+
+    let entry_a = ServiceEntry::new("maya", "127.0.0.1", 18812);
+    let entry_b = ServiceEntry::new("blender", "127.0.0.1", 9090);
+    registry.register(entry_a).unwrap();
+    registry.register(entry_b).unwrap();
+
+    let (entries, evicted) = registry.read_alive().unwrap();
+    assert_eq!(evicted, 0);
+    assert_eq!(entries.len(), 2);
+}
+
+#[test]
+fn test_read_alive_idempotent_after_first_call() {
+    // Once a ghost has been evicted, subsequent read_alive calls report
+    // evicted == 0 and the file rewrite is not repeated.
+    let dir = tempfile::tempdir().unwrap();
+    let registry = FileRegistry::new(dir.path()).unwrap();
+
+    let live = ServiceEntry::new("maya", "127.0.0.1", 18812);
+    registry.register(live).unwrap();
+    let ghost = ServiceEntry::new("maya", "127.0.0.1", 18813).with_pid(u32::MAX);
+    registry.register(ghost).unwrap();
+
+    let (_, evicted_first) = registry.read_alive().unwrap();
+    assert_eq!(evicted_first, 1);
+    let (entries, evicted_second) = registry.read_alive().unwrap();
+    assert_eq!(evicted_second, 0);
+    assert_eq!(entries.len(), 1);
+}
+
+#[test]
+fn test_read_alive_with_log_returns_same_result() {
+    // The logging variant must behave identically apart from emitting a
+    // warn on the threshold cross — verify the data path here, leave the
+    // log assertion to a manual smoke (tracing-test would be a heavy dep).
+    let dir = tempfile::tempdir().unwrap();
+    let registry = FileRegistry::new(dir.path()).unwrap();
+
+    let live = ServiceEntry::new("maya", "127.0.0.1", 18812);
+    registry.register(live).unwrap();
+    let ghost = ServiceEntry::new("maya", "127.0.0.1", 18813).with_pid(u32::MAX);
+    registry.register(ghost).unwrap();
+
+    // Threshold larger than the eviction count → no warn, but counts match.
+    let (entries, evicted) = registry.read_alive_with_log(100).unwrap();
+    assert_eq!(evicted, 1);
+    assert_eq!(entries.len(), 1);
+}
+
+#[test]
+fn test_read_alive_handles_multiple_ghosts_for_dcc_maya_126() {
+    // Reproduces loonghao/dcc-mcp-maya#126: gateway sees N stale instances
+    // because Maya crashed N times without cleanup. read_alive should
+    // evict them all in a single sweep.
+    let dir = tempfile::tempdir().unwrap();
+    let registry = FileRegistry::new(dir.path()).unwrap();
+
+    for port in 18812..18812 + 5 {
+        let ghost = ServiceEntry::new("maya", "127.0.0.1", port).with_pid(u32::MAX - port as u32);
+        registry.register(ghost).unwrap();
+    }
+    let live = ServiceEntry::new("maya", "127.0.0.1", 19000);
+    registry.register(live).unwrap();
+
+    let (entries, evicted) = registry.read_alive().unwrap();
+    assert_eq!(evicted, 5);
+    assert_eq!(entries.len(), 1);
+}


### PR DESCRIPTION
## Summary

DCCs crash. When Maya/Houdini/Unreal terminates without running cleanup hooks, the `FileRegistry` JSON entry for the MCP server instance is left behind. Today, eviction happens lazily inside `dcc-mcp-gateway`'s periodic `prune_dead_pids` loop, often only on gateway restart, leaving stale entries visible to MCP clients between restarts. External readers (`gateway_election`, `dcc-mcp-cli`, third-party tools) re-implement the prune-then-list dance every time.

This change lifts that dance into a single public method on `FileRegistry` so any reader gets auto-eviction for free.

Closes #523. Refs loonghao/dcc-mcp-maya#126 ("Gateway: evicted N stale instance(s)").

## New API

`crates/dcc-mcp-transport/src/discovery/file_registry.rs`:

| Method | Description |
|---|---|
| `FileRegistry::read_alive() -> TransportResult<(Vec<ServiceEntry>, usize)>` | Combines `prune_dead_pids` + `list_all`. Returns `(live_entries, evicted_count)`. The atomic temp+rename rewrite of `services.json` happens automatically inside `prune_dead_pids` whenever at least one entry is evicted. |
| `FileRegistry::read_alive_with_log(warn_threshold: usize)` | Same, plus `tracing::warn!` whenever the eviction count crosses the threshold. Default-recommended threshold is `10` — small enough to surface real problems, large enough to absorb a single noisy crash on startup without spamming the log. |

## Hot-path policy

Gateway `tools/list`, aggregator fingerprint, and proxy lookup deliberately keep using `list_all` + the existing periodic `prune_dead_pids` task — calling sysinfo per request would add measurable latency. The new API targets cold paths (gateway election, CLI tools, third-party introspection).

## Tests

`crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs` (+5 cases, 17 total in module):

- `test_read_alive_evicts_ghost_and_returns_live` — single ghost
- `test_read_alive_returns_zero_evicted_when_all_live` — happy path
- `test_read_alive_idempotent_after_first_call` — second call is a no-op once ghosts are gone
- `test_read_alive_with_log_returns_same_result` — logging variant matches data path
- `test_read_alive_handles_multiple_ghosts_for_dcc_maya_126` — reproduces loonghao/dcc-mcp-maya#126's "5 stale instances after Maya crashes" scenario; one sweep evicts all five

## Verification

```text
cargo test -p dcc-mcp-transport --lib discovery::file_registry  -> 17 passed
cargo clippy -p dcc-mcp-transport --all-targets -- -D warnings   -> clean
cargo fmt --all -- --check                                       -> clean
```