### PR TITLE
fix(ci): sync generated Cargo metadata for bot PRs

### DIFF
--- a/.github/workflows/release-please-lock-sync.yml
+++ b/.github/workflows/release-please-lock-sync.yml
@@ -1,4 +1,4 @@
-name: Release Please lock sync
+name: Generated Cargo metadata sync
 
 on:
   pull_request:
@@ -7,6 +7,7 @@ on:
     paths:
       - "Cargo.toml"
       - "Cargo.lock"
+      - "crates/**/Cargo.toml"
       - "pyproject.toml"
       - "release-please-config.json"
 
@@ -19,13 +20,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  sync-cargo-lock:
-    name: Sync Cargo.lock for Release Please
+  sync-cargo-metadata:
+    name: Sync generated Cargo metadata
     runs-on: ubuntu-latest
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
-      startsWith(github.event.pull_request.head.ref, 'release-please--branches--main') &&
-      startsWith(github.event.pull_request.title, 'chore(main): release ')
+      (
+        (startsWith(github.event.pull_request.head.ref, 'release-please--branches--main') &&
+         startsWith(github.event.pull_request.title, 'chore(main): release ')) ||
+        startsWith(github.event.pull_request.head.ref, 'renovate/')
+      )
     steps:
       - uses: actions/checkout@v6
         with:
@@ -55,5 +59,5 @@ jobs:
           git config user.name "loonghao"
           git config user.email "hal.long@outlook.com"
           git add Cargo.lock crates/workspace-hack/Cargo.toml
-          git commit -m "chore(release): sync Cargo.lock"
+          git commit -m "chore(ci): sync generated Cargo metadata"
           git push origin HEAD:${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
## Summary
- Generalize the generated Cargo metadata sync workflow beyond release-please-only branches.
- Run it for same-repository Renovate PRs so dependency updates refresh Cargo.lock and workspace-hack before CI gates run.
- Include crate Cargo.toml changes in the trigger paths.

## Validation
- git diff --check
- vx cargo hakari verify