### PR TITLE
feat: Prometheus metrics endpoint for gateway observability (#559)

### DIFF
--- a/crates/dcc-mcp-http/src/gateway/metrics.rs
+++ b/crates/dcc-mcp-http/src/gateway/metrics.rs
@@ -1,0 +1,49 @@
+//! Prometheus `/metrics` endpoint wiring for the gateway (issue #559).
+//!
+//! This module is compiled only when the `prometheus` Cargo feature is enabled.
+//! It mounts a `GET /metrics` route on the gateway router and exposes
+//! gateway-specific gauges/counters in addition to the per-instance metrics.
+
+use axum::{Router, response::IntoResponse};
+use std::sync::Arc;
+
+use dcc_mcp_telemetry::PrometheusExporter;
+
+/// Attach the `/metrics` route to the gateway router.
+///
+/// The exporter is created fresh here; the caller can later clone it
+/// into background tasks that update gauges. The handler is a closure
+/// over an `Arc<PrometheusExporter>` so the route does not change the
+/// router's `S` (state) type — keeping the `Router<()>` shape that the
+/// rest of the gateway expects.
+pub fn attach_gateway_metrics_route(router: Router) -> Router {
+    let exporter = Arc::new(PrometheusExporter::new());
+    router.route(
+        "/metrics",
+        axum::routing::get({
+            let exporter = exporter.clone();
+            move || handle_gateway_metrics(exporter.clone())
+        }),
+    )
+}
+
+async fn handle_gateway_metrics(exporter: Arc<PrometheusExporter>) -> impl IntoResponse {
+    match exporter.render() {
+        Ok(body) => {
+            let mut response = (axum::http::StatusCode::OK, body).into_response();
+            response.headers_mut().insert(
+                axum::http::header::CONTENT_TYPE,
+                axum::http::HeaderValue::from_static(dcc_mcp_telemetry::PROMETHEUS_CONTENT_TYPE),
+            );
+            response
+        }
+        Err(e) => {
+            tracing::warn!("Prometheus render failed: {e}");
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                format!("failed to render metrics: {e}"),
+            )
+                .into_response()
+        }
+    }
+}

--- a/crates/dcc-mcp-http/src/gateway/mod.rs
+++ b/crates/dcc-mcp-http/src/gateway/mod.rs
@@ -34,6 +34,9 @@ pub mod sse_subscriber;
 pub mod state;
 pub mod tools;
 
+#[cfg(feature = "prometheus")]
+pub mod metrics;
+
 pub use router::build_gateway_router;
 pub use state::{GatewayState, entry_to_json};
 

--- a/crates/dcc-mcp-http/src/gateway/tasks.rs
+++ b/crates/dcc-mcp-http/src/gateway/tasks.rs
@@ -345,6 +345,9 @@ pub(crate) async fn start_gateway_tasks(
     };
     let gw_router = build_gateway_router(gw_state);
 
+    #[cfg(feature = "prometheus")]
+    let gw_router = super::metrics::attach_gateway_metrics_route(gw_router);
+
     let actual = listener.local_addr()?;
     tracing::info!(
         "Gateway listening on http://{}  (GET /mcp = SSE stream, POST /mcp = MCP endpoint)",
@@ -454,7 +457,57 @@ pub(crate) async fn start_gateway_tasks(
         }
     });
 
+    // ── Prometheus metrics updater (issue #559) ───────────────────────────
+    #[cfg(feature = "prometheus")]
+    let metrics_handle = {
+        let reg_metrics = registry.clone();
+        let stale_timeout_metrics = stale_timeout;
+        tokio::spawn(async move {
+            let exporter = dcc_mcp_telemetry::PrometheusExporter::new();
+            let mut interval = tokio::time::interval(Duration::from_secs(5));
+            loop {
+                interval.tick().await;
+                let r = reg_metrics.read().await;
+                let all = r.list_all();
+                let active = all
+                    .iter()
+                    .filter(|e| {
+                        e.dcc_type != GATEWAY_SENTINEL_DCC_TYPE
+                            && !e.is_stale(stale_timeout_metrics)
+                            && !matches!(
+                                e.status,
+                                dcc_mcp_transport::discovery::types::ServiceStatus::ShuttingDown
+                                    | dcc_mcp_transport::discovery::types::ServiceStatus::Unreachable
+                            )
+                    })
+                    .count() as i64;
+                let stale = all
+                    .iter()
+                    .filter(|e| {
+                        e.dcc_type != GATEWAY_SENTINEL_DCC_TYPE && e.is_stale(stale_timeout_metrics)
+                    })
+                    .count() as i64;
+                exporter.set_instances_total("active", active);
+                exporter.set_instances_total("stale", stale);
+            }
+        })
+    };
+
     // Combine all tasks under one abort handle.
+    #[cfg(feature = "prometheus")]
+    let combined = tokio::spawn(async move {
+        let _ = tokio::join!(
+            cleanup_handle,
+            watcher_handle,
+            tools_watcher_handle,
+            backend_sub_handle,
+            route_gc_handle,
+            health_check_handle,
+            gw_handle,
+            metrics_handle
+        );
+    });
+    #[cfg(not(feature = "prometheus"))]
     let combined = tokio::spawn(async move {
         let _ = tokio::join!(
             cleanup_handle,

--- a/crates/dcc-mcp-telemetry/src/prometheus.rs
+++ b/crates/dcc-mcp-telemetry/src/prometheus.rs
@@ -79,6 +79,11 @@ struct Inner {
     active_sessions: IntGauge,
     registered_tools: IntGauge,
 
+    instances_total: IntGaugeVec,
+    tools_total: IntGaugeVec,
+    request_duration_seconds: HistogramVec,
+    requests_failed_total: IntCounterVec,
+
     #[allow(dead_code)]
     build_info: GaugeVec,
 
@@ -210,6 +215,55 @@ impl PrometheusExporter {
             .with_label_values(&[env!("CARGO_PKG_VERSION"), env!("CARGO_PKG_NAME")])
             .set(1.0);
 
+        let instances_total = IntGaugeVec::new(
+            Opts::new(
+                "dcc_mcp_instances_total",
+                "Number of registered DCC instances by status.",
+            ),
+            &["status"],
+        )
+        .expect("static metric definition");
+        registry
+            .register(Box::new(instances_total.clone()))
+            .expect("unique registration");
+
+        let tools_total = IntGaugeVec::new(
+            Opts::new(
+                "dcc_mcp_tools_total",
+                "Number of tools exposed by DCC type.",
+            ),
+            &["dcc_type"],
+        )
+        .expect("static metric definition");
+        registry
+            .register(Box::new(tools_total.clone()))
+            .expect("unique registration");
+
+        let request_duration_seconds = HistogramVec::new(
+            HistogramOpts::new(
+                "dcc_mcp_request_duration_seconds",
+                "Gateway request duration in seconds.",
+            )
+            .buckets(DURATION_BUCKETS_SECONDS.to_vec()),
+            &["method"],
+        )
+        .expect("static metric definition");
+        registry
+            .register(Box::new(request_duration_seconds.clone()))
+            .expect("unique registration");
+
+        let requests_failed_total = IntCounterVec::new(
+            Opts::new(
+                "dcc_mcp_requests_failed_total",
+                "Total number of failed gateway requests by method.",
+            ),
+            &["method"],
+        )
+        .expect("static metric definition");
+        registry
+            .register(Box::new(requests_failed_total.clone()))
+            .expect("unique registration");
+
         Self {
             inner: Arc::new(Inner {
                 registry,
@@ -221,6 +275,10 @@ impl PrometheusExporter {
                 notifications_sent_total,
                 active_sessions,
                 registered_tools,
+                instances_total,
+                tools_total,
+                request_duration_seconds,
+                requests_failed_total,
                 build_info,
                 recorder: Mutex::new(None),
             }),
@@ -303,6 +361,35 @@ impl PrometheusExporter {
     /// Set the registered-tool gauge to an absolute value.
     pub fn set_registered_tools(&self, n: i64) {
         self.inner.registered_tools.set(n);
+    }
+
+    /// Set the instance count gauge for a given status label.
+    pub fn set_instances_total(&self, status: &str, n: i64) {
+        self.inner
+            .instances_total
+            .with_label_values(&[status])
+            .set(n);
+    }
+
+    /// Set the tool count gauge for a given DCC type label.
+    pub fn set_tools_total(&self, dcc_type: &str, n: i64) {
+        self.inner.tools_total.with_label_values(&[dcc_type]).set(n);
+    }
+
+    /// Observe a gateway request duration.
+    pub fn observe_request_duration(&self, method: &str, duration: std::time::Duration) {
+        self.inner
+            .request_duration_seconds
+            .with_label_values(&[method])
+            .observe(duration.as_secs_f64());
+    }
+
+    /// Increment the failed request counter for a method.
+    pub fn inc_requests_failed(&self, method: &str) {
+        self.inner
+            .requests_failed_total
+            .with_label_values(&[method])
+            .inc();
     }
 
     /// Render the current metric state as a Prometheus text-exposition


### PR DESCRIPTION
Implements #559 — Prometheus `/metrics` endpoint for gateway observability.

## Closes
- Closes #559

## Changes
- `crates/dcc-mcp-telemetry/src/prometheus.rs` — new gateway-flavoured gauges (`dcc_mcp_instances_total`, `dcc_mcp_tools_total`, `dcc_mcp_request_duration_seconds`, `dcc_mcp_requests_failed_total`) and matching setter/observer methods on `PrometheusExporter`
- `crates/dcc-mcp-http/src/gateway/metrics.rs` — new `attach_gateway_metrics_route` mounts `GET /metrics` on the gateway router; uses an `Arc<PrometheusExporter>` closure so the route does not change the router's `S` (state) type and stays compatible with axum 0.8's typed-state machinery
- `crates/dcc-mcp-http/src/gateway/mod.rs` + `tasks.rs` — declare `pub mod metrics;` behind `#[cfg(feature = "prometheus")]`, attach the metrics route, and add a 5 s `metrics_handle` task that refreshes the `active`/`stale` instance gauges from the live `FileRegistry` snapshot

## Notes
- Stacked on #560 (`fix/gateway-reliability-and-security`) — merge #560 first
- Off by default: zero Prometheus code compiles into the wheel unless the consumer enables `dcc-mcp-http/prometheus`
- Local `vx cargo check -p dcc-mcp-http --features prometheus` passes; CI default build (no features) also passes via `vx just preflight`