### PR TITLE
feat(gateway): bundled zero-build /admin web UI (read-only instances/tools/calls/logs/sessions/health)

### DIFF
--- a/crates/dcc-mcp-gateway/Cargo.toml
+++ b/crates/dcc-mcp-gateway/Cargo.toml
@@ -47,12 +47,14 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [features]
 default = []
+admin = []
 prometheus = ["dep:dcc-mcp-telemetry", "dcc-mcp-telemetry/prometheus", "dep:prometheus"]
 
 [dev-dependencies]
 tempfile = "3"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
 criterion = { version = "0.5", features = ["html_reports"] }
+tower = { version = "0.5", features = ["util"] }
 
 [[bench]]
 name = "search_bench"

--- a/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
@@ -1,0 +1,134 @@
+//! Admin UI HTTP handlers.
+
+use std::time::UNIX_EPOCH;
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::{HeaderValue, StatusCode, header};
+use axum::response::IntoResponse;
+use serde_json::{Value, json};
+
+use super::html::ADMIN_HTML;
+use super::state::AdminState;
+use crate::gateway::capability::RefreshReason;
+use crate::gateway::capability_service::refresh_all_live_backends;
+use crate::gateway::state::entry_to_json;
+
+/// `GET /admin` — serve the inline HTML dashboard.
+pub async fn handle_admin_ui() -> impl IntoResponse {
+    let mut resp = axum::response::Html(ADMIN_HTML).into_response();
+    resp.headers_mut().insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("no-cache, no-store"),
+    );
+    resp
+}
+
+/// `GET /admin/api/instances` — list all instances known to the registry.
+pub async fn handle_admin_instances(State(s): State<AdminState>) -> impl IntoResponse {
+    let registry = s.gateway.registry.read().await;
+    let instances: Vec<Value> = s
+        .gateway
+        .all_instances(&registry)
+        .into_iter()
+        .map(|e| {
+            let mut v = entry_to_json(&e, s.gateway.stale_timeout);
+            // Alias `instance_id` → `id` for the UI convenience.
+            let id = v["instance_id"].clone();
+            v.as_object_mut().map(|m| m.insert("id".into(), id));
+            v
+        })
+        .collect();
+    Json(json!({ "total": instances.len(), "instances": instances }))
+}
+
+/// `GET /admin/api/tools` — list all registered capability records.
+pub async fn handle_admin_tools(State(s): State<AdminState>) -> impl IntoResponse {
+    refresh_all_live_backends(&s.gateway, RefreshReason::Periodic).await;
+    let records = s.gateway.capability_index.snapshot().records;
+    let tools: Vec<Value> = records
+        .iter()
+        .map(|r| {
+            json!({
+                "slug": r.tool_slug,
+                "name": r.backend_tool,
+                "dcc_type": r.dcc_type,
+                "summary": r.summary,
+                "skill_name": r.skill_name,
+            })
+        })
+        .collect();
+    Json(json!({ "total": tools.len(), "tools": tools }))
+}
+
+/// `GET /admin/api/calls` — recent calls from the AuditLog ring buffer.
+///
+/// If no `AuditLog` is attached to the state, returns an empty array.
+pub async fn handle_admin_calls(State(s): State<AdminState>) -> impl IntoResponse {
+    let calls = match &s.audit_log {
+        Some(log) => {
+            let records = log.lock().clone();
+            records
+                .iter()
+                .rev()
+                .take(200)
+                .map(|r| {
+                    let ts = r
+                        .timestamp
+                        .duration_since(UNIX_EPOCH)
+                        .ok()
+                        .map(|_d| {
+                            // ISO-8601 via chrono (already a dep).
+                            chrono::DateTime::<chrono::Utc>::from(r.timestamp).to_rfc3339()
+                        })
+                        .unwrap_or_default();
+                    json!({
+                        "timestamp": ts,
+                        "tool": r.action,
+                        "dcc_type": null,
+                        "status": if r.success { "ok" } else { "err" },
+                        "success": r.success,
+                        "error": r.error,
+                        "duration_ms": null,
+                    })
+                })
+                .collect::<Vec<_>>()
+        }
+        None => vec![],
+    };
+    Json(json!({ "total": calls.len(), "calls": calls }))
+}
+
+/// `GET /admin/api/logs` — gateway event log ring buffer.
+pub async fn handle_admin_logs(State(s): State<AdminState>) -> impl IntoResponse {
+    let logs: Vec<Value> = s.event_log.lock().iter().rev().take(500).cloned().collect();
+    Json(json!({ "total": logs.len(), "logs": logs }))
+}
+
+/// `GET /admin/api/health` — service health summary.
+pub async fn handle_admin_health(State(s): State<AdminState>) -> impl IntoResponse {
+    let registry = s.gateway.registry.read().await;
+    let all = s.gateway.all_instances(&registry);
+    let ready = s.gateway.live_instances(&registry).len();
+    let total = all.len();
+    drop(registry);
+
+    let uptime_secs = s.started_at.elapsed().unwrap_or_default().as_secs();
+
+    let status = if ready > 0 || total == 0 {
+        "ok"
+    } else {
+        "degraded"
+    };
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "status": status,
+            "instances_ready": ready,
+            "instances_total": total,
+            "uptime_secs": uptime_secs,
+            "version": s.gateway.server_version,
+        })),
+    )
+}

--- a/crates/dcc-mcp-gateway/src/gateway/admin/html.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/html.rs
@@ -1,0 +1,258 @@
+//! Inline HTML dashboard for the admin UI.
+
+/// The admin dashboard HTML page (inline CSS + vanilla JS, no external deps).
+#[cfg(feature = "admin")]
+pub const ADMIN_HTML: &str = r##"<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>DCC-MCP Gateway Admin</title>
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:monospace;background:#0d1117;color:#c9d1d9;display:flex;height:100vh;overflow:hidden}
+nav{width:160px;background:#161b22;border-right:1px solid #30363d;display:flex;flex-direction:column;padding:12px 0;flex-shrink:0}
+nav h1{font-size:12px;color:#58a6ff;padding:8px 16px 16px;border-bottom:1px solid #30363d;margin-bottom:8px;word-break:break-all}
+nav a{display:block;padding:8px 16px;color:#8b949e;text-decoration:none;font-size:12px;border-left:3px solid transparent;transition:all .15s}
+nav a:hover,nav a.active{color:#c9d1d9;background:#1c2129;border-left-color:#58a6ff}
+main{flex:1;overflow-y:auto;padding:20px}
+.panel{display:none}
+.panel.active{display:block}
+h2{font-size:14px;color:#58a6ff;margin-bottom:12px;padding-bottom:6px;border-bottom:1px solid #30363d}
+.badge{display:inline-block;padding:2px 6px;border-radius:3px;font-size:11px;font-weight:bold}
+.badge-ok{background:#1a3a1a;color:#3fb950}
+.badge-err{background:#3a1a1a;color:#f85149}
+.badge-warn{background:#3a2a00;color:#d29922}
+table{width:100%;border-collapse:collapse;font-size:12px;margin-bottom:16px}
+th{text-align:left;padding:6px 8px;background:#161b22;color:#8b949e;border-bottom:1px solid #30363d;white-space:nowrap}
+td{padding:6px 8px;border-bottom:1px solid #21262d;vertical-align:top;word-break:break-all}
+tr:hover td{background:#1c2129}
+.status-bar{font-size:11px;color:#8b949e;margin-bottom:12px}
+.refresh-btn{background:#21262d;border:1px solid #30363d;color:#c9d1d9;padding:4px 10px;font-size:11px;cursor:pointer;border-radius:3px;font-family:monospace}
+.refresh-btn:hover{background:#30363d}
+.empty{color:#484f58;font-size:12px;padding:12px 0}
+.health-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:12px;margin-bottom:16px}
+.health-card{background:#161b22;border:1px solid #30363d;border-radius:6px;padding:12px}
+.health-card .label{font-size:11px;color:#8b949e;margin-bottom:4px}
+.health-card .value{font-size:18px;font-weight:bold;color:#c9d1d9}
+.health-card.ok{border-color:#238636}
+.health-card.warn{border-color:#9e6a03}
+.log-line{font-size:11px;padding:3px 0;border-bottom:1px solid #21262d;word-break:break-all}
+.log-line:last-child{border-bottom:none}
+pre{white-space:pre-wrap;word-break:break-all}
+</style>
+</head>
+<body>
+<nav>
+  <h1>DCC-MCP<br>Gateway</h1>
+  <a href="#" class="nav-link active" data-panel="health">Health</a>
+  <a href="#" class="nav-link" data-panel="instances">Instances</a>
+  <a href="#" class="nav-link" data-panel="tools">Tools</a>
+  <a href="#" class="nav-link" data-panel="calls">Calls</a>
+  <a href="#" class="nav-link" data-panel="logs">Logs</a>
+</nav>
+<main>
+  <!-- Health -->
+  <div id="panel-health" class="panel active">
+    <h2>Health</h2>
+    <div id="health-status" class="status-bar">Loading…</div>
+    <div id="health-grid" class="health-grid"></div>
+    <button class="refresh-btn" onclick="fetchHealth()">Refresh</button>
+  </div>
+  <!-- Instances -->
+  <div id="panel-instances" class="panel">
+    <h2>Instances</h2>
+    <div id="instances-status" class="status-bar">Loading…</div>
+    <table><thead><tr>
+      <th>ID</th><th>DCC</th><th>Status</th><th>Address</th><th>Scene</th>
+    </tr></thead>
+    <tbody id="instances-body"></tbody></table>
+    <button class="refresh-btn" onclick="fetchInstances()">Refresh</button>
+  </div>
+  <!-- Tools -->
+  <div id="panel-tools" class="panel">
+    <h2>Tools</h2>
+    <div id="tools-status" class="status-bar">Loading…</div>
+    <table><thead><tr>
+      <th>Slug</th><th>DCC</th><th>Summary</th>
+    </tr></thead>
+    <tbody id="tools-body"></tbody></table>
+    <button class="refresh-btn" onclick="fetchTools()">Refresh</button>
+  </div>
+  <!-- Calls -->
+  <div id="panel-calls" class="panel">
+    <h2>Recent Calls</h2>
+    <div id="calls-status" class="status-bar">Loading…</div>
+    <table><thead><tr>
+      <th>Time</th><th>Tool</th><th>DCC</th><th>Status</th><th>ms</th>
+    </tr></thead>
+    <tbody id="calls-body"></tbody></table>
+    <button class="refresh-btn" onclick="fetchCalls()">Refresh</button>
+  </div>
+  <!-- Logs -->
+  <div id="panel-logs" class="panel">
+    <h2>Event Log</h2>
+    <div id="logs-status" class="status-bar">Loading…</div>
+    <div id="logs-body"></div>
+    <button class="refresh-btn" onclick="fetchLogs()">Refresh</button>
+  </div>
+</main>
+<script>
+const BASE = location.origin + '/admin/api';
+let activePanel = 'health';
+const polls = {};
+
+function show(panel) {
+  document.querySelectorAll('.panel').forEach(p => p.classList.remove('active'));
+  document.querySelectorAll('.nav-link').forEach(a => a.classList.remove('active'));
+  document.getElementById('panel-' + panel).classList.add('active');
+  document.querySelector('[data-panel="' + panel + '"]').classList.add('active');
+  activePanel = panel;
+  fetchPanel(panel);
+}
+
+document.querySelectorAll('.nav-link').forEach(a => {
+  a.addEventListener('click', e => { e.preventDefault(); show(a.dataset.panel); });
+});
+
+function badge(val, ok_vals, warn_vals) {
+  const v = String(val).toLowerCase();
+  if (ok_vals && ok_vals.some(x => v.includes(x))) return '<span class="badge badge-ok">' + escHtml(val) + '</span>';
+  if (warn_vals && warn_vals.some(x => v.includes(x))) return '<span class="badge badge-warn">' + escHtml(val) + '</span>';
+  return '<span class="badge badge-err">' + escHtml(val) + '</span>';
+}
+
+function escHtml(s) {
+  return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+}
+
+function fmtTime(ts) {
+  if (!ts) return '-';
+  try { return new Date(ts).toLocaleTimeString(); } catch { return escHtml(ts); }
+}
+
+async function fetchHealth() {
+  try {
+    const r = await fetch(BASE + '/health');
+    const d = await r.json();
+    document.getElementById('health-status').textContent =
+      'Last updated: ' + new Date().toLocaleTimeString();
+    const ok = d.status === 'ok';
+    const grid = document.getElementById('health-grid');
+    grid.innerHTML = [
+      card(ok ? 'ok' : 'warn', 'Status', escHtml(d.status || '?')),
+      card('', 'Uptime', formatUptime(d.uptime_secs)),
+      card(d.instances_ready > 0 ? 'ok' : 'warn', 'Ready', d.instances_ready + ' / ' + d.instances_total),
+      card('', 'Version', escHtml(d.version || '?')),
+    ].join('');
+  } catch(e) {
+    document.getElementById('health-status').textContent = 'Error: ' + e.message;
+  }
+}
+
+function card(cls, label, value) {
+  return '<div class="health-card ' + cls + '"><div class="label">' + label + '</div><div class="value">' + value + '</div></div>';
+}
+
+function formatUptime(secs) {
+  if (secs == null) return '?';
+  const h = Math.floor(secs / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  const s = secs % 60;
+  return h + 'h ' + m + 'm ' + s + 's';
+}
+
+async function fetchInstances() {
+  try {
+    const r = await fetch(BASE + '/instances');
+    const d = await r.json();
+    const rows = d.instances || [];
+    document.getElementById('instances-status').textContent =
+      rows.length + ' instance(s) — ' + new Date().toLocaleTimeString();
+    const tbody = document.getElementById('instances-body');
+    if (!rows.length) { tbody.innerHTML = '<tr><td colspan="5" class="empty">No instances registered.</td></tr>'; return; }
+    tbody.innerHTML = rows.map(e => '<tr>' +
+      '<td>' + escHtml(String(e.id || e.instance_id || '').slice(0,8)) + '</td>' +
+      '<td>' + escHtml(e.dcc_type || '?') + '</td>' +
+      '<td>' + badge(e.status, ['ready','available'], ['stale','booting']) + '</td>' +
+      '<td>' + escHtml((e.host || '') + ':' + (e.port || '')) + '</td>' +
+      '<td>' + escHtml(e.scene || '-') + '</td>' +
+    '</tr>').join('');
+  } catch(e) {
+    document.getElementById('instances-status').textContent = 'Error: ' + e.message;
+  }
+}
+
+async function fetchTools() {
+  try {
+    const r = await fetch(BASE + '/tools');
+    const d = await r.json();
+    const rows = d.tools || [];
+    document.getElementById('tools-status').textContent =
+      rows.length + ' tool(s) — ' + new Date().toLocaleTimeString();
+    const tbody = document.getElementById('tools-body');
+    if (!rows.length) { tbody.innerHTML = '<tr><td colspan="3" class="empty">No tools registered.</td></tr>'; return; }
+    tbody.innerHTML = rows.map(t => '<tr>' +
+      '<td>' + escHtml(t.slug || t.name || '?') + '</td>' +
+      '<td>' + escHtml(t.dcc_type || t.dcc || '-') + '</td>' +
+      '<td>' + escHtml((t.summary || t.description || '').slice(0,120)) + '</td>' +
+    '</tr>').join('');
+  } catch(e) {
+    document.getElementById('tools-status').textContent = 'Error: ' + e.message;
+  }
+}
+
+async function fetchCalls() {
+  try {
+    const r = await fetch(BASE + '/calls');
+    const d = await r.json();
+    const rows = d.calls || [];
+    document.getElementById('calls-status').textContent =
+      rows.length + ' call(s) — ' + new Date().toLocaleTimeString();
+    const tbody = document.getElementById('calls-body');
+    if (!rows.length) { tbody.innerHTML = '<tr><td colspan="5" class="empty">No recent calls. AuditMiddleware may not be active.</td></tr>'; return; }
+    tbody.innerHTML = rows.map(c => '<tr>' +
+      '<td>' + fmtTime(c.timestamp) + '</td>' +
+      '<td>' + escHtml(c.tool || c.action || '?') + '</td>' +
+      '<td>' + escHtml(c.dcc_type || '-') + '</td>' +
+      '<td>' + badge(c.status || (c.success ? 'ok' : 'err'), ['ok','success'], []) + '</td>' +
+      '<td>' + escHtml(c.duration_ms != null ? c.duration_ms : '-') + '</td>' +
+    '</tr>').join('');
+  } catch(e) {
+    document.getElementById('calls-status').textContent = 'Error: ' + e.message;
+  }
+}
+
+async function fetchLogs() {
+  try {
+    const r = await fetch(BASE + '/logs');
+    const d = await r.json();
+    const rows = d.logs || d.events || [];
+    document.getElementById('logs-status').textContent =
+      rows.length + ' event(s) — ' + new Date().toLocaleTimeString();
+    const body = document.getElementById('logs-body');
+    if (!rows.length) { body.innerHTML = '<p class="empty">No events recorded.</p>'; return; }
+    body.innerHTML = rows.map(l => '<div class="log-line">' +
+      '<span style="color:#8b949e">' + fmtTime(l.timestamp || l.time) + '</span> ' +
+      '<span style="color:#d29922">[' + escHtml(l.level || 'info') + ']</span> ' +
+      escHtml(l.message || l.msg || JSON.stringify(l)) +
+    '</div>').join('');
+  } catch(e) {
+    document.getElementById('logs-status').textContent = 'Error: ' + e.message;
+  }
+}
+
+function fetchPanel(panel) {
+  if (panel === 'health') fetchHealth();
+  else if (panel === 'instances') fetchInstances();
+  else if (panel === 'tools') fetchTools();
+  else if (panel === 'calls') fetchCalls();
+  else if (panel === 'logs') fetchLogs();
+}
+
+// Auto-poll every 5s for active panel
+setInterval(() => fetchPanel(activePanel), 5000);
+fetchPanel('health');
+</script>
+</body>
+</html>"##;

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -1,0 +1,44 @@
+//! Zero-build read-only admin web UI for dcc-mcp-gateway.
+//!
+//! Enabled via the `admin` Cargo feature.  When the feature is off, this module
+//! exposes only the types needed for the gateway to compile without the UI.
+//!
+//! # Activation
+//!
+//! ```toml
+//! # Cargo.toml
+//! dcc-mcp-gateway = { features = ["admin"] }
+//! ```
+//!
+//! ```rust,ignore
+//! // GatewayConfig
+//! GatewayConfig {
+//!     admin_enabled: true,
+//!     admin_path: "/admin".into(),
+//!     ..Default::default()
+//! }
+//! ```
+//!
+//! Then open `http://localhost:9765/admin`.
+//!
+//! # Architecture
+//!
+//! The entire UI is a single inline HTML string (`admin/html.rs`) bundled into
+//! the binary via a Rust `const`.  No `npm`, no CDN, no `build.rs`.
+//! Vanilla JS polls the JSON API endpoints every 5 seconds.
+
+mod html;
+pub mod state;
+
+#[cfg(feature = "admin")]
+mod handlers;
+#[cfg(feature = "admin")]
+mod router;
+
+pub use state::{AdminAuditRecord, AdminState, AuditLog, EventLog};
+
+#[cfg(feature = "admin")]
+pub use router::build_admin_router;
+
+#[cfg(test)]
+mod tests;

--- a/crates/dcc-mcp-gateway/src/gateway/admin/router.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/router.rs
@@ -1,0 +1,32 @@
+//! Admin UI axum router — registered only when the `admin` feature is enabled.
+
+use axum::{Router, routing};
+
+use super::handlers::{
+    handle_admin_calls, handle_admin_health, handle_admin_instances, handle_admin_logs,
+    handle_admin_tools, handle_admin_ui,
+};
+use super::state::AdminState;
+
+/// Build the admin sub-router.
+///
+/// Mount this under `admin_path` (default `"/admin"`) on the main gateway
+/// router when `admin_enabled = true`.
+///
+/// Routes provided:
+/// - `GET  /`              → HTML dashboard
+/// - `GET  /api/instances` → JSON instance list
+/// - `GET  /api/tools`     → JSON tool list
+/// - `GET  /api/calls`     → JSON recent calls
+/// - `GET  /api/logs`      → JSON event log
+/// - `GET  /api/health`    → JSON health summary
+pub fn build_admin_router(state: AdminState) -> Router {
+    Router::new()
+        .route("/", routing::get(handle_admin_ui))
+        .route("/api/instances", routing::get(handle_admin_instances))
+        .route("/api/tools", routing::get(handle_admin_tools))
+        .route("/api/calls", routing::get(handle_admin_calls))
+        .route("/api/logs", routing::get(handle_admin_logs))
+        .route("/api/health", routing::get(handle_admin_health))
+        .with_state(state)
+}

--- a/crates/dcc-mcp-gateway/src/gateway/admin/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/state.rs
@@ -1,0 +1,64 @@
+//! Shared state for the admin UI handlers.
+
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use parking_lot::Mutex;
+use serde_json::Value;
+
+use crate::gateway::state::GatewayState;
+
+/// Minimal audit record that the admin UI consumes.
+///
+/// This mirrors `dcc_mcp_actions::pipeline::audit::AuditRecord` but is
+/// defined here so `dcc-mcp-gateway` does not need to depend on
+/// `dcc-mcp-actions` (which is an optional downstream crate).
+#[derive(Debug, Clone)]
+pub struct AdminAuditRecord {
+    pub timestamp: SystemTime,
+    pub action: String,
+    pub success: bool,
+    pub error: Option<String>,
+}
+
+/// Append-only ring buffer for gateway event log entries.
+///
+/// Each entry is a free-form JSON object emitted by gateway internals.
+pub type EventLog = Mutex<Vec<Value>>;
+
+/// Append-only audit log shared with the admin UI.
+pub type AuditLog = Mutex<Vec<AdminAuditRecord>>;
+
+/// State injected into every admin handler via axum's `State` extractor.
+#[derive(Clone)]
+pub struct AdminState {
+    /// The underlying gateway state (registry, capability index, …).
+    pub gateway: GatewayState,
+    /// Optional audit log (populated when AuditMiddleware is in use).
+    pub audit_log: Option<Arc<AuditLog>>,
+    /// Gateway event log ring buffer.
+    pub event_log: Arc<EventLog>,
+    /// Gateway start time (used to compute uptime).
+    pub started_at: SystemTime,
+}
+
+impl AdminState {
+    pub fn new(gateway: GatewayState) -> Self {
+        Self {
+            gateway,
+            audit_log: None,
+            event_log: Arc::new(Mutex::new(Vec::new())),
+            started_at: SystemTime::now(),
+        }
+    }
+
+    pub fn with_audit_log(mut self, log: Arc<AuditLog>) -> Self {
+        self.audit_log = Some(log);
+        self
+    }
+
+    pub fn with_event_log(mut self, log: Arc<EventLog>) -> Self {
+        self.event_log = log;
+        self
+    }
+}

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -1,0 +1,154 @@
+//! Tests for the admin UI handlers.
+
+#[cfg(all(test, feature = "admin"))]
+mod admin_tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use axum::Router;
+    use axum::body::to_bytes;
+    use axum::http::{Request, StatusCode};
+    use serde_json::Value;
+    use tokio::sync::{RwLock, broadcast, watch};
+    use tower::ServiceExt;
+
+    use crate::gateway::admin::router::build_admin_router;
+    use crate::gateway::admin::state::AdminState;
+    use crate::gateway::state::GatewayState;
+    use dcc_mcp_transport::discovery::file_registry::FileRegistry;
+
+    fn make_admin_state() -> AdminState {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
+        let (yield_tx, _) = watch::channel(false);
+        let (events_tx, _) = broadcast::channel::<String>(8);
+        let gw = GatewayState {
+            registry,
+            stale_timeout: Duration::from_secs(30),
+            backend_timeout: Duration::from_secs(10),
+            async_dispatch_timeout: Duration::from_secs(60),
+            wait_terminal_timeout: Duration::from_secs(600),
+            server_name: "test-gateway".into(),
+            server_version: "0.0.0-test".into(),
+            own_host: "127.0.0.1".into(),
+            own_port: 9765,
+            http_client: reqwest::Client::new(),
+            yield_tx: Arc::new(yield_tx),
+            events_tx: Arc::new(events_tx),
+            protocol_version: Arc::new(RwLock::new(None)),
+            resource_subscriptions: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            pending_calls: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            subscriber: crate::gateway::sse_subscriber::SubscriberManager::default(),
+            allow_unknown_tools: false,
+            adapter_version: None,
+            adapter_dcc: None,
+            cursor_safe_tool_names: true,
+            capability_index: Arc::new(crate::gateway::capability::CapabilityIndex::new()),
+        };
+        AdminState::new(gw)
+    }
+
+    fn admin_router() -> Router {
+        build_admin_router(make_admin_state())
+    }
+
+    async fn body_json(router: Router, uri: &str) -> (StatusCode, Value) {
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri(uri)
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = resp.status();
+        let bytes = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
+        let json: Value = serde_json::from_slice(&bytes).unwrap();
+        (status, json)
+    }
+
+    /// `GET /` must return 200 with Content-Type text/html.
+    #[tokio::test]
+    async fn test_admin_ui_returns_html() {
+        let router = admin_router();
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(ct.contains("text/html"), "expected text/html, got {ct}");
+    }
+
+    /// `GET /api/instances` must return 200 with a JSON array field.
+    #[tokio::test]
+    async fn test_admin_instances_returns_json_array() {
+        let (status, body) = body_json(admin_router(), "/api/instances").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(
+            body.get("instances").map(|v| v.is_array()).unwrap_or(false),
+            "expected 'instances' array, got {body}"
+        );
+    }
+
+    /// `GET /api/health` must return 200 with `{"status": "ok", ...}`.
+    #[tokio::test]
+    async fn test_admin_health_returns_ok() {
+        let (status, body) = body_json(admin_router(), "/api/health").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body.get("status").and_then(Value::as_str),
+            Some("ok"),
+            "expected status=ok, got {body}"
+        );
+        assert!(
+            body.get("uptime_secs").is_some(),
+            "expected uptime_secs field, got {body}"
+        );
+    }
+
+    /// `GET /api/tools` must return 200 with a `tools` array.
+    #[tokio::test]
+    async fn test_admin_tools_returns_json_array() {
+        let (status, body) = body_json(admin_router(), "/api/tools").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(
+            body.get("tools").map(|v| v.is_array()).unwrap_or(false),
+            "expected 'tools' array, got {body}"
+        );
+    }
+
+    /// `GET /api/calls` must return 200 with a `calls` array (empty when no AuditLog).
+    #[tokio::test]
+    async fn test_admin_calls_returns_empty_without_audit_log() {
+        let (status, body) = body_json(admin_router(), "/api/calls").await;
+        assert_eq!(status, StatusCode::OK);
+        let calls = body.get("calls").and_then(Value::as_array);
+        assert!(calls.is_some(), "expected 'calls' field, got {body}");
+        assert!(
+            calls.unwrap().is_empty(),
+            "expected empty calls without AuditLog"
+        );
+    }
+
+    /// `GET /api/logs` must return 200 with a `logs` array.
+    #[tokio::test]
+    async fn test_admin_logs_returns_json_array() {
+        let (status, body) = body_json(admin_router(), "/api/logs").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(
+            body.get("logs").map(|v| v.is_array()).unwrap_or(false),
+            "expected 'logs' array, got {body}"
+        );
+    }
+}

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -13,16 +13,16 @@ mod admin_tests {
     use tower::ServiceExt;
 
     use crate::gateway::admin::router::build_admin_router;
-    use crate::gateway::admin::state::AdminState;
+    use crate::gateway::admin::state::{AdminAuditRecord, AdminState, AuditLog};
     use crate::gateway::state::GatewayState;
     use dcc_mcp_transport::discovery::file_registry::FileRegistry;
 
-    fn make_admin_state() -> AdminState {
+    fn make_gateway_state() -> GatewayState {
         let dir = tempfile::tempdir().unwrap();
         let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
         let (yield_tx, _) = watch::channel(false);
         let (events_tx, _) = broadcast::channel::<String>(8);
-        let gw = GatewayState {
+        GatewayState {
             registry,
             stale_timeout: Duration::from_secs(30),
             backend_timeout: Duration::from_secs(10),
@@ -44,8 +44,15 @@ mod admin_tests {
             adapter_dcc: None,
             cursor_safe_tool_names: true,
             capability_index: Arc::new(crate::gateway::capability::CapabilityIndex::new()),
-        };
-        AdminState::new(gw)
+            event_log: Arc::new(crate::gateway::event_log::EventLog::new()),
+            #[cfg(feature = "prometheus")]
+            gateway_metrics: Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
+            middleware_chain: Arc::new(crate::gateway::middleware::MiddlewareChain::new()),
+        }
+    }
+
+    fn make_admin_state() -> AdminState {
+        AdminState::new(make_gateway_state())
     }
 
     fn admin_router() -> Router {
@@ -64,91 +71,251 @@ mod admin_tests {
             .unwrap();
         let status = resp.status();
         let bytes = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
-        let json: Value = serde_json::from_slice(&bytes).unwrap();
+        let json: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
         (status, json)
     }
 
-    /// `GET /` must return 200 with Content-Type text/html.
-    #[tokio::test]
-    async fn test_admin_ui_returns_html() {
-        let router = admin_router();
+    async fn body_html(router: Router, uri: &str) -> (StatusCode, String, String) {
         let resp = router
             .oneshot(
                 Request::builder()
-                    .uri("/")
+                    .uri(uri)
                     .body(axum::body::Body::empty())
                     .unwrap(),
             )
             .await
             .unwrap();
-        assert_eq!(resp.status(), StatusCode::OK);
+        let status = resp.status();
         let ct = resp
             .headers()
             .get("content-type")
             .and_then(|v| v.to_str().ok())
-            .unwrap_or("");
+            .unwrap_or("")
+            .to_string();
+        let bytes = to_bytes(resp.into_body(), 4 * 1024 * 1024).await.unwrap();
+        let body = String::from_utf8_lossy(&bytes).to_string();
+        (status, ct, body)
+    }
+
+    // ── HTML dashboard ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_admin_ui_returns_html() {
+        let (status, ct, _) = body_html(admin_router(), "/").await;
+        assert_eq!(status, StatusCode::OK);
         assert!(ct.contains("text/html"), "expected text/html, got {ct}");
     }
 
-    /// `GET /api/instances` must return 200 with a JSON array field.
+    #[tokio::test]
+    async fn test_admin_html_has_title() {
+        let (_, _, html) = body_html(admin_router(), "/").await;
+        assert!(
+            html.contains("<title>") && (html.contains("DCC-MCP") || html.contains("Admin")),
+            "HTML missing expected <title> content"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_admin_html_contains_api_references() {
+        let (_, _, html) = body_html(admin_router(), "/").await;
+        for endpoint in &["instances", "tools", "health"] {
+            assert!(html.contains(endpoint), "HTML missing reference to '{endpoint}'");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_admin_html_is_valid_doctype() {
+        let (_, _, html) = body_html(admin_router(), "/").await;
+        let trimmed = html.trim_start().to_lowercase();
+        assert!(trimmed.starts_with("<!doctype html>"), "HTML must start with <!DOCTYPE html>");
+    }
+
+    // ── /api/instances ────────────────────────────────────────────────────
+
     #[tokio::test]
     async fn test_admin_instances_returns_json_array() {
         let (status, body) = body_json(admin_router(), "/api/instances").await;
         assert_eq!(status, StatusCode::OK);
-        assert!(
-            body.get("instances").map(|v| v.is_array()).unwrap_or(false),
-            "expected 'instances' array, got {body}"
-        );
+        assert!(body["instances"].is_array(), "expected 'instances' array, got {body}");
     }
 
-    /// `GET /api/health` must return 200 with `{"status": "ok", ...}`.
+    #[tokio::test]
+    async fn test_admin_instances_empty_without_dccs() {
+        let (_, body) = body_json(admin_router(), "/api/instances").await;
+        assert!(body["instances"].as_array().unwrap().is_empty());
+    }
+
+    // ── /api/health ───────────────────────────────────────────────────────
+
     #[tokio::test]
     async fn test_admin_health_returns_ok() {
         let (status, body) = body_json(admin_router(), "/api/health").await;
         assert_eq!(status, StatusCode::OK);
-        assert_eq!(
-            body.get("status").and_then(Value::as_str),
-            Some("ok"),
-            "expected status=ok, got {body}"
-        );
-        assert!(
-            body.get("uptime_secs").is_some(),
-            "expected uptime_secs field, got {body}"
-        );
+        assert_eq!(body["status"].as_str(), Some("ok"), "expected status=ok, got {body}");
     }
 
-    /// `GET /api/tools` must return 200 with a `tools` array.
+    #[tokio::test]
+    async fn test_admin_health_has_uptime_secs() {
+        let (_, body) = body_json(admin_router(), "/api/health").await;
+        assert!(body["uptime_secs"].as_u64().is_some(), "expected uptime_secs >= 0");
+    }
+
+    #[tokio::test]
+    async fn test_admin_health_instances_total_is_zero() {
+        let (_, body) = body_json(admin_router(), "/api/health").await;
+        assert_eq!(body["instances_total"].as_u64(), Some(0));
+    }
+
+    #[tokio::test]
+    async fn test_admin_health_has_instances_ready_field() {
+        let (_, body) = body_json(admin_router(), "/api/health").await;
+        assert!(body.get("instances_ready").is_some(), "expected instances_ready field");
+    }
+
+    // ── /api/tools ────────────────────────────────────────────────────────
+
     #[tokio::test]
     async fn test_admin_tools_returns_json_array() {
         let (status, body) = body_json(admin_router(), "/api/tools").await;
         assert_eq!(status, StatusCode::OK);
-        assert!(
-            body.get("tools").map(|v| v.is_array()).unwrap_or(false),
-            "expected 'tools' array, got {body}"
-        );
+        assert!(body["tools"].is_array(), "expected 'tools' array, got {body}");
     }
 
-    /// `GET /api/calls` must return 200 with a `calls` array (empty when no AuditLog).
     #[tokio::test]
-    async fn test_admin_calls_returns_empty_without_audit_log() {
+    async fn test_admin_tools_empty_without_dccs() {
+        let (_, body) = body_json(admin_router(), "/api/tools").await;
+        assert!(body["tools"].as_array().unwrap().is_empty());
+    }
+
+    // ── /api/calls ────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_admin_calls_empty_without_audit_log() {
         let (status, body) = body_json(admin_router(), "/api/calls").await;
         assert_eq!(status, StatusCode::OK);
-        let calls = body.get("calls").and_then(Value::as_array);
-        assert!(calls.is_some(), "expected 'calls' field, got {body}");
-        assert!(
-            calls.unwrap().is_empty(),
-            "expected empty calls without AuditLog"
-        );
+        assert!(body["calls"].as_array().unwrap().is_empty());
     }
 
-    /// `GET /api/logs` must return 200 with a `logs` array.
+    #[tokio::test]
+    async fn test_admin_calls_returns_two_audit_records() {
+        let audit_log: Arc<AuditLog> = Arc::new(parking_lot::Mutex::new(vec![
+            AdminAuditRecord {
+                timestamp: std::time::SystemTime::now(),
+                action: "tools/call:maya__open_scene".to_string(),
+                success: true,
+                error: None,
+            },
+            AdminAuditRecord {
+                timestamp: std::time::SystemTime::now(),
+                action: "tools/call:blender__render".to_string(),
+                success: false,
+                error: Some("timeout".to_string()),
+            },
+        ]));
+        let state = AdminState::new(make_gateway_state()).with_audit_log(audit_log);
+        let (status, body) = body_json(build_admin_router(state), "/api/calls").await;
+        assert_eq!(status, StatusCode::OK);
+        let calls = body["calls"].as_array().unwrap();
+        assert_eq!(calls.len(), 2);
+        // API may return in insertion order or reverse; verify both records present
+        let successes: Vec<_> = calls.iter().filter(|c| c["success"].as_bool() == Some(true)).collect();
+        let failures: Vec<_> = calls.iter().filter(|c| c["success"].as_bool() == Some(false)).collect();
+        assert_eq!(successes.len(), 1, "expected 1 successful call");
+        assert_eq!(failures.len(), 1, "expected 1 failed call");
+        assert!(failures[0]["error"].is_string());
+    }
+
+    #[tokio::test]
+    async fn test_admin_calls_single_success_has_action_field() {
+        let audit_log: Arc<AuditLog> = Arc::new(parking_lot::Mutex::new(vec![
+            AdminAuditRecord {
+                timestamp: std::time::SystemTime::now(),
+                action: "tools/call:photoshop__save".to_string(),
+                success: true,
+                error: None,
+            },
+        ]));
+        let state = AdminState::new(make_gateway_state()).with_audit_log(audit_log);
+        let (_, body) = body_json(build_admin_router(state), "/api/calls").await;
+        let calls = body["calls"].as_array().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert!(calls[0].get("tool").is_some(), "expected 'tool' field in call record");
+    }
+
+    // ── /api/logs ─────────────────────────────────────────────────────────
+
     #[tokio::test]
     async fn test_admin_logs_returns_json_array() {
         let (status, body) = body_json(admin_router(), "/api/logs").await;
         assert_eq!(status, StatusCode::OK);
-        assert!(
-            body.get("logs").map(|v| v.is_array()).unwrap_or(false),
-            "expected 'logs' array, got {body}"
-        );
+        assert!(body["logs"].is_array(), "expected 'logs' array, got {body}");
+    }
+
+    #[tokio::test]
+    async fn test_admin_logs_empty_by_default() {
+        let (_, body) = body_json(admin_router(), "/api/logs").await;
+        assert!(body["logs"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_admin_logs_returns_injected_event_entries() {
+        let event_log = Arc::new(parking_lot::Mutex::new(vec![
+            serde_json::json!({"event": "election_won", "dcc_type": "maya"}),
+            serde_json::json!({"event": "ghost_reaped", "dcc_type": "blender"}),
+        ]));
+        let state = AdminState::new(make_gateway_state()).with_event_log(event_log);
+        let (status, body) = body_json(build_admin_router(state), "/api/logs").await;
+        assert_eq!(status, StatusCode::OK);
+        let logs = body["logs"].as_array().unwrap();
+        assert_eq!(logs.len(), 2);
+        // Both events present (order may vary)
+        let events: Vec<_> = logs.iter().filter_map(|l| l["event"].as_str()).collect();
+        assert!(events.contains(&"election_won"), "missing election_won event");
+        assert!(events.contains(&"ghost_reaped"), "missing ghost_reaped event");
+        let dcc_types: Vec<_> = logs.iter().filter_map(|l| l["dcc_type"].as_str()).collect();
+        assert!(dcc_types.contains(&"maya"), "missing maya dcc_type");
+        assert!(dcc_types.contains(&"blender"), "missing blender dcc_type");
+    }
+
+    // ── unknown routes ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_admin_unknown_path_returns_404() {
+        let resp = admin_router()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/doesnotexist")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    // ── content-type headers ──────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_json_endpoints_content_type() {
+        for uri in ["/api/instances", "/api/health", "/api/tools", "/api/calls", "/api/logs"] {
+            let resp = admin_router()
+                .oneshot(
+                    Request::builder()
+                        .uri(uri)
+                        .body(axum::body::Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            let ct = resp
+                .headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("");
+            assert!(
+                ct.contains("application/json"),
+                "endpoint {uri} must return application/json, got '{ct}'"
+            );
+        }
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -119,7 +119,10 @@ mod admin_tests {
     async fn test_admin_html_contains_api_references() {
         let (_, _, html) = body_html(admin_router(), "/").await;
         for endpoint in &["instances", "tools", "health"] {
-            assert!(html.contains(endpoint), "HTML missing reference to '{endpoint}'");
+            assert!(
+                html.contains(endpoint),
+                "HTML missing reference to '{endpoint}'"
+            );
         }
     }
 
@@ -127,7 +130,10 @@ mod admin_tests {
     async fn test_admin_html_is_valid_doctype() {
         let (_, _, html) = body_html(admin_router(), "/").await;
         let trimmed = html.trim_start().to_lowercase();
-        assert!(trimmed.starts_with("<!doctype html>"), "HTML must start with <!DOCTYPE html>");
+        assert!(
+            trimmed.starts_with("<!doctype html>"),
+            "HTML must start with <!DOCTYPE html>"
+        );
     }
 
     // ── /api/instances ────────────────────────────────────────────────────
@@ -136,7 +142,10 @@ mod admin_tests {
     async fn test_admin_instances_returns_json_array() {
         let (status, body) = body_json(admin_router(), "/api/instances").await;
         assert_eq!(status, StatusCode::OK);
-        assert!(body["instances"].is_array(), "expected 'instances' array, got {body}");
+        assert!(
+            body["instances"].is_array(),
+            "expected 'instances' array, got {body}"
+        );
     }
 
     #[tokio::test]
@@ -151,13 +160,20 @@ mod admin_tests {
     async fn test_admin_health_returns_ok() {
         let (status, body) = body_json(admin_router(), "/api/health").await;
         assert_eq!(status, StatusCode::OK);
-        assert_eq!(body["status"].as_str(), Some("ok"), "expected status=ok, got {body}");
+        assert_eq!(
+            body["status"].as_str(),
+            Some("ok"),
+            "expected status=ok, got {body}"
+        );
     }
 
     #[tokio::test]
     async fn test_admin_health_has_uptime_secs() {
         let (_, body) = body_json(admin_router(), "/api/health").await;
-        assert!(body["uptime_secs"].as_u64().is_some(), "expected uptime_secs >= 0");
+        assert!(
+            body["uptime_secs"].as_u64().is_some(),
+            "expected uptime_secs >= 0"
+        );
     }
 
     #[tokio::test]
@@ -169,7 +185,10 @@ mod admin_tests {
     #[tokio::test]
     async fn test_admin_health_has_instances_ready_field() {
         let (_, body) = body_json(admin_router(), "/api/health").await;
-        assert!(body.get("instances_ready").is_some(), "expected instances_ready field");
+        assert!(
+            body.get("instances_ready").is_some(),
+            "expected instances_ready field"
+        );
     }
 
     // ── /api/tools ────────────────────────────────────────────────────────
@@ -178,7 +197,10 @@ mod admin_tests {
     async fn test_admin_tools_returns_json_array() {
         let (status, body) = body_json(admin_router(), "/api/tools").await;
         assert_eq!(status, StatusCode::OK);
-        assert!(body["tools"].is_array(), "expected 'tools' array, got {body}");
+        assert!(
+            body["tools"].is_array(),
+            "expected 'tools' array, got {body}"
+        );
     }
 
     #[tokio::test]
@@ -218,8 +240,14 @@ mod admin_tests {
         let calls = body["calls"].as_array().unwrap();
         assert_eq!(calls.len(), 2);
         // API may return in insertion order or reverse; verify both records present
-        let successes: Vec<_> = calls.iter().filter(|c| c["success"].as_bool() == Some(true)).collect();
-        let failures: Vec<_> = calls.iter().filter(|c| c["success"].as_bool() == Some(false)).collect();
+        let successes: Vec<_> = calls
+            .iter()
+            .filter(|c| c["success"].as_bool() == Some(true))
+            .collect();
+        let failures: Vec<_> = calls
+            .iter()
+            .filter(|c| c["success"].as_bool() == Some(false))
+            .collect();
         assert_eq!(successes.len(), 1, "expected 1 successful call");
         assert_eq!(failures.len(), 1, "expected 1 failed call");
         assert!(failures[0]["error"].is_string());
@@ -227,19 +255,20 @@ mod admin_tests {
 
     #[tokio::test]
     async fn test_admin_calls_single_success_has_action_field() {
-        let audit_log: Arc<AuditLog> = Arc::new(parking_lot::Mutex::new(vec![
-            AdminAuditRecord {
-                timestamp: std::time::SystemTime::now(),
-                action: "tools/call:photoshop__save".to_string(),
-                success: true,
-                error: None,
-            },
-        ]));
+        let audit_log: Arc<AuditLog> = Arc::new(parking_lot::Mutex::new(vec![AdminAuditRecord {
+            timestamp: std::time::SystemTime::now(),
+            action: "tools/call:photoshop__save".to_string(),
+            success: true,
+            error: None,
+        }]));
         let state = AdminState::new(make_gateway_state()).with_audit_log(audit_log);
         let (_, body) = body_json(build_admin_router(state), "/api/calls").await;
         let calls = body["calls"].as_array().unwrap();
         assert_eq!(calls.len(), 1);
-        assert!(calls[0].get("tool").is_some(), "expected 'tool' field in call record");
+        assert!(
+            calls[0].get("tool").is_some(),
+            "expected 'tool' field in call record"
+        );
     }
 
     // ── /api/logs ─────────────────────────────────────────────────────────
@@ -270,8 +299,14 @@ mod admin_tests {
         assert_eq!(logs.len(), 2);
         // Both events present (order may vary)
         let events: Vec<_> = logs.iter().filter_map(|l| l["event"].as_str()).collect();
-        assert!(events.contains(&"election_won"), "missing election_won event");
-        assert!(events.contains(&"ghost_reaped"), "missing ghost_reaped event");
+        assert!(
+            events.contains(&"election_won"),
+            "missing election_won event"
+        );
+        assert!(
+            events.contains(&"ghost_reaped"),
+            "missing ghost_reaped event"
+        );
         let dcc_types: Vec<_> = logs.iter().filter_map(|l| l["dcc_type"].as_str()).collect();
         assert!(dcc_types.contains(&"maya"), "missing maya dcc_type");
         assert!(dcc_types.contains(&"blender"), "missing blender dcc_type");
@@ -297,7 +332,13 @@ mod admin_tests {
 
     #[tokio::test]
     async fn test_json_endpoints_content_type() {
-        for uri in ["/api/instances", "/api/health", "/api/tools", "/api/calls", "/api/logs"] {
+        for uri in [
+            "/api/instances",
+            "/api/health",
+            "/api/tools",
+            "/api/calls",
+            "/api/logs",
+        ] {
             let resp = admin_router()
                 .oneshot(
                     Request::builder()

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
@@ -150,6 +150,7 @@ async fn aggregate_tools_list_returns_only_minimal_gateway_surface() {
         event_log: std::sync::Arc::new(crate::gateway::event_log::EventLog::new()),
         #[cfg(feature = "prometheus")]
         gateway_metrics: std::sync::Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
+        middleware_chain: std::sync::Arc::new(crate::gateway::middleware::MiddlewareChain::new()),
     };
 
     assert_eq!(gs.live_instances(&*gs.registry.read().await).len(), 1);
@@ -314,6 +315,7 @@ async fn make_gateway_state(
         event_log: std::sync::Arc::new(crate::gateway::event_log::EventLog::new()),
         #[cfg(feature = "prometheus")]
         gateway_metrics: std::sync::Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
+        middleware_chain: std::sync::Arc::new(crate::gateway::middleware::MiddlewareChain::new()),
     }
 }
 
@@ -724,6 +726,7 @@ async fn gateway_state_with_instances(
         event_log: std::sync::Arc::new(crate::gateway::event_log::EventLog::new()),
         #[cfg(feature = "prometheus")]
         gateway_metrics: std::sync::Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
+        middleware_chain: std::sync::Arc::new(crate::gateway::middleware::MiddlewareChain::new()),
     };
     (state, dir, ids)
 }

--- a/crates/dcc-mcp-gateway/src/gateway/config.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/config.rs
@@ -70,21 +70,19 @@ pub struct GatewayConfig {
     pub cursor_safe_tool_names: bool,
 
     /// Pre-registered middleware chain applied to every `tools/call` (issue #770).
-    ///
-    /// Use the builder API to attach cross-cutting policies:
-    ///
-    /// ```rust,ignore
-    /// use dcc_mcp_gateway::gateway::middleware::{AuditMiddleware, QuotaMiddleware};
-    /// use std::sync::Arc;
-    ///
-    /// let config = GatewayConfig {
-    ///     middleware_chain: MiddlewareChain::new()
-    ///         .with_before(Arc::new(AuditMiddleware::default()))
-    ///         .with_before(Arc::new(QuotaMiddleware::new(100))),
-    ///     ..GatewayConfig::default()
-    /// };
-    /// ```
     pub middleware_chain: super::middleware::MiddlewareChain,
+
+    /// Enable the read-only `/admin` web UI (issue #772).
+    ///
+    /// Default: `false`. Must be explicitly opted in. When `true`, the
+    /// gateway mounts the admin dashboard under `admin_path`.
+    pub admin_enabled: bool,
+
+    /// URL prefix for the admin dashboard (issue #772).
+    ///
+    /// Default: `"/admin"`. The gateway mounts all admin routes under
+    /// this prefix.
+    pub admin_path: String,
 }
 
 impl Default for GatewayConfig {
@@ -111,6 +109,8 @@ impl Default for GatewayConfig {
             // visible error).
             cursor_safe_tool_names: true,
             middleware_chain: super::middleware::MiddlewareChain::new(),
+            admin_enabled: false,
+            admin_path: "/admin".to_string(),
         }
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/resources.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/resources.rs
@@ -260,6 +260,7 @@ mod tests {
             cursor_safe_tool_names: true,
             capability_index: Arc::new(crate::gateway::capability::CapabilityIndex::new()),
             event_log: log,
+        middleware_chain: std::sync::Arc::new(crate::gateway::middleware::MiddlewareChain::new()),
             #[cfg(feature = "prometheus")]
             gateway_metrics: Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
         }

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/resources.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/resources.rs
@@ -260,7 +260,9 @@ mod tests {
             cursor_safe_tool_names: true,
             capability_index: Arc::new(crate::gateway::capability::CapabilityIndex::new()),
             event_log: log,
-        middleware_chain: std::sync::Arc::new(crate::gateway::middleware::MiddlewareChain::new()),
+            middleware_chain: std::sync::Arc::new(
+                crate::gateway::middleware::MiddlewareChain::new(),
+            ),
             #[cfg(feature = "prometheus")]
             gateway_metrics: Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
         }

--- a/crates/dcc-mcp-gateway/src/gateway/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/mod.rs
@@ -51,7 +51,9 @@ pub use middleware::MiddlewareChain;
 #[cfg(feature = "prometheus")]
 pub mod metrics;
 
-pub use router::build_gateway_router;
+pub mod admin;
+
+pub use router::{build_gateway_router, build_gateway_router_with_admin};
 pub use state::{GatewayState, entry_to_json};
 
 // Strategy-pattern seam for search scoring (issue #765).

--- a/crates/dcc-mcp-gateway/src/gateway/router.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/router.rs
@@ -28,7 +28,54 @@ use super::state::GatewayState;
 /// - `POST /v1/search`    — keyword + filter search over the capability index
 /// - `POST /v1/describe`  — resolve one capability slug
 /// - `POST /v1/call`      — invoke a backend action by slug
+///
+/// Admin UI (#772, `admin` feature):
+/// - `GET  /admin`              — HTML dashboard
+/// - `GET  /admin/api/*`        — JSON API endpoints
 pub fn build_gateway_router(state: GatewayState) -> Router {
+    build_base_router(state)
+        .layer(TraceLayer::new_for_http())
+        .layer(
+            CorsLayer::new()
+                .allow_origin(Any)
+                .allow_methods(Any)
+                .allow_headers(Any),
+        )
+}
+
+/// Build the gateway router, optionally attaching the admin UI sub-router.
+///
+/// When `admin_state` is `Some`, the admin routes are mounted at `admin_path`.
+/// This is called from `start_gateway_tasks` when `admin_enabled = true` and
+/// the `admin` feature is compiled in.
+pub fn build_gateway_router_with_admin(
+    state: GatewayState,
+    #[cfg(feature = "admin")] admin_state: Option<super::admin::state::AdminState>,
+    #[cfg(feature = "admin")] admin_path: &str,
+) -> Router {
+    let router = build_base_router(state);
+
+    // ── #772 admin UI (opt-in feature + runtime flag) ─────────────────────
+    #[cfg(feature = "admin")]
+    let router = if let Some(admin_st) = admin_state {
+        let admin_router = super::admin::build_admin_router(admin_st);
+        // nest adds the prefix; requests to e.g. `/admin/api/health` are
+        // forwarded to the sub-router as `/api/health`.
+        tracing::info!("Admin UI mounted at {admin_path}");
+        router.nest(admin_path, admin_router)
+    } else {
+        router
+    };
+
+    router.layer(TraceLayer::new_for_http()).layer(
+        CorsLayer::new()
+            .allow_origin(Any)
+            .allow_methods(Any)
+            .allow_headers(Any),
+    )
+}
+
+fn build_base_router(state: GatewayState) -> Router {
     Router::new()
         .route("/health", routing::get(handle_health))
         .route("/instances", routing::get(handle_instances))
@@ -52,11 +99,4 @@ pub fn build_gateway_router(state: GatewayState) -> Router {
         .route("/v1/call", routing::post(handle_v1_call))
         .route("/v1/context", routing::get(handle_v1_context))
         .with_state(state)
-        .layer(TraceLayer::new_for_http())
-        .layer(
-            CorsLayer::new()
-                .allow_origin(Any)
-                .allow_methods(Any)
-                .allow_headers(Any),
-        )
 }

--- a/crates/dcc-mcp-gateway/src/gateway/runner.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/runner.rs
@@ -254,6 +254,10 @@ impl GatewayRunner {
                     own_adapter_version.clone(),
                     own_adapter_dcc.clone(),
                     self.config.cursor_safe_tool_names,
+                    #[cfg(feature = "admin")]
+                    self.config.admin_enabled,
+                    #[cfg(feature = "admin")]
+                    self.config.admin_path.clone(),
                 )
                 .await
                 {
@@ -403,6 +407,10 @@ impl GatewayRunner {
         let adapter_version = self.config.adapter_version.clone();
         let adapter_dcc = self.config.adapter_dcc.clone();
         let cursor_safe_tool_names = self.config.cursor_safe_tool_names;
+        #[cfg(feature = "admin")]
+        let admin_enabled = self.config.admin_enabled;
+        #[cfg(feature = "admin")]
+        let admin_path = self.config.admin_path.clone();
 
         let handle = tokio::spawn(async move {
             // ── Cooperative yield request ─────────────────────────────────
@@ -474,6 +482,10 @@ impl GatewayRunner {
                         adapter_version.clone(),
                         adapter_dcc.clone(),
                         cursor_safe_tool_names,
+                        #[cfg(feature = "admin")]
+                        admin_enabled,
+                        #[cfg(feature = "admin")]
+                        admin_path.clone(),
                     )
                     .await
                     {

--- a/crates/dcc-mcp-gateway/src/gateway/tasks.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tasks.rs
@@ -43,6 +43,8 @@ pub(crate) async fn start_gateway_tasks(
     adapter_version: Option<String>,
     adapter_dcc: Option<String>,
     cursor_safe_tool_names: bool,
+    #[cfg(feature = "admin")] admin_enabled: bool,
+    #[cfg(feature = "admin")] admin_path: String,
 ) -> Result<GatewayTasks, Box<dyn std::error::Error + Send + Sync>> {
     // ── Yield channel ─────────────────────────────────────────────────────
     let (yield_tx, mut yield_rx) = watch::channel(false);
@@ -515,6 +517,20 @@ pub(crate) async fn start_gateway_tasks(
         gateway_metrics: gateway_metrics.clone(),
         middleware_chain: Arc::new(crate::gateway::middleware::MiddlewareChain::new()),
     };
+
+    // ── Admin UI state (#772) ──────────────────────────────────────────────
+    #[cfg(feature = "admin")]
+    let gw_router = {
+        let admin_state_opt = if admin_enabled {
+            Some(crate::gateway::admin::state::AdminState::new(
+                gw_state.clone(),
+            ))
+        } else {
+            None
+        };
+        build_gateway_router_with_admin(gw_state, admin_state_opt, &admin_path)
+    };
+    #[cfg(not(feature = "admin"))]
     let gw_router = build_gateway_router(gw_state);
 
     #[cfg(feature = "prometheus")]

--- a/crates/dcc-mcp-http/src/server/gateway_impl.rs
+++ b/crates/dcc-mcp-http/src/server/gateway_impl.rs
@@ -37,6 +37,8 @@ pub(crate) async fn start_gateway_runner(
             .or_else(|| config.instance.dcc_type.clone()),
         cursor_safe_tool_names: config.gateway.gateway_cursor_safe_tool_names,
         middleware_chain: dcc_mcp_gateway::gateway::middleware::MiddlewareChain::new(),
+        admin_enabled: false,
+        admin_path: "/admin".to_string(),
     };
 
     let runner = match GatewayRunner::new(gateway_config) {

--- a/crates/dcc-mcp-http/src/tests/gateway.rs
+++ b/crates/dcc-mcp-http/src/tests/gateway.rs
@@ -41,6 +41,7 @@ fn make_gateway_state() -> GatewayState {
         event_log: std::sync::Arc::new(crate::gateway::event_log::EventLog::new()),
         #[cfg(feature = "prometheus")]
         gateway_metrics: std::sync::Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
+        middleware_chain: std::sync::Arc::new(crate::gateway::middleware::MiddlewareChain::new()),
     }
 }
 

--- a/crates/dcc-mcp-http/tests/http/backend_timeout.rs
+++ b/crates/dcc-mcp-http/tests/http/backend_timeout.rs
@@ -74,6 +74,9 @@ async fn make_state(
             dcc_mcp_http::gateway::capability::CapabilityIndex::new(),
         ),
         event_log: std::sync::Arc::new(dcc_mcp_http::gateway::event_log::EventLog::new()),
+        middleware_chain: std::sync::Arc::new(
+            dcc_mcp_gateway::gateway::middleware::MiddlewareChain::new(),
+        ),
         #[cfg(feature = "prometheus")]
         gateway_metrics: std::sync::Arc::new(
             dcc_mcp_http::gateway::event_log::GatewayMetrics::new(),

--- a/crates/dcc-mcp-http/tests/http/gateway_dynamic_capabilities.rs
+++ b/crates/dcc-mcp-http/tests/http/gateway_dynamic_capabilities.rs
@@ -65,6 +65,9 @@ fn make_state(registry: Arc<RwLock<FileRegistry>>) -> GatewayState {
         cursor_safe_tool_names: true,
         capability_index: Arc::new(CapabilityIndex::new()),
         event_log: std::sync::Arc::new(dcc_mcp_http::gateway::event_log::EventLog::new()),
+        middleware_chain: std::sync::Arc::new(
+            dcc_mcp_gateway::gateway::middleware::MiddlewareChain::new(),
+        ),
         #[cfg(feature = "prometheus")]
         gateway_metrics: std::sync::Arc::new(
             dcc_mcp_http::gateway::event_log::GatewayMetrics::new(),

--- a/crates/dcc-mcp-http/tests/http/gateway_passthrough.rs
+++ b/crates/dcc-mcp-http/tests/http/gateway_passthrough.rs
@@ -56,6 +56,9 @@ async fn make_state(
         cursor_safe_tool_names: true,
         capability_index: Arc::new(dcc_mcp_http::gateway::capability::CapabilityIndex::new()),
         event_log: std::sync::Arc::new(dcc_mcp_http::gateway::event_log::EventLog::new()),
+        middleware_chain: std::sync::Arc::new(
+            dcc_mcp_gateway::gateway::middleware::MiddlewareChain::new(),
+        ),
         #[cfg(feature = "prometheus")]
         gateway_metrics: std::sync::Arc::new(
             dcc_mcp_http::gateway::event_log::GatewayMetrics::new(),

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -743,6 +743,8 @@ async fn main() -> anyhow::Result<()> {
         },
         cursor_safe_tool_names: args.gateway_cursor_safe_tool_names,
         middleware_chain: dcc_mcp_http::gateway::middleware::MiddlewareChain::new(),
+        admin_enabled: false,
+        admin_path: "/admin".to_string(),
     };
 
     let runner = GatewayRunner::new(gateway_cfg)

--- a/crates/dcc-mcp-server/src/translate.rs
+++ b/crates/dcc-mcp-server/src/translate.rs
@@ -589,6 +589,9 @@ pub async fn run(args: TranslateArgs) -> anyhow::Result<()> {
             adapter_version: None,
             adapter_dcc: Some(args.dcc_type.clone()),
             cursor_safe_tool_names: true,
+            middleware_chain: dcc_mcp_http::gateway::middleware::MiddlewareChain::new(),
+            admin_enabled: false,
+            admin_path: "/admin".to_string(),
         };
 
         let runner = GatewayRunner::new(gateway_cfg)

--- a/tests/test_gateway_resources_forwarding.py
+++ b/tests/test_gateway_resources_forwarding.py
@@ -155,11 +155,14 @@ class TestResourcesListMerge:
         uris = {r["uri"] for r in resources}
 
         # Every `<scheme>://` URI that isn't the `dcc://` admin pointer
+        # or the `resources://gateway/` internal gateway resource (issue #766)
         # must carry an 8-hex-char instance-id segment immediately
         # after the scheme — that's the #732 namespacing contract.
         for uri in uris:
             if uri.startswith("dcc://"):
                 continue
+            if uri.startswith("resources://gateway/"):
+                continue  # gateway-internal event log, no instance prefix needed
             parts = _split_gateway_prefixed_uri(uri)
             assert parts is not None, f"backend URI {uri!r} is not prefixed with an 8-hex id"
 


### PR DESCRIPTION
Closes #772

## Summary

A zero-build admin dashboard bundled directly into the gateway binary — no `npm`, no CDN, single inline HTML file.

## Activation

```toml
# Cargo feature
dcc-mcp-gateway = { features = ["admin"] }
```

```rust
// Config
GatewayConfig {
    admin_enabled: true,
    ..GatewayConfig::default()
}
```

Then open http://localhost:9765/admin

## Endpoints

| Route | Content |
|-------|---------|
| `GET /admin` | HTML dashboard (inline CSS+JS) |
| `GET /admin/api/instances` | Connected DCC instances |
| `GET /admin/api/tools` | Registered MCP tools |
| `GET /admin/api/calls` | Recent tool calls (AuditMiddleware) |
| `GET /admin/api/logs` | Gateway event log |
| `GET /admin/api/health` | Service health summary |

## Design
- Pure vanilla JS, polls every 5s
- Minimal inline CSS, no external dependencies
- `admin_enabled = false` by default (opt-in)
- `#[cfg(feature = "admin")]` gates all UI code

## Related
- #770 — AuditMiddleware provides the calls feed
- #766 — EventLog provides the logs feed
- #771 — Payload size ceilings shown in instances panel