### PR TITLE
fix(gateway): replace production unwrap() with safe alternatives (#840)

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/prompts.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/prompts.rs
@@ -115,7 +115,13 @@ pub async fn route_prompts_get(
             let instances = live_backends(gs).await;
             match instances.len() {
                 0 => return Err(PromptsGetError::NoLiveBackend),
-                1 => (instances.into_iter().next().unwrap(), name.to_string()),
+                1 => (
+                    instances
+                        .into_iter()
+                        .next()
+                        .expect("instances.len() == 1 guarantees a first element"),
+                    name.to_string(),
+                ),
                 _ => return Err(PromptsGetError::AmbiguousBareName(name.to_string())),
             }
         }

--- a/crates/dcc-mcp-gateway/src/gateway/middleware/quota.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/middleware/quota.rs
@@ -57,7 +57,7 @@ impl BeforeCallMiddleware for QuotaMiddleware {
         let window = self.window;
 
         let result = {
-            let mut buckets = self.buckets.lock().unwrap();
+            let mut buckets = self.buckets.lock().unwrap_or_else(|e| e.into_inner());
             let now = Instant::now();
             let bucket = buckets.entry(key.clone()).or_insert(BucketState {
                 count: 0,


### PR DESCRIPTION
Fixes #840 — replace the two real production-path `unwrap()` calls in the gateway crate with safe alternatives.

## Changes

1. **`aggregator/prompts.rs:118`** — `.unwrap()` → `.expect("instances.len() == 1 guarantees a first element")`
   - The match arm is guarded by `len() == 1`, so this cannot panic in practice.
   - `.expect()` makes the invariant explicit and avoids a bare panic if logic changes.

2. **`middleware/quota.rs:60`** — `.unwrap()` → `.unwrap_or_else(|e| e.into_inner())`
   - Mutex poison recovery: if a thread panicked while holding the quota lock, recover the inner data instead of propagating a panic through the middleware chain.

## Audit Result

Grep audit confirmed: all other `unwrap()` / `panic!` in the gateway crate are inside `#[cfg(test)]` blocks. The 501 `unwrap()` count from the initial audit was dominated by test code and `..Default::default()` syntax (not actual unwrap calls).

## CI

CI must pass on this branch (rebased onto `origin/main` which includes #872 merge — `contextlib.suppress` fix for `try-except-pass`).