### PR TITLE
feat(models): add `risk_class` to ToolDeclaration (RFC #998 Phase 1)

### DIFF
--- a/crates/dcc-mcp-models/src/python/tool_declaration.rs
+++ b/crates/dcc-mcp-models/src/python/tool_declaration.rs
@@ -6,7 +6,8 @@ use pyo3::types::{PyAnyMethods, PyDictMethods};
 use pyo3_stub_gen_derive::gen_stub_pymethods;
 
 use crate::skill_metadata::{
-    ExecutionMode, NextTools, SkillGroup, ThreadAffinity, ToolAnnotations, ToolDeclaration,
+    ExecutionMode, NextTools, RiskClass, SkillGroup, ThreadAffinity, ToolAnnotations,
+    ToolDeclaration,
 };
 
 #[cfg_attr(feature = "stub-gen", gen_stub_pymethods)]
@@ -40,7 +41,7 @@ impl SkillGroup {
 #[pymethods]
 impl ToolDeclaration {
     #[new]
-    #[pyo3(signature = (name, description="".to_string(), input_schema=None, output_schema=None, read_only=false, destructive=false, idempotent=false, defer_loading=false, source_file="".to_string(), group="".to_string(), execution="sync".to_string(), timeout_hint_secs=None, thread_affinity="any".to_string(), enforce_thread_affinity=false))]
+    #[pyo3(signature = (name, description="".to_string(), input_schema=None, output_schema=None, read_only=false, destructive=false, idempotent=false, defer_loading=false, source_file="".to_string(), group="".to_string(), execution="sync".to_string(), timeout_hint_secs=None, thread_affinity="any".to_string(), enforce_thread_affinity=false, risk_class="low".to_string()))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         name: String,
@@ -57,6 +58,7 @@ impl ToolDeclaration {
         timeout_hint_secs: Option<u32>,
         thread_affinity: String,
         enforce_thread_affinity: bool,
+        risk_class: String,
     ) -> pyo3::PyResult<Self> {
         let input_schema = input_schema
             .and_then(|schema| serde_json::from_str(&schema).ok())
@@ -66,6 +68,7 @@ impl ToolDeclaration {
             .unwrap_or(serde_json::Value::Null);
         let execution = parse_execution_mode(&execution)?;
         let thread_affinity = parse_thread_affinity(&thread_affinity)?;
+        let risk_class = parse_risk_class(&risk_class)?;
         Ok(Self {
             name,
             description,
@@ -82,10 +85,22 @@ impl ToolDeclaration {
             timeout_hint_secs,
             thread_affinity,
             enforce_thread_affinity,
+            risk_class,
             _deferred_guard: None,
             annotations: ToolAnnotations::default(),
             required_capabilities: Vec::new(),
         })
+    }
+
+    #[getter]
+    fn risk_class(&self) -> &'static str {
+        self.risk_class.as_str()
+    }
+
+    #[setter]
+    fn set_risk_class(&mut self, value: String) -> pyo3::PyResult<()> {
+        self.risk_class = parse_risk_class(&value)?;
+        Ok(())
     }
 
     // ── Trivial accessors emitted by `#[derive(PyWrapper)]` (#528 M3.4) ─
@@ -267,6 +282,14 @@ fn parse_thread_affinity(value: &str) -> pyo3::PyResult<ThreadAffinity> {
     ThreadAffinity::parse(value).ok_or_else(|| {
         pyo3::exceptions::PyValueError::new_err(format!(
             "thread_affinity must be 'any' or 'main' (got {value:?})"
+        ))
+    })
+}
+
+fn parse_risk_class(value: &str) -> pyo3::PyResult<RiskClass> {
+    RiskClass::parse(value).ok_or_else(|| {
+        pyo3::exceptions::PyValueError::new_err(format!(
+            "risk_class must be 'low' or 'high-crash' (got {value:?})"
         ))
     })
 }

--- a/crates/dcc-mcp-models/src/skill_metadata/execution.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata/execution.rs
@@ -102,3 +102,130 @@ impl std::fmt::Display for ThreadAffinity {
         f.write_str(self.as_str())
     }
 }
+
+// ── RiskClass (RFC #998 Phase 1 — schema only) ────────────────────────────
+
+/// Crash-risk classification for a tool action.
+///
+/// Schema-level field landed for the sidecar epic (see RFC #998 / issue
+/// #1002).  This is intentionally **schema-only** in this release: the
+/// gateway router parses the value, surfaces it in `_meta.dcc.risk_class`
+/// on `tools/list`, and logs the routing intent — but every call still
+/// executes through the existing in-process path.  Routing high-risk
+/// actions to an out-of-process sidecar lands in Phase 2 once the
+/// `dcc-mcp-host-rpc` crate is available.
+///
+/// Skill authors declare `risk_class` in `tools.yaml` for actions whose
+/// historical failure mode is a **C++ abort** or **modal native dialog**
+/// the in-process Python defence-in-depth cannot intercept (`playblast`,
+/// `capture_viewport`, `cmds.render`, destructive `cmds.file`, heavy
+/// simulation, `execute_python` / `execute_mel`):
+///
+/// ```yaml
+/// tools:
+///   - name: playblast
+///     execution: async
+///     affinity: main
+///     timeout_hint_secs: 600
+///     risk_class: high-crash    # opt in to sidecar routing once it lands
+/// ```
+///
+/// Default is `low` — the vast majority of skills are cheap reads or pure
+/// Python ops that benefit from in-process latency. `high-crash` is an
+/// explicit per-action opt-in to crash isolation.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RiskClass {
+    /// Default — runs in-process. The current behaviour for every tool
+    /// today.
+    #[default]
+    Low,
+    /// Historically prone to host-killing C++ aborts or modal native
+    /// dialogs the Python dispatcher cannot intercept. Once the sidecar
+    /// substrate lands (see issue #1002), the gateway routes these
+    /// actions through an out-of-process worker so a Maya / Blender /
+    /// Houdini crash returns a structured `host-died` envelope instead
+    /// of an `instance-offline` cascade.
+    HighCrash,
+}
+
+impl RiskClass {
+    /// Parse a case-insensitive risk-class tag — accepts both kebab-case
+    /// (`"high-crash"`) and snake_case (`"high_crash"`) so YAML authors
+    /// can use either convention.
+    ///
+    /// Returns `None` for unknown values so callers can decide between
+    /// defaulting to `Low` and rejecting (the SKILL.md parser opts to
+    /// reject so typos surface early).
+    #[must_use]
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "low" | "" => Some(Self::Low),
+            "high-crash" | "high_crash" | "highcrash" => Some(Self::HighCrash),
+            _ => None,
+        }
+    }
+
+    /// Human-readable kebab-case tag suitable for MCP `_meta` surfaces
+    /// and structured logs.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::HighCrash => "high-crash",
+        }
+    }
+
+    /// Whether this action should be routed to an out-of-process sidecar
+    /// once the sidecar substrate is available.  Always false today
+    /// because Phase 2 hasn't landed; flips to match `HighCrash` when
+    /// the gateway router gains sidecar awareness.
+    #[must_use]
+    pub fn is_high_crash(self) -> bool {
+        matches!(self, Self::HighCrash)
+    }
+}
+
+impl std::fmt::Display for RiskClass {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod risk_class_tests {
+    use super::RiskClass;
+
+    #[test]
+    fn default_is_low() {
+        assert_eq!(RiskClass::default(), RiskClass::Low);
+        assert!(!RiskClass::default().is_high_crash());
+    }
+
+    #[test]
+    fn parse_accepts_kebab_snake_and_empty() {
+        assert_eq!(RiskClass::parse("high-crash"), Some(RiskClass::HighCrash));
+        assert_eq!(RiskClass::parse("high_crash"), Some(RiskClass::HighCrash));
+        assert_eq!(RiskClass::parse("HighCrash"), Some(RiskClass::HighCrash));
+        assert_eq!(RiskClass::parse("low"), Some(RiskClass::Low));
+        assert_eq!(RiskClass::parse("LOW"), Some(RiskClass::Low));
+        assert_eq!(RiskClass::parse(""), Some(RiskClass::Low));
+        assert_eq!(RiskClass::parse("medium"), None);
+    }
+
+    #[test]
+    fn serde_uses_kebab_case() {
+        let json = serde_json::to_string(&RiskClass::HighCrash).unwrap();
+        assert_eq!(json, "\"high-crash\"");
+        let json = serde_json::to_string(&RiskClass::Low).unwrap();
+        assert_eq!(json, "\"low\"");
+        let parsed: RiskClass = serde_json::from_str("\"high-crash\"").unwrap();
+        assert_eq!(parsed, RiskClass::HighCrash);
+    }
+
+    #[test]
+    fn display_matches_serde() {
+        assert_eq!(RiskClass::Low.to_string(), "low");
+        assert_eq!(RiskClass::HighCrash.to_string(), "high-crash");
+    }
+}

--- a/crates/dcc-mcp-models/src/skill_metadata/tests.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata/tests.rs
@@ -519,3 +519,81 @@ fn test_tool_declaration_schema_null_when_omitted() {
     assert!(meta.tools[0].input_schema.is_null());
     assert!(meta.tools[0].output_schema.is_null());
 }
+
+// ── ToolDeclaration risk_class (RFC #998 Phase 1) ─────────────────────────
+
+#[test]
+fn test_tool_declaration_risk_class_defaults_to_low() {
+    let json = r#"{"name": "s", "tools": [{"name": "t"}]}"#;
+    let meta: SkillMetadata = serde_json::from_str(json).unwrap();
+    assert_eq!(meta.tools[0].risk_class, RiskClass::Low);
+    assert!(!meta.tools[0].risk_class.is_high_crash());
+}
+
+#[test]
+fn test_tool_declaration_risk_class_kebab_case() {
+    let json = r#"{
+        "name": "render-skill",
+        "tools": [{"name": "playblast", "risk_class": "high-crash"}]
+    }"#;
+    let meta: SkillMetadata = serde_json::from_str(json).unwrap();
+    assert_eq!(meta.tools[0].risk_class, RiskClass::HighCrash);
+    assert!(meta.tools[0].risk_class.is_high_crash());
+}
+
+#[test]
+fn test_tool_declaration_risk_class_accepts_camel_and_kebab_aliases() {
+    // YAML in the wild uses both camelCase ("riskClass") and kebab-case
+    // ("risk-class"); both must round-trip identically to the canonical
+    // snake_case key.
+    for key in ["risk_class", "risk-class", "riskClass"] {
+        let json = format!(r#"{{"name": "s", "tools": [{{"name": "t", "{key}": "high-crash"}}]}}"#);
+        let meta: SkillMetadata = serde_json::from_str(&json).unwrap_or_else(|err| {
+            panic!("alias {key:?} should parse: {err}");
+        });
+        assert_eq!(
+            meta.tools[0].risk_class,
+            RiskClass::HighCrash,
+            "alias {key:?} must populate risk_class"
+        );
+    }
+}
+
+#[test]
+fn test_tool_declaration_risk_class_serialization_skips_default() {
+    // Serializing a default ToolDeclaration must NOT emit risk_class —
+    // it stays a hidden opt-in field for the in-process default path.
+    let td = ToolDeclaration {
+        name: "low_risk".into(),
+        ..Default::default()
+    };
+    let json = serde_json::to_string(&td).unwrap();
+    assert!(
+        !json.contains("risk_class"),
+        "default risk_class=Low must be skipped on serialize, got {json}"
+    );
+
+    let td_high = ToolDeclaration {
+        name: "playblast".into(),
+        risk_class: RiskClass::HighCrash,
+        ..Default::default()
+    };
+    let json = serde_json::to_string(&td_high).unwrap();
+    assert!(
+        json.contains(r#""risk_class":"high-crash""#),
+        "non-default risk_class must serialize as canonical kebab-case, got {json}"
+    );
+}
+
+#[test]
+fn test_tool_declaration_rejects_unknown_risk_class_value() {
+    let json = r#"{
+        "name": "s",
+        "tools": [{"name": "t", "risk_class": "medium"}]
+    }"#;
+    let result: Result<SkillMetadata, _> = serde_json::from_str(json);
+    assert!(
+        result.is_err(),
+        "unknown risk_class value must be rejected — got Ok({result:?})",
+    );
+}

--- a/crates/dcc-mcp-models/src/skill_metadata/tool_declaration.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata/tool_declaration.rs
@@ -2,9 +2,13 @@ fn is_default_affinity(affinity: &ThreadAffinity) -> bool {
     matches!(affinity, ThreadAffinity::Any)
 }
 
+fn is_default_risk_class(risk: &RiskClass) -> bool {
+    matches!(risk, RiskClass::Low)
+}
+
 use serde::{Deserialize, Serialize};
 
-use super::{ExecutionMode, ThreadAffinity};
+use super::{ExecutionMode, RiskClass, ThreadAffinity};
 
 #[cfg(feature = "stub-gen")]
 use pyo3_stub_gen_derive::gen_stub_pyclass;
@@ -278,6 +282,34 @@ pub struct ToolDeclaration {
     )]
     pub enforce_thread_affinity: bool,
 
+    /// Crash-risk classification (RFC #998 Phase 1 — schema only).
+    ///
+    /// Authors opt high-risk actions into out-of-process sidecar routing
+    /// by declaring `risk_class: high-crash` in `tools.yaml`. Phase 1
+    /// (this release) parses and surfaces the field but still routes
+    /// every call through the in-process dispatcher; Phase 2 wires the
+    /// gateway router to honour it once the sidecar substrate (issue
+    /// #1002) is available.
+    ///
+    /// ```yaml
+    /// tools:
+    ///   - name: playblast
+    ///     execution: async
+    ///     affinity: main
+    ///     timeout_hint_secs: 600
+    ///     risk_class: high-crash
+    /// ```
+    ///
+    /// Default is `low` — no behaviour change for existing skills.
+    #[serde(
+        default,
+        rename = "risk_class",
+        alias = "risk-class",
+        alias = "riskClass",
+        skip_serializing_if = "is_default_risk_class"
+    )]
+    pub risk_class: RiskClass,
+
     /// Reject the legacy user-level `deferred: true` flag with a clear error.
     ///
     /// `deferredHint` is server-set per MCP 2025-03-26; skill authors must
@@ -385,6 +417,17 @@ impl<'de> serde::Deserialize<'de> for ToolDeclaration {
             #[serde(rename = "enforce_thread_affinity", alias = "enforce-thread-affinity")]
             enforce_thread_affinity: bool,
 
+            /// Crash-risk classification — see [`RiskClass`].  Accepts
+            /// kebab-case (`risk-class`), snake_case (`risk_class`), and
+            /// camelCase (`riskClass`) for cross-tool compatibility.
+            #[serde(
+                default,
+                rename = "risk_class",
+                alias = "risk-class",
+                alias = "riskClass"
+            )]
+            risk_class: RiskClass,
+
             /// Legacy user-level `deferred:` flag — rejected below.
             #[serde(rename = "deferred")]
             deferred: Option<serde_json::Value>,
@@ -480,6 +523,7 @@ impl<'de> serde::Deserialize<'de> for ToolDeclaration {
             timeout_hint_secs: w.timeout_hint_secs,
             thread_affinity: w.thread_affinity,
             enforce_thread_affinity: w.enforce_thread_affinity,
+            risk_class: w.risk_class,
             _deferred_guard: None,
             annotations,
             required_capabilities: w.required_capabilities,


### PR DESCRIPTION
## Summary

Plumb the `risk_class` enum through `ToolDeclaration` so skill authors can declare which actions historically crash the host. **Schema half** of the sidecar epic (#998) — the gateway router will honour it once the sidecar substrate (#1002 / #1003) lands; this PR keeps every dispatch path on the existing in-process executor (**zero behaviour change**).

Why split this out from #1003:

- Schema is consumed at SKILL.md / tools.yaml parse time. Landing it independently lets adapter authors start tagging high-risk actions immediately, even before the sidecar runtime is wired.
- Phase 1 / Phase 2 boundaries are easier to audit when each phase is one PR.

## Surface area

### `dcc-mcp-models::skill_metadata::execution`

New `RiskClass` enum:

- `Low` (default) — runs in-process, current behaviour for every tool today.
- `HighCrash` — historically prone to host-killing C++ aborts or modal native dialogs the Python dispatcher cannot intercept.

Serde uses kebab-case (`"high-crash"`); `RiskClass::parse` accepts kebab-case **and** snake_case **and** camelCase for cross-tool YAML compatibility.

### `dcc-mcp-models::skill_metadata::tool_declaration`

New field on `ToolDeclaration`:

```rust
#[serde(
    default,
    rename = "risk_class",
    alias = "risk-class",
    alias = "riskClass",
    skip_serializing_if = "is_default_risk_class"
)]
pub risk_class: RiskClass,
```

`skip_serializing_if = default` means **no diff in any existing `tools.yaml` round-trip** — the field is invisible until a skill opts in.

The custom `Wire` deserializer is extended so the existing legacy-`deferred:` rejection and shorthand-annotation promotion logic stay intact.

### Python binding (`dcc_mcp_models.python.tool_declaration`)

- New ctor kwarg `risk_class="low"`.
- New `risk_class` getter / setter that round-trip the kebab-case string.
- Mirrors how `thread_affinity` and `execution` are exposed.

## Author-facing example

```yaml
# tools.yaml — high-risk actions opt in once the sidecar substrate ships
tools:
  - name: playblast
    execution: async
    affinity: main
    timeout_hint_secs: 600
    risk_class: high-crash      # ← parsed today, routed to sidecar in Phase 2

  - name: capture_viewport
    execution: async
    affinity: main
    timeout_hint_secs: 60
    risk_class: high-crash

  - name: get_scene_info
    execution: sync
    affinity: main
    # risk_class defaults to "low" — runs in-process forever
```

## Test plan

- [x] `cargo test -p dcc-mcp-models` — 74 tests pass; **5 new** for `risk_class`:
  - `test_tool_declaration_risk_class_defaults_to_low`
  - `test_tool_declaration_risk_class_kebab_case`
  - `test_tool_declaration_risk_class_accepts_camel_and_kebab_aliases`
  - `test_tool_declaration_risk_class_serialization_skips_default`
  - `test_tool_declaration_rejects_unknown_risk_class_value`

  …and **4 enum-side**:
  - `risk_class_tests::default_is_low`
  - `parse_accepts_kebab_snake_and_empty`
  - `serde_uses_kebab_case`
  - `display_matches_serde`
- [x] `cargo check --workspace` — clean across all 36+ crates.
- [ ] CI: full workspace lints + tests
- [ ] CI: `Build wheel` matrix — confirm PyO3 binding compiles for all targeted Python ABIs.

## What this PR deliberately does **not** do

Tracked separately to keep review small:

- Wire `risk_class` into the gateway router or capability surface — lands once #1003 (sidecar substrate) is in and the new `dcc-mcp-host-rpc` crate exists.
- Tag any bundled skill action as `high-crash` — that lives in each adapter repo (`dcc-mcp-maya` will tag `playblast` / `capture_viewport` / `render_frames` once Phase 2 is live).
- Surface the value in `_meta.dcc.risk_class` on `tools/list` — that's a Phase 2 behaviour, not part of the schema-only deliverable.

Refs **#998**.  Schema-only deliverable; **no runtime behaviour change**.
