### PR TITLE
ci: harden release pipeline against partial publishes

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -20,7 +20,10 @@ on:
         default: ""
 
 concurrency:
-  group: build-wheels-${{ github.event.pull_request.number || github.ref }}
+  # Scope by the resolved checkout target so a release-driven build for tag
+  # vX.Y.Z is never grouped with (and never cancelled by) another run for a
+  # different ref. Falls back to github.ref when no checkout-ref is provided.
+  group: build-wheels-${{ inputs.checkout-ref || github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,14 +28,14 @@ permissions:
   actions: read
 
 jobs:
-  # ── Release Please (only on main branch push) ──
+  # ── Decide what to release (release-please for push, manual backfill for dispatch) ──
   release-please:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     outputs:
-      release_created: ${{ inputs.release_tag != '' && 'true' || steps.release.outputs.release_created }}
-      tag_name: ${{ inputs.release_tag || steps.release.outputs.tag_name }}
-      version: ${{ inputs.release_version || steps.release.outputs.version }}
+      release_created: ${{ steps.decide.outputs.release_created }}
+      tag_name: ${{ steps.decide.outputs.tag_name }}
+      version: ${{ steps.decide.outputs.version }}
     steps:
       - name: Validate manual release backfill inputs
         if: github.event_name == 'workflow_dispatch' && inputs.release_tag != ''
@@ -61,6 +61,29 @@ jobs:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Decide release outputs
+        id: decide
+        env:
+          BACKFILL_TAG: ${{ inputs.release_tag }}
+          BACKFILL_VERSION: ${{ inputs.release_version }}
+          RP_RELEASE_CREATED: ${{ steps.release.outputs.release_created }}
+          RP_TAG_NAME: ${{ steps.release.outputs.tag_name }}
+          RP_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          if [ -n "$BACKFILL_TAG" ]; then
+            release_created=true
+            tag_name="$BACKFILL_TAG"
+            version="$BACKFILL_VERSION"
+          else
+            release_created="${RP_RELEASE_CREATED:-false}"
+            tag_name="$RP_TAG_NAME"
+            version="$RP_VERSION"
+          fi
+          echo "release_created=$release_created" >> "$GITHUB_OUTPUT"
+          echo "tag_name=$tag_name" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Release decision: created=$release_created tag=$tag_name version=$version"
 
   # ── Build standalone dcc-mcp-server binaries ──
   build-binaries:
@@ -168,22 +191,28 @@ jobs:
           from pathlib import Path
 
           release_version = os.environ["RELEASE_VERSION"]
-          versions = {
+          # Only the public-facing versions must match the release tag.
+          # Cargo.lock member-crate versions can lag behind for a single release
+          # cycle and are reconciled by release-please-lock-sync.yml; treating
+          # that drift as fatal here turned every minor lag into a missing
+          # PyPI/GitHub Release upload (see v0.15.2 post-mortem).
+          fatal = {
               "pyproject.toml": tomllib.loads(Path("pyproject.toml").read_text())["project"]["version"],
               "Cargo.toml": tomllib.loads(Path("Cargo.toml").read_text())["workspace"]["package"]["version"],
           }
+          mismatches = {src: ver for src, ver in fatal.items() if ver != release_version}
+          if mismatches:
+              for src, ver in sorted(mismatches.items()):
+                  print(f"::error::{src} has {ver}, expected {release_version}", file=sys.stderr)
+              sys.exit(1)
 
           lock = tomllib.loads(Path("Cargo.lock").read_text())
           for package in lock["package"]:
               name = package["name"]
               if name == "dcc-mcp-core" or name.startswith("dcc-mcp-"):
-                  versions[f"Cargo.lock:{name}"] = package["version"]
-
-          mismatches = {source: version for source, version in versions.items() if version != release_version}
-          if mismatches:
-              for source, version in sorted(mismatches.items()):
-                  print(f"{source} has {version}, expected {release_version}", file=sys.stderr)
-              sys.exit(1)
+                  ver = package["version"]
+                  if ver != release_version:
+                      print(f"::warning::Cargo.lock:{name} has {ver}, expected {release_version}")
           PY
 
       - name: Download all wheel artifacts
@@ -195,8 +224,12 @@ jobs:
       - name: List wheels
         run: ls -la dist/
 
-      # Trusted Publishers — no credentials needed
+      # Trusted Publishers — no credentials needed.
+      # continue-on-error so that a PyPI failure (e.g. file already exists from
+      # a previous partial run) does not block the GitHub Release upload below.
       - name: Upload to PyPI
+        id: pypi
+        continue-on-error: true
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist
@@ -204,8 +237,17 @@ jobs:
           print-hash: true
           skip-existing: true
 
+      # Always attempt the GitHub Release upload, even if PyPI failed; this is
+      # the user-visible artifact set and must be complete per release tag.
       - name: Upload wheels to GitHub Release
+        if: always()
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.release-please.outputs.tag_name }}
           files: dist/*
+
+      - name: Fail job if PyPI upload failed
+        if: steps.pypi.outcome == 'failure'
+        run: |
+          echo "::error::PyPI upload failed; GitHub Release artifacts were still uploaded above."
+          exit 1


### PR DESCRIPTION
## Why

0.15.0 was the last fully clean release. After that:

| Tag | Asset count | Failure |
|-----|-------------|---------|
| v0.15.0 | 15 | clean |
| v0.15.1 | 3 | publish failed: PyPI rejected uploads with 'File already exists' for 0.15.0 wheels (downloaded the wrong artifact pattern at the time); GitHub Release wheels never uploaded because the step ran sequentially after PyPI |
| v0.15.2 | 3 | publish failed: 'Validate release version' treated Cargo.lock member-crate drift as fatal; wheels never uploaded |
| v0.15.3 | 15 | clean (release-please-lock-sync.yml landed) |
| v0.15.4 | 0 | Release run was cancelled mid-build by a later main push (cancel-in-progress: true on the Release workflow); the next Release run had release_created=false and skipped every artifact job |

PR 808 already disabled cancel-in-progress and added a workflow_dispatch backfill, but a manual dispatch with empty inputs (run 25505726141) still ran release-please, which returned empty outputs because v0.15.4 already exists, so every downstream job got skipped again.

## What this PR changes

release.yml
- Replace inline ternary outputs with a 'Decide release outputs' step that explicitly chooses backfill inputs vs release-please outputs and prints the resolved decision. Manual dispatch with backfill inputs no longer depends on release-please outputs at all.
- Loosen 'Validate release version' to only treat pyproject.toml and Cargo.toml as fatal. Cargo.lock member-crate drift is now a warning (it is reconciled by release-please-lock-sync.yml on the release PR; treating it as fatal at publish time was the v0.15.2 root cause).
- Decouple PyPI from GitHub Release in the publish job: PyPI upload uses continue-on-error, GitHub Release upload uses if: always(), and a final guard step fails the job when PyPI failed so the failure is still visible. This means a 'File already exists' on PyPI no longer blocks GitHub Release artifacts.

build-wheels.yml
- Concurrency group is now keyed by the resolved checkout-ref so release-driven builds for vX.Y.Z cannot collide with PR builds or other workflow_dispatch runs.

## Backfill v0.15.4

After merge, run:

```
gh workflow run release.yml --repo loonghao/dcc-mcp-core --ref main   -f release_tag=v0.15.4 -f release_version=0.15.4
```

## Testing

- vx pre-commit run check-yaml --files .github/workflows/release.yml .github/workflows/build-wheels.yml
- pre-commit hooks during commit (check-yaml, end-of-file-fixer, trailing-whitespace) all green