### PR TITLE
fix: keep schema helpers py37 compatible

### DIFF
--- a/crates/dcc-mcp-skills/src/feedback.rs
+++ b/crates/dcc-mcp-skills/src/feedback.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(
     feature = "python-bindings",
-    pyo3::pyclass(name = "SkillFeedback", get_all, set_all)
+    pyo3::pyclass(name = "SkillFeedback", get_all, set_all, skip_from_py_object)
 )]
 pub struct SkillFeedback {
     /// ISO-8601 timestamp.

--- a/crates/dcc-mcp-skills/src/versioning.rs
+++ b/crates/dcc-mcp-skills/src/versioning.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(
     feature = "python-bindings",
-    pyo3::pyclass(name = "SkillVersionManifest", get_all, set_all)
+    pyo3::pyclass(name = "SkillVersionManifest", get_all, set_all, skip_from_py_object)
 )]
 pub struct SkillVersionManifest {
     /// Current semantic version.
@@ -24,7 +24,7 @@ pub struct SkillVersionManifest {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(
     feature = "python-bindings",
-    pyo3::pyclass(name = "SkillVersionEntry", get_all, set_all)
+    pyo3::pyclass(name = "SkillVersionEntry", get_all, set_all, from_py_object)
 )]
 pub struct SkillVersionEntry {
     /// Version string at this point.

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -183,7 +183,7 @@ Write a typed handler:
 
 ```python
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Tuple
 
 from dcc_mcp_core import tool_spec_from_callable
 from dcc_mcp_core._tool_registration import register_tools
@@ -192,8 +192,8 @@ from dcc_mcp_core._tool_registration import register_tools
 @dataclass
 class ExportInput:
     scene_path: str = field(metadata={"description": "Scene file to export."})
-    format: Literal["fbx", "abc", "usd"] = "fbx"
-    frame_range: tuple[int, int] = (1, 100)
+    format: str = "fbx"
+    frame_range: Tuple[int, int] = (1, 100)
 
 
 @dataclass
@@ -228,7 +228,11 @@ Supported types (stdlib only): `bool`, `int`, `float`, `str`, `bytes`,
 `None`, `list[X]`, `tuple[X, ...]`, `tuple[A, B, ...]` (fixed),
 `dict[str, V]`, `Optional[X]` / `X | None`, `Union[A, B]`,
 `Literal[...]`, `Enum`, `datetime.datetime`, `datetime.date`,
-`pathlib.Path`, `uuid.UUID`, `@dataclass`, `TypedDict`. Unsupported
+`pathlib.Path`, `uuid.UUID`, `@dataclass`, `TypedDict`. On Python 3.7,
+spell containers and unions with `typing.List`, `typing.Dict`,
+`typing.Tuple`, `typing.Optional`, and `typing.Union`; `Literal` and
+`TypedDict` require `typing_extensions` in the skill author's environment.
+The core package still imports with zero runtime dependencies. Unsupported
 types raise `TypeError` with a clear escape hatch: pass an explicit
 `input_schema=...` dict or use pydantic's `MyModel.model_json_schema()`.
 

--- a/docs/zh/guide/skills.md
+++ b/docs/zh/guide/skills.md
@@ -183,7 +183,7 @@ decl = ToolDeclaration(
 
 ```python
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Tuple
 
 from dcc_mcp_core import tool_spec_from_callable
 from dcc_mcp_core._tool_registration import register_tools
@@ -191,9 +191,9 @@ from dcc_mcp_core._tool_registration import register_tools
 
 @dataclass
 class ExportInput:
-    scene_path: str = field(metadata={"description": "需要导出的场景文件。"})
-    format: Literal["fbx", "abc", "usd"] = "fbx"
-    frame_range: tuple[int, int] = (1, 100)
+    scene_path: str = field(metadata={"description": "Scene file to export."})
+    format: str = "fbx"
+    frame_range: Tuple[int, int] = (1, 100)
 
 
 @dataclass
@@ -219,7 +219,7 @@ register_tools(server, [spec], dcc_name="maya")
 
 若有返回类型标注，会作为 `outputSchema`，MCP 2025-06-18 的客户端即可用它校验 `structuredContent`。未类型化的 handler 抛 `TypeError`，不会静默回退成宽松的 `{"type": "object"}`（修掉 #588 同代的陷阱）。
 
-支持的类型（全标准库）：`bool`、`int`、`float`、`str`、`bytes`、`None`、`list[X]`、`tuple[X, ...]`、定长 `tuple[A, B, ...]`、`dict[str, V]`、`Optional[X]` / `X | None`、`Union[A, B]`、`Literal[...]`、`Enum`、`datetime.datetime`、`datetime.date`、`pathlib.Path`、`uuid.UUID`、`@dataclass`、`TypedDict`。不支持的类型会抛 `TypeError` 并附一条明确的"逃生通道"：显式传 `input_schema=...` dict 或用 pydantic 的 `MyModel.model_json_schema()`。
+支持的类型（全标准库）：`bool`、`int`、`float`、`str`、`bytes`、`None`、`list[X]`、`tuple[X, ...]`、定长 `tuple[A, B, ...]`、`dict[str, V]`、`Optional[X]` / `X | None`、`Union[A, B]`、`Literal[...]`、`Enum`、`datetime.datetime`、`datetime.date`、`pathlib.Path`、`uuid.UUID`、`@dataclass`、`TypedDict`。Python 3.7 中请用 `typing.List`、`typing.Dict`、`typing.Tuple`、`typing.Optional`、`typing.Union` 来书写容器与联合类型；`Literal` 与 `TypedDict` 需要由 skill 作者环境提供 `typing_extensions`。核心包自身仍保持零运行时依赖。不支持的类型会抛 `TypeError` 并附一条明确的"逃生通道"：显式传 `input_schema=...` dict 或用 pydantic 的 `MyModel.model_json_schema()`。
 
 ::: tip 为什么不用 pydantic？
 我们刻意保持 0 依赖。仅为此特性引入 `pydantic` 会拉进 3MB wheel 再加 `pydantic-core`，对只想写几个 dataclass handler 的作者成本过高。对于已经在用 pydantic 的调用方，派生出的 shape 与 pydantic 的约定一致（`title`、`$defs`、`$ref`、`anyOf`、`required`），因此换成 `MyModel.model_json_schema()` 是即插即用的。

--- a/examples/skills/typed-schema-demo/scripts/demo.py
+++ b/examples/skills/typed-schema-demo/scripts/demo.py
@@ -12,10 +12,13 @@ Run this module standalone to print the derived schemas::
 
 from __future__ import annotations
 
+# ruff: noqa: I001, UP006
+
 from dataclasses import dataclass
 from dataclasses import field
 import json
 from typing import Literal
+from typing import Tuple
 
 from dcc_mcp_core import tool_spec_from_callable
 from dcc_mcp_core._tool_registration import ToolSpec
@@ -32,7 +35,7 @@ class ExportInput:
         default="fbx",
         metadata={"description": "Interchange format; one of fbx / abc / usd."},
     )
-    frame_range: tuple[int, int] = field(
+    frame_range: Tuple[int, int] = field(
         default=(1, 100),
         metadata={"description": "Inclusive frame range (start, end)."},
     )

--- a/python/dcc_mcp_core/schema.py
+++ b/python/dcc_mcp_core/schema.py
@@ -38,10 +38,38 @@ import types
 import typing
 from typing import Any
 from typing import Callable
-from typing import get_args
-from typing import get_origin
-from typing import get_type_hints
+from typing import get_type_hints as _typing_get_type_hints
 import uuid
+
+try:
+    from typing import get_args
+    from typing import get_origin
+except ImportError:  # pragma: no cover - Python 3.7 only
+
+    def get_args(tp: Any) -> tuple[Any, ...]:
+        return getattr(tp, "__args__", ()) or ()
+
+    def get_origin(tp: Any) -> Any | None:
+        return getattr(tp, "__origin__", None)
+
+
+_UNION_ORIGINS = (typing.Union,)
+_union_type = getattr(types, "UnionType", None)
+if _union_type is not None:  # pragma: no cover - Python 3.10+
+    _UNION_ORIGINS = (*_UNION_ORIGINS, _union_type)
+
+_LITERAL_TYPE = getattr(typing, "Literal", None)
+_TYPEDDICT_META = getattr(typing, "_TypedDictMeta", None)
+
+
+def _get_type_hints(obj: Any, *, include_extras: bool = False) -> dict[str, Any]:
+    if include_extras:
+        try:
+            return _typing_get_type_hints(obj, include_extras=True)
+        except TypeError:  # pragma: no cover - Python 3.8 and earlier
+            pass
+    return _typing_get_type_hints(obj)
+
 
 # JSON Schema draft + MCP protocol pair we target.
 _JSON_SCHEMA_DRAFT = "https://json-schema.org/draft/2020-12/schema"
@@ -56,7 +84,7 @@ def _is_optional(tp: Any) -> tuple[bool, Any]:
     For non-optional types returns ``(False, tp)``.
     """
     origin = get_origin(tp)
-    if origin is typing.Union or origin is types.UnionType:
+    if origin in _UNION_ORIGINS:
         args = [a for a in get_args(tp) if a is not type(None)]
         had_none = len(args) != len(get_args(tp))
         if had_none:
@@ -101,7 +129,8 @@ def _primitive_schema(tp: Any) -> dict[str, Any] | None:
 
 def _literal_schema(tp: Any) -> dict[str, Any] | None:
     """Return a schema for ``Literal[...]`` or ``None`` if *tp* is not one."""
-    if get_origin(tp) is typing.Literal:
+    origin = get_origin(tp)
+    if _LITERAL_TYPE is not None and origin is _LITERAL_TYPE:
         values = list(get_args(tp))
         types_seen = {type(v) for v in values}
         # If all values share a single primitive type, pin it — this helps
@@ -185,7 +214,7 @@ def _dataclass_schema(tp: type, defs: dict[str, dict[str, Any]]) -> dict[str, An
     # Reserve the slot *before* recursing so cycles terminate.
     defs[title] = {}  # placeholder
 
-    hints = get_type_hints(tp)
+    hints = _get_type_hints(tp)
     properties: dict[str, Any] = {}
     required: list[str] = []
     for f in dataclass_fields(tp):
@@ -217,6 +246,8 @@ def _dataclass_schema(tp: type, defs: dict[str, dict[str, Any]]) -> dict[str, An
 
 
 def _is_typeddict(tp: Any) -> bool:
+    if _TYPEDDICT_META is not None and isinstance(tp, _TYPEDDICT_META):
+        return True
     return isinstance(tp, type) and issubclass(tp, dict) and hasattr(tp, "__required_keys__")
 
 
@@ -226,7 +257,7 @@ def _typeddict_schema(tp: type, defs: dict[str, dict[str, Any]]) -> dict[str, An
         return {"$ref": f"#/$defs/{title}"}
     defs[title] = {}  # placeholder for cycle safety
 
-    hints = get_type_hints(tp)
+    hints = _get_type_hints(tp)
     properties: dict[str, Any] = {}
     for key, annotation in hints.items():
         is_opt, inner = _is_optional(annotation)
@@ -240,7 +271,11 @@ def _typeddict_schema(tp: type, defs: dict[str, dict[str, Any]]) -> dict[str, An
         "title": title,
         "properties": properties,
     }
-    required = sorted(tp.__required_keys__)
+    required_keys = getattr(tp, "__required_keys__", None)
+    if required_keys is None:  # pragma: no cover - Python 3.8 only
+        required = sorted(hints) if getattr(tp, "__total__", True) else []
+    else:
+        required = sorted(required_keys)
     if required:
         schema["required"] = required
     schema["additionalProperties"] = False
@@ -284,7 +319,7 @@ def _derive(tp: Any, defs: dict[str, dict[str, Any]]) -> dict[str, Any]:
 
     # Union (non-optional).
     origin = get_origin(tp)
-    if origin is typing.Union or origin is types.UnionType:
+    if origin in _UNION_ORIGINS:
         return {"anyOf": [_derive(a, defs) for a in get_args(tp)]}
 
     # Dataclass / TypedDict.
@@ -361,7 +396,7 @@ def derive_parameters_schema(fn: Callable[..., Any]) -> dict[str, Any]:
     "accept anything" fallback (the #588-era footgun).
     """
     sig = inspect.signature(fn)
-    hints = get_type_hints(fn, include_extras=True)
+    hints = _get_type_hints(fn, include_extras=True)
 
     param_descriptions = schema_from_doc(fn)
 
@@ -587,7 +622,7 @@ def tool_spec_from_callable(
     resolved_description = description if description is not None else first_line
 
     sig = inspect.signature(handler)
-    hints = get_type_hints(handler, include_extras=True)
+    hints = _get_type_hints(handler, include_extras=True)
     real_params = [
         p
         for p in sig.parameters.values()

--- a/tests/test_integration_dcc_blender.py
+++ b/tests/test_integration_dcc_blender.py
@@ -193,6 +193,44 @@ class TestBlenderIntegration:
         assert out["success"] is True
         assert out["major"] >= 3
 
+    def test_blender_py37_can_load_schema_derivation_helper(self) -> None:
+        schema_path = Path(dcc_mcp_core.__file__).resolve().parent / "schema.py"
+        script = textwrap.dedent(f"""\
+            import importlib.util, json
+            from dataclasses import dataclass
+            from typing import List, Optional, Tuple
+
+            spec = importlib.util.spec_from_file_location("dcc_mcp_schema", r"{schema_path}")
+            schema = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(schema)
+
+            @dataclass
+            class BlenderExportInput:
+                object_names: List[str]
+                frame_range: Tuple[int, int]
+                collection: Optional[str] = None
+
+            derived = schema.derive_schema(BlenderExportInput)
+            props = derived["properties"]
+            print(json.dumps({{
+                "success": True,
+                "title": derived["title"],
+                "required": sorted(derived["required"]),
+                "object_names_type": props["object_names"]["type"],
+                "frame_range_items": len(props["frame_range"]["prefixItems"]),
+                "collection_anyof": len(props["collection"]["anyOf"]),
+            }}))
+        """)
+        out = _run_blender_script(script)
+        assert out == {
+            "success": True,
+            "title": "BlenderExportInput",
+            "required": ["frame_range", "object_names"],
+            "object_names_type": "array",
+            "frame_range_items": 2,
+            "collection_anyof": 2,
+        }
+
 
 @blender_available
 class TestBlenderSkillPipeline:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,5 +1,7 @@
 """Tests for dcc_mcp_core.schema — zero-dep type → JSON Schema derivation (#242)."""
 
+# ruff: noqa: UP006, UP045
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -7,8 +9,13 @@ from dataclasses import field
 import datetime
 import enum
 from pathlib import Path
+import sys
 from typing import Any
+from typing import Dict
+from typing import List
 from typing import Literal
+from typing import Optional
+from typing import Tuple
 from typing import TypedDict
 from typing import Union
 import uuid
@@ -69,19 +76,19 @@ class TestPrimitiveTypes:
 
 class TestContainers:
     def test_list_of_str(self) -> None:
-        assert derive_schema(list[str]) == {
+        assert derive_schema(List[str]) == {
             "type": "array",
             "items": {"type": "string"},
         }
 
     def test_homogeneous_tuple(self) -> None:
-        assert derive_schema(tuple[int, ...]) == {
+        assert derive_schema(Tuple[int, ...]) == {
             "type": "array",
             "items": {"type": "integer"},
         }
 
     def test_fixed_tuple(self) -> None:
-        assert derive_schema(tuple[int, str, bool]) == {
+        assert derive_schema(Tuple[int, str, bool]) == {
             "type": "array",
             "prefixItems": [
                 {"type": "integer"},
@@ -93,13 +100,13 @@ class TestContainers:
         }
 
     def test_dict_str_v(self) -> None:
-        assert derive_schema(dict[str, int]) == {
+        assert derive_schema(Dict[str, int]) == {
             "type": "object",
             "additionalProperties": {"type": "integer"},
         }
 
     def test_nested_list_of_list(self) -> None:
-        assert derive_schema(list[list[int]]) == {
+        assert derive_schema(List[List[int]]) == {
             "type": "array",
             "items": {
                 "type": "array",
@@ -113,12 +120,13 @@ class TestContainers:
 
 class TestUnionAndLiterals:
     def test_optional_unwraps_to_anyof_with_null(self) -> None:
-        assert derive_schema(int | None) == {
+        assert derive_schema(Optional[int]) == {
             "anyOf": [{"type": "integer"}, {"type": "null"}],
         }
 
     def test_pep604_union_none(self) -> None:
-        # Same as above, kept as a separate assertion to spell out the intent.
+        if sys.version_info < (3, 10):
+            pytest.skip("PEP 604 unions require Python 3.10+")
         assert derive_schema(int | None) == {
             "anyOf": [{"type": "integer"}, {"type": "null"}],
         }
@@ -173,13 +181,13 @@ class TestUnionAndLiterals:
 class Point:
     x: float
     y: float
-    label: str | None = None
+    label: Optional[str] = None
 
 
 @dataclass
 class Polygon:
     name: str
-    vertices: list[Point]
+    vertices: List[Point]
     closed: bool = True
 
 
@@ -229,7 +237,7 @@ class TestDataclasses:
         @dataclass
         class WithList:
             name: str
-            tags: list[str] = field(default_factory=list)
+            tags: List[str] = field(default_factory=list)
 
         schema = derive_schema(WithList)
         assert schema["required"] == ["name"]
@@ -311,7 +319,7 @@ class TestDeriveParametersSchema:
         assert schema["required"] == ["radius"]
 
     def test_optional_param_is_not_required(self) -> None:
-        def fn(x: int, y: int | None = None) -> None: ...
+        def fn(x: int, y: Optional[int] = None) -> None: ...
 
         schema = derive_parameters_schema(fn)
         assert schema["required"] == ["x"]
@@ -406,7 +414,7 @@ class TestSchemaFromDoc:
 
 class TestEdgeCases:
     def test_optional_dataclass(self) -> None:
-        schema = derive_schema(Point | None)
+        schema = derive_schema(Optional[Point])
         assert schema["anyOf"][1] == {"type": "null"}
         # First branch is the Point object schema.
         first = schema["anyOf"][0]
@@ -450,7 +458,7 @@ class TestToolSpecFromCallable:
         assert spec.output_schema["title"] == "_ExportResult"
 
     def test_multi_primitive_params(self) -> None:
-        def make_sphere(radius: float, segments: int = 16) -> dict[str, int]:
+        def make_sphere(radius: float, segments: int = 16) -> Dict[str, int]:
             return {"radius": int(radius), "segments": segments}
 
         spec = tool_spec_from_callable(make_sphere)
@@ -459,7 +467,7 @@ class TestToolSpecFromCallable:
         assert spec.input_schema["type"] == "object"
         assert set(spec.input_schema["properties"]) == {"radius", "segments"}
         assert spec.input_schema["required"] == ["radius"]
-        # Return type dict[str, int] → outputSchema is an object with additionalProperties.
+        # Return type Dict[str, int] → outputSchema is an object with additionalProperties.
         assert spec.output_schema == {
             "type": "object",
             "additionalProperties": {"type": "integer"},

--- a/uv.lock
+++ b/uv.lock
@@ -421,7 +421,7 @@ toml = [
 
 [[package]]
 name = "dcc-mcp-core"
-version = "0.14.15"
+version = "0.14.21"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -438,6 +438,8 @@ dev = [
     { name = "pytest-cov", version = "4.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8'" },
     { name = "pytest-cov", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.8.*'" },
     { name = "pytest-cov", version = "7.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "rez", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8'" },
+    { name = "rez", version = "3.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.8'" },
     { name = "ruff" },
 ]
 test = [
@@ -448,6 +450,8 @@ test = [
     { name = "pytest-cov", version = "4.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8'" },
     { name = "pytest-cov", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.8.*'" },
     { name = "pytest-cov", version = "7.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "rez", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8'" },
+    { name = "rez", version = "3.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.8'" },
 ]
 
 [package.metadata]
@@ -457,6 +461,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.0" },
+    { name = "rez", marker = "extra == 'test'" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
 ]
 provides-extras = ["test", "dev"]
@@ -1101,6 +1106,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "rez"
+version = "3.2.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.8'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/52/c4e763d1005b5df4963f10af7f8a77aeeb16cfd11dba0de47c3776d26829/rez-3.2.1.tar.gz", hash = "sha256:f74559499ac12f09b54f0caf9f0c54db70675ef8c8f84dd1dd08ee487be7959d", size = 2000129, upload-time = "2024-10-27T16:59:03.941Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/82/91d27b8c78698a6d669abc89d3bdc2bf63bf7f05ef10f2941bae9460bf52/rez-3.2.1-py3-none-any.whl", hash = "sha256:f411f75662a3ddf06941cb9579869768b117f9bb744d428e1146b1afc999fb51", size = 2261106, upload-time = "2024-10-27T16:59:01.736Z" },
+]
+
+[[package]]
+name = "rez"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
+    "python_full_version == '3.8.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/d3/215c58885a603ef708987e47828b67bddd416841b17fa831ff2ed08cc148/rez-3.3.0.tar.gz", hash = "sha256:a0d265a6e840f85a76ceabbe541f8396b988da8432b07521df320cf6a8bfac4c", size = 2210462, upload-time = "2025-10-17T18:54:30.67Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/db/b70a12dd0998cd2228cfd91328dc468d1c81aa14c84a22f61b02f968876d/rez-3.3.0-py3-none-any.whl", hash = "sha256:aea6b56277788d1dc53a81e98a4397a4468c5e735bfbb52d8558f59de7973baf", size = 2475603, upload-time = "2025-10-17T18:54:28.592Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add Python 3.7-safe fallbacks for `typing.get_args` / `typing.get_origin` in `dcc_mcp_core.schema`
- avoid evaluating `types.UnionType` and `typing.Literal` on runtimes that do not expose them
- opt PyO3 skill snapshot structs into explicit FromPyObject behavior to remove the deprecation warning
- document Python 3.7-compatible type spelling and add a Blender DCC integration regression test for the schema helper

## Validation
- `vx cargo check -p dcc-mcp-skills --features python-bindings`
- `PYTHONPATH=python vx uv run pytest tests/test_schema.py -q`
- `PYTHONPATH=python vx uv run pytest tests/test_integration_dcc_blender.py -q`
- `vx ruff check python/dcc_mcp_core/schema.py tests/test_schema.py tests/test_integration_dcc_blender.py`