### PR TITLE
fix: allow bare gateway tools for single instance

### DIFF
--- a/crates/dcc-mcp-http/src/gateway/aggregator/call.rs
+++ b/crates/dcc-mcp-http/src/gateway/aggregator/call.rs
@@ -29,32 +29,44 @@ pub async fn route_tools_call(
         return skill_mgmt_dispatch(gs, tool, args).await;
     }
 
-    // ── Prefixed backend tool ───────────────────────────────────────────
-    let Some((prefix, original)) = decode_tool_name(tool) else {
-        // Detect the common "skill__toolname" internal-format mistake and emit
-        // a targeted hint instead of the generic "Unknown tool" message.
-        let hint = if tool.contains("__") {
-            format!(
-                "Unknown tool: '{tool}'. \
-                 '{tool}' looks like an internal action name (double-underscore format). \
-                 Gateway tools are published as '{{id8}}.{{bare_name}}' (e.g. 'a1b2c3d.execute_python'). \
-                 Call tools/list to discover the exact names, or use search_skills to find the right tool."
-            )
-        } else {
-            format!(
-                "Unknown tool: '{tool}'. \
-                 Call tools/list (or search_skills) to discover available tool names. \
-                 Gateway tools use the form '{{id8}}.{{tool_name}}'."
-            )
-        };
-        return (hint, true);
-    };
-
-    let Some(entry) = find_instance_by_prefix(gs, prefix).await else {
-        return (
-            format!("No live DCC instance matches prefix '{prefix}' in tool '{tool}'."),
-            true,
-        );
+    // ── Backend tool routing ────────────────────────────────────────────
+    // Preferred gateway names are prefixed (`{id8}.{tool}`), but with a
+    // single live backend a bare tool name is unambiguous and easier for
+    // clients to call (#583).
+    let (entry, original) = match decode_tool_name(tool) {
+        Some((prefix, original)) => {
+            let Some(entry) = find_instance_by_prefix(gs, prefix).await else {
+                return (
+                    format!("No live DCC instance matches prefix '{prefix}' in tool '{tool}'."),
+                    true,
+                );
+            };
+            (entry, original)
+        }
+        None => {
+            let instances = live_backends(gs).await;
+            if instances.len() == 1 {
+                (instances.into_iter().next().unwrap(), tool)
+            } else {
+                // Detect the common "skill__toolname" internal-format mistake and emit
+                // a targeted hint instead of the generic "Unknown tool" message.
+                let hint = if tool.contains("__") {
+                    format!(
+                        "Unknown tool: '{tool}'. \
+                         '{tool}' looks like an internal action name (double-underscore format). \
+                         Gateway tools are published as '{{id8}}.{{bare_name}}' (e.g. 'a1b2c3d.execute_python'). \
+                         Call tools/list to discover the exact names, or use search_skills to find the right tool."
+                    )
+                } else {
+                    format!(
+                        "Unknown tool: '{tool}'. \
+                         Call tools/list (or search_skills) to discover available tool names. \
+                         Gateway tools use the form '{{id8}}.{{tool_name}}'."
+                    )
+                };
+                return (hint, true);
+            }
+        }
     };
 
     let url = format!("http://{}:{}/mcp", entry.host, entry.port);

--- a/crates/dcc-mcp-http/src/gateway/aggregator/list.rs
+++ b/crates/dcc-mcp-http/src/gateway/aggregator/list.rs
@@ -40,6 +40,7 @@ pub async fn aggregate_tools_list(gs: &GatewayState, cursor: Option<&str>) -> Va
         (entry.instance_id, entry.dcc_type.clone(), backend_tools)
     });
     let results = join_all(futs).await;
+    let publish_bare_aliases = instances.len() == 1;
 
     for (iid, dcc_type, backend_tools) in results {
         for mut tool in backend_tools {
@@ -49,11 +50,19 @@ pub async fn aggregate_tools_list(gs: &GatewayState, cursor: Option<&str>) -> Va
             if is_local_tool(&tool.name) {
                 continue;
             }
+            let bare_name = tool.name.clone();
             let encoded = encode_tool_name(&iid, &tool.name);
             tool.name = encoded;
             let mut json_val = serde_json::to_value(&tool).unwrap_or(Value::Null);
             inject_instance_metadata(&mut json_val, &iid, &dcc_type);
             tools.push(json_val);
+
+            if publish_bare_aliases {
+                tool.name = bare_name;
+                let mut alias_val = serde_json::to_value(&tool).unwrap_or(Value::Null);
+                inject_instance_metadata(&mut alias_val, &iid, &dcc_type);
+                tools.push(alias_val);
+            }
         }
     }
 

--- a/crates/dcc-mcp-http/tests/http/gateway_passthrough.rs
+++ b/crates/dcc-mcp-http/tests/http/gateway_passthrough.rs
@@ -27,7 +27,7 @@ use axum::{Json, Router, routing::post};
 use serde_json::{Value, json};
 use tokio::sync::{RwLock, broadcast, watch};
 
-use dcc_mcp_http::gateway::aggregator::route_tools_call;
+use dcc_mcp_http::gateway::aggregator::{aggregate_tools_list, route_tools_call};
 use dcc_mcp_http::gateway::sse_subscriber::SubscriberManager;
 use dcc_mcp_http::gateway::state::GatewayState;
 use dcc_mcp_transport::discovery::file_registry::FileRegistry;
@@ -143,6 +143,102 @@ fn encoded_tool_name(instance_id: uuid::Uuid, tool: &str) -> String {
     // Mirror `encode_tool_name` — 8-char prefix + '.' + tool name.
     let short = &instance_id.to_string().replace('-', "")[..8];
     format!("{short}.{tool}")
+}
+
+// ── Single-instance bare-name aliases (#583) ───────────────────────────────
+
+#[tokio::test]
+async fn single_backend_tools_list_publishes_bare_alias() {
+    let port = spawn_pending_backend(Duration::ZERO).await;
+    let (state, registry, _tmp) = make_state(
+        Duration::from_secs(1),
+        Duration::from_secs(1),
+        Duration::from_secs(1),
+    )
+    .await;
+    let entry = register_backend(&registry, port).await;
+    let encoded = encoded_tool_name(entry.instance_id, "slow_tool");
+
+    let result = aggregate_tools_list(&state, None).await;
+    let names: Vec<&str> = result["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .filter_map(|tool| tool.get("name").and_then(Value::as_str))
+        .collect();
+
+    assert!(
+        names.contains(&encoded.as_str()),
+        "prefixed tool name missing from tools/list: {names:?}"
+    );
+    assert!(
+        names.contains(&"slow_tool"),
+        "single-instance bare alias missing from tools/list: {names:?}"
+    );
+}
+
+#[tokio::test]
+async fn single_backend_tools_call_accepts_bare_name() {
+    let port = spawn_pending_backend(Duration::ZERO).await;
+    let (state, registry, _tmp) = make_state(
+        Duration::from_secs(1),
+        Duration::from_secs(1),
+        Duration::from_secs(1),
+    )
+    .await;
+    register_backend(&registry, port).await;
+
+    let (text, is_error) = route_tools_call(
+        &state,
+        "slow_tool",
+        &json!({}),
+        None,
+        Some("req-bare".into()),
+        Some("sess-bare"),
+    )
+    .await;
+
+    assert!(!is_error, "bare single-instance call failed: {text}");
+    assert!(text.contains("job-1") || text.contains("Job"));
+}
+
+#[tokio::test]
+async fn multiple_backends_keep_bare_name_ambiguous() {
+    let port_a = spawn_pending_backend(Duration::ZERO).await;
+    let port_b = spawn_pending_backend(Duration::ZERO).await;
+    let (state, registry, _tmp) = make_state(
+        Duration::from_secs(1),
+        Duration::from_secs(1),
+        Duration::from_secs(1),
+    )
+    .await;
+    register_backend(&registry, port_a).await;
+    register_backend(&registry, port_b).await;
+
+    let result = aggregate_tools_list(&state, None).await;
+    let names: Vec<&str> = result["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .filter_map(|tool| tool.get("name").and_then(Value::as_str))
+        .collect();
+    assert!(
+        !names.contains(&"slow_tool"),
+        "multi-instance tools/list must not expose ambiguous bare aliases: {names:?}"
+    );
+
+    let (text, is_error) = route_tools_call(
+        &state,
+        "slow_tool",
+        &json!({}),
+        None,
+        Some("req-ambiguous".into()),
+        Some("sess-ambiguous"),
+    )
+    .await;
+
+    assert!(is_error, "ambiguous bare call must fail; text={text}");
+    assert!(text.contains("Unknown tool"));
 }
 
 // ── Async dispatch timeout ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Publish bare backend tool aliases in `tools/list` when the gateway has exactly one live DCC instance.
- Route bare `tools/call` names to the only live backend while preserving prefixed names and multi-instance ambiguity errors.
- Add gateway passthrough regression coverage for single-instance aliases and multi-instance ambiguity.

## Test plan
- `vx cargo fmt --all`
- `vx cargo test -p dcc-mcp-http --test http gateway_passthrough -- --nocapture`
- `vx cargo test -p dcc-mcp-http`