### PR TITLE
feat: add gateway openapi contract

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
@@ -177,8 +177,7 @@ fn readiness_value_is_ready(readiness: &Value) -> bool {
 
 /// `GET /v1/openapi.json` — gateway REST contract.
 pub async fn handle_v1_openapi(State(gs): State<GatewayState>) -> impl IntoResponse {
-    let doc =
-        dcc_mcp_skill_rest::openapi::build_openapi_document("dcc-mcp-gateway", &gs.server_version);
+    let doc = crate::gateway::rest_openapi::build_gateway_openapi_document(&gs.server_version);
     #[cfg(feature = "admin")]
     let doc = {
         let mut doc = doc;
@@ -192,8 +191,7 @@ pub async fn handle_v1_openapi(State(gs): State<GatewayState>) -> impl IntoRespo
 
 /// `GET /docs` — gateway REST API reference.
 pub async fn handle_v1_docs(State(gs): State<GatewayState>) -> Response {
-    let doc =
-        dcc_mcp_skill_rest::openapi::build_openapi_document("dcc-mcp-gateway", &gs.server_version);
+    let doc = crate::gateway::rest_openapi::build_gateway_openapi_document(&gs.server_version);
     #[cfg(feature = "admin")]
     let doc = {
         let mut doc = doc;

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
@@ -1,11 +1,13 @@
 use super::*;
-use axum::body::to_bytes;
+use axum::body::{Body, to_bytes};
+use axum::http::Request;
 use dcc_mcp_transport::discovery::file_registry::FileRegistry;
 use dcc_mcp_transport::discovery::types::ServiceEntry;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::{RwLock, broadcast, watch};
+use tower::ServiceExt;
 
 #[derive(Default)]
 struct CaptureSink(Mutex<Vec<crate::gateway::middleware::AuditEntry>>);
@@ -144,6 +146,111 @@ async fn gateway_docs_serves_scalar_openapi_ui() {
     assert!(body.contains("dcc-mcp-gateway"));
     assert!(body.contains("/v1/search"));
     assert!(!body.contains("/v1/debug/instances"));
+    assert!(!body.contains("/v1/dcc/{dcc_type}/call"));
+}
+
+#[tokio::test]
+async fn gateway_openapi_lists_gateway_routes_not_per_dcc_routes() {
+    let (status, doc) = response_json(
+        handle_v1_openapi(State(test_gateway_state("1.2.3")))
+            .await
+            .into_response(),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let paths = doc["paths"].as_object().expect("paths object");
+    for route in crate::gateway::rest_openapi::GATEWAY_OPENAPI_ROUTES {
+        let path_item = paths.get(route.path);
+        assert!(
+            path_item.is_some(),
+            "gateway OpenAPI doc missing {} {}: {doc:#}",
+            route.method,
+            route.path
+        );
+        assert!(
+            path_item
+                .and_then(|item| item.get(route.method.to_ascii_lowercase()))
+                .is_some(),
+            "gateway OpenAPI doc missing operation {} {}: {doc:#}",
+            route.method,
+            route.path
+        );
+    }
+    for forbidden in [
+        "/v1/resources",
+        "/v1/resources/{uri}",
+        "/v1/prompts",
+        "/v1/prompts/{name}",
+        "/v1/jobs/{id}/events",
+        "/v1/jobs/{id}",
+        "/v1/dcc/{dcc_type}/call",
+    ] {
+        assert!(
+            paths.get(forbidden).is_none(),
+            "gateway OpenAPI doc must not advertise per-DCC-only path {forbidden}: {doc:#}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn gateway_openapi_canonical_routes_are_mounted_by_router() {
+    let app = crate::gateway::router::build_gateway_router(test_gateway_state("1.2.3"));
+
+    for route in crate::gateway::rest_openapi::GATEWAY_OPENAPI_ROUTES {
+        let uri = materialized_gateway_route(route.path);
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(route.method)
+                    .uri(uri.as_str())
+                    .header("content-type", "application/json")
+                    .body(route_body(route.path))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        assert_ne!(
+            status,
+            StatusCode::METHOD_NOT_ALLOWED,
+            "{} {} is documented but mounted with a different method",
+            route.method,
+            route.path
+        );
+        if status == StatusCode::NOT_FOUND {
+            assert!(
+                !body.is_empty(),
+                "{} {} returned Axum's empty 404 and is likely not mounted",
+                route.method,
+                route.path
+            );
+        }
+    }
+}
+
+fn materialized_gateway_route(path: &str) -> String {
+    let mut materialized = path
+        .replace("{slug}", "maya.abcdef01.example_tool")
+        .replace("{dcc_type}", "maya")
+        .replace("{instance_id}", "abcdef01");
+    if path == "/v1/dcc/{dcc_type}/instances/{instance_id}/describe" {
+        materialized.push_str("?backend_tool=example_tool");
+    }
+    materialized
+}
+
+fn route_body(path: &str) -> Body {
+    let body = match path {
+        "/v1/call_batch" => r#"{"calls":[]}"#,
+        "/v1/dcc/{dcc_type}/instances/{instance_id}/call" => {
+            r#"{"backend_tool":"example_tool","arguments":{}}"#
+        }
+        _ => "{}",
+    };
+    Body::from(body)
 }
 
 #[tokio::test]

--- a/crates/dcc-mcp-gateway/src/gateway/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/mod.rs
@@ -48,6 +48,7 @@ pub mod openapi;
 pub mod proxy;
 pub mod resilience;
 pub(crate) mod response_codec;
+pub(crate) mod rest_openapi;
 pub mod router;
 pub mod sse_subscriber;
 pub mod state;

--- a/crates/dcc-mcp-gateway/src/gateway/rest_openapi.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/rest_openapi.rs
@@ -1,0 +1,708 @@
+//! Gateway-specific OpenAPI contract for the canonical `/v1/*` REST surface.
+//!
+//! The gateway is an aggregating facade, not a per-DCC adapter server.  It
+//! shares several request/response envelopes with `dcc-mcp-skill-rest`, but its
+//! mounted routes are different.  Keep the path list here gateway-owned so
+//! `GET /v1/openapi.json` does not advertise per-DCC-only resources, prompts, or
+//! job routes.
+
+use serde_json::{Map, Value, json};
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct GatewayOpenApiRoute {
+    pub(crate) method: &'static str,
+    pub(crate) path: &'static str,
+}
+
+#[cfg(test)]
+pub(crate) const GATEWAY_OPENAPI_ROUTES: &[GatewayOpenApiRoute] = &[
+    get("/v1/instances"),
+    get("/v1/healthz"),
+    get("/v1/readyz"),
+    get("/v1/openapi.json"),
+    get("/docs"),
+    get("/v1/skills"),
+    post("/v1/list_skills"),
+    post("/v1/search"),
+    post("/v1/load_skill"),
+    post("/v1/unload_skill"),
+    post("/v1/describe"),
+    get("/v1/tools/{slug}"),
+    post("/v1/call"),
+    post("/v1/call_batch"),
+    get("/v1/context"),
+    get("/v1/dcc/{dcc_type}/instances/{instance_id}/describe"),
+    post("/v1/dcc/{dcc_type}/instances/{instance_id}/call"),
+    post("/v1/dcc/{dcc_type}/instances/{instance_id}/stop"),
+];
+
+#[cfg(test)]
+const fn get(path: &'static str) -> GatewayOpenApiRoute {
+    GatewayOpenApiRoute {
+        method: "GET",
+        path,
+    }
+}
+
+#[cfg(test)]
+const fn post(path: &'static str) -> GatewayOpenApiRoute {
+    GatewayOpenApiRoute {
+        method: "POST",
+        path,
+    }
+}
+
+#[must_use]
+pub(crate) fn build_gateway_openapi_document(server_version: &str) -> Value {
+    let mut doc = json!({
+        "openapi": "3.1.0",
+        "info": {
+            "title": "dcc-mcp-gateway",
+            "description": "Gateway-specific REST API for multi-DCC discovery, skill loading, routing, and instance-scoped tool calls.",
+            "version": server_version,
+        },
+        "tags": [
+            {"name": "health", "description": "Gateway liveness and readiness probes."},
+            {"name": "instances", "description": "Live DCC instance inventory."},
+            {"name": "skills", "description": "Gateway skill discovery and lifecycle operations."},
+            {"name": "tools", "description": "Gateway capability describe and invocation operations."},
+            {"name": "meta", "description": "Gateway API self-description."},
+            {"name": "lifecycle", "description": "Guarded test-owned instance lifecycle operations."}
+        ],
+        "paths": {},
+        "components": {
+            "schemas": common_schemas(),
+        },
+    });
+
+    let paths = doc
+        .get_mut("paths")
+        .and_then(Value::as_object_mut)
+        .expect("gateway OpenAPI document owns a paths object");
+
+    paths.insert(
+        "/v1/instances".to_string(),
+        get_operation(
+            &["instances"],
+            "List live gateway instances",
+            "Returns the gateway registry rows that are currently live and routable.",
+            json_response_ref("GatewayInstanceList"),
+        ),
+    );
+    paths.insert(
+        "/v1/healthz".to_string(),
+        get_operation(
+            &["health"],
+            "Check gateway liveness",
+            "Reports whether the gateway HTTP handler is alive.",
+            json_response_ref("GatewayHealth"),
+        ),
+    );
+    paths.insert(
+        "/v1/readyz".to_string(),
+        get_operation(
+            &["health"],
+            "Summarize gateway readiness",
+            "Aggregates live instance readiness bits; the gateway itself remains reachable even when no DCC instance is ready.",
+            json_response_ref("GatewayReadyz"),
+        ),
+    );
+    paths.insert(
+        "/v1/openapi.json".to_string(),
+        get_operation(
+            &["meta"],
+            "Return the gateway OpenAPI document",
+            "Returns this gateway-specific OpenAPI document.",
+            json_response_ref("OpenApiDocument"),
+        ),
+    );
+    paths.insert(
+        "/docs".to_string(),
+        get_operation(
+            &["meta"],
+            "Render the gateway API reference",
+            "Renders Scalar using the same gateway-specific OpenAPI document served by /v1/openapi.json.",
+            text_response("text/html"),
+        ),
+    );
+    paths.insert(
+        "/v1/skills".to_string(),
+        get_operation(
+            &["skills"],
+            "List indexed gateway skills",
+            "Lists loaded gateway capability records as skill-like entries.",
+            json_response_ref("GatewaySkillList"),
+        ),
+    );
+    paths.insert(
+        "/v1/list_skills".to_string(),
+        post_operation(
+            &["skills"],
+            "List backend skills",
+            "Forwards a skill list request to one gateway-selected backend instance.",
+            request_body_ref("GatewaySkillLifecycleRequest"),
+            json_response_ref("SkillLifecycleResponse"),
+        ),
+    );
+    paths.insert(
+        "/v1/search".to_string(),
+        post_operation(
+            &["skills"],
+            "Search gateway capabilities",
+            "Searches loaded and unloaded capabilities across live DCC instances.",
+            request_body_ref("SearchRequest"),
+            json_response_ref("SearchResponse"),
+        ),
+    );
+    paths.insert(
+        "/v1/load_skill".to_string(),
+        post_operation(
+            &["skills"],
+            "Load a backend skill",
+            "Loads a skill on a selected backend instance. Gateway load_skill defaults to lazy group activation.",
+            request_body_ref("LoadSkillRequest"),
+            json_response_ref("SkillLifecycleResponse"),
+        ),
+    );
+    paths.insert(
+        "/v1/unload_skill".to_string(),
+        post_operation(
+            &["skills"],
+            "Unload a backend skill",
+            "Unloads a skill from a selected backend instance.",
+            request_body_ref("UnloadSkillRequest"),
+            json_response_ref("SkillLifecycleResponse"),
+        ),
+    );
+    paths.insert(
+        "/v1/describe".to_string(),
+        post_operation(
+            &["tools"],
+            "Describe a gateway capability",
+            "Resolves a gateway tool_slug and returns its schema, annotations, backend owner, and loading state.",
+            request_body_ref("DescribeRequest"),
+            json_response_ref("DescribeResponse"),
+        ),
+    );
+    paths.insert(
+        "/v1/tools/{slug}".to_string(),
+        get_operation_with_params(
+            &["tools"],
+            "Describe a gateway capability by URL slug",
+            "URL alias for /v1/describe.",
+            vec![path_param("slug", "Gateway capability slug.")],
+            json_response_ref("DescribeResponse"),
+        ),
+    );
+    paths.insert(
+        "/v1/call".to_string(),
+        post_operation(
+            &["tools"],
+            "Call a gateway capability",
+            "Invokes one gateway capability by tool_slug.",
+            request_body_ref("CallRequest"),
+            json_response_ref("CallOutcome"),
+        ),
+    );
+    paths.insert(
+        "/v1/call_batch".to_string(),
+        post_operation(
+            &["tools"],
+            "Call multiple gateway capabilities",
+            "Invokes up to 25 gateway capabilities in order with optional stop_on_error semantics.",
+            request_body_ref("GatewayCallBatchRequest"),
+            json_response_ref("GatewayCallBatchResponse"),
+        ),
+    );
+    paths.insert(
+        "/v1/context".to_string(),
+        get_operation(
+            &["instances"],
+            "Return gateway context",
+            "Returns gateway metadata, live instance rows, and aggregate capability counts.",
+            json_response_ref("GatewayContext"),
+        ),
+    );
+    paths.insert(
+        "/v1/dcc/{dcc_type}/instances/{instance_id}/describe".to_string(),
+        get_operation_with_params(
+            &["tools"],
+            "Describe an instance-scoped backend tool",
+            "Describes a backend tool by DCC type and instance id or unique id prefix.",
+            vec![
+                path_param("dcc_type", "DCC type, for example maya or blender."),
+                path_param(
+                    "instance_id",
+                    "Full instance UUID, instance_short, or unique UUID prefix.",
+                ),
+                query_param("backend_tool", true, "Backend callable id to describe."),
+            ],
+            json_response_ref("DescribeResponse"),
+        ),
+    );
+    paths.insert(
+        "/v1/dcc/{dcc_type}/instances/{instance_id}/call".to_string(),
+        post_operation_with_params(
+            &["tools"],
+            "Call an instance-scoped backend tool",
+            "Calls a backend tool by DCC type and instance id or unique id prefix.",
+            vec![
+                path_param("dcc_type", "DCC type, for example maya or blender."),
+                path_param(
+                    "instance_id",
+                    "Full instance UUID, instance_short, or unique UUID prefix.",
+                ),
+            ],
+            request_body_ref("GatewayDirectCallRequest"),
+            json_response_ref("CallOutcome"),
+        ),
+    );
+    paths.insert(
+        "/v1/dcc/{dcc_type}/instances/{instance_id}/stop".to_string(),
+        post_operation_with_params(
+            &["lifecycle"],
+            "Safely stop a test-owned instance",
+            "Forwards a guarded stop request only when the instance advertises safe_stop_url metadata.",
+            vec![
+                path_param("dcc_type", "DCC type, for example maya or blender."),
+                path_param("instance_id", "Full instance UUID, instance_short, or unique UUID prefix."),
+            ],
+            request_body_ref("GatewaySafeStopRequest"),
+            json_response_ref("GatewaySafeStopResponse"),
+        ),
+    );
+
+    doc
+}
+
+fn common_schemas() -> Map<String, Value> {
+    let source = dcc_mcp_skill_rest::openapi::build_openapi_document("schema-source", "0.0.0");
+    let mut schemas = source
+        .pointer("/components/schemas")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+
+    for (name, schema) in gateway_schemas() {
+        schemas.insert(name.to_string(), schema);
+    }
+
+    schemas
+}
+
+fn gateway_schemas() -> Vec<(&'static str, Value)> {
+    vec![
+        (
+            "GatewayHealth",
+            json!({
+                "type": "object",
+                "required": ["ok"],
+                "properties": {"ok": {"type": "boolean"}},
+                "additionalProperties": true,
+            }),
+        ),
+        (
+            "GatewayInstance",
+            json!({
+                "type": "object",
+                "description": "Live gateway registry row. Custom DCC metadata is preserved as additional properties.",
+                "required": ["instance_id", "dcc_type", "status", "mcp_url"],
+                "properties": {
+                    "instance_id": {"type": "string", "format": "uuid"},
+                    "instance_short": {"type": "string"},
+                    "display_id": {"type": "string"},
+                    "dcc_type": {"type": "string"},
+                    "status": {"type": "string"},
+                    "mcp_url": {"type": "string"},
+                    "lifecycle": {"type": "object", "additionalProperties": true},
+                    "diagnostics": {"type": "object", "additionalProperties": true}
+                },
+                "additionalProperties": true,
+            }),
+        ),
+        (
+            "GatewayInstanceList",
+            json!({
+                "type": "object",
+                "required": ["total", "instances"],
+                "properties": {
+                    "total": {"type": "integer", "minimum": 0},
+                    "instances": {
+                        "type": "array",
+                        "items": {"$ref": "#/components/schemas/GatewayInstance"}
+                    }
+                },
+            }),
+        ),
+        (
+            "GatewayReadyz",
+            json!({
+                "type": "object",
+                "required": ["ok", "checks", "live_instance_count", "ready_instance_count", "not_ready_instance_count", "instances"],
+                "properties": {
+                    "ok": {"type": "boolean"},
+                    "checks": {
+                        "type": "array",
+                        "items": {"type": "object", "additionalProperties": true}
+                    },
+                    "live_instance_count": {"type": "integer", "minimum": 0},
+                    "ready_instance_count": {"type": "integer", "minimum": 0},
+                    "not_ready_instance_count": {"type": "integer", "minimum": 0},
+                    "instances": {
+                        "type": "array",
+                        "items": {"$ref": "#/components/schemas/GatewayInstance"}
+                    }
+                },
+                "additionalProperties": true,
+            }),
+        ),
+        (
+            "GatewayContext",
+            json!({
+                "type": "object",
+                "required": ["dcc", "version", "instances"],
+                "properties": {
+                    "dcc": {"type": "string", "const": "gateway"},
+                    "version": {"type": "string"},
+                    "display_name": {"type": "string"},
+                    "instances": {
+                        "type": "array",
+                        "items": {"$ref": "#/components/schemas/GatewayInstance"}
+                    },
+                    "capabilities": {"type": "object", "additionalProperties": true},
+                    "loaded_skill_count": {"type": "integer", "minimum": 0},
+                    "tool_count": {"type": "integer", "minimum": 0}
+                },
+                "additionalProperties": true,
+            }),
+        ),
+        (
+            "GatewaySkillList",
+            json!({
+                "type": "object",
+                "required": ["total", "skills"],
+                "properties": {
+                    "total": {"type": "integer", "minimum": 0},
+                    "skills": {
+                        "type": "array",
+                        "items": {"type": "object", "additionalProperties": true}
+                    }
+                },
+            }),
+        ),
+        (
+            "GatewaySkillLifecycleRequest",
+            json!({
+                "type": "object",
+                "properties": {
+                    "dcc_type": {"type": "string"},
+                    "instance_id": {"type": "string"},
+                    "query": {"type": "string"}
+                },
+                "additionalProperties": true,
+            }),
+        ),
+        (
+            "GatewayDirectCallRequest",
+            json!({
+                "type": "object",
+                "required": ["backend_tool"],
+                "properties": {
+                    "backend_tool": {"type": "string"},
+                    "arguments": {"type": "object", "additionalProperties": true},
+                    "params": {"type": "object", "additionalProperties": true},
+                    "meta": {"type": "object", "additionalProperties": true}
+                },
+                "additionalProperties": false,
+            }),
+        ),
+        (
+            "GatewayCallBatchRequest",
+            json!({
+                "type": "object",
+                "required": ["calls"],
+                "properties": {
+                    "calls": {
+                        "type": "array",
+                        "maxItems": 25,
+                        "items": {"$ref": "#/components/schemas/CallRequest"}
+                    },
+                    "stop_on_error": {"type": "boolean"},
+                    "meta": {"type": "object", "additionalProperties": true},
+                    "response_format": {"type": "string", "enum": ["json", "toon"]},
+                    "compact": {"type": "boolean"}
+                },
+                "additionalProperties": false,
+            }),
+        ),
+        (
+            "GatewayCallBatchResponse",
+            json!({
+                "type": "object",
+                "required": ["results"],
+                "properties": {
+                    "results": {
+                        "type": "array",
+                        "items": {"type": "object", "additionalProperties": true}
+                    },
+                    "stopped_on_error": {"type": "boolean"},
+                    "request_id": {"type": "string"}
+                },
+                "additionalProperties": true,
+            }),
+        ),
+        (
+            "GatewaySafeStopRequest",
+            json!({
+                "type": "object",
+                "properties": {
+                    "expected_owner": {"type": "string"},
+                    "expected_session": {"type": "string"}
+                },
+                "additionalProperties": false,
+            }),
+        ),
+        (
+            "GatewaySafeStopResponse",
+            json!({
+                "type": "object",
+                "required": ["ok", "stopping", "instance_id", "dcc_type"],
+                "properties": {
+                    "ok": {"type": "boolean"},
+                    "stopping": {"type": "boolean"},
+                    "instance_id": {"type": "string", "format": "uuid"},
+                    "dcc_type": {"type": "string"},
+                    "safe_stop_url": {"type": "string"},
+                    "response": {"type": "object", "additionalProperties": true}
+                },
+                "additionalProperties": true,
+            }),
+        ),
+        (
+            "OpenApiDocument",
+            json!({
+                "type": "object",
+                "required": ["openapi", "info", "paths"],
+                "additionalProperties": true,
+            }),
+        ),
+    ]
+}
+
+fn get_operation(tags: &[&str], summary: &str, description: &str, response: Value) -> Value {
+    get_operation_with_params(tags, summary, description, Vec::new(), response)
+}
+
+fn get_operation_with_params(
+    tags: &[&str],
+    summary: &str,
+    description: &str,
+    parameters: Vec<Value>,
+    response: Value,
+) -> Value {
+    operation(
+        "get",
+        tags,
+        summary,
+        description,
+        parameters,
+        None,
+        response,
+    )
+}
+
+fn post_operation(
+    tags: &[&str],
+    summary: &str,
+    description: &str,
+    request_body: Value,
+    response: Value,
+) -> Value {
+    post_operation_with_params(
+        tags,
+        summary,
+        description,
+        Vec::new(),
+        request_body,
+        response,
+    )
+}
+
+fn post_operation_with_params(
+    tags: &[&str],
+    summary: &str,
+    description: &str,
+    parameters: Vec<Value>,
+    request_body: Value,
+    response: Value,
+) -> Value {
+    operation(
+        "post",
+        tags,
+        summary,
+        description,
+        parameters,
+        Some(request_body),
+        response,
+    )
+}
+
+fn operation(
+    method: &str,
+    tags: &[&str],
+    summary: &str,
+    description: &str,
+    parameters: Vec<Value>,
+    request_body: Option<Value>,
+    response: Value,
+) -> Value {
+    let mut op = json!({
+        "tags": tags,
+        "summary": summary,
+        "description": description,
+        "responses": {
+            "200": response,
+            "400": error_response("Bad request"),
+            "404": error_response("Not found"),
+            "409": error_response("Conflict"),
+            "502": error_response("Backend error"),
+            "503": error_response("Unavailable")
+        }
+    });
+    if !parameters.is_empty() {
+        op["parameters"] = json!(parameters);
+    }
+    if let Some(request_body) = request_body {
+        op["requestBody"] = request_body;
+    }
+    json!({method: op})
+}
+
+fn request_body_ref(schema: &str) -> Value {
+    json!({
+        "required": true,
+        "content": {
+            "application/json": {
+                "schema": {"$ref": format!("#/components/schemas/{schema}")}
+            }
+        }
+    })
+}
+
+fn json_response_ref(schema: &str) -> Value {
+    json!({
+        "description": "JSON response",
+        "content": {
+            "application/json": {
+                "schema": {"$ref": format!("#/components/schemas/{schema}")}
+            }
+        }
+    })
+}
+
+fn text_response(content_type: &str) -> Value {
+    json!({
+        "description": "Text response",
+        "content": {
+            content_type: {
+                "schema": {"type": "string"}
+            }
+        }
+    })
+}
+
+fn error_response(description: &str) -> Value {
+    json!({
+        "description": description,
+        "content": {
+            "application/json": {
+                "schema": {"$ref": "#/components/schemas/ServiceError"}
+            }
+        }
+    })
+}
+
+fn path_param(name: &str, description: &str) -> Value {
+    json!({
+        "name": name,
+        "in": "path",
+        "required": true,
+        "description": description,
+        "schema": {"type": "string"}
+    })
+}
+
+fn query_param(name: &str, required: bool, description: &str) -> Value {
+    json!({
+        "name": name,
+        "in": "query",
+        "required": required,
+        "description": description,
+        "schema": {"type": "string"}
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn gateway_openapi_lists_only_gateway_routes() {
+        let doc = build_gateway_openapi_document("1.2.3");
+        assert_eq!(doc["info"]["title"], "dcc-mcp-gateway");
+        assert_eq!(doc["info"]["version"], "1.2.3");
+
+        let paths = doc["paths"].as_object().expect("paths object");
+        let expected: HashSet<_> = GATEWAY_OPENAPI_ROUTES
+            .iter()
+            .map(|route| route.path)
+            .collect();
+        let actual: HashSet<_> = paths.keys().map(String::as_str).collect();
+        assert_eq!(actual, expected);
+
+        for forbidden in [
+            "/v1/resources",
+            "/v1/resources/{uri}",
+            "/v1/resources/{uri}/events",
+            "/v1/prompts",
+            "/v1/prompts/{name}",
+            "/v1/jobs/{id}/events",
+            "/v1/jobs/{id}",
+            "/v1/dcc/{dcc_type}/call",
+        ] {
+            assert!(
+                !paths.contains_key(forbidden),
+                "gateway OpenAPI must not advertise per-DCC-only path {forbidden}"
+            );
+        }
+    }
+
+    #[test]
+    fn gateway_openapi_keeps_shared_envelope_schemas() {
+        let doc = build_gateway_openapi_document("1.2.3");
+        let schemas = doc["components"]["schemas"]
+            .as_object()
+            .expect("schemas object");
+        for schema in [
+            "ServiceError",
+            "SearchRequest",
+            "SearchResponse",
+            "LoadSkillRequest",
+            "UnloadSkillRequest",
+            "SkillLifecycleResponse",
+            "DescribeRequest",
+            "DescribeResponse",
+            "CallRequest",
+            "CallOutcome",
+            "GatewayDirectCallRequest",
+            "GatewayCallBatchRequest",
+        ] {
+            assert!(
+                schemas.contains_key(schema),
+                "gateway OpenAPI schema set missing {schema}"
+            );
+        }
+    }
+}

--- a/docs/guide/rest-api-surface.md
+++ b/docs/guide/rest-api-surface.md
@@ -1,10 +1,15 @@
 # REST API Surface
 
-Every per-DCC server and the multi-DCC gateway expose the same `/v1/*` REST
-surface, alongside their MCP endpoint. This page is the integration contract
-for **traditional callers** (cURL, CI pipelines, studio automation, non-MCP
-tooling) — anything that can speak HTTP can drive a DCC through these routes
-without touching the MCP protocol stack.
+Per-DCC adapter servers and the multi-DCC gateway expose overlapping, but not
+identical, `/v1/*` REST surfaces alongside their MCP endpoint. This page is the
+integration contract for **traditional callers** (cURL, CI pipelines, studio
+automation, non-MCP tooling) — anything that can speak HTTP can drive a DCC
+through these routes without touching the MCP protocol stack.
+
+The gateway now publishes a gateway-specific `GET /v1/openapi.json` contract.
+It documents only the routes mounted by the gateway router and deliberately
+omits per-DCC-only resource, prompt, and job routes. Per-DCC adapter servers
+continue to serve their own adapter OpenAPI contract from the same path.
 
 > **Relationship to MCP** — The gateway advertises the same bounded workflow
 > over MCP as four tools: `search`, `describe`, `load_skill`, and `call`.
@@ -14,28 +19,26 @@ without touching the MCP protocol stack.
 
 ---
 
-## Endpoints
+## Gateway Endpoints
 
 | Method | Path | Purpose |
 |---|---|---|
-| `GET` | `/v1/healthz` | Liveness probe. `200 {"status": "ok"}` as long as the HTTP handler is up. |
-| `GET` | `/v1/readyz` | Three-state readiness: `200 Ready` / `503 Booting` / body omitted `Unreachable` (see below). |
-| `GET` | `/v1/skills` | Flat listing of loaded tools, deterministically sorted. |
+| `GET` | `/v1/instances` | Live DCC instance rows known to the elected gateway. |
+| `GET` | `/v1/healthz` | Gateway liveness probe. Returns `200 {"ok": true}` when the HTTP handler is up. |
+| `GET` | `/v1/readyz` | Gateway readiness summary with per-instance readiness bits; the route stays `200` even when no instance is ready. |
+| `GET` | `/v1/skills` | Loaded gateway capability records projected as skill entries. |
+| `POST` | `/v1/list_skills` | Forward a skill-list request to a selected backend instance. |
 | `POST` | `/v1/search` | Fuzzy / exact search across loaded + unloaded skills. |
-| `POST` | `/v1/load_skill` | Load a discovered skill without using MCP `tools/call`. |
-| `POST` | `/v1/unload_skill` | Unload a skill without using MCP `tools/call`. |
+| `POST` | `/v1/load_skill` | Load a discovered backend skill without using MCP `tools/call`; gateway default is lazy group activation. |
+| `POST` | `/v1/unload_skill` | Unload a backend skill without using MCP `tools/call`. |
 | `POST` | `/v1/describe` | Return the full input schema + annotations for one `tool_slug`. |
 | `GET` | `/v1/tools/{slug}` | Alias of `/v1/describe` (read-only lookup via URL). |
-| `POST` | `/v1/call` | **Invoke** a tool by slug. This is the canonical invocation plane. |
-| `POST` | `/v1/call_batch` | Gateway only: invoke up to 25 ordered tool calls with optional `stop_on_error`. |
-| `GET` | `/v1/context` | Scene / document snapshot (per-DCC or gateway-aggregated). |
-| `GET` | `/v1/resources` | MCP-style resource list. |
-| `GET` | `/v1/resources/{uri}` | Read one percent-encoded resource URI. |
-| `GET` | `/v1/resources/{uri}/events` | Server-Sent Events for resource changes. |
-| `GET` | `/v1/prompts` | MCP-style prompt template list. |
-| `GET` | `/v1/prompts/{name}` | Render one prompt; pass JSON object arguments in `?args=...`. |
-| `GET` | `/v1/jobs/{id}/events` | Server-Sent Events for one async job. |
-| `DELETE` | `/v1/jobs/{id}` | Cancel one async job. |
+| `POST` | `/v1/call` | Invoke one gateway capability by slug. This is the canonical gateway invocation plane. |
+| `POST` | `/v1/call_batch` | Invoke up to 25 ordered gateway capability calls with optional `stop_on_error`. |
+| `GET` | `/v1/context` | Gateway snapshot with live instances and aggregate capability counts. |
+| `GET` | `/v1/dcc/{dcc_type}/instances/{instance_id}/describe` | Describe a backend tool on one DCC instance; accepts `backend_tool` / `tool` / `action` query keys. |
+| `POST` | `/v1/dcc/{dcc_type}/instances/{instance_id}/call` | Call a backend tool on one DCC instance using `{backend_tool, arguments, meta}`. |
+| `POST` | `/v1/dcc/{dcc_type}/instances/{instance_id}/stop` | Safe-stop route for test-owned instances that advertise `safe_stop_url` metadata. |
 | `GET` | `/v1/debug/instances` | Gateway only: stable agent-facing instance diagnostics. |
 | `GET` | `/v1/debug/activity` | Gateway only: stable activity feed from audits, traces, and gateway events. |
 | `GET` | `/v1/debug/traces` | Gateway only: recent dispatch trace list. |
@@ -48,12 +51,40 @@ without touching the MCP protocol stack.
 | `GET` | `/v1/debug/logs` | Gateway only: merged gateway events, file logs, and audit summaries. |
 | `GET` | `/v1/debug/stats` | Gateway only: aggregated call statistics. |
 | `GET` | `/v1/debug/health` | Gateway only: debug subsystem health summary. |
-| `GET` | `/v1/openapi.json` | Auto-generated OpenAPI 3.x document for code-gen clients. |
+| `GET` | `/v1/openapi.json` | Gateway-specific OpenAPI 3.x document for code-gen clients. |
+| `GET` | `/docs` | Scalar API reference rendered from the same gateway-specific OpenAPI document. |
 
-The gateway exposes the same paths as an aggregating facade. Gateway capability
-slugs use `<dcc>.<id8>.<tool>` and are obtained from `POST /v1/search`; direct
-per-DCC REST slugs use `<dcc>.<skill>.<action>` and do not include an instance
-id prefix.
+Gateway capability slugs use `<dcc>.<id8>.<tool>` and are obtained from
+`POST /v1/search`. Instance-scoped describe/call routes are for callers that
+already know the target `dcc_type`, `instance_id`, and backend tool id.
+
+## Per-DCC Adapter Endpoints
+
+Per-DCC adapter servers expose the skill REST API for one host process. Their
+OpenAPI document may include routes that the gateway does not mount:
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/v1/healthz` | Adapter liveness probe. |
+| `GET` | `/v1/readyz` | Adapter readiness: may report `Ready`, `Booting`, or be unreachable while the DCC starts. |
+| `GET` | `/v1/skills` | Skills already discovered by that adapter. |
+| `POST` | `/v1/search` | Search skills in that adapter's catalog. |
+| `POST` | `/v1/load_skill` | Load one adapter skill. |
+| `POST` | `/v1/unload_skill` | Unload one adapter skill. |
+| `POST` | `/v1/describe` | Describe an adapter-local tool slug. |
+| `GET` | `/v1/tools/{slug}` | URL alias of adapter `/v1/describe`. |
+| `POST` | `/v1/call` | Call an adapter-local tool slug. |
+| `POST` | `/v1/dcc/{dcc_type}/call` | Adapter-local backend call helper; not mounted by the gateway. |
+| `GET` | `/v1/context` | Host scene/document snapshot. |
+| `GET` | `/v1/resources` | MCP-style resource list for that adapter. |
+| `GET` | `/v1/resources/{uri}` | Read one percent-encoded adapter resource URI. |
+| `GET` | `/v1/resources/{uri}/events` | Resource update SSE stream. |
+| `GET` | `/v1/prompts` | MCP-style prompt template list. |
+| `GET` | `/v1/prompts/{name}` | Render one prompt; pass JSON object arguments in `?args=...`. |
+| `GET` | `/v1/jobs/{id}/events` | Async job SSE stream. |
+| `DELETE` | `/v1/jobs/{id}` | Cancel one async job. |
+| `GET` | `/v1/openapi.json` | Per-DCC adapter OpenAPI document. |
+| `GET` | `/docs` | Scalar API reference rendered from the adapter OpenAPI document. |
 
 ---
 

--- a/docs/zh/guide/rest-api-surface.md
+++ b/docs/zh/guide/rest-api-surface.md
@@ -1,8 +1,14 @@
 # REST API 面板
 
-每个 per-DCC 服务和多 DCC 网关都同时暴露 `/v1/*` REST API，和 MCP 端点并列。
-这个页面是面向**传统调用方**（cURL、CI 流水线、片场自动化、非-MCP 工具）的
-接入契约 —— 任何能讲 HTTP 的客户端都能用这些路由驱动 DCC，不需要碰 MCP 协议栈。
+per-DCC adapter 服务和多 DCC 网关都在 MCP 端点旁边暴露 `/v1/*` REST API，
+但两者的 surface 是重叠而非完全相同。这个页面是面向**传统调用方**
+（cURL、CI 流水线、片场自动化、非-MCP 工具）的接入契约 —— 任何能讲
+HTTP 的客户端都能用这些路由驱动 DCC，不需要碰 MCP 协议栈。
+
+Gateway 现在发布 gateway 专属的 `GET /v1/openapi.json` 契约。它只记录
+gateway router 真正挂载的路由，并刻意不广告 per-DCC-only 的 resource、
+prompt、job 路由。per-DCC adapter 服务继续在同一路径发布自己的 adapter
+OpenAPI 契约。
 
 > **和 MCP 的关系** —— 网关在 MCP `tools/list` 里广告同一条有界工作流：
 > `search`、`describe`、`load_skill`、`call`。这些工具与 `/v1/search`、
@@ -11,28 +17,26 @@
 
 ---
 
-## 端点一览
+## Gateway 端点
 
 | 方法 | 路径 | 用途 |
 |---|---|---|
-| `GET` | `/v1/healthz` | 存活探针。只要 HTTP 处理器在跑就 `200 {"status": "ok"}`。 |
-| `GET` | `/v1/readyz` | 三态就绪：`200 Ready` / `503 Booting` / 无响应 `Unreachable`。 |
-| `GET` | `/v1/skills` | 已加载 action 的扁平清单，按字典序稳定排序。 |
+| `GET` | `/v1/instances` | elected gateway 当前知道的在线 DCC instance rows。 |
+| `GET` | `/v1/healthz` | Gateway 存活探针。HTTP handler 在线时返回 `200 {"ok": true}`。 |
+| `GET` | `/v1/readyz` | Gateway readiness 汇总，包含每个 instance 的 readiness bits；即使没有 ready instance，该路由仍返回 `200`。 |
+| `GET` | `/v1/skills` | 把已加载 gateway capability records 投影成 skill entries。 |
+| `POST` | `/v1/list_skills` | 把 skill-list 请求转发给选中的 backend instance。 |
 | `POST` | `/v1/search` | 模糊 / 精确搜索 loaded + unloaded skills。 |
-| `POST` | `/v1/load_skill` | 不经过 MCP `tools/call`，直接加载一个已发现的 skill。 |
-| `POST` | `/v1/unload_skill` | 不经过 MCP `tools/call`，直接卸载一个 skill。 |
+| `POST` | `/v1/load_skill` | 不经过 MCP `tools/call`，加载一个 backend skill；gateway 默认 lazy group activation。 |
+| `POST` | `/v1/unload_skill` | 不经过 MCP `tools/call`，卸载一个 backend skill。 |
 | `POST` | `/v1/describe` | 按 `tool_slug` 返回完整 input schema + 注解。 |
 | `GET` | `/v1/tools/{slug}` | `/v1/describe` 的别名（只读 URL 查询）。 |
-| `POST` | `/v1/call` | **按 slug 调用**一个工具。这是唯一规范的调用面。 |
-| `POST` | `/v1/call_batch` | 仅网关：按顺序调用最多 25 个工具，可选 `stop_on_error`。 |
-| `GET` | `/v1/context` | 场景 / 文档快照（per-DCC 或网关汇聚）。 |
-| `GET` | `/v1/resources` | MCP 风格 resource 清单。 |
-| `GET` | `/v1/resources/{uri}` | 读取一个 percent-encoded resource URI。 |
-| `GET` | `/v1/resources/{uri}/events` | resource 更新的 Server-Sent Events。 |
-| `GET` | `/v1/prompts` | MCP 风格 prompt template 清单。 |
-| `GET` | `/v1/prompts/{name}` | 渲染一个 prompt；JSON object 参数放在 `?args=...`。 |
-| `GET` | `/v1/jobs/{id}/events` | 单个 async job 的 Server-Sent Events。 |
-| `DELETE` | `/v1/jobs/{id}` | 取消单个 async job。 |
+| `POST` | `/v1/call` | 按 slug 调用一个 gateway capability。这是 gateway 的规范调用面。 |
+| `POST` | `/v1/call_batch` | 按顺序调用最多 25 个 gateway capability，可选 `stop_on_error`。 |
+| `GET` | `/v1/context` | Gateway snapshot，包含在线 instances 和 aggregate capability counts。 |
+| `GET` | `/v1/dcc/{dcc_type}/instances/{instance_id}/describe` | 描述某个 DCC instance 上的 backend tool；query 支持 `backend_tool` / `tool` / `action`。 |
+| `POST` | `/v1/dcc/{dcc_type}/instances/{instance_id}/call` | 使用 `{backend_tool, arguments, meta}` 调用某个 DCC instance 上的 backend tool。 |
+| `POST` | `/v1/dcc/{dcc_type}/instances/{instance_id}/stop` | 仅用于广告了 `safe_stop_url` metadata 的 test-owned instance safe stop。 |
 | `GET` | `/v1/debug/instances` | 仅网关：稳定的 agent-facing instance diagnostics。 |
 | `GET` | `/v1/debug/activity` | 仅网关：来自 audit、trace、gateway event 的稳定 activity feed。 |
 | `GET` | `/v1/debug/traces` | 仅网关：最近的 dispatch trace 列表。 |
@@ -45,11 +49,40 @@
 | `GET` | `/v1/debug/logs` | 仅网关：合并 gateway events、file logs、audit summaries。 |
 | `GET` | `/v1/debug/stats` | 仅网关：聚合 call statistics。 |
 | `GET` | `/v1/debug/health` | 仅网关：debug subsystem health summary。 |
-| `GET` | `/v1/openapi.json` | 自动生成的 OpenAPI 3.x 文档，可供代码生成。 |
+| `GET` | `/v1/openapi.json` | Gateway 专属 OpenAPI 3.x 文档，可供代码生成。 |
+| `GET` | `/docs` | 用同一份 gateway 专属 OpenAPI 文档渲染的 Scalar API reference。 |
 
-网关也暴露相同的路径作为汇聚面板。网关 capability slug 使用
-`<dcc>.<id8>.<tool>`，从 `POST /v1/search` 获取；直接 per-DCC REST slug
-使用 `<dcc>.<skill>.<action>`，不带 instance id 前缀。
+Gateway capability slug 使用 `<dcc>.<id8>.<tool>`，从 `POST /v1/search`
+获取。instance-scoped describe/call 路由适合已经知道目标 `dcc_type`、
+`instance_id` 和 backend tool id 的调用方。
+
+## Per-DCC Adapter 端点
+
+per-DCC adapter 服务只代表一个 host 进程。它们的 OpenAPI 文档可以包含
+gateway 不挂载的路由：
+
+| 方法 | 路径 | 用途 |
+|---|---|---|
+| `GET` | `/v1/healthz` | Adapter 存活探针。 |
+| `GET` | `/v1/readyz` | Adapter readiness；DCC 启动时可能是 `Ready`、`Booting` 或 unreachable。 |
+| `GET` | `/v1/skills` | 该 adapter 已发现的 skills。 |
+| `POST` | `/v1/search` | 搜索该 adapter catalog。 |
+| `POST` | `/v1/load_skill` | 加载一个 adapter skill。 |
+| `POST` | `/v1/unload_skill` | 卸载一个 adapter skill。 |
+| `POST` | `/v1/describe` | 描述 adapter-local tool slug。 |
+| `GET` | `/v1/tools/{slug}` | adapter `/v1/describe` 的 URL 别名。 |
+| `POST` | `/v1/call` | 调用 adapter-local tool slug。 |
+| `POST` | `/v1/dcc/{dcc_type}/call` | Adapter-local backend call helper；gateway 不挂载。 |
+| `GET` | `/v1/context` | Host scene/document snapshot。 |
+| `GET` | `/v1/resources` | 该 adapter 的 MCP 风格 resource 清单。 |
+| `GET` | `/v1/resources/{uri}` | 读取一个 percent-encoded adapter resource URI。 |
+| `GET` | `/v1/resources/{uri}/events` | resource 更新 SSE stream。 |
+| `GET` | `/v1/prompts` | MCP 风格 prompt template 清单。 |
+| `GET` | `/v1/prompts/{name}` | 渲染一个 prompt；JSON object 参数放在 `?args=...`。 |
+| `GET` | `/v1/jobs/{id}/events` | async job SSE stream。 |
+| `DELETE` | `/v1/jobs/{id}` | 取消一个 async job。 |
+| `GET` | `/v1/openapi.json` | per-DCC adapter OpenAPI 文档。 |
+| `GET` | `/docs` | 用 adapter OpenAPI 文档渲染的 Scalar API reference。 |
 
 ---
 

--- a/skills/dcc-mcp-skill-developer/SKILL.md
+++ b/skills/dcc-mcp-skill-developer/SKILL.md
@@ -69,6 +69,11 @@ into a faster authoring loop.
    the shipped server paths enable the required gateway `admin` feature and
    Admin telemetry runtime state, while minimal direct `dcc-mcp-gateway` builds
    or runtimes started with Admin disabled may omit those debug routes.
+   Gateway `GET /v1/openapi.json` is gateway-specific: it documents only the
+   mounted aggregating routes and intentionally omits per-DCC-only resources,
+   prompts, jobs, and adapter-local `/v1/dcc/{dcc_type}/call`. Use a concrete
+   adapter's own `mcp_url` / `/v1/openapi.json` when examples need those
+   per-DCC endpoints.
    For REST discovery, describe, call, and batch examples, keep `/v1/search`,
    `/v1/describe`, `/v1/call`, and `/v1/call_batch` legacy JSON-compatible by
    default and request compact TOON only explicitly with


### PR DESCRIPTION
## Summary
- add a gateway-owned OpenAPI document for the canonical /v1 gateway routes
- keep debug OpenAPI paths gated by admin feature and runtime debug state
- document gateway vs per-DCC REST differences in English/Chinese docs and skill-developer guidance

## Validation
- vx cargo test -p dcc-mcp-gateway --lib
- vx cargo clippy -p dcc-mcp-gateway --all-targets -- -D warnings
- vx cargo test -p dcc-mcp-gateway --features admin gateway_openapi --lib
- vx cargo test -p dcc-mcp-skill-rest openapi --lib
- vx just dev
- pytest tests/test_mcp_mcpcall_e2e.py -v --tb=short with mcpcall 0.3.0
- vx just preflight

Closes #1173