### PR TITLE
feat: harden gateway initialization

### DIFF
--- a/crates/dcc-mcp-cli/src/application/client.rs
+++ b/crates/dcc-mcp-cli/src/application/client.rs
@@ -69,4 +69,91 @@ impl DccMcpClient {
             .await
             .map_err(Into::into)
     }
+
+    pub async fn smoke(&self, mcp_url: Option<String>, query: String, limit: usize) -> Value {
+        let mcp_url = mcp_url.unwrap_or_else(|| self.endpoint.mcp_url());
+        let mut checks = Vec::new();
+
+        let health = self.gateway.get_json(&self.endpoint.path("/health")).await;
+        checks.push(check_json("health", &self.endpoint.path("/health"), health));
+
+        let initialize = self
+            .gateway
+            .post_json_with_headers(
+                &mcp_url,
+                &json!({
+                    "jsonrpc": "2.0",
+                    "id": "smoke-initialize",
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2025-03-26",
+                        "capabilities": {},
+                        "clientInfo": {
+                            "name": "dcc-mcp-cli",
+                            "version": env!("CARGO_PKG_VERSION")
+                        }
+                    }
+                }),
+                &[("Mcp-Protocol-Version", "2025-03-26")],
+            )
+            .await;
+        checks.push(check_json("mcp_initialize", &mcp_url, initialize));
+
+        let tools_list = self
+            .gateway
+            .post_json_with_headers(
+                &mcp_url,
+                &json!({
+                    "jsonrpc": "2.0",
+                    "id": "smoke-tools-list",
+                    "method": "tools/list",
+                    "params": {}
+                }),
+                &[("Mcp-Protocol-Version", "2025-03-26")],
+            )
+            .await;
+        checks.push(check_json("mcp_tools_list", &mcp_url, tools_list));
+
+        let search_body = json!({
+            "query": query,
+            "limit": limit,
+        });
+        let search = self
+            .gateway
+            .post_json(&self.endpoint.path("/v1/search"), &search_body)
+            .await;
+        checks.push(check_json(
+            "rest_search",
+            &self.endpoint.path("/v1/search"),
+            search,
+        ));
+
+        let ok = checks
+            .iter()
+            .all(|check| check.get("ok").and_then(Value::as_bool).unwrap_or(false));
+
+        json!({
+            "ok": ok,
+            "base_url": self.endpoint.base_url.clone(),
+            "mcp_url": mcp_url,
+            "checks": checks,
+        })
+    }
+}
+
+fn check_json(name: &str, url: &str, result: Result<Value, HttpError>) -> Value {
+    match result {
+        Ok(value) => json!({
+            "name": name,
+            "url": url,
+            "ok": value.get("error").is_none(),
+            "response": value,
+        }),
+        Err(error) => json!({
+            "name": name,
+            "url": url,
+            "ok": false,
+            "error": error.to_string(),
+        }),
+    }
 }

--- a/crates/dcc-mcp-cli/src/domain/rest.rs
+++ b/crates/dcc-mcp-cli/src/domain/rest.rs
@@ -40,6 +40,19 @@ impl Endpoint {
     pub fn path(&self, path: &str) -> String {
         format!("{}/{}", self.base_url, path.trim_start_matches('/'))
     }
+
+    #[must_use]
+    pub fn mcp_url(&self) -> String {
+        self.path("/mcp")
+    }
+
+    #[must_use]
+    pub fn from_mcp_url(url: impl Into<String>) -> Self {
+        let url = url.into();
+        let trimmed = url.trim_end_matches('/');
+        let base_url = trimmed.strip_suffix("/mcp").unwrap_or(trimmed).to_string();
+        Self { base_url }
+    }
 }
 
 #[cfg(test)]
@@ -53,6 +66,13 @@ mod tests {
             endpoint.path("/v1/instances"),
             "http://127.0.0.1:9765/v1/instances"
         );
+    }
+
+    #[test]
+    fn endpoint_accepts_mcp_url_for_base() {
+        let endpoint = Endpoint::from_mcp_url("http://127.0.0.1:9765/mcp");
+        assert_eq!(endpoint.base_url, "http://127.0.0.1:9765");
+        assert_eq!(endpoint.mcp_url(), "http://127.0.0.1:9765/mcp");
     }
 
     #[test]

--- a/crates/dcc-mcp-cli/src/infra/http.rs
+++ b/crates/dcc-mcp-cli/src/infra/http.rs
@@ -21,16 +21,21 @@ pub struct HttpGateway {
 
 impl Default for HttpGateway {
     fn default() -> Self {
-        Self {
-            client: reqwest::Client::builder()
-                .timeout(Duration::from_secs(30))
-                .build()
-                .unwrap_or_else(|_| reqwest::Client::new()),
-        }
+        Self::with_timeout(Duration::from_secs(30))
     }
 }
 
 impl HttpGateway {
+    #[must_use]
+    pub fn with_timeout(timeout: Duration) -> Self {
+        Self {
+            client: reqwest::Client::builder()
+                .timeout(timeout)
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
+        }
+    }
+
     pub async fn get_json(&self, url: &str) -> Result<Value, HttpError> {
         let response = self.client.get(url).send().await?;
         Self::json_response(response).await
@@ -38,6 +43,20 @@ impl HttpGateway {
 
     pub async fn post_json(&self, url: &str, body: &Value) -> Result<Value, HttpError> {
         let response = self.client.post(url).json(body).send().await?;
+        Self::json_response(response).await
+    }
+
+    pub async fn post_json_with_headers(
+        &self,
+        url: &str,
+        body: &Value,
+        headers: &[(&str, &str)],
+    ) -> Result<Value, HttpError> {
+        let mut request = self.client.post(url).json(body);
+        for (name, value) in headers {
+            request = request.header(*name, *value);
+        }
+        let response = request.send().await?;
         Self::json_response(response).await
     }
 

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeSet;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::Context;
 use clap::{Parser, Subcommand, ValueEnum};
@@ -12,6 +13,7 @@ use crate::application::client::DccMcpClient;
 use crate::application::install::InstallService;
 use crate::domain::install::InstallRequest;
 use crate::domain::rest::{CallRequest, DescribeRequest, Endpoint, SearchRequest};
+use crate::infra::http::HttpGateway;
 
 const DEFAULT_BASE_URL: &str = "http://127.0.0.1:9765";
 
@@ -34,6 +36,21 @@ enum OutputFormat {
 
 #[derive(Debug, Subcommand)]
 enum Command {
+    /// Run health + MCP + REST smoke checks against a service.
+    Smoke {
+        /// MCP URL or base URL. Accepts either http://host:port or http://host:port/mcp.
+        #[arg(long)]
+        url: Option<String>,
+        /// Query used for the REST dynamic-capability search check.
+        #[arg(long, default_value = "sphere")]
+        query: String,
+        /// Result limit used for the REST dynamic-capability search check.
+        #[arg(long, default_value = "5")]
+        limit: usize,
+        /// Per-request timeout for smoke checks.
+        #[arg(long, default_value = "5")]
+        timeout_secs: u64,
+    },
     /// Check the configured gateway or per-DCC REST endpoint.
     Health,
     /// List live DCC instances from the gateway.
@@ -98,6 +115,25 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
 
     let mut failed = false;
     let value = match command {
+        Command::Smoke {
+            url,
+            query,
+            limit,
+            timeout_secs,
+        } => {
+            let endpoint = url
+                .as_deref()
+                .map(Endpoint::from_mcp_url)
+                .unwrap_or_else(|| Endpoint::new(base_url));
+            let mcp_url = url.as_ref().map(|raw| endpoint_for_mcp(raw));
+            let client = DccMcpClient::with_gateway(
+                endpoint,
+                HttpGateway::with_timeout(Duration::from_secs(timeout_secs.max(1))),
+            );
+            let result = client.smoke(mcp_url, query, limit).await;
+            failed = !result.get("ok").and_then(Value::as_bool).unwrap_or(false);
+            result
+        }
         Command::Health => {
             let client = DccMcpClient::new(Endpoint::new(base_url));
             client.health().await?
@@ -284,6 +320,15 @@ fn parse_json_object(raw: &str, flag_name: &str) -> anyhow::Result<Value> {
         Ok(value)
     } else {
         anyhow::bail!("{flag_name} must be a JSON object")
+    }
+}
+
+fn endpoint_for_mcp(raw: &str) -> String {
+    let trimmed = raw.trim_end_matches('/');
+    if trimmed.ends_with("/mcp") {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed}/mcp")
     }
 }
 

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -26,6 +26,51 @@ impl Drop for GatewayFixture {
 
 fn spawn_gateway_fixture() -> GatewayFixture {
     let app = Router::new()
+        .route(
+            "/health",
+            get(|| async { Json(json!({"ok": true, "service": "dcc-mcp-gateway"})) }),
+        )
+        .route(
+            "/mcp",
+            post(|Json(body): Json<Value>| async move {
+                let method = body.get("method").and_then(Value::as_str).unwrap_or("");
+                match method {
+                    "initialize" => Json(json!({
+                        "jsonrpc": "2.0",
+                        "id": body.get("id").cloned().unwrap_or(json!(null)),
+                        "result": {
+                            "protocolVersion": "2025-03-26",
+                            "capabilities": {
+                                "tools": {"listChanged": true}
+                            },
+                            "serverInfo": {
+                                "name": "fixture-gateway",
+                                "version": "0.0.0-test"
+                            }
+                        }
+                    })),
+                    "tools/list" => Json(json!({
+                        "jsonrpc": "2.0",
+                        "id": body.get("id").cloned().unwrap_or(json!(null)),
+                        "result": {
+                            "tools": [{
+                                "name": "search_tools",
+                                "description": "Search tools",
+                                "inputSchema": {"type": "object"}
+                            }]
+                        }
+                    })),
+                    _ => Json(json!({
+                        "jsonrpc": "2.0",
+                        "id": body.get("id").cloned().unwrap_or(json!(null)),
+                        "error": {
+                            "code": -32601,
+                            "message": "method not found"
+                        }
+                    })),
+                }
+            }),
+        )
         .route("/v1/healthz", get(|| async { Json(json!({"ok": true})) }))
         .route(
             "/v1/instances",
@@ -164,6 +209,30 @@ fn list_search_describe_and_call_gateway_rest_surface() {
     ]);
     assert_eq!(call["success"], true);
     assert_eq!(call["arguments"]["radius"], 2);
+}
+
+#[test]
+fn smoke_checks_gateway_mcp_and_rest_surfaces() {
+    let fixture = spawn_gateway_fixture();
+    let value = run_json(&[
+        "--base-url",
+        &fixture.base_url,
+        "smoke",
+        "--url",
+        &format!("{}/mcp", fixture.base_url),
+    ]);
+
+    assert_eq!(value["ok"], true);
+    assert_eq!(value["mcp_url"], format!("{}/mcp", fixture.base_url));
+    let checks = value["checks"].as_array().unwrap();
+    for expected in ["health", "mcp_initialize", "mcp_tools_list", "rest_search"] {
+        assert!(
+            checks
+                .iter()
+                .any(|check| check["name"] == expected && check["ok"] == true),
+            "missing successful smoke check {expected}: {checks:#?}"
+        );
+    }
 }
 
 #[test]

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
@@ -591,10 +591,10 @@ async fn gateway_mcp_concurrent_initialize_completes_within_one_second() {
 }
 
 #[tokio::test]
-async fn gateway_mcp_initialize_timeout_returns_gateway_busy() {
-    // Issue #1009 — server-side 5s cap returns structured gateway-busy instead
-    // of hanging until the MCP client's own init timeout fires.
-    use dcc_mcp_jsonrpc::error_codes::GATEWAY_BUSY;
+async fn gateway_mcp_initialize_does_not_wait_for_protocol_cache_lock() {
+    // The protocol-version cache is diagnostic state, not a handshake
+    // dependency. If another task holds the lock, initialize must still
+    // complete normally so multiple MCP clients do not queue behind it.
     use std::time::Duration;
 
     let dir = tempfile::tempdir().unwrap();
@@ -624,7 +624,7 @@ async fn gateway_mcp_initialize_timeout_returns_gateway_busy() {
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(8))
+        .timeout(Duration::from_secs(2))
         .build()
         .unwrap();
     let resp: Value = client
@@ -642,8 +642,8 @@ async fn gateway_mcp_initialize_timeout_returns_gateway_busy() {
         .await
         .unwrap();
 
-    assert_eq!(resp["error"]["code"], json!(GATEWAY_BUSY));
-    assert_eq!(resp["error"]["data"]["reason"], json!("gateway-busy"));
+    assert_eq!(resp["result"]["protocolVersion"], json!("2025-03-26"));
+    assert!(resp.get("error").is_none(), "initialize failed: {resp}");
 
     hold.abort();
     let _ = shutdown_tx.send(());

--- a/crates/dcc-mcp-gateway/src/gateway/config.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/config.rs
@@ -53,6 +53,13 @@ pub struct GatewayConfig {
     pub host: String,
     /// Well-known port to compete for. `0` disables the gateway.
     pub gateway_port: u16,
+    /// Optional second gateway listener for remote/LAN clients.
+    ///
+    /// This listener does not participate in gateway election; the local
+    /// `host:gateway_port` bind remains the single authority.
+    pub remote_host: Option<String>,
+    /// Optional second gateway port for remote/LAN clients. `0` disables it.
+    pub remote_gateway_port: u16,
     /// Seconds without heartbeat before an instance is considered stale.
     pub stale_timeout_secs: u64,
     /// Heartbeat interval in seconds. `0` disables the heartbeat task.
@@ -141,6 +148,8 @@ impl Default for GatewayConfig {
         Self {
             host: "127.0.0.1".to_string(),
             gateway_port: 9765,
+            remote_host: None,
+            remote_gateway_port: 0,
             stale_timeout_secs: 30,
             heartbeat_secs: 5,
             server_name: "dcc-mcp-gateway".to_string(),

--- a/crates/dcc-mcp-gateway/src/gateway/config.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/config.rs
@@ -75,6 +75,11 @@ pub struct GatewayConfig {
     ///
     /// Default: `120` seconds (12 × 10-second retry intervals).
     pub challenger_timeout_secs: u64,
+    /// Seconds between challenger bind attempts after an incumbent yields.
+    ///
+    /// Default: `10` seconds. Tests and embedded adapters may lower this
+    /// when they need faster failover without changing the overall timeout.
+    pub challenger_poll_interval_secs: u64,
     /// Per-backend request timeout (milliseconds) used for fan-out calls
     /// from the gateway to each live DCC instance. Default: `10_000`.
     /// Issue #314.
@@ -156,6 +161,7 @@ impl Default for GatewayConfig {
             server_version: env!("CARGO_PKG_VERSION").to_string(),
             registry_dir: None,
             challenger_timeout_secs: 120,
+            challenger_poll_interval_secs: 10,
             backend_timeout_ms: 10_000,
             async_dispatch_timeout_ms: 60_000,
             wait_terminal_timeout_ms: 600_000,

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
@@ -216,9 +216,16 @@ async fn handle_initialize(gs: &GatewayState, id: Value, req: &JsonRpcRequest) -
         .and_then(|params| params.get("protocolVersion"))
         .and_then(|value| value.as_str());
     let negotiated = negotiate_protocol_version(client_version);
-    {
-        let mut protocol_version = gs.protocol_version.write().await;
-        *protocol_version = Some(negotiated.to_string());
+    match gs.protocol_version.try_write() {
+        Ok(mut protocol_version) => {
+            *protocol_version = Some(negotiated.to_string());
+        }
+        Err(_) => {
+            tracing::warn!(
+                protocol_version = negotiated,
+                "gateway initialize: protocol version lock busy; continuing without updating cached value"
+            );
+        }
     }
 
     json!({

--- a/crates/dcc-mcp-gateway/src/gateway/runner.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/runner.rs
@@ -59,7 +59,8 @@ impl GatewayRunner {
     ///    - First tries a cooperative [`POST /gateway/yield`] to the existing
     ///      gateway (works if the gateway supports it, i.e. is also `≥ 0.12.29`).
     ///    - Regardless of the response, enters a **challenger retry loop** that
-    ///      polls the port every 10 s for up to `challenger_timeout_secs`.
+    ///      polls the port every `challenger_poll_interval_secs` for up to
+    ///      `challenger_timeout_secs`.
     ///    - When the port becomes free (old gateway yielded or crashed),
     ///      the challenger binds it and becomes the new gateway.
     ///
@@ -435,9 +436,9 @@ impl GatewayRunner {
                 // crate version as the dead gateway would never poll
                 // for the port to free up — they would stay as plain
                 // instances forever, leaving 9765 dark until someone
-                // restarts a DCC. The challenger loop polls every 10 s
-                // (up to ``challenger_timeout_secs``) and wins the bind
-                // the moment TIME_WAIT releases (#893 follow-up).
+                // restarts a DCC. The challenger loop polls up to
+                // ``challenger_timeout_secs`` and wins the bind the
+                // moment TIME_WAIT releases (#893 follow-up).
                 let challenger_reason = if gw_version.is_empty() {
                     "Bind failed but no resident sentinel (TIME_WAIT / race) — entering challenger mode"
                 } else if is_newer_election(own_info, gw_info) {
@@ -511,6 +512,7 @@ impl GatewayRunner {
         let max_routes_per_session = self.config.max_routes_per_session as usize;
         let server_name = self.config.server_name.clone();
         let timeout_secs = self.config.challenger_timeout_secs;
+        let poll_interval_secs = self.config.challenger_poll_interval_secs.max(1);
         let allow_unknown_tools = self.config.allow_unknown_tools;
         let remote_host = self.config.remote_host.clone();
         let remote_gateway_port = self.config.remote_gateway_port;
@@ -561,9 +563,9 @@ impl GatewayRunner {
             }
 
             // ── Retry loop ────────────────────────────────────────────────
-            let max_retries = (timeout_secs / 10).max(1);
+            let max_retries = (timeout_secs / poll_interval_secs).max(1);
             for attempt in 1..=max_retries {
-                tokio::time::sleep(Duration::from_secs(10)).await;
+                tokio::time::sleep(Duration::from_secs(poll_interval_secs)).await;
 
                 if let Some(listener) = try_bind_port_opt(&host, port).await {
                     tracing::info!(
@@ -613,7 +615,7 @@ impl GatewayRunner {
                         bind_remote_gateway_listener(remote_host.clone(), remote_gateway_port)
                             .await;
 
-                    if let Err(e) = start_gateway_tasks(
+                    match start_gateway_tasks(
                         listener,
                         remote_listener,
                         registry.clone(),
@@ -625,7 +627,7 @@ impl GatewayRunner {
                         max_routes_per_session,
                         format!("{server_name} (gateway)"),
                         own_ver.clone(),
-                        sentinel_key,
+                        sentinel_key.clone(),
                         host.clone(),
                         port,
                         allow_unknown_tools,
@@ -643,7 +645,23 @@ impl GatewayRunner {
                     )
                     .await
                     {
-                        tracing::error!("Challenger: failed to start gateway tasks: {e}");
+                        Ok(tasks) => {
+                            tracing::info!(
+                                version = %own_ver,
+                                "Challenger: promoted to gateway"
+                            );
+                            let _guard = PromotedGatewayGuard {
+                                abort: Some(tasks.abort),
+                                registry: registry.clone(),
+                                sentinel_key: Some(sentinel_key),
+                            };
+                            let _ = tasks.supervisor.await;
+                        }
+                        Err(e) => {
+                            tracing::error!("Challenger: failed to start gateway tasks: {e}");
+                            let reg = registry.read().await;
+                            let _ = reg.deregister(&sentinel_key);
+                        }
                     }
                     return;
                 }
@@ -667,6 +685,25 @@ impl GatewayRunner {
             self.config.remote_gateway_port,
         )
         .await
+    }
+}
+
+struct PromotedGatewayGuard {
+    abort: Option<AbortHandle>,
+    registry: Arc<RwLock<FileRegistry>>,
+    sentinel_key: Option<ServiceKey>,
+}
+
+impl Drop for PromotedGatewayGuard {
+    fn drop(&mut self) {
+        if let Some(abort) = self.abort.take() {
+            abort.abort();
+        }
+        if let Some(key) = self.sentinel_key.take()
+            && let Ok(registry) = self.registry.try_read()
+        {
+            let _ = registry.deregister(&key);
+        }
     }
 }
 

--- a/crates/dcc-mcp-gateway/src/gateway/runner.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/runner.rs
@@ -309,8 +309,11 @@ impl GatewayRunner {
                     let _ = reg.register(sentinel);
                 }
 
+                let remote_listener = self.bind_remote_gateway_listener().await;
+
                 match start_gateway_tasks(
                     listener,
+                    remote_listener,
                     self.registry.clone(),
                     stale_timeout,
                     backend_timeout,
@@ -509,6 +512,8 @@ impl GatewayRunner {
         let server_name = self.config.server_name.clone();
         let timeout_secs = self.config.challenger_timeout_secs;
         let allow_unknown_tools = self.config.allow_unknown_tools;
+        let remote_host = self.config.remote_host.clone();
+        let remote_gateway_port = self.config.remote_gateway_port;
         let adapter_version = self.config.adapter_version.clone();
         let adapter_dcc = self.config.adapter_dcc.clone();
         let middleware_chain = self.config.middleware_chain.clone();
@@ -604,8 +609,13 @@ impl GatewayRunner {
                         let _ = reg.register(sentinel);
                     }
 
+                    let remote_listener =
+                        bind_remote_gateway_listener(remote_host.clone(), remote_gateway_port)
+                            .await;
+
                     if let Err(e) = start_gateway_tasks(
                         listener,
+                        remote_listener,
                         registry.clone(),
                         stale_timeout,
                         backend_timeout,
@@ -649,6 +659,42 @@ impl GatewayRunner {
         });
 
         handle.abort_handle()
+    }
+
+    async fn bind_remote_gateway_listener(&self) -> Option<tokio::net::TcpListener> {
+        bind_remote_gateway_listener(
+            self.config.remote_host.clone(),
+            self.config.remote_gateway_port,
+        )
+        .await
+    }
+}
+
+async fn bind_remote_gateway_listener(
+    remote_host: Option<String>,
+    remote_gateway_port: u16,
+) -> Option<tokio::net::TcpListener> {
+    if remote_gateway_port == 0 {
+        return None;
+    }
+    let host = remote_host.unwrap_or_else(|| "0.0.0.0".to_string());
+    match try_bind_port_opt(&host, remote_gateway_port).await {
+        Some(listener) => {
+            tracing::info!(
+                host = %host,
+                port = remote_gateway_port,
+                "Gateway remote listener enabled"
+            );
+            Some(listener)
+        }
+        None => {
+            tracing::warn!(
+                host = %host,
+                port = remote_gateway_port,
+                "Gateway remote listener unavailable; continuing with local gateway only"
+            );
+            None
+        }
     }
 }
 

--- a/crates/dcc-mcp-gateway/src/gateway/tasks.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tasks.rs
@@ -37,6 +37,7 @@ const ADMIN_AUDIT_RING_CAPACITY: usize = 512;
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn start_gateway_tasks(
     listener: tokio::net::TcpListener,
+    remote_listener: Option<tokio::net::TcpListener>,
     registry: Arc<RwLock<FileRegistry>>,
     stale_timeout: Duration,
     backend_timeout: Duration,
@@ -60,7 +61,7 @@ pub(crate) async fn start_gateway_tasks(
     health_check_failures: u32,
 ) -> Result<GatewayTasks, Box<dyn std::error::Error + Send + Sync>> {
     // ── Yield channel ─────────────────────────────────────────────────────
-    let (yield_tx, mut yield_rx) = watch::channel(false);
+    let (yield_tx, yield_rx) = watch::channel(false);
     let yield_tx = Arc::new(yield_tx);
 
     // ── SSE broadcast channel ──────────────────────────────────────────────
@@ -655,19 +656,31 @@ pub(crate) async fn start_gateway_tasks(
     let gw_router = super::metrics::attach_gateway_metrics_route(gw_router);
 
     let actual = listener.local_addr()?;
+    let remote_actual = remote_listener
+        .as_ref()
+        .and_then(|listener| listener.local_addr().ok());
     tracing::info!(
         "Gateway listening on http://{}  (GET /mcp = SSE stream, POST /mcp = MCP endpoint)",
         actual
     );
+    if let Some(addr) = remote_actual {
+        tracing::info!(
+            "Gateway remote listener on http://{}  (LAN clients should use the machine IP, not 0.0.0.0)",
+            addr
+        );
+    }
 
+    let local_yield_rx = yield_rx.clone();
+    let local_router = gw_router.clone();
     let gw_handle = tokio::spawn(async move {
         use std::net::SocketAddr;
 
         axum::serve(
             listener,
-            gw_router.into_make_service_with_connect_info::<SocketAddr>(),
+            local_router.into_make_service_with_connect_info::<SocketAddr>(),
         )
         .with_graceful_shutdown(async move {
+            let mut yield_rx = local_yield_rx;
             loop {
                 if yield_rx.changed().await.is_err() {
                     break;
@@ -681,6 +694,36 @@ pub(crate) async fn start_gateway_tasks(
         .await
         .ok();
     });
+
+    let remote_handle = remote_listener
+        .map(|remote_listener| {
+            let mut remote_yield_rx = yield_rx.clone();
+            let remote_router = gw_router.clone();
+            tokio::spawn(async move {
+                use std::net::SocketAddr;
+
+                axum::serve(
+                    remote_listener,
+                    remote_router.into_make_service_with_connect_info::<SocketAddr>(),
+                )
+                .with_graceful_shutdown(async move {
+                    loop {
+                        if remote_yield_rx.changed().await.is_err() {
+                            break;
+                        }
+                        if *remote_yield_rx.borrow() {
+                            tracing::info!(
+                                "Gateway remote listener: graceful shutdown triggered — releasing port"
+                            );
+                            break;
+                        }
+                    }
+                })
+                .await
+                .ok();
+            })
+        })
+        .unwrap_or_else(|| tokio::spawn(async {}));
 
     // Periodic health-check task (issue #556)
     let health_cfg = health::HealthCheckConfig {
@@ -715,6 +758,7 @@ pub(crate) async fn start_gateway_tasks(
             route_gc_handle,
             health_check_handle,
             gw_handle,
+            remote_handle,
             metrics_handle
         );
     });
@@ -729,7 +773,8 @@ pub(crate) async fn start_gateway_tasks(
             backend_sub_handle,
             route_gc_handle,
             health_check_handle,
-            gw_handle
+            gw_handle,
+            remote_handle
         );
     });
 
@@ -759,6 +804,15 @@ pub(crate) async fn start_gateway_tasks(
         // rely on `combined.abort_handle()` / `yield_tx` for cleanup.
         tokio::time::sleep(Duration::from_millis(50)).await;
         return Err(format!("gateway listener self-probe failed at {actual}: {e}").into());
+    }
+    if let Some(addr) = remote_actual
+        && let Err(e) = self_probe_listener(addr).await
+    {
+        tracing::warn!(
+            addr = %addr,
+            error = %e,
+            "Gateway remote listener self-probe failed — local gateway remains active"
+        );
     }
 
     Ok(GatewayTasks {

--- a/crates/dcc-mcp-gateway/src/gateway/tasks/probe.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tasks/probe.rs
@@ -80,6 +80,7 @@ pub(crate) async fn probe_and_evict_dead_instances(
 /// PyO3-embedded hosts where workers are slow to pick up newly spawned tasks
 /// (issue #303).
 pub(crate) async fn self_probe_listener(addr: std::net::SocketAddr) -> Result<(), std::io::Error> {
+    let addr = probe_addr(addr);
     const MAX_ATTEMPTS: u32 = 10;
     const ATTEMPT_TIMEOUT: Duration = Duration::from_millis(200);
     const BACKOFF: Duration = Duration::from_millis(100);
@@ -107,4 +108,20 @@ pub(crate) async fn self_probe_listener(addr: std::net::SocketAddr) -> Result<()
     }
 
     Err(last_err.unwrap_or_else(|| std::io::Error::other("self-probe failed with no error")))
+}
+
+fn probe_addr(addr: std::net::SocketAddr) -> std::net::SocketAddr {
+    if !addr.ip().is_unspecified() {
+        return addr;
+    }
+    match addr {
+        std::net::SocketAddr::V4(addr) => std::net::SocketAddr::new(
+            std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            addr.port(),
+        ),
+        std::net::SocketAddr::V6(addr) => std::net::SocketAddr::new(
+            std::net::IpAddr::V6(std::net::Ipv6Addr::LOCALHOST),
+            addr.port(),
+        ),
+    }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tests.rs
@@ -303,6 +303,49 @@ fn ephemeral_port() -> u16 {
     port
 }
 
+async fn gateway_initialize_version(port: u16) -> Option<String> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_millis(500))
+        .build()
+        .ok()?;
+    let resp = client
+        .post(format!("http://127.0.0.1:{port}/mcp"))
+        .json(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "gateway-test", "version": "0.0.0"}
+            }
+        }))
+        .send()
+        .await
+        .ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let body: serde_json::Value = resp.json().await.ok()?;
+    body.pointer("/result/serverInfo/version")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned)
+}
+
+async fn wait_gateway_initialize_version(port: u16, expected: &str, timeout: Duration) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if gateway_initialize_version(port).await.as_deref() == Some(expected) {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "gateway on port {port} did not advertise version {expected} before timeout"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
 #[tokio::test]
 async fn test_gateway_winner_serves_optional_remote_listener() {
     let dir = tempfile::tempdir().unwrap();
@@ -328,6 +371,61 @@ async fn test_gateway_winner_serves_optional_remote_listener() {
     assert!(resp.status().is_success());
 
     if let Some(abort) = outcome.gateway_abort {
+        abort.abort();
+    }
+}
+
+#[tokio::test]
+async fn test_newer_gateway_takes_over_local_and_remote_listeners() {
+    let dir = tempfile::tempdir().unwrap();
+    let gw_port = ephemeral_port();
+    let remote_port = ephemeral_port();
+
+    let old_runner = GatewayRunner::new(GatewayConfig {
+        host: "127.0.0.1".to_string(),
+        gateway_port: gw_port,
+        remote_host: Some("127.0.0.1".to_string()),
+        remote_gateway_port: remote_port,
+        server_version: "0.1.0".to_string(),
+        heartbeat_secs: 0,
+        registry_dir: Some(dir.path().to_path_buf()),
+        ..GatewayConfig::default()
+    })
+    .unwrap();
+    let old = old_runner.run_election().await.unwrap();
+    assert!(old.is_gateway, "old runner should win the initial election");
+    wait_gateway_initialize_version(remote_port, "0.1.0", Duration::from_secs(2)).await;
+
+    let new_runner = GatewayRunner::new(GatewayConfig {
+        host: "127.0.0.1".to_string(),
+        gateway_port: gw_port,
+        remote_host: Some("127.0.0.1".to_string()),
+        remote_gateway_port: remote_port,
+        server_version: "9.9.9".to_string(),
+        heartbeat_secs: 0,
+        challenger_timeout_secs: 5,
+        challenger_poll_interval_secs: 1,
+        registry_dir: Some(dir.path().to_path_buf()),
+        ..GatewayConfig::default()
+    })
+    .unwrap();
+    let new = new_runner.run_election().await.unwrap();
+
+    assert!(
+        !new.is_gateway,
+        "new runner starts as challenger while old owns the port"
+    );
+    assert!(
+        new.challenger_abort.is_some(),
+        "newer runner must start a challenger loop"
+    );
+    wait_gateway_initialize_version(gw_port, "9.9.9", Duration::from_secs(6)).await;
+    wait_gateway_initialize_version(remote_port, "9.9.9", Duration::from_secs(2)).await;
+
+    if let Some(abort) = new.challenger_abort {
+        abort.abort();
+    }
+    if let Some(abort) = old.gateway_abort {
         abort.abort();
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tests.rs
@@ -303,11 +303,11 @@ fn ephemeral_port() -> u16 {
     port
 }
 
-async fn gateway_initialize_version(port: u16) -> Option<String> {
+async fn gateway_initialize_version(port: u16) -> Result<String, String> {
     let client = reqwest::Client::builder()
-        .timeout(Duration::from_millis(500))
+        .timeout(Duration::from_secs(2))
         .build()
-        .ok()?;
+        .map_err(|err| format!("failed to build client: {err}"))?;
     let resp = client
         .post(format!("http://127.0.0.1:{port}/mcp"))
         .json(&serde_json::json!({
@@ -322,25 +322,58 @@ async fn gateway_initialize_version(port: u16) -> Option<String> {
         }))
         .send()
         .await
-        .ok()?;
+        .map_err(|err| format!("request failed: {err}"))?;
     if !resp.status().is_success() {
-        return None;
+        return Err(format!("HTTP {}", resp.status()));
     }
-    let body: serde_json::Value = resp.json().await.ok()?;
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|err| format!("invalid JSON response: {err}"))?;
     body.pointer("/result/serverInfo/version")
         .and_then(serde_json::Value::as_str)
         .map(str::to_owned)
+        .ok_or_else(|| format!("missing serverInfo.version in {body}"))
 }
 
 async fn wait_gateway_initialize_version(port: u16, expected: &str, timeout: Duration) {
     let deadline = tokio::time::Instant::now() + timeout;
     loop {
-        if gateway_initialize_version(port).await.as_deref() == Some(expected) {
-            return;
-        }
+        let observed = match gateway_initialize_version(port).await {
+            Ok(version) if version == expected => return,
+            Ok(version) => format!("version {version}"),
+            Err(err) => err,
+        };
         assert!(
             tokio::time::Instant::now() < deadline,
-            "gateway on port {port} did not advertise version {expected} before timeout"
+            "gateway on port {port} did not advertise version {expected} before timeout; last observed: {observed}"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn wait_gateway_sentinel_version(runner: &GatewayRunner, expected: &str, timeout: Duration) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let observed = {
+            let reg = runner.registry.read().await;
+            let versions: Vec<_> = reg
+                .list_instances(GATEWAY_SENTINEL_DCC_TYPE)
+                .into_iter()
+                .map(|entry| entry.version.unwrap_or_else(|| "<missing>".to_string()))
+                .collect();
+            if versions.iter().any(|version| version == expected) {
+                return;
+            }
+            if !versions.is_empty() {
+                versions.join(", ")
+            } else {
+                "no sentinel row".to_string()
+            }
+        };
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "gateway sentinel did not advertise version {expected} before timeout; last observed: {observed}"
         );
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
@@ -394,7 +427,7 @@ async fn test_newer_gateway_takes_over_local_and_remote_listeners() {
     .unwrap();
     let old = old_runner.run_election().await.unwrap();
     assert!(old.is_gateway, "old runner should win the initial election");
-    wait_gateway_initialize_version(remote_port, "0.1.0", Duration::from_secs(2)).await;
+    wait_gateway_initialize_version(remote_port, "0.1.0", Duration::from_secs(10)).await;
 
     let new_runner = GatewayRunner::new(GatewayConfig {
         host: "127.0.0.1".to_string(),
@@ -419,8 +452,9 @@ async fn test_newer_gateway_takes_over_local_and_remote_listeners() {
         new.challenger_abort.is_some(),
         "newer runner must start a challenger loop"
     );
-    wait_gateway_initialize_version(gw_port, "9.9.9", Duration::from_secs(6)).await;
-    wait_gateway_initialize_version(remote_port, "9.9.9", Duration::from_secs(2)).await;
+    wait_gateway_sentinel_version(&new_runner, "9.9.9", Duration::from_secs(10)).await;
+    wait_gateway_initialize_version(gw_port, "9.9.9", Duration::from_secs(20)).await;
+    wait_gateway_initialize_version(remote_port, "9.9.9", Duration::from_secs(10)).await;
 
     if let Some(abort) = new.challenger_abort {
         abort.abort();

--- a/crates/dcc-mcp-gateway/src/gateway/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tests.rs
@@ -304,6 +304,35 @@ fn ephemeral_port() -> u16 {
 }
 
 #[tokio::test]
+async fn test_gateway_winner_serves_optional_remote_listener() {
+    let dir = tempfile::tempdir().unwrap();
+    let gw_port = ephemeral_port();
+    let remote_port = ephemeral_port();
+    let cfg = GatewayConfig {
+        host: "127.0.0.1".to_string(),
+        gateway_port: gw_port,
+        remote_host: Some("127.0.0.1".to_string()),
+        remote_gateway_port: remote_port,
+        heartbeat_secs: 0,
+        registry_dir: Some(dir.path().to_path_buf()),
+        ..GatewayConfig::default()
+    };
+    let runner = GatewayRunner::new(cfg).unwrap();
+
+    let outcome = runner.run_election().await.unwrap();
+
+    assert!(outcome.is_gateway, "free local port must win election");
+    let resp = reqwest::get(format!("http://127.0.0.1:{remote_port}/health"))
+        .await
+        .expect("remote gateway listener should accept connections");
+    assert!(resp.status().is_success());
+
+    if let Some(abort) = outcome.gateway_abort {
+        abort.abort();
+    }
+}
+
+#[tokio::test]
 async fn test_gateway_handle_drop_deregisters_instance_row() {
     // Point gateway_port at something that is already bound so we land
     // on the `port taken` branch and the handle holds only the instance

--- a/crates/dcc-mcp-http-py/src/config.rs
+++ b/crates/dcc-mcp-http-py/src/config.rs
@@ -351,6 +351,30 @@ impl PyMcpHttpConfig {
         self.inner.gateway.gateway_port = v;
     }
 
+    /// Optional remote/LAN gateway bind host.
+    #[getter]
+    fn gateway_remote_host(&self) -> Option<String> {
+        self.inner.gateway.remote_host.clone()
+    }
+
+    /// Optional remote/LAN gateway bind host.
+    #[setter]
+    fn set_gateway_remote_host(&mut self, v: Option<String>) {
+        self.inner.gateway.remote_host = v;
+    }
+
+    /// Optional remote/LAN gateway port. ``0`` disables the remote listener.
+    #[getter]
+    fn gateway_remote_port(&self) -> u16 {
+        self.inner.gateway.remote_gateway_port
+    }
+
+    /// Optional remote/LAN gateway port. ``0`` disables the remote listener.
+    #[setter]
+    fn set_gateway_remote_port(&mut self, v: u16) {
+        self.inner.gateway.remote_gateway_port = v;
+    }
+
     /// Whether the elected gateway serves the read-only Admin UI.
     #[getter]
     fn admin_enabled(&self) -> bool {

--- a/crates/dcc-mcp-http-py/src/config/build.rs
+++ b/crates/dcc-mcp-http-py/src/config/build.rs
@@ -28,6 +28,8 @@ pub(crate) fn build_config(
     cfg.server.enable_cors = enable_cors;
     cfg.server.request_timeout_ms = request_timeout_ms;
     cfg.gateway.gateway_port = 9765;
+    cfg.gateway.remote_host = Some("0.0.0.0".to_string());
+    cfg.gateway.remote_gateway_port = 19765;
     cfg.gateway.backend_timeout_ms = backend_timeout_ms;
     cfg.telemetry.enable_prometheus = enable_prometheus;
     cfg.telemetry.prometheus_basic_auth = prometheus_basic_auth;

--- a/crates/dcc-mcp-http-py/src/config/build.rs
+++ b/crates/dcc-mcp-http-py/src/config/build.rs
@@ -29,7 +29,7 @@ pub(crate) fn build_config(
     cfg.server.request_timeout_ms = request_timeout_ms;
     cfg.gateway.gateway_port = 9765;
     cfg.gateway.remote_host = Some("0.0.0.0".to_string());
-    cfg.gateway.remote_gateway_port = 19765;
+    cfg.gateway.remote_gateway_port = 59765;
     cfg.gateway.backend_timeout_ms = backend_timeout_ms;
     cfg.telemetry.enable_prometheus = enable_prometheus;
     cfg.telemetry.prometheus_basic_auth = prometheus_basic_auth;

--- a/crates/dcc-mcp-http-py/src/config/tests.rs
+++ b/crates/dcc-mcp-http-py/src/config/tests.rs
@@ -60,6 +60,8 @@ fn all_mcp_http_config_fields_have_py_getters() {
 
     // ── GatewayConfig ────────────────────────────────────────────
     let _ = cfg.gateway_port();
+    let _ = cfg.gateway_remote_host();
+    let _ = cfg.gateway_remote_port();
     let _ = cfg.registry_dir();
     let _ = cfg.stale_timeout_secs();
     let _ = cfg.heartbeat_secs();

--- a/crates/dcc-mcp-http-types/src/config/aggregate.rs
+++ b/crates/dcc-mcp-http-types/src/config/aggregate.rs
@@ -148,6 +148,18 @@ impl McpHttpConfig {
     pub fn set_gateway_port(&mut self, v: u16) {
         self.gateway.gateway_port = v;
     }
+    pub fn remote_host(&self) -> Option<String> {
+        self.gateway.remote_host.clone()
+    }
+    pub fn set_remote_host(&mut self, v: Option<String>) {
+        self.gateway.remote_host = v;
+    }
+    pub fn remote_gateway_port(&self) -> u16 {
+        self.gateway.remote_gateway_port
+    }
+    pub fn set_remote_gateway_port(&mut self, v: u16) {
+        self.gateway.remote_gateway_port = v;
+    }
     pub fn admin_enabled(&self) -> bool {
         self.gateway.admin_enabled
     }

--- a/crates/dcc-mcp-http-types/src/config/gateway.rs
+++ b/crates/dcc-mcp-http-types/src/config/gateway.rs
@@ -11,6 +11,15 @@ pub struct GatewayConfig {
     /// `0` disables the gateway entirely. Default: 0 (disabled).
     pub gateway_port: u16,
 
+    /// Optional second gateway listener for remote/LAN clients.
+    ///
+    /// This listener does not participate in gateway election; it is opened
+    /// only by the process that wins `gateway_port`.
+    pub remote_host: Option<String>,
+
+    /// Optional second gateway port for remote/LAN clients. `0` disables it.
+    pub remote_gateway_port: u16,
+
     /// Shared `FileRegistry` directory. `None` uses a system temp dir.
     pub registry_dir: Option<PathBuf>,
 
@@ -88,6 +97,8 @@ impl Default for GatewayConfig {
     fn default() -> Self {
         Self {
             gateway_port: 0,
+            remote_host: None,
+            remote_gateway_port: 0,
             registry_dir: None,
             stale_timeout_secs: 30,
             heartbeat_secs: 5,

--- a/crates/dcc-mcp-http/src/server/gateway_impl.rs
+++ b/crates/dcc-mcp-http/src/server/gateway_impl.rs
@@ -26,6 +26,7 @@ pub(crate) async fn start_gateway_runner(
         server_version: config.server.server_version.clone(),
         registry_dir: config.gateway.registry_dir.clone(),
         challenger_timeout_secs: 120,
+        challenger_poll_interval_secs: 10,
         backend_timeout_ms: config.gateway.backend_timeout_ms,
         async_dispatch_timeout_ms: config.gateway.gateway_async_dispatch_timeout_ms,
         wait_terminal_timeout_ms: config.gateway.gateway_wait_terminal_timeout_ms,

--- a/crates/dcc-mcp-http/src/server/gateway_impl.rs
+++ b/crates/dcc-mcp-http/src/server/gateway_impl.rs
@@ -18,6 +18,8 @@ pub(crate) async fn start_gateway_runner(
     let gateway_config = GatewayConfig {
         host: config.server.host.to_string(),
         gateway_port: config.gateway.gateway_port,
+        remote_host: config.gateway.remote_host.clone(),
+        remote_gateway_port: config.gateway.remote_gateway_port,
         stale_timeout_secs: config.gateway.stale_timeout_secs,
         heartbeat_secs: config.gateway.heartbeat_secs,
         server_name: config.server.server_name.clone(),

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -72,7 +72,7 @@
 //! | `DCC_MCP_GATEWAY_PORT`    | Gateway port to compete for (default 9765, 0=off)  |
 //! | `DCC_MCP_GATEWAY_HOST`    | Gateway bind host (default follows `--host`)       |
 //! | `DCC_MCP_GATEWAY_REMOTE_HOST` | Optional remote gateway bind host (default 0.0.0.0) |
-//! | `DCC_MCP_GATEWAY_REMOTE_PORT` | Optional remote gateway port (default 19765, 0=off) |
+//! | `DCC_MCP_GATEWAY_REMOTE_PORT` | Optional remote gateway port (default 59765, 0=off) |
 //! | `DCC_MCP_NO_ADMIN`        | Disable read-only `/admin` on the elected gateway  |
 //! | `DCC_MCP_ADMIN_PATH`      | Admin URL prefix (default `/admin`)                |
 //! | `DCC_MCP_GATEWAY_ADMIN_DB` | Override path for admin SQLite (traces / skill paths) |
@@ -184,7 +184,7 @@ struct Args {
     gateway_remote_host: String,
 
     /// Remote/LAN gateway port. 0 disables the remote listener.
-    #[arg(long, env = "DCC_MCP_GATEWAY_REMOTE_PORT", default_value = "19765")]
+    #[arg(long, env = "DCC_MCP_GATEWAY_REMOTE_PORT", default_value = "59765")]
     gateway_remote_port: u16,
 
     /// Disable the read-only Admin UI on the elected gateway.

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -71,6 +71,8 @@
 //! | `DCC_MCP_SERVER_NAME`     | Server name advertised to MCP clients              |
 //! | `DCC_MCP_GATEWAY_PORT`    | Gateway port to compete for (default 9765, 0=off)  |
 //! | `DCC_MCP_GATEWAY_HOST`    | Gateway bind host (default follows `--host`)       |
+//! | `DCC_MCP_GATEWAY_REMOTE_HOST` | Optional remote gateway bind host (default 0.0.0.0) |
+//! | `DCC_MCP_GATEWAY_REMOTE_PORT` | Optional remote gateway port (default 19765, 0=off) |
 //! | `DCC_MCP_NO_ADMIN`        | Disable read-only `/admin` on the elected gateway  |
 //! | `DCC_MCP_ADMIN_PATH`      | Admin URL prefix (default `/admin`)                |
 //! | `DCC_MCP_GATEWAY_ADMIN_DB` | Override path for admin SQLite (traces / skill paths) |
@@ -176,6 +178,14 @@ struct Args {
     /// Gateway host/interface to bind. Defaults to the MCP `--host`.
     #[arg(long, env = "DCC_MCP_GATEWAY_HOST")]
     gateway_host: Option<String>,
+
+    /// Remote/LAN gateway host/interface to bind.
+    #[arg(long, env = "DCC_MCP_GATEWAY_REMOTE_HOST", default_value = "0.0.0.0")]
+    gateway_remote_host: String,
+
+    /// Remote/LAN gateway port. 0 disables the remote listener.
+    #[arg(long, env = "DCC_MCP_GATEWAY_REMOTE_PORT", default_value = "19765")]
+    gateway_remote_port: u16,
 
     /// Disable the read-only Admin UI on the elected gateway.
     #[arg(long, env = "DCC_MCP_NO_ADMIN", default_value = "false")]
@@ -817,6 +827,8 @@ async fn main() -> anyhow::Result<()> {
     let gateway_cfg = GatewayConfig {
         host: gateway_host,
         gateway_port: args.gateway_port,
+        remote_host: Some(args.gateway_remote_host.clone()),
+        remote_gateway_port: args.gateway_remote_port,
         stale_timeout_secs: args.stale_timeout_secs,
         heartbeat_secs: args.heartbeat_secs,
         server_name: args.server_name.clone(),

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -70,6 +70,7 @@
 //! | `DCC_MCP_APP`             | App name hint (e.g. "maya", "photoshop")           |
 //! | `DCC_MCP_SERVER_NAME`     | Server name advertised to MCP clients              |
 //! | `DCC_MCP_GATEWAY_PORT`    | Gateway port to compete for (default 9765, 0=off)  |
+//! | `DCC_MCP_GATEWAY_HOST`    | Gateway bind host (default follows `--host`)       |
 //! | `DCC_MCP_NO_ADMIN`        | Disable read-only `/admin` on the elected gateway  |
 //! | `DCC_MCP_ADMIN_PATH`      | Admin URL prefix (default `/admin`)                |
 //! | `DCC_MCP_GATEWAY_ADMIN_DB` | Override path for admin SQLite (traces / skill paths) |
@@ -171,6 +172,10 @@ struct Args {
     /// 0 = gateway disabled entirely (and therefore disables admin too).
     #[arg(long, env = "DCC_MCP_GATEWAY_PORT", default_value = "9765")]
     gateway_port: u16,
+
+    /// Gateway host/interface to bind. Defaults to the MCP `--host`.
+    #[arg(long, env = "DCC_MCP_GATEWAY_HOST")]
+    gateway_host: Option<String>,
 
     /// Disable the read-only Admin UI on the elected gateway.
     #[arg(long, env = "DCC_MCP_NO_ADMIN", default_value = "false")]
@@ -804,8 +809,13 @@ async fn main() -> anyhow::Result<()> {
         .unwrap_or(30)
         .clamp(1, 3650);
 
+    let gateway_host = args
+        .gateway_host
+        .clone()
+        .unwrap_or_else(|| args.host.clone());
+
     let gateway_cfg = GatewayConfig {
-        host: args.host.clone(),
+        host: gateway_host,
         gateway_port: args.gateway_port,
         stale_timeout_secs: args.stale_timeout_secs,
         heartbeat_secs: args.heartbeat_secs,

--- a/crates/dcc-mcp-server/src/sidecar.rs
+++ b/crates/dcc-mcp-server/src/sidecar.rs
@@ -150,9 +150,15 @@ pub struct SidecarArgs {
     #[arg(long, default_value = "9765", env = "DCC_MCP_GATEWAY_PORT")]
     pub gateway_port: u16,
 
-    /// Host interface for the gateway listener (default ``127.0.0.1``).
+    /// Legacy host/interface for the gateway listener (default ``127.0.0.1``).
+    ///
+    /// Prefer ``--gateway-host`` / ``DCC_MCP_GATEWAY_HOST`` for new launchers.
     #[arg(long, default_value = "127.0.0.1")]
     pub host: String,
+
+    /// Gateway host/interface to bind. Use ``0.0.0.0`` to accept LAN clients.
+    #[arg(long, env = "DCC_MCP_GATEWAY_HOST")]
+    pub gateway_host: Option<String>,
 }
 
 /// Run the sidecar lifecycle until the parent DCC dies or a signal arrives.
@@ -458,13 +464,17 @@ mod tests {
     use super::*;
     use dcc_mcp_transport::discovery::types::ServiceKey;
     use std::process::Stdio;
+    use std::sync::Mutex;
     use std::time::Instant;
     use tempfile::TempDir;
 
     // ── Regression: ``default_registry_dir`` must match GatewayRunner's ──
 
+    static REGISTRY_ENV_LOCK: Mutex<()> = Mutex::new(());
+
     #[test]
     fn default_registry_dir_matches_gateway_runner_fallback() {
+        let _guard = REGISTRY_ENV_LOCK.lock().expect("registry env lock");
         // ``GatewayRunner::new`` (crates/dcc-mcp-gateway/src/gateway/
         // runner.rs) falls back to ``std::env::temp_dir().join("dcc-mcp-
         // registry")``. The sidecar binary MUST agree, otherwise an
@@ -499,6 +509,7 @@ mod tests {
 
     #[test]
     fn default_registry_dir_honours_env_var_override() {
+        let _guard = REGISTRY_ENV_LOCK.lock().expect("registry env lock");
         let saved = std::env::var("DCC_MCP_REGISTRY_DIR").ok();
         let custom = std::env::temp_dir().join("dcc-mcp-custom-registry-test");
         unsafe { std::env::set_var("DCC_MCP_REGISTRY_DIR", &custom) };
@@ -554,6 +565,7 @@ mod tests {
             ppid_poll_ms: Some(50),
             gateway_port: 0,
             host: "127.0.0.1".to_string(),
+            gateway_host: None,
         };
         let pinned_uuid = args.instance_id.unwrap();
 
@@ -659,6 +671,7 @@ mod tests {
             ppid_poll_ms: Some(50),
             gateway_port: 0,
             host: "127.0.0.1".to_string(),
+            gateway_host: None,
         };
 
         let sidecar_handle = tokio::spawn(async move { run(args).await });
@@ -746,6 +759,7 @@ mod tests {
             ppid_poll_ms: Some(50),
             gateway_port: 0,
             host: "127.0.0.1".to_string(),
+            gateway_host: None,
         };
 
         let sidecar_handle = tokio::spawn(async move { run(args).await });

--- a/crates/dcc-mcp-server/src/sidecar.rs
+++ b/crates/dcc-mcp-server/src/sidecar.rs
@@ -165,7 +165,7 @@ pub struct SidecarArgs {
     pub gateway_remote_host: String,
 
     /// Remote/LAN gateway port. ``0`` disables the remote listener.
-    #[arg(long, env = "DCC_MCP_GATEWAY_REMOTE_PORT", default_value = "19765")]
+    #[arg(long, env = "DCC_MCP_GATEWAY_REMOTE_PORT", default_value = "59765")]
     pub gateway_remote_port: u16,
 }
 
@@ -575,7 +575,7 @@ mod tests {
             host: "127.0.0.1".to_string(),
             gateway_host: None,
             gateway_remote_host: "0.0.0.0".to_string(),
-            gateway_remote_port: 19765,
+            gateway_remote_port: 59765,
         };
         let pinned_uuid = args.instance_id.unwrap();
 
@@ -683,7 +683,7 @@ mod tests {
             host: "127.0.0.1".to_string(),
             gateway_host: None,
             gateway_remote_host: "0.0.0.0".to_string(),
-            gateway_remote_port: 19765,
+            gateway_remote_port: 59765,
         };
 
         let sidecar_handle = tokio::spawn(async move { run(args).await });
@@ -773,7 +773,7 @@ mod tests {
             host: "127.0.0.1".to_string(),
             gateway_host: None,
             gateway_remote_host: "0.0.0.0".to_string(),
-            gateway_remote_port: 19765,
+            gateway_remote_port: 59765,
         };
 
         let sidecar_handle = tokio::spawn(async move { run(args).await });

--- a/crates/dcc-mcp-server/src/sidecar.rs
+++ b/crates/dcc-mcp-server/src/sidecar.rs
@@ -159,6 +159,14 @@ pub struct SidecarArgs {
     /// Gateway host/interface to bind. Use ``0.0.0.0`` to accept LAN clients.
     #[arg(long, env = "DCC_MCP_GATEWAY_HOST")]
     pub gateway_host: Option<String>,
+
+    /// Remote/LAN gateway host/interface to bind.
+    #[arg(long, env = "DCC_MCP_GATEWAY_REMOTE_HOST", default_value = "0.0.0.0")]
+    pub gateway_remote_host: String,
+
+    /// Remote/LAN gateway port. ``0`` disables the remote listener.
+    #[arg(long, env = "DCC_MCP_GATEWAY_REMOTE_PORT", default_value = "19765")]
+    pub gateway_remote_port: u16,
 }
 
 /// Run the sidecar lifecycle until the parent DCC dies or a signal arrives.
@@ -566,6 +574,8 @@ mod tests {
             gateway_port: 0,
             host: "127.0.0.1".to_string(),
             gateway_host: None,
+            gateway_remote_host: "0.0.0.0".to_string(),
+            gateway_remote_port: 19765,
         };
         let pinned_uuid = args.instance_id.unwrap();
 
@@ -672,6 +682,8 @@ mod tests {
             gateway_port: 0,
             host: "127.0.0.1".to_string(),
             gateway_host: None,
+            gateway_remote_host: "0.0.0.0".to_string(),
+            gateway_remote_port: 19765,
         };
 
         let sidecar_handle = tokio::spawn(async move { run(args).await });
@@ -760,6 +772,8 @@ mod tests {
             gateway_port: 0,
             host: "127.0.0.1".to_string(),
             gateway_host: None,
+            gateway_remote_host: "0.0.0.0".to_string(),
+            gateway_remote_port: 19765,
         };
 
         let sidecar_handle = tokio::spawn(async move { run(args).await });

--- a/crates/dcc-mcp-server/src/sidecar_gateway.rs
+++ b/crates/dcc-mcp-server/src/sidecar_gateway.rs
@@ -110,8 +110,13 @@ pub async fn start_sidecar_gateway(
 }
 
 fn build_gateway_config(args: &SidecarArgs) -> GatewayConfig {
+    let gateway_host = args
+        .gateway_host
+        .clone()
+        .unwrap_or_else(|| args.host.clone());
+
     GatewayConfig {
-        host: args.host.clone(),
+        host: gateway_host,
         gateway_port: args.gateway_port,
         registry_dir: args.registry_dir.clone(),
         server_name: format!("dcc-mcp-gateway-{}", args.dcc),

--- a/crates/dcc-mcp-server/src/sidecar_gateway.rs
+++ b/crates/dcc-mcp-server/src/sidecar_gateway.rs
@@ -118,6 +118,8 @@ fn build_gateway_config(args: &SidecarArgs) -> GatewayConfig {
     GatewayConfig {
         host: gateway_host,
         gateway_port: args.gateway_port,
+        remote_host: Some(args.gateway_remote_host.clone()),
+        remote_gateway_port: args.gateway_remote_port,
         registry_dir: args.registry_dir.clone(),
         server_name: format!("dcc-mcp-gateway-{}", args.dcc),
         server_version: env!("CARGO_PKG_VERSION").to_string(),

--- a/crates/dcc-mcp-server/src/translate.rs
+++ b/crates/dcc-mcp-server/src/translate.rs
@@ -111,6 +111,14 @@ pub struct TranslateArgs {
     #[arg(long, env = "DCC_MCP_GATEWAY_HOST")]
     pub gateway_host: Option<String>,
 
+    /// Remote/LAN gateway host/interface to bind.
+    #[arg(long, env = "DCC_MCP_GATEWAY_REMOTE_HOST", default_value = "0.0.0.0")]
+    pub gateway_remote_host: String,
+
+    /// Remote/LAN gateway port. 0 disables the remote listener.
+    #[arg(long, env = "DCC_MCP_GATEWAY_REMOTE_PORT", default_value = "19765")]
+    pub gateway_remote_port: u16,
+
     /// Disable the read-only Admin UI on the elected gateway.
     #[arg(long, env = "DCC_MCP_NO_ADMIN", default_value = "false")]
     pub no_admin: bool,
@@ -591,6 +599,8 @@ pub async fn run(args: TranslateArgs) -> anyhow::Result<()> {
         let gateway_cfg = GatewayConfig {
             host: gateway_host,
             gateway_port: args.gateway_port,
+            remote_host: Some(args.gateway_remote_host.clone()),
+            remote_gateway_port: args.gateway_remote_port,
             stale_timeout_secs: args.stale_timeout_secs,
             heartbeat_secs: args.heartbeat_secs,
             server_name: server_name.clone(),

--- a/crates/dcc-mcp-server/src/translate.rs
+++ b/crates/dcc-mcp-server/src/translate.rs
@@ -116,7 +116,7 @@ pub struct TranslateArgs {
     pub gateway_remote_host: String,
 
     /// Remote/LAN gateway port. 0 disables the remote listener.
-    #[arg(long, env = "DCC_MCP_GATEWAY_REMOTE_PORT", default_value = "19765")]
+    #[arg(long, env = "DCC_MCP_GATEWAY_REMOTE_PORT", default_value = "59765")]
     pub gateway_remote_port: u16,
 
     /// Disable the read-only Admin UI on the elected gateway.

--- a/crates/dcc-mcp-server/src/translate.rs
+++ b/crates/dcc-mcp-server/src/translate.rs
@@ -107,6 +107,10 @@ pub struct TranslateArgs {
     #[arg(long, env = "DCC_MCP_GATEWAY_PORT", default_value = "9765")]
     pub gateway_port: u16,
 
+    /// Gateway host/interface to bind. Defaults to the HTTP `--host`.
+    #[arg(long, env = "DCC_MCP_GATEWAY_HOST")]
+    pub gateway_host: Option<String>,
+
     /// Disable the read-only Admin UI on the elected gateway.
     #[arg(long, env = "DCC_MCP_NO_ADMIN", default_value = "false")]
     pub no_admin: bool,
@@ -579,8 +583,13 @@ pub async fn run(args: TranslateArgs) -> anyhow::Result<()> {
 
         let registry_dir_path: Option<PathBuf> = args.registry_dir.as_deref().map(PathBuf::from);
 
+        let gateway_host = args
+            .gateway_host
+            .clone()
+            .unwrap_or_else(|| args.host.clone());
+
         let gateway_cfg = GatewayConfig {
-            host: args.host.clone(),
+            host: gateway_host,
             gateway_port: args.gateway_port,
             stale_timeout_secs: args.stale_timeout_secs,
             heartbeat_secs: args.heartbeat_secs,


### PR DESCRIPTION
## Summary
- avoid blocking gateway initialize on the protocol-version cache lock
- keep the local gateway endpoint stable while adding an optional remote/LAN listener
- default server/sidecar/translate launches to local 127.0.0.1:9765 plus remote 0.0.0.0:59765
- expose remote gateway host/port through Rust/Python config and CLI/env
- make challenger polling configurable and keep promoted challenger gateway tasks guarded for clean shutdown
- cover newer-gateway takeover of both local and remote listeners
- add dcc-mcp-cli smoke checks for health, MCP initialize, tools/list, and REST search
- serialize registry env-var tests to avoid gateway registry flakes

## LAN usage
- local clients: http://127.0.0.1:9765/mcp
- LAN clients: http://<machine-ip>:59765/mcp
- disable remote listener with DCC_MCP_GATEWAY_REMOTE_PORT=0

## CLI smoke
- cargo run -p dcc-mcp-cli -- --output pretty smoke --url http://127.0.0.1:9765/mcp --timeout-secs 5
- cargo run -p dcc-mcp-cli -- --output pretty smoke --url http://<machine-ip>:59765/mcp --timeout-secs 5

## Tests
- cargo test -p dcc-mcp-gateway --lib
- cargo test -p dcc-mcp-server
- cargo test -p dcc-mcp-http-types
- cargo test -p dcc-mcp-http-py
- cargo test -p dcc-mcp-cli