### PR TITLE
refactor(http-py): use http-types for config bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,6 +946,7 @@ dependencies = [
  "dcc-mcp-artefact",
  "dcc-mcp-host",
  "dcc-mcp-http",
+ "dcc-mcp-http-types",
  "dcc-mcp-jsonrpc",
  "dcc-mcp-models",
  "dcc-mcp-pybridge",

--- a/crates/dcc-mcp-http-py/Cargo.toml
+++ b/crates/dcc-mcp-http-py/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 
 [dependencies]
 dcc-mcp-http = { path = "../dcc-mcp-http" }
+dcc-mcp-http-types = { path = "../dcc-mcp-http-types" }
 dcc-mcp-actions = { path = "../dcc-mcp-actions" }
 dcc-mcp-artefact = { path = "../dcc-mcp-artefact" }
 dcc-mcp-host = { path = "../dcc-mcp-host" }

--- a/crates/dcc-mcp-http-py/src/config.rs
+++ b/crates/dcc-mcp-http-py/src/config.rs
@@ -687,7 +687,7 @@ impl PyMcpHttpConfig {
     /// Lower-case wire identifier of the configured job-recovery policy (issue #567).
     #[setter]
     fn set_job_recovery(&mut self, policy: &str) -> PyResult<()> {
-        self.inner.job.job_recovery = dcc_mcp_http::config::JobRecoveryPolicy::parse(policy)
+        self.inner.job.job_recovery = dcc_mcp_http_types::config::JobRecoveryPolicy::parse(policy)
             .map_err(pyo3::exceptions::PyValueError::new_err)?;
         Ok(())
     }
@@ -721,7 +721,7 @@ impl PyMcpHttpConfig {
 #[cfg(test)]
 mod drift_tests {
     use super::*;
-    use dcc_mcp_http::config::McpHttpConfig;
+    use dcc_mcp_http_types::config::McpHttpConfig;
 
     fn default_cfg() -> PyMcpHttpConfig {
         PyMcpHttpConfig {

--- a/crates/dcc-mcp-http-py/src/lib.rs
+++ b/crates/dcc-mcp-http-py/src/lib.rs
@@ -9,6 +9,8 @@
 //!
 //! ```text
 //! dcc-mcp-core (_core extension) → dcc-mcp-http-py → dcc-mcp-http
+//!                                        │
+//!                                        └── dcc-mcp-http-types (config/value surface)
 //! ```
 
 #![forbid(unsafe_code)]
@@ -57,10 +59,9 @@ pub use workspace::PyWorkspaceRoots;
 #[cfg(feature = "python-bindings")]
 use dcc_mcp_actions::{ToolDispatcher, ToolRegistry};
 #[cfg(feature = "python-bindings")]
-use dcc_mcp_http::{
-    config::{McpHttpConfig, ServerSpawnMode},
-    server::{LiveMetaInner, McpHttpServer, McpServerHandle},
-};
+use dcc_mcp_http::server::{LiveMetaInner, McpHttpServer, McpServerHandle};
+#[cfg(feature = "python-bindings")]
+use dcc_mcp_http_types::config::{McpHttpConfig, ServerSpawnMode};
 #[cfg(feature = "python-bindings")]
 use dcc_mcp_skills::SkillCatalog;
 #[cfg(feature = "python-bindings")]


### PR DESCRIPTION
## Summary
- make http-py config bindings import McpHttpConfig and ServerSpawnMode from dcc-mcp-http-types
- add a direct dcc-mcp-http-types dependency for the Python binding crate
- keep runtime/server bindings on dcc-mcp-http

## Tests
- vx cargo fmt --check
- vx cargo test -p dcc-mcp-http-py
- vx cargo clippy -p dcc-mcp-http-py --tests -- -D warnings
- vx cargo hakari generate

Refs #852