### PR TITLE
Remove Maya-only DCC assumptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,24 @@
 5. Debug on failure: Use dcc_diagnostics__screenshot or audit_log
 ```
 
+### Multi-DCC Guardrails
+
+- This repository must support multiple DCC hosts (Maya, Blender, Houdini,
+  Photoshop, ZBrush, Unreal, Unity, Figma, and custom studio hosts). Do not
+  introduce Maya-only assumptions in core code, gateway routing, skill
+  discovery, auth examples, error messages, or tests.
+- Keep DCC identity parameterized (`dcc_name`, `dcc_type`, `app_name`,
+  `DccName::parse`) and preserve unknown/custom DCC names instead of rejecting
+  them unless a boundary explicitly requires a known host.
+- When fixing an issue, add realistic Rust **and** Python regression tests when
+  the behavior crosses Rust/Python or downstream APIs. Use real-looking DCC
+  examples from at least two host families where practical (for example Maya +
+  Photoshop/ZBrush/custom), not only synthetic single-DCC fixtures.
+- For MCP/gateway changes, include an E2E-style validation path that exercises
+  actual `tools/list` / `tools/call` / REST or gateway routing. If a real DCC is
+  unavailable, use the closest executable/server path and state the gap in the
+  PR.
+
 **API surface** — read in this order:
 1. 🆕 **[`AI_AGENT_GUIDE.md`](AI_AGENT_GUIDE.md)** — **START HERE** for using dcc-mcp-core effectively
 2. `python/dcc_mcp_core/__init__.py` — every public symbol
@@ -136,7 +154,7 @@
 | Discover team-level skills | `scan_and_load_team()` / `scan_and_load_team_lenient()` |
 | Discover user-level skills | `scan_and_load_user()` / `scan_and_load_user_lenient()` |
 | Disable evolved skills | `ENV_DISABLE_ACCUMULATED_SKILLS` |
-| MCP HTTP (recommended) | `create_skill_server("maya", McpHttpConfig(port=8765))` |
+| MCP HTTP (recommended) | `create_skill_server("<dcc>", McpHttpConfig(port=8765))` |
 | MCP HTTP (manual) | `McpHttpServer(registry, McpHttpConfig(port=8765))` |
 | Full-screen capture | `Capturer.new_auto().capture()` |
 | Single-window capture | `Capturer.new_window_auto().capture_window(...)` |
@@ -249,6 +267,7 @@ docs/            # guides + API reference
 - Tag every skill with `metadata.dcc-mcp.layer`
 - Unpack `scan_and_load()`: `skills, skipped = scan_and_load(...)`
 - Use `DccName::parse(s)` at Rust API boundaries instead of `&str` (#491)
+- Keep core code DCC-agnostic; parameterize `dcc_name` / `dcc_type` and cover multi-DCC behavior in Rust + Python tests
 - Use `MethodRouter::with_builtins()` then `.register(...)` to add custom JSON-RPC methods (#492)
 - Use Conventional Commits: `feat:`, `fix:`, `docs:`, `refactor:`
 - Use `vx just dev` before `vx just test`
@@ -261,6 +280,8 @@ docs/            # guides + API reference
 - Don't hand-roll `{"success": ..., "context": ...}` dicts in handlers → **return `ToolResult.ok(...).to_dict()`** (the factory is `ok`/`success_`, NOT `success`) (#487)
 - Don't write inline `"dcc-mcp.recipes"` / `"thin-harness"` literals → **import from `dcc_mcp_core`** (constants re-exported at top level) (#487)
 - Don't pass raw `&str` DCC names through Rust APIs → **`DccName::parse(s)` at the boundary** (#491)
+- Don't hardcode Maya as the default/example for generic core behavior → **use generic DCC examples or at least two DCCs in tests**
+- Don't fix issues with Rust-only or Python-only coverage when both surfaces are affected → **add realistic tests on both sides**
 - Don't extend the JSON-RPC `match` arm in `dispatch.rs` → **register a `MethodHandler` on `MethodRouter`** (#492)
 - Don't hand-roll JSON-RPC envelopes → **`NotificationBuilder` / `JsonRpcRequestBuilder`** (#484)
 - Don't add per-crate `*Error` enums → **return `DccMcpError` via `From` impls** (#488)

--- a/crates/dcc-mcp-models/src/dcc_name.rs
+++ b/crates/dcc-mcp-models/src/dcc_name.rs
@@ -174,6 +174,40 @@ mod tests {
         assert_eq!(unk, back);
     }
 
+    #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+    struct GatewayRegistration {
+        dcc_type: DccName,
+        app_name: String,
+        tools: Vec<String>,
+    }
+
+    #[test]
+    fn serde_preserves_real_gateway_registration_dcc_types() {
+        let payloads = [
+            (
+                r#"{"dcc_type":"photoshop","app_name":"Photoshop 2026","tools":["photoshop.layers.list"]}"#,
+                DccName::Photoshop,
+            ),
+            (
+                r#"{"dcc_type":"zbrush","app_name":"ZBrush 2026","tools":["zbrush.subtool.list"]}"#,
+                DccName::Zbrush,
+            ),
+            (
+                r#"{"dcc_type":"krita","app_name":"Krita Studio","tools":["krita.document.active"]}"#,
+                DccName::Other("krita".into()),
+            ),
+        ];
+
+        for (payload, expected_dcc) in payloads {
+            let registration: GatewayRegistration = serde_json::from_str(payload).unwrap();
+            assert_eq!(registration.dcc_type, expected_dcc);
+            assert_eq!(
+                serde_json::to_value(&registration).unwrap()["dcc_type"],
+                serde_json::Value::String(registration.dcc_type.to_string())
+            );
+        }
+    }
+
     #[test]
     fn display_uses_as_str() {
         assert_eq!(DccName::Maya.to_string(), "maya");

--- a/crates/dcc-mcp-models/src/dcc_name.rs
+++ b/crates/dcc-mcp-models/src/dcc_name.rs
@@ -31,6 +31,14 @@ pub enum DccName {
     Cinema4d,
     /// Adobe Photoshop
     Photoshop,
+    /// Pixologic ZBrush
+    Zbrush,
+    /// Epic Unreal Engine
+    Unreal,
+    /// Unity Editor
+    Unity,
+    /// Figma
+    Figma,
     /// Foundry Nuke
     Nuke,
     /// Any DCC not covered by the canonical variants — preserves the
@@ -51,6 +59,10 @@ impl DccName {
             "3dsmax" | "max" | "threedsmax" => Self::ThreedsMax,
             "c4d" | "cinema4d" => Self::Cinema4d,
             "photoshop" | "ps" => Self::Photoshop,
+            "zbrush" => Self::Zbrush,
+            "unreal" | "ue" | "ue5" => Self::Unreal,
+            "unity" => Self::Unity,
+            "figma" => Self::Figma,
             "nuke" => Self::Nuke,
             _ => Self::Other(lower),
         }
@@ -65,6 +77,10 @@ impl DccName {
             Self::ThreedsMax => "3dsmax",
             Self::Cinema4d => "c4d",
             Self::Photoshop => "photoshop",
+            Self::Zbrush => "zbrush",
+            Self::Unreal => "unreal",
+            Self::Unity => "unity",
+            Self::Figma => "figma",
             Self::Nuke => "nuke",
             Self::Other(s) => s.as_str(),
         }
@@ -117,6 +133,11 @@ mod tests {
         assert_eq!(DccName::parse("blender"), DccName::Blender);
         assert_eq!(DccName::parse("houdini"), DccName::Houdini);
         assert_eq!(DccName::parse("c4d"), DccName::Cinema4d);
+        assert_eq!(DccName::parse("photoshop"), DccName::Photoshop);
+        assert_eq!(DccName::parse("zbrush"), DccName::Zbrush);
+        assert_eq!(DccName::parse("unreal"), DccName::Unreal);
+        assert_eq!(DccName::parse("unity"), DccName::Unity);
+        assert_eq!(DccName::parse("figma"), DccName::Figma);
         assert_eq!(DccName::parse("nuke"), DccName::Nuke);
     }
 
@@ -125,6 +146,8 @@ mod tests {
         assert_eq!(DccName::parse("MAYA"), DccName::Maya);
         assert_eq!(DccName::parse("  Blender  "), DccName::Blender);
         assert_eq!(DccName::parse("3DsMax"), DccName::ThreedsMax);
+        assert_eq!(DccName::parse("PS"), DccName::Photoshop);
+        assert_eq!(DccName::parse("UE5"), DccName::Unreal);
     }
 
     #[test]
@@ -154,6 +177,10 @@ mod tests {
     #[test]
     fn display_uses_as_str() {
         assert_eq!(DccName::Maya.to_string(), "maya");
+        assert_eq!(DccName::Zbrush.to_string(), "zbrush");
+        assert_eq!(DccName::Unreal.to_string(), "unreal");
+        assert_eq!(DccName::Unity.to_string(), "unity");
+        assert_eq!(DccName::Figma.to_string(), "figma");
         assert_eq!(DccName::Other("krita".into()).to_string(), "krita");
     }
 

--- a/crates/dcc-mcp-skills/src/scanner.rs
+++ b/crates/dcc-mcp-skills/src/scanner.rs
@@ -252,14 +252,55 @@ mod tests {
     }
 
     #[test]
-    fn test_scan_for_dcc_typed_entry_point() {
+    fn test_scan_for_dcc_uses_non_maya_typed_env_paths() {
         use dcc_mcp_models::DccName;
+        use std::fs;
 
-        // Typed entry point delegates to scan() with the canonical
-        // lowercase string form (#491).
+        fn write_skill_dir(root: &Path, name: &str) -> String {
+            let dir = root.join(name);
+            fs::create_dir_all(&dir).unwrap();
+            fs::write(
+                dir.join(crate::constants::SKILL_METADATA_FILE),
+                format!("name: {name}\nversion: 1.0.0\n"),
+            )
+            .unwrap();
+            path_to_string(&dir)
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        let photoshop_skill = write_skill_dir(tmp.path(), "photoshop-retouch");
+        let krita_skill = write_skill_dir(tmp.path(), "krita-paintover");
+
+        let saved_photoshop = std::env::var("DCC_MCP_PHOTOSHOP_SKILL_PATHS").ok();
+        let saved_krita = std::env::var("DCC_MCP_KRITA_SKILL_PATHS").ok();
+        unsafe {
+            std::env::set_var("DCC_MCP_PHOTOSHOP_SKILL_PATHS", &photoshop_skill);
+            std::env::set_var("DCC_MCP_KRITA_SKILL_PATHS", &krita_skill);
+        }
+
         let mut scanner = SkillScanner::new();
-        let dcc = DccName::Maya;
-        let result = scanner.scan_for_dcc(Some(&["/nonexistent".to_string()]), Some(&dcc), false);
-        assert!(result.is_empty());
+        let photoshop = scanner.scan_for_dcc(None, Some(&DccName::Photoshop), true);
+        scanner.clear_cache();
+        let custom = scanner.scan_for_dcc(None, Some(&DccName::Other("krita".into())), true);
+
+        unsafe {
+            match saved_photoshop {
+                Some(value) => std::env::set_var("DCC_MCP_PHOTOSHOP_SKILL_PATHS", value),
+                None => std::env::remove_var("DCC_MCP_PHOTOSHOP_SKILL_PATHS"),
+            }
+            match saved_krita {
+                Some(value) => std::env::set_var("DCC_MCP_KRITA_SKILL_PATHS", value),
+                None => std::env::remove_var("DCC_MCP_KRITA_SKILL_PATHS"),
+            }
+        }
+
+        assert!(
+            photoshop.contains(&photoshop_skill),
+            "photoshop scan returned {photoshop:?}"
+        );
+        assert!(
+            custom.contains(&krita_skill),
+            "custom DCC scan returned {custom:?}"
+        );
     }
 }

--- a/python/dcc_mcp_core/auth.py
+++ b/python/dcc_mcp_core/auth.py
@@ -33,9 +33,9 @@ Usage
     # OAuth 2.1 + CIMD (recommended for production)
     oauth_cfg = OAuthConfig(
         provider_url="https://auth.shotgrid.example.com",
-        client_id="maya-mcp-client",
+        client_id="dcc-mcp-client",
         scopes=["scene:read", "render:write"],
-        client_name="Maya MCP Server",
+        client_name="DCC MCP Server",
     )
     cimd_doc = oauth_cfg.to_cimd_document(redirect_uri="http://localhost:8765/oauth/callback")
 
@@ -162,7 +162,7 @@ class OAuthConfig:
         cfg = OAuthConfig(
             provider_url="https://auth.shotgrid.example.com",
             scopes=["scene:read", "render:write"],
-            client_name="Maya MCP Server",
+            client_name="DCC MCP Server",
         )
         doc = cfg.to_cimd_document(redirect_uri="http://localhost:8765/oauth/callback")
 

--- a/python/dcc_mcp_core/skill.py
+++ b/python/dcc_mcp_core/skill.py
@@ -620,14 +620,30 @@ def _serialize_result(result: ResultDict) -> str:
         )
 
 
+_DCC_IMPORT_LABELS = {
+    "maya": "Maya",
+    "houdini": "Houdini",
+    "nuke": "Nuke",
+    "blender": "Blender",
+    "cinema4d": "Cinema 4D",
+    "c4d": "Cinema 4D",
+    "3dsmax": "3ds Max",
+    "unreal": "Unreal",
+    "unity": "Unity",
+    "photoshop": "Photoshop",
+    "zbrush": "ZBrush",
+    "figma": "Figma",
+}
+
+
 def _guess_dcc_from_import_error(exc: ImportError) -> str:
     """Best-effort guess of the DCC name from an ImportError message."""
-    msg = str(exc).lower()
-    for dcc in ("maya", "houdini", "nuke", "blender", "cinema4d", "3dsmax", "unreal"):
-        if dcc in msg:
-            return dcc.capitalize()
-    # Check module name if available (Python 3.6+)
     if exc.name:
-        top = exc.name.split(".")[0]
-        return top
+        top = exc.name.split(".")[0].lower()
+        return _DCC_IMPORT_LABELS.get(top, top)
+
+    msg = str(exc).lower()
+    for dcc, label in _DCC_IMPORT_LABELS.items():
+        if dcc in msg:
+            return label
     return "DCC"

--- a/tests/test_skill_error_with_trace.py
+++ b/tests/test_skill_error_with_trace.py
@@ -114,45 +114,48 @@ def test_default_prompt_present():
     assert result["prompt"]
 
 
-def test_skill_entry_import_error_uses_bridge_dcc_name_from_module():
+@pytest.mark.parametrize(
+    ("exc", "expected_label"),
+    [
+        (
+            ImportError("No module named 'photoshop.api' while probing Maya fallback", name="photoshop.api"),
+            "Photoshop",
+        ),
+        (ImportError("No module named 'zbrush' while loading bridge adapter"), "ZBrush"),
+        (ImportError("No module named 'krita.api'", name="krita.api"), "krita"),
+    ],
+)
+def test_skill_entry_import_error_reports_actual_bridge_host(exc, expected_label):
     from dcc_mcp_core.skill import skill_entry
 
     @skill_entry
-    def photoshop_bridge_tool():
-        raise ImportError("No module named 'photoshop.api'", name="photoshop.api")
+    def bridge_tool():
+        raise exc
 
-    result = photoshop_bridge_tool()
+    result = bridge_tool()
 
     assert result["success"] is False
-    assert result["message"] == "Photoshop is not available in this environment"
-    assert "Photoshop is running" in result["prompt"]
-    assert "Maya" not in result["message"]
+    assert result["message"] == f"{expected_label} is not available in this environment"
+    assert f"{expected_label} is running" in result["prompt"]
+    assert "Maya is not available" not in result["message"]
     assert "Maya" not in result["prompt"]
 
 
-def test_skill_entry_import_error_uses_bridge_dcc_name_from_message():
+def test_run_main_emits_non_maya_bridge_error_json(capsys):
+    import json
+
+    from dcc_mcp_core.skill import run_main
     from dcc_mcp_core.skill import skill_entry
 
     @skill_entry
     def zbrush_bridge_tool():
         raise ImportError("No module named 'zbrush' while loading bridge adapter")
 
-    result = zbrush_bridge_tool()
+    with pytest.raises(SystemExit) as exit_info:
+        run_main(zbrush_bridge_tool)
 
-    assert result["success"] is False
-    assert result["message"] == "ZBrush is not available in this environment"
-    assert "ZBrush is running" in result["prompt"]
-
-
-def test_skill_entry_import_error_preserves_unknown_custom_dcc_module():
-    from dcc_mcp_core.skill import skill_entry
-
-    @skill_entry
-    def custom_dcc_tool():
-        raise ImportError("No module named 'krita.api'", name="krita.api")
-
-    result = custom_dcc_tool()
-
-    assert result["success"] is False
-    assert result["message"] == "krita is not available in this environment"
-    assert "krita is running" in result["prompt"]
+    assert exit_info.value.code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["success"] is False
+    assert payload["message"] == "ZBrush is not available in this environment"
+    assert "Maya" not in payload["prompt"]

--- a/tests/test_skill_error_with_trace.py
+++ b/tests/test_skill_error_with_trace.py
@@ -112,3 +112,47 @@ def test_default_prompt_present():
 
     result = skill_error_with_trace("msg", "err")
     assert result["prompt"]
+
+
+def test_skill_entry_import_error_uses_bridge_dcc_name_from_module():
+    from dcc_mcp_core.skill import skill_entry
+
+    @skill_entry
+    def photoshop_bridge_tool():
+        raise ImportError("No module named 'photoshop.api'", name="photoshop.api")
+
+    result = photoshop_bridge_tool()
+
+    assert result["success"] is False
+    assert result["message"] == "Photoshop is not available in this environment"
+    assert "Photoshop is running" in result["prompt"]
+    assert "Maya" not in result["message"]
+    assert "Maya" not in result["prompt"]
+
+
+def test_skill_entry_import_error_uses_bridge_dcc_name_from_message():
+    from dcc_mcp_core.skill import skill_entry
+
+    @skill_entry
+    def zbrush_bridge_tool():
+        raise ImportError("No module named 'zbrush' while loading bridge adapter")
+
+    result = zbrush_bridge_tool()
+
+    assert result["success"] is False
+    assert result["message"] == "ZBrush is not available in this environment"
+    assert "ZBrush is running" in result["prompt"]
+
+
+def test_skill_entry_import_error_preserves_unknown_custom_dcc_module():
+    from dcc_mcp_core.skill import skill_entry
+
+    @skill_entry
+    def custom_dcc_tool():
+        raise ImportError("No module named 'krita.api'", name="krita.api")
+
+    result = custom_dcc_tool()
+
+    assert result["success"] is False
+    assert result["message"] == "krita is not available in this environment"
+    assert "krita is running" in result["prompt"]


### PR DESCRIPTION
## Summary
- Add AGENTS.md guardrails requiring DCC-agnostic core behavior and realistic Rust + Python regression tests for issue fixes.
- Extend `DccName` known variants for bridge/editor hosts: ZBrush, Unreal, Unity, and Figma while keeping unknown/custom hosts preserved.
- Make generic auth examples DCC-neutral instead of Maya-specific.
- Improve skill ImportError messages for Photoshop/ZBrush/custom DCC modules without falling back to Maya wording.

## Tests
- `vx cargo test -p dcc-mcp-models dcc_name`
- `vx cargo check -p dcc-mcp-models`
- `vx cargo check -p dcc-mcp-core`
- `vx uv run --with pytest python -m pytest tests/test_skill_error_with_trace.py -q`
- `vx uv run --with ruff ruff check python/dcc_mcp_core/auth.py python/dcc_mcp_core/skill.py tests/test_skill_error_with_trace.py`
- `git diff --check`