### PR TITLE
feat: add structured recipe packs

### DIFF
--- a/docs/api/recipes.md
+++ b/docs/api/recipes.md
@@ -1,8 +1,8 @@
 # Recipes API
 
-Recipes system for dcc-mcp-core skills (issue #428). Formalizes the `metadata.dcc-mcp.recipes` sibling-file key per the #356 sibling-file pattern.
+Recipes system for dcc-mcp-core skills (issues #428, #616). Formalizes the `metadata.dcc-mcp.recipes` sibling-file key per the #356 sibling-file pattern and supports both legacy Markdown anchors and structured YAML recipe packs.
 
-**Exported symbols:** `get_recipe_content`, `get_recipes_path`, `parse_recipe_anchors`, `register_recipes_tools`
+**Exported symbols:** `RecipeDefinition`, `get_recipe_content`, `get_recipes_path`, `get_recipes_paths`, `parse_recipe_anchors`, `load_recipe_pack`, `list_recipe_entries`, `find_recipe_entry`, `validate_recipe_inputs`, `register_recipes_tools`
 
 ## get_recipes_path
 
@@ -11,6 +11,14 @@ get_recipes_path(metadata: Any) -> str | None
 ```
 
 Extract the recipes file path from a `SkillMetadata` object. Supports both flat (`"dcc-mcp.recipes"`) and nested (`"dcc-mcp": {"recipes": ...}`) forms. Returns absolute path resolved relative to skill's `skill_path`.
+
+## get_recipes_paths
+
+```python
+get_recipes_paths(metadata: Any) -> list[str]
+```
+
+Extract all recipe sibling file paths. The metadata value may be a filename, glob string, or list of filenames/globs.
 
 ## parse_recipe_anchors
 
@@ -28,13 +36,41 @@ get_recipe_content(recipes_path: str, anchor: str) -> str | None
 
 Return the Markdown content of a specific anchor section (from `## <anchor>` up to the next `##` heading).
 
+## Structured Recipe Packs
+
+YAML recipe packs use a `recipes:` list:
+
+```yaml
+recipes:
+  - name: build_pbr_material
+    dcc: maya
+    description: Build a PBR material network.
+    inputs_schema:
+      type: object
+      required: [material_name]
+      properties:
+        material_name:
+          type: string
+    steps:
+      - tool: maya_materials__create
+        arguments:
+          name: ${material_name}
+    output_contract: material_graph
+```
+
+```python
+load_recipe_pack(path) -> list[RecipeDefinition]
+list_recipe_entries(skill_metadata) -> list[dict]
+validate_recipe_inputs(recipe, inputs) -> list[str]
+```
+
 ## register_recipes_tools
 
 ```python
 register_recipes_tools(server, *, skills: list, dcc_name="dcc") -> None
 ```
 
-Register `recipes__list` and `recipes__get` MCP tools on `server`. Call **before** `server.start()`.
+Register `recipes__list`, `recipes__search`, `recipes__get`, `recipes__validate`, and `recipes__apply` MCP tools on `server`. Call **before** `server.start()`.
 
 ```python
 from dcc_mcp_core import create_skill_server, McpHttpConfig, scan_and_load

--- a/llms.txt
+++ b/llms.txt
@@ -42,7 +42,7 @@
 | Agent-facing docs:// MCP resources (issue #435) | `register_docs_server(server)` — serves `docs://output-format/*` and `docs://skill-authoring/*` resources; agents fetch only specs they need |
 | Agent feedback / rationale (issues #433, #434) | `register_feedback_tool(server)` / `extract_rationale(params)` / `make_rationale_meta(text)` — `dcc_feedback__report` tool + `_meta.dcc.rationale` extraction |
 | Runtime DCC namespace introspection (issue #426) | `register_introspect_tools(server)` — `dcc_introspect__list_module`, `dcc_introspect__signature`, `dcc_introspect__search`, `dcc_introspect__eval` |
-| Skill recipe anchors (issue #428) | `register_recipes_tools(server, skills=...)` — `recipes__list` and `recipes__get` tools for thin-harness skill recipe lookup |
+| Skill/domain recipes (issues #428, #616) | `register_recipes_tools(server, skills=...)` — `recipes__list/search/get/validate/apply` tools for Markdown anchors and structured YAML recipe packs |
 | YAML declarative workflows (issue #439) | `WorkflowYaml` + `load_workflow_yaml(path)` + `register_workflow_yaml_tools(server)` — task vs step semantics for multi-step DCC workflows |
 | WebSocket bridge for non-Python DCCs | `DccBridge(host, port)` — WebSocket JSON-RPC 2.0 bridge; `.call(method, **params)` for synchronous RPC to DCC plugin |
 | Gateway failover election | `DccGatewayElection(dcc_name, server)` — automatic gateway failover via first-wins socket election |
@@ -481,9 +481,13 @@ tools:
 ### Recipes (`dcc_mcp_core.recipes`)
 
 - `get_recipes_path(metadata) -> str | None` — extract recipes file path from SkillMetadata
+- `get_recipes_paths(metadata) -> list[str]` — extract filename/glob/list recipe sibling files
 - `parse_recipe_anchors(recipes_path) -> list[str]` — list anchor names from a RECIPES.md file
 - `get_recipe_content(recipes_path, anchor) -> str | None` — fetch content of a specific anchor section
-- `register_recipes_tools(server, *, skills, dcc_name="dcc")` — register `recipes__list` and `recipes__get` tools
+- `load_recipe_pack(path) -> list[RecipeDefinition]` — load YAML `recipes:` packs with inputs schema, steps, output contract, and provenance (#616)
+- `list_recipe_entries(skill_metadata) -> list[dict]` / `find_recipe_entry(skill_metadata, name)` — merge Markdown anchors and structured recipe pack entries
+- `validate_recipe_inputs(recipe, inputs) -> list[str]` — zero-dep required/type validation for recipe input schemas
+- `register_recipes_tools(server, *, skills, dcc_name="dcc")` — register `recipes__list/search/get/validate/apply` tools
 
 ### YAML Workflows (`dcc_mcp_core.workflow_yaml`)
 

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -435,10 +435,16 @@ from dcc_mcp_core.plugin_manifest import build_plugin_manifest
 from dcc_mcp_core.plugin_manifest import export_plugin_manifest
 
 # Recipes system: metadata.dcc-mcp.recipes + recipes__list/get tools (issue #428)
+from dcc_mcp_core.recipes import RecipeDefinition
+from dcc_mcp_core.recipes import find_recipe_entry
 from dcc_mcp_core.recipes import get_recipe_content
 from dcc_mcp_core.recipes import get_recipes_path
+from dcc_mcp_core.recipes import get_recipes_paths
+from dcc_mcp_core.recipes import list_recipe_entries
+from dcc_mcp_core.recipes import load_recipe_pack
 from dcc_mcp_core.recipes import parse_recipe_anchors
 from dcc_mcp_core.recipes import register_recipes_tools
+from dcc_mcp_core.recipes import validate_recipe_inputs
 
 # MCP Apps rich content (issue #409)
 from dcc_mcp_core.rich_content import RichContent
@@ -621,6 +627,7 @@ __all__ = [
     "PySharedSceneBuffer",
     "PyStandaloneDispatcher",
     "RateLimitMiddleware",
+    "RecipeDefinition",
     "RecordingGuard",
     "RenderOutput",
     "ResourceAnnotations",
@@ -733,6 +740,7 @@ __all__ = [
     "expand_transitive_dependencies",
     "export_plugin_manifest",
     "extract_rationale",
+    "find_recipe_entry",
     "flush_logs",
     "from_exception",
     "gc_orphans",
@@ -753,6 +761,7 @@ __all__ = [
     "get_platform_dir",
     "get_recipe_content",
     "get_recipes_path",
+    "get_recipes_paths",
     "get_server_instance",
     "get_skill_feedback",
     "get_skill_paths_from_env",
@@ -775,6 +784,8 @@ __all__ = [
     "json_dumps",
     "json_loads",
     "list_checkpoints",
+    "list_recipe_entries",
+    "load_recipe_pack",
     "load_workflow_yaml",
     "make_rationale_meta",
     "make_start_stop",
@@ -837,6 +848,7 @@ __all__ = [
     "validate_action_result",
     "validate_bearer_token",
     "validate_dependencies",
+    "validate_recipe_inputs",
     "validate_skill",
     "validate_tool_name",
     "verify_hub_signature_256",

--- a/python/dcc_mcp_core/recipes.py
+++ b/python/dcc_mcp_core/recipes.py
@@ -62,12 +62,15 @@ Usage::
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+import json
 import logging
 from pathlib import Path
 import re
 from typing import Any
 
 from dcc_mcp_core import json_loads
+from dcc_mcp_core import yaml_loads
 from dcc_mcp_core._tool_registration import ToolSpec
 from dcc_mcp_core._tool_registration import register_tools
 from dcc_mcp_core.constants import CATEGORY_RECIPES
@@ -78,6 +81,33 @@ from dcc_mcp_core.result_envelope import ToolResult
 logger = logging.getLogger(__name__)
 
 _ANCHOR_PATTERN = re.compile(r"^##\s+(\S.+)$", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class RecipeDefinition:
+    """Structured domain recipe loaded from a YAML recipe pack."""
+
+    name: str
+    dcc: str = ""
+    description: str = ""
+    inputs_schema: dict[str, Any] | None = None
+    steps: list[Any] | None = None
+    output_contract: str | dict[str, Any] | None = None
+    toolset_profiles: list[str] | None = None
+    provenance: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable recipe payload."""
+        return {
+            "name": self.name,
+            "dcc": self.dcc,
+            "description": self.description,
+            "inputs_schema": self.inputs_schema or {},
+            "steps": self.steps or [],
+            "output_contract": self.output_contract,
+            "toolset_profiles": self.toolset_profiles or [],
+            "provenance": self.provenance or {},
+        }
 
 
 # ── Core parsing utilities ─────────────────────────────────────────────────
@@ -106,6 +136,18 @@ def get_recipes_path(metadata: Any) -> str | None:
         if the skill does not declare a recipes file.
 
     """
+    paths = get_recipes_paths(metadata)
+    return paths[0] if paths else None
+
+
+def get_recipes_paths(metadata: Any) -> list[str]:
+    """Extract all recipe sibling file paths from a ``SkillMetadata`` object.
+
+    ``metadata.dcc-mcp.recipes`` may be a filename, glob string, or list of
+    filenames/globs. Relative paths are resolved under ``skill_path`` when
+    present. Missing globs are preserved as the raw path so callers can report
+    useful diagnostics instead of silently hiding configuration mistakes.
+    """
     meta_dict: dict[str, Any] = getattr(metadata, "metadata", {}) or {}
 
     # Flat form: "dcc-mcp.recipes": "path"
@@ -118,13 +160,36 @@ def get_recipes_path(metadata: Any) -> str | None:
             recipes_rel = dcc_mcp_nested.get("recipes")
 
     if not recipes_rel:
-        return None
+        return []
 
-    # Resolve relative to skill_path if possible
+    raw_values = recipes_rel if isinstance(recipes_rel, list) else [recipes_rel]
     skill_path = getattr(metadata, "skill_path", None)
-    if skill_path and not Path(recipes_rel).is_absolute():
-        return str(Path(skill_path) / recipes_rel)
-    return str(recipes_rel)
+    base = Path(skill_path) if skill_path else None
+    paths: list[str] = []
+    for raw in raw_values:
+        if not raw:
+            continue
+        raw_path = Path(str(raw))
+        candidate = raw_path if raw_path.is_absolute() or base is None else base / raw_path
+
+        if any(ch in str(raw_path) for ch in "*?[]"):
+            matches = _expand_recipe_glob(raw_path, base)
+            paths.extend(str(p) for p in matches)
+            if not matches:
+                paths.append(str(candidate))
+        else:
+            paths.append(str(raw) if base is None and not raw_path.is_absolute() else str(candidate))
+
+    return paths
+
+
+def _expand_recipe_glob(raw_path: Path, base: Path | None) -> list[Path]:
+    """Expand a recipe glob with pathlib so linted code stays path-safe."""
+    if raw_path.is_absolute():
+        root = Path(raw_path.anchor)
+        pattern = str(raw_path.relative_to(root))
+        return sorted(root.glob(pattern))
+    return sorted((base or Path.cwd()).glob(str(raw_path)))
 
 
 def parse_recipe_anchors(recipes_path: str) -> list[str]:
@@ -205,6 +270,152 @@ def get_recipe_content(recipes_path: str, anchor: str) -> str | None:
     return "".join(lines[start_idx:end_idx]).rstrip()
 
 
+def load_recipe_pack(recipes_path: str, *, skill_name: str = "") -> list[RecipeDefinition]:
+    """Load structured recipe definitions from a YAML recipe pack.
+
+    Recipe packs use the convention proposed in issue #616::
+
+        recipes:
+          - name: build_pbr_material
+            dcc: substance-designer
+            inputs_schema: {...}
+            steps: [...]
+            output_contract: material_graph
+
+    Non-YAML files and malformed packs return ``[]`` so legacy
+    ``RECIPES.md`` anchors continue to be handled by the Markdown helpers.
+    """
+    path = Path(recipes_path)
+    if path.suffix.lower() not in {".yaml", ".yml"} or not path.is_file():
+        return []
+    try:
+        raw = yaml_loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        logger.warning("load_recipe_pack: could not parse %s: %s", path, exc)
+        return []
+    recipes = raw.get("recipes") if isinstance(raw, dict) else None
+    if not isinstance(recipes, list):
+        return []
+
+    loaded: list[RecipeDefinition] = []
+    for item in recipes:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name") or "").strip()
+        if not name:
+            continue
+        profiles = item.get("toolset_profiles") or item.get("toolset_profile") or []
+        if isinstance(profiles, str):
+            profiles = [profiles]
+        loaded.append(
+            RecipeDefinition(
+                name=name,
+                dcc=str(item.get("dcc") or ""),
+                description=str(item.get("description") or ""),
+                inputs_schema=item.get("inputs_schema") if isinstance(item.get("inputs_schema"), dict) else {},
+                steps=item.get("steps") if isinstance(item.get("steps"), list) else [],
+                output_contract=item.get("output_contract"),
+                toolset_profiles=[str(p) for p in profiles] if isinstance(profiles, list) else [],
+                provenance={
+                    "skill": skill_name,
+                    "path": str(path),
+                    "format": "recipe-pack",
+                },
+            ),
+        )
+    return loaded
+
+
+def list_recipe_entries(skill_md: Any) -> list[dict[str, Any]]:
+    """Return Markdown anchors and structured recipe pack entries for a skill."""
+    entries: list[dict[str, Any]] = []
+    skill_name = str(getattr(skill_md, "name", "") or "")
+    for rp in get_recipes_paths(skill_md):
+        pack = load_recipe_pack(rp, skill_name=skill_name)
+        if pack:
+            entries.extend(recipe.to_dict() for recipe in pack)
+            continue
+        for anchor in parse_recipe_anchors(rp):
+            entries.append(
+                {
+                    "name": anchor,
+                    "description": "",
+                    "inputs_schema": {},
+                    "steps": [],
+                    "output_contract": "markdown_recipe",
+                    "toolset_profiles": [],
+                    "provenance": {
+                        "skill": skill_name,
+                        "path": rp,
+                        "format": "markdown-anchor",
+                    },
+                },
+            )
+    return entries
+
+
+def find_recipe_entry(skill_md: Any, recipe_name: str) -> dict[str, Any] | None:
+    """Find a structured recipe entry or Markdown anchor by name."""
+    for entry in list_recipe_entries(skill_md):
+        if entry["name"] == recipe_name:
+            return entry
+    return None
+
+
+def validate_recipe_inputs(recipe: dict[str, Any], inputs: dict[str, Any]) -> list[str]:
+    """Validate inputs against the recipe's JSON-schema-like input shape.
+
+    This intentionally implements a conservative subset (`required`,
+    `properties`, and primitive `type`) so recipe packs remain zero-dep and
+    useful even before adapters wire richer validation.
+    """
+    schema = recipe.get("inputs_schema") or {}
+    if not isinstance(schema, dict):
+        return []
+    errors: list[str] = []
+    required = schema.get("required") or []
+    if isinstance(required, list):
+        for name in required:
+            if name not in inputs:
+                errors.append(f"Missing required input: {name}")
+
+    properties = schema.get("properties") or {}
+    if not isinstance(properties, dict):
+        return errors
+    for name, spec in properties.items():
+        if name not in inputs or not isinstance(spec, dict):
+            continue
+        expected = spec.get("type")
+        if expected and not _matches_json_type(inputs[name], expected):
+            errors.append(f"Input '{name}' expected {expected}, got {type(inputs[name]).__name__}")
+    return errors
+
+
+def _matches_json_type(value: Any, expected: Any) -> bool:
+    expected_types = expected if isinstance(expected, list) else [expected]
+    for item in expected_types:
+        if item == "string" and isinstance(value, str):
+            return True
+        if item == "number" and isinstance(value, int | float) and not isinstance(value, bool):
+            return True
+        if item == "integer" and isinstance(value, int) and not isinstance(value, bool):
+            return True
+        if item == "boolean" and isinstance(value, bool):
+            return True
+        if item == "array" and isinstance(value, list):
+            return True
+        if item == "object" and isinstance(value, dict):
+            return True
+        if item == "null" and value is None:
+            return True
+    return False
+
+
+def json_dumps_pretty(value: Any) -> str:
+    """Render recipe data for legacy text/content clients."""
+    return json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True)
+
+
 # ── MCP tool registration ─────────────────────────────────────────────────
 
 _LIST_SCHEMA: dict[str, Any] = {
@@ -235,11 +446,44 @@ _GET_SCHEMA: dict[str, Any] = {
     "additionalProperties": False,
 }
 
+_SEARCH_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "query": {"type": "string", "description": "Case-insensitive recipe search text."},
+        "dcc": {"type": "string", "description": "Optional DCC filter."},
+        "skill": {"type": "string", "description": "Optional skill filter."},
+    },
+    "additionalProperties": False,
+}
+
+_VALIDATE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "skill": {"type": "string", "description": "Skill name."},
+        "recipe": {"type": "string", "description": "Recipe name."},
+        "inputs": {"type": "object", "description": "Candidate recipe inputs."},
+    },
+    "required": ["skill", "recipe", "inputs"],
+    "additionalProperties": False,
+}
+
+_APPLY_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "skill": {"type": "string", "description": "Skill name."},
+        "recipe": {"type": "string", "description": "Recipe name."},
+        "inputs": {"type": "object", "description": "Recipe inputs."},
+        "target": {"description": "Optional scene/document/graph/timeline target."},
+    },
+    "required": ["skill", "recipe", "inputs"],
+    "additionalProperties": False,
+}
+
 _RECIPES_LIST_DESCRIPTION = (
-    "List available recipe anchors for a skill's RECIPES.md file. "
+    "List available recipe anchors or structured domain recipes for a skill. "
     "When to use: before calling execute_python — check if a recipe covers "
     "the operation. "
-    "How to use: pass skill name, then call recipes__get for the matching anchor."
+    "How to use: pass skill name, then call recipes__get for the matching recipe."
 )
 
 _RECIPES_GET_DESCRIPTION = (
@@ -247,6 +491,23 @@ _RECIPES_GET_DESCRIPTION = (
     "RECIPES.md file. "
     "When to use: when recipes__list returns an anchor matching your intent. "
     "How to use: pass skill name and anchor name; copy the code snippet."
+)
+
+_RECIPES_SEARCH_DESCRIPTION = (
+    "Search structured domain recipes across loaded skills. "
+    "When to use: when you know the creative intent but not the owning skill. "
+    "How to use: pass query text and optional dcc/skill filters."
+)
+
+_RECIPES_VALIDATE_DESCRIPTION = (
+    "Validate candidate inputs against a structured recipe pack input schema. "
+    "When to use: before recipes__apply or before dispatching recipe steps."
+)
+
+_RECIPES_APPLY_DESCRIPTION = (
+    "Build an application plan for a structured recipe pack entry. "
+    "The core returns validated inputs, steps, output contract, and provenance; "
+    "adapters or agents dispatch the returned steps through the relevant tools/workflows."
 )
 
 
@@ -303,14 +564,17 @@ def register_recipes_tools(
                 f"Skill '{skill_name}' has no recipes file.",
                 skill=skill_name,
                 anchors=[],
+                recipes=[],
                 path=None,
             ).to_dict()
-        anchors = parse_recipe_anchors(rp)
+        entries = list_recipe_entries(skill_md)
+        anchors = [entry["name"] for entry in entries if entry.get("provenance", {}).get("format") == "markdown-anchor"]
         return ToolResult.ok(
-            f"Found {len(anchors)} recipes.",
+            f"Found {len(entries)} recipes.",
             skill=skill_name,
             anchors=anchors,
-            path=rp,
+            recipes=entries,
+            paths=get_recipes_paths(skill_md),
         ).to_dict()
 
     def _handle_get(params: Any) -> Any:
@@ -323,18 +587,101 @@ def register_recipes_tools(
         rp = get_recipes_path(skill_md)
         if not rp:
             return ToolResult(success=False, message=f"Skill '{skill_name}' has no recipes file.").to_dict()
-        content = get_recipe_content(rp, anchor)
+        recipe = find_recipe_entry(skill_md, anchor)
+        if recipe and recipe.get("provenance", {}).get("format") == "recipe-pack":
+            return ToolResult.ok(
+                f"Recipe '{anchor}'",
+                skill=skill_name,
+                anchor=anchor,
+                recipe=recipe,
+                content=json_dumps_pretty(recipe),
+            ).to_dict()
+        content_path = str(recipe.get("provenance", {}).get("path") or rp) if recipe else rp
+        content = get_recipe_content(content_path, anchor)
         if content is None:
             return ToolResult(
                 success=False,
                 message=f"Anchor '{anchor}' not found in {rp}.",
-                context={"available_anchors": parse_recipe_anchors(rp)},
+                context={"available_anchors": [entry["name"] for entry in list_recipe_entries(skill_md)]},
             ).to_dict()
         return ToolResult.ok(
             f"Recipe '{anchor}'",
             skill=skill_name,
             anchor=anchor,
             content=content,
+        ).to_dict()
+
+    def _handle_search(params: Any) -> Any:
+        args: dict[str, Any] = json_loads(params) if isinstance(params, str) else (params or {})
+        query = str(args.get("query") or "").lower()
+        dcc_filter = str(args.get("dcc") or "").lower()
+        skill_filter = str(args.get("skill") or "")
+        matches: list[dict[str, Any]] = []
+        for skill in skills:
+            skill_name = str(getattr(skill, "name", "") or "")
+            if skill_filter and skill_name != skill_filter:
+                continue
+            for entry in list_recipe_entries(skill):
+                haystack = " ".join(
+                    [
+                        entry.get("name", ""),
+                        entry.get("description", ""),
+                        str(entry.get("output_contract") or ""),
+                        " ".join(entry.get("toolset_profiles") or []),
+                    ],
+                ).lower()
+                if query and query not in haystack:
+                    continue
+                if dcc_filter and str(entry.get("dcc") or "").lower() != dcc_filter:
+                    continue
+                matches.append(entry)
+        return ToolResult.ok(f"Found {len(matches)} matching recipes.", query=query, recipes=matches).to_dict()
+
+    def _handle_validate(params: Any) -> Any:
+        args: dict[str, Any] = json_loads(params) if isinstance(params, str) else (params or {})
+        skill_name = args.get("skill", "")
+        recipe_name = args.get("recipe", "")
+        inputs = args.get("inputs") or {}
+        skill_md = skill_map.get(skill_name)
+        if skill_md is None:
+            return ToolResult.not_found("Skill", skill_name).to_dict()
+        recipe = find_recipe_entry(skill_md, recipe_name)
+        if recipe is None:
+            return ToolResult.not_found("Recipe", recipe_name).to_dict()
+        errors = validate_recipe_inputs(recipe, inputs if isinstance(inputs, dict) else {})
+        return ToolResult.ok(
+            "Recipe inputs are valid." if not errors else "Recipe inputs are invalid.",
+            valid=not errors,
+            errors=errors,
+            recipe=recipe_name,
+            skill=skill_name,
+        ).to_dict()
+
+    def _handle_apply(params: Any) -> Any:
+        args: dict[str, Any] = json_loads(params) if isinstance(params, str) else (params or {})
+        skill_name = args.get("skill", "")
+        recipe_name = args.get("recipe", "")
+        inputs = args.get("inputs") or {}
+        skill_md = skill_map.get(skill_name)
+        if skill_md is None:
+            return ToolResult.not_found("Skill", skill_name).to_dict()
+        recipe = find_recipe_entry(skill_md, recipe_name)
+        if recipe is None:
+            return ToolResult.not_found("Recipe", recipe_name).to_dict()
+        if recipe.get("provenance", {}).get("format") != "recipe-pack":
+            return ToolResult.invalid_input("recipes__apply requires a structured YAML recipe pack entry.").to_dict()
+        errors = validate_recipe_inputs(recipe, inputs if isinstance(inputs, dict) else {})
+        if errors:
+            return ToolResult.invalid_input("Recipe inputs are invalid.", errors=errors).to_dict()
+        return ToolResult.ok(
+            f"Recipe '{recipe_name}' application plan ready.",
+            skill=skill_name,
+            recipe=recipe_name,
+            inputs=inputs,
+            target=args.get("target"),
+            steps=recipe.get("steps", []),
+            output_contract=recipe.get("output_contract"),
+            provenance=recipe.get("provenance", {}),
         ).to_dict()
 
     specs = [
@@ -352,6 +699,27 @@ def register_recipes_tools(
             handler=_handle_get,
             category=CATEGORY_RECIPES,
         ),
+        ToolSpec(
+            name="recipes__search",
+            description=_RECIPES_SEARCH_DESCRIPTION,
+            input_schema=_SEARCH_SCHEMA,
+            handler=_handle_search,
+            category=CATEGORY_RECIPES,
+        ),
+        ToolSpec(
+            name="recipes__validate",
+            description=_RECIPES_VALIDATE_DESCRIPTION,
+            input_schema=_VALIDATE_SCHEMA,
+            handler=_handle_validate,
+            category=CATEGORY_RECIPES,
+        ),
+        ToolSpec(
+            name="recipes__apply",
+            description=_RECIPES_APPLY_DESCRIPTION,
+            input_schema=_APPLY_SCHEMA,
+            handler=_handle_apply,
+            category=CATEGORY_RECIPES,
+        ),
     ]
     register_tools(
         server,
@@ -365,8 +733,14 @@ def register_recipes_tools(
 # ── Public API ─────────────────────────────────────────────────────────────
 
 __all__ = [
+    "RecipeDefinition",
+    "find_recipe_entry",
     "get_recipe_content",
     "get_recipes_path",
+    "get_recipes_paths",
+    "list_recipe_entries",
+    "load_recipe_pack",
     "parse_recipe_anchors",
     "register_recipes_tools",
+    "validate_recipe_inputs",
 ]

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -12,8 +12,12 @@ import pytest
 
 from dcc_mcp_core.recipes import get_recipe_content
 from dcc_mcp_core.recipes import get_recipes_path
+from dcc_mcp_core.recipes import get_recipes_paths
+from dcc_mcp_core.recipes import list_recipe_entries
+from dcc_mcp_core.recipes import load_recipe_pack
 from dcc_mcp_core.recipes import parse_recipe_anchors
 from dcc_mcp_core.recipes import register_recipes_tools
+from dcc_mcp_core.recipes import validate_recipe_inputs
 
 # ── Fixtures ──────────────────────────────────────────────────────────────
 
@@ -52,6 +56,38 @@ def recipes_md(tmp_path: Path) -> Path:
         """
     )
     p = tmp_path / "RECIPES.md"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+@pytest.fixture()
+def recipe_pack_yaml(tmp_path: Path) -> Path:
+    content = textwrap.dedent(
+        """\
+        recipes:
+          - name: build_pbr_material
+            dcc: maya
+            description: Build a PBR material network.
+            inputs_schema:
+              type: object
+              required: [material_name, roughness]
+              properties:
+                material_name:
+                  type: string
+                roughness:
+                  type: number
+            steps:
+              - tool: maya_materials__create
+                arguments:
+                  name: ${material_name}
+              - tool: maya_materials__set_roughness
+                arguments:
+                  value: ${roughness}
+            output_contract: material_graph
+            toolset_profiles: [lookdev, surfacing]
+        """
+    )
+    p = tmp_path / "recipes.yaml"
     p.write_text(content, encoding="utf-8")
     return p
 
@@ -107,6 +143,19 @@ class TestGetRecipesPath:
         md.metadata = None
         md.skill_path = None
         assert get_recipes_path(md) is None
+
+    def test_get_recipes_paths_expands_glob(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "my-skill"
+        recipe_dir = skill_dir / "recipes"
+        recipe_dir.mkdir(parents=True)
+        (recipe_dir / "a.yaml").write_text("recipes: []\n", encoding="utf-8")
+        (recipe_dir / "b.yaml").write_text("recipes: []\n", encoding="utf-8")
+        md = _make_metadata(str(skill_dir), "recipes/*.yaml", nested=True)
+
+        assert get_recipes_paths(md) == [
+            str(recipe_dir / "a.yaml"),
+            str(recipe_dir / "b.yaml"),
+        ]
 
 
 # ── parse_recipe_anchors ──────────────────────────────────────────────────
@@ -175,6 +224,41 @@ class TestGetRecipeContent:
         assert not result.endswith("\n")
 
 
+# ── structured recipe packs ────────────────────────────────────────────────
+
+
+class TestRecipePacks:
+    def test_load_recipe_pack_returns_structured_recipe(self, recipe_pack_yaml: Path) -> None:
+        recipes = load_recipe_pack(str(recipe_pack_yaml), skill_name="maya-domain")
+
+        assert len(recipes) == 1
+        payload = recipes[0].to_dict()
+        assert payload["name"] == "build_pbr_material"
+        assert payload["dcc"] == "maya"
+        assert payload["inputs_schema"]["required"] == ["material_name", "roughness"]
+        assert payload["steps"][0]["tool"] == "maya_materials__create"
+        assert payload["provenance"]["skill"] == "maya-domain"
+
+    def test_list_recipe_entries_includes_yaml_pack(self, recipe_pack_yaml: Path, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "maya-domain"
+        skill_dir.mkdir()
+        md = _make_metadata(str(skill_dir), str(recipe_pack_yaml), nested=True)
+        md.name = "maya-domain"
+
+        entries = list_recipe_entries(md)
+
+        assert [entry["name"] for entry in entries] == ["build_pbr_material"]
+        assert entries[0]["provenance"]["format"] == "recipe-pack"
+
+    def test_validate_recipe_inputs_reports_missing_and_type_errors(self, recipe_pack_yaml: Path) -> None:
+        recipe = load_recipe_pack(str(recipe_pack_yaml))[0].to_dict()
+
+        errors = validate_recipe_inputs(recipe, {"material_name": "mat", "roughness": "high"})
+
+        assert errors == ["Input 'roughness' expected number, got str"]
+        assert validate_recipe_inputs(recipe, {"material_name": "mat", "roughness": 0.5}) == []
+
+
 # ── register_recipes_tools ────────────────────────────────────────────────
 
 
@@ -198,6 +282,9 @@ class TestRegisterRecipesTools:
         calls = [c.kwargs["name"] for c in server.registry.register.call_args_list]
         assert "recipes__list" in calls
         assert "recipes__get" in calls
+        assert "recipes__search" in calls
+        assert "recipes__validate" in calls
+        assert "recipes__apply" in calls
 
     def test_list_handler_returns_anchors(self, recipes_md: Path, tmp_path: Path) -> None:
         skill_dir = tmp_path / "maya-scripting"
@@ -254,6 +341,85 @@ class TestRegisterRecipesTools:
         result = handlers["recipes__list"](json.dumps({"skill": "no-recipes-skill"}))
         assert result["success"] is True
         assert result["context"]["anchors"] == []
+
+    def test_list_handler_returns_structured_recipes(self, recipe_pack_yaml: Path, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "maya-domain"
+        skill_dir.mkdir()
+        md = _make_metadata(str(skill_dir), str(recipe_pack_yaml), nested=True)
+        md.name = "maya-domain"
+        server, handlers = self._make_server([md])
+        register_recipes_tools(server, skills=[md])
+
+        result = handlers["recipes__list"](json.dumps({"skill": "maya-domain"}))
+
+        assert result["success"] is True
+        assert result["context"]["anchors"] == []
+        assert result["context"]["recipes"][0]["name"] == "build_pbr_material"
+
+    def test_get_handler_returns_structured_recipe(self, recipe_pack_yaml: Path, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "maya-domain"
+        skill_dir.mkdir()
+        md = _make_metadata(str(skill_dir), str(recipe_pack_yaml), nested=True)
+        md.name = "maya-domain"
+        server, handlers = self._make_server([md])
+        register_recipes_tools(server, skills=[md])
+
+        result = handlers["recipes__get"](json.dumps({"skill": "maya-domain", "anchor": "build_pbr_material"}))
+
+        assert result["success"] is True
+        assert result["context"]["recipe"]["output_contract"] == "material_graph"
+
+    def test_search_handler_finds_structured_recipe(self, recipe_pack_yaml: Path, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "maya-domain"
+        skill_dir.mkdir()
+        md = _make_metadata(str(skill_dir), str(recipe_pack_yaml), nested=True)
+        md.name = "maya-domain"
+        server, handlers = self._make_server([md])
+        register_recipes_tools(server, skills=[md])
+
+        result = handlers["recipes__search"](json.dumps({"query": "pbr", "dcc": "maya"}))
+
+        assert result["success"] is True
+        assert result["context"]["recipes"][0]["name"] == "build_pbr_material"
+
+    def test_validate_handler_checks_recipe_inputs(self, recipe_pack_yaml: Path, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "maya-domain"
+        skill_dir.mkdir()
+        md = _make_metadata(str(skill_dir), str(recipe_pack_yaml), nested=True)
+        md.name = "maya-domain"
+        server, handlers = self._make_server([md])
+        register_recipes_tools(server, skills=[md])
+
+        result = handlers["recipes__validate"](
+            json.dumps({"skill": "maya-domain", "recipe": "build_pbr_material", "inputs": {"material_name": "mat"}}),
+        )
+
+        assert result["success"] is True
+        assert result["context"]["valid"] is False
+        assert "Missing required input: roughness" in result["context"]["errors"]
+
+    def test_apply_handler_returns_application_plan(self, recipe_pack_yaml: Path, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "maya-domain"
+        skill_dir.mkdir()
+        md = _make_metadata(str(skill_dir), str(recipe_pack_yaml), nested=True)
+        md.name = "maya-domain"
+        server, handlers = self._make_server([md])
+        register_recipes_tools(server, skills=[md])
+
+        result = handlers["recipes__apply"](
+            json.dumps(
+                {
+                    "skill": "maya-domain",
+                    "recipe": "build_pbr_material",
+                    "inputs": {"material_name": "mat", "roughness": 0.5},
+                    "target": "scene",
+                },
+            ),
+        )
+
+        assert result["success"] is True
+        assert result["context"]["steps"][0]["tool"] == "maya_materials__create"
+        assert result["context"]["output_contract"] == "material_graph"
 
     def test_no_registry_logs_warning(self) -> None:
         class _BadServer:


### PR DESCRIPTION
## Summary
- Add structured YAML recipe packs under the existing `metadata.dcc-mcp.recipes` sibling-file hook, alongside legacy Markdown recipe anchors.
- Expose recipe pack helpers plus `recipes__list/search/get/validate/apply` so adapters can discover recipe schemas, validate inputs, and return application plans with provenance.
- Update recipes API docs and `llms.txt` for the new domain recipe pack surface.

## Test plan
- `vx ruff check python/dcc_mcp_core/recipes.py python/dcc_mcp_core/__init__.py tests/test_recipes.py`
- `vx ruff format --check python/dcc_mcp_core/recipes.py python/dcc_mcp_core/__init__.py tests/test_recipes.py`
- `.venv\Scripts\python.exe -m pytest tests/test_recipes.py tests/test_inprocess_executor.py -q`

Fixes #616