### PR TITLE
fix: surface gateway host death metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,11 @@ jobs:
           echo "RUSTC=$(rustup which rustc)" >> "$GITHUB_ENV"
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
       - uses: loonghao/vx@v0.8.36
+      - name: Prepare admin UI dependencies
+        shell: bash
+        run: |
+          vx node --version
+          vx npm --prefix admin-ui ci
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
         with:
@@ -329,7 +334,10 @@ jobs:
       - uses: loonghao/vx@v0.8.36
 
       - name: Expose vx global shims
-        run: echo "$HOME/.vx/bin" >> "$GITHUB_PATH"
+        run: |
+          echo "$HOME/.vx/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
         shell: bash
 
       - name: Download wheel
@@ -345,11 +353,11 @@ jobs:
       # Install mcporter globally (Node/npm from vx.toml via vx).
       # The global binary is detected by the test suite and used directly.
       - name: Install mcporter globally
-        run: vx npm install -g mcporter@0.9.0
+        run: vx npm install -g mcporter@0.9.0 --force
         shell: bash
 
       - name: Verify mcporter
-        run: mcporter --version
+        run: mcporter --version || npx --yes mcporter@0.9.0 --version
         shell: bash
 
       - name: Run mcporter e2e tests

--- a/crates/dcc-mcp-gateway-core/src/event.rs
+++ b/crates/dcc-mcp-gateway-core/src/event.rs
@@ -23,6 +23,8 @@ pub enum EventKind {
     ProbeUnreachable,
     /// A backend instance was auto-deregistered after consecutive probe failures.
     AutoDeregister,
+    /// A backend DCC host died while a gateway-routed call was in flight.
+    HostDied,
     /// Operator-facing admin action (skill paths, etc.) — no Prometheus counter.
     OperatorNote,
 }
@@ -38,6 +40,7 @@ impl EventKind {
             EventKind::ProbeBooting => "booting",
             EventKind::ProbeUnreachable => "unreachable",
             EventKind::AutoDeregister => "probe_fail",
+            EventKind::HostDied => "host_died",
             EventKind::OperatorNote => "operator",
         }
     }
@@ -92,6 +95,7 @@ mod tests {
         assert_eq!(EventKind::ProbeBooting.as_label(), "booting");
         assert_eq!(EventKind::ProbeUnreachable.as_label(), "unreachable");
         assert_eq!(EventKind::AutoDeregister.as_label(), "probe_fail");
+        assert_eq!(EventKind::HostDied.as_label(), "host_died");
         assert_eq!(EventKind::OperatorNote.as_label(), "operator");
     }
 

--- a/crates/dcc-mcp-gateway/build.rs
+++ b/crates/dcc-mcp-gateway/build.rs
@@ -45,7 +45,12 @@ fn run_npm_or_vx(
     match vx_result {
         Ok(status) if status.success() => return Ok(()),
         Ok(status) => {
-            return Err(format!("`vx {}` exited with {status}", vx_argv.join(" ")));
+            println!(
+                "cargo:warning=`vx {}` exited with {status}; trying `npm {}` in {}",
+                vx_argv.join(" "),
+                npm_args.join(" "),
+                admin_ui.display()
+            );
         }
         Err(e) if e.kind() == io::ErrorKind::NotFound => {
             println!(

--- a/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
@@ -21,6 +21,7 @@ use serde_json::{Value, json};
 use uuid::Uuid;
 
 use dcc_mcp_jsonrpc::McpTool;
+use dcc_mcp_transport::discovery::types::ServiceEntry;
 
 use super::backend_client::{forward_tools_call, try_describe_tool};
 use super::capability::{
@@ -28,6 +29,7 @@ use super::capability::{
     refresh_instance, remove_instance, search,
 };
 use super::state::GatewayState;
+use dcc_mcp_gateway_core::naming::instance_short;
 
 /// Shape of a structured error emitted by the call / describe paths.
 ///
@@ -222,6 +224,8 @@ pub async fn call_service(
         .with_instance_provenance("deregistered", Some(record.instance_id)));
     };
     let url = format!("http://{}:{}/mcp", entry.host, entry.port);
+    let entry = entry.clone();
+    drop(reg);
 
     match forward_tools_call(
         &gs.http_client,
@@ -234,11 +238,23 @@ pub async fn call_service(
     )
     .await
     {
-        Ok(result) => Ok(result),
-        Err(e) => Err(ServiceError::new(
-            "backend-error",
-            format!("backend call failed: {e}"),
-        )),
+        Ok(mut result) => {
+            inject_call_instance_meta(&mut result, &entry);
+            Ok(result)
+        }
+        Err(e) => {
+            if is_host_died_backend_error(&e) {
+                record_host_died(gs, &entry, &record, &e);
+                return Err(ServiceError::new(
+                    "host-died",
+                    format!("backend host died during {}: {e}", record.callable_id),
+                ));
+            }
+            Err(ServiceError::new(
+                "backend-error",
+                format!("backend call failed: {e}"),
+            ))
+        }
     }
 }
 
@@ -317,6 +333,79 @@ pub fn service_error_to_json(err: &ServiceError) -> Value {
             "previous_instance_id": err.previous_instance_id,
         }
     })
+}
+
+fn inject_call_instance_meta(result: &mut Value, entry: &ServiceEntry) {
+    let Some(obj) = result.as_object_mut() else {
+        return;
+    };
+
+    let meta = obj.entry("_meta".to_string()).or_insert_with(|| json!({}));
+    if !meta.is_object() {
+        *meta = json!({});
+    }
+    let meta_obj = meta.as_object_mut().expect("_meta just normalised");
+    let dcc = meta_obj
+        .entry("dcc".to_string())
+        .or_insert_with(|| json!({}));
+    if !dcc.is_object() {
+        *dcc = json!({});
+    }
+    let dcc_obj = dcc.as_object_mut().expect("_meta.dcc just normalised");
+    dcc_obj.insert("dcc_type".to_string(), json!(entry.dcc_type));
+    dcc_obj.insert(
+        "instance_id".to_string(),
+        json!(entry.instance_id.to_string()),
+    );
+    dcc_obj.insert(
+        "instance_short".to_string(),
+        json!(instance_short(&entry.instance_id)),
+    );
+    dcc_obj.insert("display_id".to_string(), json!(entry.display_id()));
+}
+
+fn is_host_died_backend_error(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    lower.contains("host-died") || lower.contains("host_died")
+}
+
+fn record_host_died(
+    gs: &GatewayState,
+    entry: &ServiceEntry,
+    record: &CapabilityRecord,
+    backend_error: &str,
+) {
+    let mut reason = format!(
+        "call={} display_id={} error={}",
+        record.callable_id,
+        entry.display_id(),
+        backend_error
+    );
+    const MAX_REASON_CHARS: usize = 512;
+    if reason.chars().count() > MAX_REASON_CHARS {
+        reason = reason.chars().take(MAX_REASON_CHARS).collect();
+        reason.push_str("...");
+    }
+
+    crate::gateway::event_log::record_event(
+        &gs.event_log,
+        #[cfg(feature = "prometheus")]
+        &gs.gateway_metrics,
+        crate::gateway::event_log::EventKind::HostDied,
+        entry.dcc_type.clone(),
+        instance_short(&entry.instance_id),
+        Some(reason),
+    );
+
+    if gs.events_tx.receiver_count() > 0 {
+        let notif = serde_json::to_string(&json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/resources/updated",
+            "params": {"uri": crate::gateway::handlers::resources::GATEWAY_EVENTS_URI}
+        }))
+        .unwrap_or_default();
+        let _ = gs.events_tx.send(notif);
+    }
 }
 
 fn parse_instance_uuid(instance_hint: &str) -> Option<Uuid> {
@@ -428,6 +517,36 @@ mod unit_tests {
         assert_eq!(j["error"]["kind"], "unknown-slug");
         assert_eq!(j["error"]["message"], "x");
         assert_eq!(j["error"]["candidates"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn call_result_meta_includes_display_id() {
+        let mut entry =
+            dcc_mcp_transport::discovery::types::ServiceEntry::new("maya", "127.0.0.1", 8765);
+        entry.instance_id = Uuid::parse_str("abcdef0123456789abcdef0123456789").unwrap();
+        entry.version = Some("2026".to_string());
+        let mut result = json!({"slug": "maya.test.tool", "output": {"ok": true}});
+
+        inject_call_instance_meta(&mut result, &entry);
+
+        assert_eq!(result["_meta"]["dcc"]["dcc_type"], "maya");
+        assert_eq!(
+            result["_meta"]["dcc"]["instance_id"],
+            "abcdef01-2345-6789-abcd-ef0123456789"
+        );
+        assert_eq!(result["_meta"]["dcc"]["instance_short"], "abcdef01");
+        assert_eq!(result["_meta"]["dcc"]["display_id"], "maya@2026-abcdef01");
+    }
+
+    #[test]
+    fn host_died_classifier_matches_kebab_and_snake_case() {
+        assert!(is_host_died_backend_error(
+            r#"HTTP 502: {"error":{"kind":"host-died"}}"#
+        ));
+        assert!(is_host_died_backend_error("event=host_died"));
+        assert!(!is_host_died_backend_error(
+            "transport error: connection refused"
+        ));
     }
 
     #[test]

--- a/crates/dcc-mcp-gateway/src/gateway/event_log.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/event_log.rs
@@ -218,6 +218,9 @@ pub fn record_event(
             EventKind::AutoDeregister => {
                 metrics.inc_eviction(event.as_label());
             }
+            EventKind::HostDied => {
+                metrics.inc_eviction(event.as_label());
+            }
             EventKind::OperatorNote => {}
         }
     }

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
@@ -514,6 +514,7 @@ fn error_response(err: &ServiceError) -> (StatusCode, Json<Value>) {
         "unknown-slug" => StatusCode::NOT_FOUND,
         "ambiguous" => StatusCode::CONFLICT,
         "instance-offline" => StatusCode::SERVICE_UNAVAILABLE,
+        "host-died" => StatusCode::BAD_GATEWAY,
         "backend-error" | "schema-unavailable" => StatusCode::BAD_GATEWAY,
         _ => StatusCode::BAD_REQUEST,
     };


### PR DESCRIPTION
## Summary
- Add gateway call result `_meta.dcc` provenance with DCC type, instance UUID, short ID, and display ID.
- Classify backend `host-died` / `host_died` failures as a dedicated gateway service error.
- Record host death events in `resources://gateway/events` and map REST responses to 502.
- Harden CI npm setup by pre-installing admin UI dependencies before Rust preflight, falling back from vx npm to host npm in the gateway build script, and forcing mcporter shim creation for the e2e job.

## Validation
- `vx cargo fmt --check`
- `vx npm --prefix admin-ui ci`
- `vx cargo test -p dcc-mcp-gateway-core --lib`
- `vx cargo test -p dcc-mcp-gateway --lib`
- pre-commit hook: `cargo fmt`, `cargo clippy`