### PR TITLE
ci: run DCC integration after CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ on:
       - "pyproject.toml"
       - "rust-toolchain.toml"
       - ".github/workflows/ci.yml"
+      - ".github/workflows/dcc-integration.yml"
       - ".github/actions/build-wheel/**"
   push:
     branches: [main]
@@ -37,6 +38,7 @@ on:
       - "pyproject.toml"
       - "rust-toolchain.toml"
       - ".github/workflows/ci.yml"
+      - ".github/workflows/dcc-integration.yml"
       - ".github/actions/build-wheel/**"
 
 permissions:

--- a/.github/workflows/dcc-integration.yml
+++ b/.github/workflows/dcc-integration.yml
@@ -121,7 +121,7 @@ jobs:
   blender:
     name: Blender ${{ matrix.blender-version }}
     needs: [wheel-ready]
-    if: github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'blender'
+    if: github.event_name == 'workflow_run' || github.event_name == 'workflow_call' || github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'blender'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -179,7 +179,7 @@ jobs:
   openscad:
     name: OpenSCAD
     needs: [wheel-ready]
-    if: github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'openscad'
+    if: github.event_name == 'workflow_run' || github.event_name == 'workflow_call' || github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'openscad'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -209,7 +209,7 @@ jobs:
   godot:
     name: Godot
     needs: [wheel-ready]
-    if: github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'godot'
+    if: github.event_name == 'workflow_run' || github.event_name == 'workflow_call' || github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'godot'
     runs-on: ubuntu-latest
     env:
       GODOT_VERSION: "4.4.1"
@@ -245,7 +245,7 @@ jobs:
   cross-dcc:
     name: Cross-DCC Pipeline
     needs: [wheel-ready]
-    if: github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'cross'
+    if: github.event_name == 'workflow_run' || github.event_name == 'workflow_call' || github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'cross'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- run DCC jobs for workflow_run and workflow_call triggers instead of only workflow_dispatch inputs
- include dcc-integration.yml in CI path filters so workflow changes trigger upstream CI and then DCC Integration

## Validation
- git diff --check
- vx yq e '.name' .github/workflows/dcc-integration.yml
- pre-commit yaml hook passed

Fixes the skipped DCC Integration workflow runs.