### PR TITLE
Support Python 3.7 dcc-mcp-server wheel releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,9 +92,11 @@ jobs:
   #      attached to the GitHub Release. Backward-compat artefact for
   #      ops / docker users who don't want to `pip install`.
   #   2. PyPI wheel `dcc_mcp_server-<ver>-py3-none-<plat>.whl` built from
-  #      pkg/dcc-mcp-server-bin/ via maturin's `bindings = "bin"`. maturin
-  #      reuses the just-built binary from `target/release/` so we do NOT
-  #      compile twice (#1003 review feedback).
+  #      pkg/dcc-mcp-server-bin/ via maturin's `bindings = "bin"`. It has
+  #      no Python extension ABI and declares Python 3.7+ compatibility so
+  #      Maya 2022's embedded Python can install it. maturin reuses the
+  #      just-built binary from `target/release/` so we do NOT compile twice
+  #      (#1003 review feedback).
   #
   # Both artefacts ride the same release-please tag — there is exactly
   # one release lifecycle for the workspace, and `dcc-mcp-server` ships
@@ -202,6 +204,38 @@ jobs:
           "$PY" -c "from dcc_mcp_server import binary_path; print('binary_path =', binary_path())"
           "$PY" -m dcc_mcp_server --help 2>/dev/null || true  # module entry not required
 
+      - name: Check server wheel Python compatibility metadata
+        shell: bash
+        run: |
+          python - <<'PY'
+          import sys
+          import zipfile
+          from pathlib import Path
+
+          wheels = sorted(Path("pkg/dcc-mcp-server-bin/wheels").glob("*.whl"))
+          if not wheels:
+              print("::error::No dcc-mcp-server wheel was built", file=sys.stderr)
+              sys.exit(1)
+
+          for wheel in wheels:
+              with zipfile.ZipFile(wheel) as zf:
+                  metadata_name = next(
+                      name for name in zf.namelist()
+                      if name.endswith(".dist-info/METADATA")
+                  )
+                  metadata = zf.read(metadata_name).decode("utf-8")
+
+              if "Requires-Python: >=3.7" not in metadata:
+                  print(
+                      f"::error::{wheel.name} must declare Requires-Python: >=3.7 "
+                      "so Maya 2022 / Python 3.7 can install dcc-mcp-server",
+                      file=sys.stderr,
+                  )
+                  sys.exit(1)
+
+              print(f"{wheel.name}: Python 3.7+ metadata OK")
+          PY
+
       - name: Upload raw binary artefact (for cross-job collection)
         uses: actions/upload-artifact@v4
         with:
@@ -228,15 +262,16 @@ jobs:
     if: needs.release-please.outputs.release_created == 'true'
     uses: ./.github/workflows/build-wheels.yml
     with:
-      test-wheel: 'true'
+      test-wheel: ${{ 'true' }}
       checkout-ref: ${{ needs.release-please.outputs.tag_name }}
 
   # ── Publish to PyPI ──
   publish:
-    needs: [release-please, build-wheels]
+    needs: [release-please, build-wheels, build-binaries]
     if: |
       needs.release-please.outputs.release_created == 'true' &&
-      needs.build-wheels.result == 'success'
+      needs.build-wheels.result == 'success' &&
+      needs.build-binaries.result == 'success'
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/pkg/dcc-mcp-server-bin/README.md
+++ b/pkg/dcc-mcp-server-bin/README.md
@@ -8,8 +8,7 @@ This directory packages the `crates/dcc-mcp-server` Rust binary as a
 platform-specific **binary-only** PyPI wheel, following the same pattern as
 `ruff`, `uv`, `cmake`, and `pyright`. The result is a single
 `pip install dcc-mcp-server` that drops the gateway / sidecar / translate
-CLI onto `PATH` regardless of the user's Python version or which DCC they
-run.
+CLI onto `PATH` for Python 3.7+ regardless of which DCC the user runs.
 
 ## Why a separate PyPI package?
 
@@ -22,7 +21,7 @@ cadences and ABI matrices. Splitting them is the standard pattern.
 | Package | Distributes | Audience |
 |---|---|---|
 | `dcc-mcp-core` (existing) | PyO3 wheel (`_core.so` + Python facade) | Skill authors, plugin/addon code running *inside* a DCC interpreter |
-| `dcc-mcp-server` (this dir) | platform-specific binary wheels | Operators, sidecar spawners, anyone who wants a standalone gateway |
+| `dcc-mcp-server` (this dir) | platform-specific Python 3.7+ binary wheels | Operators, sidecar spawners, anyone who wants a standalone gateway |
 | `dcc-mcp-<dcc>` (each repo) | pure-Python plugin/addon glue | DCC plugin loaders (`userSetup.py`, addon `register()`, …) |
 
 ## Layout
@@ -52,6 +51,11 @@ vx maturin build --release
 vx pip install ../../target/wheels/dcc_mcp_server-*.whl
 dcc-mcp-server --help
 ```
+
+The wheel uses maturin `bindings = "bin"`, so it does not load a Python
+extension module and has no CPython ABI dependency. Its metadata deliberately
+declares `Requires-Python: >=3.7` so embedded Python 3.7 hosts such as Maya
+2022 can install it directly.
 
 ## Cross-platform CI release
 

--- a/pkg/dcc-mcp-server-bin/pyproject.toml
+++ b/pkg/dcc-mcp-server-bin/pyproject.toml
@@ -17,7 +17,7 @@ version = "0.17.4"  # x-release-please-version
 description = "Standalone dcc-mcp-server CLI binary — gateway, sidecar, stdio bridge (Rust)"
 readme = "README.md"
 license = {text = "MIT"}
-requires-python = ">=3.8"
+requires-python = ">=3.7"
 keywords = ["dcc", "mcp", "gateway", "sidecar", "maya", "blender", "houdini"]
 authors = [
     {name = "Hal Long", email = "hal.long@outlook.com"},
@@ -28,6 +28,14 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Rust",
     "Topic :: Software Development",
     "Topic :: Multimedia :: Graphics :: 3D Modeling",


### PR DESCRIPTION
## Summary

- Lower the `dcc-mcp-server` binary wheel metadata to `Requires-Python: >=3.7` so Maya 2022's embedded Python 3.7 can install it.
- Add release-time validation that fails if a server wheel no longer advertises Python 3.7 compatibility.
- Make the PyPI publish job wait for `build-binaries` so server wheel artifacts are available before upload.
- Document that `dcc-mcp-server` uses maturin `bindings = "bin"`, so it has no CPython extension ABI dependency and is expected to publish as `py3-none-<platform>`.

## Validation

- `vx actionlint .github/workflows/release.yml`
- Static pyproject/release metadata assertions
- `git diff --check`

## Issue Status

Updated the open implementation tracking issues while preparing this packaging fix:

- #998 remains the umbrella sidecar/release epic.
- #1000 remains active for the narrowed dispatcher follow-ups.
