### PR TITLE
fix: retag server binary wheels as py3-none

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,7 +192,7 @@ jobs:
         working-directory: pkg/dcc-mcp-server-bin
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "maturin>=1.5,<2.0"
+          python -m pip install "maturin>=1.5,<2.0" "wheel>=0.46"
           maturin build --release --target universal2-apple-darwin --out wheels
 
       - name: Build PyPI wheel (Linux / Windows)
@@ -201,8 +201,38 @@ jobs:
         working-directory: pkg/dcc-mcp-server-bin
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "maturin>=1.5,<2.0"
+          python -m pip install "maturin>=1.5,<2.0" "wheel>=0.46"
           maturin build --release --out wheels
+
+      - name: Retag server binary wheel as Python-version independent
+        shell: bash
+        run: |
+          python - <<'PY'
+          import sys
+          import zipfile
+          from pathlib import Path
+
+          wheels = sorted(Path("pkg/dcc-mcp-server-bin/wheels").glob("dcc_mcp_server-*.whl"))
+          if not wheels:
+              print("::error::No dcc-mcp-server wheel was built", file=sys.stderr)
+              sys.exit(1)
+
+          for wheel in wheels:
+              with zipfile.ZipFile(wheel) as zf:
+                  python_extensions = [
+                      name for name in zf.namelist()
+                      if name.lower().endswith((".pyd", ".abi3.so"))
+                      or (".cpython-" in name.lower() and name.lower().endswith(".so"))
+                  ]
+              if python_extensions:
+                  print(
+                      f"::error::{wheel.name} contains CPython extension files "
+                      f"and cannot be tagged py3-none: {python_extensions}",
+                      file=sys.stderr,
+                  )
+                  sys.exit(1)
+          PY
+          python -m wheel tags --remove --python-tag=py3 --abi-tag=none pkg/dcc-mcp-server-bin/wheels/*.whl
 
       - name: Smoke-test the wheel
         if: matrix.os != 'macos-latest'
@@ -233,6 +263,11 @@ jobs:
 
           for wheel in wheels:
               with zipfile.ZipFile(wheel) as zf:
+                  wheel_name = next(
+                      name for name in zf.namelist()
+                      if name.endswith(".dist-info/WHEEL")
+                  )
+                  wheel_metadata = zf.read(wheel_name).decode("utf-8")
                   metadata_name = next(
                       name for name in zf.namelist()
                       if name.endswith(".dist-info/METADATA")
@@ -243,6 +278,14 @@ jobs:
                   print(
                       f"::error::{wheel.name} must declare Requires-Python: >=3.7 "
                       "so Maya 2022 / Python 3.7 can install dcc-mcp-server",
+                      file=sys.stderr,
+                  )
+                  sys.exit(1)
+
+              if "-py3-none-" not in wheel.name or "Tag: py3-none-" not in wheel_metadata:
+                  print(
+                      f"::error::{wheel.name} must use py3-none platform tags "
+                      "because dcc-mcp-server ships a standalone binary, not a CPython extension",
                       file=sys.stderr,
                   )
                   sys.exit(1)


### PR DESCRIPTION
## Summary
- use PyPA wheel tags to retag dcc-mcp-server binary wheels from maturin's cp311 tag to py3-none platform tags
- guard the retag step by checking the wheel does not contain CPython extension modules
- extend release metadata validation so uploaded server wheels must contain py3-none tags and Requires-Python >=3.7

## Tests
- git diff --check
- python -m wheel tags --help
- commit hooks: check yaml