### PR TITLE
ci: validate built wheels with uv

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -101,11 +101,22 @@ runs:
         sccache: ${{ inputs.use-sccache == 'true' }}
         manylinux: auto
 
+    - name: Setup Python for wheel metadata check
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.11'
+
     - name: Check wheel metadata
       shell: bash
       run: |
-        pip install twine
-        twine check --strict dist/*
+        python -m pip install --upgrade twine
+        python -m twine check --strict dist/*
+
+    - name: Restore requested Python for wheel test
+      if: inputs.test-wheel == 'true'
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python-version }}
 
     - name: Test wheel
       if: inputs.test-wheel == 'true'

--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -101,22 +101,13 @@ runs:
         sccache: ${{ inputs.use-sccache == 'true' }}
         manylinux: auto
 
-    - name: Setup Python for wheel metadata check
-      uses: actions/setup-python@v6
-      with:
-        python-version: '3.11'
+    - name: Install uv
+      uses: loonghao/vx@v0.8.33
 
-    - name: Check wheel metadata
+    - name: Check wheel contents
       shell: bash
       run: |
-        python -m pip install --upgrade twine
-        python -m twine check --strict dist/*
-
-    - name: Restore requested Python for wheel test
-      if: inputs.test-wheel == 'true'
-      uses: actions/setup-python@v6
-      with:
-        python-version: ${{ inputs.python-version }}
+        vx uvx --python 3.12 check-wheel-contents dist/*.whl
 
     - name: Test wheel
       if: inputs.test-wheel == 'true'


### PR DESCRIPTION
## Summary
- Replace the `twine check` metadata validation step with a uv-powered wheel content check.
- Keep the requested Python interpreter active for the wheel smoke test, including py3.7 builds.

## Test plan
- `vx uvx --python 3.12 check-wheel-contents --help`
- `git diff --check`
- pre-commit YAML hooks during commit