### PR TITLE
fix: clarify gateway mcp auth hints

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/handlers/sse_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/sse_impl.rs
@@ -50,8 +50,12 @@ pub async fn handle_gateway_get(State(gs): State<GatewayState>, headers: HeaderM
 
     if !accepts_sse {
         return (
-            StatusCode::METHOD_NOT_ALLOWED,
-            Json(json!({"error": "This endpoint streams SSE. Set Accept: text/event-stream"})),
+            StatusCode::NOT_ACCEPTABLE,
+            Json(json!({
+                "error": "This endpoint streams SSE. Set Accept: text/event-stream",
+                "auth_required": false,
+                "hint": "Use POST /mcp with Accept: application/json, text/event-stream for JSON-RPC requests."
+            })),
         )
             .into_response();
     }
@@ -134,4 +138,82 @@ fn make_session_stream(
             .to_owned();
         Some(Ok::<Event, Infallible>(Event::default().data(payload)))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+    use axum::http::{Request, header};
+    use axum::routing::get;
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::sync::{RwLock, broadcast, watch};
+    use tower::ServiceExt;
+
+    fn make_gateway_state() -> GatewayState {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = Arc::new(RwLock::new(
+            dcc_mcp_transport::discovery::file_registry::FileRegistry::new(dir.path()).unwrap(),
+        ));
+        let (yield_tx, _) = watch::channel(false);
+        let (events_tx, _) = broadcast::channel::<String>(8);
+        GatewayState {
+            registry,
+            stale_timeout: Duration::from_secs(30),
+            backend_timeout: Duration::from_secs(10),
+            async_dispatch_timeout: Duration::from_secs(60),
+            wait_terminal_timeout: Duration::from_secs(600),
+            server_name: "test-gateway".into(),
+            server_version: "0.0.0-test".into(),
+            own_host: "127.0.0.1".into(),
+            own_port: 9765,
+            http_client: reqwest::Client::new(),
+            yield_tx: Arc::new(yield_tx),
+            events_tx: Arc::new(events_tx),
+            protocol_version: Arc::new(RwLock::new(None)),
+            resource_subscriptions: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            pending_calls: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            subscriber: crate::gateway::sse_subscriber::SubscriberManager::default(),
+            allow_unknown_tools: false,
+            adapter_version: None,
+            adapter_dcc: None,
+            capability_index: Arc::new(crate::gateway::capability::CapabilityIndex::new()),
+            event_log: Arc::new(crate::gateway::event_log::EventLog::new()),
+            #[cfg(feature = "prometheus")]
+            gateway_metrics: Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
+            middleware_chain: Arc::new(crate::gateway::middleware::MiddlewareChain::new()),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_mcp_without_sse_accept_is_protocol_hint_not_auth_challenge() {
+        let app = axum::Router::new()
+            .route("/mcp", get(handle_gateway_get))
+            .with_state(make_gateway_state());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/mcp")
+                    .header(header::ACCEPT, "application/json")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_ACCEPTABLE);
+        assert!(
+            response.headers().get(header::WWW_AUTHENTICATE).is_none(),
+            "Accept negotiation failures must not trigger browser/client login flows"
+        );
+        let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let body: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["auth_required"], false);
+        assert!(
+            body["hint"].as_str().unwrap().contains("POST /mcp"),
+            "expected actionable POST /mcp hint, got {body}"
+        );
+    }
 }

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -4,8 +4,8 @@
 >
 > **[中文版](../zh/api/auth.md)**
 
-Declarative authentication configuration for remote MCP servers. Provides
-Bearer-token ("API key") auth for studio environments and OAuth 2.1 +
+Declarative authentication helpers for remote MCP servers. Provides
+Bearer-token ("API key") validation helpers for studio environments and OAuth 2.1 +
 [CIMD (Client ID Metadata Documents)](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#client-id-metadata-documents)
 for production cloud deployments.
 
@@ -40,7 +40,6 @@ Configuration dataclass for Bearer-token auth.
 ```python
 cfg = ApiKeyConfig(env_var="MY_MCP_SECRET")
 token = cfg.resolve()   # field → env var → None
-mcp_cfg.api_key = token
 ```
 
 ## `OAuthConfig`
@@ -118,18 +117,18 @@ token = generate_api_key()            # "xZ3qB2..." — use as DCC_MCP_API_KEY
 
 ## Integration path
 
-Today these types are **declarative configuration objects** consumed either
-by (a) Python tool handlers calling `validate_bearer_token` directly, or
-(b) the `McpHttpConfig.api_key` field (Bearer-token path, supported now).
+Today these types are **declarative configuration objects** consumed by Python
+tool handlers calling `validate_bearer_token` directly, or by deployment code
+that configures an edge proxy.
 
 Full Rust-side enforcement of the `/.well-known/oauth-client-metadata`
 endpoint and the `/mcp` Bearer check is tracked in issue
-[#408](https://github.com/loonghao/dcc-mcp-core/issues/408). API keys work
-today; OAuth is opt-in via `McpHttpConfig(enable_oauth=True)` once the
-Rust layer lands.
+[#408](https://github.com/loonghao/dcc-mcp-core/issues/408). Until that lands,
+do not treat `McpHttpConfig` as an auth boundary; enforce API keys or OAuth in
+a reverse proxy / dedicated MCP OAuth gateway.
 
 ## See also
 
 - [Remote Server guide](../guide/remote-server.md) — end-to-end deployment
-- [`McpHttpConfig.api_key`](./http.md) — how the server consumes the token
+- [Remote Server guide](../guide/remote-server.md#auth) — edge-auth deployment guidance
 - [MCP authorization spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)

--- a/docs/guide/remote-server.md
+++ b/docs/guide/remote-server.md
@@ -56,17 +56,15 @@ print(handle.mcp_url())        # "http://0.0.0.0:8765/mcp"
 | `host` | `"0.0.0.0"` | Bind to all interfaces (default `"127.0.0.1"` = localhost only) |
 | `port` | `8765` | Must be accessible through firewall / NAT |
 | `enable_cors` | `True` | Required for browser and Claude.ai web clients |
-| `allowed_origins` | `["*"]` | Restrict to specific client origins in production |
 | `spawn_mode` | `"dedicated"` | Always use `"dedicated"` for PyO3-embedded hosts |
-| `api_key` | env var | Optional Bearer token auth (see [Auth](#auth)) |
-| `enable_oauth` | `False` | OAuth 2.1 + CIMD auth (see [OAuth](#oauth--cimd)) |
+| Edge auth | reverse proxy | Terminate TLS and enforce auth before traffic reaches `/mcp` |
+| OAuth | external gateway | Use a standards-compliant OAuth proxy until native MCP OAuth lands |
 
 ```python
 cfg = McpHttpConfig(
     host="0.0.0.0",
     port=8765,
     enable_cors=True,
-    allowed_origins=["https://claude.ai", "https://cursor.sh"],
     spawn_mode="dedicated",    # always for DCC-embedded hosts
 )
 ```
@@ -75,22 +73,58 @@ cfg = McpHttpConfig(
 
 ## Auth
 
-### API Key (simplest)
+Native `McpHttpServer` / gateway auth enforcement is not implemented yet.
+The Python `ApiKeyConfig` and `OAuthConfig` helpers are declarative helpers for
+tool authors and future server wiring; setting `cfg.api_key` or
+`cfg.enable_oauth` is not a supported runtime security boundary today.
+
+For internet-facing deployments, put the MCP endpoint behind a reverse proxy
+or a dedicated OAuth gateway and keep the DCC process itself bound to
+localhost. Avoid HTTP Basic Auth on `/mcp`: browser-based clients often render
+that as a generic "login required" prompt, and it is easy to confuse with MCP
+OAuth. If Basic Auth is needed for observability, scope it to `/metrics` only.
+
+### Bearer Token at the Edge
 
 For studio environments where OAuth is impractical:
 
-```python
-import os
-cfg = McpHttpConfig(port=8765, host="0.0.0.0")
-cfg.api_key = os.environ.get("DCC_MCP_API_KEY")  # Bearer token
+```nginx
+map $http_authorization $mcp_authorized {
+    default 0;
+    "Bearer change-me" 1;
+}
+
+server {
+    listen 443 ssl;
+    server_name mcp.example.com;
+
+    location /mcp {
+        # Prefer njs/lua/auth_request for production; this compact example
+        # shows the contract only.
+        if ($mcp_authorized = 0) { return 401; }
+        proxy_pass http://127.0.0.1:8765;
+        proxy_http_version 1.1;
+        proxy_buffering off;
+        proxy_cache off;
+    }
+
+    # Keep metrics separate so Basic auth challenges never apply to /mcp.
+    location /metrics {
+        auth_basic "dcc-mcp metrics";
+        auth_basic_user_file /etc/nginx/.htpasswd;
+        proxy_pass http://127.0.0.1:8765;
+    }
+}
 ```
 
 Clients include `Authorization: Bearer <key>` in every request.
 
-### OAuth 2.1 + CIMD (recommended for production)
+### OAuth 2.1
 
-See [CIMD OAuth guide](remote-server.md#oauth--cimd) below and issue #408.
-Enable with `McpHttpConfig(enable_oauth=True)`.
+Use an external MCP-aware OAuth proxy/gateway for production OAuth today. Native
+OAuth protected-resource metadata, `WWW-Authenticate: Bearer
+resource_metadata=...`, and token validation for `/mcp` are tracked as future
+work in issue #408.
 
 ---
 
@@ -102,17 +136,13 @@ CORS headers are required whenever the MCP client runs in a browser
 ```python
 cfg = McpHttpConfig(enable_cors=True)
 
-# Production: restrict to known origins
-cfg.allowed_origins = [
-    "https://claude.ai",
-    "https://cursor.sh",
-    "https://vscode.dev",
-]
+# Production: restrict origins at the reverse proxy until native allow-list
+# configuration is available on McpHttpConfig.
 ```
 
-When `enable_cors=True` and `allowed_origins` is empty (default), the server
-sends `Access-Control-Allow-Origin: *` — convenient for development but
-**not recommended for production**.
+When `enable_cors=True`, the server sends permissive CORS headers for browser
+clients. Restrict allowed origins in the reverse proxy for production
+deployments.
 
 ---
 
@@ -125,13 +155,11 @@ FROM python:3.14-slim
 RUN pip install dcc-mcp-core
 COPY skills/ /opt/skills/
 ENV DCC_MCP_SKILL_PATHS=/opt/skills
-ENV DCC_MCP_API_KEY=change-me
 EXPOSE 8765
 CMD ["python", "-c", "
 from dcc_mcp_core import create_skill_server, McpHttpConfig
 import os, time
 cfg = McpHttpConfig(host='0.0.0.0', port=8765, enable_cors=True)
-cfg.api_key = os.environ.get('DCC_MCP_API_KEY')
 server = create_skill_server('generic', cfg)
 handle = server.start()
 print(handle.mcp_url())
@@ -143,7 +171,7 @@ Build and run:
 
 ```bash
 docker build -t my-mcp-server .
-docker run -p 8765:8765 -e DCC_MCP_API_KEY=secret my-mcp-server
+docker run -p 127.0.0.1:8765:8765 my-mcp-server
 ```
 
 ---
@@ -154,7 +182,7 @@ See [`examples/remote-server/`](https://github.com/loonghao/dcc-mcp-core/tree/ma
 complete, deployable example that:
 
 - Starts a publicly reachable MCP server on `0.0.0.0:8765`
-- Enables CORS and API-key auth from environment variables
+- Enables CORS and is intended to sit behind an edge auth proxy
 - Includes a minimal `hello-world` skill
 - Ships a `Dockerfile` and `docker-compose.yml`
 
@@ -165,31 +193,33 @@ complete, deployable example that:
 Use this checklist when deploying a DCC adapter for remote access:
 
 - [ ] Server is bound to `0.0.0.0` (not just `127.0.0.1`)
-- [ ] Auth is configured: API key (`cfg.api_key`) or OAuth (`cfg.enable_oauth = True`)
-- [ ] CORS is enabled (`cfg.enable_cors = True`) with restricted `allowed_origins` in production
+- [ ] Auth is configured at the edge: Bearer-token proxy or OAuth gateway
+- [ ] CORS is enabled (`cfg.enable_cors = True`), with origins restricted at the reverse proxy in production
 - [ ] Tool descriptions follow the 3-layer behavioral structure (issue #341)
 - [ ] Tools are grouped by user intent, not 1:1 with API endpoints
 - [ ] `McpHttpConfig.spawn_mode = "dedicated"` for DCC-embedded hosts (Maya, Blender…)
 - [ ] Port 8765 is open in firewall / security group
 - [ ] TLS is terminated at a reverse proxy (nginx, Caddy, AWS ALB) for internet-facing deployments
-- [ ] `DCC_MCP_API_KEY` is set as an environment variable — never hardcoded
+- [ ] Secrets live in the reverse proxy / secret manager — never hardcoded
 - [ ] File logging is enabled (`enable_file_logging=True`, the default) for audit trails
 
 ---
 
 ## OAuth / CIMD
 
-> Full guide: issue #408 — CIMD OAuth support is planned for a future release.
+> Full guide: issue #408 — native MCP OAuth support is planned for a future
+> release.
 
-When `McpHttpConfig.enable_oauth = True`, the server will expose:
+Native support will expose:
 
 ```
+GET /.well-known/oauth-protected-resource
 GET /.well-known/oauth-client-metadata
 ```
 
-returning a CIMD document that enables automatic client registration with
-no manual client ID setup. This is the recommended approach for
-production cloud deployments.
+and validate `Authorization: Bearer <token>` on `/mcp`. Until then, deploy a
+standards-compliant OAuth proxy in front of dcc-mcp-core when cloud clients
+require MCP OAuth.
 
 Token injection via Claude Managed Agents Vaults: register OAuth tokens
 once in a Vault; the platform injects and refreshes credentials

--- a/docs/zh/api/auth.md
+++ b/docs/zh/api/auth.md
@@ -4,7 +4,7 @@
 >
 > **[English](../../api/auth.md)**
 
-远程 MCP 服务器的声明式认证配置。提供面向工作室/内网的 Bearer-token（API Key）认证，以及面向公网 SaaS 部署的 OAuth 2.1 + [CIMD（Client ID Metadata Documents）](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#client-id-metadata-documents) 动态客户端注册。
+远程 MCP 服务器的声明式认证 helper。提供面向工作室/内网的 Bearer-token（API Key）校验工具，以及面向公网 SaaS 部署的 OAuth 2.1 + [CIMD（Client ID Metadata Documents）](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#client-id-metadata-documents) 动态客户端注册对象。
 
 **如何选择**
 
@@ -37,7 +37,6 @@ Bearer Token 认证配置数据类。
 ```python
 cfg = ApiKeyConfig(env_var="MY_MCP_SECRET")
 token = cfg.resolve()   # 字段 → 环境变量 → None
-mcp_cfg.api_key = token
 ```
 
 ## `OAuthConfig`
@@ -106,12 +105,16 @@ def secure_handler(params, *, request_headers=None):
 
 ## 落地现状
 
-目前这些类型是**声明式配置对象**，服务于：(a) Python 工具处理器直接调用 `validate_bearer_token`；(b) `McpHttpConfig.api_key` 字段（Bearer Token 路径，当前已可用）。
+目前这些类型是**声明式配置对象**，服务于 Python 工具处理器直接调用
+`validate_bearer_token`，或由部署代码拿来配置边界代理。
 
-Rust 侧对 `/.well-known/oauth-client-metadata` 端点以及 `/mcp` 请求 Bearer 检查的完整支持，跟踪于 issue [#408](https://github.com/loonghao/dcc-mcp-core/issues/408)。API Key 路径立即可用；OAuth 路径在 Rust 层落地后通过 `McpHttpConfig(enable_oauth=True)` 开启。
+Rust 侧对 `/.well-known/oauth-client-metadata` 端点以及 `/mcp` 请求 Bearer
+检查的完整支持，跟踪于 issue [#408](https://github.com/loonghao/dcc-mcp-core/issues/408)。
+在它落地前，不要把 `McpHttpConfig` 当作认证边界；API key 或 OAuth 应在
+反向代理 / 专用 MCP OAuth 网关中 enforcement。
 
 ## 参见
 
 - [远程服务器指南](../guide/remote-server.md)
-- [`McpHttpConfig.api_key`](./http.md)
+- [远程服务器指南](../guide/remote-server.md#auth)
 - [MCP 认证规范](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)

--- a/docs/zh/guide/remote-server.md
+++ b/docs/zh/guide/remote-server.md
@@ -56,17 +56,15 @@ print(handle.mcp_url())        # "http://0.0.0.0:8765/mcp"
 | `host` | `"0.0.0.0"` | 绑定到所有接口（默认 `"127.0.0.1"` = 仅 localhost） |
 | `port` | `8765` | 必须可通过防火墙 / NAT 访问 |
 | `enable_cors` | `True` | 浏览器和 Claude.ai Web 客户端必需 |
-| `allowed_origins` | `["*"]` | 生产环境限制为特定客户端来源 |
 | `spawn_mode` | `"dedicated"` | PyO3 嵌入宿主始终使用 `"dedicated"` |
-| `api_key` | 环境变量 | 可选 Bearer token 认证（见 [Auth](#auth)） |
-| `enable_oauth` | `False` | OAuth 2.1 + CIMD 认证（见 [OAuth](#oauth--cimd)） |
+| 边界认证 | 反向代理 | 在流量到达 `/mcp` 前终止 TLS 并执行认证 |
+| OAuth | 外部网关 | 原生 MCP OAuth 落地前使用符合标准的 OAuth 代理 |
 
 ```python
 cfg = McpHttpConfig(
     host="0.0.0.0",
     port=8765,
     enable_cors=True,
-    allowed_origins=["https://claude.ai", "https://cursor.sh"],
     spawn_mode="dedicated",    # DCC 嵌入宿主始终使用
 )
 ```
@@ -75,22 +73,55 @@ cfg = McpHttpConfig(
 
 ## Auth
 
-### API Key（最简单）
+当前原生 `McpHttpServer` / gateway 尚未实现请求级认证 enforcement。
+Python 的 `ApiKeyConfig` 和 `OAuthConfig` 是给工具作者与未来服务器接线
+使用的声明式 helper；设置 `cfg.api_key` 或 `cfg.enable_oauth` 目前不是
+可依赖的运行时安全边界。
+
+面向互联网部署时，把 MCP 端点放在反向代理或专用 OAuth 网关后面，并让
+DCC 进程自身只绑定 localhost。避免在 `/mcp` 上使用 HTTP Basic Auth：
+浏览器类客户端通常会把它显示成通用“需要登录”，也容易和 MCP OAuth 混淆。
+如果观测端点需要 Basic Auth，请只作用于 `/metrics`。
+
+### 边界 Bearer Token
 
 对于 OAuth 不实用的工作室环境：
 
-```python
-import os
-cfg = McpHttpConfig(port=8765, host="0.0.0.0")
-cfg.api_key = os.environ.get("DCC_MCP_API_KEY")  # Bearer token
+```nginx
+map $http_authorization $mcp_authorized {
+    default 0;
+    "Bearer change-me" 1;
+}
+
+server {
+    listen 443 ssl;
+    server_name mcp.example.com;
+
+    location /mcp {
+        # 生产环境建议使用 njs/lua/auth_request；这里仅展示契约。
+        if ($mcp_authorized = 0) { return 401; }
+        proxy_pass http://127.0.0.1:8765;
+        proxy_http_version 1.1;
+        proxy_buffering off;
+        proxy_cache off;
+    }
+
+    # 单独保护 metrics，避免 Basic auth challenge 影响 /mcp。
+    location /metrics {
+        auth_basic "dcc-mcp metrics";
+        auth_basic_user_file /etc/nginx/.htpasswd;
+        proxy_pass http://127.0.0.1:8765;
+    }
+}
 ```
 
 客户端在每次请求中携带 `Authorization: Bearer <key>`。
 
-### OAuth 2.1 + CIMD（生产环境推荐）
+### OAuth 2.1
 
-见下方的 [CIMD OAuth 指南](remote-server.md#oauth--cimd) 和 issue #408。
-使用 `McpHttpConfig(enable_oauth=True)` 启用。
+生产环境 OAuth 目前请使用外部 MCP-aware OAuth 代理/网关。原生 OAuth
+protected-resource metadata、`WWW-Authenticate: Bearer resource_metadata=...`
+以及 `/mcp` token 校验仍在 issue #408 中跟踪。
 
 ---
 
@@ -102,17 +133,11 @@ cfg.api_key = os.environ.get("DCC_MCP_API_KEY")  # Bearer token
 ```python
 cfg = McpHttpConfig(enable_cors=True)
 
-# 生产环境：限制为已知来源
-cfg.allowed_origins = [
-    "https://claude.ai",
-    "https://cursor.sh",
-    "https://vscode.dev",
-]
+# 生产环境：在反向代理限制来源，直到 McpHttpConfig 提供原生 allow-list。
 ```
 
-当 `enable_cors=True` 且 `allowed_origins` 为空（默认）时，服务器
-发送 `Access-Control-Allow-Origin: *` —— 开发方便但
-**不推荐用于生产环境**。
+当 `enable_cors=True` 时，服务器会为浏览器客户端发送宽松的 CORS 头。
+生产环境请在反向代理限制允许来源。
 
 ---
 
@@ -125,13 +150,11 @@ FROM python:3.14-slim
 RUN pip install dcc-mcp-core
 COPY skills/ /opt/skills/
 ENV DCC_MCP_SKILL_PATHS=/opt/skills
-ENV DCC_MCP_API_KEY=change-me
 EXPOSE 8765
 CMD ["python", "-c", "
 from dcc_mcp_core import create_skill_server, McpHttpConfig
 import os, time
 cfg = McpHttpConfig(host='0.0.0.0', port=8765, enable_cors=True)
-cfg.api_key = os.environ.get('DCC_MCP_API_KEY')
 server = create_skill_server('generic', cfg)
 handle = server.start()
 print(handle.mcp_url())
@@ -143,7 +166,7 @@ while True: time.sleep(60)
 
 ```bash
 docker build -t my-mcp-server .
-docker run -p 8765:8765 -e DCC_MCP_API_KEY=secret my-mcp-server
+docker run -p 127.0.0.1:8765:8765 my-mcp-server
 ```
 
 ---
@@ -154,7 +177,7 @@ docker run -p 8765:8765 -e DCC_MCP_API_KEY=secret my-mcp-server
 完整的、可部署的示例，包含：
 
 - 在 `0.0.0.0:8765` 启动可公开访问的 MCP 服务器
-- 从环境变量启用 CORS 和 API-key 认证
+- 启用 CORS，并预期放在边界认证代理后
 - 包含一个最小的 `hello-world` skill
 - 提供 `Dockerfile` 和 `docker-compose.yml`
 
@@ -165,30 +188,31 @@ docker run -p 8765:8765 -e DCC_MCP_API_KEY=secret my-mcp-server
 为 DCC 适配器部署远程访问时使用此检查清单：
 
 - [ ] 服务器绑定到 `0.0.0.0`（而非仅 `127.0.0.1`）
-- [ ] 认证已配置：API key (`cfg.api_key`) 或 OAuth (`cfg.enable_oauth = True`)
-- [ ] CORS 已启用 (`cfg.enable_cors = True`)，且生产环境限制 `allowed_origins`
+- [ ] 认证已在边界配置：Bearer-token 代理或 OAuth 网关
+- [ ] CORS 已启用 (`cfg.enable_cors = True`)，且生产环境在反向代理限制来源
 - [ ] Tool 描述遵循 3 层行为结构（issue #341）
 - [ ] Tools 按用户意图分组，而非 1:1 对应 API 端点
 - [ ] DCC 嵌入宿主（Maya、Blender…）使用 `McpHttpConfig.spawn_mode = "dedicated"`
 - [ ] 防火墙 / 安全组中端口 8765 已开放
 - [ ] TLS 在反向代理（nginx、Caddy、AWS ALB）处终止，面向互联网的部署
-- [ ] `DCC_MCP_API_KEY` 设置为环境变量 —— 切勿硬编码
+- [ ] 密钥存放在反向代理 / secret manager 中 —— 切勿硬编码
 - [ ] 文件日志已启用（`enable_file_logging=True`，默认值）用于审计追踪
 
 ---
 
 ## OAuth / CIMD
 
-> 完整指南：issue #408 —— CIMD OAuth 支持计划在未来版本中推出。
+> 完整指南：issue #408 —— 原生 MCP OAuth 支持计划在未来版本中推出。
 
-当 `McpHttpConfig.enable_oauth = True` 时，服务器将暴露：
+原生支持将暴露：
 
 ```
+GET /.well-known/oauth-protected-resource
 GET /.well-known/oauth-client-metadata
 ```
 
-返回 CIMD 文档，实现无需手动客户端 ID 设置的自动客户端注册。
-这是生产环境云端部署的推荐方案。
+并在 `/mcp` 校验 `Authorization: Bearer <token>`。在此之前，如果云端
+客户端要求 MCP OAuth，请在 dcc-mcp-core 前部署符合标准的 OAuth 代理。
 
 通过 Claude Managed Agents Vaults 注入 Token：在 Vault 中注册一次 OAuth token；
 平台会为每个 MCP 连接自动注入和刷新凭证。

--- a/python/dcc_mcp_core/auth.py
+++ b/python/dcc_mcp_core/auth.py
@@ -25,10 +25,9 @@ Usage
 
     from dcc_mcp_core.auth import OAuthConfig, ApiKeyConfig, validate_bearer_token
 
-    # API key auth (simplest — no OAuth needed)
+    # API key helper (use at the edge today, or validate manually in a tool)
     import os
-    cfg = McpHttpConfig(port=8765)
-    cfg.api_key = os.environ.get("DCC_MCP_API_KEY")
+    api_key = ApiKeyConfig(env_var="DCC_MCP_API_KEY").resolve()
 
     # OAuth 2.1 + CIMD (recommended for production)
     oauth_cfg = OAuthConfig(
@@ -76,7 +75,7 @@ class TokenValidationError(Exception):
 
 @dataclasses.dataclass
 class ApiKeyConfig:
-    """Configuration for API-key (Bearer token) auth.
+    """Configuration for API-key (Bearer token) auth helpers.
 
     Args:
         api_key: The expected Bearer token.  ``None`` disables auth
@@ -90,7 +89,8 @@ class ApiKeyConfig:
     Example::
 
         cfg = ApiKeyConfig(env_var="MY_MCP_SECRET")
-        # In practice: set McpHttpConfig.api_key = cfg.resolve()
+        # In practice today: use cfg.resolve() in a reverse proxy config
+        # or pass the token to validate_bearer_token() in a tool handler.
 
     """
 


### PR DESCRIPTION
## Summary

- Return a protocol-specific 406 response for `GET /mcp` requests that do not accept SSE, with `auth_required: false` and a POST `/mcp` hint.
- Add a regression test ensuring this negotiation failure never emits `WWW-Authenticate`.
- Update remote auth docs in English and Chinese to distinguish current edge-auth guidance from planned native MCP OAuth support.

## Why

Some clients can present generic "login required" UI when protocol negotiation, Basic Auth, and MCP OAuth expectations are conflated. This clarifies the gateway response and removes docs that implied `McpHttpConfig.api_key` / `enable_oauth` are currently runtime auth boundaries.

## Validation

- `cargo fmt --check`
- `cargo test -p dcc-mcp-gateway get_mcp_without_sse_accept_is_protocol_hint_not_auth_challenge`
- pre-commit hook: `cargo clippy`