### PR TITLE
fix(gateway): exclude status-stale instances

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state.rs
@@ -332,7 +332,7 @@ impl GatewayState {
 /// when the row is still live, and the redundant `stale: bool` field is
 /// kept for clients that prefer to branch on a boolean.
 pub fn entry_to_json(e: &ServiceEntry, stale_timeout: Duration) -> Value {
-    let stale = e.is_stale(stale_timeout);
+    let stale = e.is_stale(stale_timeout) || e.status == ServiceStatus::Stale;
     let status = if stale {
         "stale".to_string()
     } else {

--- a/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use dcc_mcp_transport::discovery::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry};
+use dcc_mcp_transport::discovery::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry, ServiceStatus};
 use std::sync::Arc;
 use tokio::sync::{RwLock, broadcast, watch};
 
@@ -142,6 +142,29 @@ async fn test_live_instances_self_row_localhost_aliases() {
     );
 }
 
+/// Issue #940: `ServiceStatus::Stale` is an immediate routing veto even
+/// before the heartbeat crosses `stale_timeout`.
+#[tokio::test]
+async fn test_live_instances_excludes_status_stale_immediately() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
+
+    {
+        let r = registry.read().await;
+        let mut stale = ServiceEntry::new("maya", "127.0.0.1", 18812);
+        stale.status = ServiceStatus::Stale;
+        r.register(stale).unwrap();
+
+        let photoshop = ServiceEntry::new("photoshop", "127.0.0.1", 18813);
+        r.register(photoshop).unwrap();
+    }
+
+    let gs = test_gateway_state(registry.clone());
+    let live = gs.live_instances(&*registry.read().await);
+    assert_eq!(live.len(), 1, "only the non-stale row should remain");
+    assert_eq!(live[0].dcc_type, "photoshop");
+}
+
 /// Issue #555: instances with `dcc_type == "unknown"` must be hidden from
 /// `live_instances` when `allow_unknown_tools` is `false` (the default).
 #[tokio::test]
@@ -259,6 +282,16 @@ fn test_entry_to_json_status_stale_for_aged_row() {
     let json = entry_to_json(&e, Duration::from_secs(30));
     assert_eq!(json["status"].as_str(), Some("stale"));
     assert_eq!(json["stale"].as_bool(), Some(true));
+}
+
+#[test]
+fn test_entry_to_json_status_stale_for_marked_row() {
+    let mut e = ServiceEntry::new("maya", "127.0.0.1", 18812);
+    e.status = ServiceStatus::Stale;
+    let json = entry_to_json(&e, Duration::from_secs(30));
+    assert_eq!(json["status"].as_str(), Some("stale"));
+    assert_eq!(json["stale"].as_bool(), Some(true));
+    assert_eq!(json["pool"]["available"].as_bool(), Some(false));
 }
 
 #[test]

--- a/crates/dcc-mcp-gateway/src/gateway/state/views.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state/views.rs
@@ -127,6 +127,7 @@ impl<'a> DiscoveryState<'a> {
                         ServiceStatus::ShuttingDown
                             | ServiceStatus::Unreachable
                             | ServiceStatus::Booting
+                            | ServiceStatus::Stale
                     )
                     && !crate::gateway::is_own_instance(e, self.own_host, self.own_port)
                     && (self.allow_unknown_tools || !e.dcc_type.eq_ignore_ascii_case("unknown"))

--- a/crates/dcc-mcp-transport/src/discovery/types.rs
+++ b/crates/dcc-mcp-transport/src/discovery/types.rs
@@ -45,6 +45,10 @@ pub enum ServiceStatus {
     /// dead backend — the row stays in the registry but no traffic
     /// should be routed to it until readiness flips green.
     Booting,
+    /// Service has already been marked stale by a probe or registry owner.
+    /// This is stronger than heartbeat age and must be treated as unroutable
+    /// immediately, even before the gateway's stale timeout elapses.
+    Stale,
 }
 
 impl std::fmt::Display for ServiceStatus {
@@ -55,6 +59,7 @@ impl std::fmt::Display for ServiceStatus {
             Self::Unreachable => write!(f, "unreachable"),
             Self::ShuttingDown => write!(f, "shutting_down"),
             Self::Booting => write!(f, "booting"),
+            Self::Stale => write!(f, "stale"),
         }
     }
 }


### PR DESCRIPTION
## Summary
- add ServiceStatus::Stale as an explicit unroutable registry status
- exclude status-stale rows from the shared live_instances view immediately
- surface marked stale rows as status=stale in instance JSON

## Tests
- vx cargo test -p dcc-mcp-gateway status_stale
- vx cargo fmt --check

Closes #940