### PR TITLE
feat(admin): SQLite persistence, skill-path CRUD & CI maturin fix

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -84,23 +84,22 @@ runs:
         echo "value=${args}" >> "$GITHUB_OUTPUT"
 
     - name: Verify cargo is in PATH (macOS maturin fix)
+      if: runner.os == 'macOS'
       shell: bash
       run: |
         # maturin calls 'cargo metadata' but on macOS cargo sometimes
         # resolves to rustup-init wrapper that hasn't been replaced yet.
         # Force rustup to install the default toolchain proxy.
         rustup show active-toolchain || rustup default stable
-        # Rehash to pick up the freshly-installed proxy binaries.
         hash -r 2>/dev/null || true
-        which cargo
-        cargo_version=$(cargo --version 2>&1)
-        echo "cargo version: ${cargo_version}"
-        if ! echo "${cargo_version}" | grep -q "^cargo "; then
-          echo "::error::cargo is not working correctly: ${cargo_version}"
-          # Attempt recovery: explicitly set PATH to include cargo bin
-          export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
-          cargo --version || exit 1
-        fi
+        # Pin CARGO/RUSTC so maturin's subprocess uses the real binary,
+        # not a Homebrew shim that is actually rustup-init.
+        CARGO_BIN="$(rustup which cargo 2>/dev/null || which cargo)"
+        RUSTC_BIN="$(rustup which rustc 2>/dev/null || which rustc)"
+        echo "CARGO=${CARGO_BIN}" >> "$GITHUB_ENV"
+        echo "RUSTC=${RUSTC_BIN}" >> "$GITHUB_ENV"
+        echo "cargo: ${CARGO_BIN}"
+        "${CARGO_BIN}" --version
 
     # manylinux Docker builds do not have `vx` on PATH. Pre-bundle the Vite admin
     # UI on the GitHub runner (vx + Node from vx.toml), then tell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,17 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
+      - name: Fix cargo PATH on macOS
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          # macOS runners have a Homebrew `cargo` shim (actually rustup-init)
+          # that shadows ~/.cargo/bin/cargo. Pin CARGO env so all tools
+          # (cargo-hakari, vx just preflight, etc.) use the real binary.
+          CARGO_BIN="$(rustup which cargo)"
+          echo "CARGO=${CARGO_BIN}" >> "$GITHUB_ENV"
+          echo "RUSTC=$(rustup which rustc)" >> "$GITHUB_ENV"
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
       - uses: loonghao/vx@v0.8.36
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
@@ -123,7 +134,12 @@ jobs:
           # rustup-init shim, which does NOT dispatch to `cargo-<subcmd>` in
           # ~/.cargo/bin and instead errors with `unexpected argument 'hakari'`.
           # Calling cargo-hakari directly bypasses that PATH ordering issue.
+          # Also pin CARGO env so hakari's internal `cargo metadata` uses the
+          # real binary, not the Homebrew shim.
           export PATH="$HOME/.cargo/bin:$PATH"
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            export CARGO="$(rustup which cargo 2>/dev/null || which cargo)"
+          fi
           cargo-hakari hakari verify && exit 0
 
           # If we get here, verify failed. Run generate and show the diff.
@@ -253,7 +269,7 @@ jobs:
           maturin-extra-args: '-i python3.7'
           test-wheel: 'true'
           artifact-name: wheel-py37-${{ matrix.os }}
-          use-sccache: 'true'
+          use-sccache: 'false'
 
   # ── Lint Python source ──
   lint:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,6 +861,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dcc-mcp-db"
+version = "0.17.0"
+dependencies = [
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+ "workspace-hack",
+]
+
+[[package]]
 name = "dcc-mcp-gateway"
 version = "0.17.0"
 dependencies = [
@@ -869,6 +882,7 @@ dependencies = [
  "criterion",
  "dashmap",
  "dcc-mcp-catalog",
+ "dcc-mcp-db",
  "dcc-mcp-gateway-core",
  "dcc-mcp-jsonrpc",
  "dcc-mcp-naming",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "crates/dcc-mcp-tunnel-relay",
     "crates/dcc-mcp-tunnel-agent",
     "crates/dcc-mcp-catalog",
+    "crates/dcc-mcp-db",
     "crates/workspace-hack",
 ]
 resolver = "2"
@@ -81,6 +82,7 @@ dcc-mcp-tunnel-protocol = { path = "crates/dcc-mcp-tunnel-protocol" }
 dcc-mcp-tunnel-relay = { path = "crates/dcc-mcp-tunnel-relay" }
 dcc-mcp-tunnel-agent = { path = "crates/dcc-mcp-tunnel-agent" }
 dcc-mcp-catalog = { path = "crates/dcc-mcp-catalog" }
+dcc-mcp-db = { path = "crates/dcc-mcp-db" }
 dcc-mcp-gateway = { path = "crates/dcc-mcp-gateway" }
 dcc-mcp-gateway-search = { path = "crates/dcc-mcp-gateway-search" }
 

--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
 import mayaIcon from './assets/icons/autodesk.svg';
 import blenderIcon from './assets/icons/blender.svg';
 import gimpIcon from './assets/icons/gimp.svg';
@@ -9,7 +9,7 @@ import unrealIcon from './assets/icons/unrealengine.svg';
 import substancePainterIcon from './assets/icons/photoshop.svg';
 import puzzleIcon from './assets/icons/puzzle.svg';
 
-type Panel = 'health' | 'instances' | 'tools' | 'calls' | 'traces' | 'stats' | 'workers' | 'logs';
+type Panel = 'health' | 'instances' | 'tools' | 'calls' | 'traces' | 'stats' | 'logs' | 'skill-paths';
 
 type HealthPayload = {
   status: string;
@@ -27,15 +27,6 @@ type HealthPayload = {
     circuit_open_secs: number;
   };
   circuits?: { tracked_backends: number; circuits_open: number };
-};
-
-type InstanceRow = {
-  id: string;
-  dcc_type: string;
-  status: string;
-  host: string;
-  port: number;
-  scene: string | null;
 };
 
 type ToolRow = {
@@ -110,6 +101,7 @@ type WorkerRow = {
   cpu_percent: number | null;
   memory_bytes: number | null;
   mcp_url: string;
+  scene?: string | null;
 };
 
 type WorkerSummary = {
@@ -132,6 +124,36 @@ type LogRow = {
   detail?: string;
   reason?: string | null;
 };
+
+type SkillPathRow = {
+  path: string;
+  source: string;
+  id?: number;
+};
+
+function normalizeLogRow(raw: unknown): LogRow {
+  if (!raw || typeof raw !== 'object') {
+    return { timestamp: '', level: '', message: '' };
+  }
+  const o = raw as Record<string, unknown>;
+  return {
+    timestamp: String(o.timestamp ?? ''),
+    level: String(o.level ?? ''),
+    message: String(o.message ?? ''),
+    source: o.source != null ? String(o.source) : undefined,
+    event: o.event != null ? String(o.event) : undefined,
+    dcc_type: o.dcc_type != null ? String(o.dcc_type) : undefined,
+    instance_id:
+      o.instance_id === null || o.instance_id === undefined
+        ? null
+        : String(o.instance_id),
+    request_id: o.request_id != null ? String(o.request_id) : undefined,
+    tool: o.tool != null ? String(o.tool) : undefined,
+    success: typeof o.success === 'boolean' ? o.success : undefined,
+    detail: o.detail != null ? String(o.detail) : undefined,
+    reason: o.reason == null ? null : String(o.reason),
+  };
+}
 
 /// DCC-type → icon URL (local SVGs, bundled by Vite + vite-plugin-singlefile).
 /// Unknown/missing types fall back to a generic puzzle-piece icon.
@@ -159,7 +181,19 @@ function resolveDccIcon(dccType: string): string {
   return DCC_ICON_FALLBACK;
 }
 
-const API_BASE = `${location.origin}/admin/api`;
+/// Resolve JSON API base from the current admin URL so custom `--admin-path`
+/// (e.g. `/gw-admin`) works. A fixed `/admin/api` prefix 404s on non-default mounts.
+function adminApiBase(): string {
+  const { origin, pathname } = window.location;
+  let basePath = pathname.replace(/\/+$/, '');
+  if (!basePath || basePath === '/') {
+    basePath = '/admin';
+  }
+  const prefix = basePath.endsWith('/') ? basePath : `${basePath}/`;
+  return `${origin}${prefix}api`;
+}
+
+const API_BASE = adminApiBase();
 /** Abort hung admin fetches so the UI does not wait indefinitely on a wedged gateway. */
 const ADMIN_FETCH_TIMEOUT_MS = 25_000;
 const PANELS: { id: Panel; label: string }[] = [
@@ -169,9 +203,90 @@ const PANELS: { id: Panel; label: string }[] = [
   { id: 'calls', label: 'Calls' },
   { id: 'traces', label: 'Traces' },
   { id: 'stats', label: 'Stats' },
-  { id: 'workers', label: 'Workers' },
+  { id: 'skill-paths', label: 'Skill paths' },
   { id: 'logs', label: 'Logs' },
 ];
+
+const PANEL_ID_SET = new Set<Panel>(PANELS.map((p) => p.id));
+
+const STATS_RANGE_IDS = new Set(['1h', '24h', '7d', 'all']);
+
+function isPanelId(value: string | null | undefined): value is Panel {
+  return value != null && value !== '' && PANEL_ID_SET.has(value as Panel);
+}
+
+/** Admin HTML path without `/api` (honours custom `--admin-path`). */
+function adminShellPath(): string {
+  const { pathname } = window.location;
+  let base = pathname.replace(/\/+$/, '');
+  if (!base || base === '/') {
+    base = '/admin';
+  }
+  return base.startsWith('/') ? base : `/${base}`;
+}
+
+/** Shareable relative URL: `/admin?panel=stats&range=7d`. */
+function hrefForAdmin(panel: Panel, extra?: Record<string, string | undefined>): string {
+  const u = new URL(`${window.location.origin}${adminShellPath()}`);
+  u.searchParams.set('panel', panel);
+  if (extra) {
+    for (const [k, v] of Object.entries(extra)) {
+      if (v != null && v !== '') {
+        u.searchParams.set(k, v);
+      }
+    }
+  }
+  return `${u.pathname}${u.search}`;
+}
+
+function readPanelFromUrl(): Panel {
+  const u = new URL(window.location.href);
+  const raw = u.searchParams.get('panel') ?? u.searchParams.get('tab');
+  if (raw === 'workers') {
+    return 'instances';
+  }
+  return isPanelId(raw) ? raw : 'health';
+}
+
+function readStatsRangeFromUrl(): string {
+  const u = new URL(window.location.href);
+  const r = u.searchParams.get('range');
+  return r && STATS_RANGE_IDS.has(r) ? r : '24h';
+}
+
+function readTraceIdFromUrl(): string | null {
+  const u = new URL(window.location.href);
+  const t = u.searchParams.get('trace');
+  return t != null && t.trim() !== '' ? t.trim() : null;
+}
+
+type AdminQuickLinkProps = {
+  panel: Panel;
+  traceId?: string;
+  range?: string;
+  className?: string;
+  children: ReactNode;
+  onNavigate: (panel: Panel, opts?: { traceId?: string; range?: string }) => void;
+};
+
+function AdminQuickLink({ panel, traceId, range, className, children, onNavigate }: AdminQuickLinkProps) {
+  const extra: Record<string, string | undefined> = {};
+  if (traceId) extra.trace = traceId;
+  if (range) extra.range = range;
+  const href = hrefForAdmin(panel, extra);
+  return (
+    <a
+      href={href}
+      className={className ?? 'admin-quick-link'}
+      onClick={(e) => {
+        e.preventDefault();
+        onNavigate(panel, { traceId, range });
+      }}
+    >
+      {children}
+    </a>
+  );
+}
 
 function haystack(...parts: (string | number | null | undefined)[]): string {
   return parts
@@ -187,6 +302,26 @@ function matchesListFilter(query: string, hay: string): boolean {
     return true;
   }
   return hay.includes(q);
+}
+
+/** Open host root, MCP endpoint, and `/docs` on the DCC HTTP server (same origin as MCP). */
+function McpBackendLinks({ mcpUrl }: { mcpUrl: string }) {
+  try {
+    const u = new URL(mcpUrl);
+    const origin = u.origin;
+    const docs = `${origin}/docs`;
+    return (
+      <span className="mcp-backend-links">
+        <a href={origin} target="_blank" rel="noopener noreferrer">host</a>
+        {' · '}
+        <a href={mcpUrl} target="_blank" rel="noopener noreferrer">MCP</a>
+        {' · '}
+        <a href={docs} target="_blank" rel="noopener noreferrer">docs</a>
+      </span>
+    );
+  } catch {
+    return <span className="mono-path">{mcpUrl}</span>;
+  }
 }
 
 async function apiJson<T>(path: string): Promise<T> {
@@ -363,17 +498,19 @@ function groupRows<T>(rows: T[], keyFn: (row: T) => string): Map<string, T[]> {
 }
 
 function App() {
-  const [activePanel, setActivePanel] = useState<Panel>('health');
+  const [activePanel, setActivePanel] = useState<Panel>(() => readPanelFromUrl());
   const [health, setHealth] = useState<HealthPayload | null>(null);
-  const [instances, setInstances] = useState<InstanceRow[]>([]);
   const [tools, setTools] = useState<ToolRow[]>([]);
   const [calls, setCalls] = useState<CallRow[]>([]);
   const [traces, setTraces] = useState<TraceRow[]>([]);
   const [stats, setStats] = useState<StatsPayload | null>(null);
-  const [statsRange, setStatsRange] = useState('24h');
+  const [statsRange, setStatsRange] = useState(() => readStatsRangeFromUrl());
   const [workers, setWorkers] = useState<WorkerRow[]>([]);
   const [workerSummary, setWorkerSummary] = useState<WorkerSummary>({ live: 0, stale: 0, unhealthy: 0 });
   const [logs, setLogs] = useState<LogRow[]>([]);
+  const [skillPaths, setSkillPaths] = useState<SkillPathRow[]>([]);
+  const [skillPathInput, setSkillPathInput] = useState('');
+  const [skillPathBusy, setSkillPathBusy] = useState(false);
   const [traceDetail, setTraceDetail] = useState<string>('Select a trace row for detail.');
   const [callDetail, setCallDetail] = useState<string>('Select a call row for trace detail.');
   const [updatedAt, setUpdatedAt] = useState<Record<Panel, string>>({
@@ -383,28 +520,23 @@ function App() {
     calls: 'Loading…',
     traces: 'Loading…',
     stats: 'Loading…',
-    workers: 'Loading…',
     logs: 'Loading…',
+    'skill-paths': 'Loading…',
   });
   const [errors, setErrors] = useState<Partial<Record<Panel, string>>>({});
   const [listSearch, setListSearch] = useState('');
 
   useEffect(() => {
+    const u = new URL(window.location.href);
+    if (u.searchParams.get('panel') === 'workers') {
+      u.searchParams.set('panel', 'instances');
+      window.history.replaceState({}, '', `${u.pathname}${u.search}`);
+    }
+  }, []);
+
+  useEffect(() => {
     setListSearch('');
   }, [activePanel]);
-
-  const filteredInstances = useMemo(() => {
-    const q = listSearch.trim().toLowerCase();
-    if (!q) {
-      return instances;
-    }
-    return instances.filter((i) =>
-      matchesListFilter(
-        q,
-        haystack(i.id, i.dcc_type, i.status, i.host, String(i.port), i.scene ?? ''),
-      ),
-    );
-  }, [instances, listSearch]);
 
   const filteredTools = useMemo(() => {
     const q = listSearch.trim().toLowerCase();
@@ -479,6 +611,7 @@ function App() {
           w.version ?? '',
           w.adapter_version ?? '',
           String(w.pid ?? ''),
+          w.scene ?? '',
         ),
       ),
     );
@@ -508,6 +641,16 @@ function App() {
       ),
     );
   }, [logs, listSearch]);
+
+  const filteredSkillPaths = useMemo(() => {
+    const q = listSearch.trim().toLowerCase();
+    if (!q) {
+      return skillPaths;
+    }
+    return skillPaths.filter((r) =>
+      matchesListFilter(q, haystack(r.path, r.source, r.id != null ? String(r.id) : '')),
+    );
+  }, [skillPaths, listSearch]);
 
   const filteredTopTools = useMemo(() => {
     const q = listSearch.trim().toLowerCase();
@@ -546,11 +689,15 @@ function App() {
     }
   }, [markError, markUpdated]);
 
-  const fetchInstances = useCallback(async () => {
+  const fetchInstanceBackends = useCallback(async () => {
     try {
-      const payload = await apiJson<{ instances: InstanceRow[] }>('/instances');
-      setInstances(payload.instances);
-      markUpdated('instances', `${payload.instances.length} instance(s) — ${new Date().toLocaleTimeString()}`);
+      const payload = await apiJson<{ workers: WorkerRow[]; summary: WorkerSummary }>('/workers');
+      setWorkers(payload.workers);
+      setWorkerSummary(payload.summary);
+      markUpdated(
+        'instances',
+        `${payload.workers.length} instance(s) (live ${payload.summary.live}, stale ${payload.summary.stale}, unhealthy ${payload.summary.unhealthy}) — ${new Date().toLocaleTimeString()}`,
+      );
     } catch (error) {
       markError('instances', error);
     }
@@ -596,29 +743,81 @@ function App() {
     }
   }, [markError, markUpdated, statsRange]);
 
-  const fetchWorkers = useCallback(async () => {
-    try {
-      const payload = await apiJson<{ workers: WorkerRow[]; summary: WorkerSummary }>('/workers');
-      setWorkers(payload.workers);
-      setWorkerSummary(payload.summary);
-      markUpdated(
-        'workers',
-        `${payload.workers.length} worker(s) (live ${payload.summary.live}, stale ${payload.summary.stale}, unhealthy ${payload.summary.unhealthy}) — ${new Date().toLocaleTimeString()}`,
-      );
-    } catch (error) {
-      markError('workers', error);
-    }
-  }, [markError, markUpdated]);
-
   const fetchLogs = useCallback(async () => {
     try {
-      const payload = await apiJson<{ logs: LogRow[] }>('/logs');
-      setLogs(payload.logs);
-      markUpdated('logs', `${payload.logs.length} event(s) — ${new Date().toLocaleTimeString()}`);
+      const payload = await apiJson<{ logs?: unknown[] }>('/logs');
+      const raw = Array.isArray(payload.logs) ? payload.logs : [];
+      setLogs(raw.map(normalizeLogRow));
+      markUpdated('logs', `${raw.length} event(s) — ${new Date().toLocaleTimeString()}`);
     } catch (error) {
       markError('logs', error);
     }
   }, [markError, markUpdated]);
+
+  const fetchSkillPaths = useCallback(async () => {
+    try {
+      const payload = await apiJson<{ paths: SkillPathRow[] }>('/skill-paths');
+      setSkillPaths(Array.isArray(payload.paths) ? payload.paths : []);
+      markUpdated(
+        'skill-paths',
+        `${payload.paths?.length ?? 0} path(s) — ${new Date().toLocaleTimeString()}`,
+      );
+    } catch (error) {
+      markError('skill-paths', error);
+    }
+  }, [markError, markUpdated]);
+
+  const addSkillPath = useCallback(async () => {
+    const path = skillPathInput.trim();
+    if (!path) {
+      return;
+    }
+    setSkillPathBusy(true);
+    try {
+      const ctrl = new AbortController();
+      const tid = window.setTimeout(() => ctrl.abort(), ADMIN_FETCH_TIMEOUT_MS);
+      const res = await fetch(`${API_BASE}/skill-paths`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path }),
+        signal: ctrl.signal,
+      });
+      clearTimeout(tid);
+      if (!res.ok) {
+        throw new Error(`${res.status} ${res.statusText}`);
+      }
+      setSkillPathInput('');
+      await fetchSkillPaths();
+    } catch (error) {
+      markError('skill-paths', error);
+    } finally {
+      setSkillPathBusy(false);
+    }
+  }, [fetchSkillPaths, markError, skillPathInput]);
+
+  const deleteSkillPath = useCallback(
+    async (id: number) => {
+      setSkillPathBusy(true);
+      try {
+        const ctrl = new AbortController();
+        const tid = window.setTimeout(() => ctrl.abort(), ADMIN_FETCH_TIMEOUT_MS);
+        const res = await fetch(`${API_BASE}/skill-paths/${encodeURIComponent(String(id))}`, {
+          method: 'DELETE',
+          signal: ctrl.signal,
+        });
+        clearTimeout(tid);
+        if (!res.ok) {
+          throw new Error(`${res.status} ${res.statusText}`);
+        }
+        await fetchSkillPaths();
+      } catch (error) {
+        markError('skill-paths', error);
+      } finally {
+        setSkillPathBusy(false);
+      }
+    },
+    [fetchSkillPaths, markError],
+  );
 
   const fetchTraceInto = useCallback(async (requestId: string, target: 'call' | 'trace') => {
     try {
@@ -639,16 +838,91 @@ function App() {
     }
   }, []);
 
+  const pushAdminUrl = useCallback(
+    (panel: Panel, opts?: { traceId?: string | null; range?: string | null; replace?: boolean }) => {
+      const u = new URL(window.location.href);
+      u.searchParams.set('panel', panel);
+      u.searchParams.delete('range');
+      u.searchParams.delete('trace');
+      if (panel === 'stats') {
+        const r = opts?.range;
+        if (r && STATS_RANGE_IDS.has(r)) {
+          u.searchParams.set('range', r);
+        }
+      }
+      if (panel === 'traces' && opts?.traceId) {
+        u.searchParams.set('trace', opts.traceId);
+      }
+      const next = `${u.pathname}${u.search}`;
+      const cur = `${window.location.pathname}${window.location.search}`;
+      if (next === cur) {
+        return;
+      }
+      if (opts?.replace) {
+        window.history.replaceState({ panel }, '', next);
+      } else {
+        window.history.pushState({ panel }, '', next);
+      }
+    },
+    [],
+  );
+
+  const goToPanel = useCallback(
+    (panel: Panel, opts?: { traceId?: string; range?: string; replace?: boolean }) => {
+      let effectiveRange = statsRange;
+      if (opts?.range && STATS_RANGE_IDS.has(opts.range)) {
+        effectiveRange = opts.range;
+        setStatsRange(opts.range);
+      }
+      setActivePanel(panel);
+      pushAdminUrl(panel, {
+        traceId: opts?.traceId,
+        range: panel === 'stats' ? effectiveRange : null,
+        replace: opts?.replace,
+      });
+      if (panel === 'traces' && opts?.traceId) {
+        void fetchTraceInto(opts.traceId, 'trace');
+      } else if (panel === 'traces' && !opts?.traceId) {
+        setTraceDetail('Select a trace row for detail.');
+      }
+    },
+    [fetchTraceInto, pushAdminUrl, statsRange],
+  );
+
+  useEffect(() => {
+    const onPop = () => {
+      const panel = readPanelFromUrl();
+      setActivePanel(panel);
+      setStatsRange(readStatsRangeFromUrl());
+      const tid = readTraceIdFromUrl();
+      if (panel === 'traces' && tid) {
+        void fetchTraceInto(tid, 'trace');
+      } else if (panel === 'traces') {
+        setTraceDetail('Select a trace row for detail.');
+      }
+    };
+    window.addEventListener('popstate', onPop);
+    return () => window.removeEventListener('popstate', onPop);
+  }, [fetchTraceInto]);
+
+  useEffect(() => {
+    const panel = readPanelFromUrl();
+    const tid = readTraceIdFromUrl();
+    if (panel === 'traces' && tid) {
+      void fetchTraceInto(tid, 'trace');
+    }
+  }, [fetchTraceInto]);
+
   const fetchPanel = useCallback((panel: Panel) => {
     if (panel === 'health') void fetchHealth();
-    if (panel === 'instances') void fetchInstances();
+    if (panel === 'instances') void fetchInstanceBackends();
     if (panel === 'tools') void fetchTools();
     if (panel === 'calls') void fetchCalls();
     if (panel === 'traces') void fetchTraces();
     if (panel === 'stats') void fetchStats();
-    if (panel === 'workers') void fetchWorkers();
+    if (panel === 'skill-paths') void fetchSkillPaths();
     if (panel === 'logs') void fetchLogs();
-  }, [fetchCalls, fetchHealth, fetchInstances, fetchLogs, fetchStats, fetchTools, fetchTraces, fetchWorkers]);
+  }, [fetchCalls, fetchHealth, fetchInstanceBackends, fetchLogs, fetchSkillPaths, fetchStats, fetchTools, fetchTraces]);
 
   useEffect(() => {
     fetchPanel(activePanel);
@@ -668,14 +942,18 @@ function App() {
         </div>
         <div className="nav-links">
           {PANELS.map((panel) => (
-            <button
+            <a
               key={panel.id}
+              href={hrefForAdmin(panel.id, panel.id === 'stats' ? { range: statsRange } : undefined)}
               className={panel.id === activePanel ? 'nav-link active' : 'nav-link'}
-              type="button"
-              onClick={() => setActivePanel(panel.id)}
+              aria-current={panel.id === activePanel ? 'page' : undefined}
+              onClick={(e) => {
+                e.preventDefault();
+                goToPanel(panel.id);
+              }}
             >
               {panel.label}
-            </button>
+            </a>
           ))}
         </div>
       </nav>
@@ -692,11 +970,11 @@ function App() {
             />
             {listSearch.trim() ? (
               <span className="list-search-meta">
-                {activePanel === 'instances' ? `${filteredInstances.length} / ${instances.length}` : ''}
+                {activePanel === 'instances' ? `${filteredWorkers.length} / ${workers.length}` : ''}
                 {activePanel === 'tools' ? `${filteredTools.length} / ${tools.length}` : ''}
                 {activePanel === 'calls' ? `${filteredCalls.length} / ${calls.length}` : ''}
                 {activePanel === 'traces' ? `${filteredTraces.length} / ${traces.length}` : ''}
-                {activePanel === 'workers' ? `${filteredWorkers.length} / ${workers.length}` : ''}
+                {activePanel === 'skill-paths' ? `${filteredSkillPaths.length} / ${skillPaths.length}` : ''}
                 {activePanel === 'logs' ? `${filteredLogs.length} / ${logs.length}` : ''}
                 {activePanel === 'stats' ? `charts: ${filteredTopTools.length} tools / ${filteredTopInstances.length} instances` : ''}
               </span>
@@ -731,41 +1009,62 @@ function App() {
               />
             </div>
             <button className="refresh-btn" type="button" onClick={fetchHealth}>Refresh</button>
+            <p className="admin-quick-nav-hint">
+              Quick links (shareable URLs):{' '}
+              <AdminQuickLink panel="instances" onNavigate={goToPanel}>Instances</AdminQuickLink>
+              {' · '}
+              <AdminQuickLink panel="tools" onNavigate={goToPanel}>Tools</AdminQuickLink>
+              {' · '}
+              <AdminQuickLink panel="calls" onNavigate={goToPanel}>Calls</AdminQuickLink>
+              {' · '}
+              <AdminQuickLink panel="traces" onNavigate={goToPanel}>Traces</AdminQuickLink>
+              {' · '}
+              <AdminQuickLink panel="stats" range={statsRange} onNavigate={goToPanel}>Stats</AdminQuickLink>
+              {' · '}
+              <AdminQuickLink panel="logs" onNavigate={goToPanel}>Logs</AdminQuickLink>
+              {' · '}
+              <AdminQuickLink panel="skill-paths" onNavigate={goToPanel}>Skill paths</AdminQuickLink>
+            </p>
           </section>
         )}
 
         {activePanel === 'instances' && (
           <section className="panel active">
             <h2>Instances</h2>
+            <p className="empty log-hint">
+              One row per registered DCC backend (same data as the former Workers tab). Use the links to open the adapter HTTP host, MCP streamable endpoint, or <code>/docs</code> when the host exposes it.
+            </p>
             <StatusLine text={updatedAt.instances} error={errors.instances} />
-            <table>
-              <thead><tr><th>ID</th><th>DCC</th><th>Status</th><th>Address</th><th>Scene</th></tr></thead>
-              <tbody>
-                {instances.length === 0 ? (
-                  <EmptyRow columns={5}>No instances registered.</EmptyRow>
-                ) : filteredInstances.length === 0 ? (
-                  <EmptyRow columns={5}>No rows match your search.</EmptyRow>
-                ) : (
-                  filteredInstances.map((instance) => (
-                  <tr key={instance.id}>
-                    <td>{instance.id.slice(0, 8)}</td>
-                    <td>
-                      <img
-                        src={resolveDccIcon(instance.dcc_type)}
-                        alt={instance.dcc_type}
-                        className="dcc-icon"
-                      />
-                      {instance.dcc_type}
-                    </td>
-                    <td><StatusBadge value={instance.status} /></td>
-                    <td>{instance.host}:{instance.port}</td>
-                    <td>{instance.scene ?? '-'}</td>
-                  </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
-            <button className="refresh-btn" type="button" onClick={fetchInstances}>Refresh</button>
+            <div className="workers-grid">
+              {workers.length === 0 ? (
+                <p className="empty">No instances registered.</p>
+              ) : filteredWorkers.length === 0 ? (
+                <p className="empty">No instances match your search.</p>
+              ) : (
+                filteredWorkers.map((worker) => (
+                  <div key={worker.instance_id} className={`worker-card ${worker.stale ? 'stale' : statusClass(worker.status).replace('badge badge-', '')}`}>
+                    <div className="wname">
+                      <img src={resolveDccIcon(worker.dcc_type)} alt="" className="dcc-icon" aria-hidden />
+                      {worker.display_name} <span>{worker.instance_id.slice(0, 8)}</span>
+                    </div>
+                    <div className="wkv">
+                      <span>DCC</span><span>{worker.dcc_type}</span>
+                      <span>Status</span><span><StatusBadge value={worker.status} /></span>
+                      <span>PID</span><span>{worker.pid ?? '-'}</span>
+                      <span>Uptime</span><span>{formatUptime(worker.uptime_secs)}</span>
+                      <span>Version</span><span>{worker.version ?? '-'}</span>
+                      <span>Adapter</span><span>{worker.adapter_version ?? '-'}</span>
+                      <span>Scene</span><span>{worker.scene ?? '-'}</span>
+                      <span>CPU%</span><span>{worker.cpu_percent == null ? '-' : worker.cpu_percent.toFixed(1)}</span>
+                      <span>Memory</span><span>{formatBytes(worker.memory_bytes)}</span>
+                      <span>Endpoints</span><span><McpBackendLinks mcpUrl={worker.mcp_url} /></span>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+            <div className="status-bar">Summary: live {workerSummary.live}, stale {workerSummary.stale}, unhealthy {workerSummary.unhealthy}</div>
+            <button className="refresh-btn" type="button" onClick={fetchInstanceBackends}>Refresh</button>
           </section>
         )}
 
@@ -819,7 +1118,7 @@ function App() {
                         <tr key={call.request_id}>
                           <td>{formatTime(call.timestamp)}</td>
                           <td>
-                            <button className="refresh-btn" type="button" title={call.request_id} onClick={() => { setActivePanel('traces'); void fetchTraceInto(call.request_id, 'trace'); }}>
+                            <button className="refresh-btn" type="button" title={call.request_id} onClick={() => goToPanel('traces', { traceId: call.request_id })}>
                               {call.request_id.slice(0, 12)}
                             </button>
                           </td>
@@ -859,7 +1158,7 @@ function App() {
                         <tr
                           key={trace.request_id}
                           className="trace-row"
-                          onClick={() => void fetchTraceInto(trace.request_id, 'trace')}
+                          onClick={() => goToPanel('traces', { traceId: trace.request_id, replace: true })}
                         >
                           <td>{formatTime(trace.timestamp)}</td>
                           <td>{trace.request_id}</td>
@@ -883,7 +1182,14 @@ function App() {
             <StatusLine text={updatedAt.stats} error={errors.stats} />
             <label className="range-label">
               Range
-              <select value={statsRange} onChange={(event) => setStatsRange(event.target.value)}>
+              <select
+                value={statsRange}
+                onChange={(event) => {
+                  const v = event.target.value;
+                  setStatsRange(v);
+                  pushAdminUrl('stats', { range: v, replace: true });
+                }}
+              >
                 <option value="1h">1h</option>
                 <option value="24h">24h</option>
                 <option value="7d">7d</option>
@@ -906,43 +1212,74 @@ function App() {
           </section>
         )}
 
-        {activePanel === 'workers' && (
+        {activePanel === 'skill-paths' && (
           <section className="panel active">
-            <h2>Workers</h2>
-            <StatusLine text={updatedAt.workers} error={errors.workers} />
-            <div className="workers-grid">
-              {workers.length === 0 ? <p className="empty">No workers registered.</p> : filteredWorkers.length === 0 ? (
-                <p className="empty">No workers match your search.</p>
-              ) : (
-                filteredWorkers.map((worker) => (
-                <div key={worker.instance_id} className={`worker-card ${worker.stale ? 'stale' : statusClass(worker.status).replace('badge badge-', '')}`}>
-                  <div className="wname">{worker.display_name} <span>{worker.instance_id.slice(0, 8)}</span></div>
-                  <div className="wkv">
-                    <span>DCC</span><span>{worker.dcc_type}</span>
-                    <span>Status</span><span><StatusBadge value={worker.status} /></span>
-                    <span>PID</span><span>{worker.pid ?? '-'}</span>
-                    <span>Uptime</span><span>{formatUptime(worker.uptime_secs)}</span>
-                    <span>Version</span><span>{worker.version ?? '-'}</span>
-                    <span>Adapter</span><span>{worker.adapter_version ?? '-'}</span>
-                    <span>CPU%</span><span>{worker.cpu_percent == null ? '-' : worker.cpu_percent.toFixed(1)}</span>
-                    <span>Memory</span><span>{formatBytes(worker.memory_bytes)}</span>
-                    <span>MCP URL</span><span>{worker.mcp_url}</span>
-                  </div>
-                </div>
-                ))
-              )}
+            <h2>Skill search paths</h2>
+            <StatusLine text={updatedAt['skill-paths']} error={errors['skill-paths']} />
+            <p className="empty log-hint">
+              Paths used for skill discovery (CLI, environment variables, bundled data dir, and optional SQLite-backed custom entries). Adding or removing a custom path persists to SQLite, re-runs disk catalog discovery in-process, and refreshes gateway capability data; Event Log records each change.
+            </p>
+            <div className="skill-path-add">
+              <input
+                type="text"
+                className="list-search-input"
+                placeholder="Add directory path…"
+                value={skillPathInput}
+                onChange={(e) => setSkillPathInput(e.target.value)}
+                aria-label="New skill path"
+              />
+              <button className="refresh-btn" type="button" disabled={skillPathBusy} onClick={() => void addSkillPath()}>
+                Add path
+              </button>
             </div>
-            <div className="status-bar">Summary: live {workerSummary.live}, stale {workerSummary.stale}, unhealthy {workerSummary.unhealthy}</div>
-            <button className="refresh-btn" type="button" onClick={fetchWorkers}>Refresh</button>
+            <table>
+              <thead>
+                <tr>
+                  <th>Source</th>
+                  <th>Path</th>
+                  <th />
+                </tr>
+              </thead>
+              <tbody>
+                {skillPaths.length === 0 ? (
+                  <EmptyRow columns={3}>No paths reported.</EmptyRow>
+                ) : filteredSkillPaths.length === 0 ? (
+                  <EmptyRow columns={3}>No rows match your search.</EmptyRow>
+                ) : (
+                  filteredSkillPaths.map((row) => (
+                    <tr key={`${row.source}-${row.path}-${row.id ?? 'x'}`}>
+                      <td>
+                        <span className="source-pill" data-source={row.source}>
+                          {row.source}
+                        </span>
+                      </td>
+                      <td className="mono-path">{row.path}</td>
+                      <td>
+                        {row.id != null ? (
+                          <button type="button" className="linkish" disabled={skillPathBusy} onClick={() => void deleteSkillPath(row.id!)}>
+                            Remove
+                          </button>
+                        ) : (
+                          '—'
+                        )}
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+            <button className="refresh-btn" type="button" onClick={fetchSkillPaths}>
+              Refresh
+            </button>
           </section>
         )}
 
         {activePanel === 'logs' && (
-          <section className="panel active">
+          <section className="panel active logs-panel">
             <h2>Event Log</h2>
             <StatusLine text={updatedAt.logs} error={errors.logs} />
             <p className="empty log-hint">
-              Contention events (election, probe, eviction) plus recent audited gateway calls, merged newest-first and grouped by DCC / instance prefix.
+              Merged feed (newest first): in-memory gateway contention events (same ring as MCP resource <code>resources://gateway/events</code> — elections, yields, evictions, ghost reaping, etc.); optional rolling log files under <code>DCC_MCP_LOG_DIR</code> when that directory exists; recent audit rows (in-memory ring and optional SQLite); operator notes when you add/remove custom skill paths. If nothing has happened yet and no log directory is configured, this list stays empty.
             </p>
             {logs.length === 0 ? <p className="empty">No events in buffer yet. Use the gateway (tool calls) or wait for registry / probe activity.</p> : filteredLogs.length === 0 ? (
               <p className="empty">No log lines match your search.</p>

--- a/admin-ui/src/styles.css
+++ b/admin-ui/src/styles.css
@@ -145,6 +145,28 @@ select {
   outline-offset: 2px;
 }
 
+a.nav-link {
+  display: block;
+  text-decoration: none;
+}
+
+.admin-quick-nav-hint {
+  color: var(--slate-light);
+  font-size: 0.875rem;
+  line-height: 1.6;
+  margin-top: 1rem;
+}
+
+.admin-quick-link {
+  color: var(--accent-warm);
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.admin-quick-link:hover {
+  text-decoration: underline;
+}
+
 .main-stage {
   background: var(--ivory-light);
   flex: 1;
@@ -660,4 +682,38 @@ pre.empty {
   min-height: 0.75rem;
   text-align: center;
   width: 100%;
+}
+
+.skill-path-add {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.skill-path-add .list-search-input {
+  flex: 1 1 240px;
+  min-width: 0;
+}
+
+.mono-path {
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  word-break: break-all;
+}
+
+button.linkish {
+  background: none;
+  border: none;
+  color: var(--ember);
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+  text-decoration: underline;
+}
+
+button.linkish:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
 }

--- a/crates/dcc-mcp-db/Cargo.toml
+++ b/crates/dcc-mcp-db/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "dcc-mcp-db"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Persistence contracts, path policies, gateway admin SQLite, and shared DDL for DCC-MCP."
+
+[features]
+default = []
+gateway-admin-sqlite = ["dep:rusqlite", "dep:tracing"]
+
+[dependencies]
+thiserror = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tracing = { workspace = true, optional = true }
+rusqlite = { workspace = true, optional = true }
+workspace-hack = { version = "0.1", path = "../workspace-hack" }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/dcc-mcp-db/src/application/gateway_admin.rs
+++ b/crates/dcc-mcp-db/src/application/gateway_admin.rs
@@ -1,0 +1,69 @@
+//! Gateway admin SQLite — path resolution and location policy (DIP for embedders).
+
+use std::path::PathBuf;
+
+use crate::domain::env::{ENV_GATEWAY_ADMIN_DB, ENV_REGISTRY_DIR, GATEWAY_ADMIN_SQLITE_FILENAME};
+
+/// Default path: `<registry_or_temp>/gateway_admin.sqlite`.
+#[must_use]
+pub fn default_gateway_admin_sqlite_path(registry_dir: Option<&PathBuf>) -> PathBuf {
+    let base = registry_dir
+        .cloned()
+        .or_else(|| std::env::var_os(ENV_REGISTRY_DIR).map(PathBuf::from))
+        .unwrap_or_else(|| std::env::temp_dir().join("dcc-mcp-registry"));
+    base.join(GATEWAY_ADMIN_SQLITE_FILENAME)
+}
+
+/// Resolve path: explicit config → `DCC_MCP_GATEWAY_ADMIN_DB` → [`default_gateway_admin_sqlite_path`].
+#[must_use]
+pub fn resolve_gateway_admin_sqlite_path(
+    explicit: Option<&PathBuf>,
+    registry_dir: Option<&PathBuf>,
+) -> PathBuf {
+    if let Some(p) = explicit {
+        return p.clone();
+    }
+    if let Some(p) = std::env::var_os(ENV_GATEWAY_ADMIN_DB) {
+        return PathBuf::from(p);
+    }
+    default_gateway_admin_sqlite_path(registry_dir)
+}
+
+/// Strategy interface for **where** the gateway admin database lives (tests / embedders).
+pub trait GatewayAdminDbLocationPolicy: Send + Sync {
+    /// Return the absolute or process-relative SQLite path.
+    fn resolve_gateway_admin_sqlite(&self) -> PathBuf;
+}
+
+/// Policy used by `dcc-mcp-server` / gateway: optional explicit path + registry hint.
+#[derive(Clone, Default, Debug)]
+pub struct EnvAndRegistryGatewayAdminPolicy {
+    pub explicit: Option<PathBuf>,
+    pub registry_dir: Option<PathBuf>,
+}
+
+impl GatewayAdminDbLocationPolicy for EnvAndRegistryGatewayAdminPolicy {
+    fn resolve_gateway_admin_sqlite(&self) -> PathBuf {
+        resolve_gateway_admin_sqlite_path(self.explicit.as_ref(), self.registry_dir.as_ref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_wins_over_everything() {
+        let explicit = PathBuf::from("/tmp/explicit.sqlite");
+        let got = resolve_gateway_admin_sqlite_path(Some(&explicit), None);
+        assert_eq!(got, explicit);
+    }
+
+    #[test]
+    fn default_uses_filename_under_registry_or_temp() {
+        let reg = PathBuf::from("/tmp/reg-test-only");
+        let got = resolve_gateway_admin_sqlite_path(None, Some(&reg));
+        assert!(got.ends_with(GATEWAY_ADMIN_SQLITE_FILENAME));
+        assert!(got.starts_with(&reg));
+    }
+}

--- a/crates/dcc-mcp-db/src/application/mod.rs
+++ b/crates/dcc-mcp-db/src/application/mod.rs
@@ -1,0 +1,3 @@
+//! Application layer: policies and ports — pure logic or trait contracts, no drivers.
+
+pub mod gateway_admin;

--- a/crates/dcc-mcp-db/src/domain/env.rs
+++ b/crates/dcc-mcp-db/src/domain/env.rs
@@ -1,0 +1,13 @@
+//! Canonical environment variable names for on-disk DCC-MCP state.
+
+/// Shared file-backed service registry directory (`DCC_MCP_REGISTRY_DIR`).
+pub const ENV_REGISTRY_DIR: &str = "DCC_MCP_REGISTRY_DIR";
+
+/// Explicit override for the gateway admin SQLite file (traces, audits, custom skill paths).
+pub const ENV_GATEWAY_ADMIN_DB: &str = "DCC_MCP_GATEWAY_ADMIN_DB";
+
+/// Default filename inside the registry directory when no explicit path is set.
+pub const GATEWAY_ADMIN_SQLITE_FILENAME: &str = "gateway_admin.sqlite";
+
+/// Rolling file log directory for `dcc_mcp_logging` (`DCC_MCP_LOG_DIR`).
+pub const ENV_DCC_MCP_LOG_DIR: &str = "DCC_MCP_LOG_DIR";

--- a/crates/dcc-mcp-db/src/domain/error.rs
+++ b/crates/dcc-mcp-db/src/domain/error.rs
@@ -1,0 +1,13 @@
+//! Single error surface for `dcc-mcp-db` (extend variants as infra grows).
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum DbError {
+    /// Invalid configuration (e.g. retention window).
+    #[error("invalid database configuration: {0}")]
+    InvalidConfig(String),
+    /// Backend-specific failure (wrapped for `From` impls in infra).
+    #[error("database backend error: {0}")]
+    Backend(String),
+}

--- a/crates/dcc-mcp-db/src/domain/gateway_admin_audit.rs
+++ b/crates/dcc-mcp-db/src/domain/gateway_admin_audit.rs
@@ -1,0 +1,18 @@
+//! JSON shape persisted in gateway admin SQLite `audits.audit_json` rows.
+
+use serde::{Deserialize, Serialize};
+
+/// Stable audit envelope stored in SQLite (gateway admin).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayAdminAuditPersistedJson {
+    pub timestamp_ms: u64,
+    pub request_id: String,
+    pub method: Option<String>,
+    pub instance_id: Option<String>,
+    pub session_id: Option<String>,
+    pub action: String,
+    pub dcc_type: Option<String>,
+    pub success: bool,
+    pub error: Option<String>,
+    pub duration_ms: Option<u64>,
+}

--- a/crates/dcc-mcp-db/src/domain/mod.rs
+++ b/crates/dcc-mcp-db/src/domain/mod.rs
@@ -1,0 +1,6 @@
+//! Domain layer: configuration keys, errors, and value objects — no framework or I/O.
+
+pub mod env;
+pub mod error;
+pub mod gateway_admin_audit;
+pub mod model;

--- a/crates/dcc-mcp-db/src/domain/model.rs
+++ b/crates/dcc-mcp-db/src/domain/model.rs
@@ -1,0 +1,37 @@
+//! Small value objects shared across persistence features.
+
+/// Bounded retention window for time-series or append-only tables (days).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RetentionDays(u32);
+
+impl RetentionDays {
+    /// Clamp to `[1, 3650]` so operators cannot accidentally pass `0` or absurd values.
+    #[must_use]
+    pub const fn new(days: u32) -> Self {
+        let d = if days == 0 {
+            1
+        } else if days > 3650 {
+            3650
+        } else {
+            days
+        };
+        Self(d)
+    }
+
+    #[must_use]
+    pub const fn get(self) -> u32 {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retention_clamps() {
+        assert_eq!(RetentionDays::new(0).get(), 1);
+        assert_eq!(RetentionDays::new(10_000).get(), 3650);
+        assert_eq!(RetentionDays::new(30).get(), 30);
+    }
+}

--- a/crates/dcc-mcp-db/src/infra/file_log_merge.rs
+++ b/crates/dcc-mcp-db/src/infra/file_log_merge.rs
@@ -1,0 +1,167 @@
+//! Parse tracing-style `.log` files for gateway admin log merge (`GET /admin/api/logs`).
+
+use serde_json::{Value, json};
+
+/// Parse one log line (tracing / log4rs style) into an admin log row JSON object.
+///
+/// `tracing-subscriber` default fmt may use **runs of spaces** between fields.
+/// Use `split_whitespace()` for the first two tokens, then rejoin the remainder.
+pub fn parse_gateway_file_log_line(line: &str) -> Option<Value> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let mut it = trimmed.split_whitespace();
+    let ts = it.next()?;
+    if !ts.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    let level = it.next()?.to_lowercase();
+    let rest: String = it.collect::<Vec<_>>().join(" ");
+    if rest.is_empty() {
+        return None;
+    }
+    let (target, message) = if let Some(idx) = rest.find(':') {
+        (&rest[..idx], rest[idx + 1..].trim())
+    } else {
+        ("", rest.as_str())
+    };
+    Some(json!({
+        "timestamp": ts,
+        "level": level,
+        "message": message,
+        "source": "file",
+        "event": null,
+        "dcc_type": if target.is_empty() { None } else { Some(target) },
+        "instance_id": null,
+        "request_id": null,
+        "tool": null,
+        "success": level == "info" || level == "debug",
+        "detail": null,
+        "reason": null,
+    }))
+}
+
+/// Default rolling log directory for the current platform (matches `dcc_mcp_logging` layout).
+#[must_use]
+pub fn default_gateway_log_dir() -> String {
+    #[cfg(windows)]
+    {
+        let profile = std::env::var("USERPROFILE").unwrap_or_default();
+        format!("{}\\AppData\\Local\\dcc-mcp\\log", profile)
+    }
+    #[cfg(not(windows))]
+    {
+        let home = std::env::var("HOME").unwrap_or_default();
+        format!("{}/.local/share/dcc-mcp/log", home)
+    }
+}
+
+/// Read `*.log` files under `dir`, parse lines, sort by timestamp descending, keep `limit` rows.
+///
+/// Returns an empty vector when `dir` is empty or not a directory.
+#[must_use]
+pub fn read_gateway_log_dir_rows_recent(dir: &str, limit: usize) -> Vec<Value> {
+    if dir.is_empty() {
+        return Vec::new();
+    }
+    if !std::fs::metadata(dir).map(|m| m.is_dir()).unwrap_or(false) {
+        return Vec::new();
+    }
+    let mut rows: Vec<Value> = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().map(|e| e == "log").unwrap_or(false)
+                && let Ok(contents) = std::fs::read_to_string(&path)
+            {
+                for line in contents.lines() {
+                    if let Some(row) = parse_gateway_file_log_line(line) {
+                        rows.push(row);
+                    }
+                }
+            }
+        }
+    }
+    rows.sort_by(|a, b| {
+        let ta = a.get("timestamp").and_then(|v| v.as_str()).unwrap_or("");
+        let tb = b.get("timestamp").and_then(|v| v.as_str()).unwrap_or("");
+        tb.cmp(ta)
+    });
+    rows.truncate(limit);
+    rows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_gateway_file_log_line;
+
+    #[test]
+    fn tracing_double_space_after_level() {
+        let line = "2026-05-16T12:00:00.000000Z  INFO  dcc_mcp_test: hello admin";
+        let v = parse_gateway_file_log_line(line).expect("parsable tracing line");
+        assert_eq!(v["timestamp"], "2026-05-16T12:00:00.000000Z");
+        assert_eq!(v["level"], "info");
+        assert_eq!(v["message"], "hello admin");
+        assert_eq!(v["dcc_type"], "dcc_mcp_test");
+        assert_eq!(v["success"], true);
+    }
+
+    #[test]
+    fn tracing_single_space_still_works() {
+        let line = "2026-05-16T12:00:00.000000Z INFO dcc_mcp_gateway: Registered";
+        let v = parse_gateway_file_log_line(line).expect("parsable");
+        assert_eq!(v["level"], "info");
+        assert_eq!(v["message"], "Registered");
+        assert_eq!(v["dcc_type"], "dcc_mcp_gateway");
+    }
+
+    #[test]
+    fn rejects_non_timestamp_lines() {
+        assert!(parse_gateway_file_log_line("not-a-log-line").is_none());
+        assert!(parse_gateway_file_log_line("").is_none());
+    }
+
+    #[test]
+    fn read_dir_respects_limit() {
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+        let p = dir.path().join("a.log");
+        std::fs::write(
+            &p,
+            "2026-05-16T12:00:00.000000Z INFO t: one\n2026-05-16T13:00:00.000000Z WARN t: two\n",
+        )
+        .unwrap();
+        let rows = super::read_gateway_log_dir_rows_recent(&dir.path().to_string_lossy(), 1);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["message"], "two");
+    }
+
+    #[test]
+    fn read_dir_empty_string_returns_empty() {
+        let rows = super::read_gateway_log_dir_rows_recent("", 100);
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn read_dir_nonexistent_returns_empty() {
+        let rows = super::read_gateway_log_dir_rows_recent("/nonexistent_dir_12345", 100);
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn error_level_has_success_false() {
+        let line = "2026-05-16T12:00:00.000000Z ERROR target: something failed";
+        let v = parse_gateway_file_log_line(line).expect("parsable");
+        assert_eq!(v["level"], "error");
+        assert_eq!(v["success"], false);
+    }
+
+    #[test]
+    fn no_colon_target_yields_empty_dcc_type() {
+        let line = "2026-05-16T12:00:00.000000Z INFO message without colon target";
+        let v = parse_gateway_file_log_line(line).expect("parsable");
+        assert!(v["dcc_type"].is_null());
+        assert_eq!(v["message"], "message without colon target");
+    }
+}

--- a/crates/dcc-mcp-db/src/infra/gateway_admin_schema.rs
+++ b/crates/dcc-mcp-db/src/infra/gateway_admin_schema.rs
@@ -1,0 +1,24 @@
+//! Canonical DDL for the gateway admin SQLite database (single source of truth).
+
+/// Bootstrap script executed once per writer connection (WAL + tables + indexes).
+pub const GATEWAY_ADMIN_SQLITE_DDL: &str = r#"
+PRAGMA journal_mode=WAL;
+PRAGMA synchronous=NORMAL;
+CREATE TABLE IF NOT EXISTS traces (
+  request_id TEXT PRIMARY KEY NOT NULL,
+  started_ms INTEGER NOT NULL,
+  trace_json TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS audits (
+  request_id TEXT PRIMARY KEY NOT NULL,
+  ts_ms INTEGER NOT NULL,
+  audit_json TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS skill_paths_custom (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  path TEXT NOT NULL UNIQUE,
+  created_ms INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_traces_started ON traces(started_ms);
+CREATE INDEX IF NOT EXISTS idx_audits_ts ON audits(ts_ms);
+"#;

--- a/crates/dcc-mcp-db/src/infra/gateway_admin_sqlite.rs
+++ b/crates/dcc-mcp-db/src/infra/gateway_admin_sqlite.rs
@@ -1,0 +1,455 @@
+//! Gateway admin SQLite reader + writer thread (traces, audits, custom skill paths).
+//!
+//! JSON blobs for traces/audits are opaque at this layer; the gateway deserialises
+//! into its own trace/audit types.
+
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use rusqlite::{Connection, params};
+use serde::Deserialize;
+
+use crate::domain::gateway_admin_audit::GatewayAdminAuditPersistedJson;
+use crate::infra::gateway_admin_schema::GATEWAY_ADMIN_SQLITE_DDL;
+
+const SCHEMA: &str = GATEWAY_ADMIN_SQLITE_DDL;
+
+#[derive(Deserialize)]
+struct TraceInsertMeta {
+    request_id: String,
+    started_at: u64,
+}
+
+#[derive(Clone)]
+pub struct GatewayAdminSqliteReader {
+    path: PathBuf,
+}
+
+impl GatewayAdminSqliteReader {
+    #[must_use]
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    fn open_ro(&self) -> Option<Connection> {
+        Connection::open_with_flags(
+            &self.path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )
+        .ok()
+    }
+
+    /// Raw `trace_json` rows, newest first, bounded by `limit`.
+    pub fn list_traces_since_json(&self, cutoff: Option<SystemTime>, limit: usize) -> Vec<String> {
+        let Some(conn) = self.open_ro() else {
+            return Vec::new();
+        };
+        let cutoff_ms = cutoff
+            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(0);
+        let mut stmt = match conn.prepare_cached(
+            "SELECT trace_json FROM traces WHERE started_ms >= ?1 ORDER BY started_ms DESC LIMIT ?2",
+        ) {
+            Ok(s) => s,
+            Err(_) => return Vec::new(),
+        };
+        let rows = stmt.query_map(params![cutoff_ms, limit as i64], |row| {
+            let s: String = row.get(0)?;
+            Ok(s)
+        });
+        let Ok(rows) = rows else {
+            return Vec::new();
+        };
+        rows.filter_map(|r| r.ok()).collect()
+    }
+
+    pub fn get_trace_json(&self, request_id: &str) -> Option<String> {
+        let conn = self.open_ro()?;
+        conn.query_row(
+            "SELECT trace_json FROM traces WHERE request_id = ?1",
+            params![request_id],
+            |row| row.get(0),
+        )
+        .ok()
+    }
+
+    pub fn list_audits_recent_json(&self, limit: usize) -> Vec<String> {
+        let Some(conn) = self.open_ro() else {
+            return Vec::new();
+        };
+        let mut stmt = match conn
+            .prepare_cached("SELECT audit_json FROM audits ORDER BY ts_ms DESC LIMIT ?1")
+        {
+            Ok(s) => s,
+            Err(_) => return Vec::new(),
+        };
+        let rows = stmt.query_map(params![limit as i64], |row| {
+            let s: String = row.get(0)?;
+            Ok(s)
+        });
+        let Ok(rows) = rows else {
+            return Vec::new();
+        };
+        rows.filter_map(|r| r.ok()).collect()
+    }
+
+    pub fn list_custom_skill_paths(&self) -> Vec<(i64, String)> {
+        let Some(conn) = self.open_ro() else {
+            return Vec::new();
+        };
+        let mut stmt =
+            match conn.prepare_cached("SELECT id, path FROM skill_paths_custom ORDER BY id ASC") {
+                Ok(s) => s,
+                Err(_) => return Vec::new(),
+            };
+        let rows = stmt.query_map([], |row| {
+            Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+        });
+        let Ok(rows) = rows else {
+            return Vec::new();
+        };
+        rows.filter_map(|r| r.ok()).collect()
+    }
+}
+
+enum PersistMsg {
+    TraceJson(String),
+    AuditJson(String),
+    AddSkillPath(String),
+    DeleteSkillPath(i64),
+}
+
+struct LaneShared {
+    reader: GatewayAdminSqliteReader,
+    tx: Mutex<Option<SyncSender<PersistMsg>>>,
+    join: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl Drop for LaneShared {
+    fn drop(&mut self) {
+        if let Ok(mut g) = self.tx.lock() {
+            g.take();
+        }
+        if let Ok(mut jg) = self.join.lock()
+            && let Some(j) = jg.take()
+        {
+            let _ = j.join();
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct GatewayAdminSqliteLane {
+    inner: Arc<LaneShared>,
+}
+
+impl GatewayAdminSqliteLane {
+    pub fn spawn(path: PathBuf, retention_days: u32) -> Result<Self, String> {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        {
+            let conn = Connection::open(&path).map_err(|e| e.to_string())?;
+            conn.execute_batch(SCHEMA).map_err(|e| e.to_string())?;
+        }
+
+        let (tx, rx) = sync_channel::<PersistMsg>(8_192);
+        let path_thread = path.clone();
+        let join = std::thread::Builder::new()
+            .name("dcc-mcp-admin-sqlite".into())
+            .spawn(move || writer_main(path_thread, retention_days, rx))
+            .map_err(|e| e.to_string())?;
+
+        Ok(Self {
+            inner: Arc::new(LaneShared {
+                reader: GatewayAdminSqliteReader::new(path),
+                tx: Mutex::new(Some(tx)),
+                join: Mutex::new(Some(join)),
+            }),
+        })
+    }
+
+    #[must_use]
+    pub fn reader(&self) -> GatewayAdminSqliteReader {
+        self.inner.reader.clone()
+    }
+
+    pub fn try_persist_trace_json(&self, trace_json: &str) {
+        if let Ok(g) = self.inner.tx.lock()
+            && let Some(tx) = g.as_ref()
+        {
+            let _ = tx.try_send(PersistMsg::TraceJson(trace_json.to_owned()));
+        }
+    }
+
+    pub fn try_persist_audit_json(&self, audit_json: &str) {
+        if let Ok(g) = self.inner.tx.lock()
+            && let Some(tx) = g.as_ref()
+        {
+            let _ = tx.try_send(PersistMsg::AuditJson(audit_json.to_owned()));
+        }
+    }
+
+    pub fn try_add_skill_path(&self, path: String) -> bool {
+        self.inner
+            .tx
+            .lock()
+            .ok()
+            .and_then(|g| {
+                g.as_ref()
+                    .map(|tx| tx.try_send(PersistMsg::AddSkillPath(path)).is_ok())
+            })
+            .unwrap_or(false)
+    }
+
+    pub fn try_delete_skill_path(&self, id: i64) -> bool {
+        self.inner
+            .tx
+            .lock()
+            .ok()
+            .and_then(|g| {
+                g.as_ref()
+                    .map(|tx| tx.try_send(PersistMsg::DeleteSkillPath(id)).is_ok())
+            })
+            .unwrap_or(false)
+    }
+}
+
+fn writer_main(path: PathBuf, retention_days: u32, rx: Receiver<PersistMsg>) {
+    let Ok(mut conn) = Connection::open(&path) else {
+        tracing::error!(path = %path.display(), "admin sqlite writer: failed to open DB");
+        return;
+    };
+    let _ = conn.execute_batch(SCHEMA);
+    let mut n: u64 = 0;
+    while let Ok(msg) = rx.recv() {
+        match msg {
+            PersistMsg::TraceJson(json) => {
+                if let Ok(meta) = serde_json::from_str::<TraceInsertMeta>(&json) {
+                    let ms = meta.started_at.min(i64::MAX as u64) as i64;
+                    if let Err(e) = conn.execute(
+                        "INSERT OR REPLACE INTO traces (request_id, started_ms, trace_json) VALUES (?1, ?2, ?3)",
+                        params![meta.request_id, ms, json],
+                    ) {
+                        tracing::debug!(error = %e, request_id = %meta.request_id, "admin sqlite: trace insert failed");
+                    }
+                }
+            }
+            PersistMsg::AuditJson(json) => {
+                if let Ok(p) = serde_json::from_str::<GatewayAdminAuditPersistedJson>(&json)
+                    && let Err(e) = conn.execute(
+                        "INSERT OR REPLACE INTO audits (request_id, ts_ms, audit_json) VALUES (?1, ?2, ?3)",
+                        params![p.request_id, p.timestamp_ms as i64, json],
+                    )
+                {
+                    tracing::debug!(error = %e, request_id = %p.request_id, "admin sqlite: audit insert failed");
+                }
+            }
+            PersistMsg::AddSkillPath(p) => {
+                let now = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map(|d| d.as_millis() as i64)
+                    .unwrap_or(0);
+                if let Err(e) = conn.execute(
+                    "INSERT OR IGNORE INTO skill_paths_custom (path, created_ms) VALUES (?1, ?2)",
+                    params![p, now],
+                ) {
+                    tracing::debug!(error = %e, path = %p, "admin sqlite: skill path insert failed");
+                }
+            }
+            PersistMsg::DeleteSkillPath(id) => {
+                if let Err(e) = conn.execute("DELETE FROM skill_paths_custom WHERE id = ?1", params![id]) {
+                    tracing::debug!(error = %e, id = id, "admin sqlite: skill path delete failed");
+                }
+            }
+        }
+        n += 1;
+        if n.is_multiple_of(128) {
+            prune_old_rows(&mut conn, retention_days);
+        }
+    }
+    let _ = conn.execute("PRAGMA optimize", []);
+}
+
+fn prune_old_rows(conn: &mut Connection, retention_days: u32) {
+    let days = u64::from(retention_days.clamp(1, 3650));
+    let cutoff = SystemTime::now()
+        .checked_sub(Duration::from_secs(days * 86_400))
+        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0);
+    let _ = conn.execute("DELETE FROM traces WHERE started_ms < ?1", params![cutoff]);
+    let _ = conn.execute("DELETE FROM audits WHERE ts_ms < ?1", params![cutoff]);
+}
+
+pub fn read_custom_skill_paths_for_startup(db_path: &Path) -> Vec<PathBuf> {
+    let Ok(conn) = Connection::open_with_flags(
+        db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    ) else {
+        return Vec::new();
+    };
+    let mut stmt = match conn.prepare_cached("SELECT path FROM skill_paths_custom ORDER BY id ASC")
+    {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+    let rows = stmt.query_map([], |row| {
+        let s: String = row.get(0)?;
+        Ok(PathBuf::from(s))
+    });
+    let Ok(rows) = rows else {
+        return Vec::new();
+    };
+    rows.filter_map(|r| r.ok()).collect()
+}
+
+#[cfg(all(test, feature = "gateway-admin-sqlite"))]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn roundtrip_trace_json() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("t.sqlite");
+        let lane = GatewayAdminSqliteLane::spawn(db.clone(), 30).expect("spawn");
+        let json = r#"{"request_id":"r1","method":"tools/call","started_at":1700000000000,"total_ms":12,"ok":true,"spans":[]}"#;
+        lane.try_persist_trace_json(json);
+        drop(lane);
+        let r = GatewayAdminSqliteReader::new(db);
+        let list = r.list_traces_since_json(None, 10);
+        assert!(list.iter().any(|s| s.contains("r1")));
+    }
+
+    #[test]
+    fn roundtrip_audit_json() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("a.sqlite");
+        let lane = GatewayAdminSqliteLane::spawn(db.clone(), 30).expect("spawn");
+        let row = GatewayAdminAuditPersistedJson {
+            timestamp_ms: 1_700_000_000_000,
+            request_id: "rid".into(),
+            method: Some("call".into()),
+            instance_id: None,
+            session_id: None,
+            action: "x".into(),
+            dcc_type: Some("maya".into()),
+            success: true,
+            error: None,
+            duration_ms: Some(5),
+        };
+        lane.try_persist_audit_json(&serde_json::to_string(&row).unwrap());
+        drop(lane);
+        let r = GatewayAdminSqliteReader::new(db);
+        let list = r.list_audits_recent_json(10);
+        assert_eq!(list.len(), 1);
+        let back: GatewayAdminAuditPersistedJson = serde_json::from_str(&list[0]).unwrap();
+        assert_eq!(back.request_id, "rid");
+    }
+
+    #[test]
+    fn roundtrip_skill_path_add_list_delete() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("sp.sqlite");
+        let lane = GatewayAdminSqliteLane::spawn(db.clone(), 30).expect("spawn");
+        assert!(lane.try_add_skill_path("/tmp/skills/maya".to_string()));
+        assert!(lane.try_add_skill_path("/tmp/skills/houdini".to_string()));
+        // Wait for writer to process
+        drop(lane);
+
+        let r = GatewayAdminSqliteReader::new(db.clone());
+        let paths = r.list_custom_skill_paths();
+        assert_eq!(paths.len(), 2);
+        assert!(paths.iter().any(|(_, p)| p == "/tmp/skills/maya"));
+        assert!(paths.iter().any(|(_, p)| p == "/tmp/skills/houdini"));
+
+        // Delete the first path
+        let id_maya = paths
+            .iter()
+            .find(|(_, p)| p == "/tmp/skills/maya")
+            .unwrap()
+            .0;
+        let lane2 = GatewayAdminSqliteLane::spawn(db.clone(), 30).expect("spawn");
+        assert!(lane2.try_delete_skill_path(id_maya));
+        drop(lane2);
+
+        let r2 = GatewayAdminSqliteReader::new(db);
+        let paths2 = r2.list_custom_skill_paths();
+        assert_eq!(paths2.len(), 1);
+        assert_eq!(paths2[0].1, "/tmp/skills/houdini");
+    }
+
+    #[test]
+    fn duplicate_path_insert_is_noop() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("dup.sqlite");
+        let lane = GatewayAdminSqliteLane::spawn(db.clone(), 30).expect("spawn");
+        assert!(lane.try_add_skill_path("/tmp/dup".to_string()));
+        assert!(lane.try_add_skill_path("/tmp/dup".to_string())); // INSERT OR IGNORE
+        drop(lane);
+
+        let r = GatewayAdminSqliteReader::new(db);
+        let paths = r.list_custom_skill_paths();
+        assert_eq!(paths.len(), 1);
+    }
+
+    #[test]
+    fn read_custom_skill_paths_for_startup_works() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("startup.sqlite");
+        let lane = GatewayAdminSqliteLane::spawn(db.clone(), 30).expect("spawn");
+        assert!(lane.try_add_skill_path("/opt/skills/blender".to_string()));
+        drop(lane);
+
+        let paths = read_custom_skill_paths_for_startup(&db);
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], PathBuf::from("/opt/skills/blender"));
+    }
+
+    #[test]
+    fn prune_old_rows_removes_expired() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("prune.sqlite");
+        // Open and create schema
+        let conn = Connection::open(&db).unwrap();
+        conn.execute_batch(SCHEMA).unwrap();
+        // Insert a trace with a very old timestamp (1 ms)
+        conn.execute(
+            "INSERT INTO traces (request_id, started_ms, trace_json) VALUES (?1, ?2, ?3)",
+            params![
+                "old-req",
+                1i64,
+                r#"{"request_id":"old-req","started_at":1}"#
+            ],
+        )
+        .unwrap();
+        // Insert a recent trace
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64;
+        conn.execute(
+            "INSERT INTO traces (request_id, started_ms, trace_json) VALUES (?1, ?2, ?3)",
+            params![
+                "new-req",
+                now_ms,
+                r#"{"request_id":"new-req","started_at":0}"#
+            ],
+        )
+        .unwrap();
+
+        // Prune with retention = 1 day (old trace should be removed)
+        let mut conn = conn;
+        prune_old_rows(&mut conn, 1);
+
+        let r = GatewayAdminSqliteReader::new(db);
+        let traces = r.list_traces_since_json(None, 100);
+        assert_eq!(traces.len(), 1);
+        assert!(traces[0].contains("new-req"));
+    }
+}

--- a/crates/dcc-mcp-db/src/infra/mod.rs
+++ b/crates/dcc-mcp-db/src/infra/mod.rs
@@ -1,0 +1,6 @@
+//! Infrastructure: DDL and (future) drivers. Domain must not import from here.
+
+pub mod file_log_merge;
+pub mod gateway_admin_schema;
+#[cfg(feature = "gateway-admin-sqlite")]
+pub mod gateway_admin_sqlite;

--- a/crates/dcc-mcp-db/src/lib.rs
+++ b/crates/dcc-mcp-db/src/lib.rs
@@ -1,0 +1,35 @@
+//! # dcc-mcp-db
+//!
+//! Single place for **persistence contracts** and **shared primitives** across
+//! DCC-MCP (gateway admin SQLite, future log/stats materialisation, job stores).
+//!
+//! ## Architecture
+//!
+//! - **domain** — value objects, env key names, and `DbError` (no I/O).
+//! - **application** — pure policies (path resolution) and `GatewayAdminDbLocationPolicy`.
+//! - **infra** — versioned DDL strings, SQLite adapters, and file-log merge helpers.
+//!
+//! Gateway and server crates depend on this package instead of duplicating
+//! environment variable names or schema text. The admin SQLite writer thread
+//! lives behind the `gateway-admin-sqlite` feature.
+
+pub mod application;
+pub mod domain;
+pub mod infra;
+
+pub use application::gateway_admin::{
+    EnvAndRegistryGatewayAdminPolicy, GatewayAdminDbLocationPolicy,
+    default_gateway_admin_sqlite_path, resolve_gateway_admin_sqlite_path,
+};
+pub use domain::env;
+pub use domain::error::DbError;
+pub use domain::gateway_admin_audit::GatewayAdminAuditPersistedJson;
+pub use infra::file_log_merge::{
+    default_gateway_log_dir, parse_gateway_file_log_line, read_gateway_log_dir_rows_recent,
+};
+pub use infra::gateway_admin_schema::GATEWAY_ADMIN_SQLITE_DDL;
+
+#[cfg(feature = "gateway-admin-sqlite")]
+pub use infra::gateway_admin_sqlite::{
+    GatewayAdminSqliteLane, GatewayAdminSqliteReader, read_custom_skill_paths_for_startup,
+};

--- a/crates/dcc-mcp-gateway-core/src/event.rs
+++ b/crates/dcc-mcp-gateway-core/src/event.rs
@@ -23,6 +23,8 @@ pub enum EventKind {
     ProbeUnreachable,
     /// A backend instance was auto-deregistered after consecutive probe failures.
     AutoDeregister,
+    /// Operator-facing admin action (skill paths, etc.) — no Prometheus counter.
+    OperatorNote,
 }
 
 impl EventKind {
@@ -36,6 +38,7 @@ impl EventKind {
             EventKind::ProbeBooting => "booting",
             EventKind::ProbeUnreachable => "unreachable",
             EventKind::AutoDeregister => "probe_fail",
+            EventKind::OperatorNote => "operator",
         }
     }
 }
@@ -89,6 +92,7 @@ mod tests {
         assert_eq!(EventKind::ProbeBooting.as_label(), "booting");
         assert_eq!(EventKind::ProbeUnreachable.as_label(), "unreachable");
         assert_eq!(EventKind::AutoDeregister.as_label(), "probe_fail");
+        assert_eq!(EventKind::OperatorNote.as_label(), "operator");
     }
 
     #[test]

--- a/crates/dcc-mcp-gateway/Cargo.toml
+++ b/crates/dcc-mcp-gateway/Cargo.toml
@@ -11,6 +11,7 @@ build = "build.rs"
 
 [dependencies]
 # Internal
+dcc-mcp-db = { path = "../dcc-mcp-db", default-features = false }
 dcc-mcp-gateway-core = { path = "../dcc-mcp-gateway-core" }
 dcc-mcp-jsonrpc = { path = "../dcc-mcp-jsonrpc" }
 dcc-mcp-naming = { path = "../dcc-mcp-naming" }
@@ -51,6 +52,7 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 [features]
 default = ["prometheus"]
 admin = []
+admin-persist-sqlite = ["admin", "dcc-mcp-db/gateway-admin-sqlite"]
 prometheus = ["dep:dcc-mcp-telemetry", "dcc-mcp-telemetry/prometheus", "dep:prometheus"]
 
 [dev-dependencies]

--- a/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
@@ -1,5 +1,7 @@
 //! Admin UI HTTP handlers.
 
+use std::collections::HashMap;
+use std::time::Duration;
 use std::time::UNIX_EPOCH;
 
 use axum::Json;
@@ -7,97 +9,19 @@ use axum::extract::State;
 use axum::http::{HeaderValue, StatusCode, header};
 use axum::response::IntoResponse;
 use dcc_mcp_gateway_core::naming::instance_short;
+use serde::Deserialize;
 use serde_json::{Value, json};
 
 use super::html::ADMIN_HTML;
-use super::state::AdminState;
+use super::state::{AdminAuditRecord, AdminState};
 use super::trace::DispatchTrace;
 use crate::gateway::capability::RefreshReason;
 use crate::gateway::capability_service::refresh_all_live_backends;
-use crate::gateway::event_log::ContendEvent;
+use crate::gateway::event_log::{ContendEvent, EventKind};
 use crate::gateway::resilience::{self as gw_resilience, gateway_limits};
 use crate::gateway::state::entry_to_json;
-
-/// Read `.log` files from `dir` and parse them into admin log rows.
-/// Only keeps the most recent `limit` entries (by timestamp, descending).
-fn read_log_files(dir: &str, limit: usize) -> Vec<Value> {
-    let mut rows: Vec<Value> = Vec::new();
-    if let Ok(entries) = std::fs::read_dir(dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().map(|e| e == "log").unwrap_or(false)
-                && let Ok(contents) = std::fs::read_to_string(&path)
-            {
-                for line in contents.lines() {
-                    if let Some(row) = parse_log_line(line) {
-                        rows.push(row);
-                    }
-                }
-            }
-        }
-    }
-    rows.sort_by(|a, b| {
-        let ta = a.get("timestamp").and_then(|v| v.as_str()).unwrap_or("");
-        let tb = b.get("timestamp").and_then(|v| v.as_str()).unwrap_or("");
-        tb.cmp(ta) // descending
-    });
-    rows.truncate(limit);
-    rows
-}
-
-/// Return the default log directory for the current platform.
-/// Returns empty string in test builds so disk scanning is skipped.
-fn default_log_dir() -> String {
-    #[cfg(test)]
-    {
-        String::new()
-    }
-    #[cfg(not(test))]
-    {
-        #[cfg(windows)]
-        {
-            let profile = std::env::var("USERPROFILE").unwrap_or_default();
-            format!("{}\\AppData\\Local\\dcc-mcp\\log", profile)
-        }
-        #[cfg(not(windows))]
-        {
-            let home = std::env::var("HOME").unwrap_or_default();
-            format!("{}/.local/share/dcc-mcp/log", home)
-        }
-    }
-}
-
-/// Parse one log line (tracing / log4rs format) into an admin log row.
-fn parse_log_line(line: &str) -> Option<Value> {
-    let trimmed = line.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-    // Expected format: "2024-01-01T00:00:00.000000Z  LEVEL  target: message"
-    let mut parts = trimmed.splitn(3, ' ');
-    let ts = parts.next().unwrap_or("");
-    let level = parts.next().unwrap_or("info").to_lowercase();
-    let rest = parts.next().unwrap_or("");
-    let (target, message) = if let Some(idx) = rest.find(':') {
-        (&rest[..idx], rest[idx + 1..].trim())
-    } else {
-        ("", rest)
-    };
-    Some(json!({
-        "timestamp": ts,
-        "level": level,
-        "message": message,
-        "source": "file",
-        "event": null,
-        "dcc_type": if target.is_empty() { None } else { Some(target) },
-        "instance_id": null,
-        "request_id": null,
-        "tool": null,
-        "success": level == "info" || level == "debug",
-        "detail": null,
-        "reason": null,
-    }))
-}
+use dcc_mcp_db::env::ENV_DCC_MCP_LOG_DIR;
+use dcc_mcp_db::read_gateway_log_dir_rows_recent;
 
 /// `GET /admin` — serve the inline HTML dashboard.
 pub async fn handle_admin_ui() -> impl IntoResponse {
@@ -149,45 +73,51 @@ pub async fn handle_admin_tools(State(s): State<AdminState>) -> impl IntoRespons
     Json(json!({ "total": tools.len(), "tools": tools }))
 }
 
+fn admin_audit_row_json(r: &AdminAuditRecord) -> Value {
+    let ts = r
+        .timestamp
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|_d| chrono::DateTime::<chrono::Utc>::from(r.timestamp).to_rfc3339())
+        .unwrap_or_default();
+    json!({
+        "timestamp": ts,
+        "request_id": r.request_id,
+        "method": r.method,
+        "instance_id": r.instance_id,
+        "session_id": r.session_id,
+        "tool": r.action,
+        "dcc_type": r.dcc_type,
+        "status": if r.success { "ok" } else { "err" },
+        "success": r.success,
+        "error": r.error,
+        "duration_ms": r.duration_ms,
+    })
+}
+
 /// `GET /admin/api/calls` — recent calls from the AuditLog ring buffer.
 ///
 /// If no `AuditLog` is attached to the state, returns an empty array.
 pub async fn handle_admin_calls(State(s): State<AdminState>) -> impl IntoResponse {
-    let calls = match &s.audit_log {
-        Some(log) => {
-            let records = log.lock().clone();
-            records
-                .iter()
-                .rev()
-                .take(200)
-                .map(|r| {
-                    let ts = r
-                        .timestamp
-                        .duration_since(UNIX_EPOCH)
-                        .ok()
-                        .map(|_d| {
-                            // ISO-8601 via chrono (already a dep).
-                            chrono::DateTime::<chrono::Utc>::from(r.timestamp).to_rfc3339()
-                        })
-                        .unwrap_or_default();
-                    json!({
-                        "timestamp": ts,
-                        "request_id": r.request_id,
-                        "method": r.method,
-                        "instance_id": r.instance_id,
-                        "session_id": r.session_id,
-                        "tool": r.action,
-                        "dcc_type": r.dcc_type,
-                        "status": if r.success { "ok" } else { "err" },
-                        "success": r.success,
-                        "error": r.error,
-                        "duration_ms": r.duration_ms,
-                    })
-                })
-                .collect::<Vec<_>>()
+    let mut by_rid: HashMap<String, Value> = HashMap::new();
+    if let Some(ref lane) = s.admin_sqlite_lane {
+        let r = lane.reader();
+        for rec in r.list_audits_recent(500) {
+            by_rid.insert(rec.request_id.clone(), admin_audit_row_json(&rec));
         }
-        None => vec![],
-    };
+    }
+    if let Some(log) = &s.audit_log {
+        for r in log.lock().iter().rev().take(200) {
+            by_rid.insert(r.request_id.clone(), admin_audit_row_json(r));
+        }
+    }
+    let mut calls: Vec<Value> = by_rid.into_values().collect();
+    calls.sort_by(|a, b| {
+        let ta = a.get("timestamp").and_then(|v| v.as_str()).unwrap_or("");
+        let tb = b.get("timestamp").and_then(|v| v.as_str()).unwrap_or("");
+        tb.cmp(ta)
+    });
+    calls.truncate(200);
     Json(json!({ "total": calls.len(), "calls": calls }))
 }
 
@@ -207,12 +137,21 @@ pub async fn handle_admin_logs(State(s): State<AdminState>) -> impl IntoResponse
         .collect();
 
     // Merge on-disk log files (issue #963).
-    let log_dir = std::env::var("DCC_MCP_LOG_DIR").unwrap_or_else(|_| default_log_dir());
+    let log_dir = std::env::var(ENV_DCC_MCP_LOG_DIR).unwrap_or_else(|_| {
+        #[cfg(test)]
+        {
+            String::new()
+        }
+        #[cfg(not(test))]
+        {
+            dcc_mcp_db::default_gateway_log_dir()
+        }
+    });
     if std::fs::metadata(&log_dir)
         .map(|m| m.is_dir())
         .unwrap_or(false)
     {
-        let mut file_logs = read_log_files(&log_dir, 500);
+        let mut file_logs = read_gateway_log_dir_rows_recent(&log_dir, 500);
         logs.append(&mut file_logs);
     }
 
@@ -328,34 +267,58 @@ pub async fn handle_admin_traces(
         .and_then(|v| v.parse::<usize>().ok())
         .unwrap_or(200)
         .min(500);
-    let mapped: Vec<Value> = match &s.trace_log {
-        Some(log) => log
-            .recent(limit)
-            .iter()
-            .map(dispatch_trace_to_admin_row)
-            .collect(),
-        None => vec![],
-    };
+    let mut by_id: HashMap<String, DispatchTrace> = HashMap::new();
+    if let Some(ref lane) = s.admin_sqlite_lane {
+        let r = lane.reader();
+        for t in r.list_traces_since(None, limit.saturating_mul(4).max(500)) {
+            by_id.insert(t.request_id.clone(), t);
+        }
+    }
+    if let Some(log) = &s.trace_log {
+        for t in log.recent(limit) {
+            by_id.insert(t.request_id.clone(), t);
+        }
+    }
+    let mut traces: Vec<DispatchTrace> = by_id.into_values().collect();
+    traces.sort_by(|a, b| {
+        let ta = a.started_at.duration_since(UNIX_EPOCH).ok();
+        let tb = b.started_at.duration_since(UNIX_EPOCH).ok();
+        tb.cmp(&ta)
+    });
+    traces.truncate(limit);
+    let mapped: Vec<Value> = traces.iter().map(dispatch_trace_to_admin_row).collect();
     Json(json!({ "total": mapped.len(), "traces": mapped }))
 }
 
 /// `GET /admin/api/traces/{request_id}` — full waterfall for one call.
 ///
-/// Returns 404 when the trace is not in the ring buffer.
+/// Returns 404 when the trace is not in the ring buffer or SQLite store.
 pub async fn handle_admin_trace_detail(
     State(s): State<AdminState>,
     axum::extract::Path(request_id): axum::extract::Path<String>,
 ) -> impl IntoResponse {
-    match s.trace_log.as_ref().and_then(|log| log.get(&request_id)) {
-        Some(trace) => (
+    if let Some(trace) = s.trace_log.as_ref().and_then(|log| log.get(&request_id)) {
+        return (
             StatusCode::OK,
             Json(serde_json::to_value(&trace).unwrap_or(json!({}))),
-        ),
-        None => (
-            StatusCode::NOT_FOUND,
-            Json(json!({ "error": "trace not found", "request_id": request_id })),
-        ),
+        )
+            .into_response();
     }
+    if let Some(ref lane) = s.admin_sqlite_lane {
+        let r = lane.reader();
+        if let Some(trace) = r.get_trace(&request_id) {
+            return (
+                StatusCode::OK,
+                Json(serde_json::to_value(&trace).unwrap_or(json!({}))),
+            )
+                .into_response();
+        }
+    }
+    (
+        StatusCode::NOT_FOUND,
+        Json(json!({ "error": "trace not found", "request_id": request_id })),
+    )
+        .into_response()
 }
 
 /// `GET /admin/api/stats?range=1h|24h|7d` — aggregated call statistics (Phase 3).
@@ -395,6 +358,158 @@ pub async fn handle_admin_stats(
     }
 }
 
+#[derive(Debug, Deserialize)]
+pub struct SkillPathAddBody {
+    pub path: String,
+}
+
+async fn wait_for_custom_skill_path_visible(
+    lane: &crate::gateway::admin::sqlite_lane::AdminSqliteLane,
+    needle: &str,
+) {
+    for _ in 0..80 {
+        if lane
+            .reader()
+            .list_custom_skill_paths()
+            .iter()
+            .any(|(_, p)| p == needle)
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    tracing::warn!(path = %needle, "skill path not visible after 2 s poll — writer may be lagging");
+}
+
+async fn wait_until_custom_skill_path_id_removed(
+    lane: &crate::gateway::admin::sqlite_lane::AdminSqliteLane,
+    id: i64,
+) {
+    for _ in 0..80 {
+        if !lane
+            .reader()
+            .list_custom_skill_paths()
+            .iter()
+            .any(|(i, _)| *i == id)
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    tracing::warn!(
+        skill_path_id = id,
+        "skill path id not removed after 2 s poll — writer may be lagging"
+    );
+}
+
+fn push_admin_operator_note(state: &AdminState, msg: String) {
+    state.gateway.event_log.push(ContendEvent::new(
+        EventKind::OperatorNote,
+        "admin",
+        "gateway",
+        Some(msg),
+    ));
+}
+
+/// `GET /admin/api/skill-paths` — skill search paths (snapshot + SQLite custom).
+pub async fn handle_admin_skill_paths(State(s): State<AdminState>) -> impl IntoResponse {
+    let mut flat: Vec<Value> = s
+        .skill_paths_snapshot
+        .iter()
+        .map(|e| json!({ "path": e.path, "source": e.source }))
+        .collect();
+    if let Some(ref lane) = s.admin_sqlite_lane {
+        let r = lane.reader();
+        for (id, path) in r.list_custom_skill_paths() {
+            if !flat
+                .iter()
+                .any(|v| v.get("path").and_then(|x| x.as_str()) == Some(path.as_str()))
+            {
+                flat.push(json!({ "path": path, "source": "admin_custom", "id": id }));
+            }
+        }
+    }
+    Json(json!({ "paths": flat }))
+}
+
+/// `POST /admin/api/skill-paths` — enqueue a custom path; embedder hook may reload disk catalog.
+pub async fn handle_admin_skill_path_add(
+    State(s): State<AdminState>,
+    Json(body): Json<SkillPathAddBody>,
+) -> impl IntoResponse {
+    let path = body.path.trim().to_string();
+    if path.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "path is empty" })),
+        )
+            .into_response();
+    }
+    let Some(ref lane) = s.admin_sqlite_lane else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "admin sqlite lane disabled" })),
+        )
+            .into_response();
+    };
+    if lane.try_add_skill_path(path.clone()) {
+        wait_for_custom_skill_path_visible(lane, &path).await;
+        if let Some(cb) = s.skill_paths_reload.clone() {
+            cb();
+        }
+        let gw = s.gateway.clone();
+        tokio::spawn(async move {
+            refresh_all_live_backends(&gw, RefreshReason::ToolsListChanged).await;
+        });
+        push_admin_operator_note(
+            &s,
+            format!("Custom skill path persisted; catalog reload hook ran: {path}"),
+        );
+        (StatusCode::OK, Json(json!({ "ok": true, "path": path }))).into_response()
+    } else {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "persist queue full or sqlite disabled" })),
+        )
+            .into_response()
+    }
+}
+
+/// `DELETE /admin/api/skill-paths/{id}` — remove a custom path row.
+pub async fn handle_admin_skill_path_delete(
+    State(s): State<AdminState>,
+    axum::extract::Path(id): axum::extract::Path<i64>,
+) -> impl IntoResponse {
+    let Some(ref lane) = s.admin_sqlite_lane else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "admin sqlite lane disabled" })),
+        )
+            .into_response();
+    };
+    if lane.try_delete_skill_path(id) {
+        wait_until_custom_skill_path_id_removed(lane, id).await;
+        if let Some(cb) = s.skill_paths_reload.clone() {
+            cb();
+        }
+        let gw = s.gateway.clone();
+        tokio::spawn(async move {
+            refresh_all_live_backends(&gw, RefreshReason::ToolsListChanged).await;
+        });
+        push_admin_operator_note(
+            &s,
+            format!("Custom skill path removed (id={id}); catalog reload hook ran."),
+        );
+        (StatusCode::OK, Json(json!({ "ok": true, "id": id }))).into_response()
+    } else {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "persist queue full or sqlite disabled" })),
+        )
+            .into_response()
+    }
+}
+
 /// `GET /admin/api/workers` — per-instance worker cards (Phase 4).
 ///
 /// Returns the live registry view of each known instance plus best-effort
@@ -424,6 +539,22 @@ fn dispatch_trace_to_admin_row(t: &DispatchTrace) -> Value {
 }
 
 fn contend_event_to_admin_row(e: ContendEvent) -> Value {
+    if matches!(e.event, EventKind::OperatorNote) {
+        let message = e
+            .reason
+            .clone()
+            .unwrap_or_else(|| "operator note".to_string());
+        return json!({
+            "timestamp": e.timestamp,
+            "level": "info",
+            "message": message,
+            "source": "admin",
+            "event": e.event,
+            "dcc_type": e.dcc_type,
+            "instance_id": e.instance_id,
+            "reason": e.reason,
+        });
+    }
     let label = e.event.as_label();
     let mut message = format!("{label} dcc_type={} instance={}", e.dcc_type, e.instance_id);
     if let Some(r) = &e.reason {

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -44,6 +44,7 @@
 //! See `docs/guide/gateway-admin.md` for screenshots and configuration knobs.
 
 mod html;
+pub mod sqlite_lane;
 pub mod state;
 pub mod stats;
 pub mod trace;
@@ -54,6 +55,11 @@ mod handlers;
 #[cfg(feature = "admin")]
 mod router;
 
+pub use dcc_mcp_db::{
+    default_gateway_admin_sqlite_path as default_admin_db_path,
+    resolve_gateway_admin_sqlite_path as resolve_admin_db_path,
+};
+pub use sqlite_lane::{AdminSqliteLane, AdminSqliteReader, read_custom_skill_paths_for_startup};
 pub use state::{AdminAuditRecord, AdminAuditSink, AdminState, AuditLog, DurableAuditStore};
 pub use stats::{GatewayStats, LatencyStats, StatsAggregator, StatsRange, TopEntry};
 pub use trace::{DispatchTrace, TraceLog, TracePayload, TraceSpan};

--- a/crates/dcc-mcp-gateway/src/gateway/admin/router.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/router.rs
@@ -4,6 +4,7 @@ use axum::{Router, routing};
 
 use super::handlers::{
     handle_admin_calls, handle_admin_health, handle_admin_instances, handle_admin_logs,
+    handle_admin_skill_path_add, handle_admin_skill_path_delete, handle_admin_skill_paths,
     handle_admin_stats, handle_admin_tools, handle_admin_trace_detail, handle_admin_traces,
     handle_admin_ui, handle_admin_workers,
 };
@@ -35,6 +36,15 @@ pub fn build_admin_router(state: AdminState) -> Router {
         .route(
             "/api/traces/{request_id}",
             routing::get(handle_admin_trace_detail),
+        )
+        .route("/api/skill-paths", routing::get(handle_admin_skill_paths))
+        .route(
+            "/api/skill-paths",
+            routing::post(handle_admin_skill_path_add),
+        )
+        .route(
+            "/api/skill-paths/{id}",
+            routing::delete(handle_admin_skill_path_delete),
         )
         .route("/api/logs", routing::get(handle_admin_logs))
         .route("/api/stats", routing::get(handle_admin_stats))

--- a/crates/dcc-mcp-gateway/src/gateway/admin/sqlite_lane.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/sqlite_lane.rs
@@ -1,0 +1,261 @@
+//! SQLite-backed admin persistence (traces, audits, custom skill paths).
+//!
+//! When the `admin-persist-sqlite` feature is off, this module exposes no-op
+//! stubs so `admin`-only test builds keep compiling.
+//!
+//! The writer thread and schema live in `dcc-mcp-db` (`gateway-admin-sqlite`);
+//! this module is a thin type-preserving façade over [`DispatchTrace`] /
+//! [`AdminAuditRecord`].
+
+use std::path::PathBuf;
+
+#[cfg(not(feature = "admin-persist-sqlite"))]
+use std::path::Path;
+use std::time::SystemTime;
+
+#[cfg(not(feature = "admin-persist-sqlite"))]
+use super::state::AdminAuditRecord;
+#[cfg(not(feature = "admin-persist-sqlite"))]
+use super::trace::DispatchTrace;
+
+#[cfg(feature = "admin-persist-sqlite")]
+use std::time::{Duration, UNIX_EPOCH};
+
+#[cfg(feature = "admin-persist-sqlite")]
+use super::state::AdminAuditRecord;
+#[cfg(feature = "admin-persist-sqlite")]
+use super::trace::DispatchTrace;
+#[cfg(feature = "admin-persist-sqlite")]
+use dcc_mcp_db::{
+    GatewayAdminAuditPersistedJson, GatewayAdminSqliteLane as InnerLane,
+    GatewayAdminSqliteReader as InnerReader,
+};
+
+#[cfg(feature = "admin-persist-sqlite")]
+#[derive(Clone)]
+pub struct AdminSqliteReader {
+    inner: InnerReader,
+}
+
+#[cfg(feature = "admin-persist-sqlite")]
+impl AdminSqliteReader {
+    #[must_use]
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            inner: InnerReader::new(path),
+        }
+    }
+
+    pub fn list_traces_since(
+        &self,
+        cutoff: Option<SystemTime>,
+        limit: usize,
+    ) -> Vec<DispatchTrace> {
+        self.inner
+            .list_traces_since_json(cutoff, limit)
+            .into_iter()
+            .filter_map(|s| serde_json::from_str(&s).ok())
+            .collect()
+    }
+
+    pub fn get_trace(&self, request_id: &str) -> Option<DispatchTrace> {
+        let s = self.inner.get_trace_json(request_id)?;
+        serde_json::from_str(&s).ok()
+    }
+
+    pub fn list_audits_recent(&self, limit: usize) -> Vec<AdminAuditRecord> {
+        self.inner
+            .list_audits_recent_json(limit)
+            .into_iter()
+            .filter_map(|s| {
+                let p: GatewayAdminAuditPersistedJson = serde_json::from_str(&s).ok()?;
+                Some(admin_audit_from_persisted(p))
+            })
+            .collect()
+    }
+
+    pub fn list_custom_skill_paths(&self) -> Vec<(i64, String)> {
+        self.inner.list_custom_skill_paths()
+    }
+}
+
+#[cfg(feature = "admin-persist-sqlite")]
+fn admin_audit_from_persisted(p: GatewayAdminAuditPersistedJson) -> AdminAuditRecord {
+    AdminAuditRecord {
+        timestamp: UNIX_EPOCH + Duration::from_millis(p.timestamp_ms),
+        request_id: p.request_id,
+        method: p.method,
+        instance_id: p.instance_id,
+        session_id: p.session_id,
+        action: p.action,
+        dcc_type: p.dcc_type,
+        success: p.success,
+        error: p.error,
+        duration_ms: p.duration_ms,
+    }
+}
+
+#[cfg(feature = "admin-persist-sqlite")]
+#[derive(Clone)]
+pub struct AdminSqliteLane {
+    inner: InnerLane,
+}
+
+#[cfg(feature = "admin-persist-sqlite")]
+impl AdminSqliteLane {
+    pub fn spawn(path: PathBuf, retention_days: u32) -> Result<Self, String> {
+        Ok(Self {
+            inner: InnerLane::spawn(path, retention_days)?,
+        })
+    }
+
+    #[must_use]
+    pub fn reader(&self) -> AdminSqliteReader {
+        AdminSqliteReader {
+            inner: self.inner.reader(),
+        }
+    }
+
+    pub fn try_persist_trace(&self, t: &DispatchTrace) {
+        if let Ok(json) = serde_json::to_string(t) {
+            self.inner.try_persist_trace_json(&json);
+        }
+    }
+
+    pub fn try_persist_audit(&self, r: &AdminAuditRecord) {
+        let row = audit_to_persisted(r);
+        if let Ok(json) = serde_json::to_string(&row) {
+            self.inner.try_persist_audit_json(&json);
+        }
+    }
+
+    pub fn try_add_skill_path(&self, path: String) -> bool {
+        self.inner.try_add_skill_path(path)
+    }
+
+    pub fn try_delete_skill_path(&self, id: i64) -> bool {
+        self.inner.try_delete_skill_path(id)
+    }
+}
+
+#[cfg(feature = "admin-persist-sqlite")]
+fn audit_to_persisted(r: &AdminAuditRecord) -> GatewayAdminAuditPersistedJson {
+    GatewayAdminAuditPersistedJson {
+        timestamp_ms: r
+            .timestamp
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO)
+            .as_millis() as u64,
+        request_id: r.request_id.clone(),
+        method: r.method.clone(),
+        instance_id: r.instance_id.clone(),
+        session_id: r.session_id.clone(),
+        action: r.action.clone(),
+        dcc_type: r.dcc_type.clone(),
+        success: r.success,
+        error: r.error.clone(),
+        duration_ms: r.duration_ms,
+    }
+}
+
+#[cfg(feature = "admin-persist-sqlite")]
+pub use dcc_mcp_db::read_custom_skill_paths_for_startup;
+
+#[cfg(not(feature = "admin-persist-sqlite"))]
+#[derive(Clone, Default)]
+pub struct AdminSqliteReader;
+
+#[cfg(not(feature = "admin-persist-sqlite"))]
+impl AdminSqliteReader {
+    #[must_use]
+    pub fn new(_path: PathBuf) -> Self {
+        Self
+    }
+
+    pub fn list_traces_since(
+        &self,
+        _cutoff: Option<SystemTime>,
+        _limit: usize,
+    ) -> Vec<DispatchTrace> {
+        vec![]
+    }
+
+    pub fn get_trace(&self, _request_id: &str) -> Option<DispatchTrace> {
+        None
+    }
+
+    pub fn list_audits_recent(&self, _limit: usize) -> Vec<AdminAuditRecord> {
+        vec![]
+    }
+
+    pub fn list_custom_skill_paths(&self) -> Vec<(i64, String)> {
+        vec![]
+    }
+}
+
+#[cfg(not(feature = "admin-persist-sqlite"))]
+#[derive(Clone)]
+pub struct AdminSqliteLane;
+
+#[cfg(not(feature = "admin-persist-sqlite"))]
+impl AdminSqliteLane {
+    pub fn spawn(_path: PathBuf, _retention_days: u32) -> Result<Self, String> {
+        Ok(Self)
+    }
+
+    #[must_use]
+    pub fn reader(&self) -> AdminSqliteReader {
+        AdminSqliteReader::new(PathBuf::new())
+    }
+
+    pub fn try_persist_trace(&self, _: &DispatchTrace) {}
+
+    pub fn try_persist_audit(&self, _: &AdminAuditRecord) {}
+
+    pub fn try_add_skill_path(&self, _: String) -> bool {
+        false
+    }
+
+    pub fn try_delete_skill_path(&self, _: i64) -> bool {
+        false
+    }
+}
+
+#[cfg(not(feature = "admin-persist-sqlite"))]
+pub fn read_custom_skill_paths_for_startup(_: &Path) -> Vec<PathBuf> {
+    Vec::new()
+}
+
+#[cfg(all(test, feature = "admin-persist-sqlite"))]
+mod tests {
+    use super::{AdminSqliteLane, AdminSqliteReader};
+    use crate::gateway::admin::trace::DispatchTrace;
+    use std::time::SystemTime;
+    use tempfile::tempdir;
+
+    #[test]
+    fn roundtrip_trace() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("t.sqlite");
+        let lane = AdminSqliteLane::spawn(db.clone(), 30).expect("spawn");
+        let t = DispatchTrace {
+            request_id: "r1".into(),
+            method: "tools/call".into(),
+            tool_slug: Some("x".into()),
+            instance_id: None,
+            session_id: None,
+            dcc_type: Some("maya".into()),
+            started_at: SystemTime::now(),
+            total_ms: 12,
+            ok: true,
+            spans: vec![],
+            input: None,
+            output: None,
+        };
+        lane.try_persist_trace(&t);
+        drop(lane);
+        let r = AdminSqliteReader::new(db);
+        let list = r.list_traces_since(None, 10);
+        assert!(list.iter().any(|x| x.request_id == "r1"));
+    }
+}

--- a/crates/dcc-mcp-gateway/src/gateway/admin/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/state.rs
@@ -18,6 +18,9 @@ use crate::gateway::state::GatewayState;
 use super::stats::StatsAggregator;
 use super::trace::{DispatchTrace, TraceLog};
 
+type SqliteTracePersistFn = Arc<dyn Fn(&DispatchTrace) + Send + Sync>;
+type SqliteAuditPersistFn = Arc<dyn Fn(&AdminAuditRecord) + Send + Sync>;
+
 /// Minimal audit record that the admin UI consumes.
 #[derive(Debug, Clone)]
 pub struct AdminAuditRecord {
@@ -242,6 +245,8 @@ pub struct AdminAuditSink {
     capacity: usize,
     trace_log: Option<Arc<TraceLog>>,
     durable_store: Option<DurableAuditStore>,
+    sqlite_trace: Option<SqliteTracePersistFn>,
+    sqlite_audit: Option<SqliteAuditPersistFn>,
 }
 
 impl AdminAuditSink {
@@ -253,6 +258,8 @@ impl AdminAuditSink {
             capacity,
             trace_log: None,
             durable_store: None,
+            sqlite_trace: None,
+            sqlite_audit: None,
         }
     }
 
@@ -265,6 +272,21 @@ impl AdminAuditSink {
     /// Attach a trace log so `record()` also appends a [`DispatchTrace`].
     pub fn with_trace_log(mut self, trace_log: Arc<TraceLog>) -> Self {
         self.trace_log = Some(trace_log);
+        self
+    }
+
+    /// Persist traces / audits to the admin SQLite lane (bounded `try_send`).
+    pub fn with_sqlite_lane(
+        mut self,
+        lane: crate::gateway::admin::sqlite_lane::AdminSqliteLane,
+    ) -> Self {
+        let lt = lane.clone();
+        self.sqlite_trace = Some(Arc::new(move |t: &DispatchTrace| {
+            lt.try_persist_trace(t);
+        }));
+        self.sqlite_audit = Some(Arc::new(move |r: &AdminAuditRecord| {
+            lane.try_persist_audit(r);
+        }));
         self
     }
 }
@@ -293,6 +315,9 @@ impl AuditSink for AdminAuditSink {
         if let Some(store) = &self.durable_store {
             store.append_audit(&record);
         }
+        if let Some(cb) = &self.sqlite_audit {
+            cb(&record);
+        }
         let mut buf = self.log.lock();
         buf.push(record);
         if self.capacity > 0 {
@@ -319,6 +344,9 @@ impl AuditSink for AdminAuditSink {
             };
             if let Some(store) = &self.durable_store {
                 store.append_trace(&trace);
+            }
+            if let Some(cb) = &self.sqlite_trace {
+                cb(&trace);
             }
             tl.push(trace);
         }
@@ -420,6 +448,12 @@ pub struct AdminState {
     pub stats: Option<Arc<StatsAggregator>>,
     /// Wall-clock time the gateway started, used for the Health card uptime.
     pub started_at: SystemTime,
+    /// Skill search path snapshot (CLI / env / bundled) for the admin UI.
+    pub skill_paths_snapshot: Vec<crate::gateway::SkillPathEntry>,
+    /// SQLite lane for custom skill path mutations from the admin API.
+    pub admin_sqlite_lane: Option<crate::gateway::admin::sqlite_lane::AdminSqliteLane>,
+    /// Optional embedder hook: re-run disk skill discovery after admin SQLite path changes.
+    pub skill_paths_reload: Option<std::sync::Arc<dyn Fn() + Send + Sync>>,
 }
 
 impl AdminState {
@@ -433,6 +467,9 @@ impl AdminState {
             trace_log: None,
             stats: None,
             started_at: SystemTime::now(),
+            skill_paths_snapshot: Vec::new(),
+            admin_sqlite_lane: None,
+            skill_paths_reload: None,
         }
     }
 
@@ -445,10 +482,41 @@ impl AdminState {
     /// Attach the Phase 2 [`TraceLog`]. Implicitly bootstraps a
     /// [`StatsAggregator`] (Phase 3) over the same log so the admin
     /// router can serve `GET /admin/api/stats` without extra wiring.
-    pub fn with_trace_log(mut self, log: Arc<TraceLog>) -> Self {
-        // Phase 3: auto-create StatsAggregator when a TraceLog is attached.
-        self.stats = Some(Arc::new(StatsAggregator::new(log.clone())));
+    pub fn with_trace_log(
+        mut self,
+        log: Arc<TraceLog>,
+        sqlite_reader: Option<crate::gateway::admin::sqlite_lane::AdminSqliteReader>,
+    ) -> Self {
+        let mut agg = StatsAggregator::new(log.clone());
+        if let Some(r) = sqlite_reader {
+            agg = agg.with_sqlite_reader(r);
+        }
+        self.stats = Some(Arc::new(agg));
         self.trace_log = Some(log);
+        self
+    }
+
+    /// Attach skill path snapshot rows (from CLI / env / bundled).
+    pub fn with_skill_paths_snapshot(mut self, paths: Vec<crate::gateway::SkillPathEntry>) -> Self {
+        self.skill_paths_snapshot = paths;
+        self
+    }
+
+    /// Attach SQLite lane for admin API skill-path mutations.
+    pub fn with_admin_sqlite_lane(
+        mut self,
+        lane: Option<crate::gateway::admin::sqlite_lane::AdminSqliteLane>,
+    ) -> Self {
+        self.admin_sqlite_lane = lane;
+        self
+    }
+
+    /// Hook invoked after SQLite-backed custom skill paths change (add/delete).
+    pub fn with_skill_paths_reload(
+        mut self,
+        cb: Option<std::sync::Arc<dyn Fn() + Send + Sync>>,
+    ) -> Self {
+        self.skill_paths_reload = cb;
         self
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/admin/stats.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/stats.rs
@@ -20,7 +20,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
-use super::trace::TraceLog;
+use super::sqlite_lane::AdminSqliteReader;
+use super::trace::{DispatchTrace, TraceLog};
 
 /// How far back to consider when computing statistics.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -119,11 +120,20 @@ pub struct TopEntry {
 /// Computes on-demand statistics from the [`TraceLog`] ring buffer.
 pub struct StatsAggregator {
     trace_log: Arc<TraceLog>,
+    sqlite_reader: Option<AdminSqliteReader>,
 }
 
 impl StatsAggregator {
     pub fn new(trace_log: Arc<TraceLog>) -> Self {
-        Self { trace_log }
+        Self {
+            trace_log,
+            sqlite_reader: None,
+        }
+    }
+
+    pub fn with_sqlite_reader(mut self, reader: AdminSqliteReader) -> Self {
+        self.sqlite_reader = Some(reader);
+        self
     }
 
     /// Compute statistics for the given range.
@@ -132,87 +142,97 @@ impl StatsAggregator {
     /// a fully-materialised [`GatewayStats`] struct.
     pub fn compute(&self, range: StatsRange) -> GatewayStats {
         let cutoff = range.cutoff();
-        let traces = self.trace_log.recent(usize::MAX);
-
-        // Filter to the requested time range.
-        let in_range: Vec<_> = traces
-            .iter()
+        let mut by_id: HashMap<String, DispatchTrace> = HashMap::new();
+        if let Some(db) = &self.sqlite_reader {
+            for t in db.list_traces_since(cutoff, 500_000) {
+                by_id.insert(t.request_id.clone(), t);
+            }
+        }
+        for t in self.trace_log.recent(usize::MAX) {
+            by_id.insert(t.request_id.clone(), t);
+        }
+        let mut traces: Vec<DispatchTrace> = by_id
+            .into_values()
             .filter(|t| cutoff.map(|c| t.started_at >= c).unwrap_or(true))
             .collect();
-
-        let total_calls = in_range.len();
-        if total_calls == 0 {
-            return GatewayStats {
-                range: range_label(range),
-                total_calls: 0,
-                successful_calls: 0,
-                failed_calls: 0,
-                success_rate: 0.0,
-                latency_ms: LatencyStats::default(),
-                top_tools: vec![],
-                top_instances: vec![],
-                hourly_distribution: vec![0u32; 24],
-            };
-        }
-
-        let successful_calls = in_range.iter().filter(|t| t.ok).count();
-        let failed_calls = total_calls - successful_calls;
-        let success_rate = successful_calls as f64 / total_calls as f64;
-
-        // Latency — collect, sort, compute percentiles.
-        let mut latencies: Vec<u64> = in_range.iter().map(|t| t.total_ms).collect();
-        latencies.sort_unstable();
-        let latency_ms = compute_latency_stats(&latencies);
-
-        // Top tools.
-        let mut tool_counts: HashMap<String, usize> = HashMap::new();
-        for t in &in_range {
-            if let Some(slug) = &t.tool_slug {
-                *tool_counts.entry(slug.clone()).or_insert(0) += 1;
-            }
-        }
-        let top_tools = top_n(tool_counts, 10);
-
-        // Top instances.
-        let mut instance_counts: HashMap<String, usize> = HashMap::new();
-        for t in &in_range {
-            let key = t
-                .instance_id
-                .clone()
-                .or_else(|| t.dcc_type.clone())
-                .unwrap_or_else(|| "unknown".to_string());
-            *instance_counts.entry(key).or_insert(0) += 1;
-        }
-        let top_instances = top_n(instance_counts, 10);
-
-        // Hour-of-day distribution (UTC).
-        let mut hourly = vec![0u32; 24];
-        for t in &in_range {
-            let hour = t
-                .started_at
-                .duration_since(UNIX_EPOCH)
-                .map(|d| ((d.as_secs() % 86_400) / 3600) as usize)
-                .unwrap_or(0);
-            if hour < 24 {
-                hourly[hour] += 1;
-            }
-        }
-
-        GatewayStats {
-            range: range_label(range),
-            total_calls,
-            successful_calls,
-            failed_calls,
-            success_rate,
-            latency_ms,
-            top_tools,
-            top_instances,
-            hourly_distribution: hourly,
-        }
+        traces.sort_by(|a, b| {
+            let ta = a.started_at.duration_since(UNIX_EPOCH).ok();
+            let tb = b.started_at.duration_since(UNIX_EPOCH).ok();
+            tb.cmp(&ta)
+        });
+        compute_from_traces(&traces, range)
     }
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn compute_from_traces(in_range: &[DispatchTrace], range: StatsRange) -> GatewayStats {
+    let total_calls = in_range.len();
+    if total_calls == 0 {
+        return GatewayStats {
+            range: range_label(range),
+            total_calls: 0,
+            successful_calls: 0,
+            failed_calls: 0,
+            success_rate: 0.0,
+            latency_ms: LatencyStats::default(),
+            top_tools: vec![],
+            top_instances: vec![],
+            hourly_distribution: vec![0u32; 24],
+        };
+    }
+
+    let successful_calls = in_range.iter().filter(|t| t.ok).count();
+    let failed_calls = total_calls - successful_calls;
+    let success_rate = successful_calls as f64 / total_calls as f64;
+
+    let mut latencies: Vec<u64> = in_range.iter().map(|t| t.total_ms).collect();
+    latencies.sort_unstable();
+    let latency_ms = compute_latency_stats(&latencies);
+
+    let mut tool_counts: HashMap<String, usize> = HashMap::new();
+    for t in in_range {
+        if let Some(slug) = &t.tool_slug {
+            *tool_counts.entry(slug.clone()).or_insert(0) += 1;
+        }
+    }
+    let top_tools = top_n(tool_counts, 10);
+
+    let mut instance_counts: HashMap<String, usize> = HashMap::new();
+    for t in in_range {
+        let key = t
+            .instance_id
+            .clone()
+            .or_else(|| t.dcc_type.clone())
+            .unwrap_or_else(|| "unknown".to_string());
+        *instance_counts.entry(key).or_insert(0) += 1;
+    }
+    let top_instances = top_n(instance_counts, 10);
+
+    let mut hourly = vec![0u32; 24];
+    for t in in_range {
+        let hour = t
+            .started_at
+            .duration_since(UNIX_EPOCH)
+            .map(|d| ((d.as_secs() % 86_400) / 3600) as usize)
+            .unwrap_or(0);
+        if hour < 24 {
+            hourly[hour] += 1;
+        }
+    }
+
+    GatewayStats {
+        range: range_label(range),
+        total_calls,
+        successful_calls,
+        failed_calls,
+        success_rate,
+        latency_ms,
+        top_tools,
+        top_instances,
+        hourly_distribution: hourly,
+    }
+}
 
 fn range_label(r: StatsRange) -> String {
     match r {

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -1,6 +1,7 @@
 //! Tests for the admin UI handlers.
 
 #[cfg(all(test, feature = "admin"))]
+#[allow(clippy::await_holding_lock)] // Intentional: parking_lot Mutex for env-var test serialization
 mod admin_tests {
     use std::sync::Arc;
     use std::time::Duration;
@@ -17,6 +18,42 @@ mod admin_tests {
     use crate::gateway::admin::state::{AdminAuditRecord, AdminState, AuditLog};
     use crate::gateway::state::GatewayState;
     use dcc_mcp_transport::discovery::file_registry::FileRegistry;
+
+    /// `handle_admin_logs` merges `DCC_MCP_LOG_DIR` (or the platform default). Parallel
+    /// tests and developer machines with real log files make counts flaky unless we
+    /// point at a non-existent directory for the duration of the request.
+    static API_LOGS_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct ScopedNoDiskLogsDir {
+        previous: Option<String>,
+    }
+
+    impl ScopedNoDiskLogsDir {
+        fn new() -> Self {
+            let previous = std::env::var("DCC_MCP_LOG_DIR").ok();
+            let d = tempfile::tempdir().unwrap();
+            let p = d.path().to_string_lossy().to_string();
+            drop(d);
+            // SAFETY: tests are serialized with `API_LOGS_ENV_LOCK`; no concurrent reads
+            // of this env var in other threads during the critical section.
+            unsafe {
+                std::env::set_var("DCC_MCP_LOG_DIR", &p);
+            }
+            Self { previous }
+        }
+    }
+
+    impl Drop for ScopedNoDiskLogsDir {
+        fn drop(&mut self) {
+            // SAFETY: same as `new` — guarded by the test mutex.
+            unsafe {
+                match &self.previous {
+                    Some(v) => std::env::set_var("DCC_MCP_LOG_DIR", v),
+                    None => std::env::remove_var("DCC_MCP_LOG_DIR"),
+                }
+            }
+        }
+    }
 
     fn make_gateway_state() -> GatewayState {
         let dir = tempfile::tempdir().unwrap();
@@ -328,6 +365,8 @@ mod admin_tests {
 
     #[tokio::test]
     async fn test_admin_logs_returns_json_array() {
+        let _env = API_LOGS_ENV_LOCK.lock();
+        let _no_disk = ScopedNoDiskLogsDir::new();
         let (status, body) = body_json(admin_router(), "/api/logs").await;
         assert_eq!(status, StatusCode::OK);
         assert!(body["logs"].is_array(), "expected 'logs' array, got {body}");
@@ -335,12 +374,16 @@ mod admin_tests {
 
     #[tokio::test]
     async fn test_admin_logs_empty_by_default() {
+        let _env = API_LOGS_ENV_LOCK.lock();
+        let _no_disk = ScopedNoDiskLogsDir::new();
         let (_, body) = body_json(admin_router(), "/api/logs").await;
         assert!(body["logs"].as_array().unwrap().is_empty());
     }
 
     #[tokio::test]
     async fn test_admin_logs_returns_injected_event_entries() {
+        let _env = API_LOGS_ENV_LOCK.lock();
+        let _no_disk = ScopedNoDiskLogsDir::new();
         use crate::gateway::event_log::{ContendEvent, EventKind};
 
         let gs = make_gateway_state();
@@ -385,6 +428,8 @@ mod admin_tests {
 
     #[tokio::test]
     async fn test_admin_logs_merges_audit_tail_when_audit_attached() {
+        let _env = API_LOGS_ENV_LOCK.lock();
+        let _no_disk = ScopedNoDiskLogsDir::new();
         use std::time::UNIX_EPOCH;
 
         let gs = make_gateway_state();
@@ -505,7 +550,7 @@ mod admin_tests {
             output: None,
         });
 
-        let state = make_admin_state().with_trace_log(log);
+        let state = make_admin_state().with_trace_log(log, None);
         let router = build_admin_router(state);
         let (status, body) = body_json(router, "/api/stats?range=1h").await;
         assert_eq!(status, StatusCode::OK);
@@ -605,5 +650,152 @@ mod admin_tests {
         assert_eq!(body["total"].as_u64(), Some(1));
         assert_eq!(body["summary"]["live"].as_u64(), Some(1));
         assert_eq!(body["summary"]["stale"].as_u64(), Some(0));
+    }
+
+    // ── /api/skill-paths (CRUD) ─────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_admin_skill_paths_returns_empty_snapshot() {
+        let (status, body) = body_json(admin_router(), "/api/skill-paths").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(body["paths"].is_array());
+        assert!(body["paths"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_admin_skill_paths_shows_snapshot_entries() {
+        use crate::gateway::SkillPathEntry;
+        let state = make_admin_state().with_skill_paths_snapshot(vec![
+            SkillPathEntry {
+                path: "/opt/skills/maya".into(),
+                source: "cli".into(),
+            },
+            SkillPathEntry {
+                path: "/opt/skills/blender".into(),
+                source: "env:DCC_MCP_SKILL_PATHS".into(),
+            },
+        ]);
+        let router = build_admin_router(state);
+        let (status, body) = body_json(router, "/api/skill-paths").await;
+        assert_eq!(status, StatusCode::OK);
+        let paths = body["paths"].as_array().unwrap();
+        assert_eq!(paths.len(), 2);
+        assert_eq!(paths[0]["path"], "/opt/skills/maya");
+        assert_eq!(paths[0]["source"], "cli");
+        assert_eq!(paths[1]["path"], "/opt/skills/blender");
+        assert_eq!(paths[1]["source"], "env:DCC_MCP_SKILL_PATHS");
+    }
+
+    #[cfg(feature = "admin-persist-sqlite")]
+    #[tokio::test]
+    async fn test_admin_skill_path_crud_via_api() {
+        use crate::gateway::admin::sqlite_lane::AdminSqliteLane;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("test_crud.sqlite");
+        let lane = AdminSqliteLane::spawn(db_path, 30).expect("spawn lane");
+
+        let state = make_admin_state().with_admin_sqlite_lane(Some(lane));
+        let router = build_admin_router(state);
+
+        // POST a new skill path
+        let resp = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/skill-paths")
+                    .header("content-type", "application/json")
+                    .body(axum::body::Body::from(
+                        serde_json::to_vec(&serde_json::json!({"path": "/tmp/new-skills"}))
+                            .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // GET should now include the new path
+        let (status, body) = body_json(router.clone(), "/api/skill-paths").await;
+        assert_eq!(status, StatusCode::OK);
+        let paths = body["paths"].as_array().unwrap();
+        let custom: Vec<_> = paths
+            .iter()
+            .filter(|p| p["source"] == "admin_custom")
+            .collect();
+        assert_eq!(custom.len(), 1, "expected 1 custom path, got {paths:?}");
+        assert_eq!(custom[0]["path"], "/tmp/new-skills");
+
+        // DELETE the custom path
+        let id = custom[0]["id"]
+            .as_i64()
+            .expect("custom path should have id");
+        let resp = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/skill-paths/{id}"))
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // GET should no longer include the deleted path
+        let (status, body) = body_json(router, "/api/skill-paths").await;
+        assert_eq!(status, StatusCode::OK);
+        let paths = body["paths"].as_array().unwrap();
+        let custom: Vec<_> = paths
+            .iter()
+            .filter(|p| p["source"] == "admin_custom")
+            .collect();
+        assert!(
+            custom.is_empty(),
+            "expected no custom paths after delete, got {custom:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_admin_skill_path_post_empty_returns_400() {
+        let state = make_admin_state();
+        let router = build_admin_router(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/skill-paths")
+                    .header("content-type", "application/json")
+                    .body(axum::body::Body::from(
+                        serde_json::to_vec(&serde_json::json!({"path": ""})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_admin_skill_path_post_without_lane_returns_503() {
+        // AdminState without sqlite lane attached
+        let state = make_admin_state();
+        let router = build_admin_router(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/skill-paths")
+                    .header("content-type", "application/json")
+                    .body(axum::body::Body::from(
+                        serde_json::to_vec(&serde_json::json!({"path": "/valid/path"})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/skill_mgmt.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/skill_mgmt.rs
@@ -92,7 +92,9 @@ pub(crate) async fn skill_mgmt_dispatch(
             let targets = targets_for_fanout(gs, dcc_filter).await;
             if targets.is_empty() {
                 return (
-                    "No live DCC instances. Start dcc-mcp-server on the DCC you want to use."
+                    "No live DCC instances. Start dcc-mcp-server (or your DCC adapter) so the gateway can fan out skill tools. \
+Standalone `dcc-mcp-server` without `--app` registers as `dcc_type` from DCC_MCP_STANDALONE_REGISTRY_DCC_TYPE (default `generic`); \
+`unknown` is hidden from fan-out unless gateway `allow_unknown_tools` is enabled."
                         .to_string(),
                     true,
                 );

--- a/crates/dcc-mcp-gateway/src/gateway/config.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/config.rs
@@ -1,4 +1,51 @@
-use super::*;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+/// Admin persistence configuration (SQLite + skill-path reload hook).
+///
+/// Grouped to satisfy the Open/Closed Principle: adding new admin-persist
+/// knobs extends this struct without changing `start_gateway_tasks` or
+/// `GatewayRunner` call sites.
+pub struct AdminPersistConfig {
+    /// Optional explicit path for the gateway admin SQLite database
+    /// (traces, audits, custom skill paths). When `None`, uses
+    /// `DCC_MCP_GATEWAY_ADMIN_DB` or `<registry>/gateway_admin.sqlite`.
+    pub sqlite_path: Option<PathBuf>,
+
+    /// Retention window for rows in the admin SQLite database (days).
+    ///
+    /// Default: `30`. Override with `DCC_MCP_GATEWAY_ADMIN_RETENTION_DAYS`.
+    pub sqlite_retention_days: u32,
+
+    /// Snapshot of skill search paths (for the admin UI); populated by embedders.
+    pub skill_paths_snapshot: Vec<super::SkillPathEntry>,
+
+    /// When set, invoked after admin API adds/removes a custom SQLite skill path
+    /// so embedders can re-run `SkillCatalog::discover` without restarting the process.
+    pub skill_paths_reload: Option<Arc<dyn Fn() + Send + Sync>>,
+}
+
+impl Default for AdminPersistConfig {
+    fn default() -> Self {
+        Self {
+            sqlite_path: None,
+            sqlite_retention_days: 30,
+            skill_paths_snapshot: Vec::new(),
+            skill_paths_reload: None,
+        }
+    }
+}
+
+impl Clone for AdminPersistConfig {
+    fn clone(&self) -> Self {
+        Self {
+            sqlite_path: self.sqlite_path.clone(),
+            sqlite_retention_days: self.sqlite_retention_days,
+            skill_paths_snapshot: self.skill_paths_snapshot.clone(),
+            skill_paths_reload: self.skill_paths_reload.clone(),
+        }
+    }
+}
 
 /// Configuration for the optional gateway.
 pub struct GatewayConfig {
@@ -84,6 +131,9 @@ pub struct GatewayConfig {
     /// Default: `2`. Override at runtime with
     /// `DCC_MCP_GATEWAY_HEALTH_FAILURES`.
     pub health_check_failures: u32,
+
+    /// Admin persistence settings (SQLite, skill-path snapshot, reload hook).
+    pub admin_persist: AdminPersistConfig,
 }
 
 impl Default for GatewayConfig {
@@ -110,6 +160,7 @@ impl Default for GatewayConfig {
             admin_path: "/admin".to_string(),
             health_check_interval_secs: 5,
             health_check_failures: 2,
+            admin_persist: AdminPersistConfig::default(),
         }
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/event_log.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/event_log.rs
@@ -218,6 +218,7 @@ pub fn record_event(
             EventKind::AutoDeregister => {
                 metrics.inc_eviction(event.as_label());
             }
+            EventKind::OperatorNote => {}
         }
     }
 

--- a/crates/dcc-mcp-gateway/src/gateway/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/mod.rs
@@ -54,6 +54,9 @@ pub use middleware::MiddlewareChain;
 pub mod metrics;
 
 pub mod admin;
+pub mod skill_paths;
+
+pub use skill_paths::SkillPathEntry;
 
 pub use router::{build_gateway_router, build_gateway_router_with_admin};
 pub use state::{GatewayState, ResolveInstanceError, entry_to_json};
@@ -65,7 +68,6 @@ pub use capability::{
 };
 
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -108,7 +110,7 @@ mod tasks;
 mod version;
 
 pub(crate) use bind::try_bind_port_opt;
-pub use config::GatewayConfig;
+pub use config::{AdminPersistConfig, GatewayConfig};
 pub(crate) use handle::ElectionOutcome;
 pub use handle::GatewayHandle;
 pub use runner::GatewayRunner;

--- a/crates/dcc-mcp-gateway/src/gateway/runner.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/runner.rs
@@ -264,6 +264,8 @@ impl GatewayRunner {
                     self.config.admin_enabled,
                     #[cfg(feature = "admin")]
                     self.config.admin_path.clone(),
+                    #[cfg(feature = "admin")]
+                    self.config.admin_persist.clone(),
                     self.config.health_check_interval_secs,
                     self.config.health_check_failures,
                 )
@@ -419,6 +421,8 @@ impl GatewayRunner {
         let admin_enabled = self.config.admin_enabled;
         #[cfg(feature = "admin")]
         let admin_path = self.config.admin_path.clone();
+        #[cfg(feature = "admin")]
+        let admin_persist = self.config.admin_persist.clone();
         let health_check_interval_secs = self.config.health_check_interval_secs;
         let health_check_failures = self.config.health_check_failures;
 
@@ -496,6 +500,8 @@ impl GatewayRunner {
                         admin_enabled,
                         #[cfg(feature = "admin")]
                         admin_path.clone(),
+                        #[cfg(feature = "admin")]
+                        admin_persist.clone(),
                         health_check_interval_secs,
                         health_check_failures,
                     )

--- a/crates/dcc-mcp-gateway/src/gateway/skill_paths.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/skill_paths.rs
@@ -1,0 +1,36 @@
+//! Skill search path entries for admin UI and embedder snapshots.
+
+use serde::{Deserialize, Serialize};
+
+/// One resolved skill directory with a human-readable source label.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SkillPathEntry {
+    /// Absolute or normalised directory path.
+    pub path: String,
+    /// Origin label, e.g. `cli`, `env:DCC_MCP_SKILL_PATHS`, `bundled`, `admin_custom`.
+    pub source: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serde_roundtrip() {
+        let entry = SkillPathEntry {
+            path: "/opt/skills/maya".to_string(),
+            source: "cli".to_string(),
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        let back: SkillPathEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(entry, back);
+    }
+
+    #[test]
+    fn deserialize_from_json_literal() {
+        let json = r#"{"path":"/home/user/.dcc-mcp/skills","source":"env:DCC_MCP_SKILL_PATHS"}"#;
+        let entry: SkillPathEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.path, "/home/user/.dcc-mcp/skills");
+        assert_eq!(entry.source, "env:DCC_MCP_SKILL_PATHS");
+    }
+}

--- a/crates/dcc-mcp-gateway/src/gateway/tasks.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tasks.rs
@@ -22,6 +22,10 @@ pub(crate) struct GatewayTasks {
     pub(crate) yield_tx: Arc<watch::Sender<bool>>,
 }
 
+/// Capacity of the in-memory audit ring buffer and SQLite merge limit.
+#[cfg(feature = "admin")]
+const ADMIN_AUDIT_RING_CAPACITY: usize = 512;
+
 /// Build and run the gateway HTTP server with graceful-yield and live-push support.
 ///
 /// Returns a [`GatewayTasks`] handle holding both the `AbortHandle` and the
@@ -51,6 +55,7 @@ pub(crate) async fn start_gateway_tasks(
     middleware_chain: crate::gateway::middleware::MiddlewareChain,
     #[cfg(feature = "admin")] admin_enabled: bool,
     #[cfg(feature = "admin")] admin_path: String,
+    #[cfg(feature = "admin")] admin_persist: crate::gateway::config::AdminPersistConfig,
     health_check_interval_secs: u64,
     health_check_failures: u32,
 ) -> Result<GatewayTasks, Box<dyn std::error::Error + Send + Sync>> {
@@ -546,11 +551,18 @@ pub(crate) async fn start_gateway_tasks(
 
             // 1. Shared ring buffer — the middleware writes here; the handler reads it.
             let audit_log: std::sync::Arc<crate::gateway::admin::state::AuditLog> =
-                std::sync::Arc::new(parking_lot::Mutex::new(Vec::with_capacity(512)));
+                std::sync::Arc::new(parking_lot::Mutex::new(Vec::with_capacity(
+                    ADMIN_AUDIT_RING_CAPACITY,
+                )));
             if let Some(store) = &durable_store {
-                audit_log
-                    .lock()
-                    .extend(store.load_audit().into_iter().rev().take(512).rev());
+                audit_log.lock().extend(
+                    store
+                        .load_audit()
+                        .into_iter()
+                        .rev()
+                        .take(ADMIN_AUDIT_RING_CAPACITY)
+                        .rev(),
+                );
             }
 
             // 2. Phase 2 trace log — ring buffer for per-call dispatch traces.
@@ -562,12 +574,47 @@ pub(crate) async fn start_gateway_tasks(
                 trace_log.extend(store.load_traces());
             }
 
+            let db_path = dcc_mcp_db::resolve_gateway_admin_sqlite_path(
+                admin_persist.sqlite_path.as_ref(),
+                None,
+            );
+            let sqlite_lane = match crate::gateway::admin::sqlite_lane::AdminSqliteLane::spawn(
+                db_path,
+                admin_persist.sqlite_retention_days.clamp(1, 3650),
+            ) {
+                Ok(l) => Some(l),
+                Err(e) => {
+                    tracing::warn!(error = %e, "gateway admin SQLite unavailable");
+                    None
+                }
+            };
+            if let Some(ref lane) = sqlite_lane {
+                let r = lane.reader();
+                trace_log.extend(r.list_traces_since(None, 10_000));
+                let from_sqlite = r.list_audits_recent(ADMIN_AUDIT_RING_CAPACITY);
+                if !from_sqlite.is_empty() {
+                    let mut buf = audit_log.lock();
+                    let mut merged: Vec<crate::gateway::admin::state::AdminAuditRecord> =
+                        from_sqlite;
+                    merged.extend(buf.drain(..));
+                    merged.sort_by_key(|a| a.timestamp);
+                    let overflow = merged.len().saturating_sub(ADMIN_AUDIT_RING_CAPACITY);
+                    if overflow > 0 {
+                        merged.drain(0..overflow);
+                    }
+                    *buf = merged;
+                }
+            }
+
             // 3. Build the sink that feeds the audit ring buffer and the trace log.
             let mut admin_sink = crate::gateway::admin::state::AdminAuditSink::new(
                 audit_log.clone(),
-                /* capacity = */ 512,
+                ADMIN_AUDIT_RING_CAPACITY,
             )
             .with_trace_log(trace_log.clone());
+            if let Some(ref lane) = sqlite_lane {
+                admin_sink = admin_sink.with_sqlite_lane(lane.clone());
+            }
             if let Some(store) = durable_store.clone() {
                 admin_sink = admin_sink.with_durable_store(store);
             }
@@ -587,10 +634,14 @@ pub(crate) async fn start_gateway_tasks(
             }
 
             // 5. Build AdminState with audit log and trace log attached.
+            let sqlite_reader = sqlite_lane.as_ref().map(|l| l.reader());
             Some(
                 crate::gateway::admin::state::AdminState::new(gw_state.clone())
                     .with_audit_log(audit_log)
-                    .with_trace_log(trace_log),
+                    .with_trace_log(trace_log, sqlite_reader)
+                    .with_skill_paths_snapshot(admin_persist.skill_paths_snapshot)
+                    .with_admin_sqlite_lane(sqlite_lane)
+                    .with_skill_paths_reload(admin_persist.skill_paths_reload.clone()),
             )
         } else {
             None

--- a/crates/dcc-mcp-http/Cargo.toml
+++ b/crates/dcc-mcp-http/Cargo.toml
@@ -18,7 +18,7 @@ dcc-mcp-protocols = { path = "../dcc-mcp-protocols" }
 dcc-mcp-jsonrpc = { path = "../dcc-mcp-jsonrpc" }
 dcc-mcp-job = { path = "../dcc-mcp-job" }
 dcc-mcp-skill-rest = { path = "../dcc-mcp-skill-rest" }
-dcc-mcp-gateway = { path = "../dcc-mcp-gateway", features = ["admin"] }
+dcc-mcp-gateway = { path = "../dcc-mcp-gateway", features = ["admin", "admin-persist-sqlite"] }
 dcc-mcp-models = { path = "../dcc-mcp-models" }
 dcc-mcp-skills = { path = "../dcc-mcp-skills" }
 dcc-mcp-pybridge = { path = "../dcc-mcp-pybridge", optional = true }

--- a/crates/dcc-mcp-http/src/server/gateway_impl.rs
+++ b/crates/dcc-mcp-http/src/server/gateway_impl.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use crate::config::McpHttpConfig;
 use crate::server::{LiveMeta, LiveMetaInner};
 use dcc_mcp_gateway::{GatewayConfig, GatewayRunner, LiveSnapshot, MetadataProvider};
+use dcc_mcp_skills::constants::resolve_registry_dcc_type;
 use dcc_mcp_transport::discovery::types::ServiceEntry;
 
 pub(crate) async fn start_gateway_runner(
@@ -40,6 +41,7 @@ pub(crate) async fn start_gateway_runner(
         admin_path: config.gateway.admin_path.clone(),
         health_check_interval_secs: 5,
         health_check_failures: 2,
+        admin_persist: dcc_mcp_gateway::AdminPersistConfig::default(),
     };
 
     let runner = match GatewayRunner::new(gateway_config) {
@@ -51,7 +53,7 @@ pub(crate) async fn start_gateway_runner(
     };
 
     let mut entry = ServiceEntry::new(
-        config.instance.dcc_type.as_deref().unwrap_or("unknown"),
+        resolve_registry_dcc_type(config.instance.dcc_type.as_deref()),
         config.server.host.to_string(),
         port,
     );

--- a/crates/dcc-mcp-server/Cargo.toml
+++ b/crates/dcc-mcp-server/Cargo.toml
@@ -39,7 +39,7 @@ tower-http = { version = "0.6", features = ["cors", "trace"] }
 clap = { version = "4", features = ["derive", "env"] }
 sysinfo.workspace = true
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
-dcc-mcp-gateway = { version = "0.17.0", path = "../dcc-mcp-gateway" }
+dcc-mcp-gateway = { version = "0.17.0", path = "../dcc-mcp-gateway", features = ["admin", "admin-persist-sqlite"] }
 
 [features]
 default = []

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -72,9 +72,13 @@
 //! | `DCC_MCP_GATEWAY_PORT`    | Gateway port to compete for (default 9765, 0=off)  |
 //! | `DCC_MCP_NO_ADMIN`        | Disable read-only `/admin` on the elected gateway  |
 //! | `DCC_MCP_ADMIN_PATH`      | Admin URL prefix (default `/admin`)                |
+//! | `DCC_MCP_GATEWAY_ADMIN_DB` | Override path for admin SQLite (traces / skill paths) |
+//! | `DCC_MCP_GATEWAY_ADMIN_RETENTION_DAYS` | Admin SQLite retention in days (default 30, max 3650) |
+//! | `DCC_MCP_STANDALONE_REGISTRY_DCC_TYPE` | FileRegistry `dcc_type` when `--app` is empty (default `generic`) |
 //! | `DCC_MCP_REGISTRY_DIR`    | Shared FileRegistry directory                      |
 //! | `DCC_MCP_STALE_TIMEOUT`   | Seconds without heartbeat = stale (default 30)     |
 
+use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::sync::Arc;
@@ -82,13 +86,44 @@ use std::time::Duration;
 
 use clap::{Parser, Subcommand};
 use dcc_mcp_actions::{ToolDispatcher, ToolRegistry};
-use dcc_mcp_gateway::{GatewayConfig, GatewayRunner};
+use dcc_mcp_gateway::{AdminPersistConfig, GatewayConfig, GatewayRunner, SkillPathEntry};
 use dcc_mcp_http::{McpHttpConfig, McpHttpServer};
 use dcc_mcp_logging::file_logging::prune_old_logs;
 use dcc_mcp_skills::SkillCatalog;
+use dcc_mcp_skills::constants::{
+    ENV_SKILL_PATHS, app_skill_paths_env_key, resolve_registry_dcc_type,
+};
 use dcc_mcp_transport::discovery::types::ServiceEntry;
 use sysinfo::{Pid, ProcessesToUpdate, System};
 mod translate;
+
+// #region agent log
+/// NDJSON debug ingest (session `ce2112`). Set `DCC_MCP_AGENT_DEBUG_LOG` to a file path to enable.
+fn agent_debug_log(hypothesis_id: &str, location: &str, message: &str, data: serde_json::Value) {
+    let Ok(path) = std::env::var("DCC_MCP_AGENT_DEBUG_LOG") else {
+        return;
+    };
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    let payload = serde_json::json!({
+        "sessionId": "ce2112",
+        "hypothesisId": hypothesis_id,
+        "location": location,
+        "message": message,
+        "data": data,
+        "timestamp": ts,
+    });
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        let _ = writeln!(f, "{}", payload);
+    }
+}
+// #endregion agent log
 
 // ── CLI ───────────────────────────────────────────────────────────────────────
 
@@ -629,23 +664,68 @@ async fn main() -> anyhow::Result<()> {
 
     // ── Collect skill paths ───────────────────────────────────────────────
 
+    let registry_dir_path: Option<PathBuf> = args.registry_dir.as_deref().map(PathBuf::from);
+
+    let mut skill_paths_snapshot: Vec<SkillPathEntry> = Vec::new();
+    for p in &args.skill_paths {
+        skill_paths_snapshot.push(SkillPathEntry {
+            path: p.display().to_string(),
+            source: "cli".into(),
+        });
+    }
+
     let mut skill_paths: Vec<PathBuf> = args.skill_paths.clone();
     skill_paths.extend(
         dcc_mcp_skills::paths::get_skill_paths_from_env()
             .into_iter()
+            .inspect(|s| {
+                skill_paths_snapshot.push(SkillPathEntry {
+                    path: s.clone(),
+                    source: format!("env:{ENV_SKILL_PATHS}"),
+                });
+            })
             .map(PathBuf::from),
     );
     if !args.app.is_empty() {
+        let env_key = app_skill_paths_env_key(&args.app);
         skill_paths.extend(
             dcc_mcp_skills::paths::get_app_skill_paths_from_env(&args.app)
                 .into_iter()
+                .inspect(|s| {
+                    skill_paths_snapshot.push(SkillPathEntry {
+                        path: s.clone(),
+                        source: format!("env:{env_key}"),
+                    });
+                })
                 .map(PathBuf::from),
         );
     }
     if let Ok(bundled) = dcc_mcp_skills::paths::get_skills_dir(None) {
-        let p = PathBuf::from(bundled);
+        let p = PathBuf::from(&bundled);
         if p.exists() {
+            skill_paths_snapshot.push(SkillPathEntry {
+                path: bundled.clone(),
+                source: "bundled".into(),
+            });
             skill_paths.push(p);
+        }
+    }
+
+    let skill_paths_for_catalog_reload = skill_paths.clone();
+
+    let admin_db =
+        dcc_mcp_gateway::gateway::admin::resolve_admin_db_path(None, registry_dir_path.as_ref());
+    for p in
+        dcc_mcp_gateway::gateway::admin::sqlite_lane::read_custom_skill_paths_for_startup(&admin_db)
+    {
+        if p.exists() {
+            skill_paths_snapshot.push(SkillPathEntry {
+                path: p.display().to_string(),
+                source: "admin_custom".into(),
+            });
+            if !skill_paths.iter().any(|x| x == &p) {
+                skill_paths.push(p);
+            }
         }
     }
 
@@ -674,8 +754,67 @@ async fn main() -> anyhow::Result<()> {
                 .collect(),
         )
     };
+
+    // #region agent log
+    let launch_t0 = std::time::Instant::now();
+    agent_debug_log(
+        "H1",
+        "dcc-mcp-server/src/main.rs:pre_discover",
+        "before catalog.discover",
+        serde_json::json!({
+            "skill_path_count": skill_paths.len(),
+            "extra_dir_count": extra_dirs.as_ref().map(|v| v.len()).unwrap_or(0),
+            "app": args.app,
+        }),
+    );
+    // #endregion agent log
+
     let n = catalog.discover(extra_dirs.as_deref(), app_hint);
     tracing::info!("Discovered {} skill(s) in catalog", n);
+
+    // #region agent log
+    agent_debug_log(
+        "H1",
+        "dcc-mcp-server/src/main.rs:post_discover",
+        "after catalog.discover",
+        serde_json::json!({
+            "discovered": n,
+            "discover_ms": launch_t0.elapsed().as_millis(),
+        }),
+    );
+    // #endregion agent log
+
+    let catalog_discover_hook: Arc<dyn Fn() + Send + Sync> = {
+        let catalog = catalog.clone();
+        let base_dirs = skill_paths_for_catalog_reload.clone();
+        let admin_db_path = admin_db.clone();
+        let app_owned = args.app.clone();
+        Arc::new(move || {
+            let mut merged = base_dirs.clone();
+            for p in
+                dcc_mcp_gateway::gateway::admin::read_custom_skill_paths_for_startup(&admin_db_path)
+            {
+                if p.exists() && !merged.iter().any(|x| x == &p) {
+                    merged.push(p);
+                }
+            }
+            let extra: Vec<String> = merged
+                .into_iter()
+                .filter(|p| p.exists())
+                .map(|p| p.display().to_string())
+                .collect();
+            let hint = if app_owned.is_empty() {
+                None
+            } else {
+                Some(app_owned.as_str())
+            };
+            let discovered = catalog.discover(Some(&extra), hint);
+            tracing::info!(
+                discovered,
+                "catalog.discover after admin skill-path change (hook)"
+            );
+        })
+    };
 
     // ── Start MCP HTTP server (DCC-specific tools) ────────────────────────
 
@@ -687,25 +826,69 @@ async fn main() -> anyhow::Result<()> {
         .parse()
         .map_err(|e| anyhow::anyhow!("Invalid --host '{}': {e}", args.host))?;
 
+    // #region agent log
+    agent_debug_log(
+        "H2",
+        "dcc-mcp-server/src/main.rs:pre_mcp_start",
+        "before McpHttpServer::start",
+        serde_json::json!({
+            "spawn_mode": format!("{:?}", config.server.spawn_mode),
+            "self_probe_timeout_ms": config.server.self_probe_timeout_ms,
+            "mcp_port_cli": args.mcp_port,
+            "elapsed_since_launch_ms": launch_t0.elapsed().as_millis(),
+        }),
+    );
+    // #endregion agent log
+
     let mcp_server = McpHttpServer::with_catalog(action_registry.clone(), catalog.clone(), config)
         .with_dispatcher(dispatcher.clone());
 
     let handle = mcp_server.start().await?;
 
+    // #region agent log
+    agent_debug_log(
+        "H2",
+        "dcc-mcp-server/src/main.rs:post_mcp_start",
+        "after McpHttpServer::start",
+        serde_json::json!({
+            "listen_port": handle.port,
+            "bind_addr": handle.bind_addr,
+            "elapsed_since_launch_ms": launch_t0.elapsed().as_millis(),
+        }),
+    );
+    // #endregion agent log
+
+    let registry_dcc =
+        resolve_registry_dcc_type((!args.app.is_empty()).then_some(args.app.as_str()));
+
     tracing::info!(
         "MCP server listening on http://{}:{}/mcp  (app={})",
         args.host,
         handle.port,
-        if args.app.is_empty() {
-            "generic"
-        } else {
-            &args.app
-        }
+        registry_dcc,
     );
 
     // ── Register + gateway competition (via library) ──────────────────────
 
-    let registry_dir_path: Option<PathBuf> = args.registry_dir.as_deref().map(PathBuf::from);
+    // #region agent log
+    agent_debug_log(
+        "H3",
+        "dcc-mcp-server/src/main.rs:pre_gateway_start",
+        "before GatewayRunner::start",
+        serde_json::json!({
+            "gateway_port": args.gateway_port,
+            "registry_dir": registry_dir_path.as_ref().map(|p| p.display().to_string()),
+            "env_registry_dir": std::env::var("DCC_MCP_REGISTRY_DIR").ok(),
+            "elapsed_since_launch_ms": launch_t0.elapsed().as_millis(),
+        }),
+    );
+    // #endregion agent log
+
+    let admin_retention = std::env::var("DCC_MCP_GATEWAY_ADMIN_RETENTION_DAYS")
+        .ok()
+        .and_then(|s| s.parse::<u32>().ok())
+        .unwrap_or(30)
+        .clamp(1, 3650);
 
     let gateway_cfg = GatewayConfig {
         host: args.host.clone(),
@@ -725,21 +908,19 @@ async fn main() -> anyhow::Result<()> {
         },
         admin_enabled: !args.no_admin,
         admin_path: args.admin_path.clone(),
+        admin_persist: AdminPersistConfig {
+            sqlite_path: std::env::var_os("DCC_MCP_GATEWAY_ADMIN_DB").map(PathBuf::from),
+            sqlite_retention_days: admin_retention,
+            skill_paths_snapshot,
+            skill_paths_reload: Some(catalog_discover_hook),
+        },
         ..GatewayConfig::default()
     };
 
     let runner = GatewayRunner::new(gateway_cfg)
         .map_err(|e| anyhow::anyhow!("Failed to create GatewayRunner: {e}"))?;
 
-    let mut entry = ServiceEntry::new(
-        if args.app.is_empty() {
-            "unknown"
-        } else {
-            &args.app
-        },
-        &args.host,
-        handle.port,
-    );
+    let mut entry = ServiceEntry::new(registry_dcc.as_str(), &args.host, handle.port);
     entry.version = args.app_version.clone();
     entry.scene = args.scene.clone();
     entry
@@ -756,6 +937,18 @@ async fn main() -> anyhow::Result<()> {
         .await
         .map_err(|e| anyhow::anyhow!("Failed to start gateway: {e}"))?;
     let is_gateway = gw_handle.is_gateway;
+
+    // #region agent log
+    agent_debug_log(
+        "H3",
+        "dcc-mcp-server/src/main.rs:post_gateway_start",
+        "after GatewayRunner::start",
+        serde_json::json!({
+            "is_gateway": is_gateway,
+            "elapsed_since_launch_ms": launch_t0.elapsed().as_millis(),
+        }),
+    );
+    // #endregion agent log
 
     // ── Start WebSocket bridge (optional) ─────────────────────────────────
 

--- a/crates/dcc-mcp-skills/src/constants.rs
+++ b/crates/dcc-mcp-skills/src/constants.rs
@@ -28,6 +28,38 @@ pub const ENV_TEAM_SKILL_PATHS: &str = "DCC_MCP_TEAM_SKILL_PATHS";
 /// Template for per-app team skill search paths: `DCC_MCP_TEAM_{APP}_SKILL_PATHS`.
 pub const ENV_TEAM_APP_SKILL_PATHS_TEMPLATE: &str = "DCC_MCP_TEAM_{APP}_SKILL_PATHS";
 
+/// Environment variable to override FileRegistry `dcc_type` when the embedder
+/// did not set an app/DCC name (e.g. standalone `dcc-mcp-server` with no `--app`).
+///
+/// Default when unset: [`DEFAULT_STANDALONE_REGISTRY_DCC_TYPE`]. Use a value
+/// other than `unknown` so the gateway includes this instance in `live_instances`
+/// without enabling `allow_unknown_tools`.
+pub const ENV_STANDALONE_REGISTRY_DCC_TYPE: &str = "DCC_MCP_STANDALONE_REGISTRY_DCC_TYPE";
+
+/// Default registry `dcc_type` for standalone / generic hosts (not `"unknown"`).
+pub const DEFAULT_STANDALONE_REGISTRY_DCC_TYPE: &str = "generic";
+
+/// Resolve the `dcc_type` string stored on a [`ServiceEntry`] for MCP registration.
+#[must_use]
+pub fn resolve_registry_dcc_type(embedder_dcc: Option<&str>) -> String {
+    let from_embedder = embedder_dcc.and_then(|s| {
+        let t = s.trim();
+        if t.is_empty() {
+            None
+        } else {
+            Some(t.to_ascii_lowercase())
+        }
+    });
+    if let Some(v) = from_embedder {
+        return v;
+    }
+    std::env::var(ENV_STANDALONE_REGISTRY_DCC_TYPE)
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .map(|s| s.trim().to_ascii_lowercase())
+        .unwrap_or_else(|| DEFAULT_STANDALONE_REGISTRY_DCC_TYPE.to_string())
+}
+
 /// Environment variable to disable automatic discovery of accumulated skills.
 pub const ENV_DISABLE_ACCUMULATED_SKILLS: &str = "DCC_MCP_DISABLE_ACCUMULATED_SKILLS";
 
@@ -235,5 +267,10 @@ mod tests {
             team_skill_paths_env_key("maya"),
             "DCC_MCP_TEAM_MAYA_SKILL_PATHS"
         );
+    }
+
+    #[test]
+    fn test_resolve_registry_dcc_type_prefers_embedder() {
+        assert_eq!(resolve_registry_dcc_type(Some("Maya")), "maya");
     }
 }


### PR DESCRIPTION
## Summary

- **New `dcc-mcp-db` crate** — Clean Architecture (domain/application/infra) for gateway admin SQLite persistence (traces, audits, custom skill paths)
- **Admin skill-path CRUD API** — `GET/POST/DELETE /admin/api/skill-paths` for runtime skill directory management with embedder reload hooks
- **`AdminPersistConfig` refactor** — Groups 4 scattered admin params into one struct, fixing OCP violations and reducing `start_gateway_tasks()` parameter bloat
- **CI fix** — Pin `CARGO`/`RUSTC` env vars via `rustup which` to prevent macOS maturin "unexpected argument metadata" failures; disable sccache for py37 manylinux Docker builds
- **Code quality** — Extract `ADMIN_AUDIT_RING_CAPACITY` constant, add `tracing::warn`/`debug` for polling timeouts and SQLite write failures

## Highlights

| Area | Change |
|------|--------|
| Architecture | `AdminPersistConfig` struct (OCP), `dcc-mcp-db` with domain/app/infra layers |
| Features | Skill-path hot-reload via admin UI, SQLite-backed trace/audit durability |
| CI reliability | Deterministic cargo resolution on macOS runners; fix py37 sccache in Docker |
| Test coverage | +20 new tests (unit + integration) covering SQLite CRUD, log parsing, API endpoints |

## Test plan

- [x] `cargo test -p dcc-mcp-db --features gateway-admin-sqlite` — 17 tests pass
- [x] `cargo test -p dcc-mcp-gateway --features admin,admin-persist-sqlite` — 314 tests pass
- [x] `cargo clippy` with `-D warnings` — zero warnings
- [ ] CI workflow validates maturin fix on macOS runner
- [ ] CI py37 build passes with sccache disabled
- [ ] Manual verification: admin UI skill-paths panel reflects add/delete operations