### PR TITLE
docs: add CODEBUDDY.md for CodeBuddy AI agent support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,7 @@ CLEANUP_TODO.md
 .roo/
 .trae/
 .windsurf/
-CODEBUDDY.md
+
 
 # Harbor tasks (local only, not committed)
 tasks/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@
 | Layer | File | When to read it |
 |-------|------|-----------------|
 | Navigation | `AGENTS.md` (this file) | First contact |
-| AI agent entry points | `CLAUDE.md`, `GEMINI.md`, `COPILOT.md` | Agent-specific onboarding (reference this file) |
+| AI agent entry points | `CLAUDE.md`, `GEMINI.md`, `COPILOT.md`, `CODEBUDDY.md` | Agent-specific onboarding (reference this file) |
 | AI-friendly index | `llms.txt` | When you need to *use* APIs |
 | Full index | `llms-full.txt` | When `llms.txt` lacks detail |
 | Detailed rules | [`docs/guide/agents-reference.md`](docs/guide/agents-reference.md) | Before writing code — traps, do/don't, code style |

--- a/CODEBUDDY.md
+++ b/CODEBUDDY.md
@@ -1,0 +1,54 @@
+# CODEBUDDY.md — dcc-mcp-core
+
+> This file is the entry point for Tencent CodeBuddy AI agents.
+> For full documentation, follow the links below — do **not** read everything upfront.
+
+## Quick Start
+
+This project uses the [AGENTS.md](AGENTS.md) standard. Read `AGENTS.md` first — it is the navigation map that points to all other documentation.
+
+## Document Hierarchy
+
+| Layer | File | When to read it |
+|-------|------|-----------------|
+| Navigation | [AGENTS.md](AGENTS.md) | First contact — defines response language, PR rules, merge workflow |
+| AI-friendly index | [llms.txt](llms.txt) | When you need to *use* APIs |
+| Full index | [llms-full.txt](llms-full.txt) | When `llms.txt` lacks detail |
+| Detailed rules & traps | [docs/guide/agents-reference.md](docs/guide/agents-reference.md) | Before writing code |
+| Conceptual docs | [docs/guide/](docs/guide/) + [docs/api/](docs/api/) | Building a new adapter or skill |
+| Skill authoring | [skills/README.md](skills/README.md) + [examples/skills/](examples/skills/) | Creating or modifying skills |
+
+## Response Language
+
+- Reply to the user in **Simplified Chinese** (中文简体) by default.
+- Keep all code, identifiers, commit messages, branch names, docstrings, comments, and file contents in **English**.
+
+## Project Overview
+
+**What**: Rust-powered MCP library for DCC software (Maya, Blender, Houdini, Photoshop…). PyO3/maturin. Zero Python runtime deps. MCP 2025-03-26 Streamable HTTP.
+
+**Key entry points**:
+- `python/dcc_mcp_core/__init__.py` — every public Python symbol
+- `python/dcc_mcp_core/_core.pyi` — parameter names & types
+- `llms.txt` — compressed API index for AI agents
+- `AGENTS.md` — navigation map (this document chain starts here)
+
+## Build & Test
+
+```bash
+vx just dev      # build wheel
+vx just test     # run tests
+vx just preflight  # pre-commit check + docs dead-link check
+```
+
+## Top Traps — Read Before Coding
+
+See [AGENTS.md → Top Traps](AGENTS.md#top-traps--memorize-these) and [docs/guide/agents-reference.md](docs/guide/agents-reference.md) for the full list.
+
+1. **`scan_and_load` returns a 2-tuple** — always `skills, skipped = scan_and_load(...)`
+2. **`success_result` kwargs become context** — `success_result("msg", count=5)`, never `context=`
+3. **`ToolDispatcher` uses `.dispatch()`** — never `.call()`
+4. **Register ALL handlers BEFORE `server.start()`**
+5. **SKILL.md extensions use `metadata.dcc-mcp.<feature>`** — never top-level keys (v0.15+ / #356)
+6. **Use `dcc_mcp_core.METADATA_*` / `LAYER_*` / `CATEGORY_*`** — re-exported at top level; no inline `"dcc-mcp.recipes"` literals (#487)
+7. **Return `ToolResult` from Python tool handlers** — `ToolResult.ok("...", **ctx).to_dict()`; `success`/`error` are dataclass *fields*, not factories (#487)


### PR DESCRIPTION
## Summary

- Create CODEBUDDY.md following the same pattern as CLAUDE.md, GEMINI.md, COPILOT.md
- Update AGENTS.md to include CODEBUDDY.md in the Document Hierarchy table
- Remove CODEBUDDY.md from .gitignore so it can be tracked

## Details

This completes the AI agent entry point coverage for:
- Anthropic Claude (CLAUDE.md)
- Google Gemini (GEMINI.md)
- GitHub Copilot (COPILOT.md)
- Tencent CodeBuddy (CODEBUDDY.md)

## Checklist

- [x] CODEBUDDY.md created with proper content
- [x] AGENTS.md updated to reference CODEBUDDY.md
- [x] .gitignore updated to track CODEBUDDY.md
- [x] Pre-commit hooks passed
- [ ] CI passes
- [ ] Ready for review