### PR TITLE
fix(gateway): find short capability queries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ Per-DCC MCP server:
 5. Debug on failure: use dcc_diagnostics__screenshot or audit_log
 
 Gateway dynamic-capability / REST exposure:
-1. Discover: search_tools(query="keyword", dcc_type="maya") → get tool_slug
+1. Discover: search_tools(query="keyword", dcc_type="maya") → get tool_slug; names/summaries are tokenized, so underscores are optional (`create_sphere` and `sphere` both work)
 2. Inspect: describe_tool(tool_slug) → read schema + annotations
 3. Execute: call_tool(tool_slug, arguments={...})
 4. The gateway never fans out per-tool backend tools into tools/list.

--- a/crates/dcc-mcp-gateway-core/src/capability/search.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/search.rs
@@ -467,6 +467,124 @@ mod tests {
     }
 
     #[test]
+    fn fuzzy_mode_finds_obvious_short_keywords() {
+        let iid = Uuid::from_u128(1);
+        let snap = snapshot(vec![
+            record(
+                "maya",
+                iid,
+                "maya_primitives__create_sphere",
+                "Create a polygon sphere",
+                &[],
+                true,
+                true,
+            ),
+            record(
+                "maya",
+                iid,
+                "maya_scene__execute_python",
+                "Execute Python in Maya",
+                &[],
+                true,
+                true,
+            ),
+            record(
+                "maya",
+                iid,
+                "maya_scene__group_objects",
+                "Group a list of objects under a new transform node",
+                &[],
+                true,
+                true,
+            ),
+            record(
+                "maya",
+                iid,
+                "maya_anim__bake_simulation",
+                "Bake animation simulation",
+                &[],
+                true,
+                true,
+            ),
+            record(
+                "maya",
+                iid,
+                "maya_io__import_scene",
+                "Import a scene file",
+                &[],
+                true,
+                true,
+            ),
+            record(
+                "maya",
+                iid,
+                "maya_geometry__export_fbx",
+                "Export selected geometry as FBX",
+                &[],
+                true,
+                true,
+            ),
+            record(
+                "maya",
+                iid,
+                "maya_viewport__playblast",
+                "Create a viewport playblast",
+                &[],
+                true,
+                true,
+            ),
+            record(
+                "maya",
+                iid,
+                "maya_scene__find_by_pattern",
+                "Find objects by name pattern",
+                &[],
+                true,
+                true,
+            ),
+        ]);
+
+        for query in [
+            "sphere",
+            "create_sphere",
+            "execute_python",
+            "group",
+            "bake",
+            "import",
+            "export",
+            "playblast",
+        ] {
+            let hits = search(
+                &snap,
+                &SearchQuery {
+                    query: query.into(),
+                    ..Default::default()
+                },
+            );
+            assert!(!hits.is_empty(), "expected at least one hit for {query:?}");
+        }
+
+        let fbx_hits = search(
+            &snap,
+            &SearchQuery {
+                query: "fbx".into(),
+                ..Default::default()
+            },
+        );
+        assert!(
+            fbx_hits
+                .iter()
+                .any(|hit| hit.record.backend_tool == "maya_geometry__export_fbx")
+        );
+        assert!(
+            fbx_hits
+                .iter()
+                .all(|hit| hit.record.backend_tool != "maya_scene__find_by_pattern"),
+            "fbx must not match unrelated find_by_pattern rows: {fbx_hits:?}"
+        );
+    }
+
+    #[test]
     fn pagination_returns_stable_slices() {
         let iid = Uuid::from_u128(1);
         let records: Vec<CapabilityRecord> = (0..75)

--- a/crates/dcc-mcp-gateway-core/src/capability/search_ranking.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/search_ranking.rs
@@ -131,6 +131,81 @@ const EXACT_BONUS: u32 = 20;
 /// buckets which preserves the ordering while collapsing
 /// fingerprint-level jitter.
 const FUZZY_QUANTISE_DIVISOR: u32 = 32;
+const SHORT_QUERY_MAX_LEN: usize = 3;
+
+fn search_tokens(value: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut prev_lower = false;
+
+    for ch in value.chars() {
+        if ch.is_ascii_alphanumeric() {
+            if prev_lower && ch.is_ascii_uppercase() && !current.is_empty() {
+                tokens.push(current.to_ascii_lowercase());
+                current.clear();
+            }
+            current.push(ch);
+            prev_lower = ch.is_ascii_lowercase() || ch.is_ascii_digit();
+        } else {
+            if !current.is_empty() {
+                tokens.push(current.to_ascii_lowercase());
+                current.clear();
+            }
+            prev_lower = false;
+        }
+    }
+
+    if !current.is_empty() {
+        tokens.push(current.to_ascii_lowercase());
+    }
+
+    tokens
+}
+
+fn token_match_score(query: &str, candidate: &str, exact: u32, prefix: u32, substring: u32) -> u32 {
+    if query.is_empty() || candidate.is_empty() {
+        return 0;
+    }
+
+    let candidate_lower = candidate.to_ascii_lowercase();
+    if candidate_lower == query {
+        return exact;
+    }
+    if candidate_lower.contains(query) {
+        return substring;
+    }
+
+    let query_tokens = search_tokens(query);
+    let candidate_tokens = search_tokens(candidate);
+    if query_tokens.is_empty() || candidate_tokens.is_empty() {
+        return 0;
+    }
+
+    let mut total = 0;
+    for qtok in &query_tokens {
+        let token_score = candidate_tokens
+            .iter()
+            .map(|ctok| {
+                if ctok == qtok {
+                    exact
+                } else if ctok.starts_with(qtok) {
+                    prefix
+                } else if ctok.contains(qtok) {
+                    substring
+                } else {
+                    0
+                }
+            })
+            .max()
+            .unwrap_or(0);
+        if token_score == 0 {
+            return 0;
+        }
+        total += token_score;
+    }
+
+    total
+}
 
 /// Fuzzy scorer built on top of `nucleo-matcher`.
 ///
@@ -227,6 +302,10 @@ impl Scorer for FuzzyScorer {
         let mut score: u32 = 0;
 
         if !q.is_empty() {
+            let deterministic = token_match_score(q, &r.backend_tool, 18, 12, 8)
+                + token_match_score(q, &r.summary, 8, 5, 3);
+            score += deterministic;
+
             let pattern = Self::compile_pattern(q);
             let tool_lower = r.backend_tool.to_ascii_lowercase();
             let exact_tool = tool_lower == q;
@@ -237,6 +316,10 @@ impl Scorer for FuzzyScorer {
                 score += EXACT_BONUS;
             } else if prefix_tool {
                 score += PREFIX_BONUS;
+            }
+
+            if q.len() <= SHORT_QUERY_MAX_LEN && deterministic == 0 {
+                return 0;
             }
 
             if let Some(skill) = r.skill_name.as_deref() {

--- a/llms.txt
+++ b/llms.txt
@@ -25,6 +25,8 @@
 2. CHECK: Read the skill's description and tools
 3. ACTIVATE: load_skill("skill-name") → expose the tools and cascade-activate declared tool groups by default
 4. EXECUTE: Call the specific tool with validated parameters
+
+`search_tools` tokenizes backend tool names and summaries; literal underscores are honored but not required (`create_sphere` and `sphere` both match).
 5. FOLLOW UP: Check next-tools.on-success for suggested next steps
 6. DEBUG: On failure, use dcc_diagnostics__screenshot or audit_log
 ```


### PR DESCRIPTION
## Summary
- add deterministic token scoring for backend tool names and summaries
- keep short queries from surviving on unrelated fuzzy-only matches
- add golden coverage for sphere/create_sphere/execute_python/group/bake/import/export/playblast and fbx false positive
- document tokenized search behavior

## Tests
- vx cargo test -p dcc-mcp-gateway-core fuzzy_mode_finds_obvious_short_keywords
- vx cargo test -p dcc-mcp-gateway-core exact_mode_preserves_legacy_table
- vx cargo check --workspace
- vx cargo fmt --check

Closes #942