### PR TITLE
feat(skills): declare static MCP resources from YAML

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,7 @@ Gateway / slim / REST exposure:
 |------|----------|
 | Expose DCC tools over MCP | `DccServerBase` → subclass → `start()` |
 | Zero-code tool registration | `SKILL.md` + `scripts/` ([agentskills.io](https://agentskills.io/specification)) |
+| Zero-code static MCP resources | `metadata.dcc-mcp.resources` → `resources/*.resource.yaml` with `source.type: file` |
 | Structured results | `success_result()` / `error_result()` |
 | Rich error with traceback | `skill_error_with_trace()` |
 | Bridge non-Python DCC | `DccBridge` (WebSocket JSON-RPC 2.0) |

--- a/crates/dcc-mcp-http/src/handlers/resources_prompts.rs
+++ b/crates/dcc-mcp-http/src/handlers/resources_prompts.rs
@@ -6,6 +6,10 @@ pub async fn handle_resources_list(
     state: &AppState,
     req: &JsonRpcRequest,
 ) -> Result<JsonRpcResponse, HttpError> {
+    let catalog = state.catalog.clone();
+    state.resources.sync_skill_resources(|visit| {
+        catalog.for_each_loaded_metadata(|md| visit(md));
+    });
     let resources = state.resources.list();
     let result = ListResourcesResult {
         resources,
@@ -33,6 +37,10 @@ pub async fn handle_resources_read(
         ));
     };
 
+    let catalog = state.catalog.clone();
+    state.resources.sync_skill_resources(|visit| {
+        catalog.for_each_loaded_metadata(|md| visit(md));
+    });
     match state.resources.read(&params.uri) {
         Ok(result) => Ok(JsonRpcResponse::success(
             req.id.clone(),

--- a/crates/dcc-mcp-http/src/resources/mod.rs
+++ b/crates/dcc-mcp-http/src/resources/mod.rs
@@ -33,6 +33,7 @@
 //! | `resources_tests.rs`     | Unit + `tokio::test` suite |
 
 mod producers;
+mod skill_resources;
 mod types;
 
 #[cfg(test)]
@@ -48,6 +49,7 @@ use serde_json::Value;
 use tokio::sync::broadcast;
 
 use self::producers::{ArtefactProducer, AuditProducer, CaptureProducer, SceneProducer};
+use self::skill_resources::{SkillResourceProducer, SkillResourceState};
 use self::types::uri_scheme;
 use crate::protocol::{McpResource, ReadResourceResult};
 
@@ -81,6 +83,9 @@ struct ResourceRegistryInner {
     /// registration time and kept here so callers can hand it back to
     /// tools/workflow steps via [`ResourceRegistry::artefact_store`].
     artefact_store: Option<SharedArtefactStore>,
+    /// Cache of resources declared by loaded skills via
+    /// `metadata.dcc-mcp.resources`.
+    skill_resources: Arc<RwLock<SkillResourceState>>,
 }
 
 impl ResourceRegistry {
@@ -121,6 +126,7 @@ impl ResourceRegistry {
     ) -> Self {
         let (updated_tx, _) = broadcast::channel(64);
         let scene_snapshot = Arc::new(RwLock::new(None));
+        let skill_resources = Arc::new(RwLock::new(SkillResourceState::default()));
         let inner = Arc::new(ResourceRegistryInner {
             producers: RwLock::new(Vec::new()),
             subscriptions: RwLock::new(std::collections::HashMap::new()),
@@ -129,6 +135,7 @@ impl ResourceRegistry {
             enabled,
             artefact_enabled,
             artefact_store: store.clone(),
+            skill_resources: skill_resources.clone(),
         });
         let registry = Self { inner };
         if enabled {
@@ -141,6 +148,7 @@ impl ResourceRegistry {
                 enabled: artefact_enabled,
                 store,
             }));
+            registry.add_producer(Arc::new(SkillResourceProducer::new(skill_resources)));
         }
         registry
     }
@@ -159,6 +167,17 @@ impl ResourceRegistry {
     /// `initialize` (mirrors `McpHttpConfig::enable_resources`).
     pub fn is_enabled(&self) -> bool {
         self.inner.enabled
+    }
+
+    /// Refresh the static resources declared by currently loaded skills.
+    pub fn sync_skill_resources<F>(&self, walk_loaded: F)
+    where
+        F: FnMut(&mut dyn FnMut(&dcc_mcp_models::SkillMetadata)),
+    {
+        if !self.inner.enabled {
+            return;
+        }
+        skill_resources::sync_skill_resources(&self.inner.skill_resources, walk_loaded);
     }
 
     /// Register an additional producer.
@@ -244,13 +263,20 @@ impl ResourceRegistry {
             let producers = self.inner.producers.read();
             producers.iter().find(|p| p.scheme() == scheme).cloned()
         };
-        let Some(producer) = producer else {
-            return Err(ResourceError::NotFound(uri.to_string()));
-        };
-        let content = producer.read(uri)?;
-        Ok(ReadResourceResult {
-            contents: vec![content.into_contents()],
-        })
+        if let Some(producer) = producer {
+            let content = producer.read(uri)?;
+            return Ok(ReadResourceResult {
+                contents: vec![content.into_contents()],
+            });
+        }
+        if let Some(result) = skill_resources::read_skill_resource(&self.inner.skill_resources, uri)
+        {
+            let content = result?;
+            return Ok(ReadResourceResult {
+                contents: vec![content.into_contents()],
+            });
+        }
+        Err(ResourceError::NotFound(uri.to_string()))
     }
 
     /// Record a subscription for `session_id -> uri`.

--- a/crates/dcc-mcp-http/src/resources/skill_resources.rs
+++ b/crates/dcc-mcp-http/src/resources/skill_resources.rs
@@ -1,0 +1,284 @@
+use std::collections::{BTreeMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+use serde::Deserialize;
+
+use super::types::{ProducerContent, ResourceError, ResourceProducer, ResourceResult};
+use crate::protocol::McpResource;
+
+#[derive(Default)]
+pub(crate) struct SkillResourceState {
+    loaded_skills: HashSet<String>,
+    entries: BTreeMap<String, SkillResourceEntry>,
+}
+
+#[derive(Clone)]
+struct SkillResourceEntry {
+    resource: McpResource,
+    yaml_dir: PathBuf,
+    source: ResourceSourceSpec,
+}
+
+pub(crate) struct SkillResourceProducer {
+    state: Arc<RwLock<SkillResourceState>>,
+}
+
+impl SkillResourceProducer {
+    pub(crate) fn new(state: Arc<RwLock<SkillResourceState>>) -> Self {
+        Self { state }
+    }
+}
+
+impl ResourceProducer for SkillResourceProducer {
+    fn scheme(&self) -> &str {
+        "skill-resource"
+    }
+
+    fn list(&self) -> Vec<McpResource> {
+        self.state
+            .read()
+            .entries
+            .values()
+            .map(|entry| entry.resource.clone())
+            .collect()
+    }
+
+    fn read(&self, uri: &str) -> ResourceResult<ProducerContent> {
+        let entry = self
+            .state
+            .read()
+            .entries
+            .get(uri)
+            .cloned()
+            .ok_or_else(|| ResourceError::NotFound(uri.to_string()))?;
+        entry.read()
+    }
+}
+
+impl SkillResourceEntry {
+    fn read(&self) -> ResourceResult<ProducerContent> {
+        let source_path = self.yaml_dir.join(&self.source.path);
+        let bytes = std::fs::read(&source_path).map_err(|err| {
+            ResourceError::Read(format!("failed to read {}: {err}", source_path.display()))
+        })?;
+        let mime_type = self
+            .resource
+            .mime_type
+            .clone()
+            .unwrap_or_else(|| "application/octet-stream".to_string());
+        if is_text_mime(&mime_type) {
+            let text = String::from_utf8(bytes).map_err(|err| {
+                ResourceError::Read(format!(
+                    "{} is not valid UTF-8: {err}",
+                    source_path.display()
+                ))
+            })?;
+            Ok(ProducerContent::Text {
+                uri: self.resource.uri.clone(),
+                mime_type,
+                text,
+            })
+        } else {
+            Ok(ProducerContent::Blob {
+                uri: self.resource.uri.clone(),
+                mime_type,
+                bytes,
+            })
+        }
+    }
+}
+
+pub(crate) fn read_skill_resource(
+    state: &Arc<RwLock<SkillResourceState>>,
+    uri: &str,
+) -> Option<ResourceResult<ProducerContent>> {
+    let entry = state.read().entries.get(uri).cloned()?;
+    Some(entry.read())
+}
+
+pub(crate) fn sync_skill_resources<F>(state: &Arc<RwLock<SkillResourceState>>, mut walk_loaded: F)
+where
+    F: FnMut(&mut dyn FnMut(&dcc_mcp_models::SkillMetadata)),
+{
+    let mut loaded_now = HashSet::new();
+    let mut metadatas = Vec::new();
+    let mut visit = |md: &dcc_mcp_models::SkillMetadata| {
+        loaded_now.insert(md.name.clone());
+        metadatas.push(md.clone());
+    };
+    walk_loaded(&mut visit);
+
+    {
+        let current = state.read();
+        if current.loaded_skills == loaded_now {
+            return;
+        }
+    }
+
+    let mut entries = BTreeMap::new();
+    for md in &metadatas {
+        let Some(reference) = resources_reference(md) else {
+            continue;
+        };
+        let skill_root = PathBuf::from(&md.skill_path);
+        for entry in load_resources_from_reference(&skill_root, reference) {
+            entries.insert(entry.resource.uri.clone(), entry);
+        }
+    }
+
+    let mut current = state.write();
+    current.loaded_skills = loaded_now;
+    current.entries = entries;
+}
+
+fn resources_reference(md: &dcc_mcp_models::SkillMetadata) -> Option<&str> {
+    md.metadata
+        .pointer("/dcc-mcp/resources")
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+}
+
+fn load_resources_from_reference(skill_root: &Path, reference: &str) -> Vec<SkillResourceEntry> {
+    let path = skill_root.join(reference);
+    if path.is_dir() {
+        return load_resource_dir(&path);
+    }
+
+    if reference.contains('*') || reference.contains('?') {
+        let pattern_root = match reference.split_once('/') {
+            Some((dir, _)) if !dir.contains('*') && !dir.contains('?') => skill_root.join(dir),
+            _ => skill_root.to_path_buf(),
+        };
+        return load_resource_dir(&pattern_root);
+    }
+
+    load_resource_file(&path)
+}
+
+fn load_resource_dir(path: &Path) -> Vec<SkillResourceEntry> {
+    let Ok(read_dir) = std::fs::read_dir(path) else {
+        tracing::warn!(
+            "resource sidecar directory {} missing or unreadable",
+            path.display()
+        );
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+        if path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .map(|ext| matches!(ext, "yaml" | "yml"))
+            .unwrap_or(false)
+        {
+            out.extend(load_resource_file(&path));
+        }
+    }
+    out
+}
+
+fn load_resource_file(path: &Path) -> Vec<SkillResourceEntry> {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        tracing::warn!(
+            "resource sidecar file {} missing or unreadable",
+            path.display()
+        );
+        return Vec::new();
+    };
+    let specs = match serde_yaml_ng::from_str::<ResourceDocument>(&text) {
+        Ok(doc) => doc.into_specs(),
+        Err(err) => {
+            tracing::warn!("failed to parse resource sidecar {}: {err}", path.display());
+            return Vec::new();
+        }
+    };
+    let yaml_dir = path.parent().unwrap_or_else(|| Path::new("")).to_path_buf();
+    specs
+        .into_iter()
+        .filter_map(|spec| spec.into_entry(&yaml_dir))
+        .collect()
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum ResourceDocument {
+    Wrapped { resources: Vec<ResourceSpec> },
+    List(Vec<ResourceSpec>),
+    Single(ResourceSpec),
+}
+
+impl ResourceDocument {
+    fn into_specs(self) -> Vec<ResourceSpec> {
+        match self {
+            ResourceDocument::Wrapped { resources } | ResourceDocument::List(resources) => {
+                resources
+            }
+            ResourceDocument::Single(resource) => vec![resource],
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ResourceSpec {
+    uri: String,
+    name: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    mime_type: Option<String>,
+    source: ResourceSourceSpec,
+}
+
+impl ResourceSpec {
+    fn into_entry(self, yaml_dir: &Path) -> Option<SkillResourceEntry> {
+        if self.uri.trim().is_empty() || self.name.trim().is_empty() {
+            tracing::warn!("resource sidecar entry requires non-empty uri and name");
+            return None;
+        }
+        if self.source.kind != "file" {
+            tracing::warn!(
+                "resource sidecar entry {} uses unsupported source.type {}; skipping",
+                self.uri,
+                self.source.kind
+            );
+            return None;
+        }
+        if self.source.path.trim().is_empty() {
+            tracing::warn!("resource sidecar entry {} requires source.path", self.uri);
+            return None;
+        }
+        Some(SkillResourceEntry {
+            resource: McpResource {
+                uri: self.uri,
+                name: self.name,
+                description: self.description,
+                mime_type: self.mime_type,
+            },
+            yaml_dir: yaml_dir.to_path_buf(),
+            source: self.source,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct ResourceSourceSpec {
+    #[serde(rename = "type")]
+    kind: String,
+    path: String,
+}
+
+fn is_text_mime(mime_type: &str) -> bool {
+    mime_type.starts_with("text/")
+        || matches!(
+            mime_type,
+            "application/json"
+                | "application/yaml"
+                | "application/x-yaml"
+                | "application/xml"
+                | "application/javascript"
+        )
+}

--- a/crates/dcc-mcp-http/src/resources/tests.rs
+++ b/crates/dcc-mcp-http/src/resources/tests.rs
@@ -139,3 +139,81 @@ fn enabled_artefact_read_unknown_uri_returns_not_found() {
     let err = reg.read("artefact://sha256/deadbeef").unwrap_err();
     assert!(matches!(err, ResourceError::NotFound(_)));
 }
+
+#[test]
+fn skill_resources_list_and_read_text_and_binary_files() {
+    let tmp = tempfile::tempdir().unwrap();
+    let resources_dir = tmp.path().join("resources");
+    let data_dir = resources_dir.join("data");
+    std::fs::create_dir_all(&data_dir).unwrap();
+    std::fs::write(data_dir.join("help.txt"), "polySphere help").unwrap();
+    std::fs::write(data_dir.join("preset.bin"), [0_u8, 1, 2, 3]).unwrap();
+    std::fs::write(
+        resources_dir.join("static.resource.yaml"),
+        r#"
+resources:
+  - uri: maya-cmds://help/polySphere
+    name: cmds.polySphere help
+    mimeType: text/plain
+    source:
+      type: file
+      path: data/help.txt
+  - uri: preset://binary/cube
+    name: cube preset
+    mimeType: application/octet-stream
+    source:
+      type: file
+      path: data/preset.bin
+"#,
+    )
+    .unwrap();
+
+    let reg = ResourceRegistry::new(true, false);
+    let metadata = dcc_mcp_models::SkillMetadata {
+        name: "maya-docs".to_string(),
+        skill_path: tmp.path().to_string_lossy().into_owned(),
+        metadata: json!({"dcc-mcp": {"resources": "resources/"}}),
+        ..Default::default()
+    };
+    reg.sync_skill_resources(|visit| visit(&metadata));
+
+    let uris: Vec<_> = reg
+        .list()
+        .into_iter()
+        .map(|resource| resource.uri)
+        .collect();
+    assert!(uris.iter().any(|uri| uri == "maya-cmds://help/polySphere"));
+    assert!(uris.iter().any(|uri| uri == "preset://binary/cube"));
+
+    let text = reg.read("maya-cmds://help/polySphere").unwrap();
+    assert_eq!(text.contents[0].text.as_deref(), Some("polySphere help"));
+
+    let blob = reg.read("preset://binary/cube").unwrap();
+    let decoded = BASE64_STANDARD
+        .decode(blob.contents[0].blob.as_deref().unwrap())
+        .unwrap();
+    assert_eq!(decoded, [0_u8, 1, 2, 3]);
+}
+
+#[test]
+fn malformed_skill_resource_yaml_is_skipped() {
+    let tmp = tempfile::tempdir().unwrap();
+    let resources_dir = tmp.path().join("resources");
+    std::fs::create_dir_all(&resources_dir).unwrap();
+    std::fs::write(resources_dir.join("bad.resource.yaml"), "resources: [").unwrap();
+
+    let reg = ResourceRegistry::new(true, false);
+    let metadata = dcc_mcp_models::SkillMetadata {
+        name: "bad-docs".to_string(),
+        skill_path: tmp.path().to_string_lossy().into_owned(),
+        metadata: json!({"dcc-mcp": {"resources": "resources/"}}),
+        ..Default::default()
+    };
+    reg.sync_skill_resources(|visit| visit(&metadata));
+
+    assert!(
+        !reg.list()
+            .iter()
+            .any(|resource| resource.uri.starts_with("bad://"))
+    );
+}

--- a/crates/dcc-mcp-skills/src/python/catalog.rs
+++ b/crates/dcc-mcp-skills/src/python/catalog.rs
@@ -6,10 +6,8 @@ use pyo3::prelude::*;
 #[cfg(feature = "stub-gen")]
 use pyo3_stub_gen_derive::gen_stub_pymethods;
 
-use dcc_mcp_actions::registry::ActionRegistry;
-use dcc_mcp_models::{SkillMetadata, SkillScope};
-
 use crate::catalog::{SkillCatalog, SkillSummary, helpers};
+use dcc_mcp_actions::registry::ActionRegistry;
 
 #[cfg_attr(feature = "stub-gen", gen_stub_pymethods)]
 #[pymethods]

--- a/crates/dcc-mcp-skills/src/python/validator.rs
+++ b/crates/dcc-mcp-skills/src/python/validator.rs
@@ -64,6 +64,7 @@ impl From<SkillValidationIssue> for PySkillValidationIssue {
 }
 
 /// Register Python bindings for the validator module.
+#[allow(dead_code)]
 pub fn register_classes(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PySkillValidationIssue>()?;
     m.add_class::<PySkillValidationReport>()?;

--- a/crates/dcc-mcp-skills/src/validator/rules.rs
+++ b/crates/dcc-mcp-skills/src/validator/rules.rs
@@ -333,6 +333,7 @@ fn validate_sidecars(
     validate_sidecar_file(skill_dir, mapping, "tools", report);
     validate_sidecar_file(skill_dir, mapping, "groups", report);
     validate_sidecar_file(skill_dir, mapping, "prompts", report);
+    validate_sidecar_file(skill_dir, mapping, "resources", report);
 }
 
 fn validate_sidecar_file(
@@ -350,7 +351,12 @@ fn validate_sidecar_file(
         .and_then(|value| value.as_str())
     {
         let path = skill_dir.join(sidecar_ref);
-        if !path.is_file() {
+        let exists = if sidecar_ref.contains('*') || sidecar_ref.contains('?') {
+            path.parent().map(|parent| parent.is_dir()).unwrap_or(false)
+        } else {
+            path.is_file() || path.is_dir()
+        };
+        if !exists {
             report.issues.push(SkillValidationIssue::error(
                 IssueCategory::Sidecars,
                 format!(

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -1155,6 +1155,7 @@ in `legacy_extension_fields`).
 | `tools: [...]` inline block     | `metadata["dcc-mcp.tools"]`                  | sibling `.yaml` file  |
 | `groups: [...]` inline block    | `metadata["dcc-mcp.groups"]`                 | sibling `.yaml` file  |
 | *(MCP prompts primitive)*       | `metadata["dcc-mcp.prompts"]`                | sibling `.yaml` file or `prompts/*.prompt.yaml` glob |
+| *(MCP resources primitive)*     | `metadata["dcc-mcp.resources"]`              | sibling `.yaml` file, directory, or `resources/*.resource.yaml` glob |
 
 ### Priority rules
 
@@ -1186,6 +1187,7 @@ Concrete applications (shipped or in flight):
 | Tool declarations + groups | `metadata["dcc-mcp.tools"]`, `metadata["dcc-mcp.groups"]` | `tools.yaml` | #356 |
 | Workflow specs | `metadata["dcc-mcp.workflows"]` | `workflows/*.workflow.yaml` | #348 |
 | Prompts / templates | `metadata["dcc-mcp.prompts"]` | `prompts/*.prompt.yaml` | #351, #355 |
+| Static MCP resources | `metadata["dcc-mcp.resources"]` | `resources/*.resource.yaml` | #733 |
 | Example dialogues | `metadata["dcc-mcp.examples"]` | `references/EXAMPLES.md` or `examples/*.md` | (future) |
 | Tool annotation packs | `metadata["dcc-mcp.annotations"]` | `annotations.yaml` or carried in `tools.yaml` | #344 |
 | next-tools behaviour chains | (carried inline inside `tools.yaml`) | n/a — never a top-level SKILL.md field | #342 |
@@ -1201,6 +1203,10 @@ my-skill/
 │   └── nightly_cleanup.workflow.yaml
 ├── prompts/                 # many files — one per prompt template
 │   └── review_scene.prompt.yaml
+├── resources/               # many files — one per MCP resource bundle
+│   ├── cmds_help.resource.yaml
+│   └── help/
+│       └── polySphere.txt
 └── references/              # Markdown reference material (agentskills.io standard)
     ├── EXAMPLES.md
     └── REFERENCE.md
@@ -1220,6 +1226,36 @@ Why the rule holds:
 If a feature you are designing can't fit this pattern, that is a
 signal to write a proposal under `docs/proposals/` and discuss the
 frontmatter impact before implementing.
+
+### Declaring static MCP resources
+
+A skill can expose static reference material through MCP `resources/list`
+and `resources/read` without Python glue. Point `metadata.dcc-mcp.resources`
+at a resources directory, glob, or single YAML file:
+
+```yaml
+metadata:
+  dcc-mcp:
+    resources: resources/
+```
+
+Each `.resource.yaml` file may contain one resource, a top-level list, or a
+`resources:` list. Static file resources use paths relative to the YAML file:
+
+```yaml
+resources:
+  - uri: maya-cmds://help/polySphere
+    name: cmds.polySphere help
+    mimeType: text/plain
+    description: Output of cmds.help('polySphere') captured at skill build time.
+    source:
+      type: file
+      path: help/polySphere.txt
+```
+
+Loaded skills contribute these entries to `resources/list`; `resources/read`
+returns text for `text/*`, JSON, YAML, XML, and JavaScript MIME types, and a
+base64 `blob` for other MIME types.
 
 ## Validating Skills
 


### PR DESCRIPTION
## Summary

- add static skill resource producer backed by metadata.dcc-mcp.resources sidecars
- sync loaded skill resources into resources/list and resources/read
- document the resources sidecar shape and validate resources sidecar references

## Validation

- vx cargo test --manifest-path G:/PycharmProjects/github/dcc-mcp-core.feat-issue-733-skill-resources/Cargo.toml -p dcc-mcp-http resources::tests --features python-bindings
- vx cargo test --manifest-path G:/PycharmProjects/github/dcc-mcp-core.feat-issue-733-skill-resources/Cargo.toml -p dcc-mcp-skills validator --features python-bindings
- vx just preflight reached cargo nextest after stubgen/check/clippy/fmt; stopped after no new progress from the long workspace test run

Closes #733