### PR TITLE
fix: cover Python 3.7 import compatibility

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -125,7 +125,7 @@ runs:
         pip install --no-index --find-links dist dcc-mcp-core --force-reinstall --no-deps
         pip check
 
-        python tests/import_tests.py
+        python tests/test_imports.py
 
     - name: Upload wheel
       uses: actions/upload-artifact@v7

--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -125,30 +125,7 @@ runs:
         pip install --no-index --find-links dist dcc-mcp-core --force-reinstall --no-deps
         pip check
 
-        python - <<'PY'
-        import importlib
-        import pkgutil
-
-        import dcc_mcp_core
-        print(f'Version: {dcc_mcp_core.__version__}')
-        from dcc_mcp_core._core import SkillScanner, ToolRegistry, ToolResult
-        result = ToolResult(success=True, message='Wheel test passed')
-        print(f'Result: {result}')
-        reg = ToolRegistry()
-        print(f'Registry: {reg}')
-
-        failures = []
-        for module_info in pkgutil.walk_packages(dcc_mcp_core.__path__, prefix=f'{dcc_mcp_core.__name__}.'):
-            try:
-                importlib.import_module(module_info.name)
-            except Exception as exc:
-                failures.append((module_info.name, f'{type(exc).__name__}: {exc}'))
-        if failures:
-            for name, error in failures:
-                print(f'Import failed: {name}: {error}')
-            raise SystemExit(1)
-        print('All imports OK!')
-        PY
+        python tests/import_tests.py
 
     - name: Upload wheel
       uses: actions/upload-artifact@v7

--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -125,16 +125,30 @@ runs:
         pip install --no-index --find-links dist dcc-mcp-core --force-reinstall --no-deps
         pip check
 
-        python -c "
+        python - <<'PY'
+        import importlib
+        import pkgutil
+
         import dcc_mcp_core
         print(f'Version: {dcc_mcp_core.__version__}')
-        from dcc_mcp_core._core import ToolRegistry, ToolResult, SkillScanner
+        from dcc_mcp_core._core import SkillScanner, ToolRegistry, ToolResult
         result = ToolResult(success=True, message='Wheel test passed')
         print(f'Result: {result}')
         reg = ToolRegistry()
         print(f'Registry: {reg}')
+
+        failures = []
+        for module_info in pkgutil.walk_packages(dcc_mcp_core.__path__, prefix=f'{dcc_mcp_core.__name__}.'):
+            try:
+                importlib.import_module(module_info.name)
+            except Exception as exc:
+                failures.append((module_info.name, f'{type(exc).__name__}: {exc}'))
+        if failures:
+            for name, error in failures:
+                print(f'Import failed: {name}: {error}')
+            raise SystemExit(1)
         print('All imports OK!')
-        "
+        PY
 
     - name: Upload wheel
       uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,19 @@ jobs:
         with:
           tool: cargo-nextest
       - name: Verify workspace-hack is up to date
-        run: cargo hakari verify
+        shell: bash
+        run: |
+          cargo hakari verify && exit 0
+
+          # If we get here, verify failed. Run generate and show the diff.
+          echo "::error::workspace-hack is out of date — run 'cargo hakari generate' locally"
+          echo ""
+          echo "Expected changes to crates/workspace-hack/Cargo.toml:"
+          cargo hakari generate
+          git diff --no-color crates/workspace-hack/Cargo.toml
+          echo ""
+          echo "::error::Run 'cargo hakari generate' and commit the changes to fix this CI step."
+          exit 1
       - name: Preflight (check + clippy + fmt + test)
         run: vx just preflight
 

--- a/docs/guide/host-adapter.md
+++ b/docs/guide/host-adapter.md
@@ -75,7 +75,10 @@ server = McpHttpServer(reg, cfg)
 # 2. Create a dispatcher. BlockingDispatcher is right for --background
 #    DCCs; QueueDispatcher is right for GUI sessions. Either one is
 #    accepted by HostAdapter, McpHttpServer.attach_dispatcher, and
-#    StandaloneHost (LSP in practice).
+#    StandaloneHost (LSP in practice). If you need a type-only
+#    contract for custom dispatchers, import the public
+#    TickableDispatcher protocol from dcc_mcp_core.host; do not import
+#    private host protocol modules directly.
 dispatcher = BlockingDispatcher()
 server.attach_dispatcher(dispatcher)
 

--- a/docs/zh/guide/host-adapter.md
+++ b/docs/zh/guide/host-adapter.md
@@ -65,6 +65,9 @@ server = McpHttpServer(reg, cfg)
 # 2. 创建分发器。BlockingDispatcher 适用于 --background DCC；
 #    QueueDispatcher 适用于 GUI 会话。两者均被 HostAdapter、
 #    McpHttpServer.attach_dispatcher 和 StandaloneHost 接受（实践中的 LSP）。
+#    如果自定义 dispatcher 只需要类型契约，请从 dcc_mcp_core.host
+#    导入公开的 TickableDispatcher 协议；不要直接导入私有
+#    host protocol 模块。
 dispatcher = BlockingDispatcher()
 server.attach_dispatcher(dispatcher)
 

--- a/justfile
+++ b/justfile
@@ -78,6 +78,14 @@ rust-cov:
 bench:
     cargo bench -p dcc-mcp-transport
 
+# Regenerate workspace-hack (run after dependency updates to fix CI)
+hakari-generate:
+    cargo hakari generate
+
+# Verify workspace-hack is up to date (local preflight check)
+hakari-verify:
+    cargo hakari verify
+
 # ── Standalone binary (dcc-mcp-server) ───────────────────────────────────────
 
 # Build dcc-mcp-server for the current platform

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -45,7 +45,7 @@
 | Capture DCC stdout/stderr/script-editor output | `OutputCapture` |
 | Rich skill error with traceback | `skill_error_with_trace()` |
 | Skill warning / exception helpers | `skill_warning()` / `skill_exception()` |
-| Drive a DCC main-thread dispatcher (interactive/headless) | `HostAdapter` (subclass for your DCC) + `StandaloneHost` (pure-Python driver) + `QueueDispatcher` / `BlockingDispatcher` (Rust-backed primitives). Wire via `McpHttpServer.attach_dispatcher()`. See [`docs/guide/host-adapter.md`](docs/guide/host-adapter.md) |
+| Drive a DCC main-thread dispatcher (interactive/headless) | `HostAdapter` (subclass for your DCC) + `StandaloneHost` (pure-Python driver) + `QueueDispatcher` / `BlockingDispatcher` (Rust-backed primitives). Use public `TickableDispatcher` only for structural typing (`tick`, `shutdown`, `is_shutdown`); do not import private host protocols. Wire via `McpHttpServer.attach_dispatcher()`. See [`docs/guide/host-adapter.md`](docs/guide/host-adapter.md) |
 | Disable accumulated/evolved skills | `ENV_DISABLE_ACCUMULATED_SKILLS` |
 
 ---

--- a/llms.txt
+++ b/llms.txt
@@ -55,6 +55,7 @@
 | Expose DCC tools over HTTP/MCP | `create_skill_server("maya", McpHttpConfig(port=8765))` — Skills-First setup; falls back to `McpHttpServer(registry, config)` for manual registry wiring |
 | Register MCP prompts from Python (issue #792) | `handle = server.prompts(); handle.register_prompt(name, template, description=..., arguments=[...])` — `server.prompts()` returns `PromptHandle`; registration upserts in-place and appears in the next `prompts/list` / `prompts/get` |
 | Build a DCC adapter | `DccServerBase(dcc_name, builtin_skills_dir)` — skill/lifecycle/gateway/hot-reload inherited |
+| Drive a DCC main-thread dispatcher | `from dcc_mcp_core.host import HostAdapter, StandaloneHost, TickableDispatcher, QueueDispatcher, BlockingDispatcher`; `TickableDispatcher` is the public minimal protocol (`tick`, `shutdown`, `is_shutdown`) for adapter typing. Do not import private host protocols. |
 | Write skill scripts | `skill_entry` + `skill_success` / `skill_error` — zero-boilerplate skill authoring |
 | Control skill trust level | `SkillScope` (Repo < User < System < Admin) — higher scope shadows lower |
 | Progressive tool exposure | `SkillGroup` with `default_active` + `activate_tool_group()` |

--- a/python/dcc_mcp_core/host/_adapter.py
+++ b/python/dcc_mcp_core/host/_adapter.py
@@ -68,7 +68,7 @@ from typing import Optional
 # Import local modules — re-export the shared protocol so subclass
 # authors can type against ``TickableDispatcher`` from a single
 # import.
-from dcc_mcp_core.host._standalone import _TickableDispatcher as TickableDispatcher
+from dcc_mcp_core.host._protocols import TickableDispatcher
 
 if TYPE_CHECKING:
     # Import local modules

--- a/python/dcc_mcp_core/host/_protocols.py
+++ b/python/dcc_mcp_core/host/_protocols.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 
 # Import built-in modules
 import sys
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    # Import local modules
-    from dcc_mcp_core._core import TickOutcome
+# Import local modules
+from dcc_mcp_core._core import TickOutcome
 
 # `typing.Protocol` and `typing.runtime_checkable` are 3.8+. The package
 # still supports Python 3.7 for older embedded DCC runtimes such as Maya 2022

--- a/python/dcc_mcp_core/host/_protocols.py
+++ b/python/dcc_mcp_core/host/_protocols.py
@@ -1,0 +1,35 @@
+"""Shared structural protocols for host dispatcher adapters."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # Import local modules
+    from dcc_mcp_core._core import TickOutcome
+
+# `typing.Protocol` and `typing.runtime_checkable` are 3.8+. The package
+# still supports Python 3.7 for older embedded DCC runtimes such as Maya 2022
+# and Blender 2.83, so expose a duck-typed base class there.
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+    from typing import runtime_checkable
+else:  # pragma: no cover - py3.7 only
+
+    def runtime_checkable(cls):
+        return cls
+
+    class Protocol:  # type: ignore[no-redef]
+        pass
+
+
+@runtime_checkable
+class TickableDispatcher(Protocol):
+    """Minimum dispatcher surface required by host tick drivers."""
+
+    def tick(self, max_jobs: int = ...) -> TickOutcome: ...
+    def shutdown(self) -> None: ...
+    def is_shutdown(self) -> bool: ...

--- a/python/dcc_mcp_core/host/_standalone.py
+++ b/python/dcc_mcp_core/host/_standalone.py
@@ -20,29 +20,14 @@ from __future__ import annotations
 import contextlib
 import threading
 from typing import TYPE_CHECKING
-from typing import Protocol
-from typing import runtime_checkable
+
+# Import local modules
+from dcc_mcp_core.host._protocols import TickableDispatcher
 
 if TYPE_CHECKING:
     # Import local modules
     from dcc_mcp_core._core import BlockingDispatcher
     from dcc_mcp_core._core import QueueDispatcher
-    from dcc_mcp_core._core import TickOutcome
-
-
-@runtime_checkable
-class _TickableDispatcher(Protocol):
-    """Minimum surface :class:`StandaloneHost` needs from its dispatcher.
-
-    Keeps the class independent of the concrete dispatcher type (DIP)
-    and lets callers swap in test doubles without subclassing.
-    """
-
-    def tick(self, max_jobs: int = ...) -> TickOutcome: ...
-    def has_pending(self) -> bool: ...
-    def pending(self) -> int: ...
-    def shutdown(self) -> None: ...
-    def is_shutdown(self) -> bool: ...
 
 
 class StandaloneHost:
@@ -71,7 +56,7 @@ class StandaloneHost:
 
     def __init__(
         self,
-        dispatcher: QueueDispatcher | BlockingDispatcher | _TickableDispatcher,
+        dispatcher: QueueDispatcher | BlockingDispatcher | TickableDispatcher,
         *,
         tick_interval: float = 0.01,
         max_jobs_per_tick: int = 16,

--- a/python/dcc_mcp_core/host/_standalone.py
+++ b/python/dcc_mcp_core/host/_standalone.py
@@ -19,15 +19,11 @@ from __future__ import annotations
 # Import built-in modules
 import contextlib
 import threading
-from typing import TYPE_CHECKING
 
 # Import local modules
+from dcc_mcp_core._core import BlockingDispatcher
+from dcc_mcp_core._core import QueueDispatcher
 from dcc_mcp_core.host._protocols import TickableDispatcher
-
-if TYPE_CHECKING:
-    # Import local modules
-    from dcc_mcp_core._core import BlockingDispatcher
-    from dcc_mcp_core._core import QueueDispatcher
 
 
 class StandaloneHost:

--- a/tests/import_tests.py
+++ b/tests/import_tests.py
@@ -1,0 +1,46 @@
+"""Import smoke tests for wheel and embedded Python compatibility."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import importlib
+import pkgutil
+
+# Import local modules
+import dcc_mcp_core
+from dcc_mcp_core._core import SkillScanner
+from dcc_mcp_core._core import ToolRegistry
+from dcc_mcp_core._core import ToolResult
+
+
+def collect_import_failures() -> list[tuple[str, str]]:
+    """Import every package module and return failures as ``(name, error)``."""
+    failures: list[tuple[str, str]] = []
+    for module_info in pkgutil.walk_packages(dcc_mcp_core.__path__, prefix=f"{dcc_mcp_core.__name__}."):
+        try:
+            importlib.import_module(module_info.name)
+        except Exception as exc:
+            failures.append((module_info.name, f"{type(exc).__name__}: {exc}"))
+    return failures
+
+
+def run_import_smoke_test() -> None:
+    """Run the same import smoke test used by wheel CI and pytest."""
+    print(f"Version: {dcc_mcp_core.__version__}")
+    result = ToolResult(success=True, message="Wheel test passed")
+    print(f"Result: {result}")
+    reg = ToolRegistry()
+    print(f"Registry: {reg}")
+    print(f"Scanner: {SkillScanner}")
+
+    failures = collect_import_failures()
+    if failures:
+        for name, error in failures:
+            print(f"Import failed: {name}: {error}")
+        raise SystemExit(1)
+    print("All imports OK!")
+
+
+if __name__ == "__main__":
+    run_import_smoke_test()

--- a/tests/test_host_protocols.py
+++ b/tests/test_host_protocols.py
@@ -1,0 +1,36 @@
+"""Tests for host dispatcher protocol exports."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import local modules
+from dcc_mcp_core.host import BlockingDispatcher
+from dcc_mcp_core.host import QueueDispatcher
+from dcc_mcp_core.host import TickableDispatcher
+
+
+class _DuckDispatcher:
+    def tick(self, max_jobs: int = 16):
+        return None
+
+    def shutdown(self) -> None:
+        pass
+
+    def is_shutdown(self) -> bool:
+        return False
+
+
+def test_tickable_dispatcher_accepts_core_dispatchers() -> None:
+    assert isinstance(QueueDispatcher(), TickableDispatcher)
+    assert isinstance(BlockingDispatcher(), TickableDispatcher)
+
+
+def test_tickable_dispatcher_accepts_duck_typed_dispatcher() -> None:
+    assert isinstance(_DuckDispatcher(), TickableDispatcher)
+
+
+def test_tickable_dispatcher_protocol_methods_are_noop_stubs() -> None:
+    dispatcher = object()
+    assert TickableDispatcher.tick(dispatcher) is None
+    assert TickableDispatcher.shutdown(dispatcher) is None
+    assert TickableDispatcher.is_shutdown(dispatcher) is None

--- a/tests/test_import_surface.py
+++ b/tests/test_import_surface.py
@@ -1,18 +1,19 @@
-"""Import-surface tests for embedded Python compatibility."""
+"""Backward-compatible import surface test module."""
 
 # Import future modules
 from __future__ import annotations
 
 # Import built-in modules
+import importlib.util
 from pathlib import Path
-import sys
 
-sys.path.insert(0, str(Path(__file__).resolve().parent))
-
-# Import local modules
-from import_tests import collect_import_failures
+_IMPORTS_PATH = Path(__file__).with_name("test_imports.py")
+_SPEC = importlib.util.spec_from_file_location("_dcc_mcp_core_test_imports", _IMPORTS_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_IMPORTS = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_IMPORTS)
 
 
 def test_dcc_mcp_core_modules_are_importable() -> None:
     """Every importable package module should load without side effects."""
-    assert collect_import_failures() == []
+    _IMPORTS.assert_import_smoke()

--- a/tests/test_import_surface.py
+++ b/tests/test_import_surface.py
@@ -1,0 +1,23 @@
+"""Import-surface tests for embedded Python compatibility."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import importlib
+import pkgutil
+
+# Import local modules
+import dcc_mcp_core
+
+
+def test_dcc_mcp_core_modules_are_importable() -> None:
+    """Every importable package module should load without side effects."""
+    failures: list[tuple[str, str]] = []
+    for module_info in pkgutil.walk_packages(dcc_mcp_core.__path__, prefix=f"{dcc_mcp_core.__name__}."):
+        try:
+            importlib.import_module(module_info.name)
+        except Exception as exc:  # pragma: no cover - assertion reports details
+            failures.append((module_info.name, f"{type(exc).__name__}: {exc}"))
+
+    assert failures == []

--- a/tests/test_import_surface.py
+++ b/tests/test_import_surface.py
@@ -4,20 +4,15 @@
 from __future__ import annotations
 
 # Import built-in modules
-import importlib
-import pkgutil
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 # Import local modules
-import dcc_mcp_core
+from import_tests import collect_import_failures
 
 
 def test_dcc_mcp_core_modules_are_importable() -> None:
     """Every importable package module should load without side effects."""
-    failures: list[tuple[str, str]] = []
-    for module_info in pkgutil.walk_packages(dcc_mcp_core.__path__, prefix=f"{dcc_mcp_core.__name__}."):
-        try:
-            importlib.import_module(module_info.name)
-        except Exception as exc:  # pragma: no cover - assertion reports details
-            failures.append((module_info.name, f"{type(exc).__name__}: {exc}"))
-
-    assert failures == []
+    assert collect_import_failures() == []

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -25,7 +25,7 @@ def collect_import_failures() -> list[tuple[str, str]]:
     return failures
 
 
-def run_import_smoke_test() -> None:
+def assert_import_smoke() -> None:
     """Run the same import smoke test used by wheel CI and pytest."""
     print(f"Version: {dcc_mcp_core.__version__}")
     result = ToolResult(success=True, message="Wheel test passed")
@@ -38,9 +38,14 @@ def run_import_smoke_test() -> None:
     if failures:
         for name, error in failures:
             print(f"Import failed: {name}: {error}")
-        raise SystemExit(1)
+    assert failures == []
     print("All imports OK!")
 
 
+def test_dcc_mcp_core_import_smoke() -> None:
+    """Every importable package module should load without side effects."""
+    assert_import_smoke()
+
+
 if __name__ == "__main__":
-    run_import_smoke_test()
+    assert_import_smoke()


### PR DESCRIPTION
## Summary
- move the host dispatcher protocol into a Python 3.7-compatible shared module
- avoid importing typing.Protocol from the host standalone path on embedded Python 3.7 runtimes
- add import-surface coverage to both tests and wheel smoke tests, including py3.7 wheel jobs
- keep the existing hakari CI diagnostics and local just recipes that were already on this branch

## Validation
- vx uv run pytest tests/test_import_surface.py tests/test_host_adapter.py -v --tb=short
- vx just lint-py

## Context
Maya 2022 embeds Python 3.7, where typing.Protocol is unavailable. The previous py3.7 wheel smoke test only imported the top-level package and selected _core symbols, so dcc_mcp_core.host import failures were not caught before downstream Maya E2E.