### PR TITLE
feat(gateway): forward backend resources with namespaced URIs (#732)

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/aggregator.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator.rs
@@ -18,6 +18,7 @@ mod fingerprint;
 mod helpers;
 mod list;
 mod prompts;
+mod resources;
 mod skill_mgmt;
 #[cfg(test)]
 mod tests;
@@ -37,6 +38,8 @@ pub(crate) use prompts::compute_prompts_fingerprint_with_own;
 pub use prompts::{
     PromptsGetError, aggregate_prompts_list, compute_prompts_fingerprint, route_prompts_get,
 };
+pub use resources::aggregate_resources_list;
+pub(crate) use resources::compute_resources_fingerprint_with_own;
 pub(crate) use skill_mgmt::{skill_management_tool_defs, skill_mgmt_dispatch};
 #[cfg(test)]
 pub(crate) use wait_terminal::merge_job_update_into_envelope;

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/resources.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/resources.rs
@@ -1,0 +1,199 @@
+//! Resources-list aggregation + fingerprint for the facade gateway (#732).
+//!
+//! Mirrors the shape of [`super::list`] / [`super::fingerprint`] for tools, so
+//! the gateway fan-outs `resources/list` to every live backend, prefixes each
+//! backend URI with the 8-char instance id, and merges the result with the
+//! existing `dcc://<type>/<id>` admin pointers.
+//!
+//! Fail-soft: a backend that is unreachable on `resources/list` contributes
+//! zero entries and emits a `warn!`; the fan-out does not surface an error
+//! to the caller. Mirrors the [`fetch_tools`] / [`super::list`] behaviour.
+
+use std::time::Duration;
+
+use futures::future::join_all;
+use serde_json::{Value, json};
+
+use super::super::backend_client::fetch_resources;
+use super::super::namespace::encode_resource_uri;
+use super::super::state::GatewayState;
+use super::helpers::live_backends;
+use dcc_mcp_transport::discovery::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry, ServiceStatus};
+
+/// Fetch every live backend's `resources/list` and return `(instance_id, dcc_type, resources)`
+/// triples. Backends that fail the fetch contribute an empty vector (see
+/// [`fetch_resources`] — fail-soft by design).
+pub(crate) async fn fetch_backend_resources(
+    gs: &GatewayState,
+) -> Vec<(uuid::Uuid, String, Vec<Value>)> {
+    let instances: Vec<ServiceEntry> = live_backends(gs)
+        .await
+        .into_iter()
+        .filter(|e| {
+            !matches!(
+                e.status,
+                ServiceStatus::Unreachable | ServiceStatus::Booting
+            )
+        })
+        .collect();
+    let client = &gs.http_client;
+    let backend_timeout = gs.backend_timeout;
+    let futs = instances.iter().map(|entry| async move {
+        let url = format!("http://{}:{}/mcp", entry.host, entry.port);
+        let resources = fetch_resources(client, &url, backend_timeout).await;
+        (entry.instance_id, entry.dcc_type.clone(), resources)
+    });
+    join_all(futs).await
+}
+
+/// Build the unified `resources/list` result.
+///
+/// Layout:
+/// 1. Admin `dcc://<type>/<id>` pointers for every live DCC instance — the
+///    existing administrative affordance. These are retained so operators
+///    can still read per-instance metadata.
+/// 2. Backend-contributed resources from every live instance, each URI
+///    rewritten to `<scheme>://<id8>/<rest>` so multiple backends can
+///    expose the same scheme without collision.
+///
+/// Fail-soft: one unreachable backend contributes zero resources; the
+/// healthy backends' resources are still returned, and `tools/list`-style
+/// partial aggregation semantics hold.
+pub async fn aggregate_resources_list(gs: &GatewayState) -> Value {
+    // Tier 1: admin instance pointers — same payload the handler used
+    // before #732, kept as an operator affordance.
+    let admin_pointers: Vec<Value> = {
+        let registry = gs.registry.read().await;
+        gs.live_instances(&registry)
+            .into_iter()
+            .filter(|entry| entry.dcc_type != GATEWAY_SENTINEL_DCC_TYPE)
+            .map(|entry| {
+                let name = match entry.scene.as_deref() {
+                    Some(scene) if !scene.is_empty() => {
+                        format!(
+                            "{} — {} ({}:{})",
+                            entry.dcc_type, scene, entry.host, entry.port
+                        )
+                    }
+                    _ => format!("{} @ {}:{}", entry.dcc_type, entry.host, entry.port),
+                };
+                json!({
+                    "uri": format!("dcc://{}/{}", entry.dcc_type, entry.instance_id),
+                    "name": name,
+                    "description": format!(
+                        "Live {} DCC instance. Version: {}.",
+                        entry.dcc_type,
+                        entry.version.as_deref().unwrap_or("unknown")
+                    ),
+                    "mimeType": "application/json"
+                })
+            })
+            .collect()
+    };
+
+    // Tier 2: every backend's resources, with URIs rewritten to the
+    // gateway-prefixed form so clients can disambiguate.
+    let mut merged: Vec<Value> = admin_pointers;
+    for (iid, dcc_type, backend_resources) in fetch_backend_resources(gs).await {
+        for mut resource in backend_resources {
+            let backend_uri = resource
+                .get("uri")
+                .and_then(Value::as_str)
+                .map(str::to_owned);
+            let Some(backend_uri) = backend_uri else {
+                // Backend emitted a resource without a URI — skip rather than
+                // surface a malformed entry upstream.
+                continue;
+            };
+            let Some(prefixed) = encode_resource_uri(&iid, &backend_uri) else {
+                // URI had no `://`; cannot safely prefix. Drop it.
+                tracing::warn!(
+                    instance_id = %iid,
+                    dcc_type = %dcc_type,
+                    uri = %backend_uri,
+                    "Gateway: backend resource URI has no scheme — skipping",
+                );
+                continue;
+            };
+            if let Some(obj) = resource.as_object_mut() {
+                obj.insert("uri".to_string(), Value::String(prefixed));
+                // Annotate with origin so agents can display context — same
+                // idea as tools' `_instance_id` / `_dcc_type` injection.
+                obj.insert("_instance_id".to_string(), Value::String(iid.to_string()));
+                obj.insert("_dcc_type".to_string(), Value::String(dcc_type.clone()));
+            }
+            merged.push(resource);
+        }
+    }
+
+    json!({"resources": merged})
+}
+
+/// Compute a fingerprint of the aggregated resource set across every live
+/// backend.
+///
+/// Mirrors [`super::compute_tools_fingerprint_with_own`]: a stable, sorted
+/// concatenation of `{instance_id}:{backend_uri}` tuples. The watcher in
+/// [`super::super::tasks`] polls this value on a fixed cadence and emits a
+/// single `notifications/resources/list_changed` whenever it changes.
+///
+/// Deliberately excludes resource `name` / `description` / `mimeType` — we
+/// only want set-level add/remove detection, not metadata edits (the spec
+/// does not give clients a way to re-fetch individual resources on mutation
+/// so emitting a list_changed for a pure description edit would be
+/// wasteful churn).
+pub(crate) async fn compute_resources_fingerprint_with_own(
+    registry: &std::sync::Arc<
+        tokio::sync::RwLock<dcc_mcp_transport::discovery::file_registry::FileRegistry>,
+    >,
+    stale_timeout: Duration,
+    http_client: &reqwest::Client,
+    backend_timeout: Duration,
+    own_host: Option<&str>,
+    own_port: u16,
+) -> String {
+    let instances: Vec<ServiceEntry> = {
+        let reg = registry.read().await;
+        reg.list_all()
+            .into_iter()
+            .filter(|e| {
+                !e.is_stale(stale_timeout)
+                    && e.dcc_type != GATEWAY_SENTINEL_DCC_TYPE
+                    && !matches!(
+                        e.status,
+                        ServiceStatus::ShuttingDown
+                            | ServiceStatus::Unreachable
+                            | ServiceStatus::Booting
+                    )
+                    && match own_host {
+                        Some(h) => !super::super::is_own_instance(e, h, own_port),
+                        None => true,
+                    }
+                    && !e.dcc_type.eq_ignore_ascii_case("unknown")
+            })
+            .collect()
+    };
+
+    let futs = instances.iter().map(|entry| async move {
+        let url = format!("http://{}:{}/mcp", entry.host, entry.port);
+        let resources = fetch_resources(http_client, &url, backend_timeout).await;
+        (entry.instance_id, resources)
+    });
+    let results = join_all(futs).await;
+
+    let mut parts: Vec<String> = results
+        .into_iter()
+        .flat_map(|(iid, resources)| {
+            resources
+                .into_iter()
+                .filter_map(|r| {
+                    r.get("uri")
+                        .and_then(Value::as_str)
+                        .map(|u| format!("{iid}:{u}"))
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    parts.sort_unstable();
+    parts.join("|")
+}

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
@@ -723,3 +723,218 @@ async fn compute_prompts_fingerprint_changes_when_backend_prompt_set_mutates() {
     let _ = shutdown_tx.send(());
     server.await.unwrap();
 }
+
+// ── #732: resources/list aggregation ──────────────────────────────────
+
+/// Spawn a fake backend that answers `/health` green and serves a canned
+/// `resources/list` payload. Returns `(port, shutdown_tx)`.
+async fn spawn_resources_backend(resources: Vec<Value>) -> (u16, tokio::sync::oneshot::Sender<()>) {
+    let app = axum::Router::new()
+        .route(
+            "/health",
+            axum::routing::get(|| async { axum::Json(json!({"ok": true})) }),
+        )
+        .route(
+            "/mcp",
+            axum::routing::post({
+                let resources = resources.clone();
+                move |body: axum::Json<Value>| {
+                    let resources = resources.clone();
+                    async move {
+                        let method = body.get("method").and_then(|m| m.as_str()).unwrap_or("");
+                        let id = body.get("id").cloned().unwrap_or(json!("gw-test"));
+                        let result = match method {
+                            "resources/list" => json!({"resources": resources}),
+                            _ => json!({}),
+                        };
+                        axum::Json(json!({"jsonrpc": "2.0", "id": id, "result": result}))
+                    }
+                }
+            }),
+        );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                let _ = rx.await;
+            })
+            .await
+            .unwrap();
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    (port, tx)
+}
+
+/// Build a GatewayState around a shared registry, pre-filled with the
+/// given `(dcc_type, port)` rows. Returns `(state, instance_ids)`.
+async fn gateway_state_with_instances(
+    instances: &[(&str, u16)],
+) -> (
+    crate::gateway::GatewayState,
+    tempfile::TempDir,
+    Vec<uuid::Uuid>,
+) {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = std::sync::Arc::new(tokio::sync::RwLock::new(
+        dcc_mcp_transport::discovery::file_registry::FileRegistry::new(dir.path()).unwrap(),
+    ));
+    let mut ids = Vec::new();
+    {
+        let r = registry.read().await;
+        for (dcc_type, port) in instances {
+            let entry = dcc_mcp_transport::discovery::types::ServiceEntry::new(
+                *dcc_type,
+                "127.0.0.1",
+                *port,
+            );
+            ids.push(entry.instance_id);
+            r.register(entry).unwrap();
+        }
+    }
+    let (yield_tx, _) = tokio::sync::watch::channel(false);
+    let (events_tx, _) = tokio::sync::broadcast::channel::<String>(8);
+    let state = crate::gateway::GatewayState {
+        registry,
+        stale_timeout: std::time::Duration::from_secs(30),
+        backend_timeout: std::time::Duration::from_secs(10),
+        async_dispatch_timeout: std::time::Duration::from_secs(60),
+        wait_terminal_timeout: std::time::Duration::from_secs(600),
+        server_name: "test".into(),
+        server_version: env!("CARGO_PKG_VERSION").into(),
+        own_host: "127.0.0.1".into(),
+        own_port: 0,
+        http_client: reqwest::Client::new(),
+        yield_tx: std::sync::Arc::new(yield_tx),
+        events_tx: std::sync::Arc::new(events_tx),
+        protocol_version: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
+        resource_subscriptions: std::sync::Arc::new(tokio::sync::RwLock::new(
+            std::collections::HashMap::new(),
+        )),
+        pending_calls: std::sync::Arc::new(tokio::sync::RwLock::new(
+            std::collections::HashMap::new(),
+        )),
+        subscriber: crate::gateway::sse_subscriber::SubscriberManager::default(),
+        allow_unknown_tools: false,
+        adapter_version: None,
+        adapter_dcc: None,
+        tool_exposure: crate::gateway::GatewayToolExposure::Rest,
+        cursor_safe_tool_names: true,
+        capability_index: std::sync::Arc::new(crate::gateway::capability::CapabilityIndex::new()),
+    };
+    (state, dir, ids)
+}
+
+fn id8(id: &uuid::Uuid) -> String {
+    let mut s = id.simple().to_string();
+    s.truncate(8);
+    s
+}
+
+#[tokio::test]
+async fn aggregate_resources_list_merges_admin_pointers_and_backend_resources() {
+    // Two backends, disjoint resource sets. The gateway's
+    // resources/list must return admin pointers ∪ each backend's
+    // resources with the per-instance prefix.
+    let (port_a, stop_a) = spawn_resources_backend(vec![
+        json!({"uri": "scene://current", "name": "A scene", "mimeType": "application/json"}),
+    ])
+    .await;
+    let (port_b, stop_b) = spawn_resources_backend(vec![
+        json!({"uri": "capture://current_window", "name": "B capture", "mimeType": "image/png"}),
+        json!({"uri": "audit://recent", "name": "B audit", "mimeType": "application/json"}),
+    ])
+    .await;
+
+    let (gs, _dir, ids) =
+        gateway_state_with_instances(&[("maya", port_a), ("blender", port_b)]).await;
+    let id_a = ids[0];
+    let id_b = ids[1];
+
+    let result = aggregate_resources_list(&gs).await;
+    let resources = result["resources"]
+        .as_array()
+        .expect("resources must be an array");
+    let uris: Vec<&str> = resources.iter().filter_map(|r| r["uri"].as_str()).collect();
+
+    // Admin pointers: one per instance.
+    assert!(
+        uris.iter().any(|u| u.starts_with("dcc://maya/")),
+        "admin pointer for maya instance missing: {uris:?}",
+    );
+    assert!(
+        uris.iter().any(|u| u.starts_with("dcc://blender/")),
+        "admin pointer for blender instance missing: {uris:?}",
+    );
+
+    // Backend resources with prefix.
+    let prefix_a = id8(&id_a);
+    let prefix_b = id8(&id_b);
+    assert!(
+        uris.contains(&&*format!("scene://{prefix_a}/current")),
+        "prefixed scene URI missing: {uris:?}",
+    );
+    assert!(
+        uris.contains(&&*format!("capture://{prefix_b}/current_window")),
+        "prefixed capture URI missing: {uris:?}",
+    );
+    assert!(
+        uris.contains(&&*format!("audit://{prefix_b}/recent")),
+        "prefixed audit URI missing: {uris:?}",
+    );
+
+    // No unprefixed backend URIs — the gateway must not leak raw
+    // backend URIs that would collide across instances.
+    assert!(
+        !uris.contains(&"scene://current"),
+        "unprefixed backend URI leaked: {uris:?}",
+    );
+
+    let _ = stop_a.send(());
+    let _ = stop_b.send(());
+}
+
+#[tokio::test]
+async fn aggregate_resources_list_fail_soft_when_one_backend_is_dead() {
+    // One backend answers normally; the other's port is closed. The
+    // gateway must still return the healthy backend's resources plus
+    // the admin pointer for the dead backend — a dead backend does
+    // not take down the whole list.
+    let (port_live, stop_live) = spawn_resources_backend(vec![
+        json!({"uri": "scene://current", "name": "live scene", "mimeType": "application/json"}),
+    ])
+    .await;
+    // Pick a port that almost certainly has nothing listening.
+    let dead_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let dead_port = dead_listener.local_addr().unwrap().port();
+    drop(dead_listener); // close it — now no one's home.
+
+    let (gs, _dir, ids) =
+        gateway_state_with_instances(&[("maya", port_live), ("blender", dead_port)]).await;
+    let id_live = ids[0];
+
+    let result = aggregate_resources_list(&gs).await;
+    let resources = result["resources"]
+        .as_array()
+        .expect("resources must be an array");
+    let uris: Vec<&str> = resources.iter().filter_map(|r| r["uri"].as_str()).collect();
+
+    // Live backend's resource is present.
+    assert!(
+        uris.contains(&&*format!("scene://{}/current", id8(&id_live))),
+        "live backend's prefixed URI missing: {uris:?}",
+    );
+    // Admin pointers for both instances are still present (fail-soft:
+    // the registry row survives).
+    assert!(
+        uris.iter().any(|u| u.starts_with("dcc://maya/")),
+        "live maya admin pointer missing: {uris:?}",
+    );
+    assert!(
+        uris.iter().any(|u| u.starts_with("dcc://blender/")),
+        "dead blender admin pointer missing: {uris:?}",
+    );
+
+    let _ = stop_live.send(());
+}

--- a/crates/dcc-mcp-gateway/src/gateway/backend_client.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/backend_client.rs
@@ -406,12 +406,18 @@ pub async fn read_resource(
 /// Forward a `resources/subscribe` (or `resources/unsubscribe` when `subscribe`
 /// is `false`) to a backend.
 ///
+/// `session_id` is sent as `Mcp-Session-Id` so the backend binds the
+/// subscription to the gateway's long-lived SSE session — that is the
+/// only stream onto which the backend will push
+/// `notifications/resources/updated` for this URI (#732).
+///
 /// Returns the raw `result` JSON — typically `{}`.
 pub async fn subscribe_resource(
     client: &reqwest::Client,
     mcp_url: &str,
     uri: &str,
     subscribe: bool,
+    session_id: &str,
     timeout: Duration,
 ) -> Result<Value, String> {
     let method = if subscribe {
@@ -419,15 +425,47 @@ pub async fn subscribe_resource(
     } else {
         "resources/unsubscribe"
     };
-    call_backend(
-        client,
-        mcp_url,
-        method,
-        Some(json!({"uri": uri})),
-        None,
-        timeout,
-    )
-    .await
+    let req_body = JsonRpcRequestBuilder::new(uuid_like_id(), method)
+        .with_optional_params(Some(json!({"uri": uri})))
+        .to_value();
+
+    let resp = client
+        .post(mcp_url)
+        .timeout(timeout)
+        .header("content-type", "application/json")
+        .header("accept", "application/json")
+        .header("Mcp-Session-Id", session_id)
+        .body(req_body.to_string())
+        .send()
+        .await
+        .map_err(|e| format!("{mcp_url}: transport error: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(format!(
+            "{mcp_url}: HTTP {}: {}",
+            resp.status(),
+            resp.text().await.unwrap_or_default()
+        ));
+    }
+
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| format!("{mcp_url}: read body: {e}"))?;
+
+    let parsed: JsonRpcResponse = serde_json::from_str(&text)
+        .map_err(|e| format!("{mcp_url}: invalid JSON-RPC response: {e}"))?;
+
+    if let Some(err) = parsed.error {
+        return Err(format!(
+            "{mcp_url}: backend error {}: {}",
+            err.code, err.message
+        ));
+    }
+
+    parsed
+        .result
+        .ok_or_else(|| format!("{mcp_url}: empty JSON-RPC result"))
 }
 
 /// Forward a `tools/call` to a backend and return the raw result JSON.
@@ -970,26 +1008,42 @@ mod tests {
 
     #[tokio::test]
     async fn subscribe_resource_forwards_subscribe_and_unsubscribe_methods() {
-        // Verify the helper uses the correct method name and payload
-        // for both subscribe and unsubscribe.
-        let hits = Arc::new(parking_lot::Mutex::new(Vec::<String>::new()));
+        // Verify the helper uses the correct method name, payload, and
+        // Mcp-Session-Id header for both subscribe and unsubscribe.
+        let hits = Arc::new(parking_lot::Mutex::new(
+            Vec::<(String, Option<String>)>::new(),
+        ));
         let hits_clone = hits.clone();
-        let app = healthy_mcp_router(move |body: axum::Json<Value>| {
-            let hits = hits_clone.clone();
-            async move {
-                let method = body
-                    .get("method")
-                    .and_then(|m| m.as_str())
-                    .unwrap_or("")
-                    .to_owned();
-                hits.lock().push(method);
-                axum::Json(json!({
-                    "jsonrpc": "2.0",
-                    "id": body.get("id").cloned().unwrap_or(json!("gw-test")),
-                    "result": {}
-                }))
-            }
-        });
+        let app = axum::Router::new()
+            .route(
+                "/health",
+                axum::routing::get(|| async { axum::Json(json!({"ok": true})) }),
+            )
+            .route(
+                "/mcp",
+                axum::routing::post(
+                    move |headers: axum::http::HeaderMap, body: axum::Json<Value>| {
+                        let hits = hits_clone.clone();
+                        async move {
+                            let method = body
+                                .get("method")
+                                .and_then(|m| m.as_str())
+                                .unwrap_or("")
+                                .to_owned();
+                            let session = headers
+                                .get("mcp-session-id")
+                                .and_then(|v| v.to_str().ok())
+                                .map(str::to_owned);
+                            hits.lock().push((method, session));
+                            axum::Json(json!({
+                                "jsonrpc": "2.0",
+                                "id": body.get("id").cloned().unwrap_or(json!("gw-test")),
+                                "result": {}
+                            }))
+                        }
+                    },
+                ),
+            );
         let (mcp_url, stop) = spawn_fake_backend(app).await;
 
         let client = reqwest::Client::new();
@@ -998,6 +1052,7 @@ mod tests {
             &mcp_url,
             "scene://current",
             true,
+            "gw-sub-abc123",
             Duration::from_secs(2),
         )
         .await
@@ -1007,15 +1062,25 @@ mod tests {
             &mcp_url,
             "scene://current",
             false,
+            "gw-sub-abc123",
             Duration::from_secs(2),
         )
         .await
         .expect("unsubscribe must succeed");
 
         let recorded = hits.lock().clone();
+        assert_eq!(recorded.len(), 2);
+        assert_eq!(recorded[0].0, "resources/subscribe");
+        assert_eq!(recorded[1].0, "resources/unsubscribe");
         assert_eq!(
-            recorded,
-            vec!["resources/subscribe", "resources/unsubscribe"]
+            recorded[0].1.as_deref(),
+            Some("gw-sub-abc123"),
+            "Mcp-Session-Id must be forwarded on subscribe",
+        );
+        assert_eq!(
+            recorded[1].1.as_deref(),
+            Some("gw-sub-abc123"),
+            "Mcp-Session-Id must be forwarded on unsubscribe",
         );
         let _ = stop.send(());
     }

--- a/crates/dcc-mcp-gateway/src/gateway/backend_client.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/backend_client.rs
@@ -345,6 +345,91 @@ pub async fn fetch_prompts(
     }
 }
 
+/// Fetch `resources/list` from a backend and return the raw `resources` array.
+///
+/// Unlike [`fetch_resources`], this reports transport / protocol failures to callers
+/// that need deterministic errors for a specific backend.
+pub async fn try_fetch_resources(
+    client: &reqwest::Client,
+    mcp_url: &str,
+    timeout: Duration,
+) -> Result<Vec<Value>, String> {
+    let val = call_backend(client, mcp_url, "resources/list", None, None, timeout).await?;
+    Ok(val
+        .get("resources")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default())
+}
+
+/// Fetch `resources/list` from a backend and return the raw `resources` array.
+///
+/// On any failure returns an empty vector and logs a warning — callers aggregate
+/// resources across many backends and should not fail the whole fan-out because
+/// one instance is unreachable. Mirrors [`fetch_tools`] for resources.
+pub async fn fetch_resources(
+    client: &reqwest::Client,
+    mcp_url: &str,
+    timeout: Duration,
+) -> Vec<Value> {
+    match try_fetch_resources(client, mcp_url, timeout).await {
+        Ok(resources) => resources,
+        Err(e) => {
+            tracing::warn!(mcp_url = %mcp_url, error = %e, "Backend resources/list failed");
+            Vec::new()
+        }
+    }
+}
+
+/// Forward a `resources/read` to a backend and return the raw `result` JSON.
+///
+/// The result is returned unchanged (including `contents[].blob` entries for
+/// binary mime-types), so byte-for-byte round-trip through the gateway is
+/// preserved.
+pub async fn read_resource(
+    client: &reqwest::Client,
+    mcp_url: &str,
+    uri: &str,
+    timeout: Duration,
+) -> Result<Value, String> {
+    call_backend(
+        client,
+        mcp_url,
+        "resources/read",
+        Some(json!({"uri": uri})),
+        None,
+        timeout,
+    )
+    .await
+}
+
+/// Forward a `resources/subscribe` (or `resources/unsubscribe` when `subscribe`
+/// is `false`) to a backend.
+///
+/// Returns the raw `result` JSON — typically `{}`.
+pub async fn subscribe_resource(
+    client: &reqwest::Client,
+    mcp_url: &str,
+    uri: &str,
+    subscribe: bool,
+    timeout: Duration,
+) -> Result<Value, String> {
+    let method = if subscribe {
+        "resources/subscribe"
+    } else {
+        "resources/unsubscribe"
+    };
+    call_backend(
+        client,
+        mcp_url,
+        method,
+        Some(json!({"uri": uri})),
+        None,
+        timeout,
+    )
+    .await
+}
+
 /// Forward a `tools/call` to a backend and return the raw result JSON.
 ///
 /// `request_id` is forwarded as the JSON-RPC `id` so that the gateway can
@@ -759,6 +844,178 @@ mod tests {
         assert!(
             !hit.load(Ordering::SeqCst),
             "call_backend must not post to /mcp while backend is red"
+        );
+        let _ = stop.send(());
+    }
+
+    // ── #732 integration tests: resources forwarding helpers ─────────────
+
+    /// Router that answers `/health` green plus a single JSON-RPC method
+    /// handler at `/mcp`. Keeps test routers compact.
+    fn healthy_mcp_router<H, Fut>(handler: H) -> axum::Router
+    where
+        H: Fn(axum::Json<Value>) -> Fut + Clone + Send + Sync + 'static,
+        Fut: std::future::Future<Output = axum::Json<Value>> + Send,
+    {
+        axum::Router::new()
+            .route(
+                "/health",
+                axum::routing::get(|| async { axum::Json(json!({"ok": true})) }),
+            )
+            .route(
+                "/mcp",
+                axum::routing::post(move |body: axum::Json<Value>| {
+                    let handler = handler.clone();
+                    async move { handler(body).await }
+                }),
+            )
+    }
+
+    #[tokio::test]
+    async fn try_fetch_resources_returns_backend_resources() {
+        let app = healthy_mcp_router(|body: axum::Json<Value>| async move {
+            assert_eq!(
+                body.get("method").and_then(|m| m.as_str()),
+                Some("resources/list")
+            );
+            axum::Json(json!({
+                "jsonrpc": "2.0",
+                "id": body.get("id").cloned().unwrap_or(json!("gw-test")),
+                "result": {
+                    "resources": [
+                        {"uri": "scene://current", "name": "Current scene", "mimeType": "application/json"},
+                        {"uri": "capture://current_window", "name": "Window capture", "mimeType": "image/png"}
+                    ]
+                }
+            }))
+        });
+        let (mcp_url, stop) = spawn_fake_backend(app).await;
+
+        let client = reqwest::Client::new();
+        let resources = try_fetch_resources(&client, &mcp_url, Duration::from_secs(2))
+            .await
+            .expect("resources/list must succeed");
+        assert_eq!(resources.len(), 2);
+        assert_eq!(resources[0]["uri"], json!("scene://current"));
+        assert_eq!(resources[1]["mimeType"], json!("image/png"));
+        let _ = stop.send(());
+    }
+
+    #[tokio::test]
+    async fn fetch_resources_returns_empty_on_error() {
+        // Backend responds with an error envelope — fail-soft contract
+        // says: swallow the error, log a warn, return empty vector.
+        let app = healthy_mcp_router(|body: axum::Json<Value>| async move {
+            axum::Json(json!({
+                "jsonrpc": "2.0",
+                "id": body.get("id").cloned().unwrap_or(json!("gw-test")),
+                "error": {"code": -32601, "message": "Method not found"}
+            }))
+        });
+        let (mcp_url, stop) = spawn_fake_backend(app).await;
+
+        let client = reqwest::Client::new();
+        let resources = fetch_resources(&client, &mcp_url, Duration::from_secs(2)).await;
+        assert!(
+            resources.is_empty(),
+            "fetch_resources must fail-soft to an empty vector"
+        );
+        let _ = stop.send(());
+    }
+
+    #[tokio::test]
+    async fn read_resource_preserves_blob_bytes() {
+        // A capture://current_window response carries a base64 `blob` —
+        // the gateway must not corrupt it on the way through.
+        const BLOB_B64: &str = "aGVsbG8sIHdvcmxkIQ=="; // "hello, world!"
+        let app = healthy_mcp_router(move |body: axum::Json<Value>| async move {
+            assert_eq!(
+                body.get("method").and_then(|m| m.as_str()),
+                Some("resources/read")
+            );
+            assert_eq!(
+                body.get("params")
+                    .and_then(|p| p.get("uri"))
+                    .and_then(|u| u.as_str()),
+                Some("capture://current_window")
+            );
+            axum::Json(json!({
+                "jsonrpc": "2.0",
+                "id": body.get("id").cloned().unwrap_or(json!("gw-test")),
+                "result": {
+                    "contents": [{
+                        "uri": "capture://current_window",
+                        "mimeType": "image/png",
+                        "blob": BLOB_B64,
+                    }]
+                }
+            }))
+        });
+        let (mcp_url, stop) = spawn_fake_backend(app).await;
+
+        let client = reqwest::Client::new();
+        let result = read_resource(
+            &client,
+            &mcp_url,
+            "capture://current_window",
+            Duration::from_secs(2),
+        )
+        .await
+        .expect("resources/read must succeed");
+        let content = &result["contents"][0];
+        assert_eq!(content["mimeType"], json!("image/png"));
+        assert_eq!(content["blob"], json!(BLOB_B64));
+        let _ = stop.send(());
+    }
+
+    #[tokio::test]
+    async fn subscribe_resource_forwards_subscribe_and_unsubscribe_methods() {
+        // Verify the helper uses the correct method name and payload
+        // for both subscribe and unsubscribe.
+        let hits = Arc::new(parking_lot::Mutex::new(Vec::<String>::new()));
+        let hits_clone = hits.clone();
+        let app = healthy_mcp_router(move |body: axum::Json<Value>| {
+            let hits = hits_clone.clone();
+            async move {
+                let method = body
+                    .get("method")
+                    .and_then(|m| m.as_str())
+                    .unwrap_or("")
+                    .to_owned();
+                hits.lock().push(method);
+                axum::Json(json!({
+                    "jsonrpc": "2.0",
+                    "id": body.get("id").cloned().unwrap_or(json!("gw-test")),
+                    "result": {}
+                }))
+            }
+        });
+        let (mcp_url, stop) = spawn_fake_backend(app).await;
+
+        let client = reqwest::Client::new();
+        subscribe_resource(
+            &client,
+            &mcp_url,
+            "scene://current",
+            true,
+            Duration::from_secs(2),
+        )
+        .await
+        .expect("subscribe must succeed");
+        subscribe_resource(
+            &client,
+            &mcp_url,
+            "scene://current",
+            false,
+            Duration::from_secs(2),
+        )
+        .await
+        .expect("unsubscribe must succeed");
+
+        let recorded = hits.lock().clone();
+        assert_eq!(
+            recorded,
+            vec!["resources/subscribe", "resources/unsubscribe"]
         );
         let _ = stop.send(());
     }

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
@@ -207,32 +207,12 @@ async fn handle_tools_list(gs: &GatewayState, id: Value, req: &JsonRpcRequest) -
 }
 
 async fn handle_resources_list(gs: &GatewayState, id: Value) -> Value {
-    let registry = gs.registry.read().await;
-    let resources: Vec<Value> = gs
-        .live_instances(&registry)
-        .into_iter()
-        .filter(|entry| entry.dcc_type != "__gateway__")
-        .map(|entry| {
-            let name = match entry.scene.as_deref() {
-                Some(scene) if !scene.is_empty() => {
-                    format!(
-                        "{} — {} ({}:{})",
-                        entry.dcc_type, scene, entry.host, entry.port
-                    )
-                }
-                _ => format!("{} @ {}:{}", entry.dcc_type, entry.host, entry.port),
-            };
-            json!({
-                "uri":         format!("dcc://{}/{}", entry.dcc_type, entry.instance_id),
-                "name":        name,
-                "description": format!("Live {} DCC instance. Version: {}.",
-                    entry.dcc_type,
-                    entry.version.as_deref().unwrap_or("unknown")),
-                "mimeType":    "application/json"
-            })
-        })
-        .collect();
-    json!({"jsonrpc":"2.0","id":id,"result":{"resources": resources}})
+    // #732: fan-out `resources/list` to every live backend and merge the
+    // results with the existing `dcc://<type>/<id>` admin pointers.
+    // Fail-soft: a backend that cannot be reached contributes zero
+    // entries; healthy backends' resources are still returned.
+    let result = aggregator::aggregate_resources_list(gs).await;
+    json!({"jsonrpc": "2.0", "id": id, "result": result})
 }
 
 async fn handle_resources_read(gs: &GatewayState, id: Value, req: &JsonRpcRequest) -> Value {
@@ -241,9 +221,43 @@ async fn handle_resources_read(gs: &GatewayState, id: Value, req: &JsonRpcReques
         .as_ref()
         .and_then(|params| params.get("uri"))
         .and_then(|value| value.as_str())
-        .unwrap_or("");
-    let parts: Vec<&str> = uri.trim_start_matches("dcc://").splitn(2, '/').collect();
+        .unwrap_or("")
+        .to_owned();
 
+    // #732: gateway-prefixed URIs (`<scheme>://<id8>/<rest>`) are
+    // forwarded to the owning backend, preserving the raw `result`
+    // payload — including `contents[].blob` entries for binary
+    // mime-types — byte-for-byte.
+    if let Some((id8, backend_uri)) = crate::gateway::namespace::decode_resource_uri(&uri) {
+        let owning = aggregator::find_instance_by_prefix(gs, &id8).await;
+        return match owning {
+            Some(entry) => {
+                let url = format!("http://{}:{}/mcp", entry.host, entry.port);
+                match crate::gateway::backend_client::read_resource(
+                    &gs.http_client,
+                    &url,
+                    &backend_uri,
+                    gs.backend_timeout,
+                )
+                .await
+                {
+                    Ok(result) => json!({"jsonrpc": "2.0", "id": id, "result": result}),
+                    Err(e) => json!({
+                        "jsonrpc": "2.0", "id": id,
+                        "error": {"code": -32002, "message": format!("Backend resources/read failed: {e}")}
+                    }),
+                }
+            }
+            None => json!({
+                "jsonrpc": "2.0", "id": id,
+                "error": {"code": -32002, "message": format!("Resource not found: {uri} (no live instance matches prefix '{id8}')")}
+            }),
+        };
+    }
+
+    // Fallback: the legacy `dcc://<type>/<id>` admin pointer format —
+    // the gateway renders the same instance metadata it did pre-#732.
+    let parts: Vec<&str> = uri.trim_start_matches("dcc://").splitn(2, '/').collect();
     let registry = gs.registry.read().await;
     let found = gs.live_instances(&registry).into_iter().find(|entry| {
         parts.len() == 2
@@ -286,15 +300,93 @@ async fn handle_resource_subscription(
         .and_then(|value| value.as_str())
         .unwrap_or("")
         .to_owned();
-    let mut subscriptions = gs.resource_subscriptions.write().await;
-    if subscribe {
-        subscriptions
-            .entry(session_id.to_owned())
-            .or_default()
-            .insert(uri);
-    } else if let Some(set) = subscriptions.get_mut(session_id) {
-        set.remove(&uri);
+
+    // Always track the session-level subscription set so the legacy
+    // behaviour (admin `dcc://` pointers, bookkeeping) is preserved
+    // verbatim — callers pre-#732 relied on this map being authoritative.
+    {
+        let mut subscriptions = gs.resource_subscriptions.write().await;
+        if subscribe {
+            subscriptions
+                .entry(session_id.to_owned())
+                .or_default()
+                .insert(uri.clone());
+        } else if let Some(set) = subscriptions.get_mut(session_id) {
+            set.remove(&uri);
+        }
     }
+
+    // #732: when the URI names a gateway-prefixed backend resource,
+    // forward the subscription to the owning backend and register a
+    // routing entry so the per-backend SSE loop can fan any
+    // `notifications/resources/updated` frames back to this session.
+    if let Some((id8, backend_uri)) = crate::gateway::namespace::decode_resource_uri(&uri) {
+        let owning = aggregator::find_instance_by_prefix(gs, &id8).await;
+        return match owning {
+            Some(entry) => {
+                let backend_url = format!("http://{}:{}/mcp", entry.host, entry.port);
+                // Register the gateway-side routing table entry **before**
+                // telling the backend to subscribe, so the very first
+                // update the backend emits cannot race the bookkeeping.
+                if subscribe {
+                    gs.subscriber.bind_resource_subscription(
+                        &backend_url,
+                        &backend_uri,
+                        session_id,
+                        &uri,
+                    );
+                    // Ensure an SSE subscriber is running for this backend
+                    // (idempotent — no-op when the periodic task already
+                    // spawned one).
+                    gs.subscriber.ensure_subscribed(&backend_url);
+                } else {
+                    gs.subscriber.unbind_resource_subscription(
+                        &backend_url,
+                        &backend_uri,
+                        session_id,
+                        &uri,
+                    );
+                }
+
+                match crate::gateway::backend_client::subscribe_resource(
+                    &gs.http_client,
+                    &backend_url,
+                    &backend_uri,
+                    subscribe,
+                    gs.backend_timeout,
+                )
+                .await
+                {
+                    Ok(_) => json!({"jsonrpc": "2.0", "id": id, "result": {}}),
+                    Err(e) => {
+                        // Forwarding failed — undo the routing entry so
+                        // we do not leak a ghost subscriber. We keep the
+                        // session-level bookkeeping either way; the next
+                        // client-driven unsubscribe will tidy it.
+                        if subscribe {
+                            gs.subscriber.unbind_resource_subscription(
+                                &backend_url,
+                                &backend_uri,
+                                session_id,
+                                &uri,
+                            );
+                        }
+                        json!({
+                            "jsonrpc": "2.0", "id": id,
+                            "error": {"code": -32002, "message": format!("Backend resources/{}: {e}", if subscribe { "subscribe" } else { "unsubscribe" })}
+                        })
+                    }
+                }
+            }
+            None => json!({
+                "jsonrpc": "2.0", "id": id,
+                "error": {"code": -32002, "message": format!("Resource not found: {uri} (no live instance matches prefix '{id8}')")}
+            }),
+        };
+    }
+
+    // Legacy admin-pointer subscription (no backend fan-out needed —
+    // the gateway itself does not emit updates for these URIs today).
     json!({"jsonrpc":"2.0","id":id,"result":{}})
 }
 

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
@@ -225,9 +225,12 @@ async fn handle_resources_read(gs: &GatewayState, id: Value, req: &JsonRpcReques
         .to_owned();
 
     // #732: gateway-prefixed URIs (`<scheme>://<id8>/<rest>`) are
-    // forwarded to the owning backend, preserving the raw `result`
-    // payload — including `contents[].blob` entries for binary
-    // mime-types — byte-for-byte.
+    // forwarded to the owning backend. The raw `result` payload —
+    // including `contents[].blob` entries for binary mime-types — is
+    // preserved byte-for-byte; the only rewrite applied is
+    // `contents[].uri`, which is flipped from the backend URI back
+    // to the client-visible prefixed form so agents can match the
+    // returned resource to the URI they originally asked for.
     if let Some((id8, backend_uri)) = crate::gateway::namespace::decode_resource_uri(&uri) {
         let owning = aggregator::find_instance_by_prefix(gs, &id8).await;
         return match owning {
@@ -241,7 +244,10 @@ async fn handle_resources_read(gs: &GatewayState, id: Value, req: &JsonRpcReques
                 )
                 .await
                 {
-                    Ok(result) => json!({"jsonrpc": "2.0", "id": id, "result": result}),
+                    Ok(mut result) => {
+                        rewrite_content_uris(&mut result, &backend_uri, &uri);
+                        json!({"jsonrpc": "2.0", "id": id, "result": result})
+                    }
                     Err(e) => json!({
                         "jsonrpc": "2.0", "id": id,
                         "error": {"code": -32002, "message": format!("Backend resources/read failed: {e}")}
@@ -283,6 +289,27 @@ async fn handle_resources_read(gs: &GatewayState, id: Value, req: &JsonRpcReques
             "jsonrpc": "2.0", "id": id,
             "error": {"code": -32002, "message": format!("Resource not found: {uri}")}
         }),
+    }
+}
+
+/// Rewrite every ``contents[].uri`` in a `resources/read` result so it
+/// matches the client's original prefixed URI rather than the raw
+/// backend URI. Mirrors the `params.uri` rewrite performed in
+/// [`super::super::sse_subscriber::dispatch_resource_updated`]: both
+/// surfaces return the URI the client subscribed / read with (#732).
+fn rewrite_content_uris(result: &mut Value, backend_uri: &str, client_uri: &str) {
+    let Some(contents) = result.get_mut("contents").and_then(Value::as_array_mut) else {
+        return;
+    };
+    for entry in contents {
+        if let Some(obj) = entry.as_object_mut()
+            && obj
+                .get("uri")
+                .and_then(Value::as_str)
+                .is_some_and(|u| u == backend_uri)
+        {
+            obj.insert("uri".to_string(), Value::String(client_uri.to_string()));
+        }
     }
 }
 
@@ -348,11 +375,40 @@ async fn handle_resource_subscription(
                     );
                 }
 
+                // #732: the backend binds its per-session
+                // `notifications/resources/updated` fan-out to whichever
+                // `Mcp-Session-Id` the subscribe POST carried. Send the
+                // gateway's stable backend-session id so the backend
+                // pushes updates onto the same SSE stream the gateway
+                // subscriber loop is already reading. The id is minted
+                // by the subscriber's `initialize` handshake; wait a
+                // few hundred ms for it to land when `ensure_subscribed`
+                // only just spawned the loop.
+                let Some(backend_session_id) = gs
+                    .subscriber
+                    .wait_for_backend_session_id(&backend_url, std::time::Duration::from_secs(3))
+                    .await
+                else {
+                    if subscribe {
+                        gs.subscriber.unbind_resource_subscription(
+                            &backend_url,
+                            &backend_uri,
+                            session_id,
+                            &uri,
+                        );
+                    }
+                    return json!({
+                        "jsonrpc": "2.0", "id": id,
+                        "error": {"code": -32002, "message": format!("Backend {backend_url} SSE subscriber not yet ready; retry")}
+                    });
+                };
+
                 match crate::gateway::backend_client::subscribe_resource(
                     &gs.http_client,
                     &backend_url,
                     &backend_uri,
                     subscribe,
+                    &backend_session_id,
                     gs.backend_timeout,
                 )
                 .await

--- a/crates/dcc-mcp-gateway/src/gateway/namespace/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/namespace/mod.rs
@@ -51,6 +51,7 @@
 mod bare;
 mod constants;
 mod encode;
+mod resource_uri;
 
 pub use bare::{BareNameInput, resolve_bare_names, warn_legacy_prefixed_once};
 pub use constants::{
@@ -63,6 +64,7 @@ pub use encode::{
     encode_tool_name_cursor_safe, escape_cursor_safe, extract_bare_tool_name,
     is_cursor_safe_alphabet, skill_tool_name, unescape_cursor_safe,
 };
+pub use resource_uri::{decode_resource_uri, encode_resource_uri};
 
 #[cfg(test)]
 pub use bare::__reset_warn_state_for_tests;

--- a/crates/dcc-mcp-gateway/src/gateway/namespace/resource_uri.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/namespace/resource_uri.rs
@@ -1,0 +1,159 @@
+//! Resource URI encoding/decoding for gateway aggregation (#732).
+//!
+//! Backend DCC servers expose resource URIs like `scene://current` or
+//! `capture://current_window`. The gateway aggregates resources from
+//! multiple backends, so it prefixes each backend URI with the 8-hex-char
+//! instance id to disambiguate:
+//!
+//!   `scene://current` on backend `abcdef01...`  →  `scene://abcdef01/current`
+//!
+//! The instance-id segment is the first path segment following `<scheme>://`.
+//! When the first segment is a valid 8-char hex string, the URI is treated
+//! as gateway-encoded and decoded back to the backend's original URI.
+//!
+//! Backend URIs that happen to start with 8 hex chars (unlikely in practice —
+//! `scene://deadbeef` would be a path, not a prefix) are unambiguously
+//! handled: the gateway only emits the prefixed form, and backends never
+//! see the prefixed form on `resources/read`.
+//!
+//! Unlike the tool-name encoding, resource URIs already use `://` which is
+//! not in the tool-name alphabet, so no escape layer is required — the
+//! `<scheme>://<id8>/<rest>` shape is preserved byte-for-byte.
+
+use uuid::Uuid;
+
+use super::constants::{ID_PREFIX_LEN, instance_short};
+
+/// Encode a backend resource URI for gateway aggregation:
+/// `<scheme>://<rest>` → `<scheme>://<id8>/<rest>`.
+///
+/// Preserves the scheme. When the backend URI has an empty authority
+/// (e.g. `scene://current`), the instance id becomes the authority and
+/// the original path is appended after `/`. When the backend URI already
+/// has an authority (e.g. `file://host/path`), the id is inserted before
+/// the authority so the authority becomes part of the path.
+///
+/// Returns `None` when the input does not contain `://`.
+pub fn encode_resource_uri(id: &Uuid, backend_uri: &str) -> Option<String> {
+    let (scheme, rest) = backend_uri.split_once("://")?;
+    let id8 = instance_short(id);
+    // Normalise: drop any leading `/` from the rest so we emit exactly one.
+    let rest = rest.trim_start_matches('/');
+    Some(format!("{scheme}://{id8}/{rest}"))
+}
+
+/// Decode a gateway-prefixed resource URI into `(id8, backend_uri)`.
+///
+/// Returns `None` when the URI does not follow the `<scheme>://<id8>/<rest>`
+/// shape — callers fall back to the legacy `dcc://<type>/<id>` admin pointer
+/// handling.
+///
+/// The returned `backend_uri` always reconstructs the scheme, so callers can
+/// forward it directly to the owning backend's `resources/read`.
+pub fn decode_resource_uri(prefixed: &str) -> Option<(String, String)> {
+    let (scheme, rest) = prefixed.split_once("://")?;
+    // Extract the first path segment — that's the instance-id candidate.
+    let (id_candidate, remainder) = match rest.split_once('/') {
+        Some((head, tail)) => (head, tail),
+        // No trailing slash at all: the whole rest is the id candidate and
+        // the backend URI is `<scheme>://` (empty rest).
+        None => (rest, ""),
+    };
+    if !is_instance_id8(id_candidate) {
+        return None;
+    }
+    let backend_uri = format!("{scheme}://{remainder}");
+    Some((id_candidate.to_string(), backend_uri))
+}
+
+/// Return `true` iff `s` is an 8-char lowercase hex string — the canonical
+/// shape emitted by [`instance_short`].
+fn is_instance_id8(s: &str) -> bool {
+    s.len() == ID_PREFIX_LEN && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixed_id() -> Uuid {
+        Uuid::parse_str("abcdef01-0000-0000-0000-000000000000").unwrap()
+    }
+
+    #[test]
+    fn encodes_simple_scheme_uri() {
+        let id = fixed_id();
+        let encoded = encode_resource_uri(&id, "scene://current").unwrap();
+        assert_eq!(encoded, "scene://abcdef01/current");
+    }
+
+    #[test]
+    fn encodes_uri_with_path_components() {
+        let id = fixed_id();
+        let encoded = encode_resource_uri(&id, "output://job_42/stdout.log").unwrap();
+        assert_eq!(encoded, "output://abcdef01/job_42/stdout.log");
+    }
+
+    #[test]
+    fn encodes_uri_whose_rest_starts_with_slash() {
+        // Some backends emit `scene:///current` (triple slash). Normalise
+        // so the prefixed form has exactly one `/` after the id.
+        let id = fixed_id();
+        let encoded = encode_resource_uri(&id, "scene:///current").unwrap();
+        assert_eq!(encoded, "scene://abcdef01/current");
+    }
+
+    #[test]
+    fn encode_rejects_non_uri() {
+        assert!(encode_resource_uri(&fixed_id(), "not-a-uri").is_none());
+    }
+
+    #[test]
+    fn decodes_prefixed_uri_round_trip() {
+        let id = fixed_id();
+        for backend_uri in &[
+            "scene://current",
+            "capture://current_window",
+            "output://job_42/stdout.log",
+            "artefact://session/42/meta.json",
+        ] {
+            let prefixed = encode_resource_uri(&id, backend_uri).unwrap();
+            let (id8, decoded) = decode_resource_uri(&prefixed).unwrap();
+            assert_eq!(id8, "abcdef01");
+            // Normalise the expected backend uri: encoder strips leading
+            // slashes from the rest, so triple-slash input comes back as
+            // single-slash. The gateway forwards `decoded` to the backend,
+            // and MCP spec treats `scheme://x` and `scheme:///x` as
+            // equivalent so either is valid; our contract is "whatever
+            // round-trips exactly".
+            let expected = {
+                let (scheme, rest) = backend_uri.split_once("://").unwrap();
+                format!("{scheme}://{}", rest.trim_start_matches('/'))
+            };
+            assert_eq!(decoded, expected);
+        }
+    }
+
+    #[test]
+    fn decode_rejects_uris_without_valid_id_prefix() {
+        // Admin pointer: first segment is `maya`, not an 8-hex id.
+        assert!(decode_resource_uri("dcc://maya/abc").is_none());
+        // Too short.
+        assert!(decode_resource_uri("scene://abc/current").is_none());
+        // Too long.
+        assert!(decode_resource_uri("scene://abcdef0123/current").is_none());
+        // Non-hex.
+        assert!(decode_resource_uri("scene://xyzxyzxy/current").is_none());
+        // No scheme separator.
+        assert!(decode_resource_uri("abcdef01/current").is_none());
+    }
+
+    #[test]
+    fn decode_handles_empty_backend_path() {
+        // `scene://abcdef01` (no trailing slash, no rest) maps to the
+        // backend URI `scene://` which is unusual but well-formed per RFC.
+        let (id8, backend) = decode_resource_uri("scene://abcdef01").unwrap();
+        assert_eq!(id8, "abcdef01");
+        assert_eq!(backend, "scene://");
+    }
+}

--- a/crates/dcc-mcp-gateway/src/gateway/sse_subscriber.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/sse_subscriber.rs
@@ -46,12 +46,14 @@ mod helpers;
 mod job_bus;
 mod manager;
 mod reconnect;
+mod resource_subs;
 mod route_gc;
 #[cfg(test)]
 mod tests;
 mod types;
 
 pub use manager::SubscriberManager;
+pub(crate) use types::ResourceSubscriberRoute;
 pub use types::{BackendId, BindJobError, ClientSessionId, JobRoute};
 
 #[cfg(test)]

--- a/crates/dcc-mcp-gateway/src/gateway/sse_subscriber/backend.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/sse_subscriber/backend.rs
@@ -35,6 +35,27 @@ impl Drop for BackendSubscriber {
 pub(crate) struct BackendShared {
     /// Backend URL for logging.
     pub(crate) url: String,
+    /// Stable `Mcp-Session-Id` the gateway uses for every outbound
+    /// request (SSE GET + forwarded JSON-RPC POSTs) to this backend.
+    ///
+    /// The backend's `resources/subscribe` handler requires a session
+    /// header so it can route `notifications/resources/updated` back
+    /// onto *that* session's SSE stream (#732). The gateway's subscriber
+    /// loop is the reader of that stream, so we bind the subscribe POST
+    /// to the same session — giving the backend a single sink to push
+    /// resource updates to.
+    ///
+    /// Wrapped in a `Mutex` because the id is not known until the first
+    /// `initialize` handshake against the backend completes (see
+    /// [`SubscriberManager::open_stream`] / the reconnect loop). Writers
+    /// overwrite the slot on every reconnect so a backend restart that
+    /// loses its session table gets a fresh id without restarting the
+    /// gateway. Readers (the handler that forwards `resources/subscribe`)
+    /// block until the first id is minted; in practice this is a
+    /// microsecond-scale wait since `ensure_subscribed` is called
+    /// eagerly by the gateway supervisor long before any client
+    /// subscription arrives.
+    pub(crate) session_id: Mutex<Option<String>>,
     /// Per-backend bounded buffer of notifications whose target session
     /// could not yet be resolved.
     pub(crate) pending: Mutex<VecDeque<Pending>>,
@@ -47,6 +68,7 @@ impl BackendShared {
     pub(crate) fn new(url: String) -> Self {
         Self {
             url,
+            session_id: Mutex::new(None),
             pending: Mutex::new(VecDeque::with_capacity(PENDING_BUFFER_CAP)),
             reconnect_attempts: Mutex::new(0),
         }

--- a/crates/dcc-mcp-gateway/src/gateway/sse_subscriber/delivery.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/sse_subscriber/delivery.rs
@@ -20,6 +20,18 @@ impl SubscriberManager {
         if let Some(jid) = terminal_job_id(&value) {
             self.forget_job(&jid);
         }
+        // #732: `notifications/resources/updated` is fanned out to every
+        // client session that subscribed to the owning backend resource.
+        // Delivery is independent of the progress / job-id correlation
+        // routes — it keys off `(backend_url, backend_uri)` directly.
+        if value
+            .get("method")
+            .and_then(|m| m.as_str())
+            .is_some_and(|m| m == "notifications/resources/updated")
+            && self.dispatch_resource_updated(&value, &backend_shared.url)
+        {
+            return;
+        }
         let session = resolve_target(&self.inner, &value);
         match session {
             Some(sid) => {

--- a/crates/dcc-mcp-gateway/src/gateway/sse_subscriber/manager.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/sse_subscriber/manager.rs
@@ -39,6 +39,15 @@ pub(crate) struct SubscriberManagerInner {
     /// forwarding an async `tools/call` so the waiter cannot miss a
     /// terminal event that arrives while the POST reply is in flight.
     pub(crate) job_event_buses: DashMap<String, broadcast::Sender<Value>>,
+    /// Resource-subscription routes (issue #732).
+    ///
+    /// Key: `(backend_url, backend_uri)` — uniquely identifies a
+    /// backend resource. Value: set of `ResourceSubscriberRoute`s
+    /// that must receive every `notifications/resources/updated`
+    /// frame for that resource, each carrying the client-visible
+    /// prefixed URI so the gateway can rewrite the notification's
+    /// `params.uri` before forwarding.
+    pub(crate) resource_subscriptions: DashMap<(String, String), DashSet<ResourceSubscriberRoute>>,
     /// Shared HTTP client with connection pooling.
     pub(crate) http_client: reqwest::Client,
     /// TTL beyond which a non-terminal route is evicted by the GC task
@@ -82,6 +91,7 @@ impl SubscriberManager {
                 backend_inflight: DashMap::new(),
                 client_sinks: DashMap::new(),
                 job_event_buses: DashMap::new(),
+                resource_subscriptions: DashMap::new(),
                 http_client,
                 route_ttl,
                 max_routes_per_session,
@@ -133,6 +143,12 @@ impl SubscriberManager {
         self.inner
             .progress_token_routes
             .retain(|_, sid| sid.as_str() != session_id);
+        // #732: drop any resource subscriptions owned by this session.
+        // We deliberately do NOT forward `resources/unsubscribe` to the
+        // backend here — the session's broken SSE stream already means
+        // the backend cannot reach this client, and other sessions on
+        // the same gateway may still be subscribed to the same resource.
+        let _ = self.forget_client_resource_subs(session_id);
     }
 
     // ── Correlation updates ────────────────────────────────────────────

--- a/crates/dcc-mcp-gateway/src/gateway/sse_subscriber/manager.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/sse_subscriber/manager.rs
@@ -308,6 +308,45 @@ impl SubscriberManager {
         );
     }
 
+    /// Return the stable `Mcp-Session-Id` the gateway uses for every
+    /// request to `backend_url` — both the long-lived SSE GET and any
+    /// forwarded JSON-RPC POST that must land on the same backend
+    /// session (e.g. `resources/subscribe` / `resources/unsubscribe`
+    /// under #732).
+    ///
+    /// Returns `None` when no subscriber exists for that URL yet, OR
+    /// when the subscriber has started but has not yet completed its
+    /// `initialize` handshake with the backend. Callers that hit this
+    /// path can retry after a short delay; in practice the handshake
+    /// completes within milliseconds of `ensure_subscribed`.
+    pub fn backend_session_id(&self, backend_url: &str) -> Option<String> {
+        self.inner
+            .backends
+            .get(backend_url)
+            .and_then(|entry| entry.shared.session_id.lock().clone())
+    }
+
+    /// Wait up to `budget` for the backend SSE subscriber to complete
+    /// its `initialize` handshake and publish a session id. Returns
+    /// `None` when either the subscriber does not exist or the
+    /// handshake did not land before the deadline.
+    pub async fn wait_for_backend_session_id(
+        &self,
+        backend_url: &str,
+        budget: std::time::Duration,
+    ) -> Option<String> {
+        let deadline = std::time::Instant::now() + budget;
+        loop {
+            if let Some(id) = self.backend_session_id(backend_url) {
+                return Some(id);
+            }
+            if std::time::Instant::now() >= deadline {
+                return None;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+    }
+
     /// Abort and remove any subscriber whose URL is **not** in `live_urls`.
     ///
     /// Called after each `FileRegistry` scan so that dead backends (ports that

--- a/crates/dcc-mcp-gateway/src/gateway/sse_subscriber/reconnect.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/sse_subscriber/reconnect.rs
@@ -8,7 +8,30 @@ impl SubscriberManager {
     pub(super) async fn run_backend_loop(self, url: String, shared: Arc<BackendShared>) {
         let mut attempt: u32 = 0;
         loop {
-            match self.open_stream(&url).await {
+            // #732: the backend fans `notifications/resources/updated`
+            // per-session, so the gateway must hold a *real* session id
+            // that exists in the backend's `SessionManager`. Only an
+            // `initialize` RPC creates a session; a bare GET /mcp with
+            // a made-up id would 404. Do the handshake, then open the
+            // SSE stream with whatever id the backend minted.
+            let session_id = match self.handshake_session_id(&url).await {
+                Ok(id) => id,
+                Err(e) => {
+                    tracing::debug!(
+                        backend = %url,
+                        attempt,
+                        error = %e,
+                        "gateway SSE: initialize handshake failed — will retry"
+                    );
+                    attempt = attempt.saturating_add(1);
+                    *shared.reconnect_attempts.lock() = attempt;
+                    tokio::time::sleep(backoff_delay(attempt)).await;
+                    continue;
+                }
+            };
+            *shared.session_id.lock() = Some(session_id.clone());
+
+            match self.open_stream(&url, &session_id).await {
                 Ok(resp) => {
                     if attempt > 0 {
                         tracing::info!(
@@ -40,7 +63,69 @@ impl SubscriberManager {
         }
     }
 
-    pub(super) async fn open_stream(&self, url: &str) -> reqwest::Result<reqwest::Response> {
+    /// Perform the `initialize` handshake against a backend and return
+    /// the session id the backend minted. This id is the contract the
+    /// per-session fan-out in `background_impl::spawn_notifications_task`
+    /// uses, so we must use it for both the SSE GET and any forwarded
+    /// `resources/subscribe` on behalf of clients (#732).
+    pub(super) async fn handshake_session_id(&self, url: &str) -> Result<String, String> {
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": "gw-sub-init",
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "dcc-mcp-gateway-subscriber",
+                    "version": env!("CARGO_PKG_VERSION"),
+                },
+            }
+        });
+        // Explicit short timeout for the handshake — unlike the SSE
+        // stream, this is a bounded request/response round-trip and
+        // must not hang indefinitely when the backend is slow.
+        let resp = self
+            .inner
+            .http_client
+            .post(url)
+            .timeout(std::time::Duration::from_secs(5))
+            .header("content-type", "application/json")
+            .header("accept", "application/json")
+            .body(body.to_string())
+            .send()
+            .await
+            .map_err(|e| format!("transport: {e}"))?;
+        if !resp.status().is_success() {
+            return Err(format!("status {}", resp.status()));
+        }
+        // Prefer the `Mcp-Session-Id` response header — that's the
+        // canonical carrier. Fall back to the `__session_id` field some
+        // older code paths splice into the `result` object.
+        if let Some(header) = resp.headers().get("mcp-session-id")
+            && let Ok(s) = header.to_str()
+            && !s.is_empty()
+        {
+            let owned = s.to_owned();
+            // Drain the body so the connection is reusable.
+            let _ = resp.bytes().await;
+            return Ok(owned);
+        }
+        let text = resp.text().await.map_err(|e| format!("read body: {e}"))?;
+        let value: Value = serde_json::from_str(&text).map_err(|e| format!("parse body: {e}"))?;
+        value
+            .get("result")
+            .and_then(|r| r.get("__session_id"))
+            .and_then(|v| v.as_str())
+            .map(str::to_owned)
+            .ok_or_else(|| "initialize response lacked session id".to_string())
+    }
+
+    pub(super) async fn open_stream(
+        &self,
+        url: &str,
+        session_id: &str,
+    ) -> reqwest::Result<reqwest::Response> {
         // NOTE: Intentionally do NOT call `.timeout(..)` here.
         //
         // `RequestBuilder::timeout()` in reqwest 0.13 applies to the *entire*
@@ -55,10 +140,17 @@ impl SubscriberManager {
         // read (see [`STREAM_IDLE_TIMEOUT`]), so the connect phase here
         // only needs whatever default the shared `reqwest::Client` was
         // built with.
+        //
+        // #732: the `Mcp-Session-Id` header binds this SSE stream to a
+        // stable backend session id. Any `resources/subscribe` the gateway
+        // forwards on behalf of a client is sent with the SAME header so
+        // the backend's per-session `notifications/resources/updated`
+        // fan-out lands on this stream (and nowhere else).
         self.inner
             .http_client
             .get(url)
             .header("accept", "text/event-stream")
+            .header("Mcp-Session-Id", session_id)
             .send()
             .await
             .and_then(|r| r.error_for_status())

--- a/crates/dcc-mcp-gateway/src/gateway/sse_subscriber/resource_subs.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/sse_subscriber/resource_subs.rs
@@ -1,0 +1,143 @@
+//! Resource-subscription routing (#732).
+//!
+//! Layered on top of the existing [`SubscriberManager`]: the per-backend
+//! SSE subscriber already receives every notification a backend emits, so
+//! no new network plumbing is required. This module adds a routing table
+//! keyed by `(backend_url, backend_uri)` → set of subscribing client
+//! sessions + the prefixed URI each client originally subscribed with,
+//! and a `dispatch_resource_updated` helper the delivery path calls when
+//! a `notifications/resources/updated` frame arrives.
+
+use super::types::ResourceSubscriberRoute;
+use super::*;
+use dcc_mcp_jsonrpc::format_sse_event;
+
+impl SubscriberManager {
+    /// Register a `(client_session, client_uri)` subscription for the
+    /// `(backend_url, backend_uri)` resource. Idempotent.
+    ///
+    /// Returns `true` when a new route was inserted, `false` when the
+    /// same subscription already existed.
+    pub fn bind_resource_subscription(
+        &self,
+        backend_url: &str,
+        backend_uri: &str,
+        client_session_id: &str,
+        client_uri: &str,
+    ) -> bool {
+        let key = (backend_url.to_string(), backend_uri.to_string());
+        let route = ResourceSubscriberRoute {
+            client_session_id: client_session_id.to_string(),
+            client_uri: client_uri.to_string(),
+        };
+        let set = self.inner.resource_subscriptions.entry(key).or_default();
+        set.insert(route)
+    }
+
+    /// Remove a specific `(client_session, client_uri)` subscription for
+    /// the `(backend_url, backend_uri)` resource. Returns `true` when
+    /// the set is now empty so the caller can decide whether to forward
+    /// a `resources/unsubscribe` to the backend.
+    pub fn unbind_resource_subscription(
+        &self,
+        backend_url: &str,
+        backend_uri: &str,
+        client_session_id: &str,
+        client_uri: &str,
+    ) -> bool {
+        let key = (backend_url.to_string(), backend_uri.to_string());
+        let Some(set_ref) = self.inner.resource_subscriptions.get(&key) else {
+            return false;
+        };
+        let route = ResourceSubscriberRoute {
+            client_session_id: client_session_id.to_string(),
+            client_uri: client_uri.to_string(),
+        };
+        set_ref.remove(&route);
+        let empty = set_ref.is_empty();
+        drop(set_ref);
+        if empty {
+            self.inner.resource_subscriptions.remove(&key);
+        }
+        empty
+    }
+
+    /// Forward a backend `notifications/resources/updated` to every
+    /// subscribing client session, with the `params.uri` rewritten back
+    /// to the gateway-prefixed form each client originally subscribed
+    /// with.
+    ///
+    /// Returns `true` when at least one subscriber was matched (used by
+    /// the delivery path to decide whether the event has already been
+    /// consumed and should not be buffered).
+    pub(super) fn dispatch_resource_updated(&self, value: &Value, backend_url: &str) -> bool {
+        let Some(backend_uri) = value
+            .get("params")
+            .and_then(|p| p.get("uri"))
+            .and_then(Value::as_str)
+        else {
+            return false;
+        };
+        let key = (backend_url.to_string(), backend_uri.to_string());
+        let Some(set_ref) = self.inner.resource_subscriptions.get(&key) else {
+            return false;
+        };
+        let routes: Vec<ResourceSubscriberRoute> = set_ref.iter().map(|e| e.clone()).collect();
+        drop(set_ref);
+
+        let mut dispatched_any = false;
+        for route in routes {
+            // Rewrite the URI so each subscriber sees the prefixed form
+            // it originally requested — two clients may have subscribed
+            // to the same backend resource through different encodings
+            // and we must honour each one's wire contract.
+            let mut outbound = value.clone();
+            if let Some(params) = outbound.get_mut("params").and_then(Value::as_object_mut) {
+                params.insert("uri".to_string(), Value::String(route.client_uri.clone()));
+            }
+            if let Some(sender) = self.inner.client_sinks.get(&route.client_session_id) {
+                let event = format_sse_event(&outbound, None);
+                let _ = sender.send(event);
+                dispatched_any = true;
+            } else {
+                tracing::debug!(
+                    session = %route.client_session_id,
+                    backend = %backend_url,
+                    uri = %backend_uri,
+                    "gateway SSE: resources/updated subscriber has no live sink — dropping"
+                );
+            }
+        }
+        dispatched_any
+    }
+
+    /// Drop every subscription owned by `session_id`. Returns the set
+    /// of `(backend_url, backend_uri)` pairs whose subscriber list
+    /// became empty — callers use this to fire trailing
+    /// `resources/unsubscribe` calls at the owning backends.
+    pub fn forget_client_resource_subs(&self, session_id: &str) -> Vec<(String, String)> {
+        let mut emptied: Vec<(String, String)> = Vec::new();
+        let mut drop_keys: Vec<(String, String)> = Vec::new();
+        for entry in self.inner.resource_subscriptions.iter() {
+            let key = entry.key().clone();
+            let set = entry.value();
+            // DashSet::retain is not available; collect removals then apply.
+            let to_remove: Vec<ResourceSubscriberRoute> = set
+                .iter()
+                .filter(|r| r.client_session_id == session_id)
+                .map(|r| r.clone())
+                .collect();
+            for route in &to_remove {
+                set.remove(route);
+            }
+            if set.is_empty() && !to_remove.is_empty() {
+                emptied.push(key.clone());
+                drop_keys.push(key);
+            }
+        }
+        for key in drop_keys {
+            self.inner.resource_subscriptions.remove(&key);
+        }
+        emptied
+    }
+}

--- a/crates/dcc-mcp-gateway/src/gateway/sse_subscriber/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/sse_subscriber/tests.rs
@@ -69,6 +69,7 @@ fn empty_inner() -> SubscriberManagerInner {
         backend_inflight: DashMap::new(),
         client_sinks: DashMap::new(),
         job_event_buses: DashMap::new(),
+        resource_subscriptions: DashMap::new(),
         http_client: reqwest::Client::new(),
         route_ttl: DEFAULT_ROUTE_TTL,
         max_routes_per_session: DEFAULT_MAX_ROUTES_PER_SESSION,
@@ -487,4 +488,95 @@ fn subscriber_manager_uses_timeout_free_client_for_sse() {
          timeout that caused the 30-second SSE reconnect storm bug)",
         STREAM_IDLE_TIMEOUT.as_secs()
     );
+}
+
+// ── #732: resource-subscription routing ───────────────────────────────
+
+#[tokio::test]
+async fn dispatch_resource_updated_rewrites_uri_and_forwards_to_subscribers() {
+    // One backend, two subscribers of the same resource via different
+    // client-visible prefixed URIs. Both must receive the notification
+    // with `params.uri` rewritten to each client's own prefixed URI.
+    let mgr = SubscriberManager::default();
+    let session_one = "client-one";
+    let session_two = "client-two";
+    let mut rx_one = mgr.register_client(session_one);
+    let mut rx_two = mgr.register_client(session_two);
+
+    let backend_url = "http://127.0.0.1:9999/mcp";
+    let backend_uri = "scene://current";
+    let uri_one = "scene://aaaaaaaa/current";
+    let uri_two = "scene://bbbbbbbb/current";
+
+    assert!(mgr.bind_resource_subscription(backend_url, backend_uri, session_one, uri_one));
+    assert!(mgr.bind_resource_subscription(backend_url, backend_uri, session_two, uri_two));
+
+    let update = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/resources/updated",
+        "params": {"uri": backend_uri}
+    });
+    assert!(mgr.dispatch_resource_updated(&update, backend_url));
+
+    let event_one = rx_one.try_recv().expect("session one must receive update");
+    assert!(
+        event_one.contains(uri_one),
+        "session one's event should carry its own URI: {event_one}"
+    );
+    assert!(
+        !event_one.contains(backend_uri) || event_one.contains(uri_one),
+        "session one must not see the raw backend URI: {event_one}"
+    );
+
+    let event_two = rx_two.try_recv().expect("session two must receive update");
+    assert!(
+        event_two.contains(uri_two),
+        "session two's event should carry its own URI: {event_two}"
+    );
+
+    // Cleanup: unbind session one — session two still subscribed, so
+    // the set is non-empty.
+    assert!(
+        !mgr.unbind_resource_subscription(backend_url, backend_uri, session_one, uri_one),
+        "set must not be empty yet"
+    );
+    // Unbind session two — last route, set becomes empty.
+    assert!(
+        mgr.unbind_resource_subscription(backend_url, backend_uri, session_two, uri_two),
+        "set must report empty after last unbind"
+    );
+
+    // A further update with no subscribers goes nowhere.
+    assert!(!mgr.dispatch_resource_updated(&update, backend_url));
+}
+
+#[tokio::test]
+async fn forget_client_drops_resource_subscriptions() {
+    let mgr = SubscriberManager::default();
+    let session = "ghost";
+    let _ = mgr.register_client(session);
+
+    mgr.bind_resource_subscription(
+        "http://127.0.0.1:9999/mcp",
+        "scene://current",
+        session,
+        "scene://aaaaaaaa/current",
+    );
+    mgr.bind_resource_subscription(
+        "http://127.0.0.1:9999/mcp",
+        "audit://recent",
+        session,
+        "audit://aaaaaaaa/recent",
+    );
+
+    // `forget_client_resource_subs` reports the two keys that became empty.
+    let emptied = mgr.forget_client_resource_subs(session);
+    assert_eq!(emptied.len(), 2, "both resources should have been dropped");
+
+    // Subsequent dispatch finds no route.
+    let update = serde_json::json!({
+        "method": "notifications/resources/updated",
+        "params": {"uri": "scene://current"}
+    });
+    assert!(!mgr.dispatch_resource_updated(&update, "http://127.0.0.1:9999/mcp"));
 }

--- a/crates/dcc-mcp-gateway/src/gateway/sse_subscriber/types.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/sse_subscriber/types.rs
@@ -70,3 +70,25 @@ pub(crate) struct Pending {
     pub(crate) inserted_at: Instant,
     pub(crate) value: Value,
 }
+
+/// A single client's subscription to a backend resource (#732).
+///
+/// The gateway tracks `(backend_url, backend_uri)` → `{ClientRoute}` so
+/// that a backend-emitted `notifications/resources/updated` can be fanned
+/// out to every subscribing client session with the URI rewritten back
+/// to the gateway-prefixed form the client originally subscribed with.
+///
+/// Stored inside a `DashSet`, so `Eq` / `Hash` must be total over the
+/// fields that uniquely identify a subscription; two subscribers that
+/// differ only in `client_uri` still count as distinct entries because
+/// the outbound notification rewrites the URI per-route.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ResourceSubscriberRoute {
+    /// Owning client session — key into `client_sinks`.
+    pub(crate) client_session_id: ClientSessionId,
+    /// The gateway-prefixed URI the client originally subscribed with.
+    /// Written back into `params.uri` on every outbound
+    /// `notifications/resources/updated`, so the client sees the URI
+    /// shape it originally requested (not the raw backend URI).
+    pub(crate) client_uri: String,
+}

--- a/crates/dcc-mcp-gateway/src/gateway/tasks.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tasks.rs
@@ -292,6 +292,62 @@ pub(crate) async fn start_gateway_tasks(
         }
     });
 
+    // ── Aggregated resources/list_changed watcher (every 3 s) ─────────────
+    // Polls every live backend's `resources/list`, computes a set-fingerprint
+    // of "{instance_id}:{backend_uri}" tuples, and broadcasts one
+    // `notifications/resources/list_changed` to gateway SSE subscribers when
+    // the aggregated set changes (resource added / removed on any DCC).
+    //
+    // Parallel to the tools watcher above. Same 3-second cadence, same
+    // hysteresis (no broadcast on the empty→empty first tick), same
+    // fail-soft semantics (unreachable backends contribute zero resources).
+    //
+    // #732: the instance-change watcher above already emits
+    // `resources/list_changed` when the set of live DCC instances changes;
+    // this watcher adds the second, finer signal — a resource added on an
+    // existing backend, without any membership change.
+    let reg_resources = registry.clone();
+    let events_tx_resources = events_tx.clone();
+    let http_client_resources = http_client.clone();
+    let resources_own_host = own_host.clone();
+    let resources_own_port = own_port;
+    let resources_watcher_handle = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(3));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let mut last_fingerprint = String::new();
+
+        loop {
+            interval.tick().await;
+            let fingerprint = aggregator::compute_resources_fingerprint_with_own(
+                &reg_resources,
+                stale_timeout,
+                &http_client_resources,
+                backend_timeout,
+                Some(resources_own_host.as_str()),
+                resources_own_port,
+            )
+            .await;
+
+            if fingerprint != last_fingerprint {
+                if (!last_fingerprint.is_empty() || !fingerprint.is_empty())
+                    && events_tx_resources.receiver_count() > 0
+                {
+                    tracing::debug!(
+                        "Gateway: aggregated resource set changed — broadcasting resources/list_changed"
+                    );
+                    let notif = serde_json::to_string(&serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "method": "notifications/resources/list_changed",
+                        "params": {}
+                    }))
+                    .unwrap_or_default();
+                    let _ = events_tx_resources.send(notif);
+                }
+                last_fingerprint = fingerprint;
+            }
+        }
+    });
+
     // ── Backend SSE subscriber manager (#320) ─────────────────────────────
     // Multiplexes per-backend SSE notifications back to originating client
     // sessions. Each `ensure_subscribed` spawns a reconnecting task.
@@ -615,6 +671,7 @@ pub(crate) async fn start_gateway_tasks(
             watcher_handle,
             tools_watcher_handle,
             prompts_watcher_handle,
+            resources_watcher_handle,
             backend_sub_handle,
             route_gc_handle,
             health_check_handle,
@@ -629,6 +686,7 @@ pub(crate) async fn start_gateway_tasks(
             watcher_handle,
             tools_watcher_handle,
             prompts_watcher_handle,
+            resources_watcher_handle,
             backend_sub_handle,
             route_gc_handle,
             health_check_handle,

--- a/crates/dcc-mcp-http/src/handler/routes.rs
+++ b/crates/dcc-mcp-http/src/handler/routes.rs
@@ -220,9 +220,18 @@ pub async fn handle_get(State(state): State<AppState>, headers: HeaderMap) -> Re
     let sse_stream = BroadcastStream::new(rx)
         .filter_map(|res| res.ok())
         .map(|data| {
-            // Each item is already a formatted SSE event string
-            // Parse it back to send as axum SSE Event
-            Ok::<_, std::convert::Infallible>(Event::default().data(data))
+            // `data` is already a formatted SSE record (ends with `\n\n`).
+            // Strip the outer `data: ` / trailing blank line so that
+            // axum's `Event::data()` re-wraps a *bare* JSON payload —
+            // otherwise the wire output is `data: data: {json}` which
+            // breaks every downstream SSE parser (including the
+            // gateway's own subscriber loop, #732).
+            let payload = data
+                .strip_prefix("data: ")
+                .and_then(|v| v.strip_suffix("\n\n"))
+                .map(str::to_owned)
+                .unwrap_or(data);
+            Ok::<_, std::convert::Infallible>(Event::default().data(payload))
         });
 
     Sse::new(sse_stream)

--- a/crates/dcc-mcp-http/tests/http.rs
+++ b/crates/dcc-mcp-http/tests/http.rs
@@ -34,6 +34,9 @@ mod gateway_prompts_e2e;
 #[path = "http/gateway_reachability.rs"]
 mod gateway_reachability;
 
+#[path = "http/gateway_resources.rs"]
+mod gateway_resources;
+
 #[path = "http/gateway_tool_exposure.rs"]
 mod gateway_tool_exposure;
 

--- a/crates/dcc-mcp-http/tests/http/gateway_resources.rs
+++ b/crates/dcc-mcp-http/tests/http/gateway_resources.rs
@@ -1,0 +1,874 @@
+//! End-to-end tests for gateway resource forwarding (#732).
+//!
+//! Spin up a real `McpHttpServer` that wins the gateway election, plus one
+//! or two real plain-instance backends sharing a common registry directory,
+//! then drive the gateway's `/mcp` endpoint over real HTTP to exercise the
+//! full wire contract:
+//!
+//! * `resources/list` returns admin pointers PLUS every backend's resources
+//!   with URIs rewritten to `<scheme>://<id8>/<rest>`.
+//! * `resources/read` on the prefixed form forwards to the owning backend
+//!   and returns the raw payload unchanged — including base64 `blob` bytes
+//!   for binary mime-types, byte-for-byte identical to a direct backend read.
+//! * `resources/subscribe` + a backend scene update propagates to the
+//!   subscribing SSE client as `notifications/resources/updated` within a
+//!   short deadline, with `params.uri` rewritten to the client-visible
+//!   prefixed URI. Unsubscribe then stops the propagation.
+//! * The aggregated `resources/list_changed` watcher emits one SSE frame
+//!   when a backend adds or removes a resource.
+//! * Fail-soft: one backend with a closed port does not take down
+//!   `resources/list` — the healthy backend's resources still appear.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use base64::Engine as _;
+use dcc_mcp_actions::ActionRegistry;
+use dcc_mcp_http::{McpHttpConfig, McpHttpServer, McpServerHandle};
+use serde_json::{Value, json};
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+/// Pick a free TCP port on 127.0.0.1 and return it. The port is closed
+/// before returning, so there is a tiny race window — acceptable for
+/// tests which bind immediately after.
+fn pick_free_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}
+
+/// Start a plain-instance backend registered in `registry_dir`. The
+/// returned handle owns the serving task; `resources/list`
+/// automatically exposes `scene://current` (with a synthetic payload)
+/// and `audit://recent` via the default `ResourceRegistry`.
+///
+/// The `ResourceRegistry` is kept alive via `McpHttpServer`'s internal
+/// `Arc` and reachable through `ResourceRegistry::handle_for` only
+/// while the server is running — callers that need to drive
+/// `set_scene` later must keep a clone of the registry handle from
+/// `McpHttpServer::resources()` **before** `start()` consumes self.
+async fn spawn_backend_with_scene(
+    dcc_type: &str,
+    gw_port: u16,
+    registry_dir: &std::path::Path,
+    initial_scene: Value,
+) -> (McpServerHandle, dcc_mcp_http::ResourceRegistry) {
+    let action_registry = Arc::new(ActionRegistry::new());
+    let cfg = McpHttpConfig::new(0)
+        .with_name(format!("{dcc_type}-resources-e2e"))
+        .with_gateway(gw_port)
+        .with_dcc_type(dcc_type)
+        .with_registry_dir(registry_dir);
+
+    let server = McpHttpServer::new(action_registry, cfg);
+    // Capture a clone of the registry handle BEFORE start() — the registry
+    // is internally an `Arc`, so this clone shares the same subscription
+    // map and producers list the serving task holds.
+    let resources = server.resources().clone();
+    resources.set_scene(initial_scene);
+    let handle = server
+        .start()
+        .await
+        .expect("backend McpHttpServer must start");
+    (handle, resources)
+}
+
+/// POST a JSON-RPC request body to `url` and return the parsed JSON reply.
+async fn post_rpc(
+    client: &reqwest::Client,
+    url: &str,
+    method: &str,
+    params: Option<Value>,
+    id: i64,
+) -> Value {
+    let mut body = json!({"jsonrpc": "2.0", "id": id, "method": method});
+    if let Some(p) = params {
+        body["params"] = p;
+    }
+    let resp = client
+        .post(url)
+        .header("content-type", "application/json")
+        .header("accept", "application/json")
+        .body(body.to_string())
+        .send()
+        .await
+        .expect("request must succeed");
+    let text = resp.text().await.expect("body readable");
+    serde_json::from_str(&text).unwrap_or_else(|_| panic!("invalid JSON response: {text}"))
+}
+
+/// Poll `f` every 50 ms up to `budget`, returning the first non-None
+/// result. Panics with `diag` on timeout.
+async fn wait_until<T, F>(budget: Duration, diag: &str, mut f: F) -> T
+where
+    F: FnMut() -> Option<T>,
+{
+    let deadline = Instant::now() + budget;
+    loop {
+        if let Some(v) = f() {
+            return v;
+        }
+        if Instant::now() > deadline {
+            panic!("timeout after {budget:?}: {diag}");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+/// Extract the `resources` array from a successful `resources/list`
+/// reply — panic with `method` + error payload on failure.
+fn resources_from_reply(reply: &Value) -> &Vec<Value> {
+    if reply.get("error").is_some() {
+        panic!("resources/list returned error: {reply:#}");
+    }
+    reply
+        .get("result")
+        .and_then(|r| r.get("resources"))
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("no resources array in reply: {reply:#}"))
+}
+
+/// Try to extract the 8-char hex instance id from a prefixed URI.
+/// Returns `None` for admin pointers (`dcc://...`) or non-prefixed URIs.
+fn id8_from_prefixed(uri: &str) -> Option<(String, String)> {
+    let (scheme, rest) = uri.split_once("://")?;
+    let (id, remainder) = rest.split_once('/').unwrap_or((rest, ""));
+    if id.len() == 8 && id.bytes().all(|b| b.is_ascii_hexdigit()) {
+        Some((id.to_string(), format!("{scheme}://{remainder}")))
+    } else {
+        None
+    }
+}
+
+/// Sleep just past the gateway's 2-second instance-watcher tick so a new
+/// registration is visible through the facade. Slightly generous to
+/// account for CI jitter.
+async fn wait_for_instance_watcher() {
+    tokio::time::sleep(Duration::from_millis(2500)).await;
+}
+
+// ── integration tests ────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn gateway_resources_list_merges_admin_pointers_and_prefixed_backend_uris() {
+    let registry_dir = tempfile::tempdir().unwrap();
+    let gw_port = pick_free_port();
+
+    // First backend — wins gateway election.
+    let (handle_a, _res_a) = spawn_backend_with_scene(
+        "maya",
+        gw_port,
+        registry_dir.path(),
+        json!({"scene_name": "maya_shot_A", "node_count": 7}),
+    )
+    .await;
+    // Give the elected process time to bind the gateway listener.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // Second backend — plain instance under the same gateway.
+    let (handle_b, _res_b) = spawn_backend_with_scene(
+        "blender",
+        gw_port,
+        registry_dir.path(),
+        json!({"scene_name": "blender_shot_B", "node_count": 42}),
+    )
+    .await;
+    wait_for_instance_watcher().await;
+
+    assert!(handle_a.is_gateway, "backend A must win gateway election");
+    assert!(!handle_b.is_gateway, "backend B must be a plain instance");
+
+    let gw_url = format!("http://127.0.0.1:{gw_port}/mcp");
+    let client = reqwest::Client::new();
+    let reply = post_rpc(&client, &gw_url, "resources/list", None, 1).await;
+    let resources = resources_from_reply(&reply);
+    let uris: Vec<&str> = resources
+        .iter()
+        .filter_map(|r| r.get("uri").and_then(Value::as_str))
+        .collect();
+
+    // Admin pointers — one per live DCC instance.
+    assert!(
+        uris.iter().any(|u| u.starts_with("dcc://maya/")),
+        "missing dcc://maya/ admin pointer; got {uris:#?}",
+    );
+    assert!(
+        uris.iter().any(|u| u.starts_with("dcc://blender/")),
+        "missing dcc://blender/ admin pointer; got {uris:#?}",
+    );
+
+    // Backend-contributed resources — every live instance's scene + audit.
+    let scene_prefixed: Vec<&str> = uris
+        .iter()
+        .copied()
+        .filter(|u| u.starts_with("scene://") && id8_from_prefixed(u).is_some())
+        .collect();
+    assert_eq!(
+        scene_prefixed.len(),
+        2,
+        "expected one prefixed scene URI per backend, got {scene_prefixed:#?} (all uris: {uris:#?})",
+    );
+    let audit_prefixed: Vec<&str> = uris
+        .iter()
+        .copied()
+        .filter(|u| u.starts_with("audit://") && id8_from_prefixed(u).is_some())
+        .collect();
+    assert_eq!(
+        audit_prefixed.len(),
+        2,
+        "expected one prefixed audit URI per backend, got {audit_prefixed:#?}",
+    );
+
+    // No unprefixed backend URIs leaked — clients would not be able to
+    // route them back to a specific instance.
+    assert!(
+        !uris.contains(&"scene://current"),
+        "gateway leaked unprefixed backend URI; got {uris:#?}",
+    );
+
+    handle_b.shutdown().await;
+    handle_a.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn gateway_resources_read_matches_direct_backend_byte_for_byte() {
+    let registry_dir = tempfile::tempdir().unwrap();
+    let gw_port = pick_free_port();
+
+    let scene_payload = json!({
+        "scene_name": "byte_round_trip",
+        "nodes": ["alpha", "beta", "gamma"],
+        "frame_range": [1, 240],
+        "unicode": "café — こんにちは — 🌟",
+    });
+    let (handle, _res) =
+        spawn_backend_with_scene("maya", gw_port, registry_dir.path(), scene_payload.clone()).await;
+    wait_for_instance_watcher().await;
+    assert!(handle.is_gateway);
+
+    let gw_url = format!("http://127.0.0.1:{gw_port}/mcp");
+    let backend_url = format!("http://{}/mcp", handle.bind_addr);
+    let client = reqwest::Client::new();
+
+    // Discover the prefixed scene URI from the gateway's list.
+    let list_reply = post_rpc(&client, &gw_url, "resources/list", None, 1).await;
+    let resources = resources_from_reply(&list_reply);
+    let prefixed_scene = resources
+        .iter()
+        .filter_map(|r| r.get("uri").and_then(Value::as_str))
+        .find(|u| u.starts_with("scene://") && id8_from_prefixed(u).is_some())
+        .unwrap_or_else(|| panic!("no prefixed scene URI in {resources:#?}"))
+        .to_owned();
+
+    // Read via the gateway (prefixed URI) and directly from the backend
+    // (raw URI). The contents array must be identical.
+    let gw_reply = post_rpc(
+        &client,
+        &gw_url,
+        "resources/read",
+        Some(json!({"uri": prefixed_scene})),
+        2,
+    )
+    .await;
+    let backend_reply = post_rpc(
+        &client,
+        &backend_url,
+        "resources/read",
+        Some(json!({"uri": "scene://current"})),
+        2,
+    )
+    .await;
+
+    assert!(
+        gw_reply.get("error").is_none(),
+        "gw read errored: {gw_reply:#}"
+    );
+    assert!(
+        backend_reply.get("error").is_none(),
+        "backend read errored: {backend_reply:#}"
+    );
+    let gw_contents = gw_reply["result"]["contents"]
+        .as_array()
+        .expect("gateway contents array");
+    let backend_contents = backend_reply["result"]["contents"]
+        .as_array()
+        .expect("backend contents array");
+    assert_eq!(gw_contents.len(), backend_contents.len());
+    // The gateway rewrites `contents[].uri` from the backend URI back
+    // to the prefixed client form so agents can match the response to
+    // the URI they originally asked for (#732). Everything else —
+    // `mimeType`, `text`, and for binary resources `blob` — must
+    // round-trip unchanged byte-for-byte.
+    for (gw_item, backend_item) in gw_contents.iter().zip(backend_contents.iter()) {
+        assert_eq!(
+            gw_item.get("uri").and_then(Value::as_str),
+            Some(prefixed_scene.as_str()),
+        );
+        assert_eq!(
+            backend_item.get("uri").and_then(Value::as_str),
+            Some("scene://current"),
+        );
+        for key in ["mimeType", "text", "blob"] {
+            assert_eq!(
+                gw_item.get(key),
+                backend_item.get(key),
+                "{key} must survive the proxy unchanged",
+            );
+        }
+    }
+
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn gateway_resources_read_preserves_blob_bytes_end_to_end() {
+    // Install a custom producer on a backend that returns a raw PNG-ish
+    // byte payload as a `blob`. The gateway must round-trip the exact
+    // base64 string — any UTF-8 lossy conversion anywhere in the path
+    // would corrupt the bytes and break this assertion.
+    use dcc_mcp_http::{ProducerContent, ResourceError, ResourceProducer, ResourceResult};
+    use dcc_mcp_jsonrpc::McpResource;
+
+    struct BlobProducer {
+        payload: Vec<u8>,
+    }
+    impl ResourceProducer for BlobProducer {
+        fn scheme(&self) -> &str {
+            // Use a unique scheme — the built-in `capture://` producer
+            // is registered by default and would take precedence if we
+            // also claimed `"capture"`.
+            "testblob"
+        }
+        fn list(&self) -> Vec<McpResource> {
+            vec![McpResource {
+                uri: "testblob://snapshot".to_string(),
+                name: "Binary snapshot".to_string(),
+                description: Some("Synthetic PNG for #732 byte round-trip".to_string()),
+                mime_type: Some("image/png".to_string()),
+            }]
+        }
+        fn read(&self, uri: &str) -> ResourceResult<ProducerContent> {
+            if uri != "testblob://snapshot" {
+                return Err(ResourceError::NotFound(uri.to_string()));
+            }
+            Ok(ProducerContent::Blob {
+                uri: uri.to_string(),
+                mime_type: "image/png".to_string(),
+                bytes: self.payload.clone(),
+            })
+        }
+    }
+
+    let registry_dir = tempfile::tempdir().unwrap();
+    let gw_port = pick_free_port();
+
+    // Hand-crafted "PNG" — uses the real signature plus a payload that
+    // is deliberately not valid UTF-8 (0xFF, 0xFE bytes in the middle).
+    // If any layer UTF-8-lossy-decodes this, the round-trip assertion
+    // will fail with the pattern `[U+FFFD]` replacement chars visible
+    // in the diff.
+    let mut raw: Vec<u8> = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+    raw.extend_from_slice(b"IDAT-payload-");
+    raw.extend_from_slice(&[0xFF, 0xFE, 0xFD, 0xFC, 0x00, 0x01]);
+    raw.extend_from_slice(b"-trailer");
+    let expected_b64 = base64::engine::general_purpose::STANDARD.encode(&raw);
+
+    let action_registry = Arc::new(ActionRegistry::new());
+    let cfg = McpHttpConfig::new(0)
+        .with_name("maya-blob-e2e")
+        .with_gateway(gw_port)
+        .with_dcc_type("maya")
+        .with_registry_dir(registry_dir.path());
+    let server = McpHttpServer::new(action_registry, cfg);
+    server.resources().add_producer(Arc::new(BlobProducer {
+        payload: raw.clone(),
+    }));
+    let handle = server.start().await.expect("backend must start");
+    wait_for_instance_watcher().await;
+    assert!(handle.is_gateway);
+
+    let gw_url = format!("http://127.0.0.1:{gw_port}/mcp");
+    let client = reqwest::Client::new();
+
+    // Find the prefixed testblob URI.
+    let list_reply = post_rpc(&client, &gw_url, "resources/list", None, 1).await;
+    let resources = resources_from_reply(&list_reply);
+    let prefixed = resources
+        .iter()
+        .filter_map(|r| r.get("uri").and_then(Value::as_str))
+        .find(|u| u.starts_with("testblob://") && id8_from_prefixed(u).is_some())
+        .unwrap_or_else(|| panic!("testblob:// prefixed URI missing from {resources:#?}"))
+        .to_owned();
+
+    let read_reply = post_rpc(
+        &client,
+        &gw_url,
+        "resources/read",
+        Some(json!({"uri": prefixed})),
+        2,
+    )
+    .await;
+    assert!(
+        read_reply.get("error").is_none(),
+        "gateway read errored: {read_reply:#}"
+    );
+    let content = &read_reply["result"]["contents"][0];
+    assert_eq!(
+        content["mimeType"].as_str(),
+        Some("image/png"),
+        "mimeType must survive the proxy"
+    );
+    let round_tripped_b64 = content["blob"]
+        .as_str()
+        .expect("blob field must be a base64 string");
+    assert_eq!(
+        round_tripped_b64, expected_b64,
+        "blob base64 must match byte-for-byte through the gateway",
+    );
+
+    // Decode and diff the raw bytes to prove there was no UTF-8 lossy
+    // conversion anywhere in the round-trip.
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(round_tripped_b64)
+        .expect("round-tripped base64 must be valid");
+    assert_eq!(
+        decoded, raw,
+        "decoded bytes must equal the original payload"
+    );
+
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn gateway_resources_list_is_fail_soft_when_one_backend_is_down() {
+    let registry_dir = tempfile::tempdir().unwrap();
+    let gw_port = pick_free_port();
+
+    let (handle_alive, _res) = spawn_backend_with_scene(
+        "maya",
+        gw_port,
+        registry_dir.path(),
+        json!({"scene_name": "alive_one"}),
+    )
+    .await;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // Manually register a dead entry: bind a port, grab it, close the
+    // listener, and write a ServiceEntry for that closed port. The
+    // gateway's `resources/list` must fan out to both, find the dead
+    // port unreachable, emit a WARN, and still return the alive
+    // backend's resources.
+    let dead_port = {
+        let l = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let p = l.local_addr().unwrap().port();
+        drop(l);
+        p
+    };
+    {
+        let reg =
+            dcc_mcp_transport::discovery::file_registry::FileRegistry::new(registry_dir.path())
+                .unwrap();
+        let entry = dcc_mcp_transport::discovery::types::ServiceEntry::new(
+            "blender",
+            "127.0.0.1",
+            dead_port,
+        );
+        reg.register(entry).unwrap();
+    }
+    // Poll until the gateway's live_instances view picks up the dead row.
+    wait_for_instance_watcher().await;
+
+    let gw_url = format!("http://127.0.0.1:{gw_port}/mcp");
+    let client = reqwest::Client::new();
+    let reply = post_rpc(&client, &gw_url, "resources/list", None, 1).await;
+    assert!(
+        reply.get("error").is_none(),
+        "one dead backend must not surface a JSON-RPC error (fail-soft): {reply:#}",
+    );
+    let resources = resources_from_reply(&reply);
+    let uris: Vec<&str> = resources
+        .iter()
+        .filter_map(|r| r.get("uri").and_then(Value::as_str))
+        .collect();
+
+    // Alive backend's prefixed scene URI is present.
+    let alive_scene = uris
+        .iter()
+        .copied()
+        .find(|u| u.starts_with("scene://") && id8_from_prefixed(u).is_some());
+    assert!(
+        alive_scene.is_some(),
+        "alive backend's prefixed scene URI missing: {uris:#?}",
+    );
+
+    // Admin pointers: expect at least the alive maya row. The blender
+    // admin pointer may or may not appear depending on whether the
+    // gateway's health-probe has already flipped the row Unreachable in
+    // this short window; the hard invariant is that the ALIVE one is
+    // present and the call did not 500.
+    assert!(
+        uris.iter().any(|u| u.starts_with("dcc://maya/")),
+        "alive maya admin pointer missing: {uris:#?}",
+    );
+
+    handle_alive.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn gateway_resources_subscribe_propagates_updated_frame_within_deadline() {
+    let registry_dir = tempfile::tempdir().unwrap();
+    let gw_port = pick_free_port();
+
+    // Gateway-owning backend (backend A) — resources on A are filtered
+    // out of the facade's `live_instances` because it IS the gateway,
+    // so subscriptions would never route. Spin up a second, plain
+    // backend (B) whose scene we can subscribe to through the facade.
+    let (handle_a, _res_a) = spawn_backend_with_scene(
+        "maya",
+        gw_port,
+        registry_dir.path(),
+        json!({"scene_name": "gateway_owner_initial"}),
+    )
+    .await;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert!(handle_a.is_gateway);
+
+    let (handle_b, resources_registry_b) = spawn_backend_with_scene(
+        "blender",
+        gw_port,
+        registry_dir.path(),
+        json!({"scene_name": "plain_backend_initial"}),
+    )
+    .await;
+    wait_for_instance_watcher().await;
+    assert!(!handle_b.is_gateway);
+
+    let gw_url = format!("http://127.0.0.1:{gw_port}/mcp");
+    let client = reqwest::Client::new();
+
+    // 1. Discover backend B's prefixed scene URI.
+    let list_reply = post_rpc(&client, &gw_url, "resources/list", None, 1).await;
+    let resources = resources_from_reply(&list_reply);
+    let prefixed_scene = resources
+        .iter()
+        .filter_map(|r| r.get("uri").and_then(Value::as_str))
+        .find(|u| u.starts_with("scene://") && id8_from_prefixed(u).is_some())
+        .unwrap_or_else(|| panic!("no prefixed scene URI: {resources:#?}"))
+        .to_owned();
+
+    // 2. Open an SSE stream on the gateway with a stable session id,
+    //    then consume frames on a background task.
+    let session_id = "test-session-7a55da".to_string();
+    let sse_resp = client
+        .get(&gw_url)
+        .header("accept", "text/event-stream")
+        .header("mcp-session-id", &session_id)
+        .send()
+        .await
+        .expect("SSE GET must succeed");
+    assert!(sse_resp.status().is_success());
+    let events = Arc::new(tokio::sync::Mutex::new(Vec::<String>::new()));
+    let events_bg = events.clone();
+    let sse_task = tokio::spawn(async move {
+        use futures::StreamExt;
+        let mut stream = sse_resp.bytes_stream();
+        let mut buf = Vec::<u8>::new();
+        while let Some(Ok(chunk)) = stream.next().await {
+            buf.extend_from_slice(&chunk);
+            // Drain complete SSE records ("\n\n"-terminated).
+            while let Some(pos) = find_double_newline(&buf) {
+                let record = buf.drain(..pos).collect::<Vec<u8>>();
+                let _ = buf.drain(..2); // trailing "\n\n"
+                if let Ok(text) = std::str::from_utf8(&record) {
+                    events_bg.lock().await.push(text.to_owned());
+                }
+            }
+        }
+    });
+
+    // 3. Subscribe via the SAME session id — the gateway must register
+    //    the route for this client session.
+    let sub_reply = client
+        .post(&gw_url)
+        .header("content-type", "application/json")
+        .header("accept", "application/json")
+        .header("mcp-session-id", &session_id)
+        .body(
+            json!({
+                "jsonrpc": "2.0", "id": 2,
+                "method": "resources/subscribe",
+                "params": {"uri": prefixed_scene}
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .expect("subscribe POST must succeed");
+    let sub_body: Value = serde_json::from_str(&sub_reply.text().await.unwrap()).unwrap();
+    assert!(
+        sub_body.get("error").is_none(),
+        "subscribe returned error: {sub_body:#}"
+    );
+
+    // Give backend B's per-session fan-out a beat to observe the
+    // subscription before we fire an update — the subscribe path
+    // returns as soon as the backend stores the row, but the
+    // `spawn_notifications_task` that pushes updates to session
+    // broadcasts runs on a separate tokio task which may not have
+    // been scheduled yet when we proceed. Poll the backend's
+    // subscription table directly so we know it's hot before we
+    // move on — avoids flakiness under parallel test load. Use a
+    // generous 10 s budget to tolerate a fully-saturated CI runner
+    // (the full workspace test suite has ~1500 tokio tasks alive
+    // concurrently during `cargo nextest run --workspace`).
+    wait_until(Duration::from_secs(10), "backend sub registered", || {
+        let subs = resources_registry_b.sessions_subscribed_to("scene://current");
+        if subs.is_empty() { None } else { Some(()) }
+    })
+    .await;
+
+    // 4. Trigger a scene update on the backend — the real publisher
+    //    that emits `notifications/resources/updated` on the backend's
+    //    own SSE stream, which the gateway multiplexer must forward.
+    resources_registry_b.set_scene(json!({"scene_name": "after_update"}));
+
+    // 5. Wait up to 10 s for the prefixed URI to appear in an
+    //    `resources/updated` frame on the gateway SSE stream. The
+    //    real propagation path crosses several tokio tasks (backend
+    //    notification fan-out → backend SSE broadcast → gateway
+    //    subscriber `pump_stream` → `dispatch_resource_updated` →
+    //    client sink) and under full workspace-level load each
+    //    schedule point can slip by hundreds of ms.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let updated_uri = loop {
+        let snapshot = events.lock().await.clone();
+        if let Some(hit) = snapshot
+            .iter()
+            .find_map(|frame| extract_resources_updated_uri(frame))
+        {
+            break hit;
+        }
+        if Instant::now() > deadline {
+            panic!("no notifications/resources/updated within 10s; frames so far: {snapshot:#?}",);
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    };
+    assert_eq!(
+        updated_uri, prefixed_scene,
+        "gateway must rewrite params.uri to the client-visible prefixed form",
+    );
+
+    // 6. Unsubscribe, drive another update, and assert no further
+    //    `resources/updated` frame arrives within 2 s.
+    let unsub_reply = client
+        .post(&gw_url)
+        .header("content-type", "application/json")
+        .header("accept", "application/json")
+        .header("mcp-session-id", &session_id)
+        .body(
+            json!({
+                "jsonrpc": "2.0", "id": 3,
+                "method": "resources/unsubscribe",
+                "params": {"uri": prefixed_scene}
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .expect("unsubscribe POST must succeed");
+    let unsub_body: Value = serde_json::from_str(&unsub_reply.text().await.unwrap()).unwrap();
+    assert!(
+        unsub_body.get("error").is_none(),
+        "unsubscribe returned error: {unsub_body:#}"
+    );
+
+    // Wait for the backend's subscription table to drain.
+    wait_until(Duration::from_secs(10), "backend sub cleared", || {
+        let subs = resources_registry_b.sessions_subscribed_to("scene://current");
+        if subs.is_empty() { Some(()) } else { None }
+    })
+    .await;
+
+    // Take a baseline of updated-uris seen so far, then push another
+    // scene change.
+    let baseline: Vec<String> = {
+        let snapshot = events.lock().await.clone();
+        snapshot
+            .iter()
+            .filter_map(|f| extract_resources_updated_uri(f))
+            .collect()
+    };
+    resources_registry_b.set_scene(json!({"scene_name": "after_unsubscribe"}));
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    let post_unsubscribe: Vec<String> = {
+        let snapshot = events.lock().await.clone();
+        snapshot
+            .iter()
+            .filter_map(|f| extract_resources_updated_uri(f))
+            .collect()
+    };
+    assert_eq!(
+        post_unsubscribe.len(),
+        baseline.len(),
+        "after unsubscribe, no more resources/updated frames should arrive; \
+         baseline={baseline:?} post_unsubscribe={post_unsubscribe:?}",
+    );
+
+    sse_task.abort();
+    handle_b.shutdown().await;
+    handle_a.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn gateway_resources_list_changed_fires_when_backend_resource_set_changes() {
+    use dcc_mcp_http::{ProducerContent, ResourceError, ResourceProducer, ResourceResult};
+    use dcc_mcp_jsonrpc::McpResource;
+
+    /// A toggleable producer: when `enabled` is false its `list()` is
+    /// empty so the backend drops the `extra://` URI from its set.
+    /// Changing the flag at runtime mutates the backend's aggregated
+    /// resource fingerprint, which the gateway watcher must observe.
+    struct ToggleProducer {
+        enabled: Arc<std::sync::atomic::AtomicBool>,
+    }
+    impl ResourceProducer for ToggleProducer {
+        fn scheme(&self) -> &str {
+            "extra"
+        }
+        fn list(&self) -> Vec<McpResource> {
+            if !self.enabled.load(std::sync::atomic::Ordering::SeqCst) {
+                return Vec::new();
+            }
+            vec![McpResource {
+                uri: "extra://dynamic".to_string(),
+                name: "Dynamic extra".to_string(),
+                description: Some("Added at runtime for #732 watcher test".into()),
+                mime_type: Some("application/json".to_string()),
+            }]
+        }
+        fn read(&self, uri: &str) -> ResourceResult<ProducerContent> {
+            if uri == "extra://dynamic" && self.enabled.load(std::sync::atomic::Ordering::SeqCst) {
+                Ok(ProducerContent::Text {
+                    uri: uri.to_string(),
+                    mime_type: "application/json".to_string(),
+                    text: "{\"ok\":true}".to_string(),
+                })
+            } else {
+                Err(ResourceError::NotFound(uri.to_string()))
+            }
+        }
+    }
+
+    let registry_dir = tempfile::tempdir().unwrap();
+    let gw_port = pick_free_port();
+    let action_registry = Arc::new(ActionRegistry::new());
+    let cfg = McpHttpConfig::new(0)
+        .with_name("maya-listchanged-e2e")
+        .with_gateway(gw_port)
+        .with_dcc_type("maya")
+        .with_registry_dir(registry_dir.path());
+    let server = McpHttpServer::new(action_registry, cfg);
+    let toggle = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    server.resources().add_producer(Arc::new(ToggleProducer {
+        enabled: toggle.clone(),
+    }));
+    let handle = server.start().await.expect("backend must start");
+    wait_for_instance_watcher().await;
+    assert!(handle.is_gateway);
+
+    let gw_url = format!("http://127.0.0.1:{gw_port}/mcp");
+    let client = reqwest::Client::new();
+    let session_id = "listchanged-session".to_string();
+
+    // Open an SSE stream first so the initial baseline
+    // resources/list_changed (if any) is already consumed before we
+    // mutate the producer.
+    let sse_resp = client
+        .get(&gw_url)
+        .header("accept", "text/event-stream")
+        .header("mcp-session-id", &session_id)
+        .send()
+        .await
+        .expect("SSE GET must succeed");
+    assert!(sse_resp.status().is_success());
+    let events = Arc::new(tokio::sync::Mutex::new(Vec::<String>::new()));
+    let events_bg = events.clone();
+    let sse_task = tokio::spawn(async move {
+        use futures::StreamExt;
+        let mut stream = sse_resp.bytes_stream();
+        let mut buf = Vec::<u8>::new();
+        while let Some(Ok(chunk)) = stream.next().await {
+            buf.extend_from_slice(&chunk);
+            while let Some(pos) = find_double_newline(&buf) {
+                let record = buf.drain(..pos).collect::<Vec<u8>>();
+                let _ = buf.drain(..2);
+                if let Ok(text) = std::str::from_utf8(&record) {
+                    events_bg.lock().await.push(text.to_owned());
+                }
+            }
+        }
+    });
+
+    // Wait a full watcher period so the initial fingerprint is
+    // captured without firing a list_changed (empty → empty skip rule).
+    tokio::time::sleep(Duration::from_secs(4)).await;
+    let baseline_count = count_list_changed(&events.lock().await);
+
+    // Flip the producer on — new `extra://` URI appears in the
+    // backend's resources/list, the gateway watcher's fingerprint
+    // changes, a list_changed should be emitted within ~3 s + jitter.
+    toggle.store(true, std::sync::atomic::Ordering::SeqCst);
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let current = count_list_changed(&events.lock().await);
+        if current > baseline_count {
+            break;
+        }
+        if Instant::now() > deadline {
+            let snapshot = events.lock().await.clone();
+            panic!("no resources/list_changed within 15s after producer add; frames={snapshot:#?}");
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    sse_task.abort();
+    handle.shutdown().await;
+}
+
+// ── Local SSE helpers ────────────────────────────────────────────────────
+
+fn find_double_newline(buf: &[u8]) -> Option<usize> {
+    buf.windows(2).position(|w| w == b"\n\n")
+}
+
+/// If `frame` is a `data: {...notifications/resources/updated...}`
+/// line, return the `params.uri` payload.
+fn extract_resources_updated_uri(frame: &str) -> Option<String> {
+    for line in frame.lines() {
+        let Some(payload) = line.strip_prefix("data:") else {
+            continue;
+        };
+        let payload = payload.trim_start();
+        let Ok(value) = serde_json::from_str::<Value>(payload) else {
+            continue;
+        };
+        if value.get("method").and_then(Value::as_str) == Some("notifications/resources/updated") {
+            return value
+                .get("params")
+                .and_then(|p| p.get("uri"))
+                .and_then(Value::as_str)
+                .map(str::to_owned);
+        }
+    }
+    None
+}
+
+fn count_list_changed(frames: &[String]) -> usize {
+    frames
+        .iter()
+        .filter(|f| f.contains("notifications/resources/list_changed"))
+        .count()
+}

--- a/tests/test_gateway_resources_forwarding.py
+++ b/tests/test_gateway_resources_forwarding.py
@@ -1,0 +1,377 @@
+"""End-to-end tests for gateway resources forwarding (issue #732).
+
+From a Python-client perspective, verifies that the aggregating-facade
+gateway surfaces backend resources correctly:
+
+* ``resources/list`` returns ``dcc://<type>/<id>`` admin pointers PLUS
+  every backend's resources, each rewritten to ``<scheme>://<id8>/<rest>``.
+* ``resources/read <scheme>://<id8>/<rest>`` on the gateway returns the
+  same ``contents`` payload as a direct read against the owning backend
+  — including ``blob`` base64 strings, byte-for-byte.
+* A dead backend does not take down ``resources/list`` on the healthy
+  one (fail-soft).
+
+Mirrors the Rust integration coverage in
+``crates/dcc-mcp-http/tests/http/gateway_resources.rs`` but drives the
+surface entirely over HTTP from Python, the way an AI client actually
+consumes the gateway.
+"""
+
+from __future__ import annotations
+
+import base64
+import contextlib
+import json
+from pathlib import Path
+import socket
+import time
+import urllib.request
+
+import pytest
+
+from dcc_mcp_core import McpHttpConfig
+from dcc_mcp_core import McpHttpServer
+from dcc_mcp_core import ToolRegistry
+
+
+def _pick_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _post_mcp(url: str, method: str, params: dict | None = None, rpc_id: int = 1) -> dict:
+    body = {"jsonrpc": "2.0", "id": rpc_id, "method": method}
+    if params is not None:
+        body["params"] = params
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        return json.loads(resp.read())
+
+
+def _make_backend(dcc: str, registry_dir: Path, gw_port: int) -> tuple[McpHttpServer, object]:
+    """Start a backend ``McpHttpServer`` sharing ``registry_dir``.
+
+    No actions are registered — this test only cares about resources,
+    which the default ``ResourceRegistry`` (``scene://current``,
+    ``audit://recent``) exposes automatically. Returns
+    ``(server, handle)``; the server reference keeps the live
+    ``ResourceRegistry`` alive for the test's use of
+    ``server.resources()``.
+    """
+    cfg = McpHttpConfig(port=0, server_name=f"{dcc}-resources-e2e")
+    cfg.gateway_port = gw_port
+    cfg.registry_dir = str(registry_dir)
+    cfg.dcc_type = dcc
+    cfg.heartbeat_secs = 1
+    cfg.stale_timeout_secs = 10
+
+    server = McpHttpServer(ToolRegistry(), cfg)
+    handle = server.start()
+    return server, handle
+
+
+def _split_gateway_prefixed_uri(uri: str) -> tuple[str, str, str] | None:
+    """Return ``(scheme, id8, rest)`` if ``uri`` follows the gateway's
+    forwarded shape ``<scheme>://<id8>/<rest>``, else ``None``.
+    """
+    if "://" not in uri:
+        return None
+    scheme, _, remainder = uri.partition("://")
+    if "/" in remainder:
+        id8, _, rest = remainder.partition("/")
+    else:
+        id8, rest = remainder, ""
+    if len(id8) != 8 or not all(ch in "0123456789abcdef" for ch in id8):
+        return None
+    return scheme, id8, rest
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def two_backend_cluster(tmp_path_factory):
+    """Spin up 2 backends + gateway, yield a dict with the urls + handles."""
+    registry_dir = tmp_path_factory.mktemp("resources-e2e-registry")
+    gw_port = _pick_free_port()
+
+    _server_a, handle_a = _make_backend("maya", registry_dir, gw_port)
+    time.sleep(0.3)  # let A bind the gateway port before B registers
+    _server_b, handle_b = _make_backend("blender", registry_dir, gw_port)
+
+    # Give the gateway's 2-second instance-watcher time to observe both.
+    time.sleep(2.2)
+
+    if not handle_a.is_gateway:
+        pytest.skip(f"backend A did not win the gateway port competition on {gw_port}; another process may hold it")
+
+    try:
+        yield {
+            "gateway_url": f"http://127.0.0.1:{gw_port}/mcp",
+            "gateway_port": gw_port,
+            "handle_a": handle_a,
+            "handle_b": handle_b,
+            # Direct backend URLs — used to prove byte-for-byte equality
+            # between the forwarded read and a direct read.
+            "backend_a_url": f"http://{handle_a.bind_addr}/mcp",
+            "backend_b_url": f"http://{handle_b.bind_addr}/mcp",
+        }
+    finally:
+        for h in (handle_b, handle_a):
+            with contextlib.suppress(Exception):
+                h.shutdown()
+
+
+# ── tests ─────────────────────────────────────────────────────────────────────
+
+
+class TestResourcesListMerge:
+    """``resources/list`` surfaces admin pointers merged with prefixed backend URIs."""
+
+    def test_returns_admin_pointers_for_each_live_backend(self, two_backend_cluster):
+        resp = _post_mcp(two_backend_cluster["gateway_url"], "resources/list")
+        resources = resp["result"]["resources"]
+        uris = {r["uri"] for r in resources}
+
+        # Each live backend (A is the gateway owner and gets filtered
+        # out of `live_instances`; B is plain-instance so it stays).
+        # Only B's admin pointer is expected here; A's self-row is
+        # hidden to avoid the facade fanning into itself (#419).
+        assert any(u.startswith("dcc://blender/") for u in uris), f"blender admin pointer missing: {sorted(uris)}"
+
+    def test_returns_prefixed_backend_resources_with_instance_id(self, two_backend_cluster):
+        resp = _post_mcp(two_backend_cluster["gateway_url"], "resources/list")
+        resources = resp["result"]["resources"]
+        uris = {r["uri"] for r in resources}
+
+        # Every `<scheme>://` URI that isn't the `dcc://` admin pointer
+        # must carry an 8-hex-char instance-id segment immediately
+        # after the scheme — that's the #732 namespacing contract.
+        for uri in uris:
+            if uri.startswith("dcc://"):
+                continue
+            parts = _split_gateway_prefixed_uri(uri)
+            assert parts is not None, f"backend URI {uri!r} is not prefixed with an 8-hex id"
+
+        # At least one prefixed scene URI comes from backend B
+        # (backend A's self-row is hidden; the gateway does not fan
+        # resources back into itself).
+        prefixed_scenes = [u for u in uris if u.startswith("scene://") and _split_gateway_prefixed_uri(u) is not None]
+        assert prefixed_scenes, f"no prefixed scene URIs in {sorted(uris)}"
+
+    def test_unprefixed_backend_uris_do_not_leak(self, two_backend_cluster):
+        """Raw ``scene://current`` must never reach the client — it
+        would be ambiguous across multiple backends.
+        """
+        resp = _post_mcp(two_backend_cluster["gateway_url"], "resources/list")
+        uris = {r["uri"] for r in resp["result"]["resources"]}
+        assert "scene://current" not in uris
+        assert "audit://recent" not in uris
+
+    def test_backend_resources_carry_instance_annotations(self, two_backend_cluster):
+        """Prefixed backend resources carry ``_instance_id`` /
+        ``_dcc_type`` so agents can display origin context (mirrors the
+        tools-forwarding annotation convention).
+        """
+        resp = _post_mcp(two_backend_cluster["gateway_url"], "resources/list")
+        resources = resp["result"]["resources"]
+        backend_scene_entries = [
+            r
+            for r in resources
+            if r.get("uri", "").startswith("scene://") and _split_gateway_prefixed_uri(r["uri"]) is not None
+        ]
+        assert backend_scene_entries, "expected at least one prefixed scene resource"
+        for entry in backend_scene_entries:
+            assert "_instance_id" in entry, f"resource missing _instance_id annotation: {entry}"
+            assert "_dcc_type" in entry, f"resource missing _dcc_type annotation: {entry}"
+
+
+class TestResourcesReadForwarding:
+    """``resources/read`` on a prefixed URI equals a direct backend read."""
+
+    def test_forwarded_read_matches_direct_backend_read_byte_for_byte(self, two_backend_cluster):
+        # Discover backend B's prefixed scene URI via the gateway list.
+        list_resp = _post_mcp(two_backend_cluster["gateway_url"], "resources/list")
+        prefixed = next(
+            (
+                r["uri"]
+                for r in list_resp["result"]["resources"]
+                if r.get("uri", "").startswith("scene://") and _split_gateway_prefixed_uri(r["uri"]) is not None
+            ),
+            None,
+        )
+        assert prefixed is not None, "no prefixed scene URI to test"
+
+        gw_read = _post_mcp(
+            two_backend_cluster["gateway_url"],
+            "resources/read",
+            {"uri": prefixed},
+            rpc_id=2,
+        )
+        direct_read = _post_mcp(
+            two_backend_cluster["backend_b_url"],
+            "resources/read",
+            {"uri": "scene://current"},
+            rpc_id=2,
+        )
+
+        assert "error" not in gw_read, f"gateway read errored: {gw_read}"
+        assert "error" not in direct_read, f"direct read errored: {direct_read}"
+
+        # The gateway rewrites `contents[].uri` from the backend URI
+        # back to the prefixed client form (so clients can match the
+        # response to the URI they asked for). Every other field —
+        # `mimeType`, `text`, and for binary resources `blob` — must
+        # round-trip unchanged byte-for-byte.
+        gw_contents = gw_read["result"]["contents"]
+        direct_contents = direct_read["result"]["contents"]
+        assert len(gw_contents) == len(direct_contents)
+        for gw_item, direct_item in zip(gw_contents, direct_contents):
+            # URI: prefixed on the gateway side, raw on the backend side.
+            assert gw_item["uri"] == prefixed
+            assert direct_item["uri"] == "scene://current"
+            # Everything else must match exactly.
+            gw_other = {k: v for k, v in gw_item.items() if k != "uri"}
+            direct_other = {k: v for k, v in direct_item.items() if k != "uri"}
+            assert gw_other == direct_other, (
+                "non-URI fields of the forwarded read must match the direct "
+                f"backend read: gw={gw_other}, direct={direct_other}"
+            )
+
+    def test_unknown_prefix_returns_resource_not_found(self, two_backend_cluster):
+        """A URI whose id8 does not match any live instance must not
+        fall back to the gateway's admin-pointer handler — it is a
+        real not-found, not an ambiguous shape.
+        """
+        gw_read = _post_mcp(
+            two_backend_cluster["gateway_url"],
+            "resources/read",
+            {"uri": "scene://deadbeef/current"},
+            rpc_id=2,
+        )
+        assert "error" in gw_read, f"expected error, got {gw_read}"
+        assert gw_read["error"]["code"] == -32002
+
+
+class TestResourcesReadBlobRoundTrip:
+    """Binary ``blob`` payloads must round-trip base64-identical."""
+
+    def test_blob_base64_survives_gateway_proxy(self, tmp_path_factory):
+        """Install a custom binary-producing resource on a plain backend
+        via the Rust-side ``register_producer`` is not exposed to
+        Python, so we instead exercise the built-in ``audit://recent``
+        producer and validate the envelope shape. The byte-level
+        guarantee is already covered in the Rust E2E test
+        (``gateway_resources_read_preserves_blob_bytes_end_to_end``);
+        here we validate the Python client surface does not
+        accidentally corrupt a base64 payload it passes through
+        ``json.loads``.
+
+        This test uses audit's JSON payload and confirms that the
+        ``contents`` envelope round-trips through ``urllib`` +
+        ``json.loads`` without mutation — a proxy for the blob path.
+        """
+        # Reuse a fresh cluster instead of the module-scoped one so the
+        # audit log starts empty and the assertions are stable.
+        registry_dir = tmp_path_factory.mktemp("blob-e2e-registry")
+        gw_port = _pick_free_port()
+        _server_a, handle_a = _make_backend("maya", registry_dir, gw_port)
+        time.sleep(0.3)
+        _server_b, handle_b = _make_backend("blender", registry_dir, gw_port)
+        time.sleep(2.2)
+
+        if not handle_a.is_gateway:
+            handle_b.shutdown()
+            handle_a.shutdown()
+            pytest.skip("gateway port contention — blob round-trip test")
+
+        gw_url = f"http://127.0.0.1:{gw_port}/mcp"
+        try:
+            list_resp = _post_mcp(gw_url, "resources/list")
+            prefixed_audit = next(
+                (
+                    r["uri"]
+                    for r in list_resp["result"]["resources"]
+                    if r.get("uri", "").startswith("audit://") and _split_gateway_prefixed_uri(r["uri"]) is not None
+                ),
+                None,
+            )
+            assert prefixed_audit is not None, (
+                f"no prefixed audit URI; list was {[r['uri'] for r in list_resp['result']['resources']]}"
+            )
+
+            read_resp = _post_mcp(gw_url, "resources/read", {"uri": prefixed_audit}, rpc_id=2)
+            assert "error" not in read_resp, f"read errored: {read_resp}"
+
+            contents = read_resp["result"]["contents"]
+            assert len(contents) == 1
+            item = contents[0]
+            assert item["uri"] == prefixed_audit, (
+                "forwarded read must echo the client-visible prefixed URI, not the raw backend URI"
+            )
+            assert item["mimeType"] == "application/json", "mimeType must survive the proxy unchanged"
+            # Audit payload is UTF-8 JSON text; parse it to prove the
+            # envelope is intact (no BOM, no escape corruption).
+            payload = json.loads(item["text"])
+            assert "entries" in payload
+            # Also prove that arbitrary base64 passed through the client
+            # would survive — standard lib `base64` decodes the text
+            # encoding of the JSON payload cleanly.
+            encoded = base64.b64encode(item["text"].encode("utf-8")).decode("ascii")
+            decoded = base64.b64decode(encoded).decode("utf-8")
+            assert decoded == item["text"]
+        finally:
+            with contextlib.suppress(Exception):
+                handle_b.shutdown()
+            with contextlib.suppress(Exception):
+                handle_a.shutdown()
+
+
+class TestResourcesListFailSoft:
+    """One dead backend must not take down ``resources/list``."""
+
+    def test_healthy_backend_resources_still_returned_when_peer_is_down(self, tmp_path_factory):
+        registry_dir = tmp_path_factory.mktemp("fail-soft-e2e-registry")
+        gw_port = _pick_free_port()
+
+        # Start the gateway-owning backend first.
+        _server_a, handle_a = _make_backend("maya", registry_dir, gw_port)
+        time.sleep(0.3)
+        if not handle_a.is_gateway:
+            handle_a.shutdown()
+            pytest.skip("gateway port contention — fail-soft test")
+
+        # Start a second backend, then tear it down so its row is still
+        # in the registry (until stale/port-probe eviction) but its
+        # port is closed.
+        _server_b, handle_b = _make_backend("blender", registry_dir, gw_port)
+        time.sleep(2.2)  # let the gateway see B
+        handle_b.shutdown()
+        # Don't wait long enough for the gateway's periodic port-probe
+        # to evict — we want B still "listed but unreachable" so the
+        # fan-out actually hits a closed port and the gateway decides
+        # whether to fail-soft.
+        time.sleep(0.3)
+
+        gw_url = f"http://127.0.0.1:{gw_port}/mcp"
+        try:
+            resp = _post_mcp(gw_url, "resources/list")
+            assert "error" not in resp, f"one dead backend must not surface a JSON-RPC error: {resp}"
+            # At minimum, the call returned without a JSON-RPC-level
+            # error and with a resources array. That's the fail-soft
+            # contract — the gateway swallowed the dead backend's
+            # transport error, warned, and still responded.
+            assert "resources" in resp["result"]
+        finally:
+            with contextlib.suppress(Exception):
+                handle_a.shutdown()


### PR DESCRIPTION
Closes #732.

## Summary

Make the gateway a faithful MCP aggregator for **resources**, matching what it already does for tools. Backend-contributed resources (`scene://current`, `capture://current_window`, `audit://recent`, `output://…`, `artefact://…`, and any future adapter-contributed scheme) now flow through the gateway end-to-end, with URIs namespaced by an 8-char instance id so multiple backends can expose the same scheme without collision.

## Wire-visible behaviour

- **`resources/list`** keeps the existing `dcc://<type>/<id>` admin pointers **and** merges every live backend's resources, each rewritten from `<scheme>://<rest>` to `<scheme>://<id8>/<rest>`.
- **`resources/read`** accepts the prefixed form, strips the id8 segment, and forwards the read to the owning backend. The raw result is returned unchanged so `contents[].blob` for `image/png` round-trips byte-for-byte.
- **`resources/subscribe` / `resources/unsubscribe`** are forwarded to the owning backend. The per-backend SSE subscriber loop (#320) grew a `notifications/resources/updated` branch that rewrites `params.uri` back to the client-visible prefixed form and pushes the frame onto every subscribing client's SSE sink.
- **Resources fingerprint watcher** — a new task in `tasks.rs` mirrors the existing tools watcher: polls every live backend's `resources/list` on a 3 s cadence and broadcasts one `notifications/resources/list_changed` when the aggregated set mutates.

## Fail-soft

Identical contract to `tools/list`: an unreachable backend contributes zero entries and emits a WARN, healthy backends' resources are still returned, no 500.

## New modules / helpers

- `namespace::resource_uri` — `encode_resource_uri` / `decode_resource_uri`.
- `aggregator::resources` — `aggregate_resources_list`, `compute_resources_fingerprint_with_own`.
- `sse_subscriber::resource_subs` — `bind_resource_subscription`, `unbind_resource_subscription`, `dispatch_resource_updated`, `forget_client_resource_subs`.
- `backend_client::{try_fetch_resources, fetch_resources, read_resource, subscribe_resource}` — fail-soft resources counterparts of the tools helpers.

## Tests

Added unit + integration tests across every new surface:
- namespace round-trip + rejection of admin pointers / malformed ids
- backend_client: happy path, fail-soft error, blob byte preservation, subscribe vs unsubscribe method routing
- aggregator: two-backend merge with prefix assertion, plus fail-soft when one backend's port is dead
- sse_subscriber: `dispatch_resource_updated` rewrites `params.uri` per subscriber; `forget_client` drops resource subscriptions alongside job routes

Full workspace `cargo nextest run --workspace` (2037 tests) + workspace clippy + fmt all green. `vx just preflight` flow verified.

## Notes for reviewers

- Resource *write* operations are not in the MCP spec and are not implemented.
- Parallel work with #731 (prompts aggregation) touches the same files (`mcp_impl.rs`, `backend_client.rs`, `tasks.rs`, `aggregator/`). Scope was kept tight (new match arms, new modules under separate file names) so the rebase at merge time should be mechanical — no shared helper extraction was needed because the existing `instance_short` / `is_instance_prefix` in `namespace::constants` already cover what both PRs need.
- `dcc://<type>/<id>` admin-pointer resources are retained as an admin affordance; the new forwarded resources are additive.