### PR TITLE
refactor(http): migrate prompt spec types to http-types (#852)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,6 +944,7 @@ dependencies = [
  "dcc-mcp-models",
  "serde",
  "serde_json",
+ "serde_yaml_ng",
  "thiserror 2.0.18",
 ]
 

--- a/crates/dcc-mcp-http-types/Cargo.toml
+++ b/crates/dcc-mcp-http-types/Cargo.toml
@@ -25,4 +25,5 @@ dcc-mcp-models = { path = "../dcc-mcp-models" }
 serde = { workspace = true }
 base64 = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml_ng = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/dcc-mcp-http-types/src/lib.rs
+++ b/crates/dcc-mcp-http-types/src/lib.rs
@@ -27,6 +27,7 @@
 //! | [`error`]   | [`HttpError`] / [`HttpResult`] error taxonomy             |
 //! | [`config`]  | [`ServerSpawnMode`], [`JobRecoveryPolicy`], [`JobConfig`], [`WorkflowConfig`], [`TelemetryConfig`], [`FeatureFlags`], [`InstanceConfig`] |
 //! | [`output`]  | [`output::OutputStream`] and [`output::OutputEntry`] output capture wire types |
+//! | [`prompts`] | [`prompts::PromptSpec`], [`prompts::PromptsSpec`], and related prompt spec types |
 //!
 //! # Migration plan (issue #852)
 //!
@@ -48,6 +49,9 @@
 //! | [`config::InstanceConfig`]  |                                  |
 //! | [`output::OutputStream`]    |                                  |
 //! | [`output::OutputEntry`]     |                                  |
+//! | [`prompts::PromptError`]    |                                  |
+//! | [`prompts::PromptSpec`]     |                                  |
+//! | [`prompts::PromptsSpec`]    |                                  |
 //!
 //! Each new round of #852 PRs migrates one self-contained subsystem at a
 //! time and re-exports it from `dcc-mcp-http` to preserve the public API.
@@ -58,6 +62,7 @@
 pub mod config;
 pub mod error;
 pub mod output;
+pub mod prompts;
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/dcc-mcp-http-types/src/prompts.rs
+++ b/crates/dcc-mcp-http-types/src/prompts.rs
@@ -1,0 +1,191 @@
+//! Pure wire/spec types for the MCP Prompts primitive.
+//!
+//! Runtime prompt registry, filesystem loading, and template rendering stay in
+//! `dcc-mcp-http`.  This module only hosts serialisable prompt specification
+//! types parsed from sibling `prompts.yaml` files plus the prompt error shape.
+
+use serde::{Deserialize, Serialize};
+
+/// Error type surfaced by prompt lookup and rendering.
+#[must_use]
+#[derive(Debug, thiserror::Error)]
+pub enum PromptError {
+    /// Prompt with the requested name was not found.
+    #[error("prompt not found: {0}")]
+    NotFound(String),
+    /// Required argument was missing from the render request.
+    #[error("missing required argument: {0}")]
+    MissingArg(String),
+    /// Prompt source failed to load or parse.
+    #[error("failed to load prompt source: {0}")]
+    Load(String),
+}
+
+/// Result alias for prompt operations.
+pub type PromptResult<T> = Result<T, PromptError>;
+
+/// Declared argument for a hand-authored prompt.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct PromptArgumentSpec {
+    /// Argument name used in `{{placeholder}}` template substitutions.
+    pub name: String,
+    /// Human-readable argument description surfaced by `prompts/list`.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Whether this argument must be provided to `prompts/get`.
+    #[serde(default)]
+    pub required: bool,
+}
+
+/// Single prompt entry inside a sibling `prompts.yaml`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PromptSpec {
+    /// Public prompt name.
+    pub name: String,
+    /// Human-readable prompt description.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Prompt arguments declared for this template.
+    #[serde(default)]
+    pub arguments: Vec<PromptArgumentSpec>,
+    /// Raw prompt template text.
+    pub template: String,
+}
+
+/// Reference to a workflow that should be surfaced as an auto-generated prompt.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkflowPromptRef {
+    /// Path to the workflow YAML (relative to the skill root).
+    pub file: String,
+    /// Public prompt name. When omitted, `{skill}.{workflow.name}` is used.
+    #[serde(default)]
+    pub prompt_name: Option<String>,
+}
+
+/// Parsed contents of a skill's `prompts.yaml`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct PromptsSpec {
+    /// Hand-authored prompt templates.
+    #[serde(default)]
+    pub prompts: Vec<PromptSpec>,
+    /// Workflow YAML files surfaced as generated prompts.
+    #[serde(default)]
+    pub workflows: Vec<WorkflowPromptRef>,
+}
+
+impl PromptsSpec {
+    /// Parse a YAML document into a [`PromptsSpec`].
+    pub fn from_yaml(s: &str) -> Result<Self, String> {
+        serde_yaml_ng::from_str(s).map_err(|e| e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prompt_error_display_is_stable() {
+        assert_eq!(
+            PromptError::NotFound("foo".to_owned()).to_string(),
+            "prompt not found: foo"
+        );
+        assert_eq!(
+            PromptError::MissingArg("scene".to_owned()).to_string(),
+            "missing required argument: scene"
+        );
+        assert_eq!(
+            PromptError::Load("bad yaml".to_owned()).to_string(),
+            "failed to load prompt source: bad yaml"
+        );
+    }
+
+    #[test]
+    fn prompt_argument_defaults_description_and_required() {
+        let arg: PromptArgumentSpec = serde_yaml_ng::from_str("name: frame_range").unwrap();
+
+        assert_eq!(arg.name, "frame_range");
+        assert_eq!(arg.description, None);
+        assert!(!arg.required);
+    }
+
+    #[test]
+    fn prompt_spec_accepts_minimal_yaml() {
+        let spec: PromptSpec = serde_yaml_ng::from_str(
+            r#"
+name: inspect_scene
+template: "Inspect {{scene}}."
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(spec.name, "inspect_scene");
+        assert_eq!(spec.description, None);
+        assert!(spec.arguments.is_empty());
+        assert_eq!(spec.template, "Inspect {{scene}}.");
+    }
+
+    #[test]
+    fn prompts_spec_accepts_prompts_and_workflows() {
+        let spec = PromptsSpec::from_yaml(
+            r#"
+prompts:
+  - name: bake
+    description: Bake a rig.
+    arguments:
+      - name: frame_range
+        description: Frame range to bake.
+        required: true
+    template: "Bake {{frame_range}}."
+workflows:
+  - file: workflows/bake.yaml
+    prompt_name: bake_workflow
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(spec.prompts.len(), 1);
+        assert_eq!(spec.prompts[0].name, "bake");
+        assert_eq!(spec.prompts[0].arguments[0].name, "frame_range");
+        assert!(spec.prompts[0].arguments[0].required);
+        assert_eq!(spec.workflows.len(), 1);
+        assert_eq!(spec.workflows[0].file, "workflows/bake.yaml");
+        assert_eq!(
+            spec.workflows[0].prompt_name.as_deref(),
+            Some("bake_workflow")
+        );
+    }
+
+    #[test]
+    fn prompts_spec_defaults_missing_sections_to_empty() {
+        let spec = PromptsSpec::from_yaml("{}").unwrap();
+
+        assert!(spec.prompts.is_empty());
+        assert!(spec.workflows.is_empty());
+    }
+
+    #[test]
+    fn prompts_spec_round_trips_through_json() {
+        let spec = PromptsSpec {
+            prompts: vec![PromptSpec {
+                name: "review".to_owned(),
+                description: Some("Review scene".to_owned()),
+                arguments: vec![PromptArgumentSpec {
+                    name: "target".to_owned(),
+                    description: None,
+                    required: true,
+                }],
+                template: "Review {{target}}".to_owned(),
+            }],
+            workflows: vec![WorkflowPromptRef {
+                file: "workflows/review.yaml".to_owned(),
+                prompt_name: None,
+            }],
+        };
+
+        let encoded = serde_json::to_string(&spec).unwrap();
+        let decoded: PromptsSpec = serde_json::from_str(&encoded).unwrap();
+
+        assert_eq!(decoded, spec);
+    }
+}

--- a/crates/dcc-mcp-http/src/prompts/spec.rs
+++ b/crates/dcc-mcp-http/src/prompts/spec.rs
@@ -1,64 +1,10 @@
-//! YAML spec types parsed from a skill's sibling `prompts.yaml`.
+//! Prompt spec compatibility facade (issue #852).
+//!
+//! Pure prompt specification types now live in `dcc-mcp-http-types` so callers
+//! can parse and validate prompt YAML without depending on the HTTP runtime
+//! crate. This module re-exports the historical `crate::prompts::spec::*` path
+//! for source compatibility.
 
-use serde::{Deserialize, Serialize};
-
-/// Error type surfaced by [`crate::prompts::PromptRegistry::get`].
-#[must_use]
-#[derive(Debug, thiserror::Error)]
-pub enum PromptError {
-    #[error("prompt not found: {0}")]
-    NotFound(String),
-    #[error("missing required argument: {0}")]
-    MissingArg(String),
-    #[error("failed to load prompt source: {0}")]
-    Load(String),
-}
-
-pub type PromptResult<T> = Result<T, PromptError>;
-
-/// Declared argument for a hand-authored prompt.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct PromptArgumentSpec {
-    pub name: String,
-    #[serde(default)]
-    pub description: Option<String>,
-    #[serde(default)]
-    pub required: bool,
-}
-
-/// Single prompt entry inside a sibling `prompts.yaml`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PromptSpec {
-    pub name: String,
-    #[serde(default)]
-    pub description: Option<String>,
-    #[serde(default)]
-    pub arguments: Vec<PromptArgumentSpec>,
-    pub template: String,
-}
-
-/// Reference to a workflow that should be surfaced as an auto-generated prompt.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct WorkflowPromptRef {
-    /// Path to the workflow YAML (relative to the skill root).
-    pub file: String,
-    /// Public prompt name. When omitted, `{skill}.{workflow.name}` is used.
-    #[serde(default)]
-    pub prompt_name: Option<String>,
-}
-
-/// Parsed contents of a skill's `prompts.yaml`.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct PromptsSpec {
-    #[serde(default)]
-    pub prompts: Vec<PromptSpec>,
-    #[serde(default)]
-    pub workflows: Vec<WorkflowPromptRef>,
-}
-
-impl PromptsSpec {
-    /// Parse a YAML document into a [`PromptsSpec`].
-    pub fn from_yaml(s: &str) -> Result<Self, String> {
-        serde_yaml_ng::from_str(s).map_err(|e| e.to_string())
-    }
-}
+pub use dcc_mcp_http_types::prompts::{
+    PromptArgumentSpec, PromptError, PromptResult, PromptSpec, PromptsSpec, WorkflowPromptRef,
+};


### PR DESCRIPTION
## Summary

Continues #852 by moving pure MCP Prompts spec types from the runtime `dcc-mcp-http` crate into the pure `dcc-mcp-http-types` crate.

## Changes

- Add `crates/dcc-mcp-http-types/src/prompts.rs`
  - `PromptError`
  - `PromptResult`
  - `PromptArgumentSpec`
  - `PromptSpec`
  - `WorkflowPromptRef`
  - `PromptsSpec`
  - YAML / JSON / error display unit tests
- Add `serde_yaml_ng` to `dcc-mcp-http-types` for `PromptsSpec::from_yaml` parity.
- Expose `prompts` from `dcc-mcp-http-types/src/lib.rs` and update module docs.
- Keep `dcc-mcp-http/src/prompts/spec.rs` as a compatibility facade re-exporting the historical public surface.
- Leave runtime prompt registry, filesystem loading, template rendering, and workflow-derived prompt generation in `dcc-mcp-http`.

## Clean Architecture

- `dcc-mcp-http-types` now owns the serialisable prompt YAML contract.
- `dcc-mcp-http` still owns runtime concerns (`PromptRegistry`, `PromptEntry`, `PromptSource`, loader and template renderer).
- Historical imports through `dcc_mcp_http::prompts::*` remain source-compatible.

## Validation

- `vx cargo test -p dcc-mcp-http-types` — 56 passed
- `vx cargo test -p dcc-mcp-http` — 225 unit + 68 integration + doctests passed
- `vx cargo check --all` — passed
- `vx cargo fmt --check` — passed

Contributes to #852.