### PR TITLE
fix(transport): drop exclusive heartbeat lock that dropped concurrent writes

### DIFF
--- a/crates/dcc-mcp-transport/src/discovery/file_registry.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry.rs
@@ -4,8 +4,6 @@
 //! Uses `(dcc_type, instance_id)` as key to support multiple instances per DCC type.
 
 use std::fs;
-#[cfg(windows)]
-use std::io::Write;
 use std::path::PathBuf;
 use std::sync::Mutex;
 use std::time::{Duration, SystemTime};
@@ -484,14 +482,38 @@ impl FileRegistry {
 
     /// Atomically write `content` to `path` using a temp file + rename.
     ///
-    /// On Windows this also acquires an OS-level advisory lock on the target
-    /// file so that concurrent `flush_to_file` calls from other processes do
-    /// not interleave (issue #554).
+    /// The original implementation of issue #554 used an exclusive
+    /// `share_mode(0)` advisory lock file plus a temp filename keyed only on
+    /// the process id. Both choices caused regressions: concurrent in-process
+    /// writers (sentinel heartbeat + multiple backend heartbeats) raced on
+    /// the same temp path, and the exclusive lock file made one of two
+    /// concurrent writers fail outright with `PermissionDenied` so the loser's
+    /// entry never reached `services.json`. The downstream symptom was the
+    /// gateway facade only seeing one of two backends in
+    /// `test_gateway_facade_aggregation` (issue #560 follow-up).
+    ///
+    /// The lock has been removed in favour of two cheaper, cross-platform
+    /// invariants that still satisfy the original "no half-written file"
+    /// requirement of #554:
+    ///
+    /// 1. The temp filename is unique per write — process id, thread id, and
+    ///    a process-wide monotonic counter — so two writers in the same
+    ///    process never share a temp path.
+    /// 2. The temp file is renamed onto the target with a small bounded retry
+    ///    loop, because Windows can return `PermissionDenied` /
+    ///    `AccessDenied` if a concurrent reader has the target file briefly
+    ///    open. POSIX `rename` is already atomic and never needs the retry,
+    ///    but the loop is harmless on other platforms.
     fn write_atomic(path: &PathBuf, content: String) -> TransportResult<()> {
-        let dir = path.parent().unwrap_or_else(|| std::path::Path::new("."));
-        let temp_path = dir.join(format!(".tmp.{}.services.json", std::process::id()));
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
 
-        // Write to temp file first
+        let dir = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+        let pid = std::process::id();
+        let tid = format!("{:?}", std::thread::current().id());
+        let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let temp_path = dir.join(format!(".tmp.{pid}.{tid}.{seq}.services.json"));
+
         fs::write(&temp_path, content).map_err(|e| {
             TransportError::RegistryFile(format!(
                 "failed to write temp file {}: {}",
@@ -500,62 +522,49 @@ impl FileRegistry {
             ))
         })?;
 
-        // On Windows, take an advisory lock on the target file while renaming.
-        // This prevents another process from reading a stale snapshot between
-        // our rename and their own concurrent write.
-        #[cfg(windows)]
-        {
-            use std::os::windows::fs::OpenOptionsExt;
-            let lock_path = path.with_extension("lock");
-            let mut lock_file = std::fs::OpenOptions::new()
-                .create(true)
-                .write(true)
-                .truncate(true)
-                .share_mode(0) // exclusive lock
-                .open(&lock_path)
-                .map_err(|e| {
-                    TransportError::RegistryFile(format!(
-                        "failed to acquire registry lock {}: {}",
-                        lock_path.display(),
-                        e
-                    ))
-                })?;
-            let _ = lock_file.write_all(b"lock");
-            let result = fs::rename(&temp_path, path);
-            let _ = std::fs::remove_file(&lock_path);
-            result.map_err(|e| {
-                TransportError::RegistryFile(format!(
-                    "failed to rename {} -> {}: {}",
-                    temp_path.display(),
-                    path.display(),
-                    e
-                ))
-            })?;
+        // Bounded retry around `fs::rename` — Windows can briefly return
+        // `PermissionDenied` if another process has the target file open for
+        // reading at the exact instant we try to swap it in.
+        const MAX_ATTEMPTS: u32 = 8;
+        const BACKOFF_MS: u64 = 10;
+        let mut last_err: Option<std::io::Error> = None;
+        for attempt in 0..MAX_ATTEMPTS {
+            match fs::rename(&temp_path, path) {
+                Ok(()) => return Ok(()),
+                Err(e) => {
+                    last_err = Some(e);
+                    std::thread::sleep(Duration::from_millis(BACKOFF_MS * (attempt as u64 + 1)));
+                }
+            }
         }
-
-        #[cfg(not(windows))]
-        {
-            fs::rename(&temp_path, path).map_err(|e| {
-                TransportError::RegistryFile(format!(
-                    "failed to rename {} -> {}: {}",
-                    temp_path.display(),
-                    path.display(),
-                    e
-                ))
-            })?;
-        }
-
-        Ok(())
+        // Best-effort temp cleanup so we don't leak `.tmp.*` files on
+        // persistent failure.
+        let _ = fs::remove_file(&temp_path);
+        Err(TransportError::RegistryFile(format!(
+            "failed to rename {} -> {} after {} attempts: {}",
+            temp_path.display(),
+            path.display(),
+            MAX_ATTEMPTS,
+            last_err
+                .map(|e| e.to_string())
+                .unwrap_or_else(|| "unknown error".to_string())
+        )))
     }
 
-    /// Load services from the JSON file into memory with advisory locking on Windows.
+    /// Load services from the JSON file into memory.
+    ///
+    /// Readers do not take a lock — `write_atomic` swaps the target file in
+    /// via `rename`, so the worst case for a racing reader is briefly seeing
+    /// the previous snapshot. With a small bounded retry on
+    /// `read_to_string` we also tolerate the narrow Windows window where a
+    /// concurrent `rename` returns `PermissionDenied` to the reader.
     fn load_from_file(&self) -> TransportResult<()> {
         let path = self.registry_file_path();
         if !path.exists() {
             return Ok(());
         }
 
-        let content = Self::read_locked(&path)?;
+        let content = Self::read_with_retry(&path)?;
 
         if content.trim().is_empty() {
             return Ok(());
@@ -574,29 +583,30 @@ impl FileRegistry {
         Ok(())
     }
 
-    /// Read the registry file, waiting briefly for any concurrent Windows lock to clear.
-    #[cfg(windows)]
-    fn read_locked(path: &PathBuf) -> TransportResult<String> {
-        let lock_path = path.with_extension("lock");
-        let max_wait = Duration::from_secs(5);
-        let poll = Duration::from_millis(50);
-        let mut waited = Duration::ZERO;
-
-        while lock_path.exists() && waited < max_wait {
-            std::thread::sleep(poll);
-            waited += poll;
+    /// Read the registry file with a short bounded retry to tolerate the
+    /// Windows "file briefly held by another process" `PermissionDenied`
+    /// race that can happen during a concurrent `rename`.
+    fn read_with_retry(path: &PathBuf) -> TransportResult<String> {
+        const MAX_ATTEMPTS: u32 = 5;
+        const BACKOFF_MS: u64 = 5;
+        let mut last_err: Option<std::io::Error> = None;
+        for attempt in 0..MAX_ATTEMPTS {
+            match fs::read_to_string(path) {
+                Ok(s) => return Ok(s),
+                Err(e) => {
+                    last_err = Some(e);
+                    std::thread::sleep(Duration::from_millis(BACKOFF_MS * (attempt as u64 + 1)));
+                }
+            }
         }
-
-        fs::read_to_string(path).map_err(|e| {
-            TransportError::RegistryFile(format!("failed to read {}: {}", path.display(), e))
-        })
-    }
-
-    #[cfg(not(windows))]
-    fn read_locked(path: &PathBuf) -> TransportResult<String> {
-        fs::read_to_string(path).map_err(|e| {
-            TransportError::RegistryFile(format!("failed to read {}: {}", path.display(), e))
-        })
+        Err(TransportError::RegistryFile(format!(
+            "failed to read {} after {} attempts: {}",
+            path.display(),
+            MAX_ATTEMPTS,
+            last_err
+                .map(|e| e.to_string())
+                .unwrap_or_else(|| "unknown error".to_string())
+        )))
     }
 }
 

--- a/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
@@ -392,3 +392,59 @@ fn test_read_alive_handles_multiple_ghosts_for_dcc_maya_126() {
     assert_eq!(evicted, 5);
     assert_eq!(entries.len(), 1);
 }
+
+/// Regression for the #560 follow-up: two threads heartbeating different
+/// `ServiceEntry` rows at the same time must both succeed and the resulting
+/// `services.json` must contain *both* entries, not just one.
+///
+/// The original #554 implementation used a single shared `services.lock`
+/// file with `share_mode(0)` (exclusive) — concurrent writers would fail
+/// the lock open with `PermissionDenied` and silently drop their entry,
+/// which manifested as the gateway facade only seeing one of two backends
+/// in `tests/test_gateway_facade_aggregation.py` on Windows.
+#[test]
+fn test_concurrent_heartbeat_does_not_drop_entries() {
+    use std::sync::Arc;
+    use std::thread;
+
+    let dir = tempfile::tempdir().unwrap();
+    let registry = Arc::new(FileRegistry::new(dir.path()).unwrap());
+
+    // Pre-register both rows so each thread only heartbeats (the path that
+    // hammered `flush_to_file` in production).
+    let maya = ServiceEntry::new("maya", "127.0.0.1", 18900);
+    let blender = ServiceEntry::new("blender", "127.0.0.1", 18901);
+    let maya_key = maya.key();
+    let blender_key = blender.key();
+    registry.register(maya).unwrap();
+    registry.register(blender).unwrap();
+
+    let r1 = Arc::clone(&registry);
+    let r2 = Arc::clone(&registry);
+    let t1 = thread::spawn(move || {
+        for _ in 0..50 {
+            r1.heartbeat(&maya_key).unwrap();
+        }
+    });
+    let t2 = thread::spawn(move || {
+        for _ in 0..50 {
+            r2.heartbeat(&blender_key).unwrap();
+        }
+    });
+    t1.join().unwrap();
+    t2.join().unwrap();
+
+    // Re-load from disk in a second registry to verify both entries
+    // survived every flush, not just the in-memory snapshot.
+    let reread = FileRegistry::new(dir.path()).unwrap();
+    let dccs: std::collections::HashSet<_> =
+        reread.list_all().into_iter().map(|e| e.dcc_type).collect();
+    assert!(
+        dccs.contains("maya"),
+        "maya entry lost in concurrent heartbeat"
+    );
+    assert!(
+        dccs.contains("blender"),
+        "blender entry lost in concurrent heartbeat"
+    );
+}


### PR DESCRIPTION
## Regression

The Windows path of `FileRegistry::write_atomic` shipped in PR #560 (issue #554) introduced an exclusive `share_mode(0)` advisory lock on `services.lock` plus a temp filename keyed only on the process id. Two failure modes followed:

1. Concurrent in-process writers (sentinel heartbeat + multiple backend heartbeats with `heartbeat_secs=1`) raced on the same `.tmp.<pid>.services.json` path, so one writer's content could be overwritten by the other before the rename.
2. The exclusive lock made one of two simultaneous writers fail outright with `PermissionDenied`. The loser's `register` / `heartbeat` returned `Err`, so its row never reached `services.json`.

Downstream symptom: `tests/test_gateway_facade_aggregation.py::TestFacadeDiscovery::test_list_dcc_instances_reports_both_backends` and `::test_aggregated_list_contains_local_and_backend_tools` failed on three Windows Python matrix slots (py3.8, py3.10, py3.12) because the gateway only saw `{'maya'}` instead of `{'maya', 'blender'}`.

## Fix

Replace the lock with two cheaper, cross-platform invariants that still satisfy the original “no half-written file” requirement of #554:

1. **Unique temp filename per write** — `pid + thread id + monotonic counter` — so two writers in the same process never share a temp path.
2. **Bounded retry around `fs::rename`** for the narrow Windows window where a concurrent reader briefly holds the target file open and the rename returns `PermissionDenied`. Readers also retry `read_to_string` for the symmetric race.

No more `services.lock` file, no more shared-mode dance.

## Regression test

New `test_concurrent_heartbeat_does_not_drop_entries` in `crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs` registers `maya` + `blender`, hammers `heartbeat()` 50×2 times concurrently from two threads, then re-loads `services.json` from a fresh `FileRegistry` and asserts both rows survived every flush. With the old lock implementation this fails on Windows.

## Notes

- Hot-fixes a regression introduced by the just-merged PR #560
- PR #561 (`feat/observability-metrics`) is stacked downstream and inherits the regression — will be rebased onto this fix once it merges
- PR #562 (docs) is also based on the buggy main and will be rebased after this lands