### PR TITLE
fix(http): honour ThreadAffinity on sync tools/call path (#716)

### DIFF
--- a/crates/dcc-mcp-http/src/handlers/tools_call/async_impl.rs
+++ b/crates/dcc-mcp-http/src/handlers/tools_call/async_impl.rs
@@ -98,9 +98,11 @@ fn spawn_async_execution(
     let spawn_job_id = job_id.clone();
     let spawn_name = resolved_name.clone();
     let spawn_params = call_params;
-    let use_main_thread = matches!(thread_affinity, dcc_mcp_models::ThreadAffinity::Main);
+    // Issue #716: use the shared routing helper so sync and async paths
+    // agree on "does this call need the UI dispatcher?".
+    let use_main_thread = super::use_main_thread_route(thread_affinity, executor.is_some());
 
-    if use_main_thread && executor.is_none() {
+    if matches!(thread_affinity, dcc_mcp_models::ThreadAffinity::Main) && executor.is_none() {
         tracing::warn!(
             tool = %spawn_name,
             "tool declares thread_affinity=main but no DeferredExecutor is wired; \

--- a/crates/dcc-mcp-http/src/handlers/tools_call/mod.rs
+++ b/crates/dcc-mcp-http/src/handlers/tools_call/mod.rs
@@ -13,6 +13,34 @@ use async_impl::async_dispatch_config;
 use resolve_impl::{ToolCallResolution, resolve_tool_call};
 use sync_impl::dispatch_sync_tool_call;
 
+/// Shared routing decision used by both sync and async `tools/call` paths
+/// (issue #716).
+///
+/// Returns `true` when the call should be dispatched on the DCC main thread
+/// (via the wired [`crate::executor::DccExecutorHandle`]), `false` when it
+/// should run on a Tokio worker via `spawn_blocking`.
+///
+/// Routing is driven by **action metadata**, not by whether an executor
+/// happens to be wired:
+///
+/// * `ThreadAffinity::Main` + executor present → main thread
+/// * `ThreadAffinity::Main` + no executor       → worker (with a warning
+///   logged by the caller; scene API calls would be unsafe here)
+/// * `ThreadAffinity::Any`                      → worker, even when an
+///   executor is wired — the UI dispatcher is a single-slot queue and must
+///   not be reserved for tools that don't need the main thread.
+///
+/// Before this helper existed, the sync path branched on
+/// `executor.is_some()` alone, so every embedded-DCC backend routed
+/// `affinity: any` tools through the UI dispatcher where they would fight
+/// `affinity: main` tools for the same slot.
+pub(crate) fn use_main_thread_route(
+    thread_affinity: dcc_mcp_models::ThreadAffinity,
+    executor_present: bool,
+) -> bool {
+    matches!(thread_affinity, dcc_mcp_models::ThreadAffinity::Main) && executor_present
+}
+
 pub async fn handle_tools_call(
     state: &AppState,
     req: &JsonRpcRequest,

--- a/crates/dcc-mcp-http/src/handlers/tools_call/sync_impl.rs
+++ b/crates/dcc-mcp-http/src/handlers/tools_call/sync_impl.rs
@@ -52,6 +52,7 @@ pub(super) async fn dispatch_sync_tool_call(
         &resolved.resolved_name,
         resolved.call_params.clone(),
         cancel_token.clone(),
+        resolved.action_meta.thread_affinity,
     )
     .await;
 
@@ -189,8 +190,29 @@ async fn execute_sync_dispatch(
     resolved_name: &str,
     call_params: Value,
     cancel_token: CancelToken,
+    thread_affinity: dcc_mcp_models::ThreadAffinity,
 ) -> Result<Value, String> {
-    if let Some(executor) = &state.executor {
+    // Issue #716: route based on the tool's declared `ThreadAffinity`, not on
+    // whether an executor is wired. `Any` tools must bypass the UI dispatcher
+    // even when we have one, or they fight `Main` tools for the same
+    // single-slot queue. See `super::use_main_thread_route` for the shared
+    // decision between sync and async paths.
+    let executor_present = state.executor.is_some();
+    let on_main = super::use_main_thread_route(thread_affinity, executor_present);
+
+    if matches!(thread_affinity, dcc_mcp_models::ThreadAffinity::Main) && !executor_present {
+        tracing::warn!(
+            tool = %resolved_name,
+            "sync tool declares thread_affinity=main but no DeferredExecutor is wired; \
+             falling back to Tokio worker — scene API calls will be unsafe"
+        );
+    }
+
+    if on_main {
+        let executor = state
+            .executor
+            .as_ref()
+            .expect("executor presence gated by use_main_thread_route");
         run_on_main_thread(
             state,
             executor,

--- a/crates/dcc-mcp-http/tests/http.rs
+++ b/crates/dcc-mcp-http/tests/http.rs
@@ -48,3 +48,6 @@ mod prometheus_endpoint;
 
 #[path = "http/resources.rs"]
 mod resources;
+
+#[path = "http/sync_affinity_routing.rs"]
+mod sync_affinity_routing;

--- a/crates/dcc-mcp-http/tests/http/sync_affinity_routing.rs
+++ b/crates/dcc-mcp-http/tests/http/sync_affinity_routing.rs
@@ -1,0 +1,200 @@
+//! Integration tests for sync `tools/call` affinity-aware routing (issue #716).
+//!
+//! The sync path used to branch on "is a DccExecutor wired?" alone, so every
+//! embedded-DCC backend ran `affinity: any` tools through the UI dispatcher
+//! where they fought `affinity: main` tools for the same single-slot queue.
+//!
+//! These tests exercise the full HTTP surface with a `DeferredExecutor` whose
+//! pump is **never called**:
+//!
+//! * an `affinity: any` sync `tools/call` must still complete (it must route
+//!   to `spawn_blocking`, bypassing the executor queue)
+//! * an `affinity: main` sync `tools/call` must NOT complete while the pump
+//!   is starved — demonstrating that `main` tools still go through the
+//!   executor and that the routing really does differ between the two
+//!   affinities
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use dcc_mcp_actions::{ActionDispatcher, ActionMeta, ActionRegistry};
+use dcc_mcp_http::{DeferredExecutor, McpHttpConfig, McpHttpServer};
+use dcc_mcp_models::ThreadAffinity;
+
+async fn wait_reachable(addr: &str) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < deadline {
+        if tokio::net::TcpStream::connect(addr).await.is_ok() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    false
+}
+
+/// Build a registry with two tools:
+/// - `any_tool`: declared `ThreadAffinity::Any`, returns `{"ok": true}`
+/// - `main_tool`: declared `ThreadAffinity::Main`, returns `{"ok": true}`
+fn make_registry_with_both_affinities() -> (Arc<ActionRegistry>, Arc<ActionDispatcher>) {
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_action(ActionMeta {
+        name: "any_tool".into(),
+        description: "pure compute — no DCC state, any thread is fine".into(),
+        category: "test".into(),
+        version: "1.0.0".into(),
+        thread_affinity: ThreadAffinity::Any,
+        ..Default::default()
+    });
+    registry.register_action(ActionMeta {
+        name: "main_tool".into(),
+        description: "mutates scene — must run on DCC main thread".into(),
+        category: "test".into(),
+        version: "1.0.0".into(),
+        thread_affinity: ThreadAffinity::Main,
+        ..Default::default()
+    });
+    let dispatcher = Arc::new(ActionDispatcher::new((*registry).clone()));
+    dispatcher.register_handler("any_tool", |_args| Ok(serde_json::json!({"ok": true})));
+    dispatcher.register_handler("main_tool", |_args| Ok(serde_json::json!({"ok": true})));
+    (registry, dispatcher)
+}
+
+async fn call_tool(client: &reqwest::Client, addr: &str, tool: &str) -> reqwest::Response {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": { "name": tool, "arguments": {} }
+    });
+    client
+        .post(format!("http://{addr}/mcp"))
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream")
+        .json(&body)
+        .send()
+        .await
+        .expect("POST /mcp")
+}
+
+/// Acceptance test from the issue: with a DeferredExecutor whose pump is
+/// never drained, a sync `tools/call` to an `affinity: any` tool must still
+/// complete — because the router now bypasses the executor for `Any`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn sync_any_affinity_bypasses_blocked_ui_dispatcher() {
+    let (registry, dispatcher) = make_registry_with_both_affinities();
+
+    // Build a DeferredExecutor but keep ownership of it so nothing ever
+    // calls poll_pending(): the UI queue is effectively stuck.
+    let executor = DeferredExecutor::new(16);
+    let handle = executor.handle();
+
+    let cfg = McpHttpConfig::new(0).with_name("sync-affinity-any");
+    let server = McpHttpServer::new(registry, cfg)
+        .with_dispatcher(dispatcher)
+        .with_executor(handle);
+
+    let server_handle = server.start().await.expect("server starts");
+    let addr = server_handle.bind_addr.clone();
+    assert!(wait_reachable(&addr).await);
+
+    let client = reqwest::Client::new();
+
+    // The executor is wired but its pump never runs. If the sync path
+    // blindly sends every call through the executor, this request would
+    // hang. With #716, `any_tool` must route to spawn_blocking and return
+    // quickly.
+    let fut = call_tool(&client, &addr, "any_tool");
+    let resp = tokio::time::timeout(Duration::from_secs(3), fut)
+        .await
+        .expect("sync any_tool must not block on starved UI dispatcher")
+        .error_for_status()
+        .expect("2xx");
+    let payload: serde_json::Value = resp.json().await.expect("valid JSON-RPC");
+    let is_error = payload
+        .pointer("/result/isError")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    assert!(
+        !is_error,
+        "any-affinity tool must succeed off the UI dispatcher, got {payload:#}"
+    );
+
+    // Keep executor alive for the duration of the test; dropping the
+    // DeferredExecutor closes the mpsc which would also unblock main calls.
+    drop(executor);
+    server_handle.shutdown().await;
+}
+
+/// Regression guard: `affinity: main` sync calls still route through the
+/// executor. Without a pump they never complete within the test window —
+/// which is exactly the behaviour that would fail the test above for
+/// `any_tool` if #716 had not been fixed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn sync_main_affinity_still_routes_through_executor() {
+    let (registry, dispatcher) = make_registry_with_both_affinities();
+
+    let executor = DeferredExecutor::new(16);
+    let handle = executor.handle();
+
+    let cfg = McpHttpConfig::new(0).with_name("sync-affinity-main");
+    let server = McpHttpServer::new(registry, cfg)
+        .with_dispatcher(dispatcher)
+        .with_executor(handle);
+
+    let server_handle = server.start().await.expect("server starts");
+    let addr = server_handle.bind_addr.clone();
+    assert!(wait_reachable(&addr).await);
+
+    let client = reqwest::Client::new();
+
+    // With no pump, `main_tool` cannot progress — the request times out.
+    // (A generous 500 ms is plenty; we want to observe the *lack* of a
+    // response, not measure precise timing.)
+    let fut = call_tool(&client, &addr, "main_tool");
+    let outcome = tokio::time::timeout(Duration::from_millis(500), fut).await;
+    assert!(
+        outcome.is_err(),
+        "main-affinity sync call must NOT complete while the UI pump is starved; \
+         got {outcome:?} — did #716 accidentally route `Main` off the executor?"
+    );
+
+    drop(executor);
+    server_handle.shutdown().await;
+}
+
+/// Sanity: when no DeferredExecutor is wired at all, both affinities go
+/// through `spawn_blocking` and succeed — this has always been the case and
+/// #716 must not regress it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn sync_calls_succeed_without_executor_for_both_affinities() {
+    let (registry, dispatcher) = make_registry_with_both_affinities();
+
+    let cfg = McpHttpConfig::new(0).with_name("sync-affinity-no-executor");
+    let server = McpHttpServer::new(registry, cfg).with_dispatcher(dispatcher);
+
+    let server_handle = server.start().await.expect("server starts");
+    let addr = server_handle.bind_addr.clone();
+    assert!(wait_reachable(&addr).await);
+
+    let client = reqwest::Client::new();
+
+    for tool in ["any_tool", "main_tool"] {
+        let fut = call_tool(&client, &addr, tool);
+        let resp = tokio::time::timeout(Duration::from_secs(3), fut)
+            .await
+            .unwrap_or_else(|_| panic!("{tool} timed out without an executor"))
+            .error_for_status()
+            .expect("2xx");
+        let payload: serde_json::Value = resp.json().await.unwrap();
+        let is_error = payload
+            .pointer("/result/isError")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        assert!(
+            !is_error,
+            "{tool} must succeed with no executor, got {payload:#}"
+        );
+    }
+
+    server_handle.shutdown().await;
+}

--- a/docs/guide/dcc-thread-safety.md
+++ b/docs/guide/dcc-thread-safety.md
@@ -140,6 +140,33 @@ Key invariants:
    no DCC host), the handler falls back to `spawn_blocking` and logs
    `tracing::warn!` so the misconfiguration is visible.
 
+### Sync-path parity (issue #716)
+
+The **sync** `tools/call` path follows the same rule as the async path:
+routing is driven by `ActionMeta.thread_affinity`, not by whether a
+`DeferredExecutor` happens to be wired. Before #716 the sync branch
+always ran through the executor whenever one existed, so every
+`ThreadAffinity::Any` sync tool contended with `Main`-affined tools for
+the same single-slot UI dispatcher.
+
+The invariant is now:
+
+> **`affinity: any` tools never block the host UI thread, regardless of
+> transport (sync or async) or DCC.**
+
+Concretely:
+
+- `ThreadAffinity::Main` + executor present → runs on DCC main thread via
+  `DeferredExecutor`.
+- `ThreadAffinity::Main` + no executor → falls back to `spawn_blocking`
+  with a warning (scene API calls would be unsafe).
+- `ThreadAffinity::Any` → always runs on a Tokio worker via
+  `spawn_blocking`, even when an executor is wired.
+
+Sync and async paths share this decision via
+`use_main_thread_route(thread_affinity, executor_present)` in
+`crates/dcc-mcp-http/src/handlers/tools_call/mod.rs`.
+
 #### Long-running async tools (cooperative contract)
 
 If your tool declares `long_running: true` or `timeout_hint_secs > 1`,


### PR DESCRIPTION
Fixes #716.

## Problem

The sync `tools/call` branch used to decide routing on `executor.is_some()` alone, so every embedded-DCC backend ran `affinity: any` sync tools through the single-slot UI dispatcher where they fought `affinity: main` tools for the same queue. Trivial calls like `execute_python("3 + 4")` would stall whenever Maya's main thread was busy booting.

## Fix

Sync and async `tools/call` paths now share a `use_main_thread_route(thread_affinity, executor_present)` helper (in `crates/dcc-mcp-http/src/handlers/tools_call/mod.rs`). The invariant:

- `Main` + executor present → `DeferredExecutor` (DCC main thread)
- `Main` + no executor → `spawn_blocking` with warning (unsafe fallback)
- `Any` → `spawn_blocking`, **always** — even when an executor is wired

## Tests

New integration tests in `crates/dcc-mcp-http/tests/http/sync_affinity_routing.rs`:

1. **`sync_any_affinity_bypasses_blocked_ui_dispatcher`** — acceptance test from the issue: with a `DeferredExecutor` whose pump is never drained, a sync `any_tool` call still completes within 3 s.
2. **`sync_main_affinity_still_routes_through_executor`** — regression guard: `main_tool` sync calls still hang when the pump is starved, proving the two affinities take different routes.
3. **`sync_calls_succeed_without_executor_for_both_affinities`** — sanity: pure-HTTP mode works for both affinities.

All 57 pre-existing `dcc-mcp-http` integration tests still pass; `cargo fmt` / `cargo clippy --tests` clean.

## Docs

Adds a "Sync-path parity (issue #716)" section to `docs/guide/dcc-thread-safety.md` documenting the new invariant:

> `affinity: any` tools never block the host UI thread, regardless of transport (sync or async) or DCC.

## Follow-ups

- The Python-side `_executor.execute_in_process` affinity branch in `dcc-mcp-maya` becomes redundant once this lands and can be removed in a follow-up (noted in the issue).