### PR TITLE
fix(http): synthesise progressive-loading stubs in search_tools (follow-up #677)

### DIFF
--- a/crates/dcc-mcp-http/src/handlers/job_tools.rs
+++ b/crates/dcc-mcp-http/src/handlers/job_tools.rs
@@ -201,6 +201,89 @@ pub async fn handle_search_tools(
         }
     }
 
+    // ── 1b. Progressive-loading stubs (debug opt-in) ───────────────────
+    //
+    // Stubs are *not* stored in the ActionRegistry — they are synthesised
+    // on demand by `tools/list` for unloaded skills and inactive tool
+    // groups. When `include_stubs=true`, mirror that synthesis here so
+    // operators can verify the progressive-loading surface end-to-end
+    // from a single `search_tools` call.
+    if include_stubs && tool_hits.len() < limit {
+        // Skill stubs: every non-loaded skill whose metadata matches the
+        // query gets surfaced as `__skill__<name>`.
+        for summary in state.catalog.list_skills(Some("unloaded")) {
+            if let Some(filter) = dcc {
+                if !summary.dcc.eq_ignore_ascii_case(filter) {
+                    continue;
+                }
+            }
+            let haystack = format!(
+                "{} {} {} {} {}",
+                summary.name,
+                summary.description,
+                summary.search_hint,
+                summary.tags.join(" "),
+                summary.tool_names.join(" "),
+            )
+            .to_lowercase();
+            if !haystack.contains(&query) {
+                continue;
+            }
+            tool_hits.push(serde_json::json!({
+                "kind": "tool",
+                "name": format!("__skill__{}", summary.name),
+                "description": format!(
+                    "[stub] unloaded skill `{}` — call load_skill(\"{}\") to expose its {} tool(s)",
+                    summary.name, summary.name, summary.tool_count,
+                ),
+                "category": "stub",
+                "group": "",
+                "enabled": false,
+                "dcc": summary.dcc,
+                "skill_name": summary.name,
+            }));
+            if tool_hits.len() >= limit {
+                break;
+            }
+        }
+
+        // Group stubs: every declared-but-inactive tool group gets surfaced
+        // as `__group__<name>`. Names can repeat across skills, so we
+        // de-duplicate by group name.
+        if tool_hits.len() < limit {
+            let mut seen_groups: std::collections::HashSet<String> =
+                std::collections::HashSet::new();
+            for (skill, group, active) in state.catalog.list_groups() {
+                if active {
+                    continue;
+                }
+                if !seen_groups.insert(group.clone()) {
+                    continue;
+                }
+                let haystack = format!("__group__{} {} {}", group, group, skill).to_lowercase();
+                if !haystack.contains(&query) {
+                    continue;
+                }
+                tool_hits.push(serde_json::json!({
+                    "kind": "tool",
+                    "name": format!("__group__{}", group),
+                    "description": format!(
+                        "[stub] inactive tool group `{}` — call activate_tool_group(group=\"{}\") to expose its members",
+                        group, group,
+                    ),
+                    "category": "stub",
+                    "group": group,
+                    "enabled": false,
+                    "dcc": "",
+                    "skill_name": skill,
+                }));
+                if tool_hits.len() >= limit {
+                    break;
+                }
+            }
+        }
+    }
+
     // ── 2. Unloaded-skill candidates ──────────────────────────────────
     let mut skill_candidates: Vec<serde_json::Value> = Vec::new();
     if include_unloaded_skills {

--- a/crates/dcc-mcp-http/src/tests/search_tools.rs
+++ b/crates/dcc-mcp-http/src/tests/search_tools.rs
@@ -295,3 +295,41 @@ pub async fn test_search_tools_no_results_envelope() {
     assert_eq!(result["tools"].as_array().unwrap().len(), 0);
     assert_eq!(result["skill_candidates"].as_array().unwrap().len(), 0);
 }
+
+// ── 5. Stub synthesis from the catalog (regression for PR #681 e2e bug) ──
+
+/// Regression: stubs are **not** stored in `ActionRegistry`; they are
+/// synthesised on demand by `tools/list` for unloaded skills and
+/// inactive tool groups. When `include_stubs=true`, `search_tools` must
+/// walk the catalog itself and emit the same synthetic entries — mere
+/// pass-through of registry rows is not enough because realistic
+/// deployments (e.g. `McpHttpServer.discover()`) never write stub-named
+/// actions into the registry.
+///
+/// PR #681 caught this gap in CI when running against a server built
+/// from the catalog alone:
+///
+/// ```text
+/// AssertionError: include_stubs=true must surface at least one stub, got: []
+/// ```
+#[tokio::test]
+pub async fn test_search_tools_include_stubs_synthesises_from_catalog() {
+    // Catalog-only server: no stub names pre-registered. The only way
+    // `include_stubs=true` can surface __skill__maya-bevel is by
+    // synthesising it from `SkillCatalog::list_skills("unloaded")`.
+    let server = TestServer::new(make_router_with_skills());
+
+    let body = call_search_tools(&server, json!({ "query": "bevel", "include_stubs": true })).await;
+    let result = parse_tool_result_text(&body);
+    let names: Vec<&str> = result["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|t| t["name"].as_str().unwrap())
+        .collect();
+    assert!(
+        names.contains(&"__skill__maya-bevel"),
+        "include_stubs=true must synthesise __skill__maya-bevel from the \
+         catalog even when no stub-named action exists in the registry, got: {names:?}"
+    );
+}


### PR DESCRIPTION
Follow-up to #680 (which was merged as da322d8). Caught by PR #681's Linux e2e:

```
AssertionError: include_stubs=true must surface at least one stub, got: []
```
Run: https://github.com/loonghao/dcc-mcp-core/actions/runs/25245795234/job/74029722675

## Root cause

The first iteration of `search_tools` only passed `ActionRegistry` rows through when `include_stubs=true`. That works for the Rust in-process test (`make_app_state_with_stub_named_actions` inserts `__skill__maya-bevel` / `__group__modeling` straight into the registry) but it cannot surface stubs in realistic deployments: **stubs are never stored in the registry**. `tools/list` synthesises them on demand — from `SkillCatalog::list_skills("unloaded")` for `__skill__<name>` and from `SkillCatalog::list_groups()` for `__group__<name>`. Any server built via `McpHttpServer.discover()` therefore returned an empty `tools[]` when `include_stubs=true`.

## Fix

When `include_stubs=true`, `handle_search_tools` now walks the catalog itself and emits the same synthetic entries that `tools/list` would. The haystack mirrors the data `build_skill_stub` already considers (name, description, search-hint, tags, tool names for skills; name + owning skill for groups). Groups are de-duplicated by name across skills.

## Verification

- New regression test `test_search_tools_include_stubs_synthesises_from_catalog` uses the catalog-only fixture (`make_router_with_skills`) — reproduces the CI failure before the fix and passes after.
- `cargo test -p dcc-mcp-http --lib tests::search_tools` → 7/7 pass.
- `cargo test -p dcc-mcp-http --lib` → 208/208 pass.
- `cargo clippy -p dcc-mcp-http --lib --tests -- -D warnings` clean.

## Coordination

Once this lands on main, PR #681 (e2e coverage) needs to be rebased (currently shows mergeable: CONFLICTING because its branch was stacked on the pre-merge #680 tip). I'll do that immediately after merge.