### PR TITLE
docs: add gateway RFC proposals

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -19,6 +19,7 @@ export default defineConfig({
         nav: [
           { text: 'Guide', link: '/guide/what-is-dcc-mcp-core' },
           { text: 'API', link: '/api/models' },
+          { text: 'RFCs', link: '/rfcs/' },
           {
             text: 'v0.17.22', // x-release-please-version
             items: [
@@ -141,6 +142,17 @@ export default defineConfig({
                 { text: 'Hot Reload', link: '/api/hot-reload' },
                 { text: 'Server Factory', link: '/api/factory' },
                 { text: 'Callable Dispatcher', link: '/api/dispatcher' },
+              ],
+            }
+          ],
+          '/rfcs/': [
+            {
+              text: 'Request for Comments',
+              items: [
+                { text: 'Overview', link: '/rfcs/' },
+                { text: '0001: Gateway Election Resilience', link: '/rfcs/0001-gateway-election-resilience' },
+                { text: '0002: Event Bus & Webhooks', link: '/rfcs/0002-event-bus-and-webhooks' },
+                { text: '0003: Traffic Interception & Agent Debugging', link: '/rfcs/0003-traffic-interception-and-replay' },
               ],
             }
           ]

--- a/docs/rfcs/0001-gateway-election-resilience.md
+++ b/docs/rfcs/0001-gateway-election-resilience.md
@@ -68,7 +68,7 @@ unresponsive).
 
 ## Hard constraints
 
-These come from real downstream deployments, but they are typical of
+These constraints are typical of
 any in-DCC Python ecosystem:
 
 1. **No new processes.** The current "every DCC adapter ships its own
@@ -539,10 +539,3 @@ harden the upgrade path and make the protocol fully resumable.
   observable disconnect classes - current analysis says they don't.
 - **Cross-host gateway federation**. Today everything is localhost; LAN
   federation would belong in a separate RFC after this one lands.
-
-## Acknowledgements
-
-This RFC originated from end-to-end integration work on a downstream
-Maya adapter package - bootstrap, debugpy attach, and agent-driven
-`create_shelves` flows that exposed the
-preemption-induced disconnect in a reproducible way.

--- a/docs/rfcs/0001-gateway-election-resilience.md
+++ b/docs/rfcs/0001-gateway-election-resilience.md
@@ -1,0 +1,548 @@
+# RFC 0001 - Gateway Election Resilience
+
+**Status**: Draft
+**Target repo**: `dcc-mcp-core`
+**Authors**: dcc-mcp-core contributors
+**Date**: 2026-05-23
+**Related code**: `dcc_mcp_gateway::gateway::runner`, `dcc_mcp_transport::discovery::file_registry`, `dcc_mcp_http::server`, `dcc_mcp_http_server::session`
+
+---
+
+## Summary
+
+Today, when a second DCC instance starts and wins the gateway election, the
+process that was previously serving port 9765 yields, the port briefly
+closes, and the new process binds it. Long-lived MCP clients (Cursor,
+VS Code, custom agents) **lose their connection mid-session** with no
+in-band recovery signal, and a stateless backend has no way to resume.
+
+This RFC proposes a set of independently shippable changes to `dcc-mcp-core`
+that make gateway transitions either **invisible to clients** or **cleanly
+recoverable**, without adding new processes, new packaging artifacts, or
+DCC-specific code paths.
+
+## Motivation - two scenarios that today share one mechanism
+
+Election today is **version-driven preemption**: whichever adapter has the
+higher `dcc_mcp_core` version wins, and the previous owner cooperatively
+yields. This single mechanism is asked to serve two very different
+scenarios with opposite client-facing requirements:
+
+### Scenario 1 - startup of a co-existing DCC (`disconnect == bug`)
+
+A studio user already has Maya open with an active agent session. They
+start a second Maya for a parallel scene. The second Maya's adapter
+finds the current gateway "outranked" and triggers a handover, taking
+down the first user's MCP session as collateral damage:
+
+```text
+2026-05-22T19:36:08  INFO  Registered in FileRegistry instance=ff70b208-...
+2026-05-22T19:36:08  INFO  We outrank the current gateway - entering challenger mode
+                              own=0.17.21 own_adapter_dcc=None
+                              gateway=0.3.7 gateway_adapter_dcc=Some("maya")
+2026-05-22T19:36:08  INFO  Cooperative yield accepted - waiting for port to free up
+2026-05-22T19:36:08  INFO  Won gateway election version=0.3.7
+2026-05-22T19:36:08  INFO  gateway SSE: backend in stateless mode
+                              - no MCP-Session-Id / __session_id
+2026-05-22T19:36:08  INFO  gateway SSE: stateless MCP backend
+                              - SSE subscription unavailable; parked
+```
+
+The MCP client (Cursor) sees only `"Server is not ready"` thereafter.
+**This is the bug.**
+
+### Scenario 2 - owner adapter crashes (`failover == feature`)
+
+A Maya holding the gateway dies hard - segfault, OOM, force-kill, host
+sleep. Without something to take over, port 9765 has no listener and the
+whole studio's agent fleet is offline until someone notices. Today the
+crash is "rescued" only because **any** newer DCC startup will preempt
+and rebind the port - i.e. failover happens as a side effect of the
+preemption rule that breaks Scenario 1.
+
+**These two scenarios need different decisions and different signals.**
+Disconnect-on-coexist is purely the wrong default; disconnect-on-crash-
+recovery is the correct trade-off but is currently triggered by the
+wrong condition (version outranks) instead of the right one (peer
+unresponsive).
+
+## Hard constraints
+
+These come from real downstream deployments, but they are typical of
+any in-DCC Python ecosystem:
+
+1. **No new processes.** The current "every DCC adapter ships its own
+   embedded HTTP server, and one of them happens to also host the gateway"
+   model deploys cleanly through rez / thm / per-host plugin managers.
+   Introducing a separate `gateway` daemon, sidecar proxy, systemd unit,
+   or Windows service breaks studio packaging and asks operators to manage
+   a new lifecycle.
+2. **rez packaging must stay flat.** Any new artifact (extra rez package,
+   extra entry point, extra environment variable) multiplies the number
+   of packages a DCC `package.py` has to `requires`. Prefer changes that
+   live inside `dcc-mcp-core` and propagate via existing dependencies.
+3. **Multi-DCC by construction.** Maya, Blender, 3ds Max, Houdini,
+   Photoshop, ZBrush, Unreal, Unity - and the long-tail of studio
+   integrations on top - all share the gateway. Every change must be
+   implemented in `dcc-mcp-core` and inherited; no per-adapter changes
+   should be required to opt in to resilience.
+4. **Backward compatible.** Old `dcc-mcp-*` adapters and old MCP clients
+   must keep working unchanged. Resilience features are negotiated.
+
+## Non-goals
+
+- Hot binary upgrade of an in-flight DCC adapter (the DCC process itself
+  is still ephemeral).
+- High-availability gateway across hosts (everything here is on
+  localhost; remote LAN clients keep using the existing 0.0.0.0 listener).
+- Reimplementing the MCP wire protocol.
+
+---
+
+## Design
+
+Four independent components. Each is shippable on its own and brings
+visible value; together they remove the disconnect class entirely.
+
+### A. Liveness-driven election with automatic failover
+
+The right decision for an arriving adapter is **not** "am I higher
+version", it is **"is the current owner actually serving traffic right
+now?"**. Co-existence and failover are both correctly answered by that
+single question.
+
+**Mechanism: lease + heartbeat + active probe.**
+
+The gateway owner publishes a lease in `FileRegistry`:
+
+```jsonc
+// services.json (extended)
+{
+  "gateway_lease": {
+    "instance_id": "1f363976-dcf9-4e35-aa5a-b854b47b1ec2",
+    "endpoint":    "http://127.0.0.1:9765/mcp",
+    "version":     "0.17.21",
+    "renewed_unix_secs": 1779478211,
+    "ttl_secs":         5
+  }
+}
+```
+
+The owner renews `renewed_unix_secs` every `ttl_secs / 3` seconds (1.6 s
+default) - same write path the registry already uses for adapter
+heartbeats.
+
+**Arriving adapter decision tree (replaces the current
+`version_outranks` branch):**
+
+1. Read `gateway_lease`.
+2. **If lease is fresh** (`now - renewed <= ttl_secs`):
+   - **Active probe**: `GET http://<endpoint>/health` with a 2 s
+     timeout.
+   - Probe **200 OK** -> owner is alive and healthy. **Skip election.**
+     Register only as an instance and return; the existing gateway will
+     route to us via its FileRegistry watcher (already implemented).
+   - Probe **fails / times out / 5xx** -> owner is hung. Continue to
+     step 4 (failover path).
+3. **If lease is stale** (`now - renewed > ttl_secs`):
+   - Owner missed heartbeats - likely crashed. Still active-probe once
+     (cheap) to avoid racing a temporary GC pause; on failure continue.
+4. **Failover path** (formerly the "preemption" path):
+   - Atomically CAS the `gateway_lease` to ourselves (FileRegistry
+     already serializes writes via `services.lock`). If CAS loses, some
+     other arrival won the race - re-read and goto 1.
+   - Wait `socket_takeover_grace_ms` (default 500) for the dead owner's
+     OS socket to release (some platforms hold TIME_WAIT).
+   - Bind 9765 and start serving.
+   - Log clearly: `"Promoted to gateway after liveness failure of
+     <prev_instance> (last_renewed=...s ago, probe=<err>)"`.
+
+**Version-driven preemption** is *not* part of this default path. It
+remains available as an explicit opt-in for the rare rolling-upgrade
+case:
+
+```yaml
+# gateway_policy.yaml - defaults are conservative
+election:
+  default: liveness_driven    # Do not preempt healthy owners; take over failed owners.
+  lease_ttl_secs: 5
+  lease_renew_interval_secs: 1.6
+  probe_timeout_secs: 2
+  socket_takeover_grace_ms: 500
+
+  # Opt-in: rolling upgrades. Off by default to protect interactive sessions.
+  allow_version_preempt:
+    enabled: false
+    when:
+      component: dcc_mcp_core
+      bump: minor             # 0.17 -> 0.18 may preempt; 0.17.21 -> 0.17.22 may not
+```
+
+**Why this satisfies both scenarios:**
+
+- **Co-existing DCC starts.** Today: always preempts -> client drop.
+  Liveness-driven: probe passes -> silent register, no drop.
+- **Owner crashes.** Today: rescued only if a newer DCC happens to
+  start. Liveness-driven: detected within `ttl_secs`, *any* peer adapter
+  can promote.
+- **Owner hung** (Maya UI deadlock, long GC, kernel pause). Today:
+  same as crash, rescue is accidental. Liveness-driven: probe fails ->
+  controlled failover with explicit `Promoted` log line.
+- **Genuine rolling upgrade.** Today: always preempts. Liveness-driven:
+  opt-in via `allow_version_preempt` (off by default).
+
+### A.event - Pre-shutdown handoff event (graceful-exit fast path)
+
+Lease+heartbeat above gives ~`ttl_secs` MTTR for crashes. For the very
+common case of an *intentional* exit (user closes Maya, `kill -TERM`,
+planned upgrade, idle scheduler eviction) the owner has full opportunity
+to **actively announce** before going down. This collapses MTTR from
+seconds to tens of milliseconds and avoids any window where 9765 is
+unowned.
+
+**Mechanism: a single record in `services.json` + a single SSE
+notification, both atomic, both fire-and-forget.**
+
+When the gateway owner decides to shut down (or receives a shutdown
+signal), before closing its listener it performs **one write** to
+`FileRegistry` and **one broadcast** on its SSE stream:
+
+```jsonc
+// services.json - gateway_handoff is a transient record, GC'd by the
+// next successor on promotion or by the registry sweep after `until`.
+{
+  "gateway_handoff": {
+    "from_instance_id": "1f363976-...",
+    "endpoint":         "http://127.0.0.1:9765/mcp",
+    "reason":           "graceful_shutdown",
+                        // | "explicit_release" | "scheduled_upgrade"
+    "issued_unix_secs":  1779478215.0,
+    "deadline_unix_secs": 1779478220.0,   // owner promises to stay up
+                                          // until this point (5s grace)
+    "in_flight_calls":   2,
+    "subscribed_clients": 3,
+    "suggested_successor": "4a3c0197-..."   // optional - see A.standby
+  }
+}
+```
+
+```jsonc
+// SSE notification on every active /mcp subscription
+{
+  "jsonrpc": "2.0",
+  "method":  "notifications/gateway/handoff",
+  "params": {
+    "from":     "1f363976-...",
+    "deadline_unix_secs": 1779478220.0,
+    "reason":   "graceful_shutdown",
+    "endpoint_after_handoff_will_be_same": true
+  }
+}
+```
+
+**Two consumers, both already wired:**
+
+- **Peer adapters** subscribe to FileRegistry change events today (used
+  for instance discovery) - the new `gateway_handoff` field arrives via
+  the same callback. The first peer to observe it CAS's the
+  `gateway_lease` to itself, binds the port (the outgoing owner is still
+  holding it until `deadline`, so the bind succeeds via `SO_REUSEPORT`
+  on Linux, or via the cooperative-handoff window on Windows), and
+  starts serving. Once the new owner reports `bound`, the outgoing
+  owner releases. Total client-visible gap: typically &lt; 50 ms.
+- **MCP clients** subscribed to `/mcp` SSE receive
+  `notifications/gateway/handoff` and learn the deadline. Smart clients
+  hold their request queue for the grace window then retry in place
+  (since `endpoint_after_handoff_will_be_same=true` for the
+  "everyone shares 9765" deployment); naive clients fall through to
+  reconnect-on-error, no worse than today.
+
+**Interaction with the heartbeat path (A) - they are dual:**
+
+- **Graceful shutdown / SIGTERM** -> detected by A.event (this section),
+  MTTR ~50 ms.
+- **Hard crash, kill -9, host sleep** -> detected by A (lease expiry +
+  probe), MTTR ~`ttl_secs`.
+- **Slow hang (UI thread deadlock)** -> detected by A (probe fails
+  before lease expires), MTTR ~probe timeout.
+- **Planned upgrade with version bump** -> A.event when the outgoing
+  owner cooperates, plus opt-in `allow_version_preempt` as fallback;
+  MTTR ~50 ms.
+
+The two mechanisms write the **same** `gateway_lease` afterwards, so
+peers don't need to know which path triggered the change - they just
+re-read the lease.
+
+**Public API (so studio code can request a handoff explicitly):**
+
+```python
+# dcc_mcp_core.gateway
+def request_release(reason: str = "explicit_release",
+                    grace_secs: float = 5.0,
+                    suggested_successor: str | None = None) -> dict:
+    """Announce a handoff and return the result.
+
+    Useful when the embedding DCC tool wants to gracefully drop its
+    gateway role - e.g. a `before_quit` hook in Maya / Blender that
+    fires before plugin unload.
+    """
+```
+
+**Constraints check**: [ok] no new process (uses existing FileRegistry
+write + existing SSE channel) ; [ok] flat rez (one symbol added to
+`dcc-mcp-core`) ; [ok] multi-DCC (announce path is DCC-agnostic; only
+`reason` strings differ per integration) ; [ok] backward compatible
+(handoff is a hint - peers without the watcher still failover via the
+heartbeat path; clients without the notification handler fall through
+to reconnect).
+
+**SIGTERM hookup per host**: dcc-mcp-core registers a single signal
+handler / atexit hook. Per-adapter integration is one line:
+
+```python
+# dcc_mcp_maya: register on plugin load
+gateway.install_graceful_shutdown_hook(
+    fire_on=["maya.OpenMaya.MSceneMessage.kBeforeQuit",
+             "SIGTERM", "SIGINT", "atexit"])
+```
+
+Blender / 3ds Max / Houdini ship analogous one-liners pointed at their
+own `before_quit` events.
+
+**Constraints check**: [ok] no new process ; [ok] flat rez (gateway_policy.yaml
+ships inside `dcc-mcp-core` with conservative defaults; studios may
+override at runtime) ; [ok] multi-DCC (decision is `dcc_type`-agnostic) ; [ok]
+backward compatible (any pre-RFC adapter falls back to today's
+version-driven path because it doesn't know how to write the lease;
+new gateway treats missing-lease as "stale" and takes over after probe
+fails, matching today's behavior).
+
+### B. Graceful drain on election (when preemption *does* happen)
+
+When preemption is intentionally requested (`allow_preempt_when`), the
+outgoing gateway must hand over instead of vanishing:
+
+```text
+state machine:
+  Active  -- peer asserts higher rank --->  Draining
+  Draining (T_grace = 5s):
+     * stop accepting new SSE subscribers / POSTs
+     * finish in-flight tool calls (or fail them with retriable error)
+     * broadcast notification to all subscribers:
+         {"jsonrpc":"2.0",
+          "method":"notifications/gateway/draining",
+          "params":{
+             "next_endpoint":"http://127.0.0.1:54521/mcp",
+             "next_endpoint_stable":"http://127.0.0.1:9765/mcp",
+             "grace_ms":4500,
+             "reason":"preempted_by",
+             "peer":{"version":"0.18.0","instance_id":"..."}}}
+     * after grace: close listener with HTTP/2 GOAWAY equivalent
+                    (Connection: close + SSE event: close)
+  Closed   -- peer ready ---> peer binds 9765
+```
+
+**Wire format**: extends MCP `notifications/*` namespace under
+`notifications/gateway/...`. Clients that don't understand it ignore the
+notification (standard JSON-RPC behavior) and fall through to plain
+reconnect - they're no worse off than today.
+
+**Constraints check**: [ok] protocol-only, no process ; [ok] multi-DCC ; [ok]
+compatible (unknown notifications dropped silently).
+
+### C. Stable session id with backend-agnostic resume
+
+**Today.** Two relevant log lines:
+
+```text
+session created: fc4c2da2-1b72-401a-89e3-300e784785a8
+gateway SSE: backend in stateless mode - no MCP-Session-Id / __session_id
+```
+
+The session id exists internally but is not propagated through the
+gateway, so a client that reconnects after a drop starts fresh - all
+loaded skills, tool subscriptions, pending tasks are gone.
+
+**Proposal**:
+
+1. **Always propagate** `MCP-Session-Id` end-to-end. Gateway adds it on
+   first `initialize` if the backend didn't, and stores
+   `session_id -> {instance_id, last_active, capability_snapshot}` in a
+   small SQLite file under `dcc_mcp_transport::discovery` (next to
+   `services.lock`). One file, no service.
+2. **Resume path**. When a client reconnects with a known
+   `MCP-Session-Id`:
+   - If the backing DCC instance is still alive -> reattach.
+   - If gone -> return MCP error `session_resumed_on_new_instance` with
+     a `replay_hint` listing which skills were loaded, so the client
+     can `load_skill` them again in one batch.
+3. **GC**. Sessions older than `session_ttl_secs` (default 3600) are
+   evicted by the FileRegistry sweep that already runs.
+
+This is also the canonical answer to MCP spec 2025-06-18's "Streamable
+HTTP with resumable sessions" - so it doubles as **spec compliance
+work**, not just election fix.
+
+**Constraints check**: [ok] adds one SQLite file, no daemon ; [ok] DCC-agnostic
+(lives entirely in `dcc-mcp-core`) ; [ok] optional from the client side
+(clients without `MCP-Session-Id` get current behavior).
+
+### D. First-class resource for liveness/election state
+
+**Today.** `gateway://instances` exists but is queried on demand. The
+gateway capability declares `resources.subscribe=true` (good!) but the
+internal hook from election events -> `notifications/resources/updated`
+is missing, so clients can't passively follow.
+
+**Proposal**: wire two existing-but-unused signals into the resource
+subscription mechanism:
+
+| Resource URI            | Push trigger                                                  |
+| ----------------------- | ------------------------------------------------------------- |
+| `gateway://instances`   | adapter register / deregister / readiness change              |
+| `gateway://election`    | state machine transitions (A/B/Active/Draining/Closed)        |
+| `gateway://endpoint`    | when the stable endpoint a client should connect to changes   |
+
+Smart clients subscribe once and receive push notifications. Combined
+with **A**, virtually no client ever has to handle a hard disconnect.
+
+**Constraints check**: [ok] piggybacks on existing
+`resources/subscribe` plumbing ; [ok] ignored by clients that don't
+subscribe ; [ok] DCC-agnostic.
+
+---
+
+## Phasing & per-phase delivery value
+
+Each phase ships and is useful on its own:
+
+- **P0** - gateway lease + heartbeat write path (A, foundation).
+  ~150 lines. Adds the data structures; election behavior unchanged.
+  No client-visible effect; pre-req for everything below.
+- **P1** - switch arrival decision from `version_outranks` to
+  `liveness_driven` (A, behavior). ~80 lines.
+  Visible effect: "start a 2nd Maya without dropping the 1st Maya's
+  agents" *and* "owner crash -> automatic failover within `ttl_secs`".
+  Solves the original Cursor disconnect.
+- **P1.5** - handoff event (A.event): adds the `gateway_handoff` record, the `notifications/gateway/handoff` SSE message, a `request_release()` public API, and the per-adapter graceful-shutdown hook. ~250 lines. Visible effect: graceful Maya exit and planned upgrade switch in &lt; 50 ms instead of `ttl_secs`. Pairs naturally with P1 and shares its data structures.
+- **P2** - `gateway_policy.yaml` + `allow_version_preempt` opt-in
+  (A, policy). ~200 lines.
+  Studios can declare rolling-upgrade policy without code change.
+- **P3** - graceful drain protocol for opt-in preemption / planned
+  shutdown (B). ~400 lines.
+  Generalises P1.5 to in-flight tool calls (lets the outgoing owner
+  finish a long `run_check` before releasing) and adds the formal
+  `Draining` state machine entry.
+- **P4** - stable session id + SQLite resume store (C). ~600 lines.
+  MCP 2025-06-18 compliance + zero-skill-reload after disconnect.
+- **P5** - resource subscriptions for election events (D). ~150 lines.
+  Observability tools (Admin UI, MCP inspectors) follow election live.
+
+**Future work (separate RFC)** - *Standby pre-election*: have peers
+periodically vote a "next in line" successor that pre-warms (cache
+endpoint, pre-bind to a temporary port, pre-load common skills). On
+A.event or A failover the successor promotes in single-digit ms with
+zero election-race. This is etcd/zookeeper-style HA and brings real
+value at studio scale; deferred from this RFC to keep the surface area
+manageable.
+
+P0+P1 together delete the original Cursor disconnect *and* give the
+fleet automatic gateway failover after crashes. Adding P1.5 cuts the
+graceful-exit handoff from seconds to ~50 ms. The remaining phases
+harden the upgrade path and make the protocol fully resumable.
+
+## Implementation notes for the constraints
+
+- **No new process**: Phase 0-4 add code only inside the existing gateway
+  process. The SQLite session store (Phase 3) is a file managed by the
+  gateway, not a service.
+- **rez packaging**: every change ships inside the existing
+  `dcc_mcp_core` rez package. Adapter packages (`dcc_mcp_maya`,
+  `dcc_mcp_blender`, future `dcc_mcp_houdini`, ...) keep their current
+  `requires = ["dcc_mcp_core-0.17+"]` - the upper version range bumps
+  alone activate the new behavior.
+- **Multi-DCC**: nothing in the design references Maya / Blender / etc.
+  Adapter shipping order is irrelevant; whichever DCC the user happens
+  to start first owns the gateway, others register as instances.
+- **Backward compatibility matrix**:
+
+  | Client                       | Old gateway              | New gateway                              |
+  | ---------------------------- | ------------------------ | ---------------------------------------- |
+  | Old (no `MCP-Session-Id`)    | works (today)            | works (sessions auto-issued but unused)  |
+  | New (sends `MCP-Session-Id`) | works (header ignored)   | resumable across drops                   |
+
+## Open questions
+
+1. **Lease TTL vs. failover MTTR**. Default `ttl_secs=5` /
+   `renew_interval=1.6` means worst-case 5 s of "no one serves 9765"
+   between a hard crash and a peer promoting. Acceptable for interactive
+   agent use, possibly too long for render farm. Should `ttl_secs` be a
+   first-class env var (`DCC_MCP_GATEWAY_LEASE_TTL_SECS`) for studios
+   to tune per deployment?
+
+2. **Probe semantics on partial outage**. If `GET /health` returns 200
+   but `/v1/readyz` would say "dispatcher dead" (Maya UI thread frozen),
+   the lease holder is *technically* alive but useless. Should the
+   probe be `/v1/readyz` instead of `/health`, accepting longer
+   timeouts? Or two-phase: probe `/health` first, only escalate to
+   `/v1/readyz` if a client recently reported a tool timeout?
+
+3. **Split-brain on `services.lock` failure**. If two adapters both
+   CAS the lease at the same millisecond and the file lock is buggy,
+   both could bind 9765 -> bind fails on one, but lease says "mine" on
+   that loser. Defense: after a successful bind, re-verify lease
+   ownership and roll back if lost.
+
+4. **Election policy storage**. Should `gateway_policy.yaml` live next to
+   `services.json` in `%TEMP%/dcc-mcp-registry/`, or follow studio
+   convention (`%APPDATA%/dcc-mcp/`)? Both are off the rez install root
+   so admins can pin policy without rebuilding adapters.
+
+5. **`MCP-Session-Id` and DCC instance death**. If a DCC dies mid-session,
+   should `resume` return an error (current direction) or silently re-
+   bind to a peer DCC of the same type? The latter is convenient for
+   farm/headless but dangerous for interactive sessions where scene
+   state matters. Suggest: error by default, opt-in re-bind via
+   `session.rebind_policy=any_alive_peer`.
+
+6. **Notification namespace**. `notifications/gateway/*` is not in the
+   MCP spec. Confirm OK to extend, or use a vendor prefix like
+   `notifications/x-dcc-mcp/gateway/*` to make non-standard nature
+   explicit and prevent collision with future spec additions.
+
+7. **Drain grace timing**. 5 s feels right for human-interactive cases
+   but may be wrong for long-running async tools (`run_check`,
+   `capture_ui`, render submits). Should drain timeout be derived from
+   `max(tool.timeout_hint_secs across in-flight)` rather than fixed?
+
+8. **Handoff successor selection**. The simple version of A.event lets
+   *any* peer race to CAS the lease after the announcement. With many
+   peers this is a thundering herd. Should we require the outgoing
+   owner to nominate a `suggested_successor` (e.g. "newest healthy
+   instance whose dcc_type equals mine"), and have non-suggested peers
+   wait `successor_grace_ms` (default 200) before joining the race?
+   Compromise between simplicity (no leader-election sub-protocol) and
+   thundering-herd avoidance.
+
+9. **Cross-platform port handoff**. SO_REUSEPORT lets two processes
+   share a listening socket on Linux & macOS, making the handoff
+   literally zero-gap. Windows requires the outgoing owner to release
+   first. Should A.event hard-code a per-OS code path, or should the
+   protocol treat the bind-overlap window as best-effort and rely on
+   client retry to bridge the 1-10 ms Windows gap?
+
+## Out-of-scope follow-ups
+
+- **Sidecar `gateway-front` proxy on a fixed port**. Considered and
+  rejected for this RFC because it violates constraint #1 (extra
+  process). Worth revisiting **only** if A/B/C/D combined still leave
+  observable disconnect classes - current analysis says they don't.
+- **Cross-host gateway federation**. Today everything is localhost; LAN
+  federation would belong in a separate RFC after this one lands.
+
+## Acknowledgements
+
+This RFC originated from end-to-end integration work on a downstream
+Maya adapter package - bootstrap, debugpy attach, and agent-driven
+`create_shelves` flows that exposed the
+preemption-induced disconnect in a reproducible way.

--- a/docs/rfcs/0002-event-bus-and-webhooks.md
+++ b/docs/rfcs/0002-event-bus-and-webhooks.md
@@ -32,7 +32,7 @@ written for one consumer keeps working when moved to the other.
 
 ## Motivation
 
-Real downstream integration use cases that today require log-scraping or
+Common downstream integration use cases that today require log-scraping or
 patches to upstream code:
 
 - **Per-call audit log into studio observability.** Every tool call
@@ -317,10 +317,3 @@ the list is hand-curated rather than open.
    Python EventBus with a one-way Rust->Python bridge? The former is
    faster but adds GIL coordination; the latter is simpler but adds
    one IPC hop. Suggest: prototype both, decide on benchmark.
-
-## Acknowledgements
-
-Originated from the downstream Maya integration work after
-realising that downstream studio code (per-call metrics, skill
-gating, destructive-tool alerts) all needed the same primitive that
-didn't exist in `dcc-mcp-core`.

--- a/docs/rfcs/0002-event-bus-and-webhooks.md
+++ b/docs/rfcs/0002-event-bus-and-webhooks.md
@@ -1,0 +1,326 @@
+# RFC 0002 - Event Bus & Webhooks
+
+**Status**: Draft
+**Target repo**: `dcc-mcp-core` (with surface in `dcc-mcp-server`)
+**Authors**: dcc-mcp-core contributors
+**Date**: 2026-05-23
+**Related**: RFC 0001 (gateway election); RFC 0003 (traffic interception - reuses the EventBus from this RFC)
+
+---
+
+## Summary
+
+Today, downstream DCC integrators (Maya shelf tools, character rigging
+tools, future Blender / Houdini / 3ds Max / Photoshop tools, and other
+studio plugins) can only observe and extend the
+dcc-mcp-server by either (a) re-reading log files or (b) forking the
+server. There is no first-class way to **hook** into the lifecycle of
+the gateway, an adapter, a skill, or a tool call.
+
+This RFC proposes a single in-process **`EventBus`** in `dcc-mcp-core`,
+exposed via two compatible surfaces:
+
+1. **In-process Python subscriptions** for downstream Python code (Maya
+   plugins, studio tools, automated test fixtures) that runs alongside
+   the adapter.
+2. **Out-of-process HTTP webhooks** for sidecar tools that live in a
+   different process / language / host (CI gates, dashboards,
+   notification bots, external monitoring).
+
+Both surfaces emit the **same event taxonomy and schema**, so a hook
+written for one consumer keeps working when moved to the other.
+
+## Motivation
+
+Real downstream integration use cases that today require log-scraping or
+patches to upstream code:
+
+- **Per-call audit log into studio observability.** Every tool call
+  produced by an artist's agent session should land in the studio
+  metrics pipeline (latency, success rate, which `dcc_type`, which
+  skill, which user). Today there's no callback to fan this out without
+  parsing `dcc_mcp_http::trace::on_response` log lines.
+- **Skill load gating.** A studio policy may forbid loading `experimental-maya-tools`
+  on a render farm node. Without a `skill/loading` event we can't
+  decline before the skill enters the catalog.
+- **Custom progress UI on tool dispatch.** A studio Maya panel wants
+  a small toast when an agent dispatches a long tool ("agent is
+  exporting your shot"). Today the panel polls the admin task list.
+- **Alert when an agent calls a destructive tool.** A webhook on
+  `tool/dispatched` where `annotations.destructive_hint=true`
+  takes minutes to wire if the event exists; today it's not feasible
+  without a proxy in front of the gateway.
+- **CI gate on adapter promotion.** When a new gateway is promoted in
+  a CI environment a webhook to the CI service lets it run a smoke
+  test and tear the env down.
+
+The unifying observation: dcc-mcp-server **already raises every
+interesting state change internally** (we can see them in the trace
+logs) - it just doesn't expose them as a first-class extension point.
+
+## Constraints
+
+Same hard constraints as RFC 0001:
+
+1. **No new processes.** The EventBus lives inside the existing
+   gateway / adapter processes. Webhook delivery is an outbound HTTP
+   client task, not a new daemon.
+2. **Flat rez packaging.** Hooks ship inside `dcc-mcp-core`; downstream
+   adapters and studio tools inherit via existing `requires`.
+3. **Multi-DCC by construction.** Event taxonomy and schema are
+   DCC-agnostic. Per-DCC details live in `event.attributes`.
+4. **Backward compatible.** No event subscription is required; with no
+   subscribers the bus is a near-zero-cost pass-through.
+
+## Non-goals
+
+- High-throughput log shipping (>10k events/sec). Studios that need that
+  should feed the EventBus into a real broker (Kafka, NATS) via a
+  webhook - out of scope for the core bus.
+- Replacing structured logging. Logs stay; events are an orthogonal
+  *programmatic* channel.
+- Replacing OpenTelemetry. Events are higher-level domain semantics
+  ("skill loaded", "tool dispatched"); OT spans remain the source of
+  truth for distributed tracing. An OT exporter for events is a Phase-3
+  follow-up.
+
+---
+
+## Design
+
+### 1. Event taxonomy
+
+Events are addressed by hierarchical dotted names. Subscribers can
+register for an exact name or a `prefix.*` wildcard.
+
+| Namespace        | Examples                                                                                              | Lifecycle of payload     |
+| ---------------- | ----------------------------------------------------------------------------------------------------- | ------------------------ |
+| `gateway.*`      | `gateway.started`, `gateway.stopping`, `gateway.election_changed`, `gateway.handoff_announced`        | Process / cluster level  |
+| `instance.*`     | `instance.registered`, `instance.deregistered`, `instance.health_changed`                             | Per-DCC adapter          |
+| `skill.*`        | `skill.discovered`, `skill.loading`, `skill.loaded`, `skill.unloaded`, `skill.validation_failed`      | Per skill                |
+| `tool.*`         | `tool.dispatched`, `tool.completed`, `tool.failed`, `tool.cancelled`, `tool.timed_out`                | Per tool call            |
+| `resource.*`     | `resource.read`, `resource.subscribed`, `resource.changed`                                            | Per MCP resource URI     |
+| `session.*`      | `session.created`, `session.resumed`, `session.expired` (depends on RFC 0001's session work)          | Per MCP session          |
+| `client.*`       | `client.connected`, `client.disconnected`, `client.initialize`                                        | Per connection           |
+| `policy.*`       | `policy.skill_denied`, `policy.tool_denied`                                                           | Per enforcement decision |
+
+Studios may emit their own events under a `studio.<name>.*` prefix; the
+core bus does not interpret them but delivers them to any subscriber.
+
+### 2. Event schema
+
+Every event is a single JSON object with a stable envelope:
+
+```jsonc
+{
+  "schema_version": 1,
+  "name":           "tool.completed",
+  "id":             "ev_01HQX...",        // ULID, sortable by time
+  "timestamp_ns":   1779478215123456789,
+  "source": {
+    "instance_id":  "1f363976-...",
+    "dcc_type":     "maya",
+    "adapter_version": "0.3.7",
+    "host":         "WORKSTATION-01",
+    "pid":          68616
+  },
+  "correlation": {
+    "session_id":   "fc4c2da2-...",       // present iff client-driven
+    "request_id":   "cd4aacff-...",       // MCP request id
+    "trace_id":     "abc123...",          // OT trace id when available
+    "span_id":      "def456..."
+  },
+  "attributes": {
+    // event-specific payload, snake_case keys, JSON primitives only
+    "tool_slug":    "maya.1f363976.maya_pipeline__bootstrap_project",
+    "skill_name":   "maya-pipeline-dev",
+    "duration_ms":  142,
+    "result_success": true
+  }
+}
+```
+
+`schema_version` bumps only on breaking changes; additive attribute
+additions are non-breaking.
+
+### 3. Subscription surfaces
+
+#### 3a. In-process Python
+
+```python
+from dcc_mcp_core.events import bus, EventFilter
+
+@bus.on("tool.completed")
+def record_metric(event: dict) -> None:
+    studio_metrics.observe(
+        name=event["attributes"]["tool_slug"],
+        latency_ms=event["attributes"]["duration_ms"],
+        ok=event["attributes"]["result_success"],
+    )
+
+# Wildcards + filters
+@bus.on("skill.*", filter=EventFilter(dcc_type="maya"))
+def audit_skill_lifecycle(event): ...
+
+# Decline-on-skill-loading hook (synchronous, blocking - see section 6)
+@bus.before("skill.loading")
+def gate_skill(event):
+    if event["attributes"]["skill_name"] == "experimental-maya-tools" and is_farm_node():
+        return bus.Veto("experimental-maya-tools not allowed on farm nodes")
+    return None
+```
+
+Two flavors of subscriber:
+
+- **`on(name)`** - asynchronous, fire-and-forget, no return value.
+  Subscriber crash is isolated (logged + bus continues).
+- **`before(name)`** - synchronous, may return a `Veto` to abort the
+  triggering action. Only allowed on a small set of "vetoable" event
+  names (defined per event below); other names raise at registration.
+
+Subscriptions live for the lifetime of the process; an explicit
+`bus.unsubscribe(handler)` is provided.
+
+#### 3b. Out-of-process HTTP webhook
+
+Studios configure webhooks declaratively in a YAML file picked up by
+the gateway on startup (and reloaded on file change):
+
+```yaml
+# webhooks.yaml - sits next to gateway_policy.yaml (see RFC 0001)
+webhooks:
+  - name: studio-metrics
+    url: https://example.com/dcc-mcp/events
+    events:
+      - tool.completed
+      - tool.failed
+    headers:
+      Authorization: "Bearer ${DCC_MCP_WEBHOOK_TOKEN}"
+    delivery:
+      attempts: 3
+      backoff_ms: [200, 1000, 5000]
+      timeout_ms: 2000
+    filters:
+      - attributes.skill_name: "maya-*"
+
+  - name: destructive-tool-alert
+    url: https://hooks.example.com/services/...
+    events:
+      - tool.dispatched
+    filters:
+      - attributes.annotations.destructive_hint: true
+    payload_template: |
+      { "text": "Agent in {{source.dcc_type}} called destructive tool {{attributes.tool_slug}} (session {{correlation.session_id}})" }
+```
+
+Webhook delivery runs on an internal Tokio task pool, bounded queue
+length, and applies per-webhook backoff. Failed deliveries are logged
+and emitted on the bus as a `webhook.delivery_failed` event (which
+itself can have subscribers but **cannot** trigger webhook delivery -
+loop-break by construction).
+
+### 4. Delivery guarantees
+
+- **In-process `on(...)` subscribers**: best-effort, fire-and-forget.
+  Subscriber exceptions are caught and reported on
+  `bus.subscriber_failed`. Order within a single emit point is preserved
+  per-subscriber; order across emit points is not guaranteed.
+- **In-process `before(...)` subscribers**: synchronous, returns a
+  decision that the emitting site must honor. Strict registration-order.
+- **Out-of-process webhooks**: at-least-once with bounded retry. If all
+  retries exhaust, the event is dropped and `webhook.delivery_failed`
+  is emitted with the original event id (so it can be replayed from a
+  durable sink, see RFC 0003).
+
+### 5. Performance budget
+
+- With **0 subscribers** on a given event name: cost is a single
+  hashmap lookup + one branch - measurable but not material to the
+  hot path of a tool call. The bus must benchmark this and pass a
+  microbenchmark gate before each release.
+- With **N in-process subscribers**: O(N) calls. The emitter is
+  responsible for not emitting in tight loops; bus is not.
+- Webhook fan-out is fully async; emitting tool path is **not** blocked
+  by webhook delivery latency.
+
+### 6. Vetoable events (`before(...)` subscribers)
+
+Only these events accept a veto, because their emission site has a
+well-defined "do nothing instead" branch:
+
+- `skill.loading` -> reject skill load
+- `tool.dispatched` (before the host call) -> reject the tool call with
+  a structured error
+- `resource.subscribed` -> reject subscription
+- `client.initialize` -> reject the new client (e.g. policy match
+  failure)
+
+Adding more vetoable events requires changes at the emission site, so
+the list is hand-curated rather than open.
+
+---
+
+## Phasing
+
+- **P0** - `EventBus` core, in-process `on()` API, taxonomy for
+  `gateway.*` and `instance.*`. ~250 lines. No subscribers shipped yet;
+  enables downstream experimentation.
+- **P1** - Emit points for `skill.*` and `tool.*` (the most-requested
+  category). ~200 lines.
+- **P2** - `before()` API + vetoable-event whitelist. ~150 lines.
+- **P3** - Webhook delivery worker + `webhooks.yaml` loader.
+  ~400 lines.
+- **P4** - OpenTelemetry exporter for the event stream (events become
+  span events on the current OT span). ~150 lines. Optional, can land
+  any time after P0.
+
+## Backward compatibility
+
+- The bus exists from P0 but emits nothing if no events are wired yet.
+- Downstream adapters / clients that don't import `dcc_mcp_core.events`
+  see no behavior change.
+- Webhook config absent => no outbound HTTP.
+- Schema changes to **`attributes`** are additive; **envelope** changes
+  bump `schema_version` and the bus refuses subscribers with a
+  declared `min_schema_version` higher than runtime.
+
+## Open questions
+
+1. **Event payload size cap**. Should we hard-cap `attributes` size
+   (e.g. 4 KiB) to keep webhook payloads sane, with overflow indicated
+   by an `attributes_truncated: true` flag? RFC 0003 will want the
+   *full* payload - does it bypass the cap because it reads from a
+   different sink, or does the bus carry full payloads and webhook
+   delivery alone applies the cap?
+
+2. **Static dispatch for the zero-subscriber hot path**. Should we
+   generate per-event-name dispatcher functions at build time so the
+   "no subscribers" check is a constant-folded `false` instead of a
+   hashmap lookup? Worth it only if benchmarks show the hashmap is
+   visible in profiles.
+
+3. **Per-DCC namespaces vs flat namespaces**. Today the proposal uses
+   one flat namespace. Alternative: `maya.tool.completed` vs
+   `tool.completed` with `source.dcc_type=maya`. The flat version is
+   simpler; the namespaced version composes better with subscription
+   wildcards. Suggest: stay flat, rely on `source.dcc_type` for
+   filtering.
+
+4. **Webhook authentication for inbound (i.e. webhook *receivers* that
+   need to know the request came from us)**. Should we sign the HTTP
+   body with an HMAC keyed off a per-webhook secret? Common pattern
+   (GitHub, Stripe). Defer to P3 if scope creeps.
+
+5. **In-process subscribers crossing Python <-> Rust boundary**. The
+   core is Rust with a Python facade. Should we keep the subscriber
+   list in Rust and call into Python via PyO3, or proxy to a pure-
+   Python EventBus with a one-way Rust->Python bridge? The former is
+   faster but adds GIL coordination; the latter is simpler but adds
+   one IPC hop. Suggest: prototype both, decide on benchmark.
+
+## Acknowledgements
+
+Originated from the downstream Maya integration work after
+realising that downstream studio code (per-call metrics, skill
+gating, destructive-tool alerts) all needed the same primitive that
+didn't exist in `dcc-mcp-core`.

--- a/docs/rfcs/0003-traffic-interception-and-replay.md
+++ b/docs/rfcs/0003-traffic-interception-and-replay.md
@@ -1,0 +1,325 @@
+# RFC 0003 - Traffic Interception & Agent Debugging
+
+**Status**: Draft
+**Target repo**: `dcc-mcp-core` (with admin UI surface in `dcc-mcp-server`)
+**Authors**: dcc-mcp-core contributors
+**Date**: 2026-05-23
+**Depends on**: RFC 0002 (event bus). This RFC is the highest-fidelity sink that consumes the bus.
+
+---
+
+## Summary
+
+When an agent calls our skills and the result is wrong (skill returned
+poor data, agent re-prompted in a way we didn't predict, latency
+spiked, a notification we sent was misread), the **only** way to debug
+today is to add `print` to skill scripts and tail Maya's stdout. There
+is no first-class way to see **what the agent actually sent, what we
+sent back, in what order, with what timing**.
+
+This RFC proposes an **opt-in, dev-grade traffic interceptor** that
+captures every byte the gateway exchanges with MCP clients and every
+tool dispatch it forwards to a DCC adapter, into a structured store
+that supports:
+
+- **Live inspection** in the existing admin UI (`/admin`)
+- **Recording** to JSONL / SQLite for later analysis
+- **Replay** against a mock client to verify skill fixes deterministically
+- **Diff** between two captures to verify a prompt or skill change does what we think
+
+It is **explicitly a development & debugging tool**, not a production
+audit log - different file from RFC 0002's webhook-style event log.
+
+## Motivation - what studio agent authors actually need
+
+From real downstream Maya skill iteration:
+
+- "The agent called `bootstrap_project` with `enable_debugpy=true` but
+  my report says `debugpy.status=error`. Did the agent actually send
+  `enable_debugpy=true`, or did it default? Did my schema description
+  mislead it?" - answer requires the **raw JSON-RPC payload**.
+- "I changed my skill's description from X to Y. Did the agent's
+  retrieval / selection actually change?" - answer requires
+  **diffing two captures** of the same prompt before and after.
+- "Cursor is showing 'Server not ready' but `/health` says OK." -
+  answer requires the **SSE notification stream** that the gateway
+  sent, in order, with timing.
+- "My skill returns `{success: true}` but the agent's user-facing
+  message says 'I couldn't do that'. What does the agent see vs what
+  I sent?" - answer requires the **server-side response payload**,
+  including any framing/transformation done by the gateway.
+- "I want to write a regression test: when the agent says
+  'screenshot the shelves view', it should end up calling
+  `maya_pipeline__create_shelves` then `maya_dev__capture_ui`."
+  - answer requires **deterministic replay** of a recorded session.
+
+The unifying observation: prompt-engineering and skill design are
+**empirical** disciplines today. Without a tape recorder we are
+designing in the dark.
+
+## Constraints
+
+Same as RFC 0001 / RFC 0002, plus these additional constraints:
+
+1. **Dev-grade, not prod-grade.** It is acceptable for the interceptor
+   to add 5-20% latency, double memory for the capture buffer, and ship
+   a SQLite file that grows without bound during a recording session.
+   The interceptor must be **off by default** and refuse to start if
+   `DCC_MCP_PROD_PROFILE=1` unless `DCC_MCP_FORCE_TRAFFIC_CAPTURE=1`
+   is *also* set.
+
+2. **PII / scene-content safety.** Recordings may contain artist names,
+   project paths, scene-graph snippets, and screenshots. The capture
+   subsystem must support **redact rules** (regex / key-path) applied
+   at write time, *not* read time - once written, the file is the
+   ground truth.
+
+## Non-goals
+
+- Production audit log (use RFC 0002 webhooks -> durable sink).
+- Security tracing or SIEM integration.
+- Cross-host distributed tracing (use OpenTelemetry).
+
+---
+
+## Design
+
+### 1. Capture surface
+
+The interceptor taps three points in the gateway request/response
+pipeline. All three are **already** instrumented in the trace logs
+(see `dcc_mcp_http::trace::on_request/on_response` in the live logs)
+- this RFC formalises and structures them.
+
+```
++---- MCP client (Cursor) ----+
+| HTTP POST /mcp              |     -- (1) capture inbound MCP envelope
+| GET  /mcp  (SSE)            |     -- (2) capture outbound SSE frames
++------------+----------------+
+             v
+       +------------+
+       |  gateway   |
+       +-----+------+
+             v
++---- DCC adapter ------------+
+| HTTP POST /v1/call          |     -- (3) capture forwarded tool call
+|         /v1/load_skill etc. |         and its response
++-----------------------------+
+```
+
+Capture frame schema:
+
+```jsonc
+{
+  "schema_version": 1,
+  "capture_id":  "cap_01HQX...",          // ULID
+  "session_id":  "cap_session_01HQX...",  // groups frames from one recording run
+  "timestamp_ns": 1779478215123456789,
+  "direction":   "inbound" | "outbound" | "internal",
+  "leg":         "client_to_gateway" | "gateway_to_client_sse"
+               | "gateway_to_adapter" | "adapter_to_gateway",
+  "transport":   "http" | "sse",
+  "http": {
+    "method":  "POST",
+    "url":     "http://127.0.0.1:9765/v1/call",
+    "headers": { "content-type": "application/json", "mcp-session-id": "..." },
+    "status":  null  // request side
+  },
+  "mcp": {
+    "kind":    "request" | "response" | "notification",
+    "method":  "tools/call",
+    "id":      42,
+    "session_id": "fc4c2da2-..."
+  },
+  "body": {
+    "encoding": "json" | "base64" | "text",
+    "data":     "...",            // see section 3 PII rules
+    "size_bytes": 1234,
+    "redacted_paths": ["params.arguments.api_key"]  // recorded redactions
+  },
+  "correlation": {
+    "request_id": "cd4aacff-...",
+    "trace_id":   "abc123..."
+  }
+}
+```
+
+Same `EventBus` envelope conventions as RFC 0002 - capture frames are
+emitted on `traffic.frame` and any subscriber (notably the writers in
+section 2) consumes them.
+
+### 2. Sinks
+
+The interceptor is a thin emitter on `traffic.frame`. Any number of
+writers can subscribe. We ship four:
+
+| Writer        | Format                   | When to use                                        |
+| ------------- | ------------------------ | -------------------------------------------------- |
+| `file_jsonl`  | newline-delimited JSON   | Quick local capture, `tail -f` friendly, git-able  |
+| `sqlite`      | one row per frame        | Replay / diff (indexed by session, method, leg)    |
+| `admin_live`  | in-memory ring buffer    | Real-time admin UI inspector                       |
+| `ot_exporter` | OT span events           | Cross-correlate with existing OpenTelemetry tools  |
+
+Configured via env var (single-sink quick mode) or YAML
+(multi-sink studio mode):
+
+```bash
+# Quick mode
+DCC_MCP_TRAFFIC_CAPTURE=jsonl:./capture.jsonl
+DCC_MCP_TRAFFIC_FILTER=skill=maya-pipeline-dev
+
+# Studio mode: declarative config
+DCC_MCP_TRAFFIC_CONFIG=./traffic_capture.yaml
+```
+
+```yaml
+# traffic_capture.yaml
+enabled: true
+sinks:
+  - kind: sqlite
+    path: ./captures/run-${TIMESTAMP}.db
+  - kind: admin_live
+    ring_buffer: 5000
+filters:
+  include:
+    - mcp.method: tools/call
+    - mcp.method: notifications/*
+  exclude:
+    - http.url: "*/v1/readyz"
+    - http.url: "*/v1/resources"   # noisy poll
+redact:
+  - body.data.params.arguments.api_key: "[REDACTED]"
+  - http.headers.authorization: "[REDACTED]"
+  - body.data.params.arguments.scene_path: "[SCRUBBED:path]"
+```
+
+### 3. PII & redaction
+
+Redactions are applied **before** writing to any sink. Three rule kinds:
+
+- **Exact-key replacement**: `body.data.params.arguments.api_key ->
+  "[REDACTED]"`
+- **Regex on string values**: any `\S+@\S+\.\S+` -> `[email]`
+- **Type tags**: `[SCRUBBED:path]` rewrites filesystem paths to anchored
+  workspace-relative form (`/Users/.../my_project/` -> `<workspace>/`).
+  Useful for shareable bug reports.
+
+Captures that pass through redactions carry `body.redacted_paths` so a
+replay tool knows which fields were modified and can warn if a
+downstream test depends on them.
+
+### 4. Replay
+
+A CLI (`dcc-mcp capture replay <capture.db>`) drives a recorded
+session against a live gateway:
+
+```bash
+# Replay session "sess_01HQX..." against the local gateway,
+# using the recorded MCP messages as inputs and asserting outputs match.
+dcc-mcp capture replay run-2026-05-23.db \
+    --session sess_01HQX... \
+    --target http://127.0.0.1:9765/mcp \
+    --assert outputs_equal \
+    --rebind-instance-id current_live
+
+# Modes:
+#   --assert outputs_equal       fail if any response body differs
+#   --assert outputs_compatible  loose match (status code + json shape)
+#   --assert outputs_ignored     fire-and-forget regression smoke
+```
+
+`--rebind-instance-id` substitutes the recorded instance id with the
+current live one (instance ids are necessarily different on replay).
+
+### 5. Diff
+
+```bash
+dcc-mcp capture diff before.db after.db --session-pair s1 s2
+
+# Outputs a structured diff:
+#   matched 47 of 50 frames
+#   frame 7:  tool.dispatched maya_pipeline__create_shelves
+#     args:   force_path_inject changed false -> true
+#   frame 9:  tool.completed
+#     result: success true -> false
+#     reason: ModuleNotFoundError("pymel")
+```
+
+This is the workflow for "I changed my skill description / I changed my
+prompt / I bumped shelf tools - did anything observable change?"
+
+### 6. Admin UI live inspector
+
+Today `/admin` shows tasks. Add a `/admin/traffic` page powered by the
+`admin_live` ring-buffer sink:
+
+- Tab `Live` - websocket-streamed frames as they arrive
+- Tab `Sessions` - group by `session_id`, expandable timeline
+- Tab `Frame detail` - full JSON of any frame, with diff link to
+  another frame
+- Tab `Export` - download last N frames as JSONL / SQLite
+
+A small **"Privacy"** banner at the top reminds the operator the
+session may contain artist data and links to the redact rules in
+effect.
+
+---
+
+## Phasing
+
+- **P0** - `traffic.frame` event on the EventBus (depends on RFC 0002
+  P0) + `file_jsonl` sink + env-var quick mode. ~300 lines. Brings
+  the "tail -f my capture" use case in one PR.
+- **P1** - `sqlite` sink + filters + redact rules. ~250 lines.
+- **P2** - replay CLI. ~400 lines.
+- **P3** - diff CLI. ~250 lines.
+- **P4** - admin UI Live inspector + WebSocket fan-out. ~600 lines.
+- **P5** - OT exporter. ~150 lines.
+
+P0 alone unlocks the "what did the agent actually send" question.
+
+## Backward compatibility
+
+- The interceptor is **opt-in**; default OFF.
+- When OFF, the capture taps are no-ops behind a single boolean check.
+- Capture file format carries `schema_version=1`; breaking changes bump
+  it; replay/diff tools support reading old versions for at least two
+  bumps.
+
+## Open questions
+
+1. **What "outbound" really means for streaming responses**. A large
+   tool result may stream out as multiple SSE frames; do we record one
+   frame per SSE chunk (verbose, lossless) or one logical frame
+   reconstructed by the gateway (denser, easier to diff but lossy on
+   timing)? Suggest: capture both, distinguish via `frame.transport`.
+
+2. **Replay against a different DCC**. Should `replay` allow targeting
+   a different `dcc_type` than was recorded (e.g. recorded against
+   Maya, replay against Blender) for adapter portability testing?
+   Probably yes with `--allow-cross-dcc` flag plus a warning when tool
+   slugs differ.
+
+3. **Capture and the session resume from RFC 0001**. If a client
+   resumes a session mid-recording, do we record the resume as a new
+   capture session or stitch it back? Suggest: stitch, key by the
+   pre-resume `session_id`.
+
+4. **Capture file sharing**. The natural studio workflow is "I hit a
+   weird agent behavior, I send my capture to the skill author."
+   Should we ship a one-liner `dcc-mcp capture share <file>` that
+   redacts default-sensitive fields and uploads to studio
+   internal storage? Out of scope of this RFC but pencil it in.
+
+5. **Capture of `before(...)` veto decisions**. RFC 0002 lets
+   subscribers veto tool dispatch. If a tool is vetoed, do we record
+   the request that *would* have been forwarded? Yes - emit
+   `traffic.frame` with `direction=internal` and an `outcome=vetoed`
+   field.
+
+## Acknowledgements
+
+Originated from prompt-engineering iteration on downstream Maya skill
+descriptions where the only feedback channel was Cursor's user-facing
+chat output - which is precisely the wrong signal to optimise against.
+The agent's *raw protocol* is the ground truth and we need it.

--- a/docs/rfcs/0003-traffic-interception-and-replay.md
+++ b/docs/rfcs/0003-traffic-interception-and-replay.md
@@ -32,7 +32,7 @@ audit log - different file from RFC 0002's webhook-style event log.
 
 ## Motivation - what studio agent authors actually need
 
-From real downstream Maya skill iteration:
+Common skill iteration questions:
 
 - "The agent called `bootstrap_project` with `enable_debugpy=true` but
   my report says `debugpy.status=error`. Did the agent actually send
@@ -316,10 +316,3 @@ P0 alone unlocks the "what did the agent actually send" question.
    the request that *would* have been forwarded? Yes - emit
    `traffic.frame` with `direction=internal` and an `outcome=vetoed`
    field.
-
-## Acknowledgements
-
-Originated from prompt-engineering iteration on downstream Maya skill
-descriptions where the only feedback channel was Cursor's user-facing
-chat output - which is precisely the wrong signal to optimise against.
-The agent's *raw protocol* is the ground truth and we need it.

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -1,0 +1,53 @@
+# Request for Comments
+
+This directory holds design proposals that are still in the RFC stage. RFCs
+are intentionally more exploratory than ADRs: they capture problem framing,
+constraints, phased designs, alternatives, and open questions before the
+project accepts or rejects a direction.
+
+Each RFC should be independently reviewable and should keep these constraints
+explicit:
+
+1. No new required processes for existing gateway or adapter deployments.
+2. Flat packaging: downstream adapters inherit behavior through their existing
+   `dcc-mcp-core` dependency.
+3. Multi-DCC by construction: core behavior must not assume Maya, Blender, or
+   any single host.
+4. Backward compatible by default: new behavior should be additive, opt-in, or
+   safely negotiated.
+
+## Active RFCs
+
+| ID | Title | Solves | Status |
+| --- | --- | --- | --- |
+| [0001](./0001-gateway-election-resilience.md) | Gateway Election Resilience | MCP clients dropping when a co-existing DCC starts; automatic failover when the gateway owner crashes; graceful handoff when the owner exits cleanly | Draft |
+| [0002](./0002-event-bus-and-webhooks.md) | Event Bus & Webhooks | Downstream DCC integrators need lifecycle, tool, and skill hooks without forking the server | Draft |
+| [0003](./0003-traffic-interception-and-replay.md) | Traffic Interception & Agent Debugging | Skill authors need opt-in protocol capture, replay, and diff tooling for empirical agent iteration | Draft |
+
+## Dependency graph
+
+```text
+0001 (election)
+
+0002 (event bus)
+   |
+   +-- depended on by --> 0003 (traffic interception)
+                          traffic frames consume the EventBus
+```
+
+0001 and 0002 can land in either order. 0003 is gated on 0002 P0, the
+`EventBus` primitive.
+
+## Recommended landing order
+
+1. 0001 P0+P1: switch election from version-driven preemption to
+   liveness-driven failover.
+2. 0002 P0+P1: add the `EventBus` primitive and initial `tool.*` /
+   `skill.*` emit points.
+3. 0003 P0: add the `traffic.frame` event and JSONL sink.
+4. 0001 P1.5: add pre-shutdown gateway handoff.
+5. 0002 P3: add webhook delivery.
+6. 0003 P2+P3: add replay and diff CLIs.
+
+Accepted decisions that become project policy should be moved or summarized in
+`../adr/` once the implementation direction is no longer exploratory.


### PR DESCRIPTION
## Summary

- Add `docs/rfcs/` with an overview index and three draft RFCs for gateway election resilience, event bus/webhooks, and traffic interception/replay.
- Link the RFC section from the English VitePress navigation.
- Keep the RFC text neutral and upstream-facing, without internal repository links, hostnames, or local paths.

Refs #1117, #1114, #1115, #1116.

## Validation

- `vx npx markdownlint-cli2 "docs/rfcs/*.md"`
- `vx npm --prefix docs run docs:build`

Note: `vx just docs-check` could not run in this Windows shell because just could not find `cygpath`; the equivalent npm install/build path was run directly.