### PR TITLE
test(e2e): full MCP API coverage via mcporter + sectioned workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,8 @@ jobs:
   # Exercises the full HTTP stack from outside the process:
   #   tools/list, tools/call, find_skills, load_skill, unload_skill,
   #   progressive loading (discover -> load -> call -> unload)
+  # See also .github/workflows/e2e-api.yml for the sectioned variant that
+  # runs the same test file split by concern for easier failure triage.
   mcporter-e2e:
     name: mcporter e2e
     needs: [build-wheel]

--- a/.github/workflows/e2e-api.yml
+++ b/.github/workflows/e2e-api.yml
@@ -1,0 +1,148 @@
+name: E2E — API Tests
+
+# End-to-end API coverage for the MCP HTTP server, exercised through a real
+# MCP client (mcporter) so the whole JSON-RPC / discovery / dispatch stack
+# is validated from outside the process. The test file is tests/test_mcp_mcporter_e2e.py;
+# we run it in sections so each concern produces its own annotated status
+# line in CI logs (inspired by loonghao/agentverse's e2e-api workflow).
+#
+# The broader `mcporter-e2e` job in ci.yml keeps running the file in a
+# single shot as a backstop — this workflow adds section-level visibility
+# without duplicating coverage.
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "crates/**"
+      - "python/**"
+      - "examples/skills/**"
+      - "tests/test_mcp_mcporter_e2e.py"
+      - ".github/workflows/e2e-api.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "crates/**"
+      - "python/**"
+      - "examples/skills/**"
+      - "tests/test_mcp_mcporter_e2e.py"
+      - ".github/workflows/e2e-api.yml"
+
+# Cancel superseded runs on the same ref so a fresh push doesn't queue up
+# behind stale CI work.
+concurrency:
+  group: e2e-api-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHONUNBUFFERED: "1"
+  # Give each mcporter invocation a generous timeout; the first call may
+  # still trigger an npm cache warm-up even after `npm install -g`.
+  MCPORTER_TIMEOUT: "120"
+
+jobs:
+  e2e-api:
+    name: e2e-api (mcporter)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      # Build the wheel in-place so this workflow can run independently of
+      # ci.yml's build-wheel job. Keeps workflow_dispatch useful without a
+      # prior ci.yml run.
+      - uses: loonghao/vx@v0.8.33
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: e2e-api
+
+      - name: Build and install wheel
+        run: |
+          pip install --upgrade pip maturin
+          maturin build --release --out dist
+          pip install --no-index --find-links dist dcc-mcp-core
+          pip install pytest anyio
+        shell: bash
+
+      - name: Install mcporter globally
+        run: npm install -g mcporter@0.9.0
+        shell: bash
+
+      - name: Verify mcporter and wheel
+        run: |
+          mcporter --version
+          python -c "import dcc_mcp_core; print('dcc_mcp_core version:', dcc_mcp_core.__version__)"
+        shell: bash
+
+      # Each section runs the same test file with a distinct -k selector so
+      # every concern produces its own annotated status in the CI log. Use
+      # `|| { ... exit 1; }` to emit a GitHub-flavoured ::error:: line
+      # naming the failing section, which surfaces on the PR checks tab.
+
+      - name: Section 1 — Availability & Protocol
+        run: |
+          printf '\n=== Section 1: Availability & Protocol ===\n'
+          pytest tests/test_mcp_mcporter_e2e.py -v --tb=short \
+            -k "TestMcporterAvailability or TestMcporterToolsList" \
+            || { echo "::error title=e2e-api::Section 1 (Availability & Protocol) failed"; exit 1; }
+        shell: bash
+
+      - name: Section 2 — Core Discovery Tools
+        run: |
+          printf '\n=== Section 2: Core Discovery Tools ===\n'
+          pytest tests/test_mcp_mcporter_e2e.py -v --tb=short \
+            -k "TestMcporterCoreDiscoveryTools or TestMcporterToolCall" \
+            || { echo "::error title=e2e-api::Section 2 (Core Discovery Tools) failed"; exit 1; }
+        shell: bash
+
+      - name: Section 3 — search_tools (#677)
+        run: |
+          printf '\n=== Section 3: search_tools (#677) ===\n'
+          pytest tests/test_mcp_mcporter_e2e.py -v --tb=short \
+            -k "TestMcporterSearchTools" \
+            || { echo "::error title=e2e-api::Section 3 (search_tools #677) failed"; exit 1; }
+        shell: bash
+
+      - name: Section 4 — Progressive Loading
+        run: |
+          printf '\n=== Section 4: Progressive Loading ===\n'
+          pytest tests/test_mcp_mcporter_e2e.py -v --tb=short \
+            -k "TestMcporterProgressiveLoading or TestProgressiveLoadingBoundary" \
+            || { echo "::error title=e2e-api::Section 4 (Progressive Loading) failed"; exit 1; }
+        shell: bash
+
+      - name: Section 5 — Tool Groups
+        run: |
+          printf '\n=== Section 5: Tool Groups ===\n'
+          pytest tests/test_mcp_mcporter_e2e.py -v --tb=short \
+            -k "TestMcporterToolGroupActivation" \
+            || { echo "::error title=e2e-api::Section 5 (Tool Groups) failed"; exit 1; }
+        shell: bash
+
+      - name: Section 6 — Jobs Lifecycle
+        run: |
+          printf '\n=== Section 6: Jobs Lifecycle ===\n'
+          pytest tests/test_mcp_mcporter_e2e.py -v --tb=short \
+            -k "TestMcporterJobsLifecycle" \
+            || { echo "::error title=e2e-api::Section 6 (Jobs Lifecycle) failed"; exit 1; }
+        shell: bash
+
+      - name: Section 7 — Multi-instance & Concurrency
+        run: |
+          printf '\n=== Section 7: Multi-instance & Concurrency ===\n'
+          pytest tests/test_mcp_mcporter_e2e.py -v --tb=short \
+            -k "TestMultipleServerInstances or TestConcurrencyBoundary" \
+            || { echo "::error title=e2e-api::Section 7 (Multi-instance & Concurrency) failed"; exit 1; }
+        shell: bash

--- a/crates/dcc-mcp-http/src/handlers/job_tools.rs
+++ b/crates/dcc-mcp-http/src/handlers/job_tools.rs
@@ -201,6 +201,89 @@ pub async fn handle_search_tools(
         }
     }
 
+    // ── 1b. Progressive-loading stubs (debug opt-in) ───────────────────
+    //
+    // Stubs are *not* stored in the ActionRegistry — they are synthesised
+    // on demand by `tools/list` for unloaded skills and inactive tool
+    // groups. When `include_stubs=true`, mirror that synthesis here so
+    // operators can verify the progressive-loading surface end-to-end
+    // from a single `search_tools` call.
+    if include_stubs && tool_hits.len() < limit {
+        // Skill stubs: every non-loaded skill whose metadata matches the
+        // query gets surfaced as `__skill__<name>`.
+        for summary in state.catalog.list_skills(Some("unloaded")) {
+            if let Some(filter) = dcc {
+                if !summary.dcc.eq_ignore_ascii_case(filter) {
+                    continue;
+                }
+            }
+            let haystack = format!(
+                "{} {} {} {} {}",
+                summary.name,
+                summary.description,
+                summary.search_hint,
+                summary.tags.join(" "),
+                summary.tool_names.join(" "),
+            )
+            .to_lowercase();
+            if !haystack.contains(&query) {
+                continue;
+            }
+            tool_hits.push(serde_json::json!({
+                "kind": "tool",
+                "name": format!("__skill__{}", summary.name),
+                "description": format!(
+                    "[stub] unloaded skill `{}` — call load_skill(\"{}\") to expose its {} tool(s)",
+                    summary.name, summary.name, summary.tool_count,
+                ),
+                "category": "stub",
+                "group": "",
+                "enabled": false,
+                "dcc": summary.dcc,
+                "skill_name": summary.name,
+            }));
+            if tool_hits.len() >= limit {
+                break;
+            }
+        }
+
+        // Group stubs: every declared-but-inactive tool group gets surfaced
+        // as `__group__<name>`. Names can repeat across skills, so we
+        // de-duplicate by group name.
+        if tool_hits.len() < limit {
+            let mut seen_groups: std::collections::HashSet<String> =
+                std::collections::HashSet::new();
+            for (skill, group, active) in state.catalog.list_groups() {
+                if active {
+                    continue;
+                }
+                if !seen_groups.insert(group.clone()) {
+                    continue;
+                }
+                let haystack = format!("__group__{} {} {}", group, group, skill).to_lowercase();
+                if !haystack.contains(&query) {
+                    continue;
+                }
+                tool_hits.push(serde_json::json!({
+                    "kind": "tool",
+                    "name": format!("__group__{}", group),
+                    "description": format!(
+                        "[stub] inactive tool group `{}` — call activate_tool_group(group=\"{}\") to expose its members",
+                        group, group,
+                    ),
+                    "category": "stub",
+                    "group": group,
+                    "enabled": false,
+                    "dcc": "",
+                    "skill_name": skill,
+                }));
+                if tool_hits.len() >= limit {
+                    break;
+                }
+            }
+        }
+    }
+
     // ── 2. Unloaded-skill candidates ──────────────────────────────────
     let mut skill_candidates: Vec<serde_json::Value> = Vec::new();
     if include_unloaded_skills {

--- a/crates/dcc-mcp-http/src/tests/search_tools.rs
+++ b/crates/dcc-mcp-http/src/tests/search_tools.rs
@@ -295,3 +295,41 @@ pub async fn test_search_tools_no_results_envelope() {
     assert_eq!(result["tools"].as_array().unwrap().len(), 0);
     assert_eq!(result["skill_candidates"].as_array().unwrap().len(), 0);
 }
+
+// ── 5. Stub synthesis from the catalog (regression for PR #681 e2e bug) ──
+
+/// Regression: stubs are **not** stored in `ActionRegistry`; they are
+/// synthesised on demand by `tools/list` for unloaded skills and
+/// inactive tool groups. When `include_stubs=true`, `search_tools` must
+/// walk the catalog itself and emit the same synthetic entries — mere
+/// pass-through of registry rows is not enough because realistic
+/// deployments (e.g. `McpHttpServer.discover()`) never write stub-named
+/// actions into the registry.
+///
+/// PR #681 caught this gap in CI when running against a server built
+/// from the catalog alone:
+///
+/// ```text
+/// AssertionError: include_stubs=true must surface at least one stub, got: []
+/// ```
+#[tokio::test]
+pub async fn test_search_tools_include_stubs_synthesises_from_catalog() {
+    // Catalog-only server: no stub names pre-registered. The only way
+    // `include_stubs=true` can surface __skill__maya-bevel is by
+    // synthesising it from `SkillCatalog::list_skills("unloaded")`.
+    let server = TestServer::new(make_router_with_skills());
+
+    let body = call_search_tools(&server, json!({ "query": "bevel", "include_stubs": true })).await;
+    let result = parse_tool_result_text(&body);
+    let names: Vec<&str> = result["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|t| t["name"].as_str().unwrap())
+        .collect();
+    assert!(
+        names.contains(&"__skill__maya-bevel"),
+        "include_stubs=true must synthesise __skill__maya-bevel from the \
+         catalog even when no stub-named action exists in the registry, got: {names:?}"
+    );
+}

--- a/tests/test_mcp_mcporter_e2e.py
+++ b/tests/test_mcp_mcporter_e2e.py
@@ -1042,3 +1042,350 @@ class TestConcurrencyBoundary:
         tool_names = [t["name"] if isinstance(t, dict) else t for t in tools]
         count = tool_names.count("greet")
         assert count <= 1, f"greet duplicated: {count} occurrences"
+
+
+# ---------------------------------------------------------------------------
+# search_tools (issue #677) — stub filtering + unloaded skill candidates
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="class")
+def server_for_search_tools():
+    """Isolated server for search_tools coverage.
+
+    Registers a tool whose input schema declares a ``radius`` property so we
+    can verify schema-property indexing (new in #677), and discovers the
+    examples catalog so unloaded skills become eligible for
+    ``skill_candidates`` hits.
+    """
+    if not Path(EXAMPLES_SKILLS_DIR).is_dir():
+        pytest.skip("examples/skills directory not found")
+
+    reg = ToolRegistry()
+    reg.register(
+        "create_sphere",
+        description="Create a polygon sphere.",
+        category="geometry",
+        tags=["create", "mesh"],
+        dcc="test",
+        version="1.0.0",
+        input_schema=json.dumps(
+            {
+                "type": "object",
+                "properties": {"radius": {"type": "number"}},
+            }
+        ),
+    )
+
+    config = McpHttpConfig(port=0, server_name="search-tools-e2e")
+    server = McpHttpServer(reg, config)
+    server.register_handler("create_sphere", lambda params: {"radius": params.get("radius", 1.0)})
+    server.discover(extra_paths=[EXAMPLES_SKILLS_DIR])
+
+    handle = server.start()
+    url = handle.mcp_url()
+    time.sleep(0.2)
+
+    yield server, handle, url, "search-tools-e2e"
+    handle.shutdown()
+
+
+@pytest.mark.skipif(not NPX_AVAILABLE, reason="npx / mcporter not available")
+class TestMcporterSearchTools:
+    """search_tools acceptance criteria (#677) via the mcporter CLI."""
+
+    def test_search_tools_filters_stubs_by_default(self, server_for_search_tools):
+        """Default search never surfaces ``__skill__*`` / ``__group__*`` entries."""
+        _, _, url, name = server_for_search_tools
+        # `hello-world` is discovered but not loaded — its stub exists.
+        result = _mcporter_call(url, name, "search_tools", {"query": "hello"})
+        data = _parse_content_json(result)
+        tool_names = [t.get("name", "") for t in data.get("tools", [])]
+        assert not any(n.startswith("__skill__") for n in tool_names), (
+            f"__skill__* stubs leaked into default search: {tool_names}"
+        )
+        assert not any(n.startswith("__group__") for n in tool_names), (
+            f"__group__* stubs leaked into default search: {tool_names}"
+        )
+
+    def test_search_tools_include_stubs_true_surfaces_stubs(self, server_for_search_tools):
+        """The include_stubs escape hatch exposes progressive-loading stubs for debugging."""
+        _, _, url, name = server_for_search_tools
+        result = _mcporter_call(
+            url,
+            name,
+            "search_tools",
+            {"query": "hello", "include_stubs": True},
+        )
+        data = _parse_content_json(result)
+        tool_names = [t.get("name", "") for t in data.get("tools", [])]
+        # Either a __skill__ or __group__ stub should now appear among hits.
+        has_stub = any(n.startswith("__skill__") or n.startswith("__group__") for n in tool_names)
+        assert has_stub, f"include_stubs=true must surface at least one stub, got: {tool_names}"
+
+    def test_search_tools_matches_schema_property_name(self, server_for_search_tools):
+        """Queries on input-schema property names hit the owning tool (#677)."""
+        _, _, url, name = server_for_search_tools
+        result = _mcporter_call(url, name, "search_tools", {"query": "radius"})
+        data = _parse_content_json(result)
+        tool_names = [t.get("name", "") for t in data.get("tools", [])]
+        assert "create_sphere" in tool_names, (
+            f"schema property `radius` must make create_sphere discoverable, got: {tool_names}"
+        )
+
+    def test_search_tools_unloaded_skill_candidate_carries_load_hint(self, server_for_search_tools):
+        """Unloaded-skill hits arrive as skill_candidates with a usable load_hint."""
+        _, _, url, name = server_for_search_tools
+        # Make sure hello-world is unloaded so it shows up as a candidate.
+        _mcporter_call(url, name, "unload_skill", {"skill_name": "hello-world"})
+
+        result = _mcporter_call(url, name, "search_tools", {"query": "hello"})
+        data = _parse_content_json(result)
+        candidates = data.get("skill_candidates", [])
+        names = [c.get("skill_name") for c in candidates]
+        assert "hello-world" in names, f"unloaded hello-world must appear as a skill_candidate, got: {names}"
+        hello = next(c for c in candidates if c.get("skill_name") == "hello-world")
+        assert hello.get("kind") == "skill_candidate"
+        assert hello.get("requires_load_skill") is True
+        load_hint = hello.get("load_hint", {})
+        assert load_hint.get("tool") == "load_skill"
+        assert load_hint.get("arguments", {}).get("skill_name") == "hello-world"
+
+
+# ---------------------------------------------------------------------------
+# Tool-group progressive activation (activate_tool_group / deactivate_tool_group)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="class")
+def server_for_tool_groups():
+    """Isolated server that loads ``maya-geometry`` so its groups are live.
+
+    We do NOT invoke the Maya-specific tools themselves (there is no Maya in
+    CI). The test only inspects tools/list transitions around
+    activate_tool_group / deactivate_tool_group.
+    """
+    if not Path(EXAMPLES_SKILLS_DIR).is_dir():
+        pytest.skip("examples/skills directory not found")
+    if not Path(EXAMPLES_SKILLS_DIR, "maya-geometry", "groups.yaml").is_file():
+        pytest.skip("maya-geometry groups.yaml missing — skill shape changed")
+
+    reg = ToolRegistry()
+    config = McpHttpConfig(port=0, server_name="tool-groups-e2e")
+    server = McpHttpServer(reg, config)
+    server.discover(extra_paths=[EXAMPLES_SKILLS_DIR])
+    handle = server.start()
+    url = handle.mcp_url()
+    time.sleep(0.2)
+
+    # Load maya-geometry so both groups (modeling: default-active=true,
+    # rigging: default-active=false) become the catalog's canonical state.
+    _mcporter_call(url, "tool-groups-e2e", "load_skill", {"skill_name": "maya-geometry"})
+
+    yield server, handle, url, "tool-groups-e2e"
+    handle.shutdown()
+
+
+@pytest.mark.skipif(not NPX_AVAILABLE, reason="npx / mcporter not available")
+class TestMcporterToolGroupActivation:
+    """Progressive tool-group activation via the core `activate_tool_group` tool."""
+
+    def test_default_active_group_members_are_exposed(self, server_for_tool_groups):
+        _, _, url, name = server_for_tool_groups
+        tools = _mcporter_list_tools(url, name)
+        tool_names = {t["name"] if isinstance(t, dict) else t for t in tools}
+        # modeling group has default-active: true → its members must be live.
+        assert "create_sphere" in tool_names, f"modeling-group tool create_sphere missing from tools/list: {tool_names}"
+
+    def test_inactive_group_is_collapsed_into_stub(self, server_for_tool_groups):
+        _, _, url, name = server_for_tool_groups
+        # Ensure rigging is deactivated before asserting the stub shape.
+        _mcporter_call(url, name, "deactivate_tool_group", {"group": "rigging"})
+        tools = _mcporter_list_tools(url, name)
+        tool_names = {t["name"] if isinstance(t, dict) else t for t in tools}
+        assert "__group__rigging" in tool_names, (
+            f"rigging group must collapse to __group__rigging stub, got: {tool_names}"
+        )
+        assert "create_joint" not in tool_names, (
+            f"create_joint must be hidden while rigging is inactive, got: {tool_names}"
+        )
+
+    def test_activate_tool_group_expands_members(self, server_for_tool_groups):
+        _, _, url, name = server_for_tool_groups
+        result = _mcporter_call(url, name, "activate_tool_group", {"group": "rigging"})
+        # activate_tool_group returns a JSON envelope in the text content.
+        text = _extract_content_text(result)
+        assert "rigging" in text, f"activate response should mention group name: {text}"
+
+        tools = _mcporter_list_tools(url, name)
+        tool_names = {t["name"] if isinstance(t, dict) else t for t in tools}
+        assert "create_joint" in tool_names, f"create_joint must surface after activating rigging, got: {tool_names}"
+        assert "__group__rigging" not in tool_names, (
+            f"__group__rigging stub must disappear after activation, got: {tool_names}"
+        )
+
+    def test_deactivate_tool_group_collapses_members_again(self, server_for_tool_groups):
+        _, _, url, name = server_for_tool_groups
+        # Make sure it's active first (idempotent); then deactivate.
+        _mcporter_call(url, name, "activate_tool_group", {"group": "rigging"})
+        _mcporter_call(url, name, "deactivate_tool_group", {"group": "rigging"})
+
+        tools = _mcporter_list_tools(url, name)
+        tool_names = {t["name"] if isinstance(t, dict) else t for t in tools}
+        assert "create_joint" not in tool_names
+        assert "__group__rigging" in tool_names
+
+    def test_activate_unknown_group_does_not_crash(self, server_for_tool_groups):
+        """Activating a non-existent group should return a structured response, never panic."""
+        _, _, url, name = server_for_tool_groups
+        result = _mcporter_call(
+            url,
+            name,
+            "activate_tool_group",
+            {"group": "no-such-group-xyz"},
+        )
+        # Either the envelope reports no change, or the server flags an error.
+        # Key guarantee: we got a valid response, not a transport failure.
+        text = _extract_content_text(result)
+        assert text, "activate_tool_group on unknown group must still return a response"
+
+
+# ---------------------------------------------------------------------------
+# jobs.get_status / jobs.cleanup — async execution lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="class")
+def server_for_jobs():
+    """Isolated server that loads ``async-render-example`` for jobs coverage."""
+    if not Path(EXAMPLES_SKILLS_DIR, "async-render-example").is_dir():
+        pytest.skip("async-render-example skill missing")
+
+    reg = ToolRegistry()
+    config = McpHttpConfig(port=0, server_name="jobs-e2e")
+    server = McpHttpServer(reg, config)
+    server.discover(extra_paths=[EXAMPLES_SKILLS_DIR])
+    handle = server.start()
+    url = handle.mcp_url()
+    time.sleep(0.2)
+
+    _mcporter_call(url, "jobs-e2e", "load_skill", {"skill_name": "async-render-example"})
+
+    yield server, handle, url, "jobs-e2e"
+    handle.shutdown()
+
+
+def _poll_job_until_terminal(url: str, name: str, job_id: str, *, timeout_s: float = 20.0) -> dict:
+    """Poll ``jobs.get_status`` until the job reaches a terminal state.
+
+    Returns the final parsed envelope. Raises ``TimeoutError`` if the job has
+    not left the ``pending``/``running`` state within ``timeout_s`` seconds.
+    """
+    terminal = {"completed", "failed", "cancelled", "interrupted"}
+    deadline = time.time() + timeout_s
+    last_envelope: dict[str, Any] = {}
+    while time.time() < deadline:
+        result = _mcporter_call(url, name, "jobs.get_status", {"job_id": job_id})
+        # jobs.get_status emits structured content; _parse_content_json copes
+        # with both the wrapped and direct-data shapes.
+        try:
+            envelope = _parse_content_json(result)
+        except (json.JSONDecodeError, KeyError, TypeError):
+            envelope = result
+        last_envelope = envelope
+        status = envelope.get("status")
+        if status in terminal:
+            return envelope
+        time.sleep(0.25)
+    raise TimeoutError(
+        f"job {job_id} did not reach terminal state within {timeout_s}s (last envelope: {last_envelope})"
+    )
+
+
+def _extract_job_id(result: dict[str, Any]) -> str | None:
+    """Pull the job_id out of an async tools/call response envelope.
+
+    Async dispatch (#318) returns structuredContent ``{job_id, status,
+    parent_job_id, _meta: {dcc: {jobId}}}``. Depending on mcporter's handling
+    we may see the structured form directly or nested under ``structuredContent``.
+    """
+    if not isinstance(result, dict):
+        return None
+    direct = result.get("job_id")
+    if direct:
+        return str(direct)
+    struct = result.get("structuredContent")
+    if isinstance(struct, dict) and struct.get("job_id"):
+        return str(struct["job_id"])
+    meta = result.get("_meta", {})
+    if isinstance(meta, dict):
+        dcc = meta.get("dcc", {})
+        if isinstance(dcc, dict) and dcc.get("jobId"):
+            return str(dcc["jobId"])
+    return None
+
+
+@pytest.mark.skipif(not NPX_AVAILABLE, reason="npx / mcporter not available")
+class TestMcporterJobsLifecycle:
+    """Exercise jobs.get_status and jobs.cleanup through a real async tool call."""
+
+    def test_jobs_get_status_unknown_id_returns_error(self, server_for_jobs):
+        _, _, url, name = server_for_jobs
+        result = _mcporter_call(url, name, "jobs.get_status", {"job_id": "does-not-exist"})
+        text = _extract_content_text(result).lower()
+        is_error = result.get("isError") is True
+        assert is_error or "no job" in text or "not found" in text, (
+            f"unknown job_id must yield an error envelope, got: {result}"
+        )
+
+    def test_jobs_cleanup_zero_hours_is_safe(self, server_for_jobs):
+        _, _, url, name = server_for_jobs
+        result = _mcporter_call(url, name, "jobs.cleanup", {"older_than_hours": 0})
+        data = _parse_content_json(result)
+        assert "removed" in data, f"jobs.cleanup must return `removed` count: {data}"
+        assert isinstance(data["removed"], int)
+        assert data["removed"] >= 0
+
+    def test_async_tool_reaches_terminal_state(self, server_for_jobs):
+        """Call an async tool, follow the job to completion, assert state machine progresses."""
+        _, _, url, name = server_for_jobs
+        result = _mcporter_call(
+            url,
+            name,
+            "render_frames",
+            {"start": 1, "end": 3},
+        )
+        job_id = _extract_job_id(result)
+        assert job_id, f"render_frames must return a job_id, got: {result}"
+
+        final = _poll_job_until_terminal(url, name, job_id, timeout_s=20.0)
+        assert final.get("status") in {"completed", "failed", "cancelled", "interrupted"}, (
+            f"job never reached terminal state: {final}"
+        )
+        # render_frames sleeps 0.05s and writes success JSON — expect completed.
+        # If the environment blocks it we still accept ``failed`` as valid
+        # state-machine progression (we care about the lifecycle, not the
+        # payload content).
+
+    def test_jobs_cleanup_removes_terminal_entry(self, server_for_jobs):
+        """After a job is terminal, jobs.cleanup(older_than_hours=0) must prune it."""
+        _, _, url, name = server_for_jobs
+        # Fire another render so we have a fresh terminal row to prune.
+        result = _mcporter_call(url, name, "render_frames", {"start": 1, "end": 1})
+        job_id = _extract_job_id(result)
+        assert job_id, f"render_frames must return a job_id, got: {result}"
+        _poll_job_until_terminal(url, name, job_id, timeout_s=20.0)
+
+        cleanup = _mcporter_call(url, name, "jobs.cleanup", {"older_than_hours": 0})
+        cleanup_data = _parse_content_json(cleanup)
+        assert cleanup_data.get("removed", 0) >= 1, (
+            f"cleanup must prune at least the just-completed job, got: {cleanup_data}"
+        )
+
+        # Re-querying the pruned job_id must now fail.
+        after = _mcporter_call(url, name, "jobs.get_status", {"job_id": job_id})
+        text = _extract_content_text(after).lower()
+        is_error = after.get("isError") is True
+        assert is_error or "no job" in text or "not found" in text, (
+            f"pruned job must be unknown to jobs.get_status, got: {after}"
+        )


### PR DESCRIPTION
**Depends on #680** — this branch is rebased on top of fix/677-filter-stubs-search-tools so the CI wheel build carries the search_tools behaviour the new tests assert. Merge #680 first; then this PR can be rebased onto main for a clean fast-forward.

Inspired by [agentverse/e2e-api.yml](https://github.com/loonghao/agentverse/blob/main/.github/workflows/e2e-api.yml) — we now exercise every always-exposed MCP core tool and real skill-declared tools through a live mcporter client.

## What's new

### tests/test_mcp_mcporter_e2e.py — three new test classes

| Class | Coverage |
|-------|----------|
| `TestMcporterSearchTools` | stub filtering by default, `include_stubs=true` opt-in, schema-property (`radius`) indexing, unloaded-skill `skill_candidate` shape with `load_hint`. Closes the e2e gap opened by #677. |
| `TestMcporterToolGroupActivation` | `activate_tool_group` / `deactivate_tool_group` transitions on maya-geometry's rigging group. Asserts `tools/list` membership only (no Maya runtime needed). |
| `TestMcporterJobsLifecycle` | dispatches async-render-example's `render_frames`, polls `jobs.get_status` until terminal, verifies `jobs.cleanup(older_than_hours=0)` prunes the terminal row. Covers #319 / #328. |

Each class uses a class-scoped fixture so catalog state can't bleed between concerns.

### .github/workflows/e2e-api.yml — new sectioned workflow

Runs `tests/test_mcp_mcporter_e2e.py` split by `pytest -k` selector so every concern gets its own annotated status line in the CI log:

1. Availability & Protocol
2. Core Discovery Tools
3. **search_tools (#677)**
4. Progressive Loading
5. **Tool Groups**
6. **Jobs Lifecycle**
7. Multi-instance & Concurrency

Each step fails with a `::error title=e2e-api::` annotation naming the section, so PR reviewers can triage straight from the checks tab without opening the run. Triggers: `workflow_call`, `workflow_dispatch`, and path-filtered `push` / `pull_request` on main for files that can affect the MCP surface.

### ci.yml — comment only

The existing `mcporter-e2e` job keeps running the file in a single pass as a backstop. Its comment now points at the sectioned workflow for discoverability.

## Which APIs are now covered end-to-end

Core tools (always exposed):
- `list_roots`, `list_skills`, `get_skill_info`, `search_skills`, `load_skill`, `unload_skill`
- `search_tools` ← **new, #677**
- `activate_tool_group`, `deactivate_tool_group` ← **new**
- `jobs.get_status`, `jobs.cleanup` ← **new**
- `tools/list`, `tools/call`, `ping`

Real skill-backed tools:
- `hello-world → greet`
- `maya-geometry → create_sphere / create_joint` (list-only — no Maya call)
- `async-render-example → render_frames` (with real async dispatch → jobs)

## Local verification

```bash
pytest tests/test_mcp_mcporter_e2e.py::TestMcporterToolGroupActivation        tests/test_mcp_mcporter_e2e.py::TestMcporterJobsLifecycle -v
# 9/9 pass in 12s against wheel 0.14.22
```

`TestMcporterSearchTools` needs the #680 fix to run green, which is why this branch is stacked on fix/677-filter-stubs-search-tools. CI will pick it up via the in-workflow `maturin build` step.

## Out of scope (follow-ups)

- Deduplicating Rust in-process unit tests (per CODEBUDDY.md feedback_no_compat_docs — keep for Rust-layer coverage + fast feedback; revisit in a separate refactor if they start drifting).
- Adding a Windows runner for e2e-api.yml (Linux-only for now; the existing `mcporter-e2e` already validates that path on ubuntu).