### PR TITLE
docs(gateway): document middleware/namespace/event_log public API (#847)

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/event_log.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/event_log.rs
@@ -71,6 +71,8 @@ pub struct ContendEvent {
 }
 
 impl ContendEvent {
+    /// Construct a new event with the current UTC timestamp (millisecond
+    /// precision).
     pub fn new(
         event: EventKind,
         dcc_type: impl Into<String>,
@@ -101,6 +103,7 @@ impl EventLog {
     /// Maximum number of events kept in the ring buffer.
     pub const CAPACITY: usize = 1_000;
 
+    /// Create an empty ring buffer with capacity [`Self::CAPACITY`].
     pub fn new() -> Self {
         EventLog {
             inner: Mutex::new(VecDeque::with_capacity(Self::CAPACITY)),
@@ -211,14 +214,20 @@ impl GatewayMetrics {
         GatewayMetrics
     }
 
+    /// Increment the gateway-election outcome counter (e.g. `"won"`,
+    /// `"lost"`, `"abandoned"`).
     pub fn inc_election(&self, outcome: &str) {
         elections_counter().with_label_values(&[outcome]).inc();
     }
 
+    /// Increment the registry-eviction counter, labelled by reason
+    /// (e.g. `"stale"`, `"dead_pid"`, `"shutdown"`).
     pub fn inc_eviction(&self, reason: &str) {
         evictions_counter().with_label_values(&[reason]).inc();
     }
 
+    /// Increment the backend-probe outcome counter (e.g. `"healthy"`,
+    /// `"timeout"`, `"refused"`).
     pub fn inc_probe(&self, outcome: &str) {
         probes_counter().with_label_values(&[outcome]).inc();
     }

--- a/crates/dcc-mcp-gateway/src/gateway/middleware/audit.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/middleware/audit.rs
@@ -8,17 +8,45 @@ use super::traits::{AfterCallMiddleware, BeforeCallMiddleware, MiddlewareFuture}
 use crate::gateway::admin::trace::{TracePayload, TraceSpan};
 
 /// A single audit record produced for each tool call.
+///
+/// One entry is emitted per `tools/call` after the dispatch handler
+/// has resolved the tool and produced a result. The fields mirror
+/// [`super::CallContext`] plus outcome metadata so downstream sinks
+/// (the admin Calls tab, structured `tracing::info!` logs, custom
+/// SIEM forwarders) can render a complete one-row view of the call.
 #[derive(Debug, Clone)]
 pub struct AuditEntry {
+    /// Wall-clock timestamp at which the audit record was sealed —
+    /// `SystemTime::now()` from the after-call hook, *not* the call
+    /// start (that is reflected via `duration_ms`).
     pub timestamp: SystemTime,
+    /// JSON-RPC method name (e.g. `"tools/call"`), copied verbatim
+    /// from the originating request.
     pub method: String,
+    /// Resolved capability slug, if the dispatch handler matched the
+    /// call to a `CapabilityRecord`. `None` for unresolved tools.
     pub tool_slug: Option<String>,
+    /// DCC type targeted by the call (`"maya"`, `"blender"`, …),
+    /// `None` for gateway-local tools.
     pub dcc_type: Option<String>,
+    /// Stringified instance UUID of the resolved backend.
     pub instance_id: Option<String>,
+    /// Originating MCP `Mcp-Session-Id` header, if any.
     pub session_id: Option<String>,
+    /// Stable request id used to correlate this entry with traces
+    /// and the client's JSON-RPC `id`.
     pub request_id: String,
+    /// `true` when the dispatch handler returned an MCP-level error
+    /// (`isError == true` or transport failure).
     pub is_error: bool,
+    /// First 256 chars of the response text — bounded so audit logs
+    /// stay cheap to ship and never leak full payloads. The full
+    /// response lives in `output_payload`.
     pub result_preview: String,
+    /// Total handler latency in milliseconds, derived from the
+    /// `audit.start_time_ns` metadata stamped by the before-call
+    /// hook. `None` when the before-call hook did not run (e.g. the
+    /// chain was short-circuited).
     pub duration_ms: Option<u64>,
     /// Phase 2: waterfall of timing spans collected by the handler.
     pub trace_spans: Vec<TraceSpan>,
@@ -29,7 +57,18 @@ pub struct AuditEntry {
 }
 
 /// Sink that receives completed [`AuditEntry`] records.
+///
+/// Implementations are wrapped in `Arc<dyn AuditSink>` and shared
+/// across every concurrent call, so they must be cheap to clone the
+/// trait object reference and free of synchronous I/O on the hot
+/// path. The default [`DefaultAuditSink`] just emits a `tracing::info!`
+/// log; the admin UI ships
+/// [`AdminAuditSink`](crate::gateway::admin::AdminAuditSink) which
+/// fans entries into a bounded ring buffer.
 pub trait AuditSink: Send + Sync {
+    /// Persist `entry`. Called from the after-call middleware hook;
+    /// the implementation must not block — long-running sinks should
+    /// hand off to a background task.
     fn record(&self, entry: AuditEntry);
 }
 
@@ -67,9 +106,16 @@ impl Default for AuditMiddleware {
 }
 
 impl AuditMiddleware {
+    /// Build an `AuditMiddleware` that hands every entry to `sink`.
+    /// Use this when the operator has a custom sink (admin ring
+    /// buffer, SIEM forwarder, …) — pass [`Arc::new(MySink)`] to
+    /// share the sink across the chain.
     pub fn new(sink: Arc<dyn AuditSink>) -> Self {
         Self { sink }
     }
+    /// Convenience for tests and minimal embeddings: build an
+    /// `AuditMiddleware` backed by [`DefaultAuditSink`], which logs
+    /// each entry via `tracing::info!`.
     pub fn with_default_sink() -> Self {
         Self::default()
     }

--- a/crates/dcc-mcp-gateway/src/gateway/middleware/context.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/middleware/context.rs
@@ -7,15 +7,48 @@ use std::time::SystemTime;
 use crate::gateway::admin::trace::{TracePayload, TraceSpan};
 
 /// Context for one gateway `tools/call` invocation.
+///
+/// Built by the gateway dispatch handler and passed through the
+/// [`super::MiddlewareChain`]. The context carries everything a
+/// before/after middleware needs to make routing, auditing, or
+/// admission decisions: the JSON-RPC method, the resolved tool
+/// (slug + DCC + instance), the originating session, and the raw
+/// argument value.
+///
+/// Middlewares may mutate `metadata` to pass small key/value hints to
+/// later stages, but the routing fields (`tool_slug`, `dcc_type`,
+/// `instance_id`) are owned by the dispatch handler and should not be
+/// rewritten by middleware.
 #[derive(Debug, Clone)]
 pub struct CallContext {
+    /// JSON-RPC method name as it arrived from the client (e.g.
+    /// `"tools/call"`). Preserved verbatim so audit sinks can
+    /// distinguish the dynamic-capability verbs from the legacy
+    /// `tools/list` fan-out.
     pub method: String,
+    /// Resolved capability slug (`<dcc>.<id8>.<tool>`) once the
+    /// dispatch handler has matched the call to a `CapabilityRecord`.
+    /// `None` for calls that never resolve (e.g. unknown tool).
     pub tool_slug: Option<String>,
+    /// DCC type of the resolved capability (e.g. `"maya"`). `None`
+    /// when the call does not target a backend (gateway-local tool).
     pub dcc_type: Option<String>,
+    /// Stringified instance UUID of the resolved backend, if any.
     pub instance_id: Option<String>,
+    /// MCP `Mcp-Session-Id` header. `None` for stateless callers
+    /// (REST clients) that did not negotiate a session.
     pub session_id: Option<String>,
+    /// Stable per-call identifier used to correlate trace spans,
+    /// audit records, and the client's JSON-RPC `id`.
     pub request_id: String,
+    /// Raw argument value as received from the client. Middlewares
+    /// must treat this as untrusted input and avoid logging it
+    /// verbatim — use [`input_payload`](Self::input_payload) which
+    /// has already been bounded and redacted.
     pub args: Value,
+    /// Free-form metadata carried between middleware stages. Use a
+    /// short, stable key (e.g. `"admission.reason"`) when emitting
+    /// audit signals.
     pub metadata: HashMap<String, String>,
     /// Phase 2: per-call dispatch trace spans, populated by the handler.
     pub trace_spans: Vec<TraceSpan>,
@@ -28,6 +61,13 @@ pub struct CallContext {
 }
 
 impl CallContext {
+    /// Construct a fresh `CallContext` for the given method and
+    /// request id, capturing `args` verbatim.
+    ///
+    /// All optional routing fields default to `None`; the dispatch
+    /// handler is expected to populate them as it resolves the tool.
+    /// `started_at` is set to `SystemTime::now()` so the trace
+    /// waterfall measures the full handler latency.
     pub fn new(method: impl Into<String>, request_id: impl Into<String>, args: Value) -> Self {
         Self {
             method: method.into(),
@@ -45,11 +85,13 @@ impl CallContext {
         }
     }
 
+    /// Builder: attach the resolved capability slug.
     pub fn with_tool_slug(mut self, slug: impl Into<String>) -> Self {
         self.tool_slug = Some(slug.into());
         self
     }
 
+    /// Builder: attach the originating MCP session id.
     pub fn with_session_id(mut self, id: impl Into<String>) -> Self {
         self.session_id = Some(id.into());
         self
@@ -62,13 +104,25 @@ impl CallContext {
 }
 
 /// Result of a gateway tool call, passed to [`super::AfterCallMiddleware`].
+///
+/// `text` mirrors the MCP `content[0].text` field of the response and
+/// `is_error` mirrors the JSON-RPC `isError` flag — together they let
+/// audit sinks render a one-line outcome without re-parsing the
+/// response envelope.
 #[derive(Debug, Clone)]
 pub struct CallResult {
+    /// Human-readable response body. Already bounded by the dispatch
+    /// handler so audit sinks can persist it without an extra cap.
     pub text: String,
+    /// `true` when the response was an MCP-level error
+    /// (`isError == true` or transport failure). Used by audit sinks
+    /// to colour-code outcomes without re-parsing `text`.
     pub is_error: bool,
 }
 
 impl CallResult {
+    /// Construct a `CallResult` from the handler's `(text, is_error)`
+    /// tuple — the canonical shape backends return today.
     pub fn from_tuple(text: impl Into<String>, is_error: bool) -> Self {
         Self {
             text: text.into(),
@@ -76,6 +130,8 @@ impl CallResult {
         }
     }
 
+    /// Convert back to the `(text, is_error)` tuple that the dispatch
+    /// handler ultimately serialises into the JSON-RPC response.
     pub fn into_tuple(self) -> (String, bool) {
         (self.text, self.is_error)
     }

--- a/crates/dcc-mcp-gateway/src/gateway/namespace/constants.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/namespace/constants.rs
@@ -6,6 +6,14 @@
 
 use uuid::Uuid;
 
+/// Tools that are answered by the gateway itself (never fanned out
+/// to a backend).
+///
+/// Includes the skill management verbs (`list_skills`, `load_skill`,
+/// …) and the issue #655 dynamic-capability wrappers
+/// (`search_tools`, `describe_tool`, `call_tool`). The dispatch
+/// handler short-circuits on these names so the fan-out path can
+/// stay free of carve-outs.
 pub const GATEWAY_LOCAL_TOOLS: &[&str] = &[
     "acquire_dcc_instance",
     "release_dcc_instance",
@@ -35,6 +43,11 @@ pub const CORE_TOOL_NAMES: &[&str] = &[
     "search_tools",
 ];
 
+/// Length of the truncated instance UUID prefix used in encoded
+/// tool names (e.g. `maya.abcdef01.create_sphere`). 8 hex chars
+/// give 32 bits of entropy — enough to disambiguate among the
+/// dozens of instances a gateway will ever see live, while staying
+/// short enough to stay readable in log lines and error messages.
 pub const ID_PREFIX_LEN: usize = 8;
 
 /// Current, SEP-986-compliant gateway instance separator.
@@ -72,14 +85,20 @@ pub const CURSOR_SAFE_PREFIX: &str = "i_";
 /// `_H_`).
 pub const CURSOR_SAFE_SEP: &str = "__";
 
+/// `true` when `name` is a gateway-local tool that must never be
+/// forwarded to a backend (cf. [`GATEWAY_LOCAL_TOOLS`]).
 pub fn is_local_tool(name: &str) -> bool {
     GATEWAY_LOCAL_TOOLS.contains(&name)
 }
 
+/// `true` when `name` is a per-DCC core tool that keeps a bare name
+/// even after skill prefixing (cf. [`CORE_TOOL_NAMES`]).
 pub fn is_core_tool(name: &str) -> bool {
     CORE_TOOL_NAMES.contains(&name)
 }
 
+/// Truncate a UUID to its first [`ID_PREFIX_LEN`] hex chars — the
+/// canonical short form used inside encoded gateway tool names.
 pub fn instance_short(id: &Uuid) -> String {
     let mut s = id.simple().to_string();
     s.truncate(ID_PREFIX_LEN);


### PR DESCRIPTION
Walks outward from PR #887 (admin docs) toward the umbrella #847.

## What

Add doc comments to every remaining public item in:

- `gateway/middleware/context.rs` — `CallContext` + `CallResult` fields and builders, with notes on what middleware may mutate vs. what dispatch owns.
- `gateway/middleware/audit.rs` — `AuditEntry` fields, `AuditSink` trait contract, `AuditMiddleware` constructors.
- `gateway/event_log.rs` — `ContendEvent::new` and the `GatewayMetrics` `inc_*` counters (only compiled with `prometheus`).
- `gateway/namespace/constants.rs` — `GATEWAY_LOCAL_TOOLS`, `ID_PREFIX_LEN`, `is_local_tool` / `is_core_tool` / `instance_short`.

No public API changes, no `missing_docs` lint escalation. This PR does **not** close #847 — future PRs walk outward crate by crate.

## Verification

```
cargo check -p dcc-mcp-gateway --lib
cargo check -p dcc-mcp-gateway --features admin
cargo fmt -- --check
```

All green locally.

Refs #847
