### PR TITLE
fix: align cli smoke mcp accept headers

### DIFF
--- a/crates/dcc-mcp-cli/src/application/client.rs
+++ b/crates/dcc-mcp-cli/src/application/client.rs
@@ -6,6 +6,9 @@ use crate::domain::rest::{
 };
 use crate::infra::http::{HttpError, HttpGateway};
 
+const MCP_STREAMABLE_HTTP_ACCEPT: &str = "application/json, text/event-stream";
+const MCP_PROTOCOL_VERSION: &str = "2025-03-26";
+
 #[derive(Debug, Error)]
 pub enum ClientError {
     #[error(transparent)]
@@ -121,7 +124,7 @@ impl DccMcpClient {
                     "id": "smoke-initialize",
                     "method": "initialize",
                     "params": {
-                        "protocolVersion": "2025-03-26",
+                        "protocolVersion": MCP_PROTOCOL_VERSION,
                         "capabilities": {},
                         "clientInfo": {
                             "name": "dcc-mcp-cli",
@@ -129,7 +132,10 @@ impl DccMcpClient {
                         }
                     }
                 }),
-                &[("Mcp-Protocol-Version", "2025-03-26")],
+                &[
+                    ("Mcp-Protocol-Version", MCP_PROTOCOL_VERSION),
+                    ("Accept", MCP_STREAMABLE_HTTP_ACCEPT),
+                ],
             )
             .await;
         checks.push(check_json("mcp_initialize", &mcp_url, initialize));
@@ -144,7 +150,10 @@ impl DccMcpClient {
                     "method": "tools/list",
                     "params": {}
                 }),
-                &[("Mcp-Protocol-Version", "2025-03-26")],
+                &[
+                    ("Mcp-Protocol-Version", MCP_PROTOCOL_VERSION),
+                    ("Accept", MCP_STREAMABLE_HTTP_ACCEPT),
+                ],
             )
             .await;
         checks.push(check_json("mcp_tools_list", &mcp_url, tools_list));

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -2,6 +2,7 @@ use std::process::Command;
 
 use axum::Router;
 use axum::extract::Json;
+use axum::http::{HeaderMap, StatusCode, header};
 use axum::routing::{get, post};
 use serde_json::{Value, json};
 use tempfile::{NamedTempFile, TempDir};
@@ -32,42 +33,66 @@ fn spawn_gateway_fixture() -> GatewayFixture {
         )
         .route(
             "/mcp",
-            post(|Json(body): Json<Value>| async move {
+            post(|headers: HeaderMap, Json(body): Json<Value>| async move {
+                let accept = headers
+                    .get(header::ACCEPT)
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or_default();
+                if !(accept.contains("application/json") && accept.contains("text/event-stream"))
+                {
+                    return (
+                        StatusCode::NOT_ACCEPTABLE,
+                        Json(json!({
+                            "error": "not_acceptable",
+                            "message": "Client must accept both application/json and text/event-stream"
+                        })),
+                    );
+                }
+
                 let method = body.get("method").and_then(Value::as_str).unwrap_or("");
                 match method {
-                    "initialize" => Json(json!({
-                        "jsonrpc": "2.0",
-                        "id": body.get("id").cloned().unwrap_or(json!(null)),
-                        "result": {
-                            "protocolVersion": "2025-03-26",
-                            "capabilities": {
-                                "tools": {"listChanged": true}
-                            },
-                            "serverInfo": {
-                                "name": "fixture-gateway",
-                                "version": "0.0.0-test"
+                    "initialize" => (
+                        StatusCode::OK,
+                        Json(json!({
+                            "jsonrpc": "2.0",
+                            "id": body.get("id").cloned().unwrap_or(json!(null)),
+                            "result": {
+                                "protocolVersion": "2025-03-26",
+                                "capabilities": {
+                                    "tools": {"listChanged": true}
+                                },
+                                "serverInfo": {
+                                    "name": "fixture-gateway",
+                                    "version": "0.0.0-test"
+                                }
                             }
-                        }
-                    })),
-                    "tools/list" => Json(json!({
-                        "jsonrpc": "2.0",
-                        "id": body.get("id").cloned().unwrap_or(json!(null)),
-                        "result": {
-                            "tools": [{
-                                "name": "search_tools",
-                                "description": "Search tools",
-                                "inputSchema": {"type": "object"}
-                            }]
-                        }
-                    })),
-                    _ => Json(json!({
-                        "jsonrpc": "2.0",
-                        "id": body.get("id").cloned().unwrap_or(json!(null)),
-                        "error": {
-                            "code": -32601,
-                            "message": "method not found"
-                        }
-                    })),
+                        })),
+                    ),
+                    "tools/list" => (
+                        StatusCode::OK,
+                        Json(json!({
+                            "jsonrpc": "2.0",
+                            "id": body.get("id").cloned().unwrap_or(json!(null)),
+                            "result": {
+                                "tools": [{
+                                    "name": "search_tools",
+                                    "description": "Search tools",
+                                    "inputSchema": {"type": "object"}
+                                }]
+                            }
+                        })),
+                    ),
+                    _ => (
+                        StatusCode::OK,
+                        Json(json!({
+                            "jsonrpc": "2.0",
+                            "id": body.get("id").cloned().unwrap_or(json!(null)),
+                            "error": {
+                                "code": -32601,
+                                "message": "method not found"
+                            }
+                        })),
+                    ),
                 }
             }),
         )


### PR DESCRIPTION
## Summary
- send Streamable HTTP Accept negotiation headers from `dcc-mcp-cli smoke` MCP checks
- make the CLI smoke fixture reject MCP requests missing `application/json` and `text/event-stream`

## Validation
- `vx cargo fmt --check -p dcc-mcp-cli`
- `vx cargo test -p dcc-mcp-cli --test cli_e2e`
- `vx cargo clippy -p dcc-mcp-cli --all-targets -- -D warnings`

Skill developer guidance not updated; this is a CLI smoke transport header fix only.

Closes #1150