### PR TITLE
fix(output): pause OutputCapture during execute_python to stop stdout double-capture (#856)

### DIFF
--- a/crates/dcc-mcp-http/src/output.rs
+++ b/crates/dcc-mcp-http/src/output.rs
@@ -32,6 +32,7 @@
 
 use std::collections::VecDeque;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use parking_lot::RwLock;
@@ -115,6 +116,13 @@ struct OutputBufferInner {
     /// Fan-out broadcast for SSE subscribers.
     tx: broadcast::Sender<OutputEntry>,
     instance_id: String,
+    /// When `true`, `push()` calls are silently dropped (issue #856).
+    ///
+    /// Set via [`OutputBuffer::set_paused`] to suppress Maya Script Editor
+    /// output during `execute_python` so the `output://` buffer does not
+    /// accumulate a mangled duplicate of what `ScriptExecutionCapture` is
+    /// already capturing cleanly via `sys.stdout` replacement.
+    paused: AtomicBool,
 }
 
 impl OutputBuffer {
@@ -132,12 +140,18 @@ impl OutputBuffer {
                 capacity,
                 tx,
                 instance_id: instance_id.into(),
+                paused: AtomicBool::new(false),
             }),
         }
     }
 
     /// Push a new entry into the ring and notify all SSE subscribers.
+    ///
+    /// No-op when the buffer is paused (see [`OutputBuffer::set_paused`]).
     pub fn push(&self, entry: OutputEntry) {
+        if self.inner.paused.load(Ordering::Relaxed) {
+            return;
+        }
         {
             let mut ring = self.inner.ring.write();
             ring.push_back(entry.clone());
@@ -147,6 +161,22 @@ impl OutputBuffer {
         }
         // Best-effort fan-out — ignore errors if no subscribers.
         let _ = self.inner.tx.send(entry);
+    }
+
+    /// Pause or resume the buffer (issue #856).
+    ///
+    /// When paused, [`push`] calls are silently dropped so the `output://`
+    /// resource does not accumulate duplicates of output that a
+    /// `ScriptExecutionCapture` context is already capturing via
+    /// `sys.stdout` replacement. Spontaneous Maya warnings between calls
+    /// are unaffected because the executor resumes the buffer on exit.
+    pub fn set_paused(&self, paused: bool) {
+        self.inner.paused.store(paused, Ordering::Relaxed);
+    }
+
+    /// Whether the buffer is currently paused.
+    pub fn is_paused(&self) -> bool {
+        self.inner.paused.load(Ordering::Relaxed)
     }
 
     /// Convenience: push a stdout line.
@@ -326,6 +356,21 @@ impl OutputCapture {
     /// Drain all entries since `since_ns` (pass 0 for all).
     pub fn drain(&self, since_ns: u128) -> Vec<OutputEntry> {
         self.buffer.drain_since(since_ns)
+    }
+
+    /// Pause or resume the buffer (issue #856).
+    ///
+    /// When paused, [`OutputCapture::push`] calls are silently dropped.
+    /// Call with `paused = true` before executing a skill script and
+    /// `paused = false` after to prevent the `output://` resource from
+    /// accumulating a mangled duplicate alongside `ScriptExecutionCapture`.
+    pub fn set_paused(&self, paused: bool) {
+        self.buffer.set_paused(paused);
+    }
+
+    /// Whether the buffer is currently paused.
+    pub fn is_paused(&self) -> bool {
+        self.buffer.is_paused()
     }
 
     /// Get the MCP resource URI for this capture instance.

--- a/crates/dcc-mcp-http/src/python/output_dynamic.rs
+++ b/crates/dcc-mcp-http/src/python/output_dynamic.rs
@@ -276,6 +276,24 @@ impl PyOutputCapture {
             self.inner.buffer.instance_id()
         )
     }
+
+    /// Pause or resume output buffering (issue #856).
+    ///
+    /// Call ``set_paused(True)`` before executing a skill script body so the
+    /// ``output://`` resource does not accumulate a mangled duplicate of the
+    /// output that ``ScriptExecutionCapture`` is already collecting cleanly
+    /// via ``sys.stdout`` replacement. Call ``set_paused(False)`` after the
+    /// script body returns so spontaneous Maya warnings between calls still
+    /// reach the resource.
+    fn set_paused(&self, paused: bool) {
+        self.inner.set_paused(paused);
+    }
+
+    /// Whether the buffer is currently paused.
+    #[getter]
+    fn paused(&self) -> bool {
+        self.inner.is_paused()
+    }
 }
 
 // ── Module registration ────────────────────────────────────────────────────────

--- a/python/dcc_mcp_core/script_execution.py
+++ b/python/dcc_mcp_core/script_execution.py
@@ -108,10 +108,22 @@ class ScriptExecutionCapture(AbstractContextManager):
     ``tee=True`` keeps host-console visibility while still collecting output
     for the tool response. This mirrors DCC plugin expectations where artists
     should continue seeing script output in the native console.
+
+    ``output_capture`` accepts an ``OutputCapture`` (the Rust ``output://``
+    ring-buffer object). When supplied, ``ScriptExecutionCapture`` calls
+    ``output_capture.set_paused(True)`` on ``__enter__`` and
+    ``set_paused(False)`` on ``__exit__``, preventing the ``output://``
+    resource from accumulating a mangled duplicate of the output that this
+    context already captures cleanly via ``sys.stdout`` replacement
+    (issue #856).
+
+    The object only needs to expose a ``set_paused(bool)`` method; it does
+    not need to be the exact ``OutputCapture`` class so test doubles work.
     """
 
-    def __init__(self, *, tee: bool = False) -> None:
+    def __init__(self, *, tee: bool = False, output_capture: Any = None) -> None:
         self._tee = tee
+        self._output_capture = output_capture
         self._old_stdout: TextIO | None = None
         self._old_stderr: TextIO | None = None
         self._stdout_capture: _CaptureStream | None = None
@@ -124,6 +136,14 @@ class ScriptExecutionCapture(AbstractContextManager):
         self._stderr_capture = _CaptureStream(sys.stderr, tee=self._tee)
         sys.stdout = self._stdout_capture
         sys.stderr = self._stderr_capture
+        # Suspend the output:// ring buffer so Maya Script Editor output
+        # during this script body does not produce a mangled duplicate in
+        # the response envelope (issue #856).
+        if self._output_capture is not None:
+            try:
+                self._output_capture.set_paused(True)
+            except Exception:
+                pass
         return self
 
     def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
@@ -131,6 +151,13 @@ class ScriptExecutionCapture(AbstractContextManager):
             sys.stdout = self._old_stdout
         if self._old_stderr is not None:
             sys.stderr = self._old_stderr
+        # Always resume, even on exception, so spontaneous Maya warnings
+        # between calls keep reaching the output:// resource.
+        if self._output_capture is not None:
+            try:
+                self._output_capture.set_paused(False)
+            except Exception:
+                pass
 
     @property
     def stdout(self) -> str:

--- a/tests/test_script_execution.py
+++ b/tests/test_script_execution.py
@@ -135,3 +135,62 @@ def test_from_exception_includes_traceback_and_captured_output() -> None:
     assert result["context"]["exception_type"] == "RuntimeError"
     assert result["context"]["exception_message"] == "boom"
     assert "Traceback" in result["context"]["traceback"]
+
+
+# ── issue #856 regression: output_capture pause/resume ────────────────────────
+
+
+class _FakeOutputCapture:
+    """Minimal test double for OutputCapture (the Rust PyO3 object)."""
+
+    def __init__(self) -> None:
+        self.paused = False
+        self.pause_calls: list[bool] = []
+
+    def set_paused(self, value: bool) -> None:
+        self.paused = value
+        self.pause_calls.append(value)
+
+
+def test_capture_pauses_output_capture_on_enter_resumes_on_exit() -> None:
+    """ScriptExecutionCapture must pause output_capture on enter and resume on exit."""
+    oc = _FakeOutputCapture()
+    with ScriptExecutionCapture(output_capture=oc):
+        assert oc.paused is True, "must be paused during script body"
+
+    assert oc.paused is False, "must be resumed after exit"
+    assert oc.pause_calls == [True, False]
+
+
+def test_capture_resumes_output_capture_on_exception() -> None:
+    """output_capture must be resumed even when the script body raises."""
+    oc = _FakeOutputCapture()
+    try:
+        with ScriptExecutionCapture(output_capture=oc):
+            raise RuntimeError("script error")
+    except RuntimeError:
+        pass
+
+    assert oc.paused is False, "must resume on exception exit"
+    assert oc.pause_calls == [True, False]
+
+
+def test_capture_without_output_capture_works_normally() -> None:
+    """Passing no output_capture must leave existing behaviour unchanged."""
+    with ScriptExecutionCapture() as cap:
+        print("hello")
+
+    assert cap.stdout == "hello\n"
+
+
+def test_capture_tolerates_set_paused_raising() -> None:
+    """A broken output_capture must not abort the script body."""
+
+    class _BrokenCapture:
+        def set_paused(self, _value: bool) -> None:
+            raise RuntimeError("broken")
+
+    with ScriptExecutionCapture(output_capture=_BrokenCapture()) as cap:
+        print("still works")
+
+    assert cap.stdout == "still works\n"


### PR DESCRIPTION
## Summary

Fixes #856 — every execute_python response contained two copies of each print() line: a clean copy from ScriptExecutionCapture and a mangled copy from Maya Script Editor via OutputCapture, with "
 
" inserted between print() arguments.

## Root cause

Two capture paths were simultaneously active during execute_python:
1. ScriptExecutionCapture replaces sys.stdout with a StringIO buffer (clean copy)
2. OutputCapture.push() receives Maya Script Editor output through the MEL print pipeline (mangled copy with newlines between args)

Both were concatenated into context.stdout, doubling response size and corrupting structured output.

## Fix

Add a pause/resume mechanism to OutputBuffer so it silences itself during script execution.

**Rust (dcc-mcp-http):**
- OutputBufferInner gains paused: AtomicBool (lock-free, zero contention)
- OutputBuffer::push() returns early when paused
- OutputBuffer::set_paused(bool) / is_paused() added
- OutputCapture::set_paused() / is_paused() delegate to buffer
- PyOutputCapture gains set_paused(paused: bool) and paused property

**Python (dcc-mcp-core):**
- ScriptExecutionCapture.__init__ gains output_capture=None kwarg
- __enter__ calls output_capture.set_paused(True) if provided
- __exit__ calls set_paused(False) unconditionally (even on exception)
- Both wrapped in try/except so broken output_capture never aborts script

**Usage in dcc-mcp-maya:**


## Tests

- 4 new Python unit tests covering pause/resume, exception safety, None case, and broken capture
- 8 existing Rust output tests pass
- 14 Python script_execution tests pass (with PYTHONPATH=python to use local source)
