### PR TITLE
feat: add admin postmortem debug context

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/admin/activity.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/activity.rs
@@ -16,6 +16,9 @@ use super::state::{AdminAuditRecord, AdminState};
 use super::trace::DispatchTrace;
 use crate::gateway::event_log::ContendEvent;
 
+const POSTMORTEM_PREVIOUS_CALL_LIMIT: usize = 5;
+const POSTMORTEM_EVENT_LIMIT: usize = 10;
+
 #[derive(Debug, Clone, Serialize)]
 pub struct ActivityCorrelation {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -94,24 +97,19 @@ pub async fn build_debug_bundle(state: &AdminState, request_id: &str) -> Option<
     if audit.is_none() && trace.is_none() {
         return None;
     }
-    let related_activity: Vec<Value> = state
-        .gateway
-        .event_log
-        .recent_events(500)
+    let gateway_events = related_gateway_events(state, request_id, trace.as_ref());
+    let related_activity: Vec<Value> = gateway_events
+        .clone()
         .into_iter()
-        .filter(|event| {
-            event
-                .reason
-                .as_deref()
-                .is_some_and(|r| r.contains(request_id))
-        })
         .map(gateway_event_json)
         .collect();
+    let postmortem = build_postmortem(state, trace.as_ref(), gateway_events).await;
     Some(json!({
         "request_id": request_id,
         "audit": audit.map(|r| audit_event(&r)),
         "trace": trace,
         "related_activity": related_activity,
+        "postmortem": postmortem,
         "hints": debug_hints(trace.as_ref()),
     }))
 }
@@ -263,6 +261,130 @@ fn gateway_event(event: &ContendEvent) -> ActivityEvent {
 
 fn gateway_event_json(event: ContendEvent) -> Value {
     serde_json::to_value(gateway_event(&event)).unwrap_or_else(|_| json!({}))
+}
+
+fn related_gateway_events(
+    state: &AdminState,
+    request_id: &str,
+    trace: Option<&DispatchTrace>,
+) -> Vec<ContendEvent> {
+    state
+        .gateway
+        .event_log
+        .recent_events(500)
+        .into_iter()
+        .filter(|event| gateway_event_matches(event, request_id, trace))
+        .take(POSTMORTEM_EVENT_LIMIT)
+        .collect()
+}
+
+fn gateway_event_matches(
+    event: &ContendEvent,
+    request_id: &str,
+    trace: Option<&DispatchTrace>,
+) -> bool {
+    if event
+        .reason
+        .as_deref()
+        .is_some_and(|reason| reason.contains(request_id))
+    {
+        return true;
+    }
+    let Some(trace) = trace else {
+        return false;
+    };
+    if let Some(instance_id) = trace.instance_id.as_deref()
+        && instance_hint_matches(&event.instance_id, instance_id)
+    {
+        return true;
+    }
+    trace
+        .dcc_type
+        .as_deref()
+        .is_some_and(|dcc| event.dcc_type.eq_ignore_ascii_case(dcc))
+        && event.event.as_label() == "host_died"
+}
+
+async fn build_postmortem(
+    state: &AdminState,
+    trace: Option<&DispatchTrace>,
+    gateway_events: Vec<ContendEvent>,
+) -> Value {
+    let Some(trace) = trace else {
+        return json!({
+            "previous_calls": [],
+            "gateway_events": gateway_events.into_iter().map(gateway_event_json).collect::<Vec<_>>(),
+        });
+    };
+
+    let previous_calls: Vec<Value> = collect_traces(state, 1_000)
+        .await
+        .into_iter()
+        .filter(|candidate| candidate.request_id != trace.request_id)
+        .filter(|candidate| candidate.started_at <= trace.started_at)
+        .filter(|candidate| trace_matches_postmortem_scope(candidate, trace))
+        .take(POSTMORTEM_PREVIOUS_CALL_LIMIT)
+        .map(postmortem_trace_row)
+        .collect();
+
+    json!({
+        "target": postmortem_trace_row(trace.clone()),
+        "previous_calls": previous_calls,
+        "gateway_events": gateway_events.into_iter().map(gateway_event_json).collect::<Vec<_>>(),
+    })
+}
+
+fn trace_matches_postmortem_scope(candidate: &DispatchTrace, target: &DispatchTrace) -> bool {
+    if let (Some(a), Some(b)) = (
+        candidate.instance_id.as_deref(),
+        target.instance_id.as_deref(),
+    ) {
+        return instance_hint_matches(a, b);
+    }
+    if let (Some(a), Some(b)) = (
+        candidate.session_id.as_deref(),
+        target.session_id.as_deref(),
+    ) {
+        return a == b;
+    }
+    if let (Some(a), Some(b)) = (candidate.dcc_type.as_deref(), target.dcc_type.as_deref()) {
+        return a.eq_ignore_ascii_case(b);
+    }
+    false
+}
+
+fn postmortem_trace_row(trace: DispatchTrace) -> Value {
+    json!({
+        "request_id": trace.request_id,
+        "started_at": rfc3339(trace.started_at),
+        "tool": trace.tool_slug.unwrap_or(trace.method),
+        "dcc_type": trace.dcc_type,
+        "instance_id": trace.instance_id,
+        "session_id": trace.session_id,
+        "transport": trace.transport,
+        "agent_context": trace.agent_context,
+        "ok": trace.ok,
+        "total_ms": trace.total_ms,
+        "input": trace.input,
+        "output": trace.output,
+    })
+}
+
+fn instance_hint_matches(a: &str, b: &str) -> bool {
+    let a = normalise_instance_hint(a);
+    let b = normalise_instance_hint(b);
+    if a.is_empty() || b.is_empty() {
+        return false;
+    }
+    a == b || (a.len() >= 4 && b.starts_with(&a)) || (b.len() >= 4 && a.starts_with(&b))
+}
+
+fn normalise_instance_hint(value: &str) -> String {
+    value
+        .chars()
+        .filter(|c| c.is_ascii_hexdigit())
+        .flat_map(|c| c.to_lowercase())
+        .collect()
 }
 
 fn trace_correlation(trace: &DispatchTrace) -> ActivityCorrelation {

--- a/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
@@ -927,10 +927,21 @@ fn issue_report_json(request_id: &str, bundle: Value, links: Value) -> Value {
         .or_else(|| audit.get("duration_ms"))
         .cloned()
         .unwrap_or(Value::Null);
+    let postmortem = bundle.get("postmortem").cloned().unwrap_or(Value::Null);
+    let previous_call_count = postmortem
+        .get("previous_calls")
+        .and_then(Value::as_array)
+        .map(Vec::len)
+        .unwrap_or(0);
+    let gateway_event_count = postmortem
+        .get("gateway_events")
+        .and_then(Value::as_array)
+        .map(Vec::len)
+        .unwrap_or(0);
     let generated_at = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
     let title = format!("DCC-MCP request {request_id} {status}: {tool}");
     let body_template = format!(
-        "## Summary\n\nRequest `{request_id}` returned `{status}` for `{tool}` on `{dcc_type}`.\n\n## Attached data\n\nUpload this JSON export to the issue so maintainers can inspect trace spans, audit metadata, payload previews, and links.\n\n## Notes\n\nReview the JSON for secrets or proprietary scene paths before uploading."
+        "## Summary\n\nRequest `{request_id}` returned `{status}` for `{tool}` on `{dcc_type}`.\n\n## Attached data\n\nUpload this JSON export to the issue so maintainers can inspect trace spans, audit metadata, payload previews, postmortem context, and links.\n\n## Notes\n\nReview the JSON for secrets or proprietary scene paths before uploading."
     );
 
     json!({
@@ -944,6 +955,10 @@ fn issue_report_json(request_id: &str, bundle: Value, links: Value) -> Value {
             "tool": tool,
             "dcc_type": dcc_type,
             "total_ms": total_ms,
+            "postmortem": {
+                "previous_call_count": previous_call_count,
+                "gateway_event_count": gateway_event_count,
+            },
         },
         "github_issue": {
             "title": title,

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -10,7 +10,7 @@ mod admin_tests {
     use axum::body::to_bytes;
     use axum::http::{Request, StatusCode};
     use parking_lot::Mutex;
-    use serde_json::Value;
+    use serde_json::{Value, json};
     use tokio::sync::{RwLock, broadcast, watch};
     use tower::ServiceExt;
 
@@ -447,27 +447,55 @@ mod admin_tests {
 
     #[tokio::test]
     async fn test_admin_tasks_and_debug_bundle_from_trace() {
-        use crate::gateway::admin::trace::{DispatchTrace, TraceLog};
+        use crate::gateway::admin::trace::{DispatchTrace, TraceLog, TracePayload};
+        use crate::gateway::event_log::{ContendEvent, EventKind};
         use std::time::SystemTime;
 
         let traces = Arc::new(TraceLog::new(10));
+        let instance_id = "abcdef01-2345-6789-abcd-ef0123456789";
         traces.push(DispatchTrace {
-            request_id: "req-task".into(),
+            request_id: "req-prev".into(),
             method: "tools/call".into(),
-            tool_slug: Some("maya.inst.long_task".into()),
-            instance_id: Some("inst-1".into()),
+            tool_slug: Some("maya.abcdef01.save_scene".into()),
+            instance_id: Some(instance_id.into()),
             session_id: Some("session-1".into()),
             dcc_type: Some("maya".into()),
             transport: None,
             agent_context: None,
-            started_at: SystemTime::now(),
+            started_at: SystemTime::UNIX_EPOCH + Duration::from_millis(1_000),
+            total_ms: 12,
+            ok: true,
+            spans: vec![],
+            input: Some(TracePayload::from_value(
+                &json!({"file": "scene.ma", "token": "[REDACTED]"}),
+                1024,
+            )),
+            output: None,
+        });
+        traces.push(DispatchTrace {
+            request_id: "req-task".into(),
+            method: "tools/call".into(),
+            tool_slug: Some("maya.inst.long_task".into()),
+            instance_id: Some(instance_id.into()),
+            session_id: Some("session-1".into()),
+            dcc_type: Some("maya".into()),
+            transport: None,
+            agent_context: None,
+            started_at: SystemTime::UNIX_EPOCH + Duration::from_millis(2_000),
             total_ms: 25,
             ok: false,
             spans: vec![],
             input: None,
             output: None,
         });
-        let state = AdminState::new(make_gateway_state()).with_trace_log(traces, None);
+        let gateway = make_gateway_state();
+        gateway.event_log.push(ContendEvent::new(
+            EventKind::HostDied,
+            "maya",
+            "abcdef01",
+            Some("call=long_task display_id=maya@2026-abcdef01".into()),
+        ));
+        let state = AdminState::new(gateway).with_trace_log(traces, None);
         let router = build_admin_router(state);
 
         let (tasks_status, tasks_body) = body_json(router.clone(), "/api/tasks").await;
@@ -481,6 +509,19 @@ mod admin_tests {
         assert_eq!(bundle_body["request_id"], "req-task");
         assert!(bundle_body["trace"].is_object());
         assert!(bundle_body["related_activity"].is_array());
+        assert_eq!(
+            bundle_body["postmortem"]["previous_calls"][0]["request_id"],
+            "req-prev"
+        );
+        assert!(
+            bundle_body["postmortem"]["previous_calls"][0]["input"]["content"]
+                .as_str()
+                .is_some_and(|content| content.contains("[REDACTED]"))
+        );
+        assert_eq!(
+            bundle_body["postmortem"]["gateway_events"][0]["status"],
+            "host_died"
+        );
         assert!(bundle_body.get("related_logs").is_none());
         assert!(bundle_body["hints"].is_array());
         assert!(
@@ -507,6 +548,14 @@ mod admin_tests {
         );
         assert_eq!(report_body["request_id"], "req-task");
         assert_eq!(report_body["summary"]["status"], "failed");
+        assert_eq!(
+            report_body["summary"]["postmortem"]["previous_call_count"],
+            1
+        );
+        assert_eq!(
+            report_body["summary"]["postmortem"]["gateway_event_count"],
+            1
+        );
         assert_eq!(report_body["debug_bundle"]["request_id"], "req-task");
         assert!(
             report_body["github_issue"]["body_template"]

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -309,6 +309,18 @@ matching Scalar reference.
   "trace": { "request_id": "req-123", "spans": [] },
   "audit": { "request_id": "req-123", "success": true },
   "related_activity": [],
+  "postmortem": {
+    "target": { "request_id": "req-123", "tool": "maya.abcdef01.maya__open_scene" },
+    "previous_calls": [
+      {
+        "request_id": "req-122",
+        "tool": "maya.abcdef01.maya__save_scene",
+        "ok": true,
+        "input": { "mime_type": "application/json", "truncated": false, "content": "{...}" }
+      }
+    ],
+    "gateway_events": []
+  },
   "links": {
     "debug_bundle_url": "http://127.0.0.1:9765/admin/api/debug-bundle/req-123",
     "issue_report_url": "http://127.0.0.1:9765/admin/api/issue-report/req-123",
@@ -329,7 +341,11 @@ matching Scalar reference.
     "status": "failed",
     "tool": "maya.abcdef01.maya__open_scene",
     "dcc_type": "maya",
-    "total_ms": 48
+    "total_ms": 48,
+    "postmortem": {
+      "previous_call_count": 1,
+      "gateway_event_count": 0
+    }
   },
   "github_issue": {
     "title": "DCC-MCP request req-123 failed: maya.abcdef01.maya__open_scene",


### PR DESCRIPTION
## Summary
- add a postmortem section to admin debug bundles with the target request, recent same-instance calls, and matching gateway events
- surface postmortem counts in issue-report JSON for GitHub attachments
- document the debug bundle and issue report JSON shape

Refs #998

## Validation
- cargo test -p dcc-mcp-gateway --features admin --lib