### PR TITLE
fix: keep healthy gateway residents active

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/runner.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/runner.rs
@@ -22,6 +22,13 @@ pub struct GatewayRunner {
     pub registry: Arc<RwLock<FileRegistry>>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ResidentGatewayHealth {
+    Missing,
+    Healthy,
+    Unhealthy,
+}
+
 impl GatewayRunner {
     /// Create a new runner, initializing (or loading) the `FileRegistry` from
     /// `config.registry_dir`, the `DCC_MCP_REGISTRY_DIR` environment variable,
@@ -43,7 +50,7 @@ impl GatewayRunner {
         })
     }
 
-    /// Register `entry`, start heartbeat, and run the **version-aware gateway election**.
+    /// Register `entry`, start heartbeat, and run the liveness-aware gateway election.
     ///
     /// ## Election algorithm
     ///
@@ -52,12 +59,14 @@ impl GatewayRunner {
     ///    - Periodically checks whether any live instance has a *newer* version;
     ///      if so, initiates voluntary yield (graceful shutdown of its listener).
     ///
-    /// 2. **Lose + same-or-older version**: registers as a plain DCC instance
-    ///    (current `is_gateway = false` behaviour).
+    /// 2. **Lose + healthy resident**: registers as a plain DCC instance
+    ///    even when this process has a newer version. Healthy co-existing
+    ///    DCCs must not drop active MCP clients just because another adapter
+    ///    started.
     ///
-    /// 3. **Lose + newer version** (e.g. `0.12.29` vs `0.12.6` gateway):
-    ///    - First tries a cooperative [`POST /gateway/yield`] to the existing
-    ///      gateway (works if the gateway supports it, i.e. is also `≥ 0.12.29`).
+    /// 3. **Lose + missing or unhealthy resident**:
+    ///    - First tries a cooperative [`POST /gateway/yield`] when this
+    ///      process is newer and the incumbent supports it.
     ///    - Regardless of the response, enters a **challenger retry loop** that
     ///      polls the port every `challenger_poll_interval_secs` for up to
     ///      `challenger_timeout_secs`.
@@ -203,7 +212,7 @@ impl GatewayRunner {
         })
     }
 
-    /// Core version-aware election logic, extracted for clarity.
+    /// Core liveness-aware election logic, extracted for clarity.
     ///
     /// Public so out-of-process sidecars can re-run election after the
     /// incumbent gateway dies without restarting the whole DCC host.
@@ -386,13 +395,10 @@ impl GatewayRunner {
                 }
             }
 
-            // ── Port is taken — version-aware challenger logic ────────────
+            // ── Port is taken — liveness-aware challenger logic ───────────
             None => {
-                // Read the sentinel to discover the current gateway's full
-                // election profile (crate version + adapter metadata).
-                // Issue maya#137: the previous lookup only fetched `version`,
-                // so a freshly-released DCC adapter could never preempt an
-                // older standalone server pinned to a newer crate version.
+                // Read the sentinel so logs and optional cooperative-yield
+                // requests can identify the resident gateway profile.
                 let resident = {
                     let reg = self.registry.read().await;
                     reg.list_instances(GATEWAY_SENTINEL_DCC_TYPE)
@@ -407,30 +413,26 @@ impl GatewayRunner {
                 let gw_adapter_version = resident.as_ref().and_then(|e| e.adapter_version.clone());
                 let gw_adapter_dcc = resident.as_ref().and_then(|e| e.adapter_dcc.clone());
 
-                let own_info = ElectionInfo::new(
-                    &own_version,
-                    own_adapter_version.as_deref(),
-                    own_adapter_dcc.as_deref(),
-                );
-                let gw_info = ElectionInfo::new(
-                    if gw_version.is_empty() {
-                        "0.0.0"
-                    } else {
-                        &gw_version
-                    },
-                    gw_adapter_version.as_deref(),
-                    gw_adapter_dcc.as_deref(),
-                );
+                let resident_health = if resident.is_none() {
+                    ResidentGatewayHealth::Missing
+                } else {
+                    probe_resident_gateway_health(
+                        &self.config.host,
+                        self.config.gateway_port,
+                        Duration::from_secs(self.config.challenger_poll_interval_secs.clamp(1, 5)),
+                    )
+                    .await
+                };
 
                 // Three cases reach this branch:
-                //   A. Resident exists AND we outrank it     -> challenger
-                //   B. Resident is gone (TIME_WAIT / race    -> challenger
+                //   A. Resident exists and /health passes    -> plain
+                //   B. Resident exists but /health fails     -> challenger
+                //   C. Resident is gone (TIME_WAIT / race    -> challenger
                 //      with no live sentinel; the OS still
                 //      holds the address but no peer is the
                 //      authoritative owner)
-                //   C. Resident exists and same-or-stronger  -> plain
                 //
-                // (B) is the post-crash recovery case: the previous
+                // (C) is the post-crash recovery case: the previous
                 // gateway died, ``prune_dead_entries`` cleared the stale
                 // sentinel, but the kernel still keeps the port in
                 // TIME_WAIT so our first bind attempt failed. Without
@@ -441,15 +443,9 @@ impl GatewayRunner {
                 // restarts a DCC. The challenger loop polls up to
                 // ``challenger_timeout_secs`` and wins the bind the
                 // moment TIME_WAIT releases (#893 follow-up).
-                let challenger_reason = if gw_version.is_empty() {
-                    "Bind failed but no resident sentinel (TIME_WAIT / race) — entering challenger mode"
-                } else if is_newer_election(own_info, gw_info) {
-                    "We outrank the current gateway — entering challenger mode"
-                } else {
-                    ""
-                };
+                let challenger_reason = challenger_reason(resident_health);
 
-                if !challenger_reason.is_empty() {
+                if let Some(challenger_reason) = challenger_reason {
                     tracing::info!(
                         own = %own_version,
                         own_adapter_version = ?own_adapter_version,
@@ -457,6 +453,7 @@ impl GatewayRunner {
                         gateway = %gw_version,
                         gateway_adapter_version = ?gw_adapter_version,
                         gateway_adapter_dcc = ?gw_adapter_dcc,
+                        resident_health = ?resident_health,
                         "{}",
                         challenger_reason,
                     );
@@ -479,7 +476,8 @@ impl GatewayRunner {
                         own_version = %own_version,
                         own_adapter_version = ?own_adapter_version,
                         own_adapter_dcc = ?own_adapter_dcc,
-                        "Gateway port held by same-or-stronger candidate — running as plain DCC instance"
+                        resident_health = ?resident_health,
+                        "Gateway port held by healthy resident — running as plain DCC instance"
                     );
                     Ok(ElectionOutcome {
                         is_gateway: false,
@@ -723,6 +721,50 @@ fn stamp_gateway_sentinel(entry: &mut ServiceEntry, gateway_name: &str, role: &s
     );
 }
 
+fn challenger_reason(resident_health: ResidentGatewayHealth) -> Option<&'static str> {
+    match resident_health {
+        ResidentGatewayHealth::Missing => Some(
+            "Bind failed but no resident sentinel (TIME_WAIT / race) — entering challenger mode",
+        ),
+        ResidentGatewayHealth::Unhealthy => {
+            Some("Resident gateway failed /health probe — entering challenger mode")
+        }
+        ResidentGatewayHealth::Healthy => None,
+    }
+}
+
+async fn probe_resident_gateway_health(
+    host: &str,
+    port: u16,
+    timeout: Duration,
+) -> ResidentGatewayHealth {
+    let url = format!("http://{host}:{port}/health");
+    let client = reqwest::Client::builder()
+        .connect_timeout(timeout)
+        .timeout(timeout)
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
+    match client.get(&url).send().await {
+        Ok(resp) if resp.status().is_success() => ResidentGatewayHealth::Healthy,
+        Ok(resp) => {
+            tracing::warn!(
+                status = %resp.status(),
+                url = %url,
+                "Resident gateway /health probe failed"
+            );
+            ResidentGatewayHealth::Unhealthy
+        }
+        Err(err) => {
+            tracing::warn!(
+                error = %err,
+                url = %url,
+                "Resident gateway /health probe failed"
+            );
+            ResidentGatewayHealth::Unhealthy
+        }
+    }
+}
+
 struct PromotedGatewayGuard {
     abort: Option<AbortHandle>,
     registry: Arc<RwLock<FileRegistry>>,
@@ -928,5 +970,28 @@ mod tests {
         assert!(should_probe_cooperative_yield("0.17.9", "0.17.8"));
         assert!(!should_probe_cooperative_yield("0.17.8", "0.17.8"));
         assert!(!should_probe_cooperative_yield("0.17.7", "0.17.8"));
+    }
+
+    #[test]
+    fn healthy_resident_suppresses_version_preemption() {
+        assert_eq!(challenger_reason(ResidentGatewayHealth::Healthy), None);
+    }
+
+    #[test]
+    fn unhealthy_resident_enters_challenger_mode_even_without_version_advantage() {
+        assert_eq!(
+            challenger_reason(ResidentGatewayHealth::Unhealthy),
+            Some("Resident gateway failed /health probe — entering challenger mode")
+        );
+    }
+
+    #[test]
+    fn missing_resident_still_recovers_time_wait_race() {
+        assert_eq!(
+            challenger_reason(ResidentGatewayHealth::Missing),
+            Some(
+                "Bind failed but no resident sentinel (TIME_WAIT / race) — entering challenger mode"
+            )
+        );
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tests.rs
@@ -446,7 +446,7 @@ async fn test_gateway_winner_stamps_human_readable_name_on_sentinel() {
 }
 
 #[tokio::test]
-async fn test_newer_gateway_takes_over_local_and_remote_listeners() {
+async fn test_newer_gateway_does_not_preempt_healthy_local_and_remote_listeners() {
     let dir = tempfile::tempdir().unwrap();
     let gw_port = ephemeral_port();
     let remote_port = ephemeral_port();
@@ -483,15 +483,15 @@ async fn test_newer_gateway_takes_over_local_and_remote_listeners() {
 
     assert!(
         !new.is_gateway,
-        "new runner starts as challenger while old owns the port"
+        "new runner must not win while a healthy resident owns the port"
     );
     assert!(
-        new.challenger_abort.is_some(),
-        "newer runner must start a challenger loop"
+        new.challenger_abort.is_none(),
+        "newer runner must stay a plain peer while the resident gateway is healthy"
     );
-    wait_gateway_sentinel_version(&new_runner, "9.9.9", Duration::from_secs(25)).await;
-    wait_gateway_initialize_version(gw_port, "9.9.9", Duration::from_secs(120)).await;
-    wait_gateway_initialize_version(remote_port, "9.9.9", Duration::from_secs(20)).await;
+    wait_gateway_sentinel_version(&old_runner, "0.1.0", Duration::from_secs(10)).await;
+    wait_gateway_initialize_version(gw_port, "0.1.0", Duration::from_secs(10)).await;
+    wait_gateway_initialize_version(remote_port, "0.1.0", Duration::from_secs(10)).await;
 
     if let Some(abort) = new.challenger_abort {
         abort.abort();

--- a/docs/guide/gateway-diagnostics.md
+++ b/docs/guide/gateway-diagnostics.md
@@ -72,8 +72,11 @@ logs.
 ## Election (three-tier comparison)
 
 Only one process can bind the gateway port at a time; the rest stand by.
-When a newer/better adapter shows up, the current gateway yields
-cooperatively (issue #718). The comparison uses three tiers, in order:
+When another adapter shows up, the newcomer first probes the resident gateway's
+`/health` endpoint. A healthy resident keeps the gateway role so active MCP
+clients stay connected. Only a missing or unhealthy resident enters challenger
+mode; version comparison only affects whether cooperative yield is attempted.
+That comparison uses three tiers, in order:
 
 1. **`crate_version`** — the `dcc_mcp_core` version baked into the
    binary. A 0.14.28 challenger beats a 0.14.17 resident.
@@ -105,6 +108,8 @@ Inspect them by reading `gateway://instances`:
 | Cooperative yield accepted | `Cooperative yield accepted — waiting for port to free up` | `INFO` |
 | Optional cooperative yield fallback | `Cooperative yield optional capability unavailable (...) — polling for port` | `DEBUG` |
 | Yield probe skipped for same-or-older challenger | `Skipping cooperative yield probe because challenger is not newer than the current gateway` | `DEBUG` |
+| Healthy resident kept gateway role | `Gateway port held by healthy resident — running as plain DCC instance` | `INFO` |
+| Resident health probe failed | `Resident gateway /health probe failed` | `WARN` |
 | Newer sentinel detected | `Gateway: newer-version sentinel detected — initiating voluntary yield` | `INFO` |
 
 ---

--- a/docs/guide/gateway-election.md
+++ b/docs/guide/gateway-election.md
@@ -14,7 +14,7 @@ The **gateway** is a single Rust HTTP server (running on `localhost:9765` by def
 
 **One gateway per machine**. It's started automatically when the first DCC instance registers.
 
-## The Problem: First-Come-First-Served
+## The Problem: First-Come-First-Served and Unsafe Preemption
 
 Without version awareness, the oldest DCC wins the gateway role:
 
@@ -24,7 +24,11 @@ Maya v0.12.29 starts → port 9999 taken → becomes subordinate
 ❌ Old version controls routing; new features ignored
 ```
 
-## Our Solution: Version-Aware Election
+Pure version preemption has the opposite failure mode: a healthy existing
+gateway can be asked to yield just because a newer adapter starts, dropping
+long-lived MCP clients even though no failover is needed.
+
+## Our Solution: Liveness-Aware Election
 
 ```
 Maya v0.12.6 (gateway)           Maya v0.12.29 (new)
@@ -32,6 +36,24 @@ Maya v0.12.6 (gateway)           Maya v0.12.29 (new)
          │                   port 9999 taken
          │                                │
          │         read __gateway__ sentinel
+         │         GET /health -> 200 OK
+         │                                │
+         │         healthy resident wins
+         │                                │
+                         register as plain instance
+                         ✅ existing MCP sessions stay connected
+```
+
+If the resident does not answer `/health`, the newcomer enters challenger
+mode and polls for the port so crash/TIME_WAIT recovery still works:
+
+```
+Maya v0.12.6 (gateway)           Maya v0.12.29 (new)
+         │                                │
+         │                   port 9999 taken
+         │                                │
+         │         read __gateway__ sentinel
+         │         GET /health fails
          │         own version 0.12.29 > gw 0.12.6
          │                                │
          │ ←── POST /gateway/yield {"challenger_version": "0.12.29"}
@@ -66,8 +88,14 @@ the adapter is bound to.
 
 **2. Three-Tier Election Comparison** (issue maya#137)
 
-The challenger compares its own profile against the resident sentinel in
-this order — each tier is only consulted when the previous tier ties:
+The challenger still compares its own profile against the resident sentinel,
+but that comparison only gates the cooperative yield request. A healthy
+resident keeps the gateway role so co-existing DCC launches do not interrupt
+active clients; missing or unhealthy residents enter challenger mode so
+recovery can still happen.
+
+When cooperative yield is considered, the profile comparison runs in this order
+— each tier is only consulted when the previous tier ties:
 
 | Tier | Field             | Rule                                                                 |
 |------|-------------------|----------------------------------------------------------------------|
@@ -93,11 +121,21 @@ field would otherwise look newer than the `0.14.18` crate version — see
 issue #228 — so only the `__gateway__` sentinel row contributes to the
 self-yield decision).
 
-**3. Voluntary Yield**
+**3. Resident Health Probe**
 
-The cleanup task (every 15s) checks for newer challengers. If found, it shuts down gracefully.
+When the gateway port is occupied and a sentinel exists, new instances probe
+`GET /health` on the resident gateway before considering challenger mode.
+`200` means "stay plain"; non-success or transport failure means "recover or
+fail over". If no sentinel exists, the process still enters challenger mode to
+cover the post-crash TIME_WAIT race.
 
-**4. Challenger Retry Loop**
+**4. Voluntary Yield**
+
+The cleanup task (every 15s) checks for newer challengers. If found, it shuts
+down gracefully. Healthy-resident startup no longer creates such a challenger
+sentinel.
+
+**5. Challenger Retry Loop**
 
 New instances poll the port every 10s for up to 120s. As soon as the port is free, they take over.
 


### PR DESCRIPTION
## Summary
- probe the resident gateway `/health` endpoint before entering challenger mode
- keep healthy resident gateways active so co-existing DCC launches do not drop MCP clients
- still enter challenger mode for missing or unhealthy residents so crash/TIME_WAIT recovery works
- update gateway election and diagnostics docs for the liveness-driven contract

## Validation
- `vx cargo fmt --check -p dcc-mcp-gateway`
- `vx cargo test -p dcc-mcp-gateway --lib -- --nocapture`
- pre-commit: `cargo fmt`, `cargo clippy`

## Notes
- Refs #1114
- Skill developer guidance unchanged: this changes gateway election behavior, not adapter skill authoring, tool schemas, or server wiring contracts.