### PR TITLE
fix(release-please): add x-release-please-version marker to llms.txt

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -161,7 +161,7 @@ meta = dcc_mcp_core.parse_skill_md(dirs[0])  # -> SkillMetadata or None
 - Build from source: `maturin develop --features python-bindings,ext-module`
 - Python: >=3.7 (CI tests 3.7–3.13; abi3-py38 wheel for 3.8+)
 - Build: maturin (Rust 1.85+ + PyO3)
-- Version: 0.14.23
+- Version: 0.14.25 <!-- x-release-please-version -->
 - License: MIT
 
 ## Architecture


### PR DESCRIPTION
## Problem

`llms.txt` line 164 has been silently drifting behind every release:

\`\`\`
- Version: 0.14.23      ← llms.txt
- Version: 0.14.25      ← Cargo.toml, pyproject.toml, SKILL.md, docs, …
\`\`\`

The file **is** listed as a \`generic\` extra-file in [\`release-please-config.json\`](https://github.com/loonghao/dcc-mcp-core/blob/main/release-please-config.json), but release-please's generic updater only rewrites lines that carry an inline \`x-release-please-version\` marker. \`llms.txt\` never had one, so every release-please PR skipped it without error, and the file fell two releases behind.

## Fix

Add the marker to the \`Version:\` line and bring the stale value up to the current release:

\`\`\`diff
-- Version: 0.14.23
+- Version: 0.14.25 <!-- x-release-please-version -->
\`\`\`

HTML-comment form matches the convention already used in \`docs/guide/what-is-dcc-mcp-core.md\` and \`docs/zh/guide/what-is-dcc-mcp-core.md\`. Invisible in any rendered view; visible to release-please's regex.

Future release-please runs will now update this line automatically alongside \`Cargo.toml\`, \`pyproject.toml\`, etc.

## Audit of other version-hardcoded locations

As part of this fix I scanned the repo for other files that pin the project version. All of these **already** have the marker — no change needed:

| File | Marker form |
|------|-------------|
| \`Cargo.toml\` | \`# x-release-please-version\` |
| \`pyproject.toml\` | \`# x-release-please-version\` |
| \`.agents/skills/dcc-mcp-core/SKILL.md\` | \`# x-release-please-version\` |
| \`docs/.vitepress/config.mts\` (×2) | \`// x-release-please-version\` |
| \`docs/guide/what-is-dcc-mcp-core.md\` | \`<!-- x-release-please-version -->\` |
| \`docs/zh/guide/what-is-dcc-mcp-core.md\` | \`<!-- x-release-please-version -->\` |

Verified there are **no** hardcoded version strings in:

- \`README.md\` / \`README_zh.md\` — use dynamic PyPI badges only
- \`AGENTS.md\` / \`AI_AGENT_GUIDE.md\` / \`CLAUDE.md\` / \`GEMINI.md\` / \`COPILOT.md\` / \`CODEBUDDY.md\` — no version strings
- \`llms-full.txt\` — no \`Version:\` line
- \`python/dcc_mcp_core/__init__.py\` — \`__version__\` is derived from \`_core\` at runtime

So \`llms.txt\` was the only gap.

## Verification

- Pre-commit hooks ran on the docs-only change (passed / correctly skipped).
- Marker format confirmed against [release-please generic updater docs](https://github.com/googleapis/release-please/blob/main/docs/customizing.md): any occurrence of \`x-release-please-version\` on the same line is sufficient; the HTML-comment wrapping is purely cosmetic.