### PR TITLE
refactor(gateway): migrate search_ranking scorers to gateway-core (#845)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,7 +841,6 @@ dependencies = [
  "dcc-mcp-transport",
  "futures",
  "http",
- "nucleo-matcher",
  "parking_lot",
  "prometheus",
  "proptest",
@@ -865,6 +864,7 @@ dependencies = [
 name = "dcc-mcp-gateway-core"
 version = "0.15.7"
 dependencies = [
+ "nucleo-matcher",
  "serde",
  "serde_json",
  "uuid",

--- a/crates/dcc-mcp-gateway-core/Cargo.toml
+++ b/crates/dcc-mcp-gateway-core/Cargo.toml
@@ -19,6 +19,10 @@ workspace = true
 # returns CapabilityRecord arrays), so serde is a hard dependency.
 serde = { workspace = true }
 uuid = { workspace = true }
+# Fuzzy matcher that backs the `FuzzyScorer` / `StrategyFuzzyScorer`
+# ranking strategies (issue #659). Pure CPU code with no async / IO
+# surface, so it keeps the "no HTTP, no runtime" domain-layer rule.
+nucleo-matcher = "0.3"
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/dcc-mcp-gateway-core/src/capability/mod.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/mod.rs
@@ -2,13 +2,14 @@
 //!
 //! # Module map
 //!
-//! | Submodule    | What lives here                                              |
-//! |--------------|--------------------------------------------------------------|
-//! | [`record`]   | `CapabilityRecord`, slug encoding / parsing, validation      |
-//! | [`search`]   | `SearchQuery`, `SearchHit`, `SearchPage`, `SearchMode`       |
-//! | [`index`]    | `IndexSnapshot`, `InstanceFingerprint` — read-side snapshot  |
-//! | [`builder`]  | `BuildOutcome` — output of the per-instance record builder   |
-//! | [`refresh`]  | `RefreshReason` — why a refresh cycle is running             |
+//! | Submodule          | What lives here                                              |
+//! |--------------------|--------------------------------------------------------------|
+//! | [`record`]         | `CapabilityRecord`, slug encoding / parsing, validation      |
+//! | [`search`]         | `SearchQuery`, `SearchHit`, `SearchPage`, `SearchMode`       |
+//! | [`search_ranking`] | `Scorer` / `StrategyScorer` traits + built-in implementations |
+//! | [`index`]          | `IndexSnapshot`, `InstanceFingerprint` — read-side snapshot  |
+//! | [`builder`]        | `BuildOutcome` — output of the per-instance record builder   |
+//! | [`refresh`]        | `RefreshReason` — why a refresh cycle is running             |
 //!
 //! The mutable `CapabilityIndex` (which owns a `parking_lot::RwLock`
 //! and a `BTreeMap` of per-instance state), the `build_records_from_backend`
@@ -20,12 +21,20 @@
 //! refresh-reason classification — live here so any REST/admin
 //! client talking to the gateway can deserialise responses without
 //! pulling the full gateway crate.
+//!
+//! The ranking strategies in [`search_ranking`] also live here even
+//! though they are behaviour rather than wire types: they are pure
+//! CPU code (no async, no IO, no runtime state) and are part of the
+//! search contract — the same query against the same snapshot must
+//! produce the same ordering for every consumer of the domain, not
+//! just the gateway binary.
 
 pub mod builder;
 pub mod index;
 pub mod record;
 pub mod refresh;
 pub mod search;
+pub mod search_ranking;
 
 // Re-export each submodule's public surface from the capability
 // facade so historical paths (`dcc_mcp_gateway_core::capability::
@@ -35,3 +44,7 @@ pub use index::{IndexSnapshot, InstanceFingerprint};
 pub use record::{CapabilityRecord, SCHEMA_AVAILABLE, is_valid_dcc_bucket, parse_slug, tool_slug};
 pub use refresh::RefreshReason;
 pub use search::{DEFAULT_LIMIT, MAX_LIMIT, SearchHit, SearchMode, SearchPage, SearchQuery};
+pub use search_ranking::{
+    ExactScorer, FuzzyScorer, Scorer, ScorerFactory, StrategyExactScorer, StrategyFuzzyScorer,
+    StrategyScorer, SubstringScorer,
+};

--- a/crates/dcc-mcp-gateway-core/src/capability/search_ranking.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/search_ranking.rs
@@ -37,7 +37,7 @@
 //!   exercise search.
 //!
 //! Both internal scorers return scores on the **same scale** (`0` = no
-//! match, higher = better) so the zero-filter in [`super::search::search`]
+//! match, higher = better) so the zero-filter in the search loop
 //! stays valid for either strategy.
 //!
 //! [#659]: https://github.com/loonghao/dcc-mcp-core/issues/659
@@ -162,6 +162,7 @@ pub struct FuzzyScorer {
 impl FuzzyScorer {
     /// Build a scorer with nucleo's default configuration
     /// (case-insensitive, standard ASCII/Unicode rules).
+    #[must_use]
     pub fn new() -> Self {
         Self {
             matcher: Matcher::new(Config::DEFAULT),
@@ -321,7 +322,7 @@ pub type ExactScorer = SubstringScorer;
 /// # Example
 ///
 /// ```rust
-/// use dcc_mcp_gateway::StrategyScorer;
+/// use dcc_mcp_gateway_core::capability::search_ranking::StrategyScorer;
 ///
 /// struct PrefixScorer;
 ///
@@ -411,7 +412,8 @@ impl StrategyScorer for StrategyExactScorer {
 /// # Example
 ///
 /// ```rust
-/// use dcc_mcp_gateway::{ScorerFactory, SearchMode};
+/// use dcc_mcp_gateway_core::capability::search::SearchMode;
+/// use dcc_mcp_gateway_core::capability::search_ranking::ScorerFactory;
 ///
 /// let scorer = ScorerFactory::from_mode(SearchMode::Fuzzy);
 /// let s = scorer.score("sphere", "create_sphere");
@@ -426,6 +428,7 @@ impl ScorerFactory {
     /// |---------------------|--------------------------|
     /// | [`SearchMode::Fuzzy`] | [`StrategyFuzzyScorer`] |
     /// | [`SearchMode::Exact`] | [`StrategyExactScorer`] |
+    #[must_use]
     pub fn from_mode(mode: SearchMode) -> Box<dyn StrategyScorer> {
         match mode {
             SearchMode::Fuzzy => Box::new(StrategyFuzzyScorer),
@@ -444,6 +447,7 @@ impl ScorerFactory {
     ///
     /// Unknown tags fall back to [`StrategyFuzzyScorer`] so existing
     /// configurations that add a new tag do not silently break.
+    #[must_use]
     pub fn from_tag(tag: &str) -> Box<dyn StrategyScorer> {
         match tag.to_ascii_lowercase().as_str() {
             "exact" | "substring" => Box::new(StrategyExactScorer),
@@ -455,7 +459,7 @@ impl ScorerFactory {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::gateway::capability::record::tool_slug;
+    use crate::capability::record::tool_slug;
     use uuid::Uuid;
 
     fn rec(

--- a/crates/dcc-mcp-gateway/Cargo.toml
+++ b/crates/dcc-mcp-gateway/Cargo.toml
@@ -41,8 +41,12 @@ http = "1.0"
 futures = "0.3"
 tokio-stream = { version = "0.1", features = ["sync", "tokio-util"] }
 
-# High-performance fuzzy matcher for the capability search layer (#659).
-nucleo-matcher = "0.3"
+# `nucleo-matcher` (the fuzzy engine backing the `FuzzyScorer` /
+# `StrategyFuzzyScorer` ranking strategies for #659) now lives in
+# `dcc-mcp-gateway-core`. Consuming it transitively here keeps the
+# gateway crate free of any direct fuzzy-matcher dependency while
+# preserving the historical `use dcc_mcp_gateway::ScorerFactory`
+# re-exports.
 
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 

--- a/crates/dcc-mcp-gateway/src/gateway/capability/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/mod.rs
@@ -59,7 +59,6 @@ mod index;
 mod record;
 mod refresh;
 mod search;
-mod search_ranking;
 
 #[cfg(test)]
 mod tests;
@@ -71,7 +70,14 @@ pub use refresh::{RefreshReason, refresh_instance, remove_instance};
 pub use search::{
     DEFAULT_LIMIT, MAX_LIMIT, SearchHit, SearchMode, SearchPage, SearchQuery, search, search_page,
 };
-pub use search_ranking::{
+// Ranking strategies migrated to `dcc-mcp-gateway-core::capability::
+// search_ranking` (issue #845). Re-exported here so historical paths
+// (`crate::gateway::capability::FuzzyScorer`, …) and the
+// `dcc_mcp_gateway::{FuzzyScorer, ScorerFactory, …}` top-level
+// re-exports keep compiling unchanged. New code should prefer
+// importing from `dcc_mcp_gateway_core::capability::search_ranking`
+// directly.
+pub use dcc_mcp_gateway_core::capability::search_ranking::{
     ExactScorer, FuzzyScorer, Scorer, ScorerFactory, StrategyExactScorer, StrategyFuzzyScorer,
     StrategyScorer, SubstringScorer,
 };

--- a/crates/dcc-mcp-gateway/src/gateway/capability/search.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/search.rs
@@ -23,7 +23,7 @@
 
 use super::index::IndexSnapshot;
 use super::record::CapabilityRecord;
-use super::search_ranking::{FuzzyScorer, Scorer, SubstringScorer};
+use dcc_mcp_gateway_core::capability::search_ranking::{FuzzyScorer, Scorer, SubstringScorer};
 
 // Wire types migrated to `dcc-mcp-gateway-core::capability::search`
 // (issue #845, part 3). Re-exported from the historical


### PR DESCRIPTION
Move the pluggable `Scorer` / `StrategyScorer` traits plus the built-in `SubstringScorer`, `FuzzyScorer`, `StrategyFuzzyScorer`, `StrategyExactScorer`, and `ScorerFactory` from `dcc-mcp-gateway` into `dcc-mcp-gateway-core`.

## Why

These types are pure CPU code — no async, no HTTP, no runtime state — so they satisfy the gateway-core invariant ("types + pure domain behaviour, nothing that needs a tokio runtime or a reqwest client"). Ranking is part of the search contract: the same query against the same snapshot must produce the same ordering for every consumer of the domain, not just the gateway binary. That is the same reason `SearchQuery` / `SearchHit` / `SearchMode` already live in gateway-core.

## What

- Add `nucleo-matcher` as a direct dep of gateway-core; drop it from dcc-mcp-gateway (now transitive).
- Register `capability::search_ranking` in gateway-core and re-export its public surface from `capability::mod`.
- `dcc-mcp-gateway` re-exports the same eight names from the historical `crate::gateway::capability::*` and `dcc_mcp_gateway::*` paths so existing call sites (benches, `search.rs`, `gateway/mod.rs`) keep compiling unchanged.
- Annotate `FuzzyScorer::new` and `ScorerFactory::{from_mode, from_tag}` with `#[must_use]` for gateway-core's pedantic clippy lints.

## Part of

Incremental step in #845 (gateway crate split). Follows the pattern established by #894 / #896 / #898 / #900 / #903: one migration per PR, preserved public API via re-export.

## Verification

- `cargo check --workspace` ✅
- `cargo test -p dcc-mcp-gateway-core` — 46 passed, 2 doctests ✅
- `cargo test -p dcc-mcp-gateway --lib` — 295 passed ✅
- `cargo clippy -p dcc-mcp-gateway-core --all-targets -- -D warnings` ✅
- `cargo check -p dcc-mcp-gateway --benches` ✅