### PR TITLE
ci: clean cargo proxies on macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,12 +137,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
-      # Ubuntu images can ship rustup proxy binaries that conflict when
-      # rust-toolchain.toml requests clippy/rustfmt during `vx just build`.
-      # Remove them before dtolnay/rust-toolchain/vx lets rustup install the
-      # requested components. Mirrors .github/actions/build-wheel.
+      # GitHub-hosted Linux and macOS runners can ship rustup proxy binaries
+      # that conflict when rust-toolchain.toml requests clippy/rustfmt during
+      # `vx just build`. Remove them before dtolnay/rust-toolchain/vx lets
+      # rustup install the requested components. Mirrors .github/actions/build-wheel.
       - name: Remove pre-installed cargo component proxies
-        if: runner.os == 'Linux'
+        if: runner.os != 'Windows'
         run: rm -f ~/.cargo/bin/cargo-clippy ~/.cargo/bin/cargo-fmt || true
         shell: bash
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
- clean pre-installed cargo component proxies on Linux and macOS in CI wheel builds
- align the inline CI wheel build workaround with the composite build-wheel action

## Testing
- pre-commit hooks ran during commit: check yaml passed