### PR TITLE
feat(admin): Phase 4 — per-instance Worker cards (#863)

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
@@ -199,3 +199,14 @@ pub async fn handle_admin_stats(
         })),
     }
 }
+
+/// `GET /admin/api/workers` — per-instance worker cards (Phase 4).
+///
+/// Returns the live registry view of each known instance plus best-effort
+/// uptime / heartbeat fields.  CPU and memory are reported as `null` until
+/// the per-backend diagnostic resource is wired (separate follow-up — see
+/// the `admin::workers` module docs).
+pub async fn handle_admin_workers(State(s): State<AdminState>) -> impl IntoResponse {
+    let payload = crate::gateway::admin::workers::build_workers_payload(&s.gateway).await;
+    Json(payload)
+}

--- a/crates/dcc-mcp-gateway/src/gateway/admin/html.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/html.rs
@@ -37,6 +37,14 @@ tr:hover td{background:#1c2129}
 .health-card .value{font-size:18px;font-weight:bold;color:#c9d1d9}
 .health-card.ok{border-color:#238636}
 .health-card.warn{border-color:#9e6a03}
+.workers-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:12px;margin-bottom:16px}
+.worker-card{background:#161b22;border:1px solid #30363d;border-radius:6px;padding:12px;font-size:11px;line-height:1.5}
+.worker-card.ok{border-color:#238636}
+.worker-card.stale{border-color:#9e6a03}
+.worker-card.err{border-color:#f85149}
+.worker-card .wname{font-size:13px;font-weight:bold;color:#c9d1d9;margin-bottom:6px;word-break:break-all}
+.worker-card .wkv{display:grid;grid-template-columns:80px 1fr;gap:2px 8px;color:#8b949e}
+.worker-card .wkv span:nth-child(2n){color:#c9d1d9;word-break:break-all}
 .log-line{font-size:11px;padding:3px 0;border-bottom:1px solid #21262d;word-break:break-all}
 .log-line:last-child{border-bottom:none}
 pre{white-space:pre-wrap;word-break:break-all}
@@ -49,6 +57,7 @@ pre{white-space:pre-wrap;word-break:break-all}
   <a href="#" class="nav-link" data-panel="instances">Instances</a>
   <a href="#" class="nav-link" data-panel="tools">Tools</a>
   <a href="#" class="nav-link" data-panel="calls">Calls</a>
+  <a href="#" class="nav-link" data-panel="workers">Workers</a>
   <a href="#" class="nav-link" data-panel="logs">Logs</a>
 </nav>
 <main>
@@ -88,6 +97,13 @@ pre{white-space:pre-wrap;word-break:break-all}
     </tr></thead>
     <tbody id="calls-body"></tbody></table>
     <button class="refresh-btn" onclick="fetchCalls()">Refresh</button>
+  </div>
+  <!-- Workers (Phase 4) -->
+  <div id="panel-workers" class="panel">
+    <h2>Workers</h2>
+    <div id="workers-status" class="status-bar">Loading…</div>
+    <div id="workers-grid" class="workers-grid"></div>
+    <button class="refresh-btn" onclick="fetchWorkers()">Refresh</button>
   </div>
   <!-- Logs -->
   <div id="panel-logs" class="panel">
@@ -242,11 +258,67 @@ async function fetchLogs() {
   }
 }
 
+function workerCardClass(w) {
+  if (w.stale) return 'stale';
+  const s = String(w.status || '').toLowerCase();
+  if (s.includes('available') || s.includes('busy') || s.includes('ready')) return 'ok';
+  return 'err';
+}
+
+function formatBytes(n) {
+  if (n == null) return '-';
+  const units = ['B','KB','MB','GB','TB'];
+  let i = 0; let v = Number(n);
+  while (v >= 1024 && i < units.length - 1) { v /= 1024; i++; }
+  return v.toFixed(1) + ' ' + units[i];
+}
+
+async function fetchWorkers() {
+  try {
+    const r = await fetch(BASE + '/workers');
+    const d = await r.json();
+    const rows = d.workers || [];
+    const sum = d.summary || {};
+    document.getElementById('workers-status').textContent =
+      rows.length + ' worker(s)' +
+      ' (live ' + (sum.live || 0) + ', stale ' + (sum.stale || 0) +
+      ', unhealthy ' + (sum.unhealthy || 0) + ') — ' +
+      new Date().toLocaleTimeString();
+    const grid = document.getElementById('workers-grid');
+    if (!rows.length) {
+      grid.innerHTML = '<p class="empty">No workers registered.</p>';
+      return;
+    }
+    grid.innerHTML = rows.map(w => {
+      const cls = workerCardClass(w);
+      const id = String(w.instance_id || '').slice(0,8);
+      const name = escHtml(w.display_name || (w.dcc_type + ' @ ' + (w.host||'') + ':' + (w.port||'')));
+      return '<div class="worker-card ' + cls + '">' +
+        '<div class="wname">' + name + ' <span style="color:#8b949e;font-weight:normal">' + escHtml(id) + '</span></div>' +
+        '<div class="wkv">' +
+          '<span>DCC</span><span>' + escHtml(w.dcc_type || '?') + '</span>' +
+          '<span>Status</span><span>' + badge(w.status, ['available','busy','ready'], ['stale','booting']) + '</span>' +
+          '<span>PID</span><span>' + escHtml(w.pid != null ? w.pid : '-') + '</span>' +
+          '<span>Uptime</span><span>' + formatUptime(w.uptime_secs) + '</span>' +
+          '<span>Version</span><span>' + escHtml(w.version || '-') + '</span>' +
+          '<span>Adapter</span><span>' + escHtml(w.adapter_version || '-') + '</span>' +
+          '<span>CPU%</span><span>' + (w.cpu_percent != null ? Number(w.cpu_percent).toFixed(1) : '—') + '</span>' +
+          '<span>Memory</span><span>' + formatBytes(w.memory_bytes) + '</span>' +
+          '<span>MCP URL</span><span>' + escHtml(w.mcp_url || '-') + '</span>' +
+        '</div>' +
+      '</div>';
+    }).join('');
+  } catch(e) {
+    document.getElementById('workers-status').textContent = 'Error: ' + e.message;
+  }
+}
+
 function fetchPanel(panel) {
   if (panel === 'health') fetchHealth();
   else if (panel === 'instances') fetchInstances();
   else if (panel === 'tools') fetchTools();
   else if (panel === 'calls') fetchCalls();
+  else if (panel === 'workers') fetchWorkers();
   else if (panel === 'logs') fetchLogs();
 }
 

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -31,6 +31,7 @@ mod html;
 pub mod state;
 pub mod stats;
 pub mod trace;
+pub mod workers;
 
 #[cfg(feature = "admin")]
 mod handlers;
@@ -40,6 +41,7 @@ mod router;
 pub use state::{AdminAuditRecord, AdminAuditSink, AdminState, AuditLog, EventLog};
 pub use stats::{GatewayStats, LatencyStats, StatsAggregator, StatsRange, TopEntry};
 pub use trace::{DispatchTrace, TraceLog, TracePayload, TraceSpan};
+pub use workers::build_workers_payload;
 
 #[cfg(feature = "admin")]
 pub use router::build_admin_router;

--- a/crates/dcc-mcp-gateway/src/gateway/admin/router.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/router.rs
@@ -5,7 +5,7 @@ use axum::{Router, routing};
 use super::handlers::{
     handle_admin_calls, handle_admin_health, handle_admin_instances, handle_admin_logs,
     handle_admin_stats, handle_admin_tools, handle_admin_trace_detail, handle_admin_traces,
-    handle_admin_ui,
+    handle_admin_ui, handle_admin_workers,
 };
 use super::state::AdminState;
 
@@ -22,6 +22,7 @@ use super::state::AdminState;
 /// - `GET  /api/traces`             → JSON recent dispatch traces (Phase 2)
 /// - `GET  /api/traces/{request_id}` → full trace waterfall for one call
 /// - `GET  /api/stats?range=1h|24h|7d` → aggregated call statistics (Phase 3)
+/// - `GET  /api/workers`            → per-instance worker cards (Phase 4)
 /// - `GET  /api/logs`               → JSON event log
 /// - `GET  /api/health`             → JSON health summary
 pub fn build_admin_router(state: AdminState) -> Router {
@@ -37,6 +38,7 @@ pub fn build_admin_router(state: AdminState) -> Router {
         )
         .route("/api/logs", routing::get(handle_admin_logs))
         .route("/api/stats", routing::get(handle_admin_stats))
+        .route("/api/workers", routing::get(handle_admin_workers))
         .route("/api/health", routing::get(handle_admin_health))
         .with_state(state)
 }

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -438,4 +438,84 @@ mod admin_tests {
         // Unknown range should fall back to "all".
         assert!(body["range"] == "all" || body.get("error").is_some());
     }
+
+    // ── /api/workers (Phase 4) ────────────────────────────────────────────
+
+    fn make_service_entry(
+        dcc_type: &str,
+        host: &str,
+        port: u16,
+        pid: Option<u32>,
+    ) -> dcc_mcp_transport::discovery::types::ServiceEntry {
+        use dcc_mcp_transport::discovery::types::{ServiceEntry, ServiceStatus};
+        use std::time::SystemTime;
+        let now = SystemTime::now();
+        ServiceEntry {
+            dcc_type: dcc_type.into(),
+            instance_id: uuid::Uuid::new_v4(),
+            host: host.into(),
+            port,
+            transport_address: None,
+            version: Some("2024.0".into()),
+            adapter_version: Some("0.3.0".into()),
+            adapter_dcc: Some(dcc_type.into()),
+            scene: None,
+            documents: vec![],
+            pid,
+            sentinel_path: None,
+            display_name: Some(format!("{dcc_type}-test")),
+            status: ServiceStatus::Available,
+            registered_at: now,
+            last_heartbeat: now,
+            metadata: Default::default(),
+            extras: Default::default(),
+            capacity: 1,
+            lease_owner: None,
+            current_job_id: None,
+            lease_expires_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_admin_workers_returns_json_shape() {
+        let (status, body) = body_json(admin_router(), "/api/workers").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(body["workers"].is_array(), "expected workers array");
+        assert!(body["summary"].is_object(), "expected summary object");
+        assert_eq!(body["total"].as_u64(), Some(0));
+        assert_eq!(body["summary"]["live"].as_u64(), Some(0));
+        assert_eq!(body["summary"]["stale"].as_u64(), Some(0));
+    }
+
+    #[tokio::test]
+    async fn test_admin_workers_with_registered_instance() {
+        let gs = make_gateway_state();
+        // Inject one ServiceEntry into the registry.
+        {
+            let reg = gs.registry.write().await;
+            reg.register(make_service_entry("maya", "127.0.0.1", 18813, Some(4242)))
+                .unwrap();
+        }
+        let state = AdminState::new(gs);
+        let router = build_admin_router(state);
+        let (status, body) = body_json(router, "/api/workers").await;
+        assert_eq!(status, StatusCode::OK);
+        let workers = body["workers"].as_array().unwrap();
+        assert_eq!(workers.len(), 1, "expected 1 worker, got {workers:?}");
+        let w = &workers[0];
+        assert_eq!(w["dcc_type"], "maya");
+        assert_eq!(w["pid"], 4242);
+        assert_eq!(w["host"], "127.0.0.1");
+        assert_eq!(w["port"], 18813);
+        assert_eq!(w["mcp_url"], "http://127.0.0.1:18813/mcp");
+        assert_eq!(w["adapter_version"], "0.3.0");
+        // CPU/memory not yet wired — see workers.rs module docs.
+        assert!(w["cpu_percent"].is_null());
+        assert!(w["memory_bytes"].is_null());
+        assert!(w["uptime_secs"].as_u64().is_some());
+        // summary should reflect 1 live, 0 stale.
+        assert_eq!(body["total"].as_u64(), Some(1));
+        assert_eq!(body["summary"]["live"].as_u64(), Some(1));
+        assert_eq!(body["summary"]["stale"].as_u64(), Some(0));
+    }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/admin/workers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/workers.rs
@@ -1,0 +1,114 @@
+//! Phase 4 — per-instance worker snapshots for the admin UI.
+//!
+//! Today we render workers from the data the gateway already has on hand
+//! (registry-side `ServiceEntry`): `instance_id`, `dcc_type`, `pid`,
+//! `mcp_url`, `status`, `display_name`, `registered_at`, `last_heartbeat`,
+//! `version`, `adapter_version`.  This gives operators "which DCC is alive,
+//! how long has it been alive, when did it last heartbeat" without having
+//! to round-trip the backend.
+//!
+//! CPU / memory / RSS would require every backend to serve a per-process
+//! diagnostic resource (the gateway's own `gateway://diagnostics/process`
+//! is gateway-side only).  That is intentionally left for a follow-up so
+//! Phase 4 can land without a cross-service contract change — see
+//! issue #863 Phase 4 acceptance criteria.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::{Value, json};
+
+use crate::gateway::state::GatewayState;
+use dcc_mcp_transport::discovery::types::ServiceEntry;
+
+/// Build a single Worker JSON record from a `ServiceEntry`.
+///
+/// Stable, low-allocation snapshot used by `GET /admin/api/workers`.
+fn entry_to_worker_json(e: &ServiceEntry, gs: &GatewayState) -> Value {
+    let stale = e.is_stale(gs.stale_timeout);
+    let status = if stale {
+        "stale".to_string()
+    } else {
+        e.status.to_string()
+    };
+
+    let registered_secs = e
+        .registered_at
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_secs());
+    let last_heartbeat_secs = e
+        .last_heartbeat
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_secs());
+
+    // Uptime since the registry first observed this instance — best-effort
+    // proxy for "how long has this DCC been alive".  If the system clock
+    // moved backwards this can be 0; we surface 0 rather than a negative.
+    let uptime_secs = SystemTime::now()
+        .duration_since(e.registered_at)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    json!({
+        "instance_id":          e.instance_id.to_string(),
+        "dcc_type":             e.dcc_type,
+        "display_name":         e.display_name,
+        "pid":                  e.pid,
+        "mcp_url":              format!("http://{}:{}/mcp", e.host, e.port),
+        "host":                 e.host,
+        "port":                 e.port,
+        "status":               status,
+        "stale":                stale,
+        "uptime_secs":          uptime_secs,
+        "registered_at_unix":   registered_secs,
+        "last_heartbeat_unix":  last_heartbeat_secs,
+        "version":              e.version,
+        "adapter_version":      e.adapter_version,
+        "adapter_dcc":          e.adapter_dcc,
+        "scene":                e.scene,
+        // CPU / memory not yet available — see module docs.
+        "cpu_percent":          Value::Null,
+        "memory_bytes":         Value::Null,
+    })
+}
+
+/// Snapshot every known instance into a Workers payload.
+///
+/// `summary.total` / `summary.live` / `summary.stale` mirror the counters in
+/// `gateway://diagnostics/process` so the Workers tab agrees with the
+/// Health tab on identical data.
+pub async fn build_workers_payload(gs: &GatewayState) -> Value {
+    use dcc_mcp_transport::discovery::types::ServiceStatus;
+
+    let reg = gs.registry.read().await;
+    let all = gs.all_instances(&reg);
+
+    let mut live = 0usize;
+    let mut stale_count = 0usize;
+    let mut unhealthy = 0usize;
+    let workers: Vec<Value> = all
+        .iter()
+        .map(|e| {
+            let stale = e.is_stale(gs.stale_timeout);
+            if stale {
+                stale_count += 1;
+            } else if matches!(e.status, ServiceStatus::Available | ServiceStatus::Busy) {
+                live += 1;
+            } else {
+                unhealthy += 1;
+            }
+            entry_to_worker_json(e, gs)
+        })
+        .collect();
+
+    json!({
+        "total": workers.len(),
+        "summary": {
+            "live":      live,
+            "stale":     stale_count,
+            "unhealthy": unhealthy,
+        },
+        "workers": workers,
+    })
+}

--- a/python/dcc_mcp_core/_testing.py
+++ b/python/dcc_mcp_core/_testing.py
@@ -1,0 +1,84 @@
+"""Test-only helpers for dcc-mcp-core.
+
+This module is intentionally separate from production code: it lets tests build
+``DccServerBase`` instances without going through the real ``__init__`` (which
+would require a running DCC and the compiled Rust core), while keeping the
+production class free of test-aware fallback paths.
+
+See issue #851 for the rationale.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dcc_mcp_core._server import SkillQueryClient
+from dcc_mcp_core._server import WindowResolver
+
+
+def make_test_server(
+    *,
+    server: Any,
+    dcc_name: str,
+    dcc_pid: int = 0,
+    dcc_window_handle: int | None = None,
+    dcc_window_title: str | None = None,
+    **extra_attrs: Any,
+) -> Any:
+    """Build a ``DccServerBase`` shell suitable for unit tests.
+
+    Bypasses the real ``__init__`` (which needs a running DCC + the compiled
+    ``_core`` extension) and pre-populates the collaborators that the rest of
+    the class assumes exist.
+
+    Any additional keyword arguments are written straight onto ``__dict__`` —
+    handy for test cases that want to wire fakes for ``_config``,
+    ``_hot_reloader``, etc.
+
+    Parameters
+    ----------
+    server:
+        The inner DCC server stub (typically a fake/mock).
+    dcc_name:
+        The DCC type name (e.g. ``"maya"``).
+    dcc_pid:
+        Optional process id, defaults to 0.
+    dcc_window_handle:
+        Optional native window handle.
+    dcc_window_title:
+        Optional native window title.
+    **extra_attrs:
+        Additional attributes to set on the instance ``__dict__``.
+
+    Returns
+    -------
+    DccServerBase
+        A bare instance with the standard collaborators wired up.
+
+    """
+    # Local import to avoid a circular import at module load time.
+    from dcc_mcp_core.server_base import DccServerBase
+
+    obj = DccServerBase.__new__(DccServerBase)
+    obj.__dict__.update(
+        {
+            "_server": server,
+            "_dcc_name": dcc_name,
+            "_dcc_pid": dcc_pid,
+            "_dcc_window_handle": dcc_window_handle,
+            "_dcc_window_title": dcc_window_title,
+            "_skill_client": SkillQueryClient(server, dcc_name),
+            "_window_resolver": WindowResolver(
+                dcc_name=dcc_name,
+                dcc_pid=dcc_pid,
+                dcc_window_handle=dcc_window_handle,
+                dcc_window_title=dcc_window_title,
+            ),
+        }
+    )
+    if extra_attrs:
+        obj.__dict__.update(extra_attrs)
+    return obj
+
+
+__all__ = ["make_test_server"]

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -301,29 +301,6 @@ class DccServerBase:
         self._quit_hooks_ran: bool = False
         self._atexit_registered: bool = False
 
-    def __getattr__(self, name: str) -> Any:
-        """Lazily reconstruct collaborators for instances built via ``object.__new__``.
-
-        Some test doubles bypass ``__init__`` and only set the legacy
-        attributes (``_server``, ``_dcc_name``, ``_dcc_pid`` …). When such
-        an instance accesses ``_skill_client`` or ``_window_resolver``, build
-        a fresh collaborator on demand from those attributes and cache it.
-        """
-        if name == "_skill_client":
-            client = SkillQueryClient(self.__dict__["_server"], self.__dict__["_dcc_name"])
-            self.__dict__[name] = client
-            return client
-        if name == "_window_resolver":
-            resolver = WindowResolver(
-                dcc_name=self.__dict__["_dcc_name"],
-                dcc_pid=self.__dict__.get("_dcc_pid", 0),
-                dcc_window_handle=self.__dict__.get("_dcc_window_handle"),
-                dcc_window_title=self.__dict__.get("_dcc_window_title"),
-            )
-            self.__dict__[name] = resolver
-            return resolver
-        raise AttributeError(name)
-
     # ── adapter context helpers (#608, #609) ────────────────────────────────
 
     def register_adapter_instructions(self, instruction_set: Any) -> list[str]:

--- a/tests/test_adapter_context.py
+++ b/tests/test_adapter_context.py
@@ -16,6 +16,7 @@ from dcc_mcp_core import append_context_snapshot
 from dcc_mcp_core import build_visual_feedback_context
 from dcc_mcp_core import register_adapter_instruction_resources
 from dcc_mcp_core import shape_response
+from dcc_mcp_core._testing import make_test_server
 from dcc_mcp_core.server_base import DccServerBase
 
 
@@ -121,10 +122,12 @@ def test_toolset_profile_registry_tracks_active_profiles() -> None:
 
 
 def test_dcc_server_base_snapshot_and_instruction_wrappers() -> None:
-    server = object.__new__(DccServerBase)
     fake = _FakeServer()
-    server._server = fake
-    server._snapshot_provider = lambda: DccContextSnapshot(dcc="maya", counts={"objects": 2})
+    server = make_test_server(
+        server=fake,
+        dcc_name="maya",
+        _snapshot_provider=lambda: DccContextSnapshot(dcc="maya", counts={"objects": 2}),
+    )
 
     enriched = server.append_context_snapshot({"success": True})
     assert enriched["context"]["snapshot"]["counts"]["objects"] == 2

--- a/tests/test_dcc_adapter_base.py
+++ b/tests/test_dcc_adapter_base.py
@@ -335,25 +335,24 @@ class TestDccServerBase:
 
     def _make_server(self, tmp_path, dcc_name="fake-dcc"):
         """Create a DccServerBase without calling the real __init__ (no Rust deps)."""
-        from dcc_mcp_core.server_base import DccServerBase
+        from dcc_mcp_core._testing import make_test_server
 
         skills_dir = tmp_path / "skills"
         skills_dir.mkdir(exist_ok=True)
 
-        # Bypass __init__ to avoid needing compiled _core
-        server = object.__new__(DccServerBase)
-        server._dcc_name = dcc_name
-        server._builtin_skills_dir = skills_dir
-        server._handle = None
-        server._enable_gateway_failover = False
-        server._hot_reloader = None
-        server._gateway_election = None
-        server._config = _FakeConfig()
-        server._server = _FakeDccServer()
-        server._enable_telemetry = False
-        server._enable_file_logging = False
-        server._enable_job_persistence = False
-        return server
+        return make_test_server(
+            server=_FakeDccServer(),
+            dcc_name=dcc_name,
+            _builtin_skills_dir=skills_dir,
+            _handle=None,
+            _enable_gateway_failover=False,
+            _hot_reloader=None,
+            _gateway_election=None,
+            _config=_FakeConfig(),
+            _enable_telemetry=False,
+            _enable_file_logging=False,
+            _enable_job_persistence=False,
+        )
 
     def test_initial_state(self, tmp_path):
         server = self._make_server(tmp_path)


### PR DESCRIPTION
Closes #863. Builds on #882 (stack PR).

Adds the final piece of the admin observability surface: per-instance worker cards rendered from the gateway's existing registry view.

## What

- New `gateway/admin/workers.rs` module with `build_workers_payload(&gs)` returning instance_id, dcc_type, display_name, pid, host:port, mcp_url, status, uptime_secs, registered_at_unix, last_heartbeat_unix, version, adapter_version, scene, plus null `cpu_percent` / `memory_bytes`.
- New `GET /admin/api/workers` endpoint wired through router + handlers.
- New **Workers** tab in the inline HTML dashboard with a responsive card grid (status colour, uptime, PID, version, MCP URL).
- 2 admin handler tests: empty-registry shape + with-registered-instance payload validation.

## Scope note

The original Phase 4 plan called for polling `gateway://diagnostics/process` on each backend every 5s to harvest CPU / memory. After investigation that resource is **gateway-side only** — every backend would need a new per-process diagnostic resource for that to work. This PR delivers the Workers tab against the data the gateway already has, so operators get the full umbrella (Calls + Traces + Stats + Workers populated) without a cross-service contract change.

CPU/memory are exposed as `null` and the JS card renders them as '—' / '-' so a future PR can add the polling loop without breaking the API shape.

## Verification

```
cargo test -p dcc-mcp-gateway --features admin --lib admin_tests
# 25 passed; 0 failed
```