### PR TITLE
refactor(http): migrate HttpError + HttpResult to dcc-mcp-http-types (#852)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,8 +941,10 @@ name = "dcc-mcp-http-types"
 version = "0.15.7"
 dependencies = [
  "base64",
+ "dcc-mcp-models",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/crates/dcc-mcp-http-types/Cargo.toml
+++ b/crates/dcc-mcp-http-types/Cargo.toml
@@ -15,6 +15,14 @@ categories = ["api-bindings"]
 workspace = true
 
 [dependencies]
+# Internal — DccMcpError is the cross-crate error taxonomy that
+# HttpError bubbles into (issue #488). dcc-mcp-models is itself a
+# pure-types crate, so depending on it here keeps the dependency
+# direction inward.
+dcc-mcp-models = { path = "../dcc-mcp-models" }
+
+# Workspace shared
 serde = { workspace = true }
 base64 = { workspace = true }
 serde_json = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/dcc-mcp-http-types/src/error.rs
+++ b/crates/dcc-mcp-http-types/src/error.rs
@@ -1,0 +1,207 @@
+//! Error types for the MCP HTTP server.
+//!
+//! Migrated to `dcc-mcp-http-types` (issue #852) so external Rust
+//! consumers — REST clients, integration tests, gateway code that maps
+//! HTTP errors into the cross-crate [`DccMcpError`] taxonomy (#488) —
+//! can pull just the error surface without the full HTTP server crate.
+//!
+//! The full `dcc-mcp-http` crate re-exports [`HttpError`] / [`HttpResult`]
+//! from `dcc_mcp_http::error` so historical call sites keep compiling
+//! unchanged.
+
+use dcc_mcp_models::DccMcpError;
+use thiserror::Error;
+
+/// Result type alias for HTTP server operations.
+pub type HttpResult<T> = Result<T, HttpError>;
+
+/// Errors produced by the MCP HTTP server surface.
+///
+/// Variants are intentionally fine-grained so the `axum` layer can map
+/// each one to a precise HTTP status code (see [`Self::status_code`])
+/// and so tests / orchestrators can branch on the cause without parsing
+/// the human-readable message.
+///
+/// # Bubbling into the cross-crate taxonomy
+///
+/// Every variant has a documented mapping into [`DccMcpError`] via the
+/// [`From`] impl below — see issue #488 for the rationale. Add a new
+/// variant only when the existing taxonomy genuinely cannot carry the
+/// caller's branching needs; otherwise extend [`HttpError::Internal`]
+/// with a richer message.
+#[must_use]
+#[derive(Debug, Error)]
+pub enum HttpError {
+    /// The HTTP server is already running on this binding.
+    #[error("server already running")]
+    AlreadyRunning,
+
+    /// The HTTP server has not been started yet.
+    #[error("server not running")]
+    NotRunning,
+
+    /// The TCP listener could not bind to `addr`.
+    #[error("failed to bind to {addr}: {source}")]
+    BindFailed {
+        /// The bind target that failed.
+        addr: String,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The MCP `Mcp-Session-Id` did not resolve to a known session.
+    #[error("session not found: {0}")]
+    SessionNotFound(String),
+
+    /// The MCP `Mcp-Session-Id` failed validation (wrong shape, etc).
+    #[error("invalid session id: {0}")]
+    InvalidSessionId(String),
+
+    /// JSON serialisation / deserialisation error.
+    #[error("JSON serialization error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// The DCC executor channel is closed (the worker exited).
+    #[error("executor channel closed")]
+    ExecutorClosed,
+
+    /// The DCC main-thread queue refused a new task because it is at
+    /// capacity and did not drain within the configured send timeout
+    /// (issue #715).
+    ///
+    /// Distinct from [`Self::ExecutorClosed`] (dispatcher gone) so
+    /// orchestrators can decide between "retry after `retry_after_secs`"
+    /// vs. "fail over to a different backend". `depth` / `capacity` are
+    /// exposed for operator diagnostics.
+    #[error("queue overloaded (depth={depth}/{capacity}); retry in {retry_after_secs}s")]
+    QueueOverloaded {
+        /// Current queue depth at the moment the dispatch was rejected.
+        depth: usize,
+        /// Maximum queue depth.
+        capacity: usize,
+        /// Seconds the caller should wait before retrying.
+        retry_after_secs: u64,
+    },
+
+    /// Action dispatch failed downstream of the HTTP server (e.g. the
+    /// action raised, the bridge cancelled, etc).
+    #[error("action dispatch error: {0}")]
+    Dispatch(String),
+
+    /// The dispatch did not complete within the configured timeout.
+    #[error("request timeout after {ms}ms")]
+    Timeout {
+        /// Configured timeout in milliseconds.
+        ms: u64,
+    },
+
+    /// The action exceeded its rate-limit quota.
+    #[error("rate limit exceeded for action: {0}")]
+    RateLimit(String),
+
+    /// Catch-all for errors that do not fit any other variant. Add a
+    /// new variant rather than reaching for this one when callers need
+    /// to branch on the cause.
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+impl HttpError {
+    /// Convert to an HTTP status code.
+    #[must_use]
+    pub fn status_code(&self) -> u16 {
+        match self {
+            Self::SessionNotFound(_) => 404,
+            Self::InvalidSessionId(_) => 400,
+            Self::RateLimit(_) => 429,
+            Self::AlreadyRunning | Self::NotRunning => 409,
+            Self::Timeout { .. } => 504,
+            Self::QueueOverloaded { .. } => 503,
+            _ => 500,
+        }
+    }
+}
+
+/// Bubble `HttpError` into the shared `DccMcpError` taxonomy (#488).
+///
+/// Maps each fine-grained variant to the closest cross-crate kind so the
+/// gateway / MCP error-code mapping stays consistent regardless of which
+/// crate produced the error.
+impl From<HttpError> for DccMcpError {
+    fn from(err: HttpError) -> Self {
+        match &err {
+            HttpError::SessionNotFound(_) => DccMcpError::NotFound(err.to_string()),
+            HttpError::InvalidSessionId(_) | HttpError::RateLimit(_) => {
+                DccMcpError::Validation(err.to_string())
+            }
+            HttpError::Json(_) => DccMcpError::Serialization(err.to_string()),
+            HttpError::BindFailed { .. } => DccMcpError::Io(err.to_string()),
+            HttpError::Timeout { ms } => DccMcpError::Timeout { ms: *ms },
+            _ => DccMcpError::Internal(err.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_not_found_maps_to_not_found() {
+        let err: DccMcpError = HttpError::SessionNotFound("abc".into()).into();
+        assert!(matches!(err, DccMcpError::NotFound(_)));
+        assert_eq!(err.code(), "not_found");
+    }
+
+    #[test]
+    fn invalid_session_id_maps_to_validation() {
+        let err: DccMcpError = HttpError::InvalidSessionId("bad".into()).into();
+        assert!(matches!(err, DccMcpError::Validation(_)));
+    }
+
+    #[test]
+    fn timeout_carries_ms() {
+        let err: DccMcpError = HttpError::Timeout { ms: 500 }.into();
+        assert!(matches!(err, DccMcpError::Timeout { ms: 500 }));
+    }
+
+    #[test]
+    fn bind_failed_maps_to_io() {
+        let err: DccMcpError = HttpError::BindFailed {
+            addr: "127.0.0.1:0".into(),
+            source: std::io::Error::new(std::io::ErrorKind::AddrInUse, "addr in use"),
+        }
+        .into();
+        assert!(matches!(err, DccMcpError::Io(_)));
+    }
+
+    #[test]
+    fn already_running_maps_to_internal() {
+        let err: DccMcpError = HttpError::AlreadyRunning.into();
+        assert!(matches!(err, DccMcpError::Internal(_)));
+    }
+
+    // ── Status code mapping (regression guards for #488 contract) ──────
+
+    #[test]
+    fn status_codes_match_documented_contract() {
+        assert_eq!(HttpError::SessionNotFound("x".into()).status_code(), 404);
+        assert_eq!(HttpError::InvalidSessionId("x".into()).status_code(), 400);
+        assert_eq!(HttpError::RateLimit("x".into()).status_code(), 429);
+        assert_eq!(HttpError::AlreadyRunning.status_code(), 409);
+        assert_eq!(HttpError::NotRunning.status_code(), 409);
+        assert_eq!(HttpError::Timeout { ms: 1 }.status_code(), 504);
+        assert_eq!(
+            HttpError::QueueOverloaded {
+                depth: 1,
+                capacity: 1,
+                retry_after_secs: 1,
+            }
+            .status_code(),
+            503
+        );
+        assert_eq!(HttpError::ExecutorClosed.status_code(), 500);
+        assert_eq!(HttpError::Internal("x".into()).status_code(), 500);
+    }
+}

--- a/crates/dcc-mcp-http-types/src/lib.rs
+++ b/crates/dcc-mcp-http-types/src/lib.rs
@@ -19,26 +19,32 @@
 //! Consumers in `dcc-mcp-http` re-export these types under their historical
 //! paths so existing call sites keep compiling.
 //!
-//! # What lives here (migration plan)
+//! # Module map
 //!
-//! This is the **first** landing zone of the #852 chain. The current
-//! boundary line:
+//! | Module      | What lives here                                           |
+//! |-------------|-----------------------------------------------------------|
+//! | crate root  | [`TruncationEnvelope`], [`SseChunkFrame`] + chunk helpers |
+//! | [`error`]   | [`HttpError`] / [`HttpResult`] error taxonomy             |
+//!
+//! # Migration plan (issue #852)
+//!
+//! The current boundary line:
 //!
 //! | Lives here now          | Stays in `dcc-mcp-http` for now       |
 //! |-------------------------|----------------------------------------|
 //! | [`TruncationEnvelope`]  | `McpHttpConfig` (needs own split)     |
-//! | [`SseChunkFrame`]       | `HttpError` (depends on `DccMcpError`)|
-//! | [`chunk_sse_data`]      | `JobRecoveryPolicy` / `MinimalModeConfig` |
+//! | [`SseChunkFrame`]       | `JobRecoveryPolicy` / `MinimalModeConfig` |
+//! | [`chunk_sse_data`]      |                                        |
 //! | [`format_chunked_sse`]  |                                        |
+//! | [`error::HttpError`]    |                                        |
 //!
-//! Picking the payload-size / SSE-chunking layer as the seed is
-//! deliberate: they are the smallest, most self-contained wire types in
-//! `dcc-mcp-http`, with only `serde` + `base64` as third-party
-//! dependencies. Migrating them first verifies the direction of the
-//! dependency graph before larger types (`McpHttpConfig` especially) move.
+//! Each new round of #852 PRs migrates one self-contained subsystem at a
+//! time and re-exports it from `dcc-mcp-http` to preserve the public API.
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+
+pub mod error;
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/dcc-mcp-http/src/error.rs
+++ b/crates/dcc-mcp-http/src/error.rs
@@ -1,138 +1,15 @@
 //! Error types for the MCP HTTP server.
+//!
+//! # Relocation notice (issue #852)
+//!
+//! [`HttpError`] / [`HttpResult`] were migrated to the dedicated
+//! [`dcc_mcp_http_types::error`] module as part of the `dcc-mcp-http`
+//! Clean-Architecture split. This module now re-exports them so existing
+//! call sites (`crate::error::HttpError`, `crate::error::HttpResult`)
+//! keep compiling under their historical paths; the canonical
+//! definitions live in `dcc-mcp-http-types`.
+//!
+//! New code should depend on `dcc-mcp-http-types` directly when it only
+//! needs the error surface.
 
-use dcc_mcp_models::DccMcpError;
-use thiserror::Error;
-
-/// Result type alias for HTTP server operations.
-pub type HttpResult<T> = Result<T, HttpError>;
-
-#[must_use]
-#[derive(Debug, Error)]
-pub enum HttpError {
-    #[error("server already running")]
-    AlreadyRunning,
-
-    #[error("server not running")]
-    NotRunning,
-
-    #[error("failed to bind to {addr}: {source}")]
-    BindFailed {
-        addr: String,
-        #[source]
-        source: std::io::Error,
-    },
-
-    #[error("session not found: {0}")]
-    SessionNotFound(String),
-
-    #[error("invalid session id: {0}")]
-    InvalidSessionId(String),
-
-    #[error("JSON serialization error: {0}")]
-    Json(#[from] serde_json::Error),
-
-    #[error("executor channel closed")]
-    ExecutorClosed,
-
-    /// The DCC main-thread queue refused a new task because it is at
-    /// capacity and did not drain within the configured send timeout
-    /// (issue #715).
-    ///
-    /// Distinct from [`Self::ExecutorClosed`] (dispatcher gone) so
-    /// orchestrators can decide between "retry after `retry_after_secs`"
-    /// vs. "fail over to a different backend". `depth` / `capacity` are
-    /// exposed for operator diagnostics.
-    #[error("queue overloaded (depth={depth}/{capacity}); retry in {retry_after_secs}s")]
-    QueueOverloaded {
-        depth: usize,
-        capacity: usize,
-        retry_after_secs: u64,
-    },
-
-    #[error("action dispatch error: {0}")]
-    Dispatch(String),
-
-    #[error("request timeout after {ms}ms")]
-    Timeout { ms: u64 },
-
-    #[error("rate limit exceeded for action: {0}")]
-    RateLimit(String),
-
-    #[error("internal error: {0}")]
-    Internal(String),
-}
-
-impl HttpError {
-    /// Convert to an HTTP status code.
-    pub fn status_code(&self) -> u16 {
-        match self {
-            Self::SessionNotFound(_) => 404,
-            Self::InvalidSessionId(_) => 400,
-            Self::RateLimit(_) => 429,
-            Self::AlreadyRunning | Self::NotRunning => 409,
-            Self::Timeout { .. } => 504,
-            Self::QueueOverloaded { .. } => 503,
-            _ => 500,
-        }
-    }
-}
-
-/// Bubble `HttpError` into the shared `DccMcpError` taxonomy (#488).
-///
-/// Maps each fine-grained variant to the closest cross-crate kind so the
-/// gateway / MCP error-code mapping stays consistent regardless of which
-/// crate produced the error.
-impl From<HttpError> for DccMcpError {
-    fn from(err: HttpError) -> Self {
-        match &err {
-            HttpError::SessionNotFound(_) => DccMcpError::NotFound(err.to_string()),
-            HttpError::InvalidSessionId(_) | HttpError::RateLimit(_) => {
-                DccMcpError::Validation(err.to_string())
-            }
-            HttpError::Json(_) => DccMcpError::Serialization(err.to_string()),
-            HttpError::BindFailed { .. } => DccMcpError::Io(err.to_string()),
-            HttpError::Timeout { ms } => DccMcpError::Timeout { ms: *ms },
-            _ => DccMcpError::Internal(err.to_string()),
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn session_not_found_maps_to_not_found() {
-        let err: DccMcpError = HttpError::SessionNotFound("abc".into()).into();
-        assert!(matches!(err, DccMcpError::NotFound(_)));
-        assert_eq!(err.code(), "not_found");
-    }
-
-    #[test]
-    fn invalid_session_id_maps_to_validation() {
-        let err: DccMcpError = HttpError::InvalidSessionId("bad".into()).into();
-        assert!(matches!(err, DccMcpError::Validation(_)));
-    }
-
-    #[test]
-    fn timeout_carries_ms() {
-        let err: DccMcpError = HttpError::Timeout { ms: 500 }.into();
-        assert!(matches!(err, DccMcpError::Timeout { ms: 500 }));
-    }
-
-    #[test]
-    fn bind_failed_maps_to_io() {
-        let err: DccMcpError = HttpError::BindFailed {
-            addr: "127.0.0.1:0".into(),
-            source: std::io::Error::new(std::io::ErrorKind::AddrInUse, "addr in use"),
-        }
-        .into();
-        assert!(matches!(err, DccMcpError::Io(_)));
-    }
-
-    #[test]
-    fn already_running_maps_to_internal() {
-        let err: DccMcpError = HttpError::AlreadyRunning.into();
-        assert!(matches!(err, DccMcpError::Internal(_)));
-    }
-}
+pub use dcc_mcp_http_types::error::{HttpError, HttpResult};


### PR DESCRIPTION
## Summary

Second migration in the **#852 chain**. Moves the HTTP error taxonomy into `dcc-mcp-http-types` so external Rust consumers — REST clients, integration tests, gateway code that maps HTTP errors into the cross-crate `DccMcpError` taxonomy (#488) — can pull just the error surface without the full HTTP server crate.

## What moves

| Symbol | Now at | Old path (re-exported) |
|---|---|---|
| `HttpError` (12 variants) | `dcc_mcp_http_types::error::HttpError` | `dcc_mcp_http::error::HttpError` / `dcc_mcp_http::HttpError` |
| `HttpResult<T>` | `dcc_mcp_http_types::error::HttpResult` | `dcc_mcp_http::error::HttpResult` |
| `HttpError::status_code` | same | same |
| `From<HttpError> for DccMcpError` | same | same |

`crates/dcc-mcp-http/src/error.rs` is now a re-export shim. The historical paths (`crate::error::HttpError`, `crate::error::HttpResult`, `dcc_mcp_http::HttpError`) keep compiling unchanged across the 14 places in the HTTP crate that touch these types.

## Cargo.toml additions for `dcc-mcp-http-types`

- `thiserror` (workspace) — `HttpError` uses `#[derive(Error)]`.
- `dcc-mcp-models` (path internal) — `DccMcpError` is the cross-crate error taxonomy. `dcc-mcp-models` is itself a pure-types crate (no `axum` / `tokio` / `reqwest`), so the dependency direction stays strictly inward.

## Documentation discipline

`error.rs` spells out each variant's responsibility and adds an explicit contract for adding new variants — "only when `DccMcpError` genuinely cannot carry the caller's branching needs" — so the taxonomy does not sprawl as more handlers land.

## New regression test

Plus all 5 existing tests carried over verbatim:

- `status_codes_match_documented_contract` — pins every variant's HTTP status code so the #488 mapping cannot silently drift when a new variant is added.

## Verification

- `cargo check --workspace` ✅
- `cargo test -p dcc-mcp-http-types` ✅ (18 total: 12 prior + 6 error)
- `cargo test -p dcc-mcp-http --lib` ✅ (225 tests)
- `cargo clippy -p dcc-mcp-http-types --all-targets -- -D warnings` ✅
- `cargo clippy -p dcc-mcp-http --no-deps -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅

## Follow-up

Next in the #852 chain: `JobRecoveryPolicy` and `MinimalModeConfig` (small self-contained config types), then `McpHttpConfig` carved up along the four DccServerOptions axes (gateway / observability / execution / diagnostics).

Builds on #895 (#852 part 1) and #896 (#845 part 2). Part of #848 epic.