### PR TITLE
refactor(http): migrate InstanceConfig to http-types (#852)

### DIFF
--- a/crates/dcc-mcp-http-types/src/config.rs
+++ b/crates/dcc-mcp-http-types/src/config.rs
@@ -11,6 +11,7 @@
 //! until every sub-struct has migrated; this module captures the
 //! self-contained pieces one at a time.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -275,6 +276,61 @@ impl Default for FeatureFlags {
 /// serde's attribute parser does not accept inline literals here.
 fn default_true() -> bool {
     true
+}
+
+// ── InstanceConfig ─────────────────────────────────────────────────────────
+
+/// DCC instance registration metadata.
+///
+/// One of the orthogonal sub-configs that compose `McpHttpConfig`
+/// (issue #852). Reported into the shared `FileRegistry` so the
+/// gateway can route by DCC type / version / scene. Captured here
+/// as a pure value type — every field is plain string-shaped,
+/// nothing carries runtime state.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct InstanceConfig {
+    /// DCC application type (e.g. `"maya"`, `"blender"`). Reported in
+    /// the shared `FileRegistry` so the gateway can route by DCC
+    /// type.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dcc_type: Option<String>,
+
+    /// DCC application version (e.g. `"2025.1"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dcc_version: Option<String>,
+
+    /// Currently open scene/file. Improves routing accuracy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scene: Option<String>,
+
+    /// Arbitrary instance metadata recorded in `FileRegistry`.
+    ///
+    /// Rez/package launchers use this for context-bundle fields such
+    /// as `context_bundle`, `production_domain`, `context_kind`,
+    /// `project`, `task`, `toolset_profile`, and `package_provenance`.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub instance_metadata: HashMap<String, String>,
+
+    /// Capabilities declared by the DCC adapter hosting this server
+    /// (issue #354).
+    ///
+    /// Each tool may list `required_capabilities` in its sibling
+    /// `tools.yaml`; on `tools/call` the server intersects the
+    /// tool's requirements against this declared set. Missing
+    /// capabilities surface as a `-32001 capability_missing` MCP
+    /// error. Tools with unmet capabilities still appear in
+    /// `tools/list` but carry `_meta.dcc.missing_capabilities = [...]`
+    /// so clients can filter.
+    ///
+    /// The list is freeform — conventionally lowercase dotted
+    /// identifiers like `"usd"`, `"scene.mutate"`,
+    /// `"filesystem.read"`. Adapters hard-code it at construction
+    /// time; there is no runtime introspection of the DCC.
+    ///
+    /// Default: empty (no capabilities declared — any tool with
+    /// declared requirements will report them as missing).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub declared_capabilities: Vec<String>,
 }
 
 #[cfg(test)]
@@ -560,5 +616,66 @@ mod tests {
         // And the `false`-by-default ones stay `false`:
         assert!(!f.enable_artefact_resources);
         assert!(!f.shutdown_on_drop);
+    }
+
+    // ── InstanceConfig ─────────────────────────────────────────────────
+
+    #[test]
+    fn instance_config_default_is_anonymous() {
+        // A pristine InstanceConfig must reveal nothing about the
+        // host adapter — every field is None / empty so that
+        // `FileRegistry` rows from a misconfigured launcher do not
+        // accidentally claim to be Maya / Blender / etc.
+        let cfg = InstanceConfig::default();
+        assert!(cfg.dcc_type.is_none());
+        assert!(cfg.dcc_version.is_none());
+        assert!(cfg.scene.is_none());
+        assert!(cfg.instance_metadata.is_empty());
+        assert!(cfg.declared_capabilities.is_empty());
+    }
+
+    #[test]
+    fn instance_config_round_trips() {
+        let mut metadata = HashMap::new();
+        metadata.insert("project".to_owned(), "shotpack".to_owned());
+        metadata.insert("task".to_owned(), "lighting".to_owned());
+
+        let cfg = InstanceConfig {
+            dcc_type: Some("maya".into()),
+            dcc_version: Some("2025.1".into()),
+            scene: Some("/tmp/scene.ma".into()),
+            instance_metadata: metadata.clone(),
+            declared_capabilities: vec!["usd".into(), "scene.mutate".into()],
+        };
+        let s = serde_json::to_string(&cfg).unwrap();
+        let back: InstanceConfig = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.dcc_type, cfg.dcc_type);
+        assert_eq!(back.dcc_version, cfg.dcc_version);
+        assert_eq!(back.scene, cfg.scene);
+        assert_eq!(back.instance_metadata, metadata);
+        assert_eq!(back.declared_capabilities, cfg.declared_capabilities);
+    }
+
+    /// Every optional / collection field carries
+    /// `skip_serializing_if = ...` so a pristine `InstanceConfig`
+    /// serialises to the literal `"{}"`. Pin this so a future field
+    /// addition does not silently bloat config dumps with `null`s
+    /// and empty arrays.
+    #[test]
+    fn instance_config_default_serialises_empty_object() {
+        let cfg = InstanceConfig::default();
+        let s = serde_json::to_string(&cfg).unwrap();
+        assert_eq!(s, "{}", "default config must serialise to empty object");
+    }
+
+    #[test]
+    fn instance_config_accepts_minimal_body() {
+        // `{}` must deserialise to defaults. Operators routinely
+        // boot a server without any of these fields set, then patch
+        // the registry row in via subsequent calls; if `{}` failed
+        // to deserialise, the boot sequence would break.
+        let cfg: InstanceConfig = serde_json::from_str("{}").unwrap();
+        assert!(cfg.dcc_type.is_none());
+        assert!(cfg.declared_capabilities.is_empty());
     }
 }

--- a/crates/dcc-mcp-http-types/src/lib.rs
+++ b/crates/dcc-mcp-http-types/src/lib.rs
@@ -25,7 +25,7 @@
 //! |-------------|-----------------------------------------------------------|
 //! | crate root  | [`TruncationEnvelope`], [`SseChunkFrame`] + chunk helpers |
 //! | [`error`]   | [`HttpError`] / [`HttpResult`] error taxonomy             |
-//! | [`config`]  | [`ServerSpawnMode`], [`JobRecoveryPolicy`], [`JobConfig`], [`WorkflowConfig`], [`TelemetryConfig`], [`FeatureFlags`] |
+//! | [`config`]  | [`ServerSpawnMode`], [`JobRecoveryPolicy`], [`JobConfig`], [`WorkflowConfig`], [`TelemetryConfig`], [`FeatureFlags`], [`InstanceConfig`] |
 //!
 //! # Migration plan (issue #852)
 //!
@@ -35,15 +35,16 @@
 //! |-----------------------------|----------------------------------|
 //! | [`TruncationEnvelope`]      | `McpHttpConfig` aggregate       |
 //! | [`SseChunkFrame`]           | `ServerConfig` (uses `IpAddr`)  |
-//! | [`chunk_sse_data`]          | `InstanceConfig`                 |
-//! | [`format_chunked_sse`]      | `SessionConfig`                  |
-//! | [`error::HttpError`]        | `GatewayConfig`                  |
-//! | [`config::ServerSpawnMode`] | `QueueConfig`                    |
+//! | [`chunk_sse_data`]          | `SessionConfig`                  |
+//! | [`format_chunked_sse`]      | `GatewayConfig`                  |
+//! | [`error::HttpError`]        | `QueueConfig`                    |
+//! | [`config::ServerSpawnMode`] |                                  |
 //! | [`config::JobRecoveryPolicy`]|                                 |
 //! | [`config::JobConfig`]       |                                  |
 //! | [`config::WorkflowConfig`]  |                                  |
 //! | [`config::TelemetryConfig`] |                                  |
 //! | [`config::FeatureFlags`]    |                                  |
+//! | [`config::InstanceConfig`]  |                                  |
 //!
 //! Each new round of #852 PRs migrates one self-contained subsystem at a
 //! time and re-exports it from `dcc-mcp-http` to preserve the public API.

--- a/crates/dcc-mcp-http/src/config.rs
+++ b/crates/dcc-mcp-http/src/config.rs
@@ -5,14 +5,16 @@ use std::net::IpAddr;
 use std::path::PathBuf;
 
 // `ServerSpawnMode`, `JobRecoveryPolicy`, `JobConfig`,
-// `WorkflowConfig`, `TelemetryConfig`, and `FeatureFlags` were
-// migrated to `dcc-mcp-http-types::config` (issue #852, parts 3-5)
-// so external Rust tooling (CLI drivers, config validators, adapter
-// orchestrators) can depend on just the value-type contract without
-// dragging in axum / tokio / reqwest / pyo3. Re-exported here so the
-// historical `crate::config::*` paths keep compiling.
+// `WorkflowConfig`, `TelemetryConfig`, `FeatureFlags`, and
+// `InstanceConfig` were migrated to `dcc-mcp-http-types::config`
+// (issue #852, parts 3-6) so external Rust tooling (CLI drivers,
+// config validators, adapter orchestrators) can depend on just the
+// value-type contract without dragging in axum / tokio / reqwest /
+// pyo3. Re-exported here so the historical `crate::config::*`
+// paths keep compiling.
 pub use dcc_mcp_http_types::config::{
-    FeatureFlags, JobConfig, JobRecoveryPolicy, ServerSpawnMode, TelemetryConfig, WorkflowConfig,
+    FeatureFlags, InstanceConfig, JobConfig, JobRecoveryPolicy, ServerSpawnMode, TelemetryConfig,
+    WorkflowConfig,
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -372,43 +374,9 @@ impl McpHttpConfig {
     }
 }
 
-/// DCC instance registration metadata.
-#[derive(Debug, Clone, Default)]
-pub struct InstanceConfig {
-    /// DCC application type (e.g. `"maya"`, `"blender"`). Reported in the
-    /// shared `FileRegistry` so the gateway can route by DCC type.
-    pub dcc_type: Option<String>,
-
-    /// DCC application version (e.g. `"2025.1"`).
-    pub dcc_version: Option<String>,
-
-    /// Currently open scene/file. Improves routing accuracy.
-    pub scene: Option<String>,
-
-    /// Arbitrary instance metadata recorded in FileRegistry.
-    ///
-    /// Rez/package launchers use this for context-bundle fields such as
-    /// `context_bundle`, `production_domain`, `context_kind`, `project`,
-    /// `task`, `toolset_profile`, and `package_provenance`.
-    pub instance_metadata: HashMap<String, String>,
-
-    /// Capabilities declared by the DCC adapter hosting this server (issue #354).
-    ///
-    /// Each tool may list [`required_capabilities`] in its sibling
-    /// `tools.yaml`; on `tools/call` the server intersects the tool's
-    /// requirements against this declared set. Missing capabilities
-    /// surface as a `-32001 capability_missing` MCP error. Tools with
-    /// unmet capabilities still appear in `tools/list` but carry
-    /// `_meta.dcc.missing_capabilities = [...]` so clients can filter.
-    ///
-    /// The list is freeform — conventionally lowercase dotted identifiers
-    /// like `"usd"`, `"scene.mutate"`, `"filesystem.read"`. Adapters hard-code
-    /// it at construction time; there is no runtime introspection of the DCC.
-    ///
-    /// Default: empty (no capabilities declared — any tool with declared
-    /// requirements will report them as missing).
-    pub declared_capabilities: Vec<String>,
-}
+// `InstanceConfig` was migrated to `dcc-mcp-http-types::config`
+// (issue #852, part 6) — see the `pub use` re-export at the top of
+// this file.
 
 /// Session lifecycle & tool-cache configuration.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary

Sixth migration in the **#852 chain**. Moves `InstanceConfig` — the DCC adapter's registration metadata reported into `FileRegistry` — into `dcc-mcp-http-types::config`.

This is the **last** sub-config whose fields are all plain string-shaped (`Option<String>`, `HashMap<String,String>`, `Vec<String>`). The remaining sub-configs (`ServerConfig`, `SessionConfig`, `GatewayConfig`, `QueueConfig`) need wire-shape decisions for `IpAddr` / `std::time::Duration` so they are deferred to a future PR with `humantime` plumbing.

## What moves

| Symbol | Now at | Old path (re-exported) |
|---|---|---|
| `InstanceConfig` { `dcc_type`, `dcc_version`, `scene`, `instance_metadata`, `declared_capabilities` } | `dcc_mcp_http_types::config::InstanceConfig` | `dcc_mcp_http::config::InstanceConfig` |

## Design choices

- **Pristine boot is fully anonymous.** Every field defaults to `None` / empty so a misconfigured launcher cannot silently claim to be Maya / Blender / etc. — a real safety property pinned by `instance_config_default_is_anonymous`.
- **Default serialises to literal `{}`.** Every `Option` / `HashMap` / `Vec` field carries `skip_serializing_if`. New `instance_config_default_serialises_empty_object` test pins this — a future field addition without `skip_serializing_if` would silently bloat config dumps with `null`s and empty arrays.

## New wire-contract tests in `http-types`

- `instance_config_default_is_anonymous` — pristine-boot no-claim contract.
- `instance_config_round_trips` — every field including the metadata `HashMap`.
- `instance_config_default_serialises_empty_object` — empty-object regression guard.
- `instance_config_accepts_minimal_body` — operators boot servers without these fields set; `{}` must deserialise.

## Verification

- `cargo check --workspace` ✅
- `cargo test -p dcc-mcp-http-types` ✅ (45 total: 41 prior + 4 new)
- `cargo test -p dcc-mcp-http --lib config::` ✅ (11 tests)
- `cargo clippy -p dcc-mcp-http-types --all-targets -- -D warnings` ✅
- `cargo clippy -p dcc-mcp-http --no-deps --tests -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅

## Follow-up

Next sub-configs (`ServerConfig`, `SessionConfig`, `GatewayConfig`, `QueueConfig`) need an explicit wire-shape decision: `IpAddr` has a stable serde Display form, but `std::time::Duration` serialises as `{ secs, nanos }` by default which is awkward for env-var / JSON config files. `humantime_serde` produces `"30s"` / `"500ms"` strings; that is the recommended next step.

Builds on #895, #897, #899, #901, #902. Part of #848 epic.