### PR TITLE
feat(gateway): pluggable BeforeCall/AfterCall middleware chain for cross-cutting policies

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/config.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/config.rs
@@ -68,6 +68,23 @@ pub struct GatewayConfig {
     /// Flip to `false` only to emit the SEP-986 dotted form for
     /// diagnostic parity.
     pub cursor_safe_tool_names: bool,
+
+    /// Pre-registered middleware chain applied to every `tools/call` (issue #770).
+    ///
+    /// Use the builder API to attach cross-cutting policies:
+    ///
+    /// ```rust,ignore
+    /// use dcc_mcp_gateway::gateway::middleware::{AuditMiddleware, QuotaMiddleware};
+    /// use std::sync::Arc;
+    ///
+    /// let config = GatewayConfig {
+    ///     middleware_chain: MiddlewareChain::new()
+    ///         .with_before(Arc::new(AuditMiddleware::default()))
+    ///         .with_before(Arc::new(QuotaMiddleware::new(100))),
+    ///     ..GatewayConfig::default()
+    /// };
+    /// ```
+    pub middleware_chain: super::middleware::MiddlewareChain,
 }
 
 impl Default for GatewayConfig {
@@ -93,6 +110,7 @@ impl Default for GatewayConfig {
             // silent (it just hides prompts from the agent with no
             // visible error).
             cursor_safe_tool_names: true,
+            middleware_chain: super::middleware::MiddlewareChain::new(),
         }
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
@@ -260,15 +260,57 @@ async fn handle_tools_call(
         );
     }
 
+    // ── Middleware: BeforeCall ────────────────────────────────────────────
+    let mut ctx = crate::gateway::middleware::CallContext::new("tools/call", id_str, args.clone())
+        .with_tool_slug(tool)
+        .with_session_id(session_id);
+
+    // Run before-middlewares; abort the call if any rejects.
+    if !gs.middleware_chain.is_empty()
+        && let Err(e) = gs.middleware_chain.run_before(&mut ctx).await
+    {
+        let mut pending = gs.pending_calls.write().await;
+        pending.remove(id_str);
+        let msg = e.to_string();
+        return json!({
+            "jsonrpc": "2.0", "id": id,
+            "result": {"content": [{"type": "text", "text": msg}], "isError": true}
+        });
+    }
+
+    // Use potentially-redacted args from context.
+    let effective_args = if gs.middleware_chain.is_empty() {
+        args
+    } else {
+        ctx.args.clone()
+    };
+
     let (text, is_error) = aggregator::route_tools_call(
         gs,
         tool,
-        &args,
+        &effective_args,
         meta.as_ref(),
         Some(id_str.to_string()),
         Some(session_id),
     )
     .await;
+
+    // ── Middleware: AfterCall ────────────────────────────────────────────
+    let mut call_result = crate::gateway::middleware::CallResult::from_tuple(&text, is_error);
+
+    if !gs.middleware_chain.is_empty()
+        && let Err(e) = gs.middleware_chain.run_after(&ctx, &mut call_result).await
+    {
+        let mut pending = gs.pending_calls.write().await;
+        pending.remove(id_str);
+        let msg = e.to_string();
+        return json!({
+            "jsonrpc": "2.0", "id": id,
+            "result": {"content": [{"type": "text", "text": msg}], "isError": true}
+        });
+    }
+
+    let (final_text, final_is_error) = call_result.into_tuple();
 
     {
         let mut pending = gs.pending_calls.write().await;
@@ -277,7 +319,7 @@ async fn handle_tools_call(
 
     json!({
         "jsonrpc": "2.0", "id": id,
-        "result": {"content": [{"type": "text", "text": text}], "isError": is_error}
+        "result": {"content": [{"type": "text", "text": final_text}], "isError": final_is_error}
     })
 }
 

--- a/crates/dcc-mcp-gateway/src/gateway/middleware/audit.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/middleware/audit.rs
@@ -1,0 +1,124 @@
+//! Audit middleware — records every tool call to a structured log.
+
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use super::context::{CallContext, CallResult};
+use super::traits::{AfterCallMiddleware, BeforeCallMiddleware, MiddlewareFuture};
+
+/// A single audit record produced for each tool call.
+#[derive(Debug, Clone)]
+pub struct AuditEntry {
+    /// The ISO-8601 timestamp when the audit event was created.
+    pub timestamp: SystemTime,
+    /// MCP method (e.g. `"tools/call"`).
+    pub method: String,
+    /// Tool slug / name.
+    pub tool_slug: Option<String>,
+    /// DCC type of the target backend.
+    pub dcc_type: Option<String>,
+    /// Target instance ID.
+    pub instance_id: Option<String>,
+    /// Session identifier.
+    pub session_id: Option<String>,
+    /// Request ID (unique per call).
+    pub request_id: String,
+    /// Whether the call produced an error.
+    pub is_error: bool,
+    /// Short snippet of the result text (first 256 chars).
+    pub result_preview: String,
+}
+
+/// Sink that receives completed [`AuditEntry`] records.
+pub trait AuditSink: Send + Sync {
+    fn record(&self, entry: AuditEntry);
+}
+
+/// Default sink — emits one structured `tracing::info!` log per call.
+#[derive(Debug, Default)]
+pub struct DefaultAuditSink;
+
+impl AuditSink for DefaultAuditSink {
+    fn record(&self, entry: AuditEntry) {
+        tracing::info!(
+            method        = %entry.method,
+            tool_slug     = ?entry.tool_slug,
+            dcc_type      = ?entry.dcc_type,
+            instance_id   = ?entry.instance_id,
+            session_id    = ?entry.session_id,
+            request_id    = %entry.request_id,
+            is_error      = entry.is_error,
+            result_preview = %entry.result_preview,
+            "gateway audit"
+        );
+    }
+}
+
+/// Middleware that records each call via an [`AuditSink`].
+///
+/// - In `before_call`: captures the call context into `ctx.metadata` under
+///   `"audit.start_time_ns"` for latency tracking.
+/// - In `after_call`: writes the completed [`AuditEntry`] to the sink.
+pub struct AuditMiddleware {
+    sink: Arc<dyn AuditSink>,
+}
+
+impl Default for AuditMiddleware {
+    fn default() -> Self {
+        Self {
+            sink: Arc::new(DefaultAuditSink),
+        }
+    }
+}
+
+impl AuditMiddleware {
+    /// Create a middleware with the given audit sink.
+    pub fn new(sink: Arc<dyn AuditSink>) -> Self {
+        Self { sink }
+    }
+
+    /// Create a middleware that writes to `tracing::info!`.
+    pub fn with_default_sink() -> Self {
+        Self::default()
+    }
+}
+
+impl BeforeCallMiddleware for AuditMiddleware {
+    fn before_call<'a>(&'a self, ctx: &'a mut CallContext) -> MiddlewareFuture<'a, ()> {
+        Box::pin(async move {
+            // Store epoch nanoseconds for post-call latency computation.
+            let ns = SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0);
+            ctx.metadata
+                .insert("audit.start_time_ns".to_string(), ns.to_string());
+            Ok(())
+        })
+    }
+}
+
+impl AfterCallMiddleware for AuditMiddleware {
+    fn after_call<'a>(
+        &'a self,
+        ctx: &'a CallContext,
+        result: &'a mut CallResult,
+    ) -> MiddlewareFuture<'a, ()> {
+        let entry = AuditEntry {
+            timestamp: SystemTime::now(),
+            method: ctx.method.clone(),
+            tool_slug: ctx.tool_slug.clone(),
+            dcc_type: ctx.dcc_type.clone(),
+            instance_id: ctx.instance_id.clone(),
+            session_id: ctx.session_id.clone(),
+            request_id: ctx.request_id.clone(),
+            is_error: result.is_error,
+            result_preview: result.text.chars().take(256).collect(),
+        };
+        let sink = self.sink.clone();
+        Box::pin(async move {
+            sink.record(entry);
+            Ok(())
+        })
+    }
+}

--- a/crates/dcc-mcp-gateway/src/gateway/middleware/chain.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/middleware/chain.rs
@@ -1,0 +1,86 @@
+//! [`MiddlewareChain`] — ordered pipeline of before/after middlewares.
+
+use std::sync::Arc;
+
+use super::context::{CallContext, CallResult};
+use super::error::MiddlewareError;
+use super::traits::{AfterCallMiddleware, BeforeCallMiddleware};
+
+/// An ordered pipeline of [`BeforeCallMiddleware`] and [`AfterCallMiddleware`].
+///
+/// Middlewares are called in registration order. If any `before` middleware
+/// returns an error the pipeline is aborted and no further middlewares run.
+///
+/// Cloning is cheap — inner `Arc`s are just reference-counted.
+#[derive(Clone, Default)]
+pub struct MiddlewareChain {
+    before: Vec<Arc<dyn BeforeCallMiddleware>>,
+    after: Vec<Arc<dyn AfterCallMiddleware>>,
+}
+
+impl MiddlewareChain {
+    /// Create an empty chain.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append a `BeforeCallMiddleware` at the end of the before-chain.
+    pub fn with_before(mut self, m: Arc<dyn BeforeCallMiddleware>) -> Self {
+        self.before.push(m);
+        self
+    }
+
+    /// Append an `AfterCallMiddleware` at the end of the after-chain.
+    pub fn with_after(mut self, m: Arc<dyn AfterCallMiddleware>) -> Self {
+        self.after.push(m);
+        self
+    }
+
+    /// Register a `BeforeCallMiddleware` in-place.
+    pub fn add_before(&mut self, m: Arc<dyn BeforeCallMiddleware>) {
+        self.before.push(m);
+    }
+
+    /// Register an `AfterCallMiddleware` in-place.
+    pub fn add_after(&mut self, m: Arc<dyn AfterCallMiddleware>) {
+        self.after.push(m);
+    }
+
+    /// Run every `before` middleware in order.
+    ///
+    /// Stops and returns the first error encountered.
+    pub async fn run_before(&self, ctx: &mut CallContext) -> Result<(), MiddlewareError> {
+        for m in &self.before {
+            m.before_call(ctx).await?;
+        }
+        Ok(())
+    }
+
+    /// Run every `after` middleware in order.
+    ///
+    /// Stops and returns the first error encountered.
+    pub async fn run_after(
+        &self,
+        ctx: &CallContext,
+        result: &mut CallResult,
+    ) -> Result<(), MiddlewareError> {
+        for m in &self.after {
+            m.after_call(ctx, result).await?;
+        }
+        Ok(())
+    }
+
+    /// Returns `true` when no middlewares are registered (fast-path skip).
+    pub fn is_empty(&self) -> bool {
+        self.before.is_empty() && self.after.is_empty()
+    }
+}
+
+impl std::fmt::Debug for MiddlewareChain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MiddlewareChain")
+            .field("before_count", &self.before.len())
+            .field("after_count", &self.after.len())
+            .finish()
+    }
+}

--- a/crates/dcc-mcp-gateway/src/gateway/middleware/context.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/middleware/context.rs
@@ -1,0 +1,84 @@
+//! CallContext and CallResult — data passed through the middleware chain.
+
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// Context for one gateway `tools/call` invocation.
+///
+/// Passed (mutably) through every [`super::BeforeCallMiddleware`] before the
+/// call is dispatched, and available (read-only alongside `CallResult`) to
+/// every [`super::AfterCallMiddleware`] afterwards.
+#[derive(Debug, Clone)]
+pub struct CallContext {
+    /// MCP method name, e.g. `"tools/call"`.
+    pub method: String,
+    /// Gateway tool name or slug (e.g. `"call_tool"`, `"list_skills"`).
+    pub tool_slug: Option<String>,
+    /// DCC type of the target backend (e.g. `"maya"`, `"blender"`).
+    pub dcc_type: Option<String>,
+    /// Instance ID of the target backend.
+    pub instance_id: Option<String>,
+    /// MCP session identifier (from `Mcp-Session-Id` header).
+    pub session_id: Option<String>,
+    /// Unique request identifier (JSON-RPC `id` serialised to string).
+    pub request_id: String,
+    /// Tool arguments. Middlewares may inspect or redact fields in-place.
+    pub args: Value,
+    /// Free-form key-value store for middleware-to-middleware communication.
+    ///
+    /// Middlewares can stash data here (e.g. a quota bucket key, a trace ID)
+    /// and read it back in subsequent middlewares without coupling to each other.
+    pub metadata: HashMap<String, String>,
+}
+
+impl CallContext {
+    /// Create a minimal context for the given method and request ID.
+    pub fn new(method: impl Into<String>, request_id: impl Into<String>, args: Value) -> Self {
+        Self {
+            method: method.into(),
+            tool_slug: None,
+            dcc_type: None,
+            instance_id: None,
+            session_id: None,
+            request_id: request_id.into(),
+            args,
+            metadata: HashMap::new(),
+        }
+    }
+
+    /// Convenience builder — sets `tool_slug`.
+    pub fn with_tool_slug(mut self, slug: impl Into<String>) -> Self {
+        self.tool_slug = Some(slug.into());
+        self
+    }
+
+    /// Convenience builder — sets `session_id`.
+    pub fn with_session_id(mut self, id: impl Into<String>) -> Self {
+        self.session_id = Some(id.into());
+        self
+    }
+}
+
+/// Result of a gateway tool call, passed to [`super::AfterCallMiddleware`].
+#[derive(Debug, Clone)]
+pub struct CallResult {
+    /// Text body of the response (`CallToolResult.content[0].text`).
+    pub text: String,
+    /// Whether the result represents an error (`CallToolResult.isError`).
+    pub is_error: bool,
+}
+
+impl CallResult {
+    /// Construct from the `(text, is_error)` tuple returned by `route_tools_call`.
+    pub fn from_tuple(text: impl Into<String>, is_error: bool) -> Self {
+        Self {
+            text: text.into(),
+            is_error,
+        }
+    }
+
+    /// Destructure back into the `(text, is_error)` form used by the gateway.
+    pub fn into_tuple(self) -> (String, bool) {
+        (self.text, self.is_error)
+    }
+}

--- a/crates/dcc-mcp-gateway/src/gateway/middleware/error.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/middleware/error.rs
@@ -1,0 +1,19 @@
+//! Error types for the middleware chain.
+
+use thiserror::Error;
+
+/// Errors that a middleware can return to abort the call pipeline.
+#[derive(Debug, Error, Clone)]
+pub enum MiddlewareError {
+    /// Quota limit exceeded (e.g. too many calls per minute).
+    #[error("quota exceeded: {0}")]
+    QuotaExceeded(String),
+
+    /// A required field or policy was violated.
+    #[error("policy violation: {0}")]
+    PolicyViolation(String),
+
+    /// The middleware encountered an internal error.
+    #[error("middleware error: {0}")]
+    Internal(String),
+}

--- a/crates/dcc-mcp-gateway/src/gateway/middleware/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/middleware/mod.rs
@@ -1,0 +1,37 @@
+//! Pluggable BeforeCall/AfterCall middleware chain for the gateway.
+//!
+//! Operators register middlewares via [`MiddlewareChain`] to apply cross-cutting
+//! policies (audit, quota, redaction, transformation) without forking core.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use dcc_mcp_gateway::gateway::middleware::{
+//!     MiddlewareChain, AuditMiddleware, QuotaMiddleware, RedactionMiddleware,
+//! };
+//! use std::sync::Arc;
+//!
+//! let chain = MiddlewareChain::new()
+//!     .with_before(Arc::new(AuditMiddleware::default()))
+//!     .with_before(Arc::new(QuotaMiddleware::new(100)))
+//!     .with_before(Arc::new(RedactionMiddleware::new(vec!["api_key", "token"])));
+//! ```
+
+mod audit;
+mod chain;
+mod context;
+mod error;
+mod quota;
+mod redaction;
+mod traits;
+
+#[cfg(test)]
+mod tests;
+
+pub use audit::{AuditEntry, AuditMiddleware, AuditSink, DefaultAuditSink};
+pub use chain::MiddlewareChain;
+pub use context::{CallContext, CallResult};
+pub use error::MiddlewareError;
+pub use quota::QuotaMiddleware;
+pub use redaction::RedactionMiddleware;
+pub use traits::{AfterCallMiddleware, BeforeCallMiddleware};

--- a/crates/dcc-mcp-gateway/src/gateway/middleware/quota.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/middleware/quota.rs
@@ -1,0 +1,87 @@
+//! Quota middleware — per-session call-rate limiting.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use super::context::CallContext;
+use super::error::MiddlewareError;
+use super::traits::{BeforeCallMiddleware, MiddlewareFuture};
+
+struct BucketState {
+    count: u64,
+    window_start: Instant,
+}
+
+/// Simple sliding-window quota middleware.
+///
+/// Counts calls per `window` (default: 1 minute) per bucket key. The bucket
+/// key defaults to `session_id` when present, otherwise `"global"`. When the
+/// count exceeds `limit` within the window, the call is rejected with
+/// [`MiddlewareError::QuotaExceeded`].
+pub struct QuotaMiddleware {
+    limit: u64,
+    window: Duration,
+    buckets: Mutex<HashMap<String, BucketState>>,
+}
+
+impl QuotaMiddleware {
+    /// Create a new quota middleware with the given per-window limit.
+    ///
+    /// The window defaults to 60 seconds. Use [`QuotaMiddleware::with_window`]
+    /// to customise the window duration.
+    pub fn new(limit: u64) -> Self {
+        Self {
+            limit,
+            window: Duration::from_secs(60),
+            buckets: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Override the sliding window duration.
+    pub fn with_window(mut self, window: Duration) -> Self {
+        self.window = window;
+        self
+    }
+}
+
+impl BeforeCallMiddleware for QuotaMiddleware {
+    fn before_call<'a>(&'a self, ctx: &'a mut CallContext) -> MiddlewareFuture<'a, ()> {
+        // Determine the bucket key: prefer session_id, fall back to "global".
+        let key = ctx
+            .session_id
+            .clone()
+            .unwrap_or_else(|| "global".to_string());
+
+        let limit = self.limit;
+        let window = self.window;
+
+        let result = {
+            let mut buckets = self.buckets.lock().unwrap();
+            let now = Instant::now();
+            let bucket = buckets.entry(key.clone()).or_insert(BucketState {
+                count: 0,
+                window_start: now,
+            });
+
+            // Reset window if expired.
+            if now.duration_since(bucket.window_start) >= window {
+                bucket.count = 0;
+                bucket.window_start = now;
+            }
+
+            bucket.count += 1;
+
+            if bucket.count > limit {
+                Err(MiddlewareError::QuotaExceeded(format!(
+                    "session '{key}' exceeded {limit} calls per {}s window",
+                    window.as_secs()
+                )))
+            } else {
+                Ok(())
+            }
+        };
+
+        Box::pin(async move { result })
+    }
+}

--- a/crates/dcc-mcp-gateway/src/gateway/middleware/redaction.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/middleware/redaction.rs
@@ -1,0 +1,62 @@
+//! Redaction middleware — masks sensitive fields in `CallContext.args`.
+
+use std::collections::HashSet;
+
+use serde_json::Value;
+
+use super::context::CallContext;
+use super::error::MiddlewareError;
+use super::traits::{BeforeCallMiddleware, MiddlewareFuture};
+
+const REDACTED: &str = "[REDACTED]";
+
+/// Middleware that replaces the value of matching keys anywhere in `ctx.args`
+/// with `"[REDACTED]"`.
+///
+/// Matching is case-sensitive and applies recursively through nested objects
+/// and arrays.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let m = RedactionMiddleware::new(vec!["api_key", "token", "password"]);
+/// ```
+pub struct RedactionMiddleware {
+    fields: HashSet<String>,
+}
+
+impl RedactionMiddleware {
+    /// Create a new middleware that redacts the given field names.
+    pub fn new(fields: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        Self {
+            fields: fields.into_iter().map(|f| f.into()).collect(),
+        }
+    }
+
+    fn redact_value(&self, value: &mut Value) {
+        match value {
+            Value::Object(map) => {
+                for (key, val) in map.iter_mut() {
+                    if self.fields.contains(key) {
+                        *val = Value::String(REDACTED.to_string());
+                    } else {
+                        self.redact_value(val);
+                    }
+                }
+            }
+            Value::Array(arr) => {
+                for item in arr.iter_mut() {
+                    self.redact_value(item);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+impl BeforeCallMiddleware for RedactionMiddleware {
+    fn before_call<'a>(&'a self, ctx: &'a mut CallContext) -> MiddlewareFuture<'a, ()> {
+        self.redact_value(&mut ctx.args);
+        Box::pin(async move { Ok::<(), MiddlewareError>(()) })
+    }
+}

--- a/crates/dcc-mcp-gateway/src/gateway/middleware/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/middleware/tests.rs
@@ -1,0 +1,299 @@
+//! Tests for the middleware chain (issue #770).
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use serde_json::json;
+
+use super::audit::{AuditEntry, AuditMiddleware, AuditSink};
+use super::chain::MiddlewareChain;
+use super::context::{CallContext, CallResult};
+use super::error::MiddlewareError;
+use super::quota::QuotaMiddleware;
+use super::redaction::RedactionMiddleware;
+use super::traits::{AfterCallMiddleware, BeforeCallMiddleware, MiddlewareFuture};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn make_ctx(tool: &str) -> CallContext {
+    CallContext::new("tools/call", "req-1", json!({})).with_tool_slug(tool)
+}
+
+// ── Ordering ─────────────────────────────────────────────────────────────────
+
+struct AppendBefore(String, Arc<Mutex<Vec<String>>>);
+
+impl BeforeCallMiddleware for AppendBefore {
+    fn before_call<'a>(&'a self, ctx: &'a mut CallContext) -> MiddlewareFuture<'a, ()> {
+        let tag = self.0.clone();
+        let log = self.1.clone();
+        ctx.metadata.insert(format!("order_{}", &tag), tag.clone());
+        Box::pin(async move {
+            log.lock().unwrap().push(tag);
+            Ok(())
+        })
+    }
+}
+
+struct AppendAfter(String, Arc<Mutex<Vec<String>>>);
+
+impl AfterCallMiddleware for AppendAfter {
+    fn after_call<'a>(
+        &'a self,
+        _ctx: &'a CallContext,
+        _result: &'a mut CallResult,
+    ) -> MiddlewareFuture<'a, ()> {
+        let tag = self.0.clone();
+        let log = self.1.clone();
+        Box::pin(async move {
+            log.lock().unwrap().push(tag);
+            Ok(())
+        })
+    }
+}
+
+#[tokio::test]
+async fn test_chain_before_executes_in_order() {
+    let log = Arc::new(Mutex::new(Vec::<String>::new()));
+
+    let chain = MiddlewareChain::new()
+        .with_before(Arc::new(AppendBefore("A".into(), log.clone())))
+        .with_before(Arc::new(AppendBefore("B".into(), log.clone())))
+        .with_before(Arc::new(AppendBefore("C".into(), log.clone())));
+
+    let mut ctx = make_ctx("search_tools");
+    chain.run_before(&mut ctx).await.unwrap();
+
+    assert_eq!(*log.lock().unwrap(), vec!["A", "B", "C"]);
+}
+
+#[tokio::test]
+async fn test_chain_after_executes_in_order() {
+    let log = Arc::new(Mutex::new(Vec::<String>::new()));
+
+    let chain = MiddlewareChain::new()
+        .with_after(Arc::new(AppendAfter("X".into(), log.clone())))
+        .with_after(Arc::new(AppendAfter("Y".into(), log.clone())));
+
+    let ctx = make_ctx("call_tool");
+    let mut result = CallResult::from_tuple("ok", false);
+    chain.run_after(&ctx, &mut result).await.unwrap();
+
+    assert_eq!(*log.lock().unwrap(), vec!["X", "Y"]);
+}
+
+#[tokio::test]
+async fn test_chain_aborts_on_first_before_error() {
+    let log = Arc::new(Mutex::new(Vec::<String>::new()));
+
+    struct Abort;
+    impl BeforeCallMiddleware for Abort {
+        fn before_call<'a>(&'a self, _ctx: &'a mut CallContext) -> MiddlewareFuture<'a, ()> {
+            Box::pin(async move { Err(MiddlewareError::PolicyViolation("blocked".into())) })
+        }
+    }
+
+    let chain = MiddlewareChain::new()
+        .with_before(Arc::new(AppendBefore("first".into(), log.clone())))
+        .with_before(Arc::new(Abort))
+        .with_before(Arc::new(AppendBefore("should_not_run".into(), log.clone())));
+
+    let mut ctx = make_ctx("call_tool");
+    let err = chain.run_before(&mut ctx).await.unwrap_err();
+
+    assert!(matches!(err, MiddlewareError::PolicyViolation(_)));
+    // Only "first" should have run before the abort.
+    assert_eq!(*log.lock().unwrap(), vec!["first"]);
+}
+
+// ── AuditMiddleware ───────────────────────────────────────────────────────────
+
+#[derive(Default)]
+struct SpySink(Arc<Mutex<Vec<AuditEntry>>>);
+
+impl AuditSink for SpySink {
+    fn record(&self, entry: AuditEntry) {
+        self.0.lock().unwrap().push(entry);
+    }
+}
+
+#[tokio::test]
+async fn test_audit_middleware_records_call() {
+    let spy = Arc::new(SpySink::default());
+    let entries = spy.0.clone();
+    let m = AuditMiddleware::new(spy);
+
+    let mut ctx = CallContext::new("tools/call", "req-42", json!({"x": 1}))
+        .with_tool_slug("call_tool")
+        .with_session_id("sess-1");
+
+    // BeforeCall stamps start time.
+    m.before_call(&mut ctx).await.unwrap();
+    assert!(ctx.metadata.contains_key("audit.start_time_ns"));
+
+    // AfterCall writes the entry to the sink.
+    let mut result = CallResult::from_tuple("all good", false);
+    m.after_call(&ctx, &mut result).await.unwrap();
+
+    let log = entries.lock().unwrap();
+    assert_eq!(log.len(), 1);
+    let e = &log[0];
+    assert_eq!(e.method, "tools/call");
+    assert_eq!(e.tool_slug.as_deref(), Some("call_tool"));
+    assert_eq!(e.session_id.as_deref(), Some("sess-1"));
+    assert_eq!(e.request_id, "req-42");
+    assert!(!e.is_error);
+    assert!(e.result_preview.contains("all good"));
+}
+
+// ── QuotaMiddleware ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_quota_middleware_allows_under_limit() {
+    let m = QuotaMiddleware::new(5).with_window(Duration::from_secs(60));
+
+    for i in 0..5u64 {
+        let mut ctx = CallContext::new("tools/call", format!("req-{i}"), json!({}))
+            .with_session_id("sess-quota");
+        m.before_call(&mut ctx).await.unwrap_or_else(|_| {
+            panic!("call {i} should be allowed");
+        });
+    }
+}
+
+#[tokio::test]
+async fn test_quota_middleware_rejects_over_limit() {
+    let m = QuotaMiddleware::new(3).with_window(Duration::from_secs(60));
+
+    for i in 0..3u64 {
+        let mut ctx = CallContext::new("tools/call", format!("req-{i}"), json!({}))
+            .with_session_id("sess-quota-over");
+        m.before_call(&mut ctx).await.unwrap();
+    }
+
+    // 4th call should be rejected.
+    let mut ctx =
+        CallContext::new("tools/call", "req-over", json!({})).with_session_id("sess-quota-over");
+    let err = m.before_call(&mut ctx).await.unwrap_err();
+    assert!(
+        matches!(err, MiddlewareError::QuotaExceeded(_)),
+        "expected QuotaExceeded, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_quota_middleware_resets_after_window() {
+    let m = QuotaMiddleware::new(2).with_window(Duration::from_millis(50));
+
+    for i in 0..2u64 {
+        let mut ctx = CallContext::new("tools/call", format!("req-{i}"), json!({}))
+            .with_session_id("sess-reset");
+        m.before_call(&mut ctx).await.unwrap();
+    }
+
+    // Wait for the window to expire.
+    tokio::time::sleep(Duration::from_millis(60)).await;
+
+    // Should be allowed again.
+    let mut ctx =
+        CallContext::new("tools/call", "req-new-window", json!({})).with_session_id("sess-reset");
+    m.before_call(&mut ctx)
+        .await
+        .expect("call after window reset should succeed");
+}
+
+// ── RedactionMiddleware ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_redaction_replaces_matching_fields() {
+    let m = RedactionMiddleware::new(vec!["api_key", "token"]);
+
+    let mut ctx = CallContext::new(
+        "tools/call",
+        "req-r",
+        json!({
+            "api_key": "secret-123",
+            "name": "my-tool",
+            "nested": {"token": "tok-456", "keep": "value"}
+        }),
+    );
+
+    m.before_call(&mut ctx).await.unwrap();
+
+    assert_eq!(ctx.args["api_key"].as_str(), Some("[REDACTED]"));
+    assert_eq!(ctx.args["name"].as_str(), Some("my-tool"));
+    assert_eq!(ctx.args["nested"]["token"].as_str(), Some("[REDACTED]"));
+    assert_eq!(ctx.args["nested"]["keep"].as_str(), Some("value"));
+}
+
+#[tokio::test]
+async fn test_redaction_handles_arrays() {
+    let m = RedactionMiddleware::new(vec!["password"]);
+
+    let mut ctx = CallContext::new(
+        "tools/call",
+        "req-arr",
+        json!({
+            "users": [
+                {"name": "alice", "password": "pw1"},
+                {"name": "bob", "password": "pw2"}
+            ]
+        }),
+    );
+
+    m.before_call(&mut ctx).await.unwrap();
+
+    assert_eq!(
+        ctx.args["users"][0]["password"].as_str(),
+        Some("[REDACTED]")
+    );
+    assert_eq!(
+        ctx.args["users"][1]["password"].as_str(),
+        Some("[REDACTED]")
+    );
+    assert_eq!(ctx.args["users"][0]["name"].as_str(), Some("alice"));
+}
+
+#[tokio::test]
+async fn test_redaction_noop_on_no_match() {
+    let m = RedactionMiddleware::new(vec!["secret"]);
+
+    let original = json!({"a": 1, "b": "hello"});
+    let mut ctx = CallContext::new("tools/call", "req-noop", original.clone());
+    m.before_call(&mut ctx).await.unwrap();
+
+    assert_eq!(ctx.args, original);
+}
+
+// ── Integration: combined chain ───────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_combined_chain_audit_quota_redaction() {
+    let spy = Arc::new(SpySink::default());
+    let entries = spy.0.clone();
+
+    let chain = MiddlewareChain::new()
+        .with_before(Arc::new(AuditMiddleware::new(spy.clone())))
+        .with_before(Arc::new(QuotaMiddleware::new(10)))
+        .with_before(Arc::new(RedactionMiddleware::new(vec!["token"])))
+        .with_after(Arc::new(AuditMiddleware::new(spy)));
+
+    let mut ctx = CallContext::new(
+        "tools/call",
+        "combined-1",
+        json!({"tool": "run", "token": "secret"}),
+    )
+    .with_session_id("sess-combined");
+
+    chain.run_before(&mut ctx).await.unwrap();
+
+    // Token should be redacted.
+    assert_eq!(ctx.args["token"].as_str(), Some("[REDACTED]"));
+
+    let mut result = CallResult::from_tuple("success", false);
+    chain.run_after(&ctx, &mut result).await.unwrap();
+
+    // AfterCall audit entry should have been written.
+    let log = entries.lock().unwrap();
+    assert!(!log.is_empty(), "at least one audit entry expected");
+}

--- a/crates/dcc-mcp-gateway/src/gateway/middleware/traits.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/middleware/traits.rs
@@ -1,0 +1,36 @@
+//! Core middleware traits.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use super::context::{CallContext, CallResult};
+use super::error::MiddlewareError;
+
+/// Type alias for a boxed async middleware future.
+pub type MiddlewareFuture<'a, T> =
+    Pin<Box<dyn Future<Output = Result<T, MiddlewareError>> + Send + 'a>>;
+
+/// Runs synchronously/asynchronously **before** a `tools/call` is dispatched.
+///
+/// Implementors may:
+/// - Inspect or mutate `ctx.args` (e.g. redaction).
+/// - Record audit state into `ctx.metadata`.
+/// - Abort the pipeline by returning `Err(MiddlewareError::*)`.
+pub trait BeforeCallMiddleware: Send + Sync {
+    fn before_call<'a>(&'a self, ctx: &'a mut CallContext) -> MiddlewareFuture<'a, ()>;
+}
+
+/// Runs **after** a `tools/call` response is available, before it is serialised
+/// and sent to the client.
+///
+/// Implementors may:
+/// - Inspect `ctx` and `result` for audit logging.
+/// - Mutate `result.text` for response transformation.
+/// - Return `Err` to replace the response with an error.
+pub trait AfterCallMiddleware: Send + Sync {
+    fn after_call<'a>(
+        &'a self,
+        ctx: &'a CallContext,
+        result: &'a mut CallResult,
+    ) -> MiddlewareFuture<'a, ()>;
+}

--- a/crates/dcc-mcp-gateway/src/gateway/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/mod.rs
@@ -37,12 +37,15 @@ pub mod capability;
 pub mod capability_service;
 pub mod event_log;
 pub mod handlers;
+pub mod middleware;
 pub mod namespace;
 pub mod proxy;
 pub mod router;
 pub mod sse_subscriber;
 pub mod state;
 pub mod tools;
+
+pub use middleware::MiddlewareChain;
 
 #[cfg(feature = "prometheus")]
 pub mod metrics;

--- a/crates/dcc-mcp-gateway/src/gateway/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state.rs
@@ -12,6 +12,8 @@ use super::event_log::EventLog;
 use dcc_mcp_transport::discovery::file_registry::FileRegistry;
 use dcc_mcp_transport::discovery::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry, ServiceStatus};
 
+use super::middleware::MiddlewareChain;
+
 /// A call that the gateway has forwarded to a backend and is still awaiting.
 #[derive(Debug, Clone)]
 pub struct PendingCall {
@@ -136,6 +138,11 @@ pub struct GatewayState {
     /// (endpoint handler) refer to the same registered counter objects.
     #[cfg(feature = "prometheus")]
     pub gateway_metrics: Arc<super::event_log::GatewayMetrics>,
+
+    /// Pluggable middleware chain applied to every `tools/call` dispatch
+    /// (issue #770). Empty by default; operators register middlewares via
+    /// [`GatewayConfig::middleware_chain`] or the builder API.
+    pub middleware_chain: Arc<MiddlewareChain>,
 }
 
 impl GatewayState {
@@ -342,6 +349,7 @@ mod tests {
             event_log: Arc::new(crate::gateway::event_log::EventLog::new()),
             #[cfg(feature = "prometheus")]
             gateway_metrics: Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
+            middleware_chain: Arc::new(MiddlewareChain::new()),
         }
     }
 

--- a/crates/dcc-mcp-gateway/src/gateway/tasks.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tasks.rs
@@ -513,6 +513,7 @@ pub(crate) async fn start_gateway_tasks(
         event_log: contention_log.clone(),
         #[cfg(feature = "prometheus")]
         gateway_metrics: gateway_metrics.clone(),
+        middleware_chain: Arc::new(crate::gateway::middleware::MiddlewareChain::new()),
     };
     let gw_router = build_gateway_router(gw_state);
 

--- a/crates/dcc-mcp-http/src/server/gateway_impl.rs
+++ b/crates/dcc-mcp-http/src/server/gateway_impl.rs
@@ -36,6 +36,7 @@ pub(crate) async fn start_gateway_runner(
             .clone()
             .or_else(|| config.instance.dcc_type.clone()),
         cursor_safe_tool_names: config.gateway.gateway_cursor_safe_tool_names,
+        middleware_chain: dcc_mcp_gateway::gateway::middleware::MiddlewareChain::new(),
     };
 
     let runner = match GatewayRunner::new(gateway_config) {

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -742,6 +742,7 @@ async fn main() -> anyhow::Result<()> {
             Some(args.dcc.clone())
         },
         cursor_safe_tool_names: args.gateway_cursor_safe_tool_names,
+        middleware_chain: dcc_mcp_http::gateway::middleware::MiddlewareChain::new(),
     };
 
     let runner = GatewayRunner::new(gateway_cfg)


### PR DESCRIPTION
Closes #770

## Summary

Introduces a composable middleware chain for cross-cutting policies in the gateway. Operators can extend behavior (auth forwarding, redaction, quota, transformation, audit) without forking core.

## API

```rust
// Register middlewares via GatewayConfig
let config = GatewayConfig {
    middleware_chain: MiddlewareChain::new()
        .with_before(Arc::new(AuditMiddleware::default()))
        .with_before(Arc::new(QuotaMiddleware::new(100))) // 100 calls/min
        .with_before(Arc::new(RedactionMiddleware::new(["api_key", "token"]))),
    ..GatewayConfig::default()
};
```

## Built-in Middlewares
| Middleware | Purpose |
|-----------|---------|
| `AuditMiddleware` | Structured tracing log per call (who, what, when, result) |
| `QuotaMiddleware` | Per-session/global call rate limiting |
| `RedactionMiddleware` | Redact sensitive fields from tool args |

## Extension Point
Implement `BeforeCallMiddleware` or `AfterCallMiddleware` trait to add custom policies.

## Related
- #768 — OTLP traces (middleware can enrich span attrs via CallContext)
- #773 — Auth forwarding policies plug in here
- #772 — Admin audit feed from AuditMiddleware