### PR TITLE
feat(admin-ui): improve gateway dashboard interactions

### DIFF
--- a/admin-ui/package-lock.json
+++ b/admin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dcc-mcp-core-admin-ui",
-  "version": "0.16.0",
+  "version": "0.17.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dcc-mcp-core-admin-ui",
-      "version": "0.16.0",
+      "version": "0.17.7",
       "hasInstallScript": true,
       "dependencies": {
         "@vitejs/plugin-react": "latest",

--- a/admin-ui/playwright.config.ts
+++ b/admin-ui/playwright.config.ts
@@ -6,6 +6,12 @@ export default defineConfig({
   retries: 1,
   workers: 1,
   reporter: [['html', { open: 'never' }]],
+  webServer: {
+    command: 'vx npm run dev -- --port 3721',
+    url: 'http://127.0.0.1:3721/admin/',
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
   use: {
     baseURL: 'http://127.0.0.1:3721',
     screenshot: 'only-on-failure',

--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import mayaIcon from './assets/icons/autodesk.svg';
 import blenderIcon from './assets/icons/blender.svg';
 import gimpIcon from './assets/icons/gimp.svg';
@@ -125,6 +125,16 @@ type LogRow = {
   reason?: string | null;
 };
 
+type RequestLogGroup = {
+  requestId: string;
+  timestamp: string;
+  tool: string;
+  dccType: string;
+  status: string;
+  success?: boolean;
+  steps: LogRow[];
+};
+
 type SkillPathRow = {
   path: string;
   source: string;
@@ -186,6 +196,9 @@ function resolveDccIcon(dccType: string): string {
 function adminApiBase(): string {
   const { origin, pathname } = window.location;
   let basePath = pathname.replace(/\/+$/, '');
+  if (basePath.endsWith('/index.html')) {
+    basePath = basePath.slice(0, -'/index.html'.length);
+  }
   if (!basePath || basePath === '/') {
     basePath = '/admin';
   }
@@ -219,6 +232,9 @@ function isPanelId(value: string | null | undefined): value is Panel {
 function adminShellPath(): string {
   const { pathname } = window.location;
   let base = pathname.replace(/\/+$/, '');
+  if (base.endsWith('/index.html')) {
+    base = base.slice(0, -'/index.html'.length);
+  }
   if (!base || base === '/') {
     base = '/admin';
   }
@@ -258,34 +274,6 @@ function readTraceIdFromUrl(): string | null {
   const u = new URL(window.location.href);
   const t = u.searchParams.get('trace');
   return t != null && t.trim() !== '' ? t.trim() : null;
-}
-
-type AdminQuickLinkProps = {
-  panel: Panel;
-  traceId?: string;
-  range?: string;
-  className?: string;
-  children: ReactNode;
-  onNavigate: (panel: Panel, opts?: { traceId?: string; range?: string }) => void;
-};
-
-function AdminQuickLink({ panel, traceId, range, className, children, onNavigate }: AdminQuickLinkProps) {
-  const extra: Record<string, string | undefined> = {};
-  if (traceId) extra.trace = traceId;
-  if (range) extra.range = range;
-  const href = hrefForAdmin(panel, extra);
-  return (
-    <a
-      href={href}
-      className={className ?? 'admin-quick-link'}
-      onClick={(e) => {
-        e.preventDefault();
-        onNavigate(panel, { traceId, range });
-      }}
-    >
-      {children}
-    </a>
-  );
 }
 
 function haystack(...parts: (string | number | null | undefined)[]): string {
@@ -432,13 +420,57 @@ function traceGroupLabel(trace: TraceRow): string {
   return `${trace.dcc_type ?? '?'} · unrouted`;
 }
 
-function logGroupLabel(log: LogRow): string {
+function gatewayLogGroupLabel(log: LogRow): string {
   const dcc = log.dcc_type ?? '?';
   const raw = log.instance_id;
   if (typeof raw === 'string' && raw.length > 0) {
     return `${dcc} · ${raw.length > 8 ? raw.slice(0, 8) : raw}`;
   }
   return `${dcc} · gateway`;
+}
+
+function logStepTitle(log: LogRow): string {
+  if (log.event) {
+    return String(log.event);
+  }
+  if (log.tool) {
+    return log.tool;
+  }
+  return log.source ?? 'event';
+}
+
+function logStepDetail(log: LogRow): string {
+  const parts = [log.message];
+  if (log.detail) parts.push(log.detail);
+  if (log.reason) parts.push(log.reason);
+  return parts.filter(Boolean).join(' — ');
+}
+
+function buildRequestLogGroups(rows: LogRow[]): RequestLogGroup[] {
+  const map = new Map<string, LogRow[]>();
+  for (const row of rows) {
+    if (!row.request_id) {
+      continue;
+    }
+    const bucket = map.get(row.request_id) ?? [];
+    bucket.push(row);
+    map.set(row.request_id, bucket);
+  }
+  return Array.from(map.entries())
+    .map(([requestId, steps]) => {
+      const sorted = [...steps].sort((a, b) => (a.timestamp || '').localeCompare(b.timestamp || ''));
+      const newest = sorted[sorted.length - 1] ?? steps[0];
+      return {
+        requestId,
+        timestamp: newest?.timestamp ?? '',
+        tool: newest?.tool ?? newest?.message ?? 'unknown tool',
+        dccType: newest?.dcc_type ?? '?',
+        status: newest?.success === false ? 'failed' : 'ok',
+        success: newest?.success,
+        steps: sorted,
+      };
+    })
+    .sort((a, b) => (b.timestamp || '').localeCompare(a.timestamp || ''));
 }
 
 function maxTopCount(items: TopEntry[]): number {
@@ -642,6 +674,13 @@ function App() {
     );
   }, [logs, listSearch]);
 
+  const requestLogGroups = useMemo(() => buildRequestLogGroups(filteredLogs), [filteredLogs]);
+
+  const gatewayLogs = useMemo(
+    () => filteredLogs.filter((log) => !log.request_id),
+    [filteredLogs],
+  );
+
   const filteredSkillPaths = useMemo(() => {
     const q = listSearch.trim().toLowerCase();
     if (!q) {
@@ -776,15 +815,23 @@ function App() {
     try {
       const ctrl = new AbortController();
       const tid = window.setTimeout(() => ctrl.abort(), ADMIN_FETCH_TIMEOUT_MS);
-      const res = await fetch(`${API_BASE}/skill-paths`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ path }),
-        signal: ctrl.signal,
-      });
-      clearTimeout(tid);
-      if (!res.ok) {
-        throw new Error(`${res.status} ${res.statusText}`);
+      try {
+        const res = await fetch(`${API_BASE}/skill-paths`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ path }),
+          signal: ctrl.signal,
+        });
+        if (!res.ok) {
+          throw new Error(`${res.status} ${res.statusText}`);
+        }
+      } catch (err) {
+        if (err instanceof DOMException && err.name === 'AbortError') {
+          throw new Error(`Request timed out after ${ADMIN_FETCH_TIMEOUT_MS / 1000}s`);
+        }
+        throw err;
+      } finally {
+        clearTimeout(tid);
       }
       setSkillPathInput('');
       await fetchSkillPaths();
@@ -801,13 +848,21 @@ function App() {
       try {
         const ctrl = new AbortController();
         const tid = window.setTimeout(() => ctrl.abort(), ADMIN_FETCH_TIMEOUT_MS);
-        const res = await fetch(`${API_BASE}/skill-paths/${encodeURIComponent(String(id))}`, {
-          method: 'DELETE',
-          signal: ctrl.signal,
-        });
-        clearTimeout(tid);
-        if (!res.ok) {
-          throw new Error(`${res.status} ${res.statusText}`);
+        try {
+          const res = await fetch(`${API_BASE}/skill-paths/${encodeURIComponent(String(id))}`, {
+            method: 'DELETE',
+            signal: ctrl.signal,
+          });
+          if (!res.ok) {
+            throw new Error(`${res.status} ${res.statusText}`);
+          }
+        } catch (err) {
+          if (err instanceof DOMException && err.name === 'AbortError') {
+            throw new Error(`Request timed out after ${ADMIN_FETCH_TIMEOUT_MS / 1000}s`);
+          }
+          throw err;
+        } finally {
+          clearTimeout(tid);
         }
         await fetchSkillPaths();
       } catch (error) {
@@ -982,7 +1037,7 @@ function App() {
           </div>
         )}
         {activePanel === 'health' && (
-          <section className="panel active">
+          <section className="panel active health-panel">
             <h2>Health</h2>
             <StatusLine text={updatedAt.health} error={errors.health} />
             <div className="health-grid">
@@ -1001,35 +1056,19 @@ function App() {
                 value={health?.limits ? String(health.limits.xff_trusted_depth) : '?'}
               />
               <HealthCard label="Read retries (max)" value={health?.limits ? String(health.limits.read_retry_max) : '?'} />
-              <HealthCard label="Circuit thr / open s" value={health?.limits ? `${health.limits.circuit_failure_threshold} / ${health.limits.circuit_open_secs}s` : '?'} />
+              <HealthCard label="Circuit limit / open" value={health?.limits ? `${health.limits.circuit_failure_threshold} / ${health.limits.circuit_open_secs}s` : '?'} />
               <HealthCard
                 tone={health?.circuits && health.circuits.circuits_open > 0 ? 'warn' : undefined}
-                label="Circuits (open / tracked)"
+                label="Circuits open / tracked"
                 value={health?.circuits ? `${health.circuits.circuits_open} / ${health.circuits.tracked_backends}` : '?'}
               />
             </div>
             <button className="refresh-btn" type="button" onClick={fetchHealth}>Refresh</button>
-            <p className="admin-quick-nav-hint">
-              Quick links (shareable URLs):{' '}
-              <AdminQuickLink panel="instances" onNavigate={goToPanel}>Instances</AdminQuickLink>
-              {' · '}
-              <AdminQuickLink panel="tools" onNavigate={goToPanel}>Tools</AdminQuickLink>
-              {' · '}
-              <AdminQuickLink panel="calls" onNavigate={goToPanel}>Calls</AdminQuickLink>
-              {' · '}
-              <AdminQuickLink panel="traces" onNavigate={goToPanel}>Traces</AdminQuickLink>
-              {' · '}
-              <AdminQuickLink panel="stats" range={statsRange} onNavigate={goToPanel}>Stats</AdminQuickLink>
-              {' · '}
-              <AdminQuickLink panel="logs" onNavigate={goToPanel}>Logs</AdminQuickLink>
-              {' · '}
-              <AdminQuickLink panel="skill-paths" onNavigate={goToPanel}>Skill paths</AdminQuickLink>
-            </p>
           </section>
         )}
 
         {activePanel === 'instances' && (
-          <section className="panel active">
+          <section className="panel active instances-panel">
             <h2>Instances</h2>
             <p className="empty log-hint">
               One row per registered DCC backend (same data as the former Workers tab). Use the links to open the adapter HTTP host, MCP streamable endpoint, or <code>/docs</code> when the host exposes it.
@@ -1069,7 +1108,7 @@ function App() {
         )}
 
         {activePanel === 'tools' && (
-          <section className="panel active">
+          <section className="panel active tools-panel">
             <h2>Tools</h2>
             <StatusLine text={updatedAt.tools} error={errors.tools} />
             {tools.length === 0 ? <p className="empty">No tools registered.</p> : filteredTools.length === 0 ? (
@@ -1100,7 +1139,7 @@ function App() {
         )}
 
         {activePanel === 'calls' && (
-          <section className="panel active">
+          <section className="panel active calls-panel">
             <h2>Recent Calls</h2>
             <StatusLine text={updatedAt.calls} error={errors.calls} />
             {calls.length === 0 ? <p className="empty">No recent calls. AuditMiddleware may not be active.</p> : filteredCalls.length === 0 ? (
@@ -1140,7 +1179,7 @@ function App() {
         )}
 
         {activePanel === 'traces' && (
-          <section className="panel active" data-panel="traces">
+          <section className="panel active traces-panel" data-panel="traces">
             <h2>Traces</h2>
             <StatusLine text={updatedAt.traces} error={errors.traces} />
             {traces.length === 0 ? <p className="empty">No traces recorded.</p> : filteredTraces.length === 0 ? (
@@ -1177,12 +1216,14 @@ function App() {
         )}
 
         {activePanel === 'stats' && (
-          <section className="panel active" data-panel="stats">
+          <section className="panel active stats-panel" data-panel="stats">
             <h2>Stats</h2>
             <StatusLine text={updatedAt.stats} error={errors.stats} />
-            <label className="range-label">
+            <label className="range-label" htmlFor="stats-range-select">
               Range
               <select
+                id="stats-range-select"
+                aria-label="Range"
                 value={statsRange}
                 onChange={(event) => {
                   const v = event.target.value;
@@ -1213,7 +1254,7 @@ function App() {
         )}
 
         {activePanel === 'skill-paths' && (
-          <section className="panel active">
+          <section className="panel active skill-paths-panel">
             <h2>Skill search paths</h2>
             <StatusLine text={updatedAt['skill-paths']} error={errors['skill-paths']} />
             <p className="empty log-hint">
@@ -1279,32 +1320,70 @@ function App() {
             <h2>Event Log</h2>
             <StatusLine text={updatedAt.logs} error={errors.logs} />
             <p className="empty log-hint">
-              Merged feed (newest first): in-memory gateway contention events (same ring as MCP resource <code>resources://gateway/events</code> — elections, yields, evictions, ghost reaping, etc.); optional rolling log files under <code>DCC_MCP_LOG_DIR</code> when that directory exists; recent audit rows (in-memory ring and optional SQLite); operator notes when you add/remove custom skill paths. If nothing has happened yet and no log directory is configured, this list stays empty.
+              Live request stream, refreshed every 5s. Rows with a request id are grouped like a run with ordered steps; gateway events without a request id stay in their own event lane.
             </p>
             {logs.length === 0 ? <p className="empty">No events in buffer yet. Use the gateway (tool calls) or wait for registry / probe activity.</p> : filteredLogs.length === 0 ? (
               <p className="empty">No log lines match your search.</p>
             ) : (
-              Array.from(groupRows(filteredLogs, logGroupLabel).entries())
-              .sort(([a], [b]) => a.localeCompare(b))
-              .map(([group, groupLogs]) => (
-                <div key={group} className="group-block">
-                  <h3 className="group-title">{group}</h3>
-                  {groupLogs.map((log, idx) => (
-                    <div key={`${log.timestamp}-${log.request_id ?? ''}-${idx}`} className="log-line">
-                      <span className="source-pill" data-source={log.source ?? 'contention'}>{log.source ?? 'contention'}</span>
-                      {' '}
-                      <span className="muted">{formatTime(log.timestamp)}</span>
-                      {' '}
-                      <span className="warn-text">[{log.level}]</span>
-                      {' '}
-                      {log.event ? <span className="log-event">{String(log.event)}</span> : null}
-                      {' '}
-                      {log.message}
-                      {log.detail ? <span className="muted"> — {log.detail}</span> : null}
+              <div className="live-log-board">
+                {requestLogGroups.map((run) => (
+                  <div key={run.requestId} className="request-run">
+                    <div className="run-header">
+                      <div>
+                        <div className="run-title">
+                          Request <span className="mono-path">{run.requestId}</span>
+                        </div>
+                        <div className="run-meta">
+                          {formatTime(run.timestamp)} · {run.dccType} · {run.tool}
+                        </div>
+                      </div>
+                      <StatusBadge value={run.status} />
                     </div>
-                  ))}
-                </div>
-              )))}
+                    <div className="run-steps">
+                      {run.steps.map((log, idx) => (
+                        <div key={`${log.timestamp}-${log.source ?? ''}-${idx}`} className="run-step">
+                          <span className={`step-dot ${log.success === false ? 'err' : 'ok'}`} aria-hidden="true" />
+                          <div className="step-body">
+                            <div className="step-head">
+                              <span className="step-name">Step {idx + 1}: {logStepTitle(log)}</span>
+                              <span className="muted">{formatTime(log.timestamp)}</span>
+                              <span className="source-pill" data-source={log.source ?? 'contention'}>{log.source ?? 'contention'}</span>
+                            </div>
+                            <div className="step-detail">{logStepDetail(log)}</div>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+                {gatewayLogs.length > 0 ? (
+                  <div className="group-block">
+                    <h3 className="group-title">Gateway events</h3>
+                    {Array.from(groupRows(gatewayLogs, gatewayLogGroupLabel).entries())
+                      .sort(([a], [b]) => a.localeCompare(b))
+                      .map(([group, groupLogs]) => (
+                        <div key={group} className="gateway-event-group">
+                          <p className="group-meta">{group}</p>
+                          {groupLogs.map((log, idx) => (
+                            <div key={`${log.timestamp}-${log.request_id ?? ''}-${idx}`} className="log-line">
+                              <span className="source-pill" data-source={log.source ?? 'contention'}>{log.source ?? 'contention'}</span>
+                              {' '}
+                              <span className="muted">{formatTime(log.timestamp)}</span>
+                              {' '}
+                              <span className="warn-text">[{log.level}]</span>
+                              {' '}
+                              {log.event ? <span className="log-event">{String(log.event)}</span> : null}
+                              {' '}
+                              {log.message}
+                              {log.detail ? <span className="muted"> — {log.detail}</span> : null}
+                            </div>
+                          ))}
+                        </div>
+                      ))}
+                  </div>
+                ) : null}
+              </div>
+            )}
             <button className="refresh-btn" type="button" onClick={fetchLogs}>Refresh</button>
           </section>
         )}

--- a/admin-ui/src/styles.css
+++ b/admin-ui/src/styles.css
@@ -47,7 +47,7 @@ body {
   font-size: 15px;
   font-weight: 400;
   height: 100vh;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
   line-height: 1.5;
   overflow: hidden;
 }
@@ -148,23 +148,6 @@ select {
 a.nav-link {
   display: block;
   text-decoration: none;
-}
-
-.admin-quick-nav-hint {
-  color: var(--slate-light);
-  font-size: 0.875rem;
-  line-height: 1.6;
-  margin-top: 1rem;
-}
-
-.admin-quick-link {
-  color: var(--accent-warm);
-  font-weight: 500;
-  text-decoration: none;
-}
-
-.admin-quick-link:hover {
-  text-decoration: underline;
 }
 
 .main-stage {
@@ -300,7 +283,7 @@ td .refresh-btn:hover {
 }
 
 .empty {
-  color: var(--cloud-medium);
+  color: var(--slate-light);
   font-size: 0.875rem;
 }
 
@@ -467,6 +450,110 @@ tbody tr:hover td {
 
 .log-line:last-child {
   border-bottom: none;
+}
+
+.live-log-board {
+  display: grid;
+  gap: 1rem;
+}
+
+.request-run {
+  background: #fff;
+  border: 1px solid var(--border-faint);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.run-header {
+  align-items: center;
+  background: var(--ivory-medium);
+  border-bottom: 1px solid var(--border-faint);
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  padding: 0.75rem 0.9rem;
+}
+
+.run-title {
+  color: var(--slate-dark);
+  font-weight: 700;
+}
+
+.run-meta {
+  color: var(--slate-light);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  margin-top: 0.15rem;
+  word-break: break-all;
+}
+
+.run-steps {
+  display: grid;
+  padding: 0.4rem 0.9rem 0.8rem;
+}
+
+.run-step {
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: 0.9rem 1fr;
+  padding: 0.45rem 0;
+  position: relative;
+}
+
+.run-step:not(:last-child)::after {
+  background: var(--border-faint);
+  bottom: -0.4rem;
+  content: '';
+  left: 0.33rem;
+  position: absolute;
+  top: 1.25rem;
+  width: 1px;
+}
+
+.step-dot {
+  border-radius: 50%;
+  height: 0.7rem;
+  margin-top: 0.25rem;
+  width: 0.7rem;
+  z-index: 1;
+}
+
+.step-dot.ok {
+  background: #788c5d;
+}
+
+.step-dot.err {
+  background: #8a3e58;
+}
+
+.step-head {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.step-name {
+  color: var(--slate-dark);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.step-detail {
+  color: var(--slate-medium);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  margin-top: 0.2rem;
+  word-break: break-word;
+}
+
+.gateway-event-group {
+  background: #fff;
+  border: 1px solid var(--border-faint);
+  border-radius: var(--radius);
+  margin-bottom: 0.75rem;
+  padding: 0.65rem 0.8rem;
 }
 
 .muted {
@@ -706,7 +793,7 @@ pre.empty {
 button.linkish {
   background: none;
   border: none;
-  color: var(--ember);
+  color: var(--accent-warm);
   cursor: pointer;
   font: inherit;
   padding: 0;

--- a/admin-ui/tests/admin.spec.ts
+++ b/admin-ui/tests/admin.spec.ts
@@ -1,59 +1,263 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
+
+const now = '2026-05-18T08:00:00.000Z';
+
+async function mockAdminApi(page: Page) {
+  const state = {
+    skillPaths: [
+      { source: 'env:DCC_MCP_SKILL_PATHS', path: 'G:/studio/skills' },
+      { id: 7, source: 'admin_custom', path: 'G:/custom/admin-skills' },
+    ],
+  };
+
+  await page.route('**/admin/api/**', async (route) => {
+    const url = new URL(route.request().url());
+    const path = url.pathname.replace(/^\/admin\/api/, '');
+    const method = route.request().method();
+    let body: unknown;
+    let status = 200;
+
+    if (path === '/health') {
+      body = {
+        status: 'ok',
+        instances_ready: 1,
+        instances_total: 2,
+        uptime_secs: 3723,
+        version: '0.17.7',
+        rss_bytes: 2097152,
+        limits: {
+          body_max_bytes: 1048576,
+          rate_limit_per_minute_per_ip: 60,
+          xff_trusted_depth: 1,
+          read_retry_max: 2,
+          circuit_failure_threshold: 3,
+          circuit_open_secs: 30,
+        },
+        circuits: { tracked_backends: 2, circuits_open: 0 },
+      };
+    } else if (path === '/workers') {
+      body = {
+        total: 2,
+        summary: { live: 1, stale: 1, unhealthy: 0 },
+        workers: [
+          {
+            instance_id: 'maya-1234567890',
+            display_name: 'Maya Layout',
+            dcc_type: 'maya',
+            status: 'ready',
+            stale: false,
+            pid: 4242,
+            uptime_secs: 120,
+            version: '2026',
+            adapter_version: '0.5.0',
+            cpu_percent: 3.5,
+            memory_bytes: 734003200,
+            mcp_url: 'http://127.0.0.1:8765/mcp',
+            scene: 'shot010.ma',
+          },
+          {
+            instance_id: 'blender-abcdef1234',
+            display_name: 'Blender Lookdev',
+            dcc_type: 'blender',
+            status: 'stale',
+            stale: true,
+            pid: null,
+            uptime_secs: null,
+            version: null,
+            adapter_version: null,
+            cpu_percent: null,
+            memory_bytes: null,
+            mcp_url: 'http://127.0.0.1:8766/mcp',
+            scene: null,
+          },
+        ],
+      };
+    } else if (path === '/tools') {
+      body = {
+        total: 2,
+        tools: [
+          {
+            slug: 'maya-1234__create_sphere',
+            dcc_type: 'maya',
+            summary: 'Create a polygon sphere.',
+            skill_name: 'modeling',
+            name: 'create_sphere',
+            instance_id: 'maya-1234567890',
+            instance_prefix: 'maya-123',
+          },
+          {
+            slug: 'blender-abcd__render_preview',
+            dcc_type: 'blender',
+            summary: 'Render a viewport preview.',
+            skill_name: 'rendering',
+            name: 'render_preview',
+            instance_id: 'blender-abcdef1234',
+            instance_prefix: 'blender-',
+          },
+        ],
+      };
+    } else if (path === '/calls') {
+      body = {
+        total: 1,
+        calls: [
+          {
+            timestamp: now,
+            request_id: 'req-123',
+            tool: 'maya-1234__create_sphere',
+            dcc_type: 'maya',
+            status: 'ok',
+            success: true,
+            error: null,
+            duration_ms: 42,
+            instance_id: 'maya-1234567890',
+          },
+        ],
+      };
+    } else if (path === '/traces') {
+      body = {
+        total: 1,
+        traces: [
+          {
+            timestamp: now,
+            request_id: 'req-123',
+            tool: 'maya-1234__create_sphere',
+            dcc_type: 'maya',
+            status: 'ok',
+            success: true,
+            total_ms: 42,
+            instance_id: 'maya-1234567890',
+          },
+        ],
+      };
+    } else if (path === '/traces/req-123') {
+      body = {
+        request_id: 'req-123',
+        method: 'tools/call',
+        spans: [{ name: 'dispatch', duration_ms: 42 }],
+      };
+    } else if (path === '/stats') {
+      body = {
+        range: url.searchParams.get('range') ?? '24h',
+        total_calls: 4,
+        successful_calls: 3,
+        failed_calls: 1,
+        success_rate: 75,
+        latency_ms: { p50_ms: 20, p95_ms: 90 },
+        top_tools: [{ name: 'maya-1234__create_sphere', count: 3 }],
+        top_instances: [{ name: 'maya-1234567890', count: 3 }],
+        hourly_distribution: Array.from({ length: 24 }, (_, i) => (i === 8 ? 4 : 0)),
+      };
+    } else if (path === '/logs') {
+      body = {
+        total: 1,
+        logs: [
+          {
+            timestamp: now,
+            level: 'info',
+            source: 'audit',
+            message: 'tools/call ok 42ms — maya-1234__create_sphere',
+            dcc_type: 'maya',
+            instance_id: 'maya-1234567890',
+            request_id: 'req-123',
+            tool: 'maya-1234__create_sphere',
+            success: true,
+          },
+          {
+            timestamp: '2026-05-18T08:00:01.000Z',
+            level: 'info',
+            source: 'contention',
+            event: 'gateway_elected',
+            message: 'gateway elected dcc_type=gateway instance=local',
+            dcc_type: 'gateway',
+            instance_id: 'local',
+          },
+        ],
+      };
+    } else if (path === '/skill-paths' && method === 'GET') {
+      body = { paths: state.skillPaths };
+    } else if (path === '/skill-paths' && method === 'POST') {
+      const payload = route.request().postDataJSON() as { path?: string };
+      state.skillPaths.push({ id: 8, source: 'admin_custom', path: payload.path ?? '' });
+      body = { ok: true, path: payload.path };
+    } else if (path === '/skill-paths/7' && method === 'DELETE') {
+      state.skillPaths = state.skillPaths.filter((row) => row.id !== 7);
+      body = { ok: true, id: 7 };
+    } else {
+      status = 404;
+      body = { error: `Unhandled test route: ${method} ${path}` };
+    }
+
+    await route.fulfill({
+      status,
+      contentType: 'application/json',
+      body: JSON.stringify(body),
+    });
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  await mockAdminApi(page);
+});
 
 test.describe('Admin Page', () => {
-  test('should load admin page and display health panel', async ({ page }) => {
+  test('loads the health panel and navigation', async ({ page }) => {
     await page.goto('/admin/');
     await expect(page.locator('h1')).toContainText('DCC-MCP Gateway');
-    await expect(page.locator('.nav button', { hasText: 'Health' })).toBeVisible();
-  });
-
-  test('should display all navigation panels', async ({ page }) => {
-    await page.goto('/admin/');
-    const panels = ['Health', 'Instances', 'Tools', 'Calls', 'Traces', 'Stats', 'Workers', 'Logs'];
-    for (const label of panels) {
-      await expect(page.locator('.nav button', { hasText: label })).toBeVisible();
+    await expect(page.getByRole('navigation').getByRole('link', { name: 'Health' })).toHaveClass(/active/);
+    for (const label of ['Health', 'Instances', 'Tools', 'Calls', 'Traces', 'Stats', 'Skill paths', 'Logs']) {
+      await expect(page.getByRole('navigation').getByRole('link', { name: label })).toBeVisible();
     }
+    await expect(page.locator('.health-panel')).toContainText('0.17.7');
   });
 
-  test('should switch to Instances panel and show icons', async ({ page }) => {
+  test('switches to instances, renders DCC cards, and filters rows', async ({ page }) => {
     await page.goto('/admin/');
-    await page.click('button:has-text("Instances")');
-    await page.waitForSelector('.instances-panel');
-    // Check that DCC icons are rendered (img with data:image/svg+xml)
-    const icons = await page.locator('.dcc-icon').count();
-    if (icons > 0) {
-      await expect(page.locator('.dcc-icon').first()).toHaveAttribute('src', /data:image\/svg\+xml/);
-    }
+    await page.getByRole('navigation').getByRole('link', { name: 'Instances' }).click();
+    await expect(page.locator('.instances-panel')).toBeVisible();
+    await expect(page.locator('.dcc-icon')).toHaveCount(2);
+    await page.getByLabel('Filter current panel').fill('blender');
+    await expect(page.locator('.worker-card')).toHaveCount(1);
+    await expect(page.locator('.worker-card')).toContainText('Blender Lookdev');
   });
 
-  test('should switch to Logs panel and display log rows', async ({ page }) => {
+  test('opens trace detail from the calls panel and keeps the URL shareable', async ({ page }) => {
     await page.goto('/admin/');
-    await page.click('button:has-text("Logs")');
-    await page.waitForSelector('.logs-panel');
-    // Logs panel should either show rows or "no data" message
-    const hasRows = await page.locator('.log-row').count();
-    expect(hasRows).toBeGreaterThanOrEqual(0);
+    await page.getByRole('navigation').getByRole('link', { name: 'Calls' }).click();
+    await page.getByRole('button', { name: 'req-123' }).click();
+    await expect(page).toHaveURL(/panel=traces/);
+    await expect(page).toHaveURL(/trace=req-123/);
+    await expect(page.locator('.traces-panel pre')).toContainText('"request_id": "req-123"');
+    await expect(page.locator('.traces-panel pre')).toContainText('"dispatch"');
   });
 
-  test('should switch to Stats panel and display stats cards', async ({ page }) => {
-    await page.goto('/admin/');
-    await page.click('button:has-text("Stats")');
-    await page.waitForSelector('.stats-panel');
-    await expect(page.locator('.health-card')).toHaveCount(4); // total, success rate, p50, p95
+  test('updates stats when the range selector changes', async ({ page }) => {
+    await page.goto('/admin/?panel=stats&range=1h');
+    await expect(page.locator('.stats-panel')).toBeVisible();
+    await expect(page.getByLabel('Range')).toHaveValue('1h');
+    await page.getByLabel('Range').selectOption('7d');
+    await expect(page).toHaveURL(/range=7d/);
+    await expect(page.locator('.stats-panel')).toContainText('Range 7d');
   });
 
-  test('should switch to Traces panel and display trace rows', async ({ page }) => {
-    await page.goto('/admin/');
-    await page.click('button:has-text("Traces")');
-    await page.waitForSelector('.traces-panel');
-    const hasRows = await page.locator('.trace-row').count();
-    expect(hasRows).toBeGreaterThanOrEqual(0);
+  test('adds and removes SQLite-backed skill paths', async ({ page }) => {
+    await page.goto('/admin/?panel=skill-paths');
+    await expect(page.locator('.skill-paths-panel')).toContainText('G:/custom/admin-skills');
+    await page.getByLabel('New skill path').fill('G:/new/team-skills');
+    await page.getByRole('button', { name: 'Add path' }).click();
+    await expect(page.locator('.skill-paths-panel')).toContainText('G:/new/team-skills');
+    await page.getByRole('button', { name: 'Remove' }).first().click();
+    await expect(page.locator('.skill-paths-panel')).not.toContainText('G:/custom/admin-skills');
   });
 
-  test('should display search filter in Instances panel', async ({ page }) => {
+  test('shows logs and panel search metadata', async ({ page }) => {
     await page.goto('/admin/');
-    await page.click('button:has-text("Instances")');
-    await page.waitForSelector('.search-input');
-    await expect(page.locator('.search-input')).toBeVisible();
+    await page.getByRole('navigation').getByRole('link', { name: 'Logs' }).click();
+    await expect(page.locator('.logs-panel')).toContainText('Request req-123');
+    await expect(page.locator('.logs-panel')).toContainText('Step 1: maya-1234__create_sphere');
+    await expect(page.locator('.logs-panel')).toContainText('Gateway events');
+    await expect(page.locator('.logs-panel')).toContainText('tools/call ok');
+    await page.getByLabel('Filter current panel').fill('missing');
+    await expect(page.locator('.list-search-meta')).toHaveText('0 / 2');
+    await expect(page.locator('.logs-panel')).toContainText('No log lines match your search.');
   });
 });


### PR DESCRIPTION
## Summary

- improve the embedded admin dashboard navigation and panel behavior
- make logs easier to read by grouping request-scoped entries into run-style steps and separating gateway events
- add stronger Playwright coverage with mocked admin API data and self-starting Vite test server

## Validation

- `vx npm run build`
- `vx npm test -- --reporter=list`
- `vx cargo test -p dcc-mcp-gateway gateway::admin::tests --features admin,admin-persist-sqlite`
- `git diff --check`
