### PR TITLE
fix(gateway): prune dead PIDs on list_dcc_instances read path (#719)

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state.rs
@@ -176,6 +176,49 @@ impl GatewayState {
             })
             .collect()
     }
+
+    /// Return operator-facing registry rows with dead-PID entries pruned.
+    ///
+    /// Issue #719: before this method existed, `list_dcc_instances` could
+    /// return rows whose owning DCC process had already exited — for up to
+    /// `stale_timeout_secs` (default 30 s) after the process died, or
+    /// indefinitely if no gateway process was running the periodic sweep.
+    /// Agents then routed `call_tool` / `acquire_dcc_instance` to a dead
+    /// backend and hit connection-refused.
+    ///
+    /// This is a self-healing read path: every call consults
+    /// [`FileRegistry::read_alive`] which probes each row's `pid` field via
+    /// `sysinfo` and evicts dead-PID rows from both the in-memory view and
+    /// the on-disk `services.json` before returning. The same
+    /// sentinel / self-row filters that [`Self::all_instances`] uses are
+    /// applied after the prune so the caller sees the identical view
+    /// minus the zombies.
+    ///
+    /// Fail-open contract (#227): rows with no `pid` are considered alive
+    /// and survive the prune. `FileRegistry::read_alive` enforces this
+    /// internally; we do not re-check it here.
+    ///
+    /// Returns `(alive_entries, evicted_count)`. `evicted_count` is the
+    /// total number of dead-PID rows the registry dropped — callers can
+    /// surface it so operators notice when a backend crashed without
+    /// deregistering. Note that the count reflects every dead row the
+    /// registry held, not just rows that would have passed the gateway's
+    /// own filters (e.g. a zombie `__gateway__` sentinel still bumps the
+    /// count even though it is filtered out of the returned slice).
+    pub fn read_alive_instances(
+        &self,
+        registry: &FileRegistry,
+    ) -> dcc_mcp_transport::TransportResult<(Vec<ServiceEntry>, usize)> {
+        let (raw, evicted) = registry.read_alive()?;
+        let filtered = raw
+            .into_iter()
+            .filter(|e| {
+                e.dcc_type != GATEWAY_SENTINEL_DCC_TYPE
+                    && !super::is_own_instance(e, &self.own_host, self.own_port)
+            })
+            .collect();
+        Ok((filtered, evicted))
+    }
 }
 
 /// Serialize a `ServiceEntry` to a JSON `Value` suitable for gateway responses.
@@ -513,5 +556,136 @@ mod tests {
         assert_eq!(json["pool"]["current_job_id"].as_str(), Some("job-1"));
         assert_eq!(json["pool"]["available"].as_bool(), Some(false));
         assert!(json["pool"]["lease_expires_at"].as_u64().is_some());
+    }
+
+    // ── Issue #719: read_alive_instances ───────────────────────────────────
+
+    /// A row whose PID points at a live process survives the prune; a row
+    /// whose PID points at a dead process is evicted — even if its
+    /// heartbeat was freshly written. Dead rows also disappear from the
+    /// on-disk `services.json`, not just from the returned slice.
+    #[tokio::test]
+    async fn test_read_alive_instances_prunes_dead_pid() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
+
+        let live_id;
+        let dead_id;
+        {
+            let r = registry.read().await;
+            // Live row — uses the current test process's pid, guaranteed alive.
+            let mut live = ServiceEntry::new("maya", "127.0.0.1", 18812);
+            live.pid = Some(std::process::id());
+            live_id = live.instance_id;
+            r.register(live).unwrap();
+
+            // Dead row — a pid that cannot plausibly belong to a real process
+            // on any supported platform. `u32::MAX - 1` lives above the Linux
+            // `pid_max` ceiling and above the Windows PID space as well.
+            let mut dead = ServiceEntry::new("blender", "127.0.0.1", 18813);
+            dead.pid = Some(u32::MAX - 1);
+            dead_id = dead.instance_id;
+            r.register(dead).unwrap();
+        }
+
+        let gs = test_gateway_state(registry.clone());
+        let (alive, evicted) = gs
+            .read_alive_instances(&*registry.read().await)
+            .expect("read_alive_instances must succeed");
+
+        assert_eq!(evicted, 1, "exactly one dead row must be evicted");
+        assert_eq!(alive.len(), 1, "only the live row survives");
+        assert_eq!(alive[0].instance_id, live_id);
+        assert_ne!(alive[0].instance_id, dead_id);
+
+        // The dead row must also be gone from services.json — not just
+        // filtered out of the returned slice.
+        let raw = gs.all_instances(&*registry.read().await);
+        assert!(
+            raw.iter().all(|e| e.instance_id != dead_id),
+            "dead row must be purged from the on-disk registry after read_alive_instances",
+        );
+    }
+
+    /// Fail-open guard (#227): a row without a `pid` is assumed alive and
+    /// must survive the prune — older registrations predate the pid field.
+    #[tokio::test]
+    async fn test_read_alive_instances_keeps_rows_without_pid() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
+
+        {
+            let r = registry.read().await;
+            // `ServiceEntry::new` defaults pid to the current process; null
+            // it out to simulate a legacy registration that predates the
+            // pid field.
+            let mut legacy = ServiceEntry::new("photoshop", "127.0.0.1", 18814);
+            legacy.pid = None;
+            r.register(legacy).unwrap();
+        }
+
+        let gs = test_gateway_state(registry.clone());
+        let (alive, evicted) = gs
+            .read_alive_instances(&*registry.read().await)
+            .expect("read_alive_instances must succeed");
+
+        assert_eq!(evicted, 0);
+        assert_eq!(alive.len(), 1, "pid-less rows must survive (#227 contract)");
+        assert_eq!(alive[0].dcc_type, "photoshop");
+        assert!(
+            alive[0].pid.is_none(),
+            "pid must remain null after read_alive"
+        );
+    }
+
+    /// Regression guard for maya#138 and #419: the PID-pruned path must
+    /// still filter out the bookkeeping `__gateway__` sentinel and the
+    /// gateway's own self-row. Otherwise a gateway that crashed and
+    /// re-bound would briefly expose its own sentinel to agents.
+    #[tokio::test]
+    async fn test_read_alive_instances_filters_sentinel_and_self() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
+
+        {
+            let r = registry.read().await;
+
+            // Sentinel row — carries the current pid (looks alive) but
+            // must still be excluded.
+            let mut sentinel = ServiceEntry::new(GATEWAY_SENTINEL_DCC_TYPE, "127.0.0.1", 9765);
+            sentinel.pid = Some(std::process::id());
+            r.register(sentinel).unwrap();
+
+            // Gateway's own plain-instance row (same host/port as the
+            // facade under test).
+            let mut self_row = ServiceEntry::new("maya", "127.0.0.1", 9765);
+            self_row.pid = Some(std::process::id());
+            r.register(self_row).unwrap();
+
+            // A real, non-self Maya instance on another port — must
+            // survive.
+            let mut other = ServiceEntry::new("maya", "127.0.0.1", 18815);
+            other.pid = Some(std::process::id());
+            r.register(other).unwrap();
+        }
+
+        let gs = test_gateway_state_with_own(registry.clone(), "127.0.0.1", 9765);
+        let (alive, evicted) = gs
+            .read_alive_instances(&*registry.read().await)
+            .expect("read_alive_instances must succeed");
+
+        assert_eq!(evicted, 0, "no rows were dead; nothing should be evicted");
+        assert_eq!(
+            alive.len(),
+            1,
+            "only the non-self non-sentinel maya row should remain; got {alive:#?}",
+        );
+        assert_eq!(alive[0].port, 18815);
+        assert!(
+            !alive
+                .iter()
+                .any(|e| e.dcc_type == GATEWAY_SENTINEL_DCC_TYPE),
+            "sentinel must never appear in read_alive_instances output",
+        );
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/tools.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tools.rs
@@ -55,15 +55,38 @@ fn document_matches(e: &ServiceEntry, hint: &str) -> bool {
 ///
 /// Pass `include_stale: false` (boolean) to opt out of stale rows for
 /// callers that genuinely want only routable instances.
+///
+/// Issue #719: the read path is now self-healing. By default the tool
+/// consults [`GatewayState::read_alive_instances`], which evicts rows
+/// whose PID is no longer alive before returning them. Agents no longer
+/// see "available" entries for backends that crashed without
+/// deregistering (heartbeats stayed fresh because the gateway sweep
+/// hadn't run yet). The number of rows evicted is surfaced as
+/// `evicted_dead` so operators notice the transition.
+///
+/// Pass `include_dead: true` (boolean) to fall back to the raw view
+/// (unchanged pre-#719 behaviour) — useful when inspecting the registry
+/// for debugging, or when running the tool from a watchdog that wants
+/// to see every row the file system holds.
 pub async fn tool_list_instances(gs: &GatewayState, args: &Value) -> Result<String, String> {
     let dcc_filter = args.get("dcc_type").and_then(|v| v.as_str());
     let include_stale = args
         .get("include_stale")
         .and_then(|v| v.as_bool())
         .unwrap_or(true);
+    // Issue #719: default to the prune-on-read path. Operators that
+    // genuinely want the unfiltered view opt in with `include_dead: true`.
+    let include_dead = args
+        .get("include_dead")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
 
     let reg = gs.registry.read().await;
-    let raw = gs.all_instances(&reg);
+    let (raw, evicted_dead) = if include_dead {
+        (gs.all_instances(&reg), 0usize)
+    } else {
+        gs.read_alive_instances(&reg).map_err(|e| e.to_string())?
+    };
 
     let mut stale_count: usize = 0;
     let mut instances: Vec<Value> = raw
@@ -88,6 +111,11 @@ pub async fn tool_list_instances(gs: &GatewayState, args: &Value) -> Result<Stri
 
     let tip = if instances.is_empty() {
         "No DCC instances in the registry. Start dcc-mcp-server for each DCC application."
+    } else if evicted_dead > 0 {
+        "Some rows had dead PIDs and were pruned from services.json. \
+         If a backend you expected is missing, start it again — the previous \
+         process exited without deregistering. Pass include_dead=true to see \
+         the raw registry view for debugging."
     } else if stale_count > 0 && include_stale {
         "Some rows have status='stale' (no recent heartbeat). \
          Use connect_to_dcc(dcc_type=..., scene=...) to route to a live one — \
@@ -99,10 +127,11 @@ pub async fn tool_list_instances(gs: &GatewayState, args: &Value) -> Result<Stri
     };
 
     serde_json::to_string_pretty(&json!({
-        "total":        instances.len(),
-        "stale_count":  stale_count,
-        "instances":    instances,
-        "tip":          tip,
+        "total":         instances.len(),
+        "stale_count":   stale_count,
+        "evicted_dead":  evicted_dead,
+        "instances":     instances,
+        "tip":           tip,
     }))
     .map_err(|e| e.to_string())
 }
@@ -630,7 +659,9 @@ pub fn gateway_tool_defs() -> serde_json::Value {
                 Returns type, port, scene, documents, pid, display_name, version, adapter_version, \
                 adapter_dcc, and status. Stale rows (no recent heartbeat) are reported with \
                 status='stale' so operators can see why a registration is no longer routable; \
-                pass include_stale=false to hide them. Call this first to discover what's available.",
+                pass include_stale=false to hide them. Dead-PID rows are pruned by default (\
+                issue #719) — pass include_dead=true for the raw registry view. Call this first \
+                to discover what's available.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -642,6 +673,11 @@ pub fn gateway_tool_defs() -> serde_json::Value {
                         "type": "boolean",
                         "description": "Include rows with status='stale' (default: true). Set to false for routable-only output.",
                         "default": true
+                    },
+                    "include_dead": {
+                        "type": "boolean",
+                        "description": "Include rows whose owning process has exited (default: false). Dead-PID rows are pruned from services.json on every read when this is false; set true for debugging the raw registry view.",
+                        "default": false
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Makes `list_dcc_instances` self-healing so agents never see "available" entries for backends that crashed without deregistering. Complements #718 (graceful-shutdown deregister) — together they close the zombie-row window from ~30s to effectively zero.

## Changes
- New `GatewayState::read_alive_instances(&FileRegistry) -> TransportResult<(Vec<ServiceEntry>, usize)>` in `crates/dcc-mcp-gateway/src/gateway/state.rs` — delegates to `FileRegistry::read_alive` (already present via #227 / #523) which probes each row's pid via sysinfo and evicts dead-PID rows from both the in-memory view and the on-disk `services.json`. Re-applies the `__gateway__` sentinel + gateway self-row filters from `all_instances`.
- `tool_list_instances` now consults `read_alive_instances` by default and surfaces `evicted_dead` in the response.
- New `include_dead: bool` knob (default `false`) on the tool schema so operators can still see raw snapshots for debugging (preserves the maya#138 admin-debug affordance).
- Fail-open for pid-less rows preserved per #227 contract.
- `all_instances` untouched so `diagnostics__process_status`, `tool_release_instance`, etc. still show the full picture.

## Tests
3 new tests in `gateway::state::tests`:
1. `test_read_alive_instances_prunes_dead_pid` — live-pid row + dead-pid row (`u32::MAX - 1`) with fresh heartbeat ⇒ only live survives, evicted count = 1, dead row purged from `services.json`.
2. `test_read_alive_instances_keeps_rows_without_pid` — fail-open guard.
3. `test_read_alive_instances_filters_sentinel_and_self` — maya#138 + #419 regression guard.

Full gateway suite: **202 passed, 0 failed**. `cargo clippy -p dcc-mcp-gateway --tests -- -D warnings` clean. `cargo fmt` clean.

## History
First attempt (PR #722) shipped an empty commit due to a shared-worktree branch-swap race — the implementation was never actually committed. Second attempt stalled silently. This is a clean third pass on a dedicated worktree; `git diff-tree --no-commit-id --name-only -r HEAD` confirms two files in the commit. See the attached commit SHA `8e2a71c`.

Closes #719