### PR TITLE
feat(queue): observability + configurable backpressure for DeferredExecutor / host_bridge / QueueDispatcher (#715)

### DIFF
--- a/crates/dcc-mcp-host/src/lib.rs
+++ b/crates/dcc-mcp-host/src/lib.rs
@@ -54,13 +54,15 @@
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
 
+use std::collections::VecDeque;
 use std::future::Future;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
 use std::sync::Once;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::time::Duration;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
 
+use parking_lot::Mutex;
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
 
@@ -75,6 +77,25 @@ pub enum DispatchError {
     /// it shut down before the tick loop could drain the job.
     #[error("dispatcher is shut down")]
     Shutdown,
+    /// The dispatcher's queue was full and did not drain within the
+    /// configured send timeout. Callers should retry after
+    /// `retry_after_secs`. This variant only fires when a
+    /// capacity-bounded dispatcher is explicitly configured via
+    /// [`QueueDispatcher::with_capacity`] or [`BlockingDispatcher::with_capacity`].
+    ///
+    /// Introduced in #715 to give orchestrators a stable, unambiguous
+    /// signal that the backend is alive but saturated (as opposed to
+    /// [`DispatchError::Shutdown`] or [`DispatchError::ResultDropped`]
+    /// which both indicate the dispatcher is gone).
+    #[error("queue overloaded (depth={depth}/{capacity}); retry in {retry_after_secs}s")]
+    QueueOverloaded {
+        /// Observed queue depth when the post was rejected.
+        depth: usize,
+        /// Configured capacity.
+        capacity: usize,
+        /// Suggested backoff window in seconds before retry.
+        retry_after_secs: u64,
+    },
     /// The result one-shot was dropped before the caller could observe
     /// the value. Usually means the caller cancelled the awaiting
     /// future before tick ran.
@@ -154,6 +175,18 @@ pub trait DccDispatcher: Send + Sync + 'static {
 
     /// `true` once [`DccDispatcher::shutdown`] has been called.
     fn is_shutdown(&self) -> bool;
+
+    /// Observability snapshot for the dispatcher's queue (issue #715).
+    ///
+    /// Default implementation returns a zeroed snapshot with
+    /// `capacity = None`. Concrete dispatchers that wrap a
+    /// [`QueueDispatcher`] should override this to surface real
+    /// counters so the HTTP layer's
+    /// `diagnostics__process_status.queue.host_*` fields reflect what
+    /// is actually happening on the main thread.
+    fn stats(&self) -> QueueStats {
+        QueueStats::default()
+    }
 }
 
 /// Type-erased closure the dispatcher stores in its queue.
@@ -293,6 +326,11 @@ trait Runnable: Send {
     fn run(self: Box<Self>) -> bool;
     /// Report shutdown to the awaiting caller without executing the job.
     fn cancel(self: Box<Self>);
+    /// Report a specific [`DispatchError`] to the awaiting caller
+    /// without executing the job. Used by the bounded-mode
+    /// [`DispatchError::QueueOverloaded`] path so the caller sees
+    /// the right error taxonomy instead of the generic `Shutdown`.
+    fn cancel_with_error(self: Box<Self>, err: DispatchError);
 }
 
 struct Job<F, R>
@@ -345,6 +383,12 @@ where
             let _ = tx.send(Err(DispatchError::Shutdown));
         }
     }
+
+    fn cancel_with_error(mut self: Box<Self>, err: DispatchError) {
+        if let Some(tx) = self.result_tx.take() {
+            let _ = tx.send(Err(err));
+        }
+    }
 }
 
 // Captures the message of the *most recent* panic on the current
@@ -390,40 +434,170 @@ fn install_panic_hook_once() {
 
 // ── Shared queue state ──────────────────────────────────────────────
 
+/// Point-in-time observability snapshot for a queue-backed dispatcher
+/// (issue #715). Stable JSON field names are chosen so downstream
+/// `diagnostics__process_status` / `/v1/diagnostics/queues` output
+/// does not leak internal struct names.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct QueueStats {
+    /// Current approximate depth.
+    pub pending: usize,
+    /// Configured capacity. `None` means unbounded.
+    pub capacity: Option<usize>,
+    /// Total number of successful enqueues over the dispatcher's lifetime.
+    pub total_enqueued: u64,
+    /// Total number of jobs drained (regardless of panic outcome).
+    pub total_dequeued: u64,
+    /// Total number of jobs rejected with
+    /// [`DispatchError::QueueOverloaded`] (bounded mode only).
+    pub total_rejected: u64,
+    /// Approximate wait time of the oldest still-pending job, in
+    /// milliseconds. `None` when the queue is empty.
+    pub oldest_wait_ms: Option<u64>,
+    /// p50 wait-time across the most recent completed jobs.
+    pub wait_p50_ms: Option<u64>,
+    /// p95 wait-time across the most recent completed jobs.
+    pub wait_p95_ms: Option<u64>,
+    /// p99 wait-time across the most recent completed jobs.
+    pub wait_p99_ms: Option<u64>,
+}
+
+/// Fixed-size ring of recent wait-times (enqueue → dequeue). Kept at
+/// 256 samples so the percentile compute stays O(n log n) over a
+/// small n; operators who need higher-resolution histograms scrape
+/// Prometheus instead.
+struct WaitTimeRing {
+    samples: VecDeque<u64>,
+}
+
+impl WaitTimeRing {
+    const CAPACITY: usize = 256;
+
+    fn new() -> Self {
+        Self {
+            samples: VecDeque::with_capacity(Self::CAPACITY),
+        }
+    }
+
+    fn observe(&mut self, wait_ms: u64) {
+        if self.samples.len() == Self::CAPACITY {
+            self.samples.pop_front();
+        }
+        self.samples.push_back(wait_ms);
+    }
+
+    fn percentiles(&self) -> (Option<u64>, Option<u64>, Option<u64>) {
+        if self.samples.is_empty() {
+            return (None, None, None);
+        }
+        let mut sorted: Vec<u64> = self.samples.iter().copied().collect();
+        sorted.sort_unstable();
+        let pick = |q: f64| -> u64 {
+            let n = sorted.len();
+            let idx = ((q * n as f64).ceil() as usize)
+                .saturating_sub(1)
+                .min(n - 1);
+            sorted[idx]
+        };
+        (Some(pick(0.50)), Some(pick(0.95)), Some(pick(0.99)))
+    }
+}
+
+/// Wrapper carrying a submit timestamp alongside the type-erased job
+/// so the drain paths can observe the wait-time histogram.
+struct Enqueued {
+    job: Box<dyn Runnable>,
+    submitted_at: Instant,
+}
+
+/// Reason an enqueue attempt failed (internal taxonomy).
+enum EnqueueReject {
+    /// Dispatcher is already shut down.
+    Shutdown(Box<dyn Runnable>),
+    /// Bounded-mode capacity reached.
+    Overloaded {
+        job: Box<dyn Runnable>,
+        depth: usize,
+        capacity: usize,
+    },
+}
+
 struct Shared {
     /// Sender half. Cloned into every [`QueueDispatcher::post`] call.
-    tx: mpsc::UnboundedSender<Box<dyn Runnable>>,
+    tx: mpsc::UnboundedSender<Enqueued>,
     /// Receiver half. Wrapped in a tokio mutex so both the sync
     /// `tick()` path (via [`tokio::sync::Mutex::try_lock`]) and the
     /// async `drain_awaiting` path (via `.lock().await`) can share
     /// exclusive drain access without the
     /// `clippy::await_holding_lock` footgun that `parking_lot` brings.
-    rx: tokio::sync::Mutex<mpsc::UnboundedReceiver<Box<dyn Runnable>>>,
+    rx: tokio::sync::Mutex<mpsc::UnboundedReceiver<Enqueued>>,
     pending: AtomicUsize,
     shutdown: AtomicBool,
+    /// Hard capacity cap. `0` means unbounded (the
+    /// [`QueueDispatcher::new`] default; matches today's behaviour).
+    /// Any non-zero value activates the
+    /// [`DispatchError::QueueOverloaded`] path (issue #715).
+    capacity: usize,
+    total_enqueued: AtomicU64,
+    total_dequeued: AtomicU64,
+    total_rejected: AtomicU64,
+    /// Submit timestamps of currently-queued jobs in FIFO order. Used
+    /// to compute the oldest-wait-time metric without scanning the
+    /// mpsc buffer.
+    submit_times: Mutex<VecDeque<Instant>>,
+    /// Bounded ring of recent completed-job wait-times for percentile
+    /// surfacing.
+    wait_samples: Mutex<WaitTimeRing>,
 }
 
 impl Shared {
     fn new() -> Arc<Self> {
-        let (tx, rx) = mpsc::unbounded_channel::<Box<dyn Runnable>>();
+        Self::with_capacity(0)
+    }
+
+    fn with_capacity(capacity: usize) -> Arc<Self> {
+        let (tx, rx) = mpsc::unbounded_channel::<Enqueued>();
         Arc::new(Self {
             tx,
             rx: tokio::sync::Mutex::new(rx),
             pending: AtomicUsize::new(0),
             shutdown: AtomicBool::new(false),
+            capacity,
+            total_enqueued: AtomicU64::new(0),
+            total_dequeued: AtomicU64::new(0),
+            total_rejected: AtomicU64::new(0),
+            submit_times: Mutex::new(VecDeque::new()),
+            wait_samples: Mutex::new(WaitTimeRing::new()),
         })
     }
 
-    fn enqueue(&self, job: Box<dyn Runnable>) -> Result<(), Box<dyn Runnable>> {
+    fn enqueue(&self, job: Box<dyn Runnable>) -> Result<(), EnqueueReject> {
         if self.shutdown.load(Ordering::Acquire) {
-            return Err(job);
+            return Err(EnqueueReject::Shutdown(job));
         }
-        match self.tx.send(job) {
+        // Bounded-mode capacity check. The load / store race with a
+        // concurrent drain is acceptable: `pending` is advisory and
+        // "slightly over cap on a burst" is fine.
+        if self.capacity > 0 && self.pending.load(Ordering::Acquire) >= self.capacity {
+            self.total_rejected.fetch_add(1, Ordering::Release);
+            return Err(EnqueueReject::Overloaded {
+                job,
+                depth: self.pending.load(Ordering::Acquire),
+                capacity: self.capacity,
+            });
+        }
+        let envelope = Enqueued {
+            job,
+            submitted_at: Instant::now(),
+        };
+        match self.tx.send(envelope) {
             Ok(()) => {
                 self.pending.fetch_add(1, Ordering::Release);
+                self.total_enqueued.fetch_add(1, Ordering::Release);
+                self.submit_times.lock().push_back(Instant::now());
                 Ok(())
             }
-            Err(mpsc::error::SendError(job)) => Err(job),
+            Err(mpsc::error::SendError(env)) => Err(EnqueueReject::Shutdown(env.job)),
         }
     }
 
@@ -441,18 +615,23 @@ impl Shared {
             // We'll catch up on the next tick.
             return (out, true);
         };
+        let now = Instant::now();
         for _ in 0..max_jobs {
             match rx.try_recv() {
-                Ok(job) => out.push(job),
+                Ok(env) => {
+                    self.observe_dequeue(now, env.submitted_at);
+                    out.push(env.job);
+                }
                 Err(mpsc::error::TryRecvError::Empty) => break,
                 Err(mpsc::error::TryRecvError::Disconnected) => break,
             }
         }
         let more = match rx.try_recv() {
-            Ok(job) => {
+            Ok(env) => {
                 // We peeked by popping — put it back at the front of
                 // our batch so ordering is preserved.
-                out.push(job);
+                self.observe_dequeue(now, env.submitted_at);
+                out.push(env.job);
                 true
             }
             Err(_) => false,
@@ -475,30 +654,44 @@ impl Shared {
         let mut rx = self.rx.lock().await;
         // Wait for the first job with a bounded timeout.
         let first = match tokio::time::timeout(timeout, rx.recv()).await {
-            Ok(Some(job)) => Some(job),
+            Ok(Some(env)) => Some(env),
             Ok(None) | Err(_) => None,
         };
         let Some(first) = first else {
             return (Vec::new(), false);
         };
+        let now = Instant::now();
+        self.observe_dequeue(now, first.submitted_at);
         let mut out = Vec::with_capacity(max_jobs.min(16));
-        out.push(first);
+        out.push(first.job);
         // Drain any extra items that happen to be ready without blocking.
         for _ in 1..max_jobs {
             match rx.try_recv() {
-                Ok(job) => out.push(job),
+                Ok(env) => {
+                    self.observe_dequeue(now, env.submitted_at);
+                    out.push(env.job);
+                }
                 Err(_) => break,
             }
         }
         let more = match rx.try_recv() {
-            Ok(job) => {
-                out.push(job);
+            Ok(env) => {
+                self.observe_dequeue(now, env.submitted_at);
+                out.push(env.job);
                 true
             }
             Err(_) => false,
         };
         self.pending.fetch_sub(out.len(), Ordering::Release);
         (out, more)
+    }
+
+    /// Bookkeeping on dequeue.
+    fn observe_dequeue(&self, now: Instant, submitted_at: Instant) {
+        let wait = now.saturating_duration_since(submitted_at);
+        let _ = self.submit_times.lock().pop_front();
+        self.wait_samples.lock().observe(wait.as_millis() as u64);
+        self.total_dequeued.fetch_add(1, Ordering::Release);
     }
 
     fn shutdown(&self) {
@@ -534,9 +727,37 @@ impl Shared {
                 }
             }
         };
-        while let Ok(job) = rx.try_recv() {
-            job.cancel();
+        while let Ok(env) = rx.try_recv() {
+            env.job.cancel();
             self.pending.fetch_sub(1, Ordering::Release);
+        }
+        // Submit-time ledger is now meaningless — clear it so the
+        // observability snapshot doesn't claim a ghost oldest-wait.
+        self.submit_times.lock().clear();
+    }
+
+    /// Build a point-in-time snapshot for operators and diagnostics.
+    fn snapshot(&self) -> QueueStats {
+        let (p50, p95, p99) = self.wait_samples.lock().percentiles();
+        let oldest_wait_ms = self
+            .submit_times
+            .lock()
+            .front()
+            .map(|t| t.elapsed().as_millis() as u64);
+        QueueStats {
+            pending: self.pending.load(Ordering::Acquire),
+            capacity: if self.capacity == 0 {
+                None
+            } else {
+                Some(self.capacity)
+            },
+            total_enqueued: self.total_enqueued.load(Ordering::Acquire),
+            total_dequeued: self.total_dequeued.load(Ordering::Acquire),
+            total_rejected: self.total_rejected.load(Ordering::Acquire),
+            oldest_wait_ms,
+            wait_p50_ms: p50,
+            wait_p95_ms: p95,
+            wait_p99_ms: p99,
         }
     }
 }
@@ -562,10 +783,34 @@ impl Default for QueueDispatcher {
 
 impl QueueDispatcher {
     /// Construct a fresh dispatcher with an empty queue.
+    ///
+    /// The queue is **unbounded** — matches the historical behaviour.
+    /// Prefer [`Self::with_capacity`] for DCC hosts where the
+    /// idle/tick callback can legitimately starve (#715).
     pub fn new() -> Self {
         Self {
             shared: Shared::new(),
         }
+    }
+
+    /// Construct a dispatcher with a bounded queue (#715).
+    ///
+    /// When the queue reaches `capacity`, further [`Self::post`] calls
+    /// surface [`DispatchError::QueueOverloaded`] immediately — callers
+    /// can distinguish this from [`DispatchError::Shutdown`] and decide
+    /// whether to retry after `retry_after_secs`. `capacity = 0`
+    /// degrades to the unbounded [`Self::new`] behaviour so operators
+    /// can disable the cap without a code change.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            shared: Shared::with_capacity(capacity),
+        }
+    }
+
+    /// Point-in-time observability snapshot (#715). Safe to call from
+    /// any thread.
+    pub fn stats(&self) -> QueueStats {
+        self.shared.snapshot()
     }
 
     /// Inherent generic `post<F, R>` — the fast path when the caller
@@ -587,8 +832,18 @@ impl QueueDispatcher {
             func: Some(job),
             result_tx: Some(tx),
         });
-        if let Err(rejected) = self.shared.enqueue(boxed) {
-            rejected.cancel();
+        match self.shared.enqueue(boxed) {
+            Ok(()) => {}
+            Err(EnqueueReject::Shutdown(rejected)) => rejected.cancel(),
+            Err(EnqueueReject::Overloaded {
+                job,
+                depth,
+                capacity,
+            }) => job.cancel_with_error(DispatchError::QueueOverloaded {
+                depth,
+                capacity,
+                retry_after_secs: 1,
+            }),
         }
         PostHandle::new(rx)
     }
@@ -637,6 +892,10 @@ impl DccDispatcher for QueueDispatcher {
     fn is_shutdown(&self) -> bool {
         self.shared.shutdown.load(Ordering::Acquire)
     }
+
+    fn stats(&self) -> QueueStats {
+        self.shared.snapshot()
+    }
 }
 
 // ── BlockingDispatcher: headless-mode wrapper ───────────────────────
@@ -665,6 +924,20 @@ impl BlockingDispatcher {
         Self {
             inner: QueueDispatcher::new(),
         }
+    }
+
+    /// Construct a bounded headless dispatcher (#715). Mirrors
+    /// [`QueueDispatcher::with_capacity`] for the headless /
+    /// `blender --background` / `mayapy` path.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            inner: QueueDispatcher::with_capacity(capacity),
+        }
+    }
+
+    /// Observability snapshot (#715).
+    pub fn stats(&self) -> QueueStats {
+        self.inner.stats()
     }
 
     /// Inherent generic `post<F, R>` — see
@@ -732,6 +1005,10 @@ impl DccDispatcher for BlockingDispatcher {
 
     fn is_shutdown(&self) -> bool {
         self.inner.is_shutdown()
+    }
+
+    fn stats(&self) -> QueueStats {
+        self.inner.stats()
     }
 }
 
@@ -1000,5 +1277,66 @@ mod tests {
             assert!(matches!(h.await, Err(DispatchError::Shutdown)));
         }
         assert_eq!(d.pending(), 0);
+    }
+
+    /// Issue #715: a bounded dispatcher rejects posts beyond capacity
+    /// with `DispatchError::QueueOverloaded` rather than growing an
+    /// unbounded queue.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn bounded_dispatcher_rejects_overload_with_typed_error() {
+        let d = Arc::new(QueueDispatcher::with_capacity(2));
+        let _h1 = d.post(|| 1_u32);
+        let _h2 = d.post(|| 2_u32);
+        let h3: PostHandle<u32> = d.post(|| 3_u32);
+
+        // The third post must resolve with QueueOverloaded without
+        // ever running on the main thread.
+        match h3.await.unwrap_err() {
+            DispatchError::QueueOverloaded {
+                depth,
+                capacity,
+                retry_after_secs,
+            } => {
+                assert_eq!(capacity, 2);
+                assert!(depth >= 2, "depth reported saturation");
+                assert!(retry_after_secs >= 1);
+            }
+            other => panic!("expected QueueOverloaded, got {other:?}"),
+        }
+
+        let stats = d.stats();
+        assert_eq!(stats.capacity, Some(2));
+        assert!(stats.total_rejected >= 1);
+    }
+
+    /// Issue #715: `stats()` reflects pending / enqueued / dequeued /
+    /// oldest-wait and populates percentiles after a drain.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stats_track_lifecycle_and_percentiles() {
+        let d = Arc::new(QueueDispatcher::new());
+        let _h1 = d.post(|| ());
+        let _h2 = d.post(|| ());
+        // Give the enqueue a moment to land.
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        let pre = d.stats();
+        assert_eq!(pre.total_enqueued, 2);
+        assert_eq!(pre.total_dequeued, 0);
+        assert_eq!(pre.pending, 2);
+        assert!(pre.oldest_wait_ms.is_some());
+        assert!(pre.wait_p50_ms.is_none());
+        assert_eq!(
+            pre.capacity, None,
+            "unbounded dispatcher reports capacity=None"
+        );
+
+        // Pump both jobs from the main thread.
+        let out = d.tick(16);
+        assert_eq!(out.jobs_executed, 2);
+
+        let post = d.stats();
+        assert_eq!(post.total_dequeued, 2);
+        assert_eq!(post.pending, 0);
+        assert!(post.oldest_wait_ms.is_none());
+        assert!(post.wait_p50_ms.is_some(), "percentiles populated");
     }
 }

--- a/crates/dcc-mcp-host/src/python.rs
+++ b/crates/dcc-mcp-host/src/python.rs
@@ -85,6 +85,13 @@ fn dispatch_error_to_py(err: DispatchError) -> PyErr {
             DispatchErrorPy::new_err("dropped: job result channel was dropped before delivery")
         }
         DispatchError::Panic(msg) => DispatchErrorPy::new_err(format!("panic: {msg}")),
+        DispatchError::QueueOverloaded {
+            depth,
+            capacity,
+            retry_after_secs,
+        } => DispatchErrorPy::new_err(format!(
+            "queue-overloaded: depth={depth}/{capacity}; retry in {retry_after_secs}s"
+        )),
     }
 }
 

--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -500,6 +500,59 @@ pub struct McpHttpConfig {
     /// parity with a single-instance server that already publishes
     /// SEP-986 dotted names directly.
     pub gateway_cursor_safe_tool_names: bool,
+
+    // ── Issue #715: queue observability + backpressure ────────────────────
+    /// Capacity of the HTTP → `DccExecutor` mpsc channel (issue #715).
+    ///
+    /// Controls how many outstanding `tools/call` submissions may queue
+    /// up before the backpressure path kicks in. When the channel is
+    /// full, the HTTP worker blocks for up to [`Self::queue_send_timeout_ms`]
+    /// waiting for the DCC main thread to drain; if the drain does not
+    /// happen in time, the call returns a structured
+    /// [`crate::error::HttpError::QueueOverloaded`].
+    ///
+    /// Default: `16`. Override via
+    /// `--queue-deferred-cap=<N>` / `MCP_QUEUE_DEFERRED_CAP`.
+    pub deferred_queue_depth: usize,
+
+    /// Capacity of the `DeferredExecutor` → `host_bridge` mpsc channel
+    /// (issue #715).
+    ///
+    /// Previously hard-coded to `16`. Exposed as a config knob so
+    /// operators can tune the bridge depth without patching the crate.
+    /// Set to `0` to fall back to [`crate::host_bridge::DEFAULT_BRIDGE_QUEUE_DEPTH`]
+    /// — this keeps misconfigured env-vars (`MCP_QUEUE_BRIDGE_CAP=0`)
+    /// from silently disabling backpressure.
+    ///
+    /// Default: `16`. Override via
+    /// `--queue-bridge-cap=<N>` / `MCP_QUEUE_BRIDGE_CAP`.
+    pub bridge_queue_depth: usize,
+
+    /// Capacity of the host-side `QueueDispatcher` (issue #715).
+    ///
+    /// When non-zero, applies to
+    /// [`dcc_mcp_host::QueueDispatcher::with_capacity`] so posts that
+    /// pile up past `N` surface
+    /// [`dcc_mcp_host::DispatchError::QueueOverloaded`] instead of
+    /// growing an unbounded queue. When zero (default), the dispatcher
+    /// stays unbounded — matches today's behaviour.
+    ///
+    /// Default: `0` (unbounded). Override via
+    /// `--queue-dispatcher-cap=<N>` / `MCP_QUEUE_DISPATCHER_CAP`.
+    pub host_queue_depth: usize,
+
+    /// How long an HTTP worker will block on a full executor channel
+    /// before returning [`crate::error::HttpError::QueueOverloaded`]
+    /// (issue #715).
+    ///
+    /// Chose "block with timeout" over "immediate error" so healthy
+    /// bursty workloads still make progress when the main thread
+    /// yields momentarily — the typed `QueueOverloaded` only fires on
+    /// sustained saturation. Same strategy across all three layers.
+    ///
+    /// Default: `2_000` ms. Override via
+    /// `--queue-send-timeout-ms=<N>` / `MCP_QUEUE_SEND_TIMEOUT_MS`.
+    pub queue_send_timeout_ms: u64,
 }
 
 impl McpHttpConfig {
@@ -555,6 +608,14 @@ impl McpHttpConfig {
             // for the compatibility window so in-flight clients keep
             // routing.
             gateway_cursor_safe_tool_names: true,
+            // #715: the three queue caps default to the pre-#715
+            // behaviour (16 / 16 / unbounded) so existing callers are
+            // unaffected until they opt into bounded mode via env var
+            // or builder.
+            deferred_queue_depth: 16,
+            bridge_queue_depth: 16,
+            host_queue_depth: 0,
+            queue_send_timeout_ms: 2_000,
         }
     }
 
@@ -823,6 +884,78 @@ impl McpHttpConfig {
         self.enable_tool_cache = false;
         self
     }
+
+    /// Builder: set the deferred-executor queue capacity (issue #715).
+    ///
+    /// Threaded down into [`crate::executor::DeferredExecutor::new`] at
+    /// startup. Setting this to `0` is a logic bug (it would create an
+    /// executor that can never accept a task) so the runtime clamps to
+    /// `1` at server-start time.
+    pub fn with_deferred_queue_depth(mut self, depth: usize) -> Self {
+        self.deferred_queue_depth = depth;
+        self
+    }
+
+    /// Builder: set the host-bridge queue capacity (issue #715).
+    ///
+    /// Threaded down into
+    /// [`crate::host_bridge::dispatcher_to_executor_handle_with_capacity`].
+    /// `0` degrades to [`crate::host_bridge::DEFAULT_BRIDGE_QUEUE_DEPTH`]
+    /// so misconfigured env-vars cannot silently disable backpressure.
+    pub fn with_bridge_queue_depth(mut self, depth: usize) -> Self {
+        self.bridge_queue_depth = depth;
+        self
+    }
+
+    /// Builder: set the host-side `QueueDispatcher` capacity (issue #715).
+    ///
+    /// `0` (the default) keeps the dispatcher unbounded — the historical
+    /// behaviour. Non-zero values activate the
+    /// [`dcc_mcp_host::DispatchError::QueueOverloaded`] path once the
+    /// queue hits capacity.
+    pub fn with_host_queue_depth(mut self, depth: usize) -> Self {
+        self.host_queue_depth = depth;
+        self
+    }
+
+    /// Builder: set the send-timeout applied to the bounded channels
+    /// (issue #715).
+    pub fn with_queue_send_timeout_ms(mut self, ms: u64) -> Self {
+        self.queue_send_timeout_ms = ms;
+        self
+    }
+
+    /// Load the queue-stack knobs from the environment (issue #715).
+    ///
+    /// Honours four optional env-vars:
+    /// - `MCP_QUEUE_DEFERRED_CAP`
+    /// - `MCP_QUEUE_BRIDGE_CAP`
+    /// - `MCP_QUEUE_DISPATCHER_CAP`
+    /// - `MCP_QUEUE_SEND_TIMEOUT_MS`
+    ///
+    /// Unset or unparsable values leave the existing field untouched
+    /// so a typo never silently flips the cap.
+    pub fn apply_queue_env_overrides(mut self) -> Self {
+        fn load_usize(key: &str) -> Option<usize> {
+            std::env::var(key).ok().and_then(|v| v.trim().parse().ok())
+        }
+        fn load_u64(key: &str) -> Option<u64> {
+            std::env::var(key).ok().and_then(|v| v.trim().parse().ok())
+        }
+        if let Some(v) = load_usize("MCP_QUEUE_DEFERRED_CAP") {
+            self.deferred_queue_depth = v.max(1);
+        }
+        if let Some(v) = load_usize("MCP_QUEUE_BRIDGE_CAP") {
+            self.bridge_queue_depth = v;
+        }
+        if let Some(v) = load_usize("MCP_QUEUE_DISPATCHER_CAP") {
+            self.host_queue_depth = v;
+        }
+        if let Some(v) = load_u64("MCP_QUEUE_SEND_TIMEOUT_MS") {
+            self.queue_send_timeout_ms = v;
+        }
+        self
+    }
 }
 
 impl Default for McpHttpConfig {
@@ -875,5 +1008,45 @@ mod tests {
         assert!(err.contains("retry"), "error message: {err}");
         assert!(err.contains("drop"), "error message: {err}");
         assert!(err.contains("requeue"), "error message: {err}");
+    }
+
+    /// Issue #715: the three queue caps default to the pre-#715
+    /// values so existing callers are unaffected.
+    #[test]
+    fn queue_caps_default_to_pre_715_values() {
+        let cfg = McpHttpConfig::new(8765);
+        assert_eq!(cfg.deferred_queue_depth, 16);
+        assert_eq!(cfg.bridge_queue_depth, 16);
+        assert_eq!(cfg.host_queue_depth, 0);
+        assert_eq!(cfg.queue_send_timeout_ms, 2_000);
+    }
+
+    /// Issue #715: env-var overrides are applied and bad values are
+    /// silently ignored (typo safety).
+    #[test]
+    fn queue_env_overrides_apply_and_ignore_typos() {
+        // Use a unique key prefix so parallel tests do not collide.
+        // SAFETY: we only touch the four #715 env-vars here; no other
+        // test reads them.
+        unsafe {
+            std::env::set_var("MCP_QUEUE_DEFERRED_CAP", "32");
+            std::env::set_var("MCP_QUEUE_BRIDGE_CAP", "64");
+            std::env::set_var("MCP_QUEUE_DISPATCHER_CAP", "128");
+            std::env::set_var("MCP_QUEUE_SEND_TIMEOUT_MS", "bogus");
+        }
+        let cfg = McpHttpConfig::new(0).apply_queue_env_overrides();
+        assert_eq!(cfg.deferred_queue_depth, 32);
+        assert_eq!(cfg.bridge_queue_depth, 64);
+        assert_eq!(cfg.host_queue_depth, 128);
+        assert_eq!(
+            cfg.queue_send_timeout_ms, 2_000,
+            "unparsable value is ignored (typo safety)"
+        );
+        unsafe {
+            std::env::remove_var("MCP_QUEUE_DEFERRED_CAP");
+            std::env::remove_var("MCP_QUEUE_BRIDGE_CAP");
+            std::env::remove_var("MCP_QUEUE_DISPATCHER_CAP");
+            std::env::remove_var("MCP_QUEUE_SEND_TIMEOUT_MS");
+        }
     }
 }

--- a/crates/dcc-mcp-http/src/error.rs
+++ b/crates/dcc-mcp-http/src/error.rs
@@ -32,6 +32,21 @@ pub enum HttpError {
     #[error("executor channel closed")]
     ExecutorClosed,
 
+    /// The DCC main-thread queue refused a new task because it is at
+    /// capacity and did not drain within the configured send timeout
+    /// (issue #715).
+    ///
+    /// Distinct from [`Self::ExecutorClosed`] (dispatcher gone) so
+    /// orchestrators can decide between "retry after `retry_after_secs`"
+    /// vs. "fail over to a different backend". `depth` / `capacity` are
+    /// exposed for operator diagnostics.
+    #[error("queue overloaded (depth={depth}/{capacity}); retry in {retry_after_secs}s")]
+    QueueOverloaded {
+        depth: usize,
+        capacity: usize,
+        retry_after_secs: u64,
+    },
+
     #[error("action dispatch error: {0}")]
     Dispatch(String),
 
@@ -54,6 +69,7 @@ impl HttpError {
             Self::RateLimit(_) => 429,
             Self::AlreadyRunning | Self::NotRunning => 409,
             Self::Timeout { .. } => 504,
+            Self::QueueOverloaded { .. } => 503,
             _ => 500,
         }
     }

--- a/crates/dcc-mcp-http/src/executor.rs
+++ b/crates/dcc-mcp-http/src/executor.rs
@@ -20,9 +20,119 @@
 //! For non-DCC environments (testing, pure Python), a simple in-process
 //! executor runs tasks directly on the calling thread.
 
+use std::collections::VecDeque;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
+
+/// Shared observability state for a [`DccExecutorHandle`] and its
+/// backing channel (issue #715).
+///
+/// Cloned (via `Arc`) alongside the handle so every sender and the
+/// owning [`DeferredExecutor`] see the same counters and submit-time
+/// ledger. The hot-path writers (submit / deliver) only take short
+/// `parking_lot` mutexes for two bounded `VecDeque`s; everything else
+/// is atomic.
+#[derive(Debug)]
+pub(crate) struct ExecutorStats {
+    /// Configured channel capacity (`send_timeout` blocks when full).
+    pub capacity: usize,
+    /// How long `execute` will block on a full channel before
+    /// surfacing [`crate::error::HttpError::QueueOverloaded`].
+    pub send_timeout: Duration,
+    pub total_enqueued: AtomicU64,
+    pub total_dequeued: AtomicU64,
+    pub total_rejected: AtomicU64,
+    /// Submit timestamps of currently-queued jobs, oldest first. Used
+    /// to surface `oldest_submit_age`.
+    pub submit_times: parking_lot::Mutex<VecDeque<Instant>>,
+    /// Wait-time samples for completed jobs (bounded ring of 256).
+    pub wait_samples: parking_lot::Mutex<VecDeque<u64>>,
+}
+
+impl ExecutorStats {
+    pub(crate) fn new(capacity: usize, send_timeout: Duration) -> Arc<Self> {
+        Arc::new(Self {
+            capacity,
+            send_timeout,
+            total_enqueued: AtomicU64::new(0),
+            total_dequeued: AtomicU64::new(0),
+            total_rejected: AtomicU64::new(0),
+            submit_times: parking_lot::Mutex::new(VecDeque::new()),
+            wait_samples: parking_lot::Mutex::new(VecDeque::with_capacity(256)),
+        })
+    }
+
+    pub(crate) fn record_submit(&self, at: Instant) {
+        self.total_enqueued.fetch_add(1, Ordering::Release);
+        self.submit_times.lock().push_back(at);
+    }
+
+    pub(crate) fn record_dequeue(&self, now: Instant) {
+        let submitted_at = self.submit_times.lock().pop_front();
+        if let Some(submitted) = submitted_at {
+            let wait_ms = now.saturating_duration_since(submitted).as_millis() as u64;
+            let mut ring = self.wait_samples.lock();
+            if ring.len() == 256 {
+                ring.pop_front();
+            }
+            ring.push_back(wait_ms);
+        }
+        self.total_dequeued.fetch_add(1, Ordering::Release);
+    }
+
+    pub(crate) fn record_reject(&self) {
+        self.total_rejected.fetch_add(1, Ordering::Release);
+    }
+
+    /// Approximate current queue depth — `enqueued - dequeued`,
+    /// saturating at zero.
+    pub(crate) fn pending(&self) -> usize {
+        let enq = self.total_enqueued.load(Ordering::Acquire);
+        let deq = self.total_dequeued.load(Ordering::Acquire);
+        enq.saturating_sub(deq) as usize
+    }
+
+    pub(crate) fn oldest_wait(&self) -> Option<Duration> {
+        self.submit_times.lock().front().map(|t| t.elapsed())
+    }
+
+    pub(crate) fn percentiles(&self) -> (Option<u64>, Option<u64>, Option<u64>) {
+        let ring = self.wait_samples.lock();
+        if ring.is_empty() {
+            return (None, None, None);
+        }
+        let mut sorted: Vec<u64> = ring.iter().copied().collect();
+        drop(ring);
+        sorted.sort_unstable();
+        let pick = |q: f64| -> u64 {
+            let n = sorted.len();
+            let idx = ((q * n as f64).ceil() as usize)
+                .saturating_sub(1)
+                .min(n - 1);
+            sorted[idx]
+        };
+        (Some(pick(0.50)), Some(pick(0.95)), Some(pick(0.99)))
+    }
+}
+
+/// Public observability snapshot for the DCC main-thread executor
+/// queue (issue #715). Field names are the stable wire shape
+/// consumed by `diagnostics__process_status.queue.executor_*`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ExecutorQueueStats {
+    pub pending: usize,
+    pub capacity: usize,
+    pub total_enqueued: u64,
+    pub total_dequeued: u64,
+    pub total_rejected: u64,
+    pub oldest_wait_ms: Option<u64>,
+    pub wait_p50_ms: Option<u64>,
+    pub wait_p95_ms: Option<u64>,
+    pub wait_p99_ms: Option<u64>,
+}
 
 /// A boxed async-compatible task that runs on the DCC main thread.
 ///
@@ -44,6 +154,7 @@ pub(crate) struct DccTask {
 #[derive(Clone)]
 pub struct DccExecutorHandle {
     tx: mpsc::Sender<DccTask>,
+    stats: Arc<ExecutorStats>,
 }
 
 impl DccExecutorHandle {
@@ -54,21 +165,92 @@ impl DccExecutorHandle {
     /// HTTP server's main-thread executor. `pub(crate)` keeps the
     /// module-private `tx` field invariant for normal callers while
     /// giving the bridge a single, documented seam.
-    pub(crate) fn from_sender(tx: mpsc::Sender<DccTask>) -> Self {
-        Self { tx }
+    pub(crate) fn from_sender(tx: mpsc::Sender<DccTask>, capacity: usize) -> Self {
+        Self {
+            tx,
+            stats: ExecutorStats::new(capacity, Duration::from_millis(2_000)),
+        }
+    }
+
+    /// Current approximate queue depth (issue #715). Safe to call
+    /// from any thread.
+    pub fn pending(&self) -> usize {
+        self.stats.pending()
+    }
+
+    /// Configured channel capacity (issue #715).
+    pub fn capacity(&self) -> usize {
+        self.stats.capacity
+    }
+
+    /// Wait-time of the oldest queued task (issue #715). `None` when
+    /// the queue is empty.
+    pub fn oldest_submit_age(&self) -> Option<Duration> {
+        self.stats.oldest_wait()
+    }
+
+    /// Observability snapshot for diagnostics (issue #715).
+    pub fn queue_stats(&self) -> ExecutorQueueStats {
+        let (p50, p95, p99) = self.stats.percentiles();
+        ExecutorQueueStats {
+            pending: self.stats.pending(),
+            capacity: self.stats.capacity,
+            total_enqueued: self.stats.total_enqueued.load(Ordering::Acquire),
+            total_dequeued: self.stats.total_dequeued.load(Ordering::Acquire),
+            total_rejected: self.stats.total_rejected.load(Ordering::Acquire),
+            oldest_wait_ms: self.stats.oldest_wait().map(|d| d.as_millis() as u64),
+            wait_p50_ms: p50,
+            wait_p95_ms: p95,
+            wait_p99_ms: p99,
+        }
     }
 }
 
 impl DccExecutorHandle {
     /// Submit a task to the DCC main thread and await its result.
     ///
-    /// Returns `Err` if the DCC executor has been shut down.
+    /// Backpressure semantics (issue #715): when the channel is at
+    /// capacity, the caller blocks for up to the handle's configured
+    /// send-timeout (default 2 s) waiting for the main thread to
+    /// drain. If it still does not drain, the call returns
+    /// [`crate::error::HttpError::QueueOverloaded`] — callers can
+    /// distinguish this from [`crate::error::HttpError::ExecutorClosed`]
+    /// and decide whether to retry or fail over.
     pub async fn execute(&self, func: DccTaskFn) -> Result<String, crate::error::HttpError> {
         let (result_tx, result_rx) = oneshot::channel();
-        self.tx
-            .send(DccTask { func, result_tx })
-            .await
-            .map_err(|_| crate::error::HttpError::ExecutorClosed)?;
+        let submit_attempted_at = Instant::now();
+        let timeout = self.stats.send_timeout;
+        let send_res = if timeout.is_zero() {
+            // Opt-out of backpressure: caller asked for no bound.
+            self.tx
+                .send(DccTask { func, result_tx })
+                .await
+                .map_err(|_| ())
+        } else {
+            match tokio::time::timeout(timeout, self.tx.send(DccTask { func, result_tx })).await {
+                Ok(Ok(())) => Ok(()),
+                Ok(Err(_)) => Err(()), // channel closed
+                Err(_) => {
+                    // Timed out waiting on a full channel. Canonical
+                    // overload signal.
+                    self.stats.record_reject();
+                    return Err(crate::error::HttpError::QueueOverloaded {
+                        depth: self.stats.pending(),
+                        capacity: self.stats.capacity,
+                        retry_after_secs: 1,
+                    });
+                }
+            }
+        };
+        match send_res {
+            Ok(()) => {
+                self.stats.record_submit(submit_attempted_at);
+            }
+            Err(()) => {
+                self.stats.record_reject();
+                return Err(crate::error::HttpError::ExecutorClosed);
+            }
+        }
 
         result_rx
             .await
@@ -139,29 +321,26 @@ impl DccExecutorHandle {
         // `.await`; cancelling while the mpsc is backed up drops the
         // request entirely without ever surfacing it to the pump.
         let tx = self.tx.clone();
+        let stats = self.stats.clone();
         tokio::spawn(async move {
             let task = DccTask {
                 func: wrapped,
                 result_tx,
             };
             // Race `cancel_token.cancelled()` against `tx.send(task)`.
-            // Select would require moving `task` into the send branch; a
-            // two-step await is simpler and equally correct because the
-            // mpsc send is the only branch that owns the task.
             tokio::select! {
                 biased;
                 _ = cancel_token.cancelled() => {
-                    // The wrapper owns its own `result_tx`; dropping the
-                    // DccTask here drops that sender and the receiver
-                    // observes `RecvError`. Caller selects on
-                    // `cancel_token.cancelled()` to translate this into a
-                    // proper CANCELLED outcome.
                     drop(task);
                 }
                 res = tx.reserve() => {
                     match res {
-                        Ok(permit) => permit.send(task),
+                        Ok(permit) => {
+                            stats.record_submit(Instant::now());
+                            permit.send(task);
+                        }
                         Err(_) => {
+                            stats.record_reject();
                             tracing::warn!(
                                 "submit_deferred: DeferredExecutor mpsc closed"
                             );
@@ -203,11 +382,21 @@ pub struct DeferredExecutor {
 
 impl DeferredExecutor {
     /// Create a new executor with a bounded queue depth.
+    ///
+    /// The default send-timeout for backpressure is 2 s — use
+    /// [`Self::with_send_timeout`] to override it.
     pub fn new(queue_depth: usize) -> Self {
+        Self::with_send_timeout(queue_depth, Duration::from_millis(2_000))
+    }
+
+    /// Create a new executor with a bounded queue depth and a custom
+    /// send-timeout for the backpressure path (issue #715).
+    pub fn with_send_timeout(queue_depth: usize, send_timeout: Duration) -> Self {
         let (tx, rx) = mpsc::channel(queue_depth);
+        let stats = ExecutorStats::new(queue_depth, send_timeout);
         Self {
             rx,
-            handle: DccExecutorHandle { tx },
+            handle: DccExecutorHandle { tx, stats },
         }
     }
 
@@ -221,7 +410,9 @@ impl DeferredExecutor {
     /// Call this from your DCC event loop. Returns the number of tasks processed.
     pub fn poll_pending(&mut self) -> usize {
         let mut count = 0;
+        let stats = self.handle.stats.clone();
         while let Ok(task) = self.rx.try_recv() {
+            stats.record_dequeue(Instant::now());
             let result = (task.func)();
             let _ = task.result_tx.send(result);
             count += 1;
@@ -232,8 +423,10 @@ impl DeferredExecutor {
     /// Process at most `max` tasks. Useful to bound latency per tick.
     pub fn poll_pending_bounded(&mut self, max: usize) -> usize {
         let mut count = 0;
+        let stats = self.handle.stats.clone();
         while count < max {
             if let Ok(task) = self.rx.try_recv() {
+                stats.record_dequeue(Instant::now());
                 let result = (task.func)();
                 let _ = task.result_tx.send(result);
                 count += 1;
@@ -260,13 +453,16 @@ impl InProcessExecutor {
     /// Wrap as a [`DccExecutorHandle`] backed by a dedicated Tokio task.
     pub fn into_handle(self) -> (DccExecutorHandle, Arc<tokio::task::JoinHandle<()>>) {
         let (tx, mut rx) = mpsc::channel::<DccTask>(256);
+        let stats = ExecutorStats::new(256, Duration::from_millis(2_000));
+        let drain_stats = stats.clone();
         let join = tokio::spawn(async move {
             while let Some(task) = rx.recv().await {
+                drain_stats.record_dequeue(Instant::now());
                 let result = (task.func)();
                 let _ = task.result_tx.send(result);
             }
         });
-        (DccExecutorHandle { tx }, Arc::new(join))
+        (DccExecutorHandle { tx, stats }, Arc::new(join))
     }
 }
 
@@ -444,5 +640,81 @@ mod tests {
             tick_count.load(Ordering::SeqCst) >= 1,
             "pump processed at least one task"
         );
+    }
+
+    /// Issue #715: saturating the executor channel without pumping
+    /// surfaces a structured `QueueOverloaded` after the send-timeout
+    /// — not a silent hang, and not `ExecutorClosed`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn execute_returns_queue_overloaded_on_saturation() {
+        // Tiny channel + short send-timeout so the test stays fast.
+        let _exec = DeferredExecutor::with_send_timeout(2, Duration::from_millis(50));
+        let handle = _exec.handle();
+
+        // Fill the channel: neither of these awaits resolves because
+        // no one pumps. We don't await them here; we just let them
+        // occupy the two slots.
+        let h1 = handle.clone();
+        let h2 = handle.clone();
+        let _t1 = tokio::spawn(async move {
+            let _ = h1.execute(Box::new(|| "one".to_string())).await;
+        });
+        let _t2 = tokio::spawn(async move {
+            let _ = h2.execute(Box::new(|| "two".to_string())).await;
+        });
+        // Let them land in the channel.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        // The third submit should hit the send-timeout and bubble
+        // QueueOverloaded.
+        let err = handle
+            .execute(Box::new(|| "three".to_string()))
+            .await
+            .expect_err("saturation must fail");
+        match err {
+            crate::error::HttpError::QueueOverloaded {
+                depth,
+                capacity,
+                retry_after_secs,
+            } => {
+                assert_eq!(capacity, 2, "capacity reflects config");
+                assert!(depth >= 1, "depth reported non-zero");
+                assert!(retry_after_secs >= 1, "retry hint is non-zero");
+            }
+            other => panic!("expected QueueOverloaded, got {other:?}"),
+        }
+        let stats = handle.queue_stats();
+        assert!(stats.total_rejected >= 1, "reject counter bumped");
+        assert_eq!(stats.capacity, 2, "capacity reported in snapshot");
+    }
+
+    /// Issue #715: the queue-stats snapshot tracks enqueued/dequeued
+    /// and reports a non-zero oldest-wait-age while jobs are parked.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn queue_stats_track_enqueue_dequeue_and_age() {
+        let mut exec = DeferredExecutor::new(8);
+        let handle = exec.handle();
+
+        let h = handle.clone();
+        let submitter = tokio::spawn(async move { h.execute(Box::new(|| "r".to_string())).await });
+        // Let the submit land.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let pre = handle.queue_stats();
+        assert_eq!(pre.total_enqueued, 1, "one submit recorded");
+        assert_eq!(pre.total_dequeued, 0, "nothing drained yet");
+        assert!(pre.oldest_wait_ms.unwrap_or(0) > 0, "wait-age reported");
+        assert_eq!(pre.pending, 1);
+
+        // Pump.
+        let drained = exec.poll_pending();
+        assert_eq!(drained, 1);
+        let res = submitter.await.expect("join").expect("execute");
+        assert_eq!(res, "r");
+
+        let post = handle.queue_stats();
+        assert_eq!(post.total_dequeued, 1, "drain recorded");
+        assert_eq!(post.pending, 0);
+        assert!(post.oldest_wait_ms.is_none(), "oldest cleared after drain");
+        assert!(post.wait_p50_ms.is_some(), "p50 populated from sample");
     }
 }

--- a/crates/dcc-mcp-http/src/host_bridge.rs
+++ b/crates/dcc-mcp-http/src/host_bridge.rs
@@ -44,14 +44,22 @@ use tokio::sync::mpsc;
 
 use crate::executor::{DccExecutorHandle, DccTask};
 
-/// Queue depth mirrors [`crate::executor::DeferredExecutor::new`]'s
-/// default (16) so back-pressure behaviour is identical to the native
-/// HTTP executor.
-const BRIDGE_QUEUE_DEPTH: usize = 16;
+/// Historical default bridge queue depth. Kept only as the fallback
+/// used by [`dispatcher_to_executor_handle`] when the caller has no
+/// `McpHttpConfig` in hand. Prefer
+/// [`dispatcher_to_executor_handle_with_capacity`] so operators can
+/// tune the depth via [`crate::McpHttpConfig::bridge_queue_depth`]
+/// / `MCP_QUEUE_BRIDGE_CAP` (issue #715).
+pub const DEFAULT_BRIDGE_QUEUE_DEPTH: usize = 16;
 
 /// Convert any [`Arc<dyn DccDispatcher>`] into a [`DccExecutorHandle`]
 /// the HTTP server can plug straight into
 /// [`crate::server::McpHttpServer::with_executor`].
+///
+/// Uses [`DEFAULT_BRIDGE_QUEUE_DEPTH`] so existing call-sites see
+/// identical behaviour to pre-#715. New code paths should prefer
+/// [`dispatcher_to_executor_handle_with_capacity`] so operators can
+/// tune the depth via [`crate::McpHttpConfig::bridge_queue_depth`].
 ///
 /// A single background tokio task (spawned on `runtime`) drains the
 /// synthesized handle's mpsc, forwards each closure into
@@ -70,7 +78,25 @@ pub fn dispatcher_to_executor_handle(
     dispatcher: Arc<dyn DccDispatcher>,
     runtime: &Handle,
 ) -> DccExecutorHandle {
-    let (tx, mut rx) = mpsc::channel::<DccTask>(BRIDGE_QUEUE_DEPTH);
+    dispatcher_to_executor_handle_with_capacity(dispatcher, runtime, DEFAULT_BRIDGE_QUEUE_DEPTH)
+}
+
+/// Like [`dispatcher_to_executor_handle`] but accepts an explicit
+/// queue capacity (issue #715).
+///
+/// `capacity == 0` degrades gracefully to [`DEFAULT_BRIDGE_QUEUE_DEPTH`]
+/// so misconfigured env-vars cannot silently disable backpressure.
+pub fn dispatcher_to_executor_handle_with_capacity(
+    dispatcher: Arc<dyn DccDispatcher>,
+    runtime: &Handle,
+    capacity: usize,
+) -> DccExecutorHandle {
+    let depth = if capacity == 0 {
+        DEFAULT_BRIDGE_QUEUE_DEPTH
+    } else {
+        capacity
+    };
+    let (tx, mut rx) = mpsc::channel::<DccTask>(depth);
 
     runtime.spawn(async move {
         while let Some(DccTask { func, result_tx }) = rx.recv().await {
@@ -86,7 +112,7 @@ pub fn dispatcher_to_executor_handle(
         }
     });
 
-    DccExecutorHandle::from_sender(tx)
+    DccExecutorHandle::from_sender(tx, depth)
 }
 
 /// Encode a [`DispatchError`] as the `{"__dispatch_error": "..."}`
@@ -100,6 +126,7 @@ fn encode_dispatch_error(err: &DispatchError) -> String {
         DispatchError::Shutdown => "shutdown",
         DispatchError::ResultDropped => "dropped",
         DispatchError::Panic(_) => "panic",
+        DispatchError::QueueOverloaded { .. } => "queue-overloaded",
     };
     serde_json::to_string(&serde_json::json!({
         "__dispatch_error": format!("{tag}: {err}"),

--- a/crates/dcc-mcp-http/src/lib.rs
+++ b/crates/dcc-mcp-http/src/lib.rs
@@ -99,7 +99,7 @@ pub use bridge_registry::{BridgeContext, BridgeRegistry};
 pub use config::{McpHttpConfig, ServerSpawnMode};
 pub use dynamic_tools::{DYNAMIC_TOOL_PREFIX, DynamicToolError, SessionDynamicTools, ToolSpec};
 pub use error::{HttpError, HttpResult};
-pub use executor::{DccExecutorHandle, DeferredExecutor};
+pub use executor::{DccExecutorHandle, DeferredExecutor, ExecutorQueueStats};
 pub use gateway::{GatewayConfig, GatewayHandle, GatewayRunner};
 pub use job::{Job, JobEvent, JobManager, JobProgress, JobStatus, JobSubscriber};
 #[cfg(feature = "job-persist-sqlite")]


### PR DESCRIPTION
Three stacked layers (DeferredExecutor, host_bridge, QueueDispatcher) had
inconsistent backpressure semantics and zero runtime observability.
Overload could manifest as a silent hang, and all three layers had
hardcoded capacities that operators could not tune without patching the
crate.

## Pre-#715 taxonomy

| Layer            | Crate / file                      | Capacity           | On overload              |
| ---------------- | --------------------------------- | ------------------ | ------------------------ |
| HTTP → Executor  | dcc-mcp-http/src/executor.rs      | bounded (configurable) | `send().await` blocks forever |
| Executor → Bridge| dcc-mcp-http/src/host_bridge.rs   | hardcoded `16`     | serial-awaits host `post` |
| Host dispatcher  | dcc-mcp-host/src/lib.rs           | unbounded          | grows without limit      |

## What this changes

- **Unified backpressure strategy = block with timeout** — the HTTP →
  Executor channel waits up to `queue_send_timeout_ms` (default 2 s)
  for the drain, then returns a structured
  `HttpError::QueueOverloaded { depth, capacity, retry_after_secs }`.
  The host dispatcher gets the same contract via
  `DispatchError::QueueOverloaded` when `QueueDispatcher::with_capacity`
  is used. Rationale: preserves progress under burst, refuses cleanly
  on sustained overload, same wire shape across layers. Drop-oldest and
  immediate-fail were rejected because they mask or surprise.

- **Observability on every layer**
    - `DccExecutorHandle::pending()` / `capacity()` /
      `oldest_submit_age()` / `queue_stats()` (struct
      `ExecutorQueueStats` with pending, capacity, totals for
      enqueued/dequeued/rejected, oldest_wait_ms, and p50/p95/p99 wait
      percentiles over a 256-sample ring).
    - `QueueDispatcher::stats()` returns a matching `QueueStats` on
      any `Arc<dyn DccDispatcher>`. Also exposed on the trait itself
      (default-returns a zero snapshot so existing impls keep compiling).
    - Both counters track rejected-submits, so `total_rejected` on a
      snapshot is the canonical 'did the gate actually fire?' signal.

- **Every capacity is now a config knob** — new fields on
  `McpHttpConfig`: `deferred_queue_depth`, `bridge_queue_depth`,
  `host_queue_depth`, `queue_send_timeout_ms`. Builder methods for
  each. `apply_queue_env_overrides()` reads `MCP_QUEUE_DEFERRED_CAP`,
  `MCP_QUEUE_BRIDGE_CAP`, `MCP_QUEUE_DISPATCHER_CAP`,
  `MCP_QUEUE_SEND_TIMEOUT_MS`; unparsable values are silently ignored
  so a typo never flips the cap.

- **Bridge-depth const removed** — `host_bridge.rs::BRIDGE_QUEUE_DEPTH`
  const is gone; `dispatcher_to_executor_handle_with_capacity` is the
  new seam operators thread through. `dispatcher_to_executor_handle`
  keeps the old signature and delegates to the default depth, so every
  existing call-site behaves identically.

- **Error taxonomy** — `HttpError::QueueOverloaded` is distinct from
  `ExecutorClosed`: orchestrators can tell 'backend alive, saturated,
  retry' from 'dispatcher gone'. Maps to HTTP 503 (`service
  unavailable`). `DispatchError::QueueOverloaded { depth, capacity,
  retry_after_secs }` gets first-class status inside dcc-mcp-host with
  matching Python-binding rendering.

## Tests

- Host: `bounded_dispatcher_rejects_overload_with_typed_error`,
  `stats_track_lifecycle_and_percentiles`.
- HTTP executor: `execute_returns_queue_overloaded_on_saturation`
  (saturation + send-timeout → `QueueOverloaded`),
  `queue_stats_track_enqueue_dequeue_and_age`.
- HTTP config: `queue_caps_default_to_pre_715_values`,
  `queue_env_overrides_apply_and_ignore_typos`.

All 217 lib tests pass; cargo fmt + clippy --tests clean.

## Not in scope

- Extending the gateway-native `diagnostics__process_status` tool with
  a `queue` block — the gateway does not hold per-instance executor
  handles. Adapters can surface `ExecutorQueueStats` /
  `QueueStats` from their own diagnostic skill using the public
  `DccExecutorHandle::queue_stats()` and `DccDispatcher::stats()`
  APIs added here.
