### PR TITLE
refactor(http-py): move WorkspaceRoots binding out of http crate (#852)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,6 +943,7 @@ name = "dcc-mcp-http-py"
 version = "0.15.7"
 dependencies = [
  "dcc-mcp-http",
+ "dcc-mcp-jsonrpc",
  "pyo3",
  "pyo3-stub-gen",
  "pyo3-stub-gen-derive",

--- a/crates/dcc-mcp-http-py/Cargo.toml
+++ b/crates/dcc-mcp-http-py/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 
 [dependencies]
 dcc-mcp-http = { path = "../dcc-mcp-http" }
+dcc-mcp-jsonrpc = { path = "../dcc-mcp-jsonrpc" }
 pyo3 = { workspace = true, optional = true }
 pyo3-stub-gen = { workspace = true, optional = true }
 pyo3-stub-gen-derive = { workspace = true, optional = true }

--- a/crates/dcc-mcp-http-py/src/lib.rs
+++ b/crates/dcc-mcp-http-py/src/lib.rs
@@ -1,10 +1,8 @@
 //! PyO3 facade for the DCC MCP HTTP server (issue #852).
 //!
-//! This crate is the Python-binding boundary for `dcc-mcp-http`. The
-//! implementation still lives in `dcc-mcp-http::python` for this first
-//! extraction step; downstream crates should depend on this crate for Python
-//! registration so the implementation can move here module-by-module without
-//! changing the root `_core` module again.
+//! This crate is the Python-binding boundary for `dcc-mcp-http`. Modules move
+//! here incrementally; during the transition, unmoved bindings are still
+//! delegated to `dcc-mcp-http::python`.
 //!
 //! Dependency direction:
 //!
@@ -15,10 +13,19 @@
 #![forbid(unsafe_code)]
 
 #[cfg(feature = "python-bindings")]
+use pyo3::types::PyModuleMethods;
+
+#[cfg(feature = "python-bindings")]
+pub mod workspace;
+
+#[cfg(feature = "python-bindings")]
 pub use dcc_mcp_http::python::*;
+#[cfg(feature = "python-bindings")]
+pub use workspace::PyWorkspaceRoots;
 
 /// Register HTTP Python classes and functions on the root `_core` module.
 #[cfg(feature = "python-bindings")]
 pub fn register_classes(m: &pyo3::Bound<'_, pyo3::types::PyModule>) -> pyo3::PyResult<()> {
+    m.add_class::<PyWorkspaceRoots>()?;
     dcc_mcp_http::python::register_classes(m)
 }

--- a/crates/dcc-mcp-http-py/src/workspace.rs
+++ b/crates/dcc-mcp-http-py/src/workspace.rs
@@ -1,6 +1,9 @@
 //! Typed `workspace://` URI resolver.
 
-use super::*;
+use pyo3::prelude::*;
+
+/// Re-exported Rust resolver backing the Python wrapper.
+use dcc_mcp_http::workspace::WorkspaceRoots;
 
 /// Typed `workspace://` URI resolver built from the client-advertised MCP
 /// roots (issue #354).
@@ -14,7 +17,7 @@ use super::*;
 #[pyclass(name = "WorkspaceRoots", skip_from_py_object)]
 #[derive(Clone, Default)]
 pub struct PyWorkspaceRoots {
-    pub(crate) inner: crate::workspace::WorkspaceRoots,
+    pub(crate) inner: WorkspaceRoots,
 }
 
 #[pymethods]
@@ -43,7 +46,7 @@ impl PyWorkspaceRoots {
             client_roots.push(dcc_mcp_jsonrpc::ClientRoot { uri, name: None });
         }
         Self {
-            inner: crate::workspace::WorkspaceRoots::from_client_roots(&client_roots),
+            inner: WorkspaceRoots::from_client_roots(&client_roots),
         }
     }
 

--- a/crates/dcc-mcp-http/src/lib.rs
+++ b/crates/dcc-mcp-http/src/lib.rs
@@ -105,9 +105,7 @@ pub use session::SessionManager;
 pub use workspace::{WorkspaceResolveError, WorkspaceRoots};
 
 #[cfg(feature = "python-bindings")]
-pub use python::{
-    PyMcpHttpConfig, PyMcpHttpServer, PyReadinessProbe, PyServerHandle, PyWorkspaceRoots,
-};
+pub use python::{PyMcpHttpConfig, PyMcpHttpServer, PyReadinessProbe, PyServerHandle};
 
 #[cfg(test)]
 mod tests;

--- a/crates/dcc-mcp-http/src/python/bridge.rs
+++ b/crates/dcc-mcp-http/src/python/bridge.rs
@@ -250,7 +250,6 @@ pub fn register_classes(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyServerHandle>()?;
     m.add_class::<PyBridgeContext>()?;
     m.add_class::<PyBridgeRegistry>()?;
-    m.add_class::<PyWorkspaceRoots>()?;
     // Shared readiness probe (issue #714) — adapters install one
     // `ReadinessProbe` and both `/mcp` and `/v1/call` consult it.
     m.add_class::<super::PyReadinessProbe>()?;

--- a/crates/dcc-mcp-http/src/python/mod.rs
+++ b/crates/dcc-mcp-http/src/python/mod.rs
@@ -8,7 +8,6 @@ pub mod readiness;
 pub mod resources_handle;
 pub mod server;
 pub mod skill_server;
-pub mod workspace;
 
 pub use bridge::{
     PyBridgeContext, PyBridgeRegistry, py_create_skill_server, py_get_bridge_context,
@@ -21,7 +20,6 @@ pub use readiness::PyReadinessProbe;
 pub use resources_handle::PyResourceHandle;
 pub use server::PyServerHandle;
 pub use skill_server::PyMcpHttpServer;
-pub use workspace::PyWorkspaceRoots;
 
 use parking_lot::RwLock;
 use pyo3::prelude::*;


### PR DESCRIPTION
Move the first concrete Python module from `dcc-mcp-http/src/python` into `dcc-mcp-http-py`.

## What moved

- `WorkspaceRoots` / `PyWorkspaceRoots` moved from `crates/dcc-mcp-http/src/python/workspace.rs` to `crates/dcc-mcp-http-py/src/workspace.rs`.
- `dcc-mcp-http-py::register_classes` now registers `WorkspaceRoots` before delegating the still-unmoved bindings to `dcc-mcp-http::python::register_classes`.
- `dcc-mcp-http::python::register_classes` no longer registers `WorkspaceRoots`, avoiding duplicate class registration.

## Why

This is the first safe module-level move after introducing the `dcc-mcp-http-py` facade in #919. `WorkspaceRoots` is low-coupling: it wraps the public `dcc_mcp_http::workspace::WorkspaceRoots` resolver and does not need private HTTP server internals.

## Compatibility

The Python API remains unchanged: `from dcc_mcp_core import WorkspaceRoots` still works via root `_core` registration.

## Verification

- `cargo check --workspace`
- `cargo check -p dcc-mcp-http-py --features python-bindings`
- `cargo check -p dcc-mcp-core --features python-bindings`
- `cargo test -p dcc-mcp-http-py`
- `cargo clippy -p dcc-mcp-http-py --all-targets -- -D warnings`
