### PR TITLE
refactor(http): migrate resource value types to http-types (#852)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,6 +941,7 @@ name = "dcc-mcp-http-types"
 version = "0.15.7"
 dependencies = [
  "base64",
+ "dcc-mcp-jsonrpc",
  "dcc-mcp-models",
  "serde",
  "serde_json",

--- a/crates/dcc-mcp-http-types/Cargo.toml
+++ b/crates/dcc-mcp-http-types/Cargo.toml
@@ -20,6 +20,7 @@ workspace = true
 # pure-types crate, so depending on it here keeps the dependency
 # direction inward.
 dcc-mcp-models = { path = "../dcc-mcp-models" }
+dcc-mcp-jsonrpc = { path = "../dcc-mcp-jsonrpc" }
 
 # Workspace shared
 serde = { workspace = true }

--- a/crates/dcc-mcp-http-types/src/lib.rs
+++ b/crates/dcc-mcp-http-types/src/lib.rs
@@ -28,6 +28,7 @@
 //! | [`config`]  | [`ServerSpawnMode`], [`JobRecoveryPolicy`], [`JobConfig`], [`WorkflowConfig`], [`TelemetryConfig`], [`FeatureFlags`], [`InstanceConfig`] |
 //! | [`output`]  | [`output::OutputStream`] and [`output::OutputEntry`] output capture wire types |
 //! | [`prompts`] | [`prompts::PromptSpec`], [`prompts::PromptsSpec`], and related prompt spec types |
+//! | [`resources`] | [`resources::ProducerContent`] / [`resources::ResourceError`] resource values |
 //!
 //! # Migration plan (issue #852)
 //!
@@ -52,6 +53,8 @@
 //! | [`prompts::PromptError`]    |                                  |
 //! | [`prompts::PromptSpec`]     |                                  |
 //! | [`prompts::PromptsSpec`]    |                                  |
+//! | [`resources::ProducerContent`] |                                |
+//! | [`resources::ResourceError`] |                                  |
 //!
 //! Each new round of #852 PRs migrates one self-contained subsystem at a
 //! time and re-exports it from `dcc-mcp-http` to preserve the public API.
@@ -63,6 +66,7 @@ pub mod config;
 pub mod error;
 pub mod output;
 pub mod prompts;
+pub mod resources;
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/dcc-mcp-http-types/src/resources.rs
+++ b/crates/dcc-mcp-http-types/src/resources.rs
@@ -1,0 +1,130 @@
+//! Pure value types for the MCP Resources primitive.
+//!
+//! Runtime producer traits, registries, subscriptions, and built-in resource
+//! producers stay in `dcc-mcp-http`. This module only hosts resource content
+//! and error values that can be shared without depending on the HTTP runtime.
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use dcc_mcp_jsonrpc::ResourceContents;
+
+/// Content returned by a resource producer implementation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProducerContent {
+    /// UTF-8 text payload (stored in `text`). Typically `application/json`.
+    Text {
+        /// Full resource URI.
+        uri: String,
+        /// MIME type for the text payload.
+        mime_type: String,
+        /// UTF-8 resource body.
+        text: String,
+    },
+    /// Binary payload — serialized as base64 under `blob`.
+    Blob {
+        /// Full resource URI.
+        uri: String,
+        /// MIME type for the binary payload.
+        mime_type: String,
+        /// Raw binary resource body.
+        bytes: Vec<u8>,
+    },
+}
+
+impl ProducerContent {
+    /// Convert this producer payload into the JSON-RPC resource content shape.
+    #[must_use]
+    pub fn into_contents(self) -> ResourceContents {
+        match self {
+            Self::Text {
+                uri,
+                mime_type,
+                text,
+            } => ResourceContents {
+                uri,
+                mime_type: Some(mime_type),
+                text: Some(text),
+                blob: None,
+            },
+            Self::Blob {
+                uri,
+                mime_type,
+                bytes,
+            } => ResourceContents {
+                uri,
+                mime_type: Some(mime_type),
+                text: None,
+                blob: Some(BASE64_STANDARD.encode(bytes)),
+            },
+        }
+    }
+}
+
+/// Error type returned by resource producer implementations.
+#[must_use]
+#[derive(Debug, thiserror::Error)]
+pub enum ResourceError {
+    /// Requested resource URI is unknown.
+    #[error("resource not found: {0}")]
+    NotFound(String),
+    /// Requested resource scheme is known but currently disabled.
+    #[error("resource not enabled: {0}")]
+    NotEnabled(String),
+    /// Producer failed while reading resource contents.
+    #[error("resource read failed: {0}")]
+    Read(String),
+}
+
+/// Result alias for resource operations.
+pub type ResourceResult<T> = Result<T, ResourceError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resource_error_display_is_stable() {
+        assert_eq!(
+            ResourceError::NotFound("scene://missing".to_owned()).to_string(),
+            "resource not found: scene://missing"
+        );
+        assert_eq!(
+            ResourceError::NotEnabled("artefact://x".to_owned()).to_string(),
+            "resource not enabled: artefact://x"
+        );
+        assert_eq!(
+            ResourceError::Read("io".to_owned()).to_string(),
+            "resource read failed: io"
+        );
+    }
+
+    #[test]
+    fn text_content_maps_to_resource_contents_text() {
+        let contents = ProducerContent::Text {
+            uri: "scene://current".to_owned(),
+            mime_type: "application/json".to_owned(),
+            text: "{}".to_owned(),
+        }
+        .into_contents();
+
+        assert_eq!(contents.uri, "scene://current");
+        assert_eq!(contents.mime_type.as_deref(), Some("application/json"));
+        assert_eq!(contents.text.as_deref(), Some("{}"));
+        assert_eq!(contents.blob, None);
+    }
+
+    #[test]
+    fn blob_content_maps_to_base64_resource_contents_blob() {
+        let contents = ProducerContent::Blob {
+            uri: "capture://current_window".to_owned(),
+            mime_type: "image/png".to_owned(),
+            bytes: b"png".to_vec(),
+        }
+        .into_contents();
+
+        assert_eq!(contents.uri, "capture://current_window");
+        assert_eq!(contents.mime_type.as_deref(), Some("image/png"));
+        assert_eq!(contents.text, None);
+        assert_eq!(contents.blob.as_deref(), Some("cG5n"));
+    }
+}

--- a/crates/dcc-mcp-http/src/resources/mod.rs
+++ b/crates/dcc-mcp-http/src/resources/mod.rs
@@ -28,7 +28,7 @@
 //!
 //! | File | Responsibility |
 //! |------|----------------|
-//! | `resources_types.rs`     | `ProducerContent`, `ResourceError`, `ResourceResult`, `ResourceProducer` trait, `uri_scheme` helper |
+//! | `resources_types.rs`     | `ProducerContent` / `ResourceError` compatibility re-exports, `ResourceProducer` trait, `uri_scheme` helper |
 //! | `resources_producers.rs` | Built-in producers (`SceneProducer`, `CaptureProducer`, `AuditProducer`, `ArtefactProducer`) + `parse_audit_limit` |
 //! | `resources_tests.rs`     | Unit + `tokio::test` suite |
 

--- a/crates/dcc-mcp-http/src/resources/types.rs
+++ b/crates/dcc-mcp-http/src/resources/types.rs
@@ -1,66 +1,13 @@
-//! Trait + value types shared by [`crate::resources`] producers.
+//! Runtime resource producer trait and compatibility re-exports.
+//!
+//! Pure resource value types live in `dcc-mcp-http-types` so clients can share
+//! the resource content/error contract without depending on the HTTP runtime
+//! crate. The runtime `ResourceProducer` trait stays here because producers are
+//! invoked by the tokio-backed MCP server.
 
-use base64::Engine as _;
-use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use dcc_mcp_jsonrpc::McpResource;
 
-use dcc_mcp_jsonrpc::{McpResource, ResourceContents};
-
-/// Content returned by a [`ResourceProducer`].
-pub enum ProducerContent {
-    /// UTF-8 text payload (stored in `text`). Typically `application/json`.
-    Text {
-        uri: String,
-        mime_type: String,
-        text: String,
-    },
-    /// Binary payload — serialized as base64 under `blob`.
-    Blob {
-        uri: String,
-        mime_type: String,
-        bytes: Vec<u8>,
-    },
-}
-
-impl ProducerContent {
-    pub(crate) fn into_contents(self) -> ResourceContents {
-        match self {
-            ProducerContent::Text {
-                uri,
-                mime_type,
-                text,
-            } => ResourceContents {
-                uri,
-                mime_type: Some(mime_type),
-                text: Some(text),
-                blob: None,
-            },
-            ProducerContent::Blob {
-                uri,
-                mime_type,
-                bytes,
-            } => ResourceContents {
-                uri,
-                mime_type: Some(mime_type),
-                text: None,
-                blob: Some(BASE64_STANDARD.encode(bytes)),
-            },
-        }
-    }
-}
-
-/// Error type returned by [`ResourceProducer::read`].
-#[must_use]
-#[derive(Debug, thiserror::Error)]
-pub enum ResourceError {
-    #[error("resource not found: {0}")]
-    NotFound(String),
-    #[error("resource not enabled: {0}")]
-    NotEnabled(String),
-    #[error("resource read failed: {0}")]
-    Read(String),
-}
-
-pub type ResourceResult<T> = Result<T, ResourceError>;
+pub use dcc_mcp_http_types::resources::{ProducerContent, ResourceError, ResourceResult};
 
 /// A URI-scheme-keyed producer of MCP resources.
 ///


### PR DESCRIPTION
## Summary

Continues #852 by moving pure MCP Resources value types from the runtime `dcc-mcp-http` crate into the pure `dcc-mcp-http-types` crate.

## Changes

- Add `crates/dcc-mcp-http-types/src/resources.rs`
  - `ProducerContent`
  - `ResourceError`
  - `ResourceResult`
  - `ProducerContent::into_contents()` conversion tests for text/blob payloads
  - stable error display tests
- Add `dcc-mcp-jsonrpc` to `dcc-mcp-http-types` so `ProducerContent` can convert to the shared `ResourceContents` wire shape.
- Expose `resources` from `dcc-mcp-http-types/src/lib.rs` and update module docs.
- Keep `dcc-mcp-http/src/resources/types.rs` as the runtime compatibility facade:
  - re-exports pure resource values from `dcc-mcp-http-types`
  - keeps `ResourceProducer` trait in `dcc-mcp-http`
  - keeps `uri_scheme()` runtime helper in `dcc-mcp-http`
- Update resources module docs to describe the new split.

## Clean Architecture

- `dcc-mcp-http-types` owns pure resource content/error values.
- `dcc-mcp-http` still owns runtime concerns (`ResourceProducer`, `ResourceRegistry`, subscriptions, built-in producers, tokio fan-out).
- Historical imports through `dcc_mcp_http::resources::*` remain source-compatible.

## Validation

- `vx cargo test -p dcc-mcp-http-types` — 59 passed
- `vx cargo test -p dcc-mcp-http` — 225 unit + 68 integration + doctests passed
- `vx cargo check --all` — passed
- `vx cargo fmt --check` — passed

Contributes to #852.