### PR TITLE
fix(dispatcher): map CancelledError to HostUiJobEntry outcome

### DIFF
--- a/python/dcc_mcp_core/_server/host_ui_dispatcher.py
+++ b/python/dcc_mcp_core/_server/host_ui_dispatcher.py
@@ -149,7 +149,13 @@ class HostUiJobEntry:
                 job_id=self.job_id,
             )
         except CancelledError:
-            raise
+            self.outcome = host_ui_outcome(
+                self.request_id,
+                self.affinity,
+                success=False,
+                error=DispatcherErrorCode.CANCELLED,
+                job_id=self.job_id,
+            )
         except Exception as exc:
             self.outcome = host_ui_outcome(
                 self.request_id,

--- a/tests/test_host_ui_dispatcher.py
+++ b/tests/test_host_ui_dispatcher.py
@@ -93,8 +93,9 @@ def test_host_ui_job_honours_check_dcc_cancelled():
         check_dcc_cancelled()
 
     entry.task = _task
-    with pytest.raises(CancelledError):
-        entry.execute()
+    outcome = entry.execute()
+    assert outcome["success"] is False
+    assert outcome["error"] == DispatcherErrorCode.CANCELLED
 
 
 def test_async_any_affinity_completes():


### PR DESCRIPTION
## Summary
- Cooperative cancellation during `HostUiJobEntry.execute` now sets a failed outcome with `error=Cancelled` instead of re-raising, so `submit_callable` waiters unblock and Maya `drain_queue` tests pass.

## Test plan
- [x] `pytest tests/test_host_ui_dispatcher.py`

Blocks dcc-mcp-maya dispatcher adoption PR until merged and released as **0.17.3**.