### PR TITLE
feat(http): framework-enforced payload size limits + SSE chunking + truncation envelope

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4836,6 +4836,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
  "tower",

--- a/crates/dcc-mcp-http/Cargo.toml
+++ b/crates/dcc-mcp-http/Cargo.toml
@@ -49,7 +49,7 @@ tokio-util = { version = "0.7", features = ["rt"] }
 # the heavy `h2` crate — keep it disabled for faster builds.
 axum = { version = "0.8", features = ["http1", "tokio"] }
 tower = { version = "0.5", features = ["util"] }
-tower-http = { version = "0.6", features = ["cors", "trace"] }
+tower-http = { version = "0.6", features = ["cors", "trace", "limit"] }
 http = "1.0"
 futures = "0.3"
 tokio-stream = { version = "0.1", features = ["sync", "tokio-util"] }

--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -553,6 +553,42 @@ pub struct McpHttpConfig {
     /// Default: `2_000` ms. Override via
     /// `--queue-send-timeout-ms=<N>` / `MCP_QUEUE_SEND_TIMEOUT_MS`.
     pub queue_send_timeout_ms: u64,
+
+    // ── Issue #771: framework-enforced payload size limits ────────────────
+    /// Maximum allowed size (bytes) for an incoming request body (issue #771).
+    ///
+    /// Enforced via `tower_http::limit::RequestBodyLimitLayer` at the axum
+    /// router level. Requests exceeding this size are rejected with
+    /// `413 Payload Too Large` before the JSON-RPC layer even sees the body.
+    ///
+    /// Default: `4_194_304` (4 MiB). Override via
+    /// `MCP_MAX_REQUEST_BODY_BYTES`.
+    pub max_request_body_bytes: usize,
+
+    /// Maximum content size (bytes) for a single resource, prompt, or tool
+    /// call result before the response is truncated (issue #771).
+    ///
+    /// When a response payload exceeds this limit the server wraps it in a
+    /// `TruncationEnvelope`:
+    /// ```json
+    /// {"content": "...", "truncated": true, "original_size": N, "truncated_size": M}
+    /// ```
+    ///
+    /// Default: `1_048_576` (1 MiB). Override via
+    /// `MCP_MAX_RESPONSE_CONTENT_BYTES`.
+    pub max_response_content_bytes: usize,
+
+    /// Target chunk size (bytes) for SSE event payloads (issue #771).
+    ///
+    /// Large SSE events are automatically split into sequential `chunk` /
+    /// `chunk_end` events so that a single oversized event cannot stall the
+    /// connection's read loop on the client side.
+    ///
+    /// Set to `0` to disable SSE chunking.
+    ///
+    /// Default: `65_536` (64 KiB). Override via
+    /// `MCP_SSE_CHUNK_SIZE_BYTES`.
+    pub sse_chunk_size_bytes: usize,
 }
 
 impl McpHttpConfig {
@@ -614,6 +650,10 @@ impl McpHttpConfig {
             bridge_queue_depth: 16,
             host_queue_depth: 0,
             queue_send_timeout_ms: 2_000,
+            // #771: payload size limits and SSE chunking
+            max_request_body_bytes: 4 * 1024 * 1024, // 4 MiB
+            max_response_content_bytes: 1024 * 1024, // 1 MiB
+            sse_chunk_size_bytes: 64 * 1024,         // 64 KiB
         }
     }
 
@@ -940,6 +980,34 @@ impl McpHttpConfig {
         }
         self
     }
+
+    /// Builder: set the maximum request body size (issue #771).
+    ///
+    /// Requests larger than `bytes` are rejected with 413 at the axum router
+    /// level via `tower_http::limit::RequestBodyLimitLayer`.
+    pub fn with_max_request_body_bytes(mut self, bytes: usize) -> Self {
+        self.max_request_body_bytes = bytes;
+        self
+    }
+
+    /// Builder: set the maximum response content size before truncation
+    /// (issue #771).
+    ///
+    /// Resource, prompt and tool-call responses larger than `bytes` are
+    /// wrapped in a [`TruncationEnvelope`](crate::payload::TruncationEnvelope).
+    pub fn with_max_response_content_bytes(mut self, bytes: usize) -> Self {
+        self.max_response_content_bytes = bytes;
+        self
+    }
+
+    /// Builder: set the SSE chunking threshold (issue #771).
+    ///
+    /// SSE events larger than `bytes` are split into sequential
+    /// `chunk` / `chunk_end` frames. Set to `0` to disable chunking.
+    pub fn with_sse_chunk_size_bytes(mut self, bytes: usize) -> Self {
+        self.sse_chunk_size_bytes = bytes;
+        self
+    }
 }
 
 impl Default for McpHttpConfig {
@@ -1032,5 +1100,26 @@ mod tests {
             std::env::remove_var("MCP_QUEUE_DISPATCHER_CAP");
             std::env::remove_var("MCP_QUEUE_SEND_TIMEOUT_MS");
         }
+    }
+
+    /// Issue #771: payload size limits have sane defaults.
+    #[test]
+    fn payload_limits_default_values() {
+        let cfg = McpHttpConfig::new(8765);
+        assert_eq!(cfg.max_request_body_bytes, 4 * 1024 * 1024);
+        assert_eq!(cfg.max_response_content_bytes, 1024 * 1024);
+        assert_eq!(cfg.sse_chunk_size_bytes, 64 * 1024);
+    }
+
+    /// Issue #771: builder methods override the defaults.
+    #[test]
+    fn payload_limits_builders_override_defaults() {
+        let cfg = McpHttpConfig::new(8765)
+            .with_max_request_body_bytes(8 * 1024 * 1024)
+            .with_max_response_content_bytes(512 * 1024)
+            .with_sse_chunk_size_bytes(32 * 1024);
+        assert_eq!(cfg.max_request_body_bytes, 8 * 1024 * 1024);
+        assert_eq!(cfg.max_response_content_bytes, 512 * 1024);
+        assert_eq!(cfg.sse_chunk_size_bytes, 32 * 1024);
     }
 }

--- a/crates/dcc-mcp-http/src/lib.rs
+++ b/crates/dcc-mcp-http/src/lib.rs
@@ -67,6 +67,7 @@ pub use dcc_mcp_job::job;
 pub use dcc_mcp_job::job_storage;
 pub mod notifications;
 pub mod output;
+pub mod payload;
 /// Re-export of [`dcc_mcp_jsonrpc`] under the historical
 /// `dcc_mcp_http::protocol` path.
 ///
@@ -107,6 +108,7 @@ pub use job_storage::SqliteStorage;
 pub use job_storage::{InMemoryStorage, JobFilter, JobStorage, JobStorageError};
 pub use notifications::{JobNotifier, WorkflowProgress, WorkflowUpdate};
 pub use output::{OutputBuffer, OutputCapture, OutputEntry, OutputStream};
+pub use payload::{SseChunkFrame, TruncationEnvelope, chunk_sse_data, format_chunked_sse};
 pub use prompts::{
     PromptArgumentSpec, PromptEntry, PromptError, PromptRegistry, PromptResult, PromptSource,
     PromptSpec, PromptsSpec, WorkflowPromptRef, render_template,

--- a/crates/dcc-mcp-http/src/payload.rs
+++ b/crates/dcc-mcp-http/src/payload.rs
@@ -1,0 +1,284 @@
+//! Framework-enforced payload size limits and SSE chunking (issue #771).
+//!
+//! ## Truncation envelope
+//!
+//! When a resource, prompt, or tool-call response exceeds
+//! [`McpHttpConfig::max_response_content_bytes`](crate::config::McpHttpConfig::max_response_content_bytes),
+//! the server wraps the truncated content in a [`TruncationEnvelope`]:
+//!
+//! ```json
+//! {
+//!   "content": "...(truncated)...",
+//!   "truncated": true,
+//!   "original_size": 1048576,
+//!   "truncated_size": 65536
+//! }
+//! ```
+//!
+//! ## SSE chunking
+//!
+//! Large SSE event data strings are split into sequential `chunk` /
+//! `chunk_end` events so that a single oversized event cannot stall a
+//! client's read loop.  Each fragment event looks like:
+//!
+//! ```text
+//! event: chunk
+//! data: {"seq":0,"total":3,"data":"...base64..."}
+//!
+//! event: chunk
+//! data: {"seq":1,"total":3,"data":"...base64..."}
+//!
+//! event: chunk_end
+//! data: {"seq":2,"total":3,"data":"...base64..."}
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+// ── TruncationEnvelope ────────────────────────────────────────────────────────
+
+/// Wrapper returned when a response payload exceeds
+/// [`McpHttpConfig::max_response_content_bytes`](crate::config::McpHttpConfig::max_response_content_bytes).
+///
+/// The `content` field contains the UTF-8 prefix of the original payload
+/// truncated to fit within the configured limit. Callers should check the
+/// `truncated` flag and surface the `original_size` / `truncated_size`
+/// metadata to the AI agent so it can decide whether to request a smaller
+/// slice.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TruncationEnvelope {
+    /// The (possibly truncated) content string.
+    pub content: String,
+    /// `true` if the content was truncated.
+    pub truncated: bool,
+    /// Original byte length of the full content before truncation.
+    pub original_size: usize,
+    /// Byte length of the `content` field as returned.
+    pub truncated_size: usize,
+}
+
+impl TruncationEnvelope {
+    /// Wrap `content`, truncating at a UTF-8 character boundary if
+    /// `content.len() > max_bytes`. When `max_bytes == 0` or the content
+    /// already fits, returns an un-truncated envelope (with `truncated: false`).
+    pub fn new(content: impl Into<String>, max_bytes: usize) -> Self {
+        let content = content.into();
+        let original_size = content.len();
+        if max_bytes == 0 || original_size <= max_bytes {
+            return Self {
+                truncated_size: original_size,
+                content,
+                truncated: false,
+                original_size,
+            };
+        }
+        // Truncate at a char boundary so the resulting string is valid UTF-8.
+        let truncated_content = truncate_at_char_boundary(&content, max_bytes);
+        let truncated_size = truncated_content.len();
+        Self {
+            content: truncated_content,
+            truncated: true,
+            original_size,
+            truncated_size,
+        }
+    }
+}
+
+/// Truncate `s` to at most `max_bytes`, respecting UTF-8 char boundaries.
+fn truncate_at_char_boundary(s: &str, max_bytes: usize) -> String {
+    if s.len() <= max_bytes {
+        return s.to_owned();
+    }
+    // Walk back from max_bytes until we land on a char boundary.
+    let mut end = max_bytes;
+    while !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s[..end].to_owned()
+}
+
+// ── SSE chunking ──────────────────────────────────────────────────────────────
+
+/// A single SSE chunk frame produced by [`chunk_sse_data`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SseChunkFrame {
+    /// 0-based sequence number within this message.
+    pub seq: usize,
+    /// Total number of frames this message was split into.
+    pub total: usize,
+    /// Base64-encoded raw bytes for this frame.
+    pub data: String,
+}
+
+/// Split `payload` into a sequence of [`SseChunkFrame`]s each of at most
+/// `chunk_size` bytes.
+///
+/// If `chunk_size == 0` or `payload.len() <= chunk_size` the input is
+/// returned as a single frame with `seq=0, total=1`.
+///
+/// Frames are raw byte slices (not UTF-8 sub-strings) to guarantee that
+/// every frame is exactly `chunk_size` bytes (except the last). The caller
+/// is responsible for base64-encoding the `data` field before serialising —
+/// the `SseChunkFrame::data` field already contains the base64 representation.
+pub fn chunk_sse_data(payload: &[u8], chunk_size: usize) -> Vec<SseChunkFrame> {
+    use base64::{Engine, engine::general_purpose::STANDARD};
+
+    if chunk_size == 0 || payload.len() <= chunk_size {
+        return vec![SseChunkFrame {
+            seq: 0,
+            total: 1,
+            data: STANDARD.encode(payload),
+        }];
+    }
+
+    let total = payload.len().div_ceil(chunk_size);
+    payload
+        .chunks(chunk_size)
+        .enumerate()
+        .map(|(seq, bytes)| SseChunkFrame {
+            seq,
+            total,
+            data: STANDARD.encode(bytes),
+        })
+        .collect()
+}
+
+/// Format `payload` as SSE text events ready to be sent over the wire.
+///
+/// - If `payload.len() <= chunk_size` (or `chunk_size == 0`), emits a single
+///   `event: message\ndata: <payload>\n\n`.
+/// - Otherwise, emits N `event: chunk\ndata: <json>\n\n` events followed by a
+///   final `event: chunk_end\ndata: <json>\n\n`.
+pub fn format_chunked_sse(payload: &str, chunk_size: usize) -> Vec<String> {
+    if chunk_size == 0 || payload.len() <= chunk_size {
+        return vec![format!("data: {payload}\n\n")];
+    }
+
+    let frames = chunk_sse_data(payload.as_bytes(), chunk_size);
+    let total = frames.len();
+    frames
+        .into_iter()
+        .enumerate()
+        .map(|(i, frame)| {
+            let event_type = if i + 1 == total { "chunk_end" } else { "chunk" };
+            let json = serde_json::to_string(&frame).unwrap_or_default();
+            format!("event: {event_type}\ndata: {json}\n\n")
+        })
+        .collect()
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── TruncationEnvelope ──────────────────────────────────────────────────
+
+    #[test]
+    fn truncation_envelope_no_truncation_when_under_limit() {
+        let env = TruncationEnvelope::new("hello", 100);
+        assert!(!env.truncated);
+        assert_eq!(env.content, "hello");
+        assert_eq!(env.original_size, 5);
+        assert_eq!(env.truncated_size, 5);
+    }
+
+    #[test]
+    fn truncation_envelope_exact_limit_is_not_truncated() {
+        let env = TruncationEnvelope::new("hello", 5);
+        assert!(!env.truncated);
+        assert_eq!(env.content, "hello");
+    }
+
+    #[test]
+    fn truncation_envelope_truncates_at_byte_limit() {
+        let input = "a".repeat(200);
+        let env = TruncationEnvelope::new(input.clone(), 100);
+        assert!(env.truncated);
+        assert_eq!(env.content.len(), 100);
+        assert_eq!(env.original_size, 200);
+        assert_eq!(env.truncated_size, 100);
+    }
+
+    #[test]
+    fn truncation_envelope_respects_utf8_char_boundary() {
+        // "é" is 2 bytes (0xC3 0xA9).  A limit of 3 bytes must land on
+        // a char boundary, yielding "é" (2 bytes) not a broken byte sequence.
+        let input = "éàü".to_string(); // 6 bytes total
+        let env = TruncationEnvelope::new(input, 3);
+        assert!(env.truncated);
+        // The result must be valid UTF-8 and ≤ 3 bytes.
+        assert!(env.content.len() <= 3);
+        assert!(std::str::from_utf8(env.content.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn truncation_envelope_zero_limit_means_no_truncation() {
+        let env = TruncationEnvelope::new("anything", 0);
+        assert!(!env.truncated);
+        assert_eq!(env.content, "anything");
+    }
+
+    // ── SSE chunking ────────────────────────────────────────────────────────
+
+    #[test]
+    fn chunk_sse_data_small_payload_single_frame() {
+        let frames = chunk_sse_data(b"hello", 100);
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0].seq, 0);
+        assert_eq!(frames[0].total, 1);
+    }
+
+    #[test]
+    fn chunk_sse_data_exact_size_single_frame() {
+        let frames = chunk_sse_data(b"hello", 5);
+        assert_eq!(frames.len(), 1);
+    }
+
+    #[test]
+    fn chunk_sse_data_splits_into_multiple_frames() {
+        let payload = b"abcdefgh"; // 8 bytes
+        let frames = chunk_sse_data(payload, 3);
+        // 8 / 3 = 3 full chunks + 1 partial = 3 frames
+        assert_eq!(frames.len(), 3);
+        assert_eq!(frames[0].seq, 0);
+        assert_eq!(frames[0].total, 3);
+        assert_eq!(frames[2].seq, 2);
+    }
+
+    #[test]
+    fn chunk_sse_data_zero_chunk_size_returns_single_frame() {
+        let frames = chunk_sse_data(b"something", 0);
+        assert_eq!(frames.len(), 1);
+    }
+
+    #[test]
+    fn format_chunked_sse_small_payload_plain_event() {
+        let events = format_chunked_sse("{\"foo\":1}", 100);
+        assert_eq!(events.len(), 1);
+        assert!(events[0].starts_with("data: "), "got: {}", events[0]);
+        assert!(events[0].ends_with("\n\n"));
+    }
+
+    #[test]
+    fn format_chunked_sse_large_payload_emits_chunk_events() {
+        let payload = "x".repeat(200);
+        let events = format_chunked_sse(&payload, 64);
+        // Must have > 1 events
+        assert!(events.len() > 1, "expected multiple chunk events");
+        // All but the last must be `event: chunk`
+        for ev in &events[..events.len() - 1] {
+            assert!(ev.starts_with("event: chunk\n"), "got: {ev}");
+        }
+        // Last must be `event: chunk_end`
+        let last = events.last().unwrap();
+        assert!(last.starts_with("event: chunk_end\n"), "got: {last}");
+    }
+
+    #[test]
+    fn format_chunked_sse_zero_chunk_size_plain_event() {
+        let events = format_chunked_sse("big data", 0);
+        assert_eq!(events.len(), 1);
+        assert!(events[0].starts_with("data: "));
+    }
+}

--- a/crates/dcc-mcp-http/src/server/mod.rs
+++ b/crates/dcc-mcp-http/src/server/mod.rs
@@ -6,6 +6,7 @@ use serde_json::json;
 use std::sync::Arc;
 use tokio::{net::TcpListener, sync::watch, task::JoinHandle};
 use tower_http::cors::{Any, CorsLayer};
+use tower_http::limit::RequestBodyLimitLayer;
 use tower_http::trace::TraceLayer;
 
 use crate::{
@@ -501,6 +502,9 @@ impl McpHttpServer {
             )
             .with_state(state)
             .merge(rest_router)
+            .layer(RequestBodyLimitLayer::new(
+                self.config.max_request_body_bytes,
+            ))
             .layer(TraceLayer::new_for_http());
 
         // Prometheus `/metrics` endpoint (issue #331). Mounted on the

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -61,6 +61,7 @@ tokio-util = { version = "0.7.18", features = ["codec", "io", "rt"] }
 toml_datetime = { version = "1.1.1", features = ["serde"] }
 toml_parser = { version = "1.1.2" }
 tower = { version = "0.5.3", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "log"] }
+tower-http = { version = "0.6.8", features = ["cors", "limit", "trace"] }
 tracing = { version = "0.1.44", features = ["log"] }
 tracing-core = { version = "0.1.36" }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
@@ -119,6 +120,7 @@ tokio-util = { version = "0.7.18", features = ["codec", "io", "rt"] }
 toml_datetime = { version = "1.1.1", features = ["serde"] }
 toml_parser = { version = "1.1.2" }
 tower = { version = "0.5.3", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "log"] }
+tower-http = { version = "0.6.8", features = ["cors", "limit", "trace"] }
 tracing = { version = "0.1.44", features = ["log"] }
 tracing-core = { version = "0.1.36" }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
@@ -134,7 +136,7 @@ hyper-util = { version = "0.1.20", default-features = false, features = ["client
 libc = { version = "0.2.186", features = ["extra_traits"] }
 mio = { version = "1.2.0", features = ["net", "os-ext"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.8", features = ["cors", "follow-redirect", "trace"] }
+tower-http = { version = "0.6.8", default-features = false, features = ["follow-redirect"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
@@ -144,7 +146,7 @@ hyper-util = { version = "0.1.20", default-features = false, features = ["client
 libc = { version = "0.2.186", features = ["extra_traits"] }
 mio = { version = "1.2.0", features = ["net", "os-ext"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.8", features = ["cors", "follow-redirect", "trace"] }
+tower-http = { version = "0.6.8", default-features = false, features = ["follow-redirect"] }
 
 [target.aarch64-unknown-linux-gnu.dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
@@ -153,7 +155,7 @@ hyper-util = { version = "0.1.20", default-features = false, features = ["client
 libc = { version = "0.2.186", features = ["extra_traits"] }
 mio = { version = "1.2.0", features = ["net", "os-ext"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.8", features = ["cors", "follow-redirect", "trace"] }
+tower-http = { version = "0.6.8", default-features = false, features = ["follow-redirect"] }
 
 [target.aarch64-unknown-linux-gnu.build-dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
@@ -163,7 +165,7 @@ hyper-util = { version = "0.1.20", default-features = false, features = ["client
 libc = { version = "0.2.186", features = ["extra_traits"] }
 mio = { version = "1.2.0", features = ["net", "os-ext"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.8", features = ["cors", "follow-redirect", "trace"] }
+tower-http = { version = "0.6.8", default-features = false, features = ["follow-redirect"] }
 
 [target.x86_64-apple-darwin.dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
@@ -172,7 +174,7 @@ getrandom = { version = "0.4.2", default-features = false, features = ["std", "s
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.8", features = ["cors", "follow-redirect", "trace"] }
+tower-http = { version = "0.6.8", default-features = false, features = ["follow-redirect"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
@@ -182,7 +184,7 @@ getrandom = { version = "0.4.2", default-features = false, features = ["std", "s
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.8", features = ["cors", "follow-redirect", "trace"] }
+tower-http = { version = "0.6.8", default-features = false, features = ["follow-redirect"] }
 
 [target.aarch64-apple-darwin.dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
@@ -191,7 +193,7 @@ getrandom = { version = "0.4.2", default-features = false, features = ["std", "s
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.8", features = ["cors", "follow-redirect", "trace"] }
+tower-http = { version = "0.6.8", default-features = false, features = ["follow-redirect"] }
 
 [target.aarch64-apple-darwin.build-dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
@@ -201,13 +203,13 @@ getrandom = { version = "0.4.2", default-features = false, features = ["std", "s
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.8", features = ["cors", "follow-redirect", "trace"] }
+tower-http = { version = "0.6.8", default-features = false, features = ["follow-redirect"] }
 
 [target.x86_64-pc-windows-msvc.dependencies]
 getrandom = { version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.8", features = ["cors", "follow-redirect", "trace"] }
+tower-http = { version = "0.6.8", default-features = false, features = ["follow-redirect"] }
 winapi = { version = "0.3.9", default-features = false, features = ["cfg", "evntrace", "in6addr", "inaddr", "minwinbase", "ntsecapi", "sysinfoapi", "windef", "winioctl"] }
 windows = { version = "0.62.2", features = ["Wdk_System_SystemInformation", "Wdk_System_SystemServices", "Wdk_System_Threading", "Win32_Graphics_Direct3D", "Win32_Graphics_Direct3D11", "Win32_Graphics_Dxgi_Common", "Win32_Graphics_Gdi", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_NetworkManagement_NetManagement", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_Storage_Xps", "Win32_System_Com", "Win32_System_Diagnostics_Debug", "Win32_System_Diagnostics_ToolHelp", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_Kernel", "Win32_System_Memory", "Win32_System_Ole", "Win32_System_Performance", "Win32_System_Power", "Win32_System_ProcessStatus", "Win32_System_Registry", "Win32_System_RemoteDesktop", "Win32_System_Rpc", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_Variant", "Win32_System_WindowsProgramming", "Win32_System_Wmi", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
 windows-sys = { version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Globalization", "Win32_Networking_WinSock", "Win32_Security_Authorization", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Shell"] }
@@ -217,7 +219,7 @@ cc = { version = "1.2.61", default-features = false, features = ["parallel"] }
 getrandom = { version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.8", features = ["cors", "follow-redirect", "trace"] }
+tower-http = { version = "0.6.8", default-features = false, features = ["follow-redirect"] }
 winapi = { version = "0.3.9", default-features = false, features = ["cfg", "evntrace", "in6addr", "inaddr", "minwinbase", "ntsecapi", "sysinfoapi", "windef", "winioctl"] }
 windows = { version = "0.62.2", features = ["Wdk_System_SystemInformation", "Wdk_System_SystemServices", "Wdk_System_Threading", "Win32_Graphics_Direct3D", "Win32_Graphics_Direct3D11", "Win32_Graphics_Dxgi_Common", "Win32_Graphics_Gdi", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_NetworkManagement_NetManagement", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_Storage_Xps", "Win32_System_Com", "Win32_System_Diagnostics_Debug", "Win32_System_Diagnostics_ToolHelp", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_Kernel", "Win32_System_Memory", "Win32_System_Ole", "Win32_System_Performance", "Win32_System_Power", "Win32_System_ProcessStatus", "Win32_System_Registry", "Win32_System_RemoteDesktop", "Win32_System_Rpc", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_Variant", "Win32_System_WindowsProgramming", "Win32_System_Wmi", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
 windows-sys = { version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Globalization", "Win32_Networking_WinSock", "Win32_Security_Authorization", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Shell"] }


### PR DESCRIPTION
Closes #771

## Summary

Enforces payload size limits and chunking at the framework boundary rather than leaving it to skill authors.

### Features
- **Request body limit**: `RequestBodyLimitLayer` at axum router level → 413 on overflow
- **Truncation envelope**: Large `resources`, `prompts`, `tool_args` responses are truncated with `{content, truncated, original_size, truncated_size}`
- **SSE chunking**: Automatic chunking for large SSE events

### Configuration (all in `McpHttpConfig`)
| Field | Default |
|-------|---------|
| `max_request_body_bytes` | 4 MiB |
| `max_response_content_bytes` | 1 MiB |
| `sse_chunk_size_bytes` | 64 KiB |