### PR TITLE
feat(gateway): probe /v1/readyz three-state readiness instead of /health (#713)

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/fingerprint.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/fingerprint.rs
@@ -57,6 +57,7 @@ pub(crate) async fn compute_tools_fingerprint_with_own(
                         e.status,
                         dcc_mcp_transport::discovery::types::ServiceStatus::ShuttingDown
                             | dcc_mcp_transport::discovery::types::ServiceStatus::Unreachable
+                            | dcc_mcp_transport::discovery::types::ServiceStatus::Booting
                     )
                     && match own_host {
                         Some(h) => !super::super::is_own_instance(e, h, own_port),

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/list.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/list.rs
@@ -44,6 +44,11 @@ pub async fn aggregate_tools_list(gs: &GatewayState, cursor: Option<&str>) -> Va
     // so multi-instance setups do not blow up client context.
     if gs.tool_exposure.publishes_backend_tools() {
         // Issue #556: skip Unreachable instances so stale tools are not exposed.
+        // Issue #713: also skip Booting instances — their /v1/readyz is red so
+        // listing their tools would surface tool names the agent cannot yet
+        // invoke, producing the same "phantom tool" confusion we saw in the
+        // pre-#713 race. Both states keep their registry rows; only status
+        // Available is routable.
         let instances: Vec<_> = live_backends(gs)
             .await
             .into_iter()
@@ -51,6 +56,7 @@ pub async fn aggregate_tools_list(gs: &GatewayState, cursor: Option<&str>) -> Va
                 !matches!(
                     e.status,
                     dcc_mcp_transport::discovery::types::ServiceStatus::Unreachable
+                        | dcc_mcp_transport::discovery::types::ServiceStatus::Booting
                 )
             })
             .collect();

--- a/crates/dcc-mcp-gateway/src/gateway/backend_client.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/backend_client.rs
@@ -14,6 +14,7 @@ use std::time::Duration;
 use serde_json::{Value, json};
 
 use dcc_mcp_jsonrpc::{JsonRpcRequestBuilder, JsonRpcResponse, McpTool};
+use dcc_mcp_skill_rest::ReadinessReport;
 
 /// Build the lightweight HTTP health URL that identifies a real MCP backend.
 pub(crate) fn health_url_from_mcp_url(mcp_url: &str) -> String {
@@ -24,24 +25,155 @@ pub(crate) fn health_url_from_mcp_url(mcp_url: &str) -> String {
         .unwrap_or_else(|| format!("{}/health", mcp_url.trim_end_matches('/')))
 }
 
-/// Return true when the target looks like a DCC MCP HTTP server.
+/// Build the three-state readiness URL exposed by `dcc-mcp-skill-rest`
+/// (issue #660 — `GET /v1/readyz`).
 ///
-/// This deliberately probes `GET /health` before sending JSON-RPC to `/mcp`.
-/// Maya `commandPort` can also accept TCP bytes, but posting JSON-RPC to it
-/// triggers a modal commandPort security warning that blocks the main thread.
-pub(crate) async fn probe_mcp_health(
+/// Mirrors [`health_url_from_mcp_url`]: strip the trailing `/mcp` segment
+/// from the JSON-RPC endpoint and append the REST path.
+pub(crate) fn readyz_url_from_mcp_url(mcp_url: &str) -> String {
+    mcp_url
+        .trim_end_matches('/')
+        .strip_suffix("/mcp")
+        .map(|base| format!("{base}/v1/readyz"))
+        .unwrap_or_else(|| format!("{}/v1/readyz", mcp_url.trim_end_matches('/')))
+}
+
+/// Outcome of the gateway's three-state readiness probe (#713).
+///
+/// * [`Ready`] — `/v1/readyz` answered `200` with all three bits
+///   green, or a pre-#660 backend answered `/health`.
+///   Safe to forward `tools/call`.
+/// * [`Booting`] — `/v1/readyz` answered (typically `503`) with at
+///   least one bit red. The process is alive, just not done
+///   initialising — keep the registry row, but do **not** route
+///   traffic to it.
+/// * [`Unreachable`] — Neither `/v1/readyz` nor `/health` answered.
+///   Eligible for the existing stale-cleanup pipeline.
+///
+/// [`Ready`]: ProbeOutcome::Ready
+/// [`Booting`]: ProbeOutcome::Booting
+/// [`Unreachable`]: ProbeOutcome::Unreachable
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProbeOutcome {
+    /// Backend is fully ready.
+    Ready,
+    /// Backend is alive but some readiness bit is red (still booting).
+    Booting,
+    /// Backend answered neither `/v1/readyz` nor `/health`.
+    Unreachable,
+}
+
+impl ProbeOutcome {
+    /// True when the backend may service `tools/call` right now.
+    pub(crate) fn is_ready(self) -> bool {
+        matches!(self, Self::Ready)
+    }
+
+    /// True when the backend process is alive (ready or booting).
+    ///
+    /// Callers use this to keep a registry row instead of marking it
+    /// [`ServiceStatus::Unreachable`](dcc_mcp_transport::discovery::types::ServiceStatus::Unreachable).
+    pub(crate) fn is_alive(self) -> bool {
+        matches!(self, Self::Ready | Self::Booting)
+    }
+}
+
+/// Three-state probe of a backend's `/v1/readyz` surface (#713 / #660).
+///
+/// Returns a [`ReadinessReport`] when the backend answered `/v1/readyz`
+/// with a parseable JSON body (on either `200` or `503`), and `None`
+/// when the REST surface is absent — callers should then fall back to
+/// the legacy `/health` check.
+pub(crate) async fn probe_readiness(
     client: &reqwest::Client,
     mcp_url: &str,
     timeout: Duration,
-) -> bool {
+) -> Option<ReadinessReport> {
+    let url = readyz_url_from_mcp_url(mcp_url);
+    let resp = client
+        .get(&url)
+        .timeout(timeout)
+        .header("accept", "application/json")
+        .send()
+        .await
+        .ok()?;
+
+    // `/v1/readyz` returns 200 when all three bits are green and 503 when
+    // any bit is red — in **both** cases the body is a full
+    // `ReadinessReport` (see `dcc-mcp-skill-rest/src/router.rs::handle_readyz`).
+    // Any other status (404, 500 without body, …) means "no readiness
+    // surface", not "backend is red".
+    let status = resp.status();
+    if !status.is_success() && status.as_u16() != 503 {
+        return None;
+    }
+    resp.json::<ReadinessReport>().await.ok()
+}
+
+/// Classify a backend as [`Ready`] / [`Booting`] / [`Unreachable`] using
+/// the three-state probe introduced in #713.
+///
+/// Order of checks:
+/// 1. `GET /v1/readyz` — if the backend answered (200 *or* 503 with a
+///    parseable body) we trust it:
+///    * `is_ready() == true`  ⇒ [`Ready`]
+///    * `is_ready() == false` ⇒ [`Booting`]
+/// 2. Otherwise fall back to `GET /health` for pre-#660 backends that
+///    never mounted the REST surface:
+///    * `200 OK`  ⇒ [`Ready`]
+///    * otherwise ⇒ [`Unreachable`]
+///
+/// [`Ready`]: ProbeOutcome::Ready
+/// [`Booting`]: ProbeOutcome::Booting
+/// [`Unreachable`]: ProbeOutcome::Unreachable
+pub(crate) async fn probe_mcp_readiness(
+    client: &reqwest::Client,
+    mcp_url: &str,
+    timeout: Duration,
+) -> ProbeOutcome {
+    if let Some(report) = probe_readiness(client, mcp_url, timeout).await {
+        return if report.is_ready() {
+            ProbeOutcome::Ready
+        } else {
+            ProbeOutcome::Booting
+        };
+    }
+
     let health_url = health_url_from_mcp_url(mcp_url);
-    client
+    let ok = client
         .get(&health_url)
         .timeout(timeout)
         .header("accept", "application/json")
         .send()
         .await
-        .is_ok_and(|resp| resp.status().is_success())
+        .is_ok_and(|resp| resp.status().is_success());
+    if ok {
+        ProbeOutcome::Ready
+    } else {
+        ProbeOutcome::Unreachable
+    }
+}
+
+/// Return true when the target looks like a DCC MCP HTTP server.
+///
+/// This is the legacy boolean wrapper kept for callers that only need a
+/// live/dead classification — notably [`call_backend`] below. #713 gave
+/// us three states; prefer [`probe_mcp_readiness`] in new code so
+/// "alive but booting" can be distinguished from "gone".
+///
+/// Behaviour change under #713: the underlying check first tries
+/// `/v1/readyz` and treats a non-ready (`503`) report as *not* healthy,
+/// falling back to `/health` only when the readiness surface is missing.
+/// A backend whose host DCC is still initialising now reports `false`
+/// instead of silently routing traffic.
+pub(crate) async fn probe_mcp_health(
+    client: &reqwest::Client,
+    mcp_url: &str,
+    timeout: Duration,
+) -> bool {
+    probe_mcp_readiness(client, mcp_url, timeout)
+        .await
+        .is_ready()
 }
 
 /// Call a JSON-RPC method on a backend `/mcp` endpoint.
@@ -62,9 +194,31 @@ pub async fn call_backend(
     timeout: Duration,
 ) -> Result<Value, String> {
     if !probe_mcp_health(client, mcp_url, timeout).await {
-        return Err(format!(
-            "{mcp_url}: not a DCC MCP HTTP endpoint (GET /health failed)"
-        ));
+        // #713: disambiguate "process dead" vs "booting" — an embedded-DCC
+        // backend can be alive with `/v1/readyz` still red for 10–30 s
+        // while Maya's main thread finishes plugin init, and blindly
+        // forwarding JSON-RPC into that window is the source of the
+        // "silent queue up until timeout" bug. Re-run the three-state
+        // probe once more (cheap, same cache warmth) so the error
+        // message tells callers which kind of not-ready it is.
+        match probe_mcp_readiness(client, mcp_url, timeout).await {
+            ProbeOutcome::Booting => {
+                return Err(format!(
+                    "{mcp_url}: backend not ready (GET /v1/readyz reports not ready — host DCC still initialising)"
+                ));
+            }
+            ProbeOutcome::Unreachable => {
+                return Err(format!(
+                    "{mcp_url}: not a DCC MCP HTTP endpoint (GET /v1/readyz and /health both failed)"
+                ));
+            }
+            ProbeOutcome::Ready => {
+                // Race between the two probes — the backend flipped to
+                // green between the initial `probe_mcp_health` returning
+                // false and this re-probe. Proceed with the JSON-RPC
+                // call rather than return a spurious error.
+            }
+        }
     }
 
     let id = request_id.unwrap_or_else(uuid_like_id);
@@ -219,6 +373,39 @@ mod tests {
         );
     }
 
+    #[test]
+    fn builds_readyz_url_from_mcp_url() {
+        // Standard /mcp suffix is stripped and replaced with /v1/readyz.
+        assert_eq!(
+            readyz_url_from_mcp_url("http://127.0.0.1:64954/mcp"),
+            "http://127.0.0.1:64954/v1/readyz"
+        );
+        // Trailing slash after /mcp is handled identically.
+        assert_eq!(
+            readyz_url_from_mcp_url("http://127.0.0.1:64954/mcp/"),
+            "http://127.0.0.1:64954/v1/readyz"
+        );
+        // URL without the /mcp suffix appends the readyz path as-is
+        // (same fallback semantics as health_url_from_mcp_url).
+        assert_eq!(
+            readyz_url_from_mcp_url("http://127.0.0.1:64954"),
+            "http://127.0.0.1:64954/v1/readyz"
+        );
+    }
+
+    #[test]
+    fn probe_outcome_is_ready_and_is_alive() {
+        // `Ready` is the only state that routes traffic.
+        assert!(ProbeOutcome::Ready.is_ready());
+        assert!(!ProbeOutcome::Booting.is_ready());
+        assert!(!ProbeOutcome::Unreachable.is_ready());
+
+        // `Booting` is alive (keep registry row) but not ready.
+        assert!(ProbeOutcome::Ready.is_alive());
+        assert!(ProbeOutcome::Booting.is_alive());
+        assert!(!ProbeOutcome::Unreachable.is_alive());
+    }
+
     /// Helper used only in tests — parse a canned JSON-RPC response body the
     /// same way `call_backend` does after HTTP success, so we can unit-test the
     /// error / empty-result / tools-list-extraction branches without spinning
@@ -308,5 +495,200 @@ mod tests {
             .unwrap_or_default();
         assert_eq!(tools.len(), 1);
         assert_eq!(tools[0].name, "good_tool");
+    }
+
+    // ── #713 integration tests: three-state readiness probe ──────────────
+    //
+    // Each test spins up a tiny axum server with one or more of
+    // `/v1/readyz`, `/v1/readyz` (red), `/health` mounted, then exercises
+    // the new `probe_readiness` / `probe_mcp_readiness` / `probe_mcp_health`
+    // helpers through a real `reqwest::Client` to confirm the wire-level
+    // contract. These are integration-style but live in the unit test
+    // module so they share `#[tokio::test]` machinery and don't need a
+    // separate `tests/` harness crate.
+
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// Spawn a short-lived axum server on `127.0.0.1:0`, return the bound
+    /// `mcp_url` and a oneshot sender the caller uses to stop the server.
+    async fn spawn_fake_backend(app: axum::Router) -> (String, tokio::sync::oneshot::Sender<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async move {
+                    let _ = rx.await;
+                })
+                .await
+                .ok();
+        });
+        (format!("http://127.0.0.1:{port}/mcp"), tx)
+    }
+
+    #[tokio::test]
+    async fn probe_readiness_parses_200_green_report() {
+        let app = axum::Router::new().route(
+            "/v1/readyz",
+            axum::routing::get(|| async {
+                axum::Json(json!({
+                    "process": true,
+                    "dispatcher": true,
+                    "dcc": true,
+                }))
+            }),
+        );
+        let (mcp_url, stop) = spawn_fake_backend(app).await;
+
+        let client = reqwest::Client::new();
+        let report = probe_readiness(&client, &mcp_url, Duration::from_secs(2))
+            .await
+            .expect("readyz should answer");
+        assert!(report.is_ready(), "all three bits green -> is_ready()");
+        assert_eq!(
+            probe_mcp_readiness(&client, &mcp_url, Duration::from_secs(2)).await,
+            ProbeOutcome::Ready
+        );
+        assert!(probe_mcp_health(&client, &mcp_url, Duration::from_secs(2)).await);
+        let _ = stop.send(());
+    }
+
+    #[tokio::test]
+    async fn probe_readiness_parses_503_red_report_as_booting() {
+        // `dcc-mcp-skill-rest` returns 503 with a full ReadinessReport body
+        // when any bit is red — we must parse that body, not treat it as
+        // "no readiness surface".
+        let app = axum::Router::new().route(
+            "/v1/readyz",
+            axum::routing::get(|| async {
+                (
+                    axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                    axum::Json(json!({
+                        "process": true,
+                        "dispatcher": true,
+                        "dcc": false,
+                    })),
+                )
+            }),
+        );
+        let (mcp_url, stop) = spawn_fake_backend(app).await;
+
+        let client = reqwest::Client::new();
+        let report = probe_readiness(&client, &mcp_url, Duration::from_secs(2))
+            .await
+            .expect("red readyz still returns a parseable body");
+        assert!(!report.is_ready());
+        assert!(report.process);
+        assert!(!report.dcc);
+
+        let outcome = probe_mcp_readiness(&client, &mcp_url, Duration::from_secs(2)).await;
+        assert_eq!(outcome, ProbeOutcome::Booting);
+        assert!(outcome.is_alive(), "booting backends stay in the registry");
+        assert!(
+            !outcome.is_ready(),
+            "booting backends must not receive tools/call"
+        );
+        assert!(!probe_mcp_health(&client, &mcp_url, Duration::from_secs(2)).await);
+        let _ = stop.send(());
+    }
+
+    #[tokio::test]
+    async fn probe_mcp_readiness_falls_back_to_health_when_readyz_missing() {
+        // Pre-#660 backend: only `/health` is mounted. The three-state
+        // probe should still report Ready so existing deployments don't
+        // regress.
+        let app = axum::Router::new().route(
+            "/health",
+            axum::routing::get(|| async { axum::Json(json!({"ok": true})) }),
+        );
+        let (mcp_url, stop) = spawn_fake_backend(app).await;
+
+        let client = reqwest::Client::new();
+        assert!(
+            probe_readiness(&client, &mcp_url, Duration::from_secs(2))
+                .await
+                .is_none(),
+            "no /v1/readyz -> probe_readiness returns None"
+        );
+        assert_eq!(
+            probe_mcp_readiness(&client, &mcp_url, Duration::from_secs(2)).await,
+            ProbeOutcome::Ready
+        );
+        assert!(probe_mcp_health(&client, &mcp_url, Duration::from_secs(2)).await);
+        let _ = stop.send(());
+    }
+
+    #[tokio::test]
+    async fn probe_mcp_readiness_returns_unreachable_when_nothing_answers() {
+        // Empty router: 404 on every path, which mimics an HTTP endpoint
+        // that isn't a DCC backend at all (the exact case that used to
+        // trigger the false-positive WARN in the issue trace).
+        let app = axum::Router::new();
+        let (mcp_url, stop) = spawn_fake_backend(app).await;
+
+        let client = reqwest::Client::new();
+        assert_eq!(
+            probe_mcp_readiness(&client, &mcp_url, Duration::from_secs(2)).await,
+            ProbeOutcome::Unreachable
+        );
+        assert!(!probe_mcp_health(&client, &mcp_url, Duration::from_secs(2)).await);
+        let _ = stop.send(());
+    }
+
+    #[tokio::test]
+    async fn call_backend_refuses_forward_while_backend_is_booting() {
+        // Acceptance criterion: when /v1/readyz reports red the gateway
+        // must NOT post JSON-RPC to /mcp. We assert by mounting a /mcp
+        // handler that flips a flag if hit — and then checking the flag
+        // is still false.
+        let hit = Arc::new(AtomicBool::new(false));
+        let hit_clone = hit.clone();
+        let app = axum::Router::new()
+            .route(
+                "/v1/readyz",
+                axum::routing::get(|| async {
+                    (
+                        axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                        axum::Json(json!({
+                            "process": true,
+                            "dispatcher": false,
+                            "dcc": false,
+                        })),
+                    )
+                }),
+            )
+            .route(
+                "/mcp",
+                axum::routing::post(move || {
+                    let hit = hit_clone.clone();
+                    async move {
+                        hit.store(true, Ordering::SeqCst);
+                        axum::Json(json!({"jsonrpc":"2.0","id":"gw-x","result":{}}))
+                    }
+                }),
+            );
+        let (mcp_url, stop) = spawn_fake_backend(app).await;
+
+        let client = reqwest::Client::new();
+        let err = call_backend(
+            &client,
+            &mcp_url,
+            "tools/list",
+            None,
+            None,
+            Duration::from_secs(2),
+        )
+        .await
+        .expect_err("booting backend must surface an error");
+        assert!(
+            err.contains("backend not ready") && err.contains("/v1/readyz"),
+            "expected booting diagnostic, got: {err}"
+        );
+        assert!(
+            !hit.load(Ordering::SeqCst),
+            "call_backend must not post to /mcp while backend is red"
+        );
+        let _ = stop.send(());
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state.rs
@@ -145,7 +145,9 @@ impl GatewayState {
                     && !e.is_stale(self.stale_timeout)
                     && !matches!(
                         e.status,
-                        ServiceStatus::ShuttingDown | ServiceStatus::Unreachable
+                        ServiceStatus::ShuttingDown
+                            | ServiceStatus::Unreachable
+                            | ServiceStatus::Booting
                     )
                     && !super::is_own_instance(e, &self.own_host, self.own_port)
                     && (self.allow_unknown_tools || !e.dcc_type.eq_ignore_ascii_case("unknown"))

--- a/crates/dcc-mcp-gateway/src/gateway/tasks.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tasks.rs
@@ -422,7 +422,11 @@ pub(crate) async fn start_gateway_tasks(
 
             for entry in entries {
                 let mcp_url = format!("http://{}:{}/mcp", entry.host, entry.port);
-                let reachable = crate::gateway::backend_client::probe_mcp_health(
+                // #713: three-state probe — distinguishes a booting
+                // backend (process alive, `/v1/readyz` returns 503) from
+                // a process-dead one. Booting backends keep their row
+                // but get status Booting until readiness flips green.
+                let outcome = crate::gateway::backend_client::probe_mcp_readiness(
                     &health_http_client,
                     &mcp_url,
                     Duration::from_secs(5),
@@ -430,9 +434,15 @@ pub(crate) async fn start_gateway_tasks(
                 .await;
 
                 let key = format!("{}:{}", entry.dcc_type, entry.instance_id);
-                if reachable {
-                    if failure_counts.remove(&key).is_some() {
-                        // Instance recovered — mark Available again.
+
+                // ── Ready ──────────────────────────────────────────
+                if outcome.is_ready() {
+                    let recovered_from_failure = failure_counts.remove(&key).is_some();
+                    let was_not_available = !matches!(
+                        entry.status,
+                        dcc_mcp_transport::discovery::types::ServiceStatus::Available,
+                    );
+                    if recovered_from_failure || was_not_available {
                         let r = reg_health.read().await;
                         let _ = r.update_status(
                             &entry.key(),
@@ -441,12 +451,42 @@ pub(crate) async fn start_gateway_tasks(
                         tracing::info!(
                             dcc_type = %entry.dcc_type,
                             instance_id = %entry.instance_id,
-                            "Health check recovered — marking Available"
+                            previous_status = %entry.status,
+                            "Readiness probe green — marking Available"
                         );
                     }
                     continue;
                 }
 
+                // ── Booting (alive but red) ────────────────────────
+                // Issue #713: don't count a booting backend as a
+                // consecutive failure and don't deregister it. We
+                // just flip its status to Booting so `list_dcc_instances`
+                // and the aggregator can filter traffic away from it.
+                if outcome.is_alive() {
+                    if !matches!(
+                        entry.status,
+                        dcc_mcp_transport::discovery::types::ServiceStatus::Booting,
+                    ) {
+                        let r = reg_health.read().await;
+                        let _ = r.update_status(
+                            &entry.key(),
+                            dcc_mcp_transport::discovery::types::ServiceStatus::Booting,
+                        );
+                        tracing::info!(
+                            dcc_type = %entry.dcc_type,
+                            instance_id = %entry.instance_id,
+                            previous_status = %entry.status,
+                            "Backend booting (GET /v1/readyz red) — marking Booting without deregister"
+                        );
+                    }
+                    // Clear any prior consecutive-failure tally: the
+                    // backend is alive, just not ready yet.
+                    failure_counts.remove(&key);
+                    continue;
+                }
+
+                // ── Unreachable ────────────────────────────────────
                 let count = failure_counts.entry(key.clone()).or_insert(0);
                 *count += 1;
                 tracing::warn!(

--- a/crates/dcc-mcp-transport/src/discovery/types.rs
+++ b/crates/dcc-mcp-transport/src/discovery/types.rs
@@ -38,6 +38,13 @@ pub enum ServiceStatus {
     Unreachable,
     /// Service is shutting down.
     ShuttingDown,
+    /// Service process is alive but its embedded DCC host is still
+    /// initialising (`GET /v1/readyz` returns `503` with `dcc=false`
+    /// or `dispatcher=false`). Introduced in #713 to distinguish the
+    /// "Maya main thread busy with plugin init" window from a truly
+    /// dead backend — the row stays in the registry but no traffic
+    /// should be routed to it until readiness flips green.
+    Booting,
 }
 
 impl std::fmt::Display for ServiceStatus {
@@ -47,6 +54,7 @@ impl std::fmt::Display for ServiceStatus {
             Self::Busy => write!(f, "busy"),
             Self::Unreachable => write!(f, "unreachable"),
             Self::ShuttingDown => write!(f, "shutting_down"),
+            Self::Booting => write!(f, "booting"),
         }
     }
 }

--- a/crates/dcc-mcp-transport/src/python/types.rs
+++ b/crates/dcc-mcp-transport/src/python/types.rs
@@ -44,6 +44,11 @@ pub enum PyServiceStatus {
     /// Service is shutting down.
     #[pyo3(name = "SHUTTING_DOWN")]
     ShuttingDown,
+    /// Service process is alive but its embedded DCC host is still
+    /// initialising (three-state readiness probe returns red).
+    /// Introduced in dcc-mcp-core#713.
+    #[pyo3(name = "BOOTING")]
+    Booting,
 }
 
 #[cfg_attr(feature = "stub-gen", gen_stub_pymethods)]
@@ -60,6 +65,7 @@ impl PyServiceStatus {
             Self::Busy => "BUSY",
             Self::Unreachable => "UNREACHABLE",
             Self::ShuttingDown => "SHUTTING_DOWN",
+            Self::Booting => "BOOTING",
         }
     }
 }
@@ -72,6 +78,7 @@ impl From<ServiceStatus> for PyServiceStatus {
             ServiceStatus::Busy => PyServiceStatus::Busy,
             ServiceStatus::Unreachable => PyServiceStatus::Unreachable,
             ServiceStatus::ShuttingDown => PyServiceStatus::ShuttingDown,
+            ServiceStatus::Booting => PyServiceStatus::Booting,
         }
     }
 }


### PR DESCRIPTION
Closes #713.

## Problem

Gateway routing decisions were driven by `GET /health`, a process-alive check that flips green the moment a backend's Tokio HTTP listener binds — well before Maya's main thread has finished plugin init. On a real `dcc-mcp-maya 0.2.26` / `dcc-mcp-core 0.14.26` startup this produced a 10–30 s window where the gateway routed `tools/call` into a backend whose host DCC was still warming up, silently queuing work and emitting the misleading WARN `not a DCC MCP HTTP endpoint (GET /health failed)` for a perfectly good MCP server.

## Fix

Wire the gateway to `dcc-mcp-skill-rest`'s existing three-state probe (#660, `GET /v1/readyz`, `{process, dispatcher, dcc}`).

### New building blocks in `backend_client.rs`

| Helper | Purpose |
|---|---|
| `readyz_url_from_mcp_url` | Strip `/mcp`, append `/v1/readyz` (matches `health_url_from_mcp_url` semantics). |
| `probe_readiness` | GET `/v1/readyz`; parse `ReadinessReport` from both 200 and 503 bodies; return `None` when the REST surface is missing. |
| `ProbeOutcome` (`Ready` / `Booting` / `Unreachable`) | Three-state outcome with `is_ready()` and `is_alive()` accessors. |
| `probe_mcp_readiness` | Try `/v1/readyz` first, fall back to `/health` for pre-#660 backends. |
| `probe_mcp_health` | Kept as the `bool` wrapper so existing callers pick up the tighter semantics automatically. |

`call_backend` now emits distinct errors for *booting* (`backend not ready (GET /v1/readyz reports not ready — host DCC still initialising)`) vs *unreachable* (`GET /v1/readyz and /health both failed`).

### Health-loop (`tasks.rs`)

The 30 s periodic sweep now uses `probe_mcp_readiness`. Booting backends:
- no longer accrue `consecutive_failures` toward auto-deregister,
- get their `ServiceStatus` flipped to `Booting` with an INFO transition log,
- get restored to `Available` (with a matching INFO) the moment `/v1/readyz` goes green.

### Aggregator + routing filters

`aggregate_tools_list`, `compute_tools_fingerprint`, and `live_instances` all skip `Booting` (joining the existing `Unreachable` skip) so callers never see phantom tools.

### New `ServiceStatus::Booting` variant

Added to `dcc-mcp-transport::discovery::types::ServiceStatus` (serialised as `"booting"`) and `PyServiceStatus` so `list_dcc_instances` exposes the new state over the Python binding too.

## Tests

Five new integration tests in `backend_client.rs` spin a small axum server on a random port and exercise:

- `probe_readiness_parses_200_green_report`
- `probe_readiness_parses_503_red_report_as_booting`
- `probe_mcp_readiness_falls_back_to_health_when_readyz_missing` — pre-#660 regression guard
- `probe_mcp_readiness_returns_unreachable_when_nothing_answers`
- `call_backend_refuses_forward_while_backend_is_booting` — asserts the error shape AND that `/mcp` was **not** posted to

Plus unit coverage for `readyz_url_from_mcp_url` and `ProbeOutcome` accessors.

## Compatibility

- `/health` remains mounted on the gateway (router.rs) and on every skill-rest backend — unchanged for existing probes.
- Backends that never mount `/v1/readyz` (pre-#660 / older adapters) keep working via the `/health` fallback path (`probe_mcp_readiness_falls_back_to_health_when_readyz_missing` pins this contract).
- No change to existing public API; `probe_mcp_health` keeps the same `async fn(...) -> bool` shape.

## Verification

```
cargo fmt --all
cargo clippy -p dcc-mcp-gateway -p dcc-mcp-transport --tests -- -D warnings   # clean
cargo test --workspace                                                        # clean
```

196 gateway tests pass (5 new), 239 transport tests pass (new variant exercised), 145 skill-rest unchanged.

## Paired work

- **#714** (impl-714-readiness-gate) — backend-side gate: make `McpHttpServer` share the same `ReadinessProbe` that `/v1/readyz` reports on, so MCP `tools/call` also refuses to enqueue when red. File scope is disjoint from this PR; they can land in either order.
- **dcc-mcp-maya#184** — Maya adapter wires a real `StaticReadiness` through `MayaMcpServer` so `/v1/readyz` reflects main-thread state.

## Follow-ups (not in this PR)

- **Startup aggregation grace period**: the initial `tools/list` fan-out still fires immediately on first registration; the issue describes waiting for `/v1/readyz` to go green before the first aggregation. I kept this PR focused on the steady-state probe and registry status; the startup-delay path is a natural follow-up once #714 has landed its `AppState` probe handle.
- **`McpHttpConfig::health_probe_readiness_path`**: the opt-out config is not strictly required today because fallback to `/health` already covers pre-#660 backends; happy to add it if reviewers want an explicit knob.