### PR TITLE
fix(release): sync Cargo.lock package versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,7 +713,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dcc-mcp-actions"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "dashmap",
  "dcc-mcp-models",
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-artefact"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "chrono",
  "hex",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-capture"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "image",
  "libc",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-catalog"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-core"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "dcc-mcp-actions",
  "dcc-mcp-artefact",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-gateway"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "axum",
  "chrono",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-host"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-http"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "axum",
  "axum-test",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-job"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "chrono",
  "dashmap",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-jsonrpc"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-logging"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "dcc-mcp-paths",
  "parking_lot",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-models"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "dcc-mcp-naming",
  "dcc-mcp-pybridge",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-naming"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "pyo3",
  "pyo3-stub-gen",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-paths"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "dirs",
  "pyo3",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-process"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "dcc-mcp-models",
  "ipckit",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-protocols"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-pybridge"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "dcc-mcp-pybridge-derive",
  "pyo3",
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-pybridge-derive"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-sandbox"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-scheduler"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "axum",
  "bytes",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-server"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-shm"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "ipckit",
  "libc",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-skill-rest"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "axum",
  "axum-test",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-skills"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "dashmap",
  "dcc-mcp-actions",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-telemetry"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-transport"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "criterion",
  "dashmap",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-agent"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1261,7 +1261,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-protocol"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "jsonwebtoken",
  "rmp-serde",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-tunnel-relay"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-usd"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "dcc-mcp-protocols",
  "pyo3",
@@ -1313,7 +1313,7 @@ dependencies = [
 
 [[package]]
 name = "dcc-mcp-workflow"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "base64",
  "chrono",


### PR DESCRIPTION
## Summary
- sync Cargo.lock workspace package versions to 0.15.2
- fix release metadata validation failures after the release PR bumped Cargo.toml and pyproject.toml

## Validation
- vx cargo hakari verify
- vx cargo hakari generate --diff --quiet
- local release metadata validation script

Refs: actions/runs/25472963450/job/74742064537