### PR TITLE
test(gateway): Python + real-TCP E2E coverage for prompts aggregation (#731 follow-up)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,7 +713,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dcc-mcp-actions"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "dashmap",
  "dcc-mcp-models",
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-artefact"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "chrono",
  "hex",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-capture"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "image",
  "libc",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-core"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "dcc-mcp-actions",
  "dcc-mcp-artefact",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-gateway"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "axum",
  "chrono",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-host"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-http"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "axum",
  "axum-test",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-job"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "chrono",
  "dashmap",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-jsonrpc"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "serde",
  "serde_json",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-logging"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "dcc-mcp-paths",
  "parking_lot",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-models"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "dcc-mcp-naming",
  "dcc-mcp-pybridge",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-naming"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "pyo3",
  "pyo3-stub-gen",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-paths"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "dirs",
  "pyo3",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-process"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "dcc-mcp-models",
  "ipckit",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-protocols"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-pybridge"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "dcc-mcp-pybridge-derive",
  "pyo3",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-pybridge-derive"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-sandbox"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -1052,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-scheduler"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "axum",
  "bytes",
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-server"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "anyhow",
  "axum",
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-shm"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "ipckit",
  "libc",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-skill-rest"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "axum",
  "axum-test",
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-skills"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "dashmap",
  "dcc-mcp-actions",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-telemetry"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-transport"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "criterion",
  "dashmap",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-agent"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "dashmap",
  "dcc-mcp-tunnel-protocol",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-protocol"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "jsonwebtoken",
  "rmp-serde",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-relay"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "axum",
  "dashmap",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-usd"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "dcc-mcp-protocols",
  "pyo3",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-workflow"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "base64",
  "chrono",

--- a/crates/dcc-mcp-http/tests/http.rs
+++ b/crates/dcc-mcp-http/tests/http.rs
@@ -28,6 +28,9 @@ mod gateway_dynamic_capabilities;
 #[path = "http/gateway_passthrough.rs"]
 mod gateway_passthrough;
 
+#[path = "http/gateway_prompts_e2e.rs"]
+mod gateway_prompts_e2e;
+
 #[path = "http/gateway_reachability.rs"]
 mod gateway_reachability;
 

--- a/crates/dcc-mcp-http/tests/http/gateway_prompts_e2e.rs
+++ b/crates/dcc-mcp-http/tests/http/gateway_prompts_e2e.rs
@@ -1,0 +1,431 @@
+//! End-to-end gateway prompts aggregation over real TCP (issue #731).
+//!
+//! The in-crate unit tests in `dcc-mcp-gateway` exercise the aggregator
+//! handlers against an axum `Router` wrapped around a [`GatewayState`]
+//! — sufficient for the JSON-RPC contract, but the SSE push path
+//! (`notifications/prompts/list_changed`) lives in a separate tokio
+//! task (`prompts_watcher_handle` in `tasks.rs`) and can only be proven
+//! by a client that actually subscribes to the gateway's `GET /mcp`
+//! SSE stream over the wire.
+//!
+//! This module fills that gap:
+//!
+//! 1. Spawn fake MCP backends on real TCP sockets — each with its own
+//!    `prompts/list` response — and register them in a shared
+//!    [`FileRegistry`] dir.
+//! 2. Spin up a real gateway via [`GatewayRunner::start`] (its `Won
+//!    gateway election` branch runs the full watcher pipeline).
+//! 3. Drive `initialize` / `prompts/list` / `prompts/get` from a
+//!    [`reqwest::Client`] — the same HTTP surface any external MCP
+//!    client would see.
+//! 4. Subscribe to the gateway's SSE stream, mutate a backend's
+//!    advertised prompt, and assert
+//!    `notifications/prompts/list_changed` arrives within the watcher's
+//!    3 s cadence budget.
+//!
+//! The module guards against regressions that in-process unit tests
+//! can't see: a broken broadcast channel wiring, a missing watcher
+//! spawn, or an SSE endpoint that drops the prompts notifications on
+//! the floor.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use axum::{
+    Json, Router,
+    routing::{get, post},
+};
+use futures::StreamExt;
+use serde_json::{Value, json};
+
+use dcc_mcp_http::gateway::{GatewayConfig, GatewayRunner};
+use dcc_mcp_transport::discovery::types::ServiceEntry;
+
+// ── Fake backend ────────────────────────────────────────────────────────────
+
+/// State shared with the axum handler so a test can mutate the
+/// advertised prompt set mid-flight (for the SSE watcher test).
+#[derive(Clone)]
+struct FakeBackendState {
+    prompt_name: Arc<Mutex<&'static str>>,
+    /// Flips to `true` the first time `prompts/get` is observed — lets
+    /// the routing test assert the request landed on the right backend.
+    get_hit: Arc<AtomicBool>,
+    /// Deterministic echo marker embedded in the rendered prompt text.
+    echo_marker: &'static str,
+}
+
+/// Spawn a fake MCP backend that answers `prompts/list` and `prompts/get`.
+///
+/// Returns the listening port and the shared state so the caller can
+/// swap the prompt name during the test.
+async fn spawn_fake_prompts_backend(
+    initial_prompt: &'static str,
+    echo_marker: &'static str,
+) -> (u16, FakeBackendState) {
+    let state = FakeBackendState {
+        prompt_name: Arc::new(Mutex::new(initial_prompt)),
+        get_hit: Arc::new(AtomicBool::new(false)),
+        echo_marker,
+    };
+
+    async fn handler(
+        axum::extract::State(state): axum::extract::State<FakeBackendState>,
+        Json(req): Json<Value>,
+    ) -> Json<Value> {
+        let id = req.get("id").cloned().unwrap_or(Value::Null);
+        let method = req.get("method").and_then(|m| m.as_str()).unwrap_or("");
+        let result: Value = match method {
+            "tools/list" => json!({"tools": []}),
+            "prompts/list" => {
+                let name = *state.prompt_name.lock().unwrap();
+                json!({
+                    "prompts": [{
+                        "name": name,
+                        "description": format!("prompt from {}", state.echo_marker),
+                        "arguments": [],
+                    }]
+                })
+            }
+            "prompts/get" => {
+                state.get_hit.store(true, Ordering::SeqCst);
+                let requested = req
+                    .get("params")
+                    .and_then(|p| p.get("name"))
+                    .and_then(|n| n.as_str())
+                    .unwrap_or_default()
+                    .to_string();
+                json!({
+                    "description": format!("{}:{}", state.echo_marker, requested),
+                    "messages": [{
+                        "role": "user",
+                        "content": {
+                            "type": "text",
+                            "text": format!("{}:{}", state.echo_marker, requested),
+                        }
+                    }]
+                })
+            }
+            _ => {
+                return Json(json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "error": {"code": -32601, "message": format!("unknown method: {method}")}
+                }));
+            }
+        };
+        Json(json!({"jsonrpc": "2.0", "id": id, "result": result}))
+    }
+
+    let app = Router::new()
+        .route("/health", get(|| async { "ok" }))
+        .route("/mcp", post(handler))
+        .with_state(state.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.ok();
+    });
+    tokio::time::sleep(Duration::from_millis(40)).await;
+    (port, state)
+}
+
+// ── Gateway bootstrap ───────────────────────────────────────────────────────
+
+/// Pick an unused TCP port on 127.0.0.1.
+///
+/// Bind + close pattern — there is a small race window, but the gateway
+/// immediately tries to re-bind inside `start()` and the test runs
+/// serially per module.
+fn pick_free_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}
+
+/// Start a full [`GatewayRunner`] winner on `gw_port`.
+///
+/// The runner creates its own [`FileRegistry`] directory inside
+/// `registry_dir`, so callers must pre-populate the backend rows in
+/// that directory *before* calling this helper — the gateway's startup
+/// port probe will otherwise evict rows whose TCP socket is closed.
+///
+/// Returns the [`GatewayHandle`] (must be kept alive for the duration
+/// of the test to keep the gateway port bound) and the `http://…/mcp`
+/// URL callers hit.
+async fn start_gateway_winner(
+    registry_dir: &std::path::Path,
+    gw_port: u16,
+) -> (dcc_mcp_http::gateway::GatewayHandle, String) {
+    let cfg = GatewayConfig {
+        host: "127.0.0.1".to_string(),
+        gateway_port: gw_port,
+        heartbeat_secs: 1,
+        registry_dir: Some(registry_dir.to_path_buf()),
+        ..GatewayConfig::default()
+    };
+    let runner = GatewayRunner::new(cfg).expect("GatewayRunner::new");
+
+    // The runner still requires an instance row of its own so its
+    // sentinel-election + heartbeat bookkeeping has a plain-instance
+    // target. Use a filler `maya` row on port 0 — the gateway will
+    // not fan-out to it because its port is unreachable.
+    let own_entry = ServiceEntry::new("maya", "127.0.0.1", 0);
+    let handle = runner.start(own_entry, None).await.expect("runner.start");
+    assert!(
+        handle.is_gateway,
+        "test harness must win gateway election on the dedicated port"
+    );
+
+    (handle, format!("http://127.0.0.1:{gw_port}/mcp"))
+}
+
+async fn register_backend_async(
+    registry_dir: &std::path::Path,
+    dcc: &str,
+    port: u16,
+) -> ServiceEntry {
+    let reg = dcc_mcp_transport::discovery::file_registry::FileRegistry::new(registry_dir).unwrap();
+    let entry = ServiceEntry::new(dcc, "127.0.0.1", port);
+    let out = entry.clone();
+    reg.register(entry).unwrap();
+    out
+}
+
+// ── JSON-RPC client helpers ─────────────────────────────────────────────────
+
+async fn post_json(client: &reqwest::Client, url: &str, body: Value) -> Value {
+    let resp = client
+        .post(url)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .body(body.to_string())
+        .send()
+        .await
+        .expect("POST failed");
+    resp.json().await.expect("JSON decode failed")
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+/// Empty-cluster contract: no live backends → `prompts/list` is
+/// `{"prompts": []}`, never the historic `-32601` Method-not-found.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_empty_gateway_prompts_list_is_empty_array() {
+    let dir = tempfile::tempdir().unwrap();
+    let gw_port = pick_free_port();
+
+    let (_handle, gw_url) = start_gateway_winner(dir.path(), gw_port).await;
+
+    // Give the gateway a moment to finish its self-probe.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let client = reqwest::Client::new();
+    let resp = post_json(
+        &client,
+        &gw_url,
+        json!({"jsonrpc": "2.0", "id": 1, "method": "prompts/list"}),
+    )
+    .await;
+    assert!(resp.get("error").is_none(), "must not be an error: {resp}");
+    assert_eq!(resp["result"]["prompts"], json!([]));
+
+    // initialize must advertise prompts.listChanged=true even when the
+    // cluster is empty.
+    let init = post_json(
+        &client,
+        &gw_url,
+        json!({
+            "jsonrpc": "2.0", "id": 2, "method": "initialize",
+            "params": {"protocolVersion": "2025-03-26"}
+        }),
+    )
+    .await;
+    assert_eq!(
+        init["result"]["capabilities"]["prompts"]["listChanged"],
+        json!(true),
+    );
+}
+
+/// Two backends, disjoint prompts → merged list, correct cursor-safe
+/// prefixes, and `prompts/get` routes to the owning backend's echo.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn e2e_merges_and_routes_across_real_backends() {
+    let dir = tempfile::tempdir().unwrap();
+    let gw_port = pick_free_port();
+
+    // Register the two fake backends in the shared registry dir BEFORE
+    // the gateway starts so its startup port probe keeps both rows.
+    let (port_a, _state_a) = spawn_fake_prompts_backend("bake_animation", "maya-A").await;
+    let (port_b, state_b) = spawn_fake_prompts_backend("export_gltf", "blender-B").await;
+    let entry_a = register_backend_async(dir.path(), "maya", port_a).await;
+    let entry_b = register_backend_async(dir.path(), "blender", port_b).await;
+
+    let (_handle, gw_url) = start_gateway_winner(dir.path(), gw_port).await;
+
+    // Let the gateway's instance watcher + tools watcher see both
+    // backend rows before we query.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    let client = reqwest::Client::new();
+    let resp = post_json(
+        &client,
+        &gw_url,
+        json!({"jsonrpc": "2.0", "id": 1, "method": "prompts/list"}),
+    )
+    .await;
+    assert!(resp.get("error").is_none(), "unexpected error: {resp}");
+    let prompts = resp["result"]["prompts"].as_array().unwrap();
+    let names: Vec<String> = prompts
+        .iter()
+        .filter_map(|p| p["name"].as_str().map(str::to_owned))
+        .collect();
+
+    fn short(iid: &uuid::Uuid) -> String {
+        let mut s = iid.to_string().replace('-', "");
+        s.truncate(8);
+        s
+    }
+    let expect_a = format!("i_{}__bake_U_animation", short(&entry_a.instance_id));
+    let expect_b = format!("i_{}__export_U_gltf", short(&entry_b.instance_id));
+    assert!(names.contains(&expect_a), "missing {expect_a}: {names:?}");
+    assert!(names.contains(&expect_b), "missing {expect_b}: {names:?}");
+
+    // prompts/get against backend B: the response text must carry
+    // B's echo marker *and* the decoded bare name, proving the
+    // gateway decoded the prefix + reached the right backend.
+    let get_resp = post_json(
+        &client,
+        &gw_url,
+        json!({
+            "jsonrpc": "2.0", "id": 2, "method": "prompts/get",
+            "params": {"name": expect_b}
+        }),
+    )
+    .await;
+    assert!(
+        get_resp.get("error").is_none(),
+        "prompts/get error: {get_resp}"
+    );
+    let text = get_resp["result"]["messages"][0]["content"]["text"]
+        .as_str()
+        .expect("text content");
+    assert_eq!(text, "blender-B:export_gltf");
+    assert!(
+        state_b.get_hit.load(Ordering::SeqCst),
+        "backend B must have received the prompts/get"
+    );
+}
+
+/// Watcher SSE contract: subscribe to the gateway's SSE stream, mutate
+/// a backend's prompt set, then assert `notifications/prompts/list_changed`
+/// arrives within the watcher's 3-second cadence + a small slack.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn e2e_prompts_list_changed_fires_on_backend_mutation() {
+    let dir = tempfile::tempdir().unwrap();
+    let gw_port = pick_free_port();
+
+    let (port_a, state_a) = spawn_fake_prompts_backend("bake_animation", "maya-A").await;
+    register_backend_async(dir.path(), "maya", port_a).await;
+
+    let (_handle, gw_url) = start_gateway_winner(dir.path(), gw_port).await;
+
+    // Open a real SSE subscription — reqwest's bytes_stream keeps the
+    // stream open without the per-readline timeout foot-gun that
+    // Python's urllib imposes, so this test's assertion can wait as
+    // long as the watcher needs without special socket config.
+    let client = reqwest::Client::builder().build().expect("reqwest client");
+    let sse_resp = client
+        .get(&gw_url)
+        .header("Accept", "text/event-stream")
+        .header("Cache-Control", "no-cache")
+        .send()
+        .await
+        .expect("SSE GET failed");
+    assert!(
+        sse_resp.status().is_success(),
+        "SSE not accepted: {:?}",
+        sse_resp.status()
+    );
+
+    // Collect SSE frames in a background task so the main thread can
+    // continue to drive the mutation.
+    let (notif_tx, mut notif_rx) = tokio::sync::mpsc::unbounded_channel::<Value>();
+    tokio::spawn(async move {
+        let mut stream = sse_resp.bytes_stream();
+        let mut buf = String::new();
+        while let Some(Ok(bytes)) = stream.next().await {
+            buf.push_str(&String::from_utf8_lossy(&bytes));
+            // Split on blank-line SSE frame boundaries.
+            while let Some(idx) = buf.find("\n\n") {
+                let frame = buf[..idx].to_string();
+                buf.drain(..idx + 2);
+                // Concatenate every `data:` line in the frame.
+                let mut data = String::new();
+                for line in frame.lines() {
+                    if let Some(rest) = line.strip_prefix("data:") {
+                        if !data.is_empty() {
+                            data.push('\n');
+                        }
+                        data.push_str(rest.trim_start());
+                    }
+                }
+                if !data.is_empty()
+                    && let Ok(val) = serde_json::from_str::<Value>(&data)
+                {
+                    let _ = notif_tx.send(val);
+                }
+            }
+        }
+    });
+
+    // Let the watcher commit its baseline fingerprint (one tick + slack).
+    tokio::time::sleep(Duration::from_millis(3_500)).await;
+
+    // Mutate the backend's advertised prompt set. Next watcher tick
+    // (≤ 3 s away) must observe a different fingerprint and broadcast.
+    *state_a.prompt_name.lock().unwrap() = "render_preview";
+
+    // Drain events looking for the prompts/list_changed one —
+    // resources/list_changed and tools/list_changed share the channel,
+    // so we must keep reading until the prompts one surfaces (or the
+    // budget expires).
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(12);
+    let mut saw_prompts_changed = false;
+    while tokio::time::Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        let ev = match tokio::time::timeout(remaining, notif_rx.recv()).await {
+            Ok(Some(v)) => v,
+            Ok(None) | Err(_) => break,
+        };
+        if ev.get("method").and_then(Value::as_str) == Some("notifications/prompts/list_changed") {
+            saw_prompts_changed = true;
+            break;
+        }
+    }
+
+    assert!(
+        saw_prompts_changed,
+        "gateway did not broadcast notifications/prompts/list_changed within 12s",
+    );
+
+    // Final sanity: a fresh prompts/list must show the mutated name.
+    let resp = post_json(
+        &client,
+        &gw_url,
+        json!({"jsonrpc": "2.0", "id": 99, "method": "prompts/list"}),
+    )
+    .await;
+    let names: Vec<String> = resp["result"]["prompts"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|p| p["name"].as_str().map(str::to_owned))
+        .collect();
+    assert!(
+        names.iter().any(|n| n.contains("render_U_preview")),
+        "post-mutation prompts/list missing render_preview: {names:?}",
+    );
+}

--- a/tests/fixtures/prompts_skills/blender-only/blender-prompts-demo/SKILL.md
+++ b/tests/fixtures/prompts_skills/blender-only/blender-prompts-demo/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: blender-prompts-demo
+description: >-
+  Fixture skill exercising the MCP prompts primitive (issue #731 gateway
+  aggregation coverage). Ships one template prompt whose name is
+  deliberately disjoint from the maya-side fixture so the aggregated
+  list contains a clear union.
+license: MIT
+compatibility: Python 3.7+
+metadata:
+  dcc-mcp.dcc: blender
+  dcc-mcp.version: "1.0.0"
+  dcc-mcp.layer: example
+  dcc-mcp.search-hint: "export gltf, prompts fixture"
+  dcc-mcp.prompts: prompts.yaml
+---
+
+# Blender prompts demo
+
+Fixture-only skill for `test_gateway_prompts_aggregation.py`. Publishes
+one prompt (`export_gltf`) disjoint from the maya fixture's prompts so
+the merged ``prompts/list`` round-trip can be asserted set-wise.

--- a/tests/fixtures/prompts_skills/blender-only/blender-prompts-demo/prompts.yaml
+++ b/tests/fixtures/prompts_skills/blender-only/blender-prompts-demo/prompts.yaml
@@ -1,0 +1,13 @@
+prompts:
+  - name: export_gltf
+    description: Blender-side glTF export instruction
+    arguments:
+      - name: output_path
+        description: Destination .glb or .gltf file path
+        required: true
+      - name: include_animations
+        description: Whether to bake animations into the export
+        required: false
+    template: |
+      Export the current Blender scene to glTF at {{output_path}}.
+      Include animations: {{include_animations}}.

--- a/tests/fixtures/prompts_skills/maya-only/maya-prompts-demo/SKILL.md
+++ b/tests/fixtures/prompts_skills/maya-only/maya-prompts-demo/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: maya-prompts-demo
+description: >-
+  Fixture skill exercising the MCP prompts primitive (issue #731 gateway
+  aggregation coverage). Ships two template prompts via a sibling
+  ``prompts.yaml`` so gateway ``prompts/list`` has something to merge
+  from the maya-side backend.
+license: MIT
+compatibility: Python 3.7+
+metadata:
+  dcc-mcp.dcc: maya
+  dcc-mcp.version: "1.0.0"
+  dcc-mcp.layer: example
+  dcc-mcp.search-hint: "bake animation, render frame, prompts fixture"
+  dcc-mcp.prompts: prompts.yaml
+---
+
+# Maya prompts demo
+
+Fixture-only skill for `test_gateway_prompts_aggregation.py` and
+`test_e2e_gateway_prompts_sse.py`. Publishes two prompts so aggregation
+tests can confirm routing and prefixing across multiple DCC backends.

--- a/tests/fixtures/prompts_skills/maya-only/maya-prompts-demo/prompts.yaml
+++ b/tests/fixtures/prompts_skills/maya-only/maya-prompts-demo/prompts.yaml
@@ -1,0 +1,23 @@
+prompts:
+  - name: bake_animation
+    description: Guide for baking a Maya rig animation to keyframes
+    arguments:
+      - name: frame_range
+        description: Frame range to bake (e.g. "1-100")
+        required: true
+      - name: sample_rate
+        description: Samples per frame
+        required: false
+    template: |
+      Bake the selected Maya rig across frames {{frame_range}} using
+      sample rate {{sample_rate}}. Report the final keyframe count.
+
+  - name: render_preview
+    description: Short render-preview instruction for Maya viewport
+    arguments:
+      - name: camera
+        description: Viewport camera name
+        required: true
+    template: |
+      Render a preview pass through camera {{camera}} at half
+      resolution. Save to the scene's images/ directory.

--- a/tests/test_e2e_gateway_prompts_sse.py
+++ b/tests/test_e2e_gateway_prompts_sse.py
@@ -1,0 +1,314 @@
+"""E2E regression test: gateway SSE → load_skill → prompts/list_changed (#731).
+
+Complement to ``test_e2e_gateway_skill_load_sse.py`` which guards the
+``notifications/tools/list_changed`` invariant. This module guards the
+prompts-primitive counterpart introduced by PR #740: the gateway's
+prompts fingerprint watcher must emit ``notifications/prompts/list_changed``
+over SSE whenever a backend's set of MCP prompts changes — which happens
+when a skill that carries a ``metadata.dcc-mcp.prompts`` sibling file is
+loaded or unloaded.
+
+The flow covered end-to-end:
+
+1. A backend ``McpHttpServer`` is built via ``create_skill_server`` with
+   skill discovery pointed at ``tests/fixtures/prompts_skills/maya-only``
+   so the ``maya-prompts-demo`` fixture skill is visible as a skill stub
+   but **not** loaded — meaning its prompts have not been published to
+   the gateway-facing ``prompts/list`` yet.
+2. A background SSE subscriber opens ``GET /mcp`` on the gateway and
+   records every JSON-RPC notification.
+3. ``load_skill`` is invoked through the gateway. After the prompts
+   watcher's tick (~3 s), the client MUST see a
+   ``notifications/prompts/list_changed`` and a subsequent
+   ``prompts/list`` MUST expose the fixture's prompts.
+4. ``unload_skill`` is then invoked — we assert a *second*
+   ``notifications/prompts/list_changed`` is delivered, guarding the
+   symmetric unload path.
+
+Runtime budget: the prompts watcher inherits the same 3-second tick as
+the tools/resources aggregators, so we allow up to 12 s end-to-end for
+each wait.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from pathlib import Path
+import queue
+import socket
+import threading
+import time
+from typing import Any
+import urllib.request
+
+import pytest
+
+from dcc_mcp_core import McpHttpConfig
+from dcc_mcp_core import create_skill_server
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIXTURE_SKILL_PARENT = str(REPO_ROOT / "tests" / "fixtures" / "prompts_skills" / "maya-only")
+
+# The aggregating prompts watcher ticks every 3 s (same cadence as the
+# tools and resources aggregators); add slack for scheduling jitter.
+SSE_NOTIFICATION_BUDGET_S = 12.0
+AGGREGATOR_TICK_S = 3.0
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _pick_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _post_mcp(url: str, method: str, params: dict | None = None, rpc_id: int = 1, timeout: float = 10.0) -> dict:
+    body: dict[str, Any] = {"jsonrpc": "2.0", "id": rpc_id, "method": method}
+    if params is not None:
+        body["params"] = params
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read())
+
+
+def _wait_tcp_reachable(host: str, port: int, budget: float = 3.0) -> bool:
+    deadline = time.time() + budget
+    while time.time() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=0.3):
+                return True
+        except OSError:
+            time.sleep(0.05)
+    return False
+
+
+class _SseSubscriber(threading.Thread):
+    """Background SSE consumer — same shape as the one in ``test_e2e_gateway_skill_load_sse.py``."""
+
+    def __init__(self, url: str, events: queue.Queue[dict], stop_event: threading.Event) -> None:
+        super().__init__(daemon=True)
+        self.url = url
+        self.events = events
+        self.stop_event = stop_event
+        self.error: BaseException | None = None
+        self.connected = threading.Event()
+
+    def run(self) -> None:
+        try:
+            req = urllib.request.Request(
+                self.url,
+                headers={"Accept": "text/event-stream", "Cache-Control": "no-cache"},
+                method="GET",
+            )
+            with urllib.request.urlopen(req, timeout=20.0) as resp:
+                self.connected.set()
+                pending_data: list[str] = []
+                while not self.stop_event.is_set():
+                    line = resp.readline()
+                    if not line:
+                        break
+                    try:
+                        text = line.decode("utf-8", errors="replace").rstrip("\r\n")
+                    except Exception:
+                        continue
+                    if text == "":
+                        if pending_data:
+                            payload = "\n".join(pending_data)
+                            pending_data = []
+                            with contextlib.suppress(json.JSONDecodeError):
+                                self.events.put(json.loads(payload))
+                        continue
+                    if text.startswith(":"):
+                        continue
+                    if text.startswith("data:"):
+                        pending_data.append(text[5:].lstrip())
+        except BaseException as e:
+            self.error = e
+            self.connected.set()
+
+
+def _drain_for_notification(events: queue.Queue[dict], method: str, budget: float) -> dict | None:
+    deadline = time.time() + budget
+    while time.time() < deadline:
+        remaining = max(0.0, deadline - time.time())
+        try:
+            ev = events.get(timeout=min(remaining, 0.5))
+        except queue.Empty:
+            continue
+        if isinstance(ev, dict) and ev.get("method") == method:
+            return ev
+    return None
+
+
+# ── fixture ───────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def gateway_with_prompts_skill(tmp_path):
+    """Start a single backend + gateway. The fixture skill is discovered but not loaded."""
+    registry_dir = tmp_path / "registry"
+    registry_dir.mkdir()
+
+    if not (Path(FIXTURE_SKILL_PARENT) / "maya-prompts-demo" / "prompts.yaml").exists():
+        pytest.skip(f"fixture skill not present at {FIXTURE_SKILL_PARENT}")
+
+    gw_port = _pick_free_port()
+
+    cfg = McpHttpConfig(port=0, server_name="prompts-backend")
+    cfg.gateway_port = gw_port
+    cfg.registry_dir = str(registry_dir)
+    cfg.dcc_type = "maya"
+    cfg.heartbeat_secs = 1
+    cfg.stale_timeout_secs = 10
+
+    server = create_skill_server(
+        "maya",
+        cfg,
+        extra_paths=[FIXTURE_SKILL_PARENT],
+        accumulated=False,
+    )
+    handle = server.start()
+
+    assert _wait_tcp_reachable("127.0.0.1", handle.port, budget=3.0), (
+        f"backend port {handle.port} unreachable after start()"
+    )
+    if handle.is_gateway:
+        assert _wait_tcp_reachable("127.0.0.1", gw_port, budget=3.0), (
+            f"gateway port {gw_port} unreachable after start()"
+        )
+
+    try:
+        yield {
+            "handle": handle,
+            "gateway_url": f"http://127.0.0.1:{gw_port}/mcp",
+        }
+    finally:
+        with contextlib.suppress(Exception):
+            handle.shutdown()
+
+
+# ── tests ─────────────────────────────────────────────────────────────────────
+
+
+class TestGatewayPromptsListChangedSse:
+    """The gateway must push ``notifications/prompts/list_changed`` on load/unload."""
+
+    def test_backend_won_gateway_election(self, gateway_with_prompts_skill):
+        """The single backend must win the election so the test URL has a gateway."""
+        assert gateway_with_prompts_skill["handle"].is_gateway, "single-backend fixture must win the gateway election"
+
+    def test_prompts_list_starts_empty_before_load_skill(self, gateway_with_prompts_skill):
+        """The fixture prompts must not appear in prompts/list until load_skill runs."""
+        resp = _post_mcp(gateway_with_prompts_skill["gateway_url"], "prompts/list")
+        assert "error" not in resp, f"prompts/list error: {resp.get('error')}"
+        assert resp["result"]["prompts"] == [], f"prompts/list should be empty pre-load; got: {resp['result']}"
+
+    def test_load_skill_emits_prompts_list_changed(self, gateway_with_prompts_skill):
+        """Full regression: SSE subscribe → load_skill → notifications/prompts/list_changed."""
+        gateway_url = gateway_with_prompts_skill["gateway_url"]
+        events: queue.Queue[dict] = queue.Queue()
+        stop = threading.Event()
+        subscriber = _SseSubscriber(gateway_url, events, stop)
+        subscriber.start()
+        try:
+            assert subscriber.connected.wait(timeout=5.0), "SSE subscriber never connected"
+            if subscriber.error is not None:
+                pytest.fail(f"SSE subscription failed: {subscriber.error!r}")
+
+            # Let the baseline prompts fingerprint settle (empty set) so
+            # the load-triggered transition isn't collapsed into any
+            # initial-state broadcast.
+            time.sleep(AGGREGATOR_TICK_S + 0.5)
+
+            load_resp = _post_mcp(
+                gateway_url,
+                "tools/call",
+                {"name": "load_skill", "arguments": {"skill_name": "maya-prompts-demo"}},
+            )
+            assert "error" not in load_resp, f"load_skill JSON-RPC error: {load_resp.get('error')}"
+            assert "result" in load_resp
+            # Surface the structured result so failures show *why* load_skill
+            # was a no-op (e.g. ambiguous target, unknown skill, missing DCC).
+            lr_text = load_resp["result"]["content"][0]["text"]
+            lr_body = json.loads(lr_text)
+            assert lr_body.get("loaded") or lr_body.get("newly_loaded"), (
+                f"load_skill did not load maya-prompts-demo: {lr_text}"
+            )
+
+            notif = _drain_for_notification(
+                events,
+                "notifications/prompts/list_changed",
+                budget=SSE_NOTIFICATION_BUDGET_S,
+            )
+            assert notif is not None, (
+                "gateway did not push notifications/prompts/list_changed within "
+                f"{SSE_NOTIFICATION_BUDGET_S}s after load_skill"
+            )
+            assert notif.get("jsonrpc") == "2.0"
+            assert notif.get("method") == "notifications/prompts/list_changed"
+
+            # Sanity: the new prompts must now be visible on the aggregated
+            # prompts/list. Allow one watcher tick of cache slack.
+            deadline = time.time() + AGGREGATOR_TICK_S + 2.0
+            names: list[str] = []
+            while time.time() < deadline:
+                resp = _post_mcp(gateway_url, "prompts/list")
+                names = [p["name"] for p in resp["result"]["prompts"]]
+                if names:
+                    break
+                time.sleep(0.3)
+            assert names, "prompts/list is still empty after load_skill + list_changed fired"
+        finally:
+            stop.set()
+            subscriber.join(timeout=1.0)
+
+    def test_unload_skill_also_emits_prompts_list_changed(self, gateway_with_prompts_skill):
+        """Symmetric unload path — a regression in only one direction must still be caught."""
+        gateway_url = gateway_with_prompts_skill["gateway_url"]
+
+        # Precondition: load the skill so the fingerprint is non-empty.
+        pre = _post_mcp(
+            gateway_url,
+            "tools/call",
+            {"name": "load_skill", "arguments": {"skill_name": "maya-prompts-demo"}},
+        )
+        assert "result" in pre, f"precondition load_skill failed: {pre}"
+
+        events: queue.Queue[dict] = queue.Queue()
+        stop = threading.Event()
+        subscriber = _SseSubscriber(gateway_url, events, stop)
+        subscriber.start()
+        try:
+            assert subscriber.connected.wait(timeout=5.0), "SSE subscriber never connected"
+            if subscriber.error is not None:
+                pytest.fail(f"SSE subscription failed: {subscriber.error!r}")
+
+            time.sleep(AGGREGATOR_TICK_S + 0.5)
+
+            unload_resp = _post_mcp(
+                gateway_url,
+                "tools/call",
+                {"name": "unload_skill", "arguments": {"skill_name": "maya-prompts-demo"}},
+            )
+            assert "result" in unload_resp, f"unload_skill missing result: {unload_resp}"
+
+            notif = _drain_for_notification(
+                events,
+                "notifications/prompts/list_changed",
+                budget=SSE_NOTIFICATION_BUDGET_S,
+            )
+            assert notif is not None, (
+                "gateway did not push notifications/prompts/list_changed within "
+                f"{SSE_NOTIFICATION_BUDGET_S}s after unload_skill"
+            )
+        finally:
+            stop.set()
+            subscriber.join(timeout=1.0)

--- a/tests/test_gateway_prompts_aggregation.py
+++ b/tests/test_gateway_prompts_aggregation.py
@@ -1,0 +1,342 @@
+"""Python-side integration tests for the gateway's prompts aggregation (#731).
+
+The Rust unit tests in ``crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs``
+exercise the handler logic against mock backends. These tests instead drive the
+full stack from a Python client's perspective:
+
+* Two real ``McpHttpServer`` backends — each built via ``create_skill_server``
+  with a disjoint fixture skill that ships a ``prompts.yaml`` sibling file.
+* One gateway process elected by the first backend to bind the gateway port.
+* A plain ``urllib`` client POSTs ``prompts/list`` / ``prompts/get`` against the
+  gateway's ``/mcp`` endpoint and decodes the cursor-safe ``i_<id8>__<name>``
+  namespace to verify routing.
+
+Coverage:
+
+1. Zero-backend gateway → ``prompts/list`` returns ``{"prompts": []}``.
+2. Two backends with disjoint prompts → merged list with correct per-backend
+   prefixes; each entry carries ``_instance_id`` / ``_dcc_type`` annotations.
+3. ``prompts/get`` against a prefixed name → request reaches the owning backend
+   and the rendered template references the decoded bare name.
+
+The fixture skills live under ``tests/fixtures/prompts_skills/`` so they remain
+hermetic to this test module — no bundled ``examples/skills`` prompt
+regression can mask a gateway regression.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from pathlib import Path
+import socket
+import time
+import urllib.request
+
+import pytest
+
+from dcc_mcp_core import McpHttpConfig
+from dcc_mcp_core import McpHttpServer
+from dcc_mcp_core import ToolRegistry
+from dcc_mcp_core import create_skill_server
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIXTURE_SKILLS_DIR = REPO_ROOT / "tests" / "fixtures" / "prompts_skills"
+MAYA_SKILL_PARENT = str(FIXTURE_SKILLS_DIR / "maya-only")
+BLENDER_SKILL_PARENT = str(FIXTURE_SKILLS_DIR / "blender-only")
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _pick_free_port() -> int:
+    """Return a port that is currently free on 127.0.0.1."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _post_mcp(url: str, method: str, params: dict | None = None, rpc_id: int = 1, timeout: float = 10.0) -> dict:
+    body: dict = {"jsonrpc": "2.0", "id": rpc_id, "method": method}
+    if params is not None:
+        body["params"] = params
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read())
+
+
+def _unescape_cursor_safe(escaped: str) -> str | None:
+    """Inverse of the ``escape_cursor_safe`` helper from gateway/namespace (#656)."""
+    out: list[str] = []
+    i = 0
+    n = len(escaped)
+    while i < n:
+        ch = escaped[i]
+        if ch == "_":
+            if i + 2 >= n or escaped[i + 2] != "_":
+                return None
+            mapped = {"U": "_", "D": ".", "H": "-"}.get(escaped[i + 1])
+            if mapped is None:
+                return None
+            out.append(mapped)
+            i += 3
+        elif ch.isascii() and ch.isalnum():
+            out.append(ch)
+            i += 1
+        else:
+            return None
+    return "".join(out)
+
+
+def _split_gateway_prefixed(name: str) -> tuple[str, str] | None:
+    """Decode ``i_<id8>__<escaped>`` or legacy ``<id8>.<name>`` into (prefix, bare)."""
+    if name.startswith("i_"):
+        rest = name[2:]
+        sep_idx = rest.find("__")
+        if sep_idx == 8:
+            prefix = rest[:8]
+            escaped = rest[10:]
+            if all(ch in "0123456789abcdef" for ch in prefix):
+                decoded = _unescape_cursor_safe(escaped)
+                if decoded is not None:
+                    return prefix, decoded
+    prefix, sep, suffix = name.partition(".")
+    if sep and len(prefix) == 8 and all(ch in "0123456789abcdef" for ch in prefix):
+        return prefix, suffix
+    return None
+
+
+def _start_backend(dcc: str, skill_parent: Path, registry_dir: Path, gw_port: int) -> object:
+    """Start an ``McpHttpServer`` via ``create_skill_server`` discovering ``skill_parent``."""
+    cfg = McpHttpConfig(port=0, server_name=f"{dcc}-prompts-backend")
+    cfg.gateway_port = gw_port
+    cfg.registry_dir = str(registry_dir)
+    cfg.dcc_type = dcc
+    cfg.heartbeat_secs = 1
+    cfg.stale_timeout_secs = 10
+    # Disable accumulated user/team skills so the test stays hermetic:
+    # a stray `~/.dcc-mcp/skills` must not introduce additional prompts
+    # that confuse the aggregated set assertions.
+    server = create_skill_server(
+        dcc,
+        cfg,
+        extra_paths=[str(skill_parent)],
+        accumulated=False,
+    )
+    return server.start()
+
+
+# ── fixture: zero-backend gateway ────────────────────────────────────────────
+
+
+@pytest.fixture()
+def empty_gateway(tmp_path):
+    """Spin up a gateway with zero backends.
+
+    The fixture binds a throwaway backend just to win the gateway election
+    (the gateway needs somebody to host ``/mcp``), then disables backend
+    fan-out by pointing the instance at a DCC filter that matches no
+    fixture skill — so the aggregated prompts set is empty from the
+    client's perspective.
+    """
+    registry_dir = tmp_path / "registry"
+    registry_dir.mkdir()
+    gw_port = _pick_free_port()
+
+    # "python" backend with no fixture skill — nothing to aggregate.
+    cfg = McpHttpConfig(port=0, server_name="empty-gateway-host")
+    cfg.gateway_port = gw_port
+    cfg.registry_dir = str(registry_dir)
+    cfg.dcc_type = "python"
+    cfg.heartbeat_secs = 1
+    cfg.stale_timeout_secs = 10
+    server = create_skill_server("python", cfg, accumulated=False)
+    handle = server.start()
+    assert handle.is_gateway, "host backend must win gateway election"
+
+    try:
+        yield f"http://127.0.0.1:{gw_port}/mcp"
+    finally:
+        with contextlib.suppress(Exception):
+            handle.shutdown()
+
+
+# ── fixture: two backends with disjoint prompts ──────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def prompts_cluster(tmp_path_factory):
+    """Two backends + gateway, each backend exposes one fixture prompts-demo skill.
+
+    We build per-DCC fixture-parent directories (``maya-only/`` and
+    ``blender-only/``) so each backend's ``create_skill_server`` discovers
+    exactly its own skill — the gateway aggregator is what merges them.
+    """
+    # Layout the fixture parents on disk if not already present.
+    # ``tests/fixtures/prompts_skills/<dcc>-only/<skill-name>/`` contains
+    # symlinks or direct files; for portability we materialise directories.
+    maya_parent = FIXTURE_SKILLS_DIR / "maya-only"
+    blender_parent = FIXTURE_SKILLS_DIR / "blender-only"
+    if not (maya_parent / "maya-prompts-demo" / "SKILL.md").exists():
+        pytest.skip(f"fixture skill missing at {maya_parent}")
+    if not (blender_parent / "blender-prompts-demo" / "SKILL.md").exists():
+        pytest.skip(f"fixture skill missing at {blender_parent}")
+
+    registry_dir = tmp_path_factory.mktemp("prompts-registry")
+    gw_port = _pick_free_port()
+
+    # First backend wins the gateway election.
+    handle_a = _start_backend("maya", maya_parent, registry_dir, gw_port)
+    # Give the gateway a moment to bind its sentinel before #2 starts.
+    time.sleep(0.25)
+    handle_b = _start_backend("blender", blender_parent, registry_dir, gw_port)
+
+    # Give the gateway's 2-second instance watcher + 3-second tools
+    # watcher enough time to see both registrations.
+    time.sleep(2.5)
+
+    gateway_url = f"http://127.0.0.1:{gw_port}/mcp"
+
+    # Load each fixture skill **on its owning backend directly** rather
+    # than via the gateway. Each backend discovered only its own skill
+    # (different ``extra_paths`` per DCC) so a cross-backend load_skill
+    # would fail. Hitting the backend's own /mcp endpoint is the
+    # unambiguous path.
+    for handle, skill in ((handle_a, "maya-prompts-demo"), (handle_b, "blender-prompts-demo")):
+        backend_url = handle.mcp_url()
+        resp = _post_mcp(
+            backend_url,
+            "tools/call",
+            {"name": "load_skill", "arguments": {"skill_name": skill}},
+        )
+        assert "error" not in resp, f"load_skill({skill}) on {backend_url} failed: {resp.get('error')}"
+
+    # One more tick so the prompts watcher picks up the newly loaded
+    # prompts before the first assertion runs.
+    time.sleep(3.2)
+
+    try:
+        yield {
+            "gateway_url": gateway_url,
+            "handle_a": handle_a,
+            "handle_b": handle_b,
+        }
+    finally:
+        for h in (handle_b, handle_a):
+            with contextlib.suppress(Exception):
+                h.shutdown()
+
+
+# ── tests ─────────────────────────────────────────────────────────────────────
+
+
+class TestPromptsListEmptyGateway:
+    """A gateway with no prompt-bearing backend must still answer prompts/list."""
+
+    def test_prompts_list_returns_empty_array_not_method_not_found(self, empty_gateway):
+        """Hard acceptance criterion from #731 — must not be -32601."""
+        resp = _post_mcp(empty_gateway, "prompts/list")
+        assert "error" not in resp, f"unexpected JSON-RPC error: {resp.get('error')}"
+        assert resp["result"] == {"prompts": []}
+
+    def test_initialize_advertises_prompts_capability(self, empty_gateway):
+        """`prompts: {listChanged: true}` must appear in the capabilities object."""
+        resp = _post_mcp(
+            empty_gateway,
+            "initialize",
+            {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "prompts-empty-test", "version": "0.1"},
+            },
+        )
+        caps = resp["result"]["capabilities"]
+        assert caps.get("prompts", {}).get("listChanged") is True, (
+            f"initialize must advertise prompts.listChanged=true; got: {caps}"
+        )
+
+
+class TestPromptsListAggregatesBackends:
+    """Two backends with disjoint prompt sets merge into one namespaced list."""
+
+    def test_merged_list_contains_every_backend_prompt(self, prompts_cluster):
+        resp = _post_mcp(prompts_cluster["gateway_url"], "prompts/list")
+        assert "error" not in resp, f"prompts/list error: {resp.get('error')}"
+        names = [p["name"] for p in resp["result"]["prompts"]]
+
+        decoded = [(n, _split_gateway_prefixed(n)) for n in names]
+        bare_names = {bare for (_, split) in decoded if split is not None for bare in (split[1],)}
+
+        for expected in ("bake_animation", "render_preview", "export_gltf"):
+            assert expected in bare_names, f"expected bare prompt {expected!r} in merged list; names={names}"
+
+    def test_backend_prompts_carry_instance_metadata(self, prompts_cluster):
+        resp = _post_mcp(prompts_cluster["gateway_url"], "prompts/list")
+        for prompt in resp["result"]["prompts"]:
+            assert "_instance_id" in prompt, f"prompt missing _instance_id: {prompt!r}"
+            assert "_instance_short" in prompt
+            assert "_dcc_type" in prompt
+            split = _split_gateway_prefixed(prompt["name"])
+            assert split is not None, f"prompt name not cursor-safe-prefixed: {prompt['name']}"
+            prefix, _ = split
+            assert prompt["_instance_short"] == prefix, (
+                f"prefix {prefix!r} doesn't match _instance_short {prompt['_instance_short']!r}"
+            )
+
+    def test_prompts_get_routes_to_owning_backend(self, prompts_cluster):
+        """prompts/get on a namespaced name must reach the owning backend and render its template."""
+        resp = _post_mcp(prompts_cluster["gateway_url"], "prompts/list")
+        prompts = resp["result"]["prompts"]
+
+        # Pick the blender-side prompt so we exercise cross-backend
+        # routing (the gateway winner hosts the maya backend).
+        target = next(
+            (p for p in prompts if _split_gateway_prefixed(p["name"])[1] == "export_gltf"),
+            None,
+        )
+        assert target is not None, f"export_gltf prompt missing from {[p['name'] for p in prompts]}"
+
+        get_resp = _post_mcp(
+            prompts_cluster["gateway_url"],
+            "prompts/get",
+            {
+                "name": target["name"],
+                "arguments": {
+                    "output_path": "/tmp/demo.glb",
+                    "include_animations": "true",
+                },
+            },
+        )
+        assert "error" not in get_resp, f"prompts/get error: {get_resp.get('error')}"
+        messages = get_resp["result"]["messages"]
+        assert len(messages) >= 1, f"prompts/get returned no messages: {get_resp}"
+        text = messages[0]["content"]["text"]
+        # The backend-side PromptRegistry renders the template — the
+        # rendered output must have substituted the arguments, proving
+        # the request actually reached the right backend.
+        assert "/tmp/demo.glb" in text, f"rendered prompt missing output_path arg: {text!r}"
+        assert "true" in text, f"rendered prompt missing include_animations arg: {text!r}"
+
+    def test_prompts_get_with_unknown_prefix_returns_routing_error(self, prompts_cluster):
+        """An unknown 8-hex prefix must surface -32602 without hitting any backend."""
+        resp = _post_mcp(
+            prompts_cluster["gateway_url"],
+            "prompts/get",
+            {"name": "i_deadbeef__bake_U_animation"},
+        )
+        err = resp.get("error")
+        assert err is not None, f"expected routing error, got: {resp}"
+        assert err["code"] == -32602
+        assert "deadbeef" in err["message"]
+
+
+# A tiny helper to defeat linter warnings for unused imports in environments
+# where ``ToolRegistry`` is not referenced directly — we rely on
+# ``create_skill_server`` building registries for us, but importing the
+# symbol keeps parity with sibling gateway tests.
+_ = ToolRegistry


### PR DESCRIPTION
Follow-up to merged PR #740. Complements the in-crate aggregator unit
tests with Python-client and real-HTTP E2E coverage. Nothing in
production changed — only tests and fixture skills (plus a rebase-time
Cargo.lock refresh).

## Python-side aggregation (`tests/test_gateway_prompts_aggregation.py`)
- Zero-backend gateway → `prompts/list` returns `{"prompts": []}` and
  `initialize` advertises `prompts.listChanged=true`.
- Two `McpHttpServer` backends discovering disjoint fixture skills →
  gateway `prompts/list` merges the sets under the cursor-safe
  `i_<id8>__<escaped>` prefix; each entry carries `_instance_id` /
  `_dcc_type` annotations.
- `prompts/get` against the prefixed blender-side name routes to the
  owning backend and the rendered template substitutes caller-supplied
  arguments (proves cross-backend routing, not just local).
- Unknown 8-hex prefix surfaces JSON-RPC `-32602` without a backend
  round-trip.

## Python-side SSE (`tests/test_e2e_gateway_prompts_sse.py`)
Sister test to `test_e2e_gateway_skill_load_sse.py`. Subscribes to
`GET /mcp` on the gateway, calls `load_skill` on a prompt-bearing
fixture skill, and asserts `notifications/prompts/list_changed` arrives
within the watcher's 3-s cadence. Mirrors the unload path. Uses a
20-second urllib socket timeout because the prompts fingerprint is
silent between the initial tools broadcast and the `load_skill`
trigger — the sibling 5-s tools test never hits that gap because its
fingerprint changes immediately on backend boot.

## Rust-side E2E (`crates/dcc-mcp-http/tests/http/gateway_prompts_e2e.rs`)
Real TCP fake backends + real `GatewayRunner` winner + `reqwest`
client — no in-process Router shortcut. Covers the same three
contracts (empty gateway, merge + route, SSE `list_changed`) end-to-end
over the wire.

## Fixture skills (`tests/fixtures/prompts_skills/`)
- `maya-only/maya-prompts-demo` — `bake_animation` + `render_preview`.
- `blender-only/blender-prompts-demo` — `export_gltf`.
Per-DCC parent directories keep each backend's skill scanner scoped so
`extra_paths` discovery doesn't leak across backends.

## Verification
- `pytest tests/test_gateway_prompts_aggregation.py tests/test_e2e_gateway_prompts_sse.py` — 10 passed.
- `cargo test -p dcc-mcp-http --test http gateway_prompts_e2e` — 3 passed.
- `cargo test -p dcc-mcp-gateway` — 208 unit tests + 3 doctests pass.
- Full `pytest tests/` — 8894 passed (pre-existing SEP-986 encoder panic
  in `test_e2e_gateway_skill_load_sse.py::test_hello_world_*` and
  `test_load_skill_triggers_tools_list_changed_via_sse` is unrelated —
  reproduces on `origin/main` with no PR #731 tests present; tracked
  separately).