### PR TITLE
feat(admin): Phase 3 statistics dashboard — GET /admin/api/stats (#863)

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
@@ -172,3 +172,30 @@ pub async fn handle_admin_trace_detail(
         ),
     }
 }
+
+/// `GET /admin/api/stats?range=1h|24h|7d` — aggregated call statistics (Phase 3).
+///
+/// Computes on-demand from the [`TraceLog`] ring buffer: call count, success
+/// rate, latency percentiles, top-N tools, top-N instances, and hour-of-day
+/// distribution.  Returns `{"range":"...", "total_calls":N, ...}`.
+pub async fn handle_admin_stats(
+    State(s): State<AdminState>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> impl IntoResponse {
+    use crate::gateway::admin::stats::StatsRange;
+
+    let range_str = params.get("range").map(String::as_str).unwrap_or("all");
+    let range = StatsRange::from_str(range_str);
+
+    match &s.stats {
+        Some(agg) => {
+            let stats = agg.compute(range);
+            Json(serde_json::to_value(&stats).unwrap_or(json!({})))
+        }
+        None => Json(json!({
+            "error": "stats aggregator not available — admin feature may be disabled",
+            "range": range_str,
+            "total_calls": 0,
+        })),
+    }
+}

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -29,6 +29,7 @@
 
 mod html;
 pub mod state;
+pub mod stats;
 pub mod trace;
 
 #[cfg(feature = "admin")]
@@ -37,6 +38,7 @@ mod handlers;
 mod router;
 
 pub use state::{AdminAuditRecord, AdminAuditSink, AdminState, AuditLog, EventLog};
+pub use stats::{GatewayStats, LatencyStats, StatsAggregator, StatsRange, TopEntry};
 pub use trace::{DispatchTrace, TraceLog, TracePayload, TraceSpan};
 
 #[cfg(feature = "admin")]

--- a/crates/dcc-mcp-gateway/src/gateway/admin/router.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/router.rs
@@ -4,7 +4,8 @@ use axum::{Router, routing};
 
 use super::handlers::{
     handle_admin_calls, handle_admin_health, handle_admin_instances, handle_admin_logs,
-    handle_admin_tools, handle_admin_trace_detail, handle_admin_traces, handle_admin_ui,
+    handle_admin_stats, handle_admin_tools, handle_admin_trace_detail, handle_admin_traces,
+    handle_admin_ui,
 };
 use super::state::AdminState;
 
@@ -20,6 +21,7 @@ use super::state::AdminState;
 /// - `GET  /api/calls`              → JSON recent calls
 /// - `GET  /api/traces`             → JSON recent dispatch traces (Phase 2)
 /// - `GET  /api/traces/{request_id}` → full trace waterfall for one call
+/// - `GET  /api/stats?range=1h|24h|7d` → aggregated call statistics (Phase 3)
 /// - `GET  /api/logs`               → JSON event log
 /// - `GET  /api/health`             → JSON health summary
 pub fn build_admin_router(state: AdminState) -> Router {
@@ -34,6 +36,7 @@ pub fn build_admin_router(state: AdminState) -> Router {
             routing::get(handle_admin_trace_detail),
         )
         .route("/api/logs", routing::get(handle_admin_logs))
+        .route("/api/stats", routing::get(handle_admin_stats))
         .route("/api/health", routing::get(handle_admin_health))
         .with_state(state)
 }

--- a/crates/dcc-mcp-gateway/src/gateway/admin/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/state.rs
@@ -9,6 +9,7 @@ use serde_json::Value;
 use crate::gateway::middleware::{AuditEntry, AuditSink};
 use crate::gateway::state::GatewayState;
 
+use super::stats::StatsAggregator;
 use super::trace::{DispatchTrace, TraceLog};
 
 /// Minimal audit record that the admin UI consumes.
@@ -108,6 +109,8 @@ pub struct AdminState {
     pub audit_log: Option<Arc<AuditLog>>,
     /// Phase 2 trace log — `None` until `with_trace_log` is called.
     pub trace_log: Option<Arc<TraceLog>>,
+    /// Phase 3 stats aggregator — `None` until `with_trace_log` is called.
+    pub stats: Option<Arc<StatsAggregator>>,
     pub event_log: Arc<EventLog>,
     pub started_at: SystemTime,
 }
@@ -118,6 +121,7 @@ impl AdminState {
             gateway,
             audit_log: None,
             trace_log: None,
+            stats: None,
             event_log: Arc::new(Mutex::new(Vec::new())),
             started_at: SystemTime::now(),
         }
@@ -129,6 +133,8 @@ impl AdminState {
     }
 
     pub fn with_trace_log(mut self, log: Arc<TraceLog>) -> Self {
+        // Phase 3: auto-create StatsAggregator when a TraceLog is attached.
+        self.stats = Some(Arc::new(StatsAggregator::new(log.clone())));
         self.trace_log = Some(log);
         self
     }

--- a/crates/dcc-mcp-gateway/src/gateway/admin/stats.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/stats.rs
@@ -1,0 +1,360 @@
+//! Phase 3 — Statistics aggregator for the admin UI `/api/stats` endpoint.
+//!
+//! Computes on-demand aggregations from the [`TraceLog`] ring buffer:
+//!
+//! - Overall call rate, success rate, total call count
+//! - Latency percentiles (p50 / p95 / p99) in milliseconds
+//! - Top-N tools by call count
+//! - Top-N instances by call count
+//! - Hour-of-day call distribution (24 buckets, UTC)
+//!
+//! All computations are pure (no background tasks, no write side), so Phase 3
+//! adds zero to the `tools/call` hot path.  The `GET /admin/api/stats` handler
+//! calls `StatsAggregator::compute()` on the current ring-buffer snapshot;
+//! the whole operation takes O(N) time and memory where N = ring-buffer size
+//! (default 200).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use super::trace::TraceLog;
+
+/// How far back to consider when computing statistics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatsRange {
+    /// Last 1 hour.
+    Hour1,
+    /// Last 24 hours.
+    Hour24,
+    /// Last 7 days.
+    Day7,
+    /// All data in the ring buffer (default).
+    All,
+}
+
+impl StatsRange {
+    pub fn from_str(s: &str) -> Self {
+        match s {
+            "1h" => Self::Hour1,
+            "24h" => Self::Hour24,
+            "7d" => Self::Day7,
+            _ => Self::All,
+        }
+    }
+
+    fn cutoff(&self) -> Option<SystemTime> {
+        match self {
+            Self::Hour1 => Some(SystemTime::now() - Duration::from_secs(3600)),
+            Self::Hour24 => Some(SystemTime::now() - Duration::from_secs(86_400)),
+            Self::Day7 => Some(SystemTime::now() - Duration::from_secs(7 * 86_400)),
+            Self::All => None,
+        }
+    }
+}
+
+/// Snapshot of aggregate statistics for the admin Stats tab.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayStats {
+    /// Time range these stats cover (e.g. `"1h"`, `"24h"`, `"7d"`, `"all"`).
+    pub range: String,
+    /// Total number of calls in the ring buffer that fall within `range`.
+    pub total_calls: usize,
+    /// Number of successful calls.
+    pub successful_calls: usize,
+    /// Number of failed calls.
+    pub failed_calls: usize,
+    /// Success rate as a fraction [0.0, 1.0].
+    pub success_rate: f64,
+    /// Latency statistics in milliseconds.
+    pub latency_ms: LatencyStats,
+    /// Top tools by call count (up to 10).
+    pub top_tools: Vec<TopEntry>,
+    /// Top DCC instances by call count (up to 10).
+    pub top_instances: Vec<TopEntry>,
+    /// Call distribution across the 24 hours of the day (UTC, index 0 = midnight).
+    ///
+    /// Each element is the number of calls that started in that hour window
+    /// within the selected `range`.
+    pub hourly_distribution: Vec<u32>,
+}
+
+/// Latency percentile summary.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct LatencyStats {
+    /// Minimum observed latency in milliseconds.
+    pub min_ms: u64,
+    /// Maximum observed latency in milliseconds.
+    pub max_ms: u64,
+    /// Mean latency in milliseconds.
+    pub mean_ms: f64,
+    /// Median (p50) latency in milliseconds.
+    pub p50_ms: u64,
+    /// 95th-percentile latency in milliseconds.
+    pub p95_ms: u64,
+    /// 99th-percentile latency in milliseconds.
+    pub p99_ms: u64,
+}
+
+/// A (name, count) pair for top-N rankings.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TopEntry {
+    pub name: String,
+    pub count: usize,
+}
+
+/// Computes on-demand statistics from the [`TraceLog`] ring buffer.
+pub struct StatsAggregator {
+    trace_log: Arc<TraceLog>,
+}
+
+impl StatsAggregator {
+    pub fn new(trace_log: Arc<TraceLog>) -> Self {
+        Self { trace_log }
+    }
+
+    /// Compute statistics for the given range.
+    ///
+    /// Reads the ring buffer once (O(N)), performs a single pass, and returns
+    /// a fully-materialised [`GatewayStats`] struct.
+    pub fn compute(&self, range: StatsRange) -> GatewayStats {
+        let cutoff = range.cutoff();
+        let traces = self.trace_log.recent(usize::MAX);
+
+        // Filter to the requested time range.
+        let in_range: Vec<_> = traces
+            .iter()
+            .filter(|t| cutoff.map(|c| t.started_at >= c).unwrap_or(true))
+            .collect();
+
+        let total_calls = in_range.len();
+        if total_calls == 0 {
+            return GatewayStats {
+                range: range_label(range),
+                total_calls: 0,
+                successful_calls: 0,
+                failed_calls: 0,
+                success_rate: 0.0,
+                latency_ms: LatencyStats::default(),
+                top_tools: vec![],
+                top_instances: vec![],
+                hourly_distribution: vec![0u32; 24],
+            };
+        }
+
+        let successful_calls = in_range.iter().filter(|t| t.ok).count();
+        let failed_calls = total_calls - successful_calls;
+        let success_rate = successful_calls as f64 / total_calls as f64;
+
+        // Latency — collect, sort, compute percentiles.
+        let mut latencies: Vec<u64> = in_range.iter().map(|t| t.total_ms).collect();
+        latencies.sort_unstable();
+        let latency_ms = compute_latency_stats(&latencies);
+
+        // Top tools.
+        let mut tool_counts: HashMap<String, usize> = HashMap::new();
+        for t in &in_range {
+            if let Some(slug) = &t.tool_slug {
+                *tool_counts.entry(slug.clone()).or_insert(0) += 1;
+            }
+        }
+        let top_tools = top_n(tool_counts, 10);
+
+        // Top instances.
+        let mut instance_counts: HashMap<String, usize> = HashMap::new();
+        for t in &in_range {
+            let key = t
+                .instance_id
+                .clone()
+                .or_else(|| t.dcc_type.clone())
+                .unwrap_or_else(|| "unknown".to_string());
+            *instance_counts.entry(key).or_insert(0) += 1;
+        }
+        let top_instances = top_n(instance_counts, 10);
+
+        // Hour-of-day distribution (UTC).
+        let mut hourly = vec![0u32; 24];
+        for t in &in_range {
+            let hour = t
+                .started_at
+                .duration_since(UNIX_EPOCH)
+                .map(|d| ((d.as_secs() % 86_400) / 3600) as usize)
+                .unwrap_or(0);
+            if hour < 24 {
+                hourly[hour] += 1;
+            }
+        }
+
+        GatewayStats {
+            range: range_label(range),
+            total_calls,
+            successful_calls,
+            failed_calls,
+            success_rate,
+            latency_ms,
+            top_tools,
+            top_instances,
+            hourly_distribution: hourly,
+        }
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn range_label(r: StatsRange) -> String {
+    match r {
+        StatsRange::Hour1 => "1h".into(),
+        StatsRange::Hour24 => "24h".into(),
+        StatsRange::Day7 => "7d".into(),
+        StatsRange::All => "all".into(),
+    }
+}
+
+fn compute_latency_stats(sorted: &[u64]) -> LatencyStats {
+    if sorted.is_empty() {
+        return LatencyStats::default();
+    }
+    let n = sorted.len();
+    let min_ms = sorted[0];
+    let max_ms = sorted[n - 1];
+    let sum: u64 = sorted.iter().sum();
+    let mean_ms = sum as f64 / n as f64;
+    let p50_ms = sorted[(n * 50 / 100).min(n - 1)];
+    let p95_ms = sorted[(n * 95 / 100).min(n - 1)];
+    let p99_ms = sorted[(n * 99 / 100).min(n - 1)];
+    LatencyStats {
+        min_ms,
+        max_ms,
+        mean_ms,
+        p50_ms,
+        p95_ms,
+        p99_ms,
+    }
+}
+
+fn top_n(counts: HashMap<String, usize>, n: usize) -> Vec<TopEntry> {
+    let mut v: Vec<_> = counts
+        .into_iter()
+        .map(|(name, count)| TopEntry { name, count })
+        .collect();
+    v.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.name.cmp(&b.name)));
+    v.truncate(n);
+    v
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::time::SystemTime;
+
+    use super::*;
+    use crate::gateway::admin::trace::{DispatchTrace, TraceLog};
+
+    fn make_trace(ok: bool, total_ms: u64, tool: &str, instance: &str) -> DispatchTrace {
+        DispatchTrace {
+            request_id: uuid::Uuid::new_v4().to_string(),
+            method: "tools/call".into(),
+            tool_slug: Some(tool.to_string()),
+            instance_id: Some(instance.to_string()),
+            session_id: None,
+            dcc_type: Some("maya".into()),
+            started_at: SystemTime::now(),
+            total_ms,
+            ok,
+            spans: vec![],
+            input: None,
+            output: None,
+        }
+    }
+
+    #[test]
+    fn empty_log_returns_zero_stats() {
+        let log = Arc::new(TraceLog::new(100));
+        let agg = StatsAggregator::new(log);
+        let s = agg.compute(StatsRange::All);
+        assert_eq!(s.total_calls, 0);
+        assert_eq!(s.successful_calls, 0);
+        assert_eq!(s.success_rate, 0.0);
+        assert_eq!(s.hourly_distribution.len(), 24);
+    }
+
+    #[test]
+    fn success_rate_is_correct() {
+        let log = Arc::new(TraceLog::new(100));
+        log.push(make_trace(true, 100, "maya.create_sphere", "inst-1"));
+        log.push(make_trace(true, 200, "maya.create_sphere", "inst-1"));
+        log.push(make_trace(false, 50, "maya.open_file", "inst-2"));
+
+        let agg = StatsAggregator::new(log);
+        let s = agg.compute(StatsRange::All);
+        assert_eq!(s.total_calls, 3);
+        assert_eq!(s.successful_calls, 2);
+        assert_eq!(s.failed_calls, 1);
+        assert!((s.success_rate - 2.0 / 3.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn latency_percentiles_are_monotone() {
+        let log = Arc::new(TraceLog::new(100));
+        for ms in [10, 20, 30, 40, 50, 60, 70, 80, 90, 100u64] {
+            log.push(make_trace(true, ms, "maya.t", "inst-1"));
+        }
+        let agg = StatsAggregator::new(log);
+        let s = agg.compute(StatsRange::All);
+        let l = &s.latency_ms;
+        assert!(l.p50_ms <= l.p95_ms, "p50 <= p95");
+        assert!(l.p95_ms <= l.p99_ms, "p95 <= p99");
+        assert!(l.min_ms <= l.p50_ms, "min <= p50");
+        assert!(l.p99_ms <= l.max_ms, "p99 <= max");
+        assert_eq!(l.min_ms, 10);
+        assert_eq!(l.max_ms, 100);
+    }
+
+    #[test]
+    fn top_tools_sorted_by_count_descending() {
+        let log = Arc::new(TraceLog::new(100));
+        for _ in 0..5 {
+            log.push(make_trace(true, 10, "maya.popular", "inst-1"));
+        }
+        for _ in 0..2 {
+            log.push(make_trace(true, 10, "maya.rare", "inst-1"));
+        }
+        let agg = StatsAggregator::new(log);
+        let s = agg.compute(StatsRange::All);
+        assert_eq!(s.top_tools[0].name, "maya.popular");
+        assert_eq!(s.top_tools[0].count, 5);
+        assert_eq!(s.top_tools[1].name, "maya.rare");
+        assert_eq!(s.top_tools[1].count, 2);
+    }
+
+    #[test]
+    fn hourly_distribution_has_24_buckets() {
+        let log = Arc::new(TraceLog::new(100));
+        log.push(make_trace(true, 10, "maya.t", "inst-1"));
+        let agg = StatsAggregator::new(log);
+        let s = agg.compute(StatsRange::All);
+        assert_eq!(s.hourly_distribution.len(), 24);
+        // The single trace should land in exactly one bucket.
+        assert_eq!(s.hourly_distribution.iter().sum::<u32>(), 1);
+    }
+
+    #[test]
+    fn range_filter_excludes_old_traces() {
+        let log = Arc::new(TraceLog::new(100));
+        // Add a trace with a very old timestamp (well outside 1h).
+        let mut old = make_trace(true, 10, "maya.old", "inst-1");
+        old.started_at = UNIX_EPOCH; // epoch = Jan 1 1970
+        log.push(old);
+        // Add a recent trace.
+        log.push(make_trace(true, 10, "maya.new", "inst-1"));
+
+        let agg = StatsAggregator::new(log);
+        let s_all = agg.compute(StatsRange::All);
+        let s_1h = agg.compute(StatsRange::Hour1);
+        assert_eq!(s_all.total_calls, 2);
+        assert_eq!(s_1h.total_calls, 1);
+    }
+}

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -347,6 +347,8 @@ mod admin_tests {
             "/api/tools",
             "/api/calls",
             "/api/logs",
+            "/api/stats",
+            "/api/traces",
         ] {
             let resp = admin_router()
                 .oneshot(
@@ -367,5 +369,73 @@ mod admin_tests {
                 "endpoint {uri} must return application/json, got '{ct}'"
             );
         }
+    }
+
+    // -- Phase 3: /api/stats -----------------------------------------------
+
+    #[tokio::test]
+    async fn test_admin_stats_empty_returns_zero_total() {
+        let (status, body) = body_json(admin_router(), "/api/stats").await;
+        assert_eq!(status, StatusCode::OK);
+        // Without a trace log attached, should return 0 or an error object.
+        assert!(body.is_object());
+    }
+
+    #[tokio::test]
+    async fn test_admin_stats_with_trace_log_returns_fields() {
+        use crate::gateway::admin::trace::{DispatchTrace, TraceLog};
+        use std::sync::Arc;
+        use std::time::SystemTime;
+
+        let log = Arc::new(TraceLog::new(100));
+        log.push(DispatchTrace {
+            request_id: "r1".into(),
+            method: "tools/call".into(),
+            tool_slug: Some("maya.create_sphere".into()),
+            instance_id: Some("inst-abc".into()),
+            session_id: None,
+            dcc_type: Some("maya".into()),
+            started_at: SystemTime::now(),
+            total_ms: 150,
+            ok: true,
+            spans: vec![],
+            input: None,
+            output: None,
+        });
+        log.push(DispatchTrace {
+            request_id: "r2".into(),
+            method: "tools/call".into(),
+            tool_slug: Some("maya.open_file".into()),
+            instance_id: Some("inst-abc".into()),
+            session_id: None,
+            dcc_type: Some("maya".into()),
+            started_at: SystemTime::now(),
+            total_ms: 50,
+            ok: false,
+            spans: vec![],
+            input: None,
+            output: None,
+        });
+
+        let state = make_admin_state().with_trace_log(log);
+        let router = build_admin_router(state);
+        let (status, body) = body_json(router, "/api/stats?range=1h").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["range"], "1h");
+        assert_eq!(body["total_calls"], 2);
+        assert_eq!(body["successful_calls"], 1);
+        assert_eq!(body["failed_calls"], 1);
+        assert!(body["latency_ms"]["p50_ms"].as_u64().unwrap() > 0);
+        assert!(body["top_tools"].is_array());
+        assert!(body["hourly_distribution"].is_array());
+        assert_eq!(body["hourly_distribution"].as_array().unwrap().len(), 24);
+    }
+
+    #[tokio::test]
+    async fn test_admin_stats_all_range_is_default() {
+        let (status, body) = body_json(admin_router(), "/api/stats?range=invalid").await;
+        assert_eq!(status, StatusCode::OK);
+        // Unknown range should fall back to "all".
+        assert!(body["range"] == "all" || body.get("error").is_some());
     }
 }


### PR DESCRIPTION
## Phase 3 of Admin Observability (#863)

Adds on-demand aggregate statistics from the Phase 2 `TraceLog` ring buffer.

## New endpoint

`GET /admin/api/stats?range=1h|24h|7d`

```json
{
  "range": "1h",
  "total_calls": 142,
  "successful_calls": 138,
  "failed_calls": 4,
  "success_rate": 0.972,
  "latency_ms": { "min_ms": 12, "p50_ms": 185, "p95_ms": 640, "p99_ms": 1200, "max_ms": 3400, "mean_ms": 213.5 },
  "top_tools": [ {"name": "maya.create_sphere", "count": 42}, ... ],
  "top_instances": [ {"name": "inst-abc123", "count": 98}, ... ],
  "hourly_distribution": [0, 0, 1, 3, ...]
}
```

## Design

- **`admin/stats.rs`** — new `StatsAggregator` + `GatewayStats` / `LatencyStats` / `TopEntry` types
- Pure read-side: zero write-path overhead, O(N) one-pass over the ring buffer
- `AdminState.stats` auto-created by `with_trace_log()` — no changes needed in `tasks.rs`

## Tests

- 6 unit tests in `stats.rs` (empty log, success rate, latency monotonicity, top-N, hourly distribution, range filter)
- 3 end-to-end tests via admin router
- 326 total pass (was 317)