### PR TITLE
refactor(http-py): split config support modules

### DIFF
--- a/crates/dcc-mcp-http-py/src/config.rs
+++ b/crates/dcc-mcp-http-py/src/config.rs
@@ -3,6 +3,8 @@
 use super::*;
 use std::collections::HashMap;
 
+mod build;
+
 /// Python-visible MCP HTTP server configuration.
 ///
 /// Example::
@@ -16,17 +18,8 @@ use std::collections::HashMap;
 /// (issue #764). Each hand-written getter/setter accesses the correct
 /// nested field path (e.g., `self.inner.server.port`).
 ///
-/// Three accessor families use non-trivial conversions and remain
-/// hand-written (see commented markers in the `#[pymethods]` block):
-///
-/// - `spawn_mode` / `set_spawn_mode` — enum ↔ `&str` with `PyResult` validation.
-/// - `job_recovery` / `set_job_recovery` — same shape as `spawn_mode` (#567).
-/// - `job_storage_path` / `set_job_storage_path` — `Option<PathBuf>` ↔ `Option<String>`.
-/// - `registry_dir` / `set_registry_dir` — same `PathBuf` shape as above.
-/// - `instance_metadata` / `set_instance_metadata` — `HashMap<String, String>` clone.
-/// - `gateway_cursor_safe_tool_names` / `set_gateway_cursor_safe_tool_names` — bool.
-/// - `__repr__` — selects three identifying fields with one renamed
-///   (`server_name` → `name`) via the shared `repr_pairs!` helper.
+/// Non-trivial conversions (enum/path/map/repr) stay explicit in the
+/// `#[pymethods]` block so Python errors remain precise.
 #[pyclass(name = "McpHttpConfig", skip_from_py_object)]
 #[derive(Clone)]
 pub struct PyMcpHttpConfig {
@@ -60,31 +53,23 @@ impl PyMcpHttpConfig {
         gateway_max_routes_per_session: u64,
         shutdown_on_drop: bool,
     ) -> Self {
-        let mut cfg = McpHttpConfig::default();
-        cfg.server.port = port;
-        if let Some(name) = server_name {
-            cfg.server.server_name = name;
+        Self {
+            inner: build::build_config(
+                port,
+                server_name,
+                server_version,
+                enable_cors,
+                request_timeout_ms,
+                backend_timeout_ms,
+                enable_prometheus,
+                prometheus_basic_auth,
+                gateway_async_dispatch_timeout_ms,
+                gateway_wait_terminal_timeout_ms,
+                gateway_route_ttl_secs,
+                gateway_max_routes_per_session,
+                shutdown_on_drop,
+            ),
         }
-        if let Some(ver) = server_version {
-            cfg.server.server_version = ver;
-        }
-        cfg.server.enable_cors = enable_cors;
-        cfg.server.request_timeout_ms = request_timeout_ms;
-        cfg.gateway.gateway_port = 9765;
-        cfg.gateway.backend_timeout_ms = backend_timeout_ms;
-        cfg.telemetry.enable_prometheus = enable_prometheus;
-        cfg.telemetry.prometheus_basic_auth = prometheus_basic_auth;
-        cfg.gateway.gateway_async_dispatch_timeout_ms = gateway_async_dispatch_timeout_ms;
-        cfg.gateway.gateway_wait_terminal_timeout_ms = gateway_wait_terminal_timeout_ms;
-        cfg.gateway.gateway_route_ttl_secs = gateway_route_ttl_secs;
-        cfg.gateway.gateway_max_routes_per_session = gateway_max_routes_per_session;
-        cfg.features.shutdown_on_drop = shutdown_on_drop;
-        // Issue #303: PyO3-embedded hosts (Maya on Windows etc.) cannot
-        // rely on shared tokio worker threads to drive the accept loop
-        // after `block_on` returns. Default to `Dedicated` so the listener
-        // runs on its own OS thread owning a `current_thread` runtime.
-        cfg.server.spawn_mode = ServerSpawnMode::Dedicated;
-        Self { inner: cfg }
     }
 
     // ── ServerConfig getters (read-only) ─────────────────────────────
@@ -706,113 +691,5 @@ impl PyMcpHttpConfig {
     }
 }
 
-// ── Drift-detection tests ─────────────────────────────────────────────────────
-//
-// Every field in `McpHttpConfig` that Python callers should be able to read
-// must have a matching getter on `PyMcpHttpConfig`. All are now hand-written
-// in the `#[pymethods]` block above.
-//
-// When you add a new field:
-//   1. Add a hand-written getter (and setter if needed) in the `#[pymethods]` block.
-//   2. Add `let _ = cfg.<getter>();` to the test below.
-//
-// The test fails to **compile** if a getter is removed — that is the intended
-// safety net against silent drift between the Rust config and the Python API.
 #[cfg(test)]
-mod drift_tests {
-    use super::*;
-    use dcc_mcp_http_types::config::McpHttpConfig;
-
-    fn default_cfg() -> PyMcpHttpConfig {
-        PyMcpHttpConfig {
-            inner: McpHttpConfig::default(),
-        }
-    }
-
-    #[test]
-    fn all_mcp_http_config_fields_have_py_getters() {
-        let cfg = default_cfg();
-
-        // ── ServerConfig (read-only) ────────────────────────────────
-        let _ = cfg.port();
-        let _ = cfg.host();
-        let _ = cfg.endpoint_path();
-        let _ = cfg.server_name();
-        let _ = cfg.server_version();
-        let _ = cfg.max_sessions();
-        let _ = cfg.request_timeout_ms();
-        let _ = cfg.enable_cors();
-
-        // ── ServerConfig (read-write, hand-written) ──────────────────
-        let _ = cfg.spawn_mode();
-        let _ = cfg.self_probe_timeout_ms();
-
-        // ── SessionConfig ────────────────────────────────────────────
-        let _ = cfg.session_ttl_secs();
-        let _ = cfg.enable_tool_cache();
-
-        // ── TelemetryConfig ──────────────────────────────────────────
-        let _ = cfg.enable_prometheus();
-        let _ = cfg.prometheus_basic_auth();
-
-        // ── FeatureFlags ────────────────────────────────────────────
-        let _ = cfg.lazy_actions();
-        let _ = cfg.enable_workflows();
-        let _ = cfg.shutdown_on_drop();
-        let _ = cfg.enable_job_notifications();
-        let _ = cfg.bare_tool_names();
-        let _ = cfg.enable_resources();
-        let _ = cfg.enable_artefact_resources();
-        let _ = cfg.enable_prompts();
-
-        // ── GatewayConfig ────────────────────────────────────────────
-        let _ = cfg.gateway_port();
-        let _ = cfg.registry_dir();
-        let _ = cfg.stale_timeout_secs();
-        let _ = cfg.heartbeat_secs();
-        let _ = cfg.backend_timeout_ms();
-        let _ = cfg.gateway_async_dispatch_timeout_ms();
-        let _ = cfg.gateway_wait_terminal_timeout_ms();
-        let _ = cfg.gateway_route_ttl_secs();
-        let _ = cfg.gateway_max_routes_per_session();
-        let _ = cfg.gateway_cursor_safe_tool_names();
-        let _ = cfg.adapter_version();
-        let _ = cfg.adapter_dcc();
-        let _ = cfg.allow_unknown_tools();
-
-        // ── QueueConfig ─────────────────────────────────────────────
-        let _ = cfg.deferred_queue_depth();
-        let _ = cfg.bridge_queue_depth();
-        let _ = cfg.host_queue_depth();
-        let _ = cfg.queue_send_timeout_ms();
-
-        // ── InstanceConfig ──────────────────────────────────────────
-        let _ = cfg.dcc_type();
-        let _ = cfg.dcc_version();
-        let _ = cfg.scene();
-        let _ = cfg.instance_metadata();
-        let _ = cfg.declared_capabilities();
-
-        // ── WorkflowConfig ──────────────────────────────────────────
-        let _ = cfg.enable_scheduler();
-        let _ = cfg.schedules_dir();
-
-        // ── JobConfig ───────────────────────────────────────────────
-        let _ = cfg.job_storage_path();
-        let _ = cfg.job_recovery();
-    }
-
-    #[test]
-    fn repr_contains_port() {
-        let cfg = PyMcpHttpConfig {
-            inner: McpHttpConfig::default().with_port(1234),
-        };
-        assert!(cfg.__repr__().contains("1234"));
-    }
-
-    #[test]
-    fn repr_contains_class_name() {
-        let cfg = default_cfg();
-        assert!(cfg.__repr__().contains("McpHttpConfig"));
-    }
-}
+mod tests;

--- a/crates/dcc-mcp-http-py/src/config/build.rs
+++ b/crates/dcc-mcp-http-py/src/config/build.rs
@@ -1,0 +1,43 @@
+use dcc_mcp_http_types::config::{McpHttpConfig, ServerSpawnMode};
+
+/// Build the Rust config backing `PyMcpHttpConfig.__new__`.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn build_config(
+    port: u16,
+    server_name: Option<String>,
+    server_version: Option<String>,
+    enable_cors: bool,
+    request_timeout_ms: u64,
+    backend_timeout_ms: u64,
+    enable_prometheus: bool,
+    prometheus_basic_auth: Option<(String, String)>,
+    gateway_async_dispatch_timeout_ms: u64,
+    gateway_wait_terminal_timeout_ms: u64,
+    gateway_route_ttl_secs: u64,
+    gateway_max_routes_per_session: u64,
+    shutdown_on_drop: bool,
+) -> McpHttpConfig {
+    let mut cfg = McpHttpConfig::default();
+    cfg.server.port = port;
+    if let Some(name) = server_name {
+        cfg.server.server_name = name;
+    }
+    if let Some(ver) = server_version {
+        cfg.server.server_version = ver;
+    }
+    cfg.server.enable_cors = enable_cors;
+    cfg.server.request_timeout_ms = request_timeout_ms;
+    cfg.gateway.gateway_port = 9765;
+    cfg.gateway.backend_timeout_ms = backend_timeout_ms;
+    cfg.telemetry.enable_prometheus = enable_prometheus;
+    cfg.telemetry.prometheus_basic_auth = prometheus_basic_auth;
+    cfg.gateway.gateway_async_dispatch_timeout_ms = gateway_async_dispatch_timeout_ms;
+    cfg.gateway.gateway_wait_terminal_timeout_ms = gateway_wait_terminal_timeout_ms;
+    cfg.gateway.gateway_route_ttl_secs = gateway_route_ttl_secs;
+    cfg.gateway.gateway_max_routes_per_session = gateway_max_routes_per_session;
+    cfg.features.shutdown_on_drop = shutdown_on_drop;
+    // Issue #303: PyO3-embedded hosts (Maya on Windows etc.) cannot rely on
+    // shared Tokio workers after `block_on` returns. Default to `Dedicated`.
+    cfg.server.spawn_mode = ServerSpawnMode::Dedicated;
+    cfg
+}

--- a/crates/dcc-mcp-http-py/src/config/tests.rs
+++ b/crates/dcc-mcp-http-py/src/config/tests.rs
@@ -1,0 +1,107 @@
+// ── Drift-detection tests ─────────────────────────────────────────────────────
+//
+// Every field in `McpHttpConfig` that Python callers should be able to read
+// must have a matching getter on `PyMcpHttpConfig`. All are now hand-written
+// in the `#[pymethods]` block above.
+//
+// When you add a new field:
+//   1. Add a hand-written getter (and setter if needed) in the `#[pymethods]` block.
+//   2. Add `let _ = cfg.<getter>();` to the test below.
+//
+// The test fails to **compile** if a getter is removed — that is the intended
+// safety net against silent drift between the Rust config and the Python API.
+use super::*;
+use dcc_mcp_http_types::config::McpHttpConfig;
+
+fn default_cfg() -> PyMcpHttpConfig {
+    PyMcpHttpConfig {
+        inner: McpHttpConfig::default(),
+    }
+}
+
+#[test]
+fn all_mcp_http_config_fields_have_py_getters() {
+    let cfg = default_cfg();
+
+    // ── ServerConfig (read-only) ────────────────────────────────
+    let _ = cfg.port();
+    let _ = cfg.host();
+    let _ = cfg.endpoint_path();
+    let _ = cfg.server_name();
+    let _ = cfg.server_version();
+    let _ = cfg.max_sessions();
+    let _ = cfg.request_timeout_ms();
+    let _ = cfg.enable_cors();
+
+    // ── ServerConfig (read-write, hand-written) ──────────────────
+    let _ = cfg.spawn_mode();
+    let _ = cfg.self_probe_timeout_ms();
+
+    // ── SessionConfig ────────────────────────────────────────────
+    let _ = cfg.session_ttl_secs();
+    let _ = cfg.enable_tool_cache();
+
+    // ── TelemetryConfig ──────────────────────────────────────────
+    let _ = cfg.enable_prometheus();
+    let _ = cfg.prometheus_basic_auth();
+
+    // ── FeatureFlags ────────────────────────────────────────────
+    let _ = cfg.lazy_actions();
+    let _ = cfg.enable_workflows();
+    let _ = cfg.shutdown_on_drop();
+    let _ = cfg.enable_job_notifications();
+    let _ = cfg.bare_tool_names();
+    let _ = cfg.enable_resources();
+    let _ = cfg.enable_artefact_resources();
+    let _ = cfg.enable_prompts();
+
+    // ── GatewayConfig ────────────────────────────────────────────
+    let _ = cfg.gateway_port();
+    let _ = cfg.registry_dir();
+    let _ = cfg.stale_timeout_secs();
+    let _ = cfg.heartbeat_secs();
+    let _ = cfg.backend_timeout_ms();
+    let _ = cfg.gateway_async_dispatch_timeout_ms();
+    let _ = cfg.gateway_wait_terminal_timeout_ms();
+    let _ = cfg.gateway_route_ttl_secs();
+    let _ = cfg.gateway_max_routes_per_session();
+    let _ = cfg.gateway_cursor_safe_tool_names();
+    let _ = cfg.adapter_version();
+    let _ = cfg.adapter_dcc();
+    let _ = cfg.allow_unknown_tools();
+
+    // ── QueueConfig ─────────────────────────────────────────────
+    let _ = cfg.deferred_queue_depth();
+    let _ = cfg.bridge_queue_depth();
+    let _ = cfg.host_queue_depth();
+    let _ = cfg.queue_send_timeout_ms();
+
+    // ── InstanceConfig ──────────────────────────────────────────
+    let _ = cfg.dcc_type();
+    let _ = cfg.dcc_version();
+    let _ = cfg.scene();
+    let _ = cfg.instance_metadata();
+    let _ = cfg.declared_capabilities();
+
+    // ── WorkflowConfig ──────────────────────────────────────────
+    let _ = cfg.enable_scheduler();
+    let _ = cfg.schedules_dir();
+
+    // ── JobConfig ───────────────────────────────────────────────
+    let _ = cfg.job_storage_path();
+    let _ = cfg.job_recovery();
+}
+
+#[test]
+fn repr_contains_port() {
+    let cfg = PyMcpHttpConfig {
+        inner: McpHttpConfig::default().with_port(1234),
+    };
+    assert!(cfg.__repr__().contains("1234"));
+}
+
+#[test]
+fn repr_contains_class_name() {
+    let cfg = default_cfg();
+    assert!(cfg.__repr__().contains("McpHttpConfig"));
+}


### PR DESCRIPTION
## Summary
- move `PyMcpHttpConfig` constructor assembly into `config/build.rs`
- move config drift-detection tests into `config/tests.rs`
- keep Python class name, accessors, setters, and repr behavior unchanged while bringing `config.rs` under the file-size target

Refs #852
Refs #848

## Validation
- `vx just fmt`
- `vx cargo test -p dcc-mcp-http-py --features python-bindings config::tests`
- `vx cargo check -p dcc-mcp-http-py -p dcc-mcp-http`
- `vx cargo clippy -p dcc-mcp-http-py -- -D warnings`