### PR TITLE
docs: refresh gateway instance resource guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,11 +92,19 @@ Gateway dynamic-capability / REST exposure:
 4. The gateway never fans out per-action backend tools into tools/list.
 5. For non-MCP clients, use the matching /v1/search, /v1/describe, /v1/call REST endpoints.
 
+Gateway instance discovery:
+1. Usually skip instance discovery and go straight to search_tools → describe_tool → call_tool.
+2. When you need a concrete DCC session or direct MCP URL, call resources/read with uri="gateway://instances".
+3. For one instance, read gateway://instances/{instance_id}; full UUID or unique prefix works.
+4. Do not call legacy list_dcc_instances / get_dcc_instance / connect_to_dcc; #813 removed them from tools/list.
+
 Gateway resources/prompts:
 1. List hand-off artefacts with resources/list; gateway-prefixed URIs identify the owning DCC instance.
-2. Read/subscribe with the exact URI returned by resources/list; do not strip `dcc://<type>/<id>` or backend-resource prefixes.
-3. Use prompts/list and prompts/get through the gateway when prompt templates are aggregated from multiple DCC instances.
-4. Subscribe only to URIs you plan to react to, and unsubscribe when done.
+2. resources/list includes the gateway://instances root pointer only; do not expect every gateway://instances/{id} URI to be enumerated.
+3. Read/subscribe with the exact URI returned by resources/list; do not strip `dcc://<type>/<id>` or backend-resource prefixes.
+4. Use prompts/list and prompts/get through the gateway when prompt templates are aggregated from multiple DCC instances.
+5. Subscribe only to URIs you plan to react to, and unsubscribe when done.
+
 ```
 
 ### Multi-DCC Guardrails
@@ -141,8 +149,10 @@ Gateway resources/prompts:
 | IPC | `IpcChannelAdapter` / `SocketServerAdapter` + `DccLinkFrame` |
 | Hand off files between tools | `FileRef` + `artefact_put_file()` / `artefact_get_bytes()` |
 | Multi-DCC gateway | `McpHttpConfig(gateway_port=9765)` |
+| Discover gateway DCC instances / direct MCP URLs | `resources/read uri="gateway://instances"` or `gateway://instances/{id}`; entries carry `mcp_url` and replace the removed `list_dcc_instances` / `get_dcc_instance` / `connect_to_dcc` tools |
 | Gateway dynamic capabilities | `search_tools` → `describe_tool` → `call_tool` or REST `/v1/search` → `/v1/describe` → `/v1/call` |
 | Gateway resources/prompts | `resources/list` / `resources/read` with exact gateway-returned URIs; `prompts/list` / `prompts/get` for aggregated backend prompt templates |
+
 | Persist project state | `DccProject.open/load(...)` + `register_project_tools(server, ...)` exposing `project.save/load/resume/status` |
 | Remote MCP relay (zero-config tunnel) | `RelayServer::start(RelayConfig, agent_bind, frontend_bind).await` — accepts agent registrations on `agent_bind`, multiplexes remote-client TCP from `frontend_bind` to the agent's local MCP server (issue #504) |
 | Enable WS frontend / `/tunnels` admin | `RelayServer::start_with(cfg, agent_bind, frontend_bind, OptionalBinds { ws_frontend, admin })` — opt-in WS upgrade endpoint at `/tunnel/<id>` and read-only `GET /tunnels` + `/healthz` |

--- a/AI_AGENT_GUIDE.md
+++ b/AI_AGENT_GUIDE.md
@@ -76,15 +76,30 @@ result = call_tool(tool_slug=info["tool_slug"], arguments={"radius": 2.0})
 
 Non-MCP clients use the equivalent REST endpoints: `POST /v1/search`, `POST /v1/describe`, and `POST /v1/call`. See `docs/guide/gateway.md` and `docs/guide/dcc-rest-skill-api.md`.
 
+### Gateway Instance Discovery
+
+Usually you do **not** need to enumerate instances: let `search_tools` and `call_tool` route for you. When you must pick a concrete DCC session, inspect context metadata, or connect directly, read the gateway-native MCP resource instead of looking for instance-discovery tools:
+
+```python
+# MCP request shape; use your client's resources/read helper if it has one.
+{"method": "resources/read", "params": {"uri": "gateway://instances"}}
+{"method": "resources/read", "params": {"uri": "gateway://instances/{instance_id}"}}
+```
+
+Each entry carries `mcp_url`, so no separate connect verb is needed. The legacy `list_dcc_instances`, `get_dcc_instance`, `connect_to_dcc`, and non-standard `instances/list` surfaces were removed in #813 phase 1.
+
 ### Gateway Resources and Prompts
+
 
 Use MCP resources for files, scene artefacts, thumbnails, diagnostics, and other hand-off data that should not be squeezed into tool text output:
 
 1. Call `resources/list` and keep the returned URI exactly as-is. Gateway-prefixed URIs encode the owning DCC instance (`dcc://<type>/<id>` or `<scheme>://<id8>/<rest>`).
-2. Call `resources/read` with that exact URI. Do not remove or rewrite the instance prefix client-side.
-3. Use `resources/subscribe` only when you need live `notifications/resources/updated` events, then call `resources/unsubscribe` when done.
-4. Prefer resources over ad-hoc local file paths in tool messages; resources are portable across DCC hosts and easier for agents to trace.
-5. For reusable prompt templates, call gateway `prompts/list` and then `prompts/get` with the returned namespaced prompt name.
+2. `resources/list` advertises `gateway://instances` as one root pointer; read `gateway://instances/{id}` directly when you know an instance id because per-instance URIs are intentionally not fanned out.
+3. Call `resources/read` with that exact URI. Do not remove or rewrite the instance prefix client-side.
+4. Use `resources/subscribe` only when you need live `notifications/resources/updated` events, then call `resources/unsubscribe` when done.
+5. Prefer resources over ad-hoc local file paths in tool messages; resources are portable across DCC hosts and easier for agents to trace.
+6. For reusable prompt templates, call gateway `prompts/list` and then `prompts/get` with the returned namespaced prompt name.
+
 
 ## 📚 Key Concepts You Must Understand
 

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -178,8 +178,9 @@ MCP requests use JSON-RPC 2.0:
 | `initialize` | Protocol handshake, returns server capabilities |
 | `tools/list` | List all registered tools from the registry |
 | `tools/call` | Dispatch a tool by name with parameters |
-| `resources/list` | List available resources (empty in current impl) |
-| `prompts/list` | List available prompts (empty in current impl) |
+| `resources/list` | List available resources; gateways include the `gateway://instances` root pointer |
+| `prompts/list` | List registered prompts; gateways return namespaced backend prompt templates |
+
 | `ping` | Liveness check |
 
 ## Built-in Tools {#builtin-tools}

--- a/docs/api/resources.md
+++ b/docs/api/resources.md
@@ -37,7 +37,28 @@ Resources are advertised in `initialize` as:
 `capture://current_window` is only listed when a real window-capture backend is available
 (currently Windows `HWND PrintWindow`). On other platforms it is hidden from `resources/list`.
 
+## Gateway-Native Resources
+
+When an agent is connected to the multi-DCC gateway, instance discovery is also
+modeled as an MCP resource instead of a tool:
+
+| URI | MIME | Description |
+|-----|------|-------------|
+| `gateway://instances` | `application/json` | Live DCC registry. Rows include `instance_id`, `dcc_type`, health/status fields, metadata, and `mcp_url` for direct sessions. |
+| `gateway://instances?include_stale=false` | `application/json` | Same registry with stale-but-parseable rows hidden. |
+| `gateway://instances?include_dead=true` | `application/json` | Rawer registry view including rows whose owner process has exited. |
+| `gateway://instances/{instance_id}` | `application/json` | One instance selected by full UUID or unique prefix. |
+| `resources://gateway/events` | `application/jsonl` | Gateway contention and election event ring buffer. |
+
+`resources/list` advertises only the `gateway://instances` root pointer; it does
+not enumerate every `gateway://instances/{id}` URI. Read the per-instance URI
+directly when you already know the id. The legacy gateway tools
+`list_dcc_instances`, `get_dcc_instance`, and `connect_to_dcc` were removed in
+#813 phase 1; entries already carry `mcp_url`, so no separate connect verb is
+required.
+
 ## Enabling / Disabling
+
 
 ```python
 from dcc_mcp_core import McpHttpConfig

--- a/docs/guide/agents-reference.md
+++ b/docs/guide/agents-reference.md
@@ -1,8 +1,9 @@
 # Agents Reference — Detailed Rules and Traps
 
 > This file is the detailed companion to `AGENTS.md`.
-> `AGENTS.md` is the navigation map (≤150 lines); this file holds the
-> expanded rules, code examples, and traps that agents need on demand.
+> `AGENTS.md` is the navigation map; this file holds the expanded rules,
+> code examples, and traps that agents need on demand.
+
 > Read `AGENTS.md` first, then follow links here when you need detail.
 
 ---

--- a/docs/zh/api/http.md
+++ b/docs/zh/api/http.md
@@ -166,8 +166,9 @@ MCP 请求使用 JSON-RPC 2.0：
 | `initialize` | 协议握手，返回服务器能力 |
 | `tools/list` | 列出注册表中的所有 Action |
 | `tools/call` | 按名称和参数调度 Action |
-| `resources/list` | 列出可用资源（当前实现为空） |
-| `prompts/list` | 列出可用提示（当前实现为空） |
+| `resources/list` | 列出可用资源；网关会包含 `gateway://instances` 根指针 |
+| `prompts/list` | 列出已注册 prompt；网关返回带命名空间的后端 prompt 模板 |
+
 | `ping` | 存活检查 |
 
 ## 完整示例：Maya MCP 服务器

--- a/docs/zh/api/resources.md
+++ b/docs/zh/api/resources.md
@@ -39,7 +39,27 @@ Resources 在 `initialize` 中通告为：
 （目前为 Windows `HWND PrintWindow`）。在其他平台上它会从
 `resources/list` 中隐藏。
 
+## Gateway 原生 Resources
+
+当 Agent 连接到多 DCC Gateway 时，实例发现也建模为 MCP resource，
+而不是 tool：
+
+| URI | MIME | 说明 |
+|-----|------|------|
+| `gateway://instances` | `application/json` | 实时 DCC 注册表。行内包含 `instance_id`、`dcc_type`、健康/状态字段、metadata，以及用于直连会话的 `mcp_url`。 |
+| `gateway://instances?include_stale=false` | `application/json` | 隐藏 stale 但可解析行的同一注册表视图。 |
+| `gateway://instances?include_dead=true` | `application/json` | 更接近原始注册表的视图，包含拥有进程已退出的行。 |
+| `gateway://instances/{instance_id}` | `application/json` | 通过完整 UUID 或唯一前缀选择的单个实例。 |
+| `resources://gateway/events` | `application/jsonl` | Gateway 竞争和选举事件 ring buffer。 |
+
+`resources/list` 只通告 `gateway://instances` 根指针；不会枚举每个
+`gateway://instances/{id}` URI。当已知实例 id 时，直接读取单实例 URI。
+旧的 Gateway 工具 `list_dcc_instances`、`get_dcc_instance`、
+`connect_to_dcc` 已在 #813 phase 1 移除；每条记录已经携带 `mcp_url`，
+因此不需要单独的 connect 动词。
+
 ## 启用 / 禁用
+
 
 ```python
 from dcc_mcp_core import McpHttpConfig

--- a/docs/zh/guide/gateway.md
+++ b/docs/zh/guide/gateway.md
@@ -88,6 +88,23 @@ facade 抖动都会浪费 socket 并塞满重连日志。
    秒才触发一次；没有这次同步前置扫描的话，上一次崩溃残留的幽灵
    行会在 Gateway 启动后的前 ~15 秒内耗尽完整的指数退避重连预算。
 
+## 实例与诊断发现
+
+Gateway 将实时 DCC 注册表暴露为 Gateway 原生 MCP resource（也见
+`docs/zh/api/http.md`）：
+
+```json
+{"jsonrpc":"2.0","id":1,"method":"resources/read",
+ "params":{"uri":"gateway://instances"}}
+```
+
+payload 会包含 live、stale 与 unhealthy 行，方便客户端决定是路由、
+重连，还是提示用户重启 DCC 实例。每条记录已经携带 `mcp_url`，因此
+读取这个 resource 后即可直连。可选 URI 查询参数
+（`?include_stale=false`、`?include_dead=true`）对应旧实例发现工具的
+过滤意图。`tools/list` 会在每次调用时基于当前注册表组装，因此
+Gateway 启动后新注册的实例不需要重启即可被发现。
+
 ## 动态能力索引与有界工具暴露 (#652-#657)
 
 在大型多 DCC 部署中，Gateway **永远不会**把每个后端 action 直接发布到
@@ -95,9 +112,11 @@ facade 抖动都会浪费 socket 并塞满重连日志。
 `McpHttpConfig.gateway_tool_exposure`、`publishes_backend_tools` 与
 `--gateway-tool-exposure` 都是 0.15 之前的概念。现在只有一个无条件表面：
 
+
 | 表面 | `tools/list` 中出现什么 | Agent 工作流 |
 |------|--------------------------|--------------|
-| Gateway MCP | 固定的发现+派发原语：`list_dcc_instances`、`connect_to_dcc`、`search_skills`、`load_skill`、`search_tools`、`describe_tool`、`call_tool`、池化工具、诊断工具 | `search_tools` → `describe_tool` → `call_tool` |
+| Gateway MCP | 固定的发现+派发原语：`search_skills`、`load_skill`、`search_tools`、`describe_tool`、`call_tool`、池化工具、诊断工具。实例注册表通过 `gateway://instances` MCP resource 暴露（用 `resources/read` 读取），而不是工具 — 见 #813 phase 1 | `resources/read uri=gateway://instances`（或跳过它，直接 `search_tools` → `describe_tool` → `call_tool`） |
+
 | Gateway REST | `/v1/search`、`/v1/describe`、`/v1/call`、`/v1/instances` | `POST /v1/search` → `/v1/describe` → `/v1/call` |
 | 直连 per-DCC MCP | 单个 DCC 服务的 skills 与已加载工具 | `search_skills` → `load_skill` → 调用工具 |
 

--- a/docs/zh/guide/rez-skill-packages.md
+++ b/docs/zh/guide/rez-skill-packages.md
@@ -61,7 +61,7 @@ def commands():
     env.DCC_MCP_RESOURCE_PATHS.append("{root}/resources")
 ```
 
-`DccServerBase` 将这些上下文值复制到 `McpHttpConfig.instance_metadata`。网关随后从 `list_dcc_instances` 返回它们，客户端可以路由到匹配请求包的已启动实例。
+`DccServerBase` 将这些上下文值复制到 `McpHttpConfig.instance_metadata`。网关随后通过 `gateway://instances` MCP 资源返回它们，客户端可以路由到匹配请求包的已启动实例。
 
 ## 来源追踪
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -36,8 +36,10 @@
 | Wrap values for safe RPyC transport | `wrap_value()` / `unwrap_value()` |
 | Handle multiple versions of an action | `VersionedRegistry` + `VersionConstraint` |
 | Expose DCC tools over HTTP/MCP | `create_skill_server("maya", McpHttpConfig(port=8765))` — Skills-First one-call setup; gateway/slim agents use `search_tools` → `describe_tool` → `call_tool`; falls back to `McpHttpServer(registry, config)` for manual registry wiring |
+| Discover gateway DCC instances / direct MCP URLs (#813 phase 1) | `resources/read uri="gateway://instances"` or `gateway://instances/{id}` — entries include `mcp_url`; `resources/list` shows the root pointer only; legacy `list_dcc_instances` / `get_dcc_instance` / `connect_to_dcc` and non-standard `instances/list` are removed |
 | Register MCP prompts from Python (issue #792) | `handle = server.prompts(); handle.register_prompt(name, template, description=..., arguments=[{"name": str, "description": str, "required": bool}])` — `server.prompts()` returns `PromptHandle`; registration upserts in-place and appears in the next `prompts/list` / `prompts/get` |
 | Persist and resume DCC project state | `DccProject.open/load(...)` + `register_project_tools(server, ...)` exposing `project.save/load/resume/status` |
+
 | Share resources/prompts through a gateway | `resources/list/read/subscribe` with exact gateway-returned URIs; `prompts/list/get` for namespaced backend prompts |
 | Discover team-level skills | `scan_and_load_team()` / `scan_and_load_team_lenient()` |
 | Discover user-level skills | `scan_and_load_user()` / `scan_and_load_user_lenient()` |


### PR DESCRIPTION
## Summary
- document gateway://instances as the current MCP resource for DCC instance discovery
- update AGENTS/AI_AGENT_GUIDE/llms-full so agents avoid removed instance-discovery tools
- sync English and Chinese HTTP/resources/gateway docs for #813 phase 1

## Validation
- git diff --check
- pre-commit hooks during commit
- local docs build skipped because docs/node_modules is absent and this run avoids installing dependencies without explicit authorization