### PR TITLE
fix: keep soft dependency skills discoverable

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/skill_mgmt.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/skill_mgmt.rs
@@ -275,7 +275,7 @@ pub(crate) fn skill_management_tool_defs() -> Vec<Value> {
             "inputSchema": {
                 "type": "object",
                 "properties": {
-                    "status": {"type": "string", "enum": ["all", "loaded", "unloaded", "error"], "default": "all"},
+                    "status": {"type": "string", "enum": ["all", "loaded", "unloaded", "pending_deps", "error"], "default": "all"},
                     "dcc":    {"type": "string", "description": "Restrict to one DCC type (maya, blender, …)"},
                     "dcc_type": {"type": "string", "description": "Alias for dcc (REST callers)."},
                     "limit": {"type": "integer", "minimum": 1, "maximum": 50},

--- a/crates/dcc-mcp-skills/src/catalog/catalog.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog.rs
@@ -105,7 +105,9 @@ impl SkillCatalog {
                 let state = &entry.value().state;
                 match status {
                     Some("loaded") => state == &SkillState::Loaded,
-                    Some("unloaded") | Some("discovered") => state == &SkillState::Discovered,
+                    Some("unloaded") => !matches!(state, SkillState::Loaded | SkillState::Error(_)),
+                    Some("discovered") => state == &SkillState::Discovered,
+                    Some("pending_deps") => matches!(state, SkillState::PendingDeps { .. }),
                     Some("error") => matches!(state, SkillState::Error(_)),
                     _ => true, // "all" or None
                 }
@@ -138,6 +140,7 @@ impl SkillCatalog {
                 scripts: e.metadata.scripts.clone(),
                 tools: e.metadata.tools.clone(),
                 state: e.state.to_string(),
+                missing_dependencies: e.state.missing_dependencies(),
                 registered_tools: e.registered_tools.clone(),
                 scope: e.scope.label().to_string(),
                 implicit_invocation: e

--- a/crates/dcc-mcp-skills/src/catalog/catalog_discovery.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog_discovery.rs
@@ -1,6 +1,41 @@
 use super::*;
 
+fn dependency_state_for(
+    metadata: &SkillMetadata,
+    names: &std::collections::HashSet<String>,
+) -> SkillState {
+    let missing: Vec<String> = metadata
+        .depends
+        .iter()
+        .filter(|dep| !names.contains(dep.as_str()))
+        .cloned()
+        .collect();
+    if missing.is_empty() {
+        SkillState::Discovered
+    } else {
+        SkillState::PendingDeps { missing }
+    }
+}
+
 impl SkillCatalog {
+    pub(crate) fn refresh_dependency_states(&self) {
+        let names: std::collections::HashSet<String> = self
+            .entries
+            .iter()
+            .map(|entry| entry.key().clone())
+            .collect();
+        for mut entry in self.entries.iter_mut() {
+            if self.loaded.contains(entry.key()) {
+                entry.state = SkillState::Loaded;
+                continue;
+            }
+            if matches!(entry.state, SkillState::Error(_)) {
+                continue;
+            }
+            entry.state = dependency_state_for(&entry.metadata, &names);
+        }
+    }
+
     /// Create a new, empty catalog backed by the given registry.
     pub fn new(registry: Arc<ToolRegistry>) -> Self {
         Self {
@@ -107,6 +142,7 @@ impl SkillCatalog {
                 new_count += 1;
             }
         }
+        self.refresh_dependency_states();
 
         if !result.skipped.is_empty() {
             tracing::warn!(
@@ -174,6 +210,7 @@ impl SkillCatalog {
                 removed += 1;
             }
         }
+        self.refresh_dependency_states();
 
         if !result.skipped.is_empty() {
             tracing::warn!(
@@ -211,6 +248,7 @@ impl SkillCatalog {
                 },
             );
         }
+        self.refresh_dependency_states();
     }
 
     /// Discover skills from paths grouped by [`SkillScope`].
@@ -257,6 +295,7 @@ impl SkillCatalog {
                 }
             }
         }
+        self.refresh_dependency_states();
         tracing::info!(
             "SkillCatalog::discover_scoped: {} new skill(s) across {} scope(s)",
             total_new,

--- a/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
@@ -26,6 +26,16 @@ impl SkillCatalog {
         skill_name: &str,
         activate_groups: bool,
     ) -> Result<Vec<String>, String> {
+        let mut visiting = Vec::new();
+        self.load_skill_recursive(skill_name, activate_groups, &mut visiting)
+    }
+
+    fn load_skill_recursive(
+        &self,
+        skill_name: &str,
+        activate_groups: bool,
+        visiting: &mut Vec<String>,
+    ) -> Result<Vec<String>, String> {
         if self.loaded.contains(skill_name) {
             let actions = self
                 .entries
@@ -40,6 +50,15 @@ impl SkillCatalog {
             return Ok(actions);
         }
 
+        if let Some(pos) = visiting.iter().position(|name| name == skill_name) {
+            let mut cycle = visiting[pos..].to_vec();
+            cycle.push(skill_name.to_string());
+            return Err(format!(
+                "Cannot load skill '{skill_name}' because its dependencies contain a cycle: {}",
+                cycle.join(" -> ")
+            ));
+        }
+
         let metadata = {
             self.entries
                 .get(skill_name)
@@ -47,12 +66,64 @@ impl SkillCatalog {
                 .ok_or_else(|| format!("Skill '{skill_name}' not found in catalog"))
         }?;
 
+        let known_names: std::collections::HashSet<String> = self
+            .entries
+            .iter()
+            .map(|entry| entry.key().clone())
+            .collect();
+        let missing: Vec<String> = metadata
+            .depends
+            .iter()
+            .filter(|dep| !known_names.contains(dep.as_str()))
+            .cloned()
+            .collect();
+        if !missing.is_empty() {
+            if let Some(mut entry) = self.entries.get_mut(skill_name) {
+                entry.state = SkillState::PendingDeps {
+                    missing: missing.clone(),
+                };
+            }
+            return Err(format!(
+                "Skill '{skill_name}' is pending dependencies: missing {}. \
+                 Discover or install the dependency skill(s), then retry load_skill('{skill_name}').",
+                missing.join(", ")
+            ));
+        }
+
+        visiting.push(skill_name.to_string());
+        for dep in &metadata.depends {
+            if !self.loaded.contains(dep.as_str()) {
+                self.load_skill_recursive(dep, activate_groups, visiting)
+                    .map_err(|err| {
+                        format!("Failed to load dependency '{dep}' for skill '{skill_name}': {err}")
+                    })?;
+            }
+        }
+        visiting.pop();
+
+        if self.loaded.contains(skill_name) {
+            return Ok(self
+                .entries
+                .get(skill_name)
+                .map(|entry| entry.registered_tools.clone())
+                .unwrap_or_default());
+        }
+
+        self.load_skill_metadata(skill_name, &metadata, activate_groups)
+    }
+
+    fn load_skill_metadata(
+        &self,
+        skill_name: &str,
+        metadata: &SkillMetadata,
+        activate_groups: bool,
+    ) -> Result<Vec<String>, String> {
         let mut registered = Vec::new();
         let skill_base = metadata.name.replace('-', "_");
         let skill_path = std::path::Path::new(&metadata.skill_path);
 
         if activate_groups {
-            activate_skill_groups(self, &metadata);
+            activate_skill_groups(self, metadata);
         } else {
             for group in &metadata.groups {
                 if group.default_active {
@@ -296,7 +367,11 @@ impl SkillCatalog {
         if self.loaded.contains(skill_name) {
             let _ = self.unload_skill(skill_name);
         }
-        self.entries.remove(skill_name).is_some()
+        let removed = self.entries.remove(skill_name).is_some();
+        if removed {
+            self.refresh_dependency_states();
+        }
+        removed
     }
 
     /// Clear all skills from the catalog.

--- a/crates/dcc-mcp-skills/src/catalog/helpers.rs
+++ b/crates/dcc-mcp-skills/src/catalog/helpers.rs
@@ -37,6 +37,8 @@ pub fn skill_entry_to_summary(e: &SkillEntry) -> SkillSummary {
         tool_count: e.metadata.tools.len(),
         tool_names: e.metadata.tools.iter().map(|t| t.name.clone()).collect(),
         loaded: e.state == SkillState::Loaded,
+        status: e.state.status().to_string(),
+        missing_dependencies: e.state.missing_dependencies(),
         scope: e.scope.label().to_string(),
         implicit_invocation: e
             .metadata

--- a/crates/dcc-mcp-skills/src/catalog/list_projection.rs
+++ b/crates/dcc-mcp-skills/src/catalog/list_projection.rs
@@ -17,6 +17,8 @@ const COMPACT_FIELDS: &[&str] = &[
     "stage",
     "tool_count",
     "loaded",
+    "status",
+    "missing_dependencies",
     "scope",
     "summary",
     "dcc",
@@ -96,6 +98,15 @@ fn project_summary(summary: &SkillSummary, fields: &[String]) -> Value {
             }
             "loaded" => {
                 obj.insert("loaded".into(), json!(summary.loaded));
+            }
+            "status" => {
+                obj.insert("status".into(), json!(summary.status));
+            }
+            "missing_dependencies" if !summary.missing_dependencies.is_empty() => {
+                obj.insert(
+                    "missing_dependencies".into(),
+                    json!(summary.missing_dependencies),
+                );
             }
             "scope" => {
                 obj.insert("scope".into(), json!(summary.scope));
@@ -205,6 +216,27 @@ fn skill_summary_from_value(v: &Value) -> Option<SkillSummary> {
             .map(|s| s.split(',').map(str::to_string).collect())
             .unwrap_or_default(),
         loaded: v.get("loaded").and_then(Value::as_bool).unwrap_or(false),
+        status: v
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or_else(|| {
+                if v.get("loaded").and_then(Value::as_bool).unwrap_or(false) {
+                    "loaded"
+                } else {
+                    "discovered"
+                }
+            })
+            .to_string(),
+        missing_dependencies: v
+            .get("missing_dependencies")
+            .and_then(Value::as_array)
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default(),
         scope: v
             .get("scope")
             .and_then(Value::as_str)
@@ -234,6 +266,8 @@ mod tests {
             tool_count: 3,
             tool_names: vec!["a".to_string(), "b".to_string()],
             loaded: false,
+            status: "discovered".to_string(),
+            missing_dependencies: Vec::new(),
             scope: "repo".to_string(),
             implicit_invocation: true,
             layer: None,

--- a/crates/dcc-mcp-skills/src/catalog/mod.rs
+++ b/crates/dcc-mcp-skills/src/catalog/mod.rs
@@ -153,6 +153,7 @@ pub(crate) fn group_default_active(groups: &[SkillGroup], group_name: &str) -> b
 impl Registry<SkillEntry> for SkillCatalog {
     fn register(&self, entry: SkillEntry) {
         self.entries.insert(entry.key(), entry);
+        self.refresh_dependency_states();
     }
 
     fn get(&self, key: &str) -> Option<SkillEntry> {
@@ -164,7 +165,11 @@ impl Registry<SkillEntry> for SkillCatalog {
     }
 
     fn remove(&self, key: &str) -> bool {
-        self.entries.remove(key).is_some()
+        let removed = self.entries.remove(key).is_some();
+        if removed {
+            self.refresh_dependency_states();
+        }
+        removed
     }
 
     fn count(&self) -> usize {

--- a/crates/dcc-mcp-skills/src/catalog/tests/test_catalog_crud.rs
+++ b/crates/dcc-mcp-skills/src/catalog/tests/test_catalog_crud.rs
@@ -36,6 +36,40 @@ fn test_add_skill() {
 }
 
 #[test]
+fn test_add_skill_marks_missing_soft_dependencies_pending() {
+    let catalog = make_test_catalog();
+    let mut skill = make_test_skill("shot-publish", "maya", &["publish"]);
+    skill.depends = vec!["maya-dev".to_string()];
+    catalog.add_skill(skill);
+
+    let pending = catalog.list_skills(Some("pending_deps"));
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].name, "shot-publish");
+    assert_eq!(pending[0].status, "pending_deps");
+    assert_eq!(pending[0].missing_dependencies, vec!["maya-dev"]);
+
+    let search = catalog.search_skills(Some("publish"), &[], Some("maya"), None, None);
+    assert_eq!(search.len(), 1, "pending skills must remain discoverable");
+    assert_eq!(search[0].status, "pending_deps");
+}
+
+#[test]
+fn test_add_dependency_clears_pending_dependency_state() {
+    let catalog = make_test_catalog();
+    let mut skill = make_test_skill("shot-publish", "maya", &["publish"]);
+    skill.depends = vec!["maya-dev".to_string()];
+    catalog.add_skill(skill);
+    assert_eq!(catalog.list_skills(Some("pending_deps")).len(), 1);
+
+    catalog.add_skill(make_test_skill("maya-dev", "maya", &["inspect"]));
+
+    assert!(catalog.list_skills(Some("pending_deps")).is_empty());
+    let info = catalog.get_skill_info("shot-publish").unwrap();
+    assert_eq!(info.state, "discovered");
+    assert!(info.missing_dependencies.is_empty());
+}
+
+#[test]
 fn test_rediscover_removes_missing_skill_and_registered_tools() {
     let tmp = tempfile::tempdir().unwrap();
     write_skill_dir(tmp.path(), "fresh-skill", "maya");
@@ -75,6 +109,44 @@ fn test_load_skill_registers_tools() {
     let registry = catalog.registry();
     assert_eq!(registry.len(), 2);
     assert!(registry.get_action("modeling_bevel__bevel", None).is_some());
+}
+
+#[test]
+fn test_load_skill_auto_loads_discovered_dependencies_first() {
+    let catalog = make_test_catalog();
+    catalog.add_skill(make_test_skill("maya-dev", "maya", &["inspect"]));
+    let mut skill = make_test_skill("shot-publish", "maya", &["publish"]);
+    skill.depends = vec!["maya-dev".to_string()];
+    catalog.add_skill(skill);
+
+    let actions = catalog.load_skill("shot-publish").unwrap();
+
+    assert_eq!(actions, vec!["shot_publish__publish".to_string()]);
+    assert!(catalog.is_loaded("maya-dev"));
+    assert!(catalog.is_loaded("shot-publish"));
+    assert!(
+        catalog
+            .registry()
+            .get_action("maya_dev__inspect", None)
+            .is_some(),
+        "dependency tools should be registered before the dependent skill"
+    );
+}
+
+#[test]
+fn test_load_skill_missing_dependency_error_is_actionable() {
+    let catalog = make_test_catalog();
+    let mut skill = make_test_skill("shot-publish", "maya", &["publish"]);
+    skill.depends = vec!["maya-dev".to_string()];
+    catalog.add_skill(skill);
+
+    let err = catalog
+        .load_skill("shot-publish")
+        .expect_err("missing dependency should block activation");
+
+    assert!(err.contains("pending dependencies"), "{err}");
+    assert!(err.contains("maya-dev"), "{err}");
+    assert!(err.contains("retry load_skill('shot-publish')"), "{err}");
 }
 
 #[test]

--- a/crates/dcc-mcp-skills/src/catalog/types.rs
+++ b/crates/dcc-mcp-skills/src/catalog/types.rs
@@ -22,16 +22,38 @@ where
 pub enum SkillState {
     /// Skill discovered but not loaded (tools not registered).
     Discovered,
+    /// Skill is discoverable, but one or more declared dependencies
+    /// are not present in the catalog yet.
+    PendingDeps { missing: Vec<String> },
     /// Skill loaded — tools registered in ToolRegistry.
     Loaded,
     /// Skill failed to load.
     Error(String),
 }
 
+impl SkillState {
+    pub fn status(&self) -> &'static str {
+        match self {
+            SkillState::Discovered => "discovered",
+            SkillState::PendingDeps { .. } => "pending_deps",
+            SkillState::Loaded => "loaded",
+            SkillState::Error(_) => "error",
+        }
+    }
+
+    pub fn missing_dependencies(&self) -> Vec<String> {
+        match self {
+            SkillState::PendingDeps { missing } => missing.clone(),
+            _ => Vec::new(),
+        }
+    }
+}
+
 impl std::fmt::Display for SkillState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             SkillState::Discovered => write!(f, "discovered"),
+            SkillState::PendingDeps { .. } => write!(f, "pending_deps"),
             SkillState::Loaded => write!(f, "loaded"),
             SkillState::Error(e) => write!(f, "error: {e}"),
         }
@@ -79,6 +101,13 @@ pub struct SkillSummary {
     #[serde(serialize_with = "serialize_tool_names")]
     pub tool_names: Vec<String>,
     pub loaded: bool,
+    /// Machine-readable load status: `"discovered"`, `"pending_deps"`,
+    /// `"loaded"`, or `"error"`.
+    #[serde(default)]
+    pub status: String,
+    /// Declared dependencies not currently present in the catalog.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub missing_dependencies: Vec<String>,
     /// Trust level / origin scope of this skill (e.g. `"repo"`, `"user"`, `"system"`).
     pub scope: String,
     /// `true` when this skill declares `allow_implicit_invocation: false`.
@@ -121,6 +150,8 @@ pub struct SkillDetail {
     pub scripts: Vec<String>,
     pub tools: Vec<ToolDeclaration>,
     pub state: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub missing_dependencies: Vec<String>,
     pub registered_tools: Vec<String>,
     /// Trust level / origin scope of this skill.
     pub scope: String,

--- a/crates/dcc-mcp-skills/src/loader/mod.rs
+++ b/crates/dcc-mcp-skills/src/loader/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! - [`parse_skill_md`]: Load a single skill from a directory.
 //! - [`scan_and_load`]: Full pipeline — scan directories, load all skills, resolve dependencies.
-//! - [`scan_and_load_lenient`]: Same pipeline but skips skills with missing deps instead of failing.
+//! - [`scan_and_load_lenient`]: Same pipeline but keeps skills with missing soft deps discoverable.
 
 // PyO3 bindings live in `crate::python::loader`.
 

--- a/crates/dcc-mcp-skills/src/loader/scan.rs
+++ b/crates/dcc-mcp-skills/src/loader/scan.rs
@@ -78,7 +78,8 @@ pub fn scan_and_load_strict(
     })
 }
 
-/// Lenient pipeline: scan, load, and resolve dependencies but skip unresolvable skills.
+/// Lenient pipeline: scan, load, and resolve dependencies while keeping
+/// skills with missing soft dependencies discoverable.
 pub fn scan_and_load_lenient(
     extra_paths: Option<&[String]>,
     dcc_name: Option<&str>,
@@ -86,32 +87,18 @@ pub fn scan_and_load_lenient(
     let mut scanner = SkillScanner::new();
     let dirs = scanner.scan(extra_paths, dcc_name, false);
 
-    let (skills, mut skipped) = load_all_skills(&dirs);
+    let (skills, skipped) = load_all_skills(&dirs);
     let errors = resolver::validate_dependencies(&skills);
     if !errors.is_empty() {
-        let mut bad_skills = std::collections::HashSet::new();
         for err in &errors {
             if let ResolveError::MissingDependency { skill, dependency } = err {
                 tracing::warn!(
-                    "Skill '{skill}' depends on '{dependency}' which is not available; skipping."
+                    "Skill '{skill}' depends on '{dependency}' which is not available yet; \
+                     keeping it discoverable as a pending dependency."
                 );
-                bad_skills.insert(skill.clone());
             }
         }
-
-        let filtered: Vec<SkillMetadata> = skills
-            .into_iter()
-            .filter(|skill| {
-                if bad_skills.contains(&skill.name) {
-                    skipped.push(skill.skill_path.clone());
-                    false
-                } else {
-                    true
-                }
-            })
-            .collect();
-
-        let resolved = resolver::resolve_dependencies(&filtered)?;
+        let resolved = resolve_dependencies_soft(&skills)?;
         return Ok(LoadResult {
             skills: resolved.ordered,
             skipped,
@@ -123,6 +110,31 @@ pub fn scan_and_load_lenient(
         skills: resolved.ordered,
         skipped,
     })
+}
+
+fn resolve_dependencies_soft(
+    skills: &[SkillMetadata],
+) -> Result<resolver::ResolvedSkills, ResolveError> {
+    let names: std::collections::HashSet<&str> = skills.iter().map(|s| s.name.as_str()).collect();
+    let orderable: Vec<SkillMetadata> = skills
+        .iter()
+        .map(|skill| {
+            let mut clone = skill.clone();
+            clone.depends.retain(|dep| names.contains(dep.as_str()));
+            clone
+        })
+        .collect();
+    let resolved = resolver::resolve_dependencies(&orderable)?;
+    let originals: std::collections::HashMap<&str, &SkillMetadata> = skills
+        .iter()
+        .map(|skill| (skill.name.as_str(), skill))
+        .collect();
+    let ordered = resolved
+        .ordered
+        .into_iter()
+        .filter_map(|skill| originals.get(skill.name.as_str()).map(|s| (*s).clone()))
+        .collect();
+    Ok(resolver::ResolvedSkills { ordered })
 }
 
 /// Load all skill metadata from a list of directories.

--- a/crates/dcc-mcp-skills/src/loader/tests/test_scan_and_load_lenient.rs
+++ b/crates/dcc-mcp-skills/src/loader/tests/test_scan_and_load_lenient.rs
@@ -16,17 +16,25 @@ fn create_skill(base: &std::path::Path, name: &str, deps: &[&str]) {
 }
 
 #[test]
-fn lenient_skips_missing_deps() {
+fn lenient_keeps_missing_deps_discoverable() {
     let tmp = tempfile::tempdir().unwrap();
     create_skill(tmp.path(), "good", &[]);
     create_skill(tmp.path(), "broken", &["nonexistent"]);
 
     let result =
         scan_and_load_lenient(Some(&[tmp.path().to_string_lossy().to_string()]), None).unwrap();
-    assert_eq!(result.skills.len(), 1);
-    assert_eq!(result.skills[0].name, "good");
-    // broken should be in skipped
-    assert!(!result.skipped.is_empty());
+    let names: Vec<&str> = result
+        .skills
+        .iter()
+        .map(|skill| skill.name.as_str())
+        .collect();
+    assert_eq!(names.len(), 2);
+    assert!(names.contains(&"good"));
+    assert!(names.contains(&"broken"));
+    assert!(
+        result.skipped.is_empty(),
+        "missing soft dependencies are not parse/load skips"
+    );
 }
 
 #[test]
@@ -55,7 +63,11 @@ fn lenient_preserves_valid_skills() {
     let names: Vec<&str> = result.skills.iter().map(|s| s.name.as_str()).collect();
     assert!(names.contains(&"base"));
     assert!(names.contains(&"child"));
-    assert!(!names.contains(&"orphan"));
+    assert!(names.contains(&"orphan"));
+    assert!(
+        names.iter().position(|name| *name == "base").unwrap()
+            < names.iter().position(|name| *name == "child").unwrap()
+    );
 }
 
 #[test]

--- a/docs/api/skills.md
+++ b/docs/api/skills.md
@@ -35,7 +35,7 @@ SkillCatalog(registry: ToolRegistry) -> SkillCatalog
 | `load_skill(skill_name)` | `List[str]` | Load a skill; returns list of registered action names. Raises `ValueError` if not found |
 | `unload_skill(skill_name)` | `int` | Unload a skill; returns number of actions removed. Raises `ValueError` if not loaded |
 | `search_skills(query=None, tags=None, dcc=None, scope=None, limit=None)` | `List[SkillSummary]` | Unified discovery with `scope` (`"repo" \| "user" \| "system" \| "admin"`) and `limit`. Empty call returns top skills by scope precedence (Admin > System > User > Repo). |
-| `list_skills(status=None)` | `List[SkillSummary]` | List skills. `status`: `"loaded"` or `"unloaded"`, or `None` for all |
+| `list_skills(status=None)` | `List[SkillSummary]` | List skills. `status`: `"loaded"`, `"unloaded"`, `"pending_deps"`, `"error"`, or `None` for all |
 | `get_skill_info(skill_name)` | `dict \| None` | Full metadata for a skill, or `None` if not found |
 | `is_loaded(skill_name)` | `bool` | Whether a skill is currently loaded |
 | `loaded_count()` | `int` | Number of loaded skills |
@@ -101,6 +101,8 @@ Lightweight summary returned by `SkillCatalog.search_skills()` and `list_skills(
 | `tool_count` | `int` | Number of declared tools |
 | `tool_names` | `List[str]` | Names of declared tools |
 | `loaded` | `bool` | Whether the skill is currently loaded |
+| `status` | `str` | Machine-readable load status: `"discovered"`, `"pending_deps"`, `"loaded"`, or `"error"` |
+| `missing_dependencies` | `List[str]` | Dependency skill names that are not currently present in the catalog |
 
 ### Dunder Methods
 
@@ -337,7 +339,7 @@ scan_and_load_lenient(
 ) -> tuple[List[SkillMetadata], List[str]]
 ```
 
-Same as `scan_and_load` but silently skips skills with missing dependencies (warns via logging). Only cyclic dependencies raise `ValueError`.
+Same as `scan_and_load` but keeps skills with missing soft dependencies in the returned skill list (warns via logging). Missing dependencies are ignored only for ordering; dependencies that are present are still sorted before their dependents. Only cyclic dependencies raise `ValueError`.
 
 Returns `(ordered_skills, skipped_dirs)`.
 

--- a/docs/api/utilities.md
+++ b/docs/api/utilities.md
@@ -145,13 +145,13 @@ print(f"Skipped {len(skipped)} directories")
 
 ### `scan_and_load_lenient()`
 
-Like `scan_and_load()` but silently skips skills with missing dependencies (only fails on cycles):
+Like `scan_and_load()` but keeps skills with missing soft dependencies discoverable (only fails on cycles):
 
 ```python
 from dcc_mcp_core import scan_and_load_lenient
 
 skills, skipped = scan_and_load_lenient(dcc_name="maya")
-# skills with unresolvable deps are in skipped, not raised as errors
+# skills with missing soft deps stay in skills; parse failures remain in skipped
 ```
 
 ### `resolve_dependencies()`

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -340,7 +340,7 @@ os.environ["DCC_MCP_SKILL_PATHS"] = "/path/to/skills"
 
 # One-shot scan + load + dependency sort → returns (skills, skipped_dirs)
 skills, skipped = scan_and_load(extra_paths=["/my/skills"], dcc_name="maya")
-skills_lenient, skipped = scan_and_load_lenient(dcc_name="maya")  # skip errors
+skills_lenient, skipped = scan_and_load_lenient(dcc_name="maya")  # keep soft-dep skills discoverable
 
 # Strict variant (issue maya#138): raises ValueError when any directory
 # was silently skipped, so embedders can fail start-up loudly instead of
@@ -355,12 +355,12 @@ except ValueError as exc:
 ```
 
 ::: tip Choosing the right entry point
-- `scan_and_load` — default; logs a `warn`-level summary for every skipped
-  directory (issue maya#138) and a per-failure `warn` from
-  `parse_skill_md`. Good for production where missing skills should be
-  visible in logs but not block start-up.
-- `scan_and_load_lenient` — same return shape but tolerates resolver
-  errors (missing dependency, dependency cycle).
+- `scan_and_load` — fail-fast on missing dependencies or cycles after logging
+  skipped directories and parse failures. Good for CI and packaged adapter
+  releases where dependency completeness should block the build.
+- `scan_and_load_lenient` — same return shape but keeps skills with missing
+  soft dependencies discoverable; present dependencies still sort before their
+  dependents, and dependency cycles still fail.
 - `scan_and_load_strict` — fails fast when the scanner skipped any
   directory. Use in CI / packaged adapter releases where a malformed
   `SKILL.md` should be a blocking error rather than a silent omission.
@@ -700,6 +700,16 @@ errors = validate_dependencies(skills)
 deps = expand_transitive_dependencies(skills, "maya-animation")
 # ["maya-geometry"]
 ```
+
+Dependency declarations are soft during catalog discovery. If a composition
+skill depends on `maya-dev` before that skill has been discovered, the
+composition skill still appears in `search_skills()` / `list_skills()` with
+`status: "pending_deps"` and a `missing_dependencies` list. Calling
+`load_skill("maya-animation")` auto-loads any discovered dependencies first;
+when a dependency is still missing, `load_skill` returns an actionable error
+that names the missing skill and asks the caller to discover or install it.
+Use `scan_and_load()` / `resolve_dependencies()` when you explicitly want a
+fail-fast dependency check for packaging or CI.
 
 ## Skill Directory Structure
 

--- a/docs/zh/api/skills.md
+++ b/docs/zh/api/skills.md
@@ -40,7 +40,7 @@ SkillCatalog(registry: ToolRegistry) -> SkillCatalog
 | `remove_skill(skill_name)` | `bool` | 从目录中完全移除（已加载则先卸载） |
 | `clear()` | `None` | 清空所有 Skill（已加载的先卸载） |
 | `search_skills(query=None, tags=None, dcc=None, scope=None, limit=None)` | `List[SkillSummary]` | 统一发现：支持 `scope`（`"repo" \| "user" \| "system" \| "admin"`）和 `limit`。空调用按 scope 优先级返回顶级 Skill（Admin > System > User > Repo）。 |
-| `list_skills(status=None)` | `List[SkillSummary]` | 列出 Skill。status：`"loaded"` 或 `"unloaded"`，`None` 为全部 |
+| `list_skills(status=None)` | `List[SkillSummary]` | 列出 Skill。status：`"loaded"`、`"unloaded"`、`"pending_deps"` 或 `"error"`，`None` 为全部 |
 | `get_skill_info(skill_name)` | `SkillMetadata \| None` | 返回完整元数据，未找到返回 `None` |
 | `is_loaded(skill_name)` | `bool` | 指定 Skill 是否已加载 |
 | `loaded_count()` | `int` | 已加载 Skill 的数量 |
@@ -107,6 +107,8 @@ print(f"已移除 {removed} 个 action")
 | `tool_count` | `int` | 声明的工具数量 |
 | `tool_names` | `List[str]` | 声明的工具名称列表 |
 | `loaded` | `bool` | 当前是否已加载 |
+| `status` | `str` | 机器可读加载状态：`"discovered"`、`"pending_deps"`、`"loaded"` 或 `"error"` |
+| `missing_dependencies` | `List[str]` | 当前 catalog 中尚未出现的依赖 Skill 名称 |
 
 ### 特殊方法
 
@@ -312,7 +314,7 @@ scan_and_load_lenient(
 ) -> tuple[List[SkillMetadata], List[str]]
 ```
 
-与 `scan_and_load` 相同，但静默跳过依赖缺失的 Skill（通过日志记录警告）。仅循环依赖会抛出 `ValueError`。
+与 `scan_and_load` 相同，但会保留缺失软依赖的 Skill，让它们仍可被发现（通过日志记录警告）。缺失依赖只会在排序时被忽略；已经存在的依赖仍会排在依赖方之前。仅循环依赖会抛出 `ValueError`。
 
 ### resolve_dependencies
 

--- a/docs/zh/api/utilities.md
+++ b/docs/zh/api/utilities.md
@@ -145,13 +145,13 @@ print(f"跳过 {len(skipped)} 个目录")
 
 ### `scan_and_load_lenient()`
 
-与 `scan_and_load()` 类似，但会静默跳过依赖缺失的 Skill（仅在出现循环依赖时失败）：
+与 `scan_and_load()` 类似，但会保留缺失软依赖的 Skill，让它们仍可被发现（仅在出现循环依赖时失败）：
 
 ```python
 from dcc_mcp_core import scan_and_load_lenient
 
 skills, skipped = scan_and_load_lenient(dcc_name="maya")
-# 依赖无法解析的 Skill 会出现在 skipped 中，而非抛出异常
+# 缺失软依赖的 Skill 仍在 skills 中；解析失败的目录仍在 skipped 中
 ```
 
 ### `resolve_dependencies()`

--- a/docs/zh/guide/skills.md
+++ b/docs/zh/guide/skills.md
@@ -269,7 +269,7 @@ os.environ["DCC_MCP_SKILL_PATHS"] = "/path/to/skills"
 
 # 一次性扫描 + 加载 + 依赖排序 → 返回 (skills, skipped_dirs)
 skills, skipped = scan_and_load(extra_paths=["/my/skills"], dcc_name="maya")
-skills_lenient, skipped = scan_and_load_lenient(dcc_name="maya")  # 跳过错误
+skills_lenient, skipped = scan_and_load_lenient(dcc_name="maya")  # 保留软依赖缺失的 Skill
 
 # 扫描目录中的 SKILL.md 文件
 scanner = SkillScanner()
@@ -338,6 +338,14 @@ errors = validate_dependencies(skills)
 deps = expand_transitive_dependencies(skills, "maya-animation")
 # ["maya-geometry"]
 ```
+
+Catalog 发现阶段会把这些声明当作软依赖处理。若组合 Skill 依赖
+`maya-dev`，但扫描时 `maya-dev` 还没有被发现，组合 Skill 仍会出现在
+`search_skills()` / `list_skills()` 中，并带有 `status: "pending_deps"` 和
+`missing_dependencies`。调用 `load_skill("maya-animation")` 时会先自动加载已经
+发现的依赖；如果依赖仍缺失，则返回包含缺失 Skill 名称和修复建议的错误。
+需要在打包或 CI 中强制校验依赖时，继续使用 `scan_and_load()` /
+`resolve_dependencies()` 的 fail-fast 行为。
 
 ## SkillMetadata 字段
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -168,8 +168,12 @@ Infrastructure skills do not require `on-failure` chains (they ARE the fallback)
 
 Domain skills **must** declare dependencies for every infrastructure skill they chain to via
 `next-tools.on-failure`. Use `metadata.dcc-mcp.depends` for short lists or
-`metadata/depends.md` for longer dependency notes. This ensures the infrastructure skill is
-loaded before the domain skill is activated:
+`metadata/depends.md` for longer dependency notes. Discovery treats these as
+soft dependencies: a domain skill remains searchable with `status:
+pending_deps` until every dependency is present. `load_skill` auto-loads
+dependencies that have been discovered and returns an actionable error for
+dependencies that are still missing. This ensures the infrastructure skill is
+loaded before the domain skill is activated without making scan order fragile:
 
 ```yaml
 metadata:

--- a/skills/dcc-mcp-skill-developer/SKILL.md
+++ b/skills/dcc-mcp-skill-developer/SKILL.md
@@ -49,7 +49,12 @@ into a faster authoring loop.
    safety annotations, and `timeout_hint_secs` for async tools.
    Published MCP tool names must be client-safe
    `^[A-Za-z0-9_-]{1,64}$`; use underscores instead of dotted tool names.
-6. When changing adapter server wiring or caller examples, keep Admin telemetry
+6. Treat `metadata.dcc-mcp.depends` as soft during discovery. Composition
+   skills may remain searchable with `status: pending_deps` while host-specific
+   dependencies are injected later through `DCC_MCP_*_SKILL_PATHS`. `load_skill`
+   auto-loads discovered dependencies first and returns a clear missing-dep
+   error only when a dependency is still absent.
+7. When changing adapter server wiring or caller examples, keep Admin telemetry
    useful: pass optional `agent_context` / `caller_context` summaries through
    MCP `_meta`, REST `meta`, or `x-dcc-mcp-agent-*` headers when the caller is
    an agent. Include only explicit summaries, plans, observations, and
@@ -64,7 +69,7 @@ into a faster authoring loop.
    the shipped server paths enable the required gateway `admin` feature and
    Admin telemetry runtime state, while minimal direct `dcc-mcp-gateway` builds
    or runtimes started with Admin disabled may omit those debug routes.
-7. For adapter install, uninstall, or upgrade flows, use
+8. For adapter install, uninstall, or upgrade flows, use
    `dcc_mcp_core.install_lifecycle` before importing Rust-backed public API:
    query/stop registered sidecars, inspect install roots, classify locked
    native artifacts, and call `safe_remove_tree` / `safe_replace_tree` from a
@@ -73,7 +78,7 @@ into a faster authoring loop.
    `adapter_version`); `ServiceEntry.version` is the DCC application version.
    Stop helpers must respect FileRegistry sentinel locks before trusting PID
    liveness so installer code never terminates a reused PID from a stale row.
-8. Add tests at the lowest executable layer, then one discovery/load/call or
+9. Add tests at the lowest executable layer, then one discovery/load/call or
    gateway REST path when behavior crosses MCP or REST boundaries.
 
 ## Adapter Selection

--- a/tests/test_skills_loader.py
+++ b/tests/test_skills_loader.py
@@ -128,7 +128,7 @@ class TestScanAndLoad:
 
 
 # ---------------------------------------------------------------------------
-# scan_and_load_lenient — tolerates missing dependencies
+# scan_and_load_lenient — preserves soft dependency discovery
 # ---------------------------------------------------------------------------
 
 
@@ -169,15 +169,14 @@ class TestScanAndLoadLenient:
         assert len(skills) == 4
 
     def test_missing_dependency_reports_skipped_skill_path_not_exception(self, tmp_path: Path) -> None:
-        """Lenient scans keep valid skills and report dependency failures as skipped paths."""
+        """Lenient scans keep skills with missing soft dependencies discoverable."""
         _write_skill(tmp_path, "orphan-skill", deps=["missing-dep"])
         _write_skill(tmp_path, "good-skill")
 
         skills, skipped = dcc_mcp_core.scan_and_load_lenient(extra_paths=[str(tmp_path)])
 
-        assert {skill.name for skill in skills} == {"good-skill"}
-        assert len(skipped) == 1
-        assert Path(skipped[0]).name == "orphan-skill"
+        assert {skill.name for skill in skills} == {"good-skill", "orphan-skill"}
+        assert skipped == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- keep lenient skill discovery from dropping skills whose declared dependencies are not installed yet
- surface `pending_deps` and `missing_dependencies` through skill catalog/list projections and gateway skill management schema
- auto-load discovered skill dependencies before loading a target skill, and return an actionable error when dependencies are still missing
- update English/Chinese docs and skill developer guidance for soft dependency behavior

## Validation
- `vx cargo test -p dcc-mcp-skills lenient --lib`
- `vx cargo test -p dcc-mcp-skills catalog --lib`
- `vx cargo test -p dcc-mcp-skill-rest search_loaded_only_false --lib`
- `vx cargo test -p dcc-mcp-skills --lib`
- `vx cargo test -p dcc-mcp-skill-rest --lib`
- `vx cargo test -p dcc-mcp-gateway skill_management_tool_defs --lib`
- `vx cargo fmt --all --check`
- `git diff --check`
- `vx just dev` with `DCC_MCP_ADMIN_UI_PREBUILT=1` after prebuilding admin-ui
- `.\.venv\Scripts\python.exe -m pytest tests/test_skills_loader.py -q --tb=short --show-capture=no`
- `.\.venv\Scripts\python.exe -m pytest tests/test_progressive_skill_discovery.py tests/test_search_skills_unified.py -q --tb=short --show-capture=no`
- pre-commit hook: cargo clippy, cargo fmt, ruff, whitespace checks

Closes #1118