### PR TITLE
fix: normalize script execution parameters

### DIFF
--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -421,8 +421,10 @@ from dcc_mcp_core.rich_content import skill_success_with_chart
 from dcc_mcp_core.rich_content import skill_success_with_image
 from dcc_mcp_core.rich_content import skill_success_with_table
 from dcc_mcp_core.script_execution import ScriptExecutionCapture
+from dcc_mcp_core.script_execution import ScriptExecutionParams
 from dcc_mcp_core.script_execution import ScriptExecutionResult
 from dcc_mcp_core.script_execution import ScriptExecutionSerializationError
+from dcc_mcp_core.script_execution import normalize_script_execution_params
 from dcc_mcp_core.server_base import DccServerBase
 
 # Pure-Python skill script helpers (no _core dependency)
@@ -592,6 +594,7 @@ __all__ = [
     "SceneStatistics",
     "ScheduleSpec",
     "ScriptExecutionCapture",
+    "ScriptExecutionParams",
     "ScriptExecutionResult",
     "ScriptExecutionSerializationError",
     "ScriptLanguage",
@@ -726,6 +729,7 @@ __all__ = [
     "make_rationale_meta",
     "make_start_stop",
     "mpu_to_units",
+    "normalize_script_execution_params",
     "parse_recipe_anchors",
     "parse_schedules_yaml",
     "parse_skill_md",

--- a/python/dcc_mcp_core/script_execution.py
+++ b/python/dcc_mcp_core/script_execution.py
@@ -24,6 +24,56 @@ class ScriptExecutionSerializationError(TypeError):
     """Raised when a strict script result cannot be JSON-encoded."""
 
 
+@dataclass(frozen=True)
+class ScriptExecutionParams:
+    """Normalized script execution parameters shared by DCC adapters."""
+
+    code: str
+    timeout_secs: int | None = None
+    code_key: str = "code"
+    timeout_key: str | None = None
+
+
+def normalize_script_execution_params(
+    params: Mapping[str, Any],
+    *,
+    default_timeout_secs: int | None = None,
+) -> ScriptExecutionParams:
+    """Normalize script execution parameter aliases.
+
+    Adapters can expose one stable implementation while clients pass the
+    source as ``code``, ``script``, or ``source`` and the timeout as either
+    ``timeout_secs`` or ``timeout``.
+    """
+    if default_timeout_secs is not None and default_timeout_secs <= 0:
+        raise ValueError("default_timeout_secs must be greater than zero")
+
+    code_key = next((key for key in ("code", "script", "source") if params.get(key) is not None), None)
+    if code_key is None:
+        raise ValueError("Missing required script source: pass one of code, script, or source")
+
+    code = params[code_key]
+    if not isinstance(code, str):
+        raise TypeError(f"{code_key} must be a string")
+
+    timeout_key = next((key for key in ("timeout_secs", "timeout") if params.get(key) is not None), None)
+    timeout_secs = default_timeout_secs
+    if timeout_key is not None:
+        timeout_value = params[timeout_key]
+        if isinstance(timeout_value, bool) or not isinstance(timeout_value, int):
+            raise TypeError(f"{timeout_key} must be an integer number of seconds")
+        if timeout_value <= 0:
+            raise ValueError(f"{timeout_key} must be greater than zero")
+        timeout_secs = timeout_value
+
+    return ScriptExecutionParams(
+        code=code,
+        timeout_secs=timeout_secs,
+        code_key=code_key,
+        timeout_key=timeout_key,
+    )
+
+
 class _CaptureStream(io.TextIOBase):
     """Capture text writes and optionally tee them to the original stream."""
 
@@ -184,6 +234,8 @@ class ScriptExecutionResult:
 
 __all__ = [
     "ScriptExecutionCapture",
+    "ScriptExecutionParams",
     "ScriptExecutionResult",
     "ScriptExecutionSerializationError",
+    "normalize_script_execution_params",
 ]

--- a/skills/templates/thin-harness/scripts/execute.py
+++ b/skills/templates/thin-harness/scripts/execute.py
@@ -2,13 +2,20 @@
 
 from __future__ import annotations
 
+from dcc_mcp_core import normalize_script_execution_params
 from dcc_mcp_core import skill_entry
 from dcc_mcp_core import skill_error
 from dcc_mcp_core import skill_success
 
 
 @skill_entry
-def execute_python(code: str, timeout_secs: int = 30) -> dict:
+def execute_python(
+    code: str | None = None,
+    script: str | None = None,
+    source: str | None = None,
+    timeout_secs: int | None = None,
+    timeout: int | None = None,
+) -> dict:
     """Execute a Python script string in the live DCC interpreter.
 
     The script runs in an isolated namespace. Set ``result`` in the script
@@ -18,7 +25,10 @@ def execute_python(code: str, timeout_secs: int = 30) -> dict:
 
     Args:
         code: Python source to execute.
-        timeout_secs: Execution timeout in seconds. Default 30.
+        script: Alias for ``code``.
+        source: Alias for ``code``.
+        timeout_secs: Execution timeout hint in seconds.
+        timeout: Alias for ``timeout_secs``.
 
     Returns:
         skill_success with ``output`` key on success, skill_error on failure.
@@ -26,14 +36,24 @@ def execute_python(code: str, timeout_secs: int = 30) -> dict:
     """
     import traceback
 
+    params = normalize_script_execution_params(
+        {
+            "code": code,
+            "script": script,
+            "source": source,
+            "timeout_secs": timeout_secs,
+            "timeout": timeout,
+        },
+        default_timeout_secs=30,
+    )
     local_ns: dict = {}
     try:
-        exec(compile(code, "<execute_python>", "exec"), {}, local_ns)
+        exec(compile(params.code, "<execute_python>", "exec"), {}, local_ns)
         output = local_ns.get("result")
-        return skill_success("Script executed", output=output)
+        return skill_success("Script executed", output=output, timeout_secs=params.timeout_secs)
     except Exception as exc:
         return skill_error(
             f"Script raised {type(exc).__name__}: {exc}",
-            underlying_call=code[:300],
+            underlying_call=params.code[:300],
             traceback=traceback.format_exc(),
         )

--- a/skills/templates/thin-harness/tools.yaml
+++ b/skills/templates/thin-harness/tools.yaml
@@ -6,6 +6,33 @@ tools:
       a working DCC API snippet. How to use: pass the full script as
       'code'; check references/RECIPES.md first; read
       _meta.dcc.raw_trace on error.
+    input_schema:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Python source to execute.
+          aliases: [script, source]
+        script:
+          type: string
+          description: Alias for code.
+        source:
+          type: string
+          description: Alias for code.
+        timeout_secs:
+          type: integer
+          minimum: 1
+          default: 30
+          description: Execution timeout hint in seconds.
+          aliases: [timeout]
+        timeout:
+          type: integer
+          minimum: 1
+          description: Alias for timeout_secs.
+      anyOf:
+        - required: [code]
+        - required: [script]
+        - required: [source]
     annotations:
       read_only_hint: false
       destructive_hint: true

--- a/tests/test_script_execution.py
+++ b/tests/test_script_execution.py
@@ -4,16 +4,58 @@ from __future__ import annotations
 
 import sys
 
+import pytest
+
 import dcc_mcp_core
 from dcc_mcp_core.script_execution import ScriptExecutionCapture
+from dcc_mcp_core.script_execution import ScriptExecutionParams
 from dcc_mcp_core.script_execution import ScriptExecutionResult
+from dcc_mcp_core.script_execution import normalize_script_execution_params
 
 
 def test_script_execution_helpers_are_exported() -> None:
     assert dcc_mcp_core.ScriptExecutionCapture is ScriptExecutionCapture
+    assert dcc_mcp_core.ScriptExecutionParams is ScriptExecutionParams
     assert dcc_mcp_core.ScriptExecutionResult is ScriptExecutionResult
+    assert dcc_mcp_core.normalize_script_execution_params is normalize_script_execution_params
     assert "ScriptExecutionCapture" in dcc_mcp_core.__all__
+    assert "ScriptExecutionParams" in dcc_mcp_core.__all__
     assert "ScriptExecutionResult" in dcc_mcp_core.__all__
+    assert "normalize_script_execution_params" in dcc_mcp_core.__all__
+
+
+def test_normalize_script_execution_params_accepts_code_aliases() -> None:
+    assert normalize_script_execution_params({"code": "print(1)"}).code == "print(1)"
+
+    script = normalize_script_execution_params({"script": "print(2)"})
+    assert script.code == "print(2)"
+    assert script.code_key == "script"
+
+    source = normalize_script_execution_params({"source": "print(3)"})
+    assert source.code == "print(3)"
+    assert source.code_key == "source"
+
+
+def test_normalize_script_execution_params_accepts_timeout_aliases() -> None:
+    timeout = normalize_script_execution_params({"code": "pass", "timeout": 5})
+    assert timeout.timeout_secs == 5
+    assert timeout.timeout_key == "timeout"
+
+    timeout_secs = normalize_script_execution_params({"code": "pass", "timeout_secs": 7})
+    assert timeout_secs.timeout_secs == 7
+    assert timeout_secs.timeout_key == "timeout_secs"
+
+    default = normalize_script_execution_params({"code": "pass"}, default_timeout_secs=30)
+    assert default.timeout_secs == 30
+
+
+def test_normalize_script_execution_params_validates_input() -> None:
+    with pytest.raises(ValueError, match="code, script, or source"):
+        normalize_script_execution_params({})
+    with pytest.raises(TypeError, match="code must be a string"):
+        normalize_script_execution_params({"code": 123})
+    with pytest.raises(ValueError, match="greater than zero"):
+        normalize_script_execution_params({"code": "pass", "timeout": 0})
 
 
 def test_capture_collects_stdout_and_stderr() -> None:


### PR DESCRIPTION
## Summary
- Add `normalize_script_execution_params` and `ScriptExecutionParams` for shared `code` / `script` / `source` and `timeout_secs` / `timeout` handling.
- Export the helper from the top-level Python package and cover alias validation in `tests/test_script_execution.py`.
- Update the thin-harness `execute_python` template and schema to advertise and accept the aliases.

## Test plan
- `vx uvx:ruff check python/dcc_mcp_core/script_execution.py python/dcc_mcp_core/__init__.py tests/test_script_execution.py skills/templates/thin-harness/scripts/execute.py`
- `vx uvx:ruff format --check python/dcc_mcp_core/script_execution.py python/dcc_mcp_core/__init__.py tests/test_script_execution.py skills/templates/thin-harness/scripts/execute.py`
- `vx python -m py_compile python/dcc_mcp_core/script_execution.py python/dcc_mcp_core/__init__.py tests/test_script_execution.py skills/templates/thin-harness/scripts/execute.py`
- Manual direct-module alias normalization assertions passed.
- `vx uvx:pytest tests/test_script_execution.py -q` is blocked before test collection because this worktree lacks a built `_core` extension.
- `vx just dev` is blocked locally while installing `maturin` into the generated venv.