### PR TITLE
feat: add script execution envelopes

### DIFF
--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -420,6 +420,9 @@ from dcc_mcp_core.rich_content import attach_rich_content
 from dcc_mcp_core.rich_content import skill_success_with_chart
 from dcc_mcp_core.rich_content import skill_success_with_image
 from dcc_mcp_core.rich_content import skill_success_with_table
+from dcc_mcp_core.script_execution import ScriptExecutionCapture
+from dcc_mcp_core.script_execution import ScriptExecutionResult
+from dcc_mcp_core.script_execution import ScriptExecutionSerializationError
 from dcc_mcp_core.server_base import DccServerBase
 
 # Pure-Python skill script helpers (no _core dependency)
@@ -588,6 +591,9 @@ __all__ = [
     "SceneObject",
     "SceneStatistics",
     "ScheduleSpec",
+    "ScriptExecutionCapture",
+    "ScriptExecutionResult",
+    "ScriptExecutionSerializationError",
     "ScriptLanguage",
     "ScriptResult",
     "SdfPath",

--- a/python/dcc_mcp_core/script_execution.py
+++ b/python/dcc_mcp_core/script_execution.py
@@ -1,0 +1,189 @@
+"""Reusable script execution capture and result envelopes (#603).
+
+DCC adapters expose ad-hoc script execution tools such as ``execute_python``.
+Those tools need the same stdout/stderr capture behaviour and the same
+``ToolResult``-shaped return contract, independent of the host application.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+import io
+import json
+import sys
+import traceback
+from typing import Any
+from typing import TextIO
+
+from dcc_mcp_core.result_envelope import ToolResult
+
+
+class ScriptExecutionSerializationError(TypeError):
+    """Raised when a strict script result cannot be JSON-encoded."""
+
+
+class _CaptureStream(io.TextIOBase):
+    """Capture text writes and optionally tee them to the original stream."""
+
+    def __init__(self, original: TextIO, *, tee: bool) -> None:
+        self._original = original
+        self._tee = tee
+        self._buffer = io.StringIO()
+
+    def write(self, text: str) -> int:
+        written = self._buffer.write(text)
+        if self._tee:
+            self._original.write(text)
+        return written
+
+    def flush(self) -> None:
+        if self._tee:
+            self._original.flush()
+
+    def writable(self) -> bool:
+        return True
+
+    def isatty(self) -> bool:
+        return False
+
+    def getvalue(self) -> str:
+        return self._buffer.getvalue()
+
+
+class ScriptExecutionCapture(AbstractContextManager["ScriptExecutionCapture"]):
+    """Capture ``sys.stdout`` and ``sys.stderr`` during host script execution.
+
+    ``tee=True`` keeps host-console visibility while still collecting output
+    for the tool response. This mirrors DCC plugin expectations where artists
+    should continue seeing script output in the native console.
+    """
+
+    def __init__(self, *, tee: bool = False) -> None:
+        self._tee = tee
+        self._old_stdout: TextIO | None = None
+        self._old_stderr: TextIO | None = None
+        self._stdout_capture: _CaptureStream | None = None
+        self._stderr_capture: _CaptureStream | None = None
+
+    def __enter__(self) -> ScriptExecutionCapture:
+        self._old_stdout = sys.stdout
+        self._old_stderr = sys.stderr
+        self._stdout_capture = _CaptureStream(sys.stdout, tee=self._tee)
+        self._stderr_capture = _CaptureStream(sys.stderr, tee=self._tee)
+        sys.stdout = self._stdout_capture
+        sys.stderr = self._stderr_capture
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        if self._old_stdout is not None:
+            sys.stdout = self._old_stdout
+        if self._old_stderr is not None:
+            sys.stderr = self._old_stderr
+
+    @property
+    def stdout(self) -> str:
+        """Captured stdout text."""
+        return "" if self._stdout_capture is None else self._stdout_capture.getvalue()
+
+    @property
+    def stderr(self) -> str:
+        """Captured stderr text."""
+        return "" if self._stderr_capture is None else self._stderr_capture.getvalue()
+
+
+def _assert_json_serializable(value: Any) -> None:
+    try:
+        json.dumps(value)
+    except (TypeError, ValueError) as exc:
+        raise ScriptExecutionSerializationError(
+            f"Script result is not JSON serializable: {exc}",
+        ) from exc
+
+
+def _repr_json_safe(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Mapping):
+        return {str(key): _repr_json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return [_repr_json_safe(item) for item in value]
+    return repr(value)
+
+
+def _normalize_result(value: Any, *, strict_json: bool, repr_fallback: bool) -> Any:
+    try:
+        _assert_json_serializable(value)
+        return value
+    except ScriptExecutionSerializationError:
+        if strict_json or not repr_fallback:
+            raise
+
+    converted = _repr_json_safe(value)
+    _assert_json_serializable(converted)
+    return converted
+
+
+@dataclass(frozen=True)
+class ScriptExecutionResult:
+    """Factory for standard DCC script execution envelopes."""
+
+    @staticmethod
+    def from_value(
+        result: Any,
+        *,
+        stdout: str = "",
+        stderr: str = "",
+        strict_json: bool = True,
+        repr_fallback: bool | None = None,
+        message: str = "Script executed successfully",
+    ) -> dict[str, Any]:
+        """Return a success envelope, or a strict serialization error envelope."""
+        use_repr = not strict_json if repr_fallback is None else repr_fallback
+        try:
+            normalized = _normalize_result(
+                result,
+                strict_json=strict_json,
+                repr_fallback=use_repr,
+            )
+        except ScriptExecutionSerializationError as exc:
+            return ToolResult.fail(
+                str(exc),
+                error="non_serializable_result",
+                stdout=stdout,
+                stderr=stderr,
+            ).to_dict()
+
+        return ToolResult.ok(
+            message,
+            result=normalized,
+            stdout=stdout,
+            stderr=stderr,
+        ).to_dict()
+
+    @staticmethod
+    def from_exception(
+        exc: BaseException,
+        *,
+        stdout: str = "",
+        stderr: str = "",
+        message: str | None = None,
+    ) -> dict[str, Any]:
+        """Return a structured failure envelope with traceback and captured output."""
+        return ToolResult.fail(
+            message or f"Script execution failed: {exc}",
+            error="script_execution_error",
+            stdout=stdout,
+            stderr=stderr,
+            exception_type=type(exc).__name__,
+            exception_message=str(exc),
+            traceback="".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
+        ).to_dict()
+
+
+__all__ = [
+    "ScriptExecutionCapture",
+    "ScriptExecutionResult",
+    "ScriptExecutionSerializationError",
+]

--- a/tests/test_script_execution.py
+++ b/tests/test_script_execution.py
@@ -1,0 +1,95 @@
+"""Tests for standard script execution capture/envelopes (#603)."""
+
+from __future__ import annotations
+
+import sys
+
+import dcc_mcp_core
+from dcc_mcp_core.script_execution import ScriptExecutionCapture
+from dcc_mcp_core.script_execution import ScriptExecutionResult
+
+
+def test_script_execution_helpers_are_exported() -> None:
+    assert dcc_mcp_core.ScriptExecutionCapture is ScriptExecutionCapture
+    assert dcc_mcp_core.ScriptExecutionResult is ScriptExecutionResult
+    assert "ScriptExecutionCapture" in dcc_mcp_core.__all__
+    assert "ScriptExecutionResult" in dcc_mcp_core.__all__
+
+
+def test_capture_collects_stdout_and_stderr() -> None:
+    with ScriptExecutionCapture() as cap:
+        print("hello stdout")
+        print("hello stderr", file=sys.stderr)
+
+    assert cap.stdout == "hello stdout\n"
+    assert cap.stderr == "hello stderr\n"
+
+
+def test_capture_tee_forwards_to_original_streams(capsys) -> None:
+    with ScriptExecutionCapture(tee=True) as cap:
+        print("visible stdout")
+        print("visible stderr", file=sys.stderr)
+
+    captured = capsys.readouterr()
+    assert cap.stdout == "visible stdout\n"
+    assert cap.stderr == "visible stderr\n"
+    assert captured.out == "visible stdout\n"
+    assert captured.err == "visible stderr\n"
+
+
+def test_result_from_value_returns_standard_success_envelope() -> None:
+    result = ScriptExecutionResult.from_value(
+        {"created": "pCube1"},
+        stdout="out",
+        stderr="err",
+    )
+
+    assert result == {
+        "success": True,
+        "message": "Script executed successfully",
+        "context": {
+            "result": {"created": "pCube1"},
+            "stdout": "out",
+            "stderr": "err",
+        },
+    }
+
+
+def test_strict_json_reports_non_serializable_values() -> None:
+    result = ScriptExecutionResult.from_value({"bad": object()}, strict_json=True)
+
+    assert result["success"] is False
+    assert result["error"] == "non_serializable_result"
+    assert "not JSON serializable" in result["message"]
+    assert result["context"]["stdout"] == ""
+    assert result["context"]["stderr"] == ""
+
+
+def test_non_strict_json_uses_repr_fallback() -> None:
+    class HostObject:
+        def __repr__(self) -> str:
+            return "<HostObject pCube1>"
+
+    result = ScriptExecutionResult.from_value(
+        {"node": HostObject(), "items": {1, 2}},
+        strict_json=False,
+    )
+
+    assert result["success"] is True
+    assert result["context"]["result"]["node"] == "<HostObject pCube1>"
+    assert sorted(result["context"]["result"]["items"]) == [1, 2]
+
+
+def test_from_exception_includes_traceback_and_captured_output() -> None:
+    try:
+        raise RuntimeError("boom")
+    except RuntimeError as exc:
+        result = ScriptExecutionResult.from_exception(exc, stdout="out", stderr="err")
+
+    assert result["success"] is False
+    assert result["error"] == "script_execution_error"
+    assert result["context"]["stdout"] == "out"
+    assert result["context"]["stderr"] == "err"
+    assert result["context"]["exception_type"] == "RuntimeError"
+    assert result["context"]["exception_message"] == "boom"
+    assert "Traceback" in result["context"]["traceback"]


### PR DESCRIPTION
## Summary
- Add reusable script execution capture helpers for stdout/stderr with optional teeing.
- Add standard script execution result envelopes with strict JSON validation and repr fallback for host objects.
- Export the helpers from the top-level Python package and cover the contract with tests.

## Testing
- `vx uvx:ruff check python/dcc_mcp_core/script_execution.py tests/test_script_execution.py` passed.
- `python3 -m py_compile python/dcc_mcp_core/script_execution.py tests/test_script_execution.py` passed.
- `PYTHONPATH=python python3 - <<'PY' ...` passed for capture, success envelope, strict serialization failure, repr fallback, and exception envelope.
- `vx just dev` is blocked in this environment by missing `libpython3.12` during Rust linking.
- `PYTHONPATH=python vx python -m pytest tests/test_script_execution.py -q` is blocked by the existing local `_core` extension missing `DEFAULT_LOG_FILE_PREFIX`.

Closes #603