### PR TITLE
feat: pass in-process execution metadata

### DIFF
--- a/crates/dcc-mcp-http/src/python/skill_server.rs
+++ b/crates/dcc-mcp-http/src/python/skill_server.rs
@@ -156,12 +156,19 @@ impl PyMcpHttpServer {
     /// the in-process path from the start, eliminating the timing race that
     /// occurred when handlers were overridden one-by-one after loading.
     ///
-    /// The callable receives two positional arguments:
+    /// The callable receives two positional arguments plus execution metadata:
     ///
     /// - ``script_path`` (``str``) — absolute path to the skill's ``.py`` file.
     /// - ``params`` (``dict``) — tool input parameters.
     ///
+    /// - ``action_name`` (kw-only ``str``) — registered MCP tool name.
+    /// - ``skill_name`` (kw-only ``str | None``) — owning skill name.
+    /// - ``thread_affinity`` (kw-only ``"main" | "any"``).
+    /// - ``execution`` (kw-only ``"sync" | "async"``).
+    /// - ``timeout_hint_secs`` (kw-only ``int | None``).
+    ///
     /// It must return a JSON-serialisable value (``dict``, ``list``, scalar…).
+    /// Legacy two-argument callables remain supported.
     ///
     /// When called, ``load_skill()`` will register **in-process** handlers for
     /// every tool in the loaded skill instead of spawning subprocesses.
@@ -189,15 +196,49 @@ impl PyMcpHttpServer {
         }
         let executor_ref = executor.clone_ref(py);
         self.catalog
-            .set_in_process_executor(move |script_path, params| {
+            .set_in_process_executor(move |script_path, params, context| {
                 Python::attach(|gil| {
+                    use dcc_mcp_models::ExecutionMode;
                     use dcc_mcp_pybridge::py_json::{json_value_to_bound_py, py_any_to_json_value};
+                    use pyo3::types::PyDict;
 
                     let py_params = json_value_to_bound_py(gil, &params)
                         .map_err(|e| format!("failed to convert params: {e}"))?;
-                    let raw = executor_ref
-                        .call1(gil, (script_path, py_params))
-                        .map_err(|e| format!("executor error: {e}"))?;
+                    let kwargs = PyDict::new(gil);
+                    kwargs
+                        .set_item("action_name", &context.action_name)
+                        .map_err(|e| format!("executor kwargs: {e}"))?;
+                    kwargs
+                        .set_item("skill_name", context.skill_name.as_deref())
+                        .map_err(|e| format!("executor kwargs: {e}"))?;
+                    kwargs
+                        .set_item("thread_affinity", context.thread_affinity.as_str())
+                        .map_err(|e| format!("executor kwargs: {e}"))?;
+                    kwargs
+                        .set_item(
+                            "execution",
+                            match context.execution {
+                                ExecutionMode::Sync => "sync",
+                                ExecutionMode::Async => "async",
+                            },
+                        )
+                        .map_err(|e| format!("executor kwargs: {e}"))?;
+                    kwargs
+                        .set_item("timeout_hint_secs", context.timeout_hint_secs)
+                        .map_err(|e| format!("executor kwargs: {e}"))?;
+                    let args = (script_path.as_str(), py_params);
+                    let raw = match executor_ref.call(gil, args, Some(&kwargs)) {
+                        Ok(value) => value,
+                        Err(err) if err.is_instance_of::<pyo3::exceptions::PyTypeError>(gil) => {
+                            drop(err);
+                            let py_params = json_value_to_bound_py(gil, &params)
+                                .map_err(|e| format!("failed to convert params: {e}"))?;
+                            executor_ref
+                                .call1(gil, (script_path, py_params))
+                                .map_err(|e| format!("executor error: {e}"))?
+                        }
+                        Err(err) => return Err(format!("executor error: {err}")),
+                    };
                     py_any_to_json_value(raw.bind(gil)).map_err(|e| e.to_string())
                 })
             });

--- a/crates/dcc-mcp-skills/src/catalog/catalog_discovery.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog_discovery.rs
@@ -37,7 +37,11 @@ impl SkillCatalog {
     /// Register an **in-process** script executor (builder-style).
     pub fn with_in_process_executor<F>(self, executor: F) -> Self
     where
-        F: Fn(String, serde_json::Value) -> Result<serde_json::Value, String>
+        F: Fn(
+                String,
+                serde_json::Value,
+                crate::catalog::execute::ScriptExecutionContext,
+            ) -> Result<serde_json::Value, String>
             + Send
             + Sync
             + 'static,
@@ -53,7 +57,11 @@ impl SkillCatalog {
     /// adapters can call it between construction and the first `load_skill()`.
     pub fn set_in_process_executor<F>(&self, executor: F)
     where
-        F: Fn(String, serde_json::Value) -> Result<serde_json::Value, String>
+        F: Fn(
+                String,
+                serde_json::Value,
+                crate::catalog::execute::ScriptExecutionContext,
+            ) -> Result<serde_json::Value, String>
             + Send
             + Sync
             + 'static,

--- a/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
@@ -87,8 +87,15 @@ impl SkillCatalog {
                 let action_name_clone = action_name.clone();
                 let dcc_owned = metadata.dcc.clone();
                 if let Some(executor) = maybe_executor {
+                    let context = execute::ScriptExecutionContext {
+                        action_name: action_name.clone(),
+                        skill_name: Some(skill_name.to_string()),
+                        thread_affinity: tool_decl.thread_affinity,
+                        execution: tool_decl.execution,
+                        timeout_hint_secs: tool_decl.timeout_hint_secs,
+                    };
                     dispatcher.register_handler(&action_name_clone, move |params| {
-                        executor(script_path_owned.clone(), params)
+                        executor(script_path_owned.clone(), params, context.clone())
                     });
                 } else {
                     dispatcher.register_handler(&action_name_clone, move |params| {
@@ -137,8 +144,15 @@ impl SkillCatalog {
                     let dcc_owned = metadata.dcc.clone();
                     let maybe_executor = self.script_executor.read().clone();
                     if let Some(executor) = maybe_executor {
+                        let context = execute::ScriptExecutionContext {
+                            action_name: action_name.clone(),
+                            skill_name: Some(skill_name.to_string()),
+                            thread_affinity: dcc_mcp_models::ThreadAffinity::Any,
+                            execution: dcc_mcp_models::ExecutionMode::Sync,
+                            timeout_hint_secs: None,
+                        };
                         dispatcher.register_handler(&action_name_clone, move |params| {
-                            executor(script_path_owned.clone(), params)
+                            executor(script_path_owned.clone(), params, context.clone())
                         });
                     } else {
                         dispatcher.register_handler(&action_name_clone, move |params| {

--- a/crates/dcc-mcp-skills/src/catalog/execute.rs
+++ b/crates/dcc-mcp-skills/src/catalog/execute.rs
@@ -23,7 +23,17 @@
 //! [`SkillCatalog::with_in_process_executor`]) it is used; otherwise the
 //! subprocess path is taken.
 
-use dcc_mcp_models::ToolDeclaration;
+use dcc_mcp_models::{ExecutionMode, ThreadAffinity, ToolDeclaration};
+
+/// Metadata passed to an in-process skill executor for a specific tool call.
+#[derive(Clone, Debug)]
+pub struct ScriptExecutionContext {
+    pub action_name: String,
+    pub skill_name: Option<String>,
+    pub thread_affinity: ThreadAffinity,
+    pub execution: ExecutionMode,
+    pub timeout_hint_secs: Option<u32>,
+}
 
 /// A pluggable script executor that runs a skill script inside the **current**
 /// process rather than spawning a child process.
@@ -36,10 +46,12 @@ use dcc_mcp_models::ToolDeclaration;
 /// The closure receives:
 /// - `script_path` — absolute path to the `.py` script to execute.
 /// - `params`      — the tool's input parameters as a `serde_json::Value`.
+/// - `context`     — action/execution metadata used by host dispatchers.
 ///
 /// It must return `Ok(Value)` on success or `Err(String)` on failure.
-pub type ScriptExecutorFn =
-    dyn Fn(String, serde_json::Value) -> Result<serde_json::Value, String> + Send + Sync;
+pub type ScriptExecutorFn = dyn Fn(String, serde_json::Value, ScriptExecutionContext) -> Result<serde_json::Value, String>
+    + Send
+    + Sync;
 
 /// Execute a skill script **in-process** using PyO3.
 ///

--- a/crates/dcc-mcp-skills/src/python/catalog.rs
+++ b/crates/dcc-mcp-skills/src/python/catalog.rs
@@ -69,7 +69,9 @@ impl SkillCatalog {
     ///
     /// The callable signature must be::
     ///
-    ///     def executor(script_path: str, params: dict) -> dict:
+    ///     def executor(script_path: str, params: dict, *, action_name: str,
+    ///                  skill_name: str | None, thread_affinity: str,
+    ///                  execution: str, timeout_hint_secs: int | None) -> dict:
     ///         ...
     ///
     /// Example (Maya adapter)::
@@ -92,22 +94,69 @@ impl SkillCatalog {
                 self.clear_in_process_executor();
             }
             Some(py_fn) => {
-                let executor_fn = move |script_path: String,
-                                        params: serde_json::Value|
-                      -> Result<serde_json::Value, String> {
-                    use dcc_mcp_pybridge::py_json::{json_value_to_pyobject, py_any_to_json_value};
-                    Python::try_attach(|py| {
-                        let py_params = json_value_to_pyobject(py, &params)
-                            .map_err(|e| format!("params → Python: {e}"))?;
-                        let result = py_fn
-                            .call1(py, (script_path, py_params))
-                            .map_err(|e| format!("in-process executor failed: {e}"))?;
-                        let bound = result.into_bound(py);
-                        py_any_to_json_value(&bound).map_err(|e| format!("result → JSON: {e}"))
-                    })
-                    .ok_or_else(|| "Python interpreter not attached".to_string())
-                    .and_then(|r| r)
-                };
+                let executor_fn =
+                    move |script_path: String,
+                          params: serde_json::Value,
+                          context: crate::catalog::execute::ScriptExecutionContext|
+                          -> Result<serde_json::Value, String> {
+                        use dcc_mcp_models::ExecutionMode;
+                        use dcc_mcp_pybridge::py_json::{
+                            json_value_to_pyobject, py_any_to_json_value,
+                        };
+                        use pyo3::types::PyDict;
+                        Python::try_attach(|py| {
+                            let py_params = json_value_to_pyobject(py, &params)
+                                .map_err(|e| format!("params → Python: {e}"))?;
+                            let kwargs = PyDict::new(py);
+                            kwargs
+                                .set_item("action_name", &context.action_name)
+                                .map_err(|e| format!("executor kwargs: {e}"))?;
+                            kwargs
+                                .set_item("skill_name", context.skill_name.as_deref())
+                                .map_err(|e| format!("executor kwargs: {e}"))?;
+                            kwargs
+                                .set_item("thread_affinity", context.thread_affinity.as_str())
+                                .map_err(|e| format!("executor kwargs: {e}"))?;
+                            kwargs
+                                .set_item(
+                                    "execution",
+                                    match context.execution {
+                                        ExecutionMode::Sync => "sync",
+                                        ExecutionMode::Async => "async",
+                                    },
+                                )
+                                .map_err(|e| format!("executor kwargs: {e}"))?;
+                            kwargs
+                                .set_item("timeout_hint_secs", context.timeout_hint_secs)
+                                .map_err(|e| format!("executor kwargs: {e}"))?;
+                            let args = (script_path.as_str(), py_params);
+                            let result = match py_fn.call(py, args, Some(&kwargs)) {
+                                Ok(value) => value,
+                                Err(err)
+                                    if err.is_instance_of::<pyo3::exceptions::PyTypeError>(py) =>
+                                {
+                                    drop(err);
+                                    py_fn
+                                        .call1(
+                                            py,
+                                            (
+                                                script_path,
+                                                json_value_to_pyobject(py, &params)
+                                                    .map_err(|e| format!("params → Python: {e}"))?,
+                                            ),
+                                        )
+                                        .map_err(|e| format!("in-process executor failed: {e}"))?
+                                }
+                                Err(err) => {
+                                    return Err(format!("in-process executor failed: {err}"));
+                                }
+                            };
+                            let bound = result.into_bound(py);
+                            py_any_to_json_value(&bound).map_err(|e| format!("result → JSON: {e}"))
+                        })
+                        .ok_or_else(|| "Python interpreter not attached".to_string())
+                        .and_then(|r| r)
+                    };
                 self.set_in_process_executor(executor_fn);
             }
         }

--- a/docs/api/dispatcher.md
+++ b/docs/api/dispatcher.md
@@ -9,10 +9,11 @@ the same pattern: receive an MCP `tools/call`, route the script to the host's
 event loop, return a JSON-serialisable result. This module lifts that pattern
 into reusable contracts so each adapter only supplies host-specific glue.
 
-**Exported symbols:** `BaseDccCallableDispatcher`, `BaseDccCallableDispatcherFull`,
-`BaseDccPump`, `InProcessCallableDispatcher`, `JobEntry`, `JobOutcome`,
-`PendingEnvelope`, `DrainStats`, `PumpStats`, `current_callable_job`,
-`MinimalModeConfig`, `build_inprocess_executor`, `run_skill_script`.
+**Exported symbols:** `BaseDccCallableDispatcher`, `InProcessExecutionContext`,
+`BaseDccCallableDispatcherFull`, `BaseDccPump`, `InProcessCallableDispatcher`,
+`JobEntry`, `JobOutcome`, `PendingEnvelope`, `DrainStats`, `PumpStats`,
+`current_callable_job`, `MinimalModeConfig`, `build_inprocess_executor`,
+`run_skill_script`.
 
 ## When to use what
 
@@ -44,6 +45,24 @@ assert isinstance(MyDispatcher(), BaseDccCallableDispatcher)
 The single `dispatch_callable(func, *args, **kwargs) -> Any` method is the **only**
 contractual surface — kept narrow so the simplest hosts can satisfy it with one
 line of glue. Use the *Full* variant below when you also need cancellation.
+
+When skill tools execute in-process, core passes execution metadata through the
+executor and into `dispatch_callable`:
+
+```python
+from dcc_mcp_core import InProcessExecutionContext
+
+def dispatch_callable(self, func, *args, **kwargs):
+    context: InProcessExecutionContext = kwargs["context"]
+    if context.thread_affinity == "main":
+        return run_on_ui_thread(lambda: func())
+    return func()
+```
+
+The keyword arguments include `affinity`, `context`, `action_name`,
+`skill_name`, `execution`, and `timeout_hint_secs`. Dispatchers may ignore the
+extra fields, but should use `affinity` / `context.thread_affinity` to avoid
+routing pure filesystem tools through the DCC UI thread.
 
 ## BaseDccCallableDispatcherFull (cancellable)
 
@@ -96,6 +115,17 @@ from dcc_mcp_core import InProcessCallableDispatcher, build_inprocess_executor
 dispatcher = InProcessCallableDispatcher()
 executor = build_inprocess_executor(dispatcher)
 # Pass `executor` to McpHttpServer.set_in_process_executor / DccServerBase.register_inprocess_executor.
+
+# Core calls the executor with metadata from ActionMeta/tools.yaml:
+executor(
+    "/path/to/script.py",
+    {"root": "/show/shot010"},
+    action_name="review__cache_manifest",
+    skill_name="review",
+    thread_affinity="any",
+    execution="sync",
+    timeout_hint_secs=None,
+)
 
 # Standalone fallback for mayapy / batch — runs scripts inline:
 inline_executor = build_inprocess_executor(None)

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -307,6 +307,7 @@ from dcc_mcp_core._server import BaseDccCallableDispatcher
 from dcc_mcp_core._server import BaseDccCallableDispatcherFull
 from dcc_mcp_core._server import BaseDccPump
 from dcc_mcp_core._server import InProcessCallableDispatcher
+from dcc_mcp_core._server import InProcessExecutionContext
 from dcc_mcp_core._server import JobEntry
 from dcc_mcp_core._server import JobOutcome
 from dcc_mcp_core._server import MinimalModeConfig
@@ -549,6 +550,7 @@ __all__ = [
     "GracefulIpcChannelAdapter",
     "GuiExecutableHint",
     "InProcessCallableDispatcher",
+    "InProcessExecutionContext",
     "InputValidator",
     "IntWrapper",
     "IpcChannelAdapter",

--- a/python/dcc_mcp_core/_server/__init__.py
+++ b/python/dcc_mcp_core/_server/__init__.py
@@ -17,6 +17,7 @@ from dcc_mcp_core._server.callable_dispatcher import PendingEnvelope
 from dcc_mcp_core._server.callable_dispatcher import PumpStats
 from dcc_mcp_core._server.callable_dispatcher import current_callable_job
 from dcc_mcp_core._server.inprocess_executor import BaseDccCallableDispatcher
+from dcc_mcp_core._server.inprocess_executor import InProcessExecutionContext
 from dcc_mcp_core._server.inprocess_executor import build_inprocess_executor
 from dcc_mcp_core._server.inprocess_executor import exception_to_error_envelope
 from dcc_mcp_core._server.inprocess_executor import run_skill_script
@@ -35,6 +36,7 @@ __all__ = [
     "DrainStats",
     "FileLoggingManager",
     "InProcessCallableDispatcher",
+    "InProcessExecutionContext",
     "JobEntry",
     "JobOutcome",
     "JobPersistenceManager",

--- a/python/dcc_mcp_core/_server/inprocess_executor.py
+++ b/python/dcc_mcp_core/_server/inprocess_executor.py
@@ -22,6 +22,7 @@ through.
 # Import built-in modules
 from __future__ import annotations
 
+from dataclasses import dataclass
 import importlib.util
 import logging
 from pathlib import Path
@@ -57,10 +58,39 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "BaseDccCallableDispatcher",
+    "InProcessExecutionContext",
     "build_inprocess_executor",
     "exception_to_error_envelope",
     "run_skill_script",
 ]
+
+
+@dataclass(frozen=True)
+class InProcessExecutionContext:
+    """Execution metadata for a single in-process skill-script call."""
+
+    action_name: str = ""
+    skill_name: str | None = None
+    thread_affinity: str = "any"
+    execution: str = "sync"
+    timeout_hint_secs: int | None = None
+
+
+def _context_from_kwargs(
+    *,
+    action_name: str = "",
+    skill_name: str | None = None,
+    thread_affinity: str = "any",
+    execution: str = "sync",
+    timeout_hint_secs: int | None = None,
+) -> InProcessExecutionContext:
+    return InProcessExecutionContext(
+        action_name=action_name,
+        skill_name=skill_name,
+        thread_affinity=thread_affinity or "any",
+        execution=execution or "sync",
+        timeout_hint_secs=timeout_hint_secs,
+    )
 
 
 def exception_to_error_envelope(exc: BaseException, *, message: str | None = None) -> dict[str, Any]:
@@ -163,7 +193,7 @@ def build_inprocess_executor(
     dispatcher: BaseDccCallableDispatcher | None,
     *,
     runner: Callable[[str, Mapping[str, Any]], Any] = run_skill_script,
-) -> Callable[[str, Mapping[str, Any]], Any]:
+) -> Callable[..., Any]:
     """Return an executor callable suitable for ``set_in_process_executor``.
 
     When *dispatcher* is ``None`` (e.g. ``mayapy``, Houdini batch,
@@ -183,14 +213,31 @@ def build_inprocess_executor(
             :func:`run_skill_script`). Mostly useful for tests.
 
     Returns:
-        A ``(script_path, params) -> Any`` callable that
-        :meth:`McpHttpServer.set_in_process_executor` accepts.
+        A callable accepting ``(script_path, params, *, action_name,
+        skill_name, thread_affinity, execution, timeout_hint_secs)``. Older
+        two-argument callers remain supported because all metadata is optional.
 
     """
     if dispatcher is None:
 
-        def _inline(script_path: str, params: Mapping[str, Any]) -> Any:
+        def _inline(
+            script_path: str,
+            params: Mapping[str, Any],
+            *,
+            action_name: str = "",
+            skill_name: str | None = None,
+            thread_affinity: str = "any",
+            execution: str = "sync",
+            timeout_hint_secs: int | None = None,
+        ) -> Any:
             try:
+                _context_from_kwargs(
+                    action_name=action_name,
+                    skill_name=skill_name,
+                    thread_affinity=thread_affinity,
+                    execution=execution,
+                    timeout_hint_secs=timeout_hint_secs,
+                )
                 return runner(script_path, params)
             except Exception as exc:
                 logger.exception("In-process skill %s failed", script_path)
@@ -198,9 +245,37 @@ def build_inprocess_executor(
 
         return _inline
 
-    def _routed(script_path: str, params: Mapping[str, Any]) -> Any:
+    def _routed(
+        script_path: str,
+        params: Mapping[str, Any],
+        *,
+        action_name: str = "",
+        skill_name: str | None = None,
+        thread_affinity: str = "any",
+        execution: str = "sync",
+        timeout_hint_secs: int | None = None,
+    ) -> Any:
+        context = _context_from_kwargs(
+            action_name=action_name,
+            skill_name=skill_name,
+            thread_affinity=thread_affinity,
+            execution=execution,
+            timeout_hint_secs=timeout_hint_secs,
+        )
+
+        def _invoke(*_args: Any, **_kwargs: Any) -> Any:
+            return runner(script_path, params)
+
         try:
-            return dispatcher.dispatch_callable(runner, script_path, params)
+            return dispatcher.dispatch_callable(
+                _invoke,
+                affinity=context.thread_affinity,
+                context=context,
+                action_name=context.action_name,
+                skill_name=context.skill_name,
+                execution=context.execution,
+                timeout_hint_secs=context.timeout_hint_secs,
+            )
         except Exception as exc:
             logger.exception("In-process skill %s failed via dispatcher", script_path)
             return exception_to_error_envelope(exc)

--- a/tests/test_inprocess_executor.py
+++ b/tests/test_inprocess_executor.py
@@ -14,6 +14,7 @@ import pytest
 # Import local modules
 import dcc_mcp_core
 from dcc_mcp_core._server.inprocess_executor import BaseDccCallableDispatcher
+from dcc_mcp_core._server.inprocess_executor import InProcessExecutionContext
 from dcc_mcp_core._server.inprocess_executor import build_inprocess_executor
 from dcc_mcp_core._server.inprocess_executor import exception_to_error_envelope
 from dcc_mcp_core._server.inprocess_executor import run_skill_script
@@ -24,16 +25,20 @@ from dcc_mcp_core._server.inprocess_executor import run_skill_script
 def test_base_dispatcher_exported_from_top_level() -> None:
     assert hasattr(dcc_mcp_core, "BaseDccCallableDispatcher")
     assert "BaseDccCallableDispatcher" in dcc_mcp_core.__all__
+    assert hasattr(dcc_mcp_core, "InProcessExecutionContext")
+    assert "InProcessExecutionContext" in dcc_mcp_core.__all__
 
 
 def test_helpers_exported_from_underscore_server() -> None:
     # Import local modules
     from dcc_mcp_core._server import BaseDccCallableDispatcher as B
+    from dcc_mcp_core._server import InProcessExecutionContext as IEC
     from dcc_mcp_core._server import build_inprocess_executor as BIE
     from dcc_mcp_core._server import run_skill_script as RSS
 
     assert B is BaseDccCallableDispatcher
     assert BIE is build_inprocess_executor
+    assert IEC is InProcessExecutionContext
     assert RSS is run_skill_script
 
 
@@ -131,9 +136,10 @@ def test_executor_routes_through_dispatcher(tmp_path: Path) -> None:
     assert executor(str(p), {"x": 41}) == 42
     assert len(spy.calls) == 1
     func, args, kwargs = spy.calls[0]
-    assert func is run_skill_script
-    assert args == (str(p), {"x": 41})
-    assert kwargs == {}
+    assert callable(func)
+    assert args == ()
+    assert kwargs["affinity"] == "any"
+    assert kwargs["context"] == InProcessExecutionContext()
 
 
 def test_executor_dispatcher_exception_becomes_error_envelope(tmp_path: Path) -> None:
@@ -205,6 +211,54 @@ def test_executor_uses_custom_runner() -> None:
     out = executor("/tmp/skill.py", {"k": "v"})
     assert seen == [("/tmp/skill.py", {"k": "v"})]
     assert out == "/tmp/skill.py|{'k': 'v'}"
+
+
+def test_executor_passes_execution_context_to_dispatcher() -> None:
+    seen: list[tuple[str, Mapping[str, Any]]] = []
+
+    def _fake_runner(script_path: str, params: Mapping[str, Any]) -> dict[str, Any]:
+        seen.append((script_path, params))
+        return {"ok": True}
+
+    class _DispatcherSpy:
+        def __init__(self) -> None:
+            self.kwargs: dict[str, Any] = {}
+
+        def dispatch_callable(
+            self,
+            func: Callable[..., Any],
+            *args: Any,
+            **kwargs: Any,
+        ) -> Any:
+            self.kwargs = kwargs
+            return func(*args, **kwargs)
+
+    spy = _DispatcherSpy()
+    executor = build_inprocess_executor(spy, runner=_fake_runner)
+    result = executor(
+        "/tmp/tool.py",
+        {"value": 1},
+        action_name="demo__tool",
+        skill_name="demo",
+        thread_affinity="main",
+        execution="async",
+        timeout_hint_secs=30,
+    )
+
+    assert result == {"ok": True}
+    assert seen == [("/tmp/tool.py", {"value": 1})]
+    assert spy.kwargs["affinity"] == "main"
+    assert spy.kwargs["action_name"] == "demo__tool"
+    assert spy.kwargs["skill_name"] == "demo"
+    assert spy.kwargs["execution"] == "async"
+    assert spy.kwargs["timeout_hint_secs"] == 30
+    assert spy.kwargs["context"] == InProcessExecutionContext(
+        action_name="demo__tool",
+        skill_name="demo",
+        thread_affinity="main",
+        execution="async",
+        timeout_hint_secs=30,
+    )
 
 
 # ── DccServerBase.register_inprocess_executor integration ───────────────────

--- a/tests/test_skill_execute_real.py
+++ b/tests/test_skill_execute_real.py
@@ -27,13 +27,9 @@ import textwrap
 from typing import Any
 from typing import Callable
 
-# Import third-party modules
-import pytest
-
 # Import local modules
 import dcc_mcp_core
 from dcc_mcp_core._server.inprocess_executor import build_inprocess_executor
-from dcc_mcp_core._server.inprocess_executor import run_skill_script
 
 # ── helpers ────────────────────────────────────────────────────────────────
 
@@ -135,9 +131,9 @@ class TestInProcessSkillProcessesFile:
         # Dispatcher must have been routed through (UI-thread contract).
         assert len(dispatcher.calls) == 1
         func, args, kwargs = dispatcher.calls[0]
-        assert func is run_skill_script
-        assert args[0] == str(script)
-        assert kwargs == {}
+        assert callable(func)
+        assert args == ()
+        assert kwargs["affinity"] == "any"
 
     def test_executor_runs_script_that_writes_json_manifest(self, tmp_path: Path) -> None:
         """A common DCC skill pattern: scan a directory, emit a JSON manifest."""
@@ -262,11 +258,13 @@ class TestSkillScriptErrorPropagation:
         )
 
         executor = build_inprocess_executor(None)
-        with pytest.raises(RuntimeError, match="skill failed: invalid input"):
-            executor(
-                str(skill_dir / "scripts" / "boom.py"),
-                {"reason": "invalid input"},
-            )
+        result = executor(
+            str(skill_dir / "scripts" / "boom.py"),
+            {"reason": "invalid input"},
+        )
+        assert result["success"] is False
+        assert result["error"]["type"] == "RuntimeError"
+        assert result["error"]["message"] == "skill failed: invalid input"
 
     def test_dispatcher_errors_are_visible_to_caller(self, tmp_path: Path) -> None:
         """If the host dispatcher's UI thread fails (e.g. Maya viewport closed),
@@ -290,8 +288,10 @@ class TestSkillScriptErrorPropagation:
                 raise RuntimeError("UI thread shutting down")
 
         executor = build_inprocess_executor(_BoomDispatcher())
-        with pytest.raises(RuntimeError, match="UI thread shutting down"):
-            executor(str(skill_dir / "scripts" / "noop.py"), {})
+        result = executor(str(skill_dir / "scripts" / "noop.py"), {})
+        assert result["success"] is False
+        assert result["error"]["type"] == "RuntimeError"
+        assert result["error"]["message"] == "UI thread shutting down"
 
     def test_missing_main_callable_raises_attribute_error(self, tmp_path: Path) -> None:
         skill_dir = _write_skill(
@@ -302,8 +302,10 @@ class TestSkillScriptErrorPropagation:
             },
         )
         executor = build_inprocess_executor(None)
-        with pytest.raises(AttributeError, match="`main` callable"):
-            executor(str(skill_dir / "scripts" / "module_only.py"), {})
+        result = executor(str(skill_dir / "scripts" / "module_only.py"), {})
+        assert result["success"] is False
+        assert result["error"]["type"] == "AttributeError"
+        assert "`main` callable" in result["error"]["message"]
 
 
 # ── catalog ↔ executor wiring round-trip ───────────────────────────────────

--- a/tests/test_skills_e2e.py
+++ b/tests/test_skills_e2e.py
@@ -21,7 +21,9 @@ from pathlib import Path
 import subprocess
 import sys
 import tempfile
+import time
 from typing import Any
+import urllib.request
 
 # Import local modules
 from conftest import REPO_ROOT
@@ -545,3 +547,88 @@ class TestInProcessExecutor:
 
         # Skill was loaded — executor contract is verified structurally
         assert catalog.is_loaded("my-skill")
+
+    def test_in_process_executor_receives_tool_execution_metadata(self, tmp_path: Path) -> None:
+        """Loaded skill tools pass ActionMeta affinity/execution into Python executors."""
+        skill_dir = tmp_path / "affinity-skill"
+        (skill_dir / "scripts").mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: affinity-skill\n"
+            "description: Test affinity metadata\n"
+            "metadata:\n"
+            "  dcc-mcp.dcc: python\n"
+            "  dcc-mcp.tools: tools.yaml\n"
+            "---\n",
+            encoding="utf-8",
+        )
+        (skill_dir / "tools.yaml").write_text(
+            "tools:\n"
+            "  - name: host_scene\n"
+            "    description: Host scene tool\n"
+            "    source_file: scripts/host_scene.py\n"
+            "    thread_affinity: main\n"
+            "    execution: async\n"
+            "    timeout_hint_secs: 45\n"
+            "  - name: pure_file\n"
+            "    description: Pure filesystem tool\n"
+            "    source_file: scripts/pure_file.py\n"
+            "    thread_affinity: any\n",
+            encoding="utf-8",
+        )
+        (skill_dir / "scripts" / "host_scene.py").write_text(
+            "def main(**_): return {'success': True}\n", encoding="utf-8"
+        )
+        (skill_dir / "scripts" / "pure_file.py").write_text(
+            "def main(**_): return {'success': True}\n", encoding="utf-8"
+        )
+
+        seen: list[dict[str, Any]] = []
+
+        def capture_exec(script_path: str, params: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+            seen.append({"script": Path(script_path).name, "params": params, **kwargs})
+            return {"success": True, "message": kwargs["action_name"]}
+
+        server = dcc_mcp_core.create_skill_server("python", dcc_mcp_core.McpHttpConfig(port=0))
+        server.set_in_process_executor(capture_exec)
+        server.discover(extra_paths=[str(tmp_path)])
+        loaded = server.load_skill("affinity-skill")
+        assert loaded == ["affinity_skill__host_scene", "affinity_skill__pure_file"]
+
+        handle = server.start()
+        time.sleep(0.25)
+        try:
+            url = handle.mcp_url()
+
+            def _call(name: str) -> None:
+                body = json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": name,
+                        "method": "tools/call",
+                        "params": {"name": name, "arguments": {"value": 1}},
+                    }
+                ).encode()
+                req = urllib.request.Request(
+                    url,
+                    data=body,
+                    headers={"Content-Type": "application/json", "Accept": "application/json"},
+                    method="POST",
+                )
+                with urllib.request.urlopen(req, timeout=10) as resp:
+                    result = json.loads(resp.read())
+                assert result["result"]["isError"] is False
+
+            _call("affinity_skill__host_scene")
+            _call("affinity_skill__pure_file")
+        finally:
+            handle.shutdown()
+
+        by_tool = {entry["action_name"]: entry for entry in seen}
+        assert by_tool["affinity_skill__host_scene"]["thread_affinity"] == "main"
+        assert by_tool["affinity_skill__host_scene"]["execution"] == "async"
+        assert by_tool["affinity_skill__host_scene"]["timeout_hint_secs"] == 45
+        assert by_tool["affinity_skill__host_scene"]["skill_name"] == "affinity-skill"
+        assert by_tool["affinity_skill__pure_file"]["thread_affinity"] == "any"
+        assert by_tool["affinity_skill__pure_file"]["execution"] == "sync"
+        assert by_tool["affinity_skill__pure_file"]["timeout_hint_secs"] is None


### PR DESCRIPTION
## Summary
- Carry skill tool execution metadata (`action_name`, `skill_name`, `thread_affinity`, `execution`, `timeout_hint_secs`) into the in-process script executor context.
- Pass metadata through Python `SkillCatalog` / `McpHttpServer.set_in_process_executor` callables while preserving legacy two-argument executors.
- Expose `InProcessExecutionContext` and document how dispatchers use affinity to avoid routing all scripts through the host main thread.

Closes #598.

## Test plan
- `vx ruff check python/dcc_mcp_core/_server/inprocess_executor.py python/dcc_mcp_core/_server/__init__.py python/dcc_mcp_core/__init__.py tests/test_inprocess_executor.py tests/test_skill_execute_real.py tests/test_skills_e2e.py`
- `vx cargo check --features python-bindings,workflow,scheduler,prometheus,job-persist-sqlite`
- `vx maturin develop --features python-bindings,ext-module,workflow,scheduler,prometheus,job-persist-sqlite`
- `.venv\Scripts\python.exe -m pytest tests/test_inprocess_executor.py tests/test_skill_execute_real.py tests/test_skills_e2e.py -q`
- `vx ruff format --check python/dcc_mcp_core/_server/inprocess_executor.py python/dcc_mcp_core/_server/__init__.py python/dcc_mcp_core/__init__.py tests/test_inprocess_executor.py tests/test_skill_execute_real.py tests/test_skills_e2e.py`
- `vx cargo fmt --all --check`