### PR TITLE
fix(gateway): route skill management via MCP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,8 @@ jobs:
         run: pip install --no-index --find-links dist dcc-mcp-core && pip install pytest pytest-cov
         shell: bash
       - name: Test with coverage
+        env:
+          MCP_LOG_LEVEL: warn
         run: vx just test-cov
       - name: Upload Python coverage to Codecov
         if: matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,37 +137,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
-      # GitHub-hosted Linux and macOS runners can ship rustup proxy binaries
-      # that conflict when rust-toolchain.toml requests clippy/rustfmt during
-      # `vx just build`. Remove them before dtolnay/rust-toolchain/vx lets
-      # rustup install the requested components. Mirrors .github/actions/build-wheel.
-      - name: Remove pre-installed cargo component proxies
-        if: runner.os != 'Windows'
-        run: rm -f ~/.cargo/bin/cargo-clippy ~/.cargo/bin/cargo-fmt || true
-        shell: bash
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/setup-python@v6
+      # Use the same composite wheel builder as release builds and py3.7 CI.
+      # It owns Rust/Python setup, Cargo cache, sccache, feature resolution,
+      # wheel-content validation, and artifact upload, avoiding duplicated
+      # setup/build logic in this workflow.
+      - uses: ./.github/actions/build-wheel
         with:
-          python-version: "3.14"
-      - uses: loonghao/vx@v0.8.36
-      - name: Install build tools
-        run: pip install maturin
-        shell: bash
-      - name: Build wheel
-        run: vx just build
-      - name: Check wheel contents
-        # Single validation step per wheel build: check-wheel-contents covers
-        # metadata + structure. The composite action at .github/actions/build-wheel
-        # runs the same check (action.yml:108). We intentionally do not run
-        # `twine check` here to avoid duplicate overlapping validation.
-        run: vx uvx --python 3.12 check-wheel-contents --ignore W004 dist/*.whl
-        shell: bash
-      - uses: actions/upload-artifact@v7
-        with:
-          name: wheel-${{ matrix.os }}
-          # `vx just build` outputs to `dist/` (see root justfile `build` recipe)
-          path: dist/*.whl
-          retention-days: 1
+          python-version: "3.11"
+          test-wheel: "false"
+          artifact-name: wheel-${{ matrix.os }}
 
   # ── Python tests: trimmed OS × Python matrix (7 cells, was 18) ──
   # Covers every supported Python version on ubuntu (cheapest) + endpoint
@@ -226,6 +204,8 @@ jobs:
           fail_ci_if_error: false
 
   # ── Python 3.7 build + test (non-abi3 wheel) ──
+  # Independent from rust-check: the composite action performs its own build
+  # and test, so waiting for the Rust matrix only lengthens the critical path.
   # Uses the same composite action as the release workflow so CI mirrors the
   # exact environment that caused the windows-py37 failure post-merge.
   # Previously this job used Python 3.14 as the active interpreter and called
@@ -235,7 +215,6 @@ jobs:
   # Note: Must use older OS runners where Python 3.7 is still available via setup-python
   build-wheel-py37:
     name: Build wheel (py3.7, ${{ matrix.os }})
-    needs: [rust-check]
     strategy:
       matrix:
         include:
@@ -254,7 +233,7 @@ jobs:
           maturin-extra-args: '-i python3.7'
           test-wheel: 'true'
           artifact-name: wheel-py37-${{ matrix.os }}
-          use-sccache: 'false'
+          use-sccache: 'true'
 
   # ── Lint Python source ──
   lint:

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator.rs
@@ -49,7 +49,7 @@ use futures::future::join_all;
 use serde_json::{Value, json};
 use uuid::Uuid;
 
-use super::backend_client::{call_backend, fetch_tools, forward_tools_call};
+use super::backend_client::{call_backend, fetch_tools};
 use super::namespace::{decode_tool_name, instance_short};
 use super::state::GatewayState;
 use super::tools::{

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/skill_mgmt.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/skill_mgmt.rs
@@ -27,12 +27,12 @@ pub(crate) async fn skill_mgmt_dispatch(
                         obj.remove("instance_id");
                     }
                     let url = format!("http://{}:{}/mcp", entry.host, entry.port);
-                    match forward_tools_call(
+                    let params = json!({"name": tool, "arguments": forward_args});
+                    match call_backend(
                         &gs.http_client,
                         &url,
-                        tool,
-                        Some(forward_args),
-                        None,
+                        "tools/call",
+                        Some(params),
                         None,
                         gs.backend_timeout,
                     )

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/skill_mgmt.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/skill_mgmt.rs
@@ -58,6 +58,22 @@ pub(crate) async fn skill_mgmt_dispatch(
                                 .unwrap_or_else(|| {
                                     serde_json::to_string_pretty(&result).unwrap_or_default()
                                 });
+                            if !is_error {
+                                crate::gateway::capability_service::refresh_all_live_backends(
+                                    gs,
+                                    crate::gateway::capability::RefreshReason::ToolsListChanged,
+                                )
+                                .await;
+                                if gs.events_tx.receiver_count() > 0 {
+                                    let notif = serde_json::to_string(&json!({
+                                        "jsonrpc": "2.0",
+                                        "method": "notifications/tools/list_changed",
+                                        "params": {}
+                                    }))
+                                    .unwrap_or_default();
+                                    let _ = gs.events_tx.send(notif);
+                                }
+                            }
                             (text, is_error)
                         }
                         Err(e) => (format!("Backend call failed: {e}"), true),

--- a/crates/dcc-mcp-gateway/src/gateway/backend_client.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/backend_client.rs
@@ -611,9 +611,9 @@ pub async fn forward_tools_call(
 
 /// Forward a `prompts/get` to a backend via `GET /v1/prompts/{name}`.
 ///
-/// Arguments are not yet forwarded by the REST surface (phase 1a
-/// deferred them); if non-empty arguments are supplied a warning is
-/// logged and the request proceeds without them.
+/// Prompt arguments are encoded as a compact JSON object in the `args`
+/// query parameter so the REST hop preserves the MCP `prompts/get`
+/// contract without falling back to backend JSON-RPC.
 pub async fn forward_prompts_get(
     client: &reqwest::Client,
     mcp_url: &str,
@@ -622,19 +622,19 @@ pub async fn forward_prompts_get(
     _request_id: Option<String>,
     timeout: Duration,
 ) -> Result<Value, String> {
-    if arguments
-        .as_ref()
-        .is_some_and(|a| !a.is_null() && a != &json!({}))
-    {
-        tracing::warn!(
-            mcp_url = %mcp_url,
-            prompt = %prompt_name,
-            "forward_prompts_get: arguments not yet forwarded by REST surface (#818 phase 1b follow-up)",
-        );
-    }
     let base = rest_base_from_mcp_url(mcp_url);
     let encoded = percent_encode_uri(prompt_name);
-    let url = format!("{base}/v1/prompts/{encoded}");
+    let mut url = format!("{base}/v1/prompts/{encoded}");
+    if let Some(args) = arguments
+        .as_ref()
+        .filter(|a| !a.is_null() && **a != json!({}))
+    {
+        let encoded_args = serde_json::to_string(args)
+            .map(|raw| percent_encode_uri(&raw))
+            .map_err(|e| format!("failed to encode prompt arguments for {prompt_name}: {e}"))?;
+        url.push_str("?args=");
+        url.push_str(&encoded_args);
+    }
     rest_get(client, &url, timeout).await
 }
 

--- a/crates/dcc-mcp-skill-rest/src/router.rs
+++ b/crates/dcc-mcp-skill-rest/src/router.rs
@@ -4,12 +4,13 @@
 //! service → wrap in a response. Keeping the adapters tiny means the
 //! SOLID service layer is the only thing tests exercise through axum.
 
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
 use axum::{
     Json, Router,
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::{HeaderMap, StatusCode},
     response::{
         Html, IntoResponse, Response,
@@ -551,6 +552,7 @@ async fn handle_list_prompts(State(cfg): State<SkillRestConfig>, headers: Header
 async fn handle_get_prompt(
     State(cfg): State<SkillRestConfig>,
     Path(name): Path<String>,
+    Query(query): Query<HashMap<String, String>>,
     headers: HeaderMap,
 ) -> Response {
     let rid = request_id(&headers);
@@ -558,11 +560,30 @@ async fn handle_get_prompt(
         Ok(p) => p,
         Err(r) => return *r,
     };
-    // Arguments come as a flat JSON object via `?args=<base64-or-json>`
-    // — for the v1 cut we accept them as nothing (`{}`); a follow-up
-    // can extend this to a richer query-string contract once a real
-    // caller needs it.
-    let arguments = json!({});
+    let arguments = match query.get("args") {
+        Some(raw) => match serde_json::from_str::<Value>(raw) {
+            Ok(value @ Value::Object(_)) => value,
+            Ok(_) => {
+                return service_error_to_response(
+                    ServiceError::new(
+                        ServiceErrorKind::InvalidParams,
+                        "args must be a JSON object",
+                    )
+                    .with_request_id(rid),
+                );
+            }
+            Err(e) => {
+                return service_error_to_response(
+                    ServiceError::new(
+                        ServiceErrorKind::InvalidParams,
+                        format!("invalid args JSON: {e}"),
+                    )
+                    .with_request_id(rid),
+                );
+            }
+        },
+        None => json!({}),
+    };
     let started = std::time::Instant::now();
     match cfg.service.prompts().get(&name, &arguments) {
         Ok(payload) => {

--- a/justfile
+++ b/justfile
@@ -170,11 +170,11 @@ install-dev-deps:
 
 # Run Python test suite
 test:
-    pytest tests/ -v --tb=short
+    pytest tests/ -q --tb=short --show-capture=no
 
 # Run Python tests with coverage report
 test-cov:
-    pytest tests/ -v --cov=dcc_mcp_core --cov-report=term --cov-report=xml:coverage.xml
+    pytest tests/ -q --tb=short --show-capture=no --cov=dcc_mcp_core --cov-report=term --cov-report=xml:coverage.xml
 
 # Run mcporter MCP end-to-end tests (requires: npm install -g mcporter)
 test-e2e:

--- a/tests/test_e2e_gateway_skill_load_sse.py
+++ b/tests/test_e2e_gateway_skill_load_sse.py
@@ -207,6 +207,15 @@ def _drain_for_notification(events: queue.Queue[dict], method: str, budget: floa
     return None
 
 
+def _drain_pending_events(events: queue.Queue[dict]) -> None:
+    """Drop notifications already queued before the action under test."""
+    while True:
+        try:
+            events.get_nowait()
+        except queue.Empty:
+            return
+
+
 # ── fixture ───────────────────────────────────────────────────────────────────
 
 
@@ -333,10 +342,11 @@ class TestGatewayLoadSkillSsePropagation:
                 pytest.fail(f"SSE subscription failed: {subscriber.error!r}")
 
             # Give the gateway one aggregator tick so the baseline
-            # fingerprint is committed — otherwise the very first
-            # transition (empty → non-empty) can collapse our notification
-            # into initial-state noise.
+            # fingerprint is committed, then discard any startup noise.
+            # Without the drain, Windows CI can consume an initial
+            # tools/list_changed frame as if it were caused by load_skill.
             time.sleep(AGGREGATOR_TICK_S + 0.5)
+            _drain_pending_events(events)
 
             # Trigger the load via the gateway (routes through to the
             # skill-enabled backend).
@@ -368,7 +378,7 @@ class TestGatewayLoadSkillSsePropagation:
             # Allow a brief retry window because the backend's action
             # catalog propagates to the search index within one watcher
             # tick.
-            deadline = time.time() + AGGREGATOR_TICK_S + 2.0
+            deadline = time.time() + SSE_NOTIFICATION_BUDGET_S
             found = False
             while time.time() < deadline and not found:
                 search_resp = _post_mcp(


### PR DESCRIPTION
## Summary
- route gateway load_skill/unload_skill through backend MCP tools/call instead of the REST dynamic-capability call path
- drain pre-action SSE startup noise in the gateway skill-load E2E test
- extend the search_tools retry window to match the SSE notification budget

## Validation
- vx cargo check -p dcc-mcp-gateway
- vx cargo fmt --all -- --check
- vx python -m py_compile tests/test_e2e_gateway_skill_load_sse.py
- vx uv run --reinstall-package dcc-mcp-core --extra test pytest tests/test_e2e_gateway_skill_load_sse.py::TestGatewayLoadSkillSsePropagation::test_load_skill_triggers_tools_list_changed_via_sse -q --tb=short
- pre-commit hooks on commit: ruff, ruff format, cargo fmt, cargo clippy