### PR TITLE
fix(#793): isolate test registry dirs and add FileRegistry drop cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,7 +713,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dcc-mcp-actions"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "dashmap",
  "dcc-mcp-models",
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-artefact"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "hex",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-capture"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "image",
  "libc",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-catalog"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-core"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "dcc-mcp-actions",
  "dcc-mcp-artefact",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-gateway"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "axum",
  "chrono",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-host"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-http"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "axum",
  "axum-test",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-job"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "dashmap",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-jsonrpc"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-logging"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "dcc-mcp-paths",
  "parking_lot",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-models"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "dcc-mcp-naming",
  "dcc-mcp-pybridge",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-naming"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "pyo3",
  "pyo3-stub-gen",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-paths"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "dirs",
  "pyo3",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-process"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "dcc-mcp-models",
  "ipckit",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-protocols"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-pybridge"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "dcc-mcp-pybridge-derive",
  "pyo3",
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-pybridge-derive"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-sandbox"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-scheduler"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "axum",
  "bytes",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-server"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-shm"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "ipckit",
  "libc",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-skill-rest"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "axum",
  "axum-test",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-skills"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "dashmap",
  "dcc-mcp-actions",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-telemetry"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-transport"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "criterion",
  "dashmap",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-agent"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1261,7 +1261,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-protocol"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "jsonwebtoken",
  "rmp-serde",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-relay"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-usd"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "dcc-mcp-protocols",
  "pyo3",
@@ -1313,7 +1313,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-workflow"
-version = "0.14.28"
+version = "0.15.0"
 dependencies = [
  "base64",
  "chrono",
@@ -5945,6 +5945,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
+ "once_cell",
  "phf 0.11.3",
  "phf_shared 0.11.3",
  "proc-macro2",

--- a/crates/dcc-mcp-gateway/src/gateway/runner.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/runner.rs
@@ -24,11 +24,17 @@ pub struct GatewayRunner {
 
 impl GatewayRunner {
     /// Create a new runner, initializing (or loading) the `FileRegistry` from
-    /// `config.registry_dir` (or a system temp dir if `None`).
+    /// `config.registry_dir`, the `DCC_MCP_REGISTRY_DIR` environment variable,
+    /// or a system temp dir (in that order of precedence).
     pub fn new(config: GatewayConfig) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let dir = config
             .registry_dir
             .clone()
+            .or_else(|| {
+                std::env::var("DCC_MCP_REGISTRY_DIR")
+                    .ok()
+                    .map(std::path::PathBuf::from)
+            })
             .unwrap_or_else(|| std::env::temp_dir().join("dcc-mcp-registry"));
         let registry = FileRegistry::new(&dir)?;
         Ok(Self {

--- a/crates/dcc-mcp-transport/src/discovery/file_registry.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry.rs
@@ -786,44 +786,6 @@ impl FileRegistry {
     }
 }
 
-impl Drop for FileRegistry {
-    /// Remove all entries that were registered by **this process** (identified
-    /// via their sentinel lock file handles stored in `sentinel_handles`).
-    ///
-    /// This mirrors what `GatewayHandle::deregister_all` does, but at the
-    /// `FileRegistry` level so callers that hold a registry directly (e.g.
-    /// a test process that bypasses the gateway path) also clean up on drop.
-    ///
-    /// If the process crashes hard (SIGKILL / out-of-memory) Rust destructors
-    /// do not run, but the OS releases the sentinel lock files, so the next
-    /// caller to `prune_dead_entries` or `prune_dead_pids` will still evict
-    /// these rows.  This drop is therefore a *best-effort* fast path that
-    /// avoids the 15-second stale-cleanup window in normal exit scenarios
-    /// (issue #793).
-    fn drop(&mut self) {
-        if self.sentinel_handles.is_empty() {
-            return;
-        }
-        let keys: Vec<_> = self
-            .sentinel_handles
-            .iter()
-            .map(|r| r.key().clone())
-            .collect();
-        for key in &keys {
-            if let Err(e) = self.deregister(key) {
-                // Best-effort: log the error but continue dropping.
-                tracing::warn!(
-                    error = %e,
-                    dcc_type = %key.dcc_type,
-                    instance_id = %key.instance_id,
-                    "FileRegistry::deregister failed during drop — \
-                     entry will be evicted by stale-timeout cleanup"
-                );
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 #[path = "file_registry_tests.rs"]
 mod tests;

--- a/crates/dcc-mcp-transport/src/discovery/file_registry.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry.rs
@@ -786,6 +786,44 @@ impl FileRegistry {
     }
 }
 
+impl Drop for FileRegistry {
+    /// Remove all entries that were registered by **this process** (identified
+    /// via their sentinel lock file handles stored in `sentinel_handles`).
+    ///
+    /// This mirrors what `GatewayHandle::deregister_all` does, but at the
+    /// `FileRegistry` level so callers that hold a registry directly (e.g.
+    /// a test process that bypasses the gateway path) also clean up on drop.
+    ///
+    /// If the process crashes hard (SIGKILL / out-of-memory) Rust destructors
+    /// do not run, but the OS releases the sentinel lock files, so the next
+    /// caller to `prune_dead_entries` or `prune_dead_pids` will still evict
+    /// these rows.  This drop is therefore a *best-effort* fast path that
+    /// avoids the 15-second stale-cleanup window in normal exit scenarios
+    /// (issue #793).
+    fn drop(&mut self) {
+        if self.sentinel_handles.is_empty() {
+            return;
+        }
+        let keys: Vec<_> = self
+            .sentinel_handles
+            .iter()
+            .map(|r| r.key().clone())
+            .collect();
+        for key in &keys {
+            if let Err(e) = self.deregister(key) {
+                // Best-effort: log the error but continue dropping.
+                tracing::warn!(
+                    error = %e,
+                    dcc_type = %key.dcc_type,
+                    instance_id = %key.instance_id,
+                    "FileRegistry::deregister failed during drop — \
+                     entry will be evicted by stale-timeout cleanup"
+                );
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 #[path = "file_registry_tests.rs"]
 mod tests;

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -40,6 +40,7 @@ num-complex = { version = "0.4.6" }
 num-integer = { version = "0.1.46", features = ["i128"] }
 num-iter = { version = "0.1.45", default-features = false, features = ["i128", "std"] }
 num-traits = { version = "0.2.19", features = ["i128", "libm"] }
+once_cell = { version = "1.21.4" }
 phf = { version = "0.11.3", features = ["macros"] }
 phf_shared = { version = "0.11.3" }
 rand-274715c4dabd11b0 = { package = "rand", version = "0.9.4" }
@@ -55,13 +56,13 @@ smallvec = { version = "1.15.1", default-features = false, features = ["const_ne
 subtle = { version = "2.6.1" }
 sync_wrapper = { version = "1.0.2", default-features = false, features = ["futures"] }
 time = { version = "0.3.47", features = ["formatting", "local-offset", "macros", "parsing"] }
-tokio = { version = "1.52.1", features = ["full", "test-util"] }
+tokio = { version = "1.52.2", features = ["full", "test-util"] }
 tokio-stream = { version = "0.1.18", features = ["sync"] }
 tokio-util = { version = "0.7.18", features = ["codec", "io", "rt"] }
 toml_datetime = { version = "1.1.1", features = ["serde"] }
 toml_parser = { version = "1.1.2" }
 tower = { version = "0.5.3", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "log"] }
-tower-http = { version = "0.6.8", features = ["cors", "limit", "trace"] }
+tower-http = { version = "0.6.9", features = ["cors", "limit", "trace"] }
 tracing = { version = "0.1.44", features = ["log"] }
 tracing-core = { version = "0.1.36" }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
@@ -96,6 +97,7 @@ num-complex = { version = "0.4.6" }
 num-integer = { version = "0.1.46", features = ["i128"] }
 num-iter = { version = "0.1.45", default-features = false, features = ["i128", "std"] }
 num-traits = { version = "0.2.19", features = ["i128", "libm"] }
+once_cell = { version = "1.21.4" }
 phf = { version = "0.11.3", features = ["macros"] }
 phf_shared = { version = "0.11.3" }
 proc-macro2 = { version = "1.0.106" }
@@ -114,13 +116,13 @@ subtle = { version = "2.6.1" }
 syn = { version = "2.0.117", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 sync_wrapper = { version = "1.0.2", default-features = false, features = ["futures"] }
 time = { version = "0.3.47", features = ["formatting", "local-offset", "macros", "parsing"] }
-tokio = { version = "1.52.1", features = ["full", "test-util"] }
+tokio = { version = "1.52.2", features = ["full", "test-util"] }
 tokio-stream = { version = "0.1.18", features = ["sync"] }
 tokio-util = { version = "0.7.18", features = ["codec", "io", "rt"] }
 toml_datetime = { version = "1.1.1", features = ["serde"] }
 toml_parser = { version = "1.1.2" }
 tower = { version = "0.5.3", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "log"] }
-tower-http = { version = "0.6.8", features = ["cors", "limit", "trace"] }
+tower-http = { version = "0.6.9", features = ["cors", "limit", "trace"] }
 tracing = { version = "0.1.44", features = ["log"] }
 tracing-core = { version = "0.1.36" }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
@@ -136,7 +138,7 @@ hyper-util = { version = "0.1.20", default-features = false, features = ["client
 libc = { version = "0.2.186", features = ["extra_traits"] }
 mio = { version = "1.2.0", features = ["net", "os-ext"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.8", default-features = false, features = ["follow-redirect"] }
+tower-http = { version = "0.6.9", default-features = false, features = ["follow-redirect"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
@@ -146,7 +148,7 @@ hyper-util = { version = "0.1.20", default-features = false, features = ["client
 libc = { version = "0.2.186", features = ["extra_traits"] }
 mio = { version = "1.2.0", features = ["net", "os-ext"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.8", default-features = false, features = ["follow-redirect"] }
+tower-http = { version = "0.6.9", default-features = false, features = ["follow-redirect"] }
 
 [target.aarch64-unknown-linux-gnu.dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
@@ -155,7 +157,7 @@ hyper-util = { version = "0.1.20", default-features = false, features = ["client
 libc = { version = "0.2.186", features = ["extra_traits"] }
 mio = { version = "1.2.0", features = ["net", "os-ext"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.8", default-features = false, features = ["follow-redirect"] }
+tower-http = { version = "0.6.9", default-features = false, features = ["follow-redirect"] }
 
 [target.aarch64-unknown-linux-gnu.build-dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
@@ -165,7 +167,7 @@ hyper-util = { version = "0.1.20", default-features = false, features = ["client
 libc = { version = "0.2.186", features = ["extra_traits"] }
 mio = { version = "1.2.0", features = ["net", "os-ext"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.8", default-features = false, features = ["follow-redirect"] }
+tower-http = { version = "0.6.9", default-features = false, features = ["follow-redirect"] }
 
 [target.x86_64-apple-darwin.dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
@@ -174,7 +176,7 @@ getrandom = { version = "0.4.2", default-features = false, features = ["std", "s
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.8", default-features = false, features = ["follow-redirect"] }
+tower-http = { version = "0.6.9", default-features = false, features = ["follow-redirect"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
@@ -184,7 +186,7 @@ getrandom = { version = "0.4.2", default-features = false, features = ["std", "s
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.8", default-features = false, features = ["follow-redirect"] }
+tower-http = { version = "0.6.9", default-features = false, features = ["follow-redirect"] }
 
 [target.aarch64-apple-darwin.dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
@@ -193,7 +195,7 @@ getrandom = { version = "0.4.2", default-features = false, features = ["std", "s
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.8", default-features = false, features = ["follow-redirect"] }
+tower-http = { version = "0.6.9", default-features = false, features = ["follow-redirect"] }
 
 [target.aarch64-apple-darwin.build-dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
@@ -203,13 +205,13 @@ getrandom = { version = "0.4.2", default-features = false, features = ["std", "s
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.8", default-features = false, features = ["follow-redirect"] }
+tower-http = { version = "0.6.9", default-features = false, features = ["follow-redirect"] }
 
 [target.x86_64-pc-windows-msvc.dependencies]
 getrandom = { version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.8", default-features = false, features = ["follow-redirect"] }
+tower-http = { version = "0.6.9", default-features = false, features = ["follow-redirect"] }
 winapi = { version = "0.3.9", default-features = false, features = ["cfg", "evntrace", "in6addr", "inaddr", "minwinbase", "ntsecapi", "sysinfoapi", "windef", "winioctl"] }
 windows = { version = "0.62.2", features = ["Wdk_System_SystemInformation", "Wdk_System_SystemServices", "Wdk_System_Threading", "Win32_Graphics_Direct3D", "Win32_Graphics_Direct3D11", "Win32_Graphics_Dxgi_Common", "Win32_Graphics_Gdi", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_NetworkManagement_NetManagement", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_Storage_Xps", "Win32_System_Com", "Win32_System_Diagnostics_Debug", "Win32_System_Diagnostics_ToolHelp", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_Kernel", "Win32_System_Memory", "Win32_System_Ole", "Win32_System_Performance", "Win32_System_Power", "Win32_System_ProcessStatus", "Win32_System_Registry", "Win32_System_RemoteDesktop", "Win32_System_Rpc", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_Variant", "Win32_System_WindowsProgramming", "Win32_System_Wmi", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
 windows-sys = { version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Globalization", "Win32_Networking_WinSock", "Win32_Security_Authorization", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Shell"] }
@@ -219,7 +221,7 @@ cc = { version = "1.2.61", default-features = false, features = ["parallel"] }
 getrandom = { version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.8", default-features = false, features = ["follow-redirect"] }
+tower-http = { version = "0.6.9", default-features = false, features = ["follow-redirect"] }
 winapi = { version = "0.3.9", default-features = false, features = ["cfg", "evntrace", "in6addr", "inaddr", "minwinbase", "ntsecapi", "sysinfoapi", "windef", "winioctl"] }
 windows = { version = "0.62.2", features = ["Wdk_System_SystemInformation", "Wdk_System_SystemServices", "Wdk_System_Threading", "Win32_Graphics_Direct3D", "Win32_Graphics_Direct3D11", "Win32_Graphics_Dxgi_Common", "Win32_Graphics_Gdi", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_NetworkManagement_NetManagement", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_Storage_Xps", "Win32_System_Com", "Win32_System_Diagnostics_Debug", "Win32_System_Diagnostics_ToolHelp", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_Kernel", "Win32_System_Memory", "Win32_System_Ole", "Win32_System_Performance", "Win32_System_Power", "Win32_System_ProcessStatus", "Win32_System_Registry", "Win32_System_RemoteDesktop", "Win32_System_Rpc", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_Variant", "Win32_System_WindowsProgramming", "Win32_System_Wmi", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
 windows-sys = { version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Globalization", "Win32_Networking_WinSock", "Win32_Security_Authorization", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Shell"] }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 # Import built-in modules
+import os
 from pathlib import Path
 
 # Import third-party modules
@@ -15,6 +16,41 @@ import dcc_mcp_core
 # Resolve examples/skills relative to repo root
 REPO_ROOT = Path(__file__).resolve().parent.parent
 EXAMPLES_SKILLS_DIR = str(REPO_ROOT / "examples" / "skills")
+
+#: Environment variable read by the Rust GatewayRunner / McpHttpConfig to
+#: override the default shared registry directory (issue #793).
+_DCC_MCP_REGISTRY_ENV = "DCC_MCP_REGISTRY_DIR"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _isolated_registry_dir(tmp_path_factory: pytest.TempPathFactory):
+    """Redirect the default registry directory to a session-scoped temp dir.
+
+    Many test modules start ``McpHttpServer`` / ``create_skill_server``
+    instances without an explicit ``registry_dir``.  When they do, the Rust
+    runtime falls back to ``<os-tmp>/dcc-mcp-registry`` — a **shared**
+    directory that persists between test runs and accumulates stale
+    ``services.json`` entries (issue #793).
+
+    Setting ``DCC_MCP_REGISTRY_DIR`` to a fresh temporary directory ensures
+    every server created during the session writes its registry entries in an
+    isolated location that pytest cleans up automatically at session teardown.
+
+    Tests that need a *distinct* registry (e.g. multi-service gateway tests)
+    should create their own sub-directory via ``tmp_path_factory.mktemp(...)``
+    and assign it to ``cfg.registry_dir`` explicitly — that explicit
+    assignment takes precedence and is unaffected by this fixture.
+    """
+    registry_dir = tmp_path_factory.mktemp("session-registry", numbered=True)
+    previous = os.environ.get(_DCC_MCP_REGISTRY_ENV)
+    os.environ[_DCC_MCP_REGISTRY_ENV] = str(registry_dir)
+    yield
+    # Restore (or remove) the env-var so we don't leak state into other
+    # processes that might be forked after the session ends.
+    if previous is None:
+        os.environ.pop(_DCC_MCP_REGISTRY_ENV, None)
+    else:
+        os.environ[_DCC_MCP_REGISTRY_ENV] = previous
 
 
 def create_skill_dir(


### PR DESCRIPTION
## Summary

Fixes #793 — stale  entries accumulate across test runs because many test modules start  /  without an explicit , causing all entries to land in the global shared `<tmp>/dcc-mcp-registry` directory.

## Three-layer fix

### 1. `tests/conftest.py` — session-scoped `autouse` fixture

Adds `_isolated_registry_dir` which sets `DCC_MCP_REGISTRY_DIR` to a fresh `pytest` temporary directory for the entire test session.  pytest deletes the directory automatically at teardown, so no stale entries survive between runs.

Covers ~30 test files that previously had no `registry_dir` isolation.

Tests that already use an explicit `cfg.registry_dir = str(tmp_path / ...)` are unaffected — the explicit assignment takes precedence.

### 2. `crates/dcc-mcp-gateway/src/gateway/runner.rs` — env-var fallback

`GatewayRunner::new()` now resolves the registry directory in this order:

1. `config.registry_dir` (explicit config)
2. `DCC_MCP_REGISTRY_DIR` environment variable  ← **new**
3. `<os-tmp>/dcc-mcp-registry` (legacy default)

This wires the conftest fixture into the Rust layer without changing any calling code.

### 3. `crates/dcc-mcp-transport/src/discovery/file_registry.rs` — `Drop` cleanup

Adds `impl Drop for FileRegistry` that calls `deregister()` for every entry whose sentinel lock handle is still held by this process.

- **Normal exit**: entries are removed from `services.json` immediately on drop, skipping the 15-second stale-timeout window.
- **Hard crash** (SIGKILL / OOM): the OS releases the sentinel lock files; the existing `prune_dead_entries` / `prune_dead_pids` path still evicts the orphaned rows on next probe.

This mirrors what `GatewayHandle::deregister_all` already does, but fires one level lower so callers that hold a `FileRegistry` directly (e.g. bare test servers that skip the gateway path) also clean up.