### PR TITLE
feat: add embedded dispatcher bootstrap

### DIFF
--- a/docs/api/factory.md
+++ b/docs/api/factory.md
@@ -2,14 +2,16 @@
 
 Singleton factory helpers for DCC MCP server instances. Eliminates the boilerplate threading lock + `None` check that every adapter would otherwise duplicate.
 
-**Exported symbols:** `create_dcc_server`, `get_server_instance`, `make_start_stop`
+**Exported symbols:** `create_dcc_server`, `start_embedded_dcc_server`,
+`get_server_instance`, `make_start_stop`
 
 ## create_dcc_server
 
 ```python
 create_dcc_server(
     *, instance_holder: list, lock: threading.Lock, server_class: type,
-    port: int = 8765, register_builtins: bool = True,
+    port: int = 8765, dispatcher=None, dispatcher_factory=None,
+    register_builtins: bool = True,
     extra_skill_paths: list[str] | None = None,
     include_bundled: bool = True, enable_hot_reload: bool = False,
     hot_reload_env_var: str | None = None, **server_kwargs
@@ -24,16 +26,66 @@ Create-or-return a singleton DCC MCP server and start it. Thread-safe.
 | `lock` | `threading.Lock` | (required) | Module-level lock for thread safety |
 | `server_class` | `type` | (required) | DccServerBase subclass to instantiate |
 | `port` | `int` | `8765` | TCP port for the MCP HTTP server |
+| `dispatcher` | `Any \| None` | `None` | Pre-created host dispatcher forwarded to the server constructor before skill discovery |
+| `dispatcher_factory` | `Callable[[], Any \| None] \| None` | `None` | Lazily creates a dispatcher only when a new singleton is constructed |
 | `register_builtins` | `bool` | `True` | Call `register_builtin_actions()` after creation |
 | `extra_skill_paths` | `list[str] \| None` | `None` | Additional skill directories |
 | `include_bundled` | `bool` | `True` | Include dcc-mcp-core bundled skills |
 | `enable_hot_reload` | `bool` | `False` | Enable skill hot-reload |
 | `hot_reload_env_var` | `str \| None` | `None` | Env var for hot-reload override |
 
+## start_embedded_dcc_server
+
+```python
+start_embedded_dcc_server(
+    *,
+    dcc_name: str,
+    instance_holder: list,
+    lock: threading.Lock,
+    server_class: type,
+    dispatcher_factory: Callable[[], Any | None] | None = None,
+    dispatcher: Any | None = None,
+    env_prefix: str | None = None,
+    ...
+) -> McpServerHandle
+```
+
+Adapter bootstrap helper that fixes the safe order for embedded hosts:
+
+1. Create or receive the host dispatcher.
+2. Construct the `DccServerBase` subclass with that dispatcher.
+3. Discover/load skills.
+4. Start the HTTP server and gateway registration.
+
+Use this when a DCC plugin has to build its dispatcher before any skill can be
+loaded:
+
+```python
+from dcc_mcp_core import start_embedded_dcc_server
+
+_holder = [None]
+_lock = threading.Lock()
+
+def start_server(port=8765):
+    return start_embedded_dcc_server(
+        dcc_name="blender",
+        instance_holder=_holder,
+        lock=_lock,
+        server_class=BlenderMcpServer,
+        dispatcher_factory=create_blender_dispatcher,
+        env_prefix="DCC_MCP_BLENDER",
+        port=port,
+    )
+```
+
 ## make_start_stop
 
 ```python
-make_start_stop(server_class: type, hot_reload_env_var: str | None = None) -> tuple[Callable, Callable]
+make_start_stop(
+    server_class: type,
+    hot_reload_env_var: str | None = None,
+    dispatcher_factory: Callable[[], Any | None] | None = None,
+) -> tuple[Callable, Callable]
 ```
 
 Generate a `(start_server, stop_server)` function pair for a DCC adapter. Zero-boilerplate.
@@ -44,6 +96,7 @@ from dcc_mcp_core import make_start_stop
 start_server, stop_server = make_start_stop(
     MyDccServer,
     hot_reload_env_var="DCC_MCP_MYDCC_HOT_RELOAD",
+    dispatcher_factory=create_my_dcc_dispatcher,
 )
 ```
 
@@ -71,21 +124,15 @@ two pieces of glue beyond the bare server:
 `register_builtin_actions(minimal_mode=...)` for exactly this:
 
 ```python
-from dcc_mcp_core import (
-    DccServerBase, McpHttpConfig,
-    InProcessCallableDispatcher, build_inprocess_executor,
-    MinimalModeConfig,
-)
+from dcc_mcp_core import DccServerBase, InProcessCallableDispatcher, MinimalModeConfig
 
 class MayaDccServer(DccServerBase):
     @classmethod
     def dcc_name(cls) -> str: return "maya"
 
-server = MayaDccServer(McpHttpConfig(port=8765))
-
-# 1) Wire the in-process executor BEFORE registering builtins.
+# 1) Pass the dispatcher into the constructor BEFORE registering builtins.
 dispatcher = InProcessCallableDispatcher()    # or your Maya UI-thread subclass
-server.register_inprocess_executor(build_inprocess_executor(dispatcher))
+server = MayaDccServer(port=8765, dispatcher=dispatcher)
 
 # 2) Pin the boot-time skill set declaratively.
 server.register_builtin_actions(minimal_mode=MinimalModeConfig(

--- a/docs/guide/dcc-thread-safety.md
+++ b/docs/guide/dcc-thread-safety.md
@@ -183,6 +183,29 @@ architectural rationale.
 
 [chunked]: https://github.com/loonghao/dcc-mcp-core/issues/332
 
+## Dispatcher-first server construction
+
+Embedded adapters should create their host dispatcher before skill discovery and
+pass it into `DccServerBase`:
+
+```python
+dispatcher = create_blender_dispatcher()
+server = BlenderMcpServer(port=8765, dispatcher=dispatcher)
+server.register_builtin_actions()
+handle = server.start()
+```
+
+`DccServerBase` installs the in-process executor immediately after the inner
+`McpHttpServer` is created, so any later `register_builtin_actions()` or
+`load_skill()` call wires scripts through the dispatcher. This avoids the late
+attachment race where a main-thread skill is discovered before the adapter has
+registered its UI-thread bridge.
+
+For plugin entry points, prefer `start_embedded_dcc_server(...)` or
+`make_start_stop(..., dispatcher_factory=...)`; both create the dispatcher before
+constructing the server singleton and before skill loading. See
+[Server Factory API](../api/factory.md).
+
 ### Python usage
 
 ```python

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -385,6 +385,7 @@ from dcc_mcp_core.elicitation import elicit_url
 from dcc_mcp_core.factory import create_dcc_server
 from dcc_mcp_core.factory import get_server_instance
 from dcc_mcp_core.factory import make_start_stop
+from dcc_mcp_core.factory import start_embedded_dcc_server
 
 # Agent feedback + rationale utilities (issues #433, #434)
 from dcc_mcp_core.feedback import clear_feedback
@@ -775,6 +776,7 @@ __all__ = [
     "skill_success_with_table",
     "skill_warning",
     "stage_to_scene_info_json",
+    "start_embedded_dcc_server",
     "success_result",
     "units_to_mpu",
     "unwrap_parameters",

--- a/python/dcc_mcp_core/factory.py
+++ b/python/dcc_mcp_core/factory.py
@@ -66,6 +66,8 @@ def create_dcc_server(
     lock: threading.Lock,
     server_class: type[Any],
     port: int = 8765,
+    dispatcher: Any | None = None,
+    dispatcher_factory: Callable[[], Any | None] | None = None,
     register_builtins: bool = True,
     extra_skill_paths: list[str] | None = None,
     include_bundled: bool = True,
@@ -86,6 +88,13 @@ def create_dcc_server(
         server_class: The :class:`~dcc_mcp_core.server_base.DccServerBase`
             subclass to instantiate.
         port: TCP port for the MCP HTTP server.
+        dispatcher: Optional pre-created host dispatcher. When supplied and
+            ``server_kwargs`` does not already contain ``dispatcher``, it is
+            forwarded to ``server_class`` before skill discovery.
+        dispatcher_factory: Optional zero-argument factory called while creating
+            a new server instance. Use this when the dispatcher should be
+            constructed immediately before the server and not on repeated
+            ``start_server()`` calls that return an existing singleton.
         register_builtins: If ``True``, call ``register_builtin_actions()``
             after creating the server.
         extra_skill_paths: Additional skill directories.
@@ -117,6 +126,12 @@ def create_dcc_server(
     with lock:
         instance: Any | None = instance_holder[0]
         if instance is None or not instance.is_running:
+            effective_dispatcher = dispatcher
+            if effective_dispatcher is None and dispatcher_factory is not None:
+                effective_dispatcher = dispatcher_factory()
+            if effective_dispatcher is not None and "dispatcher" not in server_kwargs:
+                server_kwargs["dispatcher"] = effective_dispatcher
+
             instance = server_class(port=port, **server_kwargs)
 
             if register_builtins:
@@ -144,9 +159,61 @@ def create_dcc_server(
         return instance_holder[0].start()
 
 
+def start_embedded_dcc_server(
+    *,
+    dcc_name: str,
+    instance_holder: list[Any | None],
+    lock: threading.Lock,
+    server_class: type[Any],
+    port: int = 8765,
+    dispatcher_factory: Callable[[], Any | None] | None = None,
+    dispatcher: Any | None = None,
+    env_prefix: str | None = None,
+    register_builtins: bool = True,
+    extra_skill_paths: list[str] | None = None,
+    include_bundled: bool = True,
+    enable_hot_reload: bool = False,
+    hot_reload_env_var: str | None = None,
+    **server_kwargs: Any,
+) -> Any:
+    """Start an embedded DCC server with the safe dispatcher-first ordering.
+
+    This is a small adapter bootstrap for hosts such as Blender, Photoshop,
+    Houdini, Unreal, and Maya. It standardizes the lifecycle that adapters used
+    to open-code:
+
+    1. Create or receive the host dispatcher.
+    2. Construct the ``DccServerBase`` subclass with that dispatcher.
+    3. Discover/load skills.
+    4. Start the HTTP server and optional gateway registration.
+
+    Args mirror :func:`create_dcc_server`. ``env_prefix`` can be used to infer
+    a hot-reload variable such as ``DCC_MCP_BLENDER_HOT_RELOAD``.
+    """
+    inferred_hot_reload = hot_reload_env_var
+    if inferred_hot_reload is None and env_prefix:
+        inferred_hot_reload = f"{env_prefix.rstrip('_')}_HOT_RELOAD"
+
+    return create_dcc_server(
+        instance_holder=instance_holder,
+        lock=lock,
+        server_class=server_class,
+        port=port,
+        dispatcher=dispatcher,
+        dispatcher_factory=dispatcher_factory,
+        register_builtins=register_builtins,
+        extra_skill_paths=extra_skill_paths,
+        include_bundled=include_bundled,
+        enable_hot_reload=enable_hot_reload,
+        hot_reload_env_var=inferred_hot_reload,
+        **server_kwargs,
+    )
+
+
 def make_start_stop(
     server_class: type[Any],
     hot_reload_env_var: str | None = None,
+    dispatcher_factory: Callable[[], Any | None] | None = None,
 ) -> tuple[Callable[..., Any], Callable[[], None]]:
     """Generate a ``(start_server, stop_server)`` function pair for a DCC adapter.
 
@@ -157,6 +224,8 @@ def make_start_stop(
         server_class: The :class:`~dcc_mcp_core.server_base.DccServerBase` subclass.
         hot_reload_env_var: Env var to check for hot-reload (e.g.
             ``"DCC_MCP_BLENDER_HOT_RELOAD"``).
+        dispatcher_factory: Optional factory used to create the host dispatcher
+            before constructing the server singleton.
 
     Returns:
         Tuple of ``(start_server_fn, stop_server_fn)``.
@@ -185,6 +254,7 @@ def make_start_stop(
             lock=_lock,
             server_class=server_class,
             port=port,
+            dispatcher_factory=dispatcher_factory,
             register_builtins=register_builtins,
             extra_skill_paths=extra_skill_paths,
             include_bundled=include_bundled,

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -117,6 +117,11 @@ class DccServerBase:
             ``job-persist-sqlite`` wheel feature; silently skipped when the
             feature is absent.  Set ``DCC_MCP_DISABLE_JOB_PERSISTENCE=1`` to
             override.  Default ``True``.
+        dispatcher: Optional host callable dispatcher installed immediately
+            after the inner ``McpHttpServer`` is created and before any
+            subsequent ``register_builtin_actions()`` / skill loading call.
+            Embedded adapters should pass their UI/main-thread dispatcher here
+            instead of attaching it after startup.
         enable_telemetry: Initialise in-process metrics collection via
             ``TelemetryConfig`` so that ``diagnostics__tool_metrics`` returns
             real latency and success-rate data.  Set
@@ -140,6 +145,7 @@ class DccServerBase:
         dcc_pid: int | None = None,
         dcc_window_title: str | None = None,
         dcc_window_handle: int | None = None,
+        dispatcher: BaseDccCallableDispatcher | None = None,
         enable_file_logging: bool = True,
         enable_job_persistence: bool = True,
         enable_telemetry: bool = True,
@@ -171,6 +177,8 @@ class DccServerBase:
         self._dcc_pid: int = dcc_pid if dcc_pid is not None else os.getpid()
         self._dcc_window_title: str | None = dcc_window_title
         self._dcc_window_handle: int | None = dcc_window_handle
+        self._dcc_dispatcher: BaseDccCallableDispatcher | None = dispatcher
+        self._inprocess_executor_registered: bool = False
         self._cached_hwnd: int | None = None
 
         # Resolve gateway port
@@ -216,6 +224,8 @@ class DccServerBase:
 
         # Create the inner skill manager (registry + dispatcher + catalog)
         self._server: Any = create_skill_server(dcc_name, self._config)
+        if dispatcher is not None:
+            self.register_inprocess_executor(dispatcher)
 
         # Composed collaborators (#486) — constructed eagerly here, but the
         # `_skill_client` / `_window_resolver` properties below also fall
@@ -411,6 +421,9 @@ class DccServerBase:
                 leaving every skill as a stub.
 
         """
+        if self._dcc_dispatcher is not None and not self._inprocess_executor_registered:
+            self.register_inprocess_executor(self._dcc_dispatcher)
+
         skill_paths = self.collect_skill_search_paths(
             extra_paths=extra_skill_paths,
             include_bundled=include_bundled,
@@ -491,9 +504,11 @@ class DccServerBase:
                 inline on the calling thread.
 
         """
+        self._dcc_dispatcher = dispatcher
         executor = build_inprocess_executor(dispatcher)
         try:
             self._server.set_in_process_executor(executor)
+            self._inprocess_executor_registered = True
             logger.info(
                 "[%s] In-process executor registered (dispatcher=%s)",
                 self._dcc_name,

--- a/tests/test_embedded_bootstrap.py
+++ b/tests/test_embedded_bootstrap.py
@@ -1,0 +1,100 @@
+"""Tests for embedded DCC adapter bootstrap helpers."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+from typing import ClassVar
+
+import dcc_mcp_core
+from dcc_mcp_core.factory import create_dcc_server
+from dcc_mcp_core.factory import make_start_stop
+from dcc_mcp_core.factory import start_embedded_dcc_server
+
+
+class _FakeServer:
+    events: ClassVar[list[str]] = []
+
+    def __init__(self, port: int = 8765, **kwargs: Any) -> None:
+        self.port = port
+        self.kwargs = kwargs
+        self.is_running = False
+        self.events.append("construct")
+        if kwargs.get("dispatcher") is not None:
+            self.events.append("dispatcher")
+
+    def register_builtin_actions(self, **_kwargs: Any) -> None:
+        self.events.append("register_builtin_actions")
+
+    def start(self) -> str:
+        self.is_running = True
+        self.events.append("start")
+        return "handle"
+
+    def stop(self) -> None:
+        self.is_running = False
+        self.events.append("stop")
+
+
+def test_start_embedded_dcc_server_creates_dispatcher_before_skill_registration() -> None:
+    _FakeServer.events = []
+    holder: list[Any | None] = [None]
+    lock = threading.Lock()
+    dispatcher = object()
+
+    handle = start_embedded_dcc_server(
+        dcc_name="blender",
+        instance_holder=holder,
+        lock=lock,
+        server_class=_FakeServer,
+        dispatcher_factory=lambda: dispatcher,
+        register_builtins=True,
+    )
+
+    assert handle == "handle"
+    assert holder[0].kwargs["dispatcher"] is dispatcher
+    assert _FakeServer.events == ["construct", "dispatcher", "register_builtin_actions", "start"]
+
+
+def test_create_dcc_server_does_not_recreate_dispatcher_for_running_singleton() -> None:
+    _FakeServer.events = []
+    holder: list[Any | None] = [None]
+    lock = threading.Lock()
+    calls = 0
+
+    def _factory() -> object:
+        nonlocal calls
+        calls += 1
+        return object()
+
+    create_dcc_server(
+        instance_holder=holder,
+        lock=lock,
+        server_class=_FakeServer,
+        dispatcher_factory=_factory,
+    )
+    create_dcc_server(
+        instance_holder=holder,
+        lock=lock,
+        server_class=_FakeServer,
+        dispatcher_factory=_factory,
+    )
+
+    assert calls == 1
+    assert _FakeServer.events == ["construct", "dispatcher", "register_builtin_actions", "start", "start"]
+
+
+def test_make_start_stop_accepts_dispatcher_factory() -> None:
+    _FakeServer.events = []
+    dispatcher = object()
+    start_server, stop_server = make_start_stop(_FakeServer, dispatcher_factory=lambda: dispatcher)
+
+    assert start_server() == "handle"
+    assert _FakeServer.events[:4] == ["construct", "dispatcher", "register_builtin_actions", "start"]
+    stop_server()
+    assert _FakeServer.events[-1] == "stop"
+
+
+def test_start_embedded_dcc_server_exported_from_top_level() -> None:
+    assert dcc_mcp_core.start_embedded_dcc_server is start_embedded_dcc_server
+    assert "start_embedded_dcc_server" in dcc_mcp_core.__all__

--- a/tests/test_inprocess_executor.py
+++ b/tests/test_inprocess_executor.py
@@ -274,3 +274,42 @@ def test_register_inprocess_executor_with_dispatcher_routes(tmp_path: Path) -> N
     p = _write_script(tmp_path, "def main(x): return x * 3\n")
     assert captured[0](str(p), {"x": 7}) == 21
     assert dispatcher.count == 1
+
+
+def test_dcc_server_base_constructor_registers_dispatcher_before_discovery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Import local modules
+    from dcc_mcp_core.server_base import DccServerBase
+
+    events: list[str] = []
+
+    class _Server:
+        def set_in_process_executor(self, executor: Callable[..., Any]) -> None:
+            events.append("set_in_process_executor")
+            self.executor = executor
+
+        def discover(self, extra_paths: list[str]) -> int:
+            events.append("discover")
+            return len(extra_paths)
+
+    fake_server = _Server()
+    monkeypatch.setattr(dcc_mcp_core, "create_skill_server", lambda *_args, **_kwargs: fake_server)
+
+    class _Dispatcher:
+        def dispatch_callable(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+            return func(*args, **kwargs)
+
+    base = DccServerBase(
+        "test_inproc_ctor",
+        tmp_path,
+        port=0,
+        dispatcher=_Dispatcher(),
+        enable_file_logging=False,
+        enable_job_persistence=False,
+        enable_telemetry=False,
+    )
+    base.register_builtin_actions(include_bundled=False)
+
+    assert events == ["set_in_process_executor", "discover"]


### PR DESCRIPTION
## Summary
- Let `DccServerBase` accept a host dispatcher at construction time and install the in-process executor before skill discovery/loading.
- Add dispatcher-aware factory/bootstrap helpers for embedded DCC adapters and export `start_embedded_dcc_server`.
- Document dispatcher-first startup and add regression tests for ordering and singleton dispatcher factory behavior.

Closes #597.
Closes #600.

## Test plan
- `vx ruff check python/dcc_mcp_core/__init__.py python/dcc_mcp_core/server_base.py python/dcc_mcp_core/factory.py tests/test_inprocess_executor.py tests/test_embedded_bootstrap.py`
- `vx ruff format --check python/dcc_mcp_core/server_base.py python/dcc_mcp_core/factory.py tests/test_inprocess_executor.py tests/test_embedded_bootstrap.py`
- `vx cargo fmt --all --check`
- `python -m venv .venv; .venv\Scripts\python.exe -m pip install maturin pytest -q; vx maturin develop --features python-bindings,ext-module,workflow,scheduler,prometheus,job-persist-sqlite`
- `.venv\Scripts\python.exe -m pytest tests/test_inprocess_executor.py tests/test_embedded_bootstrap.py -q`