### PR TITLE
test(host-rpc): pin Python 3.7 syntax for in-DCC bootstrap sources (RFC #998)

### DIFF
--- a/tests/test_dcc_qt_dispatcher_py.py
+++ b/tests/test_dcc_qt_dispatcher_py.py
@@ -25,6 +25,7 @@ dcc-mcp-core CI suite.
 from __future__ import annotations
 
 # Import built-in modules
+import ast
 import json
 from pathlib import Path
 import sys
@@ -339,6 +340,63 @@ def test_bootstrap_returns_failure_envelope_on_syntax_error() -> None:
         assert "_dcc_qt_dispatcher" not in sys.modules, "broken dispatcher must not pollute sys.modules"
     finally:
         sys.modules.pop("_dcc_qt_dispatcher", None)
+
+
+def test_python_3_7_guard_catches_walrus() -> None:
+    """Self-test for the ``feature_version=(3, 7)`` guard.
+
+    If a future CPython release silently weakens ``feature_version``
+    (or pytest is run on an interpreter old enough to lack it), the
+    guard tests below would silently pass without doing any work and
+    a 3.8+ regression in the dispatcher source could slip through.
+    This negative-path test feeds a known walrus operator and
+    asserts ``SyntaxError`` is raised — if it ever stops raising,
+    the rest of the 3.7 pinning machinery cannot be trusted and
+    this test fails the build.
+    """
+    walrus_src = "(n := 1)\n"
+    with pytest.raises(SyntaxError):
+        ast.parse(walrus_src, feature_version=(3, 7))
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param(DISPATCHER_PATH, id="dispatcher"),
+        pytest.param(BOOTSTRAP_PATH, id="bootstrap"),
+    ],
+)
+def test_source_parses_under_python_3_7_feature_version(path: Path) -> None:
+    """Pin the dispatcher and bootstrap to **Python 3.7 syntax**.
+
+    Maya 2020/2022, Blender 2.83 LTS, and several legacy DCC hosts
+    still ship Python 3.7. The dispatcher source is ``include_str!``-ed
+    into the Rust binary and ships **verbatim** to those hosts — any
+    3.8+ syntax (walrus ``:=``, ``match/case``, positional-only ``/``,
+    f-string ``=`` debug, PEP 604 ``int | None`` at runtime, …) would
+    raise ``SyntaxError`` inside the DCC and break the entire qtserver
+    handoff.
+
+    ``ast.parse(feature_version=(3, 7))`` rejects every grammar feature
+    added after Python 3.7, so the test fails loudly the moment a
+    contributor introduces a 3.8+ construct into either file.
+
+    Note: this only catches **syntax-level** drift. Runtime usage of
+    3.8+ stdlib APIs (e.g. ``ast.Module(type_ignores=...)``,
+    ``functools.cache``) is covered by the dedicated semantic tests
+    above — they exec the source against a real interpreter, so
+    failures surface as ``AttributeError`` / ``TypeError`` rather than
+    syntax errors. The two layers together prevent every flavour of
+    3.7-incompat regression we've actually hit in production.
+    """
+    src = _read(path)
+    try:
+        ast.parse(src, filename=str(path), feature_version=(3, 7))
+    except SyntaxError as exc:
+        pytest.fail(
+            f"{path} contains Python 3.8+ syntax that would break on Maya 2020/2022 "
+            f"and Blender 2.83 LTS (Python 3.7): {exc}"
+        )
 
 
 def test_dispatcher_source_compiles_without_qt() -> None:

--- a/tests/test_sidecar_bootstrap_py.py
+++ b/tests/test_sidecar_bootstrap_py.py
@@ -22,9 +22,9 @@ that has a ``dcc_mcp_maya.sidecar._dispatcher`` module on
 # Import future modules
 from __future__ import annotations
 
-from pathlib import Path
-
 # Import built-in modules
+import ast
+from pathlib import Path
 import sys
 import types
 from typing import Iterator
@@ -226,3 +226,26 @@ def test_bootstrap_source_pins_known_contract():
     assert "_BOOTSTRAP_VERSION" in src
     assert "types.ModuleType" in src
     assert "sys.modules" in src
+
+
+def test_bootstrap_source_parses_under_python_3_7_feature_version():
+    """Pin :file:`maya_sidecar_bootstrap.py` to **Python 3.7 syntax**.
+
+    Maya 2020 and 2022 ship Python 3.7. The bootstrap is
+    ``include_str!``-ed into the Rust binary and shipped verbatim
+    over Maya's ``commandPort`` to the embedded interpreter — any
+    3.8+ syntax (walrus ``:=``, ``match/case``, positional-only ``/``,
+    f-string ``=`` debug, PEP 604 ``int | None`` at runtime, …) would
+    raise ``SyntaxError`` inside Maya and break sidecar mode entirely.
+
+    ``ast.parse(feature_version=(3, 7))`` rejects every grammar
+    feature added after Python 3.7, so the test fails loudly the
+    moment a contributor introduces a 3.8+ construct.
+    """
+    src = _read_bootstrap_source()
+    try:
+        ast.parse(src, filename=str(BOOTSTRAP_PATH), feature_version=(3, 7))
+    except SyntaxError as exc:
+        pytest.fail(
+            f"{BOOTSTRAP_PATH} contains Python 3.8+ syntax that would break on Maya 2020/2022 (Python 3.7): {exc}"
+        )


### PR DESCRIPTION
## Summary

Pin the three embedded in-DCC Python sources to **Python 3.7 syntax** so a 3.8+ regression in any of them is caught at pytest time, not at real-DCC-deployment time.

Maya 2020 and 2022, plus Blender 2.83 LTS, all ship Python 3.7. The dispatcher/bootstrap sources are `include_str!`-ed into the Rust binary and shipped **verbatim** over the wire to those interpreters, so any 3.8+ syntax (walrus `:=`, `match/case`, PEP 604 union types at runtime, …) would raise `SyntaxError` inside the host and break sidecar mode entirely.

## Files guarded

| Path | Pinned to |
|---|---|
| `crates/dcc-mcp-host-rpc/python/dcc_qt_dispatcher.py` | Python 3.7 syntax |
| `crates/dcc-mcp-host-rpc/python/dcc_qt_dispatcher_bootstrap.py` | Python 3.7 syntax |
| `crates/dcc-mcp-host-rpc/python/maya_sidecar_bootstrap.py` | Python 3.7 syntax |

## Why a guard is needed

The CI test matrix runs pytest on 3.14 today. The existing semantic tests use `compile(src, ..., "exec")` which is the CI Python's compiler — so a contributor adding a walrus operator to the dispatcher would see the test pass on CI and fail only inside a real Maya 2022 session.

`ast.parse(feature_version=(3, 7))` solves this:

- Parses the source with the **3.7 grammar**, raising `SyntaxError` for any feature added after 3.7.
- Does NOT require running on a 3.7 interpreter — works on CPython 3.8+.
- Only catches **syntax-level** drift. Runtime drift (e.g. `ast.Module(type_ignores=...)`, `functools.cache`) is still covered by the dedicated semantic tests that exec the source against the live interpreter.

## Self-protecting layer

A negative-path test (`test_python_3_7_guard_catches_walrus`) feeds a known walrus operator through the same guard and asserts `SyntaxError` is raised. If CPython ever silently weakens `feature_version` — or pytest is run on an interpreter old enough to lack the kwarg — this negative test fails first, so the rest of the pinning machinery cannot silently lose its teeth.

## What this PR does NOT do

No behaviour change in the dispatcher/bootstrap sources. The three files already pass the 3.7 guard today — this PR only adds the structural enforcement so future drift is caught by `pytest`, not by an angry studio operator on a Tuesday morning.

## Validation

```
ruff check --fix tests/test_dcc_qt_dispatcher_py.py tests/test_sidecar_bootstrap_py.py   # clean
ruff format tests/test_dcc_qt_dispatcher_py.py tests/test_sidecar_bootstrap_py.py        # clean
pytest tests/test_dcc_qt_dispatcher_py.py tests/test_sidecar_bootstrap_py.py             # 31 passed (3 new) + 1 skipped (live-Qt)
```

## Refs

- RFC #998 Addendum B
- Follow-up to #1012 (qtserver scheme) and #1008 (bootstrap injection)
- Independent of #1013 (display_id) — touches different files, no merge-order constraint
