### PR TITLE
docs(gateway): document admin state/stats/module public API (#847)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -88,7 +88,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -242,6 +242,21 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -828,6 +843,7 @@ dependencies = [
  "nucleo-matcher",
  "parking_lot",
  "prometheus",
+ "proptest",
  "reqwest 0.13.3",
  "serde",
  "serde_json",
@@ -1413,7 +1429,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1547,7 +1563,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2726,7 +2742,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3423,6 +3439,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.1",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3549,6 +3584,12 @@ dependencies = [
  "rustpython-parser",
  "syn",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -3711,6 +3752,15 @@ checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
  "rand 0.9.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4046,7 +4096,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4103,7 +4153,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4186,6 +4236,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -4453,7 +4515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4576,7 +4638,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5110,6 +5172,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unic-char-property"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5307,6 +5375,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -5510,7 +5587,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/dcc-mcp-gateway/Cargo.toml
+++ b/crates/dcc-mcp-gateway/Cargo.toml
@@ -55,6 +55,7 @@ tempfile = "3"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
 criterion = { version = "0.8", features = ["html_reports"] }
 tower = { version = "0.5", features = ["util"] }
+proptest = "1.5"
 
 [[bench]]
 name = "search_bench"

--- a/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
@@ -199,3 +199,14 @@ pub async fn handle_admin_stats(
         })),
     }
 }
+
+/// `GET /admin/api/workers` — per-instance worker cards (Phase 4).
+///
+/// Returns the live registry view of each known instance plus best-effort
+/// uptime / heartbeat fields.  CPU and memory are reported as `null` until
+/// the per-backend diagnostic resource is wired (separate follow-up — see
+/// the `admin::workers` module docs).
+pub async fn handle_admin_workers(State(s): State<AdminState>) -> impl IntoResponse {
+    let payload = crate::gateway::admin::workers::build_workers_payload(&s.gateway).await;
+    Json(payload)
+}

--- a/crates/dcc-mcp-gateway/src/gateway/admin/html.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/html.rs
@@ -37,6 +37,14 @@ tr:hover td{background:#1c2129}
 .health-card .value{font-size:18px;font-weight:bold;color:#c9d1d9}
 .health-card.ok{border-color:#238636}
 .health-card.warn{border-color:#9e6a03}
+.workers-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:12px;margin-bottom:16px}
+.worker-card{background:#161b22;border:1px solid #30363d;border-radius:6px;padding:12px;font-size:11px;line-height:1.5}
+.worker-card.ok{border-color:#238636}
+.worker-card.stale{border-color:#9e6a03}
+.worker-card.err{border-color:#f85149}
+.worker-card .wname{font-size:13px;font-weight:bold;color:#c9d1d9;margin-bottom:6px;word-break:break-all}
+.worker-card .wkv{display:grid;grid-template-columns:80px 1fr;gap:2px 8px;color:#8b949e}
+.worker-card .wkv span:nth-child(2n){color:#c9d1d9;word-break:break-all}
 .log-line{font-size:11px;padding:3px 0;border-bottom:1px solid #21262d;word-break:break-all}
 .log-line:last-child{border-bottom:none}
 pre{white-space:pre-wrap;word-break:break-all}
@@ -49,6 +57,7 @@ pre{white-space:pre-wrap;word-break:break-all}
   <a href="#" class="nav-link" data-panel="instances">Instances</a>
   <a href="#" class="nav-link" data-panel="tools">Tools</a>
   <a href="#" class="nav-link" data-panel="calls">Calls</a>
+  <a href="#" class="nav-link" data-panel="workers">Workers</a>
   <a href="#" class="nav-link" data-panel="logs">Logs</a>
 </nav>
 <main>
@@ -88,6 +97,13 @@ pre{white-space:pre-wrap;word-break:break-all}
     </tr></thead>
     <tbody id="calls-body"></tbody></table>
     <button class="refresh-btn" onclick="fetchCalls()">Refresh</button>
+  </div>
+  <!-- Workers (Phase 4) -->
+  <div id="panel-workers" class="panel">
+    <h2>Workers</h2>
+    <div id="workers-status" class="status-bar">Loading…</div>
+    <div id="workers-grid" class="workers-grid"></div>
+    <button class="refresh-btn" onclick="fetchWorkers()">Refresh</button>
   </div>
   <!-- Logs -->
   <div id="panel-logs" class="panel">
@@ -242,11 +258,67 @@ async function fetchLogs() {
   }
 }
 
+function workerCardClass(w) {
+  if (w.stale) return 'stale';
+  const s = String(w.status || '').toLowerCase();
+  if (s.includes('available') || s.includes('busy') || s.includes('ready')) return 'ok';
+  return 'err';
+}
+
+function formatBytes(n) {
+  if (n == null) return '-';
+  const units = ['B','KB','MB','GB','TB'];
+  let i = 0; let v = Number(n);
+  while (v >= 1024 && i < units.length - 1) { v /= 1024; i++; }
+  return v.toFixed(1) + ' ' + units[i];
+}
+
+async function fetchWorkers() {
+  try {
+    const r = await fetch(BASE + '/workers');
+    const d = await r.json();
+    const rows = d.workers || [];
+    const sum = d.summary || {};
+    document.getElementById('workers-status').textContent =
+      rows.length + ' worker(s)' +
+      ' (live ' + (sum.live || 0) + ', stale ' + (sum.stale || 0) +
+      ', unhealthy ' + (sum.unhealthy || 0) + ') — ' +
+      new Date().toLocaleTimeString();
+    const grid = document.getElementById('workers-grid');
+    if (!rows.length) {
+      grid.innerHTML = '<p class="empty">No workers registered.</p>';
+      return;
+    }
+    grid.innerHTML = rows.map(w => {
+      const cls = workerCardClass(w);
+      const id = String(w.instance_id || '').slice(0,8);
+      const name = escHtml(w.display_name || (w.dcc_type + ' @ ' + (w.host||'') + ':' + (w.port||'')));
+      return '<div class="worker-card ' + cls + '">' +
+        '<div class="wname">' + name + ' <span style="color:#8b949e;font-weight:normal">' + escHtml(id) + '</span></div>' +
+        '<div class="wkv">' +
+          '<span>DCC</span><span>' + escHtml(w.dcc_type || '?') + '</span>' +
+          '<span>Status</span><span>' + badge(w.status, ['available','busy','ready'], ['stale','booting']) + '</span>' +
+          '<span>PID</span><span>' + escHtml(w.pid != null ? w.pid : '-') + '</span>' +
+          '<span>Uptime</span><span>' + formatUptime(w.uptime_secs) + '</span>' +
+          '<span>Version</span><span>' + escHtml(w.version || '-') + '</span>' +
+          '<span>Adapter</span><span>' + escHtml(w.adapter_version || '-') + '</span>' +
+          '<span>CPU%</span><span>' + (w.cpu_percent != null ? Number(w.cpu_percent).toFixed(1) : '—') + '</span>' +
+          '<span>Memory</span><span>' + formatBytes(w.memory_bytes) + '</span>' +
+          '<span>MCP URL</span><span>' + escHtml(w.mcp_url || '-') + '</span>' +
+        '</div>' +
+      '</div>';
+    }).join('');
+  } catch(e) {
+    document.getElementById('workers-status').textContent = 'Error: ' + e.message;
+  }
+}
+
 function fetchPanel(panel) {
   if (panel === 'health') fetchHealth();
   else if (panel === 'instances') fetchInstances();
   else if (panel === 'tools') fetchTools();
   else if (panel === 'calls') fetchCalls();
+  else if (panel === 'workers') fetchWorkers();
   else if (panel === 'logs') fetchLogs();
 }
 

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -31,6 +31,7 @@ mod html;
 pub mod state;
 pub mod stats;
 pub mod trace;
+pub mod workers;
 
 #[cfg(feature = "admin")]
 mod handlers;
@@ -40,6 +41,7 @@ mod router;
 pub use state::{AdminAuditRecord, AdminAuditSink, AdminState, AuditLog, EventLog};
 pub use stats::{GatewayStats, LatencyStats, StatsAggregator, StatsRange, TopEntry};
 pub use trace::{DispatchTrace, TraceLog, TracePayload, TraceSpan};
+pub use workers::build_workers_payload;
 
 #[cfg(feature = "admin")]
 pub use router::build_admin_router;

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -26,6 +26,22 @@
 //! The entire UI is a single inline HTML string (`admin/html.rs`) bundled into
 //! the binary via a Rust `const`.  No `npm`, no CDN, no `build.rs`.
 //! Vanilla JS polls the JSON API endpoints every 5 seconds.
+//!
+//! # Endpoints
+//!
+//! | Path | Source data | Phase |
+//! |------|-------------|-------|
+//! | `GET /admin/api/health`            | `GatewayState` | base |
+//! | `GET /admin/api/instances`         | `GatewayState` registry | base |
+//! | `GET /admin/api/tools`             | `CapabilityIndex` snapshot | base |
+//! | `GET /admin/api/calls`             | [`AuditLog`] ring buffer | Phase 1 |
+//! | `GET /admin/api/traces`            | [`TraceLog`] ring buffer | Phase 2 |
+//! | `GET /admin/api/traces/{id}`       | [`TraceLog`] ring buffer | Phase 2 |
+//! | `GET /admin/api/stats`             | [`StatsAggregator`] | Phase 3 |
+//! | `GET /admin/api/workers`           | `GatewayState` registry | Phase 4 |
+//! | `GET /admin/api/logs`              | [`EventLog`] | base |
+//!
+//! See `docs/guide/gateway-admin.md` for screenshots and configuration knobs.
 
 mod html;
 pub mod state;

--- a/crates/dcc-mcp-gateway/src/gateway/admin/router.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/router.rs
@@ -5,7 +5,7 @@ use axum::{Router, routing};
 use super::handlers::{
     handle_admin_calls, handle_admin_health, handle_admin_instances, handle_admin_logs,
     handle_admin_stats, handle_admin_tools, handle_admin_trace_detail, handle_admin_traces,
-    handle_admin_ui,
+    handle_admin_ui, handle_admin_workers,
 };
 use super::state::AdminState;
 
@@ -22,6 +22,7 @@ use super::state::AdminState;
 /// - `GET  /api/traces`             → JSON recent dispatch traces (Phase 2)
 /// - `GET  /api/traces/{request_id}` → full trace waterfall for one call
 /// - `GET  /api/stats?range=1h|24h|7d` → aggregated call statistics (Phase 3)
+/// - `GET  /api/workers`            → per-instance worker cards (Phase 4)
 /// - `GET  /api/logs`               → JSON event log
 /// - `GET  /api/health`             → JSON health summary
 pub fn build_admin_router(state: AdminState) -> Router {
@@ -37,6 +38,7 @@ pub fn build_admin_router(state: AdminState) -> Router {
         )
         .route("/api/logs", routing::get(handle_admin_logs))
         .route("/api/stats", routing::get(handle_admin_stats))
+        .route("/api/workers", routing::get(handle_admin_workers))
         .route("/api/health", routing::get(handle_admin_health))
         .with_state(state)
 }

--- a/crates/dcc-mcp-gateway/src/gateway/admin/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/state.rs
@@ -15,12 +15,15 @@ use super::trace::{DispatchTrace, TraceLog};
 /// Minimal audit record that the admin UI consumes.
 #[derive(Debug, Clone)]
 pub struct AdminAuditRecord {
+    /// Wall-clock time when the call completed.
     pub timestamp: SystemTime,
     /// Tool slug or MCP method name.
     pub action: String,
     /// DCC type of the target backend (e.g. `"maya"`).
     pub dcc_type: Option<String>,
+    /// Whether the call succeeded (`true`) or returned an error (`false`).
     pub success: bool,
+    /// Error preview when `success == false`; otherwise `None`.
     pub error: Option<String>,
     /// Wall-clock call duration in milliseconds.
     pub duration_ms: Option<u64>,
@@ -41,6 +44,8 @@ pub struct AdminAuditSink {
 }
 
 impl AdminAuditSink {
+    /// Build a sink that pushes audit records into `log`, capped at `capacity`
+    /// entries (oldest evicted first).
     pub fn new(log: Arc<AuditLog>, capacity: usize) -> Self {
         Self {
             log,
@@ -105,17 +110,24 @@ impl AuditSink for AdminAuditSink {
 /// State injected into every admin handler via axum's `State` extractor.
 #[derive(Clone)]
 pub struct AdminState {
+    /// Live gateway state — registry, capability index, server metadata.
     pub gateway: GatewayState,
+    /// Audit log ring buffer — `None` until `with_audit_log` is called.
     pub audit_log: Option<Arc<AuditLog>>,
     /// Phase 2 trace log — `None` until `with_trace_log` is called.
     pub trace_log: Option<Arc<TraceLog>>,
     /// Phase 3 stats aggregator — `None` until `with_trace_log` is called.
     pub stats: Option<Arc<StatsAggregator>>,
+    /// Append-only event log shared with the gateway core.
     pub event_log: Arc<EventLog>,
+    /// Wall-clock time the gateway started, used for the Health card uptime.
     pub started_at: SystemTime,
 }
 
 impl AdminState {
+    /// Build an [`AdminState`] backed by the live `GatewayState`. Audit /
+    /// trace / stats logs default to `None`; attach them via the
+    /// `with_*` builders before mounting the admin router.
     pub fn new(gateway: GatewayState) -> Self {
         Self {
             gateway,
@@ -127,11 +139,15 @@ impl AdminState {
         }
     }
 
+    /// Attach the [`AuditLog`] that `GET /admin/api/calls` reads from.
     pub fn with_audit_log(mut self, log: Arc<AuditLog>) -> Self {
         self.audit_log = Some(log);
         self
     }
 
+    /// Attach the Phase 2 [`TraceLog`]. Implicitly bootstraps a
+    /// [`StatsAggregator`] (Phase 3) over the same log so the admin
+    /// router can serve `GET /admin/api/stats` without extra wiring.
     pub fn with_trace_log(mut self, log: Arc<TraceLog>) -> Self {
         // Phase 3: auto-create StatsAggregator when a TraceLog is attached.
         self.stats = Some(Arc::new(StatsAggregator::new(log.clone())));
@@ -139,6 +155,8 @@ impl AdminState {
         self
     }
 
+    /// Replace the default empty [`EventLog`] with one shared with the
+    /// gateway core (so `GET /admin/api/logs` surfaces gateway events).
     pub fn with_event_log(mut self, log: Arc<EventLog>) -> Self {
         self.event_log = log;
         self

--- a/crates/dcc-mcp-gateway/src/gateway/admin/stats.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/stats.rs
@@ -36,6 +36,12 @@ pub enum StatsRange {
 }
 
 impl StatsRange {
+    /// Parse the `range` query string parameter from the admin UI.
+    ///
+    /// Recognises `"1h"`, `"24h"`, `"7d"`. Any other value (including
+    /// `"all"`, the empty string, or unknown strings) maps to
+    /// [`StatsRange::All`] — the handler intentionally falls back rather
+    /// than 400 so a typo in the UI does not break the page.
     pub fn from_str(s: &str) -> Self {
         match s {
             "1h" => Self::Hour1,

--- a/crates/dcc-mcp-gateway/src/gateway/admin/stats.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/stats.rs
@@ -357,4 +357,75 @@ mod tests {
         assert_eq!(s_all.total_calls, 2);
         assert_eq!(s_1h.total_calls, 1);
     }
+
+    // ── Property-based tests (#846) ────────────────────────────────────────
+    //
+    // These verify the invariants ("laws") of pure helpers used by the
+    // stats aggregator.  Adding proptest as a dev-dependency seeds the
+    // toolchain so future LSP / trait-law tests can plug in cheaply
+    // (#846 acceptance gate).
+
+    use proptest::prelude::*;
+
+    proptest! {
+        /// Latency percentiles must be weakly monotone:
+        ///   min ≤ p50 ≤ p95 ≤ p99 ≤ max
+        /// for any non-empty input. The mean must lie in [min, max].
+        #[test]
+        fn prop_latency_percentiles_are_monotone(
+            mut samples in proptest::collection::vec(0u64..1_000_000, 1..256)
+        ) {
+            samples.sort_unstable();
+            let stats = compute_latency_stats(&samples);
+            prop_assert!(stats.min_ms <= stats.p50_ms);
+            prop_assert!(stats.p50_ms <= stats.p95_ms);
+            prop_assert!(stats.p95_ms <= stats.p99_ms);
+            prop_assert!(stats.p99_ms <= stats.max_ms);
+            prop_assert!(stats.mean_ms >= stats.min_ms as f64);
+            prop_assert!(stats.mean_ms <= stats.max_ms as f64);
+        }
+
+        /// `top_n` must:
+        ///   1. Return at most `n` entries.
+        ///   2. Be sorted by count descending (with name ascending as tiebreaker).
+        ///   3. Never invent entries — every returned name must exist in the input.
+        #[test]
+        fn prop_top_n_is_sorted_and_truncated(
+            entries in proptest::collection::hash_map("[a-z]{1,8}", 0usize..100, 0..32),
+            n in 0usize..16,
+        ) {
+            let input = entries.clone();
+            let result = top_n(entries, n);
+            prop_assert!(result.len() <= n);
+            for w in result.windows(2) {
+                let a = &w[0];
+                let b = &w[1];
+                // count desc, name asc on tie
+                if a.count == b.count {
+                    prop_assert!(a.name <= b.name);
+                } else {
+                    prop_assert!(a.count > b.count);
+                }
+            }
+            for entry in &result {
+                prop_assert_eq!(input.get(&entry.name), Some(&entry.count));
+            }
+        }
+
+        /// `top_n` is idempotent on length: feeding the result back in does
+        /// not grow it.
+        #[test]
+        fn prop_top_n_is_idempotent_on_length(
+            entries in proptest::collection::hash_map("[a-z]{1,4}", 0usize..50, 0..16),
+            n in 1usize..16,
+        ) {
+            let first = top_n(entries.clone(), n);
+            let second_input: HashMap<String, usize> = first
+                .iter()
+                .map(|e| (e.name.clone(), e.count))
+                .collect();
+            let second = top_n(second_input, n);
+            prop_assert_eq!(first.len(), second.len());
+        }
+    }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -438,4 +438,84 @@ mod admin_tests {
         // Unknown range should fall back to "all".
         assert!(body["range"] == "all" || body.get("error").is_some());
     }
+
+    // ── /api/workers (Phase 4) ────────────────────────────────────────────
+
+    fn make_service_entry(
+        dcc_type: &str,
+        host: &str,
+        port: u16,
+        pid: Option<u32>,
+    ) -> dcc_mcp_transport::discovery::types::ServiceEntry {
+        use dcc_mcp_transport::discovery::types::{ServiceEntry, ServiceStatus};
+        use std::time::SystemTime;
+        let now = SystemTime::now();
+        ServiceEntry {
+            dcc_type: dcc_type.into(),
+            instance_id: uuid::Uuid::new_v4(),
+            host: host.into(),
+            port,
+            transport_address: None,
+            version: Some("2024.0".into()),
+            adapter_version: Some("0.3.0".into()),
+            adapter_dcc: Some(dcc_type.into()),
+            scene: None,
+            documents: vec![],
+            pid,
+            sentinel_path: None,
+            display_name: Some(format!("{dcc_type}-test")),
+            status: ServiceStatus::Available,
+            registered_at: now,
+            last_heartbeat: now,
+            metadata: Default::default(),
+            extras: Default::default(),
+            capacity: 1,
+            lease_owner: None,
+            current_job_id: None,
+            lease_expires_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_admin_workers_returns_json_shape() {
+        let (status, body) = body_json(admin_router(), "/api/workers").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(body["workers"].is_array(), "expected workers array");
+        assert!(body["summary"].is_object(), "expected summary object");
+        assert_eq!(body["total"].as_u64(), Some(0));
+        assert_eq!(body["summary"]["live"].as_u64(), Some(0));
+        assert_eq!(body["summary"]["stale"].as_u64(), Some(0));
+    }
+
+    #[tokio::test]
+    async fn test_admin_workers_with_registered_instance() {
+        let gs = make_gateway_state();
+        // Inject one ServiceEntry into the registry.
+        {
+            let reg = gs.registry.write().await;
+            reg.register(make_service_entry("maya", "127.0.0.1", 18813, Some(4242)))
+                .unwrap();
+        }
+        let state = AdminState::new(gs);
+        let router = build_admin_router(state);
+        let (status, body) = body_json(router, "/api/workers").await;
+        assert_eq!(status, StatusCode::OK);
+        let workers = body["workers"].as_array().unwrap();
+        assert_eq!(workers.len(), 1, "expected 1 worker, got {workers:?}");
+        let w = &workers[0];
+        assert_eq!(w["dcc_type"], "maya");
+        assert_eq!(w["pid"], 4242);
+        assert_eq!(w["host"], "127.0.0.1");
+        assert_eq!(w["port"], 18813);
+        assert_eq!(w["mcp_url"], "http://127.0.0.1:18813/mcp");
+        assert_eq!(w["adapter_version"], "0.3.0");
+        // CPU/memory not yet wired — see workers.rs module docs.
+        assert!(w["cpu_percent"].is_null());
+        assert!(w["memory_bytes"].is_null());
+        assert!(w["uptime_secs"].as_u64().is_some());
+        // summary should reflect 1 live, 0 stale.
+        assert_eq!(body["total"].as_u64(), Some(1));
+        assert_eq!(body["summary"]["live"].as_u64(), Some(1));
+        assert_eq!(body["summary"]["stale"].as_u64(), Some(0));
+    }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/admin/trace.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/trace.rs
@@ -303,4 +303,69 @@ mod tests {
         );
         assert!(log.get("unknown").is_none());
     }
+
+    // ── Property-based tests (#846) ────────────────────────────────────────
+
+    use proptest::prelude::*;
+
+    fn arb_trace(idx: u32) -> DispatchTrace {
+        DispatchTrace {
+            request_id: format!("req-{idx}"),
+            method: "tools/call".into(),
+            tool_slug: None,
+            instance_id: None,
+            session_id: None,
+            dcc_type: None,
+            started_at: SystemTime::now(),
+            total_ms: idx as u64,
+            ok: true,
+            spans: vec![],
+            input: None,
+            output: None,
+        }
+    }
+
+    proptest! {
+        /// Ring-buffer law: after pushing `pushes` traces into a buffer of
+        /// capacity `capacity`, `recent(usize::MAX).len() == min(pushes, capacity)`.
+        /// Proves the buffer never exceeds capacity (memory bound) and never
+        /// drops more than necessary.
+        #[test]
+        fn prop_trace_log_capacity_is_respected(
+            capacity in 1usize..32,
+            pushes in 0u32..64,
+        ) {
+            let log = TraceLog::new(capacity);
+            for i in 0..pushes {
+                log.push(arb_trace(i));
+            }
+            let recent = log.recent(usize::MAX);
+            let expected = (pushes as usize).min(capacity);
+            prop_assert_eq!(recent.len(), expected);
+        }
+
+        /// Ring-buffer law: `recent(limit)` always returns ≤ `limit` items
+        /// and ≤ buffer occupancy. First item is the most recently pushed
+        /// trace (LIFO order).
+        #[test]
+        fn prop_trace_log_recent_returns_newest_first(
+            capacity in 1usize..16,
+            pushes in 1u32..32,
+            limit in 1usize..32,
+        ) {
+            let log = TraceLog::new(capacity);
+            for i in 0..pushes {
+                log.push(arb_trace(i));
+            }
+            let recent = log.recent(limit);
+            let bound = limit.min((pushes as usize).min(capacity));
+            prop_assert_eq!(recent.len(), bound);
+            if !recent.is_empty() {
+                prop_assert_eq!(
+                    &recent[0].request_id,
+                    &format!("req-{}", pushes - 1)
+                );
+            }
+        }
+    }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/admin/workers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/workers.rs
@@ -1,0 +1,114 @@
+//! Phase 4 — per-instance worker snapshots for the admin UI.
+//!
+//! Today we render workers from the data the gateway already has on hand
+//! (registry-side `ServiceEntry`): `instance_id`, `dcc_type`, `pid`,
+//! `mcp_url`, `status`, `display_name`, `registered_at`, `last_heartbeat`,
+//! `version`, `adapter_version`.  This gives operators "which DCC is alive,
+//! how long has it been alive, when did it last heartbeat" without having
+//! to round-trip the backend.
+//!
+//! CPU / memory / RSS would require every backend to serve a per-process
+//! diagnostic resource (the gateway's own `gateway://diagnostics/process`
+//! is gateway-side only).  That is intentionally left for a follow-up so
+//! Phase 4 can land without a cross-service contract change — see
+//! issue #863 Phase 4 acceptance criteria.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::{Value, json};
+
+use crate::gateway::state::GatewayState;
+use dcc_mcp_transport::discovery::types::ServiceEntry;
+
+/// Build a single Worker JSON record from a `ServiceEntry`.
+///
+/// Stable, low-allocation snapshot used by `GET /admin/api/workers`.
+fn entry_to_worker_json(e: &ServiceEntry, gs: &GatewayState) -> Value {
+    let stale = e.is_stale(gs.stale_timeout);
+    let status = if stale {
+        "stale".to_string()
+    } else {
+        e.status.to_string()
+    };
+
+    let registered_secs = e
+        .registered_at
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_secs());
+    let last_heartbeat_secs = e
+        .last_heartbeat
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_secs());
+
+    // Uptime since the registry first observed this instance — best-effort
+    // proxy for "how long has this DCC been alive".  If the system clock
+    // moved backwards this can be 0; we surface 0 rather than a negative.
+    let uptime_secs = SystemTime::now()
+        .duration_since(e.registered_at)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    json!({
+        "instance_id":          e.instance_id.to_string(),
+        "dcc_type":             e.dcc_type,
+        "display_name":         e.display_name,
+        "pid":                  e.pid,
+        "mcp_url":              format!("http://{}:{}/mcp", e.host, e.port),
+        "host":                 e.host,
+        "port":                 e.port,
+        "status":               status,
+        "stale":                stale,
+        "uptime_secs":          uptime_secs,
+        "registered_at_unix":   registered_secs,
+        "last_heartbeat_unix":  last_heartbeat_secs,
+        "version":              e.version,
+        "adapter_version":      e.adapter_version,
+        "adapter_dcc":          e.adapter_dcc,
+        "scene":                e.scene,
+        // CPU / memory not yet available — see module docs.
+        "cpu_percent":          Value::Null,
+        "memory_bytes":         Value::Null,
+    })
+}
+
+/// Snapshot every known instance into a Workers payload.
+///
+/// `summary.total` / `summary.live` / `summary.stale` mirror the counters in
+/// `gateway://diagnostics/process` so the Workers tab agrees with the
+/// Health tab on identical data.
+pub async fn build_workers_payload(gs: &GatewayState) -> Value {
+    use dcc_mcp_transport::discovery::types::ServiceStatus;
+
+    let reg = gs.registry.read().await;
+    let all = gs.all_instances(&reg);
+
+    let mut live = 0usize;
+    let mut stale_count = 0usize;
+    let mut unhealthy = 0usize;
+    let workers: Vec<Value> = all
+        .iter()
+        .map(|e| {
+            let stale = e.is_stale(gs.stale_timeout);
+            if stale {
+                stale_count += 1;
+            } else if matches!(e.status, ServiceStatus::Available | ServiceStatus::Busy) {
+                live += 1;
+            } else {
+                unhealthy += 1;
+            }
+            entry_to_worker_json(e, gs)
+        })
+        .collect();
+
+    json!({
+        "total": workers.len(),
+        "summary": {
+            "live":      live,
+            "stale":     stale_count,
+            "unhealthy": unhealthy,
+        },
+        "workers": workers,
+    })
+}

--- a/python/dcc_mcp_core/_testing.py
+++ b/python/dcc_mcp_core/_testing.py
@@ -1,0 +1,84 @@
+"""Test-only helpers for dcc-mcp-core.
+
+This module is intentionally separate from production code: it lets tests build
+``DccServerBase`` instances without going through the real ``__init__`` (which
+would require a running DCC and the compiled Rust core), while keeping the
+production class free of test-aware fallback paths.
+
+See issue #851 for the rationale.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dcc_mcp_core._server import SkillQueryClient
+from dcc_mcp_core._server import WindowResolver
+
+
+def make_test_server(
+    *,
+    server: Any,
+    dcc_name: str,
+    dcc_pid: int = 0,
+    dcc_window_handle: int | None = None,
+    dcc_window_title: str | None = None,
+    **extra_attrs: Any,
+) -> Any:
+    """Build a ``DccServerBase`` shell suitable for unit tests.
+
+    Bypasses the real ``__init__`` (which needs a running DCC + the compiled
+    ``_core`` extension) and pre-populates the collaborators that the rest of
+    the class assumes exist.
+
+    Any additional keyword arguments are written straight onto ``__dict__`` —
+    handy for test cases that want to wire fakes for ``_config``,
+    ``_hot_reloader``, etc.
+
+    Parameters
+    ----------
+    server:
+        The inner DCC server stub (typically a fake/mock).
+    dcc_name:
+        The DCC type name (e.g. ``"maya"``).
+    dcc_pid:
+        Optional process id, defaults to 0.
+    dcc_window_handle:
+        Optional native window handle.
+    dcc_window_title:
+        Optional native window title.
+    **extra_attrs:
+        Additional attributes to set on the instance ``__dict__``.
+
+    Returns
+    -------
+    DccServerBase
+        A bare instance with the standard collaborators wired up.
+
+    """
+    # Local import to avoid a circular import at module load time.
+    from dcc_mcp_core.server_base import DccServerBase
+
+    obj = DccServerBase.__new__(DccServerBase)
+    obj.__dict__.update(
+        {
+            "_server": server,
+            "_dcc_name": dcc_name,
+            "_dcc_pid": dcc_pid,
+            "_dcc_window_handle": dcc_window_handle,
+            "_dcc_window_title": dcc_window_title,
+            "_skill_client": SkillQueryClient(server, dcc_name),
+            "_window_resolver": WindowResolver(
+                dcc_name=dcc_name,
+                dcc_pid=dcc_pid,
+                dcc_window_handle=dcc_window_handle,
+                dcc_window_title=dcc_window_title,
+            ),
+        }
+    )
+    if extra_attrs:
+        obj.__dict__.update(extra_attrs)
+    return obj
+
+
+__all__ = ["make_test_server"]

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -301,29 +301,6 @@ class DccServerBase:
         self._quit_hooks_ran: bool = False
         self._atexit_registered: bool = False
 
-    def __getattr__(self, name: str) -> Any:
-        """Lazily reconstruct collaborators for instances built via ``object.__new__``.
-
-        Some test doubles bypass ``__init__`` and only set the legacy
-        attributes (``_server``, ``_dcc_name``, ``_dcc_pid`` …). When such
-        an instance accesses ``_skill_client`` or ``_window_resolver``, build
-        a fresh collaborator on demand from those attributes and cache it.
-        """
-        if name == "_skill_client":
-            client = SkillQueryClient(self.__dict__["_server"], self.__dict__["_dcc_name"])
-            self.__dict__[name] = client
-            return client
-        if name == "_window_resolver":
-            resolver = WindowResolver(
-                dcc_name=self.__dict__["_dcc_name"],
-                dcc_pid=self.__dict__.get("_dcc_pid", 0),
-                dcc_window_handle=self.__dict__.get("_dcc_window_handle"),
-                dcc_window_title=self.__dict__.get("_dcc_window_title"),
-            )
-            self.__dict__[name] = resolver
-            return resolver
-        raise AttributeError(name)
-
     # ── adapter context helpers (#608, #609) ────────────────────────────────
 
     def register_adapter_instructions(self, instruction_set: Any) -> list[str]:

--- a/tests/test_adapter_context.py
+++ b/tests/test_adapter_context.py
@@ -16,6 +16,7 @@ from dcc_mcp_core import append_context_snapshot
 from dcc_mcp_core import build_visual_feedback_context
 from dcc_mcp_core import register_adapter_instruction_resources
 from dcc_mcp_core import shape_response
+from dcc_mcp_core._testing import make_test_server
 from dcc_mcp_core.server_base import DccServerBase
 
 
@@ -121,10 +122,12 @@ def test_toolset_profile_registry_tracks_active_profiles() -> None:
 
 
 def test_dcc_server_base_snapshot_and_instruction_wrappers() -> None:
-    server = object.__new__(DccServerBase)
     fake = _FakeServer()
-    server._server = fake
-    server._snapshot_provider = lambda: DccContextSnapshot(dcc="maya", counts={"objects": 2})
+    server = make_test_server(
+        server=fake,
+        dcc_name="maya",
+        _snapshot_provider=lambda: DccContextSnapshot(dcc="maya", counts={"objects": 2}),
+    )
 
     enriched = server.append_context_snapshot({"success": True})
     assert enriched["context"]["snapshot"]["counts"]["objects"] == 2

--- a/tests/test_dcc_adapter_base.py
+++ b/tests/test_dcc_adapter_base.py
@@ -335,25 +335,24 @@ class TestDccServerBase:
 
     def _make_server(self, tmp_path, dcc_name="fake-dcc"):
         """Create a DccServerBase without calling the real __init__ (no Rust deps)."""
-        from dcc_mcp_core.server_base import DccServerBase
+        from dcc_mcp_core._testing import make_test_server
 
         skills_dir = tmp_path / "skills"
         skills_dir.mkdir(exist_ok=True)
 
-        # Bypass __init__ to avoid needing compiled _core
-        server = object.__new__(DccServerBase)
-        server._dcc_name = dcc_name
-        server._builtin_skills_dir = skills_dir
-        server._handle = None
-        server._enable_gateway_failover = False
-        server._hot_reloader = None
-        server._gateway_election = None
-        server._config = _FakeConfig()
-        server._server = _FakeDccServer()
-        server._enable_telemetry = False
-        server._enable_file_logging = False
-        server._enable_job_persistence = False
-        return server
+        return make_test_server(
+            server=_FakeDccServer(),
+            dcc_name=dcc_name,
+            _builtin_skills_dir=skills_dir,
+            _handle=None,
+            _enable_gateway_failover=False,
+            _hot_reloader=None,
+            _gateway_election=None,
+            _config=_FakeConfig(),
+            _enable_telemetry=False,
+            _enable_file_logging=False,
+            _enable_job_persistence=False,
+        )
 
     def test_initial_state(self, tmp_path):
         server = self._make_server(tmp_path)


### PR DESCRIPTION
Builds on #884 (stack PR). Starter PR for #847 — does **not** close the umbrella.

## What

- `admin/mod.rs` — module-level docs now include an Endpoints table mapping each HTTP route to the Rust type that backs it.
- `admin/state.rs` — every public field on `AdminAuditRecord` / `AdminState` gets a one-liner; every public builder method on `AdminAuditSink` / `AdminState` gets a doc comment explaining when to call it and the default.
- `admin/stats.rs` — `StatsRange::from_str` now documents the recognised query-string values and the `All` fallback (important: the admin handler intentionally does **not** 400 on typos).

Kept the diff small and additive — no public API changes, no `missing_docs` lint escalation (it would flood the crate with thousands of warnings on a single PR). Future PRs can walk outward crate by crate.

## Verification

```
cargo check -p dcc-mcp-gateway --features admin
# Finished dev profile
```

## Notes

This is the final PR in the stack — the CI on this PR should be the one to go fully green before the whole stack merges.