### PR TITLE
feat: add standalone gateway diagnostics

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -9,7 +9,7 @@ import unrealIcon from './assets/icons/unrealengine.svg';
 import substancePainterIcon from './assets/icons/photoshop.svg';
 import puzzleIcon from './assets/icons/puzzle.svg';
 
-type Panel = 'activity' | 'health' | 'instances' | 'tools' | 'tasks' | 'calls' | 'traces' | 'stats' | 'logs' | 'skill-paths';
+type Panel = 'debug' | 'activity' | 'health' | 'instances' | 'tools' | 'tasks' | 'calls' | 'traces' | 'stats' | 'logs' | 'skill-paths';
 
 type HealthPayload = {
   status: string;
@@ -18,6 +18,10 @@ type HealthPayload = {
   uptime_secs: number;
   version: string;
   rss_bytes?: number | null;
+  gateway?: {
+    current?: GatewaySentinel | null;
+    candidates?: GatewaySentinel[];
+  };
   limits?: {
     body_max_bytes: number;
     rate_limit_per_minute_per_ip: number;
@@ -27,6 +31,18 @@ type HealthPayload = {
     circuit_open_secs: number;
   };
   circuits?: { tracked_backends: number; circuits_open: number };
+};
+
+type GatewaySentinel = {
+  name: string;
+  role: string;
+  pid?: number | null;
+  host: string;
+  port: number;
+  instance_id: string;
+  version?: string | null;
+  adapter_version?: string | null;
+  adapter_dcc?: string | null;
 };
 
 type ToolRow = {
@@ -241,6 +257,7 @@ const API_BASE = adminApiBase();
 /** Abort hung admin fetches so the UI does not wait indefinitely on a wedged gateway. */
 const ADMIN_FETCH_TIMEOUT_MS = 25_000;
 const PANELS: { id: Panel; label: string }[] = [
+  { id: 'debug', label: 'Debug' },
   { id: 'activity', label: 'Activity' },
   { id: 'health', label: 'Health' },
   { id: 'instances', label: 'Instances' },
@@ -294,7 +311,7 @@ function readPanelFromUrl(): Panel {
   if (raw === 'workers') {
     return 'instances';
   }
-  return isPanelId(raw) ? raw : 'activity';
+  return isPanelId(raw) ? raw : 'debug';
 }
 
 function readStatsRangeFromUrl(): string {
@@ -538,6 +555,62 @@ function maxTopCount(items: TopEntry[]): number {
   return Math.max(1, ...items.map((i) => i.count));
 }
 
+function latencyTone(value: number | null | undefined): 'ok' | 'warn' | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  return value > 5_000 ? 'warn' : 'ok';
+}
+
+function errorRateTone(stats: StatsPayload | null): 'ok' | 'warn' | undefined {
+  if (!stats || stats.total_calls === 0) {
+    return undefined;
+  }
+  return stats.success_rate < 95 ? 'warn' : 'ok';
+}
+
+function traceLatency(trace: TraceRow): number {
+  return trace.total_ms ?? -1;
+}
+
+function compactId(value: string | null | undefined): string {
+  if (!value) {
+    return '-';
+  }
+  return value.length > 12 ? value.slice(0, 12) : value;
+}
+
+function gatewayLabel(health: HealthPayload | null): string {
+  const current = health?.gateway?.current;
+  if (!current) {
+    return health?.status ?? '?';
+  }
+  const pid = current.pid ? ` pid ${current.pid}` : '';
+  return `${current.name}${pid}`;
+}
+
+function isProblemActivity(event: ActivityEvent): boolean {
+  const text = haystack(event.status, event.severity, event.kind, event.message);
+  return text.includes('err') || text.includes('fail') || text.includes('warn') || text.includes('timeout') || text.includes('stale');
+}
+
+function isProblemLog(log: LogRow): boolean {
+  const text = haystack(log.level, log.message, log.event ?? '', log.reason ?? '', log.detail ?? '');
+  return log.success === false || text.includes('error') || text.includes('warn') || text.includes('timeout') || text.includes('failed') || text.includes('stale');
+}
+
+function MiniSparkline({ buckets }: { buckets: number[] }) {
+  const values = buckets.length ? buckets : Array.from({ length: 24 }, () => 0);
+  const max = Math.max(1, ...values);
+  return (
+    <div className="mini-sparkline" role="img" aria-label="Call distribution sparkline">
+      {values.map((value, index) => (
+        <span key={index} style={{ height: `${Math.max(5, (value / max) * 100)}%` }} title={`${index}:00 UTC — ${value} call(s)`} />
+      ))}
+    </div>
+  );
+}
+
 function StatBarList({ title, items }: { title: string; items: TopEntry[] }) {
   const max = maxTopCount(items);
   return (
@@ -606,6 +679,7 @@ function App() {
   const [traceDetail, setTraceDetail] = useState<string>('Select a trace row for detail.');
   const [callDetail, setCallDetail] = useState<string>('Select a call row for trace detail.');
   const [updatedAt, setUpdatedAt] = useState<Record<Panel, string>>({
+    debug: 'Loading…',
     activity: 'Loading…',
     health: 'Loading…',
     instances: 'Loading…',
@@ -805,6 +879,33 @@ function App() {
     );
   }, [skillPaths, listSearch]);
 
+  const failedCalls = useMemo(
+    () => calls.filter((call) => call.success === false || call.status.toLowerCase().includes('err') || call.status.toLowerCase().includes('fail')).slice(0, 8),
+    [calls],
+  );
+
+  const slowTraces = useMemo(
+    () => [...traces].filter((trace) => trace.total_ms != null).sort((a, b) => traceLatency(b) - traceLatency(a)).slice(0, 8),
+    [traces],
+  );
+
+  const problemActivity = useMemo(
+    () => activity.filter(isProblemActivity).slice(0, 8),
+    [activity],
+  );
+
+  const problemLogs = useMemo(
+    () => logs.filter(isProblemLog).slice(0, 10),
+    [logs],
+  );
+
+  const unhealthyWorkers = useMemo(
+    () => workers.filter((worker) => worker.stale || !statusClass(worker.status).includes('ok')),
+    [workers],
+  );
+
+  const debugIssues = failedCalls.length + problemActivity.length + problemLogs.length + unhealthyWorkers.length;
+
   const filteredTopTools = useMemo(() => {
     const q = listSearch.trim().toLowerCase();
     const rows = stats?.top_tools ?? [];
@@ -939,6 +1040,19 @@ function App() {
       markError('skill-paths', error);
     }
   }, [markError, markUpdated]);
+
+  const fetchDebug = useCallback(async () => {
+    await Promise.allSettled([
+      fetchHealth(),
+      fetchInstanceBackends(),
+      fetchActivity(),
+      fetchCalls(),
+      fetchTraces(),
+      fetchStats(),
+      fetchLogs(),
+    ]);
+    markUpdated('debug', `Debug snapshot — ${new Date().toLocaleTimeString()}`);
+  }, [fetchActivity, fetchCalls, fetchHealth, fetchInstanceBackends, fetchLogs, fetchStats, fetchTraces, markUpdated]);
 
   const addSkillPath = useCallback(async () => {
     const path = skillPathInput.trim();
@@ -1103,6 +1217,7 @@ function App() {
   }, [fetchTraceInto]);
 
   const fetchPanel = useCallback((panel: Panel) => {
+    if (panel === 'debug') void fetchDebug();
     if (panel === 'activity') void fetchActivity();
     if (panel === 'health') void fetchHealth();
     if (panel === 'instances') void fetchInstanceBackends();
@@ -1113,7 +1228,7 @@ function App() {
     if (panel === 'stats') void fetchStats();
     if (panel === 'skill-paths') void fetchSkillPaths();
     if (panel === 'logs') void fetchLogs();
-  }, [fetchActivity, fetchCalls, fetchHealth, fetchInstanceBackends, fetchLogs, fetchSkillPaths, fetchStats, fetchTasks, fetchTools, fetchTraces]);
+  }, [fetchActivity, fetchCalls, fetchDebug, fetchHealth, fetchInstanceBackends, fetchLogs, fetchSkillPaths, fetchStats, fetchTasks, fetchTools, fetchTraces]);
 
   useEffect(() => {
     fetchPanel(activePanel);
@@ -1149,7 +1264,7 @@ function App() {
         </div>
       </nav>
       <main className="main-stage">
-        {activePanel !== 'health' && (
+        {activePanel !== 'health' && activePanel !== 'debug' && (
           <div className="list-search-wrap">
             <input
               type="search"
@@ -1173,6 +1288,110 @@ function App() {
               </span>
             ) : null}
           </div>
+        )}
+        {activePanel === 'debug' && (
+          <section className="panel active debug-panel">
+            <div className="debug-hero">
+              <div>
+                <h2>Debug Workbench</h2>
+                <StatusLine text={updatedAt.debug} error={errors.debug} />
+              </div>
+              <div className="debug-pulse">
+                <span className={debugIssues > 0 ? 'pulse-dot warn' : 'pulse-dot ok'} />
+                {debugIssues > 0 ? `${debugIssues} signals need attention` : 'No active warning signals'}
+              </div>
+            </div>
+            <div className="debug-grid">
+              <HealthCard tone={health?.status === 'ok' ? 'ok' : 'warn'} label="Gateway" value={gatewayLabel(health)} />
+              <HealthCard tone={unhealthyWorkers.length ? 'warn' : 'ok'} label="Instances" value={`${workerSummary.live} live / ${unhealthyWorkers.length} flagged`} />
+              <HealthCard tone={errorRateTone(stats)} label="Success" value={stats ? `${stats.success_rate.toFixed(1)}%` : '?'} />
+              <HealthCard tone={latencyTone(stats?.latency_ms?.p95_ms ?? stats?.p95_ms)} label="p95 latency" value={stats?.latency_ms?.p95_ms ?? stats?.p95_ms ?? '-'} />
+            </div>
+            <div className="debug-map">
+              <div className="debug-card debug-wide">
+                <div className="debug-card-head">
+                  <h3>Traffic Shape</h3>
+                  <button className="linkish" type="button" onClick={() => goToPanel('stats')}>Open stats</button>
+                </div>
+                <MiniSparkline buckets={stats?.hourly_distribution ?? []} />
+                <div className="debug-metrics">
+                  <span>{stats?.total_calls ?? 0} calls</span>
+                  <span>{stats?.latency_ms?.p50_ms ?? stats?.p50_ms ?? '-'} ms p50</span>
+                  <span>{stats?.latency_ms?.p99_ms ?? '-'} ms p99</span>
+                </div>
+              </div>
+
+              <div className="debug-card">
+                <div className="debug-card-head">
+                  <h3>Failed Calls</h3>
+                  <button className="linkish" type="button" onClick={() => goToPanel('calls')}>Open calls</button>
+                </div>
+                {failedCalls.length === 0 ? <p className="empty">No failed calls in the retained window.</p> : failedCalls.map((call) => (
+                  <button key={call.request_id} className="debug-row" type="button" onClick={() => goToPanel('traces', { traceId: call.request_id })}>
+                    <span><StatusBadge value={call.status} /></span>
+                    <span>{compactId(call.request_id)}</span>
+                    <span title={call.error ?? call.tool}>{call.error ?? call.tool}</span>
+                  </button>
+                ))}
+              </div>
+
+              <div className="debug-card">
+                <div className="debug-card-head">
+                  <h3>Slowest Traces</h3>
+                  <button className="linkish" type="button" onClick={() => goToPanel('traces')}>Open traces</button>
+                </div>
+                {slowTraces.length === 0 ? <p className="empty">No latency samples yet.</p> : slowTraces.map((trace) => (
+                  <button key={trace.request_id} className="debug-row" type="button" onClick={() => goToPanel('traces', { traceId: trace.request_id })}>
+                    <span>{trace.total_ms ?? '-'} ms</span>
+                    <span>{compactId(trace.request_id)}</span>
+                    <span title={trace.tool}>{trace.tool}</span>
+                  </button>
+                ))}
+              </div>
+
+              <div className="debug-card">
+                <div className="debug-card-head">
+                  <h3>Instance Signals</h3>
+                  <button className="linkish" type="button" onClick={() => goToPanel('instances')}>Open instances</button>
+                </div>
+                {unhealthyWorkers.length === 0 ? <p className="empty">All retained instances look healthy.</p> : unhealthyWorkers.slice(0, 8).map((worker) => (
+                  <div key={worker.instance_id} className="debug-row static">
+                    <span><StatusBadge value={worker.stale ? 'stale' : worker.status} /></span>
+                    <span>{worker.dcc_type}</span>
+                    <span>{worker.display_name} · {compactId(worker.instance_id)}</span>
+                  </div>
+                ))}
+              </div>
+
+              <div className="debug-card">
+                <div className="debug-card-head">
+                  <h3>Event Warnings</h3>
+                  <button className="linkish" type="button" onClick={() => goToPanel('logs')}>Open logs</button>
+                </div>
+                {[...problemLogs, ...problemActivity.map((event) => ({
+                  timestamp: event.timestamp,
+                  level: event.severity,
+                  message: event.message,
+                  source: event.kind,
+                  request_id: event.correlation?.request_id,
+                  dcc_type: event.correlation?.dcc_type,
+                } as LogRow))].slice(0, 10).map((row, index) => (
+                  <button
+                    key={`${row.timestamp}-${row.message}-${index}`}
+                    className="debug-row"
+                    type="button"
+                    onClick={() => row.request_id ? goToPanel('traces', { traceId: row.request_id }) : goToPanel('logs')}
+                  >
+                    <span>{formatTime(row.timestamp)}</span>
+                    <span>{row.source ?? row.level}</span>
+                    <span title={row.message}>{row.message}</span>
+                  </button>
+                ))}
+                {problemLogs.length === 0 && problemActivity.length === 0 ? <p className="empty">No warning events in the retained window.</p> : null}
+              </div>
+            </div>
+            <button className="refresh-btn" type="button" onClick={fetchDebug}>Refresh snapshot</button>
+          </section>
         )}
         {activePanel === 'activity' && (
           <section className="panel active activity-panel">
@@ -1222,6 +1441,8 @@ function App() {
               <HealthCard label="Uptime" value={formatUptime(health?.uptime_secs)} />
               <HealthCard tone={health && health.instances_ready > 0 ? 'ok' : 'warn'} label="Ready" value={`${health?.instances_ready ?? 0} / ${health?.instances_total ?? 0}`} />
               <HealthCard label="Version" value={health?.version ?? '?'} />
+              <HealthCard label="Gateway owner" value={gatewayLabel(health)} />
+              <HealthCard label="Gateway candidates" value={String(health?.gateway?.candidates?.length ?? 0)} />
               <HealthCard label="RSS" value={formatBytes(health?.rss_bytes ?? undefined)} />
               <HealthCard label="Body limit" value={health?.limits ? formatBytes(health.limits.body_max_bytes) : '?'} />
               <HealthCard

--- a/admin-ui/src/styles.css
+++ b/admin-ui/src/styles.css
@@ -331,6 +331,156 @@ td .refresh-btn:hover {
   border-color: rgba(217, 119, 87, 0.45);
 }
 
+.debug-hero {
+  align-items: flex-start;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.debug-hero h2 {
+  margin-bottom: 0.6rem;
+}
+
+.debug-pulse {
+  align-items: center;
+  background: #fff;
+  border: 1px solid var(--border-faint);
+  border-radius: var(--radius-lg);
+  color: var(--slate-medium);
+  display: inline-flex;
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+  padding: 0.65rem 0.85rem;
+}
+
+.pulse-dot {
+  border-radius: 50%;
+  display: inline-block;
+  height: 0.65rem;
+  width: 0.65rem;
+}
+
+.pulse-dot.ok {
+  background: #788c5d;
+  box-shadow: 0 0 0 5px rgba(120, 140, 93, 0.12);
+}
+
+.pulse-dot.warn {
+  background: var(--accent-warm);
+  box-shadow: 0 0 0 5px rgba(198, 97, 63, 0.14);
+}
+
+.debug-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  margin-bottom: 1rem;
+}
+
+.debug-map {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-bottom: 1rem;
+}
+
+.debug-card {
+  background: #fff;
+  border: 1px solid var(--border-faint);
+  border-radius: var(--radius-lg);
+  min-width: 0;
+  padding: 1rem;
+}
+
+.debug-card.debug-wide {
+  grid-column: 1 / -1;
+}
+
+.debug-card-head {
+  align-items: center;
+  border-bottom: 1px solid var(--border-faint);
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+  margin-bottom: 0.8rem;
+  padding-bottom: 0.65rem;
+}
+
+.debug-card-head h3 {
+  color: var(--slate-dark);
+  font-family: var(--font-serif);
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.debug-row {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--border-faint);
+  color: var(--slate-medium);
+  cursor: pointer;
+  display: grid;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  gap: 0.6rem;
+  grid-template-columns: minmax(4.5rem, auto) minmax(5.5rem, auto) minmax(0, 1fr);
+  padding: 0.5rem 0;
+  text-align: left;
+  width: 100%;
+}
+
+.debug-row:last-child {
+  border-bottom: 0;
+}
+
+.debug-row:hover {
+  color: var(--slate-dark);
+}
+
+.debug-row.static {
+  cursor: default;
+}
+
+.debug-row span:last-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.debug-metrics {
+  color: var(--cloud-dark);
+  display: flex;
+  flex-wrap: wrap;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  gap: 0.45rem 1rem;
+  margin-top: 0.75rem;
+}
+
+.mini-sparkline {
+  align-items: flex-end;
+  background: var(--ivory-medium);
+  border: 1px solid var(--border-faint);
+  border-radius: var(--radius);
+  display: flex;
+  gap: 3px;
+  height: 132px;
+  padding: 0.75rem;
+}
+
+.mini-sparkline span {
+  background: linear-gradient(180deg, var(--clay), var(--accent-warm));
+  border-radius: 2px 2px 0 0;
+  flex: 1;
+  min-height: 5px;
+}
+
 table {
   border-collapse: collapse;
   font-family: var(--font-mono);
@@ -803,4 +953,77 @@ button.linkish {
 button.linkish:disabled {
   cursor: not-allowed;
   opacity: 0.5;
+}
+
+@media (max-width: 720px) {
+  body {
+    height: auto;
+    min-height: 100vh;
+    overflow: auto;
+  }
+
+  .app-shell {
+    display: block;
+    height: auto;
+    min-height: 100vh;
+  }
+
+  .side-rail {
+    border-bottom: 1px solid var(--border-faint);
+    border-right: 0;
+    padding: 1rem 0 0.8rem;
+    position: sticky;
+    top: 0;
+    width: 100%;
+    z-index: 5;
+  }
+
+  .brand-lockup {
+    margin-bottom: 0.75rem;
+    padding-bottom: 0.75rem;
+  }
+
+  .nav-links {
+    flex-direction: row;
+    gap: 0.4rem;
+    overflow-x: auto;
+    padding: 0 1rem 0.1rem;
+  }
+
+  .nav-link {
+    flex: 0 0 auto;
+    padding: 0.48rem 0.75rem;
+    white-space: nowrap;
+  }
+
+  .main-stage {
+    padding: 1rem;
+  }
+
+  .debug-hero {
+    display: block;
+  }
+
+  .debug-pulse {
+    margin-bottom: 1rem;
+    margin-top: 0;
+    width: 100%;
+  }
+
+  .debug-map {
+    grid-template-columns: 1fr;
+  }
+
+  .debug-row {
+    grid-template-columns: minmax(3.8rem, auto) minmax(4.6rem, auto) minmax(0, 1fr);
+  }
+
+  .mini-sparkline {
+    height: 112px;
+  }
+
+  .workers-grid,
+  .stats-charts {
+    grid-template-columns: 1fr;
+  }
 }

--- a/admin-ui/tests/admin.spec.ts
+++ b/admin-ui/tests/admin.spec.ts
@@ -250,14 +250,15 @@ test.beforeEach(async ({ page }) => {
 });
 
 test.describe('Admin Page', () => {
-  test('loads the health panel and navigation', async ({ page }) => {
+  test('loads the debug panel and navigation', async ({ page }) => {
     await page.goto('/admin/');
     await expect(page.locator('h1')).toContainText('DCC-MCP Gateway');
-    await expect(page.getByRole('navigation').getByRole('link', { name: 'Activity' })).toHaveClass(/active/);
-    for (const label of ['Activity', 'Health', 'Instances', 'Tools', 'Tasks', 'Calls', 'Traces', 'Stats', 'Skill paths', 'Logs']) {
+    await expect(page.getByRole('navigation').getByRole('link', { name: 'Debug' })).toHaveClass(/active/);
+    for (const label of ['Debug', 'Activity', 'Health', 'Instances', 'Tools', 'Tasks', 'Calls', 'Traces', 'Stats', 'Skill paths', 'Logs']) {
       await expect(page.getByRole('navigation').getByRole('link', { name: label })).toBeVisible();
     }
-    await expect(page.locator('.activity-panel')).toContainText('maya-1234__create_sphere');
+    await expect(page.locator('.debug-panel')).toContainText('Debug Workbench');
+    await expect(page.locator('.debug-panel')).toContainText('Traffic Shape');
     await page.getByRole('navigation').getByRole('link', { name: 'Health' }).click();
     await expect(page.locator('.health-panel')).toContainText('0.17.7');
   });

--- a/crates/dcc-mcp-cli/src/application/client.rs
+++ b/crates/dcc-mcp-cli/src/application/client.rs
@@ -36,10 +36,36 @@ impl DccMcpClient {
     }
 
     pub async fn list_instances(&self) -> Result<Value, ClientError> {
-        self.gateway
+        let mut payload = self
+            .gateway
             .get_json(&self.endpoint.path("/v1/instances"))
             .await
-            .map_err(Into::into)
+            .map_err(ClientError::from)?;
+
+        let gateway = match self
+            .gateway
+            .get_json(&self.endpoint.path("/admin/api/health"))
+            .await
+        {
+            Ok(health) => health.get("gateway").cloned().unwrap_or_else(|| {
+                json!({
+                    "current": null,
+                    "candidates": [],
+                    "source": "/admin/api/health"
+                })
+            }),
+            Err(err) => json!({
+                "current": null,
+                "candidates": [],
+                "error": err.to_string(),
+                "source": "/admin/api/health"
+            }),
+        };
+
+        if let Some(obj) = payload.as_object_mut() {
+            obj.insert("gateway".to_string(), gateway);
+        }
+        Ok(payload)
     }
 
     pub async fn search(&self, request: SearchRequest) -> Result<Value, ClientError> {

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -339,7 +339,121 @@ fn to_json(value: impl Serialize) -> anyhow::Result<Value> {
 fn print_value(value: &Value, output: OutputFormat) -> anyhow::Result<()> {
     match output {
         OutputFormat::Json => println!("{}", serde_json::to_string(value)?),
+        OutputFormat::Pretty if is_list_payload(value) => print_list_pretty(value),
         OutputFormat::Pretty => println!("{}", serde_json::to_string_pretty(value)?),
     }
     Ok(())
+}
+
+fn is_list_payload(value: &Value) -> bool {
+    value.get("instances").is_some() && value.get("gateway").is_some()
+}
+
+fn print_list_pretty(value: &Value) {
+    let gateway = value.get("gateway").unwrap_or(&Value::Null);
+    println!("Gateway");
+    if let Some(current) = gateway.get("current").filter(|v| !v.is_null()) {
+        println!(
+            "  owner      {}",
+            gateway_summary(
+                current,
+                current
+                    .get("role")
+                    .and_then(Value::as_str)
+                    .unwrap_or("active")
+            )
+        );
+    } else if let Some(error) = gateway.get("error").and_then(Value::as_str) {
+        println!("  owner      unknown ({error})");
+    } else {
+        println!("  owner      unknown");
+    }
+
+    let candidates = gateway
+        .get("candidates")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if candidates.is_empty() {
+        println!("  candidates none");
+    } else {
+        println!("  candidates");
+        for candidate in candidates {
+            println!("    {}", gateway_summary(&candidate, "challenger"));
+        }
+    }
+
+    println!();
+    println!("Instances");
+    let instances = value
+        .get("instances")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if instances.is_empty() {
+        println!("  none");
+        return;
+    }
+    for instance in instances {
+        let dcc = instance
+            .get("dcc_type")
+            .and_then(Value::as_str)
+            .unwrap_or("-");
+        let short = instance
+            .get("instance_short")
+            .or_else(|| instance.get("instance_id"))
+            .and_then(Value::as_str)
+            .unwrap_or("-");
+        let name = instance
+            .get("display_name")
+            .and_then(Value::as_str)
+            .unwrap_or("-");
+        let pid = instance
+            .get("pid")
+            .and_then(Value::as_u64)
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let status = instance
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("available");
+        let mcp_url = instance
+            .get("mcp_url")
+            .and_then(Value::as_str)
+            .unwrap_or("-");
+        println!("  {dcc:<12} {short:<12} {status:<12} pid={pid:<8} name={name} mcp={mcp_url}");
+    }
+}
+
+fn gateway_summary(value: &Value, fallback_role: &str) -> String {
+    let name = value
+        .get("name")
+        .or_else(|| value.get("display_name"))
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let role = value
+        .get("role")
+        .and_then(Value::as_str)
+        .unwrap_or(fallback_role);
+    let pid = value
+        .get("pid")
+        .and_then(Value::as_u64)
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| "-".to_string());
+    let dcc = value
+        .get("adapter_dcc")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let version = value
+        .get("adapter_version")
+        .or_else(|| value.get("version"))
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let host = value.get("host").and_then(Value::as_str).unwrap_or("-");
+    let port = value
+        .get("port")
+        .and_then(Value::as_u64)
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| "-".to_string());
+    format!("{name} role={role} pid={pid} dcc={dcc} version={version} addr={host}:{port}")
 }

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -73,6 +73,38 @@ fn spawn_gateway_fixture() -> GatewayFixture {
         )
         .route("/v1/healthz", get(|| async { Json(json!({"ok": true})) }))
         .route(
+            "/admin/api/health",
+            get(|| async {
+                Json(json!({
+                    "status": "ok",
+                    "gateway": {
+                        "current": {
+                            "name": "Maya-main-15084",
+                            "role": "active",
+                            "pid": 15084,
+                            "host": "127.0.0.1",
+                            "port": 9765,
+                            "instance_id": "11111111-0000-0000-0000-000000000000",
+                            "version": "0.17.9",
+                            "adapter_version": "0.3.4",
+                            "adapter_dcc": "maya"
+                        },
+                        "candidates": [{
+                            "name": "Maya-layout-120920",
+                            "role": "challenger",
+                            "pid": 120920,
+                            "host": "127.0.0.1",
+                            "port": 9765,
+                            "instance_id": "22222222-0000-0000-0000-000000000000",
+                            "version": "0.17.9",
+                            "adapter_version": "0.3.4",
+                            "adapter_dcc": "maya"
+                        }]
+                    }
+                }))
+            }),
+        )
+        .route(
             "/v1/instances",
             get(|| async {
                 Json(json!({
@@ -162,6 +194,16 @@ fn run_json(args: &[&str]) -> Value {
     serde_json::from_slice(&output.stdout).unwrap()
 }
 
+fn run_text(args: &[&str]) -> String {
+    let output = cli_command().args(args).output().unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap()
+}
+
 fn write_skill(root: &std::path::Path, relative: &str, content: &str) -> std::path::PathBuf {
     let dir = root.join(relative);
     std::fs::create_dir_all(&dir).unwrap();
@@ -176,6 +218,11 @@ fn list_search_describe_and_call_gateway_rest_surface() {
     let list = run_json(&["--base-url", &fixture.base_url, "list"]);
     assert_eq!(list["total"], 1);
     assert_eq!(list["instances"][0]["dcc_type"], "maya");
+    assert_eq!(list["gateway"]["current"]["name"], "Maya-main-15084");
+    assert_eq!(
+        list["gateway"]["candidates"][0]["name"],
+        "Maya-layout-120920"
+    );
 
     let search = run_json(&[
         "--base-url",
@@ -209,6 +256,25 @@ fn list_search_describe_and_call_gateway_rest_surface() {
     ]);
     assert_eq!(call["success"], true);
     assert_eq!(call["arguments"]["radius"], 2);
+}
+
+#[test]
+fn pretty_list_shows_gateway_owner_and_candidates() {
+    let fixture = spawn_gateway_fixture();
+
+    let output = run_text(&[
+        "--base-url",
+        &fixture.base_url,
+        "--output",
+        "pretty",
+        "list",
+    ]);
+
+    assert!(output.contains("Gateway"));
+    assert!(output.contains("owner      Maya-main-15084"));
+    assert!(output.contains("Maya-layout-120920"));
+    assert!(output.contains("Instances"));
+    assert!(output.contains("maya"));
 }
 
 #[test]

--- a/crates/dcc-mcp-db/src/infra/file_log_merge.rs
+++ b/crates/dcc-mcp-db/src/infra/file_log_merge.rs
@@ -1,6 +1,13 @@
 //! Parse tracing-style `.log` files for gateway admin log merge (`GET /admin/api/logs`).
 
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
 use serde_json::{Value, json};
+
+const MAX_LOG_FILES_TO_SCAN: usize = 32;
+const LOG_TAIL_BYTES: u64 = 256 * 1024;
 
 /// Parse one log line (tracing / log4rs style) into an admin log row JSON object.
 ///
@@ -69,16 +76,11 @@ pub fn read_gateway_log_dir_rows_recent(dir: &str, limit: usize) -> Vec<Value> {
         return Vec::new();
     }
     let mut rows: Vec<Value> = Vec::new();
-    if let Ok(entries) = std::fs::read_dir(dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().map(|e| e == "log").unwrap_or(false)
-                && let Ok(contents) = std::fs::read_to_string(&path)
-            {
-                for line in contents.lines() {
-                    if let Some(row) = parse_gateway_file_log_line(line) {
-                        rows.push(row);
-                    }
+    for path in recent_log_files(dir) {
+        if let Ok(contents) = read_log_tail(&path, LOG_TAIL_BYTES) {
+            for line in contents.lines() {
+                if let Some(row) = parse_gateway_file_log_line(line) {
+                    rows.push(row);
                 }
             }
         }
@@ -90,6 +92,45 @@ pub fn read_gateway_log_dir_rows_recent(dir: &str, limit: usize) -> Vec<Value> {
     });
     rows.truncate(limit);
     rows
+}
+
+fn recent_log_files(dir: &str) -> Vec<PathBuf> {
+    let mut files: Vec<(SystemTime, PathBuf)> = std::fs::read_dir(dir)
+        .into_iter()
+        .flat_map(|entries| entries.flatten())
+        .filter_map(|entry| {
+            let path = entry.path();
+            if !path.extension().map(|e| e == "log").unwrap_or(false) {
+                return None;
+            }
+            let modified = entry
+                .metadata()
+                .and_then(|m| m.modified())
+                .unwrap_or(SystemTime::UNIX_EPOCH);
+            Some((modified, path))
+        })
+        .collect();
+    files.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| b.1.cmp(&a.1)));
+    files
+        .into_iter()
+        .take(MAX_LOG_FILES_TO_SCAN)
+        .map(|(_, path)| path)
+        .collect()
+}
+
+fn read_log_tail(path: &Path, max_bytes: u64) -> std::io::Result<String> {
+    let mut file = std::fs::File::open(path)?;
+    let len = file.metadata()?.len();
+    let start = len.saturating_sub(max_bytes);
+    file.seek(SeekFrom::Start(start))?;
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)?;
+    if start > 0
+        && let Some(pos) = bytes.iter().position(|b| *b == b'\n')
+    {
+        bytes.drain(..=pos);
+    }
+    Ok(String::from_utf8_lossy(&bytes).into_owned())
 }
 
 #[cfg(test)]
@@ -163,5 +204,40 @@ mod tests {
         let v = parse_gateway_file_log_line(line).expect("parsable");
         assert!(v["dcc_type"].is_null());
         assert_eq!(v["message"], "message without colon target");
+    }
+
+    #[test]
+    fn read_dir_uses_tail_instead_of_full_file() {
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+        let p = dir.path().join("large.log");
+        let mut contents = String::from("2026-05-16T12:00:00.000000Z INFO t: old\n");
+        contents.push_str(&"x".repeat((super::LOG_TAIL_BYTES as usize) + 1024));
+        contents.push('\n');
+        contents.push_str("2026-05-16T13:00:00.000000Z WARN t: newest\n");
+        std::fs::write(&p, contents).unwrap();
+
+        let rows = super::read_gateway_log_dir_rows_recent(&dir.path().to_string_lossy(), 10);
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["message"], "newest");
+    }
+
+    #[test]
+    fn read_dir_scans_bounded_recent_file_set() {
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+        for i in 0..(super::MAX_LOG_FILES_TO_SCAN + 4) {
+            let p = dir.path().join(format!("{i:02}.log"));
+            std::fs::write(
+                &p,
+                format!("2026-05-16T12:00:{i:02}.000000Z INFO t: row-{i}\n"),
+            )
+            .unwrap();
+        }
+
+        let rows = super::read_gateway_log_dir_rows_recent(&dir.path().to_string_lossy(), 100);
+
+        assert!(rows.len() <= super::MAX_LOG_FILES_TO_SCAN);
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
@@ -22,6 +22,9 @@ use crate::gateway::resilience::{self as gw_resilience, gateway_limits};
 use crate::gateway::state::entry_to_json;
 use dcc_mcp_db::env::ENV_DCC_MCP_LOG_DIR;
 use dcc_mcp_db::read_gateway_log_dir_rows_recent;
+use dcc_mcp_transport::discovery::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry};
+
+const ADMIN_FILE_LOG_READ_TIMEOUT: Duration = Duration::from_millis(750);
 
 /// `GET /admin` — serve the inline HTML dashboard.
 pub async fn handle_admin_ui() -> impl IntoResponse {
@@ -160,12 +163,26 @@ pub async fn handle_admin_logs(State(s): State<AdminState>) -> impl IntoResponse
             dcc_mcp_db::default_gateway_log_dir()
         }
     });
-    if std::fs::metadata(&log_dir)
-        .map(|m| m.is_dir())
-        .unwrap_or(false)
-    {
-        let mut file_logs = read_gateway_log_dir_rows_recent(&log_dir, 500);
-        logs.append(&mut file_logs);
+    let file_log_task = tokio::task::spawn_blocking(move || {
+        if !std::fs::metadata(&log_dir)
+            .map(|m| m.is_dir())
+            .unwrap_or(false)
+        {
+            return Vec::new();
+        }
+        read_gateway_log_dir_rows_recent(&log_dir, 500)
+    });
+    match tokio::time::timeout(ADMIN_FILE_LOG_READ_TIMEOUT, file_log_task).await {
+        Ok(Ok(mut file_logs)) => logs.append(&mut file_logs),
+        Ok(Err(err)) => {
+            tracing::warn!(error = %err, "admin file log read task failed");
+        }
+        Err(_) => {
+            tracing::warn!(
+                timeout_ms = ADMIN_FILE_LOG_READ_TIMEOUT.as_millis() as u64,
+                "admin file log read timed out"
+            );
+        }
     }
 
     if let Some(audit) = &s.audit_log {
@@ -221,6 +238,7 @@ pub async fn handle_admin_health(State(s): State<AdminState>) -> impl IntoRespon
     let registry = s.gateway.registry.read().await;
     let all = s.gateway.all_instances(&registry);
     let ready = s.gateway.live_instances(&registry).len();
+    let gateway_sentinels = registry.list_instances(GATEWAY_SENTINEL_DCC_TYPE);
     let total = all.len();
     drop(registry);
 
@@ -245,6 +263,7 @@ pub async fn handle_admin_health(State(s): State<AdminState>) -> impl IntoRespon
             "uptime_secs": uptime_secs,
             "version": s.gateway.server_version,
             "rss_bytes": rss_bytes,
+            "gateway": gateway_health_snapshot(&gateway_sentinels),
             "limits": {
                 "body_max_bytes": limits.body_max_bytes,
                 "rate_limit_per_minute_per_ip": limits.rate_limit_per_minute_per_ip,
@@ -256,6 +275,72 @@ pub async fn handle_admin_health(State(s): State<AdminState>) -> impl IntoRespon
             "circuits": circuits,
         })),
     )
+}
+
+fn gateway_health_snapshot(sentinels: &[ServiceEntry]) -> Value {
+    let mut rows: Vec<Value> = sentinels.iter().map(gateway_sentinel_json).collect();
+    rows.sort_by(|a, b| {
+        let role_a = a.get("role").and_then(Value::as_str).unwrap_or("");
+        let role_b = b.get("role").and_then(Value::as_str).unwrap_or("");
+        let rank_a = if role_a == "active" { 0 } else { 1 };
+        let rank_b = if role_b == "active" { 0 } else { 1 };
+        rank_a.cmp(&rank_b).then_with(|| {
+            let ta = a
+                .get("last_heartbeat_unix")
+                .and_then(Value::as_u64)
+                .unwrap_or(0);
+            let tb = b
+                .get("last_heartbeat_unix")
+                .and_then(Value::as_u64)
+                .unwrap_or(0);
+            tb.cmp(&ta)
+        })
+    });
+    let current = rows
+        .iter()
+        .find(|row| row.get("role").and_then(Value::as_str) == Some("active"))
+        .cloned()
+        .or_else(|| rows.first().cloned());
+    let candidates: Vec<Value> = rows
+        .into_iter()
+        .filter(|row| row.get("role").and_then(Value::as_str) != Some("active"))
+        .collect();
+    json!({
+        "current": current,
+        "candidates": candidates,
+    })
+}
+
+fn gateway_sentinel_json(entry: &ServiceEntry) -> Value {
+    let last_heartbeat_secs = entry
+        .last_heartbeat
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_secs());
+    let role = entry
+        .metadata
+        .get("gateway_role")
+        .cloned()
+        .unwrap_or_else(|| "active".to_string());
+    let name = entry
+        .metadata
+        .get("gateway_name")
+        .cloned()
+        .or_else(|| entry.display_name.clone())
+        .unwrap_or_else(|| format!("gateway-pid{}", entry.pid.unwrap_or_default()));
+    json!({
+        "name": name,
+        "role": role,
+        "pid": entry.pid,
+        "host": entry.host,
+        "port": entry.port,
+        "instance_id": entry.instance_id.to_string(),
+        "version": entry.version,
+        "adapter_version": entry.adapter_version,
+        "adapter_dcc": entry.adapter_dcc,
+        "last_heartbeat_unix": last_heartbeat_secs,
+        "metadata": entry.metadata,
+    })
 }
 
 fn gateway_self_rss_bytes() -> Option<u64> {

--- a/crates/dcc-mcp-gateway/src/gateway/config.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/config.rs
@@ -66,6 +66,10 @@ pub struct GatewayConfig {
     pub heartbeat_secs: u64,
     /// Server name advertised in gateway `initialize` responses.
     pub server_name: String,
+    /// Human-readable identity for the process currently competing for or
+    /// serving the gateway role. Written to the `__gateway__` sentinel so
+    /// operators can tell which peer owns the well-known port.
+    pub gateway_name: Option<String>,
     /// Server version advertised in gateway `initialize` responses.
     pub server_version: String,
     /// Shared `FileRegistry` directory. `None` falls back to a temp dir.
@@ -158,6 +162,7 @@ impl Default for GatewayConfig {
             stale_timeout_secs: 30,
             heartbeat_secs: 5,
             server_name: "dcc-mcp-gateway".to_string(),
+            gateway_name: None,
             server_version: env!("CARGO_PKG_VERSION").to_string(),
             registry_dir: None,
             challenger_timeout_secs: 120,

--- a/crates/dcc-mcp-gateway/src/gateway/runner.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/runner.rs
@@ -219,6 +219,7 @@ impl GatewayRunner {
         let own_version = self.config.server_version.clone();
         let own_adapter_version = self.config.adapter_version.clone();
         let own_adapter_dcc = self.config.adapter_dcc.clone();
+        let gateway_name = self.effective_gateway_name();
 
         // Prune dead FileRegistry entries BEFORE election so:
         //
@@ -304,6 +305,7 @@ impl GatewayRunner {
                 sentinel.version = Some(own_version.clone());
                 sentinel.adapter_version = own_adapter_version.clone();
                 sentinel.adapter_dcc = own_adapter_dcc.clone();
+                stamp_gateway_sentinel(&mut sentinel, &gateway_name, "active");
                 let sentinel_key = sentinel.key();
                 {
                     let reg = self.registry.read().await;
@@ -322,7 +324,7 @@ impl GatewayRunner {
                     wait_terminal_timeout,
                     route_ttl,
                     max_routes_per_session,
-                    format!("{} (gateway)", self.config.server_name),
+                    format!("{} ({gateway_name})", self.config.server_name),
                     own_version.clone(),
                     sentinel_key.clone(),
                     self.config.host.clone(),
@@ -511,6 +513,7 @@ impl GatewayRunner {
         let route_ttl = Duration::from_secs(self.config.route_ttl_secs);
         let max_routes_per_session = self.config.max_routes_per_session as usize;
         let server_name = self.config.server_name.clone();
+        let gateway_name = self.effective_gateway_name();
         let timeout_secs = self.config.challenger_timeout_secs;
         let poll_interval_secs = self.config.challenger_poll_interval_secs.max(1);
         let allow_unknown_tools = self.config.allow_unknown_tools;
@@ -539,6 +542,7 @@ impl GatewayRunner {
             challenge_sentinel.version = Some(own_ver.clone());
             challenge_sentinel.adapter_version = adapter_version.clone();
             challenge_sentinel.adapter_dcc = adapter_dcc.clone();
+            stamp_gateway_sentinel(&mut challenge_sentinel, &gateway_name, "challenger");
             let challenge_sentinel_key = challenge_sentinel.key();
             {
                 let reg = registry.read().await;
@@ -605,6 +609,7 @@ impl GatewayRunner {
                     sentinel.version = Some(own_ver.clone());
                     sentinel.adapter_version = adapter_version.clone();
                     sentinel.adapter_dcc = adapter_dcc.clone();
+                    stamp_gateway_sentinel(&mut sentinel, &gateway_name, "active");
                     let sentinel_key = sentinel.key();
                     {
                         let reg = registry.read().await;
@@ -625,7 +630,7 @@ impl GatewayRunner {
                         wait_terminal_timeout,
                         route_ttl,
                         max_routes_per_session,
-                        format!("{server_name} (gateway)"),
+                        format!("{server_name} ({gateway_name})"),
                         own_ver.clone(),
                         sentinel_key.clone(),
                         host.clone(),
@@ -687,6 +692,35 @@ impl GatewayRunner {
         )
         .await
     }
+
+    fn effective_gateway_name(&self) -> String {
+        self.config
+            .gateway_name
+            .as_ref()
+            .filter(|name| !name.trim().is_empty())
+            .cloned()
+            .unwrap_or_else(|| {
+                let dcc = self.config.adapter_dcc.as_deref().unwrap_or("standalone");
+                format!("{dcc}-gateway-pid{}", std::process::id())
+            })
+    }
+}
+
+fn stamp_gateway_sentinel(entry: &mut ServiceEntry, gateway_name: &str, role: &str) {
+    entry.display_name = Some(gateway_name.to_string());
+    entry
+        .metadata
+        .insert("dcc_mcp_role".to_string(), "gateway-sentinel".to_string());
+    entry
+        .metadata
+        .insert("gateway_name".to_string(), gateway_name.to_string());
+    entry
+        .metadata
+        .insert("gateway_role".to_string(), role.to_string());
+    entry.metadata.insert(
+        "gateway_process_pid".to_string(),
+        std::process::id().to_string(),
+    );
 }
 
 struct PromotedGatewayGuard {

--- a/crates/dcc-mcp-gateway/src/gateway/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tests.rs
@@ -409,6 +409,43 @@ async fn test_gateway_winner_serves_optional_remote_listener() {
 }
 
 #[tokio::test]
+async fn test_gateway_winner_stamps_human_readable_name_on_sentinel() {
+    let dir = tempfile::tempdir().unwrap();
+    let gw_port = ephemeral_port();
+    let cfg = GatewayConfig {
+        host: "127.0.0.1".to_string(),
+        gateway_port: gw_port,
+        gateway_name: Some("maya-main-window".to_string()),
+        heartbeat_secs: 0,
+        registry_dir: Some(dir.path().to_path_buf()),
+        ..GatewayConfig::default()
+    };
+    let runner = GatewayRunner::new(cfg).unwrap();
+
+    let outcome = runner.run_election().await.unwrap();
+
+    assert!(outcome.is_gateway, "free local port must win election");
+    let reg = runner.registry.read().await;
+    let sentinels = reg.list_instances(GATEWAY_SENTINEL_DCC_TYPE);
+    assert_eq!(sentinels.len(), 1);
+    let sentinel = &sentinels[0];
+    assert_eq!(sentinel.display_name.as_deref(), Some("maya-main-window"));
+    assert_eq!(
+        sentinel.metadata.get("gateway_name").map(String::as_str),
+        Some("maya-main-window")
+    );
+    assert_eq!(
+        sentinel.metadata.get("gateway_role").map(String::as_str),
+        Some("active")
+    );
+    drop(reg);
+
+    if let Some(abort) = outcome.gateway_abort {
+        abort.abort();
+    }
+}
+
+#[tokio::test]
 async fn test_newer_gateway_takes_over_local_and_remote_listeners() {
     let dir = tempfile::tempdir().unwrap();
     let gw_port = ephemeral_port();

--- a/crates/dcc-mcp-http-py/src/config.rs
+++ b/crates/dcc-mcp-http-py/src/config.rs
@@ -507,6 +507,18 @@ impl PyMcpHttpConfig {
         self.inner.gateway.adapter_dcc = v;
     }
 
+    /// Human-readable gateway candidate name written to the gateway sentinel.
+    #[getter]
+    fn gateway_name(&self) -> Option<String> {
+        self.inner.gateway.gateway_name.clone()
+    }
+
+    /// Human-readable gateway candidate name written to the gateway sentinel.
+    #[setter]
+    fn set_gateway_name(&mut self, v: Option<String>) {
+        self.inner.gateway.gateway_name = v;
+    }
+
     /// Allow instances with ``dcc_type == "unknown"`` to expose tools (#555).
     #[getter]
     fn allow_unknown_tools(&self) -> bool {

--- a/crates/dcc-mcp-http-types/src/config/aggregate.rs
+++ b/crates/dcc-mcp-http-types/src/config/aggregate.rs
@@ -226,6 +226,12 @@ impl McpHttpConfig {
     pub fn set_adapter_dcc(&mut self, v: Option<String>) {
         self.gateway.adapter_dcc = v;
     }
+    pub fn gateway_name(&self) -> Option<String> {
+        self.gateway.gateway_name.clone()
+    }
+    pub fn set_gateway_name(&mut self, v: Option<String>) {
+        self.gateway.gateway_name = v;
+    }
     pub fn allow_unknown_tools(&self) -> bool {
         self.gateway.allow_unknown_tools
     }
@@ -417,6 +423,13 @@ impl McpHttpConfig {
     /// servers (issue maya#137).
     pub fn with_adapter_dcc(mut self, dcc: impl Into<String>) -> Self {
         self.gateway.adapter_dcc = Some(dcc.into());
+        self
+    }
+
+    /// Builder: give this gateway candidate a human-readable identity for
+    /// admin diagnostics and the `__gateway__` sentinel row.
+    pub fn with_gateway_name(mut self, name: impl Into<String>) -> Self {
+        self.gateway.gateway_name = Some(name.into());
         self
     }
 

--- a/crates/dcc-mcp-http-types/src/config/gateway.rs
+++ b/crates/dcc-mcp-http-types/src/config/gateway.rs
@@ -74,6 +74,11 @@ pub struct GatewayConfig {
     /// gateway election (issue maya#137).
     pub adapter_dcc: Option<String>,
 
+    /// Human-readable identity for this gateway candidate. The elected
+    /// gateway writes it to the `__gateway__` sentinel so operators can see
+    /// which process owns the gateway port.
+    pub gateway_name: Option<String>,
+
     /// Allow instances with `dcc_type == "unknown"` to expose their tools
     /// via the gateway (issue #555).
     ///
@@ -109,6 +114,7 @@ impl Default for GatewayConfig {
             gateway_max_routes_per_session: 1_000,
             adapter_version: None,
             adapter_dcc: None,
+            gateway_name: None,
             allow_unknown_tools: false,
             admin_enabled: true,
             admin_path: "/admin".to_string(),

--- a/crates/dcc-mcp-http/src/server/gateway_impl.rs
+++ b/crates/dcc-mcp-http/src/server/gateway_impl.rs
@@ -23,6 +23,7 @@ pub(crate) async fn start_gateway_runner(
         stale_timeout_secs: config.gateway.stale_timeout_secs,
         heartbeat_secs: config.gateway.heartbeat_secs,
         server_name: config.server.server_name.clone(),
+        gateway_name: config.gateway.gateway_name.clone(),
         server_version: config.server.server_version.clone(),
         registry_dir: config.gateway.registry_dir.clone(),
         challenger_timeout_secs: 120,

--- a/crates/dcc-mcp-server/src/gateway_daemon.rs
+++ b/crates/dcc-mcp-server/src/gateway_daemon.rs
@@ -1,0 +1,244 @@
+//! Machine-wide standalone gateway daemon and auto-launch helper.
+
+use std::fs::{File, OpenOptions};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use anyhow::Context as _;
+use clap::Args;
+use dcc_mcp_gateway::{AdminPersistConfig, GatewayConfig, GatewayRunner};
+
+/// CLI surface for the machine-wide gateway process.
+#[derive(Debug, Args, Clone)]
+pub struct GatewayArgs {
+    /// Gateway host/interface to bind.
+    #[arg(long, env = "DCC_MCP_GATEWAY_HOST", default_value = "127.0.0.1")]
+    pub host: String,
+
+    /// Well-known gateway port.
+    #[arg(long, env = "DCC_MCP_GATEWAY_PORT", default_value = "9765")]
+    pub port: u16,
+
+    /// Human-readable gateway owner label.
+    #[arg(long, env = "DCC_MCP_GATEWAY_NAME")]
+    pub name: Option<String>,
+
+    /// Remote/LAN gateway host/interface to bind.
+    #[arg(long, env = "DCC_MCP_GATEWAY_REMOTE_HOST", default_value = "0.0.0.0")]
+    pub remote_host: String,
+
+    /// Remote/LAN gateway port. 0 disables the remote listener.
+    #[arg(long, env = "DCC_MCP_GATEWAY_REMOTE_PORT", default_value = "59765")]
+    pub remote_port: u16,
+
+    /// Directory for the shared FileRegistry.
+    #[arg(long, env = "DCC_MCP_REGISTRY_DIR")]
+    pub registry_dir: Option<PathBuf>,
+
+    /// Disable the read-only Admin UI.
+    #[arg(long, env = "DCC_MCP_NO_ADMIN", default_value = "false")]
+    pub no_admin: bool,
+
+    /// URL prefix for the read-only Admin UI.
+    #[arg(long, env = "DCC_MCP_ADMIN_PATH", default_value = "/admin")]
+    pub admin_path: String,
+
+    /// Seconds without a heartbeat before an instance is considered stale.
+    #[arg(long, env = "DCC_MCP_STALE_TIMEOUT", default_value = "30")]
+    pub stale_timeout_secs: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct EnsureGatewayOptions {
+    pub host: String,
+    pub port: u16,
+    pub name: Option<String>,
+    pub registry_dir: PathBuf,
+    pub remote_host: String,
+    pub remote_port: u16,
+}
+
+/// Run the standalone gateway until a shutdown signal arrives.
+pub async fn run(args: GatewayArgs) -> anyhow::Result<()> {
+    let admin_retention = std::env::var("DCC_MCP_GATEWAY_ADMIN_RETENTION_DAYS")
+        .ok()
+        .and_then(|s| s.parse::<u32>().ok())
+        .unwrap_or(30)
+        .clamp(1, 3650);
+    let gateway_name = args.name.clone().unwrap_or_else(default_gateway_name);
+    let cfg = GatewayConfig {
+        host: args.host.clone(),
+        gateway_port: args.port,
+        remote_host: Some(args.remote_host.clone()),
+        remote_gateway_port: args.remote_port,
+        stale_timeout_secs: args.stale_timeout_secs,
+        server_name: "dcc-mcp-gateway".to_string(),
+        gateway_name: Some(gateway_name.clone()),
+        server_version: env!("CARGO_PKG_VERSION").to_string(),
+        registry_dir: args.registry_dir.clone(),
+        adapter_dcc: Some("gateway".to_string()),
+        admin_enabled: !args.no_admin,
+        admin_path: args.admin_path.clone(),
+        admin_persist: AdminPersistConfig {
+            sqlite_path: std::env::var_os("DCC_MCP_GATEWAY_ADMIN_DB").map(PathBuf::from),
+            sqlite_retention_days: admin_retention,
+            ..AdminPersistConfig::default()
+        },
+        ..GatewayConfig::default()
+    };
+    let runner =
+        GatewayRunner::new(cfg).map_err(|err| anyhow::anyhow!("creating GatewayRunner: {err}"))?;
+    let mut outcome = runner
+        .run_election()
+        .await
+        .map_err(|err| anyhow::anyhow!("running gateway election: {err}"))?;
+
+    if !outcome.is_gateway {
+        tracing::info!(
+            host = %args.host,
+            port = args.port,
+            "standalone gateway found an existing owner; exiting"
+        );
+        return Ok(());
+    }
+
+    tracing::info!(
+        gateway_name = %gateway_name,
+        host = %args.host,
+        port = args.port,
+        "standalone gateway running"
+    );
+
+    let shutdown_reason = crate::select_shutdown_signal().await?;
+    tracing::info!(shutdown_reason, "standalone gateway shutting down");
+
+    if let Some(abort) = outcome.gateway_abort.take() {
+        abort.abort();
+    }
+    if let Some(key) = outcome.sentinel_key.take() {
+        let reg = runner.registry.read().await;
+        let _ = reg.deregister(&key);
+    }
+    Ok(())
+}
+
+/// Ensure the machine-wide gateway is reachable, launching it once if needed.
+pub async fn ensure_gateway_running(opts: &EnsureGatewayOptions) -> anyhow::Result<()> {
+    if opts.port == 0 || gateway_health_ok(&opts.host, opts.port).await {
+        return Ok(());
+    }
+
+    std::fs::create_dir_all(&opts.registry_dir)
+        .with_context(|| format!("creating registry dir {}", opts.registry_dir.display()))?;
+    let lock_path = opts.registry_dir.join("gateway-launch.lock");
+    match acquire_launch_lock(&lock_path) {
+        Ok(_lock) => {
+            if gateway_health_ok(&opts.host, opts.port).await {
+                return Ok(());
+            }
+            spawn_detached_gateway(opts)?;
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+            tracing::info!(
+                path = %lock_path.display(),
+                "another process is launching the gateway"
+            );
+        }
+        Err(err) => return Err(err).with_context(|| format!("creating {}", lock_path.display())),
+    }
+
+    wait_gateway_ready(&opts.host, opts.port, Duration::from_secs(10)).await
+}
+
+async fn wait_gateway_ready(host: &str, port: u16, timeout: Duration) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if gateway_health_ok(host, port).await {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+    anyhow::bail!(
+        "gateway did not become healthy at http://{host}:{port}/health within {timeout:?}"
+    )
+}
+
+async fn gateway_health_ok(host: &str, port: u16) -> bool {
+    let url = format!("http://{host}:{port}/health");
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_millis(600))
+        .build()
+    {
+        Ok(client) => client,
+        Err(_) => return false,
+    };
+    client
+        .get(url)
+        .send()
+        .await
+        .is_ok_and(|resp| resp.status().is_success())
+}
+
+struct LaunchLock {
+    _file: File,
+    path: PathBuf,
+}
+
+impl Drop for LaunchLock {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+fn acquire_launch_lock(path: &std::path::Path) -> std::io::Result<LaunchLock> {
+    OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map(|file| LaunchLock {
+            _file: file,
+            path: path.to_path_buf(),
+        })
+}
+
+fn spawn_detached_gateway(opts: &EnsureGatewayOptions) -> anyhow::Result<()> {
+    let exe = std::env::current_exe().context("resolving current executable")?;
+    let mut cmd = Command::new(exe);
+    cmd.arg("gateway")
+        .arg("--host")
+        .arg(&opts.host)
+        .arg("--port")
+        .arg(opts.port.to_string())
+        .arg("--remote-host")
+        .arg(&opts.remote_host)
+        .arg("--remote-port")
+        .arg(opts.remote_port.to_string())
+        .arg("--registry-dir")
+        .arg(&opts.registry_dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    if let Some(name) = opts.name.as_ref().filter(|name| !name.trim().is_empty()) {
+        cmd.arg("--name").arg(name);
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        const DETACHED_PROCESS: u32 = 0x0000_0008;
+        cmd.creation_flags(CREATE_NO_WINDOW | DETACHED_PROCESS);
+    }
+
+    cmd.spawn().context("spawning standalone gateway")?;
+    tracing::info!(port = opts.port, "spawned standalone gateway process");
+    Ok(())
+}
+
+fn default_gateway_name() -> String {
+    let host = std::env::var("COMPUTERNAME")
+        .or_else(|_| std::env::var("HOSTNAME"))
+        .unwrap_or_else(|_| "local".to_string());
+    format!("gateway-{host}-pid{}", std::process::id())
+}

--- a/crates/dcc-mcp-server/src/main.rs
+++ b/crates/dcc-mcp-server/src/main.rs
@@ -69,8 +69,9 @@
 //! | `DCC_MCP_WS_PORT`         | WebSocket bridge port (default 9001)               |
 //! | `DCC_MCP_APP`             | App name hint (e.g. "maya", "photoshop")           |
 //! | `DCC_MCP_SERVER_NAME`     | Server name advertised to MCP clients              |
-//! | `DCC_MCP_GATEWAY_PORT`    | Gateway port to compete for (default 9765, 0=off)  |
+//! | `DCC_MCP_GATEWAY_PORT`    | Gateway port to run/ensure (default 9765, 0=off)   |
 //! | `DCC_MCP_GATEWAY_HOST`    | Gateway bind host (default follows `--host`)       |
+//! | `DCC_MCP_GATEWAY_NAME`    | Human-readable gateway candidate/owner label       |
 //! | `DCC_MCP_GATEWAY_REMOTE_HOST` | Optional remote gateway bind host (default 0.0.0.0) |
 //! | `DCC_MCP_GATEWAY_REMOTE_PORT` | Optional remote gateway port (default 59765, 0=off) |
 //! | `DCC_MCP_NO_ADMIN`        | Disable read-only `/admin` on the elected gateway  |
@@ -97,6 +98,7 @@ use dcc_mcp_skills::constants::{
 };
 use dcc_mcp_transport::discovery::types::ServiceEntry;
 use sysinfo::{Pid, ProcessesToUpdate, System};
+mod gateway_daemon;
 mod sidecar;
 mod sidecar_gateway;
 mod sidecar_mcp;
@@ -120,6 +122,8 @@ enum SubCmd {
     /// and supervised via `--watch-pid`.  Exits cleanly when its parent
     /// DCC dies so we never leak stale workers.
     Sidecar(sidecar::SidecarArgs),
+    /// Machine-wide gateway daemon. Per-DCC sidecars auto-launch this when needed.
+    Gateway(gateway_daemon::GatewayArgs),
 }
 
 /// DCC-MCP server with integrated auto-gateway.
@@ -178,6 +182,11 @@ struct Args {
     /// Gateway host/interface to bind. Defaults to the MCP `--host`.
     #[arg(long, env = "DCC_MCP_GATEWAY_HOST")]
     gateway_host: Option<String>,
+
+    /// Human-readable gateway candidate name written to the `__gateway__`
+    /// sentinel when this process wins or challenges the gateway role.
+    #[arg(long, env = "DCC_MCP_GATEWAY_NAME")]
+    gateway_name: Option<String>,
 
     /// Remote/LAN gateway host/interface to bind.
     #[arg(long, env = "DCC_MCP_GATEWAY_REMOTE_HOST", default_value = "0.0.0.0")]
@@ -581,6 +590,7 @@ async fn main() -> anyhow::Result<()> {
         Some(SubCmd::Translate(translate_args)) => return translate::run(translate_args).await,
         Some(SubCmd::Catalog { action }) => return run_catalog_cmd(&action),
         Some(SubCmd::Sidecar(sidecar_args)) => return sidecar::run(sidecar_args).await,
+        Some(SubCmd::Gateway(gateway_args)) => return gateway_daemon::run(gateway_args).await,
         None => {}
     }
 
@@ -832,6 +842,7 @@ async fn main() -> anyhow::Result<()> {
         stale_timeout_secs: args.stale_timeout_secs,
         heartbeat_secs: args.heartbeat_secs,
         server_name: args.server_name.clone(),
+        gateway_name: args.gateway_name.clone(),
         server_version: env!("CARGO_PKG_VERSION").to_string(),
         registry_dir: registry_dir_path,
         // Issue maya#137: standalone server has no adapter package, so the

--- a/crates/dcc-mcp-server/src/sidecar.rs
+++ b/crates/dcc-mcp-server/src/sidecar.rs
@@ -22,10 +22,9 @@
 //! * **per-DCC sidecar**: one per DCC, lifetime bound to DCC's PID.  This
 //!   subcommand is the per-DCC sidecar.  The `--watch-pid` flag is the
 //!   parent-DCC PID; this process is **not** detached.
-//! * **gateway sidecar**: machine-wide singleton, lives in the same binary
-//!   but runs *without* `sidecar` subcommand (i.e. the default
-//!   `dcc-mcp-server` invocation that wins the `bind(9765)` race).  Existing
-//!   gateway logic is unchanged.
+//! * **gateway daemon**: machine-wide singleton, lives in the same binary
+//!   under the `gateway` subcommand. Per-DCC sidecars auto-launch it when
+//!   needed and do not participate in gateway election by default.
 //!
 //! # Example
 //!
@@ -142,13 +141,20 @@ pub struct SidecarArgs {
     #[arg(long, value_name = "MS", hide = true)]
     pub ppid_poll_ms: Option<u64>,
 
-    /// Well-known gateway port to compete for (first-wins). ``0`` disables
-    /// gateway election in this sidecar process.
+    /// Well-known gateway port to ensure. ``0`` disables gateway auto-launch.
     ///
-    /// Defaults to ``DCC_MCP_GATEWAY_PORT`` (9765). Sidecar mode should set
-    /// the in-DCC adapter's gateway port to ``0`` so only the sidecar competes.
+    /// Defaults to ``DCC_MCP_GATEWAY_PORT`` (9765). Per-DCC sidecars no longer
+    /// compete for this port unless ``--legacy-gateway-election`` is set.
     #[arg(long, default_value = "9765", env = "DCC_MCP_GATEWAY_PORT")]
     pub gateway_port: u16,
+
+    /// Disable auto-launching the machine-wide standalone gateway.
+    #[arg(long, default_value = "false")]
+    pub no_ensure_gateway: bool,
+
+    /// Legacy mode: let this per-DCC sidecar compete for the gateway role.
+    #[arg(long, env = "DCC_MCP_LEGACY_GATEWAY_ELECTION", default_value = "false")]
+    pub legacy_gateway_election: bool,
 
     /// Legacy host/interface for the gateway listener (default ``127.0.0.1``).
     ///
@@ -159,6 +165,11 @@ pub struct SidecarArgs {
     /// Gateway host/interface to bind. Use ``0.0.0.0`` to accept LAN clients.
     #[arg(long, env = "DCC_MCP_GATEWAY_HOST")]
     pub gateway_host: Option<String>,
+
+    /// Human-readable gateway candidate name written to the `__gateway__`
+    /// sentinel when this sidecar wins or challenges the gateway role.
+    #[arg(long, env = "DCC_MCP_GATEWAY_NAME")]
+    pub gateway_name: Option<String>,
 
     /// Remote/LAN gateway host/interface to bind.
     #[arg(long, env = "DCC_MCP_GATEWAY_REMOTE_HOST", default_value = "0.0.0.0")]
@@ -189,6 +200,29 @@ pub async fn run(args: SidecarArgs) -> anyhow::Result<()> {
         FileRegistry::new(&registry_dir)
             .with_context(|| format!("opening FileRegistry at {}", registry_dir.display()))?,
     );
+
+    if args.gateway_port > 0 && !args.no_ensure_gateway {
+        let gateway_host = args
+            .gateway_host
+            .clone()
+            .unwrap_or_else(|| args.host.clone());
+        crate::gateway_daemon::ensure_gateway_running(
+            &crate::gateway_daemon::EnsureGatewayOptions {
+                host: gateway_host,
+                port: args.gateway_port,
+                name: args.gateway_name.clone().or_else(|| {
+                    args.display_name
+                        .as_ref()
+                        .map(|name| format!("gateway-for-{name}"))
+                }),
+                registry_dir: registry_dir.clone(),
+                remote_host: args.gateway_remote_host.clone(),
+                remote_port: args.gateway_remote_port,
+            },
+        )
+        .await
+        .with_context(|| "ensuring standalone gateway is running")?;
+    }
 
     let entry = build_service_entry(&args);
     let key = entry.key();
@@ -262,7 +296,8 @@ pub async fn run(args: SidecarArgs) -> anyhow::Result<()> {
                             "FileRegistry republish with mcp_url failed; gateway will route via stub"
                         );
                     }
-                    if args.gateway_port > 0
+                    if args.legacy_gateway_election
+                        && args.gateway_port > 0
                         && let Some(entry) = registry.get(&key)
                     {
                         match crate::sidecar_gateway::start_sidecar_gateway(
@@ -572,8 +607,11 @@ mod tests {
             connect_timeout_secs: 2,
             ppid_poll_ms: Some(50),
             gateway_port: 0,
+            no_ensure_gateway: false,
+            legacy_gateway_election: false,
             host: "127.0.0.1".to_string(),
             gateway_host: None,
+            gateway_name: None,
             gateway_remote_host: "0.0.0.0".to_string(),
             gateway_remote_port: 59765,
         };
@@ -680,8 +718,11 @@ mod tests {
             connect_timeout_secs: 2,
             ppid_poll_ms: Some(50),
             gateway_port: 0,
+            no_ensure_gateway: false,
+            legacy_gateway_election: false,
             host: "127.0.0.1".to_string(),
             gateway_host: None,
+            gateway_name: None,
             gateway_remote_host: "0.0.0.0".to_string(),
             gateway_remote_port: 59765,
         };
@@ -770,8 +811,11 @@ mod tests {
             connect_timeout_secs: 1,
             ppid_poll_ms: Some(50),
             gateway_port: 0,
+            no_ensure_gateway: false,
+            legacy_gateway_election: false,
             host: "127.0.0.1".to_string(),
             gateway_host: None,
+            gateway_name: None,
             gateway_remote_host: "0.0.0.0".to_string(),
             gateway_remote_port: 59765,
         };

--- a/crates/dcc-mcp-server/src/sidecar_gateway.rs
+++ b/crates/dcc-mcp-server/src/sidecar_gateway.rs
@@ -122,11 +122,21 @@ fn build_gateway_config(args: &SidecarArgs) -> GatewayConfig {
         remote_gateway_port: args.gateway_remote_port,
         registry_dir: args.registry_dir.clone(),
         server_name: format!("dcc-mcp-gateway-{}", args.dcc),
+        gateway_name: Some(resolve_sidecar_gateway_name(args)),
         server_version: env!("CARGO_PKG_VERSION").to_string(),
         adapter_version: args.adapter_version.clone(),
         adapter_dcc: Some(args.dcc.clone()),
         ..GatewayConfig::default()
     }
+}
+
+fn resolve_sidecar_gateway_name(args: &SidecarArgs) -> String {
+    args.gateway_name
+        .as_ref()
+        .filter(|name| !name.trim().is_empty())
+        .cloned()
+        .or_else(|| args.display_name.clone())
+        .unwrap_or_else(|| format!("{}-pid{}", args.dcc, args.watch_pid))
 }
 
 fn spawn_failover_probe(

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -256,16 +256,18 @@ Set `DCC_MCP_GATEWAY_AUDIT_DIR` to enable durable JSONL persistence. The gateway
 ## Dashboard Features
 
 The HTML dashboard includes:
-- **Left navigation**: Instances / Tools / Calls / Traces / Stats / Workers / Logs panels
+- **Debug Workbench**: the default first screen combines health, instances, calls, traces, stats, and warning logs so operators can triage gateway failures without jumping between panels.
+- **Gateway owner identity**: the Health and Debug panels show the current `__gateway__` sentinel label from `gateway_name` / `DCC_MCP_GATEWAY_NAME`, plus any challenger candidates.
+- **Left navigation**: Debug / Activity / Health / Instances / Tools / Tasks / Calls / Traces / Stats / Skill paths / Logs panels
 - **Auto-refresh**: Panels poll their JSON endpoints every 5 seconds
 - **DCC icons**: common hosts such as Maya/Autodesk, Blender, GIMP, Inkscape, Krita, Unity, and Unreal get recognizable icons, with a safe fallback for custom hosts.
 - **Worker cards**: Per-instance status, heartbeat, and routing metadata
 - **Calls table**: request ids, error previews, and trace-detail links; DCC is displayed from the resolved backend slug when available, otherwise from explicit call arguments such as `dcc` / `dcc_type`.
 - **Trace drill-down**: `/admin/api/traces/{request_id}` exposes the full waterfall plus bounded/redacted input/output payloads for one call.
-- **Logs panel**: groups normalized `contention`, `file`, and `audit` rows so operators can correlate routing events, rolling files, and tool calls in one timeline.
+- **Logs panel**: groups normalized `contention`, `file`, and `audit` rows so operators can correlate routing events, rolling files, and tool calls in one timeline. File log reads are bounded to recent files and tail slices so the admin API does not scan unbounded historical logs.
 - **Durable audit option**: `DCC_MCP_GATEWAY_AUDIT_DIR` preserves the Calls and Traces panels across restarts without changing the JSON API shapes.
 - **Dark theme**: Vite/React source with embedded runtime asset and no required runtime build step
-- **Responsive**: CSS grid layout
+- **Responsive**: narrow screens switch to a top navigation rail, and debug cards/charts keep a usable single-column width.
 
 ## Security Note
 

--- a/docs/guide/gateway.md
+++ b/docs/guide/gateway.md
@@ -10,6 +10,24 @@ indexes backend capabilities on demand, routes `search_tools` /
 and multiplexes server-pushed notifications back to the originating
 client session.
 
+Set `gateway_name`, `--gateway-name`, or `DCC_MCP_GATEWAY_NAME` on each
+candidate to make ownership explicit. The elected process writes this label
+to the `__gateway__` sentinel and `/admin/api/health.gateway.current`; a
+challenger writes the same label with `gateway_role=challenger`, so operators
+can see both the current owner and the next peer trying to take over.
+
+For production, prefer the machine-wide standalone gateway:
+
+```bash
+dcc-mcp-server gateway --port 9765 --name studio-gateway
+```
+
+Per-DCC sidecars now auto-launch that process when `GET /health` is not
+reachable. They use a single-flight `gateway-launch.lock` in the registry
+directory so three DCCs starting at once still spawn at most one gateway.
+Use `dcc-mcp-server sidecar --no-ensure-gateway` to disable auto-launch, or
+`--legacy-gateway-election` to restore the old per-DCC first-wins election.
+
 ## Topology
 
 ```

--- a/docs/zh/guide/admin-ui.md
+++ b/docs/zh/guide/admin-ui.md
@@ -256,16 +256,18 @@ GatewayConfig {
 ## 仪表盘功能
 
 HTML 仪表盘包含：
-- **左侧导航**：实例 / 工具 / 调用 / Traces / Stats / Workers / 日志面板
+- **Debug Workbench**：默认首屏会组合 health、instances、calls、traces、stats 和 warning logs，方便排查 gateway 故障时不用在多个面板之间来回跳转
+- **Gateway owner identity**：Health 和 Debug 面板会展示来自 `gateway_name` / `DCC_MCP_GATEWAY_NAME` 的当前 `__gateway__` sentinel 标签，以及 challenger 候选
+- **左侧导航**：Debug / Activity / Health / 实例 / 工具 / Tasks / Calls / Traces / Stats / Skill paths / 日志面板
 - **自动刷新**：每个面板每 5 秒轮询对应 JSON 端点
 - **DCC 图标**：Maya/Autodesk、Blender、GIMP、Inkscape、Krita、Unity、Unreal 等常见宿主显示可识别图标，自定义宿主使用安全 fallback
 - **Worker 卡片**：按实例展示状态、心跳与路由元数据
 - **Calls 表格**：展示 request id、错误摘要与 trace detail 链接；DCC 优先从解析后的 backend slug 展示，其次使用调用参数中的 `dcc` / `dcc_type`
 - **Trace 下钻**：`/admin/api/traces/{request_id}` 暴露单次调用的完整 waterfall，以及有界/已脱敏的输入输出 payload
-- **Logs 面板**：将标准化的 `contention`、`file`、`audit` 行分组，方便在一条时间线里关联路由事件、滚动日志和工具调用
+- **Logs 面板**：将标准化的 `contention`、`file`、`audit` 行分组，方便在一条时间线里关联路由事件、滚动日志和工具调用。文件日志读取会限制为最近文件与尾部片段，避免 admin API 扫描无界历史日志
 - **可选持久化**：`DCC_MCP_GATEWAY_AUDIT_DIR` 可让 Calls 与 Traces 面板跨重启保留，且不改变 JSON API 结构
 - **深色主题**：Vite/React 源码，运行时嵌入资产，不要求现场构建
-- **响应式布局**：CSS grid 布局
+- **响应式布局**：窄屏会切换为顶部导航，debug 卡片和图表保持可用的单列宽度
 
 ## 安全注意事项
 

--- a/docs/zh/guide/gateway.md
+++ b/docs/zh/guide/gateway.md
@@ -8,6 +8,24 @@ Gateway（`McpHttpConfig::gateway_port > 0`）是一个 first-wins HTTP
 `search_tools` / `describe_tool` / `call_tool`（或 REST `/v1/*`）
 路由到正确的后端，同时将服务器推送的通知多路复用回原始客户端会话。
 
+可以在每个候选进程上设置 `gateway_name`、`--gateway-name` 或
+`DCC_MCP_GATEWAY_NAME` 来显式声明身份。赢得选举的进程会把这个标签写入
+`__gateway__` sentinel，并暴露在 `/admin/api/health.gateway.current`；
+challenger 会以 `gateway_role=challenger` 写入同类标签，因此排障时能同时
+看到当前网关和正在尝试接班的下一个候选。
+
+生产环境推荐机器级独立 gateway：
+
+```bash
+dcc-mcp-server gateway --port 9765 --name studio-gateway
+```
+
+Per-DCC sidecar 现在会在 `GET /health` 不可达时自动拉起这个进程。它们会
+在 registry 目录里使用单飞 `gateway-launch.lock`，因此三个 DCC 同时启动也
+最多只会 spawn 一个 gateway。使用 `dcc-mcp-server sidecar --no-ensure-gateway`
+可以关闭自动拉起；使用 `--legacy-gateway-election` 可以恢复旧的 per-DCC
+first-wins 选举。
+
 ## 拓扑
 
 ```


### PR DESCRIPTION
## Summary
- split the gateway into a standalone `dcc-mcp-server gateway` process and make sidecars auto-ensure it by default
- keep legacy sidecar gateway election behind `--legacy-gateway-election` for compatibility
- expose explicit gateway names/roles in health, admin UI, and CLI list output
- make admin logs bounded/non-blocking and reshape the dashboard around debugging signals

## Checks
- cargo check -p dcc-mcp-gateway -p dcc-mcp-http -p dcc-mcp-http-py -p dcc-mcp-server -p dcc-mcp-cli
- npm test (admin-ui)
- npm run build (admin-ui)
