### PR TITLE
feat: extend compact REST responses

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
@@ -5,7 +5,9 @@ use crate::gateway::capability_service::{
     ServiceError, call_service, describe_tool_full, parse_search_payload,
     refresh_all_live_backends, search_service_rows, service_error_to_json,
 };
-use crate::gateway::response_codec::search_response;
+use crate::gateway::response_codec::{
+    compact_call_batch_payload, compact_describe_payload, negotiated_response, search_response,
+};
 
 #[derive(Debug, Deserialize)]
 pub struct DccInstanceDescribeQuery {
@@ -318,7 +320,7 @@ pub async fn handle_v1_search(
             }
             Err(err) => {
                 drop(registry);
-                return resolve_instance_http_response(err).into_response();
+                return resolve_instance_negotiated_response(&headers, &body, err);
             }
         }
     }
@@ -365,43 +367,48 @@ async fn skill_lifecycle_response(gs: &GatewayState, tool: &str, body: Value) ->
 /// Request body: `{"tool_slug": "<dcc>.<id8>.<tool>"}`.
 pub async fn handle_v1_describe(
     State(gs): State<GatewayState>,
+    headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> Response {
     let Some(slug) = body.get("tool_slug").and_then(Value::as_str) else {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(service_error_to_json(&ServiceError::new(
-                "bad-request",
-                "missing required field: tool_slug",
-            ))),
-        )
-            .into_response();
+        return service_error_response(
+            &headers,
+            &body,
+            &ServiceError::new("bad-request", "missing required field: tool_slug"),
+        );
     };
     refresh_all_live_backends(&gs, RefreshReason::Periodic).await;
 
-    describe_slug_response(&gs, slug).await
+    describe_slug_response(&gs, &headers, &body, slug).await
 }
 
 /// `GET /v1/tools/{slug}` — path form of describe.
 pub async fn handle_v1_describe_path(
     State(gs): State<GatewayState>,
+    headers: HeaderMap,
     Path(slug): Path<String>,
 ) -> Response {
     refresh_all_live_backends(&gs, RefreshReason::Periodic).await;
-    describe_slug_response(&gs, &slug).await
+    let body = json!({});
+    describe_slug_response(&gs, &headers, &body, &slug).await
 }
 
-async fn describe_slug_response(gs: &GatewayState, slug: &str) -> Response {
+async fn describe_slug_response(
+    gs: &GatewayState,
+    headers: &HeaderMap,
+    body: &Value,
+    slug: &str,
+) -> Response {
     match describe_tool_full(gs, slug).await {
-        Ok((record, tool)) => (
-            StatusCode::OK,
-            Json(json!({
+        Ok((record, tool)) => {
+            let legacy = json!({
                 "record": record,
                 "tool": tool,
-            })),
-        )
-            .into_response(),
-        Err(err) => error_response(&err).into_response(),
+            });
+            let compact = compact_describe_payload(&legacy);
+            negotiated_response(headers, body, StatusCode::OK, legacy, Some(compact))
+        }
+        Err(err) => service_error_response(headers, body, &err),
     }
 }
 
@@ -413,19 +420,21 @@ async fn describe_slug_response(gs: &GatewayState, slug: &str) -> Response {
 /// Response matches [`handle_v1_describe_path`] (`GET /v1/tools/{slug}`).
 pub async fn handle_v1_dcc_instance_describe(
     State(gs): State<GatewayState>,
+    headers: HeaderMap,
     Path((dcc_type, instance_id)): Path<(String, String)>,
     Query(q): Query<DccInstanceDescribeQuery>,
 ) -> Response {
+    let body = json!({});
     let backend_tool = q.backend_tool.trim();
     if backend_tool.is_empty() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(service_error_to_json(&ServiceError::new(
+        return service_error_response(
+            &headers,
+            &body,
+            &ServiceError::new(
                 "bad-request",
                 "missing or empty required query parameter: backend_tool (aliases: tool, action)",
-            ))),
-        )
-            .into_response();
+            ),
+        );
     }
 
     refresh_all_live_backends(&gs, RefreshReason::Periodic).await;
@@ -439,24 +448,24 @@ pub async fn handle_v1_dcc_instance_describe(
         Ok(e) => e,
         Err(err) => {
             drop(registry);
-            return resolve_instance_http_response(err).into_response();
+            return resolve_instance_negotiated_response(&headers, &body, err);
         }
     };
     drop(registry);
 
     if !entry.dcc_type.eq_ignore_ascii_case(dcc_type.as_str()) {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(service_error_to_json(&ServiceError::new(
+        return service_error_response(
+            &headers,
+            &body,
+            &ServiceError::new(
                 "bad-request",
                 "path dcc_type does not match resolved registry row",
-            ))),
-        )
-            .into_response();
+            ),
+        );
     }
 
     let slug = tool_slug(&entry.dcc_type, &entry.instance_id, backend_tool);
-    describe_slug_response(&gs, &slug).await
+    describe_slug_response(&gs, &headers, &body, &slug).await
 }
 
 /// `POST /v1/call` — invoke a backend action by slug.
@@ -469,27 +478,21 @@ pub async fn handle_v1_call(
     Json(body): Json<Value>,
 ) -> Response {
     let Some(slug) = body.get("tool_slug").and_then(Value::as_str) else {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(service_error_to_json(&ServiceError::new(
-                "bad-request",
-                "missing required field: tool_slug",
-            ))),
-        )
-            .into_response();
+        return service_error_response(
+            &headers,
+            &body,
+            &ServiceError::new("bad-request", "missing required field: tool_slug"),
+        );
     };
     let arguments =
         match dcc_mcp_jsonrpc::coerce_tool_arguments_object(body.get("arguments").cloned()) {
             Ok(v) => v,
             Err(msg) => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(service_error_to_json(&ServiceError::new(
-                        "bad-request",
-                        msg,
-                    ))),
-                )
-                    .into_response();
+                return service_error_response(
+                    &headers,
+                    &body,
+                    &ServiceError::new("bad-request", msg),
+                );
             }
         };
     let meta = body.get("meta").cloned();
@@ -497,8 +500,8 @@ pub async fn handle_v1_call(
     match call_service_with_admin_trace(&gs, &headers, "v1/call", slug, arguments, meta, &body)
         .await
     {
-        Ok(result) => (StatusCode::OK, Json(result)).into_response(),
-        Err(err) => error_response(&err).into_response(),
+        Ok(result) => negotiated_response(&headers, &body, StatusCode::OK, result, None),
+        Err(err) => service_error_response(&headers, &body, &err),
     }
 }
 
@@ -527,14 +530,14 @@ pub async fn handle_v1_dcc_instance_call(
         .map(str::trim)
         .filter(|s| !s.is_empty());
     let Some(backend_tool) = backend_tool else {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(service_error_to_json(&ServiceError::new(
+        return service_error_response(
+            &headers,
+            &body,
+            &ServiceError::new(
                 "bad-request",
                 "missing required field: backend_tool (accepted aliases: tool, action)",
-            ))),
-        )
-            .into_response();
+            ),
+        );
     };
 
     refresh_all_live_backends(&gs, RefreshReason::Periodic).await;
@@ -548,20 +551,20 @@ pub async fn handle_v1_dcc_instance_call(
         Ok(e) => e,
         Err(err) => {
             drop(registry);
-            return resolve_instance_http_response(err).into_response();
+            return resolve_instance_negotiated_response(&headers, &body, err);
         }
     };
     drop(registry);
 
     if !entry.dcc_type.eq_ignore_ascii_case(dcc_type.as_str()) {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(service_error_to_json(&ServiceError::new(
+        return service_error_response(
+            &headers,
+            &body,
+            &ServiceError::new(
                 "bad-request",
                 "path dcc_type does not match resolved registry row",
-            ))),
-        )
-            .into_response();
+            ),
+        );
     }
 
     let slug = tool_slug(&entry.dcc_type, &entry.instance_id, backend_tool);
@@ -569,14 +572,11 @@ pub async fn handle_v1_dcc_instance_call(
         match dcc_mcp_jsonrpc::coerce_tool_arguments_object(body.get("arguments").cloned()) {
             Ok(v) => v,
             Err(msg) => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(service_error_to_json(&ServiceError::new(
-                        "bad-request",
-                        msg,
-                    ))),
-                )
-                    .into_response();
+                return service_error_response(
+                    &headers,
+                    &body,
+                    &ServiceError::new("bad-request", msg),
+                );
             }
         };
     let meta = body.get("meta").cloned();
@@ -592,36 +592,44 @@ pub async fn handle_v1_dcc_instance_call(
     )
     .await
     {
-        Ok(result) => (StatusCode::OK, Json(result)).into_response(),
-        Err(err) => error_response(&err).into_response(),
+        Ok(result) => negotiated_response(&headers, &body, StatusCode::OK, result, None),
+        Err(err) => service_error_response(&headers, &body, &err),
     }
 }
 
 pub(crate) fn resolve_instance_http_response(err: ResolveInstanceError) -> impl IntoResponse {
+    let (status, body) = resolve_instance_error_parts(&err);
+    (status, Json(body))
+}
+
+fn resolve_instance_negotiated_response(
+    headers: &HeaderMap,
+    body: &Value,
+    err: ResolveInstanceError,
+) -> Response {
+    let (status, legacy) = resolve_instance_error_parts(&err);
+    negotiated_response(headers, body, status, legacy, None)
+}
+
+fn resolve_instance_error_parts(err: &ResolveInstanceError) -> (StatusCode, Value) {
     let refresh_hint = " After a DCC crash or reconnect the instance UUID usually changes — call \
         GET /v1/instances (or resources/read gateway://instances), then search_tools / POST /v1/search \
         again; do not reuse old tool_slug strings.";
-    match &err {
+    match err {
         ResolveInstanceError::PrefixTooShort { .. } => (
             StatusCode::BAD_REQUEST,
-            Json(service_error_to_json(&ServiceError::new(
-                "bad-request",
-                err.to_string(),
-            ))),
+            service_error_to_json(&ServiceError::new("bad-request", err.to_string())),
         ),
         ResolveInstanceError::NoMatch { .. } => (
             StatusCode::NOT_FOUND,
-            Json(service_error_to_json(
+            service_error_to_json(
                 &ServiceError::new("instance-offline", format!("{err}.{refresh_hint}"))
                     .with_instance_provenance("never-registered", None),
-            )),
+            ),
         ),
         ResolveInstanceError::MultipleMatches { .. } => (
             StatusCode::CONFLICT,
-            Json(service_error_to_json(&ServiceError::new(
-                "ambiguous",
-                err.to_string(),
-            ))),
+            service_error_to_json(&ServiceError::new("ambiguous", err.to_string())),
         ),
     }
 }
@@ -636,15 +644,17 @@ pub async fn handle_v1_call_batch(
     Json(body): Json<Value>,
 ) -> Response {
     match call_batch_with_admin_trace(&gs, &headers, &body).await {
-        Ok(value) => (StatusCode::OK, Json(value)).into_response(),
-        Err(message) => (
-            StatusCode::BAD_REQUEST,
-            Json(json!({
+        Ok(value) => {
+            let compact = compact_call_batch_payload(&value);
+            negotiated_response(&headers, &body, StatusCode::OK, value, Some(compact))
+        }
+        Err(message) => {
+            let legacy = json!({
                 "success": false,
                 "error": {"kind": "bad-request", "message": message},
-            })),
-        )
-            .into_response(),
+            });
+            negotiated_response(&headers, &body, StatusCode::BAD_REQUEST, legacy, None)
+        }
     }
 }
 
@@ -958,8 +968,8 @@ fn now_ns() -> u64 {
         .unwrap_or(0)
 }
 
-fn error_response(err: &ServiceError) -> (StatusCode, Json<Value>) {
-    let status = match err.kind.as_str() {
+fn service_error_status(err: &ServiceError) -> StatusCode {
+    match err.kind.as_str() {
         "unknown-slug" => StatusCode::NOT_FOUND,
         "ambiguous" => StatusCode::CONFLICT,
         "instance-offline" => StatusCode::SERVICE_UNAVAILABLE,
@@ -967,440 +977,19 @@ fn error_response(err: &ServiceError) -> (StatusCode, Json<Value>) {
         "host-died" => StatusCode::BAD_GATEWAY,
         "backend-error" | "schema-unavailable" => StatusCode::BAD_GATEWAY,
         _ => StatusCode::BAD_REQUEST,
-    };
-    (status, Json(service_error_to_json(err)))
+    }
+}
+
+fn service_error_response(headers: &HeaderMap, body: &Value, err: &ServiceError) -> Response {
+    negotiated_response(
+        headers,
+        body,
+        service_error_status(err),
+        service_error_to_json(err),
+        None,
+    )
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use axum::body::to_bytes;
-    use dcc_mcp_transport::discovery::file_registry::FileRegistry;
-    use dcc_mcp_transport::discovery::types::ServiceEntry;
-    use std::collections::HashMap;
-    use std::sync::{Arc, Mutex};
-    use std::time::Duration;
-    use tokio::sync::{RwLock, broadcast, watch};
-
-    #[derive(Default)]
-    struct CaptureSink(Mutex<Vec<crate::gateway::middleware::AuditEntry>>);
-
-    impl crate::gateway::middleware::AuditSink for CaptureSink {
-        fn record(&self, entry: crate::gateway::middleware::AuditEntry) {
-            self.0.lock().unwrap().push(entry);
-        }
-    }
-
-    struct ReplaceArgs(serde_json::Value);
-
-    impl crate::gateway::middleware::BeforeCallMiddleware for ReplaceArgs {
-        fn before_call<'a>(
-            &'a self,
-            ctx: &'a mut crate::gateway::middleware::CallContext,
-        ) -> std::pin::Pin<
-            Box<
-                dyn std::future::Future<
-                        Output = Result<(), crate::gateway::middleware::MiddlewareError>,
-                    > + Send
-                    + 'a,
-            >,
-        > {
-            ctx.args = self.0.clone();
-            Box::pin(async move { Ok::<(), crate::gateway::middleware::MiddlewareError>(()) })
-        }
-    }
-
-    fn test_gateway_state(server_version: &str) -> GatewayState {
-        test_gateway_state_with_debug_routes(server_version, false)
-    }
-
-    fn test_gateway_state_with_debug_routes(
-        server_version: &str,
-        debug_routes_enabled: bool,
-    ) -> GatewayState {
-        let dir = tempfile::tempdir().unwrap();
-        let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
-        let (yield_tx, _) = watch::channel(false);
-        let (events_tx, _) = broadcast::channel::<String>(8);
-        GatewayState {
-            registry,
-            stale_timeout: Duration::from_secs(30),
-            backend_timeout: Duration::from_secs(10),
-            async_dispatch_timeout: Duration::from_secs(60),
-            wait_terminal_timeout: Duration::from_secs(600),
-            server_name: "test".into(),
-            server_version: server_version.into(),
-            own_host: "127.0.0.1".into(),
-            own_port: 9765,
-            http_client: reqwest::Client::new(),
-            yield_tx: Arc::new(yield_tx),
-            events_tx: Arc::new(events_tx),
-            protocol_version: Arc::new(RwLock::new(None)),
-            resource_subscriptions: Arc::new(RwLock::new(HashMap::new())),
-            pending_calls: Arc::new(RwLock::new(HashMap::new())),
-            subscriber: crate::gateway::sse_subscriber::SubscriberManager::default(),
-            allow_unknown_tools: false,
-            adapter_version: None,
-            adapter_dcc: None,
-            capability_index: Arc::new(crate::gateway::capability::CapabilityIndex::new()),
-            event_log: Arc::new(crate::gateway::event_log::EventLog::new()),
-            middleware_chain: Arc::new(crate::gateway::middleware::MiddlewareChain::new()),
-            instance_diagnostics: Arc::new(
-                crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
-            ),
-            traffic_capture: Arc::new(crate::gateway::traffic::TrafficCapture::disabled()),
-            debug_routes_enabled,
-            #[cfg(feature = "prometheus")]
-            gateway_metrics: Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
-        }
-    }
-
-    async fn response_json(resp: Response) -> (StatusCode, Value) {
-        let status = resp.status();
-        let bytes = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
-        let body = serde_json::from_slice(&bytes).unwrap();
-        (status, body)
-    }
-
-    async fn response_text(resp: Response) -> (StatusCode, String) {
-        let status = resp.status();
-        let bytes = to_bytes(resp.into_body(), 4 * 1024 * 1024).await.unwrap();
-        (status, String::from_utf8_lossy(&bytes).to_string())
-    }
-
-    #[tokio::test]
-    async fn gateway_readyz_summarises_instance_readiness_bits() {
-        let gs = test_gateway_state("1.2.3");
-        let mut entry = ServiceEntry::new("maya", "127.0.0.1", 18812);
-        entry.instance_id = uuid::Uuid::parse_str("abcdef01-2345-6789-abcd-ef0123456789").unwrap();
-        {
-            let registry = gs.registry.read().await;
-            registry.register(entry.clone()).unwrap();
-        }
-        gs.instance_diagnostics.record_readiness(
-            entry.instance_id,
-            dcc_mcp_skill_rest::ReadinessReport {
-                process: true,
-                dcc: true,
-                skill_catalog: true,
-                dispatcher: true,
-                host_execution_bridge: false,
-                main_thread_executor: false,
-            },
-        );
-
-        let (status, body) = response_json(handle_v1_readyz(State(gs)).await.into_response()).await;
-
-        assert_eq!(status, StatusCode::OK);
-        assert_eq!(body["live_instance_count"], 1);
-        assert_eq!(body["ready_instance_count"], 1);
-        assert_eq!(body["instances"][0]["instance_short"], "abcdef01");
-        assert_eq!(body["instances"][0]["readiness"]["skill_catalog"], true);
-        assert_eq!(
-            body["instances"][0]["readiness"]["host_execution_bridge"],
-            false
-        );
-    }
-
-    #[tokio::test]
-    async fn gateway_docs_serves_scalar_openapi_ui() {
-        let (status, body) =
-            response_text(handle_v1_docs(State(test_gateway_state("1.2.3"))).await).await;
-
-        assert_eq!(status, StatusCode::OK);
-        assert!(body.contains("scalar") || body.contains("Scalar"));
-        assert!(body.contains("dcc-mcp-gateway"));
-        assert!(body.contains("/v1/search"));
-        assert!(!body.contains("/v1/debug/instances"));
-    }
-
-    #[tokio::test]
-    #[cfg(feature = "admin")]
-    async fn gateway_docs_lists_debug_routes_when_runtime_debug_routes_enabled() {
-        let (status, body) = response_text(
-            handle_v1_docs(State(test_gateway_state_with_debug_routes("1.2.3", true))).await,
-        )
-        .await;
-
-        assert_eq!(status, StatusCode::OK);
-        assert!(body.contains("/v1/debug/instances"));
-    }
-
-    #[tokio::test]
-    #[cfg(feature = "admin")]
-    async fn gateway_openapi_lists_stable_debug_routes() {
-        let (status, doc) = response_json(
-            handle_v1_openapi(State(test_gateway_state_with_debug_routes("1.2.3", true)))
-                .await
-                .into_response(),
-        )
-        .await;
-
-        assert_eq!(status, StatusCode::OK);
-        for path in [
-            "/v1/debug/instances",
-            "/v1/debug/activity",
-            "/v1/debug/calls",
-            "/v1/debug/traces",
-            "/v1/debug/traces/{request_id}",
-            "/v1/debug/trace-context/{lookup_id}",
-            "/v1/debug/tasks",
-            "/v1/debug/bundles/{request_id}",
-            "/v1/debug/issue-reports/{request_id}",
-            "/v1/debug/logs",
-            "/v1/debug/deregistered",
-            "/v1/debug/stats",
-            "/v1/debug/health",
-        ] {
-            assert!(
-                doc["paths"].get(path).is_some(),
-                "gateway OpenAPI doc missing debug path {path}: {doc:#}"
-            );
-        }
-        assert!(
-            doc["tags"]
-                .as_array()
-                .is_some_and(|tags| tags.iter().any(|tag| tag["name"] == "debug"))
-        );
-        assert!(
-            doc["components"]["schemas"]
-                .get("GatewayDebugPayload")
-                .is_some()
-        );
-    }
-
-    #[tokio::test]
-    #[cfg(feature = "admin")]
-    async fn gateway_openapi_omits_debug_routes_when_runtime_admin_disabled() {
-        let (status, doc) = response_json(
-            handle_v1_openapi(State(test_gateway_state("1.2.3")))
-                .await
-                .into_response(),
-        )
-        .await;
-
-        assert_eq!(status, StatusCode::OK);
-        assert!(doc["paths"].get("/v1/search").is_some());
-        assert!(doc["paths"].get("/v1/debug/instances").is_none());
-        assert!(
-            doc["tags"]
-                .as_array()
-                .is_none_or(|tags| !tags.iter().any(|tag| tag["name"] == "debug"))
-        );
-        assert!(
-            doc["components"]["schemas"]
-                .get("GatewayDebugPayload")
-                .is_none()
-        );
-    }
-
-    #[tokio::test]
-    #[cfg(not(feature = "admin"))]
-    async fn gateway_openapi_omits_debug_routes_without_admin_feature() {
-        let (status, doc) = response_json(
-            handle_v1_openapi(State(test_gateway_state("1.2.3")))
-                .await
-                .into_response(),
-        )
-        .await;
-
-        assert_eq!(status, StatusCode::OK);
-        assert!(doc["paths"].get("/v1/search").is_some());
-        assert!(doc["paths"].get("/v1/debug/instances").is_none());
-        assert!(
-            doc["tags"]
-                .as_array()
-                .is_none_or(|tags| !tags.iter().any(|tag| tag["name"] == "debug"))
-        );
-        assert!(
-            doc["components"]["schemas"]
-                .get("GatewayDebugPayload")
-                .is_none()
-        );
-    }
-
-    #[tokio::test]
-    async fn gateway_yield_missing_challenger_is_structured_optional_capability() {
-        let (status, body) = response_json(
-            handle_gateway_yield(
-                State(test_gateway_state("1.2.3")),
-                axum::body::Bytes::from_static(b"{}"),
-            )
-            .await,
-        )
-        .await;
-
-        assert_eq!(status, StatusCode::CONFLICT);
-        assert_eq!(body["success"], false);
-        assert_eq!(body["fallback"], "polling");
-        assert_eq!(body["error"]["kind"], "optional-capability-unsupported");
-        assert_eq!(body["error"]["capability"], "cooperative_yield");
-    }
-
-    #[tokio::test]
-    async fn gateway_yield_same_version_is_structured_optional_capability() {
-        let (status, body) = response_json(
-            handle_gateway_yield(
-                State(test_gateway_state("1.2.3")),
-                axum::body::Bytes::from_static(br#"{"challenger_version":"1.2.3"}"#),
-            )
-            .await,
-        )
-        .await;
-
-        assert_eq!(status, StatusCode::CONFLICT);
-        assert_eq!(body["current_version"], "1.2.3");
-        assert_eq!(body["challenger_version"], "1.2.3");
-        assert_eq!(body["error"]["kind"], "optional-capability-unsupported");
-    }
-
-    #[tokio::test]
-    async fn gateway_yield_newer_challenger_still_accepts() {
-        let (status, body) = response_json(
-            handle_gateway_yield(
-                State(test_gateway_state("1.2.3")),
-                axum::body::Bytes::from_static(br#"{"challenger_version":"1.2.4"}"#),
-            )
-            .await,
-        )
-        .await;
-
-        assert_eq!(status, StatusCode::OK);
-        assert_eq!(body["ok"], true);
-    }
-
-    #[tokio::test]
-    async fn rest_trace_input_payload_uses_redacted_arguments() {
-        use crate::gateway::middleware::{AuditMiddleware, MiddlewareChain, RedactionMiddleware};
-
-        let sink = Arc::new(CaptureSink::default());
-        let chain = MiddlewareChain::new()
-            .with_before(Arc::new(RedactionMiddleware::new(vec!["api_key", "token"])))
-            .with_after(Arc::new(AuditMiddleware::new(sink.clone())));
-        let mut gs = test_gateway_state("1.2.3");
-        gs.middleware_chain = Arc::new(chain);
-
-        let request_body = json!({
-            "tool_slug": "maya.abcdef01.render",
-            "arguments": {
-                "api_key": "secret-key",
-                "nested": {"token": "secret-token"}
-            },
-            "meta": {}
-        });
-
-        let result = call_service_with_admin_trace(
-            &gs,
-            &HeaderMap::new(),
-            "v1/call",
-            "maya.abcdef01.render",
-            request_body["arguments"].clone(),
-            request_body.get("meta").cloned(),
-            &request_body,
-        )
-        .await;
-
-        assert!(result.is_err());
-        let entries = sink.0.lock().unwrap();
-        assert_eq!(entries.len(), 1);
-        let input = entries[0].input_payload.as_ref().unwrap().content.clone();
-        assert!(input.contains("[REDACTED]"));
-        assert!(!input.contains("secret-key"));
-        assert!(!input.contains("secret-token"));
-    }
-
-    #[tokio::test]
-    async fn rest_traceparent_does_not_replace_request_id() {
-        use crate::gateway::middleware::{AuditMiddleware, MiddlewareChain};
-
-        let sink = Arc::new(CaptureSink::default());
-        let chain = MiddlewareChain::new().with_after(Arc::new(AuditMiddleware::new(sink.clone())));
-        let mut gs = test_gateway_state("1.2.3");
-        gs.middleware_chain = Arc::new(chain);
-
-        let mut headers = HeaderMap::new();
-        headers.insert("x-request-id", "req-rest-1".parse().unwrap());
-        headers.insert(
-            "traceparent",
-            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
-                .parse()
-                .unwrap(),
-        );
-        let request_body = json!({
-            "tool_slug": "maya.abcdef01.render",
-            "arguments": {},
-            "meta": {}
-        });
-
-        let _ = call_service_with_admin_trace(
-            &gs,
-            &headers,
-            "v1/call",
-            "maya.abcdef01.render",
-            json!({}),
-            request_body.get("meta").cloned(),
-            &request_body,
-        )
-        .await;
-
-        let entries = sink.0.lock().unwrap();
-        assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].request_id, "req-rest-1");
-        assert_eq!(
-            entries[0].trace_context.trace_id,
-            "4bf92f3577b34da6a3ce929d0e0e4736"
-        );
-        assert_eq!(
-            entries[0].trace_context.parent_span_id.as_deref(),
-            Some("00f067aa0ba902b7")
-        );
-        let root_span_id = entries[0]
-            .trace_context
-            .span_id
-            .as_deref()
-            .expect("REST trace context should create a gateway root span id");
-        assert_eq!(root_span_id.len(), 16);
-        let backend_span = entries[0]
-            .trace_spans
-            .iter()
-            .find(|span| span.name == "backend.execute")
-            .expect("REST call should record backend.execute span");
-        let backend_span_id = backend_span
-            .span_id
-            .as_deref()
-            .expect("backend.execute should carry its own span id");
-        assert_eq!(backend_span_id.len(), 16);
-        assert_ne!(backend_span_id, root_span_id);
-        assert_eq!(backend_span.parent_span_id.as_deref(), Some(root_span_id));
-    }
-
-    #[tokio::test]
-    async fn rest_call_batch_uses_arguments_mutated_by_before_middleware() {
-        use crate::gateway::middleware::{AuditMiddleware, MiddlewareChain, RedactionMiddleware};
-
-        let sink = Arc::new(CaptureSink::default());
-        let rewritten = json!({
-            "calls": [{
-                "tool_slug": "maya.abcdef01.render",
-                "arguments": {"token": "secret-token"}
-            }]
-        });
-        let chain = MiddlewareChain::new()
-            .with_before(Arc::new(ReplaceArgs(rewritten)))
-            .with_before(Arc::new(RedactionMiddleware::new(vec!["token"])))
-            .with_after(Arc::new(AuditMiddleware::new(sink.clone())));
-        let mut gs = test_gateway_state("1.2.3");
-        gs.middleware_chain = Arc::new(chain);
-
-        let result =
-            call_batch_with_admin_trace(&gs, &HeaderMap::new(), &json!({"calls": []})).await;
-
-        let body = result.expect("batch should use middleware-mutated args");
-        assert_eq!(body["results"][0]["tool_slug"], "maya.abcdef01.render");
-        let entries = sink.0.lock().unwrap();
-        assert_eq!(entries.len(), 1);
-        let input = entries[0].input_payload.as_ref().unwrap().content.clone();
-        assert!(input.contains("[REDACTED]"));
-        assert!(!input.contains("secret-token"));
-    }
-}
+#[path = "rest_impl_tests.rs"]
+mod rest_impl_tests;

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
@@ -1,0 +1,526 @@
+use super::*;
+use axum::body::to_bytes;
+use dcc_mcp_transport::discovery::file_registry::FileRegistry;
+use dcc_mcp_transport::discovery::types::ServiceEntry;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::sync::{RwLock, broadcast, watch};
+
+#[derive(Default)]
+struct CaptureSink(Mutex<Vec<crate::gateway::middleware::AuditEntry>>);
+
+impl crate::gateway::middleware::AuditSink for CaptureSink {
+    fn record(&self, entry: crate::gateway::middleware::AuditEntry) {
+        self.0.lock().unwrap().push(entry);
+    }
+}
+
+struct ReplaceArgs(serde_json::Value);
+
+impl crate::gateway::middleware::BeforeCallMiddleware for ReplaceArgs {
+    fn before_call<'a>(
+        &'a self,
+        ctx: &'a mut crate::gateway::middleware::CallContext,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = Result<(), crate::gateway::middleware::MiddlewareError>,
+                > + Send
+                + 'a,
+        >,
+    > {
+        ctx.args = self.0.clone();
+        Box::pin(async move { Ok::<(), crate::gateway::middleware::MiddlewareError>(()) })
+    }
+}
+
+fn test_gateway_state(server_version: &str) -> GatewayState {
+    test_gateway_state_with_debug_routes(server_version, false)
+}
+
+fn test_gateway_state_with_debug_routes(
+    server_version: &str,
+    debug_routes_enabled: bool,
+) -> GatewayState {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = Arc::new(RwLock::new(FileRegistry::new(dir.path()).unwrap()));
+    let (yield_tx, _) = watch::channel(false);
+    let (events_tx, _) = broadcast::channel::<String>(8);
+    GatewayState {
+        registry,
+        stale_timeout: Duration::from_secs(30),
+        backend_timeout: Duration::from_secs(10),
+        async_dispatch_timeout: Duration::from_secs(60),
+        wait_terminal_timeout: Duration::from_secs(600),
+        server_name: "test".into(),
+        server_version: server_version.into(),
+        own_host: "127.0.0.1".into(),
+        own_port: 9765,
+        http_client: reqwest::Client::new(),
+        yield_tx: Arc::new(yield_tx),
+        events_tx: Arc::new(events_tx),
+        protocol_version: Arc::new(RwLock::new(None)),
+        resource_subscriptions: Arc::new(RwLock::new(HashMap::new())),
+        pending_calls: Arc::new(RwLock::new(HashMap::new())),
+        subscriber: crate::gateway::sse_subscriber::SubscriberManager::default(),
+        allow_unknown_tools: false,
+        adapter_version: None,
+        adapter_dcc: None,
+        capability_index: Arc::new(crate::gateway::capability::CapabilityIndex::new()),
+        event_log: Arc::new(crate::gateway::event_log::EventLog::new()),
+        middleware_chain: Arc::new(crate::gateway::middleware::MiddlewareChain::new()),
+        instance_diagnostics: Arc::new(
+            crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
+        ),
+        traffic_capture: Arc::new(crate::gateway::traffic::TrafficCapture::disabled()),
+        debug_routes_enabled,
+        #[cfg(feature = "prometheus")]
+        gateway_metrics: Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
+    }
+}
+
+async fn response_json(resp: Response) -> (StatusCode, Value) {
+    let status = resp.status();
+    let bytes = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
+    let body = serde_json::from_slice(&bytes).unwrap();
+    (status, body)
+}
+
+async fn response_text(resp: Response) -> (StatusCode, String) {
+    let status = resp.status();
+    let bytes = to_bytes(resp.into_body(), 4 * 1024 * 1024).await.unwrap();
+    (status, String::from_utf8_lossy(&bytes).to_string())
+}
+
+async fn response_text_with_headers(resp: Response) -> (StatusCode, HeaderMap, String) {
+    let status = resp.status();
+    let headers = resp.headers().clone();
+    let bytes = to_bytes(resp.into_body(), 4 * 1024 * 1024).await.unwrap();
+    (status, headers, String::from_utf8_lossy(&bytes).to_string())
+}
+
+#[tokio::test]
+async fn gateway_readyz_summarises_instance_readiness_bits() {
+    let gs = test_gateway_state("1.2.3");
+    let mut entry = ServiceEntry::new("maya", "127.0.0.1", 18812);
+    entry.instance_id = uuid::Uuid::parse_str("abcdef01-2345-6789-abcd-ef0123456789").unwrap();
+    {
+        let registry = gs.registry.read().await;
+        registry.register(entry.clone()).unwrap();
+    }
+    gs.instance_diagnostics.record_readiness(
+        entry.instance_id,
+        dcc_mcp_skill_rest::ReadinessReport {
+            process: true,
+            dcc: true,
+            skill_catalog: true,
+            dispatcher: true,
+            host_execution_bridge: false,
+            main_thread_executor: false,
+        },
+    );
+
+    let (status, body) = response_json(handle_v1_readyz(State(gs)).await.into_response()).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["live_instance_count"], 1);
+    assert_eq!(body["ready_instance_count"], 1);
+    assert_eq!(body["instances"][0]["instance_short"], "abcdef01");
+    assert_eq!(body["instances"][0]["readiness"]["skill_catalog"], true);
+    assert_eq!(
+        body["instances"][0]["readiness"]["host_execution_bridge"],
+        false
+    );
+}
+
+#[tokio::test]
+async fn gateway_docs_serves_scalar_openapi_ui() {
+    let (status, body) =
+        response_text(handle_v1_docs(State(test_gateway_state("1.2.3"))).await).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(body.contains("scalar") || body.contains("Scalar"));
+    assert!(body.contains("dcc-mcp-gateway"));
+    assert!(body.contains("/v1/search"));
+    assert!(!body.contains("/v1/debug/instances"));
+}
+
+#[tokio::test]
+#[cfg(feature = "admin")]
+async fn gateway_docs_lists_debug_routes_when_runtime_debug_routes_enabled() {
+    let (status, body) = response_text(
+        handle_v1_docs(State(test_gateway_state_with_debug_routes("1.2.3", true))).await,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(body.contains("/v1/debug/instances"));
+}
+
+#[tokio::test]
+#[cfg(feature = "admin")]
+async fn gateway_openapi_lists_stable_debug_routes() {
+    let (status, doc) = response_json(
+        handle_v1_openapi(State(test_gateway_state_with_debug_routes("1.2.3", true)))
+            .await
+            .into_response(),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    for path in [
+        "/v1/debug/instances",
+        "/v1/debug/activity",
+        "/v1/debug/calls",
+        "/v1/debug/traces",
+        "/v1/debug/traces/{request_id}",
+        "/v1/debug/trace-context/{lookup_id}",
+        "/v1/debug/tasks",
+        "/v1/debug/bundles/{request_id}",
+        "/v1/debug/issue-reports/{request_id}",
+        "/v1/debug/logs",
+        "/v1/debug/deregistered",
+        "/v1/debug/stats",
+        "/v1/debug/health",
+    ] {
+        assert!(
+            doc["paths"].get(path).is_some(),
+            "gateway OpenAPI doc missing debug path {path}: {doc:#}"
+        );
+    }
+    assert!(
+        doc["tags"]
+            .as_array()
+            .is_some_and(|tags| tags.iter().any(|tag| tag["name"] == "debug"))
+    );
+    assert!(
+        doc["components"]["schemas"]
+            .get("GatewayDebugPayload")
+            .is_some()
+    );
+}
+
+#[tokio::test]
+#[cfg(feature = "admin")]
+async fn gateway_openapi_omits_debug_routes_when_runtime_admin_disabled() {
+    let (status, doc) = response_json(
+        handle_v1_openapi(State(test_gateway_state("1.2.3")))
+            .await
+            .into_response(),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(doc["paths"].get("/v1/search").is_some());
+    assert!(doc["paths"].get("/v1/debug/instances").is_none());
+    assert!(
+        doc["tags"]
+            .as_array()
+            .is_none_or(|tags| !tags.iter().any(|tag| tag["name"] == "debug"))
+    );
+    assert!(
+        doc["components"]["schemas"]
+            .get("GatewayDebugPayload")
+            .is_none()
+    );
+}
+
+#[tokio::test]
+#[cfg(not(feature = "admin"))]
+async fn gateway_openapi_omits_debug_routes_without_admin_feature() {
+    let (status, doc) = response_json(
+        handle_v1_openapi(State(test_gateway_state("1.2.3")))
+            .await
+            .into_response(),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(doc["paths"].get("/v1/search").is_some());
+    assert!(doc["paths"].get("/v1/debug/instances").is_none());
+    assert!(
+        doc["tags"]
+            .as_array()
+            .is_none_or(|tags| !tags.iter().any(|tag| tag["name"] == "debug"))
+    );
+    assert!(
+        doc["components"]["schemas"]
+            .get("GatewayDebugPayload")
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn gateway_yield_missing_challenger_is_structured_optional_capability() {
+    let (status, body) = response_json(
+        handle_gateway_yield(
+            State(test_gateway_state("1.2.3")),
+            axum::body::Bytes::from_static(b"{}"),
+        )
+        .await,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert_eq!(body["success"], false);
+    assert_eq!(body["fallback"], "polling");
+    assert_eq!(body["error"]["kind"], "optional-capability-unsupported");
+    assert_eq!(body["error"]["capability"], "cooperative_yield");
+}
+
+#[tokio::test]
+async fn gateway_yield_same_version_is_structured_optional_capability() {
+    let (status, body) = response_json(
+        handle_gateway_yield(
+            State(test_gateway_state("1.2.3")),
+            axum::body::Bytes::from_static(br#"{"challenger_version":"1.2.3"}"#),
+        )
+        .await,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert_eq!(body["current_version"], "1.2.3");
+    assert_eq!(body["challenger_version"], "1.2.3");
+    assert_eq!(body["error"]["kind"], "optional-capability-unsupported");
+}
+
+#[tokio::test]
+async fn gateway_yield_newer_challenger_still_accepts() {
+    let (status, body) = response_json(
+        handle_gateway_yield(
+            State(test_gateway_state("1.2.3")),
+            axum::body::Bytes::from_static(br#"{"challenger_version":"1.2.4"}"#),
+        )
+        .await,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["ok"], true);
+}
+
+#[tokio::test]
+async fn rest_describe_bad_request_can_return_compact_toon() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        axum::http::header::ACCEPT,
+        crate::gateway::response_codec::TOON_MIME.parse().unwrap(),
+    );
+
+    let (status, response_headers, body) = response_text_with_headers(
+        handle_v1_describe(State(test_gateway_state("1.2.3")), headers, Json(json!({}))).await,
+    )
+    .await;
+    let decoded: Value = toon_format::decode_default(&body).unwrap();
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        response_headers
+            .get(crate::gateway::response_codec::HEADER_RESPONSE_FORMAT)
+            .and_then(|value| value.to_str().ok()),
+        Some("toon")
+    );
+    assert_eq!(decoded["error"]["kind"], "bad-request");
+    assert_eq!(
+        decoded["error"]["message"],
+        "missing required field: tool_slug"
+    );
+}
+
+#[tokio::test]
+async fn rest_call_bad_request_json_override_wins_over_accept() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        axum::http::header::ACCEPT,
+        crate::gateway::response_codec::TOON_MIME.parse().unwrap(),
+    );
+    let body = json!({
+        "response_format": "json",
+        "arguments": {}
+    });
+
+    let (status, response_headers, body_text) = response_text_with_headers(
+        handle_v1_call(State(test_gateway_state("1.2.3")), headers, Json(body)).await,
+    )
+    .await;
+    let decoded: Value = serde_json::from_str(&body_text).unwrap();
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        response_headers
+            .get(crate::gateway::response_codec::HEADER_RESPONSE_FORMAT)
+            .and_then(|value| value.to_str().ok()),
+        Some("json")
+    );
+    assert_eq!(decoded["error"]["kind"], "bad-request");
+}
+
+#[tokio::test]
+async fn rest_call_batch_bad_request_can_return_compact_toon() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        axum::http::header::ACCEPT,
+        crate::gateway::response_codec::TOON_MIME.parse().unwrap(),
+    );
+
+    let (status, response_headers, body) = response_text_with_headers(
+        handle_v1_call_batch(
+            State(test_gateway_state("1.2.3")),
+            headers,
+            Json(json!({"calls": []})),
+        )
+        .await,
+    )
+    .await;
+    let decoded: Value = toon_format::decode_default(&body).unwrap();
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        response_headers
+            .get(crate::gateway::response_codec::HEADER_RESPONSE_FORMAT)
+            .and_then(|value| value.to_str().ok()),
+        Some("toon")
+    );
+    assert_eq!(decoded["success"], false);
+    assert_eq!(decoded["error"]["kind"], "bad-request");
+    assert_eq!(
+        decoded["error"]["message"],
+        "calls must be a non-empty array"
+    );
+}
+
+#[tokio::test]
+async fn rest_trace_input_payload_uses_redacted_arguments() {
+    use crate::gateway::middleware::{AuditMiddleware, MiddlewareChain, RedactionMiddleware};
+
+    let sink = Arc::new(CaptureSink::default());
+    let chain = MiddlewareChain::new()
+        .with_before(Arc::new(RedactionMiddleware::new(vec!["api_key", "token"])))
+        .with_after(Arc::new(AuditMiddleware::new(sink.clone())));
+    let mut gs = test_gateway_state("1.2.3");
+    gs.middleware_chain = Arc::new(chain);
+
+    let request_body = json!({
+        "tool_slug": "maya.abcdef01.render",
+        "arguments": {
+            "api_key": "secret-key",
+            "nested": {"token": "secret-token"}
+        },
+        "meta": {}
+    });
+
+    let result = call_service_with_admin_trace(
+        &gs,
+        &HeaderMap::new(),
+        "v1/call",
+        "maya.abcdef01.render",
+        request_body["arguments"].clone(),
+        request_body.get("meta").cloned(),
+        &request_body,
+    )
+    .await;
+
+    assert!(result.is_err());
+    let entries = sink.0.lock().unwrap();
+    assert_eq!(entries.len(), 1);
+    let input = entries[0].input_payload.as_ref().unwrap().content.clone();
+    assert!(input.contains("[REDACTED]"));
+    assert!(!input.contains("secret-key"));
+    assert!(!input.contains("secret-token"));
+}
+
+#[tokio::test]
+async fn rest_traceparent_does_not_replace_request_id() {
+    use crate::gateway::middleware::{AuditMiddleware, MiddlewareChain};
+
+    let sink = Arc::new(CaptureSink::default());
+    let chain = MiddlewareChain::new().with_after(Arc::new(AuditMiddleware::new(sink.clone())));
+    let mut gs = test_gateway_state("1.2.3");
+    gs.middleware_chain = Arc::new(chain);
+
+    let mut headers = HeaderMap::new();
+    headers.insert("x-request-id", "req-rest-1".parse().unwrap());
+    headers.insert(
+        "traceparent",
+        "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+            .parse()
+            .unwrap(),
+    );
+    let request_body = json!({
+        "tool_slug": "maya.abcdef01.render",
+        "arguments": {},
+        "meta": {}
+    });
+
+    let _ = call_service_with_admin_trace(
+        &gs,
+        &headers,
+        "v1/call",
+        "maya.abcdef01.render",
+        json!({}),
+        request_body.get("meta").cloned(),
+        &request_body,
+    )
+    .await;
+
+    let entries = sink.0.lock().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].request_id, "req-rest-1");
+    assert_eq!(
+        entries[0].trace_context.trace_id,
+        "4bf92f3577b34da6a3ce929d0e0e4736"
+    );
+    assert_eq!(
+        entries[0].trace_context.parent_span_id.as_deref(),
+        Some("00f067aa0ba902b7")
+    );
+    let root_span_id = entries[0]
+        .trace_context
+        .span_id
+        .as_deref()
+        .expect("REST trace context should create a gateway root span id");
+    assert_eq!(root_span_id.len(), 16);
+    let backend_span = entries[0]
+        .trace_spans
+        .iter()
+        .find(|span| span.name == "backend.execute")
+        .expect("REST call should record backend.execute span");
+    let backend_span_id = backend_span
+        .span_id
+        .as_deref()
+        .expect("backend.execute should carry its own span id");
+    assert_eq!(backend_span_id.len(), 16);
+    assert_ne!(backend_span_id, root_span_id);
+    assert_eq!(backend_span.parent_span_id.as_deref(), Some(root_span_id));
+}
+
+#[tokio::test]
+async fn rest_call_batch_uses_arguments_mutated_by_before_middleware() {
+    use crate::gateway::middleware::{AuditMiddleware, MiddlewareChain, RedactionMiddleware};
+
+    let sink = Arc::new(CaptureSink::default());
+    let rewritten = json!({
+        "calls": [{
+            "tool_slug": "maya.abcdef01.render",
+            "arguments": {"token": "secret-token"}
+        }]
+    });
+    let chain = MiddlewareChain::new()
+        .with_before(Arc::new(ReplaceArgs(rewritten)))
+        .with_before(Arc::new(RedactionMiddleware::new(vec!["token"])))
+        .with_after(Arc::new(AuditMiddleware::new(sink.clone())));
+    let mut gs = test_gateway_state("1.2.3");
+    gs.middleware_chain = Arc::new(chain);
+
+    let result = call_batch_with_admin_trace(&gs, &HeaderMap::new(), &json!({"calls": []})).await;
+
+    let body = result.expect("batch should use middleware-mutated args");
+    assert_eq!(body["results"][0]["tool_slug"], "maya.abcdef01.render");
+    let entries = sink.0.lock().unwrap();
+    assert_eq!(entries.len(), 1);
+    let input = entries[0].input_payload.as_ref().unwrap().content.clone();
+    assert!(input.contains("[REDACTED]"));
+    assert!(!input.contains("secret-token"));
+}

--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/agent_workflows.md
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/agent_workflows.md
@@ -81,7 +81,7 @@ When a gateway-proxied `call_tool` / `POST /v1/call` fails with `thread-affinity
 
 Where the gateway mounts them, mirror MCP with **`POST /v1/search`**, **`/v1/describe`**, **`/v1/call`**, **`/v1/call_batch`**, and **`/v1/resources*`** / **`/v1/prompts*`**. Same discovery order and same URI hygiene as MCP.
 
-`POST /v1/search` returns legacy JSON unless compact output is explicit. REST agents can request TOON with `Accept: application/toon`, `response_format: "toon"`, or `compact: true`; use `response_format: "json"` to force compatibility. Search responses include `x-dcc-mcp-token-estimator`, original/returned byte and token counts, and savings headers so an agent can budget repeated discovery calls.
+`POST /v1/search`, `/v1/describe`, `/v1/call`, direct per-instance describe/call routes, and `/v1/call_batch` return legacy JSON unless compact output is explicit. REST agents can request TOON with `Accept: application/toon`, `response_format: "toon"`, or `compact: true`; use `response_format: "json"` to force compatibility. Compact-capable responses include `x-dcc-mcp-token-estimator`, original/returned byte and token counts, and savings headers so an agent can budget repeated discovery, schema, and invocation calls. Compact batch responses also include per-result `token_accounting` metadata.
 
 ### Path-style invocation (optional; for curl / service accounts)
 

--- a/crates/dcc-mcp-gateway/src/gateway/response_codec.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/response_codec.rs
@@ -13,14 +13,14 @@ pub(crate) const TOON_MIME: &str = "application/toon";
 pub(crate) const JSON_MIME: &str = "application/json";
 pub(crate) const TOKEN_ESTIMATOR: &str = "dcc-mcp-byte4-v1";
 
-const HEADER_RESPONSE_FORMAT: &str = "x-dcc-mcp-response-format";
-const HEADER_TOKEN_ESTIMATOR: &str = "x-dcc-mcp-token-estimator";
-const HEADER_ORIGINAL_BYTES: &str = "x-dcc-mcp-original-bytes";
-const HEADER_RETURNED_BYTES: &str = "x-dcc-mcp-returned-bytes";
-const HEADER_ORIGINAL_TOKENS: &str = "x-dcc-mcp-original-tokens";
-const HEADER_RETURNED_TOKENS: &str = "x-dcc-mcp-returned-tokens";
-const HEADER_SAVED_TOKENS: &str = "x-dcc-mcp-saved-tokens";
-const HEADER_SAVINGS_PERCENT: &str = "x-dcc-mcp-savings-pct";
+pub(crate) const HEADER_RESPONSE_FORMAT: &str = "x-dcc-mcp-response-format";
+pub(crate) const HEADER_TOKEN_ESTIMATOR: &str = "x-dcc-mcp-token-estimator";
+pub(crate) const HEADER_ORIGINAL_BYTES: &str = "x-dcc-mcp-original-bytes";
+pub(crate) const HEADER_RETURNED_BYTES: &str = "x-dcc-mcp-returned-bytes";
+pub(crate) const HEADER_ORIGINAL_TOKENS: &str = "x-dcc-mcp-original-tokens";
+pub(crate) const HEADER_RETURNED_TOKENS: &str = "x-dcc-mcp-returned-tokens";
+pub(crate) const HEADER_SAVED_TOKENS: &str = "x-dcc-mcp-saved-tokens";
+pub(crate) const HEADER_SAVINGS_PERCENT: &str = "x-dcc-mcp-savings-pct";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ResponseFormat {
@@ -62,6 +62,20 @@ impl TokenAccounting {
         } else {
             (self.saved_tokens as f64 / self.original_tokens as f64) * 100.0
         }
+    }
+
+    #[must_use]
+    pub(crate) fn to_json(self, format: ResponseFormat) -> Value {
+        json!({
+            "response_format": format.as_str(),
+            "token_estimator": TOKEN_ESTIMATOR,
+            "original_bytes": self.original_bytes,
+            "returned_bytes": self.returned_bytes,
+            "original_tokens": self.original_tokens,
+            "returned_tokens": self.returned_tokens,
+            "saved_tokens": self.saved_tokens,
+            "savings_pct": format!("{:.2}", self.savings_percent()),
+        })
     }
 }
 
@@ -154,6 +168,23 @@ pub(crate) fn encoded_response(status: StatusCode, encoded: EncodedResponse) -> 
     response
 }
 
+pub(crate) fn negotiated_response(
+    headers: &HeaderMap,
+    body: &Value,
+    status: StatusCode,
+    legacy_json: Value,
+    compact_json: Option<Value>,
+) -> Response {
+    match encode_response(
+        &legacy_json,
+        compact_json.as_ref(),
+        negotiate_response_format(headers, body),
+    ) {
+        Ok(encoded) => encoded_response(status, encoded),
+        Err(err) => json_error_response(StatusCode::INTERNAL_SERVER_ERROR, &err),
+    }
+}
+
 pub(crate) fn search_response(headers: &HeaderMap, body: &Value, hits: Vec<Value>) -> Response {
     let total = hits.len();
     let legacy = json!({
@@ -167,14 +198,7 @@ pub(crate) fn search_response(headers: &HeaderMap, body: &Value, hits: Vec<Value
             .map(Vec::as_slice)
             .unwrap_or_default(),
     );
-    match encode_response(
-        &legacy,
-        Some(&compact),
-        negotiate_response_format(headers, body),
-    ) {
-        Ok(encoded) => encoded_response(StatusCode::OK, encoded),
-        Err(err) => json_error_response(StatusCode::INTERNAL_SERVER_ERROR, &err),
-    }
+    negotiated_response(headers, body, StatusCode::OK, legacy, Some(compact))
 }
 
 fn json_error_response(status: StatusCode, err: &EncodeError) -> Response {
@@ -196,23 +220,61 @@ pub(crate) fn compact_search_payload(total: usize, hits: &[Value]) -> Value {
     })
 }
 
-fn compact_search_hit(hit: &Value) -> Value {
+pub(crate) fn compact_describe_payload(legacy: &Value) -> Value {
     let mut out = Map::new();
-    copy_field(&mut out, hit, "tool_slug");
-    copy_field(&mut out, hit, "backend_tool");
-    copy_callable_if_distinct(&mut out, hit);
-    copy_field(&mut out, hit, "skill_name");
-    copy_field(&mut out, hit, "summary");
-    copy_field(&mut out, hit, "tags");
-    copy_field(&mut out, hit, "dcc_type");
-    copy_field(&mut out, hit, "instance_id");
-    copy_field(&mut out, hit, "has_schema");
-    copy_field(&mut out, hit, "loaded");
-    copy_field(&mut out, hit, "score");
-    copy_field(&mut out, hit, "annotations");
-    copy_field(&mut out, hit, "metadata");
-    copy_field(&mut out, hit, "next_step");
+    if let Some(record) = legacy.get("record") {
+        out.insert("record".to_string(), compact_record(record));
+    }
+    if let Some(tool) = legacy.get("tool") {
+        // The schema-bearing tool definition is the describe contract.
+        // Preserve it verbatim so compact output never hides validation hints.
+        out.insert("tool".to_string(), tool.clone());
+    }
     Value::Object(out)
+}
+
+pub(crate) fn compact_call_batch_payload(legacy: &Value) -> Value {
+    let mut compact = legacy.clone();
+    if let Some(results) = compact.get_mut("results").and_then(Value::as_array_mut) {
+        for item in results {
+            let item_payload = item.clone();
+            if let Some(accounting) = token_accounting_for_compact_value(&item_payload)
+                && let Some(obj) = item.as_object_mut()
+            {
+                obj.insert("token_accounting".to_string(), accounting);
+            }
+        }
+    }
+    compact
+}
+
+fn compact_search_hit(hit: &Value) -> Value {
+    compact_record(hit)
+}
+
+fn compact_record(record: &Value) -> Value {
+    let mut out = Map::new();
+    copy_field(&mut out, record, "tool_slug");
+    copy_field(&mut out, record, "backend_tool");
+    copy_callable_if_distinct(&mut out, record);
+    copy_field(&mut out, record, "skill_name");
+    copy_field(&mut out, record, "summary");
+    copy_field(&mut out, record, "tags");
+    copy_field(&mut out, record, "dcc_type");
+    copy_field(&mut out, record, "instance_id");
+    copy_field(&mut out, record, "has_schema");
+    copy_field(&mut out, record, "loaded");
+    copy_field(&mut out, record, "score");
+    copy_field(&mut out, record, "annotations");
+    copy_field(&mut out, record, "metadata");
+    copy_field(&mut out, record, "next_step");
+    Value::Object(out)
+}
+
+fn token_accounting_for_compact_value(value: &Value) -> Option<Value> {
+    encode_response(value, Some(value), ResponseFormat::Toon)
+        .ok()
+        .map(|encoded| encoded.accounting.to_json(encoded.format))
 }
 
 fn copy_field(out: &mut Map<String, Value>, hit: &Value, field: &str) {
@@ -569,6 +631,147 @@ mod tests {
         assert_eq!(
             compact["hits"][0]["tool_slug"],
             "maya.abcdef01.create_sphere"
+        );
+    }
+
+    #[test]
+    fn compact_describe_payload_preserves_schema_and_hints() {
+        let legacy = json!({
+            "record": {
+                "tool_slug": "maya.abcdef01.export_fbx",
+                "backend_tool": "export_fbx",
+                "callable_id": "export_fbx",
+                "skill_name": "maya-export",
+                "summary": "Export selected Maya objects to FBX.",
+                "tags": [],
+                "dcc_type": "maya",
+                "instance_id": "abcdef01-2345-6789-abcd-ef0123456789",
+                "has_schema": true,
+                "loaded": true,
+                "annotations": {"readOnlyHint": false},
+                "metadata": {"affinity": "main"}
+            },
+            "tool": {
+                "name": "export_fbx",
+                "description": "Export selected objects.",
+                "inputSchema": {
+                    "type": "object",
+                    "required": ["path"],
+                    "properties": {
+                        "path": {"type": "string"},
+                        "selected_only": {"type": "boolean"}
+                    }
+                },
+                "annotations": {"destructiveHint": false}
+            }
+        });
+
+        let compact = compact_describe_payload(&legacy);
+
+        assert!(compact["record"].get("callable_id").is_none());
+        assert!(compact["record"].get("tags").is_none());
+        assert_eq!(compact["record"]["metadata"]["affinity"], "main");
+        assert_eq!(
+            compact["tool"]["inputSchema"]["properties"]["path"]["type"],
+            "string"
+        );
+        assert_eq!(compact["tool"]["inputSchema"]["required"][0], "path");
+        assert_eq!(compact["tool"]["annotations"]["destructiveHint"], false);
+    }
+
+    #[test]
+    fn compact_call_batch_payload_adds_per_item_token_accounting() {
+        let legacy = json!({
+            "success": false,
+            "stop_on_error": false,
+            "results": [
+                {
+                    "index": 0,
+                    "tool_slug": "maya.abcdef01.big_result",
+                    "ok": true,
+                    "result": {
+                        "output": {
+                            "success": true,
+                            "context": {
+                                "objects": [
+                                    {"name": "cube_a", "type": "mesh"},
+                                    {"name": "cube_b", "type": "mesh"}
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "index": 1,
+                    "tool_slug": "photoshop.12345678.select_layer",
+                    "ok": false,
+                    "error": {
+                        "success": false,
+                        "error": {
+                            "kind": "backend-error",
+                            "message": "Layer not found"
+                        }
+                    }
+                }
+            ]
+        });
+
+        let compact = compact_call_batch_payload(&legacy);
+
+        assert_eq!(compact["success"], false);
+        assert_eq!(compact["results"][0]["ok"], true);
+        assert_eq!(
+            compact["results"][1]["error"]["error"]["kind"],
+            "backend-error"
+        );
+        for item in compact["results"].as_array().unwrap() {
+            assert_eq!(item["token_accounting"]["response_format"], "toon");
+            assert_eq!(item["token_accounting"]["token_estimator"], TOKEN_ESTIMATOR);
+            assert!(item["token_accounting"]["original_tokens"].is_number());
+            assert!(item["token_accounting"]["returned_tokens"].is_number());
+            assert!(item["token_accounting"]["saved_tokens"].is_number());
+        }
+    }
+
+    #[tokio::test]
+    async fn negotiated_response_returns_compact_error_envelope() {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::ACCEPT, HeaderValue::from_static(TOON_MIME));
+        let legacy = json!({
+            "success": false,
+            "error": {
+                "kind": "unknown-slug",
+                "message": "No capability matched",
+                "candidates": [
+                    {"tool_slug": "maya.abcdef01.render"}
+                ]
+            }
+        });
+
+        let (status, response_headers, bytes) = response_bytes(negotiated_response(
+            &headers,
+            &json!({}),
+            StatusCode::NOT_FOUND,
+            legacy,
+            None,
+        ))
+        .await;
+        let text = String::from_utf8(bytes).unwrap();
+        let body: Value = toon_format::decode_default(&text).unwrap();
+
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(
+            response_headers
+                .get(HEADER_RESPONSE_FORMAT)
+                .and_then(|value| value.to_str().ok()),
+            Some("toon")
+        );
+        assert_eq!(body["success"], false);
+        assert_eq!(body["error"]["kind"], "unknown-slug");
+        assert_eq!(body["error"]["message"], "No capability matched");
+        assert_eq!(
+            body["error"]["candidates"][0]["tool_slug"],
+            "maya.abcdef01.render"
         );
     }
 }

--- a/docs/guide/rest-api-surface.md
+++ b/docs/guide/rest-api-surface.md
@@ -378,8 +378,10 @@ the gateway includes it so same-DCC multi-instance calls stay routed.
 
 ### Compact output
 
-`/v1/search` keeps legacy JSON as the default response format. Agent clients
-that want a smaller discovery payload can request TOON explicitly:
+`/v1/search`, `/v1/describe`, `/v1/tools/{slug}`, the direct per-instance
+describe/call routes, `/v1/call`, and `/v1/call_batch` keep legacy JSON as the
+default response format. Agent clients that want smaller REST payloads can
+request TOON explicitly:
 
 ```bash
 curl -H 'Accept: application/toon' \
@@ -391,7 +393,8 @@ The request body may also set `"response_format": "toon"` or `"compact": true`.
 Set `"response_format": "json"` to force the legacy JSON body even when the
 `Accept` header prefers TOON.
 
-Every search response includes approximate token accounting headers:
+Every compact-capable REST response includes approximate token accounting
+headers:
 
 | Header | Meaning |
 |---|---|
@@ -409,6 +412,14 @@ empty objects. RTK's compaction model is treated as design guidance here; the
 gateway uses the deterministic in-process `toon-format` library so
 `serde_json::Value` payloads round-trip inside Rust tests without spawning an
 external codec process.
+
+Compact describe output applies the same small-record rules to `record` while
+preserving the full `tool` definition verbatim, including `inputSchema`,
+annotations, and validation hints. Compact call output preserves the same
+success/error envelope and HTTP status as JSON, just encoded as TOON. Compact
+batch output preserves request order and includes per-result `token_accounting`
+metadata when compact output is requested, while the response headers report the
+aggregate body savings.
 
 ## `POST /v1/load_skill` and `/v1/unload_skill`
 

--- a/docs/zh/guide/rest-api-surface.md
+++ b/docs/zh/guide/rest-api-surface.md
@@ -169,8 +169,10 @@ OpenAPI contract 预留了 `cursor`、`since`、`until` 给后续 normalized env
 
 ## `POST /v1/search` —— compact discovery
 
-`/v1/search` 默认仍返回旧版 JSON，保持现有 REST 客户端兼容。Agent 客户端
-如果想减少 discovery payload，可以显式请求 TOON：
+`/v1/search`、`/v1/describe`、`/v1/tools/{slug}`、直接 per-instance
+describe/call 路由、`/v1/call` 和 `/v1/call_batch` 默认仍返回旧版 JSON，
+保持现有 REST 客户端兼容。Agent 客户端如果想减少 REST payload，可以显式
+请求 TOON：
 
 ```bash
 curl -H 'Accept: application/toon' \
@@ -182,7 +184,7 @@ curl -H 'Accept: application/toon' \
 `Accept` 头偏好 TOON，但当前调用必须保持旧 JSON，传
 `"response_format": "json"` 即可强制回退。
 
-每个 search 响应都会带近似 token 统计头：
+每个支持 compact 的 REST 响应都会带近似 token 统计头：
 
 | Header | 含义 |
 |---|---|
@@ -199,6 +201,12 @@ compact search 仍保留 agent 后续工作需要的字段：`tool_slug`、
 语义压缩模型作为设计参考；gateway 内部直接使用确定性的 `toon-format`
 库，让 `serde_json::Value` payload 在 Rust 测试中可 round-trip，不需要
 派生外部 codec 进程。
+
+compact describe 会对 `record` 应用相同的小记录规则，但完整保留 `tool`
+定义，包括 `inputSchema`、annotations 和 validation hints。compact call
+保留与 JSON 相同的成功 / 失败 envelope 和 HTTP 状态，只是用 TOON 编码。
+compact batch 保留结果顺序；请求 compact 输出时，每个 result 会带
+`token_accounting`，响应头则给出整个响应体的聚合节省。
 
 ---
 

--- a/skills/dcc-mcp-skill-developer/SKILL.md
+++ b/skills/dcc-mcp-skill-developer/SKILL.md
@@ -69,11 +69,13 @@ into a faster authoring loop.
    the shipped server paths enable the required gateway `admin` feature and
    Admin telemetry runtime state, while minimal direct `dcc-mcp-gateway` builds
    or runtimes started with Admin disabled may omit those debug routes.
-   For REST discovery examples, keep `/v1/search` legacy JSON-compatible by
+   For REST discovery, describe, call, and batch examples, keep `/v1/search`,
+   `/v1/describe`, `/v1/call`, and `/v1/call_batch` legacy JSON-compatible by
    default and request compact TOON only explicitly with
    `Accept: application/toon`, `response_format: "toon"`, or `compact: true`;
    surface the `x-dcc-mcp-*` token accounting headers when teaching agents how
-   to budget discovery payloads.
+   to budget discovery, schema, invocation, and batch payloads. Compact batch
+   examples may also read per-result `token_accounting` metadata.
    Subscribe to the shared `EventBus` when an adapter or studio integration
    needs programmatic lifecycle hooks: use `skill.*` events for load/unload
    visibility and `tool.*` events for dispatch/completion/failure metrics

--- a/tests/test_gateway_facade_aggregation.py
+++ b/tests/test_gateway_facade_aggregation.py
@@ -7,10 +7,10 @@ gateway port, then drive the gateway's MCP endpoint directly to verify:
 
 * The first server to bind the gateway port wins the election and serves the
   aggregated endpoint; the second registers as a plain backend.
-* ``tools/list`` on the gateway returns the 6 canonical tools (search,
-  describe, call, lease, load_skill, unload_skill).  Legacy aliases like
+* ``tools/list`` on the gateway returns the two advertised discovery tools
+  (search, describe).  Execution, lease, lifecycle, and legacy aliases like
   ``search_tools`` are hidden from the listing but still route via
-  ``tools/call``.
+  ``tools/call`` for compatibility.
 * Tool-name collisions across DCCs never surface — each backend tool carries
   ``_instance_id`` / ``_dcc_type`` annotations so agents can disambiguate.
 * ``initialize`` advertises ``tools.listChanged: true`` and
@@ -220,15 +220,14 @@ class TestFacadeInitialize:
 
 
 class TestFacadeToolsAggregation:
-    """Gateway ``tools/list`` exposes only the 6-verb canonical surface.
+    """Gateway ``tools/list`` exposes only the read-only discovery surface.
 
-    After the consolidation (commit e7e3c7ec), the gateway publishes exactly
-    6 tools: ``search``, ``describe``, ``call``, ``lease``, ``load_skill``,
-    ``unload_skill``.  Legacy aliases (``search_tools``, ``describe_tool``,
-    ``call_tool``) are still callable but hidden from ``tools/list``.
-    Backend per-action tools are NOT fanned out — agents discover them via
-    ``search`` → ``describe`` → ``call`` (or the per-DCC REST
-    ``POST /v1/call``).
+    The gateway publishes exactly two tools: ``search`` and ``describe``.
+    Execution, lease, lifecycle, and legacy aliases remain callable through
+    ``tools/call`` but are hidden from ``tools/list``.  Backend per-action tools
+    are NOT fanned out — agents discover them via ``search`` → ``describe``,
+    then execute through the canonical REST plane (``POST /v1/call`` or
+    ``POST /v1/call_batch``).
     """
 
     def test_aggregated_list_contains_local_and_backend_tools(self, facade_cluster):
@@ -243,19 +242,25 @@ class TestFacadeToolsAggregation:
                 "(promoted to gateway://instances resource in #813)"
             )
 
-        # Tier 2 — skill-management tools (one canonical set gateway-side).
-        # After #813 refactor, the canonical set is: search, describe, call,
-        # lease, load_skill, unload_skill.
-        for mgmt in ("search", "describe", "call", "lease", "load_skill", "unload_skill"):
+        # Tier 2 — advertised gateway discovery tools.
+        for mgmt in ("search", "describe"):
             assert mgmt in names, f"missing skill-management tool {mgmt!r}"
+        assert names == {"search", "describe"}, (
+            f"gateway tools/list should advertise only read-only discovery tools; got {sorted(names)!r}"
+        )
 
-        # Tier 3 — legacy discover+dispatch wrappers (search_tools, describe_tool,
-        # call_tool) are hidden from tools/list after the 6-verb consolidation
-        # (commit e7e3c7ec) but remain callable as aliases via tools/call.
-        for alias in ("search_tools", "describe_tool", "call_tool"):
-            assert alias not in names, (
-                f"legacy alias {alias!r} should be hidden from tools/list (consolidated into canonical 6-verb surface)"
-            )
+        # Tier 3 — hidden compatibility and state-changing routes remain
+        # callable via tools/call, but are not advertised in tools/list.
+        for alias in (
+            "call",
+            "lease",
+            "load_skill",
+            "unload_skill",
+            "search_tools",
+            "describe_tool",
+            "call_tool",
+        ):
+            assert alias not in names, f"route {alias!r} should be hidden from tools/list"
 
         # Per-action backend tools must NOT be fanned out anymore.
         prefixed = [t for t in tools if _split_gateway_prefixed_tool(t["name"]) is not None]

--- a/tests/vrs/README.md
+++ b/tests/vrs/README.md
@@ -79,6 +79,7 @@ python scripts/vrs_replay.py --base-url http://127.0.0.1:1 --dry-run --trace tes
 | `traces/gateway-rest-describe-unknown-slug.jsonl` | No | Well-formed unknown slug → `404`, `error.kind` = `unknown-slug`. |
 | `traces/gateway-rest-call-missing-tool-slug.jsonl` | No | `POST /v1/call` without `tool_slug` → `400`, `bad-request`. |
 | `traces/gateway-rest-call-unknown-slug.jsonl` | No | Unknown slug on call path → `404`, `unknown-slug` (matches refresh-retry semantics). |
+| `traces/core-1153-rest-compact-errors.jsonl` | No | Compact TOON negotiation on `/v1/describe` and `/v1/call_batch` preserves bad-request details; `/v1/call` can still force JSON. |
 | `traces/maya-215-execute-python-regression.jsonl` | Yes (Maya) | After harmless `execute_python`, triggers `TypeError` via bad `polySphere` arg; follow-up call must still succeed (maya#215 / #199 class). |
 | `traces/maya-235-capture-then-playblast-survives.jsonl` | Yes (Maya) | `capture_viewport` → `playblast` → `capture_viewport`; the third call MUST still return a JSON envelope (not transport error / instance-offline) — generalises the maya#215 watchdog to any `affinity:main` async action (maya#235). |
 | `traces/maya-export-fbx-describe-path-schema.jsonl` | Yes (Maya, minimal mode) | `export_fbx` MUST appear in `POST /v1/search` with `has_schema: true` before `load_skill`; `POST /v1/describe` MUST expose `inputSchema.properties.path` + `required: ["path"]`; `destination` alone MUST NOT succeed on `POST /v1/call`. |

--- a/tests/vrs/traces/core-1153-rest-compact-errors.jsonl
+++ b/tests/vrs/traces/core-1153-rest-compact-errors.jsonl
@@ -1,0 +1,4 @@
+{"_vrs": {"version": 1}, "trace_id": "core-1153-rest-compact-errors", "title": "REST compact negotiation preserves error contracts for describe/call/call_batch"}
+{"id": "describe_missing_slug_toon", "http": {"method": "POST", "path": "/v1/describe", "headers": {"Accept": "application/toon"}, "json": {}}, "expect": {"status": 400, "body_contains_all": ["bad-request", "missing required field: tool_slug"]}}
+{"id": "call_missing_slug_json_override", "http": {"method": "POST", "path": "/v1/call", "headers": {"Accept": "application/toon"}, "json": {"response_format": "json", "arguments": {}}}, "expect": {"status": 400, "json_subset": {"error": {"kind": "bad-request"}}}}
+{"id": "call_batch_empty_toon", "http": {"method": "POST", "path": "/v1/call_batch", "headers": {"Accept": "application/toon"}, "json": {"calls": []}}, "expect": {"status": 400, "body_contains_all": ["bad-request", "calls must be a non-empty array"]}}


### PR DESCRIPTION
## Summary
- extend explicit compact TOON negotiation from search to REST describe, call, direct per-instance call/describe, and call_batch
- preserve legacy JSON defaults and JSON opt-out while adding token accounting headers and per-batch-result token metadata
- document compact REST invocation behavior and add a VRS trace for compact error compatibility
- keep gateway facade tests aligned with the read-only MCP discovery surface after rebasing onto latest main

## Validation
- `git diff --check`
- `python scripts/vrs_replay.py --base-url http://127.0.0.1:1 --dry-run --trace tests/vrs/traces/core-1153-rest-compact-errors.jsonl`
- `vx cargo test -p dcc-mcp-gateway response_codec --lib`
- `vx cargo test -p dcc-mcp-gateway rest_ --lib`
- `vx cargo test -p dcc-mcp-gateway --lib`
- `vx cargo clippy -p dcc-mcp-gateway --all-targets -- -D warnings`
- `DCC_MCP_ADMIN_UI_PREBUILT=1 vx just preflight`
- `.\.venv\Scripts\python.exe -m pytest tests/test_gateway_facade_aggregation.py -q --tb=short --show-capture=no`

Closes #1153