### PR TITLE
fix: align async host busy handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,70 @@
 
 It combines **MCP 2025-03-26 Streamable HTTP**, a **zero-code Skills system** built on [agentskills.io 1.0](https://agentskills.io/specification), and a Rust gateway for discovery, routing, installation, linting, and operations. The Python package keeps **zero runtime Python dependencies** for embedded DCC hosts, while standalone `dcc-mcp-cli` and `dcc-mcp-server` binaries ship through GitHub Releases for workstation-style installs. Supports Python 3.7–3.13.
 
+Use it when you want agents to operate production DCC sessions without flooding the context window, hand-writing Python glue for every tool, or shipping fragile one-off shell scripts. Start with the CLI in two commands, or embed the Python core directly in a DCC adapter.
+
+---
+
+## What You Get
+
+| Need | dcc-mcp-core gives you |
+|---|---|
+| Let agents operate real DCC sessions | MCP + REST endpoints for Maya, Blender, Houdini, Photoshop, and custom hosts |
+| Keep tool context small | Gateway discovery: `search_tools` -> `describe_tool` -> `call_tool` |
+| Add tools without framework glue | `SKILL.md` + sibling YAML/scripts, aligned with agentskills.io |
+| Debug live workstation state | Admin UI, viewport diagnostics, audit logs, traces, metrics |
+| Survive production constraints | Main-thread dispatch, async jobs, sidecar/server binaries, workflow and artefact primitives |
+
+## Quick Start
+
+### Install the standalone CLI
+
+Use the release binary when you want the operator/CI control plane without a Python environment:
+
 ```bash
-# Install the standalone CLI on Linux/macOS
+# Linux/macOS
 curl -fsSL https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.sh | bash
 
-# Install the standalone CLI on Windows PowerShell
+# Windows PowerShell
 powershell -c "irm https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+```
 
-# Then inspect a gateway or lint local Skills before they ever reach runtime
+After install:
+
+```bash
+dcc-mcp-cli health
 dcc-mcp-cli list
+dcc-mcp-cli search --query sphere --dcc-type maya
 dcc-mcp-cli lint path/to/skills
 ```
 
-Use it when you want agents to operate production DCC sessions without flooding the context window, hand-writing Python glue for every tool, or shipping fragile one-off shell scripts.
+### Install the Python core
+
+```bash
+pip install dcc-mcp-core
+```
+
+Or build from source with the repo's canonical feature set:
+
+```bash
+git clone https://github.com/loonghao/dcc-mcp-core.git
+cd dcc-mcp-core
+vx just dev
+```
+
+### Serve a DCC over MCP — Skills-First
+
+`create_skill_server` wires up progressive discovery, skill loading, routing, and structured results:
+
+```python
+from dcc_mcp_core import create_skill_server, McpHttpConfig
+
+server = create_skill_server("maya", McpHttpConfig(port=8765))
+handle = server.start()
+print(handle.mcp_url())   # "http://127.0.0.1:8765/mcp"
+```
+
+Agents then use `search_skills` -> `load_skill` on a per-DCC server, or `search_tools` -> `describe_tool` -> `call_tool` through the gateway.
 
 ---
 
@@ -162,7 +213,7 @@ multi-DCC workstation.
 
 ---
 
-## Quick Start
+## Installation Details & Manual API Example
 
 ### Install the standalone CLI
 

--- a/README.md
+++ b/README.md
@@ -157,44 +157,6 @@ AI-friendly docs: [AGENTS.md](AGENTS.md) · [`docs/guide/agents-reference.md`](d
 
 ![dcc-mcp-core architecture diagram](docs/assets/architecture/current-stack.svg)
 
-```
-+--------------------------------------------------------------------------------+
-| Agent / operator surfaces                                                       |
-| - MCP clients: search_tools -> describe_tool -> call_tool                       |
-| - CLI users: dcc-mcp-cli list/search/describe/call                              |
-| - ClawHub/OpenClaw skills: dcc-cli-gateway or dcc-rest-gateway                  |
-| - CI and custom clients: REST /v1/*                                             |
-+----------------------------------------+---------------------------------------+
-                                         |
-                       MCP Streamable HTTP + REST /v1/*
-                                         |
-+----------------------------------------v---------------------------------------+
-| Elected gateway (Rust HTTP control plane)                                       |
-| - Minimal MCP tools/list: discovery and dispatch primitives only                |
-| - Dynamic capability search, schema describe, single/batch call routing         |
-| - Instance registry, TCP liveness probes, version-aware election, failover      |
-| - Admin UI, OpenAPI, audit logs, traces, metrics, jobs, workflows, artefacts    |
-+----------------------------------------+---------------------------------------+
-                                         |
-                    Gateway-routed calls to owning per-DCC server
-                                         |
-        +-------------------------------+-------------------------------+
-        |                               |                               |
-+-------v--------+              +-------v--------+              +-------v--------+
-| Maya adapter   |              | Blender adapter|              | Custom host    |
-| MCP + REST     |              | MCP + REST     |              | MCP + REST     |
-| Skills catalog |              | Skills catalog |              | Skills catalog |
-+-------+--------+              +-------+--------+              +-------+--------+
-        |                               |                               |
-  Host bridge / UI-thread pump    Host bridge / add-on           Host RPC / IPC
-        |                               |                               |
-   Maya Python APIs                 Blender Python APIs           Studio APIs
-```
-
-- **Agent surface**: MCP clients use a bounded discovery/dispatch tool set; CLI and skill users can reach the same gateway through `dcc-mcp-cli` or `/v1/*`.
-- **Gateway surface**: One elected gateway aggregates per-DCC servers, keeps `tools/list` small, exposes OpenAPI/Admin UI, records audit/trace data, and routes by tool slug.
-- **DCC surface**: Embedded adapters, standalone `dcc-mcp-server`, and bridge-based hosts all expose the same Skills-derived capabilities over MCP + REST.
-
 ### Gateway Admin UI
 
 The elected gateway ships with a built-in admin console for operators who need

--- a/README_zh.md
+++ b/README_zh.md
@@ -147,43 +147,7 @@ AI 友好文档：[AGENTS.md](AGENTS.md) · [`docs/guide/agents-reference.md`](d
 
 ## 架构：当前栈
 
-```
-+--------------------------------------------------------------------------------+
-| Agent / operator surfaces                                                       |
-| - MCP clients: search_tools -> describe_tool -> call_tool                       |
-| - CLI users: dcc-mcp-cli list/search/describe/call                              |
-| - ClawHub/OpenClaw skills: dcc-cli-gateway or dcc-rest-gateway                  |
-| - CI and custom clients: REST /v1/*                                             |
-+----------------------------------------+---------------------------------------+
-                                         |
-                       MCP Streamable HTTP + REST /v1/*
-                                         |
-+----------------------------------------v---------------------------------------+
-| Elected gateway (Rust HTTP control plane)                                       |
-| - Minimal MCP tools/list: discovery and dispatch primitives only                |
-| - Dynamic capability search, schema describe, single/batch call routing         |
-| - Instance registry, TCP liveness probes, version-aware election, failover      |
-| - Admin UI, OpenAPI, audit logs, traces, metrics, jobs, workflows, artefacts    |
-+----------------------------------------+---------------------------------------+
-                                         |
-                    Gateway-routed calls to owning per-DCC server
-                                         |
-        +-------------------------------+-------------------------------+
-        |                               |                               |
-+-------v--------+              +-------v--------+              +-------v--------+
-| Maya adapter   |              | Blender adapter|              | Custom host    |
-| MCP + REST     |              | MCP + REST     |              | MCP + REST     |
-| Skills catalog |              | Skills catalog |              | Skills catalog |
-+-------+--------+              +-------+--------+              +-------+--------+
-        |                               |                               |
-  Host bridge / UI-thread pump    Host bridge / add-on           Host RPC / IPC
-        |                               |                               |
-   Maya Python APIs                 Blender Python APIs           Studio APIs
-```
-
-- **Agent 表面**：MCP 客户端使用有界的发现/调度工具集；CLI 与 skill 用户通过 `dcc-mcp-cli` 或 `/v1/*` 访问同一网关。
-- **Gateway 表面**：一个获选网关汇聚 per-DCC servers，让 `tools/list` 保持很小，暴露 OpenAPI/Admin UI，记录 audit/trace，并按 tool slug 路由。
-- **DCC 表面**：嵌入式适配器、独立 `dcc-mcp-server`、bridge 型宿主都通过 MCP + REST 暴露同一套 Skills 派生能力。
+![dcc-mcp-core 架构图](docs/assets/architecture/current-stack.svg)
 
 ---
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -24,19 +24,70 @@
 
 它结合 **MCP 2025-03-26 Streamable HTTP**、遵循 [agentskills.io 1.0](https://agentskills.io/specification) 的 **零代码 Skills 系统**，以及负责发现、路由、安装、lint 和运维的 Rust gateway。Python 包面向嵌入式 DCC 宿主保持**运行时零 Python 依赖**；独立的 `dcc-mcp-cli` 与 `dcc-mcp-server` 二进制随 GitHub Release 发布，适合像传统软件一样下载安装到工作站。支持 Python 3.7–3.13。
 
+当你希望 Agent 操作真实 DCC 会话，同时避免上下文爆炸、为每个工具手写 Python 胶水、或者维护脆弱的一次性 shell 脚本时，它就是这层基础设施。你可以用两条命令从 CLI 开始，也可以把 Python core 直接嵌进 DCC adapter。
+
+---
+
+## 你能得到什么
+
+| 需求 | dcc-mcp-core 提供 |
+|---|---|
+| 让 Agent 操作真实 DCC 会话 | 面向 Maya、Blender、Houdini、Photoshop 和自定义宿主的 MCP + REST 端点 |
+| 控制工具上下文大小 | Gateway 发现流程：`search_tools` -> `describe_tool` -> `call_tool` |
+| 不写框架胶水也能加工具 | `SKILL.md` + 同级 YAML / 脚本，遵循 agentskills.io |
+| 调试真实工作站状态 | Admin UI、视口诊断、审计日志、trace、metrics |
+| 扛住生产约束 | 主线程调度、异步 job、sidecar/server 二进制、workflow 与 artefact 原语 |
+
+## 快速开始
+
+### 安装独立 CLI
+
+如果你只需要 operator/CI 控制面，不想先准备 Python 环境，直接安装 release 二进制：
+
 ```bash
-# Linux/macOS 安装独立 CLI
+# Linux/macOS
 curl -fsSL https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.sh | bash
 
-# Windows PowerShell 安装独立 CLI
+# Windows PowerShell
 powershell -c "irm https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+```
 
-# 然后检查 gateway，或在运行时加载前 lint 本地 Skills
+安装后：
+
+```bash
+dcc-mcp-cli health
 dcc-mcp-cli list
+dcc-mcp-cli search --query sphere --dcc-type maya
 dcc-mcp-cli lint path/to/skills
 ```
 
-当你希望 Agent 操作真实 DCC 会话，同时避免上下文爆炸、为每个工具手写 Python 胶水、或者维护脆弱的一次性 shell 脚本时，它就是这层基础设施。
+### 安装 Python core
+
+```bash
+pip install dcc-mcp-core
+```
+
+也可以用仓库的标准 feature set 从源码构建：
+
+```bash
+git clone https://github.com/loonghao/dcc-mcp-core.git
+cd dcc-mcp-core
+vx just dev
+```
+
+### 以 Skills-First 方式暴露 DCC
+
+`create_skill_server` 会接好渐进式发现、skill 加载、路由和结构化结果：
+
+```python
+from dcc_mcp_core import create_skill_server, McpHttpConfig
+
+server = create_skill_server("maya", McpHttpConfig(port=8765))
+handle = server.start()
+print(handle.mcp_url())   # "http://127.0.0.1:8765/mcp"
+```
+
+Agent 可以在 per-DCC server 上使用 `search_skills` -> `load_skill`，也可以通过 gateway 使用 `search_tools` -> `describe_tool` -> `call_tool`。
 
 ---
 
@@ -136,7 +187,7 @@ AI 友好文档：[AGENTS.md](AGENTS.md) · [`docs/guide/agents-reference.md`](d
 
 ---
 
-## 快速开始
+## 安装详情与手动 API 示例
 
 ### 安装独立 CLI
 

--- a/python/dcc_mcp_core/_server/host_ui_dispatcher.py
+++ b/python/dcc_mcp_core/_server/host_ui_dispatcher.py
@@ -302,6 +302,14 @@ class HostUiDispatcherBase:
                 on_complete=on_complete,
             )
             with self._lock:
+                if self._fail_fast_on_main_queue_busy and len(self._main_queue) > 0:
+                    return {
+                        "request_id": request_id,
+                        "job_id": job_id,
+                        "status": "failed",
+                        "success": False,
+                        "error": DispatcherErrorCode.HOST_BUSY,
+                    }
                 self._main_queue.append(job)
             self.poke_host_pump()
 

--- a/tests/test_host_ui_dispatcher.py
+++ b/tests/test_host_ui_dispatcher.py
@@ -24,6 +24,13 @@ class _SyncPumpDispatcher(HostUiDispatcherBase):
         self.drain_queue(budget_ms=DEFAULT_UI_JOB_TIMEOUT_MS)
 
 
+class _NoopPumpDispatcher(HostUiDispatcherBase):
+    """Test double: leave queued jobs pending until tests inspect them."""
+
+    def poke_host_pump(self) -> None:
+        return None
+
+
 def test_normalize_affinity_rejects_unknown():
     with pytest.raises(ValueError):
         normalize_affinity("worker")
@@ -83,6 +90,27 @@ def test_fail_fast_host_busy():
     out = disp.submit_callable("behind", lambda: None, affinity="main")
     assert out["success"] is False
     assert out["error"] == DispatcherErrorCode.HOST_BUSY
+
+
+def test_async_main_fail_fast_host_busy():
+    disp = _NoopPumpDispatcher(fail_fast_on_main_queue_busy=True)
+    with disp._lock:
+        disp._main_queue.append(
+            HostUiJobEntry("ahead", "main", lambda: None),
+        )
+
+    out = disp.submit_async_callable(
+        "behind",
+        lambda: None,
+        affinity="main",
+        job_id="job-2",
+    )
+
+    assert out["success"] is False
+    assert out["status"] == "failed"
+    assert out["error"] == DispatcherErrorCode.HOST_BUSY
+    assert out["job_id"] == "job-2"
+    assert disp.pending_count() == 1
 
 
 def test_host_ui_job_honours_check_dcc_cancelled():


### PR DESCRIPTION
## Summary

- align async main-thread dispatch with the existing fail-fast host-busy behavior
- add a regression test for async main-affinity back-pressure
- reorder the English and Chinese READMEs so new users see value and quick start instructions before deeper architecture details

## Why

The narrowed dispatcher follow-up in core#1000 needs async dispatch to surface explicit host-busy back-pressure instead of silently queueing behind busy main-thread work. The README flow also now leads with user value and a short path to first use, which should make the project easier to evaluate.

## Validation

- `PYTHONPATH=G:\PycharmProjects\github\dcc-mcp-core\python python -m pytest tests/test_host_ui_dispatcher.py -q`
- `python scripts/vrs_replay.py --base-url http://127.0.0.1:1 --dry-run --trace tests/vrs/traces/core-1037-gateway-yield-unsupported-envelope.jsonl`