### PR TITLE
refactor(http): migrate session log types to http-types (#852)

### DIFF
--- a/crates/dcc-mcp-http-types/src/lib.rs
+++ b/crates/dcc-mcp-http-types/src/lib.rs
@@ -29,6 +29,7 @@
 //! | [`output`]  | [`output::OutputStream`] and [`output::OutputEntry`] output capture wire types |
 //! | [`prompts`] | [`prompts::PromptSpec`], [`prompts::PromptsSpec`], and related prompt spec types |
 //! | [`resources`] | [`resources::ProducerContent`] / [`resources::ResourceError`] resource values |
+//! | [`session`] | [`session::SessionLogLevel`] / [`session::SessionLogMessage`] log values |
 //!
 //! # Migration plan (issue #852)
 //!
@@ -55,6 +56,8 @@
 //! | [`prompts::PromptsSpec`]    |                                  |
 //! | [`resources::ProducerContent`] |                                |
 //! | [`resources::ResourceError`] |                                  |
+//! | [`session::SessionLogLevel`] |                                  |
+//! | [`session::SessionLogMessage`] |                                |
 //!
 //! Each new round of #852 PRs migrates one self-contained subsystem at a
 //! time and re-exports it from `dcc-mcp-http` to preserve the public API.
@@ -67,6 +70,7 @@ pub mod error;
 pub mod output;
 pub mod prompts;
 pub mod resources;
+pub mod session;
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/dcc-mcp-http-types/src/session.rs
+++ b/crates/dcc-mcp-http-types/src/session.rs
@@ -1,0 +1,150 @@
+//! Pure session-scoped wire/value types.
+//!
+//! Runtime session storage, SSE broadcast channels, TTL eviction, and dynamic
+//! tool registries remain in `dcc-mcp-http`. This module only contains
+//! lightweight values used in session-scoped MCP logging.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Session-scoped MCP logging threshold.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionLogLevel {
+    /// Emit all debug/info/warning/error messages.
+    Debug,
+    /// Emit info/warning/error messages.
+    #[default]
+    Info,
+    /// Emit warning/error messages.
+    Warning,
+    /// Emit error messages only.
+    Error,
+}
+
+impl SessionLogLevel {
+    /// Parse MCP log level strings (case-insensitive).
+    #[must_use]
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "debug" => Some(Self::Debug),
+            "info" => Some(Self::Info),
+            "warning" | "warn" => Some(Self::Warning),
+            "error" => Some(Self::Error),
+            _ => None,
+        }
+    }
+
+    /// Return the canonical MCP wire string for this level.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Debug => "debug",
+            Self::Info => "info",
+            Self::Warning => "warning",
+            Self::Error => "error",
+        }
+    }
+
+    /// Whether a message at `message_level` should be emitted under this threshold.
+    #[must_use]
+    pub fn allows(self, message_level: Self) -> bool {
+        self.rank() <= message_level.rank()
+    }
+
+    fn rank(self) -> u8 {
+        match self {
+            Self::Debug => 10,
+            Self::Info => 20,
+            Self::Warning => 30,
+            Self::Error => 40,
+        }
+    }
+}
+
+/// A retained per-session log message for error correlation (`details.log_tail`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionLogMessage {
+    /// Message severity.
+    pub level: SessionLogLevel,
+    /// Logger name that emitted the message.
+    pub logger: String,
+    /// Structured log payload.
+    pub data: Value,
+    /// Optional request id used to correlate messages with a failed tool call.
+    pub request_id: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn log_level_default_is_info() {
+        assert_eq!(SessionLogLevel::default(), SessionLogLevel::Info);
+    }
+
+    #[test]
+    fn log_level_parse_is_case_insensitive_and_accepts_warn_alias() {
+        assert_eq!(
+            SessionLogLevel::parse("DEBUG"),
+            Some(SessionLogLevel::Debug)
+        );
+        assert_eq!(SessionLogLevel::parse("info"), Some(SessionLogLevel::Info));
+        assert_eq!(
+            SessionLogLevel::parse("warn"),
+            Some(SessionLogLevel::Warning)
+        );
+        assert_eq!(
+            SessionLogLevel::parse("warning"),
+            Some(SessionLogLevel::Warning)
+        );
+        assert_eq!(
+            SessionLogLevel::parse("error"),
+            Some(SessionLogLevel::Error)
+        );
+        assert_eq!(SessionLogLevel::parse("trace"), None);
+    }
+
+    #[test]
+    fn log_level_as_str_matches_mcp_wire_values() {
+        assert_eq!(SessionLogLevel::Debug.as_str(), "debug");
+        assert_eq!(SessionLogLevel::Info.as_str(), "info");
+        assert_eq!(SessionLogLevel::Warning.as_str(), "warning");
+        assert_eq!(SessionLogLevel::Error.as_str(), "error");
+    }
+
+    #[test]
+    fn log_level_allows_messages_at_or_above_threshold() {
+        assert!(SessionLogLevel::Debug.allows(SessionLogLevel::Debug));
+        assert!(SessionLogLevel::Debug.allows(SessionLogLevel::Error));
+        assert!(!SessionLogLevel::Warning.allows(SessionLogLevel::Info));
+        assert!(SessionLogLevel::Warning.allows(SessionLogLevel::Error));
+        assert!(SessionLogLevel::Error.allows(SessionLogLevel::Error));
+    }
+
+    #[test]
+    fn log_level_serialises_as_lowercase() {
+        assert_eq!(
+            serde_json::to_string(&SessionLogLevel::Warning).unwrap(),
+            "\"warning\""
+        );
+        let level: SessionLogLevel = serde_json::from_str("\"debug\"").unwrap();
+        assert_eq!(level, SessionLogLevel::Debug);
+    }
+
+    #[test]
+    fn session_log_message_round_trips_through_json() {
+        let msg = SessionLogMessage {
+            level: SessionLogLevel::Error,
+            logger: "dcc.tool".to_owned(),
+            data: serde_json::json!({"message": "failed"}),
+            request_id: Some("req-1".to_owned()),
+        };
+
+        let encoded = serde_json::to_string(&msg).unwrap();
+        let decoded: SessionLogMessage = serde_json::from_str(&encoded).unwrap();
+
+        assert_eq!(decoded, msg);
+    }
+}

--- a/crates/dcc-mcp-http/src/session.rs
+++ b/crates/dcc-mcp-http/src/session.rs
@@ -18,6 +18,7 @@ use tokio::sync::broadcast;
 use uuid::Uuid;
 
 use crate::dynamic_tools::SessionDynamicTools;
+pub use dcc_mcp_http_types::session::{SessionLogLevel, SessionLogMessage};
 use dcc_mcp_jsonrpc::{ClientRoot, McpTool};
 
 /// Maximum number of recent log messages retained per session.
@@ -41,61 +42,6 @@ pub struct ToolListSnapshot {
     pub generation: u64,
     /// The total tool count (before pagination) at snapshot time.
     pub total: usize,
-}
-
-/// Session-scoped MCP logging threshold.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum SessionLogLevel {
-    Debug,
-    #[default]
-    Info,
-    Warning,
-    Error,
-}
-
-impl SessionLogLevel {
-    /// Parse MCP log level strings (case-insensitive).
-    pub fn parse(raw: &str) -> Option<Self> {
-        match raw.trim().to_ascii_lowercase().as_str() {
-            "debug" => Some(Self::Debug),
-            "info" => Some(Self::Info),
-            "warning" | "warn" => Some(Self::Warning),
-            "error" => Some(Self::Error),
-            _ => None,
-        }
-    }
-
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Debug => "debug",
-            Self::Info => "info",
-            Self::Warning => "warning",
-            Self::Error => "error",
-        }
-    }
-
-    /// Whether a message at `message_level` should be emitted under this threshold.
-    pub fn allows(self, message_level: SessionLogLevel) -> bool {
-        self.rank() <= message_level.rank()
-    }
-
-    fn rank(self) -> u8 {
-        match self {
-            Self::Debug => 10,
-            Self::Info => 20,
-            Self::Warning => 30,
-            Self::Error => 40,
-        }
-    }
-}
-
-/// A retained per-session log message for error correlation (`details.log_tail`).
-#[derive(Debug, Clone)]
-pub struct SessionLogMessage {
-    pub level: SessionLogLevel,
-    pub logger: String,
-    pub data: Value,
-    pub request_id: Option<String>,
 }
 
 /// A single MCP session.


### PR DESCRIPTION
## Summary

Continues #852 by moving pure session-scoped MCP logging values from the runtime `dcc-mcp-http` crate into the pure `dcc-mcp-http-types` crate.

## Changes

- Add `crates/dcc-mcp-http-types/src/session.rs`
  - `SessionLogLevel`
  - `SessionLogMessage`
  - parse/as_str/allows unit tests
  - serde roundtrip tests
- Expose `session` from `dcc-mcp-http-types/src/lib.rs` and update module docs.
- Keep `dcc-mcp-http/src/session.rs` as the runtime owner for:
  - `McpSession`
  - `SessionManager`
  - SSE broadcast channels
  - TTL eviction
  - dynamic tools and tool-list cache
- Re-export `SessionLogLevel` and `SessionLogMessage` from the historical `dcc_mcp_http::session` path.

## Clean Architecture

- `dcc-mcp-http-types` owns pure session log value contracts.
- `dcc-mcp-http` still owns all runtime session state and concurrency.
- Historical imports through `dcc_mcp_http::session::{SessionLogLevel, SessionLogMessage}` remain source-compatible.

## Validation

- `vx cargo test -p dcc-mcp-http-types` — 65 passed
- `vx cargo test -p dcc-mcp-http` — 225 unit + 68 integration + doctests passed
- `vx cargo check --all` — passed
- `vx cargo fmt --check` — passed

Contributes to #852.