### PR TITLE
feat: add adapter context policy helpers

### DIFF
--- a/docs/api/adapter-context.md
+++ b/docs/api/adapter-context.md
@@ -1,0 +1,103 @@
+# Adapter Context And Policy Helpers
+
+This API gives DCC adapters shared contracts for concise instructions,
+post-tool snapshots, visual feedback, response shaping, toolset profiles, and
+searchable API docs.
+
+## Instruction Resources
+
+```python
+from dcc_mcp_core import AdapterInstructionSet, register_adapter_instruction_resources
+
+register_adapter_instruction_resources(
+    server,
+    AdapterInstructionSet(
+        dcc="maya",
+        instructions="Use screenshots after visual scene changes.",
+        capabilities={"screenshots": True, "in_process_execution": True},
+        troubleshooting="If execution stalls, check for modal dialogs.",
+        adapter_version="0.3.0",
+    ),
+)
+```
+
+This registers:
+
+- `docs://adapter/<dcc>/instructions`
+- `docs://adapter/<dcc>/capabilities`
+- `docs://adapter/<dcc>/troubleshooting` when provided
+
+`DccServerBase.register_adapter_instructions(...)` is a thin wrapper for
+embedded adapters.
+
+## Context Snapshots
+
+Adapters can attach a small, bounded scene/document snapshot after mutating
+tools:
+
+```python
+from dcc_mcp_core import DccContextSnapshot, append_context_snapshot
+
+result = append_context_snapshot(
+    {"success": True, "message": "Layer created"},
+    DccContextSnapshot(
+        dcc="photoshop",
+        document={"name": "hero.psd"},
+        active_layer={"name": "Glow"},
+        counts={"layers": 12},
+    ),
+)
+```
+
+`DccServerBase.set_context_snapshot_provider(callable)` stores a provider, and
+`DccServerBase.append_context_snapshot(result)` applies it.
+
+## Response Shaping
+
+`ResponseShapePolicy` truncates large lists, dicts, and strings and adds
+`_meta["dcc.response_shape"]` with omitted counts and a `next_query` hint.
+
+```python
+from dcc_mcp_core import ResponseShapePolicy, shape_response
+
+payload = shape_response(scene_graph, ResponseShapePolicy(max_items=200, max_bytes=256_000))
+```
+
+## Visual Feedback
+
+`VisualFeedbackPolicy` standardizes resource-backed previews:
+
+```python
+from dcc_mcp_core import VisualFeedbackPolicy, build_visual_feedback_context
+
+context = build_visual_feedback_context(
+    resource="output://viewport.png",
+    width=1280,
+    height=720,
+    policy=VisualFeedbackPolicy(mode="after_mutation", max_size=800),
+)
+```
+
+## Toolset Profiles
+
+`DccToolsetProfile` and `ToolsetProfileRegistry` provide a high-level layer over
+skill groups for adapter modes such as `modeling-basic`, `rendering`, or
+`photoshop-layer-editing`.
+
+## API Docs
+
+Adapters can expose bundled or generated host API docs without arbitrary runtime
+introspection:
+
+```python
+from dcc_mcp_core import DccApiDocEntry, DccApiDocIndex, register_dcc_api_docs
+
+index = DccApiDocIndex(
+    "blender",
+    [DccApiDocEntry("bpy.ops.mesh.primitive_cube_add", "Add a cube")],
+    version="4.0",
+)
+register_dcc_api_docs(server, index)
+```
+
+This registers `docs://adapter/<dcc>/api/index` and one resource per symbol.

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -313,6 +313,19 @@ from dcc_mcp_core._server import JobOutcome
 from dcc_mcp_core._server import MinimalModeConfig
 from dcc_mcp_core._server import PendingEnvelope
 from dcc_mcp_core._server import current_callable_job
+from dcc_mcp_core.adapter_context import AdapterInstructionSet
+from dcc_mcp_core.adapter_context import DccApiDocEntry
+from dcc_mcp_core.adapter_context import DccApiDocIndex
+from dcc_mcp_core.adapter_context import DccContextSnapshot
+from dcc_mcp_core.adapter_context import DccToolsetProfile
+from dcc_mcp_core.adapter_context import ResponseShapePolicy
+from dcc_mcp_core.adapter_context import ToolsetProfileRegistry
+from dcc_mcp_core.adapter_context import VisualFeedbackPolicy
+from dcc_mcp_core.adapter_context import append_context_snapshot
+from dcc_mcp_core.adapter_context import build_visual_feedback_context
+from dcc_mcp_core.adapter_context import register_adapter_instruction_resources
+from dcc_mcp_core.adapter_context import register_dcc_api_docs
+from dcc_mcp_core.adapter_context import shape_response
 from dcc_mcp_core.adapters import CAPABILITY_KEYS
 from dcc_mcp_core.adapters import WEBVIEW_DEFAULT_CAPABILITIES
 from dcc_mcp_core.adapters import WebViewAdapter
@@ -505,6 +518,7 @@ __all__ = [
     "SKILL_SCRIPTS_DIR",
     "TOOL_NAME_RE",
     "WEBVIEW_DEFAULT_CAPABILITIES",
+    "AdapterInstructionSet",
     "ApiKeyConfig",
     "AuditEntry",
     "AuditLog",
@@ -531,10 +545,13 @@ __all__ = [
     "CheckpointStore",
     "CimdDocument",
     "DccApiCatalog",
+    "DccApiDocEntry",
+    "DccApiDocIndex",
     "DccApiExecutor",
     "DccBlockedCall",
     "DccBridge",
     "DccCapabilities",
+    "DccContextSnapshot",
     "DccError",
     "DccErrorCode",
     "DccGatewayElection",
@@ -543,6 +560,7 @@ __all__ = [
     "DccLinkFrame",
     "DccServerBase",
     "DccSkillHotReloader",
+    "DccToolsetProfile",
     "DccWeakSandbox",
     "ElicitationMode",
     "ElicitationRequest",
@@ -592,6 +610,7 @@ __all__ = [
     "ResourceAnnotations",
     "ResourceDefinition",
     "ResourceTemplateDefinition",
+    "ResponseShapePolicy",
     "RetryPolicy",
     "RichContent",
     "RichContentKind",
@@ -642,6 +661,7 @@ __all__ = [
     "ToolResult",
     "ToolSpec",
     "ToolValidator",
+    "ToolsetProfileRegistry",
     "TransportAddress",
     "TransportScheme",
     "TriggerSpec",
@@ -650,6 +670,7 @@ __all__ = [
     "UsdStage",
     "VersionConstraint",
     "VersionedRegistry",
+    "VisualFeedbackPolicy",
     "VtValue",
     "WebViewAdapter",
     "WebViewContext",
@@ -663,6 +684,7 @@ __all__ = [
     "WorkspaceRoots",
     "__author__",
     "__version__",
+    "append_context_snapshot",
     "artefact_get_bytes",
     "artefact_list",
     "artefact_put_bytes",
@@ -670,6 +692,7 @@ __all__ = [
     "attach_rich_content",
     "batch_dispatch",
     "build_plugin_manifest",
+    "build_visual_feedback_context",
     "check_cancelled",
     "check_dcc_cancelled",
     "checkpoint_every",
@@ -743,8 +766,10 @@ __all__ = [
     "parse_schedules_yaml",
     "parse_skill_md",
     "record_skill_feedback",
+    "register_adapter_instruction_resources",
     "register_bridge",
     "register_checkpoint_tools",
+    "register_dcc_api_docs",
     "register_dcc_api_executor",
     "register_diagnostic_handlers",
     "register_diagnostic_mcp_tools",
@@ -772,6 +797,7 @@ __all__ = [
     "serialize_result",
     "set_cancel_token",
     "set_current_job",
+    "shape_response",
     "shutdown_file_logging",
     "shutdown_telemetry",
     "skill_entry",

--- a/python/dcc_mcp_core/adapter_context.py
+++ b/python/dcc_mcp_core/adapter_context.py
@@ -1,0 +1,387 @@
+"""Adapter-facing context, instruction, and policy helpers.
+
+These helpers give DCC adapters a small shared vocabulary for session
+instructions, post-tool context snapshots, visual feedback, response shaping,
+toolset profiles, and searchable host API docs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+import json
+from typing import Any
+from typing import Callable
+from typing import Iterable
+from typing import Mapping
+
+from dcc_mcp_core.docs_resources import register_docs_resource
+
+__all__ = [
+    "AdapterInstructionSet",
+    "DccApiDocEntry",
+    "DccApiDocIndex",
+    "DccContextSnapshot",
+    "DccToolsetProfile",
+    "ResponseShapePolicy",
+    "ToolsetProfileRegistry",
+    "VisualFeedbackPolicy",
+    "append_context_snapshot",
+    "build_visual_feedback_context",
+    "register_adapter_instruction_resources",
+    "register_dcc_api_docs",
+    "shape_response",
+]
+
+
+@dataclass(frozen=True)
+class AdapterInstructionSet:
+    """Concise adapter guidance exposed as MCP resources."""
+
+    dcc: str
+    instructions: str
+    capabilities: Mapping[str, Any] = field(default_factory=dict)
+    troubleshooting: str = ""
+    adapter_version: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class DccContextSnapshot:
+    """Bounded post-tool context snapshot for DCC adapters."""
+
+    dcc: str
+    document: Mapping[str, Any] | None = None
+    selection: Mapping[str, Any] | None = None
+    active_object: Mapping[str, Any] | None = None
+    active_layer: Mapping[str, Any] | None = None
+    counts: Mapping[str, int] = field(default_factory=dict)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {"dcc": self.dcc}
+        for key in ("document", "selection", "active_object", "active_layer"):
+            value = getattr(self, key)
+            if value is not None:
+                data[key] = dict(value)
+        if self.counts:
+            data["counts"] = dict(self.counts)
+        if self.metadata:
+            data["metadata"] = dict(self.metadata)
+        return data
+
+
+@dataclass(frozen=True)
+class VisualFeedbackPolicy:
+    """Policy describing when and how an adapter returns visual previews."""
+
+    mode: str = "manual"
+    max_size: int = 800
+    format: str = "png"
+    resource_backed: bool = True
+
+    def __post_init__(self) -> None:
+        if self.mode not in {"manual", "after_mutation", "on_request"}:
+            raise ValueError("mode must be 'manual', 'after_mutation', or 'on_request'")
+        if self.max_size <= 0:
+            raise ValueError("max_size must be > 0")
+
+
+@dataclass(frozen=True)
+class ResponseShapePolicy:
+    """Reusable truncation policy for large DCC payloads."""
+
+    max_bytes: int = 256_000
+    max_items: int = 200
+    summarize: bool = True
+    include_truncation_notice: bool = True
+
+    def __post_init__(self) -> None:
+        if self.max_bytes <= 0:
+            raise ValueError("max_bytes must be > 0")
+        if self.max_items <= 0:
+            raise ValueError("max_items must be > 0")
+
+
+@dataclass(frozen=True)
+class DccToolsetProfile:
+    """High-level toolset profile spanning tools, resources, prompts, and policy."""
+
+    name: str
+    description: str = ""
+    tools: tuple[str, ...] = ()
+    resources: tuple[str, ...] = ()
+    prompts: tuple[str, ...] = ()
+    default: bool = False
+    policy_hints: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "tools": list(self.tools),
+            "resources": list(self.resources),
+            "prompts": list(self.prompts),
+            "default": self.default,
+            "policy_hints": dict(self.policy_hints),
+        }
+
+
+class ToolsetProfileRegistry:
+    """In-memory registry for adapter toolset profiles."""
+
+    def __init__(self, profiles: Iterable[DccToolsetProfile] = ()) -> None:
+        self._profiles = {profile.name: profile for profile in profiles}
+        self._active = {profile.name for profile in self._profiles.values() if profile.default}
+
+    def register(self, profile: DccToolsetProfile) -> None:
+        self._profiles[profile.name] = profile
+        if profile.default:
+            self._active.add(profile.name)
+
+    def list_profiles(self) -> list[dict[str, Any]]:
+        return [
+            {**profile.to_dict(), "active": profile.name in self._active}
+            for profile in sorted(self._profiles.values(), key=lambda item: item.name)
+        ]
+
+    def activate(self, name: str) -> None:
+        if name not in self._profiles:
+            raise KeyError(f"unknown toolset profile: {name}")
+        self._active.add(name)
+
+    def deactivate(self, name: str) -> None:
+        if name not in self._profiles:
+            raise KeyError(f"unknown toolset profile: {name}")
+        self._active.discard(name)
+
+    def active_profiles(self) -> list[DccToolsetProfile]:
+        return [self._profiles[name] for name in sorted(self._active)]
+
+
+@dataclass(frozen=True)
+class DccApiDocEntry:
+    """Searchable DCC host API documentation entry."""
+
+    symbol: str
+    summary: str
+    body: str = ""
+    uri: str | None = None
+    version: str | None = None
+    tags: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "symbol": self.symbol,
+            "summary": self.summary,
+            "body": self.body,
+            "uri": self.uri,
+            "version": self.version,
+            "tags": list(self.tags),
+        }
+
+
+class DccApiDocIndex:
+    """Tiny searchable docs index for adapter-provided API references."""
+
+    def __init__(self, dcc: str, entries: Iterable[DccApiDocEntry] = (), version: str | None = None) -> None:
+        self.dcc = dcc
+        self.version = version
+        self._entries = {entry.symbol: entry for entry in entries}
+
+    def add(self, entry: DccApiDocEntry) -> None:
+        self._entries[entry.symbol] = entry
+
+    def get(self, symbol: str) -> DccApiDocEntry | None:
+        return self._entries.get(symbol)
+
+    def search(self, query: str, *, limit: int = 10) -> list[dict[str, Any]]:
+        needle = query.casefold()
+        scored: list[tuple[int, DccApiDocEntry]] = []
+        for entry in self._entries.values():
+            haystack = " ".join([entry.symbol, entry.summary, entry.body, " ".join(entry.tags)]).casefold()
+            if needle in haystack:
+                score = 0 if entry.symbol.casefold() == needle else haystack.find(needle)
+                scored.append((score, entry))
+        return [entry.to_dict() for _, entry in sorted(scored, key=lambda item: (item[0], item[1].symbol))[:limit]]
+
+    def to_resource_manifest(self) -> dict[str, Any]:
+        return {
+            "dcc": self.dcc,
+            "version": self.version,
+            "entries": [entry.to_dict() for entry in sorted(self._entries.values(), key=lambda item: item.symbol)],
+        }
+
+
+def register_adapter_instruction_resources(
+    server: Any,
+    instruction_set: AdapterInstructionSet,
+    *,
+    uri_prefix: str | None = None,
+) -> list[str]:
+    """Register standard adapter instruction/capability resources."""
+    prefix = (uri_prefix or f"docs://adapter/{instruction_set.dcc}").rstrip("/")
+    resources = [
+        (
+            f"{prefix}/instructions",
+            f"{instruction_set.dcc} instructions",
+            "Adapter instructions and recommended workflows.",
+            instruction_set.instructions,
+            "text/markdown",
+        ),
+        (
+            f"{prefix}/capabilities",
+            f"{instruction_set.dcc} capabilities",
+            "Adapter capability and version metadata.",
+            json.dumps(
+                {
+                    "dcc": instruction_set.dcc,
+                    "adapter_version": instruction_set.adapter_version,
+                    "capabilities": dict(instruction_set.capabilities),
+                    "metadata": dict(instruction_set.metadata),
+                },
+                indent=2,
+                sort_keys=True,
+            ),
+            "application/json",
+        ),
+    ]
+    if instruction_set.troubleshooting:
+        resources.append(
+            (
+                f"{prefix}/troubleshooting",
+                f"{instruction_set.dcc} troubleshooting",
+                "Adapter setup and troubleshooting guidance.",
+                instruction_set.troubleshooting,
+                "text/markdown",
+            )
+        )
+
+    registered: list[str] = []
+    for uri, name, description, content, mime in resources:
+        register_docs_resource(server, uri=uri, name=name, description=description, content=content, mime=mime)
+        registered.append(uri)
+    return registered
+
+
+def append_context_snapshot(
+    result: Mapping[str, Any],
+    snapshot: DccContextSnapshot | Mapping[str, Any] | Callable[[], DccContextSnapshot | Mapping[str, Any]],
+    *,
+    policy: ResponseShapePolicy | None = None,
+) -> dict[str, Any]:
+    """Return a copy of *result* with ``context.snapshot`` attached."""
+    shaped_policy = policy or ResponseShapePolicy(max_bytes=64_000, max_items=100)
+    raw_snapshot = snapshot() if callable(snapshot) else snapshot
+    snapshot_dict = raw_snapshot.to_dict() if isinstance(raw_snapshot, DccContextSnapshot) else dict(raw_snapshot)
+    shaped = shape_response(snapshot_dict, shaped_policy)
+    output = dict(result)
+    context = dict(output.get("context") or {})
+    context["snapshot"] = shaped["data"]
+    if shaped.get("truncated"):
+        context["snapshot_truncation"] = shaped["_meta"]["dcc.response_shape"]
+    output["context"] = context
+    return output
+
+
+def build_visual_feedback_context(
+    *,
+    resource: str,
+    width: int | None = None,
+    height: int | None = None,
+    feedback_type: str = "image",
+    policy: VisualFeedbackPolicy | None = None,
+) -> dict[str, Any]:
+    """Build the standard ``context.visual_feedback`` payload."""
+    visual_policy = policy or VisualFeedbackPolicy()
+    payload: dict[str, Any] = {
+        "type": feedback_type,
+        "resource": resource,
+        "format": visual_policy.format,
+        "mode": visual_policy.mode,
+        "max_size": visual_policy.max_size,
+    }
+    if width is not None:
+        payload["width"] = min(width, visual_policy.max_size)
+    if height is not None:
+        payload["height"] = min(height, visual_policy.max_size)
+    return {"visual_feedback": payload}
+
+
+def shape_response(data: Any, policy: ResponseShapePolicy | None = None) -> dict[str, Any]:
+    """Shape a potentially large payload and return truncation metadata."""
+    active_policy = policy or ResponseShapePolicy()
+    shaped, omitted = _shape_value(data, active_policy)
+    encoded = json.dumps(shaped, ensure_ascii=False, default=str)
+    byte_len = len(encoded.encode("utf-8"))
+    truncated = bool(omitted) or byte_len > active_policy.max_bytes
+    if byte_len > active_policy.max_bytes:
+        text = encoded.encode("utf-8")[: active_policy.max_bytes].decode("utf-8", errors="ignore")
+        shaped = {"truncated_json": text}
+        omitted.append({"reason": "max_bytes", "original_bytes": byte_len, "max_bytes": active_policy.max_bytes})
+    result = {"data": shaped, "truncated": truncated}
+    if truncated and active_policy.include_truncation_notice:
+        result["_meta"] = {
+            "dcc.response_shape": {
+                "truncated": True,
+                "omitted": omitted,
+                "next_query": "Request a narrower path, filter, or page to inspect omitted data.",
+            }
+        }
+    return result
+
+
+def register_dcc_api_docs(server: Any, index: DccApiDocIndex, *, uri_prefix: str | None = None) -> list[str]:
+    """Register a searchable API docs index as resource-backed Markdown/JSON."""
+    prefix = (uri_prefix or f"docs://adapter/{index.dcc}/api").rstrip("/")
+    manifest_uri = f"{prefix}/index"
+    register_docs_resource(
+        server,
+        uri=manifest_uri,
+        name=f"{index.dcc} API docs index",
+        description="Searchable adapter-provided DCC API documentation index.",
+        content=json.dumps(index.to_resource_manifest(), indent=2, sort_keys=True),
+        mime="application/json",
+    )
+    registered = [manifest_uri]
+    for entry in index.to_resource_manifest()["entries"]:
+        uri = f"{prefix}/{entry['symbol']}"
+        register_docs_resource(
+            server,
+            uri=uri,
+            name=entry["symbol"],
+            description=entry["summary"],
+            content=entry["body"] or entry["summary"],
+            mime="text/markdown",
+        )
+        registered.append(uri)
+    return registered
+
+
+def _shape_value(value: Any, policy: ResponseShapePolicy) -> tuple[Any, list[dict[str, Any]]]:
+    omitted: list[dict[str, Any]] = []
+    if isinstance(value, Mapping):
+        shaped = {}
+        for idx, (key, child) in enumerate(value.items()):
+            if idx >= policy.max_items:
+                omitted.append({"path": ".", "omitted_items": len(value) - policy.max_items})
+                break
+            shaped_child, child_omitted = _shape_value(child, policy)
+            shaped[key] = shaped_child
+            omitted.extend(child_omitted)
+        return shaped, omitted
+    if isinstance(value, (list, tuple)):
+        items = list(value)
+        shaped_items = []
+        for child in items[: policy.max_items]:
+            shaped_child, child_omitted = _shape_value(child, policy)
+            shaped_items.append(shaped_child)
+            omitted.extend(child_omitted)
+        if len(items) > policy.max_items:
+            omitted.append({"path": "[]", "omitted_items": len(items) - policy.max_items})
+        return shaped_items, omitted
+    if isinstance(value, str) and len(value.encode("utf-8")) > policy.max_bytes:
+        truncated = value.encode("utf-8")[: policy.max_bytes].decode("utf-8", errors="ignore")
+        omitted.append({"path": "$", "reason": "string_max_bytes"})
+        return truncated, omitted
+    return value, omitted

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -149,6 +149,7 @@ class DccServerBase:
         enable_file_logging: bool = True,
         enable_job_persistence: bool = True,
         enable_telemetry: bool = True,
+        snapshot_provider: Any | None = None,
     ) -> None:
         # Deferred: circular import — __init__.py imports DccServerBase from
         # this module, so we cannot import from dcc_mcp_core at module level.
@@ -242,6 +243,7 @@ class DccServerBase:
         # Lazy-initialised helpers
         self._hot_reloader: Any | None = None
         self._gateway_election: Any | None = None
+        self._snapshot_provider: Any | None = snapshot_provider
 
     def __getattr__(self, name: str) -> Any:
         """Lazily reconstruct collaborators for instances built via ``object.__new__``.
@@ -265,6 +267,26 @@ class DccServerBase:
             self.__dict__[name] = resolver
             return resolver
         raise AttributeError(name)
+
+    # ── adapter context helpers (#608, #609) ────────────────────────────────
+
+    def register_adapter_instructions(self, instruction_set: Any) -> list[str]:
+        """Register standard adapter instruction/capability resources."""
+        from dcc_mcp_core.adapter_context import register_adapter_instruction_resources
+
+        return register_adapter_instruction_resources(self._server, instruction_set)
+
+    def set_context_snapshot_provider(self, provider: Any | None) -> None:
+        """Set an optional callable used to append post-tool context snapshots."""
+        self._snapshot_provider = provider
+
+    def append_context_snapshot(self, result: dict[str, Any], *, policy: Any | None = None) -> dict[str, Any]:
+        """Attach the configured post-tool context snapshot to a result envelope."""
+        if self._snapshot_provider is None:
+            return dict(result)
+        from dcc_mcp_core.adapter_context import append_context_snapshot
+
+        return append_context_snapshot(result, self._snapshot_provider, policy=policy)
 
     @staticmethod
     def _context_metadata_from_env(dcc_name: str) -> dict[str, str]:

--- a/tests/test_adapter_context.py
+++ b/tests/test_adapter_context.py
@@ -1,0 +1,157 @@
+"""Tests for adapter context/resources/policy helpers (#608-#613)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import dcc_mcp_core
+from dcc_mcp_core import AdapterInstructionSet
+from dcc_mcp_core import DccApiDocEntry
+from dcc_mcp_core import DccApiDocIndex
+from dcc_mcp_core import DccContextSnapshot
+from dcc_mcp_core import DccToolsetProfile
+from dcc_mcp_core import ResponseShapePolicy
+from dcc_mcp_core import ToolsetProfileRegistry
+from dcc_mcp_core import VisualFeedbackPolicy
+from dcc_mcp_core import append_context_snapshot
+from dcc_mcp_core import build_visual_feedback_context
+from dcc_mcp_core import register_adapter_instruction_resources
+from dcc_mcp_core import register_dcc_api_docs
+from dcc_mcp_core import shape_response
+from dcc_mcp_core.server_base import DccServerBase
+
+
+class _FakeServer:
+    def __init__(self) -> None:
+        self.resources: dict[str, dict[str, Any]] = {}
+
+    def add_docs_resource(self, **kwargs: Any) -> None:
+        self.resources[kwargs["uri"]] = kwargs
+
+
+def test_adapter_context_symbols_exported() -> None:
+    for name in (
+        "AdapterInstructionSet",
+        "DccContextSnapshot",
+        "VisualFeedbackPolicy",
+        "ResponseShapePolicy",
+        "DccToolsetProfile",
+        "ToolsetProfileRegistry",
+        "DccApiDocEntry",
+        "DccApiDocIndex",
+        "register_adapter_instruction_resources",
+        "register_dcc_api_docs",
+    ):
+        assert hasattr(dcc_mcp_core, name)
+        assert name in dcc_mcp_core.__all__
+
+
+def test_register_adapter_instruction_resources() -> None:
+    server = _FakeServer()
+    uris = register_adapter_instruction_resources(
+        server,
+        AdapterInstructionSet(
+            dcc="maya",
+            instructions="Use screenshots after visual changes.",
+            capabilities={"screenshots": True},
+            troubleshooting="Check the Script Editor.",
+            adapter_version="1.2.3",
+        ),
+    )
+
+    assert uris == [
+        "docs://adapter/maya/instructions",
+        "docs://adapter/maya/capabilities",
+        "docs://adapter/maya/troubleshooting",
+    ]
+    assert server.resources["docs://adapter/maya/instructions"]["content"].startswith("Use screenshots")
+    capabilities = json.loads(server.resources["docs://adapter/maya/capabilities"]["content"])
+    assert capabilities["adapter_version"] == "1.2.3"
+    assert capabilities["capabilities"]["screenshots"] is True
+
+
+def test_append_context_snapshot_shapes_snapshot() -> None:
+    result = {"success": True, "message": "ok"}
+    snapshot = DccContextSnapshot(
+        dcc="photoshop",
+        document={"name": "hero.psd"},
+        selection={"kind": "layer"},
+        counts={"layers": 250},
+    )
+
+    enriched = append_context_snapshot(result, snapshot, policy=ResponseShapePolicy(max_items=3))
+
+    assert enriched["context"]["snapshot"]["dcc"] == "photoshop"
+    assert enriched["context"]["snapshot"]["document"]["name"] == "hero.psd"
+    assert result.get("context") is None
+
+
+def test_visual_feedback_context_clamps_dimensions() -> None:
+    payload = build_visual_feedback_context(
+        resource="output://preview.png",
+        width=1200,
+        height=600,
+        policy=VisualFeedbackPolicy(mode="after_mutation", max_size=800, format="png"),
+    )
+
+    feedback = payload["visual_feedback"]
+    assert feedback["resource"] == "output://preview.png"
+    assert feedback["width"] == 800
+    assert feedback["height"] == 600
+    assert feedback["mode"] == "after_mutation"
+
+
+def test_shape_response_truncates_lists_with_metadata() -> None:
+    shaped = shape_response({"objects": list(range(5))}, ResponseShapePolicy(max_items=3))
+
+    assert shaped["truncated"] is True
+    assert shaped["data"]["objects"] == [0, 1, 2]
+    assert shaped["_meta"]["dcc.response_shape"]["omitted"][0]["omitted_items"] == 2
+
+
+def test_toolset_profile_registry_tracks_active_profiles() -> None:
+    registry = ToolsetProfileRegistry(
+        [
+            DccToolsetProfile("modeling-basic", tools=("create_cube",), default=True),
+            DccToolsetProfile("rendering", tools=("render",)),
+        ]
+    )
+
+    assert [profile.name for profile in registry.active_profiles()] == ["modeling-basic"]
+    registry.activate("rendering")
+    names = [profile["name"] for profile in registry.list_profiles() if profile["active"]]
+    assert names == ["modeling-basic", "rendering"]
+    registry.deactivate("modeling-basic")
+    assert [profile.name for profile in registry.active_profiles()] == ["rendering"]
+
+
+def test_api_docs_index_search_and_resource_registration() -> None:
+    server = _FakeServer()
+    index = DccApiDocIndex(
+        "blender",
+        [
+            DccApiDocEntry("bpy.ops.mesh.primitive_cube_add", "Add a cube", tags=("mesh",)),
+            DccApiDocEntry("bpy.ops.wm.quit_blender", "Quit Blender", tags=("dangerous",)),
+        ],
+        version="4.0",
+    )
+
+    results = index.search("cube")
+    assert results[0]["symbol"] == "bpy.ops.mesh.primitive_cube_add"
+    uris = register_dcc_api_docs(server, index)
+    assert "docs://adapter/blender/api/index" in uris
+    assert "docs://adapter/blender/api/bpy.ops.mesh.primitive_cube_add" in uris
+
+
+def test_dcc_server_base_snapshot_and_instruction_wrappers() -> None:
+    server = object.__new__(DccServerBase)
+    fake = _FakeServer()
+    server._server = fake
+    server._snapshot_provider = lambda: DccContextSnapshot(dcc="maya", counts={"objects": 2})
+
+    enriched = server.append_context_snapshot({"success": True})
+    assert enriched["context"]["snapshot"]["counts"]["objects"] == 2
+
+    uris = server.register_adapter_instructions(AdapterInstructionSet(dcc="maya", instructions="Use tools/list first."))
+    assert uris == ["docs://adapter/maya/instructions", "docs://adapter/maya/capabilities"]


### PR DESCRIPTION
## Summary
- Add shared adapter contracts for standard instruction resources, post-tool context snapshots, visual feedback payloads, response shaping, toolset profiles, and searchable DCC API docs.
- Add `DccServerBase` wrappers for adapter instructions and context snapshot providers so embedded adapters can opt in without bespoke glue.
- Document the new adapter context API and cover the public exports with focused tests.

Closes #608.
Closes #609.
Closes #610.
Closes #611.
Closes #612.
Closes #613.

## Test plan
- `vx ruff check python/dcc_mcp_core/adapter_context.py python/dcc_mcp_core/__init__.py python/dcc_mcp_core/server_base.py tests/test_adapter_context.py`
- `vx ruff format --check python/dcc_mcp_core/adapter_context.py python/dcc_mcp_core/__init__.py python/dcc_mcp_core/server_base.py tests/test_adapter_context.py`
- `vx maturin develop --features python-bindings,ext-module,workflow,scheduler,prometheus,job-persist-sqlite`
- `.venv\\Scripts\\python.exe -m pytest tests/test_adapter_context.py -q`