### PR TITLE
refactor(http): migrate output wire types to http-types (#852)

### DIFF
--- a/crates/dcc-mcp-http-types/src/lib.rs
+++ b/crates/dcc-mcp-http-types/src/lib.rs
@@ -26,6 +26,7 @@
 //! | crate root  | [`TruncationEnvelope`], [`SseChunkFrame`] + chunk helpers |
 //! | [`error`]   | [`HttpError`] / [`HttpResult`] error taxonomy             |
 //! | [`config`]  | [`ServerSpawnMode`], [`JobRecoveryPolicy`], [`JobConfig`], [`WorkflowConfig`], [`TelemetryConfig`], [`FeatureFlags`], [`InstanceConfig`] |
+//! | [`output`]  | [`output::OutputStream`] and [`output::OutputEntry`] output capture wire types |
 //!
 //! # Migration plan (issue #852)
 //!
@@ -45,6 +46,8 @@
 //! | [`config::TelemetryConfig`] |                                  |
 //! | [`config::FeatureFlags`]    |                                  |
 //! | [`config::InstanceConfig`]  |                                  |
+//! | [`output::OutputStream`]    |                                  |
+//! | [`output::OutputEntry`]     |                                  |
 //!
 //! Each new round of #852 PRs migrates one self-contained subsystem at a
 //! time and re-exports it from `dcc-mcp-http` to preserve the public API.
@@ -54,6 +57,7 @@
 
 pub mod config;
 pub mod error;
+pub mod output;
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/dcc-mcp-http-types/src/output.rs
+++ b/crates/dcc-mcp-http-types/src/output.rs
@@ -1,0 +1,130 @@
+//! Pure wire types for DCC output capture resources.
+//!
+//! Runtime components such as ring buffers, broadcast channels, and resource
+//! producers remain in `dcc-mcp-http`.  This module only contains serialisable
+//! value types shared across crate boundaries.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+/// Which output stream an [`OutputEntry`] came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OutputStream {
+    /// Standard output stream.
+    Stdout,
+    /// Standard error stream.
+    Stderr,
+    /// DCC script editor / console output stream.
+    ScriptEditor,
+}
+
+impl OutputStream {
+    /// Return the stable wire string for this stream.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Stdout => "stdout",
+            Self::Stderr => "stderr",
+            Self::ScriptEditor => "script_editor",
+        }
+    }
+}
+
+/// A single captured output line with metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutputEntry {
+    /// Unix epoch nanoseconds when the line was captured.
+    pub timestamp_ns: u128,
+    /// DCC instance identifier (matches the resource URI segment).
+    pub instance_id: String,
+    /// Which output channel this came from.
+    pub stream: OutputStream,
+    /// The captured text (may include newlines).
+    pub text: String,
+}
+
+impl OutputEntry {
+    /// Create a new output entry with the current system timestamp.
+    #[must_use]
+    pub fn new(
+        instance_id: impl Into<String>,
+        stream: OutputStream,
+        text: impl Into<String>,
+    ) -> Self {
+        let timestamp_ns = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        Self {
+            timestamp_ns,
+            instance_id: instance_id.into(),
+            stream,
+            text: text.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn output_stream_as_str_matches_wire_values() {
+        assert_eq!(OutputStream::Stdout.as_str(), "stdout");
+        assert_eq!(OutputStream::Stderr.as_str(), "stderr");
+        assert_eq!(OutputStream::ScriptEditor.as_str(), "script_editor");
+    }
+
+    #[test]
+    fn output_stream_serialises_as_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&OutputStream::Stdout).unwrap(),
+            "\"stdout\""
+        );
+        assert_eq!(
+            serde_json::to_string(&OutputStream::Stderr).unwrap(),
+            "\"stderr\""
+        );
+        assert_eq!(
+            serde_json::to_string(&OutputStream::ScriptEditor).unwrap(),
+            "\"script_editor\""
+        );
+    }
+
+    #[test]
+    fn output_stream_deserialises_from_snake_case() {
+        let stream: OutputStream = serde_json::from_str("\"script_editor\"").unwrap();
+        assert_eq!(stream, OutputStream::ScriptEditor);
+    }
+
+    #[test]
+    fn output_entry_new_populates_fields() {
+        let entry = OutputEntry::new("maya-1", OutputStream::Stdout, "hello\n");
+
+        assert!(entry.timestamp_ns > 0);
+        assert_eq!(entry.instance_id, "maya-1");
+        assert_eq!(entry.stream, OutputStream::Stdout);
+        assert_eq!(entry.text, "hello\n");
+    }
+
+    #[test]
+    fn output_entry_round_trips_through_json() {
+        let entry = OutputEntry {
+            timestamp_ns: 42,
+            instance_id: "houdini-1".to_owned(),
+            stream: OutputStream::Stderr,
+            text: "warning".to_owned(),
+        };
+
+        let encoded = serde_json::to_string(&entry).unwrap();
+        assert!(encoded.contains("\"stream\":\"stderr\""));
+        let decoded: OutputEntry = serde_json::from_str(&encoded).unwrap();
+
+        assert_eq!(decoded.timestamp_ns, entry.timestamp_ns);
+        assert_eq!(decoded.instance_id, entry.instance_id);
+        assert_eq!(decoded.stream, entry.stream);
+        assert_eq!(decoded.text, entry.text);
+    }
+}

--- a/crates/dcc-mcp-http/src/output.rs
+++ b/crates/dcc-mcp-http/src/output.rs
@@ -33,67 +33,13 @@
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use parking_lot::RwLock;
-use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 
 use crate::resources::{ProducerContent, ResourceError, ResourceProducer, ResourceResult};
+pub use dcc_mcp_http_types::output::{OutputEntry, OutputStream};
 use dcc_mcp_jsonrpc::McpResource;
-
-// ── OutputEntry ────────────────────────────────────────────────────────────────
-
-/// Which output stream an [`OutputEntry`] came from.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum OutputStream {
-    Stdout,
-    Stderr,
-    ScriptEditor,
-}
-
-impl OutputStream {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Stdout => "stdout",
-            Self::Stderr => "stderr",
-            Self::ScriptEditor => "script_editor",
-        }
-    }
-}
-
-/// A single captured output line with metadata.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct OutputEntry {
-    /// Unix epoch nanoseconds when the line was captured.
-    pub timestamp_ns: u128,
-    /// DCC instance identifier (matches the resource URI segment).
-    pub instance_id: String,
-    /// Which output channel this came from.
-    pub stream: OutputStream,
-    /// The captured text (may include newlines).
-    pub text: String,
-}
-
-impl OutputEntry {
-    pub fn new(
-        instance_id: impl Into<String>,
-        stream: OutputStream,
-        text: impl Into<String>,
-    ) -> Self {
-        let timestamp_ns = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos();
-        Self {
-            timestamp_ns,
-            instance_id: instance_id.into(),
-            stream,
-            text: text.into(),
-        }
-    }
-}
 
 // ── OutputBuffer ──────────────────────────────────────────────────────────────
 
@@ -407,8 +353,8 @@ mod tests {
         // round to the same nanosecond count and the `>= cutoff`
         // filter would include line1).
         std::thread::sleep(std::time::Duration::from_millis(20));
-        let cutoff = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
+        let cutoff = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_nanos();
         std::thread::sleep(std::time::Duration::from_millis(20));


### PR DESCRIPTION
## Summary

Continues #852 by moving the pure DCC output capture wire types from the runtime `dcc-mcp-http` crate into the pure `dcc-mcp-http-types` crate.

## Changes

- Add `crates/dcc-mcp-http-types/src/output.rs`
  - `OutputStream`
  - `OutputEntry`
  - serde / constructor unit tests
- Expose the new module from `dcc-mcp-http-types/src/lib.rs`
- Keep runtime logic in `dcc-mcp-http/src/output.rs`
  - `OutputBuffer`, `OutputCapture`, resource producer code stay in the HTTP runtime crate
  - `dcc_mcp_http::output::{OutputEntry, OutputStream}` stays source-compatible via re-export

## Clean Architecture

- `dcc-mcp-http-types` remains free of axum/tokio/reqwest/parking_lot.
- Only pure data contracts moved inward.
- Runtime infrastructure stays in `dcc-mcp-http`.

## Validation

- `vx cargo test -p dcc-mcp-http-types` — 50 passed
- `vx cargo test -p dcc-mcp-http` — 225 unit + 68 integration + doctests passed
- `vx cargo check --all` — passed
- `vx cargo fmt --check` — passed

Contributes to #852.