### PR TITLE
feat: expose gateway instance diagnostics

### DIFF
--- a/crates/dcc-mcp-http/src/gateway/aggregator.rs
+++ b/crates/dcc-mcp-http/src/gateway/aggregator.rs
@@ -22,6 +22,7 @@ mod skill_mgmt;
 mod tests;
 mod wait_terminal;
 
+pub(crate) use super::tools::tool_list_instances;
 pub use call::route_tools_call;
 pub use fingerprint::compute_tools_fingerprint;
 pub(crate) use fingerprint::compute_tools_fingerprint_with_own;
@@ -47,7 +48,8 @@ use super::backend_client::{call_backend, fetch_tools, forward_tools_call};
 use super::namespace::{decode_tool_name, encode_tool_name, instance_short, is_local_tool};
 use super::state::GatewayState;
 use super::tools::{
-    gateway_tool_defs, tool_connect_to_dcc, tool_get_instance, tool_list_instances,
+    gateway_tool_defs, tool_connect_to_dcc, tool_diagnostics_audit_log,
+    tool_diagnostics_process_status, tool_diagnostics_tool_metrics, tool_get_instance,
 };
 use crate::protocol::{TOOLS_LIST_PAGE_SIZE, decode_cursor, encode_cursor};
 use dcc_mcp_transport::discovery::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry};

--- a/crates/dcc-mcp-http/src/gateway/aggregator/call.rs
+++ b/crates/dcc-mcp-http/src/gateway/aggregator/call.rs
@@ -18,6 +18,15 @@ pub async fn route_tools_call(
         "list_dcc_instances" => return to_text_result(tool_list_instances(gs, args).await),
         "get_dcc_instance" => return to_text_result(tool_get_instance(gs, args).await),
         "connect_to_dcc" => return to_text_result(tool_connect_to_dcc(gs, args).await),
+        "diagnostics__process_status" => {
+            return to_text_result(tool_diagnostics_process_status(gs, args).await);
+        }
+        "diagnostics__audit_log" => {
+            return to_text_result(tool_diagnostics_audit_log(gs, args).await);
+        }
+        "diagnostics__tool_metrics" => {
+            return to_text_result(tool_diagnostics_tool_metrics(gs, args).await);
+        }
         _ => {}
     }
 

--- a/crates/dcc-mcp-http/src/gateway/backend_client.rs
+++ b/crates/dcc-mcp-http/src/gateway/backend_client.rs
@@ -15,6 +15,35 @@ use serde_json::{Value, json};
 
 use crate::protocol::{JsonRpcRequestBuilder, JsonRpcResponse, McpTool};
 
+/// Build the lightweight HTTP health URL that identifies a real MCP backend.
+pub(crate) fn health_url_from_mcp_url(mcp_url: &str) -> String {
+    mcp_url
+        .trim_end_matches('/')
+        .strip_suffix("/mcp")
+        .map(|base| format!("{base}/health"))
+        .unwrap_or_else(|| format!("{}/health", mcp_url.trim_end_matches('/')))
+}
+
+/// Return true when the target looks like a DCC MCP HTTP server.
+///
+/// This deliberately probes `GET /health` before sending JSON-RPC to `/mcp`.
+/// Maya `commandPort` can also accept TCP bytes, but posting JSON-RPC to it
+/// triggers a modal commandPort security warning that blocks the main thread.
+pub(crate) async fn probe_mcp_health(
+    client: &reqwest::Client,
+    mcp_url: &str,
+    timeout: Duration,
+) -> bool {
+    let health_url = health_url_from_mcp_url(mcp_url);
+    client
+        .get(&health_url)
+        .timeout(timeout)
+        .header("accept", "application/json")
+        .send()
+        .await
+        .is_ok_and(|resp| resp.status().is_success())
+}
+
 /// Call a JSON-RPC method on a backend `/mcp` endpoint.
 ///
 /// Returns the raw `result` value on success, or an error string on transport
@@ -32,6 +61,12 @@ pub async fn call_backend(
     request_id: Option<String>,
     timeout: Duration,
 ) -> Result<Value, String> {
+    if !probe_mcp_health(client, mcp_url, timeout).await {
+        return Err(format!(
+            "{mcp_url}: not a DCC MCP HTTP endpoint (GET /health failed)"
+        ));
+    }
+
     let id = request_id.unwrap_or_else(uuid_like_id);
     let req_body = JsonRpcRequestBuilder::new(id, method)
         .with_optional_params(params)
@@ -157,6 +192,18 @@ mod tests {
         assert_ne!(a, b);
         assert!(a.starts_with("gw-"));
         assert!(b.starts_with("gw-"));
+    }
+
+    #[test]
+    fn builds_health_url_from_mcp_url() {
+        assert_eq!(
+            health_url_from_mcp_url("http://127.0.0.1:64954/mcp"),
+            "http://127.0.0.1:64954/health"
+        );
+        assert_eq!(
+            health_url_from_mcp_url("http://127.0.0.1:64954/mcp/"),
+            "http://127.0.0.1:64954/health"
+        );
     }
 
     /// Helper used only in tests — parse a canned JSON-RPC response body the

--- a/crates/dcc-mcp-http/src/gateway/handlers/mcp_impl.rs
+++ b/crates/dcc-mcp-http/src/gateway/handlers/mcp_impl.rs
@@ -121,6 +121,7 @@ pub(crate) async fn dispatch_single_request(
         "ping" => Some(json!({"jsonrpc":"2.0","id":id,"result":{}})),
         "notifications/initialized" => Some(json!({"jsonrpc":"2.0","id":id,"result":{}})),
         "tools/list" => Some(handle_tools_list(gs, id, req).await),
+        "instances/list" => Some(handle_instances_list(gs, id, req).await),
         "resources/list" => Some(handle_resources_list(gs, id).await),
         "resources/read" => Some(handle_resources_read(gs, id, req).await),
         "resources/subscribe" => {
@@ -174,6 +175,22 @@ async fn handle_initialize(gs: &GatewayState, id: Value, req: &JsonRpcRequest) -
                  Subscribe to GET /mcp (SSE) for push notifications."
         }
     })
+}
+
+async fn handle_instances_list(gs: &GatewayState, id: Value, req: &JsonRpcRequest) -> Value {
+    let args = req.params.as_ref().cloned().unwrap_or_else(|| json!({}));
+    match aggregator::tool_list_instances(gs, &args).await {
+        Ok(text) => {
+            let result =
+                serde_json::from_str::<Value>(&text).unwrap_or_else(|_| json!({"text": text}));
+            json!({"jsonrpc": "2.0", "id": id, "result": result})
+        }
+        Err(message) => json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": {"code": -32000, "message": message}
+        }),
+    }
 }
 
 async fn handle_tools_list(gs: &GatewayState, id: Value, req: &JsonRpcRequest) -> Value {

--- a/crates/dcc-mcp-http/src/gateway/tasks.rs
+++ b/crates/dcc-mcp-http/src/gateway/tasks.rs
@@ -348,7 +348,7 @@ pub(crate) async fn start_gateway_tasks(
         server_version,
         own_host: own_host.clone(),
         own_port,
-        http_client,
+        http_client: http_client.clone(),
         yield_tx: yield_tx.clone(),
         events_tx,
         protocol_version: Arc::new(RwLock::new(None)),
@@ -388,10 +388,13 @@ pub(crate) async fn start_gateway_tasks(
     });
 
     // ── Periodic health-check task (issue #556) ───────────────────────────
-    // Every 30 s, attempt a lightweight TCP connect to every registered
-    // instance. After 2 consecutive failures mark it Unreachable; after 3
-    // stale rounds auto-deregister it.
+    // Every 30 s, attempt a lightweight `GET /health` against every registered
+    // instance. TCP reachability alone is not enough: Maya commandPort also
+    // accepts TCP bytes, but it is not an MCP HTTP backend and JSON-RPC POSTs to
+    // it can trigger a modal security dialog (#592). After 2 consecutive
+    // failures mark the row Unreachable; after 3 stale rounds auto-deregister.
     let reg_health = registry.clone();
+    let health_http_client = http_client.clone();
     let health_own_host = own_host.clone();
     let health_own_port = own_port;
     let health_check_handle = tokio::spawn(async move {
@@ -414,13 +417,13 @@ pub(crate) async fn start_gateway_tasks(
             };
 
             for entry in entries {
-                let addr = format!("{}:{}", entry.host, entry.port);
-                let reachable = tokio::time::timeout(
+                let mcp_url = format!("http://{}:{}/mcp", entry.host, entry.port);
+                let reachable = crate::gateway::backend_client::probe_mcp_health(
+                    &health_http_client,
+                    &mcp_url,
                     Duration::from_secs(5),
-                    tokio::net::TcpStream::connect(&addr),
                 )
-                .await
-                .is_ok_and(|r| r.is_ok());
+                .await;
 
                 let key = format!("{}:{}", entry.dcc_type, entry.instance_id);
                 if reachable {

--- a/crates/dcc-mcp-http/src/gateway/tools.rs
+++ b/crates/dcc-mcp-http/src/gateway/tools.rs
@@ -250,6 +250,98 @@ pub async fn tool_connect_to_dcc(gs: &GatewayState, args: &Value) -> Result<Stri
     Err("Provide instance_id or dcc_type".to_string())
 }
 
+/// Gateway-native `diagnostics__process_status`.
+pub async fn tool_diagnostics_process_status(
+    gs: &GatewayState,
+    args: &Value,
+) -> Result<String, String> {
+    let reg = gs.registry.read().await;
+    let all = gs.all_instances(&reg);
+    let dcc_filter = args.get("dcc_type").and_then(|v| v.as_str());
+
+    let mut live_count = 0usize;
+    let mut stale_count = 0usize;
+    let mut unhealthy_count = 0usize;
+    let instances: Vec<Value> = all
+        .iter()
+        .filter(|e| dcc_filter.is_none_or(|f| e.dcc_type == f))
+        .map(|e| {
+            let stale = e.is_stale(gs.stale_timeout);
+            if stale {
+                stale_count += 1;
+            } else if matches!(
+                e.status,
+                dcc_mcp_transport::discovery::types::ServiceStatus::Available
+                    | dcc_mcp_transport::discovery::types::ServiceStatus::Busy
+            ) {
+                live_count += 1;
+            } else {
+                unhealthy_count += 1;
+            }
+            entry_to_json(e, gs.stale_timeout)
+        })
+        .collect();
+
+    serde_json::to_string_pretty(&json!({
+        "success": true,
+        "message": "Gateway process status",
+        "gateway": {
+            "server_name": gs.server_name,
+            "server_version": gs.server_version,
+            "own_host": gs.own_host,
+            "own_port": gs.own_port,
+        },
+        "instances": instances,
+        "counts": {
+            "total": instances.len(),
+            "live": live_count,
+            "stale": stale_count,
+            "unhealthy": unhealthy_count,
+        }
+    }))
+    .map_err(|e| e.to_string())
+}
+
+/// Gateway-native `diagnostics__audit_log`.
+pub async fn tool_diagnostics_audit_log(
+    gs: &GatewayState,
+    _args: &Value,
+) -> Result<String, String> {
+    let pending_calls = gs.pending_calls.read().await.len();
+    let subscriptions = gs.resource_subscriptions.read().await.len();
+    serde_json::to_string_pretty(&json!({
+        "success": true,
+        "message": "Gateway audit summary",
+        "entries": [],
+        "summary": {
+            "pending_calls": pending_calls,
+            "resource_subscription_sessions": subscriptions,
+            "note": "Gateway-native audit history is not persisted; backend audit logs remain available via prefixed diagnostics tools when exposed by a DCC instance."
+        }
+    }))
+    .map_err(|e| e.to_string())
+}
+
+/// Gateway-native `diagnostics__tool_metrics`.
+pub async fn tool_diagnostics_tool_metrics(
+    gs: &GatewayState,
+    _args: &Value,
+) -> Result<String, String> {
+    let reg = gs.registry.read().await;
+    let live_instances = gs.live_instances(&reg);
+    serde_json::to_string_pretty(&json!({
+        "success": true,
+        "message": "Gateway tool metrics summary",
+        "metrics": {
+            "gateway_local_tools": gateway_tool_defs().as_array().map_or(0, Vec::len),
+            "live_instances": live_instances.len(),
+            "backend_timeout_ms": gs.backend_timeout.as_millis(),
+            "async_dispatch_timeout_ms": gs.async_dispatch_timeout.as_millis(),
+        }
+    }))
+    .map_err(|e| e.to_string())
+}
+
 // ── private helpers ────────────────────────────────────────────────────────
 
 fn format_connect_response(entry: &ServiceEntry) -> Result<String, String> {
@@ -381,6 +473,26 @@ pub fn gateway_tool_defs() -> serde_json::Value {
                     "display_name":  {"type": "string", "description": "Human-readable label set by the bridge plugin"}
                 }
             }
+        },
+        {
+            "name": "diagnostics__process_status",
+            "description": "Gateway-native process and instance health summary. Lists live, stale, and unhealthy DCC registrations without requiring a backend instance.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "dcc_type": {"type": "string", "description": "Optional DCC type filter."}
+                }
+            }
+        },
+        {
+            "name": "diagnostics__audit_log",
+            "description": "Gateway-native audit summary for pending calls and resource subscriptions. Backend audit logs remain available through instance tools.",
+            "inputSchema": {"type": "object", "properties": {}}
+        },
+        {
+            "name": "diagnostics__tool_metrics",
+            "description": "Gateway-native tool metrics summary for local gateway tools and live backend count.",
+            "inputSchema": {"type": "object", "properties": {}}
         }
     ])
 }

--- a/crates/dcc-mcp-http/src/tests/gateway_mcp.rs
+++ b/crates/dcc-mcp-http/src/tests/gateway_mcp.rs
@@ -62,6 +62,18 @@ async fn test_gateway_mcp_tools_list() {
         names.contains(&"connect_to_dcc"),
         "connect_to_dcc missing: {names:?}"
     );
+    assert!(
+        names.contains(&"diagnostics__process_status"),
+        "diagnostics__process_status missing: {names:?}"
+    );
+    assert!(
+        names.contains(&"diagnostics__audit_log"),
+        "diagnostics__audit_log missing: {names:?}"
+    );
+    assert!(
+        names.contains(&"diagnostics__tool_metrics"),
+        "diagnostics__tool_metrics missing: {names:?}"
+    );
 }
 
 #[tokio::test]
@@ -115,6 +127,100 @@ async fn test_gateway_mcp_list_dcc_instances_with_entry() {
     let result: serde_json::Value = serde_json::from_str(text).unwrap();
     assert_eq!(result["total"], 1);
     assert_eq!(result["instances"][0]["dcc_type"], "houdini");
+}
+
+#[tokio::test]
+async fn test_gateway_mcp_instances_list_method_with_entry() {
+    let state = make_gateway_state();
+    {
+        let reg = state.registry.read().await;
+        let entry = ServiceEntry::new("maya", "127.0.0.1", 19766);
+        reg.register(entry).unwrap();
+    }
+    let server = TestServer::new(build_gateway_router(state));
+    let resp = server
+        .post("/mcp")
+        .add_header(
+            axum::http::header::CONTENT_TYPE,
+            "application/json".parse::<HeaderValue>().unwrap(),
+        )
+        .json(&serde_json::json!({
+            "jsonrpc": "2.0", "id": 11, "method": "instances/list", "params": {}
+        }))
+        .await;
+    resp.assert_status_ok();
+    let body: serde_json::Value = resp.json();
+    assert_eq!(body["result"]["total"], 1);
+    assert_eq!(body["result"]["instances"][0]["dcc_type"], "maya");
+}
+
+#[tokio::test]
+async fn test_gateway_diagnostics_tools_are_native() {
+    let state = make_gateway_state();
+    {
+        let reg = state.registry.read().await;
+        let entry = ServiceEntry::new("maya", "127.0.0.1", 19767);
+        reg.register(entry).unwrap();
+    }
+    let server = TestServer::new(build_gateway_router(state));
+    let resp = server
+        .post("/mcp")
+        .add_header(
+            axum::http::header::CONTENT_TYPE,
+            "application/json".parse::<HeaderValue>().unwrap(),
+        )
+        .json(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 12,
+            "method": "tools/call",
+            "params": {"name": "diagnostics__process_status", "arguments": {}}
+        }))
+        .await;
+    resp.assert_status_ok();
+    let body: serde_json::Value = resp.json();
+    assert_eq!(body["result"]["isError"], false);
+    let text = body["result"]["content"][0]["text"]
+        .as_str()
+        .expect("no text content");
+    let result: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(result["success"], true);
+    assert_eq!(result["counts"]["total"], 1);
+    assert_eq!(result["instances"][0]["dcc_type"], "maya");
+}
+
+#[tokio::test]
+async fn test_connect_to_dcc_succeeds_for_available_instance_prefix() {
+    let state = make_gateway_state();
+    let prefix = {
+        let reg = state.registry.read().await;
+        let entry = ServiceEntry::new("maya", "127.0.0.1", 19768);
+        let prefix = entry.instance_id.to_string()[..8].to_string();
+        reg.register(entry).unwrap();
+        prefix
+    };
+    let server = TestServer::new(build_gateway_router(state));
+    let resp = server
+        .post("/mcp")
+        .add_header(
+            axum::http::header::CONTENT_TYPE,
+            "application/json".parse::<HeaderValue>().unwrap(),
+        )
+        .json(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 13,
+            "method": "tools/call",
+            "params": {"name": "connect_to_dcc", "arguments": {"instance_id": prefix}}
+        }))
+        .await;
+    resp.assert_status_ok();
+    let body: serde_json::Value = resp.json();
+    assert_eq!(body["result"]["isError"], false);
+    let text = body["result"]["content"][0]["text"]
+        .as_str()
+        .expect("no text content");
+    let result: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(result["dcc_type"], "maya");
+    assert_eq!(result["mcp_url"], "http://127.0.0.1:19768/mcp");
 }
 
 #[tokio::test]

--- a/docs/guide/gateway.md
+++ b/docs/guide/gateway.md
@@ -94,6 +94,33 @@ Two invariants prevent this:
    crash would eat the full exponential-backoff retry budget during
    the first ~15 s of gateway lifetime.
 
+### Instance and Diagnostics Discovery
+
+The gateway exposes instance health through both the MCP tool surface and a
+native JSON-RPC method:
+
+```json
+{"jsonrpc":"2.0","id":1,"method":"instances/list","params":{"include_stale":true}}
+```
+
+The response matches `list_dcc_instances` and includes live, stale, and
+unhealthy rows so clients can decide whether to route, reconnect, or ask the
+user to restart a DCC instance. `tools/list` is assembled from the current
+registry on each call, so instances registered after gateway startup are picked
+up without a restart.
+
+Gateway-native diagnostics tools are always present, even when no backend is
+routable:
+
+| Tool | Purpose |
+|------|---------|
+| `diagnostics__process_status` | Gateway process metadata plus live/stale/unhealthy instance counts |
+| `diagnostics__audit_log` | Gateway pending-call and subscription summary |
+| `diagnostics__tool_metrics` | Gateway-local tool count, live backend count, and timeout settings |
+
+Backend diagnostics tools remain available as normal prefixed instance tools
+when a DCC exposes them.
+
 ## Code pointers
 
 | Piece | File |

--- a/docs/guide/gateway.md
+++ b/docs/guide/gateway.md
@@ -109,6 +109,11 @@ user to restart a DCC instance. `tools/list` is assembled from the current
 registry on each call, so instances registered after gateway startup are picked
 up without a restart.
 
+Before the gateway sends JSON-RPC to a backend, it verifies that the target
+responds to `GET /health`. This avoids treating non-MCP listeners such as Maya
+`commandPort` as routable backends; posting MCP JSON-RPC to commandPort can
+trigger Maya's modal commandPort security dialog and block the DCC main thread.
+
 Gateway-native diagnostics tools are always present, even when no backend is
 routable:
 


### PR DESCRIPTION
## Summary
- Add `instances/list` as a gateway-native JSON-RPC method backed by the live registry view.
- Expose gateway-native `diagnostics__process_status`, `diagnostics__audit_log`, and `diagnostics__tool_metrics` so diagnostics are callable even when no backend tool is routable.
- Require backend `GET /health` before gateway fan-out and periodic health checks so non-MCP listeners such as Maya commandPort are filtered before JSON-RPC POSTs.
- Add regression coverage for diagnostics discovery, diagnostics calls, `instances/list`, `connect_to_dcc` by available instance prefix, and backend health URL handling.

Closes #584.
Closes #585.
Closes #586.
Closes #587.
Closes #592.

## Test plan
- `vx cargo fmt --all --check`
- `vx cargo test -p dcc-mcp-http tests::gateway::mcp --features python-bindings,job-persist-sqlite`
- `vx cargo test -p dcc-mcp-http backend_client --features python-bindings,job-persist-sqlite`