### PR TITLE
fix(ci): prebuild admin ui before release binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ on:
       - "rust-toolchain.toml"
       - ".github/workflows/ci.yml"
       - ".github/workflows/dcc-integration.yml"
+      - ".github/workflows/release.yml"
       - ".github/actions/build-wheel/**"
   push:
     branches: [main]
@@ -41,6 +42,7 @@ on:
       - "rust-toolchain.toml"
       - ".github/workflows/ci.yml"
       - ".github/workflows/dcc-integration.yml"
+      - ".github/workflows/release.yml"
       - ".github/actions/build-wheel/**"
 
 permissions:
@@ -85,6 +87,21 @@ jobs:
                   print(f"{source} has {version}, expected {pyproject_version}", file=sys.stderr)
               sys.exit(1)
           PY
+
+  admin-ui-bundle:
+    name: Admin UI bundle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: loonghao/vx@v0.8.36
+      - name: Build admin UI bundle
+        shell: bash
+        run: scripts/release/prebuild_admin_ui.sh
+      - name: Upload admin UI bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: admin-ui-bundle
+          path: crates/dcc-mcp-gateway/src/gateway/admin/generated/index.html
 
   # ── Rust checks (check + clippy + fmt + cargo test) ──
   rust-check:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,27 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Release decision: created=$release_created tag=$tag_name version=$version"
 
+  build-admin-ui:
+    needs: [release-please]
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - uses: loonghao/vx@v0.8.36
+
+      - name: Build admin UI bundle
+        shell: bash
+        run: scripts/release/prebuild_admin_ui.sh
+
+      - name: Upload admin UI bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: admin-ui-bundle
+          path: crates/dcc-mcp-gateway/src/gateway/admin/generated/index.html
+
   # ── Build standalone binaries (raw Release assets + server PyPI wheel) ──
   #
   # One job, one native cargo target/ (plus an isolated manylinux target/), three outputs:
@@ -106,7 +127,7 @@ jobs:
   # one release lifecycle for the workspace, and `dcc-mcp-server` ships
   # at the same workspace.package.version as `dcc-mcp-core`.
   build-binaries:
-    needs: [release-please]
+    needs: [release-please, build-admin-ui]
     if: needs.release-please.outputs.release_created == 'true'
     strategy:
       fail-fast: false
@@ -159,6 +180,18 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-binary-
 
       # ── Raw binary build ──────────────────────────────────────────
+      - name: Download admin UI bundle for Linux builds
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/download-artifact@v8
+        with:
+          name: admin-ui-bundle
+          path: crates/dcc-mcp-gateway/src/gateway/admin/generated
+
+      - name: Use pre-built admin UI for Linux builds
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: echo "DCC_MCP_ADMIN_UI_PREBUILT=1" >> "$GITHUB_ENV"
+
       - name: Build raw binary (macOS universal2)
         if: matrix.os == 'macos-latest'
         run: |
@@ -200,11 +233,6 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install "maturin>=1.5,<2.0" "wheel>=0.46"
           maturin build --release --target universal2-apple-darwin --out wheels
-
-      - name: Pre-build admin UI for Linux manylinux wheel
-        if: matrix.os == 'ubuntu-latest'
-        shell: bash
-        run: scripts/release/prebuild_admin_ui.sh
 
       - name: Build PyPI wheel (Linux manylinux2014)
         if: matrix.os == 'ubuntu-latest'

--- a/scripts/release/prebuild_admin_ui.sh
+++ b/scripts/release/prebuild_admin_ui.sh
@@ -7,3 +7,7 @@ cd "$repo_root"
 vx npm --prefix admin-ui ci
 vx npm --prefix admin-ui run build
 test -f crates/dcc-mcp-gateway/src/gateway/admin/generated/index.html
+
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  echo "DCC_MCP_ADMIN_UI_PREBUILT=1" >> "$GITHUB_ENV"
+fi


### PR DESCRIPTION
## Summary
- add a dedicated `build-admin-ui` release job that builds and uploads the generated admin UI bundle once
- have only the Ubuntu `build-binaries` matrix download that bundle before raw binary builds
- set `DCC_MCP_ADMIN_UI_PREBUILT=1` for Ubuntu builds so both raw binary and manylinux wheel builds reuse the generated bundle
- add a PR CI `Admin UI bundle` job that runs the same bundle build script and uploads the same artifact

## Root cause
The Linux release job builds raw binaries before the manylinux wheel phase. That raw binary build compiles `dcc-mcp-gateway`, whose build script tried to run the admin UI npm build directly and failed before any later prebuild step could run.

## Validation
- `vx uvx:pre-commit run actionlint --files .github/workflows/ci.yml .github/workflows/release.yml`
- `vx uvx:pre-commit run check-yaml --files .github/workflows/ci.yml .github/workflows/release.yml`
- commit hooks