### PR TITLE
docs: refresh gateway agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,11 +85,12 @@ Per-DCC MCP server:
 4. Follow up: check next-tools.on-success for suggested next steps
 5. Debug on failure: use dcc_diagnostics__screenshot or audit_log
 
-Gateway / slim / REST exposure:
+Gateway dynamic-capability / REST exposure:
 1. Discover: search_tools(query="keyword", dcc_type="maya") → get tool_slug
 2. Inspect: describe_tool(tool_slug) → read schema + annotations
 3. Execute: call_tool(tool_slug, arguments={...})
-4. For non-MCP clients, use the matching /v1/search, /v1/describe, /v1/call REST endpoints.
+4. The gateway never fans out per-action backend tools into tools/list.
+5. For non-MCP clients, use the matching /v1/search, /v1/describe, /v1/call REST endpoints.
 
 Gateway resources/prompts:
 1. List hand-off artefacts with resources/list; gateway-prefixed URIs identify the owning DCC instance.
@@ -132,7 +133,7 @@ Gateway resources/prompts:
 | Need | Use this |
 |------|----------|
 | Expose DCC tools over MCP | `DccServerBase` → subclass → `start()` |
-| Zero-code tool registration | `SKILL.md` + `scripts/` ([agentskills.io](https://agentskills.io/specification)) |
+| Zero-code tool registration | agentskills.io `SKILL.md` + `metadata.dcc-mcp.tools` → sibling `tools.yaml` + `scripts/` |
 | Zero-code static MCP resources | `metadata.dcc-mcp.resources` → `resources/*.resource.yaml` with `source.type: file` |
 | Structured results | `success_result()` / `error_result()` |
 | Rich error with traceback | `skill_error_with_trace()` |

--- a/AI_AGENT_GUIDE.md
+++ b/AI_AGENT_GUIDE.md
@@ -63,9 +63,9 @@ else:
 
 When an MCP `tools/call` response includes `CallToolResult._meta["dcc.next_tools"].on_success` or `.on_failure`, **always consider calling those tools next**. This creates a guided workflow chain; the declarations live per tool in sibling `tools.yaml`, not as top-level `SKILL.md` keys.
 
-### Gateway / Slim / REST Surfaces
+### Gateway Dynamic-Capability / REST Surfaces
 
-If your MCP connection is the multi-DCC gateway, especially with `gateway_tool_exposure="slim"` or `"rest"`, do not expect every backend tool to appear in `tools/list`. Use the bounded dynamic-capability workflow instead:
+If your MCP connection is the multi-DCC gateway, do not expect backend actions to appear directly in `tools/list`. The gateway surface is intentionally fixed and bounded; use the dynamic-capability workflow instead:
 
 ```python
 # Gateway MCP wrapper flow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,9 @@
 When interacting with Maya, Blender, Houdini, Photoshop, ZBrush, Unreal, Unity,
 Figma, or any custom DCC host, use the Skills-First workflow from `AGENTS.md`.
 Prefer `search_skills` → `load_skill` → tool call on a per-DCC server, or
-`search_tools` → `describe_tool` → `call_tool` on a gateway/slim REST surface.
+`search_tools` → `describe_tool` → `call_tool` on the gateway's bounded
+dynamic-capability surface. Non-MCP clients use the equivalent `/v1/search` →
+`/v1/describe` → `/v1/call` REST flow.
 Do not jump straight to raw subprocesses or host scripting unless the docs say a
 low-level fallback is required.
 

--- a/CODEBUDDY.md
+++ b/CODEBUDDY.md
@@ -20,7 +20,9 @@
 When interacting with Maya, Blender, Houdini, Photoshop, ZBrush, Unreal, Unity,
 Figma, or any custom DCC host, use the Skills-First workflow from `AGENTS.md`.
 Prefer `search_skills` → `load_skill` → tool call on a per-DCC server, or
-`search_tools` → `describe_tool` → `call_tool` on a gateway/slim REST surface.
+`search_tools` → `describe_tool` → `call_tool` on the gateway's bounded
+dynamic-capability surface. Non-MCP clients use the equivalent `/v1/search` →
+`/v1/describe` → `/v1/call` REST flow.
 Do not jump straight to raw subprocesses or host scripting unless the docs say a
 low-level fallback is required.
 

--- a/COPILOT.md
+++ b/COPILOT.md
@@ -20,7 +20,9 @@
 When interacting with Maya, Blender, Houdini, Photoshop, ZBrush, Unreal, Unity,
 Figma, or any custom DCC host, use the Skills-First workflow from `AGENTS.md`.
 Prefer `search_skills` → `load_skill` → tool call on a per-DCC server, or
-`search_tools` → `describe_tool` → `call_tool` on a gateway/slim REST surface.
+`search_tools` → `describe_tool` → `call_tool` on the gateway's bounded
+dynamic-capability surface. Non-MCP clients use the equivalent `/v1/search` →
+`/v1/describe` → `/v1/call` REST flow.
 Do not jump straight to raw subprocesses or host scripting unless the docs say a
 low-level fallback is required.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -20,7 +20,9 @@
 When interacting with Maya, Blender, Houdini, Photoshop, ZBrush, Unreal, Unity,
 Figma, or any custom DCC host, use the Skills-First workflow from `AGENTS.md`.
 Prefer `search_skills` → `load_skill` → tool call on a per-DCC server, or
-`search_tools` → `describe_tool` → `call_tool` on a gateway/slim REST surface.
+`search_tools` → `describe_tool` → `call_tool` on the gateway's bounded
+dynamic-capability surface. Non-MCP clients use the equivalent `/v1/search` →
+`/v1/describe` → `/v1/call` REST flow.
 Do not jump straight to raw subprocesses or host scripting unless the docs say a
 low-level fallback is required.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **Production-grade foundation for AI-assisted DCC workflows** — combining the **Model Context Protocol (MCP 2025-03-26 Streamable HTTP)** with a **zero-code Skills system** built on [agentskills.io 1.0](https://agentskills.io/specification). A **Rust-powered core with Python bindings (PyO3)** delivering enterprise-grade performance, security, and scalability — all with **zero runtime Python dependencies**. Supports Python 3.7–3.13.
 
-> **Note**: This project is in active development (v0.14+). APIs may evolve; see `CHANGELOG.md` for version history.
+> **Note**: This project is in active development (v0.15+). APIs may evolve; see `CHANGELOG.md` for version history.
 
 ---
 
@@ -441,7 +441,7 @@ tools/list response (Maya session, nothing loaded yet):
 - **Screen capture** — Full-screen or per-window (HWND `PrintWindow`) viewport capture for AI visual feedback.
 - **USD integration** — Universal Scene Description read/write bridge.
 - **Structured telemetry** — Tracing, recording, optional Prometheus `/metrics` exporter.
-- **~180 public Python symbols** via top-level re-exports; `_core.pyi` is generated after a stub-gen/dev build rather than hand-edited source.
+- **380+ public Python symbols** via top-level re-exports; `_core.pyi` is generated after a stub-gen/dev build rather than hand-edited source.
 
 ---
 
@@ -670,7 +670,7 @@ If you're an AI coding agent, also read:
 - [AGENTS.md](AGENTS.md) — Navigation map for AI agents (entry point, decision tables, top traps).
 - [`docs/guide/agents-reference.md`](docs/guide/agents-reference.md) — Detailed agent rules, traps, code style, and project-specific architecture constraints.
 - [`.agents/skills/dcc-mcp-core/SKILL.md`](.agents/skills/dcc-mcp-core/SKILL.md) — Complete API skill definition.
-- [`python/dcc_mcp_core/__init__.py`](python/dcc_mcp_core/__init__.py) — Full public API surface (~180 symbols).
+- [`python/dcc_mcp_core/__init__.py`](python/dcc_mcp_core/__init__.py) — Full public API surface (380+ symbols).
 - [`python/dcc_mcp_core/_core.pyi`](python/dcc_mcp_core/_core.pyi) — Ground-truth type stubs (parameter names, types, signatures).
 - [`llms.txt`](llms.txt) — Concise API reference optimised for LLMs.
 - [`llms-full.txt`](llms-full.txt) — Complete API reference optimised for LLMs.

--- a/README_zh.md
+++ b/README_zh.md
@@ -13,7 +13,7 @@
 
 **面向 AI 辅助 DCC 工作流的生产级基础库** —— 结合 **模型上下文协议（MCP 2025-03-26 Streamable HTTP）** 与 **零代码 Skills 系统**，后者遵循 [agentskills.io 1.0](https://agentskills.io/specification) 规范。**Rust 核心 + PyO3 Python 绑定**，交付企业级性能、安全性与可扩展性；**运行时零 Python 依赖**。支持 Python 3.7–3.13。
 
-> **注意**：本项目处于积极开发中（v0.14+），API 可能演进；版本历史参见 `CHANGELOG.md`。
+> **注意**：本项目处于积极开发中（v0.15+），API 可能演进；版本历史参见 `CHANGELOG.md`。
 
 ---
 
@@ -433,7 +433,7 @@ tools/list 响应（Maya 会话、尚未加载任何 skill）：
 - **屏幕捕获** —— 全屏或单窗口（HWND `PrintWindow`）视口捕获，供 AI 视觉反馈。
 - **USD 集成** —— Universal Scene Description 读写桥。
 - **结构化遥测** —— 追踪、录制，可选 Prometheus `/metrics` 导出器。
-- **~180 个公开 Python 符号** —— 通过顶层重导出提供；`_core.pyi` 是 stub-gen/dev 构建后的生成产物，不是手写源码。
+- **380+ 个公开 Python 符号** —— 通过顶层重导出提供；`_core.pyi` 是 stub-gen/dev 构建后的生成产物，不是手写源码。
 
 ---
 
@@ -658,7 +658,7 @@ MIT —— 详情见 [LICENSE](LICENSE)。
 - [AGENTS.md](AGENTS.md) —— AI Agent 导航图（入口、决策表、Top traps）。
 - [`docs/guide/agents-reference.md`](docs/guide/agents-reference.md) —— Agent 详细规则、陷阱、代码风格与项目专属架构约束。
 - [`.agents/skills/dcc-mcp-core/SKILL.md`](.agents/skills/dcc-mcp-core/SKILL.md) —— 完整 API skill 定义。
-- [`python/dcc_mcp_core/__init__.py`](python/dcc_mcp_core/__init__.py) —— 完整公开 API（~180 符号）。
+- [`python/dcc_mcp_core/__init__.py`](python/dcc_mcp_core/__init__.py) —— 完整公开 API（380+ 符号）。
 - [`python/dcc_mcp_core/_core.pyi`](python/dcc_mcp_core/_core.pyi) —— 真实类型 stub（参数名、类型、签名）。
 - [`llms.txt`](llms.txt) —— LLM 优化的简洁 API 参考。
 - [`llms-full.txt`](llms-full.txt) —— LLM 优化的完整 API 参考。

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -263,14 +263,14 @@ print(f"Maya MCP server: {handle.mcp_url()}")
 
 ## Gateway
 
-When multiple DCC instances start simultaneously, one automatically becomes the **gateway** — a single well-known `/mcp` endpoint that **aggregates** every running instance's tools into one unified MCP interface.
+When multiple DCC instances start simultaneously, one automatically becomes the **gateway** — a single well-known `/mcp` endpoint and `/v1/*` REST facade for all running instances. Since v0.15, the gateway does **not** merge every backend action into `tools/list`; it keeps MCP bounded and routes backend capabilities through search/describe/call primitives.
 
 ### How it works
 
 - Every instance registers itself in a shared `FileRegistry` (JSON file on disk) and sends periodic heartbeats.
 - The **first** process to bind `gateway_port` (default: `9765`) becomes the gateway; all others are plain instances.
 - Mutual exclusion uses `SO_REUSEADDR=false` (via `socket2`), so the first-wins semantics are reliable across platforms including Windows.
-- The gateway automatically evicts stale instances (no heartbeat within `stale_timeout_secs`).
+- The gateway probes `GET /v1/readyz` (falling back to `/health` for old backends) and evicts instances after consecutive failures.
 - When the process exits, `McpServerHandle` is dropped and the instance is automatically deregistered.
 
 ### Gateway endpoints
@@ -278,25 +278,28 @@ When multiple DCC instances start simultaneously, one automatically becomes the 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/instances` | GET | JSON list of all live instances |
+| `/v1/instances` | GET | REST alias for instance discovery |
 | `/health` | GET | `{"ok": true}` health check |
-| `/mcp` | POST | Aggregating MCP endpoint (merges every backend's tools) |
-| `/mcp` | GET | SSE stream — `tools/list_changed` and `resources/list_changed` |
+| `/mcp` | POST | Bounded MCP endpoint with gateway discover+dispatch primitives |
+| `/mcp` | GET | SSE stream for progress, job/workflow, resource, and prompt notifications |
+| `/v1/search` | POST | Search compact backend capability records |
+| `/v1/describe` | POST | Fetch schema, annotations, and routing record for one `tool_slug` |
+| `/v1/call` | POST | Invoke one backend capability by `tool_slug` |
 | `/mcp/{instance_id}` | POST | Transparent proxy to a specific instance (low-level escape hatch) |
 | `/mcp/dcc/{dcc_type}` | POST | Proxy to the best instance of a DCC type |
 
-### Aggregating facade
+### Bounded facade
 
-`POST /mcp` on the gateway is a single MCP server that exposes three tiers of tools merged into one `tools/list` response:
+`POST /mcp` on the gateway is a single MCP server that exposes fixed gateway tools in `tools/list`:
 
 | Tier | Tools | Purpose |
 |------|-------|---------|
 | Discovery meta | `list_dcc_instances`, `get_dcc_instance`, `connect_to_dcc` | Enumerate / inspect live DCCs; get a direct MCP URL when needed |
-| Skill management | `list_skills`, `search_skills`, `get_skill_info`, `load_skill`, `unload_skill` | Fan-out to every DCC (read ops) or target a specific instance via the `instance_id` / `dcc` argument (`load_skill` / `unload_skill`) |
-| Backend tools | Every live DCC's own tools, prefixed with an 8-char instance id — e.g. `a1b2c3d4__create_sphere` | Routed to the originating backend by the prefix |
+| Skill management | `list_skills`, `search_skills`, `get_skill_info`, `load_skill`, `unload_skill` | Search/load skills across DCCs or target a specific instance via `instance_id` / `dcc` |
+| Dynamic capability wrappers | `search_tools`, `describe_tool`, `call_tool` | Discover compact backend records, fetch one schema, then invoke by `tool_slug` |
+| Operations | `acquire_dcc_instance`, `release_dcc_instance`, diagnostics tools | Pool warm instances and debug gateway health |
 
-Each namespaced backend tool also carries `_instance_id`, `_instance_short`, and `_dcc_type` annotations so agents can disambiguate colliding names (e.g. `create_cube` on Maya and Blender appear as two distinct entries with different prefixes).
-
-The gateway advertises `capabilities.tools.listChanged: true` and polls backends every 3 s; when the aggregated set changes (skill loaded / unloaded anywhere) it broadcasts `notifications/tools/list_changed` to every connected SSE client.
+Backend actions are addressed by `tool_slug` (`<dcc>.<id8>.<tool>`). Agents should not construct slugs by hand; obtain them from `search_tools` or `POST /v1/search`, then call `describe_tool` / `call_tool` or the equivalent REST endpoints.
 
 #### `list_dcc_instances` — operator view (issue maya#138)
 
@@ -371,7 +374,7 @@ print(handle.mcp_url())         # direct MCP URL for this instance
 ```
 
 ::: tip Multiple DCCs, one endpoint
-Start any number of DCC servers — the first one wins the gateway port. Agents always connect to `http://localhost:9765/mcp` and see every backend's tools in a single `tools/list`, namespaced by instance. `list_dcc_instances` / `connect_to_dcc` are available when an agent wants a direct, un-proxied session.
+Start any number of DCC servers — the first one wins the gateway port. Agents connect to `http://localhost:9765/mcp`, call `search_tools` to discover backend capabilities, then `describe_tool` / `call_tool` to use one capability. `list_dcc_instances` / `connect_to_dcc` are available when an agent wants a direct, un-proxied session.
 :::
 
 ::: info Skills-First + gateway

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -187,9 +187,10 @@ dcc-mcp-server --dcc maya --scene /shots/ep101/sh0200/shot.ma
 ### Scenario 3 — Gateway aggregating multiple DCC servers
 
 Multiple `dcc-mcp-server` processes on the same workstation. The first one
-binds the gateway port `9765` and aggregates the others. Everything else
-connects to `127.0.0.1:9765/mcp` (or `/v1/*`) and gets every DCC through
-one endpoint.
+binds the gateway port `9765` and indexes the others. Clients connect to
+`127.0.0.1:9765/mcp` (or `/v1/*`), then use `search_tools` /
+`describe_tool` / `call_tool` or the REST equivalents to reach any DCC
+through one endpoint.
 
 Example manifests: `examples/compose/gateway-ha/` and
 `examples/k8s/gateway-ha/`.

--- a/docs/guide/gateway-election.md
+++ b/docs/guide/gateway-election.md
@@ -7,9 +7,10 @@
 The **gateway** is a single Rust HTTP server (running on `localhost:9765` by default) that:
 
 - Discovers all running DCC instances (Maya, Blender, Houdini, Photoshop, etc.)
-- Aggregates every live backend's tools into one unified `/mcp` endpoint (namespaced by `{instance_short}__{name}`)
+- Keeps one unified, bounded `/mcp` endpoint with discover+dispatch primitives instead of fanning out every backend action
+- Routes `search_tools` / `describe_tool` / `call_tool` and `/v1/*` REST calls to the selected backend capability
 - Fans out skill-management calls (`search_skills`, `list_skills`) and routes targeted calls (`load_skill`) to a specific instance
-- Pushes `tools/list_changed` and `resources/list_changed` over SSE as skills load/unload or instances come and go
+- Pushes progress, job/workflow, resource, and prompt notifications over SSE as instances come and go
 
 **One gateway per machine**. It's started automatically when the first DCC instance registers.
 
@@ -262,10 +263,10 @@ session_b = mgr.get_or_create_session("maya", iid_rig)
 # Sessions are different — no context bleeding
 assert session_a != session_b
 
-# Through the aggregating gateway, both instances' tools appear in a single
-# tools/list with distinct 8-char prefixes, so the agent can target either:
-#   a1b2c3d4__set_keyframe   ← maya-animation
-#   e5f6g7h8__mirror_joints  ← maya-rigging
+# Through the gateway, the agent targets an instance by choosing a
+# tool_slug returned from search_tools / /v1/search:
+#   maya.a1b2c3d4.set_keyframe   ← maya-animation
+#   maya.e5f6g7h8.mirror_joints  ← maya-rigging
 ```
 
 ## Instance Health

--- a/docs/guide/gateway.md
+++ b/docs/guide/gateway.md
@@ -4,9 +4,11 @@ The gateway (`McpHttpConfig::gateway_port > 0`) is a first-wins HTTP
 façade that presents every live DCC instance under one MCP endpoint.
 A single client can talk to Maya, Blender and Houdini through the same
 `/mcp` URL; the gateway discovers live backends via `FileRegistry`,
-aggregates their `tools/list`, routes each `tools/call` to the right
-backend, and multiplexes server-pushed notifications back to the
-originating client session.
+keeps its MCP `tools/list` bounded to discover+dispatch primitives,
+indexes backend capabilities on demand, routes `search_tools` /
+`describe_tool` / `call_tool` (or REST `/v1/*`) to the right backend,
+and multiplexes server-pushed notifications back to the originating
+client session.
 
 ## Topology
 
@@ -158,16 +160,17 @@ when a DCC exposes them.
 
 ## Dynamic Capability Index and Bounded Tool Exposure (#652-#657)
 
-For large multi-DCC deployments, the gateway should not publish every backend
-tool directly through `tools/list`. Use `McpHttpConfig.gateway_tool_exposure`
-to choose the surface:
+For large multi-DCC deployments, the gateway **never** publishes every backend
+action directly through `tools/list`. The removed `GatewayToolExposure` enum,
+`McpHttpConfig.gateway_tool_exposure`, `publishes_backend_tools`, and
+`--gateway-tool-exposure` switch are pre-0.15 concepts. There is now one
+unconditional surface:
 
-| Mode | Behavior | Agent workflow |
-|------|----------|----------------|
-| `full` | Historical fan-out: backend tools appear directly in `tools/list` | Call the prefixed/cursor-safe backend tool directly |
-| `slim` | Bounded gateway meta-tools plus skill-management tools | `search_tools` → `describe_tool` → `call_tool` |
-| `rest` | Same bounded MCP surface; REST `/v1/*` is the primary integration | `POST /v1/search` → `/v1/describe` → `/v1/call` |
-| `both` | Forward-compatible alias for the full transition window | Prefer the dynamic workflow for new agents |
+| Surface | What appears in `tools/list` | Agent workflow |
+|---------|------------------------------|----------------|
+| Gateway MCP | Fixed discover+dispatch primitives: `list_dcc_instances`, `connect_to_dcc`, `search_skills`, `load_skill`, `search_tools`, `describe_tool`, `call_tool`, pooling tools, diagnostics | `search_tools` → `describe_tool` → `call_tool` |
+| Gateway REST | `/v1/search`, `/v1/describe`, `/v1/call`, `/v1/instances` | `POST /v1/search` → `/v1/describe` → `/v1/call` |
+| Direct per-DCC MCP | One DCC server's skills and loaded tools | `search_skills` → `load_skill` → tool call |
 
 The gateway capability index stores compact records keyed by
 `<dcc>.<id8>.<tool>` and refreshes on demand, so the first agent query after
@@ -176,13 +179,13 @@ MCP wrappers are cursor-safe and stable:
 
 | Tool | Purpose |
 |------|---------|
-| `search_tools` | Search compact capability records by query, DCC type, tags, instance, and pagination options |
-| `describe_tool` | Fetch the full schema and annotations for a selected `tool_slug` |
-| `call_tool` | Invoke the selected backend capability with validated arguments |
+| `search_tools` | Search compact capability records by query, DCC type, tags, instance, scene hint, and pagination options |
+| `describe_tool` | Fetch the full schema, annotations, and routing record for a selected `tool_slug` |
+| `call_tool` | Invoke the selected backend capability with validated arguments and optional MCP `_meta` |
 
-Use this flow whenever an agent is connected to a gateway/slim endpoint. Use the
-per-DCC Skills-First flow (`search_skills` → `load_skill` → tool call) when the
-agent is connected directly to one DCC server.
+Use this dynamic-capability flow whenever an agent is connected to the gateway.
+Use the per-DCC Skills-First flow (`search_skills` → `load_skill` → tool call)
+when the agent is connected directly to one DCC server.
 
 ## Resources and Prompts Aggregation (#731, #732)
 

--- a/docs/zh/api/http.md
+++ b/docs/zh/api/http.md
@@ -205,7 +205,7 @@ print(f"Maya MCP 服务器: {handle.mcp_url()}")
 
 ## 网关
 
-当多个 DCC 实例同时启动时，其中一个会自动成为**网关** — 一个统一的 `/mcp` 入口点，将所有运行中实例的工具**聚合**成单一 MCP 接口。
+当多个 DCC 实例同时启动时，其中一个会自动成为**网关** — 一个统一的 `/mcp` 入口点和 `/v1/*` REST 门面。自 v0.15 起，网关不会把所有后端 action 合并进 `tools/list`；它保持 MCP 表面有界，并通过 search/describe/call 原语路由后端能力。
 
 ### 工作原理
 
@@ -220,25 +220,28 @@ print(f"Maya MCP 服务器: {handle.mcp_url()}")
 | 端点 | 方法 | 说明 |
 |------|------|------|
 | `/instances` | GET | 所有活跃实例的 JSON 列表 |
+| `/v1/instances` | GET | 实例发现的 REST 别名 |
 | `/health` | GET | `{"ok": true}` 健康检查 |
-| `/mcp` | POST | 聚合 MCP 端点（合并所有后端工具） |
-| `/mcp` | GET | SSE 事件流 — 推送 `tools/list_changed` 与 `resources/list_changed` |
+| `/mcp` | POST | 有界 MCP 端点，只暴露网关发现+派发原语 |
+| `/mcp` | GET | SSE 事件流 — 进度、作业/工作流、资源、prompt 通知 |
+| `/v1/search` | POST | 搜索紧凑后端能力记录 |
+| `/v1/describe` | POST | 获取一个 `tool_slug` 的 schema、annotations 与路由记录 |
+| `/v1/call` | POST | 通过 `tool_slug` 调用一个后端能力 |
 | `/mcp/{instance_id}` | POST | 透明代理到指定实例（底层逃生通道） |
 | `/mcp/dcc/{dcc_type}` | POST | 代理到指定 DCC 类型的最佳实例 |
 
-### 聚合式 Facade
+### 有界 Facade
 
-网关的 `POST /mcp` 是一个统一 MCP 服务器，在单次 `tools/list` 响应中合并三层工具：
+网关的 `POST /mcp` 是一个统一 MCP 服务器，在 `tools/list` 中只暴露固定网关工具：
 
 | 层级 | 工具 | 用途 |
 |------|------|------|
 | 发现元工具 | `list_dcc_instances`、`get_dcc_instance`、`connect_to_dcc` | 枚举 / 查看活跃 DCC；需要直连时返回直接 MCP URL |
-| 技能管理 | `list_skills`、`search_skills`、`get_skill_info`、`load_skill`、`unload_skill` | 读操作向全部 DCC 扇出；`load_skill` / `unload_skill` 通过 `instance_id` / `dcc` 参数指向具体实例 |
-| 后端工具 | 所有活跃 DCC 自身的工具，带 8 字符实例前缀 — 例如 `a1b2c3d4__create_sphere` | 按前缀路由回原始后端 |
+| 技能管理 | `list_skills`、`search_skills`、`get_skill_info`、`load_skill`、`unload_skill` | 跨 DCC 搜索/加载 skills，或用 `instance_id` / `dcc` 指向具体实例 |
+| 动态能力 wrapper | `search_tools`、`describe_tool`、`call_tool` | 发现紧凑后端记录、拉取单个 schema、再按 `tool_slug` 调用 |
+| 运维工具 | `acquire_dcc_instance`、`release_dcc_instance`、诊断工具 | 预热实例池化和网关健康排障 |
 
-每个命名空间化的后端工具还会附带 `_instance_id`、`_instance_short`、`_dcc_type` 注解，以便 agent 消歧（比如 `create_cube` 在 Maya 和 Blender 上各注册一次时，会表现为两个带不同前缀的独立条目）。
-
-网关声明 `capabilities.tools.listChanged: true`，每 3 秒轮询后端；当聚合集合发生变化（任何一处加载 / 卸载 skill）时，向所有连接的 SSE 客户端广播 `notifications/tools/list_changed`。
+后端 action 通过 `tool_slug`（`<dcc>.<id8>.<tool>`）寻址。Agent 不应手写 slug；应从 `search_tools` 或 `POST /v1/search` 获取，然后调用 `describe_tool` / `call_tool` 或等价 REST 端点。
 
 ### Python 示例
 
@@ -264,7 +267,7 @@ print(handle.mcp_url())         # 本实例的直接 MCP URL
 ```
 
 ::: tip 多 DCC、单入口
-启动任意数量的 DCC 服务器 — 第一个赢得网关端口。Agent 始终连接 `http://localhost:9765/mcp`，在单一 `tools/list` 中看到所有后端工具（按实例命名空间化）。需要直连、不经代理时再使用 `list_dcc_instances` / `connect_to_dcc`。
+启动任意数量的 DCC 服务器 — 第一个赢得网关端口。Agent 连接 `http://localhost:9765/mcp` 后，先用 `search_tools` 发现后端能力，再用 `describe_tool` / `call_tool` 使用其中一个能力。需要直连、不经代理时再使用 `list_dcc_instances` / `connect_to_dcc`。
 :::
 
 ::: info Skills-First + 网关

--- a/docs/zh/guide/cli-reference.md
+++ b/docs/zh/guide/cli-reference.md
@@ -181,8 +181,8 @@ dcc-mcp-server --dcc maya --scene /shots/ep101/sh0200/shot.ma
 ### 场景 3 —— 网关汇聚多个 DCC 服务
 
 同一工作站上多个 `dcc-mcp-server`。先起的绑定网关端口 `9765` 成为
-赢家，把其余汇聚起来。其他客户端只连 `127.0.0.1:9765/mcp`（或 `/v1/*`）
-就能访问所有 DCC。
+赢家，并索引其余实例。客户端只连 `127.0.0.1:9765/mcp`（或 `/v1/*`），
+再通过 `search_tools` / `describe_tool` / `call_tool` 或等价 REST 端点访问任意 DCC。
 
 示例清单：`examples/compose/gateway-ha/` 与 `examples/k8s/gateway-ha/`。
 

--- a/docs/zh/guide/gateway-election.md
+++ b/docs/zh/guide/gateway-election.md
@@ -7,9 +7,10 @@
 **网关**是一个单一的 Rust HTTP 服务器（默认运行在 `localhost:9765`），负责：
 
 - 发现所有运行中的 DCC 实例（Maya、Blender、Houdini、Photoshop 等）
-- 将所有活跃后端的工具聚合到统一的 `/mcp` 端点（按 `{instance_short}__{name}` 命名空间化）
+- 提供统一且有界的 `/mcp` 端点，只暴露发现+派发原语，而不是扇出每个后端 action
+- 将 `search_tools` / `describe_tool` / `call_tool` 以及 `/v1/*` REST 调用路由到选中的后端能力
 - 对 skill 管理调用做扇出（`search_skills`、`list_skills`）或按实例路由（`load_skill`）
-- 当 skill 加载 / 卸载或实例进出时，通过 SSE 推送 `tools/list_changed` 和 `resources/list_changed`
+- 当实例进出时，通过 SSE 推送进度、作业/工作流、资源与 prompt 通知
 
 **每台机器只有一个网关**。当第一个 DCC 实例注册时自动启动。
 
@@ -130,11 +131,11 @@ handle = server.start()
 
 ## 会话隔离
 
-每个 AI 会话**绑定到一个实例**。通过聚合式网关，多个实例的工具都会出现在同一份 `tools/list` 中，通过 8 字符前缀区分，agent 可定向调用任一实例：
+每个 AI 会话**绑定到一个实例**。通过 Gateway 时，agent 先用 `search_tools` / `/v1/search` 选择带实例短 ID 的 `tool_slug`，再定向调用任一实例：
 
 ```
-a1b2c3d4__set_keyframe   ← maya-animation
-e5f6g7h8__mirror_joints  ← maya-rigging
+maya.a1b2c3d4.set_keyframe   ← maya-animation
+maya.e5f6g7h8.mirror_joints  ← maya-rigging
 ```
 
 ## 实例健康检查

--- a/docs/zh/guide/gateway.md
+++ b/docs/zh/guide/gateway.md
@@ -3,9 +3,10 @@
 Gateway（`McpHttpConfig::gateway_port > 0`）是一个 first-wins HTTP
 门面，将所有在线的 DCC 实例呈现在一个 MCP 端点下。
 单个客户端可以通过同一个 `/mcp` URL 与 Maya、Blender 和 Houdini
-通信；Gateway 通过 `FileRegistry` 发现在线后端，聚合它们的
-`tools/list`，将每个 `tools/call` 路由到正确的后端，并将
-服务器推送的通知多路复用回原始客户端会话。
+通信；Gateway 通过 `FileRegistry` 发现在线后端，将自身 MCP
+`tools/list` 固定为发现+派发原语，按需索引后端能力，并把
+`search_tools` / `describe_tool` / `call_tool`（或 REST `/v1/*`）
+路由到正确的后端，同时将服务器推送的通知多路复用回原始客户端会话。
 
 ## 拓扑
 
@@ -86,6 +87,32 @@ facade 抖动都会浪费 socket 并塞满重连日志。
    `prune_dead_pids()` + `cleanup_stale()`。周期性清理任务每 15
    秒才触发一次；没有这次同步前置扫描的话，上一次崩溃残留的幽灵
    行会在 Gateway 启动后的前 ~15 秒内耗尽完整的指数退避重连预算。
+
+## 动态能力索引与有界工具暴露 (#652-#657)
+
+在大型多 DCC 部署中，Gateway **永远不会**把每个后端 action 直接发布到
+`tools/list`。已移除的 `GatewayToolExposure` 枚举、
+`McpHttpConfig.gateway_tool_exposure`、`publishes_backend_tools` 与
+`--gateway-tool-exposure` 都是 0.15 之前的概念。现在只有一个无条件表面：
+
+| 表面 | `tools/list` 中出现什么 | Agent 工作流 |
+|------|--------------------------|--------------|
+| Gateway MCP | 固定的发现+派发原语：`list_dcc_instances`、`connect_to_dcc`、`search_skills`、`load_skill`、`search_tools`、`describe_tool`、`call_tool`、池化工具、诊断工具 | `search_tools` → `describe_tool` → `call_tool` |
+| Gateway REST | `/v1/search`、`/v1/describe`、`/v1/call`、`/v1/instances` | `POST /v1/search` → `/v1/describe` → `/v1/call` |
+| 直连 per-DCC MCP | 单个 DCC 服务的 skills 与已加载工具 | `search_skills` → `load_skill` → 调用工具 |
+
+Gateway capability index 使用 `<dcc>.<id8>.<tool>` 作为紧凑记录键，并按需刷新。
+因此启动后或 `load_skill` 后的第一次 agent 查询就能看到最新能力，不需要等待轮询。
+固定 MCP wrapper 是 cursor-safe 且稳定的：
+
+| 工具 | 用途 |
+|------|------|
+| `search_tools` | 按 query、DCC 类型、tag、实例、scene hint、分页参数搜索紧凑能力记录 |
+| `describe_tool` | 获取选中 `tool_slug` 的完整 schema、annotations 与路由记录 |
+| `call_tool` | 使用校验后的 arguments 和可选 MCP `_meta` 调用后端能力 |
+
+Agent 连接到 Gateway 时使用这条动态能力流程；直接连接某个 DCC 服务时使用
+per-DCC Skills-First 流程（`search_skills` → `load_skill` → 调用工具）。
 
 ## 代码指针
 

--- a/skills/dcc-skills-creator/SKILL.md
+++ b/skills/dcc-skills-creator/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   an existing skill directory, or generate a SKILL.md template. Not for
   executing DCC commands — use domain-specific skills for that.
 license: MIT
-compatibility: "Python 3.7+, dcc-mcp-core 0.14.3+"
+compatibility: "Python 3.7+, dcc-mcp-core 0.15+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:
@@ -106,4 +106,4 @@ The validator checks:
 - **Script files**: `source_file` references exist in `scripts/`
 - **Sidecar files**: `metadata.dcc-mcp.tools/groups/prompts` references exist
 - **Dependencies**: `depends` vs `metadata/depends.md` consistency
-- **Legacy fields**: top-level extension keys (info-level notice)
+- **Spec compliance**: non-standard top-level keys are frontmatter errors; dcc-mcp-core extensions must live under `metadata.dcc-mcp.*` and point to sibling files

--- a/skills/integration-guide.md
+++ b/skills/integration-guide.md
@@ -696,14 +696,14 @@ handle = server.start()
 
 ### Multiple DCC instances
 
-The Gateway automatically discovers and aggregates tools from all running
-DCC instances. Each instance registers with a unique `instance_id` and its
-tools are namespaced as `<8char_prefix>__<tool_name>` in the Gateway's
-`tools/list` response.
+The Gateway automatically discovers all running DCC instances, but it keeps
+`tools/list` bounded to fixed discover+dispatch primitives. Each instance
+registers with a unique `instance_id`; backend actions are addressed by
+`tool_slug` values returned from `search_tools` / `/v1/search`.
 
 ```python
-# AI agent sees:
-# a1b2c3d4__create_sphere  (Maya instance 1)
-# e5f6g7h8__create_sphere  (Maya instance 2)
-# i9j0k1l2__add_material   (Blender instance 1)
+# AI agent flow:
+# hits = search_tools(query="create sphere", dcc_type="maya")
+# info = describe_tool(tool_slug=hits["hits"][0]["tool_slug"])
+# result = call_tool(tool_slug=info["record"]["tool_slug"], arguments={"radius": 1.0})
 ```


### PR DESCRIPTION
## Summary
- Refresh AGENTS and agent entry shims for the v0.15 gateway dynamic-capability workflow
- Update gateway, HTTP API, CLI, and election docs in English and Chinese to remove obsolete backend tools/list fan-out guidance
- Align README API counts and dcc-skills-creator metadata guidance with current v0.15 behavior

## Validation
- git diff --check
- vx just docs-check (blocked on Windows: missing cygpath for bash shebang)
- cd docs; npm ci --no-audit --no-fund; npm run docs:build