### PR TITLE
fix: build server linux wheel for manylinux2014

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,9 +178,11 @@ jobs:
         shell: bash
 
       # ── PyPI wheel build ──────────────────────────────────────────
-      # Reuses the same target/ directory the raw-binary step just
-      # populated; maturin sees the binary as already-compiled and does
-      # only the wheel-pack step. No second cargo build.
+      # macOS / Windows reuse the same target/ directory the raw-binary
+      # step just populated; maturin sees the binary as already-compiled
+      # and does only the wheel-pack step. Linux intentionally builds
+      # inside a manylinux2014 container so the uploaded wheel is accepted
+      # by older embedded hosts such as Maya 2022 / Python 3.7.
       # NOTE: maturin's `--strip` is intentionally OMITTED — the workspace
       # already has `strip = true` in `[profile.release]` (Cargo.toml:214),
       # so the binary is stripped at the cargo level. Adding `--strip` here
@@ -195,8 +197,18 @@ jobs:
           python -m pip install "maturin>=1.5,<2.0" "wheel>=0.46"
           maturin build --release --target universal2-apple-darwin --out wheels
 
-      - name: Build PyPI wheel (Linux / Windows)
-        if: matrix.os != 'macos-latest'
+      - name: Build PyPI wheel (Linux manylinux2014)
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          docker run --rm \
+            -v "$PWD:/io" \
+            -w /io/pkg/dcc-mcp-server-bin \
+            ghcr.io/pyo3/maturin:v1.13.3 \
+            build --release --manylinux 2014 --out wheels
+
+      - name: Build PyPI wheel (Windows)
+        if: matrix.os == 'windows-latest'
         shell: bash
         working-directory: pkg/dcc-mcp-server-bin
         run: |
@@ -286,6 +298,25 @@ jobs:
                   print(
                       f"::error::{wheel.name} must use py3-none platform tags "
                       "because dcc-mcp-server ships a standalone binary, not a CPython extension",
+                      file=sys.stderr,
+                  )
+                  sys.exit(1)
+
+              if "manylinux_2_39" in wheel.name:
+                  print(
+                      f"::error::{wheel.name} was built against the GitHub runner glibc. "
+                      "Build Linux server wheels in manylinux2014 so Maya 2022 / Python 3.7 "
+                      "can resolve dcc-mcp-server.",
+                      file=sys.stderr,
+                  )
+                  sys.exit(1)
+
+              if "manylinux" in wheel.name and not (
+                  "manylinux_2_17" in wheel.name or "manylinux2014" in wheel.name
+              ):
+                  print(
+                      f"::error::{wheel.name} must target manylinux2014 / manylinux_2_17 "
+                      "for older DCC-hosted Python environments.",
                       file=sys.stderr,
                   )
                   sys.exit(1)


### PR DESCRIPTION
## Summary
- build the Linux `dcc-mcp-server` PyPI wheel inside a manylinux2014 container
- keep macOS and Windows server wheel builds on their existing paths
- reject Linux server wheels tagged with the host runner glibc, such as `manylinux_2_39`

## Root cause
`dcc-mcp-server` is a standalone Rust binary packaged as a Python wheel, so it should be installable from Python 3.7. The published metadata already says `Requires-Python: >=3.7`, but the Linux wheel was tagged `manylinux_2_39_x86_64` because it was built directly on the GitHub-hosted Ubuntu runner. Older embedded hosts such as Maya 2022 / Python 3.7 cannot resolve that platform tag.

## Validation
- `python -m pip download --only-binary=:all: --no-deps --python-version 37 --implementation cp --abi cp37m --platform manylinux2014_x86_64 dcc-mcp-server==0.17.9` reproduces the current no-matching-distribution failure
- parsed `.github/workflows/release.yml` with PyYAML
- verified `ghcr.io/pyo3/maturin:v1.13.3` exists
- commit hook `check yaml` passed
