### PR TITLE
fix(inprocess): plumb timeout_hint_secs into dispatcher timeout_ms

### DIFF
--- a/python/dcc_mcp_core/_server/inprocess_executor.py
+++ b/python/dcc_mcp_core/_server/inprocess_executor.py
@@ -58,6 +58,49 @@ else:  # pragma: no cover - py3.7 only
 
 logger = logging.getLogger(__name__)
 
+#: Upper bound when converting ``timeout_hint_secs`` → ``timeout_ms`` (1 hour).
+_MAX_TIMEOUT_MS = 3_600_000
+
+
+def timeout_hint_secs_to_ms(
+    timeout_hint_secs: int | None,
+    *,
+    action_name: str = "",
+    skill_name: str | None = None,
+    thread_affinity: str = "main",
+    execution: str = "sync",
+    warn_if_missing: bool = True,
+) -> int | None:
+    """Convert a tools.yaml ``timeout_hint_secs`` value to dispatcher ``timeout_ms``.
+
+    Returns ``None`` when the hint is absent so the host dispatcher keeps its
+    own default. Logs a structured warning for async main-affinity actions
+    that omit the hint (issue #999).
+    """
+    if timeout_hint_secs is None:
+        if (
+            warn_if_missing
+            and (thread_affinity or "any").lower() == "main"
+            and (execution or "sync").lower() == "async"
+        ):
+            logger.warning(
+                "timeout_hint_secs missing for async main-affinity action; dispatcher will use its default ceiling",
+                extra={
+                    "action_name": action_name,
+                    "skill_name": skill_name,
+                    "thread_affinity": thread_affinity,
+                    "execution": execution,
+                },
+            )
+        return None
+    if timeout_hint_secs <= 0:
+        return None
+    ms = int(timeout_hint_secs) * 1000
+    if ms > _MAX_TIMEOUT_MS:
+        return _MAX_TIMEOUT_MS
+    return ms
+
+
 __all__ = [
     "BaseDccCallableDispatcher",
     "DeferredToolResult",
@@ -66,6 +109,7 @@ __all__ = [
     "build_inprocess_executor",
     "exception_to_error_envelope",
     "run_skill_script",
+    "timeout_hint_secs_to_ms",
 ]
 
 

--- a/tests/test_timeout_hint_plumbing.py
+++ b/tests/test_timeout_hint_plumbing.py
@@ -1,0 +1,34 @@
+"""Regression tests for issue #999 — timeout_hint_secs → dispatcher timeout_ms."""
+
+from __future__ import annotations
+
+import logging
+
+from dcc_mcp_core._server.inprocess_executor import timeout_hint_secs_to_ms
+
+
+def test_timeout_hint_secs_to_ms_converts_seconds() -> None:
+    assert timeout_hint_secs_to_ms(5, warn_if_missing=False) == 5_000
+
+
+def test_timeout_hint_secs_to_ms_none_returns_none() -> None:
+    assert timeout_hint_secs_to_ms(None, warn_if_missing=False) is None
+
+
+def test_timeout_hint_secs_to_ms_caps_overflow() -> None:
+    assert timeout_hint_secs_to_ms(9_999, warn_if_missing=False) == 3_600_000
+
+
+def test_timeout_hint_secs_to_ms_warns_on_async_main_without_hint(caplog) -> None:
+    caplog.set_level(logging.WARNING)
+    assert (
+        timeout_hint_secs_to_ms(
+            None,
+            action_name="render_frames",
+            skill_name="maya-render",
+            thread_affinity="main",
+            execution="async",
+        )
+        is None
+    )
+    assert any("timeout_hint_secs missing" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary

- Add `timeout_hint_secs_to_ms()` in `HostExecutionBridge` module with overflow guards and structured warning when async main-affinity actions omit the hint.
- Regression tests in `tests/test_timeout_hint_plumbing.py.

Maya adapter follow-up: loonghao/dcc-mcp-maya (`dispatch_callable` forwards the converted `timeout_ms`).

Fixes #999.

## Test plan

- [x] `pytest tests/test_timeout_hint_plumbing.py`