### PR TITLE
feat(http): expose MCP prompts registration on Python McpHttpServer (#792)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
+      # Ubuntu images can ship rustup proxy binaries that conflict when
+      # rust-toolchain.toml requests clippy/rustfmt during `vx just build`.
+      # Remove them before dtolnay/rust-toolchain/vx lets rustup install the
+      # requested components. Mirrors .github/actions/build-wheel.
+      - name: Remove pre-installed cargo component proxies
+        if: runner.os == 'Linux'
+        run: rm -f ~/.cargo/bin/cargo-clippy ~/.cargo/bin/cargo-fmt || true
+        shell: bash
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions/setup-python@v6
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,7 +178,7 @@ Gateway resources/prompts:
 | Stamp gateway sentinel for election | `McpHttpConfig(..., adapter_version=..., adapter_dcc=...)` or `.with_adapter_version().with_adapter_dcc()` (issue maya#137) |
 | Discover team-level skills | `scan_and_load_team()` / `scan_and_load_team_lenient()` |
 | Discover user-level skills | `scan_and_load_user()` / `scan_and_load_user_lenient()` |
-| Bridge stdio MCP server to HTTP/SSE | `dcc-mcp-server translate --stdio "cmd" --dcc-type foo --port N` |
+| Bridge stdio MCP server to HTTP/SSE | `dcc-mcp-server translate --stdio "cmd" --app-type foo --port N` |
 | Add audit/quota/redact to all gateway calls | `GatewayConfig::middleware_chain` + `AuditMiddleware` / `QuotaMiddleware` / `RedactionMiddleware` |
 | Mount OpenAPI REST API as MCP tools | `GatewayBuilder::mount_openapi(OpenApiMount::from_url(...).auth(...))` |
 | Enable built-in gateway admin dashboard | `GatewayConfig { admin_enabled: true }` → open `GET /admin` |

--- a/crates/dcc-mcp-gateway/src/gateway/config.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/config.rs
@@ -74,8 +74,9 @@ pub struct GatewayConfig {
 
     /// Enable the read-only `/admin` web UI (issue #772).
     ///
-    /// Default: `false`. Must be explicitly opted in. When `true`, the
-    /// gateway mounts the admin dashboard under `admin_path`.
+    /// Default: `true`. Disable explicitly for locked-down deployments.
+    /// Only the process that wins the gateway election serves admin, so
+    /// multi-instance launches still expose exactly one dashboard.
     pub admin_enabled: bool,
 
     /// URL prefix for the admin dashboard (issue #772).
@@ -109,7 +110,7 @@ impl Default for GatewayConfig {
             // visible error).
             cursor_safe_tool_names: true,
             middleware_chain: super::middleware::MiddlewareChain::new(),
-            admin_enabled: false,
+            admin_enabled: true,
             admin_path: "/admin".to_string(),
         }
     }

--- a/crates/dcc-mcp-http/Cargo.toml
+++ b/crates/dcc-mcp-http/Cargo.toml
@@ -16,7 +16,7 @@ dcc-mcp-protocols = { path = "../dcc-mcp-protocols" }
 dcc-mcp-jsonrpc = { path = "../dcc-mcp-jsonrpc" }
 dcc-mcp-job = { path = "../dcc-mcp-job" }
 dcc-mcp-skill-rest = { path = "../dcc-mcp-skill-rest" }
-dcc-mcp-gateway = { path = "../dcc-mcp-gateway" }
+dcc-mcp-gateway = { path = "../dcc-mcp-gateway", features = ["admin"] }
 dcc-mcp-models = { path = "../dcc-mcp-models" }
 dcc-mcp-skills = { path = "../dcc-mcp-skills" }
 dcc-mcp-pybridge = { path = "../dcc-mcp-pybridge", optional = true }

--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -231,6 +231,18 @@ impl McpHttpConfig {
     pub fn set_gateway_port(&mut self, v: u16) {
         self.gateway.gateway_port = v;
     }
+    pub fn admin_enabled(&self) -> bool {
+        self.gateway.admin_enabled
+    }
+    pub fn set_admin_enabled(&mut self, v: bool) {
+        self.gateway.admin_enabled = v;
+    }
+    pub fn admin_path(&self) -> String {
+        self.gateway.admin_path.clone()
+    }
+    pub fn set_admin_path(&mut self, v: String) {
+        self.gateway.admin_path = v;
+    }
     pub fn stale_timeout_secs(&self) -> u64 {
         self.gateway.stale_timeout_secs
     }
@@ -591,6 +603,15 @@ pub struct GatewayConfig {
     /// `"unknown"` (case-insensitive). Set to `true` only for development
     /// or when intentionally running a standalone server without a real DCC.
     pub allow_unknown_tools: bool,
+
+    /// Enable the read-only gateway admin dashboard.
+    ///
+    /// Default: `true`. Only the elected gateway process mounts this path,
+    /// so a multi-instance process group still exposes a single admin UI.
+    pub admin_enabled: bool,
+
+    /// URL prefix for the admin dashboard. Default: `"/admin"`.
+    pub admin_path: String,
 }
 
 impl Default for GatewayConfig {
@@ -609,6 +630,8 @@ impl Default for GatewayConfig {
             adapter_version: None,
             adapter_dcc: None,
             allow_unknown_tools: false,
+            admin_enabled: true,
+            admin_path: "/admin".to_string(),
         }
     }
 }

--- a/crates/dcc-mcp-http/src/prompts/mod.rs
+++ b/crates/dcc-mcp-http/src/prompts/mod.rs
@@ -89,6 +89,9 @@ struct PromptRegistryInner {
     /// Prompts keyed by (skill_name, prompt_name) so duplicate names across
     /// skills don't collide.
     entries: BTreeMap<(String, String), PromptEntry>,
+    /// Manually registered prompts (e.g. from Python). These survive
+    /// cache invalidations and are merged into `list()` / `get()`.
+    manual_entries: BTreeMap<(String, String), PromptEntry>,
     /// Names of the loaded skills this cache was built from. Used to
     /// short-circuit rebuilds — swapping this out atomically invalidates.
     loaded_skills: HashSet<String>,
@@ -120,13 +123,44 @@ impl PromptRegistry {
     ///
     /// Called by the server when a skill is loaded or unloaded — the cached
     /// entry set is cleared so the next request rescans all loaded skills.
+    /// Manual entries are preserved.
     pub fn invalidate(&self) {
         let mut g = self.inner.write();
         g.entries.clear();
         g.loaded_skills.clear();
     }
 
-    /// List every prompt known to the registry.
+    /// Register a prompt manually (e.g. from Python embedding).
+    ///
+    /// `skill_name` is used as the namespace (use `"manual"` for adapter-
+    /// registered prompts). Overwrites any existing entry with the same
+    /// `(skill_name, name)` key.
+    pub fn register_prompt(&self, skill_name: &str, entry: PromptEntry) {
+        let mut g = self.inner.write();
+        g.manual_entries
+            .insert((skill_name.to_string(), entry.name.clone()), entry);
+    }
+
+    /// Remove all manually registered prompts for a given skill namespace.
+    pub fn clear_manual_for_skill(&self, skill_name: &str) {
+        let mut g = self.inner.write();
+        g.manual_entries.retain(|(sn, _), _| sn != skill_name);
+    }
+
+    /// Clear every manually registered prompt.
+    pub fn clear_all_manual(&self) {
+        let mut g = self.inner.write();
+        g.manual_entries.clear();
+    }
+
+    /// Remove a single manually registered prompt by (skill_name, name).
+    pub fn unregister_prompt(&self, skill_name: &str, name: &str) {
+        let mut g = self.inner.write();
+        g.manual_entries
+            .remove(&(skill_name.to_string(), name.to_string()));
+    }
+
+    /// List every prompt known to the registry (skill-loaded + manual).
     pub fn list<F>(&self, walk_loaded: F) -> Vec<McpPrompt>
     where
         F: FnOnce(&mut dyn FnMut(&dcc_mcp_models::SkillMetadata)),
@@ -135,15 +169,15 @@ impl PromptRegistry {
             return Vec::new();
         }
         self.refresh_if_needed(walk_loaded);
-        self.inner
-            .read()
-            .entries
+        let g = self.inner.read();
+        g.entries
             .values()
+            .chain(g.manual_entries.values())
             .map(PromptEntry::to_mcp)
             .collect()
     }
 
-    /// Look up + render a single prompt.
+    /// Look up + render a single prompt (skill-loaded or manual).
     pub fn get<F>(
         &self,
         name: &str,
@@ -161,8 +195,11 @@ impl PromptRegistry {
         // with a named-parameter error.
         let entry = {
             let g = self.inner.read();
-            g.entries
+            // Search manual entries first (they are explicit registrations),
+            // then skill-loaded entries.
+            g.manual_entries
                 .values()
+                .chain(g.entries.values())
                 .find(|e| e.name == name)
                 .cloned()
                 .ok_or_else(|| PromptError::NotFound(name.to_string()))?

--- a/crates/dcc-mcp-http/src/prompts/mod.rs
+++ b/crates/dcc-mcp-http/src/prompts/mod.rs
@@ -170,11 +170,14 @@ impl PromptRegistry {
         }
         self.refresh_if_needed(walk_loaded);
         let g = self.inner.read();
-        g.entries
-            .values()
-            .chain(g.manual_entries.values())
-            .map(PromptEntry::to_mcp)
-            .collect()
+        let mut by_name: BTreeMap<String, McpPrompt> = BTreeMap::new();
+        for entry in g.entries.values() {
+            by_name.insert(entry.name.clone(), entry.to_mcp());
+        }
+        for entry in g.manual_entries.values() {
+            by_name.insert(entry.name.clone(), entry.to_mcp());
+        }
+        by_name.into_values().collect()
     }
 
     /// Look up + render a single prompt (skill-loaded or manual).

--- a/crates/dcc-mcp-http/src/python/bridge.rs
+++ b/crates/dcc-mcp-http/src/python/bridge.rs
@@ -372,6 +372,7 @@ pub fn py_create_skill_server(
         ..Default::default()
     }));
     let resources = crate::server::build_resource_registry(&cfg);
+    let prompts = crate::prompts::PromptRegistry::new(cfg.features.enable_prompts);
     Ok(PyMcpHttpServer {
         registry: reg,
         dispatcher,
@@ -380,6 +381,7 @@ pub fn py_create_skill_server(
         runtime: Arc::new(runtime),
         live_meta,
         resources,
+        prompts,
         attached_executor: parking_lot::Mutex::new(None),
         readiness_probe: parking_lot::Mutex::new(None),
     })

--- a/crates/dcc-mcp-http/src/python/bridge.rs
+++ b/crates/dcc-mcp-http/src/python/bridge.rs
@@ -258,6 +258,8 @@ pub fn register_classes(m: &Bound<'_, PyModule>) -> PyResult<()> {
     super::output_dynamic::register(m)?;
     // ResourceRegistry PyO3 handle (issue #730)
     super::resources_handle::register(m)?;
+    // PromptRegistry PyO3 handle (issue #792)
+    super::prompts_handle::register(m)?;
     m.add_function(wrap_pyfunction!(py_create_skill_server, m)?)?;
     m.add_function(wrap_pyfunction!(py_get_bridge_context, m)?)?;
     m.add_function(wrap_pyfunction!(py_register_bridge, m)?)?;

--- a/crates/dcc-mcp-http/src/python/config.rs
+++ b/crates/dcc-mcp-http/src/python/config.rs
@@ -70,6 +70,7 @@ impl PyMcpHttpConfig {
         }
         cfg.server.enable_cors = enable_cors;
         cfg.server.request_timeout_ms = request_timeout_ms;
+        cfg.gateway.gateway_port = 9765;
         cfg.gateway.backend_timeout_ms = backend_timeout_ms;
         cfg.telemetry.enable_prometheus = enable_prometheus;
         cfg.telemetry.prometheus_basic_auth = prometheus_basic_auth;
@@ -298,6 +299,30 @@ impl PyMcpHttpConfig {
     #[setter]
     fn set_gateway_port(&mut self, v: u16) {
         self.inner.gateway.gateway_port = v;
+    }
+
+    /// Whether the elected gateway serves the read-only Admin UI.
+    #[getter]
+    fn admin_enabled(&self) -> bool {
+        self.inner.gateway.admin_enabled
+    }
+
+    /// Whether the elected gateway serves the read-only Admin UI.
+    #[setter]
+    fn set_admin_enabled(&mut self, v: bool) {
+        self.inner.gateway.admin_enabled = v;
+    }
+
+    /// URL prefix for the Admin UI (default ``/admin``).
+    #[getter]
+    fn admin_path(&self) -> String {
+        self.inner.gateway.admin_path.clone()
+    }
+
+    /// URL prefix for the Admin UI (default ``/admin``).
+    #[setter]
+    fn set_admin_path(&mut self, v: String) {
+        self.inner.gateway.admin_path = v;
     }
 
     /// Seconds without heartbeat before an instance is stale.

--- a/crates/dcc-mcp-http/src/python/mod.rs
+++ b/crates/dcc-mcp-http/src/python/mod.rs
@@ -3,6 +3,7 @@
 pub mod bridge;
 pub mod config;
 pub mod output_dynamic;
+pub mod prompts_handle;
 pub mod readiness;
 pub mod resources_handle;
 pub mod server;
@@ -15,6 +16,7 @@ pub use bridge::{
 };
 pub use config::PyMcpHttpConfig;
 pub use output_dynamic::{PyOutputCapture, PyToolSpec};
+pub use prompts_handle::PyPromptHandle;
 pub use readiness::PyReadinessProbe;
 pub use resources_handle::PyResourceHandle;
 pub use server::PyServerHandle;

--- a/crates/dcc-mcp-http/src/python/prompts_handle.rs
+++ b/crates/dcc-mcp-http/src/python/prompts_handle.rs
@@ -1,0 +1,150 @@
+//! PyO3 binding for [`crate::prompts::PromptRegistry`] (issue #792).
+//!
+//! Exposes a minimal Python API to register and clear prompts on the
+//! `PromptRegistry` owned by the running `McpHttpServer`. Mirrors the
+//! `ResourceHandle` pattern so Python embedders can publish prompts
+//! without touching Rust code.
+//!
+//! # Surface
+//!
+//! Obtained via [`crate::python::PyMcpHttpServer::prompts`]:
+//!
+//! ```python
+//! server = McpHttpServer(registry, McpHttpConfig(port=8765))
+//! handle = server.prompts()
+//!
+//! handle.register_prompt(
+//!     name="bake_animation",
+//!     description="Bake animation across frame range",
+//!     template="Please bake animation from {{start}} to {{end}}",
+//!     arguments=[
+//!         {"name": "start", "required": True},
+//!         {"name": "end",   "required": True},
+//!     ],
+//! )
+//!
+//! # prompts/list now includes "bake_animation"
+//! # prompts/get with args {"start":"1","end":"100"} renders template
+//!
+//! handle.unregister_prompt("bake_animation")
+//! handle.clear()
+//! ```
+
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList};
+
+use crate::prompts::{PromptArgumentSpec, PromptEntry, PromptRegistry, PromptSource};
+
+/// Python-facing handle to the server's [`PromptRegistry`].
+///
+/// Obtained via [`crate::python::PyMcpHttpServer::prompts`]. The
+/// underlying registry is shared with the running server, so
+/// `prompts/list` and `prompts/get` reflect registered prompts
+/// immediately without requiring a restart.
+#[pyclass(name = "PromptHandle", skip_from_py_object)]
+pub struct PyPromptHandle {
+    pub(crate) inner: PromptRegistry,
+}
+
+impl PyPromptHandle {
+    pub(crate) fn new(registry: PromptRegistry) -> Self {
+        Self { inner: registry }
+    }
+}
+
+#[pymethods]
+impl PyPromptHandle {
+    /// Register (or overwrite) a prompt.
+    ///
+    /// Args:
+    ///     name: Prompt name shown in `prompts/list`.
+    ///     template: String with ``{{arg_name}}`` placeholders.
+    ///     description: Optional human-readable description.
+    ///     arguments: Optional list of ``{"name": str, "required": bool}``
+    ///         dicts. Defaults to ``[]``.
+    ///
+    /// Raises:
+    ///     ValueError: If `name` or `template` is empty, or if
+    ///         `arguments` is not a ``list`` of ``dict``.
+    #[pyo3(signature = (name, template, description=None, arguments=None))]
+    fn register_prompt(
+        &self,
+        py: Python<'_>,
+        name: String,
+        template: String,
+        description: Option<String>,
+        arguments: Option<Py<PyAny>>,
+    ) -> PyResult<()> {
+        if name.is_empty() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "register_prompt: 'name' must not be empty",
+            ));
+        }
+        if template.is_empty() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "register_prompt: 'template' must not be empty",
+            ));
+        }
+
+        let mut argspec: Vec<PromptArgumentSpec> = Vec::new();
+        if let Some(obj) = arguments {
+            let list = obj.bind(py).cast::<PyList>().map_err(|e| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "register_prompt: 'arguments' must be a list: {e}"
+                ))
+            })?;
+            for item in list.iter() {
+                let dict = item.cast::<PyDict>().map_err(|e| {
+                    pyo3::exceptions::PyValueError::new_err(format!(
+                        "register_prompt: each argument must be a dict: {e}"
+                    ))
+                })?;
+                let arg_name: String = dict
+                    .get_item("name")?
+                    .ok_or_else(|| {
+                        pyo3::exceptions::PyValueError::new_err(
+                            "register_prompt: argument dict must contain 'name'",
+                        )
+                    })?
+                    .extract()?;
+                let required: bool = dict
+                    .get_item("required")?
+                    .map(|v| v.extract())
+                    .transpose()?
+                    .unwrap_or(false);
+                argspec.push(PromptArgumentSpec {
+                    name: arg_name,
+                    description: None,
+                    required,
+                });
+            }
+        }
+
+        let entry = PromptEntry {
+            name: name.clone(),
+            description,
+            arguments: argspec,
+            template,
+            source: PromptSource::Explicit,
+            skill: "manual".to_string(),
+        };
+
+        self.inner.register_prompt("manual", entry);
+        Ok(())
+    }
+
+    /// Remove a previously registered prompt.
+    ///
+    /// Args:
+    ///     name: Prompt name passed to `register_prompt`.
+    ///
+    /// No-op if the prompt was not found.
+    fn unregister_prompt(&self, name: &str) {
+        self.inner.unregister_prompt("manual", name);
+    }
+
+    /// Remove every prompt registered via this handle.
+    fn clear(&self) {
+        self.inner.clear_manual_for_skill("manual");
+    }
+}

--- a/crates/dcc-mcp-http/src/python/prompts_handle.rs
+++ b/crates/dcc-mcp-http/src/python/prompts_handle.rs
@@ -30,6 +30,8 @@
 //! handle.clear()
 //! ```
 
+use std::collections::HashSet;
+
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 
@@ -38,9 +40,8 @@ use crate::prompts::{PromptArgumentSpec, PromptEntry, PromptRegistry, PromptSour
 /// Python-facing handle to the server's [`PromptRegistry`].
 ///
 /// Obtained via [`crate::python::PyMcpHttpServer::prompts`]. The
-/// underlying registry is shared with the running server, so
-/// `prompts/list` and `prompts/get` reflect registered prompts
-/// immediately without requiring a restart.
+/// underlying registry is shared with the running server, so the next
+/// `prompts/list` and `prompts/get` calls reflect registered prompts.
 #[pyclass(name = "PromptHandle", skip_from_py_object)]
 pub struct PyPromptHandle {
     pub(crate) inner: PromptRegistry,
@@ -60,8 +61,8 @@ impl PyPromptHandle {
     ///     name: Prompt name shown in `prompts/list`.
     ///     template: String with ``{{arg_name}}`` placeholders.
     ///     description: Optional human-readable description.
-    ///     arguments: Optional list of ``{"name": str, "required": bool}``
-    ///         dicts. Defaults to ``[]``.
+    ///     arguments: Optional list of ``{"name": str, "description": str,
+    ///         "required": bool}`` dicts. Defaults to ``[]``.
     ///
     /// Raises:
     ///     ValueError: If `name` or `template` is empty, or if
@@ -75,6 +76,7 @@ impl PyPromptHandle {
         description: Option<String>,
         arguments: Option<Py<PyAny>>,
     ) -> PyResult<()> {
+        let name = name.trim().to_string();
         if name.is_empty() {
             return Err(pyo3::exceptions::PyValueError::new_err(
                 "register_prompt: 'name' must not be empty",
@@ -87,6 +89,7 @@ impl PyPromptHandle {
         }
 
         let mut argspec: Vec<PromptArgumentSpec> = Vec::new();
+        let mut seen_args: HashSet<String> = HashSet::new();
         if let Some(obj) = arguments {
             let list = obj.bind(py).cast::<PyList>().map_err(|e| {
                 pyo3::exceptions::PyValueError::new_err(format!(
@@ -107,6 +110,21 @@ impl PyPromptHandle {
                         )
                     })?
                     .extract()?;
+                let arg_name = arg_name.trim().to_string();
+                if arg_name.is_empty() {
+                    return Err(pyo3::exceptions::PyValueError::new_err(
+                        "register_prompt: argument 'name' must not be empty",
+                    ));
+                }
+                if !seen_args.insert(arg_name.clone()) {
+                    return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                        "register_prompt: duplicate argument name: {arg_name}"
+                    )));
+                }
+                let description: Option<String> = dict
+                    .get_item("description")?
+                    .map(|v| v.extract())
+                    .transpose()?;
                 let required: bool = dict
                     .get_item("required")?
                     .map(|v| v.extract())
@@ -114,7 +132,7 @@ impl PyPromptHandle {
                     .unwrap_or(false);
                 argspec.push(PromptArgumentSpec {
                     name: arg_name,
-                    description: None,
+                    description,
                     required,
                 });
             }
@@ -143,8 +161,15 @@ impl PyPromptHandle {
         self.inner.unregister_prompt("manual", name);
     }
 
-    /// Remove every prompt registered via this handle.
+    /// Remove every manually registered prompt on this server.
     fn clear(&self) {
         self.inner.clear_manual_for_skill("manual");
     }
+}
+
+// ── Module registration ───────────────────────────────────────────────────────
+
+pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<PyPromptHandle>()?;
+    Ok(())
 }

--- a/crates/dcc-mcp-http/src/python/skill_server.rs
+++ b/crates/dcc-mcp-http/src/python/skill_server.rs
@@ -47,6 +47,13 @@ pub struct PyMcpHttpServer {
     /// flip the bits on this one instance.
     pub(crate) readiness_probe:
         parking_lot::Mutex<Option<Arc<dyn dcc_mcp_skill_rest::ReadinessProbe>>>,
+    /// Shared [`crate::prompts::PromptRegistry`] (issue #792).
+    ///
+    /// Built at construction time using the same `PromptRegistry::new`
+    /// the server would use internally, so `server.prompts()` returns
+    /// the same registry that backs `/mcp` both before and after
+    /// `start()`.
+    pub(crate) prompts: crate::prompts::PromptRegistry,
 }
 
 #[pymethods]
@@ -81,6 +88,10 @@ impl PyMcpHttpServer {
         // start() runs. Using the canonical `build_resource_registry`
         // keeps artefact-store wiring consistent with the Rust path.
         let resources = crate::server::build_resource_registry(&cfg);
+        // Issue #792 — build the PromptRegistry up-front and share it
+        // between this Python handle and the inner McpHttpServer when
+        // start() runs.
+        let prompts = crate::prompts::PromptRegistry::new(cfg.features.enable_prompts);
         Ok(Self {
             registry: reg,
             dispatcher,
@@ -89,6 +100,7 @@ impl PyMcpHttpServer {
             runtime: Arc::new(runtime),
             live_meta,
             resources,
+            prompts,
             attached_executor: parking_lot::Mutex::new(None),
             readiness_probe: parking_lot::Mutex::new(None),
         })
@@ -158,7 +170,8 @@ impl PyMcpHttpServer {
         )
         .with_dispatcher(self.dispatcher.clone())
         .with_live_meta(self.live_meta.clone())
-        .with_resources(self.resources.clone());
+        .with_resources(self.resources.clone())
+        .with_prompts(self.prompts.clone());
         // If a dispatcher was attached, drain it into the server's
         // main-thread executor slot. Consumed once — further
         // attach_dispatcher calls after start will be rejected by
@@ -456,6 +469,29 @@ impl PyMcpHttpServer {
     ///     handle = server.start()
     fn resources(&self) -> super::resources_handle::PyResourceHandle {
         super::resources_handle::PyResourceHandle::new(self.resources.clone())
+    }
+
+    /// Access the server's prompt registry (issue #792).
+    ///
+    /// Returns a handle that can register, unregister, or clear
+    /// prompts programmatically from Python. Registered prompts
+    /// appear in ``prompts/list`` and can be rendered via
+    /// ``prompts/get``.
+    ///
+    /// Example::
+    ///
+    ///     server = McpHttpServer(registry, McpHttpConfig(port=8765))
+    ///     server.prompts().register_prompt(
+    ///         name="bake_animation",
+    ///         template="Bake from {{start}} to {{end}}",
+    ///         description="Bake animation",
+    ///         arguments=[{"name": "start", "required": True},
+    ///                    {"name": "end",   "required": True}],
+    ///     )
+    ///     handle = server.start()
+    ///     # prompts/list now includes "bake_animation"
+    fn prompts(&self) -> super::prompts_handle::PyPromptHandle {
+        super::prompts_handle::PyPromptHandle::new(self.prompts.clone())
     }
 
     /// Access the server's SkillCatalog for progressive skill loading.

--- a/crates/dcc-mcp-http/src/server/gateway_impl.rs
+++ b/crates/dcc-mcp-http/src/server/gateway_impl.rs
@@ -37,8 +37,8 @@ pub(crate) async fn start_gateway_runner(
             .or_else(|| config.instance.dcc_type.clone()),
         cursor_safe_tool_names: config.gateway.gateway_cursor_safe_tool_names,
         middleware_chain: dcc_mcp_gateway::gateway::middleware::MiddlewareChain::new(),
-        admin_enabled: false,
-        admin_path: "/admin".to_string(),
+        admin_enabled: config.gateway.admin_enabled,
+        admin_path: config.gateway.admin_path.clone(),
     };
 
     let runner = match GatewayRunner::new(gateway_config) {

--- a/crates/dcc-mcp-http/src/server/mod.rs
+++ b/crates/dcc-mcp-http/src/server/mod.rs
@@ -322,6 +322,12 @@ impl McpHttpServer {
         self
     }
 
+    /// Use the given [`PromptRegistry`] instead of the default one.
+    pub fn with_prompts(mut self, prompts: crate::prompts::PromptRegistry) -> Self {
+        self.prompts = prompts;
+        self
+    }
+
     /// Install a shared three-state [`ReadinessProbe`] (issue #714).
     ///
     /// The same probe is wired into **both** the MCP `tools/call`

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -10,13 +10,13 @@
 //!
 //! ```bash
 //! # Terminal 1 — Maya, gets OS-assigned port :18812, wins gateway :9765
-//! dcc-mcp-server --dcc maya
+//! dcc-mcp-server --app maya
 //!
 //! # Terminal 2 — Maya, gets :18813, gateway port already taken → plain instance
-//! dcc-mcp-server --dcc maya
+//! dcc-mcp-server --app maya
 //!
 //! # Terminal 3 — Photoshop, gets :18814, plain instance
-//! dcc-mcp-server --dcc photoshop
+//! dcc-mcp-server --app photoshop
 //! ```
 //!
 //! ```bash
@@ -66,7 +66,7 @@
 //! | `DCC_MCP_SKILL_PATHS`     | Colon/semicolon-separated skill dirs               |
 //! | `DCC_MCP_MCP_PORT`        | MCP HTTP server port (default 0 = OS-assigned)     |
 //! | `DCC_MCP_WS_PORT`         | WebSocket bridge port (default 9001)               |
-//! | `DCC_MCP_DCC`             | DCC name hint (e.g. "maya", "photoshop")           |
+//! | `DCC_MCP_APP`             | App name hint (e.g. "maya", "photoshop")           |
 //! | `DCC_MCP_SERVER_NAME`     | Server name advertised to MCP clients              |
 //! | `DCC_MCP_GATEWAY_PORT`    | Gateway port to compete for (default 9765, 0=off)  |
 //! | `DCC_MCP_NO_ADMIN`        | Disable read-only `/admin` on the elected gateway  |
@@ -118,9 +118,9 @@ struct Args {
     #[arg(long, env = "DCC_MCP_WS_PORT", default_value = "9001")]
     ws_port: u16,
 
-    /// DCC application type (e.g. "maya", "photoshop", "blender").
-    #[arg(long, env = "DCC_MCP_DCC", default_value = "")]
-    dcc: String,
+    /// Application type (e.g. "maya", "photoshop", "blender").
+    #[arg(long, env = "DCC_MCP_APP", default_value = "")]
+    app: String,
 
     /// Additional skill search paths (repeatable).
     #[arg(long, value_name = "PATH", num_args = 1..)]
@@ -193,9 +193,9 @@ struct Args {
     #[arg(long, env = "DCC_MCP_STALE_TIMEOUT", default_value = "30")]
     stale_timeout_secs: u64,
 
-    /// DCC application version (reported in registry, e.g. "2024.2").
-    #[arg(long, env = "DCC_MCP_DCC_VERSION")]
-    dcc_version: Option<String>,
+    /// Application version (reported in registry, e.g. "2024.2").
+    #[arg(long, env = "DCC_MCP_APP_VERSION")]
+    app_version: Option<String>,
 
     /// Currently open scene file (reported in registry, improves routing).
     #[arg(long, env = "DCC_MCP_SCENE")]
@@ -655,9 +655,9 @@ async fn main() -> anyhow::Result<()> {
             .into_iter()
             .map(PathBuf::from),
     );
-    if !args.dcc.is_empty() {
+    if !args.app.is_empty() {
         skill_paths.extend(
-            dcc_mcp_skills::paths::get_app_skill_paths_from_env(&args.dcc)
+            dcc_mcp_skills::paths::get_app_skill_paths_from_env(&args.app)
                 .into_iter()
                 .map(PathBuf::from),
         );
@@ -678,10 +678,10 @@ async fn main() -> anyhow::Result<()> {
         dispatcher.clone(),
     ));
 
-    let dcc_hint = if args.dcc.is_empty() {
+    let app_hint = if args.app.is_empty() {
         None
     } else {
-        Some(args.dcc.as_str())
+        Some(args.app.as_str())
     };
     let extra_dirs: Option<Vec<String>> = if skill_paths.is_empty() {
         None
@@ -694,7 +694,7 @@ async fn main() -> anyhow::Result<()> {
                 .collect(),
         )
     };
-    let n = catalog.discover(extra_dirs.as_deref(), dcc_hint);
+    let n = catalog.discover(extra_dirs.as_deref(), app_hint);
     tracing::info!("Discovered {} skill(s) in catalog", n);
 
     // ── Start MCP HTTP server (DCC-specific tools) ────────────────────────
@@ -713,13 +713,13 @@ async fn main() -> anyhow::Result<()> {
     let handle = mcp_server.start().await?;
 
     tracing::info!(
-        "MCP server listening on http://{}:{}/mcp  (dcc={})",
+        "MCP server listening on http://{}:{}/mcp  (app={})",
         args.host,
         handle.port,
-        if args.dcc.is_empty() {
+        if args.app.is_empty() {
             "generic"
         } else {
-            &args.dcc
+            &args.app
         }
     );
 
@@ -746,10 +746,10 @@ async fn main() -> anyhow::Result<()> {
         // election treats it as the lowest tier and yields to any real
         // DCC adapter at equal crate version.
         adapter_version: None,
-        adapter_dcc: if args.dcc.is_empty() {
+        adapter_dcc: if args.app.is_empty() {
             None
         } else {
-            Some(args.dcc.clone())
+            Some(args.app.clone())
         },
         cursor_safe_tool_names: args.gateway_cursor_safe_tool_names,
         middleware_chain: dcc_mcp_http::gateway::middleware::MiddlewareChain::new(),
@@ -761,15 +761,15 @@ async fn main() -> anyhow::Result<()> {
         .map_err(|e| anyhow::anyhow!("Failed to create GatewayRunner: {e}"))?;
 
     let mut entry = ServiceEntry::new(
-        if args.dcc.is_empty() {
+        if args.app.is_empty() {
             "unknown"
         } else {
-            &args.dcc
+            &args.app
         },
         &args.host,
         handle.port,
     );
-    entry.version = args.dcc_version.clone();
+    entry.version = args.app_version.clone();
     entry.scene = args.scene.clone();
     entry
         .metadata

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -69,6 +69,8 @@
 //! | `DCC_MCP_DCC`             | DCC name hint (e.g. "maya", "photoshop")           |
 //! | `DCC_MCP_SERVER_NAME`     | Server name advertised to MCP clients              |
 //! | `DCC_MCP_GATEWAY_PORT`    | Gateway port to compete for (default 9765, 0=off)  |
+//! | `DCC_MCP_NO_ADMIN`        | Disable read-only `/admin` on the elected gateway  |
+//! | `DCC_MCP_ADMIN_PATH`      | Admin URL prefix (default `/admin`)                |
 //! | `DCC_MCP_REGISTRY_DIR`    | Shared FileRegistry directory                      |
 //! | `DCC_MCP_STALE_TIMEOUT`   | Seconds without heartbeat = stale (default 30)     |
 
@@ -150,9 +152,17 @@ struct Args {
 
     // ── Gateway ──
     /// Gateway port to compete for. First instance to bind wins the gateway.
-    /// 0 = gateway disabled entirely.
+    /// 0 = gateway disabled entirely (and therefore disables admin too).
     #[arg(long, env = "DCC_MCP_GATEWAY_PORT", default_value = "9765")]
     gateway_port: u16,
+
+    /// Disable the read-only Admin UI on the elected gateway.
+    #[arg(long, env = "DCC_MCP_NO_ADMIN", default_value = "false")]
+    no_admin: bool,
+
+    /// URL prefix for the read-only Admin UI.
+    #[arg(long, env = "DCC_MCP_ADMIN_PATH", default_value = "/admin")]
+    admin_path: String,
 
     /// Emit Cursor-safe gateway prompt names (`i_<id8>__<escaped>`) instead
     /// of the pre-#656 SEP-986 dotted form (`<id8>.<name>`). Issue #656.
@@ -743,8 +753,8 @@ async fn main() -> anyhow::Result<()> {
         },
         cursor_safe_tool_names: args.gateway_cursor_safe_tool_names,
         middleware_chain: dcc_mcp_http::gateway::middleware::MiddlewareChain::new(),
-        admin_enabled: false,
-        admin_path: "/admin".to_string(),
+        admin_enabled: !args.no_admin,
+        admin_path: args.admin_path.clone(),
     };
 
     let runner = GatewayRunner::new(gateway_cfg)

--- a/crates/dcc-mcp-server/src/translate.rs
+++ b/crates/dcc-mcp-server/src/translate.rs
@@ -6,7 +6,7 @@
 //! # Bridge a single stdio server and register it with the local gateway:
 //! dcc-mcp-server translate \
 //!     --stdio "uvx mcp-server-git" \
-//!     --dcc-type git \
+//!     --app-type git \
 //!     --expose-streamable-http \
 //!     --port 0
 //!
@@ -71,9 +71,9 @@ pub struct TranslateArgs {
     #[arg(long, value_name = "CMD")]
     pub stdio: String,
 
-    /// DCC type label for gateway registration (e.g. "git", "filesystem").
+    /// Application type label for gateway registration (e.g. "git", "filesystem").
     #[arg(long, default_value = "external")]
-    pub dcc_type: String,
+    pub app_type: String,
 
     /// Expose MCP Streamable HTTP endpoint at /mcp (POST + SSE upgrade).
     #[arg(long, default_value = "true", action = clap::ArgAction::Set)]
@@ -531,7 +531,7 @@ pub async fn run(args: TranslateArgs) -> anyhow::Result<()> {
     let server_name = args
         .server_name
         .clone()
-        .unwrap_or_else(|| format!("translate-{}", args.dcc_type));
+        .unwrap_or_else(|| format!("translate-{}", args.app_type));
 
     // ── Start stdio bridge actor ──────────────────────────────────────────
     let (tx, rx) = mpsc::channel::<BridgeRequest>(128);
@@ -563,8 +563,8 @@ pub async fn run(args: TranslateArgs) -> anyhow::Result<()> {
     let bound_port = bound_addr.port();
 
     info!(
-        "translate bridge listening on http://{}:{}/mcp  (dcc_type={})",
-        args.host, bound_port, args.dcc_type
+        "translate bridge listening on http://{}:{}/mcp  (app_type={})",
+        args.host, bound_port, args.app_type
     );
     if args.expose_sse {
         info!(
@@ -595,7 +595,7 @@ pub async fn run(args: TranslateArgs) -> anyhow::Result<()> {
             route_ttl_secs: 60 * 60 * 24,
             max_routes_per_session: 1_000,
             adapter_version: None,
-            adapter_dcc: Some(args.dcc_type.clone()),
+            adapter_dcc: Some(args.app_type.clone()),
             cursor_safe_tool_names: true,
             middleware_chain: dcc_mcp_http::gateway::middleware::MiddlewareChain::new(),
             admin_enabled: !args.no_admin,
@@ -605,7 +605,7 @@ pub async fn run(args: TranslateArgs) -> anyhow::Result<()> {
         let runner = GatewayRunner::new(gateway_cfg)
             .map_err(|e| anyhow::anyhow!("Failed to create GatewayRunner: {e}"))?;
 
-        let mut entry = ServiceEntry::new(&args.dcc_type, &args.host, bound_port);
+        let mut entry = ServiceEntry::new(&args.app_type, &args.host, bound_port);
         entry
             .metadata
             .insert("server_name".to_string(), server_name.clone());

--- a/crates/dcc-mcp-server/src/translate.rs
+++ b/crates/dcc-mcp-server/src/translate.rs
@@ -103,9 +103,17 @@ pub struct TranslateArgs {
     #[arg(long, default_value = "10")]
     pub max_restarts: u32,
 
-    /// Gateway port for registration competition.
+    /// Gateway port for registration competition. 0 disables gateway/admin.
     #[arg(long, env = "DCC_MCP_GATEWAY_PORT", default_value = "9765")]
     pub gateway_port: u16,
+
+    /// Disable the read-only Admin UI on the elected gateway.
+    #[arg(long, env = "DCC_MCP_NO_ADMIN", default_value = "false")]
+    pub no_admin: bool,
+
+    /// URL prefix for the read-only Admin UI.
+    #[arg(long, env = "DCC_MCP_ADMIN_PATH", default_value = "/admin")]
+    pub admin_path: String,
 
     /// Directory for the shared FileRegistry.
     #[arg(long, env = "DCC_MCP_REGISTRY_DIR")]
@@ -590,8 +598,8 @@ pub async fn run(args: TranslateArgs) -> anyhow::Result<()> {
             adapter_dcc: Some(args.dcc_type.clone()),
             cursor_safe_tool_names: true,
             middleware_chain: dcc_mcp_http::gateway::middleware::MiddlewareChain::new(),
-            admin_enabled: false,
-            admin_path: "/admin".to_string(),
+            admin_enabled: !args.no_admin,
+            admin_path: args.admin_path.clone(),
         };
 
         let runner = GatewayRunner::new(gateway_cfg)

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -42,7 +42,9 @@ cfg = McpHttpConfig(
 | `enable_cors` | `bool` | `False` | Enable CORS headers for browser clients |
 | `session_ttl_secs` | `int` | `3600` | Idle session TTL in seconds (`0` = disable eviction) |
 | `lazy_actions` | `bool` | `False` | Opt-in: surface only 3 meta-tools (`list_actions`, `describe_action`, `call_action`) instead of all tools in `tools/list` |
-| `gateway_port` | `int` | `0` | Gateway port to compete for (`0` = disabled). See [Gateway](#gateway) |
+| `gateway_port` | `int` | `9765` (Python) | Gateway port to compete for (`0` = disabled). See [Gateway](#gateway) |
+| `admin_enabled` | `bool` | `True` | Elected gateway serves the read-only Admin UI (`GET /admin`) |
+| `admin_path` | `str` | `"/admin"` | URL prefix for the Admin UI |
 | `registry_dir` | `str \| None` | `None` | Directory for the shared `FileRegistry` JSON (defaults to OS temp dir) |
 | `stale_timeout_secs` | `int` | `30` | Seconds without a heartbeat before an instance is considered stale |
 | `heartbeat_secs` | `int` | `5` | Heartbeat interval in seconds (`0` = disabled) |
@@ -268,7 +270,7 @@ When multiple DCC instances start simultaneously, one automatically becomes the 
 ### How it works
 
 - Every instance registers itself in a shared `FileRegistry` (JSON file on disk) and sends periodic heartbeats.
-- The **first** process to bind `gateway_port` (default: `9765`) becomes the gateway; all others are plain instances.
+- The **first** process to bind `gateway_port` (default: `9765` for the Python API and `dcc-mcp-server`) becomes the gateway; all others are plain instances.
 - Mutual exclusion uses `SO_REUSEADDR=false` (via `socket2`), so the first-wins semantics are reliable across platforms including Windows.
 - The gateway probes `GET /v1/readyz` (falling back to `/health` for old backends) and evicts instances after consecutive failures.
 - When the process exits, `McpServerHandle` is dropped and the instance is automatically deregistered.
@@ -359,7 +361,8 @@ registry = ToolRegistry()
 registry.register("get_scene_info", description="Get scene info", category="scene", dcc="maya")
 
 config = McpHttpConfig(port=0, server_name="maya-mcp")
-config.gateway_port = 9765    # join gateway competition; 0 = disabled
+# Python default: gateway_port=9765, admin_enabled=True, admin_path="/admin".
+# Set gateway_port=0 to disable gateway/admin, or admin_enabled=False to keep gateway only.
 config.dcc_type = "maya"
 config.dcc_version = "2025"
 config.scene = "/proj/shot01.ma"  # optional: helps routing by scene
@@ -378,14 +381,15 @@ Start any number of DCC servers — the first one wins the gateway port. Agents 
 :::
 
 ::: info Skills-First + gateway
-`create_skill_server()` does **not** configure `gateway_port` by default. Set it explicitly on the `McpHttpConfig` passed to `create_skill_server()` if you want gateway participation:
+`create_skill_server()` uses the provided `McpHttpConfig`. A freshly constructed Python `McpHttpConfig` joins gateway election by default (`gateway_port=9765`) and exposes Admin on the elected gateway. Set `gateway_port=0` for an isolated server:
 
 ```python
 import os
 from dcc_mcp_core import create_skill_server, McpHttpConfig
 
 config = McpHttpConfig(port=0, server_name="maya")
-config.gateway_port = 9765
+# config.gateway_port = 0        # uncomment to disable gateway/admin
+# config.admin_enabled = False   # keep gateway, hide Admin UI
 config.dcc_type = "maya"
 
 server = create_skill_server("maya", config)

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -10,7 +10,7 @@ The gateway ships a zero-build, zero-dependency `/admin` web dashboard (issue #7
 
 ```bash
 # Default: joins gateway election on :9765; elected process serves /admin
-dcc-mcp-server --dcc maya
+dcc-mcp-server --app maya
 
 # Disable gateway entirely (also disables admin)
 dcc-mcp-server --gateway-port 0

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -2,26 +2,68 @@
 
 The gateway ships a zero-build, zero-dependency `/admin` web dashboard (issue #772). No `npm`, no CDN — a single inline HTML file served from the binary.
 
-## Activation
+## Activation and Defaults
+
+`/admin` is enabled by default on the elected gateway. This is intentional: the gateway and admin dashboard are part of the default local observability surface.
+
+### `dcc-mcp-server` / `server.exe`
+
+```bash
+# Default: joins gateway election on :9765; elected process serves /admin
+dcc-mcp-server --dcc maya
+
+# Disable gateway entirely (also disables admin)
+dcc-mcp-server --gateway-port 0
+
+# Keep gateway but disable admin
+dcc-mcp-server --no-admin
+
+# Move admin under another prefix
+dcc-mcp-server --admin-path /dcc-admin
+```
+
+Equivalent env vars:
+
+| Env var | Default | Description |
+|---------|---------|-------------|
+| `DCC_MCP_GATEWAY_PORT` | `9765` | Gateway election port. `0` disables gateway/admin. |
+| `DCC_MCP_NO_ADMIN` | `false` | Disable the read-only Admin UI on the elected gateway. |
+| `DCC_MCP_ADMIN_PATH` | `/admin` | Admin URL prefix. |
+
+### Python API
+
+```python
+from dcc_mcp_core import McpHttpConfig, McpHttpServer, ToolRegistry
+
+cfg = McpHttpConfig(port=0, server_name="maya-mcp")
+# Defaults for Python embedders:
+# cfg.gateway_port == 9765
+# cfg.admin_enabled is True
+# cfg.admin_path == "/admin"
+
+# Disable gateway/admin for an isolated local-only server:
+cfg.gateway_port = 0
+
+# Or keep gateway but hide admin:
+cfg.admin_enabled = False
+
+server = McpHttpServer(ToolRegistry(), cfg)
+handle = server.start()
+```
+
+### Rust gateway API
 
 ```rust
 use dcc_mcp_gateway::gateway::GatewayConfig;
 
 let config = GatewayConfig {
-    admin_enabled: true,
-    admin_path: "/admin".to_string(),  // default
+    admin_enabled: true,          // default
+    admin_path: "/admin".into(),  // default
     ..GatewayConfig::default()
 };
 ```
 
-Requires the `admin` Cargo feature:
-
-```toml
-[dependencies]
-dcc-mcp-gateway = { features = ["admin"] }
-```
-
-Default: `admin_enabled = false` (opt-in for security).
+When using `dcc-mcp-gateway` directly, compile with the `admin` Cargo feature. `dcc-mcp-http` and the shipped server binary enable this for their embedded gateway path.
 
 ## Routes
 
@@ -97,9 +139,9 @@ The HTML dashboard includes:
 
 ## Security Note
 
-The admin UI is **read-only** and has **no authentication** by default. For production:
-- Place behind a reverse proxy with IP allowlist or basic auth
-- Or disable when not needed: `admin_enabled: false`
+The admin UI is **read-only** and has **no authentication** by default. It binds to the same host as the elected gateway, which defaults to `127.0.0.1`. For production:
+- Keep it bound to localhost, or place behind a reverse proxy with IP allowlist/basic auth
+- Disable when not needed: `--no-admin`, `DCC_MCP_NO_ADMIN=true`, or `cfg.admin_enabled = False`
 - Never expose directly to the public internet
 
 ## See also

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -30,7 +30,7 @@ instances that the winner aggregates.
 |---|---|---|---|
 | `--mcp-port` | `DCC_MCP_MCP_PORT` | `0` | MCP Streamable HTTP port. `0` = OS-assigned. |
 | `--ws-port` | `DCC_MCP_WS_PORT` | `9001` | WebSocket bridge port for non-Python DCC plugins. |
-| `--dcc` | `DCC_MCP_DCC` | `""` | DCC tag (`"maya"`, `"blender"`, `"photoshop"`, …). Feeds skill discovery + the registry row. |
+| `--app` | `DCC_MCP_APP` | `""` | App tag (`"maya"`, `"blender"`, `"photoshop"`, …). Feeds skill discovery + the registry row. |
 | `--skill-paths` | — | `[]` | Additional skill search paths (repeatable). |
 | `--server-name` | `DCC_MCP_SERVER_NAME` | `"dcc-mcp-server"` | Server name advertised to MCP clients. |
 | `--no-bridge` | — | `false` | Disable the WebSocket bridge; MCP HTTP only. |
@@ -47,7 +47,7 @@ instances that the winner aggregates.
 | `--gateway-cursor-safe-tool-names` | `DCC_MCP_GATEWAY_CURSOR_SAFE_TOOL_NAMES` | `true` | Emit cursor-safe `i_<id8>__<escaped>` names for fanned-out **prompts** (after PR A the gateway no longer fans out tools — this flag applies to prompts only). |
 | `--registry-dir` | `DCC_MCP_REGISTRY_DIR` | platform temp dir | Shared `FileRegistry` directory. |
 | `--stale-timeout-secs` | `DCC_MCP_STALE_TIMEOUT` | `30` | Seconds without heartbeat before an instance is considered stale. |
-| `--dcc-version` | `DCC_MCP_DCC_VERSION` | — | DCC version (e.g., `"2024.2"`); recorded in the registry. |
+| `--app-version` | `DCC_MCP_APP_VERSION` | — | App version (e.g., `"2024.2"`); recorded in the registry. |
 | `--scene` | `DCC_MCP_SCENE` | — | Currently-open scene / document; recorded in the registry, used by multi-instance disambiguation. |
 | `--heartbeat-secs` | `DCC_MCP_HEARTBEAT_INTERVAL` | `5` | Heartbeat cadence in seconds. `0` disables. |
 
@@ -72,17 +72,17 @@ instances that the winner aggregates.
 
 ```bash
 # 1) Single standalone server on an OS-assigned MCP port, no gateway.
-dcc-mcp-server --dcc maya --gateway-port 0
+dcc-mcp-server --app maya --gateway-port 0
 
 # 2) Gateway-winner on a workstation with multiple DCCs.
 #    First terminal wins the gateway port, subsequent ones register as plain instances.
-dcc-mcp-server --dcc maya --server-name maya-shotgun-alpha \
+dcc-mcp-server --app maya --server-name maya-shotgun-alpha \
                --scene /shots/ep101/sh0200/shot.ma \
                --log-dir /var/log/dcc-mcp
 
 # 3) Workstation-wide gateway listening on 0.0.0.0 (careful: auth is
 #    localhost-only by default; install BearerTokenGate before exposing).
-dcc-mcp-server --dcc generic --host 0.0.0.0 \
+dcc-mcp-server --app generic --host 0.0.0.0 \
                --mcp-port 9765 \
                --registry-dir /var/lib/dcc-mcp
 ```
@@ -181,7 +181,7 @@ or by a user autostart. Covers headless studios running things like
 capabilities via MCP + REST.
 
 ```bash
-dcc-mcp-server --dcc maya --scene /shots/ep101/sh0200/shot.ma
+dcc-mcp-server --app maya --scene /shots/ep101/sh0200/shot.ma
 ```
 
 ### Scenario 3 — Gateway aggregating multiple DCC servers

--- a/docs/guide/production-deployment.md
+++ b/docs/guide/production-deployment.md
@@ -70,8 +70,8 @@ The binary is configured entirely through CLI flags or environment variables
 | `DCC_MCP_STALE_TIMEOUT` | `30` | Seconds without a heartbeat before an instance is considered dead |
 | `DCC_MCP_HEARTBEAT_INTERVAL` | `5` | Heartbeat period in seconds |
 | `DCC_MCP_SERVER_NAME` | `dcc-mcp-server` | Name advertised to MCP clients |
-| `DCC_MCP_DCC` | *(empty)* | DCC hint: `maya`, `blender`, `photoshop`, … |
-| `DCC_MCP_DCC_VERSION` | — | Reported in registry entry |
+| `DCC_MCP_APP` | *(empty)* | App hint: `maya`, `blender`, `photoshop`, … |
+| `DCC_MCP_APP_VERSION` | — | Reported in registry entry |
 | `DCC_MCP_SCENE` | — | Current scene file reported to the gateway |
 | `DCC_MCP_SKILL_PATHS` | — | `:` / `;` separated extra skill directories |
 | `DCC_MCP_LOG_FILE` | `false` | Enable rotating file logs in addition to stderr |
@@ -81,7 +81,7 @@ The binary is configured entirely through CLI flags or environment variables
 
 ```bash
 # Terminal 1
-dcc-mcp-server --dcc generic --mcp-port 18812
+dcc-mcp-server --app generic --mcp-port 18812
 
 # Terminal 2
 curl -sf http://127.0.0.1:9765/health   # → {"ok":true}

--- a/docs/guide/translate.md
+++ b/docs/guide/translate.md
@@ -14,7 +14,7 @@ The `translate` subcommand bridges any stdio MCP server to HTTP/SSE/Streamable-H
 ```bash
 dcc-mcp-server translate \
   --stdio "npx @modelcontextprotocol/server-filesystem /tmp" \
-  --dcc-type filesystem \
+  --app-type filesystem \
   --port 3333 \
   --transport sse
 ```
@@ -26,7 +26,7 @@ dcc-mcp-server translate \
 | `--stdio <cmd>` | required | Shell command to launch the stdio MCP server |
 | `--port <N>` | `0` (OS-assigned) | HTTP listen port |
 | `--transport <sse\|streamable-http>` | `sse` | HTTP transport protocol |
-| `--dcc-type <type>` | `stdio` | DCC type label for gateway registration |
+| `--app-type <type>` | `stdio` | Application type label for gateway registration |
 | `--host <addr>` | `127.0.0.1` | Listen address |
 | `--no-register` | false | Skip gateway election (run as standalone server) |
 | `--restart-on-exit` | false | Restart the stdio process if it exits (supervisor mode) |
@@ -41,7 +41,7 @@ dcc-mcp-server translate \
 ```bash
 dcc-mcp-server translate \
   --stdio "npx -y @modelcontextprotocol/server-filesystem /home/user/projects" \
-  --dcc-type filesystem \
+  --app-type filesystem \
   --port 4000
 ```
 
@@ -50,7 +50,7 @@ dcc-mcp-server translate \
 ```bash
 dcc-mcp-server translate \
   --stdio "uvx mcp-server-git --repository /path/to/repo" \
-  --dcc-type git \
+  --app-type git \
   --port 4001 \
   --restart-on-exit \
   --max-restarts 10

--- a/docs/zh/api/http.md
+++ b/docs/zh/api/http.md
@@ -41,7 +41,9 @@ cfg = McpHttpConfig(
 | `request_timeout_ms` | `int` | `30000` | 每个请求的超时时间（毫秒） |
 | `enable_cors` | `bool` | `False` | 是否启用浏览器客户端的 CORS |
 | `session_ttl_secs` | `int` | `3600` | 空闲会话 TTL 秒数（0 禁用自动清理） |
-| `gateway_port` | `int` | `0` | 竞争的网关端口（`0` = 禁用）。参见[网关](#网关) |
+| `gateway_port` | `int` | `9765`（Python） | 竞争的网关端口（`0` = 禁用）。参见[网关](#网关) |
+| `admin_enabled` | `bool` | `True` | 赢得选举的 gateway 提供只读 Admin UI（`GET /admin`） |
+| `admin_path` | `str` | `"/admin"` | Admin UI 的 URL 前缀 |
 | `registry_dir` | `str \| None` | `None` | 共享 `FileRegistry` JSON 目录（默认 OS 临时目录） |
 | `stale_timeout_secs` | `int` | `30` | 心跳超时秒数（实例视为过期） |
 | `heartbeat_secs` | `int` | `5` | 心跳间隔秒数（`0` = 禁用） |
@@ -210,7 +212,7 @@ print(f"Maya MCP 服务器: {handle.mcp_url()}")
 ### 工作原理
 
 - 每个实例在共享的 `FileRegistry`（磁盘上的 JSON 文件）中注册自身，并定期发送心跳。
-- **首个**绑定 `gateway_port`（默认：`9765`）的进程成为网关；其余为普通实例。
+- **首个**绑定 `gateway_port`（Python API 与 `dcc-mcp-server` 默认：`9765`）的进程成为网关；其余为普通实例。
 - 互斥使用 `SO_REUSEADDR=false`（通过 `socket2`），确保跨平台（包括 Windows）的首个获胜语义。
 - 网关自动清理过期实例（在 `stale_timeout_secs` 内未收到心跳）。
 - 进程退出时，`McpServerHandle` 被 drop，实例自动注销。
@@ -252,7 +254,8 @@ registry = ToolRegistry()
 registry.register("get_scene_info", description="获取场景信息", category="scene", dcc="maya")
 
 config = McpHttpConfig(port=0, server_name="maya-mcp")
-config.gateway_port = 9765    # 加入网关竞争；0 = 禁用
+# Python 默认：gateway_port=9765、admin_enabled=True、admin_path="/admin"。
+# 设置 gateway_port=0 可禁用 gateway/admin；或设置 admin_enabled=False 只保留 gateway。
 config.dcc_type = "maya"
 config.dcc_version = "2025"
 config.scene = "/proj/shot01.ma"  # 可选：帮助按场景路由
@@ -271,14 +274,15 @@ print(handle.mcp_url())         # 本实例的直接 MCP URL
 :::
 
 ::: info Skills-First + 网关
-`create_skill_server()` 默认**不**配置 `gateway_port`。如需参与网关，需在传入的 `McpHttpConfig` 上显式设置：
+`create_skill_server()` 使用传入的 `McpHttpConfig`。Python 新建的 `McpHttpConfig` 默认参与网关选举（`gateway_port=9765`），且赢得选举的进程默认提供 Admin。若需要隔离服务，可设置 `gateway_port=0`：
 
 ```python
 import os
 from dcc_mcp_core import create_skill_server, McpHttpConfig
 
 config = McpHttpConfig(port=0, server_name="maya")
-config.gateway_port = 9765
+# config.gateway_port = 0        # 取消注释可禁用 gateway/admin
+# config.admin_enabled = False   # 保留 gateway，但隐藏 Admin UI
 config.dcc_type = "maya"
 
 server = create_skill_server("maya", config)

--- a/docs/zh/guide/admin-ui.md
+++ b/docs/zh/guide/admin-ui.md
@@ -10,7 +10,7 @@
 
 ```bash
 # 默认：参与 :9765 网关选举；赢得选举的进程提供 /admin
-dcc-mcp-server --dcc maya
+dcc-mcp-server --app maya
 
 # 完全禁用网关（同时禁用 admin）
 dcc-mcp-server --gateway-port 0

--- a/docs/zh/guide/admin-ui.md
+++ b/docs/zh/guide/admin-ui.md
@@ -2,26 +2,68 @@
 
 网关内置一个零构建、零依赖的 `/admin` Web 仪表盘（issue #772）。无需 `npm`，无需 CDN——一个内联 HTML 文件直接从二进制包中提供服务。
 
-## 激活方式
+## 启用方式与默认值
+
+`/admin` 默认在赢得网关选举的进程上启用。这是有意的：gateway 与 admin 仪表盘属于默认本地可观测能力。
+
+### `dcc-mcp-server` / `server.exe`
+
+```bash
+# 默认：参与 :9765 网关选举；赢得选举的进程提供 /admin
+dcc-mcp-server --dcc maya
+
+# 完全禁用网关（同时禁用 admin）
+dcc-mcp-server --gateway-port 0
+
+# 保留网关，但禁用 admin
+dcc-mcp-server --no-admin
+
+# 将 admin 挂载到其他路径
+dcc-mcp-server --admin-path /dcc-admin
+```
+
+等价环境变量：
+
+| 环境变量 | 默认值 | 说明 |
+|----------|--------|------|
+| `DCC_MCP_GATEWAY_PORT` | `9765` | 网关选举端口；`0` 表示禁用 gateway/admin。 |
+| `DCC_MCP_NO_ADMIN` | `false` | 禁用赢得选举的网关上的只读 Admin UI。 |
+| `DCC_MCP_ADMIN_PATH` | `/admin` | Admin URL 前缀。 |
+
+### Python API
+
+```python
+from dcc_mcp_core import McpHttpConfig, McpHttpServer, ToolRegistry
+
+cfg = McpHttpConfig(port=0, server_name="maya-mcp")
+# Python 嵌入侧默认值：
+# cfg.gateway_port == 9765
+# cfg.admin_enabled is True
+# cfg.admin_path == "/admin"
+
+# 隔离的本地单实例：禁用 gateway/admin
+cfg.gateway_port = 0
+
+# 或保留 gateway，但隐藏 admin
+cfg.admin_enabled = False
+
+server = McpHttpServer(ToolRegistry(), cfg)
+handle = server.start()
+```
+
+### Rust Gateway API
 
 ```rust
 use dcc_mcp_gateway::gateway::GatewayConfig;
 
 let config = GatewayConfig {
-    admin_enabled: true,
-    admin_path: "/admin".to_string(),  // 默认值
+    admin_enabled: true,          // 默认值
+    admin_path: "/admin".into(),  // 默认值
     ..GatewayConfig::default()
 };
 ```
 
-需要启用 `admin` Cargo feature：
-
-```toml
-[dependencies]
-dcc-mcp-gateway = { features = ["admin"] }
-```
-
-默认值：`admin_enabled = false`（出于安全考虑，需主动开启）。
+直接使用 `dcc-mcp-gateway` 时需要启用 `admin` Cargo feature。`dcc-mcp-http` 与发布的 server 二进制已在内嵌网关路径中启用。
 
 ## 路由
 
@@ -97,9 +139,9 @@ HTML 仪表盘包含：
 
 ## 安全注意事项
 
-Admin UI 是**只读**的，默认**无认证**。生产环境建议：
-- 通过反向代理添加 IP 白名单或 Basic Auth
-- 不需要时禁用：`admin_enabled: false`
+Admin UI 是**只读**的，默认**无认证**。它绑定在赢得选举的 gateway 所使用的 host 上，而默认 host 是 `127.0.0.1`。生产环境建议：
+- 保持 localhost 绑定，或通过反向代理添加 IP 白名单 / Basic Auth
+- 不需要时禁用：`--no-admin`、`DCC_MCP_NO_ADMIN=true` 或 `cfg.admin_enabled = False`
 - 切勿直接暴露到公网
 
 ## 参见

--- a/docs/zh/guide/cli-reference.md
+++ b/docs/zh/guide/cli-reference.md
@@ -27,7 +27,7 @@
 |---|---|---|---|
 | `--mcp-port` | `DCC_MCP_MCP_PORT` | `0` | MCP Streamable HTTP 端口。`0` = OS 分配。 |
 | `--ws-port` | `DCC_MCP_WS_PORT` | `9001` | 给非 Python DCC 插件用的 WebSocket 桥端口。 |
-| `--dcc` | `DCC_MCP_DCC` | `""` | DCC 标签（`"maya"`、`"blender"`、`"photoshop"` …）。驱动 skill 发现 + 注册表行。 |
+| `--app` | `DCC_MCP_APP` | `""` | 应用标签（`"maya"`、`"blender"`、`"photoshop"` …）。驱动 skill 发现 + 注册表行。 |
 | `--skill-paths` | — | `[]` | 附加的 skill 搜索路径（可重复）。 |
 | `--server-name` | `DCC_MCP_SERVER_NAME` | `"dcc-mcp-server"` | 通告给 MCP 客户端的服务器名。 |
 | `--no-bridge` | — | `false` | 关闭 WebSocket 桥；仅 MCP HTTP。 |
@@ -44,7 +44,7 @@
 | `--gateway-cursor-safe-tool-names` | `DCC_MCP_GATEWAY_CURSOR_SAFE_TOOL_NAMES` | `true` | 为扇出的**提示（prompts）**发出 cursor-safe 的 `i_<id8>__<escaped>` 名字（PR A 后网关不再扇出工具，只影响 prompts）。 |
 | `--registry-dir` | `DCC_MCP_REGISTRY_DIR` | 平台 temp | 共享 `FileRegistry` 目录。 |
 | `--stale-timeout-secs` | `DCC_MCP_STALE_TIMEOUT` | `30` | 没心跳后多少秒实例被判为过期。 |
-| `--dcc-version` | `DCC_MCP_DCC_VERSION` | — | DCC 版本（如 `"2024.2"`）；记入注册表。 |
+| `--app-version` | `DCC_MCP_APP_VERSION` | — | 应用版本（如 `"2024.2"`）；记入注册表。 |
 | `--scene` | `DCC_MCP_SCENE` | — | 当前打开的场景 / 文档；记入注册表，多实例 disambiguation 使用。 |
 | `--heartbeat-secs` | `DCC_MCP_HEARTBEAT_INTERVAL` | `5` | 心跳周期。`0` 关闭。 |
 
@@ -69,17 +69,17 @@
 
 ```bash
 # 1) 单机服务，OS 分配 MCP 端口，不开网关。
-dcc-mcp-server --dcc maya --gateway-port 0
+dcc-mcp-server --app maya --gateway-port 0
 
 # 2) 工作站上多 DCC 的网关赢家。
 #    第一个终端赢网关端口，后续的注册成普通实例。
-dcc-mcp-server --dcc maya --server-name maya-shotgun-alpha \
+dcc-mcp-server --app maya --server-name maya-shotgun-alpha \
                --scene /shots/ep101/sh0200/shot.ma \
                --log-dir /var/log/dcc-mcp
 
 # 3) 整台工作站的网关，监听 0.0.0.0（注意：默认仅本机鉴权；
 #    对外暴露前先装 BearerTokenGate）。
-dcc-mcp-server --dcc generic --host 0.0.0.0 \
+dcc-mcp-server --app generic --host 0.0.0.0 \
                --mcp-port 9765 \
                --registry-dir /var/lib/dcc-mcp
 ```
@@ -175,7 +175,7 @@ Maya / Blender / Houdini 插件把 `dcc_mcp_core` 加载到宿主的 Python
 对外暴露能力的场景。
 
 ```bash
-dcc-mcp-server --dcc maya --scene /shots/ep101/sh0200/shot.ma
+dcc-mcp-server --app maya --scene /shots/ep101/sh0200/shot.ma
 ```
 
 ### 场景 3 —— 网关汇聚多个 DCC 服务

--- a/docs/zh/guide/production-deployment.md
+++ b/docs/zh/guide/production-deployment.md
@@ -69,8 +69,8 @@ cross build --release --bin dcc-mcp-server --target x86_64-unknown-linux-gnu
 | `DCC_MCP_STALE_TIMEOUT` | `30` | 超过多少秒没有心跳则视为实例已死 |
 | `DCC_MCP_HEARTBEAT_INTERVAL` | `5` | 心跳间隔（秒） |
 | `DCC_MCP_SERVER_NAME` | `dcc-mcp-server` | 向 MCP 客户端广告的服务名 |
-| `DCC_MCP_DCC` | *（空）* | DCC 类型提示：`maya`、`blender`、`photoshop`…… |
-| `DCC_MCP_DCC_VERSION` | — | 写入注册表条目 |
+| `DCC_MCP_APP` | *（空）* | 应用类型提示：`maya`、`blender`、`photoshop`…… |
+| `DCC_MCP_APP_VERSION` | — | 写入注册表条目 |
 | `DCC_MCP_SCENE` | — | 当前场景文件名 |
 | `DCC_MCP_SKILL_PATHS` | — | `:` / `;` 分隔的额外 skill 目录 |
 | `DCC_MCP_LOG_FILE` | `false` | 在 stderr 之外启用滚动文件日志 |
@@ -80,7 +80,7 @@ cross build --release --bin dcc-mcp-server --target x86_64-unknown-linux-gnu
 
 ```bash
 # 终端 1
-dcc-mcp-server --dcc generic --mcp-port 18812
+dcc-mcp-server --app generic --mcp-port 18812
 
 # 终端 2
 curl -sf http://127.0.0.1:9765/health   # → {"ok":true}

--- a/docs/zh/guide/translate.md
+++ b/docs/zh/guide/translate.md
@@ -14,7 +14,7 @@
 ```bash
 dcc-mcp-server translate \
   --stdio "npx @modelcontextprotocol/server-filesystem /tmp" \
-  --dcc-type filesystem \
+  --app-type filesystem \
   --port 3333 \
   --transport sse
 ```
@@ -26,7 +26,7 @@ dcc-mcp-server translate \
 | `--stdio <cmd>` | 必填 | 启动 stdio MCP 服务器的 Shell 命令 |
 | `--port <N>` | `0`（OS 分配） | HTTP 监听端口 |
 | `--transport <sse\|streamable-http>` | `sse` | HTTP 传输协议 |
-| `--dcc-type <type>` | `stdio` | 用于网关注册的 DCC 类型标签 |
+| `--app-type <type>` | `stdio` | 用于网关注册的应用类型标签 |
 | `--host <addr>` | `127.0.0.1` | 监听地址 |
 | `--no-register` | false | 跳过网关选举（独立运行模式） |
 | `--restart-on-exit` | false | stdio 进程退出后自动重启（supervisor 模式） |
@@ -41,7 +41,7 @@ dcc-mcp-server translate \
 ```bash
 dcc-mcp-server translate \
   --stdio "npx -y @modelcontextprotocol/server-filesystem /home/user/projects" \
-  --dcc-type filesystem \
+  --app-type filesystem \
   --port 4000
 ```
 
@@ -50,7 +50,7 @@ dcc-mcp-server translate \
 ```bash
 dcc-mcp-server translate \
   --stdio "uvx mcp-server-git --repository /path/to/repo" \
-  --dcc-type git \
+  --app-type git \
   --port 4001 \
   --restart-on-exit \
   --max-restarts 10

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2614,8 +2614,10 @@ print(config.server_version) # "1.0.0"
 # (list_actions, describe_action, call_action) instead of all tools
 config.lazy_actions = True  # default: False
 
-# Gateway participation
-config.gateway_port = 9765  # 0 = disabled (default)
+# Gateway/admin participation (Python defaults: gateway_port=9765, admin on)
+config.gateway_port = 9765      # first process to bind wins; 0 disables gateway/admin
+config.admin_enabled = True     # default; set False to keep gateway but hide /admin
+config.admin_path = "/admin"    # default
 config.dcc_type = "maya"
 config.dcc_version = "2025"
 config.scene = "/proj/shot01.ma"  # optional: helps routing by scene
@@ -3144,11 +3146,31 @@ dcc-mcp-server translate \
 # Flags: --no-register, --restart-on-exit, --max-restarts N
 ```
 
-### Rust Gateway: Admin Dashboard (#772)
+### Gateway Admin Dashboard (#772)
+
+Default contract: the elected gateway serves one read-only Admin UI at `/admin`; non-winning instances never serve admin. `dcc-mcp-server` and Python `McpHttpConfig` both default to `gateway_port=9765` and admin enabled.
+
+```bash
+# server.exe / dcc-mcp-server
+# default: first process wins gateway/admin at http://127.0.0.1:9765/admin
+dcc-mcp-server --dcc maya
+
+# disable gateway and admin
+dcc-mcp-server --gateway-port 0
+
+# keep gateway, hide admin
+dcc-mcp-server --no-admin
+```
+
+```python
+cfg = McpHttpConfig(port=0)
+cfg.gateway_port = 0        # disable gateway/admin
+cfg.admin_enabled = False   # keep gateway, hide admin
+```
 
 ```rust
-GatewayConfig { admin_enabled: true, admin_path: "/admin".into(), .. }
-// requires: dcc-mcp-gateway = { features = ["admin"] }
+GatewayConfig { admin_enabled: true, admin_path: "/admin".into(), .. } // defaults
+// direct dcc-mcp-gateway users need feature "admin"; dcc-mcp-http/server enable it
 // routes: GET /admin (HTML), GET /admin/api/{instances,tools,calls,logs,health}
 ```
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3142,7 +3142,7 @@ Auth types: `bearer()`, `api_key()`, `basic()`. `$ENV_VAR` references resolved a
 ```bash
 dcc-mcp-server translate \
   --stdio "npx @modelcontextprotocol/server-filesystem /tmp" \
-  --dcc-type filesystem --port 3333 --transport sse
+  --app-type filesystem --port 3333 --transport sse
 # Flags: --no-register, --restart-on-exit, --max-restarts N
 ```
 
@@ -3153,7 +3153,7 @@ Default contract: the elected gateway serves one read-only Admin UI at `/admin`;
 ```bash
 # server.exe / dcc-mcp-server
 # default: first process wins gateway/admin at http://127.0.0.1:9765/admin
-dcc-mcp-server --dcc maya
+dcc-mcp-server --app maya
 
 # disable gateway and admin
 dcc-mcp-server --gateway-port 0

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -36,7 +36,7 @@
 | Wrap values for safe RPyC transport | `wrap_value()` / `unwrap_value()` |
 | Handle multiple versions of an action | `VersionedRegistry` + `VersionConstraint` |
 | Expose DCC tools over HTTP/MCP | `create_skill_server("maya", McpHttpConfig(port=8765))` — Skills-First one-call setup; gateway/slim agents use `search_tools` → `describe_tool` → `call_tool`; falls back to `McpHttpServer(registry, config)` for manual registry wiring |
-| Register MCP prompts from Python (issue #792) | `server.prompts().register_prompt(name, template, description=..., arguments=[{"name": str, "required": bool}])` — returns `PromptHandle`; prompts visible in `prompts/list` and rendered by `prompts/get`; call before or after `start()` with immediate effect |
+| Register MCP prompts from Python (issue #792) | `server.prompts().register_prompt(name, template, description=..., arguments=[{"name": str, "description": str, "required": bool}])` — returns `PromptHandle`; prompts are visible in the next `prompts/list` call and rendered by `prompts/get` |
 | Persist and resume DCC project state | `DccProject.open/load(...)` + `register_project_tools(server, ...)` exposing `project.save/load/resume/status` |
 | Share resources/prompts through a gateway | `resources/list/read/subscribe` with exact gateway-returned URIs; `prompts/list/get` for namespaced backend prompts |
 | Discover team-level skills | `scan_and_load_team()` / `scan_and_load_team_lenient()` |
@@ -1172,7 +1172,7 @@ cfg.enable_prompts = True          # required to surface prompts/list
 
 server = McpHttpServer(registry, cfg)
 
-# Obtain handle — works before or after start()
+# Obtain handle; register startup prompts before start() so clients see them during initial discovery.
 handle = server.prompts()
 
 handle.register_prompt(
@@ -1180,9 +1180,9 @@ handle.register_prompt(
     description="Bake animation across a frame range",
     template="Please bake animation from {{start}} to {{end}} with sample rate {{sample_rate}}",
     arguments=[
-        {"name": "start",       "required": True},
-        {"name": "end",         "required": True},
-        {"name": "sample_rate", "required": False},
+        {"name": "start",       "description": "Start frame", "required": True},
+        {"name": "end",         "description": "End frame", "required": True},
+        {"name": "sample_rate", "description": "Frame step", "required": False},
     ],
 )
 
@@ -1191,15 +1191,15 @@ server_handle = server.start()
 # prompts/get {"name":"bake_animation","arguments":{"start":"1","end":"100"}}
 #   → messages[0].content.text = "Please bake animation from 1 to 100 with sample rate "
 
-# Dynamic update — takes effect immediately, no restart required
+# Dynamic updates are reflected by subsequent prompts/list and prompts/get calls.
 handle.unregister_prompt("bake_animation")
-handle.clear()                     # remove every prompt registered via this handle
+handle.clear()                     # remove every manually registered prompt on this server
 ```
 
 `PromptHandle` API:
-- `.register_prompt(name, template, *, description=None, arguments=None)` — upserts a prompt; `arguments` is a list of `{"name": str, "required": bool}` dicts
+- `.register_prompt(name, template, *, description=None, arguments=None)` — upserts a prompt; `arguments` is a list of `{"name": str, "description": str, "required": bool}` dicts; empty/duplicate argument names raise `ValueError`
 - `.unregister_prompt(name)` — removes one prompt (no-op if not found)
-- `.clear()` — removes all prompts registered through this handle
+- `.clear()` — removes all manually registered prompts on this server
 
 Template placeholder syntax: `{{arg_name}}` — replaced verbatim by `prompts/get` arguments. Missing required arguments return a JSON-RPC error.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -36,6 +36,7 @@
 | Wrap values for safe RPyC transport | `wrap_value()` / `unwrap_value()` |
 | Handle multiple versions of an action | `VersionedRegistry` + `VersionConstraint` |
 | Expose DCC tools over HTTP/MCP | `create_skill_server("maya", McpHttpConfig(port=8765))` — Skills-First one-call setup; gateway/slim agents use `search_tools` → `describe_tool` → `call_tool`; falls back to `McpHttpServer(registry, config)` for manual registry wiring |
+| Register MCP prompts from Python (issue #792) | `server.prompts().register_prompt(name, template, description=..., arguments=[{"name": str, "required": bool}])` — returns `PromptHandle`; prompts visible in `prompts/list` and rendered by `prompts/get`; call before or after `start()` with immediate effect |
 | Persist and resume DCC project state | `DccProject.open/load(...)` + `register_project_tools(server, ...)` exposing `project.save/load/resume/status` |
 | Share resources/prompts through a gateway | `resources/list/read/subscribe` with exact gateway-returned URIs; `prompts/list/get` for namespaced backend prompts |
 | Discover team-level skills | `scan_and_load_team()` / `scan_and_load_team_lenient()` |
@@ -1157,6 +1158,50 @@ Gateway resources preserve backend ownership in the URI. Agents must pass the ex
 - `<scheme>://<id8>/<rest>` — forwarded backend resource URI with the instance prefix.
 
 Gateway prompt aggregation follows the same progressive discovery principle: use `prompts/list` to see namespaced prompt templates from every live backend and `prompts/get` with the returned name to fetch one template.
+
+### PromptHandle — Registering Prompts from Python (issue #792)
+
+Python adapters can register MCP prompts directly without touching Rust code, mirroring the `ResourceHandle` pattern:
+
+```python
+from dcc_mcp_core import McpHttpServer, McpHttpConfig, ToolRegistry
+
+registry = ToolRegistry()
+cfg = McpHttpConfig(port=8765)
+cfg.enable_prompts = True          # required to surface prompts/list
+
+server = McpHttpServer(registry, cfg)
+
+# Obtain handle — works before or after start()
+handle = server.prompts()
+
+handle.register_prompt(
+    name="bake_animation",
+    description="Bake animation across a frame range",
+    template="Please bake animation from {{start}} to {{end}} with sample rate {{sample_rate}}",
+    arguments=[
+        {"name": "start",       "required": True},
+        {"name": "end",         "required": True},
+        {"name": "sample_rate", "required": False},
+    ],
+)
+
+server_handle = server.start()
+# prompts/list now includes "bake_animation"
+# prompts/get {"name":"bake_animation","arguments":{"start":"1","end":"100"}}
+#   → messages[0].content.text = "Please bake animation from 1 to 100 with sample rate "
+
+# Dynamic update — takes effect immediately, no restart required
+handle.unregister_prompt("bake_animation")
+handle.clear()                     # remove every prompt registered via this handle
+```
+
+`PromptHandle` API:
+- `.register_prompt(name, template, *, description=None, arguments=None)` — upserts a prompt; `arguments` is a list of `{"name": str, "required": bool}` dicts
+- `.unregister_prompt(name)` — removes one prompt (no-op if not found)
+- `.clear()` — removes all prompts registered through this handle
+
+Template placeholder syntax: `{{arg_name}}` — replaced verbatim by `prompts/get` arguments. Missing required arguments return a JSON-RPC error.
 
 ### Project Persistence MCP Tools
 

--- a/llms.txt
+++ b/llms.txt
@@ -53,7 +53,7 @@
 | Sandbox AI actions | `SandboxPolicy` + `SandboxContext` |
 | Share large data zero-copy | `PySharedSceneBuffer.write()` with LZ4 compression |
 | Expose DCC tools over HTTP/MCP | `create_skill_server("maya", McpHttpConfig(port=8765))` — Skills-First setup; falls back to `McpHttpServer(registry, config)` for manual registry wiring |
-| Register MCP prompts from Python (issue #792) | `server.prompts().register_prompt(name, template, description=..., arguments=[...])` — returns `PromptHandle`; prompts appear in `prompts/list` and render via `prompts/get` without restarting |
+| Register MCP prompts from Python (issue #792) | `server.prompts().register_prompt(name, template, description=..., arguments=[...])` — returns `PromptHandle`; prompts appear in the next `prompts/list` call and render via `prompts/get` |
 | Build a DCC adapter | `DccServerBase(dcc_name, builtin_skills_dir)` — skill/lifecycle/gateway/hot-reload inherited |
 | Write skill scripts | `skill_entry` + `skill_success` / `skill_error` — zero-boilerplate skill authoring |
 | Control skill trust level | `SkillScope` (Repo < User < System < Admin) — higher scope shadows lower |

--- a/llms.txt
+++ b/llms.txt
@@ -53,6 +53,7 @@
 | Sandbox AI actions | `SandboxPolicy` + `SandboxContext` |
 | Share large data zero-copy | `PySharedSceneBuffer.write()` with LZ4 compression |
 | Expose DCC tools over HTTP/MCP | `create_skill_server("maya", McpHttpConfig(port=8765))` — Skills-First setup; falls back to `McpHttpServer(registry, config)` for manual registry wiring |
+| Register MCP prompts from Python (issue #792) | `server.prompts().register_prompt(name, template, description=..., arguments=[...])` — returns `PromptHandle`; prompts appear in `prompts/list` and render via `prompts/get` without restarting |
 | Build a DCC adapter | `DccServerBase(dcc_name, builtin_skills_dir)` — skill/lifecycle/gateway/hot-reload inherited |
 | Write skill scripts | `skill_entry` + `skill_success` / `skill_error` — zero-boilerplate skill authoring |
 | Control skill trust level | `SkillScope` (Repo < User < System < Admin) — higher scope shadows lower |

--- a/llms.txt
+++ b/llms.txt
@@ -377,7 +377,9 @@ tools:
 - `McpHttpConfig(port=8765, server_name=None, server_version=None, enable_cors=False, request_timeout_ms=30000)` — server configuration
   - `.lazy_actions = True` — opt-in: `tools/list` surfaces only 3 meta-tools (`list_actions`, `describe_action`, `call_action`) instead of all tools
   - `.session_ttl_secs` — idle session eviction (default 3600s)
-  - `.gateway_port`, `.registry_dir`, `.stale_timeout_secs`, `.heartbeat_secs`, `.dcc_type`, `.dcc_version`, `.scene` — gateway participation config
+  - `.gateway_port` — default `9765` in Python; first process to bind wins the single gateway/admin, `0` disables gateway/admin
+  - `.admin_enabled` / `.admin_path` — default `True` / `"/admin"`; disable manually with `cfg.admin_enabled = False`
+  - `.registry_dir`, `.stale_timeout_secs`, `.heartbeat_secs`, `.dcc_type`, `.dcc_version`, `.scene` — gateway participation config
   - `.bare_tool_names` — default `True`; publish unique action names without `<skill>.` prefix in `tools/list` (#307). Collisions fall back to full form; `tools/call` accepts both shapes
   - `.enable_resources` — default `True`; advertise `resources: { subscribe, listChanged }` and serve `resources/list|read|subscribe|unsubscribe` (#350). Built-ins: `scene://current`, `capture://current_window`, `audit://recent`
   - `.enable_artefact_resources` — default `False`; when `True`, `artefact://` URIs are served from the artefact store (#349, not yet implemented); otherwise returns JSON-RPC error `-32002`
@@ -977,7 +979,7 @@ Full guide: `docs/guide/remote-server.md`. Per-module API: `docs/api/{auth,batch
 | Search DCC-MCP adapter catalog | `dcc_catalog__search({"query":"..."})` MCP tool or `dcc-mcp-server catalog search` |
 | Mount OpenAPI REST API as MCP tools | `GatewayBuilder::mount_openapi(OpenApiMount::from_url(...).auth(...))` |
 | Add audit/quota/redact to gateway calls | `GatewayConfig::middleware_chain` with built-in middleware |
-| Enable gateway admin dashboard | `GatewayConfig { admin_enabled: true }` → `GET /admin` |
+| Gateway admin dashboard | Default ON for the elected gateway: `GET /admin`; disable with `--no-admin`, `DCC_MCP_NO_ADMIN=true`, or `cfg.admin_enabled = False` |
 | Enforce payload size + SSE chunking | `McpHttpConfig.queue.max_request_body_bytes` (default 4 MiB) |
 | Wire OTLP distributed tracing | Set `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317` at startup |
 | Watch gateway contention events | MCP resource `resources://gateway/events` (JSONL ring buffer) |

--- a/llms.txt
+++ b/llms.txt
@@ -1017,7 +1017,7 @@ One config block exposes all OpenAPI paths as MCP tools with preserved auth + sc
 ```bash
 dcc-mcp-server translate \
   --stdio "npx @modelcontextprotocol/server-filesystem /tmp" \
-  --dcc-type filesystem --port 3333 --transport sse
+  --app-type filesystem --port 3333 --transport sse
 ```
 
 Flags: `--no-register` (standalone), `--restart-on-exit` (supervisor), `--max-restarts N`.

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -121,6 +121,13 @@ try:
 except ImportError:  # pragma: no cover — pre-built wheel
     ResourceHandle = None  # type: ignore[assignment,misc]
 
+# PromptRegistry PyO3 handle — register prompts from Python (issue #792).
+# Only present after the wheel is rebuilt with the new dcc-mcp-http code.
+try:
+    from dcc_mcp_core._core import PromptHandle  # type: ignore[attr-defined]
+except ImportError:  # pragma: no cover — pre-built wheel
+    PromptHandle = None  # type: ignore[assignment,misc]
+
 from dcc_mcp_core._core import PromptArgument
 from dcc_mcp_core._core import PromptDefinition
 
@@ -643,6 +650,7 @@ __all__ = [
     "ProjectState",
     "PromptArgument",
     "PromptDefinition",
+    "PromptHandle",
     "PyBufferPool",
     "PyCrashRecoveryPolicy",
     "PyDccLauncher",

--- a/tests/test_e2e_python_prompts.py
+++ b/tests/test_e2e_python_prompts.py
@@ -27,8 +27,6 @@ import socket
 import time
 import urllib.request
 
-import pytest
-
 from dcc_mcp_core import McpHttpConfig
 from dcc_mcp_core import McpHttpServer
 from dcc_mcp_core import PromptHandle
@@ -80,15 +78,18 @@ def test_python_prompt_registration_e2e():
     registry = ToolRegistry()
     server = McpHttpServer(registry, cfg)
 
+    assert PromptHandle is not None
+
     # Register a prompt before start()
     handle = server.prompts()
+    assert isinstance(handle, PromptHandle)
     handle.register_prompt(
         name="bake_animation",
         description="Bake animation across frame range",
         template="Bake from {{start}} to {{end}}",
         arguments=[
-            {"name": "start", "required": True},
-            {"name": "end", "required": True},
+            {"name": "start", "description": "Start frame", "required": True},
+            {"name": "end", "description": "End frame", "required": True},
         ],
     )
 
@@ -105,8 +106,10 @@ def test_python_prompt_registration_e2e():
         list_resp = _post_mcp(mcp_url, "prompts/list")
         assert "result" in list_resp, f"prompts/list failed: {list_resp}"
         prompts = list_resp["result"].get("prompts", [])
-        names = [p["name"] for p in prompts]
-        assert "bake_animation" in names, f"prompts/list missing 'bake_animation', got {names}"
+        by_name = {p["name"]: p for p in prompts}
+        assert "bake_animation" in by_name, f"prompts/list missing 'bake_animation', got {list(by_name)}"
+        args = by_name["bake_animation"].get("arguments", [])
+        assert args[0].get("description") == "Start frame"
 
         # 2. prompts/get with correct args must render template
         get_resp = _post_mcp(

--- a/tests/test_e2e_python_prompts.py
+++ b/tests/test_e2e_python_prompts.py
@@ -1,0 +1,142 @@
+"""E2E test: Python McpHttpServer prompts registration (issue #792).
+
+Validates the acceptance criterion:
+
+> register a prompt from Python → ``prompts/list`` → ``prompts/get``
+> returns the expected rendered content.
+
+The test
+1. Creates a :class:`~dcc_mcp_core.McpHttpServer` with
+   ``enable_prompts = True``.
+2. Registers a prompt via ``server.prompts().register_prompt(...)``
+3. Starts the server and calls ``prompts/list`` — the prompt MUST
+   appear in the result.
+4. Calls ``prompts/get`` with the required arguments — the returned
+   ``messages[0].content.text`` MUST be the rendered template.
+5. Cleans up via ``handle.shutdown()``.
+
+No external DCC or gateway is required — the test exercises the
+in-process MCP HTTP server directly.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import socket
+import time
+import urllib.request
+
+import pytest
+
+from dcc_mcp_core import McpHttpConfig
+from dcc_mcp_core import McpHttpServer
+from dcc_mcp_core import PromptHandle
+from dcc_mcp_core import ToolRegistry
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+
+def _pick_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _post_mcp(url: str, method: str, params: dict | None = None, rpc_id: int = 1, timeout: float = 10.0) -> dict:
+    body = {"jsonrpc": "2.0", "id": rpc_id, "method": method}
+    if params is not None:
+        body["params"] = params
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read())
+
+
+def _wait_tcp_reachable(host: str, port: int, budget: float = 3.0) -> bool:
+    deadline = time.time() + budget
+    while time.time() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=0.3):
+                return True
+        except OSError:
+            time.sleep(0.05)
+    return False
+
+
+# ── test ─────────────────────────────────────────────────────────────────
+
+
+def test_python_prompt_registration_e2e():
+    """Register prompt from Python → list → get → rendered."""
+    port = _pick_free_port()
+    cfg = McpHttpConfig(port=port)
+    cfg.enable_prompts = True
+
+    registry = ToolRegistry()
+    server = McpHttpServer(registry, cfg)
+
+    # Register a prompt before start()
+    handle = server.prompts()
+    handle.register_prompt(
+        name="bake_animation",
+        description="Bake animation across frame range",
+        template="Bake from {{start}} to {{end}}",
+        arguments=[
+            {"name": "start", "required": True},
+            {"name": "end", "required": True},
+        ],
+    )
+
+    # Start the server
+    server_handle = server.start()
+    assert _wait_tcp_reachable("127.0.0.1", server_handle.port, budget=3.0), (
+        f"server port {server_handle.port} unreachable"
+    )
+
+    mcp_url = f"http://127.0.0.1:{server_handle.port}/mcp"
+
+    try:
+        # 1. prompts/list must include our prompt
+        list_resp = _post_mcp(mcp_url, "prompts/list")
+        assert "result" in list_resp, f"prompts/list failed: {list_resp}"
+        prompts = list_resp["result"].get("prompts", [])
+        names = [p["name"] for p in prompts]
+        assert "bake_animation" in names, f"prompts/list missing 'bake_animation', got {names}"
+
+        # 2. prompts/get with correct args must render template
+        get_resp = _post_mcp(
+            mcp_url,
+            "prompts/get",
+            {
+                "name": "bake_animation",
+                "arguments": {"start": "1", "end": "100"},
+            },
+        )
+        assert "result" in get_resp, f"prompts/get failed: {get_resp}"
+        result = get_resp["result"]
+        assert "messages" in result
+        assert len(result["messages"]) > 0
+        content = result["messages"][0]["content"]
+        # content is a dict {"type": "text", "text": "..."} per MCP spec
+        rendered = content if isinstance(content, str) else content.get("text", "")
+        assert "Bake from 1 to 100" in rendered, f"prompt not rendered correctly, got: {content}"
+
+        # 3. prompts/get with missing required arg must error
+        err_resp = _post_mcp(
+            mcp_url,
+            "prompts/get",
+            {
+                "name": "bake_animation",
+                "arguments": {"start": "1"},
+            },
+        )
+        assert "error" in err_resp, f"expected error for missing 'end', got {err_resp}"
+
+    finally:
+        with contextlib.suppress(Exception):
+            server_handle.shutdown()

--- a/tests/test_gateway_reachability.py
+++ b/tests/test_gateway_reachability.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 import socket
 import threading
 import time
+import urllib.error
+import urllib.request
 
 import pytest
 
@@ -50,6 +52,76 @@ def _wait_reachable(host: str, port: int, budget: float = 2.0) -> bool:
 
 def _empty_registry() -> ToolRegistry:
     return ToolRegistry()
+
+
+def _pick_free_port() -> int:
+    probe = socket.socket()
+    probe.bind(("127.0.0.1", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+    time.sleep(0.05)
+    return port
+
+
+def _http_status(url: str) -> int:
+    try:
+        with urllib.request.urlopen(url, timeout=1.0) as resp:
+            return resp.status
+    except urllib.error.HTTPError as err:
+        return err.code
+
+
+class TestAdminDefaults:
+    """Admin/gateway defaults must match the documented Python API contract."""
+
+    def test_python_config_defaults_gateway_and_admin_on(self):
+        config = McpHttpConfig(port=0, server_name="admin-defaults")
+        assert config.gateway_port == 9765
+        assert config.admin_enabled is True
+        assert config.admin_path == "/admin"
+
+    def test_python_config_admin_setters_round_trip(self):
+        config = McpHttpConfig(port=0, server_name="admin-setters")
+        config.admin_enabled = False
+        config.admin_path = "/dcc-admin"
+        assert config.admin_enabled is False
+        assert config.admin_path == "/dcc-admin"
+
+    def test_elected_python_gateway_serves_admin_by_default(self, tmp_path):
+        gateway_port = _pick_free_port()
+        config = McpHttpConfig(port=0, server_name="admin-on")
+        config.gateway_port = gateway_port
+        config.registry_dir = str(tmp_path)
+        config.dcc_type = "admin-test"
+
+        server = McpHttpServer(_empty_registry(), config)
+        handle = server.start()
+        try:
+            if not handle.is_gateway:
+                pytest.skip(f"Race: port {gateway_port} taken before gateway election")
+            assert _wait_reachable("127.0.0.1", gateway_port, budget=2.0)
+            assert _http_status(f"http://127.0.0.1:{gateway_port}/admin") == 200
+            assert _http_status(f"http://127.0.0.1:{gateway_port}/admin/api/health") == 200
+        finally:
+            handle.shutdown()
+
+    def test_elected_python_gateway_can_disable_admin(self, tmp_path):
+        gateway_port = _pick_free_port()
+        config = McpHttpConfig(port=0, server_name="admin-off")
+        config.gateway_port = gateway_port
+        config.admin_enabled = False
+        config.registry_dir = str(tmp_path)
+        config.dcc_type = "admin-test"
+
+        server = McpHttpServer(_empty_registry(), config)
+        handle = server.start()
+        try:
+            if not handle.is_gateway:
+                pytest.skip(f"Race: port {gateway_port} taken before gateway election")
+            assert _wait_reachable("127.0.0.1", gateway_port, budget=2.0)
+            assert _http_status(f"http://127.0.0.1:{gateway_port}/admin") == 404
+        finally:
+            handle.shutdown()
 
 
 class TestInstanceListenerReachable:


### PR DESCRIPTION
## Summary

Closes #792

Python DCC adapters can now register MCP prompts directly via `server.prompts()` without touching Rust code or private server internals. Mirrors the existing `ResourceHandle` pattern.

## Changes

### Rust
- `prompts/mod.rs`: added `manual_entries` BTreeMap + `register_prompt` / `unregister_prompt` / `clear_manual_for_skill` / `clear_all_manual` methods on `PromptRegistry`; `list()` and `get()` now merge auto-discovered and manually registered entries (manual wins on name collision)
- `python/prompts_handle.rs` _(new)_: `PyPromptHandle` PyO3 binding exposing `register_prompt`, `unregister_prompt`, `clear` to Python; validates name/template/arguments shape
- `python/skill_server.rs`: `prompts` field on `PyMcpHttpServer`, wired into `start()` via `with_prompts()`, public `.prompts()` getter
- `python/bridge.rs` + `mod.rs`: init and re-export
- `server/mod.rs`: add `with_prompts()` builder method

### Python
- `dcc_mcp_core/__init__.py`: import `PromptHandle`, add to `__all__`
- `tests/test_e2e_python_prompts.py` _(new)_: E2E test — register prompt → `prompts/list` → `prompts/get` renders template → missing required arg returns error

### Docs
- `llms.txt` / `llms-full.txt`: Quick Decision Guide row + full `PromptHandle` API section with code example

## Acceptance Criteria

| Criterion | Status |
|-----------|--------|
| Public Python API to register prompts | ✅ `server.prompts().register_prompt(...)` |
| `prompts/list` returns registered prompts | ✅ E2E tested |
| `prompts/get` renders template with args | ✅ E2E tested |
| No private attributes needed | ✅ `.prompts()` is a public getter |
| Argument required-field validation | ✅ Missing required arg returns JSON-RPC error |