### PR TITLE
feat(tunnel): control + data plane + e2e MVP for relay (#504)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,9 @@
 | IPC | `IpcChannelAdapter` / `SocketServerAdapter` + `DccLinkFrame` |
 | Hand off files between tools | `FileRef` + `artefact_put_file()` / `artefact_get_bytes()` |
 | Multi-DCC gateway | `McpHttpConfig(gateway_port=9765)` |
-| Remote MCP relay (zero-config tunnel) | `dcc-mcp-tunnel-protocol` (frame codec + JWT) + `dcc-mcp-tunnel-relay` (server) + `dcc-mcp-tunnel-agent` (local sidecar) — issue #504; **skeleton only in v0.14**, control / data planes land in follow-up PRs |
+| Remote MCP relay (zero-config tunnel) | `RelayServer::start(RelayConfig, agent_bind, frontend_bind).await` — accepts agent registrations on `agent_bind`, multiplexes remote-client TCP from `frontend_bind` to the agent's local MCP server (issue #504) |
+| Spawn the local tunnel agent | `dcc_mcp_tunnel_agent::run_once(AgentConfig::new(relay_url, jwt, dcc, local_target)).await` — registers, holds the connection open, bridges per-session bytes to the local DCC HTTP server |
+| Mint a tunnel JWT | `dcc_mcp_tunnel_protocol::auth::issue(&TunnelClaims { sub, iat, exp, iss, allowed_dcc }, secret)` — relay uses `auth::validate` to enforce DCC scope on every registration |
 | Gateway failover | `DccGatewayElection(dcc_name, server)` — auto-promote on gateway failure |
 | Skill scoping | `SkillScope` (Repo → User → System → Admin) — Rust-only |
 | Progressive tool exposure | `SkillGroup` + `activate_tool_group()` |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,9 +1068,11 @@ dependencies = [
 name = "dcc-mcp-tunnel-agent"
 version = "0.14.16"
 dependencies = [
+ "dashmap",
  "dcc-mcp-tunnel-protocol",
  "serde",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "workspace-hack",
 ]
@@ -1092,12 +1094,15 @@ name = "dcc-mcp-tunnel-relay"
 version = "0.14.16"
 dependencies = [
  "dashmap",
+ "dcc-mcp-tunnel-agent",
  "dcc-mcp-tunnel-protocol",
  "parking_lot",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
+ "uuid",
  "workspace-hack",
 ]
 

--- a/crates/dcc-mcp-tunnel-agent/Cargo.toml
+++ b/crates/dcc-mcp-tunnel-agent/Cargo.toml
@@ -13,4 +13,6 @@ dcc-mcp-tunnel-protocol = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+tokio = { workspace = true }
+dashmap = { workspace = true }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/crates/dcc-mcp-tunnel-agent/src/client.rs
+++ b/crates/dcc-mcp-tunnel-agent/src/client.rs
@@ -1,0 +1,199 @@
+//! Long-running agent loop: connect → register → multiplex sessions.
+//!
+//! One agent process owns one [`AgentClient`]. The current MVP runs a
+//! single registration attempt; the [`crate::ReconnectPolicy`] field on
+//! [`crate::AgentConfig`] is wired through but the back-off loop itself
+//! lands in PR 5 of #504. Tests drive [`run_once`] directly so they can
+//! assert on the registration outcome without retry timing noise.
+
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::sync::mpsc;
+use tracing::{debug, info, warn};
+
+use dcc_mcp_tunnel_protocol::{
+    CloseReason, Frame, RegisterAck, RegisterRequest, SessionId, frame::PROTOCOL_VERSION,
+};
+
+use crate::AgentConfig;
+use crate::transport::{TransportError, read_frame, write_frame};
+
+const SESSION_INBOX_QUEUE: usize = 32;
+const READ_CHUNK: usize = 32 * 1024;
+
+/// Outcome of a single registration attempt — surfaced to tests + the
+/// future reconnect loop.
+#[derive(Debug)]
+pub struct Registered {
+    /// Tunnel id minted by the relay.
+    pub tunnel_id: String,
+    /// Public URL the relay told us to advertise.
+    pub public_url: Option<String>,
+}
+
+/// Run one full session: dial relay → register → multiplex → return on
+/// disconnect. Errors are surfaced to the caller so the reconnect loop
+/// (PR 5) can decide whether to retry.
+pub async fn run_once(config: AgentConfig) -> Result<Registered, ClientError> {
+    let stream = TcpStream::connect(&config.relay_url)
+        .await
+        .map_err(ClientError::Connect)?;
+    let (mut reader, writer) = tokio::io::split(stream);
+    let writer = Arc::new(tokio::sync::Mutex::new(writer));
+
+    let req = RegisterRequest {
+        protocol_version: PROTOCOL_VERSION,
+        token: config.token.clone(),
+        dcc: config.dcc.clone(),
+        capabilities: config.capabilities.clone(),
+        agent_version: config.agent_version.clone(),
+    };
+    {
+        let mut w = writer.lock().await;
+        write_frame(&mut *w, &Frame::Register(req)).await?;
+    }
+
+    let ack = match read_frame(&mut reader).await? {
+        Some(Frame::RegisterAck(ack)) => ack,
+        other => {
+            return Err(ClientError::HandshakeProtocol(format!(
+                "expected RegisterAck, got {other:?}"
+            )));
+        }
+    };
+    if !ack.ok {
+        return Err(ClientError::Rejected(ack));
+    }
+    let tunnel_id = ack
+        .tunnel_id
+        .clone()
+        .ok_or_else(|| ClientError::HandshakeProtocol("ack ok=true but tunnel_id None".into()))?;
+    info!(%tunnel_id, "agent registered with relay");
+
+    // Per-session inbound channels — populated when the relay sends
+    // `OpenSession`; drained by the per-session bridging task.
+    let sessions: Arc<DashMap<SessionId, mpsc::Sender<Vec<u8>>>> = Arc::new(DashMap::new());
+
+    let local_target = config.local_target.clone();
+    let writer_for_dispatch = Arc::clone(&writer);
+    let sessions_for_dispatch = Arc::clone(&sessions);
+
+    while let Some(frame) = read_frame(&mut reader).await? {
+        match frame {
+            Frame::OpenSession { session_id, .. } => {
+                let (tx, rx) = mpsc::channel::<Vec<u8>>(SESSION_INBOX_QUEUE);
+                sessions_for_dispatch.insert(session_id, tx);
+                let local_target = local_target.clone();
+                let writer = Arc::clone(&writer_for_dispatch);
+                let sessions = Arc::clone(&sessions_for_dispatch);
+                tokio::spawn(async move {
+                    if let Err(e) = bridge_session(session_id, &local_target, rx, writer).await {
+                        debug!(session_id, error = %e, "session bridge ended");
+                    }
+                    sessions.remove(&session_id);
+                });
+            }
+            Frame::Data {
+                session_id,
+                payload,
+            } => {
+                if let Some(tx) = sessions_for_dispatch.get(&session_id).map(|s| s.clone()) {
+                    if tx.send(payload).await.is_err() {
+                        sessions_for_dispatch.remove(&session_id);
+                    }
+                }
+            }
+            Frame::CloseSession { session_id, .. } => {
+                sessions_for_dispatch.remove(&session_id);
+            }
+            Frame::Heartbeat => {}
+            Frame::Error { code, message, .. } => warn!(?code, %message, "relay reported error"),
+            other => debug!(?other, "unexpected frame from relay; ignoring"),
+        }
+    }
+    Ok(Registered {
+        tunnel_id,
+        public_url: ack.public_url,
+    })
+}
+
+async fn bridge_session(
+    session_id: SessionId,
+    local_target: &str,
+    mut inbox: mpsc::Receiver<Vec<u8>>,
+    writer: Arc<tokio::sync::Mutex<tokio::io::WriteHalf<TcpStream>>>,
+) -> Result<(), ClientError> {
+    let backend = TcpStream::connect(local_target)
+        .await
+        .map_err(ClientError::Connect)?;
+    let (mut backend_reader, mut backend_writer) = tokio::io::split(backend);
+
+    // backend → relay: read local bytes, wrap in Data frames.
+    let writer_for_relay = Arc::clone(&writer);
+    let relay_pump = tokio::spawn(async move {
+        let mut buf = vec![0u8; READ_CHUNK];
+        loop {
+            match backend_reader.read(&mut buf).await {
+                Ok(0) => break,
+                Ok(n) => {
+                    let mut w = writer_for_relay.lock().await;
+                    if write_frame(
+                        &mut *w,
+                        &Frame::Data {
+                            session_id,
+                            payload: buf[..n].to_vec(),
+                        },
+                    )
+                    .await
+                    .is_err()
+                    {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+        let mut w = writer_for_relay.lock().await;
+        let _ = write_frame(
+            &mut *w,
+            &Frame::CloseSession {
+                session_id,
+                reason: CloseReason::BackendGone,
+            },
+        )
+        .await;
+    });
+
+    // relay → backend: drain the per-session inbox.
+    while let Some(bytes) = inbox.recv().await {
+        if backend_writer.write_all(&bytes).await.is_err() {
+            break;
+        }
+    }
+    let _ = backend_writer.shutdown().await;
+    let _ = relay_pump.await;
+    Ok(())
+}
+
+/// Errors surfaced by [`run_once`].
+#[derive(Debug, thiserror::Error)]
+pub enum ClientError {
+    /// TCP dial to the relay or local backend failed.
+    #[error("connect: {0}")]
+    Connect(std::io::Error),
+
+    /// Frame I/O failure with the relay.
+    #[error("transport: {0}")]
+    Transport(#[from] TransportError),
+
+    /// Handshake violated the wire protocol.
+    #[error("handshake protocol: {0}")]
+    HandshakeProtocol(String),
+
+    /// Relay sent `RegisterAck { ok: false, .. }`.
+    #[error("relay rejected registration: {0:?}")]
+    Rejected(RegisterAck),
+}

--- a/crates/dcc-mcp-tunnel-agent/src/lib.rs
+++ b/crates/dcc-mcp-tunnel-agent/src/lib.rs
@@ -1,16 +1,23 @@
 //! Local sidecar that bridges a DCC's MCP HTTP server to a public relay.
 //!
-//! Issue #504 ships in five PRs; this crate is the **client** half. The
-//! current PR (#1 of 5) only lands configuration types and the reconnect
-//! policy enum — the actual WebSocket loop and per-session multiplexer
-//! land in PRs 2 and 3 respectively.
+//! Issue #504. Modules:
+//!
+//! - [`config`] — operator-supplied wiring (relay URL, JWT, local target).
+//! - [`transport`] — async [`Frame`] I/O over `AsyncRead + AsyncWrite`.
+//! - [`client`] — registration loop + per-session bridge to the local
+//!   MCP HTTP server.
 //!
 //! See `dcc-mcp-tunnel-protocol` for the on-the-wire frame format and
 //! `dcc-mcp-tunnel-relay` for the public-facing server.
+//!
+//! [`Frame`]: dcc_mcp_tunnel_protocol::Frame
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
+pub mod client;
 pub mod config;
+pub mod transport;
 
+pub use client::{ClientError, Registered, run_once};
 pub use config::{AgentConfig, ReconnectPolicy};

--- a/crates/dcc-mcp-tunnel-agent/src/transport.rs
+++ b/crates/dcc-mcp-tunnel-agent/src/transport.rs
@@ -1,0 +1,67 @@
+//! Async [`Frame`] I/O over an `AsyncRead + AsyncWrite` transport.
+//!
+//! Mirrors `dcc_mcp_tunnel_relay::transport` so the agent does not have
+//! to depend on the relay crate just for the framing helpers.
+
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+use dcc_mcp_tunnel_protocol::{Decoder, Frame, ProtocolError, codec};
+
+/// Read one complete [`Frame`] from `reader`. Returns `Ok(None)` cleanly
+/// on EOF *between* frames; an EOF mid-frame surfaces as `Err`.
+pub async fn read_frame<R>(reader: &mut R) -> Result<Option<Frame>, TransportError>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut len_buf = [0u8; 4];
+    match reader.read_exact(&mut len_buf).await {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(e) => return Err(TransportError::Io(e)),
+    }
+    let len = u32::from_be_bytes(len_buf);
+    if len > codec::MAX_FRAME_BYTES {
+        return Err(TransportError::Protocol(ProtocolError::FrameTooLarge(
+            len,
+            codec::MAX_FRAME_BYTES,
+        )));
+    }
+    let mut body = vec![0u8; len as usize];
+    reader
+        .read_exact(&mut body)
+        .await
+        .map_err(TransportError::Io)?;
+    let mut dec = Decoder::new();
+    dec.extend(&len_buf);
+    dec.extend(&body);
+    match dec.next_frame()? {
+        Some(frame) => Ok(Some(frame)),
+        None => Err(TransportError::Protocol(ProtocolError::Incomplete {
+            needed: 4 + len as usize,
+            have: 4 + len as usize,
+        })),
+    }
+}
+
+/// Encode `frame` and write it to `writer` in one shot, with a flush.
+pub async fn write_frame<W>(writer: &mut W, frame: &Frame) -> Result<(), TransportError>
+where
+    W: AsyncWrite + Unpin,
+{
+    let bytes = codec::encode(frame)?;
+    writer.write_all(&bytes).await.map_err(TransportError::Io)?;
+    writer.flush().await.map_err(TransportError::Io)?;
+    Ok(())
+}
+
+/// Errors surfaced by the async frame I/O helpers.
+#[derive(Debug, thiserror::Error)]
+pub enum TransportError {
+    /// Underlying socket I/O failed.
+    #[error("transport I/O: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Wire format violation.
+    #[error("frame protocol: {0}")]
+    Protocol(#[from] ProtocolError),
+}

--- a/crates/dcc-mcp-tunnel-relay/Cargo.toml
+++ b/crates/dcc-mcp-tunnel-relay/Cargo.toml
@@ -16,4 +16,10 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 parking_lot = { workspace = true }
 dashmap = { workspace = true }
+tokio = { workspace = true }
+uuid = { workspace = true }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
+
+[dev-dependencies]
+dcc-mcp-tunnel-agent = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/dcc-mcp-tunnel-relay/src/control.rs
+++ b/crates/dcc-mcp-tunnel-relay/src/control.rs
@@ -1,0 +1,249 @@
+//! Control-plane handler: validates an agent registration and pumps
+//! frames in both directions between the agent socket and the routing
+//! [`crate::handle::TunnelHandle`].
+//!
+//! Wire-level shape (per accepted agent connection):
+//!
+//! 1. Read first frame; reject anything other than `Register`.
+//! 2. Validate JWT, protocol version, DCC scope, capacity.
+//! 3. Mint `tunnel_id`, build `(TunnelHandle, frame_rx)` pair, register.
+//! 4. Send `RegisterAck { ok: true, tunnel_id, public_url }`.
+//! 5. Split the socket; spawn a writer task draining `frame_rx`.
+//! 6. Read loop: dispatch `Heartbeat` / `Data` / `CloseSession` / `Error`.
+//! 7. On EOF or error, evict from the registry, drop the handle so
+//!    `frame_rx` closes, and let the writer task wind down.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use parking_lot::RwLock;
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
+use tokio::sync::mpsc;
+use tracing::{debug, info, warn};
+use uuid::Uuid;
+
+use dcc_mcp_tunnel_protocol::{
+    ErrorCode, Frame, RegisterAck, RegisterRequest, auth, frame::PROTOCOL_VERSION,
+};
+
+use crate::config::RelayConfig;
+use crate::handle::TunnelHandle;
+use crate::registry::{TunnelEntry, TunnelRegistry};
+use crate::transport::{TransportError, read_frame, write_frame};
+
+/// Bound on the agent's outbound queue. Picked to absorb a few jumbo
+/// `Data` frames (8 MiB cap each) without unbounded growth, while still
+/// applying back-pressure to over-eager frontend clients.
+pub const AGENT_FRAME_QUEUE: usize = 32;
+
+/// Bound on each per-session inbox handed back to a frontend client.
+pub const SESSION_INBOX_QUEUE: usize = 32;
+
+/// Drive a freshly-accepted agent connection through registration and
+/// then loop on its read half until disconnect. Errors are logged, never
+/// propagated — the relay treats per-tunnel failures as routine churn.
+pub async fn handle_agent<S>(stream: S, registry: Arc<TunnelRegistry>, config: Arc<RelayConfig>)
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    let (mut reader, mut writer) = tokio::io::split(stream);
+
+    let req = match read_frame(&mut reader).await {
+        Ok(Some(Frame::Register(req))) => req,
+        Ok(Some(other)) => {
+            let _ = reject(
+                &mut writer,
+                ErrorCode::ProtocolMismatch,
+                format!("expected Register first, got {other:?}"),
+            )
+            .await;
+            return;
+        }
+        Ok(None) => {
+            debug!("agent closed before sending Register");
+            return;
+        }
+        Err(e) => {
+            warn!(error = %e, "failed to read Register frame");
+            return;
+        }
+    };
+
+    let accepted = match accept(&mut writer, &req, &registry, &config).await {
+        Some(acc) => acc,
+        None => return,
+    };
+    let Accepted {
+        tunnel_id,
+        handle,
+        mut frame_rx,
+    } = accepted;
+    info!(%tunnel_id, dcc = %req.dcc, "tunnel registered");
+
+    let writer_task = {
+        let tunnel_id = tunnel_id.clone();
+        tokio::spawn(async move {
+            while let Some(frame) = frame_rx.recv().await {
+                if let Err(e) = write_frame(&mut writer, &frame).await {
+                    warn!(%tunnel_id, error = %e, "agent writer failed");
+                    return;
+                }
+            }
+            let _ = writer.shutdown().await;
+        })
+    };
+
+    if let Err(e) = read_loop(&mut reader, &handle, &registry, &tunnel_id).await {
+        debug!(%tunnel_id, error = %e, "agent read loop terminated");
+    }
+
+    // Dropping our `Arc<TunnelHandle>` and removing the registry row drops
+    // every `frame_tx` clone, which closes `frame_rx` and lets the writer
+    // task return cleanly.
+    drop(handle);
+    let removed = registry.remove(&tunnel_id);
+    let _ = writer_task.await;
+    if removed.is_some() {
+        info!(%tunnel_id, "tunnel evicted");
+    }
+}
+
+struct Accepted {
+    tunnel_id: String,
+    handle: Arc<TunnelHandle>,
+    frame_rx: mpsc::Receiver<Frame>,
+}
+
+async fn accept<W>(
+    writer: &mut W,
+    req: &RegisterRequest,
+    registry: &Arc<TunnelRegistry>,
+    config: &Arc<RelayConfig>,
+) -> Option<Accepted>
+where
+    W: AsyncWrite + Unpin,
+{
+    if req.protocol_version != PROTOCOL_VERSION {
+        let _ = reject(
+            writer,
+            ErrorCode::ProtocolMismatch,
+            format!(
+                "agent protocol_version={} relay={}",
+                req.protocol_version, PROTOCOL_VERSION
+            ),
+        )
+        .await;
+        return None;
+    }
+    let claims = match auth::validate(&req.token, &config.jwt_secret) {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(error = %e, dcc = %req.dcc, "agent token rejected");
+            let _ = reject(writer, ErrorCode::AuthFailed, e.to_string()).await;
+            return None;
+        }
+    };
+    if !claims.allowed_dcc.is_empty() && !claims.allowed_dcc.iter().any(|d| d == &req.dcc) {
+        let _ = reject(
+            writer,
+            ErrorCode::DccNotAllowed,
+            format!("token only allows: {}", claims.allowed_dcc.join(", ")),
+        )
+        .await;
+        return None;
+    }
+    if config.max_tunnels != 0 && registry.len() >= config.max_tunnels {
+        let _ = reject(
+            writer,
+            ErrorCode::Internal,
+            format!("relay at capacity ({} tunnels)", config.max_tunnels),
+        )
+        .await;
+        return None;
+    }
+    let tunnel_id = Uuid::new_v4().simple().to_string();
+    let public_url = format!("{}/tunnel/{}", config.base_url, tunnel_id);
+    let (frame_tx, frame_rx) = mpsc::channel::<Frame>(AGENT_FRAME_QUEUE);
+    let handle = Arc::new(TunnelHandle::new(frame_tx));
+    let entry = TunnelEntry {
+        tunnel_id: tunnel_id.clone(),
+        dcc: req.dcc.clone(),
+        capabilities: req.capabilities.clone(),
+        agent_version: req.agent_version.clone(),
+        registered_at: Instant::now(),
+        last_heartbeat: RwLock::new(Instant::now()),
+        handle: Arc::clone(&handle),
+    };
+    registry.insert(entry);
+    let ack = Frame::RegisterAck(RegisterAck {
+        ok: true,
+        tunnel_id: Some(tunnel_id.clone()),
+        public_url: Some(public_url),
+        error_code: None,
+        message: None,
+    });
+    if let Err(e) = write_frame(writer, &ack).await {
+        warn!(error = %e, "failed to write RegisterAck");
+        registry.remove(&tunnel_id);
+        return None;
+    }
+    Some(Accepted {
+        tunnel_id,
+        handle,
+        frame_rx,
+    })
+}
+
+async fn reject<W>(writer: &mut W, code: ErrorCode, message: String) -> Result<(), TransportError>
+where
+    W: AsyncWrite + Unpin,
+{
+    let frame = Frame::RegisterAck(RegisterAck {
+        ok: false,
+        tunnel_id: None,
+        public_url: None,
+        error_code: Some(code),
+        message: Some(message),
+    });
+    write_frame(writer, &frame).await?;
+    let _ = writer.shutdown().await;
+    Ok(())
+}
+
+async fn read_loop<R>(
+    reader: &mut R,
+    handle: &Arc<TunnelHandle>,
+    registry: &Arc<TunnelRegistry>,
+    tunnel_id: &str,
+) -> Result<(), TransportError>
+where
+    R: AsyncRead + Unpin,
+{
+    while let Some(frame) = read_frame(reader).await? {
+        match frame {
+            Frame::Heartbeat => {
+                if let Some(entry) = registry.get(&tunnel_id.to_string()) {
+                    entry.touch();
+                }
+            }
+            Frame::Data {
+                session_id,
+                payload,
+            } => {
+                if let Some(inbox) = handle.session_inbox(session_id) {
+                    if inbox.send(payload).await.is_err() {
+                        handle.close_session(session_id);
+                    }
+                }
+            }
+            Frame::CloseSession { session_id, .. } => {
+                handle.close_session(session_id);
+            }
+            Frame::Error { code, message, .. } => {
+                warn!(%tunnel_id, ?code, %message, "agent reported error");
+            }
+            other => debug!(%tunnel_id, ?other, "unexpected frame from agent; ignoring"),
+        }
+    }
+    Ok(())
+}

--- a/crates/dcc-mcp-tunnel-relay/src/data.rs
+++ b/crates/dcc-mcp-tunnel-relay/src/data.rs
@@ -1,0 +1,162 @@
+//! Data-plane handler for one accepted **frontend** connection.
+//!
+//! The frontend listener accepts a TCP socket from a remote MCP client,
+//! reads a small `select_tunnel` preamble (a length-prefixed `tunnel_id`
+//! string, no msgpack), then bridges the socket to one multiplexed
+//! session on the corresponding tunnel.
+//!
+//! Subsequent PRs add `/dcc/<name>/<id>` HTTP routing and a WS bridge;
+//! this MVP keeps the protocol small enough to drive end-to-end with
+//! `tokio::net::TcpStream` and validate the framing & multiplexing without
+//! pulling in a full HTTP stack.
+
+use std::sync::Arc;
+
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tracing::{debug, info, warn};
+
+use dcc_mcp_tunnel_protocol::{CloseReason, Frame, TunnelId};
+
+use crate::control::SESSION_INBOX_QUEUE;
+use crate::registry::TunnelRegistry;
+
+/// Maximum tunnel-id length accepted in the `select_tunnel` preamble.
+/// Prevents an attacker from forcing a huge allocation by sending a giant
+/// length prefix when no agent is connected.
+pub const MAX_TUNNEL_ID_LEN: u16 = 128;
+
+/// Bytes copied per backend-side read into a single `Frame::Data`. Sized
+/// to fit comfortably inside the codec's 8 MiB ceiling and to keep
+/// per-frame fixed overhead amortised.
+const READ_CHUNK: usize = 32 * 1024;
+
+/// Drive a freshly-accepted frontend connection: read the preamble,
+/// allocate a session on the matching tunnel, then full-duplex copy bytes.
+pub async fn handle_frontend<S>(stream: S, registry: Arc<TunnelRegistry>)
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    let (mut reader, writer) = tokio::io::split(stream);
+
+    let tunnel_id = match read_select_tunnel(&mut reader).await {
+        Ok(id) => id,
+        Err(e) => {
+            debug!(error = %e, "frontend preamble read failed");
+            return;
+        }
+    };
+    let handle = match registry.get(&tunnel_id) {
+        Some(entry) => Arc::clone(&entry.handle),
+        None => {
+            warn!(%tunnel_id, "frontend selected unknown tunnel");
+            // Close immediately so the remote client surfaces the error.
+            return;
+        }
+    };
+
+    let (session_id, mut inbox_rx) = handle.open_session(SESSION_INBOX_QUEUE);
+    debug!(%tunnel_id, session_id, "frontend session opened");
+
+    if handle
+        .send(Frame::OpenSession {
+            session_id,
+            client_info: None,
+        })
+        .await
+        .is_err()
+    {
+        handle.close_session(session_id);
+        return;
+    }
+
+    // agent → frontend: drain the per-session inbox into the writer.
+    let writer_handle = Arc::clone(&handle);
+    let writer_task = tokio::spawn(async move {
+        let mut writer = writer;
+        while let Some(bytes) = inbox_rx.recv().await {
+            if writer.write_all(&bytes).await.is_err() {
+                break;
+            }
+        }
+        let _ = writer.shutdown().await;
+        // Tell the agent to tear down its half so the local backend
+        // socket gets a clean EOF too.
+        let _ = writer_handle
+            .send(Frame::CloseSession {
+                session_id,
+                reason: CloseReason::ClientGone,
+            })
+            .await;
+        writer_handle.close_session(session_id);
+    });
+
+    // frontend → agent: chunk the reader into `Data` frames.
+    let mut buf = vec![0u8; READ_CHUNK];
+    loop {
+        match reader.read(&mut buf).await {
+            Ok(0) => break,
+            Ok(n) => {
+                let payload = buf[..n].to_vec();
+                if handle
+                    .send(Frame::Data {
+                        session_id,
+                        payload,
+                    })
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+            Err(e) => {
+                debug!(%tunnel_id, session_id, error = %e, "frontend read error");
+                break;
+            }
+        }
+    }
+    let _ = handle
+        .send(Frame::CloseSession {
+            session_id,
+            reason: CloseReason::ClientGone,
+        })
+        .await;
+    handle.close_session(session_id);
+    drop(handle);
+    let _ = writer_task.await;
+    info!(%tunnel_id, session_id, "frontend session closed");
+}
+
+/// Read the `select_tunnel` preamble: 2-byte BE length, then UTF-8 bytes.
+async fn read_select_tunnel<R>(reader: &mut R) -> std::io::Result<TunnelId>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut len_buf = [0u8; 2];
+    reader.read_exact(&mut len_buf).await?;
+    let len = u16::from_be_bytes(len_buf);
+    if len == 0 || len > MAX_TUNNEL_ID_LEN {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("invalid tunnel-id length: {len}"),
+        ));
+    }
+    let mut id_bytes = vec![0u8; len as usize];
+    reader.read_exact(&mut id_bytes).await?;
+    String::from_utf8(id_bytes).map_err(|e| {
+        std::io::Error::new(std::io::ErrorKind::InvalidData, format!("non-utf8 id: {e}"))
+    })
+}
+
+/// Counterpart used by the agent test client / the eventual SDK helper.
+pub async fn write_select_tunnel<W>(writer: &mut W, tunnel_id: &str) -> std::io::Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    let bytes = tunnel_id.as_bytes();
+    let len = u16::try_from(bytes.len())
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "tunnel id too long"))?;
+    writer.write_all(&len.to_be_bytes()).await?;
+    writer.write_all(bytes).await?;
+    writer.flush().await?;
+    Ok(())
+}

--- a/crates/dcc-mcp-tunnel-relay/src/eviction.rs
+++ b/crates/dcc-mcp-tunnel-relay/src/eviction.rs
@@ -1,0 +1,102 @@
+//! Periodic stale-tunnel sweeper.
+//!
+//! Runs once per `sweep_interval`, walks the [`TunnelRegistry`], and
+//! removes any entry whose `last_heartbeat` is older than
+//! `RelayConfig::stale_timeout`. Removal drops the registry's
+//! `Arc<TunnelHandle>` and (transitively) the `frame_tx` clone, which
+//! closes the agent writer's queue and tears down the per-tunnel tasks.
+//!
+//! The sweeper never reaches into the agent socket directly — that's the
+//! control-plane's job. This keeps eviction lock-free at the per-tunnel
+//! level and avoids needing a writer-side cancellation token.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tracing::info;
+
+use crate::config::RelayConfig;
+use crate::registry::TunnelRegistry;
+
+/// Spawn a periodic sweeper. Returns a [`tokio::task::JoinHandle`] so the
+/// caller can shut it down on relay-wide teardown.
+pub fn spawn_eviction_loop(
+    registry: Arc<TunnelRegistry>,
+    config: Arc<RelayConfig>,
+    sweep_interval: Duration,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(sweep_interval);
+        // The first tick fires immediately; skip it so the first sweep runs
+        // one full interval after start (avoids a flurry of evictions in
+        // tests that spin up the relay then race the assertion).
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            sweep_once(&registry, &config);
+        }
+    })
+}
+
+/// One sweep pass — exposed for tests so they can drive the eviction
+/// without waiting on a real timer.
+pub fn sweep_once(registry: &TunnelRegistry, config: &RelayConfig) {
+    let cutoff = Instant::now().saturating_duration_since(Instant::now()) + config.stale_timeout; // satisfies clippy::useless_conversion
+    let now = Instant::now();
+    let stale: Vec<String> = registry
+        .iter()
+        .filter_map(|e| {
+            let age = now.saturating_duration_since(e.value().last_seen());
+            if age > config.stale_timeout {
+                Some(e.key().clone())
+            } else {
+                None
+            }
+        })
+        .collect();
+    for id in stale {
+        if let Some(entry) = registry.remove(&id) {
+            info!(tunnel_id = %id, age_ms = ?cutoff.as_millis(), "evicting stale tunnel");
+            drop(entry);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    use crate::handle::TunnelHandle;
+    use crate::registry::TunnelEntry;
+
+    fn entry(id: &str, age: Duration) -> TunnelEntry {
+        let (tx, _rx) = tokio::sync::mpsc::channel(8);
+        TunnelEntry {
+            tunnel_id: id.into(),
+            dcc: "test".into(),
+            capabilities: vec![],
+            agent_version: "test/0.0".into(),
+            registered_at: Instant::now(),
+            last_heartbeat: RwLock::new(
+                Instant::now().checked_sub(age).unwrap_or_else(Instant::now),
+            ),
+            handle: Arc::new(TunnelHandle::new(tx)),
+        }
+    }
+
+    #[test]
+    fn evicts_only_tunnels_past_timeout() {
+        let reg = TunnelRegistry::new();
+        reg.insert(entry("fresh", Duration::from_secs(1)));
+        reg.insert(entry("stale", Duration::from_secs(120)));
+        let cfg = RelayConfig {
+            stale_timeout: Duration::from_secs(30),
+            ..RelayConfig::default()
+        };
+        sweep_once(&reg, &cfg);
+        assert!(reg.get(&"fresh".to_string()).is_some());
+        assert!(reg.get(&"stale".to_string()).is_none());
+    }
+}

--- a/crates/dcc-mcp-tunnel-relay/src/handle.rs
+++ b/crates/dcc-mcp-tunnel-relay/src/handle.rs
@@ -1,0 +1,99 @@
+//! Per-tunnel routing handle.
+//!
+//! Each accepted agent connection produces one [`TunnelHandle`], stored on
+//! the matching [`crate::TunnelEntry`]. Two parties hold (cloned) `Arc`s
+//! to it:
+//!
+//! - The **control-plane reader** (`crate::control`) writes inbound `Data`
+//!   frames into the right session's inbox via [`TunnelHandle::session_inbox`].
+//! - The **frontend listener** (`crate::data`) allocates a new session via
+//!   [`TunnelHandle::open_session`] and pushes outbound bytes back to the
+//!   agent through the shared `frame_tx`.
+//!
+//! All locks are short-lived; the per-tunnel writer task drains `frame_tx`
+//! single-threaded so the agent socket itself is never contended.
+
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use dashmap::DashMap;
+use tokio::sync::mpsc;
+
+use dcc_mcp_tunnel_protocol::{Frame, SessionId};
+
+/// Bytes that arrived from the agent for one multiplexed session.
+pub type AgentBytes = Vec<u8>;
+
+/// Inbound channel handed to the frontend listener so it can read agent →
+/// frontend bytes for a single session.
+pub type SessionInboxRx = mpsc::Receiver<AgentBytes>;
+
+/// Routing surface for one accepted tunnel.
+#[derive(Debug)]
+pub struct TunnelHandle {
+    /// Outbound queue: anything pushed here is encoded by the per-tunnel
+    /// writer task and sent to the agent. Bounded so a slow agent applies
+    /// back-pressure to frontend producers (issue #504, hardening goal).
+    frame_tx: mpsc::Sender<Frame>,
+
+    /// Per-session inboxes — populated when the frontend opens a session
+    /// and drained when the control-plane reader receives a `Data` frame.
+    sessions: DashMap<SessionId, mpsc::Sender<AgentBytes>>,
+
+    /// Monotonic session-id allocator. Wraps at `u32::MAX`; collisions
+    /// with still-active sessions are statistically impossible at the
+    /// MVP's per-tunnel session ceiling.
+    next_session: AtomicU32,
+}
+
+impl TunnelHandle {
+    /// Build a handle that forwards outbound frames into `frame_tx`.
+    pub fn new(frame_tx: mpsc::Sender<Frame>) -> Self {
+        Self {
+            frame_tx,
+            sessions: DashMap::new(),
+            next_session: AtomicU32::new(1),
+        }
+    }
+
+    /// Reserve a fresh session and return the inbound receiver the
+    /// frontend listener should drain. The returned `SessionId` is stable
+    /// for the lifetime of the session.
+    pub fn open_session(&self, inbox_capacity: usize) -> (SessionId, SessionInboxRx) {
+        let session_id = self.next_session.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = mpsc::channel(inbox_capacity);
+        self.sessions.insert(session_id, tx);
+        (session_id, rx)
+    }
+
+    /// Look up the inbound channel for a session. Returns `None` once
+    /// `close_session` has been called or the receiver has been dropped.
+    pub fn session_inbox(&self, id: SessionId) -> Option<mpsc::Sender<AgentBytes>> {
+        self.sessions.get(&id).map(|s| s.clone())
+    }
+
+    /// Drop the per-session inbox so further `Data` frames for `id` are
+    /// silently discarded. Called from both directions on `CloseSession`.
+    pub fn close_session(&self, id: SessionId) {
+        self.sessions.remove(&id);
+    }
+
+    /// Send a frame toward the agent. `Err` only when the writer task has
+    /// already shut down (agent disconnected); callers treat this as a
+    /// terminal condition for their session.
+    pub async fn send(&self, frame: Frame) -> Result<(), mpsc::error::SendError<Frame>> {
+        self.frame_tx.send(frame).await
+    }
+
+    /// Best-effort, non-blocking send. Used by the eviction sweeper which
+    /// must not park behind a saturated agent.
+    pub fn try_send(&self, frame: Frame) -> Result<(), mpsc::error::TrySendError<Frame>> {
+        self.frame_tx.try_send(frame)
+    }
+
+    /// Number of currently-open sessions on this tunnel — used by
+    /// `/tunnels` listings and by the eviction sweeper to skip tunnels
+    /// that still have active traffic.
+    pub fn session_count(&self) -> usize {
+        self.sessions.len()
+    }
+}

--- a/crates/dcc-mcp-tunnel-relay/src/lib.rs
+++ b/crates/dcc-mcp-tunnel-relay/src/lib.rs
@@ -1,10 +1,17 @@
 //! Public-facing relay for the DCC-MCP zero-config remote-access tunnel.
 //!
-//! Issue #504 ships in five PRs; this crate is the **server** half. The
-//! current PR (#1 of 5) only lands configuration types and the in-memory
-//! tunnel registry — no network listeners yet. Subsequent PRs add the
-//! control-plane WebSocket handler, the data-plane multiplexer, and the
-//! frontend transports (WSS / TCP / HTTP-SSE).
+//! Issue #504. The MVP deliverables wired up here:
+//!
+//! - **Control plane** ([`control`]) — TCP agent listener, JWT validation,
+//!   registration, heartbeat tracking, per-tunnel writer task.
+//! - **Data plane** ([`data`]) — TCP frontend listener, `select_tunnel`
+//!   preamble, per-session multiplexing, full-duplex byte forwarding.
+//! - **Routing surface** ([`handle::TunnelHandle`]) — per-tunnel session
+//!   allocator + bounded outbound frame queue.
+//! - **Eviction** ([`eviction`]) — periodic sweeper that drops tunnels
+//!   silent past `RelayConfig::stale_timeout`.
+//! - **Server entry** ([`server::RelayServer`]) — binds both listeners,
+//!   spawns the sweeper, exposes the resolved addresses.
 //!
 //! See `dcc-mcp-tunnel-protocol` for the on-the-wire frame format and
 //! `dcc-mcp-tunnel-agent` for the local sidecar that registers here.
@@ -13,7 +20,15 @@
 #![warn(missing_docs, rust_2018_idioms)]
 
 pub mod config;
+pub mod control;
+pub mod data;
+pub mod eviction;
+pub mod handle;
 pub mod registry;
+pub mod server;
+pub mod transport;
 
 pub use config::RelayConfig;
+pub use handle::TunnelHandle;
 pub use registry::{TunnelEntry, TunnelRegistry};
+pub use server::RelayServer;

--- a/crates/dcc-mcp-tunnel-relay/src/registry.rs
+++ b/crates/dcc-mcp-tunnel-relay/src/registry.rs
@@ -5,12 +5,15 @@
 //! lock-free at the per-tunnel level (via `dashmap`) so a remote-client
 //! lookup never blocks behind an unrelated heartbeat.
 
+use std::sync::Arc;
 use std::time::Instant;
 
 use dashmap::DashMap;
 use parking_lot::RwLock;
 
 use dcc_mcp_tunnel_protocol::{TunnelId, frame::PROTOCOL_VERSION};
+
+use crate::handle::TunnelHandle;
 
 /// One row of the tunnel registry. Mutable fields are wrapped in an
 /// `RwLock` so heartbeat updates don't conflict with `/tunnels` reads.
@@ -36,6 +39,13 @@ pub struct TunnelEntry {
     /// Last heartbeat received. Updated under [`Self::touch`] without
     /// taking a write-lock on the whole registry.
     pub last_heartbeat: RwLock<Instant>,
+
+    /// Frame router for this tunnel. The frontend listener clones this to
+    /// send `OpenSession` / `Data` / `CloseSession` toward the agent and to
+    /// register per-session inbound channels. `Arc`'d so the control-plane
+    /// reader, the data-plane writer, and the eviction sweeper can all hold
+    /// references without locking the registry.
+    pub handle: Arc<TunnelHandle>,
 }
 
 impl TunnelEntry {
@@ -125,6 +135,7 @@ mod tests {
     use super::*;
 
     fn entry(id: &str, dcc: &str) -> TunnelEntry {
+        let (tx, _rx) = tokio::sync::mpsc::channel(8);
         TunnelEntry {
             tunnel_id: id.into(),
             dcc: dcc.into(),
@@ -132,6 +143,7 @@ mod tests {
             agent_version: "test/0.0".into(),
             registered_at: Instant::now(),
             last_heartbeat: RwLock::new(Instant::now()),
+            handle: Arc::new(TunnelHandle::new(tx)),
         }
     }
 

--- a/crates/dcc-mcp-tunnel-relay/src/server.rs
+++ b/crates/dcc-mcp-tunnel-relay/src/server.rs
@@ -1,0 +1,145 @@
+//! Top-level relay server: holds the shared registry, binds the agent
+//! and frontend listeners, and spawns the eviction sweeper.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::net::{TcpListener, TcpStream};
+use tracing::{info, warn};
+
+use crate::config::RelayConfig;
+use crate::control::handle_agent;
+use crate::data::handle_frontend;
+use crate::eviction::spawn_eviction_loop;
+use crate::registry::TunnelRegistry;
+
+/// Default sweep cadence. Mirrors the `stale_timeout` default so a tunnel
+/// that misses one full heartbeat cycle is evicted on the next pass.
+const DEFAULT_SWEEP_INTERVAL: Duration = Duration::from_secs(15);
+
+/// Running relay handle returned by [`RelayServer::start`]. Drop it (or
+/// call [`RelayServer::shutdown`]) to stop accepting connections; live
+/// sessions wind down on their own as their backing sockets close.
+#[derive(Debug)]
+pub struct RelayServer {
+    /// Shared tunnel registry — exposed so a future `/tunnels` HTTP
+    /// endpoint can read it without going through the relay state.
+    pub registry: Arc<TunnelRegistry>,
+
+    /// Address the agent listener actually bound to (resolves `:0`).
+    pub agent_addr: SocketAddr,
+
+    /// Address the frontend listener actually bound to (resolves `:0`).
+    pub frontend_addr: SocketAddr,
+
+    agent_task: tokio::task::JoinHandle<()>,
+    frontend_task: tokio::task::JoinHandle<()>,
+    eviction_task: tokio::task::JoinHandle<()>,
+}
+
+impl RelayServer {
+    /// Bind both listeners on the supplied addresses and start serving.
+    /// Use `"127.0.0.1:0"` to let the OS pick a port; the resolved
+    /// addresses are exposed on the returned struct for tests.
+    pub async fn start(
+        config: RelayConfig,
+        agent_bind: SocketAddr,
+        frontend_bind: SocketAddr,
+    ) -> std::io::Result<Self> {
+        let config = Arc::new(config);
+        let registry = Arc::new(TunnelRegistry::new());
+
+        let agent_listener = TcpListener::bind(agent_bind).await?;
+        let frontend_listener = TcpListener::bind(frontend_bind).await?;
+        let agent_addr = agent_listener.local_addr()?;
+        let frontend_addr = frontend_listener.local_addr()?;
+        info!(%agent_addr, %frontend_addr, "tunnel relay listening");
+
+        let agent_task = spawn_accept_loop(
+            agent_listener,
+            "agent",
+            Arc::clone(&registry),
+            Arc::clone(&config),
+            move |s, reg, cfg| Box::pin(handle_agent(s, reg, cfg)),
+        );
+
+        let frontend_task = {
+            let registry = Arc::clone(&registry);
+            tokio::spawn(async move {
+                loop {
+                    match frontend_listener.accept().await {
+                        Ok((stream, peer)) => {
+                            tracing::debug!(%peer, "frontend connection accepted");
+                            let registry = Arc::clone(&registry);
+                            tokio::spawn(handle_frontend(stream, registry));
+                        }
+                        Err(e) => {
+                            warn!(error = %e, "frontend accept failed; backing off");
+                            tokio::time::sleep(Duration::from_millis(100)).await;
+                        }
+                    }
+                }
+            })
+        };
+
+        let eviction_task = spawn_eviction_loop(
+            Arc::clone(&registry),
+            Arc::clone(&config),
+            DEFAULT_SWEEP_INTERVAL,
+        );
+
+        Ok(Self {
+            registry,
+            agent_addr,
+            frontend_addr,
+            agent_task,
+            frontend_task,
+            eviction_task,
+        })
+    }
+
+    /// Stop accepting new connections. Currently-in-flight sessions are
+    /// not interrupted; they wind down when their sockets close.
+    pub fn shutdown(self) {
+        self.agent_task.abort();
+        self.frontend_task.abort();
+        self.eviction_task.abort();
+    }
+}
+
+fn spawn_accept_loop<F>(
+    listener: TcpListener,
+    role: &'static str,
+    registry: Arc<TunnelRegistry>,
+    config: Arc<RelayConfig>,
+    handler: F,
+) -> tokio::task::JoinHandle<()>
+where
+    F: Fn(
+            TcpStream,
+            Arc<TunnelRegistry>,
+            Arc<RelayConfig>,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>
+        + Send
+        + Sync
+        + 'static,
+{
+    tokio::spawn(async move {
+        loop {
+            match listener.accept().await {
+                Ok((stream, peer)) => {
+                    tracing::debug!(role, %peer, "connection accepted");
+                    let registry = Arc::clone(&registry);
+                    let config = Arc::clone(&config);
+                    let fut = handler(stream, registry, config);
+                    tokio::spawn(fut);
+                }
+                Err(e) => {
+                    warn!(role, error = %e, "accept failed; backing off");
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+            }
+        }
+    })
+}

--- a/crates/dcc-mcp-tunnel-relay/src/transport.rs
+++ b/crates/dcc-mcp-tunnel-relay/src/transport.rs
@@ -1,0 +1,108 @@
+//! Async [`Frame`] I/O over any `AsyncRead + AsyncWrite` transport.
+//!
+//! The MVP transport (issue #504) is plain TCP carrying the protocol
+//! crate's length-prefixed msgpack codec. Every helper here operates on
+//! `tokio::io` traits so a future PR that swaps TCP for a WebSocket leg
+//! (tokio-tungstenite) only has to provide the adapter, not rewrite the
+//! framing.
+
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+use dcc_mcp_tunnel_protocol::{Decoder, Frame, ProtocolError, codec};
+
+/// Read one complete [`Frame`] from `reader`, blocking until enough bytes
+/// arrive. Returns `Ok(None)` cleanly on EOF *between* frames; an EOF in
+/// the middle of a partial frame surfaces as `Err`.
+pub async fn read_frame<R>(reader: &mut R) -> Result<Option<Frame>, TransportError>
+where
+    R: AsyncRead + Unpin,
+{
+    // Read the 4-byte length prefix first. A clean EOF here means the peer
+    // closed without owing us another frame.
+    let mut len_buf = [0u8; 4];
+    match reader.read_exact(&mut len_buf).await {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(e) => return Err(TransportError::Io(e)),
+    }
+    let len = u32::from_be_bytes(len_buf);
+    if len > codec::MAX_FRAME_BYTES {
+        return Err(TransportError::Protocol(ProtocolError::FrameTooLarge(
+            len,
+            codec::MAX_FRAME_BYTES,
+        )));
+    }
+    // Round-trip through `Decoder` so length-prefix + body parsing stays
+    // identical to the unit-tested in-memory path.
+    let mut body = vec![0u8; len as usize];
+    reader
+        .read_exact(&mut body)
+        .await
+        .map_err(TransportError::Io)?;
+    let mut dec = Decoder::new();
+    dec.extend(&len_buf);
+    dec.extend(&body);
+    match dec.next_frame()? {
+        Some(frame) => Ok(Some(frame)),
+        // The decoder cannot return `Ok(None)` here because we just fed it
+        // the entire frame; this branch exists only to keep the match
+        // exhaustive against future codec changes.
+        None => Err(TransportError::Protocol(ProtocolError::Incomplete {
+            needed: 4 + len as usize,
+            have: 4 + len as usize,
+        })),
+    }
+}
+
+/// Encode `frame` and write it to `writer` in one shot. Flushes
+/// immediately so the peer sees the frame even when the writer is buffered.
+pub async fn write_frame<W>(writer: &mut W, frame: &Frame) -> Result<(), TransportError>
+where
+    W: AsyncWrite + Unpin,
+{
+    let bytes = codec::encode(frame)?;
+    writer.write_all(&bytes).await.map_err(TransportError::Io)?;
+    writer.flush().await.map_err(TransportError::Io)?;
+    Ok(())
+}
+
+/// Errors surfaced by the async frame I/O helpers.
+#[derive(Debug, thiserror::Error)]
+pub enum TransportError {
+    /// Underlying socket I/O failed (closed, reset, write error).
+    #[error("transport I/O: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Wire format violation (oversized frame, malformed msgpack, …).
+    #[error("frame protocol: {0}")]
+    Protocol(#[from] ProtocolError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dcc_mcp_tunnel_protocol::{Frame, RegisterRequest, frame::PROTOCOL_VERSION};
+
+    #[tokio::test]
+    async fn round_trip_frame_over_duplex() {
+        let (mut a, mut b) = tokio::io::duplex(1024);
+        let frame = Frame::Register(RegisterRequest {
+            protocol_version: PROTOCOL_VERSION,
+            token: "tok".into(),
+            dcc: "maya".into(),
+            capabilities: vec![],
+            agent_version: "test/0.0".into(),
+        });
+        write_frame(&mut a, &frame).await.unwrap();
+        let got = read_frame(&mut b).await.unwrap().expect("frame");
+        assert_eq!(got, frame);
+    }
+
+    #[tokio::test]
+    async fn clean_eof_returns_none() {
+        let (a, mut b) = tokio::io::duplex(1024);
+        drop(a);
+        let got = read_frame(&mut b).await.unwrap();
+        assert!(got.is_none());
+    }
+}

--- a/crates/dcc-mcp-tunnel-relay/tests/e2e.rs
+++ b/crates/dcc-mcp-tunnel-relay/tests/e2e.rs
@@ -1,0 +1,165 @@
+//! End-to-end smoke test for the relay MVP (issue #504).
+//!
+//! Spins up:
+//!   1. an in-process echo TCP server (the "local DCC")
+//!   2. a `RelayServer` on `127.0.0.1:0` for both agent and frontend
+//!   3. one `dcc-mcp-tunnel-agent` registration that bridges to the echo
+//!   4. one frontend client that selects the tunnel and round-trips bytes
+//!
+//! Asserts that bytes round-trip end-to-end through the relay.
+
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::time::timeout;
+
+use dcc_mcp_tunnel_agent::{AgentConfig, run_once};
+use dcc_mcp_tunnel_protocol::{TunnelClaims, auth};
+use dcc_mcp_tunnel_relay::{RelayConfig, RelayServer, data::write_select_tunnel};
+
+const SECRET: &[u8] = b"e2e-test-secret-must-exceed-32-bytes";
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+async fn spawn_echo_server() -> std::net::SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let (mut sock, _) = match listener.accept().await {
+                Ok(p) => p,
+                Err(_) => return,
+            };
+            tokio::spawn(async move {
+                let mut buf = [0u8; 4096];
+                while let Ok(n) = sock.read(&mut buf).await {
+                    if n == 0 {
+                        return;
+                    }
+                    if sock.write_all(&buf[..n]).await.is_err() {
+                        return;
+                    }
+                }
+            });
+        }
+    });
+    addr
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn frontend_round_trips_through_relay_to_local_echo() {
+    let echo = spawn_echo_server().await;
+
+    let cfg = RelayConfig {
+        jwt_secret: SECRET.to_vec(),
+        public_host: "localhost".into(),
+        base_url: "tcp://localhost:0".into(),
+        stale_timeout: Duration::from_secs(60),
+        max_tunnels: 0,
+    };
+    let relay = RelayServer::start(
+        cfg,
+        "127.0.0.1:0".parse().unwrap(),
+        "127.0.0.1:0".parse().unwrap(),
+    )
+    .await
+    .unwrap();
+    let agent_addr = relay.agent_addr;
+    let frontend_addr = relay.frontend_addr;
+    let registry = Arc::clone(&relay.registry);
+
+    let claims = TunnelClaims {
+        sub: "e2e-test".into(),
+        iat: now_secs(),
+        exp: now_secs() + 600,
+        iss: "e2e".into(),
+        allowed_dcc: vec!["maya".into()],
+    };
+    let token = auth::issue(&claims, SECRET).unwrap();
+
+    let agent_cfg = AgentConfig {
+        relay_url: agent_addr.to_string(),
+        token,
+        dcc: "maya".into(),
+        capabilities: vec!["scene.read".into()],
+        agent_version: "e2e/0.0".into(),
+        local_target: echo.to_string(),
+        heartbeat_interval: Duration::from_secs(5),
+        reconnect: dcc_mcp_tunnel_agent::ReconnectPolicy::default(),
+    };
+    let agent_task = tokio::spawn(async move { run_once(agent_cfg).await });
+
+    // Wait for the registry to see the tunnel — much faster than polling
+    // the agent task itself, and gives us the assigned tunnel id.
+    let tunnel_id = wait_for_tunnel(&registry).await;
+
+    let mut frontend = TcpStream::connect(frontend_addr).await.unwrap();
+    write_select_tunnel(&mut frontend, &tunnel_id)
+        .await
+        .unwrap();
+
+    let payload = b"hello-relay-mvp";
+    frontend.write_all(payload).await.unwrap();
+
+    let mut reply = vec![0u8; payload.len()];
+    timeout(Duration::from_secs(3), frontend.read_exact(&mut reply))
+        .await
+        .expect("echo round-trip timed out")
+        .expect("echo round-trip failed");
+    assert_eq!(&reply[..], payload);
+
+    drop(frontend);
+    relay.shutdown();
+    agent_task.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rejects_invalid_token() {
+    let cfg = RelayConfig {
+        jwt_secret: SECRET.to_vec(),
+        ..RelayConfig::default()
+    };
+    let relay = RelayServer::start(
+        cfg,
+        "127.0.0.1:0".parse().unwrap(),
+        "127.0.0.1:0".parse().unwrap(),
+    )
+    .await
+    .unwrap();
+    let agent_cfg = AgentConfig::new(
+        relay.agent_addr.to_string(),
+        "garbage-token",
+        "maya",
+        "127.0.0.1:1",
+    );
+    let outcome = run_once(agent_cfg).await;
+    assert!(
+        matches!(
+            outcome,
+            Err(dcc_mcp_tunnel_agent::ClientError::Rejected(ref ack))
+                if !ack.ok
+        ),
+        "expected Rejected, got {outcome:?}"
+    );
+    relay.shutdown();
+}
+
+async fn wait_for_tunnel(registry: &dcc_mcp_tunnel_relay::TunnelRegistry) -> String {
+    timeout(Duration::from_secs(3), async {
+        loop {
+            if let Some(entry) = registry.iter().next() {
+                return entry.key().clone();
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("registry never saw the tunnel")
+}

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -46,6 +46,7 @@ export default defineConfig({
                 { text: 'Thin Harness', link: '/guide/thin-harness' },
                 { text: 'Gateway Election', link: '/guide/gateway-election' },
                 { text: 'Gateway', link: '/guide/gateway' },
+                { text: 'Tunnel Relay', link: '/guide/tunnel-relay' },
                 { text: 'Remote Server', link: '/guide/remote-server' },
                 { text: 'Production Deployment', link: '/guide/production-deployment' },
               ]
@@ -177,6 +178,7 @@ export default defineConfig({
                 { text: 'Thin Harness', link: '/zh/guide/thin-harness' },
                 { text: '网关选举机制', link: '/zh/guide/gateway-election' },
                 { text: 'Gateway', link: '/zh/guide/gateway' },
+                { text: '隧道中继', link: '/zh/guide/tunnel-relay' },
                 { text: '远程服务器', link: '/zh/guide/remote-server' },
                 { text: '生产环境部署', link: '/zh/guide/production-deployment' },
               ]

--- a/docs/guide/tunnel-relay.md
+++ b/docs/guide/tunnel-relay.md
@@ -1,0 +1,134 @@
+# Remote MCP Tunnel Relay
+
+Zero-config remote access to a DCC's local MCP server, without opening
+inbound firewall holes on the workstation. Tracked in issue #504.
+
+## When to use it
+
+Reach for the relay when you need an off-machine agent (cloud LLM,
+orchestrator on another host, web client) to talk to a DCC running
+behind NAT or a corporate firewall. Inside a single LAN keep using
+`McpHttpConfig(host="0.0.0.0", port=8765)` directly — it's one fewer hop.
+
+## Architecture
+
+```
+┌──────────────┐      WSS / TCP       ┌────────────┐      TCP      ┌─────────────┐
+│ Local Agent  │ ───── Register ────► │ Relay      │ ◄──── select  │ Remote MCP  │
+│ (in DCC)     │ ◄─── OpenSession ─── │ (public)   │   tunnel id   │ Client      │
+│              │ ◄─── Data ─────────► │  registry  │ ────────────► │             │
+│              │ ──── Heartbeat ─────► │  + sweeper │               │             │
+└──────┬───────┘                       └────────────┘               └─────────────┘
+       │ TCP
+       ▼
+┌──────────────┐
+│ DCC HTTP MCP │
+│ (localhost)  │
+└──────────────┘
+```
+
+Three crates collaborate:
+
+| Crate | Role |
+|---|---|
+| `dcc-mcp-tunnel-protocol` | Frame format (msgpack), JWT auth, codec |
+| `dcc-mcp-tunnel-relay` | Public-facing server: agent + frontend listeners, registry, eviction |
+| `dcc-mcp-tunnel-agent` | Local sidecar: registers, multiplexes per-session bytes to the local DCC |
+
+## Minimal end-to-end example (Rust)
+
+```rust
+use std::time::Duration;
+use dcc_mcp_tunnel_protocol::{auth, TunnelClaims};
+use dcc_mcp_tunnel_relay::{RelayConfig, RelayServer};
+use dcc_mcp_tunnel_agent::{AgentConfig, run_once};
+
+# async fn demo() -> anyhow::Result<()> {
+let secret = b"swap-me-with-a-real-32B-secret-please";
+
+// 1. Operator stands up the relay (e.g. on a public VM).
+let relay = RelayServer::start(
+    RelayConfig {
+        jwt_secret: secret.to_vec(),
+        public_host: "relay.example.com".into(),
+        base_url: "wss://relay.example.com".into(),
+        stale_timeout: Duration::from_secs(45),
+        max_tunnels: 0,
+    },
+    "0.0.0.0:9001".parse()?, // agent listener
+    "0.0.0.0:9002".parse()?, // frontend listener
+).await?;
+
+// 2. Operator mints a per-DCC JWT and ships it to the workstation.
+let token = auth::issue(&TunnelClaims {
+    sub: "studio-bob".into(), iat: 0, exp: u64::MAX,
+    iss: "studio-issuer".into(),
+    allowed_dcc: vec!["maya".into()],
+}, secret)?;
+
+// 3. Agent runs in the DCC process (or a sibling sidecar).
+let cfg = AgentConfig::new(
+    "relay.example.com:9001",
+    &token,
+    "maya",
+    "127.0.0.1:8765", // local DCC MCP HTTP server
+);
+let registered = run_once(cfg).await?;
+println!("public URL: {:?}", registered.public_url);
+# Ok(()) }
+```
+
+## Frontend client wire format
+
+Until the HTTP / WSS frontends land (PR 4 of #504), remote clients use
+plain TCP and a 2-byte length-prefixed tunnel id as the very first
+payload:
+
+```text
+[u16 BE: tunnel_id_len][tunnel_id_bytes][... raw MCP traffic ...]
+```
+
+Helper exposed for tests + SDKs:
+
+```rust
+use dcc_mcp_tunnel_relay::data::write_select_tunnel;
+write_select_tunnel(&mut tcp_stream, &tunnel_id).await?;
+```
+
+## Authentication & scoping
+
+Every agent registration carries a JWT signed with `RelayConfig::jwt_secret`.
+The token's `allowed_dcc` claim **caps** which DCC tags the agent may
+register under — the relay rejects mismatches with `ErrorCode::DccNotAllowed`.
+Tokens are expected to be short-lived (minutes to hours); rotation is
+the operator's job.
+
+## Stale tunnel eviction
+
+The relay sweeps the registry every 15 s by default. Any tunnel whose
+last heartbeat is older than `RelayConfig::stale_timeout` is dropped,
+which closes its outbound queue and tears down per-tunnel tasks. Active
+sessions on an evicted tunnel see a TCP RST.
+
+## What's not (yet) in the MVP
+
+| Capability | Status |
+|---|---|
+| Plain TCP transport (agent + frontend) | ✅ MVP |
+| JWT auth + DCC scoping | ✅ MVP |
+| 1:N session multiplexing per tunnel | ✅ MVP |
+| Periodic eviction | ✅ MVP |
+| WebSocket Secure transport (browser-friendly) | follow-up |
+| HTTP+SSE frontend with `/dcc/<name>/<tunnel_id>` routing | follow-up |
+| `/tunnels` listing endpoint + admin metrics | follow-up |
+| Reconnect-with-back-off on the agent | follow-up |
+
+The MVP is good enough to validate the protocol end-to-end and to
+unblock dependent work (issue #504 acceptance criteria 1-5).
+
+## See also
+
+- `crates/dcc-mcp-tunnel-relay/tests/e2e.rs` — runnable example covering
+  successful round-trip + token rejection.
+- [`docs/guide/agents-reference.md`](agents-reference.md) for trap rules
+  and conventions.

--- a/docs/zh/guide/tunnel-relay.md
+++ b/docs/zh/guide/tunnel-relay.md
@@ -1,0 +1,129 @@
+# 远程 MCP 隧道中继
+
+零配置打通工作站本地的 DCC MCP 服务到外部网络，无需在工作站上开放
+入站防火墙端口。对应 issue #504。
+
+## 何时使用
+
+当需要把本地 DCC（Maya / Blender / Houdini …）的 MCP 服务暴露给云端
+LLM、跨主机的编排器或 Web 客户端时使用。同一局域网内仍优先用
+`McpHttpConfig(host="0.0.0.0", port=8765)`，少一跳更省事。
+
+## 架构
+
+```
+┌──────────────┐      WSS / TCP       ┌────────────┐      TCP      ┌─────────────┐
+│ 本地 Agent   │ ───── 注册 ────────► │ 中继       │ ◄─── 选择隧道 │ 远端 MCP    │
+│ （DCC 内）   │ ◄─── OpenSession ─── │ （公网）   │     id        │ 客户端      │
+│              │ ◄─── Data ─────────► │ 注册表+清扫 │ ────────────► │             │
+│              │ ──── 心跳 ──────────► │            │               │             │
+└──────┬───────┘                       └────────────┘               └─────────────┘
+       │ TCP
+       ▼
+┌──────────────┐
+│ DCC 本地 MCP │
+│ HTTP 服务    │
+└──────────────┘
+```
+
+三个 crate 协作：
+
+| Crate | 角色 |
+|---|---|
+| `dcc-mcp-tunnel-protocol` | 帧格式（msgpack）、JWT 鉴权、编解码 |
+| `dcc-mcp-tunnel-relay` | 公网入口：agent + 前端监听器、注册表、清扫器 |
+| `dcc-mcp-tunnel-agent` | 本地边车：注册并把每会话字节多路复用到本地 DCC |
+
+## 端到端最小示例（Rust）
+
+```rust
+use std::time::Duration;
+use dcc_mcp_tunnel_protocol::{auth, TunnelClaims};
+use dcc_mcp_tunnel_relay::{RelayConfig, RelayServer};
+use dcc_mcp_tunnel_agent::{AgentConfig, run_once};
+
+# async fn demo() -> anyhow::Result<()> {
+let secret = b"swap-me-with-a-real-32B-secret-please";
+
+// 1. 运维在公网 VM 上拉起中继。
+let relay = RelayServer::start(
+    RelayConfig {
+        jwt_secret: secret.to_vec(),
+        public_host: "relay.example.com".into(),
+        base_url: "wss://relay.example.com".into(),
+        stale_timeout: Duration::from_secs(45),
+        max_tunnels: 0,
+    },
+    "0.0.0.0:9001".parse()?, // agent 监听端口
+    "0.0.0.0:9002".parse()?, // 前端监听端口
+).await?;
+
+// 2. 运维签发 per-DCC JWT 并下发到工作站。
+let token = auth::issue(&TunnelClaims {
+    sub: "studio-bob".into(), iat: 0, exp: u64::MAX,
+    iss: "studio-issuer".into(),
+    allowed_dcc: vec!["maya".into()],
+}, secret)?;
+
+// 3. Agent 在 DCC 进程（或同侧 sidecar）运行。
+let cfg = AgentConfig::new(
+    "relay.example.com:9001",
+    &token,
+    "maya",
+    "127.0.0.1:8765", // 本地 DCC MCP HTTP 服务
+);
+let registered = run_once(cfg).await?;
+println!("公网 URL: {:?}", registered.public_url);
+# Ok(()) }
+```
+
+## 前端客户端线协议
+
+在 HTTP / WSS 前端落地前（PR 4 of #504），远端客户端使用普通 TCP，
+首个有效载荷必须是 2 字节大端长度前缀的 tunnel id：
+
+```text
+[u16 BE: tunnel_id_len][tunnel_id_bytes][... 后续 MCP 流量 ...]
+```
+
+测试 / SDK 可直接调用：
+
+```rust
+use dcc_mcp_tunnel_relay::data::write_select_tunnel;
+write_select_tunnel(&mut tcp_stream, &tunnel_id).await?;
+```
+
+## 鉴权与作用域
+
+每个 agent 注册都携带一份用 `RelayConfig::jwt_secret` 签发的 JWT。
+Token 中的 `allowed_dcc` 字段**限定**该 agent 可以注册的 DCC 标签 ——
+不匹配时中继返回 `ErrorCode::DccNotAllowed`。
+JWT 应短期签发（分钟到小时级），轮换由运维处理。
+
+## 失活隧道剔除
+
+中继默认每 15 秒扫描一次注册表。任何上次心跳早于
+`RelayConfig::stale_timeout` 的隧道都会被丢弃 —— 出站队列随之关闭，
+per-tunnel 任务被回收。被剔除隧道上的活跃会话会感受到 TCP RST。
+
+## MVP 之外的能力
+
+| 能力 | 状态 |
+|---|---|
+| 纯 TCP 传输（agent + 前端） | ✅ MVP |
+| JWT 鉴权 + DCC 作用域 | ✅ MVP |
+| 单 tunnel 1:N 会话多路复用 | ✅ MVP |
+| 周期性失活剔除 | ✅ MVP |
+| WebSocket Secure 传输（浏览器友好） | 后续 |
+| HTTP+SSE 前端 + `/dcc/<name>/<tunnel_id>` 路由 | 后续 |
+| `/tunnels` 列表端点 + 管理指标 | 后续 |
+| Agent 退避重连 | 后续 |
+
+MVP 已能端到端跑通协议，并满足 #504 的验收条件 1-5。
+
+## 相关
+
+- `crates/dcc-mcp-tunnel-relay/tests/e2e.rs` —— 可运行示例，覆盖
+  成功的端到端往返与 token 拒绝路径。
+- [`docs/guide/agents-reference.md`](agents-reference.md) —— 陷阱清单
+  与约定。

--- a/llms.txt
+++ b/llms.txt
@@ -44,6 +44,8 @@
 | YAML declarative workflows (issue #439) | `WorkflowYaml` + `load_workflow_yaml(path)` + `register_workflow_yaml_tools(server)` — task vs step semantics for multi-step DCC workflows |
 | WebSocket bridge for non-Python DCCs | `DccBridge(host, port)` — WebSocket JSON-RPC 2.0 bridge; `.call(method, **params)` for synchronous RPC to DCC plugin |
 | Gateway failover election | `DccGatewayElection(dcc_name, server)` — automatic gateway failover via first-wins socket election |
+| Zero-config remote MCP relay (issue #504) | `RelayServer::start(RelayConfig, agent_bind, frontend_bind).await` (server) + `dcc_mcp_tunnel_agent::run_once(AgentConfig::new(relay_url, jwt, dcc, local_target)).await` (sidecar) — agent registers, frontend TCP clients select the tunnel via 2-byte length-prefixed id and full-duplex byte-stream over multiplexed sessions |
+| Mint a tunnel JWT | `dcc_mcp_tunnel_protocol::auth::issue(&TunnelClaims { sub, iat, exp, iss, allowed_dcc }, secret)` — relay validates `allowed_dcc` scope on every registration |
 | Skill hot-reload without server restart | `DccSkillHotReloader(dcc_name, server)` — monitors skill directories and auto-reloads on change |
 | Singleton DCC server factory | `create_dcc_server(instance_holder, lock, server_class, ...)` / `make_start_stop(ServerClass)` — zero-boilerplate singleton server pattern |
 | Skill validation | `validate_skill(skill_dir)` → `SkillValidationReport` with `SkillValidationIssue` list |


### PR DESCRIPTION
## Summary

Implements **PR 2-5 of issue #504 as a single cohesive MVP** that delivers acceptance criteria 1-5 of the relay design (agent registration, frontend round-trip, full-duplex bytes, stale-tunnel eviction, invalid-token rejection). #540 (PR 1/5) shipped the protocol crates + scaffolding; this PR brings the relay to a usable state with an end-to-end smoke test.

Deliberately bundled rather than split because PRs 2 → 5 share connected tasks/channels — splitting them produces broken intermediate states that can't pass an e2e test, which makes review *harder*, not easier.

## What landed (relay side)

All new modules under `crates/dcc-mcp-tunnel-relay/src/`:

| Module | Role |
|---|---|
| `transport.rs` | Async `Frame` I/O over `AsyncRead + AsyncWrite`. Round-trips through the existing codec; clean EOF semantics on the length prefix. |
| `handle.rs` | `TunnelHandle` — per-tunnel session allocator + bounded outbound frame queue. Cloneable `Arc` so the registry stays lock-free at the per-tunnel level. |
| `control.rs` | `handle_agent` splits the socket, validates `Register` (JWT + protocol_version + DCC scope + capacity), mints a UUID `tunnel_id`, sends `RegisterAck`, then runs a single writer task draining the bounded queue and a reader loop dispatching `Heartbeat` / `Data` / `CloseSession` / `Error`. |
| `data.rs` | `handle_frontend` reads a 2-byte-length-prefixed `select_tunnel` preamble, opens a session on the matching tunnel handle, sends `OpenSession` to the agent, then full-duplex copies bytes (32 KiB chunks) in both directions. |
| `eviction.rs` | `spawn_eviction_loop` ticks every 15 s, drops tunnels whose `last_heartbeat` is older than `RelayConfig::stale_timeout`. Pure registry walk — no per-tunnel cancellation tokens needed because dropping the registry's `Arc<TunnelHandle>` closes the agent writer queue. |
| `server.rs` | `RelayServer::start` binds both listeners (use `127.0.0.1:0` to let the OS pick), spawns the sweeper, returns the resolved addresses + a registry handle so a future `/tunnels` endpoint can read it without going through the relay state. |

`TunnelEntry` now carries an `Arc<TunnelHandle>` so the data plane routes to a tunnel in O(1) without touching the registry lock.

## What landed (agent side)

| Module | Role |
|---|---|
| `transport.rs` | Mirror of relay's frame helpers (no inter-crate dep just for I/O). |
| `client.rs` | `run_once` dials the relay, sends `Register`, awaits `RegisterAck`, then dispatches incoming `OpenSession` / `Data` / `CloseSession` by spawning a per-session bridge that opens TCP to the local DCC and copies bytes both ways. |

## End-to-end test

`crates/dcc-mcp-tunnel-relay/tests/e2e.rs`:

1. Spawns an in-process echo TCP server (the "local DCC").
2. Brings up `RelayServer` on `127.0.0.1:0` for both listeners.
3. Mints a JWT scoped to `allowed_dcc=["maya"]` and runs one `dcc-mcp-tunnel-agent` registration.
4. Connects a frontend client, writes the `select_tunnel` preamble, sends `b"hello-relay-mvp"`.
5. Asserts the bytes round-trip through every layer within 3 s.

A second test asserts a garbage token is rejected with `ClientError::Rejected`.

## Docs

- `AGENTS.md` decision-table now points at the working APIs (`RelayServer::start`, `run_once`, `auth::issue`).
- `llms.txt` gains the same entries.
- New `docs/guide/tunnel-relay.md` (+ `docs/zh/guide/tunnel-relay.md`) covers architecture, minimal example, wire format, JWT scoping, eviction, MVP-vs-follow-up matrix.

## Validation

- `cargo build -p dcc-mcp-tunnel-relay -p dcc-mcp-tunnel-agent` — ok
- `cargo clippy -p dcc-mcp-tunnel-relay -p dcc-mcp-tunnel-agent --all-targets -- -D warnings` — 0 warnings
- `cargo test -p dcc-mcp-tunnel-relay -p dcc-mcp-tunnel-agent -p dcc-mcp-tunnel-protocol` — **all tests pass** (incl. e2e round-trip + token rejection)
- `cargo fmt --all` — clean

## Acceptance criteria coverage (issue #504)

| # | Criterion | Status |
|---|---|---|
| 1 | Local Agent can register and obtain `tunnel_id` | ✅ covered by e2e |
| 2 | Remote Client can connect via `tunnel_id` and exchange bytes | ✅ covered by e2e |
| 3 | End-to-end full-duplex transfer | ✅ covered by e2e |
| 4 | Stale connections cleaned up automatically | ✅ unit-tested in `eviction::tests` |
| 5 | Invalid/expired tokens rejected | ✅ covered by e2e (`rejects_invalid_token`) |
| 6 | Median added RTT low intra-region | not directly benchmarked here — single-host e2e completes in ms; production benchmarking belongs to a follow-up |

## Deliberately deferred (follow-up issues)

- WebSocket Secure transport (browser-friendly, needs `tokio-tungstenite`).
- HTTP+SSE frontend with `/dcc/<name>/<tunnel_id>` routing.
- `/tunnels` listing endpoint + admin metrics.
- Agent reconnect-with-back-off (the `ReconnectPolicy` field is wired through but the loop itself is intentionally one-shot in this PR).