### PR TITLE
fix(gateway+transport): graceful shutdown deregisters from FileRegistry (#718)

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/handle.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handle.rs
@@ -19,6 +19,25 @@ use super::*;
 /// For the `ServerSpawnMode::Dedicated` path the listener runs on an OS
 /// thread with its own `current_thread` runtime; [`Self::gateway_thread`]
 /// holds its join handle so the Drop impl can block briefly for cleanup.
+///
+/// # Graceful deregistration (issue #718)
+///
+/// Prior to #718 this handle's `Drop` only aborted background tasks and
+/// left the `FileRegistry` rows stamped with a fresh `last_heartbeat`.
+/// Peers reading `services.json` kept seeing the now-dead instance as
+/// "available" until `stale_timeout_secs` (default 30 s) elapsed. We
+/// now carry an `Arc<RwLock<FileRegistry>>` and call
+/// `FileRegistry::deregister` for the service key (and, for gateway
+/// winners, the `__gateway__` sentinel) in `Drop`, so `services.json`
+/// is purged immediately on clean shutdown.
+///
+/// The deregistration is idempotent — each key is consumed via `take()`
+/// so calling Drop more than once is a no-op. The registry's outer lock
+/// is the async `tokio::sync::RwLock`; Drop uses `try_read()` to avoid
+/// blocking an executor. All callers in this crate only take *read*
+/// locks for short synchronous operations, so contention is
+/// effectively nil in practice. If `try_read` ever fails we log at
+/// `warn!` and fall back to the stale-row cleanup path.
 pub struct GatewayHandle {
     /// `true` if this instance won the gateway port at startup.
     pub is_gateway: bool,
@@ -36,10 +55,61 @@ pub struct GatewayHandle {
     pub(crate) gateway_thread: Option<std::thread::JoinHandle<()>>,
     /// Background challenger-loop abort handle (set when we entered challenger mode).
     pub(crate) challenger_abort: Option<AbortHandle>,
+    /// Shared `FileRegistry` used to deregister the instance (and the
+    /// sentinel, when we are the gateway) on Drop. See issue #718.
+    pub(crate) registry: Arc<RwLock<FileRegistry>>,
+    /// Pending deregistrations. Populated with the instance key (and the
+    /// sentinel key for winners); `Drop` drains the vector so a second
+    /// call is a no-op. See issue #718.
+    pub(crate) pending_deregister: Vec<ServiceKey>,
+}
+
+impl GatewayHandle {
+    /// Deregister every pending `ServiceKey` from the `FileRegistry` and
+    /// clear the queue. Idempotent and cheap — safe to call from both
+    /// async shutdown paths and `Drop`.
+    ///
+    /// Uses `try_read()` because Drop is synchronous and cannot await.
+    /// In this crate the registry lock is only ever held in `read` mode
+    /// for brief O(n) DashMap scans, so the fast path virtually always
+    /// succeeds. On the rare contention case we log and leave the row —
+    /// the existing `stale_timeout_secs` cleanup path still purges it.
+    pub fn deregister_all(&mut self) {
+        if self.pending_deregister.is_empty() {
+            return;
+        }
+        let keys = std::mem::take(&mut self.pending_deregister);
+        match self.registry.try_read() {
+            Ok(reg) => {
+                for key in keys {
+                    if let Err(e) = reg.deregister(&key) {
+                        tracing::warn!(
+                            error = %e,
+                            dcc_type = %key.dcc_type,
+                            instance_id = %key.instance_id,
+                            "FileRegistry::deregister failed during gateway shutdown"
+                        );
+                    }
+                }
+            }
+            Err(_) => {
+                tracing::warn!(
+                    pending = keys.len(),
+                    "FileRegistry read lock contended during shutdown — \
+                     falling back to stale-timeout cleanup (issue #718)"
+                );
+            }
+        }
+    }
 }
 
 impl Drop for GatewayHandle {
     fn drop(&mut self) {
+        // Issue #718: deregister BEFORE aborting the heartbeat so that
+        // even if the heartbeat were to race us, the row is already
+        // gone. `deregister_all` is idempotent via `take()`.
+        self.deregister_all();
+
         if let Some(h) = self.heartbeat_abort.take() {
             h.abort();
         }
@@ -77,4 +147,8 @@ pub(crate) struct ElectionOutcome {
     pub(crate) challenger_abort: Option<AbortHandle>,
     pub(crate) gateway_supervisor: Option<tokio::task::JoinHandle<()>>,
     pub(crate) gateway_thread: Option<std::thread::JoinHandle<()>>,
+    /// `__gateway__` sentinel key registered by the winner path; carried
+    /// back to the `GatewayHandle` so `Drop` can deregister it on clean
+    /// shutdown (issue #718).
+    pub(crate) sentinel_key: Option<ServiceKey>,
 }

--- a/crates/dcc-mcp-gateway/src/gateway/runner.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/runner.rs
@@ -152,19 +152,36 @@ impl GatewayRunner {
         };
 
         // ── Gateway election ──────────────────────────────────────────────
-        let (is_gateway, gateway_abort, challenger_abort, gateway_supervisor, gateway_thread) =
-            if self.config.gateway_port > 0 {
-                let outcome = self.run_election().await?;
-                (
-                    outcome.is_gateway,
-                    outcome.gateway_abort,
-                    outcome.challenger_abort,
-                    outcome.gateway_supervisor,
-                    outcome.gateway_thread,
-                )
-            } else {
-                (false, None, None, None, None)
-            };
+        let (
+            is_gateway,
+            gateway_abort,
+            challenger_abort,
+            gateway_supervisor,
+            gateway_thread,
+            sentinel_key,
+        ) = if self.config.gateway_port > 0 {
+            let outcome = self.run_election().await?;
+            (
+                outcome.is_gateway,
+                outcome.gateway_abort,
+                outcome.challenger_abort,
+                outcome.gateway_supervisor,
+                outcome.gateway_thread,
+                outcome.sentinel_key,
+            )
+        } else {
+            (false, None, None, None, None, None)
+        };
+
+        // Issue #718: on clean shutdown the `Drop` impl deregisters every
+        // key we own (the instance row, plus the gateway sentinel if we
+        // won the election), so `services.json` no longer carries zombie
+        // "available" rows for the full `stale_timeout_secs` window.
+        let mut pending_deregister = Vec::with_capacity(2);
+        pending_deregister.push(service_key.clone());
+        if let Some(k) = sentinel_key {
+            pending_deregister.push(k);
+        }
 
         Ok(GatewayHandle {
             is_gateway,
@@ -174,6 +191,8 @@ impl GatewayRunner {
             gateway_supervisor,
             gateway_thread,
             challenger_abort,
+            registry: self.registry.clone(),
+            pending_deregister,
         })
     }
 
@@ -228,7 +247,7 @@ impl GatewayRunner {
                     max_routes_per_session,
                     format!("{} (gateway)", self.config.server_name),
                     own_version.clone(),
-                    sentinel_key,
+                    sentinel_key.clone(),
                     self.config.host.clone(),
                     self.config.gateway_port,
                     self.config.allow_unknown_tools,
@@ -247,6 +266,9 @@ impl GatewayRunner {
                             challenger_abort: None,
                             gateway_supervisor: Some(tasks.supervisor),
                             gateway_thread: None,
+                            // Issue #718: winners must also deregister the
+                            // `__gateway__` sentinel on clean shutdown.
+                            sentinel_key: Some(sentinel_key),
                         })
                     }
                     // Issue #303: bind() succeeded but the accept-loop never
@@ -259,12 +281,20 @@ impl GatewayRunner {
                             version = %own_version,
                             "Gateway tasks failed to become healthy — falling back to plain-instance mode"
                         );
+                        // Issue #718: the sentinel was written before
+                        // `start_gateway_tasks` failed. Clean it up now
+                        // so peers don't see a phantom gateway.
+                        {
+                            let reg = self.registry.read().await;
+                            let _ = reg.deregister(&sentinel_key);
+                        }
                         Ok(ElectionOutcome {
                             is_gateway: false,
                             gateway_abort: None,
                             challenger_abort: None,
                             gateway_supervisor: None,
                             gateway_thread: None,
+                            sentinel_key: None,
                         })
                     }
                 }
@@ -324,6 +354,7 @@ impl GatewayRunner {
                         challenger_abort: Some(challenger_abort),
                         gateway_supervisor: None,
                         gateway_thread: None,
+                        sentinel_key: None,
                     })
                 } else {
                     tracing::info!(
@@ -342,6 +373,7 @@ impl GatewayRunner {
                         challenger_abort: None,
                         gateway_supervisor: None,
                         gateway_thread: None,
+                        sentinel_key: None,
                     })
                 }
             }

--- a/crates/dcc-mcp-gateway/src/gateway/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tests.rs
@@ -271,3 +271,170 @@ async fn test_self_probe_listener_fails_for_dead_port() {
         "probe must fail when nothing is listening on {addr}"
     );
 }
+
+// ── Regression tests for issue #718 ──────────────────────────────────
+//
+// `GatewayHandle::Drop` must call `FileRegistry::deregister` for every
+// key it owns (instance row + sentinel for winners) so peers don't see
+// a zombie "available" row for the full `stale_timeout_secs` window.
+
+/// Build a `GatewayRunner` with a dedicated registry dir and a chosen
+/// gateway port so the tests can run in parallel without colliding.
+fn make_runner_in(dir: &std::path::Path, port: u16) -> GatewayRunner {
+    let cfg = GatewayConfig {
+        host: "127.0.0.1".to_string(),
+        gateway_port: port,
+        // Disable the heartbeat loop — we don't want a background task
+        // touching `services.json` while we assert on its contents.
+        heartbeat_secs: 0,
+        registry_dir: Some(dir.to_path_buf()),
+        ..GatewayConfig::default()
+    };
+    GatewayRunner::new(cfg).unwrap()
+}
+
+/// Pick an unused high port the OS just released. Good enough for
+/// test-local first-wins elections; the runner's `try_bind_port_opt`
+/// will still behave correctly under a race.
+fn ephemeral_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}
+
+#[tokio::test]
+async fn test_gateway_handle_drop_deregisters_instance_row() {
+    // Point gateway_port at something that is already bound so we land
+    // on the `port taken` branch and the handle holds only the instance
+    // row (no sentinel). Drop must still remove that row.
+    let dir = tempfile::tempdir().unwrap();
+    let occupied = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = occupied.local_addr().unwrap().port();
+
+    let runner = make_runner_in(dir.path(), port);
+    let entry = ServiceEntry::new("maya", "127.0.0.1", 0);
+    let key = entry.key();
+    let handle = runner.start(entry, None).await.unwrap();
+    assert!(!handle.is_gateway, "port is occupied — must be non-winner");
+
+    // Row must exist while the handle is alive.
+    {
+        let reg = runner.registry.read().await;
+        assert!(
+            reg.get(&key).is_some(),
+            "instance row must be present before Drop"
+        );
+    }
+
+    // Drop the handle → `Drop::drop` must deregister the instance row.
+    drop(handle);
+
+    let reg = runner.registry.read().await;
+    assert!(
+        reg.get(&key).is_none(),
+        "GatewayHandle::Drop must remove the instance row from FileRegistry (issue #718)"
+    );
+    drop(occupied);
+}
+
+#[tokio::test]
+async fn test_explicit_deregister_all_is_idempotent() {
+    // `McpServerHandle::shutdown` calls `deregister_all` explicitly
+    // before dropping the gateway. Verify both the explicit path and
+    // the follow-up Drop produce the same end state and do not double-
+    // log / double-remove.
+    let dir = tempfile::tempdir().unwrap();
+    let occupied = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = occupied.local_addr().unwrap().port();
+
+    let runner = make_runner_in(dir.path(), port);
+    let entry = ServiceEntry::new("blender", "127.0.0.1", 0);
+    let key = entry.key();
+    let mut handle = runner.start(entry, None).await.unwrap();
+
+    // Explicit shutdown path — does NOT rely on Drop.
+    handle.deregister_all();
+
+    {
+        let reg = runner.registry.read().await;
+        assert!(
+            reg.get(&key).is_none(),
+            "explicit deregister_all must remove instance row immediately (issue #718)"
+        );
+    }
+
+    // Idempotency: a subsequent Drop must be a clean no-op.
+    drop(handle);
+    let reg = runner.registry.read().await;
+    assert!(
+        reg.get(&key).is_none(),
+        "second deregister (via Drop) must remain a no-op"
+    );
+    drop(occupied);
+}
+
+#[tokio::test]
+async fn test_gateway_winner_drop_deregisters_instance_and_sentinel() {
+    // Winner path: the handle must carry both the instance key and the
+    // `__gateway__` sentinel key, and Drop must purge both rows.
+    //
+    // We bind a real loopback listener and register the instance under
+    // that port so the gateway's startup `probe_and_evict_dead_instances`
+    // sweep keeps the row alive. Without this the probe would evict our
+    // fake port=0 instance before we could observe it.
+    let dir = tempfile::tempdir().unwrap();
+    let gw_port = ephemeral_port();
+
+    // Keep an instance listener alive for the duration of the test so
+    // the gateway's port probe finds it reachable.
+    let instance_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let instance_port = instance_listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        loop {
+            // Accept and immediately drop — all we need is a listening socket.
+            let _ = instance_listener.accept().await;
+        }
+    });
+
+    let runner = make_runner_in(dir.path(), gw_port);
+    let entry = ServiceEntry::new("maya", "127.0.0.1", instance_port);
+    let instance_key = entry.key();
+    let handle = runner.start(entry, None).await.unwrap();
+
+    // In CI the port may have been snatched back by another test before
+    // `try_bind_port_opt` got there; only assert the sentinel-deregister
+    // semantics when we actually won.
+    if handle.is_gateway {
+        {
+            let reg = runner.registry.read().await;
+            assert!(
+                reg.get(&instance_key).is_some(),
+                "instance row must exist before shutdown"
+            );
+            assert_eq!(
+                reg.list_instances(GATEWAY_SENTINEL_DCC_TYPE).len(),
+                1,
+                "winner must have written one __gateway__ sentinel row"
+            );
+        }
+
+        drop(handle);
+
+        let reg = runner.registry.read().await;
+        assert!(
+            reg.get(&instance_key).is_none(),
+            "winner Drop must remove the instance row (issue #718)"
+        );
+        assert_eq!(
+            reg.list_instances(GATEWAY_SENTINEL_DCC_TYPE).len(),
+            0,
+            "winner Drop must remove the __gateway__ sentinel (issue #718)"
+        );
+    } else {
+        // Non-winner fallback — at least the instance row must go.
+        drop(handle);
+        let reg = runner.registry.read().await;
+        assert!(reg.get(&instance_key).is_none());
+    }
+}

--- a/crates/dcc-mcp-http/src/server/mod.rs
+++ b/crates/dcc-mcp-http/src/server/mod.rs
@@ -72,6 +72,16 @@ pub struct McpServerHandle {
 impl McpServerHandle {
     /// Gracefully shut down the server and wait for it to stop.
     pub async fn shutdown(mut self) {
+        // Issue #718: deregister from FileRegistry *before* waiting for
+        // the serve loop to finish. Peers reading `services.json` should
+        // see the row disappear as soon as `shutdown()` is invoked rather
+        // than waiting the full `stale_timeout_secs` (default 30 s). The
+        // call is idempotent — the `GatewayHandle::Drop` path is still a
+        // correctness safety net for callers who skip `shutdown()`.
+        if let Some(gw) = self._gateway.as_mut() {
+            gw.deregister_all();
+        }
+
         let _ = self.shutdown_tx.send(true);
         if let Some(join) = self.join.take() {
             let _ = join.await;


### PR DESCRIPTION
## Summary

Closes #718.

`GatewayHandle::Drop` and `McpServerHandle::shutdown` now actively call `FileRegistry::deregister` for every `ServiceKey` the gateway owns (the instance row, plus the `__gateway__` sentinel on the gateway winner path) instead of just aborting the heartbeat task.

Previously, a clean adapter unload would leave `services.json` stamped with a fresh `last_heartbeat` and the row survived until `stale_timeout_secs` (default 30 s). Real deployments (dcc-mcp-maya 0.2.26 / dcc-mcp-core 0.14.26) observed zombie *available* rows for up to 30 seconds after a clean plugin unload.

## Design

- `GatewayHandle` now carries `Arc<RwLock<FileRegistry>>` plus a `Vec<ServiceKey>` `pending_deregister` queue. The queue holds the instance key and, for winners, the `__gateway__` sentinel key.
- `GatewayHandle::deregister_all` drains the queue via `mem::take` so it is idempotent — Drop after an explicit `shutdown()` is a clean no-op.
- `Drop` is synchronous. We call `try_read()` on the `tokio::sync::RwLock` rather than `block_on` / `block_in_place`. All existing consumers take read-only access for brief DashMap scans, so contention is negligible. On the pathological contention case we log at `warn!` and fall back to the existing `stale_timeout_secs` cleanup — i.e. the new path is strictly better than the old one.
- `McpServerHandle::shutdown` calls `deregister_all()` **before** awaiting the serve-loop join so clean shutdown is visible to peers immediately, not only after the HTTP layer drains.
- When `start_gateway_tasks` fails after writing the sentinel, the sentinel is deregistered explicitly so the fallback-to-plain-instance path cannot leak a phantom `__gateway__` row.

## Tests

Added to `crates/dcc-mcp-gateway/src/gateway/tests.rs`:

- `test_gateway_handle_drop_deregisters_instance_row` — non-winner path, `Drop` must remove the instance row.
- `test_explicit_deregister_all_is_idempotent` — mimics `McpServerHandle::shutdown` calling `deregister_all` explicitly; the subsequent `Drop` must be a clean no-op.
- `test_gateway_winner_drop_deregisters_instance_and_sentinel` — winner path, `Drop` must purge both the instance row and the `__gateway__` sentinel.

All 192 gateway unit tests and the full `dcc-mcp-http` test suite pass locally; `cargo fmt` / `cargo clippy --tests` clean.