### PR TITLE
feat(sidecar): gateway failover probe for per-DCC sidecars

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/handle.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handle.rs
@@ -65,6 +65,11 @@ pub struct GatewayHandle {
 }
 
 impl GatewayHandle {
+    /// Shared registry handle (for sidecar failover cleanup).
+    pub fn registry(&self) -> Arc<RwLock<FileRegistry>> {
+        self.registry.clone()
+    }
+
     /// Deregister every pending `ServiceKey` from the `FileRegistry` and
     /// clear the queue. Idempotent and cheap — safe to call from both
     /// async shutdown paths and `Drop`.
@@ -141,14 +146,14 @@ impl Drop for GatewayHandle {
 /// handle and optional OS-thread handle that must be kept alive for
 /// the lifetime of the gateway role (issue #303).
 #[allow(dead_code)]
-pub(crate) struct ElectionOutcome {
-    pub(crate) is_gateway: bool,
-    pub(crate) gateway_abort: Option<AbortHandle>,
-    pub(crate) challenger_abort: Option<AbortHandle>,
-    pub(crate) gateway_supervisor: Option<tokio::task::JoinHandle<()>>,
-    pub(crate) gateway_thread: Option<std::thread::JoinHandle<()>>,
+pub struct ElectionOutcome {
+    pub is_gateway: bool,
+    pub gateway_abort: Option<AbortHandle>,
+    pub challenger_abort: Option<AbortHandle>,
+    pub gateway_supervisor: Option<tokio::task::JoinHandle<()>>,
+    pub gateway_thread: Option<std::thread::JoinHandle<()>>,
     /// `__gateway__` sentinel key registered by the winner path; carried
     /// back to the `GatewayHandle` so `Drop` can deregister it on clean
     /// shutdown (issue #718).
-    pub(crate) sentinel_key: Option<ServiceKey>,
+    pub sentinel_key: Option<ServiceKey>,
 }

--- a/crates/dcc-mcp-gateway/src/gateway/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/mod.rs
@@ -111,7 +111,7 @@ mod version;
 
 pub(crate) use bind::try_bind_port_opt;
 pub use config::{AdminPersistConfig, GatewayConfig};
-pub(crate) use handle::ElectionOutcome;
+pub use handle::ElectionOutcome;
 pub use handle::GatewayHandle;
 pub use runner::GatewayRunner;
 pub(crate) use sentinel::{has_newer_sentinel, is_own_instance};

--- a/crates/dcc-mcp-gateway/src/gateway/runner.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/runner.rs
@@ -203,7 +203,10 @@ impl GatewayRunner {
     }
 
     /// Core version-aware election logic, extracted for clarity.
-    pub(crate) async fn run_election(
+    ///
+    /// Public so out-of-process sidecars can re-run election after the
+    /// incumbent gateway dies without restarting the whole DCC host.
+    pub async fn run_election(
         &self,
     ) -> Result<ElectionOutcome, Box<dyn std::error::Error + Send + Sync>> {
         let stale_timeout = Duration::from_secs(self.config.stale_timeout_secs);

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -96,6 +96,7 @@ use dcc_mcp_skills::constants::{
 use dcc_mcp_transport::discovery::types::ServiceEntry;
 use sysinfo::{Pid, ProcessesToUpdate, System};
 mod sidecar;
+mod sidecar_gateway;
 mod sidecar_mcp;
 mod translate;
 

--- a/crates/dcc-mcp-server/src/sidecar.rs
+++ b/crates/dcc-mcp-server/src/sidecar.rs
@@ -141,6 +141,18 @@ pub struct SidecarArgs {
     /// Override the polling interval for PPID watch (test hook).
     #[arg(long, value_name = "MS", hide = true)]
     pub ppid_poll_ms: Option<u64>,
+
+    /// Well-known gateway port to compete for (first-wins). ``0`` disables
+    /// gateway election in this sidecar process.
+    ///
+    /// Defaults to ``DCC_MCP_GATEWAY_PORT`` (9765). Sidecar mode should set
+    /// the in-DCC adapter's gateway port to ``0`` so only the sidecar competes.
+    #[arg(long, default_value = "9765", env = "DCC_MCP_GATEWAY_PORT")]
+    pub gateway_port: u16,
+
+    /// Host interface for the gateway listener (default ``127.0.0.1``).
+    #[arg(long, default_value = "127.0.0.1")]
+    pub host: String,
 }
 
 /// Run the sidecar lifecycle until the parent DCC dies or a signal arrives.
@@ -217,6 +229,8 @@ pub async fn run(args: SidecarArgs) -> anyhow::Result<()> {
     // failed, we still start the listener — it returns structured
     // `transport-error` envelopes per call, which is much friendlier
     // than the gateway seeing a registered-but-unreachable backend.
+    let mut gateway_control: Option<crate::sidecar_gateway::SidecarGatewayControl> = None;
+
     let mcp_handle = match host_rpc_client {
         Some(client) => {
             let state = crate::sidecar_mcp::SidecarMcpState::new(client, env!("CARGO_PKG_VERSION"));
@@ -233,6 +247,25 @@ pub async fn run(args: SidecarArgs) -> anyhow::Result<()> {
                             error = %err,
                             "FileRegistry republish with mcp_url failed; gateway will route via stub"
                         );
+                    }
+                    if args.gateway_port > 0
+                        && let Some(entry) = registry.get(&key)
+                    {
+                        match crate::sidecar_gateway::start_sidecar_gateway(
+                            &args,
+                            registry.clone(),
+                            entry,
+                        )
+                        .await
+                        {
+                            Ok(ctrl) => gateway_control = ctrl,
+                            Err(err) => {
+                                tracing::error!(
+                                    error = %err,
+                                    "sidecar gateway election failed; MCP listener still up"
+                                );
+                            }
+                        }
                     }
                     Some(handle)
                 }
@@ -273,6 +306,10 @@ pub async fn run(args: SidecarArgs) -> anyhow::Result<()> {
     };
 
     tracing::info!(reason = ?reason, "sidecar shutting down");
+
+    if let Some(ctrl) = gateway_control.take() {
+        ctrl.shutdown().await;
+    }
 
     // Stop the HTTP listener first so the gateway sees the URL
     // disappear before we start tearing down the inner client. This
@@ -515,6 +552,8 @@ mod tests {
             adapter_version: Some("0.0.0-test".to_string()),
             connect_timeout_secs: 2,
             ppid_poll_ms: Some(50),
+            gateway_port: 0,
+            host: "127.0.0.1".to_string(),
         };
         let pinned_uuid = args.instance_id.unwrap();
 
@@ -618,6 +657,8 @@ mod tests {
             adapter_version: Some("0.0.0-test".to_string()),
             connect_timeout_secs: 2,
             ppid_poll_ms: Some(50),
+            gateway_port: 0,
+            host: "127.0.0.1".to_string(),
         };
 
         let sidecar_handle = tokio::spawn(async move { run(args).await });
@@ -703,6 +744,8 @@ mod tests {
             // test snappy in the common case.
             connect_timeout_secs: 1,
             ppid_poll_ms: Some(50),
+            gateway_port: 0,
+            host: "127.0.0.1".to_string(),
         };
 
         let sidecar_handle = tokio::spawn(async move { run(args).await });

--- a/crates/dcc-mcp-server/src/sidecar_gateway.rs
+++ b/crates/dcc-mcp-server/src/sidecar_gateway.rs
@@ -1,0 +1,240 @@
+//! Gateway election + health-probe failover for per-DCC sidecar processes.
+//!
+//! In-process DCC adapters use :class:`dcc_mcp_core.gateway_election.DccGatewayElection`
+//! (Python) to promote when ``GET /health`` on the well-known gateway port fails.
+//! Sidecar mode moves MCP dispatch out-of-process; the sidecar must run the
+//! same probe loop in Rust so a surviving peer can take over when the elected
+//! gateway crashes without restarting Maya.
+
+use dcc_mcp_gateway::{ElectionOutcome, GatewayConfig, GatewayHandle, GatewayRunner};
+use dcc_mcp_transport::discovery::file_registry::FileRegistry;
+use dcc_mcp_transport::discovery::types::{ServiceEntry, ServiceKey};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+use tokio::task::AbortHandle;
+
+use crate::sidecar::SidecarArgs;
+
+const DEFAULT_PROBE_INTERVAL_SECS: u64 = 1;
+const DEFAULT_PROBE_FAILURES: u32 = 2;
+const DEFAULT_PROBE_TIMEOUT_SECS: u64 = 2;
+
+/// Owns the gateway runner, heartbeat, and optional failover probe task.
+pub struct SidecarGatewayControl {
+    gateway_handle: GatewayHandle,
+    probe_abort: Option<AbortHandle>,
+    failover: Arc<RwLock<FailoverHandles>>,
+}
+
+struct FailoverHandles {
+    is_gateway: bool,
+    gateway_abort: Option<AbortHandle>,
+    challenger_abort: Option<AbortHandle>,
+    gateway_supervisor: Option<tokio::task::JoinHandle<()>>,
+    gateway_thread: Option<std::thread::JoinHandle<()>>,
+    sentinel_key: Option<ServiceKey>,
+}
+
+impl SidecarGatewayControl {
+    /// Stop gateway HTTP, challenger loop, and probe task (best-effort).
+    pub async fn shutdown(self) {
+        if let Some(abort) = self.probe_abort {
+            abort.abort();
+        }
+        let mut failover = self.failover.write().await;
+        if let Some(sentinel_key) = failover.sentinel_key.take() {
+            let reg = self.gateway_handle.registry();
+            if let Ok(registry) = reg.try_read() {
+                let _ = registry.deregister(&sentinel_key);
+            }
+        }
+        abort_failover_handles(&mut failover);
+        drop(failover);
+        drop(self.gateway_handle);
+    }
+}
+
+/// Register heartbeat, run initial election, and spawn the probe loop when needed.
+pub async fn start_sidecar_gateway(
+    args: &SidecarArgs,
+    registry: Arc<FileRegistry>,
+    entry: ServiceEntry,
+) -> anyhow::Result<Option<SidecarGatewayControl>> {
+    if args.gateway_port == 0 {
+        return Ok(None);
+    }
+
+    let gateway_cfg = build_gateway_config(args);
+    let runner =
+        GatewayRunner::new(gateway_cfg).map_err(|e| anyhow::anyhow!("GatewayRunner::new: {e}"))?;
+    let gateway_handle = runner
+        .start(entry, None)
+        .await
+        .map_err(|e| anyhow::anyhow!("GatewayRunner::start: {e}"))?;
+
+    let failover = Arc::new(RwLock::new(FailoverHandles {
+        is_gateway: gateway_handle.is_gateway,
+        gateway_abort: None,
+        challenger_abort: None,
+        gateway_supervisor: None,
+        gateway_thread: None,
+        sentinel_key: None,
+    }));
+
+    let probe_abort = if gateway_handle.is_gateway {
+        tracing::info!(
+            port = args.gateway_port,
+            "sidecar won gateway election at startup"
+        );
+        None
+    } else {
+        tracing::info!(
+            port = args.gateway_port,
+            "sidecar registered as plain instance — starting gateway health probe"
+        );
+        Some(spawn_failover_probe(
+            Arc::new(runner),
+            registry,
+            failover.clone(),
+            args.host.clone(),
+            args.gateway_port,
+        ))
+    };
+
+    Ok(Some(SidecarGatewayControl {
+        gateway_handle,
+        probe_abort,
+        failover,
+    }))
+}
+
+fn build_gateway_config(args: &SidecarArgs) -> GatewayConfig {
+    GatewayConfig {
+        host: args.host.clone(),
+        gateway_port: args.gateway_port,
+        registry_dir: args.registry_dir.clone(),
+        server_name: format!("dcc-mcp-gateway-{}", args.dcc),
+        server_version: env!("CARGO_PKG_VERSION").to_string(),
+        adapter_version: args.adapter_version.clone(),
+        adapter_dcc: Some(args.dcc.clone()),
+        ..GatewayConfig::default()
+    }
+}
+
+fn spawn_failover_probe(
+    runner: Arc<GatewayRunner>,
+    registry: Arc<FileRegistry>,
+    failover: Arc<RwLock<FailoverHandles>>,
+    host: String,
+    port: u16,
+) -> AbortHandle {
+    let probe_interval = std::env::var("DCC_MCP_GATEWAY_PROBE_INTERVAL")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_PROBE_INTERVAL_SECS)
+        .max(1);
+    let probe_failures = std::env::var("DCC_MCP_GATEWAY_PROBE_FAILURES")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_PROBE_FAILURES)
+        .max(1);
+    let probe_timeout = std::env::var("DCC_MCP_GATEWAY_PROBE_TIMEOUT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_PROBE_TIMEOUT_SECS)
+        .max(1);
+
+    let handle = tokio::spawn(async move {
+        let mut consecutive_failures = 0u32;
+        loop {
+            tokio::time::sleep(Duration::from_secs(probe_interval)).await;
+
+            let is_gateway = failover.read().await.is_gateway;
+            if is_gateway {
+                consecutive_failures = 0;
+                continue;
+            }
+
+            if probe_gateway_health(&host, port, probe_timeout).await {
+                consecutive_failures = 0;
+                continue;
+            }
+
+            consecutive_failures += 1;
+            if consecutive_failures < probe_failures {
+                tracing::debug!(
+                    failures = consecutive_failures,
+                    threshold = probe_failures,
+                    "sidecar gateway probe failed"
+                );
+                continue;
+            }
+
+            tracing::warn!(
+                port,
+                failures = consecutive_failures,
+                "gateway unreachable from sidecar — re-running election"
+            );
+            consecutive_failures = 0;
+
+            match runner.run_election().await {
+                Ok(outcome) => {
+                    let mut state = failover.write().await;
+                    apply_election_outcome(&mut state, outcome);
+                    if state.is_gateway {
+                        tracing::info!(port, "sidecar promoted to gateway after probe failover");
+                    }
+                }
+                Err(err) => {
+                    tracing::error!(error = %err, "sidecar gateway re-election failed");
+                }
+            }
+
+            // Avoid hammering the registry while a challenger loop is already polling.
+            let _ = registry.prune_dead_entries();
+        }
+    });
+    handle.abort_handle()
+}
+
+async fn probe_gateway_health(host: &str, port: u16, timeout_secs: u64) -> bool {
+    let url = format!("http://{host}:{port}/health");
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(timeout_secs))
+        .build()
+    {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    match client.get(&url).send().await {
+        Ok(resp) => resp.status().is_success(),
+        Err(_) => false,
+    }
+}
+
+fn apply_election_outcome(state: &mut FailoverHandles, outcome: ElectionOutcome) {
+    abort_failover_handles(state);
+    state.is_gateway = outcome.is_gateway;
+    state.gateway_abort = outcome.gateway_abort;
+    state.challenger_abort = outcome.challenger_abort;
+    state.gateway_supervisor = outcome.gateway_supervisor;
+    state.gateway_thread = outcome.gateway_thread;
+    state.sentinel_key = outcome.sentinel_key;
+}
+
+fn abort_failover_handles(state: &mut FailoverHandles) {
+    if let Some(abort) = state.gateway_abort.take() {
+        abort.abort();
+    }
+    if let Some(abort) = state.challenger_abort.take() {
+        abort.abort();
+    }
+    if let Some(handle) = state.gateway_supervisor.take() {
+        handle.abort();
+    }
+    if let Some(handle) = state.gateway_thread.take() {
+        drop(handle);
+    }
+    state.sentinel_key = None;
+}


### PR DESCRIPTION
## Summary

- Add ``--gateway-port`` / ``--host`` to ``dcc-mcp-server sidecar`` (default 9765 via ``DCC_MCP_GATEWAY_PORT``).
- After the sidecar MCP listener is up, run ``GatewayRunner`` (heartbeat + initial election).
- If the sidecar did not win at startup, spawn a ``GET /health`` probe loop (same env knobs as ``DccGatewayElection``) that re-runs ``run_election`` when the gateway is unreachable.
- Export ``GatewayRunner::run_election`` and ``ElectionOutcome`` for sidecar re-election.

## Why

Per-DCC sidecars only registered in FileRegistry and never competed for the well-known gateway port. When the elected gateway crashed, surviving sidecars stayed plain backends forever.

## Test plan

- [x] ``cargo test -p dcc-mcp-server sidecar``
- [ ] Manual: two Maya instances with ``DCC_MCP_MAYA_SIDECAR=1``; kill gateway holder; verify another sidecar binds 9765 within probe window

Pairs with loonghao/dcc-mcp-maya PR that sets in-process ``gateway_port=0`` when sidecar mode is on.