### PR TITLE
chore(ruff): apply format + exclude generated _core.pyi from lint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,10 @@ disable_error_code = ["type-arg", "misc", "no-any-return"]
 line-length = 120
 target-version = "py37"
 src = ["python/dcc_mcp_core", "tests", "examples"]
+# `_core.pyi` is regenerated from the Rust extension by `pyo3-stub-gen`
+# on every build; running ruff against it produces ~1k spurious diffs
+# that would just get clobbered the next time `maturin develop` runs.
+extend-exclude = ["python/dcc_mcp_core/_core.pyi"]
 
 [tool.ruff.lint]
 select = [

--- a/python/dcc_mcp_core/cancellation.py
+++ b/python/dcc_mcp_core/cancellation.py
@@ -57,11 +57,13 @@ if sys.version_info >= (3, 8):
     from typing import Protocol
     from typing import runtime_checkable
 else:  # pragma: no cover - py3.7 only
+
     def runtime_checkable(cls):
         return cls
 
     class Protocol:  # type: ignore[no-redef]
         pass
+
 
 __all__ = [
     "CancelToken",

--- a/tests/test_callable_dispatcher.py
+++ b/tests/test_callable_dispatcher.py
@@ -128,9 +128,7 @@ def test_submit_async_returns_pending_envelope_then_completes() -> None:
         barrier.wait(timeout=2.0)
         return 99
 
-    pending = d.submit_async_callable(
-        "r1", task, on_complete=completed.append, progress_token="p1"
-    )
+    pending = d.submit_async_callable("r1", task, on_complete=completed.append, progress_token="p1")
     assert isinstance(pending, PendingEnvelope)
     assert pending.request_id == "r1"
     assert pending.job_id  # uuid hex

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -99,6 +99,7 @@ class TestModuleLevelHelpers:
     def setup_method(self) -> None:
         # Ensure a clean store for each test
         from dcc_mcp_core import checkpoint as cp_mod
+
         cp_mod._DEFAULT_STORE = CheckpointStore()
 
     def test_save_and_get_checkpoint(self) -> None:

--- a/tests/test_inprocess_executor.py
+++ b/tests/test_inprocess_executor.py
@@ -76,10 +76,7 @@ def test_run_skill_script_systemexit_returns_mcp_result(tmp_path: Path) -> None:
     """Mirrors Maya's existing convention used by some skills."""
     p = _write_script(
         tmp_path,
-        "import sys\n"
-        "__mcp_result__ = {'ok': True, 'frames': 12}\n"
-        "def main(**_):\n"
-        "    sys.exit(0)\n",
+        "import sys\n__mcp_result__ = {'ok': True, 'frames': 12}\ndef main(**_):\n    sys.exit(0)\n",
     )
     assert run_skill_script(str(p), {}) == {"ok": True, "frames": 12}
 
@@ -87,8 +84,7 @@ def test_run_skill_script_systemexit_returns_mcp_result(tmp_path: Path) -> None:
 def test_run_skill_script_systemexit_at_module_level(tmp_path: Path) -> None:
     p = _write_script(
         tmp_path,
-        "__mcp_result__ = {'fast_path': True}\n"
-        "raise SystemExit(0)\n",
+        "__mcp_result__ = {'fast_path': True}\nraise SystemExit(0)\n",
     )
     assert run_skill_script(str(p), {}) == {"fast_path": True}
 

--- a/tests/test_introspect.py
+++ b/tests/test_introspect.py
@@ -222,9 +222,7 @@ class TestRegisterIntrospectTools:
     def test_search_handler_works(self) -> None:
         server, handlers = self._make_server()
         register_introspect_tools(server)
-        result = handlers["dcc_introspect__search"](
-            json.dumps({"pattern": "sqrt", "module": "math"})
-        )
+        result = handlers["dcc_introspect__search"](json.dumps({"pattern": "sqrt", "module": "math"}))
         assert result["success"] is True
 
     def test_eval_handler_works(self) -> None:


### PR DESCRIPTION
## Why

`python/dcc_mcp_core/_core.pyi` is regenerated from the Rust extension by `pyo3-stub-gen` on every `maturin develop` run. Linting it produced ~1k pycodestyle/pydocstyle diffs that would just get clobbered the next time the stub regenerated.

## What

* Add `python/dcc_mcp_core/_core.pyi` to `[tool.ruff].extend-exclude` with a comment explaining the rationale.
* With the stub excluded, run `ruff format` to bring the five hand-written files in line with the configured 120-col / double-quote / sorted-imports style:
  * `cancellation.py` — pad the py3.7 fallback `Protocol` definition with blank lines.
  * `tests/test_callable_dispatcher.py` / `tests/test_inprocess_executor.py` / `tests/test_introspect.py` — collapse over-wrapped argument lists and string literals that fit inside the 120-col budget.
  * `tests/test_checkpoint.py` — blank line after the `from … import` in a `setup_method`.

No behavioural change.

## Verification

* `ruff check python/ tests/ examples/` — **clean**.
* `ruff format --check python/ tests/ examples/` — **clean** (224 already formatted + 5 reformatted).
* `pytest tests/test_callable_dispatcher.py tests/test_checkpoint.py tests/test_inprocess_executor.py tests/test_introspect.py` — **91 passed**.