### PR TITLE
fix: propagate tools/call error flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,7 +713,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dcc-mcp-actions"
-version = "0.14.18"
+version = "0.14.19"
 dependencies = [
  "dashmap",
  "dcc-mcp-models",
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-artefact"
-version = "0.14.18"
+version = "0.14.19"
 dependencies = [
  "chrono",
  "hex",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-capture"
-version = "0.14.18"
+version = "0.14.19"
 dependencies = [
  "image",
  "libc",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-core"
-version = "0.14.18"
+version = "0.14.19"
 dependencies = [
  "dcc-mcp-actions",
  "dcc-mcp-artefact",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-http"
-version = "0.14.18"
+version = "0.14.19"
 dependencies = [
  "axum",
  "axum-test",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-logging"
-version = "0.14.18"
+version = "0.14.19"
 dependencies = [
  "dcc-mcp-paths",
  "parking_lot",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-models"
-version = "0.14.18"
+version = "0.14.19"
 dependencies = [
  "dcc-mcp-naming",
  "dcc-mcp-pybridge",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-naming"
-version = "0.14.18"
+version = "0.14.19"
 dependencies = [
  "pyo3",
  "pyo3-stub-gen",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-paths"
-version = "0.14.18"
+version = "0.14.19"
 dependencies = [
  "dirs",
  "pyo3",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-process"
-version = "0.14.18"
+version = "0.14.19"
 dependencies = [
  "dcc-mcp-models",
  "ipckit",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-protocols"
-version = "0.14.18"
+version = "0.14.19"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-pybridge"
-version = "0.14.18"
+version = "0.14.19"
 dependencies = [
  "dcc-mcp-pybridge-derive",
  "pyo3",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-pybridge-derive"
-version = "0.14.18"
+version = "0.14.19"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-sandbox"
-version = "0.14.18"
+version = "0.14.19"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-scheduler"
-version = "0.14.18"
+version = "0.14.19"
 dependencies = [
  "axum",
  "bytes",
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-server"
-version = "0.14.18"
+version = "0.14.19"
 dependencies = [
  "anyhow",
  "axum",
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-shm"
-version = "0.14.18"
+version = "0.14.19"
 dependencies = [
  "ipckit",
  "libc",
@@ -1052,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-skills"
-version = "0.14.18"
+version = "0.14.19"
 dependencies = [
  "dashmap",
  "dcc-mcp-actions",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-telemetry"
-version = "0.14.18"
+version = "0.14.19"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-transport"
-version = "0.14.18"
+version = "0.14.19"
 dependencies = [
  "criterion",
  "dashmap",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-agent"
-version = "0.14.18"
+version = "0.14.19"
 dependencies = [
  "dashmap",
  "dcc-mcp-tunnel-protocol",
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-protocol"
-version = "0.14.18"
+version = "0.14.19"
 dependencies = [
  "jsonwebtoken",
  "rmp-serde",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-relay"
-version = "0.14.18"
+version = "0.14.19"
 dependencies = [
  "axum",
  "dashmap",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-usd"
-version = "0.14.18"
+version = "0.14.19"
 dependencies = [
  "dcc-mcp-protocols",
  "pyo3",
@@ -1188,7 +1188,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-workflow"
-version = "0.14.18"
+version = "0.14.19"
 dependencies = [
  "base64",
  "chrono",

--- a/crates/dcc-mcp-http/src/handlers/tools_call/sync_impl.rs
+++ b/crates/dcc-mcp-http/src/handlers/tools_call/sync_impl.rs
@@ -317,6 +317,7 @@ fn build_call_result(
 }
 
 fn success_result(state: &AppState, session_id: Option<&str>, output: Value) -> CallToolResult {
+    let is_error = output_indicates_error(&output);
     let text = match &output {
         Value::String(s) => s.clone(),
         Value::Null => String::new(),
@@ -342,8 +343,22 @@ fn success_result(state: &AppState, session_id: Option<&str>, output: Value) -> 
     CallToolResult {
         content,
         structured_content,
-        is_error: false,
+        is_error,
         meta: None,
+    }
+}
+
+fn output_indicates_error(output: &Value) -> bool {
+    match output {
+        Value::Object(obj) => {
+            obj.get("success").and_then(Value::as_bool) == Some(false)
+                || obj.get("isError").and_then(Value::as_bool) == Some(true)
+        }
+        Value::String(text) => serde_json::from_str::<Value>(text)
+            .ok()
+            .as_ref()
+            .is_some_and(output_indicates_error),
+        _ => false,
     }
 }
 

--- a/crates/dcc-mcp-http/src/tests/dispatch_with_handler.rs
+++ b/crates/dcc-mcp-http/src/tests/dispatch_with_handler.rs
@@ -54,6 +54,50 @@ pub fn make_router_with_handler() -> axum::Router {
         .with_state(state)
 }
 
+fn make_router_with_handler_output(output: Value) -> axum::Router {
+    use crate::handler::{handle_delete, handle_get, handle_post};
+    use axum::{Router, routing};
+
+    let registry = Arc::new(make_registry());
+    let catalog = Arc::new(SkillCatalog::new(registry.clone()));
+    let dispatcher = Arc::new(ActionDispatcher::new((*registry).clone()));
+    dispatcher.register_handler("get_scene_info", move |_params| Ok(output.clone()));
+    let state = AppState {
+        registry,
+        dispatcher,
+        catalog,
+        sessions: SessionManager::new(),
+        executor: None,
+        bridge_registry: crate::BridgeRegistry::new(),
+        server_name: "test-dcc".to_string(),
+        server_version: "0.1.0".to_string(),
+        cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+        in_flight: crate::inflight::InFlightRequests::new(),
+        pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
+        lazy_actions: false,
+        bare_tool_names: true,
+        declared_capabilities: std::sync::Arc::new(Vec::new()),
+        jobs: std::sync::Arc::new(crate::job::JobManager::new()),
+        job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
+        resources: crate::resources::ResourceRegistry::new(true, false),
+        enable_resources: true,
+        prompts: crate::prompts::PromptRegistry::new(true),
+        enable_prompts: true,
+        registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
+        enable_tool_cache: true,
+        method_router: crate::handler::AppState::default_method_router(),
+    };
+
+    Router::new()
+        .route(
+            "/mcp",
+            routing::post(handle_post)
+                .get(handle_get)
+                .delete(handle_delete),
+        )
+        .with_state(state)
+}
+
 #[tokio::test]
 pub async fn test_tools_call_with_registered_handler() {
     let server = TestServer::new(make_router_with_handler());
@@ -82,6 +126,72 @@ pub async fn test_tools_call_with_registered_handler() {
     let text = body["result"]["content"][0]["text"].as_str().unwrap_or("");
     // The JSON output from the handler should be present
     assert!(text.contains("test_scene") || text.contains("objects"));
+}
+
+#[tokio::test]
+pub async fn test_tools_call_success_false_sets_is_error() {
+    let server = TestServer::new(make_router_with_handler_output(json!({
+        "success": false,
+        "message": "Execution failed",
+        "error": "SyntaxError",
+    })));
+
+    let resp = server
+        .post("/mcp")
+        .add_header(
+            axum::http::header::ACCEPT,
+            "application/json".parse::<HeaderValue>().unwrap(),
+        )
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 43,
+            "method": "tools/call",
+            "params": {
+                "name": "get_scene_info",
+                "arguments": {}
+            }
+        }))
+        .await;
+
+    resp.assert_status_ok();
+    let body: Value = resp.json();
+    assert_eq!(body["result"]["isError"], true);
+    let text = body["result"]["content"][0]["text"].as_str().unwrap_or("");
+    let parsed: Value = serde_json::from_str(text).unwrap();
+    assert_eq!(parsed["success"], false);
+    assert_eq!(parsed["error"], "SyntaxError");
+}
+
+#[tokio::test]
+pub async fn test_tools_call_json_string_success_false_sets_is_error() {
+    let server = TestServer::new(make_router_with_handler_output(json!(
+        r#"{"success":false,"message":"Execution failed","error":"SyntaxError"}"#
+    )));
+
+    let resp = server
+        .post("/mcp")
+        .add_header(
+            axum::http::header::ACCEPT,
+            "application/json".parse::<HeaderValue>().unwrap(),
+        )
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 44,
+            "method": "tools/call",
+            "params": {
+                "name": "get_scene_info",
+                "arguments": {}
+            }
+        }))
+        .await;
+
+    resp.assert_status_ok();
+    let body: Value = resp.json();
+    assert_eq!(body["result"]["isError"], true);
+    let text = body["result"]["content"][0]["text"].as_str().unwrap_or("");
+    let parsed: Value = serde_json::from_str(text).unwrap();
+    assert_eq!(parsed["success"], false);
+    assert_eq!(parsed["error"], "SyntaxError");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Set `tools/call` `isError` from structured tool envelopes when handlers return `success: false` or `isError: true`.
- Cover both object outputs and JSON-string envelope outputs so direct HTTP clients can detect execution failures.
- Include the `Cargo.lock` sync generated by cargo/pre-commit for workspace crate version consistency.

## Test plan
- `cargo fmt`
- `cargo test -p dcc-mcp-http dispatch_with_handler`
- pre-commit hook: `cargo clippy`

Fixes #593
Refs #589