### PR TITLE
[codex] Add sandbox bridge regression coverage

### DIFF
--- a/tests/test_inprocess_sandbox.py
+++ b/tests/test_inprocess_sandbox.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from dcc_mcp_core import SandboxContext
 from dcc_mcp_core import SandboxPolicy
 from dcc_mcp_core._server.inprocess_executor import HostExecutionBridge
+from dcc_mcp_core._server.options import DccServerOptions
+from dcc_mcp_core.server_base import DccServerBase
 
 
 def _write_script(tmp_path: Path, body: str) -> Path:
@@ -70,19 +73,99 @@ def test_allowed_action_records_success_audit(tmp_path: Path) -> None:
     assert successes[0].outcome == "success"
 
 
-def test_mcp_http_config_forwards_sandbox_policy_to_bridge() -> None:
-    from dcc_mcp_core import McpHttpConfig
+def test_sandbox_uses_script_stem_when_action_name_missing(tmp_path: Path) -> None:
+    policy = SandboxPolicy()
+    policy.deny_actions(["execute_python"])
+    ctx = SandboxContext(policy)
+    bridge = HostExecutionBridge(sandbox_context=ctx)
+
+    script = _write_script(
+        tmp_path,
+        "def main():\n    return {'success': True, 'message': 'should not run'}\n",
+    )
+
+    with patch(
+        "dcc_mcp_core._server.inprocess_executor.run_skill_script",
+        side_effect=AssertionError("skill script must not be imported"),
+    ) as mocked:
+        result = bridge.execute_script(str(script), {})
+
+    mocked.assert_not_called()
+    assert result["success"] is False
+    assert result["error"]["type"] == "SandboxDenied"
+    assert result["error"]["action"] == "execute_python"
+    denials = ctx.audit_log.denials()
+    assert len(denials) == 1
+    assert denials[0].action == "execute_python"
+
+
+def _make_base_with_captured_executor(tmp_path: Path) -> tuple[DccServerBase, list[Any]]:
+    opts = DccServerOptions.from_env(
+        "test_inproc_sandbox",
+        tmp_path,
+        port=0,
+        enable_file_logging=False,
+        enable_job_persistence=False,
+        enable_telemetry=False,
+    )
+    with patch("dcc_mcp_core.server_base.create_skill_server", return_value=MagicMock()):
+        base = DccServerBase(opts)
+
+    captured: list[Any] = []
+
+    class _Sink:
+        def __init__(self, real: Any) -> None:
+            self._real = real
+
+        def set_in_process_executor(self, executor: Any) -> None:
+            captured.append(executor)
+
+        def __getattr__(self, item: str) -> Any:
+            return getattr(self._real, item)
+
+    base._server = _Sink(base._server)
+    return base, captured
+
+
+def test_register_inprocess_executor_attaches_configured_sandbox(tmp_path: Path) -> None:
+    base, captured = _make_base_with_captured_executor(tmp_path)
 
     policy = SandboxPolicy()
-    policy.deny_actions(["blocked"])
-    cfg = McpHttpConfig(port=0)
-    cfg.sandbox_policy = policy
+    policy.deny_actions(["execute_python"])
+    base._config.sandbox_policy = policy
+
+    base.register_inprocess_executor()
+    assert len(captured) == 1
+
+    script = _write_script(
+        tmp_path,
+        "def main():\n    return {'success': True, 'message': 'should not run'}\n",
+    )
+    result = captured[0](str(script), {})
+    assert result["success"] is False
+    assert result["error"]["type"] == "SandboxDenied"
+    assert result["error"]["action"] == "execute_python"
+    assert base._execution_bridge is not None
+    assert base._execution_bridge.sandbox_context is not None
+
+
+def test_register_host_execution_bridge_attaches_configured_sandbox(tmp_path: Path) -> None:
+    base, captured = _make_base_with_captured_executor(tmp_path)
+
+    policy = SandboxPolicy()
+    policy.deny_actions(["execute_python"])
+    base._config.sandbox_policy = policy
 
     bridge = HostExecutionBridge()
-    assert bridge.sandbox_context is None
-
-    policy_obj = cfg.sandbox_policy
-    assert policy_obj is not None
-    bridge.sandbox_context = SandboxContext(policy_obj)
+    base.register_host_execution_bridge(bridge)
+    assert len(captured) == 1
     assert bridge.sandbox_context is not None
-    assert bridge.sandbox_context.is_allowed("safe") in (True, False)
+
+    script = _write_script(
+        tmp_path,
+        "def main():\n    return {'success': True, 'message': 'should not run'}\n",
+    )
+    result = captured[0](str(script), {})
+    assert result["success"] is False
+    assert result["error"]["type"] == "SandboxDenied"
+    assert result["error"]["action"] == "execute_python"


### PR DESCRIPTION
## Summary
- replace a weak sandbox forwarding test that bypassed `DccServerBase` wiring
- add regression coverage for script-stem fallback when `action_name` is omitted
- add targeted bridge registration tests for both `register_inprocess_executor()` and `register_host_execution_bridge()` to verify configured sandbox policies deny execution before script import

## Why
The recent sandbox integration changed two real registration paths in `DccServerBase`, but the new coverage only exercised `HostExecutionBridge` directly and included one test that manually attached a `SandboxContext`. That left the actual wiring paths unverified.

## Validation
- `pytest -q tests/test_inprocess_sandbox.py`
- `pytest -q tests/test_inprocess_executor.py -k "register_inprocess_executor or constructor_registers_execution_bridge_before_discovery or constructor_registers_dispatcher_before_discovery"`