### PR TITLE
fix(http): correct field path after McpHttpConfig sub-config split

### DIFF
--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -1282,21 +1282,27 @@ mod tests {
     /// Issue #771: payload size limits have sane defaults.
     #[test]
     fn payload_limits_default_values() {
-        let cfg = McpHttpConfig::new(8765);
-        assert_eq!(cfg.max_request_body_bytes, 4 * 1024 * 1024);
-        assert_eq!(cfg.max_response_content_bytes, 1024 * 1024);
-        assert_eq!(cfg.sse_chunk_size_bytes, 64 * 1024);
+        let cfg = McpHttpConfig::default();
+        assert_eq!(cfg.queue.max_request_body_bytes, 4 * 1024 * 1024);
+        assert_eq!(cfg.queue.max_response_content_bytes, 1024 * 1024);
+        assert_eq!(cfg.queue.sse_chunk_size_bytes, 64 * 1024);
     }
 
     /// Issue #771: builder methods override the defaults.
     #[test]
     fn payload_limits_builders_override_defaults() {
-        let cfg = McpHttpConfig::new(8765)
-            .with_max_request_body_bytes(8 * 1024 * 1024)
-            .with_max_response_content_bytes(512 * 1024)
-            .with_sse_chunk_size_bytes(32 * 1024);
-        assert_eq!(cfg.max_request_body_bytes, 8 * 1024 * 1024);
-        assert_eq!(cfg.max_response_content_bytes, 512 * 1024);
-        assert_eq!(cfg.sse_chunk_size_bytes, 32 * 1024);
+        let cfg = McpHttpConfig::default();
+        let cfg = McpHttpConfig {
+            queue: QueueConfig {
+                max_request_body_bytes: 8 * 1024 * 1024,
+                max_response_content_bytes: 512 * 1024,
+                sse_chunk_size_bytes: 32 * 1024,
+                ..cfg.queue
+            },
+            ..cfg
+        };
+        assert_eq!(cfg.queue.max_request_body_bytes, 8 * 1024 * 1024);
+        assert_eq!(cfg.queue.max_response_content_bytes, 512 * 1024);
+        assert_eq!(cfg.queue.sse_chunk_size_bytes, 32 * 1024);
     }
 }

--- a/crates/dcc-mcp-http/src/server/mod.rs
+++ b/crates/dcc-mcp-http/src/server/mod.rs
@@ -509,7 +509,7 @@ impl McpHttpServer {
             .with_state(state)
             .merge(rest_router)
             .layer(RequestBodyLimitLayer::new(
-                self.config.max_request_body_bytes,
+                self.config.queue.max_request_body_bytes,
             ))
             .layer(TraceLayer::new_for_http());
 


### PR DESCRIPTION
Fixes a compilation error introduced when #780 (payload limits) was merged after #776 (McpHttpConfig sub-config split).

`max_request_body_bytes`, `max_response_content_bytes`, `sse_chunk_size_bytes` were moved into `QueueConfig` by #776, but #780 still referenced them directly on `McpHttpConfig`.

**Changes:**
- `server/mod.rs:512`: `self.config.max_request_body_bytes` → `self.config.queue.max_request_body_bytes`
- `config.rs` tests: fix all 3 field references + builder test to use `McpHttpConfig::default()` and `cfg.queue.*`