### PR TITLE
fix(http-py): register WorkspaceRoots in _core (#852)

### DIFF
--- a/crates/dcc-mcp-http-py/src/bridge.rs
+++ b/crates/dcc-mcp-http-py/src/bridge.rs
@@ -250,6 +250,7 @@ pub fn register_classes(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyServerHandle>()?;
     m.add_class::<PyBridgeContext>()?;
     m.add_class::<PyBridgeRegistry>()?;
+    m.add_class::<super::PyWorkspaceRoots>()?;
     // Shared readiness probe (issue #714) — adapters install one
     // `ReadinessProbe` and both `/mcp` and `/v1/call` consult it.
     m.add_class::<super::PyReadinessProbe>()?;


### PR DESCRIPTION
Fixes the Python package test failure on main after #921.

## Problem

`WorkspaceRoots` had already moved to `dcc-mcp-http-py`, but the bulk module move left `bridge::register_classes` without the `WorkspaceRoots` registration. The pure-Python package imports it lazily from `dcc_mcp_core._core`, so CI failed with:

`ImportError: cannot import name 'WorkspaceRoots' from 'dcc_mcp_core'`

## Fix

Register `PyWorkspaceRoots` in `dcc-mcp-http-py::bridge::register_classes` alongside the rest of the HTTP Python classes.

## Verification

- `cargo check --workspace`
- `cargo check -p dcc-mcp-core --features python-bindings`
- `cargo test -p dcc-mcp-http-py --features python-bindings`
