### PR TITLE
feat(transport): add registry sentinel locks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,7 @@ Gateway / slim / REST exposure:
 | Hide unknown DCC types from gateway | `McpHttpConfig.allow_unknown_tools = false` (default) — drops tools whose `dcc_type` is not registered with the gateway (#553, #555) |
 | Auto-evict dead gateway instances | Gateway runs a TCP probe loop; deregisters after 3 consecutive failures, also runs a startup probe to evict instances whose listener died while the registry entry survived (#551, #552, #556) |
 | Crash-safe heartbeat | `FileRegistry::heartbeat` writes via `tempfile::persist` + Windows `LockFileEx` so concurrent processes can't stomp each other's entry (#554) |
+| Crash-resilient liveness check | `FileRegistry` sentinel lock files — `read_alive()` / `prune_dead_entries()` evict rows whose owner process released its OS-held lock (#748) |
 | Default rolling file logging | `default_file_logging_config()` from `dcc_mcp_logging::file_logging` — rolling daily files under the platform log dir (#557) |
 | Trim old log files | `prune_old_logs(retention_days, max_total_size_mb)` — call on a schedule or at startup to enforce retention (#558) |
 | Prometheus `/metrics` (gateway) | Build `dcc-mcp-http` with `--features prometheus`; `attach_gateway_metrics_route` + `dcc_mcp_telemetry::PrometheusExporter` expose `dcc_mcp_instances_total{status}`, `dcc_mcp_tools_total{dcc_type}`, request duration / failure counters at `GET /metrics` (#559) |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,6 +1203,7 @@ dependencies = [
  "criterion",
  "dashmap",
  "dcc-mcp-pybridge",
+ "fs4",
  "ipckit",
  "parking_lot",
  "pyo3",
@@ -1622,6 +1623,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs4"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/dcc-mcp-transport/Cargo.toml
+++ b/crates/dcc-mcp-transport/Cargo.toml
@@ -27,6 +27,7 @@ dcc-mcp-pybridge = { workspace = true, optional = true }
 sysinfo.workspace = true
 ipckit.workspace = true
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
+fs4 = "1.1.0"
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/dcc-mcp-transport/src/discovery/file_registry.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry.rs
@@ -3,12 +3,14 @@
 //! Stores service entries as JSON in a registry directory.
 //! Uses `(dcc_type, instance_id)` as key to support multiple instances per DCC type.
 
-use std::fs;
-use std::path::PathBuf;
+use std::fs::{self, File, OpenOptions};
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::{Duration, SystemTime};
 
 use dashmap::DashMap;
+use fs4::{FileExt, TryLockError};
 use sysinfo::{Pid, ProcessesToUpdate, System};
 use tracing;
 
@@ -29,6 +31,7 @@ fn is_pid_alive(pid: u32) -> bool {
 
 /// File name for the registry JSON.
 const REGISTRY_FILE: &str = "services.json";
+const LOCKS_DIR: &str = "locks";
 
 /// File-based service registry with instance-level keying.
 ///
@@ -44,6 +47,8 @@ pub struct FileRegistry {
     services: DashMap<ServiceKey, ServiceEntry>,
     /// Directory where registry file is stored.
     registry_dir: PathBuf,
+    /// Sentinel lock files owned by entries registered in this process.
+    sentinel_handles: DashMap<ServiceKey, File>,
     /// Last-seen modification time of services.json.
     /// Used to detect external writes (hot-reload).
     last_mtime: Mutex<Option<SystemTime>>,
@@ -64,6 +69,7 @@ impl FileRegistry {
         let registry = Self {
             services: DashMap::new(),
             registry_dir,
+            sentinel_handles: DashMap::new(),
             last_mtime: Mutex::new(None),
         };
 
@@ -135,8 +141,75 @@ impl FileRegistry {
         Ok(())
     }
 
+    fn locks_dir(&self) -> PathBuf {
+        self.registry_dir.join(LOCKS_DIR)
+    }
+
+    fn sentinel_path_for(&self, key: &ServiceKey) -> PathBuf {
+        self.locks_dir()
+            .join(format!("{}-{}.lock", key.dcc_type, key.instance_id))
+    }
+
+    fn create_sentinel(&self, key: &ServiceKey) -> TransportResult<(PathBuf, File)> {
+        let locks_dir = self.locks_dir();
+        fs::create_dir_all(&locks_dir).map_err(|e| {
+            TransportError::RegistryFile(format!(
+                "failed to create sentinel dir {}: {}",
+                locks_dir.display(),
+                e
+            ))
+        })?;
+        let path = self.sentinel_path_for(key);
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .map_err(|e| {
+                TransportError::RegistryFile(format!(
+                    "failed to open sentinel {}: {}",
+                    path.display(),
+                    e
+                ))
+            })?;
+        FileExt::lock(&file).map_err(|e| {
+            TransportError::RegistryFile(format!(
+                "failed to lock sentinel {}: {}",
+                path.display(),
+                e
+            ))
+        })?;
+        Ok((path, file))
+    }
+
+    fn sentinel_is_dead(&self, key: &ServiceKey, path: &Path) -> bool {
+        if self.sentinel_handles.contains_key(key) {
+            return false;
+        }
+        let file = match OpenOptions::new().read(true).write(true).open(path) {
+            Ok(file) => file,
+            Err(err) if err.kind() == ErrorKind::NotFound => return true,
+            Err(err) => {
+                tracing::warn!(sentinel = %path.display(), error = %err, "failed to open sentinel; keeping entry");
+                return false;
+            }
+        };
+        match FileExt::try_lock(&file) {
+            Ok(()) => {
+                let _ = file.unlock();
+                true
+            }
+            Err(TryLockError::WouldBlock) => false,
+            Err(TryLockError::Error(err)) => {
+                tracing::warn!(sentinel = %path.display(), error = %err, "failed to probe sentinel; keeping entry");
+                false
+            }
+        }
+    }
+
     /// Register a service.
-    pub fn register(&self, entry: ServiceEntry) -> TransportResult<()> {
+    pub fn register(&self, mut entry: ServiceEntry) -> TransportResult<()> {
         let key = entry.key();
         tracing::info!(
             dcc_type = %entry.dcc_type,
@@ -145,6 +218,9 @@ impl FileRegistry {
             port = entry.port,
             "registering service"
         );
+        let (sentinel_path, sentinel_file) = self.create_sentinel(&key)?;
+        entry.sentinel_path = Some(sentinel_path);
+        self.sentinel_handles.insert(key.clone(), sentinel_file);
         self.services.insert(key, entry);
         self.flush_to_file()
     }
@@ -152,6 +228,14 @@ impl FileRegistry {
     /// Deregister a service by key.
     pub fn deregister(&self, key: &ServiceKey) -> TransportResult<Option<ServiceEntry>> {
         let removed = self.services.remove(key).map(|(_, entry)| entry);
+        if let Some((_, file)) = self.sentinel_handles.remove(key) {
+            let _ = file.unlock();
+        }
+        if let Some(entry) = &removed
+            && let Some(path) = &entry.sentinel_path
+        {
+            let _ = fs::remove_file(path);
+        }
         if removed.is_some() {
             tracing::info!(
                 dcc_type = %key.dcc_type,
@@ -437,30 +521,38 @@ impl FileRegistry {
 
     /// Remove entries whose owning OS process is no longer running.
     ///
-    /// Complements [`Self::cleanup_stale`]: a plugin that crashes during
-    /// `initializePlugin` (after `bind_and_register` wrote its row but before
-    /// the heartbeat task started) would otherwise leak a ghost entry for up
-    /// to `stale_timeout` seconds. This check runs a PID liveness probe and
-    /// removes entries with dead PIDs immediately — including the gateway
-    /// sentinel, since a dead gateway process must not keep the sentinel alive.
-    ///
-    /// Entries without a `pid` set are left untouched (fail-open — we cannot
-    /// probe what we cannot identify). See issue #227.
-    pub fn prune_dead_pids(&self) -> TransportResult<usize> {
+    /// Sentinel locks are checked before PID liveness: if another process can
+    /// acquire the sentinel lock, the owner is gone even if the PID has already
+    /// been reused. Rows from older versions without a sentinel fall back to the
+    /// PID probe. Includes the gateway sentinel.
+    pub fn prune_dead_entries(&self) -> TransportResult<usize> {
         let dead_keys: Vec<ServiceKey> = self
             .services
             .iter()
-            .filter(|r| r.value().pid.is_some_and(|p| !is_pid_alive(p)))
+            .filter(|r| {
+                let entry = r.value();
+                if let Some(path) = entry.sentinel_path.as_deref() {
+                    self.sentinel_is_dead(r.key(), path)
+                } else {
+                    entry.pid.is_some_and(|p| !is_pid_alive(p))
+                }
+            })
             .map(|r| r.key().clone())
             .collect();
 
         let count = dead_keys.len();
         for key in &dead_keys {
-            self.services.remove(key);
+            let removed = self.services.remove(key).map(|(_, entry)| entry);
+            self.sentinel_handles.remove(key);
+            if let Some(entry) = removed
+                && let Some(path) = entry.sentinel_path
+            {
+                let _ = fs::remove_file(path);
+            }
             tracing::info!(
                 dcc_type = %key.dcc_type,
                 instance_id = %key.instance_id,
-                "removed ghost entry (owning process is dead)"
+                "removed ghost entry (owner sentinel/PID is dead)"
             );
         }
 
@@ -468,6 +560,11 @@ impl FileRegistry {
             self.flush_to_file()?;
         }
         Ok(count)
+    }
+
+    /// Backward-compatible name for [`Self::prune_dead_entries`].
+    pub fn prune_dead_pids(&self) -> TransportResult<usize> {
+        self.prune_dead_entries()
     }
 
     /// Read all live entries, evicting any whose owning OS process is dead.
@@ -485,7 +582,7 @@ impl FileRegistry {
     ///
     /// Closes loonghao/dcc-mcp-maya#126.
     pub fn read_alive(&self) -> TransportResult<(Vec<ServiceEntry>, usize)> {
-        let evicted = self.prune_dead_pids()?;
+        let evicted = self.prune_dead_entries()?;
         Ok((self.list_all(), evicted))
     }
 

--- a/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
@@ -3,6 +3,13 @@
 use super::*;
 use uuid::Uuid;
 
+fn remove_sentinel_for_pid_fallback(registry: &FileRegistry, key: &ServiceKey) {
+    registry.sentinel_handles.remove(key);
+    if let Some(mut entry) = registry.services.get_mut(key) {
+        entry.sentinel_path = None;
+    }
+}
+
 #[test]
 fn test_file_registry_register_and_list() {
     let dir = tempfile::tempdir().unwrap();
@@ -141,6 +148,7 @@ fn test_file_registry_prune_dead_pids() {
     let ghost = ServiceEntry::new("maya", "127.0.0.1", 18813).with_pid(u32::MAX);
     let ghost_key = ghost.key();
     registry.register(ghost).unwrap();
+    remove_sentinel_for_pid_fallback(&registry, &ghost_key);
 
     let pruned = registry.prune_dead_pids().unwrap();
     assert_eq!(pruned, 1, "exactly one ghost entry should be pruned");
@@ -149,6 +157,37 @@ fn test_file_registry_prune_dead_pids() {
         registry.get(&ghost_key).is_none(),
         "ghost entry must be removed"
     );
+}
+
+#[test]
+fn test_file_registry_sentinel_survives_dead_pid_while_lock_held() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = FileRegistry::new(dir.path()).unwrap();
+
+    let entry = ServiceEntry::new("maya", "127.0.0.1", 18812).with_pid(u32::MAX);
+    let key = entry.key();
+    registry.register(entry).unwrap();
+
+    assert_eq!(registry.prune_dead_entries().unwrap(), 0);
+    assert!(registry.get(&key).is_some());
+}
+
+#[test]
+fn test_file_registry_sentinel_prunes_after_owner_drops_lock() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = {
+        let registry = FileRegistry::new(dir.path()).unwrap();
+        let entry = ServiceEntry::new("maya", "127.0.0.1", 18812);
+        let key = entry.key();
+        registry.register(entry).unwrap();
+        key
+    };
+
+    let reader = FileRegistry::new(dir.path()).unwrap();
+    let pruned = reader.prune_dead_entries().unwrap();
+
+    assert_eq!(pruned, 1);
+    assert!(reader.get(&key).is_none());
 }
 
 #[test]
@@ -380,6 +419,7 @@ fn test_read_alive_evicts_ghost_and_returns_live() {
     let ghost = ServiceEntry::new("maya", "127.0.0.1", 18813).with_pid(u32::MAX);
     let ghost_key = ghost.key();
     registry.register(ghost).unwrap();
+    remove_sentinel_for_pid_fallback(&registry, &ghost_key);
 
     let (entries, evicted) = registry.read_alive().unwrap();
     assert_eq!(evicted, 1, "exactly one ghost row must be evicted");
@@ -413,7 +453,9 @@ fn test_read_alive_idempotent_after_first_call() {
     let live = ServiceEntry::new("maya", "127.0.0.1", 18812);
     registry.register(live).unwrap();
     let ghost = ServiceEntry::new("maya", "127.0.0.1", 18813).with_pid(u32::MAX);
+    let ghost_key = ghost.key();
     registry.register(ghost).unwrap();
+    remove_sentinel_for_pid_fallback(&registry, &ghost_key);
 
     let (_, evicted_first) = registry.read_alive().unwrap();
     assert_eq!(evicted_first, 1);
@@ -433,7 +475,9 @@ fn test_read_alive_with_log_returns_same_result() {
     let live = ServiceEntry::new("maya", "127.0.0.1", 18812);
     registry.register(live).unwrap();
     let ghost = ServiceEntry::new("maya", "127.0.0.1", 18813).with_pid(u32::MAX);
+    let ghost_key = ghost.key();
     registry.register(ghost).unwrap();
+    remove_sentinel_for_pid_fallback(&registry, &ghost_key);
 
     // Threshold larger than the eviction count → no warn, but counts match.
     let (entries, evicted) = registry.read_alive_with_log(100).unwrap();
@@ -451,7 +495,9 @@ fn test_read_alive_handles_multiple_ghosts_for_dcc_maya_126() {
 
     for port in 18812..18812 + 5 {
         let ghost = ServiceEntry::new("maya", "127.0.0.1", port).with_pid(u32::MAX - port as u32);
+        let ghost_key = ghost.key();
         registry.register(ghost).unwrap();
+        remove_sentinel_for_pid_fallback(&registry, &ghost_key);
     }
     let live = ServiceEntry::new("maya", "127.0.0.1", 19000);
     registry.register(live).unwrap();

--- a/crates/dcc-mcp-transport/src/discovery/types.rs
+++ b/crates/dcc-mcp-transport/src/discovery/types.rs
@@ -140,6 +140,14 @@ pub struct ServiceEntry {
     /// same scene open (e.g. two Maya sessions reviewing the same asset).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pid: Option<u32>,
+    /// OS-held sentinel lock file for crash-resilient liveness checks.
+    ///
+    /// The owning process holds an exclusive lock while registered. Readers can
+    /// take the lock only after the owner exits or crashes, avoiding PID reuse
+    /// races while remaining backward-compatible with rows that omit this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sentinel_path: Option<std::path::PathBuf>,
+    /// Human-readable label for this instance.
     /// Human-readable label for this instance.
     ///
     /// Set by the DCC plugin at registration time (e.g. `"Maya-Rigging"`,
@@ -205,6 +213,7 @@ impl ServiceEntry {
             scene: None,
             documents: Vec::new(),
             pid: Some(std::process::id()),
+            sentinel_path: None,
             display_name: None,
             metadata: HashMap::new(),
             extras: HashMap::new(),
@@ -241,6 +250,7 @@ impl ServiceEntry {
             scene: None,
             documents: Vec::new(),
             pid: Some(std::process::id()),
+            sentinel_path: None,
             display_name: None,
             metadata: HashMap::new(),
             extras: HashMap::new(),


### PR DESCRIPTION
## Summary

- add per-entry FileRegistry sentinel lock files and persist sentinel_path in ServiceEntry
- use sentinel locks before PID probing in prune_dead_entries/read_alive to avoid PID reuse ghost rows
- clean up sentinel files on deregister and keep backward-compatible prune_dead_pids fallback for older rows

## Validation

- vx cargo test -p dcc-mcp-transport file_registry
- vx cargo check -p dcc-mcp-transport

Closes #748