### PR TITLE
test: cover skill loader error contracts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
 
   # ── Build standalone binaries (raw Release assets + server PyPI wheel) ──
   #
-  # One job, one cargo target/, three outputs:
+  # One job, one native cargo target/ (plus an isolated manylinux target/), three outputs:
   #   1. Raw binary `dcc-mcp-server[-linux-x86_64|-windows-x86_64.exe|-macos-universal2]`
   #      attached to the GitHub Release. Backward-compat artefact for
   #      ops / docker users who don't want to `pip install`.
@@ -97,8 +97,10 @@ jobs:
   #      pkg/dcc-mcp-server-bin/ via maturin's `bindings = "bin"`. It has
   #      no Python extension ABI and declares Python 3.7+ compatibility so
   #      Maya 2022's embedded Python can install it. maturin reuses the
-  #      just-built binary from `target/release/` so we do NOT compile twice
-  #      (#1003 review feedback).
+  #      just-built binary from `target/release/` on macOS/Windows so we do
+  #      NOT compile twice (#1003 review feedback). Linux manylinux wheels use
+  #      an isolated `target-manylinux2014/` because host-built Cargo build
+  #      scripts cannot run inside the older manylinux2014 glibc environment.
   #
   # Both artefacts ride the same release-please tag — there is exactly
   # one release lifecycle for the workspace, and `dcc-mcp-server` ships
@@ -182,7 +184,9 @@ jobs:
       # step just populated; maturin sees the binary as already-compiled
       # and does only the wheel-pack step. Linux intentionally builds
       # inside a manylinux2014 container so the uploaded wheel is accepted
-      # by older embedded hosts such as Maya 2022 / Python 3.7.
+      # by older embedded hosts such as Maya 2022 / Python 3.7. Keep that
+      # container build on its own Cargo target dir: reusing host-built
+      # build scripts from target/ can fail with GLIBC_* symbol errors.
       # NOTE: maturin's `--strip` is intentionally OMITTED — the workspace
       # already has `strip = true` in `[profile.release]` (Cargo.toml:214),
       # so the binary is stripped at the cargo level. Adding `--strip` here
@@ -203,6 +207,7 @@ jobs:
         run: |
           docker run --rm \
             -v "$PWD:/io" \
+            -e CARGO_TARGET_DIR=/io/target-manylinux2014 \
             -w /io/pkg/dcc-mcp-server-bin \
             ghcr.io/pyo3/maturin:v1.13.3 \
             build --release --manylinux 2014 --out wheels

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -4,6 +4,7 @@ set -eu
 REPO="${DCC_MCP_REPO:-loonghao/dcc-mcp-core}"
 VERSION="${DCC_MCP_VERSION:-latest}"
 INSTALL_DIR="${DCC_MCP_INSTALL_DIR:-$HOME/.local/bin}"
+RELEASE_FALLBACK="${DCC_MCP_RELEASE_FALLBACK:-1}"
 
 usage() {
     cat <<'EOF'
@@ -19,6 +20,10 @@ Environment:
   DCC_MCP_REPO         GitHub repo, default loonghao/dcc-mcp-core
   DCC_MCP_VERSION      Release tag, default latest
   DCC_MCP_INSTALL_DIR  Install directory, default ~/.local/bin
+  DCC_MCP_RELEASE_FALLBACK
+                       When latest asset is missing, download the newest
+                       release that includes the asset. Set to 0/false/no to
+                       disable. Default enabled.
 EOF
 }
 
@@ -84,15 +89,75 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
+download_url() {
+    url="$1"
+    echo "Downloading $url"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fL "$url" -o "$TMP_DIR/dcc-mcp-cli"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -O "$TMP_DIR/dcc-mcp-cli" "$url"
+    else
+        echo "curl or wget is required to download release assets" >&2
+        return 1
+    fi
+}
+
+release_fallback_enabled() {
+    case "$RELEASE_FALLBACK" in
+        0|false|FALSE|no|NO)
+            return 1
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+}
+
+latest_release_asset_url() {
+    releases_json="$TMP_DIR/releases.json"
+    api_url="https://api.github.com/repos/$REPO/releases?per_page=30"
+    echo "Looking for the newest release containing $ASSET" >&2
+    if command -v curl >/dev/null 2>&1; then
+        if [ -n "${GITHUB_TOKEN:-}" ]; then
+            curl -fsSL \
+                -H "Authorization: Bearer $GITHUB_TOKEN" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "$api_url" -o "$releases_json"
+        else
+            curl -fsSL "$api_url" -o "$releases_json"
+        fi
+    elif command -v wget >/dev/null 2>&1; then
+        if [ -n "${GITHUB_TOKEN:-}" ]; then
+            wget -q \
+                --header="Authorization: Bearer $GITHUB_TOKEN" \
+                --header="X-GitHub-Api-Version: 2022-11-28" \
+                -O "$releases_json" "$api_url"
+        else
+            wget -q -O "$releases_json" "$api_url"
+        fi
+    else
+        return 1
+    fi
+    tr ',' '\n' < "$releases_json" \
+        | sed -n 's/.*"browser_download_url":[[:space:]]*"\([^"]*\/'"$ASSET"'\)".*/\1/p' \
+        | head -n 1
+}
+
 mkdir -p "$INSTALL_DIR"
-echo "Downloading $URL"
-if command -v curl >/dev/null 2>&1; then
-    curl -fL "$URL" -o "$TMP_DIR/dcc-mcp-cli"
-elif command -v wget >/dev/null 2>&1; then
-    wget -O "$TMP_DIR/dcc-mcp-cli" "$URL"
-else
-    echo "curl or wget is required" >&2
-    exit 1
+if ! download_url "$URL"; then
+    if [ "$VERSION" = "latest" ] && release_fallback_enabled; then
+        fallback_url="$(latest_release_asset_url || true)"
+        if [ -n "$fallback_url" ]; then
+            echo "Latest release did not provide $ASSET; falling back to $fallback_url"
+            download_url "$fallback_url"
+        else
+            echo "No release asset named $ASSET was found in recent releases." >&2
+            exit 1
+        fi
+    else
+        echo "Release asset download failed." >&2
+        exit 1
+    fi
 fi
 
 chmod 0755 "$TMP_DIR/dcc-mcp-cli"

--- a/tests/test_skills_loader.py
+++ b/tests/test_skills_loader.py
@@ -88,6 +88,31 @@ class TestScanAndLoad:
         skills, _ = dcc_mcp_core.scan_and_load(extra_paths=["/this/path/does/not/exist"])
         assert skills == []
 
+    def test_missing_dependency_raises_with_skill_and_dependency_names(self, tmp_path: Path) -> None:
+        """scan_and_load fails loudly when a skill depends on a missing skill."""
+        _write_skill(tmp_path, "app", deps=["missing-lib"])
+
+        with pytest.raises(ValueError) as exc_info:
+            dcc_mcp_core.scan_and_load(extra_paths=[str(tmp_path)])
+
+        message = str(exc_info.value)
+        assert "app" in message
+        assert "missing-lib" in message
+        assert "skill search paths" in message
+
+    def test_cyclic_dependency_raises_with_cycle_members(self, tmp_path: Path) -> None:
+        """scan_and_load reports dependency cycles instead of returning an arbitrary order."""
+        _write_skill(tmp_path, "asset-publish", deps=["review-cache"])
+        _write_skill(tmp_path, "review-cache", deps=["asset-publish"])
+
+        with pytest.raises(ValueError) as exc_info:
+            dcc_mcp_core.scan_and_load(extra_paths=[str(tmp_path)])
+
+        message = str(exc_info.value)
+        assert "Circular dependency detected" in message
+        assert "asset-publish" in message
+        assert "review-cache" in message
+
     def test_dependency_order_respected(self, tmp_path: Path) -> None:
         """skill-b depends on skill-a; skill-a must appear first in the result."""
         _write_skill(tmp_path, "skill-a")
@@ -142,6 +167,39 @@ class TestScanAndLoadLenient:
             _write_skill(tmp_path, f"s{i}")
         skills, _ = dcc_mcp_core.scan_and_load_lenient(extra_paths=[str(tmp_path)])
         assert len(skills) == 4
+
+    def test_missing_dependency_reports_skipped_skill_path_not_exception(self, tmp_path: Path) -> None:
+        """Lenient scans keep valid skills and report dependency failures as skipped paths."""
+        _write_skill(tmp_path, "orphan-skill", deps=["missing-dep"])
+        _write_skill(tmp_path, "good-skill")
+
+        skills, skipped = dcc_mcp_core.scan_and_load_lenient(extra_paths=[str(tmp_path)])
+
+        assert {skill.name for skill in skills} == {"good-skill"}
+        assert len(skipped) == 1
+        assert Path(skipped[0]).name == "orphan-skill"
+
+
+# ---------------------------------------------------------------------------
+# scan_and_load_strict — skipped directories become actionable errors
+# ---------------------------------------------------------------------------
+
+
+class TestScanAndLoadStrict:
+    def test_invalid_skill_raises_with_bad_directory_and_remediation(self, tmp_path: Path) -> None:
+        """Strict scans turn skipped directories into a startup-time error contract."""
+        _write_skill(tmp_path, "good-skill")
+        bad_dir = tmp_path / "bad-skill"
+        bad_dir.mkdir()
+        (bad_dir / "SKILL.md").write_text("# missing frontmatter\n", encoding="utf-8")
+
+        with pytest.raises(ValueError) as exc_info:
+            dcc_mcp_core.scan_and_load_strict(extra_paths=[str(tmp_path)])
+
+        message = str(exc_info.value)
+        assert "Strict scan rejected 1 directory" in message
+        assert "bad-skill" in message
+        assert "scan_and_load_lenient" in message
 
 
 # ---------------------------------------------------------------------------
@@ -253,21 +311,23 @@ class TestValidateDependencies:
 
     def test_missing_dep_reported_as_error(self, tmp_path: Path) -> None:
         """A skill referencing a non-existent dependency produces an error entry."""
-        _write_skill(tmp_path, "broken", deps=["ghost-skill"])
-        _, _ = dcc_mcp_core.scan_and_load_lenient(extra_paths=[str(tmp_path)])
-        # lenient load skips broken, so validate on a manually-constructed list
-        broken_meta = dcc_mcp_core.SkillMetadata(name="broken")
-        # validate_dependencies on a list where dependency is missing
+        broken_meta = dcc_mcp_core.SkillMetadata(name="broken", depends=["ghost-skill"])
+
         errors = dcc_mcp_core.validate_dependencies([broken_meta])
-        # With no deps declared on the SkillMetadata (default), no errors
-        assert isinstance(errors, list)
+
+        assert errors == [
+            "Skill 'broken' depends on 'ghost-skill', but it was not found. "
+            "Ensure 'ghost-skill' is available in one of the skill search paths."
+        ]
 
     def test_missing_dep_skill_meta_with_depends(self, tmp_path: Path) -> None:
         """validate_dependencies reports error when dep listed in SkillMetadata.depends is absent."""
         missing_dep = dcc_mcp_core.SkillMetadata(name="app", depends=["missing-lib"])
         errors = dcc_mcp_core.validate_dependencies([missing_dep])
-        # Should report at least one error for the missing dependency
-        assert len(errors) > 0
+        assert len(errors) == 1
+        assert "app" in errors[0]
+        assert "missing-lib" in errors[0]
+        assert "skill search paths" in errors[0]
 
     def test_multiple_satisfied_deps_no_errors(self, tmp_path: Path) -> None:
         """Multiple satisfied dependencies in the skill list produce no errors."""


### PR DESCRIPTION
## Summary
- Add failure-path coverage for skill loader dependency errors.
- Assert strict scan errors include the skipped directory and lenient remediation hint.
- Tighten weak dependency validation assertions to check the expected error contract.
- Make `scripts/install-cli.sh` fall back from a missing latest CLI asset to the newest release that provides the same asset.
- Isolate the Linux manylinux release wheel build target dir so host-built Cargo build scripts are not reused inside the older manylinux2014 glibc container.

## Validation
- `tests/test_skills_loader.py` passed locally: 40 passed.
- `sh -n scripts/install-cli.sh`
- `scripts/install-cli.sh --help` via Git sh
- Confirmed latest `v0.17.10` lacks `dcc-mcp-cli-linux-x86_64` and `v0.17.9` provides it.
- Inspected Release run 26074521426 / job 76662722131: failure was a host-built `dcc-mcp-gateway` build script requiring GLIBC_2.18+ inside manylinux2014.
- Commit hook checks passed during commits, including YAML validation for `release.yml`.

## Notes
- Local focused pytest used the existing compiled `_core.pyd` from the main worktree because the fresh worktree environment could not resolve pytest through `uv` with the current Python 3.7 project metadata.
- The Release workflow fix affects the next run on `main`; PR checks may not fully exercise the release-only tag build path.