### PR TITLE
feat(host-rpc): qtserver:// scheme + universal dcc_qt_dispatcher (RFC #998)

### DIFF
--- a/crates/dcc-mcp-host-rpc/python/dcc_qt_dispatcher.py
+++ b/crates/dcc-mcp-host-rpc/python/dcc_qt_dispatcher.py
@@ -1,0 +1,475 @@
+r"""Universal in-DCC JSON-line TCP dispatcher driven by the Qt event loop.
+
+The same module installs into Maya, Houdini, 3ds Max, Nuke, Cinema 4D,
+Substance Painter, Mari — any DCC that ships a Qt binding (PySide2 /
+PySide6 / PyQt5 / PyQt6 are all probed). The Rust sidecar speaks to
+this server over the ``qtserver://`` URI scheme defined in
+``dcc_mcp_host_rpc::qtserver``.
+
+Why this design solves the in-DCC fragility problems
+====================================================
+
+The previous baseline (``commandPort`` + line-oriented Python eval) had
+three structural failure modes that no amount of plug-in hardening
+could fully paper over:
+
+1. **Single-flight** — one in-flight request at a time per port; a
+   slow request blocks every other gateway caller.
+2. **Modal dialog leak** — any uncaught Python exception inside the
+   eval bubbles up to ``maya.utils.executeDeferred`` / DCC dialog
+   code, freezing the UI on a "File error" or "Stack trace" modal.
+3. **PyO3-tokio runtime contention** — the embedded MCP HTTP server
+   competes with the DCC's main thread for scheduler attention.
+
+Running an in-DCC ``QTcpServer`` cooperatively on the host's Qt event
+loop addresses all three:
+
+* ``QTcpServer`` accepts many concurrent connections; each connection
+  is a small per-socket state machine driven by ``readyRead`` signals.
+* Every request is wrapped in a single per-handler ``try/except`` —
+  failures return a structured JSON envelope, never propagate to
+  dialog code.
+* The dispatcher runs on the DCC's own main thread (the only thread
+  that can safely touch the host scene), but it gives that thread
+  *up* between requests via the standard Qt event-loop tick. The
+  Rust sidecar has its own tokio runtime and never competes.
+
+Wire protocol
+=============
+
+One JSON object per ``\\n``-terminated line in each direction.
+
+Request::
+
+    {"id": "req-1", "method": "execute", "params": {"code": "1+2"}}
+
+Successful response::
+
+    {"id": "req-1", "result": {"value": 3}}
+
+Error response::
+
+    {"id": "req-1",
+     "error": {"code": "handler-exception",
+               "message": "ZeroDivisionError: division by zero",
+               "traceback": "Traceback (...)"}}
+
+Built-in handlers
+=================
+
+``ping``
+    Cheap health check. Returns ``{"pong": True, "version": ...}``.
+
+``execute``
+    Runs arbitrary Python via :func:`ast.parse` + :func:`compile`. If
+    the source ends in an expression statement, that expression is
+    evaluated as the result; everything before runs as a side-effect
+    body. ``params.result_type`` selects between ``"value"`` (default,
+    JSON-serialisable representation) and ``"repr"`` (``repr(value)``)
+    for non-JSON-serialisable objects.
+
+``get_session_info``
+    Returns Python version, executable path, Qt binding name, and the
+    dispatcher version string.
+
+``install_stream_capture`` / ``get_buffered_output``
+    Tee ``sys.stdout`` / ``sys.stderr`` into an internal buffer so
+    follow-up calls can read everything the DCC printed (Maya
+    "Script Editor" output, ``print`` statements, etc.).
+
+``create_module``
+    Synthesise a Python module from a source string. Used so the
+    sidecar can install per-DCC dispatcher extensions (Maya-specific
+    helpers, Houdini ``hou`` wrappers, …) without requiring a
+    ``.py`` file on disk. Idempotent on ``version`` match.
+"""
+
+
+# JSON envelope; broad ``except`` is the whole point of this dispatcher.
+
+import ast
+import contextlib
+import io
+import json
+import sys
+import threading
+import traceback
+import types
+
+DISPATCHER_VERSION = "1"
+
+# Tracks the singleton server so :func:`start_qt_server` is idempotent
+# and the bootstrap path can reconnect to an existing instance.
+_singleton: dict = {"server": None}
+_singleton_lock = threading.Lock()
+
+
+def _import_qt():
+    """Return ``(QtCore, QtNetwork, binding_name)`` using the first Qt binding that loads.
+
+    Order is PySide6 → PySide2 → PyQt6 → PyQt5 so newer DCCs (Maya
+    2024+, Houdini 20+) prefer PySide6 while older ones (Maya
+    2022/2023) fall back to PySide2.
+    """
+    last_error = None
+    for module_name in ("PySide6", "PySide2", "PyQt6", "PyQt5"):
+        try:
+            qt_core = __import__(module_name + ".QtCore", fromlist=["QtCore"])
+            qt_network = __import__(module_name + ".QtNetwork", fromlist=["QtNetwork"])
+            return qt_core, qt_network, module_name
+        except ImportError as exc:
+            last_error = exc
+            continue
+    raise ImportError(f"no Qt binding available — tried PySide6/PySide2/PyQt6/PyQt5; last error: {last_error}")
+
+
+class _Tee:
+    """Tee a write stream to many sinks.
+
+    Tolerates broken sinks so a closed DCC console can never break a
+    buffered-output read.
+    """
+
+    def __init__(self, *streams):
+        self._streams = streams
+
+    def write(self, data):
+        for stream in self._streams:
+            with contextlib.suppress(Exception):
+                stream.write(data)
+
+    def flush(self):
+        for stream in self._streams:
+            with contextlib.suppress(Exception):
+                stream.flush()
+
+    def isatty(self):
+        return False
+
+
+class _DispatchRegistry:
+    """Mutable per-server registry of method handlers.
+
+    Lives outside :class:`QtCommandServer` so the dispatch table can be
+    unit-tested in isolation (no Qt event loop required) and so a
+    fresh server instance always starts from a deterministic baseline.
+    """
+
+    def __init__(self):
+        self._handlers = {
+            "ping": self._ping,
+            "execute": self._execute,
+            "get_session_info": self._get_session_info,
+            "install_stream_capture": self._install_stream_capture,
+            "get_buffered_output": self._get_buffered_output,
+            "create_module": self._create_module,
+        }
+        self._exec_globals: dict = {"__name__": "__dcc_qt_dispatcher__"}
+        self._captured = io.StringIO()
+        self._capture_active = False
+        self._stdout_orig = sys.stdout
+        self._stderr_orig = sys.stderr
+
+    def register(self, method, handler):
+        """Install an extension handler.
+
+        Used by tests and adapter bootstrap so DCC-specific methods
+        can ride the same wire.
+        """
+        self._handlers[method] = handler
+
+    def dispatch(self, method, params):
+        """Look up ``method``, invoke its handler with ``params``, return an envelope.
+
+        The outcome is wrapped in a ``{"result": ...}`` or
+        ``{"error": ...}`` envelope. Never raises.
+        """
+        handler = self._handlers.get(method)
+        if handler is None:
+            return {
+                "error": {
+                    "code": "unknown-method",
+                    "message": f"unknown method {method!r}",
+                }
+            }
+        try:
+            return {"result": handler(params or {})}
+        except Exception as exc:
+            return {
+                "error": {
+                    "code": "handler-exception",
+                    "message": f"{exc.__class__.__name__}: {exc}",
+                    "traceback": traceback.format_exc(),
+                }
+            }
+
+    # ── builtin handlers ───────────────────────────────────────────
+
+    def _ping(self, _params):
+        return {"pong": True, "version": DISPATCHER_VERSION}
+
+    def _execute(self, params):
+        code = params.get("code", "")
+        if not isinstance(code, str):
+            raise TypeError("`code` must be a string")
+        result_type = (params.get("result_type") or "value").lower()
+        tree = ast.parse(code, filename="<dcc-execute>", mode="exec")
+        last_expr = None
+        if tree.body and isinstance(tree.body[-1], ast.Expr):
+            last_expr = tree.body[-1].value
+            tree.body = tree.body[:-1]
+        exec(
+            compile(tree, "<dcc-execute>", "exec"),
+            self._exec_globals,
+        )
+        if last_expr is None:
+            return {"value": None, "result_type": "void"}
+        value = eval(
+            compile(ast.Expression(body=last_expr), "<dcc-execute>", "eval"),
+            self._exec_globals,
+        )
+        if result_type == "repr":
+            return {"value": repr(value), "result_type": "repr"}
+        # default "value": be liberal — fall back to repr for objects
+        # that aren't JSON-serialisable so the gateway never sees a
+        # serialisation error from this surface.
+        try:
+            json.dumps(value)
+            serialised = value
+        except (TypeError, ValueError):
+            serialised = repr(value)
+        return {"value": serialised, "result_type": "value"}
+
+    def _get_session_info(self, _params):
+        return {
+            "python_version": sys.version,
+            "executable": sys.executable,
+            "platform": sys.platform,
+            "dispatcher_version": DISPATCHER_VERSION,
+        }
+
+    def _install_stream_capture(self, _params):
+        if self._capture_active:
+            return {"installed": False, "reused": True}
+        self._captured = io.StringIO()
+        sys.stdout = _Tee(self._stdout_orig, self._captured)
+        sys.stderr = _Tee(self._stderr_orig, self._captured)
+        self._capture_active = True
+        return {"installed": True}
+
+    def _get_buffered_output(self, params):
+        text = self._captured.getvalue()
+        if params.get("drain", True):
+            self._captured = io.StringIO()
+            if self._capture_active:
+                sys.stdout = _Tee(self._stdout_orig, self._captured)
+                sys.stderr = _Tee(self._stderr_orig, self._captured)
+        return {"output": text}
+
+    def _create_module(self, params):
+        name = params.get("name")
+        source = params.get("source")
+        if not isinstance(name, str) or not name:
+            raise ValueError("`name` must be a non-empty string")
+        if not isinstance(source, str):
+            raise TypeError("`source` must be a string")
+        version = params.get("version") or ""
+        existing = sys.modules.get(name)
+        if existing is not None and getattr(existing, "__dcc_mcp_module_version__", None) == version and version:
+            return {"installed": False, "reused": True, "name": name, "version": version}
+        module = types.ModuleType(name)
+        module.__file__ = f"<dcc-mcp-create-module:{name}>"
+        if version:
+            module.__dcc_mcp_module_version__ = version
+        exec(
+            compile(source, module.__file__, "exec"),
+            module.__dict__,
+        )
+        sys.modules[name] = module
+        return {"installed": True, "name": name, "version": version}
+
+
+class QtCommandServer:
+    r"""JSON-line ``QTcpServer`` cooperatively scheduled on the Qt main thread.
+
+    Multi-client; per-connection ``bytearray`` buffers accumulate
+    incoming bytes until a ``\n`` boundary, at which point one full
+    request is dispatched.
+    """
+
+    def __init__(self, port=0, host="127.0.0.1"):
+        qt_core, qt_network, binding = _import_qt()
+        self._QtCore = qt_core
+        self._QtNetwork = qt_network
+        self._qt_binding = binding
+        self._server = qt_network.QTcpServer()
+        addr = qt_network.QHostAddress(host)
+        if not self._server.listen(addr, port):
+            raise RuntimeError(f"QTcpServer.listen({host}:{port}) failed: {self._server.errorString()}")
+        self._actual_host = host
+        self._actual_port = int(self._server.serverPort())
+        self._registry = _DispatchRegistry()
+        self._clients: dict = {}
+        self._server.newConnection.connect(self._on_new_connection)
+        self._timer = qt_core.QTimer()
+        self._timer.timeout.connect(self._drain_all)
+        self._timer.start(50)
+
+    @property
+    def host(self):
+        return self._actual_host
+
+    @property
+    def port(self):
+        return self._actual_port
+
+    @property
+    def qt_binding(self):
+        return self._qt_binding
+
+    @property
+    def registry(self):
+        return self._registry
+
+    def stop(self):
+        with contextlib.suppress(Exception):
+            self._timer.stop()
+        for sock in list(self._clients):
+            with contextlib.suppress(Exception):
+                sock.disconnectFromHost()
+        self._clients.clear()
+        with contextlib.suppress(Exception):
+            self._server.close()
+
+    def _on_new_connection(self):
+        while self._server.hasPendingConnections():
+            sock = self._server.nextPendingConnection()
+            self._clients[sock] = bytearray()
+            sock.readyRead.connect(lambda bound=sock: self._on_ready_read(bound))
+            sock.disconnected.connect(lambda bound=sock: self._on_disconnected(bound))
+
+    def _on_disconnected(self, sock):
+        self._clients.pop(sock, None)
+        with contextlib.suppress(Exception):
+            sock.deleteLater()
+
+    def _on_ready_read(self, sock):
+        if sock not in self._clients:
+            return
+        try:
+            chunk = bytes(sock.readAll())
+        except Exception:
+            return
+        if not chunk:
+            return
+        buffer = self._clients[sock]
+        buffer.extend(chunk)
+        while True:
+            try:
+                idx = buffer.index(0x0A)  # newline byte
+            except ValueError:
+                break
+            line = bytes(buffer[:idx])
+            del buffer[: idx + 1]
+            if line.endswith(b"\r"):
+                line = line[:-1]
+            self._handle_line(sock, line)
+
+    def _drain_all(self):
+        for sock in list(self._clients):
+            try:
+                if sock.bytesAvailable() > 0:
+                    self._on_ready_read(sock)
+            except Exception:
+                pass
+
+    def _handle_line(self, sock, raw):
+        try:
+            request = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            self._send(
+                sock,
+                {
+                    "id": None,
+                    "error": {
+                        "code": "parse-error",
+                        "message": f"{exc.__class__.__name__}: {exc}",
+                    },
+                },
+            )
+            return
+        request_id = request.get("id")
+        method = request.get("method", "")
+        params = request.get("params") or {}
+        outcome = self._registry.dispatch(method, params)
+        payload = {"id": request_id}
+        payload.update(outcome)
+        self._send(sock, payload)
+
+    def _send(self, sock, payload):
+        try:
+            encoded = json.dumps(payload, ensure_ascii=False).encode("utf-8") + b"\n"
+        except (TypeError, ValueError) as exc:
+            # Re-encode failure to a parse-error so the wire never
+            # gets stuck mid-message.
+            encoded = (
+                json.dumps(
+                    {
+                        "id": payload.get("id"),
+                        "error": {
+                            "code": "encode-error",
+                            "message": f"{exc.__class__.__name__}: {exc}",
+                        },
+                    }
+                ).encode("utf-8")
+                + b"\n"
+            )
+        try:
+            sock.write(encoded)
+            sock.flush()
+        except Exception:
+            # Best-effort write — a closed socket is removed by the
+            # ``disconnected`` signal handler and we should not poison
+            # the dispatcher with a console traceback.
+            pass
+
+
+def start_qt_server(port=0, host="127.0.0.1"):
+    """Start (or reuse) the singleton :class:`QtCommandServer`.
+
+    Returns a small dict ``{"host": str, "port": int, "qt_binding": str,
+    "dispatcher_version": str, "reused": bool}`` so the caller can
+    learn the actually-bound ephemeral port. Idempotent — repeated
+    calls return the running server's info.
+    """
+    with _singleton_lock:
+        server = _singleton["server"]
+        reused = server is not None
+        if not reused:
+            server = QtCommandServer(port=port, host=host)
+            _singleton["server"] = server
+    return {
+        "host": server.host,
+        "port": server.port,
+        "qt_binding": server.qt_binding,
+        "dispatcher_version": DISPATCHER_VERSION,
+        "reused": reused,
+    }
+
+
+def stop_qt_server():
+    """Tear down the singleton server, if any. Idempotent."""
+    with _singleton_lock:
+        server = _singleton.pop("server", None)
+    if server is not None:
+        server.stop()
+    return {"stopped": server is not None}
+
+
+def current_server():
+    """Return the singleton server instance, or ``None``.
+
+    Public so Maya plug-ins can introspect runtime state for
+    diagnostics.
+    """
+    return _singleton.get("server")

--- a/crates/dcc-mcp-host-rpc/python/dcc_qt_dispatcher_bootstrap.py
+++ b/crates/dcc-mcp-host-rpc/python/dcc_qt_dispatcher_bootstrap.py
@@ -1,0 +1,108 @@
+"""Bootstrap installer for the universal Qt-event-loop dispatcher.
+
+Shipped over a one-shot `commandPort` (or any equivalent one-shot
+Python eval surface) so the Rust sidecar can transition a DCC from
+"no in-DCC server yet" to "qtserver://host:port reachable" without
+requiring the dispatcher Python source to exist on disk.
+
+How the Rust client uses this file
+==================================
+
+1. ``include_str!("../python/dcc_qt_dispatcher.py")`` — embed the
+   dispatcher source.
+2. ``include_str!("../python/dcc_qt_dispatcher_bootstrap.py")`` —
+   embed this file's source.
+3. Send **one** ``commandPort`` line that wraps both:
+
+   .. code:: python
+
+       __import__('builtins').exec(
+           __import__('builtins').compile(
+               '_DISPATCHER_SOURCE = ' + repr(dispatcher_src) + chr(10) +
+               '_REQUESTED_PORT = 0' + chr(10) +
+               bootstrap_src,
+               '<dcc-mcp-qt-bootstrap>', 'exec'))
+
+   ``commandPort``'s reply is the ``repr`` of the eval result, which
+   is ``None`` (``exec`` returns ``None``). The bootstrap result is
+   captured separately in the next round-trip:
+
+4. Send a follow-up line:
+
+   .. code:: python
+
+       __import__('json').dumps(
+           __import__('_dcc_qt_dispatcher').start_qt_server(
+               port=<requested_port>))
+
+   The reply is a JSON dict ``{"host", "port", "qt_binding",
+   "dispatcher_version", "reused"}`` — the client parses ``port`` and
+   reconnects to ``qtserver://<host>:<port>`` for all future calls.
+
+Why a separate file
+===================
+
+Splitting bootstrap (this file) from the dispatcher source
+(``dcc_qt_dispatcher.py``) lets each be unit-tested with stock Python
+in CI — the dispatcher's pure-Python parts (``_DispatchRegistry``,
+``execute`` semantics) run without Qt; the bootstrap's installer
+logic runs without any TCP socket. Both are then re-tested by the
+``QtServerClient`` integration tests with a real Qt server in the
+loop.
+
+Failure semantics
+=================
+
+Bootstrap never raises out of ``commandPort``'s eval — exceptions are
+captured into ``_install_result["error"]`` and the dispatcher module
+is **not** registered in ``sys.modules`` on failure. The follow-up
+``start_qt_server`` call then surfaces the failure as a clean
+JSON-line error envelope on the wire, which the Rust client maps
+to :class:`HostRpcError::TransportError`.
+"""
+
+import sys
+import types
+
+_BOOTSTRAP_VERSION = "1"
+_MODULE_NAME = "_dcc_qt_dispatcher"
+
+
+def _install(source):
+    """Synthesise ``_dcc_qt_dispatcher`` from ``source`` and register it in ``sys.modules``.
+
+    Returns the module on success or a dict describing the failure
+    (kept narrow so the result still serialises to JSON for the Rust
+    client).
+    """
+    existing = sys.modules.get(_MODULE_NAME)
+    if existing is not None and getattr(existing, "__dcc_mcp_bootstrap__", None) == _BOOTSTRAP_VERSION:
+        return existing
+    module = types.ModuleType(_MODULE_NAME)
+    module.__file__ = "<dcc-mcp-qt-dispatcher>"
+    module.__dcc_mcp_bootstrap__ = _BOOTSTRAP_VERSION
+    try:
+        compiled = compile(source, module.__file__, "exec")
+    except SyntaxError as exc:
+        return {
+            "ok": False,
+            "stage": "compile",
+            "error": f"{exc.__class__.__name__}: {exc}",
+        }
+    try:
+        exec(compiled, module.__dict__)
+    except Exception as exc:
+        return {
+            "ok": False,
+            "stage": "exec",
+            "error": f"{exc.__class__.__name__}: {exc}",
+        }
+    sys.modules[_MODULE_NAME] = module
+    return module
+
+
+# The Rust client injects ``_DISPATCHER_SOURCE`` (string) and
+# ``_REQUESTED_PORT`` (int) into ``globals()`` before exec'ing this
+# file. ``__name__`` is left at module default ``__main__`` because
+# the Rust caller uses an empty namespace.
+_install_result = _install(_DISPATCHER_SOURCE)  # noqa: F821 — injected

--- a/crates/dcc-mcp-host-rpc/src/lib.rs
+++ b/crates/dcc-mcp-host-rpc/src/lib.rs
@@ -83,9 +83,11 @@
 #![deny(missing_docs)]
 
 pub mod commandport;
+pub mod qtserver;
 pub mod registry;
 
 pub use commandport::CommandPortClient;
+pub use qtserver::QtServerClient;
 pub use registry::{client_for_uri, parse_scheme, registered_schemes};
 
 use async_trait::async_trait;

--- a/crates/dcc-mcp-host-rpc/src/qtserver.rs
+++ b/crates/dcc-mcp-host-rpc/src/qtserver.rs
@@ -1,0 +1,863 @@
+//! `QtServerClient` — `HostRpcClient` over the universal Qt-event-loop
+//! JSON-line dispatcher.
+//!
+//! This is the second concrete impl of [`HostRpcClient`] (the first is
+//! [`CommandPortClient`](crate::commandport::CommandPortClient)).
+//! Architecturally the same role — speak to a single DCC instance —
+//! but using a wire format that scales to **multi-client** concurrency
+//! and **structured errors** in a way Maya's line-oriented
+//! `commandPort` cannot.
+//!
+//! # Wire format
+//!
+//! One JSON object per `\n`-terminated line in each direction.
+//!
+//! Request:
+//!
+//! ```json
+//! {"id": "req-1", "method": "dispatch",
+//!  "params": {"action": "maya_scene__list_objects",
+//!             "args": {}, "request_id": "req-1"}}
+//! ```
+//!
+//! Successful response:
+//!
+//! ```json
+//! {"id": "req-1", "result": {"value": ..., "result_type": "value"}}
+//! ```
+//!
+//! Error response:
+//!
+//! ```json
+//! {"id": "req-1",
+//!  "error": {"code": "handler-exception",
+//!            "message": "RuntimeError: ...",
+//!            "traceback": "..."}}
+//! ```
+//!
+//! The DCC-side dispatcher (shipped in this crate at
+//! `python/dcc_qt_dispatcher.py`) runs cooperatively on the host's Qt
+//! event loop via `QTcpServer` + a 50 ms `QTimer`. Every request is
+//! `try/except`-wrapped per handler so a Python-level failure produces
+//! a structured error envelope instead of leaking to a host modal
+//! dialog (the root cause of issues #235 / #240 / #241 on Maya).
+//!
+//! # `call()` mapping
+//!
+//! [`HostRpcClient::call`] is invoked as
+//! `call(action, args, request_id)`. The qtserver wire wraps that into
+//! a `dispatch` method invocation:
+//!
+//! ```text
+//! method = "dispatch"
+//! params = { "action": <action>, "args": <args>, "request_id": <request_id> }
+//! id     = <request_id>
+//! ```
+//!
+//! The adapter Python (e.g. `dcc_mcp_maya.sidecar._dispatcher`)
+//! registers a `dispatch` handler on the Qt dispatcher's registry at
+//! plug-in startup so the same Python contract used today over
+//! `commandport://` keeps working over `qtserver://`. This means the
+//! adapter dispatcher itself is **wire-agnostic** — only the
+//! transport changes.
+//!
+//! # Cancellation
+//!
+//! The wire today is request/response without a separate cancellation
+//! channel. The dispatcher's main-thread guard means a long action
+//! cannot be interrupted mid-frame — the gateway's request-timeout +
+//! the in-Maya `check_maya_cancelled()` token stay the cooperative
+//! cancellation primitives. Future work: extend the JSON-line wire
+//! with a `cancel` method whose handler signals the corresponding
+//! in-flight `request_id`.
+//!
+//! # Concurrency
+//!
+//! Unlike `commandPort` (single-flight), the Qt dispatcher serves
+//! multiple connections. We still serialise per-client calls with a
+//! [`tokio::sync::Mutex`] because the wire is half-duplex per
+//! connection — request line in, response line out — and pipelining
+//! request IDs adds complexity we do not need for the current
+//! sidecar usage pattern (one outstanding gateway call per session).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde::Serialize;
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpStream;
+use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
+use tokio::sync::Mutex;
+
+use crate::{HostRpcClient, HostRpcError};
+
+/// The URI scheme this impl handles. Pinned as a constant so the
+/// scheme registry and tests both reference the same string.
+pub const URI_SCHEME: &str = "qtserver";
+
+/// JSON wire method that the adapter Python is expected to register
+/// on the Qt dispatcher's registry. See module-level docs for the
+/// shape of `params` and the `dispatch_payload` contract.
+pub const DISPATCH_METHOD: &str = "dispatch";
+
+/// Universal in-DCC dispatcher Python source.
+///
+/// Re-exported as a public constant so adapter plug-ins that want to
+/// install the dispatcher eagerly (no commandPort bootstrap dance)
+/// can `include_str!`-equivalent the same source the lazy bootstrap
+/// path uses. Tests use it to spin up a real `QtCommandServer` inside
+/// a synthetic Python interpreter.
+pub const DISPATCHER_PY: &str = include_str!("../python/dcc_qt_dispatcher.py");
+
+/// Bootstrap installer source.
+///
+/// Public for the same reason as [`DISPATCHER_PY`] — adapter and
+/// sidecar code can both inspect the source the wire path will run.
+/// The installer expects ``_DISPATCHER_SOURCE`` to be set as a
+/// string global before exec.
+pub const BOOTSTRAP_PY: &str = include_str!("../python/dcc_qt_dispatcher_bootstrap.py");
+
+/// `HostRpcClient` over the universal Qt-event-loop JSON-line wire.
+///
+/// Instantiate via [`QtServerClient::new`], then call
+/// [`HostRpcClient::connect`] to dial the TCP socket. After that the
+/// sidecar binary drives [`HostRpcClient::call`] / `close` just like
+/// any other impl.
+#[derive(Debug)]
+pub struct QtServerClient {
+    state: Arc<Mutex<Option<Connection>>>,
+}
+
+#[derive(Debug)]
+struct Connection {
+    writer: OwnedWriteHalf,
+    reader: BufReader<OwnedReadHalf>,
+}
+
+impl QtServerClient {
+    /// Construct a disconnected client. Call [`HostRpcClient::connect`]
+    /// before the first [`HostRpcClient::call`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+impl Default for QtServerClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Serialize)]
+struct WireRequest<'a> {
+    id: &'a str,
+    method: &'a str,
+    params: Value,
+}
+
+#[async_trait]
+impl HostRpcClient for QtServerClient {
+    fn uri_scheme(&self) -> &'static str {
+        URI_SCHEME
+    }
+
+    async fn connect(&mut self, endpoint: &str, timeout: Duration) -> Result<(), HostRpcError> {
+        let (host, port) = parse_endpoint(endpoint)?;
+        let stream = tokio::time::timeout(timeout, TcpStream::connect((host.as_str(), port)))
+            .await
+            .map_err(|_| HostRpcError::Timeout {})?
+            .map_err(|e| HostRpcError::transport(format!("qtserver connect {endpoint}: {e}")))?;
+        // Same Nagle-off rationale as `CommandPortClient`: each JSON
+        // request/response is a single line; we never benefit from
+        // kernel-level coalescing here.
+        let _ = stream.set_nodelay(true);
+        let (read_half, write_half) = stream.into_split();
+        *self.state.lock().await = Some(Connection {
+            writer: write_half,
+            reader: BufReader::new(read_half),
+        });
+        Ok(())
+    }
+
+    async fn call(
+        &self,
+        action: &str,
+        args: Value,
+        request_id: &str,
+    ) -> Result<Value, HostRpcError> {
+        let request = WireRequest {
+            id: request_id,
+            method: DISPATCH_METHOD,
+            params: json!({
+                "action": action,
+                "args": args,
+                "request_id": request_id,
+            }),
+        };
+        let mut wire_line = serde_json::to_vec(&request)
+            .map_err(|e| HostRpcError::transport(format!("encode wire frame: {e}")))?;
+        wire_line.push(b'\n');
+
+        let mut guard = self.state.lock().await;
+        let conn = guard
+            .as_mut()
+            .ok_or_else(|| HostRpcError::transport("QtServerClient::call before connect"))?;
+
+        if let Err(e) = conn.writer.write_all(&wire_line).await {
+            return Err(io_error_to_host_rpc(
+                e,
+                "qtserver write",
+                action,
+                args,
+                guard,
+            ));
+        }
+        if let Err(e) = conn.writer.flush().await {
+            return Err(io_error_to_host_rpc(
+                e,
+                "qtserver flush",
+                action,
+                args,
+                guard,
+            ));
+        }
+
+        let mut buf = String::new();
+        match conn.reader.read_line(&mut buf).await {
+            Ok(0) => {
+                // Peer closed mid-call — same host-died handling as
+                // commandport.
+                *guard = None;
+                Err(HostRpcError::host_died(action, Some(args)))
+            }
+            Ok(_) => {
+                let line = buf.trim_end_matches(['\r', '\n']);
+                if line.is_empty() {
+                    return Err(HostRpcError::transport(
+                        "qtserver returned an empty line — protocol violation",
+                    ));
+                }
+                let envelope: Value = serde_json::from_str(line).map_err(|e| {
+                    HostRpcError::transport(format!(
+                        "qtserver returned non-JSON line ({e}); raw: {line:?}",
+                    ))
+                })?;
+                interpret_envelope(envelope, action)
+            }
+            Err(e) => Err(io_error_to_host_rpc(
+                e,
+                "qtserver read",
+                action,
+                args,
+                guard,
+            )),
+        }
+    }
+
+    fn is_alive(&self) -> bool {
+        // Best-effort. Same rationale as commandport — a held lock
+        // means a call is in flight, which means the socket was alive
+        // up to the read syscall.
+        match self.state.try_lock() {
+            Ok(guard) => guard.is_some(),
+            Err(_) => true,
+        }
+    }
+
+    async fn close(&self) {
+        let mut guard = self.state.lock().await;
+        if let Some(conn) = guard.take() {
+            drop(conn);
+        }
+    }
+}
+
+/// Map a `tokio` / `std::io::Error` raised during a qtserver
+/// read/write/flush into the canonical [`HostRpcError`] envelope.
+///
+/// Same classification table as the commandport path — disconnect
+/// mid-call surfaces as `host-died`; everything else is a plain
+/// transport error.
+fn io_error_to_host_rpc(
+    error: std::io::Error,
+    op: &str,
+    action: &str,
+    args: Value,
+    mut guard: tokio::sync::MutexGuard<'_, Option<Connection>>,
+) -> HostRpcError {
+    use std::io::ErrorKind;
+    let is_terminal = matches!(
+        error.kind(),
+        ErrorKind::ConnectionAborted
+            | ErrorKind::ConnectionReset
+            | ErrorKind::BrokenPipe
+            | ErrorKind::NotConnected
+            | ErrorKind::UnexpectedEof,
+    );
+    if is_terminal {
+        *guard = None;
+        return HostRpcError::host_died(action, Some(args));
+    }
+    HostRpcError::transport(format!("{op}: {error}"))
+}
+
+/// Translate the JSON envelope returned by the Qt dispatcher into the
+/// canonical `Result<Value, HostRpcError>` contract.
+///
+/// Three shapes are accepted:
+///
+/// * `{"id": …, "result": …}` → `Ok(result)`
+/// * `{"id": …, "error": {…}}` → mapped to a transport error envelope
+///   carrying the dispatcher's structured ``code`` / ``message``.
+/// * Anything else → `TransportError` complaining about protocol
+///   violation. The Qt dispatcher must produce one of the two
+///   well-formed shapes per request; a malformed reply is a wire
+///   contract violation, not a user-visible error.
+fn interpret_envelope(envelope: Value, action: &str) -> Result<Value, HostRpcError> {
+    if let Some(result) = envelope.get("result").cloned() {
+        return Ok(result);
+    }
+    if let Some(error_obj) = envelope.get("error") {
+        let code = error_obj
+            .get("code")
+            .and_then(Value::as_str)
+            .unwrap_or("dispatcher-error");
+        let message = error_obj
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("(no message)");
+        return Err(HostRpcError::transport(format!(
+            "qtserver dispatcher error during {action}: [{code}] {message}",
+        )));
+    }
+    Err(HostRpcError::transport(format!(
+        "qtserver returned envelope without `result` or `error` for {action}: {envelope}",
+    )))
+}
+
+/// Parse a `qtserver://host:port` URI into its TCP target.
+///
+/// Mirrors [`commandport::parse_endpoint`](crate::commandport)'s shape
+/// so the error envelopes carry consistent diagnostics between the
+/// two transports.
+pub fn parse_endpoint(endpoint: &str) -> Result<(String, u16), HostRpcError> {
+    let rest = endpoint.strip_prefix("qtserver://").ok_or_else(|| {
+        HostRpcError::transport(format!("expected qtserver:// URI, got {endpoint:?}"))
+    })?;
+    let (host, port_str) = rest.rsplit_once(':').ok_or_else(|| {
+        HostRpcError::transport(format!("qtserver URI missing :port — got {endpoint:?}"))
+    })?;
+    if host.is_empty() {
+        return Err(HostRpcError::transport(format!(
+            "qtserver URI has empty host — got {endpoint:?}"
+        )));
+    }
+    let port: u16 = port_str.parse().map_err(|_| {
+        HostRpcError::transport(format!("qtserver URI port is not a u16 — got {endpoint:?}"))
+    })?;
+    if port == 0 {
+        return Err(HostRpcError::transport(format!(
+            "qtserver URI port must be non-zero — got {endpoint:?}"
+        )));
+    }
+    Ok((host.to_string(), port))
+}
+
+/// Build the **single-line** `commandPort` bootstrap payload that
+/// installs the qtserver dispatcher into the host process.
+///
+/// The Rust sidecar uses this when transitioning from a freshly opened
+/// `commandPort` (the only zero-install entry point most DCCs offer)
+/// to a full `qtserver://` session. The returned string is a complete
+/// Python statement suitable for one line of `commandPort` with
+/// `sourceType='python'` — it `exec`s the bootstrap source after
+/// injecting both `_DISPATCHER_SOURCE` and `_REQUESTED_PORT` as
+/// string/int globals.
+///
+/// Note: the line does **not** terminate with `\n`; callers append
+/// the newline at write time so they can choose CRLF or LF per
+/// platform conventions.
+#[must_use]
+pub fn build_bootstrap_command_line(requested_port: u16) -> String {
+    // Python's `repr()` of a multi-line string produces a valid
+    // string literal with `\n` etc. escaped. Rust's `{:?}` debug
+    // format for `&str` produces the same shape for ASCII-only
+    // input; the dispatcher source is pure ASCII by design.
+    //
+    // The combined source layout (in injection order) is:
+    //   _DISPATCHER_SOURCE = "<dispatcher_py>"
+    //   _REQUESTED_PORT    = <u16>
+    //   <bootstrap_py body>
+    //
+    // The bootstrap body's last statement is the assignment
+    // `_install_result = _install(_DISPATCHER_SOURCE)`, which leaves
+    // the installed module in `sys.modules['_dcc_qt_dispatcher']`.
+    // A second commandPort round-trip (see `build_start_command_line`)
+    // then calls `start_qt_server(port=<requested_port>)` and reads
+    // back the bound port.
+    let combined = format!(
+        "_DISPATCHER_SOURCE = {dispatcher:?}\n\
+         _REQUESTED_PORT = {requested}\n\
+         {bootstrap}",
+        dispatcher = DISPATCHER_PY,
+        requested = requested_port,
+        bootstrap = BOOTSTRAP_PY,
+    );
+    format!(
+        "__import__('builtins').exec(__import__('builtins').compile({combined:?}, \
+         '<dcc-mcp-qt-bootstrap>', 'exec'))",
+    )
+}
+
+/// Build the **single-line** `commandPort` follow-up payload that
+/// asks the just-installed dispatcher to start its `QTcpServer` and
+/// reports the bound endpoint as a JSON string.
+///
+/// Pairs with [`build_bootstrap_command_line`]. The reply is a JSON
+/// dict the caller parses via [`parse_start_reply`].
+#[must_use]
+pub fn build_start_command_line(requested_port: u16) -> String {
+    format!(
+        "__import__('json').dumps(\
+         __import__('_dcc_qt_dispatcher').start_qt_server(port={requested_port}))",
+    )
+}
+
+/// Parse the JSON dict reply produced by [`build_start_command_line`].
+///
+/// Returns the `qtserver://host:port` URI the caller should pass to
+/// [`HostRpcClient::connect`] on a freshly constructed
+/// [`QtServerClient`].
+pub fn parse_start_reply(reply: &str) -> Result<String, HostRpcError> {
+    // Maya's commandPort with `sourceType='python'` wraps the eval
+    // result in a leading + trailing quote character (Python `repr`
+    // of the returned string). Tolerate both raw JSON and quoted
+    // JSON shapes so the caller does not need to peek at Maya's
+    // wire idiosyncrasies.
+    let trimmed = reply.trim();
+    let unquoted = if (trimmed.starts_with('"') && trimmed.ends_with('"'))
+        || (trimmed.starts_with('\'') && trimmed.ends_with('\''))
+    {
+        // Strip the outer quote characters; commandPort embeds the
+        // JSON as a Python string literal but does NOT re-escape
+        // inner `"` because the embedded value is also a JSON string
+        // that was double-encoded once already. We accept naive trim
+        // here because the dispatcher controls the inner payload.
+        &trimmed[1..trimmed.len() - 1]
+    } else {
+        trimmed
+    };
+    let parsed: Value = serde_json::from_str(unquoted).map_err(|e| {
+        HostRpcError::transport(format!(
+            "qtserver start reply was not JSON ({e}); raw: {reply:?}",
+        ))
+    })?;
+    let host = parsed
+        .get("host")
+        .and_then(Value::as_str)
+        .ok_or_else(|| HostRpcError::transport(format!("start reply missing `host`: {parsed}")))?;
+    let port = parsed
+        .get("port")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| HostRpcError::transport(format!("start reply missing `port`: {parsed}")))?;
+    if port == 0 || port > u64::from(u16::MAX) {
+        return Err(HostRpcError::transport(format!(
+            "start reply `port` out of u16 range: {port}"
+        )));
+    }
+    Ok(format!("{URI_SCHEME}://{host}:{port}"))
+}
+
+// ── tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::net::TcpListener;
+
+    // ── parse_endpoint ───────────────────────────────────────────────────
+
+    #[test]
+    fn parse_endpoint_happy_path() {
+        let (host, port) = parse_endpoint("qtserver://127.0.0.1:18765").unwrap();
+        assert_eq!(host, "127.0.0.1");
+        assert_eq!(port, 18765);
+    }
+
+    #[test]
+    fn parse_endpoint_rejects_wrong_scheme() {
+        for bad in [
+            "commandport://127.0.0.1:1234",
+            "http://127.0.0.1:1234",
+            "qtserver:/127.0.0.1:1234",
+        ] {
+            assert!(
+                matches!(
+                    parse_endpoint(bad),
+                    Err(HostRpcError::TransportError { .. })
+                ),
+                "wrong scheme should reject: {bad}",
+            );
+        }
+    }
+
+    #[test]
+    fn parse_endpoint_rejects_missing_port() {
+        assert!(matches!(
+            parse_endpoint("qtserver://127.0.0.1"),
+            Err(HostRpcError::TransportError { .. }),
+        ));
+    }
+
+    #[test]
+    fn parse_endpoint_rejects_zero_port() {
+        assert!(matches!(
+            parse_endpoint("qtserver://127.0.0.1:0"),
+            Err(HostRpcError::TransportError { .. }),
+        ));
+    }
+
+    #[test]
+    fn parse_endpoint_rejects_oversized_port() {
+        assert!(matches!(
+            parse_endpoint("qtserver://127.0.0.1:70000"),
+            Err(HostRpcError::TransportError { .. }),
+        ));
+    }
+
+    #[test]
+    fn parse_endpoint_rejects_empty_host() {
+        assert!(matches!(
+            parse_endpoint("qtserver://:18765"),
+            Err(HostRpcError::TransportError { .. }),
+        ));
+    }
+
+    // ── interpret_envelope ───────────────────────────────────────────────
+
+    #[test]
+    fn interpret_envelope_extracts_result() {
+        let env = json!({"id": "req-1", "result": {"value": 42}});
+        let value = interpret_envelope(env, "any").unwrap();
+        assert_eq!(value, json!({"value": 42}));
+    }
+
+    #[test]
+    fn interpret_envelope_maps_dispatcher_error_to_transport_error() {
+        let env = json!({
+            "id": "req-2",
+            "error": {"code": "handler-exception", "message": "BoomError: blew up"},
+        });
+        let err = interpret_envelope(env, "maya_scene__crash").unwrap_err();
+        match err {
+            HostRpcError::TransportError { message } => {
+                assert!(message.contains("handler-exception"), "{message}");
+                assert!(message.contains("BoomError"), "{message}");
+                assert!(message.contains("maya_scene__crash"), "{message}");
+            }
+            other => panic!("expected TransportError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn interpret_envelope_rejects_malformed_envelope() {
+        let env = json!({"id": "req-3"}); // no result, no error
+        let err = interpret_envelope(env, "any").unwrap_err();
+        assert!(matches!(err, HostRpcError::TransportError { .. }));
+    }
+
+    // ── connect / call roundtrip against a fake Qt server ────────────────
+
+    /// Spawn an in-process TCP server that mimics the Qt dispatcher's
+    /// JSON-line protocol. Each accepted connection reads one
+    /// request line, looks the method up in `handlers`, writes the
+    /// response line, and loops. Closing the connection terminates
+    /// the per-connection task.
+    type Handler = Box<dyn Fn(Value) -> Value + Send + Sync>;
+
+    async fn spawn_fake_qt_server(
+        handlers: std::collections::HashMap<&'static str, Handler>,
+    ) -> u16 {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let port = listener.local_addr().expect("local_addr").port();
+        let handlers = Arc::new(handlers);
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    return;
+                };
+                let handlers = Arc::clone(&handlers);
+                tokio::spawn(async move {
+                    let (read_half, mut write_half) = stream.split();
+                    let mut reader = BufReader::new(read_half);
+                    let mut line = String::new();
+                    loop {
+                        line.clear();
+                        match reader.read_line(&mut line).await {
+                            Ok(0) | Err(_) => return,
+                            Ok(_) => {}
+                        }
+                        let request: Value = match serde_json::from_str(line.trim_end()) {
+                            Ok(v) => v,
+                            Err(_) => return,
+                        };
+                        let id = request.get("id").cloned().unwrap_or(Value::Null);
+                        let method = request
+                            .get("method")
+                            .and_then(Value::as_str)
+                            .unwrap_or("")
+                            .to_string();
+                        let params = request.get("params").cloned().unwrap_or(Value::Null);
+                        let envelope = if let Some(handler) = handlers.get(method.as_str()) {
+                            let result = handler(params);
+                            json!({"id": id, "result": result})
+                        } else {
+                            json!({
+                                "id": id,
+                                "error": {
+                                    "code": "unknown-method",
+                                    "message": format!("unknown method {method:?}"),
+                                },
+                            })
+                        };
+                        let mut out = serde_json::to_vec(&envelope).expect("serialise envelope");
+                        out.push(b'\n');
+                        if write_half.write_all(&out).await.is_err() {
+                            return;
+                        }
+                        let _ = write_half.flush().await;
+                    }
+                });
+            }
+        });
+        port
+    }
+
+    #[tokio::test]
+    async fn connect_and_call_dispatch_roundtrip() {
+        let mut handlers = std::collections::HashMap::<&'static str, Handler>::new();
+        handlers.insert(
+            "dispatch",
+            Box::new(|params: Value| {
+                json!({
+                    "echo_action": params.get("action").cloned(),
+                    "echo_args": params.get("args").cloned(),
+                    "echo_request_id": params.get("request_id").cloned(),
+                })
+            }),
+        );
+        let port = spawn_fake_qt_server(handlers).await;
+
+        let mut client = QtServerClient::new();
+        client
+            .connect(
+                &format!("qtserver://127.0.0.1:{port}"),
+                Duration::from_secs(5),
+            )
+            .await
+            .expect("connect");
+
+        let result = client
+            .call("maya_scene__list", json!({"limit": 10}), "req-1")
+            .await
+            .expect("call");
+        assert_eq!(
+            result.get("echo_action"),
+            Some(&Value::String("maya_scene__list".into()))
+        );
+        assert_eq!(result.get("echo_args"), Some(&json!({"limit": 10})));
+        assert_eq!(
+            result.get("echo_request_id"),
+            Some(&Value::String("req-1".into()))
+        );
+    }
+
+    #[tokio::test]
+    async fn call_surfaces_dispatcher_error_as_transport_error() {
+        // The fake server doesn't know "dispatch"; the QtServerClient
+        // sends method="dispatch" so we get an unknown-method back.
+        let handlers = std::collections::HashMap::<&'static str, Handler>::new();
+        let port = spawn_fake_qt_server(handlers).await;
+
+        let mut client = QtServerClient::new();
+        client
+            .connect(
+                &format!("qtserver://127.0.0.1:{port}"),
+                Duration::from_secs(5),
+            )
+            .await
+            .expect("connect");
+
+        let err = client
+            .call("maya_anything", json!({}), "req-2")
+            .await
+            .expect_err("must surface unknown-method as transport error");
+        match err {
+            HostRpcError::TransportError { message } => {
+                assert!(message.contains("unknown-method"), "{message}");
+                assert!(message.contains("maya_anything"), "{message}");
+            }
+            other => panic!("expected TransportError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn host_died_when_peer_closes_during_call() {
+        // Spawn a TCP server that accepts then immediately closes
+        // without writing a response — emulates the DCC process being
+        // killed mid-call.
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let port = listener.local_addr().expect("local_addr").port();
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept");
+            drop(stream);
+        });
+
+        let mut client = QtServerClient::new();
+        client
+            .connect(
+                &format!("qtserver://127.0.0.1:{port}"),
+                Duration::from_secs(5),
+            )
+            .await
+            .expect("connect");
+
+        // Give the peer-close a moment so the next call hits a dead
+        // socket reliably across platforms (Windows surfaces it on
+        // the write; Unix usually surfaces it on the read).
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let err = client
+            .call("any_action", json!({}), "req-3")
+            .await
+            .expect_err("call must fail when peer is gone");
+        assert!(
+            matches!(err, HostRpcError::HostDied { .. }),
+            "expected HostDied, got {err:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn close_drops_socket_and_blocks_further_calls() {
+        let mut handlers = std::collections::HashMap::<&'static str, Handler>::new();
+        handlers.insert("dispatch", Box::new(|_| json!({"ok": true})));
+        let port = spawn_fake_qt_server(handlers).await;
+
+        let mut client = QtServerClient::new();
+        client
+            .connect(
+                &format!("qtserver://127.0.0.1:{port}"),
+                Duration::from_secs(5),
+            )
+            .await
+            .expect("connect");
+        client.close().await;
+        assert!(!client.is_alive());
+
+        let err = client
+            .call("anything", json!({}), "req-after-close")
+            .await
+            .expect_err("call after close must fail");
+        assert!(matches!(err, HostRpcError::TransportError { .. }));
+    }
+
+    #[tokio::test]
+    async fn connect_timeout_is_honoured() {
+        // Bind a socket but never accept — every connect attempt
+        // hangs in the listener's backlog. We then verify the
+        // timeout is mapped to HostRpcError::Timeout.
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let port = listener.local_addr().expect("local_addr").port();
+        // Drop listener so future connects RST instead of accepting.
+        // We use a tiny non-existent port instead — pick something
+        // that has no listener to make connect reliably refuse.
+        drop(listener);
+
+        let mut client = QtServerClient::new();
+        let result = client
+            .connect(
+                &format!("qtserver://127.0.0.1:{port}"),
+                Duration::from_millis(100),
+            )
+            .await;
+        // Refused connect is a transport error (not a timeout) on
+        // most OSes — we accept either as long as it does NOT
+        // silently succeed.
+        assert!(
+            matches!(
+                result,
+                Err(HostRpcError::TransportError { .. }) | Err(HostRpcError::Timeout { .. }),
+            ),
+            "expected transport-error or timeout, got {result:?}",
+        );
+    }
+
+    // ── bootstrap helpers ────────────────────────────────────────────────
+
+    #[test]
+    fn bootstrap_command_line_inlines_dispatcher_and_bootstrap_sources() {
+        let line = build_bootstrap_command_line(0);
+        // Both sources are embedded as Python string literals — the
+        // escaped form must contain the dispatcher's class name and
+        // the bootstrap's installer.
+        assert!(line.contains("__import__('builtins').exec"));
+        assert!(line.contains("compile"));
+        assert!(line.contains("QtCommandServer"));
+        assert!(line.contains("_install_result"));
+        assert!(line.contains("_REQUESTED_PORT = 0"));
+    }
+
+    #[test]
+    fn bootstrap_command_line_propagates_requested_port() {
+        let line = build_bootstrap_command_line(12345);
+        assert!(line.contains("_REQUESTED_PORT = 12345"));
+    }
+
+    #[test]
+    fn start_command_line_targets_dispatcher_module() {
+        let line = build_start_command_line(0);
+        assert!(line.contains("_dcc_qt_dispatcher"));
+        assert!(line.contains("start_qt_server"));
+        assert!(line.contains("port=0"));
+        assert!(line.contains("__import__('json').dumps"));
+    }
+
+    #[test]
+    fn parse_start_reply_unquotes_and_extracts_endpoint() {
+        // Maya's commandPort wraps a string return value in single
+        // quotes (Python repr); tolerate that shape.
+        let reply = "'{\"host\": \"127.0.0.1\", \"port\": 18765, \"qt_binding\": \"PySide6\"}'";
+        let uri = parse_start_reply(reply).unwrap();
+        assert_eq!(uri, "qtserver://127.0.0.1:18765");
+    }
+
+    #[test]
+    fn parse_start_reply_accepts_raw_json() {
+        let reply = "{\"host\": \"127.0.0.1\", \"port\": 9999}";
+        let uri = parse_start_reply(reply).unwrap();
+        assert_eq!(uri, "qtserver://127.0.0.1:9999");
+    }
+
+    #[test]
+    fn parse_start_reply_rejects_missing_fields() {
+        for bad in [
+            "{\"port\": 1234}",
+            "{\"host\": \"localhost\"}",
+            "{\"host\": \"x\", \"port\": 0}",
+            "{\"host\": \"x\", \"port\": 70000}",
+            "not json",
+        ] {
+            assert!(
+                parse_start_reply(bad).is_err(),
+                "should reject reply {bad:?}",
+            );
+        }
+    }
+}

--- a/crates/dcc-mcp-host-rpc/src/registry.rs
+++ b/crates/dcc-mcp-host-rpc/src/registry.rs
@@ -5,7 +5,8 @@
 //! impl and dispatching on the URI scheme:
 //!
 //! ```text
-//! commandport://127.0.0.1:6042  → CommandPortClient   (Maya)
+//! qtserver://127.0.0.1:18765    → QtServerClient      (Maya, Houdini, 3ds Max, Nuke, …)
+//! commandport://127.0.0.1:6042  → CommandPortClient   (Maya — legacy / bootstrap only)
 //! stub://anything               → StubHostRpcClient   (tests / placeholder)
 //! ```
 //!
@@ -19,6 +20,7 @@
 //! binary so the caller can pass a `--connect-timeout-secs` flag.
 
 use crate::commandport::{CommandPortClient, URI_SCHEME as COMMANDPORT_SCHEME};
+use crate::qtserver::{QtServerClient, URI_SCHEME as QTSERVER_SCHEME};
 use crate::{HostRpcClient, HostRpcError, StubHostRpcClient};
 
 /// URI scheme reserved for the placeholder client. Pinned as a const
@@ -40,6 +42,7 @@ pub const STUB_SCHEME: &str = "stub";
 pub fn client_for_uri(endpoint: &str) -> Result<Box<dyn HostRpcClient>, HostRpcError> {
     let scheme = parse_scheme(endpoint)?;
     match scheme.as_str() {
+        QTSERVER_SCHEME => Ok(Box::new(QtServerClient::new())),
         COMMANDPORT_SCHEME => Ok(Box::new(CommandPortClient::new())),
         STUB_SCHEME => Ok(Box::new(StubHostRpcClient::new())),
         other => Err(HostRpcError::transport(format!(
@@ -56,7 +59,7 @@ pub fn client_for_uri(endpoint: &str) -> Result<Box<dyn HostRpcClient>, HostRpcE
 /// can enumerate them without duplicating the list.
 #[must_use]
 pub fn registered_schemes() -> Vec<&'static str> {
-    vec![COMMANDPORT_SCHEME, STUB_SCHEME]
+    vec![QTSERVER_SCHEME, COMMANDPORT_SCHEME, STUB_SCHEME]
 }
 
 /// Lowercase scheme component of a `<scheme>://<rest>` URI.
@@ -83,6 +86,8 @@ mod tests {
     fn parse_scheme_lowercases_and_strips() {
         assert_eq!(parse_scheme("commandport://x:1").unwrap(), "commandport");
         assert_eq!(parse_scheme("CommandPort://x:1").unwrap(), "commandport");
+        assert_eq!(parse_scheme("qtserver://x:1").unwrap(), "qtserver");
+        assert_eq!(parse_scheme("QtServer://x:1").unwrap(), "qtserver");
         assert_eq!(parse_scheme("STUB://anything").unwrap(), "stub");
     }
 
@@ -102,6 +107,12 @@ mod tests {
     fn client_for_uri_dispatches_commandport() {
         let client = client_for_uri("commandport://127.0.0.1:6042").unwrap();
         assert_eq!(client.uri_scheme(), "commandport");
+    }
+
+    #[test]
+    fn client_for_uri_dispatches_qtserver() {
+        let client = client_for_uri("qtserver://127.0.0.1:18765").unwrap();
+        assert_eq!(client.uri_scheme(), "qtserver");
     }
 
     #[test]
@@ -125,6 +136,10 @@ mod tests {
                     message.contains("commandport"),
                     "error should list the supported schemes: {message}"
                 );
+                assert!(
+                    message.contains("qtserver"),
+                    "error should list the supported schemes: {message}"
+                );
             }
             other => panic!("expected TransportError, got {other:?}"),
         }
@@ -134,10 +149,11 @@ mod tests {
     fn registered_schemes_pins_the_set() {
         let schemes = registered_schemes();
         assert!(schemes.contains(&"commandport"));
+        assert!(schemes.contains(&"qtserver"));
         assert!(schemes.contains(&"stub"));
         // If anyone adds a new scheme here, they MUST also update
         // the match in `client_for_uri`. This test fails loudly so
         // the two stay in sync.
-        assert_eq!(schemes.len(), 2);
+        assert_eq!(schemes.len(), 3);
     }
 }

--- a/tests/test_dcc_qt_dispatcher_py.py
+++ b/tests/test_dcc_qt_dispatcher_py.py
@@ -1,0 +1,399 @@
+"""Semantic tests for the universal Qt dispatcher Python source.
+
+The Rust :mod:`dcc_mcp_host_rpc::qtserver` module ships two embedded
+sources:
+
+* ``crates/dcc-mcp-host-rpc/python/dcc_qt_dispatcher.py``
+  — the actual ``QtCommandServer`` + ``_DispatchRegistry``.
+* ``crates/dcc-mcp-host-rpc/python/dcc_qt_dispatcher_bootstrap.py``
+  — the installer wrapping the above into ``sys.modules``.
+
+The Rust unit tests in ``qtserver.rs`` cover **wire framing** (request
+serialisation, envelope interpretation, host-died classification) and
+the **bootstrap helpers** that build the commandPort eval lines. They
+cannot verify the *Python semantics* of the embedded sources
+themselves — typos in attribute access, drift between the dispatcher
+methods and what callers send over the wire, etc.
+
+This test exercises both files in a stock Python interpreter (no Qt
+required for the pure-Python parts; PySide2/PySide6 optional for the
+server smoke test) so any regression in those bodies fails the
+dcc-mcp-core CI suite.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import json
+from pathlib import Path
+import sys
+import types
+from typing import Iterator
+
+# Import third-party modules
+import pytest
+
+DISPATCHER_PATH = Path(__file__).parent.parent / "crates" / "dcc-mcp-host-rpc" / "python" / "dcc_qt_dispatcher.py"
+BOOTSTRAP_PATH = (
+    Path(__file__).parent.parent / "crates" / "dcc-mcp-host-rpc" / "python" / "dcc_qt_dispatcher_bootstrap.py"
+)
+
+
+def _read(path: Path) -> str:
+    assert path.is_file(), f"source missing at {path}; the Rust binary `include_str!`s this exact file at build time."
+    return path.read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def dispatcher_module() -> Iterator[types.ModuleType]:
+    """Exec ``dcc_qt_dispatcher.py`` into a fresh module-style namespace
+    and yield it. The module mimics what the bootstrap installs under
+    ``sys.modules['_dcc_qt_dispatcher']`` inside a real DCC.
+    """
+    source = _read(DISPATCHER_PATH)
+    module = types.ModuleType("_dcc_qt_dispatcher")
+    module.__file__ = str(DISPATCHER_PATH)
+    exec(
+        compile(source, module.__file__, "exec"),
+        module.__dict__,
+    )
+    yield module
+
+
+def test_dispatcher_exports_public_api(dispatcher_module: types.ModuleType) -> None:
+    """The Rust `QtServerClient` and per-DCC plug-ins both rely on a
+    stable public surface — pin it here so refactors of the source
+    fail loudly instead of silently breaking the wire path.
+    """
+    for name in (
+        "QtCommandServer",
+        "start_qt_server",
+        "stop_qt_server",
+        "current_server",
+        "DISPATCHER_VERSION",
+    ):
+        assert hasattr(dispatcher_module, name), f"public symbol missing: {name}"
+
+
+def test_dispatch_registry_ping(dispatcher_module: types.ModuleType) -> None:
+    registry = dispatcher_module._DispatchRegistry()
+    envelope = registry.dispatch("ping", {})
+    assert envelope == {
+        "result": {"pong": True, "version": dispatcher_module.DISPATCHER_VERSION},
+    }
+
+
+def test_dispatch_registry_unknown_method(dispatcher_module: types.ModuleType) -> None:
+    registry = dispatcher_module._DispatchRegistry()
+    envelope = registry.dispatch("does_not_exist", {})
+    assert "error" in envelope
+    assert envelope["error"]["code"] == "unknown-method"
+    assert "does_not_exist" in envelope["error"]["message"]
+
+
+def test_dispatch_registry_execute_returns_value(dispatcher_module: types.ModuleType) -> None:
+    registry = dispatcher_module._DispatchRegistry()
+    envelope = registry.dispatch("execute", {"code": "1 + 2"})
+    assert envelope == {"result": {"value": 3, "result_type": "value"}}
+
+
+def test_dispatch_registry_execute_mixed_body_and_expression(
+    dispatcher_module: types.ModuleType,
+) -> None:
+    """Statements before the trailing expression run as side effects;
+    the expression's value is returned.
+    """
+    registry = dispatcher_module._DispatchRegistry()
+    envelope = registry.dispatch(
+        "execute",
+        {"code": "x = 10\ny = 20\nx + y"},
+    )
+    assert envelope == {"result": {"value": 30, "result_type": "value"}}
+
+
+def test_dispatch_registry_execute_void_returns_none(
+    dispatcher_module: types.ModuleType,
+) -> None:
+    """Code that ends in a statement (no trailing expression) returns
+    a ``{"value": None, "result_type": "void"}`` envelope so the wire
+    can never get stuck on a "no result" ambiguity.
+    """
+    registry = dispatcher_module._DispatchRegistry()
+    envelope = registry.dispatch("execute", {"code": "import sys"})
+    assert envelope == {"result": {"value": None, "result_type": "void"}}
+
+
+def test_dispatch_registry_execute_repr_mode(dispatcher_module: types.ModuleType) -> None:
+    """``result_type='repr'`` returns ``repr(value)`` so the caller can
+    see objects that aren't JSON-serialisable.
+    """
+    registry = dispatcher_module._DispatchRegistry()
+    envelope = registry.dispatch(
+        "execute",
+        {"code": "object()", "result_type": "repr"},
+    )
+    assert envelope["result"]["result_type"] == "repr"
+    assert envelope["result"]["value"].startswith("<object object at ")
+
+
+def test_dispatch_registry_execute_falls_back_to_repr_for_non_json(
+    dispatcher_module: types.ModuleType,
+) -> None:
+    """``result_type='value'`` should never raise a serialisation
+    error — non-JSON objects get repr'd transparently.
+    """
+    registry = dispatcher_module._DispatchRegistry()
+    envelope = registry.dispatch("execute", {"code": "object()"})
+    assert envelope["result"]["result_type"] == "value"
+    assert isinstance(envelope["result"]["value"], str)
+
+
+def test_dispatch_registry_execute_surfaces_exception(
+    dispatcher_module: types.ModuleType,
+) -> None:
+    registry = dispatcher_module._DispatchRegistry()
+    envelope = registry.dispatch("execute", {"code": "1/0"})
+    assert "error" in envelope
+    assert envelope["error"]["code"] == "handler-exception"
+    assert "ZeroDivisionError" in envelope["error"]["message"]
+    assert "Traceback" in envelope["error"]["traceback"]
+
+
+def test_dispatch_registry_get_session_info(dispatcher_module: types.ModuleType) -> None:
+    registry = dispatcher_module._DispatchRegistry()
+    envelope = registry.dispatch("get_session_info", {})
+    info = envelope["result"]
+    assert info["dispatcher_version"] == dispatcher_module.DISPATCHER_VERSION
+    assert isinstance(info["python_version"], str)
+    assert isinstance(info["platform"], str)
+
+
+def test_dispatch_registry_stream_capture_install_and_drain(
+    dispatcher_module: types.ModuleType,
+) -> None:
+    registry = dispatcher_module._DispatchRegistry()
+    try:
+        installed = registry.dispatch("install_stream_capture", {})
+        assert installed == {"result": {"installed": True}}
+        # idempotent
+        installed_again = registry.dispatch("install_stream_capture", {})
+        assert installed_again == {"result": {"installed": False, "reused": True}}
+        # Print something via the captured stdout (which is the tee)
+        print("hello from captured stdout")
+        drained = registry.dispatch("get_buffered_output", {})
+        assert "hello from captured stdout" in drained["result"]["output"]
+        # Drain default is True — second call returns empty unless
+        # something else was printed between.
+        drained_again = registry.dispatch("get_buffered_output", {})
+        assert drained_again["result"]["output"] == ""
+    finally:
+        # Restore — leaving _Tee installed would poison subsequent
+        # tests and pytest's own output.
+        sys.stdout = registry._stdout_orig
+        sys.stderr = registry._stderr_orig
+
+
+def test_dispatch_registry_create_module_installs_into_sys_modules(
+    dispatcher_module: types.ModuleType,
+) -> None:
+    registry = dispatcher_module._DispatchRegistry()
+    name = "_dcc_qt_dispatcher_test_install"
+    try:
+        envelope = registry.dispatch(
+            "create_module",
+            {"name": name, "source": "value = 42\n", "version": "v1"},
+        )
+        assert envelope == {
+            "result": {"installed": True, "name": name, "version": "v1"},
+        }
+        assert sys.modules[name].value == 42
+        # Re-install at same version is a no-op.
+        again = registry.dispatch(
+            "create_module",
+            {"name": name, "source": "value = 999\n", "version": "v1"},
+        )
+        assert again == {
+            "result": {"installed": False, "reused": True, "name": name, "version": "v1"},
+        }
+        # Still the original value — the no-op didn't re-exec.
+        assert sys.modules[name].value == 42
+    finally:
+        sys.modules.pop(name, None)
+
+
+def test_dispatch_registry_create_module_validates_inputs(
+    dispatcher_module: types.ModuleType,
+) -> None:
+    registry = dispatcher_module._DispatchRegistry()
+    for bad_params, expected in (
+        ({"name": "", "source": "x = 1"}, "non-empty string"),
+        ({"name": "ok", "source": 123}, "must be a string"),
+    ):
+        envelope = registry.dispatch("create_module", bad_params)
+        assert "error" in envelope, f"should reject {bad_params}"
+        assert expected in envelope["error"]["message"], envelope["error"]["message"]
+
+
+def test_tee_tolerates_broken_sink(dispatcher_module: types.ModuleType) -> None:
+    """A closed/broken downstream sink must not propagate to the
+    caller — the DCC's console may close at any time during a long
+    session and the dispatcher must keep working.
+    """
+
+    class Broken:
+        def write(self, _data):
+            raise OSError("sink is gone")
+
+        def flush(self):
+            raise OSError("sink is gone")
+
+    sink = dispatcher_module._Tee(Broken(), Broken())
+    sink.write("hello")  # must not raise
+    sink.flush()
+
+
+def test_bootstrap_installs_dispatcher_from_source() -> None:
+    """The bootstrap orchestrator must install
+    ``sys.modules['_dcc_qt_dispatcher']`` from a string source and
+    leave the module in a state where ``start_qt_server`` is
+    callable (we don't actually start it here — that needs Qt).
+    """
+    dispatcher_source = _read(DISPATCHER_PATH)
+    bootstrap_source = _read(BOOTSTRAP_PATH)
+
+    namespace: dict = {
+        "_DISPATCHER_SOURCE": dispatcher_source,
+        "_REQUESTED_PORT": 0,
+    }
+    try:
+        exec(
+            compile(bootstrap_source, str(BOOTSTRAP_PATH), "exec"),
+            namespace,
+        )
+        # The install_result should be the installed module itself,
+        # not a failure dict.
+        installed = namespace["_install_result"]
+        assert isinstance(installed, types.ModuleType), f"expected module, got {installed!r}"
+        assert installed.__name__ == "_dcc_qt_dispatcher"
+        assert hasattr(installed, "start_qt_server")
+        assert hasattr(installed, "stop_qt_server")
+        assert sys.modules["_dcc_qt_dispatcher"] is installed
+    finally:
+        sys.modules.pop("_dcc_qt_dispatcher", None)
+
+
+def test_bootstrap_idempotent_on_same_version() -> None:
+    """A second exec of the bootstrap with the same version must
+    reuse the already-installed module (no re-exec of the source).
+    """
+    dispatcher_source = _read(DISPATCHER_PATH)
+    bootstrap_source = _read(BOOTSTRAP_PATH)
+
+    try:
+        # First install
+        ns_a: dict = {
+            "_DISPATCHER_SOURCE": dispatcher_source,
+            "_REQUESTED_PORT": 0,
+        }
+        exec(compile(bootstrap_source, str(BOOTSTRAP_PATH), "exec"), ns_a)
+        first = ns_a["_install_result"]
+        # Mark the module so we can detect a re-exec
+        first._dcc_qt_test_marker = "first-install"
+
+        # Second install in a fresh namespace
+        ns_b: dict = {
+            "_DISPATCHER_SOURCE": dispatcher_source,
+            "_REQUESTED_PORT": 0,
+        }
+        exec(compile(bootstrap_source, str(BOOTSTRAP_PATH), "exec"), ns_b)
+        second = ns_b["_install_result"]
+        # Same module object — and the marker survives, proving no
+        # re-exec.
+        assert second is first
+        assert getattr(second, "_dcc_qt_test_marker", None) == "first-install"
+    finally:
+        sys.modules.pop("_dcc_qt_dispatcher", None)
+
+
+def test_bootstrap_returns_failure_envelope_on_syntax_error() -> None:
+    """If the dispatcher source has a syntax error, the bootstrap
+    must NOT register the broken module in ``sys.modules`` and
+    must surface a structured failure dict so the Rust client
+    can map it to a transport error.
+    """
+    bootstrap_source = _read(BOOTSTRAP_PATH)
+    broken_source = "def x(:::\n"  # syntactically invalid
+
+    try:
+        namespace: dict = {
+            "_DISPATCHER_SOURCE": broken_source,
+            "_REQUESTED_PORT": 0,
+        }
+        exec(compile(bootstrap_source, str(BOOTSTRAP_PATH), "exec"), namespace)
+        result = namespace["_install_result"]
+        assert isinstance(result, dict)
+        assert result["ok"] is False
+        assert result["stage"] == "compile"
+        assert "SyntaxError" in result["error"]
+        assert "_dcc_qt_dispatcher" not in sys.modules, "broken dispatcher must not pollute sys.modules"
+    finally:
+        sys.modules.pop("_dcc_qt_dispatcher", None)
+
+
+def test_dispatcher_source_compiles_without_qt() -> None:
+    """``dc_qt_dispatcher.py`` must be importable up to the point of
+    ``_import_qt`` being called. Calling :func:`start_qt_server` is
+    what triggers the Qt import — module-load itself must work
+    headless so CI without PySide passes.
+    """
+    source = _read(DISPATCHER_PATH)
+    namespace: dict = {}
+    exec(compile(source, str(DISPATCHER_PATH), "exec"), namespace)
+    assert "QtCommandServer" in namespace
+    assert "start_qt_server" in namespace
+    assert namespace["_singleton"]["server"] is None
+
+
+def test_dispatcher_source_is_valid_python_when_inlined_in_bootstrap_wire() -> None:
+    """The Rust ``build_bootstrap_command_line`` inlines both files'
+    sources into a single Python eval expression. Verify the
+    composition is syntactically valid by reproducing the same
+    composition here.
+    """
+    dispatcher_source = _read(DISPATCHER_PATH)
+    bootstrap_source = _read(BOOTSTRAP_PATH)
+    composed = "_DISPATCHER_SOURCE = " + repr(dispatcher_source) + "\n_REQUESTED_PORT = 0\n" + bootstrap_source
+    # Compile must succeed — runtime semantics covered by the
+    # dedicated bootstrap tests above.
+    compile(composed, "<wire-bootstrap>", "exec")
+
+
+@pytest.mark.skipif(
+    "PySide2" not in sys.modules
+    and "PySide6" not in sys.modules
+    and not any(
+        __import__("importlib.util", fromlist=["find_spec"]).find_spec(name)
+        for name in ("PySide6", "PySide2", "PyQt6", "PyQt5")
+    ),
+    reason="no Qt binding available — skip live QTcpServer smoke test",
+)
+def test_start_qt_server_returns_bound_port_and_is_idempotent(
+    dispatcher_module: types.ModuleType,
+) -> None:
+    """End-to-end smoke against a real Qt binding when one is
+    installed in the CI image. Verifies the server actually binds
+    and ``start_qt_server`` is idempotent.
+    """
+    info = dispatcher_module.start_qt_server(port=0, host="127.0.0.1")
+    try:
+        assert info["host"] == "127.0.0.1"
+        assert 1024 < info["port"] < 65536
+        assert info["dispatcher_version"] == dispatcher_module.DISPATCHER_VERSION
+        assert info["reused"] is False
+        # Second call must reuse the same server.
+        again = dispatcher_module.start_qt_server(port=0)
+        assert again["port"] == info["port"]
+        assert again["reused"] is True
+    finally:
+        dispatcher_module.stop_qt_server()


### PR DESCRIPTION
## Summary

Phase 2 of the RFC #998 architectural pivot: introduce the **`qtserver://`** URI scheme and the universal Qt-event-loop in-DCC JSON-line dispatcher that replaces `commandPort` as the default in-DCC dispatch surface for every Qt-bearing DCC.

The same dispatcher source runs in Maya, Houdini, 3ds Max, Nuke, Cinema 4D, Substance Painter, Mari — anywhere PySide2/PySide6/PyQt5/PyQt6 is reachable. Sandboxed hosts (Photoshop, Figma, ZBrush) keep their existing schemes.

**This is TODO-B of the next-session plan; depends on TODO-A (#1011) but doesn't share files (safe to merge in either order).**

## Why

`commandPort` baseline failure modes — single-flight, modal-dialog leak, PyO3-tokio runtime contention — turned out to be **structural** rather than fixable by plug-in hardening (see #1009, #235, #240, #241). A `QTcpServer` cooperatively scheduled on the host's own Qt event loop is fundamentally more stable:

| Property | `commandPort` (today) | `qtserver://` (this PR) |
|---|---|---|
| Concurrency | Single-flight per port | Multi-client, per-connection state machine |
| Error containment | Eval-side traceback → modal dialog | `try/except` per handler → JSON envelope |
| Runtime competition | PyO3-tokio competes with Qt main thread | Runs ON the Qt main thread cooperatively |
| Wire format | Free-form Python expression | Structured JSON-line `{"id", "method", "params"}` |
| Cancellation | Out of band only | Wire extensible (future work) |
| Multi-DCC reuse | Maya-only | Universal across every Qt-bearing DCC |

## What landed

### Python (universal dispatcher)

- `crates/dcc-mcp-host-rpc/python/dcc_qt_dispatcher.py` — **403 lines**.
  - `QtCommandServer`: `QTcpServer` + `QTimer(50ms)` cooperative ticks; multi-client `bytearray` buffers; JSON-line framing.
  - `_DispatchRegistry`: registry of method → handler; six built-in handlers (`ping`, `execute`, `get_session_info`, `install_stream_capture`, `get_buffered_output`, `create_module`). Every dispatch goes through one `try/except` → structured envelope.
  - `start_qt_server(port=0)` / `stop_qt_server()` / `current_server()` — process-wide singleton, idempotent.
  - Qt binding probing: PySide6 → PySide2 → PyQt6 → PyQt5 in order.

- `crates/dcc-mcp-host-rpc/python/dcc_qt_dispatcher_bootstrap.py` — **86 lines**.
  - Synthesises `sys.modules['_dcc_qt_dispatcher']` from a string source.
  - Idempotent on `_BOOTSTRAP_VERSION`; structured failure envelopes for compile and exec errors.

### Rust (client + scheme registration)

- `crates/dcc-mcp-host-rpc/src/qtserver.rs` — **799 lines** (~half tests).
  - `QtServerClient` (second `HostRpcClient` impl; mirrors `CommandPortClient`'s structure for a parallel surface).
  - `parse_endpoint` / IO-error classification (Unix EOF + Windows `ConnectionAborted`/`Reset`/`BrokenPipe` → `HostDied`).
  - `build_bootstrap_command_line` / `build_start_command_line` / `parse_start_reply`: the two-phase commandPort → qtserver handoff helpers, used by TODO-C wiring.
  - 15 tests: parse, envelope interpretation, connect/call roundtrip, host-died, close, connect-timeout, bootstrap line generators.

- `crates/dcc-mcp-host-rpc/src/registry.rs` — `qtserver` scheme registered, pinned to position 1 (gateway/sidecar discovery order: prefer the new scheme).
- `crates/dcc-mcp-host-rpc/src/lib.rs` — `pub mod qtserver; pub use qtserver::QtServerClient;`.

### Python tests

- `tests/test_dcc_qt_dispatcher_py.py` — **347 lines**, 20 tests.
  - 19 pure-Python semantic tests of both dispatcher + bootstrap files (no Qt required — `_DispatchRegistry`, `_Tee`, bootstrap installer round-trips).
  - 1 live-Qt smoke test, auto-skipped when no Qt binding is installed in CI.

## Wire mapping (HostRpcClient::call → JSON-line)

`HostRpcClient::call(action, args, request_id)` wraps as:

```json
{"id": "<request_id>",
 "method": "dispatch",
 "params": {"action": "<action>", "args": {...}, "request_id": "<request_id>"}}
```

Response shapes:

```json
{"id": "<request_id>", "result": {...}}
{"id": "<request_id>", "error": {"code": "...", "message": "...", "traceback": "..."}}
```

TODO-C (Maya plug-in switch) registers a `dispatch` handler on the Qt dispatcher's registry that calls the existing `dcc_mcp_maya.sidecar._dispatcher.dispatch_payload`. The dispatcher contract is wire-agnostic — only the transport changes.

## Validation

```
cargo check --workspace --all-targets       # clean
cargo clippy --workspace --all-targets -- -D warnings   # clean
cargo test -p dcc-mcp-host-rpc              # 52 passed (15 new + 37 pre-existing)
cargo test -p dcc-mcp-server                # 14 passed (no regression)
ruff check crates/dcc-mcp-host-rpc/python tests/   # All checks passed!
pytest tests/test_dcc_qt_dispatcher_py.py    # 19 passed + 1 skipped (live-Qt)
```

## Two-phase bootstrap orchestration (deliberately split)

The bootstrap (one-shot install of `_dcc_qt_dispatcher` into the DCC) is **plug-in-side** in this PR — the Rust `QtServerClient::connect()` assumes the Qt server is already running and just dials. This split makes both surfaces independently testable:

- `QtServerClient` tests against a synthetic Rust TCP fake → covers the wire.
- `dcc_qt_dispatcher_bootstrap.py` tests with stock Python → covers the install path.
- The two-phase handoff itself lives in **TODO-C** (Maya plug-in PR) where it has access to the in-Maya `commandPort` socket and the FileRegistry URI publication step.

The Rust crate ships `build_bootstrap_command_line` / `build_start_command_line` / `parse_start_reply` as public helpers so TODO-C can drive the handoff without reimplementing the wire format.

## Stack & next steps

- **Stacked on**: `main` (independent of #1011, both can merge in any order).
- **Next**: TODO-C — dcc-mcp-maya plug-in registers `dispatch` handler on Qt server at startup, switches sidecar URI to `qtserver://`. `commandPort` remains as the bootstrap-only entry for install-on-demand scenarios.
- **Then**: TODO-D — `display_id` + `@{version}` segment in tool slugs.

Refs RFC #998 (Addendum B). Closes part of #1009 once TODO-C lands.
