### PR TITLE
fix: preserve host failure envelopes through gateway

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
@@ -296,16 +296,7 @@ pub async fn call_service(
         }
         Err(e) => {
             let backend_body = super::instance_diagnostics::parse_rest_error_json(&e);
-            let kind = if is_host_died_backend_error(&e) {
-                "host-died"
-            } else {
-                backend_body
-                    .as_ref()
-                    .and_then(|b| b.get("kind"))
-                    .and_then(|k| k.as_str())
-                    .filter(|k| *k == "thread-affinity-violation")
-                    .unwrap_or("backend-error")
-            };
+            let kind = backend_failure_kind(&e, backend_body.as_ref());
             gs.instance_diagnostics.record_call_error(
                 entry.instance_id,
                 kind,
@@ -436,6 +427,34 @@ fn inject_call_instance_meta(result: &mut Value, entry: &ServiceEntry) {
         json!(instance_short(&entry.instance_id)),
     );
     dcc_obj.insert("display_id".to_string(), json!(entry.display_id()));
+}
+
+fn backend_failure_kind(message: &str, backend_body: Option<&Value>) -> &'static str {
+    if let Some(kind) = backend_body
+        .and_then(|b| b.get("kind"))
+        .and_then(Value::as_str)
+    {
+        match kind {
+            "host-busy" => return "host-busy",
+            "host-died" => return "host-died",
+            "thread-affinity-violation" => return "thread-affinity-violation",
+            _ => {}
+        }
+    }
+    if is_host_busy_backend_error(message) {
+        "host-busy"
+    } else if is_host_died_backend_error(message) {
+        "host-died"
+    } else {
+        "backend-error"
+    }
+}
+
+fn is_host_busy_backend_error(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    lower.contains("host-busy")
+        || lower.contains("queue-overloaded")
+        || lower.contains("queue overloaded")
 }
 
 fn is_host_died_backend_error(message: &str) -> bool {
@@ -706,6 +725,29 @@ mod unit_tests {
         assert!(!is_host_died_backend_error(
             "transport error: connection refused"
         ));
+    }
+
+    #[test]
+    fn backend_failure_kind_preserves_host_busy_and_host_died() {
+        assert_eq!(
+            backend_failure_kind("HTTP 503", Some(&json!({"kind": "host-busy"}))),
+            "host-busy"
+        );
+        assert_eq!(
+            backend_failure_kind("HTTP 502", Some(&json!({"kind": "host-died"}))),
+            "host-died"
+        );
+        assert_eq!(
+            backend_failure_kind("queue overloaded (depth=16/16)", None),
+            "host-busy"
+        );
+        assert_eq!(
+            backend_failure_kind(
+                "HTTP 409",
+                Some(&json!({"kind": "thread-affinity-violation"}))
+            ),
+            "thread-affinity-violation"
+        );
     }
 
     #[test]

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
@@ -914,6 +914,7 @@ fn error_response(err: &ServiceError) -> (StatusCode, Json<Value>) {
         "unknown-slug" => StatusCode::NOT_FOUND,
         "ambiguous" => StatusCode::CONFLICT,
         "instance-offline" => StatusCode::SERVICE_UNAVAILABLE,
+        "host-busy" => StatusCode::SERVICE_UNAVAILABLE,
         "host-died" => StatusCode::BAD_GATEWAY,
         "backend-error" | "schema-unavailable" => StatusCode::BAD_GATEWAY,
         _ => StatusCode::BAD_REQUEST,

--- a/crates/dcc-mcp-skill-rest/src/errors.rs
+++ b/crates/dcc-mcp-skill-rest/src/errors.rs
@@ -31,6 +31,9 @@ pub enum ServiceErrorKind {
     BadRequest,
     /// The handler itself returned an error.
     BackendError,
+    /// The host dispatcher is alive but saturated; callers should retry
+    /// after a short backoff or choose another instance.
+    HostBusy,
     /// Execution affinity violated — e.g. a main-thread-only tool was
     /// called without an executor available.
     AffinityViolation,
@@ -60,6 +63,7 @@ impl ServiceErrorKind {
             Self::PolicyDenied => 403,
             Self::BadRequest => 400,
             Self::AffinityViolation | Self::ThreadAffinityViolation => 409,
+            Self::HostBusy => 503,
             Self::NotReady => 503,
             Self::NotFound => 404,
             Self::BackendError => 502,
@@ -155,6 +159,7 @@ mod tests {
             ServiceErrorKind::PolicyDenied,
             ServiceErrorKind::BadRequest,
             ServiceErrorKind::BackendError,
+            ServiceErrorKind::HostBusy,
             ServiceErrorKind::AffinityViolation,
             ServiceErrorKind::ThreadAffinityViolation,
             ServiceErrorKind::NotReady,

--- a/crates/dcc-mcp-skill-rest/src/service.rs
+++ b/crates/dcc-mcp-skill-rest/src/service.rs
@@ -635,12 +635,24 @@ pub fn dispatch_error_to_service_error(err: DispatchError) -> ServiceError {
                     crate::thread_affinity_diagnostics::build_affinity_unavailable_context(action),
                 )
         }
+        DispatchError::HandlerError(m) if is_host_busy_dispatch_error(&m) => {
+            ServiceError::new(ServiceErrorKind::HostBusy, m).with_hint(
+                "retry after a short backoff or route the call to another live DCC instance",
+            )
+        }
         DispatchError::HandlerError(m) if m == "CANCELLED" => {
             ServiceError::new(ServiceErrorKind::BackendError, m)
         }
         DispatchError::HandlerError(m) => ServiceError::new(ServiceErrorKind::BackendError, m),
         DispatchError::MetadataNotFound(m) => ServiceError::new(ServiceErrorKind::Internal, m),
     }
+}
+
+fn is_host_busy_dispatch_error(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    lower.contains("host-busy")
+        || lower.contains("queue-overloaded")
+        || lower.contains("queue overloaded")
 }
 
 impl ToolInvoker for DispatcherInvoker {

--- a/crates/dcc-mcp-skill-rest/src/service_tests.rs
+++ b/crates/dcc-mcp-skill-rest/src/service_tests.rs
@@ -352,6 +352,19 @@ fn dispatch_veto_maps_to_policy_denied() {
 }
 
 #[test]
+fn queue_overload_maps_to_host_busy() {
+    for message in [
+        "host-busy",
+        "queue-overloaded: depth=16/16; retry in 1s",
+        "queue overloaded (depth=16/16); retry in 1s",
+    ] {
+        let err = dispatch_error_to_service_error(DispatchError::HandlerError(message.into()));
+        assert_eq!(err.kind, ServiceErrorKind::HostBusy);
+        assert_eq!(err.http_status(), 503);
+    }
+}
+
+#[test]
 fn call_dispatches_and_normalises_slug() {
     let (svc, inv) = build_service(vec![sphere_action(true)]);
     inv.set_next(Ok(serde_json::json!({"created": 1})));

--- a/docs/guide/dcc-rest-skill-api.md
+++ b/docs/guide/dcc-rest-skill-api.md
@@ -80,7 +80,7 @@ is fetched on demand by `POST /v1/describe` with `include_schema: true`
 - **Structured errors** — single envelope `{kind, message, hint, request_id, candidates?}`,
   `kind` is kebab-case (`unknown-slug`, `ambiguous`, `skill-not-loaded`,
   `invalid-params`, `unauthorized`, `bad-request`, `affinity-violation`,
-  `not-ready`, `backend-error`, `internal`).
+  `not-ready`, `host-busy`, `backend-error`, `internal`).
 - **Auth gate** — pluggable `AuthGate`. Default `AllowLocalhostGate`
   rejects non-loopback peers. Enable remote calls by installing
   `BearerTokenGate::new(vec![token])` and binding the listener to a

--- a/docs/guide/rest-api-surface.md
+++ b/docs/guide/rest-api-surface.md
@@ -280,6 +280,7 @@ Error-kind vocabulary (HTTP status in parentheses):
 - `invalid-params` (400) — JSON-Schema validation failed against normalized `arguments`.
 - `unauthorized` (401) — the `AuthGate` rejected the request. Defaults to localhost-only on per-DCC servers; install `BearerTokenGate` for remote access.
 - `not-ready` (503) — `/v1/readyz` is red; DCC is still starting up.
+- `host-busy` (503) — the DCC host is alive but its dispatcher is saturated; retry with backoff or route to another live instance.
 - `affinity-violation` (409) — the caller tried to invoke a main-thread tool from a worker thread.
 - `bad-request` (400) — malformed envelope (missing `tool_slug`, bad JSON, etc.).
 - `backend-error` (502) — the owning DCC process responded but the tool failed.

--- a/docs/zh/guide/dcc-rest-skill-api.md
+++ b/docs/zh/guide/dcc-rest-skill-api.md
@@ -55,7 +55,7 @@ SkillCatalogSource  ToolInvoker  AuthGate  AuditSink
 ## 企业级控制（#660）
 
 - **版本化路径** — `/v1/*` 是稳定契约
-- **结构化错误** — 单一信封 `{kind, message, hint, request_id, candidates?}`，`kind` 为 kebab-case（`unknown-slug`、`ambiguous`、`skill-not-loaded`、`invalid-params`、`unauthorized`、`bad-request`、`affinity-violation`、`not-ready`、`backend-error`、`internal`）
+- **结构化错误** — 单一信封 `{kind, message, hint, request_id, candidates?}`，`kind` 为 kebab-case（`unknown-slug`、`ambiguous`、`skill-not-loaded`、`invalid-params`、`unauthorized`、`bad-request`、`affinity-violation`、`not-ready`、`host-busy`、`backend-error`、`internal`）
 - **认证门** — 可插拔 `AuthGate`。默认 `AllowLocalhostGate` 拒绝非回环地址。通过安装 `BearerTokenGate::new(vec![token])` 并将监听器绑定到非回环接口来启用远程调用
 - **审计 Sink** — 每次调用发出一个 `AuditEvent`（`{request_id, at, slug, route, subject, outcome, duration_ms}`）
 - **三状态就绪** — `进程 / 分发器 / DCC`。在所有三项均为绿色之前，`/v1/call` 返回 `503 not-ready`

--- a/docs/zh/guide/rest-api-surface.md
+++ b/docs/zh/guide/rest-api-surface.md
@@ -150,6 +150,7 @@ OpenAPI contract 预留了 `cursor`、`since`、`until` 给后续 normalized env
 - `invalid-params` (400) —— JSON-Schema 校验 `arguments` / `params` 失败。
 - `unauthorized` (401) —— `AuthGate` 拒绝。per-DCC 默认仅本机；远程访问需装 `BearerTokenGate`。
 - `not-ready` (503) —— `/v1/readyz` 红灯；DCC 还在启动中。
+- `host-busy` (503) —— DCC 宿主仍在线，但分发队列已饱和；请退避重试或路由到另一个在线实例。
 - `affinity-violation` (409) —— 从 worker 线程调用了主线程独占的工具。
 - `bad-request` (400) —— envelope 有误（缺 `tool_slug`、JSON 坏、等）。
 - `backend-error` (502) —— 拥有者 DCC 进程响应了但工具失败。


### PR DESCRIPTION
## Summary
- map host dispatcher saturation/queue overloads to a structured `host-busy` REST error
- preserve `host-busy`, `host-died`, and `thread-affinity-violation` kinds through gateway call diagnostics
- return HTTP 503 for gateway `host-busy` responses and document the new error kind

## Validation
- `cargo test -p dcc-mcp-skill-rest`
- `cargo test -p dcc-mcp-gateway`
- `python scripts/vrs_replay.py --base-url http://127.0.0.1:1 --dry-run --trace tests/vrs/traces/maya-235-capture-then-playblast-survives.jsonl`
- `git diff --check`

Closes #1160