### PR TITLE
fix(skills): use ptrace TracerPid detection to skip real-exec tests under tarpaulin

### DIFF
--- a/crates/dcc-mcp-skills/src/catalog/tests/test_execute_script_real.rs
+++ b/crates/dcc-mcp-skills/src/catalog/tests/test_execute_script_real.rs
@@ -17,15 +17,34 @@ use tempfile::TempDir;
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
-/// `true` when running under `cargo tarpaulin`. Tarpaulin instruments the
-/// test binary via ptrace, which historically interferes with the
-/// `Stdio::piped()` / `wait_with_output()` pattern these tests rely on
-/// (see tarpaulin issues #843, #1011 et al.) — the child process either
-/// loses its stdin write or the wait returns prematurely. The non-tarpaulin
-/// `cargo test` runs on Linux, macOS and Windows already exercise this
-/// code path, so we skip rather than chase ptrace artefacts in coverage.
-fn under_tarpaulin() -> bool {
-    std::env::var_os("CARGO_TARPAULIN").is_some() || std::env::var_os("TARPAULIN").is_some()
+/// `true` when the current process is being ptraced (cargo tarpaulin
+/// coverage, valgrind, strace, debugger). Detection only attempts the Linux
+/// `/proc/self/status` `TracerPid` field — the only platform where tarpaulin
+/// runs in CI. On macOS / Windows the function always returns `false`, which
+/// is correct because tarpaulin does not run there. Tarpaulin's ptrace
+/// instrumentation interferes with the `Stdio::piped()` / `wait_with_output()`
+/// pattern these tests rely on, so when ptraced we skip rather than chase
+/// ptrace artefacts in coverage; the non-coverage `cargo test` runs on all
+/// three platforms still exercise the same dispatcher code paths.
+///
+/// Replaces the previous CARGO_TARPAULIN env-var check, which the current
+/// cargo-tarpaulin release does not set when invoked via taiki-e/install-action.
+fn under_ptrace() -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(status) = std::fs::read_to_string("/proc/self/status") {
+            for line in status.lines() {
+                if let Some(rest) = line.strip_prefix("TracerPid:") {
+                    return rest.trim().parse::<u32>().map(|p| p != 0).unwrap_or(false);
+                }
+            }
+        }
+        false
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        false
+    }
 }
 
 /// `true` when an executable named `program` is resolvable on PATH (with the
@@ -64,12 +83,11 @@ fn write_script(name: &str, body: &str) -> (TempDir, PathBuf) {
 }
 
 /// Combined precondition guard for every test in this module: skip when the
-/// requested interpreter is missing OR when running under tarpaulin coverage
-/// instrumentation (which historically interferes with subprocess Stdio
-/// pipes — see `under_tarpaulin` above). Returns `true` when the test should
-/// be skipped.
+/// requested interpreter is missing OR when the test binary is being ptraced
+/// (which historically interferes with subprocess Stdio pipes — see
+/// `under_ptrace` above). Returns `true` when the test should be skipped.
 fn skip_real_exec(interpreter: &str) -> bool {
-    under_tarpaulin() || !have_program(interpreter)
+    under_ptrace() || !have_program(interpreter)
 }
 
 // ── Python (.py) — stdin / CLI / file processing ───────────────────────────


### PR DESCRIPTION
## Why

Follow-up to ccef21b / e713018 (#569). The `CARGO_TARPAULIN` env-var check that landed with #569 turned out to be ineffective: the cargo-tarpaulin release pulled by `taiki-e/install-action` does not export that variable, so the skip never fires and the **Rust coverage CI job has been red on every commit since #569 merged**.

The 8/12 "failures" are not real regressions: the same tests pass cleanly under `cargo test` on Linux + macOS + Windows. Tarpaulin's ptrace-based instrumentation interferes with the `Stdio::piped()` / `wait_with_output()` pattern these tests rely on (subprocesses lose their stdin write or `wait_with_output` returns early).

## What changes

Switch the skip detection from the broken env-var check to `/proc/self/status` `TracerPid` parsing on Linux. When the field is non-zero the process is being ptraced (tarpaulin / valgrind / strace / debugger) and we early-return from each real-exec test. Detection is Linux-only because tarpaulin only runs on the Linux CI matrix; macOS and Windows always return `false` (correct: no coverage runs there).

```rust
fn under_ptrace() -> bool {
    #[cfg(target_os = "linux")]
    {
        if let Ok(status) = std::fs::read_to_string("/proc/self/status") {
            for line in status.lines() {
                if let Some(rest) = line.strip_prefix("TracerPid:") {
                    return rest.trim().parse::<u32>().map(|p| p != 0).unwrap_or(false);
                }
            }
        }
        false
    }
    #[cfg(not(target_os = "linux"))]
    { false }
}
```

## Why coverage of these lines is not lost

The dispatcher code paths that the real-exec tests cover are still touched (and counted by tarpaulin) by the smoke tests in `test_execute_script.rs`. What coverage loses is just the **assertion strength** of the real-exec tests, not the line numbers they hit. Functional verification still runs on every PR via the regular Rust matrix on all three platforms, where the file-processing assertions actually execute.

## Validation

* Local `cargo test -p dcc-mcp-skills --lib catalog::tests::test_execute_script_real::` → 12/12 pass on Windows (sanity check; tarpaulin doesn't run on Windows so the skip path isn't exercised here).
* On the next CI run the `Rust coverage` job should turn green: the Linux test binary will detect TracerPid != 0 and skip the 12 real-exec tests, leaving the other 224 dcc-mcp-skills tests to run normally.

## Backwards compatibility

No runtime / API change. Only affects test-code skip behaviour under coverage instrumentation. The previous `under_tarpaulin()` helper is removed in favour of `under_ptrace()` (test-internal symbol).