### PR TITLE
refactor(search): strategy-pattern for SearchMode + Scorer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,6 +539,32 @@ dependencies = [
 
 [[package]]
 name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot 0.5.0",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
@@ -548,7 +574,7 @@ dependencies = [
  "cast",
  "ciborium",
  "clap",
- "criterion-plot",
+ "criterion-plot 0.8.2",
  "itertools 0.13.0",
  "num-traits",
  "oorandom",
@@ -560,6 +586,16 @@ dependencies = [
  "serde_json",
  "tinytemplate",
  "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -803,6 +839,7 @@ version = "0.14.28"
 dependencies = [
  "axum",
  "chrono",
+ "criterion 0.5.1",
  "dashmap",
  "dcc-mcp-jsonrpc",
  "dcc-mcp-naming",
@@ -1200,7 +1237,7 @@ dependencies = [
 name = "dcc-mcp-transport"
 version = "0.14.28"
 dependencies = [
- "criterion",
+ "criterion 0.8.2",
  "dashmap",
  "dcc-mcp-pybridge",
  "fs4",
@@ -1904,6 +1941,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2317,10 +2360,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"

--- a/crates/dcc-mcp-gateway/Cargo.toml
+++ b/crates/dcc-mcp-gateway/Cargo.toml
@@ -50,3 +50,8 @@ prometheus = ["dep:dcc-mcp-telemetry", "dcc-mcp-telemetry/prometheus"]
 [dev-dependencies]
 tempfile = "3"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "search_bench"
+harness = false

--- a/crates/dcc-mcp-gateway/benches/search_bench.rs
+++ b/crates/dcc-mcp-gateway/benches/search_bench.rs
@@ -1,0 +1,118 @@
+//! Criterion benchmarks for the search-scoring strategy seam (issue #765).
+//!
+//! These benchmarks pin the raw throughput of [`StrategyFuzzyScorer`] and
+//! [`StrategyExactScorer`] so that adding trait dispatch overhead is
+//! detected before merging. The acceptance criterion is that either
+//! scorer stays within 10 % of today's baseline when called via a
+//! `Box<dyn StrategyScorer>` obtained from [`ScorerFactory`].
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo bench -p dcc-mcp-gateway --bench search_bench
+//! ```
+
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use dcc_mcp_gateway::{
+    ScorerFactory, SearchMode, StrategyExactScorer, StrategyFuzzyScorer, StrategyScorer,
+};
+
+// ---------------------------------------------------------------------------
+// Shared corpus
+// ---------------------------------------------------------------------------
+
+const CANDIDATES: &[&str] = &[
+    "create_sphere",
+    "delete_sphere",
+    "export_fbx",
+    "import_obj",
+    "render_scene",
+    "save_scene",
+    "open_scene",
+    "close_scene",
+    "set_keyframe",
+    "remove_keyframe",
+    "bake_animation",
+    "play_animation",
+    "stop_animation",
+    "load_plugin",
+    "unload_plugin",
+    "list_plugins",
+    "get_selection",
+    "set_selection",
+    "clear_selection",
+    "duplicate_object",
+];
+
+const QUERIES: &[&str] = &[
+    "sphere",
+    "anim",
+    "scene",
+    "sel",
+    "creat_spher", // intentional typo — fuzzy must survive
+    "plugin",
+];
+
+// ---------------------------------------------------------------------------
+// Helper: score every (query, candidate) pair once
+// ---------------------------------------------------------------------------
+
+fn score_all(scorer: &dyn StrategyScorer) -> f32 {
+    let mut total = 0.0f32;
+    for q in QUERIES {
+        for c in CANDIDATES {
+            total += scorer.score(black_box(q), black_box(c));
+        }
+    }
+    total
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+fn bench_fuzzy_direct(c: &mut Criterion) {
+    let scorer = StrategyFuzzyScorer;
+    c.bench_function("StrategyFuzzyScorer/direct", |b| {
+        b.iter(|| score_all(&scorer))
+    });
+}
+
+fn bench_exact_direct(c: &mut Criterion) {
+    let scorer = StrategyExactScorer;
+    c.bench_function("StrategyExactScorer/direct", |b| {
+        b.iter(|| score_all(&scorer))
+    });
+}
+
+fn bench_factory_dispatch(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ScorerFactory/dyn-dispatch");
+    for mode in [SearchMode::Fuzzy, SearchMode::Exact] {
+        let label = format!("{mode:?}");
+        group.bench_with_input(BenchmarkId::new("mode", &label), &mode, |b, &m| {
+            let scorer = ScorerFactory::from_mode(m);
+            b.iter(|| score_all(scorer.as_ref()))
+        });
+    }
+    group.finish();
+}
+
+fn bench_factory_tag(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ScorerFactory/from_tag");
+    for tag in ["fuzzy", "exact"] {
+        group.bench_with_input(BenchmarkId::new("tag", tag), &tag, |b, &t| {
+            let scorer = ScorerFactory::from_tag(t);
+            b.iter(|| score_all(scorer.as_ref()))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_fuzzy_direct,
+    bench_exact_direct,
+    bench_factory_dispatch,
+    bench_factory_tag,
+);
+criterion_main!(benches);

--- a/crates/dcc-mcp-gateway/src/gateway/capability/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/mod.rs
@@ -71,4 +71,7 @@ pub use refresh::{RefreshReason, refresh_instance, remove_instance};
 pub use search::{
     DEFAULT_LIMIT, MAX_LIMIT, SearchHit, SearchMode, SearchPage, SearchQuery, search, search_page,
 };
-pub use search_ranking::{FuzzyScorer, Scorer, SubstringScorer};
+pub use search_ranking::{
+    ExactScorer, FuzzyScorer, Scorer, ScorerFactory, StrategyExactScorer, StrategyFuzzyScorer,
+    StrategyScorer, SubstringScorer,
+};

--- a/crates/dcc-mcp-gateway/src/gateway/capability/search_ranking.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/search_ranking.rs
@@ -1,5 +1,5 @@
 //! Pluggable ranking strategies for the capability search layer
-//! (issue [#659]).
+//! (issues [#659] / [#765]).
 //!
 //! The original search ([`super::search`]) shipped a hand-rolled
 //! substring scorer. That gave correct answers for exact queries
@@ -17,21 +17,31 @@
 //! applied to ranking — adding a future Tantivy- or FST-backed
 //! scorer only requires implementing the trait.
 //!
-//! The two scorers shipped today are:
+//! ## Strategy seam (issue [#765])
 //!
-//! * [`SubstringScorer`] — the original exact/substring table,
-//!   preserved byte-for-byte so regressions surface in dedicated
+//! [`StrategyScorer`] is the **public extension point** for embedders
+//! that want to plug in a custom ranking algorithm (BM25, embedding
+//! vectors, studio lexicons, …) without touching the handler code.
+//! [`ScorerFactory`] selects a concrete `StrategyScorer` box from a
+//! [`super::search::SearchMode`] variant or a free-form string tag so
+//! callers outside this crate can use the same dispatch logic.
+//!
+//! The two built-in implementations are:
+//!
+//! * [`FuzzyScorer`] / [`StrategyFuzzyScorer`] — wraps `nucleo-matcher`
+//!   (the Helix editor's fuzzy engine) and adds prefix bonuses plus
+//!   multi-field weighting per the #659 acceptance criteria.
+//! * [`SubstringScorer`] / [`ExactScorer`] — the original exact/substring
+//!   table, preserved byte-for-byte so regressions surface in dedicated
 //!   unit tests rather than in integration tests that happen to
 //!   exercise search.
-//! * [`FuzzyScorer`] — wraps `nucleo-matcher` (the Helix editor's
-//!   fuzzy engine) and adds prefix bonuses plus multi-field
-//!   weighting per the #659 acceptance criteria.
 //!
-//! Both scorers return scores on the **same scale** (`0` = no match,
-//! higher = better) so the zero-filter in [`super::search::search`]
+//! Both internal scorers return scores on the **same scale** (`0` = no
+//! match, higher = better) so the zero-filter in [`super::search::search`]
 //! stays valid for either strategy.
 //!
 //! [#659]: https://github.com/loonghao/dcc-mcp-core/issues/659
+//! [#765]: https://github.com/loonghao/dcc-mcp-core/issues/765
 
 use nucleo_matcher::{
     Config, Matcher, Utf32Str,
@@ -39,6 +49,7 @@ use nucleo_matcher::{
 };
 
 use super::record::CapabilityRecord;
+use super::search::SearchMode;
 
 /// A pluggable scoring strategy for the capability index.
 ///
@@ -273,6 +284,171 @@ impl Scorer for FuzzyScorer {
         }
 
         score
+    }
+}
+
+/// `SubstringScorer` re-exported under the name used in issue #765
+/// acceptance criteria ("ExactScorer"). The implementation is identical
+/// to [`SubstringScorer`]; the alias exists so external callers can
+/// refer to the concept by a more descriptive name.
+pub type ExactScorer = SubstringScorer;
+
+// ============================================================================
+// Public strategy seam (issue #765)
+// ============================================================================
+
+/// Simplified, `Send + Sync` scoring strategy intended for **embedders**
+/// that want to plug a custom algorithm into the gateway without touching
+/// the filter/pagination/sort pipeline.
+///
+/// The signature intentionally differs from the internal [`Scorer`] trait:
+///
+/// * `&self` — no mutable state required; thread-safe by contract.
+/// * Plain `&str` inputs — the caller passes the pre-processed query and
+///   a single candidate string (tool name, summary, …) rather than an
+///   entire [`CapabilityRecord`].  This lets custom scorers be unit-tested
+///   without constructing gateway-internal types.
+/// * `f32` return — a normalised `[0.0, 1.0]` range is idiomatic for
+///   pluggable ML/embedding scorers; the gateway quantises to `u32` before
+///   writing a [`super::search::SearchHit`].
+///
+/// # Thread safety
+///
+/// Implementations **must** be `Send + Sync` so the same box can be
+/// shared across the async Axum worker threads without wrapping in a
+/// `Mutex`.
+///
+/// # Example
+///
+/// ```rust
+/// use dcc_mcp_gateway::StrategyScorer;
+///
+/// struct PrefixScorer;
+///
+/// impl StrategyScorer for PrefixScorer {
+///     fn score(&self, query: &str, candidate: &str) -> f32 {
+///         if candidate.starts_with(query) { 1.0 } else { 0.0 }
+///     }
+/// }
+/// ```
+pub trait StrategyScorer: Send + Sync {
+    /// Return a relevance score for `candidate` relative to `query`.
+    ///
+    /// * `query` — lower-cased, trimmed free-text query from the caller.
+    /// * `candidate` — one field extracted from a [`CapabilityRecord`]
+    ///   (tool name, summary, tag, …); pre-processing is the caller's
+    ///   responsibility.
+    ///
+    /// Return `0.0` to signal "no match"; any positive value to signal a
+    /// match.  Values above `1.0` are accepted but the gateway clamps the
+    /// quantised `u32` at `FUZZY_FIELD_CAP` / `10`, so saturating above
+    /// that threshold has no effect on ranking.
+    fn score(&self, query: &str, candidate: &str) -> f32;
+}
+
+/// [`StrategyScorer`] adapter backed by [`FuzzyScorer`] (nucleo-matcher).
+///
+/// Constructs a fresh internal [`FuzzyScorer`] per call so the adapter is
+/// `Sync` without a `Mutex`. The allocation cost (~few KB) is negligible
+/// compared with the nucleo scoring itself.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct StrategyFuzzyScorer;
+
+impl StrategyScorer for StrategyFuzzyScorer {
+    fn score(&self, query: &str, candidate: &str) -> f32 {
+        if query.is_empty() || candidate.is_empty() {
+            return 0.0;
+        }
+        let pattern = Pattern::new(
+            query,
+            CaseMatching::Ignore,
+            Normalization::Smart,
+            AtomKind::Fuzzy,
+        );
+        let mut matcher = Matcher::new(Config::DEFAULT);
+        let mut buf: Vec<char> = Vec::with_capacity(candidate.len());
+        let hs = Utf32Str::new(candidate, &mut buf);
+        let raw = pattern.score(hs, &mut matcher).unwrap_or(0);
+        if raw == 0 {
+            return 0.0;
+        }
+        let bucket = (raw / FUZZY_QUANTISE_DIVISOR).clamp(1, FUZZY_FIELD_CAP);
+        bucket as f32 / FUZZY_FIELD_CAP as f32
+    }
+}
+
+/// [`StrategyScorer`] adapter backed by [`SubstringScorer`] / [`ExactScorer`].
+///
+/// Mirrors the weight table in [`SubstringScorer`] but applied to a single
+/// candidate string so it can satisfy the [`StrategyScorer`] contract.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct StrategyExactScorer;
+
+impl StrategyScorer for StrategyExactScorer {
+    fn score(&self, query: &str, candidate: &str) -> f32 {
+        if query.is_empty() || candidate.is_empty() {
+            return 0.0;
+        }
+        let cand_lower = candidate.to_ascii_lowercase();
+        if cand_lower == query {
+            1.0
+        } else if cand_lower.contains(query) {
+            0.6
+        } else {
+            0.0
+        }
+    }
+}
+
+/// Factory that constructs a boxed [`StrategyScorer`] from a
+/// [`SearchMode`] variant or a free-form string tag.
+///
+/// This is the primary extension point for callers outside this crate:
+/// they can match on [`SearchMode`] without knowing the concrete scorer
+/// type, and add new strategies by extending the string-tag arm of
+/// [`ScorerFactory::from_tag`].
+///
+/// # Example
+///
+/// ```rust
+/// use dcc_mcp_gateway::{ScorerFactory, SearchMode};
+///
+/// let scorer = ScorerFactory::from_mode(SearchMode::Fuzzy);
+/// let s = scorer.score("sphere", "create_sphere");
+/// assert!(s > 0.0);
+/// ```
+pub struct ScorerFactory;
+
+impl ScorerFactory {
+    /// Return a [`StrategyScorer`] box appropriate for `mode`.
+    ///
+    /// | `mode`              | scorer                   |
+    /// |---------------------|--------------------------|
+    /// | [`SearchMode::Fuzzy`] | [`StrategyFuzzyScorer`] |
+    /// | [`SearchMode::Exact`] | [`StrategyExactScorer`] |
+    pub fn from_mode(mode: SearchMode) -> Box<dyn StrategyScorer> {
+        match mode {
+            SearchMode::Fuzzy => Box::new(StrategyFuzzyScorer),
+            SearchMode::Exact => Box::new(StrategyExactScorer),
+        }
+    }
+
+    /// Return a [`StrategyScorer`] box identified by a free-form string tag.
+    ///
+    /// Recognised tags (case-insensitive):
+    ///
+    /// | tag        | scorer                   |
+    /// |------------|--------------------------|
+    /// | `"fuzzy"`  | [`StrategyFuzzyScorer`] |
+    /// | `"exact"`  | [`StrategyExactScorer`] |
+    ///
+    /// Unknown tags fall back to [`StrategyFuzzyScorer`] so existing
+    /// configurations that add a new tag do not silently break.
+    pub fn from_tag(tag: &str) -> Box<dyn StrategyScorer> {
+        match tag.to_ascii_lowercase().as_str() {
+            "exact" | "substring" => Box::new(StrategyExactScorer),
+            _ => Box::new(StrategyFuzzyScorer),
+        }
     }
 }
 

--- a/crates/dcc-mcp-gateway/src/gateway/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/mod.rs
@@ -49,6 +49,12 @@ pub mod metrics;
 pub use router::build_gateway_router;
 pub use state::{GatewayState, entry_to_json};
 
+// Strategy-pattern seam for search scoring (issue #765).
+pub use capability::{
+    ExactScorer, FuzzyScorer, Scorer, ScorerFactory, SearchMode, SearchQuery, StrategyExactScorer,
+    StrategyFuzzyScorer, StrategyScorer, SubstringScorer,
+};
+
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;


### PR DESCRIPTION
Closes #765

## Summary

Introduces the strategy pattern for search scoring in the gateway (issue #765):

- **`StrategyScorer` trait**: `pub trait StrategyScorer: Send + Sync { fn score(&self, query: &str, candidate: &str) -> f32; }` — the public extension point for embedders
- **`StrategyFuzzyScorer`**: wraps existing nucleo-matcher logic, returns normalised `f32`
- **`StrategyExactScorer`**: wraps existing substring logic, returns normalised `f32`
- **`ExactScorer`**: type alias for `SubstringScorer` (issue #765 naming requirement)
- **`ScorerFactory`**: selects an implementation from `SearchMode` or a string tag; embedders can plug in their own without touching the handlers

Internal `Scorer` trait and `search_page` pipeline are **unchanged** — all existing tests pass byte-for-byte.

## Behavior
Byte-for-byte identical to today's behavior; 215 existing tests pass.

## Benchmarks
Added `crates/dcc-mcp-gateway/benches/search_bench.rs` with criterion benchmarks covering:
- `StrategyFuzzyScorer` direct call
- `StrategyExactScorer` direct call
- `ScorerFactory::from_mode` dynamic dispatch (Fuzzy + Exact)
- `ScorerFactory::from_tag` dynamic dispatch (`fuzzy` + `exact`)