### PR TITLE
chore(python): sync Python tests and docstrings to gateway resource API (#813 phase 1+2)

### DIFF
--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -966,7 +966,8 @@ class DccServerBase:
         ``documents`` with all open files and optionally ``display_name``).
 
         Changes propagate to ``FileRegistry`` on the next heartbeat tick
-        (≤ 5 s) so ``list_dcc_instances`` stays current without a restart.
+        (≤ 5 s) so the ``gateway://instances`` MCP resource stays current
+        without a gateway restart.
 
         Args:
             scene: Active/focused scene or document path.

--- a/tests/test_context_bundle_rez_fixture.py
+++ b/tests/test_context_bundle_rez_fixture.py
@@ -274,8 +274,9 @@ def test_rez_context_bundle_fixture_exposes_distinct_instance_metadata(tmp_path:
         time.sleep(2.2)
 
         gateway_url = f"http://127.0.0.1:{gateway_port}/mcp"
-        resp = _post_mcp(gateway_url, "tools/call", {"name": "list_dcc_instances", "arguments": {}})
-        instances = json.loads(resp["result"]["content"][0]["text"])["instances"]
+        # #813 phase 1: list_dcc_instances was replaced by the gateway://instances resource.
+        resp = _post_mcp(gateway_url, "resources/read", {"uri": "gateway://instances"})
+        instances = json.loads(resp["result"]["contents"][0]["text"])["instances"]
         by_task = {item["metadata"]["task"]: item for item in instances}
 
         assert by_task["animation"]["metadata"]["context_bundle"] == "show-a.seq010.shot020.animation"

--- a/tests/test_gateway_facade_aggregation.py
+++ b/tests/test_gateway_facade_aggregation.py
@@ -247,9 +247,13 @@ class TestFacadeToolsAggregation:
         tools = _list_all_tools(facade_cluster["gateway_url"])
         names = {t["name"] for t in tools}
 
-        # Tier 1 — gateway discovery meta-tools.
-        for meta in ("list_dcc_instances", "get_dcc_instance", "connect_to_dcc"):
-            assert meta in names, f"missing meta-tool {meta!r}"
+        # Tier 1 — gateway discovery meta-tools were promoted to MCP resources
+        # in #813 phase 1+2. Verify they are absent from tools/list.
+        for removed in ("list_dcc_instances", "get_dcc_instance", "connect_to_dcc"):
+            assert removed not in names, (
+                f"meta-tool {removed!r} should have been removed from tools/list "
+                "(promoted to gateway://instances resource in #813)"
+            )
 
         # Tier 2 — skill-management tools (one canonical set gateway-side).
         for mgmt in ("list_skills", "search_skills", "get_skill_info", "load_skill", "unload_skill"):
@@ -296,16 +300,20 @@ class TestFacadeToolsAggregation:
 
 
 class TestFacadeDiscovery:
-    """The ``list_dcc_instances`` meta-tool returns the same set the facade aggregates."""
+    """The ``gateway://instances`` MCP resource exposes the same set the facade aggregates.
 
-    def test_list_dcc_instances_reports_both_backends(self, facade_cluster):
+    In #813 phase 1 the ``list_dcc_instances`` tool was removed and replaced by
+    the ``gateway://instances`` MCP resource (``resources/read`` method).
+    """
+
+    def test_gateway_instances_resource_reports_both_backends(self, facade_cluster):
         resp = _post_mcp(
             facade_cluster["gateway_url"],
-            "tools/call",
-            {"name": "list_dcc_instances", "arguments": {}},
+            "resources/read",
+            {"uri": "gateway://instances"},
         )
-        text = resp["result"]["content"][0]["text"]
+        text = resp["result"]["contents"][0]["text"]
         data = json.loads(text)
         dccs = {entry["dcc_type"] for entry in data.get("instances", [])}
-        assert "maya" in dccs, f"maya backend not visible through gateway: {dccs}"
-        assert "blender" in dccs, f"blender backend not visible through gateway: {dccs}"
+        assert "maya" in dccs, f"maya backend not visible through gateway://instances: {dccs}"
+        assert "blender" in dccs, f"blender backend not visible through gateway://instances: {dccs}"

--- a/tests/test_gateway_resources_forwarding.py
+++ b/tests/test_gateway_resources_forwarding.py
@@ -163,6 +163,8 @@ class TestResourcesListMerge:
                 continue
             if uri.startswith("resources://gateway/"):
                 continue  # gateway-internal event log, no instance prefix needed
+            if uri.startswith("gateway://"):
+                continue  # gateway-native resources (#813 phase 1+2): instances, diagnostics, catalog
             parts = _split_gateway_prefixed_uri(uri)
             assert parts is not None, f"backend URI {uri!r} is not prefixed with an 8-hex id"
 


### PR DESCRIPTION
Syncs the Python test suite and docstrings after the gateway meta-tool removal in #819 and #820.

## What changed

After #813 phases 1+2 the following gateway tools were removed and replaced by MCP resources:
- `list_dcc_instances`, `get_dcc_instance`, `connect_to_dcc` → `gateway://instances`
- `diagnostics__process_status/audit_log/tool_metrics` → `gateway://diagnostics/*`
- `dcc_catalog__search/describe` → `gateway://catalog`

Python tests that called these tools via `tools/call` needed updating to use `resources/read`.

## Files changed

- `tests/test_gateway_facade_aggregation.py`:
  - `TestAggregation.test_aggregated_list_contains_local_and_backend_tools`: now **asserts the three instance discovery tools are ABSENT** from `tools/list` (they were promoted to resources)
  - `TestFacadeDiscovery`: renamed + updated to use `resources/read uri=gateway://instances` with correct `contents[0].text` response envelope
- `tests/test_context_bundle_rez_fixture.py`: updated `list_dcc_instances` call to `resources/read gateway://instances`
- `python/dcc_mcp_core/server_base.py`: updated docstring referencing `list_dcc_instances` → `gateway://instances` resource

## Note

The per-DCC adapter tools in `dcc_server.py` (`diagnostics__screenshot`, `diagnostics__audit_log`, `diagnostics__tool_metrics`, `diagnostics__process_status`) are **intentionally untouched** — they are per-DCC tools registered by `register_diagnostic_mcp_tools()`, distinct from the gateway-side tools that were removed.

Refs #813, #819, #820.