### PR TITLE
feat: add adaptive pump policy

### DIFF
--- a/docs/api/dispatcher.md
+++ b/docs/api/dispatcher.md
@@ -10,10 +10,10 @@ event loop, return a JSON-serialisable result. This module lifts that pattern
 into reusable contracts so each adapter only supplies host-specific glue.
 
 **Exported symbols:** `BaseDccCallableDispatcher`, `InProcessExecutionContext`,
-`BaseDccCallableDispatcherFull`, `BaseDccPump`, `InProcessCallableDispatcher`,
-`JobEntry`, `JobOutcome`, `PendingEnvelope`, `DrainStats`, `PumpStats`,
-`current_callable_job`, `MinimalModeConfig`, `build_inprocess_executor`,
-`run_skill_script`.
+`BaseDccCallableDispatcherFull`, `BaseDccPump`, `AdaptivePumpPolicy`,
+`AdaptivePumpStats`, `InProcessCallableDispatcher`, `JobEntry`, `JobOutcome`,
+`PendingEnvelope`, `DrainStats`, `PumpStats`, `current_callable_job`,
+`MinimalModeConfig`, `build_inprocess_executor`, `run_skill_script`.
 
 ## When to use what
 
@@ -22,6 +22,7 @@ into reusable contracts so each adapter only supplies host-specific glue.
 | Wire a single `dispatch_callable(func, *args, **kwargs)` shim | `BaseDccCallableDispatcher` (#521) |
 | Full submit / cancel / shutdown contract | `BaseDccCallableDispatcherFull` (#520) |
 | Cooperative idle-tick that drains a queue (Maya `scriptJob(event=['idle', …])`) | `BaseDccPump` (#520) |
+| Shared active/idle timer backoff for host pump callbacks | `AdaptivePumpPolicy` (#606) |
 | Reference single-thread implementation for `mayapy` / pytest / batch | `InProcessCallableDispatcher` |
 | Per-job cancellation handle reachable from skill scripts | `current_callable_job` ContextVar |
 | Declarative progressive skill loading at startup | `MinimalModeConfig` (#525) |
@@ -106,6 +107,41 @@ class MyPump:
 
 `DrainStats(drained, elapsed_ms, overrun)` reports a single tick;
 `PumpStats(ticks, drained, overrun_cycles)` is the cumulative counter.
+
+## AdaptivePumpPolicy
+
+`AdaptivePumpPolicy` gives embedded adapters the same active/idle timing rules
+while leaving the host-specific timer install in adapter code:
+
+```python
+from dcc_mcp_core import AdaptivePumpPolicy
+
+policy = AdaptivePumpPolicy(
+    active_interval_secs=0.05,
+    idle_interval_secs=1.0,
+    idle_delay_secs=5.0,
+    max_client_idle_secs=10.0,
+)
+
+def blender_timer_callback():
+    stats = dispatcher.drain_queue(budget_ms=8)
+    policy.record_tick(
+        drained=stats.drained,
+        elapsed_ms=stats.elapsed_ms,
+        overrun=stats.overrun,
+    )
+    return policy.next_interval(
+        has_pending=dispatcher.has_pending(),
+        deferred_pending=render_job_is_running(),
+    )
+```
+
+Use `mark_work_done(drained=N)` as shorthand when the adapter only knows that
+work completed. Use `mark_client_activity()` when a new MCP request or plugin
+event should keep the pump responsive for `max_client_idle_secs`.
+
+`policy.stats` exposes cumulative `ticks`, `drained_jobs`, `overrun_cycles`,
+`active_transitions`, `idle_transitions`, `mode`, and `last_interval_secs`.
 
 ## InProcessCallableDispatcher (reference)
 

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -303,6 +303,8 @@ except ImportError:  # pragma: no cover — feature off
 
 # Adapters (pure-Python, non-DccServerBase)
 # Cooperative cancellation (pure-Python, no _core dependency)
+from dcc_mcp_core._server import AdaptivePumpPolicy
+from dcc_mcp_core._server import AdaptivePumpStats
 from dcc_mcp_core._server import BaseDccCallableDispatcher
 from dcc_mcp_core._server import BaseDccCallableDispatcherFull
 from dcc_mcp_core._server import BaseDccPump
@@ -524,6 +526,8 @@ __all__ = [
     "TOOL_NAME_RE",
     "WEBVIEW_DEFAULT_CAPABILITIES",
     "AdapterInstructionSet",
+    "AdaptivePumpPolicy",
+    "AdaptivePumpStats",
     "ApiKeyConfig",
     "AuditEntry",
     "AuditLog",

--- a/python/dcc_mcp_core/_server/__init__.py
+++ b/python/dcc_mcp_core/_server/__init__.py
@@ -6,6 +6,8 @@ underscore-prefixed because they are an implementation detail; the public
 contract remains :class:`dcc_mcp_core.server_base.DccServerBase`.
 """
 
+from dcc_mcp_core._server.callable_dispatcher import AdaptivePumpPolicy
+from dcc_mcp_core._server.callable_dispatcher import AdaptivePumpStats
 from dcc_mcp_core._server.callable_dispatcher import Affinity
 from dcc_mcp_core._server.callable_dispatcher import BaseDccCallableDispatcherFull
 from dcc_mcp_core._server.callable_dispatcher import BaseDccPump
@@ -29,6 +31,8 @@ from dcc_mcp_core._server.skill_query import SkillQueryClient
 from dcc_mcp_core._server.window_resolver import WindowResolver
 
 __all__ = [
+    "AdaptivePumpPolicy",
+    "AdaptivePumpStats",
     "Affinity",
     "BaseDccCallableDispatcher",
     "BaseDccCallableDispatcherFull",

--- a/python/dcc_mcp_core/_server/callable_dispatcher.py
+++ b/python/dcc_mcp_core/_server/callable_dispatcher.py
@@ -71,6 +71,8 @@ else:  # pragma: no cover - py3.7 only
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "AdaptivePumpPolicy",
+    "AdaptivePumpStats",
     "Affinity",
     "BaseDccCallableDispatcherFull",
     "BaseDccPump",
@@ -123,6 +125,140 @@ class PumpStats:
     ticks: int = 0
     drained: int = 0
     overrun_cycles: int = 0
+
+
+@dataclass
+class AdaptivePumpStats:
+    """Cumulative counters for :class:`AdaptivePumpPolicy`."""
+
+    ticks: int = 0
+    drained_jobs: int = 0
+    overrun_cycles: int = 0
+    active_transitions: int = 0
+    idle_transitions: int = 0
+    mode: str = "active"
+    last_interval_secs: float = 0.0
+
+
+class AdaptivePumpPolicy:
+    """Reusable active/idle timing policy for embedded DCC pump callbacks.
+
+    Host adapters still own the actual timer primitive (Maya ``scriptJob``,
+    Blender ``bpy.app.timers``, Photoshop event-loop hook, etc.). This policy
+    only decides the next interval and records shared counters.
+    """
+
+    def __init__(
+        self,
+        active_interval_secs: float = 0.05,
+        idle_interval_secs: float = 1.0,
+        idle_delay_secs: float = 5.0,
+        max_client_idle_secs: float | None = 10.0,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if active_interval_secs <= 0:
+            raise ValueError("active_interval_secs must be > 0")
+        if idle_interval_secs <= 0:
+            raise ValueError("idle_interval_secs must be > 0")
+        if idle_delay_secs < 0:
+            raise ValueError("idle_delay_secs must be >= 0")
+        if max_client_idle_secs is not None and max_client_idle_secs < 0:
+            raise ValueError("max_client_idle_secs must be >= 0 or None")
+
+        self.active_interval_secs = active_interval_secs
+        self.idle_interval_secs = idle_interval_secs
+        self.idle_delay_secs = idle_delay_secs
+        self.max_client_idle_secs = max_client_idle_secs
+        self._clock = clock
+        now = clock()
+        self._last_work_at = now
+        self._last_client_activity_at = now
+        self._mode = "active"
+        self._stats = AdaptivePumpStats(mode=self._mode, last_interval_secs=active_interval_secs)
+
+    @property
+    def stats(self) -> AdaptivePumpStats:
+        """Return cumulative pump-policy counters."""
+        return self._stats
+
+    @property
+    def mode(self) -> str:
+        """Current policy mode: ``"active"`` or ``"idle"``."""
+        return self._mode
+
+    def mark_client_activity(self) -> None:
+        """Record that an MCP client or adapter submitted work recently."""
+        self._last_client_activity_at = self._clock()
+
+    def mark_work_done(
+        self,
+        drained: int = 1,
+        *,
+        elapsed_ms: float = 0.0,
+        overrun: bool = False,
+    ) -> None:
+        """Record completed pump work and keep the policy in active mode."""
+        self.record_tick(drained=drained, elapsed_ms=elapsed_ms, overrun=overrun)
+
+    def record_tick(
+        self,
+        drained: int = 0,
+        *,
+        elapsed_ms: float = 0.0,
+        overrun: bool = False,
+    ) -> None:
+        """Record one host pump tick.
+
+        Args:
+            drained: Number of jobs/callables drained by this tick.
+            elapsed_ms: Tick duration for adapter metrics. Currently retained
+                only through the overrun flag so adapters can compute their own
+                host-specific timings.
+            overrun: Whether the tick exceeded the adapter's budget.
+
+        """
+        if drained < 0:
+            raise ValueError("drained must be >= 0")
+        self._stats.ticks += 1
+        self._stats.drained_jobs += drained
+        if overrun:
+            self._stats.overrun_cycles += 1
+        if drained > 0:
+            self._last_work_at = self._clock()
+        _ = elapsed_ms
+
+    def next_interval(
+        self,
+        *,
+        has_pending: bool = False,
+        deferred_pending: bool = False,
+    ) -> float:
+        """Return the next host timer interval in seconds.
+
+        ``has_pending`` represents queued dispatcher work; ``deferred_pending``
+        represents host-native operations that are still waiting for completion.
+        Either one keeps the pump active.
+        """
+        now = self._clock()
+        client_recent = (
+            self.max_client_idle_secs is None or now - self._last_client_activity_at <= self.max_client_idle_secs
+        )
+        should_stay_active = (
+            has_pending or deferred_pending or (client_recent and now - self._last_work_at < self.idle_delay_secs)
+        )
+        mode = "active" if should_stay_active else "idle"
+        if mode != self._mode:
+            if mode == "active":
+                self._stats.active_transitions += 1
+            else:
+                self._stats.idle_transitions += 1
+            self._mode = mode
+            self._stats.mode = mode
+
+        interval = self.active_interval_secs if mode == "active" else self.idle_interval_secs
+        self._stats.last_interval_secs = interval
+        return interval
 
 
 @dataclass

--- a/tests/test_adaptive_pump_policy.py
+++ b/tests/test_adaptive_pump_policy.py
@@ -1,0 +1,114 @@
+"""Tests for the reusable adaptive DCC pump policy (#606)."""
+
+from __future__ import annotations
+
+import pytest
+
+import dcc_mcp_core
+from dcc_mcp_core import AdaptivePumpPolicy
+from dcc_mcp_core import AdaptivePumpStats
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def test_adaptive_pump_policy_exported() -> None:
+    assert dcc_mcp_core.AdaptivePumpPolicy is AdaptivePumpPolicy
+    assert dcc_mcp_core.AdaptivePumpStats is AdaptivePumpStats
+    assert "AdaptivePumpPolicy" in dcc_mcp_core.__all__
+    assert "AdaptivePumpStats" in dcc_mcp_core.__all__
+
+
+def test_policy_starts_active_then_backs_off_after_idle_delay() -> None:
+    clock = _Clock()
+    policy = AdaptivePumpPolicy(
+        active_interval_secs=0.05,
+        idle_interval_secs=1.0,
+        idle_delay_secs=5.0,
+        clock=clock,
+    )
+
+    assert policy.next_interval() == 0.05
+    clock.advance(4.9)
+    assert policy.next_interval() == 0.05
+    clock.advance(0.2)
+    assert policy.next_interval() == 1.0
+    assert policy.mode == "idle"
+    assert policy.stats.idle_transitions == 1
+
+
+def test_mark_work_done_returns_to_active_and_updates_stats() -> None:
+    clock = _Clock()
+    policy = AdaptivePumpPolicy(
+        active_interval_secs=0.1,
+        idle_interval_secs=2.0,
+        idle_delay_secs=1.0,
+        clock=clock,
+    )
+    clock.advance(2.0)
+    assert policy.next_interval() == 2.0
+
+    policy.mark_work_done(drained=3, overrun=True)
+    assert policy.next_interval() == 0.1
+    assert policy.stats.ticks == 1
+    assert policy.stats.drained_jobs == 3
+    assert policy.stats.overrun_cycles == 1
+    assert policy.stats.active_transitions == 1
+
+
+def test_pending_and_deferred_jobs_keep_policy_active() -> None:
+    clock = _Clock()
+    policy = AdaptivePumpPolicy(
+        active_interval_secs=0.05,
+        idle_interval_secs=1.0,
+        idle_delay_secs=0.0,
+        clock=clock,
+    )
+    clock.advance(10.0)
+
+    assert policy.next_interval(has_pending=True) == 0.05
+    assert policy.next_interval(has_pending=False, deferred_pending=True) == 0.05
+
+    assert policy.next_interval() == 1.0
+
+
+def test_client_idle_limit_allows_backoff_even_inside_idle_delay() -> None:
+    clock = _Clock()
+    policy = AdaptivePumpPolicy(
+        active_interval_secs=0.05,
+        idle_interval_secs=1.0,
+        idle_delay_secs=60.0,
+        max_client_idle_secs=10.0,
+        clock=clock,
+    )
+    clock.advance(11.0)
+
+    assert policy.next_interval() == 1.0
+
+    policy.mark_client_activity()
+    assert policy.next_interval() == 0.05
+
+
+def test_policy_validates_configuration() -> None:
+    with pytest.raises(ValueError, match="active_interval_secs"):
+        AdaptivePumpPolicy(active_interval_secs=0)
+    with pytest.raises(ValueError, match="idle_interval_secs"):
+        AdaptivePumpPolicy(idle_interval_secs=0)
+    with pytest.raises(ValueError, match="idle_delay_secs"):
+        AdaptivePumpPolicy(idle_delay_secs=-1)
+    with pytest.raises(ValueError, match="max_client_idle_secs"):
+        AdaptivePumpPolicy(max_client_idle_secs=-1)
+
+
+def test_record_tick_rejects_negative_drained_count() -> None:
+    policy = AdaptivePumpPolicy()
+    with pytest.raises(ValueError, match="drained"):
+        policy.record_tick(drained=-1)


### PR DESCRIPTION
## Summary
- Add `AdaptivePumpPolicy` and `AdaptivePumpStats` for shared active/idle pump timing in embedded DCC adapters.
- Track pump ticks, drained jobs, overruns, active/idle transitions, current mode, and last selected interval.
- Document Maya/Blender-style timer integration and add focused policy tests with a deterministic clock.

Closes #606.

## Test plan
- `vx ruff check python/dcc_mcp_core/_server/callable_dispatcher.py python/dcc_mcp_core/_server/__init__.py python/dcc_mcp_core/__init__.py tests/test_adaptive_pump_policy.py`
- `vx ruff format --check python/dcc_mcp_core/_server/callable_dispatcher.py python/dcc_mcp_core/_server/__init__.py python/dcc_mcp_core/__init__.py tests/test_adaptive_pump_policy.py`
- `python -m venv .venv; .venv\Scripts\python.exe -m pip install maturin pytest -q; vx maturin develop --features python-bindings,ext-module,workflow,scheduler,prometheus,job-persist-sqlite`
- `.venv\Scripts\python.exe -m pytest tests/test_adaptive_pump_policy.py -q`