### PR TITLE
feat(http): expose ResourceRegistry mutating API to Python (#730)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,7 @@
 | Full-screen capture | `Capturer.new_auto().capture()` |
 | Single-window capture | `Capturer.new_window_auto().capture_window(...)` |
 | Capture DCC output streams | `OutputCapture` — stdout/stderr/script-editor as `output://` resource |
+| Register a custom DCC resource | `server.resources().register_producer("maya-cmds://", cb)` — also `set_scene({...})`, `notify_updated(uri)`, `register_output_buffer(capture)` (#730) |
 | Cooperative cancellation (MCP request) | `check_cancelled()` in long-running skill scripts |
 | Cooperative cancellation (DCC dispatcher + MCP) | `check_dcc_cancelled()` — combines MCP token + per-job `JobHandle` (#522) |
 | Detect a misconfigured GUI binary as `DCC_MCP_PYTHON_EXECUTABLE` | `is_gui_executable(path)` → `GuiExecutableHint(dcc_kind, recommended_replacement)` (#524) |

--- a/crates/dcc-mcp-http/Cargo.toml
+++ b/crates/dcc-mcp-http/Cargo.toml
@@ -78,6 +78,11 @@ axum-test = "20"
 rstest = "0.26"
 tempfile = "3"
 dcc-mcp-sandbox = { path = "../dcc-mcp-sandbox" }
+# Enable `auto-initialize` only during testing so the in-crate Rust
+# tests that exercise PyO3 surface (e.g. `python::resources_handle`
+# issue #730) can spin up an embedded Python interpreter automatically.
+# Production wheels do NOT pull this in.
+pyo3 = { workspace = true, features = ["auto-initialize"] }
 
 [features]
 default = []

--- a/crates/dcc-mcp-http/src/python/bridge.rs
+++ b/crates/dcc-mcp-http/src/python/bridge.rs
@@ -256,6 +256,8 @@ pub fn register_classes(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<super::PyReadinessProbe>()?;
     // Dynamic tools + output capture (issues #462, #461)
     super::output_dynamic::register(m)?;
+    // ResourceRegistry PyO3 handle (issue #730)
+    super::resources_handle::register(m)?;
     m.add_function(wrap_pyfunction!(py_create_skill_server, m)?)?;
     m.add_function(wrap_pyfunction!(py_get_bridge_context, m)?)?;
     m.add_function(wrap_pyfunction!(py_register_bridge, m)?)?;
@@ -369,6 +371,7 @@ pub fn py_create_skill_server(
         version: cfg.dcc_version.clone(),
         ..Default::default()
     }));
+    let resources = crate::server::build_resource_registry(&cfg);
     Ok(PyMcpHttpServer {
         registry: reg,
         dispatcher,
@@ -376,6 +379,7 @@ pub fn py_create_skill_server(
         config: cfg,
         runtime: Arc::new(runtime),
         live_meta,
+        resources,
         attached_executor: parking_lot::Mutex::new(None),
         readiness_probe: parking_lot::Mutex::new(None),
     })

--- a/crates/dcc-mcp-http/src/python/mod.rs
+++ b/crates/dcc-mcp-http/src/python/mod.rs
@@ -4,6 +4,7 @@ pub mod bridge;
 pub mod config;
 pub mod output_dynamic;
 pub mod readiness;
+pub mod resources_handle;
 pub mod server;
 pub mod skill_server;
 pub mod workspace;
@@ -15,6 +16,7 @@ pub use bridge::{
 pub use config::PyMcpHttpConfig;
 pub use output_dynamic::{PyOutputCapture, PyToolSpec};
 pub use readiness::PyReadinessProbe;
+pub use resources_handle::PyResourceHandle;
 pub use server::PyServerHandle;
 pub use skill_server::PyMcpHttpServer;
 pub use workspace::PyWorkspaceRoots;

--- a/crates/dcc-mcp-http/src/python/output_dynamic.rs
+++ b/crates/dcc-mcp-http/src/python/output_dynamic.rs
@@ -215,7 +215,7 @@ fn json_value_to_py<'py>(py: Python<'py>, v: &serde_json::Value) -> PyResult<Bou
 ///     from dcc_mcp_core import McpHttpServer, McpHttpConfig
 ///     registry = ...
 ///     server = McpHttpServer(registry, McpHttpConfig(port=8765))
-///     server.resources().register_output_buffer(capture._buffer)
+///     server.resources().register_output_buffer(capture)
 ///     handle = server.start()
 #[pyclass(name = "OutputCapture")]
 pub struct PyOutputCapture {

--- a/crates/dcc-mcp-http/src/python/resources_handle.rs
+++ b/crates/dcc-mcp-http/src/python/resources_handle.rs
@@ -1,0 +1,583 @@
+//! PyO3 binding for [`crate::resources::ResourceRegistry`] (issue #730).
+//!
+//! Exposes the mutating surface of the Rust-side `ResourceRegistry` to
+//! Python adapters embedding `dcc-mcp-core` via PyO3. Without this
+//! binding, embedders (`dcc-mcp-maya`, Blender, Houdini, ...) could not
+//! push scene snapshots, register custom producers, wire an
+//! `OutputBuffer`, or emit `resources/updated` for URIs they own — even
+//! though the Rust API fully supports all of this.
+//!
+//! # Surface
+//!
+//! Obtained via [`crate::python::PyMcpHttpServer::resources`]:
+//!
+//! ```python
+//! server = McpHttpServer(registry, McpHttpConfig(port=8765))
+//! handle = server.resources()
+//!
+//! handle.set_scene({"nodes": [...]})              # scene://current
+//! handle.notify_updated("scene://current")        # kick SSE subscribers
+//! handle.register_output_buffer(capture)          # output://instance/...
+//! handle.register_producer(                       # any-scheme producer
+//!     "docs://",
+//!     lambda uri: {"mimeType": "text/markdown", "text": "..."},
+//! )
+//! ```
+
+use std::sync::Arc;
+
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use serde_json::Value;
+
+use crate::protocol::McpResource;
+use crate::resources::{
+    ProducerContent, ResourceError, ResourceProducer, ResourceRegistry, ResourceResult,
+};
+
+// ── PythonProducer ────────────────────────────────────────────────────────────
+
+/// [`ResourceProducer`] backed by a Python callable.
+///
+/// The callable is invoked from a Tokio worker thread; thread-affinity
+/// (e.g. running the body on the DCC main thread) is the Python caller's
+/// responsibility — this struct is only the bridge.
+///
+/// Expected return shape from the callable:
+///
+/// - `{"mimeType": str, "text": str}` → [`ProducerContent::Text`]
+/// - `{"mimeType": str, "blob": bytes}` → [`ProducerContent::Blob`]
+///
+/// `mimeType` defaults to `"application/octet-stream"` for blobs and
+/// `"text/plain"` for text if the key is missing.
+pub(crate) struct PythonProducer {
+    scheme: String,
+    uri_prefix: String,
+    callable: Py<PyAny>,
+}
+
+impl PythonProducer {
+    /// Build a producer for `scheme_or_uri`.
+    ///
+    /// `"docs"`, `"docs:"`, `"docs://"`, or `"docs://anything"` all yield
+    /// the scheme `"docs"`. The original string is kept as the list URI
+    /// prefix so embedders can pin a producer to a specific URI.
+    fn new(scheme_or_uri: &str, callable: Py<PyAny>) -> Self {
+        let scheme = extract_scheme(scheme_or_uri);
+        let uri_prefix = if scheme_or_uri.contains(':') {
+            scheme_or_uri.to_string()
+        } else {
+            format!("{}://", scheme)
+        };
+        Self {
+            scheme,
+            uri_prefix,
+            callable,
+        }
+    }
+}
+
+fn extract_scheme(s: &str) -> String {
+    match s.find(':') {
+        Some(idx) => s[..idx].to_string(),
+        None => s.to_string(),
+    }
+}
+
+impl ResourceProducer for PythonProducer {
+    fn scheme(&self) -> &str {
+        &self.scheme
+    }
+
+    fn list(&self) -> Vec<McpResource> {
+        // The callable is the source of truth for reads, but `resources/list`
+        // must be non-blocking and deterministic — surface a single entry
+        // matching the registered prefix so agents can discover the scheme
+        // without having to speculatively invoke the callable.
+        vec![McpResource {
+            uri: self.uri_prefix.clone(),
+            name: format!("Python-provided resource ({})", self.scheme),
+            description: Some(format!(
+                "Resources served by a Python-registered producer for scheme `{}://`.",
+                self.scheme
+            )),
+            mime_type: None,
+        }]
+    }
+
+    fn read(&self, uri: &str) -> ResourceResult<ProducerContent> {
+        Python::attach(|py| {
+            let result = self
+                .callable
+                .call1(py, (uri,))
+                .map_err(|e| ResourceError::Read(format!("python producer error: {e}")))?;
+            let bound = result.bind(py);
+            decode_producer_return(bound, uri)
+        })
+    }
+}
+
+/// Turn the Python callable's return value into a [`ProducerContent`].
+///
+/// Extracted so the pure-decoding logic can be unit-tested without
+/// going through the `ResourceProducer` trait.
+fn decode_producer_return(bound: &Bound<'_, PyAny>, uri: &str) -> ResourceResult<ProducerContent> {
+    let dict = bound
+        .cast::<PyDict>()
+        .map_err(|e| ResourceError::Read(format!("producer return must be a dict: {e}")))?;
+
+    // Prefer blob over text so binary producers that also set `text=""`
+    // as a placeholder don't accidentally become text content.
+    if let Some(blob_any) = dict
+        .get_item("blob")
+        .map_err(|e| ResourceError::Read(format!("dict lookup: {e}")))?
+    {
+        let bytes: Vec<u8> = blob_any
+            .extract()
+            .map_err(|e| ResourceError::Read(format!("producer 'blob' must be bytes-like: {e}")))?;
+        let mime_type = dict
+            .get_item("mimeType")
+            .map_err(|e| ResourceError::Read(format!("dict lookup: {e}")))?
+            .map(|v| v.extract::<String>())
+            .transpose()
+            .map_err(|e| ResourceError::Read(format!("producer 'mimeType' must be str: {e}")))?
+            .unwrap_or_else(|| "application/octet-stream".to_string());
+        return Ok(ProducerContent::Blob {
+            uri: uri.to_string(),
+            mime_type,
+            bytes,
+        });
+    }
+
+    let text_any = dict
+        .get_item("text")
+        .map_err(|e| ResourceError::Read(format!("dict lookup: {e}")))?
+        .ok_or_else(|| {
+            ResourceError::Read("producer return must contain either 'text' or 'blob'".to_string())
+        })?;
+    let text: String = text_any
+        .extract()
+        .map_err(|e| ResourceError::Read(format!("producer 'text' must be str: {e}")))?;
+    let mime_type = dict
+        .get_item("mimeType")
+        .map_err(|e| ResourceError::Read(format!("dict lookup: {e}")))?
+        .map(|v| v.extract::<String>())
+        .transpose()
+        .map_err(|e| ResourceError::Read(format!("producer 'mimeType' must be str: {e}")))?
+        .unwrap_or_else(|| "text/plain".to_string());
+    Ok(ProducerContent::Text {
+        uri: uri.to_string(),
+        mime_type,
+        text,
+    })
+}
+
+// ── PyResourceHandle ──────────────────────────────────────────────────────────
+
+/// Python-facing handle to the server's [`ResourceRegistry`].
+///
+/// Obtained via [`crate::python::PyMcpHttpServer::resources`]. The
+/// underlying registry is shared with the running server, so mutations
+/// take effect immediately — `resources/list` and `resources/read`
+/// reflect new producers, scene snapshots, and output buffers without
+/// requiring a restart.
+#[pyclass(name = "ResourceHandle", skip_from_py_object)]
+pub struct PyResourceHandle {
+    pub(crate) inner: ResourceRegistry,
+}
+
+impl PyResourceHandle {
+    pub(crate) fn new(registry: ResourceRegistry) -> Self {
+        Self { inner: registry }
+    }
+}
+
+#[pymethods]
+impl PyResourceHandle {
+    /// Publish a new scene snapshot for ``scene://current``.
+    ///
+    /// Fires ``notifications/resources/updated`` for subscribed clients.
+    ///
+    /// Args:
+    ///     value: A ``dict``/``list``/scalar that is JSON-serialisable,
+    ///         or a pre-serialised JSON ``str``. Strings are parsed to
+    ///         preserve structured content — use
+    ///         ``handle.set_scene({"raw": the_string})`` to publish a
+    ///         literal string payload.
+    ///
+    /// Raises:
+    ///     ValueError: If ``value`` cannot be converted to JSON.
+    fn set_scene(&self, py: Python<'_>, value: Py<PyAny>) -> PyResult<()> {
+        let bound = value.bind(py);
+        let json: Value = if let Ok(s) = bound.extract::<String>() {
+            // Accept pre-serialised JSON for callers that already
+            // hold a string — common when the adapter is forwarding
+            // bytes from a scene-export tool.
+            serde_json::from_str(&s).map_err(|e| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "set_scene: string payload must be valid JSON: {e}"
+                ))
+            })?
+        } else {
+            dcc_mcp_pybridge::py_json::py_any_to_json_value(bound).map_err(|e| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "set_scene: value is not JSON-serialisable: {e}"
+                ))
+            })?
+        };
+        self.inner.set_scene(json);
+        Ok(())
+    }
+
+    /// Emit ``notifications/resources/updated`` for ``uri``.
+    ///
+    /// Use this when the adapter has already mutated some state that
+    /// backs a custom producer and just needs to kick SSE subscribers.
+    fn notify_updated(&self, uri: &str) {
+        self.inner.notify_updated(uri);
+    }
+
+    /// Register an :class:`OutputCapture`'s underlying buffer as an
+    /// ``output://instance/{instance_id}`` resource (issue #461).
+    ///
+    /// After this call, ``resources/list`` advertises the buffer and
+    /// ``resources/read output://instance/{instance_id}`` returns the
+    /// buffered lines.
+    ///
+    /// Args:
+    ///     capture: An :class:`OutputCapture` instance. The capture
+    ///         continues to own its buffer — the registry keeps an
+    ///         ``Arc``-cloned reference so push/drain on the Python
+    ///         side remain visible to MCP clients.
+    fn register_output_buffer(&self, capture: PyRef<'_, super::PyOutputCapture>) {
+        self.inner
+            .register_output_buffer(capture.inner.buffer.clone());
+    }
+
+    /// Register a Python callable as a producer for ``scheme_or_uri``.
+    ///
+    /// The callable is invoked on a Tokio worker thread when an MCP
+    /// client calls ``resources/read`` for a URI whose scheme matches.
+    /// Thread-affinity (e.g. running the body on the DCC main thread)
+    /// is the caller's responsibility — this API is only the bridge.
+    ///
+    /// Args:
+    ///     scheme_or_uri: Either a bare scheme (``"maya-cmds"``) or a
+    ///         full URI prefix (``"maya-cmds://"``). The value is used
+    ///         both to dispatch reads by scheme and as the ``uri``
+    ///         field in ``resources/list``.
+    ///     callable: A Python callable of signature ``(uri: str) -> dict``.
+    ///         The returned dict must contain either
+    ///         ``{"mimeType": str, "text": str}`` or
+    ///         ``{"mimeType": str, "blob": bytes}``. ``mimeType`` is
+    ///         optional and defaults to ``"text/plain"`` or
+    ///         ``"application/octet-stream"``.
+    ///
+    /// Raises:
+    ///     TypeError: If ``callable`` is not callable.
+    ///     ValueError: If ``scheme_or_uri`` is empty.
+    fn register_producer(
+        &self,
+        py: Python<'_>,
+        scheme_or_uri: &str,
+        callable: Py<PyAny>,
+    ) -> PyResult<()> {
+        if scheme_or_uri.is_empty() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "scheme_or_uri must not be empty",
+            ));
+        }
+        if !callable.bind(py).is_callable() {
+            return Err(pyo3::exceptions::PyTypeError::new_err(
+                "callable must be callable",
+            ));
+        }
+        let producer = Arc::new(PythonProducer::new(scheme_or_uri, callable));
+        self.inner.add_producer(producer);
+        Ok(())
+    }
+
+    fn __repr__(&self) -> String {
+        format!("ResourceHandle(enabled={})", self.inner.is_enabled())
+    }
+}
+
+// ── Module registration ───────────────────────────────────────────────────────
+
+pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<PyResourceHandle>()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pyo3::types::{PyBytes, PyDict};
+
+    #[test]
+    fn extract_scheme_handles_uri_and_bare_scheme() {
+        assert_eq!(extract_scheme("docs"), "docs");
+        assert_eq!(extract_scheme("docs:"), "docs");
+        assert_eq!(extract_scheme("docs://"), "docs");
+        assert_eq!(extract_scheme("docs://foo/bar"), "docs");
+    }
+
+    #[test]
+    fn python_producer_new_uri_prefix() {
+        Python::attach(|py| {
+            let cb = py
+                .eval(
+                    c"lambda uri: {'mimeType': 'text/plain', 'text': uri}",
+                    None,
+                    None,
+                )
+                .unwrap()
+                .unbind();
+            let prod = PythonProducer::new("docs://custom/foo", cb);
+            assert_eq!(prod.scheme(), "docs");
+            let listed = prod.list();
+            assert_eq!(listed.len(), 1);
+            assert_eq!(listed[0].uri, "docs://custom/foo");
+        });
+    }
+
+    #[test]
+    fn python_producer_new_bare_scheme_prefix() {
+        Python::attach(|py| {
+            let cb = py
+                .eval(c"lambda uri: {'text': 'x'}", None, None)
+                .unwrap()
+                .unbind();
+            let prod = PythonProducer::new("maya-cmds", cb);
+            assert_eq!(prod.scheme(), "maya-cmds");
+            assert_eq!(prod.list()[0].uri, "maya-cmds://");
+        });
+    }
+
+    #[test]
+    fn decode_text_uses_default_mime() {
+        Python::attach(|py| {
+            let d = PyDict::new(py);
+            d.set_item("text", "hello").unwrap();
+            let got = decode_producer_return(d.as_any(), "foo://x").unwrap();
+            match got {
+                ProducerContent::Text {
+                    uri,
+                    mime_type,
+                    text,
+                } => {
+                    assert_eq!(uri, "foo://x");
+                    assert_eq!(mime_type, "text/plain");
+                    assert_eq!(text, "hello");
+                }
+                _ => panic!("expected text"),
+            }
+        });
+    }
+
+    #[test]
+    fn decode_blob_prefers_blob_over_text() {
+        Python::attach(|py| {
+            let d = PyDict::new(py);
+            d.set_item("mimeType", "image/png").unwrap();
+            d.set_item("blob", PyBytes::new(py, b"\x89PNG\x0d\x0a"))
+                .unwrap();
+            d.set_item("text", "").unwrap();
+            let got = decode_producer_return(d.as_any(), "img://1").unwrap();
+            match got {
+                ProducerContent::Blob {
+                    uri,
+                    mime_type,
+                    bytes,
+                } => {
+                    assert_eq!(uri, "img://1");
+                    assert_eq!(mime_type, "image/png");
+                    assert_eq!(bytes, b"\x89PNG\x0d\x0a");
+                }
+                _ => panic!("expected blob"),
+            }
+        });
+    }
+
+    #[test]
+    fn decode_missing_text_and_blob_errors() {
+        Python::attach(|py| {
+            let d = PyDict::new(py);
+            d.set_item("mimeType", "text/plain").unwrap();
+            let result = decode_producer_return(d.as_any(), "foo://x");
+            assert!(
+                result.is_err(),
+                "expected error, got {:?}",
+                result.ok().map(|_| "content")
+            );
+            if let Err(e) = result {
+                assert!(matches!(e, ResourceError::Read(_)));
+            }
+        });
+    }
+
+    // ── End-to-end: PyResourceHandle wired to a live ResourceRegistry ─────────
+
+    fn enabled_registry() -> ResourceRegistry {
+        ResourceRegistry::new(true, false)
+    }
+
+    #[test]
+    fn set_scene_roundtrips_through_scene_current() {
+        Python::attach(|py| {
+            let registry = enabled_registry();
+            let handle = PyResourceHandle::new(registry.clone());
+
+            let scene = PyDict::new(py);
+            scene
+                .set_item("nodes", pyo3::types::PyList::empty(py))
+                .unwrap();
+            scene.set_item("frame", 42i64).unwrap();
+            handle.set_scene(py, scene.into_any().unbind()).unwrap();
+
+            let read = registry.read("scene://current").expect("scene read");
+            let blob = &read.contents[0];
+            let text = blob.text.as_deref().expect("scene is text");
+            // The SceneProducer round-trips via serde_json; key presence and
+            // integer value are the stable invariants here.
+            assert!(text.contains("\"nodes\""));
+            assert!(text.contains("\"frame\""));
+            assert!(text.contains("42"));
+        });
+    }
+
+    #[test]
+    fn set_scene_accepts_pre_serialised_json_string() {
+        Python::attach(|py| {
+            let registry = enabled_registry();
+            let handle = PyResourceHandle::new(registry.clone());
+
+            let payload = "{\"count\":7}";
+            handle
+                .set_scene(py, payload.into_pyobject(py).unwrap().into_any().unbind())
+                .unwrap();
+
+            let read = registry.read("scene://current").unwrap();
+            let text = read.contents[0].text.as_deref().unwrap();
+            assert!(text.contains("\"count\""));
+            assert!(text.contains("7"));
+        });
+    }
+
+    #[test]
+    fn register_producer_lists_and_invokes_callable() {
+        Python::attach(|py| {
+            let registry = enabled_registry();
+            let handle = PyResourceHandle::new(registry.clone());
+
+            let cb = py
+                .eval(
+                    c"lambda uri: {'mimeType': 'text/plain', 'text': 'echo:' + uri}",
+                    None,
+                    None,
+                )
+                .unwrap()
+                .unbind();
+            handle.register_producer(py, "test-scheme://", cb).unwrap();
+
+            let listed = registry.list();
+            assert!(
+                listed.iter().any(|r| r.uri == "test-scheme://"),
+                "test-scheme producer should surface in resources/list"
+            );
+
+            let read = registry.read("test-scheme://hello").unwrap();
+            let text = read.contents[0].text.as_deref().unwrap();
+            assert_eq!(text, "echo:test-scheme://hello");
+        });
+    }
+
+    #[test]
+    fn register_producer_rejects_empty_scheme() {
+        Python::attach(|py| {
+            let registry = enabled_registry();
+            let handle = PyResourceHandle::new(registry);
+            let cb = py
+                .eval(c"lambda uri: {'text': ''}", None, None)
+                .unwrap()
+                .unbind();
+            let err = handle.register_producer(py, "", cb).unwrap_err();
+            assert!(err.is_instance_of::<pyo3::exceptions::PyValueError>(py));
+        });
+    }
+
+    #[test]
+    fn register_producer_rejects_non_callable() {
+        Python::attach(|py| {
+            let registry = enabled_registry();
+            let handle = PyResourceHandle::new(registry);
+            let not_callable: Py<PyAny> = 42i64.into_pyobject(py).unwrap().into_any().unbind();
+            let err = handle
+                .register_producer(py, "x://", not_callable)
+                .unwrap_err();
+            assert!(err.is_instance_of::<pyo3::exceptions::PyTypeError>(py));
+        });
+    }
+
+    #[test]
+    fn register_output_buffer_surfaces_instance_uri() {
+        Python::attach(|py| {
+            let registry = enabled_registry();
+            let handle = PyResourceHandle::new(registry.clone());
+
+            // Build a PyOutputCapture directly — its `new` is pub(crate),
+            // which is visible from within this crate's test module.
+            let inner = crate::output::OutputCapture::with_capacity("unit-test-inst", 1000);
+            inner.push("stdout", "hello");
+            let capture = super::super::output_dynamic::PyOutputCapture { inner };
+            // PyO3 method receives a `PyRef<PyOutputCapture>` — mirror that
+            // by registering the class and round-tripping through a Py<_>.
+            let py_capture: Py<super::super::output_dynamic::PyOutputCapture> =
+                Py::new(py, capture).unwrap();
+            handle.register_output_buffer(py_capture.borrow(py));
+
+            let listed = registry.list();
+            assert!(
+                listed
+                    .iter()
+                    .any(|r| r.uri == "output://instance/unit-test-inst"),
+                "output:// producer should advertise instance URI"
+            );
+            let read = registry.read("output://instance/unit-test-inst").unwrap();
+            let text = read.contents[0].text.as_deref().unwrap();
+            assert!(text.contains("hello"));
+        });
+    }
+
+    #[test]
+    fn notify_updated_is_noop_without_subscribers() {
+        let registry = enabled_registry();
+        let handle = PyResourceHandle::new(registry);
+        // Sanity: must not panic even though no SSE session is listening.
+        handle.notify_updated("scene://current");
+    }
+
+    #[test]
+    fn builtin_producers_still_work_after_custom_registration() {
+        // Regression for issue #730 — adding a Python producer must not
+        // shadow or break the built-in `scene://`, `capture://`,
+        // `audit://`, `artefact://` producers that `ResourceRegistry::new`
+        // wires up.
+        Python::attach(|py| {
+            let registry = enabled_registry();
+            let handle = PyResourceHandle::new(registry.clone());
+            let cb = py
+                .eval(c"lambda uri: {'text': 'x'}", None, None)
+                .unwrap()
+                .unbind();
+            handle.register_producer(py, "custom://", cb).unwrap();
+
+            let listed = registry.list();
+            let uris: Vec<_> = listed.iter().map(|r| r.uri.as_str()).collect();
+            assert!(uris.iter().any(|u| u.starts_with("scene://")));
+            assert!(uris.iter().any(|u| u.starts_with("capture://")));
+            assert!(uris.iter().any(|u| u.starts_with("audit://")));
+            assert!(uris.iter().any(|u| u.starts_with("custom://")));
+        });
+    }
+}

--- a/crates/dcc-mcp-http/src/python/skill_server.rs
+++ b/crates/dcc-mcp-http/src/python/skill_server.rs
@@ -28,6 +28,13 @@ pub struct PyMcpHttpServer {
     /// Shared live metadata — written by Python via `update_scene()` /
     /// `update_gateway_metadata()`; propagated to FileRegistry each heartbeat.
     pub(crate) live_meta: Arc<RwLock<LiveMetaInner>>,
+    /// Shared [`crate::resources::ResourceRegistry`] (issue #730).
+    ///
+    /// Built at construction time using the same
+    /// [`crate::server::build_resource_registry`] the server would
+    /// have used internally, so `server.resources()` returns the same
+    /// registry that backs `/mcp` both before and after `start()`.
+    pub(crate) resources: crate::resources::ResourceRegistry,
     /// Optional DCC main-thread executor attached via
     /// [`PyMcpHttpServer::attach_dispatcher`]. Consumed exactly once
     /// by [`PyMcpHttpServer::start`]; further `attach_dispatcher`
@@ -69,6 +76,11 @@ impl PyMcpHttpServer {
             version: cfg.dcc_version.clone(),
             ..Default::default()
         }));
+        // Issue #730 — build the ResourceRegistry up-front and share it
+        // between this Python handle and the inner McpHttpServer when
+        // start() runs. Using the canonical `build_resource_registry`
+        // keeps artefact-store wiring consistent with the Rust path.
+        let resources = crate::server::build_resource_registry(&cfg);
         Ok(Self {
             registry: reg,
             dispatcher,
@@ -76,6 +88,7 @@ impl PyMcpHttpServer {
             config: cfg,
             runtime: Arc::new(runtime),
             live_meta,
+            resources,
             attached_executor: parking_lot::Mutex::new(None),
             readiness_probe: parking_lot::Mutex::new(None),
         })
@@ -144,7 +157,8 @@ impl PyMcpHttpServer {
             self.config.clone(),
         )
         .with_dispatcher(self.dispatcher.clone())
-        .with_live_meta(self.live_meta.clone());
+        .with_live_meta(self.live_meta.clone())
+        .with_resources(self.resources.clone());
         // If a dispatcher was attached, drain it into the server's
         // main-thread executor slot. Consumed once — further
         // attach_dispatcher calls after start will be rejected by
@@ -419,6 +433,28 @@ impl PyMcpHttpServer {
     #[getter]
     fn registry(&self) -> ActionRegistry {
         (*self.registry).clone()
+    }
+
+    /// Access the server's :class:`ResourceHandle` for pushing scene
+    /// snapshots, registering custom producers, and wiring output
+    /// buffers (issue #730).
+    ///
+    /// The returned handle is a thin wrapper around the shared
+    /// [`crate::resources::ResourceRegistry`]: mutations take effect
+    /// immediately and are reflected in ``resources/list`` /
+    /// ``resources/read`` both before and after :meth:`start`.
+    ///
+    /// Example::
+    ///
+    ///     server = McpHttpServer(registry, McpHttpConfig(port=8765))
+    ///     server.resources().set_scene({"nodes": []})
+    ///     server.resources().register_producer(
+    ///         "maya-cmds://",
+    ///         lambda uri: {"mimeType": "text/plain", "text": "ls -l"},
+    ///     )
+    ///     handle = server.start()
+    fn resources(&self) -> super::resources_handle::PyResourceHandle {
+        super::resources_handle::PyResourceHandle::new(self.resources.clone())
     }
 
     /// Access the server's SkillCatalog for progressive skill loading.

--- a/crates/dcc-mcp-http/src/server/mod.rs
+++ b/crates/dcc-mcp-http/src/server/mod.rs
@@ -114,7 +114,9 @@ impl McpServerHandle {
 /// temp dir when no registry dir is configured). Wiring the Python
 /// helpers to the same store is the caller's responsibility — see
 /// `dcc_mcp_artefact::python::set_default_store` for that path.
-fn build_resource_registry(config: &McpHttpConfig) -> crate::resources::ResourceRegistry {
+pub(crate) fn build_resource_registry(
+    config: &McpHttpConfig,
+) -> crate::resources::ResourceRegistry {
     if config.enable_artefact_resources {
         let root = config
             .registry_dir
@@ -300,6 +302,21 @@ impl McpHttpServer {
     /// returned `PyServerHandle`).
     pub fn with_live_meta(mut self, live_meta: LiveMeta) -> Self {
         self.live_meta = live_meta;
+        self
+    }
+
+    /// Replace the [`ResourceRegistry`](crate::resources::ResourceRegistry)
+    /// with a caller-supplied one (issue #730).
+    ///
+    /// Use this when the embedding layer needs to retain a handle to
+    /// the registry so it can push scene snapshots, register custom
+    /// producers, or wire an `OutputBuffer` **after** the server has
+    /// been constructed. The canonical caller is the PyO3 binding in
+    /// `crate::python::skill_server`, where `PyMcpHttpServer` pre-builds
+    /// the registry at construction time so `server.resources()` can
+    /// return the same instance both before and after `start()`.
+    pub fn with_resources(mut self, resources: crate::resources::ResourceRegistry) -> Self {
+        self.resources = resources;
         self
     }
 

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -113,6 +113,14 @@ try:
 except ImportError:  # pragma: no cover — pre-built wheel
     OutputCapture = None  # type: ignore[assignment,misc]
 
+# ResourceRegistry PyO3 handle — let adapters push scene snapshots,
+# register custom producers, and wire output buffers (issue #730).
+# Only present after the wheel is rebuilt with the new dcc-mcp-http code.
+try:
+    from dcc_mcp_core._core import ResourceHandle  # type: ignore[attr-defined]
+except ImportError:  # pragma: no cover — pre-built wheel
+    ResourceHandle = None  # type: ignore[assignment,misc]
+
 from dcc_mcp_core._core import PromptArgument
 from dcc_mcp_core._core import PromptDefinition
 
@@ -650,6 +658,7 @@ __all__ = [
     "RenderOutput",
     "ResourceAnnotations",
     "ResourceDefinition",
+    "ResourceHandle",
     "ResourceTemplateDefinition",
     "ResponseShapePolicy",
     "RetryPolicy",

--- a/python/dcc_mcp_core/docs_resources.py
+++ b/python/dcc_mcp_core/docs_resources.py
@@ -436,15 +436,16 @@ def register_docs_resource(
     """Register a single ``docs://`` resource on *server*.
 
     The resource is added to the in-process docs registry and served via
-    ``resources/list`` + ``resources/read``.
+    ``resources/list`` + ``resources/read`` by pushing a Python producer
+    into the shared ``ResourceRegistry`` (issue #730).
 
     Parameters
     ----------
     server:
-        An ``McpHttpServer`` or compatible object exposing
-        ``server.add_docs_resource(uri, name, description, content, mime)``.
-        If the method is not present, this function logs a warning and returns
-        gracefully so callers do not need to guard against older server versions.
+        An ``McpHttpServer`` exposing ``server.resources()`` (issue #730).
+        If ``server.resources`` is unavailable (older wheel), this function
+        logs a debug message and returns gracefully so callers do not need
+        to guard against older server versions.
     uri:
         Full URI string starting with ``docs://``.
     name:
@@ -461,12 +462,52 @@ def register_docs_resource(
         logger.warning("register_docs_resource: URI must start with 'docs://' — got %r", uri)
         return
     _DOCS[uri] = {"name": name, "description": description, "mime": mime, "content": content}
-    try:
-        server.add_docs_resource(uri=uri, name=name, description=description, content=content, mime=mime)
-    except AttributeError:
-        logger.debug("register_docs_resource: server.add_docs_resource not available (Rust-side pending)")
-    except Exception as exc:
-        logger.warning("register_docs_resource: %s", exc)
+
+    # Prefer the new Rust-backed surface (issue #730). Fall back to the
+    # legacy ``server.add_docs_resource(...)`` method for hand-rolled
+    # fakes that predate the binding — test fixtures in this repo and
+    # downstream adapters still rely on the old API.
+    get_resources = getattr(server, "resources", None)
+    if callable(get_resources):
+        try:
+            handle = get_resources()
+        except Exception as exc:
+            logger.warning("register_docs_resource: server.resources() failed: %s", exc)
+            handle = None
+        register_producer = getattr(handle, "register_producer", None) if handle is not None else None
+        if register_producer is not None:
+
+            def _producer(_uri: str) -> dict[str, str]:
+                entry = _DOCS.get(_uri)
+                if entry is None:
+                    # The MCP reader already validated the scheme; unknown
+                    # path under docs:// means the caller asked for a URI
+                    # we don't know about. Return an empty body to keep
+                    # the surface honest without raising a hard error.
+                    return {"mimeType": "text/plain", "text": ""}
+                return {
+                    "mimeType": entry.get("mime", "text/markdown"),
+                    "text": entry["content"],
+                }
+
+            try:
+                register_producer(uri, _producer)
+            except Exception as exc:
+                logger.warning("register_docs_resource: register_producer failed: %s", exc)
+            return
+
+    add_docs_resource = getattr(server, "add_docs_resource", None)
+    if callable(add_docs_resource):
+        try:
+            add_docs_resource(uri=uri, name=name, description=description, content=content, mime=mime)
+        except Exception as exc:
+            logger.warning("register_docs_resource: add_docs_resource failed: %s", exc)
+        return
+
+    logger.debug(
+        "register_docs_resource: neither server.resources() nor server.add_docs_resource "
+        "available — rebuild the dcc-mcp-core wheel",
+    )
 
 
 def register_docs_resources_from_dir(

--- a/tests/test_docs_resources.py
+++ b/tests/test_docs_resources.py
@@ -128,9 +128,40 @@ def test_register_docs_server():
     server = MagicMock()
     register_docs_server(server)
 
-    # add_docs_resource should have been called for each built-in
+    # After issue #730 the shim routes each resource through
+    # ``server.resources().register_producer(uri, callable)`` — assert
+    # one call per built-in URI and that each URI is preserved.
     expected_count = len(get_builtin_docs_uris())
-    assert server.add_docs_resource.call_count == expected_count
+    handle = server.resources.return_value
+    assert handle.register_producer.call_count == expected_count
+    registered_uris = {call.args[0] for call in handle.register_producer.call_args_list}
+    assert registered_uris == set(get_builtin_docs_uris())
+
+
+def test_register_docs_resource_producer_returns_payload():
+    """Issue #730 — the callable handed to register_producer must return
+    ``{"mimeType": ..., "text": ...}`` so the Rust side can wrap it into
+    a ``ProducerContent::Text``.
+    """
+    from dcc_mcp_core.docs_resources import register_docs_resource
+
+    server = MagicMock()
+    register_docs_resource(
+        server,
+        uri="docs://custom/test-payload",
+        name="Payload Test",
+        description="Fixture for the producer callable round-trip.",
+        content="# Hello",
+        mime="text/markdown",
+    )
+
+    handle = server.resources.return_value
+    assert handle.register_producer.call_count == 1
+    args = handle.register_producer.call_args.args
+    assert args[0] == "docs://custom/test-payload"
+    callable_fn = args[1]
+    out = callable_fn("docs://custom/test-payload")
+    assert out == {"mimeType": "text/markdown", "text": "# Hello"}
 
 
 def test_importable_from_top_level():


### PR DESCRIPTION
Closes #730.

## Summary

`ResourceRegistry` was fully implemented on the Rust side but had no
mutating API bound to Python, so embedding DCC adapters
(`dcc-mcp-maya`, Blender, Houdini, …) could not push scene snapshots,
register custom producers, wire output buffers, or emit
`resources/updated` through the PyO3 surface. This PR adds that
surface and wires it end-to-end through `McpHttpServer`.

## What changed

### New PyO3 class `ResourceHandle` (`crates/dcc-mcp-http/src/python/resources_handle.rs`)

Obtained via `McpHttpServer.resources()`:

```python
server = McpHttpServer(registry, McpHttpConfig(port=8765))
handle = server.resources()

handle.set_scene({"nodes": [...]})              # scene://current
handle.notify_updated("scene://current")        # kick SSE subscribers
handle.register_output_buffer(capture)          # output://instance/...
handle.register_producer(                       # any-scheme producer
    "maya-cmds://",
    lambda uri: {"mimeType": "text/plain", "text": "..."},
)
```

The producer callable may return `{"mimeType", "text"}` or
`{"mimeType", "blob"}`; `blob` is preferred when both are present and
`mimeType` falls back to `text/plain` / `application/octet-stream`.

### `McpHttpServer::with_resources(registry)`

New builder so `PyMcpHttpServer` can pre-build its `ResourceRegistry`
via the canonical `build_resource_registry` (which handles
artefact-store wiring) and share one `Arc` with the Python handle and
the inner server. `server.resources()` now returns the same registry
**before** and **after** `start()`.

### Python shim fixes

- `python/dcc_mcp_core/docs_resources.py` — `register_docs_resource`
  is rewritten on top of `register_producer`, killing the
  `server.add_docs_resource(...) … except AttributeError` path with
  the `"Rust-side pending"` docstring lie. A legacy `add_docs_resource`
  fallback is kept so hand-rolled test fakes in downstream adapters
  don't break.
- `crates/dcc-mcp-http/src/python/output_dynamic.rs` — the PyO3
  doctest example now calls the real
  `server.resources().register_output_buffer(capture)` API instead of
  the previously compile-broken `capture._buffer` form.
- `python/dcc_mcp_core/__init__.py` — re-export `ResourceHandle`.
- `AGENTS.md` — new decision-table row pointing at
  `server.resources().register_producer(...)`.

## Tests

- 14 new Rust unit tests in `python::resources_handle` cover the
  decoder, scheme extraction, end-to-end `set_scene` roundtrip,
  `register_producer` list/read, `OutputBuffer` registration,
  error paths (empty scheme, non-callable, missing `text`/`blob`),
  and a regression guard ensuring built-in producers (`scene://`,
  `capture://`, `audit://`) still surface after a Python producer is
  added.
- 1 updated + 1 new Python test in `tests/test_docs_resources.py`
  for the new producer call path.
- `vx just preflight` passes locally (Rust checks + clippy + fmt +
  237 `dcc-mcp-http` lib tests + doctests).
- Full Python suite: 8882 passed, 69 skipped, 2 pre-existing flaky
  failures in `test_e2e_gateway_skill_load_sse` (confirmed failing
  on `main` without my changes).

## Build / feature flags

- `auto-initialize` is added to `dcc-mcp-http` **dev-dependencies**
  only so the new Rust tests can spin up an embedded Python; the
  production wheel does not pull this in.