### PR TITLE
fix(gateway,skills): three-tier election + stale-aware list_dcc_instances + strict scan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,8 @@
 | Full callable-payload dispatch protocol for DCC plugins | `BaseDccCallableDispatcherFull` + `BaseDccPump` + `JobOutcome` / `PendingEnvelope` (#520); use `InProcessCallableDispatcher` as reference impl for `mayapy` / headless / pytest |
 | Skill scanning | `scan_and_load(dcc_name=...)` → always unpack `(skills, skipped)` tuple |
 | Tolerate broken SKILL.md | `scan_and_load_lenient(...)` instead of `scan_and_load` |
+| Fail-fast on broken SKILL.md | `scan_and_load_strict(...)` — raises `ValueError` listing every skipped directory (issue maya#138) |
+| Stamp gateway sentinel for election | `McpHttpConfig(..., adapter_version=..., adapter_dcc=...)` or `.with_adapter_version().with_adapter_dcc()` (issue maya#137) |
 | Discover team-level skills | `scan_and_load_team()` / `scan_and_load_team_lenient()` |
 | Discover user-level skills | `scan_and_load_user()` / `scan_and_load_user_lenient()` |
 | Disable evolved skills | `ENV_DISABLE_ACCUMULATED_SKILLS` |

--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -395,6 +395,24 @@ pub struct McpHttpConfig {
     /// `"unknown"` (case-insensitive). Set to `true` only for development
     /// or when intentionally running a standalone server without a real DCC.
     pub allow_unknown_tools: bool,
+
+    /// Adapter package version (e.g. `dcc_mcp_maya = "0.3.0"`) recorded
+    /// on the `__gateway__` sentinel and used as the second tier of the
+    /// version-aware gateway election (issue maya#137).
+    ///
+    /// Default: `None`. Adapters that ship the gateway should set this so
+    /// peers can compare adapter releases when the embedded
+    /// `dcc-mcp-http` crate version is identical.
+    pub adapter_version: Option<String>,
+
+    /// DCC type the adapter is bound to (e.g. `"maya"`).  Drives the
+    /// third-tier "real DCC over generic standalone" tiebreaker in
+    /// gateway election (issue maya#137).
+    ///
+    /// Default: `None`. When unset (or set to `"unknown"`), the runner
+    /// is treated as a generic standalone server and yields to a real
+    /// DCC adapter at equal versions.
+    pub adapter_dcc: Option<String>,
 }
 
 impl McpHttpConfig {
@@ -439,7 +457,24 @@ impl McpHttpConfig {
             schedules_dir: None,
             enable_tool_cache: true,
             allow_unknown_tools: false,
+            adapter_version: None,
+            adapter_dcc: None,
         }
+    }
+
+    /// Builder: stamp the adapter package version onto the gateway
+    /// sentinel for version-aware election (issue maya#137).
+    pub fn with_adapter_version(mut self, version: impl Into<String>) -> Self {
+        self.adapter_version = Some(version.into());
+        self
+    }
+
+    /// Builder: declare the DCC type this adapter is bound to so the
+    /// gateway election can prefer real DCCs over generic standalone
+    /// servers (issue maya#137).
+    pub fn with_adapter_dcc(mut self, dcc: impl Into<String>) -> Self {
+        self.adapter_dcc = Some(dcc.into());
+        self
     }
 
     /// Builder: enable the scheduler subsystem and point at a directory

--- a/crates/dcc-mcp-http/src/gateway/config.rs
+++ b/crates/dcc-mcp-http/src/gateway/config.rs
@@ -48,6 +48,13 @@ pub struct GatewayConfig {
     /// with `dcc_type: "unknown"` should not leak tools into the gateway
     /// façade unless this is explicitly enabled for development (issue #555).
     pub allow_unknown_tools: bool,
+    /// Adapter package version recorded on the `__gateway__` sentinel
+    /// (e.g. `dcc_mcp_maya = "0.3.0"`). Used by the second tier of the
+    /// election comparison (issue maya#137).
+    pub adapter_version: Option<String>,
+    /// DCC type the adapter is bound to (e.g. `"maya"`). Used by the
+    /// third-tier real-DCC tiebreaker (issue maya#137).
+    pub adapter_dcc: Option<String>,
 }
 
 impl Default for GatewayConfig {
@@ -67,6 +74,8 @@ impl Default for GatewayConfig {
             route_ttl_secs: 60 * 60 * 24,
             max_routes_per_session: 1_000,
             allow_unknown_tools: false,
+            adapter_version: None,
+            adapter_dcc: None,
         }
     }
 }

--- a/crates/dcc-mcp-http/src/gateway/mod.rs
+++ b/crates/dcc-mcp-http/src/gateway/mod.rs
@@ -90,7 +90,7 @@ pub use handle::GatewayHandle;
 pub use runner::GatewayRunner;
 pub(crate) use sentinel::{has_newer_sentinel, is_own_instance};
 pub(crate) use tasks::start_gateway_tasks;
-pub(crate) use version::is_newer_version;
+pub(crate) use version::{ElectionInfo, is_newer_election, is_newer_version};
 
 #[cfg(test)]
 pub(crate) use tasks::self_probe_listener;

--- a/crates/dcc-mcp-http/src/gateway/runner.rs
+++ b/crates/dcc-mcp-http/src/gateway/runner.rs
@@ -188,6 +188,8 @@ impl GatewayRunner {
         let route_ttl = Duration::from_secs(self.config.route_ttl_secs);
         let max_routes_per_session = self.config.max_routes_per_session as usize;
         let own_version = self.config.server_version.clone();
+        let own_adapter_version = self.config.adapter_version.clone();
+        let own_adapter_dcc = self.config.adapter_dcc.clone();
 
         match try_bind_port_opt(&self.config.host, self.config.gateway_port).await {
             // ── We won the port ───────────────────────────────────────────
@@ -196,12 +198,19 @@ impl GatewayRunner {
                 // `ServiceEntry::new` auto-populates `pid` with our process id,
                 // so a crash of *this* process makes the sentinel prunable by
                 // `prune_dead_pids` on other peers (issue #227).
+                //
+                // Issue maya#137: stamp adapter_version + adapter_dcc on the
+                // sentinel so peers can apply the three-tier election
+                // comparison (crate version → adapter version → real-DCC
+                // tiebreaker).
                 let mut sentinel = ServiceEntry::new(
                     GATEWAY_SENTINEL_DCC_TYPE,
                     &self.config.host,
                     self.config.gateway_port,
                 );
                 sentinel.version = Some(own_version.clone());
+                sentinel.adapter_version = own_adapter_version.clone();
+                sentinel.adapter_dcc = own_adapter_dcc.clone();
                 let sentinel_key = sentinel.key();
                 {
                     let reg = self.registry.read().await;
@@ -223,6 +232,8 @@ impl GatewayRunner {
                     self.config.host.clone(),
                     self.config.gateway_port,
                     self.config.allow_unknown_tools,
+                    own_adapter_version.clone(),
+                    own_adapter_dcc.clone(),
                 )
                 .await
                 {
@@ -259,21 +270,49 @@ impl GatewayRunner {
 
             // ── Port is taken — version-aware challenger logic ────────────
             None => {
-                // Read the sentinel to discover the current gateway's version.
-                let gw_version = {
+                // Read the sentinel to discover the current gateway's full
+                // election profile (crate version + adapter metadata).
+                // Issue maya#137: the previous lookup only fetched `version`,
+                // so a freshly-released DCC adapter could never preempt an
+                // older standalone server pinned to a newer crate version.
+                let resident = {
                     let reg = self.registry.read().await;
                     reg.list_instances(GATEWAY_SENTINEL_DCC_TYPE)
                         .into_iter()
                         .next()
-                        .and_then(|e| e.version)
-                        .unwrap_or_default()
                 };
 
-                if !gw_version.is_empty() && is_newer_version(&own_version, &gw_version) {
+                let gw_version = resident
+                    .as_ref()
+                    .and_then(|e| e.version.clone())
+                    .unwrap_or_default();
+                let gw_adapter_version = resident.as_ref().and_then(|e| e.adapter_version.clone());
+                let gw_adapter_dcc = resident.as_ref().and_then(|e| e.adapter_dcc.clone());
+
+                let own_info = ElectionInfo::new(
+                    &own_version,
+                    own_adapter_version.as_deref(),
+                    own_adapter_dcc.as_deref(),
+                );
+                let gw_info = ElectionInfo::new(
+                    if gw_version.is_empty() {
+                        "0.0.0"
+                    } else {
+                        &gw_version
+                    },
+                    gw_adapter_version.as_deref(),
+                    gw_adapter_dcc.as_deref(),
+                );
+
+                if !gw_version.is_empty() && is_newer_election(own_info, gw_info) {
                     tracing::info!(
                         own = %own_version,
+                        own_adapter_version = ?own_adapter_version,
+                        own_adapter_dcc = ?own_adapter_dcc,
                         gateway = %gw_version,
-                        "We are newer than the current gateway — entering challenger mode"
+                        gateway_adapter_version = ?gw_adapter_version,
+                        gateway_adapter_dcc = ?gw_adapter_dcc,
+                        "We outrank the current gateway — entering challenger mode"
                     );
                     let challenger_abort = self.spawn_challenger_loop(&own_version, &gw_version);
                     // Return as non-gateway for now; challenger loop will promote us later.
@@ -288,8 +327,12 @@ impl GatewayRunner {
                     tracing::info!(
                         port = self.config.gateway_port,
                         gateway_version = %gw_version,
+                        gateway_adapter_version = ?gw_adapter_version,
+                        gateway_adapter_dcc = ?gw_adapter_dcc,
                         own_version = %own_version,
-                        "Gateway port taken by same-or-newer version — running as plain DCC instance"
+                        own_adapter_version = ?own_adapter_version,
+                        own_adapter_dcc = ?own_adapter_dcc,
+                        "Gateway port held by same-or-stronger candidate — running as plain DCC instance"
                     );
                     Ok(ElectionOutcome {
                         is_gateway: false,
@@ -324,6 +367,8 @@ impl GatewayRunner {
         let server_name = self.config.server_name.clone();
         let timeout_secs = self.config.challenger_timeout_secs;
         let allow_unknown_tools = self.config.allow_unknown_tools;
+        let adapter_version = self.config.adapter_version.clone();
+        let adapter_dcc = self.config.adapter_dcc.clone();
 
         let handle = tokio::spawn(async move {
             // ── Cooperative yield request ─────────────────────────────────
@@ -365,9 +410,12 @@ impl GatewayRunner {
                         "Challenger: won gateway port — starting gateway tasks"
                     );
 
-                    // Update sentinel with our version.
+                    // Update sentinel with our version + adapter info so
+                    // peers see the same election profile we used to win.
                     let mut sentinel = ServiceEntry::new(GATEWAY_SENTINEL_DCC_TYPE, &host, port);
                     sentinel.version = Some(own_ver.clone());
+                    sentinel.adapter_version = adapter_version.clone();
+                    sentinel.adapter_dcc = adapter_dcc.clone();
                     let sentinel_key = sentinel.key();
                     {
                         let reg = registry.read().await;
@@ -389,6 +437,8 @@ impl GatewayRunner {
                         host.clone(),
                         port,
                         allow_unknown_tools,
+                        adapter_version.clone(),
+                        adapter_dcc.clone(),
                     )
                     .await
                     {

--- a/crates/dcc-mcp-http/src/gateway/sentinel.rs
+++ b/crates/dcc-mcp-http/src/gateway/sentinel.rs
@@ -50,19 +50,31 @@ pub(crate) fn is_own_instance(
 /// of "is there a newer gateway challenger on the network". Any comparison must
 /// therefore be restricted to the sentinel row, and it must ignore our own
 /// sentinel write (same version, same host, same port).
+///
+/// Issue maya#137: the comparison now goes through [`super::is_newer_election`],
+/// which layers crate version → adapter version → real-DCC tiebreaker on
+/// top of the original semver check.  `own` carries the crate + adapter
+/// info this process is willing to advertise.
 pub(crate) fn has_newer_sentinel(
     reg: &FileRegistry,
-    own_version: &str,
+    own: super::ElectionInfo<'_>,
     stale_timeout: Duration,
 ) -> bool {
     reg.list_instances(GATEWAY_SENTINEL_DCC_TYPE)
         .into_iter()
         .any(|e| {
-            !e.is_stale(stale_timeout)
-                && e.version
-                    .as_deref()
-                    .map(|v| is_newer_version(v, own_version))
-                    .unwrap_or(false)
+            if e.is_stale(stale_timeout) {
+                return false;
+            }
+            let Some(crate_v) = e.version.as_deref() else {
+                return false;
+            };
+            let resident = super::ElectionInfo::new(
+                crate_v,
+                e.adapter_version.as_deref(),
+                e.adapter_dcc.as_deref(),
+            );
+            super::is_newer_election(resident, own)
         })
 }
 

--- a/crates/dcc-mcp-http/src/gateway/state.rs
+++ b/crates/dcc-mcp-http/src/gateway/state.rs
@@ -93,6 +93,14 @@ pub struct GatewayState {
     ///
     /// When `false` (default), `live_instances` filters them out.
     pub allow_unknown_tools: bool,
+    /// Adapter package version (e.g. `dcc_mcp_maya = "0.3.0"`) advertised
+    /// by this gateway on its `__gateway__` sentinel and used by the
+    /// version-aware election comparison (issue maya#137).
+    pub adapter_version: Option<String>,
+    /// DCC type the adapter is bound to (e.g. `"maya"`) — drives the
+    /// real-DCC vs `"unknown"` tiebreaker in gateway election
+    /// (issue maya#137).
+    pub adapter_dcc: Option<String>,
 }
 
 impl GatewayState {
@@ -124,6 +132,28 @@ impl GatewayState {
             })
             .collect()
     }
+
+    /// Return every parseable registry row that an operator-facing tool
+    /// (e.g. `list_dcc_instances`) should expose, regardless of liveness.
+    ///
+    /// Issue maya#138: the previous implementation reused [`live_instances`],
+    /// which silently dropped stale, shutting-down, and `dcc_type == "unknown"`
+    /// rows.  Operators eyeballing the registry directory then saw three
+    /// sentinels but only one row in the tool output, with no signal as to
+    /// why the others vanished.  The expanded view excludes only the bookkeeping
+    /// `__gateway__` sentinel and the gateway's own self row, so callers can
+    /// render a full picture and downgrade stale entries via the surface
+    /// `status` field instead.
+    pub fn all_instances(&self, registry: &FileRegistry) -> Vec<ServiceEntry> {
+        registry
+            .list_all()
+            .into_iter()
+            .filter(|e| {
+                e.dcc_type != GATEWAY_SENTINEL_DCC_TYPE
+                    && !super::is_own_instance(e, &self.own_host, self.own_port)
+            })
+            .collect()
+    }
 }
 
 /// Serialize a `ServiceEntry` to a JSON `Value` suitable for gateway responses.
@@ -131,28 +161,43 @@ impl GatewayState {
 /// The returned object always contains every field so that MCP clients can
 /// display a rich disambiguation prompt when multiple instances of the same
 /// DCC type are live at the same time.
+///
+/// Issue maya#138: when the entry is past `stale_timeout` the surface
+/// `status` field is reported as `"stale"` so operators inspecting
+/// `list_dcc_instances` can immediately tell why a registry row is no
+/// longer routable.  The original `ServiceStatus` is preserved verbatim
+/// when the row is still live, and the redundant `stale: bool` field is
+/// kept for clients that prefer to branch on a boolean.
 pub fn entry_to_json(e: &ServiceEntry, stale_timeout: Duration) -> Value {
+    let stale = e.is_stale(stale_timeout);
+    let status = if stale {
+        "stale".to_string()
+    } else {
+        e.status.to_string()
+    };
     json!({
-        "instance_id":  e.instance_id.to_string(),
-        "dcc_type":     e.dcc_type,
-        "host":         e.host,
-        "port":         e.port,
-        "mcp_url":      format!("http://{}:{}/mcp", e.host, e.port),
-        "status":       e.status.to_string(),
+        "instance_id":     e.instance_id.to_string(),
+        "dcc_type":        e.dcc_type,
+        "host":            e.host,
+        "port":            e.port,
+        "mcp_url":         format!("http://{}:{}/mcp", e.host, e.port),
+        "status":          status,
         // ── document / scene ───────────────────────────────────────────────
         // `scene` is the active / primary document (same field as before).
         // `documents` is the full list for multi-document apps (Photoshop etc.).
-        "scene":        e.scene,
-        "documents":    e.documents,
+        "scene":           e.scene,
+        "documents":       e.documents,
         // ── disambiguation helpers ─────────────────────────────────────────
         // Both fields are null when not set; agents should skip null values
         // when building the disambiguation prompt for users.
-        "pid":          e.pid,
-        "display_name": e.display_name,
+        "pid":             e.pid,
+        "display_name":    e.display_name,
         // ── misc ───────────────────────────────────────────────────────────
-        "version":      e.version,
-        "metadata":     e.metadata,
-        "stale":        e.is_stale(stale_timeout),
+        "version":         e.version,
+        "adapter_version": e.adapter_version,
+        "adapter_dcc":     e.adapter_dcc,
+        "metadata":        e.metadata,
+        "stale":           stale,
     })
 }
 
@@ -201,6 +246,8 @@ mod tests {
             pending_calls: Arc::new(RwLock::new(HashMap::new())),
             subscriber: crate::gateway::sse_subscriber::SubscriberManager::default(),
             allow_unknown_tools,
+            adapter_version: None,
+            adapter_dcc: None,
         }
     }
 
@@ -347,5 +394,71 @@ mod tests {
                 .any(|e| e.dcc_type.eq_ignore_ascii_case("unknown")),
             "unknown dcc_type must be present when allow_unknown_tools is true"
         );
+    }
+
+    /// Issue maya#138: `all_instances` keeps stale and `unknown` rows
+    /// (dropping only the gateway sentinel and the gateway's own
+    /// self-row) so the operator-facing `list_dcc_instances` tool can
+    /// surface a complete picture of the registry directory.
+    #[tokio::test]
+    async fn test_all_instances_keeps_stale_and_unknown() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
+
+        {
+            let r = registry.read().await;
+            // The bookkeeping sentinel — must always be filtered.
+            let mut sentinel = ServiceEntry::new(GATEWAY_SENTINEL_DCC_TYPE, "127.0.0.1", 9765);
+            sentinel.version = Some("0.14.18".into());
+            r.register(sentinel).unwrap();
+
+            // The standalone server's "unknown" row — kept by all_instances
+            // so operators can see why connect_to_dcc cannot route to it.
+            let unknown = ServiceEntry::new("unknown", "127.0.0.1", 18900);
+            r.register(unknown).unwrap();
+
+            // A live Maya plugin.
+            let maya = ServiceEntry::new("maya", "127.0.0.1", 18812);
+            r.register(maya).unwrap();
+
+            // A stale Maya plugin (heartbeat 10 minutes ago).
+            let mut stale = ServiceEntry::new("maya", "127.0.0.1", 18813);
+            stale.last_heartbeat = std::time::SystemTime::now() - Duration::from_secs(600);
+            r.register(stale).unwrap();
+        }
+
+        let gs =
+            test_gateway_state_with_own_and_unknown(registry.clone(), "127.0.0.1", 9765, false);
+        let all = gs.all_instances(&*registry.read().await);
+
+        assert_eq!(
+            all.len(),
+            3,
+            "expected unknown + live maya + stale maya, got {all:?}"
+        );
+        assert!(
+            !all.iter().any(|e| e.dcc_type == GATEWAY_SENTINEL_DCC_TYPE),
+            "gateway sentinel must always be filtered from operator output"
+        );
+        assert!(
+            all.iter().any(|e| e.dcc_type == "unknown"),
+            "unknown row must be retained even when allow_unknown_tools is false"
+        );
+        assert!(
+            all.iter().any(|e| e.is_stale(gs.stale_timeout)),
+            "stale row must be retained for diagnostics"
+        );
+    }
+
+    /// Issue maya#138: `entry_to_json` reports `status: "stale"` once a
+    /// row has aged past `stale_timeout`, regardless of the original
+    /// `ServiceStatus`, so callers can branch without a separate field.
+    #[test]
+    fn test_entry_to_json_status_stale_for_aged_row() {
+        let mut e = ServiceEntry::new("maya", "127.0.0.1", 18812);
+        e.last_heartbeat = std::time::SystemTime::now() - Duration::from_secs(600);
+        let json = entry_to_json(&e, Duration::from_secs(30));
+        assert_eq!(json["status"].as_str(), Some("stale"));
+        assert_eq!(json["stale"].as_bool(), Some(true));
     }
 }

--- a/crates/dcc-mcp-http/src/gateway/tasks.rs
+++ b/crates/dcc-mcp-http/src/gateway/tasks.rs
@@ -40,6 +40,8 @@ pub(crate) async fn start_gateway_tasks(
     own_host: String,
     own_port: u16,
     allow_unknown_tools: bool,
+    adapter_version: Option<String>,
+    adapter_dcc: Option<String>,
 ) -> Result<GatewayTasks, Box<dyn std::error::Error + Send + Sync>> {
     // ── Yield channel ─────────────────────────────────────────────────────
     let (yield_tx, mut yield_rx) = watch::channel(false);
@@ -83,6 +85,8 @@ pub(crate) async fn start_gateway_tasks(
     // plugin crashes after registering but before its own heartbeat starts.
     let reg_cleanup = registry.clone();
     let own_version = server_version.clone();
+    let own_adapter_version = adapter_version.clone();
+    let own_adapter_dcc = adapter_dcc.clone();
     let yield_tx_cleanup = yield_tx.clone();
     let sentinel_key_cleanup = sentinel_key.clone();
     let cleanup_handle = tokio::spawn(async move {
@@ -107,9 +111,19 @@ pub(crate) async fn start_gateway_tasks(
                 _ => {}
             }
 
-            if has_newer_sentinel(&r, &own_version, stale_timeout) {
+            // Issue maya#137: include adapter_version + adapter_dcc in the
+            // self-yield decision so a freshly-installed Maya plugin (real
+            // DCC) can preempt an older standalone (`unknown`) gateway.
+            let own_info = ElectionInfo::new(
+                &own_version,
+                own_adapter_version.as_deref(),
+                own_adapter_dcc.as_deref(),
+            );
+            if has_newer_sentinel(&r, own_info, stale_timeout) {
                 tracing::info!(
                     current = %own_version,
+                    adapter_version = ?own_adapter_version,
+                    adapter_dcc = ?own_adapter_dcc,
                     "Gateway: newer-version sentinel detected — initiating voluntary yield"
                 );
                 let _ = yield_tx_cleanup.send(true);
@@ -342,6 +356,8 @@ pub(crate) async fn start_gateway_tasks(
         pending_calls: Arc::new(RwLock::new(HashMap::new())),
         subscriber,
         allow_unknown_tools,
+        adapter_version,
+        adapter_dcc,
     };
     let gw_router = build_gateway_router(gw_state);
 

--- a/crates/dcc-mcp-http/src/gateway/tests.rs
+++ b/crates/dcc-mcp-http/src/gateway/tests.rs
@@ -3,6 +3,13 @@ use dcc_mcp_transport::discovery::types::ServiceEntry;
 
 const TEST_OWN_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// Build the `ElectionInfo` representing this process — crate-only, no
+/// adapter metadata — used by the issue #228 regressions where adapter
+/// info is irrelevant.
+fn own_crate_only() -> ElectionInfo<'static> {
+    ElectionInfo::new(TEST_OWN_VERSION, None, None)
+}
+
 #[test]
 fn test_parse_semver_basic() {
     assert_eq!(parse_semver("0.12.29"), (0, 12, 29));
@@ -18,6 +25,57 @@ fn test_is_newer_version_ordering() {
     assert!(is_newer_version("1.0.0", "0.99.99"));
     assert!(!is_newer_version("0.12.6", "0.12.6"));
     assert!(!is_newer_version("0.12.5", "0.12.6"));
+}
+
+// Issue maya#137 — three-tier election order.
+#[test]
+fn test_is_newer_election_crate_version_dominates() {
+    let cand = ElectionInfo::new("0.15.0", Some("0.3.0"), Some("maya"));
+    let cur = ElectionInfo::new("0.14.0", Some("9.9.9"), Some("maya"));
+    assert!(
+        is_newer_election(cand, cur),
+        "crate version must dominate adapter version"
+    );
+}
+
+#[test]
+fn test_is_newer_election_adapter_version_breaks_crate_tie() {
+    let cand = ElectionInfo::new("0.14.0", Some("0.3.1"), Some("maya"));
+    let cur = ElectionInfo::new("0.14.0", Some("0.3.0"), Some("maya"));
+    assert!(is_newer_election(cand, cur));
+    assert!(!is_newer_election(cur, cand));
+}
+
+#[test]
+fn test_is_newer_election_real_dcc_beats_unknown() {
+    // The reproduction from maya#137: standalone server pinned to a
+    // newer crate (0.14.18) is `unknown`; Maya plugin (0.3.0 adapter)
+    // ships with a real DCC. After the fix the Maya plugin should win
+    // when the crate versions are equal.
+    let cand = ElectionInfo::new("0.14.18", Some("0.3.0"), Some("maya"));
+    let cur = ElectionInfo::new("0.14.18", None, Some("unknown"));
+    assert!(
+        is_newer_election(cand, cur),
+        "real DCC must preempt unknown standalone at equal versions"
+    );
+}
+
+#[test]
+fn test_is_newer_election_two_real_dccs_remain_tied() {
+    // Two real DCCs at identical crate+adapter versions must not flip
+    // each other — the first-wins port-bind contract takes over.
+    let a = ElectionInfo::new("0.14.18", Some("0.3.0"), Some("maya"));
+    let b = ElectionInfo::new("0.14.18", Some("0.3.0"), Some("houdini"));
+    assert!(!is_newer_election(a, b));
+    assert!(!is_newer_election(b, a));
+}
+
+#[test]
+fn test_is_newer_election_missing_adapter_loses_to_present() {
+    let cand = ElectionInfo::new("0.14.0", Some("0.3.0"), Some("maya"));
+    let cur = ElectionInfo::new("0.14.0", None, Some("maya"));
+    assert!(is_newer_election(cand, cur));
+    assert!(!is_newer_election(cur, cand));
 }
 
 // Regression test for issue #228: Maya's host version ("2024") must not
@@ -36,7 +94,7 @@ fn test_has_newer_sentinel_ignores_dcc_host_version() {
     reg.register(maya).unwrap();
 
     assert!(
-        !has_newer_sentinel(&reg, TEST_OWN_VERSION, Duration::from_secs(30)),
+        !has_newer_sentinel(&reg, own_crate_only(), Duration::from_secs(30)),
         "Maya 2024 host version must not appear as a newer gateway"
     );
 }
@@ -53,7 +111,7 @@ fn test_has_newer_sentinel_detects_newer_gateway() {
     reg.register(sentinel).unwrap();
 
     assert!(
-        has_newer_sentinel(&reg, TEST_OWN_VERSION, Duration::from_secs(30)),
+        has_newer_sentinel(&reg, own_crate_only(), Duration::from_secs(30)),
         "a newer-version sentinel must trigger yield"
     );
 }
@@ -70,7 +128,7 @@ fn test_has_newer_sentinel_ignores_own_version() {
     reg.register(sentinel).unwrap();
 
     assert!(
-        !has_newer_sentinel(&reg, TEST_OWN_VERSION, Duration::from_secs(30)),
+        !has_newer_sentinel(&reg, own_crate_only(), Duration::from_secs(30)),
         "identical version sentinel must not trigger yield"
     );
 }
@@ -88,8 +146,50 @@ fn test_has_newer_sentinel_ignores_stale_sentinel() {
     reg.register(sentinel).unwrap();
 
     assert!(
-        !has_newer_sentinel(&reg, TEST_OWN_VERSION, Duration::from_secs(30)),
+        !has_newer_sentinel(&reg, own_crate_only(), Duration::from_secs(30)),
         "stale sentinel (crashed gateway) must not block newer takeover"
+    );
+}
+
+// Issue maya#137 — `has_newer_sentinel` must yield to a peer that has
+// the same crate version, the same adapter version, but a real DCC type
+// while the resident sentinel is `unknown`.
+#[test]
+fn test_has_newer_sentinel_real_dcc_preempts_unknown_standalone() {
+    let dir = tempfile::tempdir().unwrap();
+    let reg = FileRegistry::new(dir.path()).unwrap();
+
+    let mut sentinel = ServiceEntry::new(GATEWAY_SENTINEL_DCC_TYPE, "127.0.0.1", 9765);
+    sentinel.version = Some(TEST_OWN_VERSION.to_string());
+    sentinel.adapter_version = Some("0.3.0".to_string());
+    sentinel.adapter_dcc = Some("maya".to_string());
+    reg.register(sentinel).unwrap();
+
+    // We are an `unknown` standalone at the same crate + adapter version
+    // → must defer to the resident Maya gateway.
+    let own = ElectionInfo::new(TEST_OWN_VERSION, Some("0.3.0"), Some("unknown"));
+    assert!(
+        has_newer_sentinel(&reg, own, Duration::from_secs(30)),
+        "real DCC sentinel must preempt unknown standalone"
+    );
+}
+
+// Issue maya#137 (negative): an `unknown` resident sentinel must not
+// trip self-yield for a real-DCC owner of the same crate version.
+#[test]
+fn test_has_newer_sentinel_real_dcc_owner_ignores_unknown() {
+    let dir = tempfile::tempdir().unwrap();
+    let reg = FileRegistry::new(dir.path()).unwrap();
+
+    let mut sentinel = ServiceEntry::new(GATEWAY_SENTINEL_DCC_TYPE, "127.0.0.1", 9765);
+    sentinel.version = Some(TEST_OWN_VERSION.to_string());
+    sentinel.adapter_dcc = Some("unknown".to_string());
+    reg.register(sentinel).unwrap();
+
+    let own = ElectionInfo::new(TEST_OWN_VERSION, Some("0.3.0"), Some("maya"));
+    assert!(
+        !has_newer_sentinel(&reg, own, Duration::from_secs(30)),
+        "real DCC owner must not yield to an unknown peer at equal crate version"
     );
 }
 

--- a/crates/dcc-mcp-http/src/gateway/tools.rs
+++ b/crates/dcc-mcp-http/src/gateway/tools.rs
@@ -33,14 +33,49 @@ fn document_matches(e: &ServiceEntry, hint: &str) -> bool {
 
 // ── tools ──────────────────────────────────────────────────────────────────
 
-/// `list_dcc_instances` — list all live DCC servers, optionally filtered by type.
+/// `list_dcc_instances` — list every parseable DCC server registered in the
+/// shared registry, optionally filtered by `dcc_type`.
+///
+/// Issue maya#138: prior to this change the tool reused
+/// [`GatewayState::live_instances`], which silently dropped stale rows,
+/// shutting-down rows, and any registration with `dcc_type == "unknown"`.
+/// Operators inspecting `$TEMP/dcc-mcp-registry/` then saw three sentinels
+/// on disk but only one row in the tool output, with no signal as to why
+/// the others vanished — making it nearly impossible to diagnose why their
+/// Maya plugin was missing or why the standalone server appeared to "win"
+/// the gateway.  The tool now surfaces:
+///
+/// * Every parseable row except the bookkeeping `__gateway__` sentinel
+///   and the gateway's own self-row.
+/// * Stale rows with `status: "stale"` so callers can render them as
+///   crashed/abandoned without dropping them silently.
+/// * `unknown` rows unconditionally, since this view is operator-facing
+///   and the existing `allow_unknown_tools` guard still governs whether
+///   their tools are routable through the gateway façade.
+///
+/// Pass `include_stale: false` (boolean) to opt out of stale rows for
+/// callers that genuinely want only routable instances.
 pub async fn tool_list_instances(gs: &GatewayState, args: &Value) -> Result<String, String> {
     let dcc_filter = args.get("dcc_type").and_then(|v| v.as_str());
+    let include_stale = args
+        .get("include_stale")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
+
     let reg = gs.registry.read().await;
-    let mut instances: Vec<Value> = gs
-        .live_instances(&reg)
+    let raw = gs.all_instances(&reg);
+
+    let mut stale_count: usize = 0;
+    let mut instances: Vec<Value> = raw
         .iter()
         .filter(|e| dcc_filter.is_none_or(|f| e.dcc_type == f))
+        .filter(|e| {
+            let stale = e.is_stale(gs.stale_timeout);
+            if stale {
+                stale_count += 1;
+            }
+            include_stale || !stale
+        })
         .map(|e| entry_to_json(e, gs.stale_timeout))
         .collect();
 
@@ -52,7 +87,11 @@ pub async fn tool_list_instances(gs: &GatewayState, args: &Value) -> Result<Stri
     });
 
     let tip = if instances.is_empty() {
-        "No live DCC instances. Start dcc-mcp-server for each DCC application."
+        "No DCC instances in the registry. Start dcc-mcp-server for each DCC application."
+    } else if stale_count > 0 && include_stale {
+        "Some rows have status='stale' (no recent heartbeat). \
+         Use connect_to_dcc(dcc_type=..., scene=...) to route to a live one — \
+         pass `scene`, `document`, `display_name`, or `instance_id` to disambiguate."
     } else {
         "Use connect_to_dcc(dcc_type=..., scene=...) to get the direct MCP URL. \
          When multiple instances of the same DCC type are running, pass `scene`, \
@@ -60,9 +99,10 @@ pub async fn tool_list_instances(gs: &GatewayState, args: &Value) -> Result<Stri
     };
 
     serde_json::to_string_pretty(&json!({
-        "total": instances.len(),
-        "instances": instances,
-        "tip": tip
+        "total":        instances.len(),
+        "stale_count":  stale_count,
+        "instances":    instances,
+        "tip":          tip,
     }))
     .map_err(|e| e.to_string())
 }
@@ -286,15 +326,22 @@ pub fn gateway_tool_defs() -> serde_json::Value {
     json!([
         {
             "name": "list_dcc_instances",
-            "description": "List all running DCC server instances. \
-                Returns type, port, scene, documents, pid, display_name, and status. \
-                Call this first to discover what's available.",
+            "description": "List every DCC server instance registered in the shared registry. \
+                Returns type, port, scene, documents, pid, display_name, version, adapter_version, \
+                adapter_dcc, and status. Stale rows (no recent heartbeat) are reported with \
+                status='stale' so operators can see why a registration is no longer routable; \
+                pass include_stale=false to hide them. Call this first to discover what's available.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "dcc_type": {
                         "type": "string",
                         "description": "Filter by DCC type (e.g. 'maya', 'photoshop'). Omit for all."
+                    },
+                    "include_stale": {
+                        "type": "boolean",
+                        "description": "Include rows with status='stale' (default: true). Set to false for routable-only output.",
+                        "default": true
                     }
                 }
             }

--- a/crates/dcc-mcp-http/src/gateway/version.rs
+++ b/crates/dcc-mcp-http/src/gateway/version.rs
@@ -23,3 +23,70 @@ pub(crate) fn parse_semver(v: &str) -> (u64, u64, u64) {
 pub(crate) fn is_newer_version(candidate: &str, current: &str) -> bool {
     parse_semver(candidate) > parse_semver(current)
 }
+
+/// Election metadata describing one side of a gateway tiebreak (issue maya#137).
+///
+/// The comparison happens in three layers, each only consulted when the
+/// previous layer is exactly equal:
+///
+/// 1. **Crate version** — the embedded `dcc-mcp-http` semver.
+/// 2. **Adapter version** — the package wrapping the gateway (e.g.
+///    `dcc_mcp_maya = "0.3.0"`); `None` is treated as the lowest value so a
+///    challenger that exposes its adapter version always beats a peer that
+///    omitted it.
+/// 3. **Real-DCC tiebreaker** — when the resident sentinel has no
+///    `adapter_dcc` set or reports `"unknown"` (a generic standalone
+///    server) and the challenger advertises a real DCC, the challenger
+///    wins.  Two real DCCs of the same crate+adapter version remain tied
+///    so peers fall back to the existing first-wins port-bind contract.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ElectionInfo<'a> {
+    pub(crate) crate_version: &'a str,
+    pub(crate) adapter_version: Option<&'a str>,
+    pub(crate) adapter_dcc: Option<&'a str>,
+}
+
+impl<'a> ElectionInfo<'a> {
+    pub(crate) fn new(
+        crate_version: &'a str,
+        adapter_version: Option<&'a str>,
+        adapter_dcc: Option<&'a str>,
+    ) -> Self {
+        Self {
+            crate_version,
+            adapter_version,
+            adapter_dcc,
+        }
+    }
+}
+
+/// Treat `None`, empty, and `"unknown"` (case-insensitive) as the generic
+/// standalone bucket.  Any other value is considered a real DCC for the
+/// election tiebreaker.
+fn is_unknown_dcc(dcc: Option<&str>) -> bool {
+    match dcc {
+        None => true,
+        Some(s) => s.is_empty() || s.eq_ignore_ascii_case("unknown"),
+    }
+}
+
+/// Three-layer election comparison (issue maya#137).
+///
+/// Returns `true` when `candidate` should preempt `current`.
+pub(crate) fn is_newer_election(candidate: ElectionInfo<'_>, current: ElectionInfo<'_>) -> bool {
+    let cand_crate = parse_semver(candidate.crate_version);
+    let cur_crate = parse_semver(current.crate_version);
+    if cand_crate != cur_crate {
+        return cand_crate > cur_crate;
+    }
+
+    // Layer 2 — adapter version.  `None` is below any concrete value.
+    let cand_adapter = candidate.adapter_version.map(parse_semver);
+    let cur_adapter = current.adapter_version.map(parse_semver);
+    if cand_adapter != cur_adapter {
+        return cand_adapter > cur_adapter;
+    }
+
+    // Layer 3 — prefer real DCC over generic standalone.
+    is_unknown_dcc(current.adapter_dcc) && !is_unknown_dcc(candidate.adapter_dcc)
+}

--- a/crates/dcc-mcp-http/src/server/gateway_impl.rs
+++ b/crates/dcc-mcp-http/src/server/gateway_impl.rs
@@ -29,6 +29,11 @@ pub(crate) async fn start_gateway_runner(
         route_ttl_secs: config.gateway_route_ttl_secs,
         max_routes_per_session: config.gateway_max_routes_per_session,
         allow_unknown_tools: config.allow_unknown_tools,
+        adapter_version: config.adapter_version.clone(),
+        adapter_dcc: config
+            .adapter_dcc
+            .clone()
+            .or_else(|| config.dcc_type.clone()),
     };
 
     let runner = match GatewayRunner::new(gateway_config) {
@@ -46,6 +51,11 @@ pub(crate) async fn start_gateway_runner(
     );
     entry.version = config.dcc_version.clone();
     entry.scene = config.scene.clone();
+    entry.adapter_version = config.adapter_version.clone();
+    entry.adapter_dcc = config
+        .adapter_dcc
+        .clone()
+        .or_else(|| config.dcc_type.clone());
 
     let metadata_provider = Some(build_metadata_provider(Arc::clone(live_meta)));
     match runner.start(entry, metadata_provider).await {

--- a/crates/dcc-mcp-http/src/tests/gateway.rs
+++ b/crates/dcc-mcp-http/src/tests/gateway.rs
@@ -34,6 +34,8 @@ fn make_gateway_state() -> GatewayState {
         pending_calls: Arc::new(RwLock::new(std::collections::HashMap::new())),
         subscriber: crate::gateway::sse_subscriber::SubscriberManager::default(),
         allow_unknown_tools: false,
+        adapter_version: None,
+        adapter_dcc: None,
     }
 }
 

--- a/crates/dcc-mcp-http/tests/http/backend_timeout.rs
+++ b/crates/dcc-mcp-http/tests/http/backend_timeout.rs
@@ -64,6 +64,8 @@ async fn make_state(
         pending_calls: Arc::new(RwLock::new(std::collections::HashMap::new())),
         subscriber: dcc_mcp_http::gateway::sse_subscriber::SubscriberManager::default(),
         allow_unknown_tools: false,
+        adapter_version: None,
+        adapter_dcc: None,
     };
     (state, registry, dir)
 }

--- a/crates/dcc-mcp-http/tests/http/gateway_passthrough.rs
+++ b/crates/dcc-mcp-http/tests/http/gateway_passthrough.rs
@@ -62,6 +62,8 @@ async fn make_state(
         pending_calls: Arc::new(RwLock::new(std::collections::HashMap::new())),
         subscriber: SubscriberManager::default(),
         allow_unknown_tools: false,
+        adapter_version: None,
+        adapter_dcc: None,
     };
     (state, registry, dir)
 }

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -558,6 +558,15 @@ async fn main() -> anyhow::Result<()> {
         wait_terminal_timeout_ms: 600_000,
         route_ttl_secs: 60 * 60 * 24,
         max_routes_per_session: 1_000,
+        // Issue maya#137: standalone server has no adapter package, so the
+        // election treats it as the lowest tier and yields to any real
+        // DCC adapter at equal crate version.
+        adapter_version: None,
+        adapter_dcc: if args.dcc.is_empty() {
+            None
+        } else {
+            Some(args.dcc.clone())
+        },
     };
 
     let runner = GatewayRunner::new(gateway_cfg)

--- a/crates/dcc-mcp-skills/src/lib.rs
+++ b/crates/dcc-mcp-skills/src/lib.rs
@@ -20,8 +20,8 @@ pub use catalog::{SkillCatalog, SkillDetail, SkillState, SkillSummary};
 pub use feedback::{SkillFeedback, get_skill_feedback, record_skill_feedback};
 pub use gui_executable::{GuiExecutableHint, correct_python_executable, is_gui_executable};
 pub use loader::{
-    LoadResult, parse_skill_md, scan_and_load, scan_and_load_lenient, scan_and_load_team,
-    scan_and_load_team_lenient, scan_and_load_user, scan_and_load_user_lenient,
+    LoadResult, parse_skill_md, scan_and_load, scan_and_load_lenient, scan_and_load_strict,
+    scan_and_load_team, scan_and_load_team_lenient, scan_and_load_user, scan_and_load_user_lenient,
 };
 pub use manager::SkillsManager;
 pub use paths::{
@@ -45,8 +45,9 @@ pub use feedback::{py_get_skill_feedback, py_record_skill_feedback};
 pub use gui_executable::{PyGuiExecutableHint, py_correct_python_executable, py_is_gui_executable};
 #[cfg(feature = "python-bindings")]
 pub use loader::{
-    py_parse_skill_md, py_scan_and_load, py_scan_and_load_lenient, py_scan_and_load_team,
-    py_scan_and_load_team_lenient, py_scan_and_load_user, py_scan_and_load_user_lenient,
+    py_parse_skill_md, py_scan_and_load, py_scan_and_load_lenient, py_scan_and_load_strict,
+    py_scan_and_load_team, py_scan_and_load_team_lenient, py_scan_and_load_user,
+    py_scan_and_load_user_lenient,
 };
 #[cfg(feature = "python-bindings")]
 pub use paths::{

--- a/crates/dcc-mcp-skills/src/loader/mod.rs
+++ b/crates/dcc-mcp-skills/src/loader/mod.rs
@@ -63,7 +63,7 @@ pub(crate) use files::{enumerate_metadata_files, enumerate_scripts, merge_depend
 #[cfg(test)]
 pub(crate) use scan::load_all_skills;
 pub use scan::{
-    LoadResult, scan_and_load, scan_and_load_lenient, scan_and_load_team,
+    LoadResult, scan_and_load, scan_and_load_lenient, scan_and_load_strict, scan_and_load_team,
     scan_and_load_team_lenient, scan_and_load_user, scan_and_load_user_lenient,
 };
 
@@ -609,8 +609,9 @@ pub(crate) fn extract_frontmatter(content: &str) -> Option<&str> {
 
 #[cfg(feature = "python-bindings")]
 pub use crate::python::loader::{
-    py_parse_skill_md, py_scan_and_load, py_scan_and_load_lenient, py_scan_and_load_team,
-    py_scan_and_load_team_lenient, py_scan_and_load_user, py_scan_and_load_user_lenient,
+    py_parse_skill_md, py_scan_and_load, py_scan_and_load_lenient, py_scan_and_load_strict,
+    py_scan_and_load_team, py_scan_and_load_team_lenient, py_scan_and_load_user,
+    py_scan_and_load_user_lenient,
 };
 
 // ── Tests ──

--- a/crates/dcc-mcp-skills/src/loader/scan.rs
+++ b/crates/dcc-mcp-skills/src/loader/scan.rs
@@ -33,6 +33,31 @@ pub fn scan_and_load(
     })
 }
 
+/// Strict pipeline: identical to [`scan_and_load`] but rejects the load
+/// when any scanned directory failed to produce a loadable skill.
+///
+/// Issue maya#138 — operators repeatedly hit the failure mode where a
+/// bad `SKILL.md` (missing frontmatter, malformed YAML, wrong filename)
+/// caused the scanner to silently elide the directory at `tracing::debug`,
+/// leaving a hard-to-diagnose "tool went missing" symptom at run-time.
+/// `scan_and_load_strict` surfaces those skipped directories as a
+/// [`ResolveError::SkippedDirectories`] so embedders can fail start-up
+/// loudly instead.  Dependency resolution still runs first to keep error
+/// ordering deterministic (cycle / missing-dep errors win over skipped
+/// directories).
+pub fn scan_and_load_strict(
+    extra_paths: Option<&[String]>,
+    dcc_name: Option<&str>,
+) -> Result<LoadResult, ResolveError> {
+    let result = scan_and_load(extra_paths, dcc_name)?;
+    if !result.skipped.is_empty() {
+        return Err(ResolveError::SkippedDirectories {
+            directories: result.skipped,
+        });
+    }
+    Ok(result)
+}
+
 /// Lenient pipeline: scan, load, and resolve dependencies but skip unresolvable skills.
 pub fn scan_and_load_lenient(
     extra_paths: Option<&[String]>,
@@ -81,6 +106,14 @@ pub fn scan_and_load_lenient(
 }
 
 /// Load all skill metadata from a list of directories.
+///
+/// Issue maya#138: skipped directories are now reported at `warn` level
+/// (was `debug`) so operators can immediately see why a skill they
+/// expected went missing.  The per-failure root cause — missing
+/// `SKILL.md`, malformed YAML, missing required field — is logged at
+/// `warn` from inside [`parse_skill_md`]; the line emitted here is the
+/// summary marker that ties those low-level diagnostics back to the
+/// scan pipeline.
 pub(crate) fn load_all_skills(dirs: &[String]) -> (Vec<SkillMetadata>, Vec<String>) {
     let mut skills = Vec::new();
     let mut skipped = Vec::new();
@@ -90,7 +123,12 @@ pub(crate) fn load_all_skills(dirs: &[String]) -> (Vec<SkillMetadata>, Vec<Strin
         match parse_skill_md(dir) {
             Some(meta) => skills.push(meta),
             None => {
-                tracing::debug!("Skipping directory (failed to parse): {dir_str}");
+                tracing::warn!(
+                    directory = %dir_str,
+                    "Skipping skill directory: SKILL.md missing or failed validation \
+                     (see preceding parse warnings for the specific cause). \
+                     Use scan_and_load_strict() to fail-fast on such directories."
+                );
                 skipped.push(dir_str.clone());
             }
         }

--- a/crates/dcc-mcp-skills/src/loader/tests/mod.rs
+++ b/crates/dcc-mcp-skills/src/loader/tests/mod.rs
@@ -13,4 +13,5 @@ mod test_next_tools;
 mod test_parse_skill_md;
 mod test_scan_and_load;
 mod test_scan_and_load_lenient;
+mod test_scan_and_load_strict;
 mod test_tool_annotations;

--- a/crates/dcc-mcp-skills/src/loader/tests/test_scan_and_load_strict.rs
+++ b/crates/dcc-mcp-skills/src/loader/tests/test_scan_and_load_strict.rs
@@ -1,0 +1,73 @@
+//! Tests for the strict scan-and-load pipeline (issue maya#138).
+
+use super::*;
+
+fn write_skill(base: &std::path::Path, name: &str) {
+    let dir = base.join(name);
+    std::fs::create_dir_all(&dir).unwrap();
+    let content = format!("---\nname: {name}\ndcc: python\n---\n# {name}\n\nBody.");
+    std::fs::write(dir.join(SKILL_METADATA_FILE), &content).unwrap();
+}
+
+fn write_broken_skill(base: &std::path::Path, name: &str) {
+    // Directory has a SKILL.md (so the scanner picks it up) but the file
+    // is missing the YAML frontmatter required by `parse_skill_md`, so
+    // `load_all_skills` reports it via the `skipped` channel — which
+    // `scan_and_load_strict` then promotes to an error.
+    let dir = base.join(name);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join(SKILL_METADATA_FILE),
+        "# broken skill\n\nNo YAML frontmatter here.\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn strict_returns_skills_when_no_directories_skipped() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_skill(tmp.path(), "alpha");
+    write_skill(tmp.path(), "beta");
+
+    let result = crate::loader::scan_and_load_strict(
+        Some(&[tmp.path().to_string_lossy().to_string()]),
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(result.skills.len(), 2);
+    assert!(result.skipped.is_empty());
+}
+
+#[test]
+fn strict_errors_on_skipped_directory() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_skill(tmp.path(), "good");
+    write_broken_skill(tmp.path(), "broken");
+
+    let err = crate::loader::scan_and_load_strict(
+        Some(&[tmp.path().to_string_lossy().to_string()]),
+        None,
+    )
+    .unwrap_err();
+
+    match err {
+        crate::resolver::ResolveError::SkippedDirectories { directories } => {
+            assert_eq!(directories.len(), 1, "got: {directories:?}");
+            assert!(directories[0].ends_with("broken"));
+        }
+        other => panic!("expected SkippedDirectories, got {other:?}"),
+    }
+}
+
+#[test]
+fn strict_surface_message_mentions_remediation() {
+    // Display impl must point operators at scan_and_load_lenient so they
+    // know how to opt back into the silent-skip behaviour.
+    let err = crate::resolver::ResolveError::SkippedDirectories {
+        directories: vec!["/tmp/skills/broken".to_string()],
+    };
+    let msg = err.to_string();
+    assert!(msg.contains("scan_and_load_lenient"), "msg={msg}");
+    assert!(msg.contains("/tmp/skills/broken"), "msg={msg}");
+}

--- a/crates/dcc-mcp-skills/src/python/loader.rs
+++ b/crates/dcc-mcp-skills/src/python/loader.rs
@@ -9,7 +9,7 @@ use pyo3_stub_gen_derive::gen_stub_pyfunction;
 use dcc_mcp_models::SkillMetadata;
 
 use crate::loader::{
-    parse_skill_md, scan_and_load, scan_and_load_lenient, scan_and_load_team,
+    parse_skill_md, scan_and_load, scan_and_load_lenient, scan_and_load_strict, scan_and_load_team,
     scan_and_load_team_lenient, scan_and_load_user, scan_and_load_user_lenient,
 };
 
@@ -67,6 +67,23 @@ pub fn py_scan_and_load_lenient(
     dcc_name: Option<&str>,
 ) -> PyResult<(Vec<SkillMetadata>, Vec<String>)> {
     let result = scan_and_load_lenient(extra_paths.as_deref(), dcc_name)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+    Ok((result.skills, result.skipped))
+}
+
+/// Strict pipeline (issue maya#138) — same as [`py_scan_and_load`] but
+/// raises `ValueError` when any directory was silently skipped, so
+/// embedders can fail start-up loudly instead of discovering missing
+/// tools at run-time.
+#[cfg_attr(feature = "stub-gen", gen_stub_pyfunction)]
+#[pyfunction]
+#[pyo3(name = "scan_and_load_strict")]
+#[pyo3(signature = (extra_paths=None, dcc_name=None))]
+pub fn py_scan_and_load_strict(
+    extra_paths: Option<Vec<String>>,
+    dcc_name: Option<&str>,
+) -> PyResult<(Vec<SkillMetadata>, Vec<String>)> {
+    let result = scan_and_load_strict(extra_paths.as_deref(), dcc_name)
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
     Ok((result.skills, result.skipped))
 }

--- a/crates/dcc-mcp-skills/src/resolver.rs
+++ b/crates/dcc-mcp-skills/src/resolver.rs
@@ -28,6 +28,19 @@ pub enum ResolveError {
         /// The cycle path, e.g. `["A", "B", "C", "A"]`.
         cycle: Vec<String>,
     },
+    /// One or more directories matched the scan but failed to produce a
+    /// loadable skill (e.g. no `SKILL.md`, malformed YAML frontmatter,
+    /// missing required field).
+    ///
+    /// Returned exclusively by [`crate::loader::scan_and_load_strict`]
+    /// (issue maya#138) so embedders that prefer fail-fast over the
+    /// silent-skip default can surface the bad directories to operators
+    /// at start-up instead of discovering missing tools at run-time.
+    SkippedDirectories {
+        /// Absolute paths of directories that were skipped during
+        /// [`crate::loader::load_all_skills`].
+        directories: Vec<String>,
+    },
 }
 
 impl std::fmt::Display for ResolveError {
@@ -42,6 +55,16 @@ impl std::fmt::Display for ResolveError {
             }
             Self::CyclicDependency { cycle } => {
                 write!(f, "Circular dependency detected: {}", cycle.join(" → "))
+            }
+            Self::SkippedDirectories { directories } => {
+                write!(
+                    f,
+                    "Strict scan rejected {} directory/directories that failed to load: {}. \
+                     Inspect the SKILL.md files for missing/invalid YAML frontmatter or \
+                     re-run with scan_and_load_lenient to tolerate them.",
+                    directories.len(),
+                    directories.join(", ")
+                )
             }
         }
     }

--- a/crates/dcc-mcp-transport/src/discovery/types.rs
+++ b/crates/dcc-mcp-transport/src/discovery/types.rs
@@ -91,6 +91,21 @@ pub struct ServiceEntry {
     pub transport_address: Option<TransportAddress>,
     /// DCC application version (e.g. "2024.2").
     pub version: Option<String>,
+    /// Adapter package version (e.g. `dcc_mcp_maya = "0.3.0"`).
+    ///
+    /// Recorded on the `__gateway__` sentinel alongside the embedded
+    /// `dcc-mcp-http` crate version so gateway election can compare both
+    /// (issue maya#137).  Plain DCC rows may also set this — agents use it
+    /// to disambiguate two adapter releases serving the same DCC type.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub adapter_version: Option<String>,
+    /// DCC type the adapter is bound to (e.g. `"maya"`).
+    ///
+    /// On the `__gateway__` sentinel this is the host DCC of the gateway
+    /// owner — used as the third tiebreaker so a real-DCC adapter wins
+    /// over a generic standalone server (issue maya#137).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub adapter_dcc: Option<String>,
     /// Currently active scene / document.
     ///
     /// For single-document DCCs (Maya, Blender) this is the open file path.
@@ -154,6 +169,8 @@ impl ServiceEntry {
             port,
             transport_address: None,
             version: None,
+            adapter_version: None,
+            adapter_dcc: None,
             scene: None,
             documents: Vec::new(),
             pid: Some(std::process::id()),
@@ -184,6 +201,8 @@ impl ServiceEntry {
             port,
             transport_address: Some(address),
             version: None,
+            adapter_version: None,
+            adapter_dcc: None,
             scene: None,
             documents: Vec::new(),
             pid: Some(std::process::id()),
@@ -199,6 +218,24 @@ impl ServiceEntry {
     /// Override the owning process PID (useful when registering on behalf of a bridge).
     pub fn with_pid(mut self, pid: u32) -> Self {
         self.pid = Some(pid);
+        self
+    }
+
+    /// Stamp the adapter package version (e.g. `dcc_mcp_maya = "0.3.0"`).
+    ///
+    /// Set on the gateway sentinel so peers can apply the second-tier
+    /// election comparison (issue maya#137).
+    pub fn with_adapter_version(mut self, version: impl Into<String>) -> Self {
+        self.adapter_version = Some(version.into());
+        self
+    }
+
+    /// Stamp the DCC type the adapter is bound to (e.g. `"maya"`).
+    ///
+    /// Drives the third-tier "prefer real DCC over unknown standalone"
+    /// tiebreaker in gateway election (issue maya#137).
+    pub fn with_adapter_dcc(mut self, dcc: impl Into<String>) -> Self {
+        self.adapter_dcc = Some(dcc.into());
         self
     }
 
@@ -278,6 +315,37 @@ mod tests {
     fn test_service_entry_with_pid_override() {
         let entry = ServiceEntry::new("maya", "127.0.0.1", 18812).with_pid(42);
         assert_eq!(entry.pid, Some(42));
+    }
+
+    // Issue maya#137: adapter_version and adapter_dcc must round-trip
+    // through the on-disk JSON and stay absent from the wire format when
+    // unset, preserving the existing services.json shape.
+    #[test]
+    fn test_service_entry_adapter_metadata_roundtrip() {
+        let entry = ServiceEntry::new("__gateway__", "127.0.0.1", 9765)
+            .with_adapter_version("0.3.0")
+            .with_adapter_dcc("maya");
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(json.contains("\"adapter_version\":\"0.3.0\""));
+        assert!(json.contains("\"adapter_dcc\":\"maya\""));
+
+        let parsed: ServiceEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.adapter_version.as_deref(), Some("0.3.0"));
+        assert_eq!(parsed.adapter_dcc.as_deref(), Some("maya"));
+    }
+
+    #[test]
+    fn test_service_entry_adapter_metadata_omitted_when_unset() {
+        let entry = ServiceEntry::new("maya", "127.0.0.1", 18812);
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(
+            !json.contains("\"adapter_version\""),
+            "unset adapter_version must be skipped: {json}"
+        );
+        assert!(
+            !json.contains("\"adapter_dcc\""),
+            "unset adapter_dcc must be skipped: {json}"
+        );
     }
 
     #[test]

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -298,6 +298,55 @@ Each namespaced backend tool also carries `_instance_id`, `_instance_short`, and
 
 The gateway advertises `capabilities.tools.listChanged: true` and polls backends every 3 s; when the aggregated set changes (skill loaded / unloaded anywhere) it broadcasts `notifications/tools/list_changed` to every connected SSE client.
 
+#### `list_dcc_instances` — operator view (issue maya#138)
+
+`list_dcc_instances` returns every parseable row in the registry directory
+(`$TEMP/dcc-mcp-registry/`), regardless of `dcc_type`, and surfaces stale
+sentinels with `status: "stale"` so operators can see why a registration
+is no longer routable instead of having it silently elided.
+
+The response shape is:
+
+```json
+{
+  "total": 3,
+  "stale_count": 1,
+  "instances": [
+    {
+      "instance_id": "a1b2c3d4-…",
+      "dcc_type": "maya",
+      "host": "127.0.0.1",
+      "port": 18812,
+      "mcp_url": "http://127.0.0.1:18812/mcp",
+      "status": "available",
+      "scene": "/proj/shot01.ma",
+      "documents": [],
+      "pid": 1234,
+      "display_name": "Maya-Rigging",
+      "version": "2024",
+      "adapter_version": "0.3.0",
+      "adapter_dcc": "maya",
+      "metadata": {},
+      "stale": false
+    },
+    {
+      "instance_id": "f9e8d7c6-…",
+      "dcc_type": "maya",
+      "host": "127.0.0.1",
+      "port": 18813,
+      "status": "stale",
+      "stale": true,
+      "...": "fields above also present"
+    }
+  ],
+  "tip": "Some rows have status='stale' (no recent heartbeat). …"
+}
+```
+
+Pass `include_stale: false` to hide stale rows for callers that only want
+routable instances; the bookkeeping `__gateway__` sentinel and the
+gateway's own self-row are always filtered.
+
 ### Python example
 
 ```python

--- a/docs/guide/gateway-election.md
+++ b/docs/guide/gateway-election.md
@@ -51,20 +51,46 @@ Maya v0.12.6 (gateway)           Maya v0.12.29 (new)
 
 When a gateway starts, it writes a special entry to the FileRegistry:
 ```json
-{"dcc_type": "__gateway__", "version": "0.12.29"}
+{
+  "dcc_type":        "__gateway__",
+  "version":         "0.14.18",
+  "adapter_version": "0.3.0",
+  "adapter_dcc":     "maya"
+}
 ```
 
-New instances read this to know who the gateway is and what version it runs.
+New instances read this to know who the gateway is, which `dcc-mcp-http`
+crate it embeds, which adapter package shipped that crate, and which DCC
+the adapter is bound to.
 
-**2. Semantic Version Comparison**
+**2. Three-Tier Election Comparison** (issue maya#137)
 
-Versions are compared numerically (not alphabetically):
+The challenger compares its own profile against the resident sentinel in
+this order — each tier is only consulted when the previous tier ties:
+
+| Tier | Field             | Rule                                                                 |
+|------|-------------------|----------------------------------------------------------------------|
+| 1    | `version`         | `dcc-mcp-http` crate semver — newer wins.                            |
+| 2    | `adapter_version` | Adapter package semver — newer wins; `None` is below any value.      |
+| 3    | `adapter_dcc`     | Real DCC (`"maya"`, `"houdini"`…) preempts `None` / `"unknown"`.     |
+
+The third tier resolves the production failure reported in maya#137: a
+generic standalone `dcc-mcp-server` pinned to a newer crate could keep
+the gateway forever, so the freshly-installed Maya plugin never got to
+serve its own tools. With the tiebreaker the Maya adapter wins at equal
+crate + adapter versions, while two real DCCs at identical versions
+remain tied (the existing first-wins port-bind contract takes over).
+
 ```
-0.12.6  vs  0.12.29
-↓              ↓
-[0, 12, 6]  [0, 12, 29]
-                 29 > 6 → v0.12.29 is newer ✓
+0.14.18  vs  0.14.18
+adapter 0.3.0 vs adapter 0.3.0
+adapter_dcc "maya" vs "unknown" → maya wins ✓
 ```
+
+Versions are still parsed numerically (`"2024"` from a Maya host version
+field would otherwise look newer than the `0.14.18` crate version — see
+issue #228 — so only the `__gateway__` sentinel row contributes to the
+self-yield decision).
 
 **3. Voluntary Yield**
 
@@ -73,6 +99,34 @@ The cleanup task (every 15s) checks for newer challengers. If found, it shuts do
 **4. Challenger Retry Loop**
 
 New instances poll the port every 10s for up to 120s. As soon as the port is free, they take over.
+
+### Stamping the Sentinel
+
+`McpHttpConfig` exposes the two new fields so adapters can declare them
+when wiring up the server:
+
+```rust
+let cfg = McpHttpConfig::new("maya", 18812)
+    .with_gateway(9765)
+    .with_adapter_version(env!("CARGO_PKG_VERSION"))
+    .with_adapter_dcc("maya");
+```
+
+In Python:
+
+```python
+McpHttpConfig(
+    dcc_type="maya",
+    port=18812,
+    gateway_port=9765,
+    adapter_version="0.3.0",
+    adapter_dcc="maya",
+)
+```
+
+Both fields are optional; leaving them `None` reproduces the legacy
+crate-version-only comparison and is treated as the lowest tier in the
+new election.
 
 ## Multi-Instance Registration
 

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -218,6 +218,7 @@ from dcc_mcp_core import (
     scan_skill_paths,
     scan_and_load,
     scan_and_load_lenient,
+    scan_and_load_strict,
 )
 
 os.environ["DCC_MCP_SKILL_PATHS"] = "/path/to/skills"
@@ -225,6 +226,32 @@ os.environ["DCC_MCP_SKILL_PATHS"] = "/path/to/skills"
 # One-shot scan + load + dependency sort → returns (skills, skipped_dirs)
 skills, skipped = scan_and_load(extra_paths=["/my/skills"], dcc_name="maya")
 skills_lenient, skipped = scan_and_load_lenient(dcc_name="maya")  # skip errors
+
+# Strict variant (issue maya#138): raises ValueError when any directory
+# was silently skipped, so embedders can fail start-up loudly instead of
+# discovering the missing tools at run-time. The exception message lists
+# every offending directory and points at scan_and_load_lenient as the
+# opt-out for installations that genuinely want the silent-skip default.
+try:
+    skills, _ = scan_and_load_strict(dcc_name="maya")
+except ValueError as exc:
+    # Wire this into your DCC plugin's start-up error reporting.
+    raise SystemExit(f"Refusing to start: {exc}") from exc
+```
+
+::: tip Choosing the right entry point
+- `scan_and_load` — default; logs a `warn`-level summary for every skipped
+  directory (issue maya#138) and a per-failure `warn` from
+  `parse_skill_md`. Good for production where missing skills should be
+  visible in logs but not block start-up.
+- `scan_and_load_lenient` — same return shape but tolerates resolver
+  errors (missing dependency, dependency cycle).
+- `scan_and_load_strict` — fails fast when the scanner skipped any
+  directory. Use in CI / packaged adapter releases where a malformed
+  `SKILL.md` should be a blocking error rather than a silent omission.
+:::
+
+```python
 
 # Scan directories for SKILL.md files
 scanner = SkillScanner()

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -217,6 +217,7 @@ from dcc_mcp_core._core import register_bridge
 from dcc_mcp_core._core import resolve_dependencies
 from dcc_mcp_core._core import scan_and_load
 from dcc_mcp_core._core import scan_and_load_lenient
+from dcc_mcp_core._core import scan_and_load_strict
 from dcc_mcp_core._core import scan_and_load_team
 from dcc_mcp_core._core import scan_and_load_team_lenient
 from dcc_mcp_core._core import scan_and_load_user
@@ -696,6 +697,7 @@ __all__ = [
     "save_checkpoint",
     "scan_and_load",
     "scan_and_load_lenient",
+    "scan_and_load_strict",
     "scan_and_load_team",
     "scan_and_load_team_lenient",
     "scan_and_load_user",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,7 @@ fn register_skills(m: &Bound<'_, PyModule>) -> PyResult<()> {
         dcc_mcp_skills::py_expand_transitive_dependencies,
         dcc_mcp_skills::py_scan_and_load,
         dcc_mcp_skills::py_scan_and_load_lenient,
+        dcc_mcp_skills::py_scan_and_load_strict,
         dcc_mcp_skills::py_scan_and_load_user,
         dcc_mcp_skills::py_scan_and_load_team,
         dcc_mcp_skills::py_scan_and_load_user_lenient,


### PR DESCRIPTION
Addresses two production issues reported against the Maya adapter, both rooted in `dcc-mcp-core`:

* loonghao/dcc-mcp-maya#137 — gateway election keeps a generic standalone server pinned to a newer crate version, so a freshly-installed Maya plugin never gets to serve its own tools.
* loonghao/dcc-mcp-maya#138 — `list_dcc_instances` silently drops stale / unknown / shutting-down rows, hiding the very registrations operators need to diagnose, and the skill scanner elides broken `SKILL.md` directories at `debug` level.

## Summary of changes

### 1. Gateway election — three-tier comparison (maya#137)

- `ServiceEntry` gains optional `adapter_version` and `adapter_dcc` fields (skipped from the wire format when unset → backwards compatible).
- `__gateway__` sentinel is now stamped with both fields by `runner.rs::run_election` and `spawn_challenger_loop`.
- `gateway::version::is_newer_election` layers the comparison:
  1. `dcc-mcp-http` crate version
  2. adapter package version (`None` is below any concrete value)
  3. real-DCC tiebreaker — `None` / `"unknown"` loses to any real DCC.
- `has_newer_sentinel` now takes an `ElectionInfo` so the cleanup-loop self-yield decision uses the same three-tier logic.
- `McpHttpConfig` and `GatewayConfig` expose the new fields; `McpHttpConfig` ships `with_adapter_version` / `with_adapter_dcc` builders. The standalone server passes its `--dcc` value (when set) as `adapter_dcc` so it stays in the right tier.
- Tests cover all three tiers + the maya#137 reproduction (real DCC preempts unknown standalone at equal versions; two real DCCs at identical versions remain tied so the existing first-wins port-bind contract takes over).

### 2. `list_dcc_instances` — stale-aware operator view (maya#138)

- New `GatewayState::all_instances` returns every parseable row, dropping only the bookkeeping `__gateway__` sentinel and the gateway's own self-row.
- `tool_list_instances` switches to it so stale, shutting-down, and `unknown` rows are no longer silently elided.
- `entry_to_json` reports `status: "stale"` (and keeps `stale: true`) for rows past `stale_timeout`, plus surfaces `adapter_version` / `adapter_dcc`.
- New `include_stale` argument (default `true`) lets callers opt back into the routable-only view; tool-schema description updated accordingly.
- Response gains a `stale_count` field and a context-aware `tip` to nudge operators toward `connect_to_dcc`.

### 3. Skill scanner — warn on skip + strict mode (maya#138)

- `load_all_skills` promotes the per-skipped-directory log from `debug` to `warn` with a structured `directory=` field, so missing skills become visible in operator logs.
- New `scan_and_load_strict` (Rust + Python) errors via `ResolveError::SkippedDirectories { directories }` when any directory was skipped — useful in CI / packaged adapter releases where a malformed `SKILL.md` should be a blocking error rather than a silent omission.
- Re-exported from `dcc_mcp_skills::loader`, the top-level Rust crate, and registered as a Python `pyo3` function (`dcc_mcp_core.scan_and_load_strict`).

## Tests

- `cargo test --workspace` — all targets pass (1000+ tests).
- `pytest tests/` — 8562 passed / 92 skipped / 0 failed.
- `vx cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `ruff check` — clean.

New tests:
- `gateway::tests` — three-tier election + maya#137 sentinel preemption regressions.
- `gateway::state::tests::test_all_instances_keeps_stale_and_unknown` and `test_entry_to_json_status_stale_for_aged_row`.
- `loader::tests::test_scan_and_load_strict::*` — strict success / strict error / Display message remediation.
- `discovery::types::tests::test_service_entry_adapter_metadata_*` — round-trip + omit-when-unset.

## Documentation

- `docs/guide/gateway-election.md` — three-tier comparison table + sentinel JSON shape + `with_adapter_*` builder examples (Rust + Python).
- `docs/api/http.md` — full `list_dcc_instances` response shape with stale rows and `include_stale`.
- `docs/guide/skills.md` — `scan_and_load_strict` example + decision tip on choosing the right entry point.
- `AGENTS.md` decision table — added the two new APIs.

## Backwards compatibility

- All new sentinel fields are `Option<String>` with `serde(skip_serializing_if = Option::is_none)` — older readers see the same JSON shape they did before.
- `live_instances` behaviour is unchanged; only the operator-facing `list_dcc_instances` switches to `all_instances`. Programmatic callers that already filtered on `status` keep working — they additionally see `"stale"` as a possible value.
- `scan_and_load` and `scan_and_load_lenient` keep their existing semantics; `scan_and_load_strict` is purely additive.

Branch will be rebased onto the latest `main` before merge to keep history linear (per `AGENTS.md`).