### PR TITLE
fix: recover zero-padded FileRegistry snapshots

### DIFF
--- a/crates/dcc-mcp-transport/src/discovery/file_registry.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry.rs
@@ -1082,9 +1082,44 @@ impl FileRegistry {
             return Ok(Vec::new());
         }
 
+        if Self::looks_like_zero_padded_empty_registry(&content) {
+            self.quarantine_zero_padded_registry_file(&path, content.len());
+            return Ok(Vec::new());
+        }
+
         serde_json::from_str(&content).map_err(|e| {
             TransportError::RegistryFile(format!("failed to parse {}: {}", path.display(), e))
         })
+    }
+
+    fn looks_like_zero_padded_empty_registry(content: &str) -> bool {
+        content.as_bytes().contains(&0)
+            && content
+                .bytes()
+                .all(|byte| byte == 0 || byte.is_ascii_whitespace())
+    }
+
+    fn quarantine_zero_padded_registry_file(&self, path: &Path, bytes: usize) {
+        let ts = SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_secs())
+            .unwrap_or(0);
+        let quarantined = path.with_extension(format!("json.corrupted-{ts}"));
+        match fs::rename(path, &quarantined) {
+            Ok(()) => tracing::warn!(
+                path = %path.display(),
+                quarantined = %quarantined.display(),
+                bytes,
+                "FileRegistry: registry file looked like a zero-padded NTFS artefact; quarantined and starting empty"
+            ),
+            Err(error) => tracing::warn!(
+                path = %path.display(),
+                quarantined = %quarantined.display(),
+                bytes,
+                error = %error,
+                "FileRegistry: registry file looked like a zero-padded NTFS artefact; failed to quarantine but starting empty"
+            ),
+        }
     }
 
     /// Read the registry file with a short bounded retry to tolerate the

--- a/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
@@ -10,6 +10,21 @@ fn remove_sentinel_for_pid_fallback(registry: &FileRegistry, key: &ServiceKey) {
     }
 }
 
+fn corrupted_registry_files(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut paths: Vec<_> = std::fs::read_dir(dir)
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("services.json.corrupted-"))
+        })
+        .collect();
+    paths.sort();
+    paths
+}
+
 #[test]
 fn test_file_registry_register_and_list() {
     let dir = tempfile::tempdir().unwrap();
@@ -622,6 +637,58 @@ fn test_empty_registry_file_during_transaction_clears_snapshot() {
         FileRegistry::new(dir.path()).unwrap().is_empty(),
         "empty services.json must not be repopulated from stale memory"
     );
+}
+
+#[test]
+fn test_zero_padded_registry_file_is_quarantined_and_starts_empty() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join(REGISTRY_FILE);
+    std::fs::write(&path, vec![0u8; 1466]).unwrap();
+
+    let registry = FileRegistry::new(dir.path()).unwrap();
+
+    assert!(registry.is_empty());
+    assert!(!path.exists());
+    let quarantined = corrupted_registry_files(dir.path());
+    assert_eq!(quarantined.len(), 1);
+    assert_eq!(std::fs::metadata(&quarantined[0]).unwrap().len(), 1466);
+    assert!(
+        std::fs::read(&quarantined[0])
+            .unwrap()
+            .iter()
+            .all(|byte| *byte == 0)
+    );
+}
+
+#[test]
+fn test_zero_padded_registry_file_with_trailing_newline_is_quarantined() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join(REGISTRY_FILE);
+    std::fs::write(&path, [0, 0, 0, b'\r', b'\n']).unwrap();
+
+    let registry = FileRegistry::new(dir.path()).unwrap();
+
+    assert!(registry.is_empty());
+    assert!(!path.exists());
+    let quarantined = corrupted_registry_files(dir.path());
+    assert_eq!(quarantined.len(), 1);
+    assert_eq!(
+        std::fs::read(&quarantined[0]).unwrap(),
+        vec![0, 0, 0, b'\r', b'\n']
+    );
+}
+
+#[test]
+fn test_whitespace_only_registry_file_stays_empty_without_quarantine() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join(REGISTRY_FILE);
+    std::fs::write(&path, " \r\n\t").unwrap();
+
+    let registry = FileRegistry::new(dir.path()).unwrap();
+
+    assert!(registry.is_empty());
+    assert!(path.exists());
+    assert!(corrupted_registry_files(dir.path()).is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Treat NUL-padded `services.json` snapshots as corrupted-empty registry files.
- Quarantine the bad snapshot as `services.json.corrupted-<unix_ts>` and start with an empty registry instead of aborting startup.
- Add regression coverage for fully NUL, NUL plus trailing newline, and whitespace-only empty registry behavior.

Closes #1103

## Validation
- `vx cargo fmt --all -- --check`
- `git diff --check`
- `vx cargo test -p dcc-mcp-transport registry_file --lib -- --nocapture`
- `vx cargo test -p dcc-mcp-transport`
- `vx just test-rust`

Skill developer guidance: no update needed; this is an internal FileRegistry read-side recovery fix and does not change public APIs, skill authoring rules, schemas, server wiring, or agent workflows.