### PR TITLE
chore: upgrade workspace to Rust 1.95 + apply new 1.95 clippy autofixes

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -13,7 +13,7 @@ inputs:
   rust-version:
     description: 'Rust toolchain version'
     required: false
-    default: '1.90.0'
+    default: '1.95.0'
   maturin-extra-args:
     description: 'Extra maturin args (e.g. --sdist, -i python3.7). Features
       and --release/--out are set by this action from the justfile.'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: '1.90.0'
+          toolchain: '1.95.0'
           targets: aarch64-apple-darwin  # needed for macOS universal2 lipo
 
       - uses: loonghao/vx@v0.8.33

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ resolver = "2"
 [workspace.package]
 version = "0.14.22" # x-release-please-version
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.95"
 authors = ["Hal Long <hal.long@outlook.com>"]
 license = "MIT"
 repository = "https://github.com/loonghao/dcc-mcp-core"

--- a/crates/dcc-mcp-actions/src/chain_interpolate.rs
+++ b/crates/dcc-mcp-actions/src/chain_interpolate.rs
@@ -55,10 +55,11 @@ pub(crate) fn interpolate_string(s: &str, context: &Value) -> Value {
     if s.starts_with('{') && s.ends_with('}') && s.len() > 2 {
         let key = &s[1..s.len() - 1];
         // Only treat as placeholder if key has no inner braces
-        if !key.contains('{') && !key.contains('}') {
-            if let Some(v) = context.get(key) {
-                return v.clone();
-            }
+        if !key.contains('{')
+            && !key.contains('}')
+            && let Some(v) = context.get(key)
+        {
+            return v.clone();
         }
     }
 

--- a/crates/dcc-mcp-actions/src/dispatcher.rs
+++ b/crates/dcc-mcp-actions/src/dispatcher.rs
@@ -286,16 +286,16 @@ pub(crate) fn is_default_schema(schema: &Value) -> bool {
         return false;
     };
     // Must not have a "required" key with a non-empty array
-    if let Some(req) = obj.get("required") {
-        if req.as_array().map(|a| !a.is_empty()).unwrap_or(false) {
-            return false;
-        }
+    if let Some(req) = obj.get("required")
+        && req.as_array().map(|a| !a.is_empty()).unwrap_or(false)
+    {
+        return false;
     }
     // Properties must be absent or an empty object
-    if let Some(props) = obj.get("properties") {
-        if props.as_object().map(|p| !p.is_empty()).unwrap_or(false) {
-            return false;
-        }
+    if let Some(props) = obj.get("properties")
+        && props.as_object().map(|p| !p.is_empty()).unwrap_or(false)
+    {
+        return false;
     }
     // No additional constraint keywords
     let constraint_keys = [

--- a/crates/dcc-mcp-actions/src/registry/mod.rs
+++ b/crates/dcc-mcp-actions/src/registry/mod.rs
@@ -158,10 +158,11 @@ impl ActionRegistry {
             .into_iter()
             .filter(|meta| {
                 // Category filter: if provided, must match exactly
-                if let Some(cat) = category {
-                    if !cat.is_empty() && meta.category != cat {
-                        return false;
-                    }
+                if let Some(cat) = category
+                    && !cat.is_empty()
+                    && meta.category != cat
+                {
+                    return false;
                 }
                 // Tags filter: action must contain ALL requested tags
                 if !tags.is_empty() {

--- a/crates/dcc-mcp-actions/src/validator/mod.rs
+++ b/crates/dcc-mcp-actions/src/validator/mod.rs
@@ -160,85 +160,85 @@ pub(crate) fn validate_value(
     }
 
     // ── enum check ──
-    if let Some(Value::Array(variants)) = schema_obj.get("enum") {
-        if !variants.contains(value) {
+    if let Some(Value::Array(variants)) = schema_obj.get("enum")
+        && !variants.contains(value)
+    {
+        errors.push(ValidationError {
+            path: path.to_string(),
+            message: format!(
+                "value must be one of: {}",
+                variants
+                    .iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        });
+    }
+
+    // ── string constraints ──
+    if let Value::String(s) = value {
+        if let Some(max) = schema_obj.get("maxLength").and_then(|v| v.as_u64())
+            && s.chars().count() as u64 > max
+        {
             errors.push(ValidationError {
                 path: path.to_string(),
                 message: format!(
-                    "value must be one of: {}",
-                    variants
-                        .iter()
-                        .map(|v| v.to_string())
-                        .collect::<Vec<_>>()
-                        .join(", ")
+                    "string length {} exceeds maxLength {max}",
+                    s.chars().count()
+                ),
+            });
+        }
+        if let Some(min) = schema_obj.get("minLength").and_then(|v| v.as_u64())
+            && (s.chars().count() as u64) < min
+        {
+            errors.push(ValidationError {
+                path: path.to_string(),
+                message: format!(
+                    "string length {} is less than minLength {min}",
+                    s.chars().count()
                 ),
             });
         }
     }
 
-    // ── string constraints ──
-    if let Value::String(s) = value {
-        if let Some(max) = schema_obj.get("maxLength").and_then(|v| v.as_u64()) {
-            if s.chars().count() as u64 > max {
-                errors.push(ValidationError {
-                    path: path.to_string(),
-                    message: format!(
-                        "string length {} exceeds maxLength {max}",
-                        s.chars().count()
-                    ),
-                });
-            }
-        }
-        if let Some(min) = schema_obj.get("minLength").and_then(|v| v.as_u64()) {
-            if (s.chars().count() as u64) < min {
-                errors.push(ValidationError {
-                    path: path.to_string(),
-                    message: format!(
-                        "string length {} is less than minLength {min}",
-                        s.chars().count()
-                    ),
-                });
-            }
-        }
-    }
-
     // ── numeric constraints ──
     if let Some(n) = value.as_f64() {
-        if let Some(min) = schema_obj.get("minimum").and_then(|v| v.as_f64()) {
-            if n < min {
-                errors.push(ValidationError {
-                    path: path.to_string(),
-                    message: format!("{n} is less than minimum {min}"),
-                });
-            }
+        if let Some(min) = schema_obj.get("minimum").and_then(|v| v.as_f64())
+            && n < min
+        {
+            errors.push(ValidationError {
+                path: path.to_string(),
+                message: format!("{n} is less than minimum {min}"),
+            });
         }
-        if let Some(max) = schema_obj.get("maximum").and_then(|v| v.as_f64()) {
-            if n > max {
-                errors.push(ValidationError {
-                    path: path.to_string(),
-                    message: format!("{n} exceeds maximum {max}"),
-                });
-            }
+        if let Some(max) = schema_obj.get("maximum").and_then(|v| v.as_f64())
+            && n > max
+        {
+            errors.push(ValidationError {
+                path: path.to_string(),
+                message: format!("{n} exceeds maximum {max}"),
+            });
         }
     }
 
     // ── array constraints ──
     if let Value::Array(arr) = value {
-        if let Some(min) = schema_obj.get("minItems").and_then(|v| v.as_u64()) {
-            if (arr.len() as u64) < min {
-                errors.push(ValidationError {
-                    path: path.to_string(),
-                    message: format!("array length {} is less than minItems {min}", arr.len()),
-                });
-            }
+        if let Some(min) = schema_obj.get("minItems").and_then(|v| v.as_u64())
+            && (arr.len() as u64) < min
+        {
+            errors.push(ValidationError {
+                path: path.to_string(),
+                message: format!("array length {} is less than minItems {min}", arr.len()),
+            });
         }
-        if let Some(max) = schema_obj.get("maxItems").and_then(|v| v.as_u64()) {
-            if arr.len() as u64 > max {
-                errors.push(ValidationError {
-                    path: path.to_string(),
-                    message: format!("array length {} exceeds maxItems {max}", arr.len()),
-                });
-            }
+        if let Some(max) = schema_obj.get("maxItems").and_then(|v| v.as_u64())
+            && arr.len() as u64 > max
+        {
+            errors.push(ValidationError {
+                path: path.to_string(),
+                message: format!("array length {} exceeds maxItems {max}", arr.len()),
+            });
         }
         // items schema
         if let Some(items_schema) = schema_obj.get("items") {
@@ -253,13 +253,13 @@ pub(crate) fn validate_value(
         // required fields
         if let Some(Value::Array(required)) = schema_obj.get("required") {
             for req in required {
-                if let Some(field) = req.as_str() {
-                    if !obj.contains_key(field) {
-                        errors.push(ValidationError {
-                            path: path.to_string(),
-                            message: format!("missing required field '{field}'"),
-                        });
-                    }
+                if let Some(field) = req.as_str()
+                    && !obj.contains_key(field)
+                {
+                    errors.push(ValidationError {
+                        path: path.to_string(),
+                        message: format!("missing required field '{field}'"),
+                    });
                 }
             }
         }

--- a/crates/dcc-mcp-artefact/src/lib.rs
+++ b/crates/dcc-mcp-artefact/src/lib.rs
@@ -244,20 +244,20 @@ pub fn hash_file_sha256(path: &Path) -> io::Result<String> {
 }
 
 fn apply_filter(fr: &FileRef, filter: &ArtefactFilter) -> bool {
-    if let Some(job) = filter.producer_job_id {
-        if fr.producer_job_id != Some(job) {
-            return false;
-        }
+    if let Some(job) = filter.producer_job_id
+        && fr.producer_job_id != Some(job)
+    {
+        return false;
     }
-    if let Some(ref mime) = filter.mime {
-        if fr.mime.as_deref() != Some(mime.as_str()) {
-            return false;
-        }
+    if let Some(ref mime) = filter.mime
+        && fr.mime.as_deref() != Some(mime.as_str())
+    {
+        return false;
     }
-    if let Some(since) = filter.created_since {
-        if fr.created_at < since {
-            return false;
-        }
+    if let Some(since) = filter.created_since
+        && fr.created_at < since
+    {
+        return false;
     }
     true
 }

--- a/crates/dcc-mcp-capture/src/backend/mock.rs
+++ b/crates/dcc-mcp-capture/src/backend/mock.rs
@@ -33,7 +33,7 @@ impl MockBackend {
     fn make_image(&self) -> ImageBuffer<Rgba<u8>, Vec<u8>> {
         let tile = 16u32;
         ImageBuffer::from_fn(self.width, self.height, |x, y| {
-            let is_light = ((x / tile) + (y / tile)) % 2 == 0;
+            let is_light = ((x / tile) + (y / tile)).is_multiple_of(2);
             if is_light {
                 Rgba([200u8, 200, 200, 255])
             } else {

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/call.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/call.rs
@@ -115,10 +115,10 @@ pub async fn route_tools_call(
     //     session → token mapping so `notifications/progress` from the
     //     backend can be routed back here.
     gs.subscriber.ensure_subscribed(&url);
-    if let (Some(sid), Some(m)) = (client_session_id, meta) {
-        if let Some(token) = m.get("progressToken") {
-            gs.subscriber.bind_progress_token(token, sid);
-        }
+    if let (Some(sid), Some(m)) = (client_session_id, meta)
+        && let Some(token) = m.get("progressToken")
+    {
+        gs.subscriber.bind_progress_token(token, sid);
     }
 
     // ── #321: pick the right timeout ──────────────────────────────────
@@ -200,20 +200,18 @@ pub async fn route_tools_call(
             }
 
             // ── #321: wait-for-terminal passthrough ────────────────────
-            if wait_for_terminal {
-                if let Some(jid) = job_id.as_deref() {
-                    return wait_for_terminal_reply(
-                        gs,
-                        jid,
-                        &mut result,
-                        &entry,
-                        gs.wait_terminal_timeout,
-                    )
-                    .await;
-                }
-                // Synchronous reply on an async-opt-in path: nothing to
-                // wait for — fall through and return the envelope as-is.
+            if wait_for_terminal && let Some(jid) = job_id.as_deref() {
+                return wait_for_terminal_reply(
+                    gs,
+                    jid,
+                    &mut result,
+                    &entry,
+                    gs.wait_terminal_timeout,
+                )
+                .await;
             }
+            // Synchronous reply on an async-opt-in path: nothing to
+            // wait for — fall through and return the envelope as-is.
 
             inject_instance_metadata(&mut result, &entry.instance_id, &entry.dcc_type);
             envelope_to_text_result(&result)

--- a/crates/dcc-mcp-gateway/src/gateway/capability/builder.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/builder.rs
@@ -159,10 +159,11 @@ fn extract_skill_and_bare(name: &str) -> (Option<String>, String) {
     // (`<skill>__<action>`) for backends that register with the
     // underscore form — we still want the skill dimension available
     // for search ranking.
-    if let Some((skill, action)) = name.split_once("__") {
-        if !skill.is_empty() && !action.is_empty() {
-            return (Some(skill.to_string()), action.to_string());
-        }
+    if let Some((skill, action)) = name.split_once("__")
+        && !skill.is_empty()
+        && !action.is_empty()
+    {
+        return (Some(skill.to_string()), action.to_string());
     }
     (None, extract_bare_tool_name("", name).to_string())
 }
@@ -190,12 +191,12 @@ fn extract_tags(
             tags.push("destructive".to_string());
         }
     }
-    if let Some(m) = meta {
-        if let Some(t) = m.get("dcc.tags").and_then(Value::as_array) {
-            for v in t {
-                if let Some(s) = v.as_str() {
-                    tags.push(s.to_string());
-                }
+    if let Some(m) = meta
+        && let Some(t) = m.get("dcc.tags").and_then(Value::as_array)
+    {
+        for v in t {
+            if let Some(s) = v.as_str() {
+                tags.push(s.to_string());
             }
         }
     }

--- a/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
@@ -68,16 +68,17 @@ pub async fn refresh_instance(
 
     // Short-circuit when nothing changed. This is the common path —
     // most periodic refreshes find an identical tool list.
-    if let Some(prev) = index.fingerprint_for(instance_id) {
-        if prev == outcome.fingerprint && !outcome.records.is_empty() {
-            tracing::trace!(
-                instance = %instance_id,
-                reason = reason.as_str(),
-                records = outcome.records.len(),
-                "capability index: no-op refresh (fingerprint unchanged)",
-            );
-            return false;
-        }
+    if let Some(prev) = index.fingerprint_for(instance_id)
+        && prev == outcome.fingerprint
+        && !outcome.records.is_empty()
+    {
+        tracing::trace!(
+            instance = %instance_id,
+            reason = reason.as_str(),
+            records = outcome.records.len(),
+            "capability index: no-op refresh (fingerprint unchanged)",
+        );
+        return false;
     }
 
     let records_len = outcome.records.len();

--- a/crates/dcc-mcp-gateway/src/gateway/capability/search_ranking.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/search_ranking.rs
@@ -91,12 +91,11 @@ impl Scorer for SubstringScorer {
             }
         }
 
-        if let Some(hint) = scene_hint {
-            if r.summary.to_ascii_lowercase().contains(hint)
-                || r.tags.iter().any(|t| t.to_ascii_lowercase() == hint)
-            {
-                score += 2;
-            }
+        if let Some(hint) = scene_hint
+            && (r.summary.to_ascii_lowercase().contains(hint)
+                || r.tags.iter().any(|t| t.to_ascii_lowercase() == hint))
+        {
+            score += 2;
         }
 
         score
@@ -266,12 +265,11 @@ impl Scorer for FuzzyScorer {
             score += best_schema;
         }
 
-        if let Some(hint) = scene_hint {
-            if r.summary.to_ascii_lowercase().contains(hint)
-                || r.tags.iter().any(|t| t.to_ascii_lowercase() == hint)
-            {
-                score += 2;
-            }
+        if let Some(hint) = scene_hint
+            && (r.summary.to_ascii_lowercase().contains(hint)
+                || r.tags.iter().any(|t| t.to_ascii_lowercase() == hint))
+        {
+            score += 2;
         }
 
         score

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/notification_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/notification_impl.rs
@@ -68,10 +68,10 @@ async fn cascade_cancel(gs: &GatewayState, request_id: Value) {
 
     if forwarded_to.is_empty() {
         let pending = gs.pending_calls.read().await;
-        if let Some(call) = pending.get(&request_id_str) {
-            if !call.backend_url.is_empty() {
-                forward_cancel(gs, &call.backend_url, &request_id, "").await;
-            }
+        if let Some(call) = pending.get(&request_id_str)
+            && !call.backend_url.is_empty()
+        {
+            forward_cancel(gs, &call.backend_url, &request_id, "").await;
         }
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/namespace/encode.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/namespace/encode.rs
@@ -70,10 +70,10 @@ pub fn decode_skill_tool_name(namespaced: &str) -> Option<(&str, &str)> {
         return None;
     }
     // Reject gateway-encoded form — the gateway prefix owns the first dot.
-    if let Some((head, _)) = namespaced.split_once(SKILL_TOOL_SEP) {
-        if is_instance_prefix(head) {
-            return None;
-        }
+    if let Some((head, _)) = namespaced.split_once(SKILL_TOOL_SEP)
+        && is_instance_prefix(head)
+    {
+        return None;
     }
     namespaced.split_once(SKILL_TOOL_SEP)
 }
@@ -133,46 +133,45 @@ pub fn decode_tool_name(prefixed: &str) -> Option<(String, String)> {
     //    than fall through to a legacy arm (which would happily
     //    rewrite `i_abcdef01__bad_` into `(i, abcdef01__bad_)` and
     //    silently route to the wrong tool).
-    if let Some(rest) = prefixed.strip_prefix(CURSOR_SAFE_PREFIX) {
-        if let Some((p, escaped)) = rest.split_once(CURSOR_SAFE_SEP) {
-            if is_instance_prefix(p) {
-                return unescape_cursor_safe(escaped).map(|u| (p.to_string(), u));
-            }
-        }
+    if let Some(rest) = prefixed.strip_prefix(CURSOR_SAFE_PREFIX)
+        && let Some((p, escaped)) = rest.split_once(CURSOR_SAFE_SEP)
+        && is_instance_prefix(p)
+    {
+        return unescape_cursor_safe(escaped).map(|u| (p.to_string(), u));
     }
 
     // 2. SEP-986 dot form: `{id8}.{tool}`. Still legal during the
     //    compatibility window so existing clients keep working while
     //    rollout is in progress.
-    if let Some((p, r)) = prefixed.split_once(INSTANCE_SEP) {
-        if is_instance_prefix(p) {
-            return Some((p.to_string(), r.to_string()));
-        }
+    if let Some((p, r)) = prefixed.split_once(INSTANCE_SEP)
+        && is_instance_prefix(p)
+    {
+        return Some((p.to_string(), r.to_string()));
     }
 
     // 3. Deprecated: `{id8}/{tool}` — the unreleased format fixed in #261.
-    if let Some((p, r)) = prefixed.split_once(DEPRECATED_SLASH_SEP) {
-        if is_instance_prefix(p) {
-            tracing::warn!(
-                tool = prefixed,
-                "Deprecated `/` gateway separator (pre-#261). Use `i_{{id8}}__{{tool}}`."
-            );
-            return Some((p.to_string(), r.to_string()));
-        }
+    if let Some((p, r)) = prefixed.split_once(DEPRECATED_SLASH_SEP)
+        && is_instance_prefix(p)
+    {
+        tracing::warn!(
+            tool = prefixed,
+            "Deprecated `/` gateway separator (pre-#261). Use `i_{{id8}}__{{tool}}`."
+        );
+        return Some((p.to_string(), r.to_string()));
     }
 
     // 4. Legacy: `{id8}__{tool}` — pre-#258. Deliberately checked last:
     //    the cursor-safe form also uses `__`, but its `i_` prefix
     //    disambiguates it above; without that prefix the `__` arm is
     //    only the pre-#258 shape.
-    if let Some((p, r)) = prefixed.split_once(LEGACY_NAMESPACE_SEP) {
-        if is_instance_prefix(p) {
-            tracing::warn!(
-                tool = prefixed,
-                "Deprecated `__` gateway separator (pre-#258). Use `i_{{id8}}__{{tool}}`."
-            );
-            return Some((p.to_string(), r.to_string()));
-        }
+    if let Some((p, r)) = prefixed.split_once(LEGACY_NAMESPACE_SEP)
+        && is_instance_prefix(p)
+    {
+        tracing::warn!(
+            tool = prefixed,
+            "Deprecated `__` gateway separator (pre-#258). Use `i_{{id8}}__{{tool}}`."
+        );
+        return Some((p.to_string(), r.to_string()));
     }
     None
 }

--- a/crates/dcc-mcp-gateway/src/gateway/proxy.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/proxy.rs
@@ -20,10 +20,9 @@ pub async fn proxy_request(
         if matches!(
             name.as_str(),
             "content-type" | "accept" | "mcp-session-id" | "authorization"
-        ) {
-            if let Ok(v) = val.to_str() {
-                req = req.header(key.as_str(), v);
-            }
+        ) && let Ok(v) = val.to_str()
+        {
+            req = req.header(key.as_str(), v);
         }
     }
 

--- a/crates/dcc-mcp-gateway/src/gateway/sse_subscriber/manager.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/sse_subscriber/manager.rs
@@ -257,10 +257,10 @@ impl SubscriberManager {
     pub fn forget_job(&self, job_id: &str) {
         let removed = self.inner.job_routes.remove(job_id);
         self.inner.job_event_buses.remove(job_id);
-        if let Some((_, route)) = removed {
-            if let Some(set) = self.inner.session_jobs.get(&route.client_session_id) {
-                set.value().remove(job_id);
-            }
+        if let Some((_, route)) = removed
+            && let Some(set) = self.inner.session_jobs.get(&route.client_session_id)
+        {
+            set.value().remove(job_id);
         }
         self.inner
             .request_to_job

--- a/crates/dcc-mcp-gateway/src/gateway/tools.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tools.rs
@@ -142,15 +142,15 @@ pub async fn tool_get_instance(gs: &GatewayState, args: &Value) -> Result<String
         }
 
         // display_name match
-        if let Some(name) = args.get("display_name").and_then(|v| v.as_str()) {
-            if let Some(e) = candidates.iter().find(|e| {
+        if let Some(name) = args.get("display_name").and_then(|v| v.as_str())
+            && let Some(e) = candidates.iter().find(|e| {
                 e.display_name
                     .as_deref()
                     .is_some_and(|n| n.to_lowercase().contains(&name.to_lowercase()))
-            }) {
-                return serde_json::to_string_pretty(&entry_to_json(e, gs.stale_timeout))
-                    .map_err(|e| e.to_string());
-            }
+            })
+        {
+            return serde_json::to_string_pretty(&entry_to_json(e, gs.stale_timeout))
+                .map_err(|e| e.to_string());
         }
 
         // scene / document hint
@@ -158,14 +158,13 @@ pub async fn tool_get_instance(gs: &GatewayState, args: &Value) -> Result<String
             .get("scene")
             .or_else(|| args.get("document"))
             .and_then(|v| v.as_str());
-        if let Some(hint) = scene_hint {
-            if let Some(e) = candidates
+        if let Some(hint) = scene_hint
+            && let Some(e) = candidates
                 .iter()
                 .find(|e| scene_matches(e, hint) || document_matches(e, hint))
-            {
-                return serde_json::to_string_pretty(&entry_to_json(e, gs.stale_timeout))
-                    .map_err(|e| e.to_string());
-            }
+        {
+            return serde_json::to_string_pretty(&entry_to_json(e, gs.stale_timeout))
+                .map_err(|e| e.to_string());
         }
 
         // Single unambiguous candidate
@@ -214,14 +213,14 @@ pub async fn tool_connect_to_dcc(gs: &GatewayState, args: &Value) -> Result<Stri
         }
 
         // display_name match
-        if let Some(name) = args.get("display_name").and_then(|v| v.as_str()) {
-            if let Some(e) = candidates.iter().find(|e| {
+        if let Some(name) = args.get("display_name").and_then(|v| v.as_str())
+            && let Some(e) = candidates.iter().find(|e| {
                 e.display_name
                     .as_deref()
                     .is_some_and(|n| n.to_lowercase().contains(&name.to_lowercase()))
-            }) {
-                return format_connect_response(e);
-            }
+            })
+        {
+            return format_connect_response(e);
         }
 
         // scene / document hint
@@ -229,13 +228,12 @@ pub async fn tool_connect_to_dcc(gs: &GatewayState, args: &Value) -> Result<Stri
             .get("scene")
             .or_else(|| args.get("document"))
             .and_then(|v| v.as_str());
-        if let Some(hint) = scene_hint {
-            if let Some(e) = candidates
+        if let Some(hint) = scene_hint
+            && let Some(e) = candidates
                 .iter()
                 .find(|e| scene_matches(e, hint) || document_matches(e, hint))
-            {
-                return format_connect_response(e);
-            }
+        {
+            return format_connect_response(e);
         }
 
         // Single unambiguous candidate

--- a/crates/dcc-mcp-http/src/handler/dispatch.rs
+++ b/crates/dcc-mcp-http/src/handler/dispatch.rs
@@ -171,42 +171,41 @@ pub(crate) async fn handle_tools_list(
     let current_gen = state.current_registry_generation();
 
     // ── Fast path: return cached snapshot if available and still valid ──
-    if state.enable_tool_cache && !force_refresh {
-        if let Some(sid) = session_id {
-            if let Some(snapshot) = state.sessions.get_tool_list_snapshot(sid) {
-                if snapshot.generation == current_gen {
-                    // Cache hit — apply cursor pagination on the cached list
-                    // and return without rebuilding.
-                    let cursor: usize = req
-                        .params
-                        .as_ref()
-                        .and_then(|p| p.get("cursor"))
-                        .and_then(|v| v.as_str())
-                        .and_then(decode_cursor)
-                        .unwrap_or(0);
-                    let total = snapshot.total;
-                    let page_end = (cursor + TOOLS_LIST_PAGE_SIZE).min(total);
-                    let page: Vec<McpTool> = if cursor < total {
-                        snapshot.tools[cursor..page_end].to_vec()
-                    } else {
-                        Vec::new()
-                    };
-                    let next_cursor = if page_end < total {
-                        Some(encode_cursor(page_end))
-                    } else {
-                        None
-                    };
-                    let result = ListToolsResult {
-                        tools: page,
-                        next_cursor,
-                    };
-                    return Ok(JsonRpcResponse::success(
-                        req.id.clone(),
-                        serde_json::to_value(result)?,
-                    ));
-                }
-            }
-        }
+    if state.enable_tool_cache
+        && !force_refresh
+        && let Some(sid) = session_id
+        && let Some(snapshot) = state.sessions.get_tool_list_snapshot(sid)
+        && snapshot.generation == current_gen
+    {
+        // Cache hit — apply cursor pagination on the cached list
+        // and return without rebuilding.
+        let cursor: usize = req
+            .params
+            .as_ref()
+            .and_then(|p| p.get("cursor"))
+            .and_then(|v| v.as_str())
+            .and_then(decode_cursor)
+            .unwrap_or(0);
+        let total = snapshot.total;
+        let page_end = (cursor + TOOLS_LIST_PAGE_SIZE).min(total);
+        let page: Vec<McpTool> = if cursor < total {
+            snapshot.tools[cursor..page_end].to_vec()
+        } else {
+            Vec::new()
+        };
+        let next_cursor = if page_end < total {
+            Some(encode_cursor(page_end))
+        } else {
+            None
+        };
+        let result = ListToolsResult {
+            tools: page,
+            next_cursor,
+        };
+        return Ok(JsonRpcResponse::success(
+            req.id.clone(),
+            serde_json::to_value(result)?,
+        ));
     }
 
     // ── Slow path: rebuild the full tool list from the registry ──
@@ -292,15 +291,15 @@ pub(crate) async fn handle_tools_list(
     let total = tools.len();
 
     // ── Store the snapshot for future cache hits (issue #438) ──
-    if state.enable_tool_cache {
-        if let Some(sid) = session_id {
-            let snapshot = crate::session::ToolListSnapshot {
-                tools: tools.clone(),
-                generation: current_gen,
-                total,
-            };
-            state.sessions.set_tool_list_snapshot(sid, snapshot);
-        }
+    if state.enable_tool_cache
+        && let Some(sid) = session_id
+    {
+        let snapshot = crate::session::ToolListSnapshot {
+            tools: tools.clone(),
+            generation: current_gen,
+            total,
+        };
+        state.sessions.set_tool_list_snapshot(sid, snapshot);
     }
 
     // 4. Session-scoped dynamic tools (issue #462).

--- a/crates/dcc-mcp-http/src/handler/notifications.rs
+++ b/crates/dcc-mcp-http/src/handler/notifications.rs
@@ -28,13 +28,13 @@ pub(crate) async fn handle_notification(state: &AppState, method: &str, params: 
                 other => serde_json::to_string(other).unwrap_or_default(),
             });
 
-            if let Some(id) = id_str {
-                if !id.is_empty() {
-                    tracing::info!(request_id = %id, "MCP request cancelled by client");
-                    state.cancelled_requests.insert(id.clone(), Instant::now());
-                    if state.in_flight.request_cancel(&id) {
-                        tracing::debug!(request_id = %id, "cancel flag set on in-flight request");
-                    }
+            if let Some(id) = id_str
+                && !id.is_empty()
+            {
+                tracing::info!(request_id = %id, "MCP request cancelled by client");
+                state.cancelled_requests.insert(id.clone(), Instant::now());
+                if state.in_flight.request_cancel(&id) {
+                    tracing::debug!(request_id = %id, "cancel flag set on in-flight request");
                 }
             }
         }

--- a/crates/dcc-mcp-http/src/handler/routes.rs
+++ b/crates/dcc-mcp-http/src/handler/routes.rs
@@ -118,10 +118,10 @@ pub async fn handle_post(
     let mut use_sse = false;
 
     // Check if client accepts SSE
-    if let Some(accept) = headers.get(header::ACCEPT) {
-        if accept.to_str().unwrap_or("").contains("text/event-stream") {
-            use_sse = true;
-        }
+    if let Some(accept) = headers.get(header::ACCEPT)
+        && accept.to_str().unwrap_or("").contains("text/event-stream")
+    {
+        use_sse = true;
     }
 
     for msg in &messages {

--- a/crates/dcc-mcp-http/src/handlers/job_tools.rs
+++ b/crates/dcc-mcp-http/src/handlers/job_tools.rs
@@ -212,10 +212,10 @@ pub async fn handle_search_tools(
         // Skill stubs: every non-loaded skill whose metadata matches the
         // query gets surfaced as `__skill__<name>`.
         for summary in state.catalog.list_skills(Some("unloaded")) {
-            if let Some(filter) = dcc {
-                if !summary.dcc.eq_ignore_ascii_case(filter) {
-                    continue;
-                }
+            if let Some(filter) = dcc
+                && !summary.dcc.eq_ignore_ascii_case(filter)
+            {
+                continue;
             }
             let haystack = format!(
                 "{} {} {} {} {}",
@@ -479,10 +479,11 @@ pub async fn handle_jobs_get_status(
             None => Value::Null,
         },
     );
-    if include_result && job.status.is_terminal() {
-        if let Some(ref r) = job.result {
-            envelope.insert("result".into(), r.clone());
-        }
+    if include_result
+        && job.status.is_terminal()
+        && let Some(ref r) = job.result
+    {
+        envelope.insert("result".into(), r.clone());
     }
     drop(job);
 

--- a/crates/dcc-mcp-http/src/handlers/skill_tools.rs
+++ b/crates/dcc-mcp-http/src/handlers/skill_tools.rs
@@ -183,10 +183,10 @@ pub async fn handle_load_skill(
         "already_loaded":   already_loaded,
         "tools":            tool_schemas,
     });
-    if !errors.is_empty() {
-        if let Some(obj) = body.as_object_mut() {
-            obj.insert("errors".to_string(), json!(errors));
-        }
+    if !errors.is_empty()
+        && let Some(obj) = body.as_object_mut()
+    {
+        obj.insert("errors".to_string(), json!(errors));
     }
 
     let text = serde_json::to_string_pretty(&body).unwrap_or_default();

--- a/crates/dcc-mcp-http/src/handlers/tools_call/resolve_impl.rs
+++ b/crates/dcc-mcp-http/src/handlers/tools_call/resolve_impl.rs
@@ -46,12 +46,11 @@ pub(super) async fn resolve_tool_call(
     }
 
     // Check session-scoped dynamic tools before the global registry (issue #462).
-    if tool_name.starts_with(crate::dynamic_tools::DYNAMIC_TOOL_PREFIX) {
-        if let Some(response) =
+    if tool_name.starts_with(crate::dynamic_tools::DYNAMIC_TOOL_PREFIX)
+        && let Some(response) =
             route_dynamic_tool_call(state, req, session_id, &params, &tool_name)?
-        {
-            return Ok(ToolCallResolution::Response(response));
-        }
+    {
+        return Ok(ToolCallResolution::Response(response));
     }
 
     let call_params = params.arguments.clone().unwrap_or(json!({}));

--- a/crates/dcc-mcp-http/src/prompts/template.rs
+++ b/crates/dcc-mcp-http/src/prompts/template.rs
@@ -23,23 +23,25 @@ pub fn render_template(template: &str, args: &HashMap<String, String>) -> Prompt
     let mut i = 0;
     while i < bytes.len() {
         // Look for `{{`
-        if i + 1 < bytes.len() && bytes[i] == b'{' && bytes[i + 1] == b'{' {
-            if let Some(end_rel) = template[i + 2..].find("}}") {
-                let raw = &template[i + 2..i + 2 + end_rel];
-                let name = raw.trim();
-                if !name.is_empty() && is_valid_placeholder(name) {
-                    match args.get(name) {
-                        Some(v) => out.push_str(v),
-                        None => return Err(PromptError::MissingArg(name.to_string())),
-                    }
-                    i = i + 2 + end_rel + 2;
-                    continue;
+        if i + 1 < bytes.len()
+            && bytes[i] == b'{'
+            && bytes[i + 1] == b'{'
+            && let Some(end_rel) = template[i + 2..].find("}}")
+        {
+            let raw = &template[i + 2..i + 2 + end_rel];
+            let name = raw.trim();
+            if !name.is_empty() && is_valid_placeholder(name) {
+                match args.get(name) {
+                    Some(v) => out.push_str(v),
+                    None => return Err(PromptError::MissingArg(name.to_string())),
                 }
-                // Not a valid placeholder — emit `{{` literally and advance by 1.
-                out.push_str("{{");
-                i += 2;
+                i = i + 2 + end_rel + 2;
                 continue;
             }
+            // Not a valid placeholder — emit `{{` literally and advance by 1.
+            out.push_str("{{");
+            i += 2;
+            continue;
         }
         // Regular char — UTF-8 safe advance.
         let ch_end = next_char_boundary(template, i);

--- a/crates/dcc-mcp-http/tests/http/notifications.rs
+++ b/crates/dcc-mcp-http/tests/http/notifications.rs
@@ -18,10 +18,10 @@ use tokio::sync::broadcast;
 fn drain(rx: &mut broadcast::Receiver<String>) -> Vec<Value> {
     let mut out = Vec::new();
     while let Ok(frame) = rx.try_recv() {
-        if let Some(body) = frame.strip_prefix("data: ") {
-            if let Ok(v) = serde_json::from_str::<Value>(body.trim()) {
-                out.push(v);
-            }
+        if let Some(body) = frame.strip_prefix("data: ")
+            && let Ok(v) = serde_json::from_str::<Value>(body.trim())
+        {
+            out.push(v);
         }
     }
     out

--- a/crates/dcc-mcp-jsonrpc/src/sse.rs
+++ b/crates/dcc-mcp-jsonrpc/src/sse.rs
@@ -22,7 +22,7 @@ pub fn encode_cursor(offset: usize) -> String {
 
 /// Decode a cursor produced by [`encode_cursor`]. Returns `None` if malformed.
 pub fn decode_cursor(cursor: &str) -> Option<usize> {
-    if cursor.len() % 2 != 0 {
+    if !cursor.len().is_multiple_of(2) {
         return None;
     }
     let bytes: Option<Vec<u8>> = (0..cursor.len())

--- a/crates/dcc-mcp-logging/src/file_logging/config.rs
+++ b/crates/dcc-mcp-logging/src/file_logging/config.rs
@@ -123,15 +123,15 @@ impl FileLoggingConfig {
     pub fn from_env_with_defaults() -> Result<Self, FileLoggingError> {
         let mut cfg = Self::default();
 
-        if let Ok(dir) = std::env::var(ENV_LOG_DIR) {
-            if !dir.trim().is_empty() {
-                cfg.directory = Some(PathBuf::from(dir));
-            }
+        if let Ok(dir) = std::env::var(ENV_LOG_DIR)
+            && !dir.trim().is_empty()
+        {
+            cfg.directory = Some(PathBuf::from(dir));
         }
-        if let Ok(prefix) = std::env::var(ENV_LOG_FILE_PREFIX) {
-            if !prefix.trim().is_empty() {
-                cfg.file_name_prefix = prefix;
-            }
+        if let Ok(prefix) = std::env::var(ENV_LOG_FILE_PREFIX)
+            && !prefix.trim().is_empty()
+        {
+            cfg.file_name_prefix = prefix;
         }
         if let Ok(raw) = std::env::var(ENV_LOG_MAX_SIZE) {
             cfg.max_size_bytes = raw.parse().map_err(|_| {

--- a/crates/dcc-mcp-logging/src/file_logging/writer.rs
+++ b/crates/dcc-mcp-logging/src/file_logging/writer.rs
@@ -293,11 +293,11 @@ pub fn prune_old_logs(directory: &Path, prefix: &str, retention_days: u32, max_t
         let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
 
         // Age pruning — unconditional.
-        if let Some(cutoff) = cutoff {
-            if modified < cutoff {
-                let _ = std::fs::remove_file(&path);
-                continue;
-            }
+        if let Some(cutoff) = cutoff
+            && modified < cutoff
+        {
+            let _ = std::fs::remove_file(&path);
+            continue;
         }
 
         total_size += size;

--- a/crates/dcc-mcp-process/src/watcher.rs
+++ b/crates/dcc-mcp-process/src/watcher.rs
@@ -252,15 +252,15 @@ async fn poll_once(inner: &WatcherInner, event_tx: &mpsc::Sender<ProcessEvent>) 
 
         let old_status_opt = status_updates.get(idx).and_then(|(_, _, old)| *old);
 
-        if let Some(old_status) = old_status_opt {
-            if old_status != new_status {
-                debug!(pid, ?old_status, ?new_status, "process status changed");
+        if let Some(old_status) = old_status_opt
+            && old_status != new_status
+        {
+            debug!(pid, ?old_status, ?new_status, "process status changed");
 
-                let name = info.name.clone();
+            let name = info.name.clone();
 
-                let event = if new_status == ProcessStatus::Stopped
-                    || new_status == ProcessStatus::Crashed
-                {
+            let event =
+                if new_status == ProcessStatus::Stopped || new_status == ProcessStatus::Crashed {
                     // Treat stopped/crashed as an Exited event for convenience
                     ProcessEvent::Exited {
                         pid,
@@ -275,9 +275,8 @@ async fn poll_once(inner: &WatcherInner, event_tx: &mpsc::Sender<ProcessEvent>) 
                     }
                 };
 
-                if event_tx.send(event).await.is_err() {
-                    return;
-                }
+            if event_tx.send(event).await.is_err() {
+                return;
             }
         }
     }

--- a/crates/dcc-mcp-sandbox/src/context.rs
+++ b/crates/dcc-mcp-sandbox/src/context.rs
@@ -146,19 +146,19 @@ impl SandboxContext {
         }
 
         // ── 3. Input validation ───────────────────────────────────────────────
-        if let Some(v) = validator {
-            if let Err(e) = v.validate_value(params) {
-                warn!(action, error = %e, "sandbox: input validation failed");
-                self.emit_audit(
-                    action,
-                    params,
-                    start.elapsed(),
-                    AuditOutcome::Denied {
-                        reason: e.to_string(),
-                    },
-                );
-                return Err(e);
-            }
+        if let Some(v) = validator
+            && let Err(e) = v.validate_value(params)
+        {
+            warn!(action, error = %e, "sandbox: input validation failed");
+            self.emit_audit(
+                action,
+                params,
+                start.elapsed(),
+                AuditOutcome::Denied {
+                    reason: e.to_string(),
+                },
+            );
+            return Err(e);
         }
 
         // ── 4. Determine effective timeout ────────────────────────────────────
@@ -188,14 +188,14 @@ impl SandboxContext {
             // Basic timeout: check elapsed time *before* calling the handler.
             // For true async timeout, callers should use tokio::time::timeout
             // around the whole execute() call.
-            if let Some(timeout) = effective_timeout {
-                if start.elapsed() >= timeout {
-                    let err = SandboxError::Timeout {
-                        timeout_ms: timeout.as_millis() as u64,
-                    };
-                    self.emit_audit(action, params, start.elapsed(), AuditOutcome::Timeout);
-                    return Err(err);
-                }
+            if let Some(timeout) = effective_timeout
+                && start.elapsed() >= timeout
+            {
+                let err = SandboxError::Timeout {
+                    timeout_ms: timeout.as_millis() as u64,
+                };
+                self.emit_audit(action, params, start.elapsed(), AuditOutcome::Timeout);
+                return Err(err);
             }
 
             match h(params_map) {

--- a/crates/dcc-mcp-sandbox/src/policy.rs
+++ b/crates/dcc-mcp-sandbox/src/policy.rs
@@ -112,12 +112,12 @@ impl SandboxPolicy {
                 action: action.to_owned(),
             });
         }
-        if let Some(ref allowed) = self.allowed_actions {
-            if !allowed.contains(action) {
-                return Err(SandboxError::ActionNotAllowed {
-                    action: action.to_owned(),
-                });
-            }
+        if let Some(ref allowed) = self.allowed_actions
+            && !allowed.contains(action)
+        {
+            return Err(SandboxError::ActionNotAllowed {
+                action: action.to_owned(),
+            });
         }
         Ok(())
     }

--- a/crates/dcc-mcp-sandbox/src/validator.rs
+++ b/crates/dcc-mcp-sandbox/src/validator.rs
@@ -47,83 +47,81 @@ impl ValidationRule {
                 _ => Ok(()),
             },
             ValidationRule::IsString => {
-                if let Some(v) = value {
-                    if !v.is_string() {
-                        return Err(SandboxError::ValidationFailed {
-                            field: field.to_owned(),
-                            reason: format!("expected string, got {}", json_type_name(v)),
-                        });
-                    }
+                if let Some(v) = value
+                    && !v.is_string()
+                {
+                    return Err(SandboxError::ValidationFailed {
+                        field: field.to_owned(),
+                        reason: format!("expected string, got {}", json_type_name(v)),
+                    });
                 }
                 Ok(())
             }
             ValidationRule::IsNumber => {
-                if let Some(v) = value {
-                    if !v.is_number() {
-                        return Err(SandboxError::ValidationFailed {
-                            field: field.to_owned(),
-                            reason: format!("expected number, got {}", json_type_name(v)),
-                        });
-                    }
+                if let Some(v) = value
+                    && !v.is_number()
+                {
+                    return Err(SandboxError::ValidationFailed {
+                        field: field.to_owned(),
+                        reason: format!("expected number, got {}", json_type_name(v)),
+                    });
                 }
                 Ok(())
             }
             ValidationRule::IsBoolean => {
-                if let Some(v) = value {
-                    if !v.is_boolean() {
-                        return Err(SandboxError::ValidationFailed {
-                            field: field.to_owned(),
-                            reason: format!("expected boolean, got {}", json_type_name(v)),
-                        });
-                    }
+                if let Some(v) = value
+                    && !v.is_boolean()
+                {
+                    return Err(SandboxError::ValidationFailed {
+                        field: field.to_owned(),
+                        reason: format!("expected boolean, got {}", json_type_name(v)),
+                    });
                 }
                 Ok(())
             }
             ValidationRule::MaxLength(max) => {
-                if let Some(Value::String(s)) = value {
-                    if s.len() > *max {
-                        return Err(SandboxError::ValidationFailed {
-                            field: field.to_owned(),
-                            reason: format!("string length {} exceeds maximum {}", s.len(), max),
-                        });
-                    }
+                if let Some(Value::String(s)) = value
+                    && s.len() > *max
+                {
+                    return Err(SandboxError::ValidationFailed {
+                        field: field.to_owned(),
+                        reason: format!("string length {} exceeds maximum {}", s.len(), max),
+                    });
                 }
                 Ok(())
             }
             ValidationRule::MinLength(min) => {
-                if let Some(Value::String(s)) = value {
-                    if s.len() < *min {
-                        return Err(SandboxError::ValidationFailed {
-                            field: field.to_owned(),
-                            reason: format!("string length {} is below minimum {}", s.len(), min),
-                        });
-                    }
+                if let Some(Value::String(s)) = value
+                    && s.len() < *min
+                {
+                    return Err(SandboxError::ValidationFailed {
+                        field: field.to_owned(),
+                        reason: format!("string length {} is below minimum {}", s.len(), min),
+                    });
                 }
                 Ok(())
             }
             ValidationRule::MaxValue(max) => {
-                if let Some(v) = value {
-                    if let Some(n) = v.as_f64() {
-                        if n > *max {
-                            return Err(SandboxError::ValidationFailed {
-                                field: field.to_owned(),
-                                reason: format!("value {n} exceeds maximum {max}"),
-                            });
-                        }
-                    }
+                if let Some(v) = value
+                    && let Some(n) = v.as_f64()
+                    && n > *max
+                {
+                    return Err(SandboxError::ValidationFailed {
+                        field: field.to_owned(),
+                        reason: format!("value {n} exceeds maximum {max}"),
+                    });
                 }
                 Ok(())
             }
             ValidationRule::MinValue(min) => {
-                if let Some(v) = value {
-                    if let Some(n) = v.as_f64() {
-                        if n < *min {
-                            return Err(SandboxError::ValidationFailed {
-                                field: field.to_owned(),
-                                reason: format!("value {n} is below minimum {min}"),
-                            });
-                        }
-                    }
+                if let Some(v) = value
+                    && let Some(n) = v.as_f64()
+                    && n < *min
+                {
+                    return Err(SandboxError::ValidationFailed {
+                        field: field.to_owned(),
+                        reason: format!("value {n} is below minimum {min}"),
+                    });
                 }
                 Ok(())
             }

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -257,20 +257,20 @@ struct PidFileGuard {
 
 impl Drop for PidFileGuard {
     fn drop(&mut self) {
-        if let Err(error) = std::fs::remove_file(&self.path) {
-            if error.kind() != std::io::ErrorKind::NotFound {
-                tracing::warn!(path = %self.path.display(), %error, "failed to remove PID file");
-            }
+        if let Err(error) = std::fs::remove_file(&self.path)
+            && error.kind() != std::io::ErrorKind::NotFound
+        {
+            tracing::warn!(path = %self.path.display(), %error, "failed to remove PID file");
         }
     }
 }
 
 impl PidFileGuard {
     fn remove_now(&mut self) {
-        if let Err(error) = std::fs::remove_file(&self.path) {
-            if error.kind() != std::io::ErrorKind::NotFound {
-                tracing::warn!(path = %self.path.display(), %error, "failed to remove PID file");
-            }
+        if let Err(error) = std::fs::remove_file(&self.path)
+            && error.kind() != std::io::ErrorKind::NotFound
+        {
+            tracing::warn!(path = %self.path.display(), %error, "failed to remove PID file");
         }
     }
 }
@@ -318,10 +318,10 @@ fn acquire_pid_file(path: &std::path::Path, force: bool) -> anyhow::Result<PidFi
         }
     }
 
-    if let Some(parent) = path.parent() {
-        if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent)?;
-        }
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)?;
     }
 
     std::fs::write(path, format!("{current_pid}\n"))?;
@@ -361,10 +361,10 @@ fn spawn_pid_cleanup_watcher(path: &std::path::Path, pid: u32) {
 fn run_pid_cleanup_watcher(path: PathBuf, pid: u32) {
     loop {
         if !is_process_alive(pid) {
-            if let Err(error) = std::fs::remove_file(&path) {
-                if error.kind() != std::io::ErrorKind::NotFound {
-                    tracing::warn!(path = %path.display(), %error, "PID cleanup watcher failed to remove file");
-                }
+            if let Err(error) = std::fs::remove_file(&path)
+                && error.kind() != std::io::ErrorKind::NotFound
+            {
+                tracing::warn!(path = %path.display(), %error, "PID cleanup watcher failed to remove file");
             }
             break;
         }

--- a/crates/dcc-mcp-skill-rest/src/service.rs
+++ b/crates/dcc-mcp-skill-rest/src/service.rs
@@ -410,15 +410,17 @@ impl SkillRestService {
                 if req.loaded_only && !a.loaded {
                     return false;
                 }
-                if let Some(d) = &req.dcc_type {
-                    if !d.is_empty() && !a.dcc.eq_ignore_ascii_case(d) {
-                        return false;
-                    }
+                if let Some(d) = &req.dcc_type
+                    && !d.is_empty()
+                    && !a.dcc.eq_ignore_ascii_case(d)
+                {
+                    return false;
                 }
-                if let Some(scope_filter) = &req.scope {
-                    if !scope_filter.is_empty() && !a.scope.eq_ignore_ascii_case(scope_filter) {
-                        return false;
-                    }
+                if let Some(scope_filter) = &req.scope
+                    && !scope_filter.is_empty()
+                    && !a.scope.eq_ignore_ascii_case(scope_filter)
+                {
+                    return false;
                 }
                 for t in &tags_lower {
                     if !a.tags.iter().any(|x| x.to_ascii_lowercase() == *t) {

--- a/crates/dcc-mcp-skills/src/catalog/catalog.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog.rs
@@ -43,10 +43,11 @@ impl SkillCatalog {
                     }
                 }
 
-                if let Some(dcc_filter) = dcc {
-                    if !dcc_filter.is_empty() && !meta.dcc.eq_ignore_ascii_case(dcc_filter) {
-                        return false;
-                    }
+                if let Some(dcc_filter) = dcc
+                    && !dcc_filter.is_empty()
+                    && !meta.dcc.eq_ignore_ascii_case(dcc_filter)
+                {
+                    return false;
                 }
 
                 true

--- a/crates/dcc-mcp-skills/src/catalog/execute.rs
+++ b/crates/dcc-mcp-skills/src/catalog/execute.rs
@@ -339,22 +339,21 @@ pub(crate) fn execute_script(
             .ok()
             .as_deref()
             != Some("1")
+        && let Some(dcc) = skill_dcc
     {
-        if let Some(dcc) = skill_dcc {
-            let dcc_lc = dcc.to_ascii_lowercase();
-            if DCC_NAMES_REQUIRING_HOST_PYTHON.contains(&dcc_lc.as_str()) {
-                let msg = format!(
-                    "Skill for DCC '{dcc}' cannot run with the ambient Python on PATH: \
+        let dcc_lc = dcc.to_ascii_lowercase();
+        if DCC_NAMES_REQUIRING_HOST_PYTHON.contains(&dcc_lc.as_str()) {
+            let msg = format!(
+                "Skill for DCC '{dcc}' cannot run with the ambient Python on PATH: \
                      `import {dcc_lc}.cmds` (or the equivalent) is either missing or a stub. \
                      Export DCC_MCP_PYTHON_EXECUTABLE to the DCC's host interpreter \
                      (e.g. mayapy, hython, 'blender --python') and DCC_MCP_PYTHON_INIT_SNIPPET \
                      to the per-DCC bootstrap code before starting the MCP server. \
                      Set DCC_MCP_ALLOW_AMBIENT_PYTHON=1 only for tests / stubs. \
                      See issue #231 for the contract."
-                );
-                tracing::error!(target: "dcc_mcp_skills::execute", %dcc, "{}", msg);
-                return Err(msg);
-            }
+            );
+            tracing::error!(target: "dcc_mcp_skills::execute", %dcc, "{}", msg);
+            return Err(msg);
         }
     }
 
@@ -364,22 +363,22 @@ pub(crate) fn execute_script(
     // running the skill script. Detection lives in
     // `crate::gui_executable` (issue #524) so other DCC plugins reach the
     // same lookup table.
-    if let Some(ref exe) = python_exe_override {
-        if let Some(hint) = crate::gui_executable::is_gui_executable(std::path::Path::new(exe)) {
-            let suggestion = match hint.recommended_replacement.as_ref() {
-                Some(p) => format!("Use the command-line interpreter at '{}'.", p.display()),
-                None => "Use the command-line interpreter (e.g. mayapy, blender --python, hython) \
+    if let Some(ref exe) = python_exe_override
+        && let Some(hint) = crate::gui_executable::is_gui_executable(std::path::Path::new(exe))
+    {
+        let suggestion = match hint.recommended_replacement.as_ref() {
+            Some(p) => format!("Use the command-line interpreter at '{}'.", p.display()),
+            None => "Use the command-line interpreter (e.g. mayapy, blender --python, hython) \
                          or leave DCC_MCP_PYTHON_EXECUTABLE unset to use the in-process executor."
-                    .to_string(),
-            };
-            let msg = format!(
-                "DCC_MCP_PYTHON_EXECUTABLE points to a {} GUI executable '{}'. \
+                .to_string(),
+        };
+        let msg = format!(
+            "DCC_MCP_PYTHON_EXECUTABLE points to a {} GUI executable '{}'. \
                  This will spawn a new DCC window instead of running the skill script. {}",
-                hint.dcc_kind, exe, suggestion,
-            );
-            tracing::error!(target: "dcc_mcp_skills::execute", exe, dcc_kind = hint.dcc_kind, "{}", msg);
-            return Err(msg);
-        }
+            hint.dcc_kind, exe, suggestion,
+        );
+        tracing::error!(target: "dcc_mcp_skills::execute", exe, dcc_kind = hint.dcc_kind, "{}", msg);
+        return Err(msg);
     }
 
     // Build CLI args that argparse-based scripts can consume.

--- a/crates/dcc-mcp-skills/src/catalog/tests/test_execute_script.rs
+++ b/crates/dcc-mcp-skills/src/catalog/tests/test_execute_script.rs
@@ -14,10 +14,10 @@ fn test_execute_script_stdin_json_params() {
         None,
     );
     // Skip gracefully if Python is not available in this environment.
-    if let Err(ref e) = result {
-        if e.contains("Failed to spawn") || e.contains("No such file") {
-            return;
-        }
+    if let Err(ref e) = result
+        && (e.contains("Failed to spawn") || e.contains("No such file"))
+    {
+        return;
     }
     let _ = result;
 }
@@ -31,10 +31,10 @@ fn test_execute_script_cli_flags_passed_for_scalar_params() {
         serde_json::json!({"name": "Alice", "count": 3, "verbose": true}),
         None,
     );
-    if let Err(ref e) = result {
-        if e.contains("Failed to spawn") || e.contains("No such file") {
-            return;
-        }
+    if let Err(ref e) = result
+        && (e.contains("Failed to spawn") || e.contains("No such file"))
+    {
+        return;
     }
     let _ = result;
 }
@@ -52,10 +52,10 @@ fn test_execute_script_complex_values_not_expanded_as_flags() {
         }),
         None,
     );
-    if let Err(ref e) = result {
-        if e.contains("Failed to spawn") || e.contains("No such file") {
-            return;
-        }
+    if let Err(ref e) = result
+        && (e.contains("Failed to spawn") || e.contains("No such file"))
+    {
+        return;
     }
     let _ = result;
 }

--- a/crates/dcc-mcp-skills/src/gui_executable.rs
+++ b/crates/dcc-mcp-skills/src/gui_executable.rs
@@ -182,10 +182,10 @@ fn real_case(parent: &Path, candidate: &Path) -> Option<PathBuf> {
     let target = candidate.file_name()?.to_str()?.to_ascii_lowercase();
     for entry in std::fs::read_dir(parent).ok()?.flatten() {
         let name = entry.file_name();
-        if let Some(s) = name.to_str() {
-            if s.to_ascii_lowercase() == target {
-                return Some(parent.join(s));
-            }
+        if let Some(s) = name.to_str()
+            && s.to_ascii_lowercase() == target
+        {
+            return Some(parent.join(s));
         }
     }
     None

--- a/crates/dcc-mcp-skills/src/loader/files.rs
+++ b/crates/dcc-mcp-skills/src/loader/files.rs
@@ -33,10 +33,10 @@ fn enumerate_files_by_ext(dir: &Path, filter: impl Fn(&str) -> bool) -> Vec<Stri
             };
             if file_type.is_file() {
                 let path = entry.path();
-                if let Some(ext) = path.extension().and_then(|ext| ext.to_str()) {
-                    if filter(ext) {
-                        files.push(path_to_string(&path));
-                    }
+                if let Some(ext) = path.extension().and_then(|ext| ext.to_str())
+                    && filter(ext)
+                {
+                    files.push(path_to_string(&path));
                 }
             }
         }

--- a/crates/dcc-mcp-skills/src/loader/mod.rs
+++ b/crates/dcc-mcp-skills/src/loader/mod.rs
@@ -131,10 +131,9 @@ pub fn parse_skill_md(skill_dir: &Path) -> Option<SkillMetadata> {
     if let Some(raw_metadata) = raw_value
         .as_mapping()
         .and_then(|m| m.get(serde_yaml_ng::Value::String("metadata".into())))
+        && let Some(j) = yaml_to_json(raw_metadata)
     {
-        if let Some(j) = yaml_to_json(raw_metadata) {
-            meta.metadata = j;
-        }
+        meta.metadata = j;
     }
 
     // Apply the agentskills.io-compliant `metadata.dcc-mcp.*` overrides
@@ -246,20 +245,20 @@ fn apply_dcc_mcp_metadata_overrides(
                 }
             }
             "tools" => {
-                if let Some(s) = value.as_str() {
-                    if let Some((tools, groups)) = load_sibling_tools_file(skill_dir, s) {
-                        meta.tools = tools;
-                        if let Some(g) = groups {
-                            meta.groups = g;
-                        }
+                if let Some(s) = value.as_str()
+                    && let Some((tools, groups)) = load_sibling_tools_file(skill_dir, s)
+                {
+                    meta.tools = tools;
+                    if let Some(g) = groups {
+                        meta.groups = g;
                     }
                 }
             }
             "groups" => {
-                if let Some(s) = value.as_str() {
-                    if let Some(groups) = load_sibling_groups_file(skill_dir, s) {
-                        meta.groups = groups;
-                    }
+                if let Some(s) = value.as_str()
+                    && let Some(groups) = load_sibling_groups_file(skill_dir, s)
+                {
+                    meta.groups = groups;
                 }
             }
             "prompts" => {
@@ -267,38 +266,38 @@ fn apply_dcc_mcp_metadata_overrides(
                 // prompts primitive. Parsing is deferred; we just record
                 // the path (relative to skill root) so the MCP server can
                 // load it lazily on `prompts/list` / `prompts/get`.
-                if let Some(s) = value.as_str() {
-                    if !s.is_empty() {
-                        meta.prompts_file = Some(s.to_string());
-                    }
+                if let Some(s) = value.as_str()
+                    && !s.is_empty()
+                {
+                    meta.prompts_file = Some(s.to_string());
                 }
             }
             "layer" => {
                 // Architectural layer for skill routing and search partitioning.
                 // Valid values: "infrastructure", "domain", "example".
                 // See skills/README.md#skill-layering and AGENTS.md.
-                if let Some(s) = value.as_str() {
-                    if !s.is_empty() {
-                        meta.layer = Some(s.to_string());
-                    }
+                if let Some(s) = value.as_str()
+                    && !s.is_empty()
+                {
+                    meta.layer = Some(s.to_string());
                 }
             }
             "recipes" => {
                 // Sibling-file reference for pre-composed parameter templates
                 // (issue #466). Parsing is deferred; store the path for lazy loading.
-                if let Some(s) = value.as_str() {
-                    if !s.is_empty() {
-                        meta.recipes_file = Some(s.to_string());
-                    }
+                if let Some(s) = value.as_str()
+                    && !s.is_empty()
+                {
+                    meta.recipes_file = Some(s.to_string());
                 }
             }
             "introspection" => {
                 // Sibling-file reference for capability-probe / version-check
                 // metadata (issue #466). Parsing is deferred; store for lazy loading.
-                if let Some(s) = value.as_str() {
-                    if !s.is_empty() {
-                        meta.introspection_file = Some(s.to_string());
-                    }
+                if let Some(s) = value.as_str()
+                    && !s.is_empty()
+                {
+                    meta.introspection_file = Some(s.to_string());
                 }
             }
             _ => {
@@ -339,12 +338,12 @@ fn collect_dcc_mcp_overrides(raw: &serde_yaml_ng::Value) -> Vec<(String, serde_y
         // Nested form: `metadata: { dcc-mcp: { dcc: maya, ... } }` —
         // canonical agentskills.io-compliant shape (issue #356) and the
         // shape produced by the sibling-file migration tool.
-        if ks == "dcc-mcp" {
-            if let Some(inner) = v.as_mapping() {
-                for (ik, iv) in inner.iter() {
-                    let Some(iks) = ik.as_str() else { continue };
-                    out.push((iks.to_string(), iv.clone()));
-                }
+        if ks == "dcc-mcp"
+            && let Some(inner) = v.as_mapping()
+        {
+            for (ik, iv) in inner.iter() {
+                let Some(iks) = ik.as_str() else { continue };
+                out.push((iks.to_string(), iv.clone()));
             }
         }
     }

--- a/crates/dcc-mcp-skills/src/manager.rs
+++ b/crates/dcc-mcp-skills/src/manager.rs
@@ -103,13 +103,12 @@ impl SkillsManager {
         let key = Self::paths_fingerprint(extra_paths, dcc_name);
 
         // Fast path: check read lock first
-        if let Ok(cache) = self.by_paths.read() {
-            if let Some(entry) = cache.get(&key) {
-                if entry.is_fresh() {
-                    tracing::debug!(key = %key, "SkillsManager: paths cache hit");
-                    return entry.count;
-                }
-            }
+        if let Ok(cache) = self.by_paths.read()
+            && let Some(entry) = cache.get(&key)
+            && entry.is_fresh()
+        {
+            tracing::debug!(key = %key, "SkillsManager: paths cache hit");
+            return entry.count;
         }
 
         // Cache miss — run the real scan
@@ -142,13 +141,12 @@ impl SkillsManager {
     ) -> usize {
         let key = Self::config_fingerprint(extra_paths, dcc_name, config_overrides);
 
-        if let Ok(cache) = self.by_config.read() {
-            if let Some(entry) = cache.get(&key) {
-                if entry.is_fresh() {
-                    tracing::debug!(key = %key, "SkillsManager: config cache hit");
-                    return entry.count;
-                }
-            }
+        if let Ok(cache) = self.by_config.read()
+            && let Some(entry) = cache.get(&key)
+            && entry.is_fresh()
+        {
+            tracing::debug!(key = %key, "SkillsManager: config cache hit");
+            return entry.count;
         }
 
         let count = self.catalog.discover(extra_paths, dcc_name);
@@ -185,13 +183,12 @@ impl SkillsManager {
         all_paths.sort_unstable();
         let key = format!("scoped:{}:{}", all_paths.join("|"), dcc_name.unwrap_or(""));
 
-        if let Ok(cache) = self.by_paths.read() {
-            if let Some(entry) = cache.get(&key) {
-                if entry.is_fresh() {
-                    tracing::debug!(key = %key, "SkillsManager: scoped paths cache hit");
-                    return entry.count;
-                }
-            }
+        if let Ok(cache) = self.by_paths.read()
+            && let Some(entry) = cache.get(&key)
+            && entry.is_fresh()
+        {
+            tracing::debug!(key = %key, "SkillsManager: scoped paths cache hit");
+            return entry.count;
         }
 
         let count = self.catalog.discover_scoped(scoped_paths, dcc_name);

--- a/crates/dcc-mcp-skills/src/scanner.rs
+++ b/crates/dcc-mcp-skills/src/scanner.rs
@@ -103,19 +103,18 @@ impl SkillScanner {
         }
 
         // 3. Platform-specific skills directory
-        if let Ok(platform_dir) = crate::paths::get_skills_dir(dcc_name) {
-            if Path::new(&platform_dir).is_dir() {
-                search_paths.push(platform_dir);
-            }
+        if let Ok(platform_dir) = crate::paths::get_skills_dir(dcc_name)
+            && Path::new(&platform_dir).is_dir()
+        {
+            search_paths.push(platform_dir);
         }
 
         // Also check global skills dir if dcc_name was specified
-        if dcc_name.is_some() {
-            if let Ok(global_dir) = crate::paths::get_skills_dir(None) {
-                if Path::new(&global_dir).is_dir() {
-                    search_paths.push(global_dir);
-                }
-            }
+        if dcc_name.is_some()
+            && let Ok(global_dir) = crate::paths::get_skills_dir(None)
+            && Path::new(&global_dir).is_dir()
+        {
+            search_paths.push(global_dir);
         }
 
         // Deduplicate while preserving order
@@ -145,15 +144,13 @@ impl SkillScanner {
         if self_skill_md.is_file() {
             let abs_path = path_to_string(path);
             let current_mtime = Self::file_mtime_secs(&self_skill_md);
-            if !force_refresh {
-                if let (Some(&cached_mtime), Some(mtime)) =
+            if !force_refresh
+                && let (Some(&cached_mtime), Some(mtime)) =
                     (self.cache.get(&abs_path), current_mtime)
-                {
-                    if (mtime - cached_mtime).abs() < MTIME_EPSILON_SECS {
-                        results.push(abs_path);
-                        return results;
-                    }
-                }
+                && (mtime - cached_mtime).abs() < MTIME_EPSILON_SECS
+            {
+                results.push(abs_path);
+                return results;
             }
             if let Some(mtime) = current_mtime {
                 self.cache.insert(abs_path.clone(), mtime);
@@ -197,15 +194,13 @@ impl SkillScanner {
             let current_mtime = Self::file_mtime_secs(&skill_md_path);
 
             // Check cache — skip re-processing if mtime unchanged
-            if !force_refresh {
-                if let (Some(&cached_mtime), Some(mtime)) =
+            if !force_refresh
+                && let (Some(&cached_mtime), Some(mtime)) =
                     (self.cache.get(&abs_path), current_mtime)
-                {
-                    if (mtime - cached_mtime).abs() < MTIME_EPSILON_SECS {
-                        results.push(abs_path);
-                        continue;
-                    }
-                }
+                && (mtime - cached_mtime).abs() < MTIME_EPSILON_SECS
+            {
+                results.push(abs_path);
+                continue;
             }
 
             // Update cache with current mtime (before moving abs_path)

--- a/crates/dcc-mcp-skills/src/versioning.rs
+++ b/crates/dcc-mcp-skills/src/versioning.rs
@@ -187,7 +187,7 @@ fn time_from_secs(secs: u64) -> (u32, u32, u32, u32, u32, u32) {
 }
 
 fn is_leap_year(year: u32) -> bool {
-    (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    (year.is_multiple_of(4) && !year.is_multiple_of(100)) || year.is_multiple_of(400)
 }
 
 // PyO3 bindings live in `crate::python::versioning`.

--- a/crates/dcc-mcp-skills/src/watcher/filter.rs
+++ b/crates/dcc-mcp-skills/src/watcher/filter.rs
@@ -42,10 +42,10 @@ pub(crate) fn is_skill_related(path: &Path) -> bool {
     }
 
     // Script files (check extension against supported list)
-    if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
-        if crate::constants::is_supported_extension(ext) {
-            return true;
-        }
+    if let Some(ext) = path.extension().and_then(|e| e.to_str())
+        && crate::constants::is_supported_extension(ext)
+    {
+        return true;
     }
 
     false

--- a/crates/dcc-mcp-telemetry/src/provider.rs
+++ b/crates/dcc-mcp-telemetry/src/provider.rs
@@ -30,15 +30,15 @@ pub struct TelemetryHandle {
 impl TelemetryHandle {
     /// Flush all pending spans/metrics and shut down the exporters gracefully.
     pub fn shutdown(&self) {
-        if let Some(ref tp) = self.tracer_provider {
-            if let Err(e) = tp.shutdown() {
-                tracing::warn!("tracer provider shutdown error: {e}");
-            }
+        if let Some(ref tp) = self.tracer_provider
+            && let Err(e) = tp.shutdown()
+        {
+            tracing::warn!("tracer provider shutdown error: {e}");
         }
-        if let Some(ref mp) = self.meter_provider {
-            if let Err(e) = mp.shutdown() {
-                tracing::warn!("meter provider shutdown error: {e}");
-            }
+        if let Some(ref mp) = self.meter_provider
+            && let Err(e) = mp.shutdown()
+        {
+            tracing::warn!("meter provider shutdown error: {e}");
         }
     }
 }

--- a/crates/dcc-mcp-tunnel-agent/src/client.rs
+++ b/crates/dcc-mcp-tunnel-agent/src/client.rs
@@ -100,10 +100,10 @@ pub async fn run_once(config: AgentConfig) -> Result<Registered, ClientError> {
                 session_id,
                 payload,
             } => {
-                if let Some(tx) = sessions_for_dispatch.get(&session_id).map(|s| s.clone()) {
-                    if tx.send(payload).await.is_err() {
-                        sessions_for_dispatch.remove(&session_id);
-                    }
+                if let Some(tx) = sessions_for_dispatch.get(&session_id).map(|s| s.clone())
+                    && tx.send(payload).await.is_err()
+                {
+                    sessions_for_dispatch.remove(&session_id);
                 }
             }
             Frame::CloseSession { session_id, .. } => {

--- a/crates/dcc-mcp-tunnel-relay/src/control.rs
+++ b/crates/dcc-mcp-tunnel-relay/src/control.rs
@@ -230,10 +230,10 @@ where
                 session_id,
                 payload,
             } => {
-                if let Some(inbox) = handle.session_inbox(session_id) {
-                    if inbox.send(payload).await.is_err() {
-                        handle.close_session(session_id);
-                    }
+                if let Some(inbox) = handle.session_inbox(session_id)
+                    && inbox.send(payload).await.is_err()
+                {
+                    handle.close_session(session_id);
                 }
             }
             Frame::CloseSession { session_id, .. } => {

--- a/crates/dcc-mcp-usd/src/bridge.rs
+++ b/crates/dcc-mcp-usd/src/bridge.rs
@@ -186,10 +186,10 @@ pub fn stage_to_scene_info(stage: &UsdStage) -> SceneInfo {
         info.statistics.camera_count = get_u64("dcc:cameraCount");
 
         // Source format
-        if let Some(attr) = world.get_attribute("dcc:sourceFormat") {
-            if let Some(s) = attr.default_value.as_ref().and_then(|v| v.as_str()) {
-                info.format = s.to_string();
-            }
+        if let Some(attr) = world.get_attribute("dcc:sourceFormat")
+            && let Some(s) = attr.default_value.as_ref().and_then(|v| v.as_str())
+        {
+            info.format = s.to_string();
         }
     }
 

--- a/crates/dcc-mcp-workflow/src/context.rs
+++ b/crates/dcc-mcp-workflow/src/context.rs
@@ -60,10 +60,10 @@ fn extract_file_refs(output: &Value) -> Vec<FileRef> {
     if let Some(v) = output.get("file_refs") {
         try_extract(v, &mut out);
     }
-    if let Some(ctx) = output.get("context") {
-        if let Some(v) = ctx.get("file_refs") {
-            try_extract(v, &mut out);
-        }
+    if let Some(ctx) = output.get("context")
+        && let Some(v) = ctx.get("file_refs")
+    {
+        try_extract(v, &mut out);
     }
     out
 }

--- a/crates/dcc-mcp-workflow/src/executor/output.rs
+++ b/crates/dcc-mcp-workflow/src/executor/output.rs
@@ -73,11 +73,11 @@ pub fn maybe_upload_inline_refs(
     };
 
     uploaders("file_refs", output);
-    if let Some(ctx) = output.get_mut("context") {
-        if let Some(arr) = ctx.get_mut("file_refs").and_then(Value::as_array_mut) {
-            for entry in arr.iter_mut() {
-                upload_one(entry);
-            }
+    if let Some(ctx) = output.get_mut("context")
+        && let Some(arr) = ctx.get_mut("file_refs").and_then(Value::as_array_mut)
+    {
+        for entry in arr.iter_mut() {
+            upload_one(entry);
         }
     }
     // Squash unused warning when `root_job_id` not needed.

--- a/crates/dcc-mcp-workflow/src/executor/policy_wrapper.rs
+++ b/crates/dcc-mcp-workflow/src/executor/policy_wrapper.rs
@@ -26,18 +26,18 @@ where
         },
         None => None,
     };
-    if let Some(ref rendered_key) = idem_key {
-        if let Some(cached) = state.idempotency.get(
+    if let Some(ref rendered_key) = idem_key
+        && let Some(cached) = state.idempotency.get(
             step.policy.idempotency_scope,
             state.workflow_id,
             rendered_key,
-        ) {
-            debug!(step_id = %step.id, key = %rendered_key, "idempotency cache hit");
-            let step_out = ingest_output(state, &step.id, cached);
-            state.context.record_step(&step.id, step_out.clone());
-            state.record_output_snapshot(step.id.as_str(), &step_out.output);
-            return StepOutcome::Ok;
-        }
+        )
+    {
+        debug!(step_id = %step.id, key = %rendered_key, "idempotency cache hit");
+        let step_out = ingest_output(state, &step.id, cached);
+        state.context.record_step(&step.id, step_out.clone());
+        state.record_output_snapshot(step.id.as_str(), &step_out.output);
+        return StepOutcome::Ok;
     }
 
     // Retry loop.

--- a/crates/dcc-mcp-workflow/src/idempotency.rs
+++ b/crates/dcc-mcp-workflow/src/idempotency.rs
@@ -105,10 +105,10 @@ impl IdempotencyStore for IdempotencyCache {
         let now = Instant::now();
         let guard = self.inner.read();
         let entry = guard.get(&k)?;
-        if let Some(exp) = entry.expires_at {
-            if exp <= now {
-                return None;
-            }
+        if let Some(exp) = entry.expires_at
+            && exp <= now
+        {
+            return None;
         }
         Some(entry.value.clone())
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.90.0"
+channel = "1.95.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Upgrades the workspace toolchain and MSRV to **Rust 1.95.0** (released 2026-04-16). Prepares the ground for follow-up PRs that may want to use `cfg_select!` or if-let match guards without per-call-site opt-in.

## What this PR changes

- `rust-toolchain.toml` channel: `1.90.0` → `1.95.0`
- Workspace MSRV (`Cargo.toml::workspace.package.rust-version`): `1.85` → `1.95`
- `.github/workflows/release.yml`: hardcoded toolchain `1.90.0` → `1.95.0`
- `.github/actions/build-wheel/action.yml`: `rust-version` input default `1.90.0` → `1.95.0`
- `cargo clippy --fix` applied for two lint families that 1.95 tightened — both pure mechanical rewrites:
  - `collapsible_if`: `if X { if Y { … } }` → `if X && Y { … }` / `if let … && Y { … }`
  - `manual_is_multiple_of`: `x % n == 0` → `x.is_multiple_of(n)`

54 source files touched, -13 net lines. No runtime behaviour change. No dependency bumps.

## Why MSRV + channel move together

Downstream consumers that vendor dcc-mcp-core pick up whatever MSRV this crate declares. Keeping MSRV on 1.85 while our CI builds on 1.95 would let us *write* 1.95-only syntax and break consumers silently. Moving MSRV forward in lockstep makes the constraint honest: any call site that reaches for `cfg_select!` is covered.

## Verification on 1.95.0

```bash
cargo check --workspace --all-targets                  # clean
cargo clippy --workspace --all-targets -- -D warnings  # clean
cargo fmt --all -- --check                             # clean
cargo hakari verify                                    # clean
cargo test --workspace --lib                           # 1909 tests pass
```

## Out of scope

- No `cfg_select!` migrations in this PR. Future PRs (e.g. the P2 host runtime effort) can use the macro where it helps platform/feature branching; this PR just unblocks them.
- No if-let match guard migrations.
- No other dependency bumps riding along.