### PR TITLE
feat(gateway): aggregate prompts/list + prompts/get across backends (#731)

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/aggregator.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator.rs
@@ -17,6 +17,7 @@ mod call;
 mod fingerprint;
 mod helpers;
 mod list;
+mod prompts;
 mod skill_mgmt;
 #[cfg(test)]
 mod tests;
@@ -32,6 +33,10 @@ pub(crate) use helpers::{
     strip_gateway_meta_flags, targets_for_fanout, to_text_result,
 };
 pub use list::aggregate_tools_list;
+pub(crate) use prompts::compute_prompts_fingerprint_with_own;
+pub use prompts::{
+    PromptsGetError, aggregate_prompts_list, compute_prompts_fingerprint, route_prompts_get,
+};
 pub(crate) use skill_mgmt::{skill_management_tool_defs, skill_mgmt_dispatch};
 #[cfg(test)]
 pub(crate) use wait_terminal::merge_job_update_into_envelope;

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/prompts.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/prompts.rs
@@ -1,0 +1,267 @@
+//! Prompts aggregation and routing for the facade gateway (issue #731).
+//!
+//! Mirrors the shape of [`super::list`] and [`super::call`] for the MCP
+//! prompts primitive:
+//!
+//! * [`aggregate_prompts_list`] fans `prompts/list` out to every live
+//!   backend, merges the results, and namespaces each entry with the
+//!   same `i_<id8>__<escaped>` / `<id8>.<name>` prefix scheme used for
+//!   tools so identical prompt names across multiple DCCs never clash.
+//! * [`route_prompts_get`] decodes a prefixed prompt name back to
+//!   `(id8, original)` and forwards `prompts/get` to the owning
+//!   backend.
+//!
+//! Both helpers are fail-soft: an unreachable or erroring backend is
+//! logged at WARN level and skipped, matching the `tools/list`
+//! contract so one stale DCC never 500s the whole gateway endpoint.
+
+use super::*;
+
+use super::super::backend_client::{fetch_prompts, forward_prompts_get};
+use super::super::namespace::{encode_tool_name, encode_tool_name_cursor_safe};
+
+/// Build the unified `prompts/list` result by aggregating every live backend.
+///
+/// Each backend's prompts are emitted under the instance-prefixed form
+/// selected by [`GatewayState::cursor_safe_tool_names`]: the preferred
+/// cursor-safe `i_<id8>__<escaped>` name introduced in issue #656, or
+/// the legacy SEP-986 `<id8>.<name>` form for diagnostic parity. The
+/// wire-level namespace is intentionally shared with tool slugs so
+/// the same `decode_tool_name` helper can route both primitives.
+///
+/// Backends that fail or are unreachable are skipped with a WARN log
+/// (see [`fetch_prompts`]) — one stale DCC must never 500 the whole
+/// aggregated call. A zero-backend gateway returns `{"prompts": []}`
+/// rather than a `Method not found` so clients can uniformly call
+/// `prompts/list` regardless of topology.
+pub async fn aggregate_prompts_list(gs: &GatewayState) -> Value {
+    let instances: Vec<_> = live_backends(gs)
+        .await
+        .into_iter()
+        .filter(|e| {
+            !matches!(
+                e.status,
+                dcc_mcp_transport::discovery::types::ServiceStatus::Unreachable
+                    | dcc_mcp_transport::discovery::types::ServiceStatus::Booting
+            )
+        })
+        .collect();
+    let client = &gs.http_client;
+    let backend_timeout = gs.backend_timeout;
+    let cursor_safe = gs.cursor_safe_tool_names;
+
+    let futs = instances.iter().map(|entry| async move {
+        let url = format!("http://{}:{}/mcp", entry.host, entry.port);
+        let prompts = fetch_prompts(client, &url, backend_timeout).await;
+        (entry.instance_id, entry.dcc_type.clone(), prompts)
+    });
+    let results = join_all(futs).await;
+
+    let mut prompts: Vec<Value> = Vec::new();
+    for (iid, dcc_type, backend_prompts) in results {
+        for mut prompt in backend_prompts {
+            let encoded = if cursor_safe {
+                encode_tool_name_cursor_safe(&iid, &prompt.name)
+            } else {
+                encode_tool_name(&iid, &prompt.name)
+            };
+            prompt.name = encoded;
+            let mut json_val = serde_json::to_value(&prompt).unwrap_or(Value::Null);
+            if let Some(obj) = json_val.as_object_mut() {
+                obj.insert("_instance_id".to_string(), Value::String(iid.to_string()));
+                obj.insert(
+                    "_instance_short".to_string(),
+                    Value::String(instance_short(&iid)),
+                );
+                obj.insert("_dcc_type".to_string(), Value::String(dcc_type.clone()));
+            }
+            prompts.push(json_val);
+        }
+    }
+
+    json!({ "prompts": prompts })
+}
+
+/// Forward a gateway `prompts/get` to the owning backend.
+///
+/// Returns the backend's raw result envelope on success. Any
+/// transport / protocol / not-found condition is mapped to a JSON-RPC
+/// error payload (`{ "error": { "code", "message" } }`) that the
+/// caller can wrap into a full response.
+///
+/// Decoding mirrors [`super::call::route_tools_call`]: accepts the
+/// preferred cursor-safe form plus the legacy encodings exposed by
+/// [`decode_tool_name`]. With a single live backend, a bare
+/// (un-prefixed) prompt name is accepted as a convenience so clients
+/// can address an un-ambiguous target without going through
+/// `prompts/list` first.
+pub async fn route_prompts_get(
+    gs: &GatewayState,
+    name: &str,
+    arguments: Option<Value>,
+    request_id: Option<String>,
+) -> Result<Value, PromptsGetError> {
+    let (entry, original) = match decode_tool_name(name) {
+        Some((prefix, original)) => match find_instance_by_prefix(gs, &prefix).await {
+            Some(entry) => (entry, original),
+            None => {
+                return Err(PromptsGetError::NoInstanceForPrefix {
+                    prefix,
+                    full: name.to_string(),
+                });
+            }
+        },
+        None => {
+            let instances = live_backends(gs).await;
+            match instances.len() {
+                0 => return Err(PromptsGetError::NoLiveBackend),
+                1 => (instances.into_iter().next().unwrap(), name.to_string()),
+                _ => return Err(PromptsGetError::AmbiguousBareName(name.to_string())),
+            }
+        }
+    };
+
+    let url = format!("http://{}:{}/mcp", entry.host, entry.port);
+    forward_prompts_get(
+        &gs.http_client,
+        &url,
+        &original,
+        arguments,
+        request_id,
+        gs.backend_timeout,
+    )
+    .await
+    .map_err(PromptsGetError::Backend)
+}
+
+/// Failure modes for [`route_prompts_get`].
+#[derive(Debug)]
+pub enum PromptsGetError {
+    /// No live backend exposes the 8-hex instance prefix encoded in the
+    /// prompt name — typically because the instance shut down between
+    /// `prompts/list` and `prompts/get`.
+    NoInstanceForPrefix { prefix: String, full: String },
+    /// A bare (un-prefixed) prompt name was requested with no live
+    /// backends available.
+    NoLiveBackend,
+    /// A bare (un-prefixed) prompt name was requested while multiple
+    /// backends are live — the caller must use a prefixed name to
+    /// disambiguate.
+    AmbiguousBareName(String),
+    /// Backend returned a transport / protocol / error response.
+    Backend(String),
+}
+
+impl PromptsGetError {
+    /// JSON-RPC style error code for this failure.
+    ///
+    /// * `-32602` (Invalid params) — the prompt name could not be
+    ///   resolved to a live backend (no instance, ambiguous bare name,
+    ///   no live DCCs at all).
+    /// * `-32000` (Implementation-defined server error) — the backend
+    ///   itself returned an error or was unreachable.
+    pub fn code(&self) -> i64 {
+        match self {
+            Self::NoInstanceForPrefix { .. } | Self::NoLiveBackend | Self::AmbiguousBareName(_) => {
+                -32602
+            }
+            Self::Backend(_) => -32000,
+        }
+    }
+
+    /// Human-readable message matching the tool-routing error phrasing.
+    pub fn message(&self) -> String {
+        match self {
+            Self::NoInstanceForPrefix { prefix, full } => {
+                format!("No live DCC instance matches prefix '{prefix}' in prompt '{full}'.")
+            }
+            Self::NoLiveBackend => "No live DCC instances for prompts/get.".to_string(),
+            Self::AmbiguousBareName(name) => format!(
+                "Ambiguous bare prompt name '{name}' — multiple backends live. \
+                 Use the prefixed form from prompts/list."
+            ),
+            Self::Backend(e) => format!("Backend prompts/get failed: {e}"),
+        }
+    }
+}
+
+/// Compute a fingerprint of the aggregated prompt set across every live
+/// backend (issue #731 — mirror of [`super::fingerprint::compute_tools_fingerprint`]).
+///
+/// Returns a stable, sorted concatenation of `{instance_id}:{prompt_name}`
+/// that changes whenever a backend loads or unloads a prompt-bearing
+/// skill, so the gateway's watcher task can broadcast a single
+/// `notifications/prompts/list_changed` to connected SSE clients.
+pub(crate) async fn compute_prompts_fingerprint_with_own(
+    registry: &std::sync::Arc<
+        tokio::sync::RwLock<dcc_mcp_transport::discovery::file_registry::FileRegistry>,
+    >,
+    stale_timeout: Duration,
+    http_client: &reqwest::Client,
+    backend_timeout: Duration,
+    own_host: Option<&str>,
+    own_port: u16,
+) -> String {
+    let instances: Vec<_> = {
+        let reg = registry.read().await;
+        reg.list_all()
+            .into_iter()
+            .filter(|e| {
+                !e.is_stale(stale_timeout)
+                    && e.dcc_type != GATEWAY_SENTINEL_DCC_TYPE
+                    && !matches!(
+                        e.status,
+                        dcc_mcp_transport::discovery::types::ServiceStatus::ShuttingDown
+                            | dcc_mcp_transport::discovery::types::ServiceStatus::Unreachable
+                            | dcc_mcp_transport::discovery::types::ServiceStatus::Booting
+                    )
+                    && match own_host {
+                        Some(h) => !super::super::is_own_instance(e, h, own_port),
+                        None => true,
+                    }
+                    && !e.dcc_type.eq_ignore_ascii_case("unknown")
+            })
+            .collect()
+    };
+
+    let futs = instances.iter().map(|entry| async move {
+        let url = format!("http://{}:{}/mcp", entry.host, entry.port);
+        let prompts = fetch_prompts(http_client, &url, backend_timeout).await;
+        (entry.instance_id, prompts)
+    });
+    let results = join_all(futs).await;
+
+    let mut parts: Vec<String> = results
+        .into_iter()
+        .flat_map(|(iid, prompts)| {
+            prompts
+                .into_iter()
+                .map(move |p| format!("{iid}:{}", p.name))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    parts.sort_unstable();
+    parts.join("|")
+}
+
+/// Public wrapper for [`compute_prompts_fingerprint_with_own`] that
+/// disables the own-instance filter. Kept symmetric with
+/// [`super::fingerprint::compute_tools_fingerprint`].
+pub async fn compute_prompts_fingerprint(
+    registry: &std::sync::Arc<
+        tokio::sync::RwLock<dcc_mcp_transport::discovery::file_registry::FileRegistry>,
+    >,
+    stale_timeout: Duration,
+    http_client: &reqwest::Client,
+    backend_timeout: Duration,
+) -> String {
+    compute_prompts_fingerprint_with_own(
+        registry,
+        stale_timeout,
+        http_client,
+        backend_timeout,
+        None,
+        0,
+    )
+    .await
+}

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
@@ -296,3 +296,430 @@ async fn aggregate_tools_list_does_not_publish_single_instance_bare_aliases() {
     let _ = shutdown_tx.send(());
     server.await.unwrap();
 }
+
+// ── #731: prompts/list + prompts/get aggregation ─────────────────────
+//
+// Mirror of the tools aggregation tests above. Two fake backends with
+// disjoint prompt sets exercise:
+//   1. `aggregate_prompts_list` returns the merged set with correct
+//      per-backend cursor-safe prefixes.
+//   2. `route_prompts_get` decodes the prefix and routes to the
+//      owning backend.
+//   3. Zero-backend gateway returns `{"prompts": []}` instead of an
+//      error — a hard acceptance criterion from the issue.
+
+/// Spawn a tiny axum server that answers both `tools/list` (empty) and
+/// `prompts/list` / `prompts/get` with canned fixtures.
+///
+/// The caller supplies the per-backend prompt name and a marker text
+/// that the `prompts/get` route echoes back so we can assert the
+/// request landed on the intended backend.
+async fn spawn_prompts_backend(
+    prompt_name: &'static str,
+    echo_text: &'static str,
+) -> (String, tokio::sync::oneshot::Sender<()>) {
+    let app = axum::Router::new()
+        .route(
+            "/health",
+            axum::routing::get(|| async { axum::Json(json!({"ok": true})) }),
+        )
+        .route(
+            "/mcp",
+            axum::routing::post(move |body: axum::Json<Value>| async move {
+                let method = body.get("method").and_then(Value::as_str).unwrap_or("");
+                let id = body.get("id").cloned().unwrap_or(json!("gw-1"));
+                let result: Value = match method {
+                    "tools/list" => json!({"tools": []}),
+                    "prompts/list" => json!({
+                        "prompts": [{
+                            "name": prompt_name,
+                            "description": format!("Prompt from {echo_text}"),
+                            "arguments": [],
+                        }]
+                    }),
+                    "prompts/get" => {
+                        let requested = body
+                            .get("params")
+                            .and_then(|p| p.get("name"))
+                            .and_then(Value::as_str)
+                            .unwrap_or("");
+                        json!({
+                            "description": format!("Echo from {echo_text}"),
+                            "messages": [{
+                                "role": "user",
+                                "content": {
+                                    "type": "text",
+                                    "text": format!("{echo_text}:{requested}"),
+                                }
+                            }]
+                        })
+                    }
+                    _ => json!({}),
+                };
+                axum::Json(json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": result,
+                }))
+            }),
+        );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                let _ = rx.await;
+            })
+            .await
+            .ok();
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    (format!("127.0.0.1:{port}"), tx)
+}
+
+/// Build a GatewayState with the supplied registry — same shape as the
+/// tools-aggregator test helper but extracted for reuse.
+async fn make_gateway_state(
+    registry: std::sync::Arc<
+        tokio::sync::RwLock<dcc_mcp_transport::discovery::file_registry::FileRegistry>,
+    >,
+) -> crate::gateway::GatewayState {
+    let (yield_tx, _) = tokio::sync::watch::channel(false);
+    let (events_tx, _) = tokio::sync::broadcast::channel::<String>(8);
+    crate::gateway::GatewayState {
+        registry,
+        stale_timeout: std::time::Duration::from_secs(30),
+        backend_timeout: std::time::Duration::from_secs(10),
+        async_dispatch_timeout: std::time::Duration::from_secs(60),
+        wait_terminal_timeout: std::time::Duration::from_secs(600),
+        server_name: "test".into(),
+        server_version: env!("CARGO_PKG_VERSION").into(),
+        own_host: "127.0.0.1".into(),
+        own_port: 0,
+        http_client: reqwest::Client::new(),
+        yield_tx: std::sync::Arc::new(yield_tx),
+        events_tx: std::sync::Arc::new(events_tx),
+        protocol_version: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
+        resource_subscriptions: std::sync::Arc::new(tokio::sync::RwLock::new(
+            std::collections::HashMap::new(),
+        )),
+        pending_calls: std::sync::Arc::new(tokio::sync::RwLock::new(
+            std::collections::HashMap::new(),
+        )),
+        subscriber: crate::gateway::sse_subscriber::SubscriberManager::default(),
+        allow_unknown_tools: false,
+        adapter_version: None,
+        adapter_dcc: None,
+        tool_exposure: crate::gateway::GatewayToolExposure::Rest,
+        cursor_safe_tool_names: true,
+        capability_index: std::sync::Arc::new(crate::gateway::capability::CapabilityIndex::new()),
+    }
+}
+
+#[tokio::test]
+async fn aggregate_prompts_list_zero_backends_returns_empty_array() {
+    // Acceptance criterion: a gateway with no live backends must return
+    // `{"prompts": []}` — never `Method not found`.
+    let dir = tempfile::tempdir().unwrap();
+    let registry = std::sync::Arc::new(tokio::sync::RwLock::new(
+        dcc_mcp_transport::discovery::file_registry::FileRegistry::new(dir.path()).unwrap(),
+    ));
+    let gs = make_gateway_state(registry).await;
+
+    let result = aggregate_prompts_list(&gs).await;
+    assert_eq!(result["prompts"], json!([]));
+}
+
+#[tokio::test]
+async fn aggregate_prompts_list_merges_and_prefixes_across_backends() {
+    let (addr_a, stop_a) = spawn_prompts_backend("bake_animation", "maya-A").await;
+    let (addr_b, stop_b) = spawn_prompts_backend("render_frame", "blender-B").await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let registry = std::sync::Arc::new(tokio::sync::RwLock::new(
+        dcc_mcp_transport::discovery::file_registry::FileRegistry::new(dir.path()).unwrap(),
+    ));
+    let (iid_a, iid_b) = {
+        let r = registry.read().await;
+        let (host_a, port_a) = parse_addr(&addr_a);
+        let (host_b, port_b) = parse_addr(&addr_b);
+        let entry_a =
+            dcc_mcp_transport::discovery::types::ServiceEntry::new("maya", host_a, port_a);
+        let entry_b =
+            dcc_mcp_transport::discovery::types::ServiceEntry::new("blender", host_b, port_b);
+        let ia = entry_a.instance_id;
+        let ib = entry_b.instance_id;
+        r.register(entry_a).unwrap();
+        r.register(entry_b).unwrap();
+        (ia, ib)
+    };
+
+    let gs = make_gateway_state(registry).await;
+    let result = aggregate_prompts_list(&gs).await;
+
+    let names: Vec<String> = result["prompts"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|p| p["name"].as_str().map(str::to_owned))
+        .collect();
+
+    let short_a = &iid_a.to_string().replace('-', "")[..8];
+    let short_b = &iid_b.to_string().replace('-', "")[..8];
+    let expected_a = format!("i_{short_a}__bake_U_animation");
+    let expected_b = format!("i_{short_b}__render_U_frame");
+
+    assert!(
+        names.iter().any(|n| n == &expected_a),
+        "expected {expected_a} in {names:?}"
+    );
+    assert!(
+        names.iter().any(|n| n == &expected_b),
+        "expected {expected_b} in {names:?}"
+    );
+    assert_eq!(names.len(), 2, "merged list must be the union: {names:?}");
+
+    let _ = stop_a.send(());
+    let _ = stop_b.send(());
+}
+
+#[tokio::test]
+async fn route_prompts_get_decodes_prefix_and_routes_to_owning_backend() {
+    let (addr_a, stop_a) = spawn_prompts_backend("bake_animation", "maya-A").await;
+    let (addr_b, stop_b) = spawn_prompts_backend("render_frame", "blender-B").await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let registry = std::sync::Arc::new(tokio::sync::RwLock::new(
+        dcc_mcp_transport::discovery::file_registry::FileRegistry::new(dir.path()).unwrap(),
+    ));
+    let (iid_a, iid_b) = {
+        let r = registry.read().await;
+        let (host_a, port_a) = parse_addr(&addr_a);
+        let (host_b, port_b) = parse_addr(&addr_b);
+        let entry_a =
+            dcc_mcp_transport::discovery::types::ServiceEntry::new("maya", host_a, port_a);
+        let entry_b =
+            dcc_mcp_transport::discovery::types::ServiceEntry::new("blender", host_b, port_b);
+        let ia = entry_a.instance_id;
+        let ib = entry_b.instance_id;
+        r.register(entry_a).unwrap();
+        r.register(entry_b).unwrap();
+        (ia, ib)
+    };
+
+    let gs = make_gateway_state(registry).await;
+    let short_a = &iid_a.to_string().replace('-', "")[..8];
+    let short_b = &iid_b.to_string().replace('-', "")[..8];
+    let wire_a = format!("i_{short_a}__bake_U_animation");
+    let wire_b = format!("i_{short_b}__render_U_frame");
+
+    let res_a = route_prompts_get(&gs, &wire_a, None, Some("rid-a".into()))
+        .await
+        .expect("routing to backend A must succeed");
+    let echo_a = res_a["messages"][0]["content"]["text"].as_str().unwrap();
+    assert_eq!(
+        echo_a, "maya-A:bake_animation",
+        "backend A must have seen the decoded bare name"
+    );
+
+    let res_b = route_prompts_get(&gs, &wire_b, None, Some("rid-b".into()))
+        .await
+        .expect("routing to backend B must succeed");
+    let echo_b = res_b["messages"][0]["content"]["text"].as_str().unwrap();
+    assert_eq!(echo_b, "blender-B:render_frame");
+
+    let _ = stop_a.send(());
+    let _ = stop_b.send(());
+}
+
+#[tokio::test]
+async fn route_prompts_get_with_unknown_prefix_returns_routing_error() {
+    // `decode_tool_name` succeeds (valid 8-hex prefix shape) but no
+    // backend owns that prefix — this path must surface a -32602
+    // without touching any backend.
+    let dir = tempfile::tempdir().unwrap();
+    let registry = std::sync::Arc::new(tokio::sync::RwLock::new(
+        dcc_mcp_transport::discovery::file_registry::FileRegistry::new(dir.path()).unwrap(),
+    ));
+    let gs = make_gateway_state(registry).await;
+
+    let err = route_prompts_get(&gs, "i_deadbeef__whatever", None, None)
+        .await
+        .expect_err("unknown prefix must fail");
+    assert_eq!(err.code(), -32602);
+    assert!(err.message().contains("deadbeef"), "msg: {}", err.message());
+}
+
+/// Parse `127.0.0.1:12345` back into `(host, port)`.
+fn parse_addr(addr: &str) -> (&str, u16) {
+    let (h, p) = addr.rsplit_once(':').unwrap();
+    (h, p.parse().unwrap())
+}
+
+#[tokio::test]
+async fn gateway_mcp_initialize_advertises_prompts_capability() {
+    // End-to-end contract check: POST /mcp initialize must include
+    // `prompts: { listChanged: true }` in its capabilities object —
+    // hard acceptance criterion for issue #731.
+    let dir = tempfile::tempdir().unwrap();
+    let registry = std::sync::Arc::new(tokio::sync::RwLock::new(
+        dcc_mcp_transport::discovery::file_registry::FileRegistry::new(dir.path()).unwrap(),
+    ));
+    let gs = make_gateway_state(registry).await;
+    let router = crate::gateway::build_gateway_router(gs);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, router)
+            .with_graceful_shutdown(async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .unwrap();
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let client = reqwest::Client::new();
+    let resp: Value = client
+        .post(format!("http://127.0.0.1:{port}/mcp"))
+        .json(&json!({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {"protocolVersion": "2025-03-26"}
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    let caps = &resp["result"]["capabilities"];
+    assert_eq!(
+        caps["prompts"]["listChanged"],
+        json!(true),
+        "initialize response must advertise prompts.listChanged=true: {caps}"
+    );
+
+    // Zero-backend prompts/list MUST return `{"prompts": []}`, not a
+    // -32601 Method not found (issue #731 acceptance criterion).
+    let resp: Value = client
+        .post(format!("http://127.0.0.1:{port}/mcp"))
+        .json(&json!({
+            "jsonrpc": "2.0", "id": 2, "method": "prompts/list"
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(resp.get("error").is_none(), "must not be an error: {resp}");
+    assert_eq!(resp["result"]["prompts"], json!([]));
+
+    let _ = shutdown_tx.send(());
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn compute_prompts_fingerprint_changes_when_backend_prompt_set_mutates() {
+    // The prompts watcher task broadcasts
+    // `notifications/prompts/list_changed` iff this fingerprint
+    // differs between polls. Verify that swapping a backend's
+    // published prompt produces a different fingerprint — this is
+    // the hysteresis unit the watcher's broadcast relies on.
+    use std::sync::{Arc, Mutex};
+
+    let state: Arc<Mutex<&'static str>> = Arc::new(Mutex::new("bake_animation"));
+    let state_clone = state.clone();
+
+    let app = axum::Router::new()
+        .route(
+            "/health",
+            axum::routing::get(|| async { axum::Json(json!({"ok": true})) }),
+        )
+        .route(
+            "/mcp",
+            axum::routing::post(move |body: axum::Json<Value>| {
+                let state = state_clone.clone();
+                async move {
+                    let method = body.get("method").and_then(Value::as_str).unwrap_or("");
+                    let id = body.get("id").cloned().unwrap_or(json!("gw-1"));
+                    let result: Value = match method {
+                        "prompts/list" => {
+                            let name = *state.lock().unwrap();
+                            json!({
+                                "prompts": [{
+                                    "name": name,
+                                    "description": "dynamic",
+                                    "arguments": [],
+                                }]
+                            })
+                        }
+                        _ => json!({"tools": []}),
+                    };
+                    axum::Json(json!({"jsonrpc":"2.0","id":id,"result":result}))
+                }
+            }),
+        );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .unwrap();
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let registry = std::sync::Arc::new(tokio::sync::RwLock::new(
+        dcc_mcp_transport::discovery::file_registry::FileRegistry::new(dir.path()).unwrap(),
+    ));
+    {
+        let r = registry.read().await;
+        let entry =
+            dcc_mcp_transport::discovery::types::ServiceEntry::new("maya", "127.0.0.1", port);
+        r.register(entry).unwrap();
+    }
+    let client = reqwest::Client::new();
+
+    let fp_before = compute_prompts_fingerprint(
+        &registry,
+        std::time::Duration::from_secs(30),
+        &client,
+        std::time::Duration::from_secs(2),
+    )
+    .await;
+    assert!(
+        fp_before.contains("bake_animation"),
+        "initial fingerprint should include the first prompt name: {fp_before}"
+    );
+
+    // Swap the prompt set on the backend and re-fingerprint — the
+    // aggregated string must change, which is what drives the
+    // watcher's broadcast decision.
+    *state.lock().unwrap() = "render_frame";
+    let fp_after = compute_prompts_fingerprint(
+        &registry,
+        std::time::Duration::from_secs(30),
+        &client,
+        std::time::Duration::from_secs(2),
+    )
+    .await;
+    assert!(
+        fp_after.contains("render_frame"),
+        "post-swap fingerprint should include new prompt: {fp_after}"
+    );
+    assert_ne!(
+        fp_before, fp_after,
+        "mutation in backend prompt set must produce a different fingerprint"
+    );
+
+    let _ = shutdown_tx.send(());
+    server.await.unwrap();
+}

--- a/crates/dcc-mcp-gateway/src/gateway/backend_client.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/backend_client.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 
 use serde_json::{Value, json};
 
-use dcc_mcp_jsonrpc::{JsonRpcRequestBuilder, JsonRpcResponse, McpTool};
+use dcc_mcp_jsonrpc::{JsonRpcRequestBuilder, JsonRpcResponse, McpPrompt, McpTool};
 use dcc_mcp_skill_rest::ReadinessReport;
 
 /// Build the lightweight HTTP health URL that identifies a real MCP backend.
@@ -304,6 +304,47 @@ pub async fn fetch_tools(
     }
 }
 
+/// Fetch `prompts/list` from a backend and return the deserialised [`McpPrompt`] list.
+///
+/// Unlike [`fetch_prompts`], this reports transport / protocol failures to callers
+/// that need deterministic errors for a specific backend. Mirrors
+/// [`try_fetch_tools`] for the prompts primitive (issue #731).
+pub async fn try_fetch_prompts(
+    client: &reqwest::Client,
+    mcp_url: &str,
+    timeout: Duration,
+) -> Result<Vec<McpPrompt>, String> {
+    let val = call_backend(client, mcp_url, "prompts/list", None, None, timeout).await?;
+    Ok(val
+        .get("prompts")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| serde_json::from_value::<McpPrompt>(v.clone()).ok())
+                .collect()
+        })
+        .unwrap_or_default())
+}
+
+/// Fetch `prompts/list` from a backend and return the deserialised [`McpPrompt`] list.
+///
+/// On any failure returns an empty vector and logs a warning — mirrors
+/// [`fetch_tools`] so the prompts aggregator can fan out fail-soft across
+/// every live backend (issue #731).
+pub async fn fetch_prompts(
+    client: &reqwest::Client,
+    mcp_url: &str,
+    timeout: Duration,
+) -> Vec<McpPrompt> {
+    match try_fetch_prompts(client, mcp_url, timeout).await {
+        Ok(prompts) => prompts,
+        Err(e) => {
+            tracing::warn!(mcp_url = %mcp_url, error = %e, "Backend prompts/list failed");
+            Vec::new()
+        }
+    }
+}
+
 /// Forward a `tools/call` to a backend and return the raw result JSON.
 ///
 /// `request_id` is forwarded as the JSON-RPC `id` so that the gateway can
@@ -328,6 +369,36 @@ pub async fn forward_tools_call(
         client,
         mcp_url,
         "tools/call",
+        Some(params),
+        request_id,
+        timeout,
+    )
+    .await
+}
+
+/// Forward a `prompts/get` to a backend and return the raw result JSON
+/// (issue #731).
+///
+/// `prompt_name` is the **backend-local** prompt name — callers must decode
+/// the gateway-prefixed wire name with [`super::namespace::decode_tool_name`]
+/// before invoking this helper, so the request that reaches the backend
+/// carries the same name the backend published in `prompts/list`.
+pub async fn forward_prompts_get(
+    client: &reqwest::Client,
+    mcp_url: &str,
+    prompt_name: &str,
+    arguments: Option<Value>,
+    request_id: Option<String>,
+    timeout: Duration,
+) -> Result<Value, String> {
+    let mut params = json!({ "name": prompt_name });
+    if let Some(args) = arguments {
+        params["arguments"] = args;
+    }
+    call_backend(
+        client,
+        mcp_url,
+        "prompts/get",
         Some(params),
         request_id,
         timeout,

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
@@ -130,6 +130,8 @@ pub(crate) async fn dispatch_single_request(
         "resources/unsubscribe" => {
             Some(handle_resource_subscription(gs, id, req, session_id, false).await)
         }
+        "prompts/list" => Some(handle_prompts_list(gs, id).await),
+        "prompts/get" => Some(handle_prompts_get(gs, id, &id_str, req).await),
         "tools/call" => Some(handle_tools_call(gs, id, &id_str, req, session_id).await),
         other => Some(json!({
             "jsonrpc": "2.0", "id": id,
@@ -156,7 +158,8 @@ async fn handle_initialize(gs: &GatewayState, id: Value, req: &JsonRpcRequest) -
             "protocolVersion": negotiated,
             "capabilities": {
                 "tools": {"listChanged": true},
-                "resources": {"listChanged": true, "subscribe": true}
+                "resources": {"listChanged": true, "subscribe": true},
+                "prompts": {"listChanged": true}
             },
             "serverInfo": {"name": gs.server_name, "version": gs.server_version},
             "instructions":
@@ -350,4 +353,55 @@ async fn handle_tools_call(
         "jsonrpc": "2.0", "id": id,
         "result": {"content": [{"type": "text", "text": text}], "isError": is_error}
     })
+}
+
+/// `prompts/list` — fan out to every live backend, namespace entries by
+/// instance, and return the merged list (issue #731).
+///
+/// A zero-backend gateway returns `{"prompts": []}` rather than a
+/// `Method not found` so MCP clients can uniformly discover prompts
+/// through the facade.
+async fn handle_prompts_list(gs: &GatewayState, id: Value) -> Value {
+    let result = aggregator::aggregate_prompts_list(gs).await;
+    json!({"jsonrpc": "2.0", "id": id, "result": result})
+}
+
+/// `prompts/get` — decode the namespaced prompt name and forward to the
+/// owning backend (issue #731). Errors are surfaced as JSON-RPC errors
+/// with codes matching the resolution failure (`-32602` for routing,
+/// `-32000` for backend failure).
+async fn handle_prompts_get(
+    gs: &GatewayState,
+    id: Value,
+    id_str: &str,
+    req: &JsonRpcRequest,
+) -> Value {
+    let name = req
+        .params
+        .as_ref()
+        .and_then(|p| p.get("name"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    if name.is_empty() {
+        return json!({
+            "jsonrpc": "2.0", "id": id,
+            "error": {
+                "code": -32602,
+                "message": "prompts/get requires a non-empty 'name' parameter"
+            }
+        });
+    }
+    let arguments = req
+        .params
+        .as_ref()
+        .and_then(|p| p.get("arguments"))
+        .cloned();
+
+    match aggregator::route_prompts_get(gs, name, arguments, Some(id_str.to_string())).await {
+        Ok(result) => json!({"jsonrpc": "2.0", "id": id, "result": result}),
+        Err(e) => json!({
+            "jsonrpc": "2.0", "id": id,
+            "error": {"code": e.code(), "message": e.message()}
+        }),
+    }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/tasks.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tasks.rs
@@ -241,6 +241,57 @@ pub(crate) async fn start_gateway_tasks(
         }
     });
 
+    // ── Aggregated prompts/list_changed watcher (every 3 s) ────────────
+    // Mirror of the tools watcher — polls every live backend's
+    // `prompts/list`, fingerprints the `{instance_id}:{prompt_name}` set,
+    // and broadcasts one `notifications/prompts/list_changed` to gateway
+    // SSE subscribers when the aggregated set changes.
+    //
+    // Skills opt into prompts by dropping a sibling `prompts.yaml`
+    // (issues #351 / #355), so the cadence here matches the tools
+    // watcher: skill load/unload is the same workflow trigger.
+    let reg_prompts = registry.clone();
+    let events_tx_prompts = events_tx.clone();
+    let http_client_prompts = http_client.clone();
+    let prompts_own_host = own_host.clone();
+    let prompts_own_port = own_port;
+    let prompts_watcher_handle = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(3));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let mut last_fingerprint = String::new();
+
+        loop {
+            interval.tick().await;
+            let fingerprint = aggregator::compute_prompts_fingerprint_with_own(
+                &reg_prompts,
+                stale_timeout,
+                &http_client_prompts,
+                backend_timeout,
+                Some(prompts_own_host.as_str()),
+                prompts_own_port,
+            )
+            .await;
+
+            if fingerprint != last_fingerprint {
+                if (!last_fingerprint.is_empty() || !fingerprint.is_empty())
+                    && events_tx_prompts.receiver_count() > 0
+                {
+                    tracing::debug!(
+                        "Gateway: aggregated prompt set changed — broadcasting prompts/list_changed"
+                    );
+                    let notif = serde_json::to_string(&serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "method": "notifications/prompts/list_changed",
+                        "params": {}
+                    }))
+                    .unwrap_or_default();
+                    let _ = events_tx_prompts.send(notif);
+                }
+                last_fingerprint = fingerprint;
+            }
+        }
+    });
+
     // ── Backend SSE subscriber manager (#320) ─────────────────────────────
     // Multiplexes per-backend SSE notifications back to originating client
     // sessions. Each `ensure_subscribed` spawns a reconnecting task.
@@ -563,6 +614,7 @@ pub(crate) async fn start_gateway_tasks(
             cleanup_handle,
             watcher_handle,
             tools_watcher_handle,
+            prompts_watcher_handle,
             backend_sub_handle,
             route_gc_handle,
             health_check_handle,
@@ -576,6 +628,7 @@ pub(crate) async fn start_gateway_tasks(
             cleanup_handle,
             watcher_handle,
             tools_watcher_handle,
+            prompts_watcher_handle,
             backend_sub_handle,
             route_gc_handle,
             health_check_handle,


### PR DESCRIPTION
Closes #731.

The gateway (`dcc-mcp-gateway`) previously answered `Method not found` for `prompts/list` and `prompts/get` because the MCP Prompts primitive was only implemented on per-DCC backends. This PR wires prompts through the same fan-out machinery already in place for tools.

## Changes

- `handle_initialize` now advertises `prompts: { listChanged: true }`.
- `dispatch_single_request` routes `prompts/list` and `prompts/get`.
- New `aggregator/prompts.rs`: `aggregate_prompts_list` fans out and namespaces each entry using the cursor-safe `i_<id8>__<escaped>` (or legacy `<id8>.<name>`) prefix; `route_prompts_get` decodes the prefix and forwards to the owning backend. Bare names are accepted when exactly one backend is live.
- `backend_client` gains `fetch_prompts` / `try_fetch_prompts` / `forward_prompts_get`, mirroring the fail-soft tools helpers — one unreachable DCC never 500s the whole call.
- `tasks.rs` spawns a 3 s prompts watcher that broadcasts `notifications/prompts/list_changed` on aggregated-set change, matching the tools watcher hysteresis.

## Acceptance criteria

- [x] Gateway `initialize` response includes `"prompts": {"listChanged": true}`.
- [x] `prompts/list` on a zero-backend gateway returns `{"prompts": []}` (not method-not-found).
- [x] With N backends: merged list with correct prefixes; `prompts/get` routes to the owning backend.
- [x] SSE `notifications/prompts/list_changed` fires on backend prompt-set change (fingerprint-change unit covered).

## Tests

Six new integration tests in `aggregator/tests.rs`, including a full end-to-end `POST /mcp` against the live axum router for the `initialize` capability + zero-backend contract.

All 208 gateway unit tests pass; workspace `cargo check`, `cargo clippy --workspace -- -D warnings`, and `cargo fmt --all -- --check` are clean.