### PR TITLE
feat(transport): ServiceEntry::display_id() + gateway://instances exposure (RFC #998)

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state.rs
@@ -458,6 +458,10 @@ pub fn entry_to_json(e: &ServiceEntry, stale_timeout: Duration) -> Value {
     };
     json!({
         "instance_id":     e.instance_id.to_string(),
+        // Derived `{dcc}@{version}-{short8}` (RFC #998 Addendum B).
+        // Agents reading gateway://instances see DCC + version + short
+        // ID inline without cross-referencing three separate fields.
+        "display_id":      e.display_id(),
         "dcc_type":        e.dcc_type,
         "host":            e.host,
         "port":            e.port,

--- a/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
@@ -370,6 +370,48 @@ fn test_entry_to_json_includes_pool_state() {
     assert!(json["pool"]["lease_expires_at"].as_u64().is_some());
 }
 
+// ── display_id (RFC #998 Addendum B) ───────────────────────────────────
+
+/// `gateway://instances` carries the derived `{dcc}@{version}-{short8}`
+/// label so MCP clients can render a single human-readable
+/// disambiguation hint instead of stitching three fields together.
+/// The full `instance_id` UUID stays the canonical machine handle and
+/// is unaffected.
+#[test]
+fn test_entry_to_json_includes_display_id_with_version() {
+    let mut e = ServiceEntry::new("maya", "127.0.0.1", 18812);
+    e.version = Some("2026".to_string());
+    let json = entry_to_json(&e, Duration::from_secs(30));
+
+    let display = json["display_id"]
+        .as_str()
+        .expect("display_id must be present in entry_to_json output");
+    assert!(
+        display.starts_with("maya@2026-"),
+        "display_id should start with dcc@version-, got {display}"
+    );
+    // The full UUID is still surfaced verbatim for machine paths.
+    assert_eq!(
+        json["instance_id"].as_str().unwrap(),
+        e.instance_id.to_string()
+    );
+}
+
+#[test]
+fn test_entry_to_json_display_id_falls_back_to_unknown_version() {
+    let mut e = ServiceEntry::new("figma", "127.0.0.1", 8765);
+    e.version = None;
+    let json = entry_to_json(&e, Duration::from_secs(30));
+
+    let display = json["display_id"]
+        .as_str()
+        .expect("display_id must be present even when version is None");
+    assert!(
+        display.starts_with("figma@unknown-"),
+        "display_id should fall back to 'unknown' when version is None, got {display}"
+    );
+}
+
 // ── Issue #719: read_alive_instances ───────────────────────────────────
 
 /// A row whose PID points at a live process survives the prune; a row

--- a/crates/dcc-mcp-transport/src/discovery/types.rs
+++ b/crates/dcc-mcp-transport/src/discovery/types.rs
@@ -299,6 +299,41 @@ impl ServiceEntry {
         self
     }
 
+    /// Human-readable identifier of the form `{dcc}@{version}-{short8}`.
+    ///
+    /// Examples (RFC #998 Addendum B): `maya@2026-abc12345`,
+    /// `houdini@20.5-deadbeef`, `figma@unknown-cafef00d`.
+    ///
+    /// Derived from `dcc_type`, `version`, and the first 8 hex chars of
+    /// `instance_id`. Used by agent-facing surfaces (gateway resources,
+    /// admin UI, structured logs, instance-disambiguation prompts) so a
+    /// user reading a registry row sees DCC + version + short ID
+    /// without having to cross-reference three separate fields.
+    ///
+    /// When `version` is `None`, the literal `unknown` substitutes.
+    ///
+    /// # Stability
+    ///
+    /// The 8-char hex short ID must match
+    /// `dcc_mcp_gateway_core::naming::instance_short` byte-for-byte
+    /// so a `display_id` and the cursor-safe tool slug for the same
+    /// instance always reference the same 8 hex characters. Tests
+    /// pin this in [`tests::display_id_short_matches_gateway_naming`].
+    ///
+    /// # Not serialised
+    ///
+    /// `display_id` is **derived** rather than stored — `services.json`
+    /// shapes round-trip unchanged. Callers that need the value on a
+    /// remote surface should embed it explicitly in the response JSON
+    /// (e.g. `gateway://instances` does so via [`crate`]-side helpers).
+    #[must_use]
+    pub fn display_id(&self) -> String {
+        let version = self.version.as_deref().unwrap_or("unknown");
+        let mut short = self.instance_id.simple().to_string();
+        short.truncate(8);
+        format!("{}@{}-{}", self.dcc_type, version, short)
+    }
+
     /// Get the effective transport address.
     ///
     /// Returns the `transport_address` if set, otherwise constructs a TCP address
@@ -624,6 +659,77 @@ mod tests {
             .as_millis() as u64;
         // Should be within 1 second of now
         assert!(now_ms.abs_diff(heartbeat_ms) < 1000);
+    }
+
+    // ── display_id (RFC #998 Addendum B) ───────────────────────────────
+
+    #[test]
+    fn display_id_renders_dcc_at_version_dash_short() {
+        let mut entry = ServiceEntry::new("maya", "127.0.0.1", 18812);
+        entry.instance_id = Uuid::parse_str("abcdef0123456789abcdef0123456789").unwrap();
+        entry.version = Some("2026".to_string());
+        assert_eq!(entry.display_id(), "maya@2026-abcdef01");
+    }
+
+    #[test]
+    fn display_id_falls_back_to_unknown_when_version_missing() {
+        let mut entry = ServiceEntry::new("houdini", "127.0.0.1", 9100);
+        entry.instance_id = Uuid::parse_str("ffeeddccbbaa99887766554433221100").unwrap();
+        entry.version = None;
+        assert_eq!(entry.display_id(), "houdini@unknown-ffeeddcc");
+    }
+
+    #[test]
+    fn display_id_short_matches_gateway_naming() {
+        // Pinning the 8-char prefix contract — must stay byte-for-byte
+        // aligned with `dcc_mcp_gateway_core::naming::instance_short`
+        // (8 leading hex chars of the simple-form UUID). If
+        // `instance_short` ever changes its length or alphabet, this
+        // test fails loudly so both surfaces get re-aligned in lock
+        // step rather than silently drifting.
+        let entry = ServiceEntry::new("blender", "127.0.0.1", 18765);
+        let id_simple = entry.instance_id.simple().to_string();
+        let derived = entry.display_id();
+        let short_segment = derived.split('-').next_back().expect("dash present");
+        assert_eq!(short_segment.len(), 8);
+        assert_eq!(short_segment, &id_simple[..8]);
+        assert!(
+            short_segment.chars().all(|c| c.is_ascii_hexdigit()),
+            "short segment must be ASCII hex, got {short_segment}",
+        );
+    }
+
+    #[test]
+    fn display_id_includes_at_sign_and_dash_separators() {
+        let mut entry = ServiceEntry::new("photoshop", "127.0.0.1", 7777);
+        entry.version = Some("25.0.0".to_string());
+        let display = entry.display_id();
+        // Exactly one `@` and exactly one `-` between dcc / version /
+        // short. Pin so future refactors don't introduce a third
+        // separator (e.g. for prefix), which would break agent UI
+        // parsers downstream.
+        assert_eq!(display.matches('@').count(), 1);
+        assert_eq!(display.matches('-').count(), 1);
+        let at_pos = display.find('@').unwrap();
+        let dash_pos = display.find('-').unwrap();
+        assert!(at_pos < dash_pos, "@ must precede dash: {display}");
+    }
+
+    #[test]
+    fn display_id_round_trips_through_json_without_being_serialised() {
+        // `display_id` is **derived**, not stored. Round-tripping a
+        // ServiceEntry through JSON must not contain a `display_id`
+        // field — keeps services.json shapes backward-compatible.
+        let mut entry = ServiceEntry::new("maya", "127.0.0.1", 18812);
+        entry.version = Some("2024".to_string());
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(
+            !json.contains("\"display_id\""),
+            "display_id must NOT be serialised; raw JSON: {json}"
+        );
+        let parsed: ServiceEntry = serde_json::from_str(&json).unwrap();
+        // The method still works on the deserialised entry.
+        assert!(parsed.display_id().starts_with("maya@2024-"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements **TODO-D** of the next-session plan (RFC #998 Addendum B item 3): a derived `display_id` accessor on `ServiceEntry`, exposed in the `gateway://instances` MCP resource so agents render a single inline `{dcc}@{version}-{short8}` label instead of stitching three fields together at every call site.

Examples:

- `maya@2026-abc12345`
- `houdini@20.5-deadbeef`
- `figma@unknown-cafef00d` (version absent)

## Why

Agents disambiguating between multiple instances of the same DCC type today have to read `dcc_type` + `version` + `instance_id[:8]` and stitch them. `display_id` packages that into one human-readable field that:

- still leaves the canonical `instance_id` UUID intact for machine paths;
- is **derived**, not stored — `services.json` shapes round-trip unchanged;
- pins the 8-char hex suffix to the same `instance_short` value the cursor-safe tool slug uses, so an agent reading a slug and a display_id sees the same 8 chars.

## Files touched

| File | Change |
|---|---|
| `crates/dcc-mcp-transport/src/discovery/types.rs` | `ServiceEntry::display_id()` accessor + 5 unit tests |
| `crates/dcc-mcp-gateway/src/gateway/state.rs` | `entry_to_json` emits `display_id` in the gateway://instances payload |
| `crates/dcc-mcp-gateway/src/gateway/state/tests.rs` | 2 new tests pinning the field's presence + the unknown-version fallback |

Net **+152 lines** (mostly tests).

## Stability contract

The 8-char hex suffix in `display_id` is required to equal `dcc_mcp_gateway_core::naming::instance_short` byte-for-byte. Pinned in `display_id_short_matches_gateway_naming` so any drift in either side fails tests in lock step, not silently.

## Scope intentionally narrow — tool slug `@{version}` deferred

The matching wire change discussed in RFC #998 Addendum B item 3 — adding `@{version}` into the cursor-safe tool slug — is **not** in this PR:

- `encode_tool_name_cursor_safe` is constrained by SEP-986 + Cursor IDE's stricter `^[A-Za-z0-9_]+$` regex.
- Adding an `@` segment would break the cursor-safe alphabet and the existing `_U_`/`_D_`/`_H_` escape vocabulary contract.
- The version information agents need is now available via `display_id` on every instance row; mixing it back into the wire slug would require a coordinated client compat audit + an escape vocabulary extension that is out of scope for the pivot's critical path.

If the wire change is later judged worth the breakage, it can be a separate PR with its own client compat plan.

## Validation

```
cargo check --workspace --all-targets             # clean
cargo clippy --workspace --all-targets -- -D warnings   # clean
cargo test -p dcc-mcp-transport --lib             # 151 passed (5 new)
cargo test -p dcc-mcp-gateway --lib               # 282 passed (2 new)
```

## Refs

- RFC #998 Addendum B (item 3 — display_id + slug discussion)
- Independent of #1011 (revert risk_class, merged) and #1012 (qtserver scheme, open). All three branch from `main` separately; merge order does not matter.
