### PR TITLE
ci(perf): unify cargo cache + prebuilt cargo-hakari

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -64,7 +64,8 @@ runs:
     - name: Cache Cargo
       uses: Swatinem/rust-cache@v2
       with:
-        key: wheel-${{ inputs.target || 'default' }}-py${{ inputs.python-version }}
+        key: rust-${{ runner.os }}
+        shared-key: rust-${{ runner.os }}
 
     - name: Resolve features from justfile
       id: resolve-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,11 @@ jobs:
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
         with:
-          key: preflight
-      - name: Install cargo-hakari
-        run: cargo install cargo-hakari --locked
+          key: rust-${{ runner.os }}
+          shared-key: rust-${{ runner.os }}
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hakari
       - name: Verify workspace-hack is up to date
         run: cargo hakari verify
       - name: Preflight (check + clippy + fmt + test)


### PR DESCRIPTION
## Summary

Two surgical CI perf tweaks to cut wasted minutes from every PR run:

### 1. Replace `cargo install cargo-hakari` with `taiki-e/install-action`
Previously the `rust-check` job compiled `cargo-hakari` from source on each of 3 OS runners (~60-90s × 3 = 3-4 min wasted). The action fetches a prebuilt binary in 2-5s.

### 2. Unify Swatinem/rust-cache keys across `rust-check` and `build-wheel`
Before: `rust-check` used `key: preflight`; `build-wheel` used `key: wheel-<target>-py<version>`. The two jobs never shared `target/` — each recompiled from scratch.

After: both use `key: rust-${{ runner.os }}` + `shared-key: rust-${{ runner.os }}`. The Python version is intentionally excluded from the key — `target/` content depends on Rust toolchain + `Cargo.lock`, not Python. Expected saving: 2-3 min per OS on `build-wheel`.

### Not touched
- `build-wheel` `needs:` (owned by ci-perf-matrix PR)
- `PyO3/maturin-action`'s `sccache` (cross-build optimisation, coexists with Swatinem cache)
- Any other CI job / matrix dimension

### Verification
Will observe cache-hit ratio on the first post-merge CI run.