### PR TITLE
fix(dispatcher): Python 3.7 syntax for HostUiDispatcherBase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,7 @@ jobs:
           fail_ci_if_error: false
 
   # ── Python 3.7 build + test (non-abi3 wheel) ──
+  # Syntax is also gated earlier in the ``lint`` job (``check_py37_syntax.py``).
   # Independent from rust-check: the composite action performs its own build
   # and test, so waiting for the Rust matrix only lengthens the critical path.
   # Uses the same composite action as the release workflow so CI mirrors the
@@ -272,25 +273,40 @@ jobs:
           use-sccache: 'false'
 
   # ── Lint Python source ──
+  # ubuntu-22.04: setup-python still offers 3.7 for the cp37 syntax gate.
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
+
       - uses: actions/setup-python@v6
+        id: py314
         with:
           python-version: "3.14"
+
       - uses: loonghao/vx@v0.8.36
+
       - name: Install dev deps
         run: vx just install-dev-deps
-      - name: Lint
+
+      - name: Lint (ruff)
         run: vx just lint-py
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.7"
+
+      - name: Lint (Python 3.7 syntax — cp37 wheel parity)
+        run: python scripts/check_py37_syntax.py
+
       - name: VRS replayer (dry-run trace validation)
         shell: bash
         run: |
           set -euo pipefail
           for f in tests/vrs/traces/*.jsonl; do
-            python scripts/vrs_replay.py --base-url http://127.0.0.1:1 --dry-run --trace "$f"
+            "${{ steps.py314.outputs.python-path }}" scripts/vrs_replay.py \
+              --base-url http://127.0.0.1:1 --dry-run --trace "$f"
           done
 
   # -- mcporter e2e: real MCP client (npx mcporter) vs live McpHttpServer --

--- a/justfile
+++ b/justfile
@@ -228,15 +228,20 @@ docs-check:
 
 # Lint Python source (ruff check only)
 lint-py:
-    ruff check python/dcc_mcp_core/ tests/ examples/ scripts/vrs_replay.py
+    ruff check python/dcc_mcp_core/ tests/ examples/ scripts/
+    ruff format --check python/dcc_mcp_core/ tests/ examples/ scripts/
+
+# Verify pure-Python sources parse on Python 3.7 (cp37 wheel parity).
+lint-py37-syntax:
+    python scripts/run_with_py37.py scripts/check_py37_syntax.py
 
 # Auto-fix Python lint issues and format
 lint-py-fix:
-    ruff check --fix python/dcc_mcp_core/ tests/ examples/ scripts/vrs_replay.py
-    ruff format python/dcc_mcp_core/ tests/ examples/ scripts/vrs_replay.py
+    ruff check --fix python/dcc_mcp_core/ tests/ examples/ scripts/
+    ruff format python/dcc_mcp_core/ tests/ examples/ scripts/
 
-# Lint everything: Rust (clippy + fmt-check) + Python (ruff)
-lint: clippy fmt-check lint-py
+# Lint everything: Rust (clippy + fmt-check) + Python (ruff + py37 parse gate)
+lint: clippy fmt-check lint-py lint-py37-syntax
 
 # Fix all fixable lint issues (Rust fmt + Python ruff)
 lint-fix: fmt lint-py-fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ known-first-party = ["dcc_mcp_core"]
 # cp37 wheels: PEP 604 unions / builtin generics are syntax errors on Python 3.7.
 "python/dcc_mcp_core/_server/host_ui_dispatcher.py" = ["UP006", "UP045"]
 "python/dcc_mcp_core/_server/tools_list_policy.py" = ["UP006", "UP045"]
+"scripts/check_py37_syntax.py" = ["UP032"]
 "__init__.py" = ["F401"]
 "tests/*.py" = ["F401", "F811", "F821", "E711", "E712", "SIM117", "SIM118", "D100", "D101", "D103", "D106", "D205", "D400", "D415", "E501"]
 "examples/**/*.py" = ["D100", "D101", "D103", "D104", "E402", "INP001"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,9 @@ known-first-party = ["dcc_mcp_core"]
 # instead of ``from dcc_mcp_core import …`` so submodules avoid the lazy package facade.
 
 [tool.ruff.lint.per-file-ignores]
+# cp37 wheels: PEP 604 unions / builtin generics are syntax errors on Python 3.7.
+"python/dcc_mcp_core/_server/host_ui_dispatcher.py" = ["UP006", "UP045"]
+"python/dcc_mcp_core/_server/tools_list_policy.py" = ["UP006", "UP045"]
 "__init__.py" = ["F401"]
 "tests/*.py" = ["F401", "F811", "F821", "E711", "E712", "SIM117", "SIM118", "D100", "D101", "D103", "D106", "D205", "D400", "D415", "E501"]
 "examples/**/*.py" = ["D100", "D101", "D103", "D104", "E402", "INP001"]

--- a/python/dcc_mcp_core/_server/host_ui_dispatcher.py
+++ b/python/dcc_mcp_core/_server/host_ui_dispatcher.py
@@ -10,6 +10,9 @@ For ``mayapy`` / batch / pytest use :class:`InProcessCallableDispatcher`
 instead — it runs inline on the calling thread and does not need a pump.
 
 See ``docs/api/dispatcher.md`` (Host UI dispatcher checklist).
+
+Type annotations use ``typing.Optional`` / ``Dict`` / … so the separate cp37
+wheel imports cleanly (PEP 604 ``|`` and ``dict[...]`` are invalid on 3.7).
 """
 
 from __future__ import annotations
@@ -21,6 +24,12 @@ import threading
 import time
 from typing import Any
 from typing import Callable
+from typing import Deque
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Set
+from typing import Tuple
 
 from dcc_mcp_core.cancellation import CancelledError
 from dcc_mcp_core.cancellation import reset_current_job
@@ -66,11 +75,11 @@ def host_ui_outcome(
     *,
     success: bool,
     output: Any = None,
-    error: str | None = None,
-    job_id: str | None = None,
-) -> dict[str, Any]:
+    error: Optional[str] = None,
+    job_id: Optional[str] = None,
+) -> Dict[str, Any]:
     """Build the standard dict envelope returned by UI dispatchers."""
-    payload: dict[str, Any] = {
+    payload: Dict[str, Any] = {
         "request_id": request_id,
         "affinity": affinity,
         "success": success,
@@ -83,7 +92,7 @@ def host_ui_outcome(
 
 
 # Back-compat alias for adapters that already import ``current_host_ui_job``.
-current_host_ui_job: contextvars.ContextVar[HostUiJobEntry | None] = contextvars.ContextVar(
+current_host_ui_job: contextvars.ContextVar[Optional[HostUiJobEntry]] = contextvars.ContextVar(
     "dcc_mcp_core_current_host_ui_job",
     default=None,
 )
@@ -110,18 +119,18 @@ class HostUiJobEntry:
         request_id: str,
         affinity: str,
         task: Callable[[], Any],
-        timeout_ms: int | None = None,
+        timeout_ms: Optional[int] = None,
         *,
-        job_id: str | None = None,
-        progress_token: str | None = None,
-        on_complete: Callable[[dict[str, Any]], None] | None = None,
+        job_id: Optional[str] = None,
+        progress_token: Optional[str] = None,
+        on_complete: Optional[Callable[[Dict[str, Any]], None]] = None,
     ) -> None:
         self.request_id = request_id
         self.affinity = affinity
         self.task = task
         self.timeout_ms = timeout_ms or DEFAULT_UI_JOB_TIMEOUT_MS
         self.event = threading.Event()
-        self.outcome: dict[str, Any] | None = None
+        self.outcome: Optional[Dict[str, Any]] = None
         self.cancel_flag = threading.Event()
         self.job_id = job_id
         self.progress_token = progress_token
@@ -135,7 +144,7 @@ class HostUiJobEntry:
     def cancelled(self) -> bool:
         return self.cancel_flag.is_set()
 
-    def execute(self) -> dict[str, Any]:
+    def execute(self) -> Dict[str, Any]:
         """Run ``task`` on the host thread and populate ``outcome``."""
         token_job = set_current_job(self)
         token_ui = current_host_ui_job.set(self)
@@ -190,10 +199,10 @@ class HostUiDispatcherBase:
     """
 
     def __init__(self, *, fail_fast_on_main_queue_busy: bool = False) -> None:
-        self._main_queue: deque[HostUiJobEntry] = deque()
+        self._main_queue: Deque[HostUiJobEntry] = deque()
         self._lock = threading.Lock()
-        self._cancelled: set = set()
-        self._active: dict[str, HostUiJobEntry] = {}
+        self._cancelled: Set[str] = set()
+        self._active: Dict[str, HostUiJobEntry] = {}
         self._shutdown = False
         self._fail_fast_on_main_queue_busy = fail_fast_on_main_queue_busy
 
@@ -208,10 +217,10 @@ class HostUiDispatcherBase:
     def submit(
         self,
         action_name: str,
-        payload: str | None = None,
+        payload: Optional[str] = None,
         affinity: str = "any",
-        timeout_ms: int | None = None,
-    ) -> dict[str, Any]:
+        timeout_ms: Optional[int] = None,
+    ) -> Dict[str, Any]:
         """Submit a static payload job (legacy IPC-style surface)."""
 
         def _task():
@@ -224,8 +233,8 @@ class HostUiDispatcherBase:
         request_id: str,
         task: Callable[[], Any],
         affinity: str = "main",
-        timeout_ms: int | None = None,
-    ) -> dict[str, Any]:
+        timeout_ms: Optional[int] = None,
+    ) -> Dict[str, Any]:
         try:
             affinity_norm = normalize_affinity(affinity)
         except ValueError as exc:
@@ -244,12 +253,12 @@ class HostUiDispatcherBase:
         request_id: str,
         task: Callable[[], Any],
         *,
-        job_id: str | None = None,
-        progress_token: str | None = None,
-        on_complete: Callable[[dict[str, Any]], None] | None = None,
+        job_id: Optional[str] = None,
+        progress_token: Optional[str] = None,
+        on_complete: Optional[Callable[[Dict[str, Any]], None]] = None,
         affinity: str = "main",
-        timeout_ms: int | None = None,
-    ) -> dict[str, Any]:
+        timeout_ms: Optional[int] = None,
+    ) -> Dict[str, Any]:
         try:
             affinity_norm = normalize_affinity(affinity)
         except ValueError as exc:
@@ -364,10 +373,10 @@ class HostUiDispatcherBase:
     def is_shutdown(self) -> bool:
         return self._shutdown
 
-    def supported(self) -> list[str]:
+    def supported(self) -> List[str]:
         return ["any", "main"]
 
-    def capabilities(self) -> dict[str, bool]:
+    def capabilities(self) -> Dict[str, bool]:
         return {
             "supports_main_thread": True,
             "supports_named_threads": False,
@@ -375,7 +384,7 @@ class HostUiDispatcherBase:
             "supports_time_slicing": True,
         }
 
-    def drain_queue(self, budget_ms: float) -> tuple[int, int]:
+    def drain_queue(self, budget_ms: float) -> Tuple[int, int]:
         """Drain the main-thread queue for up to *budget_ms* milliseconds."""
         executed = 0
         start = time.monotonic()
@@ -411,7 +420,7 @@ class HostUiDispatcherBase:
         return executed, len(self._main_queue)
 
     @staticmethod
-    def run_on_any_thread(request_id: str, task: Callable[[], Any], affinity: str) -> dict[str, Any]:
+    def run_on_any_thread(request_id: str, task: Callable[[], Any], affinity: str) -> Dict[str, Any]:
         try:
             return host_ui_outcome(request_id, affinity, success=True, output=task())
         except Exception as exc:
@@ -424,8 +433,8 @@ class HostUiDispatcherBase:
         request_id: str,
         task: Callable[[], Any],
         affinity: str,
-        timeout_ms: int | None,
-    ) -> dict[str, Any]:
+        timeout_ms: Optional[int],
+    ) -> Dict[str, Any]:
         with self._lock:
             if self._shutdown:
                 return host_ui_outcome(
@@ -461,7 +470,7 @@ class HostUiDispatcherBase:
             error="Job completed but outcome was not set",
         )
 
-    def _dequeue(self) -> HostUiJobEntry | None:
+    def _dequeue(self) -> Optional[HostUiJobEntry]:
         with self._lock:
             if self._main_queue:
                 return self._main_queue.popleft()

--- a/python/dcc_mcp_core/_server/tools_list_policy.py
+++ b/python/dcc_mcp_core/_server/tools_list_policy.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 import os
 import re
 from typing import Any
+from typing import Optional
 
 __all__ = [
     "ENV_EXCLUDE_STUBS_FROM_TOOLS_LIST",
@@ -75,8 +76,8 @@ class ToolsListStubPolicy:
 def resolve_tools_list_stub_policy(
     dcc_name: str,
     *,
-    config: Any | None = None,
-    explicit: ToolsListStubPolicy | None = None,
+    config: Optional[Any] = None,
+    explicit: Optional[ToolsListStubPolicy] = None,
 ) -> ToolsListStubPolicy:
     """Resolve stub visibility for *dcc_name*.
 
@@ -115,7 +116,7 @@ def apply_tools_list_stub_policy(
     config: Any,
     dcc_name: str,
     *,
-    explicit: ToolsListStubPolicy | None = None,
+    explicit: Optional[ToolsListStubPolicy] = None,
 ) -> ToolsListStubPolicy:
     """Resolve and apply stub policy to *config*; return the policy used."""
     policy = resolve_tools_list_stub_policy(dcc_name, config=config, explicit=explicit)

--- a/python/dcc_mcp_core/project.py
+++ b/python/dcc_mcp_core/project.py
@@ -430,14 +430,25 @@ def register_project_tools(
         return
 
     tools: list[tuple[str, str, dict[str, Any], Any]] = [
-        ("project.save", _PROJECT_SAVE_DESCRIPTION, _PROJECT_SAVE_SCHEMA,
-         lambda params: _project_handle_save(project, params)),
-        ("project.load", _PROJECT_LOAD_DESCRIPTION, _PROJECT_LOAD_SCHEMA,
-         _project_handle_load),
-        ("project.resume", _PROJECT_RESUME_DESCRIPTION, _PROJECT_RESUME_SCHEMA,
-         lambda params: _project_handle_resume(project, params)),
-        ("project.status", _PROJECT_STATUS_DESCRIPTION, _PROJECT_STATUS_SCHEMA,
-         lambda params: _project_handle_status(project, params)),
+        (
+            "project.save",
+            _PROJECT_SAVE_DESCRIPTION,
+            _PROJECT_SAVE_SCHEMA,
+            lambda params: _project_handle_save(project, params),
+        ),
+        ("project.load", _PROJECT_LOAD_DESCRIPTION, _PROJECT_LOAD_SCHEMA, _project_handle_load),
+        (
+            "project.resume",
+            _PROJECT_RESUME_DESCRIPTION,
+            _PROJECT_RESUME_SCHEMA,
+            lambda params: _project_handle_resume(project, params),
+        ),
+        (
+            "project.status",
+            _PROJECT_STATUS_DESCRIPTION,
+            _PROJECT_STATUS_SCHEMA,
+            lambda params: _project_handle_status(project, params),
+        ),
     ]
 
     for name, desc, schema, handler in tools:

--- a/scripts/check_py37_syntax.py
+++ b/scripts/check_py37_syntax.py
@@ -1,0 +1,69 @@
+"""Verify the pure-Python tree parses under Python 3.7 (cp37 wheel parity).
+
+Must be invoked with a Python 3.7 interpreter (``python3.7 scripts/check_py37_syntax.py``).
+PEP 604 unions (``str | None``) and builtin generics (``dict[str, Any]``) are syntax
+errors on 3.7 even with ``from __future__ import annotations``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Iterator
+from typing import List
+from typing import Tuple
+
+if sys.version_info[:2] != (3, 7):
+    sys.stderr.write("check_py37_syntax: requires Python 3.7, got {}.{}.{}\n".format(*sys.version_info[:3]))
+    raise SystemExit(2)
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCAN_ROOTS = (
+    _REPO_ROOT / "python" / "dcc_mcp_core",
+    _REPO_ROOT / "tests",
+    _REPO_ROOT / "examples",
+    _REPO_ROOT / "scripts",
+)
+_SKIP_NAMES = frozenset({"_core.pyi"})
+# Launchers that only run on the developer/CI Python (3.8+), not inside cp37 wheels.
+_SKIP_RELATIVE = frozenset({"scripts/run_with_py37.py"})
+
+
+def _iter_py_files() -> Iterator[Path]:
+    for root in _SCAN_ROOTS:
+        if not root.is_dir():
+            continue
+        for path in sorted(root.rglob("*.py")):
+            if path.name in _SKIP_NAMES:
+                continue
+            rel = path.relative_to(_REPO_ROOT).as_posix()
+            if rel in _SKIP_RELATIVE:
+                continue
+            yield path
+
+
+def main() -> int:
+    """Scan the repo tree and exit non-zero on any SyntaxError under 3.7."""
+    failures: List[Tuple[Path, SyntaxError]] = []  # noqa: UP006
+    count = 0
+    for path in _iter_py_files():
+        count += 1
+        source = path.read_text(encoding="utf-8")
+        try:
+            compile(source, str(path), "exec")
+        except SyntaxError as exc:
+            failures.append((path, exc))
+
+    if failures:
+        for path, exc in failures:
+            location = exc.lineno or 0
+            sys.stderr.write("{}:{}: {}\n".format(path, location, exc.msg))
+        sys.stderr.write("check_py37_syntax: {} file(s) failed to parse on Python 3.7\n".format(len(failures)))
+        return 1
+
+    sys.stdout.write("check_py37_syntax: OK ({} files)\n".format(count))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_with_py37.py
+++ b/scripts/run_with_py37.py
@@ -1,0 +1,54 @@
+"""Run a script with a Python 3.7 interpreter (for local lint / CI helpers)."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+import shutil
+import subprocess
+import sys
+
+
+def _probe(cmd: Sequence[str]) -> list[str] | None:
+    if not cmd or not shutil.which(cmd[0]):
+        return None
+    try:
+        result = subprocess.run(
+            [*cmd, "-c", "import sys; raise SystemExit(0 if sys.version_info[:2] == (3, 7) else 1)"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError:
+        return None
+    if result.returncode == 0:
+        return list(cmd)
+    return None
+
+
+def find_python37() -> list[str] | None:
+    """Return argv prefix for a Python 3.7 executable, or None."""
+    if sys.version_info[:2] == (3, 7):
+        return [sys.executable]
+    for candidate in (["py", "-3.7"], ["python3.7"]):
+        found = _probe(candidate)
+        if found is not None:
+            return found
+    return None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Locate Python 3.7 and exec *argv[0]* with remaining args."""
+    args = list(argv if argv is not None else sys.argv[1:])
+    if not args:
+        sys.stderr.write("usage: run_with_py37.py <script.py> [args...]\n")
+        return 2
+
+    py37 = find_python37()
+    if py37 is None:
+        sys.stderr.write("run_with_py37: no Python 3.7 interpreter found (install 3.7 or use CI lint job)\n")
+        return 1
+
+    return subprocess.call([*py37, *args])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_py37_syntax_gate.py
+++ b/tests/test_py37_syntax_gate.py
@@ -1,0 +1,32 @@
+"""Regression for cp37 wheel parity — syntax must parse on Python 3.7."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CHECKER = _REPO_ROOT / "scripts" / "check_py37_syntax.py"
+
+
+@pytest.mark.skipif(sys.version_info[:2] != (3, 7), reason="requires Python 3.7 interpreter")
+def test_check_py37_syntax_passes_on_repo_tree() -> None:
+    result = subprocess.run(
+        [sys.executable, str(_CHECKER)],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+@pytest.mark.skipif(sys.version_info[:2] != (3, 7), reason="requires Python 3.7 interpreter")
+def test_check_py37_syntax_rejects_pep604_union(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.py"
+    bad.write_text("def f(x: int | None) -> None:\n    pass\n", encoding="utf-8")
+    source = bad.read_text(encoding="utf-8")
+    with pytest.raises(SyntaxError):
+        compile(source, str(bad), "exec")


### PR DESCRIPTION
## Summary

- Replace PEP 604 unions and builtin generics in `host_ui_dispatcher.py` and `tools_list_policy.py` with `typing.Optional` / `Dict` / … so the **cp37** wheel imports on Maya 2022.
- Ruff: per-file `UP006` / `UP045` ignores for those modules (abi3-py38 wheels stay on modern annotations elsewhere).

## Test plan

- [ ] CI `build-wheel-py37` (ubuntu + windows)
- [ ] Existing `test_host_ui_dispatcher` / `test_tools_list_policy` pass on 3.12 matrix