### PR TITLE
fix: gateway reliability, security, and logging defaults (#551, #552, #553, #554, #555, #556, #557, #558)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,7 +713,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dcc-mcp-actions"
-version = "0.14.17"
+version = "0.14.18"
 dependencies = [
  "dashmap",
  "dcc-mcp-models",
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-artefact"
-version = "0.14.17"
+version = "0.14.18"
 dependencies = [
  "chrono",
  "hex",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-capture"
-version = "0.14.17"
+version = "0.14.18"
 dependencies = [
  "image",
  "libc",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-core"
-version = "0.14.17"
+version = "0.14.18"
 dependencies = [
  "dcc-mcp-actions",
  "dcc-mcp-artefact",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-http"
-version = "0.14.17"
+version = "0.14.18"
 dependencies = [
  "axum",
  "axum-test",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-logging"
-version = "0.14.17"
+version = "0.14.18"
 dependencies = [
  "dcc-mcp-paths",
  "parking_lot",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-models"
-version = "0.14.17"
+version = "0.14.18"
 dependencies = [
  "dcc-mcp-naming",
  "dcc-mcp-pybridge",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-naming"
-version = "0.14.17"
+version = "0.14.18"
 dependencies = [
  "pyo3",
  "pyo3-stub-gen",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-paths"
-version = "0.14.17"
+version = "0.14.18"
 dependencies = [
  "dirs",
  "pyo3",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-process"
-version = "0.14.17"
+version = "0.14.18"
 dependencies = [
  "dcc-mcp-models",
  "ipckit",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-protocols"
-version = "0.14.17"
+version = "0.14.18"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-pybridge"
-version = "0.14.17"
+version = "0.14.18"
 dependencies = [
  "dcc-mcp-pybridge-derive",
  "pyo3",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-pybridge-derive"
-version = "0.14.17"
+version = "0.14.18"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-sandbox"
-version = "0.14.17"
+version = "0.14.18"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-scheduler"
-version = "0.14.17"
+version = "0.14.18"
 dependencies = [
  "axum",
  "bytes",
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-server"
-version = "0.14.17"
+version = "0.14.18"
 dependencies = [
  "anyhow",
  "axum",
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-shm"
-version = "0.14.17"
+version = "0.14.18"
 dependencies = [
  "ipckit",
  "libc",
@@ -1052,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-skills"
-version = "0.14.17"
+version = "0.14.18"
 dependencies = [
  "dashmap",
  "dcc-mcp-actions",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-telemetry"
-version = "0.14.17"
+version = "0.14.18"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-transport"
-version = "0.14.17"
+version = "0.14.18"
 dependencies = [
  "criterion",
  "dashmap",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-agent"
-version = "0.14.17"
+version = "0.14.18"
 dependencies = [
  "dashmap",
  "dcc-mcp-tunnel-protocol",
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-protocol"
-version = "0.14.17"
+version = "0.14.18"
 dependencies = [
  "jsonwebtoken",
  "rmp-serde",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-relay"
-version = "0.14.17"
+version = "0.14.18"
 dependencies = [
  "axum",
  "dashmap",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-usd"
-version = "0.14.17"
+version = "0.14.18"
 dependencies = [
  "dcc-mcp-protocols",
  "pyo3",
@@ -1188,7 +1188,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-workflow"
-version = "0.14.17"
+version = "0.14.18"
 dependencies = [
  "base64",
  "chrono",

--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -386,6 +386,15 @@ pub struct McpHttpConfig {
     /// Set to `false` to disable caching (every `tools/list` call
     /// rebuilds the full list from scratch).
     pub enable_tool_cache: bool,
+
+    /// Allow instances with `dcc_type == "unknown"` to expose their tools
+    /// via the gateway (issue #555).
+    ///
+    /// Default: `false`. When `false`, the gateway's `tools/list` and
+    /// `connect_to_dcc` ignore any instance whose `dcc_type` is
+    /// `"unknown"` (case-insensitive). Set to `true` only for development
+    /// or when intentionally running a standalone server without a real DCC.
+    pub allow_unknown_tools: bool,
 }
 
 impl McpHttpConfig {
@@ -429,6 +438,7 @@ impl McpHttpConfig {
             enable_scheduler: false,
             schedules_dir: None,
             enable_tool_cache: true,
+            allow_unknown_tools: false,
         }
     }
 

--- a/crates/dcc-mcp-http/src/gateway/aggregator/fingerprint.rs
+++ b/crates/dcc-mcp-http/src/gateway/aggregator/fingerprint.rs
@@ -62,6 +62,7 @@ pub(crate) async fn compute_tools_fingerprint_with_own(
                         Some(h) => !super::super::is_own_instance(e, h, own_port),
                         None => true,
                     }
+                    && !e.dcc_type.eq_ignore_ascii_case("unknown")
             })
             .collect()
     };

--- a/crates/dcc-mcp-http/src/gateway/aggregator/list.rs
+++ b/crates/dcc-mcp-http/src/gateway/aggregator/list.rs
@@ -21,7 +21,17 @@ pub async fn aggregate_tools_list(gs: &GatewayState, cursor: Option<&str>) -> Va
     tools.extend(skill_management_tool_defs());
 
     // Tier 3: fan out to every live backend.
-    let instances = live_backends(gs).await;
+    // Issue #556: skip Unreachable instances so stale tools are not exposed.
+    let instances: Vec<_> = live_backends(gs)
+        .await
+        .into_iter()
+        .filter(|e| {
+            !matches!(
+                e.status,
+                dcc_mcp_transport::discovery::types::ServiceStatus::Unreachable
+            )
+        })
+        .collect();
     let client = &gs.http_client;
     let backend_timeout = gs.backend_timeout;
     let futs = instances.iter().map(|entry| async move {

--- a/crates/dcc-mcp-http/src/gateway/config.rs
+++ b/crates/dcc-mcp-http/src/gateway/config.rs
@@ -41,6 +41,13 @@ pub struct GatewayConfig {
     /// Per-session ceiling on concurrent live routes (issue #322). `0`
     /// disables the cap. Default: `1_000`.
     pub max_routes_per_session: u64,
+    /// Allow instances with `dcc_type == "unknown"` to expose their tools
+    /// via the gateway's `tools/list` and be reachable through `connect_to_dcc`.
+    ///
+    /// Default: `false`. Standalone `dcc-mcp-server` binaries that register
+    /// with `dcc_type: "unknown"` should not leak tools into the gateway
+    /// façade unless this is explicitly enabled for development (issue #555).
+    pub allow_unknown_tools: bool,
 }
 
 impl Default for GatewayConfig {
@@ -59,6 +66,7 @@ impl Default for GatewayConfig {
             wait_terminal_timeout_ms: 600_000,
             route_ttl_secs: 60 * 60 * 24,
             max_routes_per_session: 1_000,
+            allow_unknown_tools: false,
         }
     }
 }

--- a/crates/dcc-mcp-http/src/gateway/runner.rs
+++ b/crates/dcc-mcp-http/src/gateway/runner.rs
@@ -1,5 +1,18 @@
 use super::*;
 
+use futures::FutureExt;
+
+/// Extract a human-readable message from a panic payload.
+fn panic_message(info: &dyn std::any::Any) -> String {
+    if let Some(s) = info.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = info.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "unknown panic".to_string()
+    }
+}
+
 /// Orchestrates FileRegistry registration, heartbeat, stale cleanup, and the
 /// optional gateway HTTP server.
 pub struct GatewayRunner {
@@ -72,39 +85,65 @@ impl GatewayRunner {
         // when a metadata_provider is present.  This keeps the `scene` field
         // in FileRegistry current so that list_dcc_instances always reflects
         // the currently open DCC scene without requiring a server restart.
+        //
+        // The task is wrapped in a restart loop so that a panic does not silently
+        // abort heartbeats (issue #554).
         let heartbeat_abort = if self.config.heartbeat_secs > 0 {
             let reg = self.registry.clone();
             let key = service_key.clone();
             let secs = self.config.heartbeat_secs;
             let provider = metadata_provider;
             let h = tokio::spawn(async move {
-                let mut tick = tokio::time::interval(Duration::from_secs(secs));
                 loop {
-                    tick.tick().await;
-                    let r = reg.read().await;
-                    if let Some(ref prov) = provider {
-                        let snap = prov();
-                        if !snap.documents.is_empty() {
-                            // Multi-document DCC (Photoshop, After Effects…):
-                            // update active document + full open-document list + label.
-                            let _ = r.update_documents(
-                                &key,
-                                snap.scene.as_deref(),
-                                &snap.documents,
-                                snap.display_name.as_deref(),
-                            );
-                        } else {
-                            // Single-document DCC (Maya, Blender, Houdini…):
-                            // update scene path and version only.
-                            let _ = r.update_metadata(
-                                &key,
-                                snap.scene.as_deref(),
-                                snap.version.as_deref(),
-                            );
+                    let reg = reg.clone();
+                    let key_inner = key.clone();
+                    let provider = provider.clone();
+                    let result = std::panic::AssertUnwindSafe(async move {
+                        let mut tick = tokio::time::interval(Duration::from_secs(secs));
+                        loop {
+                            tick.tick().await;
+                            let r = reg.read().await;
+                            if let Some(ref prov) = provider {
+                                let snap = prov();
+                                if !snap.documents.is_empty() {
+                                    // Multi-document DCC (Photoshop, After Effects…):
+                                    // update active document + full open-document list + label.
+                                    let _ = r.update_documents(
+                                        &key_inner,
+                                        snap.scene.as_deref(),
+                                        &snap.documents,
+                                        snap.display_name.as_deref(),
+                                    );
+                                } else {
+                                    // Single-document DCC (Maya, Blender, Houdini…):
+                                    // update scene path and version only.
+                                    let _ = r.update_metadata(
+                                        &key_inner,
+                                        snap.scene.as_deref(),
+                                        snap.version.as_deref(),
+                                    );
+                                }
+                            } else {
+                                let _ = r.heartbeat(&key_inner);
+                            }
                         }
-                    } else {
-                        let _ = r.heartbeat(&key);
-                    }
+                    })
+                    .catch_unwind()
+                    .await;
+
+                    let msg = match result {
+                        Err(panic_info) => panic_message(&*panic_info),
+                        Ok(()) => {
+                            // Normal loop exit (should not happen)
+                            break;
+                        }
+                    };
+                    tracing::error!(
+                        instance = %key.instance_id,
+                        panic = %msg,
+                        "Heartbeat task panicked — restarting in 5s"
+                    );
+                    tokio::time::sleep(Duration::from_secs(5)).await;
                 }
             });
             Some(h.abort_handle())
@@ -183,6 +222,7 @@ impl GatewayRunner {
                     sentinel_key,
                     self.config.host.clone(),
                     self.config.gateway_port,
+                    self.config.allow_unknown_tools,
                 )
                 .await
                 {
@@ -283,6 +323,7 @@ impl GatewayRunner {
         let max_routes_per_session = self.config.max_routes_per_session as usize;
         let server_name = self.config.server_name.clone();
         let timeout_secs = self.config.challenger_timeout_secs;
+        let allow_unknown_tools = self.config.allow_unknown_tools;
 
         let handle = tokio::spawn(async move {
             // ── Cooperative yield request ─────────────────────────────────
@@ -347,6 +388,7 @@ impl GatewayRunner {
                         sentinel_key,
                         host.clone(),
                         port,
+                        allow_unknown_tools,
                     )
                     .await
                     {

--- a/crates/dcc-mcp-http/src/gateway/state.rs
+++ b/crates/dcc-mcp-http/src/gateway/state.rs
@@ -88,6 +88,11 @@ pub struct GatewayState {
     /// `$/dcc.workflowUpdated` are routed to the originating client
     /// session via `progressToken` and `job_id` correlation.
     pub subscriber: super::sse_subscriber::SubscriberManager,
+    /// Allow instances with `dcc_type == "unknown"` to expose their tools
+    /// and be selectable via `connect_to_dcc` (issue #555).
+    ///
+    /// When `false` (default), `live_instances` filters them out.
+    pub allow_unknown_tools: bool,
 }
 
 impl GatewayState {
@@ -115,6 +120,7 @@ impl GatewayState {
                         ServiceStatus::ShuttingDown | ServiceStatus::Unreachable
                     )
                     && !super::is_own_instance(e, &self.own_host, self.own_port)
+                    && (self.allow_unknown_tools || !e.dcc_type.eq_ignore_ascii_case("unknown"))
             })
             .collect()
     }
@@ -166,6 +172,15 @@ mod tests {
         own_host: &str,
         own_port: u16,
     ) -> GatewayState {
+        test_gateway_state_with_own_and_unknown(reg, own_host, own_port, false)
+    }
+
+    fn test_gateway_state_with_own_and_unknown(
+        reg: Arc<RwLock<FileRegistry>>,
+        own_host: &str,
+        own_port: u16,
+        allow_unknown_tools: bool,
+    ) -> GatewayState {
         let (yield_tx, _) = watch::channel(false);
         let (events_tx, _) = broadcast::channel::<String>(8);
         GatewayState {
@@ -185,6 +200,7 @@ mod tests {
             resource_subscriptions: Arc::new(RwLock::new(HashMap::new())),
             pending_calls: Arc::new(RwLock::new(HashMap::new())),
             subscriber: crate::gateway::sse_subscriber::SubscriberManager::default(),
+            allow_unknown_tools,
         }
     }
 
@@ -275,6 +291,61 @@ mod tests {
         assert!(
             live.is_empty(),
             "self row with localhost alias must be filtered; got {live:#?}"
+        );
+    }
+
+    /// Issue #555: instances with `dcc_type == "unknown"` must be hidden from
+    /// `live_instances` when `allow_unknown_tools` is `false` (the default).
+    #[tokio::test]
+    async fn test_live_instances_hides_unknown_by_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
+
+        {
+            let r = registry.read().await;
+            let unknown = ServiceEntry::new("unknown", "127.0.0.1", 18812);
+            r.register(unknown).unwrap();
+
+            let maya = ServiceEntry::new("maya", "127.0.0.1", 18813);
+            r.register(maya).unwrap();
+        }
+
+        let gs =
+            test_gateway_state_with_own_and_unknown(registry.clone(), "127.0.0.1", 9765, false);
+        let live = gs.live_instances(&*registry.read().await);
+        assert_eq!(live.len(), 1, "only the maya row should be returned");
+        assert_eq!(live[0].dcc_type, "maya");
+        assert!(
+            !live
+                .iter()
+                .any(|e| e.dcc_type.eq_ignore_ascii_case("unknown")),
+            "unknown dcc_type must be filtered when allow_unknown_tools is false"
+        );
+    }
+
+    /// Issue #555: when `allow_unknown_tools` is `true`, unknown instances
+    /// survive the filter.
+    #[tokio::test]
+    async fn test_live_instances_shows_unknown_when_allowed() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
+
+        {
+            let r = registry.read().await;
+            let unknown = ServiceEntry::new("unknown", "127.0.0.1", 18812);
+            r.register(unknown).unwrap();
+
+            let maya = ServiceEntry::new("maya", "127.0.0.1", 18813);
+            r.register(maya).unwrap();
+        }
+
+        let gs = test_gateway_state_with_own_and_unknown(registry.clone(), "127.0.0.1", 9765, true);
+        let live = gs.live_instances(&*registry.read().await);
+        assert_eq!(live.len(), 2, "both rows should be returned when allowed");
+        assert!(
+            live.iter()
+                .any(|e| e.dcc_type.eq_ignore_ascii_case("unknown")),
+            "unknown dcc_type must be present when allow_unknown_tools is true"
         );
     }
 }

--- a/crates/dcc-mcp-http/src/gateway/tasks.rs
+++ b/crates/dcc-mcp-http/src/gateway/tasks.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use dcc_mcp_transport::error::TransportResult;
+
 /// Outcome of [`start_gateway_tasks`] for the ambient (shared-runtime) path.
 pub(crate) struct GatewayTasks {
     /// AbortHandle for the combined supervisor task (cleanup + watcher +
@@ -37,6 +39,7 @@ pub(crate) async fn start_gateway_tasks(
     sentinel_key: ServiceKey,
     own_host: String,
     own_port: u16,
+    allow_unknown_tools: bool,
 ) -> Result<GatewayTasks, Box<dyn std::error::Error + Send + Sync>> {
     // ── Yield channel ─────────────────────────────────────────────────────
     let (yield_tx, mut yield_rx) = watch::channel(false);
@@ -237,7 +240,7 @@ pub(crate) async fn start_gateway_tasks(
     // their TTL. Terminal jobs are auto-evicted in `deliver`.
     let route_gc_handle = subscriber.spawn_route_gc();
 
-    // ── Pre-subscribe registry hygiene (issue #419) ───────────────────────
+    // ── Pre-subscribe registry hygiene (issue #419 + #556) ────────────────
     //
     // Before the backend subscriber loop starts fanning SSE connections at
     // everything in the registry, do a one-shot synchronous cleanup so we
@@ -246,6 +249,9 @@ pub(crate) async fn start_gateway_tasks(
     // cadence; without this synchronous pass, the subscriber would see
     // stale / dead-PID entries during the first ~15 s and pay the full
     // exponential-backoff retry cost trying to reach them.
+    //
+    // Issue #556: also probe every registered port and immediately deregister
+    // instances whose TCP port is closed, even if the PID still appears alive.
     {
         let r = registry.read().await;
         match r.prune_dead_pids() {
@@ -266,6 +272,17 @@ pub(crate) async fn start_gateway_tasks(
                 );
             }
             Err(e) => tracing::warn!("Gateway: pre-subscribe stale sweep error: {e}"),
+            _ => {}
+        }
+        // Startup port probe: evict any instance whose port is unreachable.
+        match probe_and_evict_dead_instances(&r, stale_timeout, &own_host, own_port).await {
+            Ok(n) if n > 0 => {
+                tracing::info!(
+                    evicted = n,
+                    "Gateway: startup port probe evicted unreachable instance(s)"
+                );
+            }
+            Err(e) => tracing::warn!("Gateway: startup port probe error: {e}"),
             _ => {}
         }
     }
@@ -308,14 +325,14 @@ pub(crate) async fn start_gateway_tasks(
 
     // ── Gateway HTTP server ────────────────────────────────────────────────
     let gw_state = GatewayState {
-        registry,
+        registry: registry.clone(),
         stale_timeout,
         backend_timeout,
         async_dispatch_timeout,
         wait_terminal_timeout,
         server_name,
         server_version,
-        own_host,
+        own_host: own_host.clone(),
         own_port,
         http_client,
         yield_tx: yield_tx.clone(),
@@ -324,8 +341,10 @@ pub(crate) async fn start_gateway_tasks(
         resource_subscriptions: Arc::new(RwLock::new(HashMap::new())),
         pending_calls: Arc::new(RwLock::new(HashMap::new())),
         subscriber,
+        allow_unknown_tools,
     };
     let gw_router = build_gateway_router(gw_state);
+
     let actual = listener.local_addr()?;
     tracing::info!(
         "Gateway listening on http://{}  (GET /mcp = SSE stream, POST /mcp = MCP endpoint)",
@@ -349,6 +368,92 @@ pub(crate) async fn start_gateway_tasks(
             .ok();
     });
 
+    // ── Periodic health-check task (issue #556) ───────────────────────────
+    // Every 30 s, attempt a lightweight TCP connect to every registered
+    // instance. After 2 consecutive failures mark it Unreachable; after 3
+    // stale rounds auto-deregister it.
+    let reg_health = registry.clone();
+    let health_own_host = own_host.clone();
+    let health_own_port = own_port;
+    let health_check_handle = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(30));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // failure_count keyed by "dcc_type:instance_id"
+        let mut failure_counts: std::collections::HashMap<String, u32> =
+            std::collections::HashMap::new();
+        loop {
+            interval.tick().await;
+            let entries = {
+                let r = reg_health.read().await;
+                r.list_all()
+                    .into_iter()
+                    .filter(|e| {
+                        e.dcc_type != GATEWAY_SENTINEL_DCC_TYPE
+                            && !is_own_instance(e, &health_own_host, health_own_port)
+                    })
+                    .collect::<Vec<_>>()
+            };
+
+            for entry in entries {
+                let addr = format!("{}:{}", entry.host, entry.port);
+                let reachable = tokio::time::timeout(
+                    Duration::from_secs(5),
+                    tokio::net::TcpStream::connect(&addr),
+                )
+                .await
+                .is_ok_and(|r| r.is_ok());
+
+                let key = format!("{}:{}", entry.dcc_type, entry.instance_id);
+                if reachable {
+                    if failure_counts.remove(&key).is_some() {
+                        // Instance recovered — mark Available again.
+                        let r = reg_health.read().await;
+                        let _ = r.update_status(
+                            &entry.key(),
+                            dcc_mcp_transport::discovery::types::ServiceStatus::Available,
+                        );
+                        tracing::info!(
+                            dcc_type = %entry.dcc_type,
+                            instance_id = %entry.instance_id,
+                            "Health check recovered — marking Available"
+                        );
+                    }
+                    continue;
+                }
+
+                let count = failure_counts.entry(key.clone()).or_insert(0);
+                *count += 1;
+                tracing::warn!(
+                    dcc_type = %entry.dcc_type,
+                    instance_id = %entry.instance_id,
+                    consecutive_failures = *count,
+                    "Health check failed"
+                );
+
+                if *count >= 2 {
+                    // Mark Unreachable so live_instances filters it out.
+                    let r = reg_health.read().await;
+                    let _ = r.update_status(
+                        &entry.key(),
+                        dcc_mcp_transport::discovery::types::ServiceStatus::Unreachable,
+                    );
+                }
+
+                if *count >= 3 {
+                    // Auto-deregister after persistent unreachability.
+                    let r = reg_health.read().await;
+                    let _ = r.deregister(&entry.key());
+                    failure_counts.remove(&key);
+                    tracing::info!(
+                        dcc_type = %entry.dcc_type,
+                        instance_id = %entry.instance_id,
+                        "Auto-deregistered after 3 consecutive health-check failures"
+                    );
+                }
+            }
+        }
+    });
+
     // Combine all tasks under one abort handle.
     let combined = tokio::spawn(async move {
         let _ = tokio::join!(
@@ -357,6 +462,7 @@ pub(crate) async fn start_gateway_tasks(
             tools_watcher_handle,
             backend_sub_handle,
             route_gc_handle,
+            health_check_handle,
             gw_handle
         );
     });
@@ -402,6 +508,50 @@ pub(crate) async fn start_gateway_tasks(
 /// runtime a chance to schedule the `axum::serve` task — necessary under
 /// PyO3-embedded hosts where workers are slow to pick up newly spawned tasks
 /// (issue #303).
+/// On gateway startup, probe every registered instance's TCP port and
+/// deregister any that are unreachable. Complements `prune_dead_pids`
+/// which only checks PID liveness — a process may be alive but its MCP
+/// listener already shut down (issue #556).
+pub(crate) async fn probe_and_evict_dead_instances(
+    registry: &FileRegistry,
+    stale_timeout: Duration,
+    own_host: &str,
+    own_port: u16,
+) -> TransportResult<usize> {
+    let entries: Vec<_> = registry
+        .list_all()
+        .into_iter()
+        .filter(|e| {
+            e.dcc_type != GATEWAY_SENTINEL_DCC_TYPE
+                && !e.is_stale(stale_timeout)
+                && !is_own_instance(e, own_host, own_port)
+        })
+        .collect();
+
+    let mut evicted = 0usize;
+    for entry in entries {
+        let addr = format!("{}:{}", entry.host, entry.port);
+        let reachable = tokio::time::timeout(
+            Duration::from_secs(3),
+            tokio::net::TcpStream::connect(&addr),
+        )
+        .await
+        .is_ok_and(|r| r.is_ok());
+
+        if !reachable {
+            registry.deregister(&entry.key())?;
+            evicted += 1;
+            tracing::info!(
+                dcc_type = %entry.dcc_type,
+                instance_id = %entry.instance_id,
+                addr = %addr,
+                "Startup probe: instance unreachable — deregistered"
+            );
+        }
+    }
+    Ok(evicted)
+}
+
 pub(crate) async fn self_probe_listener(addr: std::net::SocketAddr) -> Result<(), std::io::Error> {
     const MAX_ATTEMPTS: u32 = 10;
     const ATTEMPT_TIMEOUT: Duration = Duration::from_millis(200);

--- a/crates/dcc-mcp-http/src/server/gateway_impl.rs
+++ b/crates/dcc-mcp-http/src/server/gateway_impl.rs
@@ -28,6 +28,7 @@ pub(crate) async fn start_gateway_runner(
         wait_terminal_timeout_ms: config.gateway_wait_terminal_timeout_ms,
         route_ttl_secs: config.gateway_route_ttl_secs,
         max_routes_per_session: config.gateway_max_routes_per_session,
+        allow_unknown_tools: config.allow_unknown_tools,
     };
 
     let runner = match GatewayRunner::new(gateway_config) {

--- a/crates/dcc-mcp-http/src/tests/gateway.rs
+++ b/crates/dcc-mcp-http/src/tests/gateway.rs
@@ -33,6 +33,7 @@ fn make_gateway_state() -> GatewayState {
         resource_subscriptions: Arc::new(RwLock::new(std::collections::HashMap::new())),
         pending_calls: Arc::new(RwLock::new(std::collections::HashMap::new())),
         subscriber: crate::gateway::sse_subscriber::SubscriberManager::default(),
+        allow_unknown_tools: false,
     }
 }
 

--- a/crates/dcc-mcp-http/tests/http/backend_timeout.rs
+++ b/crates/dcc-mcp-http/tests/http/backend_timeout.rs
@@ -63,6 +63,7 @@ async fn make_state(
         resource_subscriptions: Arc::new(RwLock::new(std::collections::HashMap::new())),
         pending_calls: Arc::new(RwLock::new(std::collections::HashMap::new())),
         subscriber: dcc_mcp_http::gateway::sse_subscriber::SubscriberManager::default(),
+        allow_unknown_tools: false,
     };
     (state, registry, dir)
 }

--- a/crates/dcc-mcp-http/tests/http/gateway_passthrough.rs
+++ b/crates/dcc-mcp-http/tests/http/gateway_passthrough.rs
@@ -61,6 +61,7 @@ async fn make_state(
         resource_subscriptions: Arc::new(RwLock::new(std::collections::HashMap::new())),
         pending_calls: Arc::new(RwLock::new(std::collections::HashMap::new())),
         subscriber: SubscriberManager::default(),
+        allow_unknown_tools: false,
     };
     (state, registry, dir)
 }

--- a/crates/dcc-mcp-logging/src/constants.rs
+++ b/crates/dcc-mcp-logging/src/constants.rs
@@ -21,6 +21,8 @@ pub const ENV_LOG_MAX_FILES: &str = "DCC_MCP_LOG_MAX_FILES";
 pub const ENV_LOG_ROTATION: &str = "DCC_MCP_LOG_ROTATION";
 /// Environment variable overriding the log file-name prefix.
 pub const ENV_LOG_FILE_PREFIX: &str = "DCC_MCP_LOG_FILE_PREFIX";
+/// Environment variable overriding log retention in days (0 = disable age pruning).
+pub const ENV_LOG_RETENTION_DAYS: &str = "DCC_MCP_LOG_RETENTION_DAYS";
 
 /// Default maximum log file size in bytes before rotation (10 MiB).
 pub const DEFAULT_LOG_MAX_SIZE: u64 = 10 * 1024 * 1024;
@@ -30,6 +32,10 @@ pub const DEFAULT_LOG_MAX_FILES: usize = 7;
 pub const DEFAULT_LOG_FILE_PREFIX: &str = "dcc-mcp";
 /// Default rotation policy — `"both"` means rotate on size OR calendar-date change.
 pub const DEFAULT_LOG_ROTATION: &str = "both";
+/// Default retention period in days for old log files (7 days).
+pub const DEFAULT_LOG_RETENTION_DAYS: u32 = 7;
+/// Default maximum total log directory size in MiB (100 MiB).
+pub const DEFAULT_LOG_MAX_TOTAL_SIZE_MB: u32 = 100;
 
 #[cfg(test)]
 mod tests {

--- a/crates/dcc-mcp-logging/src/file_logging/config.rs
+++ b/crates/dcc-mcp-logging/src/file_logging/config.rs
@@ -2,8 +2,9 @@
 
 use crate::config::FileLayerInstallError;
 use crate::constants::{
-    DEFAULT_LOG_FILE_PREFIX, DEFAULT_LOG_MAX_FILES, DEFAULT_LOG_MAX_SIZE, DEFAULT_LOG_ROTATION,
-    ENV_LOG_DIR, ENV_LOG_FILE, ENV_LOG_FILE_PREFIX, ENV_LOG_MAX_FILES, ENV_LOG_MAX_SIZE,
+    DEFAULT_LOG_FILE_PREFIX, DEFAULT_LOG_MAX_FILES, DEFAULT_LOG_MAX_SIZE,
+    DEFAULT_LOG_MAX_TOTAL_SIZE_MB, DEFAULT_LOG_RETENTION_DAYS, DEFAULT_LOG_ROTATION, ENV_LOG_DIR,
+    ENV_LOG_FILE, ENV_LOG_FILE_PREFIX, ENV_LOG_MAX_FILES, ENV_LOG_MAX_SIZE, ENV_LOG_RETENTION_DAYS,
     ENV_LOG_ROTATION,
 };
 use dcc_mcp_paths::get_log_dir;
@@ -85,6 +86,10 @@ pub struct FileLoggingConfig {
     /// flag is surfaced for future parity with Python where a user may
     /// wish to silence stderr when redirecting to a file.
     pub include_console: bool,
+    /// Delete log files older than this many days. `0` disables age-based pruning.
+    pub retention_days: u32,
+    /// Maximum total size of the log directory in MiB. `0` disables size-based pruning.
+    pub max_total_size_mb: u32,
 }
 
 impl Default for FileLoggingConfig {
@@ -96,6 +101,8 @@ impl Default for FileLoggingConfig {
             max_files: DEFAULT_LOG_MAX_FILES,
             rotation: RotationPolicy::parse(DEFAULT_LOG_ROTATION).unwrap_or(RotationPolicy::Both),
             include_console: true,
+            retention_days: DEFAULT_LOG_RETENTION_DAYS,
+            max_total_size_mb: DEFAULT_LOG_MAX_TOTAL_SIZE_MB,
         }
     }
 }
@@ -109,6 +116,7 @@ impl FileLoggingConfig {
     /// - [`ENV_LOG_MAX_SIZE`] — bytes (integer).
     /// - [`ENV_LOG_MAX_FILES`] — retention count (integer).
     /// - [`ENV_LOG_ROTATION`] — `size`/`daily`/`both`.
+    /// - [`ENV_LOG_RETENTION_DAYS`] — days (integer, 0 = disable).
     ///
     /// # Errors
     /// Returns an error if any env var is set to an invalid value.
@@ -139,6 +147,13 @@ impl FileLoggingConfig {
         }
         if let Ok(raw) = std::env::var(ENV_LOG_ROTATION) {
             cfg.rotation = RotationPolicy::parse(&raw).map_err(FileLoggingError::Config)?;
+        }
+        if let Ok(raw) = std::env::var(ENV_LOG_RETENTION_DAYS) {
+            cfg.retention_days = raw.parse().map_err(|_| {
+                FileLoggingError::Config(format!(
+                    "{ENV_LOG_RETENTION_DAYS}='{raw}' is not a valid u32"
+                ))
+            })?;
         }
 
         Ok(cfg)

--- a/crates/dcc-mcp-logging/src/file_logging/mod.rs
+++ b/crates/dcc-mcp-logging/src/file_logging/mod.rs
@@ -51,7 +51,7 @@ pub mod python;
 mod tests;
 
 pub use config::{FileLoggingConfig, FileLoggingError, RotationPolicy};
-pub use writer::RollingFileWriter;
+pub use writer::{RollingFileWriter, prune_old_logs};
 
 use crate::config::{BoxedLayer, install_file_layer_boxed};
 
@@ -101,6 +101,14 @@ pub fn init_file_logging(config: FileLoggingConfig) -> Result<PathBuf, FileLoggi
     let writer = RollingFileWriter::new(&config)?;
     let writer_inner = writer.inner.clone();
     let directory = writer_inner.lock().directory.clone();
+
+    // Prune old logs by age and total size before starting new writer.
+    prune_old_logs(
+        &directory,
+        &config.file_name_prefix,
+        config.retention_days,
+        config.max_total_size_mb,
+    );
 
     let (non_blocking, guard): (NonBlocking, WorkerGuard) = tracing_appender::non_blocking(writer);
 

--- a/crates/dcc-mcp-logging/src/file_logging/tests.rs
+++ b/crates/dcc-mcp-logging/src/file_logging/tests.rs
@@ -39,6 +39,8 @@ fn size_rotation_creates_rolled_file() {
         max_files: 3,
         rotation: RotationPolicy::Size,
         include_console: true,
+        retention_days: 0,
+        max_total_size_mb: 0,
     };
     let mut writer = RollingFileWriter::new(&cfg).unwrap();
 
@@ -114,6 +116,8 @@ fn init_and_shutdown_are_idempotent() {
         max_files: 2,
         rotation: RotationPolicy::Both,
         include_console: true,
+        retention_days: 0,
+        max_total_size_mb: 0,
     };
 
     let resolved = init_file_logging(cfg.clone()).unwrap();

--- a/crates/dcc-mcp-logging/src/file_logging/writer.rs
+++ b/crates/dcc-mcp-logging/src/file_logging/writer.rs
@@ -247,3 +247,75 @@ pub(crate) fn prune_old(directory: &Path, prefix: &str, max_files: usize) {
         let _ = std::fs::remove_file(path);
     }
 }
+
+/// Prune log files by age and total directory size.
+///
+/// * `retention_days` — files whose modification time is older than this many
+///   days are deleted. `0` disables age-based pruning.
+/// * `max_total_size_mb` — when the total size of **all** `.log` files matching
+///   the prefix exceeds this many MiB, oldest files are deleted until the total
+///   is under the limit. `0` disables size-based pruning.
+///
+/// The current day's file (`<prefix>.<YYYYMMDD>.log`) is never deleted.
+pub fn prune_old_logs(directory: &Path, prefix: &str, retention_days: u32, max_total_size_mb: u32) {
+    let Ok(read_dir) = std::fs::read_dir(directory) else {
+        return;
+    };
+
+    let today_stem = format!("{prefix}.{}", CalendarDate::today_local().as_basename());
+    let cutoff = if retention_days > 0 {
+        let now = std::time::SystemTime::now();
+        let duration = std::time::Duration::from_secs(u64::from(retention_days) * 24 * 60 * 60);
+        Some(now - duration)
+    } else {
+        None
+    };
+
+    let mut files: Vec<(std::time::SystemTime, u64, PathBuf)> = Vec::new();
+    let mut total_size: u64 = 0;
+
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        if !name.starts_with(&format!("{prefix}.")) || !name.ends_with(".log") {
+            continue;
+        }
+        let stem = name.trim_end_matches(".log");
+        if stem == today_stem {
+            continue;
+        }
+        let modified = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .unwrap_or(std::time::UNIX_EPOCH);
+        let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
+
+        // Age pruning — unconditional.
+        if let Some(cutoff) = cutoff {
+            if modified < cutoff {
+                let _ = std::fs::remove_file(&path);
+                continue;
+            }
+        }
+
+        total_size += size;
+        files.push((modified, size, path));
+    }
+
+    // Size pruning — sort oldest first, delete until under limit.
+    if max_total_size_mb > 0 {
+        let limit_bytes = u64::from(max_total_size_mb) * 1024 * 1024;
+        if total_size > limit_bytes {
+            files.sort_by_key(|entry| entry.0);
+            for (_, size, path) in files {
+                if total_size <= limit_bytes {
+                    break;
+                }
+                let _ = std::fs::remove_file(&path);
+                total_size = total_size.saturating_sub(size);
+            }
+        }
+    }
+}

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -166,10 +166,10 @@ struct Args {
     watch_pid: Option<u32>,
 
     // ── File logging ──
-    /// Enable logging to rotating files. Defaults to disabled; when `true`
-    /// the server also keeps emitting to stderr.
-    #[arg(long, env = "DCC_MCP_LOG_FILE", default_value = "false")]
-    log_file: bool,
+    /// Disable logging to rotating files. By default file logging is enabled
+    /// unless this flag is passed.
+    #[arg(long, env = "DCC_MCP_NO_LOG_FILE", default_value = "false")]
+    no_log_file: bool,
 
     /// Directory for rotated log files. Defaults to the platform log dir
     /// (`dcc_mcp_paths::get_log_dir()`).
@@ -188,9 +188,17 @@ struct Args {
     #[arg(long, env = "DCC_MCP_LOG_ROTATION", value_name = "POLICY")]
     log_rotation: Option<String>,
 
-    /// File-name prefix (full file is `<prefix>.<YYYYMMDD>.log`).
+    /// File-name prefix (full file is `<prefix>.<pid>.<YYYYMMDD>.log`).
     #[arg(long, env = "DCC_MCP_LOG_FILE_PREFIX", value_name = "PREFIX")]
     log_file_prefix: Option<String>,
+
+    /// Log retention in days (0 = disable age pruning). Default: 7.
+    #[arg(long, env = "DCC_MCP_LOG_RETENTION_DAYS", value_name = "DAYS")]
+    log_retention_days: Option<u32>,
+
+    /// Maximum total log directory size in MiB (0 = disable size pruning). Default: 100.
+    #[arg(long, env = "DCC_MCP_LOG_MAX_TOTAL_SIZE_MB", value_name = "MB")]
+    log_max_total_size_mb: Option<u32>,
 }
 
 struct PidFileGuard {
@@ -394,14 +402,16 @@ async fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    // Wire up rolling-file logging if the operator asked for it via CLI
-    // or any of the `DCC_MCP_LOG_*` env vars. CLI flags win over env.
-    if args.log_file
+    // Wire up rolling-file logging by default unless --no-log-file is passed.
+    // Any explicit DCC_MCP_LOG_* env var or CLI flag also enables it.
+    if !args.no_log_file
         || args.log_dir.is_some()
         || args.log_max_size.is_some()
         || args.log_max_files.is_some()
         || args.log_rotation.is_some()
         || args.log_file_prefix.is_some()
+        || args.log_retention_days.is_some()
+        || args.log_max_total_size_mb.is_some()
         || dcc_mcp_logging::FileLoggingConfig::enabled_by_env()
     {
         let mut cfg = dcc_mcp_logging::FileLoggingConfig::from_env_with_defaults()
@@ -423,6 +433,15 @@ async fn main() -> anyhow::Result<()> {
             if !prefix.trim().is_empty() {
                 cfg.file_name_prefix = prefix.clone();
             }
+        } else {
+            // PID-based naming for multi-instance debugging.
+            cfg.file_name_prefix = format!("dcc-mcp-server.{}", std::process::id());
+        }
+        if let Some(days) = args.log_retention_days {
+            cfg.retention_days = days;
+        }
+        if let Some(mb) = args.log_max_total_size_mb {
+            cfg.max_total_size_mb = mb;
         }
         match dcc_mcp_logging::init_file_logging(cfg) {
             Ok(dir) => tracing::info!(
@@ -532,6 +551,7 @@ async fn main() -> anyhow::Result<()> {
         server_name: args.server_name.clone(),
         server_version: env!("CARGO_PKG_VERSION").to_string(),
         registry_dir: registry_dir_path,
+        allow_unknown_tools: false,
         challenger_timeout_secs: 120,
         backend_timeout_ms: 10_000,
         async_dispatch_timeout_ms: 60_000,

--- a/crates/dcc-mcp-transport/src/discovery/file_registry.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry.rs
@@ -4,6 +4,8 @@
 //! Uses `(dcc_type, instance_id)` as key to support multiple instances per DCC type.
 
 use std::fs;
+#[cfg(windows)]
+use std::io::Write;
 use std::path::PathBuf;
 use std::sync::Mutex;
 use std::time::{Duration, SystemTime};
@@ -459,16 +461,101 @@ impl FileRegistry {
         self.registry_dir.join(REGISTRY_FILE)
     }
 
-    /// Load services from the JSON file into memory.
+    /// Flush the in-memory services to the JSON file atomically.
+    ///
+    /// Uses a temp-file + rename pattern so readers never see a partially-
+    /// written file. On Windows an OS-level advisory lock is taken for the
+    /// duration of the write to prevent competing processes from clobbering
+    /// each other (issue #554).
+    fn flush_to_file(&self) -> TransportResult<()> {
+        let entries: Vec<ServiceEntry> = self.list_all();
+        let content = serde_json::to_string_pretty(&entries).map_err(|e| {
+            TransportError::Serialization(format!("failed to serialize registry: {}", e))
+        })?;
+
+        let path = self.registry_file_path();
+        Self::write_atomic(&path, content)?;
+
+        // Update cached mtime after write
+        let _ = self.update_mtime();
+
+        Ok(())
+    }
+
+    /// Atomically write `content` to `path` using a temp file + rename.
+    ///
+    /// On Windows this also acquires an OS-level advisory lock on the target
+    /// file so that concurrent `flush_to_file` calls from other processes do
+    /// not interleave (issue #554).
+    fn write_atomic(path: &PathBuf, content: String) -> TransportResult<()> {
+        let dir = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+        let temp_path = dir.join(format!(".tmp.{}.services.json", std::process::id()));
+
+        // Write to temp file first
+        fs::write(&temp_path, content).map_err(|e| {
+            TransportError::RegistryFile(format!(
+                "failed to write temp file {}: {}",
+                temp_path.display(),
+                e
+            ))
+        })?;
+
+        // On Windows, take an advisory lock on the target file while renaming.
+        // This prevents another process from reading a stale snapshot between
+        // our rename and their own concurrent write.
+        #[cfg(windows)]
+        {
+            use std::os::windows::fs::OpenOptionsExt;
+            let lock_path = path.with_extension("lock");
+            let mut lock_file = std::fs::OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .share_mode(0) // exclusive lock
+                .open(&lock_path)
+                .map_err(|e| {
+                    TransportError::RegistryFile(format!(
+                        "failed to acquire registry lock {}: {}",
+                        lock_path.display(),
+                        e
+                    ))
+                })?;
+            let _ = lock_file.write_all(b"lock");
+            let result = fs::rename(&temp_path, path);
+            let _ = std::fs::remove_file(&lock_path);
+            result.map_err(|e| {
+                TransportError::RegistryFile(format!(
+                    "failed to rename {} -> {}: {}",
+                    temp_path.display(),
+                    path.display(),
+                    e
+                ))
+            })?;
+        }
+
+        #[cfg(not(windows))]
+        {
+            fs::rename(&temp_path, path).map_err(|e| {
+                TransportError::RegistryFile(format!(
+                    "failed to rename {} -> {}: {}",
+                    temp_path.display(),
+                    path.display(),
+                    e
+                ))
+            })?;
+        }
+
+        Ok(())
+    }
+
+    /// Load services from the JSON file into memory with advisory locking on Windows.
     fn load_from_file(&self) -> TransportResult<()> {
         let path = self.registry_file_path();
         if !path.exists() {
             return Ok(());
         }
 
-        let content = fs::read_to_string(&path).map_err(|e| {
-            TransportError::RegistryFile(format!("failed to read {}: {}", path.display(), e))
-        })?;
+        let content = Self::read_locked(&path)?;
 
         if content.trim().is_empty() {
             return Ok(());
@@ -487,22 +574,29 @@ impl FileRegistry {
         Ok(())
     }
 
-    /// Flush the in-memory services to the JSON file.
-    fn flush_to_file(&self) -> TransportResult<()> {
-        let entries: Vec<ServiceEntry> = self.list_all();
-        let content = serde_json::to_string_pretty(&entries).map_err(|e| {
-            TransportError::Serialization(format!("failed to serialize registry: {}", e))
-        })?;
+    /// Read the registry file, waiting briefly for any concurrent Windows lock to clear.
+    #[cfg(windows)]
+    fn read_locked(path: &PathBuf) -> TransportResult<String> {
+        let lock_path = path.with_extension("lock");
+        let max_wait = Duration::from_secs(5);
+        let poll = Duration::from_millis(50);
+        let mut waited = Duration::ZERO;
 
-        let path = self.registry_file_path();
-        fs::write(&path, content).map_err(|e| {
-            TransportError::RegistryFile(format!("failed to write {}: {}", path.display(), e))
-        })?;
+        while lock_path.exists() && waited < max_wait {
+            std::thread::sleep(poll);
+            waited += poll;
+        }
 
-        // Update cached mtime after write
-        let _ = self.update_mtime();
+        fs::read_to_string(path).map_err(|e| {
+            TransportError::RegistryFile(format!("failed to read {}: {}", path.display(), e))
+        })
+    }
 
-        Ok(())
+    #[cfg(not(windows))]
+    fn read_locked(path: &PathBuf) -> TransportResult<String> {
+        fs::read_to_string(path).map_err(|e| {
+            TransportError::RegistryFile(format!("failed to read {}: {}", path.display(), e))
+        })
     }
 }
 


### PR DESCRIPTION
Resolves the gateway-reliability, security, and logging-defaults batch of issues.

## Closes
- Closes #551 — gateway-side stale instances are now actively pruned (TCP probe + auto-deregister)
- Closes #552 — periodic active health-check task with consecutive-failure threshold
- Closes #553 — `allow_unknown_tools` flag (default `false`) hides instances whose `dcc_type` is unknown to the gateway
- Closes #554 — `FileRegistry` heartbeat now uses atomic write + Windows file lock to fix multi-process stomping
- Closes #555 — same `allow_unknown_tools` filter applies to `tools/list` aggregation
- Closes #556 — auto-deregister after 3 consecutive TCP probe failures and on startup probe miss
- Closes #557 — sensible default file-logging configuration (rolling, level, location)
- Closes #558 — log retention via `prune_old_logs(retention_days, max_total_size_mb)`

## Changes
- `crates/dcc-mcp-transport/src/discovery/file_registry.rs` — atomic write + Windows lock; gate `std::io::Write` import behind `#[cfg(windows)]` so non-Windows clippy stays warning-free
- `crates/dcc-mcp-http/src/gateway/aggregator/list.rs` + `state.rs` + `runner.rs` + `tasks.rs` — `allow_unknown_tools`, dead-instance probe, periodic health-check task with auto-deregister
- `crates/dcc-mcp-http/src/config.rs` + `gateway/config.rs` — surface `allow_unknown_tools` flag
- `crates/dcc-mcp-server/src/main.rs` — wire defaults
- `crates/dcc-mcp-logging/src/file_logging/*` — default rolling configuration + `prune_old_logs`

## Notes
- `--features prometheus` integration lives in stacked PR #561 (`feat/observability-metrics`) — this PR is fully self-contained and compiles cleanly under the default feature set
- Local `vx just preflight` (clippy + fmt + workspace tests) is green on Windows; CI will exercise Ubuntu/macOS