### PR TITLE
feat: add event bus veto hooks

### DIFF
--- a/crates/dcc-mcp-actions/src/dispatcher.rs
+++ b/crates/dcc-mcp-actions/src/dispatcher.rs
@@ -54,7 +54,7 @@ use serde_json::{Map, Value, json};
 
 use dcc_mcp_models::ThreadAffinity;
 
-use crate::events::EventBus;
+use crate::events::{EventBus, EventVeto};
 use crate::registry::{ToolMeta, ToolRegistry};
 use crate::validation_strategy::select_strategy;
 
@@ -108,6 +108,12 @@ pub enum DispatchError {
         declared: ThreadAffinity,
         actual: ThreadAffinity,
     },
+    /// A registered before hook vetoed the action before handler execution.
+    Vetoed {
+        action: String,
+        code: String,
+        reason: String,
+    },
 }
 
 impl std::fmt::Display for DispatchError {
@@ -130,6 +136,14 @@ impl std::fmt::Display for DispatchError {
             } => write!(
                 f,
                 "THREAD_AFFINITY_VIOLATION: action '{action}' declared thread_affinity={declared} but ran on {actual}"
+            ),
+            Self::Vetoed {
+                action,
+                code,
+                reason,
+            } => write!(
+                f,
+                "EVENT_VETOED: action '{action}' was vetoed ({code}): {reason}"
             ),
         }
     }
@@ -366,8 +380,8 @@ impl ToolDispatcher {
         };
 
         // 4. Call handler.
-        if emit_events {
-            self.emit_tool_event(
+        if emit_events
+            && let Err(veto) = self.emit_vetoable_tool_event(
                 "tool.dispatched",
                 action_name,
                 meta_opt.as_ref(),
@@ -375,7 +389,15 @@ impl ToolDispatcher {
                 json!({
                     "validation_skipped": outcome.skipped,
                 }),
-            );
+            )
+        {
+            let err = DispatchError::Vetoed {
+                action: action_name.to_string(),
+                code: veto.code,
+                reason: veto.reason,
+            };
+            self.emit_tool_failed(action_name, meta_opt.as_ref(), &err, started);
+            return Err(err);
         }
 
         let output = match handler(params) {
@@ -417,17 +439,40 @@ impl ToolDispatcher {
         err: &DispatchError,
         started: Instant,
     ) {
+        let mut attributes = Map::new();
+        attributes.insert("result_success".to_string(), json!(false));
+        attributes.insert("error_kind".to_string(), json!(dispatch_error_kind(err)));
+        attributes.insert("error_message".to_string(), json!(err.to_string()));
+        if let DispatchError::Vetoed { code, reason, .. } = err {
+            attributes.insert("veto_code".to_string(), json!(code));
+            attributes.insert("veto_reason".to_string(), json!(reason));
+        }
         self.emit_tool_event(
             "tool.failed",
             action_name,
             meta,
             started,
-            json!({
-                "result_success": false,
-                "error_kind": dispatch_error_kind(err),
-                "error_message": err.to_string(),
-            }),
+            Value::Object(attributes),
         );
+    }
+
+    fn emit_vetoable_tool_event(
+        &self,
+        event_name: &str,
+        action_name: &str,
+        meta: Option<&ToolMeta>,
+        started: Instant,
+        attributes: Value,
+    ) -> Result<(), EventVeto> {
+        let (source, attributes) = tool_event_payload(action_name, meta, started, attributes);
+        let event = self.event_bus.before_event(
+            event_name,
+            source,
+            Value::Object(Map::new()),
+            attributes,
+        )?;
+        self.event_bus.publish_event(&event);
+        Ok(())
     }
 
     fn emit_tool_event(
@@ -442,38 +487,11 @@ impl ToolDispatcher {
             return;
         }
 
-        let mut source = Map::new();
-        let mut attrs = attributes.as_object().cloned().unwrap_or_default();
-        attrs.insert("tool_slug".to_string(), json!(action_name));
-        attrs.insert("tool_name".to_string(), json!(action_name));
-        attrs.insert(
-            "duration_ms".to_string(),
-            json!(u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX)),
-        );
+        let (source, attributes) = tool_event_payload(action_name, meta, started, attributes);
 
-        if let Some(meta) = meta {
-            if !meta.dcc.is_empty() {
-                source.insert("dcc_type".to_string(), json!(meta.dcc));
-                attrs.insert("dcc_type".to_string(), json!(meta.dcc));
-            }
-            if let Some(skill_name) = &meta.skill_name {
-                attrs.insert("skill_name".to_string(), json!(skill_name));
-            }
-            if !meta.group.is_empty() {
-                attrs.insert("group".to_string(), json!(meta.group));
-            }
-            attrs.insert(
-                "annotations".to_string(),
-                serde_json::to_value(&meta.annotations).unwrap_or(Value::Null),
-            );
-        }
-
-        let _ = self.event_bus.emit(
-            event_name,
-            Value::Object(source),
-            Value::Object(Map::new()),
-            Value::Object(attrs),
-        );
+        let _ = self
+            .event_bus
+            .emit(event_name, source, Value::Object(Map::new()), attributes);
     }
 
     /// Access the underlying registry.
@@ -491,6 +509,7 @@ pub(crate) fn dispatch_error_kind(err: &DispatchError) -> &'static str {
         DispatchError::HandlerError(_) => "handler_error",
         DispatchError::ActionDisabled { .. } => "action_disabled",
         DispatchError::ThreadAffinityViolation { .. } => "thread_affinity_violation",
+        DispatchError::Vetoed { .. } => "event_vetoed",
     }
 }
 
@@ -499,6 +518,41 @@ fn tool_result_success(output: &Value) -> bool {
         .get("success")
         .and_then(Value::as_bool)
         .unwrap_or(true)
+}
+
+pub(crate) fn tool_event_payload(
+    action_name: &str,
+    meta: Option<&ToolMeta>,
+    started: Instant,
+    attributes: Value,
+) -> (Value, Value) {
+    let mut source = Map::new();
+    let mut attrs = attributes.as_object().cloned().unwrap_or_default();
+    attrs.insert("tool_slug".to_string(), json!(action_name));
+    attrs.insert("tool_name".to_string(), json!(action_name));
+    attrs.insert(
+        "duration_ms".to_string(),
+        json!(u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX)),
+    );
+
+    if let Some(meta) = meta {
+        if !meta.dcc.is_empty() {
+            source.insert("dcc_type".to_string(), json!(meta.dcc));
+            attrs.insert("dcc_type".to_string(), json!(meta.dcc));
+        }
+        if let Some(skill_name) = &meta.skill_name {
+            attrs.insert("skill_name".to_string(), json!(skill_name));
+        }
+        if !meta.group.is_empty() {
+            attrs.insert("group".to_string(), json!(meta.group));
+        }
+        attrs.insert(
+            "annotations".to_string(),
+            serde_json::to_value(&meta.annotations).unwrap_or(Value::Null),
+        );
+    }
+
+    (Value::Object(source), Value::Object(attrs))
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -654,6 +708,63 @@ mod tests {
         assert_eq!(events[0].1["dcc_type"], "maya");
         assert_eq!(events[1].0, "tool.completed");
         assert_eq!(events[1].1["result_success"], true);
+    }
+
+    #[cfg(not(feature = "python-bindings"))]
+    #[test]
+    fn test_dispatch_before_hook_veto_blocks_handler() {
+        let reg = ToolRegistry::new();
+        reg.register_action(ToolMeta {
+            name: "delete_scene".into(),
+            dcc: "maya".into(),
+            skill_name: Some("maya-danger".into()),
+            ..Default::default()
+        });
+        let dispatcher = ToolDispatcher::new(reg);
+        let handler_called = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let handler_called_clone = Arc::clone(&handler_called);
+        dispatcher.register_handler("delete_scene", move |_| {
+            handler_called_clone.store(true, std::sync::atomic::Ordering::Relaxed);
+            Ok(json!({"deleted": true}))
+        });
+
+        let events = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let captured = Arc::clone(&events);
+        let _id = dispatcher
+            .event_bus()
+            .subscribe_event("tool.*".to_string(), move |event| {
+                captured
+                    .lock()
+                    .unwrap()
+                    .push((event.name.clone(), event.attributes.clone()));
+            });
+        let _before = dispatcher
+            .event_bus()
+            .before("tool.dispatched".to_string(), |event| {
+                assert_eq!(event.attributes["tool_slug"], "delete_scene");
+                Some(crate::events::EventVeto::with_code(
+                    "policy_denied",
+                    "destructive tools are disabled",
+                ))
+            })
+            .unwrap();
+
+        let err = dispatcher.dispatch("delete_scene", json!({})).unwrap_err();
+
+        assert!(matches!(
+            err,
+            DispatchError::Vetoed {
+                ref action,
+                ref code,
+                ..
+            } if action == "delete_scene" && code == "policy_denied"
+        ));
+        assert!(!handler_called.load(std::sync::atomic::Ordering::Relaxed));
+        let events = events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, "tool.failed");
+        assert_eq!(events[0].1["error_kind"], "event_vetoed");
+        assert_eq!(events[0].1["veto_code"], "policy_denied");
     }
 
     #[cfg(not(feature = "python-bindings"))]

--- a/crates/dcc-mcp-actions/src/events.rs
+++ b/crates/dcc-mcp-actions/src/events.rs
@@ -19,6 +19,14 @@ use serde_json::{Map, Value};
 /// Current event envelope schema version.
 pub const EVENT_SCHEMA_VERSION: u32 = 1;
 
+/// Events that support `before` hooks and veto decisions.
+pub const VETOABLE_EVENTS: &[&str] = &[
+    "skill.loading",
+    "tool.dispatched",
+    "resource.subscribed",
+    "client.initialize",
+];
+
 /// Event subscriber ID for unsubscription.
 pub(crate) type SubscriberId = u64;
 
@@ -29,11 +37,21 @@ pub(crate) type SubscriberId = u64;
 #[cfg(not(feature = "python-bindings"))]
 type EventCallback = Arc<dyn Fn(&EventEnvelope) + Send + Sync>;
 
+/// Callback type for non-Python veto hooks.
+#[cfg(not(feature = "python-bindings"))]
+type BeforeCallback = Arc<dyn Fn(&EventEnvelope) -> Option<EventVeto> + Send + Sync>;
+
 /// Type alias for the subscriber storage map.
 #[cfg(feature = "python-bindings")]
 pub(crate) type SubscriberMap = Arc<DashMap<String, Vec<(SubscriberId, Py<PyAny>)>>>;
 #[cfg(not(feature = "python-bindings"))]
 type SubscriberMap = Arc<DashMap<String, Vec<(SubscriberId, EventCallback)>>>;
+
+/// Type alias for veto hook storage.
+#[cfg(feature = "python-bindings")]
+pub(crate) type BeforeSubscriberMap = Arc<DashMap<String, Vec<(SubscriberId, Py<PyAny>)>>>;
+#[cfg(not(feature = "python-bindings"))]
+type BeforeSubscriberMap = Arc<DashMap<String, Vec<(SubscriberId, BeforeCallback)>>>;
 
 /// Thread-safe event bus.
 #[cfg_attr(feature = "stub-gen", gen_stub_pyclass)]
@@ -46,6 +64,7 @@ pub struct EventBus {
     pub(crate) next_id: Arc<AtomicU64>,
     pub(crate) next_event_id: Arc<AtomicU64>,
     pub(crate) subscribers: SubscriberMap,
+    pub(crate) before_subscribers: BeforeSubscriberMap,
 }
 
 /// Structured event envelope shared by in-process subscribers and future webhooks.
@@ -86,6 +105,38 @@ impl EventEnvelope {
     }
 }
 
+/// A veto decision returned by an EventBus `before` hook.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EventVeto {
+    pub code: String,
+    pub reason: String,
+}
+
+impl EventVeto {
+    #[must_use]
+    pub fn new(reason: impl Into<String>) -> Self {
+        Self::with_code("vetoed", reason)
+    }
+
+    #[must_use]
+    pub fn with_code(code: impl Into<String>, reason: impl Into<String>) -> Self {
+        let code = code.into();
+        let reason = reason.into();
+        Self {
+            code: if code.trim().is_empty() {
+                "vetoed".to_string()
+            } else {
+                code
+            },
+            reason: if reason.trim().is_empty() {
+                "event vetoed".to_string()
+            } else {
+                reason
+            },
+        }
+    }
+}
+
 impl std::fmt::Debug for EventBus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EventBus")
@@ -95,6 +146,14 @@ impl std::fmt::Debug for EventBus {
                 "subscriber_events",
                 &self
                     .subscribers
+                    .iter()
+                    .map(|r| r.key().clone())
+                    .collect::<Vec<_>>(),
+            )
+            .field(
+                "before_events",
+                &self
+                    .before_subscribers
                     .iter()
                     .map(|r| r.key().clone())
                     .collect::<Vec<_>>(),
@@ -116,13 +175,22 @@ impl EventBus {
             next_id: Arc::new(AtomicU64::new(0)),
             next_event_id: Arc::new(AtomicU64::new(0)),
             subscribers: Arc::new(DashMap::new()),
+            before_subscribers: Arc::new(DashMap::new()),
         }
     }
 
     /// Get the count of all subscriptions.
     #[must_use]
     pub fn subscription_count(&self) -> usize {
-        self.subscribers.iter().map(|r| r.value().len()).sum()
+        self.subscribers
+            .iter()
+            .map(|r| r.value().len())
+            .sum::<usize>()
+            + self
+                .before_subscribers
+                .iter()
+                .map(|r| r.value().len())
+                .sum::<usize>()
     }
 
     /// Check if any subscribers exist for the given event.
@@ -133,6 +201,20 @@ impl EventBus {
         })
     }
 
+    /// Check if any veto hooks exist for the given event.
+    #[must_use]
+    pub fn has_before_subscribers(&self, event_name: &str) -> bool {
+        self.before_subscribers
+            .get(event_name)
+            .is_some_and(|entry| !entry.value().is_empty())
+    }
+
+    /// Check whether an event supports before/veto hooks.
+    #[must_use]
+    pub fn is_vetoable_event(event_name: &str) -> bool {
+        is_vetoable_event(event_name)
+    }
+
     /// Allocate a new subscriber ID (starts at 1, monotonically increasing).
     pub(crate) fn next_subscriber_id(&self) -> SubscriberId {
         self.next_id.fetch_add(1, Ordering::Relaxed) + 1
@@ -141,6 +223,20 @@ impl EventBus {
     /// Remove a subscriber by ID from a specific event (shared logic).
     pub(crate) fn remove_subscriber(&self, event_name: &str, subscriber_id: SubscriberId) -> bool {
         if let Some(mut subs) = self.subscribers.get_mut(event_name) {
+            let before = subs.len();
+            subs.retain(|(id, _)| *id != subscriber_id);
+            return subs.len() < before;
+        }
+        false
+    }
+
+    /// Remove a before hook by ID from a specific event.
+    pub(crate) fn remove_before_subscriber(
+        &self,
+        event_name: &str,
+        subscriber_id: SubscriberId,
+    ) -> bool {
+        if let Some(mut subs) = self.before_subscribers.get_mut(event_name) {
             let before = subs.len();
             subs.retain(|(id, _)| *id != subscriber_id);
             return subs.len() < before;
@@ -179,9 +275,36 @@ impl EventBus {
         event
     }
 
+    pub(crate) fn make_vetoable_event(
+        &self,
+        event_name: &str,
+        source: Value,
+        correlation: Value,
+        attributes: Value,
+    ) -> Result<EventEnvelope, EventVeto> {
+        ensure_vetoable_event(event_name)?;
+        Ok(self.make_event(event_name, source, correlation, attributes))
+    }
+
     fn next_event_id(&self) -> String {
         let seq = self.next_event_id.fetch_add(1, Ordering::Relaxed) + 1;
         format!("ev_{:x}_{:x}", timestamp_ns(), seq)
+    }
+}
+
+#[must_use]
+pub fn is_vetoable_event(event_name: &str) -> bool {
+    VETOABLE_EVENTS.contains(&event_name)
+}
+
+fn ensure_vetoable_event(event_name: &str) -> Result<(), EventVeto> {
+    if is_vetoable_event(event_name) {
+        Ok(())
+    } else {
+        Err(EventVeto::with_code(
+            "unsupported_veto_event",
+            format!("event '{event_name}' does not support before hooks"),
+        ))
     }
 }
 
@@ -247,6 +370,77 @@ impl EventBus {
     #[must_use]
     pub fn unsubscribe(&self, event_name: &str, subscriber_id: SubscriberId) -> bool {
         self.remove_subscriber(event_name, subscriber_id)
+    }
+
+    /// Register a veto hook for one of the whitelisted lifecycle events.
+    ///
+    /// The callback runs before the matching event is published. Returning
+    /// `Some(EventVeto)` rejects the operation; returning `None` allows it.
+    pub fn before<F>(&self, event_name: String, callback: F) -> Result<SubscriberId, EventVeto>
+    where
+        F: Fn(&EventEnvelope) -> Option<EventVeto> + Send + Sync + 'static,
+    {
+        ensure_vetoable_event(&event_name)?;
+        let id = self.next_subscriber_id();
+        self.before_subscribers
+            .entry(event_name)
+            .or_default()
+            .push((id, Arc::new(callback)));
+        Ok(id)
+    }
+
+    /// Remove a veto hook by subscriber ID.
+    #[must_use]
+    pub fn unsubscribe_before(&self, event_name: &str, subscriber_id: SubscriberId) -> bool {
+        self.remove_before_subscriber(event_name, subscriber_id)
+    }
+
+    /// Build a vetoable event, run matching before hooks, and return the event
+    /// for later publication when all hooks allow it.
+    pub fn before_event(
+        &self,
+        event_name: &str,
+        source: Value,
+        correlation: Value,
+        attributes: Value,
+    ) -> Result<EventEnvelope, EventVeto> {
+        let event = self.make_vetoable_event(event_name, source, correlation, attributes)?;
+        self.check_before_event(&event)?;
+        Ok(event)
+    }
+
+    /// Run before hooks against an existing event envelope.
+    pub fn check_before_event(&self, event: &EventEnvelope) -> Result<(), EventVeto> {
+        ensure_vetoable_event(&event.name)?;
+        let callbacks: Vec<_> = self
+            .before_subscribers
+            .get(&event.name)
+            .map(|entry| {
+                entry
+                    .value()
+                    .iter()
+                    .map(|(_, cb)| Clone::clone(cb))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        for callback in &callbacks {
+            match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| callback(event))) {
+                Ok(Some(veto)) => return Err(veto),
+                Ok(None) => {}
+                Err(e) => {
+                    let msg = e
+                        .downcast_ref::<&str>()
+                        .copied()
+                        .or_else(|| e.downcast_ref::<String>().map(|s| s.as_str()))
+                        .unwrap_or("unknown panic");
+                    return Err(EventVeto::with_code(
+                        "before_hook_panic",
+                        format!("before hook for '{}' panicked: {msg}", event.name),
+                    ));
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Publish an empty structured event, calling all matching subscribers.
@@ -393,6 +587,45 @@ mod tests {
             names.lock().unwrap().as_slice(),
             &["tool.completed".to_string()]
         );
+    }
+
+    #[test]
+    fn test_before_hook_rejects_non_vetoable_events() {
+        let bus = EventBus::new();
+        let err = bus
+            .before("tool.completed".to_string(), |_| None)
+            .expect_err("tool.completed is not vetoable");
+
+        assert_eq!(err.code, "unsupported_veto_event");
+        assert!(!bus.has_before_subscribers("tool.completed"));
+    }
+
+    #[test]
+    fn test_before_hook_veto_stops_event_before_publish() {
+        let bus = EventBus::new();
+        let called = Arc::new(AtomicU64::new(0));
+        let called_clone = Arc::clone(&called);
+        let _before = bus
+            .before("tool.dispatched".to_string(), move |event| {
+                called_clone.fetch_add(1, Ordering::Relaxed);
+                assert_eq!(event.attributes["tool_slug"], "maya_scene__open");
+                Some(EventVeto::with_code(
+                    "policy_denied",
+                    "scene-open tools are blocked in review mode",
+                ))
+            })
+            .unwrap();
+
+        let event = bus.before_event(
+            "tool.dispatched",
+            serde_json::json!({"dcc_type": "maya"}),
+            serde_json::json!({}),
+            serde_json::json!({"tool_slug": "maya_scene__open"}),
+        );
+
+        let veto = event.expect_err("before hook should veto");
+        assert_eq!(veto.code, "policy_denied");
+        assert_eq!(called.load(Ordering::Relaxed), 1);
     }
 
     #[test]

--- a/crates/dcc-mcp-actions/src/lib.rs
+++ b/crates/dcc-mcp-actions/src/lib.rs
@@ -20,7 +20,7 @@ pub use dispatcher::{
     DispatchError, DispatchResult, HandlerFn, ToolDispatcher, current_thread_affinity,
     with_thread_affinity,
 };
-pub use events::EventBus;
+pub use events::{EventBus, EventVeto, VETOABLE_EVENTS, is_vetoable_event};
 pub use pipeline::{
     ActionMiddleware, AuditMiddleware, AuditRecord, LoggingMiddleware, MiddlewareContext,
     RateLimitMiddleware, TimingMiddleware, ToolPipeline,

--- a/crates/dcc-mcp-actions/src/pipeline/python/pipeline.rs
+++ b/crates/dcc-mcp-actions/src/pipeline/python/pipeline.rs
@@ -281,7 +281,8 @@ impl PyToolPipeline {
                 Err(pyo3::exceptions::PyRuntimeError::new_err(msg))
             }
             Err(err @ DispatchError::ActionDisabled { .. })
-            | Err(err @ DispatchError::ThreadAffinityViolation { .. }) => Err(
+            | Err(err @ DispatchError::ThreadAffinityViolation { .. })
+            | Err(err @ DispatchError::Vetoed { .. }) => Err(
                 pyo3::exceptions::PyPermissionError::new_err(err.to_string()),
             ),
         }

--- a/crates/dcc-mcp-actions/src/python/events.rs
+++ b/crates/dcc-mcp-actions/src/python/events.rs
@@ -1,11 +1,15 @@
 //! PyO3 bindings for `EventBus`.
 
 use pyo3::prelude::*;
+use pyo3::types::PyDict;
 #[cfg(feature = "stub-gen")]
 use pyo3_stub_gen_derive::gen_stub_pymethods;
 use serde_json::{Map, Value};
 
-use crate::events::{EventBus, EventEnvelope, SubscriberId, subscription_matches};
+use crate::events::{
+    EventBus, EventEnvelope, EventVeto, SubscriberId, VETOABLE_EVENTS, is_vetoable_event,
+    subscription_matches,
+};
 
 impl EventBus {
     fn matching_callbacks(&self, py: Python<'_>, event_name: &str) -> Vec<Py<PyAny>> {
@@ -20,6 +24,75 @@ impl EventBus {
                     .collect::<Vec<_>>()
             })
             .collect()
+    }
+
+    fn matching_before_callbacks(&self, py: Python<'_>, event_name: &str) -> Vec<Py<PyAny>> {
+        self.before_subscribers
+            .get(event_name)
+            .map(|entry| {
+                entry
+                    .value()
+                    .iter()
+                    .map(|(_, cb)| cb.clone_ref(py))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Build a vetoable event, run Python before hooks, and return the event
+    /// for later publication when all hooks allow it.
+    pub fn before_event(
+        &self,
+        event_name: &str,
+        source: Value,
+        correlation: Value,
+        attributes: Value,
+    ) -> Result<EventEnvelope, EventVeto> {
+        let event = self.make_vetoable_event(event_name, source, correlation, attributes)?;
+        if !self.has_before_subscribers(event_name) {
+            return Ok(event);
+        }
+
+        let Some(result) = Python::try_attach(|py| {
+            let callbacks = self.matching_before_callbacks(py, &event.name);
+            if callbacks.is_empty() {
+                return Ok(());
+            }
+            let event_value = event.to_value();
+            let py_event = dcc_mcp_pybridge::py_json::json_value_to_pyobject(py, &event_value)
+                .map_err(|err| {
+                    EventVeto::with_code(
+                        "before_hook_error",
+                        format!(
+                            "failed to convert event '{}' for before hooks: {err}",
+                            event.name
+                        ),
+                    )
+                })?;
+
+            for callback in &callbacks {
+                let result = callback
+                    .call1(py, (py_event.clone_ref(py),))
+                    .map_err(|err| {
+                        EventVeto::with_code(
+                            "before_hook_error",
+                            format!("before hook for '{}' raised: {err}", event.name),
+                        )
+                    })?;
+                if let Some(veto) = veto_from_py_result(py, result)? {
+                    return Err(veto);
+                }
+            }
+            Ok(())
+        }) else {
+            return Err(EventVeto::with_code(
+                "before_hook_unavailable",
+                format!("Python is not attached; cannot evaluate before hooks for '{event_name}'"),
+            ));
+        };
+
+        result?;
+        Ok(event)
     }
 
     /// Publish a structured event envelope to Python subscribers.
@@ -76,10 +149,51 @@ impl EventBus {
         id
     }
 
+    /// Register a before hook for a vetoable event.
+    ///
+    /// The callback receives the structured event envelope. Return ``None`` or
+    /// ``False`` to allow the operation, or return ``EventBus.veto(...)``, a
+    /// ``{"reason": "...", "code": "..."}`` dict, or a string reason to veto.
+    fn before(&self, event_name: String, callback: Py<PyAny>) -> PyResult<SubscriberId> {
+        if !is_vetoable_event(&event_name) {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "event '{event_name}' does not support before hooks"
+            )));
+        }
+        let id = self.next_subscriber_id();
+        self.before_subscribers
+            .entry(event_name)
+            .or_default()
+            .push((id, callback));
+        Ok(id)
+    }
+
     /// Unsubscribe from an event by subscriber ID.
     #[pyo3(signature = (event_name, subscriber_id))]
     fn unsubscribe(&self, event_name: &str, subscriber_id: SubscriberId) -> bool {
         self.remove_subscriber(event_name, subscriber_id)
+    }
+
+    /// Unsubscribe a before hook by subscriber ID.
+    #[pyo3(signature = (event_name, subscriber_id))]
+    fn unsubscribe_before(&self, event_name: &str, subscriber_id: SubscriberId) -> bool {
+        self.remove_before_subscriber(event_name, subscriber_id)
+    }
+
+    /// Return a veto payload for before-hook callbacks.
+    #[staticmethod]
+    #[pyo3(signature = (reason, code = "vetoed"))]
+    fn veto(py: Python<'_>, reason: &str, code: &str) -> PyResult<Py<PyAny>> {
+        let dict = PyDict::new(py);
+        dict.set_item("reason", reason)?;
+        dict.set_item("code", code)?;
+        Ok(dict.into())
+    }
+
+    /// Return the event names that accept before hooks.
+    #[staticmethod]
+    fn vetoable_events() -> Vec<&'static str> {
+        VETOABLE_EVENTS.to_vec()
     }
 
     /// Publish an event with legacy keyword payloads, calling all subscribers.
@@ -145,4 +259,54 @@ fn object_arg(value: Option<&Bound<'_, PyAny>>) -> PyResult<Value> {
             "event source, correlation, and attributes must be dict-like objects",
         ))
     }
+}
+
+fn veto_from_py_result(py: Python<'_>, value: Py<PyAny>) -> Result<Option<EventVeto>, EventVeto> {
+    let bound = value.bind(py);
+    if bound.is_none() {
+        return Ok(None);
+    }
+    if let Ok(flag) = bound.extract::<bool>()
+        && !flag
+    {
+        return Ok(None);
+    }
+    if let Ok(reason) = bound.extract::<String>() {
+        return Ok(Some(EventVeto::new(reason)));
+    }
+    if let Ok(dict) = bound.cast::<PyDict>() {
+        let reason = py_dict_string(dict, "reason")?.unwrap_or_else(|| "event vetoed".to_string());
+        let code = py_dict_string(dict, "code")?.unwrap_or_else(|| "vetoed".to_string());
+        return Ok(Some(EventVeto::with_code(code, reason)));
+    }
+    match bound.is_truthy() {
+        Ok(false) => Ok(None),
+        Ok(true) => Ok(Some(EventVeto::with_code(
+            "invalid_before_hook_result",
+            "before hook returned an unsupported truthy value; return None/False to allow or a string/dict to veto",
+        ))),
+        Err(err) => Err(EventVeto::with_code(
+            "before_hook_error",
+            format!("failed to interpret before hook result: {err}"),
+        )),
+    }
+}
+
+fn py_dict_string(dict: &Bound<'_, PyDict>, key: &str) -> Result<Option<String>, EventVeto> {
+    dict.get_item(key)
+        .map_err(|err| {
+            EventVeto::with_code(
+                "before_hook_error",
+                format!("invalid veto payload field '{key}': {err}"),
+            )
+        })?
+        .map(|value| {
+            value.extract::<String>().map_err(|err| {
+                EventVeto::with_code(
+                    "before_hook_error",
+                    format!("veto payload field '{key}' must be a string: {err}"),
+                )
+            })
+        })
+        .transpose()
 }

--- a/crates/dcc-mcp-actions/src/python/mod.rs
+++ b/crates/dcc-mcp-actions/src/python/mod.rs
@@ -29,7 +29,7 @@ use serde_json::{Map, Value, json};
 #[cfg(feature = "stub-gen")]
 use pyo3_stub_gen_derive::{gen_stub_pyclass, gen_stub_pymethods};
 
-use crate::dispatcher::{DispatchError, ToolDispatcher, dispatch_error_kind};
+use crate::dispatcher::{DispatchError, ToolDispatcher, dispatch_error_kind, tool_event_payload};
 use crate::events::EventBus;
 use crate::registry::{ToolMeta, ToolRegistry};
 use crate::validator::ToolValidator;
@@ -192,38 +192,27 @@ impl PyToolDispatcher {
         }
 
         let meta = self.inner.registry().get_action(action_name, None);
-        let mut source = Map::new();
-        let mut attrs = attributes.as_object().cloned().unwrap_or_default();
-        attrs.insert("tool_slug".to_string(), json!(action_name));
-        attrs.insert("tool_name".to_string(), json!(action_name));
-        attrs.insert(
-            "duration_ms".to_string(),
-            json!(u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX)),
-        );
+        let (source, attributes) =
+            tool_event_payload(action_name, meta.as_ref(), started, attributes);
 
-        if let Some(meta) = meta {
-            if !meta.dcc.is_empty() {
-                source.insert("dcc_type".to_string(), json!(meta.dcc));
-                attrs.insert("dcc_type".to_string(), json!(meta.dcc));
-            }
-            if let Some(skill_name) = &meta.skill_name {
-                attrs.insert("skill_name".to_string(), json!(skill_name));
-            }
-            if !meta.group.is_empty() {
-                attrs.insert("group".to_string(), json!(meta.group));
-            }
-            attrs.insert(
-                "annotations".to_string(),
-                serde_json::to_value(&meta.annotations).unwrap_or(Value::Null),
-            );
-        }
+        let _ = event_bus.emit(event_name, source, Value::Object(Map::new()), attributes);
+    }
 
-        let _ = event_bus.emit(
-            event_name,
-            Value::Object(source),
-            Value::Object(Map::new()),
-            Value::Object(attrs),
-        );
+    fn emit_vetoable_tool_event(
+        &self,
+        event_name: &str,
+        action_name: &str,
+        started: Instant,
+        attributes: Value,
+    ) -> Result<(), crate::events::EventVeto> {
+        let event_bus = self.inner.event_bus();
+        let meta = self.inner.registry().get_action(action_name, None);
+        let (source, attributes) =
+            tool_event_payload(action_name, meta.as_ref(), started, attributes);
+        let event =
+            event_bus.before_event(event_name, source, Value::Object(Map::new()), attributes)?;
+        event_bus.publish_event(&event);
+        Ok(())
     }
 }
 
@@ -377,7 +366,8 @@ impl PyToolDispatcher {
                     false
                 }
                 Err(err @ DispatchError::ActionDisabled { .. })
-                | Err(err @ DispatchError::ThreadAffinityViolation { .. }) => {
+                | Err(err @ DispatchError::ThreadAffinityViolation { .. })
+                | Err(err @ DispatchError::Vetoed { .. }) => {
                     self.emit_tool_failed(
                         action_name,
                         dispatch_error_kind(&err),
@@ -392,14 +382,21 @@ impl PyToolDispatcher {
         };
 
         // 3. Call the Python handler
-        self.emit_tool_event(
+        if let Err(veto) = self.emit_vetoable_tool_event(
             "tool.dispatched",
             action_name,
             started,
             json!({
                 "validation_skipped": validation_skipped,
             }),
-        );
+        ) {
+            let message = format!(
+                "EVENT_VETOED: action '{action_name}' was vetoed ({}): {}",
+                veto.code, veto.reason
+            );
+            self.emit_tool_failed(action_name, "event_vetoed", message.clone(), started);
+            return Err(pyo3::exceptions::PyPermissionError::new_err(message));
+        }
         let handler = self.handler_map.get(action_name).expect("checked above");
         let py_params = value_to_py(py, &params)?;
         let raw = handler.call1(py, (py_params,)).map_err(|e| {

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/wire.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/wire.rs
@@ -59,6 +59,17 @@ fn encode_dispatch_error_wire(err: &DispatchError) -> String {
             "declared": declared.to_string(),
             "actual": actual.to_string(),
         }),
+        DispatchError::Vetoed {
+            action,
+            code,
+            reason,
+        } => json!({
+            "__dispatch_error_kind": "event_vetoed",
+            "action": action,
+            "code": code,
+            "reason": reason,
+            "message": err.to_string(),
+        }),
     };
     serde_json::to_string(&payload).unwrap_or_else(|_| {
         "{\"__dispatch_error_kind\":\"handler_error\",\"message\":\"dispatch failure\"}".to_string()
@@ -144,6 +155,23 @@ fn decode_dispatch_error_payload(value: &Value) -> DispatchError {
                 actual,
             }
         }
+        "event_vetoed" => DispatchError::Vetoed {
+            action: value
+                .get("action")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown")
+                .to_string(),
+            code: value
+                .get("code")
+                .and_then(Value::as_str)
+                .unwrap_or("vetoed")
+                .to_string(),
+            reason: value
+                .get("reason")
+                .and_then(Value::as_str)
+                .unwrap_or(message.as_str())
+                .to_string(),
+        },
         _ => DispatchError::HandlerError(message),
     }
 }
@@ -153,4 +181,31 @@ pub(crate) fn decode_dispatch_output(json_str: &str) -> Result<Value, String> {
     decode_dispatch_wire(json_str)
         .map(|r| r.output)
         .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dispatch_veto_round_trips_over_wire() {
+        let encoded = encode_dispatch_wire(Err(DispatchError::Vetoed {
+            action: "delete_scene".to_string(),
+            code: "policy_denied".to_string(),
+            reason: "destructive tools are disabled".to_string(),
+        }));
+
+        let decoded = decode_dispatch_wire(&encoded).unwrap_err();
+
+        assert!(matches!(
+            decoded,
+            DispatchError::Vetoed {
+                ref action,
+                ref code,
+                ref reason,
+            } if action == "delete_scene"
+                && code == "policy_denied"
+                && reason == "destructive tools are disabled"
+        ));
+    }
 }

--- a/crates/dcc-mcp-skill-rest/src/errors.rs
+++ b/crates/dcc-mcp-skill-rest/src/errors.rs
@@ -25,6 +25,8 @@ pub enum ServiceErrorKind {
     InvalidParams,
     /// Auth gate rejected the request.
     Unauthorized,
+    /// A policy hook rejected the request before execution.
+    PolicyDenied,
     /// Request body could not be parsed.
     BadRequest,
     /// The handler itself returned an error.
@@ -55,6 +57,7 @@ impl ServiceErrorKind {
             Self::SkillNotLoaded => 409,
             Self::InvalidParams => 400,
             Self::Unauthorized => 401,
+            Self::PolicyDenied => 403,
             Self::BadRequest => 400,
             Self::AffinityViolation | Self::ThreadAffinityViolation => 409,
             Self::NotReady => 503,
@@ -149,11 +152,13 @@ mod tests {
             ServiceErrorKind::SkillNotLoaded,
             ServiceErrorKind::InvalidParams,
             ServiceErrorKind::Unauthorized,
+            ServiceErrorKind::PolicyDenied,
             ServiceErrorKind::BadRequest,
             ServiceErrorKind::BackendError,
             ServiceErrorKind::AffinityViolation,
             ServiceErrorKind::ThreadAffinityViolation,
             ServiceErrorKind::NotReady,
+            ServiceErrorKind::NotFound,
             ServiceErrorKind::Internal,
         ] {
             // Every variant must produce a valid 4xx/5xx status.

--- a/crates/dcc-mcp-skill-rest/src/service.rs
+++ b/crates/dcc-mcp-skill-rest/src/service.rs
@@ -586,6 +586,20 @@ pub fn dispatch_error_to_service_error(err: DispatchError) -> ServiceError {
             format!("action '{action}' is disabled (group '{group}')"),
         )
         .with_hint("call load_skill / activate the owning tool group first"),
+        DispatchError::Vetoed {
+            action,
+            code,
+            reason,
+        } => ServiceError::new(
+            ServiceErrorKind::PolicyDenied,
+            format!("EVENT_VETOED: action '{action}' was vetoed ({code}): {reason}"),
+        )
+        .with_hint("inspect the registered EventBus before hook policy for this DCC instance")
+        .with_context(serde_json::json!({
+            "action": action,
+            "veto_code": code,
+            "veto_reason": reason,
+        })),
         DispatchError::ThreadAffinityViolation {
             action,
             declared,

--- a/crates/dcc-mcp-skill-rest/src/service_tests.rs
+++ b/crates/dcc-mcp-skill-rest/src/service_tests.rs
@@ -339,6 +339,19 @@ fn call_rejects_unloaded_skill() {
 }
 
 #[test]
+fn dispatch_veto_maps_to_policy_denied() {
+    let err = dispatch_error_to_service_error(DispatchError::Vetoed {
+        action: "delete_scene".into(),
+        code: "policy_denied".into(),
+        reason: "destructive tools are disabled".into(),
+    });
+
+    assert_eq!(err.kind, ServiceErrorKind::PolicyDenied);
+    assert_eq!(err.http_status(), 403);
+    assert_eq!(err.context.as_ref().unwrap()["veto_code"], "policy_denied");
+}
+
+#[test]
 fn call_dispatches_and_normalises_slug() {
     let (svc, inv) = build_service(vec![sphere_action(true)]);
     inv.set_next(Ok(serde_json::json!({"created": 1})));

--- a/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
@@ -26,33 +26,29 @@ impl SkillCatalog {
             return;
         }
 
-        let mut source = Map::new();
-        let mut attrs = attributes.as_object().cloned().unwrap_or_default();
-        attrs.insert("skill_name".to_string(), json!(skill_name));
+        let (source, attributes) = skill_event_payload(skill_name, metadata, attributes);
 
-        if let Some(metadata) = metadata {
-            if !metadata.dcc.is_empty() {
-                source.insert("dcc_type".to_string(), json!(metadata.dcc));
-                attrs.insert("dcc_type".to_string(), json!(metadata.dcc));
-            }
-            if !metadata.version.is_empty() {
-                attrs.insert("version".to_string(), json!(metadata.version));
-            }
-            if !metadata.skill_path.is_empty() {
-                attrs.insert("skill_path".to_string(), json!(metadata.skill_path));
-            }
-            attrs.insert(
-                "declared_tool_count".to_string(),
-                json!(metadata.tools.len()),
-            );
-        }
+        let _ = self
+            .event_bus
+            .emit(event_name, source, Value::Object(Map::new()), attributes);
+    }
 
-        let _ = self.event_bus.emit(
+    fn emit_vetoable_skill_event(
+        &self,
+        event_name: &str,
+        skill_name: &str,
+        metadata: Option<&SkillMetadata>,
+        attributes: Value,
+    ) -> Result<(), EventVeto> {
+        let (source, attributes) = skill_event_payload(skill_name, metadata, attributes);
+        let event = self.event_bus.before_event(
             event_name,
-            Value::Object(source),
+            source,
             Value::Object(Map::new()),
-            Value::Object(attrs),
-        );
+            attributes,
+        )?;
+        self.event_bus.publish_event(&event);
+        Ok(())
     }
 
     /// Load a skill by name — registers its tools into ToolRegistry and,
@@ -205,14 +201,31 @@ impl SkillCatalog {
         let mut registered = Vec::new();
         let skill_base = metadata.name.replace('-', "_");
         let skill_path = std::path::Path::new(&metadata.skill_path);
-        self.emit_skill_event(
+        if let Err(veto) = self.emit_vetoable_skill_event(
             "skill.loading",
             skill_name,
             Some(metadata),
             json!({
                 "activate_groups": activate_groups,
             }),
-        );
+        ) {
+            let err = format!(
+                "Skill '{skill_name}' loading vetoed ({}): {}",
+                veto.code, veto.reason
+            );
+            self.emit_skill_event(
+                "skill.validation_failed",
+                skill_name,
+                Some(metadata),
+                json!({
+                    "error_kind": "event_vetoed",
+                    "error_message": err,
+                    "veto_code": veto.code,
+                    "veto_reason": veto.reason,
+                }),
+            );
+            return Err(err);
+        }
 
         if activate_groups {
             activate_skill_groups(self, metadata);
@@ -513,4 +526,33 @@ impl SkillCatalog {
         }
         self.entries.clear();
     }
+}
+
+fn skill_event_payload(
+    skill_name: &str,
+    metadata: Option<&SkillMetadata>,
+    attributes: Value,
+) -> (Value, Value) {
+    let mut source = Map::new();
+    let mut attrs = attributes.as_object().cloned().unwrap_or_default();
+    attrs.insert("skill_name".to_string(), json!(skill_name));
+
+    if let Some(metadata) = metadata {
+        if !metadata.dcc.is_empty() {
+            source.insert("dcc_type".to_string(), json!(metadata.dcc));
+            attrs.insert("dcc_type".to_string(), json!(metadata.dcc));
+        }
+        if !metadata.version.is_empty() {
+            attrs.insert("version".to_string(), json!(metadata.version));
+        }
+        if !metadata.skill_path.is_empty() {
+            attrs.insert("skill_path".to_string(), json!(metadata.skill_path));
+        }
+        attrs.insert(
+            "declared_tool_count".to_string(),
+            json!(metadata.tools.len()),
+        );
+    }
+
+    (Value::Object(source), Value::Object(attrs))
 }

--- a/crates/dcc-mcp-skills/src/catalog/mod.rs
+++ b/crates/dcc-mcp-skills/src/catalog/mod.rs
@@ -48,7 +48,7 @@ use pyo3_stub_gen_derive::gen_stub_pyclass;
 
 use dashmap::{DashMap, DashSet};
 use dcc_mcp_actions::{
-    EventBus, ToolDispatcher,
+    EventBus, EventVeto, ToolDispatcher,
     registry::{ToolMeta, ToolRegistry},
 };
 use dcc_mcp_models::registry::{Registry, SearchQuery};

--- a/crates/dcc-mcp-skills/src/catalog/tests/test_catalog_crud.rs
+++ b/crates/dcc-mcp-skills/src/catalog/tests/test_catalog_crud.rs
@@ -143,6 +143,45 @@ fn test_load_and_unload_emit_skill_lifecycle_events() {
     assert_eq!(events[2].1["removed_tool_count"], 1);
 }
 
+#[cfg(not(feature = "python-bindings"))]
+#[test]
+fn test_skill_loading_before_hook_veto_blocks_registration() {
+    let catalog = make_test_catalog();
+    catalog.add_skill(make_test_skill("modeling-bevel", "maya", &["bevel"]));
+
+    let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let captured = std::sync::Arc::clone(&events);
+    let _id = catalog
+        .event_bus()
+        .subscribe_event("skill.*".to_string(), move |event| {
+            captured
+                .lock()
+                .unwrap()
+                .push((event.name.clone(), event.attributes.clone()));
+        });
+    let _before = catalog
+        .event_bus()
+        .before("skill.loading".to_string(), |event| {
+            assert_eq!(event.attributes["skill_name"], "modeling-bevel");
+            Some(dcc_mcp_actions::EventVeto::with_code(
+                "policy_denied",
+                "skills cannot load during maintenance",
+            ))
+        })
+        .unwrap();
+
+    let err = catalog.load_skill("modeling-bevel").unwrap_err();
+
+    assert!(err.contains("loading vetoed"), "{err}");
+    assert!(!catalog.is_loaded("modeling-bevel"));
+    assert_eq!(catalog.registry().len(), 0);
+    let events = events.lock().unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].0, "skill.validation_failed");
+    assert_eq!(events[0].1["error_kind"], "event_vetoed");
+    assert_eq!(events[0].1["veto_code"], "policy_denied");
+}
+
 #[test]
 fn test_load_skill_auto_loads_discovered_dependencies_first() {
     let catalog = make_test_catalog();

--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -18,9 +18,13 @@ bus = EventBus()
 | Method | Returns | Description |
 |--------|---------|-------------|
 | `subscribe(event_name, callback)` | `int` | Subscribe a callable. Returns subscriber ID |
+| `before(event_name, callback)` | `int` | Register a blocking veto hook for a supported lifecycle event |
 | `unsubscribe(event_name, subscriber_id)` | `bool` | Unsubscribe by ID. Returns True if found |
+| `unsubscribe_before(event_name, subscriber_id)` | `bool` | Remove a before hook by ID |
 | `publish(event_name, **kwargs)` | `None` | Call all matching subscribers with kwargs |
 | `emit(event_name, source=None, correlation=None, attributes=None)` | `dict` | Emit a structured event envelope and pass it to all matching subscribers |
+| `veto(reason, code="vetoed")` | `dict` | Build a veto payload for a before hook |
+| `vetoable_events()` | `list[str]` | Return lifecycle events that accept before hooks |
 
 ### Dunder Methods
 
@@ -34,6 +38,10 @@ bus = EventBus()
 - Subscribers receive one event-envelope dict from `emit(...)`
 - Event names support exact matches, `prefix.*` wildcards, and a catch-all `*`
 - Exceptions in subscribers are logged via `tracing` but do not propagate
+- Before hooks support only `skill.loading`, `tool.dispatched`,
+  `resource.subscribed`, and `client.initialize`
+- Before hooks return `None`/`False` to allow, or a string/dict/`veto(...)`
+  payload to reject
 - Callbacks are collected before invocation to avoid DashMap deadlocks
 - Multiple subscribers per event are supported
 - Subscriber IDs are monotonically increasing (starting at 1)
@@ -67,6 +75,21 @@ event = bus.emit(
 assert event["schema_version"] == 1
 assert events == [event]
 ```
+
+### Before Hook Veto
+
+```python
+def policy(event):
+    if event["attributes"]["tool_slug"] == "delete_scene":
+        return EventBus.veto("destructive tools are disabled", "policy_denied")
+    return None
+
+sid = bus.before("tool.dispatched", policy)
+bus.unsubscribe_before("tool.dispatched", sid)
+```
+
+Tool vetoes surface as `EVENT_VETOED` dispatch errors and `tool.failed` events
+with `error_kind="event_vetoed"`, `veto_code`, and `veto_reason`.
 
 Envelope fields:
 

--- a/docs/guide/events.md
+++ b/docs/guide/events.md
@@ -60,8 +60,8 @@ Every structured event uses this envelope shape:
 
 ## Built-In Emit Points
 
-The core dispatcher and skill catalog emit these events when subscribers are
-present:
+The core dispatcher and skill catalog emit these events when subscribers or
+policy hooks are present:
 
 | Event | Emitted when |
 |-------|--------------|
@@ -83,6 +83,44 @@ otherwise handler success defaults to `true`.
 Skill lifecycle attributes include `skill_name`, `dcc_type`, `version`,
 `skill_path`, declared/registered tool counts, registered tool names, and
 failure details such as `error_kind` and `error_message`.
+
+## Before Hooks And Vetoes
+
+`before()` registers a synchronous policy hook for lifecycle points where an
+operation can still be rejected. Unlike normal subscribers, before hooks are
+blocking: return `None` or `False` to allow the operation, or return
+`EventBus.veto(reason, code="...")`, a `{"reason": "...", "code": "..."}`
+dict, or a string reason to veto it.
+
+```python
+from dcc_mcp_core import EventBus, ToolDispatcher, ToolRegistry
+
+registry = ToolRegistry()
+registry.register("delete_scene", dcc="maya")
+dispatcher = ToolDispatcher(registry)
+
+def block_destructive(event: dict):
+    if event["attributes"]["tool_slug"] == "delete_scene":
+        return EventBus.veto("destructive tools are disabled", "policy_denied")
+    return None
+
+dispatcher.event_bus().before("tool.dispatched", block_destructive)
+```
+
+Only these event names are vetoable:
+
+| Event | Veto result |
+|-------|-------------|
+| `skill.loading` | Rejects the skill load before tools are registered |
+| `tool.dispatched` | Rejects the tool call before the handler runs |
+| `resource.subscribed` | Reserved for rejecting resource subscriptions |
+| `client.initialize` | Reserved for rejecting client initialization |
+
+When a veto rejects a tool call, the dispatcher returns a structured
+`EVENT_VETOED` error and emits `tool.failed` with
+`error_kind="event_vetoed"`, `veto_code`, and `veto_reason`. When
+`skill.loading` is vetoed, the catalog rejects the load and emits
+`skill.validation_failed` with the same veto fields.
 
 ## Gateway Traffic Capture
 
@@ -138,4 +176,6 @@ dispatcher.event_bus().subscribe("tool.*", record_metric)
 
 Subscriber exceptions are logged and do not stop later subscribers. Callbacks
 are collected before invocation so a callback can safely subscribe or
-unsubscribe without deadlocking the bus.
+unsubscribe without deadlocking the bus. Before hooks are intentionally stricter:
+an exception or unsupported truthy return value becomes a veto so policy hooks
+fail closed.

--- a/docs/zh/api/events.md
+++ b/docs/zh/api/events.md
@@ -18,8 +18,13 @@ bus = EventBus()
 | 方法 | 返回值 | 说明 |
 |------|--------|------|
 | `subscribe(event_name, callback)` | `int` | 订阅事件，返回订阅者 ID |
+| `before(event_name, callback)` | `int` | 为支持 veto 的生命周期事件注册阻塞式策略 hook |
 | `unsubscribe(event_name, subscriber_id)` | `bool` | 按 ID 取消订阅，返回是否找到 |
+| `unsubscribe_before(event_name, subscriber_id)` | `bool` | 按 ID 移除 before hook |
 | `publish(event_name, **kwargs)` | — | 调用所有订阅者，传递关键字参数 |
+| `emit(event_name, source=None, correlation=None, attributes=None)` | `dict` | 发布结构化事件 envelope |
+| `veto(reason, code="vetoed")` | `dict` | 为 before hook 构造 veto 结果 |
+| `vetoable_events()` | `list[str]` | 返回允许 before hook 的事件名 |
 
 ### Dunder 方法
 
@@ -30,7 +35,12 @@ bus = EventBus()
 ### 行为
 
 - 订阅者通过 `publish(event_name, **kwargs)` 接收关键字参数
+- 订阅者通过 `emit(...)` 接收结构化事件 dict
 - 订阅者中的异常会通过 `tracing` 记录日志，但不会传播
+- before hook 仅支持 `skill.loading`、`tool.dispatched`、
+  `resource.subscribed` 和 `client.initialize`
+- before hook 返回 `None`/`False` 表示放行，返回字符串、dict 或
+  `veto(...)` 结果表示拒绝
 - 回调在调用前会先收集，以避免 DashMap 死锁
 - 每个事件支持多个订阅者
 - 订阅者 ID 单调递增（从 1 开始）
@@ -47,6 +57,22 @@ sid = bus.subscribe("action.executed", on_action)
 bus.publish("action.executed", action_name="create_sphere")
 bus.unsubscribe("action.executed", sid)
 ```
+
+### Before Hook Veto
+
+```python
+def policy(event):
+    if event["attributes"]["tool_slug"] == "delete_scene":
+        return EventBus.veto("destructive tools are disabled", "policy_denied")
+    return None
+
+sid = bus.before("tool.dispatched", policy)
+bus.unsubscribe_before("tool.dispatched", sid)
+```
+
+Tool veto 会表现为 `EVENT_VETOED` dispatch error，并发布带有
+`error_kind="event_vetoed"`、`veto_code` 和 `veto_reason` 的 `tool.failed`
+事件。
 
 ---
 

--- a/docs/zh/guide/events.md
+++ b/docs/zh/guide/events.md
@@ -68,8 +68,31 @@ bus.publish("scene.saved", file_path="/tmp/scene.usda", size_kb=1024)
 bus.publish("scene.opened", file_path="/tmp/scene.usda")
 ```
 
+## Before Hook 与 Veto
+
+`before()` 用于注册阻塞式策略 hook，只能绑定到支持 veto 的生命周期事件。
+回调返回 `None` 或 `False` 表示放行；返回字符串、dict 或
+`EventBus.veto(reason, code)` 表示拒绝该操作。
+
+```python
+from dcc_mcp_core import EventBus
+
+def policy(event):
+    if event["attributes"].get("tool_slug") == "delete_scene":
+        return EventBus.veto("destructive tools are disabled", "policy_denied")
+    return None
+
+sub_id = bus.before("tool.dispatched", policy)
+bus.unsubscribe_before("tool.dispatched", sub_id)
+```
+
+当前支持 veto 的事件包括 `skill.loading`、`tool.dispatched`、
+`resource.subscribed` 和 `client.initialize`。工具调用被 veto 时会返回
+`EVENT_VETOED`，并发布带 `error_kind="event_vetoed"`、`veto_code`、
+`veto_reason` 的 `tool.failed` 事件。
+
 ## Dunder 方法
 
 | 方法 | 说明 |
 |------|------|
-| `__repr__` | `EventBus(subscribers=N)` |
+| `__repr__` | `EventBus(subscriptions=N)` |

--- a/skills/dcc-mcp-skill-developer/SKILL.md
+++ b/skills/dcc-mcp-skill-developer/SKILL.md
@@ -73,6 +73,10 @@ into a faster authoring loop.
    needs programmatic lifecycle hooks: use `skill.*` events for load/unload
    visibility and `tool.*` events for dispatch/completion/failure metrics
    instead of scraping logs or wrapping every handler manually.
+   For policy enforcement, register `EventBus.before(...)` only on vetoable
+   lifecycle points (`skill.loading`, `tool.dispatched`,
+   `resource.subscribed`, `client.initialize`); keep callbacks fast and return
+   `EventBus.veto(reason, code)` instead of raising for expected denials.
    For local traffic debugging, prefer the gateway `traffic.frame` capture
    stream (`DCC_MCP_TRAFFIC_CAPTURE=jsonl:<path>`) over ad-hoc print logging;
    capture files can contain prompts, scene paths, and tool arguments, so keep

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -3,6 +3,8 @@
 # Import future modules
 from __future__ import annotations
 
+import pytest
+
 # Import local modules
 import dcc_mcp_core
 
@@ -545,6 +547,18 @@ class TestEventBus:
         id2 = bus.subscribe("b", lambda: None)
         id3 = bus.subscribe("a", lambda: None)
         assert len({id1, id2, id3}) == 3
+
+    def test_before_rejects_non_vetoable_event(self) -> None:
+        bus = dcc_mcp_core.EventBus()
+
+        with pytest.raises(ValueError):
+            bus.before("tool.completed", lambda event: None)
+
+    def test_vetoable_events_exposes_policy_contract(self) -> None:
+        bus = dcc_mcp_core.EventBus()
+
+        assert "tool.dispatched" in bus.vetoable_events()
+        assert "skill.loading" in bus.vetoable_events()
 
 
 class TestListActionsDict:

--- a/tests/test_actions_validator_dispatcher.py
+++ b/tests/test_actions_validator_dispatcher.py
@@ -343,6 +343,31 @@ class TestToolDispatcher:
         assert len(events) == 1
         assert events[0]["attributes"]["error_kind"] == "action_disabled"
 
+    def test_dispatch_before_hook_veto_blocks_handler(self, dispatcher_cls, registry_cls):
+        reg = registry_cls()
+        reg.register("delete_scene", dcc="maya")
+        d = dispatcher_cls(reg)
+        called = {"value": False}
+
+        def handler(_params):
+            called["value"] = True
+            return {"deleted": True}
+
+        d.register_handler("delete_scene", handler)
+        events = []
+        d.event_bus().subscribe("tool.failed", lambda event: events.append(event))
+        d.event_bus().before(
+            "tool.dispatched",
+            lambda event: _core.EventBus.veto("destructive tools are disabled", "policy_denied"),
+        )
+
+        with pytest.raises(PermissionError):
+            d.dispatch("delete_scene", "{}")
+
+        assert called["value"] is False
+        assert len(events) == 1
+        assert events[0]["attributes"]["error_kind"] == "event_vetoed"
+
     def test_dispatch_thread_affinity_event_kind_matches_rust(self, dispatcher_cls, registry_cls):
         reg = registry_cls()
         reg.register("main_only", dcc="maya", thread_affinity="main", enforce_thread_affinity=True)


### PR DESCRIPTION
## Summary
- Adds EventBus `before()` veto hooks for the #1115 P2 lifecycle whitelist.
- Blocks `tool.dispatched` before handler execution and `skill.loading` before tool registration, with structured failure events.
- Carries veto errors through Python bindings, REST service errors, and threaded dispatch wire encoding.
- Updates event docs and skill-developer guidance for the new policy hook contract.

## Validation
- `vx cargo test -p dcc-mcp-actions -p dcc-mcp-skills -p dcc-mcp-skill-rest -p dcc-mcp-http-server`
- `vx cargo test -p dcc-mcp-actions --features python-bindings --lib`
- `DCC_MCP_ADMIN_UI_PREBUILT=1 vx just dev`
- `DCC_MCP_ADMIN_UI_PREBUILT=1 vx just stubgen-check`
- `.\.venv\Scripts\python.exe -m pytest tests/test_actions.py::TestEventBus tests/test_actions_validator_dispatcher.py::TestToolDispatcher -q`

Refs #1115