### PR TITLE
feat(http+rest): gate tools/call on shared ReadinessProbe (#714)

### DIFF
--- a/crates/dcc-mcp-http/src/handler/state.rs
+++ b/crates/dcc-mcp-http/src/handler/state.rs
@@ -58,6 +58,7 @@ use crate::{
     session::SessionManager,
 };
 use dcc_mcp_actions::{ActionDispatcher, ActionRegistry};
+use dcc_mcp_skill_rest::{ReadinessProbe, StaticReadiness};
 use dcc_mcp_skills::SkillCatalog;
 
 /// How long a cancellation record is kept before being garbage-collected.
@@ -166,6 +167,21 @@ pub struct AppState {
     /// additional handlers via [`AppState::register_method`] before the
     /// server starts serving requests.
     pub method_router: Arc<super::router::MethodRouter>,
+    /// Shared three-state readiness probe gating DCC-touching
+    /// `tools/call` dispatches (issue #714).
+    ///
+    /// This is the **same** `Arc<dyn ReadinessProbe>` that is wired
+    /// into the sibling `dcc_mcp_skill_rest` router, so `POST /mcp`
+    /// (JSON-RPC `tools/call`) and `POST /v1/call` (REST) consult a
+    /// single source of truth about whether the backend is ready.
+    ///
+    /// Defaults to [`StaticReadiness::fully_ready`] for standalone
+    /// embedders and existing tests; DCC adapters (Maya, Blender…)
+    /// should install a probe they flip from `false → true` once the
+    /// host has finished booting. Control tools (`list_skills`,
+    /// `search_skills`, `load_skill`, …) **bypass** the gate so agents
+    /// can still discover and introspect during boot.
+    pub readiness: Arc<dyn ReadinessProbe>,
 }
 
 impl AppState {
@@ -199,6 +215,19 @@ impl AppState {
     /// pre-populated with every built-in MCP method (issue #492).
     pub fn default_method_router() -> Arc<super::router::MethodRouter> {
         Arc::new(super::router::MethodRouter::with_builtins())
+    }
+
+    /// Build the default [`ReadinessProbe`] — a `StaticReadiness`
+    /// locked to the fully-ready state (issue #714).
+    ///
+    /// This preserves the pre-#714 behaviour for existing tests and
+    /// standalone embedders that do not wire a real probe. DCC
+    /// adapters should install their own `Arc<dyn ReadinessProbe>`
+    /// via [`McpHttpServer::with_readiness`](crate::McpHttpServer::with_readiness)
+    /// so the state can be flipped from `false → true` once the host
+    /// has finished booting.
+    pub fn default_readiness() -> Arc<dyn ReadinessProbe> {
+        Arc::new(StaticReadiness::fully_ready())
     }
 
     /// Register a custom [`MethodHandler`](super::router::MethodHandler)

--- a/crates/dcc-mcp-http/src/handlers/tools_call/mod.rs
+++ b/crates/dcc-mcp-http/src/handlers/tools_call/mod.rs
@@ -72,6 +72,18 @@ pub async fn handle_tools_call_inner(
         ToolCallResolution::Dispatch(resolved) => *resolved,
     };
 
+    // Issue #714 — readiness gate. Runs *after* `resolve_tool_call` so
+    // discovery/introspection tools (`list_skills`, `search_skills`,
+    // `load_skill`, `list_dynamic_tools`, `jobs.get_status`, …) — which
+    // take the early-return `ToolCallResolution::Response` branch —
+    // bypass the gate. Only DCC-touching actions reach this point, so a
+    // red probe reliably refuses work that would otherwise queue on
+    // `DeferredExecutor` / `QueueDispatcher` while the DCC is still
+    // booting.
+    if let Some(response) = readiness_gate(state, req, &resolved.tool_name) {
+        return Ok(response);
+    }
+
     if let Some(async_cfg) = async_dispatch_config(&resolved.params, &resolved.action_meta) {
         return dispatch_async_job(
             state,
@@ -87,4 +99,50 @@ pub async fn handle_tools_call_inner(
     }
 
     dispatch_sync_tool_call(state, req, session_id, resolved).await
+}
+
+/// Refuse DCC-touching `tools/call` dispatches when the shared
+/// [`ReadinessProbe`](dcc_mcp_skill_rest::ReadinessProbe) is red
+/// (issue #714).
+///
+/// Returns `None` when the probe reports ready, so the caller can
+/// continue with the normal dispatch path. When the probe is red,
+/// returns a `JsonRpcResponse` carrying error code
+/// [`BACKEND_NOT_READY`](crate::protocol::error_codes::BACKEND_NOT_READY)
+/// with a structured `data` payload echoing the three-state report so
+/// clients can back off with context.
+fn readiness_gate(
+    state: &AppState,
+    req: &JsonRpcRequest,
+    tool_name: &str,
+) -> Option<JsonRpcResponse> {
+    let report = state.readiness.report();
+    if report.is_ready() {
+        return None;
+    }
+    tracing::warn!(
+        tool = tool_name,
+        readiness.process = report.process,
+        readiness.dispatcher = report.dispatcher,
+        readiness.dcc = report.dcc,
+        "tools/call refused: backend not ready (issue #714)"
+    );
+    Some(JsonRpcResponse::error_with_data(
+        req.id.clone(),
+        crate::protocol::error_codes::BACKEND_NOT_READY,
+        format!(
+            "Backend is not ready yet: process={}, dispatcher={}, dcc={}. \
+             Refusing to queue `tools/call` for `{tool_name}` — retry once \
+             `/v1/readyz` reports ready.",
+            report.process, report.dispatcher, report.dcc
+        ),
+        Some(serde_json::json!({
+            "tool": tool_name,
+            "readiness": {
+                "process": report.process,
+                "dispatcher": report.dispatcher,
+                "dcc": report.dcc,
+            },
+        })),
+    ))
 }

--- a/crates/dcc-mcp-http/src/lib.rs
+++ b/crates/dcc-mcp-http/src/lib.rs
@@ -125,7 +125,9 @@ pub use skill_rest::{
 pub use workspace::{WorkspaceResolveError, WorkspaceRoots};
 
 #[cfg(feature = "python-bindings")]
-pub use python::{PyMcpHttpConfig, PyMcpHttpServer, PyServerHandle, PyWorkspaceRoots};
+pub use python::{
+    PyMcpHttpConfig, PyMcpHttpServer, PyReadinessProbe, PyServerHandle, PyWorkspaceRoots,
+};
 
 #[cfg(test)]
 mod tests;

--- a/crates/dcc-mcp-http/src/python/bridge.rs
+++ b/crates/dcc-mcp-http/src/python/bridge.rs
@@ -251,6 +251,9 @@ pub fn register_classes(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyBridgeContext>()?;
     m.add_class::<PyBridgeRegistry>()?;
     m.add_class::<PyWorkspaceRoots>()?;
+    // Shared readiness probe (issue #714) — adapters install one
+    // `ReadinessProbe` and both `/mcp` and `/v1/call` consult it.
+    m.add_class::<super::PyReadinessProbe>()?;
     // Dynamic tools + output capture (issues #462, #461)
     super::output_dynamic::register(m)?;
     m.add_function(wrap_pyfunction!(py_create_skill_server, m)?)?;
@@ -374,5 +377,6 @@ pub fn py_create_skill_server(
         runtime: Arc::new(runtime),
         live_meta,
         attached_executor: parking_lot::Mutex::new(None),
+        readiness_probe: parking_lot::Mutex::new(None),
     })
 }

--- a/crates/dcc-mcp-http/src/python/mod.rs
+++ b/crates/dcc-mcp-http/src/python/mod.rs
@@ -3,6 +3,7 @@
 pub mod bridge;
 pub mod config;
 pub mod output_dynamic;
+pub mod readiness;
 pub mod server;
 pub mod skill_server;
 pub mod workspace;
@@ -13,6 +14,7 @@ pub use bridge::{
 };
 pub use config::PyMcpHttpConfig;
 pub use output_dynamic::{PyOutputCapture, PyToolSpec};
+pub use readiness::PyReadinessProbe;
 pub use server::PyServerHandle;
 pub use skill_server::PyMcpHttpServer;
 pub use workspace::PyWorkspaceRoots;

--- a/crates/dcc-mcp-http/src/python/readiness.rs
+++ b/crates/dcc-mcp-http/src/python/readiness.rs
@@ -1,0 +1,110 @@
+//! Python wrapper around [`dcc_mcp_skill_rest::StaticReadiness`] so
+//! adapters (Maya, Blender, …) can share one probe instance between
+//! the MCP `tools/call` surface and the REST `POST /v1/call` surface
+//! (issue #714).
+//!
+//! Use [`PyMcpHttpServer::set_readiness_probe`](super::PyMcpHttpServer)
+//! to install the probe on the server before starting it, then flip
+//! the `dispatcher` / `dcc` bits from the DCC adapter's boot-complete
+//! hook.
+
+use std::sync::Arc;
+
+use pyo3::prelude::*;
+
+use dcc_mcp_skill_rest::{ReadinessProbe, StaticReadiness};
+
+/// A three-state readiness probe (`process` / `dispatcher` / `dcc`) that
+/// is shared between the MCP `tools/call` handler and the REST
+/// `POST /v1/call` handler. Toggle the three bits as the DCC host
+/// boots; `tools/call` refuses work with
+/// `BACKEND_NOT_READY (-32002)` until the probe reports fully ready.
+///
+/// ``process`` defaults to ``True`` (the HTTP listener answers, so by
+/// the time Python can construct this object the process is trivially
+/// alive); ``dispatcher`` and ``dcc`` default to ``False``.
+///
+/// Example:
+///
+///     from dcc_mcp_core import ReadinessProbe, McpHttpServer, McpHttpConfig
+///
+///     probe = ReadinessProbe()
+///     server = McpHttpServer(registry, McpHttpConfig(port=8765))
+///     server.set_readiness_probe(probe)
+///     server.start()
+///
+///     # ... later, once Maya's scripting engine is up:
+///     probe.set_dispatcher_ready(True)
+///     probe.set_dcc_ready(True)
+#[pyclass(name = "ReadinessProbe", module = "dcc_mcp_core", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyReadinessProbe {
+    pub(crate) inner: Arc<StaticReadiness>,
+}
+
+#[pymethods]
+impl PyReadinessProbe {
+    /// Construct a fresh probe. Starts in the not-ready state
+    /// (``dispatcher=False``, ``dcc=False``) so `tools/call` refuses
+    /// work until the adapter flips the bits.
+    #[new]
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(StaticReadiness::new()),
+        }
+    }
+
+    /// Start fully-ready. Convenient for standalone tests and servers
+    /// with no embedded DCC to wait on.
+    #[staticmethod]
+    fn fully_ready() -> Self {
+        Self {
+            inner: Arc::new(StaticReadiness::fully_ready()),
+        }
+    }
+
+    /// Toggle dispatcher readiness — call with ``True`` once the
+    /// action dispatcher is wired.
+    fn set_dispatcher_ready(&self, ready: bool) {
+        self.inner.set_dispatcher_ready(ready);
+    }
+
+    /// Toggle DCC host readiness — call with ``True`` once the DCC's
+    /// scripting engine / scene / etc. has finished booting.
+    fn set_dcc_ready(&self, ready: bool) {
+        self.inner.set_dcc_ready(ready);
+    }
+
+    /// Return ``True`` when all three bits are green.
+    fn is_ready(&self) -> bool {
+        self.inner.report().is_ready()
+    }
+
+    /// Return the current report as a ``dict`` with ``process`` /
+    /// ``dispatcher`` / ``dcc`` keys.
+    fn report(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        use pyo3::types::PyDict;
+        let report = self.inner.report();
+        let d = PyDict::new(py);
+        d.set_item("process", report.process)?;
+        d.set_item("dispatcher", report.dispatcher)?;
+        d.set_item("dcc", report.dcc)?;
+        Ok(d.into_any().unbind())
+    }
+
+    fn __repr__(&self) -> String {
+        let r = self.inner.report();
+        format!(
+            "ReadinessProbe(process={}, dispatcher={}, dcc={})",
+            r.process, r.dispatcher, r.dcc
+        )
+    }
+}
+
+impl PyReadinessProbe {
+    /// Return the shared [`Arc<dyn ReadinessProbe>`] for plumbing into
+    /// the Rust server. Cheap clone of the inner `Arc`.
+    pub(crate) fn as_dyn(&self) -> Arc<dyn ReadinessProbe> {
+        self.inner.clone()
+    }
+}

--- a/crates/dcc-mcp-http/src/python/skill_server.rs
+++ b/crates/dcc-mcp-http/src/python/skill_server.rs
@@ -33,6 +33,13 @@ pub struct PyMcpHttpServer {
     /// by [`PyMcpHttpServer::start`]; further `attach_dispatcher`
     /// calls after start are rejected.
     pub(crate) attached_executor: parking_lot::Mutex<Option<crate::executor::DccExecutorHandle>>,
+    /// Optional shared [`ReadinessProbe`] installed via
+    /// [`PyMcpHttpServer::set_readiness_probe`] (issue #714). When
+    /// present, it is wired into both the MCP `tools/call` gate and
+    /// the REST `POST /v1/call` handler, so adapters only need to
+    /// flip the bits on this one instance.
+    pub(crate) readiness_probe:
+        parking_lot::Mutex<Option<Arc<dyn dcc_mcp_skill_rest::ReadinessProbe>>>,
 }
 
 #[pymethods]
@@ -70,6 +77,7 @@ impl PyMcpHttpServer {
             runtime: Arc::new(runtime),
             live_meta,
             attached_executor: parking_lot::Mutex::new(None),
+            readiness_probe: parking_lot::Mutex::new(None),
         })
     }
 
@@ -144,6 +152,11 @@ impl PyMcpHttpServer {
         if let Some(executor) = self.attached_executor.lock().take() {
             server = server.with_executor(executor);
         }
+        // Issue #714 — propagate the shared readiness probe into the
+        // Rust server so both `/mcp` and `/v1/call` consult it.
+        if let Some(probe) = self.readiness_probe.lock().as_ref().cloned() {
+            server = server.with_readiness(probe);
+        }
         let handle = self
             .runtime
             .block_on(server.start())
@@ -161,6 +174,31 @@ impl PyMcpHttpServer {
             is_gateway,
             live_meta: self.live_meta.clone(),
         })
+    }
+
+    /// Install a shared :class:`ReadinessProbe` that gates DCC-touching
+    /// ``tools/call`` and ``POST /v1/call`` dispatches (issue #714).
+    ///
+    /// Call this **before** :meth:`start`. The same probe instance
+    /// backs both the MCP and REST surfaces, so a single
+    /// ``probe.set_dispatcher_ready(True); probe.set_dcc_ready(True)``
+    /// from the DCC adapter's boot-complete hook flips readiness
+    /// for every surface at once.
+    ///
+    /// Without a probe installed, the server defaults to the legacy
+    /// fully-ready behaviour — tests and standalone servers are
+    /// unaffected.
+    ///
+    /// Args:
+    ///     probe: A :class:`dcc_mcp_core.ReadinessProbe` instance.
+    #[pyo3(signature = (probe))]
+    fn set_readiness_probe(&self, probe: PyRef<'_, super::PyReadinessProbe>) -> PyResult<()> {
+        *self.readiness_probe.lock() = Some(probe.as_dyn());
+        tracing::info!(
+            "McpHttpServer: readiness probe installed — /mcp and /v1/call \
+             will share it (issue #714)"
+        );
+        Ok(())
     }
 
     /// Register a Python callable as the handler for ``action_name``.

--- a/crates/dcc-mcp-http/src/server/mod.rs
+++ b/crates/dcc-mcp-http/src/server/mod.rs
@@ -17,6 +17,7 @@ use crate::{
     session::SessionManager,
 };
 use dcc_mcp_actions::{ActionDispatcher, ActionRegistry};
+use dcc_mcp_skill_rest::ReadinessProbe;
 use dcc_mcp_skills::SkillCatalog;
 
 mod background_impl;
@@ -144,6 +145,11 @@ pub struct McpHttpServer {
     /// Live scene/version that is sync'd to FileRegistry on every heartbeat.
     /// Updated via [`McpHttpServer::update_live_scene`].
     live_meta: LiveMeta,
+    /// Optional shared [`ReadinessProbe`] gating DCC-touching
+    /// `tools/call` dispatches (issue #714). When `None`, the server
+    /// falls back to [`AppState::default_readiness`] (fully-ready) so
+    /// existing embedders keep working unchanged.
+    readiness: Option<Arc<dyn ReadinessProbe>>,
 }
 
 impl McpHttpServer {
@@ -174,6 +180,7 @@ impl McpHttpServer {
             resources,
             prompts,
             live_meta,
+            readiness: None,
         }
     }
 
@@ -203,6 +210,7 @@ impl McpHttpServer {
             resources,
             prompts,
             live_meta,
+            readiness: None,
         }
     }
 
@@ -282,6 +290,22 @@ impl McpHttpServer {
     /// returned `PyServerHandle`).
     pub fn with_live_meta(mut self, live_meta: LiveMeta) -> Self {
         self.live_meta = live_meta;
+        self
+    }
+
+    /// Install a shared three-state [`ReadinessProbe`] (issue #714).
+    ///
+    /// The same probe is wired into **both** the MCP `tools/call`
+    /// handler and the REST `POST /v1/call` handler, so a single
+    /// `probe.set_dispatcher_ready(true); probe.set_dcc_ready(true)`
+    /// from the hosting DCC adapter (e.g. `dcc-mcp-maya`) flips
+    /// readiness for every surface at once.
+    ///
+    /// When not installed, the server defaults to
+    /// [`AppState::default_readiness`] (fully-ready) so existing
+    /// standalone embedders and tests do not regress.
+    pub fn with_readiness(mut self, probe: Arc<dyn ReadinessProbe>) -> Self {
+        self.readiness = Some(probe);
         self
     }
 
@@ -387,12 +411,21 @@ impl McpHttpServer {
             }
         }
 
+        // Issue #714 — the same ReadinessProbe instance backs both
+        // `POST /v1/call` (REST) and `POST /mcp` (MCP tools/call), so
+        // one flip from the DCC adapter gates every surface at once.
+        let readiness = self
+            .readiness
+            .clone()
+            .unwrap_or_else(AppState::default_readiness);
+
         let mut rest_config = dcc_mcp_skill_rest::SkillRestConfig::new(
             dcc_mcp_skill_rest::SkillRestService::from_catalog_and_dispatcher(
                 catalog.clone(),
                 self.dispatcher.clone(),
             ),
-        );
+        )
+        .with_readiness(readiness.clone());
         rest_config.server_title = self.config.server_name.clone();
         rest_config.server_version = self.config.server_version.clone();
         let rest_router = dcc_mcp_skill_rest::build_skill_rest_router(rest_config);
@@ -423,6 +456,7 @@ impl McpHttpServer {
             #[cfg(feature = "prometheus")]
             prometheus: prometheus.clone(),
             method_router: AppState::default_method_router(),
+            readiness,
         };
 
         let endpoint = self.config.endpoint_path.clone();

--- a/crates/dcc-mcp-http/src/tests/dispatch_with_handler.rs
+++ b/crates/dcc-mcp-http/src/tests/dispatch_with_handler.rs
@@ -36,6 +36,7 @@ pub fn make_app_state_with_handler() -> AppState {
         registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         enable_tool_cache: true,
         method_router: crate::handler::AppState::default_method_router(),
+        readiness: crate::handler::AppState::default_readiness(),
     }
 }
 
@@ -86,6 +87,7 @@ fn make_router_with_handler_output(output: Value) -> axum::Router {
         registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         enable_tool_cache: true,
         method_router: crate::handler::AppState::default_method_router(),
+        readiness: crate::handler::AppState::default_readiness(),
     };
 
     Router::new()
@@ -261,6 +263,7 @@ pub async fn test_tools_call_handler_error() {
         registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         enable_tool_cache: true,
         method_router: crate::handler::AppState::default_method_router(),
+        readiness: crate::handler::AppState::default_readiness(),
     };
 
     use crate::handler::{handle_delete, handle_get, handle_post};

--- a/crates/dcc-mcp-http/src/tests/lazy_actions.rs
+++ b/crates/dcc-mcp-http/src/tests/lazy_actions.rs
@@ -71,6 +71,7 @@ fn make_state(lazy_actions: bool) -> AppState {
         registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         enable_tool_cache: true,
         method_router: crate::handler::AppState::default_method_router(),
+        readiness: crate::handler::AppState::default_readiness(),
     }
 }
 

--- a/crates/dcc-mcp-http/src/tests/mod.rs
+++ b/crates/dcc-mcp-http/src/tests/mod.rs
@@ -67,6 +67,7 @@ fn make_app_state() -> AppState {
         registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         enable_tool_cache: true,
         method_router: crate::handler::AppState::default_method_router(),
+        readiness: crate::handler::AppState::default_readiness(),
     }
 }
 
@@ -124,6 +125,7 @@ mod logging;
 mod method_router;
 mod on_demand_loading;
 mod pagination;
+mod readiness_gate;
 mod search_skills;
 mod search_tools;
 mod session;

--- a/crates/dcc-mcp-http/src/tests/next_tools_meta.rs
+++ b/crates/dcc-mcp-http/src/tests/next_tools_meta.rs
@@ -52,6 +52,7 @@ fn make_state(next_tools: NextTools, with_handler: bool) -> AppState {
         registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         enable_tool_cache: true,
         method_router: crate::handler::AppState::default_method_router(),
+        readiness: crate::handler::AppState::default_readiness(),
     }
 }
 

--- a/crates/dcc-mcp-http/src/tests/pagination.rs
+++ b/crates/dcc-mcp-http/src/tests/pagination.rs
@@ -40,6 +40,7 @@ pub fn make_app_state_many_tools() -> AppState {
         registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         enable_tool_cache: true,
         method_router: crate::handler::AppState::default_method_router(),
+        readiness: crate::handler::AppState::default_readiness(),
     }
 }
 

--- a/crates/dcc-mcp-http/src/tests/readiness_gate.rs
+++ b/crates/dcc-mcp-http/src/tests/readiness_gate.rs
@@ -1,0 +1,305 @@
+//! Issue #714 — the MCP `tools/call` handler MUST consult the same
+//! [`ReadinessProbe`] as the REST `POST /v1/call` surface, so a backend
+//! that is still booting refuses work up-front instead of silently
+//! queuing it on `DeferredExecutor` / `QueueDispatcher` until the
+//! gateway's deadline trips.
+
+use super::*;
+use std::sync::Arc;
+
+use dcc_mcp_skill_rest::StaticReadiness;
+
+/// Build an [`AppState`] whose dispatcher has `get_scene_info` wired,
+/// returning an [`Arc<StaticReadiness>`] so individual tests can flip
+/// the probe between red and green between requests.
+fn make_state_with_probe() -> (AppState, Arc<StaticReadiness>) {
+    let registry = Arc::new(make_registry());
+    let catalog = Arc::new(SkillCatalog::new(registry.clone()));
+    let dispatcher = Arc::new(ActionDispatcher::new((*registry).clone()));
+    dispatcher.register_handler("get_scene_info", |_params| {
+        Ok(serde_json::json!({"scene": "test_scene", "objects": 3}))
+    });
+
+    let probe = Arc::new(StaticReadiness::new());
+    let state = AppState {
+        registry,
+        dispatcher,
+        catalog,
+        sessions: SessionManager::new(),
+        executor: None,
+        bridge_registry: crate::BridgeRegistry::new(),
+        server_name: "test-dcc".to_string(),
+        server_version: "0.1.0".to_string(),
+        cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
+        in_flight: crate::inflight::InFlightRequests::new(),
+        pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
+        lazy_actions: false,
+        bare_tool_names: true,
+        declared_capabilities: std::sync::Arc::new(Vec::new()),
+        jobs: std::sync::Arc::new(crate::job::JobManager::new()),
+        job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
+        resources: crate::resources::ResourceRegistry::new(true, false),
+        enable_resources: true,
+        prompts: crate::prompts::PromptRegistry::new(true),
+        enable_prompts: true,
+        registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
+        enable_tool_cache: true,
+        method_router: crate::handler::AppState::default_method_router(),
+        readiness: probe.clone(),
+    };
+    (state, probe)
+}
+
+fn make_router_with_probe() -> (axum::Router, Arc<StaticReadiness>) {
+    use crate::handler::{handle_delete, handle_get, handle_post};
+    use axum::{Router, routing};
+
+    let (state, probe) = make_state_with_probe();
+    let router = Router::new()
+        .route(
+            "/mcp",
+            routing::post(handle_post)
+                .get(handle_get)
+                .delete(handle_delete),
+        )
+        .with_state(state);
+    (router, probe)
+}
+
+fn accept_json() -> HeaderValue {
+    "application/json".parse::<HeaderValue>().unwrap()
+}
+
+// ── Red probe refuses DCC-touching tools ──────────────────────────────
+
+#[tokio::test]
+pub async fn red_probe_refuses_tools_call_with_backend_not_ready() {
+    let (router, _probe) = make_router_with_probe();
+    let server = TestServer::new(router);
+
+    let resp = server
+        .post("/mcp")
+        .add_header(axum::http::header::ACCEPT, accept_json())
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 100,
+            "method": "tools/call",
+            "params": {"name": "get_scene_info", "arguments": {}}
+        }))
+        .await;
+
+    resp.assert_status_ok(); // JSON-RPC error still uses HTTP 200
+    let body: Value = resp.json();
+
+    // No result, structured error with the BACKEND_NOT_READY code
+    assert!(
+        body.get("result").is_none(),
+        "expected no result, got {body}"
+    );
+    let err = body.get("error").expect("error envelope");
+    assert_eq!(err["code"], json!(-32002), "BACKEND_NOT_READY code");
+    let data = err.get("data").expect("data payload");
+    assert_eq!(data["tool"], json!("get_scene_info"));
+    // Default StaticReadiness::new() is process=true, dispatcher=false, dcc=false
+    assert_eq!(data["readiness"]["process"], json!(true));
+    assert_eq!(data["readiness"]["dispatcher"], json!(false));
+    assert_eq!(data["readiness"]["dcc"], json!(false));
+}
+
+// ── Control tools bypass the gate ─────────────────────────────────────
+
+#[tokio::test]
+pub async fn red_probe_still_allows_discovery_tools() {
+    let (router, _probe) = make_router_with_probe();
+    let server = TestServer::new(router);
+
+    // list_skills is a core control tool — should succeed even when
+    // the probe is red, because an agent needs discovery during DCC
+    // boot.
+    let resp = server
+        .post("/mcp")
+        .add_header(axum::http::header::ACCEPT, accept_json())
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 101,
+            "method": "tools/call",
+            "params": {"name": "list_skills", "arguments": {}}
+        }))
+        .await;
+
+    resp.assert_status_ok();
+    let body: Value = resp.json();
+    assert!(
+        body.get("error").is_none(),
+        "list_skills must bypass the readiness gate; got error: {body}"
+    );
+    assert!(body.get("result").is_some());
+}
+
+// ── Flipping the probe green restores dispatch ────────────────────────
+
+#[tokio::test]
+pub async fn green_probe_permits_tools_call() {
+    let (router, probe) = make_router_with_probe();
+    let server = TestServer::new(router);
+
+    // Flip both bits so the probe reports fully ready.
+    probe.set_dispatcher_ready(true);
+    probe.set_dcc_ready(true);
+
+    let resp = server
+        .post("/mcp")
+        .add_header(axum::http::header::ACCEPT, accept_json())
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 102,
+            "method": "tools/call",
+            "params": {"name": "get_scene_info", "arguments": {}}
+        }))
+        .await;
+
+    resp.assert_status_ok();
+    let body: Value = resp.json();
+    assert!(body.get("error").is_none(), "expected success, got {body}");
+    let result = body.get("result").expect("result envelope");
+    // Handler returned {"scene":"test_scene","objects":3}; the MCP
+    // content envelope serialises that in the text field.
+    let text = result["content"][0]["text"].as_str().unwrap_or("");
+    assert!(
+        text.contains("test_scene"),
+        "expected handler payload, got: {text}"
+    );
+}
+
+// ── No JobManager / queue side-effects when red ───────────────────────
+
+#[tokio::test]
+pub async fn red_probe_does_not_queue_on_job_manager() {
+    use crate::handler::{handle_delete, handle_get, handle_post};
+    use axum::{Router, routing};
+
+    let (state, _probe) = make_state_with_probe();
+    let jobs = state.jobs.clone();
+    let server = TestServer::new(
+        Router::new()
+            .route(
+                "/mcp",
+                routing::post(handle_post)
+                    .get(handle_get)
+                    .delete(handle_delete),
+            )
+            .with_state(state),
+    );
+
+    let before = jobs.list().len();
+    let resp = server
+        .post("/mcp")
+        .add_header(axum::http::header::ACCEPT, accept_json())
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 103,
+            "method": "tools/call",
+            "params": {
+                "name": "get_scene_info",
+                "arguments": {},
+                "_meta": {"dcc": {"execution": "async"}}
+            }
+        }))
+        .await;
+    resp.assert_status_ok();
+    let body: Value = resp.json();
+    assert!(
+        body.get("error").is_some(),
+        "expected BACKEND_NOT_READY error, got {body}"
+    );
+
+    let after = jobs.list().len();
+    assert_eq!(
+        before, after,
+        "red readiness probe must not queue a JobManager row for refused tools/call"
+    );
+}
+
+// ── REST and MCP share the same probe ────────────────────────────────
+
+#[tokio::test]
+pub async fn rest_v1_call_and_mcp_tools_call_share_one_probe() {
+    // Build a full router that mounts both the MCP handler and the
+    // REST `/v1/*` surface so we can observe the shared probe from
+    // both entry points. We cannot easily call `McpHttpServer::start`
+    // in unit tests (it binds a socket); instead we replicate the
+    // relevant wiring locally.
+    use crate::handler::{handle_delete, handle_get, handle_post};
+    use axum::{Router, routing};
+
+    let (state, probe) = make_state_with_probe();
+    let probe_dyn: Arc<dyn dcc_mcp_skill_rest::ReadinessProbe> = probe.clone();
+
+    let rest_config = dcc_mcp_skill_rest::SkillRestConfig::new(
+        dcc_mcp_skill_rest::SkillRestService::from_catalog_and_dispatcher(
+            state.catalog.clone(),
+            state.dispatcher.clone(),
+        ),
+    )
+    .with_readiness(probe_dyn);
+    let rest_router = dcc_mcp_skill_rest::build_skill_rest_router(rest_config);
+
+    let mcp_router = Router::new()
+        .route(
+            "/mcp",
+            routing::post(handle_post)
+                .get(handle_get)
+                .delete(handle_delete),
+        )
+        .with_state(state)
+        .merge(rest_router);
+    let server = TestServer::new(mcp_router);
+
+    // Probe is red by default — both surfaces must refuse.
+    let mcp_resp = server
+        .post("/mcp")
+        .add_header(axum::http::header::ACCEPT, accept_json())
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 104,
+            "method": "tools/call",
+            "params": {"name": "get_scene_info", "arguments": {}}
+        }))
+        .await;
+    mcp_resp.assert_status_ok();
+    let mcp_body: Value = mcp_resp.json();
+    assert_eq!(
+        mcp_body["error"]["code"],
+        json!(-32002),
+        "MCP must refuse while probe is red"
+    );
+
+    let rest_resp = server
+        .post("/v1/call")
+        .json(&json!({"tool_slug": "test_dcc.get_scene_info", "arguments": {}}))
+        .await;
+    assert_eq!(rest_resp.status_code().as_u16(), 503);
+    let rest_body: Value = rest_resp.json();
+    assert_eq!(rest_body["kind"], json!("not-ready"));
+
+    // Flip the probe green — both surfaces must now accept.
+    probe.set_dispatcher_ready(true);
+    probe.set_dcc_ready(true);
+
+    let mcp_ok = server
+        .post("/mcp")
+        .add_header(axum::http::header::ACCEPT, accept_json())
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 105,
+            "method": "tools/call",
+            "params": {"name": "get_scene_info", "arguments": {}}
+        }))
+        .await;
+    mcp_ok.assert_status_ok();
+    let mcp_ok_body: Value = mcp_ok.json();
+    assert!(
+        mcp_ok_body.get("error").is_none(),
+        "MCP must accept once probe is green, got {mcp_ok_body}"
+    );
+}

--- a/crates/dcc-mcp-http/src/tests/resource_link.rs
+++ b/crates/dcc-mcp-http/src/tests/resource_link.rs
@@ -61,6 +61,7 @@ fn make_app_state_with_artifact_handler() -> AppState {
         registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         enable_tool_cache: true,
         method_router: crate::handler::AppState::default_method_router(),
+        readiness: crate::handler::AppState::default_readiness(),
     }
 }
 
@@ -257,6 +258,7 @@ fn make_app_state_with_structured_handler() -> AppState {
         registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         enable_tool_cache: true,
         method_router: crate::handler::AppState::default_method_router(),
+        readiness: crate::handler::AppState::default_readiness(),
     }
 }
 

--- a/crates/dcc-mcp-http/src/tests/search_skills.rs
+++ b/crates/dcc-mcp-http/src/tests/search_skills.rs
@@ -72,6 +72,7 @@ pub fn make_app_state_with_skills() -> AppState {
         registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         enable_tool_cache: true,
         method_router: crate::handler::AppState::default_method_router(),
+        readiness: crate::handler::AppState::default_readiness(),
     }
 }
 

--- a/crates/dcc-mcp-http/src/tests/search_tools.rs
+++ b/crates/dcc-mcp-http/src/tests/search_tools.rs
@@ -114,6 +114,7 @@ fn make_app_state_with_stub_named_actions() -> AppState {
         registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         enable_tool_cache: true,
         method_router: crate::handler::AppState::default_method_router(),
+        readiness: crate::handler::AppState::default_readiness(),
     }
 }
 

--- a/crates/dcc-mcp-http/src/tests/skill_discovery.rs
+++ b/crates/dcc-mcp-http/src/tests/skill_discovery.rs
@@ -58,6 +58,7 @@ pub fn make_app_state_with_skill() -> AppState {
         registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         enable_tool_cache: true,
         method_router: crate::handler::AppState::default_method_router(),
+        readiness: crate::handler::AppState::default_readiness(),
     }
 }
 

--- a/crates/dcc-mcp-jsonrpc/src/jsonrpc.rs
+++ b/crates/dcc-mcp-jsonrpc/src/jsonrpc.rs
@@ -68,6 +68,17 @@ pub mod error_codes {
     /// advertise any MCP `roots` on this session. The error `data` carries
     /// the original path.
     pub const NO_WORKSPACE_ROOTS: i64 = -32602;
+
+    /// Issue #714 — the hosting DCC backend has not finished initialising
+    /// yet (dispatcher not wired or DCC host still booting), so a
+    /// `tools/call` that would otherwise be queued on the
+    /// `DeferredExecutor` / `QueueDispatcher` is refused synchronously.
+    ///
+    /// The error `data` payload carries the three-state
+    /// [`ReadinessReport`](../../dcc_mcp_skill_rest/readiness/struct.ReadinessReport.html)
+    /// (`process`, `dispatcher`, `dcc`) plus the requested `tool` name so
+    /// clients can surface context in their back-off messaging.
+    pub const BACKEND_NOT_READY: i64 = -32002;
 }
 
 impl JsonRpcResponse {


### PR DESCRIPTION
## Summary

Closes #714. Pairs with dcc-mcp-maya#184 — this is the **backend half** of the readiness gate; the Maya adapter side will install the probe and drive the bits from its scripting-engine-ready hook.

Both MCP `POST /mcp` (`tools/call`) and REST `POST /v1/call` now consult the **same** `Arc<dyn ReadinessProbe>`, so an embedded-DCC backend that is still booting refuses work up-front instead of silently queuing it on `DeferredExecutor` / `QueueDispatcher` until the gateway timeout trips.

## Implementation

- **AppState**: new `readiness: Arc<dyn ReadinessProbe>` field + `AppState::default_readiness()` helper (fully-ready). Existing embedders and tests keep their baseline behaviour.
- **McpHttpServer::with_readiness(probe)**: builder that `start()` wires into **both** `SkillRestConfig::with_readiness(...)` and `AppState`. One `Arc`, two surfaces — flipping bits on the probe gates `/mcp` and `/v1/call` atomically.
- **Gate location**: `handle_tools_call_inner`, **after** `resolve_tool_call`. Discovery / introspection tools (`list_skills`, `search_skills`, `load_skill`, `list_dynamic_tools`, `jobs.get_status`, `register_tool`, …) already take the early `ToolCallResolution::Response` branch, so they bypass the gate — agents can still discover while the DCC is booting. Only DCC-touching actions reach the gate.
- **Error shape**: new JSON-RPC code `BACKEND_NOT_READY = -32002` in `dcc-mcp-jsonrpc::error_codes`. Error `data` carries the three-state report:
  ```json
  {
    "code": -32002,
    "message": "Backend is not ready yet: process=true, dispatcher=false, dcc=false. Refusing to queue `tools/call` for `maya_scripting__execute_python` — retry once `/v1/readyz` reports ready.",
    "data": {
      "tool": "maya_scripting__execute_python",
      "readiness": {"process": true, "dispatcher": false, "dcc": false}
    }
  }
  ```
  REST mirror: pre-existing `ServiceErrorKind::NotReady` → HTTP 503 `{"kind":"not-ready", …}`.
- **Python API**: new `dcc_mcp_core.ReadinessProbe` (wrapper around `StaticReadiness`) with `set_dispatcher_ready(bool)` / `set_dcc_ready(bool)` / `is_ready()` / `report()`. Wire via `server.set_readiness_probe(probe)` before `server.start()`. Maya / Blender / … can share one probe instance.

## Tests

`crates/dcc-mcp-http/src/tests/readiness_gate.rs`:

- `red_probe_refuses_tools_call_with_backend_not_ready` — code `-32002`, structured `data` payload.
- `red_probe_still_allows_discovery_tools` — `list_skills` succeeds while probe is red.
- `green_probe_permits_tools_call` — flipping `set_dispatcher_ready(true) + set_dcc_ready(true)` restores dispatch.
- `red_probe_does_not_queue_on_job_manager` — refused async `tools/call` never creates a `JobManager` row.
- `rest_v1_call_and_mcp_tools_call_share_one_probe` — same probe gates both surfaces; `-32002` from MCP and `503 {"kind":"not-ready"}` from REST when red; both succeed when green.

`cargo test --workspace --lib` green, `cargo fmt` green, `cargo clippy -p dcc-mcp-http --features python-bindings --tests` green.

## Follow-ups

- dcc-mcp-maya#184 — install `ReadinessProbe` from the Maya adapter and flip `set_dispatcher_ready` / `set_dcc_ready` as the scripting engine boots. The wire contract (`-32002` + `data.readiness`) is stable — that PR only needs the one-line install + two flips.
- #713 — gateway-side `/v1/readyz` probe is orthogonal (defense-in-depth). The gateway refuses to route to a red backend; this PR makes the backend also refuse to queue work if traffic slips through.