### PR TITLE
fix(skills): activate groups when loading skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@
 ```
 Per-DCC MCP server:
 1. Discover: search_skills(query="keyword") → find the right skill
-2. Activate: load_skill("skill-name") → expose the tools
+2. Activate: load_skill("skill-name") → expose the tools and cascade-activate declared tool groups by default
 3. Execute: call the specific tool with validated parameters
 4. Follow up: check next-tools.on-success for suggested next steps
 5. Debug on failure: use dcc_diagnostics__screenshot or audit_log

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/call.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/call.rs
@@ -33,7 +33,13 @@ pub async fn route_tools_call(
     // ── Skill-management tools ──────────────────────────────────────────
     if matches!(
         tool,
-        "list_skills" | "search_skills" | "get_skill_info" | "load_skill" | "unload_skill"
+        "list_skills"
+            | "search_skills"
+            | "get_skill_info"
+            | "load_skill"
+            | "unload_skill"
+            | "activate_tool_group"
+            | "deactivate_tool_group"
     ) {
         return skill_mgmt_dispatch(gs, tool, args).await;
     }

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/skill_mgmt.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/skill_mgmt.rs
@@ -18,13 +18,18 @@ pub(crate) async fn skill_mgmt_dispatch(
     let target_instance = args.get("instance_id").and_then(Value::as_str);
 
     match tool {
-        "load_skill" | "unload_skill" => {
+        "load_skill" | "unload_skill" | "activate_tool_group" | "deactivate_tool_group" => {
             match resolve_target(gs, target_instance, dcc_filter).await {
                 Ok(entry) => {
                     // Strip gateway-only routing keys before forwarding.
                     let mut forward_args = args.clone();
                     if let Some(obj) = forward_args.as_object_mut() {
                         obj.remove("instance_id");
+                        if let Some(group_name) = obj.get("group_name").cloned()
+                            && !obj.contains_key("group")
+                        {
+                            obj.insert("group".to_string(), group_name);
+                        }
                     }
                     let url = format!("http://{}:{}/mcp", entry.host, entry.port);
                     let params = json!({"name": tool, "arguments": forward_args});
@@ -236,7 +241,7 @@ fn call_tool_text(value: &Value) -> Option<&str> {
         .and_then(Value::as_str)
 }
 
-/// JSON-Schema definitions for the six skill-management tools the gateway
+/// JSON-Schema definitions for the skill-management tools the gateway
 /// exposes (matching the per-DCC server schemas but with gateway-specific
 /// routing parameters like `instance_id` and `dcc`).
 pub(crate) fn skill_management_tool_defs() -> Vec<Value> {
@@ -288,10 +293,11 @@ pub(crate) fn skill_management_tool_defs() -> Vec<Value> {
             "inputSchema": {
                 "type": "object",
                 "properties": {
-                    "skill_name":  {"type": "string"},
-                    "skill_names": {"type": "array", "items": {"type": "string"}},
-                    "instance_id": {"type": "string", "description": "Target instance (full UUID or short prefix)"},
-                    "dcc":         {"type": "string", "description": "DCC type when only one instance of that type is live"}
+                    "skill_name":      {"type": "string"},
+                    "skill_names":     {"type": "array", "items": {"type": "string"}},
+                    "activate_groups": {"type": "boolean", "default": true, "description": "Cascade-activate all declared tool groups after loading. Set false for lazy activation."},
+                    "instance_id":     {"type": "string", "description": "Target instance (full UUID or short prefix)"},
+                    "dcc":             {"type": "string", "description": "DCC type when only one instance of that type is live"}
                 },
                 "required": ["skill_name"]
             }
@@ -307,6 +313,36 @@ pub(crate) fn skill_management_tool_defs() -> Vec<Value> {
                     "dcc":         {"type": "string"}
                 },
                 "required": ["skill_name"]
+            }
+        }),
+        json!({
+            "name": "activate_tool_group",
+            "description": "Activate a progressive tool group on a specific DCC instance.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "group_name":  {"type": "string"},
+                    "group":       {"type": "string", "description": "Alias of group_name"},
+                    "skill_name":  {"type": "string", "description": "Optional disambiguation for clients"},
+                    "instance_id": {"type": "string"},
+                    "dcc":         {"type": "string"}
+                },
+                "required": ["group_name"]
+            }
+        }),
+        json!({
+            "name": "deactivate_tool_group",
+            "description": "Deactivate a progressive tool group on a specific DCC instance.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "group_name":  {"type": "string"},
+                    "group":       {"type": "string", "description": "Alias of group_name"},
+                    "skill_name":  {"type": "string", "description": "Optional disambiguation for clients"},
+                    "instance_id": {"type": "string"},
+                    "dcc":         {"type": "string"}
+                },
+                "required": ["group_name"]
             }
         }),
     ]

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
@@ -13,10 +13,12 @@ fn skill_management_tool_defs_cover_all_six_tools() {
         "get_skill_info",
         "load_skill",
         "unload_skill",
+        "activate_tool_group",
+        "deactivate_tool_group",
     ] {
         assert!(names.contains(&expected), "missing tool def {expected}");
     }
-    assert_eq!(defs.len(), 5, "expected exactly 5 skill-management tools");
+    assert_eq!(defs.len(), 7, "expected exactly 7 skill-management tools");
 }
 
 #[test]
@@ -185,6 +187,8 @@ async fn aggregate_tools_list_returns_only_minimal_gateway_surface() {
         "call_tool",
         "search_skills",
         "load_skill",
+        "activate_tool_group",
+        "deactivate_tool_group",
     ] {
         assert!(
             names.contains(&expected),

--- a/crates/dcc-mcp-gateway/src/gateway/tools.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tools.rs
@@ -111,7 +111,7 @@ pub async fn tool_search_tools(gs: &GatewayState, args: &Value) -> Result<String
 
     // Annotate unloaded hits with a structured `next_step` so agents
     // know they must call `load_skill` before invoking the tool.
-    let annotated: Vec<Value> = hits
+    let mut annotated: Vec<Value> = hits
         .into_iter()
         .map(|h| {
             let mut v = serde_json::to_value(&h).unwrap_or(Value::Null);
@@ -126,12 +126,56 @@ pub async fn tool_search_tools(gs: &GatewayState, args: &Value) -> Result<String
             v
         })
         .collect();
+    annotated.extend(local_gateway_tool_hits(&query.query));
 
     serde_json::to_string_pretty(&json!({
         "total": annotated.len(),
         "hits":  annotated,
     }))
     .map_err(|e| e.to_string())
+}
+
+fn local_gateway_tool_hits(query: &str) -> Vec<Value> {
+    let q = query.trim().to_ascii_lowercase();
+    let tools = [
+        (
+            "activate_tool_group",
+            "Activate a progressive tool group on a DCC instance after lazy loading.",
+        ),
+        (
+            "deactivate_tool_group",
+            "Deactivate a progressive tool group on a DCC instance.",
+        ),
+    ];
+
+    tools
+        .into_iter()
+        .filter(|(name, summary)| {
+            q.is_empty()
+                || name.contains(&q)
+                || summary.to_ascii_lowercase().contains(&q)
+                || q == "group"
+        })
+        .map(|(name, summary)| {
+            json!({
+                "tool_slug": format!("gateway.{name}"),
+                "backend_tool": name,
+                "callable_id": name,
+                "skill_name": null,
+                "summary": summary,
+                "tags": ["gateway", "group", "skill-management"],
+                "dcc_type": "gateway",
+                "instance_id": uuid::Uuid::nil(),
+                "has_schema": true,
+                "loaded": true,
+                "score": 100,
+                "next_step": {
+                    "action": "tools/call",
+                    "name": name,
+                },
+            })
+        })
+        .collect()
 }
 
 /// `describe_tool` — MCP wrapper around
@@ -362,6 +406,18 @@ mod tests {
                 (name, annotations)
             })
             .collect()
+    }
+
+    #[test]
+    fn local_gateway_tool_hits_find_group_management_tools() {
+        let hits = local_gateway_tool_hits("group");
+        let names: Vec<&str> = hits
+            .iter()
+            .filter_map(|hit| hit.get("backend_tool").and_then(Value::as_str))
+            .collect();
+
+        assert!(names.contains(&"activate_tool_group"));
+        assert!(names.contains(&"deactivate_tool_group"));
     }
 
     #[test]

--- a/crates/dcc-mcp-http-server/src/handlers/tool_builder_core.rs
+++ b/crates/dcc-mcp-http-server/src/handlers/tool_builder_core.rs
@@ -117,6 +117,7 @@ pub fn build_core_tools_inner() -> Vec<McpTool> {
                           When to use: Call after search_skills, list_skills, or get_skill_info has identified the skill you need. Idempotent — re-loading an already-loaded skill is a no-op.\n\n\
                           How to use:\n\
                           - Use skill_name for one skill, or skill_names for a batch in a single round-trip.\n\
+                          - By default, every declared tool group is activated so registered tools are immediately callable; set activate_groups=false to keep lazy group activation.\n\
                           - After success, call tools/list or the specific tool (e.g. maya_geometry__create_sphere) directly."
                 .to_string(),
             input_schema: json!({
@@ -130,6 +131,11 @@ pub fn build_core_tools_inner() -> Vec<McpTool> {
                         "type": "array",
                         "items": { "type": "string" },
                         "description": "Batch of skill names to load in one call."
+                    },
+                    "activate_groups": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Cascade-activate all declared tool groups after loading. Set false for lazy activation."
                     }
                 }
             }),
@@ -233,12 +239,16 @@ pub fn build_core_tools_inner() -> Vec<McpTool> {
             input_schema: json!({
                 "type": "object",
                 "properties": {
-                    "group": {
+                    "group_name": {
                         "type": "string",
                         "description": "Group name as shown in the __group__<name> stub."
+                    },
+                    "group": {
+                        "type": "string",
+                        "description": "Alias of group_name."
                     }
                 },
-                "required": ["group"]
+                "required": ["group_name"]
             }),
             output_schema: None,
             annotations: Some(McpToolAnnotations {
@@ -257,17 +267,21 @@ pub fn build_core_tools_inner() -> Vec<McpTool> {
                           When to use: Use to shrink the active tool surface once a sub-workflow is done, to stay within the client's token budget. Group tools remain on disk — only their visibility changes.\n\n\
                           How to use:\n\
                           - Idempotent; calling on an already-inactive group is a safe no-op.\n\
-                          - To bring the tools back, call activate_tool_group(group=...)."
+                          - To bring the tools back, call activate_tool_group(group_name=...)."
                 .to_string(),
             input_schema: json!({
                 "type": "object",
                 "properties": {
-                    "group": {
+                    "group_name": {
                         "type": "string",
                         "description": "Group name previously passed to activate_tool_group."
+                    },
+                    "group": {
+                        "type": "string",
+                        "description": "Alias of group_name."
                     }
                 },
-                "required": ["group"]
+                "required": ["group_name"]
             }),
             output_schema: None,
             annotations: Some(McpToolAnnotations {

--- a/crates/dcc-mcp-http/src/handlers/job_tools.rs
+++ b/crates/dcc-mcp-http/src/handlers/job_tools.rs
@@ -9,13 +9,15 @@ pub async fn handle_activate_tool_group(
     let group = params
         .arguments
         .as_ref()
-        .and_then(|a| a.get("group"))
+        .and_then(|a| a.get("group").or_else(|| a.get("group_name")))
         .and_then(Value::as_str)
         .unwrap_or_default();
     if group.is_empty() {
         return Ok(JsonRpcResponse::success(
             req.id.clone(),
-            serde_json::to_value(CallToolResult::error("Missing required parameter: group"))?,
+            serde_json::to_value(CallToolResult::error(
+                "Missing required parameter: group or group_name",
+            ))?,
         ));
     }
 
@@ -54,13 +56,15 @@ pub async fn handle_deactivate_tool_group(
     let group = params
         .arguments
         .as_ref()
-        .and_then(|a| a.get("group"))
+        .and_then(|a| a.get("group").or_else(|| a.get("group_name")))
         .and_then(Value::as_str)
         .unwrap_or_default();
     if group.is_empty() {
         return Ok(JsonRpcResponse::success(
             req.id.clone(),
-            serde_json::to_value(CallToolResult::error("Missing required parameter: group"))?,
+            serde_json::to_value(CallToolResult::error(
+                "Missing required parameter: group or group_name",
+            ))?,
         ));
     }
 

--- a/crates/dcc-mcp-http/src/handlers/skill_tools.rs
+++ b/crates/dcc-mcp-http/src/handlers/skill_tools.rs
@@ -100,6 +100,13 @@ pub async fn handle_load_skill(
         ));
     }
 
+    let activate_groups = params
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("activate_groups"))
+        .and_then(Value::as_bool)
+        .unwrap_or(true);
+
     // Collect the full set of requested skills, deduping `skill_name` vs the
     // `skill_names` array so callers passing both don't trigger the work twice.
     let mut requested: Vec<String> = Vec::new();
@@ -119,7 +126,11 @@ pub async fn handle_load_skill(
 
     for name in &requested {
         let was_loaded = state.server.catalog.is_loaded(name);
-        match state.server.catalog.load_skill(name) {
+        match state
+            .server
+            .catalog
+            .load_skill_with_options(name, activate_groups)
+        {
             Ok(tools) => {
                 all_registered_tools.extend(tools);
                 if was_loaded {

--- a/crates/dcc-mcp-http/src/tests/gateway_mcp.rs
+++ b/crates/dcc-mcp-http/src/tests/gateway_mcp.rs
@@ -97,18 +97,20 @@ async fn test_gateway_mcp_tools_list_omits_removed_verbs() {
         "get_skill_info",
         "load_skill",
         "unload_skill",
+        "activate_tool_group",
+        "deactivate_tool_group",
     ] {
         assert!(
             names.contains(&skill_mgmt),
             "skill-management tool {skill_mgmt} should still be published: {names:?}",
         );
     }
-    // 5 dispatch verbs + 5 skill-management = 10 gateway meta-tools.
+    // 5 dispatch verbs + 7 skill-management = 12 gateway meta-tools.
     // Diagnostics + catalog moved to resources (#813 phase 2).
     assert_eq!(
         names.len(),
-        10,
-        "expected 10 gateway meta-tools (5 dispatch + 5 skill mgmt) after #813 phases 1+2, got: {names:?}",
+        12,
+        "expected 12 gateway meta-tools (5 dispatch + 7 skill mgmt) after #813 phases 1+2, got: {names:?}",
     );
 }
 

--- a/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
@@ -1,14 +1,41 @@
 use super::*;
 
+fn activate_skill_groups(catalog: &SkillCatalog, metadata: &SkillMetadata) {
+    for group in &metadata.groups {
+        if !group.name.is_empty() {
+            catalog.activate_group(&group.name);
+        }
+    }
+    for tool in &metadata.tools {
+        if !tool.group.is_empty() {
+            catalog.activate_group(&tool.group);
+        }
+    }
+}
+
 impl SkillCatalog {
     /// Load a skill by name — registers its tools into ToolRegistry and,
     /// if a dispatcher is attached, auto-registers script execution handlers.
     pub fn load_skill(&self, skill_name: &str) -> Result<Vec<String>, String> {
+        self.load_skill_with_options(skill_name, true)
+    }
+
+    /// Load a skill, optionally activating every declared tool group.
+    pub fn load_skill_with_options(
+        &self,
+        skill_name: &str,
+        activate_groups: bool,
+    ) -> Result<Vec<String>, String> {
         if self.loaded.contains(skill_name) {
             let actions = self
                 .entries
                 .get(skill_name)
-                .map(|entry| entry.registered_tools.clone())
+                .map(|entry| {
+                    if activate_groups {
+                        activate_skill_groups(self, &entry.metadata);
+                    }
+                    entry.registered_tools.clone()
+                })
                 .unwrap_or_default();
             return Ok(actions);
         }
@@ -24,9 +51,13 @@ impl SkillCatalog {
         let skill_base = metadata.name.replace('-', "_");
         let skill_path = std::path::Path::new(&metadata.skill_path);
 
-        for group in &metadata.groups {
-            if group.default_active {
-                self.active_groups.insert(group.name.clone());
+        if activate_groups {
+            activate_skill_groups(self, &metadata);
+        } else {
+            for group in &metadata.groups {
+                if group.default_active {
+                    self.active_groups.insert(group.name.clone());
+                }
             }
         }
 
@@ -67,7 +98,8 @@ impl SkillCatalog {
                 source_file: script_path.clone(),
                 skill_name: Some(skill_name.to_string()),
                 group: tool_decl.group.clone(),
-                enabled: group_default_active(&metadata.groups, &tool_decl.group),
+                enabled: activate_groups
+                    || group_default_active(&metadata.groups, &tool_decl.group),
                 required_capabilities: tool_decl.required_capabilities.clone(),
                 execution: tool_decl.execution,
                 timeout_hint_secs: tool_decl.timeout_hint_secs,

--- a/crates/dcc-mcp-skills/src/catalog/tests/test_catalog_crud.rs
+++ b/crates/dcc-mcp-skills/src/catalog/tests/test_catalog_crud.rs
@@ -1,6 +1,6 @@
 use super::fixtures::{make_catalog_with_dispatcher, make_test_catalog, make_test_skill};
 use super::*;
-use dcc_mcp_models::ToolDeclaration;
+use dcc_mcp_models::{SkillGroup, ToolDeclaration};
 
 #[test]
 fn test_catalog_new_is_empty() {
@@ -54,6 +54,70 @@ fn test_load_skill_with_action_meta_skill_name() {
         .get_action("my_skill__tool1", None)
         .unwrap();
     assert_eq!(meta.skill_name, Some("my-skill".to_string()));
+}
+
+#[test]
+fn test_load_skill_activates_declared_groups_by_default() {
+    let catalog = make_test_catalog();
+    let mut skill = make_test_skill("maya-scene", "maya", &[]);
+    skill.groups = vec![SkillGroup {
+        name: "scene-management".to_string(),
+        default_active: false,
+        ..Default::default()
+    }];
+    skill.tools = vec![ToolDeclaration {
+        name: "new_scene".to_string(),
+        group: "scene-management".to_string(),
+        ..Default::default()
+    }];
+    catalog.add_skill(skill);
+
+    catalog.load_skill("maya-scene").unwrap();
+
+    let meta = catalog
+        .registry()
+        .get_action("maya_scene__new_scene", None)
+        .expect("grouped action registered");
+    assert!(
+        meta.enabled,
+        "load_skill should make grouped actions callable"
+    );
+    assert!(
+        catalog
+            .active_groups()
+            .contains(&"scene-management".to_string()),
+        "declared group should be active after default load"
+    );
+}
+
+#[test]
+fn test_load_skill_can_leave_groups_inactive_when_requested() {
+    let catalog = make_test_catalog();
+    let mut skill = make_test_skill("maya-scene", "maya", &[]);
+    skill.groups = vec![SkillGroup {
+        name: "scene-management".to_string(),
+        default_active: false,
+        ..Default::default()
+    }];
+    skill.tools = vec![ToolDeclaration {
+        name: "new_scene".to_string(),
+        group: "scene-management".to_string(),
+        ..Default::default()
+    }];
+    catalog.add_skill(skill);
+
+    catalog
+        .load_skill_with_options("maya-scene", false)
+        .expect("skill loads with inactive groups");
+
+    let meta = catalog
+        .registry()
+        .get_action("maya_scene__new_scene", None)
+        .expect("grouped action registered");
+    assert!(
+        !meta.enabled,
+        "activate_groups=false should preserve laziness"
+    );
 }
 
 #[test]

--- a/llms.txt
+++ b/llms.txt
@@ -23,7 +23,7 @@
 ```
 1. DISCOVER: search_skills(query="keyword") → find the right skill
 2. CHECK: Read the skill's description and tools
-3. ACTIVATE: load_skill("skill-name") → expose the tools
+3. ACTIVATE: load_skill("skill-name") → expose the tools and cascade-activate declared tool groups by default
 4. EXECUTE: Call the specific tool with validated parameters
 5. FOLLOW UP: Check next-tools.on-success for suggested next steps
 6. DEBUG: On failure, use dcc_diagnostics__screenshot or audit_log
@@ -58,7 +58,7 @@
 | Drive a DCC main-thread dispatcher | `from dcc_mcp_core.host import HostAdapter, StandaloneHost, TickableDispatcher, QueueDispatcher, BlockingDispatcher`; `TickableDispatcher` is the public minimal protocol (`tick`, `shutdown`, `is_shutdown`) for adapter typing. Do not import private host protocols. |
 | Write skill scripts | `skill_entry` + `skill_success` / `skill_error` — zero-boilerplate skill authoring |
 | Control skill trust level | `SkillScope` (Repo < User < System < Admin) — higher scope shadows lower |
-| Progressive tool exposure | `SkillGroup` with `default_active` + `activate_tool_group()` |
+| Progressive tool exposure | `SkillGroup`; `load_skill()` activates groups by default, or use `load_skill(activate_groups=false)` + `activate_tool_group(group_name=...)` for lazy activation |
 | Remote-accessible MCP server (cloud agents) | `create_skill_server("maya", McpHttpConfig(host="0.0.0.0", port=8765, enable_cors=True))` — bind `0.0.0.0`, CORS on, Bearer auth via `cfg.api_key` |
 | Bearer-token / OAuth auth | `ApiKeyConfig`, `OAuthConfig`, `CimdDocument`, `validate_bearer_token(headers, expected_token=...)`, `generate_api_key()` |
 | Batch multiple tool calls server-side (issue #406) | `batch_dispatch(dispatcher, calls, aggregate="merge")` — returns `{total, succeeded, errors, merged}` |


### PR DESCRIPTION
## Summary
- make load_skill cascade-activate declared tool groups by default
- add activate_groups=false opt-out for lazy group activation
- expose activate_tool_group/deactivate_tool_group through the gateway skill-management surface and search_tools
- accept group_name as the public group activation argument

## Tests
- vx cargo test -p dcc-mcp-skills groups
- vx cargo test -p dcc-mcp-gateway skill_management
- vx cargo test -p dcc-mcp-gateway local_gateway_tool_hits_find_group_management_tools
- vx cargo test -p dcc-mcp-http tools_list
- vx cargo check --workspace
- vx cargo fmt --check

Closes #941