### PR TITLE
feat(observability): export gateway contention events as resources + metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,6 +863,7 @@ dependencies = [
  "http",
  "nucleo-matcher",
  "parking_lot",
+ "prometheus",
  "reqwest 0.13.3",
  "serde",
  "serde_json",

--- a/crates/dcc-mcp-gateway/Cargo.toml
+++ b/crates/dcc-mcp-gateway/Cargo.toml
@@ -16,6 +16,7 @@ dcc-mcp-transport = { path = "../dcc-mcp-transport" }
 dcc-mcp-telemetry = { path = "../dcc-mcp-telemetry", optional = true }
 dcc-mcp-skill-rest = { path = "../dcc-mcp-skill-rest" }
 dcc-mcp-catalog = { path = "../dcc-mcp-catalog" }
+prometheus = { version = "0.14", default-features = false, optional = true }
 
 # Workspace shared
 serde = { workspace = true }
@@ -46,7 +47,7 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [features]
 default = []
-prometheus = ["dep:dcc-mcp-telemetry", "dcc-mcp-telemetry/prometheus"]
+prometheus = ["dep:dcc-mcp-telemetry", "dcc-mcp-telemetry/prometheus", "dep:prometheus"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/resources.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/resources.rs
@@ -15,6 +15,7 @@ use futures::future::join_all;
 use serde_json::{Value, json};
 
 use super::super::backend_client::fetch_resources;
+use super::super::handlers::resources::GATEWAY_EVENTS_URI;
 use super::super::namespace::encode_resource_uri;
 use super::super::state::GatewayState;
 use super::helpers::live_backends;
@@ -110,9 +111,20 @@ pub async fn aggregate_resources_list(gs: &GatewayState) -> Value {
             .collect()
     };
 
+    // Tier 0: gateway-internal event log (issue #766).
+    // Always visible so operators and agents can request the contention log.
+    let events_pointer = json!({
+        "uri":         GATEWAY_EVENTS_URI,
+        "name":        "Gateway contention events",
+        "description": "Append-only JSONL stream of gateway election, eviction, and probe events (ring buffer, last 1000 entries).",
+        "mimeType":    "application/x-ndjson"
+    });
+
     // Tier 2: every backend's resources, with URIs rewritten to the
     // gateway-prefixed form so clients can disambiguate.
-    let mut merged: Vec<Value> = admin_pointers;
+    let mut merged: Vec<Value> = std::iter::once(events_pointer)
+        .chain(admin_pointers)
+        .collect();
     for (iid, dcc_type, backend_resources) in fetch_backend_resources(gs).await {
         for mut resource in backend_resources {
             let backend_uri = resource

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
@@ -147,6 +147,9 @@ async fn aggregate_tools_list_returns_only_minimal_gateway_surface() {
         adapter_dcc: None,
         cursor_safe_tool_names: true,
         capability_index: std::sync::Arc::new(crate::gateway::capability::CapabilityIndex::new()),
+        event_log: std::sync::Arc::new(crate::gateway::event_log::EventLog::new()),
+        #[cfg(feature = "prometheus")]
+        gateway_metrics: std::sync::Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
     };
 
     assert_eq!(gs.live_instances(&*gs.registry.read().await).len(), 1);
@@ -308,6 +311,9 @@ async fn make_gateway_state(
         adapter_dcc: None,
         cursor_safe_tool_names: true,
         capability_index: std::sync::Arc::new(crate::gateway::capability::CapabilityIndex::new()),
+        event_log: std::sync::Arc::new(crate::gateway::event_log::EventLog::new()),
+        #[cfg(feature = "prometheus")]
+        gateway_metrics: std::sync::Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
     }
 }
 
@@ -715,6 +721,9 @@ async fn gateway_state_with_instances(
         adapter_dcc: None,
         cursor_safe_tool_names: true,
         capability_index: std::sync::Arc::new(crate::gateway::capability::CapabilityIndex::new()),
+        event_log: std::sync::Arc::new(crate::gateway::event_log::EventLog::new()),
+        #[cfg(feature = "prometheus")]
+        gateway_metrics: std::sync::Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
     };
     (state, dir, ids)
 }

--- a/crates/dcc-mcp-gateway/src/gateway/event_log.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/event_log.rs
@@ -1,0 +1,360 @@
+//! Gateway contention event log (issue #766).
+//!
+//! Two complementary observability surfaces:
+//!
+//! 1. **MCP resource `resources://gateway/events`** — an append-only JSONL ring
+//!    buffer (bounded to [`EventLog::CAPACITY`] entries) that clients can read
+//!    via a `resources/read` call.  Each line is a JSON object with:
+//!    `timestamp`, `event`, `dcc_type`, `instance_id`, `reason`.
+//!
+//! 2. **Prometheus counters** (compiled only with the `prometheus` feature) —
+//!    three monotonic counters exposed on the `/metrics` endpoint:
+//!    - `dcc_mcp_gateway_elections_total{outcome="won|yielded|lost"}`
+//!    - `dcc_mcp_gateway_evictions_total{reason="stale|ghost|probe_fail"}`
+//!    - `dcc_mcp_gateway_probes_total{outcome="ready|booting|unreachable"}`
+//!
+//!    Label cardinality is bounded: no free-form `instance_id` labels are used.
+
+use std::collections::VecDeque;
+use std::sync::Mutex;
+
+use serde::{Deserialize, Serialize};
+
+// ── Public event types ──────────────────────────────────────────────────────
+
+/// All contention-relevant event kinds the gateway can emit.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EventKind {
+    /// This gateway instance won the port election.
+    ElectionWon,
+    /// This gateway yielded the port to a higher-version challenger.
+    VoluntaryYield,
+    /// A ghost entry (dead-PID or stale) was reaped from the registry.
+    GhostReaped,
+    /// A backend instance is still booting (readiness probe → 503).
+    ProbeBooting,
+    /// A backend instance is unreachable (readiness probe failed).
+    ProbeUnreachable,
+    /// A backend instance was auto-deregistered after consecutive probe failures.
+    AutoDeregister,
+}
+
+impl EventKind {
+    /// Return the string label used in the Prometheus `outcome`/`reason` label.
+    pub fn as_label(&self) -> &'static str {
+        match self {
+            EventKind::ElectionWon => "won",
+            EventKind::VoluntaryYield => "yielded",
+            EventKind::GhostReaped => "ghost",
+            EventKind::ProbeBooting => "booting",
+            EventKind::ProbeUnreachable => "unreachable",
+            EventKind::AutoDeregister => "probe_fail",
+        }
+    }
+}
+
+/// A single contention event stored in the ring buffer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContendEvent {
+    /// ISO-8601 UTC timestamp (millisecond precision).
+    pub timestamp: String,
+    /// Event kind.
+    pub event: EventKind,
+    /// DCC type involved (`"maya"`, `"blender"`, `"__gateway__"`, …).
+    pub dcc_type: String,
+    /// Short, human-readable instance identifier (first 8 hex chars of the UUID).
+    pub instance_id: String,
+    /// Optional human-readable context (e.g. challenger version, failure count).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl ContendEvent {
+    pub fn new(
+        event: EventKind,
+        dcc_type: impl Into<String>,
+        instance_id: impl Into<String>,
+        reason: Option<String>,
+    ) -> Self {
+        let ts = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        ContendEvent {
+            timestamp: ts,
+            event,
+            dcc_type: dcc_type.into(),
+            instance_id: instance_id.into(),
+            reason,
+        }
+    }
+}
+
+// ── Ring buffer ─────────────────────────────────────────────────────────────
+
+/// Bounded, append-only JSONL event log stored in memory.
+///
+/// Older events are silently dropped when the buffer is full.
+pub struct EventLog {
+    inner: Mutex<VecDeque<ContendEvent>>,
+}
+
+impl EventLog {
+    /// Maximum number of events kept in the ring buffer.
+    pub const CAPACITY: usize = 1_000;
+
+    pub fn new() -> Self {
+        EventLog {
+            inner: Mutex::new(VecDeque::with_capacity(Self::CAPACITY)),
+        }
+    }
+
+    /// Append `event` to the ring buffer, evicting the oldest entry when full.
+    pub fn push(&self, event: ContendEvent) {
+        let mut buf = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        if buf.len() >= Self::CAPACITY {
+            buf.pop_front();
+        }
+        buf.push_back(event);
+    }
+
+    /// Render all events as a JSONL string (one JSON object per line).
+    pub fn as_jsonl(&self) -> String {
+        let buf = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        buf.iter()
+            .filter_map(|e| serde_json::to_string(e).ok())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// Number of events currently stored.
+    pub fn len(&self) -> usize {
+        self.inner.lock().unwrap_or_else(|e| e.into_inner()).len()
+    }
+
+    /// `true` when the buffer holds no events.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl Default for EventLog {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Prometheus counters ─────────────────────────────────────────────────────
+
+/// Thin wrapper around the three gateway contention counters.
+///
+/// Each counter is registered once in the default Prometheus registry when
+/// `GatewayMetrics::new()` is called. Subsequent calls to `inc_*` are cheap
+/// atomic increments.
+#[cfg(feature = "prometheus")]
+pub struct GatewayMetrics {
+    elections: prometheus::CounterVec,
+    evictions: prometheus::CounterVec,
+    probes: prometheus::CounterVec,
+}
+
+#[cfg(feature = "prometheus")]
+impl GatewayMetrics {
+    /// Register the three counters in the default Prometheus registry.
+    ///
+    /// Panics at startup if Prometheus registration fails (name collision or
+    /// malformed help string) — this is intentional because a metric that
+    /// cannot be registered is a programming error that must be caught early.
+    pub fn new() -> Self {
+        let elections = prometheus::register_counter_vec!(
+            prometheus::opts!(
+                "dcc_mcp_gateway_elections_total",
+                "Gateway port-election outcomes"
+            ),
+            &["outcome"]
+        )
+        .expect("dcc_mcp_gateway_elections_total registration must succeed");
+
+        let evictions = prometheus::register_counter_vec!(
+            prometheus::opts!(
+                "dcc_mcp_gateway_evictions_total",
+                "Gateway registry-eviction events"
+            ),
+            &["reason"]
+        )
+        .expect("dcc_mcp_gateway_evictions_total registration must succeed");
+
+        let probes = prometheus::register_counter_vec!(
+            prometheus::opts!(
+                "dcc_mcp_gateway_probes_total",
+                "Gateway backend readiness-probe outcomes"
+            ),
+            &["outcome"]
+        )
+        .expect("dcc_mcp_gateway_probes_total registration must succeed");
+
+        GatewayMetrics {
+            elections,
+            evictions,
+            probes,
+        }
+    }
+
+    pub fn inc_election(&self, outcome: &str) {
+        self.elections.with_label_values(&[outcome]).inc();
+    }
+
+    pub fn inc_eviction(&self, reason: &str) {
+        self.evictions.with_label_values(&[reason]).inc();
+    }
+
+    pub fn inc_probe(&self, outcome: &str) {
+        self.probes.with_label_values(&[outcome]).inc();
+    }
+}
+
+#[cfg(feature = "prometheus")]
+impl Default for GatewayMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Convenience: record an event into both surfaces ─────────────────────────
+
+/// Record a contention event into the `EventLog` and (if compiled with the
+/// `prometheus` feature) increment the corresponding counter.
+///
+/// # Arguments
+/// * `log`     — shared event-log ring buffer from `GatewayState`
+/// * `metrics` — optional Prometheus counter facade (None when feature is off)
+/// * `event`   — what happened
+/// * `dcc_type`  — DCC type string for the affected instance
+/// * `instance_id` — short (8-char) id of the affected instance
+/// * `reason`  — optional free-form context string (not used as a label)
+pub fn record_event(
+    log: &EventLog,
+    #[cfg(feature = "prometheus")] metrics: &GatewayMetrics,
+    event: EventKind,
+    dcc_type: impl Into<String>,
+    instance_id: impl Into<String>,
+    reason: Option<String>,
+) {
+    #[cfg(feature = "prometheus")]
+    {
+        match event {
+            EventKind::ElectionWon | EventKind::VoluntaryYield => {
+                metrics.inc_election(event.as_label());
+            }
+            EventKind::GhostReaped => {
+                metrics.inc_eviction(event.as_label());
+            }
+            EventKind::ProbeBooting => {
+                metrics.inc_probe(event.as_label());
+            }
+            EventKind::ProbeUnreachable => {
+                metrics.inc_probe(event.as_label());
+                metrics.inc_eviction("probe_fail");
+            }
+            EventKind::AutoDeregister => {
+                metrics.inc_eviction(event.as_label());
+            }
+        }
+    }
+
+    log.push(ContendEvent::new(event, dcc_type, instance_id, reason));
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ring_buffer_bounded_to_capacity() {
+        let log = EventLog::new();
+        for i in 0..EventLog::CAPACITY + 10 {
+            log.push(ContendEvent::new(
+                EventKind::GhostReaped,
+                "maya",
+                format!("dead{i:04}"),
+                None,
+            ));
+        }
+        assert_eq!(
+            log.len(),
+            EventLog::CAPACITY,
+            "ring buffer must not grow beyond CAPACITY"
+        );
+    }
+
+    #[test]
+    fn as_jsonl_produces_one_line_per_event() {
+        let log = EventLog::new();
+        log.push(ContendEvent::new(
+            EventKind::ElectionWon,
+            "blender",
+            "abcd1234",
+            None,
+        ));
+        log.push(ContendEvent::new(
+            EventKind::ProbeBooting,
+            "maya",
+            "ef012345",
+            Some("backend still initialising".into()),
+        ));
+
+        let jsonl = log.as_jsonl();
+        let lines: Vec<&str> = jsonl.lines().collect();
+        assert_eq!(lines.len(), 2);
+
+        let first: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(first["event"], "election_won");
+        assert_eq!(first["dcc_type"], "blender");
+        assert_eq!(first["instance_id"], "abcd1234");
+        assert!(
+            first.get("reason").is_none(),
+            "reason must be absent when None"
+        );
+
+        let second: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(second["event"], "probe_booting");
+        assert_eq!(second["reason"], "backend still initialising");
+    }
+
+    #[test]
+    fn empty_log_returns_empty_string() {
+        let log = EventLog::new();
+        assert!(log.as_jsonl().is_empty());
+    }
+
+    #[test]
+    fn oldest_entry_evicted_when_full() {
+        let log = EventLog::new();
+        // Fill the buffer.
+        for i in 0..EventLog::CAPACITY {
+            log.push(ContendEvent::new(
+                EventKind::GhostReaped,
+                "maya",
+                format!("id{i:04}"),
+                None,
+            ));
+        }
+        // Push one more — id0000 must be evicted.
+        log.push(ContendEvent::new(
+            EventKind::ElectionWon,
+            "gateway",
+            "newentry",
+            None,
+        ));
+
+        let jsonl = log.as_jsonl();
+        assert!(
+            !jsonl.contains("\"id0000\""),
+            "oldest entry must be evicted from the ring buffer"
+        );
+        assert!(
+            jsonl.contains("\"newentry\""),
+            "newest entry must be present after eviction"
+        );
+    }
+}

--- a/crates/dcc-mcp-gateway/src/gateway/event_log.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/event_log.rs
@@ -144,70 +144,83 @@ impl Default for EventLog {
 
 // ── Prometheus counters ─────────────────────────────────────────────────────
 
-/// Thin wrapper around the three gateway contention counters.
-///
-/// Each counter is registered once in the default Prometheus registry when
-/// `GatewayMetrics::new()` is called. Subsequent calls to `inc_*` are cheap
-/// atomic increments.
+// Process-wide singletons via std::sync::OnceLock: registered exactly once per
+// process lifetime. This prevents `AlreadyReg` panics when multiple Gateway
+// instances are created in the same process (e.g., Python integration tests).
 #[cfg(feature = "prometheus")]
-pub struct GatewayMetrics {
-    elections: prometheus::CounterVec,
-    evictions: prometheus::CounterVec,
-    probes: prometheus::CounterVec,
-}
-
-#[cfg(feature = "prometheus")]
-impl GatewayMetrics {
-    /// Register the three counters in the default Prometheus registry.
-    ///
-    /// Panics at startup if Prometheus registration fails (name collision or
-    /// malformed help string) — this is intentional because a metric that
-    /// cannot be registered is a programming error that must be caught early.
-    pub fn new() -> Self {
-        let elections = prometheus::register_counter_vec!(
+fn elections_counter() -> &'static prometheus::CounterVec {
+    static CELL: std::sync::OnceLock<prometheus::CounterVec> = std::sync::OnceLock::new();
+    CELL.get_or_init(|| {
+        prometheus::register_counter_vec!(
             prometheus::opts!(
                 "dcc_mcp_gateway_elections_total",
                 "Gateway port-election outcomes"
             ),
             &["outcome"]
         )
-        .expect("dcc_mcp_gateway_elections_total registration must succeed");
+        .expect("dcc_mcp_gateway_elections_total registration must succeed")
+    })
+}
 
-        let evictions = prometheus::register_counter_vec!(
+#[cfg(feature = "prometheus")]
+fn evictions_counter() -> &'static prometheus::CounterVec {
+    static CELL: std::sync::OnceLock<prometheus::CounterVec> = std::sync::OnceLock::new();
+    CELL.get_or_init(|| {
+        prometheus::register_counter_vec!(
             prometheus::opts!(
                 "dcc_mcp_gateway_evictions_total",
                 "Gateway registry-eviction events"
             ),
             &["reason"]
         )
-        .expect("dcc_mcp_gateway_evictions_total registration must succeed");
+        .expect("dcc_mcp_gateway_evictions_total registration must succeed")
+    })
+}
 
-        let probes = prometheus::register_counter_vec!(
+#[cfg(feature = "prometheus")]
+fn probes_counter() -> &'static prometheus::CounterVec {
+    static CELL: std::sync::OnceLock<prometheus::CounterVec> = std::sync::OnceLock::new();
+    CELL.get_or_init(|| {
+        prometheus::register_counter_vec!(
             prometheus::opts!(
                 "dcc_mcp_gateway_probes_total",
                 "Gateway backend readiness-probe outcomes"
             ),
             &["outcome"]
         )
-        .expect("dcc_mcp_gateway_probes_total registration must succeed");
+        .expect("dcc_mcp_gateway_probes_total registration must succeed")
+    })
+}
 
-        GatewayMetrics {
-            elections,
-            evictions,
-            probes,
-        }
+/// Thin wrapper around the three gateway contention counters.
+///
+/// The underlying `CounterVec`s are process-wide singletons (via
+/// `std::sync::OnceLock`). Multiple `GatewayMetrics` instances in the same
+/// process safely share the same counters without re-registration.
+#[cfg(feature = "prometheus")]
+pub struct GatewayMetrics;
+
+#[cfg(feature = "prometheus")]
+impl GatewayMetrics {
+    /// Ensure counters are registered (initialization happens at most once
+    /// per process via `OnceLock::get_or_init`).
+    pub fn new() -> Self {
+        let _ = elections_counter();
+        let _ = evictions_counter();
+        let _ = probes_counter();
+        GatewayMetrics
     }
 
     pub fn inc_election(&self, outcome: &str) {
-        self.elections.with_label_values(&[outcome]).inc();
+        elections_counter().with_label_values(&[outcome]).inc();
     }
 
     pub fn inc_eviction(&self, reason: &str) {
-        self.evictions.with_label_values(&[reason]).inc();
+        evictions_counter().with_label_values(&[reason]).inc();
     }
 
     pub fn inc_probe(&self, outcome: &str) {
-        self.probes.with_label_values(&[outcome]).inc();
+        probes_counter().with_label_values(&[outcome]).inc();
     }
 }
 

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/mod.rs
@@ -25,7 +25,7 @@ pub(crate) use dcc_mcp_transport::discovery::types::ServiceStatus;
 mod mcp_impl;
 mod notification_impl;
 mod proxy_impl;
-mod resources;
+pub(crate) mod resources;
 mod rest_impl;
 mod sse_impl;
 

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/resources.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/resources.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+/// URI for the gateway's own contention event log (issue #766).
+pub(crate) const GATEWAY_EVENTS_URI: &str = "resources://gateway/events";
+
 pub(super) async fn handle_resources_list(gs: &GatewayState, id: Value) -> Value {
     let result = aggregator::aggregate_resources_list(gs).await;
     json!({"jsonrpc": "2.0", "id": id, "result": result})
@@ -17,6 +20,21 @@ pub(super) async fn handle_resources_read(
         .and_then(|value| value.as_str())
         .unwrap_or("")
         .to_owned();
+
+    // ── Gateway-internal event log (issue #766) ──────────────────────────
+    if uri == GATEWAY_EVENTS_URI {
+        let jsonl = gs.event_log.as_jsonl();
+        return json!({
+            "jsonrpc": "2.0", "id": id,
+            "result": {
+                "contents": [{
+                    "uri":      GATEWAY_EVENTS_URI,
+                    "mimeType": "application/x-ndjson",
+                    "text":     jsonl
+                }]
+            }
+        });
+    }
 
     if let Some((id8, backend_uri)) = crate::gateway::namespace::decode_resource_uri(&uri) {
         let owning = aggregator::find_instance_by_prefix(gs, &id8).await;
@@ -201,6 +219,116 @@ pub(super) async fn handle_resource_subscription(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::gateway::event_log::{ContendEvent, EventKind};
+    use crate::gateway::handlers::mcp_impl::JsonRpcRequest;
+    use crate::gateway::state::GatewayState;
+    use dcc_mcp_transport::discovery::file_registry::FileRegistry;
+    use serde_json::json;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use tokio::sync::{RwLock, broadcast, watch};
+
+    fn test_gs_with_events(events: Vec<ContendEvent>) -> GatewayState {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
+        let (yield_tx, _) = watch::channel(false);
+        let (events_tx, _) = broadcast::channel::<String>(8);
+        let log = Arc::new(crate::gateway::event_log::EventLog::new());
+        for e in events {
+            log.push(e);
+        }
+        GatewayState {
+            registry,
+            stale_timeout: std::time::Duration::from_secs(30),
+            backend_timeout: std::time::Duration::from_secs(10),
+            async_dispatch_timeout: std::time::Duration::from_secs(60),
+            wait_terminal_timeout: std::time::Duration::from_secs(600),
+            server_name: "test".into(),
+            server_version: env!("CARGO_PKG_VERSION").into(),
+            own_host: "127.0.0.1".into(),
+            own_port: 9765,
+            http_client: reqwest::Client::new(),
+            yield_tx: Arc::new(yield_tx),
+            events_tx: Arc::new(events_tx),
+            protocol_version: Arc::new(RwLock::new(None)),
+            resource_subscriptions: Arc::new(RwLock::new(HashMap::new())),
+            pending_calls: Arc::new(RwLock::new(HashMap::new())),
+            subscriber: crate::gateway::sse_subscriber::SubscriberManager::default(),
+            allow_unknown_tools: false,
+            adapter_version: None,
+            adapter_dcc: None,
+            cursor_safe_tool_names: true,
+            capability_index: Arc::new(crate::gateway::capability::CapabilityIndex::new()),
+            event_log: log,
+            #[cfg(feature = "prometheus")]
+            gateway_metrics: Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
+        }
+    }
+
+    fn make_read_req(uri: &str) -> JsonRpcRequest {
+        JsonRpcRequest {
+            jsonrpc: Some("2.0".into()),
+            id: Some(json!(1)),
+            method: "resources/read".into(),
+            params: Some(json!({"uri": uri})),
+        }
+    }
+
+    /// Issue #766: `resources://gateway/events` must return JSONL text content
+    /// containing every event pushed to the ring buffer.
+    #[tokio::test]
+    async fn gateway_events_resource_returns_jsonl() {
+        let events = vec![
+            ContendEvent::new(EventKind::ElectionWon, "gateway", "abcd1234", None),
+            ContendEvent::new(
+                EventKind::ProbeBooting,
+                "maya",
+                "ef012345",
+                Some("still starting".into()),
+            ),
+        ];
+        let gs = test_gs_with_events(events);
+
+        let req = make_read_req(GATEWAY_EVENTS_URI);
+        let resp = handle_resources_read(&gs, json!(1), &req).await;
+
+        let text = resp["result"]["contents"][0]["text"]
+            .as_str()
+            .expect("response must contain text content");
+        let mime = resp["result"]["contents"][0]["mimeType"]
+            .as_str()
+            .expect("response must contain mimeType");
+
+        assert_eq!(mime, "application/x-ndjson");
+
+        let lines: Vec<&str> = text.lines().collect();
+        assert_eq!(lines.len(), 2, "expected 2 JSONL lines, got: {text:?}");
+
+        let first: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(first["event"], "election_won");
+        assert_eq!(first["dcc_type"], "gateway");
+
+        let second: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(second["event"], "probe_booting");
+        assert_eq!(second["reason"], "still starting");
+    }
+
+    /// Issue #766: empty event log returns an empty string (not an error).
+    #[tokio::test]
+    async fn gateway_events_resource_empty_log() {
+        let gs = test_gs_with_events(vec![]);
+        let req = make_read_req(GATEWAY_EVENTS_URI);
+        let resp = handle_resources_read(&gs, json!(1), &req).await;
+
+        assert!(
+            resp.get("error").is_none(),
+            "empty log must not return an error; got {resp}"
+        );
+        let text = resp["result"]["contents"][0]["text"]
+            .as_str()
+            .expect("must return text content");
+        assert!(text.is_empty(), "empty log text must be empty string");
+    }
 
     #[test]
     fn rewrites_matching_content_uris_only() {

--- a/crates/dcc-mcp-gateway/src/gateway/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/mod.rs
@@ -35,6 +35,7 @@ pub mod aggregator;
 pub mod backend_client;
 pub mod capability;
 pub mod capability_service;
+pub mod event_log;
 pub mod handlers;
 pub mod namespace;
 pub mod proxy;

--- a/crates/dcc-mcp-gateway/src/gateway/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state.rs
@@ -7,6 +7,8 @@ use std::time::Duration;
 use serde_json::{Value, json};
 use tokio::sync::{RwLock, broadcast, watch};
 
+use super::event_log::EventLog;
+
 use dcc_mcp_transport::discovery::file_registry::FileRegistry;
 use dcc_mcp_transport::discovery::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry, ServiceStatus};
 
@@ -119,6 +121,21 @@ pub struct GatewayState {
     /// reference; the inner `RwLock` is held only for the
     /// milliseconds it takes to swap a single instance's slice.
     pub capability_index: Arc<super::capability::CapabilityIndex>,
+
+    /// Contention event log (issue #766).
+    ///
+    /// Append-only JSONL ring buffer (bounded to [`EventLog::CAPACITY`]).
+    /// Exposed as the MCP resource `resources://gateway/events`.
+    /// Also drives Prometheus counters when the `prometheus` feature is on.
+    pub event_log: Arc<EventLog>,
+
+    /// Prometheus contention counters (issue #766).
+    ///
+    /// Compiled only when `prometheus` feature is enabled. Shared via `Arc`
+    /// so both `tasks.rs` (instrumentation points) and `metrics.rs`
+    /// (endpoint handler) refer to the same registered counter objects.
+    #[cfg(feature = "prometheus")]
+    pub gateway_metrics: Arc<super::event_log::GatewayMetrics>,
 }
 
 impl GatewayState {
@@ -322,6 +339,9 @@ mod tests {
             adapter_dcc: None,
             cursor_safe_tool_names: true,
             capability_index: Arc::new(crate::gateway::capability::CapabilityIndex::new()),
+            event_log: Arc::new(crate::gateway::event_log::EventLog::new()),
+            #[cfg(feature = "prometheus")]
+            gateway_metrics: Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
         }
     }
 

--- a/crates/dcc-mcp-gateway/src/gateway/tasks.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tasks.rs
@@ -76,6 +76,11 @@ pub(crate) async fn start_gateway_tasks(
     // when the backend goes genuinely silent.
     let sse_http_client = reqwest::Client::builder().build()?;
 
+    // ── Contention event log + Prometheus counters (issue #766) ───────────
+    let contention_log = Arc::new(crate::gateway::event_log::EventLog::new());
+    #[cfg(feature = "prometheus")]
+    let gateway_metrics = Arc::new(crate::gateway::event_log::GatewayMetrics::new());
+
     // ── Stale cleanup + sentinel heartbeat + dead-PID pruning (every 15 s) ─
     //
     // Issue #229: the sentinel row is heartbeated here — without this, it
@@ -90,6 +95,10 @@ pub(crate) async fn start_gateway_tasks(
     let own_adapter_dcc = adapter_dcc.clone();
     let yield_tx_cleanup = yield_tx.clone();
     let sentinel_key_cleanup = sentinel_key.clone();
+    let cleanup_event_log = contention_log.clone();
+    #[cfg(feature = "prometheus")]
+    let cleanup_metrics = gateway_metrics.clone();
+    let cleanup_own_version = server_version.clone();
     let cleanup_handle = tokio::spawn(async move {
         let mut interval = tokio::time::interval(Duration::from_secs(15));
         loop {
@@ -101,13 +110,36 @@ pub(crate) async fn start_gateway_tasks(
             let _ = r.heartbeat(&sentinel_key_cleanup);
 
             match r.cleanup_stale(stale_timeout) {
-                Ok(n) if n > 0 => tracing::info!("Gateway: evicted {} stale instance(s)", n),
+                Ok(n) if n > 0 => {
+                    tracing::info!("Gateway: evicted {} stale instance(s)", n);
+                    // Record one synthetic stale-eviction event per batch.
+                    crate::gateway::event_log::record_event(
+                        &cleanup_event_log,
+                        #[cfg(feature = "prometheus")]
+                        &cleanup_metrics,
+                        crate::gateway::event_log::EventKind::GhostReaped,
+                        "gateway",
+                        "cleanup",
+                        Some(format!("stale cleanup evicted {n} instance(s)")),
+                    );
+                }
                 Err(e) => tracing::warn!("Gateway: stale cleanup error: {e}"),
                 _ => {}
             }
 
             match r.prune_dead_pids() {
-                Ok(n) if n > 0 => tracing::info!("Gateway: reaped {} ghost entry/entries", n),
+                Ok(n) if n > 0 => {
+                    tracing::info!("Gateway: reaped {} ghost entry/entries", n);
+                    crate::gateway::event_log::record_event(
+                        &cleanup_event_log,
+                        #[cfg(feature = "prometheus")]
+                        &cleanup_metrics,
+                        crate::gateway::event_log::EventKind::GhostReaped,
+                        "gateway",
+                        "cleanup",
+                        Some(format!("dead-PID sweep reaped {n} ghost entry/entries")),
+                    );
+                }
                 Err(e) => tracing::warn!("Gateway: ghost-entry reap error: {e}"),
                 _ => {}
             }
@@ -126,6 +158,17 @@ pub(crate) async fn start_gateway_tasks(
                     adapter_version = ?own_adapter_version,
                     adapter_dcc = ?own_adapter_dcc,
                     "Gateway: newer-version sentinel detected — initiating voluntary yield"
+                );
+                crate::gateway::event_log::record_event(
+                    &cleanup_event_log,
+                    #[cfg(feature = "prometheus")]
+                    &cleanup_metrics,
+                    crate::gateway::event_log::EventKind::VoluntaryYield,
+                    "gateway",
+                    "self",
+                    Some(format!(
+                        "yielded to newer challenger; own={cleanup_own_version}"
+                    )),
                 );
                 let _ = yield_tx_cleanup.send(true);
                 break;
@@ -467,6 +510,9 @@ pub(crate) async fn start_gateway_tasks(
         adapter_dcc,
         cursor_safe_tool_names,
         capability_index: Arc::new(crate::gateway::capability::CapabilityIndex::new()),
+        event_log: contention_log.clone(),
+        #[cfg(feature = "prometheus")]
+        gateway_metrics: gateway_metrics.clone(),
     };
     let gw_router = build_gateway_router(gw_state);
 
@@ -506,6 +552,9 @@ pub(crate) async fn start_gateway_tasks(
     let health_http_client = http_client.clone();
     let health_own_host = own_host.clone();
     let health_own_port = own_port;
+    let health_event_log = contention_log.clone();
+    #[cfg(feature = "prometheus")]
+    let health_metrics = gateway_metrics.clone();
     let health_check_handle = tokio::spawn(async move {
         let mut interval = tokio::time::interval(Duration::from_secs(30));
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -539,6 +588,7 @@ pub(crate) async fn start_gateway_tasks(
                 .await;
 
                 let key = format!("{}:{}", entry.dcc_type, entry.instance_id);
+                let id8 = entry.instance_id.to_string()[..8].to_string();
 
                 // ── Ready ──────────────────────────────────────────
                 if outcome.is_ready() {
@@ -560,6 +610,10 @@ pub(crate) async fn start_gateway_tasks(
                             "Readiness probe green — marking Available"
                         );
                     }
+                    // Only bump the Prometheus counter; do not flood the ring
+                    // buffer with a "ready" entry on every 30-second tick.
+                    #[cfg(feature = "prometheus")]
+                    health_metrics.inc_probe("ready");
                     continue;
                 }
 
@@ -583,6 +637,15 @@ pub(crate) async fn start_gateway_tasks(
                             instance_id = %entry.instance_id,
                             previous_status = %entry.status,
                             "Backend booting (GET /v1/readyz red) — marking Booting without deregister"
+                        );
+                        crate::gateway::event_log::record_event(
+                            &health_event_log,
+                            #[cfg(feature = "prometheus")]
+                            &health_metrics,
+                            crate::gateway::event_log::EventKind::ProbeBooting,
+                            &entry.dcc_type,
+                            &id8,
+                            None,
                         );
                     }
                     // Clear any prior consecutive-failure tally: the
@@ -608,6 +671,15 @@ pub(crate) async fn start_gateway_tasks(
                         &entry.key(),
                         dcc_mcp_transport::discovery::types::ServiceStatus::Unreachable,
                     );
+                    crate::gateway::event_log::record_event(
+                        &health_event_log,
+                        #[cfg(feature = "prometheus")]
+                        &health_metrics,
+                        crate::gateway::event_log::EventKind::ProbeUnreachable,
+                        &entry.dcc_type,
+                        &id8,
+                        Some(format!("{} consecutive failures", *count)),
+                    );
                 }
 
                 if *count >= 3 {
@@ -619,6 +691,15 @@ pub(crate) async fn start_gateway_tasks(
                         dcc_type = %entry.dcc_type,
                         instance_id = %entry.instance_id,
                         "Auto-deregistered after 3 consecutive health-check failures"
+                    );
+                    crate::gateway::event_log::record_event(
+                        &health_event_log,
+                        #[cfg(feature = "prometheus")]
+                        &health_metrics,
+                        crate::gateway::event_log::EventKind::AutoDeregister,
+                        &entry.dcc_type,
+                        &id8,
+                        Some("3 consecutive health-check failures".into()),
                     );
                 }
             }

--- a/crates/dcc-mcp-http/src/tests/gateway.rs
+++ b/crates/dcc-mcp-http/src/tests/gateway.rs
@@ -38,6 +38,9 @@ fn make_gateway_state() -> GatewayState {
         adapter_dcc: None,
         cursor_safe_tool_names: true,
         capability_index: std::sync::Arc::new(crate::gateway::capability::CapabilityIndex::new()),
+        event_log: std::sync::Arc::new(crate::gateway::event_log::EventLog::new()),
+        #[cfg(feature = "prometheus")]
+        gateway_metrics: std::sync::Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
     }
 }
 

--- a/crates/dcc-mcp-http/tests/http/backend_timeout.rs
+++ b/crates/dcc-mcp-http/tests/http/backend_timeout.rs
@@ -73,6 +73,11 @@ async fn make_state(
         capability_index: std::sync::Arc::new(
             dcc_mcp_http::gateway::capability::CapabilityIndex::new(),
         ),
+        event_log: std::sync::Arc::new(dcc_mcp_http::gateway::event_log::EventLog::new()),
+        #[cfg(feature = "prometheus")]
+        gateway_metrics: std::sync::Arc::new(
+            dcc_mcp_http::gateway::event_log::GatewayMetrics::new(),
+        ),
     };
     (state, registry, dir)
 }

--- a/crates/dcc-mcp-http/tests/http/gateway_dynamic_capabilities.rs
+++ b/crates/dcc-mcp-http/tests/http/gateway_dynamic_capabilities.rs
@@ -64,6 +64,11 @@ fn make_state(registry: Arc<RwLock<FileRegistry>>) -> GatewayState {
         adapter_dcc: None,
         cursor_safe_tool_names: true,
         capability_index: Arc::new(CapabilityIndex::new()),
+        event_log: std::sync::Arc::new(dcc_mcp_http::gateway::event_log::EventLog::new()),
+        #[cfg(feature = "prometheus")]
+        gateway_metrics: std::sync::Arc::new(
+            dcc_mcp_http::gateway::event_log::GatewayMetrics::new(),
+        ),
     }
 }
 

--- a/crates/dcc-mcp-http/tests/http/gateway_passthrough.rs
+++ b/crates/dcc-mcp-http/tests/http/gateway_passthrough.rs
@@ -55,6 +55,11 @@ async fn make_state(
         adapter_dcc: None,
         cursor_safe_tool_names: true,
         capability_index: Arc::new(dcc_mcp_http::gateway::capability::CapabilityIndex::new()),
+        event_log: std::sync::Arc::new(dcc_mcp_http::gateway::event_log::EventLog::new()),
+        #[cfg(feature = "prometheus")]
+        gateway_metrics: std::sync::Arc::new(
+            dcc_mcp_http::gateway::event_log::GatewayMetrics::new(),
+        ),
     };
     (state, registry, dir)
 }


### PR DESCRIPTION
Closes #766

## Summary

Two complementary observability surfaces for gateway contention events:

### 1. MCP resource `resources://gateway/events`
Append-only JSONL event stream (ring buffer, bounded to 1000 entries). One row per contention event with: `timestamp`, `event`, `dcc_type`, `instance_id`, `reason`.

Events recorded:
- `election_won` — this gateway won the port
- `voluntary_yield` — this gateway yielded to a higher-version challenger
- `ghost_reaped` — dead-PID or stale entries reaped from registry (batched)
- `probe_booting` — backend alive but not ready (GET /v1/readyz → 503)
- `probe_unreachable` — backend unreachable after 2 consecutive health-check failures
- `auto_deregister` — backend auto-deregistered after 3 consecutive failures

### 2. Prometheus counters (under `prometheus` feature)
- `dcc_mcp_gateway_elections_total{outcome="won|yielded"}`
- `dcc_mcp_gateway_evictions_total{reason="stale|ghost|probe_fail"}`
- `dcc_mcp_gateway_probes_total{outcome="ready|booting|unreachable"}`

Metric cardinality stays bounded (no free-form `instance_id` labels).

## Tests
- `event_log::tests` — ring buffer capacity, JSONL serialization, eviction
- `handlers::resources::tests` — MCP resource returns correct JSONL, empty log returns empty string