### PR TITLE
feat(catalog): public DCC-MCP catalog + dcc_catalog__search/describe MCP tools + CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6013,7 +6013,6 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "once_cell",
  "phf 0.11.3",
  "phf_shared 0.11.3",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,6 +804,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dcc-mcp-catalog"
+version = "0.14.28"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_yaml_ng",
+ "tempfile",
+ "thiserror 2.0.18",
+ "workspace-hack",
+]
+
+[[package]]
 name = "dcc-mcp-core"
 version = "0.14.28"
 dependencies = [
@@ -841,6 +853,7 @@ dependencies = [
  "chrono",
  "criterion 0.5.1",
  "dashmap",
+ "dcc-mcp-catalog",
  "dcc-mcp-jsonrpc",
  "dcc-mcp-naming",
  "dcc-mcp-skill-rest",
@@ -1126,6 +1139,7 @@ dependencies = [
  "axum",
  "clap",
  "dcc-mcp-actions",
+ "dcc-mcp-catalog",
  "dcc-mcp-http",
  "dcc-mcp-logging",
  "dcc-mcp-protocols",
@@ -5999,6 +6013,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
+ "once_cell",
  "phf 0.11.3",
  "phf_shared 0.11.3",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "crates/dcc-mcp-tunnel-protocol",
     "crates/dcc-mcp-tunnel-relay",
     "crates/dcc-mcp-tunnel-agent",
+    "crates/dcc-mcp-catalog",
     "crates/workspace-hack",
 ]
 resolver = "2"
@@ -71,6 +72,7 @@ dcc-mcp-host = { path = "crates/dcc-mcp-host" }
 dcc-mcp-tunnel-protocol = { path = "crates/dcc-mcp-tunnel-protocol" }
 dcc-mcp-tunnel-relay = { path = "crates/dcc-mcp-tunnel-relay" }
 dcc-mcp-tunnel-agent = { path = "crates/dcc-mcp-tunnel-agent" }
+dcc-mcp-catalog = { path = "crates/dcc-mcp-catalog" }
 
 # Shared dependencies (single version across workspace)
 pyo3 = { version = "0.28", features = ["multiple-pymethods"] }

--- a/crates/dcc-mcp-catalog/Cargo.toml
+++ b/crates/dcc-mcp-catalog/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "dcc-mcp-catalog"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Public DCC-MCP catalog for ecosystem discovery — adapters, skill packs, and plugins"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml_ng = { workspace = true }
+thiserror = { workspace = true }
+workspace-hack = { version = "0.1", path = "../workspace-hack" }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/dcc-mcp-catalog/src/error.rs
+++ b/crates/dcc-mcp-catalog/src/error.rs
@@ -1,0 +1,11 @@
+use thiserror::Error;
+
+/// Errors returned by the catalog loader.
+#[derive(Debug, Error)]
+pub enum CatalogError {
+    #[error("catalog I/O error for '{0}': {1}")]
+    Io(String, #[source] std::io::Error),
+
+    #[error("catalog YAML parse error: {0}")]
+    Parse(String),
+}

--- a/crates/dcc-mcp-catalog/src/lib.rs
+++ b/crates/dcc-mcp-catalog/src/lib.rs
@@ -1,0 +1,198 @@
+//! Public DCC-MCP catalog for ecosystem discovery.
+//!
+//! Provides [`CatalogEntry`] (a typed YAML record), and two discovery
+//! functions — [`search`] and [`describe`] — that can be wired up as
+//! gateway MCP tools (`dcc_catalog__search` / `dcc_catalog__describe`).
+//!
+//! # YAML format (`dcc-mcp-catalog.yml`)
+//!
+//! ```yaml
+//! version: "1"
+//! entries:
+//!   - name: "dcc-mcp-maya-skills"
+//!     description: "Maya skill pack for DCC-MCP"
+//!     dcc: ["maya"]
+//!     url: "https://github.com/loonghao/dcc-mcp-maya-skills"
+//!     tags: ["skills", "maya", "official"]
+//! ```
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+mod error;
+pub use error::CatalogError;
+
+// ── types ─────────────────────────────────────────────────────────────────────
+
+/// A single entry in the public DCC-MCP catalog.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CatalogEntry {
+    /// Unique package / adapter name (e.g. `"dcc-mcp-maya-skills"`).
+    pub name: String,
+    /// Human-readable description.
+    pub description: String,
+    /// DCC application(s) this entry targets (e.g. `["maya", "blender"]`).
+    #[serde(default)]
+    pub dcc: Vec<String>,
+    /// Canonical URL (GitHub repo, docs site, …).
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Searchable tags.
+    #[serde(default)]
+    pub tags: Vec<String>,
+}
+
+/// Top-level catalog document.
+#[derive(Debug, Deserialize)]
+struct CatalogDoc {
+    #[allow(dead_code)]
+    version: String,
+    entries: Vec<CatalogEntry>,
+}
+
+// ── loading ───────────────────────────────────────────────────────────────────
+
+/// Load catalog entries from a YAML file on disk.
+///
+/// Returns an empty `Vec` if the file does not exist (so callers that embed a
+/// bundled catalog path don't hard-fail when the file is absent in tests or
+/// minimal installs).
+pub fn load_from_file(path: impl AsRef<Path>) -> Result<Vec<CatalogEntry>, CatalogError> {
+    let path = path.as_ref();
+    if !path.exists() {
+        return Ok(vec![]);
+    }
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| CatalogError::Io(path.display().to_string(), e))?;
+    load_from_str(&text)
+}
+
+/// Parse catalog entries from a YAML string.
+pub fn load_from_str(yaml: &str) -> Result<Vec<CatalogEntry>, CatalogError> {
+    let doc: CatalogDoc =
+        serde_yaml_ng::from_str(yaml).map_err(|e| CatalogError::Parse(e.to_string()))?;
+    Ok(doc.entries)
+}
+
+// ── search / describe ─────────────────────────────────────────────────────────
+
+/// Search catalog entries.
+///
+/// `query` is matched case-insensitively against `name`, `description`,
+/// `dcc`, and `tags`.  An empty query returns all entries.
+pub fn search(entries: &[CatalogEntry], query: &str) -> Vec<CatalogEntry> {
+    if query.is_empty() {
+        return entries.to_vec();
+    }
+    let q = query.to_lowercase();
+    entries
+        .iter()
+        .filter(|e| {
+            e.name.to_lowercase().contains(&q)
+                || e.description.to_lowercase().contains(&q)
+                || e.dcc.iter().any(|d| d.to_lowercase().contains(&q))
+                || e.tags.iter().any(|t| t.to_lowercase().contains(&q))
+        })
+        .cloned()
+        .collect()
+}
+
+/// Look up a single entry by exact name.
+pub fn describe(entries: &[CatalogEntry], name: &str) -> Option<CatalogEntry> {
+    entries.iter().find(|e| e.name == name).cloned()
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_YAML: &str = r#"
+version: "1"
+entries:
+  - name: "dcc-mcp-maya-skills"
+    description: "Maya skill pack for DCC-MCP"
+    dcc: ["maya"]
+    url: "https://github.com/loonghao/dcc-mcp-maya-skills"
+    tags: ["skills", "maya", "official"]
+  - name: "dcc-mcp-blender-skills"
+    description: "Blender skill pack for DCC-MCP"
+    dcc: ["blender"]
+    url: "https://github.com/loonghao/dcc-mcp-blender-skills"
+    tags: ["skills", "blender", "official"]
+  - name: "dcc-mcp-houdini-vfx"
+    description: "Houdini VFX tools"
+    dcc: ["houdini"]
+    tags: ["vfx", "houdini"]
+"#;
+
+    fn sample_entries() -> Vec<CatalogEntry> {
+        load_from_str(SAMPLE_YAML).unwrap()
+    }
+
+    #[test]
+    fn test_load_from_str() {
+        let entries = sample_entries();
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].name, "dcc-mcp-maya-skills");
+    }
+
+    #[test]
+    fn test_search_by_dcc_type() {
+        let entries = sample_entries();
+        let results = search(&entries, "maya");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "dcc-mcp-maya-skills");
+    }
+
+    #[test]
+    fn test_search_by_tag() {
+        let entries = sample_entries();
+        let results = search(&entries, "official");
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn test_search_empty_returns_all() {
+        let entries = sample_entries();
+        let results = search(&entries, "");
+        assert_eq!(results.len(), 3);
+    }
+
+    #[test]
+    fn test_search_case_insensitive() {
+        let entries = sample_entries();
+        let results = search(&entries, "MAYA");
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn test_describe_found() {
+        let entries = sample_entries();
+        let entry = describe(&entries, "dcc-mcp-blender-skills").unwrap();
+        assert_eq!(entry.dcc, vec!["blender"]);
+    }
+
+    #[test]
+    fn test_describe_not_found() {
+        let entries = sample_entries();
+        assert!(describe(&entries, "does-not-exist").is_none());
+    }
+
+    #[test]
+    fn test_load_from_file_missing() {
+        let entries = load_from_file("/nonexistent/path/catalog.yml").unwrap();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn test_load_from_file_exists() {
+        use std::io::Write;
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(SAMPLE_YAML.as_bytes()).unwrap();
+        let entries = load_from_file(f.path()).unwrap();
+        assert_eq!(entries.len(), 3);
+    }
+}

--- a/crates/dcc-mcp-gateway/Cargo.toml
+++ b/crates/dcc-mcp-gateway/Cargo.toml
@@ -15,6 +15,7 @@ dcc-mcp-naming = { path = "../dcc-mcp-naming" }
 dcc-mcp-transport = { path = "../dcc-mcp-transport" }
 dcc-mcp-telemetry = { path = "../dcc-mcp-telemetry", optional = true }
 dcc-mcp-skill-rest = { path = "../dcc-mcp-skill-rest" }
+dcc-mcp-catalog = { path = "../dcc-mcp-catalog" }
 
 # Workspace shared
 serde = { workspace = true }

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator.rs
@@ -54,9 +54,10 @@ use super::backend_client::{call_backend, fetch_tools, forward_tools_call};
 use super::namespace::{decode_tool_name, instance_short};
 use super::state::GatewayState;
 use super::tools::{
-    gateway_tool_defs, tool_acquire_instance, tool_call_tool, tool_connect_to_dcc,
-    tool_describe_tool, tool_diagnostics_audit_log, tool_diagnostics_process_status,
-    tool_diagnostics_tool_metrics, tool_get_instance, tool_release_instance, tool_search_tools,
+    gateway_tool_defs, tool_acquire_instance, tool_call_tool, tool_catalog_describe,
+    tool_catalog_search, tool_connect_to_dcc, tool_describe_tool, tool_diagnostics_audit_log,
+    tool_diagnostics_process_status, tool_diagnostics_tool_metrics, tool_get_instance,
+    tool_release_instance, tool_search_tools,
 };
 use dcc_mcp_jsonrpc::{TOOLS_LIST_PAGE_SIZE, decode_cursor, encode_cursor};
 use dcc_mcp_transport::discovery::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry};

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/call.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/call.rs
@@ -35,6 +35,9 @@ pub async fn route_tools_call(
         "diagnostics__tool_metrics" => {
             return to_text_result(tool_diagnostics_tool_metrics(gs, args).await);
         }
+        // ── #774 public catalog tools ────────────────────────────────
+        "dcc_catalog__search" => return to_text_result(tool_catalog_search(args)),
+        "dcc_catalog__describe" => return to_text_result(tool_catalog_describe(args)),
         // ── #655 dynamic-capability MCP wrappers ────────────────────
         "search_tools" => return to_text_result(tool_search_tools(gs, args).await),
         "describe_tool" => return to_text_result(tool_describe_tool(gs, args).await),

--- a/crates/dcc-mcp-gateway/src/gateway/tools.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tools.rs
@@ -579,6 +579,70 @@ pub async fn tool_diagnostics_tool_metrics(
     .map_err(|e| e.to_string())
 }
 
+/// `dcc_catalog__search` — search the public DCC-MCP catalog by keyword.
+///
+/// Accepts an optional `query` string; an empty / absent query returns all
+/// entries.  Results are sorted by name and serialised as a JSON array.
+pub fn tool_catalog_search(args: &Value) -> Result<String, String> {
+    let query = args
+        .get("query")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+
+    let catalog_path = catalog_yml_path();
+    let entries = dcc_mcp_catalog::load_from_file(&catalog_path)
+        .map_err(|e| format!("catalog load error: {e}"))?;
+
+    let mut hits = dcc_mcp_catalog::search(&entries, query);
+    hits.sort_by(|a, b| a.name.cmp(&b.name));
+
+    serde_json::to_string_pretty(&json!({
+        "total": hits.len(),
+        "query": query,
+        "entries": hits,
+    }))
+    .map_err(|e| e.to_string())
+}
+
+/// `dcc_catalog__describe` — look up a single catalog entry by exact name.
+pub fn tool_catalog_describe(args: &Value) -> Result<String, String> {
+    let name = args
+        .get("name")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "missing required argument: name".to_string())?;
+
+    let catalog_path = catalog_yml_path();
+    let entries = dcc_mcp_catalog::load_from_file(&catalog_path)
+        .map_err(|e| format!("catalog load error: {e}"))?;
+
+    match dcc_mcp_catalog::describe(&entries, name) {
+        Some(entry) => serde_json::to_string_pretty(&entry).map_err(|e| e.to_string()),
+        None => Err(format!("catalog entry '{name}' not found")),
+    }
+}
+
+/// Resolve the path to `dcc-mcp-catalog.yml`.
+///
+/// Priority:
+/// 1. `DCC_MCP_CATALOG_PATH` env var (absolute path override)
+/// 2. Adjacent to the running executable (`exe_dir/dcc-mcp-catalog.yml`)
+/// 3. Current working directory
+fn catalog_yml_path() -> std::path::PathBuf {
+    if let Ok(p) = std::env::var("DCC_MCP_CATALOG_PATH") {
+        return std::path::PathBuf::from(p);
+    }
+    if let Ok(exe) = std::env::current_exe() {
+        let candidate = exe
+            .parent()
+            .unwrap_or(std::path::Path::new("."))
+            .join("dcc-mcp-catalog.yml");
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+    std::path::PathBuf::from("dcc-mcp-catalog.yml")
+}
+
 // ── private helpers ────────────────────────────────────────────────────────
 
 fn format_connect_response(entry: &ServiceEntry) -> Result<String, String> {
@@ -813,6 +877,36 @@ pub fn gateway_tool_defs() -> serde_json::Value {
             "name": "diagnostics__tool_metrics",
             "description": "Gateway-native tool metrics summary for local gateway tools and live backend count.",
             "inputSchema": {"type": "object", "properties": {}}
+        },
+        {
+            "name": "dcc_catalog__search",
+            "description": "Search the public DCC-MCP catalog for adapters, skill packs, and plugins. \
+                Pass a `query` string to filter by name, description, DCC type, or tag. \
+                Omit `query` (or pass an empty string) to list every catalog entry.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Keyword to search for (matched against name, description, dcc, tags). Omit for all entries."
+                    }
+                }
+            }
+        },
+        {
+            "name": "dcc_catalog__describe",
+            "description": "Return the full catalog record for a single DCC-MCP package. \
+                Use the exact `name` returned by `dcc_catalog__search`.",
+            "inputSchema": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Exact catalog entry name (e.g. 'dcc-mcp-maya-skills')."
+                    }
+                }
+            }
         }
     ])
 }

--- a/crates/dcc-mcp-gateway/src/gateway/tools.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tools.rs
@@ -910,3 +910,130 @@ pub fn gateway_tool_defs() -> serde_json::Value {
         }
     ])
 }
+
+// ── catalog tool tests ────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod catalog_tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    /// Write YAML content to a temp file and return the handle (keep it alive).
+    fn write_catalog_yaml(content: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f
+    }
+
+    const TWO_ENTRY_YAML: &str = r#"
+version: "1"
+entries:
+  - name: maya-skills
+    description: Maya skill pack
+    dcc: [maya]
+    url: https://example.com/maya
+    tags: [skills]
+  - name: blender-skills
+    description: Blender skill pack
+    dcc: [blender]
+    url: https://example.com/blender
+    tags: [skills]
+"#;
+
+    const ONE_ENTRY_YAML: &str = r#"
+version: "1"
+entries:
+  - name: maya-skills
+    description: Maya skill pack
+    dcc: [maya]
+    url: https://example.com/maya
+    tags: [skills]
+"#;
+
+    #[test]
+    fn catalog_search_empty_query_returns_all() {
+        let f = write_catalog_yaml(TWO_ENTRY_YAML);
+        // SAFETY: single-threaded test; no concurrent env access
+        unsafe { std::env::set_var("DCC_MCP_CATALOG_PATH", f.path()) };
+
+        let args = serde_json::json!({"query": ""});
+        let result = tool_catalog_search(&args).expect("search should succeed");
+        let v: serde_json::Value = serde_json::from_str(&result).unwrap();
+
+        assert_eq!(v["total"], 2, "empty query should return all 2 entries");
+        // SAFETY: same as set_var above
+        unsafe { std::env::remove_var("DCC_MCP_CATALOG_PATH") };
+    }
+
+    #[test]
+    fn catalog_search_absent_query_returns_all() {
+        let f = write_catalog_yaml(TWO_ENTRY_YAML);
+        // SAFETY: single-threaded test; no concurrent env access
+        unsafe { std::env::set_var("DCC_MCP_CATALOG_PATH", f.path()) };
+
+        let args = serde_json::json!({});
+        let result = tool_catalog_search(&args).expect("search should succeed");
+        let v: serde_json::Value = serde_json::from_str(&result).unwrap();
+
+        assert_eq!(v["total"], 2, "absent query key should return all entries");
+        // SAFETY: same as set_var above
+        unsafe { std::env::remove_var("DCC_MCP_CATALOG_PATH") };
+    }
+
+    #[test]
+    fn catalog_search_keyword_filters_results() {
+        let f = write_catalog_yaml(TWO_ENTRY_YAML);
+        // SAFETY: single-threaded test; no concurrent env access
+        unsafe { std::env::set_var("DCC_MCP_CATALOG_PATH", f.path()) };
+
+        let args = serde_json::json!({"query": "maya"});
+        let result = tool_catalog_search(&args).expect("search should succeed");
+        let v: serde_json::Value = serde_json::from_str(&result).unwrap();
+
+        assert_eq!(v["total"], 1);
+        assert_eq!(v["entries"][0]["name"], "maya-skills");
+        // SAFETY: same as set_var above
+        unsafe { std::env::remove_var("DCC_MCP_CATALOG_PATH") };
+    }
+
+    #[test]
+    fn catalog_describe_existing_entry_returns_data() {
+        let f = write_catalog_yaml(ONE_ENTRY_YAML);
+        // SAFETY: single-threaded test; no concurrent env access
+        unsafe { std::env::set_var("DCC_MCP_CATALOG_PATH", f.path()) };
+
+        let args = serde_json::json!({"name": "maya-skills"});
+        let result = tool_catalog_describe(&args).expect("describe should succeed");
+        let v: serde_json::Value = serde_json::from_str(&result).unwrap();
+
+        assert_eq!(v["name"], "maya-skills");
+        assert_eq!(v["dcc"][0], "maya");
+        // SAFETY: same as set_var above
+        unsafe { std::env::remove_var("DCC_MCP_CATALOG_PATH") };
+    }
+
+    #[test]
+    fn catalog_describe_missing_name_returns_not_found() {
+        let f = write_catalog_yaml(ONE_ENTRY_YAML);
+        // SAFETY: single-threaded test; no concurrent env access
+        unsafe { std::env::set_var("DCC_MCP_CATALOG_PATH", f.path()) };
+
+        let args = serde_json::json!({"name": "does-not-exist"});
+        let err = tool_catalog_describe(&args).expect_err("missing entry should return Err");
+
+        assert!(
+            err.contains("not found"),
+            "error message should contain 'not found', got: {err}"
+        );
+        // SAFETY: same as set_var above
+        unsafe { std::env::remove_var("DCC_MCP_CATALOG_PATH") };
+    }
+
+    #[test]
+    fn catalog_describe_missing_name_arg_returns_error() {
+        let args = serde_json::json!({});
+        let err = tool_catalog_describe(&args).expect_err("missing 'name' arg should return Err");
+        assert!(err.contains("name"), "error should mention 'name': {err}");
+    }
+}

--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -1282,21 +1282,27 @@ mod tests {
     /// Issue #771: payload size limits have sane defaults.
     #[test]
     fn payload_limits_default_values() {
-        let cfg = McpHttpConfig::new(8765);
-        assert_eq!(cfg.max_request_body_bytes, 4 * 1024 * 1024);
-        assert_eq!(cfg.max_response_content_bytes, 1024 * 1024);
-        assert_eq!(cfg.sse_chunk_size_bytes, 64 * 1024);
+        let cfg = McpHttpConfig::default();
+        assert_eq!(cfg.queue.max_request_body_bytes, 4 * 1024 * 1024);
+        assert_eq!(cfg.queue.max_response_content_bytes, 1024 * 1024);
+        assert_eq!(cfg.queue.sse_chunk_size_bytes, 64 * 1024);
     }
 
     /// Issue #771: builder methods override the defaults.
     #[test]
     fn payload_limits_builders_override_defaults() {
-        let cfg = McpHttpConfig::new(8765)
-            .with_max_request_body_bytes(8 * 1024 * 1024)
-            .with_max_response_content_bytes(512 * 1024)
-            .with_sse_chunk_size_bytes(32 * 1024);
-        assert_eq!(cfg.max_request_body_bytes, 8 * 1024 * 1024);
-        assert_eq!(cfg.max_response_content_bytes, 512 * 1024);
-        assert_eq!(cfg.sse_chunk_size_bytes, 32 * 1024);
+        let cfg = McpHttpConfig::default();
+        let cfg = McpHttpConfig {
+            queue: QueueConfig {
+                max_request_body_bytes: 8 * 1024 * 1024,
+                max_response_content_bytes: 512 * 1024,
+                sse_chunk_size_bytes: 32 * 1024,
+                ..cfg.queue
+            },
+            ..cfg
+        };
+        assert_eq!(cfg.queue.max_request_body_bytes, 8 * 1024 * 1024);
+        assert_eq!(cfg.queue.max_response_content_bytes, 512 * 1024);
+        assert_eq!(cfg.queue.sse_chunk_size_bytes, 32 * 1024);
     }
 }

--- a/crates/dcc-mcp-http/src/server/mod.rs
+++ b/crates/dcc-mcp-http/src/server/mod.rs
@@ -509,7 +509,7 @@ impl McpHttpServer {
             .with_state(state)
             .merge(rest_router)
             .layer(RequestBodyLimitLayer::new(
-                self.config.max_request_body_bytes,
+                self.config.queue.max_request_body_bytes,
             ))
             .layer(TraceLayer::new_for_http());
 

--- a/crates/dcc-mcp-server/Cargo.toml
+++ b/crates/dcc-mcp-server/Cargo.toml
@@ -20,6 +20,7 @@ dcc-mcp-protocols.workspace = true
 dcc-mcp-logging.workspace = true
 dcc-mcp-transport.workspace = true
 dcc-mcp-telemetry = { path = "../dcc-mcp-telemetry", optional = true }
+dcc-mcp-catalog.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -77,7 +77,7 @@ use std::process::{Command, Stdio};
 use std::sync::Arc;
 use std::time::Duration;
 
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use dcc_mcp_actions::{ActionDispatcher, ActionRegistry};
 use dcc_mcp_http::gateway::{GatewayConfig, GatewayRunner};
 use dcc_mcp_http::{McpHttpConfig, McpHttpServer};
@@ -85,13 +85,15 @@ use dcc_mcp_logging::file_logging::prune_old_logs;
 use dcc_mcp_skills::SkillCatalog;
 use dcc_mcp_transport::discovery::types::ServiceEntry;
 use sysinfo::{Pid, ProcessesToUpdate, System};
-
 // ── CLI ───────────────────────────────────────────────────────────────────────
 
 /// DCC-MCP server with integrated auto-gateway.
 #[derive(Debug, Parser)]
 #[command(name = "dcc-mcp-server", about, version)]
 struct Args {
+    /// Catalog subcommand (search or describe).
+    #[command(subcommand)]
+    catalog_cmd: Option<CatalogCommand>,
     /// MCP Streamable HTTP server port. Default 0 = OS-assigned.
     #[arg(long, env = "DCC_MCP_MCP_PORT", default_value = "0")]
     mcp_port: u16,
@@ -230,6 +232,59 @@ struct Args {
     /// Maximum total log directory size in MiB (0 = disable size pruning). Default: 100.
     #[arg(long, env = "DCC_MCP_LOG_MAX_TOTAL_SIZE_MB", value_name = "MB")]
     log_max_total_size_mb: Option<u32>,
+}
+
+// ── Catalog subcommands ───────────────────────────────────────────────────────
+
+/// Catalog subcommand: query the public DCC-MCP catalog.
+#[derive(Debug, Subcommand)]
+enum CatalogCommand {
+    /// Catalog commands.
+    Catalog {
+        #[command(subcommand)]
+        action: CatalogAction,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum CatalogAction {
+    /// Search the catalog by keyword (name, description, DCC type, tags).
+    Search {
+        /// Keyword to search for. Omit to list all entries.
+        #[arg(long, default_value = "")]
+        query: String,
+    },
+    /// Show full details for a single catalog entry by exact name.
+    Describe {
+        /// Exact catalog entry name (e.g. dcc-mcp-maya-skills).
+        #[arg(long)]
+        name: String,
+    },
+}
+
+fn run_catalog_cmd(action: &CatalogAction) -> anyhow::Result<()> {
+    let catalog_path = if let Ok(p) = std::env::var("DCC_MCP_CATALOG_PATH") {
+        PathBuf::from(p)
+    } else {
+        PathBuf::from("dcc-mcp-catalog.yml")
+    };
+
+    let entries = dcc_mcp_catalog::load_from_file(&catalog_path)?;
+
+    match action {
+        CatalogAction::Search { query } => {
+            let hits = dcc_mcp_catalog::search(&entries, query);
+            println!("{}", serde_json::to_string_pretty(&hits)?);
+        }
+        CatalogAction::Describe { name } => match dcc_mcp_catalog::describe(&entries, name) {
+            Some(entry) => println!("{}", serde_json::to_string_pretty(&entry)?),
+            None => {
+                eprintln!("catalog entry '{}' not found", name);
+                std::process::exit(1);
+            }
+        },
+    }
+    Ok(())
 }
 
 struct PidFileGuard {
@@ -492,6 +547,11 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let args = Args::parse();
+
+    // Dispatch catalog subcommand without starting the server.
+    if let Some(CatalogCommand::Catalog { action }) = &args.catalog_cmd {
+        return run_catalog_cmd(action);
+    }
 
     if let (Some(path), Some(pid)) = (args.pid_cleanup_watch.clone(), args.watch_pid) {
         run_pid_cleanup_watcher(path, pid);

--- a/dcc-mcp-catalog.yml
+++ b/dcc-mcp-catalog.yml
@@ -1,0 +1,48 @@
+# DCC-MCP Public Catalog
+# Ecosystem index for DCC adapters, skill packs, and plugins.
+#
+# Schema version: "1"
+# Fields:
+#   name        - Unique package / adapter name (required)
+#   description - Human-readable description (required)
+#   dcc         - DCC target(s): maya, blender, houdini, photoshop, ... (list)
+#   url         - Canonical URL (GitHub repo, docs, PyPI, ...) (optional)
+#   tags        - Searchable tags (list, optional)
+
+version: "1"
+entries:
+  - name: "dcc-mcp-maya-skills"
+    description: "Official Maya skill pack for DCC-MCP — scene, render, and rigging tools"
+    dcc: ["maya"]
+    url: "https://github.com/loonghao/dcc-mcp-maya-skills"
+    tags: ["skills", "maya", "official", "rigging", "render"]
+
+  - name: "dcc-mcp-blender-skills"
+    description: "Official Blender skill pack for DCC-MCP — modeling, shading, and render tools"
+    dcc: ["blender"]
+    url: "https://github.com/loonghao/dcc-mcp-blender-skills"
+    tags: ["skills", "blender", "official", "modeling", "render"]
+
+  - name: "dcc-mcp-houdini-skills"
+    description: "Official Houdini skill pack for DCC-MCP — VFX, procedural, and simulation tools"
+    dcc: ["houdini"]
+    url: "https://github.com/loonghao/dcc-mcp-houdini-skills"
+    tags: ["skills", "houdini", "official", "vfx", "simulation"]
+
+  - name: "dcc-mcp-photoshop-skills"
+    description: "Official Photoshop skill pack for DCC-MCP — layer, adjustment, and export tools"
+    dcc: ["photoshop"]
+    url: "https://github.com/loonghao/dcc-mcp-photoshop-skills"
+    tags: ["skills", "photoshop", "official", "compositing"]
+
+  - name: "dcc-mcp-unreal-skills"
+    description: "Official Unreal Engine skill pack for DCC-MCP — asset, level, and sequencer tools"
+    dcc: ["unreal"]
+    url: "https://github.com/loonghao/dcc-mcp-unreal-skills"
+    tags: ["skills", "unreal", "official", "game", "engine"]
+
+  - name: "dcc-mcp-core"
+    description: "Foundational Rust + Python library for the DCC-MCP ecosystem"
+    dcc: []
+    url: "https://github.com/loonghao/dcc-mcp-core"
+    tags: ["core", "official", "rust", "python", "library"]


### PR DESCRIPTION
Closes #774

## Summary

Adds a public DCC-MCP catalog for ecosystem discovery:

### Components
1. **`dcc-mcp-catalog.yml`**: YAML specification for DCC-MCP adapters and skill packs
2. **`dcc-mcp-catalog` crate**: `CatalogEntry`, `search`, `describe` functions  
3. **MCP tools**: `dcc_catalog__search` and `dcc_catalog__describe` registered in the gateway
4. **CLI**: `dcc-mcp-server catalog search|describe`

### Example
```sh
dcc-mcp-server catalog search --query maya
dcc-mcp-server catalog describe --name dcc-mcp-maya-skills
```