### PR TITLE
feat: add event bus lifecycle hooks

### DIFF
--- a/crates/dcc-mcp-actions/src/dispatcher.rs
+++ b/crates/dcc-mcp-actions/src/dispatcher.rs
@@ -47,12 +47,14 @@
 use std::cell::Cell;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Instant;
 
 use parking_lot::Mutex;
-use serde_json::Value;
+use serde_json::{Map, Value, json};
 
 use dcc_mcp_models::ThreadAffinity;
 
+use crate::events::EventBus;
 use crate::registry::{ToolMeta, ToolRegistry};
 use crate::validation_strategy::select_strategy;
 
@@ -179,6 +181,7 @@ pub struct DispatchResult {
 pub struct ToolDispatcher {
     registry: ToolRegistry,
     handlers: Arc<Mutex<HashMap<String, HandlerFn>>>,
+    event_bus: EventBus,
     /// Whether to skip validation when the schema is `{}` or `null`.
     pub skip_empty_schema_validation: bool,
 }
@@ -198,8 +201,22 @@ impl ToolDispatcher {
         Self {
             registry,
             handlers: Arc::new(Mutex::new(HashMap::new())),
+            event_bus: EventBus::new(),
             skip_empty_schema_validation: true,
         }
+    }
+
+    /// Create a dispatcher that emits lifecycle events on the supplied bus.
+    #[must_use]
+    pub fn with_event_bus(mut self, event_bus: EventBus) -> Self {
+        self.event_bus = event_bus;
+        self
+    }
+
+    /// Return the dispatcher event bus.
+    #[must_use]
+    pub fn event_bus(&self) -> EventBus {
+        self.event_bus.clone()
     }
 
     /// Register a handler function for the given action name.
@@ -273,42 +290,117 @@ impl ToolDispatcher {
         action_name: &str,
         params: Value,
     ) -> Result<DispatchResult, DispatchError> {
+        self.dispatch_inner(action_name, params, true)
+    }
+
+    #[cfg_attr(not(feature = "python-bindings"), allow(dead_code))]
+    pub(crate) fn dispatch_for_validation(
+        &self,
+        action_name: &str,
+        params: Value,
+    ) -> Result<DispatchResult, DispatchError> {
+        self.dispatch_inner(action_name, params, false)
+    }
+
+    fn dispatch_inner(
+        &self,
+        action_name: &str,
+        params: Value,
+        emit_events: bool,
+    ) -> Result<DispatchResult, DispatchError> {
+        let started = Instant::now();
         // 1. Look up handler
         let handler = {
             let map = self.handlers.lock();
             map.get(action_name).cloned()
         };
-        let handler =
-            handler.ok_or_else(|| DispatchError::HandlerNotFound(action_name.to_string()))?;
+        let Some(handler) = handler else {
+            let err = DispatchError::HandlerNotFound(action_name.to_string());
+            if emit_events {
+                self.emit_tool_failed(action_name, None, &err, started);
+            }
+            return Err(err);
+        };
 
         // 2. Metadata + progressive-exposure gate.
         let meta_opt: Option<ToolMeta> = self.registry.get_action(action_name, None);
         if let Some(meta) = &meta_opt {
             if !meta.enabled {
-                return Err(DispatchError::ActionDisabled {
+                let err = DispatchError::ActionDisabled {
                     action: action_name.to_string(),
                     group: meta.group.clone(),
-                });
+                };
+                if emit_events {
+                    self.emit_tool_failed(action_name, meta_opt.as_ref(), &err, started);
+                }
+                return Err(err);
             }
             if meta.enforce_thread_affinity {
                 let actual = current_thread_affinity();
                 if actual != meta.thread_affinity {
-                    return Err(DispatchError::ThreadAffinityViolation {
+                    let err = DispatchError::ThreadAffinityViolation {
                         action: action_name.to_string(),
                         declared: meta.thread_affinity,
                         actual,
-                    });
+                    };
+                    if emit_events {
+                        self.emit_tool_failed(action_name, meta_opt.as_ref(), &err, started);
+                    }
+                    return Err(err);
                 }
             }
         }
 
         // 3. Validation via pluggable strategy (#493).
-        let outcome = select_strategy(meta_opt.as_ref(), self.skip_empty_schema_validation)
+        let outcome = match select_strategy(meta_opt.as_ref(), self.skip_empty_schema_validation)
             .validate(&params)
-            .map_err(DispatchError::ValidationFailed)?;
+        {
+            Ok(outcome) => outcome,
+            Err(msg) => {
+                let err = DispatchError::ValidationFailed(msg);
+                if emit_events {
+                    self.emit_tool_failed(action_name, meta_opt.as_ref(), &err, started);
+                }
+                return Err(err);
+            }
+        };
 
         // 4. Call handler.
-        let output = handler(params).map_err(DispatchError::HandlerError)?;
+        if emit_events {
+            self.emit_tool_event(
+                "tool.dispatched",
+                action_name,
+                meta_opt.as_ref(),
+                started,
+                json!({
+                    "validation_skipped": outcome.skipped,
+                }),
+            );
+        }
+
+        let output = match handler(params) {
+            Ok(output) => output,
+            Err(msg) => {
+                let err = DispatchError::HandlerError(msg);
+                if emit_events {
+                    self.emit_tool_failed(action_name, meta_opt.as_ref(), &err, started);
+                }
+                return Err(err);
+            }
+        };
+
+        if emit_events {
+            self.emit_tool_event(
+                "tool.completed",
+                action_name,
+                meta_opt.as_ref(),
+                started,
+                json!({
+                    "validation_skipped": outcome.skipped,
+                    "result_success": true,
+                }),
+            );
+        }
 
         Ok(DispatchResult {
             action: action_name.to_string(),
@@ -317,10 +409,87 @@ impl ToolDispatcher {
         })
     }
 
+    fn emit_tool_failed(
+        &self,
+        action_name: &str,
+        meta: Option<&ToolMeta>,
+        err: &DispatchError,
+        started: Instant,
+    ) {
+        self.emit_tool_event(
+            "tool.failed",
+            action_name,
+            meta,
+            started,
+            json!({
+                "result_success": false,
+                "error_kind": dispatch_error_kind(err),
+                "error_message": err.to_string(),
+            }),
+        );
+    }
+
+    fn emit_tool_event(
+        &self,
+        event_name: &str,
+        action_name: &str,
+        meta: Option<&ToolMeta>,
+        started: Instant,
+        attributes: Value,
+    ) {
+        if !self.event_bus.has_subscribers(event_name) {
+            return;
+        }
+
+        let mut source = Map::new();
+        let mut attrs = attributes.as_object().cloned().unwrap_or_default();
+        attrs.insert("tool_slug".to_string(), json!(action_name));
+        attrs.insert("tool_name".to_string(), json!(action_name));
+        attrs.insert(
+            "duration_ms".to_string(),
+            json!(u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX)),
+        );
+
+        if let Some(meta) = meta {
+            if !meta.dcc.is_empty() {
+                source.insert("dcc_type".to_string(), json!(meta.dcc));
+                attrs.insert("dcc_type".to_string(), json!(meta.dcc));
+            }
+            if let Some(skill_name) = &meta.skill_name {
+                attrs.insert("skill_name".to_string(), json!(skill_name));
+            }
+            if !meta.group.is_empty() {
+                attrs.insert("group".to_string(), json!(meta.group));
+            }
+            attrs.insert(
+                "annotations".to_string(),
+                serde_json::to_value(&meta.annotations).unwrap_or(Value::Null),
+            );
+        }
+
+        let _ = self.event_bus.emit(
+            event_name,
+            Value::Object(source),
+            Value::Object(Map::new()),
+            Value::Object(attrs),
+        );
+    }
+
     /// Access the underlying registry.
     #[must_use]
     pub fn registry(&self) -> &ToolRegistry {
         &self.registry
+    }
+}
+
+fn dispatch_error_kind(err: &DispatchError) -> &'static str {
+    match err {
+        DispatchError::HandlerNotFound(_) => "handler_not_found",
+        DispatchError::MetadataNotFound(_) => "metadata_not_found",
+        DispatchError::ValidationFailed(_) => "validation_failed",
+        DispatchError::HandlerError(_) => "handler_error",
+        DispatchError::ActionDisabled { .. } => "action_disabled",
+        DispatchError::ThreadAffinityViolation { .. } => "thread_affinity_violation",
     }
 }
 
@@ -438,6 +607,76 @@ mod tests {
             .unwrap();
         assert_eq!(result.output["radius"], json!(5.0));
         assert!(!result.validation_skipped);
+    }
+
+    #[cfg(not(feature = "python-bindings"))]
+    #[test]
+    fn test_dispatch_emits_tool_lifecycle_events() {
+        let reg = ToolRegistry::new();
+        reg.register_action(ToolMeta {
+            name: "echo".into(),
+            dcc: "maya".into(),
+            skill_name: Some("maya-core".into()),
+            ..Default::default()
+        });
+        let dispatcher = ToolDispatcher::new(reg);
+        dispatcher.register_handler("echo", Ok);
+
+        let events = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let captured = Arc::clone(&events);
+        let _id = dispatcher
+            .event_bus()
+            .subscribe_event("tool.*".to_string(), move |event| {
+                captured
+                    .lock()
+                    .unwrap()
+                    .push((event.name.clone(), event.attributes.clone()));
+            });
+
+        let result = dispatcher
+            .dispatch("echo", json!({"msg": "hello"}))
+            .unwrap();
+        assert_eq!(result.output, json!({"msg": "hello"}));
+
+        let events = events.lock().unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].0, "tool.dispatched");
+        assert_eq!(events[0].1["tool_slug"], "echo");
+        assert_eq!(events[0].1["skill_name"], "maya-core");
+        assert_eq!(events[0].1["dcc_type"], "maya");
+        assert_eq!(events[1].0, "tool.completed");
+        assert_eq!(events[1].1["result_success"], true);
+    }
+
+    #[cfg(not(feature = "python-bindings"))]
+    #[test]
+    fn test_dispatch_validation_failure_emits_tool_failed() {
+        let (dispatcher, _reg) = make_dispatcher_with_action(json!({
+            "type": "object",
+            "required": ["radius"]
+        }));
+        dispatcher.register_handler("test_action", |_| Ok(json!("ok")));
+
+        let events = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let captured = Arc::clone(&events);
+        let _id = dispatcher
+            .event_bus()
+            .subscribe_event("tool.*".to_string(), move |event| {
+                captured
+                    .lock()
+                    .unwrap()
+                    .push((event.name.clone(), event.attributes.clone()));
+            });
+
+        let err = dispatcher.dispatch("test_action", json!({})).unwrap_err();
+        assert!(matches!(err, DispatchError::ValidationFailed(_)));
+
+        let events = events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, "tool.failed");
+        assert_eq!(events[0].1["tool_slug"], "test_action");
+        assert_eq!(events[0].1["error_kind"], "validation_failed");
+        assert_eq!(events[0].1["result_success"], false);
     }
 
     #[test]

--- a/crates/dcc-mcp-actions/src/dispatcher.rs
+++ b/crates/dcc-mcp-actions/src/dispatcher.rs
@@ -390,6 +390,7 @@ impl ToolDispatcher {
         };
 
         if emit_events {
+            let result_success = tool_result_success(&output);
             self.emit_tool_event(
                 "tool.completed",
                 action_name,
@@ -397,7 +398,7 @@ impl ToolDispatcher {
                 started,
                 json!({
                     "validation_skipped": outcome.skipped,
-                    "result_success": true,
+                    "result_success": result_success,
                 }),
             );
         }
@@ -482,7 +483,7 @@ impl ToolDispatcher {
     }
 }
 
-fn dispatch_error_kind(err: &DispatchError) -> &'static str {
+pub(crate) fn dispatch_error_kind(err: &DispatchError) -> &'static str {
     match err {
         DispatchError::HandlerNotFound(_) => "handler_not_found",
         DispatchError::MetadataNotFound(_) => "metadata_not_found",
@@ -491,6 +492,13 @@ fn dispatch_error_kind(err: &DispatchError) -> &'static str {
         DispatchError::ActionDisabled { .. } => "action_disabled",
         DispatchError::ThreadAffinityViolation { .. } => "thread_affinity_violation",
     }
+}
+
+fn tool_result_success(output: &Value) -> bool {
+    output
+        .get("success")
+        .and_then(Value::as_bool)
+        .unwrap_or(true)
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -646,6 +654,48 @@ mod tests {
         assert_eq!(events[0].1["dcc_type"], "maya");
         assert_eq!(events[1].0, "tool.completed");
         assert_eq!(events[1].1["result_success"], true);
+    }
+
+    #[cfg(not(feature = "python-bindings"))]
+    #[test]
+    fn test_dispatch_completed_event_respects_success_false_payload() {
+        let reg = ToolRegistry::new();
+        reg.register_action(ToolMeta {
+            name: "soft_fail".into(),
+            dcc: "maya".into(),
+            ..Default::default()
+        });
+        let dispatcher = ToolDispatcher::new(reg);
+        dispatcher.register_handler("soft_fail", |_| {
+            Ok(json!({
+                "success": false,
+                "message": "tool reported a domain failure"
+            }))
+        });
+
+        let events = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let captured = Arc::clone(&events);
+        let _id = dispatcher
+            .event_bus()
+            .subscribe_event("tool.*".to_string(), move |event| {
+                captured
+                    .lock()
+                    .unwrap()
+                    .push((event.name.clone(), event.attributes.clone()));
+            });
+
+        let result = dispatcher.dispatch("soft_fail", json!({})).unwrap();
+        assert_eq!(result.output["success"], false);
+
+        let events = events.lock().unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .map(|(name, _)| name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["tool.dispatched", "tool.completed"]
+        );
+        assert_eq!(events[1].1["result_success"], false);
     }
 
     #[cfg(not(feature = "python-bindings"))]

--- a/crates/dcc-mcp-actions/src/events.rs
+++ b/crates/dcc-mcp-actions/src/events.rs
@@ -11,6 +11,13 @@ use pyo3_stub_gen_derive::gen_stub_pyclass;
 use dashmap::DashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// Current event envelope schema version.
+pub const EVENT_SCHEMA_VERSION: u32 = 1;
 
 /// Event subscriber ID for unsubscription.
 pub(crate) type SubscriberId = u64;
@@ -20,7 +27,7 @@ pub(crate) type SubscriberId = u64;
 /// Wrapped in `Arc` so callbacks can be cloned out of the DashMap before
 /// invocation — this avoids holding a read-lock while executing user code.
 #[cfg(not(feature = "python-bindings"))]
-type EventCallback = Arc<dyn Fn() + Send + Sync>;
+type EventCallback = Arc<dyn Fn(&EventEnvelope) + Send + Sync>;
 
 /// Type alias for the subscriber storage map.
 #[cfg(feature = "python-bindings")]
@@ -37,13 +44,53 @@ type SubscriberMap = Arc<DashMap<String, Vec<(SubscriberId, EventCallback)>>>;
 #[derive(Clone)]
 pub struct EventBus {
     pub(crate) next_id: Arc<AtomicU64>,
+    pub(crate) next_event_id: Arc<AtomicU64>,
     pub(crate) subscribers: SubscriberMap,
+}
+
+/// Structured event envelope shared by in-process subscribers and future webhooks.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EventEnvelope {
+    pub schema_version: u32,
+    pub name: String,
+    pub id: String,
+    pub timestamp_ns: u64,
+    pub source: Value,
+    pub correlation: Value,
+    pub attributes: Value,
+}
+
+impl EventEnvelope {
+    #[must_use]
+    pub fn new(
+        name: impl Into<String>,
+        id: impl Into<String>,
+        source: Value,
+        correlation: Value,
+        attributes: Value,
+    ) -> Self {
+        Self {
+            schema_version: EVENT_SCHEMA_VERSION,
+            name: name.into(),
+            id: id.into(),
+            timestamp_ns: timestamp_ns(),
+            source: object_or_empty(source),
+            correlation: object_or_empty(correlation),
+            attributes: object_or_empty(attributes),
+        }
+    }
+
+    #[must_use]
+    pub fn to_value(&self) -> Value {
+        serde_json::to_value(self).unwrap_or_else(|_| Value::Object(Map::new()))
+    }
 }
 
 impl std::fmt::Debug for EventBus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EventBus")
             .field("next_id", &self.next_id.load(Ordering::Relaxed))
+            .field("next_event_id", &self.next_event_id.load(Ordering::Relaxed))
             .field(
                 "subscriber_events",
                 &self
@@ -67,6 +114,7 @@ impl EventBus {
     pub fn new() -> Self {
         Self {
             next_id: Arc::new(AtomicU64::new(0)),
+            next_event_id: Arc::new(AtomicU64::new(0)),
             subscribers: Arc::new(DashMap::new()),
         }
     }
@@ -80,10 +128,9 @@ impl EventBus {
     /// Check if any subscribers exist for the given event.
     #[must_use]
     pub fn has_subscribers(&self, event_name: &str) -> bool {
-        self.subscribers
-            .get(event_name)
-            .map(|s| !s.is_empty())
-            .unwrap_or(false)
+        self.subscribers.iter().any(|entry| {
+            !entry.value().is_empty() && subscription_matches(entry.key().as_str(), event_name)
+        })
     }
 
     /// Allocate a new subscriber ID (starts at 1, monotonically increasing).
@@ -100,6 +147,73 @@ impl EventBus {
         }
         false
     }
+
+    #[must_use]
+    pub(crate) fn make_event(
+        &self,
+        event_name: &str,
+        source: Value,
+        correlation: Value,
+        attributes: Value,
+    ) -> EventEnvelope {
+        EventEnvelope::new(
+            event_name,
+            self.next_event_id(),
+            source,
+            correlation,
+            attributes,
+        )
+    }
+
+    /// Emit a structured event and return the envelope that was delivered.
+    #[must_use]
+    pub fn emit(
+        &self,
+        event_name: &str,
+        source: Value,
+        correlation: Value,
+        attributes: Value,
+    ) -> EventEnvelope {
+        let event = self.make_event(event_name, source, correlation, attributes);
+        self.publish_event(&event);
+        event
+    }
+
+    fn next_event_id(&self) -> String {
+        let seq = self.next_event_id.fetch_add(1, Ordering::Relaxed) + 1;
+        format!("ev_{:x}_{:x}", timestamp_ns(), seq)
+    }
+}
+
+#[must_use]
+pub(crate) fn subscription_matches(pattern: &str, event_name: &str) -> bool {
+    if pattern == event_name || pattern == "*" {
+        return true;
+    }
+    let Some(prefix) = pattern.strip_suffix(".*") else {
+        return false;
+    };
+    if prefix.is_empty() {
+        return true;
+    }
+    event_name
+        .strip_prefix(prefix)
+        .is_some_and(|suffix| suffix.starts_with('.'))
+}
+
+fn object_or_empty(value: Value) -> Value {
+    if value.is_object() {
+        value
+    } else {
+        Value::Object(Map::new())
+    }
+}
+
+fn timestamp_ns() -> u64 {
+    let duration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    duration.as_secs().saturating_mul(1_000_000_000) + u64::from(duration.subsec_nanos())
 }
 
 // ── Non-Python Rust API ──
@@ -111,6 +225,15 @@ impl EventBus {
     pub fn subscribe<F>(&self, event_name: String, callback: F) -> SubscriberId
     where
         F: Fn() + Send + Sync + 'static,
+    {
+        self.subscribe_event(event_name, move |_| callback())
+    }
+
+    /// Subscribe a Rust closure to structured event envelopes.
+    #[must_use]
+    pub fn subscribe_event<F>(&self, event_name: String, callback: F) -> SubscriberId
+    where
+        F: Fn(&EventEnvelope) + Send + Sync + 'static,
     {
         let id = self.next_subscriber_id();
         self.subscribers
@@ -126,7 +249,7 @@ impl EventBus {
         self.remove_subscriber(event_name, subscriber_id)
     }
 
-    /// Publish an event, calling all subscribers.
+    /// Publish an empty structured event, calling all matching subscribers.
     ///
     /// Callbacks are collected before invocation to avoid holding a DashMap
     /// read-lock while executing user code (which could attempt to
@@ -136,21 +259,39 @@ impl EventBus {
     /// panicking subscriber does not prevent subsequent subscribers from
     /// being called.
     pub fn publish(&self, event_name: &str) {
+        let event = self.make_event(
+            event_name,
+            Value::Object(Map::new()),
+            Value::Object(Map::new()),
+            Value::Object(Map::new()),
+        );
+        self.publish_event(&event);
+    }
+
+    /// Publish an existing structured event envelope.
+    pub fn publish_event(&self, event: &EventEnvelope) {
         let callbacks: Vec<_> = self
             .subscribers
-            .get(event_name)
-            .map(|subs| subs.iter().map(|(_, cb)| Clone::clone(cb)).collect())
-            .unwrap_or_default();
+            .iter()
+            .filter(|entry| subscription_matches(entry.key().as_str(), &event.name))
+            .flat_map(|entry| {
+                entry
+                    .value()
+                    .iter()
+                    .map(|(_, cb)| Clone::clone(cb))
+                    .collect::<Vec<_>>()
+            })
+            .collect();
         for callback in &callbacks {
             if let Err(e) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                callback();
+                callback(event);
             })) {
                 let msg = e
                     .downcast_ref::<&str>()
                     .copied()
                     .or_else(|| e.downcast_ref::<String>().map(|s| s.as_str()))
                     .unwrap_or("unknown panic");
-                tracing::error!("Panic in event subscriber for {event_name}: {msg}");
+                tracing::error!("Panic in event subscriber for {}: {msg}", event.name);
             }
         }
     }
@@ -158,7 +299,7 @@ impl EventBus {
 
 // PyO3 bindings live in `crate::python::events`.
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "python-bindings")))]
 mod tests {
     use super::*;
 
@@ -226,6 +367,58 @@ mod tests {
         assert!(!bus.has_subscribers("my_event"));
         let _id = bus.subscribe("my_event".to_string(), || {});
         assert!(bus.has_subscribers("my_event"));
+    }
+
+    #[test]
+    fn test_event_bus_wildcard_subscribers_receive_matching_events() {
+        let bus = EventBus::new();
+        let names = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let seen = Arc::clone(&names);
+        let _id = bus.subscribe_event("tool.*".to_string(), move |event| {
+            seen.lock().unwrap().push(event.name.clone());
+        });
+
+        assert!(bus.has_subscribers("tool.completed"));
+        assert!(!bus.has_subscribers("skill.loaded"));
+
+        let _ = bus.emit(
+            "tool.completed",
+            serde_json::json!({"dcc_type": "maya"}),
+            serde_json::json!({}),
+            serde_json::json!({"tool_slug": "maya.scene__open"}),
+        );
+        bus.publish("skill.loaded");
+
+        assert_eq!(
+            names.lock().unwrap().as_slice(),
+            &["tool.completed".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_event_bus_structured_envelope_contains_schema_and_payload() {
+        let bus = EventBus::new();
+        let captured = Arc::new(std::sync::Mutex::new(None));
+        let captured_clone = Arc::clone(&captured);
+        let _id = bus.subscribe_event("gateway.started".to_string(), move |event| {
+            *captured_clone.lock().unwrap() = Some(event.clone());
+        });
+
+        let event = bus.emit(
+            "gateway.started",
+            serde_json::json!({"dcc_type": "custom"}),
+            serde_json::json!({"request_id": "req-1"}),
+            serde_json::json!({"port": 9765}),
+        );
+
+        let observed = captured.lock().unwrap().clone().unwrap();
+        assert_eq!(event.schema_version, EVENT_SCHEMA_VERSION);
+        assert_eq!(observed.name, "gateway.started");
+        assert_eq!(observed.source["dcc_type"], "custom");
+        assert_eq!(observed.correlation["request_id"], "req-1");
+        assert_eq!(observed.attributes["port"], 9765);
+        assert!(observed.id.starts_with("ev_"));
+        assert!(observed.timestamp_ns > 0);
     }
 
     #[test]

--- a/crates/dcc-mcp-actions/src/python/events.rs
+++ b/crates/dcc-mcp-actions/src/python/events.rs
@@ -3,8 +3,59 @@
 use pyo3::prelude::*;
 #[cfg(feature = "stub-gen")]
 use pyo3_stub_gen_derive::gen_stub_pymethods;
+use serde_json::{Map, Value};
 
-use crate::events::{EventBus, SubscriberId};
+use crate::events::{EventBus, EventEnvelope, SubscriberId, subscription_matches};
+
+impl EventBus {
+    fn matching_callbacks(&self, py: Python<'_>, event_name: &str) -> Vec<Py<PyAny>> {
+        self.subscribers
+            .iter()
+            .filter(|entry| subscription_matches(entry.key().as_str(), event_name))
+            .flat_map(|entry| {
+                entry
+                    .value()
+                    .iter()
+                    .map(|(_, cb)| cb.clone_ref(py))
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    }
+
+    /// Publish a structured event envelope to Python subscribers.
+    pub fn publish_event(&self, event: &EventEnvelope) {
+        let Some(()) = Python::try_attach(|py| {
+            let callbacks = self.matching_callbacks(py, &event.name);
+            if callbacks.is_empty() {
+                return;
+            }
+            let event_value = event.to_value();
+            let py_event = match dcc_mcp_pybridge::py_json::json_value_to_pyobject(py, &event_value)
+            {
+                Ok(value) => value,
+                Err(err) => {
+                    tracing::error!(
+                        "Error converting event {} to Python object: {}",
+                        event.name,
+                        err
+                    );
+                    return;
+                }
+            };
+            for callback in &callbacks {
+                if let Err(err) = callback.call1(py, (py_event.clone_ref(py),)) {
+                    tracing::error!("Error in event subscriber for {}: {}", event.name, err);
+                }
+            }
+        }) else {
+            tracing::warn!(
+                "EventBus could not deliver '{}' because Python is not attached",
+                event.name
+            );
+            return;
+        };
+    }
+}
 
 // NOTE: subscribe() takes Py<PyAny>, publish() uses **kwargs — stubs may have imperfect types
 #[cfg_attr(feature = "stub-gen", gen_stub_pymethods)]
@@ -31,7 +82,7 @@ impl EventBus {
         self.remove_subscriber(event_name, subscriber_id)
     }
 
-    /// Publish an event, calling all subscribers.
+    /// Publish an event with legacy keyword payloads, calling all subscribers.
     ///
     /// Callbacks are collected before invocation to avoid holding a DashMap
     /// read-lock while executing user code (which could attempt to
@@ -43,11 +94,7 @@ impl EventBus {
         event_name: &str,
         kwargs: Option<&Bound<'_, pyo3::types::PyDict>>,
     ) {
-        let callbacks: Vec<Py<PyAny>> = self
-            .subscribers
-            .get(event_name)
-            .map(|subs| subs.iter().map(|(_, cb)| cb.clone_ref(py)).collect())
-            .unwrap_or_default();
+        let callbacks: Vec<Py<PyAny>> = self.matching_callbacks(py, event_name);
         for callback in &callbacks {
             let result = if let Some(kw) = kwargs {
                 callback.call(py, (), Some(kw))
@@ -60,7 +107,42 @@ impl EventBus {
         }
     }
 
+    /// Emit a structured RFC-0002 event envelope.
+    #[pyo3(name = "emit")]
+    #[pyo3(signature = (event_name, source=None, correlation=None, attributes=None))]
+    fn py_emit(
+        &self,
+        py: Python<'_>,
+        event_name: &str,
+        source: Option<&Bound<'_, PyAny>>,
+        correlation: Option<&Bound<'_, PyAny>>,
+        attributes: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<Py<PyAny>> {
+        let source = object_arg(source)?;
+        let correlation = object_arg(correlation)?;
+        let attributes = object_arg(attributes)?;
+        let event = self.emit(event_name, source, correlation, attributes);
+        dcc_mcp_pybridge::py_json::json_value_to_pyobject(py, &event.to_value())
+    }
+
     fn __repr__(&self) -> String {
         format!("EventBus(subscriptions={})", self.subscription_count())
+    }
+}
+
+fn object_arg(value: Option<&Bound<'_, PyAny>>) -> PyResult<Value> {
+    let Some(value) = value else {
+        return Ok(Value::Object(Map::new()));
+    };
+    if value.is_none() {
+        return Ok(Value::Object(Map::new()));
+    }
+    let value = dcc_mcp_pybridge::py_json::py_any_to_json_value(value)?;
+    if value.is_object() {
+        Ok(value)
+    } else {
+        Err(pyo3::exceptions::PyValueError::new_err(
+            "event source, correlation, and attributes must be dict-like objects",
+        ))
     }
 }

--- a/crates/dcc-mcp-actions/src/python/mod.rs
+++ b/crates/dcc-mcp-actions/src/python/mod.rs
@@ -29,7 +29,7 @@ use serde_json::{Map, Value, json};
 #[cfg(feature = "stub-gen")]
 use pyo3_stub_gen_derive::{gen_stub_pyclass, gen_stub_pymethods};
 
-use crate::dispatcher::{DispatchError, ToolDispatcher};
+use crate::dispatcher::{DispatchError, ToolDispatcher, dispatch_error_kind};
 use crate::events::EventBus;
 use crate::registry::{ToolMeta, ToolRegistry};
 use crate::validator::ToolValidator;
@@ -380,7 +380,7 @@ impl PyToolDispatcher {
                 | Err(err @ DispatchError::ThreadAffinityViolation { .. }) => {
                     self.emit_tool_failed(
                         action_name,
-                        "permission_denied",
+                        dispatch_error_kind(&err),
                         err.to_string(),
                         started,
                     );
@@ -412,13 +412,14 @@ impl PyToolDispatcher {
             pyo3::exceptions::PyRuntimeError::new_err(format!("handler error: {e}"))
         })?;
 
+        let result_success = py_result_success(&raw, py);
         self.emit_tool_event(
             "tool.completed",
             action_name,
             started,
             json!({
                 "validation_skipped": validation_skipped,
-                "result_success": true,
+                "result_success": result_success,
             }),
         );
 
@@ -497,6 +498,15 @@ fn value_to_py(py: Python<'_>, value: &Value) -> PyResult<Py<PyAny>> {
             Ok(dict.into())
         }
     }
+}
+
+fn py_result_success(raw: &Py<PyAny>, py: Python<'_>) -> bool {
+    raw.bind(py)
+        .cast::<PyDict>()
+        .ok()
+        .and_then(|dict| dict.get_item("success").ok().flatten())
+        .and_then(|value| value.extract::<bool>().ok())
+        .unwrap_or(true)
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/crates/dcc-mcp-actions/src/python/mod.rs
+++ b/crates/dcc-mcp-actions/src/python/mod.rs
@@ -19,16 +19,18 @@ mod events;
 pub(crate) mod versioned;
 
 use std::collections::HashMap;
+use std::time::Instant;
 
 use pyo3::Py;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
-use serde_json::Value;
+use serde_json::{Map, Value, json};
 
 #[cfg(feature = "stub-gen")]
 use pyo3_stub_gen_derive::{gen_stub_pyclass, gen_stub_pymethods};
 
 use crate::dispatcher::{DispatchError, ToolDispatcher};
+use crate::events::EventBus;
 use crate::registry::{ToolMeta, ToolRegistry};
 use crate::validator::ToolValidator;
 
@@ -157,6 +159,74 @@ pub struct PyToolDispatcher {
     pub skip_empty_schema_validation: bool,
 }
 
+impl PyToolDispatcher {
+    fn emit_tool_failed(
+        &self,
+        action_name: &str,
+        error_kind: &str,
+        error_message: String,
+        started: Instant,
+    ) {
+        self.emit_tool_event(
+            "tool.failed",
+            action_name,
+            started,
+            json!({
+                "result_success": false,
+                "error_kind": error_kind,
+                "error_message": error_message,
+            }),
+        );
+    }
+
+    fn emit_tool_event(
+        &self,
+        event_name: &str,
+        action_name: &str,
+        started: Instant,
+        attributes: Value,
+    ) {
+        let event_bus = self.inner.event_bus();
+        if !event_bus.has_subscribers(event_name) {
+            return;
+        }
+
+        let meta = self.inner.registry().get_action(action_name, None);
+        let mut source = Map::new();
+        let mut attrs = attributes.as_object().cloned().unwrap_or_default();
+        attrs.insert("tool_slug".to_string(), json!(action_name));
+        attrs.insert("tool_name".to_string(), json!(action_name));
+        attrs.insert(
+            "duration_ms".to_string(),
+            json!(u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX)),
+        );
+
+        if let Some(meta) = meta {
+            if !meta.dcc.is_empty() {
+                source.insert("dcc_type".to_string(), json!(meta.dcc));
+                attrs.insert("dcc_type".to_string(), json!(meta.dcc));
+            }
+            if let Some(skill_name) = &meta.skill_name {
+                attrs.insert("skill_name".to_string(), json!(skill_name));
+            }
+            if !meta.group.is_empty() {
+                attrs.insert("group".to_string(), json!(meta.group));
+            }
+            attrs.insert(
+                "annotations".to_string(),
+                serde_json::to_value(&meta.annotations).unwrap_or(Value::Null),
+            );
+        }
+
+        let _ = event_bus.emit(
+            event_name,
+            Value::Object(source),
+            Value::Object(Map::new()),
+            Value::Object(attrs),
+        );
+    }
+}
+
 #[cfg_attr(feature = "stub-gen", gen_stub_pymethods)]
 #[pymethods]
 impl PyToolDispatcher {
@@ -168,6 +238,18 @@ impl PyToolDispatcher {
             handler_map: HashMap::new(),
             skip_empty_schema_validation: true,
         }
+    }
+
+    /// Return the dispatcher event bus.
+    #[pyo3(name = "event_bus")]
+    pub fn py_event_bus(&self) -> EventBus {
+        self.inner.event_bus()
+    }
+
+    /// Replace the dispatcher event bus.
+    #[pyo3(name = "set_event_bus")]
+    pub fn py_set_event_bus(&mut self, event_bus: EventBus) {
+        self.inner = self.inner.clone().with_event_bus(event_bus);
     }
 
     /// Register a Python callable as the handler for ``action_name``.
@@ -251,20 +333,36 @@ impl PyToolDispatcher {
         action_name: &str,
         params_json: &str,
     ) -> PyResult<Bound<'py, PyDict>> {
+        let started = Instant::now();
         // 1. Parse params
         let params: Value = serde_json::from_str(params_json)
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("invalid JSON: {e}")))?;
 
         // 2. Validate via Rust dispatcher (the stub handler is registered there too)
         let validation_skipped = if !self.handler_map.contains_key(action_name) {
+            self.emit_tool_failed(
+                action_name,
+                "handler_not_found",
+                format!("no handler for '{action_name}'"),
+                started,
+            );
             return Err(pyo3::exceptions::PyKeyError::new_err(format!(
                 "no handler for '{action_name}'"
             )));
         } else {
             // Use the Rust dispatcher only for validation
-            match self.inner.dispatch(action_name, params.clone()) {
+            match self
+                .inner
+                .dispatch_for_validation(action_name, params.clone())
+            {
                 Ok(r) => r.validation_skipped,
                 Err(DispatchError::ValidationFailed(msg)) => {
+                    self.emit_tool_failed(
+                        action_name,
+                        "validation_failed",
+                        format!("validation failed: {msg}"),
+                        started,
+                    );
                     return Err(pyo3::exceptions::PyValueError::new_err(format!(
                         "validation failed: {msg}"
                     )));
@@ -280,6 +378,12 @@ impl PyToolDispatcher {
                 }
                 Err(err @ DispatchError::ActionDisabled { .. })
                 | Err(err @ DispatchError::ThreadAffinityViolation { .. }) => {
+                    self.emit_tool_failed(
+                        action_name,
+                        "permission_denied",
+                        err.to_string(),
+                        started,
+                    );
                     return Err(pyo3::exceptions::PyPermissionError::new_err(
                         err.to_string(),
                     ));
@@ -288,11 +392,35 @@ impl PyToolDispatcher {
         };
 
         // 3. Call the Python handler
+        self.emit_tool_event(
+            "tool.dispatched",
+            action_name,
+            started,
+            json!({
+                "validation_skipped": validation_skipped,
+            }),
+        );
         let handler = self.handler_map.get(action_name).expect("checked above");
         let py_params = value_to_py(py, &params)?;
         let raw = handler.call1(py, (py_params,)).map_err(|e| {
+            self.emit_tool_failed(
+                action_name,
+                "handler_error",
+                format!("handler error: {e}"),
+                started,
+            );
             pyo3::exceptions::PyRuntimeError::new_err(format!("handler error: {e}"))
         })?;
+
+        self.emit_tool_event(
+            "tool.completed",
+            action_name,
+            started,
+            json!({
+                "validation_skipped": validation_skipped,
+                "result_success": true,
+            }),
+        );
 
         // 4. Build result dict
         let d = PyDict::new(py);

--- a/crates/dcc-mcp-http/src/server/mod.rs
+++ b/crates/dcc-mcp-http/src/server/mod.rs
@@ -612,8 +612,13 @@ impl McpHttpServer {
         let actual_bind = actual_addr.to_string();
 
         tracing::info!(
-            "MCP HTTP server listening on http://{actual_bind}{}",
-            self.config.server.endpoint_path
+            server_name = %self.config.server.server_name,
+            server_version = %self.config.server.server_version,
+            "MCP HTTP server {} v{} listening on http://{}{}",
+            self.config.server.server_name,
+            self.config.server.server_version,
+            actual_bind,
+            self.config.server.endpoint_path,
         );
 
         // ── Optional gateway competition ──────────────────────────────────────

--- a/crates/dcc-mcp-models/src/python/action_result.rs
+++ b/crates/dcc-mcp-models/src/python/action_result.rs
@@ -25,7 +25,7 @@ const CTX_KEY_ERROR_TYPE: &str = "error_type";
 const CTX_KEY_TRACEBACK: &str = "traceback";
 const CTX_KEY_VALUE: &str = "value";
 const CTX_KEY_POSSIBLE_SOLUTIONS: &str = "possible_solutions";
-const ACTION_RESULT_KNOWN_KEYS: &[&str] = &["success", "message", "prompt", "error"];
+const ACTION_RESULT_KNOWN_KEYS: &[&str] = &["success", "message", "prompt", "error", "context"];
 
 #[cfg_attr(feature = "stub-gen", gen_stub_pymethods)]
 #[pymethods]
@@ -241,13 +241,29 @@ fn extract_optional_string_field(dict: &Bound<'_, PyDict>, key: &str) -> PyResul
         .map(|opt| opt.flatten())
 }
 
+fn extract_context_field(dict: &Bound<'_, PyDict>) -> PyResult<HashMap<String, serde_json::Value>> {
+    dict.get_item("context")?
+        .map(|v| {
+            if v.is_none() {
+                Ok(HashMap::new())
+            } else {
+                let context = v.cast::<PyDict>().map_err(|_| {
+                    pyo3::exceptions::PyTypeError::new_err("'context' field must be a dict")
+                })?;
+                py_dict_to_json_map(context)
+            }
+        })
+        .transpose()
+        .map(|opt| opt.unwrap_or_default())
+}
+
 fn validate_from_dict(dict: &Bound<'_, PyDict>) -> PyResult<ActionResultModel> {
     let success = extract_bool_field(dict, "success", true)?;
     let message = extract_string_field(dict, "message")?;
     let prompt = extract_optional_string_field(dict, "prompt")?;
     let error = extract_optional_string_field(dict, "error")?;
 
-    let mut ctx = HashMap::new();
+    let mut ctx = extract_context_field(dict)?;
     for (k, v) in dict.iter() {
         if let Ok(key) = k.extract::<String>()
             && !ACTION_RESULT_KNOWN_KEYS.contains(&key.as_str())

--- a/crates/dcc-mcp-skills/src/catalog/catalog.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog.rs
@@ -209,4 +209,10 @@ impl SkillCatalog {
     pub fn dispatcher(&self) -> Option<&Arc<ToolDispatcher>> {
         self.dispatcher.as_ref()
     }
+
+    /// Return the in-process lifecycle event bus.
+    #[must_use]
+    pub fn event_bus(&self) -> EventBus {
+        self.event_bus.clone()
+    }
 }

--- a/crates/dcc-mcp-skills/src/catalog/catalog_discovery.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog_discovery.rs
@@ -43,6 +43,7 @@ impl SkillCatalog {
             loaded: DashSet::new(),
             registry,
             dispatcher: None,
+            event_bus: EventBus::new(),
             script_executor: RwLock::new(None),
             active_groups: DashSet::new(),
         }
@@ -53,11 +54,13 @@ impl SkillCatalog {
         registry: Arc<ToolRegistry>,
         dispatcher: Arc<ToolDispatcher>,
     ) -> Self {
+        let event_bus = dispatcher.event_bus();
         Self {
             entries: DashMap::new(),
             loaded: DashSet::new(),
             registry,
             dispatcher: Some(dispatcher),
+            event_bus,
             script_executor: RwLock::new(None),
             active_groups: DashSet::new(),
         }
@@ -65,7 +68,14 @@ impl SkillCatalog {
 
     /// Attach a dispatcher after construction (builder-style).
     pub fn with_dispatcher(mut self, dispatcher: Arc<ToolDispatcher>) -> Self {
+        self.event_bus = dispatcher.event_bus();
         self.dispatcher = Some(dispatcher);
+        self
+    }
+
+    /// Attach a lifecycle event bus after construction (builder-style).
+    pub fn with_event_bus(mut self, event_bus: EventBus) -> Self {
+        self.event_bus = event_bus;
         self
     }
 

--- a/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
@@ -1,4 +1,5 @@
 use super::*;
+use serde_json::{Map, Value, json};
 
 fn activate_skill_groups(catalog: &SkillCatalog, metadata: &SkillMetadata) {
     for group in &metadata.groups {
@@ -14,6 +15,46 @@ fn activate_skill_groups(catalog: &SkillCatalog, metadata: &SkillMetadata) {
 }
 
 impl SkillCatalog {
+    fn emit_skill_event(
+        &self,
+        event_name: &str,
+        skill_name: &str,
+        metadata: Option<&SkillMetadata>,
+        attributes: Value,
+    ) {
+        if !self.event_bus.has_subscribers(event_name) {
+            return;
+        }
+
+        let mut source = Map::new();
+        let mut attrs = attributes.as_object().cloned().unwrap_or_default();
+        attrs.insert("skill_name".to_string(), json!(skill_name));
+
+        if let Some(metadata) = metadata {
+            if !metadata.dcc.is_empty() {
+                source.insert("dcc_type".to_string(), json!(metadata.dcc));
+                attrs.insert("dcc_type".to_string(), json!(metadata.dcc));
+            }
+            if !metadata.version.is_empty() {
+                attrs.insert("version".to_string(), json!(metadata.version));
+            }
+            if !metadata.skill_path.is_empty() {
+                attrs.insert("skill_path".to_string(), json!(metadata.skill_path));
+            }
+            attrs.insert(
+                "declared_tool_count".to_string(),
+                json!(metadata.tools.len()),
+            );
+        }
+
+        let _ = self.event_bus.emit(
+            event_name,
+            Value::Object(source),
+            Value::Object(Map::new()),
+            Value::Object(attrs),
+        );
+    }
+
     /// Load a skill by name — registers its tools into ToolRegistry and,
     /// if a dispatcher is attached, auto-registers script execution handlers.
     pub fn load_skill(&self, skill_name: &str) -> Result<Vec<String>, String> {
@@ -53,18 +94,39 @@ impl SkillCatalog {
         if let Some(pos) = visiting.iter().position(|name| name == skill_name) {
             let mut cycle = visiting[pos..].to_vec();
             cycle.push(skill_name.to_string());
-            return Err(format!(
+            let err = format!(
                 "Cannot load skill '{skill_name}' because its dependencies contain a cycle: {}",
                 cycle.join(" -> ")
-            ));
+            );
+            self.emit_skill_event(
+                "skill.validation_failed",
+                skill_name,
+                None,
+                json!({
+                    "error_kind": "dependency_cycle",
+                    "error_message": err,
+                    "cycle": cycle,
+                }),
+            );
+            return Err(err);
         }
 
-        let metadata = {
-            self.entries
-                .get(skill_name)
-                .map(|entry| entry.metadata.clone())
-                .ok_or_else(|| format!("Skill '{skill_name}' not found in catalog"))
-        }?;
+        let metadata = match self.entries.get(skill_name) {
+            Some(entry) => entry.metadata.clone(),
+            None => {
+                let err = format!("Skill '{skill_name}' not found in catalog");
+                self.emit_skill_event(
+                    "skill.validation_failed",
+                    skill_name,
+                    None,
+                    json!({
+                        "error_kind": "not_found",
+                        "error_message": err,
+                    }),
+                );
+                return Err(err);
+            }
+        };
 
         let known_names: std::collections::HashSet<String> = self
             .entries
@@ -83,20 +145,42 @@ impl SkillCatalog {
                     missing: missing.clone(),
                 };
             }
-            return Err(format!(
+            let err = format!(
                 "Skill '{skill_name}' is pending dependencies: missing {}. \
                  Discover or install the dependency skill(s), then retry load_skill('{skill_name}').",
                 missing.join(", ")
-            ));
+            );
+            self.emit_skill_event(
+                "skill.validation_failed",
+                skill_name,
+                Some(&metadata),
+                json!({
+                    "error_kind": "missing_dependencies",
+                    "error_message": err,
+                    "missing_dependencies": missing,
+                }),
+            );
+            return Err(err);
         }
 
         visiting.push(skill_name.to_string());
         for dep in &metadata.depends {
-            if !self.loaded.contains(dep.as_str()) {
-                self.load_skill_recursive(dep, activate_groups, visiting)
-                    .map_err(|err| {
-                        format!("Failed to load dependency '{dep}' for skill '{skill_name}': {err}")
-                    })?;
+            if !self.loaded.contains(dep.as_str())
+                && let Err(err) = self.load_skill_recursive(dep, activate_groups, visiting)
+            {
+                let err =
+                    format!("Failed to load dependency '{dep}' for skill '{skill_name}': {err}");
+                self.emit_skill_event(
+                    "skill.validation_failed",
+                    skill_name,
+                    Some(&metadata),
+                    json!({
+                        "error_kind": "dependency_load_failed",
+                        "error_message": err,
+                        "dependency": dep,
+                    }),
+                );
+                return Err(err);
             }
         }
         visiting.pop();
@@ -121,6 +205,14 @@ impl SkillCatalog {
         let mut registered = Vec::new();
         let skill_base = metadata.name.replace('-', "_");
         let skill_path = std::path::Path::new(&metadata.skill_path);
+        self.emit_skill_event(
+            "skill.loading",
+            skill_name,
+            Some(metadata),
+            json!({
+                "activate_groups": activate_groups,
+            }),
+        );
 
         if activate_groups {
             activate_skill_groups(self, metadata);
@@ -142,11 +234,22 @@ impl SkillCatalog {
             let script_path = resolve_tool_script(tool_decl, &metadata.scripts, skill_path);
             let maybe_executor = self.script_executor.read().clone();
             if tool_decl.thread_affinity.is_main() && maybe_executor.is_none() {
-                return Err(format!(
+                let err = format!(
                     "Tool '{}' requires thread_affinity='main', but no in-process executor is set. \
                      Ensure the DCC adapter calls set_in_process_executor() before loading skills.",
                     action_name
-                ));
+                );
+                self.emit_skill_event(
+                    "skill.validation_failed",
+                    skill_name,
+                    Some(metadata),
+                    json!({
+                        "error_kind": "missing_in_process_executor",
+                        "error_message": err,
+                        "tool_name": action_name,
+                    }),
+                );
+                return Err(err);
             }
 
             // Generate input_schema: prefer tools.yaml if present, otherwise derive from Python signature
@@ -305,6 +408,17 @@ impl SkillCatalog {
             (Some(_), None) => "subprocess",
             (None, _) => "none",
         };
+        let registered_tool_count = registered.len();
+        self.emit_skill_event(
+            "skill.loaded",
+            skill_name,
+            Some(metadata),
+            json!({
+                "registered_tools": registered.clone(),
+                "registered_tool_count": registered_tool_count,
+                "handler_mode": handler_mode,
+            }),
+        );
         tracing::info!(
             "SkillCatalog: loaded skill '{}' ({} tools registered, handlers: {})",
             skill_name,
@@ -332,6 +446,10 @@ impl SkillCatalog {
         if !self.loaded.contains(skill_name) {
             return Err(format!("Skill '{skill_name}' is not loaded"));
         }
+        let metadata = self
+            .entries
+            .get(skill_name)
+            .map(|entry| entry.metadata.clone());
 
         let action_names: Vec<String> = self
             .entries
@@ -353,6 +471,15 @@ impl SkillCatalog {
         }
         self.loaded.remove(skill_name);
 
+        self.emit_skill_event(
+            "skill.unloaded",
+            skill_name,
+            metadata.as_ref(),
+            json!({
+                "registered_tools": action_names,
+                "removed_tool_count": count,
+            }),
+        );
         tracing::info!(
             "SkillCatalog: unloaded skill '{}' ({} tools removed)",
             skill_name,

--- a/crates/dcc-mcp-skills/src/catalog/mod.rs
+++ b/crates/dcc-mcp-skills/src/catalog/mod.rs
@@ -48,7 +48,7 @@ use pyo3_stub_gen_derive::gen_stub_pyclass;
 
 use dashmap::{DashMap, DashSet};
 use dcc_mcp_actions::{
-    ToolDispatcher,
+    EventBus, ToolDispatcher,
     registry::{ToolMeta, ToolRegistry},
 };
 use dcc_mcp_models::registry::{Registry, SearchQuery};
@@ -99,6 +99,8 @@ pub struct SkillCatalog {
     pub(super) registry: Arc<ToolRegistry>,
     /// Optional dispatcher for auto-registering script handlers on load.
     pub(super) dispatcher: Option<Arc<ToolDispatcher>>,
+    /// In-process lifecycle event bus for skill load/unload events.
+    pub(super) event_bus: EventBus,
     /// Optional in-process script executor.
     ///
     /// When set, skill scripts are run inside the current Python interpreter

--- a/crates/dcc-mcp-skills/src/catalog/tests/test_catalog_crud.rs
+++ b/crates/dcc-mcp-skills/src/catalog/tests/test_catalog_crud.rs
@@ -111,6 +111,38 @@ fn test_load_skill_registers_tools() {
     assert!(registry.get_action("modeling_bevel__bevel", None).is_some());
 }
 
+#[cfg(not(feature = "python-bindings"))]
+#[test]
+fn test_load_and_unload_emit_skill_lifecycle_events() {
+    let catalog = make_test_catalog();
+    catalog.add_skill(make_test_skill("modeling-bevel", "maya", &["bevel"]));
+
+    let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let captured = std::sync::Arc::clone(&events);
+    let _id = catalog
+        .event_bus()
+        .subscribe_event("skill.*".to_string(), move |event| {
+            captured
+                .lock()
+                .unwrap()
+                .push((event.name.clone(), event.attributes.clone()));
+        });
+
+    catalog.load_skill("modeling-bevel").unwrap();
+    catalog.unload_skill("modeling-bevel").unwrap();
+
+    let events = events.lock().unwrap();
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[0].0, "skill.loading");
+    assert_eq!(events[0].1["skill_name"], "modeling-bevel");
+    assert_eq!(events[0].1["dcc_type"], "maya");
+    assert_eq!(events[1].0, "skill.loaded");
+    assert_eq!(events[1].1["registered_tool_count"], 1);
+    assert_eq!(events[1].1["registered_tools"][0], "modeling_bevel__bevel");
+    assert_eq!(events[2].0, "skill.unloaded");
+    assert_eq!(events[2].1["removed_tool_count"], 1);
+}
+
 #[test]
 fn test_load_skill_auto_loads_discovered_dependencies_first() {
     let catalog = make_test_catalog();

--- a/crates/dcc-mcp-skills/src/python/catalog.rs
+++ b/crates/dcc-mcp-skills/src/python/catalog.rs
@@ -7,6 +7,7 @@ use pyo3::prelude::*;
 use pyo3_stub_gen_derive::gen_stub_pymethods;
 
 use crate::catalog::{SkillCatalog, SkillSummary, helpers};
+use dcc_mcp_actions::EventBus;
 use dcc_mcp_actions::registry::ToolRegistry;
 
 #[cfg_attr(feature = "stub-gen", gen_stub_pymethods)]
@@ -15,6 +16,12 @@ impl SkillCatalog {
     #[new]
     fn py_new(registry: ToolRegistry) -> Self {
         Self::new(Arc::new(registry))
+    }
+
+    /// Return the catalog lifecycle event bus.
+    #[pyo3(name = "event_bus")]
+    fn py_event_bus(&self) -> EventBus {
+        self.event_bus()
     }
 
     /// Activate a tool group (enable every action in it).

--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -80,6 +80,10 @@ Envelope fields:
 | `correlation` | `dict` | Request/session/trace correlation fields when available |
 | `attributes` | `dict` | Event-specific payload |
 
+For `tool.completed`, `attributes.result_success` follows the handler output's
+`success` boolean when present. If the output has no `success` field, a handler
+that returned normally is treated as successful.
+
 ---
 
 ## ToolRecorder

--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -19,7 +19,8 @@ bus = EventBus()
 |--------|---------|-------------|
 | `subscribe(event_name, callback)` | `int` | Subscribe a callable. Returns subscriber ID |
 | `unsubscribe(event_name, subscriber_id)` | `bool` | Unsubscribe by ID. Returns True if found |
-| `publish(event_name, **kwargs)` | — | Call all subscribers with kwargs |
+| `publish(event_name, **kwargs)` | `None` | Call all matching subscribers with kwargs |
+| `emit(event_name, source=None, correlation=None, attributes=None)` | `dict` | Emit a structured event envelope and pass it to all matching subscribers |
 
 ### Dunder Methods
 
@@ -30,6 +31,8 @@ bus = EventBus()
 ### Behavior
 
 - Subscribers receive keyword arguments from `publish(event_name, **kwargs)`
+- Subscribers receive one event-envelope dict from `emit(...)`
+- Event names support exact matches, `prefix.*` wildcards, and a catch-all `*`
 - Exceptions in subscribers are logged via `tracing` but do not propagate
 - Callbacks are collected before invocation to avoid DashMap deadlocks
 - Multiple subscribers per event are supported
@@ -47,6 +50,35 @@ sid = bus.subscribe("action.executed", on_action)
 bus.publish("action.executed", action_name="create_sphere")
 bus.unsubscribe("action.executed", sid)
 ```
+
+### Structured Event Envelope
+
+```python
+events = []
+bus.subscribe("tool.*", lambda event: events.append(event))
+
+event = bus.emit(
+    "tool.completed",
+    source={"dcc_type": "maya"},
+    correlation={"request_id": "req-123"},
+    attributes={"tool_slug": "maya_scene__open", "result_success": True},
+)
+
+assert event["schema_version"] == 1
+assert events == [event]
+```
+
+Envelope fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `schema_version` | `int` | Event envelope schema version, currently `1` |
+| `name` | `str` | Dotted event name |
+| `id` | `str` | Opaque event id prefixed with `ev_` |
+| `timestamp_ns` | `int` | Unix timestamp in nanoseconds |
+| `source` | `dict` | Emitter identity such as `dcc_type` |
+| `correlation` | `dict` | Request/session/trace correlation fields when available |
+| `attributes` | `dict` | Event-specific payload |
 
 ---
 

--- a/docs/guide/events.md
+++ b/docs/guide/events.md
@@ -75,7 +75,9 @@ present:
 
 Tool lifecycle attributes include `tool_slug`, `tool_name`, `duration_ms`,
 `result_success` on terminal events, and metadata such as `dcc_type`,
-`skill_name`, `group`, and `annotations` when known.
+`skill_name`, `group`, and `annotations` when known. `tool.completed` derives
+`result_success` from an output object's `success` boolean when present;
+otherwise handler success defaults to `true`.
 
 Skill lifecycle attributes include `skill_name`, `dcc_type`, `version`,
 `skill_path`, declared/registered tool counts, registered tool names, and

--- a/docs/guide/events.md
+++ b/docs/guide/events.md
@@ -1,75 +1,113 @@
 # Event System
 
-DCC-MCP-Core provides a publish/subscribe event system via the `EventBus` for decoupled action lifecycle communication.
+DCC-MCP-Core provides a thread-safe `EventBus` for downstream extensions that
+need to observe gateway, skill, or tool lifecycle without forking the server.
+The bus supports exact subscriptions, `prefix.*` wildcard subscriptions, and a
+catch-all `*` subscription.
 
-## Usage
+## Legacy Keyword Events
+
+`publish()` preserves the original lightweight API: subscribers are called with
+the keyword arguments supplied by the publisher.
 
 ```python
 from dcc_mcp_core import EventBus
 
 bus = EventBus()
 
-def on_sphere_done(event, **kwargs):
-    print(f"Event: {event}")
-    # kwargs contains event-specific data
+def on_scene_saved(**payload):
+    print(payload["file_path"])
 
-# Subscribe to an event — returns an integer subscriber ID
-sub_id = bus.subscribe("action.after_execute.create_sphere", on_sphere_done)
-
-# Unsubscribe using the event name and subscriber ID
-bus.unsubscribe("action.after_execute.create_sphere", sub_id)
-
-# Publish manually
-bus.publish("my_custom_event", data="value")
+sub_id = bus.subscribe("scene.saved", on_scene_saved)
+bus.publish("scene.saved", file_path="/tmp/scene.usda", size_kb=1024)
+bus.unsubscribe("scene.saved", sub_id)
 ```
 
-::: tip
-`subscribe()` returns a **subscriber ID** (integer), not the callback. Pass that ID to `unsubscribe()`, not the callback.
-:::
+## Structured Lifecycle Events
 
-## Event Discovery
+`emit()` publishes an RFC-0002 event envelope and passes the same dict to every
+matching subscriber.
 
-The `EventBus` is a generic pub/sub system. What events are published depends on the DCC adapter or service that uses it. Consult your DCC-specific adapter documentation for the full list of events it publishes.
+```python
+bus = EventBus()
 
-Common patterns:
+def record_metric(event: dict) -> None:
+    attrs = event["attributes"]
+    print(event["name"], attrs["tool_slug"], attrs.get("duration_ms"))
 
-| Event Pattern | Description |
-|---------------|-------------|
-| `action.before_execute.{name}` | Before executing a specific tool |
-| `action.after_execute.{name}` | After a specific tool completes |
-| `action.error.{name}` | When a specific tool raises an error |
+bus.subscribe("tool.*", record_metric)
+bus.emit(
+    "tool.completed",
+    source={"dcc_type": "maya"},
+    correlation={"request_id": "req-123"},
+    attributes={"tool_slug": "maya_scene__open", "result_success": True},
+)
+```
+
+Every structured event uses this envelope shape:
+
+```json
+{
+  "schema_version": 1,
+  "name": "tool.completed",
+  "id": "ev_...",
+  "timestamp_ns": 1779478215123456789,
+  "source": {},
+  "correlation": {},
+  "attributes": {}
+}
+```
+
+## Built-In Emit Points
+
+The core dispatcher and skill catalog emit these events when subscribers are
+present:
+
+| Event | Emitted when |
+|-------|--------------|
+| `tool.dispatched` | A tool call passed lookup, policy, and schema validation and is about to run |
+| `tool.completed` | A tool handler returned successfully |
+| `tool.failed` | Tool lookup, policy, validation, or handler execution failed |
+| `skill.loading` | A skill load is beginning |
+| `skill.loaded` | A skill loaded and registered its tools |
+| `skill.unloaded` | A loaded skill was unloaded and its tools were removed |
+| `skill.validation_failed` | A skill could not load because it was missing, had dependency issues, or failed setup validation |
+
+Tool lifecycle attributes include `tool_slug`, `tool_name`, `duration_ms`,
+`result_success` on terminal events, and metadata such as `dcc_type`,
+`skill_name`, `group`, and `annotations` when known.
+
+Skill lifecycle attributes include `skill_name`, `dcc_type`, `version`,
+`skill_path`, declared/registered tool counts, registered tool names, and
+failure details such as `error_kind` and `error_message`.
 
 ## Wildcard Subscriptions
 
-The event bus supports `*` as a wildcard in event names:
+Use dotted event names and subscribe to either an exact name, a prefix wildcard,
+or all events:
 
 ```python
-bus = EventBus()
-
-def on_any_after_execute(event, **kwargs):
-    print(f"Action completed: {event}")
-
-# Subscribe to all "after_execute" events
-id1 = bus.subscribe("action.after_execute.*", on_any_after_execute)
-
-# Subscribe to all events
-id2 = bus.subscribe("*", on_any_event)
+bus.subscribe("tool.completed", on_completed)
+bus.subscribe("skill.*", on_any_skill_event)
+bus.subscribe("*", on_any_event)
 ```
 
-## Publishing Events
+## Dispatcher And Catalog Buses
 
-Publish custom events for decoupled communication:
+`ToolDispatcher.event_bus()` returns the dispatcher's bus. A `SkillCatalog`
+created with `SkillCatalog.new_with_dispatcher(...)` shares the dispatcher's bus
+so subscribers can observe both `skill.*` and `tool.*` events from one place.
 
 ```python
-bus = EventBus()
+from dcc_mcp_core import ToolDispatcher, ToolRegistry
 
-# Publish with keyword arguments
-bus.publish("scene.saved", file_path="/tmp/scene.usda", size_kb=1024)
-bus.publish("scene.opened", file_path="/tmp/scene.usda")
+registry = ToolRegistry()
+dispatcher = ToolDispatcher(registry)
+dispatcher.event_bus().subscribe("tool.*", record_metric)
 ```
 
-## Dunder Methods
+## Failure Isolation
 
-| Method | Description |
-|--------|-------------|
-| `__repr__` | `EventBus(subscribers=N)` |
+Subscriber exceptions are logged and do not stop later subscribers. Callbacks
+are collected before invocation so a callback can safely subscribe or
+unsubscribe without deadlocking the bus.

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -692,7 +692,13 @@ class DccServerBase:
         self._init_telemetry()
 
         self._handle = self._server.start()
-        logger.info("[%s] MCP server started at %s", self._dcc_name, self._handle.mcp_url())
+        server_version = getattr(self._config, "server_version", _PKG_VERSION)
+        logger.info(
+            "[%s] MCP server v%s started at %s",
+            self._dcc_name,
+            server_version,
+            self._handle.mcp_url(),
+        )
         self._runtime_controller().start_gateway_election_if_needed()
 
         return self._handle

--- a/skills/dcc-mcp-skill-developer/SKILL.md
+++ b/skills/dcc-mcp-skill-developer/SKILL.md
@@ -69,6 +69,10 @@ into a faster authoring loop.
    the shipped server paths enable the required gateway `admin` feature and
    Admin telemetry runtime state, while minimal direct `dcc-mcp-gateway` builds
    or runtimes started with Admin disabled may omit those debug routes.
+   Subscribe to the shared `EventBus` when an adapter or studio integration
+   needs programmatic lifecycle hooks: use `skill.*` events for load/unload
+   visibility and `tool.*` events for dispatch/completion/failure metrics
+   instead of scraping logs or wrapping every handler manually.
 8. For adapter install, uninstall, or upgrade flows, use
    `dcc_mcp_core.install_lifecycle` before importing Rust-backed public API:
    query/stop registered sidecars, inspect install roots, classify locked

--- a/tests/test_action_result_deep.py
+++ b/tests/test_action_result_deep.py
@@ -336,6 +336,13 @@ class TestValidateActionResult:
         assert isinstance(validated, ToolResult)
         assert validated.success is True
 
+    def test_wraps_dict_context_as_context(self):
+        d = {"success": True, "message": "ok", "context": {"label": "example"}}
+        validated = validate_action_result(d)
+        assert isinstance(validated, ToolResult)
+        assert validated.context["label"] == "example"
+        assert "context" not in validated.context
+
     def test_wraps_dict_with_success_false(self):
         d = {"success": False, "message": "fail", "error": "oops"}
         validated = validate_action_result(d)

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -498,6 +498,23 @@ class TestEventBus:
         bus.publish("evt", x=1, y="hello")
         assert results[0] == {"x": 1, "y": "hello"}
 
+    def test_emit_structured_event_to_wildcard_subscriber(self) -> None:
+        bus = dcc_mcp_core.EventBus()
+        results = []
+        bus.subscribe("skill.*", lambda event: results.append(event))
+
+        event = bus.emit(
+            "skill.loaded",
+            source={"dcc_type": "maya"},
+            correlation={"request_id": "req-1"},
+            attributes={"skill_name": "maya-core"},
+        )
+
+        assert event["schema_version"] == 1
+        assert event["name"] == "skill.loaded"
+        assert event["attributes"]["skill_name"] == "maya-core"
+        assert results == [event]
+
     def test_publish_no_subscribers(self) -> None:
         bus = dcc_mcp_core.EventBus()
         bus.publish("nonexistent")  # should not error

--- a/tests/test_actions_validator_dispatcher.py
+++ b/tests/test_actions_validator_dispatcher.py
@@ -313,6 +313,51 @@ class TestToolDispatcher:
         assert events[0]["attributes"]["dcc_type"] == "maya"
         assert events[1]["attributes"]["result_success"] is True
 
+    def test_dispatch_success_false_payload_marks_completed_event_failed(self, dispatcher_cls, registry_cls):
+        reg = registry_cls()
+        reg.register("soft_fail", dcc="maya")
+        d = dispatcher_cls(reg)
+        d.register_handler("soft_fail", lambda _: {"success": False, "message": "domain failure"})
+
+        events = []
+        d.event_bus().subscribe("tool.*", lambda event: events.append(event))
+
+        result = d.dispatch("soft_fail", "{}")
+
+        assert result["output"]["success"] is False
+        assert [event["name"] for event in events] == ["tool.dispatched", "tool.completed"]
+        assert events[1]["attributes"]["result_success"] is False
+
+    def test_dispatch_disabled_action_event_kind_matches_rust(self, dispatcher_cls, registry_cls):
+        reg = registry_cls()
+        reg.register("rig_a", dcc="maya", group="rigging", enabled=False)
+        d = dispatcher_cls(reg)
+        d.register_handler("rig_a", lambda _: {"ok": True})
+
+        events = []
+        d.event_bus().subscribe("tool.failed", lambda event: events.append(event))
+
+        with pytest.raises(PermissionError):
+            d.dispatch("rig_a", "{}")
+
+        assert len(events) == 1
+        assert events[0]["attributes"]["error_kind"] == "action_disabled"
+
+    def test_dispatch_thread_affinity_event_kind_matches_rust(self, dispatcher_cls, registry_cls):
+        reg = registry_cls()
+        reg.register("main_only", dcc="maya", thread_affinity="main", enforce_thread_affinity=True)
+        d = dispatcher_cls(reg)
+        d.register_handler("main_only", lambda _: {"ok": True})
+
+        events = []
+        d.event_bus().subscribe("tool.failed", lambda event: events.append(event))
+
+        with pytest.raises(PermissionError):
+            d.dispatch("main_only", "{}")
+
+        assert len(events) == 1
+        assert events[0]["attributes"]["error_kind"] == "thread_affinity_violation"
+
     def test_dispatch_no_handler_raises_key_error(self, empty_dispatcher):
         d, _ = empty_dispatcher
         with pytest.raises((KeyError, RuntimeError)):

--- a/tests/test_actions_validator_dispatcher.py
+++ b/tests/test_actions_validator_dispatcher.py
@@ -296,6 +296,23 @@ class TestToolDispatcher:
         assert result["output"]["created"] is True
         assert result["output"]["radius"] == 5.0
 
+    def test_dispatch_emits_tool_lifecycle_events(self, dispatcher_cls, registry_cls):
+        reg = registry_cls()
+        reg.register("sphere", dcc="maya")
+        d = dispatcher_cls(reg)
+        d.register_handler("sphere", lambda p: {"created": True, "radius": p.get("radius", 1.0)})
+
+        events = []
+        d.event_bus().subscribe("tool.*", lambda event: events.append(event))
+
+        result = d.dispatch("sphere", '{"radius": 2.0}')
+
+        assert result["output"]["created"] is True
+        assert [event["name"] for event in events] == ["tool.dispatched", "tool.completed"]
+        assert events[0]["attributes"]["tool_slug"] == "sphere"
+        assert events[0]["attributes"]["dcc_type"] == "maya"
+        assert events[1]["attributes"]["result_success"] is True
+
     def test_dispatch_no_handler_raises_key_error(self, empty_dispatcher):
         d, _ = empty_dispatcher
         with pytest.raises((KeyError, RuntimeError)):

--- a/tests/test_dcc_adapter_base.py
+++ b/tests/test_dcc_adapter_base.py
@@ -10,6 +10,7 @@ Covers:
 # Import future modules
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 # Import built-in modules
@@ -370,6 +371,15 @@ class TestDccServerBase:
         server.stop()
         assert not server.is_running
         assert server.mcp_url is None
+
+    def test_start_logs_server_version(self, tmp_path, caplog):
+        server = self._make_server(tmp_path)
+
+        with caplog.at_level(logging.INFO, logger="dcc_mcp_core.server_base"):
+            server.start()
+
+        assert "[fake-dcc] MCP server v0.1.0 started at http://127.0.0.1:18765/mcp" in caplog.text
+        server.stop()
 
     def test_start_returns_same_handle_if_already_running(self, tmp_path):
         server = self._make_server(tmp_path)

--- a/tests/test_dcc_skills_creator.py
+++ b/tests/test_dcc_skills_creator.py
@@ -88,7 +88,9 @@ def test_create_skill_example_tool_runs_successfully(tmp_path: Path) -> None:
     payload = json.loads(result.stdout)
     assert payload["success"] is True
     assert payload["message"] == "Example tool completed"
-    assert payload["context"]["context"]["label"] == "example"
+    assert payload["context"]["label"] == "example"
+    assert payload["context"]["dry_run"] is True
+    assert payload["context"]["extra_params"] == {}
 
 
 def test_create_skill_example_tool_runs_with_inprocess_executor(tmp_path: Path) -> None:
@@ -102,6 +104,9 @@ def test_create_skill_example_tool_runs_with_inprocess_executor(tmp_path: Path) 
 
     assert payload["success"] is True
     assert payload["message"] == "Example tool completed"
+    assert payload["context"]["label"] == "example"
+    assert payload["context"]["dry_run"] is True
+    assert payload["context"]["extra_params"] == {"unused_param": "accepted"}
 
 
 def test_create_skill_rejects_non_kebab_case_name(tmp_path: Path) -> None:

--- a/tests/test_mcp_protocols_telemetry_capturer_catalog_deep.py
+++ b/tests/test_mcp_protocols_telemetry_capturer_catalog_deep.py
@@ -856,6 +856,15 @@ class TestCapturer:
 EXAMPLES_SKILLS_DIR = str((Path(__file__).parent / ".." / "examples" / "skills").resolve())
 
 
+def _first_standalone_skill(cat):
+    """Return a discovered skill that does not auto-load dependencies."""
+    for skill in cat.list_skills():
+        info = cat.get_skill_info(skill.name) or {}
+        if not info.get("depends"):
+            return skill
+    raise AssertionError("expected at least one standalone example skill")
+
+
 class TestSkillSummary:
     @pytest.fixture
     def catalog_with_skills(self):
@@ -979,7 +988,7 @@ class TestSkillCatalog:
         reg = m.ToolRegistry()
         cat = m.SkillCatalog(reg)
         cat.discover(extra_paths=[EXAMPLES_SKILLS_DIR])
-        s = cat.list_skills()[0]
+        s = _first_standalone_skill(cat)
         cat.load_skill(s.name)
         assert cat.loaded_count() == 1
 
@@ -1005,7 +1014,7 @@ class TestSkillCatalog:
         reg = m.ToolRegistry()
         cat = m.SkillCatalog(reg)
         cat.discover(extra_paths=[EXAMPLES_SKILLS_DIR])
-        s = cat.list_skills()[0]
+        s = _first_standalone_skill(cat)
         cat.load_skill(s.name)
         cat.unload_skill(s.name)
         assert cat.loaded_count() == 0

--- a/tests/test_sandbox_audit_recorder_usd_capturer.py
+++ b/tests/test_sandbox_audit_recorder_usd_capturer.py
@@ -750,6 +750,8 @@ class TestValidateActionResult:
     def test_dict_with_context(self) -> None:
         r = dcc_mcp_core.validate_action_result({"success": True, "message": "m", "context": {"k": "v"}})
         assert r.success is True
+        assert r.context["k"] == "v"
+        assert "context" not in r.context
 
     def test_action_result_model_passthrough(self) -> None:
         original = dcc_mcp_core.success_result("hello")

--- a/tests/test_serialize_result_roundtrip.py
+++ b/tests/test_serialize_result_roundtrip.py
@@ -372,14 +372,21 @@ class TestValidateAndSerializePipeline:
     """Test the full pipeline used by skill.py: dict → validate → serialize → deserialize."""
 
     def test_success_dict_pipeline(self):
-        # validate_action_result extracts success/message/prompt/error from the dict;
-        # all other top-level keys become context entries.
-        # An empty "context" key becomes context["context"] = {} — that's expected behavior.
-        raw = {"success": True, "message": "done", "prompt": None, "error": None}
+        # validate_action_result preserves an explicit context object while
+        # still extracting success/message/prompt/error from the dict.
+        raw = {
+            "success": True,
+            "message": "done",
+            "prompt": None,
+            "error": None,
+            "context": {"label": "example"},
+        }
         arm = validate_action_result(raw)
         restored = deserialize_result(serialize_result(arm))
         assert restored.success is True
         assert restored.message == "done"
+        assert restored.context["label"] == "example"
+        assert "context" not in restored.context
 
     def test_error_dict_pipeline(self):
         # validate_action_result treats top-level non-standard keys as context.


### PR DESCRIPTION
## Summary
- add structured EventBus envelopes with exact, prefix wildcard, and catch-all subscriptions
- emit tool and skill lifecycle events from dispatch and catalog load/unload paths
- document event usage and update skill-developer guidance

## Validation
- vx cargo test -p dcc-mcp-actions --lib
- vx cargo test -p dcc-mcp-skills --lib
- vx cargo test -p dcc-mcp-actions --features python-bindings event --lib
- vx cargo test -p dcc-mcp-skills --features python-bindings test_load_skill_registers_tools --lib
- vx just dev with DCC_MCP_ADMIN_UI_PREBUILT=1
- .\.venv\Scripts\python.exe -m pytest tests/test_actions.py::TestEventBus -q
- .\.venv\Scripts\python.exe -m pytest tests/test_actions_validator_dispatcher.py::TestToolDispatcher -q

Refs #1115