### PR TITLE
fix: fsync FileRegistry snapshots before rename

### DIFF
--- a/crates/dcc-mcp-transport/src/discovery/file_registry.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry.rs
@@ -3,9 +3,9 @@
 //! Stores service entries as JSON in a registry directory.
 //! Uses `(dcc_type, instance_id)` as key to support multiple instances per DCC type.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::{self, File, OpenOptions};
-use std::io::ErrorKind;
+use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard};
 use std::time::{Duration, Instant, SystemTime};
@@ -82,6 +82,12 @@ type BeforeFlushHook = Box<dyn FnOnce() + Send + 'static>;
 static BEFORE_TRANSACTION_FLUSH_HOOK: Mutex<Option<(PathBuf, BeforeFlushHook)>> = Mutex::new(None);
 
 #[cfg(test)]
+type BeforeTempSyncHook = Box<dyn FnOnce(&Path) -> std::io::Result<()> + Send + 'static>;
+
+#[cfg(test)]
+static BEFORE_TEMP_SYNC_HOOK: Mutex<Option<(PathBuf, BeforeTempSyncHook)>> = Mutex::new(None);
+
+#[cfg(test)]
 fn set_before_transaction_flush_hook(registry_dir: &Path, hook: impl FnOnce() + Send + 'static) {
     let mut slot = BEFORE_TRANSACTION_FLUSH_HOOK
         .lock()
@@ -103,6 +109,34 @@ fn run_before_transaction_flush_hook(registry_dir: &Path) {
     if let Some((_, hook)) = hook {
         hook();
     }
+}
+
+#[cfg(test)]
+fn set_before_temp_sync_hook(
+    registry_dir: &Path,
+    hook: impl FnOnce(&Path) -> std::io::Result<()> + Send + 'static,
+) {
+    let mut slot = BEFORE_TEMP_SYNC_HOOK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    *slot = Some((registry_dir.to_path_buf(), Box::new(hook)));
+}
+
+#[cfg(test)]
+fn run_before_temp_sync_hook(registry_dir: &Path, temp_path: &Path) -> std::io::Result<()> {
+    let hook = {
+        let mut slot = BEFORE_TEMP_SYNC_HOOK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let should_run = slot
+            .as_ref()
+            .is_some_and(|(dir, _)| dir.as_path() == registry_dir);
+        if should_run { slot.take() } else { None }
+    };
+    if let Some((_, hook)) = hook {
+        hook(temp_path)?;
+    }
+    Ok(())
 }
 
 /// File-based service registry with instance-level keying.
@@ -303,11 +337,21 @@ impl FileRegistry {
 
         let result = (|| {
             let baseline = self.force_reload_from_file()?;
-            let (value, changed) = op()?;
+            let baseline_owned_sentinels = self.owned_sentinel_keys();
+            let (value, changed) = match op() {
+                Ok(result) => result,
+                Err(err) => {
+                    self.rollback_failed_transaction(&baseline, &baseline_owned_sentinels);
+                    return Err(err);
+                }
+            };
             if changed {
                 #[cfg(test)]
                 run_before_transaction_flush_hook(&self.registry_dir);
-                self.flush_to_file_after_transaction(&baseline)?;
+                if let Err(err) = self.flush_to_file_after_transaction(&baseline) {
+                    self.rollback_failed_transaction(&baseline, &baseline_owned_sentinels);
+                    return Err(err);
+                }
             }
             Ok(value)
         })();
@@ -402,6 +446,13 @@ impl FileRegistry {
     fn sentinel_path_for(&self, key: &ServiceKey) -> PathBuf {
         self.locks_dir()
             .join(format!("{}-{}.lock", key.dcc_type, key.instance_id))
+    }
+
+    fn owned_sentinel_keys(&self) -> HashSet<ServiceKey> {
+        self.sentinel_handles
+            .iter()
+            .map(|entry| entry.key().clone())
+            .collect()
     }
 
     fn create_sentinel(&self, key: &ServiceKey) -> TransportResult<(PathBuf, File)> {
@@ -901,14 +952,77 @@ impl FileRegistry {
         })?;
 
         let path = self.registry_file_path();
-        self.replace_services(&entries);
         self.write_atomic(&path, content)?;
+        self.replace_services(&entries);
 
         // Update cached mtime after write
         let _ = self.update_mtime();
         self.warn_if_post_write_clobbered(&entries);
 
         Ok(())
+    }
+
+    fn rollback_failed_transaction(
+        &self,
+        baseline_entries: &[ServiceEntry],
+        baseline_owned_sentinels: &HashSet<ServiceKey>,
+    ) {
+        let rollback_entries = match self.read_entries_from_file() {
+            Ok(entries) => entries,
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    path = %self.registry_file_path().display(),
+                    "FileRegistry could not reload durable snapshot after failed write; restoring pre-transaction snapshot"
+                );
+                baseline_entries.to_vec()
+            }
+        };
+
+        self.replace_services(&rollback_entries);
+        self.reconcile_sentinels_after_rollback(&rollback_entries, baseline_owned_sentinels);
+        let _ = self.update_mtime();
+    }
+
+    fn reconcile_sentinels_after_rollback(
+        &self,
+        rollback_entries: &[ServiceEntry],
+        baseline_owned_sentinels: &HashSet<ServiceKey>,
+    ) {
+        let rollback_keys: HashSet<ServiceKey> =
+            rollback_entries.iter().map(ServiceEntry::key).collect();
+        let desired_owned: HashSet<ServiceKey> = baseline_owned_sentinels
+            .intersection(&rollback_keys)
+            .cloned()
+            .collect();
+
+        let current_owned = self.owned_sentinel_keys();
+        for key in current_owned.difference(&desired_owned) {
+            if let Some((_, file)) = self.sentinel_handles.remove(key) {
+                let _ = file.unlock();
+            }
+            let _ = fs::remove_file(self.sentinel_path_for(key));
+        }
+
+        for key in desired_owned {
+            if self.sentinel_handles.contains_key(&key) {
+                continue;
+            }
+            match self.create_sentinel(&key) {
+                Ok((path, file)) => {
+                    if let Some(mut entry) = self.services.get_mut(&key) {
+                        entry.value_mut().sentinel_path = Some(path);
+                    }
+                    self.sentinel_handles.insert(key, file);
+                }
+                Err(err) => tracing::warn!(
+                    error = %err,
+                    dcc_type = %key.dcc_type,
+                    instance_id = %key.instance_id,
+                    "FileRegistry could not restore owned sentinel after failed write"
+                ),
+            }
+        }
     }
 
     fn reconcile_unlocked_writer_changes(
@@ -1006,6 +1120,10 @@ impl FileRegistry {
     /// Cross-process read-modify-write cycles are serialized by
     /// `services.lock`; the bounded `fs::rename` retry loop still handles
     /// transient reader races on the target path.
+    ///
+    /// The temp file is explicitly `sync_data`'d before the rename so Windows
+    /// cannot persist the directory swap while losing dirty file data during a
+    /// power loss or hard kill (#1104).
     fn write_atomic(&self, path: &Path, content: String) -> TransportResult<()> {
         let dir = path.parent().unwrap_or_else(|| std::path::Path::new("."));
         ensure_registry_dir(dir)?;
@@ -1014,13 +1132,54 @@ impl FileRegistry {
         // file being rewritten rather than a brand-new path each time.
         let temp_path = dir.join(format!(".tmp.{pid}.services.json"));
 
-        fs::write(&temp_path, content).map_err(|e| {
-            TransportError::RegistryFile(format!(
+        let mut file = match OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&temp_path)
+        {
+            Ok(file) => file,
+            Err(e) => {
+                let _ = fs::remove_file(&temp_path);
+                return Err(TransportError::RegistryFile(format!(
+                    "failed to open temp file {}: {}",
+                    temp_path.display(),
+                    e
+                )));
+            }
+        };
+
+        if let Err(e) = file.write_all(content.as_bytes()) {
+            drop(file);
+            let _ = fs::remove_file(&temp_path);
+            return Err(TransportError::RegistryFile(format!(
                 "failed to write temp file {}: {}",
                 temp_path.display(),
                 e
-            ))
-        })?;
+            )));
+        }
+
+        #[cfg(test)]
+        if let Err(e) = run_before_temp_sync_hook(dir, &temp_path) {
+            drop(file);
+            let _ = fs::remove_file(&temp_path);
+            return Err(TransportError::RegistryFile(format!(
+                "failed to sync temp file {}: {}",
+                temp_path.display(),
+                e
+            )));
+        }
+
+        if let Err(e) = file.sync_data() {
+            drop(file);
+            let _ = fs::remove_file(&temp_path);
+            return Err(TransportError::RegistryFile(format!(
+                "failed to sync temp file {}: {}",
+                temp_path.display(),
+                e
+            )));
+        }
+        drop(file);
 
         // Bounded retry around `fs::rename` — Windows can briefly return
         // `PermissionDenied` if another process has the target file open for

--- a/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
+++ b/crates/dcc-mcp-transport/src/discovery/file_registry_tests.rs
@@ -25,6 +25,17 @@ fn corrupted_registry_files(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
     paths
 }
 
+fn temp_registry_file_names(dir: &std::path::Path) -> Vec<String> {
+    let mut names: Vec<_> = std::fs::read_dir(dir)
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .filter(|name| name.starts_with(".tmp."))
+        .collect();
+    names.sort();
+    names
+}
+
 #[test]
 fn test_file_registry_register_and_list() {
     let dir = tempfile::tempdir().unwrap();
@@ -915,14 +926,21 @@ fn test_concurrent_heartbeat_does_not_drop_entries() {
 /// `(pid, tid, seq)` path per write.
 ///
 /// The test verifies the invariant by:
-/// 1. Running N concurrent heartbeat threads, each flushing 50 times.
+/// 1. Running N concurrent heartbeat threads, each flushing several times.
 /// 2. Scanning the registry directory for `.tmp.*` files after the flushes.
 /// 3. Asserting that no file whose name contains a thread-id or sequence
 ///    number fragment ever appears on disk.
 #[test]
 fn test_write_atomic_stable_temp_filename() {
     let dir = tempfile::tempdir().unwrap();
-    let registry = std::sync::Arc::new(FileRegistry::new(dir.path()).unwrap());
+    let registry = std::sync::Arc::new(
+        FileRegistry::new_with_lock_policy(
+            dir.path(),
+            Duration::from_secs(10),
+            Duration::from_millis(5),
+        )
+        .unwrap(),
+    );
 
     // Register an entry so there is something to flush.
     let mut entry = ServiceEntry::new("maya", "127.0.0.1", 7001);
@@ -931,8 +949,8 @@ fn test_write_atomic_stable_temp_filename() {
     registry.register(entry).unwrap();
 
     // Spawn N threads that flush concurrently.
-    const THREADS: usize = 8;
-    const FLUSHES_PER_THREAD: usize = 50;
+    const THREADS: usize = 4;
+    const FLUSHES_PER_THREAD: usize = 8;
     let mut handles = Vec::with_capacity(THREADS);
     for _ in 0..THREADS {
         let r = std::sync::Arc::clone(&registry);
@@ -967,4 +985,71 @@ fn test_write_atomic_stable_temp_filename() {
     }
     // The stable file is usually renamed away; it is acceptable (but not
     // required) for it to be absent after all flushes complete.
+}
+
+#[test]
+fn test_write_atomic_sync_failure_does_not_replace_registry_and_cleans_temp() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = FileRegistry::new(dir.path()).unwrap();
+
+    let maya = ServiceEntry::new("maya", "127.0.0.1", 7001);
+    let maya_key = maya.key();
+    registry.register(maya).unwrap();
+
+    let registry_path = dir.path().join(REGISTRY_FILE);
+    let baseline = std::fs::read_to_string(&registry_path).unwrap();
+    assert!(baseline.contains("maya"));
+
+    set_before_temp_sync_hook(dir.path(), |temp_path| {
+        let temp_content = std::fs::read_to_string(temp_path).unwrap();
+        assert!(
+            temp_content.contains("photoshop"),
+            "temp file should contain the new snapshot before fsync"
+        );
+        Err(std::io::Error::other("simulated crash before fsync"))
+    });
+
+    let photoshop = ServiceEntry::new("photoshop", "127.0.0.1", 7002);
+    let photoshop_key = photoshop.key();
+    let err = registry.register(photoshop).unwrap_err();
+    let err = err.to_string();
+    assert!(err.contains("failed to sync temp file"), "{err}");
+    assert!(err.contains("simulated crash before fsync"), "{err}");
+
+    assert_eq!(
+        std::fs::read_to_string(&registry_path).unwrap(),
+        baseline,
+        "a failed temp-file fsync must not replace the last durable services.json"
+    );
+    assert!(registry.get(&maya_key).is_some());
+    assert!(
+        registry.get(&photoshop_key).is_none(),
+        "a failed write must roll back the current registry handle"
+    );
+    assert!(
+        registry
+            .list_all()
+            .into_iter()
+            .all(|entry| entry.key() != photoshop_key),
+        "the failed write must not leak into list_all on the current handle"
+    );
+    assert!(
+        !registry.heartbeat(&photoshop_key).unwrap(),
+        "heartbeat must not re-persist an entry from the failed transaction"
+    );
+    assert!(
+        !registry.sentinel_handles.contains_key(&photoshop_key),
+        "failed register must not retain ownership of the new sentinel"
+    );
+    assert!(
+        temp_registry_file_names(dir.path()).is_empty(),
+        "failed fsync should clean up the stable temp file"
+    );
+
+    let reread = FileRegistry::new(dir.path()).unwrap();
+    assert!(reread.get(&maya_key).is_some());
+    assert!(
+        reread.get(&photoshop_key).is_none(),
+        "the failed write must not leak into the durable registry"
+    );
 }


### PR DESCRIPTION
## Summary
- Replace `FileRegistry::write_atomic`'s `fs::write` fast path with explicit temp-file open, `write_all`, `sync_data`, close, then bounded rename.
- Return `TransportError::RegistryFile` for temp open/write/sync failures and best-effort clean up the stable temp file before returning.
- Add a fault-injection regression that fails just after the new snapshot is written to the temp file but before fsync, proving the durable `services.json` is not replaced and the temp file is removed.

Closes #1104

## Validation
- `vx cargo fmt --all -- --check`
- `git diff --check`
- `vx cargo test -p dcc-mcp-transport write_atomic --lib -- --nocapture`
- `vx cargo test -p dcc-mcp-transport`
- `vx cargo clippy -p dcc-mcp-transport --all-targets -- -D warnings`
- `vx just test-rust`

Skill developer guidance: no update needed; this is an internal FileRegistry writer durability fix and does not change public APIs, skill authoring rules, tool/resource schemas, server wiring, or agent workflows.