### PR TITLE
feat: mark tools with fallback input schemas in _meta

### DIFF
--- a/crates/dcc-mcp-http/src/handlers/tests.rs
+++ b/crates/dcc-mcp-http/src/handlers/tests.rs
@@ -16,11 +16,15 @@ mod issue_317_tests {
         // Issue #344 — tools with no declared annotations omit the spec
         // `annotations` field entirely. `deferred_hint` is a dcc-mcp-core
         // extension that rides in `_meta` (never in the spec `annotations`
-        // map) and for a sync tool it is simply absent.
+        // map) and for a sync tool it is simply absent. Issue #588 added
+        // the `_meta.dcc.incompleteSchema` marker, which only surfaces
+        // when the author skipped `inputSchema`; declare a real schema
+        // here so this test stays focused on the annotations contract.
         let meta = ActionMeta {
             name: "quick".into(),
             description: "Fast".into(),
             execution: ExecutionMode::Sync,
+            input_schema: serde_json::json!({"type": "object"}),
             ..Default::default()
         };
         let tool = action_meta_to_mcp_tool(&meta, false, &empty_eligible(), &[]);
@@ -168,5 +172,73 @@ mod issue_317_tests {
         );
         assert!(v.pointer("/annotations/destructiveHint").is_none());
         assert!(v.pointer("/annotations/openWorldHint").is_none());
+    }
+}
+
+mod issue_588_input_schema_marker {
+    //! Issue #588 — surface `_meta.dcc.incompleteSchema` when the catalog
+    //! had to fall back to the permissive `{"type": "object"}` placeholder.
+    use super::*;
+    use dcc_mcp_actions::registry::ActionMeta;
+
+    fn empty_eligible() -> std::collections::HashSet<(String, String)> {
+        std::collections::HashSet::new()
+    }
+
+    #[test]
+    fn null_input_schema_emits_incomplete_schema_marker_and_hint() {
+        let meta = ActionMeta {
+            name: "execute_python".into(),
+            description: "Run python in the host DCC".into(),
+            input_schema: serde_json::Value::Null,
+            ..Default::default()
+        };
+        let tool = action_meta_to_mcp_tool(&meta, false, &empty_eligible(), &[]);
+        let v = serde_json::to_value(&tool).unwrap();
+
+        assert_eq!(
+            v.pointer("/inputSchema/type").and_then(|x| x.as_str()),
+            Some("object"),
+            "fallback inputSchema must remain `{{type: object}}` for backwards compatibility",
+        );
+        assert_eq!(
+            v.pointer("/_meta/dcc/incompleteSchema")
+                .and_then(|x| x.as_bool()),
+            Some(true),
+            "incompleteSchema must surface in _meta when the author skipped inputSchema",
+        );
+        let hint = v
+            .pointer("/_meta/dcc/schemaHint")
+            .and_then(|x| x.as_str())
+            .unwrap_or_default();
+        assert!(
+            hint.contains("did not declare an input schema"),
+            "schemaHint must explain the situation to the agent: got {hint:?}",
+        );
+    }
+
+    #[test]
+    fn declared_input_schema_skips_marker() {
+        let meta = ActionMeta {
+            name: "create_sphere".into(),
+            description: "Make a sphere".into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "required": ["radius"],
+                "properties": {"radius": {"type": "number"}},
+            }),
+            ..Default::default()
+        };
+        let tool = action_meta_to_mcp_tool(&meta, false, &empty_eligible(), &[]);
+        let v = serde_json::to_value(&tool).unwrap();
+
+        assert!(
+            v.pointer("/_meta/dcc/incompleteSchema").is_none(),
+            "tools with a real input schema must not carry the incomplete-schema marker",
+        );
+        assert!(
+            v.pointer("/_meta/dcc/schemaHint").is_none(),
+            "schemaHint pairs with incompleteSchema and must be absent here",
+        );
     }
 }

--- a/crates/dcc-mcp-http/src/handlers/tool_builder_skill.rs
+++ b/crates/dcc-mcp-http/src/handlers/tool_builder_skill.rs
@@ -114,7 +114,12 @@ pub fn action_meta_to_mcp_tool(
     bare_eligible: &std::collections::HashSet<(String, String)>,
     declared_capabilities: &[String],
 ) -> McpTool {
-    let input_schema = if meta.input_schema.is_null() {
+    // Issue #588 — record whether we had to fall back to the permissive
+    // `{"type": "object"}` placeholder so MCP clients can warn the user
+    // that the tool author did not declare an input schema. The marker
+    // rides in `_meta.dcc.incompleteSchema` (built below).
+    let schema_is_incomplete = meta.input_schema.is_null();
+    let input_schema = if schema_is_incomplete {
         json!({"type": "object"})
     } else {
         meta.input_schema.clone()
@@ -171,7 +176,7 @@ pub fn action_meta_to_mcp_tool(
         input_schema,
         output_schema,
         annotations,
-        meta: build_tool_meta(meta, declared_capabilities),
+        meta: build_tool_meta(meta, declared_capabilities, schema_is_incomplete),
     }
 }
 
@@ -188,11 +193,18 @@ pub fn action_meta_to_mcp_tool(
 ///   value is `true` when either the skill author declared
 ///   `deferred_hint: true` in `tools.yaml` **or** the author declared
 ///   `execution: async` (which implies deferred).
+/// * `dcc.incompleteSchema` — `true` when the skill author did not
+///   declare an input schema and the catalog had to fall back to the
+///   permissive `{"type": "object"}` placeholder. Pairs with
+///   `dcc.schemaHint` so MCP clients (and the agents driving them) can
+///   warn the user before invoking a tool whose argument shape is
+///   unspecified (issue #588).
 ///
 /// Returns `None` when there is nothing to emit.
 pub fn build_tool_meta(
     meta: &dcc_mcp_actions::registry::ActionMeta,
     declared_capabilities: &[String],
+    schema_is_incomplete: bool,
 ) -> Option<serde_json::Map<String, serde_json::Value>> {
     let deferred = meta
         .annotations
@@ -205,7 +217,7 @@ pub fn build_tool_meta(
     // out before asking the user to invoke them.
     let missing = missing_capabilities(&meta.required_capabilities, declared_capabilities);
     let has_required_caps = !meta.required_capabilities.is_empty();
-    if !has_timeout && !deferred && !has_required_caps {
+    if !has_timeout && !deferred && !has_required_caps && !schema_is_incomplete {
         return None;
     }
 
@@ -227,6 +239,16 @@ pub fn build_tool_meta(
                 serde_json::json!(missing),
             );
         }
+    }
+    if schema_is_incomplete {
+        dcc_meta.insert("incompleteSchema".to_string(), serde_json::json!(true));
+        dcc_meta.insert(
+            "schemaHint".to_string(),
+            serde_json::json!(
+                "Tool author did not declare an input schema; arguments are unvalidated. \
+                 Inspect the source script or skill docs before calling."
+            ),
+        );
     }
     let mut out = serde_json::Map::new();
     out.insert("dcc".to_string(), serde_json::Value::Object(dcc_meta));


### PR DESCRIPTION
## Summary
- Detect when `tools/list` had to fall back to the permissive `{"type": "object"}` input schema and surface a `_meta.dcc.incompleteSchema = true` marker plus a `_meta.dcc.schemaHint` warning so MCP clients can flag the tool to the user before invoking it.
- Wire the new flag through `build_tool_meta` and add unit tests for both the fallback and the well-typed cases.

## Test plan
- `cargo test -p dcc-mcp-http issue_588_input_schema_marker`
- `cargo test -p dcc-mcp-http` (full crate suite — 311 tests pass after updating the legacy `sync_action_without_annotations_omits_both_fields` test to declare an explicit input schema, since the new marker only fires on null schemas)

Closes #588.
