### PR TITLE
fix: add canonical MCP wire crate

### DIFF
--- a/.github/workflows/dcc-integration.yml
+++ b/.github/workflows/dcc-integration.yml
@@ -141,7 +141,7 @@ jobs:
   blender:
     name: Blender ${{ matrix.blender-version }}
     needs: [wheel-ready]
-    if: github.event_name != 'workflow_dispatch' || github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'blender'
+    if: always() && needs.wheel-ready.result == 'success' && (github.event_name != 'workflow_dispatch' || inputs.dcc == '' || inputs.dcc == 'all' || inputs.dcc == 'blender')
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -199,7 +199,7 @@ jobs:
   openscad:
     name: OpenSCAD
     needs: [wheel-ready]
-    if: github.event_name != 'workflow_dispatch' || github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'openscad'
+    if: always() && needs.wheel-ready.result == 'success' && (github.event_name != 'workflow_dispatch' || inputs.dcc == '' || inputs.dcc == 'all' || inputs.dcc == 'openscad')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -229,7 +229,7 @@ jobs:
   godot:
     name: Godot
     needs: [wheel-ready]
-    if: github.event_name != 'workflow_dispatch' || github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'godot'
+    if: always() && needs.wheel-ready.result == 'success' && (github.event_name != 'workflow_dispatch' || inputs.dcc == '' || inputs.dcc == 'all' || inputs.dcc == 'godot')
     runs-on: ubuntu-latest
     env:
       GODOT_VERSION: "4.4.1"
@@ -265,7 +265,7 @@ jobs:
   cross-dcc:
     name: Cross-DCC Pipeline
     needs: [wheel-ready]
-    if: github.event_name != 'workflow_dispatch' || github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'cross'
+    if: always() && needs.wheel-ready.result == 'success' && (github.event_name != 'workflow_dispatch' || inputs.dcc == '' || inputs.dcc == 'all' || inputs.dcc == 'cross')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/dcc-integration.yml
+++ b/.github/workflows/dcc-integration.yml
@@ -141,7 +141,7 @@ jobs:
   blender:
     name: Blender ${{ matrix.blender-version }}
     needs: [wheel-ready]
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_run' || github.event_name == 'workflow_call' || github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'blender'
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'blender'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -199,7 +199,7 @@ jobs:
   openscad:
     name: OpenSCAD
     needs: [wheel-ready]
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_run' || github.event_name == 'workflow_call' || github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'openscad'
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'openscad'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -229,7 +229,7 @@ jobs:
   godot:
     name: Godot
     needs: [wheel-ready]
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_run' || github.event_name == 'workflow_call' || github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'godot'
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'godot'
     runs-on: ubuntu-latest
     env:
       GODOT_VERSION: "4.4.1"
@@ -265,7 +265,7 @@ jobs:
   cross-dcc:
     name: Cross-DCC Pipeline
     needs: [wheel-ready]
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_run' || github.event_name == 'workflow_call' || github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'cross'
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'cross'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/dcc-integration.yml
+++ b/.github/workflows/dcc-integration.yml
@@ -5,6 +5,8 @@ name: DCC Integration
 # relevant test file (split from the original test_integration_dcc.py).
 #
 # Triggered by:
+#   - pull_request: runs directly on PRs and builds its own wheel so the
+#     DCC jobs are visible as PR checks.
 #   - workflow_run after CI completes: reuses the Ubuntu wheel artifact
 #     from ci.yml's `build-wheel (ubuntu-latest)` job — no rebuild.
 #     Saves ~2-3 min of duplicate maturin work per PR.
@@ -13,6 +15,24 @@ name: DCC Integration
 #   - workflow_call: invoked by release.yml; builds its own wheel.
 
 on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "crates/**"
+      - "python/**"
+      - "scripts/**"
+      - "src/**"
+      - "tests/**"
+      - "examples/**"
+      - "skills/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "justfile"
+      - "pyproject.toml"
+      - "rust-toolchain.toml"
+      - ".github/workflows/ci.yml"
+      - ".github/workflows/dcc-integration.yml"
+      - ".github/actions/build-wheel/**"
   workflow_run:
     workflows: ["CI"]
     types: [completed]
@@ -121,7 +141,7 @@ jobs:
   blender:
     name: Blender ${{ matrix.blender-version }}
     needs: [wheel-ready]
-    if: github.event_name == 'workflow_run' || github.event_name == 'workflow_call' || github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'blender'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_run' || github.event_name == 'workflow_call' || github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'blender'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -179,7 +199,7 @@ jobs:
   openscad:
     name: OpenSCAD
     needs: [wheel-ready]
-    if: github.event_name == 'workflow_run' || github.event_name == 'workflow_call' || github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'openscad'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_run' || github.event_name == 'workflow_call' || github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'openscad'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -209,7 +229,7 @@ jobs:
   godot:
     name: Godot
     needs: [wheel-ready]
-    if: github.event_name == 'workflow_run' || github.event_name == 'workflow_call' || github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'godot'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_run' || github.event_name == 'workflow_call' || github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'godot'
     runs-on: ubuntu-latest
     env:
       GODOT_VERSION: "4.4.1"
@@ -245,7 +265,7 @@ jobs:
   cross-dcc:
     name: Cross-DCC Pipeline
     needs: [wheel-ready]
-    if: github.event_name == 'workflow_run' || github.event_name == 'workflow_call' || github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'cross'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_run' || github.event_name == 'workflow_call' || github.event.inputs.dcc == '' || github.event.inputs.dcc == 'all' || github.event.inputs.dcc == 'cross'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,6 +1035,7 @@ name = "dcc-mcp-jsonrpc"
 version = "0.15.9"
 dependencies = [
  "dcc-mcp-protocols",
+ "dcc-mcp-wire",
  "serde",
  "serde_json",
  "workspace-hack",
@@ -1416,6 +1417,20 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "uuid",
+ "workspace-hack",
+]
+
+[[package]]
+name = "dcc-mcp-wire"
+version = "0.15.9"
+dependencies = [
+ "dcc-mcp-protocols",
+ "pyo3",
+ "pyo3-stub-gen",
+ "pyo3-stub-gen-derive",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
  "workspace-hack",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,10 +887,13 @@ dependencies = [
 name = "dcc-mcp-host"
 version = "0.15.9"
 dependencies = [
+ "dcc-mcp-pybridge",
+ "dcc-mcp-wire",
  "parking_lot",
  "pyo3",
  "pyo3-stub-gen",
  "pyo3-stub-gen-derive",
+ "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/dcc-mcp-skills",
     "crates/dcc-mcp-protocols",
     "crates/dcc-mcp-jsonrpc",
+    "crates/dcc-mcp-wire",
     "crates/dcc-mcp-job",
     "crates/dcc-mcp-skill-rest",
     "crates/dcc-mcp-gateway",

--- a/crates/dcc-mcp-host/Cargo.toml
+++ b/crates/dcc-mcp-host/Cargo.toml
@@ -13,6 +13,9 @@ tokio = { workspace = true }
 parking_lot = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+serde_json = { workspace = true }
+dcc-mcp-wire = { path = "../dcc-mcp-wire" }
+dcc-mcp-pybridge = { path = "../dcc-mcp-pybridge", optional = true }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 pyo3 = { workspace = true, optional = true }
@@ -28,5 +31,5 @@ pyo3 = { workspace = true, features = ["auto-initialize"] }
 
 [features]
 default = []
-python-bindings = ["pyo3"]
+python-bindings = ["pyo3", "dep:dcc-mcp-pybridge", "dcc-mcp-pybridge/python-bindings"]
 stub-gen = ["python-bindings", "dep:pyo3-stub-gen", "dep:pyo3-stub-gen-derive"]

--- a/crates/dcc-mcp-host/src/python.rs
+++ b/crates/dcc-mcp-host/src/python.rs
@@ -33,9 +33,11 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use pyo3::exceptions::PyRuntimeError;
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyTuple};
+
+use dcc_mcp_pybridge::py_json::{json_value_to_pyobject, py_any_to_json_value};
 use tokio::runtime::Runtime;
 
 use crate::{
@@ -223,6 +225,42 @@ fn make_py_job(callable: PyObj) -> impl FnOnce() -> PyResult<PyObj> + Send + 'st
     }
 }
 
+fn wire_error_to_py(err: dcc_mcp_wire::WireError) -> PyErr {
+    PyValueError::new_err(format!("{}: {}", err.kind(), err))
+}
+
+/// Normalise Python `arguments` for MCP `tools/call` / REST `/v1/call`.
+///
+/// This is the Python-facing host adapter seam for real DCC requests: adapters
+/// pass the raw Python object they received, and the same canonical wire logic
+/// used by Rust transports converts `None`, JSON object strings, and dicts into
+/// a plain Python `dict`.
+#[pyfunction]
+#[pyo3(name = "normalize_tool_arguments", signature = (arguments=None))]
+pub fn py_normalize_tool_arguments(
+    py: Python<'_>,
+    arguments: Option<&Bound<'_, PyAny>>,
+) -> PyResult<PyObj> {
+    let value = arguments.map(py_any_to_json_value).transpose()?;
+    let normalized = dcc_mcp_wire::normalize_arguments(value).map_err(wire_error_to_py)?;
+    json_value_to_pyobject(py, &normalized)
+}
+
+/// Normalise Python `_meta` for MCP `tools/call` / REST `/v1/call`.
+///
+/// Returns `None` for omitted/null/empty metadata, or a plain Python `dict` for
+/// object metadata. JSON object strings are accepted for parity with
+/// `normalize_tool_arguments`.
+#[pyfunction]
+#[pyo3(name = "normalize_tool_meta", signature = (meta=None))]
+pub fn py_normalize_tool_meta(py: Python<'_>, meta: Option<&Bound<'_, PyAny>>) -> PyResult<PyObj> {
+    let value = meta.map(py_any_to_json_value).transpose()?;
+    match dcc_mcp_wire::normalize_meta(value).map_err(wire_error_to_py)? {
+        Some(map) => json_value_to_pyobject(py, &serde_json::Value::Object(map)),
+        None => Ok(py.None()),
+    }
+}
+
 // ── PyQueueDispatcher ───────────────────────────────────────────────
 
 /// Python wrapper over [`crate::QueueDispatcher`].
@@ -407,6 +445,8 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyPostHandle>()?;
     m.add_class::<PyQueueDispatcher>()?;
     m.add_class::<PyBlockingDispatcher>()?;
+    m.add_function(wrap_pyfunction!(py_normalize_tool_arguments, m)?)?;
+    m.add_function(wrap_pyfunction!(py_normalize_tool_meta, m)?)?;
     Ok(())
 }
 

--- a/crates/dcc-mcp-jsonrpc/Cargo.toml
+++ b/crates/dcc-mcp-jsonrpc/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 description = "JSON-RPC 2.0 + MCP 2025-03-26 Streamable HTTP wire types (no transport, no axum)"
 
 [dependencies]
+dcc-mcp-wire = { path = "../dcc-mcp-wire" }
 dcc-mcp-protocols = { path = "../dcc-mcp-protocols" }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/dcc-mcp-jsonrpc/src/tools.rs
+++ b/crates/dcc-mcp-jsonrpc/src/tools.rs
@@ -1,7 +1,7 @@
 //! `tools/list` + `tools/call` message types.
 
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::Value;
 
 /// Re-export of [`dcc_mcp_protocols::ToolAnnotations`] under the historical
 /// `McpToolAnnotations` name used throughout the wire layer.
@@ -159,17 +159,6 @@ impl CallToolResult {
     }
 }
 
-fn json_value_kind(value: &Value) -> &'static str {
-    match value {
-        Value::Null => "null",
-        Value::Bool(_) => "boolean",
-        Value::Number(_) => "number",
-        Value::String(_) => "string",
-        Value::Array(_) => "array",
-        Value::Object(_) => "object",
-    }
-}
-
 /// Normalise MCP `tools/call` / gateway `call_tool` `arguments` payloads to a JSON **object**.
 ///
 /// Some clients double-serialise `arguments` as a JSON string. Serde accepts
@@ -181,36 +170,16 @@ fn json_value_kind(value: &Value) -> &'static str {
 /// - [`Value::String`] → parsed as JSON; decoded value must be an object
 /// - any other top-level kind → [`Err`]
 pub fn coerce_tool_arguments_object(arguments: Option<Value>) -> Result<Value, String> {
-    match arguments {
-        None | Some(Value::Null) => Ok(json!({})),
-        Some(Value::Object(map)) => Ok(Value::Object(map)),
-        Some(Value::String(s)) => {
-            let trimmed = s.trim();
-            if trimmed.is_empty() {
-                return Ok(json!({}));
-            }
-            let parsed: Value = serde_json::from_str(trimmed).map_err(|e| {
-                format!("arguments must be a JSON object; string value is not valid JSON ({e})")
-            })?;
-            if let Value::Object(_) = parsed {
-                Ok(parsed)
-            } else {
-                Err(format!(
-                    "arguments must be a JSON object; decoded string is {} (expected object)",
-                    json_value_kind(&parsed)
-                ))
-            }
-        }
-        Some(other) => Err(format!(
-            "arguments must be a JSON object (got {})",
-            json_value_kind(&other)
-        )),
+    match dcc_mcp_wire::normalize_arguments(arguments) {
+        Ok(v) => Ok(v),
+        Err(e) => Err(e.to_string()),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn coerce_tool_arguments_object_accepts_object_and_empty() {

--- a/crates/dcc-mcp-wire/Cargo.toml
+++ b/crates/dcc-mcp-wire/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "dcc-mcp-wire"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Canonical MCP/gateway wire serialization and argument validation for DCC-MCP."
+keywords = ["mcp", "wire", "serialization", "validation", "clean-architecture"]
+categories = ["api-bindings", "parsing"]
+
+[package.metadata.release]
+release = true
+
+[features]
+default = []
+python-bindings = ["pyo3"]
+stub-gen = ["python-bindings", "dep:pyo3-stub-gen", "dep:pyo3-stub-gen-derive"]
+
+[dependencies]
+# Internal — pure protocol types only; avoids circular imports.
+dcc-mcp-protocols = { path = "../dcc-mcp-protocols" }
+
+# Workspace shared
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+workspace-hack = { version = "0.1", path = "../workspace-hack" }
+
+# Type-stub generation (opt-in via `stub-gen` feature).
+pyo3 = { workspace = true, optional = true }
+pyo3-stub-gen = { workspace = true, optional = true }
+pyo3-stub-gen-derive = { workspace = true, optional = true }

--- a/crates/dcc-mcp-wire/src/error.rs
+++ b/crates/dcc-mcp-wire/src/error.rs
@@ -1,0 +1,127 @@
+//! Structured validation errors for wire-level checks.
+//!
+//! Consumers (clients, middleware, server handlers) get a stable
+//! [`WireError`] variant instead of a free-form string, so they can
+//! programmatically decide how to respond.
+
+use thiserror::Error;
+
+/// Structured error produced by wire-level validation.
+///
+/// Variants are intentionally fine-grained so callers can map them
+/// to HTTP status codes or MCP error codes without string matching.
+#[derive(Debug, Clone, Error)]
+pub enum WireError {
+    /// The `arguments` value was present but was not a JSON object.
+    #[error("arguments must be a JSON object, got {kind}")]
+    ArgumentsNotObject {
+        /// JSON value kind that was received.
+        kind: &'static str,
+    },
+
+    /// The `arguments` string could not be parsed as JSON.
+    #[error("arguments string is not valid JSON: {reason}")]
+    ArgumentsStringNotJson {
+        /// Parser error or other diagnostic reason.
+        reason: String,
+    },
+
+    /// The `arguments` string parsed successfully but decoded to a non-object.
+    #[error("arguments decoded string is {kind}, expected object")]
+    ArgumentsDecodedNotObject {
+        /// JSON value kind produced by decoding the string.
+        kind: &'static str,
+    },
+
+    /// A required field was missing from the request envelope.
+    #[error("missing field `{field}` in request envelope")]
+    MissingField {
+        /// Missing field name or path.
+        field: String,
+    },
+
+    /// The requested tool slug or name is invalid.
+    #[error("tool_slug is invalid: {reason}")]
+    InvalidToolSlug {
+        /// Validation failure reason.
+        reason: String,
+    },
+
+    /// Arguments failed validation against the tool input schema.
+    #[error("input schema validation failed: {reason}")]
+    SchemaValidationFailed {
+        /// Schema validation failure reason.
+        reason: String,
+    },
+
+    /// A payload was detected as double-stringified.
+    #[error("double-stringified payload detected at `{path}`")]
+    DoubleStringified {
+        /// Field path where double-stringification was detected.
+        path: String,
+    },
+
+    /// The request envelope itself was not a JSON object.
+    #[error("request envelope is not a JSON object")]
+    EnvelopeNotObject,
+
+    /// A batch item failed wire-level validation.
+    #[error("batch item {index}: {reason}")]
+    BatchItemInvalid {
+        /// Zero-based batch item index.
+        index: usize,
+        /// Item validation failure reason.
+        reason: String,
+    },
+}
+
+impl WireError {
+    /// Stable machine-readable key for this error (snake_case).
+    pub fn kind(&self) -> &'static str {
+        match self {
+            WireError::ArgumentsNotObject { .. } => "arguments-not-object",
+            WireError::ArgumentsStringNotJson { .. } => "arguments-string-not-json",
+            WireError::ArgumentsDecodedNotObject { .. } => "arguments-decoded-not-object",
+            WireError::MissingField { .. } => "missing-field",
+            WireError::InvalidToolSlug { .. } => "invalid-tool-slug",
+            WireError::SchemaValidationFailed { .. } => "schema-validation-failed",
+            WireError::DoubleStringified { .. } => "double-stringified",
+            WireError::EnvelopeNotObject => "envelope-not-object",
+            WireError::BatchItemInvalid { .. } => "batch-item-invalid",
+        }
+    }
+
+    /// Short human-readable hint (suitable for `hint` field in REST errors).
+    pub fn hint(&self) -> String {
+        match self {
+            WireError::ArgumentsNotObject { kind } => {
+                format!("pass arguments as a JSON object {{}}, not {kind}")
+            }
+            WireError::ArgumentsStringNotJson { reason } => {
+                format!("parse arguments string as JSON before sending: {reason}")
+            }
+            WireError::ArgumentsDecodedNotObject { kind } => {
+                format!("the string in arguments field decoded to {kind}, expected object")
+            }
+            WireError::MissingField { field } => {
+                format!("add `{field}` field to the request envelope")
+            }
+            WireError::InvalidToolSlug { reason } => {
+                format!("use a valid tool slug from /v1/search: {reason}")
+            }
+            WireError::SchemaValidationFailed { reason } => {
+                format!("check tool input schema via POST /v1/describe: {reason}")
+            }
+            WireError::DoubleStringified { path } => {
+                format!("avoid double-serializing the payload at `{path}`")
+            }
+            WireError::EnvelopeNotObject => "the request body must be a JSON object".to_string(),
+            WireError::BatchItemInvalid { index, reason } => {
+                format!("fix item[{index}]: {reason}")
+            }
+        }
+    }
+}
+
+/// Convenience alias: `Result<T, WireError>`.
+pub type WireResult<T> = Result<T, WireError>;

--- a/crates/dcc-mcp-wire/src/lib.rs
+++ b/crates/dcc-mcp-wire/src/lib.rs
@@ -1,0 +1,40 @@
+//! Canonical MCP/gateway wire serialization and argument validation.
+//!
+//! This crate owns the shared types and helpers so that HTTP servers, the
+//! multi-DCC gateway, and future transports do **not** each re-implement
+//! serde quirks, double-stringify hazards, or partial object checks.
+//!
+//! # Dependency direction (issue #969)
+//!
+//! ```text
+//! dcc-mcp-wire  →  dcc-mcp-protocols  (one edge, no circular)
+//! ```
+//!
+//! `dcc-mcp-jsonrpc` depends on this crate and re-exports `coerce_tool_arguments_object`.
+//!
+//! # Module map
+//!
+//! | Module            | Purpose                                              |
+//! |-------------------|------------------------------------------------------|
+//! | `wire`            | Canonical encode/decode for MCP JSON-RPC and REST  |
+//! | `validate`       | Argument shape validation and schema checks        |
+//! | `error`          | Structured validation errors for clients/middleware|
+//! | `normalize`      | Outer argument object normalisation              |
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+pub mod error;
+pub mod normalize;
+pub mod validate;
+pub mod wire;
+
+// Re-exports — consumers only need `use dcc_mcp_wire::*`.
+pub use error::{WireError, WireResult};
+pub use normalize::{normalize_arguments, normalize_meta};
+pub use validate::{validate_arguments, validate_call_tool_params};
+pub use wire::{decode_call_tool, encode_call_tool_result, parse_json_rpc_batch};
+
+/// Re-export of [`dcc_mcp_protocols::ToolAnnotations`] so consumers
+/// depending on this crate alone still have access to the annotation type.
+pub use dcc_mcp_protocols::ToolAnnotations;

--- a/crates/dcc-mcp-wire/src/normalize.rs
+++ b/crates/dcc-mcp-wire/src/normalize.rs
@@ -1,0 +1,151 @@
+//! Outer argument object normalisation.
+//!
+//! Provides `normalize_arguments` and `normalize_meta` so that
+//! HTTP servers, gateway, and transports never re-implement serde quirks.
+
+use crate::{WireError, WireResult};
+use serde_json::{Map, Value, json};
+
+/// Normalise `arguments` to a JSON object.
+///
+/// - `None` / `Null` / empty-trimmed-string → `{}`
+/// - `Object` → returned unchanged
+/// - `String` → parsed; must decode to `Object`
+/// - any other primitive → `ArgumentsNotObject`
+pub fn normalize_arguments(arguments: Option<Value>) -> WireResult<Value> {
+    match arguments {
+        None | Some(Value::Null) => Ok(json!({})),
+        Some(Value::Object(_)) => Ok(arguments.unwrap()),
+        Some(Value::String(s)) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                return Ok(json!({}));
+            }
+            let parsed: Value =
+                serde_json::from_str(trimmed).map_err(|e| WireError::ArgumentsStringNotJson {
+                    reason: e.to_string(),
+                })?;
+            if let Value::Object(_) = parsed {
+                Ok(parsed)
+            } else {
+                Err(WireError::ArgumentsDecodedNotObject {
+                    kind: value_kind(&parsed),
+                })
+            }
+        }
+        Some(other) => Err(WireError::ArgumentsNotObject {
+            kind: value_kind(&other),
+        }),
+    }
+}
+
+/// Normalise `_meta` field to `Option<Map<String, Value>>`.
+///
+/// - `None` / `Null` / empty-trimmed-string → `None`
+/// - `Object` → `Some(map)`
+/// - `String` → parsed; must decode to `Object`
+pub fn normalize_meta(meta: Option<Value>) -> WireResult<Option<Map<String, Value>>> {
+    match meta {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Object(map)) => Ok(Some(map)),
+        Some(Value::String(s)) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                return Ok(None);
+            }
+            let parsed: Value =
+                serde_json::from_str(trimmed).map_err(|e| WireError::ArgumentsStringNotJson {
+                    reason: format!("_meta: {}", e),
+                })?;
+            match parsed {
+                Value::Object(map) => Ok(Some(map)),
+                other => Err(WireError::ArgumentsDecodedNotObject {
+                    kind: value_kind(&other),
+                }),
+            }
+        }
+        Some(other) => Err(WireError::ArgumentsNotObject {
+            kind: value_kind(&other),
+        }),
+    }
+}
+
+fn value_kind(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{Value, json};
+
+    #[test]
+    fn accepts_none_and_null() {
+        assert_eq!(normalize_arguments(None).unwrap(), json!({}));
+        assert_eq!(normalize_arguments(Some(Value::Null)).unwrap(), json!({}));
+    }
+
+    #[test]
+    fn accepts_object() {
+        let obj = json!({"code": "print(1)"});
+        assert_eq!(normalize_arguments(Some(obj.clone())).unwrap(), obj);
+    }
+
+    #[test]
+    fn parses_json_string() {
+        let s = r#"{"code":"print(1)"}"#.to_string();
+        let out = normalize_arguments(Some(Value::String(s))).unwrap();
+        assert_eq!(out, json!({"code": "print(1)"}));
+    }
+
+    #[test]
+    fn rejects_non_json_string() {
+        let err = normalize_arguments(Some(Value::String("not json".into()))).unwrap_err();
+        assert_eq!(err.kind(), "arguments-string-not-json");
+    }
+
+    #[test]
+    fn rejects_array_string() {
+        let err = normalize_arguments(Some(Value::String("[1]".into()))).unwrap_err();
+        assert_eq!(err.kind(), "arguments-decoded-not-object");
+    }
+
+    #[test]
+    fn rejects_array_root() {
+        let err = normalize_arguments(Some(json!([1, 2]))).unwrap_err();
+        assert_eq!(err.kind(), "arguments-not-object");
+    }
+
+    #[test]
+    fn rejects_number() {
+        let err = normalize_arguments(Some(json!(42))).unwrap_err();
+        assert_eq!(err.kind(), "arguments-not-object");
+    }
+
+    #[test]
+    fn accepts_empty_string() {
+        let result = normalize_arguments(Some(Value::String("  ".into()))).unwrap();
+        assert_eq!(result, json!({}));
+    }
+
+    #[test]
+    fn normalize_meta_accepts_object() {
+        let mut map = Map::new();
+        map.insert("key".to_string(), json!(1));
+        let result = normalize_meta(Some(Value::Object(map))).unwrap();
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn normalize_meta_rejects_non_object_string() {
+        let err = normalize_meta(Some(Value::String("42".into()))).unwrap_err();
+        assert_eq!(err.kind(), "arguments-decoded-not-object");
+    }
+}

--- a/crates/dcc-mcp-wire/src/validate.rs
+++ b/crates/dcc-mcp-wire/src/validate.rs
@@ -1,0 +1,127 @@
+//! Argument shape validation and schema checks.
+
+use crate::{WireError, WireResult};
+use serde_json::Value;
+
+/// Validate that `arguments` is a JSON object (after normalisation).
+pub fn validate_arguments_shape(arguments: &Value) -> WireResult<()> {
+    match arguments {
+        Value::Object(_) => Ok(()),
+        other => Err(WireError::ArgumentsNotObject {
+            kind: value_kind(other),
+        }),
+    }
+}
+
+/// Validate `arguments` against a declared JSON Schema.
+pub fn validate_arguments(arguments: &Value, input_schema: Option<&Value>) -> WireResult<()> {
+    let Some(schema) = input_schema else {
+        return Ok(());
+    };
+
+    let Value::Object(schema_map) = schema else {
+        return Ok(());
+    };
+
+    let Some(Value::String(type_)) = schema_map.get("type") else {
+        return Ok(());
+    };
+
+    if type_ != "object" {
+        return Ok(());
+    }
+
+    let Some(Value::Array(required)) = schema_map.get("required") else {
+        return Ok(());
+    };
+
+    let Value::Object(args_map) = arguments else {
+        return Ok(());
+    };
+
+    for req in required {
+        let Value::String(field) = req else { continue };
+        if !args_map.contains_key(field) {
+            return Err(WireError::SchemaValidationFailed {
+                reason: format!("missing required field: {field}"),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate a `tools/call` request envelope.
+pub fn validate_call_tool_params(
+    name: Option<&str>,
+    arguments: Option<Value>,
+    input_schema: Option<&Value>,
+) -> WireResult<Value> {
+    let Some(name) = name else {
+        return Err(WireError::MissingField {
+            field: "name".to_string(),
+        });
+    };
+    if name.is_empty() {
+        return Err(WireError::InvalidToolSlug {
+            reason: "tool name must not be empty".to_string(),
+        });
+    }
+
+    let normalised = crate::normalize::normalize_arguments(arguments)?;
+    validate_arguments_shape(&normalised)?;
+    validate_arguments(&normalised, input_schema)?;
+    Ok(normalised)
+}
+
+/// Validate a `call_batch` request envelope.
+pub fn validate_call_batch_params(calls: &[Value]) -> WireResult<Vec<(String, Value)>> {
+    let mut results = Vec::new();
+    for (index, call) in calls.iter().enumerate() {
+        let obj = match call {
+            Value::Object(map) => map,
+            _ => {
+                return Err(WireError::BatchItemInvalid {
+                    index,
+                    reason: "each batch item must be a JSON object".to_string(),
+                });
+            }
+        };
+
+        let name = obj
+            .get("name")
+            .or_else(|| obj.get("tool_slug"))
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| WireError::BatchItemInvalid {
+                index,
+                reason: "missing `name` or `tool_slug` field".to_string(),
+            })?;
+
+        let arguments = obj.get("arguments").or_else(|| obj.get("params")).cloned();
+
+        let normalised = crate::normalize::normalize_arguments(arguments).map_err(|e| {
+            WireError::BatchItemInvalid {
+                index,
+                reason: e.to_string(),
+            }
+        })?;
+        validate_arguments_shape(&normalised).map_err(|e| WireError::BatchItemInvalid {
+            index,
+            reason: e.to_string(),
+        })?;
+
+        results.push((name.to_string(), normalised));
+    }
+    Ok(results)
+}
+
+fn value_kind(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}

--- a/crates/dcc-mcp-wire/src/wire.rs
+++ b/crates/dcc-mcp-wire/src/wire.rs
@@ -1,0 +1,171 @@
+//! Canonical encode/decode for MCP JSON-RPC and gateway REST surfaces.
+//!
+//! - Works with [`serde_json::Value`] — no dependency on full server frameworks.
+//! - Produces [`WireError`] variants — stable keys, no string matching.
+//! - Normalises `arguments` and `meta` via [`crate::normalize`].
+//! - Validates shapes via [`crate::validate`].
+
+use crate::{WireError, WireResult};
+use serde_json::{Map, Value, json};
+
+/// Decoded tool call tuple: `(name_or_slug, normalized_arguments, normalized_meta)`.
+pub type DecodedCall = (String, Value, Option<Map<String, Value>>);
+
+/// Decoded batch call list.
+pub type DecodedBatch = Vec<DecodedCall>;
+
+/// Parse a raw JSON-RPC `tools/call` request into (name, arguments, meta).
+pub fn decode_call_tool(request: &Value) -> WireResult<DecodedCall> {
+    let obj = request.as_object().ok_or(WireError::EnvelopeNotObject)?;
+    let params = obj.get("params").ok_or_else(|| WireError::MissingField {
+        field: "params".to_string(),
+    })?;
+    let params_obj = params.as_object().ok_or_else(|| WireError::MissingField {
+        field: "params (must be object)".to_string(),
+    })?;
+    let name = params_obj
+        .get("name")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| WireError::MissingField {
+            field: "name".to_string(),
+        })?
+        .to_string();
+    let arguments = params_obj.get("arguments").cloned();
+    let normalised = crate::normalize::normalize_arguments(arguments)?;
+    let meta = crate::normalize::normalize_meta(params_obj.get("_meta").cloned())?;
+    Ok((name, normalised, meta))
+}
+
+/// Parse a gateway REST `POST /v1/call` request into (tool_slug, arguments, meta).
+pub fn decode_rest_call(request: &Value) -> WireResult<DecodedCall> {
+    let obj = request.as_object().ok_or(WireError::EnvelopeNotObject)?;
+    let name = obj
+        .get("tool_slug")
+        .or_else(|| obj.get("name"))
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| WireError::MissingField {
+            field: "tool_slug (or name)".to_string(),
+        })?
+        .to_string();
+    let arguments = obj.get("arguments").or_else(|| obj.get("params")).cloned();
+    let normalised = crate::normalize::normalize_arguments(arguments)?;
+    let meta = crate::normalize::normalize_meta(obj.get("_meta").cloned())?;
+    Ok((name, normalised, meta))
+}
+
+/// Build a canonical MCP `CallToolResult` envelope.
+pub fn encode_call_tool_result(
+    content_text: &str,
+    is_error: bool,
+    structured_content: Option<&Value>,
+    meta: Option<&Map<String, Value>>,
+) -> Value {
+    let mut content = Vec::new();
+    content.push(json!({"type": "text", "text": content_text}));
+    let mut result = Map::new();
+    result.insert("content".to_string(), Value::Array(content));
+    result.insert("isError".to_string(), Value::Bool(is_error));
+    if let Some(sc) = structured_content {
+        result.insert("structuredContent".to_string(), sc.clone());
+    }
+    if let Some(m) = meta {
+        result.insert("_meta".to_string(), Value::Object(m.clone()));
+    }
+    Value::Object(result)
+}
+
+/// Encode a gateway REST `POST /v1/call` success response.
+pub fn encode_rest_call_response(
+    slug: &str,
+    output: &Value,
+    validation_skipped: bool,
+    request_id: &str,
+) -> Value {
+    json!({
+        "slug": slug,
+        "output": output,
+        "validation_skipped": validation_skipped,
+        "request_id": request_id
+    })
+}
+
+/// Encode a structured error response.
+pub fn encode_error_response(error: &WireError, request_id: Option<&str>) -> Value {
+    let mut body = Map::new();
+    body.insert("kind".to_string(), Value::String(error.kind().to_string()));
+    body.insert("message".to_string(), Value::String(error.to_string()));
+    body.insert("hint".to_string(), Value::String(error.hint()));
+    if let Some(rid) = request_id {
+        body.insert("request_id".to_string(), Value::String(rid.to_string()));
+    }
+    Value::Object(body)
+}
+
+/// Parse a JSON-RPC batch request into individual message values.
+pub fn parse_json_rpc_batch(payload: &Value) -> WireResult<Vec<Value>> {
+    match payload {
+        Value::Array(items) => Ok(items.clone()),
+        Value::Object(_) => Ok(vec![payload.clone()]),
+        _ => Err(WireError::EnvelopeNotObject),
+    }
+}
+
+/// Normalise a `call_batch` REST payload into (tool_slug, arguments, meta) triples.
+pub fn normalize_call_batch(payload: &Value) -> WireResult<DecodedBatch> {
+    let calls = match payload {
+        Value::Array(arr) => arr.as_slice(),
+        Value::Object(obj) => {
+            if let Some(Value::Array(calls)) = obj.get("calls") {
+                calls.as_slice()
+            } else {
+                return Err(WireError::MissingField {
+                    field: "calls (array)".to_string(),
+                });
+            }
+        }
+        _ => return Err(WireError::EnvelopeNotObject),
+    };
+
+    let mut results = Vec::new();
+    for (index, call) in calls.iter().enumerate() {
+        let obj = match call {
+            Value::Object(map) => map,
+            _ => {
+                return Err(WireError::BatchItemInvalid {
+                    index,
+                    reason: "each call must be a JSON object".to_string(),
+                });
+            }
+        };
+
+        let slug = obj
+            .get("tool_slug")
+            .or_else(|| obj.get("name"))
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| WireError::BatchItemInvalid {
+                index,
+                reason: "missing `tool_slug` or `name`".to_string(),
+            })?
+            .to_string();
+
+        let arguments = obj.get("arguments").or_else(|| obj.get("params")).cloned();
+
+        let normalised = crate::normalize::normalize_arguments(arguments).map_err(|e| {
+            WireError::BatchItemInvalid {
+                index,
+                reason: e.to_string(),
+            }
+        })?;
+
+        let meta = crate::normalize::normalize_meta(obj.get("_meta").cloned()).map_err(|e| {
+            WireError::BatchItemInvalid {
+                index,
+                reason: e.to_string(),
+            }
+        })?;
+
+        results.push((slug, normalised, meta));
+    }
+
+    Ok(results)
+}

--- a/crates/dcc-mcp-wire/tests/wire_e2e.rs
+++ b/crates/dcc-mcp-wire/tests/wire_e2e.rs
@@ -1,0 +1,234 @@
+//! End-to-end tests for `dcc-mcp-wire`.
+//! These tests exercise the full encode/decode + normalisation paths
+//! without hitting real servers, simulating real payloads from hosts/connectors.
+
+use dcc_mcp_wire::{
+    WireError,
+    validate::{validate_call_batch_params, validate_call_tool_params},
+    wire::{decode_call_tool, decode_rest_call, encode_error_response, encode_rest_call_response},
+};
+use serde_json::json;
+
+// ── Happy paths ────────────────────────────────────────//
+
+#[test]
+fn e2e_decode_valid_mcp_request() {
+    let req = json!({
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {
+            "name": "maya__create_sphere",
+            "arguments": {"radius": 2.0, "segments": 32}
+        }
+    });
+    let (name, args, meta) = decode_call_tool(&req).unwrap();
+    assert_eq!(name, "maya__create_sphere");
+    assert_eq!(args, json!({"radius": 2.0, "segments": 32}));
+    assert!(meta.is_none());
+}
+
+#[test]
+fn e2e_decode_string_arguments_normalised() {
+    // Host passed arguments as JSON string → normalised to object
+    let req = json!({
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {
+            "name": "maya__print",
+            "arguments": "{\"code\": \"print(1)\"}"
+        }
+    });
+    let (_name, args, _) = decode_call_tool(&req).unwrap();
+    assert_eq!(args, json!({"code": "print(1)"}));
+}
+
+#[test]
+fn e2e_decode_rest_call_valid() {
+    let req = json!({
+        "tool_slug": "maya__bake",
+        "arguments": {"frame": 1, "output": "/tmp/out.iff"}
+    });
+    let (slug, args, _) = decode_rest_call(&req).unwrap();
+    assert_eq!(slug, "maya__bake");
+    assert_eq!(args, json!({"frame": 1, "output": "/tmp/out.iff"}));
+}
+
+#[test]
+fn e2e_roundtrip_encode_decode() {
+    let req = json!({
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {
+            "name": "test",
+            "arguments": {"x": 1}
+        }
+    });
+    let (name, args, _meta) = decode_call_tool(&req).unwrap();
+    let response = encode_rest_call_response(&name, &args, false, "req-123");
+    let obj = response.as_object().unwrap();
+    assert_eq!(obj.get("slug").unwrap(), "test");
+    assert_eq!(obj.get("request_id").unwrap(), "req-123");
+}
+
+// ── Error paths (no panics) ──────────────────────────────────//
+
+#[test]
+fn e2e_reject_null_envelope() {
+    let err = decode_call_tool(&json!(null)).unwrap_err();
+    assert_eq!(err.kind(), "envelope-not-object");
+}
+
+#[test]
+fn e2e_reject_array_envelope() {
+    let err = decode_call_tool(&json!([1, 2])).unwrap_err();
+    assert_eq!(err.kind(), "envelope-not-object");
+}
+
+#[test]
+fn e2e_reject_missing_params() {
+    let req = json!({
+        "jsonrpc": "2.0",
+        "method": "tools/call"
+        // missing "params"
+    });
+    let err = decode_call_tool(&req).unwrap_err();
+    assert_eq!(err.kind(), "missing-field");
+}
+
+#[test]
+fn e2e_reject_missing_name() {
+    let req = json!({
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {"arguments": {"x": 1}}
+    });
+    let err = decode_call_tool(&req).unwrap_err();
+    assert_eq!(err.kind(), "missing-field");
+}
+
+#[test]
+fn e2e_reject_double_stringified() {
+    // arguments = string that decodes to string, not object
+    let inner = r#""hello""#.to_string();
+    let req = json!({
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {
+            "name": "test",
+            "arguments": inner
+        }
+    });
+    let err = decode_call_tool(&req).unwrap_err();
+    assert_eq!(err.kind(), "arguments-decoded-not-object");
+}
+
+#[test]
+fn e2e_reject_arguments_array() {
+    let req = json!({
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {
+            "name": "test",
+            "arguments": [1, 2, 3]
+        }
+    });
+    let err = decode_call_tool(&req).unwrap_err();
+    assert_eq!(err.kind(), "arguments-not-object");
+}
+
+#[test]
+fn e2e_reject_arguments_number() {
+    let req = json!({
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {
+            "name": "test",
+            "arguments": 42
+        }
+    });
+    let err = decode_call_tool(&req).unwrap_err();
+    assert_eq!(err.kind(), "arguments-not-object");
+}
+
+#[test]
+fn e2e_reject_arguments_boolean() {
+    let req = json!({
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {
+            "name": "test",
+            "arguments": true
+        }
+    });
+    let err = decode_call_tool(&req).unwrap_err();
+    assert_eq!(err.kind(), "arguments-not-object");
+}
+
+// ── validate_call_tool_params ───────────────────────────────//
+
+#[test]
+fn e2e_validate_with_schema_success() {
+    let schema = json!({
+        "type": "object",
+        "required": ["file_path"],
+        "properties": {"file_path": {"type": "string"}}
+    });
+    let args = json!({"file_path": "/tmp/test.txt"});
+    let result = validate_call_tool_params(Some("test_tool"), Some(args), Some(&schema)).unwrap();
+    assert_eq!(result, json!({"file_path": "/tmp/test.txt"}));
+}
+
+#[test]
+fn e2e_validate_with_schema_missing_field() {
+    let schema = json!({
+        "type": "object",
+        "required": ["file_path"],
+        "properties": {"file_path": {"type": "string"}}
+    });
+    let args = json!({});
+    let err = validate_call_tool_params(Some("test_tool"), Some(args), Some(&schema)).unwrap_err();
+    assert_eq!(err.kind(), "schema-validation-failed");
+}
+
+// ── encode_error_response shape ──────────────────────────────//
+
+#[test]
+fn e2e_error_response_has_stable_keys() {
+    let err = WireError::MissingField {
+        field: "name".to_string(),
+    };
+    let resp = encode_error_response(&err, Some("req-1"));
+    let obj = resp.as_object().unwrap();
+    assert!(obj.contains_key("kind"));
+    assert!(obj.contains_key("message"));
+    assert!(obj.contains_key("hint"));
+    assert_eq!(obj.get("request_id").unwrap(), "req-1");
+}
+
+// ── Batch e2e ───────────────────────────────────────────//
+
+#[test]
+fn e2e_validate_batch_happy() {
+    let calls = vec![
+        json!({"name": "tool_a", "arguments": {"x": 1}}),
+        json!({"tool_slug": "tool_b", "params": {"y": 2}}),
+    ];
+    let results = validate_call_batch_params(&calls).unwrap();
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0].0, "tool_a");
+    assert_eq!(results[1].0, "tool_b");
+}
+
+#[test]
+fn e2e_validate_batch_item_not_object() {
+    let calls = vec![json!("not an object")];
+    let err = validate_call_batch_params(&calls).unwrap_err();
+    assert_eq!(err.kind(), "batch-item-invalid");
+}
+
+#[test]
+fn e2e_validate_batch_item_missing_name() {
+    let calls = vec![json!({"arguments": {"x": 1}})];
+    let err = validate_call_batch_params(&calls).unwrap_err();
+    assert_eq!(err.kind(), "batch-item-invalid");
+}

--- a/python/dcc_mcp_core/__init__.py
+++ b/python/dcc_mcp_core/__init__.py
@@ -421,6 +421,8 @@ _LAZY: dict[str, str] = {
     "ScriptExecutionResult": "dcc_mcp_core.script_execution",
     "ScriptExecutionSerializationError": "dcc_mcp_core.script_execution",
     "normalize_script_execution_params": "dcc_mcp_core.script_execution",
+    "normalize_tool_arguments": "dcc_mcp_core.host",
+    "normalize_tool_meta": "dcc_mcp_core.host",
     # skill helpers (pure-Python, used inside skill scripts)
     "get_bundled_skill_paths": "dcc_mcp_core.skill",
     "get_bundled_skills_dir": "dcc_mcp_core.skill",
@@ -803,6 +805,8 @@ __all__ = [
     "make_start_stop",
     "mpu_to_units",
     "normalize_script_execution_params",
+    "normalize_tool_arguments",
+    "normalize_tool_meta",
     "parse_recipe_anchors",
     "parse_schedules_yaml",
     "parse_skill_md",

--- a/python/dcc_mcp_core/host/__init__.py
+++ b/python/dcc_mcp_core/host/__init__.py
@@ -32,6 +32,8 @@ from dcc_mcp_core._core import TickOutcome
 from dcc_mcp_core.host._adapter import HostAdapter
 from dcc_mcp_core.host._adapter import TickableDispatcher
 from dcc_mcp_core.host._standalone import StandaloneHost
+from dcc_mcp_core.host._wire import normalize_tool_arguments
+from dcc_mcp_core.host._wire import normalize_tool_meta
 
 __all__ = [
     "BlockingDispatcher",
@@ -42,4 +44,6 @@ __all__ = [
     "StandaloneHost",
     "TickOutcome",
     "TickableDispatcher",
+    "normalize_tool_arguments",
+    "normalize_tool_meta",
 ]

--- a/python/dcc_mcp_core/host/_wire.py
+++ b/python/dcc_mcp_core/host/_wire.py
@@ -1,0 +1,18 @@
+"""Python wrappers for host-facing MCP wire normalization helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dcc_mcp_core._core import normalize_tool_arguments as _normalize_tool_arguments
+from dcc_mcp_core._core import normalize_tool_meta as _normalize_tool_meta
+
+
+def normalize_tool_arguments(arguments: Any = None) -> dict[str, Any]:
+    """Normalize raw tool ``arguments`` to a JSON-object-shaped dict."""
+    return _normalize_tool_arguments(arguments)
+
+
+def normalize_tool_meta(meta: Any = None) -> dict[str, Any] | None:
+    """Normalize raw tool ``_meta`` to a dict or ``None``."""
+    return _normalize_tool_meta(meta)

--- a/tests/test_host_wire_python.py
+++ b/tests/test_host_wire_python.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+
+import dcc_mcp_core
+from dcc_mcp_core.host import normalize_tool_arguments
+from dcc_mcp_core.host import normalize_tool_meta
+
+
+def test_normalize_tool_arguments_accepts_python_dict() -> None:
+    assert normalize_tool_arguments({"radius": 2, "name": "sphere"}) == {
+        "radius": 2,
+        "name": "sphere",
+    }
+
+
+def test_normalize_tool_arguments_accepts_json_string() -> None:
+    assert normalize_tool_arguments('{"code": "print(1)"}') == {"code": "print(1)"}
+
+
+def test_normalize_tool_arguments_defaults_to_empty_object() -> None:
+    assert normalize_tool_arguments() == {}
+    assert normalize_tool_arguments(None) == {}
+    assert normalize_tool_arguments("  ") == {}
+
+
+def test_normalize_tool_arguments_rejects_non_object_shapes() -> None:
+    with pytest.raises(ValueError, match="arguments-not-object"):
+        normalize_tool_arguments([1, 2, 3])
+
+    with pytest.raises(ValueError, match="arguments-decoded-not-object"):
+        normalize_tool_arguments("[1, 2, 3]")
+
+    with pytest.raises(ValueError, match="arguments-string-not-json"):
+        normalize_tool_arguments("not json")
+
+
+def test_normalize_tool_meta_accepts_object_string_and_none() -> None:
+    assert normalize_tool_meta({"progressToken": "job-1"}) == {"progressToken": "job-1"}
+    assert normalize_tool_meta('{"dcc": {"async": true}}') == {"dcc": {"async": True}}
+    assert normalize_tool_meta() is None
+    assert normalize_tool_meta(None) is None
+    assert normalize_tool_meta("  ") is None
+
+
+def test_normalize_tool_meta_rejects_non_object_shapes() -> None:
+    with pytest.raises(ValueError, match="arguments-not-object"):
+        normalize_tool_meta(True)
+
+    with pytest.raises(ValueError, match="arguments-decoded-not-object"):
+        normalize_tool_meta("42")
+
+
+def test_top_level_lazy_exports_host_wire_helpers() -> None:
+    assert dcc_mcp_core.normalize_tool_arguments('{"x": 1}') == {"x": 1}
+    assert dcc_mcp_core.normalize_tool_meta(None) is None


### PR DESCRIPTION
## Summary
- add dcc-mcp-wire as the canonical MCP/gateway wire normalization and validation crate
- move argument coercion behind dcc_mcp_wire::normalize_arguments while keeping the dcc-mcp-jsonrpc compatibility entry point
- expose host-layer Python normalization wrappers for real DCC request arguments/meta
- add E2E coverage for MCP tools/call, REST call payloads, structured errors, batch validation, and Python host wrappers

Fixes #969

## Tests
- cargo fmt --all -- --check
- cargo clippy --workspace --tests -- -D warnings
- cargo test -p dcc-mcp-host --features python-bindings
- cargo test -p dcc-mcp-jsonrpc -p dcc-mcp-wire
- maturin develop with Python bindings/features
- PYTHONPATH=python python -m pytest tests/test_host_wire_python.py
- ruff check on touched Python files