### PR TITLE
ci: allow bundled skill scripts in wheels

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -107,7 +107,7 @@ runs:
     - name: Check wheel contents
       shell: bash
       run: |
-        vx uvx --python 3.12 check-wheel-contents dist/*.whl
+        vx uvx --python 3.12 check-wheel-contents --ignore W004 dist/*.whl
 
     - name: Test wheel
       if: inputs.test-wheel == 'true'


### PR DESCRIPTION
## Summary
- Keep uv-powered wheel content validation enabled.
- Ignore `check-wheel-contents` W004 because bundled skill scripts are package data resources, not importable modules.

## Test plan
- `git diff --check`
- pre-commit YAML hook during commit