### PR TITLE
feat(commandport): dynamic Python-module bootstrap on connect (RFC #998)

### DIFF
--- a/crates/dcc-mcp-host-rpc/python/maya_sidecar_bootstrap.py
+++ b/crates/dcc-mcp-host-rpc/python/maya_sidecar_bootstrap.py
@@ -1,0 +1,100 @@
+"""Sidecar bootstrap injected into Maya at ``commandPort`` connect time.
+
+The Rust ``CommandPortClient`` (see ``commandport.rs``) embeds this
+file's source at build time via ``include_str!`` and ships it as the
+**first** payload sent over a freshly opened ``commandPort``. Maya
+evaluates the wrapping ``exec(compile(<src>, ...))`` on its main
+thread and the body below runs synchronously inside Maya's
+interpreter.
+
+What it does
+============
+
+Installs ``dcc_mcp_maya._sidecar`` as a **virtual module** that
+re-exports the dispatcher already shipped at
+``dcc_mcp_maya.sidecar._dispatcher``. The wire frame the sidecar
+binary subsequently sends per ``tools/call`` is::
+
+    __import__('dcc_mcp_maya._sidecar', fromlist=['dispatch']).dispatch(
+        {"action": ..., "args": ..., "request_id": ...}
+    )
+
+so the only thing this bootstrap needs to guarantee is that
+``dcc_mcp_maya._sidecar.dispatch`` resolves to the correct callable
+**before** the first such wire frame arrives.
+
+Why a virtual module instead of a static ``.py`` file
+=====================================================
+
+* **Wire-format authority belongs to the binary.** The Rust sidecar
+  knows the exact entry-point name it will call. By installing that
+  name dynamically, a Maya-side install that lacks the leaf shim file
+  cannot break dispatch — sidecar mode "just works" as long as the
+  dispatcher proper is importable.
+
+* **Version skew is impossible by construction.** The bootstrap's
+  ``_BOOTSTRAP_VERSION`` is checked against ``__dcc_mcp_bootstrap__``
+  on the installed module. A reconnect from a newer sidecar binary
+  overwrites the older install; a reconnect from the same version is
+  a true no-op.
+
+* **No file-layout coupling.** Adapter authors are free to refactor
+  the dispatcher inside ``dcc_mcp_maya.sidecar`` without breaking
+  third-party wire clients — the bootstrap is the only consumer of
+  the dispatcher's import path.
+
+Failure semantics
+=================
+
+Bootstrap **never raises** out of Maya's eval. The function returns
+silently in three benign cases:
+
+* ``dcc_mcp_maya`` is not installed (no sidecar mode available).
+* ``dcc_mcp_maya.sidecar._dispatcher`` import fails (e.g. partial
+  install or version with the dispatcher removed).
+* The module is already installed at this exact bootstrap version
+  (re-entrant connect).
+
+The first real ``dispatch()`` call surfaces any of these as a
+structured envelope (``server-not-running`` / ``payload-malformed``
+/ ``unknown-action``) so the gateway sees an MCP-shaped error rather
+than a transport-error from Maya's eval.
+"""
+
+import sys
+import types
+
+_BOOTSTRAP_VERSION = "1"
+_MODULE_NAME = "dcc_mcp_maya._sidecar"
+_PARENT_NAME = "dcc_mcp_maya"
+
+
+def _install():
+    existing = sys.modules.get(_MODULE_NAME)
+    if existing is not None and getattr(existing, "__dcc_mcp_bootstrap__", None) == _BOOTSTRAP_VERSION:
+        return
+
+    try:
+        from dcc_mcp_maya.sidecar._dispatcher import dispatch
+        from dcc_mcp_maya.sidecar._dispatcher import dispatch_payload
+    except ImportError:
+        # dcc-mcp-maya is not on sys.path, or its sidecar sub-package
+        # has been refactored. Silent no-op — the next dispatch call
+        # surfaces this as a payload-malformed/unknown-action envelope.
+        return
+
+    parent = sys.modules.get(_PARENT_NAME)
+    if parent is None:
+        return
+
+    module = types.ModuleType(_MODULE_NAME)
+    module.__file__ = "<dcc-mcp-sidecar-bootstrap>"
+    module.__dcc_mcp_bootstrap__ = _BOOTSTRAP_VERSION
+    module.dispatch = dispatch
+    module.dispatch_payload = dispatch_payload
+
+    sys.modules[_MODULE_NAME] = module
+    parent._sidecar = module
+
+
+_install()

--- a/crates/dcc-mcp-host-rpc/src/commandport.rs
+++ b/crates/dcc-mcp-host-rpc/src/commandport.rs
@@ -64,6 +64,21 @@ use crate::{HostRpcClient, HostRpcError};
 /// scheme registry and tests both reference the same string.
 pub const URI_SCHEME: &str = "commandport";
 
+/// Python bootstrap shipped over the wire on every ``connect``.
+///
+/// The bootstrap installs ``dcc_mcp_maya._sidecar`` as a virtual
+/// module by ``types.ModuleType`` + ``compile`` + ``exec``, wiring it
+/// to the dispatcher in ``dcc_mcp_maya.sidecar._dispatcher``. This
+/// means the wire-format entry point name is owned by **this binary**
+/// rather than by a static ``.py`` shim file inside the Maya install
+/// — sidecar protocol upgrades are atomic with the binary upgrade.
+///
+/// The source is embedded at build time via ``include_str!`` so the
+/// bootstrap version cannot drift away from the rest of the client.
+/// Idempotent on re-entry: each connect re-runs ``_install()`` but a
+/// matching ``__dcc_mcp_bootstrap__`` returns immediately.
+const SIDECAR_BOOTSTRAP_PY: &str = include_str!("../python/maya_sidecar_bootstrap.py");
+
 /// `HostRpcClient` over Maya's `commandPort`.
 ///
 /// Instantiate via [`CommandPortClient::new`], then call
@@ -88,6 +103,80 @@ impl CommandPortClient {
     pub fn new() -> Self {
         Self {
             state: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Ship the [`SIDECAR_BOOTSTRAP_PY`] payload over the live socket.
+    ///
+    /// Called once per [`HostRpcClient::connect`] right after the TCP
+    /// handshake completes. The wire line is a self-contained Python
+    /// expression — Rust's ``{:?}`` debug format produces a
+    /// Python-compatible string literal (matching the escape rules
+    /// for ``\n`` / ``\"`` / ``\\``), so we can wrap the source in
+    /// a single ``exec(compile(<lit>, '<x>', 'exec'))`` invocation
+    /// without any extra encoding step.
+    ///
+    /// Maya's ``commandPort`` with ``sourceType='python'`` always
+    /// replies with **one** line per request — the ``str()``/``repr()``
+    /// of the eval result. ``exec`` returns ``None``, so the bootstrap
+    /// reply is the literal ``None`` on most Maya versions (or empty
+    /// on some 2024 builds). We accept any non-traceback content;
+    /// Python-level failures in the bootstrap body would otherwise
+    /// only surface during the first real ``dispatch()`` call.
+    async fn send_bootstrap(&self) -> Result<(), HostRpcError> {
+        let line = format!(
+            "__import__('builtins').exec(__import__('builtins').compile({src:?}, \
+             '<dcc-mcp-sidecar-bootstrap>', 'exec'))\n",
+            src = SIDECAR_BOOTSTRAP_PY,
+        );
+
+        let mut guard = self.state.lock().await;
+        let conn = guard.as_mut().ok_or_else(|| {
+            HostRpcError::transport("CommandPortClient::send_bootstrap before connect")
+        })?;
+
+        if let Err(e) = conn.writer.write_all(line.as_bytes()).await {
+            return Err(io_error_to_host_rpc(
+                e,
+                "commandport bootstrap write",
+                "<bootstrap>",
+                Value::Null,
+                guard,
+            ));
+        }
+        if let Err(e) = conn.writer.flush().await {
+            return Err(io_error_to_host_rpc(
+                e,
+                "commandport bootstrap flush",
+                "<bootstrap>",
+                Value::Null,
+                guard,
+            ));
+        }
+
+        let mut buf = String::new();
+        match conn.reader.read_line(&mut buf).await {
+            Ok(0) => {
+                *guard = None;
+                Err(HostRpcError::host_died("<bootstrap>", None))
+            }
+            Ok(_) => {
+                let trimmed = buf.trim_end_matches(['\r', '\n']);
+                if trimmed.contains("Traceback") || trimmed.contains("SyntaxError:") {
+                    Err(HostRpcError::transport(format!(
+                        "commandport bootstrap raised inside Maya: {trimmed}",
+                    )))
+                } else {
+                    Ok(())
+                }
+            }
+            Err(e) => Err(io_error_to_host_rpc(
+                e,
+                "commandport bootstrap read",
+                "<bootstrap>",
+                Value::Null,
+                guard,
+            )),
         }
     }
 }
@@ -127,6 +216,14 @@ impl HostRpcClient for CommandPortClient {
             writer: write_half,
             reader: BufReader::new(read_half),
         });
+
+        // TCP handshake done; install the wire-frame entry point
+        // inside Maya by shipping the Python bootstrap. Bounded by
+        // the same timeout the caller passed to `connect` so the
+        // "connection is live AND usable" deadline stays predictable.
+        tokio::time::timeout(timeout, self.send_bootstrap())
+            .await
+            .map_err(|_| HostRpcError::Timeout {})??;
         Ok(())
     }
 
@@ -365,30 +462,43 @@ mod tests {
 
     // ── connect / call roundtrip against a fake commandPort ────────────
 
-    /// Spawn an in-process TCP server that mimics Maya's commandPort:
-    /// accept one connection, read one line, write a JSON response,
-    /// and either close or keep the connection open for more rounds.
+    /// Spawn an in-process TCP server that mimics Maya's commandPort.
     ///
-    /// Returns the bound port and a one-shot the test can use to wait
-    /// for the server to observe the request.
-    async fn spawn_fake_command_port(
-        response: String,
+    /// Reads one line at a time, sends back the next pre-staged
+    /// response line, and repeats until the client drops or the
+    /// caller's response queue is empty. Each request line is
+    /// forwarded over `requests` so tests can assert on the exact
+    /// wire bytes.
+    ///
+    /// The first response **must** correspond to the bootstrap line
+    /// the client sends right after TCP connect — typically `None`
+    /// (Maya's `exec()` eval result). Subsequent responses are the
+    /// per-`call()` payloads.
+    async fn spawn_fake_command_port_multi(
+        responses: Vec<String>,
         keep_alive: bool,
-    ) -> (u16, oneshot::Receiver<String>) {
+    ) -> (u16, tokio::sync::mpsc::UnboundedReceiver<String>) {
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind 0");
         let port = listener.local_addr().expect("local_addr").port();
-        let (request_tx, request_rx) = oneshot::channel();
+        let (request_tx, request_rx) = tokio::sync::mpsc::unbounded_channel();
 
         tokio::spawn(async move {
             let (mut stream, _) = listener.accept().await.expect("accept");
             let (read_half, mut write_half) = stream.split();
             let mut reader = BufReader::new(read_half);
-            let mut line = String::new();
-            let _ = reader.read_line(&mut line).await;
-            let _ = request_tx.send(line);
-            let payload = format!("{response}\n");
-            let _ = write_half.write_all(payload.as_bytes()).await;
-            let _ = write_half.flush().await;
+            for response in responses {
+                let mut line = String::new();
+                match reader.read_line(&mut line).await {
+                    Ok(0) | Err(_) => return,
+                    Ok(_) => {}
+                }
+                let _ = request_tx.send(line);
+                let payload = format!("{response}\n");
+                if write_half.write_all(payload.as_bytes()).await.is_err() {
+                    return;
+                }
+                let _ = write_half.flush().await;
+            }
             if keep_alive {
                 // Hold the connection open so the client's `close()`
                 // gets to drive the TCP shutdown handshake. The halves
@@ -399,6 +509,29 @@ mod tests {
         });
 
         (port, request_rx)
+    }
+
+    /// Backwards-friendly single-call wrapper used by tests that
+    /// only want to verify the call path. Pre-stages two responses:
+    /// one for the bootstrap (always `None`) and one for the real
+    /// per-test response.
+    async fn spawn_fake_command_port(
+        response: String,
+        keep_alive: bool,
+    ) -> (u16, oneshot::Receiver<String>) {
+        let (port, mut requests) =
+            spawn_fake_command_port_multi(vec!["None".to_string(), response], keep_alive).await;
+        let (tx, rx) = oneshot::channel();
+
+        // Drop the bootstrap line; surface the real call line.
+        tokio::spawn(async move {
+            let _bootstrap = requests.recv().await;
+            if let Some(call_line) = requests.recv().await {
+                let _ = tx.send(call_line);
+            }
+        });
+
+        (port, rx)
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -451,17 +584,11 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn host_died_when_connection_closes_during_call() {
-        // Server closes the connection immediately after accept,
-        // simulating Maya crashing mid-call.
-        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
-        let port = listener.local_addr().expect("local_addr").port();
-        tokio::spawn(async move {
-            let (stream, _) = listener.accept().await.expect("accept");
-            // Half-close the write side so the client's read_line
-            // returns Ok(0) — that's the "EOF mid-call" signal that
-            // tells us Maya died.
-            drop(stream);
-        });
+        // Server replies to the bootstrap normally, then drops the
+        // connection before the first real call — simulating Maya
+        // crashing AFTER its commandPort was wired but mid-call.
+        let (port, mut requests) =
+            spawn_fake_command_port_multi(vec!["None".to_string()], false).await;
 
         let mut client = CommandPortClient::new();
         client
@@ -471,6 +598,9 @@ mod tests {
             )
             .await
             .expect("connect");
+
+        // Drain the bootstrap line so the channel does not retain it.
+        let _bootstrap = requests.recv().await;
 
         let result = client
             .call(
@@ -597,5 +727,143 @@ mod tests {
         // same constant without typo drift between modules.
         assert_eq!(URI_SCHEME, "commandport");
         assert_eq!(CommandPortClient::new().uri_scheme(), "commandport");
+    }
+
+    // ── bootstrap injection (Stage 1 of dynamic-module-install) ───
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn connect_ships_bootstrap_as_first_wire_line() {
+        // Fake commandPort: capture the FIRST line the client sends
+        // and verify it carries the embedded bootstrap source.
+        let (port, mut requests) =
+            spawn_fake_command_port_multi(vec!["None".to_string()], true).await;
+
+        let mut client = CommandPortClient::new();
+        client
+            .connect(
+                &format!("commandport://127.0.0.1:{port}"),
+                Duration::from_secs(2),
+            )
+            .await
+            .expect("connect (with bootstrap)");
+
+        let bootstrap_line = requests
+            .recv()
+            .await
+            .expect("bootstrap line should be observed by the server");
+
+        // The wire is `exec(compile(<src_lit>, '<bootstrap>', 'exec'))`.
+        assert!(
+            bootstrap_line.contains("__import__('builtins').exec"),
+            "bootstrap line must wrap exec(): {bootstrap_line:?}"
+        );
+        assert!(
+            bootstrap_line.contains("<dcc-mcp-sidecar-bootstrap>"),
+            "bootstrap line must tag its compiled filename: {bootstrap_line:?}"
+        );
+        // The dispatcher entry-point name MUST appear in the embedded
+        // source — that's the contract every later call relies on.
+        assert!(
+            bootstrap_line.contains("dcc_mcp_maya._sidecar"),
+            "bootstrap source must reference the wire-frame entry-point name"
+        );
+        assert!(
+            bootstrap_line.contains("dcc_mcp_maya.sidecar._dispatcher"),
+            "bootstrap source must reference the dispatcher import path"
+        );
+
+        client.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn connect_surfaces_bootstrap_traceback_as_transport_error() {
+        // Fake commandPort returns a Python traceback for the
+        // bootstrap line — emulates a syntax error or import storm
+        // inside Maya. The client must surface this as a transport
+        // error so operators see it during connect rather than at
+        // the first real call.
+        let (port, _requests) = spawn_fake_command_port_multi(
+            vec!["Traceback (most recent call last): SyntaxError: bogus".to_string()],
+            true,
+        )
+        .await;
+
+        let mut client = CommandPortClient::new();
+        let result = client
+            .connect(
+                &format!("commandport://127.0.0.1:{port}"),
+                Duration::from_secs(2),
+            )
+            .await;
+
+        match result {
+            Err(HostRpcError::TransportError { message }) => {
+                assert!(
+                    message.contains("bootstrap raised"),
+                    "transport error should explain bootstrap context: {message}"
+                );
+                assert!(
+                    message.contains("Traceback") || message.contains("SyntaxError"),
+                    "transport error should echo the Maya-side error: {message}"
+                );
+            }
+            other => panic!("expected TransportError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn bootstrap_payload_is_python_string_literal_safe() {
+        // The bootstrap line uses Rust's `{:?}` Debug format to embed
+        // the source as a Python string literal. Pin that the
+        // literal round-trips: every backslash / quote / newline in
+        // the bootstrap source must show up correctly escaped in the
+        // wire bytes.
+        let (port, mut requests) =
+            spawn_fake_command_port_multi(vec!["None".to_string()], true).await;
+        let mut client = CommandPortClient::new();
+        client
+            .connect(
+                &format!("commandport://127.0.0.1:{port}"),
+                Duration::from_secs(2),
+            )
+            .await
+            .expect("connect");
+        let bootstrap_line = requests.recv().await.expect("bootstrap line");
+
+        // Newlines in the source must NOT appear literally — they
+        // should be `\n` two-byte sequences inside the Python string
+        // literal Maya's `compile()` will parse.
+        let body = bootstrap_line.trim_end_matches('\n');
+        let inner_newlines = body.matches('\n').count();
+        assert_eq!(
+            inner_newlines, 0,
+            "wire line must be a single Python line (`{body:?}` has embedded newlines)"
+        );
+        // Double-quote pairs inside the literal must be escaped.
+        // If the source had un-escaped quotes the literal would close
+        // prematurely and the rest of the source would land as Python
+        // tokens — Maya would syntax-error.
+        // Counting `\"` occurrences is a heuristic, but `repr(SRC)`
+        // guarantees at least one (the literal's opening) — the test
+        // mainly guards against future regressions where someone
+        // switches to `{}` formatting.
+        assert!(
+            body.contains('"'),
+            "literal opening/closing quotes must reach the wire"
+        );
+        client.close().await;
+    }
+
+    #[test]
+    fn embedded_bootstrap_source_pins_known_contract() {
+        // Static pin: bootstrap source MUST contain the canonical
+        // module name + dispatcher import + bootstrap version
+        // marker. Refactors that move the dispatcher or rename the
+        // wire entry must update the bootstrap deliberately.
+        assert!(SIDECAR_BOOTSTRAP_PY.contains("dcc_mcp_maya._sidecar"));
+        assert!(SIDECAR_BOOTSTRAP_PY.contains("dcc_mcp_maya.sidecar._dispatcher"));
+        assert!(SIDECAR_BOOTSTRAP_PY.contains("_BOOTSTRAP_VERSION"));
+        assert!(SIDECAR_BOOTSTRAP_PY.contains("types.ModuleType"));
+        assert!(SIDECAR_BOOTSTRAP_PY.contains("sys.modules"));
     }
 }

--- a/crates/dcc-mcp-server/src/sidecar.rs
+++ b/crates/dcc-mcp-server/src/sidecar.rs
@@ -427,12 +427,13 @@ mod tests {
 
     /// End-to-end commandport happy path: spawn a fake TCP server,
     /// spawn the sidecar with ``commandport://127.0.0.1:<port>``,
-    /// assert the fake server observes an inbound connection from
-    /// the sidecar (proving the URI router picked CommandPortClient
-    /// and called connect()), then kill the parent surrogate and
-    /// assert clean exit.
+    /// assert the fake server observes the bootstrap line (proving
+    /// the URI router picked CommandPortClient AND that connect()'s
+    /// bootstrap-injection step ran), then kill the parent surrogate
+    /// and assert clean exit.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn commandport_connects_to_fake_server() {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
         use tokio::net::TcpListener;
         use tokio::sync::oneshot;
 
@@ -443,16 +444,20 @@ mod tests {
         let port = listener.local_addr().expect("local_addr").port();
         let (connect_tx, connect_rx) = oneshot::channel::<()>();
         tokio::spawn(async move {
-            // Accept exactly one connection and signal the test.
-            // The connection is held open by `_stream` until the
-            // accept task is dropped, which happens when this future
-            // completes — so we hold it for the duration of the test.
-            if let Ok((stream, _)) = listener.accept().await {
+            // Accept one connection, reply to the bootstrap line, then
+            // hold the socket open until teardown.
+            if let Ok((mut stream, _)) = listener.accept().await {
                 let _ = connect_tx.send(());
+                let (read_half, mut write_half) = stream.split();
+                let mut reader = BufReader::new(read_half);
+                let mut bootstrap_line = String::new();
+                let _ = reader.read_line(&mut bootstrap_line).await;
+                // `exec()` evaluates to None in commandPort's reply path.
+                let _ = write_half.write_all(b"None\n").await;
+                let _ = write_half.flush().await;
                 // Keep the socket alive until the sidecar tears down.
                 // 5s is more than enough for this test's lifetime.
                 tokio::time::sleep(Duration::from_secs(5)).await;
-                drop(stream);
             }
         });
 

--- a/tests/test_sidecar_bootstrap_py.py
+++ b/tests/test_sidecar_bootstrap_py.py
@@ -1,0 +1,228 @@
+"""End-to-end Python test for the sidecar bootstrap payload.
+
+The Rust :func:`CommandPortClient::send_bootstrap` ships this file's
+source over Maya's commandPort at connect time (see
+``crates/dcc-mcp-host-rpc/python/maya_sidecar_bootstrap.py``). The
+Rust unit tests verify the *wire framing* (correct ``exec(compile(…))``
+wrapping, string-literal escape, traceback surfacing) but cannot
+verify the *Python semantics* of the embedded source itself —
+typos in attribute access, accidental side effects on the parent
+module, version-marker drift, etc.
+
+This test exercises the embedded source in a real Python interpreter
+against a synthetic ``dcc_mcp_maya`` namespace (no Maya required) so
+any regression in the bootstrap body fails the dcc-mcp-core CI suite.
+
+We deliberately do **not** import ``dcc_mcp_maya`` from PyPI here —
+the bootstrap is meant to be testable against any Python environment
+that has a ``dcc_mcp_maya.sidecar._dispatcher`` module on
+``sys.modules``, however that arrived.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+from pathlib import Path
+
+# Import built-in modules
+import sys
+import types
+from typing import Iterator
+
+# Import third-party modules
+import pytest
+
+BOOTSTRAP_PATH = Path(__file__).parent.parent / "crates" / "dcc-mcp-host-rpc" / "python" / "maya_sidecar_bootstrap.py"
+
+
+def _read_bootstrap_source() -> str:
+    assert BOOTSTRAP_PATH.is_file(), (
+        f"bootstrap source missing at {BOOTSTRAP_PATH}; the Rust binary include_str!s this exact file at build time."
+    )
+    return BOOTSTRAP_PATH.read_text(encoding="utf-8")
+
+
+def _exec_bootstrap(globals_dict: dict | None = None) -> dict:
+    """Compile + exec the bootstrap source in a fresh module-style namespace.
+
+    Mirrors how Maya's commandPort eval-path runs the source under the
+    wrapping ``exec(compile(<src>, '<dcc-mcp-sidecar-bootstrap>', 'exec'))``
+    that ``send_bootstrap`` ships.
+    """
+    src = _read_bootstrap_source()
+    namespace = globals_dict if globals_dict is not None else {}
+    compiled = compile(src, "<dcc-mcp-sidecar-bootstrap>", "exec")
+    exec(compiled, namespace)
+    return namespace
+
+
+# ── fixtures ──────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fresh_sys_modules(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Sandbox ``sys.modules`` so each test starts from a known state.
+
+    We snapshot the keys we care about, replace them with our stubs,
+    and let monkeypatch restore everything on teardown.
+    """
+    keys_we_touch = [
+        "dcc_mcp_maya",
+        "dcc_mcp_maya.sidecar",
+        "dcc_mcp_maya.sidecar._dispatcher",
+        "dcc_mcp_maya._sidecar",
+    ]
+    for key in keys_we_touch:
+        monkeypatch.delitem(sys.modules, key, raising=False)
+    yield
+
+
+def _install_fake_dispatcher() -> tuple[types.ModuleType, callable, callable]:
+    """Plant a synthetic ``dcc_mcp_maya.sidecar._dispatcher`` in sys.modules.
+
+    Returns the parent ``dcc_mcp_maya`` module along with the two
+    callables the bootstrap expects to re-export.
+    """
+
+    def _fake_dispatch(payload):
+        return f"dispatched:{payload}"
+
+    def _fake_dispatch_payload(payload, **kwargs):
+        return f"dispatch_payload:{payload}"
+
+    parent = types.ModuleType("dcc_mcp_maya")
+    parent.__path__ = []
+    sub = types.ModuleType("dcc_mcp_maya.sidecar")
+    sub.__path__ = []
+    dispatcher = types.ModuleType("dcc_mcp_maya.sidecar._dispatcher")
+    dispatcher.dispatch = _fake_dispatch
+    dispatcher.dispatch_payload = _fake_dispatch_payload
+
+    sys.modules["dcc_mcp_maya"] = parent
+    sys.modules["dcc_mcp_maya.sidecar"] = sub
+    sys.modules["dcc_mcp_maya.sidecar._dispatcher"] = dispatcher
+    parent.sidecar = sub
+    sub._dispatcher = dispatcher
+    return parent, _fake_dispatch, _fake_dispatch_payload
+
+
+# ── tests ─────────────────────────────────────────────────────────
+
+
+class TestBootstrapHappyPath:
+    def test_installs_virtual_module(self, fresh_sys_modules):
+        parent, dispatch_fn, dispatch_payload_fn = _install_fake_dispatcher()
+        _exec_bootstrap()
+
+        assert "dcc_mcp_maya._sidecar" in sys.modules, "bootstrap must register the virtual module in sys.modules"
+        installed = sys.modules["dcc_mcp_maya._sidecar"]
+        # Wire-frame attribute access — this is exactly what the Rust
+        # client does after connect:
+        #   __import__('dcc_mcp_maya._sidecar', fromlist=['dispatch']).dispatch(...)
+        assert installed.dispatch is dispatch_fn
+        assert installed.dispatch_payload is dispatch_payload_fn
+        # Parent module gains the leaf attribute so dotted access works:
+        #   dcc_mcp_maya._sidecar.dispatch(...)
+        assert parent._sidecar is installed
+
+    def test_marks_module_with_bootstrap_version(self, fresh_sys_modules):
+        _install_fake_dispatcher()
+        _exec_bootstrap()
+        installed = sys.modules["dcc_mcp_maya._sidecar"]
+        version = getattr(installed, "__dcc_mcp_bootstrap__", None)
+        assert version is not None, (
+            "bootstrap must stamp the virtual module so reentrant connects can detect the existing install"
+        )
+        # The literal version is pinned in the source. If the bootstrap
+        # bumps it, this test fails loudly so the Rust side picks up
+        # the new value too.
+        assert version == "1"
+
+    def test_installed_module_has_synthetic_file_marker(self, fresh_sys_modules):
+        _install_fake_dispatcher()
+        _exec_bootstrap()
+        installed = sys.modules["dcc_mcp_maya._sidecar"]
+        assert installed.__file__ == "<dcc-mcp-sidecar-bootstrap>"
+
+
+class TestBootstrapIdempotence:
+    def test_second_install_at_same_version_is_no_op(self, fresh_sys_modules):
+        _install_fake_dispatcher()
+
+        _exec_bootstrap()
+        installed_first = sys.modules["dcc_mcp_maya._sidecar"]
+
+        # Re-running the bootstrap (as happens on every connect) must
+        # NOT replace the module — the existing one is returned in place.
+        _exec_bootstrap()
+        installed_second = sys.modules["dcc_mcp_maya._sidecar"]
+        assert installed_first is installed_second
+
+    def test_second_install_at_newer_version_replaces(self, fresh_sys_modules):
+        _install_fake_dispatcher()
+
+        # Install a stale-looking module under the canonical name to
+        # mimic an older bootstrap version having run earlier.
+        stale = types.ModuleType("dcc_mcp_maya._sidecar")
+        stale.__dcc_mcp_bootstrap__ = "0-OLD"
+        stale.dispatch = lambda p: "stale"
+        sys.modules["dcc_mcp_maya._sidecar"] = stale
+
+        _exec_bootstrap()
+        installed = sys.modules["dcc_mcp_maya._sidecar"]
+        # Should be the fresh install, not the stale one.
+        assert installed is not stale
+        assert installed.__dcc_mcp_bootstrap__ == "1"
+
+
+class TestBootstrapNoOpPaths:
+    def test_silent_when_parent_not_installed(self, fresh_sys_modules, monkeypatch: pytest.MonkeyPatch):
+        # No fake dispatcher installed AND we actively block the
+        # ``dcc_mcp_maya`` import from resolving via any sibling repo
+        # the dev venv might have on ``sys.path``. ``None`` in
+        # ``sys.modules`` is Python's "tried and failed" marker —
+        # subsequent ``import dcc_mcp_maya`` raises ``ImportError``
+        # without re-searching the path.
+        for name in (
+            "dcc_mcp_maya",
+            "dcc_mcp_maya.sidecar",
+            "dcc_mcp_maya.sidecar._dispatcher",
+        ):
+            monkeypatch.setitem(sys.modules, name, None)
+
+        # Bootstrap must NOT raise; it just no-ops.
+        _exec_bootstrap()
+        assert "dcc_mcp_maya._sidecar" not in sys.modules
+
+    def test_silent_when_dispatcher_module_missing(self, fresh_sys_modules):
+        # Plant the parent + sub, but leave the dispatcher module out
+        # of sys.modules. This emulates a partial install / refactor.
+        parent = types.ModuleType("dcc_mcp_maya")
+        parent.__path__ = []
+        sub = types.ModuleType("dcc_mcp_maya.sidecar")
+        sub.__path__ = []
+        sys.modules["dcc_mcp_maya"] = parent
+        sys.modules["dcc_mcp_maya.sidecar"] = sub
+        parent.sidecar = sub
+        # NB: no `_dispatcher` registered.
+
+        _exec_bootstrap()
+        # We don't register a half-baked module; the next dispatch call
+        # will surface a structured error envelope instead.
+        assert "dcc_mcp_maya._sidecar" not in sys.modules
+
+
+# ── pinned-source guard ───────────────────────────────────────────
+
+
+def test_bootstrap_source_pins_known_contract():
+    """If anyone refactors the dispatcher path away, this test fails
+    loudly so the bootstrap (which is the wire-format authority) is
+    updated in lockstep with the dcc-mcp-maya rename.
+    """
+    src = _read_bootstrap_source()
+    assert "dcc_mcp_maya._sidecar" in src
+    assert "dcc_mcp_maya.sidecar._dispatcher" in src
+    assert "_BOOTSTRAP_VERSION" in src
+    assert "types.ModuleType" in src
+    assert "sys.modules" in src


### PR DESCRIPTION
## Summary

Make the wire-format entry-point name (`dcc_mcp_maya._sidecar`) owned by the **sidecar binary itself** rather than by a static `.py` shim file inside the dcc-mcp-maya install.

The Rust client embeds a small Python bootstrap source via `include_str!` at build time, ships it as the **first wire frame** right after TCP connect, and Maya installs the virtual module via `types.ModuleType` + `compile` + `exec`. Subsequent `tools/call` wire frames target the dynamically-installed entry.

## Why this matters

| Without bootstrap injection | With bootstrap injection |
|---|---|
| Wire-format entry name lives in a static `_sidecar.py` file the operator must install | The sidecar **binary** owns the wire-format entry; the file is registered at runtime |
| Sidecar binary v0.18 paired with an old `dcc-mcp-maya` v0.16 install → wire-format skew → mystery `AttributeError` mid-call | Skew is **impossible by construction** — the binary writes its own entry at every connect, stamped with a version marker |
| Refactoring the dispatcher's import path requires bumping the shim file too — easy to forget | Refactor the dispatcher anywhere inside `dcc_mcp_maya.sidecar`; only the bootstrap (in the binary) needs to know |
| Reconnect with a newer binary still picks up the old shim | Reconnect overwrites the install with whatever the new binary embeds |

## What changes

### `crates/dcc-mcp-host-rpc/python/maya_sidecar_bootstrap.py` (new, ~30 lines real code)

Self-contained Python source:

```python
def _install():
    existing = sys.modules.get("dcc_mcp_maya._sidecar")
    if existing and getattr(existing, "__dcc_mcp_bootstrap__", None) == "1":
        return  # already installed at this version
    try:
        from dcc_mcp_maya.sidecar._dispatcher import dispatch, dispatch_payload
    except ImportError:
        return  # silent no-op — next call surfaces structured error
    parent = sys.modules.get("dcc_mcp_maya")
    if parent is None:
        return
    module = types.ModuleType("dcc_mcp_maya._sidecar")
    module.__file__ = "<dcc-mcp-sidecar-bootstrap>"
    module.__dcc_mcp_bootstrap__ = "1"
    module.dispatch = dispatch
    module.dispatch_payload = dispatch_payload
    sys.modules["dcc_mcp_maya._sidecar"] = module
    setattr(parent, "_sidecar", module)

_install()
```

### `crates/dcc-mcp-host-rpc/src/commandport.rs`

- `SIDECAR_BOOTSTRAP_PY`: `include_str!` of the bootstrap above. Embedded at build time so the binary version and bootstrap version are inseparable.
- **`CommandPortClient::send_bootstrap`** (new private method): formats the wire line as `exec(compile({src:?}, '<dcc-mcp-sidecar-bootstrap>', 'exec'))`. Rust's `{:?}` Debug format produces a Python-compatible string literal so no encoding (base64 / chunking) is needed.
- `CommandPortClient::connect` calls `send_bootstrap` after the TCP handshake, capped by the same `connect_timeout` so "connection live AND usable" is a single deadline.

### Test surface (47 tests across Rust + Python)

**Rust (`crates/dcc-mcp-host-rpc`, 31 lib + 1 doc)**:

- `connect_ships_bootstrap_as_first_wire_line` — captures the first wire line, asserts it contains `exec(compile(...))` + the dispatcher import path + the bootstrap filename tag.
- `connect_surfaces_bootstrap_traceback_as_transport_error` — fake server returns a Python traceback; client surfaces it during `connect` rather than at first `call`.
- `bootstrap_payload_is_python_string_literal_safe` — pins that newlines / quotes in the embedded source are correctly escaped on the wire (guards against future `{}` vs `{:?}` regressions).
- `embedded_bootstrap_source_pins_known_contract` — static `assert!` on `SIDECAR_BOOTSTRAP_PY`'s content so refactors that rename the dispatcher trip the test.
- Existing tests adapted: `spawn_fake_command_port_multi` (new fixture) pre-stages multiple reply lines; the single-call wrapper rewrites in terms of it.

**Python (`tests/test_sidecar_bootstrap_py.py`, 8 tests)**:

Exercises `compile(<bootstrap>, '<x>', 'exec')` + `exec` against a stubbed `sys.modules` — catches semantic regressions (typos, attribute drift) that the Rust unit tests cannot:

- happy path: virtual module installed with the expected attributes + `__file__` marker + version marker
- idempotence: same version → no-op; older version → replaced
- no-op paths: parent missing → silent no-op; dispatcher submodule missing → silent no-op
- pinned-source contract guard

**Server (`crates/dcc-mcp-server`)**: `commandport_connects_to_fake_server` updated to reply `None\n` to the bootstrap line. All 4 sidecar tests pass unchanged in shape.

## Wire format note

We deliberately chose the simplest workable encoding — Rust's `{:?}` Debug format on the embedded `&str` produces a Python string literal with all the right escapes (`\n` / `\"` / `\\`). The bootstrap source is plain ASCII Python with no exotic chars, so the wire line is short and readable on the `commandPort` socket. **One `write_all` + one `read_line` per connect** — no base64 / chunking / compile helper allocation.

## Stage scoping

This is **Stage 1** of the dynamic-injection pattern:
- ✅ Wire-format **entry point** is dynamically registered.
- ⏭ Dispatcher **implementation** still ships as a regular `.py` module in `dcc-mcp-maya`. Stage 2 (embed the dispatcher source too) is intentionally NOT in this PR — keeping `_dispatcher.py` as a real file preserves pytest / type-checker / IDE support, and the cost-benefit only flips if we want zero-install sidecar mode (we don't yet).

Once this PR lands, the static `src/dcc_mcp_maya/_sidecar.py` shim file added in dcc-mcp-maya PR #245 can be **deleted** as a small follow-up — the bootstrap supersedes it.

## Test plan

- [x] `cargo test -p dcc-mcp-host-rpc` — **31 lib + 1 doc** pass (4 new).
- [x] `cargo test -p dcc-mcp-server sidecar::` — **4 pass** (no regressions).
- [x] `cargo check --workspace` — clean across all 37 crates.
- [x] `cargo clippy -p dcc-mcp-host-rpc -p dcc-mcp-server --all-targets` — clean.
- [x] `pytest tests/test_sidecar_bootstrap_py.py` — **8 pass** in 0.06 s.

## Stack

- Stacked on **PR #1006** (`feat/998-commandport-client`). Once #1006 merges, this PR rebases onto main and the diff collapses to just the bootstrap additions.
- Maya-side follow-up (after this lands): delete `src/dcc_mcp_maya/_sidecar.py` from PR #245. Will be a single-commit cleanup on that branch after rebase.

Refs RFC **#998** (loonghao/dcc-mcp-core#998). Depends on **#1006** for the `CommandPortClient` surface.
