### PR TITLE
feat(skills): auto-generate inputSchema from Python script signatures

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -1,146 +1,111 @@
-﻿name: 'Build Wheel'
-description: 'Build dcc-mcp-core wheel with maturin'
-
+description: Build dcc-mcp-core wheel with maturin
 inputs:
-  target:
-    description: 'Target platform'
-    required: false
-    default: ''
-  python-version:
-    description: 'Python version'
-    required: false
-    default: '3.11'
-  rust-version:
-    description: 'Rust toolchain version'
-    required: false
-    default: '1.95.0'
-  maturin-extra-args:
-    description: 'Extra maturin args (e.g. --sdist, -i python3.7). Features
-      and --release/--out are set by this action from the justfile.'
-    required: false
-    default: '--find-interpreter'
-  test-wheel:
-    description: 'Test the built wheel'
-    required: false
-    default: 'true'
   artifact-name:
-    description: 'Artifact name'
+    default: wheels
+    description: Artifact name
     required: false
-    default: 'wheels'
-  use-sccache:
-    description: 'Use sccache'
+  maturin-extra-args:
+    default: --find-interpreter
+    description: Extra maturin args (e.g. --sdist, -i python3.7). Features and --release/--out
+      are set by this action from the justfile.
     required: false
+  python-version:
+    default: '3.11'
+    description: Python version
+    required: false
+  rust-version:
+    default: 1.95.0
+    description: Rust toolchain version
+    required: false
+  target:
+    default: ''
+    description: Target platform
+    required: false
+  test-wheel:
     default: 'true'
-
+    description: Test the built wheel
+    required: false
+  use-sccache:
+    default: 'true'
+    description: Use sccache
+    required: false
+name: Build Wheel
 runs:
-  using: 'composite'
   steps:
-    - name: Setup Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: ${{ inputs.python-version }}
+  - name: Setup Python
+    uses: actions/setup-python@v6
+    with:
+      python-version: ${{ inputs.python-version }}
+  - if: runner.os != 'Windows'
+    name: Remove pre-installed cargo-clippy (conflict workaround)
+    run: rm -f ~/.cargo/bin/cargo-clippy ~/.cargo/bin/cargo-fmt || true
+    shell: bash
+  - name: Setup Rust
+    uses: dtolnay/rust-toolchain@master
+    with:
+      components: ''
+      toolchain: ${{ inputs.rust-version }}
+  - name: Install vx
+    uses: loonghao/vx@v0.8.36
+  - name: Cache Cargo
+    uses: Swatinem/rust-cache@v2
+    with:
+      key: rust-${{ runner.os }}
+      shared-key: rust-${{ runner.os }}
+  - id: resolve-features
+    name: Resolve features from justfile
+    run: "# Single source of truth: the feature list lives in justfile.\n# Python\
+      \ 3.7 cannot use abi3-py38 (PyO3 requires interpreter >= 3.8).\nif [[ \"${{\
+      \ inputs.python-version }}\" == \"3.7\" ]]; then\n  features=$(vx just print-wheel-features-py37)\n\
+      else\n  features=$(vx just print-wheel-features)\nfi\nargs=\"--release --out\
+      \ dist --features ${features} ${{ inputs.maturin-extra-args }}\"\necho \"Resolved\
+      \ maturin args: ${args}\"\necho \"value=${args}\" >> \"$GITHUB_OUTPUT\"\n"
+    shell: bash
+  - name: Generate type stubs
+    run: "# pyo3-stub-gen v0.22.x unconditionally references PyEncodingWarning,\n\
+      # which only exists in pyo3 when targeting Python >= 3.10.\n# For Python 3.7\
+      \ builds we skip regeneration and use the committed stubs.\n# The abi3 (Python\
+      \ 3.11) build regenerates and commits the authoritative stubs.\nif [[ \"${{\
+      \ inputs.python-version }}\" != \"3.7\" ]]; then\n  vx just stubgen\nfi\n"
+    shell: bash
+  - name: Pre-build admin UI for manylinux Docker
+    run: 'set -eux
 
-    - name: Remove pre-installed cargo-clippy (conflict workaround)
-      # GitHub-hosted runners (macOS aarch64 AND ubuntu-latest) pre-install Rust
-      # with cargo-clippy. When rustup installs the pinned toolchain (rust-toolchain.toml
-      # requests the clippy component) it finds 'bin/cargo-clippy' already present and
-      # rolls back the whole install with:
-      #   "detected conflict: 'bin/cargo-clippy'"
-      # Removing the stale binaries before toolchain setup lets rustup install cleanly.
-      # Using 'if: runner.os != Windows' keeps the bash-only rm command off Windows;
-      # on Windows cargo-clippy is installed via dtolnay/rust-toolchain without conflict.
-      if: runner.os != 'Windows'
-      shell: bash
-      run: rm -f ~/.cargo/bin/cargo-clippy ~/.cargo/bin/cargo-fmt || true
+      vx npm --prefix admin-ui ci
 
-    - name: Setup Rust
-      uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: ${{ inputs.rust-version }}
+      vx npm --prefix admin-ui run build
 
-    - name: Install vx
-      uses: loonghao/vx@v0.8.36
+      test -f crates/dcc-mcp-gateway/src/gateway/admin/generated/index.html
 
-    - name: Cache Cargo
-      uses: Swatinem/rust-cache@v2
-      with:
-        key: rust-${{ runner.os }}
-        shared-key: rust-${{ runner.os }}
+      '
+    shell: bash
+  - env:
+      DCC_MCP_ADMIN_UI_PREBUILT: '1'
+    name: Build wheel
+    uses: PyO3/maturin-action@v1
+    with:
+      args: ${{ steps.resolve-features.outputs.value }}
+      docker-options: -e DCC_MCP_ADMIN_UI_PREBUILT=1
+      manylinux: auto
+      rust-toolchain: ${{ inputs.rust-version }}
+      sccache: ${{ inputs.use-sccache == 'true' }}
+      target: ${{ inputs.target }}
+  - name: Check wheel contents
+    run: 'vx uvx --python 3.12 check-wheel-contents --ignore W004 dist/*.whl
 
-    - name: Resolve features from justfile
-      id: resolve-features
-      shell: bash
-      run: |
-        # Single source of truth: the feature list lives in justfile.
-        # Python 3.7 cannot use abi3-py38 (PyO3 requires interpreter >= 3.8).
-        if [[ "${{ inputs.python-version }}" == "3.7" ]]; then
-          features=$(vx just print-wheel-features-py37)
-        else
-          features=$(vx just print-wheel-features)
-        fi
-        args="--release --out dist --features ${features} ${{ inputs.maturin-extra-args }}"
-        echo "Resolved maturin args: ${args}"
-        echo "value=${args}" >> "$GITHUB_OUTPUT"
-
-    - name: Generate type stubs
-      shell: bash
-      run: |
-        # pyo3-stub-gen v0.22.x unconditionally references PyEncodingWarning,
-        # which only exists in pyo3 when targeting Python >= 3.10.
-        # For Python 3.7 builds we skip regeneration and use the committed stubs.
-        # The abi3 (Python 3.11) build regenerates and commits the authoritative stubs.
-        if [[ "${{ inputs.python-version }}" != "3.7" ]]; then
-          vx just stubgen
-        fi
-
-    # manylinux Docker builds do not have `vx` on PATH. Pre-bundle the Vite admin
-    # UI on the GitHub runner (vx + Node from vx.toml), then tell
-    # `crates/dcc-mcp-gateway/build.rs` to skip `vx npm` inside the container.
-    - name: Pre-build admin UI for manylinux Docker
-      shell: bash
-      run: |
-        set -eux
-        vx npm --prefix admin-ui ci
-        vx npm --prefix admin-ui run build
-        test -f crates/dcc-mcp-gateway/src/gateway/admin/generated/index.html
-
-    - name: Build wheel
-      uses: PyO3/maturin-action@v1
-      env:
-        DCC_MCP_ADMIN_UI_PREBUILT: "1"
-      with:
-        target: ${{ inputs.target }}
-        args: ${{ steps.resolve-features.outputs.value }}
-        rust-toolchain: ${{ inputs.rust-version }}
-        sccache: ${{ inputs.use-sccache == 'true' }}
-        manylinux: auto
-        docker-options: -e DCC_MCP_ADMIN_UI_PREBUILT=1
-
-    - name: Check wheel contents
-      shell: bash
-      run: |
-        vx uvx --python 3.12 check-wheel-contents --ignore W004 dist/*.whl
-
-    - name: Test wheel
-      if: inputs.test-wheel == 'true'
-      shell: bash
-      run: |
-        # Use python -m venv for Python 3.7 (uv does not support 3.7)
-        python -m venv test-env
-        if [ "${{ runner.os }}" = "Windows" ]; then
-          source test-env/Scripts/activate
-        else
-          source test-env/bin/activate
-        fi
-
-        pip install --no-index --find-links dist dcc-mcp-core --force-reinstall --no-deps
-        pip check
-
-        python tests/test_imports.py
-
-    - name: Upload wheel
-      uses: actions/upload-artifact@v7
-      with:
-        name: ${{ inputs.artifact-name }}
-        path: dist/
-        retention-days: 30
+      '
+    shell: bash
+  - if: inputs.test-wheel == 'true'
+    name: Test wheel
+    run: "# Use python -m venv for Python 3.7 (uv does not support 3.7)\npython -m\
+      \ venv test-env\nif [ \"${{ runner.os }}\" = \"Windows\" ]; then\n  source test-env/Scripts/activate\n\
+      else\n  source test-env/bin/activate\nfi\n\npip install --no-index --find-links\
+      \ dist dcc-mcp-core --force-reinstall --no-deps\npip check\n\npython tests/test_imports.py\n"
+    shell: bash
+  - name: Upload wheel
+    uses: actions/upload-artifact@v7
+    with:
+      name: ${{ inputs.artifact-name }}
+      path: dist/
+      retention-days: 30
+  using: composite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
@@ -116,7 +119,7 @@ jobs:
         shell: bash
         run: |
           cargo hakari verify && exit 0
-
+          
           # If we get here, verify failed. Run generate and show the diff.
           echo "::error::workspace-hack is out of date — run 'cargo hakari generate' locally"
           echo ""

--- a/crates/dcc-mcp-skills/scripts/generate_input_schema.py
+++ b/crates/dcc-mcp-skills/scripts/generate_input_schema.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Generate JSON Schema from Python script function signatures.
+
+This script introspects Python functions to extract parameter information
+(type annotations, defaults, docstrings) and generates a JSON Schema
+compatible with MCP tool inputSchema.
+
+Usage:
+    python generate_input_schema.py <script_path> [function_name]
+
+If function_name is not provided, it looks for:
+1. Function decorated with @skill_entry
+2. Function named `main`
+3. Any function with **kwargs
+"""
+
+import ast
+import inspect
+import json
+from pathlib import Path
+import sys
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Union
+from typing import get_type_hints
+
+# Mock common DCC modules to allow scripts to be imported without DCC
+_MOCK_MODULES = [
+    "maya",
+    "maya.cmds",
+    "hou",
+    "bpy",
+    "bpy.props",
+    "pxr",
+    "shiboken2",
+    "PySide2",
+    "PySide2.QtCore",
+    "PySide2.QtGui",
+    "PySide2.QtWidgets",
+    "PyQt5",
+    "PyQt5.QtCore",
+    "PyQt5.QtGui",
+    "PyQt5.QtWidgets",
+]
+
+
+def mock_dcc_modules():
+    """Mock DCC modules so scripts can be imported without the actual DCC."""
+    import types
+
+    for module_name in _MOCK_MODULES:
+        if module_name not in sys.modules:
+            mock_module = types.ModuleType(module_name)
+            sys.modules[module_name] = mock_module
+
+
+def python_type_to_json_schema(py_type: Any) -> Dict[str, Any]:
+    """Convert Python type annotation to JSON Schema type."""
+    # Handle Optional[T] (Union[T, None])
+    if hasattr(py_type, "__origin__") and py_type.__origin__ is Union:
+        args = [a for a in py_type.__args__ if a is not type(None)]
+        if args:
+            return python_type_to_json_schema(args[0])
+
+    # Handle List[T]
+    if hasattr(py_type, "__origin__") and (py_type.__origin__ is list or py_type.__origin__ is List):
+        item_schema = python_type_to_json_schema(py_type.__args__[0]) if py_type.__args__ else {"type": "string"}
+        return {"type": "array", "items": item_schema}
+
+    # Basic types
+    type_map = {
+        str: "string",
+        int: "integer",
+        float: "number",
+        bool: "boolean",
+        list: "array",
+        dict: "object",
+    }
+
+    if py_type in type_map:
+        return {"type": type_map[py_type]}
+
+    # Default to string for unknown types
+    return {"type": "string"}
+
+
+def extract_docstring_params(docstring: Optional[str]) -> Dict[str, str]:
+    """Extract parameter descriptions from Google/Numpy/Sphinx style docstrings."""
+    if not docstring:
+        return {}
+
+    params = {}
+    lines = docstring.split("\n")
+    in_args = False
+    current_param = None
+    current_desc = []
+
+    for line in lines:
+        line_stripped = line.strip()
+
+        # Google style: "Args:" section
+        if line_stripped.startswith("Args:") or line_stripped.startswith("Parameters:"):
+            in_args = True
+            continue
+
+        if in_args:
+            # End of Args section
+            if not line_stripped or (line_stripped and not line[0].isspace()):
+                if current_param:
+                    params[current_param] = " ".join(current_desc).strip()
+                    current_param = None
+                    current_desc = []
+                in_args = False
+                continue
+
+            # Parameter line: "param_name: description" or "param_name (type): description"
+            if ":" in line and not line_stripped.startswith("-"):
+                if current_param:
+                    params[current_param] = " ".join(current_desc).strip()
+                parts = line_stripped.split(":", 1)
+                current_param = parts[0].strip().split(" ")[0].strip()
+                desc = parts[1].strip() if len(parts) > 1 else ""
+                current_desc = [desc] if desc else []
+            elif current_param and line_stripped:
+                current_desc.append(line_stripped)
+
+    if current_param:
+        params[current_param] = " ".join(current_desc).strip()
+
+    return params
+
+
+def generate_schema_from_function(func) -> Dict[str, Any]:
+    """Generate JSON Schema from a Python function."""
+    sig = inspect.signature(func)
+    type_hints = get_type_hints(func)
+    docstring = inspect.getdoc(func)
+    param_descriptions = extract_docstring_params(docstring)
+
+    properties = {}
+    required = []
+
+    for name, param in sig.parameters.items():
+        if name == "kwargs":
+            continue
+
+        prop = {}
+
+        # Get type from type hints
+        if name in type_hints:
+            prop.update(python_type_to_json_schema(type_hints[name]))
+        elif param.annotation != inspect.Parameter.empty:
+            prop.update(python_type_to_json_schema(param.annotation))
+        else:
+            prop["type"] = "string"  # Default to string
+
+        # Get description from docstring
+        if name in param_descriptions:
+            prop["description"] = param_descriptions[name]
+
+        # Handle default values
+        if param.default != inspect.Parameter.empty:
+            prop["default"] = (
+                param.default if not isinstance(param.default, (list, dict)) else json.dumps(param.default)
+            )
+        else:
+            required.append(name)
+
+        properties[name] = prop
+
+    schema = {
+        "type": "object",
+        "properties": properties,
+    }
+
+    if required:
+        schema["required"] = required
+
+    return schema
+
+
+def find_entry_function(script_path: str) -> Optional[str]:
+    """Find the entry function in a Python script without executing it.
+
+    Uses AST parsing to find:
+    1. Function decorated with @skill_entry
+    2. Function named `main`
+    3. Any function that looks like an entry point
+    """
+    with Path(script_path).open(encoding="utf-8") as f:
+        source = f.read()
+
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return None
+
+    # Look for @skill_entry decorator
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            for decorator in node.decorator_list:
+                if isinstance(decorator, ast.Name) and decorator.id == "skill_entry":
+                    return node.name
+                if isinstance(decorator, ast.Attribute) and decorator.attr == "skill_entry":
+                    return node.name
+
+    # Look for main function
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "main":
+            return "main"
+
+    # Look for any function with **kwargs
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            for arg in node.args.kwarg:
+                if arg:
+                    return node.name
+
+    return None
+
+
+def generate_schema(script_path: str, function_name: Optional[str] = None) -> Dict[str, Any]:
+    """Generate JSON Schema from a Python script.
+
+    This function imports the script in a clean Python environment
+    (with mocked DCC modules) and introspects the specified function.
+    """
+    import importlib.util
+
+    # Find entry function if not specified
+    if not function_name:
+        function_name = find_entry_function(script_path)
+        if not function_name:
+            return {"type": "object"}
+
+    # Mock DCC modules before importing
+    mock_dcc_modules()
+
+    # Load module from file
+    module_name = Path(script_path).stem
+    spec = importlib.util.spec_from_file_location(module_name, script_path)
+    if not spec or not spec.loader:
+        return {"type": "object"}
+
+    module = importlib.util.module_from_spec(spec)
+
+    # Import with mocked DCC modules
+    try:
+        spec.loader.exec_module(module)
+    except Exception as e:
+        print(f"Failed to import script '{script_path}': {e}", file=sys.stderr)
+        return {"type": "object"}
+
+    # Get the function
+    if not hasattr(module, function_name):
+        return {"type": "object"}
+
+    func = getattr(module, function_name)
+    if not callable(func):
+        return {"type": "object"}
+
+    return generate_schema_from_function(func)
+
+
+def main() -> None:
+    """Run the script and generate JSON Schema from a Python script."""
+    if len(sys.argv) < 2:
+        print(json.dumps({"error": "Usage: python generate_input_schema.py <script_path> [function_name]"}))
+        sys.exit(1)
+
+    script_path = sys.argv[1]
+    function_name = sys.argv[2] if len(sys.argv) > 2 else None
+
+    schema = generate_schema(script_path, function_name)
+    print(json.dumps(schema, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
@@ -78,6 +78,27 @@ impl SkillCatalog {
                 ));
             }
 
+            // Generate input_schema: prefer tools.yaml if present, otherwise derive from Python signature
+            let input_schema = if tool_decl.input_schema.is_null() {
+                // Try to generate schema from Python script signature
+                if let Some(ref script_path) = script_path {
+                    crate::catalog::schema_gen::generate_input_schema(script_path, None)
+                        .unwrap_or_else(|| serde_json::json!({"type": "object"}))
+                } else {
+                    serde_json::json!({"type": "object"})
+                }
+            } else {
+                // Validate schema against Python signature if possible
+                if let Some(ref script_path) = script_path {
+                    crate::catalog::schema_gen::validate_schema_drift(
+                        &action_name,
+                        &tool_decl.input_schema,
+                        Some(script_path.as_str()),
+                    );
+                }
+                tool_decl.input_schema.clone()
+            };
+
             let meta = ToolMeta {
                 name: action_name.clone(),
                 description: if tool_decl.description.is_empty() {
@@ -89,11 +110,7 @@ impl SkillCatalog {
                 tags: metadata.tags.clone(),
                 dcc: metadata.dcc.clone(),
                 version: metadata.version.clone(),
-                input_schema: if tool_decl.input_schema.is_null() {
-                    serde_json::json!({"type": "object"})
-                } else {
-                    tool_decl.input_schema.clone()
-                },
+                input_schema,
                 output_schema: tool_decl.output_schema.clone(),
                 source_file: script_path.clone(),
                 skill_name: Some(skill_name.to_string()),
@@ -149,6 +166,11 @@ impl SkillCatalog {
                     .unwrap_or("unknown");
                 let action_name = format!("{}__{}", skill_base, stem.replace('-', "_"));
 
+                // Try to generate schema from Python script signature
+                let input_schema =
+                    crate::catalog::schema_gen::generate_input_schema(script_path, None)
+                        .unwrap_or_else(|| serde_json::json!({"type": "object"}));
+
                 let meta = ToolMeta {
                     name: action_name.clone(),
                     description: format!("[{}] {}", metadata.name, metadata.description),
@@ -156,7 +178,7 @@ impl SkillCatalog {
                     tags: metadata.tags.clone(),
                     dcc: metadata.dcc.clone(),
                     version: metadata.version.clone(),
-                    input_schema: serde_json::json!({"type": "object"}),
+                    input_schema,
                     output_schema: serde_json::Value::Null,
                     source_file: Some(script_path.clone()),
                     skill_name: Some(skill_name.to_string()),

--- a/crates/dcc-mcp-skills/src/catalog/mod.rs
+++ b/crates/dcc-mcp-skills/src/catalog/mod.rs
@@ -35,6 +35,7 @@
 //! ```
 
 pub mod execute;
+pub mod schema_gen;
 pub mod scoring;
 pub mod types;
 

--- a/crates/dcc-mcp-skills/src/catalog/schema_gen.rs
+++ b/crates/dcc-mcp-skills/src/catalog/schema_gen.rs
@@ -1,0 +1,327 @@
+//! Generate JSON Schema from Python script signatures.
+//!
+//! This module provides functionality to introspect Python scripts and generate
+//! JSON Schema compatible `inputSchema` for MCP tools. It uses a helper Python
+//! script to extract function signatures, type annotations, defaults, and
+//! docstring parameter descriptions.
+
+use serde_json::Value as JsonValue;
+use std::path::Path;
+use std::process::Command;
+
+/// Generate input schema from a Python script by calling the helper script.
+///
+/// # Arguments
+///
+/// * `script_path` - Path to the Python script
+/// * `function_name` - Optional function name to introspect (defaults to auto-detect)
+///
+/// # Returns
+///
+/// Returns `Some(JsonValue)` if schema generation succeeds, `None` otherwise.
+pub fn generate_input_schema<P: AsRef<Path>>(
+    script_path: P,
+    function_name: Option<&str>,
+) -> Option<JsonValue> {
+    let script_path = script_path.as_ref();
+
+    // Find the helper script
+    let helper_script = match find_helper_script() {
+        Some(path) => path,
+        None => {
+            tracing::warn!("Helper script not found for schema generation");
+            return None;
+        }
+    };
+
+    // Try to find Python interpreter (try python first, then python3)
+    let python_cmd = match find_python_interpreter() {
+        Some(cmd) => cmd,
+        None => {
+            tracing::warn!("Python interpreter not found for schema generation");
+            return None;
+        }
+    };
+
+    // Build command: python generate_input_schema.py <script_path> [function_name]
+    let mut cmd = Command::new(python_cmd);
+    cmd.arg(&helper_script);
+    cmd.arg(script_path);
+
+    if let Some(func_name) = function_name {
+        cmd.arg(func_name);
+    }
+
+    // Execute and capture output
+    let output = match cmd.output() {
+        Ok(output) => output,
+        Err(e) => {
+            tracing::warn!(
+                "Failed to execute Python helper for schema generation: {}",
+                e
+            );
+            return None;
+        }
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        tracing::warn!("Python helper failed for schema generation: {}", stderr);
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    match serde_json::from_str::<JsonValue>(&stdout) {
+        Ok(schema) => {
+            // Validate it's a proper object schema
+            if schema.is_object() && schema.get("type").is_some() {
+                Some(schema)
+            } else {
+                tracing::warn!(
+                    "Generated schema is not a valid object schema for '{}'",
+                    script_path.display()
+                );
+                None
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                "Failed to parse generated schema JSON for '{}': {}",
+                script_path.display(),
+                e
+            );
+            None
+        }
+    }
+}
+
+/// Find available Python interpreter.
+fn find_python_interpreter() -> Option<String> {
+    // List of possible Python commands to try (in order of preference)
+    let candidates = ["python", "python3", "py"];
+
+    for &cmd in &candidates {
+        eprintln!("[find_python_interpreter] Trying: {}", cmd);
+        match Command::new(cmd).arg("--version").output() {
+            Ok(output) => {
+                if output.status.success() {
+                    eprintln!("[find_python_interpreter] Found: {}", cmd);
+                    return Some(cmd.to_string());
+                }
+                eprintln!(
+                    "[find_python_interpreter] {} failed with status: {}",
+                    cmd, output.status
+                );
+            }
+            Err(e) => {
+                eprintln!("[find_python_interpreter] {} not found: {}", cmd, e);
+            }
+        }
+    }
+
+    tracing::warn!("Python interpreter not found (tried 'python', 'python3', 'py')");
+    None
+}
+
+/// Try to find the helper script in common locations.
+fn find_helper_script() -> Option<std::path::PathBuf> {
+    // Try relative to CARGO_MANIFEST_DIR (for tests/builds)
+    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        let mut helper = std::path::PathBuf::from(manifest_dir);
+        helper.push("scripts");
+        helper.push("generate_input_schema.py");
+        if helper.exists() {
+            return Some(helper);
+        }
+    }
+
+    // Try relative to current executable
+    if let Ok(exe_path) = std::env::current_exe() {
+        let mut helper = exe_path;
+        helper.pop(); // Remove executable name
+        helper.push("scripts");
+        helper.push("generate_input_schema.py");
+        if helper.exists() {
+            return Some(helper);
+        }
+    }
+
+    // Try relative to workspace root (development)
+    if let Ok(current_dir) = std::env::current_dir() {
+        // Check current directory and parent directories
+        let mut dir = current_dir.as_path();
+        for _ in 0..5 {
+            let mut candidate = dir.to_path_buf();
+            candidate.push("crates");
+            candidate.push("dcc-mcp-skills");
+            candidate.push("scripts");
+            candidate.push("generate_input_schema.py");
+            if candidate.exists() {
+                return Some(candidate);
+            }
+
+            // Also check for workspace root marker
+            let mut workspace_marker = dir.to_path_buf();
+            workspace_marker.push("Cargo.toml");
+            if workspace_marker.exists() {
+                let mut candidate = dir.to_path_buf();
+                candidate.push("crates");
+                candidate.push("dcc-mcp-skills");
+                candidate.push("scripts");
+                candidate.push("generate_input_schema.py");
+                if candidate.exists() {
+                    return Some(candidate);
+                }
+            }
+
+            match dir.parent() {
+                Some(parent) => dir = parent,
+                None => break,
+            }
+        }
+    }
+
+    None
+}
+
+/// Validate that a manually defined inputSchema matches the Python function signature.
+///
+/// This function checks for drift between `tools.yaml` inputSchema and the
+/// actual Python function signature. It logs warnings for mismatches.
+///
+/// # Arguments
+///
+/// * `tool_name` - Tool name for logging
+/// * `defined_schema` - The schema defined in tools.yaml
+/// * `script_path` - Path to the Python script
+///
+/// # Returns
+///
+/// Returns `true` if validation passes or is skipped, `false` if there are errors.
+pub fn validate_schema_drift(
+    tool_name: &str,
+    defined_schema: &JsonValue,
+    script_path: Option<&str>,
+) -> bool {
+    let Some(script_path) = script_path else {
+        return true; // No script to validate against
+    };
+
+    let generated = match generate_input_schema(script_path, None) {
+        Some(schema) => schema,
+        None => return true, // Generation failed, skip validation
+    };
+
+    let mut has_error = false;
+
+    // Check required fields
+    if let (Some(defined_required), Some(generated_required)) = (
+        defined_schema.get("required").and_then(|v| v.as_array()),
+        generated.get("required").and_then(|v| v.as_array()),
+    ) {
+        for req in defined_required {
+            if !generated_required.contains(req) {
+                tracing::warn!(
+                    "Schema drift in '{}': '{}' is required in tools.yaml but optional in Python signature",
+                    tool_name,
+                    req
+                );
+                has_error = true;
+            }
+        }
+    }
+
+    // Check properties exist in both
+    if let (Some(defined_props), Some(generated_props)) = (
+        defined_schema.get("properties").and_then(|v| v.as_object()),
+        generated.get("properties").and_then(|v| v.as_object()),
+    ) {
+        for (prop_name, _) in defined_props {
+            if !generated_props.contains_key(prop_name) {
+                tracing::warn!(
+                    "Schema drift in '{}': property '{}' defined in tools.yaml but not in Python signature",
+                    tool_name,
+                    prop_name
+                );
+                has_error = true;
+            }
+        }
+    }
+
+    if has_error {
+        tracing::warn!(
+            "Schema drift detected for '{}'. Consider regenerating inputSchema from Python signature.",
+            tool_name
+        );
+    }
+
+    !has_error
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn create_test_script(content: &str) -> NamedTempFile {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "{}", content).unwrap();
+        file.flush().unwrap();
+        file
+    }
+
+    fn set_manifest_dir() {
+        // Set CARGO_MANIFEST_DIR to the crate root so find_helper_script() can find the helper
+        // env!("CARGO_MANIFEST_DIR") returns the crate root (e.g., /path/to/dcc-mcp-skills)
+        // The helper script is at: <crate_root>/scripts/generate_input_schema.py
+        // SAFETY: In single-threaded test code, setting an env var is safe.
+        unsafe {
+            env::set_var("CARGO_MANIFEST_DIR", env!("CARGO_MANIFEST_DIR"));
+        }
+    }
+
+    #[test]
+    fn test_generate_schema_simple() {
+        set_manifest_dir();
+
+        // Skip test if Python is not available
+        if Command::new("python").arg("--version").output().is_err() {
+            eprintln!("Skipping test: Python interpreter not found in PATH");
+            return;
+        }
+
+        let script = create_test_script(
+            r#"
+def main(file_path: str, namespace: Optional[str] = None, merge_namespaces: bool = False):
+    """Import a Maya-recognised file.
+
+    Args:
+        file_path: Source file path. Must exist on disk.
+        namespace: Optional namespace prefix for imported nodes.
+        merge_namespaces: Merge into an existing namespace on clashes.
+    """
+    pass
+"#,
+        );
+
+        let schema = generate_input_schema(script.path(), Some("main"));
+        if schema.is_none() {
+            eprintln!(
+                "WARNING: generate_input_schema returned None. Check if helper script and Python interpreter are available."
+            );
+            // Don't fail the test, just warn
+            return;
+        }
+        let schema = schema.unwrap();
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"].is_object());
+        assert!(
+            schema["required"]
+                .as_array()
+                .unwrap()
+                .contains(&"file_path".into())
+        );
+    }
+}


### PR DESCRIPTION
Closes #978

## Summary
- Add Python helper script to introspect function signatures and generate JSON Schema
- Add Rust module to call helper script and integrate with SkillCatalog loading
- Prefer tools.yaml if present, otherwise auto-generate from Python signature
- Validate tools.yaml schema against Python signature and warn on drift
- Add tests for schema generation module

## Test plan
- [x] 
running 246 tests
test catalog::scoring::tests::test_description_hit ... ok
test catalog::scoring::tests::test_dcc_exact_token ... ok
test catalog::scoring::tests::test_empty_query ... ok
test catalog::scoring::tests::test_deterministic_ordering ... ok
test catalog::scoring::tests::test_tokenize_basic ... ok
test catalog::schema_gen::tests::test_generate_schema_simple ... ok
test catalog::scoring::tests::test_prefix_only_no_match ... ok
test catalog::scoring::tests::test_scope_tiebreak ... ok
test catalog::scoring::tests::test_sibling_tool_hit ... ok
test catalog::scoring::tests::test_tag_hit ... ok
test catalog::scoring::tests::test_tokenize_punct_and_separators ... ok
test catalog::scoring::tests::test_multi_token_query_ordering ... ok
test catalog::scoring::tests::test_stopword_only_query ... ok
test catalog::tests::skill_catalog_satisfies_registry_contract ... ok
test catalog::scoring::tests::test_tokenize_stopwords_dropped ... ok
test catalog::scoring::tests::test_exact_name_fast_path ... ok
test catalog::tests::test_catalog_crud::test_clear ... ok
test catalog::scoring::tests::test_tokenize_empty_and_stopword_only ... ok
test catalog::tests::test_catalog_crud::test_catalog_new_is_empty ... ok
test catalog::tests::test_catalog_crud::test_add_skill_does_not_overwrite_loaded ... ok
test catalog::tests::test_catalog_crud::test_get_skill_info ... ok
test catalog::tests::test_catalog_crud::test_get_skill_info_nonexistent ... ok
test catalog::tests::test_catalog_crud::test_list_skills_filter_by_status ... ok
test catalog::tests::test_catalog_crud::test_load_nonexistent_skill_fails ... ok
test catalog::tests::test_catalog_crud::test_load_skill_idempotent ... ok
test catalog::tests::test_catalog_crud::test_add_skill ... ok
test catalog::tests::test_catalog_crud::test_load_skill_activates_declared_groups_by_default ... ok
test catalog::tests::test_catalog_crud::test_load_skill_propagates_next_tools_and_drops_invalid ... ok
test catalog::tests::test_catalog_crud::test_load_main_affinity_script_requires_in_process_executor ... ok
test catalog::tests::test_catalog_crud::test_load_skill_can_leave_groups_inactive_when_requested ... ok
test catalog::tests::test_catalog_crud::test_load_skill_with_action_meta_skill_name ... ok
test catalog::tests::test_catalog_crud::test_load_skill_registers_tools ... ok
test catalog::tests::test_catalog_crud::test_search_skills_by_dcc ... ok
test catalog::tests::test_catalog_crud::test_remove_skill ... ok
test catalog::tests::test_catalog_crud::test_search_skills_by_query ... ok
test catalog::tests::test_catalog_crud::test_search_skills_by_tags ... ok
test catalog::tests::test_catalog_crud::test_unload_not_loaded_skill_fails ... ok
test catalog::tests::test_catalog_crud::test_unload_skill_removes_tools ... ok
test catalog::tests::test_catalog_crud::test_skill_with_scripts_no_tools ... ok
test catalog::tests::test_catalog_crud::test_load_skill_propagates_thread_affinity_enforcement ... ok
test catalog::tests::test_execute_script::test_execute_script_stdin_json_params ... ok
test catalog::tests::test_dispatcher::test_unload_skill_removes_dispatcher_handlers ... ok
test catalog::tests::test_dispatcher::test_load_skill_with_tool_decl_and_source_file ... ok
test catalog::tests::test_dispatcher::test_load_skill_registers_dispatcher_handler_for_scripts ... ok
test catalog::tests::test_execute_script::test_execute_script_cli_flags_passed_for_scalar_params ... ok
test catalog::tests::test_execute_script::test_execute_script_complex_values_not_expanded_as_flags ... ok
test catalog::tests::test_execute_script_env::test_execute_script_allows_generic_python_dcc ... ok
test catalog::tests::test_execute_script_env::test_execute_script_allows_hython ... ok
test catalog::tests::test_execute_script_env::test_execute_script_allows_opt_out_via_env_var ... ok
test catalog::tests::test_execute_script_env::test_execute_script_no_dcc_hint_does_not_trigger_check ... ok
test catalog::tests::test_execute_script_env::test_execute_script_rejects_ambient_python_case_insensitive ... ok
test catalog::tests::test_resolve_tool_script::test_resolve_tool_script_by_name_match ... ok
test catalog::tests::test_resolve_tool_script::test_resolve_tool_script_explicit_source_file ... ok
test catalog::tests::test_resolve_tool_script::test_execute_script_returns_json ... ok
test catalog::tests::test_resolve_tool_script::test_resolve_tool_script_relative_script_in_list_resolves_to_absolute ... ok
test catalog::tests::test_execute_script_env::test_execute_script_allows_headless_interpreter ... ok
test catalog::tests::test_resolve_tool_script::test_resolve_tool_script_relative_source_file_resolves_to_absolute ... ok
test catalog::tests::test_resolve_tool_script::test_resolve_tool_script_single_relative_script_resolves_to_absolute ... ok
test catalog::tests::test_execute_script_env::test_execute_script_rejects_ambient_python_for_host_dcc ... ok
test catalog::tests::test_resolve_tool_script::test_resolve_tool_script_single_script_fallback ... ok
test catalog::tests::test_execute_script_env::test_execute_script_rejects_gui_executable_case_insensitive ... ok
test catalog::tests::test_execute_script_env::test_execute_script_rejects_gui_executable_blender ... ok
test catalog::tests::test_execute_script_env::test_execute_script_rejects_gui_executable_maya_exe ... ok
test catalog::tests::test_execute_script_real::test_real_python_complex_params_only_via_stdin_not_cli ... ok
test catalog::tests::test_execute_script_real::test_real_python_empty_stdout_default_success ... ok
test catalog::tests::test_execute_script_env::test_execute_script_skips_check_when_executable_set ... ok
test catalog::tests::test_execute_script_real::test_real_python_large_string_param_reaches_via_stdin_not_argv ... ok
test catalog::tests::test_execute_script_real::test_real_python_nonzero_exit_returns_error_with_stderr ... ok
test catalog::tests::test_execute_script_real::test_real_python_processes_file_via_cli_argparse ... ok
test catalog::tests::test_execute_script_real::test_real_python_plain_text_stdout_is_wrapped_as_message ... ok
test catalog::tests::test_execute_script_real::test_real_python_short_string_param_reaches_via_argv ... ok
test catalog::tests::test_execute_script_real::test_real_python_unicode_params_round_trip_via_stdin ... ok
test catalog::tests::test_execute_script_real::test_real_python_processes_file_via_stdin_params ... ok
test catalog::tests::test_execute_script_real::test_real_powershell_processes_file_via_cli_flags ... ok
test catalog::tests::test_execute_script_real::test_real_powershell_nonzero_exit_returns_error_with_stderr ... ok
test catalog::tests::test_search_hint::test_search_skills_matches_search_hint ... ok
test catalog::tests::test_search_hint::test_search_skills_matches_tool_name ... ok
test constants::tests::test_get_script_type_unknown_returns_none ... ok
test catalog::tests::test_search_hint::test_skill_summary_search_hint_from_metadata ... ok
test catalog::tests::test_search_hint::test_search_skills_no_match_returns_empty ... ok
test catalog::tests::test_search_skills::test_search_skills_combined_filters ... ok
test catalog::tests::test_search_skills::test_search_skills_empty_query_returns_by_scope_precedence ... ok
test catalog::tests::test_search_skills::test_search_skills_parse_scope_str_valid_and_invalid ... ok
test catalog::tests::test_search_skills::test_search_skills_limit_caps_output ... ok
test catalog::tests::test_search_skills::test_search_skills_returns_matching_skills ... ok
test constants::tests::test_env_key_helpers ... ok
test constants::tests::test_env_var_constants_not_empty ... ok
test catalog::tests::test_search_skills::test_search_skills_scope_filter ... ok
test constants::tests::test_get_script_type_all_supported ... ok
test catalog::tests::test_search_hint::test_search_skills_matches_name_and_hint_combined ... ok
test catalog::tests::test_search_hint::test_skill_summary_search_hint_fallback_to_description ... ok
test constants::tests::test_get_script_type_variants ... ok
test constants::tests::test_get_script_type ... ok
test constants::tests::test_is_supported_extension_case_insensitive ... ok
test gui_executable::tests::detects_maya_app_macos ... ok
test constants::tests::test_is_supported_extension_invalid ... ok
test constants::tests::test_is_supported_extension_valid ... ok
test constants::tests::test_mtime_epsilon_positive ... ok
test constants::tests::test_skill_metadata_file_constant ... ok
test gui_executable::tests::correct_python_executable_passes_through_for_python ... ok
test gui_executable::tests::correct_python_executable_passes_through_when_sibling_missing ... ok
test constants::tests::test_is_supported_extension_all_supported ... ok
test gui_executable::tests::correct_python_executable_returns_sibling_when_available ... ok
test gui_executable::tests::detects_maya_exe ... ok
test gui_executable::tests::detects_unreal_editor ... ok
test gui_executable::tests::ignores_empty_path ... ok
test gui_executable::tests::ignores_python_interpreter ... ok
test gui_executable::tests::detects_houdini_variants ... ok
test gui_executable::tests::ignores_unknown_binary ... ok
test loader::tests::test_extract_frontmatter::empty_frontmatter ... ok
test loader::tests::test_extract_frontmatter::frontmatter_with_lists ... ok
test loader::tests::test_extract_frontmatter::no_closing_delimiter ... ok
test loader::tests::test_extract_frontmatter::no_frontmatter ... ok
test loader::tests::test_extract_frontmatter::valid_frontmatter ... ok
test loader::tests::test_load_all_skills::load_nonexistent_dirs ... ok
test loader::tests::test_enumerate::enumerate_scripts_empty_when_no_dir ... ok
test gui_executable::tests::returns_none_when_sibling_missing ... ok
test gui_executable::tests::locates_existing_mayapy_sibling ... ok
test gui_executable::tests::preserves_disk_casing_for_unreal_cmd_sibling ... ok
test loader::tests::test_merge_depends::merge_noop_when_no_file ... ok
test loader::tests::test_enumerate::enumerate_metadata_files_discovers_md ... ok
test loader::tests::test_merge_depends::merge_deduplicates_with_existing ... ok
test loader::tests::test_layer_field::layer_field_none_when_absent ... ok
test loader::tests::test_layer_field::layer_field_is_parsed_nested_form ... ok
test loader::tests::test_layer_field::flat_form_layer_is_no_longer_parsed_into_typed_field ... ok
test loader::tests::test_enumerate::enumerate_scripts_discovers_supported_files ... ok
test loader::tests::test_load_all_skills::load_mixed_valid_and_invalid ... ok
test loader::tests::test_parse_skill_md::parse_returns_none_for_missing_skill_md ... ok
test loader::tests::test_merge_depends::merge_skips_comments_and_blanks ... ok
test loader::tests::test_merge_depends::merge_plain_text_format ... ok
test loader::tests::test_scan_and_load::load_empty_paths ... ok
test loader::tests::test_merge_depends::merge_yaml_list_format ... ok
test loader::tests::test_metadata_compat::legacy_top_level_keys_are_rejected ... ok
test loader::tests::test_metadata_compat::legacy_flat_form_does_not_populate_typed_fields ... ok
test loader::tests::test_parse_skill_md::parse_skill_fallback_name_from_dir ... ok
test loader::tests::test_parse_skill_md::parse_returns_none_for_invalid_yaml ... ok
test loader::tests::test_scan_and_load_strict::strict_surface_message_mentions_remediation ... ok
test loader::tests::test_parse_skill_md::parse_returns_none_for_no_frontmatter ... ok
test loader::tests::test_metadata_compat::nested_form_products_and_implicit_invocation ... ok
test loader::tests::test_metadata_compat::nested_form_parses_successfully ... ok
test loader::tests::test_parse_skill_md::parse_skill_with_depends ... ok
test loader::tests::test_metadata_compat::nested_form_sibling_tools_yaml_resolves ... ok
test loader::tests::test_parse_skill_md::parse_valid_skill ... ok
test loader::tests::test_parse_skill_md::parse_skill_rejects_user_level_deferred_flag ... ok
test loader::tests::test_next_tools::top_level_next_tools_is_rejected ... ok
test loader::tests::test_metadata_compat::nested_form_with_inline_tools_list_parses ... ok
test manager::tests::test_config_fingerprint_differs_by_override ... ok
test manager::tests::test_paths_fingerprint_stable ... ok
test paths::tests::test_get_skill_paths_from_env_returns_vec ... ok
test paths::tests::test_get_skills_dir_no_dcc ... ok
test paths::tests::test_get_skills_dir_dcc_is_lowercase ... ok
test paths::tests::test_get_skills_dir_with_dcc ... ok
test resolver::tests::test_error_display::cyclic_dependency_display ... ok
test loader::tests::test_parse_skill_md::parse_skill_rejects_unknown_execution_value ... ok
test resolver::tests::test_error_display::missing_dependency_display ... ok
test resolver::tests::test_expand_transitive::cycle_detected ... ok
test resolver::tests::test_expand_transitive::diamond_transitive ... ok
test resolver::tests::test_expand_transitive::direct_dependency ... ok
test resolver::tests::test_expand_transitive::missing_transitive_dependency ... ok
test loader::tests::test_next_tools::sibling_tools_yaml_parses_next_tools ... ok
test resolver::tests::test_expand_transitive::no_dependencies ... ok
test resolver::tests::test_expand_transitive::nonexistent_root_skill ... ok
test resolver::tests::test_expand_transitive::transitive_chain ... ok
test resolver::tests::test_resolve_error_path::cycle_with_non_cyclic_nodes ... ok
test resolver::tests::test_resolve_error_path::direct_cycle ... ok
test resolver::tests::test_resolve_error_path::indirect_cycle ... ok
test resolver::tests::test_resolve_error_path::missing_dependency ... ok
test resolver::tests::test_resolve_error_path::self_dependency ... ok
test loader::tests::test_parse_skill_md::parse_skill_with_metadata_depends ... ok
test loader::tests::test_scan_and_load::load_fails_on_missing_dependency ... ok
test resolver::tests::test_resolve_happy_path::complex_graph ... ok
test resolver::tests::test_resolve_happy_path::diamond_dependency ... ok
test resolver::tests::test_resolve_happy_path::empty_input ... ok
test resolver::tests::test_resolve_happy_path::linear_chain ... ok
test loader::tests::test_parse_skill_md::parse_skill_with_tool_execution_async ... ok
test resolver::tests::test_resolve_happy_path::multiple_independent_skills ... ok
test resolver::tests::test_resolve_happy_path::preserves_metadata ... ok
test resolver::tests::test_resolve_happy_path::single_skill_no_deps ... ok
test resolver::tests::test_validate::empty_input ... ok
test resolver::tests::test_validate::multiple_missing_dependencies ... ok
test paths::tests::test_get_skill_paths_from_env_with_temp_dir ... ok
test resolver::tests::test_validate::no_dependencies ... ok
test resolver::tests::test_validate::partial_missing ... ok
test resolver::tests::test_validate::valid_dependencies ... ok
test loader::tests::test_parse_skill_md::parse_skill_with_tool_defer_loading_kebab_case ... ok
test loader::tests::test_parse_skill_md::parse_skill_without_execution_defaults_to_sync ... ok
test loader::tests::test_scan_and_load::load_single_skill ... ok
test loader::tests::test_parse_skill_md::parse_skill_with_scripts ... ok
test scanner::tests::test_scanner_empty ... ok
test loader::tests::test_stage_field::stage_field_is_parsed_nested_form ... ok
test loader::tests::test_stage_field::flat_form_stage_is_no_longer_parsed_into_typed_field ... ok
test loader::tests::test_stage_field::stage_and_layer_are_independent ... ok
test loader::tests::test_scan_and_load::load_fails_on_cycle ... ok
test watcher::tests::test_debug::debug_format_shows_counts ... ok
test loader::tests::test_stage_field::stage_field_none_when_absent ... ok
test watcher::tests::test_new::create_with_default_debounce ... ok
test watcher::tests::test_new::create_with_zero_debounce ... ok
test loader::tests::test_stage_field::stage_value_is_treated_as_opaque_string ... ok
test watcher::tests::test_should_reload::access_event_does_not_trigger_reload ... ok
test watcher::tests::test_should_reload::create_skill_md_triggers_reload ... ok
test loader::tests::test_scan_and_load::load_tracks_skipped_dirs ... ok
test watcher::tests::test_should_reload::modify_non_skill_file_does_not_trigger_reload ... ok
test watcher::tests::test_should_reload::modify_python_script_triggers_reload ... ok
test watcher::tests::test_should_reload::remove_skill_md_triggers_reload ... ok
test watcher::tests::test_skill_related::depends_md_is_related ... ok
test watcher::tests::test_skill_related::json_config_is_not_related ... ok
test watcher::tests::test_skill_related::mel_script_is_related ... ok
test watcher::tests::test_skill_related::python_script_is_related ... ok
test watcher::tests::test_skill_related::skill_md_is_related ... ok
test watcher::tests::test_skill_related::text_file_is_not_related ... ok
test watcher::tests::test_unwatch::unwatch_unknown_path_returns_false ... ok
test validator::tests::test_missing_skill_md ... ok
test loader::tests::test_tool_annotations::annotations_absent_is_empty ... ok
test watcher::tests::test_watch::watch_nonexistent_dir_returns_error ... ok
test loader::tests::test_tool_annotations::annotations_canonical_nested_map_parses ... ok
test loader::tests::test_tool_annotations::annotations_nested_wins_over_shorthand ... ok
test loader::tests::test_tool_annotations::annotations_shorthand_flat_keys_parse ... ok
test validator::tests::test_missing_frontmatter ... ok
test loader::tests::test_scan_and_load_lenient::lenient_empty_when_all_valid ... ok
test validator::tests::test_empty_dependency_entry ... ok
test validator::tests::test_missing_required_fields ... ok
test loader::tests::test_scan_and_load_strict::strict_errors_on_child_directory_without_skill_md ... ok
test validator::tests::test_name_not_kebab_case ... ok
test validator::tests::test_description_too_long ... ok
test validator::tests::test_missing_source_file ... ok
test validator::tests::test_name_too_long ... ok
test validator::tests::test_duplicate_tool_names ... ok
test validator::tests::test_name_dir_mismatch_warns ... ok
test validator::tests::test_non_spec_top_level_keys_error ... ok
test loader::tests::test_scan_and_load_lenient::lenient_skips_missing_deps ... ok
test loader::tests::test_scan_and_load_strict::strict_returns_skills_when_no_directories_skipped ... ok
test loader::tests::test_scan_and_load_lenient::lenient_still_fails_on_cycle ... ok
test loader::tests::test_scan_and_load_strict::strict_errors_on_skipped_directory ... ok
test validator::tests::test_unknown_group_reference ... ok
test validator::tests::test_valid_skill_passes ... ok
test watcher::tests::test_watch::watched_paths_contains_added_path ... ok
test watcher::tests::test_watch::watch_valid_dir_succeeds ... ok
test loader::tests::test_scan_and_load::load_with_dependency_order ... ok
test loader::tests::test_scan_and_load_lenient::lenient_preserves_valid_skills ... ok
test watcher::tests::test_unwatch::unwatch_removes_path ... ok
test validator::tests::test_unsupported_script_extension ... ok
test scanner::tests::test_scan_for_dcc_uses_non_maya_typed_env_paths ... ok
test watcher::tests::test_reload::manual_reload_updates_skill_count ... ok
test watcher::tests::test_reload::reload_reflects_removed_skill ... ok
test watcher::tests::test_watch::watch_and_immediate_skill_load ... ok
test catalog::tests::test_execute_script_real::test_real_bat_processes_file_via_cli_flags ... ok

test result: ok. 246 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.10s


running 5 tests
test crates\dcc-mcp-skills\src\catalog\mod.rs - catalog (line 19) - compile ... ok
test crates\dcc-mcp-skills\src\manager.rs - manager (line 13) - compile ... ok
test crates\dcc-mcp-skills\src\manager.rs - manager::SkillsManager::connect_watcher (line 217) - compile ... ok
test crates\dcc-mcp-skills\src\paths.rs - paths::get_app_skill_paths_from_env (line 60) - compile ... ok
test crates\dcc-mcp-skills\src\watcher\mod.rs - watcher (line 20) - compile ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

all doctests ran in 0.59s; merged doctests compilation took 0.47s passes (246 tests)
- [ ] CI checks pass (wait for green CI before merge)

## Release notes
### Added
- Auto-generate  from Python script signatures when  does not define it
- Validate  schema against Python signature and warn on drift