### PR TITLE
feat(http): JobRecoveryPolicy contract for McpHttpConfig (#567)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,7 @@
 | Detect a misconfigured GUI binary as `DCC_MCP_PYTHON_EXECUTABLE` | `is_gui_executable(path)` → `GuiExecutableHint(dcc_kind, recommended_replacement)` (#524) |
 | Auto-correct GUI binary to its headless sibling | `correct_python_executable(path)` — falls back to original path if no sibling found (#524) |
 | Checkpoint/resume | `save_checkpoint(job_id, state)` / `get_checkpoint(job_id)` |
+| Job recovery policy on restart | `McpHttpConfig.with_job_recovery(JobRecoveryPolicy::Drop\|Requeue)` / Python `cfg.job_recovery = "drop"\|"requeue"` — `Requeue` is reserved (degrades to `Drop` + `WARN` until tool-arg persistence lands) (#567) |
 | Agent-facing docs resources | `register_docs_server(server)` → `docs://` MCP resources |
 | Agent feedback | `register_feedback_tool(server)` → `dcc_feedback__report` tool |
 | Runtime introspection | `register_introspect_tools(server)` → `dcc_introspect__*` tools |

--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -40,6 +40,52 @@ pub enum ServerSpawnMode {
     Dedicated,
 }
 
+/// What [`McpHttpServer::start`](crate::McpHttpServer::start) does with rows
+/// that the previous process left in `Pending` / `Running` after a crash or
+/// restart (issue #567).
+///
+/// | Variant | Behaviour |
+/// |---------|-----------|
+/// | [`JobRecoveryPolicy::Drop`]    | Each in-flight row is rewritten to [`JobStatus::Interrupted`](crate::job::JobStatus::Interrupted) with `error = "server restart"`. Clients re-subscribing after reconnect see one clean terminal transition. **This is today's behaviour and the default.** |
+/// | [`JobRecoveryPolicy::Requeue`] | Reserved for a future release that persists the original tool arguments alongside the `jobs` row. Until that lands the variant is **accepted but treated as `Drop`** — the server logs a `WARN` at startup so operators know the requested policy is not yet active, but startup itself never fails. The accepted-but-degraded contract gives DCC adapters (`dcc-mcp-maya`, `dcc-mcp-houdini`) a stable knob to plumb through today without forcing a config-shape break when the real implementation lands. |
+///
+/// String form (used by the Python binding and the upcoming `--job-recovery`
+/// CLI flag): `"drop"` / `"requeue"`. Defaults to `Drop`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum JobRecoveryPolicy {
+    /// Rewrite every `Pending` / `Running` row to `Interrupted` on startup.
+    /// Always safe; never re-runs a partially-applied tool.
+    #[default]
+    Drop,
+    /// Reserved policy: would re-submit idempotent in-flight jobs from the
+    /// persisted spec. Accepted today but treated as [`Self::Drop`] with a
+    /// `WARN` log at startup until tool-arg persistence lands.
+    Requeue,
+}
+
+impl JobRecoveryPolicy {
+    /// Lower-case wire identifier used by docs, the Python binding, and the
+    /// `--job-recovery` CLI flag.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Drop => "drop",
+            Self::Requeue => "requeue",
+        }
+    }
+
+    /// Parse the wire identifier. `&str` is matched case-insensitively to
+    /// be tolerant of env-var plumbing (`DCC_MCP_*_JOB_RECOVERY=Requeue`).
+    pub fn parse(value: &str) -> Result<Self, String> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "drop" => Ok(Self::Drop),
+            "requeue" => Ok(Self::Requeue),
+            other => Err(format!(
+                "unknown job_recovery policy {other:?}; expected \"drop\" or \"requeue\""
+            )),
+        }
+    }
+}
+
 /// Configuration for [`McpHttpServer`](crate::McpHttpServer).
 #[derive(Debug, Clone)]
 pub struct McpHttpConfig {
@@ -329,6 +375,18 @@ pub struct McpHttpConfig {
     /// Default: `None` (in-memory storage; no persistence).
     pub job_storage_path: Option<PathBuf>,
 
+    /// What to do with rows the previous process left in `Pending` /
+    /// `Running` after a crash or restart (issue #567).
+    ///
+    /// See [`JobRecoveryPolicy`] for the per-variant semantics. Today only
+    /// [`JobRecoveryPolicy::Drop`] (the default) does any real work; the
+    /// `Requeue` variant is accepted but degrades to `Drop` with a `WARN`
+    /// log so adapters can plumb the knob now and pick up the real
+    /// behaviour transparently when tool-arg persistence lands.
+    ///
+    /// Default: [`JobRecoveryPolicy::Drop`].
+    pub job_recovery: JobRecoveryPolicy,
+
     /// Capabilities declared by the DCC adapter hosting this server (issue #354).
     ///
     /// Each tool may list [`required_capabilities`] in its sibling
@@ -452,6 +510,7 @@ impl McpHttpConfig {
             prometheus_basic_auth: None,
             enable_job_notifications: true,
             job_storage_path: None,
+            job_recovery: JobRecoveryPolicy::Drop,
             declared_capabilities: Vec::new(),
             enable_scheduler: false,
             schedules_dir: None,
@@ -493,6 +552,20 @@ impl McpHttpConfig {
     /// with a descriptive error at startup.
     pub fn with_job_storage_path(mut self, path: impl Into<PathBuf>) -> Self {
         self.job_storage_path = Some(path.into());
+        self
+    }
+
+    /// Builder: choose how the next [`McpHttpServer::start`](crate::McpHttpServer::start)
+    /// reacts to in-flight rows persisted by a previous run (issue #567).
+    ///
+    /// See [`JobRecoveryPolicy`] for the supported variants. Today
+    /// `Requeue` is accepted but degrades to `Drop` with a `WARN` log;
+    /// the contract is reserved so adapter code (`dcc-mcp-maya`,
+    /// `dcc-mcp-houdini`) can wire the knob through now and pick up
+    /// the real behaviour transparently when tool-arg persistence
+    /// lands.
+    pub fn with_job_recovery(mut self, policy: JobRecoveryPolicy) -> Self {
+        self.job_recovery = policy;
         self
     }
 
@@ -668,5 +741,52 @@ impl McpHttpConfig {
 impl Default for McpHttpConfig {
     fn default() -> Self {
         Self::new(8765)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Issue #567: the policy enum defaults to `Drop` so existing callers
+    /// inherit today's behaviour without touching their config.
+    #[test]
+    fn job_recovery_default_is_drop() {
+        let cfg = McpHttpConfig::new(8765);
+        assert_eq!(cfg.job_recovery, JobRecoveryPolicy::Drop);
+    }
+
+    /// Issue #567: the builder takes the policy by value and round-trips
+    /// to the same wire identifier the Python binding exposes.
+    #[test]
+    fn job_recovery_builder_round_trips() {
+        let cfg = McpHttpConfig::new(8765).with_job_recovery(JobRecoveryPolicy::Requeue);
+        assert_eq!(cfg.job_recovery, JobRecoveryPolicy::Requeue);
+        assert_eq!(cfg.job_recovery.as_str(), "requeue");
+    }
+
+    /// Issue #567: env-var plumbing (`DCC_MCP_*_JOB_RECOVERY=Requeue`) and
+    /// the Python setter share the same case-insensitive parser.
+    #[test]
+    fn job_recovery_parse_is_case_insensitive() {
+        for raw in ["drop", "Drop", "DROP", "  drop  "] {
+            assert_eq!(JobRecoveryPolicy::parse(raw), Ok(JobRecoveryPolicy::Drop));
+        }
+        for raw in ["requeue", "Requeue", "REQUEUE"] {
+            assert_eq!(
+                JobRecoveryPolicy::parse(raw),
+                Ok(JobRecoveryPolicy::Requeue)
+            );
+        }
+    }
+
+    /// Issue #567: unknown policies surface a descriptive error that
+    /// names the rejected value and the accepted set.
+    #[test]
+    fn job_recovery_parse_rejects_unknown() {
+        let err = JobRecoveryPolicy::parse("retry").unwrap_err();
+        assert!(err.contains("retry"), "error message: {err}");
+        assert!(err.contains("drop"), "error message: {err}");
+        assert!(err.contains("requeue"), "error message: {err}");
     }
 }

--- a/crates/dcc-mcp-http/src/python/config.rs
+++ b/crates/dcc-mcp-http/src/python/config.rs
@@ -16,6 +16,7 @@ use dcc_mcp_pybridge::derive::PyWrapper;
 /// conversions the macro grammar cannot express:
 ///
 /// - `spawn_mode` / `set_spawn_mode` — enum ↔ `&str` with `PyResult` validation.
+/// - `job_recovery` / `set_job_recovery` — same shape as `spawn_mode` (#567).
 /// - `job_storage_path` / `set_job_storage_path` — `Option<PathBuf>` ↔ `Option<String>`.
 /// - `registry_dir` / `set_registry_dir` — same `PathBuf` shape as above.
 /// - `__repr__` — selects three identifying fields with one renamed
@@ -374,6 +375,27 @@ impl PyMcpHttpConfig {
         Ok(())
     }
 
+    /// Lower-case wire identifier of the configured job-recovery policy
+    /// (issue #567). Returns ``"drop"`` (default) or ``"requeue"``.
+    ///
+    /// ``"drop"`` rewrites every ``Pending`` / ``Running`` row left over
+    /// by a previous process to ``Interrupted`` on startup.
+    /// ``"requeue"`` is reserved for a future release that persists tool
+    /// arguments alongside the job row; today it is accepted but
+    /// degrades to ``"drop"`` semantics with a ``WARN`` log so adapters
+    /// can plumb the knob through now.
+    #[getter]
+    fn job_recovery(&self) -> &'static str {
+        self.inner.job_recovery.as_str()
+    }
+
+    #[setter]
+    fn set_job_recovery(&mut self, policy: &str) -> PyResult<()> {
+        self.inner.job_recovery = crate::config::JobRecoveryPolicy::parse(policy)
+            .map_err(pyo3::exceptions::PyValueError::new_err)?;
+        Ok(())
+    }
+
     fn __repr__(&self) -> String {
         dcc_mcp_pybridge::repr_pairs!(
             "McpHttpConfig",
@@ -438,6 +460,7 @@ mod drift_tests {
         let _ = cfg.enable_workflows();
         let _ = cfg.enable_job_notifications();
         let _ = cfg.job_storage_path();
+        let _ = cfg.job_recovery();
 
         // ── Prometheus ─────────────────────────────────────────────────────
         let _ = cfg.enable_prometheus();

--- a/crates/dcc-mcp-http/src/server/mod.rs
+++ b/crates/dcc-mcp-http/src/server/mod.rs
@@ -346,15 +346,41 @@ impl McpHttpServer {
         // mark them Interrupted. Emits `$/dcc.jobUpdated` through the
         // just-wired notifier. Errors are logged but not fatal — the
         // server continues with an empty in-process map.
+        //
+        // Issue #567: `job_recovery = Requeue` is accepted but
+        // currently degrades to `Drop`. Tool arguments are not
+        // persisted on the `jobs` row yet, so reconstructing the
+        // original `JobSpec` for re-submission isn't possible. We
+        // emit a `WARN` once at startup so operators who plumbed
+        // `Requeue` through their adapter know the requested policy
+        // is reserved-but-not-active, then fall through to the same
+        // `recover_from_storage` (Drop semantics) path.
         if jobs.storage().is_some() {
+            if matches!(
+                self.config.job_recovery,
+                crate::config::JobRecoveryPolicy::Requeue
+            ) {
+                tracing::warn!(
+                    requested_policy = "requeue",
+                    effective_policy = "drop",
+                    issue = "loonghao/dcc-mcp-core#567",
+                    "job_recovery=Requeue is accepted but degrades to Drop until tool-arg persistence lands; \
+                     in-flight rows will be marked Interrupted as if Drop were configured"
+                );
+            }
             match jobs.recover_from_storage() {
                 Ok(n) if n > 0 => tracing::info!(
                     interrupted_jobs = n,
+                    policy = self.config.job_recovery.as_str(),
                     "JobManager recovered pending/running rows from storage and marked them Interrupted"
                 ),
-                Ok(_) => tracing::debug!("JobManager storage recovery found no in-flight rows"),
+                Ok(_) => tracing::debug!(
+                    policy = self.config.job_recovery.as_str(),
+                    "JobManager storage recovery found no in-flight rows"
+                ),
                 Err(e) => tracing::error!(
                     error = %e,
+                    policy = self.config.job_recovery.as_str(),
                     "JobManager storage recovery failed — in-process map stays empty"
                 ),
             }

--- a/crates/dcc-mcp-http/tests/http/job_persistence.rs
+++ b/crates/dcc-mcp-http/tests/http/job_persistence.rs
@@ -9,8 +9,11 @@
 
 use std::sync::Arc;
 
+use dcc_mcp_actions::ActionRegistry;
+use dcc_mcp_http::config::JobRecoveryPolicy;
 use dcc_mcp_http::job::{JobManager, JobStatus};
 use dcc_mcp_http::job_storage::{JobFilter, JobStorage, SqliteStorage};
+use dcc_mcp_http::{McpHttpConfig, McpHttpServer};
 use serde_json::json;
 use tempfile::tempdir;
 
@@ -113,4 +116,83 @@ fn cleanup_older_than_hours_prunes_storage_rows() {
     assert!(mgr.get(&running_id).is_some());
     assert!(storage.get(&done_id).unwrap().is_none());
     assert!(storage.get(&running_id).unwrap().is_some());
+}
+
+// ── Issue #567: job_recovery policy at server startup ────────────────────
+
+/// Default policy (`Drop`) flips an in-flight row to `Interrupted` on
+/// `McpHttpServer::start()`. This locks in the existing behaviour so a
+/// future tweak that renames or re-routes the policy switch can't
+/// silently regress it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_start_with_drop_policy_marks_inflight_interrupted() {
+    let dir = tempdir().unwrap();
+    let db = dir.path().join("jobs.sqlite3");
+    let running_id = seed_running_row(&db);
+
+    let cfg = McpHttpConfig::new(0)
+        .with_name("recovery-drop-test")
+        .with_job_storage_path(&db);
+    assert_eq!(cfg.job_recovery, JobRecoveryPolicy::Drop, "default policy");
+
+    let registry = Arc::new(ActionRegistry::new());
+    let handle = McpHttpServer::new(registry, cfg)
+        .start()
+        .await
+        .expect("server must start");
+    handle.shutdown().await;
+
+    assert_recovered_interrupted(&db, &running_id);
+}
+
+/// `Requeue` is accepted but degrades to `Drop` until tool-arg
+/// persistence lands. The server MUST still start cleanly and the row
+/// MUST end up `Interrupted` — the contract is "behaves like Drop
+/// today, real requeue lands in a future release". A regression here
+/// would re-introduce the dcc-mcp-maya#567 doc/impl drift.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_start_with_requeue_policy_degrades_to_drop_today() {
+    let dir = tempdir().unwrap();
+    let db = dir.path().join("jobs.sqlite3");
+    let running_id = seed_running_row(&db);
+
+    let cfg = McpHttpConfig::new(0)
+        .with_name("recovery-requeue-test")
+        .with_job_storage_path(&db)
+        .with_job_recovery(JobRecoveryPolicy::Requeue);
+    assert_eq!(cfg.job_recovery, JobRecoveryPolicy::Requeue);
+    assert_eq!(cfg.job_recovery.as_str(), "requeue");
+
+    let registry = Arc::new(ActionRegistry::new());
+    let handle = McpHttpServer::new(registry, cfg)
+        .start()
+        .await
+        .expect("requeue policy must NOT block server startup");
+    handle.shutdown().await;
+
+    // Until real requeue lands the row reaches the same terminal state
+    // it would under Drop. The accompanying `WARN` log is intentional —
+    // we don't assert on its text here to avoid a tracing-subscriber
+    // dependency, but the contract is exercised by the second-run
+    // assertion below.
+    assert_recovered_interrupted(&db, &running_id);
+}
+
+fn seed_running_row(db: &std::path::Path) -> String {
+    let storage = open_store(db);
+    let mgr = JobManager::with_storage(storage);
+    let job = mgr.create("scene.export");
+    let id = job.read().id.clone();
+    mgr.start(&id).expect("transition pending -> running");
+    id
+}
+
+fn assert_recovered_interrupted(db: &std::path::Path, job_id: &str) {
+    let storage = open_store(db);
+    let row = storage
+        .get(job_id)
+        .expect("storage get")
+        .expect("row exists");
+    assert_eq!(row.status, JobStatus::Interrupted);
+    assert_eq!(row.error.as_deref(), Some("server restart"));
 }

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -486,9 +486,19 @@ Set `McpHttpConfig.job_storage_path` to persist `JobManager` state so in-flight 
 ```python
 cfg = McpHttpConfig(port=8765)
 cfg.job_storage_path = "/var/lib/dcc-mcp/jobs.sqlite3"
+cfg.job_recovery = "drop"        # default; "requeue" reserved (issue #567)
 ```
 
-On startup, any `pending` / `running` rows from a previous run are rewritten to the new terminal `interrupted` status with `error = "server restart"` and surfaced via `$/dcc.jobUpdated`. Full design and operational guidance: [`docs/guide/job-persistence.md`](../guide/job-persistence.md).
+On startup, any `pending` / `running` rows from a previous run are rewritten to the new terminal `interrupted` status with `error = "server restart"` and surfaced via `$/dcc.jobUpdated`.
+
+`McpHttpConfig.job_recovery` selects the policy applied to those rows (issue #567):
+
+| Value       | Behaviour                                                                                                                                                                                                                                                                  |
+|-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `"drop"`    | **Default.** Rows are flipped to `interrupted`; clients re-running the work must re-submit explicitly.                                                                                                                                                                     |
+| `"requeue"` | **Reserved.** Accepted today but degrades to `"drop"` with a `WARN` log (`requested_policy=requeue effective_policy=drop`). True requeue requires persisting the original tool arguments alongside the row, which lands in a future release. Setting this today is forward-compatible: the same config will pick up real requeue when it ships. |
+
+Full design and operational guidance: [`docs/guide/job-persistence.md`](../guide/job-persistence.md).
 
 ## CORS Configuration
 

--- a/docs/guide/job-persistence.md
+++ b/docs/guide/job-persistence.md
@@ -73,6 +73,37 @@ Recovery failures are logged at `error` level and do **not** abort startup — t
 in-process map simply starts empty and the process continues to serve new
 requests.
 
+### Recovery policy (issue #567)
+
+`McpHttpConfig::job_recovery` selects how the recovery sweep treats in-flight
+rows. Two values are accepted today:
+
+| Value (Rust)                  | Wire string | Effect                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+|-------------------------------|-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `JobRecoveryPolicy::Drop`     | `"drop"`    | **Default.** Every `Pending` / `Running` row is rewritten to `Interrupted`. Always safe — never re-runs a partially-applied tool. Matches the behaviour described above.                                                                                                                                                                                                                                                                     |
+| `JobRecoveryPolicy::Requeue`  | `"requeue"` | **Reserved.** The contract is "re-submit idempotent in-flight jobs from the persisted spec". Today the `jobs` row stores only `tool_name`, not the original arguments, so true requeue is not yet possible. The variant is **accepted but degrades to `Drop`** — startup logs a `WARN` (`requested_policy=requeue effective_policy=drop`) and the recovery sweep behaves identically to `Drop`. The accepted-but-degraded contract lets DCC adapters (`dcc-mcp-maya`, `dcc-mcp-houdini`) plumb the knob today; the real implementation will land alongside tool-arg persistence without a config-shape break. |
+
+```python
+from dcc_mcp_core import McpHttpConfig
+
+config = McpHttpConfig(port=8765)
+config.job_storage_path = "/var/lib/dcc-mcp/jobs.sqlite3"
+config.job_recovery = "requeue"   # accepted, currently behaves as "drop" + WARN
+```
+
+```rust
+use dcc_mcp_http::config::{JobRecoveryPolicy, McpHttpConfig};
+
+let cfg = McpHttpConfig::new(8765)
+    .with_job_storage_path("/var/lib/dcc-mcp/jobs.sqlite3")
+    .with_job_recovery(JobRecoveryPolicy::Requeue);
+```
+
+If you want to *guarantee* drop semantics regardless of future releases, leave
+`job_recovery` at its default. If you want to opt in to true requeue when it
+ships, set `job_recovery = "requeue"` today and the same configuration will
+pick up the new behaviour automatically.
+
 ## `jobs.cleanup` built-in tool
 
 A SEP-986-compliant built-in MCP tool prunes terminal jobs:
@@ -136,3 +167,4 @@ JSON-serialized — the schema stays stable even if internal `Job` fields evolve
 - #326 — `$/dcc.jobUpdated` notifications
 - #371 — `jobs.get_status` tool
 - **#328** — this document
+- **#567** — `job_recovery` policy contract (`drop` / `requeue`)

--- a/tests/test_http_config.py
+++ b/tests/test_http_config.py
@@ -49,3 +49,48 @@ def test_backend_timeout_ms_accepts_wide_range(value: int) -> None:
     """
     cfg = McpHttpConfig(port=8765, backend_timeout_ms=value)
     assert cfg.backend_timeout_ms == value
+
+
+# ── Issue #567: job_recovery policy contract ─────────────────────────────
+
+
+def test_job_recovery_default_is_drop() -> None:
+    """Existing callers inherit today's behaviour without touching their
+    config. ``"drop"`` is the only policy that's actually implemented.
+    """
+    cfg = McpHttpConfig(port=8765)
+    assert cfg.job_recovery == "drop"
+
+
+@pytest.mark.parametrize("policy", ["drop", "requeue"])
+def test_job_recovery_setter_round_trips(policy: str) -> None:
+    """Both wire identifiers round-trip through the setter. ``"requeue"``
+    is accepted today (degrades to ``"drop"`` at server startup) so DCC
+    adapters can plumb the knob now and pick up real requeue without a
+    config-shape break when it ships.
+    """
+    cfg = McpHttpConfig(port=8765)
+    cfg.job_recovery = policy
+    assert cfg.job_recovery == policy
+
+
+@pytest.mark.parametrize("raw", ["DROP", "Drop", "Requeue", "  requeue  "])
+def test_job_recovery_setter_is_case_insensitive(raw: str) -> None:
+    """Tolerates env-var plumbing such as ``DCC_MCP_*_JOB_RECOVERY=Requeue``
+    where adapters may emit canonical-case strings.
+    """
+    cfg = McpHttpConfig(port=8765)
+    cfg.job_recovery = raw
+    assert cfg.job_recovery == raw.strip().lower()
+
+
+def test_job_recovery_setter_rejects_unknown_value() -> None:
+    """Unknown policies surface a descriptive ``ValueError`` that names
+    the rejected value and the accepted set, so misconfigured adapters
+    fail loudly instead of silently.
+    """
+    cfg = McpHttpConfig(port=8765)
+    with pytest.raises(ValueError) as info:
+        cfg.job_recovery = "retry"
+    msg = str(info.value)
+    assert "retry" in msg and "drop" in msg and "requeue" in msg


### PR DESCRIPTION
Closes #567.

## Why

Adopters of `dcc-mcp-maya` 0.3.0 had been plumbing a `job_recovery="requeue"` knob through the adapter, but `McpHttpConfig` had no such field — the documentation in `dcc-mcp-maya/README` claimed behaviour the binary did not implement. This PR owns the contract on the core side so DCC adapters have a stable surface to bind to and so the doc lie can be retired downstream.

The issue explicitly approves a hybrid resolution ("document drop now, schedule requeue for later"). That is what this PR ships.

## What changes

### Core API

- New `JobRecoveryPolicy { Drop, Requeue }` enum in `crates/dcc-mcp-http/src/config.rs` with `as_str()` / `parse()` helpers (case-insensitive parser, tolerates env-var plumbing like `DCC_MCP_*_JOB_RECOVERY=Requeue`).
- New `McpHttpConfig::job_recovery` field defaulting to `Drop`.
- New `McpHttpConfig::with_job_recovery(JobRecoveryPolicy)` builder.
- New Python `cfg.job_recovery` getter / setter (`"drop"` / `"requeue"`, descriptive `ValueError` on unknown values).

### Server wiring

In `server/mod.rs` the recovery sweep now consults the policy. `Drop` keeps today's behaviour byte-for-byte. `Requeue` emits a single structured `WARN` at startup —

```
requested_policy=requeue effective_policy=drop issue=loonghao/dcc-mcp-core#567
job_recovery=Requeue is accepted but degrades to Drop until tool-arg persistence lands;
in-flight rows will be marked Interrupted as if Drop were configured
```

— and falls through to the same `recover_from_storage` path, so startup never fails and the row state still ends up `Interrupted`. The accepted-but-degraded contract lets adapters wire the knob through now and pick up real requeue transparently when tool-arg persistence lands (no config-shape break).

### Tests

| Layer | File | Count | What |
|-------|------|-------|------|
| Rust unit | `crates/dcc-mcp-http/src/config.rs` | +4 | default == `Drop`; builder round-trip; case-insensitive `parse`; descriptive error for unknown |
| Rust integration | `crates/dcc-mcp-http/tests/http/job_persistence.rs` | +2 | boots full `McpHttpServer` with `Drop` and `Requeue`, verifies row → `Interrupted` in either case (locks in the degrade-to-drop contract) |
| Python | `tests/test_http_config.py` | +4 | default; round-trip both wire strings; case-insensitive setter; `ValueError` names rejected value + accepted set |

### Docs

- `docs/guide/job-persistence.md` — new "Recovery policy" section with a per-variant behaviour table.
- `docs/api/http.md` — mirrors the table next to `job_storage_path`.
- `AGENTS.md` decision table — new entry for "Job recovery policy on restart".

All three explicitly state `Requeue`'s reserved status so downstream readers (and the `dcc-mcp-maya` README maintainer) have an authoritative source for the truth.

## Validation

- `cargo test -p dcc-mcp-http --features job-persist-sqlite` → 312 lib + 41 integration + 7 misc, 0 failed (was the same count before; +6 new tests slot in cleanly).
- `pytest tests/test_http_config.py -v` → 16/16 pass.
- `pytest tests/` → 8571 passed / 90 skipped / 0 failed.
- `vx just preflight` → green; ruff + clippy + cargo fmt all pass.

## Backwards compatibility

- `McpHttpConfig` gains one field with a `Default`-powered initializer; existing `McpHttpConfig::new` / `McpHttpConfig::default()` callers keep today's behaviour.
- The `recover_from_storage` row-state outcome is identical to pre-PR for both policies (ensured by the integration test).
- No serde schema in this code path, so no on-disk migration concern.

## Out of scope (future work)

- True requeue requires persisting the original tool arguments alongside the `jobs` row. That is tracked separately and will compose with this contract when it lands; this PR's `Requeue` variant is the forward-compatible API surface for it.
- `dcc-mcp-maya` README cleanup is downstream — this PR removes the upstream doc lie so the adapter can mirror the corrected story.