### PR TITLE
feat: expose stable gateway debug api

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/admin/router.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/router.rs
@@ -68,17 +68,29 @@ pub fn build_admin_router(state: AdminState) -> Router {
 /// Build stable `/v1/debug/*` routes backed by the admin trace store.
 pub fn build_v1_debug_router(state: AdminState) -> Router {
     Router::new()
+        .route("/v1/debug/instances", routing::get(handle_admin_instances))
+        .route("/v1/debug/activity", routing::get(handle_admin_activity))
+        .route("/v1/debug/calls", routing::get(handle_admin_calls))
+        .route("/v1/debug/traces", routing::get(handle_admin_traces))
         .route(
-            "/v1/debug/traces/{lookup_id}",
-            routing::get(handle_v1_debug_trace_lookup),
+            "/v1/debug/traces/{request_id}",
+            routing::get(handle_admin_trace_detail),
         )
         .route(
             "/v1/debug/trace-context/{lookup_id}",
             routing::get(handle_v1_debug_trace_lookup),
         )
+        .route("/v1/debug/tasks", routing::get(handle_admin_tasks))
+        .route(
+            "/v1/debug/issue-reports/{request_id}",
+            routing::get(handle_admin_issue_report),
+        )
         .route(
             "/v1/debug/bundles/{request_id}",
             routing::get(handle_admin_debug_bundle),
         )
+        .route("/v1/debug/logs", routing::get(handle_admin_logs))
+        .route("/v1/debug/stats", routing::get(handle_admin_stats))
+        .route("/v1/debug/health", routing::get(handle_admin_health))
         .with_state(state)
 }

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -574,6 +574,41 @@ mod admin_tests {
         );
 
         let v1_router = crate::gateway::admin::router::build_v1_debug_router(state);
+        let (instances_status, instances_body) =
+            body_json(v1_router.clone(), "/v1/debug/instances").await;
+        assert_eq!(instances_status, StatusCode::OK);
+        assert_eq!(instances_body["view"], "live");
+
+        let (activity_status, activity_body) =
+            body_json(v1_router.clone(), "/v1/debug/activity?limit=20").await;
+        assert_eq!(activity_status, StatusCode::OK);
+        assert!(activity_body["events"].as_array().is_some_and(|events| {
+            events
+                .iter()
+                .any(|event| event["correlation"]["request_id"] == "req-task")
+        }));
+
+        let (traces_status, traces_body) =
+            body_json(v1_router.clone(), "/v1/debug/traces?limit=20").await;
+        assert_eq!(traces_status, StatusCode::OK);
+        assert!(
+            traces_body["traces"]
+                .as_array()
+                .is_some_and(|traces| traces.iter().any(|trace| trace["request_id"] == "req-task"))
+        );
+
+        let (trace_detail_status, trace_detail_body) =
+            body_json(v1_router.clone(), "/v1/debug/traces/req-task").await;
+        assert_eq!(trace_detail_status, StatusCode::OK);
+        assert_eq!(trace_detail_body["request_id"], "req-task");
+        assert_eq!(trace_detail_body["trace_id"], "trace-task");
+
+        let (context_status, context_body) =
+            body_json(v1_router.clone(), "/v1/debug/trace-context/trace-task").await;
+        assert_eq!(context_status, StatusCode::OK);
+        assert_eq!(context_body["request_id"], "req-task");
+        assert_eq!(context_body["trace_id"], "trace-task");
+
         let (v1_status, v1_body) = body_json(v1_router, "/v1/debug/bundles/trace-task").await;
         assert_eq!(v1_status, StatusCode::OK);
         assert_eq!(v1_body["request_id"], "req-task");

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/debug_openapi.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/debug_openapi.rs
@@ -1,0 +1,223 @@
+use serde_json::{Value, json};
+
+#[cfg(feature = "admin")]
+pub(crate) fn add_gateway_debug_openapi_paths(doc: &mut Value) {
+    if let Some(tags) = doc.get_mut("tags").and_then(Value::as_array_mut)
+        && !tags
+            .iter()
+            .any(|tag| tag.get("name").and_then(Value::as_str) == Some("debug"))
+    {
+        tags.push(json!({
+            "name": "debug",
+            "description": "Gateway agent/debug diagnostics promoted from the Admin providers (#1092).",
+        }));
+    }
+
+    let Some(paths) = doc.get_mut("paths").and_then(Value::as_object_mut) else {
+        return;
+    };
+
+    let limit_params = vec![query_param(
+        "limit",
+        json!({"type": "integer", "minimum": 1, "maximum": 1000}),
+        "Maximum number of rows to return.",
+    )];
+    let time_filter_params = vec![
+        query_param(
+            "cursor",
+            json!({"type": "string"}),
+            "Opaque pagination cursor. Reserved for stable clients; current implementation may return null.",
+        ),
+        query_param(
+            "since",
+            json!({"type": "string", "format": "date-time"}),
+            "Lower timestamp bound in RFC3339 UTC. Reserved for stable clients.",
+        ),
+        query_param(
+            "until",
+            json!({"type": "string", "format": "date-time"}),
+            "Upper timestamp bound in RFC3339 UTC. Reserved for stable clients.",
+        ),
+    ];
+    let mut list_params = limit_params.clone();
+    list_params.extend(time_filter_params.clone());
+
+    for (path, summary, description, params) in [
+        (
+            "/v1/debug/instances",
+            "List gateway debug instances",
+            "Stable agent-facing alias for the Admin instance summary.",
+            vec![
+                query_param(
+                    "view",
+                    json!({"type": "string", "enum": ["live", "all", "registry"]}),
+                    "Instance view to return.",
+                ),
+                query_param(
+                    "include_stale",
+                    json!({"type": "boolean"}),
+                    "Include stale diagnostic rows.",
+                ),
+                query_param(
+                    "include_dead",
+                    json!({"type": "boolean"}),
+                    "Include rows whose owner process is gone.",
+                ),
+            ],
+        ),
+        (
+            "/v1/debug/activity",
+            "List gateway debug activity",
+            "Stable agent-facing activity feed built from audits, traces, and gateway events.",
+            list_params.clone(),
+        ),
+        (
+            "/v1/debug/calls",
+            "List recent debug calls",
+            "Stable agent-facing recent call list backed by audit rows.",
+            list_params.clone(),
+        ),
+        (
+            "/v1/debug/traces",
+            "List gateway debug traces",
+            "Stable agent-facing recent dispatch trace list.",
+            list_params.clone(),
+        ),
+        (
+            "/v1/debug/traces/{request_id}",
+            "Get one debug trace by request id",
+            "Stable agent-facing dispatch trace detail lookup.",
+            vec![path_param("request_id", "Gateway request id.")],
+        ),
+        (
+            "/v1/debug/trace-context/{lookup_id}",
+            "Resolve a trace context",
+            "Lookup by trace id or request id and return the primary trace plus related request ids.",
+            vec![path_param("lookup_id", "Trace id or request id.")],
+        ),
+        (
+            "/v1/debug/tasks",
+            "List task-like debug snapshots",
+            "Stable task projection reconstructed from dispatch traces.",
+            list_params.clone(),
+        ),
+        (
+            "/v1/debug/bundles/{request_id}",
+            "Get a debug bundle",
+            "Full-chain debug bundle by request id or trace id.",
+            vec![path_param("request_id", "Request id or trace id.")],
+        ),
+        (
+            "/v1/debug/issue-reports/{request_id}",
+            "Get issue-report debug JSON",
+            "GitHub-attachable debug report for one request.",
+            vec![path_param("request_id", "Gateway request id.")],
+        ),
+        (
+            "/v1/debug/logs",
+            "List merged debug logs",
+            "Merged gateway contention events, file logs, and audited call summaries.",
+            list_params.clone(),
+        ),
+        (
+            "/v1/debug/stats",
+            "Get debug statistics",
+            "Aggregated gateway call statistics.",
+            vec![query_param(
+                "range",
+                json!({"type": "string", "enum": ["1h", "24h", "7d"]}),
+                "Aggregation range.",
+            )],
+        ),
+        (
+            "/v1/debug/health",
+            "Get debug subsystem health",
+            "Compact health and readiness summary for debug providers.",
+            Vec::new(),
+        ),
+    ] {
+        paths.insert(
+            path.to_string(),
+            debug_get_path(summary, description, params),
+        );
+    }
+
+    if let Some(schemas) = doc
+        .pointer_mut("/components/schemas")
+        .and_then(Value::as_object_mut)
+    {
+        schemas.insert(
+            "GatewayDebugPayload".to_string(),
+            json!({
+                "type": "object",
+                "description": "Gateway debug JSON payload. Phase-1 endpoints preserve existing Admin provider payload fields while publishing them under stable /v1/debug routes.",
+                "additionalProperties": true,
+            }),
+        );
+        schemas.insert(
+            "GatewayDebugError".to_string(),
+            json!({
+                "type": "object",
+                "required": ["error"],
+                "properties": {
+                    "error": {"type": "string"},
+                    "request_id": {"type": "string"},
+                    "lookup_id": {"type": "string"}
+                },
+                "additionalProperties": true,
+            }),
+        );
+    }
+}
+
+#[cfg(feature = "admin")]
+fn debug_get_path(summary: &str, description: &str, parameters: Vec<Value>) -> Value {
+    json!({
+        "get": {
+            "tags": ["debug"],
+            "summary": summary,
+            "description": description,
+            "parameters": parameters,
+            "responses": {
+                "200": {
+                    "description": "Debug payload",
+                    "content": {
+                        "application/json": {
+                            "schema": {"$ref": "#/components/schemas/GatewayDebugPayload"}
+                        }
+                    }
+                },
+                "404": {
+                    "description": "Debug record not found",
+                    "content": {
+                        "application/json": {
+                            "schema": {"$ref": "#/components/schemas/GatewayDebugError"}
+                        }
+                    }
+                }
+            }
+        }
+    })
+}
+
+#[cfg(feature = "admin")]
+fn path_param(name: &str, description: &str) -> Value {
+    json!({
+        "name": name,
+        "in": "path",
+        "required": true,
+        "description": description,
+        "schema": {"type": "string"}
+    })
+}
+
+#[cfg(feature = "admin")]
+fn query_param(name: &str, schema: Value, description: &str) -> Value {
+    json!({
+        "name": name,
+        "in": "query",
+        "required": false,
+        "description": description,
+        "schema": schema
+    })
+}

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/mod.rs
@@ -22,6 +22,8 @@ pub(crate) use super::state::{GatewayState, ResolveInstanceError};
 pub(crate) use dcc_mcp_jsonrpc::negotiate_protocol_version;
 pub(crate) use dcc_mcp_transport::discovery::types::ServiceStatus;
 
+#[cfg(feature = "admin")]
+mod debug_openapi;
 mod mcp_impl;
 mod notification_impl;
 mod proxy_impl;

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
@@ -141,12 +141,26 @@ pub async fn handle_v1_readyz(State(gs): State<GatewayState>) -> impl IntoRespon
 pub async fn handle_v1_openapi(State(gs): State<GatewayState>) -> impl IntoResponse {
     let doc =
         dcc_mcp_skill_rest::openapi::build_openapi_document("dcc-mcp-gateway", &gs.server_version);
+    #[cfg(feature = "admin")]
+    let doc = {
+        let mut doc = doc;
+        super::debug_openapi::add_gateway_debug_openapi_paths(&mut doc);
+        doc
+    };
     (StatusCode::OK, Json(doc))
 }
 
 /// `GET /docs` — gateway REST API reference.
 pub async fn handle_v1_docs(State(gs): State<GatewayState>) -> Response {
-    let html = dcc_mcp_skill_rest::openapi::build_docs_html("dcc-mcp-gateway", &gs.server_version);
+    let doc =
+        dcc_mcp_skill_rest::openapi::build_openapi_document("dcc-mcp-gateway", &gs.server_version);
+    #[cfg(feature = "admin")]
+    let doc = {
+        let mut doc = doc;
+        super::debug_openapi::add_gateway_debug_openapi_paths(&mut doc);
+        doc
+    };
+    let html = dcc_mcp_skill_rest::openapi::build_docs_html_for_document(doc);
     (StatusCode::OK, Html(html)).into_response()
 }
 
@@ -895,6 +909,44 @@ mod tests {
         assert!(body.contains("scalar") || body.contains("Scalar"));
         assert!(body.contains("dcc-mcp-gateway"));
         assert!(body.contains("/v1/search"));
+        assert!(body.contains("/v1/debug/instances"));
+    }
+
+    #[tokio::test]
+    async fn gateway_openapi_lists_stable_debug_routes() {
+        let (status, doc) = response_json(
+            handle_v1_openapi(State(test_gateway_state("1.2.3")))
+                .await
+                .into_response(),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        for path in [
+            "/v1/debug/instances",
+            "/v1/debug/activity",
+            "/v1/debug/traces",
+            "/v1/debug/traces/{request_id}",
+            "/v1/debug/trace-context/{lookup_id}",
+            "/v1/debug/bundles/{request_id}",
+            "/v1/debug/issue-reports/{request_id}",
+            "/v1/debug/health",
+        ] {
+            assert!(
+                doc["paths"].get(path).is_some(),
+                "gateway OpenAPI doc missing debug path {path}: {doc:#}"
+            );
+        }
+        assert!(
+            doc["tags"]
+                .as_array()
+                .is_some_and(|tags| tags.iter().any(|tag| tag["name"] == "debug"))
+        );
+        assert!(
+            doc["components"]["schemas"]
+                .get("GatewayDebugPayload")
+                .is_some()
+        );
     }
 
     #[tokio::test]

--- a/crates/dcc-mcp-skill-rest/src/openapi.rs
+++ b/crates/dcc-mcp-skill-rest/src/openapi.rs
@@ -116,6 +116,12 @@ pub fn build_openapi_document(server_title: &str, server_version: &str) -> Value
 #[must_use]
 pub fn build_docs_html(server_title: &str, server_version: &str) -> String {
     let doc = build_openapi_document(server_title, server_version);
+    build_docs_html_for_document(doc)
+}
+
+/// Build the Scalar HTML API reference for an already-customized OpenAPI document.
+#[must_use]
+pub fn build_docs_html_for_document(doc: Value) -> String {
     utoipa_scalar::Scalar::new(doc).to_html()
 }
 

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -82,12 +82,29 @@ When using `dcc-mcp-gateway` directly, compile with the `admin` Cargo feature. `
 | `GET /admin/api/traces` | `application/json` | Recent per-call dispatch traces; accepts `?limit=200` |
 | `GET /admin/api/traces/{request_id}` | `application/json` | Full waterfall for one recorded dispatch trace |
 | `GET /admin/api/debug-bundle/{request_id}` | `application/json` | One-stop debug bundle containing the trace, matching audit row, related activity, and hints |
-| `GET /v1/debug/traces/{trace_id}` | `application/json` | Stable trace lookup by trace id or request id |
-| `GET /v1/debug/bundles/{trace_id}` | `application/json` | Full-chain debug bundle across retained requests in one trace |
 | `GET /admin/api/stats?range=1h\|24h\|7d` | `application/json` | Aggregated call counts, success rate, latency, and top tools/instances/agents |
 | `GET /admin/api/workers` | `application/json` | Per-instance worker cards from the live registry |
 | `GET /admin/api/logs` | `application/json` | Merged gateway contention events, on-disk `*.log` rows, and audited call summaries |
 | `GET /admin/api/health` | `application/json` | Service health summary |
+
+Stable agent-facing mirrors are exposed under `/v1/debug/*` and are included in
+`GET /v1/openapi.json`. The Admin routes above remain the dashboard
+compatibility layer; automation should prefer:
+
+| Stable route | Mirrors |
+|--------------|---------|
+| `GET /v1/debug/instances` | `/admin/api/instances` |
+| `GET /v1/debug/activity?limit=300` | `/admin/api/activity` |
+| `GET /v1/debug/traces?limit=200` | `/admin/api/traces` |
+| `GET /v1/debug/traces/{request_id}` | `/admin/api/traces/{request_id}` |
+| `GET /v1/debug/trace-context/{lookup_id}` | trace id or request id lookup |
+| `GET /v1/debug/bundles/{request_id_or_trace_id}` | `/admin/api/debug-bundle/{request_id}` |
+| `GET /v1/debug/issue-reports/{request_id}` | `/admin/api/issue-report/{request_id}` |
+| `GET /v1/debug/tasks` | `/admin/api/tasks` |
+| `GET /v1/debug/calls` | `/admin/api/calls` |
+| `GET /v1/debug/logs` | `/admin/api/logs` |
+| `GET /v1/debug/stats` | `/admin/api/stats` |
+| `GET /v1/debug/health` | `/admin/api/health` |
 
 ## Optional Agent / Caller Context
 

--- a/docs/guide/rest-api-surface.md
+++ b/docs/guide/rest-api-surface.md
@@ -35,12 +35,62 @@ without touching the MCP protocol stack.
 | `GET` | `/v1/prompts/{name}` | Render one prompt; pass JSON object arguments in `?args=...`. |
 | `GET` | `/v1/jobs/{id}/events` | Server-Sent Events for one async job. |
 | `DELETE` | `/v1/jobs/{id}` | Cancel one async job. |
+| `GET` | `/v1/debug/instances` | Gateway only: stable agent-facing instance diagnostics. |
+| `GET` | `/v1/debug/activity` | Gateway only: stable activity feed from audits, traces, and gateway events. |
+| `GET` | `/v1/debug/traces` | Gateway only: recent dispatch trace list. |
+| `GET` | `/v1/debug/traces/{request_id}` | Gateway only: dispatch trace detail by request id. |
+| `GET` | `/v1/debug/trace-context/{lookup_id}` | Gateway only: resolve trace id or request id to the primary trace context. |
+| `GET` | `/v1/debug/bundles/{request_id}` | Gateway only: full-chain debug bundle by request id or trace id. |
+| `GET` | `/v1/debug/issue-reports/{request_id}` | Gateway only: GitHub-attachable debug report JSON. |
+| `GET` | `/v1/debug/tasks` | Gateway only: task-like snapshots reconstructed from traces. |
+| `GET` | `/v1/debug/calls` | Gateway only: recent audited calls. |
+| `GET` | `/v1/debug/logs` | Gateway only: merged gateway events, file logs, and audit summaries. |
+| `GET` | `/v1/debug/stats` | Gateway only: aggregated call statistics. |
+| `GET` | `/v1/debug/health` | Gateway only: debug subsystem health summary. |
 | `GET` | `/v1/openapi.json` | Auto-generated OpenAPI 3.x document for code-gen clients. |
 
 The gateway exposes the same paths as an aggregating facade. Gateway capability
 slugs use `<dcc>.<id8>.<tool>` and are obtained from `POST /v1/search`; direct
 per-DCC REST slugs use `<dcc>.<skill>.<action>` and do not include an instance
 id prefix.
+
+---
+
+## Gateway Agent Debug API
+
+The elected gateway promotes the Admin telemetry providers to stable
+`/v1/debug/*` routes for agents and CI diagnostics. These routes are included
+in `GET /v1/openapi.json`; the `/admin/api/*` routes remain compatibility
+aliases for the embedded dashboard.
+
+Phase-1 debug routes intentionally preserve the existing Admin payload fields
+so operators and agents can compare results one-to-one:
+
+| Stable route | Compatibility route | Notes |
+|---|---|---|
+| `/v1/debug/instances` | `/admin/api/instances` | Accepts `view=live|all`, `include_stale`, and `include_dead`. |
+| `/v1/debug/activity?limit=200` | `/admin/api/activity?limit=200` | Unified activity feed. |
+| `/v1/debug/traces?limit=200` | `/admin/api/traces?limit=200` | Recent dispatch trace rows. |
+| `/v1/debug/traces/{request_id}` | `/admin/api/traces/{request_id}` | Exact request-id trace detail. |
+| `/v1/debug/trace-context/{lookup_id}` | n/a | Trace-context lookup by `trace_id` or `request_id`. |
+| `/v1/debug/bundles/{request_id}` | `/admin/api/debug-bundle/{request_id}` | Accepts request ids and retained trace ids. |
+| `/v1/debug/issue-reports/{request_id}` | `/admin/api/issue-report/{request_id}` | JSON export suitable for GitHub issue attachment. |
+| `/v1/debug/tasks` | `/admin/api/tasks` | Task projection from retained traces. |
+| `/v1/debug/calls` | `/admin/api/calls` | Recent audit rows. |
+| `/v1/debug/logs` | `/admin/api/logs` | Merged gateway/file/audit logs. |
+| `/v1/debug/stats` | `/admin/api/stats` | Aggregated call stats. |
+| `/v1/debug/health` | `/admin/api/health` | Debug provider health summary. |
+
+Every list endpoint supports the existing `limit` parameter where the Admin
+provider already accepted one. The OpenAPI contract reserves `cursor`,
+`since`, and `until` for the follow-up normalized envelope work; callers should
+ignore missing `next_cursor` fields until that phase lands.
+
+Common correlation fields include `request_id`, `trace_id`, `instance_id`,
+`dcc_type`, `tool` / `tool_slug`, `transport`, `agent_id`, `agent_name`,
+`agent_model`, `parent_request_id`, and timestamps where the underlying provider
+has them. Use `request_id` for exact request detail and `trace_id` for
+full-chain bundles or `/v1/debug/trace-context/{trace_id}`.
 
 ---
 

--- a/docs/guide/rest-api-surface.md
+++ b/docs/guide/rest-api-surface.md
@@ -68,7 +68,7 @@ so operators and agents can compare results one-to-one:
 
 | Stable route | Compatibility route | Notes |
 |---|---|---|
-| `/v1/debug/instances` | `/admin/api/instances` | Accepts `view=live|all`, `include_stale`, and `include_dead`. |
+| `/v1/debug/instances` | `/admin/api/instances` | Accepts `view=live\|all`, `include_stale`, and `include_dead`. |
 | `/v1/debug/activity?limit=200` | `/admin/api/activity?limit=200` | Unified activity feed. |
 | `/v1/debug/traces?limit=200` | `/admin/api/traces?limit=200` | Recent dispatch trace rows. |
 | `/v1/debug/traces/{request_id}` | `/admin/api/traces/{request_id}` | Exact request-id trace detail. |

--- a/skills/dcc-mcp-skill-developer/SKILL.md
+++ b/skills/dcc-mcp-skill-developer/SKILL.md
@@ -57,6 +57,8 @@ into a faster authoring loop.
    URL into a follow-up agent, LLM evaluation prompt, or GitHub issue. When an
    adapter example surfaces an `mcp_url`, make sure the Admin Dashboard can
    derive per-instance OpenAPI Inspector, spec JSON, and docs links from it.
+   For machine consumers, prefer the stable gateway `/v1/debug/*` routes and
+   `GET /v1/openapi.json` over scraping `/admin` HTML or dashboard internals.
 7. Add tests at the lowest executable layer, then one discovery/load/call or
    gateway REST path when behavior crosses MCP or REST boundaries.
 

--- a/tests/vrs/README.md
+++ b/tests/vrs/README.md
@@ -85,6 +85,7 @@ python scripts/vrs_replay.py --base-url http://127.0.0.1:1 --dry-run --trace tes
 | `traces/core-995-list-skills-respects-limit.jsonl` | Yes (any DCC) | `POST /v1/list_skills` MUST honour `limit` and `fields` and report a `truncated` flag (core#995). |
 | `traces/core-996-instance-offline-carries-previous-status.jsonl` | No | `instance-offline` (or `unknown-slug`) error envelope MUST carry `previous_status` so agents can distinguish manual restart from crash (core#996). |
 | `traces/core-1037-gateway-yield-unsupported-envelope.jsonl` | No | `POST /gateway/yield` unsupported/invalid optional-capability path MUST return a structured envelope that tells runners to poll instead of treating it as a crash. |
+| `traces/core-1092-stable-debug-api.jsonl` | No | Stable `/v1/debug/*` routes expose activity, trace detail, debug bundle, and OpenAPI entries without scraping Admin HTML. |
 | `traces/core-1093-trace-context-debug-bundle.jsonl` | No | `X-Request-Id` and W3C `traceparent` stay distinct, and `/v1/debug/bundles/{trace_id}` can retrieve the retained trace. |
 | `traces/gateway-multi-instance-stress.jsonl` | Yes (≥3 live instances) | Skips unless `GET /v1/instances` reports `total >= 3`; then bursts health/instances/readyz/context/search to catch registry/probe regressions under load. |
 
@@ -105,4 +106,5 @@ python scripts/vrs_replay.py --base-url http://127.0.0.1:1 --dry-run --trace tes
 - core [#995](https://github.com/loonghao/dcc-mcp-core/issues/995) — list_skills returns full metadata for every skill
 - core [#996](https://github.com/loonghao/dcc-mcp-core/issues/996) — instance-offline envelope must carry restart cause
 - core [#1037](https://github.com/loonghao/dcc-mcp-core/issues/1037) — cooperative gateway yield fallback should be structured and non-alarming
+- core [#1092](https://github.com/loonghao/dcc-mcp-core/issues/1092) — stable `/v1/debug/*` API for agent diagnostics
 - core [#1093](https://github.com/loonghao/dcc-mcp-core/issues/1093) — first-class Trace Context for full-chain debug bundles

--- a/tests/vrs/traces/core-1092-stable-debug-api.jsonl
+++ b/tests/vrs/traces/core-1092-stable-debug-api.jsonl
@@ -1,0 +1,7 @@
+{"_vrs": {"version": 1}, "trace_id": "core-1092-stable-debug-api", "title": "Stable /v1/debug routes expose admin-equivalent diagnostics for agents"}
+{"id": "call_unknown_with_request_id", "http": {"method": "POST", "path": "/v1/call", "headers": {"X-Request-Id": "vrs-core-1092-request", "traceparent": "00-7bf92f3577b34da6a3ce929d0e0e1092-00f067aa0ba91092-01"}, "json": {"tool_slug": "maya.abcdef01.__vrs_core_1092_missing_tool__", "arguments": {}}}, "expect": {"status": 404, "json_subset": {"error": {"kind": "unknown-slug"}}}}
+{"id": "debug_activity", "http": {"method": "GET", "path": "/v1/debug/activity?limit=20"}, "expect": {"status": 200, "body_contains": "vrs-core-1092-request"}}
+{"id": "debug_traces_list", "http": {"method": "GET", "path": "/v1/debug/traces?limit=20"}, "expect": {"status": 200, "body_contains": "vrs-core-1092-request"}}
+{"id": "debug_trace_detail", "http": {"method": "GET", "path": "/v1/debug/traces/vrs-core-1092-request"}, "expect": {"status": 200, "json_subset": {"request_id": "vrs-core-1092-request", "trace_id": "7bf92f3577b34da6a3ce929d0e0e1092"}}}
+{"id": "debug_bundle_by_trace_id", "http": {"method": "GET", "path": "/v1/debug/bundles/7bf92f3577b34da6a3ce929d0e0e1092"}, "expect": {"status": 200, "json_subset": {"trace_id": "7bf92f3577b34da6a3ce929d0e0e1092", "request_id": "vrs-core-1092-request"}}}
+{"id": "openapi_lists_debug_routes", "http": {"method": "GET", "path": "/v1/openapi.json"}, "expect": {"status": 200, "body_contains": "/v1/debug/traces/{request_id}"}}


### PR DESCRIPTION
## Summary
- Promote existing Admin debug providers under stable `/v1/debug/*` gateway routes for agent diagnostics.
- Add gateway-only OpenAPI path injection for the debug contract and include it in the Scalar docs output when the admin feature is enabled.
- Document the `/admin/api/*` to `/v1/debug/*` mapping and add a VRS trace for activity -> trace detail -> debug bundle coverage.

## Validation
- cargo test -p dcc-mcp-gateway --features admin
- cargo clippy -p dcc-mcp-gateway --features admin -- -D warnings
- cargo test -p dcc-mcp-skill-rest
- cargo check -p dcc-mcp-gateway --no-default-features
- python scripts/vrs_replay.py --base-url http://127.0.0.1:1 --dry-run --trace tests/vrs/traces/core-1092-stable-debug-api.jsonl

## Notes
- Based on latest origin/main at 1788975f.
- Updated skills/dcc-mcp-skill-developer/SKILL.md because this changes the agent-facing gateway debug workflow.