### PR TITLE
feat(skills): add dcc-rest-gateway ClawHub skill for REST-only DCC control

### DIFF
--- a/.github/clawhub-skills.json
+++ b/.github/clawhub-skills.json
@@ -1,0 +1,6 @@
+[
+  {
+    "path": "skills/dcc-rest-gateway",
+    "slug": "dcc-rest-gateway"
+  }
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,6 +328,10 @@ jobs:
 
       - uses: loonghao/vx@v0.8.36
 
+      - name: Expose vx global shims
+        run: echo "$HOME/.vx/bin" >> "$GITHUB_PATH"
+        shell: bash
+
       - name: Download wheel
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/clawhub.yml
+++ b/.github/workflows/clawhub.yml
@@ -1,0 +1,96 @@
+name: Sync ClawHub Skills
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "skills/**"
+      - "scripts/package_openclaw_skill.py"
+      - "scripts/clawhub_sync.py"
+      - ".github/clawhub-skills.json"
+      - ".github/workflows/clawhub.yml"
+      - "justfile"
+  push:
+    branches:
+      - main
+    paths:
+      - "skills/**"
+      - "scripts/package_openclaw_skill.py"
+      - "scripts/clawhub_sync.py"
+      - ".github/clawhub-skills.json"
+      - ".github/workflows/clawhub.yml"
+      - "justfile"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: clawhub-skills-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CLAWHUB_CLI_PACKAGE: clawhub@0.7.0
+  CLAWHUB_CONFIG_PATH: .clawhub/config.json
+  CLAWHUB_DISABLE_TELEMETRY: "1"
+
+jobs:
+  sync-skills:
+    name: Package and sync skills to ClawHub
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dcc-mcp-core (for validate_skill / parse_skill_md)
+        run: pip install -e .
+
+      - name: Package ClawHub skill archives
+        run: |
+          mkdir -p dist/skills
+          python scripts/package_openclaw_skill.py skills/dcc-rest-gateway dist/skills
+
+      - name: Upload packaged skill artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: clawhub-skill-packages
+          path: dist/skills/*.zip
+          if-no-files-found: error
+
+      - name: Skip ClawHub sync for external pull requests
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
+        run: echo "Skipping ClawHub publish for fork PRs (secrets unavailable)."
+
+      - name: Require ClawHub token
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+        shell: bash
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+        run: |
+          if [[ -z "${CLAWHUB_TOKEN}" ]]; then
+            echo "Missing CLAWHUB_TOKEN repository secret" >&2
+            exit 1
+          fi
+
+      - name: Login to ClawHub
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+        shell: bash
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+        run: |
+          mkdir -p "$(dirname "$CLAWHUB_CONFIG_PATH")"
+          npx "$CLAWHUB_CLI_PACKAGE" login --token "$CLAWHUB_TOKEN" --no-browser --no-input
+
+      - name: Dry-run ClawHub publish (pull requests)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+        run: python scripts/clawhub_sync.py --dry-run
+
+      - name: Publish skills to ClawHub (main)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: python scripts/clawhub_sync.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -397,7 +397,7 @@ If a split is genuinely out-of-scope for the current PR:
 ## Repo Layout (What Lives Where)
 
 ```
-crates/          # Rust workspace — 37 members (36 functional crates + workspace-hack); `Cargo.toml` is source of truth
+crates/          # Rust workspace — 38 members (37 functional crates + workspace-hack); `Cargo.toml` is source of truth
 python/dcc_mcp_core/__init__.py  # ← top-level Python public re-exports
 python/dcc_mcp_core/result_envelope.py  # ← typed ToolResult dataclass (#487)
 python/dcc_mcp_core/constants.py        # ← metadata key / layer / category constants (#487)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,6 +829,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "dcc-mcp-cli"
+version = "0.17.4"
+dependencies = [
+ "anyhow",
+ "axum",
+ "clap",
+ "dcc-mcp-catalog",
+ "reqwest 0.13.3",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "workspace-hack",
+]
+
+[[package]]
 name = "dcc-mcp-core"
 version = "0.17.4"
 dependencies = [
@@ -6367,7 +6384,9 @@ dependencies = [
  "digest 0.11.2",
  "either",
  "errno",
+ "form_urlencoded",
  "futures-channel",
+ "futures-core",
  "futures-executor",
  "futures-sink",
  "futures-task",
@@ -6388,6 +6407,7 @@ dependencies = [
  "num-iter",
  "num-traits",
  "once_cell",
+ "percent-encoding",
  "phf 0.11.3",
  "phf_shared 0.11.3",
  "ppv-lite86",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "crates/dcc-mcp-http-types",
     "crates/dcc-mcp-http-server",
     "crates/dcc-mcp-http-py",
+    "crates/dcc-mcp-cli",
     "crates/dcc-mcp-server",
     "crates/dcc-mcp-workflow",
     "crates/dcc-mcp-scheduler",
@@ -74,6 +75,7 @@ dcc-mcp-usd = { path = "crates/dcc-mcp-usd" }
 dcc-mcp-http = { path = "crates/dcc-mcp-http" }
 dcc-mcp-http-server = { path = "crates/dcc-mcp-http-server" }
 dcc-mcp-http-py = { path = "crates/dcc-mcp-http-py" }
+dcc-mcp-cli = { path = "crates/dcc-mcp-cli" }
 dcc-mcp-server = { path = "crates/dcc-mcp-server" }
 dcc-mcp-workflow = { path = "crates/dcc-mcp-workflow" }
 dcc-mcp-scheduler = { path = "crates/dcc-mcp-scheduler" }

--- a/crates/dcc-mcp-cli/Cargo.toml
+++ b/crates/dcc-mcp-cli/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "dcc-mcp-cli"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Client-side control plane CLI for discovering, calling, and planning DCC-MCP installations"
+
+[[bin]]
+name = "dcc-mcp-cli"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace = true
+clap = { version = "4", features = ["derive", "env"] }
+dcc-mcp-catalog.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+workspace-hack = { version = "0.1", path = "../workspace-hack" }
+
+[dev-dependencies]
+axum = { version = "0.8", features = ["http1", "tokio"] }
+tempfile = "3"

--- a/crates/dcc-mcp-cli/src/application/client.rs
+++ b/crates/dcc-mcp-cli/src/application/client.rs
@@ -1,0 +1,72 @@
+use serde_json::{Value, json};
+use thiserror::Error;
+
+use crate::domain::rest::{CallRequest, DescribeRequest, Endpoint, SearchRequest};
+use crate::infra::http::{HttpError, HttpGateway};
+
+#[derive(Debug, Error)]
+pub enum ClientError {
+    #[error(transparent)]
+    Http(#[from] HttpError),
+}
+
+pub struct DccMcpClient {
+    endpoint: Endpoint,
+    gateway: HttpGateway,
+}
+
+impl DccMcpClient {
+    pub fn new(endpoint: Endpoint) -> Self {
+        Self {
+            endpoint,
+            gateway: HttpGateway::default(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_gateway(endpoint: Endpoint, gateway: HttpGateway) -> Self {
+        Self { endpoint, gateway }
+    }
+
+    pub async fn health(&self) -> Result<Value, ClientError> {
+        self.gateway
+            .get_json(&self.endpoint.path("/v1/healthz"))
+            .await
+            .map_err(Into::into)
+    }
+
+    pub async fn list_instances(&self) -> Result<Value, ClientError> {
+        self.gateway
+            .get_json(&self.endpoint.path("/v1/instances"))
+            .await
+            .map_err(Into::into)
+    }
+
+    pub async fn search(&self, request: SearchRequest) -> Result<Value, ClientError> {
+        let body = serde_json::to_value(request).unwrap_or_else(|_| json!({}));
+        self.gateway
+            .post_json(&self.endpoint.path("/v1/search"), &body)
+            .await
+            .map_err(Into::into)
+    }
+
+    pub async fn describe(&self, request: DescribeRequest) -> Result<Value, ClientError> {
+        let body = json!({ "tool_slug": request.tool_slug });
+        self.gateway
+            .post_json(&self.endpoint.path("/v1/describe"), &body)
+            .await
+            .map_err(Into::into)
+    }
+
+    pub async fn call(&self, request: CallRequest) -> Result<Value, ClientError> {
+        let body = json!({
+            "tool_slug": request.tool_slug,
+            "arguments": request.arguments,
+            "meta": request.meta,
+        });
+        self.gateway
+            .post_json(&self.endpoint.path("/v1/call"), &body)
+            .await
+            .map_err(Into::into)
+    }
+}

--- a/crates/dcc-mcp-cli/src/application/install.rs
+++ b/crates/dcc-mcp-cli/src/application/install.rs
@@ -1,0 +1,67 @@
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+
+use crate::domain::install::{InstallPlan, InstallPlanError, InstallPlanner, InstallRequest};
+
+const BUNDLED_CATALOG: &str = include_str!("../../../../dcc-mcp-catalog.yml");
+
+#[derive(Debug, Error)]
+pub enum InstallError {
+    #[error(transparent)]
+    Catalog(#[from] dcc_mcp_catalog::CatalogError),
+    #[error(transparent)]
+    Plan(#[from] InstallPlanError),
+}
+
+pub struct InstallService {
+    default_catalog_path: PathBuf,
+}
+
+impl InstallService {
+    #[must_use]
+    pub fn new(default_catalog_path: PathBuf) -> Self {
+        Self {
+            default_catalog_path,
+        }
+    }
+
+    pub fn plan(&self, request: InstallRequest) -> Result<InstallPlan, InstallError> {
+        let entries = self.load_entries(request.catalog_path.as_deref())?;
+        InstallPlanner::plan(&entries, request).map_err(Into::into)
+    }
+
+    fn load_entries(
+        &self,
+        requested_path: Option<&Path>,
+    ) -> Result<Vec<dcc_mcp_catalog::CatalogEntry>, InstallError> {
+        if let Some(path) = requested_path {
+            return dcc_mcp_catalog::load_from_file(path).map_err(Into::into);
+        }
+
+        let entries = dcc_mcp_catalog::load_from_file(Path::new(&self.default_catalog_path))?;
+        if entries.is_empty() {
+            return dcc_mcp_catalog::load_from_str(BUNDLED_CATALOG).map_err(Into::into);
+        }
+        Ok(entries)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn service_uses_bundled_catalog_when_default_path_is_missing() {
+        let service = InstallService::new(PathBuf::from("__missing_dcc_mcp_catalog__.yml"));
+        let plan = service
+            .plan(InstallRequest {
+                dcc_type: "maya".into(),
+                version: Some("2026".into()),
+                catalog_path: None,
+            })
+            .unwrap();
+
+        assert!(plan.adapter.dcc.iter().any(|dcc| dcc == "maya"));
+    }
+}

--- a/crates/dcc-mcp-cli/src/application/mod.rs
+++ b/crates/dcc-mcp-cli/src/application/mod.rs
@@ -1,0 +1,2 @@
+pub mod client;
+pub mod install;

--- a/crates/dcc-mcp-cli/src/domain/install.rs
+++ b/crates/dcc-mcp-cli/src/domain/install.rs
@@ -1,0 +1,127 @@
+use std::path::PathBuf;
+
+use dcc_mcp_catalog::CatalogEntry;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstallRequest {
+    pub dcc_type: String,
+    pub version: Option<String>,
+    pub catalog_path: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct InstallPlan {
+    pub dcc_type: String,
+    pub version: Option<String>,
+    pub adapter: CatalogEntry,
+    pub steps: Vec<InstallStep>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InstallStep {
+    pub name: String,
+    pub description: String,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum InstallPlanError {
+    #[error("no catalog entry targets dcc type '{0}'")]
+    UnsupportedDcc(String),
+}
+
+pub struct InstallPlanner;
+
+impl InstallPlanner {
+    pub fn plan(
+        entries: &[CatalogEntry],
+        request: InstallRequest,
+    ) -> Result<InstallPlan, InstallPlanError> {
+        let adapter = entries
+            .iter()
+            .find(|entry| {
+                entry
+                    .dcc
+                    .iter()
+                    .any(|dcc| dcc.eq_ignore_ascii_case(&request.dcc_type))
+            })
+            .cloned()
+            .ok_or_else(|| InstallPlanError::UnsupportedDcc(request.dcc_type.clone()))?;
+
+        Ok(InstallPlan {
+            dcc_type: request.dcc_type,
+            version: request.version,
+            adapter,
+            steps: vec![
+                InstallStep {
+                    name: "resolve-adapter".into(),
+                    description: "Resolve the official adapter package from the DCC-MCP catalog."
+                        .into(),
+                },
+                InstallStep {
+                    name: "install-runtime".into(),
+                    description: "Install the cross-platform dcc-mcp-cli and companion runtime binaries."
+                        .into(),
+                },
+                InstallStep {
+                    name: "install-dcc-adapter".into(),
+                    description: "Install the DCC-specific adapter into the user's local DCC plugin location."
+                        .into(),
+                },
+                InstallStep {
+                    name: "verify".into(),
+                    description: "Run health, instance discovery, search, describe, and call smoke checks."
+                        .into(),
+                },
+            ],
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn catalog_entry(name: &str, dcc: &[&str]) -> CatalogEntry {
+        CatalogEntry {
+            name: name.into(),
+            description: "Adapter".into(),
+            dcc: dcc.iter().map(|value| value.to_string()).collect(),
+            url: Some("https://example.invalid/adapter".into()),
+            tags: vec!["official".into()],
+        }
+    }
+
+    #[test]
+    fn planner_selects_matching_dcc_case_insensitively() {
+        let entries = vec![catalog_entry("dcc-mcp-maya", &["maya"])];
+        let plan = InstallPlanner::plan(
+            &entries,
+            InstallRequest {
+                dcc_type: "MAYA".into(),
+                version: Some("2026".into()),
+                catalog_path: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(plan.adapter.name, "dcc-mcp-maya");
+        assert_eq!(plan.steps.len(), 4);
+    }
+
+    #[test]
+    fn planner_rejects_unknown_dcc() {
+        let err = InstallPlanner::plan(
+            &[],
+            InstallRequest {
+                dcc_type: "custom".into(),
+                version: None,
+                catalog_path: None,
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(err, InstallPlanError::UnsupportedDcc("custom".into()));
+    }
+}

--- a/crates/dcc-mcp-cli/src/domain/mod.rs
+++ b/crates/dcc-mcp-cli/src/domain/mod.rs
@@ -1,0 +1,2 @@
+pub mod install;
+pub mod rest;

--- a/crates/dcc-mcp-cli/src/domain/rest.rs
+++ b/crates/dcc-mcp-cli/src/domain/rest.rs
@@ -1,0 +1,70 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SearchRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub query: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dcc_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DescribeRequest {
+    pub tool_slug: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CallRequest {
+    pub tool_slug: String,
+    pub arguments: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Endpoint {
+    pub base_url: String,
+}
+
+impl Endpoint {
+    #[must_use]
+    pub fn new(base_url: impl Into<String>) -> Self {
+        let base_url = base_url.into().trim_end_matches('/').to_string();
+        Self { base_url }
+    }
+
+    #[must_use]
+    pub fn path(&self, path: &str) -> String {
+        format!("{}/{}", self.base_url, path.trim_start_matches('/'))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoint_normalizes_trailing_slashes() {
+        let endpoint = Endpoint::new("http://127.0.0.1:9765/");
+        assert_eq!(
+            endpoint.path("/v1/instances"),
+            "http://127.0.0.1:9765/v1/instances"
+        );
+    }
+
+    #[test]
+    fn search_request_omits_empty_filters() {
+        let body = serde_json::to_value(SearchRequest {
+            query: Some("sphere".into()),
+            dcc_type: None,
+            limit: Some(10),
+        })
+        .unwrap();
+        assert_eq!(body["query"], "sphere");
+        assert_eq!(body["limit"], 10);
+        assert!(body.get("dcc_type").is_none());
+    }
+}

--- a/crates/dcc-mcp-cli/src/infra/http.rs
+++ b/crates/dcc-mcp-cli/src/infra/http.rs
@@ -1,0 +1,53 @@
+use std::time::Duration;
+
+use serde_json::Value;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum HttpError {
+    #[error("request failed: {0}")]
+    Request(#[from] reqwest::Error),
+    #[error("server returned HTTP {status}: {body}")]
+    Status {
+        status: reqwest::StatusCode,
+        body: String,
+    },
+}
+
+#[derive(Clone)]
+pub struct HttpGateway {
+    client: reqwest::Client,
+}
+
+impl Default for HttpGateway {
+    fn default() -> Self {
+        Self {
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(30))
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
+        }
+    }
+}
+
+impl HttpGateway {
+    pub async fn get_json(&self, url: &str) -> Result<Value, HttpError> {
+        let response = self.client.get(url).send().await?;
+        Self::json_response(response).await
+    }
+
+    pub async fn post_json(&self, url: &str, body: &Value) -> Result<Value, HttpError> {
+        let response = self.client.post(url).json(body).send().await?;
+        Self::json_response(response).await
+    }
+
+    async fn json_response(response: reqwest::Response) -> Result<Value, HttpError> {
+        let status = response.status();
+        if status.is_success() {
+            return response.json::<Value>().await.map_err(Into::into);
+        }
+
+        let body = response.text().await.unwrap_or_default();
+        Err(HttpError::Status { status, body })
+    }
+}

--- a/crates/dcc-mcp-cli/src/infra/mod.rs
+++ b/crates/dcc-mcp-cli/src/infra/mod.rs
@@ -1,0 +1,1 @@
+pub mod http;

--- a/crates/dcc-mcp-cli/src/lib.rs
+++ b/crates/dcc-mcp-cli/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod application;
+pub mod domain;
+pub mod infra;
+pub mod presentation;

--- a/crates/dcc-mcp-cli/src/main.rs
+++ b/crates/dcc-mcp-cli/src/main.rs
@@ -1,0 +1,6 @@
+use dcc_mcp_cli::presentation::cli;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    cli::run().await
+}

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -1,0 +1,156 @@
+use std::path::PathBuf;
+
+use anyhow::Context;
+use clap::{Parser, Subcommand, ValueEnum};
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::application::client::DccMcpClient;
+use crate::application::install::InstallService;
+use crate::domain::install::InstallRequest;
+use crate::domain::rest::{CallRequest, DescribeRequest, Endpoint, SearchRequest};
+
+const DEFAULT_BASE_URL: &str = "http://127.0.0.1:9765";
+
+#[derive(Debug, Parser)]
+#[command(name = "dcc-mcp-cli", about, version)]
+pub struct Args {
+    #[arg(long, env = "DCC_MCP_BASE_URL", default_value = DEFAULT_BASE_URL)]
+    base_url: String,
+    #[arg(long, value_enum, default_value_t = OutputFormat::Json)]
+    output: OutputFormat,
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum OutputFormat {
+    Json,
+    Pretty,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Check the configured gateway or per-DCC REST endpoint.
+    Health,
+    /// List live DCC instances from the gateway.
+    List,
+    /// Search callable tools through the REST dynamic-capability surface.
+    Search {
+        #[arg(long)]
+        query: Option<String>,
+        #[arg(long)]
+        dcc_type: Option<String>,
+        #[arg(long)]
+        limit: Option<usize>,
+    },
+    /// Describe one tool slug.
+    Describe { tool_slug: String },
+    /// Invoke one tool slug.
+    Call {
+        tool_slug: String,
+        #[arg(long = "json", default_value = "{}")]
+        arguments_json: String,
+        #[arg(long)]
+        meta_json: Option<String>,
+    },
+    /// Build an auditable DCC adapter installation plan.
+    Install {
+        #[arg(long)]
+        dcc_type: String,
+        #[arg(long)]
+        version: Option<String>,
+        #[arg(long, env = "DCC_MCP_CATALOG_PATH")]
+        catalog: Option<PathBuf>,
+    },
+}
+
+pub async fn run() -> anyhow::Result<()> {
+    run_with_args(Args::parse()).await
+}
+
+async fn run_with_args(args: Args) -> anyhow::Result<()> {
+    let value = match args.command {
+        Command::Health => {
+            let client = DccMcpClient::new(Endpoint::new(args.base_url));
+            client.health().await?
+        }
+        Command::List => {
+            let client = DccMcpClient::new(Endpoint::new(args.base_url));
+            client.list_instances().await?
+        }
+        Command::Search {
+            query,
+            dcc_type,
+            limit,
+        } => {
+            let client = DccMcpClient::new(Endpoint::new(args.base_url));
+            client
+                .search(SearchRequest {
+                    query,
+                    dcc_type,
+                    limit,
+                })
+                .await?
+        }
+        Command::Describe { tool_slug } => {
+            let client = DccMcpClient::new(Endpoint::new(args.base_url));
+            client.describe(DescribeRequest { tool_slug }).await?
+        }
+        Command::Call {
+            tool_slug,
+            arguments_json,
+            meta_json,
+        } => {
+            let arguments = parse_json_object(&arguments_json, "--json")?;
+            let meta = meta_json
+                .as_deref()
+                .map(|raw| parse_json_object(raw, "--meta-json"))
+                .transpose()?;
+            let client = DccMcpClient::new(Endpoint::new(args.base_url));
+            client
+                .call(CallRequest {
+                    tool_slug,
+                    arguments,
+                    meta,
+                })
+                .await?
+        }
+        Command::Install {
+            dcc_type,
+            version,
+            catalog,
+        } => {
+            let service = InstallService::new(PathBuf::from("dcc-mcp-catalog.yml"));
+            to_json(service.plan(InstallRequest {
+                dcc_type,
+                version,
+                catalog_path: catalog,
+            })?)?
+        }
+    };
+
+    print_value(&value, args.output)
+}
+
+fn parse_json_object(raw: &str, flag_name: &str) -> anyhow::Result<Value> {
+    let value: Value =
+        serde_json::from_str(raw).with_context(|| format!("{flag_name} must be valid JSON"))?;
+    if value.is_object() {
+        Ok(value)
+    } else {
+        anyhow::bail!("{flag_name} must be a JSON object")
+    }
+}
+
+fn to_json(value: impl Serialize) -> anyhow::Result<Value> {
+    serde_json::to_value(value).context("failed to serialize command output")
+}
+
+fn print_value(value: &Value, output: OutputFormat) -> anyhow::Result<()> {
+    match output {
+        OutputFormat::Json => println!("{}", serde_json::to_string(value)?),
+        OutputFormat::Pretty => println!("{}", serde_json::to_string_pretty(value)?),
+    }
+    Ok(())
+}

--- a/crates/dcc-mcp-cli/src/presentation/mod.rs
+++ b/crates/dcc-mcp-cli/src/presentation/mod.rs
@@ -1,0 +1,1 @@
+pub mod cli;

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -1,0 +1,194 @@
+use std::process::Command;
+
+use axum::Router;
+use axum::extract::Json;
+use axum::routing::{get, post};
+use serde_json::{Value, json};
+use tempfile::NamedTempFile;
+use tokio::sync::oneshot;
+
+struct GatewayFixture {
+    base_url: String,
+    shutdown: Option<oneshot::Sender<()>>,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Drop for GatewayFixture {
+    fn drop(&mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+fn spawn_gateway_fixture() -> GatewayFixture {
+    let app = Router::new()
+        .route("/v1/healthz", get(|| async { Json(json!({"ok": true})) }))
+        .route(
+            "/v1/instances",
+            get(|| async {
+                Json(json!({
+                    "total": 1,
+                    "instances": [{
+                        "instance_id": "abc12345-0000-0000-0000-000000000000",
+                        "instance_short": "abc12345",
+                        "dcc_type": "maya",
+                        "mcp_url": "http://127.0.0.1:18080/mcp"
+                    }]
+                }))
+            }),
+        )
+        .route(
+            "/v1/search",
+            post(|Json(body): Json<Value>| async move {
+                Json(json!({
+                    "total": 1,
+                    "hits": [{
+                        "slug": "maya.abc12345.create_sphere",
+                        "skill": "modeling",
+                        "action": "create_sphere",
+                        "dcc": body.get("dcc_type").and_then(Value::as_str).unwrap_or("maya"),
+                        "summary": body.get("query").and_then(Value::as_str).unwrap_or("sphere"),
+                        "loaded": true,
+                        "scope": "gateway"
+                    }]
+                }))
+            }),
+        )
+        .route(
+            "/v1/describe",
+            post(|Json(body): Json<Value>| async move {
+                Json(json!({
+                    "record": {"tool_slug": body["tool_slug"]},
+                    "tool": {"inputSchema": {"type": "object"}}
+                }))
+            }),
+        )
+        .route(
+            "/v1/call",
+            post(|Json(body): Json<Value>| async move {
+                Json(json!({
+                    "success": true,
+                    "tool_slug": body["tool_slug"],
+                    "arguments": body["arguments"]
+                }))
+            }),
+        );
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+    let thread = std::thread::spawn(move || {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(async move {
+            let listener = tokio::net::TcpListener::from_std(listener).unwrap();
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+                .unwrap();
+        });
+    });
+
+    GatewayFixture {
+        base_url: format!("http://{addr}"),
+        shutdown: Some(shutdown_tx),
+        thread: Some(thread),
+    }
+}
+
+fn cli_command() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_dcc-mcp-cli"))
+}
+
+fn run_json(args: &[&str]) -> Value {
+    let output = cli_command().args(args).output().unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+
+#[test]
+fn list_search_describe_and_call_gateway_rest_surface() {
+    let fixture = spawn_gateway_fixture();
+
+    let list = run_json(&["--base-url", &fixture.base_url, "list"]);
+    assert_eq!(list["total"], 1);
+    assert_eq!(list["instances"][0]["dcc_type"], "maya");
+
+    let search = run_json(&[
+        "--base-url",
+        &fixture.base_url,
+        "search",
+        "--query",
+        "sphere",
+        "--dcc-type",
+        "maya",
+    ]);
+    assert_eq!(search["hits"][0]["slug"], "maya.abc12345.create_sphere");
+
+    let describe = run_json(&[
+        "--base-url",
+        &fixture.base_url,
+        "describe",
+        "maya.abc12345.create_sphere",
+    ]);
+    assert_eq!(
+        describe["record"]["tool_slug"],
+        "maya.abc12345.create_sphere"
+    );
+
+    let call = run_json(&[
+        "--base-url",
+        &fixture.base_url,
+        "call",
+        "maya.abc12345.create_sphere",
+        "--json",
+        r#"{"radius":2}"#,
+    ]);
+    assert_eq!(call["success"], true);
+    assert_eq!(call["arguments"]["radius"], 2);
+}
+
+#[test]
+fn install_builds_auditable_plan_from_catalog() {
+    let mut catalog = NamedTempFile::new().unwrap();
+    std::io::Write::write_all(
+        &mut catalog,
+        br#"
+version: "1"
+entries:
+  - name: "dcc-mcp-maya"
+    description: "Maya adapter"
+    dcc: ["maya"]
+    url: "https://example.invalid/maya"
+    tags: ["adapter", "official"]
+"#,
+    )
+    .unwrap();
+
+    let catalog_path = catalog.path().to_string_lossy().to_string();
+    let plan = run_json(&[
+        "install",
+        "--dcc-type",
+        "maya",
+        "--version",
+        "2026",
+        "--catalog",
+        &catalog_path,
+    ]);
+
+    assert_eq!(plan["dcc_type"], "maya");
+    assert_eq!(plan["version"], "2026");
+    assert_eq!(plan["adapter"]["name"], "dcc-mcp-maya");
+    assert_eq!(plan["steps"].as_array().unwrap().len(), 4);
+}

--- a/crates/dcc-mcp-transport/src/discovery/file_registry.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry.rs
@@ -161,6 +161,11 @@ impl FileRegistry {
         Ok(())
     }
 
+    fn force_reload_from_file(&self) -> TransportResult<()> {
+        self.load_from_file()?;
+        self.update_mtime()
+    }
+
     fn locks_dir(&self) -> PathBuf {
         self.registry_dir.join(LOCKS_DIR)
     }
@@ -555,7 +560,7 @@ impl FileRegistry {
     /// that crashed after registering itself in a different
     /// `FileRegistry` instance.
     pub fn prune_dead_entries(&self) -> TransportResult<usize> {
-        let _ = self.reload_if_stale();
+        self.force_reload_from_file()?;
 
         let dead_keys: Vec<ServiceKey> = self
             .services

--- a/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
@@ -257,6 +257,34 @@ fn test_prune_dead_entries_reloads_before_iterating() {
 }
 
 #[test]
+fn test_prune_dead_entries_ignores_cached_mtime_when_pruning() {
+    let dir = tempfile::tempdir().unwrap();
+    let reader = FileRegistry::new(dir.path()).unwrap();
+
+    let live = ServiceEntry::new("maya", "127.0.0.1", 18812);
+    reader.register(live).unwrap();
+
+    {
+        let writer = FileRegistry::new(dir.path()).unwrap();
+        let ghost = ServiceEntry::new("blender", "127.0.0.1", 18813);
+        writer.register(ghost).unwrap();
+    }
+
+    let registry_path = reader.registry_file_path();
+    let current_mtime = std::fs::metadata(registry_path)
+        .unwrap()
+        .modified()
+        .unwrap();
+    *reader.last_mtime.lock().unwrap() = Some(current_mtime);
+
+    let pruned = reader.prune_dead_entries().unwrap();
+    assert_eq!(
+        pruned, 1,
+        "prune must reload even when cached mtime matches the registry file"
+    );
+}
+
+#[test]
 fn test_file_registry_multiple_instances_same_dcc() {
     let dir = tempfile::tempdir().unwrap();
     let registry = FileRegistry::new(dir.path()).unwrap();

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -23,7 +23,9 @@ crossbeam-utils = { version = "0.8.21" }
 digest-93f6ce9d446188ac = { package = "digest", version = "0.10.7", features = ["mac", "oid", "std"] }
 digest-a6292c17cd707f01 = { package = "digest", version = "0.11.2", features = ["alloc", "mac", "oid"] }
 either = { version = "1.15.0", features = ["use_std"] }
+form_urlencoded = { version = "1.2.2" }
 futures-channel = { version = "0.3.32", features = ["sink"] }
+futures-core = { version = "0.3.32" }
 futures-executor = { version = "0.3.32" }
 futures-sink = { version = "0.3.32" }
 futures-task = { version = "0.3.32", default-features = false, features = ["std"] }
@@ -41,6 +43,7 @@ num-integer = { version = "0.1.46", features = ["i128"] }
 num-iter = { version = "0.1.45", default-features = false, features = ["i128", "std"] }
 num-traits = { version = "0.2.19", features = ["i128", "libm"] }
 once_cell = { version = "1.21.4" }
+percent-encoding = { version = "2.3.2" }
 phf = { version = "0.11.3", features = ["macros"] }
 phf_shared = { version = "0.11.3" }
 ppv-lite86 = { version = "0.2.21", default-features = false, features = ["simd", "std"] }
@@ -81,7 +84,9 @@ crossbeam-utils = { version = "0.8.21" }
 digest-93f6ce9d446188ac = { package = "digest", version = "0.10.7", features = ["mac", "oid", "std"] }
 digest-a6292c17cd707f01 = { package = "digest", version = "0.11.2", features = ["alloc", "mac", "oid"] }
 either = { version = "1.15.0", features = ["use_std"] }
+form_urlencoded = { version = "1.2.2" }
 futures-channel = { version = "0.3.32", features = ["sink"] }
+futures-core = { version = "0.3.32" }
 futures-executor = { version = "0.3.32" }
 futures-sink = { version = "0.3.32" }
 futures-task = { version = "0.3.32", default-features = false, features = ["std"] }
@@ -99,6 +104,7 @@ num-integer = { version = "0.1.46", features = ["i128"] }
 num-iter = { version = "0.1.45", default-features = false, features = ["i128", "std"] }
 num-traits = { version = "0.2.19", features = ["i128", "libm"] }
 once_cell = { version = "1.21.4" }
+percent-encoding = { version = "2.3.2" }
 phf = { version = "0.11.3", features = ["macros"] }
 phf_shared = { version = "0.11.3" }
 ppv-lite86 = { version = "0.2.21", default-features = false, features = ["simd", "std"] }

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -43,7 +43,7 @@ DCC-MCP-Core is a Rust workspace with Python bindings via PyO3. It provides:
 
 - **Zero third-party runtime dependencies** in the Rust core
 - **Optional Python bindings** via PyO3 for DCC integration
-- **37 workspace members** (36 functional crates + `workspace-hack`) for selective dependency usage; root `Cargo.toml` is the source of truth
+- **38 workspace members** (37 functional crates + `workspace-hack`) for selective dependency usage; root `Cargo.toml` is the source of truth
 
 ## Crate Structure
 

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-This repository ships three operator-facing binaries. This page is the
+This repository ships four operator-facing binaries. This page is the
 single source of truth for every flag, every environment variable, and the
 five deployment scenarios they cover. Flags on each binary map 1:1 onto an
 `DCC_MCP_*` environment variable, so any deployment manifest can drive the
@@ -8,12 +8,49 @@ same configuration surface.
 
 | Binary | Role | Source |
 |---|---|---|
+| [`dcc-mcp-cli`](#dcc-mcp-cli) | User/CI control plane for local or remote DCC-MCP REST endpoints. | `crates/dcc-mcp-cli/` |
 | [`dcc-mcp-server`](#dcc-mcp-server) | Per-DCC MCP + REST server, with an integrated auto-gateway. | `crates/dcc-mcp-server/` |
 | [`dcc-mcp-tunnel-relay`](#dcc-mcp-tunnel-relay) | Public-facing WebSocket relay for the zero-config remote tunnel (#504). | `crates/dcc-mcp-tunnel-relay/` |
 | [`dcc-mcp-tunnel-agent`](#dcc-mcp-tunnel-agent) | Local sidecar that registers with the relay and forwards MCP traffic. | `crates/dcc-mcp-tunnel-agent/` |
 
 Development helper binaries (`stub_gen`) are documented in
 [`AGENTS.md`](https://github.com/loonghao/dcc-mcp-core/blob/main/AGENTS.md).
+
+---
+
+## `dcc-mcp-cli`
+
+Client-side control plane for DCC-MCP. It does not host skills and does not
+replace `dcc-mcp-server`; it knows how to talk to a local or remote gateway /
+per-DCC REST endpoint and how to build auditable installation plans.
+
+The default endpoint is `http://127.0.0.1:9765`, override it with
+`--base-url` or `DCC_MCP_BASE_URL`.
+
+```bash
+dcc-mcp-cli list
+dcc-mcp-cli health
+dcc-mcp-cli search --query sphere --dcc-type maya
+dcc-mcp-cli describe maya.abc12345.create_sphere
+dcc-mcp-cli call maya.abc12345.create_sphere --json '{"radius":2}'
+dcc-mcp-cli install --dcc-type maya --version 2026
+```
+
+### Commands
+
+| Command | REST/API contract | Meaning |
+|---|---|---|
+| `health` | `GET /v1/healthz` | Check the configured endpoint. |
+| `list` | `GET /v1/instances` | List live DCC instances from the gateway. |
+| `search` | `POST /v1/search` | Search callable capabilities. |
+| `describe <tool-slug>` | `POST /v1/describe` | Inspect a capability before calling it. |
+| `call <tool-slug> --json <object>` | `POST /v1/call` | Invoke one capability. |
+| `install --dcc-type <dcc> [--version <v>]` | catalog-backed local plan | Resolve the matching adapter and emit an auditable install plan. |
+
+`install` intentionally starts as a planning contract: it resolves catalog
+entries and spells out the runtime / adapter / verification steps without
+silently modifying DCC plugin folders. DCC-specific installers can attach to
+that contract incrementally.
 
 ---
 

--- a/docs/guide/what-is-dcc-mcp-core.md
+++ b/docs/guide/what-is-dcc-mcp-core.md
@@ -66,7 +66,7 @@ flowchart LR
 
 ## Architecture
 
-37-member Rust workspace (36 functional crates + `workspace-hack`; root `Cargo.toml` is the source of truth), compiled by maturin into a single Python extension `dcc_mcp_core._core`:
+38-member Rust workspace (37 functional crates + `workspace-hack`; root `Cargo.toml` is the source of truth), compiled by maturin into a single Python extension `dcc_mcp_core._core`:
 
 ```
 dcc-mcp-core/
@@ -98,6 +98,7 @@ dcc-mcp-core/
 │   ├── dcc-mcp-gateway-core/        # pure gateway domain/search/ranking types (#845)
 │   ├── dcc-mcp-gateway-search/      # reusable capability search/ranking engine
 │   ├── dcc-mcp-gateway/             # multi-instance gateway + minimal MCP surface
+│   ├── dcc-mcp-cli/                 # `dcc-mcp-cli` client/control-plane CLI
 │   ├── dcc-mcp-server/              # `dcc-mcp-server` CLI
 │   ├── dcc-mcp-tunnel-protocol/     # tunnel frame format + JWT
 │   ├── dcc-mcp-tunnel-relay/        # `dcc-mcp-tunnel-relay` CLI + library

--- a/justfile
+++ b/justfile
@@ -254,6 +254,20 @@ preflight: check clippy fmt-check test-rust
 # Full local CI pipeline: preflight → build wheel → Python tests → lint
 ci: preflight install test lint-py
 
+# ── ClawHub (https://clawhub.ai/) ─────────────────────────────────────────────
+
+# Package skills from .github/clawhub-skills.json (zip under dist/skills/).
+package-clawhub-skills:
+    python scripts/package_openclaw_skill.py skills/dcc-rest-gateway dist/skills
+
+# Validate publish commands without uploading (PR / local).
+clawhub-sync-dry-run:
+    python scripts/clawhub_sync.py --dry-run
+
+# Publish manifest skills to ClawHub (requires CLAWHUB_TOKEN + login).
+clawhub-sync:
+    python scripts/clawhub_sync.py
+
 # ── Clean ─────────────────────────────────────────────────────────────────────
 
 [unix]

--- a/scripts/clawhub_sync.py
+++ b/scripts/clawhub_sync.py
@@ -1,0 +1,132 @@
+r"""Publish listed skills to ClawHub (https://clawhub.ai/)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any
+
+import dcc_mcp_core
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = REPO_ROOT / ".github" / "clawhub-skills.json"
+DEFAULT_CLI = os.environ.get("CLAWHUB_CLI_PACKAGE", "clawhub@0.7.0")
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI flags for manifest path and dry-run mode."""
+    parser = argparse.ArgumentParser(description="Publish skills from clawhub-skills.json")
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=MANIFEST,
+        help="JSON manifest: [{path, slug}]",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate and print publish commands without uploading",
+    )
+    parser.add_argument(
+        "--cli",
+        default=DEFAULT_CLI,
+        help="npm package for clawhub CLI (default: clawhub@0.7.0)",
+    )
+    return parser.parse_args()
+
+
+def load_manifest(path: Path) -> list[dict[str, Any]]:
+    """Load [{path, slug}, ...] entries from the JSON manifest."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError(f"manifest must be a JSON array: {path}")
+    return data
+
+
+def skill_version(skill_dir: Path) -> str:
+    """Return version string from SKILL.md metadata."""
+    meta = dcc_mcp_core.parse_skill_md(str(skill_dir))
+    if meta is None:
+        raise ValueError(f"failed to parse SKILL.md: {skill_dir}")
+    version = (meta.version or "").strip()
+    if not version:
+        raise ValueError(f"missing version in SKILL.md metadata: {skill_dir}")
+    return version
+
+
+def npx_cmd(cli: str, *args: str) -> list[str]:
+    """Build an npx invocation argv list."""
+    npx = os.environ.get("NPX", "npx")
+    return [npx, cli, *args]
+
+
+def publish_one(
+    entry: dict[str, Any],
+    *,
+    dry_run: bool,
+    cli: str,
+) -> int:
+    """Validate and publish one manifest entry; return process exit code."""
+    rel = entry.get("path")
+    slug = entry.get("slug")
+    if not rel or not slug:
+        print(f"invalid manifest entry (need path + slug): {entry}", file=sys.stderr)
+        return 1
+
+    skill_dir = (REPO_ROOT / str(rel)).resolve()
+    if not skill_dir.is_dir():
+        print(f"skill directory not found: {skill_dir}", file=sys.stderr)
+        return 1
+
+    version = skill_version(skill_dir)
+    report = dcc_mcp_core.validate_skill(str(skill_dir))
+    if not report.is_clean:
+        print(f"validate_skill failed for {skill_dir}:", file=sys.stderr)
+        for issue in report.issues:
+            print(f"  - {issue}", file=sys.stderr)
+        return 1
+
+    cmd = npx_cmd(
+        cli,
+        "publish",
+        str(skill_dir),
+        "--slug",
+        str(slug),
+        "--version",
+        version,
+        "--no-input",
+    )
+    if dry_run:
+        print("DRY-RUN:", " ".join(cmd))
+        return 0
+
+    print(f"Publishing {slug}@{version} from {skill_dir} ...")
+    proc = subprocess.run(cmd, check=False)
+    return int(proc.returncode)
+
+
+def main() -> int:
+    """Publish every skill in the manifest."""
+    args = parse_args()
+    manifest_path = args.manifest.resolve()
+    if not manifest_path.is_file():
+        print(f"manifest not found: {manifest_path}", file=sys.stderr)
+        return 1
+
+    entries = load_manifest(manifest_path)
+    if not entries:
+        print("manifest is empty", file=sys.stderr)
+        return 1
+
+    rc = 0
+    for entry in entries:
+        rc = max(rc, publish_one(entry, dry_run=args.dry_run, cli=args.cli))
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/package_openclaw_skill.py
+++ b/scripts/package_openclaw_skill.py
@@ -1,0 +1,107 @@
+"""Package OpenClaw/ClawHub skill directories into versioned zip archives."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+from zipfile import ZIP_DEFLATED
+from zipfile import ZipFile
+
+import tomllib
+
+IGNORED_NAMES = {".DS_Store", "Thumbs.db"}
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI for source path, output dir, and --all."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Package one skill directory, or every immediate child with SKILL.md "
+            "under a root, into versioned zip archives."
+        )
+    )
+    parser.add_argument(
+        "source",
+        help="Skill directory or root directory when --all is set",
+    )
+    parser.add_argument("output_dir", help="Directory for zip outputs")
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Package every immediate child directory that contains SKILL.md",
+    )
+    parser.add_argument(
+        "--version",
+        help="Override version in output filename (default: workspace Cargo.toml version)",
+    )
+    return parser.parse_args()
+
+
+def workspace_version(repo_root: Path) -> str:
+    """Read workspace version from the root Cargo.toml."""
+    cargo_toml = repo_root / "Cargo.toml"
+    data = tomllib.loads(cargo_toml.read_text(encoding="utf-8"))
+    return str(data["workspace"]["package"]["version"])
+
+
+def iter_skill_files(skill_dir: Path):
+    """Yield packable files under a skill directory."""
+    for path in sorted(skill_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        if path.name in IGNORED_NAMES:
+            continue
+        yield path
+
+
+def resolve_skill_dirs(source: Path, package_all: bool) -> list[Path]:
+    """Resolve one or many skill directories from CLI source path."""
+    if package_all:
+        if not source.is_dir():
+            raise ValueError(f"skills root does not exist: {source}")
+        skill_dirs = [path for path in sorted(source.iterdir()) if path.is_dir() and (path / "SKILL.md").is_file()]
+        if not skill_dirs:
+            raise ValueError(f"no skill directories with SKILL.md under: {source}")
+        return skill_dirs
+
+    if not source.is_dir():
+        raise ValueError(f"skill directory does not exist: {source}")
+    if not (source / "SKILL.md").is_file():
+        raise ValueError(f"missing SKILL.md in skill directory: {source}")
+    return [source]
+
+
+def package_skill(skill_dir: Path, output_dir: Path, version: str) -> Path:
+    """Zip one skill tree and return the archive path."""
+    archive_path = output_dir / f"{skill_dir.name}-{version}.zip"
+    with ZipFile(archive_path, "w", compression=ZIP_DEFLATED) as archive:
+        for path in iter_skill_files(skill_dir):
+            relative_path = path.relative_to(skill_dir.parent)
+            archive.write(path, arcname=relative_path.as_posix())
+    return archive_path
+
+
+def main() -> int:
+    """Package skill directories into dist/skills archives."""
+    args = parse_args()
+    repo_root = Path(__file__).resolve().parent.parent
+    source = Path(args.source).resolve()
+    output_dir = Path(args.output_dir).resolve()
+
+    try:
+        skill_dirs = resolve_skill_dirs(source, args.all)
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        return 1
+
+    version = args.version or workspace_version(repo_root)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for archive_path in (package_skill(skill_dir, output_dir, version) for skill_dir in skill_dirs):
+        print(archive_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/README.md
+++ b/skills/README.md
@@ -13,11 +13,19 @@ Official skills and starter templates for the dcc-mcp-core ecosystem.
 | [`dcc-rest-gateway`](dcc-rest-gateway/) | Control any DCC via gateway REST only (no MCP); instance inventory and zero-instance setup | `skills/dcc-rest-gateway/` |
 | [`dcc-skills-creator`](dcc-skills-creator/) | Create, validate, and scaffold DCC skills | `skills/dcc-skills-creator/` |
 
-Publish `dcc-rest-gateway` to [ClawHub](https://clawhub.ai/):
+### ClawHub publish
+
+Manifest: [`.github/clawhub-skills.json`](../.github/clawhub-skills.json). Merging to
+`main` runs [`.github/workflows/clawhub.yml`](../.github/workflows/clawhub.yml) (requires
+repository secret `CLAWHUB_TOKEN`).
 
 ```bash
+# Local dry-run (validate SKILL.md, print publish command)
+just clawhub-sync-dry-run
+
+# Manual publish
 cd skills/dcc-rest-gateway
-clawhub publish . --slug dcc-rest-gateway --version 1.0.0
+npx clawhub@0.7.0 publish . --slug dcc-rest-gateway --version 1.0.0 --no-input
 ```
 
 ## Bundled Skills

--- a/skills/README.md
+++ b/skills/README.md
@@ -6,11 +6,26 @@ Official skills and starter templates for the dcc-mcp-core ecosystem.
 (in-repo reference packages: `python/dcc_mcp_core/skills/dcc-diagnostics`,
 `python/dcc_mcp_core/skills/workflow`).
 
+## Official Skills (ClawHub-ready)
+
+| Skill | Description | Location |
+|-------|-------------|----------|
+| [`dcc-rest-gateway`](dcc-rest-gateway/) | Control any DCC via gateway REST only (no MCP); instance inventory and zero-instance setup | `skills/dcc-rest-gateway/` |
+| [`dcc-skills-creator`](dcc-skills-creator/) | Create, validate, and scaffold DCC skills | `skills/dcc-skills-creator/` |
+
+Publish `dcc-rest-gateway` to [ClawHub](https://clawhub.ai/):
+
+```bash
+cd skills/dcc-rest-gateway
+clawhub publish . --slug dcc-rest-gateway --version 1.0.0
+```
+
 ## Bundled Skills
 
 | Skill | Description | Location |
 |-------|-------------|----------|
-| [`dcc-skills-creator`](dcc-skills-creator/) | Create, validate, and scaffold DCC skills | `skills/dcc-skills-creator/` |
+| `dcc-diagnostics` | Screenshot, audit log, metrics | `python/dcc_mcp_core/skills/` |
+| `workflow` | Multi-step orchestration | `python/dcc_mcp_core/skills/` |
 
 ## Quick Start
 
@@ -258,6 +273,7 @@ skills shipped in `examples/skills/`, or browse them directly:
 | [async-render-example](../examples/skills/async-render-example/) | example | python | Async/deferred tools |
 | [cancellable-loop](../examples/skills/cancellable-loop/) | example | python | Cooperative cancellation |
 | [clawhub-compat](../examples/skills/clawhub-compat/) | example | python | Full OpenClaw format |
+| [dcc-rest-gateway](dcc-rest-gateway/) | infrastructure | python | REST-only gateway control; ClawHub publishable |
 | [dcc-diagnostics](../examples/skills/dcc-diagnostics/) | infrastructure | python | Also bundled |
 | [workflow](../examples/skills/workflow/) | infrastructure | python | Also bundled |
 | [usd-tools](../examples/skills/usd-tools/) | infrastructure | python | Read-only USD tools |

--- a/skills/dcc-rest-gateway/SKILL.md
+++ b/skills/dcc-rest-gateway/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: dcc-rest-gateway
+description: >-
+  Control live DCC hosts (Maya, Blender, Houdini, Photoshop, 3ds Max, and
+  others) through the DCC-MCP gateway REST API only — no MCP client required.
+  For any agent host (OpenClaw, Cursor, Claude, custom HTTP clients): inventory
+  online instances, obtain user consent before setup when none are registered,
+  then search, describe, and call tools via POST /v1/*. Publish target: ClawHub
+  (https://clawhub.ai).
+license: MIT
+compatibility: Requires curl on PATH; DCC-MCP gateway reachable at DCC_MCP_GATEWAY_URL (default http://127.0.0.1:9765)
+allowed-tools: Bash Read
+metadata:
+  dcc-mcp:
+    dcc: python
+    layer: infrastructure
+    version: "1.0.0"
+    search-hint: "rest api, gateway, http, no mcp, instances, dcc control, clawhub"
+    tags: "rest, gateway, infrastructure, clawhub, openclaw, instances"
+  openclaw:
+    requires:
+      env:
+        - DCC_MCP_GATEWAY_URL
+      bins:
+        - curl
+    primaryEnv: DCC_MCP_GATEWAY_URL
+    emoji: "🌐"
+    homepage: https://github.com/loonghao/dcc-mcp-core/blob/main/skills/dcc-rest-gateway/SKILL.md
+---
+
+# DCC REST Gateway — Agent Control Plane (No MCP)
+
+This skill teaches **any** AI agent to drive DCC software through the **DCC-MCP
+gateway HTTP API** only. You do **not** need MCP `tools/list`, `call_tool`,
+`resources/read`, or Streamable HTTP — only `curl` (or any HTTP client) against
+the elected gateway (default port **9765**).
+
+**Publish target:** [ClawHub](https://clawhub.ai/) — install via OpenClaw/ClawHub
+or point your agent at this `SKILL.md` after cloning
+[`dcc-mcp-core/skills/dcc-rest-gateway/`](https://github.com/loonghao/dcc-mcp-core/tree/main/skills/dcc-rest-gateway).
+
+Full contract: [`docs/guide/rest-api-surface.md`](https://github.com/loonghao/dcc-mcp-core/blob/main/docs/guide/rest-api-surface.md).
+
+---
+
+## CRITICAL RULES (read first)
+
+| Situation | You MUST |
+|-----------|----------|
+| Starting any DCC task | Run **instance inventory** (below) before `search` / `call` |
+| `GET /v1/instances` → `total == 0` | **STOP** — do **not** call `POST /v1/search` or `POST /v1/call` |
+| Gateway unreachable (`healthz` fails) | **STOP** — explain; ask user permission before troubleshooting |
+| User has **not** agreed to setup | **FORBID** `pip install`, editing env files, launching GUI apps, writing configs |
+| User **approved** setup | Follow [`references/ZERO_INSTANCES.md`](references/ZERO_INSTANCES.md); poll instances after each step |
+| After DCC crash/restart | Re-run inventory — `instance_id` and `tool_slug` values change |
+
+---
+
+## Configuration
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `DCC_MCP_GATEWAY_URL` | `http://127.0.0.1:9765` | Gateway root (no trailing slash required) |
+
+Set in the shell or OpenClaw env before running commands:
+
+```bash
+export DCC_MCP_GATEWAY_URL="${DCC_MCP_GATEWAY_URL:-http://127.0.0.1:9765}"
+GATEWAY="$DCC_MCP_GATEWAY_URL"
+```
+
+Quick probe (optional helper script):
+
+```bash
+python3 scripts/check_gateway.py
+# or: bash scripts/check_gateway.sh
+```
+
+---
+
+## Step 0 — Mandatory instance inventory
+
+Run **every** time you begin work or after the user starts/stops a DCC host:
+
+```bash
+GATEWAY="${DCC_MCP_GATEWAY_URL:-http://127.0.0.1:9765}"
+
+curl -sf "$GATEWAY/v1/healthz" || echo "GATEWAY_UNREACHABLE"
+curl -s  "$GATEWAY/v1/readyz"
+curl -s  "$GATEWAY/v1/instances"
+curl -s  "$GATEWAY/v1/context"    # optional summary
+```
+
+### Interpret `GET /v1/instances`
+
+Response shape:
+
+```json
+{
+  "total": 2,
+  "instances": [
+    {
+      "instance_id": "full-uuid",
+      "dcc_type": "maya",
+      "status": "available",
+      "stale": false,
+      "display_name": "...",
+      "scene": "...",
+      "port": 8765,
+      "mcp_url": "http://127.0.0.1:8765/mcp"
+    }
+  ]
+}
+```
+
+**Report to the user:**
+
+1. **`total`** — how many registry rows exist (routable targets when not stale).
+2. **Count by `dcc_type`** — e.g. `maya: 1`, `blender: 1`.
+3. Per row: `instance_id`, `status`, `stale` (ignore or warn on `stale: true`).
+4. From `GET /v1/context` (optional): `live_instance_count`, `loaded_skill_count`, `action_count`.
+
+Save one target `instance_id` per DCC you will use — pass it to `POST /v1/search` as `instance_id` (full UUID or unique ≥4-char prefix).
+
+### If `total == 0`
+
+1. Tell the user: gateway may be up but **no DCC has registered** yet.
+2. **Do not** call `search`, `describe`, or `call` (they fail or return empty).
+3. Ask explicitly: *"May I guide you through starting a DCC adapter for &lt;product&gt;?"*
+4. Only after **yes** → open [`references/ZERO_INSTANCES.md`](references/ZERO_INSTANCES.md).
+5. After each user action, re-run `GET /v1/instances` until `total >= 1`.
+
+---
+
+## Step 1 — Discover tools (`POST /v1/search`)
+
+Only when `total >= 1` and rows are not stale.
+
+```bash
+curl -s -X POST "$GATEWAY/v1/search" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "sphere",
+    "dcc_type": "maya",
+    "instance_id": "<from-inventory>",
+    "limit": 20
+  }'
+```
+
+Copy `hits[].tool_slug` **verbatim** — format: `<dcc>.<id8>.<backend_tool>` (e.g. `maya.a1b2c3d4.maya_primitives__create_sphere`). **Never** hand-build slugs.
+
+---
+
+## Step 2 — Inspect schema (`POST /v1/describe`)
+
+```bash
+curl -s -X POST "$GATEWAY/v1/describe" \
+  -H "Content-Type: application/json" \
+  -d '{"tool_slug": "<from-search>", "include_schema": true}'
+```
+
+Read `tool.inputSchema` and safety annotations before calling.
+
+---
+
+## Step 3 — Invoke (`POST /v1/call`)
+
+```bash
+curl -s -X POST "$GATEWAY/v1/call" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "tool_slug": "<from-search>",
+    "arguments": { "radius": 2.0 }
+  }'
+```
+
+- Tool-specific fields (`code`, `file_path`, `radius`, …) belong **inside** `arguments`, not at the top level.
+- Multi-step (≤25): `POST /v1/call_batch` with `calls[]` and optional `stop_on_error`.
+
+Path-style alternative when you already know `dcc_type` + `instance_id`:
+
+`POST /v1/dcc/{dcc_type}/instances/{instance_id}/call` with body
+`{"backend_tool": "...", "arguments": {...}}`.
+
+See [`references/REST_CHEATSHEET.md`](references/REST_CHEATSHEET.md) for the full endpoint list.
+
+---
+
+## What this skill does NOT use
+
+- MCP JSON-RPC (`POST /mcp`, `tools/call`, `resources/read`)
+- Gateway MCP wrappers (`search_tools`, `call_tool`) unless your host maps them to REST internally
+
+REST and MCP share the same backend; this skill is for agents that only have HTTP.
+
+---
+
+## Publishing to ClawHub
+
+From the skill directory (repository root `skills/dcc-rest-gateway/`):
+
+```bash
+clawhub publish ./skills/dcc-rest-gateway \
+  --slug dcc-rest-gateway \
+  --version 1.0.0
+```
+
+Or after `cd skills/dcc-rest-gateway`:
+
+```bash
+clawhub publish . --slug dcc-rest-gateway --version 1.0.0
+```
+
+Install in OpenClaw: skills under `~/.openclaw/skills` or via ClawHub UI at https://clawhub.ai .

--- a/skills/dcc-rest-gateway/SKILL.md
+++ b/skills/dcc-rest-gateway/SKILL.md
@@ -69,12 +69,21 @@ export DCC_MCP_GATEWAY_URL="${DCC_MCP_GATEWAY_URL:-http://127.0.0.1:9765}"
 GATEWAY="$DCC_MCP_GATEWAY_URL"
 ```
 
-Quick probe (optional helper script):
+Quick probe (cross-platform helper — stdlib only, no curl required):
 
 ```bash
+# Linux / macOS
 python3 scripts/check_gateway.py
-# or: bash scripts/check_gateway.sh
+
+# Windows (cmd or PowerShell)
+py -3 scripts\check_gateway.py
+# PowerShell wrapper:
+pwsh scripts/check_gateway.ps1
+
+# Optional: bash scripts/check_gateway.sh
 ```
+
+Flags: `--gateway URL`, `--pretty` for indented JSON.
 
 ---
 

--- a/skills/dcc-rest-gateway/references/REST_CHEATSHEET.md
+++ b/skills/dcc-rest-gateway/references/REST_CHEATSHEET.md
@@ -1,0 +1,94 @@
+# REST cheatsheet — DCC-MCP gateway
+
+Base URL: `$DCC_MCP_GATEWAY_URL` (default `http://127.0.0.1:9765`).
+
+Aligned with [rest-api-surface.md](https://github.com/loonghao/dcc-mcp-core/blob/main/docs/guide/rest-api-surface.md).
+
+## Discovery and health
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/v1/healthz` | Liveness |
+| GET | `/v1/readyz` | Readiness (503 while booting) |
+| GET | `/v1/instances` | **Instance inventory** (`total`, `instances[]`) |
+| GET | `/v1/context` | Aggregated context + `instances` + counts |
+| GET | `/v1/openapi.json` | OpenAPI document |
+
+## Capability workflow
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/v1/search` | Find tools; returns `hits[].tool_slug` |
+| POST | `/v1/describe` | Full schema for one slug |
+| GET | `/v1/tools/{slug}` | Describe alias (URL-encoded slug) |
+| POST | `/v1/call` | Invoke one tool |
+| POST | `/v1/call_batch` | Up to 25 ordered calls (`stop_on_error` optional) |
+
+## Path-style call (optional)
+
+| Method | Path | Body |
+|--------|------|------|
+| POST | `/v1/dcc/{dcc}/instances/{id}/call` | `{"backend_tool","arguments",...}` |
+| GET | `/v1/dcc/{dcc}/instances/{id}/describe?backend_tool=...` | — |
+
+## Example: inventory
+
+```bash
+GATEWAY="${DCC_MCP_GATEWAY_URL:-http://127.0.0.1:9765}"
+curl -s "$GATEWAY/v1/instances"
+```
+
+## Example: search
+
+```bash
+curl -s -X POST "$GATEWAY/v1/search" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"sphere","dcc_type":"maya","limit":10}'
+```
+
+## Example: describe
+
+```bash
+curl -s -X POST "$GATEWAY/v1/describe" \
+  -H "Content-Type: application/json" \
+  -d '{"tool_slug":"maya.a1b2c3d4.maya_primitives__create_sphere","include_schema":true}'
+```
+
+## Example: call
+
+```bash
+curl -s -X POST "$GATEWAY/v1/call" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "tool_slug": "maya.a1b2c3d4.maya_primitives__create_sphere",
+    "arguments": { "radius": 2.0 }
+  }'
+```
+
+## Example: batch
+
+```bash
+curl -s -X POST "$GATEWAY/v1/call_batch" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "calls": [
+      { "tool_slug": "maya.a1b2c3d4.tool_a", "arguments": {} },
+      { "tool_slug": "maya.a1b2c3d4.tool_b", "arguments": {} }
+    ],
+    "stop_on_error": true
+  }'
+```
+
+## Slug rules
+
+- Gateway: `<dcc_type>.<id8>.<backend_tool>` from **search hits only**.
+- Do not put `code`, `radius`, etc. at the top level of `/v1/call` — only inside `arguments`.
+
+## Common errors
+
+| kind | HTTP | Action |
+|------|------|--------|
+| `unknown-slug` | 404 | Re-search; instance may have restarted |
+| `instance-offline` | 503 | Re-run `/v1/instances` |
+| `skill-not-loaded` | 409 | Load skill on backend or pick another tool |
+| `invalid-params` | 400 | Fix `arguments` per describe schema |

--- a/skills/dcc-rest-gateway/references/REST_CHEATSHEET.md
+++ b/skills/dcc-rest-gateway/references/REST_CHEATSHEET.md
@@ -6,30 +6,36 @@ Aligned with [rest-api-surface.md](https://github.com/loonghao/dcc-mcp-core/blob
 
 ## Discovery and health
 
-| Method | Path | Purpose |
-|--------|------|---------|
-| GET | `/v1/healthz` | Liveness |
-| GET | `/v1/readyz` | Readiness (503 while booting) |
-| GET | `/v1/instances` | **Instance inventory** (`total`, `instances[]`) |
-| GET | `/v1/context` | Aggregated context + `instances` + counts |
-| GET | `/v1/openapi.json` | OpenAPI document |
+
+| Method | Path               | Purpose                                         |
+| ------ | ------------------ | ----------------------------------------------- |
+| GET    | `/v1/healthz`      | Liveness                                        |
+| GET    | `/v1/readyz`       | Readiness (503 while booting)                   |
+| GET    | `/v1/instances`    | **Instance inventory** (`total`, `instances[]`) |
+| GET    | `/v1/context`      | Aggregated context + `instances` + counts       |
+| GET    | `/v1/openapi.json` | OpenAPI document                                |
+
 
 ## Capability workflow
 
-| Method | Path | Purpose |
-|--------|------|---------|
-| POST | `/v1/search` | Find tools; returns `hits[].tool_slug` |
-| POST | `/v1/describe` | Full schema for one slug |
-| GET | `/v1/tools/{slug}` | Describe alias (URL-encoded slug) |
-| POST | `/v1/call` | Invoke one tool |
-| POST | `/v1/call_batch` | Up to 25 ordered calls (`stop_on_error` optional) |
+
+| Method | Path               | Purpose                                           |
+| ------ | ------------------ | ------------------------------------------------- |
+| POST   | `/v1/search`       | Find tools; returns `hits[].tool_slug`            |
+| POST   | `/v1/describe`     | Full schema for one slug                          |
+| GET    | `/v1/tools/{slug}` | Describe alias (URL-encoded slug)                 |
+| POST   | `/v1/call`         | Invoke one tool                                   |
+| POST   | `/v1/call_batch`   | Up to 25 ordered calls (`stop_on_error` optional) |
+
 
 ## Path-style call (optional)
 
-| Method | Path | Body |
-|--------|------|------|
-| POST | `/v1/dcc/{dcc}/instances/{id}/call` | `{"backend_tool","arguments",...}` |
-| GET | `/v1/dcc/{dcc}/instances/{id}/describe?backend_tool=...` | — |
+
+| Method | Path                                                     | Body                               |
+| ------ | -------------------------------------------------------- | ---------------------------------- |
+| POST   | `/v1/dcc/{dcc}/instances/{id}/call`                      | `{"backend_tool","arguments",...}` |
+| GET    | `/v1/dcc/{dcc}/instances/{id}/describe?backend_tool=...` | —                                  |
+
 
 ## Example: inventory
 
@@ -86,9 +92,10 @@ curl -s -X POST "$GATEWAY/v1/call_batch" \
 
 ## Common errors
 
-| kind | HTTP | Action |
-|------|------|--------|
-| `unknown-slug` | 404 | Re-search; instance may have restarted |
-| `instance-offline` | 503 | Re-run `/v1/instances` |
-| `skill-not-loaded` | 409 | Load skill on backend or pick another tool |
-| `invalid-params` | 400 | Fix `arguments` per describe schema |
+
+| kind               | HTTP | Action                                     |
+| ------------------ | ---- | ------------------------------------------ |
+| `unknown-slug`     | 404  | Re-search; instance may have restarted     |
+| `instance-offline` | 503  | Re-run `/v1/instances`                     |
+| `skill-not-loaded` | 409  | Load skill on backend or pick another tool |
+| `invalid-params`   | 400  | Fix `arguments` per describe schema        |

--- a/skills/dcc-rest-gateway/references/ZERO_INSTANCES.md
+++ b/skills/dcc-rest-gateway/references/ZERO_INSTANCES.md
@@ -1,0 +1,136 @@
+# Zero instances — user-consent setup guide
+
+Use this document only when:
+
+- `GET /v1/healthz` succeeds (gateway HTTP is up), **and**
+- `GET /v1/instances` returns `"total": 0`, **and**
+- The user has **explicitly approved** help with environment setup.
+
+Until all three are true, do **not** run install commands or change the user's machine.
+
+---
+
+## User consent (mandatory)
+
+Before any step below, confirm:
+
+1. Which DCC product the user needs (Maya, Blender, Houdini, Photoshop, 3ds Max, …).
+2. That they allow you to **suggest** commands (they run installs and launch apps themselves unless they ask you to run shell).
+3. That they will tell you when a step is done so you can re-poll `GET /v1/instances`.
+
+**Never** without approval:
+
+- `pip install` / `npm install`
+- Editing system or user environment variables permanently
+- Launching GUI applications
+- Modifying MCP host config files
+
+---
+
+## Diagnose why `total == 0`
+
+| Check | Meaning | Next step |
+|-------|---------|-----------|
+| `healthz` fails | Nothing listening on `DCC_MCP_GATEWAY_URL` | Ask user to start any DCC with gateway election, or run `dcc-mcp-server` with gateway port 9765 |
+| `healthz` OK, `readyz` 503 | Gateway booting | Wait; retry `readyz` |
+| `healthz` OK, `readyz` 200, `total == 0` | Gateway up, no DCC registered | Start a DCC adapter (sections below) |
+
+Gateway election: the first process binding `DCC_MCP_GATEWAY_PORT` (default **9765**) becomes the gateway; DCC adapters register in `FileRegistry`. See [gateway-election](https://github.com/loonghao/dcc-mcp-core/blob/main/docs/guide/gateway-election.md).
+
+---
+
+## Public catalog (static table)
+
+REST-only agents cannot call MCP `gateway://catalog`. Use this table or, with user permission:
+
+```bash
+dcc-mcp-server catalog search --query maya
+```
+
+| Package | DCC | URL |
+|---------|-----|-----|
+| dcc-mcp-core | (library) | https://github.com/loonghao/dcc-mcp-core |
+| dcc-mcp-maya-skills | maya | https://github.com/loonghao/dcc-mcp-maya-skills |
+| dcc-mcp-blender-skills | blender | https://github.com/loonghao/dcc-mcp-blender-skills |
+| dcc-mcp-houdini-skills | houdini | https://github.com/loonghao/dcc-mcp-houdini-skills |
+| dcc-mcp-photoshop-skills | photoshop | https://github.com/loonghao/dcc-mcp-photoshop-skills |
+
+**Adapters** (embed HTTP server inside the DCC host):
+
+| DCC | Adapter repo | Typical start |
+|-----|--------------|---------------|
+| Maya | https://github.com/loonghao/dcc-mcp-maya | `pip install dcc-mcp-maya` → Script Editor: `dcc_mcp_maya.start_server(port=8765)` |
+| Blender | https://github.com/loonghao/dcc-mcp-blender | Install addon / enable in Preferences → server auto-starts |
+| Houdini | https://github.com/loonghao/dcc-mcp-houdini | Package install + `start_server` per repo README |
+| Photoshop | https://github.com/loonghao/dcc-mcp-photoshop | Follow adapter install guide |
+| 3ds Max | https://github.com/loonghao/dcc-mcp-3dsmax | Plugin / `start_server` per repo README |
+
+Detailed steps:
+
+- Maya: [getting-started](https://github.com/loonghao/dcc-mcp-maya/blob/main/docs/guide/getting-started.md)
+- Blender: [README](https://github.com/loonghao/dcc-mcp-blender/blob/main/README.md)
+
+---
+
+## Per-DCC checklist (after user picks a product)
+
+### Maya
+
+1. Install into Maya's Python: `mayapy -m pip install dcc-mcp-maya`
+2. In Maya Script Editor (Python):
+
+   ```python
+   import dcc_mcp_maya
+   handle = dcc_mcp_maya.start_server(port=8765)
+   print(handle.mcp_url())
+   ```
+
+3. Ensure `DCC_MCP_GATEWAY_PORT` is not `0` (default gateway election on 9765).
+4. User confirms Maya is running → you run `GET /v1/instances` → expect `dcc_type: maya`.
+
+### Blender
+
+1. Install `dcc-mcp-blender` per [README](https://github.com/loonghao/dcc-mcp-blender/blob/main/README.md).
+2. Enable the addon in Blender Preferences.
+3. Confirm HTTP server is listening (default port 8765 in docs).
+4. Poll `/v1/instances` for `dcc_type: blender`.
+
+### Houdini
+
+1. Clone/install [dcc-mcp-houdini](https://github.com/loonghao/dcc-mcp-houdini).
+2. Follow repo `README` for package path and `start_server`.
+3. Poll instances for `dcc_type: houdini`.
+
+### Photoshop
+
+1. Install [dcc-mcp-photoshop](https://github.com/loonghao/dcc-mcp-photoshop) per repo docs.
+2. Start the Photoshop-side service as documented.
+3. Poll instances for `dcc_type: photoshop`.
+
+### 3ds Max
+
+1. Install [dcc-mcp-3dsmax](https://github.com/loonghao/dcc-mcp-3dsmax) per repo docs.
+2. Load plugin / run `start_server` example.
+3. Poll instances for `dcc_type: 3dsmax` (or adapter's canonical `dcc_type`).
+
+---
+
+## Polling loop
+
+After each user-confirmed step:
+
+```bash
+GATEWAY="${DCC_MCP_GATEWAY_URL:-http://127.0.0.1:9765}"
+curl -s "$GATEWAY/v1/instances" | jq '{total, types: [.instances[].dcc_type]}'
+```
+
+When `total >= 1` and target rows have `stale: false`:
+
+1. Report inventory to the user.
+2. Resume the main skill flow: `search` → `describe` → `call`.
+
+---
+
+## After a crash
+
+`instance_id` changes when the DCC process restarts. Always re-run inventory and `POST /v1/search` — do not reuse old `tool_slug` values.

--- a/skills/dcc-rest-gateway/scripts/check_gateway.ps1
+++ b/skills/dcc-rest-gateway/scripts/check_gateway.ps1
@@ -1,0 +1,6 @@
+# Probe DCC-MCP gateway (Windows PowerShell entry point).
+$ErrorActionPreference = "Stop"
+$Dir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Py = if (Get-Command py -ErrorAction SilentlyContinue) { "py", "-3" } else { "python" }
+& @Py (Join-Path $Dir "check_gateway.py") @args
+exit $LASTEXITCODE

--- a/skills/dcc-rest-gateway/scripts/check_gateway.py
+++ b/skills/dcc-rest-gateway/scripts/check_gateway.py
@@ -1,7 +1,16 @@
-"""Probe gateway health and instances; print one-line JSON to stdout."""
+r"""Probe DCC-MCP gateway health and instances; print one-line JSON to stdout.
+
+Cross-platform: run with any Python 3.7+ on Windows, macOS, or Linux:
+
+    python scripts/check_gateway.py
+    py -3 scripts\check_gateway.py
+
+Optional: bash scripts/check_gateway.sh  |  pwsh scripts/check_gateway.ps1
+"""
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import urllib.error
@@ -45,10 +54,33 @@ def probe(gateway: str | None = None) -> dict[str, object]:
     return out
 
 
-def main() -> None:
-    """Print probe result as a single JSON line on stdout."""
-    print(json.dumps(probe(), separators=(",", ":")))
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Build CLI argument parser for gateway probe."""
+    parser = argparse.ArgumentParser(description="Probe DCC-MCP gateway and print JSON summary.")
+    parser.add_argument(
+        "--gateway",
+        "-g",
+        default=None,
+        help="Gateway base URL (default: DCC_MCP_GATEWAY_URL or http://127.0.0.1:9765)",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print JSON instead of a single line",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Print probe result as JSON on stdout; return 0 on success."""
+    args = parse_args(argv)
+    payload = probe(args.gateway)
+    if args.pretty:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(json.dumps(payload, separators=(",", ":")))
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/skills/dcc-rest-gateway/scripts/check_gateway.py
+++ b/skills/dcc-rest-gateway/scripts/check_gateway.py
@@ -1,0 +1,54 @@
+"""Probe gateway health and instances; print one-line JSON to stdout."""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+
+
+def probe(gateway: str | None = None) -> dict[str, object]:
+    """Return gateway liveness, readiness, instance total, and per-dcc_type counts."""
+    base = (gateway or os.environ.get("DCC_MCP_GATEWAY_URL") or "http://127.0.0.1:9765").rstrip("/")
+    out: dict[str, object] = {
+        "gateway_url": base,
+        "gateway_ok": False,
+        "ready": False,
+        "total": 0,
+        "by_dcc_type": {},
+    }
+
+    def ok(path: str) -> bool:
+        try:
+            with urllib.request.urlopen(f"{base}{path}", timeout=5) as resp:
+                return 200 <= resp.status < 300
+        except (urllib.error.URLError, OSError):
+            return False
+
+    out["gateway_ok"] = ok("/v1/healthz")
+    out["ready"] = ok("/v1/readyz")
+
+    try:
+        with urllib.request.urlopen(f"{base}/v1/instances", timeout=10) as resp:
+            data = json.loads(resp.read().decode())
+        instances = data.get("instances") or []
+        out["total"] = int(data.get("total", len(instances)))
+        counts: dict[str, int] = {}
+        for row in instances:
+            dcc = str(row.get("dcc_type") or "unknown")
+            counts[dcc] = counts.get(dcc, 0) + 1
+        out["by_dcc_type"] = counts
+    except (urllib.error.URLError, OSError, json.JSONDecodeError, ValueError, TypeError):
+        pass
+
+    return out
+
+
+def main() -> None:
+    """Print probe result as a single JSON line on stdout."""
+    print(json.dumps(probe(), separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/dcc-rest-gateway/scripts/check_gateway.sh
+++ b/skills/dcc-rest-gateway/scripts/check_gateway.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Probe DCC-MCP gateway health and instance registry; emit one-line JSON summary.
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$DIR/check_gateway.py"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ import dcc_mcp_core
 # Resolve examples/skills relative to repo root
 REPO_ROOT = Path(__file__).resolve().parent.parent
 EXAMPLES_SKILLS_DIR = str(REPO_ROOT / "examples" / "skills")
+SKILLS_DIR = str(REPO_ROOT / "skills")
 
 #: Environment variable read by the Rust GatewayRunner / McpHttpConfig to
 #: override the default shared registry directory (issue #793).
@@ -121,6 +122,14 @@ def examples_dir() -> str:
     if not Path(EXAMPLES_SKILLS_DIR).is_dir():
         pytest.skip("examples/skills directory not found")
     return EXAMPLES_SKILLS_DIR
+
+
+@pytest.fixture()
+def skills_dir() -> str:
+    """Return the path to the top-level skills/ directory, skipping if absent."""
+    if not Path(SKILLS_DIR).is_dir():
+        pytest.skip("skills directory not found")
+    return SKILLS_DIR
 
 
 @pytest.fixture()

--- a/tests/test_clawhub_sync.py
+++ b/tests/test_clawhub_sync.py
@@ -1,0 +1,33 @@
+"""Tests for ClawHub publish manifest and dry-run script."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+from conftest import REPO_ROOT
+
+MANIFEST = REPO_ROOT / ".github" / "clawhub-skills.json"
+SYNC_SCRIPT = REPO_ROOT / "scripts" / "clawhub_sync.py"
+
+
+class TestClawhubSync:
+    def test_manifest_lists_dcc_rest_gateway(self) -> None:
+        entries = json.loads(MANIFEST.read_text(encoding="utf-8"))
+        slugs = {e["slug"] for e in entries}
+        assert "dcc-rest-gateway" in slugs
+
+    def test_dry_run_exits_zero(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, str(SYNC_SCRIPT), "--dry-run"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            cwd=str(REPO_ROOT),
+            check=False,
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert "DRY-RUN" in proc.stdout
+        assert "dcc-rest-gateway" in proc.stdout

--- a/tests/test_dcc_rest_gateway_skill.py
+++ b/tests/test_dcc_rest_gateway_skill.py
@@ -6,12 +6,19 @@ import json
 from pathlib import Path
 import subprocess
 import sys
+from unittest.mock import patch
 
 from conftest import REPO_ROOT
 import dcc_mcp_core
 
 DCC_REST_GATEWAY_DIR = str(REPO_ROOT / "skills" / "dcc-rest-gateway")
 CHECK_SCRIPT = Path(DCC_REST_GATEWAY_DIR) / "scripts" / "check_gateway.py"
+
+# Import probe from skill script (stdlib-only; safe on all platforms).
+sys.path.insert(0, str(CHECK_SCRIPT.parent))
+import check_gateway as check_gateway_mod  # noqa: E402
+
+sys.path.pop(0)
 
 
 class TestDccRestGatewaySkill:
@@ -47,19 +54,61 @@ class TestDccRestGatewaySkill:
         assert (root / "references" / "ZERO_INSTANCES.md").is_file()
         assert (root / "references" / "REST_CHEATSHEET.md").is_file()
 
-    def test_check_gateway_script_outputs_json(self) -> None:
+    def test_probe_offline_gateway(self) -> None:
+        payload = check_gateway_mod.probe("http://127.0.0.1:1")
+        assert payload["gateway_url"] == "http://127.0.0.1:1"
+        assert payload["gateway_ok"] is False
+        assert payload["total"] == 0
+
+    def test_probe_parses_instances(self) -> None:
+        body = json.dumps(
+            {
+                "total": 2,
+                "instances": [
+                    {"dcc_type": "maya"},
+                    {"dcc_type": "maya"},
+                    {"dcc_type": "blender"},
+                ],
+            }
+        ).encode()
+
+        def fake_urlopen(url, timeout=0):
+            url_s = str(url)
+
+            class Resp:
+                status = 200
+
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *args):
+                    return False
+
+                def read(self):
+                    if url_s.endswith("/v1/instances"):
+                        return body
+                    return b"{}"
+
+            return Resp()
+
+        with patch.object(check_gateway_mod.urllib.request, "urlopen", fake_urlopen):
+            payload = check_gateway_mod.probe("http://127.0.0.1:9765")
+
+        assert payload["gateway_ok"] is True
+        assert payload["ready"] is True
+        assert payload["total"] == 2
+        assert payload["by_dcc_type"] == {"maya": 2, "blender": 1}
+
+    def test_check_gateway_cli_outputs_json(self) -> None:
         assert CHECK_SCRIPT.is_file()
         result = subprocess.run(
-            [sys.executable, str(CHECK_SCRIPT)],
+            [sys.executable, str(CHECK_SCRIPT), "--gateway", "http://127.0.0.1:1"],
             capture_output=True,
             text=True,
             timeout=30,
             check=False,
-            env={**dict(__import__("os").environ), "DCC_MCP_GATEWAY_URL": "http://127.0.0.1:1"},
         )
         assert result.returncode == 0, result.stderr
         payload = json.loads(result.stdout.strip())
         assert payload["gateway_url"] == "http://127.0.0.1:1"
         assert payload["gateway_ok"] is False
-        assert payload["total"] == 0
-        assert isinstance(payload["by_dcc_type"], dict)

--- a/tests/test_dcc_rest_gateway_skill.py
+++ b/tests/test_dcc_rest_gateway_skill.py
@@ -1,0 +1,65 @@
+"""Tests for skills/dcc-rest-gateway (ClawHub REST-only agent skill)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+from conftest import REPO_ROOT
+import dcc_mcp_core
+
+DCC_REST_GATEWAY_DIR = str(REPO_ROOT / "skills" / "dcc-rest-gateway")
+CHECK_SCRIPT = Path(DCC_REST_GATEWAY_DIR) / "scripts" / "check_gateway.py"
+
+
+class TestDccRestGatewaySkill:
+    def test_skill_dir_exists(self) -> None:
+        assert Path(DCC_REST_GATEWAY_DIR).is_dir()
+
+    def test_parse_skill_md(self) -> None:
+        meta = dcc_mcp_core.parse_skill_md(DCC_REST_GATEWAY_DIR)
+        assert meta is not None
+        assert meta.name == "dcc-rest-gateway"
+        assert meta.version == "1.0.0"
+
+    def test_validate_skill_clean(self) -> None:
+        report = dcc_mcp_core.validate_skill(DCC_REST_GATEWAY_DIR)
+        assert report.is_clean, report.issues
+
+    def test_scannable_from_skills_dir(self, skills_dir: str) -> None:
+        scanner = dcc_mcp_core.SkillScanner()
+        dirs = scanner.scan(extra_paths=[skills_dir])
+        names = {Path(d).name for d in dirs}
+        assert "dcc-rest-gateway" in names
+
+    def test_description_mentions_clawhub_and_rest(self) -> None:
+        meta = dcc_mcp_core.parse_skill_md(DCC_REST_GATEWAY_DIR)
+        assert meta is not None
+        desc = (meta.description or "").lower()
+        assert "clawhub" in desc
+        assert "rest" in desc
+        assert "mcp" in desc
+
+    def test_reference_docs_present(self) -> None:
+        root = Path(DCC_REST_GATEWAY_DIR)
+        assert (root / "references" / "ZERO_INSTANCES.md").is_file()
+        assert (root / "references" / "REST_CHEATSHEET.md").is_file()
+
+    def test_check_gateway_script_outputs_json(self) -> None:
+        assert CHECK_SCRIPT.is_file()
+        result = subprocess.run(
+            [sys.executable, str(CHECK_SCRIPT)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            env={**dict(__import__("os").environ), "DCC_MCP_GATEWAY_URL": "http://127.0.0.1:1"},
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout.strip())
+        assert payload["gateway_url"] == "http://127.0.0.1:1"
+        assert payload["gateway_ok"] is False
+        assert payload["total"] == 0
+        assert isinstance(payload["by_dcc_type"], dict)


### PR DESCRIPTION
## Summary

- Add official ClawHub-ready skill `skills/dcc-rest-gateway/` for **REST-only** DCC control (no MCP client required).
- Agents must inventory instances via `GET /v1/instances` before any `search`/`call`; when `total == 0`, stop and obtain explicit user consent before setup guidance (`references/ZERO_INSTANCES.md`).
- Add `dcc-mcp-cli`, a Rust client/control-plane binary for local or remote DCC-MCP REST endpoints.
- `dcc-mcp-cli` now supports `health`, `list`, `search`, `describe`, `call`, and catalog-backed `install --dcc-type <dcc> --version <version>` planning.
- Keep the new CLI separated from server runtime code with domain/application/infra/presentation modules, so `dcc-mcp-server` remains the per-DCC runtime and gateway participant.
- Fix Windows CI ghost-row pruning by forcing `FileRegistry::prune_dead_entries()` to reload the registry snapshot before probing sentinel/PID liveness, avoiding mtime-granularity false negatives.
- Fix the `mcporter e2e` workflow by adding `$HOME/.vx/bin` to PATH before verifying the globally-installed mcporter shim.
- Update CLI and architecture docs to include the new binary and workspace member count.

## User / developer impact

- Users and CI can discover live DCC instances and invoke gateway/per-DCC REST capabilities from one cross-platform binary.
- Installation starts with an auditable plan backed by the DCC-MCP catalog, avoiding silent plugin-folder mutation while leaving a clean contract for DCC-specific installers.
- The CLI defaults to `http://127.0.0.1:9765` and can target remote endpoints with `--base-url` / `DCC_MCP_BASE_URL`.
- Gateway instance discovery is more robust on Windows when another process writes and exits within the same filesystem mtime tick.
- The mcporter e2e job now resolves vx-managed global shims consistently from CI PATH.

## Test plan

- [x] `pytest tests/test_dcc_rest_gateway_skill.py` (7 passed)
- [x] `validate_skill` via `test_validate_skill_clean`
- [x] `cargo test -p dcc-mcp-cli`
- [x] `cargo clippy -p dcc-mcp-cli --all-targets -- -D warnings`
- [x] `cargo build -p dcc-mcp-cli --bin dcc-mcp-cli`
- [x] `cargo test -p dcc-mcp-gateway gateway::state::tests::test_read_alive_instances_prunes_dead_pid -- --nocapture`
- [x] `cargo test -p dcc-mcp-transport test_prune_dead_entries_ignores_cached_mtime_when_pruning -- --nocapture`
- [x] `cargo test -p dcc-mcp-transport`
- [x] `cargo test -p dcc-mcp-gateway`
- [x] `cargo clippy -p dcc-mcp-transport -p dcc-mcp-gateway --all-targets -- -D warnings`
- [x] Workflow YAML hook passed for `.github/workflows/ci.yml`
- [ ] Manual: `clawhub publish . --slug dcc-rest-gateway --version 1.0.0` from `skills/dcc-rest-gateway/`
- [ ] Manual: live gateway with Maya/Blender registered → curl inventory + search/call