### PR TITLE
docs: add HostAdapter/StandaloneHost to llms-full.txt

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -42,6 +42,7 @@
 | Capture DCC stdout/stderr/script-editor output | `OutputCapture` |
 | Rich skill error with traceback | `skill_error_with_trace()` |
 | Skill warning / exception helpers | `skill_warning()` / `skill_exception()` |
+| Drive a DCC main-thread dispatcher (interactive/headless) | `HostAdapter` (subclass for your DCC) + `StandaloneHost` (pure-Python driver) + `QueueDispatcher` / `BlockingDispatcher` (Rust-backed primitives). Wire via `McpHttpServer.attach_dispatcher()`. See [`docs/guide/host-adapter.md`](docs/guide/host-adapter.md) |
 | Disable accumulated/evolved skills | `ENV_DISABLE_ACCUMULATED_SKILLS` |
 
 ---


### PR DESCRIPTION
## Summary

- Add \HostAdapter\, \StandaloneHost\, \QueueDispatcher\, \BlockingDispatcher\ to the Quick Decision Guide table in \llms-full.txt\$([System.Environment]::NewLine)- Help AI agents discover the main-thread dispatcher primitives
- Reference the full documentation at \docs/guide/host-adapter.md\$([System.Environment]::NewLine)
## Related

- Continuation of PR #699 (merged)
- Implements documentation for features shipped in #687, #688, #690

## Checklist

- [x] Updated \llms-full.txt\ with new API entries
- [x] Pre-commit hooks passed
- [ ] CI passes (auto-merge after CI)