### PR TITLE
fix(ci): restore manylinux wheel ownership

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -61,6 +61,8 @@ runs:
 
     - name: Install vx
       uses: loonghao/vx@v0.8.36
+      with:
+        cache: "false"
 
     - name: Cache Cargo
       uses: Swatinem/rust-cache@v2

--- a/scripts/release/build_manylinux_server_wheel.sh
+++ b/scripts/release/build_manylinux_server_wheel.sh
@@ -11,3 +11,7 @@ docker run --rm \
   -w /io/pkg/dcc-mcp-server-bin \
   ghcr.io/pyo3/maturin:v1.13.3 \
   build --release --manylinux 2014 --out wheels
+
+if command -v sudo >/dev/null 2>&1; then
+  sudo chown -R "$(id -u):$(id -g)" pkg/dcc-mcp-server-bin/wheels
+fi


### PR DESCRIPTION
## Summary
- restore ownership of Linux manylinux server wheel outputs after the Docker build

## Root cause
The manylinux container writes `pkg/dcc-mcp-server-bin/wheels` as the container user. The following host-side `python -m wheel tags` step then cannot create the retagged wheel and fails with `PermissionError: [Errno 13] Permission denied`.

## Validation
- `vx uvx:pre-commit run actionlint --all-files`
- commit hooks