### PR TITLE
fix(http): make McpHttpConfig::set_host return Result instead of panicking

### DIFF
--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -162,8 +162,9 @@ impl McpHttpConfig {
     pub fn host(&self) -> String {
         self.server.host.to_string()
     }
-    pub fn set_host(&mut self, v: &str) {
-        self.server.host = v.parse().unwrap();
+    pub fn set_host(&mut self, v: &str) -> Result<&mut Self, std::net::AddrParseError> {
+        self.server.host = v.parse()?;
+        Ok(self)
     }
     pub fn endpoint_path(&self) -> String {
         self.server.endpoint_path.clone()
@@ -1327,5 +1328,35 @@ mod tests {
         assert_eq!(cfg.queue.max_request_body_bytes, 8 * 1024 * 1024);
         assert_eq!(cfg.queue.max_response_content_bytes, 512 * 1024);
         assert_eq!(cfg.queue.sse_chunk_size_bytes, 32 * 1024);
+    }
+
+    /// Issue #811: `set_host` returns `Err` on malformed input instead of
+    /// panicking. Library/PyO3 callers can surface the error structurally.
+    #[test]
+    fn set_host_returns_err_on_invalid_input() {
+        let mut cfg = McpHttpConfig::default();
+        let original = cfg.server.host;
+        let err = cfg.set_host("not.an.ip.address").unwrap_err();
+        // The error type is the canonical std parse error; we mainly assert
+        // (a) we got `Err`, not a panic, and (b) the host field is untouched.
+        assert!(!err.to_string().is_empty());
+        assert_eq!(cfg.server.host, original);
+    }
+
+    /// Issue #811: `set_host` accepts a valid IPv4 literal and updates the
+    /// underlying `IpAddr` field.
+    #[test]
+    fn set_host_accepts_valid_ipv4() {
+        let mut cfg = McpHttpConfig::default();
+        cfg.set_host("10.0.0.5").expect("valid IPv4");
+        assert_eq!(cfg.server.host.to_string(), "10.0.0.5");
+    }
+
+    /// Issue #811: `set_host` accepts a valid IPv6 literal too.
+    #[test]
+    fn set_host_accepts_valid_ipv6() {
+        let mut cfg = McpHttpConfig::default();
+        cfg.set_host("::1").expect("valid IPv6");
+        assert_eq!(cfg.server.host.to_string(), "::1");
     }
 }

--- a/crates/dcc-mcp-http/src/python/config.rs
+++ b/crates/dcc-mcp-http/src/python/config.rs
@@ -101,6 +101,15 @@ impl PyMcpHttpConfig {
         self.inner.server.host.to_string()
     }
 
+    /// Bind address. Accepts any IPv4/IPv6 literal that ``std::net::IpAddr``
+    /// can parse. Raises ``ValueError`` for malformed input — never panics.
+    #[setter]
+    fn set_host(&mut self, v: &str) -> PyResult<()> {
+        self.inner.set_host(v).map(|_| ()).map_err(|e| {
+            pyo3::exceptions::PyValueError::new_err(format!("invalid host {v:?}: {e}"))
+        })
+    }
+
     /// MCP endpoint path (default ``"/mcp"``).
     #[getter]
     fn endpoint_path(&self) -> String {


### PR DESCRIPTION
Closes #811.

## Problem

`McpHttpConfig::set_host` did `v.parse().unwrap()` directly on user input — any malformed IP literal turned into a `panic!`, taking the host process down. PyO3 exposure path was previously closed (only a getter was wired), so no Python caller could trigger it today, but the Rust signature on a `pub` setter was a latent footgun.

## Change

- `set_host` now returns `Result<&mut Self, std::net::AddrParseError>`. Builder-style chaining preserved.
- PyO3 wrapper gains a `host` `#[setter]` that maps `AddrParseError` → `PyValueError("invalid host \"X\": ...")`. Additive on the Python side.
- 3 unit tests: invalid input → `Err` + field untouched; valid IPv4 / IPv6 → success.

## Compatibility

Breaking change for any out-of-tree caller of `McpHttpConfig::set_host` (must `?` or `.expect`). **Zero internal callers** in this workspace (verified via `grep -rn 'set_host\b'`), so the breakage surface is downstream-only and intentional in the 0.x window. Sibling setters in `config.rs` were also audited for the same pattern — none found.

## Verification

- `vx cargo check -p dcc-mcp-http --tests` — green
- `vx cargo test -p dcc-mcp-http --lib` — 239/239 green (including the 3 new `set_host_*` tests)
- pre-commit (`cargo fmt`, `cargo clippy`) — passed

## Related

- Surfaced by 2026-05-08 contract/SOLID audit (issues #810 / #811 / #812 / #813).
- Independent of the gateway meta-tool refactor (#813) and the duplicate-types epic (#812).