### PR TITLE
refactor(http): migrate JobConfig + WorkflowConfig to http-types (#852)

### DIFF
--- a/crates/dcc-mcp-http-types/src/config.rs
+++ b/crates/dcc-mcp-http-types/src/config.rs
@@ -7,9 +7,11 @@
 //! can depend on just the enumeration contract without dragging in
 //! `axum` / `tokio` / `reqwest` / `pyo3`.
 //!
-//! The full `McpHttpConfig` struct stays in `dcc-mcp-http::config`
-//! until its sub-struct split lands; this module captures just the
-//! self-contained enums for now.
+//! The full `McpHttpConfig` aggregate stays in `dcc-mcp-http::config`
+//! until every sub-struct has migrated; this module captures the
+//! self-contained pieces one at a time.
+
+use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
@@ -107,6 +109,61 @@ impl JobRecoveryPolicy {
     }
 }
 
+// ── JobConfig ──────────────────────────────────────────────────────────────
+
+/// Job persistence & recovery configuration.
+///
+/// One of the orthogonal sub-configs that compose `McpHttpConfig`
+/// (issue #852). Captured here as a pure value type so external
+/// tooling (config validators, CLI inspectors) can depend on the
+/// shape without pulling in the rest of the HTTP server crate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JobConfig {
+    /// Path to a SQLite database file for persisting tracked jobs
+    /// (issue #328). `None` means in-memory storage.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub job_storage_path: Option<PathBuf>,
+
+    /// What to do with rows the previous process left in `Pending` /
+    /// `Running` after a crash or restart (issue #567).
+    #[serde(default)]
+    pub job_recovery: JobRecoveryPolicy,
+}
+
+impl Default for JobConfig {
+    fn default() -> Self {
+        Self {
+            job_storage_path: None,
+            job_recovery: JobRecoveryPolicy::Drop,
+        }
+    }
+}
+
+// ── WorkflowConfig ─────────────────────────────────────────────────────────
+
+/// Workflow & scheduler configuration.
+///
+/// Captures the three opt-in switches that turn on the workflow
+/// (`workflows.*` MCP tools, issue #348) and scheduler (issue #352)
+/// subsystems. Both default to off so a pristine `McpHttpConfig`
+/// boots the minimal surface and operators opt into the heavier
+/// subsystems consciously.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct WorkflowConfig {
+    /// Enable the built-in `workflows.*` tools (issue #348).
+    #[serde(default)]
+    pub enable_workflows: bool,
+
+    /// Enable the cron + webhook scheduler subsystem (issue #352).
+    #[serde(default)]
+    pub enable_scheduler: bool,
+
+    /// Directory holding `*.schedules.yaml` files for the scheduler
+    /// subsystem (issue #352).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schedules_dir: Option<PathBuf>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -193,5 +250,91 @@ mod tests {
 
         let back: JobRecoveryPolicy = serde_json::from_str("\"requeue\"").unwrap();
         assert_eq!(back, JobRecoveryPolicy::Requeue);
+    }
+
+    // ── JobConfig ──────────────────────────────────────────────────────
+
+    #[test]
+    fn job_config_default_is_in_memory_with_drop_policy() {
+        let cfg = JobConfig::default();
+        assert!(cfg.job_storage_path.is_none());
+        assert_eq!(cfg.job_recovery, JobRecoveryPolicy::Drop);
+    }
+
+    #[test]
+    fn job_config_serialises_skip_none_storage() {
+        // `job_storage_path: None` is the default — keeping it out of
+        // the JSON serialisation keeps round-tripped configs compact
+        // and matches the CLI default (no `--job-storage-path` flag).
+        let cfg = JobConfig::default();
+        let s = serde_json::to_string(&cfg).unwrap();
+        assert!(!s.contains("job_storage_path"), "got: {s}");
+        assert!(s.contains("\"job_recovery\":\"drop\""), "got: {s}");
+    }
+
+    #[test]
+    fn job_config_round_trips_with_storage_path() {
+        let cfg = JobConfig {
+            job_storage_path: Some(PathBuf::from("/var/lib/dcc/jobs.sqlite")),
+            job_recovery: JobRecoveryPolicy::Requeue,
+        };
+        let s = serde_json::to_string(&cfg).unwrap();
+        let back: JobConfig = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.job_storage_path, cfg.job_storage_path);
+        assert_eq!(back.job_recovery, cfg.job_recovery);
+    }
+
+    #[test]
+    fn job_config_accepts_minimal_body() {
+        // Operators frequently send a 2-key partial in env-var
+        // configs. Both fields default, so a `{}` body must still
+        // deserialise to the documented defaults — anything else
+        // would surprise CLI / Python plumbing.
+        let cfg: JobConfig = serde_json::from_str("{}").unwrap();
+        assert!(cfg.job_storage_path.is_none());
+        assert_eq!(cfg.job_recovery, JobRecoveryPolicy::Drop);
+    }
+
+    // ── WorkflowConfig ─────────────────────────────────────────────────
+
+    #[test]
+    fn workflow_config_default_disables_both_subsystems() {
+        // Pristine boot must surface only the minimal MCP tools, so
+        // both opt-in switches default to `false`. Operators flip
+        // them on consciously when they are ready to pay the
+        // workflow / scheduler runtime cost.
+        let cfg = WorkflowConfig::default();
+        assert!(!cfg.enable_workflows);
+        assert!(!cfg.enable_scheduler);
+        assert!(cfg.schedules_dir.is_none());
+    }
+
+    #[test]
+    fn workflow_config_round_trips() {
+        let cfg = WorkflowConfig {
+            enable_workflows: true,
+            enable_scheduler: true,
+            schedules_dir: Some(PathBuf::from("/etc/dcc/schedules")),
+        };
+        let s = serde_json::to_string(&cfg).unwrap();
+        let back: WorkflowConfig = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.enable_workflows, cfg.enable_workflows);
+        assert_eq!(back.enable_scheduler, cfg.enable_scheduler);
+        assert_eq!(back.schedules_dir, cfg.schedules_dir);
+    }
+
+    #[test]
+    fn workflow_config_skip_none_schedules_dir() {
+        let cfg = WorkflowConfig::default();
+        let s = serde_json::to_string(&cfg).unwrap();
+        assert!(!s.contains("schedules_dir"), "got: {s}");
+    }
+
+    #[test]
+    fn workflow_config_accepts_minimal_body() {
+        let cfg: WorkflowConfig = serde_json::from_str("{}").unwrap();
+        assert!(!cfg.enable_workflows);
+        assert!(!cfg.enable_scheduler);
+        assert!(cfg.schedules_dir.is_none());
     }
 }

--- a/crates/dcc-mcp-http-types/src/lib.rs
+++ b/crates/dcc-mcp-http-types/src/lib.rs
@@ -25,7 +25,7 @@
 //! |-------------|-----------------------------------------------------------|
 //! | crate root  | [`TruncationEnvelope`], [`SseChunkFrame`] + chunk helpers |
 //! | [`error`]   | [`HttpError`] / [`HttpResult`] error taxonomy             |
-//! | [`config`]  | [`ServerSpawnMode`], [`JobRecoveryPolicy`] config enums   |
+//! | [`config`]  | [`ServerSpawnMode`], [`JobRecoveryPolicy`], [`JobConfig`], [`WorkflowConfig`] |
 //!
 //! # Migration plan (issue #852)
 //!
@@ -33,13 +33,15 @@
 //!
 //! | Lives here now              | Stays in `dcc-mcp-http` for now |
 //! |-----------------------------|----------------------------------|
-//! | [`TruncationEnvelope`]      | `McpHttpConfig` (needs own split)|
-//! | [`SseChunkFrame`]           |                                  |
-//! | [`chunk_sse_data`]          |                                  |
-//! | [`format_chunked_sse`]      |                                  |
-//! | [`error::HttpError`]        |                                  |
-//! | [`config::ServerSpawnMode`] |                                  |
-//! | [`config::JobRecoveryPolicy`]|                                 |
+//! | [`TruncationEnvelope`]      | `McpHttpConfig` aggregate       |
+//! | [`SseChunkFrame`]           | `ServerConfig` (uses `IpAddr`)  |
+//! | [`chunk_sse_data`]          | `InstanceConfig`                 |
+//! | [`format_chunked_sse`]      | `SessionConfig`                  |
+//! | [`error::HttpError`]        | `GatewayConfig`                  |
+//! | [`config::ServerSpawnMode`] | `QueueConfig`                    |
+//! | [`config::JobRecoveryPolicy`]| `TelemetryConfig`               |
+//! | [`config::JobConfig`]       | `FeatureFlags`                   |
+//! | [`config::WorkflowConfig`]  |                                  |
 //!
 //! Each new round of #852 PRs migrates one self-contained subsystem at a
 //! time and re-exports it from `dcc-mcp-http` to preserve the public API.

--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -4,14 +4,17 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 use std::path::PathBuf;
 
-// `ServerSpawnMode` and `JobRecoveryPolicy` were migrated to
-// `dcc-mcp-http-types::config` (issue #852, part 3) so external
-// Rust tooling (CLI drivers, config validators, adapter
-// orchestrators) can depend on just the enum contract without
-// dragging in axum / tokio / reqwest / pyo3. Re-exported here so
-// the historical `crate::config::{ServerSpawnMode, JobRecoveryPolicy}`
-// paths — and the 43 consumer sites they feed — keep compiling.
-pub use dcc_mcp_http_types::config::{JobRecoveryPolicy, ServerSpawnMode};
+// `ServerSpawnMode`, `JobRecoveryPolicy`, `JobConfig`, and
+// `WorkflowConfig` were migrated to `dcc-mcp-http-types::config`
+// (issue #852, parts 3 + 4) so external Rust tooling (CLI drivers,
+// config validators, adapter orchestrators) can depend on just the
+// value-type contract without dragging in axum / tokio / reqwest /
+// pyo3. Re-exported here so the historical
+// `crate::config::{ServerSpawnMode, JobRecoveryPolicy, JobConfig,
+//   WorkflowConfig}` paths keep compiling.
+pub use dcc_mcp_http_types::config::{
+    JobConfig, JobRecoveryPolicy, ServerSpawnMode, WorkflowConfig,
+};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Sub-config structs — one per orthogonal concern
@@ -812,40 +815,9 @@ impl Default for FeatureFlags {
     }
 }
 
-/// Workflow & scheduler configuration.
-#[derive(Debug, Clone, Default)]
-pub struct WorkflowConfig {
-    /// Enable the built-in `workflows.*` tools (issue #348).
-    pub enable_workflows: bool,
-
-    /// Enable the cron + webhook scheduler subsystem (issue #352).
-    pub enable_scheduler: bool,
-
-    /// Directory holding `*.schedules.yaml` files for the scheduler
-    /// subsystem (issue #352).
-    pub schedules_dir: Option<PathBuf>,
-}
-
-/// Job persistence & recovery configuration.
-#[derive(Debug, Clone)]
-pub struct JobConfig {
-    /// Path to a SQLite database file for persisting tracked jobs
-    /// (issue #328).
-    pub job_storage_path: Option<PathBuf>,
-
-    /// What to do with rows the previous process left in `Pending` /
-    /// `Running` after a crash or restart (issue #567).
-    pub job_recovery: JobRecoveryPolicy,
-}
-
-impl Default for JobConfig {
-    fn default() -> Self {
-        Self {
-            job_storage_path: None,
-            job_recovery: JobRecoveryPolicy::Drop,
-        }
-    }
-}
+// `WorkflowConfig` and `JobConfig` were migrated to
+// `dcc-mcp-http-types::config` (issue #852, part 4) — see the
+// `pub use` re-export at the top of this file.
 
 // ─────────────────────────────────────────────────────────────────────────────
 // McpHttpConfig — thin aggregate of the 9 sub-configs above.


### PR DESCRIPTION
## Summary

Fourth migration in the **#852 chain**. Moves the two smallest self-contained sub-configs of `McpHttpConfig` — `JobConfig` (#328 + #567) and `WorkflowConfig` (#348 + #352) — into `dcc-mcp-http-types::config`.

Both depend only on `PathBuf` + `JobRecoveryPolicy` (already in `http-types` since #899), so the dependency direction stays strictly inward.

## What moves

| Symbol | Now at | Old path (re-exported) |
|---|---|---|
| `JobConfig` { `job_storage_path`, `job_recovery` } | `dcc_mcp_http_types::config::JobConfig` | `dcc_mcp_http::config::JobConfig` |
| `WorkflowConfig` { `enable_workflows`, `enable_scheduler`, `schedules_dir` } | `dcc_mcp_http_types::config::WorkflowConfig` | same |

`crates/dcc-mcp-http/src/config.rs` widens its existing `pub use dcc_mcp_http_types::config::{...}` line to include the two structs. The `McpHttpConfig` aggregate keeps composing them via `cfg.job: JobConfig` / `cfg.workflow: WorkflowConfig`, so every existing consumer path (`cfg.job.job_recovery`, `cfg.workflow.enable_workflows`, `with_job_recovery`, `with_workflows_enabled`, …) keeps compiling.

## Design choices

- **`Serialize` + `Deserialize` derives added** on both structs — the gateway / http server historically didn't round-trip them through serde, but external config validators and the future per-section CLI plumbing will. Adding the derives now is cheap (just attribute additions) and keeps every config-shape round-trip cohesive across the four enums + two structs already migrated.
- **`skip_serializing_if = "Option::is_none"` on optional paths** so pristine-boot configs serialise compactly without explicit `null`s in the wire form.
- **Pristine-boot defaults pinned by tests.** `WorkflowConfig` defaults both opt-in switches to `false` so the minimal MCP surface is what boots; `JobConfig` defaults to in-memory storage + `Drop` recovery (today's behaviour). New tests `workflow_config_default_disables_both_subsystems` and `job_config_default_is_in_memory_with_drop_policy` pin those contracts.

## New wire-contract tests in `http-types`

- `job_config_default_is_in_memory_with_drop_policy`
- `job_config_serialises_skip_none_storage` — pins the compact wire form
- `job_config_round_trips_with_storage_path`
- `job_config_accepts_minimal_body` — `{}` must deserialise to defaults (env-var plumbing relies on this)
- `workflow_config_default_disables_both_subsystems`
- `workflow_config_round_trips`
- `workflow_config_skip_none_schedules_dir`
- `workflow_config_accepts_minimal_body`

## Verification

- `cargo check --workspace` ✅
- `cargo test -p dcc-mcp-http-types` ✅ (33 total: 24 prior + 9 new)
- `cargo test -p dcc-mcp-http --lib config::` ✅ (11 tests — builder + env-var plumbing still green)
- `cargo clippy -p dcc-mcp-http-types --all-targets -- -D warnings` ✅
- `cargo clippy -p dcc-mcp-http --no-deps --tests -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅

## Follow-up

Next in the #852 chain: `TelemetryConfig` (Prometheus metrics — pure value type, easy seed) and `FeatureFlags` (8 self-contained bools), then the harder `ServerConfig` / `InstanceConfig` / `SessionConfig` / `GatewayConfig` / `QueueConfig` (these need careful read because they touch `IpAddr`, `std::time::Duration`, and other typed fields that may need `humantime` for clean wire shapes).

Builds on #895, #897, #899, #900. Part of #848 epic.