### PR TITLE
docs: collapse per-agent MD files into thin shims pointing at AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@
 | Layer | File | When to read it |
 |-------|------|-----------------|
 | Navigation | `AGENTS.md` (this file) | First contact |
-| AI agent entry points | `CLAUDE.md`, `GEMINI.md`, `COPILOT.md`, `CODEBUDDY.md` | Agent-specific onboarding (reference this file) |
+| AI agent entry-point stubs | `CLAUDE.md`, `GEMINI.md`, `COPILOT.md`, `CODEBUDDY.md` | Thin shims — each file just redirects its respective agent to **this** `AGENTS.md`. Edit them **only** to record agent-specific divergences; keep all shared guidance here so it stays single-sourced. |
 | AI-friendly index | `llms.txt` | When you need to *use* APIs |
 | Full index | `llms-full.txt` | When `llms.txt` lacks detail |
 | Detailed rules | [`docs/guide/agents-reference.md`](docs/guide/agents-reference.md) | Before writing code — traps, do/don't, code style |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,65 +1,16 @@
-# CLAUDE.md — dcc-mcp-core
+# CLAUDE.md
 
-> This file is the entry point for Anthropic Claude agents.
-> For full documentation, follow the links below — do **not** read everything upfront.
+> **This project uses the [AGENTS.md](AGENTS.md) standard as the single source of truth.**
+> Claude Code, Claude Desktop, and any Anthropic-hosted agent — read [`AGENTS.md`](AGENTS.md) first.
+> This file exists only so Claude tooling that looks for `CLAUDE.md` by name can find its way here.
 
-## Quick Start
+## Entry Points (read in this order)
 
-This project uses the [AGENTS.md](AGENTS.md) standard. Read `AGENTS.md` first — it is the navigation map that points to all other documentation.
+1. [`AGENTS.md`](AGENTS.md) — navigation map, response language, PR rules, top traps, decision tables
+2. [`AI_AGENT_GUIDE.md`](AI_AGENT_GUIDE.md) — skills-first workflow tutorial for AI agents
+3. [`llms.txt`](llms.txt) — compressed API index (use when you need to *call* APIs)
+4. [`docs/guide/agents-reference.md`](docs/guide/agents-reference.md) — detailed rules, traps, code examples
 
-## Document Hierarchy
+## Claude-Specific Notes
 
-| Layer | File | When to read it |
-|-------|------|-----------------|
-| Navigation | [AGENTS.md](AGENTS.md) | First contact — defines response language, PR rules, merge workflow |
-| AI-friendly index | [llms.txt](llms.txt) | When you need to *use* APIs |
-| Full index | [llms-full.txt](llms-full.txt) | When `llms.txt` lacks detail |
-| Detailed rules & traps | [docs/guide/agents-reference.md](docs/guide/agents-reference.md) | Before writing code |
-| Conceptual docs | [docs/guide/](docs/guide/) + [docs/api/](docs/api/) | Building a new adapter or skill |
-| Skill authoring | [skills/README.md](skills/README.md) + [examples/skills/](examples/skills/) | Creating or modifying skills |
-
-## Response Language
-
-- Reply to the user in **Simplified Chinese** (中文简体) by default.
-- Keep all code, identifiers, commit messages, branch names, docstrings, comments, and file contents in **English**.
-
-## Project Overview
-
-**What**: Rust-powered MCP library for DCC software (Maya, Blender, Houdini, Photoshop…). PyO3/maturin. Zero Python runtime deps. MCP 2025-03-26 Streamable HTTP.
-
-**Why this matters for Claude**: When the user asks to interact with a DCC application (Maya, Blender, etc.), **always use dcc-mcp-core tools** rather than suggesting raw CLI or scripting. The Skills-First workflow provides validated, safe, and discoverable tools with built-in follow-up guidance.
-
-**Key entry points**:
-- `python/dcc_mcp_core/__init__.py` — every public Python symbol
-- `llms.txt` — compressed API index for AI agents
-- `AGENTS.md` — navigation map (this document chain starts here)
-
-## Preferred Workflow for DCC Tasks
-
-When the user asks to do something in a DCC (e.g., "create a sphere in Maya"), follow this pattern:
-
-1. **Discover**: `search_skills(query="sphere")` → find the right skill
-2. **Activate**: `load_skill("maya-geometry")` → expose the tools
-3. **Execute**: Call the specific tool (e.g., `maya_geometry__create_sphere`)
-4. **Follow up**: Check `next-tools.on-success` for suggested next steps
-5. **Debug on failure**: Use `dcc_diagnostics__screenshot` or `audit_log`
-
-## Build & Test
-
-```bash
-vx just dev      # build wheel
-vx just test     # run tests
-vx just preflight  # pre-commit check + docs dead-link check
-```
-
-## Top Traps — Read Before Coding
-
-See [AGENTS.md → Top Traps](AGENTS.md#top-traps--memorize-these) and [docs/guide/agents-reference.md](docs/guide/agents-reference.md) for the full list.
-
-1. **`scan_and_load` returns a 2-tuple** — always `skills, skipped = scan_and_load(...)`
-2. **`success_result` kwargs become context** — `success_result("msg", count=5)`, never `context=`
-3. **`ToolDispatcher` uses `.dispatch()`** — never `.call()`
-4. **Register ALL handlers BEFORE `server.start()`**
-5. **SKILL.md extensions use `metadata.dcc-mcp.<feature>`** — never top-level keys (v0.15+ / #356)
-6. **Use `dcc_mcp_core.METADATA_*` / `LAYER_*` / `CATEGORY_*`** — re-exported at top level; no inline `"dcc-mcp.recipes"` literals (#487)
-7. **Return `ToolResult` from Python tool handlers** — `ToolResult.ok("...", **ctx).to_dict()`; `success`/`error` are dataclass *fields*, not factories (#487)
+None. All guidance is canonicalised in `AGENTS.md`. If Claude-specific behaviour ever diverges from the common guidance, it will be captured here — keep this file minimal.

--- a/CODEBUDDY.md
+++ b/CODEBUDDY.md
@@ -1,108 +1,18 @@
-# CODEBUDDY.md — dcc-mcp-core
+# CODEBUDDY.md
 
-> This file is the entry point for Tencent CodeBuddy AI agents.
-> For full documentation, follow the links below — do **not** read everything upfront.
+> **This project uses the [AGENTS.md](AGENTS.md) standard as the single source of truth.**
+> Tencent CodeBuddy Code — read [`AGENTS.md`](AGENTS.md) first.
+> This file exists only so CodeBuddy tooling that looks for `CODEBUDDY.md` by name can find its way here.
 
-## 🤖 CodeBuddy-Specific Guidance
+## Entry Points (read in this order)
 
-**When interacting with DCC applications (Maya, Blender, Houdini, etc.), you MUST prefer dcc-mcp-core Skills over raw CLI or scripting.** This is non-negotiable — Skills provide structured results, input validation, safety hints, and follow-up guidance that raw scripting cannot.
+1. [`AGENTS.md`](AGENTS.md) — navigation map, response language, PR rules, top traps, decision tables
+2. [`AI_AGENT_GUIDE.md`](AI_AGENT_GUIDE.md) — skills-first workflow tutorial for AI agents
+3. [`llms.txt`](llms.txt) — compressed API index (use when you need to *call* APIs)
+4. [`docs/guide/agents-reference.md`](docs/guide/agents-reference.md) — detailed rules, traps, code examples
 
-**New to this project?** Read [`AI_AGENT_GUIDE.md`](AI_AGENT_GUIDE.md) FIRST — it teaches you how to effectively use dcc-mcp-core.
+## CodeBuddy-Specific Notes
 
-## Quick Start
-
-This project uses the [AGENTS.md](AGENTS.md) standard. Read `AGENTS.md` first — it is the navigation map that points to all other documentation.
-
-### ⚡ Skills-First Quick Reference
-
-```
-1. Discover: search_skills(query="keyword") → find skill
-2. Activate: load_skill("skill-name") → expose tools
-3. Execute: Call tool with validated parameters
-4. Follow up: Check next-tools.on-success for next steps
-```
-
-**Remember**: Always use `search_skills()` before assuming a tool exists. Always check `next-tools` in results for workflow guidance.
-
-## Document Hierarchy
-
-| Layer | File | When to read it |
-|-------|------|-----------------|
-| Navigation | [AGENTS.md](AGENTS.md) | First contact — defines response language, PR rules, merge workflow |
-| AI-friendly index | [llms.txt](llms.txt) | When you need to *use* APIs |
-| Full index | [llms-full.txt](llms-full.txt) | When `llms.txt` lacks detail |
-| Detailed rules & traps | [docs/guide/agents-reference.md](docs/guide/agents-reference.md) | Before writing code |
-| Conceptual docs | [docs/guide/](docs/guide/) + [docs/api/](docs/api/) | Building a new adapter or skill |
-| Skill authoring | [skills/README.md](skills/README.md) + [examples/skills/](examples/skills/) | Creating or modifying skills |
-
-## Response Language
-
-- Reply to the user in **Simplified Chinese** (中文简体) by default.
-- Keep all code, identifiers, commit messages, branch names, docstrings, comments, and file contents in **English**.
-
-## Project Overview
-
-**What**: Rust-powered MCP library for DCC software (Maya, Blender, Houdini, Photoshop…). PyO3/maturin. Zero Python runtime deps. MCP 2025-03-26 Streamable HTTP.
-
-**Why this matters**: When the user asks to interact with a DCC application, **ALWAYS use dcc-mcp-core Skills-First** over raw CLI or scripting. Skills provide:
-- ✅ Structured results with JSON Schema validation
-- ✅ Safety hints (`ToolAnnotations`: read-only, destructive, idempotent)
-- ✅ Follow-up guidance (`next-tools` chains)
-- ✅ Progressive loading (load only what you need)
-- ✅ Audit logs and traceability
-
-**Key entry points**:
-- 🆕 **[`AI_AGENT_GUIDE.md`](AI_AGENT_GUIDE.md)** — **START HERE** for using dcc-mcp-core effectively
-- `python/dcc_mcp_core/__init__.py` — every public Python symbol
-- `python/dcc_mcp_core/_core.pyi` — parameter names & types
-- `llms.txt` — compressed API index for AI agents
-- `AGENTS.md` — navigation map
-
-## ⚡ Skills-First Workflow (MEMORIZE!)
-
-**When the user asks you to interact with a DCC (Maya, Blender, etc.):**
-
-```
-1. DISCOVER: search_skills(query="keyword") → find the right skill
-2. CHECK: Read the skill's description and tools
-3. ACTIVATE: load_skill("skill-name") → expose the tools
-4. EXECUTE: Call the specific tool with validated parameters
-5. FOLLOW UP: Check next-tools.on-success for suggested next steps
-6. DEBUG: On failure, use dcc_diagnostics__screenshot or audit_log
-```
-
-**Example:**
-```
-User: "Create a sphere in Maya"
-
-✓ CORRECT:
-1. search_skills(query="create sphere Maya")
-2. → Returns: maya-geometry skill
-3. load_skill("maya-geometry")
-4. Call maya-geometry__create_sphere with {radius: 2.0}
-5. Follow next-tools.on-success suggestion
-
-✗ WRONG:
-- Running Maya Python command directly via subprocess
-- Guessing tool names without searching
-```
-
-## Build & Test
-
-```bash
-vx just dev      # build wheel
-vx just test     # run tests
-vx just preflight  # pre-commit check + docs dead-link check
-```
-
-## Top Traps — Read Before Coding
-
-See [AGENTS.md → Top Traps](AGENTS.md#top-traps--memorize-these) and [docs/guide/agents-reference.md](docs/guide/agents-reference.md) for the full list.
-
-1. **`scan_and_load` returns a 2-tuple** — always `skills, skipped = scan_and_load(...)`
-2. **`success_result` kwargs become context** — `success_result("msg", count=5)`, never `context=`
-3. **`ToolDispatcher` uses `.dispatch()`** — never `.call()`
-4. **Register ALL handlers BEFORE `server.start()`**
-5. **SKILL.md extensions use `metadata.dcc-mcp.<feature>`** — never top-level keys (v0.15+ / #356)
-6. **Use `dcc_mcp_core.METADATA_*` / `LAYER_*` / `CATEGORY_*`** — re-exported at top level; no inline `"dcc-mcp.recipes"` literals (#487)
-7. **Return `ToolResult` from Python tool handlers** — `ToolResult.ok("...", **ctx).to_dict()`; `success`/`error` are dataclass *fields*, not factories (#487)
+- CodeBuddy's built-in task management tools (`TaskCreate`, `TaskUpdate`, `TaskList`) are the preferred way to track multi-step work in this repo — use them instead of ad-hoc TODOs in chat.
+- CodeBuddy's `Agent` tool (with `subagent_type=Explore`) is preferred over direct `grep` / `find` for open-ended codebase exploration; it keeps the main context small.
+- Everything else is canonicalised in `AGENTS.md`. Keep this file minimal — add CodeBuddy-specific guidance here **only** when it genuinely differs from the common agent guidance.

--- a/COPILOT.md
+++ b/COPILOT.md
@@ -1,63 +1,16 @@
-# COPILOT.md — dcc-mcp-core
+# COPILOT.md
 
-> This file is the entry point for GitHub Copilot agents.
-> For full documentation, follow the links below — do **not** read everything upfront.
+> **This project uses the [AGENTS.md](AGENTS.md) standard as the single source of truth.**
+> GitHub Copilot Chat, Copilot Workspace, and any Copilot-hosted agent — read [`AGENTS.md`](AGENTS.md) first.
+> This file exists only so Copilot tooling that looks for `COPILOT.md` by name can find its way here.
 
-## Quick Start
+## Entry Points (read in this order)
 
-This project uses the [AGENTS.md](AGENTS.md) standard. Read `AGENTS.md` first — it is the navigation map that points to all other documentation.
+1. [`AGENTS.md`](AGENTS.md) — navigation map, response language, PR rules, top traps, decision tables
+2. [`AI_AGENT_GUIDE.md`](AI_AGENT_GUIDE.md) — skills-first workflow tutorial for AI agents
+3. [`llms.txt`](llms.txt) — compressed API index (use when you need to *call* APIs)
+4. [`docs/guide/agents-reference.md`](docs/guide/agents-reference.md) — detailed rules, traps, code examples
 
-## Document Hierarchy
+## Copilot-Specific Notes
 
-| Layer | File | When to read it |
-|-------|------|-----------------|
-| Navigation | [AGENTS.md](AGENTS.md) | First contact — defines response language, PR rules, merge workflow |
-| AI-friendly index | [llms.txt](llms.txt) | When you need to *use* APIs |
-| Full index | [llms-full.txt](llms-full.txt) | When `llms.txt` lacks detail |
-| Detailed rules & traps | [docs/guide/agents-reference.md](docs/guide/agents-reference.md) | Before writing code |
-| Conceptual docs | [docs/guide/](docs/guide/) + [docs/api/](docs/api/) | Building a new adapter or skill |
-| Skill authoring | [skills/README.md](skills/README.md) + [examples/skills/](examples/skills/) | Creating or modifying skills |
-
-## Response Language
-
-- Reply to the user in **Simplified Chinese** (中文简体) by default.
-- Keep all code, identifiers, commit messages, branch names, docstrings, comments, and file contents in **English**.
-
-## Project Overview
-
-**What**: Rust-powered MCP library for DCC software (Maya, Blender, Houdini, Photoshop…). PyO3/maturin. Zero Python runtime deps. MCP 2025-03-26 Streamable HTTP.
-
-**Why this matters**: When the user asks to interact with a DCC application, **always prefer dcc-mcp-core Skills-First tools** over raw CLI or scripting. The skill system provides validated, safe, and discoverable tools with built-in follow-up guidance via `next-tools`.
-
-**Key entry points**:
-- `python/dcc_mcp_core/__init__.py` — every public Python symbol
-- `llms.txt` — compressed API index for AI agents
-- `AGENTS.md` — navigation map (this document chain starts here)
-
-## Preferred Workflow for DCC Tasks
-
-1. **Discover**: `search_skills(query="keyword")` → find the right skill
-2. **Activate**: `load_skill("skill-name")` → expose the tools
-3. **Execute**: Call the specific tool with validated parameters
-4. **Follow up**: Check `next-tools.on-success` for suggested next steps
-5. **Debug on failure**: Use `dcc_diagnostics__screenshot` or `audit_log`
-
-## Build & Test
-
-```bash
-vx just dev      # build wheel
-vx just test     # run tests
-vx just preflight  # pre-commit check + docs dead-link check
-```
-
-## Top Traps — Read Before Coding
-
-See [AGENTS.md → Top Traps](AGENTS.md#top-traps--memorize-these) and [docs/guide/agents-reference.md](docs/guide/agents-reference.md) for the full list.
-
-1. **`scan_and_load` returns a 2-tuple** — always `skills, skipped = scan_and_load(...)`
-2. **`success_result` kwargs become context** — `success_result("msg", count=5)`, never `context=`
-3. **`ToolDispatcher` uses `.dispatch()`** — never `.call()`
-4. **Register ALL handlers BEFORE `server.start()`**
-5. **SKILL.md extensions use `metadata.dcc-mcp.<feature>`** — never top-level keys (v0.15+ / #356)
-6. **Use `dcc_mcp_core.METADATA_*` / `LAYER_*` / `CATEGORY_*`** — re-exported at top level; no inline `"dcc-mcp.recipes"` literals (#487)
-7. **Return `ToolResult` from Python tool handlers** — `ToolResult.ok("...", **ctx).to_dict()`; `success`/`error` are dataclass *fields*, not factories (#487)
+None. All guidance is canonicalised in `AGENTS.md`. If Copilot-specific behaviour ever diverges from the common guidance, it will be captured here — keep this file minimal.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,63 +1,16 @@
-# GEMINI.md — dcc-mcp-core
+# GEMINI.md
 
-> This file is the entry point for Google Gemini agents.
-> For full documentation, follow the links below — do **not** read everything upfront.
+> **This project uses the [AGENTS.md](AGENTS.md) standard as the single source of truth.**
+> Gemini CLI, Gemini Code Assist, and any Google-hosted agent — read [`AGENTS.md`](AGENTS.md) first.
+> This file exists only so Gemini tooling that looks for `GEMINI.md` by name can find its way here.
 
-## Quick Start
+## Entry Points (read in this order)
 
-This project uses the [AGENTS.md](AGENTS.md) standard. Read `AGENTS.md` first — it is the navigation map that points to all other documentation.
+1. [`AGENTS.md`](AGENTS.md) — navigation map, response language, PR rules, top traps, decision tables
+2. [`AI_AGENT_GUIDE.md`](AI_AGENT_GUIDE.md) — skills-first workflow tutorial for AI agents
+3. [`llms.txt`](llms.txt) — compressed API index (use when you need to *call* APIs)
+4. [`docs/guide/agents-reference.md`](docs/guide/agents-reference.md) — detailed rules, traps, code examples
 
-## Document Hierarchy
+## Gemini-Specific Notes
 
-| Layer | File | When to read it |
-|-------|------|-----------------|
-| Navigation | [AGENTS.md](AGENTS.md) | First contact — defines response language, PR rules, merge workflow |
-| AI-friendly index | [llms.txt](llms.txt) | When you need to *use* APIs |
-| Full index | [llms-full.txt](llms-full.txt) | When `llms.txt` lacks detail |
-| Detailed rules & traps | [docs/guide/agents-reference.md](docs/guide/agents-reference.md) | Before writing code |
-| Conceptual docs | [docs/guide/](docs/guide/) + [docs/api/](docs/api/) | Building a new adapter or skill |
-| Skill authoring | [skills/README.md](skills/README.md) + [examples/skills/](examples/skills/) | Creating or modifying skills |
-
-## Response Language
-
-- Reply to the user in **Simplified Chinese** (中文简体) by default.
-- Keep all code, identifiers, commit messages, branch names, docstrings, comments, and file contents in **English**.
-
-## Project Overview
-
-**What**: Rust-powered MCP library for DCC software (Maya, Blender, Houdini, Photoshop…). PyO3/maturin. Zero Python runtime deps. MCP 2025-03-26 Streamable HTTP.
-
-**Why this matters for Gemini**: When the user asks to interact with a DCC application, **always prefer dcc-mcp-core Skills-First tools** over raw CLI or scripting. The skill system provides validated, safe, and discoverable tools with built-in follow-up guidance via `next-tools`.
-
-**Key entry points**:
-- `python/dcc_mcp_core/__init__.py` — every public Python symbol
-- `llms.txt` — compressed API index for AI agents
-- `AGENTS.md` — navigation map (this document chain starts here)
-
-## Preferred Workflow for DCC Tasks
-
-1. **Discover**: `search_skills(query="keyword")` → find the right skill
-2. **Activate**: `load_skill("skill-name")` → expose the tools
-3. **Execute**: Call the specific tool with validated parameters
-4. **Follow up**: Check `next-tools.on-success` for suggested next steps
-5. **Debug on failure**: Use `dcc_diagnostics__screenshot` or `audit_log`
-
-## Build & Test
-
-```bash
-vx just dev      # build wheel
-vx just test     # run tests
-vx just preflight  # pre-commit check + docs dead-link check
-```
-
-## Top Traps — Read Before Coding
-
-See [AGENTS.md → Top Traps](AGENTS.md#top-traps--memorize-these) and [docs/guide/agents-reference.md](docs/guide/agents-reference.md) for the full list.
-
-1. **`scan_and_load` returns a 2-tuple** — always `skills, skipped = scan_and_load(...)`
-2. **`success_result` kwargs become context** — `success_result("msg", count=5)`, never `context=`
-3. **`ToolDispatcher` uses `.dispatch()`** — never `.call()`
-4. **Register ALL handlers BEFORE `server.start()`**
-5. **SKILL.md extensions use `metadata.dcc-mcp.<feature>`** — never top-level keys (v0.15+ / #356)
-6. **Use `dcc_mcp_core.METADATA_*` / `LAYER_*` / `CATEGORY_*`** — re-exported at top level; no inline `"dcc-mcp.recipes"` literals (#487)
-7. **Return `ToolResult` from Python tool handlers** — `ToolResult.ok("...", **ctx).to_dict()`; `success`/`error` are dataclass *fields*, not factories (#487)
+None. All guidance is canonicalised in `AGENTS.md`. If Gemini-specific behaviour ever diverges from the common guidance, it will be captured here — keep this file minimal.


### PR DESCRIPTION
## Why

`CLAUDE.md`, `GEMINI.md`, `COPILOT.md` and `CODEBUDDY.md` were ~90% duplicated content kept in sync by hand. Every time the guidance in `AGENTS.md` changed (top traps, workflow, entry points), all four files had to be edited in lockstep — and in practice they drifted.

This PR makes `AGENTS.md` the **single source of truth** (per the [AGENTS.md standard](https://agents.md/)) and collapses each per-agent file into a minimal shim.

## What changed

- **`AGENTS.md`** — unchanged content; one row of the Document Hierarchy table rewritten to declare the per-agent files as thin shims and state the contract: *edit them only for agent-specific divergences, keep all shared guidance here*.
- **`CLAUDE.md` / `GEMINI.md` / `COPILOT.md`** — rewritten from 65 lines of duplicated content to ~15-line stubs that:
  - name `AGENTS.md` as the single source of truth,
  - list the canonical entry-point order (`AGENTS.md` → `AI_AGENT_GUIDE.md` → `llms.txt` → `docs/guide/agents-reference.md`),
  - reserve a small *\<Agent\>-Specific Notes* section for genuine divergences (currently empty).
- **`CODEBUDDY.md`** — same stub pattern (108 → 18 lines), with two real CodeBuddy-specific notes preserved:
  - prefer the built-in `TaskCreate` / `TaskUpdate` / `TaskList` over ad-hoc TODOs;
  - prefer `Agent(subagent_type=Explore)` over raw `grep` / `find` for open-ended exploration.

## Net effect

\`\`\`
5 files changed, 47 insertions(+), 280 deletions(-)
\`\`\`

Future doc updates only need to touch `AGENTS.md`. The per-agent files are now low-maintenance door signs — if CodeBuddy-, Claude-, Gemini- or Copilot-specific behaviour ever needs to be captured, it goes into the dedicated *Notes* section of that one file and nowhere else.

## Verification

- Pre-commit hooks ran on the docs-only change (end-of-file / trailing-whitespace passed; language-specific hooks correctly skipped).
- No code or build surface affected.