### PR TITLE
feat(host): bridge DccDispatcher into McpHttpServer.tools/call via attach_dispatcher (P2b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,6 +855,7 @@ dependencies = [
  "dcc-mcp-artefact",
  "dcc-mcp-capture",
  "dcc-mcp-gateway",
+ "dcc-mcp-host",
  "dcc-mcp-job",
  "dcc-mcp-jsonrpc",
  "dcc-mcp-models",

--- a/crates/dcc-mcp-host/src/lib.rs
+++ b/crates/dcc-mcp-host/src/lib.rs
@@ -107,20 +107,27 @@ pub struct TickOutcome {
 ///
 /// Every DCC adapter in this workspace wires its native idle primitive
 /// to call [`DccDispatcher::tick`]. The MCP HTTP server layer calls
-/// [`DccDispatcher::post`] from its tokio workers.
+/// [`DccDispatcher::post`] (via the [`DccDispatcherExt`] convenience
+/// extension) from its tokio workers.
+///
+/// # Dyn compatibility
+///
+/// This trait is intentionally dyn-compatible (no generic methods in
+/// the main surface) so consumers can hold `Arc<dyn DccDispatcher>`.
+/// The ergonomic generic `post<F, R>(job)` lives on
+/// [`DccDispatcherExt`], which is blanket-implemented for every
+/// `DccDispatcher` and available whenever that trait is in scope.
 pub trait DccDispatcher: Send + Sync + 'static {
-    /// Enqueue a job for main-thread execution and return a future
-    /// that resolves to the job's return value.
+    /// Enqueue a type-erased job for main-thread execution and return
+    /// a future that resolves with the job's boxed result.
     ///
-    /// The job closure is `FnOnce() -> R + Send + 'static`; any type
-    /// that is `Send + 'static` can flow back to the awaiting future.
-    ///
-    /// This method is safe to call from any thread and is the primary
-    /// entry point for request handlers that need to touch DCC state.
-    fn post<F, R>(&self, job: F) -> PostHandle<R>
-    where
-        F: FnOnce() -> R + Send + 'static,
-        R: Send + 'static;
+    /// This is the dyn-safe primitive: every other `post*` method
+    /// (including [`DccDispatcherExt::post`]) funnels through here.
+    /// Callers who just want to schedule a closure and await a typed
+    /// result should use the generic
+    /// [`DccDispatcherExt::post`] instead — that wraps this method
+    /// and handles the down-cast.
+    fn post_boxed(&self, job: BoxedJob) -> PostHandle<BoxedResult>;
 
     /// Drain at most `max_jobs` entries from the queue and run them
     /// **on the calling thread**.
@@ -149,6 +156,39 @@ pub trait DccDispatcher: Send + Sync + 'static {
     fn is_shutdown(&self) -> bool;
 }
 
+/// Type-erased closure the dispatcher stores in its queue.
+pub type BoxedJob = Box<dyn FnOnce() -> BoxedResult + Send + 'static>;
+
+/// Type-erased return value shipped back via [`PostHandle`]. The
+/// generic [`DccDispatcherExt::post`] downcasts this transparently.
+pub type BoxedResult = Box<dyn std::any::Any + Send + 'static>;
+
+/// Convenience extension giving every [`DccDispatcher`] the ergonomic
+/// generic `post<F, R>(job)` API. Blanket-implemented — callers don't
+/// need to implement this trait themselves.
+///
+/// Keeping this out of the core trait is what makes
+/// [`DccDispatcher`] dyn-compatible.
+pub trait DccDispatcherExt: DccDispatcher {
+    /// Enqueue a `FnOnce() -> R` for main-thread execution and return
+    /// a future that resolves to `R` directly (no boxing visible at
+    /// the call site).
+    fn post<F, R>(&self, job: F) -> PostHandle<R>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        let boxed_job: BoxedJob = Box::new(move || {
+            let r = job();
+            Box::new(r) as BoxedResult
+        });
+        let raw = self.post_boxed(boxed_job);
+        PostHandle::downcasting::<R>(raw)
+    }
+}
+
+impl<T: DccDispatcher + ?Sized> DccDispatcherExt for T {}
+
 /// Handle to a posted job. Awaiting it yields the job's return value
 /// once the main thread ticks, or [`DispatchError`] on failure.
 pub struct PostHandle<R> {
@@ -158,6 +198,64 @@ pub struct PostHandle<R> {
 impl<R> PostHandle<R> {
     fn new(rx: oneshot::Receiver<Result<R, DispatchError>>) -> Self {
         Self { inner: rx }
+    }
+}
+
+impl PostHandle<BoxedResult> {
+    /// Convert a type-erased [`PostHandle<BoxedResult>`] (as produced
+    /// by [`DccDispatcher::post_boxed`]) into a typed
+    /// [`PostHandle<R>`] by attaching an adapter task that performs
+    /// the runtime downcast.
+    ///
+    /// Used by [`DccDispatcherExt::post`] so users holding
+    /// `Arc<dyn DccDispatcher>` still get the ergonomic typed
+    /// return. The conversion is infallible in practice — the
+    /// extension trait is the only way to feed data in, and it
+    /// guarantees the boxed payload is `R` — but we still surface a
+    /// [`DispatchError::ResultDropped`] if the adapter channel is
+    /// torn down.
+    fn downcasting<R>(self) -> PostHandle<R>
+    where
+        R: Send + 'static,
+    {
+        let (tx, rx) = oneshot::channel::<Result<R, DispatchError>>();
+        // Spawn an adapter task only if we're inside a tokio runtime.
+        // When called from inside `DccDispatcherExt::post`, the caller
+        // is typically on a tokio worker (HTTP hot path) or inside a
+        // `tokio::runtime::Handle::block_on` (Python bindings), so a
+        // runtime is almost always present. In the rare non-runtime
+        // case we fall back to `std::thread::spawn` so the handle
+        // still resolves correctly.
+        let inner = self.inner;
+        let forward = async move {
+            let outcome = match inner.await {
+                Ok(Ok(boxed)) => match boxed.downcast::<R>() {
+                    Ok(concrete) => Ok(*concrete),
+                    Err(_) => Err(DispatchError::Panic(
+                        "post_boxed payload downcast failed — internal bug".to_string(),
+                    )),
+                },
+                Ok(Err(err)) => Err(err),
+                Err(_) => Err(DispatchError::ResultDropped),
+            };
+            let _ = tx.send(outcome);
+        };
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) => {
+                handle.spawn(forward);
+            }
+            Err(_) => {
+                std::thread::spawn(move || {
+                    // Minimal current-thread runtime for the adapter.
+                    let rt = tokio::runtime::Builder::new_current_thread()
+                        .enable_time()
+                        .build()
+                        .expect("failed to build fallback runtime for PostHandle downcast");
+                    rt.block_on(forward);
+                });
+            }
+        }
+        PostHandle::new(rx)
     }
 }
 
@@ -469,10 +567,17 @@ impl QueueDispatcher {
             shared: Shared::new(),
         }
     }
-}
 
-impl DccDispatcher for QueueDispatcher {
-    fn post<F, R>(&self, job: F) -> PostHandle<R>
+    /// Inherent generic `post<F, R>` — the fast path when the caller
+    /// holds a concrete `QueueDispatcher`.
+    ///
+    /// Avoids the double-box the dyn-safe
+    /// [`DccDispatcher::post_boxed`] path incurs: the closure and its
+    /// return type are preserved statically until the tick thread
+    /// runs them. The ergonomic
+    /// [`DccDispatcherExt::post`] method provides the same signature
+    /// when the caller holds an `Arc<dyn DccDispatcher>`.
+    pub fn post<F, R>(&self, job: F) -> PostHandle<R>
     where
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,
@@ -486,6 +591,15 @@ impl DccDispatcher for QueueDispatcher {
             rejected.cancel();
         }
         PostHandle::new(rx)
+    }
+}
+
+impl DccDispatcher for QueueDispatcher {
+    fn post_boxed(&self, job: BoxedJob) -> PostHandle<BoxedResult> {
+        // Dyn-safe primitive: the generic closure shape has already
+        // been erased by the caller, so we just stash the boxed job
+        // in the same `Runnable` plumbing the inherent `post` uses.
+        self.post(job)
     }
 
     fn tick(&self, max_jobs: usize) -> TickOutcome {
@@ -553,6 +667,17 @@ impl BlockingDispatcher {
         }
     }
 
+    /// Inherent generic `post<F, R>` — see
+    /// [`QueueDispatcher::post`] for why we keep this outside the
+    /// trait.
+    pub fn post<F, R>(&self, job: F) -> PostHandle<R>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        self.inner.post(job)
+    }
+
     /// Drain up to `max_jobs` from the queue, blocking up to `timeout`
     /// waiting for the first job if none are immediately available.
     ///
@@ -585,12 +710,8 @@ impl BlockingDispatcher {
 }
 
 impl DccDispatcher for BlockingDispatcher {
-    fn post<F, R>(&self, job: F) -> PostHandle<R>
-    where
-        F: FnOnce() -> R + Send + 'static,
-        R: Send + 'static,
-    {
-        self.inner.post(job)
+    fn post_boxed(&self, job: BoxedJob) -> PostHandle<BoxedResult> {
+        self.inner.post_boxed(job)
     }
 
     fn tick(&self, max_jobs: usize) -> TickOutcome {

--- a/crates/dcc-mcp-host/src/python.rs
+++ b/crates/dcc-mcp-host/src/python.rs
@@ -227,6 +227,19 @@ pub struct PyQueueDispatcher {
     inner: Arc<QueueDispatcher>,
 }
 
+impl PyQueueDispatcher {
+    /// Hand out the shared Rust dispatcher so another crate (e.g.
+    /// `dcc-mcp-http::host_bridge`) can route tasks into it without
+    /// going through Python.
+    ///
+    /// Exposed at crate level only — this is an internal seam, not a
+    /// Python-visible method. SRP: the class stays focused on the
+    /// Python surface; integration crates reach in by name.
+    pub fn arc_inner(&self) -> Arc<dyn DccDispatcher> {
+        self.inner.clone() as Arc<dyn DccDispatcher>
+    }
+}
+
 #[pymethods]
 impl PyQueueDispatcher {
     /// Construct a fresh dispatcher with an empty queue.
@@ -294,6 +307,13 @@ impl PyQueueDispatcher {
 #[pyclass(name = "BlockingDispatcher", module = "dcc_mcp_core._core")]
 pub struct PyBlockingDispatcher {
     inner: Arc<BlockingDispatcher>,
+}
+
+impl PyBlockingDispatcher {
+    /// Hand out the shared Rust dispatcher. See [`PyQueueDispatcher::arc_inner`].
+    pub fn arc_inner(&self) -> Arc<dyn DccDispatcher> {
+        self.inner.clone() as Arc<dyn DccDispatcher>
+    }
 }
 
 #[pymethods]

--- a/crates/dcc-mcp-http/Cargo.toml
+++ b/crates/dcc-mcp-http/Cargo.toml
@@ -26,6 +26,7 @@ dcc-mcp-capture = { path = "../dcc-mcp-capture" }
 dcc-mcp-telemetry = { path = "../dcc-mcp-telemetry", optional = true }
 dcc-mcp-workflow = { path = "../dcc-mcp-workflow" }
 dcc-mcp-artefact = { path = "../dcc-mcp-artefact" }
+dcc-mcp-host = { path = "../dcc-mcp-host" }
 
 # Workspace shared
 serde = { workspace = true }
@@ -80,7 +81,7 @@ dcc-mcp-sandbox = { path = "../dcc-mcp-sandbox" }
 
 [features]
 default = []
-python-bindings = ["pyo3", "dcc-mcp-actions/python-bindings", "dcc-mcp-skills/python-bindings", "dcc-mcp-artefact/python-bindings", "dep:dcc-mcp-pybridge", "dcc-mcp-pybridge/python-bindings"]
+python-bindings = ["pyo3", "dcc-mcp-actions/python-bindings", "dcc-mcp-skills/python-bindings", "dcc-mcp-artefact/python-bindings", "dep:dcc-mcp-pybridge", "dcc-mcp-pybridge/python-bindings", "dcc-mcp-host/python-bindings"]
 # Enable `pyo3-stub-gen` annotations on this crate's PyO3 types.
 stub-gen = ["python-bindings", "dep:pyo3-stub-gen", "dep:pyo3-stub-gen-derive"]
 # Enable the Prometheus `/metrics` endpoint (issue #331). Pulls in the

--- a/crates/dcc-mcp-http/src/executor.rs
+++ b/crates/dcc-mcp-http/src/executor.rs
@@ -30,15 +30,33 @@ use tokio_util::sync::CancellationToken;
 pub type DccTaskFn = Box<dyn FnOnce() -> String + Send + 'static>;
 
 /// A pending DCC task with its result channel.
-struct DccTask {
-    func: DccTaskFn,
-    result_tx: oneshot::Sender<String>,
+///
+/// `pub(crate)` so [`crate::host_bridge`] can construct the mpsc
+/// channel that backs a bridged [`DccExecutorHandle`]. External
+/// crates still cannot see this type — they use the public
+/// [`DccExecutorHandle::execute`] API.
+pub(crate) struct DccTask {
+    pub(crate) func: DccTaskFn,
+    pub(crate) result_tx: oneshot::Sender<String>,
 }
 
 /// Handle owned by the HTTP server to submit tasks to the DCC main thread.
 #[derive(Clone)]
 pub struct DccExecutorHandle {
     tx: mpsc::Sender<DccTask>,
+}
+
+impl DccExecutorHandle {
+    /// Build a `DccExecutorHandle` from an externally-owned sender.
+    ///
+    /// Used by [`crate::host_bridge::dispatcher_to_executor_handle`]
+    /// to bridge a portable [`dcc_mcp_host::DccDispatcher`] into the
+    /// HTTP server's main-thread executor. `pub(crate)` keeps the
+    /// module-private `tx` field invariant for normal callers while
+    /// giving the bridge a single, documented seam.
+    pub(crate) fn from_sender(tx: mpsc::Sender<DccTask>) -> Self {
+        Self { tx }
+    }
 }
 
 impl DccExecutorHandle {

--- a/crates/dcc-mcp-http/src/host_bridge.rs
+++ b/crates/dcc-mcp-http/src/host_bridge.rs
@@ -1,0 +1,186 @@
+//! Bridge from [`dcc_mcp_host::DccDispatcher`] to
+//! [`crate::executor::DccExecutorHandle`].
+//!
+//! # Why this exists
+//!
+//! The HTTP server already has a main-thread executor
+//! ([`DccExecutorHandle`], driven by
+//! [`crate::executor::DeferredExecutor::poll_pending`]). The portable,
+//! cross-DCC dispatcher trait lives in `dcc-mcp-host`. Both solve the
+//! same "tokio worker → DCC main thread" problem, with different
+//! contracts and ownership stories. Rather than unify them into a
+//! single trait — which would drag HTTP-specific concerns
+//! ([`crate::error::HttpError`], the `DccTaskFn` string-return
+//! convention) into the host-runtime abstraction — we keep both and
+//! provide a one-directional adapter here.
+//!
+//! # Responsibility (SRP)
+//!
+//! This module is pure glue. It takes an [`Arc<dyn DccDispatcher>`]
+//! and returns a [`DccExecutorHandle`] that forwards every submitted
+//! [`crate::executor::DccTaskFn`] through `dispatcher.post(...)` and
+//! relays the resulting `String` back through the `oneshot` the HTTP
+//! layer already expects. It does not own the dispatcher, does not
+//! own the executor, and does not touch `AppState` or the request
+//! hot path.
+//!
+//! # SOLID
+//!
+//! - **SRP**: one tiny module, one job — forwarding.
+//! - **OCP**: `sync_impl.rs::run_on_main_thread` consumes any
+//!   `DccExecutorHandle` already; this adapter adds zero branches in
+//!   the hot path.
+//! - **LSP**: `QueueDispatcher`, `BlockingDispatcher`, and any future
+//!   `BlenderHost` / `MayaHost` implementing `DccDispatcher` are all
+//!   valid inputs.
+//! - **DIP**: depends on the [`DccDispatcher`] trait, not on a
+//!   concrete type.
+
+use std::sync::Arc;
+
+use dcc_mcp_host::{DccDispatcher, DccDispatcherExt, DispatchError};
+use tokio::runtime::Handle;
+use tokio::sync::mpsc;
+
+use crate::executor::{DccExecutorHandle, DccTask};
+
+/// Queue depth mirrors [`crate::executor::DeferredExecutor::new`]'s
+/// default (16) so back-pressure behaviour is identical to the native
+/// HTTP executor.
+const BRIDGE_QUEUE_DEPTH: usize = 16;
+
+/// Convert any [`Arc<dyn DccDispatcher>`] into a [`DccExecutorHandle`]
+/// the HTTP server can plug straight into
+/// [`crate::server::McpHttpServer::with_executor`].
+///
+/// A single background tokio task (spawned on `runtime`) drains the
+/// synthesized handle's mpsc, forwards each closure into
+/// `dispatcher.post(...)`, awaits the post, and ships the resulting
+/// `String` through the oneshot the HTTP hot path already awaits on.
+///
+/// # Error encoding
+///
+/// On [`DispatchError`] we encode the failure as a
+/// `{"__dispatch_error": "..."}` JSON string, matching the convention
+/// used by
+/// [`crate::handlers::tools_call::sync_impl::run_on_main_thread`].
+/// The HTTP layer's `decode_dispatch_output` unwraps this into a
+/// user-facing error without introducing a new error type.
+pub fn dispatcher_to_executor_handle(
+    dispatcher: Arc<dyn DccDispatcher>,
+    runtime: &Handle,
+) -> DccExecutorHandle {
+    let (tx, mut rx) = mpsc::channel::<DccTask>(BRIDGE_QUEUE_DEPTH);
+
+    runtime.spawn(async move {
+        while let Some(DccTask { func, result_tx }) = rx.recv().await {
+            let post = dispatcher.post(func);
+            let payload = match post.await {
+                Ok(json_string) => json_string,
+                Err(err) => encode_dispatch_error(&err),
+            };
+            // Ignore send failures: the HTTP caller may have dropped
+            // its receiver after a timeout. That's their contract,
+            // not ours.
+            let _ = result_tx.send(payload);
+        }
+    });
+
+    DccExecutorHandle::from_sender(tx)
+}
+
+/// Encode a [`DispatchError`] as the `{"__dispatch_error": "..."}`
+/// JSON string the HTTP hot path understands.
+///
+/// The tag prefix (`shutdown:` / `dropped:` / `panic:`) mirrors the
+/// convention in [`dcc_mcp_host::python::PyPostHandle::wait`] so
+/// Python and Rust surfaces report the same failure taxonomy.
+fn encode_dispatch_error(err: &DispatchError) -> String {
+    let tag = match err {
+        DispatchError::Shutdown => "shutdown",
+        DispatchError::ResultDropped => "dropped",
+        DispatchError::Panic(_) => "panic",
+    };
+    serde_json::to_string(&serde_json::json!({
+        "__dispatch_error": format!("{tag}: {err}"),
+    }))
+    .unwrap_or_else(|_| r#"{"__dispatch_error":"dispatch failure"}"#.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use dcc_mcp_host::QueueDispatcher;
+    use std::time::Duration;
+
+    /// Round-trip: submit a task through the synthesized handle, tick
+    /// the dispatcher from a "main thread" helper, assert the oneshot
+    /// returns the string the closure produced.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn round_trip_forwards_string_result() {
+        let dispatcher: Arc<dyn DccDispatcher> = Arc::new(QueueDispatcher::new());
+        let handle = dispatcher_to_executor_handle(dispatcher.clone(), &Handle::current());
+
+        let dispatcher_tick = dispatcher.clone();
+        let ticker = std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + Duration::from_secs(5);
+            while std::time::Instant::now() < deadline {
+                let outcome = dispatcher_tick.tick(16);
+                if outcome.jobs_executed > 0 {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            panic!("ticker saw no jobs within deadline");
+        });
+
+        let got = handle
+            .execute(Box::new(|| "hello".to_string()))
+            .await
+            .unwrap();
+        assert_eq!(got, "hello");
+        ticker.join().unwrap();
+    }
+
+    /// Panics inside the closure surface as `__dispatch_error` JSON.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn panic_surfaces_as_dispatch_error_json() {
+        let dispatcher: Arc<dyn DccDispatcher> = Arc::new(QueueDispatcher::new());
+        let handle = dispatcher_to_executor_handle(dispatcher.clone(), &Handle::current());
+
+        let dispatcher_tick = dispatcher.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(20));
+            dispatcher_tick.tick(16);
+        });
+
+        let got = handle
+            .execute(Box::new(|| panic!("boom in closure")))
+            .await
+            .unwrap();
+        assert!(
+            got.contains("__dispatch_error") && got.contains("panic"),
+            "expected __dispatch_error json for panic, got: {got}"
+        );
+    }
+
+    /// After the dispatcher shuts down, submits surface as
+    /// `__dispatch_error: shutdown` JSON.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn shutdown_surfaces_as_dispatch_error_json() {
+        let dispatcher: Arc<dyn DccDispatcher> = Arc::new(QueueDispatcher::new());
+        let handle = dispatcher_to_executor_handle(dispatcher.clone(), &Handle::current());
+
+        dispatcher.shutdown();
+
+        let got = handle
+            .execute(Box::new(|| "never runs".to_string()))
+            .await
+            .unwrap();
+        assert!(
+            got.contains("__dispatch_error") && got.contains("shutdown"),
+            "expected __dispatch_error json for shutdown, got: {got}"
+        );
+    }
+}

--- a/crates/dcc-mcp-http/src/lib.rs
+++ b/crates/dcc-mcp-http/src/lib.rs
@@ -43,6 +43,7 @@ pub mod config;
 pub mod dynamic_tools;
 pub mod error;
 pub mod executor;
+pub mod host_bridge;
 /// Re-export of [`dcc_mcp_gateway`] under the historical
 /// `dcc_mcp_http::gateway` path.
 ///

--- a/crates/dcc-mcp-http/src/python/bridge.rs
+++ b/crates/dcc-mcp-http/src/python/bridge.rs
@@ -373,5 +373,6 @@ pub fn py_create_skill_server(
         config: cfg,
         runtime: Arc::new(runtime),
         live_meta,
+        attached_executor: parking_lot::Mutex::new(None),
     })
 }

--- a/crates/dcc-mcp-http/src/python/skill_server.rs
+++ b/crates/dcc-mcp-http/src/python/skill_server.rs
@@ -28,6 +28,11 @@ pub struct PyMcpHttpServer {
     /// Shared live metadata — written by Python via `update_scene()` /
     /// `update_gateway_metadata()`; propagated to FileRegistry each heartbeat.
     pub(crate) live_meta: Arc<RwLock<LiveMetaInner>>,
+    /// Optional DCC main-thread executor attached via
+    /// [`PyMcpHttpServer::attach_dispatcher`]. Consumed exactly once
+    /// by [`PyMcpHttpServer::start`]; further `attach_dispatcher`
+    /// calls after start are rejected.
+    pub(crate) attached_executor: parking_lot::Mutex<Option<crate::executor::DccExecutorHandle>>,
 }
 
 #[pymethods]
@@ -64,20 +69,81 @@ impl PyMcpHttpServer {
             config: cfg,
             runtime: Arc::new(runtime),
             live_meta,
+            attached_executor: parking_lot::Mutex::new(None),
         })
+    }
+
+    /// Route every ``tools/call`` through the given dispatcher's main-thread queue.
+    ///
+    /// ``dispatcher`` must be a :class:`~dcc_mcp_core.host.QueueDispatcher`
+    /// or :class:`~dcc_mcp_core.host.BlockingDispatcher`. Once attached,
+    /// every synchronous ``tools/call`` handler runs on the thread that
+    /// drains the dispatcher (typically the DCC main thread, or the
+    /// :class:`~dcc_mcp_core.host.StandaloneHost` driver thread in tests).
+    ///
+    /// Must be called **before** :meth:`start`. Re-attaching after the
+    /// server has started is rejected with :class:`RuntimeError` — hot
+    /// swap is out of scope for this API and belongs to a dedicated
+    /// lifecycle method we may add later.
+    ///
+    /// Args:
+    ///     dispatcher: a ``QueueDispatcher`` or ``BlockingDispatcher``.
+    ///
+    /// Raises:
+    ///     TypeError: dispatcher is not one of the supported types.
+    ///     RuntimeError: ``attach_dispatcher`` was already called once
+    ///         on this server. Build a fresh ``McpHttpServer`` to swap
+    ///         the backing dispatcher.
+    fn attach_dispatcher(&self, py: Python<'_>, dispatcher: Py<PyAny>) -> PyResult<()> {
+        use dcc_mcp_host::python::{PyBlockingDispatcher, PyQueueDispatcher};
+
+        let bound = dispatcher.bind(py);
+        let shared: Arc<dyn dcc_mcp_host::DccDispatcher> =
+            if let Ok(queue) = bound.cast::<PyQueueDispatcher>() {
+                queue.borrow().arc_inner()
+            } else if let Ok(blocking) = bound.cast::<PyBlockingDispatcher>() {
+                blocking.borrow().arc_inner()
+            } else {
+                return Err(pyo3::exceptions::PyTypeError::new_err(
+                    "attach_dispatcher expects a QueueDispatcher or BlockingDispatcher",
+                ));
+            };
+
+        let mut slot = self.attached_executor.lock();
+        if slot.is_some() {
+            return Err(pyo3::exceptions::PyRuntimeError::new_err(
+                "attach_dispatcher was already called on this McpHttpServer — \
+                 build a fresh server to swap dispatchers",
+            ));
+        }
+        let executor =
+            crate::host_bridge::dispatcher_to_executor_handle(shared, self.runtime.handle());
+        *slot = Some(executor);
+        tracing::info!(
+            "McpHttpServer: main-thread dispatcher attached — tools/call will \
+             route through DccDispatcher::post"
+        );
+        Ok(())
     }
 
     /// Start the server and return a :class:`McpServerHandle`.
     ///
     /// This call returns immediately; the server runs in a background thread.
     fn start(&self) -> PyResult<PyServerHandle> {
-        let server = McpHttpServer::with_catalog(
+        let mut server = McpHttpServer::with_catalog(
             self.registry.clone(),
             self.catalog.clone(),
             self.config.clone(),
         )
         .with_dispatcher(self.dispatcher.clone())
         .with_live_meta(self.live_meta.clone());
+        // If a dispatcher was attached, drain it into the server's
+        // main-thread executor slot. Consumed once — further
+        // attach_dispatcher calls after start will be rejected by
+        // the None-vs-Some check there.
+        if let Some(executor) = self.attached_executor.lock().take() {
+            server = server.with_executor(executor);
+        }
         let handle = self
             .runtime
             .block_on(server.start())

--- a/crates/dcc-mcp-models/src/python/action_result.rs
+++ b/crates/dcc-mcp-models/src/python/action_result.rs
@@ -249,10 +249,10 @@ fn validate_from_dict(dict: &Bound<'_, PyDict>) -> PyResult<ActionResultModel> {
 
     let mut ctx = HashMap::new();
     for (k, v) in dict.iter() {
-        if let Ok(key) = k.extract::<String>() {
-            if !ACTION_RESULT_KNOWN_KEYS.contains(&key.as_str()) {
-                ctx.insert(key, py_any_to_json_value(&v)?);
-            }
+        if let Ok(key) = k.extract::<String>()
+            && !ACTION_RESULT_KNOWN_KEYS.contains(&key.as_str())
+        {
+            ctx.insert(key, py_any_to_json_value(&v)?);
         }
     }
 

--- a/tests/test_host_http_integration.py
+++ b/tests/test_host_http_integration.py
@@ -1,0 +1,187 @@
+"""Integration tests for ``McpHttpServer.attach_dispatcher`` (P2b).
+
+Verifies the cross-DCC main-thread dispatcher from
+:mod:`dcc_mcp_core.host` actually serves as the tools/call thread
+whenever an :class:`McpHttpServer` has one attached. No DCC binary
+required — :class:`StandaloneHost` stands in as the driver.
+
+Contract covered:
+
+* Attaching before ``start()`` makes every subsequent ``tools/call``
+  execute its handler on the dispatcher-tick thread, not the tokio
+  worker.
+* Re-attaching is rejected (SRP: hot-swap is future work).
+* Running without an attached dispatcher preserves legacy behaviour
+  (handlers run on a tokio worker, backward compatibility).
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import json
+import threading
+import time
+from typing import Any
+import urllib.request
+
+# Import third-party modules
+import pytest
+
+# Import local modules
+from dcc_mcp_core import McpHttpConfig
+from dcc_mcp_core import McpHttpServer
+from dcc_mcp_core import ToolRegistry
+from dcc_mcp_core.host import DispatchError
+from dcc_mcp_core.host import QueueDispatcher
+from dcc_mcp_core.host import StandaloneHost
+
+# ── helpers ─────────────────────────────────────────────────────────
+
+
+def _call_tool(url: str, tool: str, arguments: dict[str, Any] | None = None) -> dict:
+    body = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": tool, "arguments": arguments or {}},
+    }
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        return json.loads(resp.read())
+
+
+def _make_server(server_name: str) -> tuple[McpHttpServer, ToolRegistry]:
+    reg = ToolRegistry()
+    reg.register(
+        "thread_probe",
+        description="Return the thread id handling the call.",
+        category="test",
+        dcc="test",
+        version="1.0.0",
+    )
+    cfg = McpHttpConfig(port=0, server_name=server_name)
+    return McpHttpServer(reg, cfg), reg
+
+
+# ── tests ───────────────────────────────────────────────────────────
+
+
+def test_tools_call_routes_through_dispatcher() -> None:
+    """Main-thread affinity: the handler runs on the dispatcher tick
+    thread, never on a tokio worker or the poster thread.
+    """
+    server, _reg = _make_server("p2b-routing")
+
+    # Record the thread that runs the handler.
+    captured: dict[str, int | None] = {"tid": None}
+
+    def _probe(_params: dict) -> dict:
+        captured["tid"] = threading.get_ident()
+        return {"tid": captured["tid"]}
+
+    server.register_handler("thread_probe", _probe)
+
+    dispatcher = QueueDispatcher()
+    server.attach_dispatcher(dispatcher)
+
+    host = StandaloneHost(dispatcher, tick_interval=0.005)
+    host.start()
+    handle = server.start()
+    try:
+        # Give the server a moment to bind.
+        time.sleep(0.2)
+        resp = _call_tool(handle.mcp_url(), "thread_probe")
+        # tools/call returns a CallToolResult envelope; the handler's
+        # return value lives inside ``content[0].text`` as JSON text.
+        assert resp.get("error") is None, resp
+        text = resp["result"]["content"][0]["text"]
+        assert "tid" in text, text
+
+        tick_tid = host._thread.ident  # type: ignore[union-attr]
+        assert captured["tid"] == tick_tid, (
+            f"handler ran on thread {captured['tid']}, expected dispatcher tick thread {tick_tid}"
+        )
+        # Poster thread must be different — proves we didn't
+        # accidentally bypass the dispatcher.
+        assert captured["tid"] != threading.get_ident()
+    finally:
+        handle.shutdown()
+        host.stop()
+
+
+def test_attach_dispatcher_rejects_second_call() -> None:
+    """Re-attaching on the same server is rejected with RuntimeError."""
+    server, _reg = _make_server("p2b-reject")
+    dispatcher = QueueDispatcher()
+    server.attach_dispatcher(dispatcher)
+    with pytest.raises(RuntimeError, match="already called"):
+        server.attach_dispatcher(QueueDispatcher())
+
+
+def test_attach_dispatcher_rejects_non_dispatcher_type() -> None:
+    """Passing a random Python object is a TypeError, not a panic."""
+    server, _reg = _make_server("p2b-type")
+    with pytest.raises(TypeError, match="QueueDispatcher or BlockingDispatcher"):
+        server.attach_dispatcher(object())
+
+
+def test_without_dispatcher_backcompat() -> None:
+    """No ``attach_dispatcher`` call → existing tokio-worker path still works."""
+    server, _reg = _make_server("p2b-backcompat")
+    captured: dict[str, int | None] = {"tid": None}
+
+    def _probe(_params: dict) -> dict:
+        captured["tid"] = threading.get_ident()
+        return {"ok": True}
+
+    server.register_handler("thread_probe", _probe)
+    handle = server.start()
+    try:
+        time.sleep(0.2)
+        resp = _call_tool(handle.mcp_url(), "thread_probe")
+        assert resp.get("error") is None, resp
+        assert captured["tid"] is not None
+    finally:
+        handle.shutdown()
+
+
+def test_dispatcher_shutdown_during_call_surfaces_error() -> None:
+    """If the dispatcher is shut down while a call is in flight, the
+    HTTP caller receives a clean error envelope, not a hang.
+    """
+    server, _reg = _make_server("p2b-shutdown")
+
+    def _slow(_params: dict) -> dict:
+        time.sleep(0.2)
+        return {"ok": True}
+
+    server.register_handler("thread_probe", _slow)
+
+    dispatcher = QueueDispatcher()
+    server.attach_dispatcher(dispatcher)
+    host = StandaloneHost(dispatcher, tick_interval=0.005)
+    host.start()
+    handle = server.start()
+    try:
+        time.sleep(0.2)
+        # Shut down the dispatcher immediately — any later call will
+        # be rejected by the dispatcher before even reaching the
+        # handler.
+        dispatcher.shutdown()
+        host.stop()
+
+        resp = _call_tool(handle.mcp_url(), "thread_probe")
+        # The response must be well-formed JSON-RPC. Either isError is
+        # set on the CallToolResult, or the dispatch error leaked as a
+        # JSON-RPC error — both are acceptable "clean error" shapes.
+        is_tool_error = resp.get("result", {}).get("isError") is True
+        is_rpc_error = resp.get("error") is not None
+        assert is_tool_error or is_rpc_error, f"expected a clean error envelope after shutdown, got: {resp}"
+    finally:
+        handle.shutdown()


### PR DESCRIPTION
P2b of the cross-DCC host runtime effort. Stacks on merged P1 + P2a + #684. Wires the portable `DccDispatcher` trait into `McpHttpServer`'s existing main-thread executor path so every `tools/call` handler runs on whatever thread drains the user's dispatcher (DCC main thread in production, `StandaloneHost` driver thread in tests).

## What changed

### `dcc-mcp-host`: trait becomes dyn-compatible

The P1 trait had a generic `post<F, R>` which prevented `Arc<dyn DccDispatcher>`. Split the surface:

- **`DccDispatcher`** — now only requires `post_boxed(BoxedJob) -> PostHandle<BoxedResult>`. Object-safe.
- **`DccDispatcherExt`** — blanket-impl'd extension with the ergonomic `post<F, R>` method, wrapping `post_boxed` with a runtime downcast.
- **`QueueDispatcher`** / **`BlockingDispatcher`** — keep their inherent generic `post<F, R>` as a zero-cost fast path for concrete-type holders.

All P1 tests continue to pass without change.

### `dcc-mcp-http`: `host_bridge` module (new)

`crates/dcc-mcp-http/src/host_bridge.rs` exposes:

```rust
pub fn dispatcher_to_executor_handle(
    dispatcher: Arc<dyn DccDispatcher>,
    runtime: &Handle,
) -> DccExecutorHandle
```

Spawns one tokio forwarder that drains a `DccTask` mpsc and reposts each closure via `dispatcher.post(...)`, shipping the `String` result through the oneshot the HTTP hot path already awaits on. `DispatchError` encodes as `{"__dispatch_error": "<tag>: ..."}` JSON, matching the convention `run_on_main_thread` already uses — zero new error types.

**Zero changes** to `AppState`, `sync_impl.rs`, `tools_call/mod.rs`, or any request handler.

### `McpHttpServer.attach_dispatcher` Python method

Single new pymethod, must be called before `start()`:

```python
server = McpHttpServer(registry, config)
dispatcher = QueueDispatcher()
server.attach_dispatcher(dispatcher)  # ← new
with StandaloneHost(dispatcher):      # drives tick loop
    handle = server.start()
```

- Wrong type → `TypeError`.
- Called twice → `RuntimeError` (hot-swap is future work).
- Without it → server boots exactly as today (tokio `spawn_blocking` path) — fully backward compatible.

## Drive-by

`dcc-mcp-models/src/python/action_result.rs` had a stale `collapsible_if` warning behind `python-bindings` that the Rust 1.95 chore PR's `clippy --fix` didn't visit (feature gate). One-line mechanical fix included here.

## Tests

Rust (3 new in `host_bridge::tests`):
- `round_trip_forwards_string_result`
- `panic_surfaces_as_dispatch_error_json`
- `shutdown_surfaces_as_dispatch_error_json`

Python integration (5 new, `tests/test_host_http_integration.py`):
- **`test_tools_call_routes_through_dispatcher`** — main-thread affinity verified end-to-end via real HTTP: handler's `threading.get_ident()` equals `StandaloneHost._thread.ident`, not the poster's.
- `test_attach_dispatcher_rejects_second_call` — lifecycle.
- `test_attach_dispatcher_rejects_non_dispatcher_type` — type safety.
- `test_without_dispatcher_backcompat` — no-attach path unchanged.
- `test_dispatcher_shutdown_during_call_surfaces_error` — clean error, no hang.

## SOLID audit

- **SRP**: `host_bridge` is a single-purpose adapter; `attach_dispatcher` owns only lifecycle wiring; no handler logic moves.
- **OCP**: HTTP hot path consumes any `DccExecutorHandle` — zero branches added.
- **LSP**: `QueueDispatcher` / `BlockingDispatcher` / future `BlenderHost` / `MayaHost` all interchangeable as `attach_dispatcher` inputs.
- **ISP**: core `DccDispatcher` trait got **narrower** (`post<F,R>` moved to ext); HTTP-side public surface gained exactly one method.
- **DIP**: HTTP depends on `Arc<dyn DccDispatcher>` through the bridge; no HTTP code knows about concrete dispatcher types.

## Verification

```bash
cargo clippy --workspace --all-targets -- -D warnings   # clean
cargo fmt --all -- --check                              # clean
cargo hakari verify                                     # clean
cargo test -p dcc-mcp-host                              # 26/26
cargo test -p dcc-mcp-http --lib                        # 214/214
ruff check + ruff format --check                        # clean
pytest tests/test_host_http_integration.py              # 5/5
pytest tests/test_host_dispatcher.py                    # 17/17
pytest tests/test_tool_descriptions.py                  # 6/6
```

## What's next

P3 (BlenderHost) / P4 (cross-DCC verification) / P5 (Maya/Houdini/3ds Max skeletons) — tracked as GitHub issues rather than stacked PRs, per the user's request to decouple tracking from implementation cadence.