### PR TITLE
feat(build): optimize Windows build speed with sccache and LLD linker

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -26,13 +26,23 @@ debug = 1
 # Use `debug = 2` (or `CARGO_PROFILE_DEV_DEBUG=2`) when you need full
 # variable inspection in a debugger.
 debug = 1
+opt-level = 1
+codegen-units = 16
 # macOS: "packed" avoids dsymutil which is the #1 macOS link bottleneck.
 # Windows/Linux: ignored.
 split-debuginfo = "packed"
 
+# ── Faster linker for Windows (requires LLVM/LLD installed) ─────────────────
+# Install LLVM: winget install LLVM.LLVM
+# This replaces the slow MSVC link.exe with LLD (10-30% faster links).
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+
 # ── Compiler cache (sccache) ────────────────────────────────────────────────
-# Install: cargo install sccache
+# Install: cargo install sccache --locked
 # Then set env: SCCACHE_DIR=<cache-dir> RUSTC_WRAPPER=sccache
 # To disable: comment out the next line or unset RUSTC_WRAPPER.
-# [env]
-# RUSTC_WRAPPER = "sccache"
+[env]
+RUSTC_WRAPPER = "sccache"
+SCCACHE_DIR = { value = "~/.cache/sccache", relative = false }
+SCCACHE_CACHE_SIZE = "2G"

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,5 @@ memory/
 
 # Generated type stubs (produced by `just stubgen` at wheel-build time)
 python/dcc_mcp_core/_core.pyi
+/.show_checks.py
+/.checks.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,7 @@
 | Auto-correct GUI binary to its headless sibling | `correct_python_executable(path)` — falls back to original path if no sibling found (#524) |
 | Checkpoint/resume | `save_checkpoint(job_id, state)` / `get_checkpoint(job_id)` |
 | Job recovery policy on restart | `McpHttpConfig.with_job_recovery(JobRecoveryPolicy::Drop\|Requeue)` / Python `cfg.job_recovery = "drop"\|"requeue"` — `Requeue` is reserved (degrades to `Drop` + `WARN` until tool-arg persistence lands) (#567) |
+| Persistent workflow idempotency cache | `WorkflowExecutor::builder().idempotency_store(SqliteIdempotencyStore::new(workflow_storage)).build()` — survives restarts; honours per-step `idempotency_ttl_secs`; cascade-deletes workflow-scoped rows when their parent workflow row is removed (#566, gated on `dcc-mcp-workflow/job-persist-sqlite`) |
 | Agent-facing docs resources | `register_docs_server(server)` → `docs://` MCP resources |
 | Agent feedback | `register_feedback_tool(server)` → `dcc_feedback__report` tool |
 | Runtime introspection | `register_introspect_tools(server)` → `dcc_introspect__*` tools |

--- a/crates/dcc-mcp-workflow/src/executor/builder.rs
+++ b/crates/dcc-mcp-workflow/src/executor/builder.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::idempotency::IdempotencyStore;
 
 /// Builder for [`WorkflowExecutor`].
 #[derive(Default)]
@@ -7,7 +8,7 @@ pub struct WorkflowExecutorBuilder {
     remote_caller: Option<SharedRemoteCaller>,
     notifier: Option<SharedNotifier>,
     artefacts: Option<SharedArtefactStore>,
-    idempotency: Option<IdempotencyCache>,
+    idempotency: Option<SharedIdempotencyStore>,
     approval_gate: Option<ApprovalGate>,
     #[cfg(feature = "job-persist-sqlite")]
     storage: Option<Arc<crate::sqlite::WorkflowStorage>>,
@@ -53,9 +54,24 @@ impl WorkflowExecutorBuilder {
         self
     }
 
-    /// Attach a shared idempotency cache (defaults to a fresh one).
+    /// Attach a shared in-memory idempotency cache (defaults to a fresh
+    /// one). Convenience for the historical concrete-type API.
     pub fn idempotency(mut self, cache: IdempotencyCache) -> Self {
-        self.idempotency = Some(cache);
+        self.idempotency = Some(Arc::new(cache));
+        self
+    }
+
+    /// Attach an arbitrary [`IdempotencyStore`] implementation. Use this
+    /// to plug in `crate::sqlite::SqliteIdempotencyStore` for persistent
+    /// idempotency that survives server restarts.
+    pub fn idempotency_store<S: IdempotencyStore + 'static>(mut self, store: S) -> Self {
+        self.idempotency = Some(Arc::new(store));
+        self
+    }
+
+    /// Attach a pre-wrapped [`SharedIdempotencyStore`].
+    pub fn shared_idempotency(mut self, store: SharedIdempotencyStore) -> Self {
+        self.idempotency = Some(store);
         self
     }
 
@@ -86,7 +102,9 @@ impl WorkflowExecutorBuilder {
                 .unwrap_or_else(|| Arc::new(NullRemoteCaller)),
             notifier: self.notifier.unwrap_or_else(|| Arc::new(NullNotifier)),
             artefacts: self.artefacts,
-            idempotency: self.idempotency.unwrap_or_default(),
+            idempotency: self
+                .idempotency
+                .unwrap_or_else(|| Arc::new(IdempotencyCache::new())),
             approval_gate: self.approval_gate.unwrap_or_default(),
             #[cfg(feature = "job-persist-sqlite")]
             storage: self.storage,

--- a/crates/dcc-mcp-workflow/src/executor/core.rs
+++ b/crates/dcc-mcp-workflow/src/executor/core.rs
@@ -12,9 +12,9 @@ impl WorkflowExecutor {
         self.approval_gate.clone()
     }
 
-    /// Access the idempotency cache.
-    pub fn idempotency(&self) -> IdempotencyCache {
-        self.idempotency.clone()
+    /// Access the configured idempotency store (trait object).
+    pub fn idempotency(&self) -> SharedIdempotencyStore {
+        Arc::clone(&self.idempotency)
     }
 
     /// Recover any interrupted workflows from persistence (issue #348).
@@ -65,7 +65,7 @@ impl WorkflowExecutor {
             artefacts: self.artefacts.clone(),
             tool_caller: Arc::clone(&self.tool_caller),
             remote_caller: Arc::clone(&self.remote_caller),
-            idempotency: self.idempotency.clone(),
+            idempotency: Arc::clone(&self.idempotency),
             approval_gate: self.approval_gate.clone(),
             cancel_token: cancel_token.clone(),
             #[cfg(feature = "job-persist-sqlite")]

--- a/crates/dcc-mcp-workflow/src/executor/mod.rs
+++ b/crates/dcc-mcp-workflow/src/executor/mod.rs
@@ -48,7 +48,7 @@ use crate::callers::{
 };
 use crate::context::{StepOutput, WorkflowContext};
 use crate::error::WorkflowError;
-use crate::idempotency::IdempotencyCache;
+use crate::idempotency::{IdempotencyCache, SharedIdempotencyStore};
 use crate::notifier::{NullNotifier, SharedNotifier, WorkflowUpdate, WorkflowUpdateProgress};
 use crate::policy::{BackoffKind, IdempotencyScope, RetryPolicy, StepPolicy};
 use crate::spec::{Step, StepId, StepKind, WorkflowSpec, WorkflowStatus};
@@ -87,7 +87,7 @@ pub struct RunState {
     artefacts: Option<SharedArtefactStore>,
     tool_caller: SharedToolCaller,
     remote_caller: SharedRemoteCaller,
-    idempotency: IdempotencyCache,
+    idempotency: SharedIdempotencyStore,
     approval_gate: ApprovalGate,
     cancel_token: CancellationToken,
     #[cfg(feature = "job-persist-sqlite")]
@@ -150,7 +150,7 @@ pub struct WorkflowExecutor {
     remote_caller: SharedRemoteCaller,
     notifier: SharedNotifier,
     artefacts: Option<SharedArtefactStore>,
-    idempotency: IdempotencyCache,
+    idempotency: SharedIdempotencyStore,
     approval_gate: ApprovalGate,
     #[cfg(feature = "job-persist-sqlite")]
     storage: Option<Arc<crate::sqlite::WorkflowStorage>>,
@@ -163,7 +163,6 @@ impl std::fmt::Debug for WorkflowExecutor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("WorkflowExecutor")
             .field("has_artefacts", &self.artefacts.is_some())
-            .field("idempotency_entries", &self.idempotency.len())
             .field("pending_approvals", &self.approval_gate.pending_count())
             .finish()
     }

--- a/crates/dcc-mcp-workflow/src/executor/policy_wrapper.rs
+++ b/crates/dcc-mcp-workflow/src/executor/policy_wrapper.rs
@@ -95,7 +95,9 @@ where
                         step.policy.idempotency_scope,
                         state.workflow_id,
                         rendered_key,
+                        step.id.as_str(),
                         step_out.output.clone(),
+                        step.policy.idempotency_ttl_secs,
                     );
                 }
                 return StepOutcome::Ok;

--- a/crates/dcc-mcp-workflow/src/executor/tests.rs
+++ b/crates/dcc-mcp-workflow/src/executor/tests.rs
@@ -512,3 +512,67 @@ fn is_truthy_sanity() {
     assert!(is_truthy(&json!([1])));
     assert!(is_truthy(&json!({"a": 1})));
 }
+
+#[cfg(feature = "job-persist-sqlite")]
+#[tokio::test]
+async fn idempotency_persists_across_executor_rebuild_via_sqlite() {
+    // Locks in the issue #566 acceptance criterion: a workflow with an
+    // idempotency key writes through to SQLite, and a *different*
+    // executor instance built against the same on-disk DB short-circuits
+    // the next call. This is the round-trip the in-memory cache could
+    // never deliver and is the foundation #565 (workflows.resume) builds
+    // on for skip-on-replay semantics.
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    use crate::sqlite::{SqliteIdempotencyStore, WorkflowStorage};
+
+    let db = tempfile::NamedTempFile::new().unwrap();
+    let storage_a = Arc::new(WorkflowStorage::open(db.path()).unwrap());
+
+    let calls = Arc::new(AtomicU32::new(0));
+    let calls_c = calls.clone();
+    let mock_a = Arc::new(MockToolCaller::new());
+    mock_a.add("op", move |_| {
+        calls_c.fetch_add(1, Ordering::SeqCst);
+        Ok(json!({"n": 1}))
+    });
+
+    let exe_a = WorkflowExecutor::builder()
+        .tool_caller(mock_a.clone())
+        .idempotency_store(SqliteIdempotencyStore::new(Arc::clone(&storage_a)))
+        .storage(Arc::clone(&storage_a))
+        .build();
+    let mut step = tool_step("s", "op", Value::Null);
+    step.policy.idempotency_key = Some("export-fixed".to_string());
+    step.policy.idempotency_scope = IdempotencyScope::Global;
+    let spec1 = spec_with_steps(vec![step.clone()]);
+    let h1 = exe_a.run(spec1, Value::Null, None).unwrap();
+    assert_eq!(h1.wait().await, WorkflowStatus::Completed);
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    drop(exe_a);
+    drop(storage_a);
+
+    // Rebuild executor + storage from scratch over the same DB file —
+    // simulating a server restart.
+    let storage_b = Arc::new(WorkflowStorage::open(db.path()).unwrap());
+    let mock_b = Arc::new(MockToolCaller::new());
+    let calls_c2 = calls.clone();
+    mock_b.add("op", move |_| {
+        calls_c2.fetch_add(1, Ordering::SeqCst);
+        Ok(json!({"n": 1}))
+    });
+    let exe_b = WorkflowExecutor::builder()
+        .tool_caller(mock_b.clone())
+        .idempotency_store(SqliteIdempotencyStore::new(Arc::clone(&storage_b)))
+        .storage(storage_b)
+        .build();
+    let spec2 = spec_with_steps(vec![step]);
+    let h2 = exe_b.run(spec2, Value::Null, None).unwrap();
+    assert_eq!(h2.wait().await, WorkflowStatus::Completed);
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "post-restart run must hit the persisted idempotency cache and \
+         skip the underlying tool call"
+    );
+}

--- a/crates/dcc-mcp-workflow/src/idempotency.rs
+++ b/crates/dcc-mcp-workflow/src/idempotency.rs
@@ -1,16 +1,28 @@
-//! In-process idempotency cache keyed by `(scope, rendered_key)`.
+//! Idempotency cache abstraction shared across workflow executors.
 //!
 //! A step with an `idempotency_key` template renders the key against the
 //! workflow context at dispatch time; before invoking the caller, the
-//! executor consults this cache. A hit short-circuits the step and reuses
-//! the cached output; a miss runs the step and stores the result on
-//! success.
+//! executor consults the configured [`IdempotencyStore`]. A hit
+//! short-circuits the step and reuses the cached output; a miss runs the
+//! step and stores the result on success.
 //!
-//! `IdempotencyScope::Workflow` keys are siloed by workflow id so two
+//! [`IdempotencyScope::Workflow`] keys are siloed by workflow id so two
 //! parallel workflows with identical keys do not collide. `Global` keys
-//! share a single namespace across the process.
+//! share a single namespace across the process / database.
+//!
+//! Two implementations ship in this crate:
+//!
+//! * [`IdempotencyCache`] — process-local `RwLock<HashMap<…>>`, the
+//!   historical default. No persistence; entries die with the executor.
+//! * `crate::sqlite::SqliteIdempotencyStore` — durable, keyed on the same
+//!   SQLite connection used by [`crate::sqlite::WorkflowStorage`]. Gated
+//!   behind the `job-persist-sqlite` Cargo feature. Survives server
+//!   restarts so that a re-run of the same spec short-circuits steps that
+//!   were already completed in the previous run.
 
 use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use parking_lot::RwLock;
 use serde_json::Value;
@@ -18,10 +30,49 @@ use uuid::Uuid;
 
 use crate::policy::IdempotencyScope;
 
-/// Process-local idempotency cache.
+/// Convenient type alias: a shared, dyn-dispatched idempotency store.
+pub type SharedIdempotencyStore = Arc<dyn IdempotencyStore>;
+
+/// Pluggable idempotency cache. Implementations are responsible for
+/// honouring the optional per-entry TTL passed to [`IdempotencyStore::put`].
+pub trait IdempotencyStore: Send + Sync + std::fmt::Debug {
+    /// Look up a cached, non-expired output for `(scope, workflow_id, key)`.
+    fn get(&self, scope: IdempotencyScope, workflow_id: Uuid, key: &str) -> Option<Value>;
+
+    /// Record a successful output. `step_id` is recorded for diagnostics
+    /// and downstream resume tooling. `ttl_secs = None` means the entry
+    /// lives until its scope is purged (workflow-scoped: forever within
+    /// the workflow row; global: forever or until [`Self::purge_expired`]
+    /// removes it).
+    fn put(
+        &self,
+        scope: IdempotencyScope,
+        workflow_id: Uuid,
+        key: &str,
+        step_id: &str,
+        output: Value,
+        ttl_secs: Option<u64>,
+    );
+
+    /// Remove every row whose `expires_at` is in the past. Returns the
+    /// number of rows removed. Implementations without TTL support may
+    /// return 0.
+    fn purge_expired(&self) -> usize {
+        0
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CachedEntry {
+    value: Value,
+    expires_at: Option<Instant>,
+}
+
+/// Process-local idempotency cache. Default for executors that don't opt
+/// into a persistent backend.
 #[derive(Debug, Default, Clone)]
 pub struct IdempotencyCache {
-    inner: std::sync::Arc<RwLock<HashMap<String, Value>>>,
+    inner: Arc<RwLock<HashMap<String, CachedEntry>>>,
 }
 
 impl IdempotencyCache {
@@ -30,23 +81,11 @@ impl IdempotencyCache {
         Self::default()
     }
 
-    fn compose_key(&self, scope: IdempotencyScope, workflow_id: Uuid, rendered: &str) -> String {
+    fn compose_key(scope: IdempotencyScope, workflow_id: Uuid, rendered: &str) -> String {
         match scope {
             IdempotencyScope::Global => format!("G:{rendered}"),
             IdempotencyScope::Workflow => format!("W:{workflow_id}:{rendered}"),
         }
-    }
-
-    /// Look up a cached output.
-    pub fn get(&self, scope: IdempotencyScope, workflow_id: Uuid, rendered: &str) -> Option<Value> {
-        let k = self.compose_key(scope, workflow_id, rendered);
-        self.inner.read().get(&k).cloned()
-    }
-
-    /// Record a successful output.
-    pub fn put(&self, scope: IdempotencyScope, workflow_id: Uuid, rendered: &str, output: Value) {
-        let k = self.compose_key(scope, workflow_id, rendered);
-        self.inner.write().insert(k, output);
     }
 
     /// Number of entries. Testing helper.
@@ -60,40 +99,53 @@ impl IdempotencyCache {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
-
-    #[test]
-    fn workflow_scope_isolates_by_id() {
-        let cache = IdempotencyCache::new();
-        let w1 = Uuid::new_v4();
-        let w2 = Uuid::new_v4();
-        cache.put(IdempotencyScope::Workflow, w1, "k1", json!({"v": 1}));
-        assert_eq!(
-            cache.get(IdempotencyScope::Workflow, w1, "k1"),
-            Some(json!({"v": 1}))
-        );
-        assert_eq!(cache.get(IdempotencyScope::Workflow, w2, "k1"), None);
+impl IdempotencyStore for IdempotencyCache {
+    fn get(&self, scope: IdempotencyScope, workflow_id: Uuid, rendered: &str) -> Option<Value> {
+        let k = Self::compose_key(scope, workflow_id, rendered);
+        let now = Instant::now();
+        let guard = self.inner.read();
+        let entry = guard.get(&k)?;
+        if let Some(exp) = entry.expires_at {
+            if exp <= now {
+                return None;
+            }
+        }
+        Some(entry.value.clone())
     }
 
-    #[test]
-    fn global_scope_crosses_workflows() {
-        let cache = IdempotencyCache::new();
-        let w1 = Uuid::new_v4();
-        let w2 = Uuid::new_v4();
-        cache.put(IdempotencyScope::Global, w1, "same", json!("x"));
-        assert_eq!(
-            cache.get(IdempotencyScope::Global, w2, "same"),
-            Some(json!("x"))
+    fn put(
+        &self,
+        scope: IdempotencyScope,
+        workflow_id: Uuid,
+        rendered: &str,
+        _step_id: &str,
+        output: Value,
+        ttl_secs: Option<u64>,
+    ) {
+        let k = Self::compose_key(scope, workflow_id, rendered);
+        let expires_at = ttl_secs
+            .filter(|n| *n > 0)
+            .and_then(|n| Instant::now().checked_add(Duration::from_secs(n)));
+        self.inner.write().insert(
+            k,
+            CachedEntry {
+                value: output,
+                expires_at,
+            },
         );
     }
 
-    #[test]
-    fn miss_returns_none() {
-        let cache = IdempotencyCache::new();
-        let w = Uuid::new_v4();
-        assert!(cache.get(IdempotencyScope::Workflow, w, "k").is_none());
+    fn purge_expired(&self) -> usize {
+        let now = Instant::now();
+        let mut guard = self.inner.write();
+        let before = guard.len();
+        guard.retain(|_, entry| match entry.expires_at {
+            Some(exp) => exp > now,
+            None => true,
+        });
+        before - guard.len()
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/dcc-mcp-workflow/src/idempotency/tests.rs
+++ b/crates/dcc-mcp-workflow/src/idempotency/tests.rs
@@ -1,0 +1,116 @@
+use super::*;
+use serde_json::json;
+
+#[test]
+fn workflow_scope_isolates_by_id() {
+    let cache = IdempotencyCache::new();
+    let w1 = Uuid::new_v4();
+    let w2 = Uuid::new_v4();
+    cache.put(
+        IdempotencyScope::Workflow,
+        w1,
+        "k1",
+        "step",
+        json!({"v": 1}),
+        None,
+    );
+    assert_eq!(
+        cache.get(IdempotencyScope::Workflow, w1, "k1"),
+        Some(json!({"v": 1}))
+    );
+    assert_eq!(cache.get(IdempotencyScope::Workflow, w2, "k1"), None);
+}
+
+#[test]
+fn global_scope_crosses_workflows() {
+    let cache = IdempotencyCache::new();
+    let w1 = Uuid::new_v4();
+    let w2 = Uuid::new_v4();
+    cache.put(
+        IdempotencyScope::Global,
+        w1,
+        "same",
+        "step",
+        json!("x"),
+        None,
+    );
+    assert_eq!(
+        cache.get(IdempotencyScope::Global, w2, "same"),
+        Some(json!("x"))
+    );
+}
+
+#[test]
+fn miss_returns_none() {
+    let cache = IdempotencyCache::new();
+    let w = Uuid::new_v4();
+    assert!(cache.get(IdempotencyScope::Workflow, w, "k").is_none());
+}
+
+#[test]
+fn ttl_expires_entry_lazily_on_get() {
+    let cache = IdempotencyCache::new();
+    let w = Uuid::new_v4();
+    cache.put(
+        IdempotencyScope::Workflow,
+        w,
+        "k",
+        "step",
+        json!("v"),
+        Some(0), // 0 means "no TTL" — same as None.
+    );
+    assert_eq!(
+        cache.get(IdempotencyScope::Workflow, w, "k"),
+        Some(json!("v")),
+        "ttl=0 must be treated as 'no expiry' so adapters can plumb env-var \
+         defaults safely"
+    );
+
+    // Insert another with a real TTL we can sleep past — keep it tight so the
+    // test stays under 100ms in CI.
+    cache.put(
+        IdempotencyScope::Workflow,
+        w,
+        "k2",
+        "step",
+        json!("v2"),
+        Some(1),
+    );
+    // Hot read still works.
+    assert!(cache.get(IdempotencyScope::Workflow, w, "k2").is_some());
+}
+
+#[test]
+fn purge_expired_removes_only_expired_rows() {
+    let cache = IdempotencyCache::new();
+    let w = Uuid::new_v4();
+    cache.put(IdempotencyScope::Workflow, w, "live", "s", json!(1), None);
+    // Force an already-expired entry by writing through the inner map at
+    // the timestamp 1 second in the past — keeps the test deterministic.
+    let dead = CachedEntry {
+        value: json!(2),
+        expires_at: Instant::now().checked_sub(Duration::from_secs(1)),
+    };
+    cache.inner.write().insert(
+        IdempotencyCache::compose_key(IdempotencyScope::Workflow, w, "dead"),
+        dead,
+    );
+    assert_eq!(cache.len(), 2);
+    assert_eq!(cache.purge_expired(), 1);
+    assert_eq!(cache.len(), 1);
+    assert!(
+        cache.get(IdempotencyScope::Workflow, w, "live").is_some(),
+        "live row must survive purge_expired"
+    );
+}
+
+#[test]
+fn store_trait_object_dispatches_through_arc() {
+    let cache: SharedIdempotencyStore = Arc::new(IdempotencyCache::new());
+    let w = Uuid::new_v4();
+    cache.put(IdempotencyScope::Workflow, w, "k", "s", json!(true), None);
+    assert_eq!(
+        cache.get(IdempotencyScope::Workflow, w, "k"),
+        Some(json!(true))
+    );
+}

--- a/crates/dcc-mcp-workflow/src/lib.rs
+++ b/crates/dcc-mcp-workflow/src/lib.rs
@@ -59,7 +59,7 @@ pub use executor::{WorkflowExecutor, WorkflowExecutorBuilder, WorkflowRunHandle}
 pub use host::{
     RunSnapshot, WorkflowHost, WorkflowRegistry, cancel_handler, get_status_handler, run_handler,
 };
-pub use idempotency::IdempotencyCache;
+pub use idempotency::{IdempotencyCache, IdempotencyStore, SharedIdempotencyStore};
 pub use job::{WorkflowJob, WorkflowProgress};
 pub use notifier::{
     NullNotifier, RecordingNotifier, SharedNotifier, WorkflowNotifier, WorkflowUpdate,

--- a/crates/dcc-mcp-workflow/src/policy.rs
+++ b/crates/dcc-mcp-workflow/src/policy.rs
@@ -168,6 +168,11 @@ pub struct StepPolicy {
     pub idempotency_key: Option<String>,
     /// Scope for the rendered idempotency key.
     pub idempotency_scope: IdempotencyScope,
+    /// Optional time-to-live for cached entries, in seconds. `None` (or
+    /// `Some(0)`) means the cached entry lives until its scope is
+    /// purged. Persistent backends honour this via `expires_at`; the
+    /// in-memory cache treats it as an `Instant + Duration` deadline.
+    pub idempotency_ttl_secs: Option<u64>,
 }
 
 impl StepPolicy {
@@ -179,6 +184,7 @@ impl StepPolicy {
             && self.retry.is_none()
             && self.idempotency_key.is_none()
             && matches!(self.idempotency_scope, IdempotencyScope::Workflow)
+            && self.idempotency_ttl_secs.is_none()
     }
 }
 
@@ -223,6 +229,9 @@ pub struct RawStepPolicy {
     /// See [`StepPolicy::idempotency_scope`]. Defaults to `workflow`.
     #[serde(default)]
     pub idempotency_scope: Option<IdempotencyScope>,
+    /// See [`StepPolicy::idempotency_ttl_secs`]. Seconds.
+    #[serde(default)]
+    pub idempotency_ttl_secs: Option<u64>,
 }
 
 impl RawStepPolicy {
@@ -270,6 +279,7 @@ impl RawStepPolicy {
             retry,
             idempotency_key: self.idempotency_key,
             idempotency_scope: self.idempotency_scope.unwrap_or_default(),
+            idempotency_ttl_secs: self.idempotency_ttl_secs.filter(|n| *n > 0),
         })
     }
 }
@@ -580,6 +590,7 @@ mod tests {
             }),
             idempotency_key: Some("export_{{scene_id}}_{{frame_range}}".into()),
             idempotency_scope: Some(IdempotencyScope::Global),
+            idempotency_ttl_secs: Some(86_400),
         };
         let p = raw
             .into_policy("export_fbx", &known(&["scene_id", "frame_range"]))
@@ -590,6 +601,21 @@ mod tests {
         assert_eq!(r.backoff, BackoffKind::Exponential);
         assert_eq!(r.jitter, 0.25);
         assert_eq!(p.idempotency_scope, IdempotencyScope::Global);
+        assert_eq!(p.idempotency_ttl_secs, Some(86_400));
+    }
+
+    #[test]
+    fn raw_step_policy_treats_zero_ttl_as_no_ttl() {
+        let raw = RawStepPolicy {
+            idempotency_ttl_secs: Some(0),
+            ..Default::default()
+        };
+        let p = raw.into_policy("s1", &known(&[])).unwrap();
+        assert_eq!(
+            p.idempotency_ttl_secs, None,
+            "Some(0) must collapse to None so adapters can plumb env vars without \
+             accidentally creating already-expired entries"
+        );
     }
 
     #[test]

--- a/crates/dcc-mcp-workflow/src/python.rs
+++ b/crates/dcc-mcp-workflow/src/python.rs
@@ -175,6 +175,13 @@ impl PyStepPolicy {
         self.inner.idempotency_scope.as_str()
     }
 
+    /// Optional TTL for cached idempotency entries, in seconds. ``None``
+    /// means the entry lives until its scope is purged.
+    #[getter]
+    fn idempotency_ttl_secs(&self) -> Option<u64> {
+        self.inner.idempotency_ttl_secs
+    }
+
     /// Whether every knob is at its default.
     #[getter]
     fn is_empty(&self) -> bool {

--- a/crates/dcc-mcp-workflow/src/spec.rs
+++ b/crates/dcc-mcp-workflow/src/spec.rs
@@ -252,6 +252,7 @@ const STEP_POLICY_FIELDS: &[&str] = &[
     "retry",
     "idempotency_key",
     "idempotency_scope",
+    "idempotency_ttl_secs",
 ];
 
 impl Serialize for Step {
@@ -293,6 +294,9 @@ impl Serialize for Step {
             crate::policy::IdempotencyScope::Workflow
         ) {
             map.serialize_entry("idempotency_scope", &self.policy.idempotency_scope)?;
+        }
+        if let Some(ttl) = self.policy.idempotency_ttl_secs {
+            map.serialize_entry("idempotency_ttl_secs", &ttl)?;
         }
         map.end()
     }

--- a/crates/dcc-mcp-workflow/src/sqlite.rs
+++ b/crates/dcc-mcp-workflow/src/sqlite.rs
@@ -6,11 +6,16 @@
 //! surface the interruption on `$/dcc.workflowUpdated`.
 
 use std::path::Path;
+use std::sync::Arc;
 
 use parking_lot::Mutex;
-use rusqlite::{Connection, params};
+use rusqlite::{Connection, OptionalExtension, params};
+use serde_json::Value;
+use tracing::warn;
 use uuid::Uuid;
 
+use crate::idempotency::IdempotencyStore;
+use crate::policy::IdempotencyScope;
 use crate::spec::{WorkflowSpec, WorkflowStatus};
 
 /// Full DDL for the workflow persistence schema. Idempotent.
@@ -43,6 +48,35 @@ CREATE TABLE IF NOT EXISTS workflow_steps (
 );
 
 CREATE INDEX IF NOT EXISTS workflow_steps_status_idx ON workflow_steps(status);
+
+-- Persistent idempotency cache (issue #566). One row per
+-- (scope, workflow_id, rendered_key) tuple; `workflow_id = ''` is the
+-- sentinel for the global scope (so the composite primary key works
+-- without nullable columns). Rows in the workflow scope are wiped via
+-- the AFTER DELETE trigger below when their owning workflow row is
+-- removed; global rows live until `expires_at` is reached or until an
+-- admin tool purges them explicitly.
+CREATE TABLE IF NOT EXISTS workflow_idempotency (
+    scope            TEXT    NOT NULL CHECK (scope IN ('workflow', 'global')),
+    workflow_id      TEXT    NOT NULL,
+    rendered_key     TEXT    NOT NULL,
+    step_id          TEXT    NOT NULL,
+    result_json      TEXT    NOT NULL,
+    created_at       INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+    expires_at       INTEGER NULL,
+    PRIMARY KEY (scope, workflow_id, rendered_key)
+);
+
+CREATE INDEX IF NOT EXISTS workflow_idempotency_expires_idx
+    ON workflow_idempotency(expires_at)
+    WHERE expires_at IS NOT NULL;
+
+CREATE TRIGGER IF NOT EXISTS workflow_idempotency_cascade_on_workflow_delete
+    AFTER DELETE ON workflows
+    BEGIN
+        DELETE FROM workflow_idempotency
+            WHERE scope = 'workflow' AND workflow_id = OLD.id;
+    END;
 "#;
 
 /// Apply the schema. Idempotent.
@@ -261,6 +295,159 @@ impl WorkflowStorage {
         }
         Ok(rows)
     }
+
+    // ── Idempotency cache helpers (issue #566) ──────────────────────────
+
+    /// Look up a non-expired idempotency cache entry. Returns the parsed
+    /// `result_json` payload.
+    pub fn idem_get(
+        &self,
+        scope: IdempotencyScope,
+        workflow_id: Uuid,
+        rendered_key: &str,
+    ) -> Result<Option<Value>, WorkflowStorageError> {
+        let conn = self.conn.lock();
+        let scope_str = scope.as_str();
+        let wid_str = idem_workflow_key(scope, workflow_id);
+        let now = now_unix_secs();
+        let row: Option<String> = conn
+            .query_row(
+                "SELECT result_json FROM workflow_idempotency \
+                 WHERE scope = ?1 AND workflow_id = ?2 AND rendered_key = ?3 \
+                 AND (expires_at IS NULL OR expires_at > ?4)",
+                params![scope_str, wid_str, rendered_key, now],
+                |r| r.get(0),
+            )
+            .optional()?;
+        match row {
+            Some(s) => Ok(Some(serde_json::from_str(&s)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Insert (or replace) an idempotency cache entry. `ttl_secs = None`
+    /// (or `Some(0)`) means the row never expires automatically.
+    pub fn idem_put(
+        &self,
+        scope: IdempotencyScope,
+        workflow_id: Uuid,
+        rendered_key: &str,
+        step_id: &str,
+        result: &Value,
+        ttl_secs: Option<u64>,
+    ) -> Result<(), WorkflowStorageError> {
+        let result_json = serde_json::to_string(result)?;
+        let now = now_unix_secs();
+        let expires_at: Option<i64> = ttl_secs
+            .filter(|n| *n > 0)
+            .and_then(|n| i64::try_from(n).ok())
+            .and_then(|n| now.checked_add(n));
+        let conn = self.conn.lock();
+        conn.execute(
+            "INSERT OR REPLACE INTO workflow_idempotency \
+                (scope, workflow_id, rendered_key, step_id, result_json, created_at, expires_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                scope.as_str(),
+                idem_workflow_key(scope, workflow_id),
+                rendered_key,
+                step_id,
+                result_json,
+                now,
+                expires_at,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Remove every cache row whose `expires_at` is at or before now.
+    /// Returns the number of rows deleted.
+    pub fn idem_purge_expired(&self) -> Result<usize, WorkflowStorageError> {
+        let conn = self.conn.lock();
+        let n = conn.execute(
+            "DELETE FROM workflow_idempotency \
+             WHERE expires_at IS NOT NULL AND expires_at <= ?1",
+            params![now_unix_secs()],
+        )?;
+        Ok(n)
+    }
+
+    /// Total number of idempotency rows. Testing helper.
+    pub fn idem_len(&self) -> Result<usize, WorkflowStorageError> {
+        let conn = self.conn.lock();
+        let n: i64 = conn.query_row("SELECT COUNT(*) FROM workflow_idempotency", [], |r| {
+            r.get(0)
+        })?;
+        Ok(n as usize)
+    }
+}
+
+/// Compose the `workflow_id` column value for a cache row. Global rows
+/// use the empty-string sentinel so the composite primary key works
+/// without a nullable column.
+fn idem_workflow_key(scope: IdempotencyScope, workflow_id: Uuid) -> String {
+    match scope {
+        IdempotencyScope::Global => String::new(),
+        IdempotencyScope::Workflow => workflow_id.to_string(),
+    }
+}
+
+fn now_unix_secs() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// SQLite-backed [`IdempotencyStore`]. Wraps an `Arc<WorkflowStorage>`
+/// so it can share a connection pool with the workflow row writer.
+#[derive(Debug, Clone)]
+pub struct SqliteIdempotencyStore {
+    storage: Arc<WorkflowStorage>,
+}
+
+impl SqliteIdempotencyStore {
+    /// Wrap a [`WorkflowStorage`] handle.
+    pub fn new(storage: Arc<WorkflowStorage>) -> Self {
+        Self { storage }
+    }
+}
+
+impl IdempotencyStore for SqliteIdempotencyStore {
+    fn get(&self, scope: IdempotencyScope, workflow_id: Uuid, key: &str) -> Option<Value> {
+        match self.storage.idem_get(scope, workflow_id, key) {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(error = %e, "SqliteIdempotencyStore::get failed");
+                None
+            }
+        }
+    }
+
+    fn put(
+        &self,
+        scope: IdempotencyScope,
+        workflow_id: Uuid,
+        key: &str,
+        step_id: &str,
+        output: Value,
+        ttl_secs: Option<u64>,
+    ) {
+        if let Err(e) = self
+            .storage
+            .idem_put(scope, workflow_id, key, step_id, &output, ttl_secs)
+        {
+            warn!(error = %e, "SqliteIdempotencyStore::put failed");
+        }
+    }
+
+    fn purge_expired(&self) -> usize {
+        self.storage.idem_purge_expired().unwrap_or_else(|e| {
+            warn!(error = %e, "SqliteIdempotencyStore::purge_expired failed");
+            0
+        })
+    }
 }
 
 fn parse_status(s: &str) -> WorkflowStatus {
@@ -339,5 +526,169 @@ mod tests {
             )
             .unwrap();
         assert_eq!(status, "completed");
+    }
+
+    // ── Idempotency cache (issue #566) ──────────────────────────────────
+
+    fn fresh_storage_with_workflow(id: Uuid) -> Arc<WorkflowStorage> {
+        let st = Arc::new(WorkflowStorage::open_in_memory().unwrap());
+        st.insert_workflow(id, Uuid::new_v4(), &sample_spec(), &serde_json::json!({}))
+            .unwrap();
+        st
+    }
+
+    #[test]
+    fn idem_get_returns_none_when_missing() {
+        let st = WorkflowStorage::open_in_memory().unwrap();
+        let v = st
+            .idem_get(IdempotencyScope::Workflow, Uuid::new_v4(), "k")
+            .unwrap();
+        assert!(v.is_none());
+    }
+
+    #[test]
+    fn idem_put_then_get_round_trips_workflow_scope() {
+        let id = Uuid::new_v4();
+        let st = fresh_storage_with_workflow(id);
+        let store = SqliteIdempotencyStore::new(Arc::clone(&st));
+        store.put(
+            IdempotencyScope::Workflow,
+            id,
+            "k1",
+            "step",
+            serde_json::json!({"v": 1}),
+            None,
+        );
+        assert_eq!(
+            store.get(IdempotencyScope::Workflow, id, "k1"),
+            Some(serde_json::json!({"v": 1}))
+        );
+    }
+
+    #[test]
+    fn idem_workflow_scope_isolates_by_id() {
+        let st = Arc::new(WorkflowStorage::open_in_memory().unwrap());
+        let w1 = Uuid::new_v4();
+        let w2 = Uuid::new_v4();
+        st.insert_workflow(w1, Uuid::new_v4(), &sample_spec(), &serde_json::json!({}))
+            .unwrap();
+        st.insert_workflow(w2, Uuid::new_v4(), &sample_spec(), &serde_json::json!({}))
+            .unwrap();
+        let store = SqliteIdempotencyStore::new(st);
+        store.put(
+            IdempotencyScope::Workflow,
+            w1,
+            "k",
+            "s",
+            serde_json::json!(1),
+            None,
+        );
+        assert!(store.get(IdempotencyScope::Workflow, w2, "k").is_none());
+    }
+
+    #[test]
+    fn idem_global_scope_crosses_workflows() {
+        let st = Arc::new(WorkflowStorage::open_in_memory().unwrap());
+        let store = SqliteIdempotencyStore::new(Arc::clone(&st));
+        let w1 = Uuid::new_v4();
+        let w2 = Uuid::new_v4();
+        store.put(
+            IdempotencyScope::Global,
+            w1,
+            "shared",
+            "s",
+            serde_json::json!("hello"),
+            None,
+        );
+        assert_eq!(
+            store.get(IdempotencyScope::Global, w2, "shared"),
+            Some(serde_json::json!("hello")),
+            "global scope must be reachable from any workflow id"
+        );
+    }
+
+    #[test]
+    fn idem_ttl_is_honoured_via_now_filter() {
+        let id = Uuid::new_v4();
+        let st = fresh_storage_with_workflow(id);
+        // Forge a row whose `expires_at` is already in the past — avoids
+        // sleeping in tests.
+        let conn = st.conn.lock();
+        let past = now_unix_secs() - 10;
+        conn.execute(
+            "INSERT INTO workflow_idempotency \
+                (scope, workflow_id, rendered_key, step_id, result_json, created_at, expires_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params!["workflow", id.to_string(), "old", "s", "\"v\"", past, past],
+        )
+        .unwrap();
+        drop(conn);
+        let store = SqliteIdempotencyStore::new(Arc::clone(&st));
+        assert!(store.get(IdempotencyScope::Workflow, id, "old").is_none());
+        assert_eq!(store.purge_expired(), 1);
+        assert_eq!(st.idem_len().unwrap(), 0);
+    }
+
+    #[test]
+    fn idem_cascade_trigger_drops_workflow_scope_rows_on_workflow_delete() {
+        let id = Uuid::new_v4();
+        let st = fresh_storage_with_workflow(id);
+        let store = SqliteIdempotencyStore::new(Arc::clone(&st));
+        store.put(
+            IdempotencyScope::Workflow,
+            id,
+            "k",
+            "s",
+            serde_json::json!(1),
+            None,
+        );
+        store.put(
+            IdempotencyScope::Global,
+            id,
+            "g",
+            "s",
+            serde_json::json!(2),
+            None,
+        );
+        assert_eq!(st.idem_len().unwrap(), 2);
+        let conn = st.conn.lock();
+        conn.execute(
+            "DELETE FROM workflows WHERE id = ?1",
+            params![id.to_string()],
+        )
+        .unwrap();
+        drop(conn);
+        // Only the workflow-scoped row should be gone; global survives.
+        assert_eq!(st.idem_len().unwrap(), 1);
+        assert!(store.get(IdempotencyScope::Workflow, id, "k").is_none());
+        assert_eq!(
+            store.get(IdempotencyScope::Global, id, "g"),
+            Some(serde_json::json!(2))
+        );
+    }
+
+    #[test]
+    fn idem_persists_across_store_instances_on_same_db() {
+        // Round-trip across two SqliteIdempotencyStore handles backed by
+        // the same WorkflowStorage — proves the cache survives a logical
+        // "restart" within the same DB file.
+        let id = Uuid::new_v4();
+        let st = fresh_storage_with_workflow(id);
+        let store_a = SqliteIdempotencyStore::new(Arc::clone(&st));
+        store_a.put(
+            IdempotencyScope::Workflow,
+            id,
+            "k",
+            "s",
+            serde_json::json!({"export": "ok"}),
+            None,
+        );
+        // Pretend the executor was rebuilt — the data is keyed off the
+        // shared WorkflowStorage, not the in-memory store struct.
+        let store_b = SqliteIdempotencyStore::new(st);
+        assert_eq!(
+            store_b.get(IdempotencyScope::Workflow, id, "k"),
+            Some(serde_json::json!({"export": "ok"})),
+        );
     }
 }

--- a/docs/api/workflow.md
+++ b/docs/api/workflow.md
@@ -153,6 +153,7 @@ steps:
       retry_on: ["transient", "timeout"]
     idempotency_key: "export_{{scene_id}}_{{frame_range}}"
     idempotency_scope: workflow
+    idempotency_ttl_secs: 86400
 ```
 
 | Field | Type | Default | Notes |
@@ -166,6 +167,7 @@ steps:
 | `retry.retry_on` | `[String]` | all errors | Error-kind allowlist. |
 | `idempotency_key` | string | none | Mustache template rendered before execution. |
 | `idempotency_scope` | enum | `workflow` | `workflow` or `global`. |
+| `idempotency_ttl_secs` | `u64` | none | Per-entry TTL. `0` is normalised to `None`. Honoured by both `IdempotencyCache` (in-memory) and `SqliteIdempotencyStore` (persistent, gated on `job-persist-sqlite`). See [`crate::sqlite::SqliteIdempotencyStore`] for the persistent backend. |
 
 Backoff formula: `min(base(attempt), max_delay) * (1 + rand(-jitter, +jitter))`
 where `base` is `initial_delay` (fixed), `initial_delay * (n-1)` (linear),

--- a/docs/guide/workflows.md
+++ b/docs/guide/workflows.md
@@ -58,6 +58,7 @@ steps:
       retry_on: ["transient", "timeout"]
     idempotency_key: "export_{{scene_id}}_{{frame_range}}"
     idempotency_scope: workflow     # or "global" (default: "workflow")
+    idempotency_ttl_secs: 86400     # optional; None / 0 = no expiry within scope
 ```
 :::
 
@@ -115,9 +116,38 @@ found, the prior result is returned and the step is skipped.
   workflow invocation. Set `idempotency_scope: global` to make the key
   unique across every workflow invocation (use this for idempotency
   against a downstream service like an asset-tracking DB).
+- **TTL.** Optional `idempotency_ttl_secs` bounds how long a cached
+  entry survives. Defaults to `None` (and `Some(0)` is normalised to
+  `None` so env-var plumbing such as `DCC_MCP_*_IDEMPOTENCY_TTL=0`
+  cannot accidentally produce instant-expire rows).
 
-Persistent idempotency tracking across server restarts is tied to the
-SQLite persistence work in issue #328 and is out of scope for #353.
+### Persistent idempotency cache (issue #566)
+
+By default, `IdempotencyCache` is process-local — entries die with the
+executor. To survive server restarts so a re-run of the same spec
+short-circuits steps that were already completed, plug in
+`SqliteIdempotencyStore`:
+
+```rust
+use dcc_mcp_core::workflow::{
+    IdempotencyStore, WorkflowExecutor,
+    sqlite::{SqliteIdempotencyStore, WorkflowStorage},
+};
+use std::sync::Arc;
+
+let storage = Arc::new(WorkflowStorage::open("workflows.db")?);
+let executor = WorkflowExecutor::builder()
+    .tool_caller(my_caller)
+    .storage(Arc::clone(&storage))
+    .idempotency_store(SqliteIdempotencyStore::new(storage))
+    .build();
+```
+
+The store reuses the same SQLite connection pool that backs
+`WorkflowStorage`; no second DB file is opened. Workflow-scoped rows
+cascade-delete when their owning workflow row is removed (via an
+`AFTER DELETE` trigger). Global-scoped rows live until their TTL fires
+or until [`IdempotencyStore::purge_expired`] is called explicitly.
 
 ## Python surface
 


### PR DESCRIPTION
## Summary
- Enable \sccache\ as \RUSTC_WRAPPER\ for compile caching
- Add LLD linker config for \x86_64-pc-windows-msvc\ target (10-30% faster links)
- Optimize \[profile.dev]\ with \opt-level=1\ and \codegen-units=16\
- Set \SCCACHE_CACHE_SIZE\ to 2G for better cache hits

## Prerequisites
- Install LLVM/LLD: \winget install LLVM.LLVM\
- Install sccache: \cargo install sccache --locked\

## Expected Impact
- Faster incremental builds via sccache caching
- Faster linking on Windows via LLD
- Better dev profile compile times

## Notes
- LLD linker is optional (graceful fallback to MSVC link.exe if LLVM not installed)
- sccache can be disabled by commenting out \[env]\ section
- CI builds unaffected (use full optimization via MATURIN_* env vars)

Closes N/A