### PR TITLE
fix(http): filter stubs from search_tools and surface unloaded skills (#677)

### DIFF
--- a/crates/dcc-mcp-http/src/handlers/job_tools.rs
+++ b/crates/dcc-mcp-http/src/handlers/job_tools.rs
@@ -87,70 +87,198 @@ pub async fn handle_deactivate_tool_group(
     ))
 }
 
-/// Handle ``search_tools`` — free-text search across every registered tool.
+/// Handle ``search_tools`` — free-text search across every registered tool
+/// and, by default, the metadata of unloaded skills the catalog knows about.
+///
+/// Behaviour (issue #677):
+///
+/// * **Stubs are filtered by default.** Progressive-loading discovery names
+///   like `__skill__<name>` and `__group__<name>` never appear as regular
+///   tool hits unless the caller opts in with `include_stubs=true`. This
+///   matches what [`super::super::gateway::capability::builder::should_skip`]
+///   already does on the MCP-gateway side so both paths behave the same.
+/// * **Unloaded skills are searchable.** When `include_unloaded_skills` is
+///   unset or `true`, the handler also runs the query through
+///   [`SkillCatalog::search_skills`] (BM25-lite over name, description,
+///   `search-hint`, tags and `tools.yaml` names) and returns each unloaded
+///   hit as a **skill candidate** with `requires_load_skill: true` and a
+///   ready-to-send `load_hint` describing the `load_skill` call needed to
+///   expose the underlying tools.
+/// * **Schema property names are indexed.** The haystack for loaded tools
+///   includes the top-level property keys of `input_schema`, so a query
+///   like `radius` matches `create_sphere({radius}) ` even if no tag,
+///   description or tool name contains the word.
+///
+/// Output envelope (stable, additive — old fields kept):
+///
+/// ```json
+/// {
+///   "total": N,
+///   "query": "...",
+///   "tools": [...],              // loaded tools, kind = "tool"
+///   "skill_candidates": [...]    // unloaded skills, kind = "skill_candidate"
+/// }
+/// ```
 pub async fn handle_search_tools(
     state: &AppState,
     req: &JsonRpcRequest,
     params: &CallToolParams,
 ) -> Result<JsonRpcResponse, HttpError> {
-    let query = params
-        .arguments
-        .as_ref()
+    let args = params.arguments.as_ref();
+
+    let query_raw = args
         .and_then(|a| a.get("query"))
         .and_then(Value::as_str)
         .unwrap_or_default()
-        .to_lowercase();
-    if query.is_empty() {
+        .trim();
+    if query_raw.is_empty() {
         return Ok(JsonRpcResponse::success(
             req.id.clone(),
             serde_json::to_value(CallToolResult::error("Missing required parameter: query"))?,
         ));
     }
-    let dcc = params
-        .arguments
-        .as_ref()
-        .and_then(|a| a.get("dcc"))
-        .and_then(Value::as_str);
-    let include_disabled = params
-        .arguments
-        .as_ref()
+    let query = query_raw.to_lowercase();
+
+    let dcc = args.and_then(|a| a.get("dcc")).and_then(Value::as_str);
+    let include_disabled = args
         .and_then(|a| a.get("include_disabled"))
         .and_then(Value::as_bool)
         .unwrap_or(false);
+    let include_stubs = args
+        .and_then(|a| a.get("include_stubs"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let include_unloaded_skills = args
+        .and_then(|a| a.get("include_unloaded_skills"))
+        .and_then(Value::as_bool)
+        .unwrap_or(true);
+    let limit = args
+        .and_then(|a| a.get("limit"))
+        .and_then(Value::as_u64)
+        .map(|n| n.clamp(1, 100) as usize)
+        .unwrap_or(25);
 
-    let mut matches: Vec<serde_json::Value> = Vec::new();
+    // ── 1. Loaded-tool hits ───────────────────────────────────────────
+    let mut tool_hits: Vec<serde_json::Value> = Vec::new();
     for meta in state.registry.list_actions(dcc) {
         if !include_disabled && !meta.enabled {
             continue;
         }
+        if !include_stubs && is_progressive_stub(&meta.name) {
+            continue;
+        }
+        // Pull top-level input-schema property keys into the haystack so
+        // queries that name a parameter (`radius`, `force`, ...) still hit
+        // the action that declares them.
+        let schema_props = schema_property_names(&meta.input_schema);
         let haystack = format!(
-            "{} {} {} {}",
+            "{} {} {} {} {}",
             meta.name,
             meta.description,
             meta.category,
-            meta.tags.join(" ")
+            meta.tags.join(" "),
+            schema_props.join(" "),
         )
         .to_lowercase();
-        if haystack.contains(&query) {
-            matches.push(serde_json::json!({
-                "name": meta.name,
-                "description": meta.description,
-                "category": meta.category,
-                "group": meta.group,
-                "enabled": meta.enabled,
-                "dcc": meta.dcc,
+        if !haystack.contains(&query) {
+            continue;
+        }
+        let mut hit = serde_json::json!({
+            "kind": "tool",
+            "name": meta.name,
+            "description": meta.description,
+            "category": meta.category,
+            "group": meta.group,
+            "enabled": meta.enabled,
+            "dcc": meta.dcc,
+        });
+        if let Some(skill) = &meta.skill_name {
+            hit["skill_name"] = Value::String(skill.clone());
+        }
+        tool_hits.push(hit);
+        if tool_hits.len() >= limit {
+            break;
+        }
+    }
+
+    // ── 2. Unloaded-skill candidates ──────────────────────────────────
+    let mut skill_candidates: Vec<serde_json::Value> = Vec::new();
+    if include_unloaded_skills {
+        let candidates = state
+            .catalog
+            .search_skills(Some(query_raw), &[], dcc, None, Some(limit));
+        for summary in candidates {
+            if summary.loaded {
+                continue; // already surfaced through registry hits above
+            }
+            let detail = state.catalog.get_skill_info(&summary.name);
+            let matching_tools = detail
+                .as_ref()
+                .map(|d| {
+                    d.tools
+                        .iter()
+                        .filter(|t| {
+                            t.name.to_lowercase().contains(&query)
+                                || t.description.to_lowercase().contains(&query)
+                        })
+                        .map(|t| t.name.clone())
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            skill_candidates.push(serde_json::json!({
+                "kind": "skill_candidate",
+                "skill_name": summary.name,
+                "description": summary.description,
+                "tags": summary.tags,
+                "dcc": summary.dcc,
+                "scope": summary.scope,
+                "tool_count": summary.tool_count,
+                "matching_tools": matching_tools,
+                "requires_load_skill": true,
+                "load_hint": {
+                    "tool": "load_skill",
+                    "arguments": { "skill_name": summary.name },
+                },
             }));
         }
     }
+
+    let total = tool_hits.len() + skill_candidates.len();
     let result = serde_json::json!({
-        "total": matches.len(),
+        "total": total,
         "query": query,
-        "tools": matches,
+        "tools": tool_hits,
+        "skill_candidates": skill_candidates,
     });
     Ok(JsonRpcResponse::success(
         req.id.clone(),
         serde_json::to_value(CallToolResult::text(serde_json::to_string(&result)?))?,
     ))
+}
+
+/// `true` when `name` matches a progressive-loading discovery stub.
+///
+/// These names — `__skill__<name>`, `__group__<name>`, or a dotted form
+/// `<ns>.__skill__<name>` — describe *how to load* a capability, not a
+/// capability you can invoke, so `search_tools` hides them by default.
+fn is_progressive_stub(name: &str) -> bool {
+    name.starts_with("__skill__")
+        || name.starts_with("__group__")
+        || name.contains(".__skill__")
+        || name.contains(".__group__")
+}
+
+/// Collect top-level property names from a JSON Schema object.
+///
+/// Returns an empty vector for schemas without a `properties` map. Used by
+/// `handle_search_tools` to index parameter names (e.g. `radius`, `force`)
+/// so they become matchable by keyword queries.
+fn schema_property_names(schema: &Value) -> Vec<String> {
+    schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .map(|props| props.keys().cloned().collect())
+        .unwrap_or_default()
 }
 
 // ── Built-in `jobs.get_status` (#319) ─────────────────────────────────────

--- a/crates/dcc-mcp-http/src/handlers/tool_builder_core.rs
+++ b/crates/dcc-mcp-http/src/handlers/tool_builder_core.rs
@@ -272,18 +272,22 @@ pub fn build_core_tools_inner() -> Vec<McpTool> {
         },
         McpTool {
             name: "search_tools".to_string(),
-            description: "Full-text search over already-registered tools, matching name, description, category, and tags and ranking enabled tools first.\n\n\
-                          When to use: Use after skills are loaded to locate a specific tool without dumping the whole tools/list. If nothing matches, fall back to search_skills — the tool may live in an unloaded skill.\n\n\
+            description: "Full-text search over registered tools and, by default, the metadata of unloaded skills (#677).\n\n\
+                          When to use: Locate a capability by keyword without dumping the whole tools/list. Hits include both loaded tools and unloaded-skill candidates; the latter carry `requires_load_skill: true` and a ready-to-send `load_hint` so an agent can follow up with `load_skill`.\n\n\
                           How to use:\n\
-                          - Keep the query short; set include_disabled=true only when inspecting inactive groups.\n\
-                          - Call the returned tool directly by its name."
+                          - Keep the query short; matches scan name, description, category, tags, and input-schema property names.\n\
+                          - `include_disabled=true` reveals tools inside inactive tool groups.\n\
+                          - `include_unloaded_skills=false` restricts results to loaded tools only.\n\
+                          - `include_stubs=true` exposes progressive-loading `__skill__*` / `__group__*` stubs for debugging. They are filtered out by default.\n\
+                          - `limit` caps each of `tools` and `skill_candidates` (default 25, max 100).\n\
+                          - For unloaded skills, call `load_skill` with the returned `skill_name` before invoking tools."
                 .to_string(),
             input_schema: json!({
                 "type": "object",
                 "properties": {
                     "query": {
                         "type": "string",
-                        "description": "Keyword matched against tool name, description, category, and tags."
+                        "description": "Keyword matched against tool name, description, category, tags, and input-schema property names; also forwarded to the skill-catalog scorer for unloaded-skill discovery."
                     },
                     "dcc": {
                         "type": "string",
@@ -293,6 +297,23 @@ pub fn build_core_tools_inner() -> Vec<McpTool> {
                         "type": "boolean",
                         "default": false,
                         "description": "Also search tools inside inactive tool groups."
+                    },
+                    "include_unloaded_skills": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Include matching unloaded skills as `skill_candidate` results with a load_hint."
+                    },
+                    "include_stubs": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Expose progressive-loading `__skill__*` / `__group__*` stubs. Debug-only — leave false for agent consumers."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 100,
+                        "default": 25,
+                        "description": "Maximum entries returned for each of `tools` and `skill_candidates`."
                     }
                 },
                 "required": ["query"]

--- a/crates/dcc-mcp-http/src/tests/mod.rs
+++ b/crates/dcc-mcp-http/src/tests/mod.rs
@@ -125,6 +125,7 @@ mod method_router;
 mod on_demand_loading;
 mod pagination;
 mod search_skills;
+mod search_tools;
 mod session;
 mod skill_discovery;
 mod tools_call;

--- a/crates/dcc-mcp-http/src/tests/search_tools.rs
+++ b/crates/dcc-mcp-http/src/tests/search_tools.rs
@@ -1,0 +1,297 @@
+//! Tests for ``search_tools`` (issue #677).
+//!
+//! Covers the two acceptance criteria of the issue:
+//!
+//! 1. Default search results never include `__skill__*` or `__group__*`
+//!    progressive-loading stubs.
+//! 2. Domain-keyword queries can discover unloaded skills, returning
+//!    them as `skill_candidate` entries with `requires_load_skill: true`
+//!    and a ready-to-send `load_hint`.
+
+use super::*;
+
+use serde_json::json;
+
+/// Parse the stringified JSON that `CallToolResult::text` packs into
+/// `result.content[0].text`. `search_tools` always emits a single
+/// text content block on success, so this is always safe here.
+fn parse_tool_result_text(body: &Value) -> Value {
+    let text = body["result"]["content"][0]["text"]
+        .as_str()
+        .expect("search_tools always returns text content");
+    serde_json::from_str(text).expect("search_tools emits valid JSON")
+}
+
+async fn call_search_tools(server: &TestServer, args: Value) -> Value {
+    let resp = server
+        .post("/mcp")
+        .add_header(
+            axum::http::header::ACCEPT,
+            "application/json".parse::<HeaderValue>().unwrap(),
+        )
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 100,
+            "method": "tools/call",
+            "params": {
+                "name": "search_tools",
+                "arguments": args,
+            }
+        }))
+        .await;
+    resp.assert_status_ok();
+    resp.json()
+}
+
+// Build a fresh `AppState` that seeds the registry with tools whose
+// names would collide with the progressive-loading stub naming scheme
+// if they ever leaked past the dispatcher. The catalog is left empty
+// so tests that target stub filtering do not also exercise the
+// skill-candidate branch.
+fn make_app_state_with_stub_named_actions() -> AppState {
+    use dcc_mcp_actions::ActionMeta;
+
+    let registry = Arc::new(ActionRegistry::new());
+    // Regular tool — expected to always appear.
+    registry.register_action(ActionMeta {
+        name: "create_sphere".into(),
+        description: "Create a polygon sphere.".into(),
+        category: "geometry".into(),
+        tags: vec!["create".into(), "mesh".into()],
+        dcc: "maya".into(),
+        version: "1.0.0".into(),
+        input_schema: json!({
+            "type": "object",
+            "properties": {
+                "radius": { "type": "number" }
+            }
+        }),
+        ..Default::default()
+    });
+    // Stub-named action — should only surface when include_stubs=true.
+    registry.register_action(ActionMeta {
+        name: "__skill__maya-bevel".into(),
+        description: "Stub for the maya-bevel skill.".into(),
+        category: "stubs".into(),
+        tags: vec!["sphere".into()],
+        dcc: "maya".into(),
+        version: "1.0.0".into(),
+        ..Default::default()
+    });
+    registry.register_action(ActionMeta {
+        name: "__group__modeling".into(),
+        description: "Stub for the modeling group (sphere).".into(),
+        category: "stubs".into(),
+        tags: vec!["sphere".into()],
+        dcc: "maya".into(),
+        version: "1.0.0".into(),
+        ..Default::default()
+    });
+
+    let catalog = Arc::new(dcc_mcp_skills::SkillCatalog::new(registry.clone()));
+    let dispatcher = Arc::new(dcc_mcp_actions::ActionDispatcher::new((*registry).clone()));
+    AppState {
+        registry,
+        dispatcher,
+        catalog,
+        sessions: SessionManager::new(),
+        executor: None,
+        bridge_registry: crate::BridgeRegistry::new(),
+        server_name: "test-dcc".to_string(),
+        server_version: "0.1.0".to_string(),
+        cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+        in_flight: crate::inflight::InFlightRequests::new(),
+        pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
+        lazy_actions: false,
+        bare_tool_names: true,
+        declared_capabilities: std::sync::Arc::new(Vec::new()),
+        jobs: std::sync::Arc::new(crate::job::JobManager::new()),
+        job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
+        resources: crate::resources::ResourceRegistry::new(true, false),
+        enable_resources: true,
+        prompts: crate::prompts::PromptRegistry::new(true),
+        enable_prompts: true,
+        registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
+        enable_tool_cache: true,
+        method_router: crate::handler::AppState::default_method_router(),
+    }
+}
+
+fn make_router_with_stub_named_actions() -> axum::Router {
+    use crate::handler::{handle_delete, handle_get, handle_post};
+    use axum::{Router, routing};
+    Router::new()
+        .route(
+            "/mcp",
+            routing::post(handle_post)
+                .get(handle_get)
+                .delete(handle_delete),
+        )
+        .with_state(make_app_state_with_stub_named_actions())
+}
+
+// ── 1. Default stub filtering (acceptance criterion 1) ────────────────
+
+#[tokio::test]
+pub async fn test_search_tools_excludes_stubs_by_default() {
+    let server = TestServer::new(make_router_with_stub_named_actions());
+
+    // "sphere" matches all three registered actions via tag/description,
+    // but only the real `create_sphere` should come back by default.
+    let body = call_search_tools(&server, json!({ "query": "sphere" })).await;
+    let result = parse_tool_result_text(&body);
+    let names: Vec<&str> = result["tools"]
+        .as_array()
+        .expect("tools array present")
+        .iter()
+        .map(|t| t["name"].as_str().unwrap())
+        .collect();
+    assert!(
+        names.contains(&"create_sphere"),
+        "expected create_sphere in default hits, got: {names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| n.starts_with("__skill__")),
+        "__skill__* stubs must be filtered by default: {names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| n.starts_with("__group__")),
+        "__group__* stubs must be filtered by default: {names:?}"
+    );
+}
+
+#[tokio::test]
+pub async fn test_search_tools_include_stubs_flag_surfaces_stubs() {
+    let server = TestServer::new(make_router_with_stub_named_actions());
+
+    let body =
+        call_search_tools(&server, json!({ "query": "sphere", "include_stubs": true })).await;
+    let result = parse_tool_result_text(&body);
+    let names: Vec<&str> = result["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|t| t["name"].as_str().unwrap())
+        .collect();
+    assert!(
+        names.contains(&"__skill__maya-bevel"),
+        "include_stubs=true must surface __skill__* stubs, got: {names:?}"
+    );
+    assert!(
+        names.contains(&"__group__modeling"),
+        "include_stubs=true must surface __group__* stubs, got: {names:?}"
+    );
+}
+
+// ── 2. Schema-property indexing ───────────────────────────────────────
+
+#[tokio::test]
+pub async fn test_search_tools_matches_schema_property_names() {
+    let server = TestServer::new(make_router_with_stub_named_actions());
+
+    // `radius` appears only in the input schema of `create_sphere` —
+    // not in its name, description, category, or tags.
+    let body = call_search_tools(&server, json!({ "query": "radius" })).await;
+    let result = parse_tool_result_text(&body);
+    let names: Vec<&str> = result["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|t| t["name"].as_str().unwrap())
+        .collect();
+    assert!(
+        names.contains(&"create_sphere"),
+        "schema property `radius` must make `create_sphere` discoverable: {names:?}"
+    );
+}
+
+// ── 3. Unloaded-skill candidates (acceptance criterion 2) ─────────────
+
+#[tokio::test]
+pub async fn test_search_tools_surfaces_unloaded_skill_as_candidate() {
+    let server = TestServer::new(make_router_with_skills());
+
+    // `make_router_with_skills()` seeds `maya-bevel` in the catalog
+    // but never loads it, so the search must return it as a skill
+    // candidate — NOT as a `__skill__maya-bevel` stub.
+    let body = call_search_tools(&server, json!({ "query": "bevel" })).await;
+    let result = parse_tool_result_text(&body);
+
+    let candidates = result["skill_candidates"]
+        .as_array()
+        .expect("skill_candidates array present");
+    let names: Vec<&str> = candidates
+        .iter()
+        .map(|c| c["skill_name"].as_str().unwrap())
+        .collect();
+    assert!(
+        names.contains(&"maya-bevel"),
+        "expected maya-bevel candidate, got: {names:?}"
+    );
+
+    let maya = candidates
+        .iter()
+        .find(|c| c["skill_name"] == "maya-bevel")
+        .unwrap();
+    assert_eq!(maya["kind"], "skill_candidate");
+    assert_eq!(maya["requires_load_skill"], true);
+    assert_eq!(maya["load_hint"]["tool"], "load_skill");
+    assert_eq!(maya["load_hint"]["arguments"]["skill_name"], "maya-bevel");
+
+    // The matching_tools array should list the tool declarations inside
+    // the skill whose name or description contains the query — `bevel`.
+    let matching: Vec<&str> = maya["matching_tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(
+        matching.contains(&"bevel"),
+        "expected bevel tool in matching_tools: {matching:?}"
+    );
+
+    // And — critically — the candidate must NOT leak as a stub.
+    let tool_names: Vec<&str> = result["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|t| t["name"].as_str().unwrap())
+        .collect();
+    assert!(
+        !tool_names.iter().any(|n| n.starts_with("__skill__")),
+        "unloaded skills must not appear as stubs in tools[]: {tool_names:?}"
+    );
+}
+
+#[tokio::test]
+pub async fn test_search_tools_include_unloaded_skills_false() {
+    let server = TestServer::new(make_router_with_skills());
+
+    let body = call_search_tools(
+        &server,
+        json!({ "query": "bevel", "include_unloaded_skills": false }),
+    )
+    .await;
+    let result = parse_tool_result_text(&body);
+    let candidates = result["skill_candidates"].as_array().unwrap();
+    assert!(
+        candidates.is_empty(),
+        "include_unloaded_skills=false must suppress skill candidates: {candidates:?}"
+    );
+}
+
+// ── 4. Empty-result envelope shape ────────────────────────────────────
+
+#[tokio::test]
+pub async fn test_search_tools_no_results_envelope() {
+    let server = TestServer::new(make_router_with_stub_named_actions());
+
+    let body = call_search_tools(&server, json!({ "query": "zzz-no-such-thing" })).await;
+    // Still a normal success envelope — never an isError response.
+    assert_eq!(body["result"]["isError"], false);
+    let result = parse_tool_result_text(&body);
+    assert_eq!(result["total"], 0);
+    assert_eq!(result["tools"].as_array().unwrap().len(), 0);
+    assert_eq!(result["skill_candidates"].as_array().unwrap().len(), 0);
+}


### PR DESCRIPTION
Closes #677.

## Problem

`handle_search_tools` (HTTP path, `crates/dcc-mcp-http/src/handlers/job_tools.rs`) had two defects:

1. **Stub leakage.** No defensive filter for progressive-loading stubs (`__skill__*`, `__group__*`) and no opt-in for operators who actually want to see them.
2. **Narrow corpus.** Only searched loaded actions — unloaded skills were invisible, so queries like `sphere` could miss a capability that lives in a not-yet-loaded skill.

The MCP-gateway-side `tool_search_tools` was already correct (`capability/builder.rs::should_skip`); this change brings the HTTP-side handler in line and extends it to index unloaded-skill metadata.

## Changes

- `handle_search_tools` now:
  - Defensively filters `__skill__*` / `__group__*` / `.__skill__` / `.__group__` names, gated by a new `include_stubs` arg (default `false`).
  - Indexes top-level `input_schema.properties.<key>` names into the per-action haystack so queries on parameter names (e.g. `radius`) hit.
  - Calls `SkillCatalog::search_skills` to return **unloaded** skills as `skill_candidate` hits with `requires_load_skill: true` and a ready-to-send `load_hint`.
  - Emits an additive envelope: existing `tools` array untouched, plus a new parallel `skill_candidates` array. Top-level `total` sums both.
- `tool_builder_core`'s `search_tools` schema advertises the new `include_stubs`, `include_unloaded_skills` (default `true`), and `limit` (default 25, max 100) parameters with updated description.
- 6 new tests in `crates/dcc-mcp-http/src/tests/search_tools.rs`.

## Acceptance criteria (from #677)

- ✅ Default `search_tools` results do not include `__skill__*` or `__group__*` entries.
- ✅ Common domain terms return relevant skill/tool candidates or clear unloaded-skill candidates.
- ✅ Results include enough metadata for agents to know when `load_skill` is required (`requires_load_skill: true`, `load_hint`).
- ✅ Tests cover loaded tools, unloaded skill matches, group stubs, and no-result behaviour.

## Verification

```bash
cargo test -p dcc-mcp-http --lib tests::search_tools  # 6/6 new
cargo test -p dcc-mcp-http --lib                      # 207/207
cargo test -p dcc-mcp-http --tests                    # 65/65
cargo clippy -p dcc-mcp-http --lib --tests -- -D warnings
```

## Out of scope (follow-ups)

- Unifying the REST/MCP-gateway scorers (#659) — current change keeps the HTTP path's substring matcher; a shared scorer belongs to a dedicated refactor.