### PR TITLE
fix: unloaded skill search, GatewayToolExposure cleanup, log retention (#677, #674)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,7 +713,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dcc-mcp-actions"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "dashmap",
  "dcc-mcp-models",
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-artefact"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "chrono",
  "hex",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-capture"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "image",
  "libc",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-core"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "dcc-mcp-actions",
  "dcc-mcp-artefact",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-gateway"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "axum",
  "chrono",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-host"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-http"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "axum",
  "axum-test",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-job"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "chrono",
  "dashmap",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-jsonrpc"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "serde",
  "serde_json",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-logging"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "dcc-mcp-paths",
  "parking_lot",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-models"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "dcc-mcp-naming",
  "dcc-mcp-pybridge",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-naming"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "pyo3",
  "pyo3-stub-gen",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-paths"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "dirs",
  "pyo3",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-process"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "dcc-mcp-models",
  "ipckit",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-protocols"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-pybridge"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "dcc-mcp-pybridge-derive",
  "pyo3",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-pybridge-derive"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-sandbox"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -1052,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-scheduler"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "axum",
  "bytes",
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-server"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "anyhow",
  "axum",
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-shm"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "ipckit",
  "libc",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-skill-rest"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "axum",
  "axum-test",
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-skills"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "dashmap",
  "dcc-mcp-actions",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-telemetry"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-transport"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "criterion",
  "dashmap",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-agent"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "dashmap",
  "dcc-mcp-tunnel-protocol",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-protocol"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "jsonwebtoken",
  "rmp-serde",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-relay"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "axum",
  "dashmap",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-usd"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "dcc-mcp-protocols",
  "pyo3",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-workflow"
-version = "0.14.24"
+version = "0.14.26"
 dependencies = [
  "base64",
  "chrono",

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator.rs
@@ -45,7 +45,7 @@ use tokio::sync::broadcast;
 use uuid::Uuid;
 
 use super::backend_client::{call_backend, fetch_tools, forward_tools_call};
-use super::namespace::{decode_tool_name, encode_tool_name, instance_short, is_local_tool};
+use super::namespace::{decode_tool_name, instance_short};
 use super::state::GatewayState;
 use super::tools::{
     gateway_tool_defs, tool_acquire_instance, tool_call_tool, tool_connect_to_dcc,

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator.rs
@@ -45,7 +45,7 @@ use tokio::sync::broadcast;
 use uuid::Uuid;
 
 use super::backend_client::{call_backend, fetch_tools, forward_tools_call};
-use super::namespace::{decode_tool_name, instance_short};
+use super::namespace::{decode_tool_name, instance_short, is_local_tool};
 use super::state::GatewayState;
 use super::tools::{
     gateway_tool_defs, tool_acquire_instance, tool_call_tool, tool_connect_to_dcc,

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/list.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/list.rs
@@ -1,93 +1,27 @@
-use super::super::namespace::encode_tool_name_cursor_safe;
 use super::*;
 
-/// Build the unified `tools/list` result by aggregating every live backend.
+/// Build the unified `tools/list` result.
 ///
 /// Tool order:
 /// 1. Gateway discovery / pooling meta-tools (`list_dcc_instances`,
 ///    `get_dcc_instance`, `connect_to_dcc`, `acquire_dcc_instance`,
 ///    `release_dcc_instance`).
 /// 2. Skill-management tools (one canonical set for the whole gateway).
-/// 3. Backend-provided tools from every live instance, prefixed with the
-///    8-char instance id, annotated with `_instance_id` / `_dcc_type` in the
-///    tool's `annotations` map so agents can display origin context.
 ///
-/// Tier 3 fan-out is skipped entirely when the gateway is configured with
-/// [`GatewayToolExposure::Slim`] or [`GatewayToolExposure::Rest`]
-/// (issue #652). In those modes the visible surface stays bounded to Tier
-/// 1 + 2 regardless of how many live backends are registered; agents are
-/// expected to discover and invoke backend capabilities through the
-/// dynamic wrapper layer described in #657.
-///
-/// The Tier 3 encoding is selected by
-/// [`GatewayState::cursor_safe_tool_names`](super::super::state::GatewayState::cursor_safe_tool_names)
-/// (issue #656). When `true` (default), tools are published as
-/// `i_<id8>__<escaped>` names that survive the stricter
-/// `^[A-Za-z0-9_]+$` regex enforced by Cursor and other MCP clients;
-/// no bare aliases are emitted from the gateway; the prefixed form is
-/// the only advertised backend tool identifier. When `false`, pre-#656
-/// SEP-986 dotted names are emitted for diagnostic parity.
+/// Backend tools are **not** fanned out. Agents discover and invoke
+/// backend capabilities through the dynamic wrapper layer
+/// (`search_tools` → `describe_tool` → `call_tool`).
 ///
 /// Pagination uses the same cursor scheme as the per-DCC server:
 /// `cursor` is an opaque hex-encoded offset into the flat tool list.
-///
-/// [`GatewayToolExposure::Slim`]: super::super::config::GatewayToolExposure::Slim
-/// [`GatewayToolExposure::Rest`]: super::super::config::GatewayToolExposure::Rest
-pub async fn aggregate_tools_list(gs: &GatewayState, cursor: Option<&str>) -> Value {
+pub async fn aggregate_tools_list(_gs: &GatewayState, cursor: Option<&str>) -> Value {
     let mut tools: Vec<Value> = Vec::new();
 
-    // Tier 1 + 2: local gateway tools (meta + skill management).
+    // Tier1 + 2: local gateway tools (meta + skill management).
     if let Value::Array(local) = gateway_tool_defs() {
         tools.extend(local);
     }
     tools.extend(skill_management_tool_defs());
-
-    // Tier 3: fan out to every live backend — but only in modes that
-    // publish per-backend tools (#652). Slim / Rest keep the gateway
-    // surface bounded so multi-instance setups do not blow up client
-    // context.
-    if gs.tool_exposure.publishes_backend_tools() {
-        // Issue #556: skip Unreachable instances so stale tools are not exposed.
-        let instances: Vec<_> = live_backends(gs)
-            .await
-            .into_iter()
-            .filter(|e| {
-                !matches!(
-                    e.status,
-                    dcc_mcp_transport::discovery::types::ServiceStatus::Unreachable
-                )
-            })
-            .collect();
-        let client = &gs.http_client;
-        let backend_timeout = gs.backend_timeout;
-        let futs = instances.iter().map(|entry| async move {
-            let url = format!("http://{}:{}/mcp", entry.host, entry.port);
-            let backend_tools = fetch_tools(client, &url, backend_timeout).await;
-            (entry.instance_id, entry.dcc_type.clone(), backend_tools)
-        });
-        let results = join_all(futs).await;
-        let cursor_safe = gs.cursor_safe_tool_names;
-
-        for (iid, dcc_type, backend_tools) in results {
-            for mut tool in backend_tools {
-                // Skip any tool whose name would collide with a gateway-local name
-                // AFTER encoding — cannot happen today because local tools are
-                // already filtered by `is_local_tool`, but guard defensively.
-                if is_local_tool(&tool.name) {
-                    continue;
-                }
-                let encoded = if cursor_safe {
-                    encode_tool_name_cursor_safe(&iid, &tool.name)
-                } else {
-                    encode_tool_name(&iid, &tool.name)
-                };
-                tool.name = encoded;
-                let mut json_val = serde_json::to_value(&tool).unwrap_or(Value::Null);
-                inject_instance_metadata(&mut json_val, &iid, &dcc_type);
-                tools.push(json_val);
-            }
-        }
-    }
 
     // ── Pagination ───────────────────────────────────────────────────────
     let offset = cursor.and_then(decode_cursor).unwrap_or(0);

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/list.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/list.rs
@@ -1,27 +1,89 @@
+use super::super::namespace::{encode_tool_name, encode_tool_name_cursor_safe};
 use super::*;
 
-/// Build the unified `tools/list` result.
+/// Build the unified `tools/list` result by aggregating every live backend.
 ///
 /// Tool order:
 /// 1. Gateway discovery / pooling meta-tools (`list_dcc_instances`,
 ///    `get_dcc_instance`, `connect_to_dcc`, `acquire_dcc_instance`,
 ///    `release_dcc_instance`).
 /// 2. Skill-management tools (one canonical set for the whole gateway).
+/// 3. Backend-provided tools from every live instance, prefixed with the
+///    8-char instance id, annotated with `_instance_id` / `_dcc_type` in the
+///    tool's `annotations` map so agents can display origin context.
 ///
-/// Backend tools are **not** fanned out. Agents discover and invoke
-/// backend capabilities through the dynamic wrapper layer
-/// (`search_tools` → `describe_tool` → `call_tool`).
+/// Tier 3 fan-out is skipped entirely when the gateway is configured with
+/// [`GatewayToolExposure::Slim`] (#652 / #674). In that mode the visible
+/// surface stays bounded to Tier 1 + 2 regardless of how many live backends
+/// are registered; agents discover backend capabilities through the dynamic
+/// wrapper layer.
+///
+/// The Tier 3 encoding is selected by
+/// [`GatewayState::cursor_safe_tool_names`](super::super::state::GatewayState::cursor_safe_tool_names)
+/// (issue #656). When `true` (default), tools are published as
+/// `i_<id8>__<escaped>` names that survive the stricter
+/// `^[A-Za-z0-9_]+$` regex enforced by Cursor and other MCP clients.
+/// When `false`, pre-#656 SEP-986 `<id8>.<tool>` dotted names are emitted
+/// for diagnostic parity.
 ///
 /// Pagination uses the same cursor scheme as the per-DCC server:
 /// `cursor` is an opaque hex-encoded offset into the flat tool list.
-pub async fn aggregate_tools_list(_gs: &GatewayState, cursor: Option<&str>) -> Value {
+///
+/// [`GatewayToolExposure::Slim`]: super::super::config::GatewayToolExposure::Slim
+pub async fn aggregate_tools_list(gs: &GatewayState, cursor: Option<&str>) -> Value {
     let mut tools: Vec<Value> = Vec::new();
 
-    // Tier1 + 2: local gateway tools (meta + skill management).
+    // Tier 1 + 2: local gateway tools (meta + skill management).
     if let Value::Array(local) = gateway_tool_defs() {
         tools.extend(local);
     }
     tools.extend(skill_management_tool_defs());
+
+    // Tier 3: fan out to every live backend — but only in modes that
+    // publish per-backend tools. `Slim` keeps the gateway surface bounded
+    // so multi-instance setups do not blow up client context.
+    if gs.tool_exposure.publishes_backend_tools() {
+        // Issue #556: skip Unreachable instances so stale tools are not exposed.
+        let instances: Vec<_> = live_backends(gs)
+            .await
+            .into_iter()
+            .filter(|e| {
+                !matches!(
+                    e.status,
+                    dcc_mcp_transport::discovery::types::ServiceStatus::Unreachable
+                )
+            })
+            .collect();
+        let client = &gs.http_client;
+        let backend_timeout = gs.backend_timeout;
+        let futs = instances.iter().map(|entry| async move {
+            let url = format!("http://{}:{}/mcp", entry.host, entry.port);
+            let backend_tools = fetch_tools(client, &url, backend_timeout).await;
+            (entry.instance_id, entry.dcc_type.clone(), backend_tools)
+        });
+        let results = join_all(futs).await;
+        let cursor_safe = gs.cursor_safe_tool_names;
+
+        for (iid, dcc_type, backend_tools) in results {
+            for mut tool in backend_tools {
+                // Skip any tool whose name would collide with a gateway-local name
+                // AFTER encoding — cannot happen today because local tools are
+                // already filtered by `is_local_tool`, but guard defensively.
+                if is_local_tool(&tool.name) {
+                    continue;
+                }
+                let encoded = if cursor_safe {
+                    encode_tool_name_cursor_safe(&iid, &tool.name)
+                } else {
+                    encode_tool_name(&iid, &tool.name)
+                };
+                tool.name = encoded;
+                let mut json_val = serde_json::to_value(&tool).unwrap_or(Value::Null);
+                inject_instance_metadata(&mut json_val, &iid, &dcc_type);
+                tools.push(json_val);
+            }
+        }
+    }
 
     // ── Pagination ───────────────────────────────────────────────────────
     let offset = cursor.and_then(decode_cursor).unwrap_or(0);

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
@@ -265,7 +265,7 @@ async fn aggregate_tools_list_does_not_publish_single_instance_bare_aliases() {
         allow_unknown_tools: false,
         adapter_version: None,
         adapter_dcc: None,
-        tool_exposure: crate::gateway::GatewayToolExposure::Full,
+        tool_exposure: crate::gateway::GatewayToolExposure::Rest,
         cursor_safe_tool_names: true,
         capability_index: std::sync::Arc::new(crate::gateway::capability::CapabilityIndex::new()),
     };
@@ -280,10 +280,11 @@ async fn aggregate_tools_list_does_not_publish_single_instance_bare_aliases() {
         .filter_map(|tool| tool["name"].as_str())
         .collect();
 
+    // Backend tools must NOT be fanned out (issue #674).
     let prefix = format!("i_{}__", &instance_id.to_string()[..8]);
     assert!(
-        names.iter().any(|name| name.starts_with(&prefix)),
-        "expected prefixed backend tool in {names:?}"
+        !names.iter().any(|name| name.starts_with(&prefix)),
+        "backend tools must not be fanned out in Rest mode: {names:?}"
     );
     assert!(
         !names.contains(&"create_sphere"),

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
@@ -280,11 +280,13 @@ async fn aggregate_tools_list_does_not_publish_single_instance_bare_aliases() {
         .filter_map(|tool| tool["name"].as_str())
         .collect();
 
-    // Backend tools must NOT be fanned out (issue #674).
-    let prefix = format!("i_{}__", &instance_id.to_string()[..8]);
+    // In Rest mode (default), backend tools ARE fanned out under the
+    // cursor-safe `i_<id8>__<name>` form, but bare aliases are not
+    // published (the encoded form is the single canonical identifier).
+    let prefix = format!("i_{}__", &instance_id.to_string().replace('-', "")[..8]);
     assert!(
-        !names.iter().any(|name| name.starts_with(&prefix)),
-        "backend tools must not be fanned out in Rest mode: {names:?}"
+        names.iter().any(|name| name.starts_with(&prefix)),
+        "Rest mode must fan out backend tools with the cursor-safe prefix: {names:?}"
     );
     assert!(
         !names.contains(&"create_sphere"),

--- a/crates/dcc-mcp-gateway/src/gateway/capability/builder.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/builder.rs
@@ -106,6 +106,7 @@ pub fn build_records_from_backend(input: BuildInput<'_>) -> BuildOutcome {
             input.dcc_type.to_string(),
             input.instance_id,
             has_schema,
+            true, // loaded: from live backend
         ));
     }
 

--- a/crates/dcc-mcp-gateway/src/gateway/capability/index.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/index.rs
@@ -83,6 +83,10 @@ pub struct CapabilityIndex {
 #[derive(Default)]
 struct InnerState {
     per_instance: BTreeMap<Uuid, InstanceSlice>,
+    /// Records built from unloaded skill metadata (discovered but not
+    /// yet loaded). These are indexed so `search_tools` can find
+    /// skills that aren't connected yet.
+    unloaded: Arc<[CapabilityRecord]>,
 }
 
 struct InstanceSlice {
@@ -142,16 +146,23 @@ impl CapabilityIndex {
     /// Take an owned snapshot of the whole index. Intended for REST /
     /// MCP handlers that want a single stable view across a search /
     /// describe / call sequence.
+    ///
+    /// Includes both loaded (from live backends) and unloaded (from
+    /// skill metadata) records so `search_tools` can discover skills
+    /// that aren't connected yet.
     pub fn snapshot(&self) -> IndexSnapshot {
         let guard = self.inner.read();
-        let mut records: Vec<CapabilityRecord> =
-            Vec::with_capacity(guard.per_instance.values().map(|s| s.records.len()).sum());
+        let loaded_count: usize = guard.per_instance.values().map(|s| s.records.len()).sum();
+        let unloaded_count = guard.unloaded.len();
+        let mut records: Vec<CapabilityRecord> = Vec::with_capacity(loaded_count + unloaded_count);
         let mut fingerprints: HashMap<Uuid, InstanceFingerprint> =
             HashMap::with_capacity(guard.per_instance.len());
         for (iid, slice) in guard.per_instance.iter() {
             fingerprints.insert(*iid, slice.fingerprint);
             records.extend_from_slice(&slice.records);
         }
+        // Append unloaded skill records so they appear in search results.
+        records.extend_from_slice(&guard.unloaded);
         // Stable order: by slug — the builder already sorts per-
         // instance, so this sort is effectively a merge of sorted
         // runs and stays cheap.
@@ -187,6 +198,30 @@ impl CapabilityIndex {
     pub fn instance_count(&self) -> usize {
         self.inner.read().per_instance.len()
     }
+
+    /// Replace the unloaded-skill records with `records`.
+    ///
+    /// Called by the gateway refresh loop (or a dedicated skill-
+    /// watcher task) after scanning the [`SkillCatalog`] for
+    /// discovered-but-not-loaded skills.
+    ///
+    /// The caller is responsible for converting [`SkillMetadata`] to
+    /// [`CapabilityRecord`] (using [`CapabilityRecord::from_skill_tool`])
+    /// to avoid a direct dependency from `dcc-mcp-gateway` on
+    /// `dcc-mcp-models`.
+    pub fn set_unloaded_records(&self, records: Vec<CapabilityRecord>) {
+        let mut guard = self.inner.write();
+        // Keep unloaded records sorted so `snapshot()` doesn't need
+        // to re-sort them separately.
+        let mut sorted = records;
+        sorted.sort_by(|a, b| a.tool_slug.cmp(&b.tool_slug));
+        guard.unloaded = Arc::from(sorted);
+    }
+
+    /// Number of unloaded skill records currently indexed; diagnostics-only.
+    pub fn unloaded_count(&self) -> usize {
+        self.inner.read().unloaded.len()
+    }
 }
 
 impl Default for CapabilityIndex {
@@ -208,8 +243,9 @@ impl std::fmt::Debug for CapabilityIndex {
 mod unit_tests {
     use super::*;
     use crate::gateway::capability::record::tool_slug;
+    use crate::gateway::capability::search::{SearchQuery, search};
 
-    fn rec(dcc: &str, id: Uuid, tool: &str) -> CapabilityRecord {
+    fn rec(dcc: &str, id: Uuid, tool: &str, loaded: bool) -> CapabilityRecord {
         CapabilityRecord::new(
             tool_slug(dcc, &id, tool),
             tool.to_string(),
@@ -219,7 +255,8 @@ mod unit_tests {
             Vec::new(),
             dcc.to_string(),
             id,
-            false,
+            false, // has_schema
+            loaded,
         )
     }
 
@@ -237,7 +274,10 @@ mod unit_tests {
         let iid = Uuid::from_u128(0xabcdef01_2345_6789_abcd_ef0123456789);
         idx.upsert_instance(
             iid,
-            vec![rec("maya", iid, "create_sphere"), rec("maya", iid, "open")],
+            vec![
+                rec("maya", iid, "create_sphere", true),
+                rec("maya", iid, "open", true),
+            ],
             InstanceFingerprint(42),
         );
         let snap = idx.snapshot();
@@ -249,7 +289,11 @@ mod unit_tests {
     fn upsert_with_empty_records_removes_instance() {
         let idx = CapabilityIndex::new();
         let iid = Uuid::from_u128(1);
-        idx.upsert_instance(iid, vec![rec("maya", iid, "t")], InstanceFingerprint(1));
+        idx.upsert_instance(
+            iid,
+            vec![rec("maya", iid, "t", true)],
+            InstanceFingerprint(1),
+        );
         assert_eq!(idx.instance_count(), 1);
         // An empty upsert must not leave a half-populated slice.
         let prev = idx.upsert_instance(iid, Vec::new(), InstanceFingerprint(0));
@@ -262,8 +306,12 @@ mod unit_tests {
         let idx = CapabilityIndex::new();
         let a = Uuid::from_u128(0xaaaa_aaaa_0000_0000_0000_0000_0000_0001);
         let b = Uuid::from_u128(0xbbbb_bbbb_0000_0000_0000_0000_0000_0001);
-        idx.upsert_instance(a, vec![rec("maya", a, "t1")], InstanceFingerprint(1));
-        idx.upsert_instance(b, vec![rec("blender", b, "t2")], InstanceFingerprint(2));
+        idx.upsert_instance(a, vec![rec("maya", a, "t1", true)], InstanceFingerprint(1));
+        idx.upsert_instance(
+            b,
+            vec![rec("blender", b, "t2", true)],
+            InstanceFingerprint(2),
+        );
         assert!(idx.remove_instance(a));
         let snap = idx.snapshot();
         assert_eq!(snap.records.len(), 1);
@@ -279,10 +327,17 @@ mod unit_tests {
         let b = Uuid::from_u128(0x2222_2222_0000_0000_0000_0000_0000_0001);
         idx.upsert_instance(
             a,
-            vec![rec("blender", a, "z_action"), rec("blender", a, "a_action")],
+            vec![
+                rec("blender", a, "z_action", true),
+                rec("blender", a, "a_action", true),
+            ],
             InstanceFingerprint(1),
         );
-        idx.upsert_instance(b, vec![rec("maya", b, "m_action")], InstanceFingerprint(1));
+        idx.upsert_instance(
+            b,
+            vec![rec("maya", b, "m_action", true)],
+            InstanceFingerprint(1),
+        );
         let s1 = idx.snapshot();
         let s2 = idx.snapshot();
         let names: Vec<&str> = s1.records.iter().map(|r| r.tool_slug.as_str()).collect();
@@ -295,11 +350,15 @@ mod unit_tests {
         let idx = CapabilityIndex::new();
         let iid = Uuid::from_u128(7);
         assert_eq!(idx.fingerprint_for(iid), None);
-        idx.upsert_instance(iid, vec![rec("python", iid, "foo")], InstanceFingerprint(9));
+        idx.upsert_instance(
+            iid,
+            vec![rec("python", iid, "foo", true)],
+            InstanceFingerprint(9),
+        );
         assert_eq!(idx.fingerprint_for(iid), Some(InstanceFingerprint(9)));
         idx.upsert_instance(
             iid,
-            vec![rec("python", iid, "bar")],
+            vec![rec("python", iid, "bar", true)],
             InstanceFingerprint(10),
         );
         assert_eq!(idx.fingerprint_for(iid), Some(InstanceFingerprint(10)));
@@ -309,11 +368,169 @@ mod unit_tests {
     fn find_by_slug_matches_exactly() {
         let idx = CapabilityIndex::new();
         let iid = Uuid::from_u128(1);
-        let records = vec![rec("maya", iid, "create_sphere"), rec("maya", iid, "open")];
+        let records = vec![
+            rec("maya", iid, "create_sphere", true),
+            rec("maya", iid, "open", true),
+        ];
         idx.upsert_instance(iid, records, InstanceFingerprint(1));
         let snap = idx.snapshot();
         let expected_slug = tool_slug("maya", &iid, "create_sphere");
         assert!(snap.find_by_slug(&expected_slug).is_some());
         assert!(snap.find_by_slug("maya.abcdef01.not_there").is_none());
+    }
+
+    // ========================================================================
+    // Unloaded skill records (issue #677)
+    // ========================================================================
+
+    #[test]
+    fn unloaded_records_appear_in_snapshot() {
+        let idx = CapabilityIndex::new();
+        // No loaded instances yet.
+        assert!(idx.snapshot().is_empty());
+        assert_eq!(idx.unloaded_count(), 0);
+
+        // Add unloaded skill records.
+        let unloaded = vec![
+            CapabilityRecord::from_skill_tool(
+                "maya-geometry",
+                "create_sphere",
+                "Create a sphere in Maya",
+                "maya",
+            ),
+            CapabilityRecord::from_skill_tool(
+                "maya-geometry",
+                "create_cube",
+                "Create a cube in Maya",
+                "maya",
+            ),
+        ];
+        idx.set_unloaded_records(unloaded);
+        assert_eq!(idx.unloaded_count(), 2);
+
+        // Snapshot must include unloaded records.
+        let snap = idx.snapshot();
+        assert_eq!(snap.records.len(), 2);
+        // Unloaded records have loaded=false.
+        assert!(!snap.records[0].loaded);
+        assert_eq!(snap.records[0].skill_name.as_deref(), Some("maya-geometry"));
+    }
+
+    #[test]
+    fn snapshot_merges_loaded_and_unloaded() {
+        let idx = CapabilityIndex::new();
+        let iid = Uuid::from_u128(1);
+        // Add a loaded instance.
+        idx.upsert_instance(
+            iid,
+            vec![rec("maya", iid, "export_fbx", true)],
+            InstanceFingerprint(1),
+        );
+        // Add unloaded skill records.
+        let unloaded = vec![CapabilityRecord::from_skill_tool(
+            "maya-animation",
+            "set_keyframe",
+            "Set a keyframe",
+            "maya",
+        )];
+        idx.set_unloaded_records(unloaded);
+
+        let snap = idx.snapshot();
+        assert_eq!(snap.records.len(), 2);
+        // Verify both loaded and unloaded are present.
+        let loaded: Vec<&CapabilityRecord> = snap.records.iter().filter(|r| r.loaded).collect();
+        let unloaded: Vec<&CapabilityRecord> = snap.records.iter().filter(|r| !r.loaded).collect();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(unloaded.len(), 1);
+    }
+
+    #[test]
+    fn search_finds_unloaded_skills() {
+        let idx = CapabilityIndex::new();
+        // Only unloaded records.
+        let unloaded = vec![
+            CapabilityRecord::from_skill_tool(
+                "maya-geometry",
+                "create_sphere",
+                "Create a sphere",
+                "maya",
+            ),
+            CapabilityRecord::from_skill_tool(
+                "blender-geometry",
+                "create_cube",
+                "Create a cube",
+                "blender",
+            ),
+        ];
+        idx.set_unloaded_records(unloaded);
+
+        // Search should find unloaded skills.
+        let snap = idx.snapshot();
+        let hits = search(
+            &snap,
+            &SearchQuery {
+                query: "create".into(),
+                ..Default::default()
+            },
+        );
+        assert_eq!(hits.len(), 2);
+
+        // Filter by dcc_type should work for unloaded too.
+        let hits = search(
+            &snap,
+            &SearchQuery {
+                query: "create".into(),
+                dcc_type: Some("maya".into()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].record.dcc_type, "maya");
+    }
+
+    #[test]
+    fn loaded_only_filter_excludes_unloaded() {
+        let idx = CapabilityIndex::new();
+        let iid = Uuid::from_u128(1);
+        // Add both loaded and unloaded.
+        idx.upsert_instance(
+            iid,
+            vec![rec("maya", iid, "export_fbx", true)],
+            InstanceFingerprint(1),
+        );
+        let unloaded = vec![CapabilityRecord::from_skill_tool(
+            "maya-geometry",
+            "create_sphere",
+            "Create a sphere",
+            "maya",
+        )];
+        idx.set_unloaded_records(unloaded);
+
+        let snap = idx.snapshot();
+        // `loaded_only: Some(true)` must exclude unloaded records.
+        // Both records are maya DCC, so the filter is the only thing
+        // distinguishing them.
+        let hits = search(
+            &snap,
+            &SearchQuery {
+                query: String::new(), // empty query = browse all records
+                dcc_type: Some("maya".into()),
+                loaded_only: Some(true),
+                ..Default::default()
+            },
+        );
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].record.loaded);
+
+        // Without loaded_only, both are visible.
+        let hits_all = search(
+            &snap,
+            &SearchQuery {
+                query: String::new(),
+                dcc_type: Some("maya".into()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(hits_all.len(), 2);
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/capability/record.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/record.rs
@@ -122,6 +122,13 @@ pub struct CapabilityRecord {
     /// Agents should check this before calling `describe_tool` —
     /// actions with no schema can be invoked with an empty object.
     pub has_schema: bool,
+    /// True when the owning backend instance is currently connected
+    /// (loaded). False for records built from unloaded skill metadata.
+    ///
+    /// `search_tools` uses this field to allow discovering unloaded
+    /// skills; the agent can then call `load_skill` before invoking
+    /// the tool.
+    pub loaded: bool,
 }
 
 impl CapabilityRecord {
@@ -132,7 +139,7 @@ impl CapabilityRecord {
 
     /// Build a record by normalising `summary` to fit the size cap.
     ///
-    /// The eight-argument signature is deliberate: every field of a
+    /// The nine-argument signature is deliberate: every field of a
     /// `CapabilityRecord` is routing-relevant, and grouping them into
     /// a builder would trade one cursor of boilerplate for another.
     #[allow(clippy::too_many_arguments)]
@@ -146,6 +153,7 @@ impl CapabilityRecord {
         dcc_type: String,
         instance_id: Uuid,
         has_schema: bool,
+        loaded: bool,
     ) -> Self {
         Self {
             tool_slug,
@@ -157,6 +165,42 @@ impl CapabilityRecord {
             dcc_type,
             instance_id,
             has_schema,
+            loaded,
+        }
+    }
+}
+
+impl CapabilityRecord {
+    /// Build a record for a tool from an **unloaded** skill's metadata.
+    ///
+    /// Used by [`CapabilityIndex::update_unloaded_skills`] to index
+    /// skills that exist in the [`SkillCatalog`] but are not yet loaded.
+    ///
+    /// The `instance_id` is set to `Uuid::nil()` (sentinel value)
+    /// because there is no backend instance yet. The `tool_slug` is
+    /// still computable (it wil be `dcc.00000000.tool_name`), which
+    /// is fine for **search discovery** — the agent calls `load_skill`
+    /// before invoking the tool, at which point the real instance's
+    /// records replace these sentinel ones.
+    pub fn from_skill_tool(
+        skill_name: &str,
+        tool_name: &str,
+        tool_description: &str,
+        dcc_type: &str,
+    ) -> Self {
+        let nil = Uuid::nil();
+        let slug = tool_slug(dcc_type, &nil, tool_name);
+        Self {
+            tool_slug: slug,
+            backend_tool: tool_name.to_string(),
+            callable_id: tool_name.to_string(),
+            skill_name: Some(skill_name.to_string()),
+            summary: normalise_summary(tool_description),
+            tags: Vec::new(),
+            dcc_type: dcc_type.to_string(),
+            instance_id: nil,
+            has_schema: false, // unknown until loaded
+            loaded: false,
         }
     }
 }
@@ -254,6 +298,7 @@ mod unit_tests {
             "x".into(),
             Uuid::nil(),
             false,
+            false,
         );
         assert!(rec.summary.len() <= CapabilityRecord::MAX_SUMMARY_LEN + 3);
         assert!(rec.summary.ends_with("..."));
@@ -273,6 +318,7 @@ mod unit_tests {
             Vec::new(),
             "x".into(),
             Uuid::nil(),
+            false,
             false,
         );
         assert_eq!(rec.summary, "short and sweet");

--- a/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
@@ -145,7 +145,8 @@ mod unit_tests {
                 vec![],
                 "maya".into(),
                 iid,
-                false,
+                false, // has_schema
+                true,  // loaded
             )],
             InstanceFingerprint(1),
         );

--- a/crates/dcc-mcp-gateway/src/gateway/capability/search.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/search.rs
@@ -162,7 +162,7 @@ pub fn search_page(snapshot: &IndexSnapshot, query: &SearchQuery) -> SearchPage 
         .iter()
         .filter(|r| dcc_filter.is_none_or(|f| r.dcc_type == f))
         .filter(|r| instance_filter.is_none_or(|iid| r.instance_id == iid))
-        .filter(|r| loaded_filter != Some(true) || r.has_schema)
+        .filter(|r| loaded_filter != Some(true) || r.loaded)
         .filter(|r| {
             tags_filter
                 .iter()
@@ -250,6 +250,7 @@ mod unit_tests {
     use std::time::Instant;
     use uuid::Uuid;
 
+    #[allow(clippy::too_many_arguments)]
     fn push_one(
         idx: &CapabilityIndex,
         dcc: &str,
@@ -258,6 +259,7 @@ mod unit_tests {
         summary: &str,
         tags: &[&str],
         has_schema: bool,
+        loaded: bool,
     ) {
         let rec = CapabilityRecord::new(
             tool_slug(dcc, &iid, name),
@@ -269,6 +271,7 @@ mod unit_tests {
             dcc.to_string(),
             iid,
             has_schema,
+            loaded,
         );
         // Overwrite the per-instance slice with a single record for
         // focused tests; real builders always ship sorted arrays.
@@ -297,6 +300,7 @@ mod unit_tests {
             "make a sphere",
             &["geo"],
             true,
+            true, // loaded
         );
         let snap = idx.snapshot();
         let hits = search(&snap, &SearchQuery::default());
@@ -320,6 +324,7 @@ mod unit_tests {
                     "maya".into(),
                     a,
                     true,
+                    true, // loaded
                 ),
                 CapabilityRecord::new(
                     tool_slug("maya", &a, "create_sphere"),
@@ -331,6 +336,7 @@ mod unit_tests {
                     "maya".into(),
                     a,
                     true,
+                    true, // loaded
                 ),
             ],
             InstanceFingerprint(1),
@@ -347,6 +353,7 @@ mod unit_tests {
                 "maya".into(),
                 b,
                 false,
+                false, // not loaded
             )],
             InstanceFingerprint(1),
         );
@@ -367,8 +374,8 @@ mod unit_tests {
     #[test]
     fn dcc_type_filter_drops_cross_dcc_matches() {
         let (idx, a, b) = fresh_index();
-        push_one(&idx, "maya", a, "create_sphere", "", &[], true);
-        push_one(&idx, "blender", b, "create_sphere", "", &[], true);
+        push_one(&idx, "maya", a, "create_sphere", "", &[], true, true);
+        push_one(&idx, "blender", b, "create_sphere", "", &[], true, true);
         let snap = idx.snapshot();
         let hits = search(
             &snap,
@@ -393,8 +400,18 @@ mod unit_tests {
             "",
             &["read-only", "scene"],
             true,
+            true, // loaded
         );
-        push_one(&idx, "maya", b, "export_fbx", "", &["destructive"], true);
+        push_one(
+            &idx,
+            "maya",
+            b,
+            "export_fbx",
+            "",
+            &["destructive"],
+            true,
+            true,
+        );
         let snap = idx.snapshot();
         let hits = search(
             &snap,
@@ -431,6 +448,7 @@ mod unit_tests {
                     "maya".into(),
                     iid,
                     false,
+                    false, // not loaded (has_schema=false)
                 )
             })
             .collect();
@@ -462,6 +480,7 @@ mod unit_tests {
                     "maya".into(),
                     iid,
                     false,
+                    false, // not loaded
                 )
             })
             .collect();
@@ -482,7 +501,7 @@ mod unit_tests {
     #[test]
     fn scene_hint_boosts_matching_records() {
         let (idx, a, b) = fresh_index();
-        push_one(&idx, "maya", a, "export_fbx", "", &[], true);
+        push_one(&idx, "maya", a, "export_fbx", "", &[], true, true);
         push_one(
             &idx,
             "maya",
@@ -491,6 +510,7 @@ mod unit_tests {
             "open a rig scene for character work",
             &["scene"],
             true,
+            true, // loaded
         );
         let snap = idx.snapshot();
         let hits = search(
@@ -514,7 +534,7 @@ mod unit_tests {
         // typo; agents relying on recall would see nothing. Fuzzy
         // mode (the new default) must surface the record.
         let (idx, a, _) = fresh_index();
-        push_one(&idx, "maya", a, "create_sphere", "", &[], true);
+        push_one(&idx, "maya", a, "create_sphere", "", &[], true, true);
         let snap = idx.snapshot();
         let hits = search(
             &snap,
@@ -531,9 +551,9 @@ mod unit_tests {
     fn fuzzy_mode_ranks_prefix_above_substring() {
         let (idx, a, b) = fresh_index();
         // `create_sphere` — query is a prefix.
-        push_one(&idx, "maya", a, "create_sphere", "", &[], true);
+        push_one(&idx, "maya", a, "create_sphere", "", &[], true, true);
         // `recreate_plane` — query is a mid-string substring.
-        push_one(&idx, "maya", b, "recreate_plane", "", &[], true);
+        push_one(&idx, "maya", b, "recreate_plane", "", &[], true, true);
         let snap = idx.snapshot();
         let hits = search(
             &snap,
@@ -549,8 +569,8 @@ mod unit_tests {
     #[test]
     fn instance_id_filter_drops_other_instances() {
         let (idx, a, b) = fresh_index();
-        push_one(&idx, "maya", a, "create_sphere", "", &[], true);
-        push_one(&idx, "maya", b, "create_sphere", "", &[], true);
+        push_one(&idx, "maya", a, "create_sphere", "", &[], true, true);
+        push_one(&idx, "maya", b, "create_sphere", "", &[], true, true);
         let snap = idx.snapshot();
         let hits = search(
             &snap,
@@ -568,8 +588,8 @@ mod unit_tests {
     fn loaded_only_filter_drops_unloaded_records() {
         let (idx, a, b) = fresh_index();
         // Instance `a` carries the schema (loaded), `b` does not.
-        push_one(&idx, "maya", a, "load_heavy", "", &[], true);
-        push_one(&idx, "maya", b, "load_heavy", "", &[], false);
+        push_one(&idx, "maya", a, "load_heavy", "", &[], true, true);
+        push_one(&idx, "maya", b, "load_heavy", "", &[], false, false);
         let snap = idx.snapshot();
         let all = search(
             &snap,
@@ -617,6 +637,7 @@ mod unit_tests {
                     "maya".into(),
                     iid,
                     false,
+                    false, // not loaded
                 )
             })
             .collect();
@@ -696,6 +717,7 @@ mod unit_tests {
                     "maya".into(),
                     iid,
                     true,
+                    true, // loaded (has_schema=true)
                 )
             })
             .collect();
@@ -732,7 +754,16 @@ mod unit_tests {
         let maya_a = Uuid::from_u128(0xaaaa_0000_0000_0000_0000_0000_0000_0001);
         let maya_b = Uuid::from_u128(0xaaaa_0000_0000_0000_0000_0000_0000_0002);
         let blender_c = Uuid::from_u128(0xbbbb_0000_0000_0000_0000_0000_0000_0001);
-        push_one(&idx, "maya", maya_a, "read_scene", "", &["read-only"], true);
+        push_one(
+            &idx,
+            "maya",
+            maya_a,
+            "read_scene",
+            "",
+            &["read-only"],
+            true,
+            true,
+        );
         push_one(
             &idx,
             "maya",
@@ -741,6 +772,7 @@ mod unit_tests {
             "",
             &["destructive"],
             true,
+            true, // loaded
         );
         push_one(
             &idx,
@@ -750,6 +782,7 @@ mod unit_tests {
             "",
             &["read-only"],
             false,
+            false, // not loaded
         );
         let snap = idx.snapshot();
         let hits = search(
@@ -797,7 +830,8 @@ mod unit_tests {
                             vec!["animation".into(), "schema:frame".into()],
                             (*dcc).into(),
                             iid,
-                            i % 2 == 0,
+                            i % 2 == 0, // has_schema
+                            i % 2 == 0, // loaded (same as has_schema in this test)
                         )
                     })
                     .collect();

--- a/crates/dcc-mcp-gateway/src/gateway/capability/search_ranking.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/search_ranking.rs
@@ -282,7 +282,13 @@ mod tests {
     use crate::gateway::capability::record::tool_slug;
     use uuid::Uuid;
 
-    fn rec(name: &str, summary: &str, skill: Option<&str>, tags: &[&str]) -> CapabilityRecord {
+    fn rec(
+        name: &str,
+        summary: &str,
+        skill: Option<&str>,
+        tags: &[&str],
+        loaded: bool,
+    ) -> CapabilityRecord {
         let iid = Uuid::from_u128(0x1234_5678_0000_0000_0000_0000_0000_0001);
         CapabilityRecord::new(
             tool_slug("maya", &iid, name),
@@ -293,7 +299,8 @@ mod tests {
             tags.iter().map(|t| t.to_string()).collect(),
             "maya".to_string(),
             iid,
-            false,
+            false, // has_schema
+            loaded,
         )
     }
 
@@ -302,14 +309,14 @@ mod tests {
         let mut s = SubstringScorer;
         // "create_sphere" is also a substring of "create_sphere"; the
         // scorer takes the exact branch (10) and stops.
-        let r = rec("create_sphere", "make a sphere", None, &["geo"]);
+        let r = rec("create_sphere", "make a sphere", None, &["geo"], true);
         assert_eq!(s.score(&r, "create_sphere", None), 10);
     }
 
     #[test]
     fn substring_scorer_substring_plus_summary() {
         let mut s = SubstringScorer;
-        let r = rec("create_sphere", "make a sphere", None, &["geo"]);
+        let r = rec("create_sphere", "make a sphere", None, &["geo"], true);
         // Substring hit on the tool name (6) + summary contains
         // "sphere" (2) = 8.
         assert_eq!(s.score(&r, "sphere", None), 6 + 2);
@@ -318,21 +325,21 @@ mod tests {
     #[test]
     fn substring_scorer_exact_tag() {
         let mut s = SubstringScorer;
-        let r = rec("create_sphere", "", None, &["geo"]);
+        let r = rec("create_sphere", "", None, &["geo"], true);
         assert_eq!(s.score(&r, "geo", None), 5);
     }
 
     #[test]
     fn substring_scorer_zero_on_miss() {
         let mut s = SubstringScorer;
-        let r = rec("create_sphere", "make a sphere", None, &["geo"]);
+        let r = rec("create_sphere", "make a sphere", None, &["geo"], true);
         assert_eq!(s.score(&r, "xylophone", None), 0);
     }
 
     #[test]
     fn fuzzy_scorer_tolerates_single_character_typo() {
         let mut s = FuzzyScorer::new();
-        let r = rec("create_sphere", "", None, &[]);
+        let r = rec("create_sphere", "", None, &[], true);
         // Missing final `e` in the needle — legacy substring matcher
         // would miss this entirely; fuzzy must produce a positive
         // score so the agent still sees the right tool.
@@ -342,7 +349,11 @@ mod tests {
             "fuzzy must tolerate a typo; got {typo_score}"
         );
         // An exact match still wins.
-        let exact_score = s.score(&rec("create_sphere", "", None, &[]), "create_sphere", None);
+        let exact_score = s.score(
+            &rec("create_sphere", "", None, &[], true),
+            "create_sphere",
+            None,
+        );
         assert!(
             exact_score >= typo_score,
             "exact ({exact_score}) should outrank typo ({typo_score})",
@@ -352,8 +363,8 @@ mod tests {
     #[test]
     fn fuzzy_scorer_ranks_prefix_above_substring() {
         let mut s = FuzzyScorer::new();
-        let prefix_hit = s.score(&rec("create_sphere", "", None, &[]), "create", None);
-        let substring_hit = s.score(&rec("recreate_plane", "", None, &[]), "create", None);
+        let prefix_hit = s.score(&rec("create_sphere", "", None, &[], true), "create", None);
+        let substring_hit = s.score(&rec("recreate_plane", "", None, &[], true), "create", None);
         assert!(
             prefix_hit > substring_hit,
             "prefix match ({prefix_hit}) must outrank substring ({substring_hit})",
@@ -364,7 +375,7 @@ mod tests {
     fn fuzzy_scorer_matches_subsequence() {
         // Subsequence "cs" should match "create_sphere" (c…s).
         let mut s = FuzzyScorer::new();
-        let hit = s.score(&rec("create_sphere", "", None, &[]), "cs", None);
+        let hit = s.score(&rec("create_sphere", "", None, &[], true), "cs", None);
         assert!(hit > 0, "subsequence match should score > 0");
     }
 
@@ -375,7 +386,7 @@ mod tests {
         // so every field is a 0 fuzzy score and we fall through the
         // zero-filter.
         let hit = s.score(
-            &rec("create_sphere", "geometry tool", None, &[]),
+            &rec("create_sphere", "geometry tool", None, &[], true),
             "xyzzy",
             None,
         );
@@ -385,9 +396,9 @@ mod tests {
     #[test]
     fn fuzzy_scorer_weights_tool_name_above_summary() {
         let mut s = FuzzyScorer::new();
-        let via_tool = s.score(&rec("keyframe", "", None, &[]), "keyframe", None);
+        let via_tool = s.score(&rec("keyframe", "", None, &[], true), "keyframe", None);
         let via_summary = s.score(
-            &rec("unrelated", "keyframe in summary", None, &[]),
+            &rec("unrelated", "keyframe in summary", None, &[], true),
             "keyframe",
             None,
         );
@@ -402,7 +413,7 @@ mod tests {
         let mut s = FuzzyScorer::new();
         // `anim` is a fuzzy prefix of `animation` — tag scoring must
         // return > 0.
-        let hit = s.score(&rec("misc", "", None, &["animation"]), "anim", None);
+        let hit = s.score(&rec("misc", "", None, &["animation"], true), "anim", None);
         assert!(hit > 0, "tag fuzzy match must contribute; got {hit}");
     }
 
@@ -410,7 +421,13 @@ mod tests {
     fn fuzzy_scorer_credits_schema_field_tag() {
         let mut s = FuzzyScorer::new();
         let hit = s.score(
-            &rec("set_anim", "", None, &["schema:frame", "schema:value"]),
+            &rec(
+                "set_anim",
+                "",
+                None,
+                &["schema:frame", "schema:value"],
+                true,
+            ),
             "frame",
             None,
         );
@@ -421,7 +438,7 @@ mod tests {
     fn scene_hint_adds_boost_even_without_query() {
         let mut s = FuzzyScorer::new();
         let hit = s.score(
-            &rec("open", "rig scene ready", None, &["scene"]),
+            &rec("open", "rig scene ready", None, &["scene"], true),
             "",
             Some("scene"),
         );
@@ -438,6 +455,7 @@ mod tests {
             "makes a sphere",
             Some("maya-geo"),
             &["geo"],
+            true,
         );
         let scores: Vec<u32> = (0..16)
             .map(|_| FuzzyScorer::new().score(&r, "sphere", None))

--- a/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
@@ -280,7 +280,7 @@ mod unit_tests {
     use crate::gateway::capability::{CapabilityRecord, InstanceFingerprint, tool_slug};
     use uuid::Uuid;
 
-    fn push(index: &CapabilityIndex, dcc: &str, iid: Uuid, backend_tool: &str) {
+    fn push(index: &CapabilityIndex, dcc: &str, iid: Uuid, backend_tool: &str, loaded: bool) {
         let rec = CapabilityRecord::new(
             tool_slug(dcc, &iid, backend_tool),
             backend_tool.to_string(),
@@ -290,7 +290,8 @@ mod unit_tests {
             Vec::new(),
             dcc.to_string(),
             iid,
-            false,
+            false, // has_schema
+            loaded,
         );
         index.upsert_instance(iid, vec![rec], InstanceFingerprint(1));
     }
@@ -299,7 +300,7 @@ mod unit_tests {
     fn describe_returns_record_for_known_slug() {
         let idx = CapabilityIndex::new();
         let iid = Uuid::from_u128(0xabcd);
-        push(&idx, "maya", iid, "create_sphere");
+        push(&idx, "maya", iid, "create_sphere", true);
         let slug = tool_slug("maya", &iid, "create_sphere");
         let rec = describe_service(&idx, &slug).expect("slug should resolve");
         assert_eq!(rec.backend_tool, "create_sphere");
@@ -331,8 +332,8 @@ mod unit_tests {
         // checking the outputs are byte-identical.
         let idx = CapabilityIndex::new();
         let iid = Uuid::from_u128(1);
-        push(&idx, "maya", iid, "create_sphere");
-        push(&idx, "maya", iid, "open_scene");
+        push(&idx, "maya", iid, "create_sphere", true);
+        push(&idx, "maya", iid, "open_scene", true);
 
         let q = SearchQuery {
             query: "sphere".into(),

--- a/crates/dcc-mcp-gateway/src/gateway/config.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/config.rs
@@ -14,54 +14,37 @@ use super::*;
 /// [#657]: https://github.com/loonghao/dcc-mcp-core/issues/657
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum GatewayToolExposure {
-    /// Current behavior: gateway meta-tools + skill-management tools +
-    /// every live backend tool (Tier 1 + 2 + 3). Preserved as the default
-    /// for compatibility during rollout.
-    Full,
     /// Emit only gateway meta-tools + skill-management tools (Tier 1 + 2).
-    /// Backend capabilities are expected to be discovered and invoked
-    /// through dynamic `search_tools` / `describe_tool` / `call_tool`
-    /// wrappers in a later phase of #657.
+    /// Backend capabilities are discovered and invoked through dynamic
+    /// `search_tools` / `describe_tool` / `call_tool` wrappers.
     Slim,
-    /// Alias of [`Self::Full`] retained for forward compatibility with
-    /// the documented `full | slim | both | rest` configuration surface.
-    /// Behaves identically to `Full` today; may diverge once REST-backed
-    /// dynamic tools land so that operators can run both static fan-out
-    /// and dynamic wrappers side-by-side during migration.
-    Both,
-    /// Same bounded surface as [`Self::Slim`]; kept as a distinct variant
-    /// so the gateway can signal "REST is the canonical capability API"
-    /// in diagnostics and future routing decisions without another
-    /// config migration.
+    /// Same bounded surface as [`Self::Slim`]; signals that REST is the
+    /// canonical capability API. This is the default mode.
     Rest,
 }
 
 impl GatewayToolExposure {
-    /// Return `true` when the gateway should fan out to every live
-    /// backend and publish each tool as an individual MCP tool.
-    ///
-    /// `Full` and `Both` both fan out today; `Slim` and `Rest` never do.
+    /// `Slim` and `Rest` never fan out to backend tools.
+    /// Backend capabilities are always accessed via `search_tools` / `call_tool`.
     pub const fn publishes_backend_tools(self) -> bool {
-        matches!(self, Self::Full | Self::Both)
+        false
     }
 
     /// Human-readable token matching the documented config vocabulary
-    /// (`full | slim | both | rest`). Used by diagnostics and the CLI.
+    /// (`slim | rest`). Used by diagnostics and the CLI.
     pub const fn as_str(self) -> &'static str {
         match self {
-            Self::Full => "full",
             Self::Slim => "slim",
-            Self::Both => "both",
             Self::Rest => "rest",
         }
     }
 }
 
 impl Default for GatewayToolExposure {
-    /// Keep the pre-#652 behavior as the default so existing deployments
-    /// see no change until they opt in.
+    /// `Rest` is the default — the correct and unique mode.
+    /// `Full` and `Both` have been removed.
     fn default() -> Self {
-        Self::Full
+        Self::Rest
     }
 }
 
@@ -80,9 +63,7 @@ impl std::str::FromStr for GatewayToolExposure {
     /// back to the default (which would mask operator typos).
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.trim().to_ascii_lowercase().as_str() {
-            "full" => Ok(Self::Full),
             "slim" => Ok(Self::Slim),
-            "both" => Ok(Self::Both),
             "rest" => Ok(Self::Rest),
             other => Err(ParseGatewayToolExposureError(other.to_string())),
         }
@@ -98,7 +79,7 @@ impl std::fmt::Display for ParseGatewayToolExposureError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "unknown gateway tool-exposure mode '{}' (expected one of: full, slim, both, rest)",
+            "unknown gateway tool-exposure mode '{}' (expected one of: slim, rest)",
             self.0
         )
     }
@@ -164,16 +145,11 @@ pub struct GatewayConfig {
     /// How the gateway publishes backend tools through MCP `tools/list`
     /// (issue #652).
     ///
-    /// * [`GatewayToolExposure::Full`] — current behavior: every live
-    ///   backend tool is visible on the gateway. Default for
-    ///   compatibility during rollout.
-    /// * [`GatewayToolExposure::Slim`] /
-    ///   [`GatewayToolExposure::Rest`] — only gateway meta-tools and
+    /// * [`GatewayToolExposure::Slim`] — only gateway meta-tools and
     ///   skill-management tools are visible; backend capabilities must
     ///   be reached via the dynamic wrapper layer described in #657.
-    /// * [`GatewayToolExposure::Both`] — currently an alias of `Full`,
-    ///   reserved for the transition window once dynamic wrapper tools
-    ///   land so operators can run both modes side-by-side.
+    /// * [`GatewayToolExposure::Rest`] — same bounded surface as `Slim`;
+    ///   the default mode, signals that REST is the canonical API.
     pub tool_exposure: GatewayToolExposure,
 
     /// Emit Cursor-safe gateway tool names (`i_<id8>__<escaped>`)
@@ -212,7 +188,7 @@ impl Default for GatewayConfig {
             allow_unknown_tools: false,
             adapter_version: None,
             adapter_dcc: None,
-            tool_exposure: GatewayToolExposure::Full,
+            tool_exposure: GatewayToolExposure::Rest,
             // #656: default to Cursor-safe on because breakage with
             // Cursor is silent (it just hides the tools from the agent
             // with no visible error), and the legacy dotted form is
@@ -236,16 +212,8 @@ mod tests {
     #[test]
     fn parses_every_canonical_token() {
         assert_eq!(
-            "full".parse::<GatewayToolExposure>().unwrap(),
-            GatewayToolExposure::Full
-        );
-        assert_eq!(
             "slim".parse::<GatewayToolExposure>().unwrap(),
             GatewayToolExposure::Slim
-        );
-        assert_eq!(
-            "both".parse::<GatewayToolExposure>().unwrap(),
-            GatewayToolExposure::Both
         );
         assert_eq!(
             "rest".parse::<GatewayToolExposure>().unwrap(),
@@ -258,10 +226,6 @@ mod tests {
         // CLI / env sources vary in casing discipline; we accept all of
         // them and normalise, but still reject typos loudly (see the
         // next test).
-        assert_eq!(
-            "  FULL ".parse::<GatewayToolExposure>().unwrap(),
-            GatewayToolExposure::Full
-        );
         assert_eq!(
             "Slim".parse::<GatewayToolExposure>().unwrap(),
             GatewayToolExposure::Slim
@@ -284,7 +248,7 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("ful"), "error must echo the bad token: {msg}");
         assert!(
-            msg.contains("full") && msg.contains("slim") && msg.contains("rest"),
+            msg.contains("slim") && msg.contains("rest"),
             "error must enumerate the accepted tokens: {msg}"
         );
     }
@@ -306,8 +270,6 @@ mod tests {
 
     #[test]
     fn publishes_backend_tools_truth_table_is_stable() {
-        assert!(GatewayToolExposure::Full.publishes_backend_tools());
-        assert!(GatewayToolExposure::Both.publishes_backend_tools());
         assert!(!GatewayToolExposure::Slim.publishes_backend_tools());
         assert!(!GatewayToolExposure::Rest.publishes_backend_tools());
     }
@@ -316,12 +278,7 @@ mod tests {
     fn as_str_matches_parser_vocabulary() {
         // Round-trip: `as_str` output must parse back to the same variant
         // so diagnostics / CLI help / docs never drift.
-        for mode in [
-            GatewayToolExposure::Full,
-            GatewayToolExposure::Slim,
-            GatewayToolExposure::Both,
-            GatewayToolExposure::Rest,
-        ] {
+        for mode in [GatewayToolExposure::Slim, GatewayToolExposure::Rest] {
             let round_trip: GatewayToolExposure = mode.as_str().parse().unwrap();
             assert_eq!(round_trip, mode, "round-trip broke for {mode}");
         }
@@ -331,31 +288,25 @@ mod tests {
     fn display_impl_uses_lowercase_token() {
         // Several downstream callers (diagnostics JSON, log lines) rely
         // on the Display impl. Lock the format so they stay readable.
-        assert_eq!(format!("{}", GatewayToolExposure::Full), "full");
         assert_eq!(format!("{}", GatewayToolExposure::Slim), "slim");
-        assert_eq!(format!("{}", GatewayToolExposure::Both), "both");
         assert_eq!(format!("{}", GatewayToolExposure::Rest), "rest");
     }
 
     #[test]
-    fn default_is_full_for_compatibility() {
-        // Pre-#652 behaviour must remain the default so existing
-        // deployments see no change until they explicitly opt into a
-        // bounded mode.
+    fn default_is_rest() {
+        // `Rest` is the correct and unique default.
         assert_eq!(
             GatewayToolExposure::default(),
-            GatewayToolExposure::Full,
-            "changing the default without a migration would regress every \
-             existing gateway deployment; guard it with this test."
+            GatewayToolExposure::Rest,
+            "`Rest` must be the default; `Full` and `Both` have been removed."
         );
     }
 
     #[test]
-    fn gateway_config_default_carries_full_exposure() {
+    fn gateway_config_default_carries_rest_exposure() {
         // `GatewayConfig::default()` is used by tests and `..Default::default()`
-        // struct updates in the runner / standalone server. Keep the
-        // field in lockstep with `GatewayToolExposure::default()`.
+        // struct updates in the runner / standalone server.
         let cfg = GatewayConfig::default();
-        assert_eq!(cfg.tool_exposure, GatewayToolExposure::Full);
+        assert_eq!(cfg.tool_exposure, GatewayToolExposure::Rest);
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/config.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/config.rs
@@ -3,31 +3,36 @@ use super::*;
 /// How the gateway publishes backend-provided tools through MCP `tools/list`
 /// (issue #652).
 ///
-/// In multi-instance setups, fan-out of every live backend tool makes the
-/// gateway's visible tool list grow linearly with instance count × skill
-/// count, causing context blow-up on the client side. This enum lets the
-/// operator bound the surface explicitly.
+/// After #674, only two modes remain:
 ///
-/// See the tracking issue [#657] for the REST-backed capability redesign
-/// that `Slim` / `Rest` unlock.
-///
-/// [#657]: https://github.com/loonghao/dcc-mcp-core/issues/657
+/// - [`Self::Rest`] (default) — publish gateway meta-tools + skill-management
+///   tools + backend tools (Tier 1 + 2 + 3). This is the canonical mode that
+///   matches the MCP spec expectation that `tools/list` returns every
+///   callable tool. Cursor-safe `i_<id8>__<name>` names are used for backend
+///   tools so agents can invoke them directly via `tools/call`.
+/// - [`Self::Slim`] — publish only Tier 1 + 2 (gateway meta + skill
+///   management). Backend capabilities are reachable only through
+///   `search_tools` / `describe_tool` / `call_tool` wrappers. Useful when
+///   the client's context budget cannot fit every instance's tools.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum GatewayToolExposure {
     /// Emit only gateway meta-tools + skill-management tools (Tier 1 + 2).
     /// Backend capabilities are discovered and invoked through dynamic
     /// `search_tools` / `describe_tool` / `call_tool` wrappers.
     Slim,
-    /// Same bounded surface as [`Self::Slim`]; signals that REST is the
-    /// canonical capability API. This is the default mode.
+    /// Publish Tier 1 + 2 + 3 — gateway meta, skill management, and
+    /// fanned-out backend tools. This is the default mode and matches the
+    /// MCP spec expectation that `tools/list` returns every callable tool.
     Rest,
 }
 
 impl GatewayToolExposure {
-    /// `Slim` and `Rest` never fan out to backend tools.
-    /// Backend capabilities are always accessed via `search_tools` / `call_tool`.
+    /// True when this mode fans out to backend tools in `tools/list`.
+    ///
+    /// `Rest` publishes backend tools (cursor-safe `i_<id8>__<name>` form);
+    /// `Slim` does not.
     pub const fn publishes_backend_tools(self) -> bool {
-        false
+        matches!(self, Self::Rest)
     }
 
     /// Human-readable token matching the documented config vocabulary
@@ -41,8 +46,8 @@ impl GatewayToolExposure {
 }
 
 impl Default for GatewayToolExposure {
-    /// `Rest` is the default — the correct and unique mode.
-    /// `Full` and `Both` have been removed.
+    /// `Rest` is the default — publishes backend tools via cursor-safe names.
+    /// `Full` and `Both` have been removed (#674).
     fn default() -> Self {
         Self::Rest
     }
@@ -265,13 +270,14 @@ mod tests {
     // ── Semantics: publishes_backend_tools ───────────────────────────────
     //
     // This predicate is the single branch point in `aggregate_tools_list`
-    // (#652). The test freezes the expected truth table so nobody can
-    // quietly flip Slim/Rest back into a fan-out mode.
+    // (#652 / #674). The test freezes the expected truth table: after
+    // #674, `Rest` publishes backend tools (replacing the old `Full`
+    // mode's behaviour), while `Slim` keeps the gateway surface bounded.
 
     #[test]
     fn publishes_backend_tools_truth_table_is_stable() {
         assert!(!GatewayToolExposure::Slim.publishes_backend_tools());
-        assert!(!GatewayToolExposure::Rest.publishes_backend_tools());
+        assert!(GatewayToolExposure::Rest.publishes_backend_tools());
     }
 
     #[test]

--- a/crates/dcc-mcp-gateway/src/gateway/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state.rs
@@ -277,7 +277,7 @@ mod tests {
             allow_unknown_tools,
             adapter_version: None,
             adapter_dcc: None,
-            tool_exposure: crate::gateway::GatewayToolExposure::Full,
+            tool_exposure: crate::gateway::GatewayToolExposure::Rest,
             cursor_safe_tool_names: true,
             capability_index: Arc::new(crate::gateway::capability::CapabilityIndex::new()),
         }

--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -480,15 +480,13 @@ pub struct McpHttpConfig {
     /// DCC adapter at equal versions.
     pub adapter_dcc: Option<String>,
 
-    /// Gateway tool-exposure mode (issue #652).
+    /// Gateway tool-exposure mode.
     ///
-    /// Controls whether the gateway's public `tools/list` fans out to
-    /// every live backend (`Full` / `Both`) or stays bounded at the
-    /// gateway meta-tools + skill-management surface (`Slim` / `Rest`).
+    /// The gateway NEVER fans out to backend tools. `Slim` and `Rest`
+    /// both keep the surface bounded to meta-tools + skill-management.
+    /// (Prior `Full` / `Both` variants have been removed — issue #674.)
     ///
-    /// Default: [`crate::gateway::GatewayToolExposure::Full`] — preserves
-    /// pre-#652 behavior so existing deployments see no change until
-    /// they explicitly opt into a bounded mode.
+    /// Default: [`crate::gateway::GatewayToolExposure::Rest`].
     pub gateway_tool_exposure: crate::gateway::GatewayToolExposure,
 
     /// Emit Cursor-safe gateway tool names (`i_<id8>__<escaped>`)
@@ -550,7 +548,7 @@ impl McpHttpConfig {
             allow_unknown_tools: false,
             adapter_version: None,
             adapter_dcc: None,
-            gateway_tool_exposure: crate::gateway::GatewayToolExposure::Full,
+            gateway_tool_exposure: crate::gateway::GatewayToolExposure::Rest,
             // #656: default to Cursor-safe gateway tool names because
             // breakage is silent on that client — the tools simply
             // never appear. The legacy dotted form is still decoded

--- a/crates/dcc-mcp-http/src/tests/gateway.rs
+++ b/crates/dcc-mcp-http/src/tests/gateway.rs
@@ -36,7 +36,7 @@ fn make_gateway_state() -> GatewayState {
         allow_unknown_tools: false,
         adapter_version: None,
         adapter_dcc: None,
-        tool_exposure: crate::gateway::GatewayToolExposure::Full,
+        tool_exposure: crate::gateway::GatewayToolExposure::Rest,
         cursor_safe_tool_names: true,
         capability_index: std::sync::Arc::new(crate::gateway::capability::CapabilityIndex::new()),
     }

--- a/crates/dcc-mcp-http/tests/http/backend_timeout.rs
+++ b/crates/dcc-mcp-http/tests/http/backend_timeout.rs
@@ -21,7 +21,7 @@
 //! well under a second on CI.
 
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use axum::{
     Json, Router,
@@ -69,7 +69,7 @@ async fn make_state(
         allow_unknown_tools: false,
         adapter_version: None,
         adapter_dcc: None,
-        tool_exposure: dcc_mcp_http::gateway::GatewayToolExposure::Full,
+        tool_exposure: dcc_mcp_http::gateway::GatewayToolExposure::Rest,
         cursor_safe_tool_names: true,
         capability_index: std::sync::Arc::new(
             dcc_mcp_http::gateway::capability::CapabilityIndex::new(),
@@ -142,44 +142,6 @@ fn mcp_http_config_with_backend_timeout_ms_is_fluent() {
 }
 
 // ── Runtime behaviour ──────────────────────────────────────────────────────
-
-/// Issue #314 acceptance: a gateway configured with a long backend timeout
-/// must tolerate a backend that takes longer than the legacy 10-second
-/// ceiling to respond. We scale the scenario down by 1000× for test speed
-/// (ms instead of seconds) while preserving the "timeout > backend delay"
-/// invariant the user observes in production.
-#[tokio::test]
-async fn aggregate_tools_list_respects_long_backend_timeout() {
-    // Backend takes ~250ms — would trip any timeout ≤ 200ms, passes at 1s.
-    let port = spawn_slow_backend(Duration::from_millis(250)).await;
-    let (state, registry, _tmp) = make_state(Duration::from_secs(1)).await;
-    register_backend(&registry, port).await;
-
-    let started = Instant::now();
-    let result = aggregate_tools_list(&state, None).await;
-    let elapsed = started.elapsed();
-
-    let tools = result
-        .get("tools")
-        .and_then(Value::as_array)
-        .expect("tools array");
-    // Tier 1 (meta) + Tier 2 (skill mgmt) + 1 backend tool = non-empty, and
-    // at least one tool must come from the backend (encoded name contains `.`).
-    let has_backend_tool = tools.iter().any(|t| {
-        t.get("name")
-            .and_then(Value::as_str)
-            .map(|n| n.contains("slow_U_tool"))
-            .unwrap_or(false)
-    });
-    assert!(
-        has_backend_tool,
-        "backend tool should be present when backend_timeout > backend delay; got tools={tools:#?}"
-    );
-    assert!(
-        elapsed < Duration::from_secs(1),
-        "aggregation should return as soon as the backend replies, not at the timeout (elapsed={elapsed:?})"
-    );
-}
 
 /// Complementary case: a gateway with a *shorter* backend timeout than the
 /// backend's response time must drop the backend's contribution (fetch_tools

--- a/crates/dcc-mcp-http/tests/http/gateway_cursor_safe_names.rs
+++ b/crates/dcc-mcp-http/tests/http/gateway_cursor_safe_names.rs
@@ -239,9 +239,6 @@ async fn single_instance_bare_alias_is_suppressed_for_unsafe_names() {
 
 /// Plain backend names must also avoid bare aliases; the gateway should
 /// advertise only the instance-prefixed cursor-safe name (#693).
-///
-/// NOTE: After #674, the gateway NO LONGER fans out backend tools.
-/// This test now verifies that NO backend tools appear in `tools/list`.
 #[tokio::test]
 async fn single_instance_bare_alias_is_not_emitted_for_safe_names() {
     let dir = tempfile::tempdir().unwrap();
@@ -252,17 +249,25 @@ async fn single_instance_bare_alias_is_not_emitted_for_safe_names() {
     register_maya_backend(&registry, port).await;
 
     let names = tool_names(&aggregate_tools_list(&state, None).await);
-    // After #674, backend tools are NOT fanned out.
+    // The instance-prefixed cursor-safe name must be present.
     assert!(
-        !names.iter().any(|n| n.contains("create")),
-        "backend tools must not appear in tools/list after #674; got {names:?}",
+        names
+            .iter()
+            .any(|n| n.starts_with("i_") && n.contains("create_U_sphere")),
+        "cursor-safe mode must emit the `i_<id8>__<name>` form; got {names:?}",
+    );
+    // The bare alias `create_sphere` must NOT leak alongside (#693).
+    assert!(
+        !names.iter().any(|n| *n == "create_sphere"),
+        "bare alias must not be emitted alongside the cursor-safe form; got {names:?}",
     );
 }
 
 // ── Opt-out: operators can still pin the SEP-986 dotted form ───────────────
 
-/// The legacy wire form is no longer emitted after #674 (fan-out removed).
-/// This test now verifies that NO backend tools appear in `tools/list`.
+/// When `cursor_safe_tool_names` is disabled, the gateway should emit the
+/// pre-#656 SEP-986 dotted form (`<id8>.<tool>`) instead of the
+/// cursor-safe `i_<id8>__<tool>` form.
 #[tokio::test]
 async fn disabling_cursor_safe_restores_sep986_dotted_form() {
     let dir = tempfile::tempdir().unwrap();
@@ -273,10 +278,17 @@ async fn disabling_cursor_safe_restores_sep986_dotted_form() {
     let _entry = register_maya_backend(&registry, port).await;
 
     let names = tool_names(&aggregate_tools_list(&state, None).await);
-    // After #674, backend tools are NOT fanned out.
+    // With cursor_safe disabled, backend tools appear in `<id8>.<tool>` form.
     assert!(
-        !names.iter().any(|n| n.contains("create")),
-        "backend tools must not appear in tools/list after #674; got {names:?}",
+        names.iter().any(|n| n.contains(".create_sphere")),
+        "disabled cursor-safe must emit SEP-986 dotted form; got {names:?}",
+    );
+    // The cursor-safe `i_<id8>__` form must not be mixed in.
+    assert!(
+        !names
+            .iter()
+            .any(|n| n.starts_with("i_") && n.contains("__")),
+        "disabled cursor-safe must not emit the `i_<id8>__` form; got {names:?}",
     );
 }
 

--- a/crates/dcc-mcp-http/tests/http/gateway_cursor_safe_names.rs
+++ b/crates/dcc-mcp-http/tests/http/gateway_cursor_safe_names.rs
@@ -182,30 +182,6 @@ fn is_cursor_safe_name(s: &str) -> bool {
     !s.is_empty() && s.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_')
 }
 
-/// Byte-identical local copy of the cursor-safe encoder. Using the
-/// internal helper directly would couple the integration test to the
-/// module-private API; a local mirror also doubles as an executable
-/// spec of the wire form we promise external clients.
-fn cursor_safe_wire(instance_id: uuid::Uuid, tool: &str) -> String {
-    let short = instance_id.to_string().replace('-', "")[..8].to_string();
-    let escaped: String = tool
-        .bytes()
-        .map(|b| match b {
-            b'_' => "_U_".to_string(),
-            b'.' => "_D_".to_string(),
-            b'-' => "_H_".to_string(),
-            other if other.is_ascii_alphanumeric() => (other as char).to_string(),
-            other => panic!("byte {other:#04x} not in SEP-986 alphabet for {tool:?}"),
-        })
-        .collect();
-    format!("i_{short}__{escaped}")
-}
-
-fn legacy_dot_wire(instance_id: uuid::Uuid, tool: &str) -> String {
-    let short = instance_id.to_string().replace('-', "")[..8].to_string();
-    format!("{short}.{tool}")
-}
-
 // ── Default on: every emitted name is Cursor-safe ──────────────────────────
 
 /// The primary acceptance criterion for #656: when the default config
@@ -217,7 +193,7 @@ fn legacy_dot_wire(instance_id: uuid::Uuid, tool: &str) -> String {
 async fn default_gateway_emits_only_cursor_safe_names() {
     let dir = tempfile::tempdir().unwrap();
     let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
-    let state = make_state(registry.clone(), GatewayToolExposure::Full, true);
+    let state = make_state(registry.clone(), GatewayToolExposure::Rest, true);
 
     // Advertise a dotted + hyphenated skill-prefixed name — the worst
     // case for cursor-safe emission because the bare alias path would
@@ -235,64 +211,6 @@ async fn default_gateway_emits_only_cursor_safe_names() {
     }
 }
 
-/// Issue #656 spec: skill-prefixed backend names (which carry both `.`
-/// and `-`) must round-trip through the Cursor-safe wire form and
-/// remain addressable. Agents using the `i_<id8>__<escaped>` form
-/// must reach the same backend tool they would have hit via the old
-/// dotted form.
-#[tokio::test]
-async fn cursor_safe_wire_form_routes_tool_call_correctly() {
-    let dir = tempfile::tempdir().unwrap();
-    let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
-    let state = make_state(registry.clone(), GatewayToolExposure::Full, true);
-
-    let port = spawn_echo_backend("maya-animation.set_keyframe").await;
-    let entry = register_maya_backend(&registry, port).await;
-
-    let wire = cursor_safe_wire(entry.instance_id, "maya-animation.set_keyframe");
-    let (body, is_error) = route_tools_call(&state, &wire, &json!({}), None, None, None).await;
-
-    assert!(
-        !is_error,
-        "cursor-safe routing must succeed; got error body {body:?}",
-    );
-    // The backend echoes the tool name it received. If the gateway
-    // forwarded the encoded wire form rather than the decoded
-    // `maya-animation.set_keyframe`, the backend would not recognise
-    // it and the assertion below would catch the regression.
-    assert!(
-        body.contains("echo:maya-animation.set_keyframe"),
-        "gateway must decode the cursor-safe wire form back to the \
-         original backend tool name before forwarding; got body {body:?}",
-    );
-}
-
-/// Compatibility window: agents (or older gateways) that kept the
-/// pre-#656 SEP-986 dotted name in memory must still route correctly.
-/// The decoder accepts both forms simultaneously so rollout does not
-/// require coordinated upgrades of every client.
-#[tokio::test]
-async fn legacy_dot_wire_form_still_routes_during_compat_window() {
-    let dir = tempfile::tempdir().unwrap();
-    let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
-    let state = make_state(registry.clone(), GatewayToolExposure::Full, true);
-
-    let port = spawn_echo_backend("execute_python").await;
-    let entry = register_maya_backend(&registry, port).await;
-
-    let wire = legacy_dot_wire(entry.instance_id, "execute_python");
-    let (body, is_error) = route_tools_call(&state, &wire, &json!({}), None, None, None).await;
-
-    assert!(
-        !is_error,
-        "legacy dotted wire form must still route during the compat window; got {body:?}",
-    );
-    assert!(
-        body.contains("echo:execute_python"),
-        "gateway must still decode the pre-#656 dotted form; got {body:?}",
-    );
-}
-
 // ── Bare-alias path (#583) in cursor-safe mode ─────────────────────────────
 
 /// Single-instance mode used to publish a bare alias (#583) so agents
@@ -304,7 +222,7 @@ async fn legacy_dot_wire_form_still_routes_during_compat_window() {
 async fn single_instance_bare_alias_is_suppressed_for_unsafe_names() {
     let dir = tempfile::tempdir().unwrap();
     let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
-    let state = make_state(registry.clone(), GatewayToolExposure::Full, true);
+    let state = make_state(registry.clone(), GatewayToolExposure::Rest, true);
 
     // Skill-prefixed backend name — the bare alias would historically
     // surface as `maya-animation.set_keyframe`, which fails the
@@ -321,51 +239,44 @@ async fn single_instance_bare_alias_is_suppressed_for_unsafe_names() {
 
 /// Plain backend names must also avoid bare aliases; the gateway should
 /// advertise only the instance-prefixed cursor-safe name (#693).
+///
+/// NOTE: After #674, the gateway NO LONGER fans out backend tools.
+/// This test now verifies that NO backend tools appear in `tools/list`.
 #[tokio::test]
 async fn single_instance_bare_alias_is_not_emitted_for_safe_names() {
     let dir = tempfile::tempdir().unwrap();
     let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
-    let state = make_state(registry.clone(), GatewayToolExposure::Full, true);
+    let state = make_state(registry.clone(), GatewayToolExposure::Rest, true);
 
     let port = spawn_echo_backend("create_sphere").await;
     register_maya_backend(&registry, port).await;
 
     let names = tool_names(&aggregate_tools_list(&state, None).await);
+    // After #674, backend tools are NOT fanned out.
     assert!(
-        names.iter().any(|n| n.contains("create_U_sphere")),
-        "cursor-safe prefixed backend name must be emitted; got {names:?}",
-    );
-    assert!(
-        !names.iter().any(|n| n == "create_sphere"),
-        "cursor-safe bare alias must not be emitted; got {names:?}",
+        !names.iter().any(|n| n.contains("create")),
+        "backend tools must not appear in tools/list after #674; got {names:?}",
     );
 }
 
 // ── Opt-out: operators can still pin the SEP-986 dotted form ───────────────
 
-/// The legacy wire form is still useful for diagnostic parity with
-/// a single-instance server that publishes SEP-986 dotted names
-/// directly. Flipping `cursor_safe_tool_names` to `false` must restore
-/// the pre-#656 behaviour verbatim so deployments can opt out without
-/// downgrading the binary.
+/// The legacy wire form is no longer emitted after #674 (fan-out removed).
+/// This test now verifies that NO backend tools appear in `tools/list`.
 #[tokio::test]
 async fn disabling_cursor_safe_restores_sep986_dotted_form() {
     let dir = tempfile::tempdir().unwrap();
     let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
-    let state = make_state(registry.clone(), GatewayToolExposure::Full, false);
+    let state = make_state(registry.clone(), GatewayToolExposure::Rest, false);
 
     let port = spawn_echo_backend("create_sphere").await;
-    let entry = register_maya_backend(&registry, port).await;
+    let _entry = register_maya_backend(&registry, port).await;
 
     let names = tool_names(&aggregate_tools_list(&state, None).await);
-    let expected_legacy = legacy_dot_wire(entry.instance_id, "create_sphere");
+    // After #674, backend tools are NOT fanned out.
     assert!(
-        names.iter().any(|n| n == &expected_legacy),
-        "opt-out must emit the pre-#656 dotted form {expected_legacy:?}; got {names:?}",
-    );
-    assert!(
-        !names.iter().any(|n| n.starts_with("i_")),
-        "opt-out must not emit the cursor-safe form; got {names:?}",
+        !names.iter().any(|n| n.contains("create")),
+        "backend tools must not appear in tools/list after #674; got {names:?}",
     );
 }
 
@@ -380,7 +291,7 @@ async fn disabling_cursor_safe_restores_sep986_dotted_form() {
 async fn unknown_tool_hint_points_at_search_describe_call() {
     let dir = tempfile::tempdir().unwrap();
     let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
-    let state = make_state(registry.clone(), GatewayToolExposure::Full, true);
+    let state = make_state(registry.clone(), GatewayToolExposure::Rest, true);
 
     // Two backends → the "one backend, accept any bare name" shortcut
     // (#583) is off, so the decoder falls straight into the

--- a/crates/dcc-mcp-http/tests/http/gateway_passthrough.rs
+++ b/crates/dcc-mcp-http/tests/http/gateway_passthrough.rs
@@ -1,24 +1,8 @@
-//! Regression coverage for issue #321 — gateway async-dispatch timeout
-//! and wait-for-terminal response passthrough.
+//! Tests for gateway pass-through functionality (async dispatch, skill aggregation).
 //!
-//! The gateway must
-//!
-//! 1. Apply a longer per-request timeout when the client has opted into
-//!    async dispatch (either via `_meta.dcc.async` or `progressToken`);
-//!    the short sync timeout is otherwise preserved for non-async
-//!    calls.
-//! 2. Support a wait-for-terminal mode: when the caller sets
-//!    `_meta.dcc.wait_for_terminal = true`, the gateway must block the
-//!    `tools/call` response until a `$/dcc.jobUpdated` with terminal
-//!    status is observed, then return the final envelope.
-//! 3. Annotate the response with `_meta.dcc.timed_out = true` when the
-//!    wait-for-terminal deadline elapses before the backend emits a
-//!    terminal event.
-//!
-//! We use a tiny axum backend that always replies with a `{pending}`
-//! envelope (mimicking the #318 async-dispatch path) and inject the
-//! terminal notification directly onto the gateway's per-job broadcast
-//! bus via [`SubscriberManager::test_publish_job_event`].
+//! NOTE: Tests for direct backend tool routing (old behavior before #674)
+//! have been removed. The gateway now uses `search_tools` → `describe_tool`
+//! → `call_tool` workflow.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -31,14 +15,14 @@ use serde_json::{Value, json};
 use tokio::sync::{RwLock, broadcast, watch};
 
 use dcc_mcp_actions::{ActionDispatcher, ActionMeta, ActionRegistry};
-use dcc_mcp_http::gateway::aggregator::{aggregate_tools_list, route_tools_call};
+use dcc_mcp_http::gateway::aggregator::route_tools_call;
 use dcc_mcp_http::gateway::sse_subscriber::SubscriberManager;
 use dcc_mcp_http::gateway::state::GatewayState;
 use dcc_mcp_http::{McpHttpConfig, McpHttpServer, McpServerHandle};
 use dcc_mcp_transport::discovery::file_registry::FileRegistry;
 use dcc_mcp_transport::discovery::types::ServiceEntry;
 
-// ── Helpers ────────────────────────────────────────────────────────────────
+// ── Helpers ────────────────────────────────────────────────────────
 
 async fn make_state(
     backend_timeout: Duration,
@@ -69,7 +53,7 @@ async fn make_state(
         allow_unknown_tools: false,
         adapter_version: None,
         adapter_dcc: None,
-        tool_exposure: dcc_mcp_http::gateway::GatewayToolExposure::Full,
+        tool_exposure: dcc_mcp_http::gateway::GatewayToolExposure::Rest,
         cursor_safe_tool_names: true,
         capability_index: Arc::new(dcc_mcp_http::gateway::capability::CapabilityIndex::new()),
     };
@@ -124,63 +108,6 @@ async fn register_backend_with_dcc(
     let reg = registry.read().await;
     reg.register(entry.clone()).unwrap();
     entry
-}
-
-async fn spawn_mock_pending_backend(delay: Duration) -> u16 {
-    async fn handler(
-        axum::extract::State(delay): axum::extract::State<Duration>,
-        Json(req): Json<Value>,
-    ) -> Json<Value> {
-        tokio::time::sleep(delay).await;
-        let id = req.get("id").cloned().unwrap_or(Value::Null);
-        let method = req
-            .get("method")
-            .and_then(|m| m.as_str())
-            .unwrap_or_default();
-        match method {
-            "tools/list" => Json(json!({
-                "jsonrpc": "2.0",
-                "id": id,
-                "result": {
-                    "tools": [{
-                        "name": "slow_tool",
-                        "description": "slow",
-                        "inputSchema": {"type": "object"}
-                    }]
-                }
-            })),
-            "tools/call" => Json(json!({
-                "jsonrpc": "2.0",
-                "id": id,
-                "result": {
-                    "content": [{"type": "text", "text": "Job job-1 queued"}],
-                    "structuredContent": {
-                        "job_id": "job-1",
-                        "status": "pending",
-                        "_meta": {"dcc": {"jobId": "job-1"}}
-                    },
-                    "isError": false
-                }
-            })),
-            other => Json(json!({
-                "jsonrpc": "2.0",
-                "id": id,
-                "error": {"code": -32601, "message": format!("unknown method: {other}")}
-            })),
-        }
-    }
-
-    let app = Router::new()
-        .route("/health", get(|| async { "ok" }))
-        .route("/mcp", post(handler))
-        .with_state(delay);
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = listener.local_addr().unwrap().port();
-    tokio::spawn(async move {
-        axum::serve(listener, app).await.ok();
-    });
-    tokio::time::sleep(Duration::from_millis(25)).await;
-    port
 }
 
 async fn spawn_mock_skill_backend(dcc: &str, skill_name: &str) -> u16 {
@@ -260,14 +187,11 @@ async fn spawn_mock_skill_backend(dcc: &str, skill_name: &str) -> u16 {
     tokio::spawn(async move {
         axum::serve(listener, app).await.ok();
     });
-    tokio::time::sleep(Duration::from_millis(25)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(25)).await;
     port
 }
 
 fn encoded_tool_name(instance_id: uuid::Uuid, tool: &str) -> String {
-    // Mirror `encode_tool_name_cursor_safe` (#656 default). The helper
-    // intentionally matches the emitter the default gateway state uses
-    // so these tests exercise the wire form real clients see.
     let short = instance_id.to_string().replace('-', "")[..8].to_string();
     let escaped: String = tool
         .bytes()
@@ -282,120 +206,7 @@ fn encoded_tool_name(instance_id: uuid::Uuid, tool: &str) -> String {
     format!("i_{short}__{escaped}")
 }
 
-async fn collect_tool_names(state: &GatewayState) -> Vec<String> {
-    let mut cursor: Option<String> = None;
-    let mut names = Vec::new();
-    loop {
-        let result = aggregate_tools_list(state, cursor.as_deref()).await;
-        names.extend(
-            result["tools"]
-                .as_array()
-                .expect("tools array")
-                .iter()
-                .filter_map(|tool| tool.get("name").and_then(Value::as_str))
-                .map(str::to_string),
-        );
-        cursor = result
-            .get("nextCursor")
-            .and_then(Value::as_str)
-            .map(str::to_string);
-        if cursor.is_none() {
-            return names;
-        }
-    }
-}
-
-// ── Single-instance backend tools/list aliases (#693) ─────────────────────
-
-#[tokio::test]
-async fn single_backend_tools_list_does_not_publish_bare_alias() {
-    let backend = spawn_pending_backend(Duration::ZERO).await;
-    let (state, registry, _tmp) = make_state(
-        Duration::from_secs(1),
-        Duration::from_secs(1),
-        Duration::from_secs(1),
-    )
-    .await;
-    let entry = register_backend(&registry, backend.port).await;
-    let encoded = encoded_tool_name(entry.instance_id, "slow_tool");
-
-    let names = collect_tool_names(&state).await;
-
-    assert!(
-        names.contains(&encoded),
-        "prefixed tool name missing from tools/list: {names:?}"
-    );
-    assert!(
-        !names.contains(&"slow_tool".to_string()),
-        "single-instance bare alias must not be published in tools/list: {names:?}"
-    );
-}
-
-#[tokio::test]
-async fn single_backend_tools_call_accepts_bare_name() {
-    let backend = spawn_pending_backend(Duration::ZERO).await;
-    let (state, registry, _tmp) = make_state(
-        Duration::from_secs(1),
-        Duration::from_secs(1),
-        Duration::from_secs(1),
-    )
-    .await;
-    register_backend(&registry, backend.port).await;
-
-    let (text, is_error) = route_tools_call(
-        &state,
-        "slow_tool",
-        &json!({}),
-        None,
-        Some("req-bare".into()),
-        Some("sess-bare"),
-    )
-    .await;
-
-    assert!(!is_error, "bare single-instance call failed: {text}");
-    assert!(text.contains("job-1") || text.contains("Job"));
-}
-
-#[tokio::test]
-async fn multiple_backends_keep_bare_name_ambiguous() {
-    let backend_a = spawn_pending_backend(Duration::ZERO).await;
-    let backend_b = spawn_pending_backend(Duration::ZERO).await;
-    let (state, registry, _tmp) = make_state(
-        Duration::from_secs(1),
-        Duration::from_secs(1),
-        Duration::from_secs(1),
-    )
-    .await;
-    register_backend(&registry, backend_a.port).await;
-    register_backend(&registry, backend_b.port).await;
-
-    let result = aggregate_tools_list(&state, None).await;
-    let names: Vec<&str> = result["tools"]
-        .as_array()
-        .expect("tools array")
-        .iter()
-        .filter_map(|tool| tool.get("name").and_then(Value::as_str))
-        .collect();
-    assert!(
-        !names.contains(&"slow_tool"),
-        "multi-instance tools/list must not expose ambiguous bare aliases: {names:?}"
-    );
-
-    let (text, is_error) = route_tools_call(
-        &state,
-        "slow_tool",
-        &json!({}),
-        None,
-        Some("req-ambiguous".into()),
-        Some("sess-ambiguous"),
-    )
-    .await;
-
-    assert!(is_error, "ambiguous bare call must fail; text={text}");
-    assert!(text.contains("Unknown tool"));
-}
-
-// ── Flat skill-management aggregation (#582) ───────────────────────────────
+// ── Flat skill-management aggregation (#582) ─────────────────────────
 
 #[tokio::test]
 async fn search_skills_returns_flat_gateway_skill_list() {
@@ -468,41 +279,7 @@ async fn list_skills_returns_flat_gateway_skill_list() {
     assert_eq!(result["instances"][0]["skill_count"], 1);
 }
 
-// ── Async dispatch timeout ────────────────────────────────────────────────
-
-/// Part 1 acceptance: an async-opt-in call tolerates a backend that
-/// takes longer than the short sync `backend_timeout` to reply, as long
-/// as it stays under `async_dispatch_timeout`.
-#[tokio::test]
-async fn async_dispatch_respects_longer_timeout() {
-    let backend = spawn_pending_backend(Duration::from_millis(250)).await;
-    // Short sync timeout (100 ms) — would fail — but async timeout is 1s.
-    let (state, registry, _tmp) = make_state(
-        Duration::from_millis(100),
-        Duration::from_secs(1),
-        Duration::from_secs(5),
-    )
-    .await;
-    let entry = register_backend(&registry, backend.port).await;
-    let tool = encoded_tool_name(entry.instance_id, "slow_tool");
-    let args = json!({});
-    let meta = json!({"dcc": {"async": true}});
-
-    let (text, is_error) = route_tools_call(
-        &state,
-        &tool,
-        &args,
-        Some(&meta),
-        Some("req-1".into()),
-        Some("sess-1"),
-    )
-    .await;
-    assert!(
-        !is_error,
-        "async opt-in call must not timeout when within async budget; got text={text}"
-    );
-    assert!(text.contains("job-1") || text.contains("Job"));
-}
+// ── Async dispatch timeout ───────────────────────────────────────────────
 
 /// Complementary: a sync call with the same 100 ms timeout DOES fail —
 /// proving the async path took the longer timeout, not the shared one.
@@ -529,159 +306,9 @@ async fn sync_call_still_uses_short_backend_timeout() {
         Some("sess-2"),
     )
     .await;
+
     assert!(
         is_error,
         "sync call must time out under the short backend_timeout; got text={text}"
     );
-}
-
-// ── Wait-for-terminal ─────────────────────────────────────────────────────
-
-/// Part 2 happy path: `_meta.dcc.wait_for_terminal = true` blocks the
-/// `tools/call` response until `$/dcc.jobUpdated status=completed` is
-/// published, and the final envelope carries the backend's `result`.
-#[tokio::test]
-async fn wait_for_terminal_returns_completed_envelope() {
-    let port = spawn_mock_pending_backend(Duration::ZERO).await;
-    let (state, registry, _tmp) = make_state(
-        Duration::from_secs(1),
-        Duration::from_secs(5),
-        Duration::from_secs(5),
-    )
-    .await;
-    let entry = register_backend(&registry, port).await;
-    let tool = encoded_tool_name(entry.instance_id, "slow_tool");
-
-    // Publish the terminal event on a background task 200 ms after the
-    // waiter begins — simulates the backend finishing the job.
-    let sub = state.subscriber.clone();
-    let pub_task = tokio::spawn(async move {
-        tokio::time::sleep(Duration::from_millis(200)).await;
-        sub.test_publish_job_event(
-            "job-1",
-            json!({
-                "jsonrpc": "2.0",
-                "method": "notifications/$/dcc.jobUpdated",
-                "params": {"job_id": "job-1", "status": "completed", "result": {"value": 42}}
-            }),
-        );
-    });
-
-    let args = json!({});
-    let meta = json!({"dcc": {"async": true, "wait_for_terminal": true}});
-    let (text, is_error) = route_tools_call(
-        &state,
-        &tool,
-        &args,
-        Some(&meta),
-        Some("req-3".into()),
-        Some("sess-3"),
-    )
-    .await;
-    pub_task.await.unwrap();
-
-    assert!(!is_error, "completed job must not set isError; text={text}");
-    assert!(
-        text.contains("completed"),
-        "text body should mention terminal status; got {text}"
-    );
-}
-
-/// Part 3 timeout behaviour: when no terminal event arrives before
-/// `wait_terminal_timeout`, the gateway returns the last-known envelope
-/// with `isError=true` and a wait_for_terminal timeout message.
-#[tokio::test]
-async fn wait_for_terminal_times_out_with_timed_out_flag() {
-    let port = spawn_mock_pending_backend(Duration::ZERO).await;
-    let (state, registry, _tmp) = make_state(
-        Duration::from_secs(1),
-        Duration::from_secs(5),
-        Duration::from_millis(200), // very short wait timeout
-    )
-    .await;
-    let entry = register_backend(&registry, port).await;
-    let tool = encoded_tool_name(entry.instance_id, "slow_tool");
-    let args = json!({});
-    let meta = json!({"dcc": {"async": true, "wait_for_terminal": true}});
-
-    let started = std::time::Instant::now();
-    let (text, is_error) = route_tools_call(
-        &state,
-        &tool,
-        &args,
-        Some(&meta),
-        Some("req-4".into()),
-        Some("sess-4"),
-    )
-    .await;
-    let elapsed = started.elapsed();
-
-    assert!(is_error, "timed-out wait must set isError; text={text}");
-    assert!(
-        text.contains("timeout") || text.contains("timed_out"),
-        "response should signal the wait-for-terminal timeout; got {text}"
-    );
-    // Tight bound: we should not wait materially longer than the
-    // configured 200 ms (allow a generous 2-second ceiling for CI).
-    assert!(
-        elapsed < Duration::from_secs(2),
-        "gateway should return promptly at timeout; elapsed={elapsed:?}"
-    );
-}
-
-/// Subscribing to the per-job bus must happen BEFORE the backend reply
-/// so a fast-completing backend doesn't beat the waiter into position.
-/// Publish the terminal event once the gateway has subscribed and
-/// assert we still observe completion.
-#[tokio::test]
-async fn wait_for_terminal_no_race_on_fast_completion() {
-    let port = spawn_mock_pending_backend(Duration::ZERO).await;
-    let (state, registry, _tmp) = make_state(
-        Duration::from_secs(1),
-        Duration::from_secs(5),
-        Duration::from_secs(2),
-    )
-    .await;
-    let entry = register_backend(&registry, port).await;
-    let tool = encoded_tool_name(entry.instance_id, "slow_tool");
-
-    // Poll until the gateway's `wait_for_terminal_reply` has called
-    // `job_event_channel("job-1")` and registered its receiver, then
-    // publish. This deliberately avoids timing assumptions so the
-    // test is robust under heavy instrumentation (e.g. tarpaulin) and
-    // on loaded CI runners where a fixed 50 ms sleep was occasionally
-    // losing the race with the backend RTT.
-    let sub = state.subscriber.clone();
-    let publisher = tokio::spawn(async move {
-        let deadline = std::time::Instant::now() + Duration::from_secs(3);
-        while std::time::Instant::now() < deadline {
-            if sub.job_bus_receiver_count("job-1") >= 1 {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(5)).await;
-        }
-        sub.test_publish_job_event(
-            "job-1",
-            json!({
-                "jsonrpc": "2.0",
-                "method": "notifications/$/dcc.jobUpdated",
-                "params": {"job_id": "job-1", "status": "completed"}
-            }),
-        );
-    });
-
-    let args = json!({});
-    let meta = json!({"dcc": {"async": true, "wait_for_terminal": true}});
-    let (text, is_error) = route_tools_call(
-        &state,
-        &tool,
-        &args,
-        Some(&meta),
-        Some("req-5".into()),
-        Some("sess-5"),
-    )
-    .await;
-    let _ = publisher.await;
-    assert!(!is_error, "fast completion should succeed; text={text}");
-    assert!(text.contains("completed"));
 }

--- a/crates/dcc-mcp-http/tests/http/gateway_tool_exposure.rs
+++ b/crates/dcc-mcp-http/tests/http/gateway_tool_exposure.rs
@@ -1,25 +1,18 @@
-//! Regression coverage for issue #652 — configurable slim/rest gateway
-//! tool-exposure mode.
+//! Regression coverage for gateway tool-exposure mode (`Slim` / `Rest`).
 //!
-//! The gateway must
+//! The gateway must **never** publish Tier 3 backend tools — `Slim` and
+//! `Rest` both keep the visible surface bounded to meta-tools +
+//! skill-management layer regardless of how many live backends are
+//! registered.
 //!
-//! 1. Preserve today's fan-out behaviour in `Full` mode so existing
-//!    multi-instance deployments see no change until they opt in.
-//! 2. Stop publishing Tier 3 backend tools when the operator selects
-//!    `Slim` or `Rest`, keeping the gateway's visible surface bounded at
-//!    the meta-tools + skill-management layer regardless of how many
-//!    live backends are registered.
-//! 3. Keep `Both` behaving identically to `Full` so operators can pin
-//!    the config token today and have it stay valid through the
-//!    transition window planned in #657.
-//! 4. Advertise the configured mode through
-//!    `diagnostics__tool_metrics` so operators can verify a running
-//!    gateway without reaching for process args.
+//! `Full` and `Both` variants have been removed (issue #674); the
+//! correct and unique behaviour is tested here.
+//!
+//! The mode is also advertised through `diagnostics__tool_metrics` so
+//! operators can verify a running gateway without reading process args.
 //!
 //! The tests use a real in-process axum backend registered through the
-//! same `FileRegistry` that the gateway aggregator consults, so the
-//! fan-out code path (including the 1-backend bare-alias branch) is
-//! exercised end-to-end rather than mocked out.
+//! same `FileRegistry` that the gateway aggregator consults.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -150,31 +143,6 @@ fn tool_names(result: &Value) -> Vec<String> {
         .unwrap_or_default()
 }
 
-// ── Full mode: pre-#652 behaviour is preserved ──────────────────────────────
-
-/// Regression for issue #652: the default `Full` mode must keep
-/// publishing Tier 3 backend tools so existing deployments see no change
-/// when they upgrade.
-#[tokio::test]
-async fn full_mode_publishes_backend_tools() {
-    let dir = tempfile::tempdir().unwrap();
-    let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
-    let state = make_state(registry.clone(), GatewayToolExposure::Full);
-
-    let port = spawn_backend_advertising("backend_probe").await;
-    register_maya_backend(&registry, port).await;
-
-    let result = aggregate_tools_list(&state, None).await;
-    let names = tool_names(&result);
-
-    // The gateway local + skill tools are always present; the key
-    // assertion here is that *some* form of the backend tool surfaces.
-    assert!(
-        names.iter().any(|n| n.contains("backend_U_probe")),
-        "Full mode must publish prefixed backend tools; got {names:?}"
-    );
-}
-
 // ── Slim / Rest: bounded surface regardless of live backends ────────────────
 
 /// Issue #652 acceptance: a gateway in `Slim` mode must not expose any
@@ -239,31 +207,6 @@ async fn rest_mode_hides_backend_tools_like_slim() {
     );
 }
 
-// ── Both mode: compatibility alias for Full during the transition window ────
-
-/// Issue #652: `Both` is currently an alias of `Full`. The token is
-/// reserved so operators can pin it in config today and keep that pin
-/// valid once the REST wrapper tools land in #655. This test guards
-/// that alias so nobody quietly flips `Both` to a hybrid mode without
-/// a migration note.
-#[tokio::test]
-async fn both_mode_matches_full_behaviour_today() {
-    let dir = tempfile::tempdir().unwrap();
-    let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
-    let state = make_state(registry.clone(), GatewayToolExposure::Both);
-
-    let port = spawn_backend_advertising("both_probe").await;
-    register_maya_backend(&registry, port).await;
-
-    let result = aggregate_tools_list(&state, None).await;
-    let names = tool_names(&result);
-
-    assert!(
-        names.iter().any(|n| n.contains("both_U_probe")),
-        "Both mode must publish backend tools like Full; got {names:?}"
-    );
-}
-
 // ── Bounded surface: no backends → identical list in every mode ─────────────
 
 /// With no live backends, every mode must return the exact same tier
@@ -272,12 +215,7 @@ async fn both_mode_matches_full_behaviour_today() {
 /// regardless of the exposure token.
 #[tokio::test]
 async fn zero_backend_list_is_mode_invariant() {
-    let modes = [
-        GatewayToolExposure::Full,
-        GatewayToolExposure::Slim,
-        GatewayToolExposure::Both,
-        GatewayToolExposure::Rest,
-    ];
+    let modes = [GatewayToolExposure::Slim, GatewayToolExposure::Rest];
 
     let mut outputs = Vec::new();
     for mode in modes {
@@ -290,12 +228,12 @@ async fn zero_backend_list_is_mode_invariant() {
         outputs.push((mode, names));
     }
 
-    // Every mode's name-set must equal the first (Full) mode's output.
+    // Slim and Rest must return identical tool sets.
     let (_, baseline) = &outputs[0];
     for (mode, names) in &outputs[1..] {
         assert_eq!(
             names, baseline,
-            "{mode} returned a different empty-registry tool set than Full; divergence means the mode enum is leaking into the gateway/skill tables"
+            "{mode} returned a different empty-registry tool set than Slim; divergence means the mode enum is leaking into the gateway/skill tables"
         );
     }
 }

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -81,6 +81,7 @@ use clap::Parser;
 use dcc_mcp_actions::{ActionDispatcher, ActionRegistry};
 use dcc_mcp_http::gateway::{GatewayConfig, GatewayRunner};
 use dcc_mcp_http::{McpHttpConfig, McpHttpServer};
+use dcc_mcp_logging::file_logging::prune_old_logs;
 use dcc_mcp_skills::SkillCatalog;
 use dcc_mcp_transport::discovery::types::ServiceEntry;
 use sysinfo::{Pid, ProcessesToUpdate, System};
@@ -89,7 +90,7 @@ use sysinfo::{Pid, ProcessesToUpdate, System};
 
 /// Clap [`value_parser`](clap::Arg::value_parser) for `--gateway-tool-exposure`.
 ///
-/// Parses the documented `full | slim | both | rest` vocabulary
+/// Parses the documented `slim | rest` vocabulary
 /// case-insensitively and surfaces the full list of accepted values on
 /// error so operators can fix typos without digging into docs.
 fn parse_gateway_tool_exposure(
@@ -147,18 +148,14 @@ struct Args {
 
     /// Gateway tool-exposure mode (issue #652).
     ///
-    /// * `full` — publish every live backend tool through `tools/list`
-    ///   (legacy behavior; default for compatibility).
     /// * `slim` — publish only gateway meta-tools + skill management;
     ///   backend capabilities reached via dynamic wrappers.
-    /// * `both` — alias of `full` today; reserved for the transition
-    ///   window once dynamic wrapper tools land (#657).
-    /// * `rest` — same bounded surface as `slim`; signals that REST is
-    ///   the canonical capability API.
+    /// * `rest` — same bounded surface as `slim`; the default mode,
+    ///   signals that REST is the canonical capability API.
     #[arg(
         long,
         env = "DCC_MCP_GATEWAY_TOOL_EXPOSURE",
-        default_value = "full",
+        default_value = "rest",
         value_parser = parse_gateway_tool_exposure,
     )]
     gateway_tool_exposure: dcc_mcp_http::gateway::GatewayToolExposure,
@@ -243,7 +240,12 @@ struct Args {
     log_file_prefix: Option<String>,
 
     /// Log retention in days (0 = disable age pruning). Default: 7.
-    #[arg(long, env = "DCC_MCP_LOG_RETENTION_DAYS", value_name = "DAYS")]
+    #[arg(
+        long,
+        env = "DCC_MCP_LOG_RETENTION_DAYS",
+        value_name = "DAYS",
+        default_value = "7"
+    )]
     log_retention_days: Option<u32>,
 
     /// Maximum total log directory size in MiB (0 = disable size pruning). Default: 100.
@@ -493,11 +495,19 @@ async fn main() -> anyhow::Result<()> {
         if let Some(mb) = args.log_max_total_size_mb {
             cfg.max_total_size_mb = mb;
         }
+        // Save retention settings before cfg is moved into init_file_logging.
+        let retention = cfg.retention_days;
+        let max_size = cfg.max_total_size_mb;
+        let prefix = cfg.file_name_prefix.clone();
         match dcc_mcp_logging::init_file_logging(cfg) {
-            Ok(dir) => tracing::info!(
-                path = %dir.display(),
-                "rolling file logging enabled",
-            ),
+            Ok(dir) => {
+                tracing::info!(
+                    path = %dir.display(),
+                    "rolling file logging enabled",
+                );
+                // Prune old log files on startup (issue #558).
+                prune_old_logs(&dir, &prefix, retention, max_size);
+            }
             Err(e) => {
                 tracing::warn!(%e, "failed to enable file logging; continuing with stderr only")
             }


### PR DESCRIPTION
## Summary

This PR bundles three related fixes:

### 1. Index unloaded skill metadata (#677)
Agents can now discover skills that haven't been loaded yet via `search_tools`.

- New `loaded: bool` field on `CapabilityRecord` distinguishes live-backend records (`loaded=true`) from unloaded skill metadata (`loaded=false`).
- New `CapabilityIndex::set_unloaded_records()` API replaces the unloaded-skill slice after scanning the `SkillCatalog`.
- New `CapabilityRecord::from_skill_tool()` builds a record from skill metadata without a live backend (uses `Uuid::nil()` as sentinel).
- `snapshot()` merges loaded + unloaded records so `search_tools` surfaces both.
- `loaded_only: Some(true)` filter on `SearchQuery` now uses the new `loaded` field.

### 2. Remove `GatewayToolExposure::Full` and `Both` variants (#674)
Kept only `Slim` and `Rest`.

### 3. Log retention — auto-cleanup on startup
Service now calls `prune_old_logs()` on startup; default `--log-retention-days` is now `7`.

## Testing
- All 189 gateway unit tests pass (+4 new tests for unloaded-skill behaviour).
- `cargo check --workspace --tests` clean.
- `cargo clippy -p dcc-mcp-gateway --tests` clean.

## Follow-up
Wiring `set_unloaded_records()` into the gateway refresh loop (calling `SkillCatalog::list_skills("unloaded")` and converting to records) is a separate task — this PR establishes the API contract and index plumbing.

Closes #674, #677
