### PR TITLE
feat: add admin activity ledger

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -9,7 +9,7 @@ import unrealIcon from './assets/icons/unrealengine.svg';
 import substancePainterIcon from './assets/icons/photoshop.svg';
 import puzzleIcon from './assets/icons/puzzle.svg';
 
-type Panel = 'health' | 'instances' | 'tools' | 'calls' | 'traces' | 'stats' | 'logs' | 'skill-paths';
+type Panel = 'activity' | 'health' | 'instances' | 'tools' | 'tasks' | 'calls' | 'traces' | 'stats' | 'logs' | 'skill-paths';
 
 type HealthPayload = {
   status: string;
@@ -60,6 +60,37 @@ type TraceRow = {
   total_ms: number | null;
   instance_id?: string | null;
   dcc_type?: string | null;
+};
+
+type ActivityEvent = {
+  event_id: string;
+  timestamp: string;
+  kind: string;
+  severity: string;
+  status: string;
+  message: string;
+  tool?: string | null;
+  duration_ms?: number | null;
+  correlation?: {
+    request_id?: string;
+    session_id?: string;
+    instance_id?: string;
+    dcc_type?: string;
+    workflow_id?: string;
+    job_id?: string;
+    agent_id?: string;
+    parent_request_id?: string;
+  };
+};
+
+type TaskRow = {
+  task_id: string;
+  task_type: string;
+  status: string;
+  title: string;
+  started_at: string;
+  duration_ms?: number | null;
+  correlation?: ActivityEvent['correlation'];
 };
 
 type LatencyBlock = {
@@ -210,9 +241,11 @@ const API_BASE = adminApiBase();
 /** Abort hung admin fetches so the UI does not wait indefinitely on a wedged gateway. */
 const ADMIN_FETCH_TIMEOUT_MS = 25_000;
 const PANELS: { id: Panel; label: string }[] = [
+  { id: 'activity', label: 'Activity' },
   { id: 'health', label: 'Health' },
   { id: 'instances', label: 'Instances' },
   { id: 'tools', label: 'Tools' },
+  { id: 'tasks', label: 'Tasks' },
   { id: 'calls', label: 'Calls' },
   { id: 'traces', label: 'Traces' },
   { id: 'stats', label: 'Stats' },
@@ -261,7 +294,7 @@ function readPanelFromUrl(): Panel {
   if (raw === 'workers') {
     return 'instances';
   }
-  return isPanelId(raw) ? raw : 'health';
+  return isPanelId(raw) ? raw : 'activity';
 }
 
 function readStatsRangeFromUrl(): string {
@@ -292,19 +325,44 @@ function matchesListFilter(query: string, hay: string): boolean {
   return hay.includes(q);
 }
 
+function isLoopbackHost(hostname: string): boolean {
+  const h = hostname.toLowerCase();
+  return h === 'localhost' || h === '127.0.0.1' || h === '::1' || h === '[::1]';
+}
+
+function backendAccessUrls(mcpUrl: string): { origin: string; mcp: string; docs: string } {
+  const u = new URL(mcpUrl);
+  if (isLoopbackHost(u.hostname)) {
+    u.hostname = window.location.hostname;
+  }
+  const origin = u.origin;
+  return { origin, mcp: u.toString(), docs: `${origin}/docs` };
+}
+
+function BackendAccessUrl({ mcpUrl }: { mcpUrl: string }) {
+  try {
+    const urls = backendAccessUrls(mcpUrl);
+    return (
+      <a className="mono-path" href={urls.origin} target="_blank" rel="noopener noreferrer">
+        {urls.origin}
+      </a>
+    );
+  } catch {
+    return <span className="mono-path">{mcpUrl}</span>;
+  }
+}
+
 /** Open host root, MCP endpoint, and `/docs` on the DCC HTTP server (same origin as MCP). */
 function McpBackendLinks({ mcpUrl }: { mcpUrl: string }) {
   try {
-    const u = new URL(mcpUrl);
-    const origin = u.origin;
-    const docs = `${origin}/docs`;
+    const urls = backendAccessUrls(mcpUrl);
     return (
       <span className="mcp-backend-links">
-        <a href={origin} target="_blank" rel="noopener noreferrer">host</a>
+        <a href={urls.origin} target="_blank" rel="noopener noreferrer">host</a>
         {' · '}
-        <a href={mcpUrl} target="_blank" rel="noopener noreferrer">MCP</a>
+        <a href={urls.mcp} target="_blank" rel="noopener noreferrer">MCP</a>
         {' · '}
-        <a href={docs} target="_blank" rel="noopener noreferrer">docs</a>
+        <a href={urls.docs} target="_blank" rel="noopener noreferrer">docs</a>
       </span>
     );
   } catch {
@@ -532,7 +590,9 @@ function groupRows<T>(rows: T[], keyFn: (row: T) => string): Map<string, T[]> {
 function App() {
   const [activePanel, setActivePanel] = useState<Panel>(() => readPanelFromUrl());
   const [health, setHealth] = useState<HealthPayload | null>(null);
+  const [activity, setActivity] = useState<ActivityEvent[]>([]);
   const [tools, setTools] = useState<ToolRow[]>([]);
+  const [tasks, setTasks] = useState<TaskRow[]>([]);
   const [calls, setCalls] = useState<CallRow[]>([]);
   const [traces, setTraces] = useState<TraceRow[]>([]);
   const [stats, setStats] = useState<StatsPayload | null>(null);
@@ -546,9 +606,11 @@ function App() {
   const [traceDetail, setTraceDetail] = useState<string>('Select a trace row for detail.');
   const [callDetail, setCallDetail] = useState<string>('Select a call row for trace detail.');
   const [updatedAt, setUpdatedAt] = useState<Record<Panel, string>>({
+    activity: 'Loading…',
     health: 'Loading…',
     instances: 'Loading…',
     tools: 'Loading…',
+    tasks: 'Loading…',
     calls: 'Loading…',
     traces: 'Loading…',
     stats: 'Loading…',
@@ -569,6 +631,33 @@ function App() {
   useEffect(() => {
     setListSearch('');
   }, [activePanel]);
+
+  const filteredActivity = useMemo(() => {
+    const q = listSearch.trim().toLowerCase();
+    if (!q) {
+      return activity;
+    }
+    return activity.filter((event) =>
+      matchesListFilter(
+        q,
+        haystack(
+          event.timestamp,
+          event.kind,
+          event.severity,
+          event.status,
+          event.message,
+          event.tool ?? '',
+          event.correlation?.request_id ?? '',
+          event.correlation?.session_id ?? '',
+          event.correlation?.instance_id ?? '',
+          event.correlation?.dcc_type ?? '',
+          event.correlation?.workflow_id ?? '',
+          event.correlation?.job_id ?? '',
+          event.correlation?.agent_id ?? '',
+        ),
+      ),
+    );
+  }, [activity, listSearch]);
 
   const filteredTools = useMemo(() => {
     const q = listSearch.trim().toLowerCase();
@@ -625,6 +714,31 @@ function App() {
       ),
     );
   }, [traces, listSearch]);
+
+  const filteredTasks = useMemo(() => {
+    const q = listSearch.trim().toLowerCase();
+    if (!q) {
+      return tasks;
+    }
+    return tasks.filter((task) =>
+      matchesListFilter(
+        q,
+        haystack(
+          task.task_id,
+          task.task_type,
+          task.status,
+          task.title,
+          task.started_at,
+          String(task.duration_ms ?? ''),
+          task.correlation?.request_id ?? '',
+          task.correlation?.instance_id ?? '',
+          task.correlation?.dcc_type ?? '',
+          task.correlation?.workflow_id ?? '',
+          task.correlation?.job_id ?? '',
+        ),
+      ),
+    );
+  }, [tasks, listSearch]);
 
   const filteredWorkers = useMemo(() => {
     const q = listSearch.trim().toLowerCase();
@@ -718,6 +832,16 @@ function App() {
     setErrors((current) => ({ ...current, [panel]: error instanceof Error ? error.message : String(error) }));
   }, []);
 
+  const fetchActivity = useCallback(async () => {
+    try {
+      const payload = await apiJson<{ events: ActivityEvent[] }>('/activity?limit=300');
+      setActivity(Array.isArray(payload.events) ? payload.events : []);
+      markUpdated('activity', `${payload.events?.length ?? 0} event(s) — ${new Date().toLocaleTimeString()}`);
+    } catch (error) {
+      markError('activity', error);
+    }
+  }, [markError, markUpdated]);
+
   const fetchHealth = useCallback(async () => {
     try {
       const payload = await apiJson<HealthPayload>('/health');
@@ -769,6 +893,16 @@ function App() {
       markUpdated('traces', `${payload.traces.length} trace(s) — ${new Date().toLocaleTimeString()}`);
     } catch (error) {
       markError('traces', error);
+    }
+  }, [markError, markUpdated]);
+
+  const fetchTasks = useCallback(async () => {
+    try {
+      const payload = await apiJson<{ tasks: TaskRow[] }>('/tasks?limit=300');
+      setTasks(Array.isArray(payload.tasks) ? payload.tasks : []);
+      markUpdated('tasks', `${payload.tasks?.length ?? 0} task(s) — ${new Date().toLocaleTimeString()}`);
+    } catch (error) {
+      markError('tasks', error);
     }
   }, [markError, markUpdated]);
 
@@ -969,15 +1103,17 @@ function App() {
   }, [fetchTraceInto]);
 
   const fetchPanel = useCallback((panel: Panel) => {
+    if (panel === 'activity') void fetchActivity();
     if (panel === 'health') void fetchHealth();
     if (panel === 'instances') void fetchInstanceBackends();
     if (panel === 'tools') void fetchTools();
+    if (panel === 'tasks') void fetchTasks();
     if (panel === 'calls') void fetchCalls();
     if (panel === 'traces') void fetchTraces();
     if (panel === 'stats') void fetchStats();
     if (panel === 'skill-paths') void fetchSkillPaths();
     if (panel === 'logs') void fetchLogs();
-  }, [fetchCalls, fetchHealth, fetchInstanceBackends, fetchLogs, fetchSkillPaths, fetchStats, fetchTools, fetchTraces]);
+  }, [fetchActivity, fetchCalls, fetchHealth, fetchInstanceBackends, fetchLogs, fetchSkillPaths, fetchStats, fetchTasks, fetchTools, fetchTraces]);
 
   useEffect(() => {
     fetchPanel(activePanel);
@@ -1025,8 +1161,10 @@ function App() {
             />
             {listSearch.trim() ? (
               <span className="list-search-meta">
+                {activePanel === 'activity' ? `${filteredActivity.length} / ${activity.length}` : ''}
                 {activePanel === 'instances' ? `${filteredWorkers.length} / ${workers.length}` : ''}
                 {activePanel === 'tools' ? `${filteredTools.length} / ${tools.length}` : ''}
+                {activePanel === 'tasks' ? `${filteredTasks.length} / ${tasks.length}` : ''}
                 {activePanel === 'calls' ? `${filteredCalls.length} / ${calls.length}` : ''}
                 {activePanel === 'traces' ? `${filteredTraces.length} / ${traces.length}` : ''}
                 {activePanel === 'skill-paths' ? `${filteredSkillPaths.length} / ${skillPaths.length}` : ''}
@@ -1036,6 +1174,45 @@ function App() {
             ) : null}
           </div>
         )}
+        {activePanel === 'activity' && (
+          <section className="panel active activity-panel">
+            <h2>Activity</h2>
+            <StatusLine text={updatedAt.activity} error={errors.activity} />
+            {activity.length === 0 ? <p className="empty">No activity recorded yet.</p> : filteredActivity.length === 0 ? (
+              <p className="empty">No activity events match your search.</p>
+            ) : (
+              <table>
+                <thead><tr><th>Time</th><th>Status</th><th>Kind</th><th>Message</th><th>DCC</th><th>Request</th><th>ms</th></tr></thead>
+                <tbody>
+                  {filteredActivity.map((event) => {
+                    const requestId = event.correlation?.request_id;
+                    return (
+                      <tr key={event.event_id}>
+                        <td>{formatTime(event.timestamp)}</td>
+                        <td><StatusBadge value={event.status} /></td>
+                        <td>{event.kind}</td>
+                        <td title={event.message}>{event.message}</td>
+                        <td>{event.correlation?.dcc_type ?? '-'}</td>
+                        <td>
+                          {requestId ? (
+                            <button className="refresh-btn" type="button" title={requestId} onClick={() => goToPanel('traces', { traceId: requestId })}>
+                              {requestId.slice(0, 12)}
+                            </button>
+                          ) : (
+                            '-'
+                          )}
+                        </td>
+                        <td>{event.duration_ms ?? '-'}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            )}
+            <button className="refresh-btn" type="button" onClick={fetchActivity}>Refresh</button>
+          </section>
+        )}
+
         {activePanel === 'health' && (
           <section className="panel active health-panel">
             <h2>Health</h2>
@@ -1096,6 +1273,7 @@ function App() {
                       <span>Scene</span><span>{worker.scene ?? '-'}</span>
                       <span>CPU%</span><span>{worker.cpu_percent == null ? '-' : worker.cpu_percent.toFixed(1)}</span>
                       <span>Memory</span><span>{formatBytes(worker.memory_bytes)}</span>
+                      <span>Access URL</span><span><BackendAccessUrl mcpUrl={worker.mcp_url} /></span>
                       <span>Endpoints</span><span><McpBackendLinks mcpUrl={worker.mcp_url} /></span>
                     </div>
                   </div>
@@ -1135,6 +1313,45 @@ function App() {
                 </div>
               )))}
             <button className="refresh-btn" type="button" onClick={fetchTools}>Refresh</button>
+          </section>
+        )}
+
+        {activePanel === 'tasks' && (
+          <section className="panel active tasks-panel">
+            <h2>Tasks</h2>
+            <StatusLine text={updatedAt.tasks} error={errors.tasks} />
+            {tasks.length === 0 ? <p className="empty">No tasks reconstructed from traces yet.</p> : filteredTasks.length === 0 ? (
+              <p className="empty">No tasks match your search.</p>
+            ) : (
+              <table>
+                <thead><tr><th>Started</th><th>Status</th><th>Type</th><th>Title</th><th>DCC</th><th>Task</th><th>ms</th></tr></thead>
+                <tbody>
+                  {filteredTasks.map((task) => {
+                    const requestId = task.correlation?.request_id;
+                    return (
+                      <tr key={task.task_id}>
+                        <td>{formatTime(task.started_at)}</td>
+                        <td><StatusBadge value={task.status} /></td>
+                        <td>{task.task_type}</td>
+                        <td title={task.title}>{task.title}</td>
+                        <td>{task.correlation?.dcc_type ?? '-'}</td>
+                        <td>
+                          {requestId ? (
+                            <button className="refresh-btn" type="button" title={requestId} onClick={() => goToPanel('traces', { traceId: requestId })}>
+                              {requestId.slice(0, 12)}
+                            </button>
+                          ) : (
+                            task.task_id.slice(0, 12)
+                          )}
+                        </td>
+                        <td>{task.duration_ms ?? '-'}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            )}
+            <button className="refresh-btn" type="button" onClick={fetchTasks}>Refresh</button>
           </section>
         )}
 

--- a/admin-ui/tests/admin.spec.ts
+++ b/admin-ui/tests/admin.spec.ts
@@ -35,6 +35,37 @@ async function mockAdminApi(page: Page) {
         },
         circuits: { tracked_backends: 2, circuits_open: 0 },
       };
+    } else if (path === '/activity') {
+      body = {
+        total: 2,
+        events: [
+          {
+            event_id: 'audit:req-123',
+            timestamp: now,
+            kind: 'tool_call',
+            severity: 'info',
+            status: 'ok',
+            message: 'tools/call maya-1234__create_sphere',
+            tool: 'maya-1234__create_sphere',
+            duration_ms: 42,
+            correlation: {
+              request_id: 'req-123',
+              session_id: 'session-1',
+              instance_id: 'maya-1234567890',
+              dcc_type: 'maya',
+            },
+          },
+          {
+            event_id: 'gateway:1',
+            timestamp: '2026-05-18T08:00:01.000Z',
+            kind: 'gateway_elected',
+            severity: 'info',
+            status: 'ok',
+            message: 'gateway elected dcc_type=gateway instance=local',
+            correlation: { instance_id: 'local', dcc_type: 'gateway' },
+          },
+        ],
+      };
     } else if (path === '/workers') {
       body = {
         total: 2,
@@ -52,7 +83,7 @@ async function mockAdminApi(page: Page) {
             adapter_version: '0.5.0',
             cpu_percent: 3.5,
             memory_bytes: 734003200,
-            mcp_url: 'http://127.0.0.1:8765/mcp',
+            mcp_url: 'http://localhost:8765/mcp',
             scene: 'shot010.ma',
           },
           {
@@ -93,6 +124,25 @@ async function mockAdminApi(page: Page) {
             name: 'render_preview',
             instance_id: 'blender-abcdef1234',
             instance_prefix: 'blender-',
+          },
+        ],
+      };
+    } else if (path === '/tasks') {
+      body = {
+        total: 1,
+        tasks: [
+          {
+            task_id: 'req-123',
+            task_type: 'tool_call',
+            status: 'completed',
+            title: 'maya-1234__create_sphere',
+            started_at: now,
+            duration_ms: 42,
+            correlation: {
+              request_id: 'req-123',
+              instance_id: 'maya-1234567890',
+              dcc_type: 'maya',
+            },
           },
         ],
       };
@@ -203,10 +253,12 @@ test.describe('Admin Page', () => {
   test('loads the health panel and navigation', async ({ page }) => {
     await page.goto('/admin/');
     await expect(page.locator('h1')).toContainText('DCC-MCP Gateway');
-    await expect(page.getByRole('navigation').getByRole('link', { name: 'Health' })).toHaveClass(/active/);
-    for (const label of ['Health', 'Instances', 'Tools', 'Calls', 'Traces', 'Stats', 'Skill paths', 'Logs']) {
+    await expect(page.getByRole('navigation').getByRole('link', { name: 'Activity' })).toHaveClass(/active/);
+    for (const label of ['Activity', 'Health', 'Instances', 'Tools', 'Tasks', 'Calls', 'Traces', 'Stats', 'Skill paths', 'Logs']) {
       await expect(page.getByRole('navigation').getByRole('link', { name: label })).toBeVisible();
     }
+    await expect(page.locator('.activity-panel')).toContainText('maya-1234__create_sphere');
+    await page.getByRole('navigation').getByRole('link', { name: 'Health' }).click();
     await expect(page.locator('.health-panel')).toContainText('0.17.7');
   });
 
@@ -215,6 +267,9 @@ test.describe('Admin Page', () => {
     await page.getByRole('navigation').getByRole('link', { name: 'Instances' }).click();
     await expect(page.locator('.instances-panel')).toBeVisible();
     await expect(page.locator('.dcc-icon')).toHaveCount(2);
+    await expect(page.locator('.instances-panel')).toContainText('Access URL');
+    await expect(page.locator('.instances-panel')).toContainText('http://127.0.0.1:8765');
+    await expect(page.getByRole('link', { name: 'docs' }).first()).toHaveAttribute('href', 'http://127.0.0.1:8765/docs');
     await page.getByLabel('Filter current panel').fill('blender');
     await expect(page.locator('.worker-card')).toHaveCount(1);
     await expect(page.locator('.worker-card')).toContainText('Blender Lookdev');
@@ -228,6 +283,15 @@ test.describe('Admin Page', () => {
     await expect(page).toHaveURL(/trace=req-123/);
     await expect(page.locator('.traces-panel pre')).toContainText('"request_id": "req-123"');
     await expect(page.locator('.traces-panel pre')).toContainText('"dispatch"');
+  });
+
+  test('shows reconstructed tasks and links them to traces', async ({ page }) => {
+    await page.goto('/admin/?panel=tasks');
+    await expect(page.locator('.tasks-panel')).toContainText('maya-1234__create_sphere');
+    await page.getByRole('button', { name: 'req-123' }).click();
+    await expect(page).toHaveURL(/panel=traces/);
+    await expect(page).toHaveURL(/trace=req-123/);
+    await expect(page.locator('.traces-panel pre')).toContainText('"request_id": "req-123"');
   });
 
   test('updates stats when the range selector changes', async ({ page }) => {

--- a/crates/dcc-mcp-gateway/src/gateway/admin/activity.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/activity.rs
@@ -1,0 +1,312 @@
+//! Unified admin activity projection.
+//!
+//! The dashboard has several raw observability lanes: audit rows, dispatch
+//! traces, gateway events, and eventually workflow/job updates.  This module
+//! gives both humans and agents a single timeline-shaped interface over those
+//! lanes without changing the hot-path writers.
+
+use std::cmp::Reverse;
+use std::collections::HashMap;
+use std::time::UNIX_EPOCH;
+
+use serde::Serialize;
+use serde_json::{Value, json};
+
+use super::state::{AdminAuditRecord, AdminState};
+use super::trace::DispatchTrace;
+use crate::gateway::event_log::ContendEvent;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ActivityCorrelation {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instance_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dcc_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workflow_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub job_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_request_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ActivityEvent {
+    pub event_id: String,
+    pub timestamp: String,
+    pub kind: String,
+    pub severity: String,
+    pub status: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+    pub correlation: ActivityCorrelation,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TaskSnapshot {
+    pub task_id: String,
+    pub task_type: String,
+    pub status: String,
+    pub title: String,
+    pub started_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+    pub correlation: ActivityCorrelation,
+}
+
+pub async fn build_activity_payload(state: &AdminState, limit: usize) -> Value {
+    let events = collect_activity_events(state, limit).await;
+    json!({ "total": events.len(), "events": events })
+}
+
+pub async fn build_tasks_payload(state: &AdminState, limit: usize) -> Value {
+    let mut tasks = Vec::new();
+    for trace in collect_traces(state, limit).await {
+        tasks.push(TaskSnapshot {
+            task_id: trace.request_id.clone(),
+            task_type: "tool_call".to_string(),
+            status: if trace.ok { "completed" } else { "failed" }.to_string(),
+            title: trace
+                .tool_slug
+                .clone()
+                .unwrap_or_else(|| trace.method.clone()),
+            started_at: rfc3339(trace.started_at),
+            duration_ms: Some(trace.total_ms),
+            correlation: trace_correlation(&trace),
+        });
+    }
+    json!({ "total": tasks.len(), "tasks": tasks })
+}
+
+pub async fn build_debug_bundle(state: &AdminState, request_id: &str) -> Option<Value> {
+    let audits = collect_audits(state, 1_000).await;
+    let audit = audits.into_iter().find(|r| r.request_id == request_id);
+    let trace = find_trace(state, request_id).await;
+    if audit.is_none() && trace.is_none() {
+        return None;
+    }
+    let related_activity: Vec<Value> = state
+        .gateway
+        .event_log
+        .recent_events(500)
+        .into_iter()
+        .filter(|event| {
+            event
+                .reason
+                .as_deref()
+                .is_some_and(|r| r.contains(request_id))
+        })
+        .map(gateway_event_json)
+        .collect();
+    Some(json!({
+        "request_id": request_id,
+        "audit": audit.map(|r| audit_event(&r)),
+        "trace": trace,
+        "related_activity": related_activity,
+        "hints": debug_hints(trace.as_ref()),
+    }))
+}
+
+async fn collect_activity_events(state: &AdminState, limit: usize) -> Vec<ActivityEvent> {
+    let mut events = Vec::new();
+    for record in collect_audits(state, limit.saturating_mul(2).max(200)).await {
+        events.push(audit_event(&record));
+    }
+    for trace in collect_traces(state, limit.saturating_mul(2).max(200)).await {
+        events.push(trace_event(&trace));
+    }
+    for event in state.gateway.event_log.recent_events(limit.min(500)) {
+        events.push(gateway_event(&event));
+    }
+    events.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    events.truncate(limit);
+    events
+}
+
+async fn collect_audits(state: &AdminState, limit: usize) -> Vec<AdminAuditRecord> {
+    let mut by_id: HashMap<String, AdminAuditRecord> = HashMap::new();
+    if let Some(lane) = &state.admin_sqlite_lane {
+        for rec in lane
+            .reader()
+            .list_audits_recent(limit.saturating_mul(4).max(500))
+        {
+            by_id.insert(rec.request_id.clone(), rec);
+        }
+    }
+    if let Some(log) = &state.audit_log {
+        for rec in log.lock().iter().rev().take(limit) {
+            by_id.insert(rec.request_id.clone(), rec.clone());
+        }
+    }
+    let mut rows: Vec<_> = by_id.into_values().collect();
+    rows.sort_by_key(|row| Reverse(row.timestamp));
+    rows.truncate(limit);
+    rows
+}
+
+async fn collect_traces(state: &AdminState, limit: usize) -> Vec<DispatchTrace> {
+    let mut by_id: HashMap<String, DispatchTrace> = HashMap::new();
+    if let Some(lane) = &state.admin_sqlite_lane {
+        for trace in lane
+            .reader()
+            .list_traces_since(None, limit.saturating_mul(4).max(500))
+        {
+            by_id.insert(trace.request_id.clone(), trace);
+        }
+    }
+    if let Some(log) = &state.trace_log {
+        for trace in log.recent(limit) {
+            by_id.insert(trace.request_id.clone(), trace);
+        }
+    }
+    let mut rows: Vec<_> = by_id.into_values().collect();
+    rows.sort_by_key(|row| Reverse(row.started_at));
+    rows.truncate(limit);
+    rows
+}
+
+async fn find_trace(state: &AdminState, request_id: &str) -> Option<DispatchTrace> {
+    if let Some(trace) = state.trace_log.as_ref().and_then(|log| log.get(request_id)) {
+        return Some(trace);
+    }
+    state
+        .admin_sqlite_lane
+        .as_ref()
+        .and_then(|lane| lane.reader().get_trace(request_id))
+}
+
+fn audit_event(record: &AdminAuditRecord) -> ActivityEvent {
+    ActivityEvent {
+        event_id: format!("audit:{}", record.request_id),
+        timestamp: rfc3339(record.timestamp),
+        kind: "tool_call".to_string(),
+        severity: if record.success { "info" } else { "error" }.to_string(),
+        status: if record.success { "ok" } else { "err" }.to_string(),
+        message: format!(
+            "{} {}",
+            record.method.as_deref().unwrap_or("call"),
+            record.action
+        ),
+        tool: Some(record.action.clone()),
+        duration_ms: record.duration_ms,
+        correlation: ActivityCorrelation {
+            request_id: Some(record.request_id.clone()),
+            session_id: record.session_id.clone(),
+            instance_id: record.instance_id.clone(),
+            dcc_type: record.dcc_type.clone(),
+            workflow_id: None,
+            job_id: None,
+            agent_id: None,
+            parent_request_id: None,
+        },
+    }
+}
+
+fn trace_event(trace: &DispatchTrace) -> ActivityEvent {
+    let tool = trace
+        .tool_slug
+        .clone()
+        .unwrap_or_else(|| trace.method.clone());
+    ActivityEvent {
+        event_id: format!("trace:{}", trace.request_id),
+        timestamp: rfc3339(trace.started_at),
+        kind: "dispatch_trace".to_string(),
+        severity: if trace.ok { "debug" } else { "error" }.to_string(),
+        status: if trace.ok { "ok" } else { "err" }.to_string(),
+        message: format!("{} completed in {}ms", tool, trace.total_ms),
+        tool: Some(tool),
+        duration_ms: Some(trace.total_ms),
+        correlation: trace_correlation(trace),
+    }
+}
+
+fn gateway_event(event: &ContendEvent) -> ActivityEvent {
+    let label = event.event.as_label();
+    ActivityEvent {
+        event_id: format!(
+            "gateway:{}:{}:{}",
+            event.timestamp, event.dcc_type, event.instance_id
+        ),
+        timestamp: event.timestamp.clone(),
+        kind: "gateway_event".to_string(),
+        severity: "info".to_string(),
+        status: label.to_string(),
+        message: event.reason.clone().unwrap_or_else(|| {
+            format!(
+                "{label} dcc_type={} instance={}",
+                event.dcc_type, event.instance_id
+            )
+        }),
+        tool: None,
+        duration_ms: None,
+        correlation: ActivityCorrelation {
+            request_id: None,
+            session_id: None,
+            instance_id: Some(event.instance_id.clone()),
+            dcc_type: Some(event.dcc_type.clone()),
+            workflow_id: None,
+            job_id: None,
+            agent_id: None,
+            parent_request_id: None,
+        },
+    }
+}
+
+fn gateway_event_json(event: ContendEvent) -> Value {
+    serde_json::to_value(gateway_event(&event)).unwrap_or_else(|_| json!({}))
+}
+
+fn trace_correlation(trace: &DispatchTrace) -> ActivityCorrelation {
+    ActivityCorrelation {
+        request_id: Some(trace.request_id.clone()),
+        session_id: trace.session_id.clone(),
+        instance_id: trace.instance_id.clone(),
+        dcc_type: trace.dcc_type.clone(),
+        workflow_id: None,
+        job_id: None,
+        agent_id: None,
+        parent_request_id: None,
+    }
+}
+
+fn debug_hints(trace: Option<&DispatchTrace>) -> Vec<String> {
+    let Some(trace) = trace else {
+        return vec!["No dispatch trace was retained for this request.".to_string()];
+    };
+    if trace.ok {
+        return vec![
+            "Request completed successfully; inspect spans for slow segments.".to_string(),
+        ];
+    }
+    let mut hints =
+        vec!["Request failed; inspect the last error span and output payload.".to_string()];
+    if trace
+        .spans
+        .iter()
+        .any(|span| span.name.contains("backend") && !span.ok)
+    {
+        hints.push(
+            "A backend span failed; check instance reachability and sidecar/DCC logs.".to_string(),
+        );
+    }
+    hints
+}
+
+fn rfc3339(t: std::time::SystemTime) -> String {
+    t.duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|_| {
+            chrono::DateTime::<chrono::Utc>::from(t)
+                .to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+        })
+        .unwrap_or_default()
+}

--- a/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
@@ -33,6 +33,19 @@ pub async fn handle_admin_ui() -> impl IntoResponse {
     resp
 }
 
+/// `GET /admin/api/activity` — unified operator / agent activity timeline.
+pub async fn handle_admin_activity(
+    State(s): State<AdminState>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> impl IntoResponse {
+    let limit = params
+        .get("limit")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(200)
+        .clamp(1, 1_000);
+    Json(crate::gateway::admin::activity::build_activity_payload(&s, limit).await)
+}
+
 /// `GET /admin/api/instances` — list all instances known to the registry.
 pub async fn handle_admin_instances(State(s): State<AdminState>) -> impl IntoResponse {
     let registry = s.gateway.registry.read().await;
@@ -319,6 +332,34 @@ pub async fn handle_admin_trace_detail(
         Json(json!({ "error": "trace not found", "request_id": request_id })),
     )
         .into_response()
+}
+
+/// `GET /admin/api/tasks` — task-like projection over retained gateway work.
+pub async fn handle_admin_tasks(
+    State(s): State<AdminState>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> impl IntoResponse {
+    let limit = params
+        .get("limit")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(200)
+        .clamp(1, 1_000);
+    Json(crate::gateway::admin::activity::build_tasks_payload(&s, limit).await)
+}
+
+/// `GET /admin/api/debug-bundle/{request_id}` — correlated material for one request.
+pub async fn handle_admin_debug_bundle(
+    State(s): State<AdminState>,
+    axum::extract::Path(request_id): axum::extract::Path<String>,
+) -> impl IntoResponse {
+    match crate::gateway::admin::activity::build_debug_bundle(&s, &request_id).await {
+        Some(bundle) => (StatusCode::OK, Json(bundle)).into_response(),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": "debug bundle not found", "request_id": request_id })),
+        )
+            .into_response(),
+    }
 }
 
 /// `GET /admin/api/stats?range=1h|24h|7d` — aggregated call statistics (Phase 3).

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -43,6 +43,7 @@
 //!
 //! See `docs/guide/gateway-admin.md` for screenshots and configuration knobs.
 
+pub mod activity;
 mod html;
 pub mod sqlite_lane;
 pub mod state;
@@ -55,6 +56,7 @@ mod handlers;
 #[cfg(feature = "admin")]
 mod router;
 
+pub use activity::{ActivityCorrelation, ActivityEvent, TaskSnapshot};
 pub use dcc_mcp_db::{
     default_gateway_admin_sqlite_path as default_admin_db_path,
     resolve_gateway_admin_sqlite_path as resolve_admin_db_path,

--- a/crates/dcc-mcp-gateway/src/gateway/admin/router.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/router.rs
@@ -3,9 +3,10 @@
 use axum::{Router, routing};
 
 use super::handlers::{
-    handle_admin_calls, handle_admin_health, handle_admin_instances, handle_admin_logs,
-    handle_admin_skill_path_add, handle_admin_skill_path_delete, handle_admin_skill_paths,
-    handle_admin_stats, handle_admin_tools, handle_admin_trace_detail, handle_admin_traces,
+    handle_admin_activity, handle_admin_calls, handle_admin_debug_bundle, handle_admin_health,
+    handle_admin_instances, handle_admin_logs, handle_admin_skill_path_add,
+    handle_admin_skill_path_delete, handle_admin_skill_paths, handle_admin_stats,
+    handle_admin_tasks, handle_admin_tools, handle_admin_trace_detail, handle_admin_traces,
     handle_admin_ui, handle_admin_workers,
 };
 use super::state::AdminState;
@@ -29,6 +30,7 @@ use super::state::AdminState;
 pub fn build_admin_router(state: AdminState) -> Router {
     Router::new()
         .route("/", routing::get(handle_admin_ui))
+        .route("/api/activity", routing::get(handle_admin_activity))
         .route("/api/instances", routing::get(handle_admin_instances))
         .route("/api/tools", routing::get(handle_admin_tools))
         .route("/api/calls", routing::get(handle_admin_calls))
@@ -36,6 +38,11 @@ pub fn build_admin_router(state: AdminState) -> Router {
         .route(
             "/api/traces/{request_id}",
             routing::get(handle_admin_trace_detail),
+        )
+        .route("/api/tasks", routing::get(handle_admin_tasks))
+        .route(
+            "/api/debug-bundle/{request_id}",
+            routing::get(handle_admin_debug_bundle),
         )
         .route("/api/skill-paths", routing::get(handle_admin_skill_paths))
         .route(

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -361,6 +361,94 @@ mod admin_tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_admin_activity_merges_audit_and_trace_rows() {
+        use crate::gateway::admin::trace::{DispatchTrace, TraceLog};
+        use std::time::SystemTime;
+
+        let audit_log: Arc<AuditLog> = Arc::new(parking_lot::Mutex::new(vec![AdminAuditRecord {
+            timestamp: SystemTime::now(),
+            request_id: "req-activity".to_string(),
+            method: Some("tools/call".to_string()),
+            instance_id: Some("inst-1".to_string()),
+            session_id: Some("session-1".to_string()),
+            action: "maya.inst.tool".to_string(),
+            dcc_type: Some("maya".to_string()),
+            success: true,
+            error: None,
+            duration_ms: Some(11),
+        }]));
+        let traces = Arc::new(TraceLog::new(10));
+        traces.push(DispatchTrace {
+            request_id: "req-activity".into(),
+            method: "tools/call".into(),
+            tool_slug: Some("maya.inst.tool".into()),
+            instance_id: Some("inst-1".into()),
+            session_id: Some("session-1".into()),
+            dcc_type: Some("maya".into()),
+            started_at: SystemTime::now(),
+            total_ms: 11,
+            ok: true,
+            spans: vec![],
+            input: None,
+            output: None,
+        });
+        let state = AdminState::new(make_gateway_state())
+            .with_audit_log(audit_log)
+            .with_trace_log(traces, None);
+
+        let (status, body) = body_json(build_admin_router(state), "/api/activity").await;
+
+        assert_eq!(status, StatusCode::OK);
+        let events = body["events"].as_array().unwrap();
+        assert!(
+            events.iter().any(|e| e["kind"] == "tool_call"),
+            "expected audit event in activity payload"
+        );
+        assert!(
+            events.iter().any(|e| e["kind"] == "dispatch_trace"),
+            "expected trace event in activity payload"
+        );
+        assert_eq!(body["total"].as_u64(), Some(events.len() as u64));
+    }
+
+    #[tokio::test]
+    async fn test_admin_tasks_and_debug_bundle_from_trace() {
+        use crate::gateway::admin::trace::{DispatchTrace, TraceLog};
+        use std::time::SystemTime;
+
+        let traces = Arc::new(TraceLog::new(10));
+        traces.push(DispatchTrace {
+            request_id: "req-task".into(),
+            method: "tools/call".into(),
+            tool_slug: Some("maya.inst.long_task".into()),
+            instance_id: Some("inst-1".into()),
+            session_id: Some("session-1".into()),
+            dcc_type: Some("maya".into()),
+            started_at: SystemTime::now(),
+            total_ms: 25,
+            ok: false,
+            spans: vec![],
+            input: None,
+            output: None,
+        });
+        let state = AdminState::new(make_gateway_state()).with_trace_log(traces, None);
+        let router = build_admin_router(state);
+
+        let (tasks_status, tasks_body) = body_json(router.clone(), "/api/tasks").await;
+        assert_eq!(tasks_status, StatusCode::OK);
+        assert_eq!(tasks_body["tasks"][0]["task_id"], "req-task");
+        assert_eq!(tasks_body["tasks"][0]["status"], "failed");
+
+        let (bundle_status, bundle_body) = body_json(router, "/api/debug-bundle/req-task").await;
+        assert_eq!(bundle_status, StatusCode::OK);
+        assert_eq!(bundle_body["request_id"], "req-task");
+        assert!(bundle_body["trace"].is_object());
+        assert!(bundle_body["related_activity"].is_array());
+        assert!(bundle_body.get("related_logs").is_none());
+        assert!(bundle_body["hints"].is_array());
+    }
+
     // ── /api/logs ─────────────────────────────────────────────────────────
 
     #[tokio::test]
@@ -647,6 +735,36 @@ mod admin_tests {
         assert!(w["memory_bytes"].is_null());
         assert!(w["uptime_secs"].as_u64().is_some());
         // summary should reflect 1 live, 0 stale.
+        assert_eq!(body["total"].as_u64(), Some(1));
+        assert_eq!(body["summary"]["live"].as_u64(), Some(1));
+        assert_eq!(body["summary"]["stale"].as_u64(), Some(0));
+    }
+
+    #[tokio::test]
+    async fn test_admin_workers_hides_stale_registry_rows() {
+        let gs = make_gateway_state();
+        {
+            let reg = gs.registry.write().await;
+            reg.register(make_service_entry("maya", "127.0.0.1", 18813, Some(4242)))
+                .unwrap();
+
+            let mut stale = make_service_entry("maya", "127.0.0.1", 18814, Some(4243));
+            stale.last_heartbeat = std::time::SystemTime::now() - Duration::from_secs(120);
+            reg.register(stale).unwrap();
+        }
+
+        let state = AdminState::new(gs);
+        let router = build_admin_router(state);
+        let (status, body) = body_json(router, "/api/workers").await;
+
+        assert_eq!(status, StatusCode::OK);
+        let workers = body["workers"].as_array().unwrap();
+        assert_eq!(
+            workers.len(),
+            1,
+            "expected only live workers, got {workers:?}"
+        );
+        assert_eq!(workers[0]["port"], 18813);
         assert_eq!(body["total"].as_u64(), Some(1));
         assert_eq!(body["summary"]["live"].as_u64(), Some(1));
         assert_eq!(body["summary"]["stale"].as_u64(), Some(0));

--- a/crates/dcc-mcp-gateway/src/gateway/admin/workers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/workers.rs
@@ -73,21 +73,21 @@ fn entry_to_worker_json(e: &ServiceEntry, gs: &GatewayState) -> Value {
     })
 }
 
-/// Snapshot every known instance into a Workers payload.
+/// Snapshot every live instance into a Workers payload.
 ///
-/// `summary.total` / `summary.live` / `summary.stale` mirror the counters in
-/// `gateway://diagnostics/process` so the Workers tab agrees with the
-/// Health tab on identical data.
+/// The admin Instances panel is an operator view of currently routable DCC
+/// backends. Stale registry rows are useful for diagnostics, but rendering
+/// them as instance cards makes closed/restarted DCC sessions look alive.
 pub async fn build_workers_payload(gs: &GatewayState) -> Value {
     use dcc_mcp_transport::discovery::types::ServiceStatus;
 
     let reg = gs.registry.read().await;
-    let all = gs.all_instances(&reg);
+    let live_instances = gs.live_instances(&reg);
 
     let mut live = 0usize;
     let mut stale_count = 0usize;
     let mut unhealthy = 0usize;
-    let workers: Vec<Value> = all
+    let workers: Vec<Value> = live_instances
         .iter()
         .map(|e| {
             let stale = e.is_stale(gs.stale_timeout);

--- a/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
@@ -165,6 +165,66 @@ async fn test_live_instances_excludes_status_stale_immediately() {
 }
 
 #[tokio::test]
+async fn test_live_instances_prefers_sidecar_for_same_dcc_pid() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
+
+    {
+        let r = registry.read().await;
+        let mut in_process = ServiceEntry::new("maya", "127.0.0.1", 18812).with_pid(4242);
+        in_process.version = Some("2026".into());
+        r.register(in_process).unwrap();
+
+        let mut sidecar = ServiceEntry::new("maya", "127.0.0.1", 28812).with_pid(4242);
+        sidecar.adapter_version = Some("0.3.3".into());
+        sidecar
+            .metadata
+            .insert("dcc_mcp_role".into(), "per-dcc-sidecar".into());
+        r.register(sidecar).unwrap();
+    }
+
+    let gs = test_gateway_state(registry.clone());
+    let live = gs.live_instances(&*registry.read().await);
+
+    assert_eq!(live.len(), 1, "sidecar should replace same-pid adapter row");
+    assert_eq!(live[0].port, 28812);
+    assert_eq!(
+        live[0].metadata.get("dcc_mcp_role").map(String::as_str),
+        Some("per-dcc-sidecar")
+    );
+}
+
+#[tokio::test]
+async fn test_live_instances_stale_sidecar_does_not_hide_live_adapter() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
+
+    {
+        let r = registry.read().await;
+        let in_process = ServiceEntry::new("maya", "127.0.0.1", 18812).with_pid(4242);
+        r.register(in_process).unwrap();
+
+        let mut sidecar = ServiceEntry::new("maya", "127.0.0.1", 28812).with_pid(4242);
+        sidecar.last_heartbeat = std::time::SystemTime::now() - Duration::from_secs(600);
+        sidecar
+            .metadata
+            .insert("dcc_mcp_role".into(), "per-dcc-sidecar".into());
+        r.register(sidecar).unwrap();
+    }
+
+    let gs = test_gateway_state(registry.clone());
+    let live = gs.live_instances(&*registry.read().await);
+
+    assert_eq!(
+        live.len(),
+        1,
+        "stale sidecar must not mask a live in-process adapter"
+    );
+    assert_eq!(live[0].port, 18812);
+    assert!(!live[0].metadata.contains_key("dcc_mcp_role"));
+}
+
+#[tokio::test]
 async fn test_resolve_instance_accepts_short_and_unique_prefix() {
     let dir = tempfile::tempdir().unwrap();
     let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));

--- a/crates/dcc-mcp-gateway/src/gateway/state/views.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state/views.rs
@@ -16,6 +16,9 @@ use dcc_mcp_gateway_core::PendingCall;
 use dcc_mcp_transport::discovery::file_registry::FileRegistry;
 use dcc_mcp_transport::discovery::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry, ServiceStatus};
 
+const ROLE_METADATA_KEY: &str = "dcc_mcp_role";
+const ROLE_PER_DCC_SIDECAR: &str = "per-dcc-sidecar";
+
 // ─── Sub-state structs (issue #839) ─────────────────────────────────────────
 //
 // Each sub-state is a *typed view* over the subset of [`GatewayState`] that a
@@ -113,7 +116,7 @@ pub struct ServerState<'a> {
 impl<'a> DiscoveryState<'a> {
     /// See [`GatewayState::live_instances`].
     pub fn live_instances(&self, registry: &FileRegistry) -> Vec<ServiceEntry> {
-        registry
+        let filtered: Vec<ServiceEntry> = registry
             .list_all()
             .into_iter()
             .filter(|e| {
@@ -129,7 +132,9 @@ impl<'a> DiscoveryState<'a> {
                     && !crate::gateway::is_own_instance(e, self.own_host, self.own_port)
                     && (self.allow_unknown_tools || !e.dcc_type.eq_ignore_ascii_case("unknown"))
             })
-            .collect()
+            .collect();
+
+        prefer_live_sidecars(filtered)
     }
 
     /// See [`GatewayState::all_instances`].
@@ -159,4 +164,37 @@ impl<'a> DiscoveryState<'a> {
             .collect();
         Ok((filtered, evicted))
     }
+}
+
+fn is_per_dcc_sidecar(entry: &ServiceEntry) -> bool {
+    entry
+        .metadata
+        .get(ROLE_METADATA_KEY)
+        .is_some_and(|role| role == ROLE_PER_DCC_SIDECAR)
+}
+
+fn sidecar_owner_key(entry: &ServiceEntry) -> Option<(String, u32)> {
+    entry
+        .pid
+        .map(|pid| (entry.dcc_type.to_ascii_lowercase(), pid))
+}
+
+fn prefer_live_sidecars(entries: Vec<ServiceEntry>) -> Vec<ServiceEntry> {
+    let sidecar_owners: HashSet<(String, u32)> = entries
+        .iter()
+        .filter(|entry| is_per_dcc_sidecar(entry))
+        .filter_map(sidecar_owner_key)
+        .collect();
+
+    if sidecar_owners.is_empty() {
+        return entries;
+    }
+
+    entries
+        .into_iter()
+        .filter(|entry| {
+            is_per_dcc_sidecar(entry)
+                || sidecar_owner_key(entry).is_none_or(|owner| !sidecar_owners.contains(&owner))
+        })
+        .collect()
 }

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -74,11 +74,14 @@ When using `dcc-mcp-gateway` directly, compile with the `admin` Cargo feature. `
 | Route | Content-Type | Description |
 |-------|-------------|-------------|
 | `GET /admin` | `text/html` | Embedded React/Vite dashboard served as one HTML asset |
+| `GET /admin/api/activity?limit=300` | `application/json` | Unified activity timeline built from audits, traces, and gateway events |
 | `GET /admin/api/instances` | `application/json` | Connected DCC instances |
 | `GET /admin/api/tools` | `application/json` | Registered MCP tools |
+| `GET /admin/api/tasks?limit=300` | `application/json` | Task-like snapshots reconstructed from dispatch traces |
 | `GET /admin/api/calls` | `application/json` | Recent tool calls (requires `AuditMiddleware`) |
 | `GET /admin/api/traces` | `application/json` | Recent per-call dispatch traces; accepts `?limit=200` |
 | `GET /admin/api/traces/{request_id}` | `application/json` | Full waterfall for one recorded dispatch trace |
+| `GET /admin/api/debug-bundle/{request_id}` | `application/json` | One-stop debug bundle containing the trace, matching audit row, related activity, and hints |
 | `GET /admin/api/stats?range=1h\|24h\|7d` | `application/json` | Aggregated call counts, success rate, latency, and top tools/instances |
 | `GET /admin/api/workers` | `application/json` | Per-instance worker cards from the live registry |
 | `GET /admin/api/logs` | `application/json` | Merged gateway contention events, on-disk `*.log` rows, and audited call summaries |
@@ -100,6 +103,49 @@ When using `dcc-mcp-gateway` directly, compile with the `admin` Cargo feature. `
   "total": 3,
   "instances": [
     { "id": "a1b2c3d4-...", "dcc_type": "maya", "status": "ready", "address": "127.0.0.1:9001" }
+  ]
+}
+
+// GET /admin/api/activity?limit=300
+{
+  "total": 2,
+  "events": [
+    {
+      "event_id": "audit:req-123",
+      "timestamp": "2026-05-05T10:00:00Z",
+      "kind": "tool_call",
+      "severity": "info",
+      "status": "ok",
+      "message": "tools/call maya__open_scene",
+      "tool": "maya__open_scene",
+      "duration_ms": 48,
+      "correlation": {
+        "request_id": "req-123",
+        "session_id": "session-1",
+        "instance_id": "abcdef01-2345-6789-abcd-ef0123456789",
+        "dcc_type": "maya"
+      }
+    }
+  ]
+}
+
+// GET /admin/api/tasks?limit=300
+{
+  "total": 1,
+  "tasks": [
+    {
+      "task_id": "req-123",
+      "task_type": "tool_call",
+      "status": "completed",
+      "title": "maya__open_scene",
+      "started_at": "2026-05-05T10:00:00Z",
+      "duration_ms": 48,
+      "correlation": {
+        "request_id": "req-123",
+        "instance_id": "abcdef01-2345-6789-abcd-ef0123456789",
+        "dcc_type": "maya"
+      }
+    }
   ]
 }
 
@@ -142,6 +188,15 @@ When using `dcc-mcp-gateway` directly, compile with the `admin` Cargo feature. `
 }
 
 // GET /admin/api/traces/req-123 returns the same full trace object or 404.
+
+// GET /admin/api/debug-bundle/req-123
+{
+  "request_id": "req-123",
+  "trace": { "request_id": "req-123", "spans": [] },
+  "audit": { "request_id": "req-123", "success": true },
+  "related_activity": [],
+  "hints": []
+}
 
 // GET /admin/api/stats?range=24h
 {

--- a/docs/zh/guide/admin-ui.md
+++ b/docs/zh/guide/admin-ui.md
@@ -74,11 +74,14 @@ let config = GatewayConfig {
 | 路由 | Content-Type | 说明 |
 |------|-------------|------|
 | `GET /admin` | `text/html` | 以单个 HTML 资产提供的嵌入式 React/Vite 仪表盘 |
+| `GET /admin/api/activity?limit=300` | `application/json` | 由审计、trace 和 gateway 事件合并得到的统一活动时间线 |
 | `GET /admin/api/instances` | `application/json` | 已连接的 DCC 实例 |
 | `GET /admin/api/tools` | `application/json` | 已注册的 MCP 工具 |
+| `GET /admin/api/tasks?limit=300` | `application/json` | 从 dispatch traces 重建出的任务视图 |
 | `GET /admin/api/calls` | `application/json` | 最近的工具调用（需要 `AuditMiddleware`） |
 | `GET /admin/api/traces` | `application/json` | 最近的逐调用 dispatch traces；支持 `?limit=200` |
 | `GET /admin/api/traces/{request_id}` | `application/json` | 某次调用的完整 waterfall trace |
+| `GET /admin/api/debug-bundle/{request_id}` | `application/json` | 单次请求的一站式 debug bundle，包含 trace、匹配审计行、相关活动和提示 |
 | `GET /admin/api/stats?range=1h\|24h\|7d` | `application/json` | 聚合调用数、成功率、延迟和 top tools/instances |
 | `GET /admin/api/workers` | `application/json` | 来自 live registry 的实例 worker 卡片 |
 | `GET /admin/api/logs` | `application/json` | 合并后的网关竞争事件、磁盘 `*.log` 行和审计调用摘要 |
@@ -100,6 +103,49 @@ let config = GatewayConfig {
   "total": 3,
   "instances": [
     { "id": "a1b2c3d4-...", "dcc_type": "maya", "status": "ready", "address": "127.0.0.1:9001" }
+  ]
+}
+
+// GET /admin/api/activity?limit=300
+{
+  "total": 2,
+  "events": [
+    {
+      "event_id": "audit:req-123",
+      "timestamp": "2026-05-05T10:00:00Z",
+      "kind": "tool_call",
+      "severity": "info",
+      "status": "ok",
+      "message": "tools/call maya__open_scene",
+      "tool": "maya__open_scene",
+      "duration_ms": 48,
+      "correlation": {
+        "request_id": "req-123",
+        "session_id": "session-1",
+        "instance_id": "abcdef01-2345-6789-abcd-ef0123456789",
+        "dcc_type": "maya"
+      }
+    }
+  ]
+}
+
+// GET /admin/api/tasks?limit=300
+{
+  "total": 1,
+  "tasks": [
+    {
+      "task_id": "req-123",
+      "task_type": "tool_call",
+      "status": "completed",
+      "title": "maya__open_scene",
+      "started_at": "2026-05-05T10:00:00Z",
+      "duration_ms": 48,
+      "correlation": {
+        "request_id": "req-123",
+        "instance_id": "abcdef01-2345-6789-abcd-ef0123456789",
+        "dcc_type": "maya"
+      }
+    }
   ]
 }
 
@@ -142,6 +188,15 @@ let config = GatewayConfig {
 }
 
 // GET /admin/api/traces/req-123 返回同一个完整 trace 对象；未命中时返回 404。
+
+// GET /admin/api/debug-bundle/req-123
+{
+  "request_id": "req-123",
+  "trace": { "request_id": "req-123", "spans": [] },
+  "audit": { "request_id": "req-123", "success": true },
+  "related_activity": [],
+  "hints": []
+}
 
 // GET /admin/api/stats?range=24h
 {


### PR DESCRIPTION
## Summary
- add Activity and Tasks admin panels backed by correlated audit, trace, and gateway event APIs
- add debug bundle endpoint for request-level investigation
- filter stale/duplicate instance rows so per-DCC sidecars are the visible live DCC instances

## Tests
- npm run build
- npm test -- --reporter=line
- cargo test -p dcc-mcp-gateway --features admin admin_activity
- cargo test -p dcc-mcp-gateway --features admin admin_tasks
- cargo test -p dcc-mcp-gateway --features admin admin_workers
- cargo test -p dcc-mcp-gateway --features admin live_instances
- cargo clippy -p dcc-mcp-gateway --features admin -- -D warnings