### PR TITLE
fix(ci): prebuild admin ui for manylinux release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,12 +201,22 @@ jobs:
           python -m pip install "maturin>=1.5,<2.0" "wheel>=0.46"
           maturin build --release --target universal2-apple-darwin --out wheels
 
+      - name: Pre-build admin UI for Linux manylinux wheel
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          set -eux
+          vx npm --prefix admin-ui ci
+          vx npm --prefix admin-ui run build
+          test -f crates/dcc-mcp-gateway/src/gateway/admin/generated/index.html
+
       - name: Build PyPI wheel (Linux manylinux2014)
         if: matrix.os == 'ubuntu-latest'
         shell: bash
         run: |
           docker run --rm \
             -v "$PWD:/io" \
+            -e DCC_MCP_ADMIN_UI_PREBUILT=1 \
             -e CARGO_TARGET_DIR=/io/target-manylinux2014 \
             -w /io/pkg/dcc-mcp-server-bin \
             ghcr.io/pyo3/maturin:v1.13.3 \


### PR DESCRIPTION
## Summary
- pre-build the admin UI on the Ubuntu runner before the manylinux server wheel build
- pass `DCC_MCP_ADMIN_UI_PREBUILT=1` into the maturin Docker container so build.rs reuses the generated bundle

## Root cause
The release binary job builds the Linux wheel inside `ghcr.io/pyo3/maturin:v1.13.3`, which does not include `vx` or `npm`. The gateway admin UI build script therefore failed when it tried to build the Vite bundle inside the container.

## Validation
- `git diff --check`
- `vx npm --prefix admin-ui ci`
- `vx npm --prefix admin-ui run build`