### PR TITLE
fix(gateway): cap initialize latency under MCP client starvation (#1009)

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
@@ -524,6 +524,133 @@ async fn gateway_mcp_initialize_advertises_prompts_capability() {
 }
 
 #[tokio::test]
+async fn gateway_mcp_concurrent_initialize_completes_within_one_second() {
+    // Issue #1009 — N concurrent initialize handshakes must not queue past 1s
+    // on an idle gateway (no DCC backends, no lock contention).
+    use std::time::{Duration, Instant};
+
+    let dir = tempfile::tempdir().unwrap();
+    let registry = std::sync::Arc::new(tokio::sync::RwLock::new(
+        dcc_mcp_transport::discovery::file_registry::FileRegistry::new(dir.path()).unwrap(),
+    ));
+    let gs = make_gateway_state(registry).await;
+    let router = crate::gateway::build_gateway_router(gs);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, router)
+            .with_graceful_shutdown(async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .unwrap();
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let client = reqwest::Client::new();
+    let url = format!("http://127.0.0.1:{port}/mcp");
+    let concurrent = 16usize;
+    let started = Instant::now();
+    let responses = futures::future::join_all((0..concurrent).map(|id| {
+        let client = client.clone();
+        let url = url.clone();
+        async move {
+            client
+                .post(&url)
+                .json(&json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "method": "initialize",
+                    "params": {"protocolVersion": "2025-03-26"}
+                }))
+                .send()
+                .await
+                .unwrap()
+                .json::<Value>()
+                .await
+                .unwrap()
+        }
+    }))
+    .await;
+
+    assert!(
+        started.elapsed() < Duration::from_secs(1),
+        "concurrent initialize took {:?}",
+        started.elapsed()
+    );
+    for (idx, resp) in responses.iter().enumerate() {
+        assert!(
+            resp.get("result").is_some(),
+            "initialize[{idx}] failed: {resp}"
+        );
+    }
+
+    let _ = shutdown_tx.send(());
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn gateway_mcp_initialize_timeout_returns_gateway_busy() {
+    // Issue #1009 — server-side 5s cap returns structured gateway-busy instead
+    // of hanging until the MCP client's own init timeout fires.
+    use dcc_mcp_jsonrpc::error_codes::GATEWAY_BUSY;
+    use std::time::Duration;
+
+    let dir = tempfile::tempdir().unwrap();
+    let registry = std::sync::Arc::new(tokio::sync::RwLock::new(
+        dcc_mcp_transport::discovery::file_registry::FileRegistry::new(dir.path()).unwrap(),
+    ));
+    let gs = make_gateway_state(registry).await;
+    let lock = gs.protocol_version.clone();
+    let hold = tokio::spawn(async move {
+        let _guard = lock.write().await;
+        tokio::time::sleep(Duration::from_secs(6)).await;
+    });
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let router = crate::gateway::build_gateway_router(gs);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, router)
+            .with_graceful_shutdown(async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .unwrap();
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(8))
+        .build()
+        .unwrap();
+    let resp: Value = client
+        .post(format!("http://127.0.0.1:{port}/mcp"))
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 99,
+            "method": "initialize",
+            "params": {"protocolVersion": "2025-03-26"}
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    assert_eq!(resp["error"]["code"], json!(GATEWAY_BUSY));
+    assert_eq!(resp["error"]["data"]["reason"], json!("gateway-busy"));
+
+    hold.abort();
+    let _ = shutdown_tx.send(());
+    server.await.unwrap();
+}
+
+#[tokio::test]
 async fn compute_prompts_fingerprint_changes_when_backend_prompt_set_mutates() {
     // The prompts watcher task broadcasts
     // `notifications/prompts/list_changed` iff this fingerprint

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
@@ -1,5 +1,23 @@
 use super::*;
 use crate::gateway::capability::parse_slug;
+use std::time::{Duration, Instant};
+
+/// Log when gateway `/mcp` dispatch exceeds this threshold (issue #1009).
+const GATEWAY_MCP_SLOW_DISPATCH_MS: u128 = 250;
+
+/// Server-side deadline for `initialize` before returning `gateway-busy` (#1009).
+const GATEWAY_INITIALIZE_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn log_gateway_mcp_slow_dispatch(started: Instant, method: &str) {
+    let elapsed_ms = started.elapsed().as_millis();
+    if elapsed_ms > GATEWAY_MCP_SLOW_DISPATCH_MS {
+        tracing::warn!(
+            elapsed_ms = elapsed_ms as u64,
+            method = method,
+            "gateway MCP dispatch slow"
+        );
+    }
+}
 
 /// Minimal JSON-RPC 2.0 request shape accepted by the gateway `/mcp` endpoint.
 #[derive(Debug, Deserialize)]
@@ -17,6 +35,7 @@ pub async fn handle_gateway_mcp(
     headers: HeaderMap,
     body: axum::body::Bytes,
 ) -> Response {
+    let dispatch_started = Instant::now();
     let client_session_id = headers
         .get("Mcp-Session-Id")
         .and_then(|v| v.to_str().ok())
@@ -25,30 +44,47 @@ pub async fn handle_gateway_mcp(
 
     let body_value: Value = match serde_json::from_slice(&body) {
         Ok(value) => value,
-        Err(err) => return parse_error_response(&client_session_id, format!("Parse error: {err}")),
+        Err(err) => {
+            let response = parse_error_response(&client_session_id, format!("Parse error: {err}"));
+            log_gateway_mcp_slow_dispatch(dispatch_started, "parse_error");
+            return response;
+        }
     };
 
     if let Some(batch) = body_value.as_array() {
-        return handle_batch_request(&gs, &client_session_id, batch).await;
+        let label = format!("batch[{}]", batch.len());
+        let response = handle_batch_request(&gs, &client_session_id, batch).await;
+        log_gateway_mcp_slow_dispatch(dispatch_started, &label);
+        return response;
     }
 
     let req = match serde_json::from_value::<JsonRpcRequest>(body_value) {
         Ok(req) => req,
-        Err(err) => return parse_error_response(&client_session_id, format!("Parse error: {err}")),
+        Err(err) => {
+            let response = parse_error_response(&client_session_id, format!("Parse error: {err}"));
+            log_gateway_mcp_slow_dispatch(dispatch_started, "parse_error");
+            return response;
+        }
     };
+
+    let method_label = req.method.clone();
 
     if req.id.is_none() {
         handle_notification(&gs, &req, &client_session_id).await;
+        log_gateway_mcp_slow_dispatch(dispatch_started, &method_label);
         return StatusCode::ACCEPTED.into_response();
     }
 
-    if let Some(response) = dispatch_single_request(&gs, &req, &client_session_id).await {
-        let mut response = Json(response).into_response();
-        attach_session_header(&mut response, &client_session_id);
-        response
-    } else {
-        StatusCode::ACCEPTED.into_response()
-    }
+    let response =
+        if let Some(response) = dispatch_single_request(&gs, &req, &client_session_id).await {
+            let mut response = Json(response).into_response();
+            attach_session_header(&mut response, &client_session_id);
+            response
+        } else {
+            StatusCode::ACCEPTED.into_response()
+        };
+    log_gateway_mcp_slow_dispatch(dispatch_started, &method_label);
+    response
 }
 
 async fn handle_batch_request(
@@ -118,7 +154,7 @@ pub(crate) async fn dispatch_single_request(
     let id_str = serde_json::to_string(&id).unwrap_or_default();
 
     match req.method.as_str() {
-        "initialize" => Some(handle_initialize(gs, id, req).await),
+        "initialize" => Some(handle_initialize_with_timeout(gs, id, req).await),
         "ping" => Some(json!({"jsonrpc":"2.0","id":id,"result":{}})),
         "notifications/initialized" => Some(json!({"jsonrpc":"2.0","id":id,"result":{}})),
         "tools/list" => Some(handle_tools_list(gs, id, req).await),
@@ -138,6 +174,39 @@ pub(crate) async fn dispatch_single_request(
             "error": {"code": -32601, "message": format!("Method not found: {other}")}
         })),
     }
+}
+
+async fn handle_initialize_with_timeout(
+    gs: &GatewayState,
+    id: Value,
+    req: &JsonRpcRequest,
+) -> Value {
+    match tokio::time::timeout(
+        GATEWAY_INITIALIZE_TIMEOUT,
+        handle_initialize(gs, id.clone(), req),
+    )
+    .await
+    {
+        Ok(response) => response,
+        Err(_) => gateway_busy_initialize_response(id),
+    }
+}
+
+fn gateway_busy_initialize_response(id: Value) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": dcc_mcp_jsonrpc::error_codes::GATEWAY_BUSY,
+            "message": "gateway-busy: initialize did not complete within 5s; \
+                the gateway may be starved by a busy DCC host — retry with fewer \
+                concurrent MCP clients or connect directly to a per-instance port",
+            "data": {
+                "reason": "gateway-busy",
+                "timeout_secs": GATEWAY_INITIALIZE_TIMEOUT.as_secs()
+            }
+        }
+    })
 }
 
 async fn handle_initialize(gs: &GatewayState, id: Value, req: &JsonRpcRequest) -> Value {

--- a/crates/dcc-mcp-jsonrpc/src/jsonrpc.rs
+++ b/crates/dcc-mcp-jsonrpc/src/jsonrpc.rs
@@ -79,6 +79,11 @@ pub mod error_codes {
     /// (`process`, `dispatcher`, `dcc`) plus the requested `tool` name so
     /// clients can surface context in their back-off messaging.
     pub const BACKEND_NOT_READY: i64 = -32002;
+
+    /// Issue #1009 — gateway `initialize` did not complete within the server-side
+    /// deadline (typically because the embedded runtime is starved by a busy DCC
+    /// host). Clients should back off and retry with fewer concurrent sessions.
+    pub const GATEWAY_BUSY: i64 = -32003;
 }
 
 impl JsonRpcResponse {


### PR DESCRIPTION
## Summary

- Add server-side 5s timeout on gateway `initialize`; returns `GATEWAY_BUSY` (-32003) with `data.reason: gateway-busy` instead of hanging until the MCP host times out.
- Log `tracing::warn!` when `POST /mcp` dispatch exceeds 250ms (method or `batch[N]` label).
- Regression tests: 16 concurrent `initialize` complete within 1s; lock contention triggers `gateway-busy` within ~5s.

## Test plan

- [x] `cargo test -p dcc-mcp-gateway gateway_mcp_initialize`
- [x] `cargo test -p dcc-mcp-gateway gateway_mcp_concurrent_initialize`

Closes #1009