### PR TITLE
feat(host-rpc): CommandPortClient + URI scheme registry, sidecar wires HostRpcClient on startup (RFC #998 Phase 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,6 +1286,7 @@ dependencies = [
  "dcc-mcp-actions",
  "dcc-mcp-catalog",
  "dcc-mcp-gateway",
+ "dcc-mcp-host-rpc",
  "dcc-mcp-http",
  "dcc-mcp-jsonrpc",
  "dcc-mcp-logging",

--- a/crates/dcc-mcp-host-rpc/src/commandport.rs
+++ b/crates/dcc-mcp-host-rpc/src/commandport.rs
@@ -1,0 +1,601 @@
+//! `CommandPortClient` — `HostRpcClient` over Maya's `commandPort` wire.
+//!
+//! This is the **first real per-DCC impl** of the [`HostRpcClient`]
+//! trait (RFC #998 Phase 2, follow-up to PR #1005). The sidecar binary
+//! at runtime picks this impl when `--host-rpc commandport://host:port`
+//! is given.
+//!
+//! # Wire format
+//!
+//! Maya's `commandPort` (opened with
+//! `cmds.commandPort(name=":NNNN", sourceType="python", noreturn=False)`)
+//! is a plain TCP socket. The protocol is line-oriented:
+//!
+//! 1. Client connects.
+//! 2. Client sends a Python expression terminated by `\n`.
+//! 3. Maya evaluates the expression on its main thread.
+//! 4. Maya writes the result as a single `\n`-terminated line back
+//!    over the same socket. Empty line means "no return value".
+//!
+//! We pack `(action, args, request_id)` into a single Python call:
+//!
+//! ```python
+//! __import__('dcc_mcp_maya._sidecar', fromlist=['dispatch']).dispatch(
+//!     {"action": "...", "args": {...}, "request_id": "..."}
+//! )
+//! ```
+//!
+//! The Python side (`dcc_mcp_maya._sidecar.dispatch` — to be added in
+//! the matching `dcc-mcp-maya` PR) is expected to return a JSON string
+//! that the client parses back into a [`serde_json::Value`]. Until that
+//! Python helper exists, the integration tests against a fake TCP
+//! server prove the wire path is correct.
+//!
+//! # Cancellation
+//!
+//! `commandPort` does not support out-of-band cancellation — once a
+//! Python expression starts evaluating on Maya's main thread, the only
+//! way to abort it is via Maya's own escape-key mechanism (which the
+//! sidecar cannot trigger remotely). So `cancel()` is a no-op stub
+//! today. Future work: combine with Maya's `cmds.terminateLongRunning`
+//! when that lands.
+//!
+//! # Concurrency
+//!
+//! Maya's `commandPort` is single-threaded — only one in-flight
+//! request at a time per port. The client serialises calls via a
+//! [`tokio::sync::Mutex`] over the connection state. Concurrent
+//! gateway callers stack up on the mutex without races.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde::Serialize;
+use serde_json::Value;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpStream;
+use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
+use tokio::sync::Mutex;
+
+use crate::{HostRpcClient, HostRpcError};
+
+/// The URI scheme this impl handles. Pinned as a constant so the
+/// scheme registry and tests both reference the same string.
+pub const URI_SCHEME: &str = "commandport";
+
+/// `HostRpcClient` over Maya's `commandPort`.
+///
+/// Instantiate via [`CommandPortClient::new`], then call
+/// [`HostRpcClient::connect`] to dial the TCP socket. After that the
+/// sidecar binary drives [`HostRpcClient::call`] / `cancel` / `close`
+/// just like any other impl.
+#[derive(Debug)]
+pub struct CommandPortClient {
+    state: Arc<Mutex<Option<Connection>>>,
+}
+
+#[derive(Debug)]
+struct Connection {
+    writer: OwnedWriteHalf,
+    reader: BufReader<OwnedReadHalf>,
+}
+
+impl CommandPortClient {
+    /// Construct a disconnected client. Call [`HostRpcClient::connect`]
+    /// before the first [`HostRpcClient::call`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+impl Default for CommandPortClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Wire envelope sent over `commandPort`. Serialised as a JSON object
+/// argument to the Python `dispatch` helper that lives inside Maya.
+#[derive(Serialize)]
+struct WireFrame<'a> {
+    action: &'a str,
+    args: &'a Value,
+    request_id: &'a str,
+}
+
+#[async_trait]
+impl HostRpcClient for CommandPortClient {
+    fn uri_scheme(&self) -> &'static str {
+        URI_SCHEME
+    }
+
+    async fn connect(&mut self, endpoint: &str, timeout: Duration) -> Result<(), HostRpcError> {
+        let (host, port) = parse_endpoint(endpoint)?;
+        let stream = tokio::time::timeout(timeout, TcpStream::connect((host.as_str(), port)))
+            .await
+            .map_err(|_| HostRpcError::Timeout {})?
+            .map_err(|e| HostRpcError::transport(format!("commandport connect {endpoint}: {e}")))?;
+        // Disable Nagle so single-line MCP `tools/call` round-trips
+        // are not artificially delayed by the kernel coalescing.
+        let _ = stream.set_nodelay(true);
+        let (read_half, write_half) = stream.into_split();
+        *self.state.lock().await = Some(Connection {
+            writer: write_half,
+            reader: BufReader::new(read_half),
+        });
+        Ok(())
+    }
+
+    async fn call(
+        &self,
+        action: &str,
+        args: Value,
+        request_id: &str,
+    ) -> Result<Value, HostRpcError> {
+        let frame = WireFrame {
+            action,
+            args: &args,
+            request_id,
+        };
+        let payload_json = serde_json::to_string(&frame)
+            .map_err(|e| HostRpcError::transport(format!("encode wire frame: {e}")))?;
+        // Single-line Python expression invoking the in-Maya dispatcher.
+        // `__import__` form keeps it independent of `from … import …`
+        // module-cache state inside the Maya session.
+        let expression = format!(
+            "__import__('dcc_mcp_maya._sidecar', fromlist=['dispatch']).dispatch({payload_json})\n",
+        );
+
+        let mut guard = self.state.lock().await;
+        let conn = guard
+            .as_mut()
+            .ok_or_else(|| HostRpcError::transport("CommandPortClient::call before connect"))?;
+
+        if let Err(e) = conn.writer.write_all(expression.as_bytes()).await {
+            return Err(io_error_to_host_rpc(
+                e,
+                "commandport write",
+                action,
+                args,
+                guard,
+            ));
+        }
+        if let Err(e) = conn.writer.flush().await {
+            return Err(io_error_to_host_rpc(
+                e,
+                "commandport flush",
+                action,
+                args,
+                guard,
+            ));
+        }
+
+        let mut buf = String::new();
+        match conn.reader.read_line(&mut buf).await {
+            Ok(0) => {
+                // Socket closed mid-call — Maya died (or commandPort
+                // was torn down). Surface as the canonical host-died
+                // signal so the gateway can emit a structured event.
+                *guard = None;
+                Err(HostRpcError::host_died(action, Some(args)))
+            }
+            Ok(_) => {
+                let line = buf.trim_end_matches(['\r', '\n']);
+                if line.is_empty() {
+                    // Maya commandPort returns an empty line when the
+                    // Python expression evaluated to `None`. Map to
+                    // `null` rather than failing — agents see a
+                    // structured "no result" envelope.
+                    return Ok(Value::Null);
+                }
+                serde_json::from_str::<Value>(line).map_err(|e| {
+                    HostRpcError::transport(format!(
+                        "commandport returned non-JSON line ({e}); raw: {line:?}",
+                    ))
+                })
+            }
+            Err(e) => Err(io_error_to_host_rpc(
+                e,
+                "commandport read",
+                action,
+                args,
+                guard,
+            )),
+        }
+    }
+
+    fn is_alive(&self) -> bool {
+        // Best-effort. A held lock means a call is in flight, which
+        // implies the socket was alive at least up to the read syscall.
+        // Reporting "alive" while contended is honest because the
+        // sidecar's eviction logic is meant to fire on terminal
+        // disconnects, not on transient busy windows.
+        match self.state.try_lock() {
+            Ok(guard) => guard.is_some(),
+            Err(_) => true,
+        }
+    }
+
+    async fn close(&self) {
+        let mut guard = self.state.lock().await;
+        if let Some(conn) = guard.take() {
+            drop(conn); // closes the TCP halves
+        }
+    }
+}
+
+/// Map a `tokio` / `std::io::Error` raised during a `commandPort`
+/// read/write/flush into the canonical [`HostRpcError`] envelope.
+///
+/// The hot path is **disconnect mid-call**, which the gateway must
+/// surface as a structured `host-died` event (so agents stop seeing
+/// transport-error cascades when Maya crashes). On Linux/macOS this
+/// usually shows up as `read_line() == Ok(0)` (EOF). On Windows the
+/// remote close more commonly aborts the **next write** first with
+/// WSAECONNABORTED / WSAECONNRESET (mapped by tokio to
+/// `ErrorKind::ConnectionAborted` / `ConnectionReset` / `BrokenPipe`).
+///
+/// Anything else (e.g. `Interrupted`, `WouldBlock` — which tokio
+/// generally retries internally) is left as a plain transport error.
+fn io_error_to_host_rpc(
+    error: std::io::Error,
+    op: &str,
+    action: &str,
+    args: Value,
+    mut guard: tokio::sync::MutexGuard<'_, Option<Connection>>,
+) -> HostRpcError {
+    use std::io::ErrorKind;
+    let is_terminal = matches!(
+        error.kind(),
+        ErrorKind::ConnectionAborted
+            | ErrorKind::ConnectionReset
+            | ErrorKind::BrokenPipe
+            | ErrorKind::NotConnected
+            | ErrorKind::UnexpectedEof,
+    );
+    if is_terminal {
+        // Drop the socket so subsequent calls fail fast at the
+        // "before connect" check instead of dragging another error
+        // out of the dead OS handle.
+        *guard = None;
+        return HostRpcError::host_died(action, Some(args));
+    }
+    HostRpcError::transport(format!("{op}: {error}"))
+}
+
+/// Parse a `commandport://host:port` URI into its TCP target.
+fn parse_endpoint(endpoint: &str) -> Result<(String, u16), HostRpcError> {
+    let rest = endpoint.strip_prefix("commandport://").ok_or_else(|| {
+        HostRpcError::transport(format!("expected commandport:// URI, got {endpoint:?}"))
+    })?;
+    let (host, port_str) = rest.rsplit_once(':').ok_or_else(|| {
+        HostRpcError::transport(format!("commandport URI missing :port — got {endpoint:?}"))
+    })?;
+    if host.is_empty() {
+        return Err(HostRpcError::transport(format!(
+            "commandport URI has empty host — got {endpoint:?}"
+        )));
+    }
+    let port: u16 = port_str.parse().map_err(|_| {
+        HostRpcError::transport(format!(
+            "commandport URI port is not a u16 — got {endpoint:?}"
+        ))
+    })?;
+    if port == 0 {
+        return Err(HostRpcError::transport(format!(
+            "commandport URI port must be non-zero — got {endpoint:?}"
+        )));
+    }
+    Ok((host.to_string(), port))
+}
+
+// ── tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::net::TcpListener;
+    use tokio::sync::oneshot;
+
+    // ── parse_endpoint ───────────────────────────────────────────────────
+
+    #[test]
+    fn parse_endpoint_happy_path() {
+        let (host, port) = parse_endpoint("commandport://127.0.0.1:6042").unwrap();
+        assert_eq!(host, "127.0.0.1");
+        assert_eq!(port, 6042);
+    }
+
+    #[test]
+    fn parse_endpoint_accepts_ipv6_bracketed_form_skipped() {
+        // ipv6 needs `[::1]:6042` style — we only support v4 in this
+        // first slice; pin the behaviour so the future ipv6 PR has a
+        // clear surface to extend.
+        let result = parse_endpoint("commandport://::1:6042");
+        // The `rsplit_once(':')` finds the last ':' which sits in the
+        // middle of the v6 literal, producing a host of "::1" and a
+        // port of "6042". That happens to work for raw `::1` and is
+        // intentional — we just don't promise general v6 support.
+        assert!(
+            result.is_ok(),
+            "loose IPv6 parsing should currently succeed: {result:?}"
+        );
+    }
+
+    #[test]
+    fn parse_endpoint_rejects_wrong_scheme() {
+        for bad in ["http://127.0.0.1:6042", "127.0.0.1:6042", "tcp://x:1"] {
+            let result = parse_endpoint(bad);
+            assert!(
+                matches!(result, Err(HostRpcError::TransportError { .. })),
+                "wrong scheme should reject: {bad}",
+            );
+        }
+    }
+
+    #[test]
+    fn parse_endpoint_rejects_missing_port() {
+        let result = parse_endpoint("commandport://127.0.0.1");
+        assert!(matches!(result, Err(HostRpcError::TransportError { .. })));
+    }
+
+    #[test]
+    fn parse_endpoint_rejects_zero_port() {
+        let result = parse_endpoint("commandport://127.0.0.1:0");
+        assert!(matches!(result, Err(HostRpcError::TransportError { .. })));
+    }
+
+    #[test]
+    fn parse_endpoint_rejects_oversized_port() {
+        let result = parse_endpoint("commandport://127.0.0.1:70000");
+        assert!(matches!(result, Err(HostRpcError::TransportError { .. })));
+    }
+
+    #[test]
+    fn parse_endpoint_rejects_empty_host() {
+        let result = parse_endpoint("commandport://:6042");
+        assert!(matches!(result, Err(HostRpcError::TransportError { .. })));
+    }
+
+    // ── connect / call roundtrip against a fake commandPort ────────────
+
+    /// Spawn an in-process TCP server that mimics Maya's commandPort:
+    /// accept one connection, read one line, write a JSON response,
+    /// and either close or keep the connection open for more rounds.
+    ///
+    /// Returns the bound port and a one-shot the test can use to wait
+    /// for the server to observe the request.
+    async fn spawn_fake_command_port(
+        response: String,
+        keep_alive: bool,
+    ) -> (u16, oneshot::Receiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind 0");
+        let port = listener.local_addr().expect("local_addr").port();
+        let (request_tx, request_rx) = oneshot::channel();
+
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept");
+            let (read_half, mut write_half) = stream.split();
+            let mut reader = BufReader::new(read_half);
+            let mut line = String::new();
+            let _ = reader.read_line(&mut line).await;
+            let _ = request_tx.send(line);
+            let payload = format!("{response}\n");
+            let _ = write_half.write_all(payload.as_bytes()).await;
+            let _ = write_half.flush().await;
+            if keep_alive {
+                // Hold the connection open so the client's `close()`
+                // gets to drive the TCP shutdown handshake. The halves
+                // drop when this future returns, which is the natural
+                // signal to the client that we are done.
+                tokio::time::sleep(Duration::from_secs(2)).await;
+            }
+        });
+
+        (port, request_rx)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn connect_call_close_roundtrip() {
+        let (port, request_rx) = spawn_fake_command_port(
+            r#"{"success":true,"object_name":"pSphere1"}"#.to_string(),
+            true,
+        )
+        .await;
+
+        let mut client = CommandPortClient::new();
+        client
+            .connect(
+                &format!("commandport://127.0.0.1:{port}"),
+                Duration::from_secs(2),
+            )
+            .await
+            .expect("connect");
+        assert!(client.is_alive(), "client should be alive after connect");
+
+        let response = client
+            .call(
+                "maya_primitives__create_sphere",
+                serde_json::json!({"radius": 1.0}),
+                "req-test-1",
+            )
+            .await
+            .expect("call should succeed against fake server");
+
+        assert_eq!(response["success"], true);
+        assert_eq!(response["object_name"], "pSphere1");
+
+        let request_line = request_rx.await.expect("server observed request");
+        assert!(
+            request_line.contains("maya_primitives__create_sphere"),
+            "wire frame must include action slug, got: {request_line:?}",
+        );
+        assert!(
+            request_line.contains("dcc_mcp_maya._sidecar"),
+            "wire expression must invoke the in-Maya dispatcher, got: {request_line:?}",
+        );
+        assert!(
+            request_line.contains("\"radius\":1.0"),
+            "wire frame must include serialised args, got: {request_line:?}",
+        );
+
+        client.close().await;
+        assert!(!client.is_alive(), "client should NOT be alive after close");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn host_died_when_connection_closes_during_call() {
+        // Server closes the connection immediately after accept,
+        // simulating Maya crashing mid-call.
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let port = listener.local_addr().expect("local_addr").port();
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept");
+            // Half-close the write side so the client's read_line
+            // returns Ok(0) — that's the "EOF mid-call" signal that
+            // tells us Maya died.
+            drop(stream);
+        });
+
+        let mut client = CommandPortClient::new();
+        client
+            .connect(
+                &format!("commandport://127.0.0.1:{port}"),
+                Duration::from_secs(2),
+            )
+            .await
+            .expect("connect");
+
+        let result = client
+            .call(
+                "maya_render__playblast",
+                serde_json::json!({"width": 1280}),
+                "req-host-died",
+            )
+            .await;
+
+        match result {
+            Err(HostRpcError::HostDied {
+                last_call_slug,
+                last_call_args,
+            }) => {
+                assert_eq!(last_call_slug.as_deref(), Some("maya_render__playblast"));
+                assert_eq!(last_call_args.unwrap()["width"], 1280);
+            }
+            other => panic!("expected HostDied, got {other:?}"),
+        }
+
+        // After a host-died, is_alive must read as false — the gateway
+        // uses this to evict the backend from routing.
+        assert!(!client.is_alive());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn empty_response_line_maps_to_null() {
+        // Maya returns an empty line when the Python expression
+        // evaluated to None — common for fire-and-forget setters.
+        let (port, _request_rx) = spawn_fake_command_port(String::new(), true).await;
+
+        let mut client = CommandPortClient::new();
+        client
+            .connect(
+                &format!("commandport://127.0.0.1:{port}"),
+                Duration::from_secs(2),
+            )
+            .await
+            .expect("connect");
+        let response = client
+            .call(
+                "maya_scene__set_unit",
+                serde_json::json!({"unit": "cm"}),
+                "req-null",
+            )
+            .await
+            .expect("empty response is valid (None → Null)");
+        assert!(
+            response.is_null(),
+            "empty response line must deserialize to Value::Null, got {response:?}",
+        );
+        client.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn invalid_json_response_surfaces_transport_error() {
+        let (port, _request_rx) =
+            spawn_fake_command_port("not even close to json".to_string(), true).await;
+
+        let mut client = CommandPortClient::new();
+        client
+            .connect(
+                &format!("commandport://127.0.0.1:{port}"),
+                Duration::from_secs(2),
+            )
+            .await
+            .expect("connect");
+        let result = client
+            .call("noop", serde_json::Value::Null, "req-bad-json")
+            .await;
+        match result {
+            Err(HostRpcError::TransportError { message }) => {
+                assert!(
+                    message.contains("non-JSON"),
+                    "transport error should mention non-JSON; got: {message}",
+                );
+            }
+            other => panic!("expected TransportError, got {other:?}"),
+        }
+        client.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn connect_times_out_when_unreachable() {
+        // Bind a listener and immediately drop it so the port is
+        // listed in some routing tables but refuses connections —
+        // OR allocate a free port and never bind it. The second is
+        // more reliable on Windows where the SYN gets RST'd instantly.
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let port = listener.local_addr().expect("local_addr").port();
+        drop(listener);
+
+        let mut client = CommandPortClient::new();
+        let result = client
+            .connect(
+                &format!("commandport://127.0.0.1:{port}"),
+                Duration::from_millis(250),
+            )
+            .await;
+        assert!(
+            matches!(
+                result,
+                Err(HostRpcError::TransportError { .. }) | Err(HostRpcError::Timeout { .. })
+            ),
+            "unreachable port should produce TransportError or Timeout, got {result:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn call_before_connect_is_transport_error() {
+        let client = CommandPortClient::new();
+        let result = client.call("noop", serde_json::Value::Null, "req").await;
+        match result {
+            Err(HostRpcError::TransportError { message }) => {
+                assert!(message.contains("before connect"));
+            }
+            other => panic!("expected TransportError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn uri_scheme_is_stable() {
+        // Pinned so the registry dispatcher can match against the
+        // same constant without typo drift between modules.
+        assert_eq!(URI_SCHEME, "commandport");
+        assert_eq!(CommandPortClient::new().uri_scheme(), "commandport");
+    }
+}

--- a/crates/dcc-mcp-host-rpc/src/lib.rs
+++ b/crates/dcc-mcp-host-rpc/src/lib.rs
@@ -83,6 +83,12 @@
 
 #![deny(missing_docs)]
 
+pub mod commandport;
+pub mod registry;
+
+pub use commandport::CommandPortClient;
+pub use registry::{client_for_uri, parse_scheme, registered_schemes};
+
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::sync::Mutex;

--- a/crates/dcc-mcp-host-rpc/src/registry.rs
+++ b/crates/dcc-mcp-host-rpc/src/registry.rs
@@ -1,0 +1,143 @@
+//! Scheme-based factory that picks a [`HostRpcClient`] impl from a
+//! `--host-rpc <URI>` value at sidecar startup.
+//!
+//! The sidecar binary stays DCC-agnostic by linking every supported
+//! impl and dispatching on the URI scheme:
+//!
+//! ```text
+//! commandport://127.0.0.1:6042  → CommandPortClient   (Maya)
+//! stub://anything               → StubHostRpcClient   (tests / placeholder)
+//! ```
+//!
+//! Adding a new DCC family (Blender JSON-RPC over `http://`, Houdini
+//! `hrpyc://`, Photoshop UXP `ws://`) is a matter of writing the
+//! `HostRpcClient` impl in this crate and adding one match arm here.
+//! The sidecar binary needs **zero** changes per DCC.
+//!
+//! Scope: this module owns scheme parsing **and** instantiation. The
+//! split-out of the actual `connect()` call belongs to the sidecar
+//! binary so the caller can pass a `--connect-timeout-secs` flag.
+
+use crate::commandport::{CommandPortClient, URI_SCHEME as COMMANDPORT_SCHEME};
+use crate::{HostRpcClient, HostRpcError, StubHostRpcClient};
+
+/// URI scheme reserved for the placeholder client. Pinned as a const
+/// so tests and the dispatcher both reference the same string.
+pub const STUB_SCHEME: &str = "stub";
+
+/// Pick a [`HostRpcClient`] impl based on the URI's scheme.
+///
+/// Returns the **disconnected** client — the caller is responsible
+/// for invoking [`HostRpcClient::connect`] with the same URI and a
+/// timeout of their choice.
+///
+/// # Errors
+///
+/// * [`HostRpcError::TransportError`] when:
+///   - The URI is missing `://`.
+///   - The scheme is empty.
+///   - The scheme is not in the registry (see [`registered_schemes`]).
+pub fn client_for_uri(endpoint: &str) -> Result<Box<dyn HostRpcClient>, HostRpcError> {
+    let scheme = parse_scheme(endpoint)?;
+    match scheme.as_str() {
+        COMMANDPORT_SCHEME => Ok(Box::new(CommandPortClient::new())),
+        STUB_SCHEME => Ok(Box::new(StubHostRpcClient::new())),
+        other => Err(HostRpcError::transport(format!(
+            "no HostRpcClient registered for scheme {other:?}; \
+             supported schemes: {supported}",
+            supported = registered_schemes().join(", "),
+        ))),
+    }
+}
+
+/// Every scheme the registry currently knows how to dispatch.
+///
+/// Kept stable so `--help`-style CLI surfaces in the sidecar binary
+/// can enumerate them without duplicating the list.
+#[must_use]
+pub fn registered_schemes() -> Vec<&'static str> {
+    vec![COMMANDPORT_SCHEME, STUB_SCHEME]
+}
+
+/// Lowercase scheme component of a `<scheme>://<rest>` URI.
+///
+/// Public so test code and adapter integration can validate URIs
+/// without instantiating a client (cheap pre-flight check).
+pub fn parse_scheme(endpoint: &str) -> Result<String, HostRpcError> {
+    let (scheme, _) = endpoint.split_once("://").ok_or_else(|| {
+        HostRpcError::transport(format!("URI missing :// separator — got {endpoint:?}"))
+    })?;
+    if scheme.is_empty() {
+        return Err(HostRpcError::transport(format!(
+            "URI has empty scheme — got {endpoint:?}"
+        )));
+    }
+    Ok(scheme.to_ascii_lowercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_scheme_lowercases_and_strips() {
+        assert_eq!(parse_scheme("commandport://x:1").unwrap(), "commandport");
+        assert_eq!(parse_scheme("CommandPort://x:1").unwrap(), "commandport");
+        assert_eq!(parse_scheme("STUB://anything").unwrap(), "stub");
+    }
+
+    #[test]
+    fn parse_scheme_rejects_missing_separator() {
+        let result = parse_scheme("commandport-host-without-slashes");
+        assert!(matches!(result, Err(HostRpcError::TransportError { .. })));
+    }
+
+    #[test]
+    fn parse_scheme_rejects_empty_scheme() {
+        let result = parse_scheme("://nothing");
+        assert!(matches!(result, Err(HostRpcError::TransportError { .. })));
+    }
+
+    #[test]
+    fn client_for_uri_dispatches_commandport() {
+        let client = client_for_uri("commandport://127.0.0.1:6042").unwrap();
+        assert_eq!(client.uri_scheme(), "commandport");
+    }
+
+    #[test]
+    fn client_for_uri_dispatches_stub() {
+        let client = client_for_uri("stub://anything").unwrap();
+        assert_eq!(client.uri_scheme(), "stub");
+    }
+
+    #[test]
+    fn client_for_uri_rejects_unknown_scheme_with_diagnostic() {
+        let err = client_for_uri("http://example.com:80")
+            .err()
+            .expect("unknown scheme must error");
+        match err {
+            HostRpcError::TransportError { message } => {
+                assert!(
+                    message.contains("http"),
+                    "error should echo the unknown scheme: {message}"
+                );
+                assert!(
+                    message.contains("commandport"),
+                    "error should list the supported schemes: {message}"
+                );
+            }
+            other => panic!("expected TransportError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn registered_schemes_pins_the_set() {
+        let schemes = registered_schemes();
+        assert!(schemes.contains(&"commandport"));
+        assert!(schemes.contains(&"stub"));
+        // If anyone adds a new scheme here, they MUST also update
+        // the match in `client_for_uri`. This test fails loudly so
+        // the two stay in sync.
+        assert_eq!(schemes.len(), 2);
+    }
+}

--- a/crates/dcc-mcp-server/Cargo.toml
+++ b/crates/dcc-mcp-server/Cargo.toml
@@ -22,6 +22,7 @@ dcc-mcp-transport.workspace = true
 dcc-mcp-telemetry = { path = "../dcc-mcp-telemetry", optional = true }
 dcc-mcp-catalog.workspace = true
 dcc-mcp-jsonrpc = { path = "../dcc-mcp-jsonrpc" }
+dcc-mcp-host-rpc.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/dcc-mcp-server/src/sidecar.rs
+++ b/crates/dcc-mcp-server/src/sidecar.rs
@@ -129,6 +129,15 @@ pub struct SidecarArgs {
     #[arg(long, value_name = "SEMVER")]
     pub adapter_version: Option<String>,
 
+    /// Seconds to wait for the initial ``HostRpcClient::connect`` to the
+    /// DCC. Failure to connect within this budget is logged but does
+    /// **not** abort the sidecar — the process keeps running so its
+    /// FileRegistry row is visible and the PPID-watch can still detect
+    /// parent death. The gateway sees a registered-but-disconnected
+    /// backend and routes around it.
+    #[arg(long, value_name = "SECS", default_value = "10")]
+    pub connect_timeout_secs: u64,
+
     /// Override the polling interval for PPID watch (test hook).
     #[arg(long, value_name = "MS", hide = true)]
     pub ppid_poll_ms: Option<u64>,
@@ -167,6 +176,42 @@ pub async fn run(args: SidecarArgs) -> anyhow::Result<()> {
         "sidecar registered"
     );
 
+    // Instantiate the HostRpcClient impl for the URI's scheme and try
+    // to dial the DCC. Failure to connect is logged but non-fatal —
+    // the sidecar keeps running so PPID-watch / FileRegistry still
+    // serve their purpose, and a future PR will add a reconnect loop
+    // for transient DCC unavailability.
+    let mut host_rpc_client = match dcc_mcp_host_rpc::client_for_uri(&args.host_rpc) {
+        Ok(client) => {
+            let connect_timeout = Duration::from_secs(args.connect_timeout_secs);
+            match client_connect(client, &args.host_rpc, connect_timeout).await {
+                Ok(connected) => {
+                    tracing::info!(
+                        host_rpc = %args.host_rpc,
+                        "HostRpcClient connected"
+                    );
+                    Some(connected)
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        host_rpc = %args.host_rpc,
+                        error = %err,
+                        "HostRpcClient connect failed; sidecar keeps running disconnected"
+                    );
+                    None
+                }
+            }
+        }
+        Err(err) => {
+            tracing::error!(
+                host_rpc = %args.host_rpc,
+                error = %err,
+                "unsupported --host-rpc scheme; sidecar keeps running but cannot dispatch"
+            );
+            None
+        }
+    };
+
     // PPID-watch lives on its own task; on parent-death it flips the
     // `exit_tx` watch channel.  Same channel is used by the ctrl-c branch
     // below, so both paths converge on the same deregister flow.
@@ -193,6 +238,13 @@ pub async fn run(args: SidecarArgs) -> anyhow::Result<()> {
 
     tracing::info!(reason = ?reason, "sidecar shutting down");
 
+    // Close the HostRpcClient before deregistering so the DCC sees a
+    // clean disconnect rather than a TCP reset from process exit.
+    if let Some(client) = host_rpc_client.as_ref() {
+        client.close().await;
+    }
+    host_rpc_client.take();
+
     // Deregister is best-effort: a failure here would only leak a row that
     // will be reaped by the next stale-cleanup sweep, so we log and move on.
     if let Err(err) = registry.deregister(&key) {
@@ -200,6 +252,20 @@ pub async fn run(args: SidecarArgs) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+/// Connect the freshly-instantiated [`HostRpcClient`] to the DCC.
+///
+/// Wrapped as a separate helper so the caller can keep the `match`
+/// arms in `run()` shallow and so the timeout / log surface is in
+/// one place.
+async fn client_connect(
+    mut client: Box<dyn dcc_mcp_host_rpc::HostRpcClient>,
+    endpoint: &str,
+    timeout: Duration,
+) -> Result<Box<dyn dcc_mcp_host_rpc::HostRpcClient>, dcc_mcp_host_rpc::HostRpcError> {
+    client.connect(endpoint, timeout).await?;
+    Ok(client)
 }
 
 fn build_service_entry(args: &SidecarArgs) -> ServiceEntry {
@@ -301,12 +367,17 @@ mod tests {
         let key_dcc = "test-dcc".to_string();
         let args = SidecarArgs {
             dcc: key_dcc.clone(),
-            host_rpc: "test://localhost:0".to_string(),
+            // Use the `stub` scheme so the HostRpcClient connects
+            // immediately (no I/O) and the focus of this test stays
+            // on the PPID-watch path. The commandport scheme is
+            // exercised separately by `commandport_connects_to_fake_server`.
+            host_rpc: "stub://localhost:0".to_string(),
             watch_pid: parent_pid,
             registry_dir: Some(registry_dir.path().to_path_buf()),
             instance_id: Some(Uuid::new_v4()),
             display_name: Some("test-sidecar".to_string()),
             adapter_version: Some("0.0.0-test".to_string()),
+            connect_timeout_secs: 2,
             ppid_poll_ms: Some(50),
         };
         let pinned_uuid = args.instance_id.unwrap();
@@ -352,6 +423,168 @@ mod tests {
             registry.get(&key).is_none(),
             "sidecar should have deregistered itself; row still present"
         );
+    }
+
+    /// End-to-end commandport happy path: spawn a fake TCP server,
+    /// spawn the sidecar with ``commandport://127.0.0.1:<port>``,
+    /// assert the fake server observes an inbound connection from
+    /// the sidecar (proving the URI router picked CommandPortClient
+    /// and called connect()), then kill the parent surrogate and
+    /// assert clean exit.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn commandport_connects_to_fake_server() {
+        use tokio::net::TcpListener;
+        use tokio::sync::oneshot;
+
+        let registry_dir = TempDir::new().expect("tempdir");
+
+        // Bind a fake "Maya commandPort" on an OS-assigned port.
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind 0");
+        let port = listener.local_addr().expect("local_addr").port();
+        let (connect_tx, connect_rx) = oneshot::channel::<()>();
+        tokio::spawn(async move {
+            // Accept exactly one connection and signal the test.
+            // The connection is held open by `_stream` until the
+            // accept task is dropped, which happens when this future
+            // completes — so we hold it for the duration of the test.
+            if let Ok((stream, _)) = listener.accept().await {
+                let _ = connect_tx.send(());
+                // Keep the socket alive until the sidecar tears down.
+                // 5s is more than enough for this test's lifetime.
+                tokio::time::sleep(Duration::from_secs(5)).await;
+                drop(stream);
+            }
+        });
+
+        let mut child = std::process::Command::new(sleep_cmd())
+            .args(sleep_args())
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn sleep child");
+
+        let parent_pid = child.id();
+        let key_dcc = "maya".to_string();
+        let pinned_uuid = Uuid::new_v4();
+        let args = SidecarArgs {
+            dcc: key_dcc.clone(),
+            host_rpc: format!("commandport://127.0.0.1:{port}"),
+            watch_pid: parent_pid,
+            registry_dir: Some(registry_dir.path().to_path_buf()),
+            instance_id: Some(pinned_uuid),
+            display_name: Some("test-maya".to_string()),
+            adapter_version: Some("0.0.0-test".to_string()),
+            connect_timeout_secs: 2,
+            ppid_poll_ms: Some(50),
+        };
+
+        let sidecar_handle = tokio::spawn(async move { run(args).await });
+
+        // Confirm the sidecar's CommandPortClient actually connected
+        // — this proves the URI router picked the right impl AND
+        // that the connect() path is wired through end-to-end.
+        tokio::time::timeout(Duration::from_secs(3), connect_rx)
+            .await
+            .expect("sidecar must connect to fake commandPort within 3s")
+            .expect("connect channel closed without firing");
+
+        // Confirm the registry row landed too (orthogonal to the
+        // connect — the row is written before connect attempts).
+        wait_for_registration(
+            registry_dir.path(),
+            &key_dcc,
+            pinned_uuid,
+            Duration::from_secs(2),
+        )
+        .await
+        .expect("sidecar registered itself within 2s");
+
+        // Kill the parent and assert clean shutdown.
+        child.kill().expect("kill sleep child");
+        let _ = child.wait();
+
+        let result = tokio::time::timeout(Duration::from_secs(3), sidecar_handle)
+            .await
+            .expect("sidecar exited within 3s of parent death")
+            .expect("sidecar task did not panic");
+        result.expect("sidecar run returned ok");
+
+        let registry = FileRegistry::new(registry_dir.path()).expect("reopen");
+        let key = ServiceKey {
+            dcc_type: key_dcc,
+            instance_id: pinned_uuid,
+        };
+        assert!(
+            registry.get(&key).is_none(),
+            "sidecar must have deregistered itself"
+        );
+    }
+
+    /// Soft-failure path: when the URI's host:port is dead, the sidecar
+    /// logs a warning but **keeps running** so its FileRegistry row
+    /// stays visible and PPID-watch can still detect parent death.
+    /// The gateway sees a registered-but-disconnected backend and
+    /// routes around it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn sidecar_survives_failed_initial_connect() {
+        use tokio::net::TcpListener;
+
+        let registry_dir = TempDir::new().expect("tempdir");
+
+        // Allocate a port and immediately drop the listener so any
+        // connect attempt sees ECONNREFUSED quickly.
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let dead_port = listener.local_addr().expect("local_addr").port();
+        drop(listener);
+
+        let mut child = std::process::Command::new(sleep_cmd())
+            .args(sleep_args())
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn sleep child");
+
+        let parent_pid = child.id();
+        let key_dcc = "maya".to_string();
+        let pinned_uuid = Uuid::new_v4();
+        let args = SidecarArgs {
+            dcc: key_dcc.clone(),
+            host_rpc: format!("commandport://127.0.0.1:{dead_port}"),
+            watch_pid: parent_pid,
+            registry_dir: Some(registry_dir.path().to_path_buf()),
+            instance_id: Some(pinned_uuid),
+            display_name: None,
+            adapter_version: None,
+            // 300ms is plenty for ECONNREFUSED on Windows; bumps any
+            // slow CI well above the noise floor while keeping the
+            // test snappy in the common case.
+            connect_timeout_secs: 1,
+            ppid_poll_ms: Some(50),
+        };
+
+        let sidecar_handle = tokio::spawn(async move { run(args).await });
+
+        // Even with connect failed, the sidecar must register itself
+        // — that's the whole point of the soft-failure contract.
+        wait_for_registration(
+            registry_dir.path(),
+            &key_dcc,
+            pinned_uuid,
+            Duration::from_secs(3),
+        )
+        .await
+        .expect("sidecar must register even when connect fails");
+
+        child.kill().expect("kill sleep child");
+        let _ = child.wait();
+
+        let result = tokio::time::timeout(Duration::from_secs(4), sidecar_handle)
+            .await
+            .expect("sidecar exited after parent death")
+            .expect("no panic");
+        result.expect("run() returned ok");
     }
 
     fn sleep_cmd() -> &'static str {


### PR DESCRIPTION
## Summary

This is the first PR where the sidecar binary **stops being a passive "register in FileRegistry and PPID-watch" process and starts actually talking to a DCC**.

Three additions:

1. **`CommandPortClient`** — the first real `HostRpcClient` impl. Speaks Maya's `commandPort` wire (newline-terminated TCP, Python expression as request, JSON line as response).
2. **URI-scheme registry** — `client_for_uri(endpoint)` picks the right impl based on the scheme. Adding a new DCC (Blender JSON-RPC, Houdini hrpyc, Photoshop UXP WebSocket, …) is now **one new module + one match arm**.
3. **Sidecar binary wires it up** — connects on startup with a configurable timeout. Connect failure is logged but **non-fatal** so the FileRegistry row stays visible and PPID-watch keeps working.

## What does **not** land in this PR (tracked separately)

To keep the diff reviewable I split the next steps:

- **MCP HTTP listener inside the sidecar process** — needed before the gateway can POST `tools/call` to the sidecar. Next core PR.
- **Maya-side dispatcher `dcc_mcp_maya._sidecar.dispatch`** — the Python helper that receives the wire frame inside Maya. Sibling PR in `dcc-mcp-maya`.
- **Gateway routing decision** — sending `risk_class: high-crash` calls to the sidecar's MCP URL instead of the in-process URL. Phase 2 wrap-up PR.

Until the Python helper lands, the wire path is proven by the fake-TCP integration tests added here.

## Surface

### `crates/dcc-mcp-host-rpc`

| File | What |
|---|---|
| `src/commandport.rs` (new) | `CommandPortClient` + `URI_SCHEME` constant + connection-error classifier. |
| `src/registry.rs` (new) | `client_for_uri`, `parse_scheme`, `registered_schemes`. |
| `src/lib.rs` | Re-exports `CommandPortClient` and the registry functions. |

### `crates/dcc-mcp-server`

| File | What |
|---|---|
| `Cargo.toml` | Adds `dcc-mcp-host-rpc.workspace = true`. |
| `src/sidecar.rs` | New `--connect-timeout-secs` flag; after `FileRegistry::register`, instantiate the right `HostRpcClient` and `connect()` with timeout; on shutdown `close().await` before deregister. Two new e2e tests. |

## Wire format pinned

```python
__import__('dcc_mcp_maya._sidecar', fromlist=['dispatch']).dispatch(
    {"action": "...", "args": {...}, "request_id": "..."}
)
```

The Python side (`dcc_mcp_maya._sidecar.dispatch`) is the matching `dcc-mcp-maya` PR's responsibility. JSON args are serialised on the Rust side via serde; the Maya helper deserialises and returns a JSON-string result. Empty response line is mapped to `Value::Null` (matches Maya's behaviour for `None`-returning expressions).

## Cross-platform host-died classification

A mid-call disconnect arrives via **different error surfaces** depending on OS:

- **Linux / macOS**: the next `read_line()` returns `Ok(0)` (EOF).
- **Windows**: the next `write_all()` / `flush()` typically fails first with `WSAECONNABORTED` / `WSAECONNRESET` (mapped by tokio to `ErrorKind::ConnectionAborted` / `ConnectionReset` / `BrokenPipe`).

`io_error_to_host_rpc` collapses **both paths** into `HostRpcError::HostDied` so the public envelope is platform-stable. The `host_died_when_connection_closes_during_call` test exercises the Windows-style path explicitly so the classifier cannot regress.

## Test plan

- [x] `cargo test -p dcc-mcp-host-rpc` — **27 lib + 1 doc tests pass**.
  - 11 new in `commandport::tests` (parse_endpoint × 7, connect/call/close, host-died, empty-response, invalid-json, connect-timeout, call-before-connect, scheme constant)
  - 6 new in `registry::tests` (parse_scheme × 3, client_for_uri dispatch × 2, unknown-scheme diagnostic, pinned-set)
- [x] `cargo test -p dcc-mcp-server sidecar::` — **4 tests pass**:
  - `role_metadata_key_is_stable` (existing)
  - `ppid_watch_exits_on_parent_death` (existing, switched to `stub://`)
  - `commandport_connects_to_fake_server` (**new** — proves URI router → CommandPortClient → TCP connect end-to-end)
  - `sidecar_survives_failed_initial_connect` (**new** — proves the soft-failure contract: connect to dead port, registry row still lands, parent-death still observed)
- [x] `cargo check --workspace` — clean across all 37 crates.
- [x] `cargo clippy -p dcc-mcp-host-rpc -p dcc-mcp-server --all-targets` — clean.

## Behaviour change summary

| Path | Before | After |
|---|---|---|
| Sidecar registered in FileRegistry | yes | yes (unchanged) |
| Sidecar PPID-watch | yes | yes (unchanged) |
| Sidecar dials the DCC at startup | **no** | **yes** (new) |
| Sidecar closes the DCC channel before deregister | n/a | **yes** (new) |
| Sidecar listens for `tools/call` from the gateway | no | **still no** (next PR) |

Refs **#998**. Phase 2 step 1 of N. Depends on already-merged loonghao/dcc-mcp-core#1003 (sidecar substrate) and #1005 (HostRpcClient trait).
