### PR TITLE
Fix gateway dynamic capability routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,7 +713,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dcc-mcp-actions"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "dashmap",
  "dcc-mcp-models",
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-artefact"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "chrono",
  "hex",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-capture"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "image",
  "libc",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-core"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "dcc-mcp-actions",
  "dcc-mcp-artefact",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-gateway"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "axum",
  "chrono",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-http"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "axum",
  "axum-test",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-job"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "chrono",
  "dashmap",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-jsonrpc"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "serde",
  "serde_json",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-logging"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "dcc-mcp-paths",
  "parking_lot",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-models"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "dcc-mcp-naming",
  "dcc-mcp-pybridge",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-naming"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "pyo3",
  "pyo3-stub-gen",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-paths"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "dirs",
  "pyo3",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-process"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "dcc-mcp-models",
  "ipckit",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-protocols"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-pybridge"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "dcc-mcp-pybridge-derive",
  "pyo3",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-pybridge-derive"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-sandbox"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-scheduler"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "axum",
  "bytes",
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-server"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "anyhow",
  "axum",
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-shm"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "ipckit",
  "libc",
@@ -1112,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-skill-rest"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "axum",
  "axum-test",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-skills"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "dashmap",
  "dcc-mcp-actions",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-telemetry"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-transport"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "criterion",
  "dashmap",
@@ -1206,7 +1206,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-agent"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "dashmap",
  "dcc-mcp-tunnel-protocol",
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-protocol"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "jsonwebtoken",
  "rmp-serde",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-relay"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "axum",
  "dashmap",
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-usd"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "dcc-mcp-protocols",
  "pyo3",
@@ -1268,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-workflow"
-version = "0.14.21"
+version = "0.14.22"
 dependencies = [
  "base64",
  "chrono",

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/call.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/call.rs
@@ -44,6 +44,16 @@ pub async fn route_tools_call(
         return skill_mgmt_dispatch(gs, tool, args).await;
     }
 
+    if !gs.tool_exposure.publishes_backend_tools() {
+        return (
+            format!(
+                "Tool '{tool}' is not available as a direct gateway MCP tool in {} mode. Use `search_tools`, `describe_tool`, and `call_tool` instead.",
+                gs.tool_exposure.as_str(),
+            ),
+            true,
+        );
+    }
+
     // ── Backend tool routing ────────────────────────────────────────────
     // Preferred gateway names come in two Cursor-safe / SEP-986 forms
     // (both accepted by `decode_tool_name`), but with a single live

--- a/crates/dcc-mcp-gateway/src/gateway/backend_client.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/backend_client.rs
@@ -112,6 +112,27 @@ pub async fn call_backend(
 
 /// Fetch `tools/list` from a backend and return the deserialised [`McpTool`] list.
 ///
+/// Unlike [`fetch_tools`], this reports transport / protocol failures to callers
+/// that need deterministic errors for a specific backend.
+pub async fn try_fetch_tools(
+    client: &reqwest::Client,
+    mcp_url: &str,
+    timeout: Duration,
+) -> Result<Vec<McpTool>, String> {
+    let val = call_backend(client, mcp_url, "tools/list", None, None, timeout).await?;
+    Ok(val
+        .get("tools")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| serde_json::from_value::<McpTool>(v.clone()).ok())
+                .collect()
+        })
+        .unwrap_or_default())
+}
+
+/// Fetch `tools/list` from a backend and return the deserialised [`McpTool`] list.
+///
 /// On any failure returns an empty vector and logs a warning — callers aggregate
 /// tools across many backends and should not fail the whole fan-out because one
 /// instance is unreachable.
@@ -120,16 +141,8 @@ pub async fn fetch_tools(
     mcp_url: &str,
     timeout: Duration,
 ) -> Vec<McpTool> {
-    match call_backend(client, mcp_url, "tools/list", None, None, timeout).await {
-        Ok(val) => val
-            .get("tools")
-            .and_then(Value::as_array)
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| serde_json::from_value::<McpTool>(v.clone()).ok())
-                    .collect()
-            })
-            .unwrap_or_default(),
+    match try_fetch_tools(client, mcp_url, timeout).await {
+        Ok(tools) => tools,
         Err(e) => {
             tracing::warn!(mcp_url = %mcp_url, error = %e, "Backend tools/list failed");
             Vec::new()

--- a/crates/dcc-mcp-gateway/src/gateway/capability/builder.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/builder.rs
@@ -82,22 +82,24 @@ pub fn build_records_from_backend(input: BuildInput<'_>) -> BuildOutcome {
             continue;
         }
 
-        let (skill_name, backend_tool) = extract_skill_and_bare(&tool.name);
+        let (skill_name, _) = extract_skill_and_bare(&tool.name);
+        let callable_id = tool.name.clone();
         let tags = extract_tags(&tool.annotations, tool.meta.as_ref());
         let has_schema = has_meaningful_schema(&tool.input_schema);
         let summary = if tool.description.is_empty() && has_schema {
             // Keep the search text non-empty even when the backend
             // omitted the description — the input schema name still
             // gives `search_tools` something to score against.
-            format!("{} ({SCHEMA_AVAILABLE})", backend_tool)
+            format!("{} ({SCHEMA_AVAILABLE})", callable_id)
         } else {
             tool.description.clone()
         };
 
-        let slug = tool_slug(input.dcc_type, &input.instance_id, &backend_tool);
+        let slug = tool_slug(input.dcc_type, &input.instance_id, &callable_id);
         records.push(CapabilityRecord::new(
             slug,
-            backend_tool,
+            callable_id.clone(),
+            callable_id,
             skill_name,
             &summary,
             tags,
@@ -303,10 +305,21 @@ mod unit_tests {
             .map(|r| (r.backend_tool.as_str(), r))
             .collect();
         assert_eq!(
-            by_tool["set_keyframe"].skill_name.as_deref(),
+            by_tool["maya-animation.set_keyframe"].skill_name.as_deref(),
             Some("maya-animation"),
         );
-        assert_eq!(by_tool["greet"].skill_name.as_deref(), Some("hello_world"),);
+        assert_eq!(
+            by_tool["maya-animation.set_keyframe"].callable_id,
+            "maya-animation.set_keyframe",
+        );
+        assert_eq!(
+            by_tool["hello_world__greet"].skill_name.as_deref(),
+            Some("hello_world"),
+        );
+        assert_eq!(
+            by_tool["hello_world__greet"].callable_id,
+            "hello_world__greet"
+        );
         assert_eq!(by_tool["standalone_action"].skill_name, None);
     }
 

--- a/crates/dcc-mcp-gateway/src/gateway/capability/index.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/index.rs
@@ -213,6 +213,7 @@ mod unit_tests {
         CapabilityRecord::new(
             tool_slug(dcc, &id, tool),
             tool.to_string(),
+            tool.to_string(),
             None,
             "summary",
             Vec::new(),

--- a/crates/dcc-mcp-gateway/src/gateway/capability/record.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/record.rs
@@ -98,9 +98,12 @@ pub struct CapabilityRecord {
     /// Client-visible slug used to discover / describe / call the
     /// action. Built via [`tool_slug`].
     pub tool_slug: String,
-    /// Original backend action name (no gateway encoding). This is
-    /// what the backend's `tools/call` expects.
+    /// Exact backend action name (no gateway encoding). This is what
+    /// the backend's `tools/call` expects.
     pub backend_tool: String,
+    /// Alias of [`Self::backend_tool`] with an explicit routing name for
+    /// clients that distinguish display slugs from backend callables.
+    pub callable_id: String,
     /// Owning skill, if the backend advertised one; `None` for
     /// actions registered without a skill (unusual but possible).
     pub skill_name: Option<String>,
@@ -136,6 +139,7 @@ impl CapabilityRecord {
     pub fn new(
         tool_slug: String,
         backend_tool: String,
+        callable_id: String,
         skill_name: Option<String>,
         summary: &str,
         tags: Vec<String>,
@@ -146,6 +150,7 @@ impl CapabilityRecord {
         Self {
             tool_slug,
             backend_tool,
+            callable_id,
             skill_name,
             summary: normalise_summary(summary),
             tags,
@@ -242,6 +247,7 @@ mod unit_tests {
         let rec = CapabilityRecord::new(
             "x.abcdef01.a".into(),
             "a".into(),
+            "a".into(),
             None,
             &long,
             Vec::new(),
@@ -260,6 +266,7 @@ mod unit_tests {
     fn summary_under_cap_is_not_suffixed() {
         let rec = CapabilityRecord::new(
             "x.abcdef01.a".into(),
+            "a".into(),
             "a".into(),
             None,
             "short and sweet",

--- a/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
@@ -138,6 +138,7 @@ mod unit_tests {
             vec![crate::gateway::capability::CapabilityRecord::new(
                 crate::gateway::capability::tool_slug("maya", &iid, "a"),
                 "a".into(),
+                "a".into(),
                 None,
                 "",
                 vec![],

--- a/crates/dcc-mcp-gateway/src/gateway/capability/search.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/search.rs
@@ -262,6 +262,7 @@ mod unit_tests {
         let rec = CapabilityRecord::new(
             tool_slug(dcc, &iid, name),
             name.to_string(),
+            name.to_string(),
             None,
             summary,
             tags.iter().map(|t| t.to_string()).collect(),
@@ -312,6 +313,7 @@ mod unit_tests {
                 CapabilityRecord::new(
                     tool_slug("maya", &a, "sphere"),
                     "sphere".into(),
+                    "sphere".into(),
                     None,
                     "",
                     vec![],
@@ -321,6 +323,7 @@ mod unit_tests {
                 ),
                 CapabilityRecord::new(
                     tool_slug("maya", &a, "create_sphere"),
+                    "create_sphere".into(),
                     "create_sphere".into(),
                     None,
                     "",
@@ -336,6 +339,7 @@ mod unit_tests {
             b,
             vec![CapabilityRecord::new(
                 tool_slug("maya", &b, "open"),
+                "open".into(),
                 "open".into(),
                 None,
                 "open a sphere scene",
@@ -420,6 +424,7 @@ mod unit_tests {
                 CapabilityRecord::new(
                     tool_slug("maya", &iid, &format!("t{i:03}")),
                     format!("t{i:03}"),
+                    format!("t{i:03}"),
                     None,
                     "",
                     vec![],
@@ -449,6 +454,7 @@ mod unit_tests {
             .map(|i| {
                 CapabilityRecord::new(
                     tool_slug("maya", &iid, &format!("t{i:03}")),
+                    format!("t{i:03}"),
                     format!("t{i:03}"),
                     None,
                     "",
@@ -604,6 +610,7 @@ mod unit_tests {
                 CapabilityRecord::new(
                     tool_slug("maya", &iid, &format!("tool_{i:03}")),
                     format!("tool_{i:03}"),
+                    format!("tool_{i:03}"),
                     None,
                     "",
                     vec![],
@@ -681,6 +688,7 @@ mod unit_tests {
             .map(|i| {
                 CapabilityRecord::new(
                     tool_slug("maya", &iid, &format!("tool_{i:03}")),
+                    format!("tool_{i:03}"),
                     format!("tool_{i:03}"),
                     None,
                     "shared summary text",
@@ -782,6 +790,7 @@ mod unit_tests {
                     .map(|i| {
                         CapabilityRecord::new(
                             tool_slug(dcc, &iid, &format!("action_{i:03}")),
+                            format!("action_{i:03}"),
                             format!("action_{i:03}"),
                             Some(format!("{dcc}-skill-{}", i % 10)),
                             "a realistic summary blurb mentioning scene and object ops",

--- a/crates/dcc-mcp-gateway/src/gateway/capability/search_ranking.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/search_ranking.rs
@@ -289,6 +289,7 @@ mod tests {
         CapabilityRecord::new(
             tool_slug("maya", &iid, name),
             name.to_string(),
+            name.to_string(),
             skill.map(String::from),
             summary,
             tags.iter().map(|t| t.to_string()).collect(),

--- a/crates/dcc-mcp-gateway/src/gateway/capability/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/tests.rs
@@ -126,13 +126,13 @@ fn end_to_end_two_backends_search_and_route() {
         },
     );
     assert_eq!(hits.len(), 1);
-    assert_eq!(hits[0].record.backend_tool, "create_sphere");
+    assert_eq!(hits[0].record.backend_tool, "maya-geometry.create_sphere");
     // The slug carries everything needed to route the call back to
     // the exact backend instance.
     let (dcc, id8, tool) = record::parse_slug(&hits[0].record.tool_slug).unwrap();
     assert_eq!(dcc, "maya");
     assert_eq!(id8, &maya_id.to_string().replace('-', "")[..8]);
-    assert_eq!(tool, "create_sphere");
+    assert_eq!(tool, "maya-geometry.create_sphere");
 
     // Phase 4: the same query without a dcc_type filter sees both
     // backends but still scores the Maya action first because its
@@ -145,7 +145,7 @@ fn end_to_end_two_backends_search_and_route() {
         },
     );
     assert_eq!(hits.len(), 1);
-    assert_eq!(hits[0].record.backend_tool, "create_sphere");
+    assert_eq!(hits[0].record.backend_tool, "maya-geometry.create_sphere");
 
     // Phase 5: removing the Maya instance drops every Maya row in
     // one O(n) swap and leaves the Blender rows intact.

--- a/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
@@ -19,7 +19,9 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
-use super::backend_client::forward_tools_call;
+use dcc_mcp_jsonrpc::McpTool;
+
+use super::backend_client::{forward_tools_call, try_fetch_tools};
 use super::capability::{
     CapabilityIndex, CapabilityRecord, RefreshReason, SearchHit, SearchQuery, parse_slug,
     refresh_instance, remove_instance, search,
@@ -107,6 +109,50 @@ pub fn describe_service(
     }
 }
 
+/// Resolve `slug` and return the exact backend tool definition for that
+/// capability. This is the schema-bearing describe path shared by REST and MCP.
+pub async fn describe_tool_full(
+    gs: &GatewayState,
+    slug: &str,
+) -> Result<(CapabilityRecord, McpTool), ServiceError> {
+    let record = describe_service(&gs.capability_index, slug)?;
+    let reg = gs.registry.read().await;
+    let all = gs.live_instances(&reg);
+    let Some(entry) = all.iter().find(|e| e.instance_id == record.instance_id) else {
+        return Err(ServiceError::new(
+            "instance-offline",
+            format!(
+                "instance {} ({}) is no longer live; refresh and retry",
+                record.instance_id, record.dcc_type,
+            ),
+        ));
+    };
+    let url = format!("http://{}:{}/mcp", entry.host, entry.port);
+    drop(reg);
+
+    let tools = try_fetch_tools(&gs.http_client, &url, gs.backend_timeout)
+        .await
+        .map_err(|e| {
+            ServiceError::new(
+                "schema-unavailable",
+                format!("backend tools/list failed: {e}"),
+            )
+        })?;
+    let Some(tool) = tools
+        .into_iter()
+        .find(|tool| tool.name == record.callable_id)
+    else {
+        return Err(ServiceError::new(
+            "schema-unavailable",
+            format!(
+                "backend tool {:?} is no longer available on instance {}",
+                record.callable_id, record.instance_id,
+            ),
+        ));
+    };
+    Ok((record, tool))
+}
+
 /// Call a backend action by slug. Returns the raw backend
 /// `tools/call` envelope on success so REST and MCP wrappers can
 /// forward it verbatim.
@@ -137,7 +183,7 @@ pub async fn call_service(
     match forward_tools_call(
         &gs.http_client,
         &url,
-        &record.backend_tool,
+        &record.callable_id,
         Some(arguments),
         meta,
         None,
@@ -237,6 +283,7 @@ mod unit_tests {
     fn push(index: &CapabilityIndex, dcc: &str, iid: Uuid, backend_tool: &str) {
         let rec = CapabilityRecord::new(
             tool_slug(dcc, &iid, backend_tool),
+            backend_tool.to_string(),
             backend_tool.to_string(),
             None,
             "",

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
@@ -2,8 +2,8 @@ use super::*;
 
 use crate::gateway::capability::RefreshReason;
 use crate::gateway::capability_service::{
-    ServiceError, call_service, describe_service, parse_search_payload, refresh_all_live_backends,
-    search_service, service_error_to_json,
+    ServiceError, call_service, describe_tool_full, parse_search_payload,
+    refresh_all_live_backends, search_service, service_error_to_json,
 };
 
 /// `GET /health` — simple liveness probe.
@@ -127,17 +127,12 @@ pub async fn handle_v1_describe(
     };
     refresh_all_live_backends(&gs, RefreshReason::Periodic).await;
 
-    match describe_service(&gs.capability_index, slug) {
-        Ok(record) => (
+    match describe_tool_full(&gs, slug).await {
+        Ok((record, tool)) => (
             StatusCode::OK,
             Json(json!({
                 "record": record,
-                // The compact record is the primary payload; callers
-                // that need the full schema fetch it via
-                // `POST /v1/call` with a `dry_run: true` argument in a
-                // future iteration (deliberately out of scope for
-                // #654's first pass).
-                "tool": Value::Null,
+                "tool": tool,
             })),
         )
             .into_response(),
@@ -184,7 +179,7 @@ fn error_response(err: &ServiceError) -> (StatusCode, Json<Value>) {
         "unknown-slug" => StatusCode::NOT_FOUND,
         "ambiguous" => StatusCode::CONFLICT,
         "instance-offline" => StatusCode::SERVICE_UNAVAILABLE,
-        "backend-error" => StatusCode::BAD_GATEWAY,
+        "backend-error" | "schema-unavailable" => StatusCode::BAD_GATEWAY,
         _ => StatusCode::BAD_REQUEST,
     };
     (status, Json(service_error_to_json(err)))

--- a/crates/dcc-mcp-gateway/src/gateway/tools.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tools.rs
@@ -371,10 +371,10 @@ pub async fn tool_describe_tool(gs: &GatewayState, args: &Value) -> Result<Strin
         crate::gateway::capability::RefreshReason::Periodic,
     )
     .await;
-    match crate::gateway::capability_service::describe_service(&gs.capability_index, slug) {
-        Ok(record) => serde_json::to_string_pretty(&json!({
+    match crate::gateway::capability_service::describe_tool_full(gs, slug).await {
+        Ok((record, tool)) => serde_json::to_string_pretty(&json!({
             "record": record,
-            "tool":   Value::Null,
+            "tool":   tool,
         }))
         .map_err(|e| e.to_string()),
         Err(err) => {

--- a/crates/dcc-mcp-http/src/server/mod.rs
+++ b/crates/dcc-mcp-http/src/server/mod.rs
@@ -387,6 +387,16 @@ impl McpHttpServer {
             }
         }
 
+        let mut rest_config = dcc_mcp_skill_rest::SkillRestConfig::new(
+            dcc_mcp_skill_rest::SkillRestService::from_catalog_and_dispatcher(
+                catalog.clone(),
+                self.dispatcher.clone(),
+            ),
+        );
+        rest_config.server_title = self.config.server_name.clone();
+        rest_config.server_version = self.config.server_version.clone();
+        let rest_router = dcc_mcp_skill_rest::build_skill_rest_router(rest_config);
+
         let state = AppState {
             registry: self.registry,
             dispatcher: self.dispatcher,
@@ -429,6 +439,7 @@ impl McpHttpServer {
                     .delete(handle_delete),
             )
             .with_state(state)
+            .merge(rest_router)
             .layer(TraceLayer::new_for_http());
 
         // Prometheus `/metrics` endpoint (issue #331). Mounted on the

--- a/crates/dcc-mcp-http/tests/http/gateway_dynamic_capabilities.rs
+++ b/crates/dcc-mcp-http/tests/http/gateway_dynamic_capabilities.rs
@@ -368,6 +368,127 @@ async fn rest_and_mcp_wrapper_return_identical_search_hits() {
 /// the gateway slug) to the owning backend exactly once when the
 /// slug is already indexed. No extra token or HTTP round-trip cost.
 #[tokio::test]
+async fn mcp_describe_tool_returns_backend_schema() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
+    let state = make_state(registry.clone(), GatewayToolExposure::Slim);
+
+    let (port, _) = spawn_backend(BackendSpec {
+        tools: vec![("screenshot", "Capture a screenshot")],
+    })
+    .await;
+    register_backend(&registry, "maya", port).await;
+    refresh_all_live_backends(&state, RefreshReason::InstanceJoined).await;
+    let hits = search_service(
+        &state.capability_index,
+        &parse_search_payload(&json!({"query": "screenshot"})),
+    );
+    assert_eq!(hits.len(), 1);
+
+    let (body, is_error) = route_tools_call(
+        &state,
+        "describe_tool",
+        &json!({"tool_slug": hits[0].record.tool_slug}),
+        None,
+        None,
+        None,
+    )
+    .await;
+    assert!(!is_error, "MCP describe_tool failed: {body}");
+    let parsed: Value = serde_json::from_str(&body).expect("describe_tool envelope is JSON");
+    assert_eq!(parsed["tool"]["name"].as_str(), Some("screenshot"));
+    assert_eq!(
+        parsed["tool"]["inputSchema"]["type"].as_str(),
+        Some("object")
+    );
+    assert_eq!(parsed["record"]["callable_id"].as_str(), Some("screenshot"));
+}
+
+#[tokio::test]
+async fn mcp_call_tool_forwards_namespaced_callable_id() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
+    let state = make_state(registry.clone(), GatewayToolExposure::Slim);
+
+    let (port, call_count) = spawn_backend(BackendSpec {
+        tools: vec![("jobs.get_status", "Get a render job status")],
+    })
+    .await;
+    register_backend(&registry, "maya", port).await;
+    refresh_all_live_backends(&state, RefreshReason::InstanceJoined).await;
+    let hits = search_service(
+        &state.capability_index,
+        &parse_search_payload(&json!({"query": "status"})),
+    );
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].record.backend_tool, "jobs.get_status");
+    assert_eq!(hits[0].record.callable_id, "jobs.get_status");
+    let (_, _, slug_tool) = parse_slug(&hits[0].record.tool_slug).unwrap();
+    assert_eq!(slug_tool, "jobs.get_status");
+
+    let (body, is_error) = route_tools_call(
+        &state,
+        "call_tool",
+        &json!({"tool_slug": hits[0].record.tool_slug, "arguments": {"job_id": "abc"}}),
+        None,
+        None,
+        None,
+    )
+    .await;
+    assert!(!is_error, "MCP call_tool failed: {body}");
+    let parsed: Value = serde_json::from_str(&body).expect("call_tool envelope is JSON");
+    assert_eq!(
+        parsed["structuredContent"]["received_tool"].as_str(),
+        Some("jobs.get_status"),
+    );
+    assert_eq!(*call_count.read().await, 1);
+}
+
+#[tokio::test]
+async fn slim_mode_blocks_direct_backend_tool_but_call_tool_still_works() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
+    let state = make_state(registry.clone(), GatewayToolExposure::Slim);
+
+    let (port, _) = spawn_backend(BackendSpec {
+        tools: vec![("direct_probe", "Direct call probe")],
+    })
+    .await;
+    let entry = register_backend(&registry, "maya", port).await;
+    refresh_all_live_backends(&state, RefreshReason::InstanceJoined).await;
+
+    let encoded = dcc_mcp_http::gateway::namespace::encode_tool_name_cursor_safe(
+        &entry.instance_id,
+        "direct_probe",
+    );
+    let (body, is_error) = route_tools_call(&state, &encoded, &json!({}), None, None, None).await;
+    assert!(
+        is_error,
+        "direct backend call must fail in Slim mode: {body}"
+    );
+    assert!(body.contains("call_tool"));
+
+    let hits = search_service(
+        &state.capability_index,
+        &parse_search_payload(&json!({"query": "direct"})),
+    );
+    assert_eq!(hits.len(), 1);
+    let (body, is_error) = route_tools_call(
+        &state,
+        "call_tool",
+        &json!({"tool_slug": hits[0].record.tool_slug, "arguments": {}}),
+        None,
+        None,
+        None,
+    )
+    .await;
+    assert!(
+        !is_error,
+        "call_tool should remain available in Slim mode: {body}"
+    );
+}
+
+#[tokio::test]
 async fn mcp_call_tool_forwards_original_backend_tool_exactly_once() {
     let dir = tempfile::tempdir().unwrap();
     let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
@@ -565,15 +686,16 @@ async fn capability_index_never_contains_skill_stubs_or_local_tools() {
         );
         assert_ne!(hit.record.backend_tool, "list_skills");
     }
-    // The real action is reachable — and its skill metadata is
-    // preserved so `search_tools(query="hello")` still matches.
+    // The real action is reachable with its exact callable id — and its
+    // skill metadata is preserved so `search_tools(query="hello")` still matches.
     assert!(
-        hits.iter().any(|h| h.record.backend_tool == "greet"),
+        hits.iter()
+            .any(|h| h.record.backend_tool == "hello-world.greet"),
         "real action must remain addressable: {hits:?}",
     );
     assert_eq!(
         hits.iter()
-            .find(|h| h.record.backend_tool == "greet")
+            .find(|h| h.record.backend_tool == "hello-world.greet")
             .and_then(|h| h.record.skill_name.as_deref()),
         Some("hello-world"),
     );

--- a/crates/dcc-mcp-skill-rest/src/service.rs
+++ b/crates/dcc-mcp-skill-rest/src/service.rs
@@ -264,12 +264,22 @@ impl SkillCatalogSource for CatalogSource {
         }
 
         for meta in registry.list_actions(None) {
-            let skill_name = meta.skill_name.clone().unwrap_or_default();
-            let (loaded, scope, _dcc) = skill_info.get(&skill_name).cloned().unwrap_or((
-                false,
-                "repo".to_string(),
-                meta.dcc.clone(),
-            ));
+            let skill_name = meta
+                .skill_name
+                .clone()
+                .unwrap_or_else(|| "core".to_string());
+            let (loaded, scope, _dcc) = meta
+                .skill_name
+                .as_ref()
+                .and_then(|name| skill_info.get(name).cloned())
+                .unwrap_or_else(|| {
+                    // Actions registered directly on the server are not owned by a
+                    // loadable skill, but they are still callable through the
+                    // dispatcher. Give them a stable slug segment and treat them as
+                    // loaded so the REST surface works for plain Python
+                    // `registry.register(...)` + `server.register_handler(...)` users.
+                    (true, "core".to_string(), meta.dcc.clone())
+                });
             out.push(CatalogAction {
                 action_name: meta.name,
                 skill_name,

--- a/tests/test_mcp_http_server.py
+++ b/tests/test_mcp_http_server.py
@@ -74,6 +74,25 @@ def _post_raw(url: str, data: bytes, headers: dict[str, str] | None = None) -> t
         return e.code, e.read().decode()
 
 
+def _get_json(url: str, headers: dict[str, str] | None = None) -> tuple[int, dict[str, Any]]:
+    """GET a JSON endpoint and return (status_code, response_body)."""
+    req = urllib.request.Request(
+        url,
+        headers={"Accept": "application/json", **(headers or {})},
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        return e.code, {}
+
+
+def _rest_base(mcp_url: str) -> str:
+    """Return the HTTP listener base URL for /v1 REST routes."""
+    return mcp_url.rsplit("/mcp", 1)[0]
+
+
 def _make_registry() -> ToolRegistry:
     reg = ToolRegistry()
     reg.register(
@@ -219,6 +238,59 @@ class TestMcpHttpProtocol:
             assert received == [{"count": 2, "label": "cube"}]
         finally:
             handle.shutdown()
+
+    def test_rest_routes_are_mounted_on_python_server(self, running_server):
+        _, _, url = running_server
+        base = _rest_base(url)
+
+        code, body = _get_json(f"{base}/v1/healthz")
+        assert code == 200
+        assert body["ok"] is True
+
+        code, body = _post_json(f"{base}/v1/search", {"query": "scene", "loaded_only": True})
+        assert code == 200
+        slugs = {hit["slug"] for hit in body["hits"]}
+        assert "test.core.get_scene_info" in slugs
+
+    def test_rest_describe_and_call_use_registered_python_handler(self, running_server):
+        _, _, url = running_server
+        base = _rest_base(url)
+        slug = "test.core.get_scene_info"
+
+        code, body = _post_json(f"{base}/v1/describe", {"tool_slug": slug, "include_schema": True})
+        assert code == 200
+        assert body["entry"]["slug"] == slug
+        assert body["entry"]["action"] == "get_scene_info"
+        assert "input_schema" in body
+
+        code, body = _post_json(f"{base}/v1/call", {"tool_slug": slug, "params": {}})
+        assert code == 200
+        assert body["slug"] == slug
+        assert body["output"]["scene"] == "test_scene"
+
+    def test_mcp_http_server_exposes_downstream_reuse_api(self, running_server):
+        server, _, _ = running_server
+        expected = {
+            "register_handler",
+            "has_handler",
+            "set_in_process_executor",
+            "clear_in_process_executor",
+            "discover",
+            "load_skill",
+            "unload_skill",
+            "list_skills",
+            "search_skills",
+            "get_skill_info",
+            "is_loaded",
+            "loaded_count",
+            "start",
+        }
+        missing = sorted(name for name in expected if not hasattr(server, name))
+        assert missing == []
+        assert hasattr(server, "registry")
+        assert hasattr(server.registry, "get_action")
+        assert hasattr(server.registry, "search_actions")
+        assert hasattr(server.registry, "list_actions")
 
     def test_tools_call_unknown(self, running_server):
         _, _, url = running_server

--- a/tests/test_server_sidecar_e2e.py
+++ b/tests/test_server_sidecar_e2e.py
@@ -19,6 +19,7 @@ import json
 import os
 from pathlib import Path
 import platform
+import socket
 import subprocess
 import sys
 import tempfile
@@ -58,6 +59,29 @@ def _post(url: str, body: dict, headers: dict | None = None) -> tuple[int, dict]
             return resp.status, json.loads(resp.read())
     except urllib.error.HTTPError as e:
         return e.code, {}
+
+
+def _get(url: str, headers: dict | None = None) -> tuple[int, dict]:
+    """GET a JSON body; return (status, response_dict)."""
+    req = urllib.request.Request(
+        url,
+        headers={"Accept": "application/json", **(headers or {})},
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status, json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        return e.code, {}
+
+
+def _allocate_port() -> int:
+    """Return an OS-picked ephemeral port; release it immediately."""
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
 
 
 def _initialize(url: str) -> str:
@@ -509,6 +533,66 @@ class TestServerBinarySidecar:
             timeout=10,
         )
         assert result.returncode == 0
+
+    def test_photoshop_binary_exposes_rest_routes(self, binary, tmp_path):
+        """Standalone binary path must expose /v1 for bridge DCCs such as Photoshop."""
+        mcp_port = _allocate_port()
+        registry_dir = tmp_path / "registry"
+        proc = subprocess.Popen(
+            [
+                str(binary),
+                "--mcp-port",
+                str(mcp_port),
+                "--gateway-port",
+                "0",
+                "--dcc",
+                "photoshop",
+                "--no-bridge",
+                "--registry-dir",
+                str(registry_dir),
+                "--no-log-file",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            base = f"http://127.0.0.1:{mcp_port}"
+            deadline = time.monotonic() + 10.0
+            health = (0, {})
+            while time.monotonic() < deadline:
+                health = _get(f"{base}/health")
+                if health[0] == 200:
+                    break
+                if proc.poll() is not None:
+                    break
+                time.sleep(0.1)
+            if proc.poll() is not None:
+                out, err = proc.communicate(timeout=1)
+                pytest.fail(
+                    "dcc-mcp-server exited before health check "
+                    f"(code={proc.returncode})\nstdout={out.decode('utf-8', 'replace')[:1000]}\n"
+                    f"stderr={err.decode('utf-8', 'replace')[:1000]}"
+                )
+            assert health[0] == 200
+
+            code, body = _get(f"{base}/v1/healthz")
+            assert code == 200
+            assert body["ok"] is True
+
+            code, body = _post(f"{base}/v1/search", {"query": "", "loaded_only": False})
+            assert code == 200
+            assert body["total"] == 0
+            assert body["hits"] == []
+
+            sid = _initialize(f"{base}/mcp")
+            assert sid
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
 
     def test_pid_file_written_on_start(self, binary, tmp_path):
         """Server writes a PID file on startup and removes it on SIGTERM."""

--- a/uv.lock
+++ b/uv.lock
@@ -421,7 +421,7 @@ toml = [
 
 [[package]]
 name = "dcc-mcp-core"
-version = "0.14.21"
+version = "0.14.22"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Preserve exact backend callable IDs in gateway capability records and use them for `call_tool` routing.
- Return full backend tool schemas from `describe_tool` and `/v1/describe`.
- Block direct backend MCP tool calls in slim/rest gateway modes while keeping `search_tools -> describe_tool -> call_tool` available.
- Mount `/v1/*` REST routes on Python `McpHttpServer` and cover standalone `dcc-mcp-server` for bridge DCCs such as Photoshop.

Fixes #674
Fixes #675
Fixes #676

## Tests
- `vx cargo test -p dcc-mcp-gateway`
- `vx cargo test -p dcc-mcp-http --test http gateway_dynamic_capabilities -- --nocapture`
- `vx uv run --with pytest python -m pytest tests/test_mcp_http_server.py::TestMcpHttpProtocol::test_rest_routes_are_mounted_on_python_server tests/test_mcp_http_server.py::TestMcpHttpProtocol::test_rest_describe_and_call_use_registered_python_handler tests/test_mcp_http_server.py::TestMcpHttpProtocol::test_mcp_http_server_exposes_downstream_reuse_api -q`
- `vx uv run --with pytest python -m pytest tests/test_server_sidecar_e2e.py::TestServerBinarySidecar::test_photoshop_binary_exposes_rest_routes tests/test_server_sidecar_e2e.py::TestServerBinarySidecar::test_pid_file_written_on_start tests/test_server_sidecar_e2e.py::TestServerBinarySidecar::test_duplicate_start_rejected_without_force -q`
- `vx uv run --with ruff ruff check tests/test_mcp_http_server.py tests/test_server_sidecar_e2e.py`
- `vx cargo build --workspace --all-targets --timings`
- `git diff --check`