### PR TITLE
docs(agents): steer custom-resource callers to helpers before server.resources()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,7 +179,7 @@ Gateway resources:
 | Full-screen capture | `Capturer.new_auto().capture()` |
 | Single-window capture | `Capturer.new_window_auto().capture_window(...)` |
 | Capture DCC output streams | `OutputCapture` — stdout/stderr/script-editor as `output://` resource |
-| Register a custom DCC resource | `server.resources().register_producer("maya-cmds://", cb)` — also `set_scene({...})`, `notify_updated(uri)`, `register_output_buffer(capture)` (#730) |
+| Register a custom DCC resource | Prefer a module-level helper first: `register_docs_resource(server, ...)` for `docs://` payloads, `register_adapter_instruction_resources(server, ...)` for adapter instructions. Only drop to the low-level surface `server.resources().register_producer("maya-cmds://", cb)` (also `set_scene({...})`, `notify_updated(uri)`, `register_output_buffer(capture)`) when no helper fits the scheme (#730). Never reach into `server._server.*` — that is private. |
 | Cooperative cancellation (MCP request) | `check_cancelled()` in long-running skill scripts |
 | Cooperative cancellation (DCC dispatcher + MCP) | `check_dcc_cancelled()` — combines MCP token + per-job `JobHandle` (#522) |
 | Detect a misconfigured GUI binary as `DCC_MCP_PYTHON_EXECUTABLE` | `is_gui_executable(path)` → `GuiExecutableHint(dcc_kind, recommended_replacement)` (#524) |


### PR DESCRIPTION
## What

Rewrites the "Register a custom DCC resource" row in `AGENTS.md` to
spell out the decision order adapters should follow, so downstream
adapters (especially `dcc-mcp-maya`) stop reaching for
`server.resources().register_producer(...)` when a higher-level
helper already fits.

## Decision order (new)

1. `register_docs_resource(server, ...)` — for `docs://` payloads
2. `register_adapter_instruction_resources(server, ...)` — for
   adapter instructions / capabilities / troubleshooting
3. `server.resources().register_producer(...)` — only when no helper
   fits the scheme (custom `maya-cmds://`, live output buffers, etc.)
4. Never reach into `server._server.*` — explicitly private.

## Why

The old row pointed directly at the low-level surface, which set a
misleading default. Downstream feedback flagged adapters bypassing
the module-level helpers. Aligning the doc with the actual preferred
path prevents future drift.

## Scope

Docs-only. Single-line change, no runtime behaviour affected.

## Release-please

`docs:` commit — will appear under "Documentation" in the next
release changelog and does not bump the version on its own (unless
bundled with code changes in the same release window).
