### PR TITLE
feat(sandbox): wire SandboxPolicy into in-process executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,6 +1234,7 @@ dependencies = [
 name = "dcc-mcp-sandbox"
 version = "0.17.2"
 dependencies = [
+ "dcc-mcp-pybridge",
  "parking_lot",
  "pyo3",
  "pyo3-stub-gen",

--- a/crates/dcc-mcp-http-py/src/config.rs
+++ b/crates/dcc-mcp-http-py/src/config.rs
@@ -21,14 +21,34 @@ mod build;
 /// Non-trivial conversions (enum/path/map/repr) stay explicit in the
 /// `#[pymethods]` block so Python errors remain precise.
 #[pyclass(name = "McpHttpConfig", skip_from_py_object)]
-#[derive(Clone)]
 pub struct PyMcpHttpConfig {
     pub(crate) inner: McpHttpConfig,
+    /// Optional :class:`SandboxPolicy` forwarded to the in-process executor (issue #1001).
+    sandbox_policy: Option<Py<PyAny>>,
+}
+
+impl Clone for PyMcpHttpConfig {
+    fn clone(&self) -> Self {
+        Python::try_attach(|py| Self {
+            inner: self.inner.clone(),
+            sandbox_policy: self
+                .sandbox_policy
+                .as_ref()
+                .map(|policy| policy.clone_ref(py)),
+        })
+        .unwrap_or_else(|| Self {
+            inner: self.inner.clone(),
+            sandbox_policy: None,
+        })
+    }
 }
 
 impl From<McpHttpConfig> for PyMcpHttpConfig {
     fn from(inner: McpHttpConfig) -> Self {
-        Self { inner }
+        Self {
+            inner,
+            sandbox_policy: None,
+        }
     }
 }
 
@@ -69,7 +89,19 @@ impl PyMcpHttpConfig {
                 gateway_max_routes_per_session,
                 shutdown_on_drop,
             ),
+            sandbox_policy: None,
         }
+    }
+
+    /// Optional sandbox policy applied to in-process skill execution (issue #1001).
+    #[getter]
+    fn sandbox_policy(&self, py: Python<'_>) -> Option<Py<PyAny>> {
+        self.sandbox_policy.as_ref().map(|p| p.clone_ref(py))
+    }
+
+    #[setter]
+    fn set_sandbox_policy(&mut self, policy: Option<Py<PyAny>>) {
+        self.sandbox_policy = policy;
     }
 
     // ── ServerConfig getters (read-only) ─────────────────────────────

--- a/crates/dcc-mcp-http-py/src/config/tests.rs
+++ b/crates/dcc-mcp-http-py/src/config/tests.rs
@@ -16,6 +16,7 @@ use dcc_mcp_http_types::config::McpHttpConfig;
 fn default_cfg() -> PyMcpHttpConfig {
     PyMcpHttpConfig {
         inner: McpHttpConfig::default(),
+        sandbox_policy: None,
     }
 }
 
@@ -89,12 +90,16 @@ fn all_mcp_http_config_fields_have_py_getters() {
     // ── JobConfig ───────────────────────────────────────────────
     let _ = cfg.job_storage_path();
     let _ = cfg.job_recovery();
+
+    // ── In-process sandbox (issue #1001) ──────────────────────────
+    let _ = pyo3::Python::try_attach(|py| cfg.sandbox_policy(py));
 }
 
 #[test]
 fn repr_contains_port() {
     let cfg = PyMcpHttpConfig {
         inner: McpHttpConfig::default().with_port(1234),
+        sandbox_policy: None,
     };
     assert!(cfg.__repr__().contains("1234"));
 }

--- a/crates/dcc-mcp-sandbox/Cargo.toml
+++ b/crates/dcc-mcp-sandbox/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { workspace = true, features = ["rt", "time", "sync"] }
 
 # PyO3 (optional)
 pyo3 = { workspace = true, optional = true }
+dcc-mcp-pybridge = { workspace = true, optional = true }
 
 # Type-stub generation (opt-in via `stub-gen` feature).
 pyo3-stub-gen = { workspace = true, optional = true }
@@ -31,6 +32,6 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [features]
 default = []
-python-bindings = ["pyo3"]
+python-bindings = ["pyo3", "dep:dcc-mcp-pybridge", "dcc-mcp-pybridge/python-bindings"]
 # Enable `pyo3-stub-gen` annotations on this crate's PyO3 types.
 stub-gen = ["python-bindings", "dep:pyo3-stub-gen", "dep:pyo3-stub-gen-derive"]

--- a/crates/dcc-mcp-sandbox/src/python.rs
+++ b/crates/dcc-mcp-sandbox/src/python.rs
@@ -13,7 +13,7 @@ use pyo3_stub_gen_derive::{gen_stub_pyclass, gen_stub_pymethods};
 use serde_json::Value;
 
 use crate::audit::{AuditEntry, AuditLog, AuditOutcome};
-use crate::context::SandboxContext;
+use crate::context::{ActionHandler, SandboxContext};
 use crate::error::SandboxError;
 use crate::policy::{ExecutionMode, SandboxPolicy};
 use crate::validator::{FieldSchema, InputValidator, ValidationRule};
@@ -318,6 +318,46 @@ impl PySandboxContext {
         let val = result.value.unwrap_or(Value::Null);
         serde_json::to_string(&val)
             .map_err(|e| PyRuntimeError::new_err(format!("result serialization failed: {e}")))
+    }
+
+    /// Execute an action through the full sandbox pipeline with a Python handler.
+    ///
+    /// *handler* receives the validated parameter dict and must return a
+    /// JSON-serialisable object. Policy denials and validation failures raise
+    /// :class:`RuntimeError` with the sandbox error message (issue #1001).
+    fn execute_with_handler(
+        &mut self,
+        py: Python<'_>,
+        action: &str,
+        params_json: &str,
+        handler: Py<PyAny>,
+    ) -> PyResult<Py<PyAny>> {
+        use dcc_mcp_pybridge::py_json::{json_value_to_pyobject, py_any_to_json_value};
+
+        let params: Value = serde_json::from_str(params_json)
+            .map_err(|e| PyRuntimeError::new_err(format!("invalid JSON params: {e}")))?;
+
+        let py_handler = handler;
+        let rust_handler: ActionHandler = Box::new(move |params_map| {
+            Python::attach(|py| -> Result<Value, SandboxError> {
+                let params_value = Value::Object(params_map.clone());
+                let py_params = json_value_to_pyobject(py, &params_value)
+                    .map_err(|e| SandboxError::Internal(e.to_string()))?;
+                let result = py_handler
+                    .call1(py, (py_params,))
+                    .map_err(|e| SandboxError::Internal(e.to_string()))?;
+                let bound = result.bind(py);
+                py_any_to_json_value(&bound).map_err(|e| SandboxError::Internal(e.to_string()))
+            })
+        });
+
+        let exec_result = self
+            .inner
+            .execute(action, &params, None, Some(&rust_handler))
+            .map_err(sandbox_err_to_py)?;
+
+        let val = exec_result.value.unwrap_or(Value::Null);
+        json_value_to_pyobject(py, &val)
     }
 
     /// Return the number of actions executed in this session.

--- a/python/dcc_mcp_core/_server/inprocess_executor.py
+++ b/python/dcc_mcp_core/_server/inprocess_executor.py
@@ -109,6 +109,7 @@ __all__ = [
     "build_inprocess_executor",
     "exception_to_error_envelope",
     "run_skill_script",
+    "sandbox_denied_envelope",
     "timeout_hint_secs_to_ms",
 ]
 
@@ -164,6 +165,27 @@ def _context_from_kwargs(
         execution=execution or "sync",
         timeout_hint_secs=timeout_hint_secs,
     )
+
+
+def sandbox_denied_envelope(exc: BaseException, *, action_name: str = "") -> dict[str, Any]:
+    """Structured denial envelope when :class:`SandboxContext` rejects an action."""
+    msg = str(exc)
+    detail = f"Sandbox denied action '{action_name}': {msg}" if action_name else f"Sandbox denied action: {msg}"
+    return {
+        "success": False,
+        "message": detail,
+        "error": {
+            "type": "SandboxDenied",
+            "message": msg,
+            "action": action_name or None,
+        },
+    }
+
+
+def _resolve_sandbox_action_name(action_name: str, script_path: str) -> str:
+    if action_name:
+        return action_name
+    return Path(script_path).stem
 
 
 def exception_to_error_envelope(exc: BaseException, *, message: str | None = None) -> dict[str, Any]:
@@ -258,6 +280,7 @@ class HostExecutionBridge:
 
     dispatcher: BaseDccCallableDispatcher | None = None
     runner: Callable[[str, Mapping[str, Any]], Any] | None = None
+    sandbox_context: Any | None = None
     default_thread_affinity: str = "any"
     default_execution: str = "sync"
     default_timeout_hint_secs: int | None = None
@@ -389,6 +412,17 @@ class HostExecutionBridge:
         timeout_hint_secs: int | None = None,
     ) -> Any:
         """Execute a skill script using the same bridge as direct callables."""
+        resolved_action = _resolve_sandbox_action_name(action_name, script_path)
+        if self.sandbox_context is not None:
+            return self._execute_script_sandboxed(
+                script_path,
+                params,
+                action_name=resolved_action,
+                skill_name=skill_name,
+                thread_affinity=thread_affinity,
+                execution=execution,
+                timeout_hint_secs=timeout_hint_secs,
+            )
         return self.dispatch_callable(
             self.runner or run_skill_script,
             script_path,
@@ -399,6 +433,45 @@ class HostExecutionBridge:
             execution=execution,
             timeout_hint_secs=timeout_hint_secs,
         )
+
+    def _execute_script_sandboxed(
+        self,
+        script_path: str,
+        params: Mapping[str, Any],
+        *,
+        action_name: str,
+        skill_name: str | None,
+        thread_affinity: str | None,
+        execution: str | None,
+        timeout_hint_secs: int | None,
+    ) -> Any:
+        """Run a skill script inside :class:`SandboxContext` when configured."""
+        context = self.execution_context(
+            action_name=action_name,
+            skill_name=skill_name,
+            thread_affinity=thread_affinity,
+            execution=execution,
+            timeout_hint_secs=timeout_hint_secs,
+        )
+        params_json = json.dumps(dict(params))
+
+        def _sandbox_handler(_params: Mapping[str, Any]) -> Any:
+            return self._dispatch_raw(
+                self.runner or run_skill_script,
+                (script_path, _params),
+                {},
+                context,
+            )
+
+        try:
+            result = self.sandbox_context.execute_with_handler(
+                action_name,
+                params_json,
+                _sandbox_handler,
+            )
+        except RuntimeError as exc:
+            return sandbox_denied_envelope(exc, action_name=action_name)
+        return self._resolve_deferred_result(result, context)
 
     def as_inprocess_executor(self) -> Callable[..., Any]:
         """Return the callable expected by ``set_in_process_executor``."""
@@ -472,6 +545,7 @@ def build_inprocess_executor(
     dispatcher: BaseDccCallableDispatcher | None,
     *,
     runner: Callable[[str, Mapping[str, Any]], Any] = run_skill_script,
+    sandbox_context: Any | None = None,
 ) -> Callable[..., Any]:
     """Return an executor callable suitable for ``set_in_process_executor``.
 
@@ -490,6 +564,8 @@ def build_inprocess_executor(
             execution.
         runner: Override the inner script runner (defaults to
             :func:`run_skill_script`). Mostly useful for tests.
+        sandbox_context: Optional :class:`SandboxContext` that enforces
+            policy and records audit entries before running scripts.
 
     Returns:
         A callable accepting ``(script_path, params, *, action_name,
@@ -497,4 +573,8 @@ def build_inprocess_executor(
         two-argument callers remain supported because all metadata is optional.
 
     """
-    return HostExecutionBridge(dispatcher=dispatcher, runner=runner).as_inprocess_executor()
+    return HostExecutionBridge(
+        dispatcher=dispatcher,
+        runner=runner,
+        sandbox_context=sandbox_context,
+    ).as_inprocess_executor()

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -61,6 +61,7 @@ import weakref
 # this module never depends on the lazy ``dcc_mcp_core`` package facade during import.
 from dcc_mcp_core import _core
 from dcc_mcp_core._core import McpHttpConfig
+from dcc_mcp_core._core import SandboxContext
 from dcc_mcp_core._core import create_skill_server
 from dcc_mcp_core._core import get_app_skill_paths_from_env
 from dcc_mcp_core._core import get_skill_paths_from_env
@@ -72,7 +73,6 @@ from dcc_mcp_core._server import TelemetryManager
 from dcc_mcp_core._server import WindowResolver
 from dcc_mcp_core._server.inprocess_executor import BaseDccCallableDispatcher
 from dcc_mcp_core._server.inprocess_executor import HostExecutionBridge
-from dcc_mcp_core._server.inprocess_executor import build_inprocess_executor
 from dcc_mcp_core._server.minimal_mode import MinimalModeConfig
 from dcc_mcp_core._server.minimal_mode import apply_minimal_mode
 from dcc_mcp_core._server.options import DccServerOptions
@@ -439,6 +439,12 @@ class DccServerBase:
 
     # ── host execution bridge / in-process executor wiring (#599, #521) ───────
 
+    def _attach_sandbox_to_bridge(self, bridge: HostExecutionBridge) -> None:
+        """Forward ``McpHttpConfig.sandbox_policy`` to the execution bridge (#1001)."""
+        policy = getattr(self._config, "sandbox_policy", None)
+        if policy is not None:
+            bridge.sandbox_context = SandboxContext(policy)
+
     def register_host_execution_bridge(self, bridge: HostExecutionBridge) -> None:
         """Wire the adapter-facing host execution bridge.
 
@@ -447,6 +453,7 @@ class DccServerBase:
         bridge still registers through ``McpHttpServer.set_in_process_executor``
         so the existing Rust server path remains unchanged.
         """
+        self._attach_sandbox_to_bridge(bridge)
         self._execution_bridge = bridge
         self._dcc_dispatcher = bridge.dispatcher
         try:
@@ -490,8 +497,10 @@ class DccServerBase:
 
         """
         self._dcc_dispatcher = dispatcher
-        self._execution_bridge = HostExecutionBridge(dispatcher=dispatcher)
-        executor = build_inprocess_executor(dispatcher)
+        bridge = HostExecutionBridge(dispatcher=dispatcher)
+        self._attach_sandbox_to_bridge(bridge)
+        self._execution_bridge = bridge
+        executor = bridge.as_inprocess_executor()
         try:
             self._server.set_in_process_executor(executor)
             self._inprocess_executor_registered = True

--- a/tests/test_inprocess_sandbox.py
+++ b/tests/test_inprocess_sandbox.py
@@ -1,0 +1,88 @@
+"""Regression tests for sandbox-wrapped in-process skill execution (issue #1001)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from dcc_mcp_core import SandboxContext
+from dcc_mcp_core import SandboxPolicy
+from dcc_mcp_core._server.inprocess_executor import HostExecutionBridge
+
+
+def _write_script(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "execute_python.py"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_denied_action_records_audit_without_importing_script(tmp_path: Path) -> None:
+    policy = SandboxPolicy()
+    policy.deny_actions(["execute_python"])
+    ctx = SandboxContext(policy)
+    bridge = HostExecutionBridge(sandbox_context=ctx)
+
+    script = _write_script(
+        tmp_path,
+        "IMPORT_RAN = True\ndef main():\n    return {'success': True, 'message': 'should not run'}\n",
+    )
+
+    with patch(
+        "dcc_mcp_core._server.inprocess_executor.run_skill_script",
+        side_effect=AssertionError("skill script must not be imported"),
+    ) as mocked:
+        result = bridge.execute_script(
+            str(script),
+            {},
+            action_name="execute_python",
+        )
+
+    mocked.assert_not_called()
+    assert result["success"] is False
+    assert result["error"]["type"] == "SandboxDenied"
+    denials = ctx.audit_log.denials()
+    assert len(denials) == 1
+    assert denials[0].action == "execute_python"
+    assert denials[0].outcome == "denied"
+
+
+def test_allowed_action_records_success_audit(tmp_path: Path) -> None:
+    policy = SandboxPolicy()
+    policy.allow_actions(["echo_action"])
+    ctx = SandboxContext(policy)
+    bridge = HostExecutionBridge(sandbox_context=ctx)
+
+    script = _write_script(
+        tmp_path,
+        "def main(value=0):\n    return {'success': True, 'value': value}\n",
+    )
+    result = bridge.execute_script(
+        str(script),
+        {"value": 3},
+        action_name="echo_action",
+    )
+
+    assert result == {"success": True, "value": 3}
+    successes = ctx.audit_log.successes()
+    assert len(successes) == 1
+    assert successes[0].action == "echo_action"
+    assert successes[0].outcome == "success"
+
+
+def test_mcp_http_config_forwards_sandbox_policy_to_bridge() -> None:
+    from dcc_mcp_core import McpHttpConfig
+
+    policy = SandboxPolicy()
+    policy.deny_actions(["blocked"])
+    cfg = McpHttpConfig(port=0)
+    cfg.sandbox_policy = policy
+
+    bridge = HostExecutionBridge()
+    assert bridge.sandbox_context is None
+
+    policy_obj = cfg.sandbox_policy
+    assert policy_obj is not None
+    bridge.sandbox_context = SandboxContext(policy_obj)
+    assert bridge.sandbox_context is not None
+    assert bridge.sandbox_context.is_allowed("safe") in (True, False)


### PR DESCRIPTION
## Summary
- Add `SandboxContext.execute_with_handler` so Python skill runners go through the full sandbox pipeline (policy, audit).
- `HostExecutionBridge` and `McpHttpConfig.sandbox_policy` forward policy into in-process skill execution.
- Denied actions return a structured `SandboxDenied` envelope without importing the skill script.

## Test plan
- [x] `pytest tests/test_inprocess_sandbox.py tests/test_inprocess_executor.py`
- [x] `maturin develop --features python-bindings`

Closes #1001.
