### PR TITLE
refactor(http): introduce http-py facade crate (#852)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,6 +803,7 @@ dependencies = [
  "dcc-mcp-capture",
  "dcc-mcp-host",
  "dcc-mcp-http",
+ "dcc-mcp-http-py",
  "dcc-mcp-logging",
  "dcc-mcp-models",
  "dcc-mcp-naming",
@@ -934,6 +935,17 @@ dependencies = [
  "tower-http",
  "tracing",
  "uuid",
+ "workspace-hack",
+]
+
+[[package]]
+name = "dcc-mcp-http-py"
+version = "0.15.7"
+dependencies = [
+ "dcc-mcp-http",
+ "pyo3",
+ "pyo3-stub-gen",
+ "pyo3-stub-gen-derive",
  "workspace-hack",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "crates/dcc-mcp-http",
     "crates/dcc-mcp-http-types",
     "crates/dcc-mcp-http-server",
+    "crates/dcc-mcp-http-py",
     "crates/dcc-mcp-server",
     "crates/dcc-mcp-workflow",
     "crates/dcc-mcp-scheduler",
@@ -68,6 +69,7 @@ dcc-mcp-capture = { path = "crates/dcc-mcp-capture" }
 dcc-mcp-usd = { path = "crates/dcc-mcp-usd" }
 dcc-mcp-http = { path = "crates/dcc-mcp-http" }
 dcc-mcp-http-server = { path = "crates/dcc-mcp-http-server" }
+dcc-mcp-http-py = { path = "crates/dcc-mcp-http-py" }
 dcc-mcp-server = { path = "crates/dcc-mcp-server" }
 dcc-mcp-workflow = { path = "crates/dcc-mcp-workflow" }
 dcc-mcp-scheduler = { path = "crates/dcc-mcp-scheduler" }
@@ -164,6 +166,7 @@ dcc-mcp-shm.workspace = true
 dcc-mcp-capture.workspace = true
 dcc-mcp-usd.workspace = true
 dcc-mcp-http.workspace = true
+dcc-mcp-http-py.workspace = true
 dcc-mcp-artefact.workspace = true
 dcc-mcp-host.workspace = true
 
@@ -199,7 +202,7 @@ strip = true
 
 [features]
 default = []
-python-bindings = ["pyo3", "dcc-mcp-naming/python-bindings", "dcc-mcp-models/python-bindings", "dcc-mcp-actions/python-bindings", "dcc-mcp-skills/python-bindings", "dcc-mcp-protocols/python-bindings", "dcc-mcp-logging/python-bindings", "dcc-mcp-pybridge/python-bindings", "dcc-mcp-paths/python-bindings", "dcc-mcp-transport/python-bindings", "dcc-mcp-process/python-bindings", "dcc-mcp-telemetry/python-bindings", "dcc-mcp-sandbox/python-bindings", "dcc-mcp-shm/python-bindings", "dcc-mcp-capture/python-bindings", "dcc-mcp-usd/python-bindings", "dcc-mcp-http/python-bindings", "dcc-mcp-artefact/python-bindings", "dcc-mcp-host/python-bindings", "dcc-mcp-workflow?/python-bindings", "dcc-mcp-scheduler?/python-bindings"]
+python-bindings = ["pyo3", "dcc-mcp-naming/python-bindings", "dcc-mcp-models/python-bindings", "dcc-mcp-actions/python-bindings", "dcc-mcp-skills/python-bindings", "dcc-mcp-protocols/python-bindings", "dcc-mcp-logging/python-bindings", "dcc-mcp-pybridge/python-bindings", "dcc-mcp-paths/python-bindings", "dcc-mcp-transport/python-bindings", "dcc-mcp-process/python-bindings", "dcc-mcp-telemetry/python-bindings", "dcc-mcp-sandbox/python-bindings", "dcc-mcp-shm/python-bindings", "dcc-mcp-capture/python-bindings", "dcc-mcp-usd/python-bindings", "dcc-mcp-http-py/python-bindings", "dcc-mcp-artefact/python-bindings", "dcc-mcp-host/python-bindings", "dcc-mcp-workflow?/python-bindings", "dcc-mcp-scheduler?/python-bindings"]
 # Opt into the first-class Workflow primitive (issue #348). Off by default
 # for one release — enables WorkflowSpec/WorkflowStatus in Python and the
 # workflows.* built-in tools in Rust. Step execution is stubbed; see #348.
@@ -240,7 +243,7 @@ stub-gen = [
     "dcc-mcp-shm/stub-gen",
     "dcc-mcp-capture/stub-gen",
     "dcc-mcp-usd/stub-gen",
-    "dcc-mcp-http/stub-gen",
+    "dcc-mcp-http-py/stub-gen",
     "dcc-mcp-artefact/stub-gen",
     "dcc-mcp-workflow/stub-gen",
     "dcc-mcp-scheduler/stub-gen",

--- a/crates/dcc-mcp-http-py/Cargo.toml
+++ b/crates/dcc-mcp-http-py/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "dcc-mcp-http-py"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "PyO3 facade for the DCC MCP HTTP server Python bindings."
+keywords = ["mcp", "http", "python", "pyo3"]
+categories = ["api-bindings"]
+
+[lints]
+workspace = true
+
+[dependencies]
+dcc-mcp-http = { path = "../dcc-mcp-http" }
+pyo3 = { workspace = true, optional = true }
+pyo3-stub-gen = { workspace = true, optional = true }
+pyo3-stub-gen-derive = { workspace = true, optional = true }
+workspace-hack = { version = "0.1", path = "../workspace-hack" }
+
+[features]
+default = []
+python-bindings = ["dep:pyo3", "dcc-mcp-http/python-bindings"]
+stub-gen = [
+    "python-bindings",
+    "dep:pyo3-stub-gen",
+    "dep:pyo3-stub-gen-derive",
+    "dcc-mcp-http/stub-gen",
+]
+prometheus = ["dcc-mcp-http/prometheus"]
+job-persist-sqlite = ["dcc-mcp-http/job-persist-sqlite"]

--- a/crates/dcc-mcp-http-py/src/lib.rs
+++ b/crates/dcc-mcp-http-py/src/lib.rs
@@ -1,0 +1,24 @@
+//! PyO3 facade for the DCC MCP HTTP server (issue #852).
+//!
+//! This crate is the Python-binding boundary for `dcc-mcp-http`. The
+//! implementation still lives in `dcc-mcp-http::python` for this first
+//! extraction step; downstream crates should depend on this crate for Python
+//! registration so the implementation can move here module-by-module without
+//! changing the root `_core` module again.
+//!
+//! Dependency direction:
+//!
+//! ```text
+//! dcc-mcp-core (_core extension) → dcc-mcp-http-py → dcc-mcp-http
+//! ```
+
+#![forbid(unsafe_code)]
+
+#[cfg(feature = "python-bindings")]
+pub use dcc_mcp_http::python::*;
+
+/// Register HTTP Python classes and functions on the root `_core` module.
+#[cfg(feature = "python-bindings")]
+pub fn register_classes(m: &pyo3::Bound<'_, pyo3::types::PyModule>) -> pyo3::PyResult<()> {
+    dcc_mcp_http::python::register_classes(m)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,7 +301,7 @@ fn register_usd(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
 #[cfg(feature = "python-bindings")]
 fn register_http(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    dcc_mcp_http::python::register_classes(m)
+    dcc_mcp_http_py::register_classes(m)
 }
 
 #[cfg(feature = "python-bindings")]


### PR DESCRIPTION
Create `dcc-mcp-http-py` as the first explicit Python-binding boundary for #852.

## What

- Add a new workspace crate `dcc-mcp-http-py`.
- The crate currently delegates to `dcc-mcp-http::python`; this keeps the diff small while giving follow-up PRs a stable crate boundary to move PyO3 modules into module-by-module.
- Root `_core` registration now calls `dcc_mcp_http_py::register_classes` instead of `dcc_mcp_http::python::register_classes`.
- Top-level `python-bindings` and `stub-gen` features now route through `dcc-mcp-http-py` instead of directly through `dcc-mcp-http`.

## Why

This is the safe first step in the http/py split: downstream registration depends on the py crate now, so the implementation can move out of `dcc-mcp-http/src/python` in smaller PRs without touching the root extension module again.

## Verification

- `cargo check --workspace`
- `cargo check -p dcc-mcp-http-py --features python-bindings`
- `cargo check -p dcc-mcp-core --features python-bindings`
- `cargo test -p dcc-mcp-http-py`
- `cargo clippy -p dcc-mcp-http-py --all-targets -- -D warnings`

Note: `cargo clippy -p dcc-mcp-core --features python-bindings --all-targets -- -D warnings` currently exposes pre-existing `collapsible_if` lints in `dcc-mcp-actions/src/pipeline/python/pipeline.rs`; this PR does not change that area.
