### PR TITLE
feat(admin): persist audit traces as jsonl

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -54,7 +54,9 @@ mod handlers;
 #[cfg(feature = "admin")]
 mod router;
 
-pub use state::{AdminAuditRecord, AdminAuditSink, AdminState, AuditLog, EventLog};
+pub use state::{
+    AdminAuditRecord, AdminAuditSink, AdminState, AuditLog, DurableAuditStore, EventLog,
+};
 pub use stats::{GatewayStats, LatencyStats, StatsAggregator, StatsRange, TopEntry};
 pub use trace::{DispatchTrace, TraceLog, TracePayload, TraceSpan};
 pub use workers::build_workers_payload;

--- a/crates/dcc-mcp-gateway/src/gateway/admin/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/state.rs
@@ -1,10 +1,16 @@
 //! Shared state for the admin UI handlers.
 
+use std::fs;
+use std::fs::OpenOptions;
+use std::io::BufRead;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use parking_lot::Mutex;
-use serde_json::Value;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
 
 use crate::gateway::middleware::{AuditEntry, AuditSink};
 use crate::gateway::state::GatewayState;
@@ -43,12 +49,167 @@ pub type EventLog = Mutex<Vec<Value>>;
 /// Append-only audit log shared with the admin UI.
 pub type AuditLog = Mutex<Vec<AdminAuditRecord>>;
 
+#[derive(Debug, Clone)]
+pub struct DurableAuditStore {
+    dir: Arc<PathBuf>,
+    max_rows: usize,
+    lock: Arc<Mutex<()>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistedAuditRecord {
+    timestamp_ms: u64,
+    request_id: String,
+    method: Option<String>,
+    instance_id: Option<String>,
+    session_id: Option<String>,
+    action: String,
+    dcc_type: Option<String>,
+    success: bool,
+    error: Option<String>,
+    duration_ms: Option<u64>,
+}
+
+impl DurableAuditStore {
+    pub const AUDIT_FILE: &'static str = "audit.jsonl";
+    pub const TRACE_FILE: &'static str = "traces.jsonl";
+    pub const DEFAULT_MAX_ROWS: usize = 5_000;
+
+    pub fn new(dir: impl Into<PathBuf>, max_rows: usize) -> std::io::Result<Self> {
+        let dir = dir.into();
+        fs::create_dir_all(&dir)?;
+        Ok(Self {
+            dir: Arc::new(dir),
+            max_rows: max_rows.max(1),
+            lock: Arc::new(Mutex::new(())),
+        })
+    }
+
+    pub fn from_env() -> Option<Self> {
+        let dir = std::env::var_os("DCC_MCP_GATEWAY_AUDIT_DIR")?;
+        let max_rows = std::env::var("DCC_MCP_GATEWAY_AUDIT_MAX_ROWS")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(Self::DEFAULT_MAX_ROWS);
+        Self::new(dir, max_rows).ok()
+    }
+
+    pub fn load_audit(&self) -> Vec<AdminAuditRecord> {
+        read_jsonl(&self.path(Self::AUDIT_FILE))
+            .into_iter()
+            .filter_map(|value| serde_json::from_value::<PersistedAuditRecord>(value).ok())
+            .map(AdminAuditRecord::from)
+            .collect()
+    }
+
+    pub fn load_traces(&self) -> Vec<DispatchTrace> {
+        read_jsonl(&self.path(Self::TRACE_FILE))
+            .into_iter()
+            .filter_map(|value| serde_json::from_value::<DispatchTrace>(value).ok())
+            .collect()
+    }
+
+    fn append_audit(&self, record: &AdminAuditRecord) {
+        let value = json!(PersistedAuditRecord::from(record));
+        self.append_value(Self::AUDIT_FILE, &value);
+    }
+
+    fn append_trace(&self, trace: &DispatchTrace) {
+        if let Ok(value) = serde_json::to_value(trace) {
+            self.append_value(Self::TRACE_FILE, &value);
+        }
+    }
+
+    fn append_value(&self, filename: &str, value: &Value) {
+        let _guard = self.lock.lock();
+        let path = self.path(filename);
+        let Ok(mut file) = OpenOptions::new().create(true).append(true).open(&path) else {
+            return;
+        };
+        if serde_json::to_writer(&mut file, value).is_ok() {
+            let _ = file.write_all(b"\n");
+        }
+        self.trim_file(&path);
+    }
+
+    fn trim_file(&self, path: &Path) {
+        let Ok(file) = fs::File::open(path) else {
+            return;
+        };
+        let mut lines: Vec<String> = std::io::BufReader::new(file)
+            .lines()
+            .map_while(Result::ok)
+            .filter(|line| !line.trim().is_empty())
+            .collect();
+        if lines.len() <= self.max_rows {
+            return;
+        }
+        let keep_from = lines.len() - self.max_rows;
+        lines.drain(0..keep_from);
+        let _ = fs::write(path, lines.join("\n") + "\n");
+    }
+
+    fn path(&self, filename: &str) -> PathBuf {
+        self.dir.join(filename)
+    }
+}
+
+fn read_jsonl(path: &Path) -> Vec<Value> {
+    let Ok(file) = fs::File::open(path) else {
+        return Vec::new();
+    };
+    std::io::BufReader::new(file)
+        .lines()
+        .map_while(Result::ok)
+        .filter_map(|line| serde_json::from_str::<Value>(&line).ok())
+        .collect()
+}
+
+impl From<&AdminAuditRecord> for PersistedAuditRecord {
+    fn from(record: &AdminAuditRecord) -> Self {
+        Self {
+            timestamp_ms: record
+                .timestamp
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or(Duration::ZERO)
+                .as_millis() as u64,
+            request_id: record.request_id.clone(),
+            method: record.method.clone(),
+            instance_id: record.instance_id.clone(),
+            session_id: record.session_id.clone(),
+            action: record.action.clone(),
+            dcc_type: record.dcc_type.clone(),
+            success: record.success,
+            error: record.error.clone(),
+            duration_ms: record.duration_ms,
+        }
+    }
+}
+
+impl From<PersistedAuditRecord> for AdminAuditRecord {
+    fn from(record: PersistedAuditRecord) -> Self {
+        Self {
+            timestamp: UNIX_EPOCH + Duration::from_millis(record.timestamp_ms),
+            request_id: record.request_id,
+            method: record.method,
+            instance_id: record.instance_id,
+            session_id: record.session_id,
+            action: record.action,
+            dcc_type: record.dcc_type,
+            success: record.success,
+            error: record.error,
+            duration_ms: record.duration_ms,
+        }
+    }
+}
+
 /// [`AuditSink`] that pushes completed entries into the admin UI ring buffer
 /// and optionally a [`TraceLog`] for Phase 2 dispatch traces.
 pub struct AdminAuditSink {
     log: Arc<AuditLog>,
     capacity: usize,
     trace_log: Option<Arc<TraceLog>>,
+    durable_store: Option<DurableAuditStore>,
 }
 
 impl AdminAuditSink {
@@ -59,7 +220,14 @@ impl AdminAuditSink {
             log,
             capacity,
             trace_log: None,
+            durable_store: None,
         }
+    }
+
+    /// Attach a durable JSONL store so audit and trace rows survive restarts.
+    pub fn with_durable_store(mut self, store: DurableAuditStore) -> Self {
+        self.durable_store = Some(store);
+        self
     }
 
     /// Attach a trace log so `record()` also appends a [`DispatchTrace`].
@@ -90,6 +258,9 @@ impl AuditSink for AdminAuditSink {
             },
             duration_ms: entry.duration_ms,
         };
+        if let Some(store) = &self.durable_store {
+            store.append_audit(&record);
+        }
         let mut buf = self.log.lock();
         buf.push(record);
         if self.capacity > 0 {
@@ -114,8 +285,78 @@ impl AuditSink for AdminAuditSink {
                 input: entry.input_payload,
                 output: entry.output_payload,
             };
+            if let Some(store) = &self.durable_store {
+                store.append_trace(&trace);
+            }
             tl.push(trace);
         }
+    }
+}
+
+#[cfg(test)]
+mod durable_tests {
+    use super::*;
+
+    fn audit_record(id: &str) -> AdminAuditRecord {
+        AdminAuditRecord {
+            timestamp: UNIX_EPOCH + Duration::from_millis(1),
+            request_id: id.to_string(),
+            method: Some("tools/call".to_string()),
+            instance_id: Some("instance".to_string()),
+            session_id: Some("session".to_string()),
+            action: "maya.abcdef01.create_sphere".to_string(),
+            dcc_type: Some("maya".to_string()),
+            success: true,
+            error: None,
+            duration_ms: Some(7),
+        }
+    }
+
+    #[test]
+    fn durable_store_roundtrips_audit_and_traces() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = DurableAuditStore::new(dir.path(), 10).unwrap();
+        let audit = audit_record("req-1");
+        store.append_audit(&audit);
+        let trace = DispatchTrace {
+            request_id: "req-1".to_string(),
+            method: "tools/call".to_string(),
+            tool_slug: Some("maya.abcdef01.create_sphere".to_string()),
+            instance_id: Some("instance".to_string()),
+            session_id: Some("session".to_string()),
+            dcc_type: Some("maya".to_string()),
+            started_at: UNIX_EPOCH + Duration::from_millis(1),
+            total_ms: 7,
+            ok: true,
+            spans: Vec::new(),
+            input: None,
+            output: None,
+        };
+        store.append_trace(&trace);
+
+        let audits = store.load_audit();
+        assert_eq!(audits.len(), 1);
+        assert_eq!(audits[0].request_id, "req-1");
+        assert_eq!(audits[0].dcc_type.as_deref(), Some("maya"));
+        let traces = store.load_traces();
+        assert_eq!(traces.len(), 1);
+        assert_eq!(traces[0].request_id, "req-1");
+    }
+
+    #[test]
+    fn durable_store_trims_old_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = DurableAuditStore::new(dir.path(), 2).unwrap();
+        for id in ["req-1", "req-2", "req-3"] {
+            store.append_audit(&audit_record(id));
+        }
+
+        let ids: Vec<String> = store
+            .load_audit()
+            .into_iter()
+            .map(|record| record.request_id)
+            .collect();
+        assert_eq!(ids, vec!["req-2", "req-3"]);
     }
 }
 

--- a/crates/dcc-mcp-gateway/src/gateway/admin/trace.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/trace.rs
@@ -204,6 +204,13 @@ impl TraceLog {
         }
     }
 
+    /// Seed the in-memory ring from durable storage.
+    pub fn extend(&self, traces: impl IntoIterator<Item = DispatchTrace>) {
+        for trace in traces {
+            self.push(trace);
+        }
+    }
+
     /// Append a completed trace, evicting the oldest entry if at capacity.
     pub fn push(&self, trace: DispatchTrace) {
         let mut buf = self.buf.lock();

--- a/crates/dcc-mcp-gateway/src/gateway/tasks.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tasks.rs
@@ -541,25 +541,37 @@ pub(crate) async fn start_gateway_tasks(
     #[cfg(feature = "admin")]
     let gw_router = {
         let admin_state_opt = if admin_enabled {
+            let durable_store = crate::gateway::admin::state::DurableAuditStore::from_env();
+
             // 1. Shared ring buffer — the middleware writes here; the handler reads it.
             let audit_log: std::sync::Arc<crate::gateway::admin::state::AuditLog> =
                 std::sync::Arc::new(parking_lot::Mutex::new(Vec::with_capacity(512)));
+            if let Some(store) = &durable_store {
+                audit_log
+                    .lock()
+                    .extend(store.load_audit().into_iter().rev().take(512).rev());
+            }
 
             // 2. Phase 2 trace log — ring buffer for per-call dispatch traces.
             let trace_log: std::sync::Arc<crate::gateway::admin::trace::TraceLog> =
                 std::sync::Arc::new(crate::gateway::admin::trace::TraceLog::new(
                     crate::gateway::admin::trace::TraceLog::DEFAULT_CAPACITY,
                 ));
+            if let Some(store) = &durable_store {
+                trace_log.extend(store.load_traces());
+            }
 
             // 3. Build the sink that feeds the audit ring buffer and the trace log.
+            let mut admin_sink = crate::gateway::admin::state::AdminAuditSink::new(
+                audit_log.clone(),
+                /* capacity = */ 512,
+            )
+            .with_trace_log(trace_log.clone());
+            if let Some(store) = durable_store.clone() {
+                admin_sink = admin_sink.with_durable_store(store);
+            }
             let admin_sink: std::sync::Arc<dyn crate::gateway::middleware::AuditSink> =
-                std::sync::Arc::new(
-                    crate::gateway::admin::state::AdminAuditSink::new(
-                        audit_log.clone(),
-                        /* capacity = */ 512,
-                    )
-                    .with_trace_log(trace_log.clone()),
-                );
+                std::sync::Arc::new(admin_sink);
 
             // 4. Prepend AuditMiddleware to the chain so every tools/call
             //    passes through it.

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -29,6 +29,8 @@ Equivalent env vars:
 | `DCC_MCP_GATEWAY_PORT` | `9765` | Gateway election port. `0` disables gateway/admin. |
 | `DCC_MCP_NO_ADMIN` | `false` | Disable the read-only Admin UI on the elected gateway. |
 | `DCC_MCP_ADMIN_PATH` | `/admin` | Admin URL prefix. |
+| `DCC_MCP_GATEWAY_AUDIT_DIR` | unset | Optional JSONL directory for durable `audit.jsonl` and `traces.jsonl`; unset keeps zero-disk in-memory behavior. |
+| `DCC_MCP_GATEWAY_AUDIT_MAX_ROWS` | `5000` | Max JSONL rows retained per durable file when persistence is enabled. |
 
 ### Python API
 
@@ -166,6 +168,8 @@ GatewayConfig {
 ```
 
 The `/admin/api/logs` feed is populated automatically from the `EventLog` ring buffer (gateway election/eviction/probe events from issue #766). The `/admin/api/traces`, `/admin/api/stats`, and `/admin/api/workers` endpoints are populated from the dispatch `TraceLog`, `StatsAggregator`, and live gateway registry respectively.
+
+Set `DCC_MCP_GATEWAY_AUDIT_DIR` to enable durable JSONL persistence. The gateway appends bounded admin call rows to `audit.jsonl` and dispatch traces to `traces.jsonl`, trims each file to `DCC_MCP_GATEWAY_AUDIT_MAX_ROWS` rows, and seeds the in-memory admin buffers from those files on restart. Payloads remain the same bounded/redacted `TracePayload` values used by the in-memory trace capture; persistence does not store unbounded raw request bodies.
 
 ## Dashboard Features
 

--- a/docs/zh/guide/admin-ui.md
+++ b/docs/zh/guide/admin-ui.md
@@ -29,6 +29,8 @@ dcc-mcp-server --admin-path /dcc-admin
 | `DCC_MCP_GATEWAY_PORT` | `9765` | 网关选举端口；`0` 表示禁用 gateway/admin。 |
 | `DCC_MCP_NO_ADMIN` | `false` | 禁用赢得选举的网关上的只读 Admin UI。 |
 | `DCC_MCP_ADMIN_PATH` | `/admin` | Admin URL 前缀。 |
+| `DCC_MCP_GATEWAY_AUDIT_DIR` | 未设置 | 可选 JSONL 持久化目录，写入 `audit.jsonl` 与 `traces.jsonl`；未设置时保持零落盘的内存行为。 |
+| `DCC_MCP_GATEWAY_AUDIT_MAX_ROWS` | `5000` | 启用持久化时，每个 JSONL 文件保留的最大行数。 |
 
 ### Python API
 
@@ -166,6 +168,8 @@ GatewayConfig {
 ```
 
 `/admin/api/logs` 数据源由 `EventLog` 环形缓冲区自动填充（网关选举/驱逐/探针事件，来自 issue #766）。`/admin/api/traces`、`/admin/api/stats` 和 `/admin/api/workers` 分别来自 dispatch `TraceLog`、`StatsAggregator` 与 live gateway registry。
+
+设置 `DCC_MCP_GATEWAY_AUDIT_DIR` 后会启用 JSONL 持久化。网关会将有界的 admin 调用行追加到 `audit.jsonl`，将 dispatch traces 追加到 `traces.jsonl`，按 `DCC_MCP_GATEWAY_AUDIT_MAX_ROWS` 裁剪每个文件，并在重启时用这些文件回填内存中的 admin 缓冲区。持久化内容仍使用内存 trace 捕获同一套有界/已脱敏 `TracePayload`，不会写入无界原始请求体。
 
 ## 仪表盘功能
 


### PR DESCRIPTION
## Summary
- add optional durable JSONL store for admin audit rows and dispatch traces
- enable via DCC_MCP_GATEWAY_AUDIT_DIR with DCC_MCP_GATEWAY_AUDIT_MAX_ROWS retention
- seed in-memory admin calls/traces buffers from persisted JSONL on gateway startup
- document EN/ZH persistence knobs and privacy boundary

## Tests
- vx cargo test -p dcc-mcp-gateway --features admin durable_store
- vx just docs-check
- vx cargo fmt --check

Closes #950