### PR TITLE
feat: add Rez context bundle skill examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ We **reuse and extend** the existing MCP ecosystem, adding:
 
 This isn't reinventing MCP — it's **solving MCP's blind spots for desktop automation**.
 
+For production pipelines, skills can be distributed as Rez packages and composed
+into context bundles before a DCC starts. A resolved launch context sets
+`DCC_MCP_*` environment variables for project, task, asset, provenance, and
+skill paths; the adapter records those values in gateway metadata so clients
+discover only the active project/task/asset surface instead of every studio
+tool. See [Context Bundles](docs/guide/context-bundles.md) and
+[Rez Skill Packages](docs/guide/rez-skill-packages.md).
+
 ---
 
 ## Why dcc-mcp-core Over Alternatives?

--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -1,5 +1,6 @@
 //! Server configuration.
 
+use std::collections::HashMap;
 use std::net::IpAddr;
 use std::path::PathBuf;
 
@@ -146,6 +147,13 @@ pub struct McpHttpConfig {
 
     /// Currently open scene/file. Improves routing accuracy.
     pub scene: Option<String>,
+
+    /// Arbitrary instance metadata recorded in FileRegistry.
+    ///
+    /// Rez/package launchers use this for context-bundle fields such as
+    /// `context_bundle`, `production_domain`, `context_kind`, `project`,
+    /// `task`, `toolset_profile`, and `package_provenance`.
+    pub instance_metadata: HashMap<String, String>,
 
     // ── Experimental: lazy-actions fast-path (#254) ───────────────────────
     /// Enable the opt-in lazy-actions meta-tools: ``list_actions``,
@@ -493,6 +501,7 @@ impl McpHttpConfig {
             dcc_type: None,
             dcc_version: None,
             scene: None,
+            instance_metadata: HashMap::new(),
             lazy_actions: false,
             bare_tool_names: true,
             spawn_mode: ServerSpawnMode::Ambient,
@@ -533,6 +542,20 @@ impl McpHttpConfig {
     /// servers (issue maya#137).
     pub fn with_adapter_dcc(mut self, dcc: impl Into<String>) -> Self {
         self.adapter_dcc = Some(dcc.into());
+        self
+    }
+
+    /// Builder: attach context/provenance metadata to the FileRegistry row.
+    pub fn with_instance_metadata<I, K, V>(mut self, metadata: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.instance_metadata = metadata
+            .into_iter()
+            .map(|(key, value)| (key.into(), value.into()))
+            .collect();
         self
     }
 

--- a/crates/dcc-mcp-http/src/python/config.rs
+++ b/crates/dcc-mcp-http/src/python/config.rs
@@ -2,6 +2,7 @@
 
 use super::*;
 use dcc_mcp_pybridge::derive::PyWrapper;
+use std::collections::HashMap;
 
 /// Python-visible MCP HTTP server configuration.
 ///
@@ -346,6 +347,22 @@ impl PyMcpHttpConfig {
         self.inner.registry_dir = dir.map(std::path::PathBuf::from);
     }
 
+    /// Arbitrary FileRegistry metadata for this running instance.
+    ///
+    /// Rez launchers commonly set context fields such as ``context_bundle``,
+    /// ``production_domain``, ``context_kind``, ``project``, ``task``,
+    /// ``toolset_profile`` and ``package_provenance`` so gateway discovery can
+    /// route by the resolved package context.
+    #[getter]
+    fn instance_metadata(&self) -> HashMap<String, String> {
+        self.inner.instance_metadata.clone()
+    }
+
+    #[setter]
+    fn set_instance_metadata(&mut self, metadata: HashMap<String, String>) {
+        self.inner.instance_metadata = metadata;
+    }
+
     /// Listener spawn strategy (issue #303).
     ///
     /// - ``"ambient"`` — listener runs as ``tokio::spawn`` on the caller's
@@ -480,6 +497,7 @@ mod drift_tests {
         let _ = cfg.dcc_type();
         let _ = cfg.dcc_version();
         let _ = cfg.scene();
+        let _ = cfg.instance_metadata();
 
         // ── MCP primitives ─────────────────────────────────────────────────
         let _ = cfg.enable_resources();

--- a/crates/dcc-mcp-http/src/server/gateway_impl.rs
+++ b/crates/dcc-mcp-http/src/server/gateway_impl.rs
@@ -56,6 +56,7 @@ pub(crate) async fn start_gateway_runner(
         .adapter_dcc
         .clone()
         .or_else(|| config.dcc_type.clone());
+    entry.metadata = config.instance_metadata.clone();
 
     let metadata_provider = Some(build_metadata_provider(Arc::clone(live_meta)));
     match runner.start(entry, metadata_provider).await {

--- a/docs/guide/INDEX.md
+++ b/docs/guide/INDEX.md
@@ -20,6 +20,8 @@ document without scanning every file.
 | [thin-harness.md](thin-harness.md) | Thin-harness layer: `execute_python` + recipes pattern |
 | [mcp-skills-integration.md](mcp-skills-integration.md) | How skills integrate with the MCP HTTP server |
 | [skill-scopes-policies.md](skill-scopes-policies.md) | SkillScope (trust levels) and SkillPolicy |
+| [context-bundles.md](context-bundles.md) | Project/task/asset-specific skill loading via resolved launch context |
+| [rez-skill-packages.md](rez-skill-packages.md) | Rez package layout and env-var contract for distributing skills |
 
 ## MCP Server & HTTP
 

--- a/docs/guide/context-bundles.md
+++ b/docs/guide/context-bundles.md
@@ -1,0 +1,71 @@
+# Context Bundles
+
+A context bundle is the resolved runtime identity for a DCC MCP session. It
+answers: which production domain is this, what kind of work is being done, which
+project/shot/asset is active, and which skill packages should be visible?
+
+```text
+Rez context -> env vars -> DCC startup -> skill scan -> gateway metadata -> context-aware tools/list
+```
+
+`dcc-mcp-core` reads this resolved environment. It does not choose packages,
+solve versions, or replace a studio package manager.
+
+## Runtime Flow
+
+1. Rez resolves packages for a project, department, task, asset type, and DCC.
+2. The package commands set `DCC_MCP_*` context and path variables.
+3. The DCC adapter starts `DccServerBase` or `McpHttpServer`.
+4. Skills are discovered from `DCC_MCP_SKILL_PATHS` and
+   `DCC_MCP_<DCC>_SKILL_PATHS`.
+5. The gateway records context metadata in `FileRegistry`.
+6. Clients call `list_dcc_instances`, `search_skills`, and `load_skill` against
+   the selected context instead of exposing every studio tool at once.
+
+## Metadata Keys
+
+The gateway returns context metadata under each instance's `metadata` field.
+The built-in `DccServerBase` populates these keys from environment variables:
+
+| Metadata key | Environment variable |
+|--------------|----------------------|
+| `context_bundle` | `DCC_MCP_CONTEXT_BUNDLE` |
+| `production_domain` | `DCC_MCP_PRODUCTION_DOMAIN` |
+| `context_kind` | `DCC_MCP_CONTEXT_KIND` |
+| `project` | `DCC_MCP_PROJECT` |
+| `sequence` | `DCC_MCP_SEQUENCE` |
+| `shot` | `DCC_MCP_SHOT` |
+| `asset` | `DCC_MCP_ASSET` |
+| `asset_type` | `DCC_MCP_ASSET_TYPE` |
+| `task` | `DCC_MCP_TASK` |
+| `toolset_profile` | `DCC_MCP_TOOLSET_PROFILE` |
+| `package_provenance` | `DCC_MCP_PACKAGE_PROVENANCE` |
+| `skill_paths` | `DCC_MCP_SKILL_PATHS` |
+| `dcc_skill_paths` | `DCC_MCP_<DCC>_SKILL_PATHS` |
+
+Adapters that do not use `DccServerBase` can set the same values explicitly via
+`McpHttpConfig.instance_metadata`.
+
+## Gateway Routing
+
+The gateway is intentionally a selector over already-launched contexts. It
+should not multiply every backend tool into one massive global surface. A client
+should first inspect `list_dcc_instances`, choose a matching bundle or DCC
+session, and then load/search skills in that selected context.
+
+Example selection criteria:
+
+- `production_domain=film`, `context_kind=shot`, `task=animation` -> Maya
+  animation blocking tools.
+- `production_domain=film`, `context_kind=shot`, `task=fx` -> Houdini cache and
+  sim review tools.
+- `production_domain=game`, `context_kind=level` -> level-layout tools.
+
+## Examples
+
+Copyable manifests live under `examples/context-bundles/`. Example Rez skill
+packages live under `examples/rez-skills/`; each package has a `package.py`,
+`SKILL.md`, `tools.yaml`, `README.md`, and a tiny script.
+
+For package layout and provenance guidance, see
+[rez-skill-packages.md](rez-skill-packages.md).

--- a/docs/guide/rez-skill-packages.md
+++ b/docs/guide/rez-skill-packages.md
@@ -1,0 +1,107 @@
+# Rez Skill Packages
+
+Rez is a good fit for distributing DCC MCP skills because it already resolves
+project, department, task, asset, and DCC-specific package contexts before an
+application starts. `dcc-mcp-core` does not replace Rez; it reads the resolved
+environment and exposes only the active skill surface.
+
+## Package Layout
+
+Keep each package scoped to one production concern instead of shipping a single
+studio-wide package with every tool.
+
+```text
+show_a_lighting_mcp_skills/
+├── package.py
+├── skills/
+│   └── show-a-lighting/
+│       ├── SKILL.md
+│       ├── tools.yaml
+│       ├── prompts.yaml
+│       ├── resources/
+│       └── scripts/
+├── resources/
+└── prompts/
+```
+
+`SKILL.md` extensions should stay under `metadata.dcc-mcp.*` and point to
+sibling files such as `tools.yaml`, `groups.yaml`, `prompts.yaml`, and recipes.
+Package-level files can live beside `skills/` and be added to the environment
+when the context is resolved.
+
+## Environment Contract
+
+Use the generic path variables for shared packages and DCC-specific variables
+when a package should load only in one host.
+
+| Variable | Purpose |
+|----------|---------|
+| `DCC_MCP_SKILL_PATHS` | Shared skill directories, using the platform path separator |
+| `DCC_MCP_<DCC>_SKILL_PATHS` | DCC-specific skill directories, for example `DCC_MCP_MAYA_SKILL_PATHS` |
+| `DCC_MCP_RESOURCE_PATHS` | Shared MCP resource roots |
+| `DCC_MCP_PROMPT_PATHS` | Shared prompt roots |
+| `DCC_MCP_CONTEXT_BUNDLE` | Stable bundle id such as `show-a.seq010.shot020.lighting` |
+| `DCC_MCP_PRODUCTION_DOMAIN` | Broad domain such as `film`, `advertising`, `game`, or `asset` |
+| `DCC_MCP_CONTEXT_KIND` | Context shape such as `shot`, `deliverable`, `level`, or `asset` |
+| `DCC_MCP_TOOLSET_PROFILE` | Default profile name used by the adapter or gateway |
+| `DCC_MCP_PACKAGE_PROVENANCE` | Semicolon-separated package/version provenance for audit output |
+
+DCC-specific paths are additive. A Maya launch can resolve shared studio skills
+through `DCC_MCP_SKILL_PATHS` and add shot lighting tools through
+`DCC_MCP_MAYA_SKILL_PATHS`; a Houdini launch in the same shot would resolve a
+different DCC-specific path while keeping the same bundle id.
+
+## Rez Example
+
+```python
+name = "show_a_lighting_mcp_skills"
+version = "3.4.1"
+requires = ["dcc_mcp_core", "dcc_mcp_maya", "maya_scene_skills-1.2+"]
+
+def commands():
+    env.DCC_MCP_CONTEXT_BUNDLE = "show-a.seq010.shot020.lighting"
+    env.DCC_MCP_PRODUCTION_DOMAIN = "film"
+    env.DCC_MCP_CONTEXT_KIND = "shot"
+    env.DCC_MCP_PROJECT = "show-a"
+    env.DCC_MCP_SEQUENCE = "seq010"
+    env.DCC_MCP_SHOT = "shot020"
+    env.DCC_MCP_TASK = "lighting"
+    env.DCC_MCP_TOOLSET_PROFILE = "film-shot-lighting"
+    env.DCC_MCP_PACKAGE_PROVENANCE.append("{name}-{version}")
+    env.DCC_MCP_MAYA_SKILL_PATHS.append("{root}/skills")
+    env.DCC_MCP_RESOURCE_PATHS.append("{root}/resources")
+```
+
+`DccServerBase` copies these context values into `McpHttpConfig.instance_metadata`.
+The gateway then returns them from `list_dcc_instances`, so clients can route to
+the already-launched instance that matches the requested bundle.
+
+## Provenance
+
+Emit provenance as package identifiers rather than absolute build paths. A
+compact value such as
+`show_a_lighting_mcp_skills-3.4.1;maya_scene_skills-1.2.0` is easier to search
+in audit logs and avoids leaking workstation paths.
+
+Skill provenance should line up with package provenance:
+
+- `SKILL.md` declares the skill version and `metadata.dcc-mcp.layer`.
+- `package.py` declares the Rez package version and contributes
+  `DCC_MCP_PACKAGE_PROVENANCE`.
+- Audit/debug output can show both the loaded skill version and the package set
+  that made it available.
+
+## Migration Notes
+
+For existing loose skill directories, create one Rez package per context slice
+and move the directory under `skills/`. Start with shared studio primitives,
+then split project, department, and task packages only where the tool surface is
+meaningfully different. Avoid a catch-all package that every department loads by
+default; it recreates MCP context bloat and makes `tools/list` harder for agents
+to reason about.
+
+See also [context-bundles.md](context-bundles.md), [gateway.md](gateway.md),
+the toolset-profile design in
+[#611](https://github.com/loonghao/dcc-mcp-core/issues/611), instruction
+resources in [#608](https://github.com/loonghao/dcc-mcp-core/issues/608), and
+recipe packs in [#616](https://github.com/loonghao/dcc-mcp-core/issues/616).

--- a/examples/context-bundles/asset-material-substance-designer-painter.yaml
+++ b/examples/context-bundles/asset-material-substance-designer-painter.yaml
@@ -1,0 +1,37 @@
+context_bundle: asset.materials.fabric-library.authoring
+production_domain: asset
+context_kind: asset
+project: shared-assets
+asset: fabric-library
+asset_type: material
+task: material-authoring
+dcc:
+  primary: substance-designer
+  companions: [substance-painter, blender]
+rez_packages:
+  - dcc_mcp_core
+  - asset_material_authoring
+skill_paths:
+  shared: ["${REZ_ASSET_MATERIAL_AUTHORING_ROOT}/skills"]
+toolset_profile: asset-material-authoring
+resources: ["${REZ_ASSET_MATERIAL_AUTHORING_ROOT}/resources"]
+prompts: ["${REZ_ASSET_MATERIAL_AUTHORING_ROOT}/prompts"]
+instructions: "Expose material graph, texture export, and preview validation tools."
+response_policy:
+  max_text_chars: 7000
+  include_texture_manifest: true
+visual_feedback:
+  capture_after_mutation: true
+  include_material_preview: true
+env:
+  DCC_MCP_CONTEXT_BUNDLE: asset.materials.fabric-library.authoring
+  DCC_MCP_PRODUCTION_DOMAIN: asset
+  DCC_MCP_CONTEXT_KIND: asset
+  DCC_MCP_PROJECT: shared-assets
+  DCC_MCP_ASSET: fabric-library
+  DCC_MCP_ASSET_TYPE: material
+  DCC_MCP_TASK: material-authoring
+  DCC_MCP_TOOLSET_PROFILE: asset-material-authoring
+  DCC_MCP_SKILL_PATHS: "${REZ_ASSET_MATERIAL_AUTHORING_ROOT}/skills"
+  DCC_MCP_PACKAGE_PROVENANCE: asset_material_authoring-1.0.0
+docs: ../../docs/guide/rez-skill-packages.md

--- a/examples/context-bundles/commercial-2d-photoshop-motion.yaml
+++ b/examples/context-bundles/commercial-2d-photoshop-motion.yaml
@@ -1,0 +1,35 @@
+context_bundle: ad-spot.deliverable.social-16x9.motion
+production_domain: advertising
+context_kind: deliverable
+project: ad-spot
+task: motion-2d
+dcc:
+  primary: photoshop
+  companions: [aftereffects]
+rez_packages:
+  - dcc_mcp_core
+  - dcc_mcp_photoshop
+  - commercial_2d_layers
+skill_paths:
+  shared: ["${REZ_COMMERCIAL_2D_LAYERS_ROOT}/skills"]
+  photoshop: ["${REZ_COMMERCIAL_2D_LAYERS_ROOT}/skills"]
+toolset_profile: commercial-2d-motion
+resources: ["${REZ_COMMERCIAL_2D_LAYERS_ROOT}/resources"]
+prompts: ["${REZ_COMMERCIAL_2D_LAYERS_ROOT}/prompts"]
+instructions: "Keep edits layered, non-destructive, and export-review oriented."
+response_policy:
+  max_text_chars: 6000
+  prefer_summary: true
+visual_feedback:
+  capture_after_mutation: true
+  include_active_document_thumbnail: true
+env:
+  DCC_MCP_CONTEXT_BUNDLE: ad-spot.deliverable.social-16x9.motion
+  DCC_MCP_PRODUCTION_DOMAIN: advertising
+  DCC_MCP_CONTEXT_KIND: deliverable
+  DCC_MCP_PROJECT: ad-spot
+  DCC_MCP_TASK: motion-2d
+  DCC_MCP_TOOLSET_PROFILE: commercial-2d-motion
+  DCC_MCP_PHOTOSHOP_SKILL_PATHS: "${REZ_COMMERCIAL_2D_LAYERS_ROOT}/skills"
+  DCC_MCP_PACKAGE_PROVENANCE: commercial_2d_layers-1.0.0
+docs: ../../docs/guide/rez-skill-packages.md

--- a/examples/context-bundles/commercial-3d-cinema4d-blender.yaml
+++ b/examples/context-bundles/commercial-3d-cinema4d-blender.yaml
@@ -1,0 +1,37 @@
+context_bundle: product.launch-pack.hero-render.lookdev
+production_domain: advertising
+context_kind: product
+project: launch-pack
+asset: hero-product
+task: product-render
+dcc:
+  primary: blender
+  companions: [cinema4d]
+rez_packages:
+  - dcc_mcp_core
+  - dcc_mcp_blender
+  - commercial_3d_product_render
+skill_paths:
+  shared: ["${REZ_COMMERCIAL_3D_PRODUCT_RENDER_ROOT}/skills"]
+  blender: ["${REZ_COMMERCIAL_3D_PRODUCT_RENDER_ROOT}/skills"]
+toolset_profile: commercial-3d-product-render
+resources: ["${REZ_COMMERCIAL_3D_PRODUCT_RENDER_ROOT}/resources"]
+prompts: ["${REZ_COMMERCIAL_3D_PRODUCT_RENDER_ROOT}/prompts"]
+instructions: "Favor camera/material/render-preview tools over rigging or FX tools."
+response_policy:
+  max_text_chars: 8000
+  include_render_settings: true
+visual_feedback:
+  capture_after_mutation: true
+  include_viewport_preview: true
+env:
+  DCC_MCP_CONTEXT_BUNDLE: product.launch-pack.hero-render.lookdev
+  DCC_MCP_PRODUCTION_DOMAIN: advertising
+  DCC_MCP_CONTEXT_KIND: product
+  DCC_MCP_PROJECT: launch-pack
+  DCC_MCP_ASSET: hero-product
+  DCC_MCP_TASK: product-render
+  DCC_MCP_TOOLSET_PROFILE: commercial-3d-product-render
+  DCC_MCP_BLENDER_SKILL_PATHS: "${REZ_COMMERCIAL_3D_PRODUCT_RENDER_ROOT}/skills"
+  DCC_MCP_PACKAGE_PROVENANCE: commercial_3d_product_render-1.0.0
+docs: ../../docs/guide/rez-skill-packages.md

--- a/examples/context-bundles/film-shot-animation-maya.yaml
+++ b/examples/context-bundles/film-shot-animation-maya.yaml
@@ -1,0 +1,39 @@
+context_bundle: show-a.seq010.shot020.animation
+production_domain: film
+context_kind: shot
+project: show-a
+sequence: seq010
+shot: shot020
+task: animation
+dcc:
+  primary: maya
+  companions: [rv]
+rez_packages:
+  - dcc_mcp_core
+  - dcc_mcp_maya
+  - film_animation_blocking
+skill_paths:
+  shared: ["${REZ_FILM_ANIMATION_BLOCKING_ROOT}/skills"]
+  maya: ["${REZ_FILM_ANIMATION_BLOCKING_ROOT}/skills"]
+toolset_profile: film-shot-animation
+resources: ["${REZ_FILM_ANIMATION_BLOCKING_ROOT}/resources"]
+prompts: ["${REZ_FILM_ANIMATION_BLOCKING_ROOT}/prompts"]
+instructions: "Expose blocking, playblast, and selection tools; hide lighting and FX tools."
+response_policy:
+  max_text_chars: 8000
+  include_timeline_summary: true
+visual_feedback:
+  capture_after_mutation: true
+  include_playblast_reference: true
+env:
+  DCC_MCP_CONTEXT_BUNDLE: show-a.seq010.shot020.animation
+  DCC_MCP_PRODUCTION_DOMAIN: film
+  DCC_MCP_CONTEXT_KIND: shot
+  DCC_MCP_PROJECT: show-a
+  DCC_MCP_SEQUENCE: seq010
+  DCC_MCP_SHOT: shot020
+  DCC_MCP_TASK: animation
+  DCC_MCP_TOOLSET_PROFILE: film-shot-animation
+  DCC_MCP_MAYA_SKILL_PATHS: "${REZ_FILM_ANIMATION_BLOCKING_ROOT}/skills"
+  DCC_MCP_PACKAGE_PROVENANCE: film_animation_blocking-1.0.0
+docs: ../../docs/guide/rez-skill-packages.md

--- a/examples/context-bundles/film-shot-fx-houdini.yaml
+++ b/examples/context-bundles/film-shot-fx-houdini.yaml
@@ -1,0 +1,39 @@
+context_bundle: show-a.seq010.shot020.fx
+production_domain: film
+context_kind: shot
+project: show-a
+sequence: seq010
+shot: shot020
+task: fx
+dcc:
+  primary: houdini
+  companions: [maya, rv]
+rez_packages:
+  - dcc_mcp_core
+  - dcc_mcp_houdini
+  - film_fx_cache_review
+skill_paths:
+  shared: ["${REZ_FILM_FX_CACHE_REVIEW_ROOT}/skills"]
+  houdini: ["${REZ_FILM_FX_CACHE_REVIEW_ROOT}/skills"]
+toolset_profile: film-shot-fx
+resources: ["${REZ_FILM_FX_CACHE_REVIEW_ROOT}/resources"]
+prompts: ["${REZ_FILM_FX_CACHE_REVIEW_ROOT}/prompts"]
+instructions: "Expose cache review, sim status, and USD handoff tools."
+response_policy:
+  max_text_chars: 10000
+  truncate_geometry_samples: true
+visual_feedback:
+  capture_after_mutation: true
+  include_viewport_preview: true
+env:
+  DCC_MCP_CONTEXT_BUNDLE: show-a.seq010.shot020.fx
+  DCC_MCP_PRODUCTION_DOMAIN: film
+  DCC_MCP_CONTEXT_KIND: shot
+  DCC_MCP_PROJECT: show-a
+  DCC_MCP_SEQUENCE: seq010
+  DCC_MCP_SHOT: shot020
+  DCC_MCP_TASK: fx
+  DCC_MCP_TOOLSET_PROFILE: film-shot-fx
+  DCC_MCP_HOUDINI_SKILL_PATHS: "${REZ_FILM_FX_CACHE_REVIEW_ROOT}/skills"
+  DCC_MCP_PACKAGE_PROVENANCE: film_fx_cache_review-1.0.0
+docs: ../../docs/guide/rez-skill-packages.md

--- a/examples/context-bundles/game-level-unreal-blender-substance.yaml
+++ b/examples/context-bundles/game-level-unreal-blender-substance.yaml
@@ -1,0 +1,37 @@
+context_bundle: game-demo.level.city-block.layout
+production_domain: game
+context_kind: level
+project: game-demo
+asset: city-block
+task: level-layout
+dcc:
+  primary: unreal
+  companions: [blender, substance-painter]
+rez_packages:
+  - dcc_mcp_core
+  - dcc_mcp_unreal
+  - game_level_layout
+skill_paths:
+  shared: ["${REZ_GAME_LEVEL_LAYOUT_ROOT}/skills"]
+  unreal: ["${REZ_GAME_LEVEL_LAYOUT_ROOT}/skills"]
+toolset_profile: game-level-layout
+resources: ["${REZ_GAME_LEVEL_LAYOUT_ROOT}/resources"]
+prompts: ["${REZ_GAME_LEVEL_LAYOUT_ROOT}/prompts"]
+instructions: "Prefer placement, metrics, collision, and navmesh checks over render-only tools."
+response_policy:
+  max_text_chars: 9000
+  include_level_metrics: true
+visual_feedback:
+  capture_after_mutation: true
+  include_editor_viewport: true
+env:
+  DCC_MCP_CONTEXT_BUNDLE: game-demo.level.city-block.layout
+  DCC_MCP_PRODUCTION_DOMAIN: game
+  DCC_MCP_CONTEXT_KIND: level
+  DCC_MCP_PROJECT: game-demo
+  DCC_MCP_ASSET: city-block
+  DCC_MCP_TASK: level-layout
+  DCC_MCP_TOOLSET_PROFILE: game-level-layout
+  DCC_MCP_UNREAL_SKILL_PATHS: "${REZ_GAME_LEVEL_LAYOUT_ROOT}/skills"
+  DCC_MCP_PACKAGE_PROVENANCE: game_level_layout-1.0.0
+docs: ../../docs/guide/rez-skill-packages.md

--- a/examples/rez-skills/README.md
+++ b/examples/rez-skills/README.md
@@ -1,0 +1,22 @@
+# Example Rez Skill Packages
+
+These packages show how to split DCC MCP skills by production context. They are
+tiny on purpose: each package contributes one focused skill, one tool schema,
+and a minimal script so pipeline teams can copy the layout into real Rez
+packages.
+
+Prefer composing several narrow packages over one huge `studio-skills` package.
+The context bundle should load only the tools that match the active project,
+task, asset type, and DCC host.
+
+| Package | Context |
+|---------|---------|
+| `commercial_2d_layers` | Photoshop layered deliverables and motion handoff |
+| `commercial_3d_product_render` | Product lookdev and render review |
+| `film_animation_blocking` | Maya shot blocking and playblast review |
+| `film_fx_cache_review` | Houdini simulation/cache review |
+| `game_level_layout` | Game level layout checks |
+| `asset_material_authoring` | Material graph and texture export checks |
+
+See `docs/guide/rez-skill-packages.md` and `examples/context-bundles/` for the
+matching launch-context manifests.

--- a/examples/rez-skills/asset_material_authoring/README.md
+++ b/examples/rez-skills/asset_material_authoring/README.md
@@ -1,0 +1,4 @@
+# asset_material_authoring
+
+Load this package for material authoring contexts that need graph, texture, and
+preview validation without exposing shot-specific tools.

--- a/examples/rez-skills/asset_material_authoring/package.py
+++ b/examples/rez-skills/asset_material_authoring/package.py
@@ -1,0 +1,18 @@
+# ruff: noqa: F821
+
+name = "asset_material_authoring"
+version = "1.0.0"
+requires = ["dcc_mcp_core"]
+
+
+def commands():
+    env.DCC_MCP_CONTEXT_BUNDLE = "asset.materials.fabric-library.authoring"
+    env.DCC_MCP_PRODUCTION_DOMAIN = "asset"
+    env.DCC_MCP_CONTEXT_KIND = "asset"
+    env.DCC_MCP_PROJECT = "shared-assets"
+    env.DCC_MCP_ASSET = "fabric-library"
+    env.DCC_MCP_ASSET_TYPE = "material"
+    env.DCC_MCP_TASK = "material-authoring"
+    env.DCC_MCP_TOOLSET_PROFILE = "asset-material-authoring"
+    env.DCC_MCP_PACKAGE_PROVENANCE.append("asset_material_authoring-1.0.0")
+    env.DCC_MCP_SKILL_PATHS.append("{root}/skills")

--- a/examples/rez-skills/asset_material_authoring/skills/asset-material-authoring/SKILL.md
+++ b/examples/rez-skills/asset_material_authoring/skills/asset-material-authoring/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: asset-material-authoring
+description: "Material authoring helpers for asset-library contexts."
+license: MIT
+allowed-tools: Bash Read Write
+metadata:
+  dcc-mcp.dcc: python
+  dcc-mcp.version: "1.0.0"
+  dcc-mcp.layer: domain
+  dcc-mcp.search-hint: "material graph, texture export, asset material, preview"
+  dcc-mcp.tags: "asset, material, substance, texture"
+  dcc-mcp.tools: tools.yaml
+  dcc-mcp.prompts: prompts.yaml
+  dcc-mcp.toolset-profile: asset-material-authoring
+  dcc-mcp.package-provenance: asset_material_authoring-1.0.0
+---
+
+# Asset Material Authoring
+
+Use when validating material-library authoring and texture export readiness.

--- a/examples/rez-skills/asset_material_authoring/skills/asset-material-authoring/prompts.yaml
+++ b/examples/rez-skills/asset_material_authoring/skills/asset-material-authoring/prompts.yaml
@@ -1,0 +1,7 @@
+prompts:
+  - name: review_material_export
+    description: Review material export readiness.
+    arguments: []
+    messages:
+      - role: user
+        content: "Summarize graph health, texture outputs, preview status, and export risks."

--- a/examples/rez-skills/asset_material_authoring/skills/asset-material-authoring/resources/context.md
+++ b/examples/rez-skills/asset_material_authoring/skills/asset-material-authoring/resources/context.md
@@ -1,0 +1,3 @@
+# Asset Material Authoring Context
+
+Review material graph health, expected texture outputs, and preview/export readiness.

--- a/examples/rez-skills/asset_material_authoring/skills/asset-material-authoring/scripts/validate_material_export.py
+++ b/examples/rez-skills/asset_material_authoring/skills/asset-material-authoring/scripts/validate_material_export.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+import json
+
+print(json.dumps({"summary": "Material authoring package active.", "exports": ["basecolor", "roughness", "normal"]}))

--- a/examples/rez-skills/asset_material_authoring/skills/asset-material-authoring/tools.yaml
+++ b/examples/rez-skills/asset_material_authoring/skills/asset-material-authoring/tools.yaml
@@ -1,0 +1,14 @@
+tools:
+  - name: validate_material_export
+    description: Summarize material export readiness for an asset context
+    group: review
+    input_schema:
+      type: object
+      properties:
+        material:
+          type: string
+          description: Optional material identifier
+    read_only: true
+    destructive: false
+    idempotent: true
+    source_file: scripts/validate_material_export.py

--- a/examples/rez-skills/commercial_2d_layers/README.md
+++ b/examples/rez-skills/commercial_2d_layers/README.md
@@ -1,0 +1,4 @@
+# commercial_2d_layers
+
+Load this package for advertising deliverables that need Photoshop layer
+inspection, naming checks, and non-destructive export preparation.

--- a/examples/rez-skills/commercial_2d_layers/package.py
+++ b/examples/rez-skills/commercial_2d_layers/package.py
@@ -1,0 +1,16 @@
+# ruff: noqa: F821
+
+name = "commercial_2d_layers"
+version = "1.0.0"
+requires = ["dcc_mcp_core", "dcc_mcp_photoshop"]
+
+
+def commands():
+    env.DCC_MCP_CONTEXT_BUNDLE = "ad-spot.deliverable.social-16x9.motion"
+    env.DCC_MCP_PRODUCTION_DOMAIN = "advertising"
+    env.DCC_MCP_CONTEXT_KIND = "deliverable"
+    env.DCC_MCP_PROJECT = "ad-spot"
+    env.DCC_MCP_TASK = "motion-2d"
+    env.DCC_MCP_TOOLSET_PROFILE = "commercial-2d-motion"
+    env.DCC_MCP_PACKAGE_PROVENANCE.append("commercial_2d_layers-1.0.0")
+    env.DCC_MCP_PHOTOSHOP_SKILL_PATHS.append("{root}/skills")

--- a/examples/rez-skills/commercial_2d_layers/skills/commercial-2d-layers/SKILL.md
+++ b/examples/rez-skills/commercial_2d_layers/skills/commercial-2d-layers/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: commercial-2d-layers
+description: "Photoshop layer checks for commercial 2D motion deliverables."
+license: MIT
+allowed-tools: Bash Read Write
+metadata:
+  dcc-mcp.dcc: photoshop
+  dcc-mcp.version: "1.0.0"
+  dcc-mcp.layer: domain
+  dcc-mcp.search-hint: "photoshop layers, social deliverable, motion handoff, layer naming"
+  dcc-mcp.tags: "advertising, photoshop, 2d, layers"
+  dcc-mcp.tools: tools.yaml
+  dcc-mcp.prompts: prompts.yaml
+  dcc-mcp.toolset-profile: commercial-2d-motion
+  dcc-mcp.package-provenance: commercial_2d_layers-1.0.0
+---
+
+# Commercial 2D Layers
+
+Use when preparing layered Photoshop deliverables for motion or social export.

--- a/examples/rez-skills/commercial_2d_layers/skills/commercial-2d-layers/prompts.yaml
+++ b/examples/rez-skills/commercial_2d_layers/skills/commercial-2d-layers/prompts.yaml
@@ -1,0 +1,7 @@
+prompts:
+  - name: review_layer_handoff
+    description: Review a Photoshop layer stack for motion handoff.
+    arguments: []
+    messages:
+      - role: user
+        content: "Summarize layer groups, naming risks, and export notes for this deliverable."

--- a/examples/rez-skills/commercial_2d_layers/skills/commercial-2d-layers/resources/context.md
+++ b/examples/rez-skills/commercial_2d_layers/skills/commercial-2d-layers/resources/context.md
@@ -1,0 +1,3 @@
+# Commercial 2D Layer Context
+
+Layer edits should stay non-destructive and preserve group naming for motion handoff.

--- a/examples/rez-skills/commercial_2d_layers/skills/commercial-2d-layers/scripts/summarize_layers.py
+++ b/examples/rez-skills/commercial_2d_layers/skills/commercial-2d-layers/scripts/summarize_layers.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+import json
+
+print(json.dumps({"summary": "Layer groups are ready for motion handoff.", "warnings": []}))

--- a/examples/rez-skills/commercial_2d_layers/skills/commercial-2d-layers/tools.yaml
+++ b/examples/rez-skills/commercial_2d_layers/skills/commercial-2d-layers/tools.yaml
@@ -1,0 +1,14 @@
+tools:
+  - name: summarize_layers
+    description: Summarize layer groups and naming risks for a Photoshop deliverable
+    group: review
+    input_schema:
+      type: object
+      properties:
+        document:
+          type: string
+          description: Optional document path or display name
+    read_only: true
+    destructive: false
+    idempotent: true
+    source_file: scripts/summarize_layers.py

--- a/examples/rez-skills/commercial_3d_product_render/README.md
+++ b/examples/rez-skills/commercial_3d_product_render/README.md
@@ -1,0 +1,4 @@
+# commercial_3d_product_render
+
+Load this package for commercial product lookdev and render review in Blender or
+a comparable 3D DCC.

--- a/examples/rez-skills/commercial_3d_product_render/package.py
+++ b/examples/rez-skills/commercial_3d_product_render/package.py
@@ -1,0 +1,17 @@
+# ruff: noqa: F821
+
+name = "commercial_3d_product_render"
+version = "1.0.0"
+requires = ["dcc_mcp_core", "dcc_mcp_blender"]
+
+
+def commands():
+    env.DCC_MCP_CONTEXT_BUNDLE = "product.launch-pack.hero-render.lookdev"
+    env.DCC_MCP_PRODUCTION_DOMAIN = "advertising"
+    env.DCC_MCP_CONTEXT_KIND = "product"
+    env.DCC_MCP_PROJECT = "launch-pack"
+    env.DCC_MCP_ASSET = "hero-product"
+    env.DCC_MCP_TASK = "product-render"
+    env.DCC_MCP_TOOLSET_PROFILE = "commercial-3d-product-render"
+    env.DCC_MCP_PACKAGE_PROVENANCE.append("commercial_3d_product_render-1.0.0")
+    env.DCC_MCP_BLENDER_SKILL_PATHS.append("{root}/skills")

--- a/examples/rez-skills/commercial_3d_product_render/skills/commercial-3d-product-render/SKILL.md
+++ b/examples/rez-skills/commercial_3d_product_render/skills/commercial-3d-product-render/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: commercial-3d-product-render
+description: "Product lookdev and render-review helpers for commercial 3D work."
+license: MIT
+allowed-tools: Bash Read Write
+metadata:
+  dcc-mcp.dcc: blender
+  dcc-mcp.version: "1.0.0"
+  dcc-mcp.layer: domain
+  dcc-mcp.search-hint: "product render, lookdev, camera, material, turntable"
+  dcc-mcp.tags: "advertising, blender, product, render"
+  dcc-mcp.tools: tools.yaml
+  dcc-mcp.prompts: prompts.yaml
+  dcc-mcp.toolset-profile: commercial-3d-product-render
+  dcc-mcp.package-provenance: commercial_3d_product_render-1.0.0
+---
+
+# Commercial 3D Product Render
+
+Use when reviewing product cameras, materials, and render settings.

--- a/examples/rez-skills/commercial_3d_product_render/skills/commercial-3d-product-render/prompts.yaml
+++ b/examples/rez-skills/commercial_3d_product_render/skills/commercial-3d-product-render/prompts.yaml
@@ -1,0 +1,7 @@
+prompts:
+  - name: review_product_lookdev
+    description: Review product render readiness.
+    arguments: []
+    messages:
+      - role: user
+        content: "Summarize camera, material, lighting, and render-preview readiness for this product."

--- a/examples/rez-skills/commercial_3d_product_render/skills/commercial-3d-product-render/resources/context.md
+++ b/examples/rez-skills/commercial_3d_product_render/skills/commercial-3d-product-render/resources/context.md
@@ -1,0 +1,3 @@
+# Commercial 3D Product Render Context
+
+Prioritize product lookdev, camera framing, material assignment, and render-preview checks.

--- a/examples/rez-skills/commercial_3d_product_render/skills/commercial-3d-product-render/scripts/review_product_render.py
+++ b/examples/rez-skills/commercial_3d_product_render/skills/commercial-3d-product-render/scripts/review_product_render.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+import json
+
+print(json.dumps({"summary": "Product render context is scoped to lookdev review.", "missing": []}))

--- a/examples/rez-skills/commercial_3d_product_render/skills/commercial-3d-product-render/tools.yaml
+++ b/examples/rez-skills/commercial_3d_product_render/skills/commercial-3d-product-render/tools.yaml
@@ -1,0 +1,14 @@
+tools:
+  - name: review_product_render
+    description: Summarize product render readiness and missing lookdev inputs
+    group: review
+    input_schema:
+      type: object
+      properties:
+        asset:
+          type: string
+          description: Product asset name
+    read_only: true
+    destructive: false
+    idempotent: true
+    source_file: scripts/review_product_render.py

--- a/examples/rez-skills/film_animation_blocking/README.md
+++ b/examples/rez-skills/film_animation_blocking/README.md
@@ -1,0 +1,4 @@
+# film_animation_blocking
+
+Load this package for Maya shot animation blocking, selection review, and
+playblast-oriented checks.

--- a/examples/rez-skills/film_animation_blocking/package.py
+++ b/examples/rez-skills/film_animation_blocking/package.py
@@ -1,0 +1,18 @@
+# ruff: noqa: F821
+
+name = "film_animation_blocking"
+version = "1.0.0"
+requires = ["dcc_mcp_core", "dcc_mcp_maya"]
+
+
+def commands():
+    env.DCC_MCP_CONTEXT_BUNDLE = "show-a.seq010.shot020.animation"
+    env.DCC_MCP_PRODUCTION_DOMAIN = "film"
+    env.DCC_MCP_CONTEXT_KIND = "shot"
+    env.DCC_MCP_PROJECT = "show-a"
+    env.DCC_MCP_SEQUENCE = "seq010"
+    env.DCC_MCP_SHOT = "shot020"
+    env.DCC_MCP_TASK = "animation"
+    env.DCC_MCP_TOOLSET_PROFILE = "film-shot-animation"
+    env.DCC_MCP_PACKAGE_PROVENANCE.append("film_animation_blocking-1.0.0")
+    env.DCC_MCP_MAYA_SKILL_PATHS.append("{root}/skills")

--- a/examples/rez-skills/film_animation_blocking/skills/film-animation-blocking/SKILL.md
+++ b/examples/rez-skills/film_animation_blocking/skills/film-animation-blocking/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: film-animation-blocking
+description: "Maya blocking helpers for film shot animation contexts."
+license: MIT
+allowed-tools: Bash Read Write
+metadata:
+  dcc-mcp.dcc: maya
+  dcc-mcp.version: "1.0.0"
+  dcc-mcp.layer: domain
+  dcc-mcp.search-hint: "maya animation blocking, shot, timeline, playblast"
+  dcc-mcp.tags: "film, maya, animation, shot"
+  dcc-mcp.tools: tools.yaml
+  dcc-mcp.prompts: prompts.yaml
+  dcc-mcp.toolset-profile: film-shot-animation
+  dcc-mcp.package-provenance: film_animation_blocking-1.0.0
+---
+
+# Film Animation Blocking
+
+Use when working on shot blocking and playblast review inside Maya.

--- a/examples/rez-skills/film_animation_blocking/skills/film-animation-blocking/prompts.yaml
+++ b/examples/rez-skills/film_animation_blocking/skills/film-animation-blocking/prompts.yaml
@@ -1,0 +1,7 @@
+prompts:
+  - name: review_animation_blocking
+    description: Review a Maya shot blocking pass.
+    arguments: []
+    messages:
+      - role: user
+        content: "Summarize blocking clarity, timeline range, pose coverage, and playblast follow-ups."

--- a/examples/rez-skills/film_animation_blocking/skills/film-animation-blocking/resources/context.md
+++ b/examples/rez-skills/film_animation_blocking/skills/film-animation-blocking/resources/context.md
@@ -1,0 +1,3 @@
+# Film Animation Blocking Context
+
+Expose animation blocking, selection, timeline, and playblast review tools for the active shot.

--- a/examples/rez-skills/film_animation_blocking/skills/film-animation-blocking/scripts/summarize_blocking.py
+++ b/examples/rez-skills/film_animation_blocking/skills/film-animation-blocking/scripts/summarize_blocking.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+import json
+
+print(json.dumps({"summary": "Animation blocking package active.", "next": ["review poses", "make playblast"]}))

--- a/examples/rez-skills/film_animation_blocking/skills/film-animation-blocking/tools.yaml
+++ b/examples/rez-skills/film_animation_blocking/skills/film-animation-blocking/tools.yaml
@@ -1,0 +1,14 @@
+tools:
+  - name: summarize_blocking
+    description: Summarize shot blocking status from a Maya animation scene
+    group: review
+    input_schema:
+      type: object
+      properties:
+        shot:
+          type: string
+          description: Shot identifier
+    read_only: true
+    destructive: false
+    idempotent: true
+    source_file: scripts/summarize_blocking.py

--- a/examples/rez-skills/film_fx_cache_review/README.md
+++ b/examples/rez-skills/film_fx_cache_review/README.md
@@ -1,0 +1,4 @@
+# film_fx_cache_review
+
+Load this package for Houdini shot FX cache review, simulation status, and USD
+handoff checks.

--- a/examples/rez-skills/film_fx_cache_review/package.py
+++ b/examples/rez-skills/film_fx_cache_review/package.py
@@ -1,0 +1,18 @@
+# ruff: noqa: F821
+
+name = "film_fx_cache_review"
+version = "1.0.0"
+requires = ["dcc_mcp_core", "dcc_mcp_houdini"]
+
+
+def commands():
+    env.DCC_MCP_CONTEXT_BUNDLE = "show-a.seq010.shot020.fx"
+    env.DCC_MCP_PRODUCTION_DOMAIN = "film"
+    env.DCC_MCP_CONTEXT_KIND = "shot"
+    env.DCC_MCP_PROJECT = "show-a"
+    env.DCC_MCP_SEQUENCE = "seq010"
+    env.DCC_MCP_SHOT = "shot020"
+    env.DCC_MCP_TASK = "fx"
+    env.DCC_MCP_TOOLSET_PROFILE = "film-shot-fx"
+    env.DCC_MCP_PACKAGE_PROVENANCE.append("film_fx_cache_review-1.0.0")
+    env.DCC_MCP_HOUDINI_SKILL_PATHS.append("{root}/skills")

--- a/examples/rez-skills/film_fx_cache_review/skills/film-fx-cache-review/SKILL.md
+++ b/examples/rez-skills/film_fx_cache_review/skills/film-fx-cache-review/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: film-fx-cache-review
+description: "Houdini FX cache and simulation review helpers for film shots."
+license: MIT
+allowed-tools: Bash Read Write
+metadata:
+  dcc-mcp.dcc: houdini
+  dcc-mcp.version: "1.0.0"
+  dcc-mcp.layer: domain
+  dcc-mcp.search-hint: "houdini fx cache, simulation, usd, shot review"
+  dcc-mcp.tags: "film, houdini, fx, cache"
+  dcc-mcp.tools: tools.yaml
+  dcc-mcp.prompts: prompts.yaml
+  dcc-mcp.toolset-profile: film-shot-fx
+  dcc-mcp.package-provenance: film_fx_cache_review-1.0.0
+---
+
+# Film FX Cache Review
+
+Use when reviewing Houdini simulations and cache handoffs for a film shot.

--- a/examples/rez-skills/film_fx_cache_review/skills/film-fx-cache-review/prompts.yaml
+++ b/examples/rez-skills/film_fx_cache_review/skills/film-fx-cache-review/prompts.yaml
@@ -1,0 +1,7 @@
+prompts:
+  - name: review_fx_cache
+    description: Review FX cache readiness for a shot.
+    arguments: []
+    messages:
+      - role: user
+        content: "Summarize simulation status, cache versions, USD handoff risks, and visual-review needs."

--- a/examples/rez-skills/film_fx_cache_review/skills/film-fx-cache-review/resources/context.md
+++ b/examples/rez-skills/film_fx_cache_review/skills/film-fx-cache-review/resources/context.md
@@ -1,0 +1,3 @@
+# Film FX Cache Review Context
+
+Focus on simulation cache versions, viewport review, and downstream USD handoff.

--- a/examples/rez-skills/film_fx_cache_review/skills/film-fx-cache-review/scripts/review_cache_manifest.py
+++ b/examples/rez-skills/film_fx_cache_review/skills/film-fx-cache-review/scripts/review_cache_manifest.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+import json
+
+print(json.dumps({"summary": "FX cache review package active.", "cache_versions": []}))

--- a/examples/rez-skills/film_fx_cache_review/skills/film-fx-cache-review/tools.yaml
+++ b/examples/rez-skills/film_fx_cache_review/skills/film-fx-cache-review/tools.yaml
@@ -1,0 +1,14 @@
+tools:
+  - name: review_cache_manifest
+    description: Summarize FX cache versions expected by the current shot context
+    group: review
+    input_schema:
+      type: object
+      properties:
+        cache_root:
+          type: string
+          description: Optional cache root to inspect
+    read_only: true
+    destructive: false
+    idempotent: true
+    source_file: scripts/review_cache_manifest.py

--- a/examples/rez-skills/game_level_layout/README.md
+++ b/examples/rez-skills/game_level_layout/README.md
@@ -1,0 +1,4 @@
+# game_level_layout
+
+Load this package for game level layout checks such as placement summaries,
+collision readiness, and navmesh-oriented review.

--- a/examples/rez-skills/game_level_layout/package.py
+++ b/examples/rez-skills/game_level_layout/package.py
@@ -1,0 +1,17 @@
+# ruff: noqa: F821
+
+name = "game_level_layout"
+version = "1.0.0"
+requires = ["dcc_mcp_core", "dcc_mcp_unreal"]
+
+
+def commands():
+    env.DCC_MCP_CONTEXT_BUNDLE = "game-demo.level.city-block.layout"
+    env.DCC_MCP_PRODUCTION_DOMAIN = "game"
+    env.DCC_MCP_CONTEXT_KIND = "level"
+    env.DCC_MCP_PROJECT = "game-demo"
+    env.DCC_MCP_ASSET = "city-block"
+    env.DCC_MCP_TASK = "level-layout"
+    env.DCC_MCP_TOOLSET_PROFILE = "game-level-layout"
+    env.DCC_MCP_PACKAGE_PROVENANCE.append("game_level_layout-1.0.0")
+    env.DCC_MCP_UNREAL_SKILL_PATHS.append("{root}/skills")

--- a/examples/rez-skills/game_level_layout/skills/game-level-layout/SKILL.md
+++ b/examples/rez-skills/game_level_layout/skills/game-level-layout/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: game-level-layout
+description: "Game level layout review helpers for editor contexts."
+license: MIT
+allowed-tools: Bash Read Write
+metadata:
+  dcc-mcp.dcc: unreal
+  dcc-mcp.version: "1.0.0"
+  dcc-mcp.layer: domain
+  dcc-mcp.search-hint: "unreal level layout, collision, navmesh, placement"
+  dcc-mcp.tags: "game, unreal, level, layout"
+  dcc-mcp.tools: tools.yaml
+  dcc-mcp.prompts: prompts.yaml
+  dcc-mcp.toolset-profile: game-level-layout
+  dcc-mcp.package-provenance: game_level_layout-1.0.0
+---
+
+# Game Level Layout
+
+Use when checking level composition, placement, and gameplay-space metrics.

--- a/examples/rez-skills/game_level_layout/skills/game-level-layout/prompts.yaml
+++ b/examples/rez-skills/game_level_layout/skills/game-level-layout/prompts.yaml
@@ -1,0 +1,7 @@
+prompts:
+  - name: review_level_layout
+    description: Review game level layout readiness.
+    arguments: []
+    messages:
+      - role: user
+        content: "Summarize placement, scale, collision, navmesh, and gameplay-space risks."

--- a/examples/rez-skills/game_level_layout/skills/game-level-layout/resources/context.md
+++ b/examples/rez-skills/game_level_layout/skills/game-level-layout/resources/context.md
@@ -1,0 +1,3 @@
+# Game Level Layout Context
+
+Review level layout for scale, collision, navmesh, and gameplay traversal constraints.

--- a/examples/rez-skills/game_level_layout/skills/game-level-layout/scripts/summarize_level_layout.py
+++ b/examples/rez-skills/game_level_layout/skills/game-level-layout/scripts/summarize_level_layout.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+import json
+
+print(json.dumps({"summary": "Game level layout package active.", "checks": ["scale", "collision", "navmesh"]}))

--- a/examples/rez-skills/game_level_layout/skills/game-level-layout/tools.yaml
+++ b/examples/rez-skills/game_level_layout/skills/game-level-layout/tools.yaml
@@ -1,0 +1,14 @@
+tools:
+  - name: summarize_level_layout
+    description: Summarize level-layout context and likely review checks
+    group: review
+    input_schema:
+      type: object
+      properties:
+        level:
+          type: string
+          description: Optional level name
+    read_only: true
+    destructive: false
+    idempotent: true
+    source_file: scripts/summarize_level_layout.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = []
 test = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
+    "rez",
 ]
 dev = [
     "dcc-mcp-core[test]",

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -206,6 +206,7 @@ class DccServerBase:
             self._config.scene = scene
         # Always stamp the DCC type so gateway registry knows which DCC this is
         self._config.dcc_type = dcc_name
+        self._config.instance_metadata = self._context_metadata_from_env(dcc_name)
 
         # ── Job persistence ───────────────────────────────────────────────────
         # Wire a per-DCC SQLite database for job history so that tool-call
@@ -254,6 +255,35 @@ class DccServerBase:
             self.__dict__[name] = resolver
             return resolver
         raise AttributeError(name)
+
+    @staticmethod
+    def _context_metadata_from_env(dcc_name: str) -> dict[str, str]:
+        """Collect Rez-resolved context metadata for gateway discovery."""
+        env_map = {
+            "context_bundle": "DCC_MCP_CONTEXT_BUNDLE",
+            "production_domain": "DCC_MCP_PRODUCTION_DOMAIN",
+            "context_kind": "DCC_MCP_CONTEXT_KIND",
+            "project": "DCC_MCP_PROJECT",
+            "sequence": "DCC_MCP_SEQUENCE",
+            "shot": "DCC_MCP_SHOT",
+            "asset": "DCC_MCP_ASSET",
+            "asset_type": "DCC_MCP_ASSET_TYPE",
+            "task": "DCC_MCP_TASK",
+            "toolset_profile": "DCC_MCP_TOOLSET_PROFILE",
+            "package_provenance": "DCC_MCP_PACKAGE_PROVENANCE",
+            "skill_paths": "DCC_MCP_SKILL_PATHS",
+            "resource_paths": "DCC_MCP_RESOURCE_PATHS",
+            "prompt_paths": "DCC_MCP_PROMPT_PATHS",
+        }
+        metadata: dict[str, str] = {}
+        for key, env_name in env_map.items():
+            value = os.environ.get(env_name, "")
+            if value:
+                metadata[key] = value
+        dcc_skill_paths = os.environ.get(f"DCC_MCP_{dcc_name.upper()}_SKILL_PATHS", "")
+        if dcc_skill_paths:
+            metadata["dcc_skill_paths"] = dcc_skill_paths
+        return metadata
 
     # ── observability helpers (delegated to collaborators, #486) ──────────────
 

--- a/tests/test_context_bundle_rez_fixture.py
+++ b/tests/test_context_bundle_rez_fixture.py
@@ -1,0 +1,355 @@
+"""End-to-end fixture for Rez-resolved context bundle skill exposure."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+from pathlib import Path
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+
+import pytest
+
+from dcc_mcp_core import McpHttpConfig
+from dcc_mcp_core import McpHttpServer
+from dcc_mcp_core import ToolRegistry
+from dcc_mcp_core import scan_and_load_lenient
+
+REZ_CONTEXT_CASES = [
+    {
+        "package": "film_animation_blocking",
+        "dcc": "maya",
+        "skill_env": "DCC_MCP_MAYA_SKILL_PATHS",
+        "skill": "film-animation-blocking",
+        "tool": "summarize_blocking",
+        "task": "animation",
+        "summary": "Animation blocking package active.",
+    },
+    {
+        "package": "film_fx_cache_review",
+        "dcc": "houdini",
+        "skill_env": "DCC_MCP_HOUDINI_SKILL_PATHS",
+        "skill": "film-fx-cache-review",
+        "tool": "review_cache_manifest",
+        "task": "fx",
+        "summary": "FX cache review package active.",
+    },
+    {
+        "package": "commercial_2d_layers",
+        "dcc": "photoshop",
+        "skill_env": "DCC_MCP_PHOTOSHOP_SKILL_PATHS",
+        "skill": "commercial-2d-layers",
+        "tool": "summarize_layers",
+        "task": "motion-2d",
+        "summary": "Layer groups are ready for motion handoff.",
+    },
+    {
+        "package": "game_level_layout",
+        "dcc": "unreal",
+        "skill_env": "DCC_MCP_UNREAL_SKILL_PATHS",
+        "skill": "game-level-layout",
+        "tool": "summarize_level_layout",
+        "task": "level-layout",
+        "summary": "Game level layout package active.",
+    },
+    {
+        "package": "asset_material_authoring",
+        "dcc": "python",
+        "skill_env": "DCC_MCP_SKILL_PATHS",
+        "skill": "asset-material-authoring",
+        "tool": "validate_material_export",
+        "task": "material-authoring",
+        "summary": "Material authoring package active.",
+    },
+]
+
+
+def _pick_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _post_mcp(url: str, method: str, params: dict | None = None, rpc_id: int = 1) -> dict:
+    body = {"jsonrpc": "2.0", "id": rpc_id, "method": method}
+    if params is not None:
+        body["params"] = params
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        return json.loads(resp.read())
+
+
+def _backend(
+    dcc: str,
+    tool_name: str,
+    metadata: dict[str, str],
+    registry_dir: Path,
+    gateway_port: int,
+) -> tuple[McpHttpServer, object]:
+    registry = ToolRegistry()
+    registry.register(name=tool_name, description=f"{dcc}:{tool_name}", dcc=dcc, version="1.0.0")
+
+    cfg = McpHttpConfig(port=0, server_name=f"{dcc}-context-fixture")
+    cfg.gateway_port = gateway_port
+    cfg.registry_dir = str(registry_dir)
+    cfg.dcc_type = dcc
+    cfg.heartbeat_secs = 1
+    cfg.stale_timeout_secs = 10
+    cfg.instance_metadata = metadata
+
+    server = McpHttpServer(registry, cfg)
+    return server, server.start()
+
+
+def _tool_suffixes(gateway_url: str) -> set[str]:
+    tools = _post_mcp(gateway_url, "tools/list")["result"]["tools"]
+    suffixes = set()
+    for tool in tools:
+        name = tool["name"]
+        if "." in name and not name.startswith("__"):
+            suffixes.add(name.split(".", 1)[1])
+    return suffixes
+
+
+def _tool_names(mcp_url: str) -> set[str]:
+    return {tool["name"] for tool in _post_mcp(mcp_url, "tools/list")["result"]["tools"]}
+
+
+def _write_rez_stub_packages(root: Path) -> None:
+    for name in [
+        "dcc_mcp_core",
+        "dcc_mcp_maya",
+        "dcc_mcp_houdini",
+        "dcc_mcp_photoshop",
+        "dcc_mcp_blender",
+        "dcc_mcp_unreal",
+    ]:
+        package_dir = root / name
+        package_dir.mkdir(parents=True, exist_ok=True)
+        (package_dir / "package.py").write_text(
+            f'name = "{name}"\nversion = "1.0.0"\n\n\ndef commands():\n    pass\n',
+            encoding="utf-8",
+        )
+
+
+def _write_rez_verifier(path: Path) -> None:
+    path.write_text(
+        r"""
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+from dcc_mcp_core import SkillCatalog
+from dcc_mcp_core import ToolRegistry
+
+expected = json.loads(os.environ["DCC_MCP_E2E_EXPECTED"])
+skill_paths = [
+    Path(item)
+    for item in os.environ[expected["skill_env"]].split(os.pathsep)
+    if item and (Path(item) / expected["skill"]).exists()
+]
+assert len(skill_paths) == 1, skill_paths
+skill_root = skill_paths[0]
+
+registry = ToolRegistry()
+catalog = SkillCatalog(registry)
+discovered = catalog.discover(extra_paths=[str(skill_root)], dcc_name=expected["dcc"])
+assert discovered == 1, discovered
+assert len(catalog.list_skills()) == 1
+assert catalog.loaded_count() == 0
+assert len(registry.list_actions()) == 0
+
+search = catalog.search_skills(query=expected["task"], dcc=expected["dcc"], limit=5)
+assert [item.name for item in search] == [expected["skill"]]
+
+actions = catalog.load_skill(expected["skill"])
+assert len(actions) == 1, actions
+assert catalog.loaded_count() == 1
+assert len(registry.list_actions()) == 1
+
+script = skill_root / expected["skill"] / "scripts" / f"{expected['tool']}.py"
+completed = subprocess.run(
+    [sys.executable, str(script)],
+    check=True,
+    capture_output=True,
+    text=True,
+)
+result = json.loads(completed.stdout)
+assert result["summary"] == expected["summary"], result
+
+removed = catalog.unload_skill(expected["skill"])
+assert removed == 1
+assert catalog.loaded_count() == 0
+assert len(registry.list_actions()) == 0
+
+print(json.dumps({
+    "package": expected["package"],
+    "discovered": discovered,
+    "actions_after_load": len(actions),
+    "actions_after_unload": len(registry.list_actions()),
+    "summary": result["summary"],
+}))
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+
+def test_rez_context_bundle_fixture_exposes_distinct_instance_metadata(tmp_path: Path) -> None:
+    registry_dir = tmp_path / "registry"
+    gateway_port = _pick_free_port()
+    backends = [
+        (
+            "maya",
+            "summarize_blocking",
+            {
+                "context_bundle": "show-a.seq010.shot020.animation",
+                "production_domain": "film",
+                "context_kind": "shot",
+                "task": "animation",
+                "toolset_profile": "film-shot-animation",
+                "package_provenance": "film_animation_blocking-1.0.0",
+            },
+        ),
+        (
+            "houdini",
+            "review_cache_manifest",
+            {
+                "context_bundle": "show-a.seq010.shot020.fx",
+                "production_domain": "film",
+                "context_kind": "shot",
+                "task": "fx",
+                "toolset_profile": "film-shot-fx",
+                "package_provenance": "film_fx_cache_review-1.0.0",
+            },
+        ),
+        (
+            "photoshop",
+            "summarize_layers",
+            {
+                "context_bundle": "ad-spot.deliverable.social-16x9.motion",
+                "production_domain": "advertising",
+                "context_kind": "deliverable",
+                "task": "motion-2d",
+                "toolset_profile": "commercial-2d-motion",
+                "package_provenance": "commercial_2d_layers-1.0.0",
+            },
+        ),
+        (
+            "blender",
+            "summarize_level_layout",
+            {
+                "context_bundle": "game-demo.level.city-block.layout",
+                "production_domain": "game",
+                "context_kind": "level",
+                "task": "level-layout",
+                "toolset_profile": "game-level-layout",
+                "package_provenance": "game_level_layout-1.0.0",
+            },
+        ),
+    ]
+
+    handles = []
+    try:
+        for dcc, tool_name, metadata in backends:
+            handles.append(_backend(dcc, tool_name, metadata, registry_dir, gateway_port)[1])
+            time.sleep(0.25)
+        time.sleep(2.2)
+
+        gateway_url = f"http://127.0.0.1:{gateway_port}/mcp"
+        resp = _post_mcp(gateway_url, "tools/call", {"name": "list_dcc_instances", "arguments": {}})
+        instances = json.loads(resp["result"]["content"][0]["text"])["instances"]
+        by_task = {item["metadata"]["task"]: item for item in instances}
+
+        assert by_task["animation"]["metadata"]["context_bundle"] == "show-a.seq010.shot020.animation"
+        assert by_task["fx"]["metadata"]["production_domain"] == "film"
+        assert by_task["motion-2d"]["metadata"]["context_kind"] == "deliverable"
+        assert by_task["level-layout"]["metadata"]["toolset_profile"] == "game-level-layout"
+
+        suffixes = _tool_suffixes(gateway_url)
+        context_tools = {"summarize_blocking", "review_cache_manifest", "summarize_layers", "summarize_level_layout"}
+        assert not context_tools <= suffixes
+        assert "validate_material_export" not in suffixes
+
+        selected = by_task["fx"]
+        assert selected["dcc_type"] == "houdini"
+        assert selected["metadata"]["package_provenance"] == "film_fx_cache_review-1.0.0"
+        selected_tools = _tool_names(selected["mcp_url"])
+        assert "review_cache_manifest" in selected_tools
+        assert "summarize_blocking" not in selected_tools
+        assert "summarize_layers" not in selected_tools
+    finally:
+        for handle in reversed(handles):
+            with contextlib.suppress(Exception):
+                handle.shutdown()
+
+
+def test_rez_example_skills_are_searchable_by_context_metadata() -> None:
+    examples = Path(__file__).resolve().parents[1] / "examples" / "rez-skills"
+    skill_roots = [str(path / "skills") for path in examples.iterdir() if (path / "skills").exists()]
+
+    skills, skipped = scan_and_load_lenient(extra_paths=skill_roots)
+    names = {skill.name for skill in skills}
+
+    assert skipped == []
+    assert "film-animation-blocking" in names
+    assert "film-fx-cache-review" in names
+    assert "commercial-2d-layers" in names
+    assert "game-level-layout" in names
+
+    by_profile = {skill.metadata["dcc-mcp.toolset-profile"]: skill.name for skill in skills}
+    assert by_profile["film-shot-animation"] == "film-animation-blocking"
+    assert by_profile["film-shot-fx"] == "film-fx-cache-review"
+
+
+@pytest.mark.parametrize("case", REZ_CONTEXT_CASES, ids=[case["package"] for case in REZ_CONTEXT_CASES])
+def test_rez_env_composes_loads_executes_and_unloads_single_context(tmp_path: Path, case: dict) -> None:
+    rez_env = shutil.which("rez-env")
+    if rez_env is None:
+        local_rez_env = Path(sys.executable).with_name("rez-env.exe")
+        if local_rez_env.exists():
+            rez_env = str(local_rez_env)
+    if rez_env is None:
+        pytest.skip("rez-env is not installed")
+
+    repo_root = Path(__file__).resolve().parents[1]
+    examples = repo_root / "examples" / "rez-skills"
+    stubs = tmp_path / "rez-stubs"
+    _write_rez_stub_packages(stubs)
+    verifier = tmp_path / "verify_rez_context.py"
+    _write_rez_verifier(verifier)
+
+    env = os.environ.copy()
+    existing_packages = env.get("REZ_PACKAGES_PATH", "")
+    env["REZ_PACKAGES_PATH"] = os.pathsep.join(item for item in [str(examples), str(stubs), existing_packages] if item)
+    env["DCC_MCP_E2E_EXPECTED"] = json.dumps(case)
+    python_path = str(repo_root / "python")
+    if env.get("PYTHONPATH"):
+        python_path = os.pathsep.join([python_path, env["PYTHONPATH"]])
+    env["PYTHONPATH"] = python_path
+
+    completed = subprocess.run(
+        [rez_env, case["package"], "--", sys.executable, str(verifier)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    result = json.loads(completed.stdout.strip().splitlines()[-1])
+
+    assert result["package"] == case["package"]
+    assert result["discovered"] == 1
+    assert result["actions_after_load"] == 1
+    assert result["actions_after_unload"] == 0
+    assert result["summary"] == case["summary"]


### PR DESCRIPTION
## Summary
- Adds Rez/context-bundle guides plus README/index entry points for project/task/asset-scoped skill loading.
- Adds copyable context bundle manifests and focused Rez sample skill packages for 2D, 3D, animation, FX, game level, and material-authoring contexts.
- Records resolved context metadata on gateway instances and adds Rez-backed E2E coverage for scoped discovery, load/execute/unload counts, and non-explosive gateway tool surfaces.

## Test plan
- vx cargo fmt --all --check
- vx ruff check python/dcc_mcp_core/server_base.py tests/test_context_bundle_rez_fixture.py examples/rez-skills
- vx maturin develop --features python-bindings,ext-module,workflow,scheduler,prometheus,job-persist-sqlite
- .venv\Scripts\python.exe -m pytest tests/test_context_bundle_rez_fixture.py -q
- pre-commit hooks during git commit --trailer "Made-with: Cursor": ruff, ruff format, cargo fmt, cargo clippy

Closes #621.
Closes #622.
Closes #623.
Closes #624.
Closes #625.