### PR TITLE
fix: keep Python tests compatible with pagination

### DIFF
--- a/python/dcc_mcp_core/recipes.py
+++ b/python/dcc_mcp_core/recipes.py
@@ -396,7 +396,7 @@ def _matches_json_type(value: Any, expected: Any) -> bool:
     for item in expected_types:
         if item == "string" and isinstance(value, str):
             return True
-        if item == "number" and isinstance(value, int | float) and not isinstance(value, bool):
+        if item == "number" and isinstance(value, (int, float)) and not isinstance(value, bool):
             return True
         if item == "integer" and isinstance(value, int) and not isinstance(value, bool):
             return True

--- a/tests/test_e2e_gateway_skill_load_sse.py
+++ b/tests/test_e2e_gateway_skill_load_sse.py
@@ -104,6 +104,22 @@ def _post_mcp(url: str, method: str, params: dict | None = None, rpc_id: int = 1
         return json.loads(resp.read())
 
 
+def _list_all_tools(url: str) -> list[dict[str, Any]]:
+    """Collect every tools/list page from a paginated MCP endpoint."""
+    tools: list[dict[str, Any]] = []
+    cursor: str | None = None
+    rpc_id = 1
+    while True:
+        params = {"cursor": cursor} if cursor is not None else None
+        resp = _post_mcp(url, "tools/list", params=params, rpc_id=rpc_id)
+        result = resp["result"]
+        tools.extend(result["tools"])
+        cursor = result.get("nextCursor")
+        if cursor is None:
+            return tools
+        rpc_id += 1
+
+
 def _wait_tcp_reachable(host: str, port: int, budget: float = 3.0) -> bool:
     """Poll until TCP connect succeeds or budget expires."""
     deadline = time.time() + budget
@@ -270,8 +286,8 @@ class TestGatewayLoadSkillSsePropagation:
         The real tool ``hello_world__greet`` MUST NOT be in ``tools/list``.
         This guards the progressive-loading contract.
         """
-        resp = _post_mcp(gateway_with_skill_backend["gateway_url"], "tools/list")
-        names = {t["name"] for t in resp["result"]["tools"]}
+        tools = _list_all_tools(gateway_with_skill_backend["gateway_url"])
+        names = {t["name"] for t in tools}
 
         # The skill stub is how the gateway (and client) discovers that
         # hello-world exists without paying to register its tools yet.
@@ -363,8 +379,7 @@ class TestGatewayLoadSkillSsePropagation:
             deadline = time.time() + AGGREGATOR_TICK_S + 2.0
             active_names: set[str] = set()
             while time.time() < deadline:
-                resp = _post_mcp(gateway_url, "tools/list")
-                active_names = {t["name"] for t in resp["result"]["tools"]}
+                active_names = {t["name"] for t in _list_all_tools(gateway_url)}
                 if any(n.endswith(".greet") for n in active_names):
                     break
                 time.sleep(0.5)

--- a/tests/test_gateway_facade_aggregation.py
+++ b/tests/test_gateway_facade_aggregation.py
@@ -68,6 +68,22 @@ def _post_mcp(url: str, method: str, params: dict | None = None, rpc_id: int = 1
         return json.loads(resp.read())
 
 
+def _list_all_tools(url: str) -> list[dict]:
+    """Collect every tools/list page from a paginated gateway response."""
+    tools: list[dict] = []
+    cursor: str | None = None
+    rpc_id = 1
+    while True:
+        params = {"cursor": cursor} if cursor is not None else None
+        resp = _post_mcp(url, "tools/list", params=params, rpc_id=rpc_id)
+        result = resp["result"]
+        tools.extend(result["tools"])
+        cursor = result.get("nextCursor")
+        if cursor is None:
+            return tools
+        rpc_id += 1
+
+
 def _split_gateway_prefixed_tool(name: str) -> tuple[str, str] | None:
     """Return ``(instance_prefix, tool_name)`` for ``<id8>.<tool>`` names."""
     if name.startswith("__"):
@@ -169,8 +185,7 @@ class TestFacadeToolsAggregation:
     """``tools/list`` on the gateway merges every backend's tools into one list."""
 
     def test_aggregated_list_contains_local_and_backend_tools(self, facade_cluster):
-        resp = _post_mcp(facade_cluster["gateway_url"], "tools/list")
-        tools = resp["result"]["tools"]
+        tools = _list_all_tools(facade_cluster["gateway_url"])
         names = {t["name"] for t in tools}
 
         # Tier 1 — gateway discovery meta-tools.
@@ -199,8 +214,7 @@ class TestFacadeToolsAggregation:
         )
 
     def test_backend_tools_carry_instance_metadata(self, facade_cluster):
-        resp = _post_mcp(facade_cluster["gateway_url"], "tools/list")
-        tools = resp["result"]["tools"]
+        tools = _list_all_tools(facade_cluster["gateway_url"])
         backend_tools = [t for t in tools if _split_gateway_prefixed_tool(t["name"]) is not None]
         assert backend_tools, "no namespaced backend tools were aggregated"
 


### PR DESCRIPTION
## Summary
- Replace Python 3.10-only `int | float` runtime type usage in recipe validation with a Python 3.8-compatible tuple.
- Update gateway aggregation tests to walk all `tools/list` pages before asserting on backend tools or skill stubs.

## Test plan
- `vx ruff check python/dcc_mcp_core/recipes.py tests/test_e2e_gateway_skill_load_sse.py tests/test_gateway_facade_aggregation.py`
- `git diff --check`
- Attempted focused `vx pytest ...` but this worktree has not installed `dcc_mcp_core`, so pytest stopped at `ModuleNotFoundError` in `tests/conftest.py`.