### PR TITLE
feat(admin-ui): infer DCC for gateway calls

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -286,6 +286,7 @@ mod admin_tests {
         assert_eq!(successes[0]["instance_id"], "maya-instance");
         assert_eq!(successes[0]["session_id"], "session-1");
         assert_eq!(failures[0]["request_id"], "req-fail");
+        assert_eq!(failures[0]["instance_id"], "blender-instance");
     }
 
     #[tokio::test]

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::gateway::capability::parse_slug;
 
 /// Minimal JSON-RPC 2.0 request shape accepted by the gateway `/mcp` endpoint.
 #[derive(Debug, Deserialize)]
@@ -232,6 +233,11 @@ async fn handle_tools_call(
         .as_ref()
         .and_then(|params| params.get("_meta"))
         .cloned();
+    let resolved_slug = if tool == "call_tool" {
+        args.get("tool_slug").and_then(Value::as_str)
+    } else {
+        None
+    };
 
     {
         let mut pending = gs.pending_calls.write().await;
@@ -246,8 +252,17 @@ async fn handle_tools_call(
 
     // ── Middleware: BeforeCall ────────────────────────────────────────────
     let mut ctx = crate::gateway::middleware::CallContext::new("tools/call", id_str, args.clone())
-        .with_tool_slug(tool)
+        .with_tool_slug(resolved_slug.unwrap_or(tool))
         .with_session_id(session_id);
+    if let Some((dcc_type, instance_hint, _)) = resolved_slug.and_then(parse_slug) {
+        ctx = ctx.with_backend(dcc_type, instance_hint);
+    } else if let Some(dcc_type) = args
+        .get("dcc_type")
+        .or_else(|| args.get("dcc"))
+        .and_then(Value::as_str)
+    {
+        ctx.dcc_type = Some(dcc_type.to_string());
+    }
 
     // Phase 2: capture input payload before middlewares may redact args.
     {

--- a/crates/dcc-mcp-gateway/src/gateway/middleware/context.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/middleware/context.rs
@@ -91,6 +91,17 @@ impl CallContext {
         self
     }
 
+    /// Builder: attach resolved backend routing metadata.
+    pub fn with_backend(
+        mut self,
+        dcc_type: impl Into<String>,
+        instance_id: impl Into<String>,
+    ) -> Self {
+        self.dcc_type = Some(dcc_type.into());
+        self.instance_id = Some(instance_id.into());
+        self
+    }
+
     /// Builder: attach the originating MCP session id.
     pub fn with_session_id(mut self, id: impl Into<String>) -> Self {
         self.session_id = Some(id.into());

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -103,7 +103,17 @@ When using `dcc-mcp-gateway` directly, compile with the `admin` Cargo feature. `
 {
   "total": 42,
   "calls": [
-    { "tool": "maya__open_scene", "success": true, "timestamp": "2026-05-05T10:00:00Z" }
+    {
+      "request_id": "req-123",
+      "method": "tools/call",
+      "tool": "maya.abcdef01.maya__open_scene",
+      "dcc_type": "maya",
+      "instance_id": "abcdef01-2345-6789-abcd-ef0123456789",
+      "session_id": "session-1",
+      "success": false,
+      "error": "backend timeout",
+      "timestamp": "2026-05-05T10:00:00Z"
+    }
   ]
 }
 
@@ -160,13 +170,12 @@ The `/admin/api/logs` feed is populated automatically from the `EventLog` ring b
 ## Dashboard Features
 
 The HTML dashboard includes:
-- **Left navigation**: Instances / Tools / Calls / Workers / Logs panels
+- **Left navigation**: Instances / Tools / Calls / Traces / Stats / Workers / Logs panels
 - **Auto-refresh**: Panels poll their JSON endpoints every 5 seconds
 - **Worker cards**: Per-instance status, heartbeat, and routing metadata
+- **Calls table**: request ids, error previews, and trace-detail links; DCC is displayed from the resolved backend slug when available, otherwise from explicit call arguments such as `dcc` / `dcc_type`.
 - **Dark theme**: Minimal inline CSS, no external fonts
 - **Responsive**: CSS grid layout
-
-The `health`, `traces`, and `stats` APIs are stable JSON surfaces even if the current inline HTML only renders a subset of them.
 
 ## Security Note
 


### PR DESCRIPTION
## Summary
- derive audit DCC/instance metadata from dynamic capability tool_slug for call_tool rows
- support explicit dcc/dcc_type arguments for gateway-local meta calls
- document Calls table DCC display rules
- extend admin calls regression assertion for instance id fields

## Tests
- vx cargo test -p dcc-mcp-gateway --features admin admin_calls_returns_two_audit_records
- vx just docs-check
- vx cargo fmt --check

Closes #947