### PR TITLE
refactor(gateway): migrate RefreshReason + BuildOutcome to gateway-core (#845)

### DIFF
--- a/crates/dcc-mcp-gateway-core/src/capability/builder.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/builder.rs
@@ -1,0 +1,61 @@
+//! Capability builder result types (issue #845).
+//!
+//! The actual `build_records_from_backend` builder lives in
+//! `dcc-mcp-gateway` because it borrows the backend `tools/list`
+//! response (an `&[McpTool]` from `dcc-mcp-jsonrpc`). Only the
+//! *output* of the builder lives here, since [`BuildOutcome`] is a
+//! pure value type that diagnostics and tests want to inspect
+//! without spinning up the full gateway crate.
+
+use super::index::InstanceFingerprint;
+use super::record::CapabilityRecord;
+
+/// Output of the capability builder.
+///
+/// Returned by `dcc_mcp_gateway::capability::builder::build_records_from_backend`
+/// after it has filtered, slug-encoded, and fingerprinted one
+/// instance's worth of `tools/list`.
+///
+/// The struct is intentionally inert — every field is publicly
+/// readable so the index swap path can move records, fingerprint,
+/// and skip-count out without an extra accessor surface.
+#[derive(Debug, Clone, Default)]
+pub struct BuildOutcome {
+    /// Records ready to be stored in the index. Sorted by
+    /// `tool_slug` so the merge inside the gateway's
+    /// `CapabilityIndex::snapshot` stays cheap.
+    pub records: Vec<CapabilityRecord>,
+    /// Stable fingerprint of the input tool list; feed this straight
+    /// into `CapabilityIndex::upsert_instance`.
+    pub fingerprint: InstanceFingerprint,
+    /// Number of input tools rejected (e.g. missing name, skill stub
+    /// filtered out). Diagnostics-only.
+    pub skipped: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_outcome_default_is_empty() {
+        let o = BuildOutcome::default();
+        assert!(o.records.is_empty());
+        assert_eq!(o.fingerprint, InstanceFingerprint::default());
+        assert_eq!(o.skipped, 0);
+    }
+
+    #[test]
+    fn build_outcome_carries_diagnostics() {
+        // `skipped` is the only counter that tells operators the
+        // builder rejected input rows — pin the field-shape contract
+        // so a future refactor cannot silently drop it.
+        let o = BuildOutcome {
+            records: vec![],
+            fingerprint: InstanceFingerprint(0xc0ffee),
+            skipped: 3,
+        };
+        assert_eq!(o.fingerprint, InstanceFingerprint(0xc0ffee));
+        assert_eq!(o.skipped, 3);
+    }
+}

--- a/crates/dcc-mcp-gateway-core/src/capability/mod.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/mod.rs
@@ -1,4 +1,4 @@
-//! Capability records and search/index wire types.
+//! Capability records, search, and refresh wire types.
 //!
 //! # Module map
 //!
@@ -7,23 +7,31 @@
 //! | [`record`]   | `CapabilityRecord`, slug encoding / parsing, validation      |
 //! | [`search`]   | `SearchQuery`, `SearchHit`, `SearchPage`, `SearchMode`       |
 //! | [`index`]    | `IndexSnapshot`, `InstanceFingerprint` — read-side snapshot  |
+//! | [`builder`]  | `BuildOutcome` — output of the per-instance record builder   |
+//! | [`refresh`]  | `RefreshReason` — why a refresh cycle is running             |
 //!
 //! The mutable `CapabilityIndex` (which owns a `parking_lot::RwLock`
-//! and a `BTreeMap` of per-instance state) and the search ranking
-//! function (which depends on the pluggable `Scorer` trait) both live
-//! in `dcc-mcp-gateway` because they carry runtime state the domain
-//! layer has no business holding. Only the *wire types* — query
-//! parameters, result rows, pagination envelope, snapshot view — live
-//! here so any REST client talking to the gateway can deserialise
-//! responses without pulling the full gateway crate.
+//! and a `BTreeMap` of per-instance state), the `build_records_from_backend`
+//! builder (which borrows backend `&[McpTool]`), and the
+//! `refresh_instance` lifecycle driver (which owns a `reqwest::Client`)
+//! all live in `dcc-mcp-gateway` because they carry runtime state the
+//! domain layer has no business holding. Only the *wire types* —
+//! query parameters, result rows, snapshot view, builder output, and
+//! refresh-reason classification — live here so any REST/admin
+//! client talking to the gateway can deserialise responses without
+//! pulling the full gateway crate.
 
+pub mod builder;
 pub mod index;
 pub mod record;
+pub mod refresh;
 pub mod search;
 
 // Re-export each submodule's public surface from the capability
 // facade so historical paths (`dcc_mcp_gateway_core::capability::
 // CapabilityRecord` etc.) keep working verbatim.
+pub use builder::BuildOutcome;
 pub use index::{IndexSnapshot, InstanceFingerprint};
 pub use record::{CapabilityRecord, SCHEMA_AVAILABLE, is_valid_dcc_bucket, parse_slug, tool_slug};
+pub use refresh::RefreshReason;
 pub use search::{DEFAULT_LIMIT, MAX_LIMIT, SearchHit, SearchMode, SearchPage, SearchQuery};

--- a/crates/dcc-mcp-gateway-core/src/capability/refresh.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/refresh.rs
@@ -1,0 +1,83 @@
+//! Refresh-cycle telemetry types (issue #845).
+//!
+//! The mutable refresh loop — `refresh_instance`, `remove_instance`,
+//! and the I/O it drives via `reqwest` — stays in `dcc-mcp-gateway`
+//! because it carries runtime state. Only the *enum that classifies
+//! why a refresh ran* lives here, so external Rust tooling
+//! (operator dashboards, CLI inspectors) can match on the reason
+//! without depending on the gateway crate's tokio / reqwest /
+//! parking_lot footprint.
+
+use serde::{Deserialize, Serialize};
+
+/// Why a refresh cycle is running.
+///
+/// Surfaced through `tracing::info!` so operators can correlate an
+/// index update with the event that triggered it. Also serialised
+/// onto the admin UI's `/admin/api/calls` event log when the call
+/// happens to be a refresh-driven dispatch (issue #772).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RefreshReason {
+    /// Instance joined the registry for the first time.
+    InstanceJoined,
+    /// Instance is still live but sent a `tools/list_changed`
+    /// notification (typically because a skill loaded/unloaded).
+    ToolsListChanged,
+    /// Background periodic refresh — catches any change that did
+    /// not emit a push notification.
+    Periodic,
+}
+
+impl RefreshReason {
+    /// String label suitable for span tags. Returns the same
+    /// snake_case form that the JSON wire emits, so log lines and
+    /// JSON dumps are visually consistent.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::InstanceJoined => "instance_joined",
+            Self::ToolsListChanged => "tools_list_changed",
+            Self::Periodic => "periodic",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn refresh_reason_as_str_is_stable() {
+        // The strings end up in tracing spans + the admin UI's event
+        // log. Pin them so a future variant rename cannot silently
+        // break log scrapers / Grafana dashboards.
+        assert_eq!(RefreshReason::InstanceJoined.as_str(), "instance_joined");
+        assert_eq!(
+            RefreshReason::ToolsListChanged.as_str(),
+            "tools_list_changed"
+        );
+        assert_eq!(RefreshReason::Periodic.as_str(), "periodic");
+    }
+
+    #[test]
+    fn refresh_reason_wire_matches_as_str() {
+        // The JSON wire form must match `as_str()` so a single string
+        // serves both log lines and JSON dumps.
+        assert_eq!(
+            serde_json::to_string(&RefreshReason::InstanceJoined).unwrap(),
+            "\"instance_joined\""
+        );
+        assert_eq!(
+            serde_json::to_string(&RefreshReason::ToolsListChanged).unwrap(),
+            "\"tools_list_changed\""
+        );
+        assert_eq!(
+            serde_json::to_string(&RefreshReason::Periodic).unwrap(),
+            "\"periodic\""
+        );
+
+        let back: RefreshReason = serde_json::from_str("\"periodic\"").unwrap();
+        assert_eq!(back, RefreshReason::Periodic);
+    }
+}

--- a/crates/dcc-mcp-gateway/src/gateway/capability/builder.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/builder.rs
@@ -5,6 +5,17 @@
 //! here, so it can be unit-tested with synthesised JSON payloads
 //! without spinning up a real MCP backend. The REST/MCP fetch side
 //! lives in [`super::refresh`].
+//!
+//! # Wire type relocation (issue #845)
+//!
+//! [`BuildOutcome`] was migrated to
+//! [`dcc_mcp_gateway_core::capability::builder`] so diagnostics and
+//! tests can inspect builder output without depending on this
+//! crate's gateway-side runtime. The struct is intentionally inert
+//! (no methods), so moving it is a clean field-for-field migration.
+//! [`BuildInput`] stays here because it borrows
+//! `&[dcc_mcp_jsonrpc::McpTool]` — the type contract belongs in the
+//! crate that already depends on `dcc-mcp-jsonrpc`.
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -17,6 +28,8 @@ use dcc_mcp_jsonrpc::McpTool;
 
 use super::index::InstanceFingerprint;
 use super::record::{CapabilityRecord, SCHEMA_AVAILABLE, is_valid_dcc_bucket, tool_slug};
+
+pub use dcc_mcp_gateway_core::capability::builder::BuildOutcome;
 
 /// Everything the builder needs from a single live backend to emit
 /// one instance-worth of capability records.
@@ -33,20 +46,6 @@ pub struct BuildInput<'a> {
     pub dcc_type: &'a str,
     /// Raw `tools/list` response as an array of [`McpTool`].
     pub backend_tools: &'a [McpTool],
-}
-
-/// Output of [`build_records_from_backend`].
-#[derive(Debug, Clone, Default)]
-pub struct BuildOutcome {
-    /// Records ready to be stored in the index. Sorted by `tool_slug`
-    /// so the merge inside `CapabilityIndex::snapshot` stays cheap.
-    pub records: Vec<CapabilityRecord>,
-    /// Stable fingerprint of the input tool list; feed this straight
-    /// into [`crate::gateway::capability::CapabilityIndex::upsert_instance`].
-    pub fingerprint: InstanceFingerprint,
-    /// Number of input tools rejected (e.g. missing name, skill stub
-    /// filtered out). Diagnostics-only.
-    pub skipped: usize,
 }
 
 /// Build the instance slice from a backend `tools/list` response.

--- a/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
@@ -6,6 +6,16 @@
 //! [`super::builder::build_records_from_backend`] and only adds the
 //! I/O — `fetch_tools` on demand, and tracing on lifecycle
 //! transitions.
+//!
+//! # Wire type relocation (issue #845)
+//!
+//! [`RefreshReason`] was migrated to
+//! [`dcc_mcp_gateway_core::capability::refresh`] so external Rust
+//! tooling (admin dashboards, CLI inspectors, log scrapers) can
+//! match on the reason without depending on this crate's tokio /
+//! reqwest footprint. Re-exported below to keep the historical
+//! `crate::gateway::capability::refresh::RefreshReason` path working
+//! unchanged.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -17,31 +27,7 @@ use crate::gateway::backend_client::fetch_tools;
 use super::builder::{BuildInput, build_records_from_backend};
 use super::index::CapabilityIndex;
 
-/// Why a refresh cycle is running. Surfaced through `tracing::info!`
-/// so operators can correlate an index update with the event that
-/// triggered it.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RefreshReason {
-    /// Instance joined the registry for the first time.
-    InstanceJoined,
-    /// Instance is still live but sent a `tools/list_changed`
-    /// notification (typically because a skill loaded/unloaded).
-    ToolsListChanged,
-    /// Background periodic refresh — catches any change that did
-    /// not emit a push notification.
-    Periodic,
-}
-
-impl RefreshReason {
-    /// String label suitable for span tags.
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::InstanceJoined => "instance_joined",
-            Self::ToolsListChanged => "tools_list_changed",
-            Self::Periodic => "periodic",
-        }
-    }
-}
+pub use dcc_mcp_gateway_core::capability::refresh::RefreshReason;
 
 /// Refresh one instance's slice of the index by fetching its current
 /// `tools/list` from `mcp_url`.


### PR DESCRIPTION
## Summary

Fifth migration in the **#845 chain**. Moves two more pure value types out of `dcc-mcp-gateway` into `dcc-mcp-gateway-core::capability`:

- `RefreshReason` (enum, 3 variants) — the classifier for *why* a refresh cycle is running. Surfaced through tracing spans + the admin UI's event log.
- `BuildOutcome` (struct, 3 fields) — the inert output of the per-instance record builder.

External Rust tooling (admin dashboards, CLI inspectors, log scrapers) can now match on refresh telemetry without depending on the gateway crate's tokio / reqwest footprint.

## What moves

| Symbol | Now at | Old path (re-exported) |
|---|---|---|
| `RefreshReason` | `dcc_mcp_gateway_core::capability::refresh` | `dcc_mcp_gateway::gateway::capability::refresh` |
| `RefreshReason::as_str` | same (now `#[must_use]`) | same |
| `BuildOutcome` | `dcc_mcp_gateway_core::capability::builder` | `dcc_mcp_gateway::gateway::capability::builder` |

## What stays in `dcc-mcp-gateway`

- `BuildInput<'a>` — borrows `&[dcc_mcp_jsonrpc::McpTool]`, so the type contract belongs in the crate that already depends on `dcc-mcp-jsonrpc`.
- `build_records_from_backend()` — the function itself stays put; only its return type moved.
- `refresh_instance()` — drives I/O via `reqwest`; cannot live in the domain layer.

## Wire-form addition

`RefreshReason` now derives `Serialize` + `Deserialize` with `#[serde(rename_all = "snake_case")]`. The JSON form (`"instance_joined"`, `"tools_list_changed"`, `"periodic"`) is identical to the `as_str()` output, so a single string serves both log lines and JSON dumps. The new `refresh_reason_wire_matches_as_str` test pins this contract.

## New regression tests in `gateway-core`

- `refresh_reason_as_str_is_stable` — pins the strings so a future variant rename cannot silently break log scrapers / Grafana dashboards.
- `refresh_reason_wire_matches_as_str` — pins the wire/log alignment.
- `build_outcome_default_is_empty` — pins the `Default` contract.
- `build_outcome_carries_diagnostics` — pins the field shape so a future refactor cannot silently drop the `skipped` counter.

## Verification

- `cargo check --workspace` ✅
- `cargo test -p dcc-mcp-gateway-core` ✅ (33 total: 29 prior + 4 new)
- `cargo test -p dcc-mcp-gateway --lib capability::` ✅ (58 tests)
- `cargo clippy -p dcc-mcp-gateway-core --all-targets -- -D warnings` ✅
- `cargo clippy -p dcc-mcp-gateway --no-deps --tests --all-features -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅

Builds on #893, #894, #896, #898, #900. Part of #848 epic.