### PR TITLE
feat: make skill loading self describing

### DIFF
--- a/crates/dcc-mcp-gateway-core/src/capability/mod.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/mod.rs
@@ -39,8 +39,8 @@ pub mod search_ranking;
 pub use builder::BuildOutcome;
 pub use index::{IndexSnapshot, InstanceFingerprint};
 pub use record::{
-    CapabilityAnnotations, CapabilityMetadata, CapabilityRecord, SCHEMA_AVAILABLE,
-    is_valid_dcc_bucket, parse_slug, tool_slug,
+    CapabilityAnnotations, CapabilityGroupInfo, CapabilityMetadata, CapabilityRecord,
+    SCHEMA_AVAILABLE, is_valid_dcc_bucket, parse_slug, tool_slug,
 };
 pub use refresh::RefreshReason;
 pub use search::{

--- a/crates/dcc-mcp-gateway-core/src/capability/record.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/record.rs
@@ -192,6 +192,29 @@ impl CapabilityMetadata {
     }
 }
 
+/// Lightweight progressive tool-group metadata surfaced in search hits.
+///
+/// The gateway keeps this bounded: it is enough for an agent to decide whether
+/// a group must be explicitly activated, while full skill prose remains behind
+/// skill detail surfaces.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CapabilityGroupInfo {
+    /// Group identifier unique within the owning skill.
+    pub name: String,
+    /// Short group summary when the skill declared one.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub description: String,
+    /// Tool names declared in this group.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<String>,
+    /// Whether this group becomes active on a default lazy load.
+    #[serde(default)]
+    pub default_active: bool,
+    /// Runtime activation state when the backend knows it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active: Option<bool>,
+}
+
 /// One compact capability record.
 ///
 /// Field ordering and field names are part of the REST wire contract
@@ -243,6 +266,9 @@ pub struct CapabilityRecord {
     /// capability: affinity, execution mode, timeout, and risk.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<CapabilityMetadata>,
+    /// Progressive tool groups declared by the owning skill, when known.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub available_groups: Vec<CapabilityGroupInfo>,
 }
 
 impl CapabilityRecord {
@@ -283,6 +309,7 @@ impl CapabilityRecord {
             loaded,
             annotations: None,
             metadata: None,
+            available_groups: Vec::new(),
         }
     }
 
@@ -298,6 +325,16 @@ impl CapabilityRecord {
     ) -> Self {
         self.annotations = annotations.filter(|ann| !ann.is_empty());
         self.metadata = metadata.filter(|meta| !meta.is_empty());
+        self
+    }
+
+    /// Attach progressive group metadata discovered from the owning backend.
+    #[must_use]
+    pub fn with_available_groups(mut self, groups: Vec<CapabilityGroupInfo>) -> Self {
+        self.available_groups = groups
+            .into_iter()
+            .filter(|group| !group.name.is_empty())
+            .collect();
         self
     }
 
@@ -334,6 +371,7 @@ impl CapabilityRecord {
             loaded: false,
             annotations: None,
             metadata: None,
+            available_groups: Vec::new(),
         }
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/skill_mgmt.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/skill_mgmt.rs
@@ -37,6 +37,9 @@ pub(crate) async fn skill_mgmt_dispatch(
                     let mut forward_args = args.clone();
                     if let Some(obj) = forward_args.as_object_mut() {
                         obj.remove("instance_id");
+                        if tool == "load_skill" && !obj.contains_key("activate_groups") {
+                            obj.insert("activate_groups".to_string(), Value::Bool(false));
+                        }
                         if let Some(group_name) = obj.get("group_name").cloned()
                             && !obj.contains_key("group")
                         {
@@ -91,6 +94,11 @@ pub(crate) async fn skill_mgmt_dispatch(
                                     let _ = gs.events_tx.send(notif);
                                 }
                             }
+                            let text = if !is_error && tool == "load_skill" {
+                                decorate_load_skill_success(gs, &entry, &forward_args, &text)
+                            } else {
+                                text
+                            };
                             (text, is_error)
                         }
                         Err(e) => (format!("Backend call failed: {e}"), true),
@@ -322,7 +330,7 @@ pub(crate) fn skill_management_tool_defs() -> Vec<Value> {
                 "properties": {
                     "skill_name":      {"type": "string"},
                     "skill_names":     {"type": "array", "items": {"type": "string"}},
-                    "activate_groups": {"type": "boolean", "default": true, "description": "Cascade-activate all declared tool groups after loading. Set false for lazy activation."},
+                    "activate_groups": {"type": "boolean", "default": false, "description": "Gateway default is lazy: activate only default-active/core groups. Set true to cascade-activate all declared tool groups."},
                     "instance_id":     {"type": "string", "description": "Target instance (full UUID or short prefix)"},
                     "dcc":             {"type": "string", "description": "DCC type when only one instance of that type is live"}
                 },
@@ -373,4 +381,160 @@ pub(crate) fn skill_management_tool_defs() -> Vec<Value> {
             }
         }),
     ]
+}
+
+fn decorate_load_skill_success(
+    gs: &GatewayState,
+    entry: &ServiceEntry,
+    forwarded_args: &Value,
+    text: &str,
+) -> String {
+    let mut payload = serde_json::from_str::<Value>(text).unwrap_or_else(|_| {
+        json!({
+            "message": text,
+        })
+    });
+
+    if !payload.is_object() {
+        payload = json!({ "result": payload });
+    }
+
+    let Some(obj) = payload.as_object_mut() else {
+        return text.to_string();
+    };
+
+    let requested_skill = forwarded_args
+        .get("skill_name")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| {
+            forwarded_args
+                .get("skill_names")
+                .and_then(Value::as_array)
+                .and_then(|items| items.iter().find_map(Value::as_str))
+                .map(str::to_string)
+        })
+        .or_else(|| {
+            obj.get("skill_name")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        });
+
+    obj.entry("loaded".to_string()).or_insert(Value::Bool(true));
+    if let Some(skill_name) = &requested_skill {
+        obj.entry("skill_name".to_string())
+            .or_insert_with(|| Value::String(skill_name.clone()));
+    }
+    obj.insert(
+        "dcc_type".to_string(),
+        Value::String(entry.dcc_type.clone()),
+    );
+    obj.insert(
+        "instance_id".to_string(),
+        Value::String(entry.instance_id.to_string()),
+    );
+    obj.insert(
+        "instance_short".to_string(),
+        Value::String(instance_short(&entry.instance_id)),
+    );
+
+    let tool_slugs = new_tool_slugs_for_skill(gs, entry.instance_id, requested_skill.as_deref());
+    obj.insert("new_tool_slugs".to_string(), json!(tool_slugs));
+    obj.insert(
+        "index_generation".to_string(),
+        Value::String(crate::gateway::capability_service::index_generation(
+            &gs.capability_index,
+        )),
+    );
+
+    if !obj.contains_key("activated_groups") {
+        let active_groups = obj
+            .get("active_groups")
+            .cloned()
+            .unwrap_or_else(|| json!([]));
+        obj.insert("activated_groups".to_string(), active_groups);
+    }
+
+    let next_step = suggested_post_load_next_step(
+        requested_skill.as_deref(),
+        &entry.dcc_type,
+        entry.instance_id,
+        obj.get("new_tool_slugs")
+            .and_then(Value::as_array)
+            .and_then(|items| items.first())
+            .and_then(Value::as_str),
+    );
+    obj.insert("next_step".to_string(), next_step);
+
+    serde_json::to_string_pretty(&payload).unwrap_or_else(|_| text.to_string())
+}
+
+fn new_tool_slugs_for_skill(
+    gs: &GatewayState,
+    instance_id: Uuid,
+    skill_name: Option<&str>,
+) -> Vec<String> {
+    let mut slugs: Vec<String> = gs
+        .capability_index
+        .snapshot()
+        .records
+        .iter()
+        .filter(|record| record.instance_id == instance_id && record.loaded)
+        .filter(|record| {
+            skill_name.is_none_or(|skill| {
+                record
+                    .skill_name
+                    .as_deref()
+                    .is_some_and(|candidate| candidate.eq_ignore_ascii_case(skill))
+            })
+        })
+        .map(|record| record.tool_slug.clone())
+        .collect();
+    slugs.sort();
+    slugs
+}
+
+fn suggested_post_load_next_step(
+    skill_name: Option<&str>,
+    dcc_type: &str,
+    instance_id: Uuid,
+    first_tool_slug: Option<&str>,
+) -> Value {
+    if let Some(tool_slug) = first_tool_slug {
+        let arguments = json!({ "tool_slug": tool_slug });
+        return json!({
+            "action": "describe",
+            "arguments": arguments.clone(),
+            "mcp": {
+                "tool": "describe",
+                "arguments": arguments.clone(),
+            },
+            "rest": {
+                "method": "POST",
+                "path": "/v1/describe",
+                "body": arguments,
+            },
+        });
+    }
+
+    let arguments = json!({
+        "query": skill_name.unwrap_or_default(),
+        "skill_hint": skill_name.unwrap_or_default(),
+        "dcc_type": dcc_type,
+        "instance_id": instance_id.to_string(),
+        "loaded_only": true,
+    });
+    json!({
+        "action": "search",
+        "arguments": arguments.clone(),
+        "mcp": {
+            "tool": "search",
+            "arguments": arguments.clone(),
+        },
+        "rest": {
+            "method": "POST",
+            "path": "/v1/search",
+            "body": arguments,
+        },
+    })
 }

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
@@ -688,11 +688,12 @@ async fn gateway_mcp_four_tool_workflow_covers_search_describe_load_and_call() {
     ));
     {
         let r = registry.read().await;
-        let entry = dcc_mcp_transport::discovery::types::ServiceEntry::new(
+        let mut entry = dcc_mcp_transport::discovery::types::ServiceEntry::new(
             "maya",
             "127.0.0.1",
             backend_port,
         );
+        entry.instance_id = uuid::Uuid::parse_str("aaaaaaaa-0000-0000-0000-000000000001").unwrap();
         r.register(entry).unwrap();
     }
 
@@ -789,6 +790,20 @@ async fn gateway_mcp_four_tool_workflow_covers_search_describe_load_and_call() {
     let load_payload = mcp_call_text_json(&load);
     assert_eq!(load_payload["loaded"], true);
     assert_eq!(load_payload["skill_name"], "maya-primitives");
+    assert_eq!(load_payload["dcc_type"], "maya");
+    assert_eq!(
+        load_payload["instance_id"],
+        "aaaaaaaa-0000-0000-0000-000000000001"
+    );
+    assert_eq!(load_payload["activated_groups"], json!(["core"]));
+    assert_eq!(
+        load_payload["new_tool_slugs"][0],
+        "maya.aaaaaaaa.create_sphere"
+    );
+    assert!(load_payload["index_generation"].as_str().is_some());
+    assert_eq!(load_payload["next_step"]["action"], "describe");
+    assert_eq!(load_payload["next_step"]["mcp"]["tool"], "describe");
+    assert_eq!(load_payload["next_step"]["rest"]["path"], "/v1/describe");
 
     let single = post_mcp_json(
         &client,

--- a/crates/dcc-mcp-gateway/src/gateway/backend_client/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/backend_client/mod.rs
@@ -42,9 +42,9 @@ pub(crate) use probe::{
 pub(crate) use urls::{health_url_from_mcp_url, readyz_url_from_mcp_url, rest_base_from_mcp_url};
 
 pub use ops::{
-    ForwardToolsCallRequest, call_backend, fetch_prompts, fetch_resources, fetch_tools,
-    forward_prompts_get, forward_tools_call, read_resource, subscribe_resource, try_describe_tool,
-    try_fetch_prompts, try_fetch_resources, try_fetch_tools,
+    ForwardToolsCallRequest, UnloadedCapabilityHint, call_backend, fetch_prompts, fetch_resources,
+    fetch_tools, forward_prompts_get, forward_tools_call, read_resource, subscribe_resource,
+    try_describe_tool, try_fetch_prompts, try_fetch_resources, try_fetch_tools,
 };
 
 #[cfg(test)]

--- a/crates/dcc-mcp-gateway/src/gateway/backend_client/ops.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/backend_client/ops.rs
@@ -5,6 +5,7 @@ use serde_json::{Value, json};
 use dcc_mcp_jsonrpc::{McpPrompt, McpTool};
 
 use crate::gateway::admin::trace::TraceContext;
+use crate::gateway::capability::CapabilityGroupInfo;
 use crate::gateway::metrics::record_gateway_backend_error_kind;
 use crate::gateway::resilience::{
     circuits, is_circuit_worthy_rest_error, is_retryable_rest_error, jittered_backoff,
@@ -18,6 +19,14 @@ use super::http::{
 };
 use super::probe::{ProbeOutcome, probe_mcp_readiness};
 use super::urls::rest_base_from_mcp_url;
+
+#[derive(Debug, Clone)]
+pub struct UnloadedCapabilityHint {
+    pub skill_name: String,
+    pub tool_name: String,
+    pub summary: String,
+    pub available_groups: Vec<CapabilityGroupInfo>,
+}
 
 async fn rest_get_idempotent(
     client: &reqwest::Client,
@@ -165,7 +174,7 @@ pub async fn try_fetch_tools(
     client: &reqwest::Client,
     mcp_url: &str,
     timeout: Duration,
-) -> Result<(Vec<McpTool>, Vec<(String, String, String)>), String> {
+) -> Result<(Vec<McpTool>, Vec<UnloadedCapabilityHint>), String> {
     let base = rest_base_from_mcp_url(mcp_url);
     let key = base.as_str();
     let url = format!("{base}/v1/search");
@@ -180,7 +189,7 @@ pub async fn try_fetch_tools(
     .await?;
 
     let mut loaded_tools: Vec<McpTool> = Vec::new();
-    let mut unloaded_hints: Vec<(String, String, String)> = Vec::new();
+    let mut unloaded_hints: Vec<UnloadedCapabilityHint> = Vec::new();
 
     if let Some(arr) = val.get("hits").and_then(Value::as_array) {
         for v in arr {
@@ -213,7 +222,7 @@ pub async fn try_fetch_tools(
 
             if loaded {
                 let annotations = parse_tool_annotations(v.get("annotations"));
-                let meta = mcp_meta_from_rest_metadata(v.get("metadata"));
+                let meta = mcp_meta_from_rest_metadata(v.get("metadata"), v.get("skill"));
                 loaded_tools.push(McpTool {
                     name: action,
                     description,
@@ -235,7 +244,17 @@ pub async fn try_fetch_tools(
                     .and_then(Value::as_str)
                     .unwrap_or("")
                     .to_owned();
-                unloaded_hints.push((skill_name, action, description));
+                let available_groups = v
+                    .get("available_groups")
+                    .cloned()
+                    .and_then(|value| serde_json::from_value(value).ok())
+                    .unwrap_or_default();
+                unloaded_hints.push(UnloadedCapabilityHint {
+                    skill_name,
+                    tool_name: action,
+                    summary: description,
+                    available_groups,
+                });
             }
         }
     }
@@ -294,7 +313,10 @@ pub async fn try_describe_tool(
         .cloned()
         .unwrap_or_else(|| json!({"type": "object"}));
     let annotations = parse_tool_annotations(val.get("annotations"));
-    let meta = mcp_meta_from_rest_metadata(val.get("metadata"));
+    let meta = mcp_meta_from_rest_metadata(
+        val.get("metadata"),
+        val.get("entry").and_then(|entry| entry.get("skill")),
+    );
 
     Ok(McpTool {
         name,
@@ -321,8 +343,25 @@ fn parse_tool_annotations(value: Option<&Value>) -> Option<dcc_mcp_jsonrpc::McpT
     }
 }
 
-fn mcp_meta_from_rest_metadata(value: Option<&Value>) -> Option<serde_json::Map<String, Value>> {
-    let map = value?.as_object()?.clone();
+fn mcp_meta_from_rest_metadata(
+    value: Option<&Value>,
+    skill: Option<&Value>,
+) -> Option<serde_json::Map<String, Value>> {
+    let mut map = value
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    if let Some(skill_name) = skill
+        .and_then(Value::as_str)
+        .filter(|name| !name.is_empty())
+    {
+        let dcc = map.entry("dcc".to_string()).or_insert_with(|| json!({}));
+        if let Some(dcc_obj) = dcc.as_object_mut() {
+            dcc_obj
+                .entry("skill".to_string())
+                .or_insert_with(|| Value::String(skill_name.to_string()));
+        }
+    }
     (!map.is_empty()).then_some(map)
 }
 
@@ -338,7 +377,7 @@ pub async fn fetch_tools(
     client: &reqwest::Client,
     mcp_url: &str,
     timeout: Duration,
-) -> (Vec<McpTool>, Vec<(String, String, String)>) {
+) -> (Vec<McpTool>, Vec<UnloadedCapabilityHint>) {
     match try_fetch_tools(client, mcp_url, timeout).await {
         Ok(pair) => pair,
         Err(e) => {

--- a/crates/dcc-mcp-gateway/src/gateway/capability/builder.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/builder.rs
@@ -84,7 +84,8 @@ pub fn build_records_from_backend(input: BuildInput<'_>) -> BuildOutcome {
             continue;
         }
 
-        let (skill_name, _) = extract_skill_and_bare(&tool.name);
+        let (name_skill, _) = extract_skill_and_bare(&tool.name);
+        let skill_name = skill_name_from_meta(tool.meta.as_ref()).or(name_skill);
         let callable_id = tool.name.clone();
         let tags = extract_tags(&tool.annotations, tool.meta.as_ref());
         let has_schema = has_meaningful_schema(&tool.input_schema);
@@ -247,6 +248,7 @@ fn compute_fingerprint(records: &[CapabilityRecord]) -> InstanceFingerprint {
     let mut hasher = DefaultHasher::new();
     for r in records {
         r.tool_slug.hash(&mut hasher);
+        r.skill_name.hash(&mut hasher);
         r.has_schema.hash(&mut hasher);
         r.summary.hash(&mut hasher);
         r.annotations.hash(&mut hasher);
@@ -294,6 +296,19 @@ fn extract_metadata(meta: Option<&serde_json::Map<String, Value>>) -> Option<Cap
     })
 }
 
+fn skill_name_from_meta(meta: Option<&serde_json::Map<String, Value>>) -> Option<String> {
+    meta.and_then(|map| map.get("dcc"))
+        .and_then(Value::as_object)
+        .and_then(|dcc| {
+            dcc.get("skill")
+                .or_else(|| dcc.get("skillName"))
+                .or_else(|| dcc.get("skill_name"))
+        })
+        .and_then(Value::as_str)
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+}
+
 // Tiny re-import helper removed: `idempotent` tags now consistently
 // go through `.to_string()`.
 
@@ -310,6 +325,17 @@ mod unit_tests {
             output_schema: None,
             annotations: None,
             meta: None,
+        }
+    }
+
+    fn tool_with_meta(name: &str, desc: &str, schema: Value, meta: Value) -> McpTool {
+        McpTool {
+            name: name.to_string(),
+            description: desc.to_string(),
+            input_schema: schema,
+            output_schema: None,
+            annotations: None,
+            meta: meta.as_object().cloned(),
         }
     }
 
@@ -373,6 +399,29 @@ mod unit_tests {
             "hello_world__greet"
         );
         assert_eq!(by_tool["standalone_action"].skill_name, None);
+    }
+
+    #[test]
+    fn rest_metadata_skill_names_bare_loaded_actions() {
+        let iid = Uuid::from_u128(3);
+        let tools = vec![tool_with_meta(
+            "create_sphere",
+            "sphere",
+            json!({"type": "object"}),
+            json!({"dcc": {"skill": "maya-primitives"}}),
+        )];
+        let out = build_records_from_backend(BuildInput {
+            instance_id: iid,
+            dcc_type: "maya",
+            backend_tools: &tools,
+        });
+
+        assert_eq!(out.records.len(), 1);
+        assert_eq!(out.records[0].backend_tool, "create_sphere");
+        assert_eq!(
+            out.records[0].skill_name.as_deref(),
+            Some("maya-primitives")
+        );
     }
 
     #[test]

--- a/crates/dcc-mcp-gateway/src/gateway/capability/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/mod.rs
@@ -67,8 +67,8 @@ mod tests;
 pub use builder::{BuildInput, BuildOutcome, build_records_from_backend};
 pub use index::{CapabilityIndex, IndexSnapshot, InstanceFingerprint};
 pub use record::{
-    CapabilityAnnotations, CapabilityMetadata, CapabilityRecord, SCHEMA_AVAILABLE, parse_slug,
-    tool_slug,
+    CapabilityAnnotations, CapabilityGroupInfo, CapabilityMetadata, CapabilityRecord,
+    SCHEMA_AVAILABLE, parse_slug, tool_slug,
 };
 pub use refresh::{RefreshReason, refresh_instance, remove_instance};
 pub use search::{

--- a/crates/dcc-mcp-gateway/src/gateway/capability/record.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/record.rs
@@ -17,6 +17,6 @@
 //! See `dcc_mcp_gateway_core::capability` for the original documentation.
 
 pub use dcc_mcp_gateway_core::capability::{
-    CapabilityAnnotations, CapabilityMetadata, CapabilityRecord, SCHEMA_AVAILABLE,
-    is_valid_dcc_bucket, parse_slug, tool_slug,
+    CapabilityAnnotations, CapabilityGroupInfo, CapabilityMetadata, CapabilityRecord,
+    SCHEMA_AVAILABLE, is_valid_dcc_bucket, parse_slug, tool_slug,
 };

--- a/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 
 use uuid::Uuid;
 
-use crate::gateway::backend_client::fetch_tools;
+use crate::gateway::backend_client::{UnloadedCapabilityHint, fetch_tools};
 
 use super::builder::{BuildInput, build_records_from_backend};
 use super::index::{CapabilityIndex, InstanceFingerprint};
@@ -103,20 +103,25 @@ pub async fn refresh_instance(
 }
 
 fn build_unloaded_records(
-    unloaded_hints: Vec<(String, String, String)>,
+    unloaded_hints: Vec<UnloadedCapabilityHint>,
     instance_id: Uuid,
     dcc_type: &str,
 ) -> Vec<CapabilityRecord> {
     unloaded_hints
         .into_iter()
-        .filter_map(|(skill_name, tool_name, summary)| {
-            if tool_name.is_empty() {
+        .filter_map(|hint| {
+            if hint.tool_name.is_empty() {
                 return None;
             }
-            let mut rec =
-                CapabilityRecord::from_skill_tool(&skill_name, &tool_name, &summary, dcc_type);
+            let mut rec = CapabilityRecord::from_skill_tool(
+                &hint.skill_name,
+                &hint.tool_name,
+                &hint.summary,
+                dcc_type,
+            )
+            .with_available_groups(hint.available_groups);
             rec.instance_id = instance_id;
-            rec.tool_slug = tool_slug(dcc_type, &instance_id, &tool_name);
+            rec.tool_slug = tool_slug(dcc_type, &instance_id, &hint.tool_name);
             Some(rec)
         })
         .collect()
@@ -129,6 +134,11 @@ fn compute_fingerprint(records: &[CapabilityRecord]) -> InstanceFingerprint {
         r.has_schema.hash(&mut hasher);
         r.summary.hash(&mut hasher);
         r.loaded.hash(&mut hasher);
+        for group in &r.available_groups {
+            group.name.hash(&mut hasher);
+            group.default_active.hash(&mut hasher);
+            group.active.hash(&mut hasher);
+        }
         for t in &r.tags {
             t.hash(&mut hasher);
         }
@@ -205,6 +215,7 @@ mod unit_tests {
     /// covered by the integration tests in `crates/dcc-mcp-http/tests/http/`.
     #[test]
     fn unloaded_hints_use_instance_scoped_slugs() {
+        use crate::gateway::backend_client::UnloadedCapabilityHint;
         use crate::gateway::capability::{CapabilityRecord, search, search::SearchQuery};
 
         let idx = CapabilityIndex::new();
@@ -230,11 +241,12 @@ mod unit_tests {
 
         let mut records = idx.snapshot().records.to_vec();
         records.extend(build_unloaded_records(
-            vec![(
-                "maya-primitives".to_string(),
-                "maya_primitives__create_sphere".to_string(),
-                "Create a primitive sphere".to_string(),
-            )],
+            vec![UnloadedCapabilityHint {
+                skill_name: "maya-primitives".to_string(),
+                tool_name: "maya_primitives__create_sphere".to_string(),
+                summary: "Create a primitive sphere".to_string(),
+                available_groups: Vec::new(),
+            }],
             iid,
             "maya",
         ));
@@ -297,17 +309,20 @@ mod unit_tests {
 
     #[test]
     fn unloaded_hints_from_two_maya_instances_remain_distinct() {
+        use crate::gateway::backend_client::UnloadedCapabilityHint;
+
         let a = Uuid::from_u128(0xaaaa_0000_0000_0000_0000_0000_0000_0001);
         let b = Uuid::from_u128(0xbbbb_0000_0000_0000_0000_0000_0000_0001);
         let idx = CapabilityIndex::new();
 
         for iid in [a, b] {
             let records = build_unloaded_records(
-                vec![(
-                    "maya-primitives".to_string(),
-                    "maya_primitives__create_sphere".to_string(),
-                    "Create a primitive sphere".to_string(),
-                )],
+                vec![UnloadedCapabilityHint {
+                    skill_name: "maya-primitives".to_string(),
+                    tool_name: "maya_primitives__create_sphere".to_string(),
+                    summary: "Create a primitive sphere".to_string(),
+                    available_groups: Vec::new(),
+                }],
                 iid,
                 "maya",
             );

--- a/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
@@ -116,24 +116,65 @@ pub fn search_service_rows(index: &CapabilityIndex, query: &SearchQuery) -> Vec<
 
 pub fn search_hit_to_value(hit: SearchHit) -> Value {
     let mut value = serde_json::to_value(&hit).unwrap_or(Value::Null);
-    if !hit.record.loaded
-        && let Some(skill_name) = &hit.record.skill_name
-    {
-        value["next_step"] = json!({
-            "action": "load_skill",
-            "arguments": {
+    if !hit.record.loaded {
+        value["load_state"] = json!("unloaded");
+        if let Some(skill_name) = &hit.record.skill_name {
+            let arguments = json!({
                 "skill_name": skill_name,
                 "dcc": &hit.record.dcc_type,
                 "dcc_type": &hit.record.dcc_type,
                 "instance_id": hit.record.instance_id.to_string(),
-            },
-            "rest": {
-                "method": "POST",
-                "path": "/v1/load_skill",
-            },
-        });
+            });
+            value["next_step"] = json!({
+                "action": "load_skill",
+                "arguments": arguments.clone(),
+                "mcp": {
+                    "tool": "load_skill",
+                    "arguments": arguments.clone(),
+                },
+                "rest": {
+                    "method": "POST",
+                    "path": "/v1/load_skill",
+                    "body": arguments,
+                },
+            });
+        }
+    } else if hit.record.loaded {
+        value["load_state"] = json!("loaded");
     }
     value
+}
+
+/// Compute a stable, compact fingerprint for the current capability index.
+///
+/// The value is intentionally opaque. Clients can compare it for equality to
+/// detect that a cached `tool_slug` came from an older search view.
+pub fn index_generation(index: &CapabilityIndex) -> String {
+    index_snapshot_generation(&index.snapshot())
+}
+
+fn index_snapshot_generation(snapshot: &super::capability::IndexSnapshot) -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = DefaultHasher::new();
+    let mut fingerprints: Vec<_> = snapshot.fingerprints.iter().collect();
+    fingerprints.sort_by_key(|(id, _)| id.to_string());
+    for (id, fp) in fingerprints {
+        id.hash(&mut hasher);
+        fp.0.hash(&mut hasher);
+    }
+    for record in snapshot.records.iter() {
+        record.tool_slug.hash(&mut hasher);
+        record.loaded.hash(&mut hasher);
+        record.has_schema.hash(&mut hasher);
+        for group in &record.available_groups {
+            group.name.hash(&mut hasher);
+            group.default_active.hash(&mut hasher);
+            group.active.hash(&mut hasher);
+        }
+    }
+    format!("{:016x}", hasher.finish())
 }
 
 /// Resolve `slug` to its record. Returns a structured error when the
@@ -630,7 +671,14 @@ mod unit_tests {
             iid,
             true,
             false,
-        );
+        )
+        .with_available_groups(vec![crate::gateway::capability::CapabilityGroupInfo {
+            name: "core".to_string(),
+            description: "Default modeling primitives".to_string(),
+            tools: vec!["create_sphere".to_string()],
+            default_active: true,
+            active: Some(false),
+        }]);
         idx.upsert_instance(iid, vec![rec], InstanceFingerprint(1));
 
         let rows = search_service_rows(
@@ -643,17 +691,60 @@ mod unit_tests {
         );
 
         assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["load_state"], "unloaded");
+        assert_eq!(rows[0]["available_groups"][0]["name"], "core");
         assert_eq!(rows[0]["next_step"]["action"], "load_skill");
         assert_eq!(
             rows[0]["next_step"]["arguments"]["skill_name"],
             "maya-primitives"
         );
+        assert_eq!(rows[0]["next_step"]["mcp"]["tool"], "load_skill");
         assert_eq!(rows[0]["next_step"]["arguments"]["dcc"], "maya");
         assert_eq!(
             rows[0]["next_step"]["arguments"]["instance_id"],
             iid.to_string()
         );
         assert_eq!(rows[0]["next_step"]["rest"]["path"], "/v1/load_skill");
+        assert_eq!(
+            rows[0]["next_step"]["rest"]["body"]["instance_id"],
+            iid.to_string()
+        );
+    }
+
+    #[test]
+    fn search_service_rows_carry_load_state_for_two_dcc_families() {
+        let idx = CapabilityIndex::new();
+        let maya = Uuid::from_u128(1);
+        let photoshop = Uuid::from_u128(2);
+        push(&idx, "maya", maya, "maya_workflow__cube", false);
+        push(
+            &idx,
+            "photoshop",
+            photoshop,
+            "photoshop_workflow__select",
+            true,
+        );
+
+        let rows = search_service_rows(
+            &idx,
+            &SearchQuery {
+                query: "workflow".to_string(),
+                loaded_only: Some(false),
+                ..Default::default()
+            },
+        );
+
+        let states: std::collections::HashMap<_, _> = rows
+            .iter()
+            .filter_map(|row| {
+                Some((
+                    row.get("dcc_type")?.as_str()?.to_string(),
+                    row.get("load_state")?.as_str()?.to_string(),
+                ))
+            })
+            .collect();
+        assert_eq!(states.get("maya").map(String::as_str), Some("unloaded"));
+        assert_eq!(states.get("photoshop").map(String::as_str), Some("loaded"));
     }
 
     #[test]

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
@@ -351,7 +351,7 @@ async fn skill_lifecycle_response(gs: &GatewayState, tool: &str, body: Value) ->
         return (
             StatusCode::BAD_GATEWAY,
             Json(service_error_to_json(&ServiceError::new(
-                "backend-error",
+                classify_skill_lifecycle_error(tool, &text),
                 text,
             ))),
         )
@@ -359,6 +359,34 @@ async fn skill_lifecycle_response(gs: &GatewayState, tool: &str, body: Value) ->
     }
     let parsed = serde_json::from_str::<Value>(&text).unwrap_or_else(|_| json!({"message": text}));
     (StatusCode::OK, Json(parsed)).into_response()
+}
+
+fn classify_skill_lifecycle_error(tool: &str, text: &str) -> &'static str {
+    let lowered = text.to_ascii_lowercase();
+    if lowered.contains("multiple-instances-match") || lowered.contains("ambiguous") {
+        return "ambiguous-instance";
+    }
+    if lowered.contains("no-live-instance-match")
+        || lowered.contains("unreachable")
+        || lowered.contains("booting")
+    {
+        return "instance-offline";
+    }
+    if lowered.contains("schema") {
+        return "schema-unavailable";
+    }
+    if lowered.contains("group")
+        && (tool.contains("group") || lowered.contains("not found") || lowered.contains("unknown"))
+    {
+        return "group-not-found";
+    }
+    if lowered.contains("already loaded") || lowered.contains("already_loaded") {
+        return "skill-already-loaded";
+    }
+    if lowered.contains("not found") || lowered.contains("unknown skill") {
+        return "skill-not-found";
+    }
+    "backend-error"
 }
 
 /// `POST /v1/describe` — return the compact record and (optionally)

--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/agent_workflows.md
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/agent_workflows.md
@@ -11,7 +11,8 @@
 1. **`tools/list`** — Small, stable set: exactly **`search`**, **`describe`**, **`load_skill`**, and **`call`**. Treat it as an **index of gateway verbs**, not the full catalog of every backend action.
 2. **Discover backend work** — `search(kind="tool")` → **`describe`** (read schema, descriptions, safety hints, **`affinity`**, **`execution`**, timeouts) → **`call`**. On REST, use `/v1/search`, `/v1/describe`, `/v1/call` (or the path-style `POST /v1/dcc/{dcc}/instances/{id}/call` from **REST clients** below). Skipping `describe` wastes retries and breaks validation.
 3. **Chaining** — **`call({calls:[...]})`** / **`POST /v1/call_batch`** runs up to **25** ordered calls when you have several **different** validated steps. Prefer fewer, well-formed calls over chatty micro-steps.
-4. **Skills vs tools** — `search(kind="skill")` / `load_skill` load packaged workflows on a host; `search(kind="tool")` resolves a **`tool_slug`** for the dynamic surface. Keep names straight; use `describe` before calling an unfamiliar slug.
+4. **Skills vs tools** — `search(kind="skill")` / `load_skill` load packaged workflows on a host; `search(kind="tool")` resolves a **`tool_slug`** for the dynamic surface. Keep names straight; use `describe` before calling an unfamiliar slug. Unloaded hits carry `load_state`, `available_groups` when known, and `next_step` with both MCP and REST call shapes.
+5. **Progressive groups** — gateway `load_skill` defaults to lazy group activation (`activate_groups=false` unless you opt in). Default-active/core groups may become active; heavier groups should be activated explicitly through `load_skill(..., tool_group="...")`.
 
 ### Host / connector wrappers (common mistakes)
 

--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/agent_workflows.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/agent_workflows.rs
@@ -1,6 +1,6 @@
 //! `gateway://docs/agent-workflows` — static, **platform-agnostic** guidance for
 //! agents using the DCC-MCP **gateway**: MCP tools vs `resources/*` / `prompts/*`,
-//! `describe_tool` (schema, affinity, timeouts), `gateway://instances`, and
+//! `describe` (schema, affinity, timeouts), `gateway://instances`, and
 //! reading host help URIs from `resources/list`.
 //!
 //! Embeds `agent_workflows.md` in this directory; no dependency on any single
@@ -16,7 +16,7 @@ pub fn pointer() -> Value {
     json!({
         "uri":         ROOT_URI,
         "name":        "DCC-MCP Gateway — agent workflow guide",
-        "description": "How to use the MCP gateway well: tools/list vs search_tools→describe_tool→call_tool; REST GET /v1/context (instances), GET /v1/dcc/{dcc}/instances/{id}/describe, POST /v1/dcc/{dcc}/instances/{id}/call; refresh instances after DCC restart; resources/list+read; prompts; call_tools/call_batch (≤25). Connector wrappers (e.g. get_sessions) map to gateway://instances or GET /v1/instances — not extra MCP tools. DCC names in chat → dcc_type / gateway://instances.",
+        "description": "How to use the MCP gateway well: tools/list exposes search→describe→load_skill→call; unloaded search hits carry executable next_step and available_groups; REST GET /v1/context (instances), GET /v1/dcc/{dcc}/instances/{id}/describe, POST /v1/dcc/{dcc}/instances/{id}/call; refresh instances after DCC restart; resources/list+read; prompts; call/call_batch (≤25). Connector wrappers (e.g. get_sessions) map to gateway://instances or GET /v1/instances — not extra MCP tools. DCC names in chat → dcc_type / gateway://instances.",
         "mimeType":    "application/json"
     })
 }

--- a/crates/dcc-mcp-gateway/src/gateway/response_codec.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/response_codec.rs
@@ -264,6 +264,8 @@ fn compact_record(record: &Value) -> Value {
     copy_field(&mut out, record, "instance_id");
     copy_field(&mut out, record, "has_schema");
     copy_field(&mut out, record, "loaded");
+    copy_field(&mut out, record, "load_state");
+    copy_field(&mut out, record, "available_groups");
     copy_field(&mut out, record, "score");
     copy_field(&mut out, record, "annotations");
     copy_field(&mut out, record, "metadata");

--- a/crates/dcc-mcp-gateway/src/gateway/tools.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tools.rs
@@ -639,13 +639,14 @@ pub fn gateway_tool_defs() -> serde_json::Value {
             "name": "load_skill",
             "description": "Load a discovered skill on a target DCC instance, or activate/deactivate a \
                 progressive tool group. Use `skill_name` from search results and pass `instance_id` or \
-                `dcc`/`dcc_type` when more than one backend is live.",
+                `dcc`/`dcc_type` when more than one backend is live. Default loading is lazy: \
+                only default-active groups become active unless `activate_groups=true` or `tool_group` is supplied.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "skill_name": {"type": "string"},
                     "skill_names": {"type": "array", "items": {"type": "string"}},
-                    "activate_groups": {"type": "boolean", "default": true},
+                    "activate_groups": {"type": "boolean", "default": false},
                     "tool_group": {"type": "string", "description": "Progressive group to activate after loading."},
                     "group_name": {"type": "string", "description": "Alias of tool_group."},
                     "group_action": {"type": "string", "enum": ["activate", "deactivate"], "default": "activate"},

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/handlers/skills.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/handlers/skills.rs
@@ -144,6 +144,22 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_load_skill(
 
     let loaded_ok = !all_registered_tools.is_empty();
     let partial = loaded_ok && !errors.is_empty();
+    let available_groups = group_state_payloads(&state.catalog, &requested);
+    let activated_groups: Vec<String> = available_groups
+        .iter()
+        .filter(|group| {
+            group
+                .get("active")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+        })
+        .filter_map(|group| {
+            group
+                .get("name")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
+        .collect();
 
     let mut body = json!({
         "loaded":           loaded_ok,
@@ -152,6 +168,8 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_load_skill(
         "tool_count":       all_registered_tools.len(),
         "newly_loaded":     newly_loaded,
         "already_loaded":   already_loaded,
+        "available_groups":  available_groups,
+        "activated_groups":  activated_groups,
         "tools":            tool_schemas,
     });
     if !errors.is_empty()
@@ -166,6 +184,40 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_load_skill(
     } else {
         CallToolResult::error(text)
     }
+}
+
+fn group_state_payloads(
+    catalog: &dcc_mcp_skills::SkillCatalog,
+    skill_names: &[String],
+) -> Vec<Value> {
+    let active_by_skill_group: std::collections::HashMap<(String, String), bool> = catalog
+        .list_groups()
+        .into_iter()
+        .map(|(skill, group, active)| ((skill, group), active))
+        .collect();
+    let mut groups = Vec::new();
+    for skill_name in skill_names {
+        let Some(detail) = catalog.get_skill_info(skill_name) else {
+            continue;
+        };
+        for group in detail.groups {
+            if group.name.is_empty() {
+                continue;
+            }
+            let active = active_by_skill_group
+                .get(&(detail.name.clone(), group.name.clone()))
+                .copied()
+                .unwrap_or(false);
+            groups.push(json!({
+                "name": group.name,
+                "description": group.description,
+                "tools": group.tools,
+                "default_active": group.default_active,
+                "active": active,
+            }));
+        }
+    }
+    groups
 }
 
 pub(in crate::rmcp_tool_call_dispatch) fn handle_unload_skill(

--- a/crates/dcc-mcp-skill-rest/src/service.rs
+++ b/crates/dcc-mcp-skill-rest/src/service.rs
@@ -111,6 +111,9 @@ pub struct SkillListEntry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schema(value_type = Option<Object>)]
     pub metadata: Option<Value>,
+    /// Progressive tool groups declared by the owning skill, when known.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub available_groups: Vec<SkillGroupState>,
     /// Machine-executable remediation for progressive loading. Present
     /// when `loaded=false` so REST clients can load the owning skill
     /// without needing MCP tool metadata.
@@ -124,6 +127,20 @@ pub struct ProgressiveNextStep {
     pub action: String,
     #[schema(value_type = Object)]
     pub arguments: Value,
+}
+
+/// Bounded group metadata for progressive skill activation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+pub struct SkillGroupState {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub description: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<String>,
+    #[serde(default)]
+    pub default_active: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active: Option<bool>,
 }
 
 /// Stable tool slug format used across REST and MCP.
@@ -294,6 +311,7 @@ pub struct CatalogAction {
     pub timeout_hint_secs: Option<u32>,
     pub thread_affinity: ThreadAffinity,
     pub enforce_thread_affinity: bool,
+    pub available_groups: Vec<SkillGroupState>,
 }
 
 /// Anything that can invoke a tool by name and return its output.
@@ -489,6 +507,35 @@ impl SkillCatalogSource for CatalogSource {
         for s in &summaries {
             skill_info.insert(s.name.clone(), (s.loaded, s.scope.clone(), s.dcc.clone()));
         }
+        let mut active_groups: std::collections::HashMap<(String, String), bool> =
+            std::collections::HashMap::new();
+        for (skill, group, active) in self.catalog.list_groups() {
+            active_groups.insert((skill, group), active);
+        }
+        let mut groups_by_skill: std::collections::HashMap<String, Vec<SkillGroupState>> =
+            std::collections::HashMap::new();
+        for s in &summaries {
+            let Some(detail) = self.catalog.get_skill_info(&s.name) else {
+                continue;
+            };
+            let groups = detail
+                .groups
+                .iter()
+                .filter(|group| !group.name.is_empty())
+                .map(|group| SkillGroupState {
+                    name: group.name.clone(),
+                    description: group.description.clone(),
+                    tools: group.tools.clone(),
+                    default_active: group.default_active,
+                    active: active_groups
+                        .get(&(detail.name.clone(), group.name.clone()))
+                        .copied(),
+                })
+                .collect::<Vec<_>>();
+            if !groups.is_empty() {
+                groups_by_skill.insert(s.name.clone(), groups);
+            }
+        }
 
         for meta in registry.list_actions(None) {
             let skill_name = meta
@@ -510,7 +557,7 @@ impl SkillCatalogSource for CatalogSource {
             seen.insert(meta.name.clone());
             out.push(CatalogAction {
                 action_name: meta.name,
-                skill_name,
+                skill_name: skill_name.clone(),
                 dcc: meta.dcc,
                 description: meta.description,
                 tags: meta.tags,
@@ -522,6 +569,10 @@ impl SkillCatalogSource for CatalogSource {
                 timeout_hint_secs: meta.timeout_hint_secs,
                 thread_affinity: meta.thread_affinity,
                 enforce_thread_affinity: meta.enforce_thread_affinity,
+                available_groups: groups_by_skill
+                    .get(&skill_name)
+                    .cloned()
+                    .unwrap_or_default(),
             });
         }
 
@@ -564,6 +615,10 @@ impl SkillCatalogSource for CatalogSource {
                     timeout_hint_secs: tool_decl.timeout_hint_secs,
                     thread_affinity: tool_decl.thread_affinity,
                     enforce_thread_affinity: tool_decl.enforce_thread_affinity,
+                    available_groups: groups_by_skill
+                        .get(&detail.name)
+                        .cloned()
+                        .unwrap_or_default(),
                 });
             }
         }
@@ -1127,6 +1182,7 @@ fn action_to_entry(a: CatalogAction) -> SkillListEntry {
         scope: a.scope,
         annotations,
         metadata,
+        available_groups: a.available_groups,
         next_step,
     }
 }

--- a/crates/dcc-mcp-skill-rest/src/service_tests.rs
+++ b/crates/dcc-mcp-skill-rest/src/service_tests.rs
@@ -102,6 +102,7 @@ fn sphere_action(loaded: bool) -> CatalogAction {
         timeout_hint_secs: None,
         thread_affinity: Default::default(),
         enforce_thread_affinity: false,
+        available_groups: Vec::new(),
     }
 }
 
@@ -147,7 +148,15 @@ fn search_returns_loaded_only_by_default() {
 
 #[test]
 fn search_loaded_only_false_returns_executable_next_step() {
-    let (svc, _) = build_service(vec![sphere_action(false)]);
+    let mut action = sphere_action(false);
+    action.available_groups = vec![SkillGroupState {
+        name: "advanced".into(),
+        description: "Heavier modeling tools".into(),
+        tools: vec!["create_sphere".into()],
+        default_active: false,
+        active: Some(false),
+    }];
+    let (svc, _) = build_service(vec![action]);
     let resp = svc.search(&SearchRequest {
         loaded_only: false,
         ..Default::default()
@@ -158,6 +167,8 @@ fn search_loaded_only_false_returns_executable_next_step() {
     assert_eq!(next.action, "load_skill");
     assert_eq!(next.arguments["skill_name"], "spheres");
     assert_eq!(next.arguments["dcc"], "maya");
+    assert_eq!(resp.hits[0].available_groups[0].name, "advanced");
+    assert_eq!(resp.hits[0].available_groups[0].active, Some(false));
 }
 
 #[test]

--- a/crates/dcc-mcp-skills/src/catalog/catalog.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog.rs
@@ -139,6 +139,7 @@ impl SkillCatalog {
                 markdown,
                 scripts: e.metadata.scripts.clone(),
                 tools: e.metadata.tools.clone(),
+                groups: e.metadata.groups.clone(),
                 state: e.state.to_string(),
                 missing_dependencies: e.state.missing_dependencies(),
                 registered_tools: e.registered_tools.clone(),

--- a/crates/dcc-mcp-skills/src/catalog/types.rs
+++ b/crates/dcc-mcp-skills/src/catalog/types.rs
@@ -1,6 +1,6 @@
 //! Data types for the skill catalog: state, entries, summary, and detail.
 
-use dcc_mcp_models::{RegistryEntry, SkillMetadata, SkillScope, ToolDeclaration};
+use dcc_mcp_models::{RegistryEntry, SkillGroup, SkillMetadata, SkillScope, ToolDeclaration};
 #[cfg(feature = "stub-gen")]
 use pyo3_stub_gen_derive::{gen_stub_pyclass, gen_stub_pymethods};
 use serde::Serializer;
@@ -149,6 +149,8 @@ pub struct SkillDetail {
     pub markdown: Option<String>,
     pub scripts: Vec<String>,
     pub tools: Vec<ToolDeclaration>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub groups: Vec<SkillGroup>,
     pub state: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub missing_dependencies: Vec<String>,

--- a/docs/guide/gateway.md
+++ b/docs/guide/gateway.md
@@ -292,10 +292,13 @@ Use the per-DCC Skills-First flow (`search_skills` → `load_skill` → tool cal
 when the agent is connected directly to one DCC server.
 
 For REST-only clients, `POST /v1/search` with `loaded_only=false` returns
-unloaded hits with a machine-executable `next_step`. POST that
-`next_step.arguments` object to `/v1/load_skill`, then search or describe again.
-The same shape is included in MCP `search` results, so REST and MCP agents
-can share the same progressive-loading planner.
+unloaded hits with `load_state`, `available_groups` when the backend knows
+them, and a machine-executable `next_step`. POST that `next_step.arguments`
+object to `/v1/load_skill`, or call MCP `load_skill` with the `next_step.mcp`
+arguments, then search or describe again. Gateway `load_skill` defaults to
+lazy group activation (`activate_groups=false` unless supplied), so only
+default-active/core groups become active automatically; use an explicit
+`tool_group` activation for heavier groups.
 
 ### Gateway call wrapper payloads
 

--- a/docs/guide/rest-api-surface.md
+++ b/docs/guide/rest-api-surface.md
@@ -356,6 +356,15 @@ Response shape (gateway + per-DCC are identical):
       "dcc": "maya",
       "tags": ["batch"],
       "loaded": false,
+      "load_state": "unloaded",
+      "available_groups": [
+        {
+          "name": "core",
+          "tools": ["render_frame"],
+          "default_active": true,
+          "active": false
+        }
+      ],
       "next_step": {
         "action": "load_skill",
         "arguments": {
@@ -364,7 +373,23 @@ Response shape (gateway + per-DCC are identical):
           "dcc_type": "maya",
           "instance_id": "a1b2c3d4-0000-0000-0000-000000000001"
         },
-        "rest": {"method": "POST", "path": "/v1/load_skill"}
+        "mcp": {
+          "tool": "load_skill",
+          "arguments": {
+            "skill_name": "maya-render",
+            "dcc_type": "maya",
+            "instance_id": "a1b2c3d4-0000-0000-0000-000000000001"
+          }
+        },
+        "rest": {
+          "method": "POST",
+          "path": "/v1/load_skill",
+          "body": {
+            "skill_name": "maya-render",
+            "dcc_type": "maya",
+            "instance_id": "a1b2c3d4-0000-0000-0000-000000000001"
+          }
+        }
       }
     }
   ]
@@ -374,7 +399,9 @@ Response shape (gateway + per-DCC are identical):
 When `loaded=false`, clients may POST `next_step.arguments` directly to
 `/v1/load_skill`, then repeat `/v1/search` or call `/v1/describe` for the same
 tool. Per-DCC REST omits `instance_id` because there is only one owning server;
-the gateway includes it so same-DCC multi-instance calls stay routed.
+the gateway includes it so same-DCC multi-instance calls stay routed. Gateway
+`load_skill` defaults to lazy group activation (`activate_groups=false` unless
+supplied), so heavier groups should be activated explicitly.
 
 ### Compact output
 
@@ -406,9 +433,10 @@ headers:
 
 The compact search shape preserves the workflow fields agents need next:
 `tool_slug`, `backend_tool`, `dcc_type`, `instance_id`, `loaded`,
-`has_schema`, `score`, and `next_step` for unloaded skills. It omits redundant
-defaults such as `callable_id` when it matches `backend_tool`, empty arrays, and
-empty objects. RTK's compaction model is treated as design guidance here; the
+`load_state`, `available_groups`, `has_schema`, `score`, and `next_step` for
+unloaded skills. It omits redundant defaults such as `callable_id` when it
+matches `backend_tool`, empty arrays, and empty objects. RTK's compaction model
+is treated as design guidance here; the
 gateway uses the deterministic in-process `toon-format` library so
 `serde_json::Value` payloads round-trip inside Rust tests without spawning an
 external codec process.
@@ -430,7 +458,9 @@ aggregate body savings.
 `skill_name` is required. Gateway callers should pass the `dcc` / `dcc_type`
 and `instance_id` returned in `/v1/search.next_step.arguments` when more than
 one DCC instance is live. A successful load refreshes the gateway capability
-index, so the next `/v1/search` sees the newly callable actions.
+index and returns `loaded`, `skill_name`, `dcc_type`, `instance_id`,
+`activated_groups`, `new_tool_slugs`, `index_generation`, and a suggested
+`next_step` (`describe` when a new slug is known, otherwise `search`).
 
 ---
 

--- a/docs/zh/guide/gateway.md
+++ b/docs/zh/guide/gateway.md
@@ -151,6 +151,11 @@ Gateway capability index 使用 `<dcc>.<id8>.<tool>` 作为紧凑记录键，并
 
 Agent 连接到 Gateway 时使用这条四工具动态能力流程；直接连接某个 DCC 服务时使用
 per-DCC Skills-First 流程（`search_skills` → `load_skill` → 调用工具）。
+当 `/v1/search` 或 MCP `search` 返回未加载 skill 命中时，结果会带
+`load_state`、已知的 `available_groups`，以及同时包含 MCP/REST 形态的
+`next_step`。Gateway `load_skill` 默认使用惰性 group 激活
+（未显式传入时等价于 `activate_groups=false`），只让默认/core group 自动可用；
+更重或有破坏性的 group 应通过显式 `tool_group` 激活。
 
 ## 代码指针
 

--- a/docs/zh/guide/rest-api-surface.md
+++ b/docs/zh/guide/rest-api-surface.md
@@ -155,6 +155,10 @@ OpenAPI contract 预留了 `cursor`、`since`、`until` 给后续 normalized env
 - `affinity-violation` (409) —— 从 worker 线程调用了主线程独占的工具。
 - `bad-request` (400) —— envelope 有误（缺 `tool_slug`、JSON 坏、等）。
 - `backend-error` (502) —— 拥有者 DCC 进程响应了但工具失败。
+- `skill-not-found` (502) —— **仅网关 skill lifecycle** —— 请求的 skill 不存在。
+- `skill-already-loaded` (502) —— **仅网关 skill lifecycle** —— skill 已处于加载状态。
+- `group-not-found` (502) —— **仅网关 skill lifecycle** —— 请求的 progressive group 不存在。
+- `ambiguous-instance` (502) —— **仅网关 skill lifecycle** —— DCC / instance 选择不唯一。
 - `instance-offline` (503) —— **仅网关** —— `<id8>` 对应的实例已不在线。
 - `schema-unavailable` (502) —— **仅网关** —— 拥有者 DCC 在 discovery 和 call 之间失联。
 - `internal` (500) —— REST 层自身失败；查服务端日志。
@@ -195,12 +199,17 @@ curl -H 'Accept: application/toon' \
 | `x-dcc-mcp-saved-tokens` / `x-dcc-mcp-savings-pct` | 相比旧 JSON 的估算节省。 |
 
 compact search 仍保留 agent 后续工作需要的字段：`tool_slug`、
-`backend_tool`、`dcc_type`、`instance_id`、`loaded`、`has_schema`、`score`，
-以及 unloaded skill 的 `next_step`。它会省略冗余默认值，例如与
+`backend_tool`、`dcc_type`、`instance_id`、`loaded`、`load_state`、
+`available_groups`、`has_schema`、`score`，以及 unloaded skill 的
+`next_step`。`next_step` 同时带 MCP (`tool` + `arguments`) 和 REST
+(`method` + `path` + `body`) 形态；Gateway REST 调用方可以直接 POST
+`next_step.arguments` 到 `/v1/load_skill`。它会省略冗余默认值，例如与
 `backend_tool` 相同的 `callable_id`、空数组和空 object。这里把 RTK 的
 语义压缩模型作为设计参考；gateway 内部直接使用确定性的 `toon-format`
 库，让 `serde_json::Value` payload 在 Rust 测试中可 round-trip，不需要
-派生外部 codec 进程。
+派生外部 codec 进程。Gateway `load_skill` 默认惰性激活 group
+（未传入时等价于 `activate_groups=false`）：默认/core group 可自动可用，
+更重的 group 需要显式 `tool_group` 激活。
 
 compact describe 会对 `record` 应用相同的小记录规则，但完整保留 `tool`
 定义，包括 `inputSchema`、annotations 和 validation hints。compact call

--- a/skills/dcc-mcp-skill-developer/SKILL.md
+++ b/skills/dcc-mcp-skill-developer/SKILL.md
@@ -102,6 +102,11 @@ into a faster authoring loop.
    `describe_tool`, `call_tool`, `call_tools`, lease helpers) may appear in old
    clients, but new docs and skills should not advertise them in `tools/list`
    workflows.
+   Unloaded gateway search hits now carry `load_state`, `available_groups`
+   when the backend knows them, and `next_step` with both MCP and REST call
+   shapes. Keep group metadata concise (`name`, short `description`, `tools`,
+   `default-active`) so agents can decide whether to call `load_skill` directly
+   or explicitly activate a heavier `tool_group` after the lazy default load.
 8. For adapter install, uninstall, or upgrade flows, use
    `dcc_mcp_core.install_lifecycle` before importing Rust-backed public API:
    query/stop registered sidecars, inspect install roots, classify locked

--- a/tests/test_mcp_mcpcall_e2e.py
+++ b/tests/test_mcp_mcpcall_e2e.py
@@ -428,6 +428,13 @@ class TestMcpcallGatewayCanonicalWorkflow:
             _mcpcall_call(url, name, "load_skill", {"skill_name": "hello-world", "dcc_type": "python"})
         )
         assert load.get("loaded") is True
+        assert load.get("skill_name") == "hello-world"
+        assert load.get("dcc_type") == "python"
+        assert load.get("instance_id")
+        assert isinstance(load.get("new_tool_slugs"), list)
+        assert load.get("index_generation")
+        assert load.get("next_step", {}).get("mcp", {}).get("tool") in {"describe", "search"}
+        assert load.get("next_step", {}).get("rest", {}).get("path") in {"/v1/describe", "/v1/search"}
 
         greet_search = _parse_gateway_payload(
             _mcpcall_call(url, name, "search", {"query": "greet", "dcc_type": "python", "limit": 5})


### PR DESCRIPTION
## Summary
- expose unloaded search hits with load state, available groups, and executable MCP/REST next steps
- return structured gateway load_skill success metadata including instance routing, activated groups, new tool slugs, index generation, and follow-up action
- preserve owning skill metadata from REST hits so loaded capability records remain attributable after refresh
- update mcpcall E2E coverage and gateway docs/skill guidance

## Validation
- vx just preflight
- .\.venv\Scripts\python.exe -m pytest tests/ -q --tb=short --show-capture=no
- .\.venv\Scripts\python.exe -m pytest tests/test_mcp_mcpcall_e2e.py -v --tb=short
- vx cargo test -p dcc-mcp-gateway --lib
- vx cargo test -p dcc-mcp-gateway-core --lib
- vx cargo test -p dcc-mcp-skills --lib
- vx cargo test -p dcc-mcp-skill-rest --lib
- vx cargo test -p dcc-mcp-http-server --lib

Closes #1172