### PR TITLE
feat: add mutable skill object loading

### DIFF
--- a/crates/dcc-mcp-http-py/src/skill_server.rs
+++ b/crates/dcc-mcp-http-py/src/skill_server.rs
@@ -541,6 +541,24 @@ impl PyMcpHttpServer {
             .map_err(pyo3::exceptions::PyValueError::new_err)
     }
 
+    /// Return a detached, mutable skill metadata object.
+    ///
+    /// Mutating the returned object does not affect catalog state until it is
+    /// passed back to ``load_skill_object``.
+    fn get_skill(&self, skill_name: &str) -> Option<dcc_mcp_models::SkillMetadata> {
+        self.catalog.get_skill(skill_name)
+    }
+
+    /// Load a caller-supplied skill metadata object through core registration.
+    ///
+    /// Adapters can use this to adjust tool declarations at runtime without
+    /// rewriting ``SKILL.md`` / ``tools.yaml`` files.
+    fn load_skill_object(&self, metadata: dcc_mcp_models::SkillMetadata) -> PyResult<Vec<String>> {
+        self.catalog
+            .load_skill_object(metadata)
+            .map_err(pyo3::exceptions::PyValueError::new_err)
+    }
+
     /// Unload a skill — removes its tools from the ToolRegistry.
     ///
     /// Returns the number of actions removed.

--- a/crates/dcc-mcp-skills/src/catalog/catalog.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog.rs
@@ -159,6 +159,17 @@ impl SkillCatalog {
         })
     }
 
+    /// Get a mutable-by-copy skill metadata object for adapter-side policy changes.
+    ///
+    /// The returned [`SkillMetadata`] is detached from the catalog. Mutating it
+    /// does not affect discovery state or registered tools until the caller
+    /// passes it back through [`load_skill_object`](Self::load_skill_object).
+    pub fn get_skill(&self, skill_name: &str) -> Option<SkillMetadata> {
+        self.entries
+            .get(skill_name)
+            .map(|entry| entry.metadata.clone())
+    }
+
     /// Get the number of skills in the catalog.
     #[must_use]
     pub fn len(&self) -> usize {

--- a/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
@@ -67,6 +67,42 @@ impl SkillCatalog {
         self.load_skill_recursive(skill_name, activate_groups, &mut visiting)
     }
 
+    /// Load a caller-supplied skill metadata object through the normal catalog path.
+    ///
+    /// This is the adapter-facing escape hatch for runtime metadata policy
+    /// changes. Adapters can call [`get_skill`](Self::get_skill), modify the
+    /// returned copy, then pass it here so registration, dispatcher wiring,
+    /// group activation, dependency checks, and lifecycle events remain
+    /// centralized in core.
+    pub fn load_skill_object(&self, metadata: SkillMetadata) -> Result<Vec<String>, String> {
+        let skill_name = metadata.name.clone();
+        if skill_name.trim().is_empty() {
+            return Err("Cannot load a skill object with an empty name".to_string());
+        }
+
+        let scope = self
+            .entries
+            .get(&skill_name)
+            .map(|entry| entry.scope)
+            .unwrap_or(SkillScope::Repo);
+
+        if self.loaded.contains(skill_name.as_str()) {
+            self.unload_skill(&skill_name)?;
+        }
+
+        self.entries.insert(
+            skill_name.clone(),
+            SkillEntry {
+                metadata,
+                state: SkillState::Discovered,
+                registered_tools: Vec::new(),
+                scope,
+            },
+        );
+        self.refresh_dependency_states();
+        self.load_skill(&skill_name)
+    }
+
     fn load_skill_recursive(
         &self,
         skill_name: &str,

--- a/crates/dcc-mcp-skills/src/catalog/tests/test_catalog_crud.rs
+++ b/crates/dcc-mcp-skills/src/catalog/tests/test_catalog_crud.rs
@@ -325,6 +325,55 @@ fn test_load_skill_propagates_thread_affinity_enforcement() {
 }
 
 #[test]
+fn test_get_skill_returns_detached_metadata_copy() {
+    let catalog = make_test_catalog();
+    catalog.add_skill(make_test_skill("mutable-skill", "maya", &["host_scene"]));
+
+    let mut metadata = catalog
+        .get_skill("mutable-skill")
+        .expect("skill metadata should be available");
+    metadata.description = "adapter-local change".to_string();
+
+    let info = catalog.get_skill_info("mutable-skill").unwrap();
+    assert_eq!(
+        info.description, "Test skill: mutable-skill",
+        "mutating the returned copy must not alter catalog state"
+    );
+}
+
+#[test]
+fn test_load_skill_object_applies_tool_declaration_overrides() {
+    let (catalog, dispatcher) = make_catalog_with_dispatcher();
+    catalog.set_in_process_executor(|_, _, _| Ok(serde_json::json!({"ok": true})));
+    let mut skill = make_test_skill("mutable-affinity", "maya", &[]);
+    skill.tools = vec![ToolDeclaration {
+        name: "host_scene".to_string(),
+        source_file: "scripts/host_scene.py".to_string(),
+        thread_affinity: ThreadAffinity::Main,
+        enforce_thread_affinity: true,
+        ..Default::default()
+    }];
+    catalog.add_skill(skill);
+
+    let mut metadata = catalog.get_skill("mutable-affinity").unwrap();
+    metadata.tools[0].enforce_thread_affinity = false;
+    let registered = catalog.load_skill_object(metadata).unwrap();
+
+    assert_eq!(registered, vec!["mutable_affinity__host_scene".to_string()]);
+    let meta = catalog
+        .registry()
+        .get_action("mutable_affinity__host_scene", None)
+        .expect("action registered from modified skill object");
+    assert_eq!(meta.thread_affinity, ThreadAffinity::Main);
+    assert!(!meta.enforce_thread_affinity);
+
+    let ok = dispatcher
+        .dispatch("mutable_affinity__host_scene", serde_json::json!({}))
+        .expect("worker dispatch should be allowed after override");
+    assert_eq!(ok.output, serde_json::json!({"ok": true}));
+}
+
+#[test]
 fn test_load_main_affinity_script_requires_in_process_executor() {
     let (catalog, _dispatcher) = make_catalog_with_dispatcher();
     let mut skill = make_test_skill("main-thread", "maya", &[]);

--- a/crates/dcc-mcp-skills/src/python/catalog.rs
+++ b/crates/dcc-mcp-skills/src/python/catalog.rs
@@ -9,6 +9,7 @@ use pyo3_stub_gen_derive::gen_stub_pymethods;
 use crate::catalog::{SkillCatalog, SkillSummary, helpers};
 use dcc_mcp_actions::EventBus;
 use dcc_mcp_actions::registry::ToolRegistry;
+use dcc_mcp_models::SkillMetadata;
 
 #[cfg_attr(feature = "stub-gen", gen_stub_pymethods)]
 #[pymethods]
@@ -175,6 +176,25 @@ impl SkillCatalog {
     #[pyo3(name = "load_skill")]
     fn py_load_skill(&self, skill_name: &str) -> PyResult<Vec<String>> {
         self.load_skill(skill_name)
+            .map_err(pyo3::exceptions::PyValueError::new_err)
+    }
+
+    /// Return a detached, mutable skill metadata object.
+    ///
+    /// Mutating the returned object does not affect catalog state until it is
+    /// passed back to ``load_skill_object``.
+    #[pyo3(name = "get_skill")]
+    fn py_get_skill(&self, skill_name: &str) -> Option<SkillMetadata> {
+        self.get_skill(skill_name)
+    }
+
+    /// Load a caller-supplied skill metadata object through core registration.
+    ///
+    /// This lets adapters adjust tool declarations at runtime without parsing
+    /// or rewriting ``SKILL.md`` / ``tools.yaml`` sidecar files.
+    #[pyo3(name = "load_skill_object")]
+    fn py_load_skill_object(&self, metadata: SkillMetadata) -> PyResult<Vec<String>> {
+        self.load_skill_object(metadata)
             .map_err(pyo3::exceptions::PyValueError::new_err)
     }
 

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -131,7 +131,21 @@ catalog.list_skills("unloaded")    # only unloaded
 
 # Detail
 info = catalog.get_skill_info("maya-geometry")  # dict with full details or None
+
+# Adapter-side runtime policy changes
+skill = catalog.get_skill("maya-geometry")  # detached SkillMetadata copy
+for tool in skill.tools:
+    if tool.thread_affinity == "main":
+        tool.enforce_thread_affinity = False
+catalog.load_skill_object(skill)  # registers through the normal core path
 ```
+
+Use `get_skill()` / `load_skill_object()` when an adapter must adjust skill
+metadata at runtime before registration, for example standalone/headless
+compatibility for main-thread tools. Do not parse or rewrite `SKILL.md` or
+`tools.yaml` from adapter code for those runtime overrides. `get_skill_info()`
+remains the serialized inspection view; mutating the returned dict does not
+change catalog state.
 
 ### SkillSummary Fields
 

--- a/python/dcc_mcp_core/_server/skill_query.py
+++ b/python/dcc_mcp_core/_server/skill_query.py
@@ -2,9 +2,9 @@
 
 Bundles the 11 read-mostly methods that were previously inline on
 ``DccServerBase``: ``list_actions``, ``list_skills``, ``search_skills``,
-``load_skill``, ``unload_skill``, ``search_actions``, ``get_skill_categories``,
-``get_skill_tags``, ``unregister_skill``, ``is_skill_loaded``,
-``get_skill_info``.
+``load_skill``, ``get_skill``, ``load_skill_object``, ``unload_skill``,
+``search_actions``, ``get_skill_categories``, ``get_skill_tags``,
+``unregister_skill``, ``is_skill_loaded``, ``get_skill_info``.
 
 All methods preserve the original tolerant-of-failure semantics: any
 underlying exception is logged at DEBUG level and a sensible empty value
@@ -73,6 +73,23 @@ class SkillQueryClient:
             return True
         except Exception as exc:
             logger.debug("[%s] load_skill(%r) failed: %s", self._dcc_name, name, exc)
+            return False
+
+    def get_skill(self, name: str) -> Any | None:
+        """Return a detached mutable ``SkillMetadata`` object, if present."""
+        try:
+            return self._server.get_skill(name)
+        except Exception as exc:
+            logger.debug("[%s] get_skill(%r) failed: %s", self._dcc_name, name, exc)
+            return None
+
+    def load_skill_object(self, skill: Any) -> bool:
+        """Load a caller-supplied ``SkillMetadata`` object through core."""
+        try:
+            self._server.load_skill_object(skill)
+            return True
+        except Exception as exc:
+            logger.debug("[%s] load_skill_object failed: %s", self._dcc_name, exc)
             return False
 
     def unload_skill(self, name: str) -> bool:

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -570,6 +570,14 @@ class DccServerBase:
         """Load a skill by name."""
         return self._skill_client.load_skill(name)
 
+    def get_skill(self, name: str) -> Any | None:
+        """Return a detached mutable ``SkillMetadata`` object for a skill."""
+        return self._skill_client.get_skill(name)
+
+    def load_skill_object(self, skill: Any) -> bool:
+        """Load a caller-supplied ``SkillMetadata`` object through core."""
+        return self._skill_client.load_skill_object(skill)
+
     def unload_skill(self, name: str) -> bool:
         """Unload a skill by name."""
         return self._skill_client.unload_skill(name)

--- a/skills/dcc-mcp-skill-developer/SKILL.md
+++ b/skills/dcc-mcp-skill-developer/SKILL.md
@@ -103,11 +103,18 @@ into a faster authoring loop.
    `set_in_process_executor` and HTTP `attach_dispatcher` before server start,
    so MCP `tools/call` and REST `/v1/call` satisfy `thread_affinity: main`.
 10. Skill script entry points may use either modern `main(**params)` or legacy
-   `main(params)` signatures; prefer `main(**params)` for new scripts and keep
-   dict-style wrappers only for compatibility during adapter migrations.
-11. Add tests at the lowest executable layer, then one discovery/load/call or
-   gateway REST path when behavior crosses MCP or REST boundaries.
-12. For application UI automation, use the generic `app_ui__*` contract rather
+    `main(params)` signatures; prefer `main(**params)` for new scripts and keep
+    dict-style wrappers only for compatibility during adapter migrations.
+11. When an adapter must adjust discovered skill metadata before registration
+    (for example disabling thread-affinity enforcement for a standalone path),
+    use `catalog.get_skill(name)` to obtain a detached `SkillMetadata` copy,
+    mutate its `tools` / `groups` / policy fields, then call
+    `catalog.load_skill_object(skill)` or `server.load_skill_object(skill)`.
+    Do not parse or rewrite `SKILL.md` / `tools.yaml` at adapter runtime.
+    Keep `get_skill_info()` for serialized inspection only.
+12. Add tests at the lowest executable layer, then one discovery/load/call or
+    gateway REST path when behavior crosses MCP or REST boundaries.
+13. For application UI automation, use the generic `app_ui__*` contract rather
     than DCC-specific names: snapshot -> find -> act -> wait_for -> verify.
     The Rust contract types live in `dcc-mcp-app-ui`; do not add Qt, OS
     accessibility, webview, PyO3, or HTTP runtime dependencies there.

--- a/tests/test_dcc_adapter_base.py
+++ b/tests/test_dcc_adapter_base.py
@@ -296,6 +296,12 @@ class _FakeDccServer:
     def load_skill(self, name):
         pass
 
+    def get_skill(self, name):
+        return None
+
+    def load_skill_object(self, skill):
+        pass
+
     def unload_skill(self, name):
         pass
 
@@ -573,9 +579,18 @@ class TestDccServerBase:
         result = server.get_skill_info("nonexistent-skill")
         assert result is None
 
+    def test_get_skill_returns_none_when_missing(self, tmp_path):
+        server = self._make_server(tmp_path)
+        result = server.get_skill("nonexistent-skill")
+        assert result is None
+
     def test_load_skill_returns_bool(self, tmp_path):
         server = self._make_server(tmp_path)
         assert server.load_skill("some-skill") is True
+
+    def test_load_skill_object_returns_bool(self, tmp_path):
+        server = self._make_server(tmp_path)
+        assert server.load_skill_object(object()) is True
 
     def test_unload_skill_returns_bool(self, tmp_path):
         server = self._make_server(tmp_path)

--- a/tests/test_progressive_skill_discovery.py
+++ b/tests/test_progressive_skill_discovery.py
@@ -51,6 +51,46 @@ def make_skill_dir(tmp_path: Path, name: str, dcc: str = "maya") -> Path:
     return skill_dir
 
 
+def make_mutable_tool_skill_dir(tmp_path: Path, name: str, dcc: str = "maya") -> Path:
+    """Create a skill with a main-thread tool declaration."""
+    skill_dir = tmp_path / name
+    (skill_dir / "scripts").mkdir(parents=True)
+    (skill_dir / "scripts" / "host_scene.py").write_text(
+        'import json,sys; print(json.dumps({"success":True,"message":"ok"}))',
+        encoding="utf-8",
+    )
+    (skill_dir / "SKILL.md").write_text(
+        "\n".join(
+            [
+                "---",
+                f"name: {name}",
+                "description: Mutable test skill",
+                "metadata:",
+                "  dcc-mcp:",
+                f"    dcc: {dcc}",
+                "    tools: tools.yaml",
+                "---",
+                f"# {name}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (skill_dir / "tools.yaml").write_text(
+        "\n".join(
+            [
+                "tools:",
+                "  - name: host_scene",
+                "    description: Host scene tool",
+                "    source_file: scripts/host_scene.py",
+                "    thread_affinity: main",
+                "    enforce_thread_affinity: true",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
 def make_catalog(extra_paths: list[str]) -> SkillCatalog:
     """Create a fresh SkillCatalog and run discover()."""
     cat = SkillCatalog(ToolRegistry())
@@ -330,6 +370,42 @@ class TestSkillCatalogProgressivePipeline:
         cat.load_skill("info-skill")
         info = cat.get_skill_info("info-skill")
         assert info is not None
+
+    def test_get_skill_returns_mutable_copy_for_runtime_tool_overrides(self, tmp_path: Path) -> None:
+        """Adapters can mutate a skill object then load it through core."""
+        make_mutable_tool_skill_dir(tmp_path, "mutable-affinity", dcc="maya")
+        registry = ToolRegistry()
+        cat = SkillCatalog(registry)
+        cat.set_in_process_executor(lambda *_args, **_kwargs: {"success": True})
+        cat.discover(extra_paths=[str(tmp_path)])
+
+        skill = cat.get_skill("mutable-affinity")
+        assert isinstance(skill, SkillMetadata)
+        tools = skill.tools
+        assert tools[0].enforce_thread_affinity is True
+        tools[0].enforce_thread_affinity = False
+        skill.tools = tools
+
+        loaded = cat.load_skill_object(skill)
+
+        assert loaded == ["mutable_affinity__host_scene"]
+        meta = registry.get_action("mutable_affinity__host_scene")
+        assert meta is not None
+        assert meta["thread_affinity"] == "main"
+        assert meta.get("enforce_thread_affinity", False) is False
+
+    def test_get_skill_info_remains_serialized_view(self, tmp_path: Path) -> None:
+        """Mutating get_skill_info() output does not change catalog metadata."""
+        make_mutable_tool_skill_dir(tmp_path, "readonly-info", dcc="photoshop")
+        cat = make_catalog(extra_paths=[str(tmp_path)])
+
+        info = cat.get_skill_info("readonly-info")
+        assert info is not None
+        info["tools"][0]["enforce_thread_affinity"] = False
+
+        skill = cat.get_skill("readonly-info")
+        assert isinstance(skill, SkillMetadata)
+        assert skill.tools[0].enforce_thread_affinity is True
 
     def test_load_unknown_skill_raises(self, tmp_path: Path) -> None:
         """load_skill() raises for an unknown skill name."""


### PR DESCRIPTION
## Summary
- expose detached SkillMetadata retrieval with `get_skill`
- add `load_skill_object` so adapters can mutate tool declarations before core registration
- document the runtime override workflow and keep `get_skill_info` as serialized inspection

## Validation
- `vx cargo test -p dcc-mcp-skills`
- `vx cargo clippy -p dcc-mcp-skills -p dcc-mcp-http-py --all-targets -- -D warnings`
- `$env:DCC_MCP_ADMIN_UI_PREBUILT='1'; vx just dev`
- `.venv\Scripts\python.exe -m pytest tests\test_progressive_skill_discovery.py tests\test_dcc_adapter_base.py -q`

Closes #1162