### PR TITLE
test(gateway): bootstrap proptest with admin stats/trace property laws (#846)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -88,7 +88,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -242,6 +242,21 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -828,6 +843,7 @@ dependencies = [
  "nucleo-matcher",
  "parking_lot",
  "prometheus",
+ "proptest",
  "reqwest 0.13.3",
  "serde",
  "serde_json",
@@ -1413,7 +1429,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1547,7 +1563,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2726,7 +2742,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3423,6 +3439,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.1",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3549,6 +3584,12 @@ dependencies = [
  "rustpython-parser",
  "syn",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -3711,6 +3752,15 @@ checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
  "rand 0.9.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4046,7 +4096,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4103,7 +4153,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4186,6 +4236,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -4453,7 +4515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4576,7 +4638,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5110,6 +5172,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unic-char-property"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5307,6 +5375,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -5510,7 +5587,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/dcc-mcp-gateway/Cargo.toml
+++ b/crates/dcc-mcp-gateway/Cargo.toml
@@ -55,6 +55,7 @@ tempfile = "3"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
 criterion = { version = "0.8", features = ["html_reports"] }
 tower = { version = "0.5", features = ["util"] }
+proptest = "1.5"
 
 [[bench]]
 name = "search_bench"

--- a/crates/dcc-mcp-gateway/src/gateway/admin/stats.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/stats.rs
@@ -357,4 +357,75 @@ mod tests {
         assert_eq!(s_all.total_calls, 2);
         assert_eq!(s_1h.total_calls, 1);
     }
+
+    // ── Property-based tests (#846) ────────────────────────────────────────
+    //
+    // These verify the invariants ("laws") of pure helpers used by the
+    // stats aggregator.  Adding proptest as a dev-dependency seeds the
+    // toolchain so future LSP / trait-law tests can plug in cheaply
+    // (#846 acceptance gate).
+
+    use proptest::prelude::*;
+
+    proptest! {
+        /// Latency percentiles must be weakly monotone:
+        ///   min ≤ p50 ≤ p95 ≤ p99 ≤ max
+        /// for any non-empty input. The mean must lie in [min, max].
+        #[test]
+        fn prop_latency_percentiles_are_monotone(
+            mut samples in proptest::collection::vec(0u64..1_000_000, 1..256)
+        ) {
+            samples.sort_unstable();
+            let stats = compute_latency_stats(&samples);
+            prop_assert!(stats.min_ms <= stats.p50_ms);
+            prop_assert!(stats.p50_ms <= stats.p95_ms);
+            prop_assert!(stats.p95_ms <= stats.p99_ms);
+            prop_assert!(stats.p99_ms <= stats.max_ms);
+            prop_assert!(stats.mean_ms >= stats.min_ms as f64);
+            prop_assert!(stats.mean_ms <= stats.max_ms as f64);
+        }
+
+        /// `top_n` must:
+        ///   1. Return at most `n` entries.
+        ///   2. Be sorted by count descending (with name ascending as tiebreaker).
+        ///   3. Never invent entries — every returned name must exist in the input.
+        #[test]
+        fn prop_top_n_is_sorted_and_truncated(
+            entries in proptest::collection::hash_map("[a-z]{1,8}", 0usize..100, 0..32),
+            n in 0usize..16,
+        ) {
+            let input = entries.clone();
+            let result = top_n(entries, n);
+            prop_assert!(result.len() <= n);
+            for w in result.windows(2) {
+                let a = &w[0];
+                let b = &w[1];
+                // count desc, name asc on tie
+                if a.count == b.count {
+                    prop_assert!(a.name <= b.name);
+                } else {
+                    prop_assert!(a.count > b.count);
+                }
+            }
+            for entry in &result {
+                prop_assert_eq!(input.get(&entry.name), Some(&entry.count));
+            }
+        }
+
+        /// `top_n` is idempotent on length: feeding the result back in does
+        /// not grow it.
+        #[test]
+        fn prop_top_n_is_idempotent_on_length(
+            entries in proptest::collection::hash_map("[a-z]{1,4}", 0usize..50, 0..16),
+            n in 1usize..16,
+        ) {
+            let first = top_n(entries.clone(), n);
+            let second_input: HashMap<String, usize> = first
+                .iter()
+                .map(|e| (e.name.clone(), e.count))
+                .collect();
+            let second = top_n(second_input, n);
+            prop_assert_eq!(first.len(), second.len());
+        }
+    }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/admin/trace.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/trace.rs
@@ -303,4 +303,69 @@ mod tests {
         );
         assert!(log.get("unknown").is_none());
     }
+
+    // ── Property-based tests (#846) ────────────────────────────────────────
+
+    use proptest::prelude::*;
+
+    fn arb_trace(idx: u32) -> DispatchTrace {
+        DispatchTrace {
+            request_id: format!("req-{idx}"),
+            method: "tools/call".into(),
+            tool_slug: None,
+            instance_id: None,
+            session_id: None,
+            dcc_type: None,
+            started_at: SystemTime::now(),
+            total_ms: idx as u64,
+            ok: true,
+            spans: vec![],
+            input: None,
+            output: None,
+        }
+    }
+
+    proptest! {
+        /// Ring-buffer law: after pushing `pushes` traces into a buffer of
+        /// capacity `capacity`, `recent(usize::MAX).len() == min(pushes, capacity)`.
+        /// Proves the buffer never exceeds capacity (memory bound) and never
+        /// drops more than necessary.
+        #[test]
+        fn prop_trace_log_capacity_is_respected(
+            capacity in 1usize..32,
+            pushes in 0u32..64,
+        ) {
+            let log = TraceLog::new(capacity);
+            for i in 0..pushes {
+                log.push(arb_trace(i));
+            }
+            let recent = log.recent(usize::MAX);
+            let expected = (pushes as usize).min(capacity);
+            prop_assert_eq!(recent.len(), expected);
+        }
+
+        /// Ring-buffer law: `recent(limit)` always returns ≤ `limit` items
+        /// and ≤ buffer occupancy. First item is the most recently pushed
+        /// trace (LIFO order).
+        #[test]
+        fn prop_trace_log_recent_returns_newest_first(
+            capacity in 1usize..16,
+            pushes in 1u32..32,
+            limit in 1usize..32,
+        ) {
+            let log = TraceLog::new(capacity);
+            for i in 0..pushes {
+                log.push(arb_trace(i));
+            }
+            let recent = log.recent(limit);
+            let bound = limit.min((pushes as usize).min(capacity));
+            prop_assert_eq!(recent.len(), bound);
+            if !recent.is_empty() {
+                prop_assert_eq!(
+                    &recent[0].request_id,
+                    &format!("req-{}", pushes - 1)
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
Builds on #883 (stack PR). Starter PR for #846 — does **not** close it.

Adds `proptest` as a dev-dependency on `dcc-mcp-gateway` and seeds the suite with 5 property-based tests against the pure helpers behind the admin observability surface. Establishes the proptest framework so future LSP / trait-law work (#846 acceptance) can plug in cheaply.

## Why this scope

The issue calls for property tests covering trait laws (`Registry`, `ValidationStrategy`, `DccAdapter`). Most of those traits ship without proptest-friendly arbitrary generators yet, and bootstrapping them into `DccAdapter` would block on #843 (still in flight).

Targeting admin stats/trace pure helpers first:

- Adds the proptest dev-dep without forcing generators on every public trait.
- Locks down two real correctness invariants that were previously only spot-tested.
- Gives the next contributor an in-tree example to copy when they bring trait laws online.

## Properties

- `prop_latency_percentiles_are_monotone` — min ≤ p50 ≤ p95 ≤ p99 ≤ max, mean ∈ [min, max].
- `prop_top_n_is_sorted_and_truncated` — ≤ n entries, count-desc with name-asc tiebreaker, never invents names.
- `prop_top_n_is_idempotent_on_length` — feeding the result back in does not grow it.
- `prop_trace_log_capacity_is_respected` — `len(recent) == min(pushes, capacity)`.
- `prop_trace_log_recent_returns_newest_first` — first element is the most recently pushed trace.

## Verification

```
cargo test -p dcc-mcp-gateway --features admin --lib prop_
# 5 passed; 0 failed
```