### PR TITLE
refactor(server_base): drop test-double __getattr__ fallback, add _testing helper (#851)

### DIFF
--- a/python/dcc_mcp_core/_testing.py
+++ b/python/dcc_mcp_core/_testing.py
@@ -1,0 +1,84 @@
+"""Test-only helpers for dcc-mcp-core.
+
+This module is intentionally separate from production code: it lets tests build
+``DccServerBase`` instances without going through the real ``__init__`` (which
+would require a running DCC and the compiled Rust core), while keeping the
+production class free of test-aware fallback paths.
+
+See issue #851 for the rationale.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dcc_mcp_core._server import SkillQueryClient
+from dcc_mcp_core._server import WindowResolver
+
+
+def make_test_server(
+    *,
+    server: Any,
+    dcc_name: str,
+    dcc_pid: int = 0,
+    dcc_window_handle: int | None = None,
+    dcc_window_title: str | None = None,
+    **extra_attrs: Any,
+) -> Any:
+    """Build a ``DccServerBase`` shell suitable for unit tests.
+
+    Bypasses the real ``__init__`` (which needs a running DCC + the compiled
+    ``_core`` extension) and pre-populates the collaborators that the rest of
+    the class assumes exist.
+
+    Any additional keyword arguments are written straight onto ``__dict__`` —
+    handy for test cases that want to wire fakes for ``_config``,
+    ``_hot_reloader``, etc.
+
+    Parameters
+    ----------
+    server:
+        The inner DCC server stub (typically a fake/mock).
+    dcc_name:
+        The DCC type name (e.g. ``"maya"``).
+    dcc_pid:
+        Optional process id, defaults to 0.
+    dcc_window_handle:
+        Optional native window handle.
+    dcc_window_title:
+        Optional native window title.
+    **extra_attrs:
+        Additional attributes to set on the instance ``__dict__``.
+
+    Returns
+    -------
+    DccServerBase
+        A bare instance with the standard collaborators wired up.
+
+    """
+    # Local import to avoid a circular import at module load time.
+    from dcc_mcp_core.server_base import DccServerBase
+
+    obj = DccServerBase.__new__(DccServerBase)
+    obj.__dict__.update(
+        {
+            "_server": server,
+            "_dcc_name": dcc_name,
+            "_dcc_pid": dcc_pid,
+            "_dcc_window_handle": dcc_window_handle,
+            "_dcc_window_title": dcc_window_title,
+            "_skill_client": SkillQueryClient(server, dcc_name),
+            "_window_resolver": WindowResolver(
+                dcc_name=dcc_name,
+                dcc_pid=dcc_pid,
+                dcc_window_handle=dcc_window_handle,
+                dcc_window_title=dcc_window_title,
+            ),
+        }
+    )
+    if extra_attrs:
+        obj.__dict__.update(extra_attrs)
+    return obj
+
+
+__all__ = ["make_test_server"]

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -301,29 +301,6 @@ class DccServerBase:
         self._quit_hooks_ran: bool = False
         self._atexit_registered: bool = False
 
-    def __getattr__(self, name: str) -> Any:
-        """Lazily reconstruct collaborators for instances built via ``object.__new__``.
-
-        Some test doubles bypass ``__init__`` and only set the legacy
-        attributes (``_server``, ``_dcc_name``, ``_dcc_pid`` …). When such
-        an instance accesses ``_skill_client`` or ``_window_resolver``, build
-        a fresh collaborator on demand from those attributes and cache it.
-        """
-        if name == "_skill_client":
-            client = SkillQueryClient(self.__dict__["_server"], self.__dict__["_dcc_name"])
-            self.__dict__[name] = client
-            return client
-        if name == "_window_resolver":
-            resolver = WindowResolver(
-                dcc_name=self.__dict__["_dcc_name"],
-                dcc_pid=self.__dict__.get("_dcc_pid", 0),
-                dcc_window_handle=self.__dict__.get("_dcc_window_handle"),
-                dcc_window_title=self.__dict__.get("_dcc_window_title"),
-            )
-            self.__dict__[name] = resolver
-            return resolver
-        raise AttributeError(name)
-
     # ── adapter context helpers (#608, #609) ────────────────────────────────
 
     def register_adapter_instructions(self, instruction_set: Any) -> list[str]:

--- a/tests/test_adapter_context.py
+++ b/tests/test_adapter_context.py
@@ -16,6 +16,7 @@ from dcc_mcp_core import append_context_snapshot
 from dcc_mcp_core import build_visual_feedback_context
 from dcc_mcp_core import register_adapter_instruction_resources
 from dcc_mcp_core import shape_response
+from dcc_mcp_core._testing import make_test_server
 from dcc_mcp_core.server_base import DccServerBase
 
 
@@ -121,10 +122,12 @@ def test_toolset_profile_registry_tracks_active_profiles() -> None:
 
 
 def test_dcc_server_base_snapshot_and_instruction_wrappers() -> None:
-    server = object.__new__(DccServerBase)
     fake = _FakeServer()
-    server._server = fake
-    server._snapshot_provider = lambda: DccContextSnapshot(dcc="maya", counts={"objects": 2})
+    server = make_test_server(
+        server=fake,
+        dcc_name="maya",
+        _snapshot_provider=lambda: DccContextSnapshot(dcc="maya", counts={"objects": 2}),
+    )
 
     enriched = server.append_context_snapshot({"success": True})
     assert enriched["context"]["snapshot"]["counts"]["objects"] == 2

--- a/tests/test_dcc_adapter_base.py
+++ b/tests/test_dcc_adapter_base.py
@@ -335,25 +335,24 @@ class TestDccServerBase:
 
     def _make_server(self, tmp_path, dcc_name="fake-dcc"):
         """Create a DccServerBase without calling the real __init__ (no Rust deps)."""
-        from dcc_mcp_core.server_base import DccServerBase
+        from dcc_mcp_core._testing import make_test_server
 
         skills_dir = tmp_path / "skills"
         skills_dir.mkdir(exist_ok=True)
 
-        # Bypass __init__ to avoid needing compiled _core
-        server = object.__new__(DccServerBase)
-        server._dcc_name = dcc_name
-        server._builtin_skills_dir = skills_dir
-        server._handle = None
-        server._enable_gateway_failover = False
-        server._hot_reloader = None
-        server._gateway_election = None
-        server._config = _FakeConfig()
-        server._server = _FakeDccServer()
-        server._enable_telemetry = False
-        server._enable_file_logging = False
-        server._enable_job_persistence = False
-        return server
+        return make_test_server(
+            server=_FakeDccServer(),
+            dcc_name=dcc_name,
+            _builtin_skills_dir=skills_dir,
+            _handle=None,
+            _enable_gateway_failover=False,
+            _hot_reloader=None,
+            _gateway_election=None,
+            _config=_FakeConfig(),
+            _enable_telemetry=False,
+            _enable_file_logging=False,
+            _enable_job_persistence=False,
+        )
 
     def test_initial_state(self, tmp_path):
         server = self._make_server(tmp_path)


### PR DESCRIPTION
Closes #851.

## Why

`DccServerBase.__getattr__` rebuilt `_skill_client` / `_window_resolver` collaborators on demand for instances built via `object.__new__` — a textbook leak of test concerns into the domain layer:

- The class advertises immutable collaborators in `__init__`, but silently reconstructed them when callers cheated the constructor.
- Two attributes had reconstruction behaviour, every other unknown attribute raised `AttributeError` — a confusing dual contract.
- Any future collaborator needing more state would silently extend the leak.

## What

- New `python/dcc_mcp_core/_testing.py` with `make_test_server(...)` — builds a `DccServerBase` shell with collaborators pre-wired; extra kwargs go straight onto `__dict__` for tests that need fake `_config`/`_hot_reloader`/etc.
- `server_base.py` drops the `__getattr__` method entirely. Production code is now unaware of test infrastructure.
- The two test files that bypassed `__init__` (`tests/test_adapter_context.py`, `tests/test_dcc_adapter_base.py`) switch to `make_test_server(...)`.

## Verification

```
.venv/Scripts/python -m pytest tests/test_adapter_context.py tests/test_dcc_adapter_base.py -q
# 79 passed, 2 warnings in 3.24s
```

## Notes

- Pre-existing collection errors on `tests/test_step_policies.py` / `test_workflow_execution.py` / `test_workflow_spec.py` are unrelated to this change (already broken on `origin/main`).