### PR TITLE
refactor(http): centralize ServerState construction (#852)

### DIFF
--- a/crates/dcc-mcp-http-server/src/dynamic_tools.rs
+++ b/crates/dcc-mcp-http-server/src/dynamic_tools.rs
@@ -120,11 +120,13 @@ impl DynamicToolEntry {
         }
     }
 
+    #[must_use]
     pub fn is_expired(&self) -> bool {
         Instant::now() >= self.expires_at
     }
 
     /// Build the [`McpTool`] descriptor for `tools/list`.
+    #[must_use]
     pub fn to_mcp_tool(&self) -> McpTool {
         let input_schema = if let Some(props) = &self.spec.parameters {
             json!({
@@ -183,6 +185,7 @@ pub struct SessionDynamicTools {
 }
 
 impl SessionDynamicTools {
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
@@ -203,6 +206,7 @@ impl SessionDynamicTools {
     }
 
     /// Look up a tool by assigned name. Returns `None` if expired or not found.
+    #[must_use]
     pub fn get(&self, tool_name: &str) -> Option<&DynamicToolEntry> {
         self.tools.get(tool_name).filter(|e| !e.is_expired())
     }
@@ -224,10 +228,12 @@ impl SessionDynamicTools {
     }
 
     /// Number of registered (including possibly expired) tools.
+    #[must_use]
     pub fn len(&self) -> usize {
         self.tools.len()
     }
 
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.tools.is_empty()
     }
@@ -293,6 +299,7 @@ fn generate_tool_name(base: &str) -> String {
 // ── MCP tool schema builders ──────────────────────────────────────────────────
 
 /// Build the static `register_tool` MCP tool descriptor.
+#[must_use]
 pub fn build_register_tool_descriptor() -> McpTool {
     McpTool {
         name: "register_tool".to_string(),
@@ -372,6 +379,7 @@ pub fn build_register_tool_descriptor() -> McpTool {
 }
 
 /// Build the static `deregister_tool` MCP tool descriptor.
+#[must_use]
 pub fn build_deregister_tool_descriptor() -> McpTool {
     McpTool {
         name: "deregister_tool".to_string(),
@@ -405,6 +413,7 @@ pub fn build_deregister_tool_descriptor() -> McpTool {
 }
 
 /// Build the static `list_dynamic_tools` MCP tool descriptor.
+#[must_use]
 pub fn build_list_dynamic_tools_descriptor() -> McpTool {
     McpTool {
         name: "list_dynamic_tools".to_string(),

--- a/crates/dcc-mcp-http-server/src/executor.rs
+++ b/crates/dcc-mcp-http-server/src/executor.rs
@@ -176,22 +176,26 @@ impl DccExecutorHandle {
 
     /// Current approximate queue depth (issue #715). Safe to call
     /// from any thread.
+    #[must_use]
     pub fn pending(&self) -> usize {
         self.stats.pending()
     }
 
     /// Configured channel capacity (issue #715).
+    #[must_use]
     pub fn capacity(&self) -> usize {
         self.stats.capacity
     }
 
     /// Wait-time of the oldest queued task (issue #715). `None` when
     /// the queue is empty.
+    #[must_use]
     pub fn oldest_submit_age(&self) -> Option<Duration> {
         self.stats.oldest_wait()
     }
 
     /// Observability snapshot for diagnostics (issue #715).
+    #[must_use]
     pub fn queue_stats(&self) -> ExecutorQueueStats {
         let (p50, p95, p99) = self.stats.percentiles();
         ExecutorQueueStats {
@@ -277,6 +281,7 @@ impl DccExecutorHandle {
     ///
     /// `tool_name` is purely for logging; pass the fully-qualified MCP tool
     /// name (`skill__action`).
+    #[must_use]
     pub fn submit_deferred(
         &self,
         tool_name: &str,
@@ -385,12 +390,14 @@ impl DeferredExecutor {
     ///
     /// The default send-timeout for backpressure is 2 s — use
     /// [`Self::with_send_timeout`] to override it.
+    #[must_use]
     pub fn new(queue_depth: usize) -> Self {
         Self::with_send_timeout(queue_depth, Duration::from_millis(2_000))
     }
 
     /// Create a new executor with a bounded queue depth and a custom
     /// send-timeout for the backpressure path (issue #715).
+    #[must_use]
     pub fn with_send_timeout(queue_depth: usize, send_timeout: Duration) -> Self {
         let (tx, rx) = mpsc::channel(queue_depth);
         let stats = ExecutorStats::new(queue_depth, send_timeout);
@@ -401,6 +408,7 @@ impl DeferredExecutor {
     }
 
     /// Get a cloneable handle for submitting tasks from Tokio workers.
+    #[must_use]
     pub fn handle(&self) -> DccExecutorHandle {
         self.handle.clone()
     }
@@ -446,11 +454,13 @@ pub struct InProcessExecutor;
 
 impl InProcessExecutor {
     /// Execute the task immediately on the current thread.
+    #[must_use]
     pub fn execute(&self, func: DccTaskFn) -> String {
         func()
     }
 
     /// Wrap as a [`DccExecutorHandle`] backed by a dedicated Tokio task.
+    #[must_use]
     pub fn into_handle(self) -> (DccExecutorHandle, Arc<tokio::task::JoinHandle<()>>) {
         let (tx, mut rx) = mpsc::channel::<DccTask>(256);
         let stats = ExecutorStats::new(256, Duration::from_millis(2_000));

--- a/crates/dcc-mcp-http-server/src/handlers/tool_builder_core.rs
+++ b/crates/dcc-mcp-http-server/src/handlers/tool_builder_core.rs
@@ -25,6 +25,7 @@ pub fn build_core_tools() -> &'static [McpTool] {
 }
 
 /// Inner builder — called exactly once per process lifetime.
+#[must_use]
 pub fn build_core_tools_inner() -> Vec<McpTool> {
     vec![
         McpTool {

--- a/crates/dcc-mcp-http-server/src/inflight.rs
+++ b/crates/dcc-mcp-http-server/src/inflight.rs
@@ -57,6 +57,7 @@ pub struct CancelToken(Arc<AtomicBool>);
 
 impl CancelToken {
     /// Create a new token (initially not cancelled).
+    #[must_use]
     pub fn new() -> Self {
         Self(Arc::new(AtomicBool::new(false)))
     }
@@ -67,6 +68,7 @@ impl CancelToken {
     }
 
     /// Return `true` if cancellation has been requested.
+    #[must_use]
     pub fn is_cancelled(&self) -> bool {
         self.0.load(Ordering::Acquire)
     }
@@ -109,6 +111,7 @@ impl ProgressReporter {
     /// Create a new reporter.
     ///
     /// If `token` is `None`, all `report()` calls are no-ops (backward compat).
+    #[must_use]
     pub fn new(
         token: Option<Value>,
         session_id: Option<String>,
@@ -183,6 +186,7 @@ pub struct InFlightEntry {
 }
 
 impl InFlightEntry {
+    #[must_use]
     pub fn new(cancel_token: CancelToken, progress: ProgressReporter) -> Self {
         Self {
             cancel_token,
@@ -203,6 +207,7 @@ pub struct InFlightRequests {
 }
 
 impl InFlightRequests {
+    #[must_use]
     pub fn new() -> Self {
         Self {
             map: Arc::new(DashMap::new()),
@@ -215,6 +220,7 @@ impl InFlightRequests {
     }
 
     /// Remove a completed request and return its entry.
+    #[must_use]
     pub fn remove(&self, request_id: &str) -> Option<(String, InFlightEntry)> {
         self.map.remove(request_id)
     }
@@ -222,6 +228,7 @@ impl InFlightRequests {
     /// Set the cancel flag for an in-flight request.
     ///
     /// Returns `true` if the request was found and the flag was set.
+    #[must_use]
     pub fn request_cancel(&self, request_id: &str) -> bool {
         if let Some(entry) = self.map.get(request_id) {
             entry.cancel_token.cancel();
@@ -237,11 +244,13 @@ impl InFlightRequests {
     }
 
     /// Current count of in-flight requests.
+    #[must_use]
     pub fn len(&self) -> usize {
         self.map.len()
     }
 
     /// `true` when there are no in-flight requests.
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.map.is_empty()
     }

--- a/crates/dcc-mcp-http-server/src/lib.rs
+++ b/crates/dcc-mcp-http-server/src/lib.rs
@@ -16,7 +16,6 @@
 //! module paths for source compatibility.
 
 #![forbid(unsafe_code)]
-#![allow(clippy::must_use_candidate)]
 
 pub mod dynamic_tools;
 pub mod executor;
@@ -46,6 +45,7 @@ pub use inflight::{
 pub use notifications::{JobNotifier, WorkflowProgress, WorkflowUpdate};
 pub use server_state::{
     CANCELLED_REQUEST_TTL, ELICITATION_TIMEOUT, ROOTS_REFRESH_TIMEOUT, ServerState,
+    ServerStateBuilder,
 };
 pub use session::{
     McpSession, SessionLogLevel, SessionLogMessage, SessionManager, ToolListSnapshot,

--- a/crates/dcc-mcp-http-server/src/notifications.rs
+++ b/crates/dcc-mcp-http-server/src/notifications.rs
@@ -115,6 +115,7 @@ impl std::fmt::Debug for JobNotifier {
 
 impl JobNotifier {
     /// Create a new notifier bound to `sessions`.
+    #[must_use]
     pub fn new(sessions: SessionManager, job_updates_enabled: bool) -> Self {
         Self {
             sessions,
@@ -126,6 +127,7 @@ impl JobNotifier {
     }
 
     /// Whether `$/dcc.jobUpdated` emission is globally enabled.
+    #[must_use]
     pub fn job_updates_enabled(&self) -> bool {
         self.job_updates_enabled
     }
@@ -235,6 +237,7 @@ impl JobNotifier {
     ///
     /// Useful for tests that want to assert the payload shape without
     /// standing up a full session.
+    #[must_use]
     pub fn workflow_update_payload(upd: &WorkflowUpdate) -> Value {
         NotificationBuilder::new("notifications/$/dcc.workflowUpdated")
             .with_params(workflow_update_params(upd))

--- a/crates/dcc-mcp-http-server/src/server_state.rs
+++ b/crates/dcc-mcp-http-server/src/server_state.rs
@@ -4,6 +4,45 @@
 //! prompts, readiness, and method routing. This module owns the lower-level
 //! runtime fields used by many handlers: tool registries, session state,
 //! in-flight request tracking, job notification, and cache generation.
+//!
+//! ## Lock acquisition rules
+//!
+//! Several fields hold internal locks (`RwLock`, `Mutex`, `DashMap`).
+//! Handlers MUST follow these rules to avoid deadlocks and lock-order
+//! inversions:
+//!
+//! 1. **Acquisition order, outermost first**, when more than one lock is
+//!    held simultaneously:
+//!     1. `registry` / `catalog` / `prompts` / `resources` (long-lived
+//!        registries — read-heavy, may be held across an entire
+//!        `tools/list` build)
+//!     2. `sessions` (snapshots, subscribers — per-session granularity)
+//!     3. `jobs` / `bridge_registry` (per-request orchestration)
+//!     4. `cancelled_requests` / `pending_elicitations` / `in_flight`
+//!        (`DashMap` / sharded maps — never wrapped in a higher-level lock)
+//!
+//!    Do not invert this order. Acquiring `sessions` before `registry`
+//!    in one path while another path does the reverse will deadlock under
+//!    contention.
+//!
+//! 2. **Locks are released before notifying subscribers.** SSE / progress
+//!    notifications must be dispatched *after* dropping every lock they
+//!    do not strictly need — otherwise a slow subscriber stalls the
+//!    registry. Pattern: clone the data out of the lock, drop the guard,
+//!    then call `JobNotifier` / `SessionManager::publish`.
+//!
+//! 3. **Hot-path fields use `DashMap`** (`cancelled_requests`,
+//!    `pending_elicitations`) so reads / writes never require a global
+//!    lock. Do not refactor these into `Arc<RwLock<HashMap<…>>>` —
+//!    contention on the inner `RwLock` would serialise every active
+//!    SSE connection.
+//!
+//! 4. **`registry_generation`** is the canonical signal for cache
+//!    invalidation (issue #438). Bump it via
+//!    [`ServerState::bump_registry_generation`] after any mutation that
+//!    changes the visible tool surface; do *not* hold a registry lock
+//!    across the bump, because `invalidate_all_tool_list_snapshots`
+//!    re-enters `sessions`.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -77,6 +116,41 @@ pub struct ServerState {
 }
 
 impl ServerState {
+    /// Start building a [`ServerState`] from the three required registries.
+    #[must_use]
+    pub fn builder(
+        registry: Arc<ToolRegistry>,
+        dispatcher: Arc<ToolDispatcher>,
+        catalog: Arc<SkillCatalog>,
+    ) -> ServerStateBuilder {
+        let sessions = SessionManager::new();
+        ServerStateBuilder {
+            state: Self {
+                registry,
+                dispatcher,
+                catalog,
+                sessions: sessions.clone(),
+                executor: None,
+                server_name: "dcc-mcp-http".to_owned(),
+                server_version: env!("CARGO_PKG_VERSION").to_owned(),
+                cancelled_requests: Arc::new(DashMap::new()),
+                in_flight: InFlightRequests::new(),
+                pending_elicitations: Arc::new(DashMap::new()),
+                lazy_actions: false,
+                bare_tool_names: true,
+                declared_capabilities: Arc::new(Vec::new()),
+                jobs: Arc::new(JobManager::new()),
+                job_notifier: JobNotifier::new(sessions, true),
+                enable_resources: true,
+                enable_prompts: true,
+                registry_generation: Arc::new(AtomicU64::new(0)),
+                enable_tool_cache: true,
+                #[cfg(feature = "prometheus")]
+                prometheus: None,
+            },
+        }
+    }
+
     /// Remove cancellation entries older than [`CANCELLED_REQUEST_TTL`].
     pub fn purge_expired_cancellations(&self) {
         self.cancelled_requests
@@ -91,7 +165,125 @@ impl ServerState {
     }
 
     /// Read the current registry generation counter.
+    #[must_use]
     pub fn current_registry_generation(&self) -> u64 {
         self.registry_generation.load(Ordering::Relaxed)
+    }
+}
+
+/// Builder for [`ServerState`].
+#[derive(Clone)]
+pub struct ServerStateBuilder {
+    state: ServerState,
+}
+
+impl ServerStateBuilder {
+    /// Use an existing session manager.
+    #[must_use]
+    pub fn with_sessions(mut self, sessions: SessionManager) -> Self {
+        self.state.sessions = sessions;
+        self
+    }
+
+    /// Use an optional DCC main-thread executor.
+    #[must_use]
+    pub fn with_executor(mut self, executor: Option<DccExecutorHandle>) -> Self {
+        self.state.executor = executor;
+        self
+    }
+
+    /// Set the server identity surfaced in `initialize`.
+    #[must_use]
+    pub fn with_server_identity(
+        mut self,
+        server_name: impl Into<String>,
+        server_version: impl Into<String>,
+    ) -> Self {
+        self.state.server_name = server_name.into();
+        self.state.server_version = server_version.into();
+        self
+    }
+
+    /// Use an existing cancelled-request map.
+    #[must_use]
+    pub fn with_cancelled_requests(
+        mut self,
+        cancelled_requests: Arc<DashMap<String, Instant>>,
+    ) -> Self {
+        self.state.cancelled_requests = cancelled_requests;
+        self
+    }
+
+    /// Enable or disable lazy action meta-tools.
+    #[must_use]
+    pub fn with_lazy_actions(mut self, lazy_actions: bool) -> Self {
+        self.state.lazy_actions = lazy_actions;
+        self
+    }
+
+    /// Enable or disable bare tool names.
+    #[must_use]
+    pub fn with_bare_tool_names(mut self, bare_tool_names: bool) -> Self {
+        self.state.bare_tool_names = bare_tool_names;
+        self
+    }
+
+    /// Set capabilities declared by the hosting adapter.
+    #[must_use]
+    pub fn with_declared_capabilities(mut self, declared_capabilities: Vec<String>) -> Self {
+        self.state.declared_capabilities = Arc::new(declared_capabilities);
+        self
+    }
+
+    /// Use an existing job manager.
+    #[must_use]
+    pub fn with_jobs(mut self, jobs: Arc<JobManager>) -> Self {
+        self.state.jobs = jobs;
+        self
+    }
+
+    /// Use an existing job notifier.
+    #[must_use]
+    pub fn with_job_notifier(mut self, job_notifier: JobNotifier) -> Self {
+        self.state.job_notifier = job_notifier;
+        self
+    }
+
+    /// Enable or disable resource handling.
+    #[must_use]
+    pub fn with_resources_enabled(mut self, enable_resources: bool) -> Self {
+        self.state.enable_resources = enable_resources;
+        self
+    }
+
+    /// Enable or disable prompt handling.
+    #[must_use]
+    pub fn with_prompts_enabled(mut self, enable_prompts: bool) -> Self {
+        self.state.enable_prompts = enable_prompts;
+        self
+    }
+
+    /// Enable or disable per-session tool-list caching.
+    #[must_use]
+    pub fn with_tool_cache_enabled(mut self, enable_tool_cache: bool) -> Self {
+        self.state.enable_tool_cache = enable_tool_cache;
+        self
+    }
+
+    /// Use an existing Prometheus exporter.
+    #[cfg(feature = "prometheus")]
+    #[must_use]
+    pub fn with_prometheus(
+        mut self,
+        prometheus: Option<dcc_mcp_telemetry::PrometheusExporter>,
+    ) -> Self {
+        self.state.prometheus = prometheus;
+        self
+    }
+
+    /// Finish building the state.
+    #[must_use]
+    pub fn build(self) -> ServerState {
+        self.state
     }
 }

--- a/crates/dcc-mcp-http-server/src/session.rs
+++ b/crates/dcc-mcp-http-server/src/session.rs
@@ -92,6 +92,7 @@ impl Default for McpSession {
 }
 
 impl McpSession {
+    #[must_use]
     pub fn new() -> Self {
         let id = Uuid::new_v4().to_string();
         let (sse_tx, _) = broadcast::channel(256);
@@ -117,6 +118,7 @@ impl McpSession {
     }
 
     /// Subscribe to SSE events for this session.
+    #[must_use]
     pub fn subscribe(&self) -> broadcast::Receiver<String> {
         self.sse_tx.subscribe()
     }
@@ -135,6 +137,7 @@ pub struct SessionManager {
 }
 
 impl SessionManager {
+    #[must_use]
     pub fn new() -> Self {
         Self {
             sessions: Arc::new(DashMap::new()),
@@ -151,6 +154,7 @@ impl SessionManager {
     }
 
     /// Mark a session as initialized.
+    #[must_use]
     pub fn mark_initialized(&self, session_id: &str) -> bool {
         if let Some(mut s) = self.sessions.get_mut(session_id) {
             s.initialized = true;
@@ -161,6 +165,7 @@ impl SessionManager {
     }
 
     /// Whether the session exists and is initialized.
+    #[must_use]
     pub fn is_initialized(&self, session_id: &str) -> bool {
         self.sessions
             .get(session_id)
@@ -171,6 +176,7 @@ impl SessionManager {
     /// Store the negotiated protocol version on a session.
     ///
     /// Called during `initialize` after version negotiation.
+    #[must_use]
     pub fn set_protocol_version(&self, session_id: &str, version: &str) -> bool {
         if let Some(mut s) = self.sessions.get_mut(session_id) {
             s.protocol_version = Some(version.to_owned());
@@ -181,6 +187,7 @@ impl SessionManager {
     }
 
     /// Retrieve the negotiated protocol version for a session.
+    #[must_use]
     pub fn get_protocol_version(&self, session_id: &str) -> Option<String> {
         self.sessions
             .get(session_id)
@@ -188,6 +195,7 @@ impl SessionManager {
     }
 
     /// Record whether the client opted into delta-tools notifications.
+    #[must_use]
     pub fn set_supports_delta_tools(&self, session_id: &str, enabled: bool) -> bool {
         if let Some(mut s) = self.sessions.get_mut(session_id) {
             s.supports_delta_tools = enabled;
@@ -198,6 +206,7 @@ impl SessionManager {
     }
 
     /// Whether the client for `session_id` opted into delta-tools notifications.
+    #[must_use]
     pub fn supports_delta_tools(&self, session_id: &str) -> bool {
         self.sessions
             .get(session_id)
@@ -206,6 +215,7 @@ impl SessionManager {
     }
 
     /// Update the session's MCP message log threshold.
+    #[must_use]
     pub fn set_log_level(&self, session_id: &str, level: SessionLogLevel) -> bool {
         if let Some(mut s) = self.sessions.get_mut(session_id) {
             s.log_level = level;
@@ -216,6 +226,7 @@ impl SessionManager {
     }
 
     /// Return the session's effective log threshold.
+    #[must_use]
     pub fn get_log_level(&self, session_id: &str) -> SessionLogLevel {
         self.sessions
             .get(session_id)
@@ -224,6 +235,7 @@ impl SessionManager {
     }
 
     /// Retain a log message for later `details.log_tail` correlation.
+    #[must_use]
     pub fn push_log_message(&self, session_id: &str, entry: SessionLogMessage) -> bool {
         if let Some(mut s) = self.sessions.get_mut(session_id) {
             s.recent_logs.push_back(entry);
@@ -237,6 +249,7 @@ impl SessionManager {
     }
 
     /// Return up to `limit` recent log entries correlated to `request_id`.
+    #[must_use]
     pub fn tail_logs_for_request(
         &self,
         session_id: &str,
@@ -270,6 +283,7 @@ impl SessionManager {
     }
 
     /// Record whether the client advertised roots capability.
+    #[must_use]
     pub fn set_supports_roots(&self, session_id: &str, enabled: bool) -> bool {
         if let Some(mut s) = self.sessions.get_mut(session_id) {
             s.supports_roots = enabled;
@@ -280,6 +294,7 @@ impl SessionManager {
     }
 
     /// Whether the client for `session_id` supports roots/list.
+    #[must_use]
     pub fn supports_roots(&self, session_id: &str) -> bool {
         self.sessions
             .get(session_id)
@@ -288,6 +303,7 @@ impl SessionManager {
     }
 
     /// Replace cached roots for the session.
+    #[must_use]
     pub fn set_client_roots(&self, session_id: &str, roots: Vec<ClientRoot>) -> bool {
         if let Some(mut s) = self.sessions.get_mut(session_id) {
             s.client_roots = roots;
@@ -298,6 +314,7 @@ impl SessionManager {
     }
 
     /// Get cached roots for a session.
+    #[must_use]
     pub fn get_client_roots(&self, session_id: &str) -> Vec<ClientRoot> {
         self.sessions
             .get(session_id)
@@ -313,6 +330,7 @@ impl SessionManager {
     /// The caller should also check whether `snapshot.generation` matches
     /// the current `AppState::registry_generation`; if not, the cache is
     /// stale and must be rebuilt.
+    #[must_use]
     pub fn get_tool_list_snapshot(&self, session_id: &str) -> Option<ToolListSnapshot> {
         self.sessions
             .get(session_id)
@@ -326,6 +344,7 @@ impl SessionManager {
     /// subsequent calls can detect staleness.
     ///
     /// Returns `false` if the session does not exist.
+    #[must_use]
     pub fn set_tool_list_snapshot(&self, session_id: &str, snapshot: ToolListSnapshot) -> bool {
         if let Some(mut s) = self.sessions.get_mut(session_id) {
             s.tool_list_snapshot = Some(snapshot);
@@ -338,6 +357,7 @@ impl SessionManager {
     /// Invalidate the `tools/list` cache for a specific session (issue #438).
     ///
     /// Returns `false` if the session does not exist.
+    #[must_use]
     pub fn invalidate_tool_list_snapshot(&self, session_id: &str) -> bool {
         if let Some(mut s) = self.sessions.get_mut(session_id) {
             s.tool_list_snapshot = None;
@@ -358,6 +378,7 @@ impl SessionManager {
     }
 
     /// Get an SSE subscriber for the session.
+    #[must_use]
     pub fn subscribe(&self, session_id: &str) -> Option<broadcast::Receiver<String>> {
         self.sessions.get(session_id).map(|s| s.subscribe())
     }
@@ -372,6 +393,7 @@ impl SessionManager {
     /// Refresh the last-active timestamp for `session_id`.
     ///
     /// Returns `false` if the session does not exist.
+    #[must_use]
     pub fn touch(&self, session_id: &str) -> bool {
         if let Some(mut s) = self.sessions.get_mut(session_id) {
             s.touch();
@@ -414,11 +436,13 @@ impl SessionManager {
     }
 
     /// Whether a session exists.
+    #[must_use]
     pub fn exists(&self, session_id: &str) -> bool {
         self.sessions.contains_key(session_id)
     }
 
     /// Total number of active sessions.
+    #[must_use]
     pub fn count(&self) -> usize {
         self.sessions.len()
     }
@@ -429,6 +453,7 @@ impl SessionManager {
     /// `tools/list_changed`) that fan out to every subscriber. The
     /// returned vector is owned so the caller can iterate without
     /// holding a shard lock.
+    #[must_use]
     pub fn all_ids(&self) -> Vec<String> {
         self.sessions.iter().map(|e| e.key().clone()).collect()
     }
@@ -448,6 +473,7 @@ impl SessionManager {
     /// Build a `Vec<McpTool>` from the session's dynamic tools.
     ///
     /// Returns an empty vec if the session does not exist.
+    #[must_use]
     pub fn dynamic_tools_for_list(&self, session_id: &str) -> Vec<dcc_mcp_jsonrpc::McpTool> {
         self.sessions
             .get_mut(session_id)

--- a/crates/dcc-mcp-http-server/src/workspace.rs
+++ b/crates/dcc-mcp-http-server/src/workspace.rs
@@ -80,6 +80,7 @@ pub struct WorkspaceRoots {
 impl WorkspaceRoots {
     /// Build from a client-advertised list (the shape stored by the
     /// session manager).
+    #[must_use]
     pub fn from_client_roots(roots: &[ClientRoot]) -> Self {
         let mut local_roots = Vec::with_capacity(roots.len());
         let mut raw_uris = Vec::with_capacity(roots.len());
@@ -115,11 +116,13 @@ impl WorkspaceRoots {
     }
 
     /// All roots (as URI strings) in declaration order.
+    #[must_use]
     pub fn roots(&self) -> &[String] {
         &self.raw_uris
     }
 
     /// Local filesystem roots only (the subset usable as a join base).
+    #[must_use]
     pub fn local_roots(&self) -> &[PathBuf] {
         &self.local_roots
     }

--- a/crates/dcc-mcp-http/src/handler/dispatch.rs
+++ b/crates/dcc-mcp-http/src/handler/dispatch.rs
@@ -28,7 +28,7 @@ pub(crate) async fn dispatch_request(
 ) -> Result<JsonRpcResponse, HttpError> {
     // Refresh session TTL on every request so active sessions are not evicted.
     if let Some(id) = session_id {
-        state.server.sessions.touch(id);
+        let _ = state.server.sessions.touch(id);
     }
     // Pluggable method router (#492). Built-ins are pre-registered by
     // `AppState::default_method_router`; embedders may add custom
@@ -43,11 +43,11 @@ pub(crate) async fn handle_initialize(
 ) -> Result<JsonRpcResponse, HttpError> {
     // Create or mark session as initialized
     let sid = if let Some(id) = session_id {
-        state.server.sessions.mark_initialized(id);
+        let _ = state.server.sessions.mark_initialized(id);
         id.to_owned()
     } else {
         let id = state.server.sessions.create();
-        state.server.sessions.mark_initialized(&id);
+        let _ = state.server.sessions.mark_initialized(&id);
         id
     };
 
@@ -61,7 +61,7 @@ pub(crate) async fn handle_initialize(
     let negotiated = negotiate_protocol_version(client_version);
 
     // Store the negotiated version on the session for later handlers.
-    state.server.sessions.set_protocol_version(&sid, negotiated);
+    let _ = state.server.sessions.set_protocol_version(&sid, negotiated);
 
     // Negotiate vendored delta-tools capability.
     let client_wants_delta = req
@@ -73,7 +73,7 @@ pub(crate) async fn handle_initialize(
         .and_then(|d| d.get("enabled"))
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
-    state
+    let _ = state
         .server
         .sessions
         .set_supports_delta_tools(&sid, client_wants_delta);
@@ -85,7 +85,7 @@ pub(crate) async fn handle_initialize(
         .and_then(|p| p.get("capabilities"))
         .and_then(|c| c.get("roots"))
         .is_some();
-    state
+    let _ = state
         .server
         .sessions
         .set_supports_roots(&sid, client_supports_roots);
@@ -302,7 +302,7 @@ pub(crate) async fn handle_tools_list(
             generation: current_gen,
             total,
         };
-        state.server.sessions.set_tool_list_snapshot(sid, snapshot);
+        let _ = state.server.sessions.set_tool_list_snapshot(sid, snapshot);
     }
 
     // 4. Session-scoped dynamic tools (issue #462).

--- a/crates/dcc-mcp-http/src/handlers/tools_call/sync_impl.rs
+++ b/crates/dcc-mcp-http/src/handlers/tools_call/sync_impl.rs
@@ -57,7 +57,7 @@ pub(super) async fn dispatch_sync_tool_call(
     .await;
 
     if let Some(ref rid) = request_id {
-        state.server.in_flight.remove(rid);
+        let _ = state.server.in_flight.remove(rid);
     }
     update_tracked_job(state, tracked_job_id.as_deref(), &dispatch_outcome);
 
@@ -181,7 +181,7 @@ fn early_cancelled_response(
         return Ok(None);
     }
 
-    state.server.in_flight.remove(rid);
+    let _ = state.server.in_flight.remove(rid);
     state.server.cancelled_requests.remove(rid);
     tracing::info!(request_id = %rid, "request cancelled before dispatch");
     Ok(Some(cancelled_response(state, req, rid, true)?))

--- a/crates/dcc-mcp-http/src/server/mod.rs
+++ b/crates/dcc-mcp-http/src/server/mod.rs
@@ -14,7 +14,6 @@ use crate::{
     error::{HttpError, HttpResult},
     executor::DccExecutorHandle,
     handler::{AppState, handle_delete, handle_get, handle_post},
-    inflight::InFlightRequests,
     session::SessionManager,
 };
 use dcc_mcp_actions::{ToolDispatcher, ToolRegistry};
@@ -474,32 +473,28 @@ impl McpHttpServer {
         rest_config.server_version = self.config.server.server_version.clone();
         let rest_router = dcc_mcp_skill_rest::build_skill_rest_router(rest_config);
 
+        let server_state =
+            dcc_mcp_http_server::ServerState::builder(self.registry, self.dispatcher, catalog)
+                .with_sessions(sessions)
+                .with_executor(self.executor)
+                .with_server_identity(
+                    self.config.server.server_name.clone(),
+                    self.config.server.server_version.clone(),
+                )
+                .with_cancelled_requests(cancelled_requests)
+                .with_lazy_actions(self.config.features.lazy_actions)
+                .with_bare_tool_names(self.config.features.bare_tool_names)
+                .with_declared_capabilities(self.config.instance.declared_capabilities.clone())
+                .with_jobs(jobs)
+                .with_job_notifier(job_notifier)
+                .with_resources_enabled(self.config.features.enable_resources)
+                .with_prompts_enabled(self.config.features.enable_prompts)
+                .with_tool_cache_enabled(self.config.session.enable_tool_cache);
+        #[cfg(feature = "prometheus")]
+        let server_state = server_state.with_prometheus(prometheus.clone());
+
         let state = AppState {
-            server: dcc_mcp_http_server::ServerState {
-                registry: self.registry,
-                dispatcher: self.dispatcher,
-                catalog,
-                sessions,
-                executor: self.executor,
-                server_name: self.config.server.server_name.clone(),
-                server_version: self.config.server.server_version.clone(),
-                cancelled_requests,
-                in_flight: InFlightRequests::new(),
-                pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
-                lazy_actions: self.config.features.lazy_actions,
-                bare_tool_names: self.config.features.bare_tool_names,
-                declared_capabilities: std::sync::Arc::new(
-                    self.config.instance.declared_capabilities.clone(),
-                ),
-                jobs,
-                job_notifier,
-                enable_resources: self.config.features.enable_resources,
-                enable_prompts: self.config.features.enable_prompts,
-                registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
-                enable_tool_cache: self.config.session.enable_tool_cache,
-                #[cfg(feature = "prometheus")]
-                prometheus: prometheus.clone(),
-            },
+            server: server_state.build(),
             bridge_registry: crate::BridgeRegistry::new(),
             resources,
             prompts,

--- a/crates/dcc-mcp-http/src/tests/dispatch_with_handler.rs
+++ b/crates/dcc-mcp-http/src/tests/dispatch_with_handler.rs
@@ -11,36 +11,7 @@ pub fn make_app_state_with_handler() -> AppState {
     dispatcher.register_handler("get_scene_info", |_params| {
         Ok(serde_json::json!({"scene": "test_scene", "objects": 3}))
     });
-    AppState {
-        server: dcc_mcp_http_server::ServerState {
-            sessions: SessionManager::new(),
-            executor: None,
-            server_name: "test-dcc".to_string(),
-            server_version: "0.1.0".to_string(),
-            cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
-            in_flight: crate::inflight::InFlightRequests::new(),
-            pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
-            lazy_actions: false,
-            bare_tool_names: true,
-            declared_capabilities: std::sync::Arc::new(Vec::new()),
-            jobs: std::sync::Arc::new(crate::job::JobManager::new()),
-            job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
-            enable_resources: true,
-            enable_prompts: true,
-            registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
-            enable_tool_cache: true,
-            #[cfg(feature = "prometheus")]
-            prometheus: None,
-            registry,
-            dispatcher,
-            catalog,
-        },
-        bridge_registry: crate::BridgeRegistry::new(),
-        resources: crate::resources::ResourceRegistry::new(true, false),
-        prompts: crate::prompts::PromptRegistry::new(true),
-        method_router: crate::handler::AppState::default_method_router(),
-        readiness: crate::handler::AppState::default_readiness(),
-    }
+    make_app_state_from_parts(registry, dispatcher, catalog)
 }
 
 pub fn make_router_with_handler() -> axum::Router {
@@ -66,36 +37,7 @@ fn make_router_with_handler_output(output: Value) -> axum::Router {
     let catalog = Arc::new(SkillCatalog::new(registry.clone()));
     let dispatcher = Arc::new(ToolDispatcher::new((*registry).clone()));
     dispatcher.register_handler("get_scene_info", move |_params| Ok(output.clone()));
-    let state = AppState {
-        server: dcc_mcp_http_server::ServerState {
-            sessions: SessionManager::new(),
-            executor: None,
-            server_name: "test-dcc".to_string(),
-            server_version: "0.1.0".to_string(),
-            cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
-            in_flight: crate::inflight::InFlightRequests::new(),
-            pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
-            lazy_actions: false,
-            bare_tool_names: true,
-            declared_capabilities: std::sync::Arc::new(Vec::new()),
-            jobs: std::sync::Arc::new(crate::job::JobManager::new()),
-            job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
-            enable_resources: true,
-            enable_prompts: true,
-            registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
-            enable_tool_cache: true,
-            #[cfg(feature = "prometheus")]
-            prometheus: None,
-            registry,
-            dispatcher,
-            catalog,
-        },
-        bridge_registry: crate::BridgeRegistry::new(),
-        resources: crate::resources::ResourceRegistry::new(true, false),
-        prompts: crate::prompts::PromptRegistry::new(true),
-        method_router: crate::handler::AppState::default_method_router(),
-        readiness: crate::handler::AppState::default_readiness(),
-    };
+    let state = make_app_state_from_parts(registry, dispatcher, catalog);
 
     Router::new()
         .route(
@@ -245,37 +187,7 @@ pub async fn test_tools_call_handler_error() {
     dispatcher.register_handler("get_scene_info", |_params| {
         Err("simulated DCC error: scene not available".to_string())
     });
-    let state = AppState {
-        server: dcc_mcp_http_server::ServerState {
-            sessions: SessionManager::new(),
-            executor: None,
-            server_name: "test-dcc".to_string(),
-            server_version: "0.1.0".to_string(),
-            cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
-            in_flight: crate::inflight::InFlightRequests::new(),
-            pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
-            lazy_actions: false,
-            bare_tool_names: true,
-            declared_capabilities: std::sync::Arc::new(Vec::new()),
-            jobs: std::sync::Arc::new(crate::job::JobManager::new()),
-            job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
-            enable_resources: true,
-            enable_prompts: true,
-            registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
-            enable_tool_cache: true,
-            #[cfg(feature = "prometheus")]
-            prometheus: None,
-            registry,
-            dispatcher,
-            catalog,
-        },
-        bridge_registry: crate::BridgeRegistry::new(),
-
-        resources: crate::resources::ResourceRegistry::new(true, false),
-        prompts: crate::prompts::PromptRegistry::new(true),
-        method_router: crate::handler::AppState::default_method_router(),
-        readiness: crate::handler::AppState::default_readiness(),
-    };
+    let state = make_app_state_from_parts(registry, dispatcher, catalog);
 
     use crate::handler::{handle_delete, handle_get, handle_post};
     use axum::{Router, routing};

--- a/crates/dcc-mcp-http/src/tests/initialize.rs
+++ b/crates/dcc-mcp-http/src/tests/initialize.rs
@@ -40,8 +40,8 @@ pub async fn test_initialize() {
 pub async fn test_list_roots_reports_cached_session_roots() {
     let state = make_app_state();
     let sid = state.server.sessions.create();
-    state.server.sessions.set_supports_roots(&sid, true);
-    state.server.sessions.set_client_roots(
+    let _ = state.server.sessions.set_supports_roots(&sid, true);
+    let _ = state.server.sessions.set_client_roots(
         &sid,
         vec![
             dcc_mcp_jsonrpc::ClientRoot {
@@ -124,8 +124,8 @@ pub async fn test_list_roots_reports_cached_session_roots() {
 pub async fn test_list_roots_returns_cached_roots() {
     let state = make_app_state();
     let sid = state.server.sessions.create();
-    state.server.sessions.set_supports_roots(&sid, true);
-    state.server.sessions.set_client_roots(
+    let _ = state.server.sessions.set_supports_roots(&sid, true);
+    let _ = state.server.sessions.set_client_roots(
         &sid,
         vec![dcc_mcp_jsonrpc::ClientRoot {
             uri: "file:///projects/demo".to_string(),

--- a/crates/dcc-mcp-http/src/tests/lazy_actions.rs
+++ b/crates/dcc-mcp-http/src/tests/lazy_actions.rs
@@ -6,6 +6,7 @@ use dcc_mcp_skills::SkillCatalog;
 use serde_json::{Value, json};
 use std::sync::Arc;
 
+use super::make_app_state_from_parts;
 use crate::handler::AppState;
 use crate::session::SessionManager;
 
@@ -47,36 +48,9 @@ fn make_state(lazy_actions: bool) -> AppState {
         Ok(json!({"name": "|pSphere1", "radius": r}))
     });
     dispatcher.register_handler("hello_world.greet", |_p| Ok(json!("hi")));
-    AppState {
-        server: dcc_mcp_http_server::ServerState {
-            sessions: SessionManager::new(),
-            executor: None,
-            server_name: "test-dcc".to_string(),
-            server_version: "0.1.0".to_string(),
-            cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
-            in_flight: crate::inflight::InFlightRequests::new(),
-            pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
-            bare_tool_names: true,
-            declared_capabilities: std::sync::Arc::new(Vec::new()),
-            jobs: std::sync::Arc::new(crate::job::JobManager::new()),
-            job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
-            enable_resources: true,
-            enable_prompts: true,
-            registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
-            enable_tool_cache: true,
-            #[cfg(feature = "prometheus")]
-            prometheus: None,
-            registry,
-            dispatcher,
-            catalog,
-            lazy_actions,
-        },
-        bridge_registry: crate::BridgeRegistry::new(),
-        resources: crate::resources::ResourceRegistry::new(true, false),
-        prompts: crate::prompts::PromptRegistry::new(true),
-        method_router: crate::handler::AppState::default_method_router(),
-        readiness: crate::handler::AppState::default_readiness(),
-    }
+    let mut state = make_app_state_from_parts(registry, dispatcher, catalog);
+    state.server.lazy_actions = lazy_actions;
+    state
 }
 
 fn make_router(lazy_actions: bool) -> (axum::Router, SessionManager) {
@@ -115,7 +89,7 @@ async fn call(server: &TestServer, session_id: &str, body: Value) -> Value {
 async fn meta_tools_absent_when_disabled() {
     let (router, sessions) = make_router(false);
     let sid = sessions.create();
-    sessions.set_protocol_version(&sid, "2025-06-18");
+    let _ = sessions.set_protocol_version(&sid, "2025-06-18");
     let server = TestServer::new(router);
     let body = call(
         &server,
@@ -136,7 +110,7 @@ async fn meta_tools_absent_when_disabled() {
 async fn meta_tools_present_when_enabled() {
     let (router, sessions) = make_router(true);
     let sid = sessions.create();
-    sessions.set_protocol_version(&sid, "2025-06-18");
+    let _ = sessions.set_protocol_version(&sid, "2025-06-18");
     let server = TestServer::new(router);
     let body = call(
         &server,
@@ -157,7 +131,7 @@ async fn meta_tools_present_when_enabled() {
 async fn list_actions_omits_schema_body() {
     let (router, sessions) = make_router(true);
     let sid = sessions.create();
-    sessions.set_protocol_version(&sid, "2025-06-18");
+    let _ = sessions.set_protocol_version(&sid, "2025-06-18");
     let server = TestServer::new(router);
     let body = call(
         &server,
@@ -199,7 +173,7 @@ async fn list_actions_omits_schema_body() {
 async fn describe_action_matches_tools_list_schema() {
     let (router, sessions) = make_router(true);
     let sid = sessions.create();
-    sessions.set_protocol_version(&sid, "2025-06-18");
+    let _ = sessions.set_protocol_version(&sid, "2025-06-18");
     let server = TestServer::new(router);
 
     // Fetch the same action through `tools/list` for a reference.
@@ -272,7 +246,7 @@ async fn describe_action_rejects_unknown_id() {
 async fn call_action_dispatches_to_underlying_handler() {
     let (router, sessions) = make_router(true);
     let sid = sessions.create();
-    sessions.set_protocol_version(&sid, "2025-06-18");
+    let _ = sessions.set_protocol_version(&sid, "2025-06-18");
     let server = TestServer::new(router);
     let body = call(
         &server,

--- a/crates/dcc-mcp-http/src/tests/logging.rs
+++ b/crates/dcc-mcp-http/src/tests/logging.rs
@@ -65,7 +65,7 @@ pub async fn test_logging_notifications_respect_session_threshold() {
     let state = make_app_state();
     let sessions = state.server.sessions.clone();
     let sid = sessions.create();
-    sessions.set_protocol_version(&sid, "2025-06-18");
+    let _ = sessions.set_protocol_version(&sid, "2025-06-18");
     let mut rx = sessions.subscribe(&sid).expect("session receiver");
 
     let server = TestServer::new(
@@ -181,7 +181,7 @@ pub async fn test_tools_call_error_includes_log_tail_for_request() {
     let state = make_app_state();
     let sessions = state.server.sessions.clone();
     let sid = sessions.create();
-    sessions.set_protocol_version(&sid, "2025-06-18");
+    let _ = sessions.set_protocol_version(&sid, "2025-06-18");
 
     let server = TestServer::new(
         axum::Router::new()

--- a/crates/dcc-mcp-http/src/tests/mod.rs
+++ b/crates/dcc-mcp-http/src/tests/mod.rs
@@ -38,40 +38,36 @@ fn make_registry() -> ToolRegistry {
     reg
 }
 
-fn make_app_state() -> AppState {
-    let registry = Arc::new(make_registry());
-    let catalog = Arc::new(SkillCatalog::new(registry.clone()));
-    let dispatcher = Arc::new(ToolDispatcher::new((*registry).clone()));
+fn make_server_state(
+    registry: Arc<ToolRegistry>,
+    dispatcher: Arc<ToolDispatcher>,
+    catalog: Arc<SkillCatalog>,
+) -> dcc_mcp_http_server::ServerState {
+    dcc_mcp_http_server::ServerState::builder(registry, dispatcher, catalog)
+        .with_server_identity("test-dcc", "0.1.0")
+        .build()
+}
+
+fn make_app_state_from_parts(
+    registry: Arc<ToolRegistry>,
+    dispatcher: Arc<ToolDispatcher>,
+    catalog: Arc<SkillCatalog>,
+) -> AppState {
     AppState {
-        server: dcc_mcp_http_server::ServerState {
-            sessions: SessionManager::new(),
-            executor: None,
-            server_name: "test-dcc".to_string(),
-            server_version: "0.1.0".to_string(),
-            cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
-            in_flight: crate::inflight::InFlightRequests::new(),
-            pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
-            lazy_actions: false,
-            bare_tool_names: true,
-            declared_capabilities: std::sync::Arc::new(Vec::new()),
-            jobs: std::sync::Arc::new(crate::job::JobManager::new()),
-            job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
-            enable_resources: true,
-            enable_prompts: true,
-            registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
-            enable_tool_cache: true,
-            #[cfg(feature = "prometheus")]
-            prometheus: None,
-            registry,
-            dispatcher,
-            catalog,
-        },
+        server: make_server_state(registry, dispatcher, catalog),
         bridge_registry: crate::BridgeRegistry::new(),
         resources: crate::resources::ResourceRegistry::new(true, false),
         prompts: crate::prompts::PromptRegistry::new(true),
         method_router: crate::handler::AppState::default_method_router(),
         readiness: crate::handler::AppState::default_readiness(),
     }
+}
+
+fn make_app_state() -> AppState {
+    let registry = Arc::new(make_registry());
+    let catalog = Arc::new(SkillCatalog::new(registry.clone()));
+    let dispatcher = Arc::new(ToolDispatcher::new((*registry).clone()));
+    make_app_state_from_parts(registry, dispatcher, catalog)
 }
 
 fn make_router() -> axum::Router {

--- a/crates/dcc-mcp-http/src/tests/next_tools_meta.rs
+++ b/crates/dcc-mcp-http/src/tests/next_tools_meta.rs
@@ -3,6 +3,7 @@ use axum_test::TestServer;
 use serde_json::{Value, json};
 use std::sync::Arc;
 
+use super::make_app_state_from_parts;
 use crate::{handler::AppState, session::SessionManager};
 use dcc_mcp_actions::{ToolDispatcher, ToolMeta, ToolRegistry};
 use dcc_mcp_models::NextTools;
@@ -28,36 +29,7 @@ fn make_state(next_tools: NextTools, with_handler: bool) -> AppState {
     } else {
         dispatcher.register_handler("sample", |_p| Err("boom".to_string()));
     }
-    AppState {
-        server: dcc_mcp_http_server::ServerState {
-            sessions: SessionManager::new(),
-            executor: None,
-            server_name: "test-dcc".to_string(),
-            server_version: "0.1.0".to_string(),
-            cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
-            in_flight: crate::inflight::InFlightRequests::new(),
-            pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
-            lazy_actions: false,
-            bare_tool_names: true,
-            declared_capabilities: std::sync::Arc::new(Vec::new()),
-            jobs: std::sync::Arc::new(crate::job::JobManager::new()),
-            job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
-            enable_resources: true,
-            enable_prompts: true,
-            registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
-            enable_tool_cache: true,
-            #[cfg(feature = "prometheus")]
-            prometheus: None,
-            registry,
-            dispatcher,
-            catalog,
-        },
-        bridge_registry: crate::BridgeRegistry::new(),
-        resources: crate::resources::ResourceRegistry::new(true, false),
-        prompts: crate::prompts::PromptRegistry::new(true),
-        method_router: crate::handler::AppState::default_method_router(),
-        readiness: crate::handler::AppState::default_readiness(),
-    }
+    make_app_state_from_parts(registry, dispatcher, catalog)
 }
 
 fn make_router(state: AppState) -> (axum::Router, SessionManager) {

--- a/crates/dcc-mcp-http/src/tests/pagination.rs
+++ b/crates/dcc-mcp-http/src/tests/pagination.rs
@@ -15,36 +15,7 @@ pub fn make_app_state_many_tools() -> AppState {
     }
     let catalog = Arc::new(SkillCatalog::new(registry.clone()));
     let dispatcher = Arc::new(ToolDispatcher::new((*registry).clone()));
-    AppState {
-        server: dcc_mcp_http_server::ServerState {
-            sessions: SessionManager::new(),
-            executor: None,
-            server_name: "test-dcc".to_string(),
-            server_version: "0.1.0".to_string(),
-            cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
-            in_flight: crate::inflight::InFlightRequests::new(),
-            pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
-            lazy_actions: false,
-            bare_tool_names: true,
-            declared_capabilities: std::sync::Arc::new(Vec::new()),
-            jobs: std::sync::Arc::new(crate::job::JobManager::new()),
-            job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
-            enable_resources: true,
-            enable_prompts: true,
-            registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
-            enable_tool_cache: true,
-            #[cfg(feature = "prometheus")]
-            prometheus: None,
-            registry,
-            dispatcher,
-            catalog,
-        },
-        bridge_registry: crate::BridgeRegistry::new(),
-        resources: crate::resources::ResourceRegistry::new(true, false),
-        prompts: crate::prompts::PromptRegistry::new(true),
-        method_router: crate::handler::AppState::default_method_router(),
-        readiness: crate::handler::AppState::default_readiness(),
-    }
+    make_app_state_from_parts(registry, dispatcher, catalog)
 }
 
 pub fn make_router_many_tools() -> axum::Router {

--- a/crates/dcc-mcp-http/src/tests/readiness_gate.rs
+++ b/crates/dcc-mcp-http/src/tests/readiness_gate.rs
@@ -21,36 +21,8 @@ fn make_state_with_probe() -> (AppState, Arc<StaticReadiness>) {
     });
 
     let probe = Arc::new(StaticReadiness::new());
-    let state = AppState {
-        server: dcc_mcp_http_server::ServerState {
-            sessions: SessionManager::new(),
-            executor: None,
-            server_name: "test-dcc".to_string(),
-            server_version: "0.1.0".to_string(),
-            cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
-            in_flight: crate::inflight::InFlightRequests::new(),
-            pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
-            lazy_actions: false,
-            bare_tool_names: true,
-            declared_capabilities: std::sync::Arc::new(Vec::new()),
-            jobs: std::sync::Arc::new(crate::job::JobManager::new()),
-            job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
-            enable_resources: true,
-            enable_prompts: true,
-            registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
-            enable_tool_cache: true,
-            #[cfg(feature = "prometheus")]
-            prometheus: None,
-            registry,
-            dispatcher,
-            catalog,
-        },
-        bridge_registry: crate::BridgeRegistry::new(),
-        resources: crate::resources::ResourceRegistry::new(true, false),
-        prompts: crate::prompts::PromptRegistry::new(true),
-        method_router: crate::handler::AppState::default_method_router(),
-        readiness: probe.clone(),
-    };
+    let mut state = make_app_state_from_parts(registry, dispatcher, catalog);
+    state.readiness = probe.clone();
     (state, probe)
 }
 

--- a/crates/dcc-mcp-http/src/tests/resource_link.rs
+++ b/crates/dcc-mcp-http/src/tests/resource_link.rs
@@ -3,6 +3,7 @@ use axum_test::TestServer;
 use serde_json::{Value, json};
 use std::sync::Arc;
 
+use super::make_app_state_from_parts;
 use crate::{handler::AppState, session::SessionManager};
 use dcc_mcp_actions::{ToolDispatcher, ToolMeta, ToolRegistry};
 use dcc_mcp_skills::SkillCatalog;
@@ -36,36 +37,7 @@ fn make_app_state_with_artifact_handler() -> AppState {
             "artifact_paths": ["/tmp/shot_010.mp4"]
         }))
     });
-    AppState {
-        server: dcc_mcp_http_server::ServerState {
-            sessions: SessionManager::new(),
-            executor: None,
-            server_name: "test-dcc".to_string(),
-            server_version: "0.1.0".to_string(),
-            cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
-            in_flight: crate::inflight::InFlightRequests::new(),
-            pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
-            lazy_actions: false,
-            bare_tool_names: true,
-            declared_capabilities: std::sync::Arc::new(Vec::new()),
-            jobs: std::sync::Arc::new(crate::job::JobManager::new()),
-            job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
-            enable_resources: true,
-            enable_prompts: true,
-            registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
-            enable_tool_cache: true,
-            #[cfg(feature = "prometheus")]
-            prometheus: None,
-            registry,
-            dispatcher,
-            catalog,
-        },
-        bridge_registry: crate::BridgeRegistry::new(),
-        resources: crate::resources::ResourceRegistry::new(true, false),
-        prompts: crate::prompts::PromptRegistry::new(true),
-        method_router: crate::handler::AppState::default_method_router(),
-        readiness: crate::handler::AppState::default_readiness(),
-    }
+    make_app_state_from_parts(registry, dispatcher, catalog)
 }
 
 fn make_router_with_artifact_handler() -> (axum::Router, SessionManager) {
@@ -88,7 +60,7 @@ fn make_router_with_artifact_handler() -> (axum::Router, SessionManager) {
 async fn test_resource_link_emitted_on_2025_06_18_session() {
     let (router, sessions) = make_router_with_artifact_handler();
     let session_id = sessions.create();
-    sessions.set_protocol_version(&session_id, "2025-06-18");
+    let _ = sessions.set_protocol_version(&session_id, "2025-06-18");
 
     let server = TestServer::new(router);
     let resp = server
@@ -132,7 +104,7 @@ async fn test_resource_link_emitted_on_2025_06_18_session() {
 async fn test_resource_link_suppressed_on_2025_03_26_session() {
     let (router, sessions) = make_router_with_artifact_handler();
     let session_id = sessions.create();
-    sessions.set_protocol_version(&session_id, "2025-03-26");
+    let _ = sessions.set_protocol_version(&session_id, "2025-03-26");
 
     let server = TestServer::new(router);
     let resp = server
@@ -236,36 +208,7 @@ fn make_app_state_with_structured_handler() -> AppState {
         Ok(json!({"nodes": ["|pSphere1", "|pCube1"], "count": 2}))
     });
     dispatcher.register_handler("greet", |_p| Ok(json!("hi there")));
-    AppState {
-        server: dcc_mcp_http_server::ServerState {
-            sessions: SessionManager::new(),
-            executor: None,
-            server_name: "test-dcc".to_string(),
-            server_version: "0.1.0".to_string(),
-            cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
-            in_flight: crate::inflight::InFlightRequests::new(),
-            pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
-            lazy_actions: false,
-            bare_tool_names: true,
-            declared_capabilities: std::sync::Arc::new(Vec::new()),
-            jobs: std::sync::Arc::new(crate::job::JobManager::new()),
-            job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
-            enable_resources: true,
-            enable_prompts: true,
-            registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
-            enable_tool_cache: true,
-            #[cfg(feature = "prometheus")]
-            prometheus: None,
-            registry,
-            dispatcher,
-            catalog,
-        },
-        bridge_registry: crate::BridgeRegistry::new(),
-        resources: crate::resources::ResourceRegistry::new(true, false),
-        prompts: crate::prompts::PromptRegistry::new(true),
-        method_router: crate::handler::AppState::default_method_router(),
-        readiness: crate::handler::AppState::default_readiness(),
-    }
+    make_app_state_from_parts(registry, dispatcher, catalog)
 }
 
 fn make_router_with_structured_handler() -> (axum::Router, SessionManager) {
@@ -288,7 +231,7 @@ fn make_router_with_structured_handler() -> (axum::Router, SessionManager) {
 async fn test_output_schema_emitted_on_2025_06_18_tools_list() {
     let (router, sessions) = make_router_with_structured_handler();
     let session_id = sessions.create();
-    sessions.set_protocol_version(&session_id, "2025-06-18");
+    let _ = sessions.set_protocol_version(&session_id, "2025-06-18");
 
     let server = TestServer::new(router);
     let resp = server
@@ -335,7 +278,7 @@ async fn test_output_schema_emitted_on_2025_06_18_tools_list() {
 async fn test_output_schema_omitted_on_2025_03_26_tools_list() {
     let (router, sessions) = make_router_with_structured_handler();
     let session_id = sessions.create();
-    sessions.set_protocol_version(&session_id, "2025-03-26");
+    let _ = sessions.set_protocol_version(&session_id, "2025-03-26");
 
     let server = TestServer::new(router);
     let resp = server
@@ -367,7 +310,7 @@ async fn test_output_schema_omitted_on_2025_03_26_tools_list() {
 async fn test_structured_content_emitted_on_2025_06_18_call() {
     let (router, sessions) = make_router_with_structured_handler();
     let session_id = sessions.create();
-    sessions.set_protocol_version(&session_id, "2025-06-18");
+    let _ = sessions.set_protocol_version(&session_id, "2025-06-18");
 
     let server = TestServer::new(router);
     let resp = server
@@ -408,7 +351,7 @@ async fn test_structured_content_emitted_on_2025_06_18_call() {
 async fn test_structured_content_omitted_on_2025_03_26_call() {
     let (router, sessions) = make_router_with_structured_handler();
     let session_id = sessions.create();
-    sessions.set_protocol_version(&session_id, "2025-03-26");
+    let _ = sessions.set_protocol_version(&session_id, "2025-03-26");
 
     let server = TestServer::new(router);
     let resp = server
@@ -445,7 +388,7 @@ async fn test_structured_content_omitted_on_2025_03_26_call() {
 async fn test_structured_content_omitted_for_string_output() {
     let (router, sessions) = make_router_with_structured_handler();
     let session_id = sessions.create();
-    sessions.set_protocol_version(&session_id, "2025-06-18");
+    let _ = sessions.set_protocol_version(&session_id, "2025-06-18");
 
     let server = TestServer::new(router);
     let resp = server

--- a/crates/dcc-mcp-http/src/tests/search_skills.rs
+++ b/crates/dcc-mcp-http/src/tests/search_skills.rs
@@ -47,36 +47,7 @@ pub fn make_app_state_with_skills() -> AppState {
     catalog.add_skill(skill2);
 
     let dispatcher = Arc::new(ToolDispatcher::new((*registry).clone()));
-    AppState {
-        server: dcc_mcp_http_server::ServerState {
-            sessions: SessionManager::new(),
-            executor: None,
-            server_name: "test-dcc".to_string(),
-            server_version: "0.1.0".to_string(),
-            cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
-            in_flight: crate::inflight::InFlightRequests::new(),
-            pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
-            lazy_actions: false,
-            bare_tool_names: true,
-            declared_capabilities: std::sync::Arc::new(Vec::new()),
-            jobs: std::sync::Arc::new(crate::job::JobManager::new()),
-            job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
-            enable_resources: true,
-            enable_prompts: true,
-            registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
-            enable_tool_cache: true,
-            #[cfg(feature = "prometheus")]
-            prometheus: None,
-            registry,
-            dispatcher,
-            catalog,
-        },
-        bridge_registry: crate::BridgeRegistry::new(),
-        resources: crate::resources::ResourceRegistry::new(true, false),
-        prompts: crate::prompts::PromptRegistry::new(true),
-        method_router: crate::handler::AppState::default_method_router(),
-        readiness: crate::handler::AppState::default_readiness(),
-    }
+    make_app_state_from_parts(registry, dispatcher, catalog)
 }
 
 pub fn make_router_with_skills() -> axum::Router {

--- a/crates/dcc-mcp-http/src/tests/search_tools.rs
+++ b/crates/dcc-mcp-http/src/tests/search_tools.rs
@@ -90,36 +90,7 @@ fn make_app_state_with_stub_named_actions() -> AppState {
 
     let catalog = Arc::new(dcc_mcp_skills::SkillCatalog::new(registry.clone()));
     let dispatcher = Arc::new(dcc_mcp_actions::ToolDispatcher::new((*registry).clone()));
-    AppState {
-        server: dcc_mcp_http_server::ServerState {
-            sessions: SessionManager::new(),
-            executor: None,
-            server_name: "test-dcc".to_string(),
-            server_version: "0.1.0".to_string(),
-            cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
-            in_flight: crate::inflight::InFlightRequests::new(),
-            pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
-            lazy_actions: false,
-            bare_tool_names: true,
-            declared_capabilities: std::sync::Arc::new(Vec::new()),
-            jobs: std::sync::Arc::new(crate::job::JobManager::new()),
-            job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
-            enable_resources: true,
-            enable_prompts: true,
-            registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
-            enable_tool_cache: true,
-            #[cfg(feature = "prometheus")]
-            prometheus: None,
-            registry,
-            dispatcher,
-            catalog,
-        },
-        bridge_registry: crate::BridgeRegistry::new(),
-        resources: crate::resources::ResourceRegistry::new(true, false),
-        prompts: crate::prompts::PromptRegistry::new(true),
-        method_router: crate::handler::AppState::default_method_router(),
-        readiness: crate::handler::AppState::default_readiness(),
-    }
+    make_app_state_from_parts(registry, dispatcher, catalog)
 }
 
 fn make_router_with_stub_named_actions() -> axum::Router {

--- a/crates/dcc-mcp-http/src/tests/session.rs
+++ b/crates/dcc-mcp-http/src/tests/session.rs
@@ -132,7 +132,7 @@ pub fn test_session_evict_stale_does_not_touch_initialized_flag() {
     use std::time::Duration;
     let mgr = SessionManager::new();
     let id = mgr.create();
-    mgr.mark_initialized(&id);
+    let _ = mgr.mark_initialized(&id);
 
     // Sanity: session is initialized before eviction.
     assert!(mgr.is_initialized(&id));

--- a/crates/dcc-mcp-http/src/tests/skill_discovery.rs
+++ b/crates/dcc-mcp-http/src/tests/skill_discovery.rs
@@ -33,36 +33,8 @@ pub fn make_app_state_with_skill() -> AppState {
         ..Default::default()
     });
 
-    AppState {
-        server: dcc_mcp_http_server::ServerState {
-            registry: registry.clone(),
-            dispatcher: Arc::new(ToolDispatcher::new((*registry).clone())),
-            sessions: SessionManager::new(),
-            executor: None,
-            server_name: "test-dcc".to_string(),
-            server_version: "0.1.0".to_string(),
-            cancelled_requests: std::sync::Arc::new(dashmap::DashMap::new()),
-            in_flight: crate::inflight::InFlightRequests::new(),
-            pending_elicitations: std::sync::Arc::new(dashmap::DashMap::new()),
-            lazy_actions: false,
-            bare_tool_names: true,
-            declared_capabilities: std::sync::Arc::new(Vec::new()),
-            jobs: std::sync::Arc::new(crate::job::JobManager::new()),
-            job_notifier: crate::notifications::JobNotifier::new(SessionManager::new(), true),
-            enable_resources: true,
-            enable_prompts: true,
-            registry_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
-            enable_tool_cache: true,
-            #[cfg(feature = "prometheus")]
-            prometheus: None,
-            catalog,
-        },
-        bridge_registry: crate::BridgeRegistry::new(),
-        resources: crate::resources::ResourceRegistry::new(true, false),
-        prompts: crate::prompts::PromptRegistry::new(true),
-        method_router: crate::handler::AppState::default_method_router(),
-        readiness: crate::handler::AppState::default_readiness(),
-    }
+    let dispatcher = Arc::new(ToolDispatcher::new((*registry).clone()));
+    make_app_state_from_parts(registry, dispatcher, catalog)
 }
 
 pub fn make_router_with_skill() -> axum::Router {


### PR DESCRIPTION
Address review feedback from the `dcc-mcp-http-server` extraction.

## What changed

- Restored the old lock acquisition rules from the removed handler state docs into `dcc-mcp-http-server/src/server_state.rs` module docs, preserving the registry → sessions → jobs/bridge → DashMap ordering guidance.
- Added `ServerState::builder` and `ServerStateBuilder` so production startup and tests stop relying on large `ServerState { ... }` literals.
- Updated `McpHttpServer` startup to use the builder while preserving sessions, cancellation GC, jobs, notifications, declared capabilities, feature flags, tool cache, and Prometheus wiring.
- Consolidated HTTP tests on shared `make_server_state` / `make_app_state_from_parts` helpers; the duplicate ServerState literals are gone.
- Removed the crate-level `#![allow(clippy::must_use_candidate)]` from `dcc-mcp-http-server`; the concrete functions that return meaningful values now carry `#[must_use]`, and intentional ignored side-effect results use `let _ = ...`.

## Verification

- `cargo check --workspace`
- `cargo clippy -p dcc-mcp-http-server -p dcc-mcp-http --all-targets -- -D warnings`
- `cargo test -p dcc-mcp-http-server -p dcc-mcp-http --lib`

All commands were run with `PYO3_PYTHON=C:/Users/hallong/AppData/Local/Programs/Python/Python312/python.exe` where PyO3 was needed.
