### PR TITLE
feat: add cli gateway clawhub skill

### DIFF
--- a/.github/clawhub-skills.json
+++ b/.github/clawhub-skills.json
@@ -2,5 +2,9 @@
   {
     "path": "skills/dcc-rest-gateway",
     "slug": "dcc-rest-gateway"
+  },
+  {
+    "path": "skills/dcc-cli-gateway",
+    "slug": "dcc-cli-gateway"
   }
 ]

--- a/.github/workflows/clawhub.yml
+++ b/.github/workflows/clawhub.yml
@@ -55,6 +55,7 @@ jobs:
         run: |
           mkdir -p dist/skills
           python scripts/package_openclaw_skill.py skills/dcc-rest-gateway dist/skills
+          python scripts/package_openclaw_skill.py skills/dcc-cli-gateway dist/skills
 
       - name: Upload packaged skill artifacts
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -1,13 +1,20 @@
 # dcc-mcp-core
 
-[![PyPI](https://img.shields.io/pypi/v/dcc-mcp-core)](https://pypi.org/project/dcc-mcp-core/)
-[![Python](https://img.shields.io/pypi/pyversions/dcc-mcp-core)](https://www.python.org/)
-[![License](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
-[![Downloads](https://static.pepy.tech/badge/dcc-mcp-core)](https://pepy.tech/project/dcc-mcp-core)
-[![Coverage](https://img.shields.io/codecov/c/github/loonghao/dcc-mcp-core)](https://codecov.io/gh/loonghao/dcc-mcp-core)
-[![Tests](https://img.shields.io/github/actions/workflow/status/loonghao/dcc-mcp-core/ci.yml?branch=main&label=Tests)](https://github.com/loonghao/dcc-mcp-core/actions)
+[![Core PyPI](https://img.shields.io/pypi/v/dcc-mcp-core?label=core%20PyPI)](https://pypi.org/project/dcc-mcp-core/)
+[![Server PyPI](https://img.shields.io/pypi/v/dcc-mcp-server?label=server%20PyPI)](https://pypi.org/project/dcc-mcp-server/)
+[![Python](https://img.shields.io/pypi/pyversions/dcc-mcp-core?label=Python)](https://www.python.org/)
+[![License](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
+[![CI](https://img.shields.io/github/actions/workflow/status/loonghao/dcc-mcp-core/ci.yml?branch=main&label=CI)](https://github.com/loonghao/dcc-mcp-core/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/codecov/c/github/loonghao/dcc-mcp-core?label=coverage)](https://codecov.io/gh/loonghao/dcc-mcp-core)
+[![GitHub Release](https://img.shields.io/github/v/release/loonghao/dcc-mcp-core?label=GitHub%20release)](https://github.com/loonghao/dcc-mcp-core/releases)
+[![Release Downloads](https://img.shields.io/github/downloads/loonghao/dcc-mcp-core/total?label=release%20downloads)](https://github.com/loonghao/dcc-mcp-core/releases)
+[![Core Downloads](https://img.shields.io/pypi/dm/dcc-mcp-core?label=core%20PyPI%20downloads)](https://pypistats.org/packages/dcc-mcp-core)
+[![Core Pepy](https://static.pepy.tech/badge/dcc-mcp-core)](https://pepy.tech/project/dcc-mcp-core)
+[![Server Downloads](https://img.shields.io/pypi/dm/dcc-mcp-server?label=server%20PyPI%20downloads)](https://pypistats.org/packages/dcc-mcp-server)
+[![CLI Linux](https://img.shields.io/github/downloads/loonghao/dcc-mcp-core/latest/dcc-mcp-cli-linux-x86_64?label=cli%20linux)](https://github.com/loonghao/dcc-mcp-core/releases/latest)
+[![CLI Windows](https://img.shields.io/github/downloads/loonghao/dcc-mcp-core/latest/dcc-mcp-cli-windows-x86_64.exe?label=cli%20windows)](https://github.com/loonghao/dcc-mcp-core/releases/latest)
+[![CLI macOS](https://img.shields.io/github/downloads/loonghao/dcc-mcp-core/latest/dcc-mcp-cli-macos-universal2?label=cli%20macOS)](https://github.com/loonghao/dcc-mcp-core/releases/latest)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
-[![Latest Version](https://img.shields.io/github/v/tag/loonghao/dcc-mcp-core?label=Latest%20Version)](https://github.com/loonghao/dcc-mcp-core/releases)
 
 [中文](README_zh.md) | English
 
@@ -80,37 +87,42 @@ AI-friendly docs: [AGENTS.md](AGENTS.md) · [`docs/guide/agents-reference.md`](d
 ## Architecture: The Current Stack
 
 ```
-+-----------------------------------------------------------------+
-|  AI Agent (Claude, GPT, etc.)                                   |
-|  Uses MCP tools or REST /v1/* through one gateway endpoint       |
-+-------------------------------+---------------------------------+
-                                |
-                        MCP Streamable HTTP + REST
-                                |
-+-------------------------------v---------------------------------+
-|  Elected Gateway (Rust / HTTP)                                  |
-|  +-- Dynamic capability search / describe / call                |
-|  +-- Instance registry, admin UI, audit logs, traces            |
-|  +-- Version-aware election and failover                        |
-|  +-- Job lifecycle, workflows, artefacts, resources             |
-+-------------------------------+---------------------------------+
-                                |
-                 Per-DCC MCP servers, IPC, or WebSocket bridges
-                                |
-          +---------------------+---------------------+
-          |                     |                     |
-  +-------v-------+     +-------v-------+     +-------v-------+
-  |  Maya Adapter  |     | Blender Adapter|     | Houdini Adapter|
-  |  (_core.pyd)   |     |  (_core.so)    |     |  (_core.so)   |
-  +-------+--------+     +-------+--------+     +-------+-------+
-          |                      |                      |
-    Python 3.7+             Python 3.7+            Python 3.7+
-    (zero deps)             (zero deps)            (zero deps)
++--------------------------------------------------------------------------------+
+| Agent / operator surfaces                                                       |
+| - MCP clients: search_tools -> describe_tool -> call_tool                       |
+| - CLI users: dcc-mcp-cli list/search/describe/call                              |
+| - ClawHub/OpenClaw skills: dcc-cli-gateway or dcc-rest-gateway                  |
+| - CI and custom clients: REST /v1/*                                             |
++----------------------------------------+---------------------------------------+
+                                         |
+                       MCP Streamable HTTP + REST /v1/*
+                                         |
++----------------------------------------v---------------------------------------+
+| Elected gateway (Rust HTTP control plane)                                       |
+| - Minimal MCP tools/list: discovery and dispatch primitives only                |
+| - Dynamic capability search, schema describe, single/batch call routing         |
+| - Instance registry, TCP liveness probes, version-aware election, failover      |
+| - Admin UI, OpenAPI, audit logs, traces, metrics, jobs, workflows, artefacts    |
++----------------------------------------+---------------------------------------+
+                                         |
+                    Gateway-routed calls to owning per-DCC server
+                                         |
+        +-------------------------------+-------------------------------+
+        |                               |                               |
++-------v--------+              +-------v--------+              +-------v--------+
+| Maya adapter   |              | Blender adapter|              | Custom host    |
+| MCP + REST     |              | MCP + REST     |              | MCP + REST     |
+| Skills catalog |              | Skills catalog |              | Skills catalog |
++-------+--------+              +-------+--------+              +-------+--------+
+        |                               |                               |
+  Host bridge / UI-thread pump    Host bridge / add-on           Host RPC / IPC
+        |                               |                               |
+   Maya Python APIs                 Blender Python APIs           Studio APIs
 ```
 
-- **Agent surface**: MCP clients use `search_tools` -> `describe_tool` -> `call_tool`; non-MCP clients use the matching `/v1/search`, `/v1/describe`, `/v1/call`, and `/v1/call_batch` endpoints.
-- **Gateway surface**: One elected gateway aggregates per-DCC servers, exposes the admin UI, records audit/trace data, and keeps the public tool list small.
-- **DCC surface**: Embedded Python adapters, standalone `dcc-mcp-server`, and WebSocket bridges all register the same structured Skills-derived capabilities.
+- **Agent surface**: MCP clients use a bounded discovery/dispatch tool set; CLI and skill users can reach the same gateway through `dcc-mcp-cli` or `/v1/*`.
+- **Gateway surface**: One elected gateway aggregates per-DCC servers, keeps `tools/list` small, exposes OpenAPI/Admin UI, records audit/trace data, and routes by tool slug.
+- **DCC surface**: Embedded adapters, standalone `dcc-mcp-server`, and bridge-based hosts all expose the same Skills-derived capabilities over MCP + REST.
 
 ---
 
@@ -120,10 +132,10 @@ AI-friendly docs: [AGENTS.md](AGENTS.md) · [`docs/guide/agents-reference.md`](d
 
 ```bash
 # One-command CLI install from GitHub Releases
-curl -fsSL https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.sh | sh
+curl -fsSL https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.sh | bash
 
 # Windows PowerShell
-powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+powershell -c "irm https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
 
 # From PyPI (pre-built wheels for Python 3.7+)
 pip install dcc-mcp-core
@@ -369,7 +381,7 @@ That's it — no Python glue code, just `SKILL.md` + `tools.yaml` + scripts.
 | `.mel` | MEL (Maya) | Via DCC adapter |
 | `.ms` | MaxScript | Via DCC adapter |
 | `.bat`, `.cmd` | Batch | `cmd /c` |
-| `.sh`, `.bash` | Shell | `bash` |
+| `.sh`, `.bash` | bashell | `bash` |
 | `.ps1` | PowerShell | `powershell -File` |
 | `.js`, `.jsx` | JavaScript | `node` |
 | `.ts` | TypeScript | `node` (via ts-node or tsx) |
@@ -450,9 +462,9 @@ tools/list response (Maya session, nothing loaded yet):
 
 ---
 
-## Architecture Overview — 35 Workspace Members
+## Architecture Overview — 38 Workspace Members
 
-`dcc-mcp-core` is organised as a **Rust workspace of 35 members** (34 functional crates + `workspace-hack`), compiled into a single native Python extension (`_core`) via PyO3 / maturin. The root `Cargo.toml` is the source of truth for membership. Selected crates:
+`dcc-mcp-core` is organised as a **Rust workspace of 38 members** (37 functional crates + `workspace-hack`). Most library crates compile into the native Python extension (`_core`) via PyO3 / maturin, while operator-facing crates such as `dcc-mcp-cli`, `dcc-mcp-server`, and tunnel binaries also ship as release assets. The root `Cargo.toml` is the source of truth for membership. Selected crates:
 
 | Crate | Responsibility | Key Types |
 |---|---|---|
@@ -477,6 +489,7 @@ tools/list response (Maya session, nothing loaded yet):
 | `dcc-mcp-telemetry` | Observability | `TelemetryConfig`, `ToolRecorder`, `ToolMetrics`, optional Prometheus |
 | `dcc-mcp-usd` | USD integration | `UsdStage`, `UsdPrim`, `scene_info_json_to_stage` |
 | `dcc-mcp-http` | MCP Streamable HTTP facade | `McpHttpServer`, `McpHttpConfig`, `McpServerHandle`, PyO3 bindings, compatibility re-exports |
+| `dcc-mcp-cli` | Client control-plane CLI | `dcc-mcp-cli list/search/describe/call/install` |
 | `dcc-mcp-server` | Binary entry point | `dcc-mcp-server` CLI, gateway runner |
 | `dcc-mcp-workflow` | Workflow engine (opt-in) | `WorkflowSpec`, `WorkflowExecutor`, `WorkflowHost`, `StepPolicy`, `RetryPolicy` |
 | `dcc-mcp-scheduler` | Cron + webhook scheduler (opt-in) | `ScheduleSpec`, `TriggerSpec`, `SchedulerService`, HMAC verification |

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,13 +1,20 @@
 # dcc-mcp-core
 
-[![PyPI](https://img.shields.io/pypi/v/dcc-mcp-core)](https://pypi.org/project/dcc-mcp-core/)
-[![Python](https://img.shields.io/pypi/pyversions/dcc-mcp-core)](https://www.python.org/)
-[![License](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
-[![Downloads](https://static.pepy.tech/badge/dcc-mcp-core)](https://pepy.tech/project/dcc-mcp-core)
-[![Coverage](https://img.shields.io/codecov/c/github/loonghao/dcc-mcp-core)](https://codecov.io/gh/loonghao/dcc-mcp-core)
-[![Tests](https://img.shields.io/github/actions/workflow/status/loonghao/dcc-mcp-core/ci.yml?branch=main&label=Tests)](https://github.com/loonghao/dcc-mcp-core/actions)
+[![Core PyPI](https://img.shields.io/pypi/v/dcc-mcp-core?label=core%20PyPI)](https://pypi.org/project/dcc-mcp-core/)
+[![Server PyPI](https://img.shields.io/pypi/v/dcc-mcp-server?label=server%20PyPI)](https://pypi.org/project/dcc-mcp-server/)
+[![Python](https://img.shields.io/pypi/pyversions/dcc-mcp-core?label=Python)](https://www.python.org/)
+[![License](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
+[![CI](https://img.shields.io/github/actions/workflow/status/loonghao/dcc-mcp-core/ci.yml?branch=main&label=CI)](https://github.com/loonghao/dcc-mcp-core/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/codecov/c/github/loonghao/dcc-mcp-core?label=coverage)](https://codecov.io/gh/loonghao/dcc-mcp-core)
+[![GitHub Release](https://img.shields.io/github/v/release/loonghao/dcc-mcp-core?label=GitHub%20release)](https://github.com/loonghao/dcc-mcp-core/releases)
+[![Release Downloads](https://img.shields.io/github/downloads/loonghao/dcc-mcp-core/total?label=release%20downloads)](https://github.com/loonghao/dcc-mcp-core/releases)
+[![Core Downloads](https://img.shields.io/pypi/dm/dcc-mcp-core?label=core%20PyPI%20downloads)](https://pypistats.org/packages/dcc-mcp-core)
+[![Core Pepy](https://static.pepy.tech/badge/dcc-mcp-core)](https://pepy.tech/project/dcc-mcp-core)
+[![Server Downloads](https://img.shields.io/pypi/dm/dcc-mcp-server?label=server%20PyPI%20downloads)](https://pypistats.org/packages/dcc-mcp-server)
+[![CLI Linux](https://img.shields.io/github/downloads/loonghao/dcc-mcp-core/latest/dcc-mcp-cli-linux-x86_64?label=cli%20linux)](https://github.com/loonghao/dcc-mcp-core/releases/latest)
+[![CLI Windows](https://img.shields.io/github/downloads/loonghao/dcc-mcp-core/latest/dcc-mcp-cli-windows-x86_64.exe?label=cli%20windows)](https://github.com/loonghao/dcc-mcp-core/releases/latest)
+[![CLI macOS](https://img.shields.io/github/downloads/loonghao/dcc-mcp-core/latest/dcc-mcp-cli-macos-universal2?label=cli%20macOS)](https://github.com/loonghao/dcc-mcp-core/releases/latest)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
-[![Latest Version](https://img.shields.io/github/v/tag/loonghao/dcc-mcp-core?label=Latest%20Version)](https://github.com/loonghao/dcc-mcp-core/releases)
 
 [English](README.md) | 中文
 
@@ -72,37 +79,42 @@ AI 友好文档：[AGENTS.md](AGENTS.md) · [`docs/guide/agents-reference.md`](d
 ## 架构：当前栈
 
 ```
-+-----------------------------------------------------------------+
-|  AI Agent (Claude, GPT, 等)                                     |
-|  通过 MCP tools 或 REST /v1/* 访问统一网关端点                  |
-+-------------------------------+---------------------------------+
-                                |
-                        MCP Streamable HTTP + REST
-                                |
-+-------------------------------v---------------------------------+
-|  Elected Gateway (Rust / HTTP)                                  |
-|  +-- 动态能力 search / describe / call                           |
-|  +-- 实例注册表、Admin UI、审计日志、trace                       |
-|  +-- 版本感知选举与故障切换                                      |
-|  +-- Job 生命周期、workflow、artefact、resource                  |
-+-------------------------------+---------------------------------+
-                                |
-                 Per-DCC MCP server、IPC 或 WebSocket bridge
-                                |
-          +---------------------+---------------------+
-          |                     |                     |
-  +-------v-------+     +-------v-------+     +-------v-------+
-  |  Maya 适配器   |     | Blender 适配器 |     | Houdini 适配器|
-  |  (_core.pyd)   |     |  (_core.so)    |     |  (_core.so)   |
-  +-------+--------+     +-------+--------+     +-------+-------+
-          |                      |                      |
-    Python 3.7+             Python 3.7+            Python 3.7+
-    (零依赖)                (零依赖)                (零依赖)
++--------------------------------------------------------------------------------+
+| Agent / operator surfaces                                                       |
+| - MCP clients: search_tools -> describe_tool -> call_tool                       |
+| - CLI users: dcc-mcp-cli list/search/describe/call                              |
+| - ClawHub/OpenClaw skills: dcc-cli-gateway or dcc-rest-gateway                  |
+| - CI and custom clients: REST /v1/*                                             |
++----------------------------------------+---------------------------------------+
+                                         |
+                       MCP Streamable HTTP + REST /v1/*
+                                         |
++----------------------------------------v---------------------------------------+
+| Elected gateway (Rust HTTP control plane)                                       |
+| - Minimal MCP tools/list: discovery and dispatch primitives only                |
+| - Dynamic capability search, schema describe, single/batch call routing         |
+| - Instance registry, TCP liveness probes, version-aware election, failover      |
+| - Admin UI, OpenAPI, audit logs, traces, metrics, jobs, workflows, artefacts    |
++----------------------------------------+---------------------------------------+
+                                         |
+                    Gateway-routed calls to owning per-DCC server
+                                         |
+        +-------------------------------+-------------------------------+
+        |                               |                               |
++-------v--------+              +-------v--------+              +-------v--------+
+| Maya adapter   |              | Blender adapter|              | Custom host    |
+| MCP + REST     |              | MCP + REST     |              | MCP + REST     |
+| Skills catalog |              | Skills catalog |              | Skills catalog |
++-------+--------+              +-------+--------+              +-------+--------+
+        |                               |                               |
+  Host bridge / UI-thread pump    Host bridge / add-on           Host RPC / IPC
+        |                               |                               |
+   Maya Python APIs                 Blender Python APIs           Studio APIs
 ```
 
-- **Agent 表面**：MCP 客户端使用 `search_tools` -> `describe_tool` -> `call_tool`；非 MCP 客户端使用等价的 `/v1/search`、`/v1/describe`、`/v1/call`、`/v1/call_batch`。
-- **Gateway 表面**：一个获选网关汇聚 per-DCC servers，暴露 Admin UI，记录 audit/trace，并让公开工具列表保持很小。
-- **DCC 表面**：嵌入式 Python 适配器、独立 `dcc-mcp-server`、WebSocket bridge 都注册同一套结构化、由 Skills 派生的能力。
+- **Agent 表面**：MCP 客户端使用有界的发现/调度工具集；CLI 与 skill 用户通过 `dcc-mcp-cli` 或 `/v1/*` 访问同一网关。
+- **Gateway 表面**：一个获选网关汇聚 per-DCC servers，让 `tools/list` 保持很小，暴露 OpenAPI/Admin UI，记录 audit/trace，并按 tool slug 路由。
+- **DCC 表面**：嵌入式适配器、独立 `dcc-mcp-server`、bridge 型宿主都通过 MCP + REST 暴露同一套 Skills 派生能力。
 
 ---
 
@@ -112,10 +124,10 @@ AI 友好文档：[AGENTS.md](AGENTS.md) · [`docs/guide/agents-reference.md`](d
 
 ```bash
 # 从 GitHub Release 一键安装 CLI
-curl -fsSL https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.sh | sh
+curl -fsSL https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.sh | bash
 
 # Windows PowerShell
-powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+powershell -c "irm https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
 
 # 从 PyPI 安装（Python 3.7+ 预构建 wheel）
 pip install dcc-mcp-core
@@ -361,7 +373,7 @@ handle = server.start()
 | `.mel` | MEL (Maya) | 通过 DCC 适配器 |
 | `.ms` | MaxScript | 通过 DCC 适配器 |
 | `.bat`, `.cmd` | Batch | `cmd /c` |
-| `.sh`, `.bash` | Shell | `bash` |
+| `.sh`, `.bash` | bashell | `bash` |
 | `.ps1` | PowerShell | `powershell -File` |
 | `.js`, `.jsx` | JavaScript | `node` |
 | `.ts` | TypeScript | `node`（通过 ts-node 或 tsx） |
@@ -442,9 +454,9 @@ tools/list 响应（Maya 会话、尚未加载任何 skill）：
 
 ---
 
-## 架构总览 —— 35 个 Workspace 成员
+## 架构总览 —— 38 个 Workspace 成员
 
-`dcc-mcp-core` 组织为 **35 个成员的 Rust workspace**（34 个功能 crate + `workspace-hack`），通过 PyO3 / maturin 编译为单个原生 Python 扩展（`_core`）。根 `Cargo.toml` 是 workspace 成员列表的唯一来源。精选 crate：
+`dcc-mcp-core` 组织为 **38 个成员的 Rust workspace**（37 个功能 crate + `workspace-hack`）。大多数库 crate 通过 PyO3 / maturin 编译进原生 Python 扩展（`_core`），`dcc-mcp-cli`、`dcc-mcp-server` 与 tunnel 二进制也会作为面向用户的 release assets 发布。根 `Cargo.toml` 是 workspace 成员列表的唯一来源。精选 crate：
 
 | Crate | 职责 | 关键类型 |
 |---|---|---|
@@ -469,6 +481,7 @@ tools/list 响应（Maya 会话、尚未加载任何 skill）：
 | `dcc-mcp-telemetry` | 可观测性 | `TelemetryConfig`、`ToolRecorder`、`ToolMetrics`、可选 Prometheus |
 | `dcc-mcp-usd` | USD 集成 | `UsdStage`、`UsdPrim`、`scene_info_json_to_stage` |
 | `dcc-mcp-http` | MCP Streamable HTTP facade | `McpHttpServer`、`McpHttpConfig`、`McpServerHandle`、PyO3 bindings、兼容重导出 |
+| `dcc-mcp-cli` | 客户端控制面 CLI | `dcc-mcp-cli list/search/describe/call/install` |
 | `dcc-mcp-server` | 二进制入口 | `dcc-mcp-server` CLI、网关 runner |
 | `dcc-mcp-workflow` | 工作流引擎（可选） | `WorkflowSpec`、`WorkflowExecutor`、`WorkflowHost`、`StepPolicy`、`RetryPolicy` |
 | `dcc-mcp-scheduler` | Cron + Webhook 调度器（可选） | `ScheduleSpec`、`TriggerSpec`、`SchedulerService`、HMAC 校验 |

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -1,41 +1,50 @@
 # Architecture
 
-DCC-MCP-Core is a **Rust-powered DCC automation framework** with Python bindings via PyO3, designed for AI-assisted workflows. It solves MCP's context explosion and provides zero-code skill registration.
+DCC-MCP-Core is a **Rust-powered DCC automation framework** with Python bindings via PyO3, designed for AI-assisted workflows. The current architecture is gateway-first: MCP clients, CLI users, ClawHub/OpenClaw skills, CI, and custom HTTP clients all converge on a small discovery/dispatch control plane instead of receiving every backend tool in `tools/list`.
 
 ## High-Level Design
 
-### Three-Layer Stack
+### Current Gateway-First Stack
 
 ```
-┌──────────────────────────────┐
-│ AI Agent (Claude, GPT, etc.) │ ← talks MCP via HTTP
-└──────────────┬───────────────┘
-               │ MCP Streamable HTTP
-               ▼
-┌──────────────────────────────┐
-│ Gateway Server (Rust core)   │ ← coordinates tool discovery
-│ - Version-aware election     │   and session routing
-│ - Session isolation          │
-│ - Tool scoping               │
-└──────────┬──────────────────┘
-           │ IPC (fast, zero-copy)
-           │
-     ┌─────┴──────┬────────┬────────┐
-     ▼            ▼        ▼        ▼
-  ┌──────┐   ┌──────┐  ┌──────┐  ┌──────┐
-  │ Maya │   │Blend │  │Houd  │  │Photo │
-  │ (v25)│   │ (3.9)│  │(21)  │  │(2025)│
-  └──────┘   └──────┘  └──────┘  └──────┘
-   Instances with embedded Skills system
++--------------------------------------------------------------------------------+
+| Agent / operator surfaces                                                       |
+| - MCP clients: search_tools -> describe_tool -> call_tool                       |
+| - CLI users: dcc-mcp-cli list/search/describe/call                              |
+| - ClawHub/OpenClaw skills: dcc-cli-gateway or dcc-rest-gateway                  |
+| - CI and custom clients: REST /v1/*                                             |
++----------------------------------------+---------------------------------------+
+                                         |
+                       MCP Streamable HTTP + REST /v1/*
+                                         |
++----------------------------------------v---------------------------------------+
+| Elected gateway (Rust HTTP control plane)                                       |
+| - Minimal MCP tools/list: discovery and dispatch primitives only                |
+| - Dynamic capability search, schema describe, single/batch call routing         |
+| - Instance registry, TCP liveness probes, version-aware election, failover      |
+| - Admin UI, OpenAPI, audit logs, traces, metrics, jobs, workflows, artefacts    |
++----------------------------------------+---------------------------------------+
+                                         |
+                    Gateway-routed calls to owning per-DCC server
+                                         |
+        +-------------------------------+-------------------------------+
+        |                               |                               |
++-------v--------+              +-------v--------+              +-------v--------+
+| Maya adapter   |              | Blender adapter|              | Custom host    |
+| MCP + REST     |              | MCP + REST     |              | MCP + REST     |
+| Skills catalog |              | Skills catalog |              | Skills catalog |
++-------+--------+              +-------+--------+              +-------+--------+
+        |                               |                               |
+  Host bridge / UI-thread pump    Host bridge / add-on           Host RPC / IPC
 ```
 
 ### Core Principles
 
-1. **Session Isolation** — Each AI session pinned to one DCC instance (prevents context explosion)
-2. **Version-Aware Election** — Newest DCC automatically becomes gateway (no manual failover)
-3. **Zero-Code Skills** — SKILL.md + scripts/ = instant MCP tools (no Python glue)
-4. **Structured Results** — Every tool returns `{success, message, context, next_steps}` (AI-friendly)
-5. **Progressive Discovery** — Tools scoped by DCC/scope/product (71% context reduction)
+1. **Minimal MCP surface** — `tools/list` exposes discovery and dispatch primitives; backend tools are found through search/describe/call.
+2. **Version-aware election** — The gateway is elected and can fail over without hard-coding a single DCC host.
+3. **Zero-code skills** — `SKILL.md` + sibling YAML/scripts become MCP tools and REST-callable capabilities.
+4. **Structured results** — Every tool returns AI-friendly success/error, message, context, and follow-up hints.
+5. **Progressive discovery** — Capabilities are scoped by DCC, instance, scene, product, and skill state.
 
 ## The Library
 
@@ -65,6 +74,7 @@ dcc-mcp-core (workspace root)
 ├── dcc-mcp-http-server   # Reusable HTTP runtime support
 ├── dcc-mcp-http-py       # PyO3 binding boundary for HTTP APIs
 ├── dcc-mcp-http          # Embedded MCP HTTP facade + compatibility re-exports
+├── dcc-mcp-cli           # Client control-plane CLI for gateway REST
 ├── dcc-mcp-server        # Binary entry point and gateway runner
 ├── dcc-mcp-logging       # Rolling file logging
 ├── dcc-mcp-paths         # Platform path helpers
@@ -116,6 +126,8 @@ dcc-mcp-http-server ← dcc-mcp-http-types, dcc-mcp-jsonrpc, dcc-mcp-job, dcc-mc
 dcc-mcp-http ← dcc-mcp-http-types, dcc-mcp-http-server, dcc-mcp-gateway, dcc-mcp-skill-rest
        ↓
 dcc-mcp-server ← dcc-mcp-http
+
+dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 ```
 
 ## Crate Responsibilities
@@ -412,6 +424,10 @@ dcc-mcp-server ← dcc-mcp-http
 ### dcc-mcp-server
 
 **Purpose**: Binary entry point (`dcc-mcp-server` CLI) that assembles and runs the full MCP server with gateway support.
+
+### dcc-mcp-cli
+
+**Purpose**: Client-side control-plane CLI for users, CI, and shell-capable skills. It talks to the gateway REST surface for `health`, `list`, `search`, `describe`, `call`, and adapter install planning; it does not host skills or replace per-DCC servers.
 
 **Key Components**:
 - `main.rs` — CLI entry point using `GatewayRunner` and `McpHttpServer` library APIs

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -10,10 +10,10 @@ same configuration surface.
 assets on every release. The CLI can be installed directly from a URL:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.sh | sh
+curl -fsSL https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.sh | bash
 
 # Windows PowerShell
-powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+powershell -c "irm https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
 ```
 
 Pin a release by setting `DCC_MCP_VERSION=v0.17.4` or passing
@@ -110,7 +110,7 @@ instances that the winner aggregates.
 | `--gateway-port` | `DCC_MCP_GATEWAY_PORT` | `9765` | Well-known port to compete for. `0` disables the gateway role entirely and therefore disables admin too. |
 | `--no-admin` | `DCC_MCP_NO_ADMIN` | `false` | Disable the read-only Admin UI on the elected gateway. Admin is enabled by default when a process wins the gateway role. |
 | `--admin-path` | `DCC_MCP_ADMIN_PATH` | `/admin` | URL prefix for the read-only Admin UI and its JSON APIs. |
-| `--registry-dir` | `DCC_MCP_REGISTRY_DIR` | platform temp dir | Shared `FileRegistry` directory. |
+| `--registry-dir` | `DCC_MCP_REGISTRY_DIR` | platform temp dir | shared `FileRegistry` directory. |
 | `--stale-timeout-secs` | `DCC_MCP_STALE_TIMEOUT` | `30` | Seconds without heartbeat before an instance is considered stale. |
 | `--app-version` | `DCC_MCP_APP_VERSION` | — | App version (e.g., `"2024.2"`); recorded in the registry. |
 | `--scene` | `DCC_MCP_SCENE` | — | Currently-open scene / document; recorded in the registry, used by multi-instance disambiguation. |

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -284,7 +284,7 @@ vx just lint
 - Check out the [Skills System](/guide/skills) for zero-code script registration
 - Expose tools with [MCP HTTP Server](/api/http)
 - See the [Transport Layer](/guide/transport) for DCC communication
-- Understand the [Architecture](/guide/architecture) of the 15-crate Rust workspace
+- Understand the [Architecture](/guide/architecture) of the 38-member Rust workspace
 - Learn [Skill Scopes & Policies](/guide/skill-scopes-policies) for trust-based skill management
 - Validate tool names with [SEP-986 Naming Rules](/guide/naming)
 
@@ -323,12 +323,12 @@ When building tools for AI agents to consume:
 1. **Design around user workflows**, not raw API calls. A tool called `create_character` is better than three separate calls to `create_joint`, `bind_skin`, `apply_animation`.
 2. **Use `ToolAnnotations`** to signal safety properties — `read_only_hint=True`, `destructive_hint=False`, `idempotent_hint=True` — so AI clients make informed choices.
 3. **Return human-readable errors** via `error_result("msg", "specific error")` with actionable suggestions in `prompt`.
-4. **Use `next-tools`** in SKILL.md to guide AI agents to follow-up tools (e.g. `on-failure: [dcc_diagnostics__screenshot]`).
+4. **Use `next-tools`** inside sibling `tools.yaml` declarations to guide AI agents to follow-up tools (e.g. `on-failure: [dcc_diagnostics__screenshot]`).
 5. **Keep `tools/list` small** by using tool groups with `default_active=false` for power-user features. Agents activate groups on demand.
 6. **Validate all AI-provided inputs** with `ToolValidator.from_schema_json()` before execution — never trust LLM output blindly.
 7. **Write action-oriented descriptions** — describe *what the tool does* and *when to use it* in the first sentence. Include specific keywords so `search_skills()` can match. Bad: "Helper for geometry." Good: "Create a polygon sphere with configurable radius and subdivisions. Use when the user asks to create a sphere, ball, or round 3D object in Maya."
 8. **Always provide `on-failure` chains** for domain skills — point to `dcc_diagnostics__screenshot` and `dcc_diagnostics__audit_log` so agents can debug failures automatically.
-9. **Declare `depends: [dcc-diagnostics]`** in every domain skill — ensures diagnostics are loaded before the skill's tools become available.
+9. **Declare dependencies under `metadata.dcc-mcp.depends`** in every domain skill — ensures diagnostics are loaded before the skill's tools become available.
 10. **Tag every skill with `metadata.dcc-mcp.layer`** — infrastructure, domain, thin-harness, or example. Untagged skills cause routing ambiguity as the catalog grows.
 
 ### MCP Tool Design Checklist

--- a/docs/zh/guide/architecture.md
+++ b/docs/zh/guide/architecture.md
@@ -1,10 +1,44 @@
 # 架构设计
 
-DCC-MCP-Core 是一个 Rust workspace，通过 PyO3 提供 Python 绑定。核心特点：
+DCC-MCP-Core 是一个 Rust workspace，通过 PyO3 提供 Python 绑定。当前架构是 gateway-first：MCP 客户端、CLI 用户、ClawHub/OpenClaw skills、CI 和自定义 HTTP 客户端都汇聚到一套小型发现/调度控制面，而不是把所有后端工具塞进 `tools/list`。
 
 - **零运行时第三方依赖** — Rust 核心无第三方运行时依赖
 - **可选 Python 绑定** — 通过 PyO3 实现 DCC 集成
-- **35 个 workspace 成员**（34 个功能 crate + `workspace-hack`）— 以根目录 `Cargo.toml` 为准，按需选择性依赖
+- **38 个 workspace 成员**（37 个功能 crate + `workspace-hack`）— 以根目录 `Cargo.toml` 为准，按需选择性依赖
+
+## 当前 Gateway-first 栈
+
+```
++--------------------------------------------------------------------------------+
+| Agent / operator surfaces                                                       |
+| - MCP clients: search_tools -> describe_tool -> call_tool                       |
+| - CLI users: dcc-mcp-cli list/search/describe/call                              |
+| - ClawHub/OpenClaw skills: dcc-cli-gateway or dcc-rest-gateway                  |
+| - CI and custom clients: REST /v1/*                                             |
++----------------------------------------+---------------------------------------+
+                                         |
+                       MCP Streamable HTTP + REST /v1/*
+                                         |
++----------------------------------------v---------------------------------------+
+| Elected gateway (Rust HTTP control plane)                                       |
+| - Minimal MCP tools/list: discovery and dispatch primitives only                |
+| - Dynamic capability search, schema describe, single/batch call routing         |
+| - Instance registry, TCP liveness probes, version-aware election, failover      |
+| - Admin UI, OpenAPI, audit logs, traces, metrics, jobs, workflows, artefacts    |
++----------------------------------------+---------------------------------------+
+                                         |
+                    Gateway-routed calls to owning per-DCC server
+                                         |
+        +-------------------------------+-------------------------------+
+        |                               |                               |
++-------v--------+              +-------v--------+              +-------v--------+
+| Maya adapter   |              | Blender adapter|              | Custom host    |
+| MCP + REST     |              | MCP + REST     |              | MCP + REST     |
+| Skills catalog |              | Skills catalog |              | Skills catalog |
++-------+--------+              +-------+--------+              +-------+--------+
+        |                               |                               |
+  Host bridge / UI-thread pump    Host bridge / add-on           Host RPC / IPC
+```
 
 ## Crate 结构
 
@@ -15,9 +49,11 @@ dcc-mcp-core (workspace 根目录)
 ├── dcc-mcp-skills       # SkillScanner, SkillCatalog, SkillWatcher, Resolver
 ├── dcc-mcp-protocols    # MCP 类型: ToolDefinition, ResourceDefinition, Prompt, BridgeKind
 ├── dcc-mcp-jsonrpc      # MCP 2025-03-26 JSON-RPC 线协议类型
+├── dcc-mcp-wire         # MCP/REST call envelope 规范化
 ├── dcc-mcp-job          # 异步 job 追踪和可选持久化
 ├── dcc-mcp-skill-rest   # Per-DCC /v1/* REST Skill API
 ├── dcc-mcp-gateway-core # 纯 gateway 领域/search/ranking 类型
+├── dcc-mcp-gateway-search # 能力搜索/排序引擎
 ├── dcc-mcp-gateway      # Multi-DCC 网关应用层和动态 wrappers
 ├── dcc-mcp-http-types   # 纯 HTTP 线协议/配置/值类型、McpHttpConfig
 ├── dcc-mcp-http-server  # 可复用 HTTP runtime 支撑层
@@ -29,7 +65,11 @@ dcc-mcp-core (workspace 根目录)
 ├── dcc-mcp-shm          # Shared memory: PySharedBuffer, PyBufferPool
 ├── dcc-mcp-capture      # Screen capture: Capturer, CaptureFrame
 ├── dcc-mcp-usd          # USD scene description: UsdStage, SdfPath, VtValue
+├── dcc-mcp-workflow     # YAML 工作流与恢复
+├── dcc-mcp-scheduler    # cron/webhook 调度
+├── dcc-mcp-artefact     # FileRef 与内容寻址交接
 ├── dcc-mcp-http         # Embedded MCP HTTP facade + 兼容 re-export
+├── dcc-mcp-cli          # 客户端控制面 CLI
 ├── dcc-mcp-server       # 二进制入口点: dcc-mcp-server, gateway runner
 ├── dcc-mcp-logging      # 滚动文件日志
 ├── dcc-mcp-paths        # 平台路径辅助
@@ -51,11 +91,15 @@ dcc-mcp-skills ← dcc-mcp-actions, dcc-mcp-models
        ↓
 dcc-mcp-protocols ← dcc-mcp-models
        ↓
+dcc-mcp-wire ← dcc-mcp-jsonrpc, serde_json（规范化 MCP/REST call envelope）
+       ↓
 dcc-mcp-transport ← dcc-mcp-protocols
        ↓
 dcc-mcp-gateway-core ← 纯 gateway 领域/search/ranking 类型
        ↓
-dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-transport
+dcc-mcp-gateway-search ← 可复用能力搜索/排序引擎
+       ↓
+dcc-mcp-gateway ← dcc-mcp-gateway-core, dcc-mcp-gateway-search, dcc-mcp-wire, dcc-mcp-transport
        ↓
 dcc-mcp-http-types ← 纯 HTTP 线协议/配置/值类型
        ↓
@@ -64,6 +108,8 @@ dcc-mcp-http-server ← dcc-mcp-http-types, dcc-mcp-jsonrpc, dcc-mcp-job, dcc-mc
 dcc-mcp-http ← dcc-mcp-http-types, dcc-mcp-http-server, dcc-mcp-gateway, dcc-mcp-skill-rest
        ↓
 dcc-mcp-server ← dcc-mcp-http
+
+dcc-mcp-cli ← dcc-mcp-catalog + gateway REST contract
 ```
 
 ## 各 Crate 职责
@@ -108,7 +154,7 @@ dcc-mcp-server ← dcc-mcp-http
 - `SkillMetadata` — 从 agentskills.io `SKILL.md` 以及 `metadata.dcc-mcp.*` 指向的同级文件解析的元数据
 - 依赖解析：`resolve_dependencies`、`expand_transitive_dependencies`、`validate_dependencies`
 
-**技能包格式**：`SKILL.md` 含 YAML frontmatter（`name`、`version`、`description`、`tools`、`dcc`、`tags`、`depends`、`search-hint`）
+**技能包格式**：`SKILL.md` 使用 agentskills.io frontmatter（`name`、`description`、可选 `license` / `compatibility` / `allowed-tools`），dcc-mcp-core 扩展放在 `metadata.dcc-mcp.*` 下，并指向同级文件（例如 `tools.yaml`、`groups.yaml`、workflow、prompt、resource 和外部依赖声明）。严格 loader 会拒绝旧的顶层 dcc-mcp 扩展键。
 
 **依赖**：`dcc-mcp-actions`、`dcc-mcp-models`
 

--- a/docs/zh/guide/cli-reference.md
+++ b/docs/zh/guide/cli-reference.md
@@ -8,10 +8,10 @@
 Release 资产发布。CLI 可以通过 URL 直接安装：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.sh | sh
+curl -fsSL https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.sh | bash
 
 # Windows PowerShell
-powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+powershell -c "irm https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
 ```
 
 需要固定版本时，设置 `DCC_MCP_VERSION=v0.17.4`，或给安装脚本传

--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -176,7 +176,7 @@ vx just lint
 - 查看 [Skills 技能包](/zh/guide/skills) 的零代码脚本注册
 - 使用 [MCP HTTP 服务器](/zh/api/http) 暴露工具给 AI 客户端
 - 查看 [传输层](/zh/guide/transport) 的 DCC 通信
-- 了解 [架构设计](/zh/guide/architecture) — 35 个 workspace 成员的 Rust 工作区结构
+- 了解 [架构设计](/zh/guide/architecture) — 38 个 workspace 成员的 Rust 工作区结构
 - 学习 [技能作用域与策略](/zh/guide/skill-scopes-policies) — 基于信任的技能管理
 
 ## 使用 DccServerBase 构建 DCC 适配器

--- a/justfile
+++ b/justfile
@@ -276,6 +276,7 @@ ci: preflight install test lint-py
 # Package skills from .github/clawhub-skills.json (zip under dist/skills/).
 package-clawhub-skills:
     python scripts/package_openclaw_skill.py skills/dcc-rest-gateway dist/skills
+    python scripts/package_openclaw_skill.py skills/dcc-cli-gateway dist/skills
 
 # Validate publish commands without uploading (PR / local).
 clawhub-sync-dry-run:

--- a/scripts/install-cli.ps1
+++ b/scripts/install-cli.ps1
@@ -4,6 +4,9 @@ param(
     [string] $Repo = $env:DCC_MCP_REPO
 )
 
+# One-line install:
+# powershell -c "irm https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+
 $ErrorActionPreference = "Stop"
 
 if ([string]::IsNullOrWhiteSpace($Version)) {

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -12,6 +12,9 @@ Install dcc-mcp-cli from GitHub Releases.
 Usage:
   install-cli.sh [--version v0.17.4] [--install-dir ~/.local/bin]
 
+One-line install:
+  curl -fsSL https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.sh | bash
+
 Environment:
   DCC_MCP_REPO         GitHub repo, default loonghao/dcc-mcp-core
   DCC_MCP_VERSION      Release tag, default latest

--- a/skills/README.md
+++ b/skills/README.md
@@ -11,21 +11,17 @@ Official skills and starter templates for the dcc-mcp-core ecosystem.
 | Skill | Description | Location |
 |-------|-------------|----------|
 | [`dcc-rest-gateway`](dcc-rest-gateway/) | Control any DCC via gateway REST only (no MCP); instance inventory and zero-instance setup | `skills/dcc-rest-gateway/` |
+| [`dcc-cli-gateway`](dcc-cli-gateway/) | Control any DCC through `dcc-mcp-cli`; instance inventory, search, describe, and call workflow | `skills/dcc-cli-gateway/` |
 | [`dcc-skills-creator`](dcc-skills-creator/) | Create, validate, and scaffold DCC skills | `skills/dcc-skills-creator/` |
 
-### ClawHub publish
+### Install and validate
 
-Manifest: [`.github/clawhub-skills.json`](../.github/clawhub-skills.json). Merging to
-`main` runs [`.github/workflows/clawhub.yml`](../.github/workflows/clawhub.yml) (requires
-repository secret `CLAWHUB_TOKEN`).
+Users can install these skills from OpenClaw/ClawHub, or reference the checked-out
+skill directories directly.
 
 ```bash
-# Local dry-run (validate SKILL.md, print publish command)
-just clawhub-sync-dry-run
-
-# Manual publish
-cd skills/dcc-rest-gateway
-npx clawhub@0.7.0 publish . --slug dcc-rest-gateway --version 1.0.0 --no-input
+# Local validation
+python -c "from dcc_mcp_core import validate_skill; print(validate_skill('skills/dcc-cli-gateway').is_clean)"
 ```
 
 ## Bundled Skills
@@ -282,6 +278,7 @@ skills shipped in `examples/skills/`, or browse them directly:
 | [cancellable-loop](../examples/skills/cancellable-loop/) | example | python | Cooperative cancellation |
 | [clawhub-compat](../examples/skills/clawhub-compat/) | example | python | Full OpenClaw format |
 | [dcc-rest-gateway](dcc-rest-gateway/) | infrastructure | python | REST-only gateway control; ClawHub publishable |
+| [dcc-cli-gateway](dcc-cli-gateway/) | infrastructure | python | CLI gateway control with `dcc-mcp-cli`; ClawHub publishable |
 | [dcc-diagnostics](../examples/skills/dcc-diagnostics/) | infrastructure | python | Also bundled |
 | [workflow](../examples/skills/workflow/) | infrastructure | python | Also bundled |
 | [usd-tools](../examples/skills/usd-tools/) | infrastructure | python | Read-only USD tools |

--- a/skills/dcc-cli-gateway/SKILL.md
+++ b/skills/dcc-cli-gateway/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: dcc-cli-gateway
+description: >-
+  Control live DCC hosts (Maya, Blender, Houdini, Photoshop, 3ds Max, and
+  custom studio tools) through the dcc-mcp-cli command line. For ClawHub,
+  OpenClaw, Cursor, Claude, and shell-capable agent hosts: verify gateway
+  health, inventory registered DCC instances, search tools, inspect schemas,
+  and invoke tools without speaking MCP directly. If dcc-mcp-cli is missing,
+  ask for consent, download it from GitHub Releases, and fall back to Python
+  stdlib REST only if download fails.
+license: MIT
+compatibility: Cross-platform Windows/macOS/Linux. Prefers dcc-mcp-cli on PATH; can download release asset from GitHub; Python 3.7+ stdlib REST fallback. DCC-MCP gateway reachable at DCC_MCP_BASE_URL (default http://127.0.0.1:9765)
+allowed-tools: Bash Read
+metadata:
+  dcc-mcp:
+    dcc: python
+    layer: infrastructure
+    version: "1.0.0"
+    search-hint: "cli gateway dcc-mcp-cli connect dcc instances search describe call clawhub"
+    tags: "cli, gateway, infrastructure, clawhub, openclaw, instances"
+  openclaw:
+    requires:
+      env:
+        - DCC_MCP_BASE_URL
+    primaryEnv: DCC_MCP_BASE_URL
+    emoji: "🖥️"
+    homepage: https://github.com/loonghao/dcc-mcp-core/blob/main/skills/dcc-cli-gateway/SKILL.md
+---
+
+# DCC CLI Gateway — Agent Control Plane
+
+Use this skill when an agent host can run shell commands and should connect to
+DCC-MCP through **`dcc-mcp-cli`** instead of MCP JSON-RPC. The CLI wraps the
+gateway REST API and returns JSON by default.
+
+Connection order:
+
+1. Use `dcc-mcp-cli` when it is already on `PATH`.
+2. If missing, ask user permission, then download `dcc-mcp-cli` from GitHub Releases.
+3. If the download fails, use the bundled Python stdlib REST fallback.
+
+Install via OpenClaw/ClawHub, or point your agent at this `SKILL.md` after cloning
+[`dcc-mcp-core/skills/dcc-cli-gateway/`](https://github.com/loonghao/dcc-mcp-core/tree/main/skills/dcc-cli-gateway).
+
+---
+
+## Critical Rules
+
+| Situation | You MUST |
+|-----------|----------|
+| Starting any DCC task | Run `python scripts/dcc_gateway.py health` and `python scripts/dcc_gateway.py list` first |
+| `dcc-mcp-cli` missing | Ask permission before `--ensure-cli`; fallback Python REST is allowed if download fails |
+| Inventory returns `total == 0` | Stop; do not run `search`, `describe`, or `call` |
+| Gateway unreachable | Stop; explain; ask user permission before troubleshooting |
+| User has not agreed to setup | Do not install packages, edit env files, launch GUI apps, or write configs |
+| User approved setup | Follow [`references/ZERO_INSTANCES_CLI.md`](references/ZERO_INSTANCES_CLI.md) |
+| After DCC crash/restart | Re-run `list` and `search`; old slugs may be invalid |
+
+---
+
+## Configuration
+
+`dcc-mcp-cli` and the Python helper read the gateway URL from `DCC_MCP_BASE_URL`.
+
+```bash
+export DCC_MCP_BASE_URL="${DCC_MCP_BASE_URL:-http://127.0.0.1:9765}"
+dcc-mcp-cli health
+python scripts/dcc_gateway.py health
+```
+
+For a one-off command:
+
+```bash
+python scripts/dcc_gateway.py --base-url http://127.0.0.1:9765 health
+```
+
+Quick probe helper:
+
+```bash
+python3 scripts/check_cli.py
+py -3 scripts\check_cli.py
+```
+
+Flags: `--base-url URL`, `--cli dcc-mcp-cli`, `--ensure-cli`, `--install-dir DIR`, `--pretty`.
+
+When the user approves downloading the CLI:
+
+```bash
+# Linux / macOS
+python3 scripts/dcc_gateway.py --ensure-cli list
+vx python scripts/dcc_gateway.py --ensure-cli list
+
+# Windows
+py -3 scripts\dcc_gateway.py --ensure-cli list
+vx python scripts\dcc_gateway.py --ensure-cli list
+```
+
+Release assets are selected by platform:
+
+| Platform | Asset |
+|----------|-------|
+| Windows x86_64 | `dcc-mcp-cli-windows-x86_64.exe` |
+| Linux x86_64 | `dcc-mcp-cli-linux-x86_64` |
+| macOS Intel/Apple Silicon | `dcc-mcp-cli-macos-universal2` |
+
+If Python is not easy to locate, install vx first and run the helper through
+`vx python`:
+
+```bash
+# Linux / macOS
+curl -fsSL https://raw.githubusercontent.com/loonghao/vx/main/install.sh | bash
+
+# Windows PowerShell
+powershell -c "irm https://raw.githubusercontent.com/loonghao/vx/main/install.ps1 | iex"
+```
+
+---
+
+## Step 0 — Mandatory Instance Inventory
+
+Run this every time you begin work or after the user starts/stops a DCC host:
+
+```bash
+python scripts/dcc_gateway.py health
+python scripts/dcc_gateway.py list
+```
+
+Interpret `dcc-mcp-cli list`:
+
+```json
+{
+  "total": 1,
+  "instances": [
+    {
+      "instance_id": "full-uuid",
+      "instance_short": "a1b2c3d4",
+      "dcc_type": "maya",
+      "status": "available",
+      "stale": false,
+      "mcp_url": "http://127.0.0.1:8765/mcp"
+    }
+  ]
+}
+```
+
+Report to the user:
+
+1. `total`
+2. Count by `dcc_type`
+3. Any `stale: true` rows
+4. The target `instance_id` or `instance_short` you will use
+
+If `total == 0`, stop and ask whether the user wants setup guidance for the
+target DCC. Continue only after explicit approval.
+
+---
+
+## Step 1 — Search Tools
+
+Only run this when inventory shows at least one non-stale target:
+
+```bash
+python scripts/dcc_gateway.py search --query sphere --dcc-type maya --limit 20
+```
+
+Copy the returned slug exactly. Gateway slugs look like:
+
+```text
+maya.a1b2c3d4.maya_primitives__create_sphere
+```
+
+Never hand-build slugs.
+
+---
+
+## Step 2 — Describe Schema
+
+```bash
+python scripts/dcc_gateway.py describe maya.a1b2c3d4.maya_primitives__create_sphere
+```
+
+Read `tool.inputSchema` and safety annotations before calling.
+
+---
+
+## Step 3 — Call a Tool
+
+```bash
+python scripts/dcc_gateway.py call maya.a1b2c3d4.maya_primitives__create_sphere \
+  --json '{"radius":2.0}'
+```
+
+Tool-specific fields (`code`, `file_path`, `radius`, and similar) belong inside
+the `--json` object. Do not pass them as top-level CLI flags unless the CLI adds
+an explicit first-class flag later.
+
+See [`references/CLI_CHEATSHEET.md`](references/CLI_CHEATSHEET.md) for command
+patterns and common errors.
+
+---
+
+## What This Skill Does Not Use
+
+- MCP `tools/list`, `tools/call`, or `resources/read`
+- Raw `curl` workflows except when debugging the gateway itself
+- Direct Maya/Blender/Houdini scripting
+
+The CLI is the preferred agent-facing control plane. The Python fallback uses
+the same gateway REST endpoints only when the CLI is unavailable after a
+download attempt fails.

--- a/skills/dcc-cli-gateway/references/CLI_CHEATSHEET.md
+++ b/skills/dcc-cli-gateway/references/CLI_CHEATSHEET.md
@@ -1,0 +1,84 @@
+# CLI cheatsheet — DCC-MCP gateway
+
+Base URL: `$DCC_MCP_BASE_URL` (default `http://127.0.0.1:9765`).
+
+Preferred helper:
+
+```bash
+python scripts/dcc_gateway.py <command>
+vx python scripts/dcc_gateway.py <command>
+```
+
+It uses `dcc-mcp-cli` when available. With user consent, add `--ensure-cli` to
+download the CLI from GitHub Releases when missing. If download fails, it falls
+back to Python stdlib REST.
+
+If Python is not available as `python` / `py`, install vx and use
+`vx python scripts/dcc_gateway.py ...`:
+
+```bash
+# Linux / macOS
+curl -fsSL https://raw.githubusercontent.com/loonghao/vx/main/install.sh | bash
+
+# Windows PowerShell
+powershell -c "irm https://raw.githubusercontent.com/loonghao/vx/main/install.ps1 | iex"
+```
+
+## Discovery and health
+
+| Command | Purpose |
+|---------|---------|
+| `python scripts/dcc_gateway.py health` | Check gateway liveness |
+| `python scripts/dcc_gateway.py list` | List registered DCC instances |
+| `python scripts/dcc_gateway.py --pretty list` | Human-readable JSON |
+
+## Capability workflow
+
+| Command | Purpose |
+|---------|---------|
+| `python scripts/dcc_gateway.py search --query sphere --dcc-type maya --limit 20` | Find tools |
+| `python scripts/dcc_gateway.py describe <tool_slug>` | Inspect schema |
+| `python scripts/dcc_gateway.py call <tool_slug> --json '{"radius":2}'` | Invoke one tool |
+
+## Example: inventory
+
+```bash
+export DCC_MCP_BASE_URL="${DCC_MCP_BASE_URL:-http://127.0.0.1:9765}"
+python scripts/dcc_gateway.py health
+python scripts/dcc_gateway.py list
+```
+
+## Example: search
+
+```bash
+python scripts/dcc_gateway.py search --query sphere --dcc-type maya --limit 10
+```
+
+## Example: describe
+
+```bash
+python scripts/dcc_gateway.py describe maya.a1b2c3d4.maya_primitives__create_sphere
+```
+
+## Example: call
+
+```bash
+python scripts/dcc_gateway.py call maya.a1b2c3d4.maya_primitives__create_sphere \
+  --json '{"radius":2.0}'
+```
+
+## Slug rules
+
+- Gateway slugs are returned by `search`.
+- Do not invent slugs from DCC names or tool names.
+- Re-run `list` and `search` after a DCC restart.
+
+## Common errors
+
+| Symptom | Action |
+|---------|--------|
+| CLI not found | Ask user permission, then run `vx python scripts/dcc_gateway.py --ensure-cli list`; fallback Python REST runs if download fails |
+| Gateway health fails | Ask before setup; do not install or launch apps silently |
+| `total == 0` | Start a DCC adapter, then re-run `python scripts/dcc_gateway.py list` |
+| `unknown-slug` | Re-run `search`; the instance may have restarted |
+| `invalid-params` | Fix the JSON object per `describe` output |

--- a/skills/dcc-cli-gateway/references/ZERO_INSTANCES_CLI.md
+++ b/skills/dcc-cli-gateway/references/ZERO_INSTANCES_CLI.md
@@ -1,0 +1,90 @@
+# Zero instances — CLI setup guide
+
+Use this document only when:
+
+- `python scripts/dcc_gateway.py health` succeeds,
+- `python scripts/dcc_gateway.py list` returns `"total": 0`, and
+- the user has explicitly approved setup guidance.
+
+Until all three are true, do not run install commands, edit environment files,
+launch GUI applications, or modify MCP host configuration.
+
+---
+
+## User consent
+
+Before any setup step, confirm:
+
+1. Which DCC product the user needs.
+2. Whether they want commands suggested or executed.
+3. That they will confirm after each DCC-side step so you can re-run
+   `python scripts/dcc_gateway.py list`.
+
+---
+
+## Diagnose
+
+| Check | Meaning | Next step |
+|-------|---------|-----------|
+| `python scripts/dcc_gateway.py health` fails | Gateway is not reachable | Ask user to start a gateway-capable DCC adapter or `dcc-mcp-server` |
+| `python scripts/dcc_gateway.py health` succeeds and `list.total == 0` | Gateway is up, no DCC registered | Start a DCC adapter |
+
+Gateway election defaults to port `9765`. The first DCC-MCP process that binds
+the gateway port becomes the gateway; other DCC adapters register with it.
+
+---
+
+## Adapter discovery
+
+With user approval:
+
+```bash
+dcc-mcp-cli install --dcc-type maya
+dcc-mcp-cli install --dcc-type blender
+```
+
+The `install` command returns an auditable plan. Treat it as guidance unless the
+user explicitly asks you to execute installation steps.
+
+---
+
+## Per-DCC checklist
+
+### Maya
+
+1. Install into Maya's Python: `mayapy -m pip install dcc-mcp-maya`
+2. In Maya Script Editor:
+
+   ```python
+   import dcc_mcp_maya
+   handle = dcc_mcp_maya.start_server(port=8765)
+   print(handle.mcp_url())
+   ```
+
+3. Re-run `python scripts/dcc_gateway.py list`; expect `dcc_type: maya`.
+
+### Blender
+
+1. Install `dcc-mcp-blender` per its README.
+2. Enable the add-on in Blender Preferences.
+3. Re-run `python scripts/dcc_gateway.py list`; expect `dcc_type: blender`.
+
+### Houdini / Photoshop / 3ds Max
+
+Follow the adapter README for the target host, then re-run:
+
+```bash
+python scripts/dcc_gateway.py list
+```
+
+When `total >= 1`, resume the main flow: `search -> describe -> call`.
+
+If Python is not available as `python` / `py`, install vx first:
+
+```bash
+# Linux / macOS
+curl -fsSL https://raw.githubusercontent.com/loonghao/vx/main/install.sh | bash
+
+# Windows PowerShell
+powershell -c "irm https://raw.githubusercontent.com/loonghao/vx/main/install.ps1 | iex"
+```

--- a/skills/dcc-cli-gateway/scripts/check_cli.py
+++ b/skills/dcc-cli-gateway/scripts/check_cli.py
@@ -1,0 +1,141 @@
+"""Probe dcc-mcp-cli availability and gateway instance inventory."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+from typing import Any
+
+import dcc_gateway
+
+DEFAULT_BASE_URL = "http://127.0.0.1:9765"
+
+
+def _run_json(argv: list[str]) -> tuple[bool, dict[str, Any]]:
+    try:
+        proc = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except OSError as exc:
+        return False, {"error": str(exc)}
+    except subprocess.TimeoutExpired:
+        return False, {"error": "command timed out"}
+
+    if proc.returncode != 0:
+        return False, {"returncode": proc.returncode, "stderr": proc.stderr.strip()}
+
+    try:
+        payload = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        return False, {"error": f"invalid JSON output: {exc}", "stdout": proc.stdout}
+    return True, payload
+
+
+def probe(
+    cli: str = "dcc-mcp-cli",
+    base_url: str | None = None,
+    *,
+    ensure_cli: bool = False,
+    install_dir: str | None = None,
+) -> dict[str, Any]:
+    """Return CLI availability, health, and instance inventory."""
+    resolved = shutil.which(cli)
+    url = base_url or os.environ.get("DCC_MCP_BASE_URL") or DEFAULT_BASE_URL
+    result: dict[str, Any] = {
+        "cli": cli,
+        "cli_path": resolved,
+        "base_url": url,
+        "cli_ok": resolved is not None,
+        "gateway_ok": False,
+        "total": 0,
+        "by_dcc_type": {},
+    }
+    if resolved is None and ensure_cli:
+        default_install_dir = Path.home() / ".local" / "bin"
+        resolved_install_dir = install_dir or os.environ.get("DCC_MCP_INSTALL_DIR") or str(default_install_dir)
+        ok, message, download_url = dcc_gateway.install_cli(
+            install_dir=Path(resolved_install_dir),
+            repo=os.environ.get("DCC_MCP_REPO") or dcc_gateway.DEFAULT_REPO,
+            version=os.environ.get("DCC_MCP_VERSION") or dcc_gateway.DEFAULT_VERSION,
+        )
+        result["install_attempted"] = True
+        result["install_ok"] = ok
+        result["install_message"] = message
+        result["download_url"] = download_url
+        if ok:
+            resolved = message
+            result["cli_path"] = resolved
+            result["cli_ok"] = True
+    if resolved is None:
+        fallback = dcc_gateway.python_fallback(
+            "list",
+            argparse.Namespace(base_url=url),
+        )
+        result["fallback"] = "python-stdlib-rest"
+        if isinstance(fallback, dict) and "instances" in fallback:
+            instances = fallback.get("instances") or []
+            counts: dict[str, int] = {}
+            for item in instances:
+                if isinstance(item, dict):
+                    dcc_type = str(item.get("dcc_type") or "unknown")
+                    counts[dcc_type] = counts.get(dcc_type, 0) + 1
+            result["gateway_ok"] = True
+            result["total"] = int(fallback.get("total") or len(instances))
+            result["by_dcc_type"] = counts
+            result["list"] = fallback
+        return result
+
+    health_ok, health = _run_json([resolved, "--base-url", url, "health"])
+    result["health"] = health
+    result["gateway_ok"] = health_ok
+    if not health_ok:
+        return result
+
+    list_ok, listing = _run_json([resolved, "--base-url", url, "list"])
+    result["list"] = listing
+    if not list_ok:
+        return result
+
+    instances = listing.get("instances") if isinstance(listing, dict) else None
+    if not isinstance(instances, list):
+        instances = []
+    counts: dict[str, int] = {}
+    for item in instances:
+        if isinstance(item, dict):
+            dcc_type = str(item.get("dcc_type") or "unknown")
+            counts[dcc_type] = counts.get(dcc_type, 0) + 1
+    result["total"] = int(listing.get("total") or len(instances))
+    result["by_dcc_type"] = counts
+    return result
+
+
+def main() -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description="Probe dcc-mcp-cli and gateway inventory")
+    parser.add_argument("--cli", default="dcc-mcp-cli")
+    parser.add_argument("--base-url", default=os.environ.get("DCC_MCP_BASE_URL") or DEFAULT_BASE_URL)
+    parser.add_argument("--ensure-cli", action="store_true")
+    parser.add_argument("--install-dir", default=os.environ.get("DCC_MCP_INSTALL_DIR"))
+    parser.add_argument("--pretty", action="store_true")
+    args = parser.parse_args()
+
+    payload = probe(
+        cli=args.cli,
+        base_url=args.base_url,
+        ensure_cli=args.ensure_cli,
+        install_dir=args.install_dir,
+    )
+    print(json.dumps(payload, indent=2 if args.pretty else None, sort_keys=args.pretty))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/dcc-cli-gateway/scripts/dcc_gateway.py
+++ b/skills/dcc-cli-gateway/scripts/dcc_gateway.py
@@ -1,0 +1,257 @@
+"""Cross-platform gateway helper with CLI download and Python REST fallback."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+from pathlib import Path
+import platform
+import shutil
+import stat
+import subprocess
+import tempfile
+from typing import Any
+import urllib.error
+import urllib.request
+
+DEFAULT_BASE_URL = "http://127.0.0.1:9765"
+DEFAULT_REPO = "loonghao/dcc-mcp-core"
+DEFAULT_VERSION = "latest"
+
+
+def _json_dumps(payload: Any, *, pretty: bool = False) -> str:
+    return json.dumps(payload, indent=2 if pretty else None, sort_keys=pretty)
+
+
+def _run_json(argv: list[str]) -> tuple[bool, dict[str, Any]]:
+    try:
+        proc = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+    except OSError as exc:
+        return False, {"error": str(exc)}
+    except subprocess.TimeoutExpired:
+        return False, {"error": "command timed out"}
+
+    if proc.returncode != 0:
+        return False, {"returncode": proc.returncode, "stderr": proc.stderr.strip()}
+
+    try:
+        payload = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        return False, {"error": f"invalid JSON output: {exc}", "stdout": proc.stdout}
+    return True, payload
+
+
+def _request_json(base_url: str, method: str, path: str, body: dict[str, Any] | None = None) -> dict[str, Any]:
+    url = f"{base_url.rstrip('/')}{path}"
+    data = None if body is None else json.dumps(body).encode("utf-8")
+    request = urllib.request.Request(url, data=data, method=method)
+    if body is not None:
+        request.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            text = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        return {"success": False, "error": "http-error", "status": exc.code, "detail": detail}
+    except (urllib.error.URLError, OSError) as exc:
+        return {"success": False, "error": "connection-error", "detail": str(exc)}
+    if not text:
+        return {}
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        return {"success": False, "error": "invalid-json", "detail": str(exc), "body": text}
+
+
+def _asset_name() -> str | None:
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    if system == "windows" and machine in {"amd64", "x86_64"}:
+        return "dcc-mcp-cli-windows-x86_64.exe"
+    if system == "linux" and machine in {"amd64", "x86_64"}:
+        return "dcc-mcp-cli-linux-x86_64"
+    if system == "darwin":
+        return "dcc-mcp-cli-macos-universal2"
+    return None
+
+
+def _download_url(repo: str, version: str, asset: str) -> str:
+    if version == "latest":
+        return f"https://github.com/{repo}/releases/latest/download/{asset}"
+    return f"https://github.com/{repo}/releases/download/{version}/{asset}"
+
+
+def install_cli(
+    *,
+    install_dir: Path,
+    repo: str = DEFAULT_REPO,
+    version: str = DEFAULT_VERSION,
+) -> tuple[bool, str, str | None]:
+    """Download dcc-mcp-cli for the current platform."""
+    asset = _asset_name()
+    if asset is None:
+        return False, "unsupported platform for release asset", None
+
+    install_dir.mkdir(parents=True, exist_ok=True)
+    executable_name = "dcc-mcp-cli.exe" if platform.system().lower() == "windows" else "dcc-mcp-cli"
+    target = install_dir / executable_name
+    url = _download_url(repo, version, asset)
+
+    fd, tmp_name = tempfile.mkstemp(prefix="dcc-mcp-cli-", suffix=target.suffix)
+    os.close(fd)
+    tmp_path = Path(tmp_name)
+    try:
+        urllib.request.urlretrieve(url, tmp_path)
+        if platform.system().lower() != "windows":
+            tmp_path.chmod(tmp_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        shutil.move(str(tmp_path), str(target))
+    except (urllib.error.URLError, OSError) as exc:
+        with contextlib.suppress(OSError):
+            tmp_path.unlink(missing_ok=True)
+        return False, f"download failed: {exc}", url
+    return True, str(target), url
+
+
+def resolve_cli(args: argparse.Namespace) -> tuple[str | None, dict[str, Any]]:
+    """Find the CLI; optionally install it from GitHub releases."""
+    found = shutil.which(args.cli)
+    details: dict[str, Any] = {"cli": args.cli, "cli_path": found, "installed": False}
+    if found:
+        return found, details
+
+    if not args.ensure_cli:
+        return None, details
+
+    install_dir = Path(args.install_dir).expanduser()
+    ok, message, url = install_cli(install_dir=install_dir, repo=args.repo, version=args.version)
+    details.update({"install_attempted": True, "install_ok": ok, "install_message": message, "download_url": url})
+    if not ok:
+        return None, details
+    details["installed"] = True
+    return message, details
+
+
+def cli_args_for(command: str, args: argparse.Namespace) -> list[str]:
+    """Build dcc-mcp-cli argv for a command."""
+    argv = [args.cli_path, "--base-url", args.base_url, command]
+    if command == "search":
+        if args.query:
+            argv.extend(["--query", args.query])
+        if args.dcc_type:
+            argv.extend(["--dcc-type", args.dcc_type])
+        if args.limit is not None:
+            argv.extend(["--limit", str(args.limit)])
+    elif command == "describe":
+        argv.append(args.tool_slug)
+    elif command == "call":
+        argv.extend([args.tool_slug, "--json", args.json])
+        if args.meta_json:
+            argv.extend(["--meta-json", args.meta_json])
+    return argv
+
+
+def python_fallback(command: str, args: argparse.Namespace) -> dict[str, Any]:
+    """Execute the gateway workflow via Python stdlib REST calls."""
+    if command == "health":
+        return _request_json(args.base_url, "GET", "/v1/healthz")
+    if command == "list":
+        return _request_json(args.base_url, "GET", "/v1/instances")
+    if command == "search":
+        body: dict[str, Any] = {}
+        if args.query:
+            body["query"] = args.query
+        if args.dcc_type:
+            body["dcc_type"] = args.dcc_type
+        if args.limit is not None:
+            body["limit"] = args.limit
+        return _request_json(args.base_url, "POST", "/v1/search", body)
+    if command == "describe":
+        return _request_json(
+            args.base_url,
+            "POST",
+            "/v1/describe",
+            {"tool_slug": args.tool_slug, "include_schema": True},
+        )
+    if command == "call":
+        try:
+            arguments = json.loads(args.json)
+        except json.JSONDecodeError as exc:
+            return {"success": False, "error": "--json must be valid JSON", "detail": str(exc)}
+        body = {"tool_slug": args.tool_slug, "arguments": arguments}
+        if args.meta_json:
+            try:
+                body["meta"] = json.loads(args.meta_json)
+            except json.JSONDecodeError as exc:
+                return {"success": False, "error": "--meta-json must be valid JSON", "detail": str(exc)}
+        return _request_json(args.base_url, "POST", "/v1/call", body)
+    raise ValueError(f"unsupported command: {command}")
+
+
+def run_command(command: str, args: argparse.Namespace) -> dict[str, Any]:
+    """Prefer dcc-mcp-cli, optionally install it, then fall back to Python REST."""
+    cli_path, cli_details = resolve_cli(args)
+    if cli_path:
+        args.cli_path = cli_path
+        ok, payload = _run_json(cli_args_for(command, args))
+        if ok:
+            return payload
+        cli_details["cli_error"] = payload
+
+    fallback_payload = python_fallback(command, args)
+    if isinstance(fallback_payload, dict):
+        fallback_payload.setdefault("_transport", "python-stdlib-rest")
+        fallback_payload.setdefault("_cli", cli_details)
+    return fallback_payload
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the helper CLI parser."""
+    parser = argparse.ArgumentParser(description="DCC-MCP gateway helper with CLI-first execution.")
+    parser.add_argument("--base-url", default=os.environ.get("DCC_MCP_BASE_URL") or DEFAULT_BASE_URL)
+    parser.add_argument("--cli", default="dcc-mcp-cli")
+    parser.add_argument("--ensure-cli", action="store_true", help="Download dcc-mcp-cli from GitHub if it is missing")
+    parser.add_argument(
+        "--install-dir",
+        default=os.environ.get("DCC_MCP_INSTALL_DIR") or str(Path.home() / ".local" / "bin"),
+    )
+    parser.add_argument("--repo", default=os.environ.get("DCC_MCP_REPO") or DEFAULT_REPO)
+    parser.add_argument("--version", default=os.environ.get("DCC_MCP_VERSION") or DEFAULT_VERSION)
+    parser.add_argument("--pretty", action="store_true")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("health")
+    sub.add_parser("list")
+
+    search = sub.add_parser("search")
+    search.add_argument("--query")
+    search.add_argument("--dcc-type")
+    search.add_argument("--limit", type=int)
+
+    describe = sub.add_parser("describe")
+    describe.add_argument("tool_slug")
+
+    call = sub.add_parser("call")
+    call.add_argument("tool_slug")
+    call.add_argument("--json", default="{}")
+    call.add_argument("--meta-json")
+    return parser
+
+
+def main() -> int:
+    """CLI entry point."""
+    args = build_parser().parse_args()
+    payload = run_command(args.command, args)
+    print(_json_dumps(payload, pretty=args.pretty))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/dcc-rest-gateway/SKILL.md
+++ b/skills/dcc-rest-gateway/SKILL.md
@@ -3,10 +3,9 @@ name: dcc-rest-gateway
 description: >-
   Control live DCC hosts (Maya, Blender, Houdini, Photoshop, 3ds Max, and
   others) through the DCC-MCP gateway REST API only — no MCP client required.
-  For any agent host (OpenClaw, Cursor, Claude, custom HTTP clients): inventory
+  For any agent host (OpenClaw, ClawHub, Cursor, Claude, custom HTTP clients): inventory
   online instances, obtain user consent before setup when none are registered,
-  then search, describe, and call tools via POST /v1/*. Publish target: ClawHub
-  (https://clawhub.ai).
+  then search, describe, and call tools via POST /v1/*.
 license: MIT
 compatibility: Requires curl on PATH; DCC-MCP gateway reachable at DCC_MCP_GATEWAY_URL (default http://127.0.0.1:9765)
 allowed-tools: Bash Read
@@ -35,8 +34,7 @@ gateway HTTP API** only. You do **not** need MCP `tools/list`, `call_tool`,
 `resources/read`, or Streamable HTTP — only `curl` (or any HTTP client) against
 the elected gateway (default port **9765**).
 
-**Publish target:** [ClawHub](https://clawhub.ai/) — install via OpenClaw/ClawHub
-or point your agent at this `SKILL.md` after cloning
+Install via OpenClaw/ClawHub, or point your agent at this `SKILL.md` after cloning
 [`dcc-mcp-core/skills/dcc-rest-gateway/`](https://github.com/loonghao/dcc-mcp-core/tree/main/skills/dcc-rest-gateway).
 
 Full contract: [`docs/guide/rest-api-surface.md`](https://github.com/loonghao/dcc-mcp-core/blob/main/docs/guide/rest-api-surface.md).
@@ -201,23 +199,3 @@ See [`references/REST_CHEATSHEET.md`](references/REST_CHEATSHEET.md) for the ful
 - Gateway MCP wrappers (`search_tools`, `call_tool`) unless your host maps them to REST internally
 
 REST and MCP share the same backend; this skill is for agents that only have HTTP.
-
----
-
-## Publishing to ClawHub
-
-From the skill directory (repository root `skills/dcc-rest-gateway/`):
-
-```bash
-clawhub publish ./skills/dcc-rest-gateway \
-  --slug dcc-rest-gateway \
-  --version 1.0.0
-```
-
-Or after `cd skills/dcc-rest-gateway`:
-
-```bash
-clawhub publish . --slug dcc-rest-gateway --version 1.0.0
-```
-
-Install in OpenClaw: skills under `~/.openclaw/skills` or via ClawHub UI at https://clawhub.ai .

--- a/tests/test_clawhub_sync.py
+++ b/tests/test_clawhub_sync.py
@@ -14,10 +14,11 @@ SYNC_SCRIPT = REPO_ROOT / "scripts" / "clawhub_sync.py"
 
 
 class TestClawhubSync:
-    def test_manifest_lists_dcc_rest_gateway(self) -> None:
+    def test_manifest_lists_clawhub_skills(self) -> None:
         entries = json.loads(MANIFEST.read_text(encoding="utf-8"))
         slugs = {e["slug"] for e in entries}
         assert "dcc-rest-gateway" in slugs
+        assert "dcc-cli-gateway" in slugs
 
     def test_dry_run_exits_zero(self) -> None:
         proc = subprocess.run(
@@ -31,3 +32,4 @@ class TestClawhubSync:
         assert proc.returncode == 0, proc.stderr
         assert "DRY-RUN" in proc.stdout
         assert "dcc-rest-gateway" in proc.stdout
+        assert "dcc-cli-gateway" in proc.stdout

--- a/tests/test_dcc_cli_gateway_skill.py
+++ b/tests/test_dcc_cli_gateway_skill.py
@@ -1,0 +1,167 @@
+"""Tests for skills/dcc-cli-gateway (ClawHub CLI-first agent skill)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+from unittest.mock import patch
+
+from conftest import REPO_ROOT
+import dcc_mcp_core
+
+DCC_CLI_GATEWAY_DIR = str(REPO_ROOT / "skills" / "dcc-cli-gateway")
+CHECK_SCRIPT = Path(DCC_CLI_GATEWAY_DIR) / "scripts" / "check_cli.py"
+
+sys.path.insert(0, str(CHECK_SCRIPT.parent))
+import check_cli as check_cli_mod  # noqa: E402
+import dcc_gateway as dcc_gateway_mod  # noqa: E402
+
+sys.path.pop(0)
+
+
+class TestDccCliGatewaySkill:
+    def test_skill_dir_exists(self) -> None:
+        assert Path(DCC_CLI_GATEWAY_DIR).is_dir()
+
+    def test_parse_skill_md(self) -> None:
+        meta = dcc_mcp_core.parse_skill_md(DCC_CLI_GATEWAY_DIR)
+        assert meta is not None
+        assert meta.name == "dcc-cli-gateway"
+        assert meta.version == "1.0.0"
+
+    def test_validate_skill_clean(self) -> None:
+        report = dcc_mcp_core.validate_skill(DCC_CLI_GATEWAY_DIR)
+        assert report.is_clean, report.issues
+
+    def test_scannable_from_skills_dir(self, skills_dir: str) -> None:
+        scanner = dcc_mcp_core.SkillScanner()
+        dirs = scanner.scan(extra_paths=[skills_dir])
+        names = {Path(d).name for d in dirs}
+        assert "dcc-cli-gateway" in names
+
+    def test_description_mentions_clawhub_and_cli(self) -> None:
+        meta = dcc_mcp_core.parse_skill_md(DCC_CLI_GATEWAY_DIR)
+        assert meta is not None
+        desc = (meta.description or "").lower()
+        assert "clawhub" in desc
+        assert "dcc-mcp-cli" in desc
+        assert "mcp" in desc
+
+    def test_openclaw_metadata_uses_base_url_env(self) -> None:
+        meta = dcc_mcp_core.parse_skill_md(DCC_CLI_GATEWAY_DIR)
+        assert meta is not None
+        assert meta.primary_env() == "DCC_MCP_BASE_URL"
+
+    def test_reference_docs_present(self) -> None:
+        root = Path(DCC_CLI_GATEWAY_DIR)
+        assert (root / "references" / "CLI_CHEATSHEET.md").is_file()
+        assert (root / "references" / "ZERO_INSTANCES_CLI.md").is_file()
+
+    def test_probe_cli_missing(self) -> None:
+        with patch.object(check_cli_mod.shutil, "which", return_value=None):
+            payload = check_cli_mod.probe(cli="missing-dcc-mcp-cli", base_url="http://127.0.0.1:9765")
+        assert payload["cli_ok"] is False
+        assert payload["gateway_ok"] is False
+        assert payload["total"] == 0
+
+    def test_probe_download_failure_falls_back_to_python_rest(self) -> None:
+        fallback = {
+            "total": 2,
+            "instances": [
+                {"dcc_type": "houdini"},
+                {"dcc_type": "custom"},
+            ],
+        }
+        with patch.object(check_cli_mod.shutil, "which", return_value=None):
+            with patch.object(
+                check_cli_mod.dcc_gateway,
+                "install_cli",
+                return_value=(False, "download failed", "https://example.invalid"),
+            ):
+                with patch.object(check_cli_mod.dcc_gateway, "python_fallback", return_value=fallback):
+                    payload = check_cli_mod.probe(
+                        cli="missing-dcc-mcp-cli",
+                        base_url="http://127.0.0.1:9765",
+                        ensure_cli=True,
+                    )
+
+        assert payload["cli_ok"] is False
+        assert payload["install_attempted"] is True
+        assert payload["install_ok"] is False
+        assert payload["fallback"] == "python-stdlib-rest"
+        assert payload["gateway_ok"] is True
+        assert payload["by_dcc_type"] == {"houdini": 1, "custom": 1}
+
+    def test_probe_parses_cli_instances(self) -> None:
+        def fake_run(argv, capture_output=True, text=True, timeout=0, check=False):
+            class Proc:
+                returncode = 0
+                stderr = ""
+
+                @property
+                def stdout(self) -> str:
+                    if argv[-1] == "health":
+                        return json.dumps({"ok": True})
+                    return json.dumps(
+                        {
+                            "total": 3,
+                            "instances": [
+                                {"dcc_type": "maya"},
+                                {"dcc_type": "maya"},
+                                {"dcc_type": "photoshop"},
+                            ],
+                        }
+                    )
+
+            return Proc()
+
+        with patch.object(check_cli_mod.shutil, "which", return_value="dcc-mcp-cli"):
+            with patch.object(check_cli_mod.subprocess, "run", fake_run):
+                payload = check_cli_mod.probe(cli="dcc-mcp-cli", base_url="http://127.0.0.1:9765")
+
+        assert payload["cli_ok"] is True
+        assert payload["gateway_ok"] is True
+        assert payload["total"] == 3
+        assert payload["by_dcc_type"] == {"maya": 2, "photoshop": 1}
+
+    def test_check_cli_outputs_json_when_cli_missing(self) -> None:
+        assert CHECK_SCRIPT.is_file()
+        result = subprocess.run(
+            [sys.executable, str(CHECK_SCRIPT), "--cli", "missing-dcc-mcp-cli-for-test"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout.strip())
+        assert payload["cli_ok"] is False
+
+    def test_gateway_helper_python_fallback_search(self) -> None:
+        args = dcc_gateway_mod.build_parser().parse_args(
+            [
+                "--base-url",
+                "http://127.0.0.1:9765",
+                "search",
+                "--query",
+                "sphere",
+                "--dcc-type",
+                "maya",
+            ]
+        )
+        with patch.object(dcc_gateway_mod, "resolve_cli", return_value=(None, {"cli": "dcc-mcp-cli"})):
+            with patch.object(
+                dcc_gateway_mod, "_request_json", return_value={"hits": [{"slug": "maya.abc.tool"}]}
+            ) as request:
+                payload = dcc_gateway_mod.run_command("search", args)
+
+        request.assert_called_once_with(
+            "http://127.0.0.1:9765",
+            "POST",
+            "/v1/search",
+            {"query": "sphere", "dcc_type": "maya"},
+        )
+        assert payload["hits"][0]["slug"] == "maya.abc.tool"
+        assert payload["_transport"] == "python-stdlib-rest"


### PR DESCRIPTION
## Summary
- Add a ClawHub-ready `dcc-cli-gateway` skill for CLI-first DCC gateway control.
- Provide cross-platform helper scripts that prefer `dcc-mcp-cli`, can download it from GitHub Releases, and fall back to Python stdlib REST.
- Update user-facing install docs and ClawHub sync packaging to include the new skill.

## Validation
- `pytest tests/test_dcc_cli_gateway_skill.py tests/test_dcc_rest_gateway_skill.py tests/test_clawhub_sync.py -q`
- `ruff check skills/dcc-cli-gateway/scripts/check_cli.py skills/dcc-cli-gateway/scripts/dcc_gateway.py tests/test_dcc_cli_gateway_skill.py tests/test_dcc_rest_gateway_skill.py tests/test_clawhub_sync.py`
- `python scripts/clawhub_sync.py --dry-run`