### PR TITLE
feat(schema): zero-dep type to JSON Schema derivation for Python actions (#242)

### DIFF
--- a/docs/api/actions.md
+++ b/docs/api/actions.md
@@ -91,6 +91,16 @@ removed = reg.unregister("create_sphere")                  # global: True if fou
 removed = reg.unregister("create_sphere", dcc_name="maya") # scoped to maya only
 ```
 
+::: tip Derive schemas from Python types (issue #242)
+
+Rather than hand-writing the `input_schema` JSON string, use
+`tool_spec_from_callable(handler)` to derive both `inputSchema` and
+`outputSchema` from a typed Python handler with zero extra
+dependencies. See the [Structured Schema Derivation](../guide/skills.md#deriving-input-schema-output-schema-from-python-types-242)
+section of the skills guide for the full type-mapping table and a
+runnable example.
+:::
+
 ### Capability-Based Filtering
 
 Tools may declare the host-DCC capabilities they rely on at registration time.

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -171,6 +171,85 @@ decl = ToolDeclaration(
 | `defer_loading` | `bool` | `False` | Accepts `defer-loading` / `defer_loading` in SKILL.md and marks the declaration as discovery-oriented |
 | `source_file` | `str` | `""` | Explicit path to the script (relative to skill dir) |
 
+### Deriving `input_schema` / `output_schema` from Python types (#242)
+
+Hand-writing JSON Schema is error-prone — agent-authored actions drift,
+cached schemas diverge from runtime code, and the schema text is noisy
+to review. `dcc_mcp_core.schema` derives both schemas from Python type
+annotations using only the standard library (no `pydantic`, no
+`jsonschema`, no `attrs`).
+
+Write a typed handler:
+
+```python
+from dataclasses import dataclass, field
+from typing import Literal
+
+from dcc_mcp_core import tool_spec_from_callable
+from dcc_mcp_core._tool_registration import register_tools
+
+
+@dataclass
+class ExportInput:
+    scene_path: str = field(metadata={"description": "Scene file to export."})
+    format: Literal["fbx", "abc", "usd"] = "fbx"
+    frame_range: tuple[int, int] = (1, 100)
+
+
+@dataclass
+class ExportResult:
+    path: str
+    size_bytes: int
+    took_ms: int
+
+
+def export_scene(args: ExportInput) -> ExportResult:
+    """Export a scene to an interchange format."""
+    ...
+
+
+spec = tool_spec_from_callable(export_scene)
+register_tools(server, [spec], dcc_name="maya")
+```
+
+`tool_spec_from_callable` understands two signature styles:
+
+- **Single dataclass / TypedDict parameter** — the whole parameter becomes
+  the `inputSchema` (used above).
+- **Multiple primitive-typed parameters** — each parameter becomes a
+  property of an `object` `inputSchema`.
+
+The return annotation, when present, becomes the `outputSchema` so MCP
+2025-06-18 clients can validate `structuredContent` payloads. Untyped
+handlers raise `TypeError` rather than silently falling back to a
+permissive `{"type": "object"}` — this closes the #588-era footgun.
+
+Supported types (stdlib only): `bool`, `int`, `float`, `str`, `bytes`,
+`None`, `list[X]`, `tuple[X, ...]`, `tuple[A, B, ...]` (fixed),
+`dict[str, V]`, `Optional[X]` / `X | None`, `Union[A, B]`,
+`Literal[...]`, `Enum`, `datetime.datetime`, `datetime.date`,
+`pathlib.Path`, `uuid.UUID`, `@dataclass`, `TypedDict`. Unsupported
+types raise `TypeError` with a clear escape hatch: pass an explicit
+`input_schema=...` dict or use pydantic's `MyModel.model_json_schema()`.
+
+::: tip Why not pydantic?
+We intentionally stay zero-dependency. Adding `pydantic` for this one
+feature would drag in a 3MB wheel plus `pydantic-core` and is too
+heavy for authors who only want a few dataclass handlers. For callers
+who already use pydantic, the emitted shape matches pydantic's
+conventions (`title`, `$defs`, `$ref`, `anyOf`, `required`), so
+swapping in `MyModel.model_json_schema()` is a drop-in replacement.
+
+`pydantic-core` (Rust) was evaluated for reuse and doesn't help here:
+pydantic's own architecture doc confirms JSON Schema generation lives
+entirely in the Python package — the Rust crate only runs validation
+and serialization, never introspecting Python type annotations.
+:::
+
+See `examples/skills/typed-schema-demo/` for a runnable example, and
+`tests/test_schema.py` for the full type-mapping table in executable
+form.
+
 ### `next-tools` — Follow-Up Tool Hints (dcc-mcp-core extension)
 
 The `next-tools` field guides AI agents to appropriate follow-up actions after a tool

--- a/docs/zh/guide/skills.md
+++ b/docs/zh/guide/skills.md
@@ -175,6 +175,60 @@ decl = ToolDeclaration(
 
 `tools/list` 返回的未加载 skill stub 还会显式带上 `annotations.deferredHint = true`。调用 `load_skill(...)` 后，stub 会被真实工具替换，且这些工具返回 `deferredHint = false`。
 
+### 从 Python 类型派生 `input_schema` / `output_schema`（#242）
+
+手写 JSON Schema 易出错 —— 代理生成的 action 会漂移、缓存 schema 会和运行时代码分叉、schema 文本在 review 时难读。`dcc_mcp_core.schema` 只用标准库（无 `pydantic`、无 `jsonschema`、无 `attrs`）从 Python 类型注解派生这两份 schema。
+
+写一个带类型标注的 handler 即可：
+
+```python
+from dataclasses import dataclass, field
+from typing import Literal
+
+from dcc_mcp_core import tool_spec_from_callable
+from dcc_mcp_core._tool_registration import register_tools
+
+
+@dataclass
+class ExportInput:
+    scene_path: str = field(metadata={"description": "需要导出的场景文件。"})
+    format: Literal["fbx", "abc", "usd"] = "fbx"
+    frame_range: tuple[int, int] = (1, 100)
+
+
+@dataclass
+class ExportResult:
+    path: str
+    size_bytes: int
+    took_ms: int
+
+
+def export_scene(args: ExportInput) -> ExportResult:
+    """Export a scene to an interchange format."""
+    ...
+
+
+spec = tool_spec_from_callable(export_scene)
+register_tools(server, [spec], dcc_name="maya")
+```
+
+`tool_spec_from_callable` 能识别两种签名风格：
+
+- **单个 dataclass / TypedDict 参数** —— 整个参数就是 `inputSchema`（上例即为此类）。
+- **多个原子类型参数** —— 每个参数成为 `object` 型 `inputSchema` 的一个 property。
+
+若有返回类型标注，会作为 `outputSchema`，MCP 2025-06-18 的客户端即可用它校验 `structuredContent`。未类型化的 handler 抛 `TypeError`，不会静默回退成宽松的 `{"type": "object"}`（修掉 #588 同代的陷阱）。
+
+支持的类型（全标准库）：`bool`、`int`、`float`、`str`、`bytes`、`None`、`list[X]`、`tuple[X, ...]`、定长 `tuple[A, B, ...]`、`dict[str, V]`、`Optional[X]` / `X | None`、`Union[A, B]`、`Literal[...]`、`Enum`、`datetime.datetime`、`datetime.date`、`pathlib.Path`、`uuid.UUID`、`@dataclass`、`TypedDict`。不支持的类型会抛 `TypeError` 并附一条明确的"逃生通道"：显式传 `input_schema=...` dict 或用 pydantic 的 `MyModel.model_json_schema()`。
+
+::: tip 为什么不用 pydantic？
+我们刻意保持 0 依赖。仅为此特性引入 `pydantic` 会拉进 3MB wheel 再加 `pydantic-core`，对只想写几个 dataclass handler 的作者成本过高。对于已经在用 pydantic 的调用方，派生出的 shape 与 pydantic 的约定一致（`title`、`$defs`、`$ref`、`anyOf`、`required`），因此换成 `MyModel.model_json_schema()` 是即插即用的。
+
+`pydantic-core`（Rust）也被评估过，结论：对我们没帮助 —— pydantic 官方架构文档确认 JSON Schema 生成完全在 Python 层做（`pydantic.json_schema.GenerateJsonSchema`），Rust crate 只做校验和序列化，不看 Python 类型注解。
+:::
+
+完整示例见 `examples/skills/typed-schema-demo/`；完整类型映射表以可执行形式见 `tests/test_schema.py`。
+
 ## 脚本查找优先级
 
 加载 Skill 时，目录按以下优先级解析每个 ToolDeclaration 对应的脚本：

--- a/examples/skills/typed-schema-demo/README.md
+++ b/examples/skills/typed-schema-demo/README.md
@@ -1,0 +1,19 @@
+# typed-schema-demo
+
+Companion example for issue #242 — shows a typed handler whose
+`inputSchema` and `outputSchema` are derived entirely from Python type
+annotations, with no `pydantic` / `jsonschema` / `attrs` dependency.
+
+See `SKILL.md` for the skill metadata and `scripts/demo.py` for the
+handler + schema derivation.
+
+To print the derived schemas:
+
+```bash
+python -m examples.skills.typed-schema-demo.scripts.demo
+```
+
+The shape matches what `pydantic`'s `model_json_schema()` would emit
+(same `title`, `$defs`, `$ref`, `anyOf` conventions) so adopters who
+later switch to pydantic will not need to migrate agents or cached
+schemas.

--- a/examples/skills/typed-schema-demo/SKILL.md
+++ b/examples/skills/typed-schema-demo/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: typed-schema-demo
+description: >-
+  Example skill — demonstrates zero-dependency JSON Schema derivation from
+  Python dataclasses and type annotations (issue #242). Use as a reference
+  when authoring typed handlers that should publish inputSchema /
+  outputSchema without hand-writing JSON. Not intended for production use.
+license: MIT
+compatibility: Python 3.10+
+metadata:
+  dcc-mcp.dcc: python
+  dcc-mcp.version: "1.0.0"
+  dcc-mcp.layer: example
+  dcc-mcp.search-hint: "structured schema, dataclass, json schema, inputSchema, outputSchema, typed handler, pydantic-free"
+  dcc-mcp.tags: "example, schema, structured"
+---
+
+# Typed Schema Demo (issue #242)
+
+This skill demonstrates the `dcc_mcp_core.schema` helpers landed for
+issue #242: authors write a typed handler and
+`tool_spec_from_callable` derives both `inputSchema` and `outputSchema`
+from the annotations, with no dependency on `pydantic`, `jsonschema`, or
+`attrs`.
+
+## What to look at
+
+- `scripts/demo.py` — one handler using a dataclass input and a dataclass
+  output. The derived schemas are structurally compatible with pydantic's
+  `model_json_schema()` so callers can swap in pydantic later without
+  migrating agents or cached schemas.
+
+## How to wire it into a server
+
+The demo module builds a `ToolSpec` that is ready for
+`dcc_mcp_core._tool_registration.register_tools(server, [spec])`. Inside
+an adapter (e.g. Maya/Blender), register it during bootstrap:
+
+```python
+from dcc_mcp_core._tool_registration import register_tools
+from typed_schema_demo.scripts.demo import spec
+
+register_tools(server, [spec], dcc_name="python")
+```
+
+When the negotiated MCP session is `2025-06-18`, the gateway publishes
+`outputSchema` alongside `inputSchema` so clients can validate the
+`structuredContent` payload our handler returns.

--- a/examples/skills/typed-schema-demo/scripts/demo.py
+++ b/examples/skills/typed-schema-demo/scripts/demo.py
@@ -1,0 +1,66 @@
+"""Typed handler demo for issue #242.
+
+The dataclass-annotated handler below is passed through
+``tool_spec_from_callable`` which derives both ``inputSchema`` and
+``outputSchema`` from the annotations — no hand-written JSON schema, no
+``pydantic`` dependency.
+
+Run this module standalone to print the derived schemas::
+
+    python -m examples.skills.typed-schema-demo.scripts.demo
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+import json
+from typing import Literal
+
+from dcc_mcp_core import tool_spec_from_callable
+from dcc_mcp_core._tool_registration import ToolSpec
+
+
+@dataclass
+class ExportInput:
+    """Arguments for :func:`export_scene`."""
+
+    scene_path: str = field(
+        metadata={"description": "Absolute path to the scene file to export."},
+    )
+    format: Literal["fbx", "abc", "usd"] = field(
+        default="fbx",
+        metadata={"description": "Interchange format; one of fbx / abc / usd."},
+    )
+    frame_range: tuple[int, int] = field(
+        default=(1, 100),
+        metadata={"description": "Inclusive frame range (start, end)."},
+    )
+
+
+@dataclass
+class ExportResult:
+    """Result payload for :func:`export_scene`."""
+
+    path: str
+    size_bytes: int
+    took_ms: int
+
+
+def export_scene(args: ExportInput) -> ExportResult:
+    """Export a scene to an interchange format (demo — no real IO)."""
+    # In a real adapter, this would call the DCC's export API.
+    return ExportResult(path=args.scene_path, size_bytes=0, took_ms=0)
+
+
+# ToolSpec ready for register_tools(server, [spec]).  Both schemas are
+# derived; the adapter does nothing schema-related by hand.
+spec: ToolSpec = tool_spec_from_callable(export_scene, name="typed_schema_demo__export")
+
+
+if __name__ == "__main__":
+    print("inputSchema:")
+    print(json.dumps(spec.input_schema, indent=2))
+    print()
+    print("outputSchema:")
+    print(json.dumps(spec.output_schema, indent=2))

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -12,6 +12,7 @@
 | I want to… | Use this API |
 |-------------|--------------|
 | Register a script/tool for AI to call | `ToolRegistry.register()` |
+| Derive `inputSchema` / `outputSchema` from a typed Python handler (issue #242) | `tool_spec_from_callable(handler)` — zero-dep, reads `@dataclass` / `TypedDict` / `typing` annotations, refuses untyped handlers |
 | Return a result from a DCC action | `success_result()` / `error_result()` |
 | Auto-discover skill packages from directories | `scan_and_load()` / `SkillScanner` |
 | Watch a skills directory for live updates | `SkillWatcher` |

--- a/llms.txt
+++ b/llms.txt
@@ -8,6 +8,7 @@
 |------|--------------|
 | Return DCC tool result | `success_result()` / `error_result()` |
 | Register scripts as MCP tools | `ToolRegistry.register()` |
+| Derive inputSchema / outputSchema from a typed Python handler (issue #242) | `tool_spec_from_callable(handler)` — zero-dep, reads `@dataclass` / `TypedDict` / `typing` annotations |
 | Discover skills from directories | `scan_and_load()` → returns `(skills, skipped)` tuple |
 | Validate tool params | `ToolValidator.from_schema_json()` |
 | Connect to running DCC | `IpcChannelAdapter.connect(name)` or `SocketServerAdapter(path)` |

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -458,6 +458,12 @@ from dcc_mcp_core.rich_content import attach_rich_content
 from dcc_mcp_core.rich_content import skill_success_with_chart
 from dcc_mcp_core.rich_content import skill_success_with_image
 from dcc_mcp_core.rich_content import skill_success_with_table
+
+# Zero-dep type → JSON Schema derivation (issue #242)
+from dcc_mcp_core.schema import derive_parameters_schema
+from dcc_mcp_core.schema import derive_schema
+from dcc_mcp_core.schema import schema_from_doc
+from dcc_mcp_core.schema import tool_spec_from_callable
 from dcc_mcp_core.script_execution import ScriptExecutionCapture
 from dcc_mcp_core.script_execution import ScriptExecutionParams
 from dcc_mcp_core.script_execution import ScriptExecutionResult
@@ -741,6 +747,8 @@ __all__ = [
     "current_callable_job",
     "current_cancel_token",
     "current_job",
+    "derive_parameters_schema",
+    "derive_schema",
     "deserialize_result",
     "elicit_form",
     "elicit_form_sync",
@@ -833,6 +841,7 @@ __all__ = [
     "scan_and_load_user_lenient",
     "scan_skill_paths",
     "scene_info_json_to_stage",
+    "schema_from_doc",
     "serialize_result",
     "set_cancel_token",
     "set_current_job",
@@ -851,6 +860,7 @@ __all__ = [
     "stage_to_scene_info_json",
     "start_embedded_dcc_server",
     "success_result",
+    "tool_spec_from_callable",
     "units_to_mpu",
     "unwrap_parameters",
     "unwrap_value",

--- a/python/dcc_mcp_core/_tool_registration.py
+++ b/python/dcc_mcp_core/_tool_registration.py
@@ -45,6 +45,12 @@ class ToolSpec:
         Tool category tag; defaults to ``"general"``.
     version:
         Tool version string; defaults to ``"1.0.0"``.
+    output_schema:
+        Optional JSON Schema for the tool's return payload (MCP 2025-06-18
+        ``outputSchema``). When provided, the registry publishes it so
+        clients on 2025-06-18 sessions can validate ``structuredContent``;
+        the gateway drops it for 2025-03-26 sessions automatically (see
+        ``crates/dcc-mcp-http/src/handler/dispatch.rs``).
 
     """
 
@@ -54,6 +60,7 @@ class ToolSpec:
     handler: Callable[[Any], Any]
     category: str = "general"
     version: str = "1.0.0"
+    output_schema: dict[str, Any] | None = None
 
 
 def register_tools(
@@ -105,15 +112,37 @@ def register_tools(
 
     attached = 0
     for spec in specs:
+        register_kwargs: dict[str, Any] = {
+            "name": spec.name,
+            "description": spec.description,
+            "input_schema": json_dumps(spec.input_schema),
+            "dcc": dcc_name,
+            "category": spec.category,
+            "version": spec.version,
+        }
+        if spec.output_schema is not None:
+            register_kwargs["output_schema"] = json_dumps(spec.output_schema)
         try:
-            registry.register(
-                name=spec.name,
-                description=spec.description,
-                input_schema=json_dumps(spec.input_schema),
-                dcc=dcc_name,
-                category=spec.category,
-                version=spec.version,
-            )
+            registry.register(**register_kwargs)
+        except TypeError as exc:
+            # Older ToolRegistry builds may not accept ``output_schema`` yet.
+            # Drop it and retry once rather than losing the whole registration.
+            if spec.output_schema is not None and "output_schema" in str(exc):
+                log.warning(
+                    "%s: registry.register(%s) does not accept output_schema; retrying without it (%s)",
+                    log_prefix,
+                    spec.name,
+                    exc,
+                )
+                register_kwargs.pop("output_schema", None)
+                try:
+                    registry.register(**register_kwargs)
+                except Exception as exc2:  # pragma: no cover - defensive
+                    log.warning("%s: register(%s) failed: %s", log_prefix, spec.name, exc2)
+                    continue
+            else:
+                log.warning("%s: register(%s) failed: %s", log_prefix, spec.name, exc)
+                continue
         except Exception as exc:
             log.warning("%s: register(%s) failed: %s", log_prefix, spec.name, exc)
             continue

--- a/python/dcc_mcp_core/schema.py
+++ b/python/dcc_mcp_core/schema.py
@@ -513,8 +513,121 @@ def schema_from_doc(fn: Callable[..., Any]) -> dict[str, str]:
     return out
 
 
+# ── ToolSpec bridge (issue #242 acceptance criterion) ─────────────────────
+
+
+def _is_schema_object_type(tp: Any) -> bool:
+    """Return True if *tp* should become a full object schema on its own."""
+    if is_dataclass(tp) and isinstance(tp, type):
+        return True
+    return bool(_is_typeddict(tp))
+
+
+def tool_spec_from_callable(
+    handler: Callable[..., Any],
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    category: str = "general",
+    version: str = "1.0.0",
+) -> Any:
+    """Build a :class:`ToolSpec` by introspecting *handler*'s type annotations.
+
+    The handler may use either of two signature styles:
+
+    1. **Single dataclass / TypedDict parameter** — the whole parameter becomes
+       the ``inputSchema``::
+
+           @dataclass
+           class ExportInput:
+               scene_path: str
+               format: Literal["fbx", "abc"] = "fbx"
+
+           def export_scene(args: ExportInput) -> ExportResult: ...
+
+    2. **Multiple primitive-typed parameters** — each parameter becomes a
+       property of an ``object`` ``inputSchema``::
+
+           def make_sphere(radius: float, segments: int = 16) -> SphereResult: ...
+
+    The return annotation, if present and typed, becomes the ``outputSchema``.
+
+    Refuses untyped handlers (``raise TypeError``) so authors get explicit
+    feedback rather than a silently-too-permissive ``{"type": "object"}``
+    fallback — the failure mode that #588 tracked.
+
+    Parameters
+    ----------
+    handler:
+        The tool's Python callable.
+    name:
+        MCP tool name; defaults to ``handler.__name__``.
+    description:
+        Tool description; defaults to the first non-empty line of the handler's
+        docstring.
+    category, version:
+        Passed through to :class:`ToolSpec`.
+
+    Returns
+    -------
+    ToolSpec
+        Ready to pass to :func:`dcc_mcp_core._tool_registration.register_tools`.
+
+    """
+    # Local import to avoid a circular dependency at module-load time
+    # (_tool_registration is itself a small module but shared with many callers).
+    from dcc_mcp_core._tool_registration import ToolSpec
+
+    resolved_name = name or getattr(handler, "__name__", None)
+    if not resolved_name:
+        raise TypeError("tool_spec_from_callable: handler has no __name__; pass name=...")
+
+    doc = inspect.getdoc(handler) or ""
+    first_line = next((line for line in doc.splitlines() if line.strip()), "") if doc else ""
+    resolved_description = description if description is not None else first_line
+
+    sig = inspect.signature(handler)
+    hints = get_type_hints(handler, include_extras=True)
+    real_params = [
+        p
+        for p in sig.parameters.values()
+        if p.name != "self" and p.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+    ]
+
+    if len(real_params) == 1:
+        only = real_params[0]
+        annotation = hints.get(only.name, only.annotation)
+        if annotation is not inspect.Parameter.empty and _is_schema_object_type(annotation):
+            input_schema = derive_schema(annotation)
+        else:
+            input_schema = derive_parameters_schema(handler)
+    else:
+        input_schema = derive_parameters_schema(handler)
+
+    output_schema: dict[str, Any] | None = None
+    return_annotation = hints.get("return", sig.return_annotation)
+    if return_annotation not in (inspect.Parameter.empty, None, type(None)):
+        try:
+            output_schema = derive_schema(return_annotation)
+        except TypeError:
+            # Unsupported return type — leave outputSchema unset rather than
+            # failing registration. MCP treats outputSchema as optional.
+            output_schema = None
+
+    return ToolSpec(
+        name=resolved_name,
+        description=resolved_description,
+        input_schema=input_schema,
+        output_schema=output_schema,
+        handler=handler,
+        category=category,
+        version=version,
+    )
+
+
 __all__ = [
     "derive_parameters_schema",
     "derive_schema",
     "schema_from_doc",
+    "tool_spec_from_callable",
 ]

--- a/python/dcc_mcp_core/schema.py
+++ b/python/dcc_mcp_core/schema.py
@@ -1,0 +1,520 @@
+"""Zero-dependency type → JSON Schema derivation for MCP tool authors (issue #242).
+
+MCP 2025-06-18 lets servers publish ``inputSchema`` / ``outputSchema`` alongside
+every tool, and clients (LLM agents in particular) lean on those schemas to
+construct valid arguments and to *trust* the shape of returned data.  Today,
+Python tool authors in this repo must hand-write JSON schema strings — a
+footgun both for agents generating actions and for humans evolving them.
+
+This module provides a **pure-Python, stdlib-only** helper that derives a
+JSON Schema (Draft 2020-12, MCP 2025-06-18 flavoured) from:
+
+- ``@dataclass`` classes
+- ``typing.TypedDict`` subclasses
+- Plain ``typing`` annotations on function signatures
+
+The emitted shape matches what ``pydantic`` would emit for an equivalent model
+(same keys — ``title``, ``$defs``, ``$ref``, ``anyOf`` — same required-field
+rules) so callers who later switch to pydantic do not need to migrate agents or
+cached schemas.
+
+Out of scope: complex pydantic features (discriminated unions, computed
+fields, custom validators).  Callers who need those import pydantic themselves
+and pass the result of ``MyModel.model_json_schema()`` into ``ToolSpec``.
+
+See ``docs/guide/skills.md`` for usage examples.
+"""
+
+from __future__ import annotations
+
+from dataclasses import MISSING
+from dataclasses import fields as dataclass_fields
+from dataclasses import is_dataclass
+import datetime
+import enum
+import inspect
+import pathlib
+import types
+import typing
+from typing import Any
+from typing import Callable
+from typing import get_args
+from typing import get_origin
+from typing import get_type_hints
+import uuid
+
+# JSON Schema draft + MCP protocol pair we target.
+_JSON_SCHEMA_DRAFT = "https://json-schema.org/draft/2020-12/schema"
+
+
+# ── Type-to-schema atoms ──────────────────────────────────────────────────
+
+
+def _is_optional(tp: Any) -> tuple[bool, Any]:
+    """Return ``(is_optional, inner_type)`` for ``Optional[X]`` / ``X | None``.
+
+    For non-optional types returns ``(False, tp)``.
+    """
+    origin = get_origin(tp)
+    if origin is typing.Union or origin is types.UnionType:
+        args = [a for a in get_args(tp) if a is not type(None)]
+        had_none = len(args) != len(get_args(tp))
+        if had_none:
+            if len(args) == 1:
+                return True, args[0]
+            # Union[A, B, None] → treated as optional with anyOf over A, B.
+            return True, typing.Union[tuple(args)]
+    return False, tp
+
+
+def _primitive_schema(tp: Any) -> dict[str, Any] | None:
+    """Return the JSON Schema for a primitive leaf type.
+
+    Returns ``None`` when *tp* is not a primitive this helper recognises.
+    """
+    if tp is bool:
+        return {"type": "boolean"}
+    if tp is int:
+        return {"type": "integer"}
+    if tp is float:
+        return {"type": "number"}
+    if tp is str:
+        return {"type": "string"}
+    if tp is bytes:
+        return {"type": "string", "contentEncoding": "base64"}
+    if tp is type(None):
+        return {"type": "null"}
+    if tp is datetime.datetime:
+        return {"type": "string", "format": "date-time"}
+    if tp is datetime.date:
+        return {"type": "string", "format": "date"}
+    if tp is pathlib.Path or (isinstance(tp, type) and issubclass(tp, pathlib.PurePath)):
+        return {"type": "string"}
+    if tp is uuid.UUID:
+        return {"type": "string", "format": "uuid"}
+    if tp is Any:
+        # An empty schema accepts anything — this is JSON Schema's explicit
+        # "any value" form.
+        return {}
+    return None
+
+
+def _literal_schema(tp: Any) -> dict[str, Any] | None:
+    """Return a schema for ``Literal[...]`` or ``None`` if *tp* is not one."""
+    if get_origin(tp) is typing.Literal:
+        values = list(get_args(tp))
+        types_seen = {type(v) for v in values}
+        # If all values share a single primitive type, pin it — this helps
+        # validators short-circuit.
+        if types_seen == {bool}:
+            return {"enum": values, "type": "boolean"}
+        if types_seen == {int}:
+            return {"enum": values, "type": "integer"}
+        if types_seen == {str}:
+            return {"enum": values, "type": "string"}
+        return {"enum": values}
+    return None
+
+
+def _enum_schema(tp: Any) -> dict[str, Any] | None:
+    """Return a schema for an ``Enum`` subclass or ``None``."""
+    if isinstance(tp, type) and issubclass(tp, enum.Enum):
+        values = [member.value for member in tp]
+        schema: dict[str, Any] = {"enum": values, "title": tp.__name__}
+        types_seen = {type(v) for v in values}
+        if types_seen == {str}:
+            schema["type"] = "string"
+        elif types_seen == {int}:
+            schema["type"] = "integer"
+        return schema
+    return None
+
+
+# ── Container recursion ───────────────────────────────────────────────────
+
+
+def _container_schema(tp: Any, defs: dict[str, dict[str, Any]]) -> dict[str, Any] | None:
+    """Return a schema for ``list[X]`` / ``tuple[...]`` / ``dict[str, V]``."""
+    origin = get_origin(tp)
+    args = get_args(tp)
+    if origin in (list, set, frozenset):
+        item = args[0] if args else Any
+        return {"type": "array", "items": _derive(item, defs)}
+    if origin is tuple:
+        # ``tuple[X, ...]`` == homogeneous tuple
+        if len(args) == 2 and args[1] is Ellipsis:
+            return {"type": "array", "items": _derive(args[0], defs)}
+        if args:
+            return {
+                "type": "array",
+                "prefixItems": [_derive(a, defs) for a in args],
+                "minItems": len(args),
+                "maxItems": len(args),
+            }
+        return {"type": "array"}
+    if origin is dict:
+        # JSON objects only accept string keys.  We don't enforce the key type
+        # in the schema because JSON pointers make that explicit anyway.
+        if len(args) == 2:
+            return {"type": "object", "additionalProperties": _derive(args[1], defs)}
+        return {"type": "object"}
+    return None
+
+
+# ── Dataclass / TypedDict traversal ───────────────────────────────────────
+
+
+def _field_description(field_metadata: Any) -> str | None:
+    """Pull a ``description`` hint out of ``dataclasses.field(metadata=...)``."""
+    if not field_metadata:
+        return None
+    description = field_metadata.get("description") if hasattr(field_metadata, "get") else None
+    return description if isinstance(description, str) else None
+
+
+def _dataclass_schema(tp: type, defs: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    """Derive a schema for a dataclass.
+
+    Nested dataclasses are emitted into ``$defs`` and referenced via ``$ref``
+    so the output shape matches pydantic's ``model_json_schema()``.
+    """
+    title = tp.__name__
+    if title in defs:
+        return {"$ref": f"#/$defs/{title}"}
+
+    # Reserve the slot *before* recursing so cycles terminate.
+    defs[title] = {}  # placeholder
+
+    hints = get_type_hints(tp)
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    for f in dataclass_fields(tp):
+        annotation = hints.get(f.name, f.type)
+        is_opt, inner = _is_optional(annotation)
+        prop_schema = _derive(inner, defs)
+        if is_opt:
+            # Pydantic emits anyOf with a null branch for optional fields.
+            prop_schema = {"anyOf": [prop_schema, {"type": "null"}]}
+        description = _field_description(f.metadata)
+        if description:
+            prop_schema = {**prop_schema, "description": description}
+        properties[f.name] = prop_schema
+        # A field is "required" iff it has no default *and* no default_factory.
+        if f.default is MISSING and f.default_factory is MISSING:
+            required.append(f.name)
+
+    schema: dict[str, Any] = {
+        "type": "object",
+        "title": title,
+        "properties": properties,
+    }
+    if required:
+        schema["required"] = required
+    schema["additionalProperties"] = False
+
+    defs[title] = schema
+    return {"$ref": f"#/$defs/{title}"}
+
+
+def _is_typeddict(tp: Any) -> bool:
+    return isinstance(tp, type) and issubclass(tp, dict) and hasattr(tp, "__required_keys__")
+
+
+def _typeddict_schema(tp: type, defs: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    title = tp.__name__
+    if title in defs:
+        return {"$ref": f"#/$defs/{title}"}
+    defs[title] = {}  # placeholder for cycle safety
+
+    hints = get_type_hints(tp)
+    properties: dict[str, Any] = {}
+    for key, annotation in hints.items():
+        is_opt, inner = _is_optional(annotation)
+        prop = _derive(inner, defs)
+        if is_opt:
+            prop = {"anyOf": [prop, {"type": "null"}]}
+        properties[key] = prop
+
+    schema: dict[str, Any] = {
+        "type": "object",
+        "title": title,
+        "properties": properties,
+    }
+    required = sorted(tp.__required_keys__)
+    if required:
+        schema["required"] = required
+    schema["additionalProperties"] = False
+
+    defs[title] = schema
+    return {"$ref": f"#/$defs/{title}"}
+
+
+# ── Core dispatch ─────────────────────────────────────────────────────────
+
+
+def _derive(tp: Any, defs: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    """Derive a schema for *tp*, populating *defs* with referenced types.
+
+    Raises ``TypeError`` for unsupported types so callers never get a silent
+    ``{"type": "object"}`` fallback.
+    """
+    # Optional first — unwrap the None branch before anything else.
+    is_opt, inner = _is_optional(tp)
+    if is_opt:
+        sub = _derive(inner, defs)
+        return {"anyOf": [sub, {"type": "null"}]}
+
+    # Leaf primitives.
+    prim = _primitive_schema(tp)
+    if prim is not None:
+        return prim
+
+    # Literal / Enum.
+    lit = _literal_schema(tp)
+    if lit is not None:
+        return lit
+    en = _enum_schema(tp)
+    if en is not None:
+        return en
+
+    # list / tuple / dict ...
+    container = _container_schema(tp, defs)
+    if container is not None:
+        return container
+
+    # Union (non-optional).
+    origin = get_origin(tp)
+    if origin is typing.Union or origin is types.UnionType:
+        return {"anyOf": [_derive(a, defs) for a in get_args(tp)]}
+
+    # Dataclass / TypedDict.
+    if is_dataclass(tp) and isinstance(tp, type):
+        return _dataclass_schema(tp, defs)
+    if _is_typeddict(tp):
+        return _typeddict_schema(tp, defs)
+
+    raise TypeError(
+        f"derive_schema: unsupported type {tp!r}. "
+        f"Pass an explicit input_schema= / output_schema= dict for exotic types, "
+        f"or import pydantic and use MyModel.model_json_schema()."
+    )
+
+
+# ── Public API ────────────────────────────────────────────────────────────
+
+
+def derive_schema(tp: type, *, allow_additional: bool = False) -> dict[str, Any]:
+    """Derive a JSON Schema dict from a dataclass / TypedDict / primitive.
+
+    Parameters
+    ----------
+    tp:
+        The type to describe.  Most commonly a ``@dataclass`` class.
+    allow_additional:
+        When ``True``, the emitted object schemas allow extra keys
+        (``"additionalProperties": true``).  Default ``False`` mirrors
+        pydantic's ``model_config.extra="forbid"`` so typos in arguments are
+        rejected early.
+
+    Returns
+    -------
+    dict
+        A JSON Schema dict.  For dataclasses / TypedDicts the shape is an
+        inline object schema with nested ``$defs`` when referenced multiple
+        times; for primitives the leaf schema is returned unchanged.
+
+    """
+    defs: dict[str, dict[str, Any]] = {}
+    top = _derive(tp, defs)
+
+    # For object types we stored the body in $defs and the top-level is a
+    # $ref — flatten that so agents see the full schema inline.  Any remaining
+    # $defs (nested references, cycles) stay attached.
+    if "$ref" in top and top["$ref"].startswith("#/$defs/"):
+        name = top["$ref"].rsplit("/", 1)[-1]
+        body = dict(defs.pop(name))
+        if body.get("type") == "object":
+            body["additionalProperties"] = bool(allow_additional)
+        if defs:
+            body["$defs"] = defs
+        body.setdefault("$schema", _JSON_SCHEMA_DRAFT)
+        return body
+
+    # Primitive / container top-level.
+    if defs:
+        top = {**top, "$defs": defs}
+    return top
+
+
+def derive_parameters_schema(fn: Callable[..., Any]) -> dict[str, Any]:
+    """Derive an object schema where each function parameter becomes a property.
+
+    ``*args`` / ``**kwargs`` parameters are skipped — JSON Schema has no way to
+    express them losslessly, and they are discouraged in MCP tool signatures.
+    The return annotation is not inspected here; use :func:`derive_schema` on
+    the return type if you want an ``outputSchema``.
+
+    Descriptions sourced from a numpy-style or Google-style docstring are
+    attached to properties when available (:func:`schema_from_doc`).
+
+    Raises ``TypeError`` if any parameter is untyped — we never emit a silent
+    "accept anything" fallback (the #588-era footgun).
+    """
+    sig = inspect.signature(fn)
+    hints = get_type_hints(fn, include_extras=True)
+
+    param_descriptions = schema_from_doc(fn)
+
+    defs: dict[str, dict[str, Any]] = {}
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    has_untyped = False
+    for name, param in sig.parameters.items():
+        if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+            continue
+        if name == "self":
+            continue
+        annotation = hints.get(name, param.annotation)
+        if annotation is inspect.Parameter.empty:
+            has_untyped = True
+            continue
+        is_opt, inner = _is_optional(annotation)
+        prop = _derive(inner, defs)
+        if is_opt:
+            prop = {"anyOf": [prop, {"type": "null"}]}
+        description = param_descriptions.get(name)
+        if description:
+            prop = {**prop, "description": description}
+        properties[name] = prop
+        if param.default is inspect.Parameter.empty and not is_opt:
+            required.append(name)
+
+    if has_untyped:
+        raise TypeError(
+            f"derive_parameters_schema: {fn.__qualname__} has untyped parameters. "
+            f"Annotate all params or pass an explicit input_schema=."
+        )
+
+    schema: dict[str, Any] = {
+        "$schema": _JSON_SCHEMA_DRAFT,
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": False,
+    }
+    if required:
+        schema["required"] = required
+    if defs:
+        schema["$defs"] = defs
+    return schema
+
+
+def schema_from_doc(fn: Callable[..., Any]) -> dict[str, str]:
+    r"""Return a ``{param_name: description}`` map parsed from *fn*'s docstring.
+
+    Recognises numpy-style (``Parameters\n----------``) and Google-style
+    (``Args:``) docstrings without any dependency on a docstring library.
+    Unknown formats return an empty mapping — the caller falls back to
+    field-level ``metadata={"description": ...}`` on the dataclass or just
+    omits descriptions.
+    """
+    doc = inspect.getdoc(fn) or ""
+    if not doc:
+        return {}
+
+    out: dict[str, str] = {}
+
+    lines = doc.splitlines()
+    n = len(lines)
+    i = 0
+    while i < n:
+        line = lines[i].strip()
+        if line == "Parameters":
+            i += 1
+            if i < n and set(lines[i].strip()) == {"-"}:
+                i += 1
+            # numpy-style block after ``inspect.getdoc`` dedent: each
+            # "name : type" starts at column 0, its description follows on
+            # an indented line.  The block ends at a blank line followed by
+            # a new section header (or EOF).
+            while i < n:
+                raw = lines[i]
+                stripped = raw.strip()
+                if not stripped:
+                    j = i + 1
+                    while j < n and not lines[j].strip():
+                        j += 1
+                    if j >= n or lines[j].strip() in (
+                        "Returns",
+                        "Raises",
+                        "Examples",
+                        "Notes",
+                        "See Also",
+                        "Yields",
+                    ):
+                        break
+                    i += 1
+                    continue
+                # "name : type" line.
+                if ":" in stripped:
+                    name = stripped.split(":", 1)[0].strip()
+                    desc_lines: list[str] = []
+                    k = i + 1
+                    # Collect indented continuation lines.
+                    while k < n:
+                        nxt = lines[k]
+                        if not nxt.strip():
+                            break
+                        indent = len(nxt) - len(nxt.lstrip())
+                        if indent == 0:
+                            break
+                        desc_lines.append(nxt.strip())
+                        k += 1
+                    if desc_lines and name.replace("_", "").isalnum():
+                        out[name] = " ".join(desc_lines)
+                    i = k
+                    continue
+                i += 1
+            continue
+        if line == "Args:":
+            i += 1
+            # Google-style block: "name: description" with wrap continuation.
+            base_indent: int | None = None
+            while i < n:
+                raw = lines[i]
+                stripped = raw.strip()
+                if not stripped:
+                    i += 1
+                    continue
+                indent = len(raw) - len(raw.lstrip())
+                if base_indent is None:
+                    base_indent = indent
+                if indent < base_indent:
+                    break
+                if indent == base_indent and ":" in stripped:
+                    name, _, rest = stripped.partition(":")
+                    name = name.strip()
+                    desc_lines = [rest.strip()] if rest.strip() else []
+                    k = i + 1
+                    while k < n:
+                        next_indent = len(lines[k]) - len(lines[k].lstrip())
+                        if lines[k].strip() and next_indent <= base_indent:
+                            break
+                        if lines[k].strip():
+                            desc_lines.append(lines[k].strip())
+                        k += 1
+                    if desc_lines:
+                        out[name] = " ".join(desc_lines)
+                    i = k
+                    continue
+                i += 1
+            continue
+        i += 1
+
+    return out
+
+
+__all__ = [
+    "derive_parameters_schema",
+    "derive_schema",
+    "schema_from_doc",
+]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,412 @@
+"""Tests for dcc_mcp_core.schema — zero-dep type → JSON Schema derivation (#242)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+import datetime
+import enum
+from pathlib import Path
+from typing import Any
+from typing import Literal
+from typing import TypedDict
+from typing import Union
+import uuid
+
+import pytest
+
+from dcc_mcp_core.schema import derive_parameters_schema
+from dcc_mcp_core.schema import derive_schema
+from dcc_mcp_core.schema import schema_from_doc
+
+# ── Primitives ─────────────────────────────────────────────────────────────
+
+
+class TestPrimitiveTypes:
+    def test_bool(self) -> None:
+        assert derive_schema(bool) == {"type": "boolean"}
+
+    def test_int(self) -> None:
+        assert derive_schema(int) == {"type": "integer"}
+
+    def test_float(self) -> None:
+        assert derive_schema(float) == {"type": "number"}
+
+    def test_str(self) -> None:
+        assert derive_schema(str) == {"type": "string"}
+
+    def test_bytes_becomes_base64_string(self) -> None:
+        assert derive_schema(bytes) == {
+            "type": "string",
+            "contentEncoding": "base64",
+        }
+
+    def test_none_type(self) -> None:
+        assert derive_schema(type(None)) == {"type": "null"}
+
+    def test_datetime(self) -> None:
+        assert derive_schema(datetime.datetime) == {
+            "type": "string",
+            "format": "date-time",
+        }
+
+    def test_date(self) -> None:
+        assert derive_schema(datetime.date) == {"type": "string", "format": "date"}
+
+    def test_pathlib_path(self) -> None:
+        assert derive_schema(Path) == {"type": "string"}
+
+    def test_uuid(self) -> None:
+        assert derive_schema(uuid.UUID) == {"type": "string", "format": "uuid"}
+
+    def test_any(self) -> None:
+        assert derive_schema(Any) == {}
+
+
+# ── Containers ─────────────────────────────────────────────────────────────
+
+
+class TestContainers:
+    def test_list_of_str(self) -> None:
+        assert derive_schema(list[str]) == {
+            "type": "array",
+            "items": {"type": "string"},
+        }
+
+    def test_homogeneous_tuple(self) -> None:
+        assert derive_schema(tuple[int, ...]) == {
+            "type": "array",
+            "items": {"type": "integer"},
+        }
+
+    def test_fixed_tuple(self) -> None:
+        assert derive_schema(tuple[int, str, bool]) == {
+            "type": "array",
+            "prefixItems": [
+                {"type": "integer"},
+                {"type": "string"},
+                {"type": "boolean"},
+            ],
+            "minItems": 3,
+            "maxItems": 3,
+        }
+
+    def test_dict_str_v(self) -> None:
+        assert derive_schema(dict[str, int]) == {
+            "type": "object",
+            "additionalProperties": {"type": "integer"},
+        }
+
+    def test_nested_list_of_list(self) -> None:
+        assert derive_schema(list[list[int]]) == {
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {"type": "integer"},
+            },
+        }
+
+
+# ── Optional / Union / Literal / Enum ──────────────────────────────────────
+
+
+class TestUnionAndLiterals:
+    def test_optional_unwraps_to_anyof_with_null(self) -> None:
+        assert derive_schema(int | None) == {
+            "anyOf": [{"type": "integer"}, {"type": "null"}],
+        }
+
+    def test_pep604_union_none(self) -> None:
+        # Same as above, kept as a separate assertion to spell out the intent.
+        assert derive_schema(int | None) == {
+            "anyOf": [{"type": "integer"}, {"type": "null"}],
+        }
+
+    def test_union_non_optional(self) -> None:
+        assert derive_schema(Union[int, str]) == {
+            "anyOf": [{"type": "integer"}, {"type": "string"}],
+        }
+
+    def test_literal_str(self) -> None:
+        assert derive_schema(Literal["fbx", "abc", "usd"]) == {
+            "enum": ["fbx", "abc", "usd"],
+            "type": "string",
+        }
+
+    def test_literal_int(self) -> None:
+        assert derive_schema(Literal[1, 2, 3]) == {
+            "enum": [1, 2, 3],
+            "type": "integer",
+        }
+
+    def test_literal_mixed_types(self) -> None:
+        result = derive_schema(Literal["on", 1, True])
+        assert result["enum"] == ["on", 1, True]
+        assert "type" not in result  # mixed types → no `type` pin
+
+    def test_string_enum(self) -> None:
+        class Colour(enum.Enum):
+            RED = "red"
+            GREEN = "green"
+            BLUE = "blue"
+
+        schema = derive_schema(Colour)
+        assert schema["enum"] == ["red", "green", "blue"]
+        assert schema["type"] == "string"
+        assert schema["title"] == "Colour"
+
+    def test_int_enum(self) -> None:
+        class Status(enum.IntEnum):
+            OK = 0
+            ERROR = 1
+
+        schema = derive_schema(Status)
+        assert schema["enum"] == [0, 1]
+        assert schema["type"] == "integer"
+
+
+# ── Dataclasses ────────────────────────────────────────────────────────────
+
+
+@dataclass
+class Point:
+    x: float
+    y: float
+    label: str | None = None
+
+
+@dataclass
+class Polygon:
+    name: str
+    vertices: list[Point]
+    closed: bool = True
+
+
+class TestDataclasses:
+    def test_simple_dataclass(self) -> None:
+        schema = derive_schema(Point)
+        # Top-level is flattened (no $ref).
+        assert schema["type"] == "object"
+        assert schema["title"] == "Point"
+        assert schema["additionalProperties"] is False
+        assert schema["$schema"].endswith("draft/2020-12/schema")
+
+        # Required fields: only those without defaults.
+        assert set(schema["required"]) == {"x", "y"}
+
+        # Field types.
+        props = schema["properties"]
+        assert props["x"] == {"type": "number"}
+        assert props["y"] == {"type": "number"}
+        # Optional[str] → anyOf([string, null])
+        assert props["label"] == {"anyOf": [{"type": "string"}, {"type": "null"}]}
+
+    def test_nested_dataclass_uses_defs(self) -> None:
+        schema = derive_schema(Polygon)
+        assert schema["title"] == "Polygon"
+        # The nested Point lives in $defs and is $ref'd.
+        assert "$defs" in schema
+        assert "Point" in schema["$defs"]
+        assert schema["properties"]["vertices"] == {
+            "type": "array",
+            "items": {"$ref": "#/$defs/Point"},
+        }
+        assert set(schema["required"]) == {"name", "vertices"}
+
+    def test_field_metadata_description(self) -> None:
+        @dataclass
+        class Input:
+            radius: float = field(metadata={"description": "Sphere radius in cm"})
+
+        schema = derive_schema(Input)
+        assert schema["properties"]["radius"] == {
+            "type": "number",
+            "description": "Sphere radius in cm",
+        }
+
+    def test_dataclass_with_default_factory_is_optional(self) -> None:
+        @dataclass
+        class WithList:
+            name: str
+            tags: list[str] = field(default_factory=list)
+
+        schema = derive_schema(WithList)
+        assert schema["required"] == ["name"]
+
+    def test_additional_properties_opt_in(self) -> None:
+        schema_strict = derive_schema(Point)
+        assert schema_strict["additionalProperties"] is False
+
+        schema_open = derive_schema(Point, allow_additional=True)
+        assert schema_open["additionalProperties"] is True
+
+
+# ── TypedDict ──────────────────────────────────────────────────────────────
+
+
+class MovieTD(TypedDict):
+    title: str
+    year: int
+
+
+class MovieTDWithOptional(TypedDict, total=False):
+    title: str  # overridden below
+    director: str
+
+
+class TestTypedDict:
+    def test_all_required(self) -> None:
+        schema = derive_schema(MovieTD)
+        assert schema["type"] == "object"
+        assert schema["title"] == "MovieTD"
+        assert schema["properties"] == {
+            "title": {"type": "string"},
+            "year": {"type": "integer"},
+        }
+        assert set(schema["required"]) == {"title", "year"}
+
+    def test_total_false_means_none_required(self) -> None:
+        schema = derive_schema(MovieTDWithOptional)
+        assert "required" not in schema
+
+
+# ── Unsupported types raise ────────────────────────────────────────────────
+
+
+class TestUnsupported:
+    def test_plain_class_raises(self) -> None:
+        class Plain:
+            pass
+
+        with pytest.raises(TypeError, match="unsupported type"):
+            derive_schema(Plain)
+
+    def test_error_mentions_escape_hatch(self) -> None:
+        class Plain:
+            pass
+
+        with pytest.raises(TypeError, match="explicit input_schema"):
+            derive_schema(Plain)
+
+
+# ── derive_parameters_schema ───────────────────────────────────────────────
+
+
+class TestDeriveParametersSchema:
+    def test_single_typed_param(self) -> None:
+        def fn(name: str) -> None: ...
+
+        schema = derive_parameters_schema(fn)
+        assert schema["type"] == "object"
+        assert schema["properties"] == {"name": {"type": "string"}}
+        assert schema["required"] == ["name"]
+        assert schema["additionalProperties"] is False
+
+    def test_multi_params_with_defaults(self) -> None:
+        def fn(radius: float, segments: int = 16, label: str = "sphere") -> None: ...
+
+        schema = derive_parameters_schema(fn)
+        assert set(schema["properties"].keys()) == {"radius", "segments", "label"}
+        assert schema["required"] == ["radius"]
+
+    def test_optional_param_is_not_required(self) -> None:
+        def fn(x: int, y: int | None = None) -> None: ...
+
+        schema = derive_parameters_schema(fn)
+        assert schema["required"] == ["x"]
+        assert schema["properties"]["y"] == {
+            "anyOf": [{"type": "integer"}, {"type": "null"}],
+        }
+
+    def test_skips_var_args(self) -> None:
+        def fn(x: int, *args: int, **kwargs: str) -> None: ...
+
+        schema = derive_parameters_schema(fn)
+        assert set(schema["properties"].keys()) == {"x"}
+
+    def test_skips_self(self) -> None:
+        class _Holder:
+            def method(self, x: int) -> None: ...
+
+        schema = derive_parameters_schema(_Holder.method)
+        assert set(schema["properties"].keys()) == {"x"}
+
+    def test_untyped_param_raises(self) -> None:
+        def fn(x, y: int) -> None: ...
+
+        with pytest.raises(TypeError, match="untyped parameters"):
+            derive_parameters_schema(fn)
+
+    def test_numpy_style_docstring_attaches_descriptions(self) -> None:
+        def fn(radius: float, segments: int = 16) -> None:
+            """Build a sphere.
+
+            Parameters
+            ----------
+            radius : float
+                Radius of the sphere in cm.
+            segments : int
+                Number of latitude segments.
+
+            """
+
+        schema = derive_parameters_schema(fn)
+        assert schema["properties"]["radius"]["description"] == "Radius of the sphere in cm."
+        assert schema["properties"]["segments"]["description"] == "Number of latitude segments."
+
+    def test_google_style_docstring(self) -> None:
+        def fn(scene_path: str, format: str = "fbx") -> None:
+            """Export a scene.
+
+            Args:
+                scene_path: Absolute path to the scene file.
+                format: One of fbx/abc/usd.
+
+            """
+
+        schema = derive_parameters_schema(fn)
+        assert schema["properties"]["scene_path"]["description"] == ("Absolute path to the scene file.")
+        assert schema["properties"]["format"]["description"] == "One of fbx/abc/usd."
+
+
+# ── schema_from_doc ────────────────────────────────────────────────────────
+
+
+class TestSchemaFromDoc:
+    def test_empty_docstring(self) -> None:
+        def fn() -> None: ...
+
+        assert schema_from_doc(fn) == {}
+
+    def test_no_parameters_section(self) -> None:
+        def fn() -> None:
+            """Just a description."""
+
+        assert schema_from_doc(fn) == {}
+
+    def test_numpy_wrapped_description(self) -> None:
+        def fn() -> None:
+            """X.
+
+            Parameters
+            ----------
+            foo : int
+                description that
+                continues on the next line
+
+            """
+
+        result = schema_from_doc(fn)
+        assert result["foo"] == "description that continues on the next line"
+
+
+# ── Forward/cyclic ─────────────────────────────────────────────────────────
+
+
+class TestEdgeCases:
+    def test_optional_dataclass(self) -> None:
+        schema = derive_schema(Point | None)
+        assert schema["anyOf"][1] == {"type": "null"}
+        # First branch is the Point object schema.
+        first = schema["anyOf"][0]
+        assert first.get("$ref") == "#/$defs/Point" or first.get("title") == "Point"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -18,6 +18,7 @@ import pytest
 from dcc_mcp_core.schema import derive_parameters_schema
 from dcc_mcp_core.schema import derive_schema
 from dcc_mcp_core.schema import schema_from_doc
+from dcc_mcp_core.schema import tool_spec_from_callable
 
 # ── Primitives ─────────────────────────────────────────────────────────────
 
@@ -410,3 +411,93 @@ class TestEdgeCases:
         # First branch is the Point object schema.
         first = schema["anyOf"][0]
         assert first.get("$ref") == "#/$defs/Point" or first.get("title") == "Point"
+
+
+# ── tool_spec_from_callable ────────────────────────────────────────────────
+
+
+@dataclass
+class _ExportInput:
+    scene_path: str
+    format: Literal["fbx", "abc", "usd"] = "fbx"
+
+
+@dataclass
+class _ExportResult:
+    path: str
+    size_bytes: int
+
+
+class _NotAThing: ...
+
+
+class TestToolSpecFromCallable:
+    def test_single_dataclass_param(self) -> None:
+        def export_scene(args: _ExportInput) -> _ExportResult:
+            """Export a scene to an interchange format."""
+            return _ExportResult(path=args.scene_path, size_bytes=0)
+
+        spec = tool_spec_from_callable(export_scene)
+
+        assert spec.name == "export_scene"
+        assert spec.description == "Export a scene to an interchange format."
+        # Single-dataclass style: inputSchema IS the dataclass schema.
+        assert spec.input_schema["type"] == "object"
+        assert spec.input_schema["title"] == "_ExportInput"
+        assert "scene_path" in spec.input_schema["properties"]
+        # outputSchema derived from return annotation.
+        assert spec.output_schema is not None
+        assert spec.output_schema["title"] == "_ExportResult"
+
+    def test_multi_primitive_params(self) -> None:
+        def make_sphere(radius: float, segments: int = 16) -> dict[str, int]:
+            return {"radius": int(radius), "segments": segments}
+
+        spec = tool_spec_from_callable(make_sphere)
+
+        # Multi-primitive style: inputSchema is an object with each param as a property.
+        assert spec.input_schema["type"] == "object"
+        assert set(spec.input_schema["properties"]) == {"radius", "segments"}
+        assert spec.input_schema["required"] == ["radius"]
+        # Return type dict[str, int] → outputSchema is an object with additionalProperties.
+        assert spec.output_schema == {
+            "type": "object",
+            "additionalProperties": {"type": "integer"},
+        }
+
+    def test_refuses_untyped_handler(self) -> None:
+        def fn(x, y): ...  # no annotations
+
+        with pytest.raises(TypeError, match="untyped parameters"):
+            tool_spec_from_callable(fn)
+
+    def test_no_return_annotation_leaves_output_schema_unset(self) -> None:
+        def fn(x: int) -> None: ...
+
+        spec = tool_spec_from_callable(fn)
+        assert spec.output_schema is None
+
+    def test_unsupported_return_type_silently_drops_output_schema(self) -> None:
+        def fn(x: int) -> _NotAThing:
+            raise NotImplementedError
+
+        spec = tool_spec_from_callable(fn)
+        # Input schema still derived from the typed parameter.
+        assert spec.input_schema["properties"] == {"x": {"type": "integer"}}
+        # Unsupported return → outputSchema left out, but registration still works.
+        assert spec.output_schema is None
+
+    def test_name_and_description_overrides(self) -> None:
+        def fn(x: int) -> None: ...
+
+        spec = tool_spec_from_callable(
+            fn,
+            name="custom.name",
+            description="custom desc",
+            category="custom",
+            version="2.0.0",
+        )
+        assert spec.name == "custom.name"
+        assert spec.description == "custom desc"
+        assert spec.category == "custom"
+        assert spec.version == "2.0.0"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -501,3 +501,39 @@ class TestToolSpecFromCallable:
         assert spec.description == "custom desc"
         assert spec.category == "custom"
         assert spec.version == "2.0.0"
+
+
+def test_typed_schema_demo_example_imports_cleanly() -> None:
+    """Protect examples/skills/typed-schema-demo from bitrot.
+
+    We import the demo module by path (directory name has a hyphen so it's
+    not a valid Python package name) and assert that its derived ``spec``
+    has the expected schema fields.
+    """
+    import importlib.util
+    from pathlib import Path
+    import sys
+
+    repo_root = Path(__file__).resolve().parent.parent
+    demo_py = repo_root / "examples" / "skills" / "typed-schema-demo" / "scripts" / "demo.py"
+    assert demo_py.is_file(), f"demo script missing at {demo_py}"
+
+    mod_name = "_typed_schema_demo"
+    spec = importlib.util.spec_from_file_location(mod_name, demo_py)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # dataclasses with ``from __future__ import annotations`` need the module
+    # present in sys.modules so ``typing.get_type_hints`` can resolve string
+    # annotations against the module's namespace.
+    sys.modules[mod_name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(mod_name, None)
+
+    tool_spec = module.spec
+    assert tool_spec.name == "typed_schema_demo__export"
+    assert tool_spec.input_schema["type"] == "object"
+    assert "scene_path" in tool_spec.input_schema["properties"]
+    assert tool_spec.output_schema is not None
+    assert tool_spec.output_schema["title"] == "ExportResult"

--- a/tests/test_tool_registration.py
+++ b/tests/test_tool_registration.py
@@ -1,0 +1,120 @@
+"""Tests for dcc_mcp_core._tool_registration (ToolSpec + register_tools)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+from dcc_mcp_core._tool_registration import ToolSpec
+from dcc_mcp_core._tool_registration import register_tools
+
+
+def _make_fake_server() -> tuple[MagicMock, dict]:
+    server = MagicMock()
+    server.registry = MagicMock()
+    handlers: dict = {}
+    server.register_handler.side_effect = lambda name, fn: handlers.__setitem__(name, fn)
+    return server, handlers
+
+
+def _handler(params: object) -> dict:
+    return {"ok": True, "params": params}
+
+
+class TestToolSpecDefaults:
+    def test_output_schema_defaults_to_none(self) -> None:
+        spec = ToolSpec(
+            name="demo",
+            description="x",
+            input_schema={"type": "object"},
+            handler=_handler,
+        )
+        assert spec.output_schema is None
+
+    def test_output_schema_accepts_dict(self) -> None:
+        spec = ToolSpec(
+            name="demo",
+            description="x",
+            input_schema={"type": "object"},
+            handler=_handler,
+            output_schema={"type": "object", "properties": {"ok": {"type": "boolean"}}},
+        )
+        assert spec.output_schema["properties"]["ok"] == {"type": "boolean"}
+
+
+class TestRegisterTools:
+    def test_calls_registry_register_with_input_schema_only(self) -> None:
+        server, handlers = _make_fake_server()
+        spec = ToolSpec(
+            name="demo",
+            description="d",
+            input_schema={"type": "object"},
+            handler=_handler,
+        )
+
+        assert register_tools(server, [spec]) == 1
+
+        call = server.registry.register.call_args
+        assert call.kwargs["name"] == "demo"
+        # Schema is serialised to a JSON string.
+        assert json.loads(call.kwargs["input_schema"]) == {"type": "object"}
+        # output_schema kwarg must NOT be present when spec.output_schema is None.
+        assert "output_schema" not in call.kwargs
+        assert "demo" in handlers
+
+    def test_passes_output_schema_when_present(self) -> None:
+        server, _handlers = _make_fake_server()
+        spec = ToolSpec(
+            name="demo",
+            description="d",
+            input_schema={"type": "object"},
+            handler=_handler,
+            output_schema={"type": "object", "properties": {"ok": {"type": "boolean"}}},
+        )
+
+        register_tools(server, [spec])
+
+        call = server.registry.register.call_args
+        assert "output_schema" in call.kwargs
+        assert json.loads(call.kwargs["output_schema"]) == {
+            "type": "object",
+            "properties": {"ok": {"type": "boolean"}},
+        }
+
+    def test_retries_without_output_schema_on_typeerror(self) -> None:
+        """If the registry rejects the output_schema kwarg, we retry without it
+        rather than dropping the whole registration.  Logged as a warning.
+        """
+        server, handlers = _make_fake_server()
+
+        # First call raises TypeError mentioning output_schema; second succeeds.
+        call_count = {"n": 0}
+
+        def fake_register(**kwargs: object) -> None:
+            call_count["n"] += 1
+            if "output_schema" in kwargs:
+                raise TypeError("register() got an unexpected keyword argument 'output_schema'")
+
+        server.registry.register.side_effect = fake_register
+
+        spec = ToolSpec(
+            name="demo",
+            description="d",
+            input_schema={"type": "object"},
+            handler=_handler,
+            output_schema={"type": "object"},
+        )
+
+        assert register_tools(server, [spec]) == 1
+        # First call with output_schema, second retry without.
+        assert call_count["n"] == 2
+        # Handler still got attached.
+        assert "demo" in handlers
+
+    def test_no_registry_logs_warning(self) -> None:
+        class _BadServer:
+            @property
+            def registry(self) -> object:
+                raise AttributeError("no registry")
+
+        assert register_tools(_BadServer(), []) == 0


### PR DESCRIPTION
## Why

Issue #242 (structuredContent + outputSchema for tool results) landed most of its acceptance criteria, but one remained unshipped on main:

> "Python action authoring: support returning a Pydantic model or dataclass; the bridge derives the schema automatically."

Hand-written JSON Schema is a footgun — especially for LLM-authored actions. Agent-generated schemas drift from the actual code, cached schemas diverge over time, and review of the schema text is noisy. This PR lets authors write a typed Python handler and get both `inputSchema` and `outputSchema` derived automatically, **without** adding any Python dependency.

Follows up #242.

## Can we reuse pydantic-core (Rust)?

Evaluated and rejected. Verified with pydantic's own architecture doc: JSON Schema generation is done entirely in the Python package (`pydantic.json_schema.GenerateJsonSchema`, ~800 LOC); `pydantic-core` (Rust) only runs validation / serialization and never introspects Python type annotations. The Rust ecosystem has no alternative: `schemars` only handles Rust structs, `jsonschema-rs` is a validator, `pythonize` is serde↔Python object bridging.

Closest prior art is pure Python (`dc_schema`, `dataclasses-jsonschema`) — both ~200-300 LOC stdlib code, which is exactly what we ship.

## What's in this PR

Five commits, one logical feature:

| Commit | Scope |
|---|---|
| `feat(schema): zero-dep type to JSON Schema helper` | New `python/dcc_mcp_core/schema.py` (~520 LOC): `derive_schema`, `derive_parameters_schema`, `schema_from_doc` + 45-test suite |
| `feat(_tool_registration): add output_schema to ToolSpec` | `ToolSpec` gains `output_schema: dict \| None`; `register_tools` plumbs it to `registry.register(output_schema=...)` with graceful degradation on older Rust builds |
| `feat(schema): tool_spec_from_callable helper` | One-call bridge: typed handler → ready-to-register `ToolSpec`. Refuses untyped handlers (no silent permissive fallback — closes the #588-era footgun). Exported from top-level `dcc_mcp_core` |
| `feat(examples): typed-schema-demo skill` | Runnable `examples/skills/typed-schema-demo/` + bitrot-protection test |
| `docs: document structured schema derivation` | `docs/guide/skills.md` (EN + ZH) + `llms.txt` / `llms-full.txt` / `docs/api/actions.md` cross-refs, including a "Why not pydantic?" callout |

## Usage

```python
from dataclasses import dataclass, field
from typing import Literal
from dcc_mcp_core import tool_spec_from_callable
from dcc_mcp_core._tool_registration import register_tools

@dataclass
class ExportInput:
    scene_path: str = field(metadata={"description": "Scene file to export."})
    format: Literal["fbx", "abc", "usd"] = "fbx"
    frame_range: tuple[int, int] = (1, 100)

@dataclass
class ExportResult:
    path: str
    size_bytes: int
    took_ms: int

def export_scene(args: ExportInput) -> ExportResult:
    """Export a scene to an interchange format."""
    ...

spec = tool_spec_from_callable(export_scene)
register_tools(server, [spec], dcc_name="maya")
```

The derived schema shape matches what `pydantic.model_json_schema()` emits (`title`, `$defs`, `$ref`, `anyOf`), so callers can swap in pydantic later with no migration required.

## Supported types (stdlib only)

`bool`, `int`, `float`, `str`, `bytes`, `None`, `list[X]`, `tuple[X, ...]`, fixed `tuple[A, B, ...]`, `dict[str, V]`, `Optional[X]` / `X | None`, `Union[A, B]`, `Literal[...]`, `Enum`, `datetime.datetime`, `datetime.date`, `pathlib.Path`, `uuid.UUID`, `@dataclass`, `TypedDict`.

Unsupported types raise `TypeError` with a clear escape hatch ("pass an explicit `input_schema=...` dict or use pydantic's `MyModel.model_json_schema()`").

## Out of scope

- Rust-side changes. The registry still accepts `input_schema` / `output_schema` as JSON **strings**; our helper serialises before calling `registry.register`.
- Full JSON Schema Draft 2020-12 coverage. We ship the subset Python tools actually use.
- Complex pydantic features (discriminated unions, computed fields, custom validators). Callers who need those import pydantic themselves and pass `MyModel.model_json_schema()` into `ToolSpec.input_schema`.

## Validation

- `ruff check` on all touched Python files — clean
- Full Python test suite (excluding mcporter e2e): **8726 passed, 60 skipped** in 65 s (up from 8668 on #651 — the +58 are the new tests)
- 119 existing `register_tools`-dependent tests (checkpoint / recipes / introspect / feedback / project) — no regression
- `npm run docs:build` (VitePress with dead-link check) — **build complete**, 0 dead links
- `python examples/skills/typed-schema-demo/scripts/demo.py` prints a valid pydantic-shape JSON Schema end-to-end
