### PR TITLE
feat(mcp): add rmcp SDK integration spike behind feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,26 @@ jobs:
       - name: Preflight (check + clippy + fmt + test)
         run: vx just preflight
 
+  # ── rmcp transport feature validation (issue #985) ──
+  # Ensures the rmcp-transport feature flag compiles and its tests pass.
+  # Runs on a single OS (ubuntu) since the feature is platform-independent.
+  rust-rmcp:
+    name: Rust (rmcp-transport)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: rust-rmcp
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+      - name: Check (rmcp-transport)
+        run: cargo check --workspace --features rmcp-transport
+      - name: Test (rmcp-transport)
+        run: cargo nextest run -p dcc-mcp-http-server --features rmcp-transport
+
   # ── Build ABI3 wheel (one per OS, reused by python-test) ──
   # Intentionally does NOT `needs: [rust-check]` — maturin runs its own compile
   # and can start in parallel with rust-check. If rust-check fails, the PR merge

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,6 +707,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,6 +971,7 @@ dependencies = [
  "pyo3-stub-gen",
  "pyo3-stub-gen-derive",
  "reqwest 0.13.3",
+ "rmcp",
  "rstest",
  "serde",
  "serde_json",
@@ -994,6 +1029,7 @@ dependencies = [
  "dcc-mcp-telemetry",
  "dcc-mcp-workflow",
  "parking_lot",
+ "rmcp",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1571,6 +1607,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
@@ -2331,6 +2373,12 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -3224,6 +3272,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3923,6 +3977,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4062,6 +4136,50 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pastey",
+ "pin-project-lite",
+ "rand 0.10.1",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
 ]
 
 [[package]]
@@ -4381,6 +4499,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4459,6 +4603,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4651,6 +4806,19 @@ dependencies = [
  "js-sys",
  "rsqlite-vfs",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,11 @@ rusqlite = { version = "0.39", features = ["bundled"] }
 # host without `aws-lc-rs`'s build-time C toolchain requirement).
 jsonwebtoken = { version = "10.3", default-features = false, features = ["rust_crypto"] }
 
+# Official Rust MCP SDK (issue #985). Used behind the `rmcp-transport` feature
+# flag to replace the in-house Streamable HTTP + session management stack with
+# the spec-aligned implementation from modelcontextprotocol/rust-sdk.
+rmcp = { version = "1.6", features = ["transport-streamable-http-server"] }
+
 # Type-stub generation (opt-in via `stub-gen` feature). Used only by the
 # `stub_gen` binary target — never pulled into wheels or library consumers.
 pyo3-stub-gen = "0.22"

--- a/crates/dcc-mcp-http-server/Cargo.toml
+++ b/crates/dcc-mcp-http-server/Cargo.toml
@@ -39,9 +39,14 @@ parking_lot = { workspace = true }
 uuid = { workspace = true }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
+# Official MCP SDK (optional, gated behind `rmcp-transport` feature)
+rmcp = { workspace = true, optional = true }
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
 
 [features]
 default = []
 prometheus = ["dep:dcc-mcp-telemetry", "dcc-mcp-telemetry/prometheus"]
+# Use the official rmcp SDK for MCP transport (issue #985).
+rmcp-transport = ["dep:rmcp"]

--- a/crates/dcc-mcp-http-server/src/lib.rs
+++ b/crates/dcc-mcp-http-server/src/lib.rs
@@ -27,6 +27,12 @@ pub mod server_state;
 pub mod session;
 pub mod workspace;
 
+// rmcp integration modules (issue #985) — compiled only with `rmcp-transport`.
+#[cfg(feature = "rmcp-transport")]
+pub mod rmcp_adapter;
+#[cfg(feature = "rmcp-transport")]
+pub mod rmcp_handler;
+
 pub use dynamic_tools::{
     DYNAMIC_TOOL_PREFIX, DynamicToolEntry, DynamicToolError, SessionDynamicTools, ToolSpec,
     build_deregister_tool_descriptor, build_list_dynamic_tools_descriptor,

--- a/crates/dcc-mcp-http-server/src/rmcp_adapter.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_adapter.rs
@@ -1,0 +1,265 @@
+//! Type conversion adapters between `dcc-mcp-jsonrpc` wire types and `rmcp` model types.
+//!
+//! This module provides zero-copy-where-possible conversions so the existing
+//! `ToolRegistry` / `ToolDispatcher` / `SkillCatalog` internals remain
+//! unchanged while the transport layer speaks rmcp's type language.
+//!
+//! # Gating
+//!
+//! This entire module is compiled only when the `rmcp-transport` feature is
+//! enabled.
+
+use std::sync::Arc;
+
+use rmcp::model::{
+    CallToolResult as RmcpCallToolResult, Content, Meta, RawContent, RawResource, ResourceContents,
+    Tool as RmcpTool, ToolAnnotations as RmcpToolAnnotations,
+};
+use serde_json::Value;
+
+use dcc_mcp_jsonrpc::{
+    CallToolResult as DccCallToolResult, McpTool, McpToolAnnotations, ToolContent,
+};
+
+// ── McpTool → rmcp::Tool ─────────────────────────────────────────────────────
+
+/// Convert our internal [`McpTool`] to rmcp's [`Tool`](RmcpTool).
+pub fn tool_to_rmcp(tool: &McpTool) -> RmcpTool {
+    let input_schema: Arc<rmcp::model::JsonObject> = match &tool.input_schema {
+        Value::Object(map) => Arc::new(map.clone()),
+        _ => Arc::new(
+            serde_json::json!({"type": "object", "properties": {}})
+                .as_object()
+                .unwrap()
+                .clone(),
+        ),
+    };
+
+    let output_schema: Option<Arc<rmcp::model::JsonObject>> =
+        tool.output_schema.as_ref().and_then(|v| match v {
+            Value::Object(map) => Some(Arc::new(map.clone())),
+            _ => None,
+        });
+
+    let annotations = tool.annotations.as_ref().map(annotations_to_rmcp);
+
+    let meta = tool.meta.as_ref().map(|m| Meta(m.clone()));
+
+    RmcpTool::new(tool.name.clone(), tool.description.clone(), input_schema)
+        .with_raw_output_schema_opt(output_schema)
+        .with_annotations_opt(annotations)
+        .with_meta_opt(meta)
+}
+
+/// Convert our [`McpToolAnnotations`] to rmcp's [`ToolAnnotations`](RmcpToolAnnotations).
+fn annotations_to_rmcp(ann: &McpToolAnnotations) -> RmcpToolAnnotations {
+    let mut result = RmcpToolAnnotations::new();
+    if let Some(title) = &ann.title {
+        result = RmcpToolAnnotations::with_title(title.clone());
+    }
+    if let Some(v) = ann.read_only_hint {
+        result = result.read_only(v);
+    }
+    if let Some(v) = ann.destructive_hint {
+        result = result.destructive(v);
+    }
+    if let Some(v) = ann.idempotent_hint {
+        result = result.idempotent(v);
+    }
+    if let Some(v) = ann.open_world_hint {
+        result = result.open_world(v);
+    }
+    result
+}
+
+// ── CallToolResult → rmcp::CallToolResult ────────────────────────────────────
+
+/// Convert our [`CallToolResult`](DccCallToolResult) to rmcp's [`CallToolResult`](RmcpCallToolResult).
+pub fn call_result_to_rmcp(result: &DccCallToolResult) -> RmcpCallToolResult {
+    let content: Vec<Content> = result.content.iter().map(tool_content_to_rmcp).collect();
+
+    let mut out = RmcpCallToolResult::default();
+    out.content = content;
+    out.structured_content = result.structured_content.clone();
+    out.is_error = if result.is_error { Some(true) } else { None };
+    out.meta = result.meta.as_ref().map(|m| Meta(m.clone()));
+    out
+}
+
+/// Convert a single [`ToolContent`] variant to rmcp's [`Content`].
+fn tool_content_to_rmcp(tc: &ToolContent) -> Content {
+    match tc {
+        ToolContent::Text { text } => Content::text(text.clone()),
+        ToolContent::Image { data, mime_type } => Content::image(data.clone(), mime_type.clone()),
+        ToolContent::Resource { resource } => {
+            // Best-effort: try to interpret as TextResourceContents
+            let uri = resource
+                .get("uri")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown://resource")
+                .to_string();
+            let text = resource
+                .get("text")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let mime_type = resource
+                .get("mimeType")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            Content::resource(ResourceContents::TextResourceContents {
+                uri,
+                mime_type,
+                text,
+                meta: None,
+            })
+        }
+        ToolContent::ResourceLink {
+            uri,
+            name,
+            mime_type,
+            description,
+        } => {
+            // Use resource_link content type
+            Content::resource_link(RawResource {
+                uri: uri.clone(),
+                name: name.clone().unwrap_or_default(),
+                title: None,
+                description: description.clone(),
+                mime_type: mime_type.clone(),
+                size: None,
+                icons: None,
+                meta: None,
+            })
+        }
+    }
+}
+
+// ── rmcp::CallToolResult → our CallToolResult (reverse) ──────────────────────
+
+/// Convert rmcp's [`CallToolResult`](RmcpCallToolResult) back to our
+/// [`CallToolResult`](DccCallToolResult) for proxy/compatibility scenarios.
+pub fn rmcp_result_to_dcc(result: &RmcpCallToolResult) -> DccCallToolResult {
+    let content: Vec<ToolContent> = result
+        .content
+        .iter()
+        .map(rmcp_content_to_tool_content)
+        .collect();
+
+    DccCallToolResult {
+        content,
+        structured_content: result.structured_content.clone(),
+        is_error: result.is_error.unwrap_or(false),
+        meta: result.meta.as_ref().map(|m| m.0.clone()),
+    }
+}
+
+/// Convert rmcp [`Content`] back to our [`ToolContent`].
+fn rmcp_content_to_tool_content(content: &Content) -> ToolContent {
+    match &content.raw {
+        RawContent::Text(t) => ToolContent::Text {
+            text: t.text.clone(),
+        },
+        RawContent::Image(i) => ToolContent::Image {
+            data: i.data.clone(),
+            mime_type: i.mime_type.clone(),
+        },
+        RawContent::Resource(r) => {
+            let resource = serde_json::to_value(&r.resource).unwrap_or_default();
+            ToolContent::Resource { resource }
+        }
+        RawContent::Audio(a) => {
+            // Audio has no direct equivalent in our type; represent as text
+            ToolContent::Text {
+                text: format!("[audio: {}, {} bytes]", a.mime_type, a.data.len()),
+            }
+        }
+        RawContent::ResourceLink(link) => ToolContent::ResourceLink {
+            uri: link.uri.clone(),
+            name: Some(link.name.clone()),
+            mime_type: link.mime_type.clone(),
+            description: link.description.clone(),
+        },
+    }
+}
+
+// ── Helper trait extensions for optional builder patterns ─────────────────────
+
+trait ToolBuilderExt {
+    fn with_raw_output_schema_opt(
+        self,
+        output_schema: Option<Arc<rmcp::model::JsonObject>>,
+    ) -> Self;
+    fn with_annotations_opt(self, annotations: Option<RmcpToolAnnotations>) -> Self;
+    fn with_meta_opt(self, meta: Option<Meta>) -> Self;
+}
+
+impl ToolBuilderExt for RmcpTool {
+    fn with_raw_output_schema_opt(
+        mut self,
+        output_schema: Option<Arc<rmcp::model::JsonObject>>,
+    ) -> Self {
+        if let Some(schema) = output_schema {
+            self.output_schema = Some(schema);
+        }
+        self
+    }
+
+    fn with_annotations_opt(mut self, annotations: Option<RmcpToolAnnotations>) -> Self {
+        if let Some(ann) = annotations {
+            self.annotations = Some(ann);
+        }
+        self
+    }
+
+    fn with_meta_opt(mut self, meta: Option<Meta>) -> Self {
+        if let Some(m) = meta {
+            self.meta = Some(m);
+        }
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tool_conversion_name_description() {
+        let tool = McpTool {
+            name: "test_tool".to_string(),
+            description: "A test tool".to_string(),
+            input_schema: serde_json::json!({"type": "object", "properties": {}}),
+            output_schema: None,
+            annotations: None,
+            meta: None,
+        };
+
+        let rmcp_tool = tool_to_rmcp(&tool);
+        assert_eq!(rmcp_tool.name.as_ref(), "test_tool");
+        assert_eq!(rmcp_tool.description.as_deref(), Some("A test tool"));
+    }
+
+    #[test]
+    fn test_call_result_text_roundtrip() {
+        let result = DccCallToolResult::text("hello world");
+        let rmcp_result = call_result_to_rmcp(&result);
+        let back = rmcp_result_to_dcc(&rmcp_result);
+
+        assert_eq!(back.content.len(), 1);
+        assert!(!back.is_error);
+        match &back.content[0] {
+            ToolContent::Text { text } => assert_eq!(text, "hello world"),
+            _ => panic!("expected Text content"),
+        }
+    }
+
+    #[test]
+    fn test_call_result_error() {
+        let result = DccCallToolResult::error("something failed");
+        let rmcp_result = call_result_to_rmcp(&result);
+
+        assert_eq!(rmcp_result.is_error, Some(true));
+        assert_eq!(rmcp_result.content.len(), 1);
+    }
+}

--- a/crates/dcc-mcp-http-server/src/rmcp_handler.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_handler.rs
@@ -1,0 +1,153 @@
+//! rmcp [`ServerHandler`] adapter that bridges to our existing [`ServerState`].
+//!
+//! This module implements rmcp's `ServerHandler` trait by delegating each MCP
+//! method to the appropriate existing subsystem (ToolRegistry, ToolDispatcher,
+//! SkillCatalog). It is the core adapter enabling rmcp's transport to drive our
+//! DCC business logic without modifying the business logic itself.
+//!
+//! # Gating
+//!
+//! This entire module is compiled only when the `rmcp-transport` feature is
+//! enabled.
+
+use std::future::Future;
+use std::sync::Arc;
+
+use rmcp::model::{
+    CallToolRequestParams, CallToolResult as RmcpCallToolResult, Content, Implementation,
+    ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool as RmcpTool,
+    ToolsCapability,
+};
+use rmcp::service::RequestContext;
+use rmcp::{ErrorData as McpError, RoleServer, ServerHandler};
+use serde_json::Value;
+use tracing::{debug, warn};
+
+use crate::server_state::ServerState;
+
+/// Adapter that implements rmcp's [`ServerHandler`] trait by delegating to our
+/// existing [`ServerState`].
+///
+/// Created per-session by the service factory closure passed to
+/// `StreamableHttpService::new()`.
+pub struct DccMcpHandler {
+    state: ServerState,
+}
+
+impl DccMcpHandler {
+    /// Create a new handler instance backed by the given server state.
+    pub fn new(state: ServerState) -> Self {
+        Self { state }
+    }
+}
+
+impl ServerHandler for DccMcpHandler {
+    fn get_info(&self) -> ServerInfo {
+        let mut capabilities = ServerCapabilities::default();
+        capabilities.tools = Some(ToolsCapability {
+            list_changed: Some(true),
+        });
+        if self.state.enable_resources {
+            capabilities.resources = Some(rmcp::model::ResourcesCapability {
+                subscribe: Some(false),
+                list_changed: Some(true),
+            });
+        }
+        if self.state.enable_prompts {
+            capabilities.prompts = Some(rmcp::model::PromptsCapability {
+                list_changed: Some(false),
+            });
+        }
+        capabilities.logging = Some(serde_json::Map::new());
+
+        let mut info = ServerInfo::new(capabilities);
+        info.server_info = Implementation::new(
+            self.state.server_name.clone(),
+            self.state.server_version.clone(),
+        );
+        info.instructions = Some(
+            "Use search_skills to discover available DCC tools, \
+             then load_skill to activate a skill before calling its tools."
+                .to_string(),
+        );
+        info
+    }
+
+    fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> impl Future<Output = Result<ListToolsResult, McpError>> + Send + '_ {
+        async {
+            // Gather tools from the registry (all enabled actions)
+            let actions = self.state.registry.list_actions_enabled(None);
+
+            let tools: Vec<RmcpTool> = actions
+                .iter()
+                .map(|meta| {
+                    let input_schema: Arc<rmcp::model::JsonObject> = match &meta.input_schema {
+                        Value::Object(map) => Arc::new(map.clone()),
+                        _ => Arc::new(
+                            serde_json::json!({"type": "object", "properties": {}})
+                                .as_object()
+                                .unwrap()
+                                .clone(),
+                        ),
+                    };
+
+                    RmcpTool::new(meta.name.clone(), meta.description.clone(), input_schema)
+                })
+                .collect();
+
+            debug!(count = tools.len(), "rmcp: listed tools from registry");
+
+            Ok(ListToolsResult {
+                meta: None,
+                next_cursor: None,
+                tools,
+            })
+        }
+    }
+
+    fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> impl Future<Output = Result<RmcpCallToolResult, McpError>> + Send + '_ {
+        async move {
+            let tool_name = request.name.as_ref();
+            let arguments: Value = request
+                .arguments
+                .map(Value::Object)
+                .unwrap_or(Value::Object(serde_json::Map::new()));
+
+            debug!(tool = %tool_name, "rmcp: dispatching tool call");
+
+            // Dispatch through the existing synchronous dispatcher.
+            // Note: The dispatcher is sync; we call it from the async context.
+            // For main-thread affinity tools, the existing executor pattern would
+            // need to be wired in Phase 2. For the spike, we dispatch directly.
+            let result = self.state.dispatcher.dispatch(tool_name, arguments);
+
+            match result {
+                Ok(dispatch_result) => {
+                    // Convert the raw Value output to a CallToolResult
+                    let content = vec![Content::text(dispatch_result.output.to_string())];
+
+                    let mut out = RmcpCallToolResult::default();
+                    out.content = content;
+                    out.structured_content = Some(dispatch_result.output);
+                    Ok(out)
+                }
+                Err(e) => {
+                    warn!(tool = %tool_name, error = %e, "rmcp: tool dispatch failed");
+                    // Return error as tool result (not an RPC error)
+                    let mut out = RmcpCallToolResult::default();
+                    out.content = vec![Content::text(e.to_string())];
+                    out.is_error = Some(true);
+                    Ok(out)
+                }
+            }
+        }
+    }
+}

--- a/crates/dcc-mcp-http/Cargo.toml
+++ b/crates/dcc-mcp-http/Cargo.toml
@@ -63,6 +63,9 @@ pin-project-lite = "0.2"
 # PyO3 (optional)
 pyo3 = { workspace = true, optional = true }
 
+# Official MCP SDK (optional, gated behind `rmcp-transport` feature)
+rmcp = { workspace = true, optional = true }
+
 # Type-stub generation (opt-in via `stub-gen` feature).
 pyo3-stub-gen = { workspace = true, optional = true }
 pyo3-stub-gen-derive = { workspace = true, optional = true }
@@ -88,6 +91,10 @@ pyo3 = { workspace = true, features = ["auto-initialize"] }
 
 [features]
 default = []
+# Use the official rmcp SDK for MCP transport (issue #985).
+# Mounts a parallel /mcp-next endpoint that speaks MCP 2025-11-25 via rmcp's
+# StreamableHttpService while the existing /mcp path is unaffected.
+rmcp-transport = ["dep:rmcp", "dcc-mcp-http-server/rmcp-transport"]
 python-bindings = ["pyo3", "dcc-mcp-actions/python-bindings", "dcc-mcp-skills/python-bindings", "dcc-mcp-artefact/python-bindings", "dep:dcc-mcp-pybridge", "dcc-mcp-pybridge/python-bindings", "dcc-mcp-host/python-bindings"]
 # Enable `pyo3-stub-gen` annotations on this crate's PyO3 types.
 stub-gen = ["python-bindings", "dep:pyo3-stub-gen", "dep:pyo3-stub-gen-derive"]

--- a/crates/dcc-mcp-http/src/handler/mod.rs
+++ b/crates/dcc-mcp-http/src/handler/mod.rs
@@ -25,6 +25,10 @@ mod router;
 mod routes;
 mod state;
 
+// rmcp spike endpoint (issue #985) — compiled only with `rmcp-transport`.
+#[cfg(feature = "rmcp-transport")]
+pub mod rmcp_mount;
+
 pub use router::{HandlerFuture, MethodHandler, MethodRouter};
 pub use routes::{handle_delete, handle_get, handle_post};
 pub use state::AppState;

--- a/crates/dcc-mcp-http/src/handler/rmcp_mount.rs
+++ b/crates/dcc-mcp-http/src/handler/rmcp_mount.rs
@@ -1,0 +1,49 @@
+//! Mounts the rmcp-backed MCP endpoint at `/mcp-next` (spike).
+//!
+//! This module creates a [`StreamableHttpService`] backed by our
+//! [`DccMcpHandler`] and attaches it to the axum router as a nested service.
+//! The existing `/mcp` endpoint is entirely unaffected.
+//!
+//! # Usage (called from `server/mod.rs` behind `#[cfg(feature = "rmcp-transport")]`)
+//!
+//! ```ignore
+//! router = rmcp_mount::attach_rmcp_endpoint(router, &server_state);
+//! ```
+
+use std::sync::Arc;
+
+use axum::Router;
+use dcc_mcp_http_server::rmcp_handler::DccMcpHandler;
+use dcc_mcp_http_server::server_state::ServerState;
+use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
+use tracing::info;
+
+/// Attach the rmcp spike endpoint at `/mcp-next`.
+///
+/// The endpoint handles `initialize`, `tools/list`, `tools/call` and all other
+/// MCP methods via the [`DccMcpHandler`] adapter. Sessions are managed by
+/// rmcp's [`LocalSessionManager`].
+///
+/// The router passed in is already state-erased (`Router<()>`) because
+/// `.with_state()` was called earlier in the builder chain.
+pub fn attach_rmcp_endpoint(router: Router, server_state: &ServerState) -> Router {
+    let state = server_state.clone();
+
+    let session_manager = Arc::new(LocalSessionManager::default());
+
+    let mut config = StreamableHttpServerConfig::default();
+    config.stateful_mode = true;
+    // Allow any host during spike (production should restrict this)
+    config.allowed_hosts = vec![];
+
+    let service = StreamableHttpService::new(
+        move || Ok(DccMcpHandler::new(state.clone())),
+        session_manager,
+        config,
+    );
+
+    info!("rmcp spike endpoint mounted at /mcp-next");
+
+    router.nest_service("/mcp-next", service)
+}

--- a/crates/dcc-mcp-http/src/server/mod.rs
+++ b/crates/dcc-mcp-http/src/server/mod.rs
@@ -500,6 +500,10 @@ impl McpHttpServer {
             readiness,
         };
 
+        // Clone ServerState for the rmcp spike endpoint before `state` is moved.
+        #[cfg(feature = "rmcp-transport")]
+        let rmcp_server_state = state.server.clone();
+
         let endpoint = self.config.server.endpoint_path.clone();
 
         let mut router = Router::new()
@@ -532,6 +536,13 @@ impl McpHttpServer {
                 &self.config,
                 prometheus_gauge_ctx.clone(),
             );
+        }
+
+        // rmcp spike endpoint at `/mcp-next` (issue #985). Parallel to the
+        // existing `/mcp` — speaks MCP 2025-11-25 via the official rmcp SDK.
+        #[cfg(feature = "rmcp-transport")]
+        {
+            router = crate::handler::rmcp_mount::attach_rmcp_endpoint(router, &rmcp_server_state);
         }
 
         if self.config.server.enable_cors {

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -50,9 +50,9 @@ rand_chacha = { version = "0.9.0", default-features = false, features = ["std"] 
 rand_core = { version = "0.6.4", default-features = false, features = ["std"] }
 regex-automata = { version = "0.4.14", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
 regex-syntax = { version = "0.8.10" }
-serde = { version = "1.0.228", features = ["alloc", "derive"] }
-serde_core = { version = "1.0.228", features = ["alloc"] }
-serde_json = { version = "1.0.149", features = ["raw_value"] }
+serde = { version = "1.0.228", features = ["alloc", "derive", "rc"] }
+serde_core = { version = "1.0.228", features = ["alloc", "rc"] }
+serde_json = { version = "1.0.149", features = ["alloc", "raw_value"] }
 slab = { version = "0.4.12" }
 smallvec = { version = "1.15.1", default-features = false, features = ["const_new"] }
 subtle = { version = "2.6.1" }
@@ -110,9 +110,9 @@ rand_chacha = { version = "0.9.0", default-features = false, features = ["std"] 
 rand_core = { version = "0.6.4", default-features = false, features = ["std"] }
 regex-automata = { version = "0.4.14", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
 regex-syntax = { version = "0.8.10" }
-serde = { version = "1.0.228", features = ["alloc", "derive"] }
-serde_core = { version = "1.0.228", features = ["alloc"] }
-serde_json = { version = "1.0.149", features = ["raw_value"] }
+serde = { version = "1.0.228", features = ["alloc", "derive", "rc"] }
+serde_core = { version = "1.0.228", features = ["alloc", "rc"] }
+serde_json = { version = "1.0.149", features = ["alloc", "raw_value"] }
 slab = { version = "0.4.12" }
 smallvec = { version = "1.15.1", default-features = false, features = ["const_new"] }
 subtle = { version = "2.6.1" }

--- a/docs/adr/009-rmcp-migration.md
+++ b/docs/adr/009-rmcp-migration.md
@@ -1,0 +1,89 @@
+# ADR-009: Migrate MCP Transport to rmcp SDK
+
+- **Status:** Accepted
+- **Date:** 2026-05-14
+- **Issue:** [#985](https://github.com/loonghao/dcc-mcp-core/issues/985)
+
+## Context
+
+dcc-mcp-core maintains ~4k lines of MCP protocol framing (session lifecycle, SSE
+streaming, JSON-RPC method dispatch, protocol version negotiation) across
+`dcc-mcp-jsonrpc`, `dcc-mcp-http-server`, and `dcc-mcp-http`. Each MCP spec
+revision (2025-03-26, 2025-06-18, 2025-11-25) requires manual updates to types,
+dispatch logic, and transport headers.
+
+The official Rust MCP SDK [`rmcp`](https://crates.io/crates/rmcp) now provides a
+production-quality implementation of Streamable HTTP transport via its
+`transport-streamable-http-server` feature. It tracks spec versions, handles
+session lifecycle, and exposes a `ServerHandler` trait for method dispatch.
+
+## Decision
+
+Replace the MCP transport layer with rmcp's `StreamableHttpService` behind the
+`rmcp-transport` Cargo feature flag. DCC-specific business logic remains in our
+crates; only the wire-level concerns move to rmcp.
+
+## Boundary Definition
+
+| Concern | Owner after migration |
+|---------|----------------------|
+| HTTP transport, SSE framing, `Mcp-Session-Id` header | rmcp |
+| Session lifecycle (create / resume / evict) | rmcp `SessionManager` |
+| JSON-RPC frame parsing and method routing | rmcp |
+| Protocol version negotiation | rmcp (`ProtocolVersion::KNOWN_VERSIONS`) |
+| Tool registry, dispatch, readiness gating | dcc-mcp-http-server (unchanged) |
+| DCC executor, thread-affinity routing | dcc-mcp-http-server (unchanged) |
+| Skill catalog, lazy actions, progressive disclosure | dcc-mcp-http-server (unchanged) |
+| Vendor extensions (deltaToolsUpdate, dynamic tools) | Adapter layer (new) |
+| Multi-DCC gateway routing, `/v1/*` REST, admin, audit | dcc-mcp-http (unchanged) |
+| Python/PyO3 bindings | dcc-mcp-core (unchanged, public API stable) |
+
+## Approach
+
+1. **Feature-flagged**: `rmcp-transport` feature in `dcc-mcp-http` and
+   `dcc-mcp-http-server`. Off by default initially; default-on after parity is
+   proven.
+2. **Adapter pattern**: `DccMcpHandler` implements rmcp's `ServerHandler` trait
+   and delegates to our existing `ServerState` (registry, dispatcher, catalog).
+3. **Type conversion**: Thin `rmcp_adapter` module converts between our types
+   (`McpTool`, `CallToolResult`, `ToolContent`) and rmcp's (`Tool`,
+   `CallToolResult`, `Content`).
+4. **Parallel mount (spike)**: `/mcp-next` endpoint runs rmcp alongside the
+   existing `/mcp`; once stable, the paths merge.
+5. **Version routing (later)**: Middleware routes `2025-11-25` sessions to rmcp
+   and `2025-06-18`/`2025-03-26` sessions to the legacy stack until legacy is
+   removed.
+
+## Consequences
+
+### Positive
+
+- Spec protocol updates are handled by upgrading the `rmcp` dependency version.
+- Session management, SSE keep-alive, and MCP-Protocol-Version header validation
+  are maintained upstream.
+- Reduced internal code surface to maintain and test.
+
+### Negative
+
+- Vendor extensions (`dcc_mcp_core/deltaToolsUpdate`, elicitation, dynamic tools)
+  require adapter hooks outside rmcp's standard trait methods.
+- An additional dependency (~20 transitive crates) in the compile graph when the
+  feature is enabled.
+- Breaking rmcp major version bumps require adapter updates.
+
+### Neutral
+
+- Tool authors' workflow is unchanged: register tools via `ToolRegistry` /
+  `SKILL.md` as before.
+- Python binding consumers see no change (PyO3 surface uses public Rust API).
+
+## Alternatives Considered
+
+1. **Fork rmcp**: Full control but doubles maintenance burden.
+2. **Partial adoption** (types only, no transport): Saves less code, still need
+   to maintain SSE / session logic.
+3. **Stay on in-house stack**: Higher maintenance cost per spec revision, but
+   zero new dependencies.
+
+Option 2 was rejected because the transport layer is the primary maintenance cost.
+Option 1 is a fallback if rmcp's extension points prove insufficient.


### PR DESCRIPTION
## Summary

- Add the official Rust MCP SDK (`rmcp` v1.7) as an optional dependency behind the `rmcp-transport` feature flag (Issue #985 Phase 0+1)
- Implement `DccMcpHandler` adapter bridging rmcp's `ServerHandler` trait to our existing `ServerState`
- Mount a parallel `/mcp-next` endpoint using rmcp's `StreamableHttpService` (MCP 2025-11-25)
- Write ADR-009 documenting the migration boundary between rmcp and DCC-specific code

## Details

This PR introduces the foundational infrastructure for migrating the in-house MCP protocol stack to the official `rmcp` SDK. The existing `/mcp` endpoint is **completely unaffected** — all new code is gated behind `--features rmcp-transport`.

### New modules

| File | Purpose |
|------|---------|
| `docs/adr/009-rmcp-migration.md` | Boundary decision record |
| `crates/dcc-mcp-http-server/src/rmcp_adapter.rs` | Type conversions (`McpTool` ↔ `rmcp::Tool`, `CallToolResult` ↔ `rmcp::CallToolResult`) |
| `crates/dcc-mcp-http-server/src/rmcp_handler.rs` | `DccMcpHandler` — implements `ServerHandler`, delegates to `ToolRegistry`/`ToolDispatcher` |
| `crates/dcc-mcp-http/src/handler/rmcp_mount.rs` | Mounts `StreamableHttpService` at `/mcp-next` |

### What's next (follow-up PRs)

- Phase 2: Complete handler methods (resources, prompts, elicitation), session state bridge
- Phase 3: Protocol version routing middleware (2025-11-25 → rmcp, older → legacy)
- Phase 4: VRS regression tests + dual-stack comparison
- Phase 5: Switch rmcp-transport to default-on, deprecate legacy path

## Test plan

- [x] `cargo check --workspace` — default build unaffected
- [x] `cargo check -p dcc-mcp-http --features rmcp-transport` — rmcp path compiles
- [x] `cargo test -p dcc-mcp-http-server --features rmcp-transport` — 29 tests pass (3 new adapter roundtrip tests)
- [ ] CI `rust-rmcp` job validates feature-gated compilation on ubuntu

Closes #985 (Phase 0+1 only — further phases tracked in the issue)