### PR TITLE
fix: default affinity enforcement from declarations

### DIFF
--- a/crates/dcc-mcp-models/src/skill_metadata/tests.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata/tests.rs
@@ -92,6 +92,50 @@ fn test_tool_declaration_parses_thread_affinity_enforcement() {
 }
 
 #[test]
+fn test_tool_declaration_defaults_enforcement_when_affinity_is_declared() {
+    let json = r#"{
+            "name": "bake_simulation",
+            "affinity": "main"
+        }"#;
+    let decl: ToolDeclaration = serde_json::from_str(json).unwrap();
+    assert_eq!(decl.thread_affinity, ThreadAffinity::Main);
+    assert!(decl.enforce_thread_affinity);
+}
+
+#[test]
+fn test_tool_declaration_defaults_enforcement_when_any_affinity_is_declared() {
+    let json = r#"{
+            "name": "read_manifest",
+            "thread_affinity": "any"
+        }"#;
+    let decl: ToolDeclaration = serde_json::from_str(json).unwrap();
+    assert_eq!(decl.thread_affinity, ThreadAffinity::Any);
+    assert!(decl.enforce_thread_affinity);
+}
+
+#[test]
+fn test_tool_declaration_keeps_legacy_enforcement_default_without_affinity() {
+    let json = r#"{
+            "name": "legacy_tool"
+        }"#;
+    let decl: ToolDeclaration = serde_json::from_str(json).unwrap();
+    assert_eq!(decl.thread_affinity, ThreadAffinity::Any);
+    assert!(!decl.enforce_thread_affinity);
+}
+
+#[test]
+fn test_tool_declaration_allows_explicit_affinity_enforcement_opt_out() {
+    let json = r#"{
+            "name": "standalone_compat",
+            "affinity": "main",
+            "enforce_thread_affinity": false
+        }"#;
+    let decl: ToolDeclaration = serde_json::from_str(json).unwrap();
+    assert_eq!(decl.thread_affinity, ThreadAffinity::Main);
+    assert!(!decl.enforce_thread_affinity);
+}
+
+#[test]
 fn test_agentskills_standard_fields() {
     let json = r#"{
             "name": "pdf-tools",

--- a/crates/dcc-mcp-models/src/skill_metadata/tool_declaration.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata/tool_declaration.rs
@@ -268,8 +268,11 @@ pub struct ToolDeclaration {
 
     /// Enforce that runtime execution happens on the declared affinity thread.
     ///
-    /// Defaults to `false` for compatibility. Studio skills can opt in once
-    /// their `thread_affinity` declarations have been audited.
+    /// Defaults to `true` whenever the declaration explicitly provides
+    /// `thread_affinity` / `affinity`. Legacy tools that omit an affinity
+    /// contract keep the compatibility default (`false`), and explicit
+    /// `enforce_thread_affinity: false` remains an escape hatch for adapters
+    /// that intentionally flatten routing in a standalone context.
     #[serde(
         default,
         rename = "enforce_thread_affinity",
@@ -381,9 +384,9 @@ impl<'de> serde::Deserialize<'de> for ToolDeclaration {
                 alias = "thread_affinity",
                 alias = "affinity"
             )]
-            thread_affinity: ThreadAffinity,
+            thread_affinity: Option<ThreadAffinity>,
             #[serde(rename = "enforce_thread_affinity", alias = "enforce-thread-affinity")]
-            enforce_thread_affinity: bool,
+            enforce_thread_affinity: Option<bool>,
 
             /// Legacy user-level `deferred:` flag — rejected below.
             #[serde(rename = "deferred")]
@@ -464,6 +467,10 @@ impl<'de> serde::Deserialize<'de> for ToolDeclaration {
             }
         };
 
+        let affinity_was_declared = w.thread_affinity.is_some();
+        let thread_affinity = w.thread_affinity.unwrap_or_default();
+        let enforce_thread_affinity = w.enforce_thread_affinity.unwrap_or(affinity_was_declared);
+
         Ok(Self {
             name: w.name,
             description: w.description,
@@ -478,8 +485,8 @@ impl<'de> serde::Deserialize<'de> for ToolDeclaration {
             group: w.group,
             execution: w.execution,
             timeout_hint_secs: w.timeout_hint_secs,
-            thread_affinity: w.thread_affinity,
-            enforce_thread_affinity: w.enforce_thread_affinity,
+            thread_affinity,
+            enforce_thread_affinity,
             _deferred_guard: None,
             annotations,
             required_capabilities: w.required_capabilities,


### PR DESCRIPTION
## Summary
- default ToolDeclaration enforcement when affinity/thread_affinity is explicitly declared
- keep legacy no-affinity declarations unenforced
- preserve explicit enforce_thread_affinity=false as an adapter compatibility escape hatch

## Tests
- cargo test -p dcc-mcp-models