### PR TITLE
fix: stabilize gateway debug and admin time display

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -8,6 +8,7 @@ import unityIcon from './assets/icons/unity.svg';
 import unrealIcon from './assets/icons/unrealengine.svg';
 import substancePainterIcon from './assets/icons/photoshop.svg';
 import puzzleIcon from './assets/icons/puzzle.svg';
+import { formatTime, timestampTitle } from './time';
 
 type Panel = 'debug' | 'activity' | 'health' | 'instances' | 'tools' | 'tasks' | 'openapi' | 'calls' | 'traces' | 'stats' | 'logs' | 'skill-paths';
 
@@ -697,13 +698,6 @@ function flattenOpenApiOperations(spec: OpenApiSpec | null): OpenApiOperationRow
   return rows.sort((a, b) => a.path.localeCompare(b.path) || a.method.localeCompare(b.method));
 }
 
-function formatTime(value: string | null | undefined): string {
-  if (!value) {
-    return '-';
-  }
-  return new Date(value).toLocaleTimeString();
-}
-
 function formatUptime(value: number | null | undefined): string {
   if (value == null) {
     return '-';
@@ -756,6 +750,15 @@ function isWarnStatus(value: string | null | undefined): boolean {
 
 function StatusBadge({ value }: { value: string }) {
   return <span className={statusClass(value)}>{value}</span>;
+}
+
+function TimeValue({ value, className }: { value: string | null | undefined; className?: string }) {
+  const title = timestampTitle(value);
+  const text = formatTime(value);
+  if (!title) {
+    return <span className={className}>{text}</span>;
+  }
+  return <time className={className} dateTime={title} title={title}>{text}</time>;
 }
 
 function StatusLine({ text, error }: { text: string; error?: string }) {
@@ -2235,7 +2238,7 @@ function App() {
                     type="button"
                     onClick={() => row.request_id ? goToPanel('traces', { traceId: row.request_id }) : goToPanel('logs')}
                   >
-                    <span>{formatTime(row.timestamp)}</span>
+                    <TimeValue value={row.timestamp} />
                     <span>{row.source ?? row.level}</span>
                     <span title={row.message}>{row.message}</span>
                   </button>
@@ -2260,7 +2263,7 @@ function App() {
                     const requestId = event.correlation?.request_id;
                     return (
                       <tr key={event.event_id}>
-                        <td>{formatTime(event.timestamp)}</td>
+                        <td><TimeValue value={event.timestamp} /></td>
                         <td><StatusBadge value={event.status} /></td>
                         <td>{event.kind}</td>
                         <td title={event.message}>{event.message}</td>
@@ -2450,7 +2453,7 @@ function App() {
                         <div className="task-title-row">
                           <StatusBadge value={task.status} />
                           <span className="task-type">{task.task_type}</span>
-                          <span className="task-time">{formatTime(task.started_at)}</span>
+                          <TimeValue className="task-time" value={task.started_at} />
                         </div>
                         <h3 title={task.title}>{task.title}</h3>
                         <div className="task-meta">
@@ -2493,7 +2496,7 @@ function App() {
                     <tbody>
                       {groupCalls.map((call) => (
                         <tr key={call.request_id}>
-                          <td>{formatTime(call.timestamp)}</td>
+                          <td><TimeValue value={call.timestamp} /></td>
                           <td>
                             <button className="refresh-btn" type="button" title={call.request_id} onClick={() => goToPanel('traces', { traceId: call.request_id })}>
                               {call.request_id.slice(0, 12)}
@@ -2562,7 +2565,7 @@ function App() {
                         >
                           <span className="trace-item-main">
                             <strong>{trace.tool}</strong>
-                            <span>{compactId(trace.request_id)} - {formatTime(trace.timestamp)} - {trace.transport ?? '?'}</span>
+                            <span>{compactId(trace.request_id)} - <TimeValue value={trace.timestamp} /> - {trace.transport ?? '?'}</span>
                             <span>{agentLabel(trace)}{trace.slowest_span_name ? ` - slowest ${trace.slowest_span_name} ${formatDurationMs(trace.slowest_span_ms)}` : ''}</span>
                           </span>
                           <span className="trace-item-side">
@@ -2714,7 +2717,7 @@ function App() {
                           Request <span className="mono-path">{run.requestId}</span>
                         </div>
                         <div className="run-meta">
-                          {formatTime(run.timestamp)} · {run.dccType} · {run.tool}
+                          <TimeValue value={run.timestamp} /> · {run.dccType} · {run.tool}
                         </div>
                       </div>
                       <StatusBadge value={run.status} />
@@ -2726,7 +2729,7 @@ function App() {
                           <div className="step-body">
                             <div className="step-head">
                               <span className="step-name">Step {idx + 1}: {logStepTitle(log)}</span>
-                              <span className="muted">{formatTime(log.timestamp)}</span>
+                              <TimeValue className="muted" value={log.timestamp} />
                               <span className="source-pill" data-source={log.source ?? 'contention'}>{log.source ?? 'contention'}</span>
                             </div>
                             <div className="step-detail">{logStepDetail(log)}</div>
@@ -2748,7 +2751,7 @@ function App() {
                             <div key={`${log.timestamp}-${log.request_id ?? ''}-${idx}`} className="log-line">
                               <span className="source-pill" data-source={log.source ?? 'contention'}>{log.source ?? 'contention'}</span>
                               {' '}
-                              <span className="muted">{formatTime(log.timestamp)}</span>
+                              <TimeValue className="muted" value={log.timestamp} />
                               {' '}
                               <span className="warn-text">[{log.level}]</span>
                               {' '}

--- a/admin-ui/src/time.ts
+++ b/admin-ui/src/time.ts
@@ -1,0 +1,37 @@
+function twoDigit(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+function isSameLocalDate(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+function parseTimestamp(value: string | null | undefined): Date | null {
+  if (!value) {
+    return null;
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function formatTime(value: string | null | undefined, now: Date = new Date()): string {
+  const date = parseTimestamp(value);
+  if (!date) {
+    return '-';
+  }
+
+  const time = `${twoDigit(date.getHours())}:${twoDigit(date.getMinutes())}:${twoDigit(date.getSeconds())}`;
+  if (isSameLocalDate(date, now)) {
+    return time;
+  }
+  return `${twoDigit(date.getMonth() + 1)}/${twoDigit(date.getDate())} ${time}`;
+}
+
+export function timestampTitle(value: string | null | undefined): string | undefined {
+  const date = parseTimestamp(value);
+  return date ? date.toISOString() : undefined;
+}

--- a/admin-ui/tests/formatTime.spec.ts
+++ b/admin-ui/tests/formatTime.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test';
+
+import { formatTime, timestampTitle } from '../src/time';
+
+function localIso(year: number, month: number, day: number, hour: number, minute: number, second: number): string {
+  return new Date(year, month - 1, day, hour, minute, second).toISOString();
+}
+
+test.describe('formatTime', () => {
+  test('keeps same-day timestamps compact', () => {
+    const now = new Date(2026, 4, 22, 12, 0, 0);
+
+    expect(formatTime(localIso(2026, 5, 22, 14, 8, 23), now)).toBe('14:08:23');
+  });
+
+  test('adds month and day for cross-day timestamps', () => {
+    const now = new Date(2026, 4, 22, 12, 0, 0);
+
+    expect(formatTime(localIso(2026, 5, 21, 14, 8, 23), now)).toBe('05/21 14:08:23');
+  });
+
+  test('returns a dash for missing or invalid timestamps', () => {
+    expect(formatTime(null)).toBe('-');
+    expect(formatTime(undefined)).toBe('-');
+    expect(formatTime('not-a-date')).toBe('-');
+  });
+
+  test('provides absolute ISO text for hover titles', () => {
+    const value = localIso(2026, 5, 22, 14, 8, 23);
+
+    expect(timestampTitle(value)).toBe(new Date(value).toISOString());
+    expect(timestampTitle(null)).toBeUndefined();
+  });
+});

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -16,6 +16,7 @@ mod admin_tests {
 
     use crate::gateway::admin::router::build_admin_router;
     use crate::gateway::admin::state::{AdminAuditRecord, AdminState, AuditLog};
+    use crate::gateway::router::build_gateway_router_with_admin;
     use crate::gateway::state::GatewayState;
     use dcc_mcp_transport::discovery::file_registry::FileRegistry;
 
@@ -123,6 +124,7 @@ mod admin_tests {
             instance_diagnostics: Arc::new(
                 crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
             ),
+            debug_routes_enabled: false,
         }
     }
 
@@ -150,6 +152,19 @@ mod admin_tests {
         (status, json)
     }
 
+    async fn response_status(router: Router, uri: &str) -> StatusCode {
+        router
+            .oneshot(
+                Request::builder()
+                    .uri(uri)
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+            .status()
+    }
+
     async fn body_html(router: Router, uri: &str) -> (StatusCode, String, String) {
         let resp = router
             .oneshot(
@@ -173,6 +188,31 @@ mod admin_tests {
     }
 
     // ── HTML dashboard ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn gateway_router_without_admin_state_omits_debug_routes_from_openapi() {
+        let router = build_gateway_router_with_admin(make_gateway_state(), None, "/admin");
+
+        let (status, doc) = body_json(router.clone(), "/v1/openapi.json").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(doc["paths"].get("/v1/search").is_some());
+        assert!(doc["paths"].get("/v1/debug/instances").is_none());
+        assert_eq!(
+            response_status(router, "/v1/debug/instances").await,
+            StatusCode::NOT_FOUND
+        );
+    }
+
+    #[tokio::test]
+    async fn gateway_router_with_admin_state_lists_debug_routes_in_openapi() {
+        let state = make_gateway_state();
+        let router =
+            build_gateway_router_with_admin(state.clone(), Some(AdminState::new(state)), "/admin");
+
+        let (status, doc) = body_json(router, "/v1/openapi.json").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(doc["paths"].get("/v1/debug/instances").is_some());
+    }
 
     #[tokio::test]
     async fn test_admin_ui_returns_html() {

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
@@ -156,6 +156,7 @@ async fn aggregate_tools_list_returns_only_minimal_gateway_surface() {
         instance_diagnostics: std::sync::Arc::new(
             crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
         ),
+        debug_routes_enabled: false,
     };
 
     assert_eq!(gs.live_instances(&*gs.registry.read().await).len(), 1);
@@ -321,6 +322,7 @@ async fn make_gateway_state(
         instance_diagnostics: std::sync::Arc::new(
             crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
         ),
+        debug_routes_enabled: false,
     }
 }
 
@@ -853,6 +855,7 @@ async fn gateway_state_with_instances(
         instance_diagnostics: std::sync::Arc::new(
             crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
         ),
+        debug_routes_enabled: false,
     };
     (state, dir, ids)
 }

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/resources.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/resources.rs
@@ -289,6 +289,7 @@ mod tests {
             instance_diagnostics: Arc::new(
                 crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
             ),
+            debug_routes_enabled: false,
             #[cfg(feature = "prometheus")]
             gateway_metrics: Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
         }

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
@@ -144,7 +144,9 @@ pub async fn handle_v1_openapi(State(gs): State<GatewayState>) -> impl IntoRespo
     #[cfg(feature = "admin")]
     let doc = {
         let mut doc = doc;
-        super::debug_openapi::add_gateway_debug_openapi_paths(&mut doc);
+        if gs.debug_routes_enabled {
+            super::debug_openapi::add_gateway_debug_openapi_paths(&mut doc);
+        }
         doc
     };
     (StatusCode::OK, Json(doc))
@@ -157,7 +159,9 @@ pub async fn handle_v1_docs(State(gs): State<GatewayState>) -> Response {
     #[cfg(feature = "admin")]
     let doc = {
         let mut doc = doc;
-        super::debug_openapi::add_gateway_debug_openapi_paths(&mut doc);
+        if gs.debug_routes_enabled {
+            super::debug_openapi::add_gateway_debug_openapi_paths(&mut doc);
+        }
         doc
     };
     let html = dcc_mcp_skill_rest::openapi::build_docs_html_for_document(doc);
@@ -852,6 +856,13 @@ mod tests {
     }
 
     fn test_gateway_state(server_version: &str) -> GatewayState {
+        test_gateway_state_with_debug_routes(server_version, false)
+    }
+
+    fn test_gateway_state_with_debug_routes(
+        server_version: &str,
+        debug_routes_enabled: bool,
+    ) -> GatewayState {
         let dir = tempfile::tempdir().unwrap();
         let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
         let (yield_tx, _) = watch::channel(false);
@@ -882,6 +893,7 @@ mod tests {
             instance_diagnostics: Arc::new(
                 crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
             ),
+            debug_routes_enabled,
             #[cfg(feature = "prometheus")]
             gateway_metrics: Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
         }
@@ -909,13 +921,26 @@ mod tests {
         assert!(body.contains("scalar") || body.contains("Scalar"));
         assert!(body.contains("dcc-mcp-gateway"));
         assert!(body.contains("/v1/search"));
+        assert!(!body.contains("/v1/debug/instances"));
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "admin")]
+    async fn gateway_docs_lists_debug_routes_when_runtime_debug_routes_enabled() {
+        let (status, body) = response_text(
+            handle_v1_docs(State(test_gateway_state_with_debug_routes("1.2.3", true))).await,
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
         assert!(body.contains("/v1/debug/instances"));
     }
 
     #[tokio::test]
+    #[cfg(feature = "admin")]
     async fn gateway_openapi_lists_stable_debug_routes() {
         let (status, doc) = response_json(
-            handle_v1_openapi(State(test_gateway_state("1.2.3")))
+            handle_v1_openapi(State(test_gateway_state_with_debug_routes("1.2.3", true)))
                 .await
                 .into_response(),
         )
@@ -950,6 +975,56 @@ mod tests {
             doc["components"]["schemas"]
                 .get("GatewayDebugPayload")
                 .is_some()
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "admin")]
+    async fn gateway_openapi_omits_debug_routes_when_runtime_admin_disabled() {
+        let (status, doc) = response_json(
+            handle_v1_openapi(State(test_gateway_state("1.2.3")))
+                .await
+                .into_response(),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert!(doc["paths"].get("/v1/search").is_some());
+        assert!(doc["paths"].get("/v1/debug/instances").is_none());
+        assert!(
+            doc["tags"]
+                .as_array()
+                .is_none_or(|tags| !tags.iter().any(|tag| tag["name"] == "debug"))
+        );
+        assert!(
+            doc["components"]["schemas"]
+                .get("GatewayDebugPayload")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(not(feature = "admin"))]
+    async fn gateway_openapi_omits_debug_routes_without_admin_feature() {
+        let (status, doc) = response_json(
+            handle_v1_openapi(State(test_gateway_state("1.2.3")))
+                .await
+                .into_response(),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert!(doc["paths"].get("/v1/search").is_some());
+        assert!(doc["paths"].get("/v1/debug/instances").is_none());
+        assert!(
+            doc["tags"]
+                .as_array()
+                .is_none_or(|tags| !tags.iter().any(|tag| tag["name"] == "debug"))
+        );
+        assert!(
+            doc["components"]["schemas"]
+                .get("GatewayDebugPayload")
+                .is_none()
         );
     }
 

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/sse_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/sse_impl.rs
@@ -186,6 +186,7 @@ mod tests {
             instance_diagnostics: Arc::new(
                 crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
             ),
+            debug_routes_enabled: false,
         }
     }
 

--- a/crates/dcc-mcp-gateway/src/gateway/router.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/router.rs
@@ -44,7 +44,8 @@ use super::state::GatewayState;
 /// Admin UI (#772, `admin` feature):
 /// - `GET  /admin`              — HTML dashboard
 /// - `GET  /admin/api/*`        — JSON API endpoints
-pub fn build_gateway_router(state: GatewayState) -> Router {
+pub fn build_gateway_router(mut state: GatewayState) -> Router {
+    state.debug_routes_enabled = false;
     let limits = gateway_limits();
     let mut r = build_base_router(state);
     r = r.layer(RequestBodyLimitLayer::new(limits.body_max_bytes));
@@ -69,6 +70,12 @@ pub fn build_gateway_router_with_admin(
     #[cfg(feature = "admin")] admin_state: Option<super::admin::state::AdminState>,
     #[cfg(feature = "admin")] admin_path: &str,
 ) -> Router {
+    #[cfg(feature = "admin")]
+    let mut state = state;
+    #[cfg(feature = "admin")]
+    {
+        state.debug_routes_enabled = admin_state.is_some();
+    }
     let limits = gateway_limits();
     let mut router = build_base_router(state);
     router = router.layer(RequestBodyLimitLayer::new(limits.body_max_bytes));

--- a/crates/dcc-mcp-gateway/src/gateway/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state.rs
@@ -241,6 +241,13 @@ pub struct GatewayState {
 
     /// Cached per-instance readiness + last call error (#1076).
     pub instance_diagnostics: Arc<InstanceDiagnosticsStore>,
+
+    /// Whether stable gateway `/v1/debug/*` routes are mounted on this router.
+    ///
+    /// The routes require the `admin` feature at compile time and an AdminState
+    /// at runtime. OpenAPI generation reads this so the published contract does
+    /// not advertise routes disabled by `--no-admin` / `admin_enabled = false`.
+    pub debug_routes_enabled: bool,
 }
 
 impl GatewayState {

--- a/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
@@ -51,6 +51,7 @@ fn test_gateway_state_with_own_and_unknown(
         instance_diagnostics: Arc::new(
             crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
         ),
+        debug_routes_enabled: false,
     }
 }
 

--- a/crates/dcc-mcp-gateway/src/gateway/tasks.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tasks.rs
@@ -575,6 +575,7 @@ pub(crate) async fn start_gateway_tasks(
         gateway_metrics: gateway_metrics.clone(),
         middleware_chain: Arc::new(middleware_chain),
         instance_diagnostics: instance_diagnostics.clone(),
+        debug_routes_enabled: false,
     };
 
     // ── Admin UI state (#772, #864) ────────────────────────────────────────

--- a/docs/guide/rest-api-surface.md
+++ b/docs/guide/rest-api-surface.md
@@ -63,6 +63,12 @@ The elected gateway promotes the Admin telemetry providers to stable
 in `GET /v1/openapi.json`; the `/admin/api/*` routes remain compatibility
 aliases for the embedded dashboard.
 
+This surface requires the gateway `admin` feature and runtime Admin telemetry.
+The shipped `dcc-mcp-server` and Python `dcc-mcp-http` gateway path enable it
+by default; minimal direct `dcc-mcp-gateway` builds without `admin`, or
+runtimes started with Admin disabled (`--no-admin` / `admin_enabled = false`),
+omit both the `/v1/debug/*` routes and their OpenAPI entries.
+
 Phase-1 debug routes intentionally preserve the existing Admin payload fields
 so operators and agents can compare results one-to-one:
 

--- a/docs/zh/guide/rest-api-surface.md
+++ b/docs/zh/guide/rest-api-surface.md
@@ -58,6 +58,12 @@
 `/v1/debug/*` agent/CI 诊断路由。这些路由会出现在 `GET /v1/openapi.json`
 里；`/admin/api/*` 继续作为内嵌 dashboard 的兼容别名。
 
+这个 surface 依赖 gateway 的 `admin` feature 和运行时 Admin telemetry。
+发布的 `dcc-mcp-server` 和 Python `dcc-mcp-http` gateway 路径默认启用它；
+如果直接以 minimal `dcc-mcp-gateway` 构建且不启用 `admin`，或运行时关闭
+Admin（`--no-admin` / `admin_enabled = false`），则不会挂载 `/v1/debug/*`
+路由，也不会在 OpenAPI 中列出这些路径。
+
 Phase-1 debug routes 会保留现有 Admin payload 字段，让 operator 和 agent
 能一对一对照结果：
 

--- a/skills/dcc-mcp-skill-developer/SKILL.md
+++ b/skills/dcc-mcp-skill-developer/SKILL.md
@@ -58,7 +58,10 @@ into a faster authoring loop.
    adapter example surfaces an `mcp_url`, make sure the Admin Dashboard can
    derive per-instance OpenAPI Inspector, spec JSON, and docs links from it.
    For machine consumers, prefer the stable gateway `/v1/debug/*` routes and
-   `GET /v1/openapi.json` over scraping `/admin` HTML or dashboard internals.
+   `GET /v1/openapi.json` over scraping `/admin` HTML or dashboard internals;
+   the shipped server paths enable the required gateway `admin` feature and
+   Admin telemetry runtime state, while minimal direct `dcc-mcp-gateway` builds
+   or runtimes started with Admin disabled may omit those debug routes.
 7. For adapter install, uninstall, or upgrade flows, use
    `dcc_mcp_core.install_lifecycle` before importing Rust-backed public API:
    query/stop registered sidecars, inspect install roots, classify locked


### PR DESCRIPTION
## Summary
- Clarify that stable gateway `/v1/debug/*` OpenAPI routes are gated by both the gateway `admin` feature and runtime Admin telemetry being mounted.
- Update Admin UI timestamps so same-day events stay compact while cross-day events include month/day.
- Add focused timestamp formatting coverage and update skill developer guidance for debug route availability.

## Validation
- `vx npm run build`
- `vx npm run test -- tests/formatTime.spec.ts`
- `vx cargo test -p dcc-mcp-gateway debug --lib`
- `vx cargo test -p dcc-mcp-gateway --features admin debug --lib`
- `vx cargo test -p dcc-mcp-gateway --features admin gateway_openapi --lib`
- `vx cargo test -p dcc-mcp-gateway --features admin gateway_router_ --lib`
- `vx cargo test -p dcc-mcp-gateway --features admin gateway_docs --lib`
- `vx cargo test -p dcc-mcp-gateway gateway_docs_serves_scalar_openapi_ui --lib`
- `vx cargo test -p dcc-mcp-gateway --features admin gateway_docs_serves_scalar_openapi_ui --lib`
- `vx python scripts/vrs_replay.py --base-url http://127.0.0.1:1 --dry-run --trace tests/vrs/traces/core-1092-stable-debug-api.jsonl`

Closes #1092
Closes #1109