### PR TITLE
test: cover stable debug api surface

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -525,7 +525,29 @@ mod admin_tests {
             "abcdef01",
             Some("call=long_task display_id=maya@2026-abcdef01".into()),
         ));
-        let state = AdminState::new(gateway).with_trace_log(traces, None);
+        let audit_log: Arc<AuditLog> = Arc::new(Mutex::new(vec![AdminAuditRecord {
+            timestamp: SystemTime::UNIX_EPOCH + Duration::from_millis(2_500),
+            request_id: "req-task".into(),
+            trace_id: Some("trace-task".into()),
+            span_id: None,
+            parent_span_id: None,
+            method: Some("tools/call".into()),
+            instance_id: Some(instance_id.into()),
+            session_id: Some("session-1".into()),
+            transport: Some("mcp".into()),
+            agent_id: Some("agent-task".into()),
+            agent_name: Some("Task Agent".into()),
+            agent_model: Some("gpt-test".into()),
+            parent_request_id: Some("req-prev".into()),
+            action: "maya.inst.long_task".into(),
+            dcc_type: Some("maya".into()),
+            success: false,
+            error: Some("host died".into()),
+            duration_ms: Some(25),
+        }]));
+        let state = AdminState::new(gateway)
+            .with_audit_log(audit_log)
+            .with_trace_log(traces, None);
         let router = build_admin_router(state.clone());
 
         let (tasks_status, tasks_body) = body_json(router.clone(), "/api/tasks").await;
@@ -609,7 +631,47 @@ mod admin_tests {
         assert_eq!(context_body["request_id"], "req-task");
         assert_eq!(context_body["trace_id"], "trace-task");
 
-        let (v1_status, v1_body) = body_json(v1_router, "/v1/debug/bundles/trace-task").await;
+        let (v1_tasks_status, v1_tasks_body) =
+            body_json(v1_router.clone(), "/v1/debug/tasks?limit=20").await;
+        assert_eq!(v1_tasks_status, StatusCode::OK);
+        assert!(
+            v1_tasks_body["tasks"]
+                .as_array()
+                .is_some_and(|tasks| tasks.iter().any(|task| task["task_id"] == "req-task"))
+        );
+
+        let (calls_status, calls_body) = body_json(v1_router.clone(), "/v1/debug/calls").await;
+        assert_eq!(calls_status, StatusCode::OK);
+        assert!(
+            calls_body["calls"]
+                .as_array()
+                .is_some_and(|calls| calls.iter().any(|call| call["request_id"] == "req-task"))
+        );
+
+        {
+            let _env = API_LOGS_ENV_LOCK.lock();
+            let _no_disk = ScopedNoDiskLogsDir::new();
+            let (logs_status, logs_body) = body_json(v1_router.clone(), "/v1/debug/logs").await;
+            assert_eq!(logs_status, StatusCode::OK);
+            assert!(
+                logs_body["logs"]
+                    .as_array()
+                    .is_some_and(|logs| logs.iter().any(|log| log["request_id"] == "req-task"))
+            );
+        }
+
+        let (stats_status, stats_body) =
+            body_json(v1_router.clone(), "/v1/debug/stats?range=all").await;
+        assert_eq!(stats_status, StatusCode::OK);
+        assert_eq!(stats_body["range"], "all");
+        assert_eq!(stats_body["total_calls"], 2);
+
+        let (health_status, health_body) = body_json(v1_router.clone(), "/v1/debug/health").await;
+        assert_eq!(health_status, StatusCode::OK);
+        assert_eq!(health_body["version"], "0.0.0-test");
+
+        let (v1_status, v1_body) =
+            body_json(v1_router.clone(), "/v1/debug/bundles/trace-task").await;
         assert_eq!(v1_status, StatusCode::OK);
         assert_eq!(v1_body["request_id"], "req-task");
         assert_eq!(v1_body["trace_id"], "trace-task");
@@ -624,6 +686,12 @@ mod admin_tests {
                 .as_str()
                 .is_some_and(|url| url.ends_with("/admin/api/debug-bundle/req-task"))
         );
+
+        let (v1_report_status, v1_report_body) =
+            body_json(v1_router, "/v1/debug/issue-reports/req-task").await;
+        assert_eq!(v1_report_status, StatusCode::OK);
+        assert_eq!(v1_report_body["request_id"], "req-task");
+        assert_eq!(v1_report_body["debug_bundle"]["trace_id"], "trace-task");
 
         let (report_status, report_body) = body_json(router, "/api/issue-report/req-task").await;
         assert_eq!(report_status, StatusCode::OK);

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/debug_openapi.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/debug_openapi.rs
@@ -125,7 +125,7 @@ pub(crate) fn add_gateway_debug_openapi_paths(doc: &mut Value) {
             "Aggregated gateway call statistics.",
             vec![query_param(
                 "range",
-                json!({"type": "string", "enum": ["1h", "24h", "7d"]}),
+                json!({"type": "string", "enum": ["1h", "24h", "7d", "all"]}),
                 "Aggregation range.",
             )],
         ),

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
@@ -925,11 +925,15 @@ mod tests {
         for path in [
             "/v1/debug/instances",
             "/v1/debug/activity",
+            "/v1/debug/calls",
             "/v1/debug/traces",
             "/v1/debug/traces/{request_id}",
             "/v1/debug/trace-context/{lookup_id}",
+            "/v1/debug/tasks",
             "/v1/debug/bundles/{request_id}",
             "/v1/debug/issue-reports/{request_id}",
+            "/v1/debug/logs",
+            "/v1/debug/stats",
             "/v1/debug/health",
         ] {
             assert!(

--- a/tests/vrs/README.md
+++ b/tests/vrs/README.md
@@ -85,7 +85,7 @@ python scripts/vrs_replay.py --base-url http://127.0.0.1:1 --dry-run --trace tes
 | `traces/core-995-list-skills-respects-limit.jsonl` | Yes (any DCC) | `POST /v1/list_skills` MUST honour `limit` and `fields` and report a `truncated` flag (core#995). |
 | `traces/core-996-instance-offline-carries-previous-status.jsonl` | No | `instance-offline` (or `unknown-slug`) error envelope MUST carry `previous_status` so agents can distinguish manual restart from crash (core#996). |
 | `traces/core-1037-gateway-yield-unsupported-envelope.jsonl` | No | `POST /gateway/yield` unsupported/invalid optional-capability path MUST return a structured envelope that tells runners to poll instead of treating it as a crash. |
-| `traces/core-1092-stable-debug-api.jsonl` | No | Stable `/v1/debug/*` routes expose activity, trace detail, debug bundle, and OpenAPI entries without scraping Admin HTML. |
+| `traces/core-1092-stable-debug-api.jsonl` | No | Stable `/v1/debug/*` routes expose the route family needed for agent diagnostics without scraping Admin HTML. |
 | `traces/core-1093-trace-context-debug-bundle.jsonl` | No | `X-Request-Id` and W3C `traceparent` stay distinct, and `/v1/debug/bundles/{trace_id}` can retrieve the retained trace. |
 | `traces/gateway-multi-instance-stress.jsonl` | Yes (≥3 live instances) | Skips unless `GET /v1/instances` reports `total >= 3`; then bursts health/instances/readyz/context/search to catch registry/probe regressions under load. |
 

--- a/tests/vrs/traces/core-1092-stable-debug-api.jsonl
+++ b/tests/vrs/traces/core-1092-stable-debug-api.jsonl
@@ -3,5 +3,12 @@
 {"id": "debug_activity", "http": {"method": "GET", "path": "/v1/debug/activity?limit=20"}, "expect": {"status": 200, "body_contains": "vrs-core-1092-request"}}
 {"id": "debug_traces_list", "http": {"method": "GET", "path": "/v1/debug/traces?limit=20"}, "expect": {"status": 200, "body_contains": "vrs-core-1092-request"}}
 {"id": "debug_trace_detail", "http": {"method": "GET", "path": "/v1/debug/traces/vrs-core-1092-request"}, "expect": {"status": 200, "json_subset": {"request_id": "vrs-core-1092-request", "trace_id": "7bf92f3577b34da6a3ce929d0e0e1092"}}}
+{"id": "debug_trace_context", "http": {"method": "GET", "path": "/v1/debug/trace-context/7bf92f3577b34da6a3ce929d0e0e1092"}, "expect": {"status": 200, "json_subset": {"request_id": "vrs-core-1092-request", "trace_id": "7bf92f3577b34da6a3ce929d0e0e1092"}}}
+{"id": "debug_tasks", "http": {"method": "GET", "path": "/v1/debug/tasks?limit=20"}, "expect": {"status": 200, "body_contains": "vrs-core-1092-request"}}
+{"id": "debug_calls", "http": {"method": "GET", "path": "/v1/debug/calls"}, "expect": {"status": 200}}
+{"id": "debug_logs", "http": {"method": "GET", "path": "/v1/debug/logs"}, "expect": {"status": 200}}
+{"id": "debug_stats", "http": {"method": "GET", "path": "/v1/debug/stats?range=all"}, "expect": {"status": 200, "json_subset": {"range": "all"}}}
+{"id": "debug_health", "http": {"method": "GET", "path": "/v1/debug/health"}, "expect": {"status": 200, "body_contains": "status"}}
 {"id": "debug_bundle_by_trace_id", "http": {"method": "GET", "path": "/v1/debug/bundles/7bf92f3577b34da6a3ce929d0e0e1092"}, "expect": {"status": 200, "json_subset": {"trace_id": "7bf92f3577b34da6a3ce929d0e0e1092", "request_id": "vrs-core-1092-request"}}}
-{"id": "openapi_lists_debug_routes", "http": {"method": "GET", "path": "/v1/openapi.json"}, "expect": {"status": 200, "body_contains": "/v1/debug/traces/{request_id}"}}
+{"id": "debug_issue_report", "http": {"method": "GET", "path": "/v1/debug/issue-reports/vrs-core-1092-request"}, "expect": {"status": 200, "json_subset": {"request_id": "vrs-core-1092-request", "debug_bundle": {"trace_id": "7bf92f3577b34da6a3ce929d0e0e1092"}}}}
+{"id": "openapi_lists_debug_routes", "http": {"method": "GET", "path": "/v1/openapi.json"}, "expect": {"status": 200, "body_contains": "/v1/debug/health"}}


### PR DESCRIPTION
## Summary
- Extend `/v1/debug/*` route tests to cover tasks, calls, logs, stats, health, issue reports, trace-context, and bundles together.
- Expand the core #1092 VRS trace across the stable debug route family.
- Document the supported `all` stats range in the debug OpenAPI schema.

## Validation
- `cargo test -p dcc-mcp-gateway --features admin debug -- --nocapture`
- `cargo test -p dcc-mcp-gateway --features admin`
- `cargo check -p dcc-mcp-gateway --no-default-features`
- `python scripts/vrs_replay.py --base-url http://127.0.0.1:1 --dry-run --trace tests/vrs/traces/core-1092-stable-debug-api.jsonl`
- `git diff --check`

## Notes
- No `skills/dcc-mcp-skill-developer/SKILL.md` update is needed; this only strengthens test/VRS coverage and aligns OpenAPI with existing stats behavior.