### PR TITLE
feat(http): wire ResourceRegistry + PromptRegistry into SkillRestService (#818 bridge)

### DIFF
--- a/crates/dcc-mcp-http/src/lib.rs
+++ b/crates/dcc-mcp-http/src/lib.rs
@@ -78,6 +78,7 @@ pub use dcc_mcp_jsonrpc as protocol;
 pub mod prompts;
 pub mod resource_link;
 pub mod resources;
+pub(crate) mod rest_providers;
 pub mod server;
 pub mod session;
 /// Re-export of [`dcc_mcp_skill_rest`] under the historical

--- a/crates/dcc-mcp-http/src/rest_providers.rs
+++ b/crates/dcc-mcp-http/src/rest_providers.rs
@@ -1,0 +1,177 @@
+//! Adapters that bridge `dcc-mcp-http` internal registries to the
+//! `dcc-mcp-skill-rest` provider traits (#818 phase 2 bridge).
+//!
+//! These adapters are wired into [`SkillRestService`] inside
+//! [`super::server`] so that `GET /v1/resources` and `GET /v1/prompts`
+//! return real data instead of the default empty responses.
+//!
+//! `JobController` adapter is deferred until `dcc-mcp-skill-rest` ships
+//! the `JobController` trait (PR #824, #818 phase 1b).
+//!
+//! Each adapter satisfies the DIP boundary in `dcc-mcp-skill-rest`:
+//! the REST layer depends on the trait, not on these concrete types.
+
+use std::sync::Arc;
+
+use dcc_mcp_skill_rest::{
+    PromptArgumentSpec, PromptContent, PromptGetResponse, PromptListEntry, PromptMessage,
+    PromptProvider, ResourceContent, ResourceListEntry, ResourceProvider, ResourceReadResponse,
+    ServiceError, ServiceErrorKind,
+};
+use dcc_mcp_skills::SkillCatalog;
+
+// ── ResourceRegistryAdapter ───────────────────────────────────────────────
+
+/// Bridges [`crate::resources::ResourceRegistry`] to
+/// [`ResourceProvider`].
+pub(crate) struct ResourceRegistryAdapter {
+    registry: crate::resources::ResourceRegistry,
+    catalog: Arc<SkillCatalog>,
+}
+
+impl ResourceRegistryAdapter {
+    pub(crate) fn new(
+        registry: crate::resources::ResourceRegistry,
+        catalog: Arc<SkillCatalog>,
+    ) -> Self {
+        Self { registry, catalog }
+    }
+
+    fn sync(&self) {
+        let catalog = self.catalog.clone();
+        self.registry
+            .sync_skill_resources(|visit| catalog.for_each_loaded_metadata(|md| visit(md)));
+    }
+}
+
+impl ResourceProvider for ResourceRegistryAdapter {
+    fn list(&self) -> Vec<ResourceListEntry> {
+        self.sync();
+        self.registry
+            .list()
+            .into_iter()
+            .map(|r| ResourceListEntry {
+                uri: r.uri,
+                name: r.name,
+                description: r.description,
+                mime_type: r.mime_type,
+            })
+            .collect()
+    }
+
+    fn read(&self, uri: &str) -> Result<ResourceReadResponse, ServiceError> {
+        self.sync();
+        self.registry
+            .read(uri)
+            .map_err(|e| match e {
+                crate::resources::ResourceError::NotFound(msg)
+                | crate::resources::ResourceError::NotEnabled(msg) => {
+                    ServiceError::new(ServiceErrorKind::NotFound, msg)
+                }
+                crate::resources::ResourceError::Read(msg) => {
+                    ServiceError::new(ServiceErrorKind::Internal, msg)
+                }
+            })
+            .map(|result| ResourceReadResponse {
+                contents: result
+                    .contents
+                    .into_iter()
+                    .map(|c| ResourceContent {
+                        uri: c.uri,
+                        mime_type: c.mime_type,
+                        text: c.text,
+                        blob: c.blob,
+                    })
+                    .collect(),
+            })
+    }
+}
+
+// ── PromptRegistryAdapter ─────────────────────────────────────────────────
+
+/// Bridges [`crate::prompts::PromptRegistry`] to [`PromptProvider`].
+pub(crate) struct PromptRegistryAdapter {
+    registry: crate::prompts::PromptRegistry,
+    catalog: Arc<SkillCatalog>,
+}
+
+impl PromptRegistryAdapter {
+    pub(crate) fn new(
+        registry: crate::prompts::PromptRegistry,
+        catalog: Arc<SkillCatalog>,
+    ) -> Self {
+        Self { registry, catalog }
+    }
+}
+
+impl PromptProvider for PromptRegistryAdapter {
+    fn list(&self) -> Vec<PromptListEntry> {
+        let catalog = self.catalog.clone();
+        self.registry
+            .list(|visit| catalog.for_each_loaded_metadata(|md| visit(md)))
+            .into_iter()
+            .map(|p| PromptListEntry {
+                name: p.name,
+                description: p.description,
+                arguments: p
+                    .arguments
+                    .into_iter()
+                    .map(|a| PromptArgumentSpec {
+                        name: a.name,
+                        description: a.description,
+                        required: a.required,
+                    })
+                    .collect(),
+            })
+            .collect()
+    }
+
+    fn get(
+        &self,
+        name: &str,
+        arguments: &serde_json::Value,
+    ) -> Result<PromptGetResponse, ServiceError> {
+        // Convert JSON arguments Value into HashMap<String, String>
+        let args: std::collections::HashMap<String, String> = arguments
+            .as_object()
+            .map(|m| {
+                m.iter()
+                    .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let catalog = self.catalog.clone();
+        self.registry
+            .get(name, &args, |visit| {
+                catalog.for_each_loaded_metadata(|md| visit(md))
+            })
+            .map_err(|e| match e {
+                crate::prompts::PromptError::NotFound(msg) => {
+                    ServiceError::new(ServiceErrorKind::NotFound, msg)
+                }
+                crate::prompts::PromptError::MissingArg(arg) => ServiceError::new(
+                    ServiceErrorKind::InvalidParams,
+                    format!("missing required argument: {arg}"),
+                ),
+                crate::prompts::PromptError::Load(msg) => {
+                    ServiceError::new(ServiceErrorKind::Internal, msg)
+                }
+            })
+            .map(|result| PromptGetResponse {
+                description: result.description,
+                messages: result
+                    .messages
+                    .into_iter()
+                    .map(|m| PromptMessage {
+                        role: m.role,
+                        content: match m.content {
+                            dcc_mcp_jsonrpc::McpPromptContent::Text { text } => {
+                                PromptContent::Text { text }
+                            }
+                        },
+                    })
+                    .collect(),
+            })
+    }
+}

--- a/crates/dcc-mcp-http/src/server/mod.rs
+++ b/crates/dcc-mcp-http/src/server/mod.rs
@@ -457,13 +457,19 @@ impl McpHttpServer {
             .clone()
             .unwrap_or_else(AppState::default_readiness);
 
-        let mut rest_config = dcc_mcp_skill_rest::SkillRestConfig::new(
-            dcc_mcp_skill_rest::SkillRestService::from_catalog_and_dispatcher(
-                catalog.clone(),
-                self.dispatcher.clone(),
-            ),
+        let rest_service = dcc_mcp_skill_rest::SkillRestService::from_catalog_and_dispatcher(
+            catalog.clone(),
+            self.dispatcher.clone(),
         )
-        .with_readiness(readiness.clone());
+        .with_resources(std::sync::Arc::new(
+            crate::rest_providers::ResourceRegistryAdapter::new(resources.clone(), catalog.clone()),
+        ))
+        .with_prompts(std::sync::Arc::new(
+            crate::rest_providers::PromptRegistryAdapter::new(prompts.clone(), catalog.clone()),
+        ));
+
+        let mut rest_config = dcc_mcp_skill_rest::SkillRestConfig::new(rest_service)
+            .with_readiness(readiness.clone());
         rest_config.server_title = self.config.server.server_name.clone();
         rest_config.server_version = self.config.server.server_version.clone();
         let rest_router = dcc_mcp_skill_rest::build_skill_rest_router(rest_config);

--- a/crates/dcc-mcp-skill-rest/src/lib.rs
+++ b/crates/dcc-mcp-skill-rest/src/lib.rs
@@ -79,8 +79,11 @@ pub use errors::{ServiceError, ServiceErrorKind};
 pub use readiness::{ReadinessProbe, ReadinessReport, StaticReadiness};
 pub use router::{SkillRestConfig, build_skill_rest_router};
 pub use service::{
-    CallOutcome, CallRequest, ContextSnapshot, DescribeRequest, DescribeResponse, SearchRequest,
-    SearchResponse, SkillCatalogSource, SkillListEntry, SkillRestService, ToolInvoker, ToolSlug,
+    CallOutcome, CallRequest, ContextSnapshot, DescribeRequest, DescribeResponse,
+    EmptyPromptProvider, EmptyResourceProvider, PromptArgumentSpec, PromptContent,
+    PromptGetResponse, PromptListEntry, PromptMessage, PromptProvider, ResourceContent,
+    ResourceListEntry, ResourceProvider, ResourceReadResponse, SearchRequest, SearchResponse,
+    SkillCatalogSource, SkillListEntry, SkillRestService, ToolInvoker, ToolSlug,
 };
 
 /// Upper bound on per-hit serialised bytes produced by `/v1/search` —


### PR DESCRIPTION
**#818 bridge** — `GET /v1/resources` and `GET /v1/prompts` now return real DCC data.

## Problem

`SkillRestService` was constructed with `EmptyResourceProvider`/`EmptyPromptProvider` defaults, so the new REST endpoints always returned empty lists even though `McpHttpServer` has a `ResourceRegistry` and `PromptRegistry` with real data.

## Solution

New `rest_providers.rs` with two adapters:

| Adapter | Trait | Bridges |
|---|---|---|
| `ResourceRegistryAdapter` | `ResourceProvider` | `ResourceRegistry.list()`, `ResourceRegistry.read()` |
| `PromptRegistryAdapter` | `PromptProvider` | `PromptRegistry.list()`, `PromptRegistry.get()` |

Both are wired in `McpHttpServer::start()` before building `SkillRestConfig`.

`JobController` adapter deferred until PR #824 (#818 phase 1b) merges `JobController` trait into `dcc-mcp-skill-rest`.

Also exports new public types from `dcc-mcp-skill-rest`: `ResourceProvider`, `PromptProvider`, and all related response types.

## Verification

- 242 tests pass (`vx cargo test -p dcc-mcp-http --lib`)
- `vx cargo check --workspace --tests` — clean

Refs #818.