### PR TITLE
ci: harden release publishing workflows

### DIFF
--- a/.github/workflows/release-please-pr-guard.yml
+++ b/.github/workflows/release-please-pr-guard.yml
@@ -1,0 +1,30 @@
+name: Release Please PR Guard
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate-release-pr:
+    name: Validate release PR metadata
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'release-please--branches--main')
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Check release-please PR consistency
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: python scripts/ci/check_release_please_pr.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,18 @@ jobs:
       tag_name: ${{ steps.decide.outputs.tag_name }}
       version: ${{ steps.decide.outputs.version }}
     steps:
+      - uses: actions/checkout@v6
+        if: github.event_name == 'push'
+
+      - name: Classify push release state
+        id: push-preflight
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: python scripts/ci/release_push_preflight.py
+
       - name: Validate manual release backfill inputs
         if: github.event_name == 'workflow_dispatch' && inputs.release_tag != ''
         env:
@@ -55,7 +67,9 @@ jobs:
           gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null
 
       - uses: googleapis/release-please-action@v5
-        if: github.event_name != 'workflow_dispatch' || inputs.release_tag == ''
+        if: >-
+          (github.event_name != 'workflow_dispatch' || inputs.release_tag == '') &&
+          steps.push-preflight.outputs.skip_release_please != 'true'
         id: release
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
@@ -70,11 +84,18 @@ jobs:
           RP_RELEASE_CREATED: ${{ steps.release.outputs.release_created }}
           RP_TAG_NAME: ${{ steps.release.outputs.tag_name }}
           RP_VERSION: ${{ steps.release.outputs.version }}
+          PREFLIGHT_RELEASE_CREATED: ${{ steps.push-preflight.outputs.release_created }}
+          PREFLIGHT_TAG_NAME: ${{ steps.push-preflight.outputs.tag_name }}
+          PREFLIGHT_VERSION: ${{ steps.push-preflight.outputs.version }}
         run: |
           if [ -n "$BACKFILL_TAG" ]; then
             release_created=true
             tag_name="$BACKFILL_TAG"
             version="$BACKFILL_VERSION"
+          elif [ "$PREFLIGHT_RELEASE_CREATED" = "true" ]; then
+            release_created=true
+            tag_name="$PREFLIGHT_TAG_NAME"
+            version="$PREFLIGHT_VERSION"
           else
             release_created="${RP_RELEASE_CREATED:-false}"
             tag_name="$RP_TAG_NAME"

--- a/scripts/ci/check_release_please_pr.py
+++ b/scripts/ci/check_release_please_pr.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Validate release-please PR metadata before it can be merged."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+SEMVER = r"[0-9]+(?:\.[0-9]+){2}(?:[-+][0-9A-Za-z.-]+)?"
+TITLE_RE = re.compile(rf"^chore\(main\): release (?P<version>{SEMVER})$")
+CHANGELOG_RE = re.compile(rf"^## \[(?P<version>{SEMVER})\]")
+
+
+def fail(message: str) -> None:
+    """Emit a GitHub Actions error and exit."""
+    print(f"::error::{message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def first_changelog_version(path: Path) -> str | None:
+    """Return the first release heading version from a changelog."""
+    if not path.exists():
+        return None
+    for line in path.read_text(encoding="utf-8").splitlines():
+        match = CHANGELOG_RE.match(line.strip())
+        if match:
+            return match.group("version")
+    return None
+
+
+def remote_tag_exists(repo: str, tag_name: str) -> bool:
+    """Return whether a tag ref exists on GitHub."""
+    result = subprocess.run(
+        ["gh", "api", f"repos/{repo}/git/ref/tags/{tag_name}"],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    if result.returncode == 0:
+        return True
+    if "Not Found" in result.stdout or '"status":"404"' in result.stdout:
+        return False
+    fail(f"could not check remote tag {tag_name}: {result.stdout.strip()}")
+
+
+def main() -> None:
+    """Validate the current checkout against pull request metadata."""
+    head_ref = os.environ.get("PR_HEAD_REF", "")
+    title = os.environ.get("PR_TITLE", "").strip()
+    if not head_ref.startswith("release-please--branches--main"):
+        print("Not a release-please branch; skipping.")
+        return
+
+    manifest_path = Path(".release-please-manifest.json")
+    if not manifest_path.exists():
+        fail(".release-please-manifest.json is missing")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest_version = manifest.get(".")
+    if not isinstance(manifest_version, str) or not manifest_version:
+        fail('.release-please-manifest.json must contain a "." package version')
+
+    title_match = TITLE_RE.match(title)
+    if not title_match:
+        fail(f"release PR title must match 'chore(main): release X.Y.Z', got: {title!r}")
+    title_version = title_match.group("version")
+    if title_version != manifest_version:
+        fail(
+            "release PR title/version drift: "
+            f"title has {title_version}, manifest has {manifest_version}. "
+            "Close the stale PR and let release-please regenerate it."
+        )
+
+    changelog_version = first_changelog_version(Path("CHANGELOG.md"))
+    if changelog_version and changelog_version != manifest_version:
+        fail(
+            f"CHANGELOG top release/version drift: CHANGELOG has {changelog_version}, manifest has {manifest_version}."
+        )
+
+    if os.environ.get("DCC_RELEASE_GUARD_SKIP_REMOTE") != "1":
+        repo = os.environ.get("GITHUB_REPOSITORY", "")
+        if not repo:
+            fail("GITHUB_REPOSITORY is required for remote tag validation")
+        tag_name = f"v{manifest_version}"
+        if remote_tag_exists(repo, tag_name):
+            fail(
+                f"remote tag {tag_name} already exists while this release PR is still open. "
+                "This PR is stale; close it and let release-please regenerate from main."
+            )
+
+    print(f"Release PR metadata is consistent for {manifest_version}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/release_push_preflight.py
+++ b/scripts/ci/release_push_preflight.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Classify push-triggered release workflow state before release-please runs."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Any
+
+SEMVER = r"[0-9]+(?:\.[0-9]+){2}(?:[-+][0-9A-Za-z.-]+)?"
+TITLE_RE = re.compile(rf"^chore\(main\): release (?P<version>{SEMVER})$")
+
+
+def fail(message: str) -> None:
+    """Emit a GitHub Actions error and exit."""
+    print(f"::error::{message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def emit(outputs: dict[str, str]) -> None:
+    """Write step outputs for GitHub Actions and echo them for logs."""
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    lines = [f"{key}={value}" for key, value in outputs.items()]
+    if output_path:
+        with Path(output_path).open("a", encoding="utf-8") as handle:
+            handle.write("\n".join(lines))
+            handle.write("\n")
+    for line in lines:
+        print(line)
+
+
+def load_manifest_version(path: Path) -> str:
+    """Load the root package version from the release-please manifest."""
+    manifest = json.loads(path.read_text(encoding="utf-8"))
+    version = manifest.get(".")
+    if not isinstance(version, str) or not version:
+        fail('.release-please-manifest.json must contain a "." package version')
+    return version
+
+
+def associated_pulls(repo: str, sha: str) -> list[dict[str, Any]]:
+    """Return pull requests associated with a commit SHA."""
+    override = os.environ.get("DCC_RELEASE_PREFLIGHT_PULLS_JSON")
+    if override is not None:
+        return json.loads(override)
+    result = subprocess.run(
+        [
+            "gh",
+            "api",
+            "-H",
+            "Accept: application/vnd.github+json",
+            f"repos/{repo}/commits/{sha}/pulls",
+        ],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    if result.returncode != 0:
+        fail(f"could not inspect associated pull requests: {result.stdout.strip()}")
+    return json.loads(result.stdout or "[]")
+
+
+def remote_release_exists(repo: str, tag_name: str) -> bool:
+    """Return whether a GitHub Release already exists for the tag."""
+    override = os.environ.get("DCC_RELEASE_PREFLIGHT_TAG_EXISTS")
+    if override is not None:
+        return override == "1"
+    result = subprocess.run(
+        ["gh", "release", "view", tag_name, "--repo", repo],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    if result.returncode == 0:
+        return True
+    if "release not found" in result.stdout.lower() or "not found" in result.stdout.lower():
+        return False
+    fail(f"could not check release {tag_name}: {result.stdout.strip()}")
+
+
+def release_pr_from(pulls: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Pick the release-please PR associated with the push commit, if any."""
+    for pull in pulls:
+        head_ref = str(pull.get("head", {}).get("ref", ""))
+        title = str(pull.get("title", ""))
+        if head_ref.startswith("release-please--branches--main") and TITLE_RE.match(title):
+            return pull
+    return None
+
+
+def main() -> None:
+    """Validate push-triggered release state and emit release decision hints."""
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    sha = os.environ.get("GITHUB_SHA", "")
+    if not repo or not sha:
+        fail("GITHUB_REPOSITORY and GITHUB_SHA are required")
+
+    manifest_version = load_manifest_version(Path(".release-please-manifest.json"))
+    pull = release_pr_from(associated_pulls(repo, sha))
+    if pull is None:
+        emit(
+            {
+                "skip_release_please": "false",
+                "release_created": "false",
+                "tag_name": "",
+                "version": "",
+            }
+        )
+        return
+
+    title = str(pull.get("title", ""))
+    match = TITLE_RE.match(title)
+    if match is None:
+        emit({"skip_release_please": "false", "release_created": "false", "tag_name": "", "version": ""})
+        return
+
+    title_version = match.group("version")
+    if title_version != manifest_version:
+        number = pull.get("number", "<unknown>")
+        fail(
+            f"stale release PR #{number}: title has {title_version}, "
+            f"manifest has {manifest_version}. Close/regenerate the release PR "
+            "before merging so release-please does not create the wrong tag."
+        )
+
+    tag_name = f"v{manifest_version}"
+    if remote_release_exists(repo, tag_name):
+        print(f"::notice::Release {tag_name} already exists; treating this run as an asset backfill.")
+        emit(
+            {
+                "skip_release_please": "true",
+                "release_created": "true",
+                "tag_name": tag_name,
+                "version": manifest_version,
+            }
+        )
+        return
+
+    emit(
+        {
+            "skip_release_please": "false",
+            "release_created": "false",
+            "tag_name": "",
+            "version": "",
+        }
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/clawhub_sync.py
+++ b/scripts/clawhub_sync.py
@@ -15,6 +15,7 @@ import dcc_mcp_core
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MANIFEST = REPO_ROOT / ".github" / "clawhub-skills.json"
 DEFAULT_CLI = os.environ.get("CLAWHUB_CLI_PACKAGE", "clawhub@0.7.0")
+CLAWHUB_LICENSE = "MIT-0"
 
 
 def parse_args() -> argparse.Namespace:
@@ -58,6 +59,21 @@ def skill_version(skill_dir: Path) -> str:
     return version
 
 
+def skill_license(skill_dir: Path) -> str:
+    """Return the top-level SKILL.md license identifier."""
+    skill_md = skill_dir / "SKILL.md"
+    lines = skill_md.read_text(encoding="utf-8").splitlines()
+    if not lines or lines[0].strip() != "---":
+        raise ValueError(f"missing YAML frontmatter in {skill_md}")
+    for line in lines[1:]:
+        stripped = line.strip()
+        if stripped == "---":
+            break
+        if stripped.startswith("license:"):
+            return stripped.split(":", 1)[1].strip().strip("'\"")
+    raise ValueError(f"missing top-level license in {skill_md}")
+
+
 def npx_cmd(cli: str, *args: str) -> list[str]:
     """Build an npx invocation argv list."""
     npx = os.environ.get("NPX", "npx")
@@ -83,6 +99,16 @@ def publish_one(
         return 1
 
     version = skill_version(skill_dir)
+    license_id = skill_license(skill_dir)
+    if license_id != CLAWHUB_LICENSE:
+        print(
+            f"ClawHub publishes skills under {CLAWHUB_LICENSE}; "
+            f"set 'license: {CLAWHUB_LICENSE}' in {skill_dir / 'SKILL.md'} "
+            f"(found {license_id!r}).",
+            file=sys.stderr,
+        )
+        return 1
+
     report = dcc_mcp_core.validate_skill(str(skill_dir))
     if not report.is_clean:
         print(f"validate_skill failed for {skill_dir}:", file=sys.stderr)

--- a/skills/dcc-cli-gateway/SKILL.md
+++ b/skills/dcc-cli-gateway/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   and invoke tools without speaking MCP directly. If dcc-mcp-cli is missing,
   ask for consent, download it from GitHub Releases, and fall back to Python
   stdlib REST only if download fails.
-license: MIT
+license: MIT-0
 compatibility: Cross-platform Windows/macOS/Linux. Prefers dcc-mcp-cli on PATH; can download release asset from GitHub; Python 3.7+ stdlib REST fallback. DCC-MCP gateway reachable at DCC_MCP_BASE_URL (default http://127.0.0.1:9765)
 allowed-tools: Bash Read
 metadata:

--- a/skills/dcc-rest-gateway/SKILL.md
+++ b/skills/dcc-rest-gateway/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   For any agent host (OpenClaw, ClawHub, Cursor, Claude, custom HTTP clients): inventory
   online instances, obtain user consent before setup when none are registered,
   then search, describe, and call tools via POST /v1/*.
-license: MIT
+license: MIT-0
 compatibility: Requires curl on PATH; DCC-MCP gateway reachable at DCC_MCP_GATEWAY_URL (default http://127.0.0.1:9765)
 allowed-tools: Bash Read
 metadata:


### PR DESCRIPTION
## Summary
- add a release-please PR guard workflow for stale release PR metadata
- add push-time release preflight so existing release tags become asset backfills and stale release PR merges fail before release-please creates the wrong tag
- require ClawHub-published skills to use MIT-0 and update the gateway skills accordingly

## Validation
- python -m compileall scripts/ci/check_release_please_pr.py scripts/ci/release_push_preflight.py scripts/clawhub_sync.py
- python scripts/clawhub_sync.py --dry-run
- local release preflight fixtures: normal push, stale release PR, matching release PR without tag, existing-tag backfill
- python -m ruff check scripts/ci/release_push_preflight.py scripts/ci/check_release_please_pr.py scripts/clawhub_sync.py
- python -m ruff format --check scripts/ci/release_push_preflight.py scripts/ci/check_release_please_pr.py scripts/clawhub_sync.py
- actionlint .github/workflows/release.yml .github/workflows/clawhub.yml .github/workflows/release-please-pr-guard.yml
- git diff --check
- pre-commit: check yaml, ruff, ruff format, actionlint