### PR TITLE
feat: add gateway traffic JSONL capture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,6 +908,7 @@ dependencies = [
  "chrono",
  "criterion",
  "dashmap",
+ "dcc-mcp-actions",
  "dcc-mcp-catalog",
  "dcc-mcp-db",
  "dcc-mcp-gateway-core",

--- a/crates/dcc-mcp-gateway/Cargo.toml
+++ b/crates/dcc-mcp-gateway/Cargo.toml
@@ -12,6 +12,7 @@ build = "build.rs"
 [dependencies]
 # Internal
 dcc-mcp-db = { path = "../dcc-mcp-db", default-features = false }
+dcc-mcp-actions = { path = "../dcc-mcp-actions" }
 dcc-mcp-gateway-core = { path = "../dcc-mcp-gateway-core" }
 dcc-mcp-jsonrpc = { path = "../dcc-mcp-jsonrpc" }
 dcc-mcp-naming = { path = "../dcc-mcp-naming" }

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -127,6 +127,7 @@ mod admin_tests {
             instance_diagnostics: Arc::new(
                 crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
             ),
+            traffic_capture: Arc::new(crate::gateway::traffic::TrafficCapture::disabled()),
             debug_routes_enabled: false,
         }
     }

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
@@ -156,6 +156,7 @@ async fn aggregate_tools_list_returns_only_minimal_gateway_surface() {
         instance_diagnostics: std::sync::Arc::new(
             crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
         ),
+        traffic_capture: std::sync::Arc::new(crate::gateway::traffic::TrafficCapture::disabled()),
         debug_routes_enabled: false,
     };
 
@@ -322,6 +323,7 @@ async fn make_gateway_state(
         instance_diagnostics: std::sync::Arc::new(
             crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
         ),
+        traffic_capture: std::sync::Arc::new(crate::gateway::traffic::TrafficCapture::disabled()),
         debug_routes_enabled: false,
     }
 }
@@ -855,6 +857,7 @@ async fn gateway_state_with_instances(
         instance_diagnostics: std::sync::Arc::new(
             crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
         ),
+        traffic_capture: std::sync::Arc::new(crate::gateway::traffic::TrafficCapture::disabled()),
         debug_routes_enabled: false,
     };
     (state, dir, ids)

--- a/crates/dcc-mcp-gateway/src/gateway/backend_client/ops.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/backend_client/ops.rs
@@ -425,6 +425,7 @@ pub struct ForwardToolsCallRequest<'a> {
     /// not use JSON-RPC request ids.
     pub request_id: Option<String>,
     pub trace_context: Option<&'a TraceContext>,
+    pub traffic_capture: Option<&'a crate::gateway::traffic::TrafficCapture>,
     pub timeout: Duration,
 }
 
@@ -440,6 +441,7 @@ pub async fn forward_tools_call(
         meta,
         request_id: _request_id,
         trace_context,
+        traffic_capture,
         timeout,
     } = request;
     let base = rest_base_from_mcp_url(mcp_url);
@@ -452,14 +454,47 @@ pub async fn forward_tools_call(
     if let Some(m) = meta {
         body["meta"] = m;
     }
+    if let Some(capture) = traffic_capture {
+        emit_backend_traffic_frame(
+            capture,
+            trace_context,
+            &url,
+            "request",
+            "gateway_to_adapter",
+            None,
+            body.clone(),
+        );
+    }
     if let Err(reason) = circuits().check_open(key) {
         let msg = format!("{mcp_url}: {reason}");
         record_gateway_backend_error_kind(rest_error_prometheus_kind(&msg));
+        if let Some(capture) = traffic_capture {
+            emit_backend_traffic_frame(
+                capture,
+                trace_context,
+                &url,
+                "response",
+                "adapter_to_gateway",
+                None,
+                json!({"success": false, "error": {"kind": "circuit-open", "message": msg}}),
+            );
+        }
         return Err(msg);
     }
     match rest_post_with_trace_context(client, &url, body, timeout, trace_context).await {
         Ok(v) => {
             circuits().on_success(key);
+            if let Some(capture) = traffic_capture {
+                emit_backend_traffic_frame(
+                    capture,
+                    trace_context,
+                    &url,
+                    "response",
+                    "adapter_to_gateway",
+                    Some(200),
+                    v.clone(),
+                );
+            }
             Ok(v)
         }
         Err(e) => {
@@ -469,9 +504,55 @@ pub async fn forward_tools_call(
                 circuits().on_success(key);
             }
             record_gateway_backend_error_kind(rest_error_prometheus_kind(&e));
+            if let Some(capture) = traffic_capture {
+                emit_backend_traffic_frame(
+                    capture,
+                    trace_context,
+                    &url,
+                    "response",
+                    "adapter_to_gateway",
+                    None,
+                    json!({"success": false, "error": {"kind": "backend-error", "message": e}}),
+                );
+            }
             Err(e)
         }
     }
+}
+
+fn emit_backend_traffic_frame(
+    capture: &crate::gateway::traffic::TrafficCapture,
+    trace_context: Option<&TraceContext>,
+    url: &str,
+    kind: &str,
+    leg: &'static str,
+    status: Option<u16>,
+    body: Value,
+) {
+    capture.emit_json_frame(
+        crate::gateway::traffic::TrafficFrame::json(
+            crate::gateway::traffic::basic_gateway_source(),
+            trace_correlation(trace_context, None),
+            "internal",
+            leg,
+            "http",
+            body,
+        )
+        .with_http(crate::gateway::traffic::http_post(url, None, status))
+        .with_mcp(crate::gateway::traffic::mcp_message(
+            kind,
+            "tools/call",
+            None,
+        )),
+    );
+}
+
+fn trace_correlation(trace_context: Option<&TraceContext>, session_id: Option<&str>) -> Value {
+    crate::gateway::traffic::correlation(
+        trace_context.map(|ctx| ctx.request_id.as_str()),
+        trace_context.map(|ctx| ctx.trace_id.as_str()),
+        session_id,
+    )
 }
 
 /// Forward a `prompts/get` to a backend via `GET /v1/prompts/{name}`.

--- a/crates/dcc-mcp-gateway/src/gateway/backend_client/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/backend_client/tests.rs
@@ -654,6 +654,7 @@ async fn forward_tools_call_propagates_trace_context_headers() {
             meta: None,
             request_id: None,
             trace_context: Some(&trace_context),
+            traffic_capture: None,
             timeout: Duration::from_secs(2),
         },
     )

--- a/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
@@ -284,6 +284,7 @@ pub async fn call_service(
             meta,
             request_id: None,
             trace_context,
+            traffic_capture: Some(&gs.traffic_capture),
             timeout: gs.backend_timeout,
         },
     )

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
@@ -401,6 +401,27 @@ async fn handle_tools_call(
     } else {
         ctx.args.clone()
     };
+    emit_mcp_traffic_frame(
+        gs,
+        &ctx,
+        headers,
+        McpTrafficFrame {
+            id: &id,
+            direction: "inbound",
+            leg: "client_to_gateway",
+            status: None,
+            body: json!({
+            "jsonrpc": req.jsonrpc.clone().unwrap_or_else(|| "2.0".to_string()),
+            "id": id.clone(),
+            "method": "tools/call",
+            "params": {
+                "name": tool,
+                "arguments": effective_args.clone(),
+                "_meta": meta.clone(),
+            },
+            }),
+        },
+    );
 
     // Phase 2: backend.execute span
     let dispatch_ns = std::time::SystemTime::now()
@@ -460,10 +481,73 @@ async fn handle_tools_call(
         pending.remove(id_str);
     }
 
-    json!({
+    let response = json!({
         "jsonrpc": "2.0", "id": id,
         "result": {"content": [{"type": "text", "text": final_text}], "isError": final_is_error}
-    })
+    });
+    emit_mcp_traffic_frame(
+        gs,
+        &ctx,
+        headers,
+        McpTrafficFrame {
+            id: response.get("id").unwrap_or(&Value::Null),
+            direction: "outbound",
+            leg: "gateway_to_client",
+            status: Some(200),
+            body: response.clone(),
+        },
+    );
+    response
+}
+
+struct McpTrafficFrame<'a> {
+    id: &'a Value,
+    direction: &'static str,
+    leg: &'static str,
+    status: Option<u16>,
+    body: Value,
+}
+
+fn emit_mcp_traffic_frame(
+    gs: &GatewayState,
+    ctx: &crate::gateway::middleware::CallContext,
+    headers: &HeaderMap,
+    frame: McpTrafficFrame<'_>,
+) {
+    gs.traffic_capture.emit_json_frame(
+        crate::gateway::traffic::TrafficFrame::json(
+            crate::gateway::traffic::gateway_source(
+                &gs.server_name,
+                &gs.server_version,
+                &gs.own_host,
+                gs.own_port,
+            ),
+            crate::gateway::traffic::correlation(
+                Some(&ctx.trace_context.request_id),
+                Some(&ctx.trace_context.trace_id),
+                ctx.session_id.as_deref(),
+            ),
+            frame.direction,
+            frame.leg,
+            "http",
+            frame.body,
+        )
+        .with_session_id(ctx.session_id.as_deref())
+        .with_http(crate::gateway::traffic::http_post(
+            "/mcp",
+            Some(headers),
+            frame.status,
+        ))
+        .with_mcp(crate::gateway::traffic::mcp_message(
+            if frame.direction == "inbound" {
+                "request"
+            } else {
+                "response"
+            },
+            "tools/call",
+            Some(frame.id.clone()),
+        )),
+    );
 }
 
 /// `prompts/list` — fan out to every live backend, namespace entries by

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/resources.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/resources.rs
@@ -289,6 +289,7 @@ mod tests {
             instance_diagnostics: Arc::new(
                 crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
             ),
+            traffic_capture: Arc::new(crate::gateway::traffic::TrafficCapture::disabled()),
             debug_routes_enabled: false,
             #[cfg(feature = "prometheus")]
             gateway_metrics: Arc::new(crate::gateway::event_log::GatewayMetrics::new()),

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
@@ -642,6 +642,22 @@ async fn call_service_with_admin_trace(
     } else {
         ctx.args.clone()
     };
+    emit_rest_traffic_frame(
+        gs,
+        &ctx,
+        headers,
+        RestTrafficFrame {
+            path: method,
+            direction: "inbound",
+            leg: "client_to_gateway",
+            status: None,
+            body: json!({
+            "tool_slug": slug,
+            "arguments": effective_arguments.clone(),
+            "meta": meta.clone(),
+            }),
+        },
+    );
     let dispatch_ns = now_ns();
     let mut result = call_service(
         gs,
@@ -695,6 +711,19 @@ async fn call_service_with_admin_trace(
         return Err(ServiceError::new("middleware-error", err.to_string()));
     }
 
+    emit_rest_traffic_frame(
+        gs,
+        &ctx,
+        headers,
+        RestTrafficFrame {
+            path: method,
+            direction: "outbound",
+            leg: "gateway_to_client",
+            status: Some(if is_error { 502 } else { 200 }),
+            body: output_value,
+        },
+    );
+
     result
 }
 
@@ -732,6 +761,18 @@ async fn call_batch_with_admin_trace(
     }
 
     ctx.input_payload = Some(TracePayload::from_value(&ctx.args, MAX_INPUT_BYTES));
+    emit_rest_traffic_frame(
+        gs,
+        &ctx,
+        headers,
+        RestTrafficFrame {
+            path: "v1/call_batch",
+            direction: "inbound",
+            leg: "client_to_gateway",
+            status: None,
+            body: ctx.args.clone(),
+        },
+    );
 
     let dispatch_ns = now_ns();
     let result = crate::gateway::tools::gateway_call_batch_inner(
@@ -780,7 +821,70 @@ async fn call_batch_with_admin_trace(
         return Err(err.to_string());
     }
 
+    emit_rest_traffic_frame(
+        gs,
+        &ctx,
+        headers,
+        RestTrafficFrame {
+            path: "v1/call_batch",
+            direction: "outbound",
+            leg: "gateway_to_client",
+            status: Some(if is_error { 400 } else { 200 }),
+            body: output_value,
+        },
+    );
+
     result
+}
+
+struct RestTrafficFrame<'a> {
+    path: &'a str,
+    direction: &'static str,
+    leg: &'static str,
+    status: Option<u16>,
+    body: Value,
+}
+
+fn emit_rest_traffic_frame(
+    gs: &GatewayState,
+    ctx: &crate::gateway::middleware::CallContext,
+    headers: &HeaderMap,
+    frame: RestTrafficFrame<'_>,
+) {
+    gs.traffic_capture.emit_json_frame(
+        crate::gateway::traffic::TrafficFrame::json(
+            crate::gateway::traffic::gateway_source(
+                &gs.server_name,
+                &gs.server_version,
+                &gs.own_host,
+                gs.own_port,
+            ),
+            crate::gateway::traffic::correlation(
+                Some(&ctx.trace_context.request_id),
+                Some(&ctx.trace_context.trace_id),
+                ctx.session_id.as_deref(),
+            ),
+            frame.direction,
+            frame.leg,
+            "http",
+            frame.body,
+        )
+        .with_session_id(ctx.session_id.as_deref())
+        .with_http(crate::gateway::traffic::http_post(
+            frame.path,
+            Some(headers),
+            frame.status,
+        ))
+        .with_mcp(crate::gateway::traffic::mcp_message(
+            if frame.direction == "inbound" {
+                "request"
+            } else {
+                "response"
+            },
+            "tools/call",
+            None,
+        )),
+    );
 }
 
 fn session_id_from_headers(headers: &HeaderMap) -> Option<String> {
@@ -893,6 +997,7 @@ mod tests {
             instance_diagnostics: Arc::new(
                 crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
             ),
+            traffic_capture: Arc::new(crate::gateway::traffic::TrafficCapture::disabled()),
             debug_routes_enabled,
             #[cfg(feature = "prometheus")]
             gateway_metrics: Arc::new(crate::gateway::event_log::GatewayMetrics::new()),

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/sse_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/sse_impl.rs
@@ -186,6 +186,7 @@ mod tests {
             instance_diagnostics: Arc::new(
                 crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
             ),
+            traffic_capture: Arc::new(crate::gateway::traffic::TrafficCapture::disabled()),
             debug_routes_enabled: false,
         }
     }

--- a/crates/dcc-mcp-gateway/src/gateway/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/mod.rs
@@ -51,6 +51,7 @@ pub mod router;
 pub mod sse_subscriber;
 pub mod state;
 pub mod tools;
+pub mod traffic;
 
 pub use middleware::MiddlewareChain;
 

--- a/crates/dcc-mcp-gateway/src/gateway/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state.rs
@@ -242,6 +242,9 @@ pub struct GatewayState {
     /// Cached per-instance readiness + last call error (#1076).
     pub instance_diagnostics: Arc<InstanceDiagnosticsStore>,
 
+    /// Opt-in development traffic capture (RFC 0003 P0).
+    pub traffic_capture: Arc<super::traffic::TrafficCapture>,
+
     /// Whether stable gateway `/v1/debug/*` routes are mounted on this router.
     ///
     /// The routes require the `admin` feature at compile time and an AdminState

--- a/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
@@ -51,6 +51,7 @@ fn test_gateway_state_with_own_and_unknown(
         instance_diagnostics: Arc::new(
             crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
         ),
+        traffic_capture: Arc::new(crate::gateway::traffic::TrafficCapture::disabled()),
         debug_routes_enabled: false,
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/tasks.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tasks.rs
@@ -554,6 +554,10 @@ pub(crate) async fn start_gateway_tasks(
     // below reassigns `gw_state.middleware_chain`, so `mut` is required.
     let instance_diagnostics =
         Arc::new(crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new());
+    let traffic_capture = Arc::new(crate::gateway::traffic::TrafficCapture::from_env()?);
+    if traffic_capture.is_enabled() {
+        tracing::info!("Gateway traffic capture enabled");
+    }
 
     #[cfg_attr(not(feature = "admin"), allow(unused_mut))]
     let mut gw_state = GatewayState {
@@ -582,6 +586,7 @@ pub(crate) async fn start_gateway_tasks(
         gateway_metrics: gateway_metrics.clone(),
         middleware_chain: Arc::new(middleware_chain),
         instance_diagnostics: instance_diagnostics.clone(),
+        traffic_capture,
         debug_routes_enabled: false,
     };
 

--- a/crates/dcc-mcp-gateway/src/gateway/traffic.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/traffic.rs
@@ -1,0 +1,357 @@
+//! Opt-in traffic capture for gateway debugging (RFC 0003 P0).
+//!
+//! Capture is disabled unless `DCC_MCP_TRAFFIC_CAPTURE=jsonl:<path>` is set.
+//! Frames are emitted on the shared `traffic.frame` event name and the quick
+//! mode JSONL sink appends the structured EventBus envelope to disk.
+
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use dcc_mcp_actions::EventBus;
+use dcc_mcp_actions::events::EventEnvelope;
+use http::HeaderMap;
+use serde_json::{Map, Value, json};
+
+pub const TRAFFIC_FRAME_EVENT: &str = "traffic.frame";
+pub const TRAFFIC_FRAME_SCHEMA_VERSION: u32 = 1;
+const ENV_CAPTURE: &str = "DCC_MCP_TRAFFIC_CAPTURE";
+const ENV_PROD_PROFILE: &str = "DCC_MCP_PROD_PROFILE";
+const ENV_FORCE_CAPTURE: &str = "DCC_MCP_FORCE_TRAFFIC_CAPTURE";
+
+/// Gateway traffic capture bus plus optional sinks.
+#[derive(Debug)]
+pub struct TrafficCapture {
+    event_bus: EventBus,
+    jsonl_sink: Option<Arc<JsonlTrafficSink>>,
+    next_capture_id: AtomicU64,
+}
+
+impl Default for TrafficCapture {
+    fn default() -> Self {
+        Self::disabled()
+    }
+}
+
+impl TrafficCapture {
+    #[must_use]
+    pub fn disabled() -> Self {
+        Self {
+            event_bus: EventBus::new(),
+            jsonl_sink: None,
+            next_capture_id: AtomicU64::new(0),
+        }
+    }
+
+    pub fn from_env() -> Result<Self, TrafficCaptureError> {
+        let spec = match std::env::var(ENV_CAPTURE) {
+            Ok(raw) if capture_enabled(&raw) => raw,
+            _ => return Ok(Self::disabled()),
+        };
+
+        if truthy_env(ENV_PROD_PROFILE) && !truthy_env(ENV_FORCE_CAPTURE) {
+            return Err(TrafficCaptureError::ProdProfileBlocked);
+        }
+
+        let Some(path) = spec.strip_prefix("jsonl:").map(str::trim) else {
+            return Err(TrafficCaptureError::UnsupportedSpec(spec));
+        };
+        if path.is_empty() {
+            return Err(TrafficCaptureError::EmptyPath);
+        }
+        Self::with_jsonl_sink(path)
+    }
+
+    pub fn with_jsonl_sink(path: impl AsRef<Path>) -> Result<Self, TrafficCaptureError> {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+            std::fs::create_dir_all(parent)?;
+        }
+        Ok(Self {
+            event_bus: EventBus::new(),
+            jsonl_sink: Some(Arc::new(JsonlTrafficSink::open(path)?)),
+            next_capture_id: AtomicU64::new(0),
+        })
+    }
+
+    #[must_use]
+    pub fn is_enabled(&self) -> bool {
+        self.jsonl_sink.is_some() || self.event_bus.has_subscribers(TRAFFIC_FRAME_EVENT)
+    }
+
+    pub fn emit_json_frame(&self, frame: TrafficFrame) -> Option<EventEnvelope> {
+        if !self.is_enabled() {
+            return None;
+        }
+
+        let body_size = serialized_size(&frame.body);
+        let attributes = json!({
+            "schema_version": TRAFFIC_FRAME_SCHEMA_VERSION,
+            "capture_id": self.next_frame_id(),
+            "session_id": frame.session_id,
+            "direction": frame.direction,
+            "leg": frame.leg,
+            "transport": frame.transport,
+            "http": frame.http,
+            "mcp": frame.mcp,
+            "body": {
+                "encoding": "json",
+                "data": frame.body,
+                "size_bytes": body_size,
+                "redacted_paths": [],
+            },
+        });
+
+        let event = self.event_bus.emit(
+            TRAFFIC_FRAME_EVENT,
+            frame.source,
+            frame.correlation,
+            attributes,
+        );
+        if let Some(sink) = &self.jsonl_sink {
+            sink.record(&event);
+        }
+        Some(event)
+    }
+
+    fn next_frame_id(&self) -> String {
+        let seq = self.next_capture_id.fetch_add(1, Ordering::Relaxed) + 1;
+        format!("cap_{seq:016x}")
+    }
+}
+
+/// One structured traffic frame before EventBus envelope wrapping.
+#[derive(Debug)]
+pub struct TrafficFrame {
+    pub source: Value,
+    pub correlation: Value,
+    pub session_id: Option<String>,
+    pub direction: &'static str,
+    pub leg: &'static str,
+    pub transport: &'static str,
+    pub http: Value,
+    pub mcp: Value,
+    pub body: Value,
+}
+
+impl TrafficFrame {
+    #[must_use]
+    pub fn json(
+        source: Value,
+        correlation: Value,
+        direction: &'static str,
+        leg: &'static str,
+        transport: &'static str,
+        body: Value,
+    ) -> Self {
+        Self {
+            source,
+            correlation,
+            session_id: None,
+            direction,
+            leg,
+            transport,
+            http: json!({}),
+            mcp: json!({}),
+            body,
+        }
+    }
+
+    #[must_use]
+    pub fn with_session_id(mut self, session_id: Option<impl Into<String>>) -> Self {
+        self.session_id = session_id.map(Into::into);
+        self
+    }
+
+    #[must_use]
+    pub fn with_http(mut self, http: Value) -> Self {
+        self.http = http;
+        self
+    }
+
+    #[must_use]
+    pub fn with_mcp(mut self, mcp: Value) -> Self {
+        self.mcp = mcp;
+        self
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TrafficCaptureError {
+    #[error(
+        "traffic capture is blocked when DCC_MCP_PROD_PROFILE is enabled; set DCC_MCP_FORCE_TRAFFIC_CAPTURE=1 to override"
+    )]
+    ProdProfileBlocked,
+    #[error("unsupported DCC_MCP_TRAFFIC_CAPTURE value: {0}; expected jsonl:<path>")]
+    UnsupportedSpec(String),
+    #[error("DCC_MCP_TRAFFIC_CAPTURE=jsonl:<path> requires a non-empty path")]
+    EmptyPath,
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+#[derive(Debug)]
+struct JsonlTrafficSink {
+    file: Mutex<File>,
+}
+
+impl JsonlTrafficSink {
+    fn open(path: &Path) -> Result<Self, std::io::Error> {
+        let file = OpenOptions::new().create(true).append(true).open(path)?;
+        Ok(Self {
+            file: Mutex::new(file),
+        })
+    }
+
+    fn record(&self, event: &EventEnvelope) {
+        let Ok(mut line) = serde_json::to_vec(&event.to_value()) else {
+            tracing::warn!("traffic capture: failed to encode EventBus envelope");
+            return;
+        };
+        line.push(b'\n');
+
+        let Ok(mut file) = self.file.lock() else {
+            tracing::warn!("traffic capture: JSONL sink lock poisoned");
+            return;
+        };
+        if let Err(err) = file.write_all(&line).and_then(|_| file.flush()) {
+            tracing::warn!(error = %err, "traffic capture: failed to write JSONL frame");
+        }
+    }
+}
+
+#[must_use]
+pub fn gateway_source(server_name: &str, server_version: &str, host: &str, port: u16) -> Value {
+    json!({
+        "service": "dcc-mcp-gateway",
+        "server_name": server_name,
+        "server_version": server_version,
+        "host": host,
+        "port": port,
+    })
+}
+
+#[must_use]
+pub fn basic_gateway_source() -> Value {
+    json!({"service": "dcc-mcp-gateway"})
+}
+
+#[must_use]
+pub fn correlation(
+    request_id: Option<&str>,
+    trace_id: Option<&str>,
+    session_id: Option<&str>,
+) -> Value {
+    let mut map = Map::new();
+    if let Some(value) = request_id.filter(|s| !s.is_empty()) {
+        map.insert("request_id".to_string(), Value::String(value.to_string()));
+    }
+    if let Some(value) = trace_id.filter(|s| !s.is_empty()) {
+        map.insert("trace_id".to_string(), Value::String(value.to_string()));
+    }
+    if let Some(value) = session_id.filter(|s| !s.is_empty()) {
+        map.insert("session_id".to_string(), Value::String(value.to_string()));
+    }
+    Value::Object(map)
+}
+
+#[must_use]
+pub fn http_post(path: &str, headers: Option<&HeaderMap>, status: Option<u16>) -> Value {
+    json!({
+        "method": "POST",
+        "url": path,
+        "headers": headers.map(safe_headers).unwrap_or_else(|| json!({})),
+        "status": status,
+    })
+}
+
+#[must_use]
+pub fn mcp_message(kind: &str, method: &str, id: Option<Value>) -> Value {
+    json!({
+        "kind": kind,
+        "method": method,
+        "id": id,
+    })
+}
+
+fn safe_headers(headers: &HeaderMap) -> Value {
+    let mut out = Map::new();
+    for name in [
+        "accept",
+        "content-type",
+        "mcp-session-id",
+        "traceparent",
+        "tracestate",
+        "user-agent",
+        "x-dcc-mcp-session-id",
+        "x-request-id",
+        "x-session-id",
+    ] {
+        if let Some(value) = headers.get(name).and_then(|v| v.to_str().ok()) {
+            out.insert(name.to_string(), Value::String(value.to_string()));
+        }
+    }
+    Value::Object(out)
+}
+
+fn serialized_size(value: &Value) -> usize {
+    serde_json::to_vec(value)
+        .map(|bytes| bytes.len())
+        .unwrap_or(0)
+}
+
+fn capture_enabled(value: &str) -> bool {
+    let trimmed = value.trim();
+    !trimmed.is_empty()
+        && !matches!(
+            trimmed.to_ascii_lowercase().as_str(),
+            "0" | "false" | "off" | "none"
+        )
+}
+
+fn truthy_env(name: &str) -> bool {
+    std::env::var(name)
+        .ok()
+        .is_some_and(|value| matches!(value.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn jsonl_sink_writes_traffic_frame_envelope() {
+        let dir = tempfile::tempdir().unwrap();
+        let path: PathBuf = dir.path().join("capture.jsonl");
+        let capture = TrafficCapture::with_jsonl_sink(&path).unwrap();
+
+        capture.emit_json_frame(
+            TrafficFrame::json(
+                basic_gateway_source(),
+                correlation(Some("req-1"), Some("trace-1"), Some("sess-1")),
+                "inbound",
+                "client_to_gateway",
+                "http",
+                json!({"hello": "world"}),
+            )
+            .with_session_id(Some("sess-1"))
+            .with_http(http_post("/mcp", None, Some(200)))
+            .with_mcp(mcp_message("request", "tools/call", Some(json!(1)))),
+        );
+
+        let raw = std::fs::read_to_string(path).unwrap();
+        let lines: Vec<_> = raw.lines().collect();
+        assert_eq!(lines.len(), 1);
+        let value: Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(value["name"], TRAFFIC_FRAME_EVENT);
+        assert_eq!(value["correlation"]["request_id"], "req-1");
+        assert_eq!(value["attributes"]["schema_version"], 1);
+        assert_eq!(value["attributes"]["capture_id"], "cap_0000000000000001");
+        assert_eq!(value["attributes"]["direction"], "inbound");
+        assert_eq!(value["attributes"]["body"]["data"]["hello"], "world");
+    }
+}

--- a/docs/guide/events.md
+++ b/docs/guide/events.md
@@ -72,6 +72,7 @@ present:
 | `skill.loaded` | A skill loaded and registered its tools |
 | `skill.unloaded` | A loaded skill was unloaded and its tools were removed |
 | `skill.validation_failed` | A skill could not load because it was missing, had dependency issues, or failed setup validation |
+| `traffic.frame` | Opt-in gateway traffic capture frame for MCP/REST debugging |
 
 Tool lifecycle attributes include `tool_slug`, `tool_name`, `duration_ms`,
 `result_success` on terminal events, and metadata such as `dcc_type`,
@@ -82,6 +83,31 @@ otherwise handler success defaults to `true`.
 Skill lifecycle attributes include `skill_name`, `dcc_type`, `version`,
 `skill_path`, declared/registered tool counts, registered tool names, and
 failure details such as `error_kind` and `error_message`.
+
+## Gateway Traffic Capture
+
+RFC 0003 P0 adds an opt-in `traffic.frame` stream for local debugging. It is
+off by default. Enable the quick JSONL sink when starting a gateway:
+
+```bash
+DCC_MCP_TRAFFIC_CAPTURE=jsonl:./capture.jsonl dcc-mcp-server ...
+```
+
+Each JSONL row is the structured EventBus envelope. The frame payload lives in
+`attributes` and includes `capture_id`, `direction`, `leg`, `transport`, safe
+HTTP metadata, MCP method/id metadata, and a JSON body with `size_bytes`.
+Current P0 frames cover `tools/call` traffic at these gateway boundaries:
+
+| Leg | Meaning |
+|-----|---------|
+| `client_to_gateway` | MCP `/mcp` or REST `/v1/call` request entering the gateway |
+| `gateway_to_client` | Gateway response leaving through MCP or REST |
+| `gateway_to_adapter` | Gateway forwarding a backend `POST /v1/call` |
+| `adapter_to_gateway` | Backend response or transport error observed by the gateway |
+
+Traffic capture may include scene paths, user prompts, and tool arguments. If
+`DCC_MCP_PROD_PROFILE=1`, the gateway refuses to enable capture unless
+`DCC_MCP_FORCE_TRAFFIC_CAPTURE=1` is also set.
 
 ## Wildcard Subscriptions
 

--- a/docs/guide/gateway-diagnostics.md
+++ b/docs/guide/gateway-diagnostics.md
@@ -26,6 +26,26 @@ and the `/metrics` Prometheus export.
 
 ---
 
+## Traffic capture
+
+For local agent/skill debugging, start the gateway with:
+
+```bash
+DCC_MCP_TRAFFIC_CAPTURE=jsonl:./capture.jsonl dcc-mcp-server ...
+```
+
+The JSONL file receives `traffic.frame` EventBus envelopes for `tools/call`
+traffic through the gateway. P0 records MCP/REST client-to-gateway frames,
+gateway-to-client responses, and forwarded gateway-to-adapter `/v1/call`
+frames. Capture is intentionally off by default and is blocked when
+`DCC_MCP_PROD_PROFILE=1` unless `DCC_MCP_FORCE_TRAFFIC_CAPTURE=1` is also set.
+
+Because frames can contain prompts, tool arguments, scene paths, and result
+payloads, treat capture files like debugging artifacts, not production audit
+logs.
+
+---
+
 ## Election (three-tier comparison)
 
 Only one process can bind the gateway port at a time; the rest stand by.

--- a/skills/dcc-cli-gateway/SKILL.md
+++ b/skills/dcc-cli-gateway/SKILL.md
@@ -15,7 +15,7 @@ metadata:
   dcc-mcp:
     dcc: python
     layer: infrastructure
-    version: "0.17.24"  # x-release-please-version
+    version: "0.17.25"  # x-release-please-version
     search-hint: "cli gateway dcc-mcp-cli connect dcc instances search describe call clawhub"
     tags: "cli, gateway, infrastructure, clawhub, openclaw, instances"
   openclaw:

--- a/skills/dcc-mcp-skill-developer/SKILL.md
+++ b/skills/dcc-mcp-skill-developer/SKILL.md
@@ -73,6 +73,10 @@ into a faster authoring loop.
    needs programmatic lifecycle hooks: use `skill.*` events for load/unload
    visibility and `tool.*` events for dispatch/completion/failure metrics
    instead of scraping logs or wrapping every handler manually.
+   For local traffic debugging, prefer the gateway `traffic.frame` capture
+   stream (`DCC_MCP_TRAFFIC_CAPTURE=jsonl:<path>`) over ad-hoc print logging;
+   capture files can contain prompts, scene paths, and tool arguments, so keep
+   them as local debugging artifacts unless redaction has been applied.
 8. For adapter install, uninstall, or upgrade flows, use
    `dcc_mcp_core.install_lifecycle` before importing Rust-backed public API:
    query/stop registered sidecars, inspect install roots, classify locked

--- a/skills/dcc-rest-gateway/SKILL.md
+++ b/skills/dcc-rest-gateway/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   dcc-mcp:
     dcc: python
     layer: infrastructure
-    version: "0.17.24"  # x-release-please-version
+    version: "0.17.25"  # x-release-please-version
     search-hint: "rest api, gateway, http, no mcp, instances, dcc control, clawhub"
     tags: "rest, gateway, infrastructure, clawhub, openclaw, instances"
   openclaw:

--- a/tests/test_dcc_cli_gateway_skill.py
+++ b/tests/test_dcc_cli_gateway_skill.py
@@ -13,6 +13,7 @@ import dcc_mcp_core
 
 DCC_CLI_GATEWAY_DIR = str(REPO_ROOT / "skills" / "dcc-cli-gateway")
 CHECK_SCRIPT = Path(DCC_CLI_GATEWAY_DIR) / "scripts" / "check_cli.py"
+RELEASE_MANIFEST = REPO_ROOT / ".release-please-manifest.json"
 
 sys.path.insert(0, str(CHECK_SCRIPT.parent))
 import check_cli as check_cli_mod  # noqa: E402
@@ -29,7 +30,8 @@ class TestDccCliGatewaySkill:
         meta = dcc_mcp_core.parse_skill_md(DCC_CLI_GATEWAY_DIR)
         assert meta is not None
         assert meta.name == "dcc-cli-gateway"
-        assert meta.version == "1.0.0"
+        release_version = json.loads(RELEASE_MANIFEST.read_text(encoding="utf-8"))["."]
+        assert meta.version == release_version
 
     def test_validate_skill_clean(self) -> None:
         report = dcc_mcp_core.validate_skill(DCC_CLI_GATEWAY_DIR)

--- a/tests/test_dcc_rest_gateway_skill.py
+++ b/tests/test_dcc_rest_gateway_skill.py
@@ -13,6 +13,7 @@ import dcc_mcp_core
 
 DCC_REST_GATEWAY_DIR = str(REPO_ROOT / "skills" / "dcc-rest-gateway")
 CHECK_SCRIPT = Path(DCC_REST_GATEWAY_DIR) / "scripts" / "check_gateway.py"
+RELEASE_MANIFEST = REPO_ROOT / ".release-please-manifest.json"
 
 # Import probe from skill script (stdlib-only; safe on all platforms).
 sys.path.insert(0, str(CHECK_SCRIPT.parent))
@@ -29,7 +30,8 @@ class TestDccRestGatewaySkill:
         meta = dcc_mcp_core.parse_skill_md(DCC_REST_GATEWAY_DIR)
         assert meta is not None
         assert meta.name == "dcc-rest-gateway"
-        assert meta.version == "1.0.0"
+        release_version = json.loads(RELEASE_MANIFEST.read_text(encoding="utf-8"))["."]
+        assert meta.version == release_version
 
     def test_validate_skill_clean(self) -> None:
         report = dcc_mcp_core.validate_skill(DCC_REST_GATEWAY_DIR)


### PR DESCRIPTION
## Summary
- add opt-in gateway traffic capture that emits `traffic.frame` EventBus envelopes
- support `DCC_MCP_TRAFFIC_CAPTURE=jsonl:<path>` quick mode with a production-profile guard
- record tools/call frames at the client/gateway and gateway/adapter boundaries
- sync published gateway skill metadata with the release manifest and make those tests version-driven
- document capture usage and update skill developer guidance

## Validation
- `vx cargo fmt --check -p dcc-mcp-gateway`
- `vx cargo clippy -p dcc-mcp-gateway --all-targets --all-features -- -D warnings`
- `$env:DCC_MCP_ADMIN_UI_PREBUILT='1'; vx cargo run --bin stub_gen --features stub-gen`
- `vx cargo test -p dcc-mcp-gateway traffic -- --nocapture`
- `vx cargo test -p dcc-mcp-gateway --lib -- --nocapture`
- `vx ruff check tests\test_dcc_cli_gateway_skill.py tests\test_dcc_rest_gateway_skill.py`
- `vx ruff format --check tests\test_dcc_cli_gateway_skill.py tests\test_dcc_rest_gateway_skill.py`
- `$env:DCC_MCP_ADMIN_UI_PREBUILT='1'; vx just dev`
- `.\.venv\Scripts\python.exe -m pytest tests\test_clawhub_sync.py::TestClawhubSync::test_clawhub_skill_versions_follow_release_please tests\test_dcc_cli_gateway_skill.py::TestDccCliGatewaySkill::test_parse_skill_md tests\test_dcc_rest_gateway_skill.py::TestDccRestGatewaySkill::test_parse_skill_md -q`
- `vx cargo hakari generate` (no changes detected)

Refs #1116