### PR TITLE
ci: guard release package versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,41 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  release-metadata:
+    name: Release metadata
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+      - name: Validate package versions
+        run: |
+          python - <<'PY'
+          import sys
+          import tomllib
+          from pathlib import Path
+
+          pyproject_version = tomllib.loads(Path("pyproject.toml").read_text())["project"]["version"]
+          cargo_version = tomllib.loads(Path("Cargo.toml").read_text())["workspace"]["package"]["version"]
+          versions = {
+              "pyproject.toml": pyproject_version,
+              "Cargo.toml": cargo_version,
+          }
+
+          lock = tomllib.loads(Path("Cargo.lock").read_text())
+          for package in lock["package"]:
+              name = package["name"]
+              if name == "dcc-mcp-core" or name.startswith("dcc-mcp-"):
+                  versions[f"Cargo.lock:{name}"] = package["version"]
+
+          mismatches = {source: version for source, version in versions.items() if version != pyproject_version}
+          if mismatches:
+              for source, version in sorted(mismatches.items()):
+                  print(f"{source} has {version}, expected {pyproject_version}", file=sys.stderr)
+              sys.exit(1)
+          PY
+
   # ── Rust checks (check + clippy + fmt + cargo test) ──
   rust-check:
     name: Rust (${{ matrix.os }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,41 @@ jobs:
       id-token: write
       contents: write
     steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Validate release version
+        env:
+          RELEASE_VERSION: ${{ needs.release-please.outputs.version }}
+        run: |
+          python - <<'PY'
+          import os
+          import sys
+          import tomllib
+          from pathlib import Path
+
+          release_version = os.environ["RELEASE_VERSION"]
+          versions = {
+              "pyproject.toml": tomllib.loads(Path("pyproject.toml").read_text())["project"]["version"],
+              "Cargo.toml": tomllib.loads(Path("Cargo.toml").read_text())["workspace"]["package"]["version"],
+          }
+
+          lock = tomllib.loads(Path("Cargo.lock").read_text())
+          for package in lock["package"]:
+              name = package["name"]
+              if name == "dcc-mcp-core" or name.startswith("dcc-mcp-"):
+                  versions[f"Cargo.lock:{name}"] = package["version"]
+
+          mismatches = {source: version for source, version in versions.items() if version != release_version}
+          if mismatches:
+              for source, version in sorted(mismatches.items()):
+                  print(f"{source} has {version}, expected {release_version}", file=sys.stderr)
+              sys.exit(1)
+          PY
+
       - name: Download all wheel artifacts
         uses: actions/download-artifact@v8
         with:
@@ -133,6 +168,7 @@ jobs:
           packages-dir: dist
           verbose: true
           print-hash: true
+          skip-existing: true
 
       - name: Upload wheels to GitHub Release
         uses: softprops/action-gh-release@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -88,7 +88,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -713,7 +713,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dcc-mcp-actions"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "dashmap",
  "dcc-mcp-models",
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-artefact"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "chrono",
  "hex",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-capture"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "image",
  "libc",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-catalog"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-core"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "dcc-mcp-actions",
  "dcc-mcp-artefact",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-gateway"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "axum",
  "chrono",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-host"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-http"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "axum",
  "axum-test",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-job"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "chrono",
  "dashmap",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-jsonrpc"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-logging"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "dcc-mcp-paths",
  "parking_lot",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-models"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "dcc-mcp-naming",
  "dcc-mcp-pybridge",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-naming"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "pyo3",
  "pyo3-stub-gen",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-paths"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "dirs",
  "pyo3",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-process"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "dcc-mcp-models",
  "ipckit",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-protocols"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-pybridge"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "dcc-mcp-pybridge-derive",
  "pyo3",
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-pybridge-derive"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-sandbox"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-scheduler"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "axum",
  "bytes",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-server"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-shm"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "ipckit",
  "libc",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-skill-rest"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "axum",
  "axum-test",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-skills"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "dashmap",
  "dcc-mcp-actions",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-telemetry"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-transport"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "criterion",
  "dashmap",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-agent"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1261,7 +1261,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-protocol"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "jsonwebtoken",
  "rmp-serde",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-relay"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-usd"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "dcc-mcp-protocols",
  "pyo3",
@@ -1313,7 +1313,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-workflow"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "base64",
  "chrono",
@@ -1409,7 +1409,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1533,7 +1533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2712,7 +2712,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3994,7 +3994,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4051,7 +4051,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4401,7 +4401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4523,7 +4523,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4837,9 +4837,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
@@ -5457,7 +5457,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5977,6 +5977,8 @@ dependencies = [
  "typenum",
  "winapi",
  "windows",
+ "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
  "windows-sys 0.61.2",
  "winnow 1.0.2",
  "zerocopy",

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -62,7 +62,7 @@ tokio-util = { version = "0.7.18", features = ["codec", "io", "rt"] }
 toml_datetime = { version = "1.1.1", features = ["serde"] }
 toml_parser = { version = "1.1.2" }
 tower = { version = "0.5.3", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "log"] }
-tower-http = { version = "0.6.9", features = ["cors", "limit", "trace"] }
+tower-http = { version = "0.6.10", features = ["cors", "limit", "trace"] }
 tracing = { version = "0.1.44", features = ["log"] }
 tracing-core = { version = "0.1.36" }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
@@ -122,7 +122,7 @@ tokio-util = { version = "0.7.18", features = ["codec", "io", "rt"] }
 toml_datetime = { version = "1.1.1", features = ["serde"] }
 toml_parser = { version = "1.1.2" }
 tower = { version = "0.5.3", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "log"] }
-tower-http = { version = "0.6.9", features = ["cors", "limit", "trace"] }
+tower-http = { version = "0.6.10", features = ["cors", "limit", "trace"] }
 tracing = { version = "0.1.44", features = ["log"] }
 tracing-core = { version = "0.1.36" }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
@@ -138,7 +138,7 @@ hyper-util = { version = "0.1.20", default-features = false, features = ["client
 libc = { version = "0.2.186", features = ["extra_traits"] }
 mio = { version = "1.2.0", features = ["net", "os-ext"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.9", default-features = false, features = ["follow-redirect"] }
+tower-http = { version = "0.6.10", default-features = false, features = ["follow-redirect"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
@@ -148,7 +148,7 @@ hyper-util = { version = "0.1.20", default-features = false, features = ["client
 libc = { version = "0.2.186", features = ["extra_traits"] }
 mio = { version = "1.2.0", features = ["net", "os-ext"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.9", default-features = false, features = ["follow-redirect"] }
+tower-http = { version = "0.6.10", default-features = false, features = ["follow-redirect"] }
 
 [target.aarch64-unknown-linux-gnu.dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
@@ -157,7 +157,7 @@ hyper-util = { version = "0.1.20", default-features = false, features = ["client
 libc = { version = "0.2.186", features = ["extra_traits"] }
 mio = { version = "1.2.0", features = ["net", "os-ext"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.9", default-features = false, features = ["follow-redirect"] }
+tower-http = { version = "0.6.10", default-features = false, features = ["follow-redirect"] }
 
 [target.aarch64-unknown-linux-gnu.build-dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
@@ -167,7 +167,7 @@ hyper-util = { version = "0.1.20", default-features = false, features = ["client
 libc = { version = "0.2.186", features = ["extra_traits"] }
 mio = { version = "1.2.0", features = ["net", "os-ext"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.9", default-features = false, features = ["follow-redirect"] }
+tower-http = { version = "0.6.10", default-features = false, features = ["follow-redirect"] }
 
 [target.x86_64-apple-darwin.dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
@@ -176,7 +176,7 @@ getrandom = { version = "0.4.2", default-features = false, features = ["std", "s
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.9", default-features = false, features = ["follow-redirect"] }
+tower-http = { version = "0.6.10", default-features = false, features = ["follow-redirect"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
@@ -186,7 +186,7 @@ getrandom = { version = "0.4.2", default-features = false, features = ["std", "s
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.9", default-features = false, features = ["follow-redirect"] }
+tower-http = { version = "0.6.10", default-features = false, features = ["follow-redirect"] }
 
 [target.aarch64-apple-darwin.dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
@@ -195,7 +195,7 @@ getrandom = { version = "0.4.2", default-features = false, features = ["std", "s
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.9", default-features = false, features = ["follow-redirect"] }
+tower-http = { version = "0.6.10", default-features = false, features = ["follow-redirect"] }
 
 [target.aarch64-apple-darwin.build-dependencies]
 bitflags = { version = "2.11.1", default-features = false, features = ["std"] }
@@ -205,25 +205,29 @@ getrandom = { version = "0.4.2", default-features = false, features = ["std", "s
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2.186", features = ["extra_traits"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.9", default-features = false, features = ["follow-redirect"] }
+tower-http = { version = "0.6.10", default-features = false, features = ["follow-redirect"] }
 
 [target.x86_64-pc-windows-msvc.dependencies]
 getrandom = { version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.9", default-features = false, features = ["follow-redirect"] }
+tower-http = { version = "0.6.10", default-features = false, features = ["follow-redirect"] }
 winapi = { version = "0.3.9", default-features = false, features = ["cfg", "evntrace", "in6addr", "inaddr", "minwinbase", "ntsecapi", "sysinfoapi", "windef", "winioctl"] }
 windows = { version = "0.62.2", features = ["Wdk_System_SystemInformation", "Wdk_System_SystemServices", "Wdk_System_Threading", "Win32_Graphics_Direct3D", "Win32_Graphics_Direct3D11", "Win32_Graphics_Dxgi_Common", "Win32_Graphics_Gdi", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_NetworkManagement_NetManagement", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_Storage_Xps", "Win32_System_Com", "Win32_System_Diagnostics_Debug", "Win32_System_Diagnostics_ToolHelp", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_Kernel", "Win32_System_Memory", "Win32_System_Ole", "Win32_System_Performance", "Win32_System_Power", "Win32_System_ProcessStatus", "Win32_System_Registry", "Win32_System_RemoteDesktop", "Win32_System_Rpc", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_Variant", "Win32_System_WindowsProgramming", "Win32_System_Wmi", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
-windows-sys = { version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Globalization", "Win32_Networking_WinSock", "Win32_Security_Authorization", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Shell"] }
+windows-sys-4db8c43aad08e7ae = { package = "windows-sys", version = "0.60.2", features = ["Win32_Globalization", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Shell"] }
+windows-sys-b21d60becc0929df = { package = "windows-sys", version = "0.52.0", features = ["Win32_Foundation", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_SystemInformation"] }
+windows-sys-d4189bed749088b6 = { package = "windows-sys", version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Networking_WinSock", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
 
 [target.x86_64-pc-windows-msvc.build-dependencies]
 cc = { version = "1.2.61", default-features = false, features = ["parallel"] }
 getrandom = { version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy"] }
 tower = { version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
-tower-http = { version = "0.6.9", default-features = false, features = ["follow-redirect"] }
+tower-http = { version = "0.6.10", default-features = false, features = ["follow-redirect"] }
 winapi = { version = "0.3.9", default-features = false, features = ["cfg", "evntrace", "in6addr", "inaddr", "minwinbase", "ntsecapi", "sysinfoapi", "windef", "winioctl"] }
 windows = { version = "0.62.2", features = ["Wdk_System_SystemInformation", "Wdk_System_SystemServices", "Wdk_System_Threading", "Win32_Graphics_Direct3D", "Win32_Graphics_Direct3D11", "Win32_Graphics_Dxgi_Common", "Win32_Graphics_Gdi", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_NetworkManagement_NetManagement", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_Storage_Xps", "Win32_System_Com", "Win32_System_Diagnostics_Debug", "Win32_System_Diagnostics_ToolHelp", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_Kernel", "Win32_System_Memory", "Win32_System_Ole", "Win32_System_Performance", "Win32_System_Power", "Win32_System_ProcessStatus", "Win32_System_Registry", "Win32_System_RemoteDesktop", "Win32_System_Rpc", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_Variant", "Win32_System_WindowsProgramming", "Win32_System_Wmi", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
-windows-sys = { version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Globalization", "Win32_Networking_WinSock", "Win32_Security_Authorization", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Shell"] }
+windows-sys-4db8c43aad08e7ae = { package = "windows-sys", version = "0.60.2", features = ["Win32_Globalization", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Shell"] }
+windows-sys-b21d60becc0929df = { package = "windows-sys", version = "0.52.0", features = ["Win32_Foundation", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_SystemInformation"] }
+windows-sys-d4189bed749088b6 = { package = "windows-sys", version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Networking_WinSock", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
 
 ### END HAKARI SECTION


### PR DESCRIPTION
## Summary
- add CI release metadata validation so PRs fail when Cargo.lock package versions drift from pyproject/Cargo versions
- validate release artifacts before PyPI upload against release-please output version
- skip already-existing PyPI files on release workflow reruns
- refresh workspace-hack for tower-http 0.6.10 / Windows windows-sys feature sets

## Testing
- vx cargo hakari verify
- vx just preflight
- local package-version validation scripts
- git diff --check