### PR TITLE
docs: add guides and update agent docs for milestone features (#764-#774)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,13 @@ Gateway resources/prompts:
 | Stamp gateway sentinel for election | `McpHttpConfig(..., adapter_version=..., adapter_dcc=...)` or `.with_adapter_version().with_adapter_dcc()` (issue maya#137) |
 | Discover team-level skills | `scan_and_load_team()` / `scan_and_load_team_lenient()` |
 | Discover user-level skills | `scan_and_load_user()` / `scan_and_load_user_lenient()` |
+| Bridge stdio MCP server to HTTP/SSE | `dcc-mcp-server translate --stdio "cmd" --dcc-type foo --port N` |
+| Add audit/quota/redact to all gateway calls | `GatewayConfig::middleware_chain` + `AuditMiddleware` / `QuotaMiddleware` / `RedactionMiddleware` |
+| Mount OpenAPI REST API as MCP tools | `GatewayBuilder::mount_openapi(OpenApiMount::from_url(...).auth(...))` |
+| Enable built-in gateway admin dashboard | `GatewayConfig { admin_enabled: true }` → open `GET /admin` |
+| Wire OTLP distributed tracing to Jaeger/Tempo/Grafana | Set `OTEL_EXPORTER_OTLP_ENDPOINT` env var at server startup |
+| Read gateway contention event history | MCP `resources/read` on `resources://gateway/events` |
+| Search public DCC-MCP adapter catalog | `dcc_catalog__search` MCP tool or `dcc-mcp-server catalog search --query ...` |
 | Disable evolved skills | `ENV_DISABLE_ACCUMULATED_SKILLS` |
 | MCP HTTP (recommended) | `create_skill_server("<dcc>", McpHttpConfig(port=8765))` |
 | MCP HTTP (manual) | `McpHttpServer(registry, McpHttpConfig(port=8765))` |

--- a/docs/guide/INDEX.md
+++ b/docs/guide/INDEX.md
@@ -46,6 +46,11 @@ document without scanning every file.
 | [tunnel-relay.md](tunnel-relay.md) | Zero-config remote MCP relay (`RelayServer` + tunnel agent) |
 | [production-deployment.md](production-deployment.md) | Production checklist: logging, health probes, monitoring |
 | [protocols.md](protocols.md) | MCP protocol types and versioning |
+| [middleware.md](middleware.md) | Pluggable BeforeCall/AfterCall middleware chain: audit, quota, redaction |
+| [admin-ui.md](admin-ui.md) | Built-in zero-build `/admin` dashboard (instances, tools, calls, logs, health) |
+| [translate.md](translate.md) | `translate` subcommand: bridge any stdio MCP server to HTTP/SSE |
+| [openapi-mount.md](openapi-mount.md) | OpenAPI-to-MCP mount helper: expose any REST API as MCP tools |
+| [catalog.md](catalog.md) | DCC-MCP public adapter catalog: search and describe |
 
 ## Core Subsystems
 
@@ -63,6 +68,7 @@ document without scanning every file.
 | [usd.md](usd.md) | OpenUSD bridge: UsdStage, scene info JSON |
 | [artefacts.md](artefacts.md) | FileRef + ArtefactStore — cross-tool file handoff |
 | [telemetry.md](telemetry.md) | ToolMetrics, ToolRecorder, RecordingGuard |
+| [observability.md](observability.md) | OTLP exporter, gateway event log (`resources://gateway/events`), Prometheus counters |
 | [scheduler.md](scheduler.md) | ScheduleSpec, TriggerSpec, cron/webhook scheduling |
 | [workflows.md](workflows.md) | WorkflowSpec engine: step kinds, policies, persistence |
 | [job-persistence.md](job-persistence.md) | SQLite-backed job/workflow persistence and resume |

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -1,0 +1,109 @@
+# Built-in Admin Dashboard
+
+The gateway ships a zero-build, zero-dependency `/admin` web dashboard (issue #772). No `npm`, no CDN — a single inline HTML file served from the binary.
+
+## Activation
+
+```rust
+use dcc_mcp_gateway::gateway::GatewayConfig;
+
+let config = GatewayConfig {
+    admin_enabled: true,
+    admin_path: "/admin".to_string(),  // default
+    ..GatewayConfig::default()
+};
+```
+
+Requires the `admin` Cargo feature:
+
+```toml
+[dependencies]
+dcc-mcp-gateway = { features = ["admin"] }
+```
+
+Default: `admin_enabled = false` (opt-in for security).
+
+## Routes
+
+| Route | Content-Type | Description |
+|-------|-------------|-------------|
+| `GET /admin` | `text/html` | HTML dashboard (inline CSS + vanilla JS) |
+| `GET /admin/api/instances` | `application/json` | Connected DCC instances |
+| `GET /admin/api/tools` | `application/json` | Registered MCP tools |
+| `GET /admin/api/calls` | `application/json` | Recent tool calls (requires `AuditMiddleware`) |
+| `GET /admin/api/logs` | `application/json` | Gateway contention events |
+| `GET /admin/api/health` | `application/json` | Service health summary |
+
+## API Response Shapes
+
+```json
+// GET /admin/api/health
+{
+  "status": "ok",
+  "uptime_secs": 3600,
+  "instances_total": 3,
+  "instances_ready": 2
+}
+
+// GET /admin/api/instances
+{
+  "total": 3,
+  "instances": [
+    { "id": "a1b2c3d4-...", "dcc_type": "maya", "status": "ready", "address": "127.0.0.1:9001" }
+  ]
+}
+
+// GET /admin/api/calls  (requires AuditMiddleware)
+{
+  "total": 42,
+  "calls": [
+    { "tool": "maya__open_scene", "success": true, "timestamp": "2026-05-05T10:00:00Z" }
+  ]
+}
+
+// GET /admin/api/logs
+{
+  "total": 5,
+  "logs": [
+    { "event": "election_won", "dcc_type": "maya", "timestamp": "2026-05-05T09:59:00Z" }
+  ]
+}
+```
+
+## Connecting AuditMiddleware
+
+For the `/admin/api/calls` feed to be populated, add `AuditMiddleware` to the middleware chain:
+
+```rust
+use dcc_mcp_gateway::gateway::middleware::{AuditMiddleware, MiddlewareChain};
+
+GatewayConfig {
+    admin_enabled: true,
+    middleware_chain: MiddlewareChain::new()
+        .with_before(Arc::new(AuditMiddleware::default())),
+    ..GatewayConfig::default()
+}
+```
+
+The `/admin/api/logs` feed is populated automatically from the `EventLog` ring buffer (gateway election/eviction/probe events from issue #766).
+
+## Dashboard Features
+
+The HTML dashboard includes:
+- **Left navigation**: Instances / Tools / Calls / Logs / Health panels
+- **Auto-refresh**: Each panel polls its JSON endpoint every 5 seconds
+- **Dark theme**: Minimal inline CSS, no external fonts
+- **Responsive**: CSS grid layout
+
+## Security Note
+
+The admin UI is **read-only** and has **no authentication** by default. For production:
+- Place behind a reverse proxy with IP allowlist or basic auth
+- Or disable when not needed: `admin_enabled: false`
+- Never expose directly to the public internet
+
+## See also
+
+- [middleware.md](middleware.md) — `AuditMiddleware` that feeds `/admin/api/calls`
+- [observability.md](observability.md) — `EventLog` that feeds `/admin/api/logs`
+- [gateway.md](gateway.md) — full gateway configuration reference

--- a/docs/guide/catalog.md
+++ b/docs/guide/catalog.md
@@ -1,0 +1,89 @@
+# DCC-MCP Public Catalog
+
+The DCC-MCP catalog is a community-maintained registry of adapters and skill packs for the DCC-MCP ecosystem (issue #774).
+
+## Catalog File Format
+
+`dcc-mcp-catalog.yml` in the repository root:
+
+```yaml
+version: "1"
+entries:
+  - name: dcc-mcp-maya-skills
+    description: "Official Maya skill pack for DCC-MCP"
+    dcc: [maya]
+    url: "https://github.com/example/dcc-mcp-maya-skills"
+    tags: [skills, maya, official]
+
+  - name: dcc-mcp-blender-skills
+    description: "Community Blender skill pack"
+    dcc: [blender]
+    url: "https://github.com/example/dcc-mcp-blender-skills"
+    tags: [skills, blender, community]
+
+  - name: dcc-mcp-houdini-adapter
+    description: "Houdini DCC adapter for DCC-MCP"
+    dcc: [houdini]
+    url: "https://github.com/example/dcc-mcp-houdini"
+    tags: [adapter, houdini, official]
+```
+
+## Entry Fields
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `name` | ✅ | string | Unique identifier (kebab-case recommended) |
+| `description` | ✅ | string | One-sentence human-readable description |
+| `dcc` | ✅ | list[string] | Supported DCC types (e.g. `[maya, blender]`) |
+| `url` | ✅ | string | Repository or documentation URL |
+| `tags` | ❌ | list[string] | Searchable tags (e.g. `skills`, `adapter`, `official`, `community`) |
+
+## CLI Usage
+
+```bash
+# Search by keyword (matches name, description, DCC type, or tag)
+dcc-mcp-server catalog search --query maya
+
+# Search with no query → list all entries
+dcc-mcp-server catalog search
+
+# Describe a specific entry by exact name
+dcc-mcp-server catalog describe --name dcc-mcp-maya-skills
+```
+
+Output is JSON-formatted for easy parsing.
+
+## MCP Tool Usage
+
+The gateway automatically registers two MCP tools from the catalog:
+
+```python
+# In an AI agent or DCC skill
+result = tools.call("dcc_catalog__search", {"query": "blender"})
+# Returns: [{"name": "...", "description": "...", "dcc": [...], "url": "...", "tags": [...]}]
+
+result = tools.call("dcc_catalog__describe", {"name": "dcc-mcp-blender-skills"})
+# Returns: single entry or error if not found
+```
+
+## Custom Catalog Path
+
+Override the default `dcc-mcp-catalog.yml` location:
+
+```bash
+DCC_MCP_CATALOG_PATH=/path/to/my-catalog.yml dcc-mcp-server ...
+```
+
+Or set programmatically before calling the gateway tools.
+
+## Search Behavior
+
+- Case-insensitive substring match on `name`, `description`, `dcc`, and `tags`
+- Empty query returns all entries
+- `describe` requires an exact `name` match (case-sensitive)
+
+## See also
+
+- [skills.md](skills.md) — how to author a skill pack
+- [mcp-skills-integration.md](mcp-skills-integration.md) — registering skills on the server
+- [rez-skill-packages.md](rez-skill-packages.md) — Rez package layout for distributing skills

--- a/docs/guide/middleware.md
+++ b/docs/guide/middleware.md
@@ -1,0 +1,108 @@
+# Gateway Middleware Chain
+
+The gateway supports a pluggable `BeforeCall` / `AfterCall` middleware chain applied to every `tools/call` dispatch (issue #770).
+
+## Quick Start
+
+```rust
+use dcc_mcp_gateway::gateway::middleware::{
+    AuditMiddleware, MiddlewareChain, QuotaMiddleware, RedactionMiddleware,
+};
+use std::sync::Arc;
+
+let config = GatewayConfig {
+    middleware_chain: MiddlewareChain::new()
+        .with_before(Arc::new(AuditMiddleware::default()))
+        .with_before(Arc::new(QuotaMiddleware::new(100)))  // 100 calls/min
+        .with_before(Arc::new(RedactionMiddleware::new(["api_key", "token"]))),
+    ..GatewayConfig::default()
+};
+```
+
+## Built-in Middleware
+
+| Middleware | Purpose | On failure |
+|-----------|---------|-----------|
+| `AuditMiddleware` | Emits a `tracing::info!` log per `tools/call` with method, tool, DCC type, session ID, duration, and result | Never blocks |
+| `QuotaMiddleware::new(N)` | Limits to N calls/minute globally; returns `MiddlewareError::QuotaExceeded` when over | Aborts with 429-equivalent error |
+| `RedactionMiddleware::new(fields)` | Replaces matching arg field values with `"[REDACTED]"` before logging or forwarding | Never fails |
+
+## Custom Middleware
+
+Implement `BeforeCallMiddleware` or `AfterCallMiddleware`:
+
+```rust
+use dcc_mcp_gateway::gateway::middleware::{
+    AfterCallMiddleware, BeforeCallMiddleware, CallContext, CallResult, MiddlewareError,
+};
+
+pub struct MyMiddleware;
+
+#[async_trait::async_trait]
+impl BeforeCallMiddleware for MyMiddleware {
+    async fn before_call(&self, ctx: &mut CallContext) -> Result<(), MiddlewareError> {
+        // Inspect or mutate ctx before the call is dispatched
+        tracing::info!(tool = ?ctx.tool_slug, dcc = ?ctx.dcc_type, "custom before-call");
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl AfterCallMiddleware for MyMiddleware {
+    async fn after_call(
+        &self,
+        ctx: &mut CallContext,
+        result: &mut CallResult,
+    ) -> Result<(), MiddlewareError> {
+        tracing::info!(success = result.success, "custom after-call");
+        Ok(())
+    }
+}
+```
+
+Register it:
+
+```rust
+MiddlewareChain::new()
+    .with_before(Arc::new(MyMiddleware))
+    .with_after(Arc::new(MyMiddleware))
+```
+
+## `CallContext` Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `method` | `String` | MCP method (`tools/call`, `tools/list`, …) |
+| `tool_slug` | `Option<String>` | Tool name |
+| `dcc_type` | `Option<String>` | DCC type (`maya`, `blender`, …) |
+| `session_id` | `Option<String>` | MCP session ID |
+| `request_id` | `String` | Unique per-request ID (matches audit log `request_id`) |
+| `args` | `serde_json::Value` | Tool arguments (mutable; `RedactionMiddleware` modifies this) |
+| `metadata` | `HashMap<String, String>` | Pass-through bag for inter-middleware communication |
+
+## Execution Order
+
+```
+Request → BeforeCall[0] → BeforeCall[1] → ... → dispatch → AfterCall[0] → AfterCall[1] → Response
+```
+
+If any `before_call` returns `Err`, the call is aborted and subsequent middlewares are skipped.
+
+## Integration with Admin UI
+
+The `AuditMiddleware` populates the `/admin/api/calls` feed. Enable both together for a live call history in the dashboard:
+
+```rust
+GatewayConfig {
+    admin_enabled: true,
+    middleware_chain: MiddlewareChain::new()
+        .with_before(Arc::new(AuditMiddleware::default())),
+    ..GatewayConfig::default()
+}
+```
+
+## See also
+
+- [admin-ui.md](admin-ui.md) — dashboard that consumes the audit feed
+- [gateway.md](gateway.md) — full gateway configuration reference
+- [observability.md](observability.md) — OTLP tracing (middleware can enrich span attrs via `CallContext`)

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -1,0 +1,176 @@
+# Observability
+
+dcc-mcp-core provides three complementary observability surfaces for production deployments.
+
+## 1. OTLP Distributed Tracing (#768)
+
+Wire spans to any OpenTelemetry-compatible backend (Jaeger, Grafana Tempo, DataDog, New Relic, etc.).
+
+### Activation
+
+Set the standard `OTEL_*` environment variables — no code changes needed:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
+OTEL_SERVICE_NAME=dcc-mcp-gateway \
+  dcc-mcp-server ...
+```
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector endpoint — setting this activates OTLP automatically |
+| `OTEL_SERVICE_NAME` | Override service name in traces |
+| `OTEL_RESOURCE_ATTRIBUTES` | Extra resource attrs (`key=val,key2=val2`) |
+| `OTEL_EXPORTER_OTLP_HEADERS` | Auth headers for SaaS backends (e.g. `api-key=...`) |
+| `OTEL_TRACES_SAMPLER` | Sampler (`always_on`, `always_off`, `traceidratio`) |
+| `OTEL_TRACES_SAMPLER_ARG` | Sampler arg (e.g. `0.1` for 10% sampling) |
+
+### DCC Span Attributes
+
+Every `tools/call` trace includes:
+
+| Attribute | Example | Description |
+|-----------|---------|-------------|
+| `dcc.type` | `"maya"` | DCC application type |
+| `dcc.instance_id` | `"a1b2c3d4-..."` | Unique DCC instance UUID |
+| `dcc.scene` | `"/projects/shot01.ma"` | Current scene path (when known) |
+| `dcc.job_id` | `"job-..."` | Job ID (when wrapped by `JobHandle`) |
+| `mcp.method` | `"tools/call"` | MCP method name |
+| `mcp.tool_slug` | `"maya__open_scene"` | Full tool name |
+| `mcp.affinity` | `"main"` | Thread affinity requirement |
+| `mcp.session_id` | `"sess-..."` | MCP session ID |
+| `mcp.request_id` | `"req-..."` | Per-request unique ID |
+
+### Rust Config (programmatic)
+
+```rust
+use dcc_mcp_telemetry::{TelemetryConfig, ExporterBackend};
+
+TelemetryConfig::default()
+    .with_otlp_exporter("http://localhost:4317")
+    .init()?;
+```
+
+Requires the `otlp-exporter` Cargo feature:
+
+```toml
+dcc-mcp-telemetry = { features = ["otlp-exporter"] }
+```
+
+### Quick Start: Jaeger All-in-One
+
+```bash
+docker run -d --name jaeger \
+  -p 4317:4317 \   # OTLP gRPC
+  -p 16686:16686 \ # Jaeger UI
+  jaegertracing/all-in-one:latest
+
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
+OTEL_SERVICE_NAME=dcc-mcp-gateway \
+  dcc-mcp-server ...
+```
+
+Open `http://localhost:16686` to view traces.
+
+### Quick Start: Grafana Tempo
+
+```bash
+# docker-compose.yml
+services:
+  tempo:
+    image: grafana/tempo:latest
+    ports: ["4317:4317", "3200:3200"]
+```
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 dcc-mcp-server ...
+```
+
+---
+
+## 2. Gateway Contention Events (#766)
+
+Gateway election, eviction, and probe events are available as a bounded MCP resource.
+
+### MCP Resource
+
+```python
+# Read the last N contention events
+result = resources.read("resources://gateway/events")
+```
+
+Returns JSONL (one JSON object per line):
+
+```json
+{"timestamp":"2026-05-05T10:00:00Z","event":"election_won","dcc_type":"maya","instance_id":"a1b2c3d4","reason":null}
+{"timestamp":"2026-05-05T10:01:00Z","event":"ghost_reaped","dcc_type":"blender","instance_id":"b2c3d4e5","reason":"pid_dead"}
+```
+
+### Event Types
+
+| Event | Meaning |
+|-------|---------|
+| `election_won` | This instance became the active gateway |
+| `voluntary_yield` | This instance yielded to a newer candidate |
+| `ghost_reaped` | A stale registration was cleaned up |
+| `probe_booting` | Backend is starting up |
+| `probe_unreachable` | Health probe failed |
+| `auto_deregister` | Instance deregistered itself on clean shutdown |
+
+Ring buffer holds the **last 1000 events**.
+
+---
+
+## 3. Prometheus Metrics (#766)
+
+Under the `prometheus` Cargo feature, gateway contention counters are exposed at `/metrics`:
+
+```toml
+dcc-mcp-gateway = { features = ["prometheus"] }
+```
+
+### Counters
+
+```
+# Gateway port-election outcomes
+dcc_mcp_gateway_elections_total{outcome="won"}     12
+dcc_mcp_gateway_elections_total{outcome="yielded"}  3
+dcc_mcp_gateway_elections_total{outcome="lost"}     1
+
+# Registry eviction events
+dcc_mcp_gateway_evictions_total{reason="stale"}    1
+dcc_mcp_gateway_evictions_total{reason="ghost"}    0
+dcc_mcp_gateway_evictions_total{reason="probe_fail"} 2
+
+# Backend readiness-probe outcomes
+dcc_mcp_gateway_probes_total{outcome="ready"}      45
+dcc_mcp_gateway_probes_total{outcome="booting"}     3
+dcc_mcp_gateway_probes_total{outcome="unreachable"} 2
+```
+
+Label cardinality is bounded — no free-form `instance_id` labels.
+
+### Grafana Example Queries
+
+```promql
+# Election rate over time
+rate(dcc_mcp_gateway_elections_total[5m])
+
+# Eviction rate
+rate(dcc_mcp_gateway_evictions_total[5m])
+
+# Probe success ratio
+rate(dcc_mcp_gateway_probes_total{outcome="ready"}[5m])
+  / rate(dcc_mcp_gateway_probes_total[5m])
+```
+
+---
+
+## See also
+
+- [telemetry.md](telemetry.md) — `ToolMetrics`, `ToolRecorder`, legacy Python telemetry
+- [gateway-diagnostics.md](gateway-diagnostics.md) — log templates for election/eviction events
+- [production-deployment.md](production-deployment.md) — production monitoring checklist
+- [middleware.md](middleware.md) — `AuditMiddleware` for per-call audit logging

--- a/docs/guide/openapi-mount.md
+++ b/docs/guide/openapi-mount.md
@@ -1,0 +1,101 @@
+# OpenAPI → MCP Mount Helper
+
+Expose any existing REST API as MCP tools in the gateway with a single config block (issue #773).
+
+## Quick Start
+
+```rust
+gateway_builder.mount_openapi(
+    OpenApiMount::from_url("https://api.example.com/openapi.json")
+        .base_url("https://api.example.com")
+        .auth(AuthConfig::bearer("$MY_API_TOKEN"))
+        .tool_prefix("example"),
+)
+```
+
+This generates one MCP tool per OpenAPI operation. Tool names follow `{prefix}__{operationId}` or `{prefix}__{method}_{path_sanitized}` when `operationId` is absent.
+
+## How It Works
+
+1. **Spec parsing** — `OpenApiMount` fetches and parses the OpenAPI 3.x JSON spec
+2. **Tool generation** — one MCP tool per operation; `inputSchema` is built from `requestBody` + `parameters`
+3. **HTTP forwarding** — on `tools/call`, path/query/body params are mapped and the request is forwarded to the backend with auth headers injected
+
+## `OpenApiMount` Builder
+
+```rust
+OpenApiMount::from_url("https://api.example.com/openapi.json")
+    // Required: backend base URL
+    .base_url("https://api.example.com")
+    // Optional: auth forwarding
+    .auth(AuthConfig::bearer("$MY_API_TOKEN"))
+    // Optional: prefix for all generated tool names (avoids collisions)
+    .tool_prefix("example")
+```
+
+## Auth Configuration
+
+| Method | Description |
+|--------|-------------|
+| `AuthConfig::bearer("$TOKEN")` | `Authorization: Bearer <token>` — `$ENV_VAR` references resolved at call time |
+| `AuthConfig::api_key("X-Api-Key", "$KEY")` | Custom header injection |
+| `AuthConfig::basic("$USER", "$PASS")` | HTTP Basic auth (base64-encoded) |
+
+Environment variable references (`$VAR_NAME`) are resolved at call time, not at mount time. If the variable is unset, the header is omitted.
+
+## Generated Tool Schema
+
+For a `POST /pets` operation with a JSON body:
+
+```json
+{
+  "name": "example__createPet",
+  "description": "Create a new pet",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "name": { "type": "string" },
+      "species": { "type": "string" }
+    },
+    "required": ["name"]
+  }
+}
+```
+
+## Parameter Mapping
+
+| OpenAPI location | Maps to |
+|-----------------|---------|
+| `path` params (`/pets/{petId}`) | Substituted in URL path |
+| `query` params | Appended as `?key=value` |
+| `requestBody` (JSON) | Serialized as JSON body |
+
+## Error Handling
+
+HTTP 4xx/5xx responses from the backend are mapped to `CallError::BackendError { status, body }`.
+
+## Gateway Registration
+
+```rust
+impl GatewayBuilder {
+    pub fn mount_openapi(mut self, mount: OpenApiMount) -> Self { ... }
+}
+
+// Multiple mounts
+gateway_builder
+    .mount_openapi(OpenApiMount::from_url("...").tool_prefix("api1"))
+    .mount_openapi(OpenApiMount::from_url("...").tool_prefix("api2"))
+```
+
+## Limitations
+
+- Only OpenAPI 3.x JSON specs are supported (YAML support via string conversion)
+- `$ref` resolution is limited to single-level inline references
+- File upload (`multipart/form-data`) is not yet supported
+- WebSocket / streaming operations are not exposed as MCP tools
+
+## See also
+
+- [gateway.md](gateway.md) — full gateway configuration reference
+- [middleware.md](middleware.md) — add auth forwarding policies via `BeforeCallMiddleware`
+- [rest-api-surface.md](rest-api-surface.md) — per-DCC REST skill API

--- a/docs/guide/translate.md
+++ b/docs/guide/translate.md
@@ -1,0 +1,111 @@
+# translate subcommand — Bridge stdio MCP Servers to HTTP/SSE
+
+The `translate` subcommand bridges any stdio MCP server to HTTP/SSE/Streamable-HTTP transport (issue #769).
+
+## Use Cases
+
+- Expose `filesystem`, `git`, `sqlite`, `brave-search`, or any other stdio-only MCP server over HTTP
+- Connect Cursor, Claude Desktop, or any HTTP-first agent to a stdio MCP server
+- Run multiple stdio MCP servers behind a single gateway endpoint
+- Test stdio MCP servers through standard HTTP tooling
+
+## Quick Start
+
+```bash
+dcc-mcp-server translate \
+  --stdio "npx @modelcontextprotocol/server-filesystem /tmp" \
+  --dcc-type filesystem \
+  --port 3333 \
+  --transport sse
+```
+
+## CLI Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--stdio <cmd>` | required | Shell command to launch the stdio MCP server |
+| `--port <N>` | `0` (OS-assigned) | HTTP listen port |
+| `--transport <sse\|streamable-http>` | `sse` | HTTP transport protocol |
+| `--dcc-type <type>` | `stdio` | DCC type label for gateway registration |
+| `--host <addr>` | `127.0.0.1` | Listen address |
+| `--no-register` | false | Skip gateway election (run as standalone server) |
+| `--restart-on-exit` | false | Restart the stdio process if it exits (supervisor mode) |
+| `--max-restarts <N>` | `5` | Max supervisor restart attempts before giving up |
+| `--stale-timeout-secs <N>` | `30` | Gateway election stale timeout |
+| `--registry-dir <path>` | auto | Custom registry directory |
+
+## Examples
+
+### Filesystem MCP server
+
+```bash
+dcc-mcp-server translate \
+  --stdio "npx -y @modelcontextprotocol/server-filesystem /home/user/projects" \
+  --dcc-type filesystem \
+  --port 4000
+```
+
+### Git MCP server with supervisor restart
+
+```bash
+dcc-mcp-server translate \
+  --stdio "uvx mcp-server-git --repository /path/to/repo" \
+  --dcc-type git \
+  --port 4001 \
+  --restart-on-exit \
+  --max-restarts 10
+```
+
+### Standalone (no gateway registration)
+
+```bash
+dcc-mcp-server translate \
+  --stdio "python -m my_mcp_server" \
+  --no-register \
+  --port 4002
+```
+
+## Cursor / Claude Desktop Configuration
+
+Point your AI client at the translated endpoint:
+
+```json
+// .cursor/mcp.json or claude_desktop_config.json
+{
+  "mcpServers": {
+    "filesystem": {
+      "url": "http://localhost:4000/sse"
+    },
+    "git": {
+      "url": "http://localhost:4001/sse"
+    }
+  }
+}
+```
+
+For Streamable HTTP transport:
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "url": "http://localhost:4000/mcp",
+      "transport": "streamable-http"
+    }
+  }
+}
+```
+
+## Implementation Notes
+
+- **Async actor model**: one Tokio task owns the child process stdin/stdout with mpsc channel communication
+- **Concurrent requests**: request/response ID tracking supports multiple in-flight calls
+- **Notifications**: JSON messages without `id` field are forwarded to all connected SSE clients
+- **Supervisor**: exponential back-off between restarts (cap: 30 seconds)
+- **Gateway registration**: when `--no-register` is absent, the bridge registers as a DCC instance in the gateway election
+
+## See also
+
+- [gateway.md](gateway.md) — gateway registration and election
+- [tunnel-relay.md](tunnel-relay.md) — remote relay for external/internet access
+- [rest-api-surface.md](rest-api-surface.md) — per-DCC REST API surface

--- a/docs/zh/guide/INDEX.md
+++ b/docs/zh/guide/INDEX.md
@@ -1,0 +1,91 @@
+# 文档指南索引
+
+`docs/guide/` 目录的快速参考索引，帮助你找到所需文档，无需逐一扫描。
+
+## AI Agent 快速路径
+
+**如果你是 AI Agent**，请按以下顺序阅读：
+
+| 优先级 | 文档 | 说明 |
+|--------|------|------|
+| 1 | [`AGENTS.md`](https://github.com/loonghao/dcc-mcp-core/blob/main/AGENTS.md) | 导航地图、响应规则、PR 规则及链接 |
+| 2 | [`AI_AGENT_GUIDE.md`](https://github.com/loonghao/dcc-mcp-core/blob/main/AI_AGENT_GUIDE.md) | AI Agent 的技能优先使用工作流 |
+| 3 | [agents-reference.md](agents-reference.md) | **关键** — 陷阱、注意事项、代码风格、常量 |
+| 4 | [skills.md](skills.md) | 如何编写和注册技能 |
+| 5 | [gateway.md](gateway.md) + [dcc-rest-skill-api.md](dcc-rest-skill-api.md) | 网关动态能力与 REST 工作流 |
+
+## 快速上手
+
+| 文档 | 用途 |
+|------|------|
+| [getting-started.md](getting-started.md) | 安装、第一个服务器、第一个工具 |
+| [what-is-dcc-mcp-core.md](what-is-dcc-mcp-core.md) | 项目高层概述与背景 |
+| [architecture.md](architecture.md) | Rust workspace 布局、crate 边界、PyO3 桥接 |
+
+## AI Agent 与技能开发
+
+| 文档 | 用途 |
+|------|------|
+| [agents-reference.md](agents-reference.md) | **关键** — 陷阱、注意事项、代码风格、完整示例 |
+| [skills.md](skills.md) | 技能系统：扫描、加载、生命周期 |
+| [thin-harness.md](thin-harness.md) | 薄封装层：`execute_python` + recipes 模式 |
+| [mcp-skills-integration.md](mcp-skills-integration.md) | 技能与 MCP HTTP 服务器的集成方式 |
+| [skill-scopes-policies.md](skill-scopes-policies.md) | SkillScope（信任级别）与 SkillPolicy |
+| [context-bundles.md](context-bundles.md) | 通过解析的启动上下文按项目/任务/资产加载技能 |
+| [rez-skill-packages.md](rez-skill-packages.md) | Rez 包布局与分发技能的环境变量约定 |
+
+## MCP 服务器与 HTTP
+
+| 文档 | 用途 |
+|------|------|
+| [remote-server.md](remote-server.md) | 云端托管 MCP Agent：认证、批处理、引导、富内容 |
+| [gateway.md](gateway.md) | 多 DCC 网关：聚合、工具路由 |
+| [gateway-election.md](gateway-election.md) | `DccGatewayElection` — 自动故障切换 |
+| [dcc-rest-skill-api.md](dcc-rest-skill-api.md) | 每个 DCC 的 RESTful 技能 API 接口（#658 / #660） |
+| [tunnel-relay.md](tunnel-relay.md) | 零配置远程 MCP 中继（`RelayServer` + tunnel agent） |
+| [production-deployment.md](production-deployment.md) | 生产部署检查清单：日志、健康探针、监控 |
+| [protocols.md](protocols.md) | MCP 协议类型与版本管理 |
+| [middleware.md](middleware.md) | 可插拔 BeforeCall/AfterCall 中间件链：审计、限流、脱敏 |
+| [admin-ui.md](admin-ui.md) | 内置零构建 `/admin` 仪表盘（实例、工具、调用、日志、健康） |
+| [translate.md](translate.md) | `translate` 子命令：将任意 stdio MCP 服务器桥接到 HTTP/SSE |
+| [openapi-mount.md](openapi-mount.md) | OpenAPI → MCP 挂载助手：将任意 REST API 暴露为 MCP 工具 |
+| [catalog.md](catalog.md) | DCC-MCP 公共适配器目录：搜索与描述 |
+
+## 核心子系统
+
+| 文档 | 用途 |
+|------|------|
+| [actions.md](actions.md) | ToolRegistry、ToolDispatcher、ToolPipeline、VersionedRegistry |
+| [custom-actions.md](custom-actions.md) | 添加自定义工具类型与验证策略 |
+| [events.md](events.md) | EventBus 发布/订阅系统 |
+| [naming.md](naming.md) | SEP-986 工具名称与 Action ID 验证规则 |
+| [transport.md](transport.md) | IPC 传输：DccLinkFrame、IpcChannelAdapter、SocketServerAdapter |
+| [process.md](process.md) | 进程管理：启动、监控、崩溃恢复 |
+| [capture.md](capture.md) | 屏幕/窗口截图 API |
+| [sandbox.md](sandbox.md) | SandboxPolicy、InputValidator、AuditLog |
+| [shm.md](shm.md) | 共享内存与零拷贝场景数据 |
+| [usd.md](usd.md) | OpenUSD 桥接：UsdStage、场景信息 JSON |
+| [artefacts.md](artefacts.md) | FileRef + ArtefactStore — 跨工具文件交接 |
+| [telemetry.md](telemetry.md) | ToolMetrics、ToolRecorder、RecordingGuard |
+| [observability.md](observability.md) | OTLP exporter、网关事件日志（`resources://gateway/events`）、Prometheus 计数器 |
+| [scheduler.md](scheduler.md) | ScheduleSpec、TriggerSpec、cron/webhook 调度 |
+| [workflows.md](workflows.md) | WorkflowSpec 引擎：步骤类型、策略、持久化 |
+| [job-persistence.md](job-persistence.md) | SQLite 支持的作业/工作流持久化与恢复 |
+| [project-persistence.md](project-persistence.md) | 跨会话的项目级状态（场景、资产、活跃技能） |
+| [prompts.md](prompts.md) | MCP Prompt 定义 |
+| [capabilities.md](capabilities.md) | DccCapabilities 与功能检测 |
+| [faq.md](faq.md) | 常见问题解答 |
+
+## 线程安全与并发
+
+| 文档 | 用途 |
+|------|------|
+| [dcc-thread-safety.md](dcc-thread-safety.md) | DCC 主线程分发、协作式取消 |
+| [host-adapter.md](host-adapter.md) | `HostAdapter` 基类，用于每个 DCC 的分发器接线 |
+| [cross-dcc-verification.md](cross-dcc-verification.md) | 生产者→文件→验证者往返的 `SceneStats` 契约 |
+
+## 集成
+
+| 文档 | 用途 |
+|------|------|
+| [mcp-skills-integration.md](mcp-skills-integration.md) | 在 MCP HTTP 服务器上注册技能 |

--- a/docs/zh/guide/admin-ui.md
+++ b/docs/zh/guide/admin-ui.md
@@ -1,0 +1,109 @@
+# 内置 Admin 仪表盘
+
+网关内置一个零构建、零依赖的 `/admin` Web 仪表盘（issue #772）。无需 `npm`，无需 CDN——一个内联 HTML 文件直接从二进制包中提供服务。
+
+## 激活方式
+
+```rust
+use dcc_mcp_gateway::gateway::GatewayConfig;
+
+let config = GatewayConfig {
+    admin_enabled: true,
+    admin_path: "/admin".to_string(),  // 默认值
+    ..GatewayConfig::default()
+};
+```
+
+需要启用 `admin` Cargo feature：
+
+```toml
+[dependencies]
+dcc-mcp-gateway = { features = ["admin"] }
+```
+
+默认值：`admin_enabled = false`（出于安全考虑，需主动开启）。
+
+## 路由
+
+| 路由 | Content-Type | 说明 |
+|------|-------------|------|
+| `GET /admin` | `text/html` | HTML 仪表盘（内联 CSS + vanilla JS） |
+| `GET /admin/api/instances` | `application/json` | 已连接的 DCC 实例 |
+| `GET /admin/api/tools` | `application/json` | 已注册的 MCP 工具 |
+| `GET /admin/api/calls` | `application/json` | 最近的工具调用（需要 `AuditMiddleware`） |
+| `GET /admin/api/logs` | `application/json` | 网关竞争事件 |
+| `GET /admin/api/health` | `application/json` | 服务健康摘要 |
+
+## API 响应格式
+
+```json
+// GET /admin/api/health
+{
+  "status": "ok",
+  "uptime_secs": 3600,
+  "instances_total": 3,
+  "instances_ready": 2
+}
+
+// GET /admin/api/instances
+{
+  "total": 3,
+  "instances": [
+    { "id": "a1b2c3d4-...", "dcc_type": "maya", "status": "ready", "address": "127.0.0.1:9001" }
+  ]
+}
+
+// GET /admin/api/calls  （需要 AuditMiddleware）
+{
+  "total": 42,
+  "calls": [
+    { "tool": "maya__open_scene", "success": true, "timestamp": "2026-05-05T10:00:00Z" }
+  ]
+}
+
+// GET /admin/api/logs
+{
+  "total": 5,
+  "logs": [
+    { "event": "election_won", "dcc_type": "maya", "timestamp": "2026-05-05T09:59:00Z" }
+  ]
+}
+```
+
+## 接入 AuditMiddleware
+
+要让 `/admin/api/calls` 数据源有内容，需要在中间件链中添加 `AuditMiddleware`：
+
+```rust
+use dcc_mcp_gateway::gateway::middleware::{AuditMiddleware, MiddlewareChain};
+
+GatewayConfig {
+    admin_enabled: true,
+    middleware_chain: MiddlewareChain::new()
+        .with_before(Arc::new(AuditMiddleware::default())),
+    ..GatewayConfig::default()
+}
+```
+
+`/admin/api/logs` 数据源由 `EventLog` 环形缓冲区自动填充（网关选举/驱逐/探针事件，来自 issue #766）。
+
+## 仪表盘功能
+
+HTML 仪表盘包含：
+- **左侧导航**：实例 / 工具 / 调用 / 日志 / 健康 面板
+- **自动刷新**：每个面板每 5 秒轮询对应 JSON 端点
+- **深色主题**：极简内联 CSS，无外部字体
+- **响应式布局**：CSS grid 布局
+
+## 安全注意事项
+
+Admin UI 是**只读**的，默认**无认证**。生产环境建议：
+- 通过反向代理添加 IP 白名单或 Basic Auth
+- 不需要时禁用：`admin_enabled: false`
+- 切勿直接暴露到公网
+
+## 参见
+
+- [middleware.md](middleware.md) — 填充 `/admin/api/calls` 的 `AuditMiddleware`
+- [observability.md](observability.md) — 填充 `/admin/api/logs` 的 `EventLog`
+- [gateway.md](gateway.md) — 完整的网关配置参考

--- a/docs/zh/guide/catalog.md
+++ b/docs/zh/guide/catalog.md
@@ -1,0 +1,87 @@
+# DCC-MCP 公共目录
+
+DCC-MCP 目录是一个由社区维护的 DCC-MCP 生态系统适配器和技能包注册表（issue #774）。
+
+## 目录文件格式
+
+仓库根目录的 `dcc-mcp-catalog.yml`：
+
+```yaml
+version: "1"
+entries:
+  - name: dcc-mcp-maya-skills
+    description: "DCC-MCP 官方 Maya 技能包"
+    dcc: [maya]
+    url: "https://github.com/example/dcc-mcp-maya-skills"
+    tags: [skills, maya, official]
+
+  - name: dcc-mcp-blender-skills
+    description: "社区 Blender 技能包"
+    dcc: [blender]
+    url: "https://github.com/example/dcc-mcp-blender-skills"
+    tags: [skills, blender, community]
+
+  - name: dcc-mcp-houdini-adapter
+    description: "DCC-MCP 的 Houdini 适配器"
+    dcc: [houdini]
+    url: "https://github.com/example/dcc-mcp-houdini"
+    tags: [adapter, houdini, official]
+```
+
+## 条目字段
+
+| 字段 | 必填 | 类型 | 说明 |
+|------|------|------|------|
+| `name` | ✅ | string | 唯一标识符（推荐 kebab-case） |
+| `description` | ✅ | string | 一句话人类可读描述 |
+| `dcc` | ✅ | list[string] | 支持的 DCC 类型列表（如 `[maya, blender]`） |
+| `url` | ✅ | string | 仓库或文档 URL |
+| `tags` | ❌ | list[string] | 可搜索标签（如 `skills`、`adapter`、`official`、`community`） |
+
+## CLI 用法
+
+```bash
+# 按关键词搜索（匹配 name、description、DCC 类型或 tag）
+dcc-mcp-server catalog search --query maya
+
+# 不指定 query 时列出所有条目
+dcc-mcp-server catalog search
+
+# 按精确名称查看详情
+dcc-mcp-server catalog describe --name dcc-mcp-maya-skills
+```
+
+输出为 JSON 格式，便于解析。
+
+## MCP 工具用法
+
+网关会自动注册两个 MCP 工具：
+
+```python
+# 在 AI Agent 或 DCC 技能中使用
+result = tools.call("dcc_catalog__search", {"query": "blender"})
+# 返回：[{"name": "...", "description": "...", "dcc": [...], "url": "...", "tags": [...]}]
+
+result = tools.call("dcc_catalog__describe", {"name": "dcc-mcp-blender-skills"})
+# 返回：单个条目，或未找到时返回错误
+```
+
+## 自定义目录路径
+
+覆盖默认的 `dcc-mcp-catalog.yml` 位置：
+
+```bash
+DCC_MCP_CATALOG_PATH=/path/to/my-catalog.yml dcc-mcp-server ...
+```
+
+## 搜索行为
+
+- 对 `name`、`description`、`dcc`、`tags` 进行大小写不敏感的子串匹配
+- 空 query 返回所有条目
+- `describe` 需要精确匹配 `name`（区分大小写）
+
+## 参见
+
+- [skills.md](skills.md) — 如何编写技能包
+- [mcp-skills-integration.md](mcp-skills-integration.md) — 在服务器上注册技能
+- [rez-skill-packages.md](rez-skill-packages.md) — 用于分发技能的 Rez 包布局

--- a/docs/zh/guide/context-bundles.md
+++ b/docs/zh/guide/context-bundles.md
@@ -1,0 +1,56 @@
+# 上下文包（Context Bundles）
+
+上下文包是 DCC MCP 会话解析后的运行时身份。它回答了：这属于哪个制作域、正在进行什么类型的工作、当前活跃的项目/镜头/资产是什么，以及哪些技能包应该可见？
+
+```text
+Rez 上下文 -> 环境变量 -> DCC 启动 -> 技能扫描 -> 网关元数据 -> 上下文感知的 tools/list
+```
+
+`dcc-mcp-core` 读取这个已解析的环境。它不选择包、解决版本，也不替代工作室包管理器。
+
+## 运行时流程
+
+1. Rez 为项目、部门、任务、资产类型和 DCC 解析包
+2. 包命令设置 `DCC_MCP_*` 上下文和路径变量
+3. DCC 适配器启动 `DccServerBase` 或 `McpHttpServer`
+4. 从 `DCC_MCP_SKILL_PATHS` 和 `DCC_MCP_<DCC>_SKILL_PATHS` 中发现技能
+5. 网关在 `FileRegistry` 中记录上下文元数据
+6. 客户端对选定的上下文调用 `list_dcc_instances`、`search_skills` 和 `load_skill`，而不是一次性暴露所有工作室工具
+
+## 元数据键
+
+网关在每个实例的 `metadata` 字段下返回上下文元数据。内置的 `DccServerBase` 从环境变量填充这些键：
+
+| 元数据键 | 环境变量 |
+|---------|---------|
+| `context_bundle` | `DCC_MCP_CONTEXT_BUNDLE` |
+| `production_domain` | `DCC_MCP_PRODUCTION_DOMAIN` |
+| `context_kind` | `DCC_MCP_CONTEXT_KIND` |
+| `project` | `DCC_MCP_PROJECT` |
+| `sequence` | `DCC_MCP_SEQUENCE` |
+| `shot` | `DCC_MCP_SHOT` |
+| `asset` | `DCC_MCP_ASSET` |
+| `asset_type` | `DCC_MCP_ASSET_TYPE` |
+| `task` | `DCC_MCP_TASK` |
+| `toolset_profile` | `DCC_MCP_TOOLSET_PROFILE` |
+| `package_provenance` | `DCC_MCP_PACKAGE_PROVENANCE` |
+| `skill_paths` | `DCC_MCP_SKILL_PATHS` |
+| `dcc_skill_paths` | `DCC_MCP_<DCC>_SKILL_PATHS` |
+
+不使用 `DccServerBase` 的适配器可以通过 `McpHttpConfig.instance_metadata` 显式设置相同的值。
+
+## 网关路由
+
+网关本质上是对已启动上下文的选择器，不应将每个后端工具放大为一个庞大的全局接口。客户端应首先查看 `list_dcc_instances`，选择匹配的包或 DCC 会话，然后在该选定上下文中加载/搜索技能。
+
+选择标准示例：
+
+- `production_domain=film`、`context_kind=shot`、`task=animation` → Maya 动画 blocking 工具
+- `production_domain=film`、`context_kind=shot`、`task=fx` → Houdini 缓存与模拟预览工具
+- `production_domain=game`、`context_kind=level` → 关卡布局工具
+
+## 示例
+
+可复用的清单文件位于 `examples/context-bundles/`。示例 Rez 技能包位于 `examples/rez-skills/`，每个包含 `package.py`、`SKILL.md`、`tools.yaml`、`README.md` 以及一个小脚本。
+
+包布局和来源指导，请参见 [rez-skill-packages.md](rez-skill-packages.md)。

--- a/docs/zh/guide/cross-dcc-verification.md
+++ b/docs/zh/guide/cross-dcc-verification.md
@@ -1,0 +1,131 @@
+# 跨 DCC 验证
+
+> 证明由一个 DCC 通过 MCP 服务器生成的资产可以被第二个 DCC 消费、检查和验证。本页说明 `dcc-mcp-core` 提供的**契约**以及下游 DCC 仓库如何接入它。
+
+## 为什么是契约而非实现
+
+每个 DCC（Blender、Maya、Unreal、Photoshop、Houdini……）都有自己的原生导入 API、场景遍历原语以及对"网格"的定义。`dcc-mcp-core` 有意回避这片丛林：它只定义验证器结果的**形状**和每个下游实现应克隆的**技能模板**。保持形状精简（三个字段）是契约可移植的关键。
+
+实际的 `import_and_inspect` 逻辑位于下游仓库：
+
+| DCC | 仓库 | 技能名称（约定） |
+|-----|------|----------------|
+| Blender | `dcc-mcp-blender` | `blender-fbx-verifier` |
+| Maya | `dcc-mcp-maya` | `maya-fbx-verifier` |
+| Unreal | `dcc-mcp-unreal` | `unreal-fbx-verifier` |
+| Photoshop | `dcc-mcp-photoshop` | `photoshop-psd-verifier` |
+
+## `SceneStats` 契约
+
+```python
+from dcc_mcp_core import SceneStats
+
+observed = SceneStats(
+    object_count=1,
+    vertex_count=482,
+    has_mesh=True,
+    extra={"dcc": "blender-3.6"},  # 可选的 DCC 特定扩展信息
+)
+```
+
+| 字段 | 类型 | 含义 |
+|------|------|------|
+| `object_count` | `int` | 导入后看到的顶层对象数量 |
+| `vertex_count` | `int` | 所有网格几何体的总顶点数 |
+| `has_mesh` | `bool` | 当任何导入对象是多边形几何体时为 True |
+| `extra` | `dict` | 自由形式的扩展信息，可序列化，核心比较时忽略 |
+
+### 比较生产者与验证者
+
+辅助方法 `SceneStats.matches()` 实现了核心认可的唯一比较语义：
+
+- **严格**比较 `object_count`（结构不变量）
+- **严格**比较 `has_mesh`（检测静默的空导入）
+- **模糊**比较 `vertex_count`（默认 ±5%），因为 FBX 法线、UV 缝合和切线基变化可能在重新导入时分割顶点
+
+```python
+produced = SceneStats(object_count=1, vertex_count=482, has_mesh=True)
+observed = verifier_skill__import_and_inspect("/tmp/sphere.fbx")
+
+assert produced.matches(observed, vertex_tolerance=0.05), (
+    f"往返漂移：期望 {produced}，得到 {observed}"
+)
+```
+
+三个核心字段之外的扩展字段放入 `extra`。比较器不读取 `extra`，这样 DCC 特定的遥测数据就不会破坏往返断言。
+
+## 编写验证器技能
+
+模板位于 `skills/templates/verifier-harness/`。为新 DCC 创建验证器：
+
+1. 将模板目录复制到下游仓库（如 `dcc-mcp-blender/skills/blender-fbx-verifier/`）
+2. 编辑 `SKILL.md`：设置 `dcc: blender`（或类似值），并按仓库约定重命名技能
+3. 将 `scripts/import_and_inspect.py` 的桩函数体替换为 DCC 原生导入 + 检查调用，返回包裹在 `skill_success(...)` 中的 `SceneStats.to_dict()` 负载
+4. 在下游仓库添加 CI 作业：
+   - 启动两个 DCC 进程（或一个生产者 + 一个验证者）
+   - 运行生产者技能创建并导出资产
+   - 对导出的文件运行新的验证器技能
+   - 使用 `dcc_mcp_core.SceneStats` 断言 `produced.matches(observed)`
+
+### 示例桩（Blender）
+
+```python
+import bpy
+
+from dcc_mcp_core import SceneStats
+from dcc_mcp_core.skill import skill_entry, skill_success
+
+
+def main(params):
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    bpy.ops.import_scene.fbx(filepath=params["file_path"])
+    objects = list(bpy.context.scene.objects)
+    meshes = [o for o in objects if o.type == "MESH"]
+    vertex_count = sum(len(m.data.vertices) for m in meshes)
+
+    stats = SceneStats(
+        object_count=len(objects),
+        vertex_count=vertex_count,
+        has_mesh=bool(meshes),
+        extra={"blender_version": bpy.app.version_string},
+    )
+    return skill_success("导入并检查完成", **stats.to_dict())
+
+
+if __name__ == "__main__":
+    skill_entry(main)
+```
+
+## 往返 CI 的位置
+
+`dcc-mcp-core` **不**附带 Blender + FBX 往返作业。那属于拥有生产者或验证者二进制文件的下游仓库，因为只有这些仓库固定了 DCC 版本矩阵。核心断言的不变量仅限于形状，由 `tests/test_verifier_contract.py` 验证。
+
+遵循此契约的下游仓库应添加如下 CI 作业：
+
+```
+1. 以无头模式启动生产者 DCC，加载生产者技能
+2. mcporter call: producer__create_sphere, producer__export_fbx
+3. 以无头模式启动验证者 DCC，加载验证者技能
+4. mcporter call: verifier__import_and_inspect(/tmp/sphere.fbx)
+5. Python 断言: SceneStats.from_dict(...).matches(produced)
+```
+
+## 常见问题
+
+### 为什么只有三个字段？边界框、材质、动画怎么办？
+
+进入核心契约的每个字段必须在所有 DCC 中永远意义相同。三个字段（对象/顶点/has-mesh）是我们能够严格定义和测试语义的集合。任何 DCC 特定的数据（材质、相机、动画帧数、边界框）都可以通过 `extra` 传递，无需核心承诺跨 DCC 的定义。
+
+### 我可以在下游仓库中扩展 `SceneStats` 吗？
+
+不要子类化。将下游特定数据放入 `extra`。如果某个字段在所有支持的 DCC 中真正通用，我们会在次要版本中将其提升到核心契约。
+
+### 如果我的 DCC 不暴露顶点数怎么办？
+
+返回 `vertex_count=0` 并在 `extra` 中添加说明。针对该 DCC 的往返测试应仅将 `has_mesh` 作为真正的断言。
+
+## 相关文档
+
+- [`dcc-thread-safety.md`](dcc-thread-safety.md) — 验证器技能在实时 DCC 会话中运行时所依赖的主线程分发器原语
+- [`host-adapter.md`](host-adapter.md) — 下游仓库用于将验证器接入 DCC 空闲循环的 `HostAdapter` 基类
+- [`skills.md`](skills.md) — 验证器模板所基于的 SKILL.md 格式

--- a/docs/zh/guide/dcc-rest-skill-api.md
+++ b/docs/zh/guide/dcc-rest-skill-api.md
@@ -1,0 +1,108 @@
+# 每个 DCC 的 REST 技能 API
+
+> Issue 参考：[#658](https://github.com/loonghao/dcc-mcp-core/issues/658) ·
+> [#660](https://github.com/loonghao/dcc-mcp-core/issues/660) ·
+> 总揽 [#657](https://github.com/loonghao/dcc-mcp-core/issues/657)
+
+MCP 网关**并非**唯一能让外部调用 DCC 技能的方式。每个嵌入 DCC 进程的 `McpHttpServer` 也可以将已发现的技能暴露为一个小型、带版本的 REST 接口，挂载在 `/v1/*` 路径下。网关随后**索引并路由**到这些每个 DCC 的服务，而不是将每个后端 Action 单独发布为 MCP 工具。
+
+## 为什么这样设计
+
+| 仅使用网关暴露的问题 | REST 接口如何解决 |
+|---------------------|-----------------|
+| `tools/list` 随 `实例数 × Action 数` 线性增长 | REST 接口有界——仅 9 条固定路由 |
+| MCP 工具名必须符合 `[A-Za-z0-9_]+` | REST slug 使用 `<dcc>.<skill>.<action>` |
+| 非 MCP Agent 调用 DCC 代码需要额外适配器 | 直接 `POST /v1/call` 加 JSON 请求体 |
+| "技能未加载"没有结构化错误类 | `ServiceErrorKind::SkillNotLoaded`（kebab-case） |
+
+## 路由
+
+| 方法 | 路径 | 用途 |
+|------|------|------|
+| GET  | `/v1/healthz` | 存活检查 |
+| GET  | `/v1/readyz`  | 三状态就绪检查（进程/分发器/DCC） |
+| GET  | `/v1/openapi.json` | utoipa 生成的 OpenAPI 3.x 契约 |
+| GET  | `/v1/skills`  | 已加载的技能/Action 列表 |
+| POST | `/v1/search`  | 紧凑的关键词/tag/dcc/scope 搜索 |
+| POST | `/v1/describe` | 获取某个 slug 的 Schema + 注解 |
+| GET  | `/v1/tools/{slug}` | describe 的别名 |
+| POST | `/v1/call`    | 按 slug 调用一个工具 |
+| GET  | `/v1/context` | 当前 DCC 场景/文档快照 |
+
+## SOLID 分层
+
+```text
+SkillRestRouter   ← axum 薄适配层
+       │
+SkillRestService  ← 纯业务逻辑，无 axum 依赖
+   │  │  │  │
+   ▼  ▼  ▼  ▼
+SkillCatalogSource  ToolInvoker  AuthGate  AuditSink
+   (trait)          (trait)      (trait)    (trait)
+```
+
+每个协作者都是一个 **trait**，适配器（Maya/Blender/Houdini）可以替换自己的实现，而无需修改路由器。默认接线：
+
+- `SkillCatalog`（`dcc-mcp-skills`）作为目录来源
+- `ActionDispatcher`（`dcc-mcp-actions`）负责调用
+- `AllowLocalhostGate` 负责认证（仅允许回环地址）
+- `NoopAuditSink` 负责审计
+
+## Token 效率
+
+`/v1/search` 的命中结果**故意省略** `input_schema`。回归测试断言每个序列化后的 `SkillListEntry` 不超过 `SEARCH_HIT_BUDGET_BYTES`（当前为 512 字节），Agent 每轮可以翻页数百个能力，不会消耗过多上下文。Schema 通过 `POST /v1/describe` 的 `include_schema: true`（默认值）按需获取。
+
+## 企业级控制（#660）
+
+- **版本化路径** — `/v1/*` 是稳定契约
+- **结构化错误** — 单一信封 `{kind, message, hint, request_id, candidates?}`，`kind` 为 kebab-case（`unknown-slug`、`ambiguous`、`skill-not-loaded`、`invalid-params`、`unauthorized`、`bad-request`、`affinity-violation`、`not-ready`、`backend-error`、`internal`）
+- **认证门** — 可插拔 `AuthGate`。默认 `AllowLocalhostGate` 拒绝非回环地址。通过安装 `BearerTokenGate::new(vec![token])` 并将监听器绑定到非回环接口来启用远程调用
+- **审计 Sink** — 每次调用发出一个 `AuditEvent`（`{request_id, at, slug, route, subject, outcome, duration_ms}`）
+- **三状态就绪** — `进程 / 分发器 / DCC`。在所有三项均为绿色之前，`/v1/call` 返回 `503 not-ready`
+- **OpenAPI** — 由 `utoipa` 从请求/响应类型的 `ToSchema` derive 自动生成，无需手动维护 JSON
+
+## 接线示例
+
+```rust
+use std::sync::Arc;
+use axum::Router;
+use dcc_mcp_actions::{ActionDispatcher, ActionRegistry};
+use dcc_mcp_http::{
+    AllowLocalhostGate, BearerTokenGate, NoopAuditSink, SkillRestConfig,
+    SkillRestService, StaticReadiness, build_skill_rest_router,
+};
+use dcc_mcp_skills::SkillCatalog;
+
+fn build_dcc_app(
+    registry: Arc<ActionRegistry>,
+    dispatcher: Arc<ActionDispatcher>,
+) -> Router {
+    let catalog = Arc::new(SkillCatalog::new_with_dispatcher(
+        registry.clone(),
+        dispatcher.clone(),
+    ));
+    let service = SkillRestService::from_catalog_and_dispatcher(catalog, dispatcher);
+    let cfg = SkillRestConfig::new(service)
+        .with_auth(Arc::new(AllowLocalhostGate::new()))
+        .with_audit(Arc::new(NoopAuditSink))
+        .with_readiness(Arc::new(StaticReadiness::fully_ready()));
+    build_skill_rest_router(cfg)
+}
+```
+
+## 调用模式
+
+```bash
+# 1. 搜索紧凑命中
+curl -s localhost:8765/v1/search -d '{"query":"sphere"}' -H 'content-type: application/json'
+
+# 2. 获取某个 slug 的 schema
+curl -s localhost:8765/v1/describe \
+  -d '{"tool_slug":"maya.spheres.create_sphere","include_schema":true}' \
+  -H 'content-type: application/json'
+
+# 3. 调用
+curl -s localhost:8765/v1/call \
+  -d '{"tool_slug":"maya.spheres.create_sphere","params":{"radius":1.5}}' \
+  -H 'content-type: application/json'
+```

--- a/docs/zh/guide/host-adapter.md
+++ b/docs/zh/guide/host-adapter.md
@@ -1,0 +1,160 @@
+# 编写 DCC 宿主适配器
+
+> **目标读者**：构建 DCC 集成仓库的开发者
+> （`dcc-mcp-blender`、`dcc-mcp-maya`、`dcc-mcp-photoshop`、
+> `dcc-mcp-unreal` 或新的集成仓库）。
+>
+> **摘要**：子类化 [`dcc_mcp_core.host.HostAdapter`][HostAdapter]，
+> 实现 3 个方法，接线一个入口点。基类处理其余的一切——生命周期、上下文管理器、自适应时钟间隔以及交互式/后台分离。
+
+本指南假设你已经理解主线程亲和性的重要性——如果不了解，请先阅读 [`dcc-thread-safety.md`][thread-safety]。
+
+## 3-hook 契约
+
+`HostAdapter` 要求每个子类恰好实现三个方法。
+
+| Hook | 用途 | 调用时机 |
+|------|------|---------|
+| `is_background() -> bool` | DCC 是否以无头模式运行？ | 每次 `start()` 调用时执行一次 |
+| `attach_tick(tick_fn)` | 将 `tick_fn` 注册到 DCC 的原生空闲原语 | 交互模式下 `start()` 期间执行一次 |
+| `detach_tick()` | 撤销 `attach_tick`——必须幂等 | `stop()` 期间 |
+
+**不要**覆盖 `start`、`stop`、`run_headless`、`is_running`、`__enter__` 或 `__exit__`。这些方法编排这 3 个 hook，必须在所有适配器中保持一致，以便调用者可以互换使用它们（LSP）。
+
+## 最简子类
+
+```python
+from dcc_mcp_core.host import HostAdapter
+
+
+class BlenderHost(HostAdapter):
+    def is_background(self) -> bool:
+        import bpy
+        return bpy.app.background
+
+    def attach_tick(self, tick_fn):
+        import bpy
+        # 返回 ``tick_fn`` 以便每次定时器触发时重用同一个可调用对象，
+        # 这样 `detach_tick` 可以找到并注销它。
+        bpy.app.timers.register(tick_fn, first_interval=0.0, persistent=True)
+        self._tick_fn = tick_fn
+
+    def detach_tick(self) -> None:
+        import bpy
+        fn = getattr(self, "_tick_fn", None)
+        if fn is not None and bpy.app.timers.is_registered(fn):
+            bpy.app.timers.unregister(fn)
+        self._tick_fn = None
+```
+
+完成。这就是整个适配器。其余所有内容——panic 处理、停止时的分发器关闭、"等待最多 5 秒让无头线程加入"的保障、队列繁忙时返回 0 秒/空闲时返回 0.5 秒的自适应间隔——都在基类中。
+
+## 接线到 MCP 服务器
+
+适配器**驱动**分发器；它不拥有分发器。入口点同时拥有两者：
+
+```python
+from dcc_mcp_core import McpHttpConfig, McpHttpServer, ToolRegistry
+from dcc_mcp_core.host import BlockingDispatcher
+
+# 1. 构建服务器
+reg = ToolRegistry()
+cfg = McpHttpConfig(port=18765, server_name="blender")
+server = McpHttpServer(reg, cfg)
+
+# 2. 创建分发器。BlockingDispatcher 适用于 --background DCC；
+#    QueueDispatcher 适用于 GUI 会话。两者均被 HostAdapter、
+#    McpHttpServer.attach_dispatcher 和 StandaloneHost 接受（实践中的 LSP）。
+dispatcher = BlockingDispatcher()
+server.attach_dispatcher(dispatcher)
+
+# 3. 启动服务器。立即返回——只绑定端口并生成 tokio 运行时。
+handle = server.start()
+
+# 4. 用适配器驱动分发器。
+host = BlenderHost(dispatcher)
+if host.is_background():
+    host.run_headless()   # 阻塞直到关闭
+else:
+    host.start()          # 非阻塞；立即返回
+```
+
+到达 HTTP 端口的每个 `tools/call` 现在都会被投入分发器，并在驱动 `host._tick` 的任何线程上执行——即交互模式下的 DCC 主线程，或无头模式下的 `run_headless` 线程。处理器永远不会看到 tokio 工作线程。
+
+## Maya 示例
+
+```python
+class MayaHost(HostAdapter):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._script_job = None
+
+    def is_background(self) -> bool:
+        import maya.cmds as cmds
+        return cmds.about(batch=True)
+
+    def attach_tick(self, tick_fn):
+        import maya.cmds as cmds
+        # `idleEvent` 在 UI 空闲时触发——原生主线程。
+        # 用 lambda 包装使 `tick_fn` 的返回值被丢弃
+        # （scriptJob 不关心下一个间隔）。
+        self._script_job = cmds.scriptJob(
+            idleEvent=lambda: tick_fn(),
+        )
+
+    def detach_tick(self) -> None:
+        import maya.cmds as cmds
+        if self._script_job is not None and cmds.scriptJob(
+            exists=self._script_job,
+        ):
+            cmds.scriptJob(kill=self._script_job)
+        self._script_job = None
+```
+
+Maya 的 `idleEvent` 比 Blender 的定时器触发更频繁，因此默认的 `tick_interval_idle=0.5` 足够保守。如果 CPU 使用率过高，将 `tick_interval_idle` 提高到 `1.0`。
+
+## 仅无头模式的 DCC（ExtendScript、MaxScript）
+
+当 DCC 没有可从 Python 调用的空闲原语（Adobe Photoshop 的 ExtendScript、3ds Max 2022 之前的 MAXScript 桥接……）时，以完全无头模式运行：
+
+```python
+class PhotoshopHost(HostAdapter):
+    def is_background(self) -> bool:
+        return True  # 始终无头——无 ExtendScript UI 空闲 hook
+
+    def attach_tick(self, tick_fn):
+        # 永远不会被调用（is_background 始终为 True）。
+        raise NotImplementedError(
+            "PhotoshopHost 始终无头；run_headless 是唯一路径",
+        )
+
+    def detach_tick(self) -> None:
+        pass  # 空操作；没有任何内容被附加
+```
+
+入口点随后无条件调用 `host.run_headless()`。
+
+## 可替换性测试
+
+每个行为良好的子类都应通过相同的契约测试，这本质上就是 `tests/test_host_adapter.py::test_subclass_overriding_hooks_drives_dispatcher` 已在假子类上演练的内容。将其复制到你的仓库，替换为真实子类，你就有了一个 CI 门控：
+
+```python
+def test_my_host_drives_dispatcher(live_dcc_fixture):
+    dispatcher = QueueDispatcher()
+    host = MyDccHost(dispatcher)
+    with host:
+        result = dispatcher.post(lambda: 42).wait(timeout=5.0)
+    assert result == 42
+```
+
+## 开设 DCC 集成仓库时的检查清单
+
+- [ ] 子类化 `HostAdapter`，实现 3 个 hook
+- [ ] 附带至少一个示例技能（单个工具即可），证明 `bpy.ops` / `maya.cmds` / 等效函数可在主线程上工作
+- [ ] 添加 CI 作业：以无头模式启动 DCC，对实时服务器运行 `mcporter` 调用，并断言成功
+- [ ] 编写 `README.md` 指回本文档，使未来维护者理解契约
+- [ ] 在你的仓库中开一个跟踪 issue；交叉引用核心的 [总揽 issue][umbrella]，使进度跨仓库可见
+
+[HostAdapter]: https://github.com/loonghao/dcc-mcp-core/blob/main/python/dcc_mcp_core/host/_adapter.py
+[thread-safety]: ./dcc-thread-safety.md
+[umbrella]: https://github.com/loonghao/dcc-mcp-core/issues/690

--- a/docs/zh/guide/middleware.md
+++ b/docs/zh/guide/middleware.md
@@ -1,0 +1,108 @@
+# 网关中间件链
+
+网关支持可插拔的 `BeforeCall` / `AfterCall` 中间件链，应用于每一次 `tools/call` 分发（issue #770）。
+
+## 快速开始
+
+```rust
+use dcc_mcp_gateway::gateway::middleware::{
+    AuditMiddleware, MiddlewareChain, QuotaMiddleware, RedactionMiddleware,
+};
+use std::sync::Arc;
+
+let config = GatewayConfig {
+    middleware_chain: MiddlewareChain::new()
+        .with_before(Arc::new(AuditMiddleware::default()))
+        .with_before(Arc::new(QuotaMiddleware::new(100)))  // 每分钟 100 次
+        .with_before(Arc::new(RedactionMiddleware::new(["api_key", "token"]))),
+    ..GatewayConfig::default()
+};
+```
+
+## 内置中间件
+
+| 中间件 | 用途 | 失败行为 |
+|--------|------|---------|
+| `AuditMiddleware` | 每次 `tools/call` 时输出一条 `tracing::info!` 结构化日志，包含方法、工具名、DCC 类型、会话 ID、耗时及结果 | 永不阻断 |
+| `QuotaMiddleware::new(N)` | 全局每分钟最多 N 次调用；超出时返回 `MiddlewareError::QuotaExceeded` | 中止调用，返回 429 等效错误 |
+| `RedactionMiddleware::new(fields)` | 将匹配字段的参数值替换为 `"[REDACTED]"`，防止日志或转发中泄露敏感信息 | 永不失败 |
+
+## 自定义中间件
+
+实现 `BeforeCallMiddleware` 或 `AfterCallMiddleware` trait：
+
+```rust
+use dcc_mcp_gateway::gateway::middleware::{
+    AfterCallMiddleware, BeforeCallMiddleware, CallContext, CallResult, MiddlewareError,
+};
+
+pub struct MyMiddleware;
+
+#[async_trait::async_trait]
+impl BeforeCallMiddleware for MyMiddleware {
+    async fn before_call(&self, ctx: &mut CallContext) -> Result<(), MiddlewareError> {
+        // 在调用分发前检查或修改 ctx
+        tracing::info!(tool = ?ctx.tool_slug, dcc = ?ctx.dcc_type, "自定义前置中间件");
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl AfterCallMiddleware for MyMiddleware {
+    async fn after_call(
+        &self,
+        ctx: &mut CallContext,
+        result: &mut CallResult,
+    ) -> Result<(), MiddlewareError> {
+        tracing::info!(success = result.success, "自定义后置中间件");
+        Ok(())
+    }
+}
+```
+
+注册方式：
+
+```rust
+MiddlewareChain::new()
+    .with_before(Arc::new(MyMiddleware))
+    .with_after(Arc::new(MyMiddleware))
+```
+
+## `CallContext` 字段
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `method` | `String` | MCP 方法名（`tools/call`、`tools/list` 等） |
+| `tool_slug` | `Option<String>` | 工具名称 |
+| `dcc_type` | `Option<String>` | DCC 类型（`maya`、`blender` 等） |
+| `session_id` | `Option<String>` | MCP 会话 ID |
+| `request_id` | `String` | 每次请求的唯一 ID（与审计日志 `request_id` 对应） |
+| `args` | `serde_json::Value` | 工具参数（可变；`RedactionMiddleware` 会修改此字段） |
+| `metadata` | `HashMap<String, String>` | 中间件间传递数据的通用容器 |
+
+## 执行顺序
+
+```
+请求 → BeforeCall[0] → BeforeCall[1] → ... → 分发 → AfterCall[0] → AfterCall[1] → 响应
+```
+
+若任意 `before_call` 返回 `Err`，调用将被中止，后续中间件不再执行。
+
+## 与 Admin UI 集成
+
+`AuditMiddleware` 会填充 `/admin/api/calls` 数据源。同时开启两者可在仪表盘中查看实时调用历史：
+
+```rust
+GatewayConfig {
+    admin_enabled: true,
+    middleware_chain: MiddlewareChain::new()
+        .with_before(Arc::new(AuditMiddleware::default())),
+    ..GatewayConfig::default()
+}
+```
+
+## 参见
+
+- [admin-ui.md](admin-ui.md) — 消费审计数据的仪表盘
+- [gateway.md](gateway.md) — 完整的网关配置参考
+- [observability.md](observability.md) — OTLP 追踪（中间件可通过 `CallContext` 丰富 span 属性）

--- a/docs/zh/guide/observability.md
+++ b/docs/zh/guide/observability.md
@@ -1,0 +1,176 @@
+# 可观测性
+
+dcc-mcp-core 提供三种互补的可观测性接口，适用于生产环境部署。
+
+## 1. OTLP 分布式追踪（#768）
+
+将 span 数据发送到任何兼容 OpenTelemetry 的后端（Jaeger、Grafana Tempo、DataDog、New Relic 等）。
+
+### 激活方式
+
+设置标准 `OTEL_*` 环境变量——无需修改代码：
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
+OTEL_SERVICE_NAME=dcc-mcp-gateway \
+  dcc-mcp-server ...
+```
+
+### 环境变量
+
+| 变量 | 说明 |
+|------|------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector 端点——设置此变量后自动启用 OTLP |
+| `OTEL_SERVICE_NAME` | 覆盖追踪中的服务名 |
+| `OTEL_RESOURCE_ATTRIBUTES` | 额外资源属性（`key=val,key2=val2`） |
+| `OTEL_EXPORTER_OTLP_HEADERS` | SaaS 后端的认证 Header（如 `api-key=...`） |
+| `OTEL_TRACES_SAMPLER` | 采样器类型（`always_on`、`always_off`、`traceidratio`） |
+| `OTEL_TRACES_SAMPLER_ARG` | 采样器参数（如 `0.1` 表示 10% 采样率） |
+
+### DCC Span 属性
+
+每次 `tools/call` 追踪均包含：
+
+| 属性 | 示例 | 说明 |
+|------|------|------|
+| `dcc.type` | `"maya"` | DCC 应用类型 |
+| `dcc.instance_id` | `"a1b2c3d4-..."` | DCC 实例唯一 UUID |
+| `dcc.scene` | `"/projects/shot01.ma"` | 当前场景路径（已知时） |
+| `dcc.job_id` | `"job-..."` | 作业 ID（被 `JobHandle` 包装时） |
+| `mcp.method` | `"tools/call"` | MCP 方法名 |
+| `mcp.tool_slug` | `"maya__open_scene"` | 完整工具名 |
+| `mcp.affinity` | `"main"` | 线程亲和性要求 |
+| `mcp.session_id` | `"sess-..."` | MCP 会话 ID |
+| `mcp.request_id` | `"req-..."` | 每次请求的唯一 ID |
+
+### Rust 编程式配置
+
+```rust
+use dcc_mcp_telemetry::{TelemetryConfig, ExporterBackend};
+
+TelemetryConfig::default()
+    .with_otlp_exporter("http://localhost:4317")
+    .init()?;
+```
+
+需要启用 `otlp-exporter` Cargo feature：
+
+```toml
+dcc-mcp-telemetry = { features = ["otlp-exporter"] }
+```
+
+### 快速启动：Jaeger All-in-One
+
+```bash
+docker run -d --name jaeger \
+  -p 4317:4317 \   # OTLP gRPC
+  -p 16686:16686 \ # Jaeger UI
+  jaegertracing/all-in-one:latest
+
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
+OTEL_SERVICE_NAME=dcc-mcp-gateway \
+  dcc-mcp-server ...
+```
+
+打开 `http://localhost:16686` 查看追踪数据。
+
+### 快速启动：Grafana Tempo
+
+```bash
+# docker-compose.yml
+services:
+  tempo:
+    image: grafana/tempo:latest
+    ports: ["4317:4317", "3200:3200"]
+```
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 dcc-mcp-server ...
+```
+
+---
+
+## 2. 网关竞争事件（#766）
+
+网关选举、驱逐和探针事件可通过有界 MCP 资源获取。
+
+### MCP 资源
+
+```python
+# 读取最近 N 条竞争事件
+result = resources.read("resources://gateway/events")
+```
+
+返回 JSONL 格式（每行一个 JSON 对象）：
+
+```json
+{"timestamp":"2026-05-05T10:00:00Z","event":"election_won","dcc_type":"maya","instance_id":"a1b2c3d4","reason":null}
+{"timestamp":"2026-05-05T10:01:00Z","event":"ghost_reaped","dcc_type":"blender","instance_id":"b2c3d4e5","reason":"pid_dead"}
+```
+
+### 事件类型
+
+| 事件 | 含义 |
+|------|------|
+| `election_won` | 本实例成为活跃网关 |
+| `voluntary_yield` | 本实例主动让位给更新的候选者 |
+| `ghost_reaped` | 清理了一条过期注册记录 |
+| `probe_booting` | 后端正在启动中 |
+| `probe_unreachable` | 健康探针失败 |
+| `auto_deregister` | 实例在干净关闭时自注销 |
+
+环形缓冲区保留**最近 1000 条事件**。
+
+---
+
+## 3. Prometheus 指标（#766）
+
+在 `prometheus` Cargo feature 下，网关竞争计数器通过 `/metrics` 端点暴露：
+
+```toml
+dcc-mcp-gateway = { features = ["prometheus"] }
+```
+
+### 计数器
+
+```
+# 网关端口选举结果
+dcc_mcp_gateway_elections_total{outcome="won"}     12
+dcc_mcp_gateway_elections_total{outcome="yielded"}  3
+dcc_mcp_gateway_elections_total{outcome="lost"}     1
+
+# 注册表驱逐事件
+dcc_mcp_gateway_evictions_total{reason="stale"}    1
+dcc_mcp_gateway_evictions_total{reason="ghost"}    0
+dcc_mcp_gateway_evictions_total{reason="probe_fail"} 2
+
+# 后端就绪探针结果
+dcc_mcp_gateway_probes_total{outcome="ready"}      45
+dcc_mcp_gateway_probes_total{outcome="booting"}     3
+dcc_mcp_gateway_probes_total{outcome="unreachable"} 2
+```
+
+标签基数有界——不含自由形式的 `instance_id` 标签。
+
+### Grafana 示例查询
+
+```promql
+# 选举速率随时间变化
+rate(dcc_mcp_gateway_elections_total[5m])
+
+# 驱逐速率
+rate(dcc_mcp_gateway_evictions_total[5m])
+
+# 探针成功率
+rate(dcc_mcp_gateway_probes_total{outcome="ready"}[5m])
+  / rate(dcc_mcp_gateway_probes_total[5m])
+```
+
+---
+
+## 参见
+
+- [telemetry.md](telemetry.md) — `ToolMetrics`、`ToolRecorder`、旧版 Python 遥测
+- [gateway-diagnostics.md](gateway-diagnostics.md) — 选举/驱逐事件的日志模板
+- [production-deployment.md](production-deployment.md) — 生产环境监控检查清单
+- [middleware.md](middleware.md) — 用于每次调用审计日志的 `AuditMiddleware`

--- a/docs/zh/guide/openapi-mount.md
+++ b/docs/zh/guide/openapi-mount.md
@@ -1,0 +1,101 @@
+# OpenAPI → MCP 挂载助手
+
+通过单个配置块，将任意现有 REST API 暴露为网关中的 MCP 工具（issue #773）。
+
+## 快速开始
+
+```rust
+gateway_builder.mount_openapi(
+    OpenApiMount::from_url("https://api.example.com/openapi.json")
+        .base_url("https://api.example.com")
+        .auth(AuthConfig::bearer("$MY_API_TOKEN"))
+        .tool_prefix("example"),
+)
+```
+
+这会为每个 OpenAPI 操作生成一个 MCP 工具。工具名遵循 `{prefix}__{operationId}` 格式；若 `operationId` 缺失，则使用 `{prefix}__{method}_{path_sanitized}`。
+
+## 工作原理
+
+1. **解析 spec** — `OpenApiMount` 获取并解析 OpenAPI 3.x JSON spec
+2. **生成工具** — 每个操作生成一个 MCP 工具；`inputSchema` 由 `requestBody` + `parameters` 构建
+3. **HTTP 转发** — 调用 `tools/call` 时，将路径/查询/请求体参数映射并转发给后端，同时注入认证 Header
+
+## `OpenApiMount` 构建器
+
+```rust
+OpenApiMount::from_url("https://api.example.com/openapi.json")
+    // 必填：后端基础 URL
+    .base_url("https://api.example.com")
+    // 可选：认证转发
+    .auth(AuthConfig::bearer("$MY_API_TOKEN"))
+    // 可选：所有生成工具名的前缀（避免命名冲突）
+    .tool_prefix("example")
+```
+
+## 认证配置
+
+| 方法 | 说明 |
+|------|------|
+| `AuthConfig::bearer("$TOKEN")` | `Authorization: Bearer <token>` — `$ENV_VAR` 引用在调用时解析 |
+| `AuthConfig::api_key("X-Api-Key", "$KEY")` | 自定义 Header 注入 |
+| `AuthConfig::basic("$USER", "$PASS")` | HTTP Basic 认证（base64 编码） |
+
+环境变量引用（`$VAR_NAME`）在调用时而非挂载时解析。若变量未设置，则省略该 Header。
+
+## 生成的工具 Schema 示例
+
+对于带 JSON 请求体的 `POST /pets` 操作：
+
+```json
+{
+  "name": "example__createPet",
+  "description": "创建新宠物",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "name": { "type": "string" },
+      "species": { "type": "string" }
+    },
+    "required": ["name"]
+  }
+}
+```
+
+## 参数映射
+
+| OpenAPI 位置 | 映射方式 |
+|-------------|---------|
+| `path` 参数（`/pets/{petId}`） | 替换 URL 路径中的占位符 |
+| `query` 参数 | 作为 `?key=value` 追加到 URL |
+| `requestBody`（JSON） | 序列化为 JSON 请求体 |
+
+## 错误处理
+
+后端返回 HTTP 4xx/5xx 响应时，映射为 `CallError::BackendError { status, body }`。
+
+## 网关注册
+
+```rust
+impl GatewayBuilder {
+    pub fn mount_openapi(mut self, mount: OpenApiMount) -> Self { ... }
+}
+
+// 挂载多个 API
+gateway_builder
+    .mount_openapi(OpenApiMount::from_url("...").tool_prefix("api1"))
+    .mount_openapi(OpenApiMount::from_url("...").tool_prefix("api2"))
+```
+
+## 限制
+
+- 仅支持 OpenAPI 3.x JSON spec（YAML 可通过字符串转换）
+- `$ref` 解析仅限于单层内联引用
+- 尚不支持文件上传（`multipart/form-data`）
+- WebSocket / 流式操作不作为 MCP 工具暴露
+
+## 参见
+
+- [gateway.md](gateway.md) — 完整的网关配置参考
+- [middleware.md](middleware.md) — 通过 `BeforeCallMiddleware` 添加认证转发策略
+- [rest-api-surface.md](rest-api-surface.md) — 每个 DCC 的 REST 技能 API

--- a/docs/zh/guide/rez-skill-packages.md
+++ b/docs/zh/guide/rez-skill-packages.md
@@ -1,0 +1,83 @@
+# Rez 技能包
+
+Rez 非常适合分发 DCC MCP 技能，因为它在应用程序启动前就已经解析了项目、部门、任务、资产和 DCC 特定的包上下文。`dcc-mcp-core` 不替代 Rez；它读取已解析的环境并仅暴露活跃的技能接口。
+
+## 包布局
+
+将每个包的范围限定于单一制作关注点，而不是将所有工具打包到一个工作室级的巨型包中。
+
+```text
+show_a_lighting_mcp_skills/
+├── package.py
+├── skills/
+│   └── show-a-lighting/
+│       ├── SKILL.md
+│       ├── tools.yaml
+│       ├── prompts.yaml
+│       ├── resources/
+│       └── scripts/
+├── resources/
+└── prompts/
+```
+
+`SKILL.md` 的扩展应放在 `metadata.dcc-mcp.*` 下，并指向同级文件，如 `tools.yaml`、`groups.yaml`、`prompts.yaml` 和 recipes。包级文件可以放在 `skills/` 旁边，在上下文解析时添加到环境中。
+
+## 环境变量契约
+
+共享包使用通用路径变量，DCC 特定的包仅在一个宿主中加载时使用 DCC 特定变量。
+
+| 变量 | 用途 |
+|------|------|
+| `DCC_MCP_SKILL_PATHS` | 共享技能目录，使用平台路径分隔符 |
+| `DCC_MCP_<DCC>_SKILL_PATHS` | DCC 特定技能目录，例如 `DCC_MCP_MAYA_SKILL_PATHS` |
+| `DCC_MCP_RESOURCE_PATHS` | 共享 MCP 资源根目录 |
+| `DCC_MCP_PROMPT_PATHS` | 共享 Prompt 根目录 |
+| `DCC_MCP_CONTEXT_BUNDLE` | 稳定的包标识符，如 `show-a.seq010.shot020.lighting` |
+| `DCC_MCP_PRODUCTION_DOMAIN` | 广域领域，如 `film`、`advertising`、`game` 或 `asset` |
+| `DCC_MCP_CONTEXT_KIND` | 上下文形状，如 `shot`、`deliverable`、`level` 或 `asset` |
+| `DCC_MCP_TOOLSET_PROFILE` | 适配器或网关使用的默认 profile 名称 |
+| `DCC_MCP_PACKAGE_PROVENANCE` | 用于审计输出的分号分隔包/版本来源信息 |
+
+DCC 特定路径是累加的。Maya 启动可以通过 `DCC_MCP_SKILL_PATHS` 解析共享的工作室技能，并通过 `DCC_MCP_MAYA_SKILL_PATHS` 添加镜头灯光工具；同一镜头中的 Houdini 启动则会解析不同的 DCC 特定路径，同时保持相同的包标识符。
+
+## Rez 示例
+
+```python
+name = "show_a_lighting_mcp_skills"
+version = "3.4.1"
+requires = ["dcc_mcp_core", "dcc_mcp_maya", "maya_scene_skills-1.2+"]
+
+def commands():
+    env.DCC_MCP_CONTEXT_BUNDLE = "show-a.seq010.shot020.lighting"
+    env.DCC_MCP_PRODUCTION_DOMAIN = "film"
+    env.DCC_MCP_CONTEXT_KIND = "shot"
+    env.DCC_MCP_PROJECT = "show-a"
+    env.DCC_MCP_SEQUENCE = "seq010"
+    env.DCC_MCP_SHOT = "shot020"
+    env.DCC_MCP_TASK = "lighting"
+    env.DCC_MCP_TOOLSET_PROFILE = "film-shot-lighting"
+    env.DCC_MCP_PACKAGE_PROVENANCE.append("{name}-{version}")
+    env.DCC_MCP_MAYA_SKILL_PATHS.append("{root}/skills")
+    env.DCC_MCP_RESOURCE_PATHS.append("{root}/resources")
+```
+
+`DccServerBase` 将这些上下文值复制到 `McpHttpConfig.instance_metadata`。网关随后从 `list_dcc_instances` 返回它们，客户端可以路由到匹配请求包的已启动实例。
+
+## 来源追踪
+
+以包标识符而非绝对构建路径的形式记录来源。`show_a_lighting_mcp_skills-3.4.1;maya_scene_skills-1.2.0` 这样的紧凑值更易于在审计日志中搜索，并避免泄露工作站路径。
+
+技能来源应与包来源对齐：
+
+- `SKILL.md` 声明技能版本和 `metadata.dcc-mcp.layer`
+- `package.py` 声明 Rez 包版本并贡献 `DCC_MCP_PACKAGE_PROVENANCE`
+- 审计/调试输出可以同时显示已加载的技能版本和使其可用的包集合
+
+## 迁移说明
+
+对于现有的松散技能目录，为每个上下文切片创建一个 Rez 包，并将目录移动到 `skills/` 下。从共享的工作室原语开始，仅在工具接口有实质性差异时才拆分项目、部门和任务包。避免每个部门默认加载的全包；它会重新造成 MCP 上下文膨胀，使 Agent 更难以理解 `tools/list`。
+
+参见 [context-bundles.md](context-bundles.md)、[gateway.md](gateway.md)，以及
+[#611](https://github.com/loonghao/dcc-mcp-core/issues/611) 中的 toolset-profile 设计、
+[#608](https://github.com/loonghao/dcc-mcp-core/issues/608) 中的 instruction resources 和
+[#616](https://github.com/loonghao/dcc-mcp-core/issues/616) 中的 recipe packs。

--- a/docs/zh/guide/translate.md
+++ b/docs/zh/guide/translate.md
@@ -1,0 +1,111 @@
+# translate 子命令 — 将 stdio MCP 服务器桥接到 HTTP/SSE
+
+`translate` 子命令将任意 stdio MCP 服务器桥接到 HTTP/SSE/Streamable-HTTP 传输（issue #769）。
+
+## 使用场景
+
+- 将 `filesystem`、`git`、`sqlite`、`brave-search` 等只支持 stdio 的 MCP 服务器暴露为 HTTP 服务
+- 让 Cursor、Claude Desktop 或任何 HTTP 优先的 Agent 连接到 stdio MCP 服务器
+- 在单个网关端点后运行多个 stdio MCP 服务器
+- 通过标准 HTTP 工具测试 stdio MCP 服务器
+
+## 快速开始
+
+```bash
+dcc-mcp-server translate \
+  --stdio "npx @modelcontextprotocol/server-filesystem /tmp" \
+  --dcc-type filesystem \
+  --port 3333 \
+  --transport sse
+```
+
+## CLI 参数
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--stdio <cmd>` | 必填 | 启动 stdio MCP 服务器的 Shell 命令 |
+| `--port <N>` | `0`（OS 分配） | HTTP 监听端口 |
+| `--transport <sse\|streamable-http>` | `sse` | HTTP 传输协议 |
+| `--dcc-type <type>` | `stdio` | 用于网关注册的 DCC 类型标签 |
+| `--host <addr>` | `127.0.0.1` | 监听地址 |
+| `--no-register` | false | 跳过网关选举（独立运行模式） |
+| `--restart-on-exit` | false | stdio 进程退出后自动重启（supervisor 模式） |
+| `--max-restarts <N>` | `5` | supervisor 最大重启次数，超出后放弃 |
+| `--stale-timeout-secs <N>` | `30` | 网关选举的过期超时 |
+| `--registry-dir <path>` | 自动 | 自定义注册表目录 |
+
+## 示例
+
+### filesystem MCP 服务器
+
+```bash
+dcc-mcp-server translate \
+  --stdio "npx -y @modelcontextprotocol/server-filesystem /home/user/projects" \
+  --dcc-type filesystem \
+  --port 4000
+```
+
+### 带 supervisor 重启的 git MCP 服务器
+
+```bash
+dcc-mcp-server translate \
+  --stdio "uvx mcp-server-git --repository /path/to/repo" \
+  --dcc-type git \
+  --port 4001 \
+  --restart-on-exit \
+  --max-restarts 10
+```
+
+### 独立模式（不注册网关）
+
+```bash
+dcc-mcp-server translate \
+  --stdio "python -m my_mcp_server" \
+  --no-register \
+  --port 4002
+```
+
+## Cursor / Claude Desktop 配置
+
+将 AI 客户端指向转换后的端点：
+
+```json
+// .cursor/mcp.json 或 claude_desktop_config.json
+{
+  "mcpServers": {
+    "filesystem": {
+      "url": "http://localhost:4000/sse"
+    },
+    "git": {
+      "url": "http://localhost:4001/sse"
+    }
+  }
+}
+```
+
+使用 Streamable HTTP 传输时：
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "url": "http://localhost:4000/mcp",
+      "transport": "streamable-http"
+    }
+  }
+}
+```
+
+## 实现说明
+
+- **异步 Actor 模型**：一个 Tokio 任务通过 mpsc channel 管理子进程的 stdin/stdout
+- **并发请求**：通过请求/响应 ID 追踪支持多个并发请求
+- **通知处理**：无 `id` 字段的 JSON 消息（通知）转发给所有已连接的 SSE 客户端
+- **Supervisor 重启**：采用指数退避策略（最大间隔 30 秒）
+- **网关注册**：若未指定 `--no-register`，桥接器会作为 DCC 实例参与网关选举
+
+## 参见
+
+- [gateway.md](gateway.md) — 网关注册与选举
+- [tunnel-relay.md](tunnel-relay.md) — 外部/互联网访问的远程中继
+- [rest-api-surface.md](rest-api-surface.md) — 每个 DCC 的 REST API 接口

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3052,3 +3052,112 @@ Keep `SKILL.md` body < 500 lines / < 5000 tokens; move details to `references/` 
 
 - [dcc-mcp-rpyc](https://github.com/loonghao/dcc-mcp-rpyc) — RPyC bridge for remote DCC operations
 - [dcc-mcp-maya](https://github.com/loonghao/dcc-mcp-maya) — Maya MCP server implementation
+
+---
+
+## New in this milestone (issues #764–#774)
+
+### Rust Gateway: Middleware Chain (#770)
+
+```rust
+use dcc_mcp_gateway::gateway::middleware::{
+    AuditMiddleware, MiddlewareChain, QuotaMiddleware, RedactionMiddleware,
+};
+use std::sync::Arc;
+
+let config = GatewayConfig {
+    middleware_chain: MiddlewareChain::new()
+        .with_before(Arc::new(AuditMiddleware::default()))
+        .with_before(Arc::new(QuotaMiddleware::new(100)))
+        .with_before(Arc::new(RedactionMiddleware::new(["api_key", "token"]))),
+    ..GatewayConfig::default()
+};
+```
+
+Custom: implement `BeforeCallMiddleware` / `AfterCallMiddleware` traits.
+`CallContext`: `method`, `tool_slug`, `dcc_type`, `session_id`, `request_id`, `args`, `metadata`.
+
+### Rust Gateway: OpenAPI → MCP Bridge (#773)
+
+```rust
+gateway_builder.mount_openapi(
+    OpenApiMount::from_url("https://api.example.com/openapi.json")
+        .base_url("https://api.example.com")
+        .auth(AuthConfig::bearer("$MY_API_TOKEN"))
+        .tool_prefix("example"),
+)
+```
+
+Auth types: `bearer()`, `api_key()`, `basic()`. `$ENV_VAR` references resolved at call time.
+
+### Rust Server: stdio → HTTP Bridge (#769)
+
+```bash
+dcc-mcp-server translate \
+  --stdio "npx @modelcontextprotocol/server-filesystem /tmp" \
+  --dcc-type filesystem --port 3333 --transport sse
+# Flags: --no-register, --restart-on-exit, --max-restarts N
+```
+
+### Rust Gateway: Admin Dashboard (#772)
+
+```rust
+GatewayConfig { admin_enabled: true, admin_path: "/admin".into(), .. }
+// requires: dcc-mcp-gateway = { features = ["admin"] }
+// routes: GET /admin (HTML), GET /admin/api/{instances,tools,calls,logs,health}
+```
+
+### OTLP Distributed Tracing (#768)
+
+```bash
+# Environment variable (auto-activates OTLP)
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 dcc-mcp-server ...
+```
+
+```rust
+// Programmatic (requires otlp-exporter Cargo feature)
+TelemetryConfig::default().with_otlp_exporter("http://localhost:4317").init()?;
+```
+
+DCC span attrs: `dcc.type`, `dcc.instance_id`, `dcc.scene`, `mcp.method`, `mcp.tool_slug`, `mcp.session_id`, `mcp.request_id`, `dcc.job_id`.
+
+### DCC-MCP Catalog (#774)
+
+```python
+# MCP tools auto-registered on the gateway
+tools.call("dcc_catalog__search", {"query": "maya"})
+tools.call("dcc_catalog__describe", {"name": "dcc-mcp-maya-skills"})
+```
+
+```bash
+dcc-mcp-server catalog search --query maya
+dcc-mcp-server catalog describe --name dcc-mcp-maya-skills
+# Override: DCC_MCP_CATALOG_PATH=/path/to/dcc-mcp-catalog.yml
+```
+
+### Gateway Observability (#766)
+
+```
+# Prometheus (under `prometheus` Cargo feature)
+dcc_mcp_gateway_elections_total{outcome="won|yielded|lost"}
+dcc_mcp_gateway_evictions_total{reason="stale|ghost|probe_fail"}
+dcc_mcp_gateway_probes_total{outcome="ready|booting|unreachable"}
+
+# MCP resource (always available)
+resources://gateway/events  →  JSONL ring buffer, last 1000 contention events
+```
+
+### Payload Limits (#771)
+
+```rust
+// Rust McpHttpConfig sub-config (queue)
+McpHttpConfig.queue.max_request_body_bytes     // default 4 MiB → 413 on overflow
+McpHttpConfig.queue.max_response_content_bytes // default 1 MiB → TruncationEnvelope
+McpHttpConfig.queue.sse_chunk_size_bytes        // default 64 KiB → auto SSE chunking
+```
+
+### McpHttpConfig Sub-configs (#764)
+
+Rust `McpHttpConfig` is now a thin aggregate with view methods:
+`.queue_config()`, `.gateway_config()`, `.session_config()`, `.telemetry_config()`.
+Python `PyMcpHttpConfig` field-level getters/setters are **unchanged**.

--- a/llms.txt
+++ b/llms.txt
@@ -963,3 +963,108 @@ Full guide: `docs/guide/remote-server.md`. Per-module API: `docs/api/{auth,batch
 
 - [dcc-mcp-rpyc](https://github.com/loonghao/dcc-mcp-rpyc) — RPyC bridge for remote DCC operations
 - [dcc-mcp-maya](https://github.com/loonghao/dcc-mcp-maya) — Maya MCP server implementation
+
+---
+
+## New Gateway Features (issues #764–#774)
+
+### Quick Decision — New APIs
+
+| I want to… | Use this |
+|------------|---------|
+| Bridge stdio MCP server to HTTP/SSE | `dcc-mcp-server translate --stdio "cmd" --port N --transport sse` |
+| Search DCC-MCP adapter catalog | `dcc_catalog__search({"query":"..."})` MCP tool or `dcc-mcp-server catalog search` |
+| Mount OpenAPI REST API as MCP tools | `GatewayBuilder::mount_openapi(OpenApiMount::from_url(...).auth(...))` |
+| Add audit/quota/redact to gateway calls | `GatewayConfig::middleware_chain` with built-in middleware |
+| Enable gateway admin dashboard | `GatewayConfig { admin_enabled: true }` → `GET /admin` |
+| Enforce payload size + SSE chunking | `McpHttpConfig.queue.max_request_body_bytes` (default 4 MiB) |
+| Wire OTLP distributed tracing | Set `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317` at startup |
+| Watch gateway contention events | MCP resource `resources://gateway/events` (JSONL ring buffer) |
+
+### Middleware Chain (#770)
+
+```rust
+let config = GatewayConfig {
+    middleware_chain: MiddlewareChain::new()
+        .with_before(Arc::new(AuditMiddleware::default()))
+        .with_before(Arc::new(QuotaMiddleware::new(100)))  // 100 calls/min
+        .with_before(Arc::new(RedactionMiddleware::new(["api_key"]))),
+    ..GatewayConfig::default()
+};
+```
+
+Built-in middleware: `AuditMiddleware` (structured tracing log), `QuotaMiddleware` (rate limit → 429), `RedactionMiddleware` (field scrubbing).
+Custom: implement `BeforeCallMiddleware` or `AfterCallMiddleware` traits. `CallContext` fields: `method`, `tool_slug`, `dcc_type`, `session_id`, `request_id`, `args`, `metadata`.
+
+### OpenAPI → MCP Bridge (#773)
+
+```rust
+gateway_builder.mount_openapi(
+    OpenApiMount::from_url("https://api.example.com/openapi.json")
+        .base_url("https://api.example.com")
+        .auth(AuthConfig::bearer("$MY_API_TOKEN"))
+        .tool_prefix("example"),
+)
+```
+
+One config block exposes all OpenAPI paths as MCP tools with preserved auth + schemas. Auth types: `bearer()`, `api_key()`, `basic()`. `$ENV_VAR` references resolved at call time.
+
+### stdio → HTTP Bridge (#769)
+
+```bash
+dcc-mcp-server translate \
+  --stdio "npx @modelcontextprotocol/server-filesystem /tmp" \
+  --dcc-type filesystem --port 3333 --transport sse
+```
+
+Flags: `--no-register` (standalone), `--restart-on-exit` (supervisor), `--max-restarts N`.
+
+### Admin Dashboard (#772)
+
+```rust
+GatewayConfig { admin_enabled: true, admin_path: "/admin".into(), .. }
+// requires: dcc-mcp-gateway = { features = ["admin"] }
+```
+
+Routes: `GET /admin` (HTML dashboard), `GET /admin/api/{instances,tools,calls,logs,health}` (JSON APIs).
+Default: disabled (`admin_enabled: false`).
+
+### OTLP Distributed Tracing (#768)
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 dcc-mcp-server ...
+```
+
+Standard env vars: `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES`, `OTEL_EXPORTER_OTLP_HEADERS`.
+DCC span attrs: `dcc.type`, `dcc.instance_id`, `dcc.scene`, `mcp.method`, `mcp.tool_slug`, `mcp.session_id`, `mcp.request_id`, `dcc.job_id`.
+
+### DCC-MCP Catalog (#774)
+
+```bash
+dcc-mcp-server catalog search --query maya
+dcc-mcp-server catalog describe --name dcc-mcp-maya-skills
+```
+
+MCP tools: `dcc_catalog__search({"query":"..."})`, `dcc_catalog__describe({"name":"..."})`.
+Override catalog path: `DCC_MCP_CATALOG_PATH=/path/to/dcc-mcp-catalog.yml`.
+
+### Gateway Observability (#766)
+
+Prometheus counters (under `prometheus` Cargo feature):
+- `dcc_mcp_gateway_elections_total{outcome="won|yielded|lost"}`
+- `dcc_mcp_gateway_evictions_total{reason="stale|ghost|probe_fail"}`
+- `dcc_mcp_gateway_probes_total{outcome="ready|booting|unreachable"}`
+
+MCP resource `resources://gateway/events`: JSONL ring buffer, last 1000 contention events.
+
+### Payload Limits (#771)
+
+| Config field | Default | Effect |
+|-------------|---------|--------|
+| `McpHttpConfig.queue.max_request_body_bytes` | 4 MiB | 413 Payload Too Large |
+| `McpHttpConfig.queue.max_response_content_bytes` | 1 MiB | `TruncationEnvelope` (`truncated`, `original_size`, `truncated_size`) |
+| `McpHttpConfig.queue.sse_chunk_size_bytes` | 64 KiB | Automatic SSE chunking |
+
+### McpHttpConfig Sub-configs (#764)
+
+`McpHttpConfig` is now a thin aggregate. Access via view methods: `.queue_config()` → `QueueConfig`, `.gateway_config()` → `HttpGatewayConfig`, `.session_config()` → `SessionConfig`, `.telemetry_config()` → `HttpTelemetryConfig`.


### PR DESCRIPTION
Updates all agent-facing documentation for the 10 features merged in this milestone.

## New guide pages (5 files)
- `docs/guide/middleware.md` — pluggable middleware chain (BeforeCall/AfterCall, AuditMiddleware, QuotaMiddleware, RedactionMiddleware)
- `docs/guide/admin-ui.md` — built-in zero-build `/admin` dashboard (routes, response shapes, AuditMiddleware integration)
- `docs/guide/translate.md` — `translate` subcommand: bridge any stdio MCP server to HTTP/SSE with CLI reference and Cursor/Claude Desktop config examples
- `docs/guide/catalog.md` — DCC-MCP public adapter catalog: YAML format, CLI, MCP tools, custom path
- `docs/guide/observability.md` — OTLP distributed tracing (Jaeger/Tempo quick start), gateway event log, Prometheus counters + Grafana PromQL examples

## Updated files
- `llms.txt` — 8 new Quick Decision table rows + 9 new API sections (middleware, OpenAPI mount, translate, admin UI, OTLP, catalog, observability, payload limits, config split)
- `docs/guide/INDEX.md` — 6 new entries in MCP Server & HTTP table, 1 in Core Subsystems
- `AGENTS.md` — 7 new rows in the decision table

Closes the documentation acceptance criteria from issue #767.