### PR TITLE
Add one-click CLI install and release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,13 +85,15 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Release decision: created=$release_created tag=$tag_name version=$version"
 
-  # ── Build standalone dcc-mcp-server (raw binary + PyPI wheel) ──
+  # ── Build standalone binaries (raw Release assets + server PyPI wheel) ──
   #
-  # One job, one cargo target/, two outputs:
+  # One job, one cargo target/, three outputs:
   #   1. Raw binary `dcc-mcp-server[-linux-x86_64|-windows-x86_64.exe|-macos-universal2]`
   #      attached to the GitHub Release. Backward-compat artefact for
   #      ops / docker users who don't want to `pip install`.
-  #   2. PyPI wheel `dcc_mcp_server-<ver>-py3-none-<plat>.whl` built from
+  #   2. Raw binary `dcc-mcp-cli[-linux-x86_64|-windows-x86_64.exe|-macos-universal2]`
+  #      attached to the same GitHub Release and consumed by scripts/install-cli.*.
+  #   3. PyPI wheel `dcc_mcp_server-<ver>-py3-none-<plat>.whl` built from
   #      pkg/dcc-mcp-server-bin/ via maturin's `bindings = "bin"`. It has
   #      no Python extension ABI and declares Python 3.7+ compatibility so
   #      Maya 2022's embedded Python can install it. maturin reuses the
@@ -110,13 +112,19 @@ jobs:
         include:
           - os: ubuntu-latest
             artifact_name: dcc-mcp-server-linux-x86_64
+            cli_artifact_name: dcc-mcp-cli-linux-x86_64
             binary: dcc-mcp-server
+            cli_binary: dcc-mcp-cli
           - os: windows-latest
             artifact_name: dcc-mcp-server-windows-x86_64.exe
+            cli_artifact_name: dcc-mcp-cli-windows-x86_64.exe
             binary: dcc-mcp-server.exe
+            cli_binary: dcc-mcp-cli.exe
           - os: macos-latest
             artifact_name: dcc-mcp-server-macos-universal2
+            cli_artifact_name: dcc-mcp-cli-macos-universal2
             binary: dcc-mcp-server
+            cli_binary: dcc-mcp-cli
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write
@@ -151,16 +159,22 @@ jobs:
       # ── Raw binary build ──────────────────────────────────────────
       - name: Build raw binary (macOS universal2)
         if: matrix.os == 'macos-latest'
-        run: vx just build-server-universal
+        run: |
+          vx just build-server-universal
+          vx just build-cli-universal
 
       - name: Build raw binary (Linux / Windows)
         if: matrix.os != 'macos-latest'
-        run: vx just build-server
+        run: |
+          vx just build-server
+          vx just build-cli
         shell: bash
 
       - name: Stage raw binary (Linux / Windows)
         if: matrix.os != 'macos-latest'
-        run: cp target/release/${{ matrix.binary }} ${{ matrix.artifact_name }}
+        run: |
+          cp target/release/${{ matrix.binary }} ${{ matrix.artifact_name }}
+          cp target/release/${{ matrix.cli_binary }} ${{ matrix.cli_artifact_name }}
         shell: bash
 
       # ── PyPI wheel build ──────────────────────────────────────────
@@ -240,7 +254,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: server-binary-${{ matrix.os }}
-          path: ${{ matrix.artifact_name }}
+          path: |
+            ${{ matrix.artifact_name }}
+            ${{ matrix.cli_artifact_name }}
 
       - name: Upload server wheel artefact (for cross-job collection)
         uses: actions/upload-artifact@v4
@@ -254,6 +270,7 @@ jobs:
           tag_name: ${{ needs.release-please.outputs.tag_name }}
           files: |
             ${{ matrix.artifact_name }}
+            ${{ matrix.cli_artifact_name }}
             pkg/dcc-mcp-server-bin/wheels/*.whl
 
   # ── Build wheels only when release-please creates a release ──

--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@
 
 [中文](README_zh.md) | English
 
-**Production-grade foundation for AI-assisted DCC workflows** — combining the **Model Context Protocol (MCP 2025-03-26 Streamable HTTP)** with a **zero-code Skills system** built on [agentskills.io 1.0](https://agentskills.io/specification). A **Rust-powered core with Python bindings (PyO3)** delivering enterprise-grade performance, security, and scalability — all with **zero runtime Python dependencies**. Supports Python 3.7–3.13.
-
-> **Note**: This project is in active development (v0.15+). APIs may evolve; see `CHANGELOG.md` for version history.
+**Production-grade foundation for AI-assisted DCC workflows** — a new gateway-first architecture that combines **MCP 2025-03-26 Streamable HTTP**, a **zero-code Skills system** built on [agentskills.io 1.0](https://agentskills.io/specification), and a Rust control plane for discovery, routing, installation, and operations. The Python package keeps **zero runtime Python dependencies** for embedded DCC hosts, while the standalone `dcc-mcp-cli` and `dcc-mcp-server` binaries ship through GitHub Releases for workstation-style installs. Supports Python 3.7–3.13.
 
 ---
 
@@ -79,26 +77,25 @@ AI-friendly docs: [AGENTS.md](AGENTS.md) · [`docs/guide/agents-reference.md`](d
 
 ---
 
-## Architecture: The Three-Layer Stack
+## Architecture: The Current Stack
 
 ```
 +-----------------------------------------------------------------+
 |  AI Agent (Claude, GPT, etc.)                                   |
-|  Calls tools via MCP protocol (tools/list, tools/call)          |
+|  Uses MCP tools or REST /v1/* through one gateway endpoint       |
 +-------------------------------+---------------------------------+
                                 |
-                        MCP Streamable HTTP
+                        MCP Streamable HTTP + REST
                                 |
 +-------------------------------v---------------------------------+
-|  Gateway Server (Rust / HTTP)                                   |
-|  +-- Version-aware instance election                            |
-|  +-- Session isolation & routing                                |
-|  +-- Tool discovery (skills-derived)                            |
-|  +-- Job lifecycle + SSE notifications                          |
-|  +-- Workflow execution engine                                  |
+|  Elected Gateway (Rust / HTTP)                                  |
+|  +-- Dynamic capability search / describe / call                |
+|  +-- Instance registry, admin UI, audit logs, traces            |
+|  +-- Version-aware election and failover                        |
+|  +-- Job lifecycle, workflows, artefacts, resources             |
 +-------------------------------+---------------------------------+
                                 |
-                 IPC (Named Pipe / Unix Socket) via DccLink
+                 Per-DCC MCP servers, IPC, or WebSocket bridges
                                 |
           +---------------------+---------------------+
           |                     |                     |
@@ -111,9 +108,9 @@ AI-friendly docs: [AGENTS.md](AGENTS.md) · [`docs/guide/agents-reference.md`](d
     (zero deps)             (zero deps)            (zero deps)
 ```
 
-- **Layer 1 — AI Agent**: Calls tools via standard MCP protocol (`tools/list`, `tools/call`, notifications).
-- **Layer 2 — Gateway**: Orchestrates discovery, session isolation, request routing, job lifecycle, and workflow execution. Maintains a `__gateway__` sentinel for version-aware election.
-- **Layer 3 — DCC Adapters**: DCC-side Python packages (Maya, Blender, Photoshop, Houdini…) that embed the `_core` native extension plus the Skills system. WebView-host adapters (AuroraView, Electron panels) and WebSocket bridges (Photoshop, ZBrush) use narrower capability surfaces.
+- **Agent surface**: MCP clients use `search_tools` -> `describe_tool` -> `call_tool`; non-MCP clients use the matching `/v1/search`, `/v1/describe`, `/v1/call`, and `/v1/call_batch` endpoints.
+- **Gateway surface**: One elected gateway aggregates per-DCC servers, exposes the admin UI, records audit/trace data, and keeps the public tool list small.
+- **DCC surface**: Embedded Python adapters, standalone `dcc-mcp-server`, and WebSocket bridges all register the same structured Skills-derived capabilities.
 
 ---
 
@@ -122,6 +119,12 @@ AI-friendly docs: [AGENTS.md](AGENTS.md) · [`docs/guide/agents-reference.md`](d
 ### Installation
 
 ```bash
+# One-command CLI install from GitHub Releases
+curl -fsSL https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.sh | sh
+
+# Windows PowerShell
+powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+
 # From PyPI (pre-built wheels for Python 3.7+)
 pip install dcc-mcp-core
 
@@ -131,6 +134,8 @@ cd dcc-mcp-core
 vx just dev           # recommended — uses the project's canonical feature set
 # or: pip install -e .
 ```
+
+Every release attaches raw `dcc-mcp-cli` and `dcc-mcp-server` binaries for Linux, Windows, and macOS universal2. `dcc-mcp-server` also ships as the `dcc-mcp-server` Python wheel for hosts that prefer `pip install`.
 
 ### Serve a DCC over MCP — Skills-First (recommended)
 
@@ -609,7 +614,7 @@ This project uses [Release Please](https://github.com/googleapis/release-please)
 1. **Develop**: Create a branch from `main` and commit using [Conventional Commits](https://www.conventionalcommits.org/).
 2. **Merge**: Open a PR and merge to `main`.
 3. **Release PR**: Release Please automatically creates / updates a release PR that bumps the version and updates `CHANGELOG.md`.
-4. **Publish**: When the release PR merges, a GitHub Release is created and the wheel is published to PyPI.
+4. **Publish**: When the release PR merges, a GitHub Release is created with `dcc-mcp-cli` and `dcc-mcp-server` binaries, `dcc-mcp-core` wheels are published to PyPI, and `dcc-mcp-server` wheels are uploaded when its trusted publisher is configured.
 
 ### Commit Message Format
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -11,9 +11,7 @@
 
 [English](README.md) | 中文
 
-**面向 AI 辅助 DCC 工作流的生产级基础库** —— 结合 **模型上下文协议（MCP 2025-03-26 Streamable HTTP）** 与 **零代码 Skills 系统**，后者遵循 [agentskills.io 1.0](https://agentskills.io/specification) 规范。**Rust 核心 + PyO3 Python 绑定**，交付企业级性能、安全性与可扩展性；**运行时零 Python 依赖**。支持 Python 3.7–3.13。
-
-> **注意**：本项目处于积极开发中（v0.15+），API 可能演进；版本历史参见 `CHANGELOG.md`。
+**面向 AI 辅助 DCC 工作流的生产级基础库** —— 当前采用新的 gateway-first 架构，结合 **MCP 2025-03-26 Streamable HTTP**、遵循 [agentskills.io 1.0](https://agentskills.io/specification) 的 **零代码 Skills 系统**，以及负责发现、路由、安装和运维的 Rust 控制面。Python 包面向嵌入式 DCC 宿主保持**运行时零 Python 依赖**；独立的 `dcc-mcp-cli` 与 `dcc-mcp-server` 二进制则随 GitHub Release 发布，适合像传统软件一样下载安装到工作站。支持 Python 3.7–3.13。
 
 ---
 
@@ -71,26 +69,25 @@ AI 友好文档：[AGENTS.md](AGENTS.md) · [`docs/guide/agents-reference.md`](d
 
 ---
 
-## 架构：三层栈
+## 架构：当前栈
 
 ```
 +-----------------------------------------------------------------+
 |  AI Agent (Claude, GPT, 等)                                     |
-|  通过 MCP 协议调用工具 (tools/list, tools/call)                 |
+|  通过 MCP tools 或 REST /v1/* 访问统一网关端点                  |
 +-------------------------------+---------------------------------+
                                 |
-                        MCP Streamable HTTP
+                        MCP Streamable HTTP + REST
                                 |
 +-------------------------------v---------------------------------+
-|  Gateway Server (Rust / HTTP)                                   |
-|  +-- 版本感知实例选举                                            |
-|  +-- 会话隔离与路由                                              |
-|  +-- 工具发现 (从 Skills 派生)                                   |
-|  +-- Job 生命周期 + SSE 通知                                     |
-|  +-- 工作流执行引擎                                              |
+|  Elected Gateway (Rust / HTTP)                                  |
+|  +-- 动态能力 search / describe / call                           |
+|  +-- 实例注册表、Admin UI、审计日志、trace                       |
+|  +-- 版本感知选举与故障切换                                      |
+|  +-- Job 生命周期、workflow、artefact、resource                  |
 +-------------------------------+---------------------------------+
                                 |
-                 IPC (Named Pipe / Unix Socket) via DccLink
+                 Per-DCC MCP server、IPC 或 WebSocket bridge
                                 |
           +---------------------+---------------------+
           |                     |                     |
@@ -103,9 +100,9 @@ AI 友好文档：[AGENTS.md](AGENTS.md) · [`docs/guide/agents-reference.md`](d
     (零依赖)                (零依赖)                (零依赖)
 ```
 
-- **第一层 —— AI Agent**：通过标准 MCP 协议（`tools/list` / `tools/call` / notifications）调用工具。
-- **第二层 —— 网关**：编排工具发现、会话隔离、请求路由、Job 生命周期与工作流执行；维护 `__gateway__` sentinel 做版本感知选举。
-- **第三层 —— DCC 适配器**：DCC 侧的 Python 包（Maya / Blender / Photoshop / Houdini…）内嵌 `_core` 原生扩展和 Skills 系统。WebView 宿主适配器（AuroraView、Electron 面板）和 WebSocket 桥接器（Photoshop、ZBrush）使用更窄的能力面。
+- **Agent 表面**：MCP 客户端使用 `search_tools` -> `describe_tool` -> `call_tool`；非 MCP 客户端使用等价的 `/v1/search`、`/v1/describe`、`/v1/call`、`/v1/call_batch`。
+- **Gateway 表面**：一个获选网关汇聚 per-DCC servers，暴露 Admin UI，记录 audit/trace，并让公开工具列表保持很小。
+- **DCC 表面**：嵌入式 Python 适配器、独立 `dcc-mcp-server`、WebSocket bridge 都注册同一套结构化、由 Skills 派生的能力。
 
 ---
 
@@ -114,6 +111,12 @@ AI 友好文档：[AGENTS.md](AGENTS.md) · [`docs/guide/agents-reference.md`](d
 ### 安装
 
 ```bash
+# 从 GitHub Release 一键安装 CLI
+curl -fsSL https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.sh | sh
+
+# Windows PowerShell
+powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+
 # 从 PyPI 安装（Python 3.7+ 预构建 wheel）
 pip install dcc-mcp-core
 
@@ -123,6 +126,8 @@ cd dcc-mcp-core
 vx just dev           # 推荐 —— 使用项目标准 feature 集合
 # 或：pip install -e .
 ```
+
+每个 Release 都会附带 Linux、Windows、macOS universal2 的原生 `dcc-mcp-cli` 与 `dcc-mcp-server` 二进制。`dcc-mcp-server` 还会发布 `dcc-mcp-server` Python wheel，方便偏好 `pip install` 的宿主环境。
 
 ### 将 DCC 暴露为 MCP 服务 —— Skills-First（推荐）
 
@@ -601,7 +606,7 @@ feature 列表的**唯一真实源在 `justfile`**（`OPT_FEATURES`、`DEV_FEATU
 1. **开发**：从 `main` 拉分支，使用 [Conventional Commits](https://www.conventionalcommits.org/) 提交。
 2. **合并**：开 PR，合入 `main`。
 3. **发布 PR**：Release Please 自动创建 / 更新一个发布 PR，升版本并更新 `CHANGELOG.md`。
-4. **发布**：发布 PR 合入后，自动创建 GitHub Release 并发布 wheel 到 PyPI。
+4. **发布**：发布 PR 合入后，自动创建 GitHub Release，附带 `dcc-mcp-cli` 与 `dcc-mcp-server` 二进制；`dcc-mcp-core` wheels 发布到 PyPI；`dcc-mcp-server` wheels 在 trusted publisher 配好后同步上传。
 
 ### 提交信息格式
 

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -6,6 +6,19 @@ five deployment scenarios they cover. Flags on each binary map 1:1 onto an
 `DCC_MCP_*` environment variable, so any deployment manifest can drive the
 same configuration surface.
 
+`dcc-mcp-cli` and `dcc-mcp-server` are published as raw GitHub Release
+assets on every release. The CLI can be installed directly from a URL:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.sh | sh
+
+# Windows PowerShell
+powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+```
+
+Pin a release by setting `DCC_MCP_VERSION=v0.17.4` or passing
+`--version v0.17.4` to the install script.
+
 | Binary | Role | Source |
 |---|---|---|
 | [`dcc-mcp-cli`](#dcc-mcp-cli) | User/CI control plane for local or remote DCC-MCP REST endpoints. | `crates/dcc-mcp-cli/` |
@@ -52,6 +65,20 @@ entries and spells out the runtime / adapter / verification steps without
 silently modifying DCC plugin folders. DCC-specific installers can attach to
 that contract incrementally.
 
+### CLI installation assets
+
+The installer scripts download one of these GitHub Release assets:
+
+| Platform | Asset |
+|---|---|
+| Linux x86_64 | `dcc-mcp-cli-linux-x86_64` |
+| Windows x86_64 | `dcc-mcp-cli-windows-x86_64.exe` |
+| macOS universal2 | `dcc-mcp-cli-macos-universal2` |
+
+Default install locations are `~/.local/bin` on Linux/macOS and
+`%LOCALAPPDATA%\dcc-mcp\bin` on Windows. Override with
+`DCC_MCP_INSTALL_DIR` or `--install-dir`.
+
 ---
 
 ## `dcc-mcp-server`
@@ -91,7 +118,7 @@ instances that the winner aggregates.
 
 Admin audit/trace persistence is configured by environment only: set `DCC_MCP_GATEWAY_AUDIT_DIR` to a writable directory to persist `/admin/api/calls` rows in `audit.jsonl` and dispatch traces in `traces.jsonl`; set `DCC_MCP_GATEWAY_AUDIT_MAX_ROWS` (default `5000`) to cap each file.
 
-> **Removed in PR A** — `--gateway-tool-exposure` /
+> **Removed** — `--gateway-tool-exposure` /
 > `DCC_MCP_GATEWAY_TOOL_EXPOSURE` are gone. The gateway surface is now
 > unconditionally minimal (see `docs/guide/rest-api-surface.md`).
 >

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -2,6 +2,18 @@
 
 ## Installation
 
+### CLI from GitHub Releases
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.sh | sh
+
+# Windows PowerShell
+powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+```
+
+This installs the standalone `dcc-mcp-cli` control-plane binary from the
+latest GitHub Release. Pin a release with `DCC_MCP_VERSION=v0.17.4`.
+
 ### From PyPI
 
 ```bash
@@ -24,13 +36,13 @@ The build is handled by [maturin](https://www.maturin.rs/) which compiles the Ru
 ## Requirements
 
 - **Python**: >= 3.7 (CI tests 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13)
-- **Rust**: >= 1.85 (for building from source)
+- **Rust**: >= 1.95 (for building from source)
 - **License**: MIT
 - **Python Dependencies**: Zero — everything is in the compiled Rust extension
 
 ## Quick Start
 
-### Skills-First: `create_skill_server` (recommended since v0.12.12)
+### Skills-First: `create_skill_server` (recommended)
 
 The fastest way to expose scripts as MCP tools. Create a `SKILL.md` in your script folder, then use `create_skill_server` to wire everything in one call:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: DCC-MCP-Core
-  text: MCP + Skills for DCC AI
-  tagline: Production-grade foundation combining Model Context Protocol (MCP) and a zero-code Skills system. Connect AI to Maya, Blender, Houdini, Photoshop — without context explosion.
+  text: Gateway-first MCP + Skills for DCC AI
+  tagline: Production-grade foundation combining MCP, zero-code Skills, dynamic capability routing, and release-ready CLI/server binaries for Maya, Blender, Houdini, Photoshop, and custom studio hosts.
   image:
     src: /logo.svg
     alt: DCC-MCP-Core
@@ -21,14 +21,14 @@ hero:
 
 features:
   - icon: 🎯
-    title: Solves MCP Context Explosion
-    details: Session isolation pins each AI session to one DCC instance. tools/list returns 150 tools instead of 750. Progressive discovery by DCC type, scope, and product.
+    title: Dynamic Capability Routing
+    details: Agents search, describe, and call tools through one gateway instead of carrying every backend tool in context.
   - icon: 🔌
     title: Zero-Code Skill Registration
     details: Write SKILL.md + scripts/ → instant MCP tools. No Python glue code needed. Supports Python, MEL, MaxScript, Bash, PowerShell, and more.
   - icon: 🏆
     title: Version-Aware Gateway Election
-    details: Multiple DCC instances compete for gateway role. Newest version automatically takes over. No manual failover — just semantic version comparison.
+    details: Multiple DCC instances compete for the gateway role. Newer adapters can take over cleanly while existing instances stay discoverable.
   - icon: 🦀
     title: Rust-Powered Core
     details: Zero runtime Python dependencies. Zero-copy IPC via Named Pipes and Unix Sockets. rmp-serde serialization. LZ4 shared memory. Sub-millisecond tool calls.
@@ -42,8 +42,8 @@ features:
     title: Sandbox & Audit Log
     details: Policy-based access control with in-memory audit logging. Define what AI can and cannot do per DCC type.
   - icon: 🌐
-    title: MCP Streamable HTTP
-    details: Built-in server (2025-03-26 spec). Claude Desktop, Cursor, and other MCP clients connect directly over HTTP. Background thread, never blocks DCC.
+    title: MCP Streamable HTTP + REST
+    details: Built-in MCP server, REST /v1/* dynamic-capability surface, Admin UI, audit logs, traces, and gateway diagnostics.
   - icon: 📊
     title: Structured Results
     details: Every tool returns (success, message, context, next_steps). AI agents reason clearly about outcomes. No fragile text parsing.

--- a/docs/zh/guide/cli-reference.md
+++ b/docs/zh/guide/cli-reference.md
@@ -1,17 +1,79 @@
 # CLI 参考
 
-仓库提供三个面向运维的二进制文件。本页是所有旗标、所有环境变量、以及五个
+仓库提供四个面向运维的二进制文件。本页是所有旗标、所有环境变量、以及五个
 典型部署场景的**唯一信息源**。每个二进制的旗标都一对一映射到一个
 `DCC_MCP_*` 环境变量，所以任何部署清单都能驱动同一套配置面板。
 
+`dcc-mcp-cli` 与 `dcc-mcp-server` 会在每个 Release 作为原生 GitHub
+Release 资产发布。CLI 可以通过 URL 直接安装：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.sh | sh
+
+# Windows PowerShell
+powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+```
+
+需要固定版本时，设置 `DCC_MCP_VERSION=v0.17.4`，或给安装脚本传
+`--version v0.17.4`。
+
 | 二进制 | 角色 | 源码位置 |
 |---|---|---|
+| [`dcc-mcp-cli`](#dcc-mcp-cli) | 面向用户/CI 的控制面 CLI，用来访问本地或远程 DCC-MCP REST 端点。 | `crates/dcc-mcp-cli/` |
 | [`dcc-mcp-server`](#dcc-mcp-server) | per-DCC MCP + REST 服务器，内置自动网关。 | `crates/dcc-mcp-server/` |
 | [`dcc-mcp-tunnel-relay`](#dcc-mcp-tunnel-relay) | 面向公网的 WebSocket 隧道中继（零配置远程访问，#504）。 | `crates/dcc-mcp-tunnel-relay/` |
 | [`dcc-mcp-tunnel-agent`](#dcc-mcp-tunnel-agent) | 在工作站上注册到中继、转发 MCP 流量的本地 sidecar。 | `crates/dcc-mcp-tunnel-agent/` |
 
 开发辅助二进制（`stub_gen`）在
 [`AGENTS.md`](https://github.com/loonghao/dcc-mcp-core/blob/main/AGENTS.md) 里。
+
+---
+
+## `dcc-mcp-cli`
+
+DCC-MCP 的客户端控制面。它不托管 skills，也不替代 `dcc-mcp-server`；
+它负责访问本地或远程 gateway / per-DCC REST 端点，并生成可审计的安装计划。
+
+默认端点是 `http://127.0.0.1:9765`，可用 `--base-url` 或
+`DCC_MCP_BASE_URL` 覆盖。
+
+```bash
+dcc-mcp-cli list
+dcc-mcp-cli health
+dcc-mcp-cli search --query sphere --dcc-type maya
+dcc-mcp-cli describe maya.abc12345.create_sphere
+dcc-mcp-cli call maya.abc12345.create_sphere --json '{"radius":2}'
+dcc-mcp-cli install --dcc-type maya --version 2026
+```
+
+### 命令
+
+| 命令 | REST/API 契约 | 说明 |
+|---|---|---|
+| `health` | `GET /v1/healthz` | 检查配置的端点。 |
+| `list` | `GET /v1/instances` | 从 gateway 列出在线 DCC 实例。 |
+| `search` | `POST /v1/search` | 搜索可调用能力。 |
+| `describe <tool-slug>` | `POST /v1/describe` | 调用前检查能力 schema。 |
+| `call <tool-slug> --json <object>` | `POST /v1/call` | 调用一个能力。 |
+| `install --dcc-type <dcc> [--version <v>]` | catalog-backed local plan | 解析匹配的 adapter 并输出可审计安装计划。 |
+
+`install` 目前是规划契约：它解析 catalog entry，并列出 runtime、adapter、
+验证步骤，不会静默修改 DCC 插件目录。DCC-specific installer 后续可增量接入
+这份契约。
+
+### CLI 安装资产
+
+安装脚本会下载以下 GitHub Release 资产之一：
+
+| 平台 | 资产 |
+|---|---|
+| Linux x86_64 | `dcc-mcp-cli-linux-x86_64` |
+| Windows x86_64 | `dcc-mcp-cli-windows-x86_64.exe` |
+| macOS universal2 | `dcc-mcp-cli-macos-universal2` |
+
+默认安装位置：Linux/macOS 为 `~/.local/bin`，Windows 为
+`%LOCALAPPDATA%\dcc-mcp\bin`。可用 `DCC_MCP_INSTALL_DIR` 或
+`--install-dir` 覆盖。
 
 ---
 
@@ -51,7 +113,7 @@
 
 Admin 审计/trace 持久化只通过环境变量配置：设置 `DCC_MCP_GATEWAY_AUDIT_DIR` 为可写目录后，`/admin/api/calls` 行会写入 `audit.jsonl`，dispatch traces 会写入 `traces.jsonl`；`DCC_MCP_GATEWAY_AUDIT_MAX_ROWS`（默认 `5000`）限制每个文件保留行数。
 
-> **PR A 已移除** —— `--gateway-tool-exposure` /
+> **已移除** —— `--gateway-tool-exposure` /
 > `DCC_MCP_GATEWAY_TOOL_EXPOSURE` 已删除。网关表面现在无条件最小化，详见
 > `docs/zh/guide/rest-api-surface.md`。
 >

--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -2,6 +2,18 @@
 
 ## 安装
 
+### 从 GitHub Release 安装 CLI
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.sh | sh
+
+# Windows PowerShell
+powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+```
+
+这会从最新 GitHub Release 安装独立的 `dcc-mcp-cli` 控制面二进制。
+需要固定版本时设置 `DCC_MCP_VERSION=v0.17.4`。
+
 ### 从 PyPI 安装
 
 ```bash
@@ -24,13 +36,13 @@ pip install -e .
 ## 环境要求
 
 - **Python**: >= 3.7（CI 测试 3.7、3.8、3.9、3.10、3.11、3.12、3.13）
-- **Rust**: >= 1.85（从源代码构建时需要）
+- **Rust**: >= 1.95（从源代码构建时需要）
 - **许可证**: MIT
 - **Python 依赖**: 零 — 所有功能都在编译的 Rust 扩展中
 
 ## 快速上手
 
-### Skills-First：`create_skill_server`（v0.12.12+ 推荐）
+### Skills-First：`create_skill_server`（推荐）
 
 将脚本暴露为 MCP 工具最快捷的方式。在脚本目录创建 `SKILL.md`，然后一键完成所有配置：
 

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: DCC-MCP-Core
-  text: 面向 DCC 的 MCP + Skills
-  tagline: 生产级 MCP 与零代码 Skills 系统的结合。解决上下文爆炸，将 AI 与 Maya、Blender、Houdini、Photoshop 高性能对接。
+  text: 面向 DCC AI 的 Gateway-first MCP + Skills
+  tagline: 生产级 MCP、零代码 Skills、动态能力路由，以及可随 Release 直接安装的 CLI/server 二进制；面向 Maya、Blender、Houdini、Photoshop 与自定义工作室宿主。
   image:
     src: /logo.svg
     alt: DCC-MCP-Core
@@ -21,14 +21,14 @@ hero:
 
 features:
   - icon: 🎯
-    title: 解决 MCP 上下文爆炸
-    details: 会话隔离将每个 AI 会话绑定到单一 DCC 实例。tools/list 返回 150 个工具而非 750 个。按 DCC 类型、作用域和产品进行渐进式发现。
+    title: 动态能力路由
+    details: Agent 通过一个 gateway search、describe、call 工具，不再把所有后端工具塞进上下文。
   - icon: 🔌
     title: 零代码 Skill 注册
     details: 编写 SKILL.md + scripts/ 即获得 MCP 工具。无需 Python 胶水代码。支持 Python、MEL、MaxScript、Bash、PowerShell 等。
   - icon: 🏆
     title: 版本感知网关选举
-    details: 多 DCC 实例竞争网关角色，最新版本自动接管。无需手动故障转移——语义版本比较自动完成。
+    details: 多 DCC 实例竞争网关角色，新版本 adapter 可干净接管，已有实例仍可被发现和路由。
   - icon: 🦀
     title: Rust 驱动核心
     details: 零运行时 Python 依赖。通过 Named Pipe 和 Unix Socket 实现零拷贝 IPC。rmp-serde 序列化。LZ4 共享内存。毫秒级工具调用。
@@ -42,8 +42,8 @@ features:
     title: 沙箱与审计日志
     details: 基于策略的访问控制与内存审计日志。定义 AI 在每个 DCC 类型下能做什么，不能做什么。
   - icon: 🌐
-    title: MCP Streamable HTTP
-    details: 内置服务器（2025-03-26 规范）。Claude Desktop、Cursor 等 MCP 客户端直接通过 HTTP 连接。后台线程，从不阻塞 DCC。
+    title: MCP Streamable HTTP + REST
+    details: 内置 MCP server、REST /v1/* 动态能力面、Admin UI、审计日志、trace 与 gateway diagnostics。
   - icon: 📊
     title: 结构化结果
     details: 每个工具返回（success, message, context, next_steps）。AI 智能体能清晰推理执行结果。无需脆弱的文本解析。

--- a/justfile
+++ b/justfile
@@ -108,7 +108,24 @@ hakari-generate:
 hakari-verify:
     cargo hakari verify
 
-# ── Standalone binary (dcc-mcp-server) ───────────────────────────────────────
+# ── Standalone binaries ─────────────────────────────────────────────────────
+
+# Build dcc-mcp-cli for the current platform
+build-cli:
+    cargo build --release -p dcc-mcp-cli
+
+# Build dcc-mcp-cli universal2 binary for macOS (requires both targets installed)
+[unix]
+build-cli-universal:
+    #!/usr/bin/env sh
+    set -eu
+    rustup target add x86_64-apple-darwin aarch64-apple-darwin 2>/dev/null || true
+    cargo build --release -p dcc-mcp-cli --target x86_64-apple-darwin
+    cargo build --release -p dcc-mcp-cli --target aarch64-apple-darwin
+    lipo -create -output dcc-mcp-cli-macos-universal2 \
+        target/x86_64-apple-darwin/release/dcc-mcp-cli \
+        target/aarch64-apple-darwin/release/dcc-mcp-cli
+    echo "Built: dcc-mcp-cli-macos-universal2"
 
 # Build dcc-mcp-server for the current platform
 build-server:

--- a/scripts/install-cli.ps1
+++ b/scripts/install-cli.ps1
@@ -1,0 +1,52 @@
+param(
+    [string] $Version = $env:DCC_MCP_VERSION,
+    [string] $InstallDir = $env:DCC_MCP_INSTALL_DIR,
+    [string] $Repo = $env:DCC_MCP_REPO
+)
+
+$ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    $Version = "latest"
+}
+if ([string]::IsNullOrWhiteSpace($InstallDir)) {
+    $InstallDir = Join-Path $env:LOCALAPPDATA "dcc-mcp\bin"
+}
+if ([string]::IsNullOrWhiteSpace($Repo)) {
+    $Repo = "loonghao/dcc-mcp-core"
+}
+
+$asset = "dcc-mcp-cli-windows-x86_64.exe"
+if ($Version -eq "latest") {
+    $url = "https://github.com/$Repo/releases/latest/download/$asset"
+} else {
+    $url = "https://github.com/$Repo/releases/download/$Version/$asset"
+}
+
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+$target = Join-Path $InstallDir "dcc-mcp-cli.exe"
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("dcc-mcp-cli-" + [System.Guid]::NewGuid() + ".exe")
+
+try {
+    Write-Host "Downloading $url"
+    Invoke-WebRequest -Uri $url -OutFile $tmp
+    Move-Item -Force -Path $tmp -Destination $target
+} finally {
+    if (Test-Path $tmp) {
+        Remove-Item -Force $tmp
+    }
+}
+
+Write-Host "Installed dcc-mcp-cli to $target"
+
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+$pathParts = @()
+if ($userPath) {
+    $pathParts = $userPath -split ";"
+}
+
+if ($pathParts -notcontains $InstallDir) {
+    $newPath = if ($userPath) { "$userPath;$InstallDir" } else { $InstallDir }
+    [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+    Write-Host "Added $InstallDir to the user PATH. Open a new terminal before running dcc-mcp-cli."
+}

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env sh
+set -eu
+
+REPO="${DCC_MCP_REPO:-loonghao/dcc-mcp-core}"
+VERSION="${DCC_MCP_VERSION:-latest}"
+INSTALL_DIR="${DCC_MCP_INSTALL_DIR:-$HOME/.local/bin}"
+
+usage() {
+    cat <<'EOF'
+Install dcc-mcp-cli from GitHub Releases.
+
+Usage:
+  install-cli.sh [--version v0.17.4] [--install-dir ~/.local/bin]
+
+Environment:
+  DCC_MCP_REPO         GitHub repo, default loonghao/dcc-mcp-core
+  DCC_MCP_VERSION      Release tag, default latest
+  DCC_MCP_INSTALL_DIR  Install directory, default ~/.local/bin
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --version)
+            if [ "$#" -lt 2 ]; then
+                echo "--version requires a value" >&2
+                exit 2
+            fi
+            VERSION="$2"
+            shift 2
+            ;;
+        --install-dir)
+            if [ "$#" -lt 2 ]; then
+                echo "--install-dir requires a value" >&2
+                exit 2
+            fi
+            INSTALL_DIR="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+
+case "$OS" in
+    Linux)
+        if [ "$ARCH" != "x86_64" ] && [ "$ARCH" != "amd64" ]; then
+            echo "Unsupported Linux architecture: $ARCH" >&2
+            exit 1
+        fi
+        ASSET="dcc-mcp-cli-linux-x86_64"
+        ;;
+    Darwin)
+        ASSET="dcc-mcp-cli-macos-universal2"
+        ;;
+    *)
+        echo "Unsupported OS: $OS" >&2
+        exit 1
+        ;;
+esac
+
+if [ "$VERSION" = "latest" ]; then
+    URL="https://github.com/$REPO/releases/latest/download/$ASSET"
+else
+    URL="https://github.com/$REPO/releases/download/$VERSION/$ASSET"
+fi
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+    rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT INT TERM
+
+mkdir -p "$INSTALL_DIR"
+echo "Downloading $URL"
+if command -v curl >/dev/null 2>&1; then
+    curl -fL "$URL" -o "$TMP_DIR/dcc-mcp-cli"
+elif command -v wget >/dev/null 2>&1; then
+    wget -O "$TMP_DIR/dcc-mcp-cli" "$URL"
+else
+    echo "curl or wget is required" >&2
+    exit 1
+fi
+
+chmod 0755 "$TMP_DIR/dcc-mcp-cli"
+mv "$TMP_DIR/dcc-mcp-cli" "$INSTALL_DIR/dcc-mcp-cli"
+
+echo "Installed dcc-mcp-cli to $INSTALL_DIR/dcc-mcp-cli"
+case ":$PATH:" in
+    *":$INSTALL_DIR:"*) ;;
+    *)
+        echo "Add $INSTALL_DIR to PATH to run dcc-mcp-cli from any shell."
+        ;;
+esac


### PR DESCRIPTION
## Summary

- Publish `dcc-mcp-cli` raw binaries alongside `dcc-mcp-server` in the release workflow.
- Add URL-based installer scripts for Linux/macOS and Windows PowerShell.
- Refresh README and docs to describe the current gateway-first architecture, CLI install path, and release assets.

## Impact

Users can install the CLI from GitHub Releases with a single command, and release artifacts now include both the operator CLI and standalone server binaries.

## Validation

- `cargo check -p dcc-mcp-cli`
- `cargo test -p dcc-mcp-cli`
- `vx just build-cli`
- `git diff --check`
- PowerShell parser check for `scripts/install-cli.ps1`
- `npm ci` and `npm run docs:build` in `docs/`

Note: `vx just docs-check` could not run directly in this Windows shell because the recipe requires `cygpath` for its bash shebang path translation; the underlying docs commands were run manually and passed.
