### PR TITLE
fix: reject unavailable main affinity dispatch

### DIFF
--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_async.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_async.rs
@@ -17,6 +17,7 @@ pub(super) struct AsyncDispatchConfig {
     pub parent_job_id: Option<String>,
     pub progress_token: Option<Value>,
     pub thread_affinity: ThreadAffinity,
+    pub enforce_thread_affinity: bool,
 }
 
 pub(super) fn async_dispatch_config(
@@ -37,6 +38,7 @@ pub(super) fn async_dispatch_config(
         parent_job_id: meta_dcc.and_then(|dcc| dcc.parent_job_id.clone()),
         progress_token,
         thread_affinity: action_meta.thread_affinity,
+        enforce_thread_affinity: action_meta.enforce_thread_affinity,
     })
 }
 
@@ -81,11 +83,19 @@ async fn run_async_execution_lane(
     call_params: Value,
     cancel_token: CancellationToken,
     thread_affinity: ThreadAffinity,
+    enforce_thread_affinity: bool,
 ) -> Result<Value, String> {
     let dispatcher = state.dispatcher.as_ref().clone();
     let use_main_thread = use_main_thread_route(thread_affinity, state.executor.is_some());
 
     if matches!(thread_affinity, ThreadAffinity::Main) && state.executor.is_none() {
+        if enforce_thread_affinity {
+            return Err(
+                "THREAD_AFFINITY_UNAVAILABLE: tool declares thread_affinity=main, \
+                 but no DeferredExecutor is wired"
+                    .to_string(),
+            );
+        }
         tracing::warn!(
             tool = %resolved_name,
             "tool declares thread_affinity=main but no DeferredExecutor is wired; \
@@ -151,6 +161,7 @@ fn spawn_async_registry_dispatch(
     resolved_name: String,
     call_params: Value,
     thread_affinity: ThreadAffinity,
+    enforce_thread_affinity: bool,
 ) {
     let jobs = Arc::clone(&state.jobs);
     let server = state.clone();
@@ -172,6 +183,7 @@ fn spawn_async_registry_dispatch(
             call_params,
             cancel_token.clone(),
             thread_affinity,
+            enforce_thread_affinity,
         )
         .await;
 
@@ -237,6 +249,7 @@ pub(super) async fn dispatch_async_registry_tool(
         resolved_name,
         call_params,
         cfg.thread_affinity,
+        cfg.enforce_thread_affinity,
     );
 
     build_pending_envelope(&job_id, cfg.parent_job_id)

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch.rs
@@ -255,11 +255,19 @@ async fn execute_threaded_dispatch(
     resolved_name: &str,
     call_params: Value,
     thread_affinity: ThreadAffinity,
+    enforce_thread_affinity: bool,
 ) -> Result<Value, String> {
     let executor_present = state.executor.is_some();
     let on_main = use_main_thread_route(thread_affinity, executor_present);
 
     if matches!(thread_affinity, ThreadAffinity::Main) && !executor_present {
+        if enforce_thread_affinity {
+            return Err(
+                "THREAD_AFFINITY_UNAVAILABLE: tool declares thread_affinity=main, \
+                 but no DeferredExecutor is wired"
+                    .to_string(),
+            );
+        }
         tracing::warn!(
             tool = %resolved_name,
             "sync tool declares thread_affinity=main but no DeferredExecutor is wired; \
@@ -1429,6 +1437,7 @@ async fn dispatch_registry_tool(
         &resolved_name,
         call_params.clone(),
         action_meta.thread_affinity,
+        action_meta.enforce_thread_affinity,
     )
     .await;
 

--- a/tests/test_async_main_affinity.py
+++ b/tests/test_async_main_affinity.py
@@ -114,6 +114,16 @@ def server_url() -> Any:
         thread_affinity="main",
     )
     reg.register(
+        "main_affined_enforced",
+        description="Tool that requires a DeferredExecutor",
+        dcc="test",
+        version="1.0.0",
+        execution="async",
+        timeout_hint_secs=30,
+        thread_affinity="main",
+        enforce_thread_affinity=True,
+    )
+    reg.register(
         "any_affined",
         description="Tool with no thread constraint",
         dcc="test",
@@ -126,6 +136,10 @@ def server_url() -> Any:
     server.register_handler(
         "main_affined",
         lambda params: (time.sleep(0.3), {"ok": True})[1],
+    )
+    server.register_handler(
+        "main_affined_enforced",
+        lambda params: {"ok": True},
     )
     server.register_handler(
         "any_affined",
@@ -165,3 +179,28 @@ class TestMainAffinityAsyncEnvelope:
         result = resp["result"]
         assert result["isError"] is False
         assert result["structuredContent"]["status"] == "pending"
+
+    def test_enforced_main_affinity_without_executor_fails_clearly(self, mcp_client: McpClient) -> None:
+        resp = _tools_call(mcp_client, "main_affined_enforced", arguments={})
+        result = resp["result"]
+        assert result["isError"] is False
+        job_id = result["structuredContent"]["job_id"]
+
+        deadline = time.monotonic() + 5.0
+        final: dict[str, Any] | None = None
+        while time.monotonic() < deadline:
+            poll = _tools_call(
+                mcp_client,
+                "jobs.get_status",
+                arguments={"job_id": job_id, "include_result": True},
+                req_id=2,
+            )
+            env = poll["result"]["structuredContent"]
+            if env["status"] in {"completed", "failed", "cancelled", "interrupted"}:
+                final = env
+                break
+            time.sleep(0.05)
+
+        assert final is not None, f"job {job_id} did not reach a terminal state"
+        assert final["status"] == "failed"
+        assert "THREAD_AFFINITY_UNAVAILABLE" in final["error"]

--- a/tests/test_skills_e2e.py
+++ b/tests/test_skills_e2e.py
@@ -571,6 +571,7 @@ class TestInProcessExecutor:
             "    description: Host scene tool\n"
             "    source_file: scripts/host_scene.py\n"
             "    thread_affinity: main\n"
+            "    enforce_thread_affinity: false\n"
             "    execution: async\n"
             "    timeout_hint_secs: 45\n"
             "  - name: pure_file\n"
@@ -592,6 +593,15 @@ class TestInProcessExecutor:
             seen.append({"script": Path(script_path).name, "params": params, **kwargs})
             return {"success": True, "message": kwargs["action_name"]}
 
+        def wait_for_seen(action_name: str) -> dict[str, Any]:
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                for entry in seen:
+                    if entry.get("action_name") == action_name:
+                        return entry
+                time.sleep(0.02)
+            raise AssertionError(f"executor did not observe {action_name}; seen={seen!r}")
+
         server = dcc_mcp_core.create_skill_server("python", dcc_mcp_core.McpHttpConfig(port=0))
         server.set_in_process_executor(capture_exec)
         server.discover(extra_paths=[str(tmp_path)])
@@ -602,9 +612,9 @@ class TestInProcessExecutor:
         time.sleep(0.25)
         try:
             url = handle.mcp_url()
+            client = McpClient(url)
 
-            def _call(name: str) -> None:
-                client = McpClient(url)
+            def _call(name: str) -> dict[str, Any]:
                 _, result = client.post(
                     {
                         "jsonrpc": "2.0",
@@ -614,9 +624,40 @@ class TestInProcessExecutor:
                     }
                 )
                 assert result["result"]["isError"] is False
+                return result
 
-            _call("affinity_skill__host_scene")
+            def _wait_job(result: dict[str, Any]) -> None:
+                structured = result["result"].get("structuredContent")
+                if not structured or "job_id" not in structured:
+                    return
+                job_id = structured["job_id"]
+                deadline = time.monotonic() + 5.0
+                final: dict[str, Any] | None = None
+                while time.monotonic() < deadline:
+                    _, poll = client.post(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": f"jobs.get_status:{job_id}",
+                            "method": "tools/call",
+                            "params": {
+                                "name": "jobs.get_status",
+                                "arguments": {"job_id": job_id, "include_result": True},
+                            },
+                        }
+                    )
+                    assert poll["result"]["isError"] is False, poll
+                    env = poll["result"]["structuredContent"]
+                    if env["status"] in {"completed", "failed", "cancelled", "interrupted"}:
+                        final = env
+                        break
+                    time.sleep(0.05)
+                assert final is not None, f"job {job_id} did not complete"
+                assert final["status"] == "completed", final
+
+            _wait_job(_call("affinity_skill__host_scene"))
             _call("affinity_skill__pure_file")
+            wait_for_seen("affinity_skill__host_scene")
+            wait_for_seen("affinity_skill__pure_file")
         finally:
             handle.shutdown()
 


### PR DESCRIPTION
## Summary
- fail enforced main-thread tools clearly when no DeferredExecutor is wired
- keep standalone metadata tests explicit about disabled affinity enforcement
- cover async main-affinity failure through jobs.get_status

## Tests
- .\\.venv\\Scripts\\python.exe -m pytest tests/test_skills_e2e.py::TestInProcessExecutor::test_in_process_executor_receives_tool_execution_metadata tests/test_async_main_affinity.py -q
- .\\.venv\\Scripts\\python.exe -m pytest tests/test_skills_e2e.py tests/test_async_main_affinity.py -q
- cargo test -p dcc-mcp-http-server --lib
- cargo fmt --all --check
- git diff --check