### PR TITLE
feat(tunnel): scaffold dcc-mcp-tunnel-{protocol,relay,agent} crates (#504 PR 1/5)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@
 | IPC | `IpcChannelAdapter` / `SocketServerAdapter` + `DccLinkFrame` |
 | Hand off files between tools | `FileRef` + `artefact_put_file()` / `artefact_get_bytes()` |
 | Multi-DCC gateway | `McpHttpConfig(gateway_port=9765)` |
+| Remote MCP relay (zero-config tunnel) | `dcc-mcp-tunnel-protocol` (frame codec + JWT) + `dcc-mcp-tunnel-relay` (server) + `dcc-mcp-tunnel-agent` (local sidecar) — issue #504; **skeleton only in v0.14**, control / data planes land in follow-up PRs |
 | Gateway failover | `DccGatewayElection(dcc_name, server)` — auto-promote on gateway failure |
 | Skill scoping | `SkillScope` (Repo → User → System → Admin) — Rust-only |
 | Progressive tool exposure | `SkillGroup` + `activate_tool_group()` |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,6 +1065,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "dcc-mcp-tunnel-agent"
+version = "0.14.16"
+dependencies = [
+ "dcc-mcp-tunnel-protocol",
+ "serde",
+ "thiserror 2.0.18",
+ "tracing",
+ "workspace-hack",
+]
+
+[[package]]
+name = "dcc-mcp-tunnel-protocol"
+version = "0.14.16"
+dependencies = [
+ "jsonwebtoken",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "workspace-hack",
+]
+
+[[package]]
+name = "dcc-mcp-tunnel-relay"
+version = "0.14.16"
+dependencies = [
+ "dashmap",
+ "dcc-mcp-tunnel-protocol",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "workspace-hack",
+]
+
+[[package]]
 name = "dcc-mcp-usd"
 version = "0.14.16"
 dependencies = [
@@ -2092,6 +2129,19 @@ dependencies = [
  "regex",
  "serde_json",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "ring",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -5352,6 +5402,7 @@ dependencies = [
  "futures-executor",
  "futures-task",
  "futures-util",
+ "getrandom 0.2.17",
  "getrandom 0.4.2",
  "hyper",
  "hyper-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ members = [
     "crates/dcc-mcp-workflow",
     "crates/dcc-mcp-scheduler",
     "crates/dcc-mcp-artefact",
+    "crates/dcc-mcp-tunnel-protocol",
+    "crates/dcc-mcp-tunnel-relay",
+    "crates/dcc-mcp-tunnel-agent",
     "crates/workspace-hack",
 ]
 resolver = "2"
@@ -59,6 +62,9 @@ dcc-mcp-server = { path = "crates/dcc-mcp-server" }
 dcc-mcp-workflow = { path = "crates/dcc-mcp-workflow" }
 dcc-mcp-scheduler = { path = "crates/dcc-mcp-scheduler" }
 dcc-mcp-artefact = { path = "crates/dcc-mcp-artefact" }
+dcc-mcp-tunnel-protocol = { path = "crates/dcc-mcp-tunnel-protocol" }
+dcc-mcp-tunnel-relay = { path = "crates/dcc-mcp-tunnel-relay" }
+dcc-mcp-tunnel-agent = { path = "crates/dcc-mcp-tunnel-agent" }
 
 # Shared dependencies (single version across workspace)
 pyo3 = { version = "0.28", features = ["multiple-pymethods"] }
@@ -93,6 +99,10 @@ base64 = "0.22"
 # only when the `job-persist-sqlite` feature is enabled on `dcc-mcp-http`;
 # otherwise zero SQLite code compiles into the wheel.
 rusqlite = { version = "0.39", features = ["bundled"] }
+
+# JWT bearer auth for the tunnel relay (issue #504). HS256 today; RS256/EdDSA
+# can be added in a later PR without touching the protocol crate's public API.
+jsonwebtoken = { version = "9.3", default-features = false }
 
 # Type-stub generation (opt-in via `stub-gen` feature). Used only by the
 # `stub_gen` binary target — never pulled into wheels or library consumers.

--- a/crates/dcc-mcp-tunnel-agent/Cargo.toml
+++ b/crates/dcc-mcp-tunnel-agent/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "dcc-mcp-tunnel-agent"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Local sidecar that bridges a DCC's MCP HTTP server to a public dcc-mcp-tunnel-relay (issue #504). Maintains the WebSocket leg, handles per-session multiplexing, reconnects on transient failures."
+
+[dependencies]
+dcc-mcp-tunnel-protocol = { workspace = true }
+
+serde = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/crates/dcc-mcp-tunnel-agent/src/config.rs
+++ b/crates/dcc-mcp-tunnel-agent/src/config.rs
@@ -1,0 +1,97 @@
+//! Agent-side configuration.
+
+use std::time::Duration;
+
+/// Reconnect policy used when the relay leg drops.
+///
+/// The agent always retries — there is no `Never` variant — because the
+/// only sensible behaviour for a sidecar is to keep the tunnel alive
+/// until the operator explicitly tears it down.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReconnectPolicy {
+    /// Constant delay between attempts. Easiest to reason about; suitable
+    /// for tests and well-connected LAN deployments.
+    Constant {
+        /// Wait this long between attempts.
+        delay: Duration,
+    },
+
+    /// Exponential back-off, doubling each attempt up to a ceiling. The
+    /// first retry happens after `initial`; the n-th waits
+    /// `min(initial * 2^(n-1), max)`. After 60 minutes of unbroken
+    /// failure the backoff resets to `initial`.
+    Exponential {
+        /// Delay before the first retry.
+        initial: Duration,
+        /// Hard ceiling on the delay between attempts.
+        max: Duration,
+    },
+}
+
+impl Default for ReconnectPolicy {
+    fn default() -> Self {
+        Self::Exponential {
+            initial: Duration::from_secs(2),
+            max: Duration::from_secs(60),
+        }
+    }
+}
+
+/// Configuration for a `dcc-mcp-tunnel-agent` instance.
+#[derive(Debug, Clone)]
+pub struct AgentConfig {
+    /// `wss://relay.example.com` — the relay's WebSocket entrypoint. The
+    /// agent appends the registration path itself.
+    pub relay_url: String,
+
+    /// Bearer JWT minted by [`dcc_mcp_tunnel_protocol::auth::issue`].
+    /// Embedded into the `RegisterRequest` frame.
+    pub token: String,
+
+    /// DCC tag this agent identifies with (`"maya"`, `"houdini"`, …).
+    /// Must be in the JWT's `allowed_dcc` list, otherwise the relay
+    /// rejects the registration with `DccNotAllowed`.
+    pub dcc: String,
+
+    /// Capability tags forwarded to remote clients via the relay.
+    pub capabilities: Vec<String>,
+
+    /// Build identifier reported to the relay; surfaced in `/tunnels`
+    /// listings only.
+    pub agent_version: String,
+
+    /// `127.0.0.1:8765` — local MCP HTTP server the agent bridges to.
+    /// On each `OpenSession` from the relay, the agent opens a fresh
+    /// connection here.
+    pub local_target: String,
+
+    /// Cadence at which the agent emits `Frame::Heartbeat`. The relay
+    /// evicts tunnels silent longer than its own `stale_timeout`, so
+    /// keep this comfortably under that window.
+    pub heartbeat_interval: Duration,
+
+    /// What to do when the relay leg drops.
+    pub reconnect: ReconnectPolicy,
+}
+
+impl AgentConfig {
+    /// Sensible defaults for everything except the four fields the
+    /// operator must fill in (`relay_url`, `token`, `dcc`, `local_target`).
+    pub fn new(
+        relay_url: impl Into<String>,
+        token: impl Into<String>,
+        dcc: impl Into<String>,
+        local_target: impl Into<String>,
+    ) -> Self {
+        Self {
+            relay_url: relay_url.into(),
+            token: token.into(),
+            dcc: dcc.into(),
+            capabilities: Vec::new(),
+            agent_version: format!("dcc-mcp-tunnel-agent/{}", env!("CARGO_PKG_VERSION")),
+            local_target: local_target.into(),
+            heartbeat_interval: Duration::from_secs(10),
+            reconnect: ReconnectPolicy::default(),
+        }
+    }
+}

--- a/crates/dcc-mcp-tunnel-agent/src/lib.rs
+++ b/crates/dcc-mcp-tunnel-agent/src/lib.rs
@@ -1,0 +1,16 @@
+//! Local sidecar that bridges a DCC's MCP HTTP server to a public relay.
+//!
+//! Issue #504 ships in five PRs; this crate is the **client** half. The
+//! current PR (#1 of 5) only lands configuration types and the reconnect
+//! policy enum — the actual WebSocket loop and per-session multiplexer
+//! land in PRs 2 and 3 respectively.
+//!
+//! See `dcc-mcp-tunnel-protocol` for the on-the-wire frame format and
+//! `dcc-mcp-tunnel-relay` for the public-facing server.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms)]
+
+pub mod config;
+
+pub use config::{AgentConfig, ReconnectPolicy};

--- a/crates/dcc-mcp-tunnel-protocol/Cargo.toml
+++ b/crates/dcc-mcp-tunnel-protocol/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "dcc-mcp-tunnel-protocol"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Wire protocol shared by dcc-mcp-tunnel-relay (server) and dcc-mcp-tunnel-agent (client). Frame codec + JWT auth claims for the zero-config remote MCP relay (issue #504)."
+
+[dependencies]
+serde = { workspace = true }
+rmp-serde = { workspace = true }
+thiserror = { workspace = true }
+jsonwebtoken = { workspace = true }
+workspace-hack = { version = "0.1", path = "../workspace-hack" }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/dcc-mcp-tunnel-protocol/src/auth.rs
+++ b/crates/dcc-mcp-tunnel-protocol/src/auth.rs
@@ -1,0 +1,126 @@
+//! JWT-based bearer authentication for tunnel registration.
+//!
+//! The relay holds a single shared secret and signs/validates HS256 tokens
+//! against it. Per-DCC scoping is encoded in the [`TunnelClaims::allowed_dcc`]
+//! list so a token issued for "maya" cannot be replayed by an agent that
+//! identifies itself as "houdini".
+//!
+//! Asymmetric signing (RS256/EdDSA) and key rotation are deliberately
+//! deferred — they belong in PR 5 (hardening) once the data plane works.
+
+use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation, decode, encode};
+use serde::{Deserialize, Serialize};
+
+use crate::error::ProtocolError;
+
+/// Claims encoded inside a tunnel registration JWT.
+///
+/// Standard JWT timestamp claims are `iat` (issued-at) and `exp` (expiry),
+/// both expressed as **Unix seconds** so they round-trip cleanly through
+/// [`jsonwebtoken`]. The relay rejects tokens with `exp <= now` and tokens
+/// whose `iat` lies in the future (clock-skew window: 60 s).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TunnelClaims {
+    /// Subject — usually a stable agent identifier (e.g. workstation
+    /// hostname, operator email, or a wildcard like `"any"` for shared
+    /// secrets).
+    pub sub: String,
+
+    /// Issued-at (Unix seconds).
+    pub iat: u64,
+
+    /// Expiry (Unix seconds). Tokens with `exp <= now` are rejected.
+    pub exp: u64,
+
+    /// Issuer hint (e.g. relay public hostname). Logged but not enforced.
+    pub iss: String,
+
+    /// Allow-list of DCC tags this token can register under. The relay
+    /// matches [`crate::frame::RegisterRequest::dcc`] against this list and
+    /// rejects with [`crate::frame::ErrorCode::DccNotAllowed`] on mismatch.
+    /// An empty list permits any DCC (used by admin/test tokens).
+    pub allowed_dcc: Vec<String>,
+}
+
+/// Sign `claims` using `secret`. Produces a compact `"header.payload.sig"`
+/// string suitable for an `Authorization: Bearer …` header.
+pub fn issue(claims: &TunnelClaims, secret: &[u8]) -> Result<String, ProtocolError> {
+    let header = Header::new(Algorithm::HS256);
+    let key = EncodingKey::from_secret(secret);
+    let token = encode(&header, claims, &key)?;
+    Ok(token)
+}
+
+/// Validate `token` against `secret` and return the decoded claims.
+///
+/// Validation enforces signature, `exp`, and a 60-second clock-skew
+/// tolerance on `iat`. **DCC scoping is not enforced here** — that
+/// happens in the relay after parsing the [`crate::frame::RegisterRequest`]
+/// because the requested DCC is not part of the JWT payload.
+pub fn validate(token: &str, secret: &[u8]) -> Result<TunnelClaims, ProtocolError> {
+    let mut v = Validation::new(Algorithm::HS256);
+    v.leeway = 60;
+    v.validate_exp = true;
+    // The standard `iss` / `aud` claims aren't enforced here; the relay
+    // simply records `iss` for telemetry.
+    v.required_spec_claims.clear();
+    v.required_spec_claims.insert("exp".into());
+    let key = DecodingKey::from_secret(secret);
+    let data = decode::<TunnelClaims>(token, &key, &v)?;
+    Ok(data.claims)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn now() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+
+    fn sample_claims(exp_offset_secs: i64) -> TunnelClaims {
+        let now = now();
+        let exp = if exp_offset_secs >= 0 {
+            now + exp_offset_secs as u64
+        } else {
+            now.saturating_sub((-exp_offset_secs) as u64)
+        };
+        TunnelClaims {
+            sub: "workstation-001".into(),
+            iat: now,
+            exp,
+            iss: "relay.example.com".into(),
+            allowed_dcc: vec!["maya".into(), "houdini".into()],
+        }
+    }
+
+    #[test]
+    fn round_trip_signed_claims() {
+        let secret = b"super-secret-key-for-tests-only";
+        let claims = sample_claims(3600);
+        let token = issue(&claims, secret).unwrap();
+        let decoded = validate(&token, secret).unwrap();
+        assert_eq!(decoded, claims);
+    }
+
+    #[test]
+    fn rejects_expired_token() {
+        let secret = b"super-secret-key-for-tests-only";
+        let claims = sample_claims(-3600); // expired an hour ago
+        let token = issue(&claims, secret).unwrap();
+        let err = validate(&token, secret).unwrap_err();
+        assert!(matches!(err, ProtocolError::Jwt(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn rejects_wrong_secret() {
+        let claims = sample_claims(3600);
+        let token = issue(&claims, b"correct-secret-correct-secret").unwrap();
+        let err = validate(&token, b"wrong-secret-wrong-secret-123").unwrap_err();
+        assert!(matches!(err, ProtocolError::Jwt(_)), "got {err:?}");
+    }
+}

--- a/crates/dcc-mcp-tunnel-protocol/src/codec.rs
+++ b/crates/dcc-mcp-tunnel-protocol/src/codec.rs
@@ -1,0 +1,201 @@
+//! Length-prefixed msgpack frame codec.
+//!
+//! Wire format (big-endian):
+//!
+//! ```text
+//!  ┌──────────────┬───────────────────────────┐
+//!  │  4-byte len  │  msgpack body (Frame)     │
+//!  │  (u32 BE)    │  len bytes                │
+//!  └──────────────┴───────────────────────────┘
+//! ```
+//!
+//! The 4-byte prefix is the body length **only** — it does not include
+//! the prefix itself. A complete frame on the wire occupies `4 + len`
+//! bytes.
+//!
+//! This module is transport-agnostic: callers feed it `Vec<u8>` and `&[u8]`
+//! buffers. The agent and relay both wrap the same primitives around their
+//! WebSocket message handlers.
+
+use crate::error::ProtocolError;
+use crate::frame::Frame;
+
+/// Hard upper bound on a single frame's body size (8 MiB).
+///
+/// Larger payloads must be chunked into multiple [`Frame::Data`] frames by
+/// the producer. This guard exists primarily to bound a malicious peer's
+/// allocation when an oversized length prefix is read off the wire.
+pub const MAX_FRAME_BYTES: u32 = 8 * 1024 * 1024;
+
+/// Serialise a single frame into a fresh `Vec<u8>` ready to write to a
+/// transport. The returned buffer always starts with the 4-byte length
+/// prefix, so it can be passed straight to `write_all`.
+pub fn encode(frame: &Frame) -> Result<Vec<u8>, ProtocolError> {
+    let body = rmp_serde::to_vec_named(frame)?;
+    let len = u32::try_from(body.len())
+        .map_err(|_| ProtocolError::FrameTooLarge(u32::MAX, MAX_FRAME_BYTES))?;
+    if len > MAX_FRAME_BYTES {
+        return Err(ProtocolError::FrameTooLarge(len, MAX_FRAME_BYTES));
+    }
+    let mut out = Vec::with_capacity(4 + body.len());
+    out.extend_from_slice(&len.to_be_bytes());
+    out.extend_from_slice(&body);
+    Ok(out)
+}
+
+/// Decode a single frame from `buf`. The buffer must start with the
+/// 4-byte length prefix. Returns `(frame, bytes_consumed)` so the caller
+/// can advance its read cursor.
+///
+/// For streaming consumers that build up partial frames across multiple
+/// reads, use [`Decoder`] instead.
+pub fn decode(buf: &[u8]) -> Result<(Frame, usize), ProtocolError> {
+    if buf.len() < 4 {
+        return Err(ProtocolError::Incomplete {
+            needed: 4,
+            have: buf.len(),
+        });
+    }
+    let len = u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]);
+    if len > MAX_FRAME_BYTES {
+        return Err(ProtocolError::FrameTooLarge(len, MAX_FRAME_BYTES));
+    }
+    let total = 4usize.saturating_add(len as usize);
+    if buf.len() < total {
+        return Err(ProtocolError::Incomplete {
+            needed: total,
+            have: buf.len(),
+        });
+    }
+    let frame: Frame = rmp_serde::from_slice(&buf[4..total])?;
+    Ok((frame, total))
+}
+
+/// Streaming decoder that buffers partial reads from a transport.
+///
+/// Push bytes via [`Decoder::extend`] as they arrive, then call
+/// [`Decoder::next_frame`] in a loop until it returns `Ok(None)`. The
+/// buffer compacts itself after each successful pop.
+#[derive(Debug, Default)]
+pub struct Decoder {
+    buf: Vec<u8>,
+}
+
+impl Decoder {
+    /// New empty decoder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append freshly read bytes from the transport.
+    pub fn extend(&mut self, chunk: &[u8]) {
+        self.buf.extend_from_slice(chunk);
+    }
+
+    /// Pop the next complete frame, if one is available. Returns `Ok(None)`
+    /// when the buffer holds only a partial frame.
+    pub fn next_frame(&mut self) -> Result<Option<Frame>, ProtocolError> {
+        match decode(&self.buf) {
+            Ok((frame, consumed)) => {
+                self.buf.drain(..consumed);
+                Ok(Some(frame))
+            }
+            Err(ProtocolError::Incomplete { .. }) => Ok(None),
+            Err(other) => Err(other),
+        }
+    }
+
+    /// Read-only view of the unconsumed bytes — useful in tests and panic
+    /// reports.
+    pub fn pending(&self) -> &[u8] {
+        &self.buf
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frame::{
+        CloseReason, ErrorCode, Frame, PROTOCOL_VERSION, RegisterAck, RegisterRequest,
+    };
+
+    fn sample_register() -> Frame {
+        Frame::Register(RegisterRequest {
+            protocol_version: PROTOCOL_VERSION,
+            token: "header.payload.signature".into(),
+            dcc: "maya".into(),
+            capabilities: vec!["scene.read".into(), "usd".into()],
+            agent_version: "dcc-mcp-tunnel-agent/0.1".into(),
+        })
+    }
+
+    #[test]
+    fn round_trip_register() {
+        let bytes = encode(&sample_register()).unwrap();
+        let (decoded, n) = decode(&bytes).unwrap();
+        assert_eq!(n, bytes.len());
+        assert_eq!(decoded, sample_register());
+    }
+
+    #[test]
+    fn round_trip_data() {
+        let frame = Frame::Data {
+            session_id: 42,
+            payload: vec![1, 2, 3, 4, 5],
+        };
+        let bytes = encode(&frame).unwrap();
+        let (decoded, _) = decode(&bytes).unwrap();
+        assert_eq!(decoded, frame);
+    }
+
+    #[test]
+    fn round_trip_register_ack_with_message() {
+        let frame = Frame::RegisterAck(RegisterAck {
+            ok: false,
+            tunnel_id: None,
+            public_url: None,
+            error_code: Some(ErrorCode::DccNotAllowed),
+            message: Some("token only allows: houdini, blender".into()),
+        });
+        let bytes = encode(&frame).unwrap();
+        let (decoded, _) = decode(&bytes).unwrap();
+        assert_eq!(decoded, frame);
+    }
+
+    #[test]
+    fn round_trip_close_session() {
+        let frame = Frame::CloseSession {
+            session_id: 7,
+            reason: CloseReason::IdleTimeout,
+        };
+        let bytes = encode(&frame).unwrap();
+        let (decoded, _) = decode(&bytes).unwrap();
+        assert_eq!(decoded, frame);
+    }
+
+    #[test]
+    fn streaming_decoder_handles_split_frames() {
+        let bytes = encode(&sample_register()).unwrap();
+        let (a, b) = bytes.split_at(7); // arbitrary mid-frame split
+        let mut dec = Decoder::new();
+        dec.extend(a);
+        assert!(matches!(dec.next_frame(), Ok(None)));
+        dec.extend(b);
+        let popped = dec.next_frame().unwrap().expect("complete frame");
+        assert_eq!(popped, sample_register());
+        assert!(dec.pending().is_empty());
+    }
+
+    #[test]
+    fn rejects_oversized_length_prefix() {
+        let mut bytes = vec![0u8; 4];
+        bytes[..4].copy_from_slice(&(MAX_FRAME_BYTES + 1).to_be_bytes());
+        match decode(&bytes) {
+            Err(ProtocolError::FrameTooLarge(got, max)) => {
+                assert_eq!(got, MAX_FRAME_BYTES + 1);
+                assert_eq!(max, MAX_FRAME_BYTES);
+            }
+            other => panic!("expected FrameTooLarge, got {other:?}"),
+        }
+    }
+}

--- a/crates/dcc-mcp-tunnel-protocol/src/error.rs
+++ b/crates/dcc-mcp-tunnel-protocol/src/error.rs
@@ -1,0 +1,42 @@
+//! Errors raised by the codec / auth layers.
+
+use thiserror::Error;
+
+/// Errors that can occur while encoding, decoding, or authenticating frames.
+///
+/// These are intentionally library-agnostic — neither variant exposes a
+/// transport handle, so the same type can describe failures observed by the
+/// agent (decoding the relay's reply) and by the relay (decoding the agent's
+/// register request).
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ProtocolError {
+    /// The frame body could not be msgpack-decoded into the expected variant.
+    #[error("msgpack decode failed: {0}")]
+    Decode(#[from] rmp_serde::decode::Error),
+
+    /// The frame could not be msgpack-encoded.
+    #[error("msgpack encode failed: {0}")]
+    Encode(#[from] rmp_serde::encode::Error),
+
+    /// The 4-byte length prefix declares a frame larger than
+    /// [`crate::codec::MAX_FRAME_BYTES`]. This is a hard guard against
+    /// length-prefix denial-of-service.
+    #[error("frame length {0} exceeds maximum {1}")]
+    FrameTooLarge(u32, u32),
+
+    /// The buffer ran out before a complete frame could be read.
+    #[error("not enough bytes: need {needed}, have {have}")]
+    Incomplete {
+        /// Total bytes the next frame requires (including its 4-byte prefix).
+        needed: usize,
+        /// Bytes currently available in the buffer.
+        have: usize,
+    },
+
+    /// JWT signing or validation failed (expired, bad signature, malformed
+    /// header, etc.). The wrapped [`jsonwebtoken::errors::Error`] carries the
+    /// specific cause.
+    #[error("jwt error: {0}")]
+    Jwt(#[from] jsonwebtoken::errors::Error),
+}

--- a/crates/dcc-mcp-tunnel-protocol/src/frame.rs
+++ b/crates/dcc-mcp-tunnel-protocol/src/frame.rs
@@ -1,0 +1,172 @@
+//! On-the-wire frames exchanged between agent and relay.
+//!
+//! The protocol multiplexes one or more MCP **sessions** across a single
+//! WebSocket between a local DCC adapter and a public relay. Sessions are
+//! identified by [`SessionId`]; tunnels (one DCC ↔ relay leg) by
+//! [`TunnelId`]. The wire format is msgpack-serialised [`Frame`] enums
+//! framed by [`crate::codec`]'s 4-byte length prefix.
+
+use serde::{Deserialize, Serialize};
+
+/// Bumped whenever a frame variant gains or loses a non-optional field, or
+/// the JWT claim shape changes. The agent reports its supported version in
+/// [`RegisterRequest::protocol_version`]; the relay rejects any value other
+/// than its own with [`ErrorCode::ProtocolMismatch`].
+pub const PROTOCOL_VERSION: u16 = 1;
+
+/// Opaque tunnel identifier. Issued by the relay during registration.
+///
+/// Format is intentionally unspecified — agents must echo whatever the
+/// relay returned in [`RegisterAck::tunnel_id`] without parsing it. In
+/// practice the relay generates a URL-safe random token wide enough to
+/// resist online enumeration (≥128 bits of entropy).
+pub type TunnelId = String;
+
+/// Per-session identifier *within* a single tunnel.
+///
+/// Stable for the lifetime of the multiplexed MCP session. Reused after a
+/// graceful [`Frame::CloseSession`] only when the agent has acknowledged the
+/// close — the relay never reuses an in-flight ID.
+pub type SessionId = u32;
+
+/// Why a session was torn down.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CloseReason {
+    /// Remote client (browser tab, AI assistant) closed cleanly.
+    ClientGone,
+    /// Local backend (the DCC's MCP HTTP server) closed cleanly.
+    BackendGone,
+    /// Idle session evicted by the relay's TTL policy.
+    IdleTimeout,
+    /// The whole tunnel is shutting down.
+    TunnelClosing,
+    /// Unrecoverable error elsewhere — see the accompanying [`Frame::Error`].
+    Error,
+}
+
+/// Recoverable error codes carried in [`Frame::Error`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ErrorCode {
+    /// JWT missing, expired, or signed by an unknown key.
+    AuthFailed,
+    /// `RegisterRequest::protocol_version` not understood by the relay.
+    ProtocolMismatch,
+    /// The DCC type quoted in `RegisterRequest::dcc` is not in the JWT's
+    /// allowed-DCC list.
+    DccNotAllowed,
+    /// Frame larger than the relay's configured ceiling.
+    FrameTooLarge,
+    /// Session ID referenced by a `Data` / `CloseSession` frame is unknown
+    /// or already closed.
+    UnknownSession,
+    /// Catch-all for relay-side bugs the agent cannot react to.
+    Internal,
+}
+
+/// Initial frame an agent sends to advertise itself.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RegisterRequest {
+    /// Agent's protocol version. Must equal [`PROTOCOL_VERSION`] today.
+    pub protocol_version: u16,
+
+    /// Bearer JWT minted by [`crate::auth::issue`]. The relay calls
+    /// [`crate::auth::validate`] before accepting the registration.
+    pub token: String,
+
+    /// DCC application running this agent (`"maya"`, `"houdini"`, …). Used
+    /// for routing (`/dcc/<name>/<id>`) and visible in `/tunnels` listings.
+    /// Must be in the JWT's `allowed_dcc` claim.
+    pub dcc: String,
+
+    /// Free-form capability tags forwarded to remote clients on connect.
+    /// Examples: `"scene.mutate"`, `"usd"`, `"capture.window"`.
+    pub capabilities: Vec<String>,
+
+    /// Build-time identifier of the agent, e.g. `"dcc-mcp-tunnel-agent/0.1"`.
+    /// Surfaced in `/tunnels` listings only — not used for routing.
+    pub agent_version: String,
+}
+
+/// Relay's reply to [`RegisterRequest`]. Carried in [`Frame::RegisterAck`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RegisterAck {
+    /// `true` ⇔ the relay accepted the registration; `false` triggers an
+    /// immediate disconnect after this frame is sent.
+    pub ok: bool,
+
+    /// Tunnel ID assigned by the relay. The agent uses this for logging and
+    /// when reconnecting after a transient network drop. `None` on failure.
+    pub tunnel_id: Option<TunnelId>,
+
+    /// Public URL the agent can advertise to its operator (e.g.
+    /// `wss://relay.example.com/tunnel/abc123`). `None` on failure.
+    pub public_url: Option<String>,
+
+    /// Set on `ok = false` to explain the rejection.
+    pub error_code: Option<ErrorCode>,
+
+    /// Optional human-readable diagnostic appended by the relay.
+    pub message: Option<String>,
+}
+
+/// All frames carried over the agent ↔ relay WebSocket. Serde-tagged on
+/// `t` so adding a variant in a future protocol revision is forward
+/// compatible (older parties see `untagged` decoding fail and report
+/// [`ErrorCode::ProtocolMismatch`]).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "t", rename_all = "snake_case")]
+pub enum Frame {
+    /// Agent → relay: present credentials and metadata.
+    Register(RegisterRequest),
+
+    /// Relay → agent: accept or reject the registration.
+    RegisterAck(RegisterAck),
+
+    /// Agent → relay: keep-alive ping. Cadence is configured by the agent
+    /// (issue #504 design: ~10 s); the relay evicts tunnels silent longer
+    /// than its own `stale_timeout_secs` (default 30 s).
+    Heartbeat,
+
+    /// Relay → agent: a remote client connected and was assigned this
+    /// session_id. The agent should open a downstream link to its local
+    /// MCP server.
+    OpenSession {
+        /// Per-tunnel unique session identifier.
+        session_id: SessionId,
+        /// Optional client-side hint: User-Agent, source IP, etc. Not parsed
+        /// by the agent — passed through to telemetry only.
+        client_info: Option<String>,
+    },
+
+    /// Either direction: graceful teardown of a single multiplexed session.
+    /// The other end must respond with its own `CloseSession` once it has
+    /// drained the in-flight `Data` frames.
+    CloseSession {
+        /// Session being closed.
+        session_id: SessionId,
+        /// Why.
+        reason: CloseReason,
+    },
+
+    /// Bidirectional payload for one multiplexed session.
+    Data {
+        /// Session this byte chunk belongs to.
+        session_id: SessionId,
+        /// Opaque payload — the relay never inspects MCP message bodies.
+        payload: Vec<u8>,
+    },
+
+    /// Recoverable error. Receiver may continue using other sessions on the
+    /// same tunnel.
+    Error {
+        /// Session the error pertains to, if any.
+        session_id: Option<SessionId>,
+        /// Machine-readable code.
+        code: ErrorCode,
+        /// Human-readable detail. Logged but never echoed to remote clients.
+        message: String,
+    },
+}

--- a/crates/dcc-mcp-tunnel-protocol/src/lib.rs
+++ b/crates/dcc-mcp-tunnel-protocol/src/lib.rs
@@ -1,0 +1,47 @@
+//! Wire protocol shared by `dcc-mcp-tunnel-relay` and `dcc-mcp-tunnel-agent`.
+//!
+//! This crate is intentionally network-free: it defines the on-the-wire
+//! [`Frame`] enum used to multiplex one or more MCP sessions across a single
+//! WebSocket between a local DCC and a public relay (issue #504), the binary
+//! length-prefixed [`codec`] that serialises those frames with msgpack, and
+//! the [`auth`] module that issues + validates the bearer JWTs the relay
+//! uses to gate registration.
+//!
+//! Splitting these primitives out lets:
+//!
+//! - the **relay** (server, `dcc-mcp-tunnel-relay`) pull them in for inbound
+//!   parsing without having to depend on the agent's reconnect loop;
+//! - the **agent** (local sidecar, `dcc-mcp-tunnel-agent`) reuse the same
+//!   types when sending without forking the schema;
+//! - external tooling — telemetry probes, Wireshark dissectors, third-party
+//!   relay implementations — link against a tiny std-only crate to inspect
+//!   tunnel traffic.
+//!
+//! No tokio, no `bytes`, no async machinery. The codec operates on `Vec<u8>`
+//! and `&[u8]` so it round-trips cleanly under `#[test]` without a runtime.
+//!
+//! # Quick orientation
+//!
+//! | Need | Use |
+//! |---|---|
+//! | Build a tunnel control / data frame | [`Frame`] variants + [`codec::encode`] |
+//! | Parse one frame from a buffer | [`codec::decode`] / [`codec::Decoder`] |
+//! | Mint a bearer token for an agent | [`auth::issue`] |
+//! | Validate an inbound `Authorization: Bearer …` | [`auth::validate`] |
+//! | Frame protocol version (negotiated in `Register`) | [`PROTOCOL_VERSION`] |
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms)]
+
+pub mod auth;
+pub mod codec;
+pub mod error;
+pub mod frame;
+
+pub use auth::{TunnelClaims, issue, validate};
+pub use codec::{Decoder, MAX_FRAME_BYTES, decode, encode};
+pub use error::ProtocolError;
+pub use frame::{
+    CloseReason, ErrorCode, Frame, PROTOCOL_VERSION, RegisterAck, RegisterRequest, SessionId,
+    TunnelId,
+};

--- a/crates/dcc-mcp-tunnel-relay/Cargo.toml
+++ b/crates/dcc-mcp-tunnel-relay/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "dcc-mcp-tunnel-relay"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Public-facing relay for the DCC-MCP zero-config remote access tunnel (issue #504). Accepts WebSocket registrations from local agents and forwards multiplexed MCP sessions from remote AI assistants."
+
+[dependencies]
+dcc-mcp-tunnel-protocol = { workspace = true }
+
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+parking_lot = { workspace = true }
+dashmap = { workspace = true }
+workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/crates/dcc-mcp-tunnel-relay/src/config.rs
+++ b/crates/dcc-mcp-tunnel-relay/src/config.rs
@@ -1,0 +1,53 @@
+//! Relay-side configuration.
+
+use std::time::Duration;
+
+/// Configuration for a `dcc-mcp-tunnel-relay` instance.
+///
+/// Constructed once at process start and held by the relay state machine.
+/// Subsequent PRs add knobs for the data-plane buffers, the frontend
+/// listener bind addresses, and per-DCC routing policy; this skeleton
+/// keeps only the values needed by the control-plane registry.
+#[derive(Debug, Clone)]
+pub struct RelayConfig {
+    /// Shared HS256 secret used to validate inbound JWTs in
+    /// [`dcc_mcp_tunnel_protocol::auth::validate`]. Must be at least 32
+    /// bytes of entropy in production deployments.
+    pub jwt_secret: Vec<u8>,
+
+    /// Public hostname the relay advertises in [`RelayConfig::base_url`]
+    /// when minting tunnel URLs. Logged into JWT `iss` for telemetry.
+    pub public_host: String,
+
+    /// Base URL — `wss://relay.example.com` — prepended to per-tunnel
+    /// paths when the relay reports the assigned `public_url` in
+    /// `RegisterAck`.
+    pub base_url: String,
+
+    /// Heartbeat-loss window before a tunnel is considered stale and
+    /// evicted from the registry. Default: 30 s. Mirrors the `stale_*`
+    /// knobs in `McpHttpConfig` so operators have one consistent metric.
+    pub stale_timeout: Duration,
+
+    /// Hard cap on simultaneously-registered tunnels. `0` disables the
+    /// cap. Existing tunnels keep their slot when the cap is hit; new
+    /// `Register` requests are rejected with
+    /// [`dcc_mcp_tunnel_protocol::frame::ErrorCode::Internal`].
+    pub max_tunnels: usize,
+}
+
+impl Default for RelayConfig {
+    /// Test-friendly default with a placeholder secret. **Never** ship a
+    /// production deployment with the default secret — generate one with
+    /// `openssl rand -base64 48` and feed it in via the operator's
+    /// preferred secret store.
+    fn default() -> Self {
+        Self {
+            jwt_secret: b"insecure-dev-only-replace-before-prod".to_vec(),
+            public_host: "localhost".into(),
+            base_url: "ws://localhost:9870".into(),
+            stale_timeout: Duration::from_secs(30),
+            max_tunnels: 0,
+        }
+    }
+}

--- a/crates/dcc-mcp-tunnel-relay/src/lib.rs
+++ b/crates/dcc-mcp-tunnel-relay/src/lib.rs
@@ -1,0 +1,19 @@
+//! Public-facing relay for the DCC-MCP zero-config remote-access tunnel.
+//!
+//! Issue #504 ships in five PRs; this crate is the **server** half. The
+//! current PR (#1 of 5) only lands configuration types and the in-memory
+//! tunnel registry — no network listeners yet. Subsequent PRs add the
+//! control-plane WebSocket handler, the data-plane multiplexer, and the
+//! frontend transports (WSS / TCP / HTTP-SSE).
+//!
+//! See `dcc-mcp-tunnel-protocol` for the on-the-wire frame format and
+//! `dcc-mcp-tunnel-agent` for the local sidecar that registers here.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms)]
+
+pub mod config;
+pub mod registry;
+
+pub use config::RelayConfig;
+pub use registry::{TunnelEntry, TunnelRegistry};

--- a/crates/dcc-mcp-tunnel-relay/src/registry.rs
+++ b/crates/dcc-mcp-tunnel-relay/src/registry.rs
@@ -1,0 +1,160 @@
+//! In-memory registry of currently-connected tunnels.
+//!
+//! The registry is the single source of truth the data-plane (PR 3) and
+//! the `/tunnels` listing endpoint (PR 4) read from. It is intentionally
+//! lock-free at the per-tunnel level (via `dashmap`) so a remote-client
+//! lookup never blocks behind an unrelated heartbeat.
+
+use std::time::Instant;
+
+use dashmap::DashMap;
+use parking_lot::RwLock;
+
+use dcc_mcp_tunnel_protocol::{TunnelId, frame::PROTOCOL_VERSION};
+
+/// One row of the tunnel registry. Mutable fields are wrapped in an
+/// `RwLock` so heartbeat updates don't conflict with `/tunnels` reads.
+#[derive(Debug)]
+pub struct TunnelEntry {
+    /// Stable per-tunnel identifier minted by the relay.
+    pub tunnel_id: TunnelId,
+
+    /// DCC tag declared by the agent (`"maya"`, `"houdini"`, …).
+    pub dcc: String,
+
+    /// Capability tags reported by the agent. Forwarded to remote clients
+    /// so they can pre-flight tool calls without round-tripping.
+    pub capabilities: Vec<String>,
+
+    /// Build identifier the agent sent in `RegisterRequest::agent_version`.
+    pub agent_version: String,
+
+    /// Wall-clock instant the registration was accepted. Used for the
+    /// "tunnel age" column in `/tunnels` listings.
+    pub registered_at: Instant,
+
+    /// Last heartbeat received. Updated under [`Self::touch`] without
+    /// taking a write-lock on the whole registry.
+    pub last_heartbeat: RwLock<Instant>,
+}
+
+impl TunnelEntry {
+    /// Refresh `last_heartbeat` to "now".
+    pub fn touch(&self) {
+        *self.last_heartbeat.write() = Instant::now();
+    }
+
+    /// Read the most recent heartbeat instant.
+    pub fn last_seen(&self) -> Instant {
+        *self.last_heartbeat.read()
+    }
+}
+
+/// Concurrent map of `tunnel_id → TunnelEntry`. The relay's control-plane
+/// task inserts on `Register`, removes on disconnect or stale-timeout, and
+/// the data-plane / `/tunnels` reader holds short-lived references.
+#[derive(Debug, Default)]
+pub struct TunnelRegistry {
+    inner: DashMap<TunnelId, TunnelEntry>,
+}
+
+impl TunnelRegistry {
+    /// Construct an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a freshly-accepted tunnel. Returns `true` when the id was
+    /// new; `false` if a duplicate was overwritten (which should only
+    /// happen during reconnect of a still-known agent).
+    pub fn insert(&self, entry: TunnelEntry) -> bool {
+        self.inner.insert(entry.tunnel_id.clone(), entry).is_none()
+    }
+
+    /// Look up an entry by id. The returned guard pins the row for the
+    /// lifetime of the borrow — keep it short.
+    pub fn get(
+        &self,
+        id: &TunnelId,
+    ) -> Option<dashmap::mapref::one::Ref<'_, TunnelId, TunnelEntry>> {
+        self.inner.get(id)
+    }
+
+    /// Remove an entry. Returns the removed row if any.
+    pub fn remove(&self, id: &TunnelId) -> Option<TunnelEntry> {
+        self.inner.remove(id).map(|(_, v)| v)
+    }
+
+    /// Total live tunnels.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Whether the registry currently holds any tunnels.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Iterate every entry — used by `/tunnels` listings (PR 4) and the
+    /// stale-eviction sweep.
+    pub fn iter(&self) -> dashmap::iter::Iter<'_, TunnelId, TunnelEntry> {
+        self.inner.iter()
+    }
+
+    /// Filter live tunnels by their declared DCC tag. Used by the
+    /// `/dcc/<name>/<id>` routing endpoint added in PR 4.
+    pub fn iter_by_dcc<'a>(
+        &'a self,
+        dcc: &'a str,
+    ) -> impl Iterator<Item = dashmap::mapref::multiple::RefMulti<'a, TunnelId, TunnelEntry>> + 'a
+    {
+        self.inner.iter().filter(move |e| e.value().dcc == dcc)
+    }
+}
+
+/// Sanity check that the protocol crate is correctly re-exported and that
+/// the version constant is the one the relay was built against. The
+/// constant is a `u16`; this static assertion catches accidental wide-int
+/// rebases that would slip past a normal build.
+const _: () = {
+    assert!(PROTOCOL_VERSION == 1);
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(id: &str, dcc: &str) -> TunnelEntry {
+        TunnelEntry {
+            tunnel_id: id.into(),
+            dcc: dcc.into(),
+            capabilities: vec![],
+            agent_version: "test/0.0".into(),
+            registered_at: Instant::now(),
+            last_heartbeat: RwLock::new(Instant::now()),
+        }
+    }
+
+    #[test]
+    fn insert_and_lookup_roundtrip() {
+        let reg = TunnelRegistry::new();
+        assert!(reg.insert(entry("t1", "maya")));
+        assert!(reg.insert(entry("t2", "houdini")));
+        assert_eq!(reg.len(), 2);
+        assert_eq!(reg.get(&"t1".to_string()).unwrap().dcc, "maya");
+        let removed = reg.remove(&"t1".to_string()).unwrap();
+        assert_eq!(removed.tunnel_id, "t1");
+        assert_eq!(reg.len(), 1);
+    }
+
+    #[test]
+    fn iter_by_dcc_filters() {
+        let reg = TunnelRegistry::new();
+        reg.insert(entry("t1", "maya"));
+        reg.insert(entry("t2", "maya"));
+        reg.insert(entry("t3", "houdini"));
+        assert_eq!(reg.iter_by_dcc("maya").count(), 2);
+        assert_eq!(reg.iter_by_dcc("houdini").count(), 1);
+        assert_eq!(reg.iter_by_dcc("blender").count(), 0);
+    }
+}

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -107,7 +107,8 @@ zerocopy = { version = "0.8.48", default-features = false, features = ["derive",
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
-getrandom = { version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2.17", default-features = false, features = ["std"] }
+getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 mio = { version = "1.2.0", features = ["net", "os-ext"] }
@@ -118,7 +119,8 @@ tower-http = { version = "0.6.8", features = ["cors", "follow-redirect", "trace"
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 cc = { version = "1.2.61", default-features = false, features = ["parallel"] }
-getrandom = { version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2.17", default-features = false, features = ["std"] }
+getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 mio = { version = "1.2.0", features = ["net", "os-ext"] }
@@ -128,7 +130,8 @@ tower-http = { version = "0.6.8", features = ["cors", "follow-redirect", "trace"
 
 [target.aarch64-unknown-linux-gnu.dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
-getrandom = { version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2.17", default-features = false, features = ["std"] }
+getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 mio = { version = "1.2.0", features = ["net", "os-ext"] }
@@ -139,7 +142,8 @@ tower-http = { version = "0.6.8", features = ["cors", "follow-redirect", "trace"
 [target.aarch64-unknown-linux-gnu.build-dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 cc = { version = "1.2.61", default-features = false, features = ["parallel"] }
-getrandom = { version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2.17", default-features = false, features = ["std"] }
+getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 mio = { version = "1.2.0", features = ["net", "os-ext"] }
@@ -150,7 +154,8 @@ tower-http = { version = "0.6.8", features = ["cors", "follow-redirect", "trace"
 [target.x86_64-apple-darwin.dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 errno = { version = "0.3.14" }
-getrandom = { version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2.17", default-features = false, features = ["std"] }
+getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 subtle = { version = "2.6.1" }
@@ -161,7 +166,8 @@ tower-http = { version = "0.6.8", features = ["cors", "follow-redirect", "trace"
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 cc = { version = "1.2.61", default-features = false, features = ["parallel"] }
 errno = { version = "0.3.14" }
-getrandom = { version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2.17", default-features = false, features = ["std"] }
+getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 subtle = { version = "2.6.1" }
@@ -171,7 +177,8 @@ tower-http = { version = "0.6.8", features = ["cors", "follow-redirect", "trace"
 [target.aarch64-apple-darwin.dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 errno = { version = "0.3.14" }
-getrandom = { version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2.17", default-features = false, features = ["std"] }
+getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 subtle = { version = "2.6.1" }
@@ -182,7 +189,8 @@ tower-http = { version = "0.6.8", features = ["cors", "follow-redirect", "trace"
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
 cc = { version = "1.2.61", default-features = false, features = ["parallel"] }
 errno = { version = "0.3.14" }
-getrandom = { version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2.17", default-features = false, features = ["std"] }
+getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 subtle = { version = "2.6.1" }
@@ -190,7 +198,8 @@ tower = { version = "0.5.3", default-features = false, features = ["retry", "tim
 tower-http = { version = "0.6.8", features = ["cors", "follow-redirect", "trace"] }
 
 [target.x86_64-pc-windows-msvc.dependencies]
-getrandom = { version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2.17", default-features = false, features = ["std"] }
+getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 subtle = { version = "2.6.1" }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
@@ -201,7 +210,8 @@ windows-sys = { version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_F
 
 [target.x86_64-pc-windows-msvc.build-dependencies]
 cc = { version = "1.2.61", default-features = false, features = ["parallel"] }
-getrandom = { version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2.17", default-features = false, features = ["std"] }
+getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 subtle = { version = "2.6.1" }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }


### PR DESCRIPTION
## Summary

First of **five planned PRs** implementing the zero-config remote MCP relay described in issue #504. This PR lands the **protocol foundation only** — no listener, no reconnect loop, no data-plane multiplexing yet. Those arrive in PRs 2 through 5 so each step can be reviewed independently.

### Roadmap

| PR | Scope |
|---|---|
| **1 (this)** | 3 crate skeletons: protocol types, frame codec, JWT helpers, registry stub, config types |
| 2 | Control plane — local agent registers with relay over WSS, heartbeat + TTL eviction |
| 3 | Data plane — bidirectional byte streaming, 1:N session multiplexing |
| 4 | Frontend transports (TCP / WSS / HTTP-SSE) + `/dcc/<name>/<id>` routing + `/tunnels` listing |
| 5 | Hardening — bounded channels, metrics, agent-friendly docs, examples |

### Design decisions confirmed up front

- **1:N multiplexing from day one** via `SessionId: u32` in every `Data` / `OpenSession` / `CloseSession` frame.
- **Multi-frontend transport** — PR 4 will accept WSS, raw TCP, and HTTP-SSE on the public side; the protocol crate is transport-agnostic so all three converge on the same `Frame` enum.
- **Per-DCC identity in metadata** — baked into `TunnelClaims::allowed_dcc` and `RegisterRequest::dcc`. Routing endpoints (`/dcc/<name>/<id>`) consume this in PR 4.
- **Three workspace crates** (not one with features) — keeps the protocol crate `tokio`-free and unit-testable without a runtime, and lets external tooling (Wireshark dissectors, third-party relay implementations) link the tiny `protocol` crate without pulling in axum / tokio-tungstenite.

## New crates

| Crate | Purpose | Network deps |
|---|---|---|
| `dcc-mcp-tunnel-protocol` | Frame enum, length-prefix msgpack codec, JWT helpers | None — pure types |
| `dcc-mcp-tunnel-relay` | Public-facing server: `RelayConfig` + dashmap-backed `TunnelRegistry` (listener stub) | `tracing`, `dashmap`, `parking_lot` |
| `dcc-mcp-tunnel-agent` | Local sidecar: `AgentConfig` + `ReconnectPolicy` (loop stub) | `tracing` |

## Frame protocol

- `PROTOCOL_VERSION = 1`, bumped on incompatible changes.
- Tag-discriminated `Frame` enum with `Register` / `RegisterAck` / `Heartbeat` / `OpenSession` / `CloseSession` / `Data` / `Error` variants.
- Session multiplexing via `SessionId: u32` inside one tunnel.
- Per-DCC scoping baked into `TunnelClaims::allowed_dcc` and `RegisterRequest::dcc`.

## Codec

- 4-byte BE length prefix + msgpack body.
- Hard 8 MiB cap (`MAX_FRAME_BYTES`) bounds malicious-peer allocation.
- Streaming `Decoder` buffers partial reads from the transport without requiring a tokio runtime, keeping unit tests synchronous.

## Auth

- HS256 today; `jsonwebtoken 9.3` (`default-features = false`) added to `[workspace.dependencies]`.
- 60s clock-skew window on `iat`, `exp` strictly enforced.
- DCC-tag enforcement happens in the relay (PR 2), not the protocol crate, because the requested DCC arrives in the `Register` frame.

## Validation

```
cargo test  -p dcc-mcp-tunnel-protocol      9 passed (5 frame round-trips, 1 oversized-prefix DoS guard, 3 JWT)
cargo test  -p dcc-mcp-tunnel-relay         2 passed (registry insert/lookup, iter_by_dcc filter)
cargo clippy --all-targets -D warnings      0 warnings on all three crates
cargo build --workspace --exclude dcc-mcp-skills    Finished `dev` profile in 15.59s
cargo hakari generate                       workspace-hack regenerated, no drift
```

All pre-commit hooks pass (`cargo fmt`, `cargo clippy`, `cargo hakari`, ruff, toml-check, EOL/whitespace).

## Documentation

`AGENTS.md` decision table gains a single forward-looking row pointing at the three crates and flagging the v0.14 status as 'skeleton only'. Full agent-friendly docs (`docs/guide/tunnel-relay.md`, `llms.txt` entry, examples, docker-compose deployment) land with **PR 5** once the surface is real — documenting an empty skeleton would just be slop.

## Issue

First step toward closing issue #504. No `Closes` directive (issue tracks the full 5-PR sequence).