### PR TITLE
test: cover trace context propagation

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/backend_client/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/backend_client/tests.rs
@@ -605,24 +605,30 @@ async fn read_resource_preserves_blob_bytes() {
 
 #[tokio::test]
 async fn forward_tools_call_propagates_trace_context_headers() {
-    let seen = std::sync::Arc::new(parking_lot::Mutex::new(Vec::<(String, String)>::new()));
+    let seen = std::sync::Arc::new(parking_lot::Mutex::new(Vec::<(
+        String,
+        String,
+        String,
+        String,
+    )>::new()));
     let seen_clone = seen.clone();
     let app = axum::Router::new().route(
         "/v1/call",
         axum::routing::post(move |headers: axum::http::HeaderMap| {
             let seen = seen_clone.clone();
             async move {
+                let header = |name| {
+                    headers
+                        .get(name)
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or("")
+                        .to_string()
+                };
                 seen.lock().push((
-                    headers
-                        .get("x-request-id")
-                        .and_then(|v| v.to_str().ok())
-                        .unwrap_or("")
-                        .to_string(),
-                    headers
-                        .get("traceparent")
-                        .and_then(|v| v.to_str().ok())
-                        .unwrap_or("")
-                        .to_string(),
+                    header("x-request-id"),
+                    header("x-dcc-mcp-parent-request-id"),
+                    header("traceparent"),
+                    header("tracestate"),
                 ));
                 axum::Json(json!({"success": true}))
             }
@@ -634,9 +640,9 @@ async fn forward_tools_call_propagates_trace_context_headers() {
         request_id: "req-forward".into(),
         span_id: Some("00f067aa0ba902b7".into()),
         parent_span_id: None,
-        parent_request_id: None,
+        parent_request_id: Some("req-parent".into()),
         trace_flags: Some("01".into()),
-        trace_state: None,
+        trace_state: Some("vendor=value".into()),
     };
 
     forward_tools_call(
@@ -656,10 +662,12 @@ async fn forward_tools_call_propagates_trace_context_headers() {
 
     let seen = seen.lock();
     assert_eq!(seen[0].0, "req-forward");
+    assert_eq!(seen[0].1, "req-parent");
     assert_eq!(
-        seen[0].1,
+        seen[0].2,
         "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
     );
+    assert_eq!(seen[0].3, "vendor=value");
     let _ = stop.send(());
 }
 

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
@@ -1088,6 +1088,24 @@ mod tests {
             entries[0].trace_context.parent_span_id.as_deref(),
             Some("00f067aa0ba902b7")
         );
+        let root_span_id = entries[0]
+            .trace_context
+            .span_id
+            .as_deref()
+            .expect("REST trace context should create a gateway root span id");
+        assert_eq!(root_span_id.len(), 16);
+        let backend_span = entries[0]
+            .trace_spans
+            .iter()
+            .find(|span| span.name == "backend.execute")
+            .expect("REST call should record backend.execute span");
+        let backend_span_id = backend_span
+            .span_id
+            .as_deref()
+            .expect("backend.execute should carry its own span id");
+        assert_eq!(backend_span_id.len(), 16);
+        assert_ne!(backend_span_id, root_span_id);
+        assert_eq!(backend_span.parent_span_id.as_deref(), Some(root_span_id));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Assert REST debug traces keep a gateway root span id and record a child `backend.execute` span id.
- Extend backend forwarding coverage to include parent request id and `tracestate` propagation alongside `traceparent`.

## Validation
- `cargo test -p dcc-mcp-gateway --features admin rest_traceparent_does_not_replace_request_id -- --nocapture`
- `cargo test -p dcc-mcp-gateway --features admin forward_tools_call_propagates_trace_context_headers -- --nocapture`
- `cargo test -p dcc-mcp-gateway --features admin`
- `cargo check -p dcc-mcp-gateway --no-default-features`
- `git diff --check`

## Notes
- No `skills/dcc-mcp-skill-developer/SKILL.md` update is needed; this only strengthens Trace Context regression coverage.