### PR TITLE
feat(python): add defensive handle shutdown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,7 @@ Gateway / slim / REST exposure:
 | Connection-scoped cache | `McpHttpConfig(enable_tool_cache=True)` — per-session `tools/list` snapshot (#438) |
 | Instance-bound diagnostics | `DccServerBase(..., dcc_pid=pid)` |
 | Run code on DCC exit | `DccServerBase.register_quit_hook(callback)` — LIFO best-effort hooks run on `stop()`, context-manager exit, and atexit fallback (#747) |
+| Defensive Python handle cleanup | `McpHttpConfig(shutdown_on_drop=True)` or `with server.start() as handle:` — safety net for forgotten `handle.shutdown()` (#749) |
 | Remote auth | `ApiKeyConfig` / `OAuthConfig` / `validate_bearer_token` |
 | Batch / orchestration | `batch_dispatch()`, `EvalContext`, `DccApiExecutor` |
 | Mid-call user input | `elicit_form()` / `elicit_url()` |

--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -351,6 +351,13 @@ pub struct McpHttpConfig {
     /// today and pick up real execution when the follow-up PR lands.
     pub enable_workflows: bool,
 
+    /// Best-effort safety net for Python callers that drop a
+    /// `McpServerHandle` without calling `shutdown()`.
+    ///
+    /// Default: `false`. Prefer explicit `handle.shutdown()` or Python
+    /// context-manager usage for deterministic shutdown.
+    pub shutdown_on_drop: bool,
+
     /// Emit the `notifications/$/dcc.jobUpdated` and
     /// `notifications/$/dcc.workflowUpdated` SSE channels (issue #326).
     ///
@@ -592,6 +599,7 @@ impl McpHttpConfig {
             enable_prometheus: false,
             prometheus_basic_auth: None,
             enable_job_notifications: true,
+            shutdown_on_drop: false,
             job_storage_path: None,
             job_recovery: JobRecoveryPolicy::Drop,
             declared_capabilities: Vec::new(),

--- a/crates/dcc-mcp-http/src/python/config.rs
+++ b/crates/dcc-mcp-http/src/python/config.rs
@@ -82,6 +82,12 @@ use std::collections::HashMap;
         /// already usable.
         enable_workflows: bool => [get, set],
 
+        /// Best-effort safety net for Python callers that drop a
+        /// ``McpServerHandle`` without explicitly calling ``shutdown()``.
+        /// Default: ``False``. Prefer ``with server.start() as handle`` or
+        /// explicit ``handle.shutdown()`` for deterministic shutdown.
+        shutdown_on_drop: bool => [get, set],
+
         /// Emit the ``$/dcc.jobUpdated`` and ``$/dcc.workflowUpdated`` SSE
         /// channels (issue #326).
         ///
@@ -254,7 +260,7 @@ pub struct PyMcpHttpConfig {
 impl PyMcpHttpConfig {
     /// Create a new config. ``port=0`` binds to any available port.
     #[new]
-    #[pyo3(signature = (port=8765, server_name=None, server_version=None, enable_cors=false, request_timeout_ms=30000, backend_timeout_ms=120_000, enable_prometheus=false, prometheus_basic_auth=None, gateway_async_dispatch_timeout_ms=60_000, gateway_wait_terminal_timeout_ms=600_000, gateway_route_ttl_secs=86_400, gateway_max_routes_per_session=1_000))]
+    #[pyo3(signature = (port=8765, server_name=None, server_version=None, enable_cors=false, request_timeout_ms=30000, backend_timeout_ms=120_000, enable_prometheus=false, prometheus_basic_auth=None, gateway_async_dispatch_timeout_ms=60_000, gateway_wait_terminal_timeout_ms=600_000, gateway_route_ttl_secs=86_400, gateway_max_routes_per_session=1_000, shutdown_on_drop=false))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         port: u16,
@@ -269,6 +275,7 @@ impl PyMcpHttpConfig {
         gateway_wait_terminal_timeout_ms: u64,
         gateway_route_ttl_secs: u64,
         gateway_max_routes_per_session: u64,
+        shutdown_on_drop: bool,
     ) -> Self {
         let mut cfg = McpHttpConfig::new(port);
         if let Some(name) = server_name {
@@ -286,6 +293,7 @@ impl PyMcpHttpConfig {
         cfg.gateway_wait_terminal_timeout_ms = gateway_wait_terminal_timeout_ms;
         cfg.gateway_route_ttl_secs = gateway_route_ttl_secs;
         cfg.gateway_max_routes_per_session = gateway_max_routes_per_session;
+        cfg.shutdown_on_drop = shutdown_on_drop;
         // Issue #303: PyO3-embedded hosts (Maya on Windows etc.) cannot
         // rely on shared tokio worker threads to drive the accept loop
         // after `block_on` returns. Default to `Dedicated` so the listener
@@ -532,6 +540,7 @@ mod drift_tests {
         let _ = cfg.lazy_actions();
         let _ = cfg.enable_workflows();
         let _ = cfg.enable_job_notifications();
+        let _ = cfg.shutdown_on_drop();
         let _ = cfg.job_storage_path();
         let _ = cfg.job_recovery();
 

--- a/crates/dcc-mcp-http/src/python/server.rs
+++ b/crates/dcc-mcp-http/src/python/server.rs
@@ -1,6 +1,7 @@
 //! Handle returned by `McpHttpServer.start()`.
 
 use super::*;
+use std::time::Duration;
 
 /// Handle returned by `McpHttpServer.start()`.
 ///
@@ -21,6 +22,51 @@ pub struct PyServerHandle {
     /// can push scene/version/documents updates that flow into FileRegistry
     /// on the next heartbeat tick.
     pub(crate) live_meta: Arc<RwLock<LiveMetaInner>>,
+    /// Opt-in safety net for forgotten explicit shutdown calls.
+    pub(crate) shutdown_on_drop: bool,
+}
+
+impl PyServerHandle {
+    fn shutdown_inner(&mut self) {
+        if let Some(handle) = self.inner.take() {
+            self.runtime.block_on(handle.shutdown());
+        }
+    }
+
+    fn shutdown_on_drop_inner(&mut self) {
+        let Some(handle) = self.inner.take() else {
+            return;
+        };
+        if tokio::runtime::Handle::try_current().is_ok() {
+            tracing::error!(
+                "McpServerHandle dropped inside a Tokio runtime; graceful shutdown would deadlock, skipping"
+            );
+            return;
+        }
+        match self.runtime.block_on(async {
+            tokio::time::timeout(Duration::from_secs(5), handle.shutdown()).await
+        }) {
+            Ok(()) => tracing::warn!(
+                "McpServerHandle dropped without explicit shutdown(); shutdown_on_drop completed"
+            ),
+            Err(_) => tracing::error!("McpServerHandle drop shutdown timed out after 5s"),
+        }
+    }
+}
+
+impl Drop for PyServerHandle {
+    fn drop(&mut self) {
+        if self.inner.is_none() {
+            return;
+        }
+        if !self.shutdown_on_drop {
+            tracing::warn!(
+                "McpServerHandle dropped without explicit shutdown(); call shutdown() or set McpHttpConfig.shutdown_on_drop=True"
+            );
+            return;
+        }
+        self.shutdown_on_drop_inner();
+    }
 }
 
 #[pymethods]
@@ -44,9 +90,20 @@ impl PyServerHandle {
 
     /// Gracefully shut down the server.
     fn shutdown(&mut self) {
-        if let Some(handle) = self.inner.take() {
-            self.runtime.block_on(handle.shutdown());
-        }
+        self.shutdown_inner();
+    }
+
+    fn __enter__(slf: PyRefMut<'_, Self>) -> PyRefMut<'_, Self> {
+        slf
+    }
+
+    fn __exit__(
+        mut slf: PyRefMut<'_, Self>,
+        _exc_type: Py<PyAny>,
+        _exc: Py<PyAny>,
+        _tb: Py<PyAny>,
+    ) {
+        slf.shutdown_inner();
     }
 
     /// Signal shutdown without blocking.

--- a/crates/dcc-mcp-http/src/python/skill_server.rs
+++ b/crates/dcc-mcp-http/src/python/skill_server.rs
@@ -187,6 +187,7 @@ impl PyMcpHttpServer {
             bind_addr,
             is_gateway,
             live_meta: self.live_meta.clone(),
+            shutdown_on_drop: self.config.shutdown_on_drop,
         })
     }
 

--- a/docs/guide/agents-reference.md
+++ b/docs/guide/agents-reference.md
@@ -810,6 +810,18 @@ with server as handle:
 The same hook path is used by explicit `server.stop()`, context-manager
 exit, and the weak atexit fallback installed by `server.start()`.
 
+For the lower-level PyO3 handle, prefer deterministic cleanup:
+
+```python
+with server.start() as handle:
+    ...
+# handle.shutdown() is called by __exit__
+```
+
+`McpHttpConfig(shutdown_on_drop=True)` is available as a loud, opt-in
+safety net for tests and one-shot scripts that accidentally drop the final
+`McpServerHandle` reference without calling `shutdown()`.
+
 ### MCP HTTP Server Spawn Modes (issue #303)
 
 `McpHttpConfig.spawn_mode` picks how listeners are driven:

--- a/tests/test_mcp_http_server.py
+++ b/tests/test_mcp_http_server.py
@@ -16,6 +16,7 @@ always run since they only require the standard library.
 from __future__ import annotations
 
 # Import built-in modules
+import gc
 import json
 from threading import Thread
 import time
@@ -93,6 +94,17 @@ def _rest_base(mcp_url: str) -> str:
     return mcp_url.rsplit("/mcp", 1)[0]
 
 
+def _wait_unreachable(url: str, timeout: float = 2.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            urllib.request.urlopen(url, timeout=0.2)
+        except Exception:
+            return
+        time.sleep(0.05)
+    raise AssertionError(f"server still reachable at {url}")
+
+
 def _make_registry() -> ToolRegistry:
     reg = ToolRegistry()
     reg.register(
@@ -131,6 +143,34 @@ def running_server():
     url = handle.mcp_url()
     yield server, handle, url
     handle.shutdown()
+
+
+# ── handle lifecycle tests ────────────────────────────────────────────────
+
+
+def test_handle_context_manager_shutdowns_server():
+    reg = _make_registry()
+    server = McpHttpServer(reg, McpHttpConfig(port=0, server_name="ctx-test"))
+    with server.start() as handle:
+        url = handle.mcp_url()
+        code, _ = _post_json(url, {"jsonrpc": "2.0", "id": 1, "method": "ping"})
+        assert code == 200
+    _wait_unreachable(url)
+
+
+def test_handle_shutdown_on_drop_stops_server():
+    reg = _make_registry()
+    config = McpHttpConfig(port=0, server_name="drop-test", shutdown_on_drop=True)
+    server = McpHttpServer(reg, config)
+    handle = server.start()
+    url = handle.mcp_url()
+    code, _ = _post_json(url, {"jsonrpc": "2.0", "id": 1, "method": "ping"})
+    assert code == 200
+
+    del handle
+    gc.collect()
+
+    _wait_unreachable(url)
 
 
 # ── basic HTTP protocol tests (stdlib only) ───────────────────────────────


### PR DESCRIPTION
## Summary

- add McpHttpConfig.shutdown_on_drop with Python getter/setter and constructor kwarg
- add McpServerHandle context-manager shutdown plus opt-in Drop safety net with runtime re-entry guard and timeout
- add Python E2E coverage for context-manager shutdown and shutdown_on_drop, plus config drift coverage

## Validation

- vx cargo check -p dcc-mcp-http --features python-bindings
- PYTHONPATH=python vx uv run --project . pytest tests/test_mcp_http_server.py -q
- PYTHONPATH=python vx uv run --project . ruff check tests/test_mcp_http_server.py

Closes #749