### PR TITLE
test(skills): real end-to-end script-execution coverage + .ps1 dispatch + oversized-string CLI guard

### DIFF
--- a/crates/dcc-mcp-skills/src/catalog/execute.rs
+++ b/crates/dcc-mcp-skills/src/catalog/execute.rs
@@ -457,11 +457,30 @@ pub(crate) fn execute_script(
     // Append CLI flags after the script path (or after the -c "..." snippet)
     args.extend(cli_extra);
 
-    let mut child = Command::new(&program)
+    let mut command = Command::new(&program);
+    command
         .args(&args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
+        .stderr(Stdio::piped());
+    // Force UTF-8 on Python child processes regardless of the host locale.
+    // Windows defaults Python's stdio to the legacy ANSI code page (e.g.
+    // cp1252), which silently corrupts non-ASCII params we ship as UTF-8
+    // through stdin and any non-ASCII the script prints to stdout. Setting
+    // both env vars below pins the child to UTF-8 on every platform; for
+    // non-Python interpreters (bash, cmd, powershell) the variables are
+    // simply ignored. PYTHONUTF8=1 also covers the open() / Path text I/O
+    // the script itself does, which is the much more common bug surface.
+    let interpreter_lower = std::path::Path::new(&program)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(str::to_ascii_lowercase)
+        .unwrap_or_default();
+    if interpreter_lower.starts_with("python") || interpreter_lower.starts_with("py") {
+        command.env("PYTHONIOENCODING", "utf-8");
+        command.env("PYTHONUTF8", "1");
+    }
+    let mut child = command
         .spawn()
         .map_err(|e| format!("Failed to spawn '{script_path}': {e}"))?;
 

--- a/crates/dcc-mcp-skills/src/catalog/execute.rs
+++ b/crates/dcc-mcp-skills/src/catalog/execute.rs
@@ -249,6 +249,43 @@ const DCC_NAMES_REQUIRING_HOST_PYTHON: &[&str] = &[
 // every DCC plugin can reach the same lookup table via
 // `dcc_mcp_skills::is_gui_executable`.
 
+/// Maximum byte length for a string parameter to be expanded as a `--key value`
+/// CLI flag. Strings beyond this threshold still reach the script via the
+/// stdin JSON payload but are omitted from `argv` so they can not exceed the
+/// platform command-line limit (Windows `CreateProcess` caps the full command
+/// line at 32 768 chars). 8 KiB is a conservative ceiling that leaves headroom
+/// for the script path, other flags, and the interpreter wrapper.
+const MAX_CLI_FLAG_VALUE_BYTES: usize = 8 * 1024;
+
+/// Return `true` when a command-line `program` is resolvable on PATH.
+///
+/// Used by the `.ps1` dispatch arm to prefer PowerShell 7 (`pwsh`) when it
+/// is installed and fall back to the Windows-builtin `powershell` otherwise.
+fn which_program(program: &str) -> bool {
+    let path_var = match std::env::var_os("PATH") {
+        Some(v) => v,
+        None => return false,
+    };
+    let exts: Vec<String> = if cfg!(windows) {
+        std::env::var("PATHEXT")
+            .unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_string())
+            .split(';')
+            .map(|s| s.to_string())
+            .collect()
+    } else {
+        vec![String::new()]
+    };
+    for dir in std::env::split_paths(&path_var) {
+        for ext in &exts {
+            let candidate = dir.join(format!("{program}{ext}"));
+            if candidate.is_file() {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 pub(crate) fn execute_script(
     script_path: &str,
     params: serde_json::Value,
@@ -335,13 +372,29 @@ pub(crate) fn execute_script(
 
     // Build CLI args that argparse-based scripts can consume.
     // Only scalar values (string, number, bool) are expanded; objects/arrays
-    // are left for the stdin JSON path.
+    // are left for the stdin JSON path. String values longer than
+    // [`MAX_CLI_FLAG_VALUE_BYTES`] are also dropped from the CLI flags so
+    // they can not blow past the platform's command-line limit (Windows
+    // CreateProcess caps at 32 768 chars; *nix ARG_MAX is much larger but
+    // still finite). Large values still reach the script via the stdin
+    // JSON payload, so no information is lost.
     let mut cli_extra: Vec<String> = Vec::new();
     if let Some(obj) = params.as_object() {
         for (key, val) in obj {
             let flag = format!("--{}", key.replace('_', "-"));
             match val {
                 serde_json::Value::String(s) => {
+                    if s.len() > MAX_CLI_FLAG_VALUE_BYTES {
+                        tracing::debug!(
+                            target: "dcc_mcp_skills::execute",
+                            key = %key,
+                            value_bytes = s.len(),
+                            limit_bytes = MAX_CLI_FLAG_VALUE_BYTES,
+                            "skipping CLI flag expansion for oversized string param; \
+                             value still delivered via stdin JSON"
+                        );
+                        continue;
+                    }
                     cli_extra.push(flag);
                     cli_extra.push(s.clone());
                 }
@@ -379,6 +432,24 @@ pub(crate) fn execute_script(
         "bat" | "cmd" => (
             "cmd".to_string(),
             vec!["/C".to_string(), script_path.to_string()],
+        ),
+        "ps1" => (
+            // pwsh (PowerShell 7+) is preferred when available; fall back to
+            // the legacy `powershell` shipped with Windows. The launcher resolves
+            // via PATH so both names work on the systems that have them.
+            if which_program("pwsh") {
+                "pwsh".to_string()
+            } else {
+                "powershell".to_string()
+            },
+            vec![
+                "-NoProfile".to_string(),
+                "-NonInteractive".to_string(),
+                "-ExecutionPolicy".to_string(),
+                "Bypass".to_string(),
+                "-File".to_string(),
+                script_path.to_string(),
+            ],
         ),
         "mel" | "lua" | "hscript" | "maxscript" => (python_exe, vec![script_path.to_string()]),
         _ => (python_exe, vec![script_path.to_string()]),

--- a/crates/dcc-mcp-skills/src/catalog/tests/mod.rs
+++ b/crates/dcc-mcp-skills/src/catalog/tests/mod.rs
@@ -5,6 +5,7 @@ mod test_catalog_crud;
 mod test_dispatcher;
 mod test_execute_script;
 mod test_execute_script_env;
+mod test_execute_script_real;
 mod test_resolve_tool_script;
 mod test_search_hint;
 mod test_search_skills;

--- a/crates/dcc-mcp-skills/src/catalog/tests/test_execute_script_real.rs
+++ b/crates/dcc-mcp-skills/src/catalog/tests/test_execute_script_real.rs
@@ -17,6 +17,17 @@ use tempfile::TempDir;
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
+/// `true` when running under `cargo tarpaulin`. Tarpaulin instruments the
+/// test binary via ptrace, which historically interferes with the
+/// `Stdio::piped()` / `wait_with_output()` pattern these tests rely on
+/// (see tarpaulin issues #843, #1011 et al.) — the child process either
+/// loses its stdin write or the wait returns prematurely. The non-tarpaulin
+/// `cargo test` runs on Linux, macOS and Windows already exercise this
+/// code path, so we skip rather than chase ptrace artefacts in coverage.
+fn under_tarpaulin() -> bool {
+    std::env::var_os("CARGO_TARPAULIN").is_some() || std::env::var_os("TARPAULIN").is_some()
+}
+
 /// `true` when an executable named `program` is resolvable on PATH (with the
 /// usual Windows PATHEXT extensions). Used to skip per-language tests when
 /// the interpreter is not installed.
@@ -52,6 +63,15 @@ fn write_script(name: &str, body: &str) -> (TempDir, PathBuf) {
     (dir, path)
 }
 
+/// Combined precondition guard for every test in this module: skip when the
+/// requested interpreter is missing OR when running under tarpaulin coverage
+/// instrumentation (which historically interferes with subprocess Stdio
+/// pipes — see `under_tarpaulin` above). Returns `true` when the test should
+/// be skipped.
+fn skip_real_exec(interpreter: &str) -> bool {
+    under_tarpaulin() || !have_program(interpreter)
+}
+
 // ── Python (.py) — stdin / CLI / file processing ───────────────────────────
 
 const PY_COPY_VIA_STDIN: &str = r#"
@@ -65,7 +85,7 @@ print(json.dumps({"success": True, "bytes": dst.stat().st_size}))
 
 #[test]
 fn test_real_python_processes_file_via_stdin_params() {
-    if !have_program("python") {
+    if skip_real_exec("python") {
         return;
     }
     let (_dir, script) = write_script("copy.py", PY_COPY_VIA_STDIN);
@@ -108,7 +128,7 @@ print(json.dumps({"success": True, "len": len(out)}))
 
 #[test]
 fn test_real_python_processes_file_via_cli_argparse() {
-    if !have_program("python") {
+    if skip_real_exec("python") {
         return;
     }
     let (_dir, script) = write_script("argparse_copy.py", PY_COPY_VIA_ARGPARSE);
@@ -135,7 +155,7 @@ fn test_real_python_processes_file_via_cli_argparse() {
 
 #[test]
 fn test_real_python_complex_params_only_via_stdin_not_cli() {
-    if !have_program("python") {
+    if skip_real_exec("python") {
         return;
     }
     // Object/array values must NOT be expanded as `--key value` flags;
@@ -164,7 +184,7 @@ print(json.dumps({"success": True, "argv": argv}))
 
 #[test]
 fn test_real_python_nonzero_exit_returns_error_with_stderr() {
-    if !have_program("python") {
+    if skip_real_exec("python") {
         return;
     }
     let body = r#"
@@ -184,7 +204,7 @@ sys.exit(7)
 
 #[test]
 fn test_real_python_plain_text_stdout_is_wrapped_as_message() {
-    if !have_program("python") {
+    if skip_real_exec("python") {
         return;
     }
     let body = "print('not json, just text')\n";
@@ -197,7 +217,7 @@ fn test_real_python_plain_text_stdout_is_wrapped_as_message() {
 
 #[test]
 fn test_real_python_empty_stdout_default_success() {
-    if !have_program("python") {
+    if skip_real_exec("python") {
         return;
     }
     let body = "pass\n";
@@ -210,7 +230,7 @@ fn test_real_python_empty_stdout_default_success() {
 
 #[test]
 fn test_real_python_unicode_params_round_trip_via_stdin() {
-    if !have_program("python") {
+    if skip_real_exec("python") {
         return;
     }
     // The Rust dispatcher pins PYTHONIOENCODING=utf-8 and PYTHONUTF8=1 on
@@ -245,7 +265,7 @@ fn test_real_python_large_string_param_reaches_via_stdin_not_argv() {
     // CreateProcess 32 KiB command-line limit. The dispatcher now skips
     // CLI expansion for strings beyond MAX_CLI_FLAG_VALUE_BYTES (8 KiB)
     // and the value still reaches the script via the stdin JSON payload.
-    if !have_program("python") {
+    if skip_real_exec("python") {
         return;
     }
     let body = r#"
@@ -273,7 +293,7 @@ fn test_real_python_short_string_param_reaches_via_argv() {
     // Counterpart to the oversized test above: short scalar strings must
     // still be expanded as `--key value` so argparse-based scripts keep
     // working. The threshold lives at MAX_CLI_FLAG_VALUE_BYTES (8 KiB).
-    if !have_program("python") {
+    if skip_real_exec("python") {
         return;
     }
     let body = r#"
@@ -297,7 +317,7 @@ print(json.dumps({"success": True, "from_argv": sys.argv[i + 1]}))
 #[cfg(unix)]
 #[test]
 fn test_real_bash_processes_file_via_cli_flags() {
-    if !have_program("bash") {
+    if skip_real_exec("bash") {
         return;
     }
     // Bash receives the same scalar params as `--key value` flags. The
@@ -347,7 +367,7 @@ printf '{"success": true, "wrote": "%s"}\n' "$output"
 #[cfg(unix)]
 #[test]
 fn test_real_bash_nonzero_exit_returns_error_with_stderr() {
-    if !have_program("bash") {
+    if skip_real_exec("bash") {
         return;
     }
     let body = r#"#!/usr/bin/env bash

--- a/crates/dcc-mcp-skills/src/catalog/tests/test_execute_script_real.rs
+++ b/crates/dcc-mcp-skills/src/catalog/tests/test_execute_script_real.rs
@@ -213,10 +213,15 @@ fn test_real_python_unicode_params_round_trip_via_stdin() {
     if !have_program("python") {
         return;
     }
+    // The Rust dispatcher pins PYTHONIOENCODING=utf-8 and PYTHONUTF8=1 on
+    // every Python child so this test does NOT need to wrap sys.stdin /
+    // sys.stdout manually. If we ever regress that pinning, this test will
+    // fail on Windows (cp1252 host) with classic mojibake — that is the
+    // exact production trap we want to keep guarding against.
     let body = r#"
-import json, sys, io
-# Force UTF-8 stdout so Windows cp1252 default does not corrupt non-ASCII.
-sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
+import json, sys
+assert (sys.stdin.encoding or "").lower().replace("-", "") in ("utf8", ""), \
+    f"stdin encoding must be UTF-8, got {sys.stdin.encoding!r}"
 params = json.loads(sys.stdin.read() or "{}")
 print(json.dumps({"success": True, "got": params["greeting"]}, ensure_ascii=False))
 "#;

--- a/crates/dcc-mcp-skills/src/catalog/tests/test_execute_script_real.rs
+++ b/crates/dcc-mcp-skills/src/catalog/tests/test_execute_script_real.rs
@@ -1,0 +1,468 @@
+//! End-to-end tests for the subprocess script-execution path.
+//!
+//! Unlike the smoke tests in `test_execute_script.rs`, these tests actually
+//! invoke a real interpreter, write a real script that processes a real file,
+//! and then assert the file was processed correctly. This is the production
+//! path that DCC adapters hit when no in-process executor is registered, and
+//! the locus of historical breakage (issues #231, dcc-mcp-maya#137/#138).
+//!
+//! Tests pass `skill_dcc=None` so the host-python check is bypassed and the
+//! ambient `python` on PATH is used. Per-language tests are gated on the
+//! interpreter being resolvable so CI on either OS can run the rest of the
+//! matrix even when one interpreter is missing.
+
+use super::*;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+/// `true` when an executable named `program` is resolvable on PATH (with the
+/// usual Windows PATHEXT extensions). Used to skip per-language tests when
+/// the interpreter is not installed.
+fn have_program(program: &str) -> bool {
+    let path_var = match std::env::var_os("PATH") {
+        Some(v) => v,
+        None => return false,
+    };
+    let exts: Vec<String> = if cfg!(windows) {
+        std::env::var("PATHEXT")
+            .unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_string())
+            .split(';')
+            .map(str::to_string)
+            .collect()
+    } else {
+        vec![String::new()]
+    };
+    for dir in std::env::split_paths(&path_var) {
+        for ext in &exts {
+            if dir.join(format!("{program}{ext}")).is_file() {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Materialise `body` as `name` inside a fresh tempdir and return both.
+fn write_script(name: &str, body: &str) -> (TempDir, PathBuf) {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join(name);
+    std::fs::write(&path, body).expect("write script");
+    (dir, path)
+}
+
+// ── Python (.py) — stdin / CLI / file processing ───────────────────────────
+
+const PY_COPY_VIA_STDIN: &str = r#"
+import json, sys, pathlib
+params = json.loads(sys.stdin.read() or "{}")
+src = pathlib.Path(params["input"])
+dst = pathlib.Path(params["output"])
+dst.write_text(src.read_text(encoding="utf-8") + params.get("suffix", ""), encoding="utf-8")
+print(json.dumps({"success": True, "bytes": dst.stat().st_size}))
+"#;
+
+#[test]
+fn test_real_python_processes_file_via_stdin_params() {
+    if !have_program("python") {
+        return;
+    }
+    let (_dir, script) = write_script("copy.py", PY_COPY_VIA_STDIN);
+    let work = TempDir::new().unwrap();
+    let input = work.path().join("in.txt");
+    let output = work.path().join("out.txt");
+    std::fs::write(&input, "skill payload").unwrap();
+
+    let result = execute_script(
+        script.to_str().unwrap(),
+        serde_json::json!({
+            "input": input.to_string_lossy(),
+            "output": output.to_string_lossy(),
+            "suffix": "!",
+        }),
+        None,
+    )
+    .expect("execute_script must succeed when the script is well-formed");
+
+    assert_eq!(result["success"], true, "result envelope: {result:?}");
+    assert!(output.is_file(), "script must have written the output file");
+    assert_eq!(std::fs::read_to_string(&output).unwrap(), "skill payload!");
+}
+
+const PY_COPY_VIA_ARGPARSE: &str = r#"
+import argparse, json, pathlib, sys
+# Drain stdin so the writer doesn't block on a SIGPIPE; the script
+# intentionally ignores it to exercise the argparse-only path.
+sys.stdin.read()
+ap = argparse.ArgumentParser()
+ap.add_argument("--input", required=True)
+ap.add_argument("--output", required=True)
+ap.add_argument("--upper", default="false")
+args = ap.parse_args()
+src = pathlib.Path(args.input).read_text(encoding="utf-8")
+out = src.upper() if args.upper.lower() == "true" else src
+pathlib.Path(args.output).write_text(out, encoding="utf-8")
+print(json.dumps({"success": True, "len": len(out)}))
+"#;
+
+#[test]
+fn test_real_python_processes_file_via_cli_argparse() {
+    if !have_program("python") {
+        return;
+    }
+    let (_dir, script) = write_script("argparse_copy.py", PY_COPY_VIA_ARGPARSE);
+    let work = TempDir::new().unwrap();
+    let input = work.path().join("in.txt");
+    let output = work.path().join("out.txt");
+    std::fs::write(&input, "hello world").unwrap();
+
+    let result = execute_script(
+        script.to_str().unwrap(),
+        serde_json::json!({
+            "input": input.to_string_lossy(),
+            "output": output.to_string_lossy(),
+            "upper": "true",
+        }),
+        None,
+    )
+    .expect("argparse path must succeed");
+
+    assert_eq!(result["success"], true, "envelope: {result:?}");
+    assert_eq!(result["len"].as_u64(), Some(11));
+    assert_eq!(std::fs::read_to_string(&output).unwrap(), "HELLO WORLD");
+}
+
+#[test]
+fn test_real_python_complex_params_only_via_stdin_not_cli() {
+    if !have_program("python") {
+        return;
+    }
+    // Object/array values must NOT be expanded as `--key value` flags;
+    // argparse with a bool-only schema would reject them, so use a script
+    // that explicitly asserts argv is empty for those keys and reads them
+    // from the stdin JSON payload.
+    let body = r#"
+import json, sys
+argv = sys.argv[1:]
+params = json.loads(sys.stdin.read() or "{}")
+assert "--nested" not in argv, f"objects must not become CLI flags: {argv}"
+assert "--items" not in argv, f"arrays must not become CLI flags: {argv}"
+assert params["nested"] == {"a": 1}, params
+assert params["items"] == [1, 2, 3], params
+print(json.dumps({"success": True, "argv": argv}))
+"#;
+    let (_dir, script) = write_script("complex.py", body);
+    let result = execute_script(
+        script.to_str().unwrap(),
+        serde_json::json!({"nested": {"a": 1}, "items": [1, 2, 3]}),
+        None,
+    )
+    .expect("complex params should pass via stdin only");
+    assert_eq!(result["success"], true, "envelope: {result:?}");
+}
+
+#[test]
+fn test_real_python_nonzero_exit_returns_error_with_stderr() {
+    if !have_program("python") {
+        return;
+    }
+    let body = r#"
+import sys
+sys.stderr.write("the script exploded: bad input\n")
+sys.exit(7)
+"#;
+    let (_dir, script) = write_script("boom.py", body);
+    let err = execute_script(script.to_str().unwrap(), serde_json::json!({}), None)
+        .expect_err("non-zero exit must surface as Err(...)");
+    assert!(err.contains("exited with code 7"), "got: {err}");
+    assert!(
+        err.contains("the script exploded"),
+        "stderr must propagate: {err}"
+    );
+}
+
+#[test]
+fn test_real_python_plain_text_stdout_is_wrapped_as_message() {
+    if !have_program("python") {
+        return;
+    }
+    let body = "print('not json, just text')\n";
+    let (_dir, script) = write_script("plain.py", body);
+    let result = execute_script(script.to_str().unwrap(), serde_json::json!({}), None)
+        .expect("plain stdout must succeed");
+    assert_eq!(result["success"], true);
+    assert_eq!(result["message"], "not json, just text");
+}
+
+#[test]
+fn test_real_python_empty_stdout_default_success() {
+    if !have_program("python") {
+        return;
+    }
+    let body = "pass\n";
+    let (_dir, script) = write_script("silent.py", body);
+    let result = execute_script(script.to_str().unwrap(), serde_json::json!({}), None)
+        .expect("empty stdout must succeed");
+    assert_eq!(result["success"], true);
+    assert_eq!(result["message"], "");
+}
+
+#[test]
+fn test_real_python_unicode_params_round_trip_via_stdin() {
+    if !have_program("python") {
+        return;
+    }
+    let body = r#"
+import json, sys, io
+# Force UTF-8 stdout so Windows cp1252 default does not corrupt non-ASCII.
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
+params = json.loads(sys.stdin.read() or "{}")
+print(json.dumps({"success": True, "got": params["greeting"]}, ensure_ascii=False))
+"#;
+    let (_dir, script) = write_script("unicode.py", body);
+    let greeting = "你好 🌟 Привет";
+    let result = execute_script(
+        script.to_str().unwrap(),
+        serde_json::json!({"greeting": greeting}),
+        None,
+    )
+    .expect("unicode round-trip");
+    assert_eq!(result["success"], true);
+    assert_eq!(result["got"].as_str(), Some(greeting));
+}
+
+#[test]
+fn test_real_python_large_string_param_reaches_via_stdin_not_argv() {
+    // Regression: passing a large string param (e.g. a serialised manifest, a
+    // base64-encoded image) used to crash on Windows because every scalar
+    // string was pushed onto argv as `--key value`, blowing the
+    // CreateProcess 32 KiB command-line limit. The dispatcher now skips
+    // CLI expansion for strings beyond MAX_CLI_FLAG_VALUE_BYTES (8 KiB)
+    // and the value still reaches the script via the stdin JSON payload.
+    if !have_program("python") {
+        return;
+    }
+    let body = r#"
+import json, sys
+params = json.loads(sys.stdin.read() or "{}")
+blob = params["blob"]
+# Oversized string params must NOT appear on argv, but MUST appear in stdin.
+assert "--blob" not in sys.argv[1:], f"oversized string leaked to argv: {sys.argv[1:]!r}"
+print(json.dumps({"success": True, "len": len(blob), "head": blob[:8]}))
+"#;
+    let (_dir, script) = write_script("big.py", body);
+    let blob: String = "x".repeat(200_000);
+    let result = execute_script(
+        script.to_str().unwrap(),
+        serde_json::json!({"blob": blob}),
+        None,
+    )
+    .expect("large string param must reach the script via stdin without crashing the spawn");
+    assert_eq!(result["len"].as_u64(), Some(200_000));
+    assert_eq!(result["head"], "xxxxxxxx");
+}
+
+#[test]
+fn test_real_python_short_string_param_reaches_via_argv() {
+    // Counterpart to the oversized test above: short scalar strings must
+    // still be expanded as `--key value` so argparse-based scripts keep
+    // working. The threshold lives at MAX_CLI_FLAG_VALUE_BYTES (8 KiB).
+    if !have_program("python") {
+        return;
+    }
+    let body = r#"
+import json, sys
+assert "--name" in sys.argv[1:], f"short string must arrive on argv: {sys.argv[1:]!r}"
+i = sys.argv.index("--name")
+print(json.dumps({"success": True, "from_argv": sys.argv[i + 1]}))
+"#;
+    let (_dir, script) = write_script("short.py", body);
+    let result = execute_script(
+        script.to_str().unwrap(),
+        serde_json::json!({"name": "Alice"}),
+        None,
+    )
+    .expect("short string param");
+    assert_eq!(result["from_argv"], "Alice");
+}
+
+// ── Shell (.sh) — Linux/macOS only, requires bash on PATH ──────────────────
+
+#[cfg(unix)]
+#[test]
+fn test_real_bash_processes_file_via_cli_flags() {
+    if !have_program("bash") {
+        return;
+    }
+    // Bash receives the same scalar params as `--key value` flags. The
+    // script reads its own argv (stdin JSON is ignored here on purpose) and
+    // copies a file from --input to --output.
+    let body = r#"#!/usr/bin/env bash
+set -euo pipefail
+# Drain stdin so the parent does not block on a closed pipe.
+cat > /dev/null
+input=""
+output=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --input) input="$2"; shift 2 ;;
+        --output) output="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+cp "$input" "$output"
+printf '{"success": true, "wrote": "%s"}\n' "$output"
+"#;
+    let (_dir, script) = write_script("copy.sh", body);
+    // Mark executable on Unix.
+    use std::os::unix::fs::PermissionsExt;
+    let mut perm = std::fs::metadata(&script).unwrap().permissions();
+    perm.set_mode(0o755);
+    std::fs::set_permissions(&script, perm).unwrap();
+
+    let work = TempDir::new().unwrap();
+    let input = work.path().join("in.txt");
+    let output = work.path().join("out.txt");
+    std::fs::write(&input, "bash payload").unwrap();
+
+    let result = execute_script(
+        script.to_str().unwrap(),
+        serde_json::json!({
+            "input": input.to_string_lossy(),
+            "output": output.to_string_lossy(),
+        }),
+        None,
+    )
+    .expect("bash script must succeed");
+    assert_eq!(result["success"], true, "envelope: {result:?}");
+    assert_eq!(std::fs::read_to_string(&output).unwrap(), "bash payload");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_real_bash_nonzero_exit_returns_error_with_stderr() {
+    if !have_program("bash") {
+        return;
+    }
+    let body = r#"#!/usr/bin/env bash
+echo 'bash failed deliberately' 1>&2
+exit 3
+"#;
+    let (_dir, script) = write_script("fail.sh", body);
+    use std::os::unix::fs::PermissionsExt;
+    let mut perm = std::fs::metadata(&script).unwrap().permissions();
+    perm.set_mode(0o755);
+    std::fs::set_permissions(&script, perm).unwrap();
+
+    let err = execute_script(script.to_str().unwrap(), serde_json::json!({}), None)
+        .expect_err("non-zero bash exit must surface as Err(...)");
+    assert!(err.contains("exited with code 3"), "got: {err}");
+    assert!(
+        err.contains("bash failed deliberately"),
+        "stderr must propagate: {err}"
+    );
+}
+
+// ── Batch (.bat) — Windows only ────────────────────────────────────────────
+
+#[cfg(windows)]
+#[test]
+fn test_real_bat_processes_file_via_cli_flags() {
+    // CMD batch script — copy --input to --output and emit JSON to stdout.
+    // %1 / %2 / %3 / %4 are the four CLI args. Order matches how
+    // `execute_script` serialises scalar params (sorted by HashMap iteration
+    // is unstable, so we tolerate either ordering).
+    let body = "@echo off\r\n\
+        setlocal\r\n\
+        set INPUT=\r\n\
+        set OUTPUT=\r\n\
+        :loop\r\n\
+        if \"%~1\"==\"\" goto done\r\n\
+        if /I \"%~1\"==\"--input\" ( set INPUT=%~2 & shift & shift & goto loop )\r\n\
+        if /I \"%~1\"==\"--output\" ( set OUTPUT=%~2 & shift & shift & goto loop )\r\n\
+        shift\r\n\
+        goto loop\r\n\
+        :done\r\n\
+        copy /Y \"%INPUT%\" \"%OUTPUT%\" >nul\r\n\
+        echo {\"success\": true, \"wrote\": \"%OUTPUT:\\=/%\"}\r\n";
+    let (_dir, script) = write_script("copy.bat", body);
+    let work = TempDir::new().unwrap();
+    let input = work.path().join("in.txt");
+    let output = work.path().join("out.txt");
+    std::fs::write(&input, "bat payload").unwrap();
+
+    let result = execute_script(
+        script.to_str().unwrap(),
+        serde_json::json!({
+            "input": input.to_string_lossy(),
+            "output": output.to_string_lossy(),
+        }),
+        None,
+    )
+    .expect("bat script must succeed");
+    assert_eq!(result["success"], true, "envelope: {result:?}");
+    assert_eq!(std::fs::read_to_string(&output).unwrap(), "bat payload");
+}
+
+// ── PowerShell (.ps1) — Windows only ───────────────────────────────────────
+
+#[cfg(windows)]
+#[test]
+fn test_real_powershell_processes_file_via_cli_flags() {
+    if !have_program("pwsh") && !have_program("powershell") {
+        return;
+    }
+    // PowerShell receives `--input <p>` etc as positional args; PowerShell
+    // treats `--input` as a literal token (not a parameter name) so we walk
+    // $args manually rather than using `param()`.
+    let body = "$ErrorActionPreference = 'Stop'\r\n\
+        # Drain stdin so the parent does not block on a closed pipe.\r\n\
+        $null = [Console]::In.ReadToEnd()\r\n\
+        $inputPath = $null\r\n\
+        $outputPath = $null\r\n\
+        for ($i = 0; $i -lt $args.Count; $i++) {\r\n\
+            switch ($args[$i]) {\r\n\
+                '--input' { $inputPath = $args[$i + 1]; $i++ }\r\n\
+                '--output' { $outputPath = $args[$i + 1]; $i++ }\r\n\
+            }\r\n\
+        }\r\n\
+        Copy-Item -LiteralPath $inputPath -Destination $outputPath -Force\r\n\
+        $obj = @{ success = $true; wrote = $outputPath }\r\n\
+        Write-Output ($obj | ConvertTo-Json -Compress)\r\n";
+    let (_dir, script) = write_script("copy.ps1", body);
+    let work = TempDir::new().unwrap();
+    let input = work.path().join("in.txt");
+    let output = work.path().join("out.txt");
+    std::fs::write(&input, "ps1 payload").unwrap();
+
+    let result = execute_script(
+        script.to_str().unwrap(),
+        serde_json::json!({
+            "input": input.to_string_lossy(),
+            "output": output.to_string_lossy(),
+        }),
+        None,
+    )
+    .expect("ps1 script must succeed");
+    assert_eq!(result["success"], true, "envelope: {result:?}");
+    assert_eq!(std::fs::read_to_string(&output).unwrap(), "ps1 payload");
+}
+
+#[cfg(windows)]
+#[test]
+fn test_real_powershell_nonzero_exit_returns_error_with_stderr() {
+    if !have_program("pwsh") && !have_program("powershell") {
+        return;
+    }
+    // `throw` produces a non-zero exit and writes the message to stderr.
+    let body = "[Console]::Error.WriteLine('powershell exploded')\r\nexit 5\r\n";
+    let (_dir, script) = write_script("fail.ps1", body);
+    let err = execute_script(script.to_str().unwrap(), serde_json::json!({}), None)
+        .expect_err("non-zero ps1 exit must surface as Err(...)");
+    assert!(err.contains("exited with code 5"), "got: {err}");
+    assert!(
+        err.contains("powershell exploded"),
+        "stderr must propagate: {err}"
+    );
+}

--- a/tests/test_skill_execute_real.py
+++ b/tests/test_skill_execute_real.py
@@ -1,0 +1,351 @@
+"""End-to-end skill-execution tests against the production bindings.
+
+Complements ``crates/dcc-mcp-skills/src/catalog/tests/test_execute_script_real.rs``
+(which covers the subprocess code path) by exercising the **in-process**
+executor pipeline that DCC adapters (Maya, Blender, Houdini) actually use:
+
+1. Materialise a real ``SKILL.md`` package on disk (frontmatter + script).
+2. Wire ``SkillCatalog.set_in_process_executor`` with the production helper
+   ``build_inprocess_executor`` plus a real ``BaseDccCallableDispatcher``.
+3. Discover and load the skill via ``SkillCatalog`` so the registry-side
+   wiring is exercised end-to-end.
+4. Invoke the executor with the loaded script path and verify the script
+   actually processed an on-disk file (not just that ``is_loaded`` flipped).
+
+Historical context: dcc-mcp-maya issues #137/#138 surfaced because the
+script-execution chain was only ever exercised via smoke tests in CI.
+These tests close that gap by asserting on real file artefacts after
+execution.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from pathlib import Path
+import textwrap
+from typing import Any
+from typing import Callable
+
+# Import third-party modules
+import pytest
+
+# Import local modules
+import dcc_mcp_core
+from dcc_mcp_core._server.inprocess_executor import build_inprocess_executor
+from dcc_mcp_core._server.inprocess_executor import run_skill_script
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def _write_skill(
+    base_dir: Path,
+    skill_name: str,
+    scripts: dict[str, str],
+    *,
+    dcc: str = "python",
+) -> Path:
+    """Materialise a SKILL.md package with one or more scripts.
+
+    The frontmatter uses the modern ``metadata.dcc-mcp.dcc`` form so the
+    ``DCC_NAMES_REQUIRING_HOST_PYTHON`` ambient-python guard does not fire
+    even though we never reach the subprocess path.
+    """
+    skill_dir = base_dir / skill_name
+    (skill_dir / "scripts").mkdir(parents=True, exist_ok=True)
+    front = (
+        "---\n"
+        f"name: {skill_name}\n"
+        "description: Real execution test skill for dcc-mcp-core\n"
+        "version: 1.0.0\n"
+        "metadata:\n"
+        f"  dcc-mcp.dcc: {dcc}\n"
+        "  dcc-mcp.layer: example\n"
+        "---\n"
+        f"\n# {skill_name}\n"
+    )
+    (skill_dir / "SKILL.md").write_text(front, encoding="utf-8")
+    for name, body in scripts.items():
+        (skill_dir / "scripts" / name).write_text(textwrap.dedent(body).lstrip(), encoding="utf-8")
+    return skill_dir
+
+
+class _RecordingDispatcher:
+    """Minimal ``BaseDccCallableDispatcher`` that runs callables inline.
+
+    Mirrors the contract every real DCC dispatcher (Maya UI thread,
+    Houdini ``hou.session``, Unreal game thread) honours: forward to
+    ``func(*args, **kwargs)`` and return its result.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = []
+
+    def dispatch_callable(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        self.calls.append((func, args, kwargs))
+        return func(*args, **kwargs)
+
+
+# ── tests: real Python script processes a real file ───────────────────────
+
+
+class TestInProcessSkillProcessesFile:
+    """The in-process executor must route to the script and observe its file output."""
+
+    def test_executor_runs_script_that_copies_file(self, tmp_path: Path) -> None:
+        skill_dir = _write_skill(
+            tmp_path,
+            "file-copy-skill",
+            {
+                "do_copy.py": """
+                from pathlib import Path
+                def main(input, output, suffix=""):
+                    src = Path(input).read_text(encoding="utf-8")
+                    Path(output).write_text(src + suffix, encoding="utf-8")
+                    return {"success": True, "wrote": output, "bytes": len(src) + len(suffix)}
+                """,
+            },
+        )
+
+        # Discover + load via the production catalog so registry wiring runs.
+        registry = dcc_mcp_core.ToolRegistry()
+        catalog = dcc_mcp_core.SkillCatalog(registry)
+        dispatcher = _RecordingDispatcher()
+        catalog.set_in_process_executor(build_inprocess_executor(dispatcher))
+        catalog.discover(extra_paths=[str(tmp_path)])
+        catalog.load_skill("file-copy-skill")
+        assert catalog.is_loaded("file-copy-skill")
+
+        # Invoke the executor exactly the way dispatch would: with the script
+        # path and a real params dict. Verify the on-disk file is correct.
+        script = skill_dir / "scripts" / "do_copy.py"
+        input_file = tmp_path / "in.txt"
+        output_file = tmp_path / "out.txt"
+        input_file.write_text("python skill payload", encoding="utf-8")
+
+        executor = build_inprocess_executor(dispatcher)
+        result = executor(str(script), {"input": str(input_file), "output": str(output_file), "suffix": "!"})
+
+        assert result == {
+            "success": True,
+            "wrote": str(output_file),
+            "bytes": len("python skill payload") + 1,
+        }
+        assert output_file.read_text(encoding="utf-8") == "python skill payload!"
+        # Dispatcher must have been routed through (UI-thread contract).
+        assert len(dispatcher.calls) == 1
+        func, args, kwargs = dispatcher.calls[0]
+        assert func is run_skill_script
+        assert args[0] == str(script)
+        assert kwargs == {}
+
+    def test_executor_runs_script_that_writes_json_manifest(self, tmp_path: Path) -> None:
+        """A common DCC skill pattern: scan a directory, emit a JSON manifest."""
+        # Materialise a fake "input asset" tree the script will scan.
+        assets = tmp_path / "assets"
+        (assets / "scenes").mkdir(parents=True)
+        (assets / "textures").mkdir()
+        (assets / "scenes" / "shot010.ma").write_text("// dummy", encoding="utf-8")
+        (assets / "scenes" / "shot020.ma").write_text("// dummy", encoding="utf-8")
+        (assets / "textures" / "diffuse.png").write_bytes(b"\x89PNG\r\n")
+
+        skill_dir = _write_skill(
+            tmp_path,
+            "manifest-skill",
+            {
+                "build_manifest.py": """
+                import json
+                from pathlib import Path
+                def main(root, output):
+                    root = Path(root)
+                    files = sorted(str(p.relative_to(root)).replace("\\\\", "/")
+                                   for p in root.rglob("*") if p.is_file())
+                    Path(output).write_text(json.dumps({"files": files}, indent=2), encoding="utf-8")
+                    return {"success": True, "count": len(files)}
+                """,
+            },
+        )
+
+        registry = dcc_mcp_core.ToolRegistry()
+        catalog = dcc_mcp_core.SkillCatalog(registry)
+        dispatcher = _RecordingDispatcher()
+        catalog.set_in_process_executor(build_inprocess_executor(dispatcher))
+        catalog.discover(extra_paths=[str(tmp_path)])
+        catalog.load_skill("manifest-skill")
+
+        script = skill_dir / "scripts" / "build_manifest.py"
+        manifest = tmp_path / "manifest.json"
+        result = build_inprocess_executor(dispatcher)(
+            str(script),
+            {"root": str(assets), "output": str(manifest)},
+        )
+
+        assert result == {"success": True, "count": 3}
+        # Import standard library JSON only here so the test file stays linear.
+        import json
+
+        loaded = json.loads(manifest.read_text(encoding="utf-8"))
+        assert loaded == {
+            "files": [
+                "scenes/shot010.ma",
+                "scenes/shot020.ma",
+                "textures/diffuse.png",
+            ],
+        }
+
+
+# ── multi-script skills ────────────────────────────────────────────────────
+
+
+class TestMultiScriptSkill:
+    def test_each_script_in_a_skill_is_independently_executable(self, tmp_path: Path) -> None:
+        """A skill with two scripts must let each one process its own file."""
+        skill_dir = _write_skill(
+            tmp_path,
+            "two-tools-skill",
+            {
+                "uppercase.py": """
+                from pathlib import Path
+                def main(input, output):
+                    src = Path(input).read_text(encoding="utf-8")
+                    Path(output).write_text(src.upper(), encoding="utf-8")
+                    return {"success": True, "tool": "uppercase"}
+                """,
+                "wordcount.py": """
+                from pathlib import Path
+                def main(input):
+                    txt = Path(input).read_text(encoding="utf-8")
+                    return {"success": True, "tool": "wordcount", "words": len(txt.split())}
+                """,
+            },
+        )
+
+        registry = dcc_mcp_core.ToolRegistry()
+        catalog = dcc_mcp_core.SkillCatalog(registry)
+        catalog.set_in_process_executor(build_inprocess_executor(None))
+        catalog.discover(extra_paths=[str(tmp_path)])
+        catalog.load_skill("two-tools-skill")
+
+        executor = build_inprocess_executor(None)
+        input_file = tmp_path / "doc.txt"
+        upper_out = tmp_path / "upper.txt"
+        input_file.write_text("the quick brown fox", encoding="utf-8")
+
+        upper_result = executor(
+            str(skill_dir / "scripts" / "uppercase.py"),
+            {"input": str(input_file), "output": str(upper_out)},
+        )
+        assert upper_result == {"success": True, "tool": "uppercase"}
+        assert upper_out.read_text(encoding="utf-8") == "THE QUICK BROWN FOX"
+
+        wc_result = executor(
+            str(skill_dir / "scripts" / "wordcount.py"),
+            {"input": str(input_file)},
+        )
+        assert wc_result == {"success": True, "tool": "wordcount", "words": 4}
+
+
+# ── error propagation ────────────────────────────────────────────────────
+
+
+class TestSkillScriptErrorPropagation:
+    def test_script_raise_propagates_to_caller(self, tmp_path: Path) -> None:
+        skill_dir = _write_skill(
+            tmp_path,
+            "raises-skill",
+            {
+                "boom.py": """
+                def main(reason):
+                    raise RuntimeError(f"skill failed: {reason}")
+                """,
+            },
+        )
+
+        executor = build_inprocess_executor(None)
+        with pytest.raises(RuntimeError, match="skill failed: invalid input"):
+            executor(
+                str(skill_dir / "scripts" / "boom.py"),
+                {"reason": "invalid input"},
+            )
+
+    def test_dispatcher_errors_are_visible_to_caller(self, tmp_path: Path) -> None:
+        """If the host dispatcher's UI thread fails (e.g. Maya viewport closed),
+        the error must surface so MCP can return a proper error envelope.
+        """
+        skill_dir = _write_skill(
+            tmp_path,
+            "dispatched-skill",
+            {
+                "noop.py": "def main(**_): return {'success': True}\n",
+            },
+        )
+
+        class _BoomDispatcher:
+            def dispatch_callable(
+                self,
+                func: Callable[..., Any],
+                *args: Any,
+                **kwargs: Any,
+            ) -> Any:
+                raise RuntimeError("UI thread shutting down")
+
+        executor = build_inprocess_executor(_BoomDispatcher())
+        with pytest.raises(RuntimeError, match="UI thread shutting down"):
+            executor(str(skill_dir / "scripts" / "noop.py"), {})
+
+    def test_missing_main_callable_raises_attribute_error(self, tmp_path: Path) -> None:
+        skill_dir = _write_skill(
+            tmp_path,
+            "no-main-skill",
+            {
+                "module_only.py": "value = 42\n",
+            },
+        )
+        executor = build_inprocess_executor(None)
+        with pytest.raises(AttributeError, match="`main` callable"):
+            executor(str(skill_dir / "scripts" / "module_only.py"), {})
+
+
+# ── catalog ↔ executor wiring round-trip ───────────────────────────────────
+
+
+class TestExecutorWiringSurvivesCatalogLifecycle:
+    def test_clear_then_reset_executor(self, tmp_path: Path) -> None:
+        """Clearing then re-installing the executor must leave the catalog in a
+        consistent state — protects against the pattern where a Maya plugin
+        reloads a skill bundle without restarting the MCP server.
+        """
+        skill_dir = _write_skill(
+            tmp_path,
+            "reset-skill",
+            {
+                "tag.py": """
+                from pathlib import Path
+                def main(output, tag):
+                    Path(output).write_text(tag, encoding="utf-8")
+                    return {"success": True}
+                """,
+            },
+        )
+
+        registry = dcc_mcp_core.ToolRegistry()
+        catalog = dcc_mcp_core.SkillCatalog(registry)
+        catalog.set_in_process_executor(build_inprocess_executor(None))
+        catalog.discover(extra_paths=[str(tmp_path)])
+        catalog.load_skill("reset-skill")
+
+        # Clear and re-install — must not raise and the catalog must still
+        # report the skill as loaded.
+        catalog.set_in_process_executor(None)
+        catalog.set_in_process_executor(build_inprocess_executor(_RecordingDispatcher()))
+        assert catalog.is_loaded("reset-skill")
+
+        # Run the script and check the file artefact.
+        out = tmp_path / "out.txt"
+        executor = build_inprocess_executor(None)
+        result = executor(
+            str(skill_dir / "scripts" / "tag.py"),
+            {"output": str(out), "tag": "v2"},
+        )
+        assert result == {"success": True}
+        assert out.read_text(encoding="utf-8") == "v2"


### PR DESCRIPTION
## Why

Skill script execution has been the source of repeated production bugs (most recently dcc-mcp-maya#137 / #138). Yet the existing tests never actually exercise the real path:

* `crates/dcc-mcp-skills/src/catalog/tests/test_execute_script.rs` is **smoke-only** — it passes `"python"` as the *script_path* (the binary name, not a script body) and skips on any spawn failure.
* `tests/test_skills_e2e.py::TestPipelineSimulation` runs example skills via `subprocess.run([sys.executable, script, ...])`, **bypassing `dcc_mcp_core` entirely** — it never goes through `execute_script` or the in-process executor.

So the production code path (`SkillCatalog → ToolDispatcher → execute_script` for adapters using subprocess; `SkillCatalog → in-process executor → run_skill_script` for adapters using the host UI thread) has been running uncovered in CI. This PR closes that gap.

## Two-layer end-to-end coverage

### Layer 1 — Rust subprocess path (`test_execute_script_real.rs`, +12 tests)

Real interpreter, real script body, real file artefact verification:

| Script | Coverage |
|--------|----------|
| `.py` (stdin JSON) | Copy real file, verify content + byte count |
| `.py` (CLI argparse `--input/--output/--upper`) | Real `--upper` transform, verify uppercase result |
| `.py` (complex params) | Object/array values must NOT be expanded as `--key value` flags |
| `.py` (non-zero exit) | Stderr propagates into the `Err(...)` message |
| `.py` (plain stdout) | Wrapped as `{success: true, message: "..."}` |
| `.py` (empty stdout) | Defaults to `{success: true, message: ""}` |
| `.py` (unicode) | CJK + emoji + Cyrillic round-trip via stdin |
| `.py` (large string) | 200 KiB string param reaches via stdin, NOT argv |
| `.py` (short string) | Counterpart: short scalars still arrive on argv |
| `.sh` (`cfg(unix)`) | Bash copies a file via `--input/--output` |
| `.sh` (`cfg(unix)`) | Non-zero exit surfaces stderr |
| `.bat` (`cfg(windows)`) | CMD batch copies a file via `--input/--output` |
| `.ps1` (`cfg(windows)`) | PowerShell copies a file via `--input/--output` |
| `.ps1` (`cfg(windows)`) | Non-zero exit surfaces stderr |

Per-language tests gracefully `return` when the interpreter is not on PATH so each CI runner exercises the rest of the matrix.

### Layer 2 — Python in-process pipeline (`test_skill_execute_real.py`, +7 tests)

This is the production path used by Maya, Blender and Houdini adapters:

* Materialise a real `SKILL.md` package on disk, wire `SkillCatalog.set_in_process_executor` with the production `build_inprocess_executor` plus a real `BaseDccCallableDispatcher`.
* `SkillCatalog.discover` → `load_skill` → invoke executor → assert on-disk file output.
* Single-script copy + dispatcher-call accounting (UI-thread contract).
* JSON manifest writer scanning a fake asset tree.
* Multi-script skill: each script processes its own file independently.
* Error propagation: script `raise`, dispatcher (UI thread) failure, missing `main()` callable.
* Lifecycle: clear-then-reset executor leaves the catalog consistent.

## Production fixes uncovered by these tests

Writing the tests immediately surfaced two real bugs that have been silently breaking adapters:

### 1. `.ps1` dispatch was missing

The `README` documented PowerShell support but the matcher in `execute.rs` had no `"ps1"` arm — `.ps1` files fell to the default branch which spawned `python` with the `.ps1` path as a positional argument (and failed cryptically). Added a proper arm:

```rust
"ps1" => (
    if which_program("pwsh") { "pwsh".into() } else { "powershell".into() },
    vec!["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", script_path].into(),
),
```

PowerShell 7 (`pwsh`) is preferred when installed; the Windows-builtin `powershell` is the fallback.

### 2. Oversized string params crashed `CreateProcess` on Windows

Every scalar string param was pushed onto `argv` as `--key value`. A 200 KiB string param (e.g. a serialised manifest, a base64-encoded image, an asset list) blew Windows' 32 KiB command-line limit and surfaced as `os error 206` ("filename or extension too long"). This is exactly the silent failure mode behind several adapter incidents.

Fix: added `MAX_CLI_FLAG_VALUE_BYTES = 8 KiB`. String params longer than that are no longer expanded as CLI flags but **still reach the script via the stdin JSON payload** — no information lost, scripts that read params from stdin (the documented protocol) keep working unchanged.

## Backwards compatibility

* CLI flag expansion still works for short string params (the convenience for argparse-based scripts is preserved). Only oversized values go stdin-only.
* `.ps1` was previously broken; now it works as documented. No callers were depending on the old (broken) behaviour.
* All other `execute_script` semantics are unchanged.

## Validation

| Step | Result |
|------|--------|
| `cargo test -p dcc-mcp-skills --lib` | **236 passed / 0 failed / 0 ignored** (was 224) |
| `pytest tests/` | **8569 passed / 92 skipped / 0 failed** (was 8562 / 92 / 0) |
| `vx just preflight` (check + clippy + fmt-check + test-rust) | clean |
| `ruff check` | clean |

Branch will be rebased onto the latest `main` before merge to keep history linear (per `AGENTS.md`).