### PR TITLE
fix(tests): py3.8 removesuffix compat + startup version banner

### DIFF
--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -54,6 +54,7 @@ import contextlib
 import logging
 import os
 from pathlib import Path
+import sys
 from typing import Any
 
 # NOTE: dcc_mcp_core imports (McpHttpConfig, create_skill_server, get_*,
@@ -206,6 +207,18 @@ class DccServerBase:
         # Start as early as possible so that config / skill-scan errors land in
         # the log file, not just on stderr (which most DCCs swallow).
         self._log_dir: str = self._init_file_logging(dcc_name)
+
+        # Emit a single version banner so CI logs and user bug reports always
+        # identify the dcc-mcp-core release in use (pid/platform included to
+        # disambiguate multi-process DCCs like Maya + mayapy subprocesses).
+        logger.info(
+            "[%s] dcc-mcp-core %s (pid=%d, python=%s, platform=%s)",
+            dcc_name,
+            _pkg_version,
+            self._dcc_pid,
+            "{}.{}.{}".format(*sys.version_info[:3]),
+            sys.platform,
+        )
 
         # Build McpHttpConfig — port must be passed at construction time (read-only after init)
         self._config = McpHttpConfig(

--- a/tests/test_forgecad_skill_ecosystem.py
+++ b/tests/test_forgecad_skill_ecosystem.py
@@ -98,7 +98,7 @@ def test_python_forgecad_skill_discovers_loads_and_calls_over_mcp_and_rest_http(
     handle = server.start()
     try:
         mcp_url = handle.mcp_url()
-        rest_url = mcp_url.removesuffix("/mcp")
+        rest_url = mcp_url[: -len("/mcp")] if mcp_url.endswith("/mcp") else mcp_url
 
         listed = _mcp_post(
             mcp_url,


### PR DESCRIPTION
## Summary

Two small, independent fixes surfaced while reviewing recent CI runs.

### 1. Fix py3.8 CI matrix failure — `str.removesuffix`
Run [25270580058](https://github.com/loonghao/dcc-mcp-core/actions/runs/25270580058) failed on `Test (ubuntu-latest, py3.8)` and `Test (windows-latest, py3.8)` with:

```
FAILED tests/test_forgecad_skill_ecosystem.py::test_python_forgecad_skill_discovers_loads_and_calls_over_mcp_and_rest_http
  - AttributeError: 'str' object has no attribute 'removesuffix'
```

`str.removesuffix` is Python 3.9+, but our CI matrix includes py3.7/py3.8. Replaced with an explicit suffix slice.

### 2. Print dcc-mcp-core version on startup
Previously a running server left no version trace in its own log — you had to infer it from the wheel filename or issue timestamps. Now `DccServerBase.__init__` emits one banner right after file-logging is wired:

```
[maya] dcc-mcp-core 0.14.26 (pid=676, python=3.11.9, platform=linux)
```

Useful for:
- CI logs (Maya/Blender/Houdini E2E runs across repos)
- User bug reports (no more "which version are you on?" back-and-forth)
- Multi-process DCCs (Maya + mayapy subprocesses can be disambiguated by pid)

## Test plan
- `just lint-py` ✓
- `pytest tests/test_forgecad_skill_ecosystem.py` ✓ (previously failed on py3.8)
- Syntax parse on both edited files ✓

## Notes
Base: `origin/main` @ 316d4eb (0.14.26)