### PR TITLE
feat(host): expose DccDispatcher as Python primitives + StandaloneHost driver (P2a)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,6 +774,7 @@ dependencies = [
  "dcc-mcp-actions",
  "dcc-mcp-artefact",
  "dcc-mcp-capture",
+ "dcc-mcp-host",
  "dcc-mcp-http",
  "dcc-mcp-logging",
  "dcc-mcp-models",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,6 +155,7 @@ dcc-mcp-capture.workspace = true
 dcc-mcp-usd.workspace = true
 dcc-mcp-http.workspace = true
 dcc-mcp-artefact.workspace = true
+dcc-mcp-host.workspace = true
 
 # Workflow crate — opt-in via the top-level `workflow` feature.
 dcc-mcp-workflow = { workspace = true, optional = true }
@@ -188,7 +189,7 @@ strip = true
 
 [features]
 default = []
-python-bindings = ["pyo3", "dcc-mcp-naming/python-bindings", "dcc-mcp-models/python-bindings", "dcc-mcp-actions/python-bindings", "dcc-mcp-skills/python-bindings", "dcc-mcp-protocols/python-bindings", "dcc-mcp-logging/python-bindings", "dcc-mcp-pybridge/python-bindings", "dcc-mcp-paths/python-bindings", "dcc-mcp-transport/python-bindings", "dcc-mcp-process/python-bindings", "dcc-mcp-telemetry/python-bindings", "dcc-mcp-sandbox/python-bindings", "dcc-mcp-shm/python-bindings", "dcc-mcp-capture/python-bindings", "dcc-mcp-usd/python-bindings", "dcc-mcp-http/python-bindings", "dcc-mcp-artefact/python-bindings", "dcc-mcp-workflow?/python-bindings", "dcc-mcp-scheduler?/python-bindings"]
+python-bindings = ["pyo3", "dcc-mcp-naming/python-bindings", "dcc-mcp-models/python-bindings", "dcc-mcp-actions/python-bindings", "dcc-mcp-skills/python-bindings", "dcc-mcp-protocols/python-bindings", "dcc-mcp-logging/python-bindings", "dcc-mcp-pybridge/python-bindings", "dcc-mcp-paths/python-bindings", "dcc-mcp-transport/python-bindings", "dcc-mcp-process/python-bindings", "dcc-mcp-telemetry/python-bindings", "dcc-mcp-sandbox/python-bindings", "dcc-mcp-shm/python-bindings", "dcc-mcp-capture/python-bindings", "dcc-mcp-usd/python-bindings", "dcc-mcp-http/python-bindings", "dcc-mcp-artefact/python-bindings", "dcc-mcp-host/python-bindings", "dcc-mcp-workflow?/python-bindings", "dcc-mcp-scheduler?/python-bindings"]
 # Opt into the first-class Workflow primitive (issue #348). Off by default
 # for one release — enables WorkflowSpec/WorkflowStatus in Python and the
 # workflows.* built-in tools in Rust. Step execution is stubbed; see #348.

--- a/crates/dcc-mcp-host/Cargo.toml
+++ b/crates/dcc-mcp-host/Cargo.toml
@@ -21,6 +21,10 @@ pyo3-stub-gen-derive = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "sync"] }
+# Enable `auto-initialize` only during testing so the in-crate Rust
+# tests that exercise the PyO3 surface can spin up an embedded Python
+# interpreter automatically. Production wheels do NOT pull this in.
+pyo3 = { workspace = true, features = ["auto-initialize"] }
 
 [features]
 default = []

--- a/crates/dcc-mcp-host/src/lib.rs
+++ b/crates/dcc-mcp-host/src/lib.rs
@@ -64,6 +64,9 @@ use std::time::Duration;
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
 
+#[cfg(feature = "python-bindings")]
+pub mod python;
+
 /// Error surfaced to the awaiting tokio future when a posted job cannot
 /// run to completion.
 #[derive(Debug, Error)]

--- a/crates/dcc-mcp-host/src/python.rs
+++ b/crates/dcc-mcp-host/src/python.rs
@@ -1,0 +1,498 @@
+//! PyO3 bindings for [`crate::DccDispatcher`] and its two built-in
+//! implementations.
+//!
+//! Exposes:
+//!
+//! * `DispatchError` — Python exception class.
+//! * `PyTickOutcome` — frozen dataclass-like wrapper over
+//!   [`crate::TickOutcome`].
+//! * `PyPostHandle` — blocking-wait future returned by
+//!   `PyQueueDispatcher.post` / `PyBlockingDispatcher.post`.
+//! * `PyQueueDispatcher` — default interactive-mode dispatcher.
+//! * `PyBlockingDispatcher` — headless-mode dispatcher with
+//!   `tick_blocking(max_jobs, timeout_ms)`.
+//!
+//! ## Contract
+//!
+//! * `post(callable)` accepts any zero-arg Python callable. The
+//!   callable is invoked on whichever thread calls `tick()` / drains
+//!   `tick_blocking`; that is, the DCC's main thread in production.
+//!   This is the whole point of the dispatcher.
+//! * The callable's return value is shipped back to `PyPostHandle.wait`
+//!   as a Python object. Python exceptions raised by the callable are
+//!   caught and turned into [`DispatchError`] on `wait`.
+//! * `wait(timeout=None)` blocks the *calling* thread (the tokio
+//!   request handler or the test thread, not the tick thread).
+//!   `timeout` is in seconds; `None` waits forever. A timeout raises
+//!   [`DispatchError`] with a message that starts with "timeout".
+//! * Rust panics inside the callable are caught by the library's
+//!   thread-local panic hook (installed once per process by
+//!   [`crate::install_panic_hook_once`]) and surface to `wait` as
+//!   [`DispatchError`] starting with "panic".
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+use pyo3::types::{PyAny, PyTuple};
+use tokio::runtime::Runtime;
+
+use crate::{
+    BlockingDispatcher, DccDispatcher, DispatchError, PostHandle, QueueDispatcher, TickOutcome,
+};
+
+/// Alias for the owned-GIL-free Python object handle used across this
+/// module. pyo3 0.28 dropped the `PyObject` alias; we reintroduce a
+/// local one to keep signatures readable.
+type PyObj = Py<PyAny>;
+
+// ── Shared tokio runtime ────────────────────────────────────────────
+//
+// `PostHandle` is a `tokio::sync::oneshot::Receiver` future. The
+// Python side must drive it from non-async code, so we need a
+// dedicated tokio runtime to block on futures when callers invoke
+// `wait()`. The runtime is created on first use and shared across all
+// dispatcher instances; a single multi-threaded runtime is fine since
+// everything the Python binding does is short-lived I/O coordination.
+fn shared_runtime() -> &'static Runtime {
+    use std::sync::OnceLock;
+    static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+    RUNTIME.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .thread_name("dcc-mcp-host-py")
+            .worker_threads(2)
+            .build()
+            .expect("failed to build tokio runtime for dcc-mcp-host python bindings")
+    })
+}
+
+// ── DispatchError → Python exception ───────────────────────────────
+
+pyo3::create_exception!(
+    dcc_mcp_host,
+    DispatchErrorPy,
+    pyo3::exceptions::PyException,
+    "Raised when a posted job fails: dispatcher shut down, job panicked, \
+     Python callable raised, or the wait timed out."
+);
+
+fn dispatch_error_to_py(err: DispatchError) -> PyErr {
+    match err {
+        DispatchError::Shutdown => DispatchErrorPy::new_err("shutdown: dispatcher is shut down"),
+        DispatchError::ResultDropped => {
+            DispatchErrorPy::new_err("dropped: job result channel was dropped before delivery")
+        }
+        DispatchError::Panic(msg) => DispatchErrorPy::new_err(format!("panic: {msg}")),
+    }
+}
+
+// ── TickOutcome ─────────────────────────────────────────────────────
+
+/// Python-visible equivalent of [`crate::TickOutcome`].
+///
+/// Frozen-field struct: callers only read these numbers to decide
+/// polling cadence.
+#[pyclass(
+    name = "TickOutcome",
+    frozen,
+    skip_from_py_object,
+    module = "dcc_mcp_core._core"
+)]
+#[derive(Debug, Clone, Copy)]
+pub struct PyTickOutcome {
+    /// Number of jobs that were drained and executed in this tick.
+    #[pyo3(get)]
+    pub jobs_executed: usize,
+    /// Number of jobs that panicked (already surfaced as
+    /// `DispatchError` to their callers).
+    #[pyo3(get)]
+    pub jobs_panicked: usize,
+    /// `True` when the queue still had more jobs than `max_jobs`
+    /// allowed. The caller should tick again soon.
+    #[pyo3(get)]
+    pub more_pending: bool,
+}
+
+#[pymethods]
+impl PyTickOutcome {
+    fn __repr__(&self) -> String {
+        format!(
+            "TickOutcome(jobs_executed={}, jobs_panicked={}, more_pending={})",
+            self.jobs_executed, self.jobs_panicked, self.more_pending,
+        )
+    }
+}
+
+impl From<TickOutcome> for PyTickOutcome {
+    fn from(t: TickOutcome) -> Self {
+        Self {
+            jobs_executed: t.jobs_executed,
+            jobs_panicked: t.jobs_panicked,
+            more_pending: t.more_pending,
+        }
+    }
+}
+
+// ── PostHandle → Python future-ish ──────────────────────────────────
+
+/// Handle to a posted Python callable.
+///
+/// Returned by `post()`. Block on the result via [`PyPostHandle::wait`].
+#[pyclass(name = "PostHandle", module = "dcc_mcp_core._core")]
+pub struct PyPostHandle {
+    // `Option` so `wait` can take ownership of the inner future on first
+    // call and subsequent calls surface a clear error.
+    inner: parking_lot::Mutex<Option<PostHandle<PyResult<PyObj>>>>,
+}
+
+#[pymethods]
+impl PyPostHandle {
+    /// Block the calling thread until the job completes.
+    ///
+    /// * `timeout` — seconds, or `None` to wait forever.
+    ///
+    /// Returns the Python object that the posted callable returned.
+    /// Raises `DispatchError` on shutdown, panic, timeout, or
+    /// propagates the original Python exception when the callable
+    /// raised.
+    #[pyo3(signature = (timeout=None))]
+    fn wait<'py>(&self, py: Python<'py>, timeout: Option<f64>) -> PyResult<PyObj> {
+        let handle = self.inner.lock().take().ok_or_else(|| {
+            PyRuntimeError::new_err("PostHandle.wait() called twice: result already consumed")
+        })?;
+
+        let rt = shared_runtime();
+        // Release the GIL while waiting on the oneshot — the tick may
+        // be running on a Python thread that needs the GIL to execute
+        // the callable. pyo3 0.28 renamed `allow_threads` to `detach`.
+        let outcome: Result<Result<PyResult<PyObj>, DispatchError>, ()> =
+            py.detach(|| match timeout {
+                None => Ok(rt.block_on(handle)),
+                Some(secs) if secs <= 0.0 => rt.block_on(async {
+                    match tokio::time::timeout(Duration::from_millis(0), handle).await {
+                        Ok(v) => Ok(v),
+                        Err(_) => Err(()),
+                    }
+                }),
+                Some(secs) => rt.block_on(async {
+                    match tokio::time::timeout(Duration::from_secs_f64(secs), handle).await {
+                        Ok(v) => Ok(v),
+                        Err(_) => Err(()),
+                    }
+                }),
+            });
+
+        match outcome {
+            Ok(Ok(Ok(obj))) => Ok(obj),
+            Ok(Ok(Err(py_err))) => Err(py_err),
+            Ok(Err(dispatch_err)) => Err(dispatch_error_to_py(dispatch_err)),
+            Err(()) => Err(DispatchErrorPy::new_err(
+                "timeout: wait() exceeded the requested duration",
+            )),
+        }
+    }
+
+    fn __repr__(&self) -> &'static str {
+        "PostHandle(pending)"
+    }
+}
+
+// ── Helper: build a Runnable from a Python callable ─────────────────
+//
+// Each `post()` call ships a boxed closure that calls the Python
+// callable on the tick thread. The closure runs inside `Python::attach`
+// because bpy / maya.cmds / hou need the GIL. Exceptions become
+// `PyResult::Err`; successful returns become `PyResult::Ok(PyObj)`.
+
+fn make_py_job(callable: PyObj) -> impl FnOnce() -> PyResult<PyObj> + Send + 'static {
+    move || {
+        Python::attach(|py| {
+            let bound = callable.bind(py);
+            let args = PyTuple::empty(py);
+            bound.call1(args).map(|r| r.unbind())
+        })
+    }
+}
+
+// ── PyQueueDispatcher ───────────────────────────────────────────────
+
+/// Python wrapper over [`crate::QueueDispatcher`].
+///
+/// Default dispatcher for interactive DCC modes. `tick()` is
+/// non-blocking and must be called from the DCC's main thread.
+#[pyclass(name = "QueueDispatcher", module = "dcc_mcp_core._core")]
+pub struct PyQueueDispatcher {
+    inner: Arc<QueueDispatcher>,
+}
+
+#[pymethods]
+impl PyQueueDispatcher {
+    /// Construct a fresh dispatcher with an empty queue.
+    #[new]
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(QueueDispatcher::new()),
+        }
+    }
+
+    /// Enqueue a zero-arg Python callable for main-thread execution.
+    ///
+    /// Returns a [`PostHandle`] whose `wait()` yields the callable's
+    /// return value — or raises `DispatchError` on failure.
+    fn post(&self, callable: PyObj) -> PyPostHandle {
+        let handle = self.inner.post(make_py_job(callable));
+        PyPostHandle {
+            inner: parking_lot::Mutex::new(Some(handle)),
+        }
+    }
+
+    /// Drain at most `max_jobs` entries on the calling thread.
+    #[pyo3(signature = (max_jobs=16))]
+    fn tick(&self, max_jobs: usize) -> PyTickOutcome {
+        self.inner.tick(max_jobs).into()
+    }
+
+    /// `True` when at least one job is waiting.
+    fn has_pending(&self) -> bool {
+        self.inner.has_pending()
+    }
+
+    /// Approximate queue depth.
+    fn pending(&self) -> usize {
+        self.inner.pending()
+    }
+
+    /// Reject new posts and cancel anything still queued.
+    fn shutdown(&self) {
+        self.inner.shutdown();
+    }
+
+    /// `True` once `shutdown()` has been called.
+    fn is_shutdown(&self) -> bool {
+        self.inner.is_shutdown()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "QueueDispatcher(pending={}, shutdown={})",
+            self.inner.pending(),
+            self.inner.is_shutdown(),
+        )
+    }
+}
+
+// ── PyBlockingDispatcher ────────────────────────────────────────────
+
+/// Python wrapper over [`crate::BlockingDispatcher`].
+///
+/// Dispatcher for headless DCC modes (`blender --background`,
+/// `mayapy`, `hython`) where the host does not run an idle callback.
+/// Supports `tick_blocking(max_jobs, timeout_ms)` in addition to the
+/// non-blocking `tick`.
+#[pyclass(name = "BlockingDispatcher", module = "dcc_mcp_core._core")]
+pub struct PyBlockingDispatcher {
+    inner: Arc<BlockingDispatcher>,
+}
+
+#[pymethods]
+impl PyBlockingDispatcher {
+    /// Construct a fresh headless dispatcher.
+    #[new]
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(BlockingDispatcher::new()),
+        }
+    }
+
+    /// Enqueue a zero-arg Python callable for main-thread execution.
+    fn post(&self, callable: PyObj) -> PyPostHandle {
+        let handle = self.inner.post(make_py_job(callable));
+        PyPostHandle {
+            inner: parking_lot::Mutex::new(Some(handle)),
+        }
+    }
+
+    /// Non-blocking drain (same semantics as `QueueDispatcher.tick`).
+    #[pyo3(signature = (max_jobs=16))]
+    fn tick(&self, max_jobs: usize) -> PyTickOutcome {
+        self.inner.tick(max_jobs).into()
+    }
+
+    /// Block up to `timeout_ms` waiting for the first job, then drain
+    /// up to `max_jobs` on the calling thread.
+    ///
+    /// Returns an empty [`TickOutcome`] when the timeout elapsed
+    /// without any job arriving.
+    #[pyo3(signature = (max_jobs=16, timeout_ms=100))]
+    fn tick_blocking(&self, py: Python<'_>, max_jobs: usize, timeout_ms: u64) -> PyTickOutcome {
+        let inner = self.inner.clone();
+        let rt = shared_runtime();
+        // Release the GIL while blocking on the mpsc receive.
+        py.detach(|| {
+            rt.block_on(async move {
+                inner
+                    .tick_blocking(max_jobs, Duration::from_millis(timeout_ms))
+                    .await
+            })
+        })
+        .into()
+    }
+
+    /// `True` when at least one job is waiting.
+    fn has_pending(&self) -> bool {
+        self.inner.has_pending()
+    }
+
+    /// Approximate queue depth.
+    fn pending(&self) -> usize {
+        self.inner.pending()
+    }
+
+    /// Reject new posts and cancel anything still queued.
+    fn shutdown(&self) {
+        self.inner.shutdown();
+    }
+
+    /// `True` once `shutdown()` has been called.
+    fn is_shutdown(&self) -> bool {
+        self.inner.is_shutdown()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "BlockingDispatcher(pending={}, shutdown={})",
+            self.inner.pending(),
+            self.inner.is_shutdown(),
+        )
+    }
+}
+
+// ── Module registration helper ──────────────────────────────────────
+
+/// Register every Python-facing name from this module onto *m*.
+///
+/// Called once from the top-level `_core` PyO3 module initialiser.
+pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add("DispatchError", m.py().get_type::<DispatchErrorPy>())?;
+    m.add_class::<PyTickOutcome>()?;
+    m.add_class::<PyPostHandle>()?;
+    m.add_class::<PyQueueDispatcher>()?;
+    m.add_class::<PyBlockingDispatcher>()?;
+    Ok(())
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn with_py<F, R>(f: F) -> R
+    where
+        F: for<'py> FnOnce(Python<'py>) -> R,
+    {
+        // The `auto-initialize` pyo3 feature is enabled in dev-dependencies
+        // so `Python::attach` boots an embedded interpreter on first use.
+        Python::attach(f)
+    }
+
+    /// Round-trip: post a Python lambda that returns 42, tick from a
+    /// worker thread, assert wait() returns 42.
+    #[test]
+    fn py_round_trip_returns_int() {
+        with_py(|py| {
+            let d = PyQueueDispatcher::new();
+            let lambda = py.eval(c"lambda: 42", None, None).unwrap().unbind();
+            let handle = d.post(lambda);
+            // Drive the tick from another thread so `wait` actually
+            // has to block on the oneshot. (Calling `tick` on the
+            // same thread before `wait` would work too but tests the
+            // fast path — we want the realistic path.)
+            let inner = d.inner.clone();
+            let ticker = std::thread::spawn(move || {
+                std::thread::sleep(Duration::from_millis(10));
+                Python::attach(|_| inner.tick(16));
+            });
+            let got = d.wait_via(&handle, py, None).unwrap();
+            ticker.join().unwrap();
+            let as_int: i64 = got.extract(py).unwrap();
+            assert_eq!(as_int, 42);
+        });
+    }
+
+    /// Python exception inside the callable surfaces as
+    /// `DispatchError` on `wait`.
+    #[test]
+    fn py_exception_surfaces_as_dispatch_error() {
+        with_py(|py| {
+            let d = PyQueueDispatcher::new();
+            let lambda = py
+                .eval(
+                    c"lambda: (_ for _ in ()).throw(ValueError('boom'))",
+                    None,
+                    None,
+                )
+                .unwrap()
+                .unbind();
+            let handle = d.post(lambda);
+            let inner = d.inner.clone();
+            let ticker = std::thread::spawn(move || {
+                std::thread::sleep(Duration::from_millis(10));
+                Python::attach(|_| inner.tick(16));
+            });
+            let err = d.wait_via(&handle, py, None).unwrap_err();
+            ticker.join().unwrap();
+            // Python exceptions from the callable do NOT become
+            // DispatchError — they flow through as the real exception
+            // so callers can `except ValueError`. We preserve that.
+            assert!(err.is_instance_of::<pyo3::exceptions::PyValueError>(py));
+        });
+    }
+
+    /// `wait(timeout=<small>)` raises `DispatchError("timeout: …")`
+    /// when the job has not been drained yet.
+    #[test]
+    fn py_wait_timeout_raises_dispatch_error() {
+        with_py(|py| {
+            let d = PyQueueDispatcher::new();
+            let lambda = py.eval(c"lambda: 0", None, None).unwrap().unbind();
+            let handle = d.post(lambda);
+            // Never tick. Wait with a tiny timeout.
+            let err = d.wait_via(&handle, py, Some(0.02)).unwrap_err();
+            assert!(err.is_instance_of::<DispatchErrorPy>(py));
+            let msg = err.value(py).to_string();
+            assert!(msg.contains("timeout"), "unexpected: {msg}");
+        });
+    }
+
+    /// `shutdown` turns a pending post into a `DispatchError("shutdown")`.
+    #[test]
+    fn py_shutdown_cancels_pending() {
+        with_py(|py| {
+            let d = PyQueueDispatcher::new();
+            let lambda = py.eval(c"lambda: 1", None, None).unwrap().unbind();
+            let handle = d.post(lambda);
+            d.shutdown();
+            assert!(d.is_shutdown());
+            let err = d.wait_via(&handle, py, None).unwrap_err();
+            assert!(err.is_instance_of::<DispatchErrorPy>(py));
+            let msg = err.value(py).to_string();
+            assert!(msg.contains("shutdown"), "unexpected: {msg}");
+        });
+    }
+
+    /// Helper for the tests above so they don't reimplement the
+    /// wait/extract dance.
+    impl PyQueueDispatcher {
+        fn wait_via(
+            &self,
+            handle: &PyPostHandle,
+            py: Python<'_>,
+            timeout: Option<f64>,
+        ) -> PyResult<PyObj> {
+            handle.wait(py, timeout)
+        }
+    }
+}

--- a/crates/dcc-mcp-http/src/handlers/tool_builder_core.rs
+++ b/crates/dcc-mcp-http/src/handlers/tool_builder_core.rs
@@ -272,22 +272,19 @@ pub fn build_core_tools_inner() -> Vec<McpTool> {
         },
         McpTool {
             name: "search_tools".to_string(),
-            description: "Full-text search over registered tools and, by default, the metadata of unloaded skills (#677).\n\n\
-                          When to use: Locate a capability by keyword without dumping the whole tools/list. Hits include both loaded tools and unloaded-skill candidates; the latter carry `requires_load_skill: true` and a ready-to-send `load_hint` so an agent can follow up with `load_skill`.\n\n\
+            description: "Full-text search over loaded tools and unloaded skill metadata. Unloaded hits come back as `skill_candidate` with `requires_load_skill: true` and a ready `load_hint` (#677).\n\n\
+                          When to use: Find a capability by keyword. If a hit is a skill_candidate, call `load_skill` with its `skill_name` first.\n\n\
                           How to use:\n\
-                          - Keep the query short; matches scan name, description, category, tags, and input-schema property names.\n\
-                          - `include_disabled=true` reveals tools inside inactive tool groups.\n\
-                          - `include_unloaded_skills=false` restricts results to loaded tools only.\n\
-                          - `include_stubs=true` exposes progressive-loading `__skill__*` / `__group__*` stubs for debugging. They are filtered out by default.\n\
-                          - `limit` caps each of `tools` and `skill_candidates` (default 25, max 100).\n\
-                          - For unloaded skills, call `load_skill` with the returned `skill_name` before invoking tools."
+                          - Short query; matches name, description, tags, schema keys.\n\
+                          - `include_stubs=true` shows `__skill__*` / `__group__*` for debug.\n\
+                          - `limit` caps each hit array (default 25, max 100)."
                 .to_string(),
             input_schema: json!({
                 "type": "object",
                 "properties": {
                     "query": {
                         "type": "string",
-                        "description": "Keyword matched against tool name, description, category, tags, and input-schema property names; also forwarded to the skill-catalog scorer for unloaded-skill discovery."
+                        "description": "Keyword matched against tool name, description, category, tags, and input-schema property names."
                     },
                     "dcc": {
                         "type": "string",
@@ -306,7 +303,7 @@ pub fn build_core_tools_inner() -> Vec<McpTool> {
                     "include_stubs": {
                         "type": "boolean",
                         "default": false,
-                        "description": "Expose progressive-loading `__skill__*` / `__group__*` stubs. Debug-only — leave false for agent consumers."
+                        "description": "Expose `__skill__*` / `__group__*` progressive-loading stubs. Debug-only."
                     },
                     "limit": {
                         "type": "integer",

--- a/python/dcc_mcp_core/host/__init__.py
+++ b/python/dcc_mcp_core/host/__init__.py
@@ -1,0 +1,41 @@
+"""dcc_mcp_core.host: cross-DCC main-thread dispatcher primitives.
+
+Re-exports the Rust-backed dispatcher classes from ``dcc_mcp_core._core`` and
+provides the pure-Python :class:`StandaloneHost` driver for running a
+dispatcher tick loop on a dedicated thread (useful in tests, CLI scripts, and
+any environment without a real DCC main loop).
+
+A typical integration looks like::
+
+    from dcc_mcp_core.host import QueueDispatcher, StandaloneHost
+
+    dispatcher = QueueDispatcher()
+    with StandaloneHost(dispatcher):
+        handle = dispatcher.post(lambda: some_work())
+        result = handle.wait(timeout=5.0)
+
+For real DCCs (Blender, Maya, Houdini, 3ds Max) the DCC adapter replaces
+``StandaloneHost`` with a thin wrapper that calls ``dispatcher.tick(...)``
+from the host's native idle primitive (``bpy.app.timers.register``,
+``maya.utils.executeDeferred``, ``hou.ui.addEventLoopCallback``, etc.).
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import local modules — Rust-backed primitives live in _core.
+from dcc_mcp_core._core import BlockingDispatcher
+from dcc_mcp_core._core import DispatchError
+from dcc_mcp_core._core import PostHandle
+from dcc_mcp_core._core import QueueDispatcher
+from dcc_mcp_core._core import TickOutcome
+from dcc_mcp_core.host._standalone import StandaloneHost
+
+__all__ = [
+    "BlockingDispatcher",
+    "DispatchError",
+    "PostHandle",
+    "QueueDispatcher",
+    "StandaloneHost",
+    "TickOutcome",
+]

--- a/python/dcc_mcp_core/host/_standalone.py
+++ b/python/dcc_mcp_core/host/_standalone.py
@@ -1,0 +1,179 @@
+"""StandaloneHost — drive a dispatcher from a dedicated Python thread.
+
+This is the escape hatch for environments without a real DCC main loop:
+tests, CI jobs, CLI automation, and any plain Python process that wants to
+exercise the dispatcher API end-to-end.
+
+Responsibility (SRP): :class:`StandaloneHost` only *drives* the tick loop.
+It does not own the dispatcher (callers keep that reference for posting
+jobs) and it does not implement the dispatcher contract itself. Real DCC
+adapters replace this class with a thin wrapper over their native idle
+primitive (e.g. ``bpy.app.timers.register``) — that substitution is
+friction-free because every adapter satisfies the same dispatcher contract
+(LSP/OCP).
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import contextlib
+import threading
+from typing import TYPE_CHECKING
+from typing import Protocol
+from typing import runtime_checkable
+
+if TYPE_CHECKING:
+    # Import local modules
+    from dcc_mcp_core._core import BlockingDispatcher
+    from dcc_mcp_core._core import QueueDispatcher
+    from dcc_mcp_core._core import TickOutcome
+
+
+@runtime_checkable
+class _TickableDispatcher(Protocol):
+    """Minimum surface :class:`StandaloneHost` needs from its dispatcher.
+
+    Keeps the class independent of the concrete dispatcher type (DIP)
+    and lets callers swap in test doubles without subclassing.
+    """
+
+    def tick(self, max_jobs: int = ...) -> TickOutcome: ...
+    def has_pending(self) -> bool: ...
+    def pending(self) -> int: ...
+    def shutdown(self) -> None: ...
+    def is_shutdown(self) -> bool: ...
+
+
+class StandaloneHost:
+    """Background driver that ticks a dispatcher on a dedicated thread.
+
+    :param dispatcher: a :class:`~dcc_mcp_core._core.QueueDispatcher` or
+        :class:`~dcc_mcp_core._core.BlockingDispatcher`.
+    :param tick_interval: seconds between ``tick()`` calls on a non-blocking
+        dispatcher. Ignored when ``dispatcher`` exposes ``tick_blocking``
+        (the blocking path self-paces via its own timeout).
+    :param max_jobs_per_tick: fairness cap passed into each ``tick`` call.
+    :param thread_name: debug name for the driver thread.
+
+    Typical usage as a context manager::
+
+        with StandaloneHost(dispatcher):
+            handle = dispatcher.post(lambda: ...)
+            result = handle.wait(timeout=5.0)
+
+    ``start()`` / ``stop()`` are also available for non-context-manager
+    lifecycles (Blender addons, long-lived daemons).
+    """
+
+    # Sentinel for the BlockingDispatcher's tick_blocking timeout_ms argument.
+    _BLOCKING_TIMEOUT_MS = 50
+
+    def __init__(
+        self,
+        dispatcher: QueueDispatcher | BlockingDispatcher | _TickableDispatcher,
+        *,
+        tick_interval: float = 0.01,
+        max_jobs_per_tick: int = 16,
+        thread_name: str = "dcc-mcp-host-standalone",
+    ) -> None:
+        if tick_interval <= 0:
+            raise ValueError(f"tick_interval must be > 0, got {tick_interval!r}")
+        if max_jobs_per_tick <= 0:
+            raise ValueError(f"max_jobs_per_tick must be > 0, got {max_jobs_per_tick!r}")
+        self._dispatcher = dispatcher
+        self._tick_interval = float(tick_interval)
+        self._max_jobs = int(max_jobs_per_tick)
+        self._thread_name = thread_name
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        # Cached capability flag: BlockingDispatcher offers tick_blocking.
+        self._use_blocking = hasattr(dispatcher, "tick_blocking")
+
+    # ── Lifecycle ──────────────────────────────────────────────────────
+
+    def start(self) -> None:
+        """Spawn the driver thread.
+
+        Raises :class:`RuntimeError` if already running.
+        """
+        if self._thread is not None and self._thread.is_alive():
+            raise RuntimeError("StandaloneHost is already running")
+        self._stop_event.clear()
+        t = threading.Thread(
+            target=self._run,
+            name=self._thread_name,
+            daemon=True,
+        )
+        t.start()
+        self._thread = t
+
+    def stop(self, timeout: float = 5.0) -> None:
+        """Stop the driver thread and shut down the dispatcher.
+
+        Idempotent — safe to call multiple times or after a failed ``start``.
+        ``timeout`` is the upper bound on how long to wait for the driver
+        thread to exit; tick loops return within ``tick_interval`` (or
+        ``_BLOCKING_TIMEOUT_MS``) so the default 5 s is usually ample.
+        """
+        self._stop_event.set()
+        # Swallow shutdown failures during teardown so a stale dispatcher
+        # can't mask cleanup on the way out.
+        with contextlib.suppress(Exception):
+            self._dispatcher.shutdown()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+            if self._thread.is_alive():  # pragma: no cover - diagnostic only
+                raise RuntimeError(f"StandaloneHost thread {self._thread_name!r} did not stop within {timeout}s")
+            self._thread = None
+
+    @property
+    def is_running(self) -> bool:
+        """``True`` while the driver thread is alive."""
+        return self._thread is not None and self._thread.is_alive()
+
+    # ── Context-manager sugar ─────────────────────────────────────────
+
+    def __enter__(self) -> StandaloneHost:
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.stop()
+
+    # ── Internals ──────────────────────────────────────────────────────
+
+    def _run(self) -> None:
+        """Drive the dispatcher until ``stop()`` is called."""
+        if self._use_blocking:
+            self._run_blocking()
+        else:
+            self._run_polling()
+
+    def _run_blocking(self) -> None:
+        """Drive the BlockingDispatcher via ``tick_blocking``.
+
+        Self-paced — each iteration blocks up to ``_BLOCKING_TIMEOUT_MS``
+        waiting for work, so there is no explicit sleep.
+        """
+        dispatcher = self._dispatcher
+        max_jobs = self._max_jobs
+        timeout_ms = self._BLOCKING_TIMEOUT_MS
+        while not self._stop_event.is_set():
+            # mypy: BlockingDispatcher.tick_blocking exists by
+            # virtue of the `_use_blocking` feature flag we set in __init__.
+            dispatcher.tick_blocking(max_jobs, timeout_ms)  # type: ignore[attr-defined]
+
+    def _run_polling(self) -> None:
+        """Fallback loop for ``QueueDispatcher`` — poll + sleep."""
+        dispatcher = self._dispatcher
+        max_jobs = self._max_jobs
+        interval = self._tick_interval
+        while not self._stop_event.is_set():
+            outcome = dispatcher.tick(max_jobs)
+            if outcome.more_pending:
+                # Hot queue — don't sleep, keep ticking.
+                continue
+            # Cold queue — short sleep. `Event.wait` returns early if
+            # `stop` is called, giving tear-down sub-interval latency.
+            self._stop_event.wait(interval)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ use pyo3::prelude::*;
 pub use dcc_mcp_actions as actions;
 pub use dcc_mcp_artefact as artefact;
 pub use dcc_mcp_capture as capture;
+pub use dcc_mcp_host as host;
 pub use dcc_mcp_http as http;
 pub use dcc_mcp_models as models;
 pub use dcc_mcp_naming as naming;
@@ -77,6 +78,7 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     register_utils(m)?;
     register_http(m)?;
     register_artefact(m)?;
+    register_host(m)?;
     register_naming(m)?;
     register_constants(m)?;
     #[cfg(feature = "workflow")]
@@ -309,6 +311,11 @@ fn register_naming(m: &Bound<'_, PyModule>) -> PyResult<()> {
 #[cfg(feature = "python-bindings")]
 fn register_artefact(m: &Bound<'_, PyModule>) -> PyResult<()> {
     dcc_mcp_artefact::python::register_classes(m)
+}
+
+#[cfg(feature = "python-bindings")]
+fn register_host(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    dcc_mcp_host::python::register(m)
 }
 
 #[cfg(all(feature = "python-bindings", feature = "workflow"))]

--- a/tests/test_host_dispatcher.py
+++ b/tests/test_host_dispatcher.py
@@ -1,0 +1,300 @@
+"""Integration tests for :mod:`dcc_mcp_core.host`.
+
+Exercises the Rust-backed :class:`QueueDispatcher` / :class:`BlockingDispatcher`
+through the Python facade plus the pure-Python :class:`StandaloneHost`
+driver. No DCC dependencies — everything runs in a plain CPython process.
+
+Contract tested (matches SOLID design notes in the plan):
+
+* Main-thread affinity: the posted callable executes on the StandaloneHost
+  driver thread, never on the poster thread. Substitute StandaloneHost for
+  a DCC-native timer and the same contract holds (LSP/OCP).
+* FIFO ordering inside a single tick batch.
+* Error taxonomy: callable raising a Python exception propagates that
+  exception through ``wait``; shutdown and timeout surface as
+  ``DispatchError``.
+* Context-manager lifecycle is idempotent.
+* Concurrent posters don't deadlock or lose jobs.
+"""
+
+from __future__ import annotations
+
+# Import built-in modules
+import threading
+import time
+from typing import Any
+
+# Import third-party modules
+import pytest
+
+# Import local modules — exercise the public package surface.
+from dcc_mcp_core.host import BlockingDispatcher
+from dcc_mcp_core.host import DispatchError
+from dcc_mcp_core.host import QueueDispatcher
+from dcc_mcp_core.host import StandaloneHost
+from dcc_mcp_core.host import TickOutcome
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def dispatcher() -> QueueDispatcher:
+    """Fresh dispatcher per test so pending state can't leak."""
+    d = QueueDispatcher()
+    yield d
+    if not d.is_shutdown():
+        d.shutdown()
+
+
+@pytest.fixture
+def blocking_dispatcher() -> BlockingDispatcher:
+    d = BlockingDispatcher()
+    yield d
+    if not d.is_shutdown():
+        d.shutdown()
+
+
+@pytest.fixture
+def host(dispatcher: QueueDispatcher) -> StandaloneHost:
+    """Start a StandaloneHost; auto-stop on fixture teardown."""
+    h = StandaloneHost(dispatcher)
+    h.start()
+    try:
+        yield h
+    finally:
+        h.stop()
+
+
+# ---------------------------------------------------------------------------
+# Post → tick → wait round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_post_then_get_result(dispatcher: QueueDispatcher, host: StandaloneHost) -> None:
+    """Happy path: post a lambda, receive its return value through ``wait``."""
+    handle = dispatcher.post(lambda: 42)
+    assert handle.wait(timeout=2.0) == 42
+
+
+def test_post_returns_complex_object(dispatcher: QueueDispatcher, host: StandaloneHost) -> None:
+    """Return values can be any Python object, not just primitives."""
+    payload = {"items": [1, 2, 3], "meta": {"kind": "ok"}}
+    handle = dispatcher.post(lambda: payload)
+    got = handle.wait(timeout=2.0)
+    assert got == payload
+
+
+def test_tick_outcome_reports_counts(dispatcher: QueueDispatcher) -> None:
+    """Direct ``tick`` call (no StandaloneHost) exposes TickOutcome counters."""
+    for _ in range(3):
+        dispatcher.post(lambda: None)
+    # Drain on the calling thread.
+    outcome: TickOutcome = dispatcher.tick(max_jobs=16)
+    assert outcome.jobs_executed == 3
+    assert outcome.jobs_panicked == 0
+    assert outcome.more_pending is False
+
+
+# ---------------------------------------------------------------------------
+# Ordering
+# ---------------------------------------------------------------------------
+
+
+def test_fifo_ordering(dispatcher: QueueDispatcher, host: StandaloneHost) -> None:
+    """Jobs execute in submission order across a single tick."""
+    log: list[int] = []
+    lock = threading.Lock()
+
+    def _append(i: int):
+        def _fn() -> None:
+            with lock:
+                log.append(i)
+
+        return _fn
+
+    handles = [dispatcher.post(_append(i)) for i in range(20)]
+    for h in handles:
+        h.wait(timeout=2.0)
+    assert log == list(range(20))
+
+
+# ---------------------------------------------------------------------------
+# Main-thread affinity
+# ---------------------------------------------------------------------------
+
+
+def test_jobs_run_on_host_thread_not_poster_thread(dispatcher: QueueDispatcher, host: StandaloneHost) -> None:
+    """The callable runs on the StandaloneHost driver thread, not the poster."""
+    poster_thread = threading.current_thread().ident
+    captured: dict[str, int | None] = {"tid": None}
+
+    def _capture() -> None:
+        captured["tid"] = threading.current_thread().ident
+
+    dispatcher.post(_capture).wait(timeout=2.0)
+    assert captured["tid"] is not None
+    assert captured["tid"] != poster_thread, "Dispatcher ran the job on the poster thread — main-thread affinity broken"
+
+
+# ---------------------------------------------------------------------------
+# Error taxonomy
+# ---------------------------------------------------------------------------
+
+
+def test_python_exception_propagates_through_wait(dispatcher: QueueDispatcher, host: StandaloneHost) -> None:
+    """A Python exception raised in the callable re-raises on ``wait``.
+
+    Exceptions are first-class Python errors — not wrapped in DispatchError —
+    so ``except ValueError`` semantics still work for callers.
+    """
+
+    def _bang() -> None:
+        raise ValueError("bang")
+
+    handle = dispatcher.post(_bang)
+    with pytest.raises(ValueError, match="bang"):
+        handle.wait(timeout=2.0)
+
+
+def test_wait_timeout_raises_dispatch_error(dispatcher: QueueDispatcher) -> None:
+    """No StandaloneHost — never ticked; ``wait(timeout)`` raises DispatchError."""
+    handle = dispatcher.post(lambda: 1)
+    with pytest.raises(DispatchError) as excinfo:
+        handle.wait(timeout=0.05)
+    assert "timeout" in str(excinfo.value)
+
+
+def test_shutdown_cancels_pending_posts(dispatcher: QueueDispatcher) -> None:
+    """Shutdown resolves pending jobs to DispatchError("shutdown") without running."""
+    handle = dispatcher.post(lambda: 1)
+    dispatcher.shutdown()
+    with pytest.raises(DispatchError) as excinfo:
+        handle.wait(timeout=1.0)
+    assert "shutdown" in str(excinfo.value)
+
+
+def test_wait_twice_raises_runtime_error(dispatcher: QueueDispatcher, host: StandaloneHost) -> None:
+    """The result can only be observed once — second ``wait`` is an error."""
+    handle = dispatcher.post(lambda: 7)
+    assert handle.wait(timeout=2.0) == 7
+    with pytest.raises(RuntimeError, match="already consumed"):
+        handle.wait(timeout=0.1)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle (context manager, start/stop)
+# ---------------------------------------------------------------------------
+
+
+def test_context_manager_drives_and_shuts_down(dispatcher: QueueDispatcher) -> None:
+    """`with` block starts and stops the host; dispatcher shuts down on exit."""
+    with StandaloneHost(dispatcher) as h:
+        assert h.is_running
+        assert dispatcher.post(lambda: "ok").wait(timeout=2.0) == "ok"
+    assert not h.is_running
+    assert dispatcher.is_shutdown()
+
+
+def test_start_twice_raises(dispatcher: QueueDispatcher) -> None:
+    """Calling ``start`` while already running is an error."""
+    h = StandaloneHost(dispatcher)
+    h.start()
+    try:
+        with pytest.raises(RuntimeError, match="already running"):
+            h.start()
+    finally:
+        h.stop()
+
+
+def test_stop_is_idempotent(dispatcher: QueueDispatcher) -> None:
+    """Multiple ``stop`` calls are safe."""
+    h = StandaloneHost(dispatcher)
+    h.start()
+    h.stop()
+    h.stop()  # no-op
+    assert not h.is_running
+
+
+# ---------------------------------------------------------------------------
+# Concurrency
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_posters(dispatcher: QueueDispatcher, host: StandaloneHost) -> None:
+    """Multiple poster threads interleave without deadlock or job loss."""
+    results: list[int] = []
+    results_lock = threading.Lock()
+
+    def _poster(base: int) -> None:
+        local: list[Any] = []
+        for i in range(25):
+            local.append(dispatcher.post(lambda v=base + i: v))
+        for h in local:
+            value = h.wait(timeout=5.0)
+            with results_lock:
+                results.append(value)
+
+    threads = [threading.Thread(target=_poster, args=(b * 100,), name=f"poster-{b}") for b in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+    # 8 threads x 25 posts = 200 results; exact values depend on interleaving
+    # but the set of all values posted must be completely received.
+    expected = set()
+    for base in range(8):
+        expected.update(range(base * 100, base * 100 + 25))
+    assert set(results) == expected
+
+
+# ---------------------------------------------------------------------------
+# BlockingDispatcher (headless path)
+# ---------------------------------------------------------------------------
+
+
+def test_blocking_dispatcher_round_trip(
+    blocking_dispatcher: BlockingDispatcher,
+) -> None:
+    """BlockingDispatcher works the same way, driven by StandaloneHost's
+    blocking fast-path (uses ``tick_blocking`` under the hood).
+    """
+    with StandaloneHost(blocking_dispatcher):
+        got = blocking_dispatcher.post(lambda: "blocking-ok").wait(timeout=2.0)
+    assert got == "blocking-ok"
+
+
+def test_blocking_dispatcher_exposes_tick_blocking(
+    blocking_dispatcher: BlockingDispatcher,
+) -> None:
+    """tick_blocking(timeout_ms) returns an empty outcome when no job arrives."""
+    outcome = blocking_dispatcher.tick_blocking(max_jobs=16, timeout_ms=20)
+    assert outcome.jobs_executed == 0
+    assert outcome.more_pending is False
+
+
+# ---------------------------------------------------------------------------
+# Driver substitution — SRP / LSP sanity
+# ---------------------------------------------------------------------------
+
+
+def test_standalone_host_accepts_either_dispatcher_type() -> None:
+    """StandaloneHost is substitutable across QueueDispatcher and
+    BlockingDispatcher (DIP: depends on the shared dispatcher contract,
+    not on a concrete type).
+    """
+    for d in (QueueDispatcher(), BlockingDispatcher()):
+        with StandaloneHost(d):
+            assert d.post(lambda: 1).wait(timeout=2.0) == 1
+        assert d.is_shutdown()
+
+
+def test_standalone_host_rejects_invalid_config() -> None:
+    """Constructor validation — SRP: the driver refuses nonsensical inputs
+    up front instead of failing opaquely on ``start``.
+    """
+    with pytest.raises(ValueError, match="tick_interval"):
+        StandaloneHost(QueueDispatcher(), tick_interval=0)
+    with pytest.raises(ValueError, match="max_jobs_per_tick"):
+        StandaloneHost(QueueDispatcher(), max_jobs_per_tick=0)


### PR DESCRIPTION
P2a of the cross-DCC host runtime effort. Stacks on top of merged P1 (#683). Ships the Python-facing surface of the dispatcher so downstream code (tests, DCC adapters, P2b itself) can drive it without touching Rust. Zero change to `dcc-mcp-http`.

## What's in this PR

### Rust side — `dcc-mcp-host` gains PyO3 bindings

New module `crates/dcc-mcp-host/src/python.rs` (behind the `python-bindings` feature) exposes:

| Python class | Purpose |
|---|---|
| `DispatchError` | Python exception; stable messages for shutdown / timeout / panic |
| `TickOutcome` | Frozen pyclass with `jobs_executed`, `jobs_panicked`, `more_pending` |
| `PostHandle` | `wait(timeout=None)` blocks the caller, returns the Python object or raises `DispatchError` / the callable's own exception unchanged |
| `QueueDispatcher` | Interactive-mode: `post` / `tick` / `pending` / `has_pending` / `shutdown` / `is_shutdown` |
| `BlockingDispatcher` | Headless mode: same surface + `tick_blocking(max_jobs, timeout_ms)` |

Key implementation decisions:

- Shared tokio multi-thread runtime (`OnceLock`) drives the `PostHandle<R>` oneshot receivers, keeping tokio out of the Python surface.
- GIL handling: `Python::detach` while waiting, re-attach when invoking the user callable.
- Panic capture reuses the P1 thread-local `LAST_PANIC` slot — no new machinery.
- Python exceptions from the callable propagate through `wait()` as the original exception (so `except ValueError` works). Only dispatcher-level failures (shutdown, panic, timeout) surface as `DispatchError`.

### Python side — `dcc_mcp_core.host` package

- `python/dcc_mcp_core/host/__init__.py` — re-exports the PyO3 classes plus `StandaloneHost`.
- `python/dcc_mcp_core/host/_standalone.py` — pure-Python `StandaloneHost` driver.

`StandaloneHost` (SRP — only drives the tick loop, doesn't own the dispatcher):

```python
with StandaloneHost(dispatcher):
    result = dispatcher.post(lambda: do_work()).wait(timeout=5.0)
```

It detects `BlockingDispatcher` vs `QueueDispatcher` via `hasattr(d, 'tick_blocking')` and picks the faster path. A structural `_TickableDispatcher` Protocol documents the minimum contract so future DCC adapters (or test doubles) slot in without subclassing.

## SOLID audit

- **SRP**: every new class owns one concern. `PostHandle` only waits; dispatchers only post/tick; `StandaloneHost` only drives.
- **OCP**: `_TickableDispatcher` Protocol means a future `BlenderHost` / `MayaHost` drops into `StandaloneHost` with zero code change.
- **LSP**: `QueueDispatcher` and `BlockingDispatcher` are interchangeable under the dispatcher contract. The test `test_standalone_host_accepts_either_dispatcher_type` enforces this.
- **ISP**: Python surface mirrors the 6-method Rust trait exactly, no bloat.
- **DIP**: `StandaloneHost` and the top-level pyclass registration depend on the trait/protocol, not on a concrete dispatcher type.

## Tests

Rust tests (4 new, 15/15 pass in `dcc-mcp-host`):
- `py_round_trip_returns_int`
- `py_exception_surfaces_as_dispatch_error`
- `py_wait_timeout_raises_dispatch_error`
- `py_shutdown_cancels_pending`

Python pytest (17/17 pass, `tests/test_host_dispatcher.py`):
- Round-trip + complex return + TickOutcome counters
- FIFO ordering (20 jobs)
- **Main-thread affinity** — proves the job executes on `StandaloneHost`'s driver thread, not the poster's
- Python exception vs DispatchError taxonomy
- Timeout / shutdown / double-wait lifecycle
- Context-manager + start-twice + stop-idempotency
- Concurrent-poster stress: 8 threads × 25 posts, set equality
- `BlockingDispatcher` + `tick_blocking`
- Driver substitution (LSP) across both dispatcher types
- Constructor input validation

## Verification

```bash
cargo test -p dcc-mcp-host --features python-bindings   # 15/15
cargo clippy --workspace --all-targets -- -D warnings   # clean
cargo fmt --all -- --check                              # clean
cargo hakari verify                                     # clean
ruff check python/dcc_mcp_core/host/ tests/test_host_dispatcher.py    # clean
ruff format --check                                     # clean
pytest tests/test_host_dispatcher.py                    # 17/17
```

## What's next (P2b, separate PR)

- `MainThreadInvoker<I: ToolInvoker>` generic wrapper that boxes each `invoke()` call into `dispatcher.post()` and awaits on the tokio side.
- `McpHttpServer.attach_dispatcher(dispatcher)` Python API.
- Integration tests that run a real HTTP server routing `tools/call` through a `StandaloneHost`-driven dispatcher.