### PR TITLE
feat: add bridge resilience strategies

### DIFF
--- a/docs/api/bridge.md
+++ b/docs/api/bridge.md
@@ -2,7 +2,10 @@
 
 Generic WebSocket bridge for non-Python DCCs. Implements the server-side of the dcc-mcp-core WebSocket JSON-RPC 2.0 bridge protocol.
 
-**Exported symbols:** `DccBridge`, `BridgeError`, `BridgeConnectionError`, `BridgeTimeoutError`, `BridgeRpcError`
+**Exported symbols:** `DccBridge`, `BridgeError`, `BridgeConnectionError`,
+`BridgeTimeoutError`, `BridgeRpcError`, `BridgeRetryPolicy`,
+`BridgeTransportStrategy`, `BridgeFallbackClient`, `ReverseBridgeRequest`,
+`ReverseBridgeSession`
 
 ## DccBridge
 
@@ -50,3 +53,50 @@ with DccBridge(port=9001) as bridge:
 | `BridgeConnectionError` | `BridgeError` | DCC plugin not connected or connection lost |
 | `BridgeTimeoutError` | `BridgeError` | Call timed out |
 | `BridgeRpcError` | `BridgeError` | DCC plugin returned JSON-RPC error; attributes: `.code`, `.message`, `.data` |
+
+## Resilience And Fallback
+
+Adapters with multiple bridge paths can wrap them in a fallback client:
+
+```python
+from dcc_mcp_core import BridgeFallbackClient, BridgeRetryPolicy, BridgeTransportStrategy
+
+class WebSocketTransport(BridgeTransportStrategy):
+    name = "websocket"
+    def connect(self): ...
+    def disconnect(self): ...
+    def is_connected(self): ...
+    def call(self, method, **params): ...
+
+client = BridgeFallbackClient(
+    [WebSocketTransport(), NamedPipeTransport()],
+    retry_policy=BridgeRetryPolicy(attempts=3, initial_delay_secs=0.1),
+)
+result = client.call("scene.info")
+```
+
+`BridgeRetryPolicy` centralizes attempts and exponential backoff so DCC
+adapters do not each invent slightly different retry loops.
+
+## Reverse Bridge Sessions
+
+Some plugin runtimes cannot host a listener or keep inbound sockets open. For
+those cases, the host can enqueue work and let the plugin poll:
+
+```python
+from dcc_mcp_core import ReverseBridgeSession
+
+session = ReverseBridgeSession(timeout=30)
+
+# Host side
+result = session.call("ps.document.info", include_layers=True)
+
+# Plugin side
+request = session.next_request(timeout=1.0)
+if request is not None:
+    response = run_in_host(request.method, **request.params)
+    session.submit_response(request.id, result=response)
+```
+
+The request envelope can be serialized with `request.to_jsonrpc()` when the
+polling transport is HTTP, a named pipe, or an application-specific queue.

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -333,9 +333,14 @@ from dcc_mcp_core.batch import batch_dispatch
 # Pure-Python DCC adapter base classes (no _core dependency)
 from dcc_mcp_core.bridge import BridgeConnectionError
 from dcc_mcp_core.bridge import BridgeError
+from dcc_mcp_core.bridge import BridgeFallbackClient
+from dcc_mcp_core.bridge import BridgeRetryPolicy
 from dcc_mcp_core.bridge import BridgeRpcError
 from dcc_mcp_core.bridge import BridgeTimeoutError
+from dcc_mcp_core.bridge import BridgeTransportStrategy
 from dcc_mcp_core.bridge import DccBridge
+from dcc_mcp_core.bridge import ReverseBridgeRequest
+from dcc_mcp_core.bridge import ReverseBridgeSession
 from dcc_mcp_core.cancellation import CancelledError
 from dcc_mcp_core.cancellation import CancelToken
 from dcc_mcp_core.cancellation import JobHandle
@@ -518,9 +523,12 @@ __all__ = [
     "BridgeConnectionError",
     "BridgeContext",
     "BridgeError",
+    "BridgeFallbackClient",
     "BridgeRegistry",
+    "BridgeRetryPolicy",
     "BridgeRpcError",
     "BridgeTimeoutError",
+    "BridgeTransportStrategy",
     "CancelToken",
     "CancelledError",
     "CaptureBackendKind",
@@ -593,6 +601,8 @@ __all__ = [
     "ResourceDefinition",
     "ResourceTemplateDefinition",
     "RetryPolicy",
+    "ReverseBridgeRequest",
+    "ReverseBridgeSession",
     "RichContent",
     "RichContentKind",
     "SandboxContext",

--- a/python/dcc_mcp_core/bridge.py
+++ b/python/dcc_mcp_core/bridge.py
@@ -29,9 +29,15 @@ from __future__ import annotations
 
 import asyncio
 from concurrent.futures import Future
+from dataclasses import dataclass
 import logging
+import queue
 import threading
+import time
 from typing import Any
+from typing import Callable
+from typing import Iterable
+from typing import Mapping
 import uuid
 
 from dcc_mcp_core import json_dumps
@@ -97,6 +103,235 @@ INVALID_PARAMS = -32602
 INTERNAL_ERROR = -32603
 NO_ACTIVE_DOCUMENT = -32001
 DCC_ERROR = -32000
+
+
+__all__ = [
+    "BridgeConnectionError",
+    "BridgeError",
+    "BridgeFallbackClient",
+    "BridgeRetryPolicy",
+    "BridgeRpcError",
+    "BridgeTimeoutError",
+    "BridgeTransportStrategy",
+    "DccBridge",
+    "ReverseBridgeRequest",
+    "ReverseBridgeSession",
+]
+
+
+@dataclass(frozen=True)
+class BridgeRetryPolicy:
+    """Reusable retry/backoff policy for bridge connection attempts."""
+
+    attempts: int = 3
+    initial_delay_secs: float = 0.1
+    max_delay_secs: float = 2.0
+    multiplier: float = 2.0
+    retry_on: tuple[type[BaseException], ...] = (BridgeConnectionError, BridgeTimeoutError, OSError)
+
+    def __post_init__(self) -> None:
+        if self.attempts < 1:
+            raise ValueError("attempts must be >= 1")
+        if self.initial_delay_secs < 0:
+            raise ValueError("initial_delay_secs must be >= 0")
+        if self.max_delay_secs < self.initial_delay_secs:
+            raise ValueError("max_delay_secs must be >= initial_delay_secs")
+        if self.multiplier < 1:
+            raise ValueError("multiplier must be >= 1")
+
+    def delays(self) -> list[float]:
+        """Return delays between attempts."""
+        delay = self.initial_delay_secs
+        values: list[float] = []
+        for _ in range(max(0, self.attempts - 1)):
+            values.append(min(delay, self.max_delay_secs))
+            delay *= self.multiplier
+        return values
+
+    def run(self, operation: Callable[[], Any]) -> Any:
+        """Run *operation* with retry/backoff."""
+        last_error: BaseException | None = None
+        delays = self.delays()
+        for attempt in range(self.attempts):
+            try:
+                return operation()
+            except self.retry_on as exc:
+                last_error = exc
+                if attempt >= self.attempts - 1:
+                    break
+                time.sleep(delays[attempt])
+        if last_error is not None:
+            raise last_error
+        raise BridgeConnectionError("Bridge retry operation failed without an exception.")
+
+
+class BridgeTransportStrategy:
+    """Duck-typed transport strategy for DCC bridge calls."""
+
+    name = "custom"
+
+    def connect(self) -> None:
+        """Open the transport connection."""
+        raise NotImplementedError
+
+    def disconnect(self) -> None:
+        """Close the transport connection."""
+        raise NotImplementedError
+
+    def is_connected(self) -> bool:
+        """Return whether this transport can currently serve calls."""
+        raise NotImplementedError
+
+    def call(self, method: str, **params: Any) -> Any:
+        """Invoke a bridge method."""
+        raise NotImplementedError
+
+
+class BridgeFallbackClient:
+    """Try multiple bridge transports in order and fail over on connection loss."""
+
+    def __init__(
+        self,
+        strategies: Iterable[BridgeTransportStrategy],
+        *,
+        retry_policy: BridgeRetryPolicy | None = None,
+    ) -> None:
+        self._strategies = list(strategies)
+        if not self._strategies:
+            raise ValueError("at least one bridge strategy is required")
+        self._retry_policy = retry_policy or BridgeRetryPolicy()
+        self._active: BridgeTransportStrategy | None = None
+
+    @property
+    def active_strategy(self) -> BridgeTransportStrategy | None:
+        return self._active
+
+    def connect(self) -> BridgeTransportStrategy:
+        return self._connect_candidates(self._strategies)
+
+    def _connect_candidates(self, strategies: Iterable[BridgeTransportStrategy]) -> BridgeTransportStrategy:
+        errors: list[str] = []
+        for strategy in strategies:
+            try:
+                self._retry_policy.run(strategy.connect)
+                if strategy.is_connected():
+                    self._active = strategy
+                    return strategy
+            except Exception as exc:
+                errors.append(f"{strategy.name}: {exc}")
+        raise BridgeConnectionError("No bridge transport strategy connected: " + "; ".join(errors))
+
+    def disconnect(self) -> None:
+        for strategy in self._strategies:
+            try:
+                strategy.disconnect()
+            except Exception:
+                logger.debug("Bridge strategy disconnect failed: %s", strategy.name, exc_info=True)
+        self._active = None
+
+    def call(self, method: str, **params: Any) -> Any:
+        if self._active is None or not self._active.is_connected():
+            self.connect()
+        assert self._active is not None
+        try:
+            return self._active.call(method, **params)
+        except BridgeConnectionError:
+            failed = self._active
+            self._active = None
+            if failed in self._strategies:
+                failed_idx = self._strategies.index(failed)
+                candidates = self._strategies[failed_idx + 1 :] + self._strategies[:failed_idx]
+            else:
+                candidates = self._strategies
+            self._connect_candidates(candidates)
+            assert self._active is not None
+            return self._active.call(method, **params)
+
+
+@dataclass(frozen=True)
+class ReverseBridgeRequest:
+    """Request envelope consumed by a reverse-connection DCC plugin."""
+
+    id: int
+    method: str
+    params: dict[str, Any]
+
+    def to_jsonrpc(self) -> dict[str, Any]:
+        message: dict[str, Any] = {"jsonrpc": "2.0", "id": self.id, "method": self.method}
+        if self.params:
+            message["params"] = dict(self.params)
+        return message
+
+
+class ReverseBridgeSession:
+    """In-memory reverse bridge for plugins that poll for host work.
+
+    The host calls :meth:`call`, while a constrained DCC plugin repeatedly calls
+    :meth:`next_request` and answers with :meth:`submit_response`.
+    """
+
+    def __init__(self, *, timeout: float = 30.0) -> None:
+        self._timeout = timeout
+        self._queue: queue.Queue[ReverseBridgeRequest] = queue.Queue()
+        self._pending: dict[int, Future] = {}
+        self._pending_lock = threading.Lock()
+        self._next_id = 0
+        self._id_lock = threading.Lock()
+        self._closed = False
+
+    def call(self, method: str, **params: Any) -> Any:
+        if self._closed:
+            raise BridgeConnectionError("Reverse bridge session is closed.")
+        request = ReverseBridgeRequest(id=self._next_request_id(), method=method, params=dict(params))
+        future: Future = Future()
+        with self._pending_lock:
+            self._pending[request.id] = future
+        self._queue.put(request)
+        try:
+            return future.result(timeout=self._timeout)
+        except TimeoutError as exc:
+            with self._pending_lock:
+                self._pending.pop(request.id, None)
+            raise BridgeTimeoutError(f"Method '{method}' (id={request.id}) timed out after {self._timeout}s.") from exc
+
+    def next_request(self, timeout: float | None = None) -> ReverseBridgeRequest | None:
+        if self._closed:
+            return None
+        try:
+            return self._queue.get(timeout=self._timeout if timeout is None else timeout)
+        except queue.Empty:
+            return None
+
+    def submit_response(self, request_id: int, *, result: Any = None, error: Mapping[str, Any] | None = None) -> bool:
+        with self._pending_lock:
+            future = self._pending.pop(request_id, None)
+        if future is None or future.done():
+            return False
+        if error is not None:
+            future.set_exception(
+                BridgeRpcError(
+                    code=int(error.get("code", INTERNAL_ERROR)),
+                    message=str(error.get("message", "unknown error")),
+                    data=error.get("data"),
+                )
+            )
+        else:
+            future.set_result(result)
+        return True
+
+    def close(self, reason: str = "Reverse bridge session closed.") -> None:
+        self._closed = True
+        with self._pending_lock:
+            for future in self._pending.values():
+                if not future.done():
+                    future.set_exception(BridgeConnectionError(reason))
+            self._pending.clear()
+
+    def _next_request_id(self) -> int:
+        with self._id_lock:
+            request_id = self._next_id
+            self._next_id += 1
+        return request_id
 
 
 # ── DccBridge ─────────────────────────────────────────────────────────────────

--- a/tests/test_bridge_resilience.py
+++ b/tests/test_bridge_resilience.py
@@ -1,0 +1,160 @@
+"""Tests for bridge resilience, fallback, and reverse-session helpers."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+import dcc_mcp_core
+from dcc_mcp_core import BridgeConnectionError
+from dcc_mcp_core import BridgeFallbackClient
+from dcc_mcp_core import BridgeRetryPolicy
+from dcc_mcp_core import BridgeRpcError
+from dcc_mcp_core import BridgeTransportStrategy
+from dcc_mcp_core import ReverseBridgeSession
+
+
+class _Strategy(BridgeTransportStrategy):
+    def __init__(self, name: str, *, connect_failures: int = 0, call_failure: bool = False) -> None:
+        self.name = name
+        self.connect_failures = connect_failures
+        self.call_failure = call_failure
+        self.connect_attempts = 0
+        self.connected = False
+        self.calls: list[tuple[str, dict]] = []
+
+    def connect(self) -> None:
+        self.connect_attempts += 1
+        if self.connect_failures > 0:
+            self.connect_failures -= 1
+            raise BridgeConnectionError(f"{self.name} unavailable")
+        self.connected = True
+
+    def disconnect(self) -> None:
+        self.connected = False
+
+    def is_connected(self) -> bool:
+        return self.connected
+
+    def call(self, method: str, **params):
+        self.calls.append((method, params))
+        if self.call_failure:
+            self.connected = False
+            self.call_failure = False
+            raise BridgeConnectionError("lost connection")
+        return {"strategy": self.name, "method": method, "params": params}
+
+
+def test_bridge_resilience_symbols_exported() -> None:
+    for name in (
+        "BridgeFallbackClient",
+        "BridgeRetryPolicy",
+        "BridgeTransportStrategy",
+        "ReverseBridgeRequest",
+        "ReverseBridgeSession",
+    ):
+        assert hasattr(dcc_mcp_core, name)
+        assert name in dcc_mcp_core.__all__
+
+
+def test_retry_policy_retries_operation() -> None:
+    attempts = {"count": 0}
+    policy = BridgeRetryPolicy(attempts=3, initial_delay_secs=0)
+
+    def operation():
+        attempts["count"] += 1
+        if attempts["count"] < 3:
+            raise BridgeConnectionError("not yet")
+        return "ok"
+
+    assert policy.run(operation) == "ok"
+    assert attempts["count"] == 3
+
+
+def test_fallback_client_uses_next_strategy_after_failure() -> None:
+    primary = _Strategy("primary", connect_failures=1)
+    secondary = _Strategy("secondary")
+    client = BridgeFallbackClient([primary, secondary], retry_policy=BridgeRetryPolicy(attempts=1))
+
+    active = client.connect()
+
+    assert active is secondary
+    assert client.call("scene.info")["strategy"] == "secondary"
+
+
+def test_fallback_client_reconnects_when_active_call_loses_connection() -> None:
+    primary = _Strategy("primary", call_failure=True)
+    secondary = _Strategy("secondary")
+    client = BridgeFallbackClient([primary, secondary], retry_policy=BridgeRetryPolicy(attempts=1))
+    client.connect()
+
+    result = client.call("scene.info", verbose=True)
+
+    assert result["strategy"] == "secondary"
+    assert result["params"] == {"verbose": True}
+
+
+def test_reverse_bridge_session_round_trips_request() -> None:
+    session = ReverseBridgeSession(timeout=1.0)
+    results: list[object] = []
+
+    def host_call() -> None:
+        results.append(session.call("ps.document.info", include_layers=True))
+
+    thread = threading.Thread(target=host_call)
+    thread.start()
+
+    request = session.next_request(timeout=1.0)
+    assert request is not None
+    assert request.to_jsonrpc()["method"] == "ps.document.info"
+    assert request.to_jsonrpc()["params"] == {"include_layers": True}
+    assert session.submit_response(request.id, result={"name": "hero.psd"}) is True
+
+    thread.join(timeout=1.0)
+    assert results == [{"name": "hero.psd"}]
+
+
+def test_reverse_bridge_session_maps_rpc_errors() -> None:
+    session = ReverseBridgeSession(timeout=1.0)
+    errors: list[BaseException] = []
+
+    def host_call() -> None:
+        try:
+            session.call("danger")
+        except BaseException as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=host_call)
+    thread.start()
+    request = session.next_request(timeout=1.0)
+    assert request is not None
+    assert session.submit_response(request.id, error={"code": -32000, "message": "blocked"})
+    thread.join(timeout=1.0)
+
+    assert isinstance(errors[0], BridgeRpcError)
+    assert str(errors[0]) == "[-32000] blocked"
+
+
+def test_reverse_bridge_session_close_fails_pending_calls() -> None:
+    session = ReverseBridgeSession(timeout=1.0)
+    errors: list[BaseException] = []
+
+    def host_call() -> None:
+        try:
+            session.call("long.running")
+        except BaseException as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=host_call)
+    thread.start()
+    assert session.next_request(timeout=1.0) is not None
+    session.close("shutdown")
+    thread.join(timeout=1.0)
+
+    assert isinstance(errors[0], BridgeConnectionError)
+
+
+def test_retry_policy_validates_config() -> None:
+    with pytest.raises(ValueError, match="attempts"):
+        BridgeRetryPolicy(attempts=0)


### PR DESCRIPTION
## Summary
- Add `BridgeRetryPolicy` and `BridgeFallbackClient` so adapters can share retry/backoff and ordered transport fallback behavior.
- Add `ReverseBridgeSession` / `ReverseBridgeRequest` for constrained plugin runtimes that need to poll host work and submit responses.
- Document the new bridge patterns and cover retry, failover, reverse responses, errors, and close behavior with tests.

Closes #607.
Closes #614.
Closes #617.

## Test plan
- `vx ruff check python/dcc_mcp_core/bridge.py python/dcc_mcp_core/__init__.py tests/test_bridge_resilience.py`
- `vx ruff format --check python/dcc_mcp_core/bridge.py python/dcc_mcp_core/__init__.py tests/test_bridge_resilience.py`
- `vx maturin develop --features python-bindings,ext-module,workflow,scheduler,prometheus,job-persist-sqlite`
- `.venv\\Scripts\\python.exe -m pytest tests/test_bridge_resilience.py -q`