### PR TITLE
fix: update clawhub publish cli

### DIFF
--- a/.github/workflows/clawhub.yml
+++ b/.github/workflows/clawhub.yml
@@ -52,7 +52,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  CLAWHUB_CLI_PACKAGE: clawhub@0.7.0
+  CLAWHUB_CLI_PACKAGE: clawhub@0.17.0
   CLAWHUB_CONFIG_PATH: .clawhub/config.json
   CLAWHUB_DISABLE_TELEMETRY: "1"
 

--- a/scripts/clawhub_sync.py
+++ b/scripts/clawhub_sync.py
@@ -14,7 +14,7 @@ import dcc_mcp_core
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MANIFEST = REPO_ROOT / ".github" / "clawhub-skills.json"
-DEFAULT_CLI = os.environ.get("CLAWHUB_CLI_PACKAGE", "clawhub@0.7.0")
+DEFAULT_CLI = os.environ.get("CLAWHUB_CLI_PACKAGE", "clawhub@0.17.0")
 CLAWHUB_LICENSE = "MIT-0"
 
 
@@ -35,7 +35,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--cli",
         default=DEFAULT_CLI,
-        help="npm package for clawhub CLI (default: clawhub@0.7.0)",
+        help="npm package for clawhub CLI (default: clawhub@0.17.0)",
     )
     return parser.parse_args()
 

--- a/tests/test_clawhub_sync.py
+++ b/tests/test_clawhub_sync.py
@@ -36,6 +36,7 @@ class TestClawhubSync:
         )
         assert proc.returncode == 0, proc.stderr
         assert "DRY-RUN" in proc.stdout
+        assert "clawhub@0.17.0" in proc.stdout
         assert "dcc-rest-gateway" in proc.stdout
         assert "dcc-cli-gateway" in proc.stdout
 


### PR DESCRIPTION
## Summary
- update the ClawHub publish workflow to use clawhub@0.17.0
- keep the sync script default aligned with CI
- assert the dry-run publish command uses the license-aware CLI

## Validation
- python -m pytest tests/test_clawhub_sync.py -q
- python scripts/clawhub_sync.py --dry-run
- actionlint .github/workflows/clawhub.yml
- vx ruff check scripts/clawhub_sync.py tests/test_clawhub_sync.py
- vx ruff format --check scripts/clawhub_sync.py tests/test_clawhub_sync.py