### PR TITLE
refactor(gateway): migrate IndexSnapshot + InstanceFingerprint to gateway-core (#845)

### DIFF
--- a/crates/dcc-mcp-gateway-core/src/capability/index.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/index.rs
@@ -1,0 +1,159 @@
+//! Pure value types describing the gateway capability index snapshot.
+//!
+//! These are the *read-side* shapes a REST or MCP handler sees when it
+//! takes a snapshot of the capability index. The mutable
+//! `CapabilityIndex` itself — which owns a `parking_lot::RwLock` and a
+//! `BTreeMap` of per-instance state — stays in `dcc-mcp-gateway`
+//! because it carries runtime state the domain layer has no business
+//! holding (issue #845).
+//!
+//! # Why split snapshot from index
+//!
+//! The snapshot is what every search / dispatch / diagnostics path
+//! actually consumes; it is a small, immutable, `Clone`-cheap value
+//! built atop `Arc<[CapabilityRecord]>`. Moving it here lets external
+//! Rust tooling (CLI inspectors, integration tests, REST clients that
+//! cache the most recent snapshot) work with the gateway index shape
+//! without depending on the gateway crate's tokio / axum / parking_lot
+//! footprint.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use uuid::Uuid;
+
+use super::record::CapabilityRecord;
+
+/// Stable fingerprint of one instance's contribution to the index.
+///
+/// The fingerprint is used by the gateway's refresh loop to
+/// short-circuit rebuilds when the backend replied with the exact
+/// same `tools/list` shape as the previous refresh — in that case
+/// there is nothing to update and we can skip the full swap.
+///
+/// The representation is deliberately small: the builder computes a
+/// content hash of the backend's tool list, and the index stores just
+/// that hash so comparisons are O(1).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct InstanceFingerprint(pub u64);
+
+/// Owned snapshot of the capability index returned to REST / MCP
+/// callers.
+///
+/// Cloning an `IndexSnapshot` is cheap: the backing `Arc<[...]>`
+/// shares the underlying allocation across every reader that took the
+/// snapshot within the same window, so a `search_tools` call handling
+/// a large `limit` does not pay for a deep copy.
+#[derive(Debug, Clone, Default)]
+pub struct IndexSnapshot {
+    /// All live capability records, ordered by `(dcc_type, slug)` for
+    /// a stable human-readable output — the gateway builder places
+    /// them in that order on every swap so callers do not need to
+    /// sort.
+    pub records: Arc<[CapabilityRecord]>,
+    /// Per-instance fingerprint seen at snapshot time. Included so
+    /// diagnostics can trace which `refresh_instance` cycles produced
+    /// which snapshot.
+    pub fingerprints: HashMap<Uuid, InstanceFingerprint>,
+}
+
+impl IndexSnapshot {
+    /// Convenience predicate for diagnostics.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+
+    /// Resolve a capability record by its slug in O(n). The index is
+    /// bounded (every live backend × ~tens of actions) so the linear
+    /// scan is the right default; a hash map would add per-refresh
+    /// cost without a proven win until indices exceed ~10 k records.
+    #[must_use]
+    pub fn find_by_slug(&self, slug: &str) -> Option<&CapabilityRecord> {
+        self.records.iter().find(|r| r.tool_slug == slug)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_record(slug: &str) -> CapabilityRecord {
+        CapabilityRecord::new(
+            slug.to_owned(),
+            "stub".into(),
+            "stub".into(),
+            None,
+            "",
+            vec![],
+            "maya".into(),
+            Uuid::nil(),
+            false,
+            false,
+        )
+    }
+
+    #[test]
+    fn fingerprint_default_is_zero() {
+        assert_eq!(InstanceFingerprint::default(), InstanceFingerprint(0));
+    }
+
+    #[test]
+    fn fingerprint_is_value_equal() {
+        // The whole point of the fingerprint is to short-circuit
+        // rebuilds via `==`; pin the structural-equality contract.
+        assert_eq!(InstanceFingerprint(42), InstanceFingerprint(42));
+        assert_ne!(InstanceFingerprint(42), InstanceFingerprint(43));
+    }
+
+    #[test]
+    fn snapshot_default_is_empty() {
+        let snap = IndexSnapshot::default();
+        assert!(snap.is_empty());
+        assert!(snap.fingerprints.is_empty());
+        assert_eq!(snap.records.len(), 0);
+    }
+
+    #[test]
+    fn snapshot_find_by_slug_returns_first_match() {
+        let snap = IndexSnapshot {
+            records: Arc::from(vec![
+                make_record("maya.abcdef01.create_sphere"),
+                make_record("maya.abcdef01.create_cube"),
+            ]),
+            fingerprints: HashMap::new(),
+        };
+        let hit = snap.find_by_slug("maya.abcdef01.create_cube");
+        assert!(hit.is_some());
+        assert_eq!(hit.unwrap().tool_slug, "maya.abcdef01.create_cube");
+        assert!(snap.find_by_slug("maya.abcdef01.missing").is_none());
+    }
+
+    #[test]
+    fn snapshot_clone_shares_records_allocation() {
+        let snap = IndexSnapshot {
+            records: Arc::from(vec![make_record("x.abcdef01.a")]),
+            fingerprints: HashMap::new(),
+        };
+        let snap2 = snap.clone();
+        // Arc is the cheap-clone contract callers rely on; verify the
+        // backing allocation is shared, not deep-copied.
+        assert!(Arc::ptr_eq(&snap.records, &snap2.records));
+    }
+
+    #[test]
+    fn snapshot_carries_per_instance_fingerprints() {
+        let iid = Uuid::parse_str("abcdef0123456789abcdef0123456789").unwrap();
+        let mut fingerprints = HashMap::new();
+        fingerprints.insert(iid, InstanceFingerprint(0xdead_beef));
+
+        let snap = IndexSnapshot {
+            records: Arc::from(Vec::<CapabilityRecord>::new()),
+            fingerprints,
+        };
+        assert_eq!(
+            snap.fingerprints.get(&iid),
+            Some(&InstanceFingerprint(0xdead_beef))
+        );
+    }
+}

--- a/crates/dcc-mcp-gateway-core/src/capability/mod.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/mod.rs
@@ -1,25 +1,29 @@
-//! Capability records and search wire types.
+//! Capability records and search/index wire types.
 //!
 //! # Module map
 //!
-//! | Submodule    | What lives here                                        |
-//! |--------------|--------------------------------------------------------|
-//! | [`record`]   | `CapabilityRecord`, slug encoding / parsing, validation|
-//! | [`search`]   | `SearchQuery`, `SearchHit`, `SearchPage`, `SearchMode` |
+//! | Submodule    | What lives here                                              |
+//! |--------------|--------------------------------------------------------------|
+//! | [`record`]   | `CapabilityRecord`, slug encoding / parsing, validation      |
+//! | [`search`]   | `SearchQuery`, `SearchHit`, `SearchPage`, `SearchMode`       |
+//! | [`index`]    | `IndexSnapshot`, `InstanceFingerprint` — read-side snapshot  |
 //!
-//! The search function that joins a `SearchQuery` against a live
-//! capability index lives in `dcc-mcp-gateway` because it needs the
-//! `IndexSnapshot` runtime type. Only the *wire types* — query
-//! parameters, result rows, pagination envelope — live here so any
-//! REST client talking to the gateway can deserialise responses
-//! without pulling the full gateway crate.
+//! The mutable `CapabilityIndex` (which owns a `parking_lot::RwLock`
+//! and a `BTreeMap` of per-instance state) and the search ranking
+//! function (which depends on the pluggable `Scorer` trait) both live
+//! in `dcc-mcp-gateway` because they carry runtime state the domain
+//! layer has no business holding. Only the *wire types* — query
+//! parameters, result rows, pagination envelope, snapshot view — live
+//! here so any REST client talking to the gateway can deserialise
+//! responses without pulling the full gateway crate.
 
+pub mod index;
 pub mod record;
 pub mod search;
 
-// Re-export the record module's public surface from the capability
+// Re-export each submodule's public surface from the capability
 // facade so historical paths (`dcc_mcp_gateway_core::capability::
 // CapabilityRecord` etc.) keep working verbatim.
+pub use index::{IndexSnapshot, InstanceFingerprint};
 pub use record::{CapabilityRecord, SCHEMA_AVAILABLE, is_valid_dcc_bucket, parse_slug, tool_slug};
-
 pub use search::{DEFAULT_LIMIT, MAX_LIMIT, SearchHit, SearchMode, SearchPage, SearchQuery};

--- a/crates/dcc-mcp-gateway/src/gateway/capability/index.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/index.rs
@@ -10,6 +10,16 @@
 //! The external callers never hold a lock guard across an `.await`
 //! point — every public method returns an owned snapshot or a closure
 //! result so the lock never escapes the call stack.
+//!
+//! # Read-side wire types (issue #845)
+//!
+//! [`InstanceFingerprint`] and [`IndexSnapshot`] were migrated to
+//! [`dcc_mcp_gateway_core::capability::index`] so external Rust
+//! tooling can consume the snapshot shape without depending on this
+//! crate's tokio / axum / parking_lot footprint. They are re-exported
+//! below to keep the historical
+//! `crate::gateway::capability::index::{InstanceFingerprint,
+//! IndexSnapshot}` paths working unchanged.
 
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
@@ -19,51 +29,7 @@ use uuid::Uuid;
 
 use super::record::CapabilityRecord;
 
-/// Stable fingerprint of one instance's contribution to the index.
-///
-/// The fingerprint is used by [`super::refresh`] to short-circuit
-/// rebuilds when the backend replied with the exact same
-/// `tools/list` shape as the previous refresh — in that case there is
-/// nothing to update and we can skip the full swap.
-///
-/// The representation is deliberately small: the builder computes a
-/// content hash of the backend's tool list, and the index stores just
-/// that hash so comparisons are O(1).
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
-pub struct InstanceFingerprint(pub u64);
-
-/// Owned snapshot of the index returned to REST / MCP callers.
-///
-/// Cloning an `IndexSnapshot` is cheap: the backing `Arc<[...]>`
-/// shares the underlying allocation across every reader that took the
-/// snapshot within the same window, so a `search_tools` call handling
-/// a large `limit` does not pay for a deep copy.
-#[derive(Debug, Clone, Default)]
-pub struct IndexSnapshot {
-    /// All live capability records, ordered by `(dcc_type, slug)` for
-    /// a stable human-readable output — the builder places them in
-    /// that order on every swap so callers do not need to sort.
-    pub records: Arc<[CapabilityRecord]>,
-    /// Per-instance fingerprint seen at snapshot time. Included so
-    /// diagnostics can trace which `refresh_instance` cycles produced
-    /// which snapshot.
-    pub fingerprints: HashMap<Uuid, InstanceFingerprint>,
-}
-
-impl IndexSnapshot {
-    /// Convenience predicate for diagnostics.
-    pub fn is_empty(&self) -> bool {
-        self.records.is_empty()
-    }
-
-    /// Resolve a capability record by its slug in O(n). The index is
-    /// bounded (every live backend × ~tens of actions) so the linear
-    /// scan is the right default; a hash map would add per-refresh
-    /// cost without a proven win until indices exceed ~10 k records.
-    pub fn find_by_slug(&self, slug: &str) -> Option<&CapabilityRecord> {
-        self.records.iter().find(|r| r.tool_slug == slug)
-    }
-}
+pub use dcc_mcp_gateway_core::capability::index::{IndexSnapshot, InstanceFingerprint};
 
 /// The canonical gateway-scoped capability index.
 ///


### PR DESCRIPTION
## Summary

Fourth migration in the **#845 chain**. Moves the read-side capability index snapshot types — `IndexSnapshot` and `InstanceFingerprint` — into `dcc-mcp-gateway-core::capability::index`.

The mutable `CapabilityIndex` itself stays in `dcc-mcp-gateway` because it owns `parking_lot::RwLock` and `BTreeMap`-backed runtime state the domain layer has no business holding.

## What moves

| Symbol | Now at | Old path (re-exported) |
|---|---|---|
| `InstanceFingerprint` | `dcc_mcp_gateway_core::capability::index` | `dcc_mcp_gateway::gateway::capability::index` |
| `IndexSnapshot` | same | same |
| `IndexSnapshot::is_empty` / `find_by_slug` | same | same (now `#[must_use]`) |

## What stays in `dcc-mcp-gateway`

- `CapabilityIndex` — owns the `parking_lot::RwLock<InnerState>` store.
- `InnerState` — the per-instance `BTreeMap` of records and the swap logic.
- Every mutator that the refresh loop drives.

## Why this split

The snapshot is what every search / dispatch / diagnostics path actually consumes — a small, immutable, `Clone`-cheap value built atop `Arc<[CapabilityRecord]>`. Moving it into the domain crate lets external Rust tooling (CLI inspectors, integration tests, REST clients that cache the most recent snapshot) work with the gateway index shape without depending on the gateway crate's tokio / axum / parking_lot footprint.

## New regression tests in gateway-core

- `fingerprint_default_is_zero` / `_is_value_equal` — the structural-equality contract `refresh.rs` uses to short-circuit rebuilds.
- `snapshot_default_is_empty` / `find_by_slug_returns_first_match` — the diagnostics + dispatch-resolve paths.
- `snapshot_clone_shares_records_allocation` — **pins the `Arc`-shared cheap-clone contract callers rely on**. A future swap to `Box<[..]>` would silently regress search throughput; this guard catches it.
- `snapshot_carries_per_instance_fingerprints` — pins the diagnostics trace shape.

## Verification

- `cargo check --workspace` ✅
- `cargo test -p dcc-mcp-gateway-core` ✅ (29 total: 23 prior + 6 new)
- `cargo test -p dcc-mcp-gateway --lib capability::` ✅ (58 tests)
- `cargo clippy -p dcc-mcp-gateway-core --all-targets -- -D warnings` ✅
- `cargo clippy -p dcc-mcp-gateway --no-deps --tests --all-features -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅

## Follow-up

Builds on #893, #894, #896, #898. Part of #848 epic.