### PR TITLE
feat: harden app ui policy audit controls

### DIFF
--- a/crates/dcc-mcp-app-ui/src/lib.rs
+++ b/crates/dcc-mcp-app-ui/src/lib.rs
@@ -155,6 +155,10 @@ const fn default_wait_interval_ms() -> u64 {
     100
 }
 
+const fn default_true() -> bool {
+    true
+}
+
 /// Polling condition for a bounded UI backend.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct UiWaitCondition {
@@ -226,6 +230,9 @@ pub struct AppUiPolicy {
     pub allow_keyboard_shortcuts: bool,
     /// Allow raw-coordinate actions.
     pub allow_raw_coordinates: bool,
+    /// Require the backend to target a scoped application window/process.
+    #[serde(default = "default_true")]
+    pub require_scoped_window: bool,
     /// Optional allow-list for window titles.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub allowed_window_titles: Vec<String>,
@@ -245,6 +252,7 @@ impl Default for AppUiPolicy {
             allow_text_entry: true,
             allow_keyboard_shortcuts: false,
             allow_raw_coordinates: false,
+            require_scoped_window: true,
             allowed_window_titles: Vec::new(),
             allowed_process_ids: Vec::new(),
             audit_sensitive_values: false,
@@ -484,6 +492,23 @@ mod tests {
         assert!(policy.allows_action(UiActionKind::SetText));
         assert!(!policy.allows_action(UiActionKind::RawCoordinateClick));
         assert!(!policy.allows_action(UiActionKind::KeyboardShortcut));
+        assert!(policy.require_scoped_window);
+    }
+
+    #[test]
+    fn app_ui_policy_deserializes_old_payloads_as_scoped() {
+        let policy: AppUiPolicy = serde_json::from_value(serde_json::json!({
+            "allow_snapshot": true,
+            "allow_find": true,
+            "allow_mutating_actions": true,
+            "allow_text_entry": true,
+            "allow_keyboard_shortcuts": false,
+            "allow_raw_coordinates": false,
+            "audit_sensitive_values": false
+        }))
+        .unwrap();
+
+        assert!(policy.require_scoped_window);
     }
 
     #[test]

--- a/docs/guide/adapter-runtime-contracts.md
+++ b/docs/guide/adapter-runtime-contracts.md
@@ -106,7 +106,9 @@ Safety expectations:
 - Mutating actions should declare conservative safety annotations, main-thread
   affinity when required by the host, and a timeout that reflects UI polling.
 - Policy should disable whole-desktop access by default. Scope to an
-  adapter-owned process, window, or explicit allow-list.
+  adapter-owned process, window, or explicit allow-list. Keep
+  `AppUiPolicy.require_scoped_window` enabled unless the user explicitly opts
+  into a backend-specific whole-desktop fallback.
 - Raw coordinate clicks and keyboard shortcuts are high risk. Keep them disabled
   unless an adapter explicitly opts in and documents the fallback.
 - Audit records should include action kind, target control id/role/label when

--- a/python/dcc_mcp_core/adapter_contracts.py
+++ b/python/dcc_mcp_core/adapter_contracts.py
@@ -221,6 +221,7 @@ class AppUiPolicy:
     allow_text_entry: bool = True
     allow_keyboard_shortcuts: bool = False
     allow_raw_coordinates: bool = False
+    require_scoped_window: bool = True
     allowed_window_titles: List[str] = field(default_factory=list)
     allowed_process_ids: List[int] = field(default_factory=list)
     audit_sensitive_values: bool = False

--- a/python/dcc_mcp_core/skills/app-ui/scripts/_backend.py
+++ b/python/dcc_mcp_core/skills/app-ui/scripts/_backend.py
@@ -36,6 +36,7 @@ _POLICY_KEYS = {
     "allow_text_entry",
     "allow_keyboard_shortcuts",
     "allow_raw_coordinates",
+    "require_scoped_window",
     "allowed_window_titles",
     "allowed_process_ids",
     "audit_sensitive_values",
@@ -132,7 +133,18 @@ def _policy_from_params(params: Dict[str, Any]) -> AppUiPolicy:
     return AppUiPolicy(**{k: raw[k] for k in _POLICY_KEYS if k in raw})
 
 
+def _has_scoped_window(state: Dict[str, Any]) -> bool:
+    title = str(state.get("window_title") or state.get("title") or "").strip()
+    try:
+        process_id = int(state.get("process_id") or state.get("pid") or 0)
+    except Exception:
+        process_id = 0
+    return bool(title) or process_id > 0
+
+
 def _window_allowed(state: Dict[str, Any], policy: AppUiPolicy) -> bool:
+    if policy.require_scoped_window and not _has_scoped_window(state):
+        return False
     if policy.allowed_window_titles:
         title = str(state.get("window_title") or "").lower()
         allowed = [str(item).lower() for item in policy.allowed_window_titles]
@@ -317,23 +329,29 @@ def _audit_record(
     policy: AppUiPolicy,
     error_code: Optional[str] = None,
     message: Optional[str] = None,
+    before_focus_id: Optional[str] = None,
+    after_focus_id: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     redacted = []
     if action == UiActionKind.SET_TEXT and not policy.audit_sensitive_values:
         redacted.append("text")
+    audit_metadata = {"backend": "mock", "snapshot_id": _snapshot_id(state)}
+    if metadata:
+        audit_metadata.update(metadata)
     return AppUiAuditRecord(
         action_kind=action,
         success=success,
         target_control_id=control.get("id") if control else None,
         target_role=control.get("role") if control else None,
         target_label=control.get("label") if control else None,
-        before_focus_id=state.get("focus_id"),
-        after_focus_id=state.get("focus_id"),
+        before_focus_id=before_focus_id if before_focus_id is not None else state.get("focus_id"),
+        after_focus_id=after_focus_id if after_focus_id is not None else state.get("focus_id"),
         error_code=error_code,
         message=message,
         session_id=state.get("session_id"),
         redacted_fields=redacted,
-        metadata={"backend": "mock", "snapshot_id": _snapshot_id(state)},
+        metadata=audit_metadata,
     ).to_dict()
 
 
@@ -394,23 +412,30 @@ def find_tool() -> Dict[str, Any]:
     )
 
 
-def _stale_result(control_id: str, state: Dict[str, Any], requested: str) -> Dict[str, Any]:
+def _stale_result(
+    control_id: str,
+    action: str,
+    state: Dict[str, Any],
+    policy: AppUiPolicy,
+    requested: str,
+) -> Dict[str, Any]:
     result = UiActionResult.stale(control_id).to_dict()
-    result["metadata"] = {
+    metadata = {
         "requested_snapshot_id": requested,
         "current_snapshot_id": _snapshot_id(state),
     }
-    audit = AppUiAuditRecord(
-        action_kind="unknown",
-        success=False,
-        target_control_id=control_id,
-        before_focus_id=state.get("focus_id"),
-        after_focus_id=state.get("focus_id"),
-        error_code=UiErrorCode.STALE_CONTROL,
-        message="control is stale; refresh the UI snapshot",
-        session_id=state.get("session_id"),
-        metadata=result["metadata"],
-    ).to_dict()
+    result["metadata"] = metadata
+    control = _find_by_id(_snapshot_dict(state), control_id)
+    audit = _audit_record(
+        action,
+        False,
+        control or {"id": control_id},
+        state,
+        policy,
+        UiErrorCode.STALE_CONTROL,
+        "control is stale; refresh the UI snapshot",
+        metadata=metadata,
+    )
     return skill_error(
         "Control is stale; refresh the app_ui snapshot.",
         UiErrorCode.STALE_CONTROL,
@@ -429,22 +454,25 @@ def act_tool() -> Dict[str, Any]:
     action = str(params.get("action") or "")
     requested_snapshot_id = str(params.get("snapshot_id") or "")
     if requested_snapshot_id and requested_snapshot_id != _snapshot_id(state):
-        return _stale_result(control_id, state, requested_snapshot_id)
+        return _stale_result(control_id, action, state, policy, requested_snapshot_id)
     snapshot = _snapshot_dict(state)
     control = _find_by_id(snapshot, control_id)
     if not control:
+        message = "control not found in scoped app_ui window"
         result = UiActionResult(
             success=False,
             control_id=control_id,
             error_code=UiErrorCode.NOT_FOUND,
-            message="control not found in scoped app_ui window",
+            message=message,
             before_focus_id=state.get("focus_id"),
             after_focus_id=state.get("focus_id"),
         ).to_dict()
+        audit = _audit_record(action, False, None, state, policy, UiErrorCode.NOT_FOUND, message)
         return skill_error(
             "Control not found in scoped app_ui window.",
             UiErrorCode.NOT_FOUND,
             result=result,
+            audit=audit,
             current_snapshot_id=_snapshot_id(state),
         )
     if not _window_allowed(state, policy):
@@ -472,12 +500,12 @@ def act_tool() -> Dict[str, Any]:
         state["focus_id"] = control_id
     elif action == UiActionKind.SET_TEXT:
         if control.get("role") != "text_field":
-            return _unsupported_action(action, control, state, "set_text requires a text_field control")
+            return _unsupported_action(action, control, state, policy, "set_text requires a text_field control")
         state["project_name"] = str(params.get("text") or "")
         state["focus_id"] = control_id
     elif action in (UiActionKind.TOGGLE, UiActionKind.SET_CHECKED):
         if control.get("role") != "checkbox":
-            return _unsupported_action(action, control, state, f"{action} requires a checkbox control")
+            return _unsupported_action(action, control, state, policy, f"{action} requires a checkbox control")
         if action == UiActionKind.SET_CHECKED:
             state["cache_enabled"] = bool(params.get("checked"))
         else:
@@ -490,9 +518,9 @@ def act_tool() -> Dict[str, Any]:
         elif control.get("role") == "checkbox":
             state["cache_enabled"] = not bool(state.get("cache_enabled"))
         elif control.get("role") not in ("button", "text_field"):
-            return _unsupported_action(action, control, state, "click is unsupported for this control role")
+            return _unsupported_action(action, control, state, policy, "click is unsupported for this control role")
     else:
-        return _unsupported_action(action, control, state, "unsupported app_ui action")
+        return _unsupported_action(action, control, state, policy, "unsupported app_ui action")
 
     state["revision"] = int(state.get("revision") or 1) + 1
     _save_state(state)
@@ -504,7 +532,7 @@ def act_tool() -> Dict[str, Any]:
         after_focus_id=state.get("focus_id"),
         metadata={"snapshot_id": _snapshot_id(state)},
     ).to_dict()
-    audit = _audit_record(action, True, control, state, policy, None, message)
+    audit = _audit_record(action, True, control, state, policy, None, message, before_focus_id=before_focus)
     return skill_success(
         f"Completed app_ui action {action!r} on {control_id}.",
         prompt="Use app_ui__wait_for to poll for the expected UI state, then app_ui__snapshot to verify.",
@@ -519,6 +547,7 @@ def _unsupported_action(
     action: str,
     control: Dict[str, Any],
     state: Dict[str, Any],
+    policy: AppUiPolicy,
     message: str,
 ) -> Dict[str, Any]:
     result = UiActionResult(
@@ -529,18 +558,7 @@ def _unsupported_action(
         before_focus_id=state.get("focus_id"),
         after_focus_id=state.get("focus_id"),
     ).to_dict()
-    audit = AppUiAuditRecord(
-        action_kind=action,
-        success=False,
-        target_control_id=control.get("id"),
-        target_role=control.get("role"),
-        target_label=control.get("label"),
-        before_focus_id=state.get("focus_id"),
-        after_focus_id=state.get("focus_id"),
-        error_code=UiErrorCode.UNSUPPORTED_ACTION,
-        message=message,
-        session_id=state.get("session_id"),
-    ).to_dict()
+    audit = _audit_record(action, False, control, state, policy, UiErrorCode.UNSUPPORTED_ACTION, message)
     return skill_error(message, UiErrorCode.UNSUPPORTED_ACTION, result=result, audit=audit)
 
 
@@ -583,6 +601,7 @@ def _condition_matches(snapshot: Dict[str, Any], condition: UiWaitCondition) -> 
 def wait_for_tool() -> Dict[str, Any]:
     params = _read_params()
     session_id = _safe_session_id(params.get("session_id"))
+    policy = _policy_from_params(params)
     condition = _condition_from_params(params.get("condition") or {})
     timeout_ms = max(0, int(condition.timeout_ms))
     interval_ms = max(10, int(condition.interval_ms))
@@ -592,10 +611,25 @@ def wait_for_tool() -> Dict[str, Any]:
     start = time.monotonic()
     while True:
         state = _load_state(session_id)
+        if not _window_allowed(state, policy):
+            elapsed_ms = round((time.monotonic() - start) * 1000.0, 1)
+            message = "scoped app_ui window is not allowed by policy"
+            result = UiWaitResult(
+                success=False,
+                condition=condition,
+                elapsed_ms=elapsed_ms,
+                attempts=attempts,
+                snapshot=None,
+                error_code=UiErrorCode.POLICY_DISABLED,
+                message=message,
+            ).to_dict()
+            audit = _audit_record("wait_for", False, None, state, policy, UiErrorCode.POLICY_DISABLED, message)
+            return skill_error(message, UiErrorCode.POLICY_DISABLED, session_id=session_id, result=result, audit=audit)
         last_snapshot = _snapshot_dict(state)
         attempts += 1
         if _condition_matches(last_snapshot, condition):
             elapsed_ms = round((time.monotonic() - start) * 1000.0, 1)
+            control = _resolve_condition_control(last_snapshot, condition)
             result = UiWaitResult(
                 success=True,
                 condition=condition,
@@ -609,6 +643,16 @@ def wait_for_tool() -> Dict[str, Any]:
                 session_id=session_id,
                 snapshot_id=last_snapshot["metadata"]["snapshot_id"],
                 result=result,
+                audit=_audit_record(
+                    "wait_for",
+                    True,
+                    control,
+                    state,
+                    policy,
+                    None,
+                    "condition became true",
+                    metadata={"condition": condition.to_dict()},
+                ),
             )
         if time.monotonic() >= deadline:
             break
@@ -625,11 +669,23 @@ def wait_for_tool() -> Dict[str, Any]:
         message="condition did not become true before timeout",
         metadata={"last_snapshot": last_snapshot},
     ).to_dict()
+    control = _resolve_condition_control(last_snapshot, condition) if last_snapshot else None
+    audit = _audit_record(
+        "wait_for",
+        False,
+        control,
+        state,
+        policy,
+        UiErrorCode.TIMEOUT,
+        "condition did not become true before timeout",
+        metadata={"condition": condition.to_dict()},
+    )
     return skill_error(
         "app_ui wait_for timed out.",
         UiErrorCode.TIMEOUT,
         session_id=session_id,
         result=result,
+        audit=audit,
         attempts=attempts,
     )
 

--- a/python/dcc_mcp_core/skills/app-ui/scripts/_chrome_backend.py
+++ b/python/dcc_mcp_core/skills/app-ui/scripts/_chrome_backend.py
@@ -41,6 +41,7 @@ _POLICY_KEYS = {
     "allow_text_entry",
     "allow_keyboard_shortcuts",
     "allow_raw_coordinates",
+    "require_scoped_window",
     "allowed_window_titles",
     "allowed_process_ids",
     "audit_sensitive_values",
@@ -380,7 +381,18 @@ def _find_by_id(snapshot: Dict[str, Any], control_id: str) -> Optional[Dict[str,
     return None
 
 
+def _has_scoped_window(state: Dict[str, Any]) -> bool:
+    title = str(state.get("title") or state.get("window_title") or "").strip()
+    try:
+        process_id = int(state.get("pid") or state.get("process_id") or 0)
+    except Exception:
+        process_id = 0
+    return bool(title) or process_id > 0
+
+
 def _window_allowed(state: Dict[str, Any], policy: AppUiPolicy) -> bool:
+    if policy.require_scoped_window and not _has_scoped_window(state):
+        return False
     if policy.allowed_window_titles:
         title = str(state.get("title") or "Chrome").lower()
         allowed = [str(item).lower() for item in policy.allowed_window_titles]
@@ -404,27 +416,33 @@ def _audit_record(
     policy: AppUiPolicy,
     error_code: Optional[str] = None,
     message: Optional[str] = None,
+    before_focus_id: Optional[str] = None,
+    after_focus_id: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     redacted = ["text"] if action == UiActionKind.SET_TEXT and not policy.audit_sensitive_values else []
+    audit_metadata = {
+        "backend": "chrome-cdp",
+        "preset": state.get("preset"),
+        "launch_mode": state.get("launch_mode"),
+        "snapshot_id": _snapshot_id(state),
+        "current_url": state.get("current_url"),
+    }
+    if metadata:
+        audit_metadata.update(metadata)
     return AppUiAuditRecord(
         action_kind=action,
         success=success,
         target_control_id=control.get("id") if control else None,
         target_role=control.get("role") if control else None,
         target_label=control.get("label") if control else None,
-        before_focus_id=state.get("focus_id"),
-        after_focus_id=state.get("focus_id"),
+        before_focus_id=before_focus_id if before_focus_id is not None else state.get("focus_id"),
+        after_focus_id=after_focus_id if after_focus_id is not None else state.get("focus_id"),
         error_code=error_code,
         message=message,
         session_id=state.get("session_id"),
         redacted_fields=redacted,
-        metadata={
-            "backend": "chrome-cdp",
-            "preset": state.get("preset"),
-            "launch_mode": state.get("launch_mode"),
-            "snapshot_id": _snapshot_id(state),
-            "current_url": state.get("current_url"),
-        },
+        metadata=audit_metadata,
     ).to_dict()
 
 
@@ -448,23 +466,30 @@ def _policy_denied(
     return skill_error(message, UiErrorCode.POLICY_DISABLED, result=result, audit=audit)
 
 
-def _stale_result(control_id: str, state: Dict[str, Any], requested: str) -> Dict[str, Any]:
+def _stale_result(
+    control_id: str,
+    action: str,
+    state: Dict[str, Any],
+    policy: AppUiPolicy,
+    requested: str,
+) -> Dict[str, Any]:
     result = UiActionResult.stale(control_id).to_dict()
-    result["metadata"] = {
+    metadata = {
         "requested_snapshot_id": requested,
         "current_snapshot_id": _snapshot_id(state),
     }
-    audit = AppUiAuditRecord(
-        action_kind="unknown",
-        success=False,
-        target_control_id=control_id,
-        before_focus_id=state.get("focus_id"),
-        after_focus_id=state.get("focus_id"),
-        error_code=UiErrorCode.STALE_CONTROL,
-        message="control is stale; refresh the UI snapshot",
-        session_id=state.get("session_id"),
-        metadata=result["metadata"],
-    ).to_dict()
+    result["metadata"] = metadata
+    control = _find_by_id(_snapshot_dict(state), control_id)
+    audit = _audit_record(
+        action,
+        False,
+        control or {"id": control_id},
+        state,
+        policy,
+        UiErrorCode.STALE_CONTROL,
+        "control is stale; refresh the UI snapshot",
+        metadata=metadata,
+    )
     return skill_error(
         "Control is stale; refresh the app_ui snapshot.",
         UiErrorCode.STALE_CONTROL,
@@ -474,7 +499,13 @@ def _stale_result(control_id: str, state: Dict[str, Any], requested: str) -> Dic
     )
 
 
-def _unsupported_action(action: str, control: Dict[str, Any], state: Dict[str, Any], message: str) -> Dict[str, Any]:
+def _unsupported_action(
+    action: str,
+    control: Dict[str, Any],
+    state: Dict[str, Any],
+    policy: AppUiPolicy,
+    message: str,
+) -> Dict[str, Any]:
     result = UiActionResult(
         success=False,
         control_id=str(control.get("id") or ""),
@@ -483,7 +514,7 @@ def _unsupported_action(action: str, control: Dict[str, Any], state: Dict[str, A
         before_focus_id=state.get("focus_id"),
         after_focus_id=state.get("focus_id"),
     ).to_dict()
-    audit = _audit_record(action, False, control, state, AppUiPolicy(), UiErrorCode.UNSUPPORTED_ACTION, message)
+    audit = _audit_record(action, False, control, state, policy, UiErrorCode.UNSUPPORTED_ACTION, message)
     return skill_error(message, UiErrorCode.UNSUPPORTED_ACTION, result=result, audit=audit)
 
 
@@ -567,19 +598,26 @@ def act_tool() -> Dict[str, Any]:
     action = str(params.get("action") or "")
     requested_snapshot_id = str(params.get("snapshot_id") or "")
     if requested_snapshot_id and requested_snapshot_id != _snapshot_id(state):
-        return _stale_result(control_id, state, requested_snapshot_id)
+        return _stale_result(control_id, action, state, policy, requested_snapshot_id)
     snapshot = _snapshot_dict(state)
     control = _find_by_id(snapshot, control_id)
     if not control:
+        message = "control not found in scoped Chrome app_ui window"
         result = UiActionResult(
             success=False,
             control_id=control_id,
             error_code=UiErrorCode.NOT_FOUND,
-            message="control not found in scoped Chrome app_ui window",
+            message=message,
             before_focus_id=state.get("focus_id"),
             after_focus_id=state.get("focus_id"),
         ).to_dict()
-        return skill_error("Control not found in scoped Chrome app_ui window.", UiErrorCode.NOT_FOUND, result=result)
+        audit = _audit_record(action, False, None, state, policy, UiErrorCode.NOT_FOUND, message)
+        return skill_error(
+            "Control not found in scoped Chrome app_ui window.",
+            UiErrorCode.NOT_FOUND,
+            result=result,
+            audit=audit,
+        )
     if not _window_allowed(state, policy):
         return _policy_denied(action, control_id, control, state, policy, "scoped Chrome window is not allowed")
     if not policy.allows_action(action):
@@ -606,7 +644,7 @@ def act_tool() -> Dict[str, Any]:
             state = _navigate_search(state)
             message = "Chrome search submitted"
         else:
-            return _unsupported_action(action, control, state, "unsupported Chrome app_ui action")
+            return _unsupported_action(action, control, state, policy, "unsupported Chrome app_ui action")
     except Exception as exc:
         return skill_error(str(exc), "backend_error", backend="chrome")
 
@@ -621,7 +659,7 @@ def act_tool() -> Dict[str, Any]:
         after_focus_id=state.get("focus_id"),
         metadata={"snapshot_id": _snapshot_id(state), "current_url": state.get("current_url")},
     ).to_dict()
-    audit = _audit_record(action, True, control, state, policy, None, message)
+    audit = _audit_record(action, True, control, state, policy, None, message, before_focus_id=before_focus)
     return skill_success(
         f"Completed Chrome app_ui action {action!r} on {control_id}.",
         prompt="Use app_ui__wait_for to poll for the expected UI state, then app_ui__snapshot to verify.",
@@ -669,6 +707,7 @@ def _condition_matches(snapshot: Dict[str, Any], condition: UiWaitCondition) -> 
 def wait_for_tool() -> Dict[str, Any]:
     params = _read_params()
     session_id = _safe_session_id(params.get("session_id"))
+    policy = _policy_from_params(params)
     condition = _condition_from_params(params.get("condition") or {})
     timeout_ms = max(0, int(condition.timeout_ms))
     interval_ms = max(10, int(condition.interval_ms))
@@ -683,10 +722,25 @@ def wait_for_tool() -> Dict[str, Any]:
         except Exception as exc:
             return _backend_unavailable(exc, state)
         _save_state(state)
+        if not _window_allowed(state, policy):
+            elapsed_ms = round((time.monotonic() - start) * 1000.0, 1)
+            message = "scoped Chrome window is not allowed by policy"
+            result = UiWaitResult(
+                success=False,
+                condition=condition,
+                elapsed_ms=elapsed_ms,
+                attempts=attempts,
+                snapshot=None,
+                error_code=UiErrorCode.POLICY_DISABLED,
+                message=message,
+            ).to_dict()
+            audit = _audit_record("wait_for", False, None, state, policy, UiErrorCode.POLICY_DISABLED, message)
+            return skill_error(message, UiErrorCode.POLICY_DISABLED, session_id=session_id, result=result, audit=audit)
         last_snapshot = _snapshot_dict(state)
         attempts += 1
         if _condition_matches(last_snapshot, condition):
             elapsed_ms = round((time.monotonic() - start) * 1000.0, 1)
+            control = _resolve_condition_control(last_snapshot, condition)
             result = UiWaitResult(
                 success=True,
                 condition=condition,
@@ -700,6 +754,16 @@ def wait_for_tool() -> Dict[str, Any]:
                 session_id=session_id,
                 snapshot_id=last_snapshot["metadata"]["snapshot_id"],
                 result=result,
+                audit=_audit_record(
+                    "wait_for",
+                    True,
+                    control,
+                    state,
+                    policy,
+                    None,
+                    "condition became true",
+                    metadata={"condition": condition.to_dict()},
+                ),
             )
         if time.monotonic() >= deadline:
             break
@@ -716,10 +780,22 @@ def wait_for_tool() -> Dict[str, Any]:
         message="condition did not become true before timeout",
         metadata={"last_snapshot": last_snapshot},
     ).to_dict()
+    control = _resolve_condition_control(last_snapshot, condition) if last_snapshot else None
+    audit = _audit_record(
+        "wait_for",
+        False,
+        control,
+        state,
+        policy,
+        UiErrorCode.TIMEOUT,
+        "condition did not become true before timeout",
+        metadata={"condition": condition.to_dict()},
+    )
     return skill_error(
         "app_ui wait_for timed out.",
         UiErrorCode.TIMEOUT,
         session_id=session_id,
         result=result,
+        audit=audit,
         attempts=attempts,
     )

--- a/skills/dcc-mcp-skill-developer/SKILL.md
+++ b/skills/dcc-mcp-skill-developer/SKILL.md
@@ -113,8 +113,10 @@ into a faster authoring loop.
     accessibility, webview, PyO3, or HTTP runtime dependencies there.
     Prefer native DCC APIs first; use `app_ui` as a scoped, policy-controlled
     fallback. Keep raw coordinates and keyboard shortcuts disabled by default,
-    return structured `stale_control` / `policy_disabled` / `timeout` errors,
-    and redact typed text or screenshot bytes in audit records.
+    keep `require_scoped_window` enabled unless an adapter explicitly opts into
+    a documented whole-desktop fallback, return structured `stale_control` /
+    `policy_disabled` / `timeout` errors, and redact typed text or screenshot
+    bytes in audit records.
     Backend-specific implementations, such as the bundled Chrome DevTools
     prototype, belong behind the skill/runtime layer and must preserve the
     same `app_ui__snapshot` -> `find` -> `act` -> `wait_for` contract.

--- a/tests/test_adapter_contracts.py
+++ b/tests/test_adapter_contracts.py
@@ -93,7 +93,9 @@ def test_app_ui_policy_blocks_high_risk_actions_by_default() -> None:
     assert policy.allows_action(UiActionKind.SET_TEXT) is True
     assert policy.allows_action(UiActionKind.RAW_COORDINATE_CLICK) is False
     assert policy.allows_action(UiActionKind.KEYBOARD_SHORTCUT) is False
+    assert policy.require_scoped_window is True
     assert policy.to_dict()["allow_raw_coordinates"] is False
+    assert policy.to_dict()["require_scoped_window"] is True
 
 
 def test_app_ui_wait_result_and_audit_record_are_structured() -> None:

--- a/tests/test_app_ui_skill.py
+++ b/tests/test_app_ui_skill.py
@@ -174,6 +174,8 @@ def test_app_ui_mock_reports_stale_and_policy_denied_paths(tmp_path: Path) -> No
     )
     assert stale["success"] is False
     assert stale["context"]["result"]["error_code"] == "stale_control"
+    assert stale["context"]["audit"]["action_kind"] == "toggle"
+    assert stale["context"]["audit"]["error_code"] == "stale_control"
 
     denied = _run_tool(
         "act",
@@ -190,6 +192,92 @@ def test_app_ui_mock_reports_stale_and_policy_denied_paths(tmp_path: Path) -> No
     assert denied["success"] is False
     assert denied["context"]["result"]["error_code"] == "policy_disabled"
     assert denied["context"]["audit"]["redacted_fields"] == ["text"]
+
+    not_found = _run_tool(
+        "act",
+        {
+            "session_id": session_id,
+            "control_id": "missing-control",
+            "action": "click",
+            "snapshot_id": changed["context"]["snapshot_id"],
+        },
+        tmp_path,
+    )
+    assert not_found["success"] is False
+    assert not_found["context"]["result"]["error_code"] == "not_found"
+    assert not_found["context"]["audit"]["action_kind"] == "click"
+    assert not_found["context"]["audit"]["error_code"] == "not_found"
+
+
+def test_app_ui_mock_policy_scopes_wait_and_audits_timeout(tmp_path: Path) -> None:
+    session_id = "wait-policy"
+    denied = _run_tool(
+        "wait_for",
+        {
+            "session_id": session_id,
+            "condition": {
+                "kind": "text_equals",
+                "control_id": "status",
+                "text": "Never",
+                "timeout_ms": 10,
+                "interval_ms": 10,
+            },
+            "policy": {"allowed_window_titles": ["Other App"]},
+        },
+        tmp_path,
+    )
+    assert denied["success"] is False
+    assert denied["error"] == "policy_disabled"
+    assert denied["context"]["audit"]["action_kind"] == "wait_for"
+    assert denied["context"]["audit"]["error_code"] == "policy_disabled"
+
+    timed_out = _run_tool(
+        "wait_for",
+        {
+            "session_id": session_id,
+            "condition": {
+                "kind": "text_equals",
+                "control_id": "status",
+                "text": "Never",
+                "timeout_ms": 10,
+                "interval_ms": 10,
+            },
+        },
+        tmp_path,
+    )
+    assert timed_out["success"] is False
+    assert timed_out["context"]["result"]["error_code"] == "timeout"
+    assert timed_out["context"]["audit"]["action_kind"] == "wait_for"
+    assert timed_out["context"]["audit"]["target_control_id"] == "status"
+    assert timed_out["context"]["audit"]["target_role"] == "label"
+    assert timed_out["context"]["audit"]["error_code"] == "timeout"
+
+
+def test_app_ui_policy_can_leave_observation_enabled_while_actions_disabled(tmp_path: Path) -> None:
+    policy = {"allow_mutating_actions": False}
+    session_id = "read-only-policy"
+
+    snapshot = _run_tool("snapshot", {"session_id": session_id, "policy": policy}, tmp_path)
+    assert snapshot["success"] is True
+
+    found = _run_tool("find", {"session_id": session_id, "label": "Apply", "policy": policy}, tmp_path)
+    assert found["success"] is True
+    assert found["context"]["matches"][0]["id"] == "apply"
+
+    denied = _run_tool(
+        "act",
+        {
+            "session_id": session_id,
+            "control_id": "apply",
+            "action": "click",
+            "snapshot_id": snapshot["context"]["snapshot_id"],
+            "policy": policy,
+        },
+        tmp_path,
+    )
+    assert denied["success"] is False
+    assert denied["context"]["result"]["error_code"] == "policy_disabled"
+    assert denied["context"]["audit"]["target_control_id"] == "apply"
 
 
 def test_app_ui_backend_router_reports_unknown_backend(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add scoped-window enforcement to the app_ui policy contract
- include audit records for stale, missing-control, denied, success, and wait timeout paths in mock/CDP backends
- update adapter docs and skill-developer guidance for scoped app_ui safety expectations

## Tests
- DCC_MCP_ADMIN_UI_PREBUILT=1 vx just dev
- .\.venv\Scripts\python.exe -m pytest tests/test_adapter_contracts.py tests/test_app_ui_skill.py -q
- vx cargo test -p dcc-mcp-app-ui
- vx ruff check python\dcc_mcp_core\adapter_contracts.py python\dcc_mcp_core\skills\app-ui\scripts\_backend.py python\dcc_mcp_core\skills\app-ui\scripts\_chrome_backend.py tests\test_adapter_contracts.py tests\test_app_ui_skill.py
- vx ruff format --check python\dcc_mcp_core\adapter_contracts.py python\dcc_mcp_core\skills\app-ui\scripts\_backend.py python\dcc_mcp_core\skills\app-ui\scripts\_chrome_backend.py tests\test_adapter_contracts.py tests\test_app_ui_skill.py
- vx cargo fmt --check -p dcc-mcp-app-ui

Closes #1135