### PR TITLE
fix(ci): extract release wheel scripts

### DIFF
--- a/.github/workflows/release-please-lock-sync.yml
+++ b/.github/workflows/release-please-lock-sync.yml
@@ -50,6 +50,8 @@ jobs:
           cargo hakari generate
 
       - name: Commit and push changes
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           if git diff --quiet -- Cargo.lock crates/workspace-hack/Cargo.toml; then
             echo "Cargo metadata is already in sync."
@@ -60,4 +62,4 @@ jobs:
           git config user.email "hal.long@outlook.com"
           git add Cargo.lock crates/workspace-hack/Cargo.toml
           git commit -m "chore(ci): sync generated Cargo metadata"
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          git push origin "HEAD:${HEAD_REF}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,23 +204,12 @@ jobs:
       - name: Pre-build admin UI for Linux manylinux wheel
         if: matrix.os == 'ubuntu-latest'
         shell: bash
-        run: |
-          set -eux
-          vx npm --prefix admin-ui ci
-          vx npm --prefix admin-ui run build
-          test -f crates/dcc-mcp-gateway/src/gateway/admin/generated/index.html
+        run: scripts/release/prebuild_admin_ui.sh
 
       - name: Build PyPI wheel (Linux manylinux2014)
         if: matrix.os == 'ubuntu-latest'
         shell: bash
-        run: |
-          docker run --rm \
-            -v "$PWD:/io" \
-            -e DCC_MCP_ADMIN_UI_PREBUILT=1 \
-            -e CARGO_TARGET_DIR=/io/target-manylinux2014 \
-            -w /io/pkg/dcc-mcp-server-bin \
-            ghcr.io/pyo3/maturin:v1.13.3 \
-            build --release --manylinux 2014 --out wheels
+        run: scripts/release/build_manylinux_server_wheel.sh
 
       - name: Build PyPI wheel (Windows)
         if: matrix.os == 'windows-latest'
@@ -234,96 +223,12 @@ jobs:
       - name: Retag server binary wheel as Python-version independent
         shell: bash
         run: |
-          python - <<'PY'
-          import sys
-          import zipfile
-          from pathlib import Path
-
-          wheels = sorted(Path("pkg/dcc-mcp-server-bin/wheels").glob("dcc_mcp_server-*.whl"))
-          if not wheels:
-              print("::error::No dcc-mcp-server wheel was built", file=sys.stderr)
-              sys.exit(1)
-
-          for wheel in wheels:
-              with zipfile.ZipFile(wheel) as zf:
-                  python_extensions = [
-                      name for name in zf.namelist()
-                      if name.lower().endswith((".pyd", ".abi3.so"))
-                      or (".cpython-" in name.lower() and name.lower().endswith(".so"))
-                  ]
-              if python_extensions:
-                  print(
-                      f"::error::{wheel.name} contains CPython extension files "
-                      f"and cannot be tagged py3-none: {python_extensions}",
-                      file=sys.stderr,
-                  )
-                  sys.exit(1)
-          PY
-          python -m wheel tags --remove --python-tag=py3 --abi-tag=none pkg/dcc-mcp-server-bin/wheels/*.whl
+          python -m pip install --upgrade "wheel>=0.46"
+          python scripts/release/server_wheel_tags.py retag
 
       - name: Check server wheel Python compatibility metadata
         shell: bash
-        run: |
-          python - <<'PY'
-          import sys
-          import zipfile
-          from pathlib import Path
-
-          wheels = sorted(Path("pkg/dcc-mcp-server-bin/wheels").glob("*.whl"))
-          if not wheels:
-              print("::error::No dcc-mcp-server wheel was built", file=sys.stderr)
-              sys.exit(1)
-
-          for wheel in wheels:
-              with zipfile.ZipFile(wheel) as zf:
-                  wheel_name = next(
-                      name for name in zf.namelist()
-                      if name.endswith(".dist-info/WHEEL")
-                  )
-                  wheel_metadata = zf.read(wheel_name).decode("utf-8")
-                  metadata_name = next(
-                      name for name in zf.namelist()
-                      if name.endswith(".dist-info/METADATA")
-                  )
-                  metadata = zf.read(metadata_name).decode("utf-8")
-
-              if "Requires-Python: >=3.7" not in metadata:
-                  print(
-                      f"::error::{wheel.name} must declare Requires-Python: >=3.7 "
-                      "so Maya 2022 / Python 3.7 can install dcc-mcp-server",
-                      file=sys.stderr,
-                  )
-                  sys.exit(1)
-
-              if "-py3-none-" not in wheel.name or "Tag: py3-none-" not in wheel_metadata:
-                  print(
-                      f"::error::{wheel.name} must use py3-none platform tags "
-                      "because dcc-mcp-server ships a standalone binary, not a CPython extension",
-                      file=sys.stderr,
-                  )
-                  sys.exit(1)
-
-              if "manylinux_2_39" in wheel.name:
-                  print(
-                      f"::error::{wheel.name} was built against the GitHub runner glibc. "
-                      "Build Linux server wheels in manylinux2014 so Maya 2022 / Python 3.7 "
-                      "can resolve dcc-mcp-server.",
-                      file=sys.stderr,
-                  )
-                  sys.exit(1)
-
-              if "manylinux" in wheel.name and not (
-                  "manylinux_2_17" in wheel.name or "manylinux2014" in wheel.name
-              ):
-                  print(
-                      f"::error::{wheel.name} must target manylinux2014 / manylinux_2_17 "
-                      "for older DCC-hosted Python environments.",
-                      file=sys.stderr,
-                  )
-                  sys.exit(1)
-
-              print(f"{wheel.name}: Python 3.7+ metadata OK")
-          PY
+        run: python scripts/release/server_wheel_tags.py validate
 
       - name: Upload raw binary artefact (for cross-job collection)
         uses: actions/upload-artifact@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,12 @@ repos:
   # Rust checks
   - repo: local
     hooks:
+      - id: actionlint
+        name: actionlint
+        entry: vx uvx --from actionlint-py==1.7.12.24 actionlint
+        language: system
+        files: ^\.github/workflows/.*\.ya?ml$
+        pass_filenames: true
       - id: cargo-fmt
         name: cargo fmt
         entry: cargo fmt --all -- --check

--- a/scripts/release/build_manylinux_server_wheel.sh
+++ b/scripts/release/build_manylinux_server_wheel.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+docker run --rm \
+  -v "$PWD:/io" \
+  -e DCC_MCP_ADMIN_UI_PREBUILT=1 \
+  -e CARGO_TARGET_DIR=/io/target-manylinux2014 \
+  -w /io/pkg/dcc-mcp-server-bin \
+  ghcr.io/pyo3/maturin:v1.13.3 \
+  build --release --manylinux 2014 --out wheels

--- a/scripts/release/prebuild_admin_ui.sh
+++ b/scripts/release/prebuild_admin_ui.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+vx npm --prefix admin-ui ci
+vx npm --prefix admin-ui run build
+test -f crates/dcc-mcp-gateway/src/gateway/admin/generated/index.html

--- a/scripts/release/server_wheel_tags.py
+++ b/scripts/release/server_wheel_tags.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Retag and validate dcc-mcp-server binary wheels."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import subprocess
+import sys
+import zipfile
+
+EXTENSION_SUFFIXES = (".pyd", ".abi3.so")
+
+
+def _github_error(message: str) -> None:
+    print(f"::error::{message}", file=sys.stderr)
+
+
+def _find_wheels(wheel_dir: Path, pattern: str = "*.whl") -> list[Path]:
+    wheels = sorted(wheel_dir.glob(pattern))
+    if not wheels:
+        _github_error(f"No dcc-mcp-server wheel was built under {wheel_dir}")
+        raise SystemExit(1)
+    return wheels
+
+
+def _python_extensions(wheel: Path) -> list[str]:
+    with zipfile.ZipFile(wheel) as zf:
+        return [
+            name
+            for name in zf.namelist()
+            if name.lower().endswith(EXTENSION_SUFFIXES)
+            or (".cpython-" in name.lower() and name.lower().endswith(".so"))
+        ]
+
+
+def _assert_no_python_extensions(wheels: list[Path]) -> None:
+    for wheel in wheels:
+        extensions = _python_extensions(wheel)
+        if extensions:
+            _github_error(f"{wheel.name} contains CPython extension files and cannot be tagged py3-none: {extensions}")
+            raise SystemExit(1)
+
+
+def _retag(wheel_dir: Path) -> None:
+    wheels = _find_wheels(wheel_dir, "dcc_mcp_server-*.whl")
+    _assert_no_python_extensions(wheels)
+
+    try:
+        import wheel  # noqa: F401
+    except ModuleNotFoundError:
+        _github_error(
+            "The Python 'wheel' package is required to retag server binary wheels. "
+            "Install it with `python -m pip install wheel>=0.46`."
+        )
+        raise SystemExit(1) from None
+
+    try:
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "wheel",
+                "tags",
+                "--remove",
+                "--python-tag=py3",
+                "--abi-tag=none",
+                *[str(wheel) for wheel in wheels],
+            ],
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        _github_error(f"Failed to retag server binary wheels: {exc}")
+        raise SystemExit(exc.returncode) from exc
+
+
+def _read_dist_info(zf: zipfile.ZipFile, suffix: str) -> str:
+    try:
+        name = next(name for name in zf.namelist() if name.endswith(suffix))
+    except StopIteration:
+        raise ValueError(f"missing {suffix}") from None
+    return zf.read(name).decode("utf-8")
+
+
+def _validate(wheel_dir: Path) -> None:
+    wheels = _find_wheels(wheel_dir)
+
+    for wheel in wheels:
+        with zipfile.ZipFile(wheel) as zf:
+            wheel_metadata = _read_dist_info(zf, ".dist-info/WHEEL")
+            metadata = _read_dist_info(zf, ".dist-info/METADATA")
+
+        if "Requires-Python: >=3.7" not in metadata:
+            _github_error(
+                f"{wheel.name} must declare Requires-Python: >=3.7 so Maya 2022 / Python 3.7 can install dcc-mcp-server"
+            )
+            raise SystemExit(1)
+
+        if "-py3-none-" not in wheel.name or "Tag: py3-none-" not in wheel_metadata:
+            _github_error(
+                f"{wheel.name} must use py3-none platform tags because "
+                "dcc-mcp-server ships a standalone binary, not a CPython extension"
+            )
+            raise SystemExit(1)
+
+        if "manylinux_2_39" in wheel.name:
+            _github_error(
+                f"{wheel.name} was built against the GitHub runner glibc. "
+                "Build Linux server wheels in manylinux2014 so Maya 2022 / "
+                "Python 3.7 can resolve dcc-mcp-server."
+            )
+            raise SystemExit(1)
+
+        if "manylinux" in wheel.name and not ("manylinux_2_17" in wheel.name or "manylinux2014" in wheel.name):
+            _github_error(
+                f"{wheel.name} must target manylinux2014 / manylinux_2_17 for older DCC-hosted Python environments."
+            )
+            raise SystemExit(1)
+
+        print(f"{wheel.name}: Python 3.7+ metadata OK")
+
+
+def main() -> int:
+    """Run the server wheel tag helper."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=["retag", "validate"])
+    parser.add_argument(
+        "--wheel-dir",
+        type=Path,
+        default=Path("pkg/dcc-mcp-server-bin/wheels"),
+    )
+    args = parser.parse_args()
+
+    if args.command == "retag":
+        _retag(args.wheel_dir)
+    else:
+        _validate(args.wheel_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- extract release binary wheel build, admin UI prebuild, retag, and metadata checks into scripts under `scripts/release/`
- install `wheel` before retagging server binary wheels so the Ubuntu release job has `python -m wheel`
- add a pinned `actionlint` pre-commit hook via `actionlint-py`
- fix the existing actionlint warning in `release-please-lock-sync.yml` by passing the PR head ref through `env`

## Root cause
The Ubuntu release job now gets past the manylinux admin UI bundle reuse, but fails later because the host Python used for retagging does not have the `wheel` module installed. The inline workflow scripts also made this path hard to test locally.

## Validation
- `vx uvx:pre-commit run actionlint --all-files`
- `vx uvx:pre-commit run check-yaml --files .github/workflows/release.yml .github/workflows/release-please-lock-sync.yml .pre-commit-config.yaml`
- `python -m py_compile scripts/release/server_wheel_tags.py`
- temporary wheel smoke test for `server_wheel_tags.py retag` and `validate`