### PR TITLE
fix: require executor for main-affined skills

### DIFF
--- a/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
@@ -38,6 +38,15 @@ impl SkillCatalog {
             };
 
             let script_path = resolve_tool_script(tool_decl, &metadata.scripts, skill_path);
+            let maybe_executor = self.script_executor.read().clone();
+            if tool_decl.thread_affinity.is_main() && maybe_executor.is_none() {
+                return Err(format!(
+                    "Tool '{}' requires thread_affinity='main', but no in-process executor is set. \
+                     Ensure the DCC adapter calls set_in_process_executor() before loading skills.",
+                    action_name
+                ));
+            }
+
             let meta = ActionMeta {
                 name: action_name.clone(),
                 description: if tool_decl.description.is_empty() {
@@ -77,7 +86,6 @@ impl SkillCatalog {
                 let script_path_owned = script_path.clone();
                 let action_name_clone = action_name.clone();
                 let dcc_owned = metadata.dcc.clone();
-                let maybe_executor = self.script_executor.read().clone();
                 if let Some(executor) = maybe_executor {
                     dispatcher.register_handler(&action_name_clone, move |params| {
                         executor(script_path_owned.clone(), params)

--- a/crates/dcc-mcp-skills/src/catalog/tests/test_catalog_crud.rs
+++ b/crates/dcc-mcp-skills/src/catalog/tests/test_catalog_crud.rs
@@ -1,4 +1,4 @@
-use super::fixtures::{make_test_catalog, make_test_skill};
+use super::fixtures::{make_catalog_with_dispatcher, make_test_catalog, make_test_skill};
 use super::*;
 use dcc_mcp_models::ToolDeclaration;
 
@@ -54,6 +54,38 @@ fn test_load_skill_with_action_meta_skill_name() {
         .get_action("my_skill__tool1", None)
         .unwrap();
     assert_eq!(meta.skill_name, Some("my-skill".to_string()));
+}
+
+#[test]
+fn test_load_main_affinity_script_requires_in_process_executor() {
+    let (catalog, _dispatcher) = make_catalog_with_dispatcher();
+    let mut skill = make_test_skill("main-thread", "maya", &[]);
+    skill.tools = vec![ToolDeclaration {
+        name: "execute_python".to_string(),
+        source_file: "scripts/execute_python.py".to_string(),
+        thread_affinity: dcc_mcp_models::ThreadAffinity::Main,
+        ..Default::default()
+    }];
+    catalog.add_skill(skill);
+
+    let err = catalog
+        .load_skill("main-thread")
+        .expect_err("main-affined script tools need an in-process executor");
+    assert!(
+        err.contains("requires thread_affinity='main'"),
+        "error should explain the main-thread requirement: {err}"
+    );
+    assert!(
+        err.contains("set_in_process_executor()"),
+        "error should tell DCC adapters how to fix the setup: {err}"
+    );
+    assert!(
+        catalog
+            .registry()
+            .get_action("main_thread__execute_python", None)
+            .is_none(),
+        "failed loads must not leave partially registered actions"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Fail skill loading when a tool declares `thread_affinity: main` without an in-process executor.
- Avoid leaving partially registered actions when that configuration error is detected.

## Test plan
- `cargo fmt --check`
- `cargo test -p dcc-mcp-skills test_load_main_affinity_script_requires_in_process_executor`
- `cargo test -p dcc-mcp-skills`

Closes #590.
