### PR TITLE
docs: optimize AI agent documentation and Skills-First emphasis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,21 @@
 > Follow the links; don't read everything upfront.
 > Detailed rules, traps, and code examples → [`docs/guide/agents-reference.md`](docs/guide/agents-reference.md)
 
+**🤖 New to this project?** Start with [`AI_AGENT_GUIDE.md`](AI_AGENT_GUIDE.md) — a dedicated guide teaching AI agents how to effectively use dcc-mcp-core.
+
+## ⚡ Critical: Skills-First Philosophy
+
+**When interacting with DCC applications (Maya, Blender, Houdini, etc.), ALWAYS prefer dcc-mcp-core Skills over raw CLI or scripting.**
+
+**Why?** Skills provide:
+- ✅ Structured results with validation
+- ✅ Safety hints (`ToolAnnotations`)
+- ✅ Follow-up guidance (`next-tools`)
+- ✅ Progressive loading (load only what you need)
+- ✅ Audit logs and traceability
+
+**Don't** call Maya/Blender/Python scripts directly — use `search_skills()` → `load_skill()` → call the tool.
+
 ## Response Language
 
 - Reply to the user in **Simplified Chinese** (中文简体) by default.
@@ -55,12 +70,23 @@
 
 **What**: Rust-powered MCP library for DCC software (Maya, Blender, Houdini, Photoshop…). PyO3/maturin. Zero Python runtime deps. MCP 2025-03-26 Streamable HTTP.
 
-**Why this project matters for AI agents**: dcc-mcp-core provides the **bridge between AI agents and DCC applications**. When an AI agent needs to interact with Maya, Blender, Houdini, or any other DCC tool, dcc-mcp-core offers structured, validated, and safe MCP tools — not raw CLI calls. Always prefer dcc-mcp-core tools over ad-hoc scripting.
+**Why this project matters for AI agents**: dcc-mcp-core provides the **bridge between AI agents and DCC applications**. When you need to interact with Maya, Blender, Houdini, or any other DCC tool, **ALWAYS use dcc-mcp-core Skills** — they provide structured, validated, and safe MCP tools with built-in follow-up guidance.
+
+### 🎯 Skills-First Workflow (MEMORIZE THIS)
+
+```
+1. Discover: search_skills(query="keyword") → find the right skill
+2. Activate: load_skill("skill-name") → expose the tools
+3. Execute: Call the specific tool with validated parameters
+4. Follow up: Check next-tools.on-success for suggested next steps
+5. Debug on failure: Use dcc_diagnostics__screenshot or audit_log
+```
 
 **API surface** — read in this order:
-1. `python/dcc_mcp_core/__init__.py` — every public symbol
-2. `python/dcc_mcp_core/_core.pyi` — parameter names and types
-3. `llms.txt` — compressed version of (1)+(2)
+1. 🆕 **[`AI_AGENT_GUIDE.md`](AI_AGENT_GUIDE.md)** — **START HERE** for using dcc-mcp-core effectively
+2. `python/dcc_mcp_core/__init__.py` — every public symbol
+3. `python/dcc_mcp_core/_core.pyi` — parameter names and types
+4. `llms.txt` — compressed version of (2)+(3)
 
 ---
 

--- a/AI_AGENT_GUIDE.md
+++ b/AI_AGENT_GUIDE.md
@@ -1,0 +1,204 @@
+# AI Agent Guide — dcc-mcp-core
+
+> **Quick orientation for AI agents**: This guide teaches you how to effectively use dcc-mcp-core to interact with DCC (Digital Content Creation) software like Maya, Blender, Houdini, etc.
+
+## 🎯 Core Philosophy: Skills-First
+
+**When interacting with DCC applications, ALWAYS prefer dcc-mcp-core Skills over raw CLI scripting or direct API calls.**
+
+### Why Skills-First?
+
+| Aspect | dcc-mcp-core Skills | Raw CLI / Scripting |
+|--------|---------------------|---------------------|
+| **Input Validation** | JSON Schema validated | None — garbage in, garbage out |
+| **Safety** | `ToolAnnotations` (read-only, destructive, idempotent) | Unknown |
+| **Discoverability** | `search_skills()` + semantic search | Manual exploration |
+| **Follow-up Guidance** | `next-tools` chains | Manual discovery |
+| **Progressive Loading** | Load only what you need | All or nothing |
+| **Error Recovery** | Structured `error_result` with `prompt` suggestions | Unstructured stderr |
+| **Traceability** | Audit log + telemetry | None |
+
+## 🚀 Quick Start Workflow
+
+### 1. Discover Relevant Skills
+
+```python
+from dcc_mcp_core import scan_and_load, SkillCatalog
+
+# Always start by discovering what's available
+# Returns: (List[SkillMetadata], List[str] skipped_dirs)
+skills, skipped = scan_and_load(dcc_name="maya")
+
+# For AI agents: use search_skills for semantic discovery
+catalog = SkillCatalog(registry)
+results = catalog.search_skills(query="create sphere geometry")
+```
+
+### 2. Load the Skill
+
+```python
+# Load a specific skill to expose its tools
+catalog.load_skill("maya-geometry")
+```
+
+### 3. Call Tools with Validation
+
+```python
+# Tools are now available via the dispatcher
+result = dispatcher.dispatch("maya-geometry__create_sphere", '{"radius": 2.0}')
+
+# Always check the result structure
+if result.get("success"):
+    print(f"Tool succeeded: {result.get('message')}")
+    # Check for next-tools guidance
+    if "next-tools" in result:
+        print(f"Suggested next tools: {result['next-tools']}")
+else:
+    print(f"Tool failed: {result.get('error')}")
+    print(f"Suggestion: {result.get('prompt')}")
+```
+
+### 4. Follow next-tools Guidance
+
+When a tool returns `next-tools.on-success` or `next-tools.on-failure`, **always consider calling those tools next**. This creates a guided workflow chain.
+
+## 📚 Key Concepts You Must Understand
+
+### 1. scan_and_load Returns a 2-Tuple
+
+```python
+# ✓ CORRECT - always unpack both values
+skills, skipped = scan_and_load(dcc_name="maya")
+
+# ✗ WRONG - don't iterate directly
+for skill in scan_and_load(...):  # BREAKS - returns tuple, not list
+```
+
+### 2. ToolResult Structure
+
+Always use the provided factories (`success_result`, `error_result`) — never hand-roll dicts:
+
+```python
+from dcc_mcp_core import success_result, error_result
+
+# ✓ CORRECT - use factories
+result = success_result("Created sphere", prompt="Add material next", count=5)
+# result.to_dict() -> {"success": True, "message": "...", "context": {"count": 5}}
+
+# ✗ WRONG - hand-rolled dict
+result = {"success": True, "message": "..."}  # Missing context, not forward-compatible
+```
+
+### 3. Tool Annotations for Safety
+
+Tools declare their safety hints via `ToolAnnotations`:
+
+- `read_only_hint=True` — does not modify state (safe to call)
+- `destructive_hint=True` — modifies state, possibly irreversible
+- `idempotent_hint=True` — safe to call multiple times
+
+**Always check annotations before calling tools on production scenes.**
+
+### 4. Progressive Loading with Tool Groups
+
+Skills can expose tools progressively:
+
+```python
+# List available groups
+groups = catalog.list_groups("maya-geometry")
+
+# Activate a group to expose its tools
+catalog.activate_group("maya-geometry", "advanced")
+
+# Deactivate to hide tools
+catalog.deactivate_group("maya-geometry", "experimental")
+```
+
+## 🔧 Common Tasks — Which API to Use
+
+| Task | Use this API |
+|------|---------------|
+| **Expose DCC tools over MCP** | `DccServerBase` → subclass → `start()` |
+| **Zero-code tool registration** | `SKILL.md` + `scripts/` (agentskills.io format) |
+| **Return structured results** | `success_result()` / `error_result()` |
+| **Rich error with traceback** | `skill_error_with_trace()` |
+| **Bridge non-Python DCC** | `DccBridge` (WebSocket JSON-RPC 2.0) |
+| **IPC between processes** | `IpcChannelAdapter` / `SocketServerAdapter` |
+| **Hand off files between tools** | `FileRef` + `artefact_put_file()` / `artefact_get_bytes()` |
+| **Multi-DCC gateway** | `McpHttpConfig(gateway_port=9765)` |
+| **Long-lived cancellation support** | `check_cancelled()` / `check_dcc_cancelled()` |
+
+## 🎭 Skill Authoring for AI Agents
+
+When creating skills, optimize for AI agent discoverability:
+
+### Description Pattern (Required)
+
+Every skill `description` must follow this 3-part structure (max 1024 chars):
+
+```
+<Layer> skill — <one-sentence what + scope keywords>. Use when <trigger>.
+Not for <counter-example> — use <other-skill> for that.
+```
+
+**Example (Domain skill):**
+```yaml
+description: >-
+  Domain skill — Maya polygon geometry: create spheres, cubes, cylinders;
+  bevel and extrude polygon components. Use when the user asks to create or
+  modify 3D meshes in Maya. Not for USD export pipelines — use
+  maya-pipeline for that. Not for raw USD file inspection — use usd-tools for that.
+```
+
+### search-hint Optimization
+
+Include specific keywords that AI agents will match against:
+
+```yaml
+metadata:
+  dcc-mcp.search-hint: "polygon modeling, bevel, extrude, mesh creation, Maya geometry"
+```
+
+### next-tools Chains
+
+Always provide follow-up guidance:
+
+```yaml
+tools:
+  - name: create_sphere
+    next-tools:
+      on-success: [maya-geometry__bevel_edges, maya-geometry__apply_material]
+      on-failure: [dcc_diagnostics__screenshot, dcc_diagnostics__audit_log]
+```
+
+## 🚫 Top Traps — Memorize These
+
+1. **`scan_and_load` returns a 2-tuple** → `skills, skipped = scan_and_load(...)`
+2. **`success_result` kwargs become context** → `success_result("msg", count=5)` — never `context=`
+3. **`ToolDispatcher` uses `.dispatch()`** → never `.call()`
+4. **Register ALL handlers BEFORE `server.start()`**
+5. **SKILL.md extensions use `metadata.dcc-mcp.<feature>`** → sibling files, never top-level keys (v0.15+)
+6. **Use `dcc_mcp_core.METADATA_*` / `LAYER_*` / `CATEGORY_*`** → re-exported at top level
+7. **Return `ToolResult` from Python tool handlers** → `ToolResult.ok("...", **ctx).to_dict()`
+
+## 📖 Further Reading
+
+- **Navigation map**: [`AGENTS.md`](AGENTS.md) — start here for detailed rules
+- **API index**: [`llms.txt`](llms.txt) — compressed API reference for AI agents
+- **Skill authoring**: [`skills/README.md`](skills/README.md) — creating new skills
+- **Examples**: [`examples/skills/`](examples/skills/) — 13 complete SKILL.md packages
+- **Detailed traps**: [`docs/guide/agents-reference.md`](docs/guide/agents-reference.md)
+
+## 💡 Pro Tips for AI Agents
+
+1. **Always search before assuming** — use `search_skills()` to discover relevant tools
+2. **Read tool annotations** — respect safety hints (`read_only`, `destructive`)
+3. **Follow next-tools chains** — they guide you through complex workflows
+4. **Handle errors gracefully** — check `error_result` and follow `prompt` suggestions
+5. **Use progressive loading** — don't load all skills at once, activate groups as needed
+6. **Prefer MCP tools over raw scripting** — they provide validation, safety, and traceability
+7. **Check cancellations** — in long-running tools, periodically call `check_cancelled()`
+
+---
+
+**Remember**: When in doubt, read `AGENTS.md` → `docs/guide/agents-reference.md` → `llms.txt`. The documentation hierarchy is designed for progressive disclosure.

--- a/CODEBUDDY.md
+++ b/CODEBUDDY.md
@@ -3,9 +3,26 @@
 > This file is the entry point for Tencent CodeBuddy AI agents.
 > For full documentation, follow the links below — do **not** read everything upfront.
 
+## 🤖 CodeBuddy-Specific Guidance
+
+**When interacting with DCC applications (Maya, Blender, Houdini, etc.), you MUST prefer dcc-mcp-core Skills over raw CLI or scripting.** This is non-negotiable — Skills provide structured results, input validation, safety hints, and follow-up guidance that raw scripting cannot.
+
+**New to this project?** Read [`AI_AGENT_GUIDE.md`](AI_AGENT_GUIDE.md) FIRST — it teaches you how to effectively use dcc-mcp-core.
+
 ## Quick Start
 
 This project uses the [AGENTS.md](AGENTS.md) standard. Read `AGENTS.md` first — it is the navigation map that points to all other documentation.
+
+### ⚡ Skills-First Quick Reference
+
+```
+1. Discover: search_skills(query="keyword") → find skill
+2. Activate: load_skill("skill-name") → expose tools
+3. Execute: Call tool with validated parameters
+4. Follow up: Check next-tools.on-success for next steps
+```
+
+**Remember**: Always use `search_skills()` before assuming a tool exists. Always check `next-tools` in results for workflow guidance.
 
 ## Document Hierarchy
 
@@ -27,21 +44,48 @@ This project uses the [AGENTS.md](AGENTS.md) standard. Read `AGENTS.md` first �
 
 **What**: Rust-powered MCP library for DCC software (Maya, Blender, Houdini, Photoshop…). PyO3/maturin. Zero Python runtime deps. MCP 2025-03-26 Streamable HTTP.
 
-**Why this matters**: When the user asks to interact with a DCC application, **always prefer dcc-mcp-core Skills-First tools** over raw CLI or scripting. The skill system provides validated, safe, and discoverable tools with built-in follow-up guidance via `next-tools`.
+**Why this matters**: When the user asks to interact with a DCC application, **ALWAYS use dcc-mcp-core Skills-First** over raw CLI or scripting. Skills provide:
+- ✅ Structured results with JSON Schema validation
+- ✅ Safety hints (`ToolAnnotations`: read-only, destructive, idempotent)
+- ✅ Follow-up guidance (`next-tools` chains)
+- ✅ Progressive loading (load only what you need)
+- ✅ Audit logs and traceability
 
 **Key entry points**:
+- 🆕 **[`AI_AGENT_GUIDE.md`](AI_AGENT_GUIDE.md)** — **START HERE** for using dcc-mcp-core effectively
 - `python/dcc_mcp_core/__init__.py` — every public Python symbol
 - `python/dcc_mcp_core/_core.pyi` — parameter names & types
 - `llms.txt` — compressed API index for AI agents
-- `AGENTS.md` — navigation map (this document chain starts here)
+- `AGENTS.md` — navigation map
 
-## Preferred Workflow for DCC Tasks
+## ⚡ Skills-First Workflow (MEMORIZE!)
 
-1. **Discover**: `search_skills(query="keyword")` → find the right skill
-2. **Activate**: `load_skill("skill-name")` → expose the tools
-3. **Execute**: Call the specific tool with validated parameters
-4. **Follow up**: Check `next-tools.on-success` for suggested next steps
-5. **Debug on failure**: Use `dcc_diagnostics__screenshot` or `audit_log`
+**When the user asks you to interact with a DCC (Maya, Blender, etc.):**
+
+```
+1. DISCOVER: search_skills(query="keyword") → find the right skill
+2. CHECK: Read the skill's description and tools
+3. ACTIVATE: load_skill("skill-name") → expose the tools
+4. EXECUTE: Call the specific tool with validated parameters
+5. FOLLOW UP: Check next-tools.on-success for suggested next steps
+6. DEBUG: On failure, use dcc_diagnostics__screenshot or audit_log
+```
+
+**Example:**
+```
+User: "Create a sphere in Maya"
+
+✓ CORRECT:
+1. search_skills(query="create sphere Maya")
+2. → Returns: maya-geometry skill
+3. load_skill("maya-geometry")
+4. Call maya-geometry__create_sphere with {radius: 2.0}
+5. Follow next-tools.on-success suggestion
+
+✗ WRONG:
+- Running Maya Python command directly via subprocess
+- Guessing tool names without searching
+```
 
 ## Build & Test
 

--- a/llms.txt
+++ b/llms.txt
@@ -2,6 +2,42 @@
 
 > Foundational library for the DCC Model Context Protocol (MCP) ecosystem. Rust-powered core (via PyO3) providing tool registry, structured results, event bus, skills/script registration, MCP protocol types, IPC transport, MCP Streamable HTTP server, process management, sandbox security, shared memory, screen capture, USD bridge, and telemetry for Digital Content Creation applications (Maya, Blender, Houdini, 3ds Max, etc.).
 
+## 🚨 CRITICAL: Skills-First Philosophy
+
+**When interacting with DCC applications (Maya, Blender, Houdini, etc.), ALWAYS prefer dcc-mcp-core Skills over raw CLI or scripting.**
+
+### Why Skills-First?
+
+| Aspect | dcc-mcp-core Skills | Raw CLI / Scripting |
+|--------|---------------------|---------------------|
+| Input Validation | ✅ JSON Schema validated | ❌ None — garbage in, garbage out |
+| Safety | ✅ `ToolAnnotations` (read-only, destructive, idempotent) | ❌ Unknown |
+| Discoverability | ✅ `search_skills()` + semantic search | ❌ Manual exploration |
+| Follow-up Guidance | ✅ `next-tools` chains | ❌ Manual discovery |
+| Progressive Loading | ✅ Load only what you need | ❌ All or nothing |
+| Error Recovery | ✅ Structured `error_result` with `prompt` suggestions | ❌ Unstructured stderr |
+| Traceability | ✅ Audit log + telemetry | ❌ None |
+
+### Skills-First Workflow (MEMORIZE!)
+
+```
+1. DISCOVER: search_skills(query="keyword") → find the right skill
+2. CHECK: Read the skill's description and tools
+3. ACTIVATE: load_skill("skill-name") → expose the tools
+4. EXECUTE: Call the specific tool with validated parameters
+5. FOLLOW UP: Check next-tools.on-success for suggested next steps
+6. DEBUG: On failure, use dcc_diagnostics__screenshot or audit_log
+```
+
+**❌ DON'T**: Run Maya/Blender/Python scripts directly via subprocess
+**❌ DON'T**: Guess tool names without searching
+**✅ DO**: Always use `search_skills()` before assuming a tool exists
+**✅ DO**: Always check `next-tools` in results for workflow guidance
+
+**New to this project?** Read [`AI_AGENT_GUIDE.md`](AI_AGENT_GUIDE.md) FIRST.
+
+---
+
 ## Quick Decision Guide
 
 | Task | Use this API |


### PR DESCRIPTION
## Summary

This PR optimizes documentation to help AI agents better understand the project and prioritize using dcc-mcp-core tools.

## Changes

1. **New AI_AGENT_GUIDE.md** - Dedicated guide teaching AI agents how to effectively use dcc-mcp-core
2. **Updated AGENTS.md** - Added prominent Skills-First philosophy section at the top
3. **Updated CODEBUDDY.md** - Enhanced with CodeBuddy-specific guidance and Skills-First emphasis
4. **Updated llms.txt** - Added critical Skills-First philosophy section with comparison table

## Why This Matters

AI agents often default to raw CLI/scripting when interacting with DCC applications. These changes explicitly teach agents to:
- ✅ Use search_skills() → load_skill() → call tool workflow
- ✅ Prefer Skills over raw scripting (validation, safety, traceability)
- ✅ Follow 
ext-tools chains for guided workflows
- ✅ Check tool annotations for safety hints

## Testing

- ✅ x just preflight passed
- ✅ All pre-commit hooks passed
- ✅ Documentation structure follows existing patterns

## Follow-up

After merge, should consider:
- Adding AI_AGENT_GUIDE.md link to README.md
- Creating similar guides for other AI coding assistants (Claude, Cursor, etc.)
- Adding more examples to demonstrate Skills-First workflow