### PR TITLE
docs: fix markdown lint after gateway resource update

### DIFF
--- a/docs/api/resources.md
+++ b/docs/api/resources.md
@@ -54,8 +54,9 @@ modeled as an MCP resource instead of a tool:
 not enumerate every `gateway://instances/{id}` URI. Read the per-instance URI
 directly when you already know the id. The legacy gateway tools
 `list_dcc_instances`, `get_dcc_instance`, and `connect_to_dcc` were removed in
-#813 phase 1; entries already carry `mcp_url`, so no separate connect verb is
-required.
+PR #813 phase 1; entries already carry `mcp_url`, so no separate connect verb
+is required.
+
 
 ## Enabling / Disabling
 

--- a/docs/guide/agents-reference.md
+++ b/docs/guide/agents-reference.md
@@ -3,8 +3,8 @@
 > This file is the detailed companion to `AGENTS.md`.
 > `AGENTS.md` is the navigation map; this file holds the expanded rules,
 > code examples, and traps that agents need on demand.
-
 > Read `AGENTS.md` first, then follow links here when you need detail.
+
 
 ---
 


### PR DESCRIPTION
## Summary
- fix markdownlint issues introduced by the gateway instance resource docs update
- keep the already-merged #813 guidance unchanged apart from lint-safe wording and blockquote formatting

## Validation
- git diff --check
- markdownlint-cli2 passed
- pre-commit hooks during commit