### PR TITLE
fix(tests): complete REST migration fixes for #818 phase 2 (POST /v1/search, alias params, bare slug, CallOutcome format)

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/backend_client.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/backend_client.rs
@@ -10,7 +10,7 @@
 //!
 //! | Operation            | Was (MCP JSON-RPC)      | Now (REST)              |
 //! |----------------------|-------------------------|-------------------------|
-//! | list tools           | `tools/list`            | `GET  /v1/search`       |
+//! | list tools           | `tools/list`            | `POST /v1/search`       |
 //! | call a tool          | `tools/call`            | `POST /v1/call`         |
 //! | list prompts         | `prompts/list`          | `GET  /v1/prompts`      |
 //! | render a prompt      | `prompts/get`           | `GET  /v1/prompts/{n}`  |
@@ -406,7 +406,7 @@ async fn rest_post(
         .map_err(|e| format!("{url}: invalid JSON response: {e}"))
 }
 
-/// Fetch tool list from a backend via `GET /v1/search?loaded_only=false&limit=5000`.
+/// Fetch tool list from a backend via `POST /v1/search` with `loaded_only=false`.
 ///
 /// Maps each search hit to a [`McpTool`] so the capability index builder
 /// receives the same type it always has.  `input_schema` is a minimal
@@ -424,8 +424,15 @@ pub async fn try_fetch_tools(
     timeout: Duration,
 ) -> Result<Vec<McpTool>, String> {
     let base = rest_base_from_mcp_url(mcp_url);
-    let url = format!("{base}/v1/search?loaded_only=false&limit=5000");
-    let val = rest_get(client, &url, timeout).await?;
+    let url = format!("{base}/v1/search");
+    // `/v1/search` is a POST endpoint; pass the filter params in the JSON body.
+    let val = rest_post(
+        client,
+        &url,
+        json!({"loaded_only": false, "limit": 5000}),
+        timeout,
+    )
+    .await?;
     Ok(val
         .get("hits")
         .and_then(Value::as_array)

--- a/crates/dcc-mcp-http/tests/http/backend_timeout.rs
+++ b/crates/dcc-mcp-http/tests/http/backend_timeout.rs
@@ -109,7 +109,7 @@ async fn spawn_slow_backend(delay: Duration) -> u16 {
         }))
     }
 
-    // GET /v1/search handler (used by fetch_tools after #818 phase 2)
+    // POST /v1/search handler (used by fetch_tools after #818 phase 2)
     async fn search_handler(
         axum::extract::State(delay): axum::extract::State<Duration>,
     ) -> Json<Value> {
@@ -131,7 +131,7 @@ async fn spawn_slow_backend(delay: Duration) -> u16 {
     let app = Router::new()
         .route("/health", get(|| async { "ok" }))
         .route("/mcp", post(mcp_handler))
-        .route("/v1/search", get(search_handler))
+        .route("/v1/search", post(search_handler))
         .with_state(delay);
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let port = listener.local_addr().unwrap().port();

--- a/crates/dcc-mcp-http/tests/http/gateway_dynamic_capabilities.rs
+++ b/crates/dcc-mcp-http/tests/http/gateway_dynamic_capabilities.rs
@@ -152,7 +152,7 @@ async fn spawn_backend(spec: BackendSpec) -> (u16, Arc<tokio::sync::RwLock<u32>>
         }
     }
 
-    // GET /v1/search handler (#818 phase 2: gateway now uses REST for fetch_tools)
+    // POST /v1/search handler (#818 phase 2: gateway now uses REST POST for fetch_tools)
     // A real backend's /v1/search does NOT include skill stubs or gateway-local
     // tools — those are filtered by the per-DCC REST service layer.
     async fn search_handler(
@@ -199,15 +199,18 @@ async fn spawn_backend(spec: BackendSpec) -> (u16, Arc<tokio::sync::RwLock<u32>>
             .unwrap_or("")
             .to_string();
         let received_args = req.get("arguments").cloned().unwrap_or(Value::Null);
+        // Return CallOutcome format (as a real /v1/call backend would).
+        // The output.structuredContent mirrors the old MCP response shape
+        // so existing test assertions on structuredContent remain valid.
         Json(json!({
-            "content": [{
-                "type": "text",
-                "text": format!("echo name={received_slug} args={received_args}")
-            }],
-            "structuredContent": {
-                "received_tool": received_slug,
-                "received_args": received_args,
-            }
+            "slug": received_slug,
+            "output": {
+                "structuredContent": {
+                    "received_tool": received_slug,
+                    "received_args": received_args,
+                }
+            },
+            "validation_skipped": true,
         }))
     }
 
@@ -224,7 +227,7 @@ async fn spawn_backend(spec: BackendSpec) -> (u16, Arc<tokio::sync::RwLock<u32>>
     let app = Router::new()
         .route("/health", get(|| async { "ok" }))
         .route("/mcp", post(mcp_handler))
-        .route("/v1/search", get(search_handler))
+        .route("/v1/search", post(search_handler))
         .route("/v1/call", post(call_handler))
         .with_state(state);
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -354,7 +357,7 @@ async fn rest_search_describe_call_roundtrip() {
     let result = call_service(&state, &slug, json!({"radius": 2.0}), None)
         .await
         .expect("call_service must route successfully");
-    let echoed = result["structuredContent"]["received_tool"]
+    let echoed = result["output"]["structuredContent"]["received_tool"]
         .as_str()
         .unwrap_or_default();
     assert_eq!(
@@ -506,7 +509,7 @@ async fn mcp_call_tool_forwards_namespaced_callable_id() {
     assert!(!is_error, "MCP call_tool failed: {body}");
     let parsed: Value = serde_json::from_str(&body).expect("call_tool envelope is JSON");
     assert_eq!(
-        parsed["structuredContent"]["received_tool"].as_str(),
+        parsed["output"]["structuredContent"]["received_tool"].as_str(),
         Some("jobs.get_status"),
     );
     assert_eq!(*call_count.read().await, 1);
@@ -597,12 +600,12 @@ async fn mcp_call_tool_forwards_original_backend_tool_exactly_once() {
     assert!(!is_error, "MCP call_tool failed: {body}");
     let parsed: Value = serde_json::from_str(&body).expect("call_tool envelope is JSON");
     assert_eq!(
-        parsed["structuredContent"]["received_tool"].as_str(),
+        parsed["output"]["structuredContent"]["received_tool"].as_str(),
         Some("export_fbx"),
         "gateway must decode the slug back to the backend tool name",
     );
     assert_eq!(
-        parsed["structuredContent"]["received_args"],
+        parsed["output"]["structuredContent"]["received_args"],
         json!({"path": "/tmp/out.fbx"}),
     );
     // Exactly one backend `tools/call` round-trip: no wasted tokens.
@@ -649,7 +652,7 @@ async fn mcp_call_tool_retries_unknown_slug_after_refresh() {
     assert!(!is_error, "call_tool must recover after refresh: {body}");
     let parsed: Value = serde_json::from_str(&body).expect("envelope is JSON");
     assert_eq!(
-        parsed["structuredContent"]["received_tool"].as_str(),
+        parsed["output"]["structuredContent"]["received_tool"].as_str(),
         Some("late_action"),
     );
     // Exactly one backend call — the refresh is free (one extra

--- a/crates/dcc-mcp-http/tests/http/gateway_prompts_e2e.rs
+++ b/crates/dcc-mcp-http/tests/http/gateway_prompts_e2e.rs
@@ -118,8 +118,51 @@ async fn spawn_fake_prompts_backend(
         Json(json!({"jsonrpc": "2.0", "id": id, "result": result}))
     }
 
+    // REST handlers for #818 phase 2 — gateway now fetches prompts via
+    // GET /v1/prompts instead of MCP prompts/list JSON-RPC.
+    async fn rest_list_prompts(
+        axum::extract::State(state): axum::extract::State<FakeBackendState>,
+    ) -> Json<Value> {
+        let name = *state.prompt_name.lock().unwrap();
+        Json(json!({
+            "total": 1,
+            "prompts": [{
+                "name": name,
+                "description": format!("prompt from {}", state.echo_marker),
+                "arguments": [],
+            }]
+        }))
+    }
+
+    async fn rest_get_prompt(
+        axum::extract::State(state): axum::extract::State<FakeBackendState>,
+        axum::extract::Path(name): axum::extract::Path<String>,
+    ) -> Json<Value> {
+        state
+            .get_hit
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        Json(json!({
+            "description": format!("{}:{}", state.echo_marker, name),
+            "messages": [{
+                "role": "user",
+                "content": {
+                    "type": "text",
+                    "text": format!("{}:{}", state.echo_marker, name),
+                }
+            }]
+        }))
+    }
+
     let app = Router::new()
         .route("/health", get(|| async { "ok" }))
+        .route(
+            "/v1/readyz",
+            get(|| async {
+                axum::Json(serde_json::json!({"process": true, "dispatcher": true, "dcc": true}))
+            }),
+        )
+        .route("/v1/prompts", get(rest_list_prompts))
+        .route("/v1/prompts/{name}", get(rest_get_prompt))
         .route("/mcp", post(handler))
         .with_state(state.clone());
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/crates/dcc-mcp-http/tests/http/operability_roadmap_e2e.rs
+++ b/crates/dcc-mcp-http/tests/http/operability_roadmap_e2e.rs
@@ -305,10 +305,15 @@ async fn issue_775_gateway_operability_acceptance_maya_photoshop() {
     )
     .await;
     let backend_envelope: Value = serde_json::from_str(tool_text(&call)).expect("backend envelope");
-    let backend_text = backend_envelope["content"][0]["text"]
-        .as_str()
-        .expect("backend tool text");
-    let backend_payload: Value = serde_json::from_str(backend_text).expect("backend JSON payload");
+    // After #818 phase 2, forward_tools_call returns the raw CallOutcome from
+    // POST /v1/call. The backend handler's result is in the `output` field.
+    let backend_payload = backend_envelope.get("output").cloned().unwrap_or_else(|| {
+        // Fallback: old MCP content[0].text double-wrapping.
+        let text = backend_envelope["content"][0]["text"]
+            .as_str()
+            .unwrap_or("{}");
+        serde_json::from_str(text).unwrap_or_default()
+    });
     assert_eq!(backend_payload["dcc"], "photoshop");
     assert_eq!(
         backend_payload["received_args"]["asset_id"],
@@ -346,9 +351,12 @@ async fn issue_775_gateway_operability_acceptance_maya_photoshop() {
     )
     .await;
     let maya_envelope: Value = serde_json::from_str(tool_text(&maya_call)).expect("maya envelope");
-    let maya_payload: Value =
-        serde_json::from_str(maya_envelope["content"][0]["text"].as_str().unwrap())
-            .expect("maya JSON payload");
+    // After #818 phase 2, maya call returns CallOutcome with `output` containing
+    // the handler's result. See photoshop call above for explanation.
+    let maya_payload = maya_envelope.get("output").cloned().unwrap_or_else(|| {
+        let text = maya_envelope["content"][0]["text"].as_str().unwrap_or("{}");
+        serde_json::from_str(text).unwrap_or_default()
+    });
     assert_eq!(maya_payload["dcc"], "maya");
 
     // #771: the Photoshop DCC server enforces payload limits at the HTTP

--- a/crates/dcc-mcp-skill-rest/src/service.rs
+++ b/crates/dcc-mcp-skill-rest/src/service.rs
@@ -163,7 +163,10 @@ pub struct DescribeResponse {
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct CallRequest {
     pub tool_slug: ToolSlug,
-    #[serde(default)]
+    /// Action arguments. Accepts both `params` and `arguments` field
+    /// names for compatibility with the gateway REST layer (#818 phase 2)
+    /// which sends `arguments` to match the MCP `tools/call` convention.
+    #[serde(default, alias = "arguments")]
     #[schema(value_type = Object)]
     pub params: Value,
 }
@@ -715,40 +718,69 @@ impl SkillRestService {
     }
 
     fn resolve_slug(&self, slug: &ToolSlug) -> Result<CatalogAction, ServiceError> {
-        let parts = slug.parts().ok_or_else(|| {
-            ServiceError::new(
-                ServiceErrorKind::BadRequest,
-                format!(
-                    "invalid tool slug '{}' — expected '<dcc>.<skill>.<action>'",
-                    slug.0
-                ),
-            )
-        })?;
-        let (dcc, skill, action) = parts;
+        // Fast path: full `<dcc>.<skill>.<action>` slug.
+        if let Some((dcc, skill, action)) = slug.parts() {
+            let actions = self.catalog.list_actions();
+            let exact: Vec<CatalogAction> = actions
+                .iter()
+                .filter(|a| {
+                    a.dcc.eq_ignore_ascii_case(dcc)
+                        && a.skill_name.eq_ignore_ascii_case(skill)
+                        && a.action_name.eq_ignore_ascii_case(action)
+                })
+                .cloned()
+                .collect();
+            return match exact.len() {
+                1 => Ok(exact.into_iter().next().unwrap()),
+                0 => Err(ServiceError::new(
+                    ServiceErrorKind::UnknownSlug,
+                    format!("no action registered for slug '{}'", slug.0),
+                )
+                .with_hint("call /v1/search to list available tools")),
+                _ => Err(ServiceError::new(
+                    ServiceErrorKind::Ambiguous,
+                    format!("slug '{}' matches {} actions", slug.0, exact.len()),
+                )
+                .with_candidates(
+                    exact
+                        .iter()
+                        .map(|a| ToolSlug::build(&a.dcc, &a.skill_name, &a.action_name).0)
+                        .collect(),
+                )),
+            };
+        }
+
+        // Bare action name fallback (#818 phase 2): the gateway forwards
+        // `callable_id` (bare action name) from the capability record.
+        // Accept it so directly-registered actions (skill_name="core") remain
+        // callable without requiring the full slug format.
+        let action_name = slug.0.as_str();
         let actions = self.catalog.list_actions();
-        // Exact match first.
-        let exact: Vec<CatalogAction> = actions
+        let matching: Vec<CatalogAction> = actions
             .iter()
-            .filter(|a| {
-                a.dcc.eq_ignore_ascii_case(dcc)
-                    && a.skill_name.eq_ignore_ascii_case(skill)
-                    && a.action_name.eq_ignore_ascii_case(action)
-            })
+            .filter(|a| a.action_name.eq_ignore_ascii_case(action_name))
             .cloned()
             .collect();
-        match exact.len() {
-            1 => Ok(exact.into_iter().next().unwrap()),
+        match matching.len() {
+            1 => Ok(matching.into_iter().next().unwrap()),
             0 => Err(ServiceError::new(
-                ServiceErrorKind::UnknownSlug,
-                format!("no action registered for slug '{}'", slug.0),
-            )
-            .with_hint("call /v1/search to list available tools")),
+                ServiceErrorKind::BadRequest,
+                format!(
+                    "invalid tool slug '{}' — expected '<dcc>.<skill>.<action>' or bare action name",
+                    slug.0
+                ),
+            )),
             _ => Err(ServiceError::new(
                 ServiceErrorKind::Ambiguous,
-                format!("slug '{}' matches {} actions", slug.0, exact.len()),
+                format!(
+                    "bare action name '{}' is ambiguous across {} registered actions; \
+                     use the full '<dcc>.<skill>.<action>' slug",
+                    slug.0,
+                    matching.len()
+                ),
             )
             .with_candidates(
-                exact
+                matching
                     .iter()
                     .map(|a| ToolSlug::build(&a.dcc, &a.skill_name, &a.action_name).0)
                     .collect(),


### PR DESCRIPTION
Fixes 4 integration test categories that failed after the gateway-to-backend REST migration (#818 phase 2).

## Root causes & fixes

| # | Root cause | Fix |
|---|---|---|
| 1 | `/v1/search` is `POST` but `try_fetch_tools` was calling `GET` | Changed to `rest_post`; all mock backends use `post()` |
| 2 | `CallRequest.params` not mapped from gateway's `arguments` key | Added `#[serde(alias = "arguments")]` |
| 3 | `resolve_slug` rejected bare action names (callable_id like `"export_layers"`) | Added fallback to match by bare `action_name` when 3-part slug fails |
| 4 | Tests expected old MCP `content[0].text` double-wrapping but now get raw `CallOutcome` | Updated `operability_roadmap_e2e` + `gateway_dynamic_capabilities` assertions to use `output` field |
| 5 | `gateway_prompts_e2e` mock backends had no `/v1/prompts` route | Added REST prompt routes to mock |

## Verification

`vx cargo test -p dcc-mcp-http --test http` — **66/66 passed**, 0 failed.
`vx cargo test --workspace --lib` — all lib test suites pass.

Refs #818.