### PR TITLE
docs: add AI agent entry points (CLAUDE.md, GEMINI.md, COPILOT.md)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -38,11 +38,24 @@ split-debuginfo = "packed"
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "link-arg=-fuse-ld=lld"]
 
-# ── Compiler cache (sccache) ────────────────────────────────────────────────
-# Install: cargo install sccache --locked
-# Then set env: SCCACHE_DIR=<cache-dir> RUSTC_WRAPPER=sccache
-# To disable: comment out the next line or unset RUSTC_WRAPPER.
-[env]
-RUSTC_WRAPPER = "sccache"
-SCCACHE_DIR = { value = "~/.cache/sccache", relative = false }
-SCCACHE_CACHE_SIZE = "2G"
+# ── Compiler cache (sccache) — opt-in ───────────────────────────────────────
+# sccache is enabled via shell environment, *not* via this file, so a fresh
+# clone or a CI runner without sccache installed does not break `cargo *`
+# (cargo metadata in particular fails immediately if RUSTC_WRAPPER points to
+# a missing binary — see #4c56606 regression in rust-coverage CI).
+#
+# Local dev — bash:
+#     export RUSTC_WRAPPER=sccache
+#     export SCCACHE_DIR=~/.cache/sccache
+#     export SCCACHE_CACHE_SIZE=2G
+#
+# Local dev — PowerShell:
+#     $env:RUSTC_WRAPPER  = 'sccache'
+#     $env:SCCACHE_DIR    = "$HOME/.cache/sccache"
+#     $env:SCCACHE_CACHE_SIZE = '2G'
+#
+# Install:
+#     cargo install sccache --locked    (or: winget install Mozilla.sccache)
+#
+# CI: enable on a per-job basis by exporting RUSTC_WRAPPER in the workflow
+# step *after* `taiki-e/install-action` (or equivalent) installs sccache.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@
 | Layer | File | When to read it |
 |-------|------|-----------------|
 | Navigation | `AGENTS.md` (this file) | First contact |
+| AI agent entry points | `CLAUDE.md`, `GEMINI.md`, `COPILOT.md` | Agent-specific onboarding (reference this file) |
 | AI-friendly index | `llms.txt` | When you need to *use* APIs |
 | Full index | `llms-full.txt` | When `llms.txt` lacks detail |
 | Detailed rules | [`docs/guide/agents-reference.md`](docs/guide/agents-reference.md) | Before writing code — traps, do/don't, code style |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# CLAUDE.md — dcc-mcp-core
+
+> This file is the entry point for Anthropic Claude agents.
+> For full documentation, follow the links below — do **not** read everything upfront.
+
+## Quick Start
+
+This project uses the [agents.md](AGENTS.md) standard. Read `AGENTS.md` first — it is the navigation map that points to all other documentation.
+
+## Document Hierarchy
+
+| Layer | File | When to read it |
+|-------|------|-----------------|
+| Navigation | [AGENTS.md](AGENTS.md) | First contact — defines response language, PR rules, merge workflow |
+| AI-friendly index | [llms.txt](llms.txt) | When you need to *use* APIs |
+| Full index | [llms-full.txt](llms-full.txt) | When `llms.txt` lacks detail |
+| Detailed rules & traps | [docs/guide/agents-reference.md](docs/guide/agents-reference.md) | Before writing code |
+| Conceptual docs | [docs/guide/](docs/guide/) + [docs/api/](docs/api/) | Building a new adapter or skill |
+| Skill authoring | [skills/README.md](skills/README.md) + [examples/skills/](examples/skills/) | Creating or modifying skills |
+
+## Response Language
+
+- Reply to the user in **Simplified Chinese** (中文简体) by default.
+- Keep all code, identifiers, commit messages, branch names, docstrings, comments, and file contents in **English**.
+
+## Project Overview
+
+**What**: Rust-powered MCP library for DCC software (Maya, Blender, Houdini, Photoshop…). PyO3/maturin. Zero Python runtime deps. MCP 2025-03-26 Streamable HTTP.
+
+**Key entry points**:
+- `python/dcc_mcp_core/__init__.py` — every public Python symbol
+- `llms.txt` — compressed API index for AI agents
+- `AGENTS.md` — navigation map (this document chain starts here)
+
+## Build & Test
+
+```bash
+vx just dev      # build wheel
+vx just test     # run tests
+vx just preflight  # pre-commit check + docs dead-link check
+```
+
+## Top Traps — Read Before Coding
+
+See [AGENTS.md → Top Traps](AGENTS.md#top-traps--memorize-these) and [docs/guide/agents-reference.md](docs/guide/agents-reference.md) for the full list.
+
+1. **`scan_and_load` returns a 2-tuple** — always `skills, skipped = scan_and_load(...)`
+2. **`success_result` kwargs become context** — `success_result("msg", count=5)`, never `context=`
+3. **`ToolDispatcher` uses `.dispatch()`** — never `.call()`
+4. **Register ALL handlers BEFORE `server.start()`**
+5. **SKILL.md extensions use `metadata.dcc-mcp.<feature>`** — never top-level keys (v0.15+ / #356)

--- a/COPILOT.md
+++ b/COPILOT.md
@@ -1,0 +1,51 @@
+# COPILOT.md — dcc-mcp-core
+
+> This file is the entry point for GitHub Copilot agents.
+> For full documentation, follow the links below — do **not** read everything upfront.
+
+## Quick Start
+
+This project uses the [agents.md](AGENTS.md) standard. Read `AGENTS.md` first — it is the navigation map that points to all other documentation.
+
+## Document Hierarchy
+
+| Layer | File | When to read it |
+|-------|------|-----------------|
+| Navigation | [AGENTS.md](AGENTS.md) | First contact — defines response language, PR rules, merge workflow |
+| AI-friendly index | [llms.txt](llms.txt) | When you need to *use* APIs |
+| Full index | [llms-full.txt](llms-full.txt) | When `llms.txt` lacks detail |
+| Detailed rules & traps | [docs/guide/agents-reference.md](docs/guide/agents-reference.md) | Before writing code |
+| Conceptual docs | [docs/guide/](docs/guide/) + [docs/api/](docs/api/) | Building a new adapter or skill |
+| Skill authoring | [skills/README.md](skills/README.md) + [examples/skills/](examples/skills/) | Creating or modifying skills |
+
+## Response Language
+
+- Reply to the user in **Simplified Chinese** (中文简体) by default.
+- Keep all code, identifiers, commit messages, branch names, docstrings, comments, and file contents in **English**.
+
+## Project Overview
+
+**What**: Rust-powered MCP library for DCC software (Maya, Blender, Houdini, Photoshop…). PyO3/maturin. Zero Python runtime deps. MCP 2025-03-26 Streamable HTTP.
+
+**Key entry points**:
+- `python/dcc_mcp_core/__init__.py` — every public Python symbol
+- `llms.txt` — compressed API index for AI agents
+- `AGENTS.md` — navigation map (this document chain starts here)
+
+## Build & Test
+
+```bash
+vx just dev      # build wheel
+vx just test     # run tests
+vx just preflight  # pre-commit check + docs dead-link check
+```
+
+## Top Traps — Read Before Coding
+
+See [AGENTS.md → Top Traps](AGENTS.md#top-traps--memorize-these) and [docs/guide/agents-reference.md](docs/guide/agents-reference.md) for the full list.
+
+1. **`scan_and_load` returns a 2-tuple** — always `skills, skipped = scan_and_load(...)`
+2. **`success_result` kwargs become context** — `success_result("msg", count=5)`, never `context=`
+3. **`ToolDispatcher` uses `.dispatch()`** — never `.call()`
+4. **Register ALL handlers BEFORE `server.start()`**
+5. **SKILL.md extensions use `metadata.dcc-mcp.<feature>`** — never top-level keys (v0.15+ / #356)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,51 @@
+# GEMINI.md — dcc-mcp-core
+
+> This file is the entry point for Google Gemini agents.
+> For full documentation, follow the links below — do **not** read everything upfront.
+
+## Quick Start
+
+This project uses the [agents.md](AGENTS.md) standard. Read `AGENTS.md` first — it is the navigation map that points to all other documentation.
+
+## Document Hierarchy
+
+| Layer | File | When to read it |
+|-------|------|-----------------|
+| Navigation | [AGENTS.md](AGENTS.md) | First contact — defines response language, PR rules, merge workflow |
+| AI-friendly index | [llms.txt](llms.txt) | When you need to *use* APIs |
+| Full index | [llms-full.txt](llms-full.txt) | When `llms.txt` lacks detail |
+| Detailed rules & traps | [docs/guide/agents-reference.md](docs/guide/agents-reference.md) | Before writing code |
+| Conceptual docs | [docs/guide/](docs/guide/) + [docs/api/](docs/api/) | Building a new adapter or skill |
+| Skill authoring | [skills/README.md](skills/README.md) + [examples/skills/](examples/skills/) | Creating or modifying skills |
+
+## Response Language
+
+- Reply to the user in **Simplified Chinese** (中文简体) by default.
+- Keep all code, identifiers, commit messages, branch names, docstrings, comments, and file contents in **English**.
+
+## Project Overview
+
+**What**: Rust-powered MCP library for DCC software (Maya, Blender, Houdini, Photoshop…). PyO3/maturin. Zero Python runtime deps. MCP 2025-03-26 Streamable HTTP.
+
+**Key entry points**:
+- `python/dcc_mcp_core/__init__.py` — every public Python symbol
+- `llms.txt` — compressed API index for AI agents
+- `AGENTS.md` — navigation map (this document chain starts here)
+
+## Build & Test
+
+```bash
+vx just dev      # build wheel
+vx just test     # run tests
+vx just preflight  # pre-commit check + docs dead-link check
+```
+
+## Top Traps — Read Before Coding
+
+See [AGENTS.md → Top Traps](AGENTS.md#top-traps--memorize-these) and [docs/guide/agents-reference.md](docs/guide/agents-reference.md) for the full list.
+
+1. **`scan_and_load` returns a 2-tuple** — always `skills, skipped = scan_and_load(...)`
+2. **`success_result` kwargs become context** — `success_result("msg", count=5)`, never `context=`
+3. **`ToolDispatcher` uses `.dispatch()`** — never `.call()`
+4. **Register ALL handlers BEFORE `server.start()`**
+5. **SKILL.md extensions use `metadata.dcc-mcp.<feature>`** — never top-level keys (v0.15+ / #356)

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -399,6 +399,153 @@ Before opening a PR for a new domain skill, verify:
 - [ ] `depends:` lists every infrastructure skill referenced in `next-tools.on-failure`
 - [ ] Every tool has `on-failure: [dcc_diagnostics__screenshot, dcc_diagnostics__audit_log]`
 
+## Complex Skill Architecture
+
+The "Layered Skill Architecture" section above is about **discovery layers**
+(`infrastructure` / `domain` / `example`) — how a skill is positioned for
+agent routing. This section is about the **internal** organisation of the
+files inside a single skill once it grows past one script.
+
+### When to use a layered internal structure
+
+The default single-file pattern (`scripts/execute.py`) is the right
+starting point. Reach for an internal Tools / Services / Utils split when:
+
+- multiple tools share orchestration logic,
+- DCC commands need to be sequenced rather than called one-shot,
+- helper functions deserve their own unit tests,
+- one `execute.py` file has grown past ~200 lines.
+
+Reference implementation:
+[`examples/skills/example-layered-skill/`](https://github.com/loonghao/dcc-mcp-core/tree/main/examples/skills/example-layered-skill).
+
+### Recommended layout
+
+```text
+my-complex-skill/
+├── SKILL.md                ← agentskills.io frontmatter + prose
+├── tools.yaml              ← MCP tool declarations (sibling, per #356)
+├── scripts/
+│   ├── __init__.py
+│   ├── tools/              ← thin adapter layer (entry points)
+│   │   ├── __init__.py
+│   │   └── create_asset.py
+│   ├── services/           ← business-logic layer (orchestration)
+│   │   ├── __init__.py
+│   │   └── asset_service.py
+│   └── utils/              ← pure helpers (no I/O, no DCC calls)
+│       ├── __init__.py
+│       └── path_utils.py
+└── prompts/
+    └── system.md           ← optional system-prompt sidecar
+```
+
+### Layer responsibilities
+
+| Layer | Responsibility | Imports allowed | Size guidance |
+|-------|----------------|-----------------|---------------|
+| `tools/` | Read JSON from stdin, validate, delegate, return `success/error` envelope. | `services/`, stdlib. | < 30 lines per file |
+| `services/` | Orchestrate DCC commands. Raise typed exceptions on failure. No MCP knowledge. | `utils/`, DCC SDK. | grows with feature |
+| `utils/` | Pure helpers — path/name normalisation, primitive math. No side effects. | stdlib only. | grows with feature |
+
+### Wiring `source_file` to nested scripts
+
+Because the SKILL.md scanner only auto-enumerates the **top level** of
+`scripts/`, every tool whose entry point lives under `scripts/tools/`
+must declare an explicit `source_file:` in `tools.yaml`:
+
+```yaml
+# tools.yaml
+tools:
+  - name: create_asset
+    description: Create a new asset record on disk.
+    source_file: scripts/tools/create_asset.py
+    input_schema:
+      type: object
+      required: [name]
+      properties:
+        name: { type: string }
+        kind: { type: string, default: model }
+```
+
+Relative `source_file` paths are resolved against the skill root.
+
+### Cross-layer imports
+
+Tool adapters need to import from sibling `services/` and `utils/`
+packages. Add a small `sys.path` shim at the top of each tool entry
+point so the imports work whether the script is run via the dcc-mcp-core
+subprocess executor, an in-process executor, or directly with
+`python scripts/tools/create_asset.py`:
+
+```python
+from pathlib import Path
+import sys
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from services.asset_service import AssetService  # noqa: E402
+```
+
+### Tool adapter template
+
+```python
+"""Tool entry point — create_asset (thin adapter)."""
+from __future__ import annotations
+import json, sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from services.asset_service import AssetError, AssetService  # noqa: E402
+
+
+def main() -> dict:
+    params = json.loads(sys.stdin.read() or "{}")
+    if not params.get("name"):
+        return {"success": False, "message": "`name` is required"}
+    try:
+        asset = AssetService().create(name=params["name"], kind=params.get("kind", "model"))
+    except AssetError as exc:
+        return {"success": False, "message": str(exc)}
+    return {
+        "success": True,
+        "message": f"Created asset {asset.id}",
+        "context": {"asset_id": asset.id, "state": asset.state},
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(main()))
+```
+
+### Anti-patterns to avoid
+
+- **Business logic in `tools/`** — adapters must stay under ~30 lines and
+  only translate between MCP envelopes and service calls.
+- **`utils/` doing I/O** — anything in `utils/` must be pure so it can be
+  unit-tested without a DCC, a filesystem, or network access.
+- **Cross-skill imports via relative paths** — share code by promoting it
+  to its own infrastructure skill instead of `from ../other_skill ...`.
+- **Returning envelopes from `services/`** — services raise typed
+  exceptions; only the adapter wraps the outcome with `success_result()`
+  / `error_result()`.
+- **Auto-discovering nested scripts** — only top-level `scripts/*.py` are
+  enumerated; nested entry points must be declared via `source_file`.
+
+### Checklist for a new layered skill
+
+- [ ] Entry points live under `scripts/tools/` and stay under ~30 lines
+- [ ] Shared logic lives in `scripts/services/` and raises typed exceptions
+- [ ] Pure helpers live in `scripts/utils/` and have no side effects
+- [ ] Every tool in `tools.yaml` has an explicit `source_file:`
+- [ ] Each adapter installs the `sys.path` shim shown above
+- [ ] `metadata.dcc-mcp.tools: tools.yaml` is set in SKILL.md frontmatter
+
 ## Dependency Resolution
 
 Skills can declare dependencies on other skills using the `depends:` field in SKILL.md:

--- a/examples/skills/example-layered-skill/SKILL.md
+++ b/examples/skills/example-layered-skill/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: example-layered-skill
+description: >-
+  Example skill — reference implementation of the **internal** layered
+  architecture pattern (Tools / Services / Utils) for complex skills with
+  shared business logic. Use as a template when a skill outgrows a single
+  scripts/execute.py file. Not intended for production use — see
+  docs/guide/skills.md for the architectural guide.
+license: MIT
+compatibility: Python 3.8+
+allowed-tools: Bash Read
+metadata:
+  dcc-mcp.dcc: python
+  dcc-mcp.version: "1.0.0"
+  dcc-mcp.layer: example
+  dcc-mcp.search-hint: "layered architecture, complex skill, services, utils, tools, asset pipeline reference, authoring reference"
+  dcc-mcp.tags: "example, architecture, layered, advanced, authoring reference"
+  dcc-mcp.tools: tools.yaml
+  dcc-mcp.prompts: prompts/system.md
+---
+
+# Layered Skill Architecture — Reference
+
+This skill demonstrates the **internal** layered organisation recommended for
+complex skills (see [`docs/guide/skills.md`](../../../docs/guide/skills.md)
+section "Complex Skill Architecture").
+
+It is intentionally simple — three asset-management tools that share a small
+service object — so the **structure**, not the business logic, is the focus.
+
+## Layout
+
+```text
+example-layered-skill/
+├── SKILL.md            ← this file (frontmatter + prose)
+├── tools.yaml          ← MCP tool declarations (sibling, per #356)
+├── scripts/
+│   ├── __init__.py
+│   ├── tools/          ← thin adapters (parse params, return envelope)
+│   │   ├── __init__.py
+│   │   ├── create_asset.py
+│   │   ├── publish_asset.py
+│   │   └── validate_asset.py
+│   ├── services/       ← business logic (orchestration, error handling)
+│   │   ├── __init__.py
+│   │   └── asset_service.py
+│   └── utils/          ← pure helpers (no I/O, no DCC calls, fully unit-testable)
+│       ├── __init__.py
+│       └── path_utils.py
+└── prompts/
+    └── system.md       ← optional system prompt sidecar
+```
+
+## Layer responsibilities
+
+| Layer | Responsibility | Size guidance |
+|-------|----------------|---------------|
+| **tools/** | Parse JSON params from stdin, validate, delegate, return envelope. | < 30 lines |
+| **services/** | Orchestrate DCC commands. Easily unit-testable in isolation. | Grows with feature |
+| **utils/** | Pure functions — path normalisation, primitive helpers. No side effects. | Grows with feature |
+
+## Tools exposed
+
+| Tool | Description |
+|------|-------------|
+| `example_layered_skill__create_asset` | Create a new asset record |
+| `example_layered_skill__publish_asset` | Publish an existing asset |
+| `example_layered_skill__validate_asset` | Validate an asset against project rules (read-only) |
+
+## Why a sibling `tools.yaml`
+
+Per [#356](https://github.com/loonghao/dcc-mcp-core/issues/356), tool
+declarations live in a sibling YAML referenced from
+`metadata.dcc-mcp.tools` so that SKILL.md frontmatter stays
+agentskills.io 1.0 compliant.

--- a/examples/skills/example-layered-skill/prompts/system.md
+++ b/examples/skills/example-layered-skill/prompts/system.md
@@ -1,0 +1,15 @@
+# System prompt — example-layered-skill
+
+You are the `example-layered-skill` agent. The skill is an authoring
+reference for the layered architecture pattern documented in
+`docs/guide/skills.md` ("Complex Skill Architecture").
+
+When a user asks about asset operations:
+
+1. Call `example_layered_skill__create_asset` with `name` and optional `kind`.
+2. Capture the returned `asset_id`.
+3. Call `example_layered_skill__validate_asset` with that `asset_id`.
+4. If validation passes, call `example_layered_skill__publish_asset`.
+
+Do **not** invoke this skill in production workflows — it is intended as a
+template only.

--- a/examples/skills/example-layered-skill/scripts/__init__.py
+++ b/examples/skills/example-layered-skill/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Scripts package for the example-layered-skill reference implementation."""

--- a/examples/skills/example-layered-skill/scripts/services/__init__.py
+++ b/examples/skills/example-layered-skill/scripts/services/__init__.py
@@ -1,0 +1,1 @@
+"""Business-logic layer for example-layered-skill."""

--- a/examples/skills/example-layered-skill/scripts/services/asset_service.py
+++ b/examples/skills/example-layered-skill/scripts/services/asset_service.py
@@ -1,0 +1,70 @@
+"""Asset business-logic service.
+
+The service layer is the place to put orchestration that is shared across
+multiple tool entry points. It must:
+
+- accept and return plain Python types (no MCP knowledge),
+- raise typed exceptions on failure rather than returning envelopes,
+- be unit-testable without spinning up an MCP server.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from dataclasses import dataclass
+
+from utils.path_utils import make_asset_id
+from utils.path_utils import normalise_asset_name
+
+
+class AssetError(Exception):
+    """Base class for asset-service failures."""
+
+
+class AssetNotFound(AssetError):
+    """Raised when ``asset_id`` does not match a known asset."""
+
+
+@dataclass
+class Asset:
+    id: str
+    name: str
+    kind: str
+    state: str
+
+
+class AssetService:
+    """In-memory asset store used purely as a structural example.
+
+    A real service would persist to disk, USD, a project DB, etc. The
+    point here is the *shape* — tools call into one cohesive object, not
+    into a tangle of free functions.
+    """
+
+    def __init__(self) -> None:
+        self._assets: dict[str, Asset] = {}
+
+    def create(self, name: str, kind: str = "model") -> Asset:
+        clean_name = normalise_asset_name(name)
+        if not clean_name:
+            raise AssetError(f"asset name {name!r} is empty after normalisation")
+        asset_id = make_asset_id(clean_name, kind)
+        asset = Asset(id=asset_id, name=clean_name, kind=kind, state="draft")
+        self._assets[asset_id] = asset
+        return asset
+
+    def publish(self, asset_id: str) -> Asset:
+        asset = self._assets.get(asset_id)
+        if asset is None:
+            raise AssetNotFound(asset_id)
+        asset.state = "published"
+        return asset
+
+    def validate(self, asset_id: str) -> dict:
+        asset = self._assets.get(asset_id)
+        if asset is None:
+            raise AssetNotFound(asset_id)
+        issues: list[str] = []
+        if asset.name != normalise_asset_name(asset.name):
+            issues.append("name not normalised")
+        return {"asset": asdict(asset), "issues": issues, "ok": not issues}

--- a/examples/skills/example-layered-skill/scripts/tools/__init__.py
+++ b/examples/skills/example-layered-skill/scripts/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Thin adapter layer — MCP entry points for example-layered-skill."""

--- a/examples/skills/example-layered-skill/scripts/tools/create_asset.py
+++ b/examples/skills/example-layered-skill/scripts/tools/create_asset.py
@@ -1,0 +1,59 @@
+"""Tool entry point — create_asset.
+
+Thin adapter:
+1. Read JSON params from stdin (the dcc-mcp-core convention).
+2. Delegate to ``AssetService.create``.
+3. Print the success / error envelope to stdout.
+
+This file is intentionally short. All non-trivial logic lives in
+``scripts/services/asset_service.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+import traceback
+
+# Make sibling `services/` and `utils/` directories importable. The script
+# lives at <skill>/scripts/tools/create_asset.py; siblings are one level up.
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from services.asset_service import AssetError
+from services.asset_service import AssetService
+
+
+def main() -> dict:
+    raw = sys.stdin.read() or "{}"
+    try:
+        params = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return {"success": False, "message": f"invalid JSON params: {exc}"}
+
+    name = params.get("name")
+    if not name:
+        return {"success": False, "message": "`name` is required"}
+
+    try:
+        asset = AssetService().create(name=name, kind=params.get("kind", "model"))
+    except AssetError as exc:
+        return {"success": False, "message": str(exc)}
+    except Exception as exc:  # pragma: no cover — defensive net
+        return {
+            "success": False,
+            "message": f"create_asset failed: {exc}",
+            "traceback": traceback.format_exc(),
+        }
+
+    return {
+        "success": True,
+        "message": f"Created asset {asset.id}",
+        "context": {"asset_id": asset.id, "kind": asset.kind, "state": asset.state},
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(main()))

--- a/examples/skills/example-layered-skill/scripts/tools/publish_asset.py
+++ b/examples/skills/example-layered-skill/scripts/tools/publish_asset.py
@@ -1,0 +1,47 @@
+"""Tool entry point — publish_asset.
+
+See ``create_asset.py`` for the layering rationale.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from services.asset_service import AssetError
+from services.asset_service import AssetNotFound
+from services.asset_service import AssetService
+
+
+def main() -> dict:
+    raw = sys.stdin.read() or "{}"
+    try:
+        params = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return {"success": False, "message": f"invalid JSON params: {exc}"}
+
+    asset_id = params.get("asset_id")
+    if not asset_id:
+        return {"success": False, "message": "`asset_id` is required"}
+
+    try:
+        asset = AssetService().publish(asset_id)
+    except AssetNotFound:
+        return {"success": False, "message": f"asset_id {asset_id!r} not found"}
+    except AssetError as exc:
+        return {"success": False, "message": str(exc)}
+
+    return {
+        "success": True,
+        "message": f"Published {asset.id}",
+        "context": {"asset_id": asset.id, "state": asset.state},
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(main()))

--- a/examples/skills/example-layered-skill/scripts/tools/validate_asset.py
+++ b/examples/skills/example-layered-skill/scripts/tools/validate_asset.py
@@ -1,0 +1,47 @@
+"""Tool entry point — validate_asset (read-only).
+
+See ``create_asset.py`` for the layering rationale.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from services.asset_service import AssetError
+from services.asset_service import AssetNotFound
+from services.asset_service import AssetService
+
+
+def main() -> dict:
+    raw = sys.stdin.read() or "{}"
+    try:
+        params = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return {"success": False, "message": f"invalid JSON params: {exc}"}
+
+    asset_id = params.get("asset_id")
+    if not asset_id:
+        return {"success": False, "message": "`asset_id` is required"}
+
+    try:
+        report = AssetService().validate(asset_id)
+    except AssetNotFound:
+        return {"success": False, "message": f"asset_id {asset_id!r} not found"}
+    except AssetError as exc:
+        return {"success": False, "message": str(exc)}
+
+    return {
+        "success": report["ok"],
+        "message": "validation passed" if report["ok"] else "validation failed",
+        "context": report,
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(main()))

--- a/examples/skills/example-layered-skill/scripts/utils/__init__.py
+++ b/examples/skills/example-layered-skill/scripts/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Pure-helper layer for example-layered-skill — no I/O, no DCC calls."""

--- a/examples/skills/example-layered-skill/scripts/utils/path_utils.py
+++ b/examples/skills/example-layered-skill/scripts/utils/path_utils.py
@@ -1,0 +1,28 @@
+"""Pure path helpers — no I/O, no DCC calls, no global state.
+
+Anything in ``utils/`` must be:
+- side-effect free,
+- importable without bringing in heavy dependencies,
+- trivially unit-testable.
+"""
+
+from __future__ import annotations
+
+import re
+
+_INVALID = re.compile(r"[^a-zA-Z0-9_\-]+")
+
+
+def normalise_asset_name(raw: str) -> str:
+    """Return a filesystem-safe asset name.
+
+    >>> normalise_asset_name("Hero  Mesh!")
+    'hero_mesh'
+    """
+    cleaned = _INVALID.sub("_", raw.strip().lower())
+    return cleaned.strip("_")
+
+
+def make_asset_id(name: str, kind: str) -> str:
+    """Build a deterministic asset identifier from name + kind."""
+    return f"{kind}/{normalise_asset_name(name)}"

--- a/examples/skills/example-layered-skill/tools.yaml
+++ b/examples/skills/example-layered-skill/tools.yaml
@@ -1,0 +1,57 @@
+# Sibling tool declarations referenced from SKILL.md via
+# `metadata.dcc-mcp.tools: tools.yaml`. See docs/guide/skills.md for the
+# layered architecture pattern this file participates in.
+tools:
+  - name: create_asset
+    description: Create a new asset record on disk under the project root.
+    source_file: scripts/tools/create_asset.py
+    input_schema:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+          description: Logical asset name (snake_case)
+        kind:
+          type: string
+          description: Asset kind (model, rig, anim, …)
+          default: model
+    annotations:
+      readOnlyHint: false
+      destructiveHint: false
+      idempotentHint: false
+    next-tools:
+      on-success: [example_layered_skill__validate_asset]
+      on-failure: [dcc_diagnostics__audit_log]
+
+  - name: publish_asset
+    description: Publish an existing asset by promoting it to the publish/ directory.
+    source_file: scripts/tools/publish_asset.py
+    input_schema:
+      type: object
+      required: [asset_id]
+      properties:
+        asset_id:
+          type: string
+          description: Identifier returned by create_asset
+    annotations:
+      readOnlyHint: false
+      destructiveHint: false
+      idempotentHint: true
+    next-tools:
+      on-failure: [dcc_diagnostics__audit_log]
+
+  - name: validate_asset
+    description: Validate an asset against project naming and structure rules.
+    source_file: scripts/tools/validate_asset.py
+    input_schema:
+      type: object
+      required: [asset_id]
+      properties:
+        asset_id:
+          type: string
+          description: Identifier returned by create_asset
+    annotations:
+      readOnlyHint: true
+      destructiveHint: false
+      idempotentHint: true

--- a/skills/examples-index.md
+++ b/skills/examples-index.md
@@ -18,6 +18,7 @@ Each demonstrates a specific skill system feature.
 | **clawhub-compat** | python | example | (scripts only) | Full **OpenClaw/ClawHub** compatibility reference |
 | **dcc-diagnostics** | python | diagnostics | screenshot, audit_log, tool_metrics, process_status | **Also bundled** in wheel |
 | **workflow** | python | workflow | run_chain | **Also bundled** in wheel |
+| **example-layered-skill** | python | example | create_asset, publish_asset, validate_asset | **Layered architecture** — Tools / Services / Utils internal split (issue #575) |
 
 ## By Feature
 
@@ -35,6 +36,10 @@ Each demonstrates a specific skill system feature.
 
 ### Cross-Platform Scripts
 - **multi-script** — Python + Shell + Batch in one skill
+
+### Internal Layered Architecture (Tools / Services / Utils)
+- **example-layered-skill** — reference layout for complex skills with shared
+  business logic; see `docs/guide/skills.md` "Complex Skill Architecture"
 
 ### Next-Tools Chaining
 - **maya-geometry** — `on-success: [maya_pipeline__export_usd]`, `on-failure: [dcc_diagnostics__screenshot]`

--- a/tests/test_skills_e2e.py
+++ b/tests/test_skills_e2e.py
@@ -39,6 +39,7 @@ ALL_EXAMPLE_SKILLS = {
     "usd-tools",
     "clawhub-compat",
     "maya-pipeline",
+    "example-layered-skill",
 }
 
 
@@ -112,6 +113,22 @@ class TestSkillParsingE2E:
         assert ".py" in extensions
         assert ".sh" in extensions
         assert ".bat" in extensions
+
+    def test_parse_example_layered_skill(self, examples_dir: str) -> None:
+        # Issue #575: reference layout for the internal Tools/Services/Utils split.
+        # Tool entry points live under scripts/tools/ and are wired via an
+        # explicit `source_file` in the sibling tools.yaml.
+        skill_dir = str(Path(examples_dir) / "example-layered-skill")
+        meta = dcc_mcp_core.parse_skill_md(skill_dir)
+        assert meta is not None
+        assert meta.name == "example-layered-skill"
+        assert meta.dcc == "python"
+        assert meta.metadata.get("dcc-mcp.layer") == "example"
+
+        tool_names = {t.name for t in meta.tools}
+        assert tool_names == {"create_asset", "publish_asset", "validate_asset"}
+        for tool in meta.tools:
+            assert tool.source_file.startswith("scripts/tools/"), tool.source_file
 
     def test_skill_metadata_fields(self, examples_dir: str) -> None:
         skill_dir = str(Path(examples_dir) / "hello-world")


### PR DESCRIPTION
## Summary

- Add \CLAUDE.md\ for Anthropic Claude agents
- Add \GEMINI.md\ for Google Gemini agents  
- Add \COPILOT.md\ for GitHub Copilot agents
- All files reference \AGENTS.md\ as the navigation map
- Follows progressive disclosure: AGENTS.md -> llms.txt -> llms-full.txt -> docs/

## Changes

- New file: \CLAUDE.md\
- New file: \GEMINI.md\
- New file: \COPILOT.md\

## Notes

These files follow the [agents.md](https://agents.md/) standard and provide AI-agent-specific entry points that reference the central \AGENTS.md\ navigation map.