### PR TITLE
feat(workflow): workflows.resume MCP tool + executor.resume() (#565)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,7 @@
 | Checkpoint/resume | `save_checkpoint(job_id, state)` / `get_checkpoint(job_id)` |
 | Job recovery policy on restart | `McpHttpConfig.with_job_recovery(JobRecoveryPolicy::Drop\|Requeue)` / Python `cfg.job_recovery = "drop"\|"requeue"` — `Requeue` is reserved (degrades to `Drop` + `WARN` until tool-arg persistence lands) (#567) |
 | Persistent workflow idempotency cache | `WorkflowExecutor::builder().idempotency_store(SqliteIdempotencyStore::new(workflow_storage)).build()` — survives restarts; honours per-step `idempotency_ttl_secs`; cascade-deletes workflow-scoped rows when their parent workflow row is removed (#566, gated on `dcc-mcp-workflow/job-persist-sqlite`) |
+| Resume a persisted workflow run | `executor.resume(workflow_id, ResumeOptions { force_steps, expected_spec_hash, strict })` / MCP tool `workflows.resume`. Skips steps already recorded `completed`; re-runs `force_steps`; refuses on hash drift when `strict=true` (#565, gated on `dcc-mcp-workflow/job-persist-sqlite`) |
 | Agent-facing docs resources | `register_docs_server(server)` → `docs://` MCP resources |
 | Agent feedback | `register_feedback_tool(server)` → `dcc_feedback__report` tool |
 | Runtime introspection | `register_introspect_tools(server)` → `dcc_introspect__*` tools |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,6 +1206,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/dcc-mcp-workflow/Cargo.toml
+++ b/crates/dcc-mcp-workflow/Cargo.toml
@@ -36,6 +36,7 @@ base64 = { workspace = true }
 # Optional: SQLite persistence (writer + interrupted-on-restart recovery).
 rusqlite = { version = "0.39", optional = true, features = ["bundled"] }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
+sha2 = "0.11.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/dcc-mcp-workflow/src/error.rs
+++ b/crates/dcc-mcp-workflow/src/error.rs
@@ -107,3 +107,62 @@ impl From<std::io::Error> for WorkflowError {
         Self::Io(e.to_string())
     }
 }
+
+/// Errors returned by [`crate::WorkflowExecutor::resume`] (issue #565).
+#[derive(Debug, Error)]
+pub enum WorkflowResumeError {
+    /// No row found in `workflows` for this id.
+    #[error("workflow {0} not found in storage")]
+    NotFound(uuid::Uuid),
+
+    /// The row exists but is in a state where resume makes no sense
+    /// (e.g. `Completed`, `Cancelled`, or already `Running` in another
+    /// process).
+    #[error(
+        "workflow {workflow_id} is in state {status}; only Failed / Interrupted / Pending workflows can be resumed"
+    )]
+    NotResumable {
+        /// Workflow id under inspection.
+        workflow_id: uuid::Uuid,
+        /// Stringified current status.
+        status: String,
+    },
+
+    /// The persisted spec hash differs from the caller-supplied
+    /// `expected_spec_hash` and `strict=true` was requested.
+    #[error("spec drift detected for workflow {workflow_id}: expected {expected}, found {actual}")]
+    SpecChanged {
+        /// Workflow id under inspection.
+        workflow_id: uuid::Uuid,
+        /// Hash the caller asserted.
+        expected: String,
+        /// Hash actually persisted on the row.
+        actual: String,
+    },
+
+    /// Persistence is not configured on the executor (no
+    /// `WorkflowStorage` was supplied at build time).
+    #[error("resume requires a WorkflowStorage configured on the executor")]
+    NoStorage,
+
+    /// The persisted spec failed to deserialise. Indicates corruption
+    /// or a forward-incompatible schema change; the caller should
+    /// re-run the workflow from scratch.
+    #[error("failed to deserialise persisted spec for workflow {workflow_id}: {reason}")]
+    CorruptSpec {
+        /// Workflow id under inspection.
+        workflow_id: uuid::Uuid,
+        /// Underlying parse error message.
+        reason: String,
+    },
+
+    /// The re-validated spec failed validation (e.g. references a tool
+    /// that has since been removed from the registry).
+    #[error("spec for workflow {1} failed re-validation: {0}")]
+    Validation(#[source] ValidationError, uuid::Uuid),
+
+    /// Underlying storage layer I/O error.
+    #[cfg(feature = "job-persist-sqlite")]
+    #[error("storage error: {0}")]
+    Storage(#[from] crate::sqlite::WorkflowStorageError),
+}

--- a/crates/dcc-mcp-workflow/src/executor/core.rs
+++ b/crates/dcc-mcp-workflow/src/executor/core.rs
@@ -73,6 +73,7 @@ impl WorkflowExecutor {
             total_steps,
             completed: Arc::new(parking_lot::Mutex::new(0)),
             outputs_snapshot: Arc::new(parking_lot::RwLock::new(HashMap::new())),
+            preloaded_steps: Arc::new(std::collections::HashSet::new()),
         };
 
         // Persist initial row.
@@ -162,6 +163,25 @@ impl WorkflowExecutor {
                 return StepOutcome::Cancelled;
             }
             let step_id = step.id.clone();
+
+            // Resume short-circuit: if this step's id is in the
+            // preloaded set, its cached output is already in the
+            // executor's context and the row is already `completed` in
+            // storage. Skip the underlying call, emit a single
+            // `step_skipped_resume` event for observers, and move on.
+            if state.preloaded_steps.contains(step_id.as_str()) {
+                state.emit(
+                    WorkflowStatus::Running,
+                    Some(step_id.as_str()),
+                    serde_json::json!({
+                        "kind": "step_skipped_resume",
+                        "step_id": step_id.0,
+                    }),
+                );
+                state.inc_completed();
+                return StepOutcome::Ok;
+            }
+
             state.emit(
                 WorkflowStatus::Running,
                 Some(step_id.as_str()),

--- a/crates/dcc-mcp-workflow/src/executor/mod.rs
+++ b/crates/dcc-mcp-workflow/src/executor/mod.rs
@@ -65,6 +65,9 @@ pub mod helpers;
 pub mod output;
 /// Step-policy enforcement wrapper (retry, timeout, idempotency).
 pub mod policy_wrapper;
+/// Resume previously-persisted workflow runs (issue #565).
+#[cfg(feature = "job-persist-sqlite")]
+pub mod resume;
 /// Per-[`StepKind`] driver implementations.
 pub mod step_drivers;
 #[cfg(test)]
@@ -97,6 +100,9 @@ pub struct RunState {
     /// Snapshot accumulator so the executor can expose `step_outputs` to
     /// the outer MCP tool at any time.
     outputs_snapshot: Arc<parking_lot::RwLock<HashMap<String, Value>>>,
+    /// Step ids whose cached output is already in `context` and which
+    /// the executor must skip (issue #565). Empty for fresh runs.
+    preloaded_steps: Arc<std::collections::HashSet<String>>,
 }
 
 impl RunState {

--- a/crates/dcc-mcp-workflow/src/executor/resume.rs
+++ b/crates/dcc-mcp-workflow/src/executor/resume.rs
@@ -1,0 +1,225 @@
+//! `WorkflowExecutor::resume` — drive a previously-persisted workflow
+//! forward from the first non-completed step (issue #565).
+//!
+//! Resume is only available when the executor was built with
+//! `WorkflowExecutorBuilder::storage(...)` and the
+//! `job-persist-sqlite` Cargo feature is on. The persisted shape it
+//! consumes lives in `crate::sqlite::ResumeSnapshot`.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use serde_json::Value;
+use tokio_util::sync::CancellationToken;
+use tracing::warn;
+use uuid::Uuid;
+
+use super::*;
+use crate::context::{StepOutput, WorkflowContext};
+use crate::error::WorkflowResumeError;
+use crate::spec::{StepId, WorkflowSpec, WorkflowStatus};
+use crate::sqlite::{ResumeSnapshot, compute_spec_hash};
+
+/// Caller-provided knobs for [`WorkflowExecutor::resume`].
+#[derive(Debug, Default, Clone)]
+pub struct ResumeOptions {
+    /// Step ids to re-run even if their previous attempt is recorded
+    /// as `completed` in storage. Lets operators force a re-export
+    /// after a downstream pipeline correction.
+    pub force_steps: Vec<String>,
+    /// Caller-asserted spec hash (sha256 hex of the canonical spec
+    /// JSON). When `strict` is true and this differs from the hash of
+    /// the persisted spec, resume refuses with
+    /// [`WorkflowResumeError::SpecChanged`].
+    pub expected_spec_hash: Option<String>,
+    /// When `true`, refuse to resume if `expected_spec_hash` does not
+    /// match the persisted spec. When `false` (default), the persisted
+    /// spec is always treated as the source of truth and any caller
+    /// hash mismatch is logged at WARN level only.
+    pub strict: bool,
+}
+
+impl WorkflowExecutor {
+    /// Resume a previously-persisted workflow run from storage.
+    ///
+    /// Reads the persisted spec + inputs + per-step status, hydrates
+    /// the executor context with every completed step's recorded
+    /// output, marks those step ids as preloaded, then drives the spec
+    /// to completion. Steps already recorded `completed` are skipped at
+    /// the dispatcher (a single `step_skipped_resume` event is emitted
+    /// for observers); steps that were `running` or `interrupted` re-run
+    /// from the start.
+    ///
+    /// Returns [`WorkflowResumeError::NoStorage`] if the executor was
+    /// built without `WorkflowStorage`.
+    pub fn resume(
+        &self,
+        workflow_id: Uuid,
+        opts: ResumeOptions,
+    ) -> Result<WorkflowRunHandle, WorkflowResumeError> {
+        let storage = self
+            .storage
+            .as_ref()
+            .ok_or(WorkflowResumeError::NoStorage)?;
+        let snap = storage
+            .load_resume_snapshot(workflow_id)?
+            .ok_or(WorkflowResumeError::NotFound(workflow_id))?;
+        ensure_resumable(workflow_id, &snap, !opts.force_steps.is_empty())?;
+        let spec = decode_spec(workflow_id, &snap)?;
+        spec.validate()
+            .map_err(|e| WorkflowResumeError::Validation(e, workflow_id))?;
+        check_spec_hash(workflow_id, &spec, &opts)?;
+
+        let inputs: Value = serde_json::from_str(&snap.inputs_json).unwrap_or(Value::Null);
+        let force: HashSet<String> = opts.force_steps.iter().cloned().collect();
+        let preloaded: HashSet<String> = snap
+            .completed_steps
+            .iter()
+            .map(|(id, _)| id.clone())
+            .filter(|id| !force.contains(id))
+            .collect();
+
+        // Reset the row's status before driving forward — this also
+        // clears any previous error_msg so observers don't see a stale
+        // failure marker overlapping with the new run.
+        if let Err(e) = storage.reset_for_resume(workflow_id) {
+            warn!(error = %e, "reset_for_resume failed; continuing");
+        }
+
+        // Build context with completed step outputs already in place.
+        let context = WorkflowContext::new(inputs.clone());
+        for (id, output) in &snap.completed_steps {
+            if force.contains(id) {
+                continue;
+            }
+            let step_id = StepId::from(id.clone());
+            context.record_step(&step_id, StepOutput::from_value(output.clone()));
+        }
+
+        let cancel_token = CancellationToken::new();
+        let total_steps = count_steps(&spec);
+        let root_job_id = Uuid::new_v4();
+        let state = RunState {
+            workflow_id,
+            root_job_id,
+            context,
+            notifier: Arc::clone(&self.notifier),
+            artefacts: self.artefacts.clone(),
+            tool_caller: Arc::clone(&self.tool_caller),
+            remote_caller: Arc::clone(&self.remote_caller),
+            idempotency: Arc::clone(&self.idempotency),
+            approval_gate: self.approval_gate.clone(),
+            cancel_token: cancel_token.clone(),
+            storage: self.storage.clone(),
+            total_steps,
+            completed: Arc::new(parking_lot::Mutex::new(0)),
+            outputs_snapshot: Arc::new(parking_lot::RwLock::new(
+                snap.completed_steps.iter().cloned().collect(),
+            )),
+            preloaded_steps: Arc::new(preloaded),
+        };
+
+        state.emit(
+            WorkflowStatus::Pending,
+            None,
+            serde_json::json!({
+                "kind": "workflow_resumed",
+                "workflow_id": workflow_id.to_string(),
+                "preloaded_count": state.preloaded_steps.len(),
+                "force_steps": opts.force_steps,
+            }),
+        );
+
+        let default_approve_timeout = self.default_approve_timeout;
+        let spec_clone = spec.clone();
+        let state_clone = state.clone();
+        let join = tokio::spawn(async move {
+            let run_state = state_clone;
+            let terminal = Self::drive(
+                run_state.clone(),
+                spec_clone.steps.clone(),
+                default_approve_timeout,
+            )
+            .await;
+            if let Some(storage) = &run_state.storage {
+                if let Err(e) =
+                    storage.update_workflow_status(run_state.workflow_id, terminal, None)
+                {
+                    warn!(error = %e, "workflow storage status update failed");
+                }
+                if let Err(e) =
+                    storage.update_step_outputs(run_state.workflow_id, &run_state.outputs_json())
+                {
+                    warn!(error = %e, "workflow storage step outputs update failed");
+                }
+            }
+            run_state.emit(
+                terminal,
+                None,
+                serde_json::json!({"kind": "workflow_terminal"}),
+            );
+            terminal
+        });
+
+        Ok(WorkflowRunHandle {
+            workflow_id,
+            root_job_id,
+            cancel_token,
+            join,
+        })
+    }
+}
+
+fn ensure_resumable(
+    id: Uuid,
+    snap: &ResumeSnapshot,
+    has_force_steps: bool,
+) -> Result<(), WorkflowResumeError> {
+    match snap.status {
+        WorkflowStatus::Failed | WorkflowStatus::Interrupted | WorkflowStatus::Pending => Ok(()),
+        // Completed workflows can be resumed only when the caller asks
+        // to re-run specific steps (operator-driven "redo this export"
+        // scenario). A bare `resume` on a Completed workflow is a
+        // no-op and gets rejected to surface the misuse loudly.
+        WorkflowStatus::Completed if has_force_steps => Ok(()),
+        other => Err(WorkflowResumeError::NotResumable {
+            workflow_id: id,
+            status: other.as_str().to_string(),
+        }),
+    }
+}
+
+fn decode_spec(id: Uuid, snap: &ResumeSnapshot) -> Result<WorkflowSpec, WorkflowResumeError> {
+    serde_json::from_str(&snap.spec_json).map_err(|e| WorkflowResumeError::CorruptSpec {
+        workflow_id: id,
+        reason: e.to_string(),
+    })
+}
+
+fn check_spec_hash(
+    id: Uuid,
+    spec: &WorkflowSpec,
+    opts: &ResumeOptions,
+) -> Result<(), WorkflowResumeError> {
+    let Some(expected) = opts.expected_spec_hash.as_ref() else {
+        return Ok(());
+    };
+    let actual = compute_spec_hash(spec);
+    if &actual == expected {
+        return Ok(());
+    }
+    if opts.strict {
+        return Err(WorkflowResumeError::SpecChanged {
+            workflow_id: id,
+            expected: expected.clone(),
+            actual,
+        });
+    }
+    warn!(
+        workflow_id = %id,
+        expected = %expected,
+        actual = %actual,
+        "expected_spec_hash mismatch in non-strict mode; using persisted spec"
+    );
+    Ok(())
+}

--- a/crates/dcc-mcp-workflow/src/executor/tests.rs
+++ b/crates/dcc-mcp-workflow/src/executor/tests.rs
@@ -576,3 +576,196 @@ async fn idempotency_persists_across_executor_rebuild_via_sqlite() {
          skip the underlying tool call"
     );
 }
+
+#[cfg(feature = "job-persist-sqlite")]
+mod resume_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    use crate::error::WorkflowResumeError;
+    use crate::executor::resume::ResumeOptions;
+    use crate::sqlite::{WorkflowStorage, compute_spec_hash};
+
+    fn instrumented_caller(counter: Arc<AtomicU32>) -> Arc<MockToolCaller> {
+        let m = Arc::new(MockToolCaller::new());
+        m.add("a", {
+            let c = counter.clone();
+            move |_| {
+                c.fetch_add(1, Ordering::SeqCst);
+                Ok(json!({"step": "a"}))
+            }
+        });
+        m.add("b", {
+            let c = counter.clone();
+            move |_| {
+                c.fetch_add(1, Ordering::SeqCst);
+                Ok(json!({"step": "b"}))
+            }
+        });
+        m
+    }
+
+    fn two_step_spec() -> WorkflowSpec {
+        spec_with_steps(vec![
+            tool_step("a", "a", Value::Null),
+            tool_step("b", "b", Value::Null),
+        ])
+    }
+
+    #[tokio::test]
+    async fn resume_returns_not_found_for_unknown_id() {
+        let storage = Arc::new(WorkflowStorage::open_in_memory().unwrap());
+        let exe = WorkflowExecutor::builder()
+            .tool_caller(Arc::new(MockToolCaller::new()))
+            .storage(storage)
+            .build();
+        let err = exe
+            .resume(Uuid::new_v4(), ResumeOptions::default())
+            .unwrap_err();
+        assert!(matches!(err, WorkflowResumeError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn resume_skips_already_completed_steps_and_runs_the_rest() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let storage = Arc::new(WorkflowStorage::open_in_memory().unwrap());
+
+        let exe1 = WorkflowExecutor::builder()
+            .tool_caller(instrumented_caller(calls.clone()))
+            .storage(Arc::clone(&storage))
+            .build();
+        let h = exe1.run(two_step_spec(), Value::Null, None).unwrap();
+        let workflow_id = h.workflow_id;
+        assert_eq!(h.wait().await, WorkflowStatus::Completed);
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+
+        // Force the row back to Failed so it is eligible for resume.
+        storage
+            .update_workflow_status(workflow_id, WorkflowStatus::Failed, Some("a"))
+            .unwrap();
+        // Pretend step "a" completed but "b" did not.
+        storage
+            .upsert_step(workflow_id, "b", "interrupted", None, None)
+            .unwrap();
+
+        // Build a fresh executor + caller — counts only resume-time calls.
+        let calls2 = Arc::new(AtomicU32::new(0));
+        let exe2 = WorkflowExecutor::builder()
+            .tool_caller(instrumented_caller(calls2.clone()))
+            .storage(Arc::clone(&storage))
+            .build();
+        let handle = exe2.resume(workflow_id, ResumeOptions::default()).unwrap();
+        assert_eq!(handle.wait().await, WorkflowStatus::Completed);
+        assert_eq!(
+            calls2.load(Ordering::SeqCst),
+            1,
+            "resume must skip step 'a' (completed) and re-run step 'b' (interrupted) only"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_force_steps_re_runs_completed_steps() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let storage = Arc::new(WorkflowStorage::open_in_memory().unwrap());
+        let exe1 = WorkflowExecutor::builder()
+            .tool_caller(instrumented_caller(calls.clone()))
+            .storage(Arc::clone(&storage))
+            .build();
+        let wid = exe1
+            .run(two_step_spec(), Value::Null, None)
+            .unwrap()
+            .workflow_id;
+        // Wait by polling — handle.wait() consumes the join.
+        for _ in 0..50 {
+            if storage
+                .load_resume_snapshot(wid)
+                .unwrap()
+                .map(|s| s.status == WorkflowStatus::Completed)
+                .unwrap_or(false)
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        // Both 'a' and 'b' are completed. Force re-run of 'a'.
+        let calls2 = Arc::new(AtomicU32::new(0));
+        let exe2 = WorkflowExecutor::builder()
+            .tool_caller(instrumented_caller(calls2.clone()))
+            .storage(Arc::clone(&storage))
+            .build();
+        let opts = ResumeOptions {
+            force_steps: vec!["a".to_string()],
+            ..Default::default()
+        };
+        let h = exe2.resume(wid, opts).unwrap();
+        assert_eq!(h.wait().await, WorkflowStatus::Completed);
+        assert_eq!(
+            calls2.load(Ordering::SeqCst),
+            1,
+            "force_steps=['a'] must re-run step 'a' but skip 'b' (completed and not forced)"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_strict_mode_refuses_when_spec_hash_mismatches() {
+        let storage = Arc::new(WorkflowStorage::open_in_memory().unwrap());
+        let calls = Arc::new(AtomicU32::new(0));
+        let exe = WorkflowExecutor::builder()
+            .tool_caller(instrumented_caller(calls))
+            .storage(Arc::clone(&storage))
+            .build();
+        let wid = exe
+            .run(two_step_spec(), Value::Null, None)
+            .unwrap()
+            .workflow_id;
+        // Wait for terminal.
+        for _ in 0..50 {
+            if matches!(
+                storage.load_resume_snapshot(wid).unwrap().map(|s| s.status),
+                Some(WorkflowStatus::Completed)
+            ) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        storage
+            .update_workflow_status(wid, WorkflowStatus::Failed, None)
+            .unwrap();
+        let opts = ResumeOptions {
+            expected_spec_hash: Some("definitely-not-the-real-hash".to_string()),
+            strict: true,
+            ..Default::default()
+        };
+        let err = exe.resume(wid, opts).unwrap_err();
+        assert!(matches!(err, WorkflowResumeError::SpecChanged { .. }));
+    }
+
+    #[test]
+    fn resume_returns_no_storage_when_executor_lacks_storage() {
+        let exe = WorkflowExecutor::builder()
+            .tool_caller(Arc::new(MockToolCaller::new()))
+            .build();
+        let err = exe
+            .resume(Uuid::new_v4(), ResumeOptions::default())
+            .unwrap_err();
+        assert!(matches!(err, WorkflowResumeError::NoStorage));
+    }
+
+    #[test]
+    fn compute_spec_hash_is_deterministic_and_changes_with_spec() {
+        let s1 = two_step_spec();
+        let s2 = two_step_spec();
+        assert_eq!(
+            compute_spec_hash(&s1),
+            compute_spec_hash(&s2),
+            "identical specs must hash identically"
+        );
+        let s3 = spec_with_steps(vec![tool_step("c", "c", Value::Null)]);
+        assert_ne!(
+            compute_spec_hash(&s1),
+            compute_spec_hash(&s3),
+            "different specs must hash differently"
+        );
+    }
+}

--- a/crates/dcc-mcp-workflow/src/host.rs
+++ b/crates/dcc-mcp-workflow/src/host.rs
@@ -202,6 +202,19 @@ impl WorkflowHost {
             terminal_status: *r.terminal.lock(),
         })
     }
+
+    /// Resume a previously-persisted workflow run from storage.
+    /// Available only when the executor was built with a
+    /// `WorkflowStorage` and the `job-persist-sqlite` feature is on.
+    #[cfg(feature = "job-persist-sqlite")]
+    pub fn resume(
+        &self,
+        workflow_id: Uuid,
+        opts: crate::executor::resume::ResumeOptions,
+    ) -> Result<(Uuid, Uuid), crate::error::WorkflowResumeError> {
+        let handle = self.executor.resume(workflow_id, opts)?;
+        Ok(self.track(handle))
+    }
 }
 
 // ── Structured handler outputs ───────────────────────────────────────────
@@ -255,6 +268,46 @@ pub fn cancel_handler(host: &WorkflowHost, args: Value) -> Result<Value, String>
     Ok(json!({
         "workflow_id": id.to_string(),
         "cancelled": cancelled,
+    }))
+}
+
+/// Handler for the `workflows.resume` MCP tool (issue #565).
+///
+/// Accepts `{ workflow_id, force_steps?, expected_spec_hash?, strict? }`
+/// and returns `{ workflow_id, root_job_id, status, resumed: true,
+/// preloaded_steps: [...] }` on success. Any error from
+/// [`crate::error::WorkflowResumeError`] is rendered as a string.
+#[cfg(feature = "job-persist-sqlite")]
+pub fn resume_handler(host: &WorkflowHost, args: Value) -> Result<Value, String> {
+    let id = parse_workflow_id(&args)?;
+    let force_steps: Vec<String> = args
+        .get("force_steps")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    let expected_spec_hash = args
+        .get("expected_spec_hash")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let strict = args.get("strict").and_then(Value::as_bool).unwrap_or(false);
+    let opts = crate::executor::resume::ResumeOptions {
+        force_steps: force_steps.clone(),
+        expected_spec_hash,
+        strict,
+    };
+    let (workflow_id, root_job_id) = host
+        .resume(id, opts)
+        .map_err(|e| format!("workflow resume failed: {e}"))?;
+    Ok(json!({
+        "workflow_id": workflow_id.to_string(),
+        "root_job_id": root_job_id.to_string(),
+        "status": WorkflowStatus::Pending.as_str(),
+        "resumed": true,
+        "force_steps": force_steps,
     }))
 }
 

--- a/crates/dcc-mcp-workflow/src/lib.rs
+++ b/crates/dcc-mcp-workflow/src/lib.rs
@@ -54,7 +54,11 @@ pub use callers::{
 };
 pub use catalog::{WorkflowCatalog, WorkflowSummary};
 pub use context::{StepOutput, TemplateError, WorkflowContext};
+#[cfg(feature = "job-persist-sqlite")]
+pub use error::WorkflowResumeError;
 pub use error::{ValidationError, WorkflowError};
+#[cfg(feature = "job-persist-sqlite")]
+pub use executor::resume::ResumeOptions;
 pub use executor::{WorkflowExecutor, WorkflowExecutorBuilder, WorkflowRunHandle};
 pub use host::{
     RunSnapshot, WorkflowHost, WorkflowRegistry, cancel_handler, get_status_handler, run_handler,

--- a/crates/dcc-mcp-workflow/src/sqlite.rs
+++ b/crates/dcc-mcp-workflow/src/sqlite.rs
@@ -380,6 +380,108 @@ impl WorkflowStorage {
         })?;
         Ok(n as usize)
     }
+
+    // ── Resume helpers (issue #565) ────────────────────────────────────
+
+    /// Fetch every artefact needed by [`crate::WorkflowExecutor::resume`]:
+    /// the persisted spec, the original inputs, and the per-step status
+    /// + cached outputs. Returns `None` if the workflow id is unknown.
+    pub fn load_resume_snapshot(
+        &self,
+        workflow_id: Uuid,
+    ) -> Result<Option<ResumeSnapshot>, WorkflowStorageError> {
+        let conn = self.conn.lock();
+        let row: Option<(String, String, String, String)> = conn
+            .query_row(
+                "SELECT status, spec_json, inputs_json, step_outputs_json \
+                 FROM workflows WHERE id = ?1",
+                params![workflow_id.to_string()],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+            )
+            .optional()?;
+        let Some((status_str, spec_json, inputs_json, outputs_json)) = row else {
+            return Ok(None);
+        };
+        let mut stmt = conn.prepare(
+            "SELECT step_id, status, result_json FROM workflow_steps \
+             WHERE workflow_id = ?1",
+        )?;
+        let mut completed: Vec<(String, Value)> = Vec::new();
+        let rows = stmt.query_map(params![workflow_id.to_string()], |r| {
+            let id: String = r.get(0)?;
+            let status: String = r.get(1)?;
+            let out: Option<String> = r.get(2)?;
+            Ok((id, status, out))
+        })?;
+        for r in rows {
+            let (id, status, out) = r?;
+            if status == "completed" {
+                let parsed = match out {
+                    Some(s) => serde_json::from_str(&s)?,
+                    None => Value::Null,
+                };
+                completed.push((id, parsed));
+            }
+        }
+        Ok(Some(ResumeSnapshot {
+            status: parse_status(&status_str),
+            spec_json,
+            inputs_json,
+            outputs_json,
+            completed_steps: completed,
+        }))
+    }
+
+    /// Reset a workflow row's status back to `Pending` so a resume run
+    /// can drive it forward again. Clears `current_step_id` and
+    /// `error_msg`. Does NOT touch `spec_json`, `inputs_json`, or
+    /// existing `workflow_steps` rows.
+    pub fn reset_for_resume(&self, workflow_id: Uuid) -> Result<(), WorkflowStorageError> {
+        let conn = self.conn.lock();
+        conn.execute(
+            "UPDATE workflows SET status = 'pending', current_step_id = NULL, \
+                 error_msg = NULL, started_at = strftime('%s', 'now') \
+             WHERE id = ?1",
+            params![workflow_id.to_string()],
+        )?;
+        Ok(())
+    }
+}
+
+/// All persisted state needed to plan a resume — see
+/// [`WorkflowStorage::load_resume_snapshot`].
+#[derive(Debug, Clone)]
+pub struct ResumeSnapshot {
+    /// Last-persisted workflow status.
+    pub status: WorkflowStatus,
+    /// Original spec serialised at first run.
+    pub spec_json: String,
+    /// Original inputs serialised at first run.
+    pub inputs_json: String,
+    /// Latest persisted step-output bag (keyed by step id at the
+    /// outer-spec level — used for context restoration).
+    pub outputs_json: String,
+    /// `(step_id, output)` for every step that reached `completed`.
+    pub completed_steps: Vec<(String, Value)>,
+}
+
+/// Compute the canonical SHA-256 hex digest of a workflow spec. Two
+/// specs that hash the same will produce identical executor behaviour;
+/// adapters can compare this hash across catalog reloads to detect
+/// drift before issuing `workflows.resume`.
+#[must_use]
+pub fn compute_spec_hash(spec: &WorkflowSpec) -> String {
+    use sha2::{Digest, Sha256};
+    use std::fmt::Write;
+    let canonical = serde_json::to_string(spec).expect("WorkflowSpec serialises");
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.as_bytes());
+    let bytes = hasher.finalize();
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        write!(out, "{b:02x}").expect("writes to String never fail");
+    }
+    out
 }
 
 /// Compose the `workflow_id` column value for a cache row. Global rows

--- a/crates/dcc-mcp-workflow/src/tools.rs
+++ b/crates/dcc-mcp-workflow/src/tools.rs
@@ -39,6 +39,12 @@ pub mod names {
     pub const CANCEL: &str = "workflows.cancel";
     /// Read-only catalog lookup — enumerate or filter known workflows.
     pub const LOOKUP: &str = "workflows.lookup";
+    /// Resume a previously-persisted workflow run from storage (#565).
+    /// Only functional when the executor was built with persistent
+    /// storage; the metadata is registered unconditionally so
+    /// `tools/list` advertises the surface even before storage is
+    /// configured.
+    pub const RESUME: &str = "workflows.resume";
 }
 
 /// Register all four `workflows.*` built-in tools on `registry`.
@@ -53,6 +59,7 @@ pub fn register_builtin_workflow_tools(registry: &ActionRegistry) {
     registry.register_action(meta_get_status());
     registry.register_action(meta_cancel());
     registry.register_action(meta_lookup());
+    registry.register_action(meta_resume());
 }
 
 /// Register **functional** handlers for the three mutating workflow tools
@@ -74,6 +81,13 @@ pub fn register_workflow_handlers(dispatcher: &ActionDispatcher, host: &Workflow
     dispatcher.register_handler(names::GET_STATUS, move |args| get_status_handler(&h, args));
     let h = host.clone();
     dispatcher.register_handler(names::CANCEL, move |args| cancel_handler(&h, args));
+    #[cfg(feature = "job-persist-sqlite")]
+    {
+        let h = host.clone();
+        dispatcher.register_handler(names::RESUME, move |args| {
+            crate::host::resume_handler(&h, args)
+        });
+    }
 }
 
 fn meta_run() -> ActionMeta {
@@ -210,6 +224,66 @@ fn meta_lookup() -> ActionMeta {
         },
         ..Default::default()
     }
+}
+
+fn meta_resume() -> ActionMeta {
+    ActionMeta {
+        name: names::RESUME.to_string(),
+        description:
+            "Resume a previously-persisted workflow run from storage. Hydrates completed step \
+             outputs, re-runs only steps that were Pending / Running / Interrupted at \
+             persistence time. Optional `force_steps` re-runs even completed steps; optional \
+             `expected_spec_hash` + `strict=true` aborts when the persisted spec drifts. \
+             Requires the executor to be built with WorkflowStorage."
+                .to_string(),
+        category: "workflow".to_string(),
+        dcc: "core".to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        input_schema: json!({
+            "type": "object",
+            "required": ["workflow_id"],
+            "properties": {
+                "workflow_id": {"type": "string", "format": "uuid"},
+                "force_steps": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Step ids to re-run even if previously completed.",
+                },
+                "expected_spec_hash": {
+                    "type": "string",
+                    "description": "SHA-256 hex of the canonical spec JSON the caller asserts.",
+                },
+                "strict": {
+                    "type": "boolean",
+                    "description": "When true and `expected_spec_hash` mismatches the persisted spec, refuse with SpecChanged.",
+                    "default": false,
+                },
+            },
+        }),
+        output_schema: resume_output_schema(),
+        annotations: ToolAnnotations {
+            destructive_hint: Some(true),
+            read_only_hint: Some(false),
+            idempotent_hint: Some(true),
+            open_world_hint: Some(true),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+fn resume_output_schema() -> Value {
+    json!({
+        "type": "object",
+        "required": ["workflow_id", "root_job_id", "status", "resumed"],
+        "properties": {
+            "workflow_id": {"type": "string", "format": "uuid"},
+            "root_job_id": {"type": "string", "format": "uuid"},
+            "status": {"type": "string", "enum": ["pending", "running"]},
+            "resumed": {"type": "boolean", "const": true},
+            "force_steps": {"type": "array", "items": {"type": "string"}},
+        },
+    })
 }
 
 fn run_output_schema() -> Value {

--- a/docs/api/workflow.md
+++ b/docs/api/workflow.md
@@ -191,6 +191,7 @@ handlers are bound by `register_workflow_handlers(&dispatcher, &host)`.
 | `workflows.run` | Start a run (YAML or JSON spec + inputs). | `destructive_hint=true, open_world_hint=true` |
 | `workflows.get_status` | Poll terminal status + progress. | `read_only_hint=true, idempotent_hint=true` |
 | `workflows.cancel` | Cancel a run by `workflow_id` (cascade). | `destructive_hint=true, idempotent_hint=true` |
+| `workflows.resume` | Resume a persisted run from storage. Optional `force_steps` re-runs completed steps; optional `expected_spec_hash` + `strict=true` rejects on spec drift. Requires `WorkflowStorage` + `job-persist-sqlite`. (#565) | `destructive_hint=true, idempotent_hint=true, open_world_hint=true` |
 | `workflows.lookup` | Catalog search (read-only). | `read_only_hint=true` |
 
 ## Python surface

--- a/docs/guide/workflows.md
+++ b/docs/guide/workflows.md
@@ -287,7 +287,7 @@ For long-running workflows that survive a server restart, `workflows.resume`
 re-drives the persisted spec from the first non-completed step. The
 executor reads the persisted spec + inputs + per-step status from
 `WorkflowStorage`, hydrates its context with every recorded
-`completed` step's output (so downstream `{{ steps.X.output }}`
+`completed` step's output (so downstream `steps.X.output` Mustache
 references stay live), then drives forward — emitting a single
 `step_skipped_resume` event per skipped step.
 
@@ -313,8 +313,8 @@ reached `completed`.
 
 Resume requires that the executor was built with both:
 
-* `WorkflowExecutorBuilder::storage(Arc<WorkflowStorage>)`, and
-* the `dcc-mcp-workflow/job-persist-sqlite` Cargo feature.
+- `WorkflowExecutorBuilder::storage(Arc<WorkflowStorage>)`, and
+- the `dcc-mcp-workflow/job-persist-sqlite` Cargo feature.
 
 Without storage, `workflows.resume` returns `NoStorage` immediately.
 

--- a/docs/guide/workflows.md
+++ b/docs/guide/workflows.md
@@ -279,6 +279,44 @@ handlers are bound by `register_workflow_handlers(&dispatcher, &host)`.
 | `workflows.get_status` | Poll terminal status + progress.                 | `read_only_hint=true, idempotent_hint=true`   |
 | `workflows.cancel`     | Cancel a run by `workflow_id` (cascade).         | `destructive_hint=true, idempotent_hint=true` |
 | `workflows.lookup`     | Catalog search (read-only).                      | `read_only_hint=true`                         |
+| `workflows.resume`     | Resume a persisted run from storage; skips `completed` steps; honours `force_steps` + `expected_spec_hash` (#565). Requires the executor to be built with `WorkflowStorage`. | `destructive_hint=true, idempotent_hint=true, open_world_hint=true` |
+
+### Resume (issue #565)
+
+For long-running workflows that survive a server restart, `workflows.resume`
+re-drives the persisted spec from the first non-completed step. The
+executor reads the persisted spec + inputs + per-step status from
+`WorkflowStorage`, hydrates its context with every recorded
+`completed` step's output (so downstream `{{ steps.X.output }}`
+references stay live), then drives forward — emitting a single
+`step_skipped_resume` event per skipped step.
+
+Wire shape:
+
+```jsonc
+{
+  "workflow_id": "<uuid>",
+  "force_steps": ["qc"],                 // optional: re-run even if completed
+  "expected_spec_hash": "abc123...",     // optional: caller-asserted hash
+  "strict": true                          // optional: refuse on hash mismatch
+}
+```
+
+`expected_spec_hash` is the SHA-256 hex of the canonical spec JSON;
+compute it with `dcc_mcp_core::workflow::sqlite::compute_spec_hash`. With
+`strict=false` (default) a hash mismatch logs a `WARN` and proceeds
+using the persisted spec. With `strict=true` resume returns
+`SpecChanged` and the operator must reconcile the catalog before
+retrying. `force_steps` is the "re-export this step after a downstream
+correction" knob; it is the only way to re-run a step that already
+reached `completed`.
+
+Resume requires that the executor was built with both:
+
+* `WorkflowExecutorBuilder::storage(Arc<WorkflowStorage>)`, and
+* the `dcc-mcp-workflow/job-persist-sqlite` Cargo feature.
+
+Without storage, `workflows.resume` returns `NoStorage` immediately.
 
 ### Approval gating
 


### PR DESCRIPTION
Closes #565.

Depends on the persistent idempotency cache from #566 (already merged).

## Why

Long-running workflows that survive a server restart had no way to pick up where they left off — every restart forced operators to re-run the spec from the top. With #566 landed (persistent idempotency cache) the missing piece was the resume contract itself.

This PR ships the contract end-to-end: a new `WorkflowExecutor::resume(workflow_id, ResumeOptions)` method, a new `workflows.resume` MCP tool, supporting storage helpers, and the typed error enum that lets adapters react to spec drift.

## What changes

### Resume semantics

Resume reads the persisted spec + inputs + per-step status from `WorkflowStorage::load_resume_snapshot`, hydrates the executor's context with every recorded `completed` step's output (so downstream `{{ steps.X.output }}` references stay live), then drives the same spec forward. Any step id in the resume's preloaded set is short-circuited at the dispatcher with a single `step_skipped_resume` event for observers; steps that were `running`, `interrupted`, or `pending` re-run from scratch. Combined with #566's persistent idempotency cache, hot retries inside the re-run path also skip-on-replay rather than re-execute.

### Knobs

`ResumeOptions` carries three fields:

* `force_steps: Vec<String>` — operator override; re-run named steps even if their previous attempt is recorded as completed. Also unlocks resume on a `Completed` workflow (the "redo this export after a downstream pipeline correction" scenario).
* `expected_spec_hash: Option<String>` — caller-asserted SHA-256 hex of the canonical spec JSON.
* `strict: bool` — when true and `expected_spec_hash` mismatches the persisted spec, refuse with `WorkflowResumeError::SpecChanged` so the operator can reconcile the catalog before retrying. When false (default) the persisted spec stays the source of truth and the mismatch is logged at WARN.

New `compute_spec_hash(&WorkflowSpec)` helper canonicalises the spec via `serde_json` (deterministic field order) and SHA-256s it. Adapters call this once after parsing `tools.yaml` and pass the hex string through.

### Errors

```rust
pub enum WorkflowResumeError {
    NotFound(Uuid),
    NotResumable { workflow_id: Uuid, status: String },
    SpecChanged { workflow_id: Uuid, expected: String, actual: String },
    NoStorage,
    CorruptSpec { workflow_id: Uuid, reason: String },
    Validation(ValidationError, Uuid),
    Storage(WorkflowStorageError),
}
```

### MCP tool

The `workflows.resume` metadata is registered unconditionally (so `tools/list` advertises the surface even before storage is configured), but the handler is only wired when `dcc-mcp-workflow/job-persist-sqlite` is on. Without storage the call returns `NoStorage` immediately so misconfigurations fail loudly.

```jsonc
{
  "workflow_id": "<uuid>",
  "force_steps": ["qc"],                  // optional
  "expected_spec_hash": "abc123...",      // optional
  "strict": true                          // optional, default false
}
```

Response: `{ workflow_id, root_job_id, status: "pending", resumed: true, force_steps }`.

### Storage additions

All new methods on `WorkflowStorage`:

* `load_resume_snapshot(id) -> Option<ResumeSnapshot>` — single read returning persisted `(status, spec_json, inputs_json, step_outputs_json, completed_steps[])`.
* `reset_for_resume(id)` — flips status back to `Pending`, clears `current_step_id` + `error_msg`, refreshes `started_at`. Does NOT touch `spec_json`, `inputs_json`, or existing `workflow_steps` rows.
* `compute_spec_hash(&WorkflowSpec) -> String` — free function exported for catalog-side hash computation.

## Tests

| Layer | File | Count | What |
|-------|------|-------|------|
| Resume executor | `executor/tests.rs::resume_tests` | +6 | `NotFound` for unknown id; happy path (skip-completed, re-run-interrupted); `force_steps` re-runs completed steps even on a Completed workflow; `strict + hash mismatch -> SpecChanged`; `NoStorage` when storage absent; `compute_spec_hash` determinism + spec-sensitivity |

## Validation

- `cargo test -p dcc-mcp-workflow --features job-persist-sqlite` → 95 passed / 0 failed (was 89 → +6).
- `cargo test -p dcc-mcp-workflow --no-default-features` → 78 passed / 0 failed (resume module compiled out).
- `cargo test --workspace` (with sqlite features) → all green, no regressions.
- `pytest tests/` → 8579 passed / 90 skipped / 0 failed.
- `vx just preflight` → green.

## Backwards compatibility

- New `RunState.preloaded_steps` field defaults to an empty `HashSet` for fresh `run()` calls; the short-circuit branch is dead code in the non-resume path.
- `workflow_steps.result_json` is the existing column the snapshot reads; no schema migration needed.
- `executor.resume(..)` is feature-gated; without `job-persist-sqlite` the symbol is not exported and the MCP tool's handler is not registered (the metadata is, so adopters who add the feature later don't see a tool-list churn).

## Out of scope (future work)

- Per-step `step_outputs_json` is read but not yet split out into per-step columns; this PR uses what's already persisted (one `result_json` per step row).
- Mid-iteration `foreach` / `parallel` resume is still not supported — inner steps that didn't reach `completed` re-run from the start of their parent step.
- Catalog-side `expected_spec_hash` plumbing in `dcc-mcp-maya` is a downstream PR; this PR ships the core surface only.