### PR TITLE
fix(gateway): sweep stale __gateway__ sentinels on every win (rotation pollution)

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/runner.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/runner.rs
@@ -251,6 +251,38 @@ impl GatewayRunner {
         match try_bind_port_opt(&self.config.host, self.config.gateway_port).await {
             // ── We won the port ───────────────────────────────────────────
             Some(listener) => {
+                // Sweep any leftover ``__gateway__`` sentinels before
+                // writing our own. Only one process can actually own the
+                // port we just bound — the OS guarantees that — so any
+                // pre-existing sentinel row is stale. Rows belonging to
+                // dead PIDs would already have been removed by the
+                // ``prune_dead_entries`` call above, but rows owned by
+                // LIVE peers that previously held the gateway role
+                // (then lost it in a restart / failover) survive that
+                // prune. Leaving them in the registry would let peers'
+                // resident-sentinel lookups pick up a phantom version
+                // and run challenger logic against it, or worse fall
+                // into the "same-or-stronger" plain-instance branch
+                // when our own sentinel happens to sort second.
+                //
+                // We are about to register the authoritative sentinel
+                // for this port — replacement, not co-existence. RFC
+                // #998 follow-up (sentinel-rotation pollution observed
+                // in three-Maya live session, 2026-05-16).
+                {
+                    let reg = self.registry.read().await;
+                    let existing = reg.list_instances(GATEWAY_SENTINEL_DCC_TYPE);
+                    for entry in &existing {
+                        let _ = reg.deregister(&entry.key());
+                    }
+                    if !existing.is_empty() {
+                        tracing::info!(
+                            cleared = existing.len(),
+                            "Cleared stale __gateway__ sentinels before writing our own"
+                        );
+                    }
+                }
+
                 // Write a sentinel entry so challengers can read our version.
                 // `ServiceEntry::new` auto-populates `pid` with our process id,
                 // so a crash of *this* process makes the sentinel prunable by
@@ -525,6 +557,31 @@ impl GatewayRunner {
                         version = %own_ver,
                         "Challenger: won gateway port — starting gateway tasks"
                     );
+
+                    // Sweep leftover ``__gateway__`` sentinels before
+                    // writing ours. The old gateway's Drop should have
+                    // deregistered its sentinel on clean shutdown, but
+                    // unclean exits (crash, SIGKILL, Task Manager kill)
+                    // leave a row whose owning PID is alive again on a
+                    // subsequent process start with a recycled PID, or
+                    // simply outlives the bind contest because the
+                    // peer-side ``prune_dead_entries`` won't drop a row
+                    // whose PID is alive. The challenger path used to
+                    // ``register`` next to those rows, leaving N stale
+                    // sentinels per port. RFC #998 follow-up.
+                    {
+                        let reg = registry.read().await;
+                        let existing = reg.list_instances(GATEWAY_SENTINEL_DCC_TYPE);
+                        for entry in &existing {
+                            let _ = reg.deregister(&entry.key());
+                        }
+                        if !existing.is_empty() {
+                            tracing::info!(
+                                cleared = existing.len(),
+                                "Challenger: cleared stale __gateway__ sentinels before writing our own"
+                            );
+                        }
+                    }
 
                     // Update sentinel with our version + adapter info so
                     // peers see the same election profile we used to win.

--- a/crates/dcc-mcp-gateway/src/gateway/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tests.rs
@@ -536,6 +536,117 @@ async fn test_run_election_prunes_dead_gateway_sentinel_before_resident_lookup()
     }
 }
 
+/// Plant a ``__gateway__`` sentinel owned by the CURRENT process (so
+/// ``is_pid_alive`` returns ``true``, ``sentinel_is_dead`` returns
+/// ``false`` — exactly the path a live peer that previously held the
+/// gateway role takes). This row will SURVIVE ``prune_dead_entries``
+/// and must be cleaned up by the WIN-path sentinel sweep.
+fn write_live_sentinel(
+    registry_dir: &std::path::Path,
+    host: &str,
+    port: u16,
+    version: &str,
+) -> std::io::Result<()> {
+    use std::io::Write;
+
+    let mut entry = ServiceEntry::new(GATEWAY_SENTINEL_DCC_TYPE, host, port);
+    entry.version = Some(version.to_string());
+    // Current process PID — guaranteed alive for the duration of the
+    // test, so ``prune_dead_entries`` will NOT remove this row.
+    entry.pid = Some(std::process::id());
+    entry.sentinel_path = None;
+
+    let path = registry_dir.join("services.json");
+    let mut f = std::fs::File::create(&path)?;
+    f.write_all(
+        serde_json::to_string_pretty(&vec![entry])
+            .unwrap()
+            .as_bytes(),
+    )?;
+    f.sync_all()?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_run_election_win_clears_stale_live_owner_sentinels() {
+    // Reproduces the "3 Mayas, 3 __gateway__ rows, nobody on 9765"
+    // pollution observed in a live session on 2026-05-16. A live peer
+    // that previously held the gateway role left its sentinel behind
+    // when it lost the role (process is still alive → prune_dead
+    // doesn't touch it). The winner of the next election MUST replace
+    // those rows instead of co-existing with them, otherwise peers'
+    // ``list_instances(__gateway__).next()`` picks up a phantom version
+    // and the registry grows one stale row per role rotation.
+    let dir = tempfile::tempdir().unwrap();
+    let gw_port = ephemeral_port();
+
+    // Plant TWO stale sentinels (versions "1.0" and "2.0") owned by
+    // our PID, which is unambiguously alive.
+    write_live_sentinel(dir.path(), "127.0.0.1", gw_port, "1.0").unwrap();
+    {
+        // Append a second row by re-writing services.json directly.
+        use std::io::Write;
+        let mut e1 = ServiceEntry::new(GATEWAY_SENTINEL_DCC_TYPE, "127.0.0.1", gw_port);
+        e1.version = Some("1.0".to_string());
+        e1.pid = Some(std::process::id());
+        e1.sentinel_path = None;
+        let mut e2 = ServiceEntry::new(GATEWAY_SENTINEL_DCC_TYPE, "127.0.0.1", gw_port);
+        e2.version = Some("2.0".to_string());
+        e2.pid = Some(std::process::id());
+        e2.sentinel_path = None;
+        let path = dir.path().join("services.json");
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(
+            serde_json::to_string_pretty(&vec![e1, e2])
+                .unwrap()
+                .as_bytes(),
+        )
+        .unwrap();
+        f.sync_all().unwrap();
+    }
+
+    let runner = make_runner_in(dir.path(), gw_port);
+
+    let outcome = runner.run_election().await.unwrap();
+
+    // Election must have won the free port (no other process is bound).
+    assert!(
+        outcome.is_gateway,
+        "free port + clean registry must produce a winner"
+    );
+
+    // Critical assertion: exactly ONE __gateway__ sentinel survives.
+    // Pre-fix this was 3 (both ghosts + ours). The winner's sweep
+    // (RFC #998 follow-up) drops the two ghosts before registering.
+    let reg = runner.registry.read().await;
+    let surviving: Vec<_> = reg.list_instances(GATEWAY_SENTINEL_DCC_TYPE);
+    assert_eq!(
+        surviving.len(),
+        1,
+        "winner must have left exactly one __gateway__ sentinel, found {} (versions: {:?})",
+        surviving.len(),
+        surviving
+            .iter()
+            .map(|e| e.version.as_deref().unwrap_or("None"))
+            .collect::<Vec<_>>()
+    );
+    // The survivor must be ours, not one of the ghosts.
+    assert_ne!(
+        surviving[0].version.as_deref(),
+        Some("1.0"),
+        "ghost sentinel v1.0 should have been swept"
+    );
+    assert_ne!(
+        surviving[0].version.as_deref(),
+        Some("2.0"),
+        "ghost sentinel v2.0 should have been swept"
+    );
+
+    if let Some(abort) = outcome.gateway_abort {
+        abort.abort();
+    }
+}
+
 #[tokio::test]
 async fn test_run_election_spawns_challenger_when_bind_fails_with_no_resident() {
     // The TIME_WAIT recovery case: bind fails AND after pruning there


### PR DESCRIPTION
## Summary

Follow-up to **#1016** (TIME_WAIT recovery). A live three-Maya session on 2026-05-16 reproduced a registry state where:

- 3 Maya processes all alive (pids 264416 / 255240 / 264580)
- 3 `__gateway__` sentinels in FileRegistry, one owned by each
- `127.0.0.1:9765` has **no listener**
- Each Maya's election thread saw a "resident" sentinel (one of the other two siblings' rows) and decided "same-or-stronger" → stayed plain instance, never tried to take over

### Why we got there

The gateway role rotated across Mayas during restart / failover. Each new winner `reg.register`ed a fresh `__gateway__` row keyed by a unique `instance_id`, but did NOT remove the previous winner's row. The previous winner's process was still alive, so the peer-side `prune_dead_entries` from #1016 (`is_pid_alive` returns true) refused to evict it. **Registry grew one stale row per rotation; the live owner of the port could be anyone — or no one.**

### Fix

The WIN path (`run_election` direct bind branch + challenger loop after polling) now sweeps every existing `__gateway__` row before writing its own. The OS port-bind is the source of truth for "who owns the gateway right now"; the FileRegistry sentinel exists only to publish that truth to peers, so co-existence with stale rows from live PIDs is never correct — **replacement is**.

Both code paths affected:

- `GatewayRunner::run_election` — `Some(listener)` branch: before registering own sentinel, `list_instances` + `deregister` every `__gateway__` row.
- `GatewayRunner::spawn_challenger_loop` — same sweep applied inside the retry loop's `try_bind_port_opt` success branch, for the case where a challenger eventually wins after polling 9765 to come free.

## Test plan

- [x] `cargo test -p dcc-mcp-gateway --lib` — **285 passed**

### New regression test

`test_run_election_win_clears_stale_live_owner_sentinels`:

1. Plants TWO `__gateway__` rows owned by the test process's own PID (unambiguously alive — neither `prune_dead_entries` nor `sentinel_is_dead` would touch them)
2. Runs `run_election` on a free port
3. Asserts:
   - `outcome.is_gateway` is true (free port → must win)
   - exactly **ONE** surviving sentinel (the winner's), not three
   - neither ghost version survives

This catches the regression directly: pre-fix the survivors are `[v1.0, v2.0, ours]` = 3; post-fix the survivors are `[ours]` = 1.

### Live verification (manual, post-merge)

- [ ] Start 3 Maya instances → confirm exactly ONE `__gateway__` row in `services.json`
- [ ] Restart the gateway Maya → confirm the new winner replaces the sentinel (not adds beside)
- [ ] Kill -9 the gateway → confirm the survivor takes over within ~5s and the registry ends with exactly ONE `__gateway__` row (the new winner's)

## Refs

- Builds on #1016 (TIME_WAIT recovery)
- RFC #998 follow-up
- Discovered via [loonghao/dcc-mcp-maya#248](https://github.com/loonghao/dcc-mcp-maya/pull/248) live test session on 2026-05-16
