### PR TITLE
Fix strict skill scanning and add ForgeCAD HTTP E2E

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,7 +713,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dcc-mcp-actions"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "dashmap",
  "dcc-mcp-models",
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-artefact"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "chrono",
  "hex",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-capture"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "image",
  "libc",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-core"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "dcc-mcp-actions",
  "dcc-mcp-artefact",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-gateway"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "axum",
  "chrono",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-host"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-http"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "axum",
  "axum-test",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-job"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "chrono",
  "dashmap",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-jsonrpc"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "serde",
  "serde_json",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-logging"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "dcc-mcp-paths",
  "parking_lot",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-models"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "dcc-mcp-naming",
  "dcc-mcp-pybridge",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-naming"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "pyo3",
  "pyo3-stub-gen",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-paths"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "dirs",
  "pyo3",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-process"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "dcc-mcp-models",
  "ipckit",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-protocols"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-pybridge"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "dcc-mcp-pybridge-derive",
  "pyo3",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-pybridge-derive"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-sandbox"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -1052,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-scheduler"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "axum",
  "bytes",
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-server"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "anyhow",
  "axum",
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-shm"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "ipckit",
  "libc",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-skill-rest"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "axum",
  "axum-test",
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-skills"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "dashmap",
  "dcc-mcp-actions",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-telemetry"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-transport"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "criterion",
  "dashmap",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-agent"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "dashmap",
  "dcc-mcp-tunnel-protocol",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-protocol"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "jsonwebtoken",
  "rmp-serde",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-relay"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "axum",
  "dashmap",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-usd"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "dcc-mcp-protocols",
  "pyo3",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-workflow"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "base64",
  "chrono",

--- a/crates/dcc-mcp-http/tests/http.rs
+++ b/crates/dcc-mcp-http/tests/http.rs
@@ -16,6 +16,9 @@ mod async_dispatch_cancel;
 #[path = "http/backend_timeout.rs"]
 mod backend_timeout;
 
+#[path = "http/forgecad_e2e.rs"]
+mod forgecad_e2e;
+
 #[path = "http/gateway_cursor_safe_names.rs"]
 mod gateway_cursor_safe_names;
 

--- a/crates/dcc-mcp-http/tests/http/forgecad_e2e.rs
+++ b/crates/dcc-mcp-http/tests/http/forgecad_e2e.rs
@@ -1,0 +1,230 @@
+//! Third-party skill ecosystem E2E coverage using a ForgeCAD-style skill.
+//!
+//! ForgeCAD publishes public `SKILL.md` packages under `skills/*`. This test
+//! keeps the CI fixture local and deterministic while preserving the public
+//! ForgeCAD metadata shape: a non-DCC-specific skill directory, a `SKILL.md`,
+//! script-backed tools, MCP progressive loading, and the REST `/v1/call` API.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use dcc_mcp_actions::{ActionDispatcher, ActionRegistry};
+use dcc_mcp_http::{McpHttpConfig, McpHttpServer};
+use dcc_mcp_skills::SkillCatalog;
+use serde_json::{Value, json};
+
+async fn wait_reachable(addr: &str) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < deadline {
+        if tokio::net::TcpStream::connect(addr).await.is_ok() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    false
+}
+
+fn write_forgecad_skill(root: &std::path::Path) {
+    let skill_dir = root.join("forgecad-make-a-model");
+    std::fs::create_dir_all(skill_dir.join("scripts")).unwrap();
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        r#"---
+name: forgecad-make-a-model
+description: Create new ForgeCAD (.forge.js) models in the active CAD project. Handles file placement, invokes the forgecad skill for API guidance, and validates the result.
+dcc: forgecad
+forgecad-public: true
+tags: [forgecad, cad, third-party]
+tools:
+  - name: create_model
+    description: Create a ForgeCAD model from a brief and return the generated file path.
+    source_file: scripts/create_model.py
+    input_schema:
+      type: object
+      properties:
+        brief:
+          type: string
+      required: [brief]
+---
+# Make a Model
+
+Create new ForgeCAD models in the user's active ForgeCAD project.
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        skill_dir.join("scripts/create_model.py"),
+        "# The E2E uses an in-process executor; this file proves source resolution.\n",
+    )
+    .unwrap();
+}
+
+async fn mcp_post(
+    client: &reqwest::Client,
+    addr: &str,
+    id: u64,
+    method: &str,
+    params: Value,
+) -> Value {
+    let resp = client
+        .post(format!("http://{addr}/mcp"))
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .header(reqwest::header::ACCEPT, "application/json")
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        }))
+        .send()
+        .await
+        .expect("MCP POST must complete");
+    assert!(
+        resp.status().is_success(),
+        "MCP POST returned {}",
+        resp.status()
+    );
+    resp.json::<Value>()
+        .await
+        .expect("MCP response must be JSON")
+}
+
+fn tool_text(response: &Value) -> &str {
+    response["result"]["content"][0]["text"]
+        .as_str()
+        .expect("tool result text")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn forgecad_skill_discovers_loads_and_calls_over_mcp_and_rest_http() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_forgecad_skill(tmp.path());
+
+    let registry = Arc::new(ActionRegistry::new());
+    let dispatcher = Arc::new(ActionDispatcher::new((*registry).clone()));
+    let catalog = Arc::new(SkillCatalog::new_with_dispatcher(
+        registry.clone(),
+        dispatcher.clone(),
+    ));
+    catalog.set_in_process_executor(|script_path, params, context| {
+        Ok(json!({
+            "success": true,
+            "ecosystem": "forgecad",
+            "script_path": script_path,
+            "action_name": context.action_name,
+            "brief": params.get("brief").and_then(Value::as_str).unwrap_or_default(),
+            "generated": "models/acceptance-test.forge.js",
+        }))
+    });
+
+    let discovered = catalog.discover(Some(&[tmp.path().to_string_lossy().to_string()]), None);
+    assert_eq!(discovered, 1, "ForgeCAD fixture should be discovered");
+
+    let server = McpHttpServer::with_catalog(registry, catalog, McpHttpConfig::new(0));
+    let handle = server.start().await.expect("server must start");
+    let addr = handle.bind_addr.clone();
+    assert!(wait_reachable(&addr).await, "server unreachable");
+
+    let client = reqwest::Client::new();
+
+    let listed_before = mcp_post(
+        &client,
+        &addr,
+        1,
+        "tools/call",
+        json!({
+            "name": "list_skills",
+            "arguments": {"status": "discovered"}
+        }),
+    )
+    .await;
+    assert!(
+        tool_text(&listed_before).contains("forgecad-make-a-model"),
+        "discovered ForgeCAD skill missing from list_skills: {listed_before}"
+    );
+
+    let loaded = mcp_post(
+        &client,
+        &addr,
+        2,
+        "tools/call",
+        json!({
+            "name": "load_skill",
+            "arguments": {"skill_name": "forgecad-make-a-model"}
+        }),
+    )
+    .await;
+    let load_text = tool_text(&loaded);
+    assert!(
+        load_text.contains("create_model"),
+        "load_skill output: {load_text}"
+    );
+
+    let tools = mcp_post(&client, &addr, 3, "tools/list", json!({})).await;
+    let tool_names: Vec<&str> = tools["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .filter_map(|tool| tool["name"].as_str())
+        .collect();
+    assert!(
+        tool_names.contains(&"create_model"),
+        "loaded ForgeCAD tool missing from tools/list: {tool_names:?}"
+    );
+
+    let called = mcp_post(
+        &client,
+        &addr,
+        4,
+        "tools/call",
+        json!({
+            "name": "create_model",
+            "arguments": {"brief": "parametric bracket"}
+        }),
+    )
+    .await;
+    let call_text = tool_text(&called);
+    assert!(
+        call_text.contains("parametric bracket"),
+        "MCP call output: {call_text}"
+    );
+    assert!(
+        call_text.contains("acceptance-test.forge.js"),
+        "MCP call output: {call_text}"
+    );
+
+    let search = client
+        .post(format!("http://{addr}/v1/search"))
+        .json(&json!({"query": "forgecad", "loaded_only": true}))
+        .send()
+        .await
+        .expect("REST search must complete");
+    assert_eq!(search.status(), 200);
+    let search_json = search.json::<Value>().await.unwrap();
+    let slug = search_json["hits"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find_map(|hit| {
+            let slug = hit["slug"].as_str()?;
+            slug.contains("forgecad-make-a-model")
+                .then_some(slug.to_string())
+        })
+        .expect("REST search should expose ForgeCAD tool slug");
+
+    let rest_call = client
+        .post(format!("http://{addr}/v1/call"))
+        .json(&json!({
+            "tool_slug": slug,
+            "params": {"brief": "rest-driven model"}
+        }))
+        .send()
+        .await
+        .expect("REST call must complete");
+    assert_eq!(rest_call.status(), 200);
+    let rest_json = rest_call.json::<Value>().await.unwrap();
+    assert_eq!(rest_json["output"]["ecosystem"], "forgecad");
+    assert_eq!(rest_json["output"]["brief"], "rest-driven model");
+
+    handle.shutdown().await;
+}

--- a/crates/dcc-mcp-skills/src/catalog/catalog_discovery.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog_discovery.rs
@@ -109,7 +109,11 @@ impl SkillCatalog {
         }
 
         if !result.skipped.is_empty() {
-            tracing::debug!("SkillCatalog: skipped {} directories", result.skipped.len());
+            tracing::warn!(
+                count = result.skipped.len(),
+                skipped = ?result.skipped,
+                "SkillCatalog: skipped invalid or non-compliant skill directories during discovery"
+            );
         }
 
         tracing::info!(
@@ -159,6 +163,15 @@ impl SkillCatalog {
                         continue;
                     }
                 };
+
+            if !result.skipped.is_empty() {
+                tracing::warn!(
+                    scope = %scope,
+                    count = result.skipped.len(),
+                    skipped = ?result.skipped,
+                    "SkillCatalog::discover_scoped: skipped invalid or non-compliant skill directories during discovery"
+                );
+            }
 
             for skill in result.skills {
                 let name = skill.name.clone();

--- a/crates/dcc-mcp-skills/src/loader/scan.rs
+++ b/crates/dcc-mcp-skills/src/loader/scan.rs
@@ -49,13 +49,33 @@ pub fn scan_and_load_strict(
     extra_paths: Option<&[String]>,
     dcc_name: Option<&str>,
 ) -> Result<LoadResult, ResolveError> {
-    let result = scan_and_load(extra_paths, dcc_name)?;
-    if !result.skipped.is_empty() {
+    let mut scanner = SkillScanner::new();
+    let dirs = scanner.scan(extra_paths, dcc_name, false);
+    let missing_skill_md = SkillScanner::scan_explicit_directories_missing_skill_md(extra_paths);
+
+    let (skills, mut skipped) = load_all_skills(&dirs);
+    let resolved = resolver::resolve_dependencies(&skills)?;
+
+    for dir in missing_skill_md {
+        if !skipped.contains(&dir) {
+            tracing::warn!(
+                directory = %dir,
+                "Strict skill scan found a directory without SKILL.md; rejecting discovery"
+            );
+            skipped.push(dir);
+        }
+    }
+
+    if !skipped.is_empty() {
         return Err(ResolveError::SkippedDirectories {
-            directories: result.skipped,
+            directories: skipped,
         });
     }
-    Ok(result)
+
+    Ok(LoadResult {
+        skills: resolved.ordered,
+        skipped,
+    })
 }
 
 /// Lenient pipeline: scan, load, and resolve dependencies but skip unresolvable skills.

--- a/crates/dcc-mcp-skills/src/loader/tests/test_scan_and_load_strict.rs
+++ b/crates/dcc-mcp-skills/src/loader/tests/test_scan_and_load_strict.rs
@@ -23,6 +23,12 @@ fn write_broken_skill(base: &std::path::Path, name: &str) {
     .unwrap();
 }
 
+fn write_directory_without_skill_md(base: &std::path::Path, name: &str) {
+    let dir = base.join(name);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("README.md"), "# Not a skill\n").unwrap();
+}
+
 #[test]
 fn strict_returns_skills_when_no_directories_skipped() {
     let tmp = tempfile::tempdir().unwrap();
@@ -55,6 +61,27 @@ fn strict_errors_on_skipped_directory() {
         crate::resolver::ResolveError::SkippedDirectories { directories } => {
             assert_eq!(directories.len(), 1, "got: {directories:?}");
             assert!(directories[0].ends_with("broken"));
+        }
+        other => panic!("expected SkippedDirectories, got {other:?}"),
+    }
+}
+
+#[test]
+fn strict_errors_on_child_directory_without_skill_md() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_skill(tmp.path(), "good");
+    write_directory_without_skill_md(tmp.path(), "missing-skill-md");
+
+    let err = crate::loader::scan_and_load_strict(
+        Some(&[tmp.path().to_string_lossy().to_string()]),
+        None,
+    )
+    .unwrap_err();
+
+    match err {
+        crate::resolver::ResolveError::SkippedDirectories { directories } => {
+            assert_eq!(directories.len(), 1, "got: {directories:?}");
+            assert!(directories[0].ends_with("missing-skill-md"));
         }
         other => panic!("expected SkippedDirectories, got {other:?}"),
     }

--- a/crates/dcc-mcp-skills/src/scanner.rs
+++ b/crates/dcc-mcp-skills/src/scanner.rs
@@ -78,6 +78,67 @@ impl SkillScanner {
         self.skill_dirs.to_vec()
     }
 
+    /// Find child directories under explicit search paths that cannot be
+    /// loaded because they do not contain `SKILL.md`.
+    pub(crate) fn scan_explicit_directories_missing_skill_md(
+        extra_paths: Option<&[String]>,
+    ) -> Vec<String> {
+        let Some(extra_paths) = extra_paths else {
+            return Vec::new();
+        };
+        let mut seen = HashSet::new();
+        let unique_paths: Vec<String> = extra_paths
+            .iter()
+            .filter(|p| {
+                let abs = std::fs::canonicalize(p).unwrap_or_else(|e| {
+                    tracing::debug!("canonicalize({p:?}) failed ({e}), using raw path for dedup");
+                    PathBuf::from(p)
+                });
+                seen.insert(path_to_string(&abs))
+            })
+            .cloned()
+            .collect();
+        let mut missing = Vec::new();
+
+        for search_path in &unique_paths {
+            let path = Path::new(search_path);
+            if !path.is_dir() || path.join(SKILL_METADATA_FILE).is_file() {
+                continue;
+            }
+
+            let entries = match std::fs::read_dir(path) {
+                Ok(e) => e,
+                Err(e) => {
+                    tracing::warn!("Error scanning directory {}: {}", search_path, e);
+                    continue;
+                }
+            };
+
+            for entry in entries.filter_map(|e| match e {
+                Ok(entry) => Some(entry),
+                Err(err) => {
+                    tracing::warn!("Skipping unreadable entry in {search_path}: {err}");
+                    None
+                }
+            }) {
+                let ft = match entry.file_type() {
+                    Ok(ft) => ft,
+                    Err(_) => continue,
+                };
+                if !ft.is_dir() {
+                    continue;
+                }
+
+                let entry_path = entry.path();
+                if !entry_path.join(SKILL_METADATA_FILE).is_file() {
+                    missing.push(path_to_string(&entry_path));
+                }
+            }
+        }
+
+        missing
+    }
+
     /// Collect and deduplicate all skill search paths from various sources.
     ///
     /// Priority order (highest → lowest):

--- a/tests/test_forgecad_skill_ecosystem.py
+++ b/tests/test_forgecad_skill_ecosystem.py
@@ -1,0 +1,140 @@
+"""Python-side ForgeCAD skill ecosystem acceptance coverage."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import urllib.request
+
+from dcc_mcp_core import McpHttpConfig
+from dcc_mcp_core import McpHttpServer
+from dcc_mcp_core import ToolRegistry
+from dcc_mcp_core import scan_and_load
+
+FORGECAD_SKILL = "forgecad-make-a-model"
+FORGECAD_TOOL = "create_model"
+
+
+def _write_forgecad_skill(root: Path) -> None:
+    skill_dir = root / FORGECAD_SKILL
+    (skill_dir / "scripts").mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: forgecad-make-a-model
+description: Create new ForgeCAD (.forge.js) models in the active CAD project. Handles file placement, invokes the forgecad skill for API guidance, and validates the result.
+dcc: forgecad
+forgecad-public: true
+tags: [forgecad, cad, third-party]
+tools:
+  - name: create_model
+    description: Create a ForgeCAD model from a brief and return the generated file path.
+    source_file: scripts/create_model.py
+    input_schema:
+      type: object
+      properties:
+        brief:
+          type: string
+      required: [brief]
+---
+# Make a Model
+
+Create new ForgeCAD models in the user's active ForgeCAD project.
+""",
+        encoding="utf-8",
+    )
+    (skill_dir / "scripts" / "create_model.py").write_text(
+        "# Python E2E uses in-process execution; this file proves source resolution.\n",
+        encoding="utf-8",
+    )
+
+
+def _post_json(url: str, payload: dict) -> dict:
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        assert resp.status == 200
+        return json.loads(resp.read())
+
+
+def _mcp_post(mcp_url: str, method: str, params: dict | None = None, rpc_id: int = 1) -> dict:
+    body = {"jsonrpc": "2.0", "id": rpc_id, "method": method}
+    if params is not None:
+        body["params"] = params
+    return _post_json(mcp_url, body)
+
+
+def _tool_text(response: dict) -> str:
+    return response["result"]["content"][0]["text"]
+
+
+def test_python_forgecad_skill_discovers_loads_and_calls_over_mcp_and_rest_http(tmp_path: Path) -> None:
+    _write_forgecad_skill(tmp_path)
+
+    skills, skipped = scan_and_load(extra_paths=[str(tmp_path)])
+    assert skipped == []
+    forgecad = next(skill for skill in skills if skill.name == FORGECAD_SKILL)
+    assert forgecad.dcc == "forgecad"
+    assert [tool.name for tool in forgecad.tools] == [FORGECAD_TOOL]
+
+    server = McpHttpServer(ToolRegistry(), McpHttpConfig(port=0, server_name="forgecad-python-e2e"))
+
+    def executor(script_path: str, params: dict, **context: object) -> dict:
+        return {
+            "success": True,
+            "ecosystem": "forgecad",
+            "script_path": script_path,
+            "action_name": context["action_name"],
+            "brief": params.get("brief", ""),
+            "generated": "models/python-acceptance-test.forge.js",
+        }
+
+    server.set_in_process_executor(executor)
+    assert server.discover(extra_paths=[str(tmp_path)]) == 1
+
+    handle = server.start()
+    try:
+        mcp_url = handle.mcp_url()
+        rest_url = mcp_url.removesuffix("/mcp")
+
+        listed = _mcp_post(
+            mcp_url,
+            "tools/call",
+            {"name": "list_skills", "arguments": {"status": "discovered"}},
+            rpc_id=1,
+        )
+        assert FORGECAD_SKILL in _tool_text(listed)
+
+        loaded = _mcp_post(
+            mcp_url,
+            "tools/call",
+            {"name": "load_skill", "arguments": {"skill_name": FORGECAD_SKILL}},
+            rpc_id=2,
+        )
+        assert FORGECAD_TOOL in _tool_text(loaded)
+
+        tools = _mcp_post(mcp_url, "tools/list", rpc_id=3)["result"]["tools"]
+        assert FORGECAD_TOOL in {tool["name"] for tool in tools}
+
+        called = _mcp_post(
+            mcp_url,
+            "tools/call",
+            {"name": FORGECAD_TOOL, "arguments": {"brief": "python bracket"}},
+            rpc_id=4,
+        )
+        assert "python bracket" in _tool_text(called)
+        assert "python-acceptance-test.forge.js" in _tool_text(called)
+
+        search = _post_json(f"{rest_url}/v1/search", {"query": "forgecad", "loaded_only": True})
+        slug = next(hit["slug"] for hit in search["hits"] if hit["skill"] == FORGECAD_SKILL)
+        rest_call = _post_json(
+            f"{rest_url}/v1/call",
+            {"tool_slug": slug, "params": {"brief": "rest python model"}},
+        )
+        assert rest_call["output"]["ecosystem"] == "forgecad"
+        assert rest_call["output"]["brief"] == "rest python model"
+    finally:
+        handle.shutdown()


### PR DESCRIPTION
## Summary

- make `scan_and_load_strict` reject explicit child directories that are missing `SKILL.md`
- warn with skipped skill directory paths from catalog discovery for service-log debugging
- add Python-first deterministic ForgeCAD-style third-party ecosystem E2E coverage across Python bindings, MCP load/call, and REST HTTP `/v1/call`
- add matching Rust HTTP E2E coverage for the same ForgeCAD-style skill flow
- sync `Cargo.lock` workspace package versions to 0.14.24 as required by the pre-commit hook

## Validation

- `cargo test -p dcc-mcp-skills`
- `cargo test -p dcc-mcp-http --test http`
- `pytest tests/test_forgecad_skill_ecosystem.py -v`
- pre-commit hooks: `ruff`, `ruff format`, `cargo fmt`, `cargo clippy`, `cargo hakari generate`

Closes #701
Closes #702
Refs #703
Refs #705
