### PR TITLE
fix: surface in-process skill errors as structured envelopes

### DIFF
--- a/python/dcc_mcp_core/_server/__init__.py
+++ b/python/dcc_mcp_core/_server/__init__.py
@@ -18,6 +18,7 @@ from dcc_mcp_core._server.callable_dispatcher import PumpStats
 from dcc_mcp_core._server.callable_dispatcher import current_callable_job
 from dcc_mcp_core._server.inprocess_executor import BaseDccCallableDispatcher
 from dcc_mcp_core._server.inprocess_executor import build_inprocess_executor
+from dcc_mcp_core._server.inprocess_executor import exception_to_error_envelope
 from dcc_mcp_core._server.inprocess_executor import run_skill_script
 from dcc_mcp_core._server.minimal_mode import MinimalModeConfig
 from dcc_mcp_core._server.observability import FileLoggingManager
@@ -45,5 +46,6 @@ __all__ = [
     "WindowResolver",
     "build_inprocess_executor",
     "current_callable_job",
+    "exception_to_error_envelope",
     "run_skill_script",
 ]

--- a/python/dcc_mcp_core/_server/inprocess_executor.py
+++ b/python/dcc_mcp_core/_server/inprocess_executor.py
@@ -26,6 +26,7 @@ import importlib.util
 import logging
 from pathlib import Path
 import sys
+import traceback
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
@@ -57,8 +58,36 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "BaseDccCallableDispatcher",
     "build_inprocess_executor",
+    "exception_to_error_envelope",
     "run_skill_script",
 ]
+
+
+def exception_to_error_envelope(exc: BaseException, *, message: str | None = None) -> dict[str, Any]:
+    """Render *exc* as a structured ``ToolResult``-shaped error dict.
+
+    The returned envelope mirrors the wire shape clients already receive
+    on success — ``success`` / ``message`` / ``error`` (issue #589) — so
+    Rust ``CallToolResult`` construction can flag ``isError: true`` from
+    the same ``success: false`` heuristic without any extra string
+    parsing on the client side.
+
+    The traceback is folded into ``error.traceback`` (single string,
+    pre-formatted) so MCP clients can render it inline. Skill authors
+    catching exceptions inside ``main`` can reuse this helper to keep
+    the envelope shape consistent across in-process and subprocess
+    execution.
+    """
+    msg = message if message is not None else f"Execution failed: {exc}"
+    return {
+        "success": False,
+        "message": msg,
+        "error": {
+            "type": type(exc).__name__,
+            "message": str(exc),
+            "traceback": "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
+        },
+    }
 
 
 @runtime_checkable
@@ -161,11 +190,19 @@ def build_inprocess_executor(
     if dispatcher is None:
 
         def _inline(script_path: str, params: Mapping[str, Any]) -> Any:
-            return runner(script_path, params)
+            try:
+                return runner(script_path, params)
+            except Exception as exc:
+                logger.exception("In-process skill %s failed", script_path)
+                return exception_to_error_envelope(exc)
 
         return _inline
 
     def _routed(script_path: str, params: Mapping[str, Any]) -> Any:
-        return dispatcher.dispatch_callable(runner, script_path, params)
+        try:
+            return dispatcher.dispatch_callable(runner, script_path, params)
+        except Exception as exc:
+            logger.exception("In-process skill %s failed via dispatcher", script_path)
+            return exception_to_error_envelope(exc)
 
     return _routed

--- a/tests/test_inprocess_executor.py
+++ b/tests/test_inprocess_executor.py
@@ -15,6 +15,7 @@ import pytest
 import dcc_mcp_core
 from dcc_mcp_core._server.inprocess_executor import BaseDccCallableDispatcher
 from dcc_mcp_core._server.inprocess_executor import build_inprocess_executor
+from dcc_mcp_core._server.inprocess_executor import exception_to_error_envelope
 from dcc_mcp_core._server.inprocess_executor import run_skill_script
 
 # ── public surface ───────────────────────────────────────────────────────────
@@ -135,7 +136,12 @@ def test_executor_routes_through_dispatcher(tmp_path: Path) -> None:
     assert kwargs == {}
 
 
-def test_executor_propagates_dispatcher_exceptions(tmp_path: Path) -> None:
+def test_executor_dispatcher_exception_becomes_error_envelope(tmp_path: Path) -> None:
+    """Issue #589 — dispatcher / runner failures must surface as structured
+    error dicts so Rust ``CallToolResult`` can flag ``isError: true`` from
+    the ``success: false`` heuristic without forcing clients to do a second
+    JSON parse on the content text.
+    """
     p = _write_script(tmp_path, "def main(): return None\n")
 
     class _BoomDispatcher:
@@ -148,8 +154,44 @@ def test_executor_propagates_dispatcher_exceptions(tmp_path: Path) -> None:
             raise RuntimeError("UI thread shutdown")
 
     executor = build_inprocess_executor(_BoomDispatcher())
-    with pytest.raises(RuntimeError, match="UI thread shutdown"):
-        executor(str(p), {})
+    result = executor(str(p), {})
+    assert isinstance(result, dict)
+    assert result["success"] is False
+    assert "UI thread shutdown" in result["message"]
+    assert result["error"]["type"] == "RuntimeError"
+    assert result["error"]["message"] == "UI thread shutdown"
+    assert "Traceback" in result["error"]["traceback"]
+
+
+def test_executor_inline_exception_becomes_error_envelope(tmp_path: Path) -> None:
+    p = _write_script(
+        tmp_path,
+        "def main(): raise ValueError('bad input')\n",
+    )
+    executor = build_inprocess_executor(None)
+    result = executor(str(p), {})
+    assert isinstance(result, dict)
+    assert result["success"] is False
+    assert result["error"]["type"] == "ValueError"
+    assert result["error"]["message"] == "bad input"
+    assert "Traceback" in result["error"]["traceback"]
+
+
+def test_exception_to_error_envelope_overrides_message() -> None:
+    try:
+        raise KeyError("missing")
+    except KeyError as exc:
+        envelope = exception_to_error_envelope(exc, message="custom summary")
+    assert envelope == {
+        "success": False,
+        "message": "custom summary",
+        "error": {
+            "type": "KeyError",
+            "message": "'missing'",
+            "traceback": envelope["error"]["traceback"],
+        },
+    }
+    assert "KeyError" in envelope["error"]["traceback"]
 
 
 def test_executor_uses_custom_runner() -> None:


### PR DESCRIPTION
## Summary
- Add `exception_to_error_envelope` helper that renders Python exceptions as the same `success: false` / `error.type/message/traceback` shape Rust `CallToolResult` already flips into `isError: true`.
- Wrap both inline and dispatcher-routed paths in `build_inprocess_executor` to translate any failure into that envelope so MCP clients no longer have to JSON-decode `content[0].text` to recover the traceback.
- Re-export the helper from `dcc_mcp_core._server`.

## Test plan
- `python -m ruff check` / `ruff format --check` for the touched files
- `python -m pytest tests/test_inprocess_executor.py` (covered by CI; locally smoke-tested via `importlib` because the wheel rebuild is not needed for this Python-only change)

Closes #589.
