### PR TITLE
feat(server): add DCC quit hooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,7 @@ Gateway / slim / REST exposure:
 | Declarative progressive loading on startup | `MinimalModeConfig(skills=…, deactivate_groups=…)` → pass to `register_builtin_actions(minimal_mode=…)` (#525) |
 | Connection-scoped cache | `McpHttpConfig(enable_tool_cache=True)` — per-session `tools/list` snapshot (#438) |
 | Instance-bound diagnostics | `DccServerBase(..., dcc_pid=pid)` |
+| Run code on DCC exit | `DccServerBase.register_quit_hook(callback)` — LIFO best-effort hooks run on `stop()`, context-manager exit, and atexit fallback (#747) |
 | Remote auth | `ApiKeyConfig` / `OAuthConfig` / `validate_bearer_token` |
 | Batch / orchestration | `batch_dispatch()`, `EvalContext`, `DccApiExecutor` |
 | Mid-call user input | `elicit_form()` / `elicit_url()` |

--- a/docs/guide/agents-reference.md
+++ b/docs/guide/agents-reference.md
@@ -792,6 +792,24 @@ DCC adapters include these by default (`include_bundled=True`).
 - **WebSocket Bridge** (`DccBridge`) — Photoshop, ZBrush, Unity, After Effects
 - **WebView Host** (`WebViewAdapter`) — AuroraView, Electron panels
 
+### Lifecycle: quit hooks (issue #747)
+
+Embedded adapters can register cleanup callbacks with
+`DccServerBase.register_quit_hook(callback)`. Hooks run in LIFO order and
+are best-effort: exceptions are logged and do not block later hooks or core
+shutdown.
+
+```python
+server.register_quit_hook(remove_menu)
+server.register_quit_hook(flush_scene_snapshot)
+with server as handle:
+    ...
+# quit hooks run, then the MCP server shuts down
+```
+
+The same hook path is used by explicit `server.stop()`, context-manager
+exit, and the weak atexit fallback installed by `server.start()`.
+
 ### MCP HTTP Server Spawn Modes (issue #303)
 
 `McpHttpConfig.spawn_mode` picks how listeners are driven:

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -48,6 +48,7 @@ Some DCCs may need to override:
 # Import future modules
 from __future__ import annotations
 
+import atexit
 import contextlib
 
 # Import built-in modules
@@ -56,6 +57,8 @@ import os
 from pathlib import Path
 import sys
 from typing import Any
+from typing import Callable
+import weakref
 
 # NOTE: dcc_mcp_core imports (McpHttpConfig, create_skill_server, get_*,
 # get_bundled_skill_paths) are deferred inside methods to avoid a circular
@@ -270,6 +273,9 @@ class DccServerBase:
         self._hot_reloader: Any | None = None
         self._gateway_election: Any | None = None
         self._snapshot_provider: Any | None = snapshot_provider
+        self._quit_hooks: list[Callable[[], Any]] = []
+        self._quit_hooks_ran: bool = False
+        self._atexit_registered: bool = False
 
     def __getattr__(self, name: str) -> Any:
         """Lazily reconstruct collaborators for instances built via ``object.__new__``.
@@ -776,7 +782,58 @@ class DccServerBase:
 
     # ── lifecycle ─────────────────────────────────────────────────────────────
 
-    def start(self) -> Any:
+    @staticmethod
+    def _stop_from_atexit(ref: weakref.ReferenceType[DccServerBase]) -> None:
+        server = ref()
+        if server is not None:
+            server.stop()
+
+    def _ensure_quit_hook_state(self) -> None:
+        if "_quit_hooks" not in self.__dict__:
+            self._quit_hooks = []
+        if "_quit_hooks_ran" not in self.__dict__:
+            self._quit_hooks_ran = False
+        if "_atexit_registered" not in self.__dict__:
+            self._atexit_registered = False
+
+    def register_quit_hook(self, callback: Callable[[], Any]) -> Callable[[], Any]:
+        """Register a callback to run before the server shuts down.
+
+        Hooks run once per server lifetime in LIFO order. Exceptions are
+        logged and swallowed so one broken hook cannot block shutdown.
+        """
+        if not callable(callback):
+            raise TypeError("quit hook must be callable")
+        self._ensure_quit_hook_state()
+        self._quit_hooks.append(callback)
+        return callback
+
+    def unregister_quit_hook(self, callback: Callable[[], Any]) -> bool:
+        """Remove a previously registered quit hook.
+
+        Returns ``True`` when a hook was removed.
+        """
+        self._ensure_quit_hook_state()
+        for idx in range(len(self._quit_hooks) - 1, -1, -1):
+            if self._quit_hooks[idx] is callback:
+                del self._quit_hooks[idx]
+                return True
+        return False
+
+    def _run_quit_hooks(self) -> None:
+        """Run registered quit hooks in LIFO order exactly once."""
+        self._ensure_quit_hook_state()
+        if self._quit_hooks_ran:
+            return
+        self._quit_hooks_ran = True
+        while self._quit_hooks:
+            hook = self._quit_hooks.pop()
+            try:
+                hook()
+            except Exception as exc:
+                logger.warning("[%s] Quit hook failed: %s", self._dcc_name, exc, exc_info=True)
+
+    def start(self, *, install_atexit_hook: bool = True) -> Any:
         """Start the MCP HTTP server.
 
         Starts the gateway election thread if ``enable_gateway_failover`` is
@@ -786,6 +843,7 @@ class DccServerBase:
             ``McpServerHandle`` with ``.mcp_url()``, ``.port``, ``.shutdown()``.
 
         """
+        self._ensure_quit_hook_state()
         if self._handle is not None:
             logger.warning(
                 "[%s] Server already running on port %d",
@@ -793,6 +851,10 @@ class DccServerBase:
                 self._handle.port,
             )
             return self._handle
+        self._quit_hooks_ran = False
+        if install_atexit_hook and not self._atexit_registered:
+            atexit.register(DccServerBase._stop_from_atexit, weakref.ref(self))
+            self._atexit_registered = True
 
         # Register instance-bound diagnostic IPC handlers before the server
         # starts so skill subprocesses can call take_screenshot / audit_log.
@@ -847,6 +909,8 @@ class DccServerBase:
 
     def stop(self) -> None:
         """Gracefully stop the server and gateway election thread."""
+        self._run_quit_hooks()
+
         if self._gateway_election is not None:
             try:
                 self._gateway_election.stop()
@@ -867,6 +931,14 @@ class DccServerBase:
             finally:
                 self._handle = None
             logger.info("[%s] MCP server stopped", self._dcc_name)
+
+    def __enter__(self) -> Any:
+        """Start the server and return its handle for ``with`` blocks."""
+        return self.start()
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        """Stop the server when leaving a ``with`` block."""
+        self.stop()
 
     @property
     def is_running(self) -> bool:

--- a/tests/test_dcc_adapter_base.py
+++ b/tests/test_dcc_adapter_base.py
@@ -379,6 +379,69 @@ class TestDccServerBase:
         assert h1 is h2
         server.stop()
 
+    def test_quit_hooks_run_lifo_once_on_stop(self, tmp_path):
+        server = self._make_server(tmp_path)
+        calls = []
+        server.register_quit_hook(lambda: calls.append("first"))
+        server.register_quit_hook(lambda: calls.append("second"))
+
+        server.stop()
+        server.stop()
+
+        assert calls == ["second", "first"]
+
+    def test_quit_hook_exception_does_not_block_later_hooks(self, tmp_path, caplog):
+        server = self._make_server(tmp_path)
+        calls = []
+
+        def broken():
+            calls.append("broken")
+            raise RuntimeError("boom")
+
+        server.register_quit_hook(lambda: calls.append("first"))
+        server.register_quit_hook(broken)
+        server.register_quit_hook(lambda: calls.append("last"))
+
+        server.stop()
+
+        assert calls == ["last", "broken", "first"]
+        assert "Quit hook failed" in caplog.text
+
+    def test_unregister_quit_hook(self, tmp_path):
+        server = self._make_server(tmp_path)
+        calls = []
+
+        def hook():
+            calls.append("hook")
+
+        assert server.register_quit_hook(hook) is hook
+        assert server.unregister_quit_hook(hook) is True
+        assert server.unregister_quit_hook(hook) is False
+        server.stop()
+        assert calls == []
+
+    def test_context_manager_starts_and_stops(self, tmp_path):
+        server = self._make_server(tmp_path)
+        with server as handle:
+            assert handle is not None
+            assert server.is_running
+        assert not server.is_running
+
+    def test_start_installs_weak_atexit_hook(self, tmp_path, monkeypatch):
+        import dcc_mcp_core.server_base as server_base
+        from dcc_mcp_core.server_base import DccServerBase
+
+        server = self._make_server(tmp_path)
+        registrations = []
+        monkeypatch.setattr(server_base.atexit, "register", lambda *args: registrations.append(args))
+
+        server.start()
+
+        assert len(registrations) == 1
+        callback, ref = registrations[0]
+        assert callback is DccServerBase._stop_from_atexit
+        assert ref() is server
+
     def test_list_skills_returns_list(self, tmp_path):
         server = self._make_server(tmp_path)
         assert isinstance(server.list_skills(), list)


### PR DESCRIPTION
## Summary

- add DccServerBase register_quit_hook/unregister_quit_hook with LIFO exactly-once shutdown semantics
- run quit hooks from stop(), context-manager exit, and weak atexit fallback installed on start()
- document the lifecycle primitive and add regression tests for order, exception handling, unregister, context manager, and atexit registration

## Validation

- PYTHONPATH=G:/PycharmProjects/github/dcc-mcp-core.feat-issue-747-quit-hooks/python vx uv run --project G:/PycharmProjects/github/dcc-mcp-core.feat-issue-747-quit-hooks pytest G:/PycharmProjects/github/dcc-mcp-core.feat-issue-747-quit-hooks/tests/test_dcc_adapter_base.py -q
- PYTHONPATH=G:/PycharmProjects/github/dcc-mcp-core.feat-issue-747-quit-hooks/python vx uv run --project G:/PycharmProjects/github/dcc-mcp-core.feat-issue-747-quit-hooks ruff check G:/PycharmProjects/github/dcc-mcp-core.feat-issue-747-quit-hooks/python/dcc_mcp_core/server_base.py G:/PycharmProjects/github/dcc-mcp-core.feat-issue-747-quit-hooks/tests/test_dcc_adapter_base.py

Closes #747