### PR TITLE
fix: thread-affinity and gateway backend diagnostics (#1075, #1076)

### DIFF
--- a/crates/dcc-mcp-actions/src/dispatch_context.rs
+++ b/crates/dcc-mcp-actions/src/dispatch_context.rs
@@ -1,0 +1,36 @@
+//! Optional execution context threaded through synchronous dispatches.
+//!
+//! HTTP/MCP layers set [`DispatchExecutionContext`] before calling
+//! [`crate::ToolDispatcher::dispatch`] so affinity violations can cite
+//! whether a host dispatcher was wired (issue #1075).
+
+use std::cell::Cell;
+
+/// Snapshot of the runtime environment for the current dispatch.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct DispatchExecutionContext {
+    /// `Some(true)` when a host `DccExecutorHandle` / queue dispatcher is
+    /// attached; `Some(false)` when the HTTP server has no main-thread bridge;
+    /// `None` when the caller did not set context (e.g. unit tests).
+    pub host_dispatcher_attached: Option<bool>,
+}
+
+thread_local! {
+    static EXECUTION_CONTEXT: Cell<Option<DispatchExecutionContext>> = const { Cell::new(None) };
+}
+
+/// Run `f` while publishing `ctx` to affinity diagnostics.
+pub fn with_execution_context<R>(ctx: DispatchExecutionContext, f: impl FnOnce() -> R) -> R {
+    EXECUTION_CONTEXT.with(|cell| {
+        let previous = cell.replace(Some(ctx));
+        let result = f();
+        cell.set(previous);
+        result
+    })
+}
+
+/// Return the context for the current thread, if any.
+#[must_use]
+pub fn current_execution_context() -> Option<DispatchExecutionContext> {
+    EXECUTION_CONTEXT.with(Cell::get)
+}

--- a/crates/dcc-mcp-actions/src/lib.rs
+++ b/crates/dcc-mcp-actions/src/lib.rs
@@ -1,6 +1,7 @@
 //! dcc-mcp-actions: ToolRegistry, EventBus, ToolDispatcher, ToolValidator, VersionedRegistry, ToolPipeline, ActionChain.
 
 pub mod chain;
+pub mod dispatch_context;
 pub mod dispatcher;
 pub mod events;
 pub mod pipeline;
@@ -12,6 +13,9 @@ pub mod validator;
 pub mod versioned;
 
 pub use chain::{ActionChain, ChainResult, ChainStepResult, ErrorAction};
+pub use dispatch_context::{
+    DispatchExecutionContext, current_execution_context, with_execution_context,
+};
 pub use dispatcher::{
     DispatchError, DispatchResult, HandlerFn, ToolDispatcher, current_thread_affinity,
     with_thread_affinity,

--- a/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
@@ -19,7 +19,6 @@ use crate::gateway::capability::RefreshReason;
 use crate::gateway::capability_service::refresh_all_live_backends;
 use crate::gateway::event_log::{ContendEvent, EventKind};
 use crate::gateway::resilience::{self as gw_resilience, gateway_limits};
-use crate::gateway::state::entry_to_json;
 use dcc_mcp_db::env::ENV_DCC_MCP_LOG_DIR;
 use dcc_mcp_db::read_gateway_log_dir_rows_recent;
 use dcc_mcp_transport::discovery::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry};
@@ -110,7 +109,7 @@ pub async fn handle_admin_instances(
             registry_view || !stale
         })
         .map(|e| {
-            let mut v = entry_to_json(&e, s.gateway.stale_timeout);
+            let mut v = s.gateway.instance_json(&e);
             match v["status"].as_str() {
                 Some("available" | "busy") => live_count += 1,
                 Some("stale") => {}

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -85,6 +85,9 @@ mod admin_tests {
             #[cfg(feature = "prometheus")]
             gateway_metrics: Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
             middleware_chain: Arc::new(crate::gateway::middleware::MiddlewareChain::new()),
+            instance_diagnostics: Arc::new(
+                crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
+            ),
         }
     }
 

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
@@ -153,6 +153,9 @@ async fn aggregate_tools_list_returns_only_minimal_gateway_surface() {
         #[cfg(feature = "prometheus")]
         gateway_metrics: std::sync::Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
         middleware_chain: std::sync::Arc::new(crate::gateway::middleware::MiddlewareChain::new()),
+        instance_diagnostics: std::sync::Arc::new(
+            crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
+        ),
     };
 
     assert_eq!(gs.live_instances(&*gs.registry.read().await).len(), 1);
@@ -315,6 +318,9 @@ async fn make_gateway_state(
         #[cfg(feature = "prometheus")]
         gateway_metrics: std::sync::Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
         middleware_chain: std::sync::Arc::new(crate::gateway::middleware::MiddlewareChain::new()),
+        instance_diagnostics: std::sync::Arc::new(
+            crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
+        ),
     }
 }
 
@@ -844,6 +850,9 @@ async fn gateway_state_with_instances(
         #[cfg(feature = "prometheus")]
         gateway_metrics: std::sync::Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
         middleware_chain: std::sync::Arc::new(crate::gateway::middleware::MiddlewareChain::new()),
+        instance_diagnostics: std::sync::Arc::new(
+            crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
+        ),
     };
     (state, dir, ids)
 }

--- a/crates/dcc-mcp-gateway/src/gateway/backend_client/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/backend_client/mod.rs
@@ -34,7 +34,9 @@ pub(crate) mod urls;
 #[cfg(test)]
 pub(crate) use probe::probe_mcp_health;
 #[allow(unused_imports)]
-pub(crate) use probe::{ProbeOutcome, probe_mcp_readiness, probe_readiness};
+pub(crate) use probe::{
+    ProbeOutcome, probe_mcp_readiness, probe_mcp_readiness_once, probe_readiness,
+};
 
 #[allow(unused_imports)]
 pub(crate) use urls::{health_url_from_mcp_url, readyz_url_from_mcp_url, rest_base_from_mcp_url};

--- a/crates/dcc-mcp-gateway/src/gateway/backend_client/probe.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/backend_client/probe.rs
@@ -76,6 +76,47 @@ pub(crate) async fn probe_readiness(
     resp.json::<ReadinessReport>().await.ok()
 }
 
+/// Map a parsed `/v1/readyz` body to a [`ProbeOutcome`] without another HTTP hop.
+#[must_use]
+pub(crate) fn probe_outcome_from_report(report: &ReadinessReport) -> ProbeOutcome {
+    if report.is_ready() {
+        ProbeOutcome::Ready
+    } else {
+        ProbeOutcome::Booting
+    }
+}
+
+/// Classify liveness with at most one `/v1/readyz` request.
+///
+/// When readyz is present, both the cached [`ReadinessReport`] and the
+/// [`ProbeOutcome`] are derived from that single response. Legacy backends
+/// without readyz fall back to `GET /health` only.
+pub(crate) async fn probe_mcp_readiness_once(
+    client: &reqwest::Client,
+    mcp_url: &str,
+    timeout: Duration,
+) -> (Option<ReadinessReport>, ProbeOutcome) {
+    if let Some(report) = probe_readiness(client, mcp_url, timeout).await {
+        let outcome = probe_outcome_from_report(&report);
+        return (Some(report), outcome);
+    }
+
+    let health_url = health_url_from_mcp_url(mcp_url);
+    let ok = client
+        .get(&health_url)
+        .timeout(timeout)
+        .header("accept", "application/json, text/event-stream")
+        .send()
+        .await
+        .is_ok_and(|resp| resp.status().is_success());
+    let outcome = if ok {
+        ProbeOutcome::Ready
+    } else {
+        ProbeOutcome::Unreachable
+    };
+    (None, outcome)
+}
+
 /// Classify a backend as [`Ready`] / [`Booting`] / [`Unreachable`] using
 /// the three-state probe introduced in #713.
 ///
@@ -97,27 +138,7 @@ pub(crate) async fn probe_mcp_readiness(
     mcp_url: &str,
     timeout: Duration,
 ) -> ProbeOutcome {
-    if let Some(report) = probe_readiness(client, mcp_url, timeout).await {
-        return if report.is_ready() {
-            ProbeOutcome::Ready
-        } else {
-            ProbeOutcome::Booting
-        };
-    }
-
-    let health_url = health_url_from_mcp_url(mcp_url);
-    let ok = client
-        .get(&health_url)
-        .timeout(timeout)
-        .header("accept", "application/json, text/event-stream")
-        .send()
-        .await
-        .is_ok_and(|resp| resp.status().is_success());
-    if ok {
-        ProbeOutcome::Ready
-    } else {
-        ProbeOutcome::Unreachable
-    }
+    probe_mcp_readiness_once(client, mcp_url, timeout).await.1
 }
 
 /// Return true when the target looks like a DCC MCP HTTP server.

--- a/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
@@ -53,6 +53,9 @@ pub struct ServiceError {
     /// Last known instance UUID when `kind = instance-offline`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub previous_instance_id: Option<String>,
+    /// Backend identity + readiness/dispatcher diagnostics (#1076).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backend: Option<Box<Value>>,
 }
 
 impl ServiceError {
@@ -64,7 +67,14 @@ impl ServiceError {
             candidates: Vec::new(),
             previous_status: None,
             previous_instance_id: None,
+            backend: None,
         }
+    }
+
+    /// Attach backend routing/diagnostics context (#1076).
+    pub fn with_backend(mut self, backend: Value) -> Self {
+        self.backend = Some(Box::new(backend));
+        self
     }
 
     /// Attach disambiguation candidates (for `kind = "ambiguous"`).
@@ -278,17 +288,39 @@ pub async fn call_service(
             Ok(result)
         }
         Err(e) => {
+            let backend_body = super::instance_diagnostics::parse_rest_error_json(&e);
+            let error_kind = backend_body
+                .as_ref()
+                .and_then(|b| b.get("kind"))
+                .and_then(|k| k.as_str())
+                .unwrap_or("backend-error");
+            gs.instance_diagnostics.record_call_error(
+                entry.instance_id,
+                error_kind,
+                e.chars().take(512).collect::<String>(),
+            );
+            let diag = gs.instance_diagnostics.get(&entry.instance_id);
+            let backend_attachment = super::instance_diagnostics::backend_error_attachment(
+                &entry,
+                &gs.gateway_mcp_url(),
+                diag.as_ref(),
+                backend_body.as_ref(),
+            );
             if is_host_died_backend_error(&e) {
                 record_host_died(gs, &entry, &record, &e);
                 return Err(ServiceError::new(
                     "host-died",
                     format!("backend host died during {}: {e}", record.callable_id),
-                ));
+                )
+                .with_backend(backend_attachment));
             }
-            Err(ServiceError::new(
-                "backend-error",
-                format!("backend call failed: {e}"),
-            ))
+            let kind = if error_kind == "thread-affinity-violation" {
+                "thread-affinity-violation"
+            } else {
+                "backend-error"
+            };
+            Err(ServiceError::new(kind, format!("backend call failed: {e}"))
+                .with_backend(backend_attachment))
         }
     }
 }
@@ -359,15 +391,17 @@ pub async fn refresh_all_live_backends(gs: &GatewayState, reason: RefreshReason)
 /// `to_text_result` envelope shape so MCP wrappers return the same
 /// error format as every other gateway meta-tool.
 pub fn service_error_to_json(err: &ServiceError) -> Value {
-    json!({
-        "error": {
-            "kind": err.kind,
-            "message": err.message,
-            "candidates": err.candidates,
-            "previous_status": err.previous_status,
-            "previous_instance_id": err.previous_instance_id,
-        }
-    })
+    let mut error = json!({
+        "kind": err.kind,
+        "message": err.message,
+        "candidates": err.candidates,
+        "previous_status": err.previous_status,
+        "previous_instance_id": err.previous_instance_id,
+    });
+    if let Some(backend) = &err.backend {
+        error["backend"] = (**backend).clone();
+    }
+    json!({ "error": error })
 }
 
 fn inject_call_instance_meta(result: &mut Value, entry: &ServiceEntry) {
@@ -612,6 +646,34 @@ mod unit_tests {
         );
         assert_eq!(result["_meta"]["dcc"]["instance_short"], "abcdef01");
         assert_eq!(result["_meta"]["dcc"]["display_id"], "maya@2026-abcdef01");
+    }
+
+    #[test]
+    fn backend_error_attachment_includes_readiness() {
+        let mut entry =
+            dcc_mcp_transport::discovery::types::ServiceEntry::new("maya", "127.0.0.1", 8765);
+        entry.display_name = Some("Maya-Rig".into());
+        let diag = crate::gateway::instance_diagnostics::InstanceDiagnostics {
+            readiness: Some(dcc_mcp_skill_rest::ReadinessReport {
+                process: true,
+                dispatcher: false,
+                dcc: true,
+            }),
+            ..Default::default()
+        };
+        let backend = crate::gateway::instance_diagnostics::backend_error_attachment(
+            &entry,
+            "http://127.0.0.1:9765/mcp",
+            Some(&diag),
+            None,
+        );
+        assert_eq!(backend["dcc_type"], "maya");
+        assert_eq!(backend["gateway_mcp_url"], "http://127.0.0.1:9765/mcp");
+        assert!(
+            !backend["diagnostics"]["readiness"]["dispatcher"]
+                .as_bool()
+                .unwrap()
+        );
     }
 
     #[test]

--- a/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
@@ -289,14 +289,19 @@ pub async fn call_service(
         }
         Err(e) => {
             let backend_body = super::instance_diagnostics::parse_rest_error_json(&e);
-            let error_kind = backend_body
-                .as_ref()
-                .and_then(|b| b.get("kind"))
-                .and_then(|k| k.as_str())
-                .unwrap_or("backend-error");
+            let kind = if is_host_died_backend_error(&e) {
+                "host-died"
+            } else {
+                backend_body
+                    .as_ref()
+                    .and_then(|b| b.get("kind"))
+                    .and_then(|k| k.as_str())
+                    .filter(|k| *k == "thread-affinity-violation")
+                    .unwrap_or("backend-error")
+            };
             gs.instance_diagnostics.record_call_error(
                 entry.instance_id,
-                error_kind,
+                kind,
                 e.chars().take(512).collect::<String>(),
             );
             let diag = gs.instance_diagnostics.get(&entry.instance_id);
@@ -306,21 +311,14 @@ pub async fn call_service(
                 diag.as_ref(),
                 backend_body.as_ref(),
             );
-            if is_host_died_backend_error(&e) {
+            if kind == "host-died" {
                 record_host_died(gs, &entry, &record, &e);
-                return Err(ServiceError::new(
-                    "host-died",
-                    format!("backend host died during {}: {e}", record.callable_id),
-                )
-                .with_backend(backend_attachment));
             }
-            let kind = if error_kind == "thread-affinity-violation" {
-                "thread-affinity-violation"
-            } else {
-                "backend-error"
-            };
-            Err(ServiceError::new(kind, format!("backend call failed: {e}"))
-                .with_backend(backend_attachment))
+            Err(ServiceError::new(
+                kind,
+                format!("backend call failed during {}: {e}", record.callable_id),
+            )
+            .with_backend(backend_attachment))
         }
     }
 }
@@ -674,6 +672,22 @@ mod unit_tests {
                 .as_bool()
                 .unwrap()
         );
+    }
+
+    #[test]
+    fn host_died_records_consistent_last_error_kind() {
+        let entry =
+            dcc_mcp_transport::discovery::types::ServiceEntry::new("maya", "127.0.0.1", 8765);
+        let store = crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new();
+        let err_msg = r#"http://127.0.0.1:8765: HTTP 502: {"kind":"host-died","message":"gone"}"#;
+        let kind = if is_host_died_backend_error(err_msg) {
+            "host-died"
+        } else {
+            "backend-error"
+        };
+        store.record_call_error(entry.instance_id, kind, err_msg);
+        let diag = store.get(&entry.instance_id).unwrap();
+        assert_eq!(diag.last_error.as_ref().unwrap().kind, "host-died");
     }
 
     #[test]

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/mod.rs
@@ -18,7 +18,7 @@ pub(crate) use tokio_stream::wrappers::BroadcastStream;
 pub(crate) use super::super::gateway::is_newer_version;
 pub(crate) use super::aggregator;
 pub(crate) use super::proxy::proxy_request;
-pub(crate) use super::state::{GatewayState, ResolveInstanceError, entry_to_json};
+pub(crate) use super::state::{GatewayState, ResolveInstanceError};
 pub(crate) use dcc_mcp_jsonrpc::negotiate_protocol_version;
 pub(crate) use dcc_mcp_transport::discovery::types::ServiceStatus;
 

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/resources.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/resources.rs
@@ -99,7 +99,7 @@ pub(super) async fn handle_resources_read(
 
     match found {
         Some(entry) => {
-            let detail = entry_to_json(&entry, gs.stale_timeout);
+            let detail = gs.instance_json(&entry);
             json!({
                 "jsonrpc": "2.0", "id": id,
                 "result": {
@@ -284,6 +284,9 @@ mod tests {
             event_log: log,
             middleware_chain: std::sync::Arc::new(
                 crate::gateway::middleware::MiddlewareChain::new(),
+            ),
+            instance_diagnostics: Arc::new(
+                crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
             ),
             #[cfg(feature = "prometheus")]
             gateway_metrics: Arc::new(crate::gateway::event_log::GatewayMetrics::new()),

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
@@ -112,7 +112,7 @@ pub async fn handle_instances(State(gs): State<GatewayState>) -> impl IntoRespon
     let instances: Vec<Value> = gs
         .live_instances(&registry)
         .into_iter()
-        .map(|entry| entry_to_json(&entry, gs.stale_timeout))
+        .map(|entry| gs.instance_json(&entry))
         .collect();
     Json(json!({ "total": instances.len(), "instances": instances }))
 }
@@ -183,10 +183,7 @@ pub async fn handle_v1_context(State(gs): State<GatewayState>) -> impl IntoRespo
     refresh_all_live_backends(&gs, RefreshReason::Periodic).await;
     let registry = gs.registry.read().await;
     let live_instances = gs.live_instances(&registry);
-    let instances: Vec<Value> = live_instances
-        .iter()
-        .map(|e| entry_to_json(e, gs.stale_timeout))
-        .collect();
+    let instances: Vec<Value> = live_instances.iter().map(|e| gs.instance_json(e)).collect();
     drop(registry);
     let records = gs.capability_index.snapshot().records;
     let loaded_skill_count = records
@@ -634,6 +631,9 @@ mod tests {
             capability_index: Arc::new(crate::gateway::capability::CapabilityIndex::new()),
             event_log: Arc::new(crate::gateway::event_log::EventLog::new()),
             middleware_chain: Arc::new(crate::gateway::middleware::MiddlewareChain::new()),
+            instance_diagnostics: Arc::new(
+                crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
+            ),
             #[cfg(feature = "prometheus")]
             gateway_metrics: Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
         }

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/sse_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/sse_impl.rs
@@ -183,6 +183,9 @@ mod tests {
             #[cfg(feature = "prometheus")]
             gateway_metrics: Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
             middleware_chain: Arc::new(crate::gateway::middleware::MiddlewareChain::new()),
+            instance_diagnostics: Arc::new(
+                crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
+            ),
         }
     }
 

--- a/crates/dcc-mcp-gateway/src/gateway/instance_diagnostics.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/instance_diagnostics.rs
@@ -1,0 +1,164 @@
+//! Per-backend diagnostics cached by the gateway (#1076).
+//!
+//! Populated by the health-check loop (readiness) and failed call paths
+//! (last error). Surfaced on `gateway://instances`, `GET /v1/instances`,
+//! and gateway-proxied error envelopes — not on successful search/call hits.
+
+use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use dcc_mcp_skill_rest::ReadinessReport;
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+use dcc_mcp_transport::discovery::types::ServiceEntry;
+
+/// Summary of the last failed backend call for an instance.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LastCallError {
+    pub kind: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub at_unix_secs: Option<u64>,
+}
+
+/// Cached diagnostics for one DCC backend row.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InstanceDiagnostics {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub readiness: Option<ReadinessReport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<LastCallError>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub probed_at_unix_secs: Option<u64>,
+}
+
+/// In-memory store keyed by `instance_id` (not persisted to `services.json`).
+#[derive(Debug, Default)]
+pub struct InstanceDiagnosticsStore {
+    inner: RwLock<HashMap<Uuid, InstanceDiagnostics>>,
+}
+
+impl InstanceDiagnosticsStore {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn record_readiness(&self, instance_id: Uuid, report: ReadinessReport) {
+        let now = unix_now_secs();
+        let mut map = self.inner.write();
+        let entry = map.entry(instance_id).or_default();
+        entry.readiness = Some(report);
+        entry.probed_at_unix_secs = Some(now);
+    }
+
+    pub fn record_call_error(
+        &self,
+        instance_id: Uuid,
+        kind: impl Into<String>,
+        message: impl Into<String>,
+    ) {
+        let mut map = self.inner.write();
+        let entry = map.entry(instance_id).or_default();
+        entry.last_error = Some(LastCallError {
+            kind: kind.into(),
+            message: message.into(),
+            at_unix_secs: Some(unix_now_secs()),
+        });
+    }
+
+    #[must_use]
+    pub fn get(&self, instance_id: &Uuid) -> Option<InstanceDiagnostics> {
+        self.inner.read().get(instance_id).cloned()
+    }
+
+    /// Compact JSON for instance list rows and error envelopes.
+    #[must_use]
+    pub fn to_json_value(diag: &InstanceDiagnostics) -> Value {
+        serde_json::to_value(diag).unwrap_or_else(|_| json!({}))
+    }
+}
+
+/// Build the `backend` object attached to gateway call errors.
+#[must_use]
+pub fn backend_error_attachment(
+    entry: &ServiceEntry,
+    gateway_mcp_url: &str,
+    diagnostics: Option<&InstanceDiagnostics>,
+    backend_body: Option<&Value>,
+) -> Value {
+    let direct_mcp_url = format!("http://{}:{}/mcp", entry.host, entry.port);
+    let mut backend = json!({
+        "instance_id": entry.instance_id.to_string(),
+        "display_id": entry.display_id(),
+        "dcc_type": entry.dcc_type,
+        "display_name": entry.display_name,
+        "adapter_version": entry.adapter_version,
+        "adapter_dcc": entry.adapter_dcc,
+        "mcp_url": direct_mcp_url,
+        "gateway_mcp_url": gateway_mcp_url,
+    });
+    if let Some(diag) = diagnostics {
+        backend["diagnostics"] = InstanceDiagnosticsStore::to_json_value(diag);
+    }
+    if let Some(body) = backend_body {
+        backend["error_body"] = body.clone();
+    }
+    backend
+}
+
+/// Try to extract a JSON `ServiceError` body from a REST forward failure string.
+#[must_use]
+pub fn parse_rest_error_json(err: &str) -> Option<Value> {
+    let json_start = err.find('{')?;
+    let slice = &err[json_start..];
+    let value: Value = serde_json::from_str(slice).ok()?;
+    if value.get("kind").is_some() {
+        Some(value)
+    } else {
+        None
+    }
+}
+
+fn unix_now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_rest_error_json_extracts_skill_rest_body() {
+        let err = r#"http://127.0.0.1:8765: HTTP 409 Conflict: {"kind":"thread-affinity-violation","message":"x"}"#;
+        let body = parse_rest_error_json(err).expect("json body");
+        assert_eq!(body["kind"], "thread-affinity-violation");
+    }
+
+    #[test]
+    fn store_records_readiness_and_last_error() {
+        let store = InstanceDiagnosticsStore::new();
+        let id = Uuid::new_v4();
+        store.record_readiness(
+            id,
+            ReadinessReport {
+                process: true,
+                dispatcher: false,
+                dcc: true,
+            },
+        );
+        store.record_call_error(id, "thread-affinity-violation", "boom");
+        let diag = store.get(&id).unwrap();
+        assert!(!diag.readiness.as_ref().unwrap().dispatcher);
+        assert_eq!(
+            diag.last_error.as_ref().unwrap().kind,
+            "thread-affinity-violation"
+        );
+    }
+}

--- a/crates/dcc-mcp-gateway/src/gateway/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/mod.rs
@@ -34,10 +34,13 @@
 pub mod aggregator;
 pub mod backend_client;
 pub mod capability;
+#[allow(clippy::result_large_err)]
+// ServiceError carries disambiguation candidates (#1076 backend attachment)
 pub mod capability_service;
 pub mod event_log;
 pub mod handlers;
 pub mod http_limits;
+pub mod instance_diagnostics;
 pub mod middleware;
 pub mod namespace;
 pub mod native_resources;

--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/agent_workflows.md
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/agent_workflows.md
@@ -52,6 +52,9 @@ For Maya behind the gateway, prefer **`search_skills`** → **`load_skill`** →
 | `gateway://instances` | Live DCC rows: `dcc_type`, `mcp_url`, health — use when routing or when the user names a product (Maya, Photoshop, Blender, …): map the name to **`dcc_type`** / a concrete instance, not to extra `tools/list` entries. |
 | `gateway://instances/{id}` | One row (full UUID or unique prefix). |
 | `gateway://diagnostics/*` | Gateway/backend health signals for operators and agents. |
+| `gateway://instances` rows | Each instance may include a `diagnostics` object (`readiness` bits from `/v1/readyz`, `last_error` from the most recent failed gateway-proxied call). |
+
+When a gateway-proxied `call_tool` / `POST /v1/call` fails with `thread-affinity-violation`, read `error.backend` for the selected instance id, direct `mcp_url` vs `gateway_mcp_url`, readiness (`process` / `dispatcher` / `dcc`), and the backend's structured `context` before retrying.
 | `gateway://catalog` | Public package index (optional discovery). |
 | `gateway://docs/agent-workflows` | **This** guide — re-fetch when instructions drift in a long session. |
 

--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/diagnostics.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/diagnostics.rs
@@ -7,7 +7,7 @@
 
 use serde_json::{Value, json};
 
-use super::super::state::{GatewayState, entry_to_json};
+use super::super::state::GatewayState;
 use super::util::{parse_query, split_uri};
 
 /// URI for the gateway-native process / instance health summary.
@@ -103,7 +103,7 @@ pub async fn build_payload(
                     } else {
                         unhealthy_count += 1;
                     }
-                    entry_to_json(e, gs.stale_timeout)
+                    gs.instance_json(e)
                 })
                 .collect();
 

--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/instances.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/instances.rs
@@ -7,7 +7,7 @@
 
 use serde_json::{Value, json};
 
-use super::super::state::{GatewayState, entry_to_json};
+use super::super::state::GatewayState;
 use super::util::{parse_bool, parse_query, split_uri};
 
 /// Root URI for the gateway-native instance list.
@@ -111,7 +111,7 @@ pub async fn build_payload(gs: &GatewayState, query: &Query) -> Result<Value, St
                     }
                     *include_stale || !stale
                 })
-                .map(|e| entry_to_json(e, gs.stale_timeout))
+                .map(|e| gs.instance_json(e))
                 .collect();
 
             instances.sort_by(|a, b| {
@@ -138,7 +138,7 @@ pub async fn build_payload(gs: &GatewayState, query: &Query) -> Result<Value, St
                     s == *instance_id || s.starts_with(instance_id.as_str())
                 })
                 .ok_or_else(|| format!("Instance '{instance_id}' not found"))?;
-            Ok(entry_to_json(entry, gs.stale_timeout))
+            Ok(gs.instance_json(entry))
         }
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state.rs
@@ -50,6 +50,7 @@ use tokio::sync::{RwLock, broadcast, watch};
 use uuid::Uuid;
 
 use super::event_log::EventLog;
+use super::instance_diagnostics::{InstanceDiagnostics, InstanceDiagnosticsStore};
 
 use dcc_mcp_transport::discovery::file_registry::FileRegistry;
 use dcc_mcp_transport::discovery::types::{ServiceEntry, ServiceStatus};
@@ -237,6 +238,9 @@ pub struct GatewayState {
     /// (issue #770). Empty by default; operators register middlewares via
     /// [`GatewayConfig::middleware_chain`] or the builder API.
     pub middleware_chain: Arc<MiddlewareChain>,
+
+    /// Cached per-instance readiness + last call error (#1076).
+    pub instance_diagnostics: Arc<InstanceDiagnosticsStore>,
 }
 
 impl GatewayState {
@@ -280,6 +284,19 @@ impl GatewayState {
             capability_index: &self.capability_index,
             event_log: &self.event_log,
         }
+    }
+
+    /// MCP URL for this gateway process.
+    #[must_use]
+    pub fn gateway_mcp_url(&self) -> String {
+        format!("http://{}:{}/mcp", self.own_host, self.own_port)
+    }
+
+    /// Serialize a registry row with optional cached diagnostics (#1076).
+    #[must_use]
+    pub fn instance_json(&self, e: &ServiceEntry) -> Value {
+        let diag = self.instance_diagnostics.get(&e.instance_id);
+        entry_to_json(e, self.stale_timeout, diag.as_ref())
     }
 
     /// Typed server-identity view (server/adapter metadata, protocol
@@ -449,14 +466,18 @@ fn entry_to_short(instance_id: &Uuid) -> String {
 /// longer routable.  The original `ServiceStatus` is preserved verbatim
 /// when the row is still live, and the redundant `stale: bool` field is
 /// kept for clients that prefer to branch on a boolean.
-pub fn entry_to_json(e: &ServiceEntry, stale_timeout: Duration) -> Value {
+pub fn entry_to_json(
+    e: &ServiceEntry,
+    stale_timeout: Duration,
+    diagnostics: Option<&InstanceDiagnostics>,
+) -> Value {
     let stale = e.is_stale(stale_timeout) || e.status == ServiceStatus::Stale;
     let status = if stale {
         "stale".to_string()
     } else {
         e.status.to_string()
     };
-    json!({
+    let mut row = json!({
         "instance_id":     e.instance_id.to_string(),
         // Derived `{dcc}@{version}-{short8}` (RFC #998 Addendum B).
         // Agents reading gateway://instances see DCC + version + short
@@ -492,7 +513,14 @@ pub fn entry_to_json(e: &ServiceEntry, stale_timeout: Duration) -> Value {
             "available": !stale && e.status == ServiceStatus::Available && e.lease_owner.is_none(),
         },
         "stale":           stale,
-    })
+    });
+    if let Some(diag) = diagnostics.filter(|d| {
+        d.readiness.is_some() || d.last_error.is_some() || d.probed_at_unix_secs.is_some()
+    }) {
+        row["diagnostics"] =
+            super::instance_diagnostics::InstanceDiagnosticsStore::to_json_value(diag);
+    }
+    row
 }
 
 #[cfg(test)]

--- a/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
@@ -48,6 +48,9 @@ fn test_gateway_state_with_own_and_unknown(
         #[cfg(feature = "prometheus")]
         gateway_metrics: Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
         middleware_chain: Arc::new(MiddlewareChain::new()),
+        instance_diagnostics: Arc::new(
+            crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
+        ),
     }
 }
 
@@ -396,7 +399,7 @@ async fn test_all_instances_keeps_stale_and_unknown() {
 fn test_entry_to_json_status_stale_for_aged_row() {
     let mut e = ServiceEntry::new("maya", "127.0.0.1", 18812);
     e.last_heartbeat = std::time::SystemTime::now() - Duration::from_secs(600);
-    let json = entry_to_json(&e, Duration::from_secs(30));
+    let json = entry_to_json(&e, Duration::from_secs(30), None);
     assert_eq!(json["status"].as_str(), Some("stale"));
     assert_eq!(json["stale"].as_bool(), Some(true));
 }
@@ -405,7 +408,7 @@ fn test_entry_to_json_status_stale_for_aged_row() {
 fn test_entry_to_json_status_stale_for_marked_row() {
     let mut e = ServiceEntry::new("maya", "127.0.0.1", 18812);
     e.status = ServiceStatus::Stale;
-    let json = entry_to_json(&e, Duration::from_secs(30));
+    let json = entry_to_json(&e, Duration::from_secs(30), None);
     assert_eq!(json["status"].as_str(), Some("stale"));
     assert_eq!(json["stale"].as_bool(), Some(true));
     assert_eq!(json["pool"]["available"].as_bool(), Some(false));
@@ -420,7 +423,7 @@ fn test_entry_to_json_includes_pool_state() {
         Some(std::time::SystemTime::now() + Duration::from_secs(60)),
     );
 
-    let json = entry_to_json(&e, Duration::from_secs(30));
+    let json = entry_to_json(&e, Duration::from_secs(30), None);
 
     assert_eq!(json["status"].as_str(), Some("busy"));
     assert_eq!(json["pool"]["capacity"].as_u64(), Some(2));
@@ -441,7 +444,7 @@ fn test_entry_to_json_includes_pool_state() {
 fn test_entry_to_json_includes_display_id_with_version() {
     let mut e = ServiceEntry::new("maya", "127.0.0.1", 18812);
     e.version = Some("2026".to_string());
-    let json = entry_to_json(&e, Duration::from_secs(30));
+    let json = entry_to_json(&e, Duration::from_secs(30), None);
 
     let display = json["display_id"]
         .as_str()
@@ -461,7 +464,7 @@ fn test_entry_to_json_includes_display_id_with_version() {
 fn test_entry_to_json_display_id_falls_back_to_unknown_version() {
     let mut e = ServiceEntry::new("figma", "127.0.0.1", 8765);
     e.version = None;
-    let json = entry_to_json(&e, Duration::from_secs(30));
+    let json = entry_to_json(&e, Duration::from_secs(30), None);
 
     let display = json["display_id"]
         .as_str()

--- a/crates/dcc-mcp-gateway/src/gateway/tasks.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tasks.rs
@@ -545,6 +545,9 @@ pub(crate) async fn start_gateway_tasks(
     // When `admin` feature is disabled the AuditMiddleware block is compiled
     // out, so `gw_state` is never mutated.  With `admin` enabled the block
     // below reassigns `gw_state.middleware_chain`, so `mut` is required.
+    let instance_diagnostics =
+        Arc::new(crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new());
+
     #[cfg_attr(not(feature = "admin"), allow(unused_mut))]
     let mut gw_state = GatewayState {
         registry: registry.clone(),
@@ -571,6 +574,7 @@ pub(crate) async fn start_gateway_tasks(
         #[cfg(feature = "prometheus")]
         gateway_metrics: gateway_metrics.clone(),
         middleware_chain: Arc::new(middleware_chain),
+        instance_diagnostics: instance_diagnostics.clone(),
     };
 
     // ── Admin UI state (#772, #864) ────────────────────────────────────────
@@ -773,6 +777,7 @@ pub(crate) async fn start_gateway_tasks(
         registry.clone(),
         http_client.clone(),
         contention_log.clone(),
+        instance_diagnostics,
         health_cfg,
     );
 

--- a/crates/dcc-mcp-gateway/src/gateway/tasks/health.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tasks/health.rs
@@ -58,19 +58,12 @@ pub(crate) fn spawn_health_check_task(
                 futures::future::join_all(entries.iter().map(|e| {
                     let url = format!("http://{}:{}/mcp", e.host, e.port);
                     async move {
-                        let report = crate::gateway::backend_client::probe_readiness(
+                        crate::gateway::backend_client::probe_mcp_readiness_once(
                             client,
                             &url,
                             Duration::from_secs(5),
                         )
-                        .await;
-                        let outcome = crate::gateway::backend_client::probe_mcp_readiness(
-                            client,
-                            &url,
-                            Duration::from_secs(5),
-                        )
-                        .await;
-                        (report, outcome)
+                        .await
                     }
                 }))
                 .await

--- a/crates/dcc-mcp-gateway/src/gateway/tasks/health.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tasks/health.rs
@@ -6,6 +6,8 @@ use tokio::sync::RwLock;
 use dcc_mcp_transport::discovery::file_registry::FileRegistry;
 use dcc_mcp_transport::discovery::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceStatus};
 
+use crate::gateway::instance_diagnostics::InstanceDiagnosticsStore;
+
 /// Configuration for the health-check task.
 pub(crate) struct HealthCheckConfig {
     pub own_host: String,
@@ -21,6 +23,7 @@ pub(crate) fn spawn_health_check_task(
     registry: Arc<RwLock<FileRegistry>>,
     http_client: reqwest::Client,
     event_log: Arc<crate::gateway::event_log::EventLog>,
+    instance_diagnostics: Arc<InstanceDiagnosticsStore>,
     cfg: HealthCheckConfig,
 ) -> tokio::task::JoinHandle<()> {
     let effective_interval_secs = std::env::var("DCC_MCP_GATEWAY_HEALTH_INTERVAL_SECS")
@@ -55,18 +58,28 @@ pub(crate) fn spawn_health_check_task(
                 futures::future::join_all(entries.iter().map(|e| {
                     let url = format!("http://{}:{}/mcp", e.host, e.port);
                     async move {
-                        crate::gateway::backend_client::probe_mcp_readiness(
+                        let report = crate::gateway::backend_client::probe_readiness(
                             client,
                             &url,
                             Duration::from_secs(5),
                         )
-                        .await
+                        .await;
+                        let outcome = crate::gateway::backend_client::probe_mcp_readiness(
+                            client,
+                            &url,
+                            Duration::from_secs(5),
+                        )
+                        .await;
+                        (report, outcome)
                     }
                 }))
                 .await
             };
 
-            for (entry, outcome) in entries.iter().zip(probe_results) {
+            for (entry, (readiness_report, outcome)) in entries.iter().zip(probe_results) {
+                if let Some(report) = readiness_report {
+                    instance_diagnostics.record_readiness(entry.instance_id, report);
+                }
                 let key = format!("{}:{}", entry.dcc_type, entry.instance_id);
                 let id8 = entry.instance_id.to_string()[..8].to_string();
 

--- a/crates/dcc-mcp-gateway/src/gateway/tools.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tools.rs
@@ -2,7 +2,7 @@
 
 use serde_json::{Value, json};
 
-use super::state::{GatewayState, entry_to_json};
+use super::state::GatewayState;
 use dcc_mcp_jsonrpc::coerce_tool_arguments_object;
 use dcc_mcp_transport::discovery::types::ServiceKey;
 
@@ -59,7 +59,7 @@ pub async fn tool_acquire_instance(gs: &GatewayState, args: &Value) -> Result<St
     serde_json::to_string_pretty(&json!({
         "success": true,
         "message": format!("Leased {dcc_type} instance {}", entry.instance_id),
-        "instance": entry_to_json(&entry, gs.stale_timeout),
+        "instance": gs.instance_json(&entry),
     }))
     .map_err(|e| e.to_string())
 }
@@ -99,7 +99,7 @@ pub async fn tool_release_instance(gs: &GatewayState, args: &Value) -> Result<St
                 "message": "This instance has no active pool lease in the shared registry.",
                 "hint": "Call acquire_dcc_instance first (same lease_owner string you plan to pass to release). release_dcc_instance only clears pool metadata in services.json — it does not close Maya or drop MCP connections.",
                 "instance_id": entry.instance_id.to_string(),
-                "instance": entry_to_json(&entry, gs.stale_timeout),
+                "instance": gs.instance_json(&entry),
             }))
             .unwrap_or_else(|_| "no_active_lease".to_string()));
         }
@@ -135,7 +135,7 @@ pub async fn tool_release_instance(gs: &GatewayState, args: &Value) -> Result<St
     serde_json::to_string_pretty(&json!({
         "success": true,
         "message": format!("Released lease for instance {}", released.instance_id),
-        "instance": entry_to_json(&released, gs.stale_timeout),
+        "instance": gs.instance_json(&released),
     }))
     .map_err(|e| e.to_string())
 }

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/thread_route.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/thread_route.rs
@@ -2,7 +2,9 @@
 
 use serde_json::Value;
 
-use dcc_mcp_actions::{DispatchError, DispatchResult};
+use dcc_mcp_actions::{
+    DispatchError, DispatchExecutionContext, DispatchResult, with_execution_context,
+};
 use dcc_mcp_models::ThreadAffinity;
 
 use crate::executor::DccExecutorHandle;
@@ -16,13 +18,16 @@ async fn run_on_main_thread(
     dispatcher: dcc_mcp_actions::ToolDispatcher,
     resolved_name: String,
     call_params: Value,
+    exec_ctx: DispatchExecutionContext,
 ) -> Result<DispatchResult, DispatchError> {
     let json_str = executor
         .execute(Box::new(move || {
-            encode_dispatch_wire(dcc_mcp_actions::with_thread_affinity(
-                ThreadAffinity::Main,
-                || dispatcher.dispatch(&resolved_name, call_params),
-            ))
+            with_execution_context(exec_ctx, || {
+                encode_dispatch_wire(dcc_mcp_actions::with_thread_affinity(
+                    ThreadAffinity::Main,
+                    || dispatcher.dispatch(&resolved_name, call_params),
+                ))
+            })
         }))
         .await
         .map_err(|e| DispatchError::HandlerError(e.to_string()))?;
@@ -33,9 +38,13 @@ async fn run_on_worker(
     dispatcher: dcc_mcp_actions::ToolDispatcher,
     resolved_name: String,
     call_params: Value,
+    exec_ctx: DispatchExecutionContext,
 ) -> Result<DispatchResult, DispatchError> {
-    let dispatch_fut =
-        tokio::task::spawn_blocking(move || dispatcher.dispatch(&resolved_name, call_params));
+    let dispatch_fut = tokio::task::spawn_blocking(move || {
+        with_execution_context(exec_ctx, || {
+            dispatcher.dispatch(&resolved_name, call_params)
+        })
+    });
     let cancel_wait = async {
         let deadline = tokio::time::Instant::now() + CANCEL_GRACE_PERIOD;
         loop {
@@ -65,14 +74,16 @@ pub async fn dispatch_action_with_thread_routing(
 ) -> Result<DispatchResult, DispatchError> {
     let executor_present = executor.is_some();
     let on_main = use_main_thread_route(thread_affinity, executor_present);
+    let exec_ctx = DispatchExecutionContext {
+        host_dispatcher_attached: Some(executor_present),
+    };
 
     if matches!(thread_affinity, ThreadAffinity::Main) && !executor_present {
         if enforce_thread_affinity {
-            return Err(DispatchError::HandlerError(
-                "THREAD_AFFINITY_UNAVAILABLE: tool declares thread_affinity=main, \
+            return Err(DispatchError::HandlerError(format!(
+                "THREAD_AFFINITY_UNAVAILABLE: action '{resolved_name}' declares thread_affinity=main, \
                  but no DeferredExecutor is wired"
-                    .to_string(),
-            ));
+            )));
         }
         tracing::warn!(
             tool = %resolved_name,
@@ -83,9 +94,16 @@ pub async fn dispatch_action_with_thread_routing(
 
     if on_main {
         let executor = executor.expect("executor presence gated by use_main_thread_route");
-        run_on_main_thread(executor, dispatcher, resolved_name.to_string(), call_params).await
+        run_on_main_thread(
+            executor,
+            dispatcher,
+            resolved_name.to_string(),
+            call_params,
+            exec_ctx,
+        )
+        .await
     } else {
-        run_on_worker(dispatcher, resolved_name.to_string(), call_params).await
+        run_on_worker(dispatcher, resolved_name.to_string(), call_params, exec_ctx).await
     }
 }
 

--- a/crates/dcc-mcp-http-server/src/thread_routed_invoker.rs
+++ b/crates/dcc-mcp-http-server/src/thread_routed_invoker.rs
@@ -8,7 +8,7 @@
 
 use std::sync::Arc;
 
-use dcc_mcp_actions::ToolDispatcher;
+use dcc_mcp_actions::{DispatchExecutionContext, ToolDispatcher, with_execution_context};
 use dcc_mcp_skill_rest::{
     CallOutcome, ServiceError, ServiceErrorKind, ToolInvoker, ToolSlug,
     dispatch_error_to_service_error,
@@ -70,18 +70,25 @@ impl ToolInvoker for ThreadRoutedInvoker {
         // panics. Hop to a plain OS thread and block on the host-bridge
         // runtime so `run_on_main_thread` can `.await` the bridge mpsc.
         let bridge_runtime = self.bridge_runtime.clone();
+        let host_dispatcher_attached = true;
         let dispatch_result = std::thread::scope(|scope| {
             let join = scope.spawn(move || {
-                bridge_runtime
-                    .block_on(dispatch_action_with_thread_routing(
-                        dispatcher.as_ref().clone(),
-                        Some(&executor),
-                        &action,
-                        params,
-                        affinity,
-                        enforce,
-                    ))
-                    .map_err(dispatch_error_to_service_error)
+                with_execution_context(
+                    DispatchExecutionContext {
+                        host_dispatcher_attached: Some(host_dispatcher_attached),
+                    },
+                    || {
+                        bridge_runtime.block_on(dispatch_action_with_thread_routing(
+                            dispatcher.as_ref().clone(),
+                            Some(&executor),
+                            &action,
+                            params,
+                            affinity,
+                            enforce,
+                        ))
+                    },
+                )
+                .map_err(dispatch_error_to_service_error)
             });
             join.join().map_err(|_| {
                 ServiceError::new(

--- a/crates/dcc-mcp-skill-rest/src/errors.rs
+++ b/crates/dcc-mcp-skill-rest/src/errors.rs
@@ -6,6 +6,7 @@
 //! it is surfaced straight to end users.
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use utoipa::ToSchema;
 
 /// Machine-readable error class. Kebab-case so new variants can be
@@ -83,6 +84,9 @@ pub struct ServiceError {
     /// Candidate slugs for `ambiguous` errors.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub candidates: Vec<String>,
+    /// Structured diagnostics (e.g. thread-affinity remediation, #1075).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context: Option<Box<Value>>,
 }
 
 impl ServiceError {
@@ -94,6 +98,7 @@ impl ServiceError {
             hint: None,
             request_id: None,
             candidates: Vec::new(),
+            context: None,
         }
     }
 
@@ -115,6 +120,13 @@ impl ServiceError {
     #[must_use]
     pub fn with_candidates(mut self, candidates: Vec<String>) -> Self {
         self.candidates = candidates;
+        self
+    }
+
+    /// Attach structured diagnostics (affinity remediation, etc.).
+    #[must_use]
+    pub fn with_context(mut self, context: Value) -> Self {
+        self.context = Some(Box::new(context));
         self
     }
 
@@ -140,6 +152,7 @@ mod tests {
             ServiceErrorKind::BadRequest,
             ServiceErrorKind::BackendError,
             ServiceErrorKind::AffinityViolation,
+            ServiceErrorKind::ThreadAffinityViolation,
             ServiceErrorKind::NotReady,
             ServiceErrorKind::Internal,
         ] {
@@ -166,6 +179,7 @@ mod tests {
         assert!(v.get("hint").is_none());
         assert!(v.get("candidates").is_none());
         assert!(v.get("request_id").is_none());
+        assert!(v.get("context").is_none());
     }
 
     #[test]

--- a/crates/dcc-mcp-skill-rest/src/lib.rs
+++ b/crates/dcc-mcp-skill-rest/src/lib.rs
@@ -70,6 +70,7 @@ pub mod openapi;
 mod readiness;
 mod router;
 mod service;
+mod thread_affinity_diagnostics;
 
 #[cfg(test)]
 mod tests;

--- a/crates/dcc-mcp-skill-rest/src/service.rs
+++ b/crates/dcc-mcp-skill-rest/src/service.rs
@@ -21,8 +21,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use utoipa::ToSchema;
 
-use dcc_mcp_actions::current_execution_context;
 use dcc_mcp_actions::dispatcher::{DispatchError, ToolDispatcher};
+use dcc_mcp_actions::{
+    DispatchExecutionContext, current_execution_context, with_execution_context,
+};
 use dcc_mcp_skills::SkillCatalog;
 
 use super::errors::{ServiceError, ServiceErrorKind};
@@ -629,14 +631,21 @@ pub fn dispatch_error_to_service_error(err: DispatchError) -> ServiceError {
 
 impl ToolInvoker for DispatcherInvoker {
     fn invoke(&self, action_name: &str, params: Value) -> Result<CallOutcome, ServiceError> {
-        match self.dispatcher.dispatch(action_name, params) {
-            Ok(r) => Ok(CallOutcome {
-                slug: ToolSlug(r.action.clone()),
-                output: r.output,
-                validation_skipped: r.validation_skipped,
-            }),
-            Err(err) => Err(dispatch_error_to_service_error(err)),
-        }
+        // Default REST path has no host main-thread bridge — publish that so
+        // affinity diagnostics can surface host_dispatcher_attached=false (#1075).
+        let exec_ctx = DispatchExecutionContext {
+            host_dispatcher_attached: Some(false),
+        };
+        with_execution_context(exec_ctx, || {
+            match self.dispatcher.dispatch(action_name, params) {
+                Ok(r) => Ok(CallOutcome {
+                    slug: ToolSlug(r.action.clone()),
+                    output: r.output,
+                    validation_skipped: r.validation_skipped,
+                }),
+                Err(err) => Err(dispatch_error_to_service_error(err)),
+            }
+        })
     }
 }
 

--- a/crates/dcc-mcp-skill-rest/src/service.rs
+++ b/crates/dcc-mcp-skill-rest/src/service.rs
@@ -21,6 +21,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use utoipa::ToSchema;
 
+use dcc_mcp_actions::current_execution_context;
 use dcc_mcp_actions::dispatcher::{DispatchError, ToolDispatcher};
 use dcc_mcp_skills::SkillCatalog;
 
@@ -587,21 +588,36 @@ pub fn dispatch_error_to_service_error(err: DispatchError) -> ServiceError {
             action,
             declared,
             actual,
-        } => ServiceError::new(
-            ServiceErrorKind::ThreadAffinityViolation,
-            format!(
-                "THREAD_AFFINITY_VIOLATION: action '{action}' declared thread_affinity={declared} but ran on {actual}"
-            ),
-        )
-        .with_hint(
-            "check the action tools.yaml thread_affinity, or marshal through the host main-thread dispatcher",
-        ),
-        DispatchError::ValidationFailed(m) => {
-            ServiceError::new(ServiceErrorKind::InvalidParams, m)
+        } => {
+            let execution = current_execution_context();
+            let hint = crate::thread_affinity_diagnostics::thread_affinity_hint(
+                declared,
+                actual,
+                execution.and_then(|c| c.host_dispatcher_attached),
+            );
+            ServiceError::new(
+                ServiceErrorKind::ThreadAffinityViolation,
+                format!(
+                    "THREAD_AFFINITY_VIOLATION: action '{action}' declared thread_affinity={declared} but ran on {actual}"
+                ),
+            )
+            .with_hint(hint)
+            .with_context(crate::thread_affinity_diagnostics::build_thread_affinity_context(
+                &action, declared, actual, execution,
+            ))
         }
+        DispatchError::ValidationFailed(m) => ServiceError::new(ServiceErrorKind::InvalidParams, m),
         DispatchError::HandlerError(m) if m.starts_with("THREAD_AFFINITY_UNAVAILABLE:") => {
-            ServiceError::new(ServiceErrorKind::ThreadAffinityViolation, m)
-                .with_hint("attach a host QueueDispatcher/BlockingDispatcher before start()")
+            let action = m
+                .split('\'')
+                .nth(1)
+                .filter(|s| !s.is_empty())
+                .unwrap_or("unknown");
+            ServiceError::new(ServiceErrorKind::ThreadAffinityViolation, m.clone())
+                .with_hint(crate::thread_affinity_diagnostics::affinity_unavailable_hint())
+                .with_context(
+                    crate::thread_affinity_diagnostics::build_affinity_unavailable_context(action),
+                )
         }
         DispatchError::HandlerError(m) if m == "CANCELLED" => {
             ServiceError::new(ServiceErrorKind::BackendError, m)

--- a/crates/dcc-mcp-skill-rest/src/tests.rs
+++ b/crates/dcc-mcp-skill-rest/src/tests.rs
@@ -1095,3 +1095,41 @@ async fn job_events_with_real_controller_streams_and_cancels() {
     let resp = server.delete("/v1/jobs/known").await;
     resp.assert_status(axum::http::StatusCode::NO_CONTENT);
 }
+
+/// Thread-affinity violations must return structured remediation context (#1075).
+#[tokio::test]
+async fn call_thread_affinity_violation_includes_context() {
+    use dcc_mcp_models::ThreadAffinity;
+
+    let registry = Arc::new(ToolRegistry::new());
+    registry.register_action(ToolMeta {
+        name: "main_only".into(),
+        dcc: "maya".into(),
+        skill_name: Some("rig".into()),
+        enabled: true,
+        thread_affinity: ThreadAffinity::Main,
+        enforce_thread_affinity: true,
+        ..Default::default()
+    });
+    let dispatcher = Arc::new(ToolDispatcher::new((*registry).clone()));
+    dispatcher.register_handler("main_only", |_| Ok(json!({"ok": true})));
+    let catalog = Arc::new(SkillCatalog::new_with_dispatcher(
+        registry.clone(),
+        dispatcher.clone(),
+    ));
+    let _ = catalog.load_skill("rig");
+    let svc = SkillRestService::from_catalog_and_dispatcher(catalog, dispatcher);
+    let (server, _) = build_server(svc);
+
+    let resp = server
+        .post("/v1/call")
+        .json(&json!({"tool_slug": "maya.rig.main_only", "arguments": {}}))
+        .await;
+    assert_eq!(resp.status_code().as_u16(), 409);
+    let body: Value = resp.json();
+    assert_eq!(body["kind"], "thread-affinity-violation");
+    assert!(body["hint"].as_str().is_some());
+    let ctx = body["context"].as_object().expect("context object");
+    assert_eq!(ctx["declared_affinity"], "main");
+    assert_eq!(ctx["observed_affinity"], "any");
+}

--- a/crates/dcc-mcp-skill-rest/src/tests.rs
+++ b/crates/dcc-mcp-skill-rest/src/tests.rs
@@ -1132,4 +1132,6 @@ async fn call_thread_affinity_violation_includes_context() {
     let ctx = body["context"].as_object().expect("context object");
     assert_eq!(ctx["declared_affinity"], "main");
     assert_eq!(ctx["observed_affinity"], "any");
+    assert_eq!(ctx["host_dispatcher_attached"], false);
+    assert_eq!(ctx["observed_context"], "worker_no_dispatcher");
 }

--- a/crates/dcc-mcp-skill-rest/src/thread_affinity_diagnostics.rs
+++ b/crates/dcc-mcp-skill-rest/src/thread_affinity_diagnostics.rs
@@ -1,0 +1,157 @@
+//! Structured remediation payloads for thread-affinity failures (#1075).
+
+use dcc_mcp_actions::DispatchExecutionContext;
+use dcc_mcp_models::ThreadAffinity;
+use serde_json::{Value, json};
+
+/// Machine-readable context attached to `thread-affinity-violation` errors.
+#[must_use]
+pub fn build_thread_affinity_context(
+    action: &str,
+    declared: ThreadAffinity,
+    actual: ThreadAffinity,
+    execution: Option<DispatchExecutionContext>,
+) -> Value {
+    let host_dispatcher_attached = execution.and_then(|c| c.host_dispatcher_attached);
+    let observed_context = describe_observed_context(actual, host_dispatcher_attached);
+    json!({
+        "action": action,
+        "declared_affinity": declared.to_string(),
+        "observed_affinity": actual.to_string(),
+        "observed_context": observed_context,
+        "host_dispatcher_attached": host_dispatcher_attached,
+        "remediation": remediation_steps(declared, actual, host_dispatcher_attached),
+    })
+}
+
+/// Human-readable hint for the `hint` field on [`crate::ServiceError`].
+#[must_use]
+pub fn thread_affinity_hint(
+    declared: ThreadAffinity,
+    actual: ThreadAffinity,
+    host_dispatcher_attached: Option<bool>,
+) -> String {
+    match (declared, actual, host_dispatcher_attached) {
+        (ThreadAffinity::Main, ThreadAffinity::Any, Some(false)) => {
+            "This tool requires the DCC main thread but no host dispatcher is attached. \
+             In interactive hosts, load the DCC plugin or pass a UI dispatcher to start_server(); \
+             when using the gateway, confirm the backend instance is ready (dispatcher=true on GET /v1/readyz)."
+                .to_string()
+        }
+        (ThreadAffinity::Main, ThreadAffinity::Any, Some(true) | None) => {
+            "This tool requires the DCC main thread. Ensure calls are routed through the host \
+             dispatcher (plugin mode or MayaUiDispatcher + pump), not a raw Tokio worker."
+                .to_string()
+        }
+        _ => {
+            "Check the action tools.yaml thread_affinity and enforce_thread_affinity, or marshal \
+             through the host main-thread dispatcher."
+                .to_string()
+        }
+    }
+}
+
+/// Context for `THREAD_AFFINITY_UNAVAILABLE` handler errors.
+#[must_use]
+pub fn build_affinity_unavailable_context(action: &str) -> Value {
+    json!({
+        "action": action,
+        "declared_affinity": "main",
+        "observed_context": "no_host_dispatcher",
+        "host_dispatcher_attached": false,
+        "remediation": [
+            "Attach a host QueueDispatcher/BlockingDispatcher (or plugin bridge) before server.start().",
+            "For Maya GUI, prefer the bundled plugin + gateway (http://127.0.0.1:9765/mcp) instead of bare start_server(port=8765).",
+        ],
+    })
+}
+
+#[must_use]
+pub fn affinity_unavailable_hint() -> &'static str {
+    "Attach a host main-thread dispatcher before start(), or use the DCC plugin/gateway path that wires one automatically."
+}
+
+fn describe_observed_context(
+    actual: ThreadAffinity,
+    host_dispatcher_attached: Option<bool>,
+) -> &'static str {
+    match (actual, host_dispatcher_attached) {
+        (ThreadAffinity::Main, _) => "main",
+        (ThreadAffinity::Any, Some(false)) => "worker_no_dispatcher",
+        (ThreadAffinity::Any, Some(true)) => "worker",
+        (ThreadAffinity::Any, None) => "worker",
+    }
+}
+
+fn remediation_steps(
+    declared: ThreadAffinity,
+    actual: ThreadAffinity,
+    host_dispatcher_attached: Option<bool>,
+) -> Vec<&'static str> {
+    let mut steps = Vec::new();
+    if declared == ThreadAffinity::Main && actual == ThreadAffinity::Any {
+        steps.push(
+            "Route the call through the host main-thread dispatcher (plugin or explicit UI dispatcher).",
+        );
+        if host_dispatcher_attached == Some(false) {
+            steps.push(
+                "Wire HostExecutionBridge / DccExecutorHandle before starting the HTTP server.",
+            );
+            steps.push(
+                "When using the gateway, read gateway://instances and confirm readiness.dispatcher is true.",
+            );
+        }
+    }
+    if steps.is_empty() {
+        steps.push(
+            "Verify tools.yaml thread_affinity matches how the adapter executes the handler.",
+        );
+    }
+    steps
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn context_includes_dispatcher_flag() {
+        let ctx = build_thread_affinity_context(
+            "maya_scene__info",
+            ThreadAffinity::Main,
+            ThreadAffinity::Any,
+            Some(DispatchExecutionContext {
+                host_dispatcher_attached: Some(false),
+            }),
+        );
+        assert_eq!(ctx["declared_affinity"], "main");
+        assert_eq!(ctx["observed_context"], "worker_no_dispatcher");
+        assert_eq!(ctx["host_dispatcher_attached"], false);
+        assert!(ctx["remediation"].is_array());
+    }
+
+    #[test]
+    fn hint_mentions_dispatcher_when_missing() {
+        let hint = thread_affinity_hint(ThreadAffinity::Main, ThreadAffinity::Any, Some(false));
+        assert!(hint.contains("dispatcher"));
+        assert!(hint.contains("readyz") || hint.contains("gateway"));
+    }
+
+    #[test]
+    fn dispatch_error_maps_to_service_error_with_context() {
+        use dcc_mcp_actions::DispatchError;
+
+        use crate::ServiceErrorKind;
+        use crate::dispatch_error_to_service_error;
+
+        let err = DispatchError::ThreadAffinityViolation {
+            action: "main_only".into(),
+            declared: ThreadAffinity::Main,
+            actual: ThreadAffinity::Any,
+        };
+        let svc = dispatch_error_to_service_error(err);
+        assert_eq!(svc.kind, ServiceErrorKind::ThreadAffinityViolation);
+        let ctx = svc.context.expect("context");
+        assert_eq!(ctx["action"], "main_only");
+    }
+}

--- a/crates/dcc-mcp-skill-rest/src/thread_affinity_diagnostics.rs
+++ b/crates/dcc-mcp-skill-rest/src/thread_affinity_diagnostics.rs
@@ -131,6 +131,27 @@ mod tests {
     }
 
     #[test]
+    fn dispatch_error_maps_host_dispatcher_false_on_default_rest_path() {
+        use dcc_mcp_actions::{DispatchError, with_execution_context};
+
+        use crate::dispatch_error_to_service_error;
+
+        let err = DispatchError::ThreadAffinityViolation {
+            action: "main_only".into(),
+            declared: ThreadAffinity::Main,
+            actual: ThreadAffinity::Any,
+        };
+        let svc = with_execution_context(
+            DispatchExecutionContext {
+                host_dispatcher_attached: Some(false),
+            },
+            || dispatch_error_to_service_error(err),
+        );
+        let ctx = svc.context.expect("context");
+        assert_eq!(ctx["host_dispatcher_attached"], false);
+    }
+
+    #[test]
     fn hint_mentions_dispatcher_when_missing() {
         let hint = thread_affinity_hint(ThreadAffinity::Main, ThreadAffinity::Any, Some(false));
         assert!(hint.contains("dispatcher"));


### PR DESCRIPTION
## Summary

- **#1075**: Per-DCC REST 	hread-affinity-violation responses now include a structured context object (declared/observed affinity, host dispatcher attachment, remediation steps) and clearer hint text. HTTP/MCP dispatch paths publish DispatchExecutionContext so diagnostics know whether a main-thread bridge was wired.
- **#1076**: Gateway caches per-instance readiness from health probes and last call errors; gateway://instances / GET /v1/instances rows expose an optional diagnostics block. Gateway-proxied failures attach rror.backend with instance identity, direct vs gateway MCP URLs, readiness bits, and parsed backend error bodies.

## Test plan

- [x] cargo test -p dcc-mcp-skill-rest -p dcc-mcp-actions -p dcc-mcp-gateway -p dcc-mcp-http-server
- [ ] Reproduce Maya GUI affinity 409 via gateway; confirm rror.backend.diagnostics.readiness.dispatcher and backend context are present
- [ ] esources/read gateway://instances shows diagnostics after a failed proxied call