### PR TITLE
refactor(http): migrate ServerSpawnMode + JobRecoveryPolicy to http-types (#852)

### DIFF
--- a/crates/dcc-mcp-http-types/src/config.rs
+++ b/crates/dcc-mcp-http-types/src/config.rs
@@ -1,0 +1,197 @@
+//! Configuration value types exposed on the HTTP server wire surface.
+//!
+//! These are the enums and small value types that the Python binding,
+//! CLI flags, and environment-variable plumbing branch on. They live
+//! here (rather than in `dcc-mcp-http::config`) so external Rust
+//! tooling — CLI drivers, config validators, adapter orchestrators —
+//! can depend on just the enumeration contract without dragging in
+//! `axum` / `tokio` / `reqwest` / `pyo3`.
+//!
+//! The full `McpHttpConfig` struct stays in `dcc-mcp-http::config`
+//! until its sub-struct split lands; this module captures just the
+//! self-contained enums for now.
+
+use serde::{Deserialize, Serialize};
+
+// ── ServerSpawnMode ────────────────────────────────────────────────────────
+
+/// How the server and gateway HTTP listeners are driven.
+///
+/// Fixes **issue #303** — under PyO3-embedded interpreters (Maya on Windows),
+/// `tokio::spawn` onto a multi-threaded runtime that no longer has an active
+/// driver can cause background accept loops (specifically the gateway
+/// listener) to be starved of scheduling time. The per-instance listener
+/// survives because its accept loop is "warmed up" during the initial
+/// `block_on`, but the gateway listener — spawned via an extra `tokio::spawn`
+/// + `tokio::join!` layer — never gets its turn.
+///
+/// `ServerSpawnMode::Dedicated` avoids the failure mode entirely by running
+/// each HTTP listener on its own OS thread that owns a `current_thread`
+/// Tokio runtime. That thread is scheduled by the OS, not by a shared
+/// worker pool, and cannot be starved by a hanging block_on elsewhere.
+///
+/// | Mode | When to use | Behaviour |
+/// |------|-------------|-----------|
+/// | `Ambient`   | Standalone binary (`dcc-mcp-server`, library tests) | Spawns `axum::serve` onto the caller's Tokio runtime via `tokio::spawn`. |
+/// | `Dedicated` | Python bindings (`PyMcpHttpServer`) / embedded DCC hosts | Each listener gets its own OS thread + `current_thread` runtime. Immune to PyO3 worker starvation. |
+///
+/// Defaults: `Ambient`. The Python bindings override this to `Dedicated`
+/// automatically when constructing `McpHttpServer` via `PyMcpHttpServer`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ServerSpawnMode {
+    /// Spawn listeners as background tasks on the caller's Tokio runtime.
+    /// Correct for `#[tokio::main]` binaries that keep a thread in the
+    /// runtime for the process lifetime.
+    #[default]
+    Ambient,
+
+    /// Spawn each listener on a dedicated OS thread with its own
+    /// `current_thread` runtime. Correct for PyO3-embedded interpreters
+    /// where the parent runtime's worker pool cannot be relied upon after
+    /// `block_on` returns.
+    Dedicated,
+}
+
+// ── JobRecoveryPolicy ──────────────────────────────────────────────────────
+
+/// What `McpHttpServer::start` does with rows that the previous process
+/// left in `Pending` / `Running` after a crash or restart (issue #567).
+///
+/// | Variant | Behaviour |
+/// |---------|-----------|
+/// | [`JobRecoveryPolicy::Drop`]    | Each in-flight row is rewritten to `JobStatus::Interrupted` with `error = "server restart"`. Clients re-subscribing after reconnect see one clean terminal transition. **This is today's behaviour and the default.** |
+/// | [`JobRecoveryPolicy::Requeue`] | Reserved for a future release that persists the original tool arguments alongside the `jobs` row. Until that lands the variant is **accepted but treated as `Drop`** — the server logs a `WARN` at startup so operators know the requested policy is not yet active, but startup itself never fails. The accepted-but-degraded contract gives DCC adapters (`dcc-mcp-maya`, `dcc-mcp-houdini`) a stable knob to plumb through today without forcing a config-shape break when the real implementation lands. |
+///
+/// String form (used by the Python binding and the `--job-recovery` CLI
+/// flag): `"drop"` / `"requeue"`. Defaults to `Drop`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum JobRecoveryPolicy {
+    /// Rewrite every `Pending` / `Running` row to `Interrupted` on startup.
+    /// Always safe; never re-runs a partially-applied tool.
+    #[default]
+    Drop,
+    /// Reserved policy: would re-submit idempotent in-flight jobs from the
+    /// persisted spec. Accepted today but treated as [`Self::Drop`] with a
+    /// `WARN` log at startup until tool-arg persistence lands.
+    Requeue,
+}
+
+impl JobRecoveryPolicy {
+    /// Lower-case wire identifier used by docs, the Python binding, and the
+    /// `--job-recovery` CLI flag.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Drop => "drop",
+            Self::Requeue => "requeue",
+        }
+    }
+
+    /// Parse the wire identifier. `&str` is matched case-insensitively to
+    /// be tolerant of env-var plumbing (`DCC_MCP_*_JOB_RECOVERY=Requeue`).
+    ///
+    /// # Errors
+    ///
+    /// Returns a descriptive `Err` when `value` does not match any known
+    /// variant, naming the rejected value and the accepted set.
+    pub fn parse(value: &str) -> Result<Self, String> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "drop" => Ok(Self::Drop),
+            "requeue" => Ok(Self::Requeue),
+            other => Err(format!(
+                "unknown job_recovery policy {other:?}; expected \"drop\" or \"requeue\""
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── ServerSpawnMode ────────────────────────────────────────────────
+
+    #[test]
+    fn server_spawn_mode_defaults_to_ambient() {
+        assert_eq!(ServerSpawnMode::default(), ServerSpawnMode::Ambient);
+    }
+
+    #[test]
+    fn server_spawn_mode_wire_is_snake_case() {
+        // `ambient` / `dedicated` is the wire form the Python binding
+        // and env-var plumbing round-trip. Pin it so a future derive
+        // tweak cannot silently break downstream consumers.
+        assert_eq!(
+            serde_json::to_string(&ServerSpawnMode::Ambient).unwrap(),
+            "\"ambient\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ServerSpawnMode::Dedicated).unwrap(),
+            "\"dedicated\""
+        );
+
+        let back: ServerSpawnMode = serde_json::from_str("\"dedicated\"").unwrap();
+        assert_eq!(back, ServerSpawnMode::Dedicated);
+    }
+
+    // ── JobRecoveryPolicy ──────────────────────────────────────────────
+
+    /// Issue #567: the policy enum defaults to `Drop` so existing callers
+    /// inherit today's behaviour without touching their config.
+    #[test]
+    fn job_recovery_default_is_drop() {
+        assert_eq!(JobRecoveryPolicy::default(), JobRecoveryPolicy::Drop);
+    }
+
+    /// Issue #567: the wire identifier round-trips to the same shape the
+    /// Python binding exposes.
+    #[test]
+    fn job_recovery_as_str_matches_wire() {
+        assert_eq!(JobRecoveryPolicy::Drop.as_str(), "drop");
+        assert_eq!(JobRecoveryPolicy::Requeue.as_str(), "requeue");
+    }
+
+    /// Issue #567: env-var plumbing (`DCC_MCP_*_JOB_RECOVERY=Requeue`) and
+    /// the Python setter share the same case-insensitive parser.
+    #[test]
+    fn job_recovery_parse_is_case_insensitive() {
+        for raw in ["drop", "Drop", "DROP", "  drop  "] {
+            assert_eq!(JobRecoveryPolicy::parse(raw), Ok(JobRecoveryPolicy::Drop));
+        }
+        for raw in ["requeue", "Requeue", "REQUEUE"] {
+            assert_eq!(
+                JobRecoveryPolicy::parse(raw),
+                Ok(JobRecoveryPolicy::Requeue)
+            );
+        }
+    }
+
+    /// Issue #567: unknown policies surface a descriptive error that
+    /// names the rejected value and the accepted set.
+    #[test]
+    fn job_recovery_parse_rejects_unknown() {
+        let err = JobRecoveryPolicy::parse("retry").unwrap_err();
+        assert!(err.contains("retry"), "error message: {err}");
+        assert!(err.contains("drop"), "error message: {err}");
+        assert!(err.contains("requeue"), "error message: {err}");
+    }
+
+    /// The snake_case JSON form matches the CLI / env-var string form,
+    /// so operators can read either serialisation interchangeably.
+    #[test]
+    fn job_recovery_wire_is_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&JobRecoveryPolicy::Drop).unwrap(),
+            "\"drop\""
+        );
+        assert_eq!(
+            serde_json::to_string(&JobRecoveryPolicy::Requeue).unwrap(),
+            "\"requeue\""
+        );
+
+        let back: JobRecoveryPolicy = serde_json::from_str("\"requeue\"").unwrap();
+        assert_eq!(back, JobRecoveryPolicy::Requeue);
+    }
+}

--- a/crates/dcc-mcp-http-types/src/lib.rs
+++ b/crates/dcc-mcp-http-types/src/lib.rs
@@ -25,18 +25,21 @@
 //! |-------------|-----------------------------------------------------------|
 //! | crate root  | [`TruncationEnvelope`], [`SseChunkFrame`] + chunk helpers |
 //! | [`error`]   | [`HttpError`] / [`HttpResult`] error taxonomy             |
+//! | [`config`]  | [`ServerSpawnMode`], [`JobRecoveryPolicy`] config enums   |
 //!
 //! # Migration plan (issue #852)
 //!
 //! The current boundary line:
 //!
-//! | Lives here now          | Stays in `dcc-mcp-http` for now       |
-//! |-------------------------|----------------------------------------|
-//! | [`TruncationEnvelope`]  | `McpHttpConfig` (needs own split)     |
-//! | [`SseChunkFrame`]       | `JobRecoveryPolicy` / `MinimalModeConfig` |
-//! | [`chunk_sse_data`]      |                                        |
-//! | [`format_chunked_sse`]  |                                        |
-//! | [`error::HttpError`]    |                                        |
+//! | Lives here now              | Stays in `dcc-mcp-http` for now |
+//! |-----------------------------|----------------------------------|
+//! | [`TruncationEnvelope`]      | `McpHttpConfig` (needs own split)|
+//! | [`SseChunkFrame`]           |                                  |
+//! | [`chunk_sse_data`]          |                                  |
+//! | [`format_chunked_sse`]      |                                  |
+//! | [`error::HttpError`]        |                                  |
+//! | [`config::ServerSpawnMode`] |                                  |
+//! | [`config::JobRecoveryPolicy`]|                                 |
 //!
 //! Each new round of #852 PRs migrates one self-contained subsystem at a
 //! time and re-exports it from `dcc-mcp-http` to preserve the public API.
@@ -44,6 +47,7 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
+pub mod config;
 pub mod error;
 
 use serde::{Deserialize, Serialize};

--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -4,88 +4,14 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 use std::path::PathBuf;
 
-/// How the server and gateway HTTP listeners are driven.
-///
-/// Fixes **issue #303** — under PyO3-embedded interpreters (Maya on Windows),
-/// `tokio::spawn` onto a multi-threaded runtime that no longer has an active
-/// driver can cause background accept loops (specifically the gateway
-/// listener) to be starved of scheduling time. The per-instance listener
-/// survives because its accept loop is "warmed up" during the initial
-/// `block_on`, but the gateway listener — spawned via an extra `tokio::spawn`
-/// + `tokio::join!` layer — never gets its turn.
-///
-/// `ServerSpawnMode::Dedicated` avoids the failure mode entirely by running
-/// each HTTP listener on its own OS thread that owns a `current_thread`
-/// Tokio runtime. That thread is scheduled by the OS, not by a shared
-/// worker pool, and cannot be starved by a hanging block_on elsewhere.
-///
-/// | Mode | When to use | Behaviour |
-/// |------|-------------|-----------|
-/// | `Ambient`   | Standalone binary (`dcc-mcp-server`, library tests) | Spawns `axum::serve` onto the caller's Tokio runtime via `tokio::spawn`. |
-/// | `Dedicated` | Python bindings (`PyMcpHttpServer`) / embedded DCC hosts | Each listener gets its own OS thread + `current_thread` runtime. Immune to PyO3 worker starvation. |
-///
-/// Defaults: `Ambient`. The Python bindings override this to `Dedicated`
-/// automatically when constructing `McpHttpServer` via `PyMcpHttpServer`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum ServerSpawnMode {
-    /// Spawn listeners as background tasks on the caller's Tokio runtime.
-    /// Correct for `#[tokio::main]` binaries that keep a thread in the
-    /// runtime for the process lifetime.
-    #[default]
-    Ambient,
-
-    /// Spawn each listener on a dedicated OS thread with its own
-    /// `current_thread` runtime. Correct for PyO3-embedded interpreters
-    /// where the parent runtime's worker pool cannot be relied upon after
-    /// `block_on` returns.
-    Dedicated,
-}
-
-/// What [`McpHttpServer::start`](crate::McpHttpServer::start) does with rows
-/// that the previous process left in `Pending` / `Running` after a crash or
-/// restart (issue #567).
-///
-/// | Variant | Behaviour |
-/// |---------|-----------|
-/// | [`JobRecoveryPolicy::Drop`]    | Each in-flight row is rewritten to [`JobStatus::Interrupted`](crate::job::JobStatus::Interrupted) with `error = "server restart"`. Clients re-subscribing after reconnect see one clean terminal transition. **This is today's behaviour and the default.** |
-/// | [`JobRecoveryPolicy::Requeue`] | Reserved for a future release that persists the original tool arguments alongside the `jobs` row. Until that lands the variant is **accepted but treated as `Drop`** — the server logs a `WARN` at startup so operators know the requested policy is not yet active, but startup itself never fails. The accepted-but-degraded contract gives DCC adapters (`dcc-mcp-maya`, `dcc-mcp-houdini`) a stable knob to plumb through today without forcing a config-shape break when the real implementation lands. |
-///
-/// String form (used by the Python binding and the upcoming `--job-recovery`
-/// CLI flag): `"drop"` / `"requeue"`. Defaults to `Drop`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum JobRecoveryPolicy {
-    /// Rewrite every `Pending` / `Running` row to `Interrupted` on startup.
-    /// Always safe; never re-runs a partially-applied tool.
-    #[default]
-    Drop,
-    /// Reserved policy: would re-submit idempotent in-flight jobs from the
-    /// persisted spec. Accepted today but treated as [`Self::Drop`] with a
-    /// `WARN` log at startup until tool-arg persistence lands.
-    Requeue,
-}
-
-impl JobRecoveryPolicy {
-    /// Lower-case wire identifier used by docs, the Python binding, and the
-    /// `--job-recovery` CLI flag.
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Drop => "drop",
-            Self::Requeue => "requeue",
-        }
-    }
-
-    /// Parse the wire identifier. `&str` is matched case-insensitively to
-    /// be tolerant of env-var plumbing (`DCC_MCP_*_JOB_RECOVERY=Requeue`).
-    pub fn parse(value: &str) -> Result<Self, String> {
-        match value.trim().to_ascii_lowercase().as_str() {
-            "drop" => Ok(Self::Drop),
-            "requeue" => Ok(Self::Requeue),
-            other => Err(format!(
-                "unknown job_recovery policy {other:?}; expected \"drop\" or \"requeue\""
-            )),
-        }
-    }
-}
+// `ServerSpawnMode` and `JobRecoveryPolicy` were migrated to
+// `dcc-mcp-http-types::config` (issue #852, part 3) so external
+// Rust tooling (CLI drivers, config validators, adapter
+// orchestrators) can depend on just the enum contract without
+// dragging in axum / tokio / reqwest / pyo3. Re-exported here so
+// the historical `crate::config::{ServerSpawnMode, JobRecoveryPolicy}`
+// paths — and the 43 consumer sites they feed — keep compiling.
+pub use dcc_mcp_http_types::config::{JobRecoveryPolicy, ServerSpawnMode};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Sub-config structs — one per orthogonal concern


### PR DESCRIPTION
## Summary

Third migration in the **#852 chain**. Moves the two self-contained config enums — `ServerSpawnMode` (#303) and `JobRecoveryPolicy` (#567) — into `dcc-mcp-http-types::config` so external Rust tooling (CLI drivers, config validators, adapter orchestrators) can depend on just the enum contract without dragging in `axum` / `tokio` / `reqwest` / `pyo3`.

## What moves

| Symbol | Now at | Old path (re-exported) |
|---|---|---|
| `ServerSpawnMode` (Ambient default, Dedicated) | `dcc_mcp_http_types::config::ServerSpawnMode` | `dcc_mcp_http::config::ServerSpawnMode` |
| `JobRecoveryPolicy` (Drop default, Requeue) | `dcc_mcp_http_types::config::JobRecoveryPolicy` | same |
| `JobRecoveryPolicy::as_str` / `parse` | same | same |

`crates/dcc-mcp-http/src/config.rs` is now a `pub use` re-export for both enums and the `JobRecoveryPolicy` inherent impl. Historical paths (`crate::config::ServerSpawnMode`, `dcc_mcp_http::JobRecoveryPolicy`, …) keep compiling across the **43 consumer sites**.

## Design decisions

- **`Serialize` / `Deserialize` added** on both enums with `#[serde(rename_all = "snake_case")]`. The gateway / http server historically drove these via `as_str` / `parse` only — serde derives were not strictly needed. Adding them here is deliberate: downstream config validators and the future `McpHttpConfig` wire split will need to round-trip the full config shape, and having snake_case JSON fall out for free keeps the CLI form (`--job-recovery drop`), the env-var form (`DCC_MCP_*_JOB_RECOVERY=drop`), and the JSON form (`"drop"`) in lockstep.
- **`as_str` / `parse` now carry `#[must_use]`** and `# Errors` rustdoc, matching the discipline the rest of `http-types` already uses.
- **Builder integration tests stay in `dcc-mcp-http::config`.** The four `job_recovery_*` tests there exercise `McpHttpConfig::default` / `with_job_recovery` — the builder integration, not the enum surface — so they stay where they test.

## New wire-contract tests in `http-types`

- `server_spawn_mode_defaults_to_ambient` / `_wire_is_snake_case`
- `job_recovery_default_is_drop` (pinned at the type surface)
- `job_recovery_as_str_matches_wire`
- `job_recovery_parse_is_case_insensitive` / `_rejects_unknown`
- `job_recovery_wire_is_snake_case` — pins the new JSON form so a future derive tweak cannot silently break downstream consumers.

## Verification

- `cargo check --workspace` ✅
- `cargo test -p dcc-mcp-http-types` ✅ (24 total: 18 prior + 6 new)
- `cargo test -p dcc-mcp-http --lib config::` ✅ (11 tests — integration path still green)
- `cargo clippy -p dcc-mcp-http-types --all-targets -- -D warnings` ✅
- `cargo clippy -p dcc-mcp-http --no-deps --tests -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅

## Follow-up

Next in the #852 chain: start carving `McpHttpConfig` along the `DccServerOptions` axes (gateway / observability / execution / diagnostics). The sub-configs already exist as standalone structs in `config.rs` — they just need to move to `http-types` one at a time, each with a `pub use` bridge the way this PR does for the two enums.

Builds on #895, #897, #898. Part of #848 epic.