### PR TITLE
fix(models): accept inputSchema/outputSchema camelCase in tools.yaml (#857)

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/tasks.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tasks.rs
@@ -493,6 +493,10 @@ pub(crate) async fn start_gateway_tasks(
     });
 
     // ── Gateway HTTP server ────────────────────────────────────────────────
+    // When `admin` feature is disabled the AuditMiddleware block is compiled
+    // out, so `gw_state` is never mutated.  With `admin` enabled the block
+    // below reassigns `gw_state.middleware_chain`, so `mut` is required.
+    #[cfg_attr(not(feature = "admin"), allow(unused_mut))]
     let mut gw_state = GatewayState {
         registry: registry.clone(),
         stale_timeout,
@@ -659,7 +663,7 @@ pub(crate) async fn start_gateway_tasks(
                 .await
             };
 
-            for (entry, outcome) in entries.iter().zip(probe_results.into_iter()) {
+            for (entry, outcome) in entries.iter().zip(probe_results) {
                 let key = format!("{}:{}", entry.dcc_type, entry.instance_id);
                 let id8 = entry.instance_id.to_string()[..8].to_string();
 

--- a/crates/dcc-mcp-models/src/skill_metadata/tests.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata/tests.rs
@@ -436,3 +436,89 @@ fn test_tool_declaration_next_tools_default_empty() {
     assert!(meta.tools[0].next_tools.on_success.is_empty());
     assert!(meta.tools[0].next_tools.on_failure.is_empty());
 }
+
+// ── issue #857: inputSchema/outputSchema camelCase alias ─────────────────────
+
+#[test]
+fn test_tool_declaration_input_schema_alias_camel_case() {
+    // inputSchema (camelCase) must deserialize into input_schema (issue #857)
+    let json = r#"{
+        "name": "test-skill",
+        "tools": [{
+            "name": "my_tool",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "count": {"type": "integer"}
+                },
+                "required": ["path"]
+            }
+        }]
+    }"#;
+    let meta: SkillMetadata = serde_json::from_str(json).unwrap();
+    let schema = &meta.tools[0].input_schema;
+    assert_eq!(schema["type"], "object");
+    assert_eq!(schema["properties"]["path"]["type"], "string");
+    assert_eq!(schema["properties"]["count"]["type"], "integer");
+    assert_eq!(schema["required"][0], "path");
+}
+
+#[test]
+fn test_tool_declaration_input_schema_snake_case_still_works() {
+    // snake_case input_schema must still work (backward compatibility)
+    let json = r#"{
+        "name": "test-skill",
+        "tools": [{
+            "name": "my_tool",
+            "input_schema": {"type": "object", "properties": {}}
+        }]
+    }"#;
+    let meta: SkillMetadata = serde_json::from_str(json).unwrap();
+    assert_eq!(meta.tools[0].input_schema["type"], "object");
+}
+
+#[test]
+fn test_tool_declaration_output_schema_alias_camel_case() {
+    // outputSchema (camelCase) must deserialize into output_schema (issue #857)
+    let json = r#"{
+        "name": "test-skill",
+        "tools": [{
+            "name": "my_tool",
+            "outputSchema": {
+                "type": "object",
+                "properties": {
+                    "result": {"type": "string"}
+                }
+            }
+        }]
+    }"#;
+    let meta: SkillMetadata = serde_json::from_str(json).unwrap();
+    let schema = &meta.tools[0].output_schema;
+    assert_eq!(schema["type"], "object");
+    assert_eq!(schema["properties"]["result"]["type"], "string");
+}
+
+#[test]
+fn test_tool_declaration_output_schema_snake_case_still_works() {
+    // snake_case output_schema must still work (backward compatibility)
+    let json = r#"{
+        "name": "test-skill",
+        "tools": [{
+            "name": "my_tool",
+            "output_schema": {"type": "object"}
+        }]
+    }"#;
+    let meta: SkillMetadata = serde_json::from_str(json).unwrap();
+    assert_eq!(meta.tools[0].output_schema["type"], "object");
+}
+
+#[test]
+fn test_tool_declaration_schema_null_when_omitted() {
+    // When neither input_schema nor inputSchema is provided, field defaults to null
+    // (serde(default) + no alias match → Value::Null)
+    let json = r#"{"name": "s", "tools": [{"name": "t"}]}"#;
+    let meta: SkillMetadata = serde_json::from_str(json).unwrap();
+    assert!(meta.tools[0].input_schema.is_null());
+    assert!(meta.tools[0].output_schema.is_null());
+}

--- a/crates/dcc-mcp-models/src/skill_metadata/tool_declaration.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata/tool_declaration.rs
@@ -164,11 +164,17 @@ pub struct ToolDeclaration {
     pub description: String,
 
     /// JSON Schema for input parameters (as serde_json::Value).
-    #[serde(default)]
+    ///
+    /// Accepts both `input_schema` (snake_case, canonical) and `inputSchema`
+    /// (camelCase, MCP spec style) in YAML/JSON so SKILL.md authors can use
+    /// either convention (issue #857).
+    #[serde(default, alias = "inputSchema")]
     pub input_schema: serde_json::Value,
 
     /// JSON Schema for output (as serde_json::Value).
-    #[serde(default, skip_serializing_if = "is_null_value")]
+    ///
+    /// Accepts both `output_schema` and `outputSchema` (issue #857).
+    #[serde(default, skip_serializing_if = "is_null_value", alias = "outputSchema")]
     pub output_schema: serde_json::Value,
 
     /// Whether this tool only reads data (no side effects).
@@ -342,8 +348,9 @@ impl<'de> serde::Deserialize<'de> for ToolDeclaration {
         struct Wire {
             name: String,
             description: String,
+            #[serde(default, alias = "inputSchema")]
             input_schema: serde_json::Value,
-            #[serde(default)]
+            #[serde(default, alias = "outputSchema")]
             output_schema: serde_json::Value,
             read_only: bool,
             destructive: bool,


### PR DESCRIPTION
## Summary

Fixes #857 — `inputSchema` / `outputSchema` written in camelCase (MCP spec style) inside `tools.yaml` were silently deserialized as `null`, causing the `tools/list` response to carry an empty `inputSchema`.

## Root Cause

`ToolDeclaration` uses a **custom `Deserialize` impl** that delegates to an intermediate `Wire` struct. The `#[serde(alias = "...")]` attributes on `ToolDeclaration`'s own field declarations were ineffective because the custom impl never reads them — it deserializes `Wire`, then converts.

`Wire`'s `input_schema` and `output_schema` fields had **no `alias`**, so `inputSchema:` (camelCase) in YAML/JSON was simply ignored and defaulted to `Value::Null`.

## Fix (`tool_declaration.rs`)

**`Wire` struct (used by custom `Deserialize` impl):**
```rust
// Before
input_schema: serde_json::Value,
#[serde(default)]
output_schema: serde_json::Value,

// After
#[serde(default, alias = "inputSchema")]
input_schema: serde_json::Value,
#[serde(default, alias = "outputSchema")]
output_schema: serde_json::Value,
```

**`ToolDeclaration` struct (used by `Serialize` derive + docs):**
```rust
#[serde(default, alias = "inputSchema")]
pub input_schema: serde_json::Value,
#[serde(default, skip_serializing_if = "is_null_value", alias = "outputSchema")]
pub output_schema: serde_json::Value,
```

## Tests (`tests.rs`)

5 new regression tests:
- `test_tool_declaration_input_schema_alias_camel_case` — `inputSchema` (camelCase) deserializes correctly ✓
- `test_tool_declaration_input_schema_snake_case_still_works` — `input_schema` (snake_case) backward compat ✓
- `test_tool_declaration_output_schema_alias_camel_case` — `outputSchema` (camelCase) ✓
- `test_tool_declaration_output_schema_snake_case_still_works` — `output_schema` backward compat ✓
- `test_tool_declaration_schema_null_when_omitted` — neither field → `Value::Null` ✓

All 64 + 1 doctest pass.

## Impact

- `tools.yaml` authors can now use either `inputSchema` or `input_schema` — no more silent `null`.
- `tools/list` response correctly includes `inputSchema` with full `properties`.
- No behavior change when fields are omitted (still `null`, handled by `action_meta_to_mcp_tool`).