### PR TITLE
refactor(gateway): move event wire types to core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -865,6 +865,7 @@ dependencies = [
 name = "dcc-mcp-gateway-core"
 version = "0.15.7"
 dependencies = [
+ "chrono",
  "nucleo-matcher",
  "serde",
  "serde_json",

--- a/crates/dcc-mcp-gateway-core/Cargo.toml
+++ b/crates/dcc-mcp-gateway-core/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 # returns CapabilityRecord arrays), so serde is a hard dependency.
 serde = { workspace = true }
 uuid = { workspace = true }
+chrono = { version = "0.4", features = ["serde"] }
 # Fuzzy matcher that backs the `FuzzyScorer` / `StrategyFuzzyScorer`
 # ranking strategies (issue #659). Pure CPU code with no async / IO
 # surface, so it keeps the "no HTTP, no runtime" domain-layer rule.

--- a/crates/dcc-mcp-gateway-core/src/event.rs
+++ b/crates/dcc-mcp-gateway-core/src/event.rs
@@ -1,0 +1,122 @@
+//! Gateway contention event value types (issue #845).
+//!
+//! These are the wire-level records exposed through
+//! `resources://gateway/events` and mirrored into metrics labels by the gateway
+//! runtime. They live in the domain crate so admin clients and tests can parse
+//! the event stream without depending on the HTTP gateway implementation.
+
+use serde::{Deserialize, Serialize};
+
+/// All contention-relevant event kinds the gateway can emit.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EventKind {
+    /// This gateway instance won the port election.
+    ElectionWon,
+    /// This gateway yielded the port to a higher-version challenger.
+    VoluntaryYield,
+    /// A ghost entry (dead-PID or stale) was reaped from the registry.
+    GhostReaped,
+    /// A backend instance is still booting (readiness probe → 503).
+    ProbeBooting,
+    /// A backend instance is unreachable (readiness probe failed).
+    ProbeUnreachable,
+    /// A backend instance was auto-deregistered after consecutive probe failures.
+    AutoDeregister,
+}
+
+impl EventKind {
+    /// Return the string label used in the Prometheus `outcome`/`reason` label.
+    #[must_use]
+    pub fn as_label(&self) -> &'static str {
+        match self {
+            EventKind::ElectionWon => "won",
+            EventKind::VoluntaryYield => "yielded",
+            EventKind::GhostReaped => "ghost",
+            EventKind::ProbeBooting => "booting",
+            EventKind::ProbeUnreachable => "unreachable",
+            EventKind::AutoDeregister => "probe_fail",
+        }
+    }
+}
+
+/// A single contention event stored in the gateway ring buffer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContendEvent {
+    /// ISO-8601 UTC timestamp (millisecond precision).
+    pub timestamp: String,
+    /// Event kind.
+    pub event: EventKind,
+    /// DCC type involved (`"maya"`, `"blender"`, `"__gateway__"`, …).
+    pub dcc_type: String,
+    /// Short, human-readable instance identifier (first 8 hex chars of the UUID).
+    pub instance_id: String,
+    /// Optional human-readable context (e.g. challenger version, failure count).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl ContendEvent {
+    /// Construct a new event with the current UTC timestamp (millisecond
+    /// precision).
+    #[must_use]
+    pub fn new(
+        event: EventKind,
+        dcc_type: impl Into<String>,
+        instance_id: impl Into<String>,
+        reason: Option<String>,
+    ) -> Self {
+        let timestamp = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        Self {
+            timestamp,
+            event,
+            dcc_type: dcc_type.into(),
+            instance_id: instance_id.into(),
+            reason,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_kind_labels_are_stable() {
+        assert_eq!(EventKind::ElectionWon.as_label(), "won");
+        assert_eq!(EventKind::VoluntaryYield.as_label(), "yielded");
+        assert_eq!(EventKind::GhostReaped.as_label(), "ghost");
+        assert_eq!(EventKind::ProbeBooting.as_label(), "booting");
+        assert_eq!(EventKind::ProbeUnreachable.as_label(), "unreachable");
+        assert_eq!(EventKind::AutoDeregister.as_label(), "probe_fail");
+    }
+
+    #[test]
+    fn contend_event_serializes_reason_only_when_present() {
+        let event = ContendEvent {
+            timestamp: "2026-05-11T00:00:00.000Z".to_owned(),
+            event: EventKind::GhostReaped,
+            dcc_type: "maya".to_owned(),
+            instance_id: "abcdef01".to_owned(),
+            reason: None,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("\"event\":\"ghost_reaped\""));
+        assert!(!json.contains("reason"));
+    }
+
+    #[test]
+    fn contend_event_new_populates_fields() {
+        let event = ContendEvent::new(
+            EventKind::ProbeBooting,
+            "photoshop",
+            "abcdef01",
+            Some("warming up".to_owned()),
+        );
+        assert_eq!(event.event, EventKind::ProbeBooting);
+        assert_eq!(event.dcc_type, "photoshop");
+        assert_eq!(event.instance_id, "abcdef01");
+        assert_eq!(event.reason.as_deref(), Some("warming up"));
+        assert!(event.timestamp.ends_with('Z'));
+    }
+}

--- a/crates/dcc-mcp-gateway-core/src/lib.rs
+++ b/crates/dcc-mcp-gateway-core/src/lib.rs
@@ -26,6 +26,7 @@
 //! | crate root       | [`PendingCall`] (routing primitive)                 |
 //! | [`naming`]       | Pure UUID / alphabet helpers used by slug encoding  |
 //! | [`resource_uri`] | Gateway resource URI prefix encode/decode helpers   |
+//! | [`event`]        | Gateway contention event wire records               |
 //! | [`capability`]   | [`CapabilityRecord`] + slug encoding (REST wire)    |
 //!
 //! # Migration plan
@@ -40,6 +41,7 @@
 #![warn(missing_docs)]
 
 pub mod capability;
+pub mod event;
 pub mod naming;
 pub mod resource_uri;
 

--- a/crates/dcc-mcp-gateway/src/gateway/event_log.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/event_log.rs
@@ -18,77 +18,10 @@
 use std::collections::VecDeque;
 use std::sync::Mutex;
 
-use serde::{Deserialize, Serialize};
-
-// ── Public event types ──────────────────────────────────────────────────────
-
-/// All contention-relevant event kinds the gateway can emit.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum EventKind {
-    /// This gateway instance won the port election.
-    ElectionWon,
-    /// This gateway yielded the port to a higher-version challenger.
-    VoluntaryYield,
-    /// A ghost entry (dead-PID or stale) was reaped from the registry.
-    GhostReaped,
-    /// A backend instance is still booting (readiness probe → 503).
-    ProbeBooting,
-    /// A backend instance is unreachable (readiness probe failed).
-    ProbeUnreachable,
-    /// A backend instance was auto-deregistered after consecutive probe failures.
-    AutoDeregister,
-}
-
-impl EventKind {
-    /// Return the string label used in the Prometheus `outcome`/`reason` label.
-    pub fn as_label(&self) -> &'static str {
-        match self {
-            EventKind::ElectionWon => "won",
-            EventKind::VoluntaryYield => "yielded",
-            EventKind::GhostReaped => "ghost",
-            EventKind::ProbeBooting => "booting",
-            EventKind::ProbeUnreachable => "unreachable",
-            EventKind::AutoDeregister => "probe_fail",
-        }
-    }
-}
-
-/// A single contention event stored in the ring buffer.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ContendEvent {
-    /// ISO-8601 UTC timestamp (millisecond precision).
-    pub timestamp: String,
-    /// Event kind.
-    pub event: EventKind,
-    /// DCC type involved (`"maya"`, `"blender"`, `"__gateway__"`, …).
-    pub dcc_type: String,
-    /// Short, human-readable instance identifier (first 8 hex chars of the UUID).
-    pub instance_id: String,
-    /// Optional human-readable context (e.g. challenger version, failure count).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub reason: Option<String>,
-}
-
-impl ContendEvent {
-    /// Construct a new event with the current UTC timestamp (millisecond
-    /// precision).
-    pub fn new(
-        event: EventKind,
-        dcc_type: impl Into<String>,
-        instance_id: impl Into<String>,
-        reason: Option<String>,
-    ) -> Self {
-        let ts = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
-        ContendEvent {
-            timestamp: ts,
-            event,
-            dcc_type: dcc_type.into(),
-            instance_id: instance_id.into(),
-            reason,
-        }
-    }
-}
+// `EventKind` and `ContendEvent` live in `dcc-mcp-gateway-core` (issue #845)
+// so admin clients can parse `resources://gateway/events` without depending on
+// the gateway runtime crate. Re-export them here for the historical path.
+pub use dcc_mcp_gateway_core::event::{ContendEvent, EventKind};
 
 // ── Ring buffer ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- move EventKind and ContendEvent into dcc-mcp-gateway-core
- keep gateway::event_log re-exports for existing callers
- add gateway-core regression tests for labels and JSON event shape

## Tests
- vx cargo fmt --check
- vx cargo test -p dcc-mcp-gateway-core -p dcc-mcp-gateway event
- vx cargo clippy -p dcc-mcp-gateway-core -p dcc-mcp-gateway --tests -- -D warnings
- vx cargo hakari generate

Refs #845