### PR TITLE
feat: add weak DCC execution guardrails

### DIFF
--- a/docs/api/guardrails.md
+++ b/docs/api/guardrails.md
@@ -1,0 +1,45 @@
+# Weak DCC Execution Guardrails
+
+`DccWeakSandbox` is an opt-in, scoped helper for blocking known-dangerous host
+operations while executing generated DCC code.
+
+It is **not** a security sandbox. It only replaces adapter-selected Python
+attributes/functions for the duration of a `with` block and restores them when
+the block exits.
+
+```python
+import sys
+from dcc_mcp_core import DccBlockedCall, DccWeakSandbox
+
+with DccWeakSandbox(
+    blocked_calls=[
+        DccBlockedCall(
+            "sys.exit",
+            "terminates the embedded DCC Python process",
+            target=sys,
+            attribute="exit",
+        ),
+    ],
+):
+    exec(code, namespace)
+```
+
+Adapters can also provide explicit attribute overrides:
+
+```python
+with DccWeakSandbox(
+    attr_overrides={
+        sys: {
+            "exit": DccWeakSandbox.blocked_callable(
+                "sys.exit",
+                "terminates the host process",
+            ),
+        },
+    },
+):
+    exec(code, namespace)
+```
+
+Blocked calls raise `DccGuardrailError` with the blocked call name and reason.
+Use this for practical adapter guardrails such as quit/factory-reset/preference
+reset operations; do not treat it as protection from malicious code.

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -393,6 +393,9 @@ from dcc_mcp_core.feedback import get_feedback_entries
 from dcc_mcp_core.feedback import make_rationale_meta
 from dcc_mcp_core.feedback import register_feedback_tool
 from dcc_mcp_core.gateway_election import DccGatewayElection
+from dcc_mcp_core.guardrails import DccBlockedCall
+from dcc_mcp_core.guardrails import DccGuardrailError
+from dcc_mcp_core.guardrails import DccWeakSandbox
 from dcc_mcp_core.hotreload import DccSkillHotReloader
 
 # Runtime namespace introspection tools (issue #426)
@@ -527,15 +530,18 @@ __all__ = [
     "CimdDocument",
     "DccApiCatalog",
     "DccApiExecutor",
+    "DccBlockedCall",
     "DccBridge",
     "DccCapabilities",
     "DccError",
     "DccErrorCode",
     "DccGatewayElection",
+    "DccGuardrailError",
     "DccInfo",
     "DccLinkFrame",
     "DccServerBase",
     "DccSkillHotReloader",
+    "DccWeakSandbox",
     "ElicitationMode",
     "ElicitationRequest",
     "ElicitationResponse",

--- a/python/dcc_mcp_core/guardrails.py
+++ b/python/dcc_mcp_core/guardrails.py
@@ -1,0 +1,135 @@
+"""Adapter-extensible weak guardrails for ad-hoc DCC code execution.
+
+This module is intentionally small and opt-in. It is **not** a security
+sandbox; it only helps adapters block known-dangerous host operations while
+running a single generated script.
+"""
+
+from __future__ import annotations
+
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import Any
+from typing import Callable
+from typing import Iterable
+from typing import Mapping
+
+__all__ = [
+    "DccBlockedCall",
+    "DccGuardrailError",
+    "DccWeakSandbox",
+]
+
+
+class DccGuardrailError(RuntimeError):
+    """Raised when a weak guardrail blocks a known-dangerous call."""
+
+
+@dataclass(frozen=True)
+class DccBlockedCall:
+    """A blocked host operation that an adapter may install during execution.
+
+    ``target`` and ``attribute`` are optional so adapters can keep a declarative
+    table of known-dangerous calls even when some host modules are unavailable.
+    When both are provided, :class:`DccWeakSandbox` temporarily replaces the
+    attribute with a callable that raises :class:`DccGuardrailError`.
+    """
+
+    name: str
+    reason: str
+    target: Any | None = None
+    attribute: str | None = None
+
+
+@dataclass(frozen=True)
+class _Patch:
+    target: Any
+    attribute: str
+    replacement: Any
+    original: Any
+
+
+_MISSING = object()
+
+
+class DccWeakSandbox:
+    """Scoped, adapter-extensible guardrails for generated DCC scripts.
+
+    Example:
+
+    .. code-block:: python
+
+        with DccWeakSandbox(
+            blocked_calls=[
+                DccBlockedCall("sys.exit", "terminates the host process", sys, "exit"),
+            ],
+        ):
+            exec(code, namespace)
+
+    """
+
+    def __init__(
+        self,
+        *,
+        blocked_calls: Iterable[DccBlockedCall] | None = None,
+        attr_overrides: Mapping[Any, Mapping[str, Any]] | None = None,
+    ) -> None:
+        self.blocked_calls = tuple(blocked_calls or ())
+        self.attr_overrides = attr_overrides or {}
+        self._patches: list[_Patch] = []
+        self._active = False
+
+    @staticmethod
+    def blocked_callable(name: str, reason: str) -> Callable[..., Any]:
+        """Return a callable that raises a clear guardrail error."""
+
+        def _blocked(*_args: Any, **_kwargs: Any) -> Any:
+            raise DccGuardrailError(f"Blocked DCC operation '{name}': {reason}")
+
+        _blocked.__name__ = f"blocked_{name.replace('.', '_')}"
+        return _blocked
+
+    def __enter__(self) -> DccWeakSandbox:
+        if self._active:
+            raise RuntimeError("DccWeakSandbox is already active")
+        self._active = True
+        try:
+            for blocked in self.blocked_calls:
+                if blocked.target is None or blocked.attribute is None:
+                    continue
+                self._install(
+                    blocked.target,
+                    blocked.attribute,
+                    self.blocked_callable(blocked.name, blocked.reason),
+                )
+
+            for target, attrs in self.attr_overrides.items():
+                for attribute, replacement in attrs.items():
+                    self._install(target, attribute, replacement)
+        except Exception:
+            self._restore()
+            self._active = False
+            raise
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+        self._restore()
+        self._active = False
+        return False
+
+    def _install(self, target: Any, attribute: str, replacement: Any) -> None:
+        original = getattr(target, attribute, _MISSING)
+        setattr(target, attribute, replacement)
+        self._patches.append(_Patch(target, attribute, replacement, original))
+
+    def _restore(self) -> None:
+        while self._patches:
+            patch = self._patches.pop()
+            current = getattr(patch.target, patch.attribute, _MISSING)
+            if current is not patch.replacement:
+                continue
+            if patch.original is _MISSING:
+                with suppress(AttributeError):
+                    delattr(patch.target, patch.attribute)
+            else:
+                setattr(patch.target, patch.attribute, patch.original)

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -1,0 +1,90 @@
+"""Tests for adapter-extensible weak execution guardrails (#605)."""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+import dcc_mcp_core
+from dcc_mcp_core import DccBlockedCall
+from dcc_mcp_core import DccGuardrailError
+from dcc_mcp_core import DccWeakSandbox
+
+
+def test_guardrail_symbols_exported() -> None:
+    assert dcc_mcp_core.DccBlockedCall is DccBlockedCall
+    assert dcc_mcp_core.DccGuardrailError is DccGuardrailError
+    assert dcc_mcp_core.DccWeakSandbox is DccWeakSandbox
+    assert "DccBlockedCall" in dcc_mcp_core.__all__
+    assert "DccGuardrailError" in dcc_mcp_core.__all__
+    assert "DccWeakSandbox" in dcc_mcp_core.__all__
+
+
+def test_blocked_call_raises_clear_error_and_restores() -> None:
+    host = SimpleNamespace()
+
+    def original_quit() -> str:
+        return "ok"
+
+    host.quit = original_quit
+
+    with DccWeakSandbox(
+        blocked_calls=[
+            DccBlockedCall(
+                "host.quit",
+                reason="terminates the host process",
+                target=host,
+                attribute="quit",
+            )
+        ]
+    ):
+        with pytest.raises(DccGuardrailError, match=r"host\.quit"):
+            host.quit()
+        with pytest.raises(DccGuardrailError, match="terminates the host process"):
+            host.quit()
+
+    assert host.quit is original_quit
+    assert host.quit() == "ok"
+
+
+def test_attr_overrides_are_scoped_and_restored() -> None:
+    class _Host:
+        value = 1
+
+    host = _Host()
+
+    with DccWeakSandbox(attr_overrides={host: {"value": 2, "temporary": "added"}}):
+        assert host.value == 2
+        assert host.temporary == "added"
+
+    assert host.value == 1
+    assert not hasattr(host, "temporary")
+
+
+def test_restores_original_on_exception() -> None:
+    host = SimpleNamespace(exit=lambda: "ok")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with DccWeakSandbox(blocked_calls=[DccBlockedCall("host.exit", "terminates the process", host, "exit")]):
+            raise RuntimeError("boom")
+
+    assert host.exit() == "ok"
+
+
+def test_metadata_only_blocked_calls_are_allowed() -> None:
+    with DccWeakSandbox(blocked_calls=[DccBlockedCall("maya.cmds.file(new=True)", "resets the scene")]):
+        pass
+
+
+def test_custom_override_can_wrap_sys_exit() -> None:
+    original_exit = sys.exit
+
+    with DccWeakSandbox(
+        attr_overrides={sys: {"exit": DccWeakSandbox.blocked_callable("sys.exit", "terminates embedded Python")}}
+    ):
+        with pytest.raises(DccGuardrailError, match=r"sys\.exit"):
+            sys.exit(0)
+
+    assert sys.exit is original_exit


### PR DESCRIPTION
## Summary
- Add `DccWeakSandbox`, `DccBlockedCall`, and `DccGuardrailError` as opt-in scoped guardrails for generated DCC code execution.
- Restore original host attributes after execution, including exception paths and temporary attribute overrides.
- Document that this is a weak adapter guardrail pattern, not a security sandbox.

Closes #605.

## Test plan
- `vx ruff check python/dcc_mcp_core/__init__.py python/dcc_mcp_core/guardrails.py tests/test_guardrails.py`
- `vx ruff format --check python/dcc_mcp_core/__init__.py python/dcc_mcp_core/guardrails.py tests/test_guardrails.py`
- `vx maturin develop --features python-bindings,ext-module,workflow,scheduler,prometheus,job-persist-sqlite`
- `.venv\Scripts\python.exe -m pytest tests/test_guardrails.py -q`