### PR TITLE
feat: structure gateway yield fallback

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
@@ -26,7 +26,7 @@ pub async fn handle_gateway_yield(
 ) -> Response {
     #[derive(Deserialize)]
     struct YieldRequest {
-        challenger_version: String,
+        challenger_version: Option<String>,
     }
 
     let request: YieldRequest = match serde_json::from_slice(&body) {
@@ -40,9 +40,18 @@ pub async fn handle_gateway_yield(
         }
     };
 
-    if is_newer_version(&request.challenger_version, &gs.server_version) {
+    let challenger_version = request.challenger_version.unwrap_or_default();
+    if challenger_version.trim().is_empty() {
+        return gateway_yield_unavailable_response(
+            &gs.server_version,
+            None,
+            "missing challenger_version; cooperative gateway yield requires a newer challenger",
+        );
+    }
+
+    if is_newer_version(&challenger_version, &gs.server_version) {
         tracing::info!(
-            challenger = %request.challenger_version,
+            challenger = %challenger_version,
             current = %gs.server_version,
             "Gateway yield requested — initiating graceful handoff"
         );
@@ -51,23 +60,47 @@ pub async fn handle_gateway_yield(
             "ok": true,
             "message": format!(
                 "Gateway v{} yielding to challenger v{}. Port will be free shortly.",
-                gs.server_version, request.challenger_version
+                gs.server_version, challenger_version
             )
         }))
         .into_response()
     } else {
-        (
-            StatusCode::CONFLICT,
-            Json(json!({
-                "ok": false,
-                "error": format!(
-                    "Challenger version {} is not newer than gateway {}. Yield refused.",
-                    request.challenger_version, gs.server_version
-                )
-            })),
+        gateway_yield_unavailable_response(
+            &gs.server_version,
+            Some(&challenger_version),
+            &format!(
+                "challenger version {challenger_version} is not newer than gateway {}",
+                gs.server_version
+            ),
         )
-            .into_response()
     }
+}
+
+fn gateway_yield_unavailable_response(
+    current_version: &str,
+    challenger_version: Option<&str>,
+    reason: &str,
+) -> Response {
+    (
+        StatusCode::CONFLICT,
+        Json(json!({
+            "ok": false,
+            "success": false,
+            "capability": "cooperative_yield",
+            "fallback": "polling",
+            "current_version": current_version,
+            "challenger_version": challenger_version,
+            "error": {
+                "kind": "optional-capability-unsupported",
+                "capability": "cooperative_yield",
+                "message": format!(
+                    "Cooperative gateway yield is unavailable for this request: {reason}. \
+                     This is non-fatal; callers should poll for gateway availability."
+                ),
+            },
+        })),
+    )
+        .into_response()
 }
 
 /// `GET /instances` — return all live instances as JSON.
@@ -162,6 +195,9 @@ pub async fn handle_v1_context(State(gs): State<GatewayState>) -> impl IntoRespo
             "version": gs.server_version,
             "dcc": "gateway",
             "display_name": gs.server_name,
+            "capabilities": {
+                "cooperative_yield": true,
+            },
             "documents": [],
             "loaded_skill_count": loaded_skill_count,
             "action_count": records.len(),
@@ -519,4 +555,105 @@ fn error_response(err: &ServiceError) -> (StatusCode, Json<Value>) {
         _ => StatusCode::BAD_REQUEST,
     };
     (status, Json(service_error_to_json(err)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+    use dcc_mcp_transport::discovery::file_registry::FileRegistry;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::sync::{RwLock, broadcast, watch};
+
+    fn test_gateway_state(server_version: &str) -> GatewayState {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
+        let (yield_tx, _) = watch::channel(false);
+        let (events_tx, _) = broadcast::channel::<String>(8);
+        GatewayState {
+            registry,
+            stale_timeout: Duration::from_secs(30),
+            backend_timeout: Duration::from_secs(10),
+            async_dispatch_timeout: Duration::from_secs(60),
+            wait_terminal_timeout: Duration::from_secs(600),
+            server_name: "test".into(),
+            server_version: server_version.into(),
+            own_host: "127.0.0.1".into(),
+            own_port: 9765,
+            http_client: reqwest::Client::new(),
+            yield_tx: Arc::new(yield_tx),
+            events_tx: Arc::new(events_tx),
+            protocol_version: Arc::new(RwLock::new(None)),
+            resource_subscriptions: Arc::new(RwLock::new(HashMap::new())),
+            pending_calls: Arc::new(RwLock::new(HashMap::new())),
+            subscriber: crate::gateway::sse_subscriber::SubscriberManager::default(),
+            allow_unknown_tools: false,
+            adapter_version: None,
+            adapter_dcc: None,
+            capability_index: Arc::new(crate::gateway::capability::CapabilityIndex::new()),
+            event_log: Arc::new(crate::gateway::event_log::EventLog::new()),
+            middleware_chain: Arc::new(crate::gateway::middleware::MiddlewareChain::new()),
+            #[cfg(feature = "prometheus")]
+            gateway_metrics: Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
+        }
+    }
+
+    async fn response_json(resp: Response) -> (StatusCode, Value) {
+        let status = resp.status();
+        let bytes = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
+        let body = serde_json::from_slice(&bytes).unwrap();
+        (status, body)
+    }
+
+    #[tokio::test]
+    async fn gateway_yield_missing_challenger_is_structured_optional_capability() {
+        let (status, body) = response_json(
+            handle_gateway_yield(
+                State(test_gateway_state("1.2.3")),
+                axum::body::Bytes::from_static(b"{}"),
+            )
+            .await,
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(body["success"], false);
+        assert_eq!(body["fallback"], "polling");
+        assert_eq!(body["error"]["kind"], "optional-capability-unsupported");
+        assert_eq!(body["error"]["capability"], "cooperative_yield");
+    }
+
+    #[tokio::test]
+    async fn gateway_yield_same_version_is_structured_optional_capability() {
+        let (status, body) = response_json(
+            handle_gateway_yield(
+                State(test_gateway_state("1.2.3")),
+                axum::body::Bytes::from_static(br#"{"challenger_version":"1.2.3"}"#),
+            )
+            .await,
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(body["current_version"], "1.2.3");
+        assert_eq!(body["challenger_version"], "1.2.3");
+        assert_eq!(body["error"]["kind"], "optional-capability-unsupported");
+    }
+
+    #[tokio::test]
+    async fn gateway_yield_newer_challenger_still_accepts() {
+        let (status, body) = response_json(
+            handle_gateway_yield(
+                State(test_gateway_state("1.2.3")),
+                axum::body::Bytes::from_static(br#"{"challenger_version":"1.2.4"}"#),
+            )
+            .await,
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["ok"], true);
+    }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/runner.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/runner.rs
@@ -541,10 +541,16 @@ impl GatewayRunner {
                         "Cooperative yield accepted — waiting for port to free up"
                     );
                 } else {
+                    let status = resp.status();
+                    let body_text = resp.text().await.unwrap_or_default();
+                    let detail = cooperative_yield_fallback_detail(status, &body_text);
                     tracing::info!(
-                        status = %resp.status(),
-                        "Cooperative yield not supported by gateway v{gw_ver} \
-                         (normal for older versions) — polling for port"
+                        status = %status,
+                        gateway = %gw_ver,
+                        error_kind = detail.error_kind.as_deref().unwrap_or("unknown"),
+                        fallback = "polling",
+                        "Cooperative yield unavailable or refused ({}) — polling for port",
+                        detail.message
                     );
                 }
             }
@@ -643,5 +649,78 @@ impl GatewayRunner {
         });
 
         handle.abort_handle()
+    }
+}
+
+struct CooperativeYieldFallbackDetail {
+    error_kind: Option<String>,
+    message: String,
+}
+
+fn cooperative_yield_fallback_detail(
+    status: reqwest::StatusCode,
+    body: &str,
+) -> CooperativeYieldFallbackDetail {
+    let parsed = serde_json::from_str::<serde_json::Value>(body).ok();
+    let error_kind = parsed
+        .as_ref()
+        .and_then(|value| value.pointer("/error/kind"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned);
+    let message = parsed
+        .as_ref()
+        .and_then(|value| value.pointer("/error/message"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned)
+        .or_else(|| {
+            parsed
+                .as_ref()
+                .and_then(|value| value.get("error"))
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+        })
+        .unwrap_or_else(|| match status {
+            reqwest::StatusCode::NOT_FOUND | reqwest::StatusCode::METHOD_NOT_ALLOWED => {
+                "gateway does not expose /gateway/yield; this is a non-fatal optional capability miss".to_string()
+            }
+            _ => {
+                "gateway returned a non-success response to the optional yield probe".to_string()
+            }
+        });
+
+    CooperativeYieldFallbackDetail {
+        error_kind,
+        message,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cooperative_yield_fallback_reads_structured_optional_capability() {
+        let detail = cooperative_yield_fallback_detail(
+            reqwest::StatusCode::CONFLICT,
+            r#"{"error":{"kind":"optional-capability-unsupported","message":"poll instead"}}"#,
+        );
+
+        assert_eq!(
+            detail.error_kind.as_deref(),
+            Some("optional-capability-unsupported")
+        );
+        assert_eq!(detail.message, "poll instead");
+    }
+
+    #[test]
+    fn cooperative_yield_fallback_legacy_404_is_non_fatal() {
+        let detail = cooperative_yield_fallback_detail(reqwest::StatusCode::NOT_FOUND, "");
+
+        assert_eq!(detail.error_kind, None);
+        assert!(
+            detail.message.contains("optional capability miss"),
+            "legacy detail should mark the fallback as optional: {}",
+            detail.message
+        );
     }
 }

--- a/tests/vrs/README.md
+++ b/tests/vrs/README.md
@@ -84,6 +84,7 @@ python scripts/vrs_replay.py --base-url http://127.0.0.1:1 --dry-run --trace tes
 | `traces/core-994-meta-tools-do-not-dominate-ranking.jsonl` | Yes (any DCC) | Domain queries top-1 MUST be a domain tool, never `project.*` / `dcc_capability_manifest` / `recipes__*` / `diagnostics__*` (core#994). |
 | `traces/core-995-list-skills-respects-limit.jsonl` | Yes (any DCC) | `POST /v1/list_skills` MUST honour `limit` and `fields` and report a `truncated` flag (core#995). |
 | `traces/core-996-instance-offline-carries-previous-status.jsonl` | No | `instance-offline` (or `unknown-slug`) error envelope MUST carry `previous_status` so agents can distinguish manual restart from crash (core#996). |
+| `traces/core-1037-gateway-yield-unsupported-envelope.jsonl` | No | `POST /gateway/yield` unsupported/invalid optional-capability path MUST return a structured envelope that tells runners to poll instead of treating it as a crash. |
 | `traces/gateway-multi-instance-stress.jsonl` | Yes (≥3 live instances) | Skips unless `GET /v1/instances` reports `total >= 3`; then bursts health/instances/readyz/context/search to catch registry/probe regressions under load. |
 
 ## CI policy (recommended)
@@ -102,3 +103,4 @@ python scripts/vrs_replay.py --base-url http://127.0.0.1:1 --dry-run --trace tes
 - core [#994](https://github.com/loonghao/dcc-mcp-core/issues/994) — search ranking dominated by meta-tools
 - core [#995](https://github.com/loonghao/dcc-mcp-core/issues/995) — list_skills returns full metadata for every skill
 - core [#996](https://github.com/loonghao/dcc-mcp-core/issues/996) — instance-offline envelope must carry restart cause
+- core [#1037](https://github.com/loonghao/dcc-mcp-core/issues/1037) — cooperative gateway yield fallback should be structured and non-alarming

--- a/tests/vrs/traces/core-1037-gateway-yield-unsupported-envelope.jsonl
+++ b/tests/vrs/traces/core-1037-gateway-yield-unsupported-envelope.jsonl
@@ -1,0 +1,2 @@
+{"_vrs": {"version": 1}, "trace_id": "core-1037", "title": "Gateway yield unsupported path returns structured optional-capability envelope"}
+{"id": "yield_missing_challenger_version", "http": {"method": "POST", "path": "/gateway/yield", "json": {}}, "expect": {"status": 409, "json_subset": {"success": false, "capability": "cooperative_yield", "fallback": "polling", "error": {"kind": "optional-capability-unsupported", "capability": "cooperative_yield"}}}}


### PR DESCRIPTION
## Summary

- Return a structured optional-capability envelope for unsupported `POST /gateway/yield` requests.
- Update challenger fallback logging so polling is clearly marked as non-fatal.
- Add a VRS trace for the core#1037 unsupported yield envelope path.

## Validation

- `vx cargo fmt --all`
- `python scripts\vrs_replay.py --base-url http://127.0.0.1:1 --dry-run --trace tests\vrs\traces\core-1037-gateway-yield-unsupported-envelope.jsonl`
- `vx cargo test -p dcc-mcp-gateway`