### PR TITLE
docs: refresh interface architecture indexes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,9 +107,10 @@ crates/                      # Rust workspace crates (core logic)
 ├── dcc-mcp-shm/             # PyBufferPool, PySharedBuffer, LZ4 compression
 ├── dcc-mcp-capture/         # Capturer, cross-platform backends
 ├── dcc-mcp-usd/             # UsdStage, UsdPrim, scene info bridge
-├── dcc-mcp-http-types/      # Pure HTTP wire/config/value types
+├── dcc-mcp-http-types/      # Pure HTTP wire/config/value types, McpHttpConfig
 ├── dcc-mcp-http-server/     # Reusable HTTP runtime support
-├── dcc-mcp-http/            # Embedded MCP HTTP facade + Python bindings
+├── dcc-mcp-http-py/         # PyO3 binding boundary for HTTP APIs
+├── dcc-mcp-http/            # Embedded MCP HTTP facade + compatibility re-exports
 ├── dcc-mcp-gateway-core/    # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway/         # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-skill-rest/      # Per-DCC /v1/* REST skill API

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -59,9 +59,10 @@ dcc-mcp-core (workspace root)
 ├── dcc-mcp-skill-rest    # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core  # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway       # Multi-DCC gateway app + dynamic wrappers
-├── dcc-mcp-http-types    # Pure HTTP wire/config/value types
+├── dcc-mcp-http-types    # Pure HTTP wire/config/value types, McpHttpConfig
 ├── dcc-mcp-http-server   # Reusable HTTP runtime support
-├── dcc-mcp-http          # Embedded MCP HTTP facade + Python bindings
+├── dcc-mcp-http-py       # PyO3 binding boundary for HTTP APIs
+├── dcc-mcp-http          # Embedded MCP HTTP facade + compatibility re-exports
 ├── dcc-mcp-server        # Binary entry point and gateway runner
 ├── dcc-mcp-logging       # Rolling file logging
 ├── dcc-mcp-paths         # Platform path helpers
@@ -368,11 +369,11 @@ dcc-mcp-server ← dcc-mcp-http
 
 ### dcc-mcp-http
 
-**Purpose**: MCP Streamable HTTP facade (2025-03-26 spec) for HTTP-based MCP clients. It owns axum routing, server startup, the `McpHttpConfig` aggregate, Python bindings, prompt/resource registries, and compatibility re-exports from the extracted crates.
+**Purpose**: MCP Streamable HTTP facade (2025-03-26 spec) for HTTP-based MCP clients. It owns axum routing, server startup, prompt/resource registries, gateway bootstrap, and compatibility re-exports from the extracted crates.
 
 **Key Components**:
 - `McpHttpServer` — background-thread HTTP server (axum/Tokio).
-- `McpHttpConfig` — thin aggregate over queue/gateway/session/telemetry/features/instance sub-configs.
+- `McpHttpConfig` — re-export of the `dcc-mcp-http-types::config` aggregate for compatibility; new Rust code can import it from `dcc-mcp-http-types` directly.
 - `McpServerHandle` — URL retrieval, `is_gateway` flag, and graceful shutdown.
 - `ResourceRegistry` and `PromptRegistry` — MCP `resources/*` and `prompts/*` implementation.
 - Gateway bootstrap — delegates dynamic gateway behavior to `dcc-mcp-gateway`.

--- a/docs/guide/dcc-rest-skill-api.md
+++ b/docs/guide/dcc-rest-skill-api.md
@@ -98,7 +98,7 @@ is fetched on demand by `POST /v1/describe` with `include_schema: true`
 use std::sync::Arc;
 use axum::Router;
 use dcc_mcp_actions::{ToolDispatcher, ToolRegistry};
-use dcc_mcp_http::{
+use dcc_mcp_skill_rest::{
     AllowLocalhostGate, BearerTokenGate, NoopAuditSink, SkillRestConfig,
     SkillRestService, StaticReadiness, build_skill_rest_router,
 };

--- a/docs/guide/job-persistence.md
+++ b/docs/guide/job-persistence.md
@@ -92,7 +92,7 @@ config.job_recovery = "requeue"   # accepted, currently behaves as "drop" + WARN
 ```
 
 ```rust
-use dcc_mcp_http::config::{JobRecoveryPolicy, McpHttpConfig};
+use dcc_mcp_http_types::config::{JobRecoveryPolicy, McpHttpConfig};
 
 let cfg = McpHttpConfig::new(8765)
     .with_job_storage_path("/var/lib/dcc-mcp/jobs.sqlite3")

--- a/docs/guide/scheduler.md
+++ b/docs/guide/scheduler.md
@@ -153,8 +153,8 @@ cfg.schedules_dir = "/opt/dcc-mcp/schedules"
 Or via builder:
 
 ```rust
-use dcc_mcp_http::config::McpHttpConfig;
-let cfg = McpHttpConfig::new()
+use dcc_mcp_http_types::config::McpHttpConfig;
+let cfg = McpHttpConfig::default()
     .with_scheduler("/opt/dcc-mcp/schedules");
 ```
 

--- a/docs/guide/what-is-dcc-mcp-core.md
+++ b/docs/guide/what-is-dcc-mcp-core.md
@@ -89,9 +89,10 @@ dcc-mcp-core/
 │   ├── dcc-mcp-workflow/            # YAML declarative workflows
 │   ├── dcc-mcp-scheduler/           # cron / timers
 │   ├── dcc-mcp-artefact/            # file/data hand-off between tools
-│   ├── dcc-mcp-http-types/          # pure HTTP wire/config/value types (#852)
+│   ├── dcc-mcp-http-types/          # pure HTTP wire/config/value types, McpHttpConfig (#852)
 │   ├── dcc-mcp-http-server/         # reusable HTTP runtime support (#852)
-│   ├── dcc-mcp-http/                # McpHttpServer, McpHttpConfig, PyO3 facade
+│   ├── dcc-mcp-http-py/             # PyO3 binding boundary for HTTP APIs (#852)
+│   ├── dcc-mcp-http/                # McpHttpServer facade + compatibility re-exports
 │   ├── dcc-mcp-skill-rest/          # per-DCC REST router (/v1/*)
 │   ├── dcc-mcp-gateway-core/        # pure gateway domain/search/ranking types (#845)
 │   ├── dcc-mcp-gateway/             # multi-instance gateway + minimal MCP surface

--- a/docs/zh/guide/architecture.md
+++ b/docs/zh/guide/architecture.md
@@ -19,8 +19,9 @@ dcc-mcp-core (workspace 根目录)
 ├── dcc-mcp-skill-rest   # Per-DCC /v1/* REST Skill API
 ├── dcc-mcp-gateway-core # 纯 gateway 领域/search/ranking 类型
 ├── dcc-mcp-gateway      # Multi-DCC 网关应用层和动态 wrappers
-├── dcc-mcp-http-types   # 纯 HTTP 线协议/配置/值类型
+├── dcc-mcp-http-types   # 纯 HTTP 线协议/配置/值类型、McpHttpConfig
 ├── dcc-mcp-http-server  # 可复用 HTTP runtime 支撑层
+├── dcc-mcp-http-py      # HTTP API 的 PyO3 绑定边界
 ├── dcc-mcp-transport    # IPC (ipckit), DccLinkFrame, IpcChannelAdapter, SocketServerAdapter
 ├── dcc-mcp-process      # PyDccLauncher, ProcessMonitor, ProcessWatcher, CrashRecovery
 ├── dcc-mcp-telemetry    # Tracing/recording: ToolRecorder, TelemetryConfig
@@ -28,7 +29,7 @@ dcc-mcp-core (workspace 根目录)
 ├── dcc-mcp-shm          # Shared memory: PySharedBuffer, PyBufferPool
 ├── dcc-mcp-capture      # Screen capture: Capturer, CaptureFrame
 ├── dcc-mcp-usd          # USD scene description: UsdStage, SdfPath, VtValue
-├── dcc-mcp-http         # Embedded MCP HTTP facade + Python bindings
+├── dcc-mcp-http         # Embedded MCP HTTP facade + 兼容 re-export
 ├── dcc-mcp-server       # 二进制入口点: dcc-mcp-server, gateway runner
 ├── dcc-mcp-logging      # 滚动文件日志
 ├── dcc-mcp-paths        # 平台路径辅助

--- a/docs/zh/guide/dcc-rest-skill-api.md
+++ b/docs/zh/guide/dcc-rest-skill-api.md
@@ -67,7 +67,7 @@ SkillCatalogSource  ToolInvoker  AuthGate  AuditSink
 use std::sync::Arc;
 use axum::Router;
 use dcc_mcp_actions::{ToolDispatcher, ToolRegistry};
-use dcc_mcp_http::{
+use dcc_mcp_skill_rest::{
     AllowLocalhostGate, BearerTokenGate, NoopAuditSink, SkillRestConfig,
     SkillRestService, StaticReadiness, build_skill_rest_router,
 };

--- a/docs/zh/guide/scheduler.md
+++ b/docs/zh/guide/scheduler.md
@@ -146,8 +146,8 @@ cfg.schedules_dir = "/opt/dcc-mcp/schedules"
 或通过 builder：
 
 ```rust
-use dcc_mcp_http::config::McpHttpConfig;
-let cfg = McpHttpConfig::new()
+use dcc_mcp_http_types::config::McpHttpConfig;
+let cfg = McpHttpConfig::default()
     .with_scheduler("/opt/dcc-mcp/schedules");
 ```
 

--- a/docs/zh/guide/what-is-dcc-mcp-core.md
+++ b/docs/zh/guide/what-is-dcc-mcp-core.md
@@ -89,9 +89,10 @@ dcc-mcp-core/
 │   ├── dcc-mcp-workflow/            # YAML 声明式工作流
 │   ├── dcc-mcp-scheduler/           # cron / 定时器
 │   ├── dcc-mcp-artefact/            # 工具之间的文件/数据交接
-│   ├── dcc-mcp-http-types/          # 纯 HTTP 线协议/配置/值类型（#852）
+│   ├── dcc-mcp-http-types/          # 纯 HTTP 线协议/配置/值类型、McpHttpConfig（#852）
 │   ├── dcc-mcp-http-server/         # 可复用 HTTP runtime 支撑层（#852）
-│   ├── dcc-mcp-http/                # McpHttpServer, McpHttpConfig, PyO3 facade
+│   ├── dcc-mcp-http-py/             # HTTP API 的 PyO3 绑定边界（#852）
+│   ├── dcc-mcp-http/                # McpHttpServer facade + 兼容 re-export
 │   ├── dcc-mcp-skill-rest/          # per-DCC REST 路由(`/v1/*`)
 │   ├── dcc-mcp-gateway-core/        # 纯 gateway 领域/search/ranking 类型（#845）
 │   ├── dcc-mcp-gateway/             # 多实例网关 + 最小 MCP 表面

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -75,7 +75,8 @@ crates/
 ├── dcc-mcp-gateway/      # Multi-DCC gateway app + dynamic wrappers
 ├── dcc-mcp-http-types/   # Pure HTTP wire/config/value types
 ├── dcc-mcp-http-server/  # Reusable HTTP runtime support
-├── dcc-mcp-http/         # Embedded MCP HTTP facade + Python bindings
+├── dcc-mcp-http-py/      # PyO3 binding boundary for HTTP APIs
+├── dcc-mcp-http/         # Embedded MCP HTTP facade + compatibility re-exports
 ├── dcc-mcp-transport/    # DccLink IPC adapters
 ├── dcc-mcp-process/      # PyDccLauncher, monitors, crash recovery
 ├── dcc-mcp-telemetry/    # TelemetryConfig, RecordingGuard, ToolMetrics, ToolRecorder
@@ -3233,7 +3234,4 @@ McpHttpConfig.queue.sse_chunk_size_bytes        // default 64 KiB → auto SSE c
 
 ### McpHttpConfig Sub-configs and HTTP type crates (#764 / #852)
 
-Rust `McpHttpConfig` is a thin aggregate with view methods:
-`.queue_config()`, `.gateway_config()`, `.session_config()`, `.telemetry_config()`.
-Python `PyMcpHttpConfig` field-level getters/setters are **unchanged**.
-Pure wire/config/value types that do not need axum/PyO3 live in `dcc-mcp-http-types` and remain re-exported from `dcc-mcp-http`; reusable runtime support (core tool builders, sessions, executors, in-flight request state, notifications, workspace roots) lives in `dcc-mcp-http-server`.
+Rust `McpHttpConfig` is a thin aggregate in `dcc-mcp-http-types::config` with public sub-config fields (`server`, `instance`, `session`, `gateway`, `queue`, `telemetry`, `features`, `workflow`, `job`) plus compatibility accessors/builders. Python `PyMcpHttpConfig` field-level getters/setters are **unchanged**. Pure wire/config/value types that do not need axum/PyO3 live in `dcc-mcp-http-types` and remain re-exported from `dcc-mcp-http`; reusable runtime support (core tool builders, sessions, executors, in-flight request state, notifications, workspace roots) lives in `dcc-mcp-http-server`; the PyO3 HTTP binding boundary lives in `dcc-mcp-http-py`.

--- a/llms.txt
+++ b/llms.txt
@@ -182,7 +182,7 @@ The historical god-crate `dcc-mcp-http` was decomposed into cohesive crates. New
 - **`dcc-mcp-http-types`** — pure HTTP wire/config/value types (`HttpError`, `JobConfig`, `InstanceConfig`, `TelemetryConfig`, `FeatureFlags`, prompt/resource/output/session values), re-exported by `dcc-mcp-http` for compatibility.
 - **`dcc-mcp-http-server`** — reusable runtime support for the embedded server (core tool builders, executor bridge, session state, in-flight cancellation/progress, notifications, workspace roots) without axum/PyO3.
 
-`dcc-mcp-http` remains the embedded MCP HTTP server facade (axum routes, server startup, config aggregate, Python bindings, resource/prompt registries) and depends on the extracted crates.
+`dcc-mcp-http` remains the embedded MCP HTTP server facade (axum routes, server startup, resource/prompt registries, gateway bootstrap, and compatibility re-exports) and depends on the extracted crates. New Rust code should import pure config/value types, including `McpHttpConfig`, from `dcc-mcp-http-types`; the PyO3 HTTP binding boundary lives in `dcc-mcp-http-py`.
 
 ```
 crates/
@@ -196,9 +196,10 @@ crates/
 ├── dcc-mcp-skill-rest/     # Per-DCC /v1/* REST skill API
 ├── dcc-mcp-gateway-core/   # Pure gateway domain/search/ranking types
 ├── dcc-mcp-gateway/        # Multi-DCC gateway app + dynamic wrappers
-├── dcc-mcp-http-types/     # Pure HTTP wire/config/value types
+├── dcc-mcp-http-types/     # Pure HTTP wire/config/value types, McpHttpConfig
 ├── dcc-mcp-http-server/    # Reusable HTTP runtime support
-├── dcc-mcp-http/           # Embedded MCP HTTP facade + Python bindings
+├── dcc-mcp-http-py/        # PyO3 binding boundary for HTTP APIs
+├── dcc-mcp-http/           # Embedded MCP HTTP facade + compatibility re-exports
 ├── dcc-mcp-server/         # Binary entry point and gateway runner
 ├── dcc-mcp-logging/        # File logging + retention helpers
 ├── dcc-mcp-paths/          # Platform cache/config/data path helpers
@@ -1078,4 +1079,4 @@ MCP resource `resources://gateway/events`: JSONL ring buffer, last 1000 contenti
 
 ### McpHttpConfig Sub-configs and HTTP type crates (#764 / #852)
 
-`McpHttpConfig` is a thin aggregate. Access via view methods: `.queue_config()` → `QueueConfig`, `.gateway_config()` → `HttpGatewayConfig`, `.session_config()` → `SessionConfig`, `.telemetry_config()` → `HttpTelemetryConfig`. Pure wire/config/value types that no longer need axum/PyO3 live in `dcc-mcp-http-types` and are re-exported from `dcc-mcp-http` for compatibility; reusable runtime support such as core tool builders, sessions, executors, in-flight request state, notifications, and workspace roots lives in `dcc-mcp-http-server`.
+`McpHttpConfig` is a thin aggregate in `dcc-mcp-http-types::config`. Access cohesive sub-configs through public fields: `.server`, `.instance`, `.session`, `.gateway`, `.queue`, `.telemetry`, `.features`, `.workflow`, and `.job`; compatibility accessors/builders remain available. Pure wire/config/value types that no longer need axum/PyO3 live in `dcc-mcp-http-types` and are re-exported from `dcc-mcp-http` for compatibility; reusable runtime support such as core tool builders, sessions, executors, in-flight request state, notifications, and workspace roots lives in `dcc-mcp-http-server`; the PyO3 HTTP binding boundary lives in `dcc-mcp-http-py`.


### PR DESCRIPTION
## Summary
- update architecture maps, CONTRIBUTING, and what-is docs for the current #845/#852 crate split
- clarify that `McpHttpConfig` lives in `dcc-mcp-http-types::config` and `dcc-mcp-http-py` owns the PyO3 HTTP boundary
- update Rust examples to import HTTP config from `dcc_mcp_http_types` and REST wiring from `dcc_mcp_skill_rest`
- refresh `llms.txt` and `llms-full.txt` so AI-facing API guidance matches the latest interface design

Refs #848

## Validation
- `git diff --check`
- `vx just docs-check`