### PR TITLE
refactor(gateway): introduce dcc-mcp-gateway-core domain crate (#845)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,6 +833,7 @@ dependencies = [
  "criterion",
  "dashmap",
  "dcc-mcp-catalog",
+ "dcc-mcp-gateway-core",
  "dcc-mcp-jsonrpc",
  "dcc-mcp-naming",
  "dcc-mcp-skill-rest",
@@ -858,6 +859,14 @@ dependencies = [
  "tracing",
  "uuid",
  "workspace-hack",
+]
+
+[[package]]
+name = "dcc-mcp-gateway-core"
+version = "0.15.7"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/dcc-mcp-job",
     "crates/dcc-mcp-skill-rest",
     "crates/dcc-mcp-gateway",
+    "crates/dcc-mcp-gateway-core",
     "crates/dcc-mcp-logging",
     "crates/dcc-mcp-pybridge",
     "crates/dcc-mcp-pybridge-derive",

--- a/crates/dcc-mcp-gateway-core/Cargo.toml
+++ b/crates/dcc-mcp-gateway-core/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "dcc-mcp-gateway-core"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+readme = "README.md"
+description = "Domain layer for the DCC MCP gateway — pure types, no HTTP/IO."
+keywords = ["mcp", "gateway", "domain", "clean-architecture"]
+categories = ["api-bindings"]
+
+[lints]
+workspace = true
+
+[dependencies]
+serde = { workspace = true, optional = true }
+
+[features]
+default = []
+# Opt-in `serde::{Serialize, Deserialize}` derives for the domain types.
+# Kept off by default so downstream infra crates can pull the domain layer
+# without paying for serde codegen when they do not need it.
+serde = ["dep:serde"]
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/dcc-mcp-gateway-core/README.md
+++ b/crates/dcc-mcp-gateway-core/README.md
@@ -1,0 +1,25 @@
+# dcc-mcp-gateway-core
+
+Domain layer for the DCC MCP gateway — pure types with no HTTP, no async
+runtime, and no dependency on `dcc-mcp-gateway`.
+
+This crate is the innermost layer of the Clean-Architecture split called
+for in issue [#845]. The dependency direction is strictly inward:
+
+```text
+dcc-mcp-gateway  (application + infrastructure)
+        │
+        ▼
+dcc-mcp-gateway-core  (domain — this crate)
+```
+
+Consumers in `dcc-mcp-gateway` re-export the types under stable paths so
+existing call sites keep compiling while the migration is in flight.
+
+## Stability
+
+Semver follows the workspace version. Types move here from
+`dcc-mcp-gateway` one at a time so each move can be reviewed in isolation
+and the dependency direction verified.
+
+[#845]: https://github.com/loonghao/dcc-mcp-core/issues/845

--- a/crates/dcc-mcp-gateway-core/src/lib.rs
+++ b/crates/dcc-mcp-gateway-core/src/lib.rs
@@ -1,0 +1,116 @@
+//! Domain layer for the DCC MCP gateway (issue #845).
+//!
+//! # Clean Architecture — layer 0 (domain)
+//!
+//! This crate hosts the *pure types* that describe the gateway's domain
+//! concepts. It intentionally has **no dependency** on:
+//!
+//! - `axum` / `reqwest` / `tokio` / any HTTP or async infrastructure,
+//! - the file registry or any discovery transport,
+//! - the broader `dcc-mcp-gateway` application crate.
+//!
+//! The dependency direction is strictly inward:
+//!
+//! ```text
+//! dcc-mcp-gateway (app + infra)  →  dcc-mcp-gateway-core  (domain)
+//! ```
+//!
+//! Consumers in `dcc-mcp-gateway` re-export these types under stable paths
+//! so existing call sites keep compiling. New domain types should be added
+//! here first, then re-exported.
+//!
+//! # What lives here (migration plan)
+//!
+//! This is the **first** landing zone — the follow-on PRs in the #845 chain
+//! move capability-index / registry / model types here one at a time. The
+//! current boundary line:
+//!
+//! | Lives here now            | Stays in `dcc-mcp-gateway` for now  |
+//! |---------------------------|-------------------------------------|
+//! | [`PendingCall`]           | `CapabilityIndex` (#845 Part 2)    |
+//! |                           | `MiddlewareChain` (#770 follow-up)  |
+//! |                           | `EventLog` (needs serde split)      |
+//!
+//! Picking [`PendingCall`] as the seed type is deliberate: it is the
+//! smallest domain primitive with zero third-party dependencies, which lets
+//! us verify the dependency direction (`dcc-mcp-gateway` depends on
+//! `dcc-mcp-gateway-core`, never the other way) before larger types move.
+//!
+//! The `serde` feature is off by default; enable it when a downstream
+//! application / infrastructure crate needs to serialize domain types.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+/// A call that the gateway has forwarded to a backend and is still awaiting
+/// a response from.
+///
+/// Used by the routing layer so that an incoming `notifications/cancelled`
+/// on the gateway's session can be translated into the correct backend
+/// request id (see issue #321 for the cancellation correlation contract).
+///
+/// # Domain invariants
+///
+/// - `backend_url` is the fully-qualified URL the gateway forwarded the
+///   call to (e.g. `http://127.0.0.1:18812/mcp`). It is *not* normalised —
+///   callers store whatever URL they actually dispatched to so that
+///   cancellations target the same physical endpoint.
+/// - `backend_request_id` is the request id the backend sees, which may
+///   differ from the gateway-side id when the gateway renames requests
+///   for fan-out.
+///
+/// This is a pure value type: no `Arc`, no interior mutability, no
+/// dependency on the routing layer's transport choice. Infrastructure code
+/// owns the table that maps gateway ids to [`PendingCall`]s.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct PendingCall {
+    /// URL of the backend that is servicing this call.
+    pub backend_url: String,
+    /// Request id as seen by the backend (may differ from the gateway id).
+    pub backend_request_id: String,
+}
+
+impl PendingCall {
+    /// Construct a new [`PendingCall`].
+    ///
+    /// Prefer this over struct-literal construction in new code so that any
+    /// future validation (URL well-formedness, id non-emptiness) has a
+    /// single place to live.
+    pub fn new(backend_url: impl Into<String>, backend_request_id: impl Into<String>) -> Self {
+        Self {
+            backend_url: backend_url.into(),
+            backend_request_id: backend_request_id.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pending_call_new_and_fields() {
+        let c = PendingCall::new("http://127.0.0.1:18812/mcp", "req-42");
+        assert_eq!(c.backend_url, "http://127.0.0.1:18812/mcp");
+        assert_eq!(c.backend_request_id, "req-42");
+    }
+
+    #[test]
+    fn pending_call_equality_is_structural() {
+        let a = PendingCall::new("http://a", "1");
+        let b = PendingCall::new("http://a", "1");
+        let c = PendingCall::new("http://a", "2");
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn pending_call_roundtrip_json() {
+        let c = PendingCall::new("http://127.0.0.1:18812/mcp", "req-7");
+        let s = serde_json::to_string(&c).unwrap();
+        let back: PendingCall = serde_json::from_str(&s).unwrap();
+        assert_eq!(c, back);
+    }
+}

--- a/crates/dcc-mcp-gateway/Cargo.toml
+++ b/crates/dcc-mcp-gateway/Cargo.toml
@@ -10,6 +10,7 @@ description = "Multi-DCC MCP gateway: aggregation, routing, capability index, RE
 
 [dependencies]
 # Internal
+dcc-mcp-gateway-core = { path = "../dcc-mcp-gateway-core" }
 dcc-mcp-jsonrpc = { path = "../dcc-mcp-jsonrpc" }
 dcc-mcp-naming = { path = "../dcc-mcp-naming" }
 dcc-mcp-transport = { path = "../dcc-mcp-transport" }

--- a/crates/dcc-mcp-gateway/src/gateway/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state.rs
@@ -55,11 +55,13 @@ use dcc_mcp_transport::discovery::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceEntr
 use super::middleware::MiddlewareChain;
 
 /// A call that the gateway has forwarded to a backend and is still awaiting.
-#[derive(Debug, Clone)]
-pub struct PendingCall {
-    pub backend_url: String,
-    pub backend_request_id: String,
-}
+///
+/// Re-exported from [`dcc_mcp_gateway_core::PendingCall`] as part of the
+/// Clean-Architecture split (issue #845). The domain type lives in
+/// `dcc-mcp-gateway-core`; this re-export keeps the historical
+/// `crate::gateway::state::PendingCall` / `crate::gateway::PendingCall`
+/// path working for the ~30 files that already import it.
+pub use dcc_mcp_gateway_core::PendingCall;
 
 // ─── Sub-state structs (issue #839) ─────────────────────────────────────────
 //


### PR DESCRIPTION
## Summary

First landing zone for the Clean-Architecture split called for in #845.

`dcc-mcp-gateway-core` hosts the **domain layer** — pure types with no `axum`, `reqwest`, `tokio`, or transport dependency. The dependency direction is strictly inward:

```
dcc-mcp-gateway  (application + infrastructure)
        │
        ▼
dcc-mcp-gateway-core  (domain — this crate)
```

## What moves

This PR moves exactly one type: `PendingCall`. Re-exported from the historical `crate::gateway::state::PendingCall` / `crate::gateway::PendingCall` paths so the ~30 call sites keep compiling unchanged.

### Why `PendingCall` as the seed

Smallest domain primitive in the gateway with zero third-party deps. Picking it as the first type to move lets us verify:

1. The dependency direction (`dcc-mcp-gateway` depends on `dcc-mcp-gateway-core`, never the other way) actually holds end-to-end.
2. Workspace-hack / feature propagation still works.
3. Tests in `dcc-mcp-gateway` still pass with the re-exported type.

Larger types (`CapabilityIndex`, `MiddlewareChain`, registry models) follow in subsequent PRs of the #845 chain — each a small, mechanical review.

## Crate design choices

- **`serde` feature is off by default.** Downstream infra crates only pay for serde codegen when they need it.
- **New `PendingCall::new(...)` constructor** so any future validation (URL well-formedness, id non-emptiness) has a single place to live without changing call sites.
- **`#![forbid(unsafe_code)]`** and **`#![warn(missing_docs)]`** to keep the domain layer disciplined.

## Verification

- `cargo check --workspace` ✅
- `cargo test -p dcc-mcp-gateway-core --all-features` ✅ (3 tests, incl. serde round-trip)
- `cargo test -p dcc-mcp-gateway --lib state::` ✅ (13 tests, re-export works)
- `cargo clippy -p dcc-mcp-gateway-core --all-features --tests -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅

## Follow-up

Subsequent PRs in the #845 chain will migrate `CapabilityIndex`, registry model types, and eventually carve out `dcc-mcp-gateway-app` / `dcc-mcp-gateway-infra`. Each migration stays small and re-exports the moved type to preserve the public API.

Builds on #839 (PR #893). Part of #848 epic.