### PR TITLE
feat: add hybrid capability ranking explanations

### DIFF
--- a/crates/dcc-mcp-gateway-core/src/capability/search.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/search.rs
@@ -140,10 +140,12 @@ mod tests {
                 true,
             ),
             score: 42,
+            match_reasons: vec!["tool_exact".to_string()],
         };
         let v: serde_json::Value = serde_json::to_value(&hit).unwrap();
         assert_eq!(v["tool_slug"], "maya.abcdef01.create_sphere");
         assert_eq!(v["score"], 42);
+        assert_eq!(v["match_reasons"], serde_json::json!(["tool_exact"]));
         assert!(v.get("record").is_none());
     }
 

--- a/crates/dcc-mcp-gateway-search/src/engine.rs
+++ b/crates/dcc-mcp-gateway-search/src/engine.rs
@@ -84,7 +84,7 @@ pub fn search_page<R: SearchRecord + Clone>(records: &[R], query: &SearchQuery) 
     };
 
     for hit in &mut hits {
-        hit.score = apply_skill_hint_boost(&hit.record, query.skill_hint.as_deref(), hit.score);
+        apply_skill_hint_boost(hit, query.skill_hint.as_deref());
     }
 
     if let Some(min) = query.min_score
@@ -117,20 +117,27 @@ pub fn search_page<R: SearchRecord + Clone>(records: &[R], query: &SearchQuery) 
     }
 }
 
-fn apply_skill_hint_boost<R: SearchRecord>(r: &R, hint: Option<&str>, score: u32) -> u32 {
+fn apply_skill_hint_boost<R: SearchRecord>(hit: &mut SearchHit<R>, hint: Option<&str>) {
     let Some(h) = hint.map(str::trim).filter(|s| !s.is_empty()) else {
-        return score;
+        return;
     };
     let h = h.to_ascii_lowercase();
     if h.len() < 2 {
-        return score;
+        return;
     }
-    if r.skill_name()
+    if hit
+        .record
+        .skill_name()
         .is_some_and(|s| s.to_ascii_lowercase().contains(h.as_str()))
     {
-        score.saturating_add(8)
-    } else {
-        score
+        hit.score = hit.score.saturating_add(8);
+        if !hit
+            .match_reasons
+            .iter()
+            .any(|reason| reason == "skill_hint")
+        {
+            hit.match_reasons.push("skill_hint".to_string());
+        }
     }
 }
 
@@ -144,18 +151,19 @@ fn rank_multi<R: SearchRecord + Clone, S: Scorer>(
     candidates
         .iter()
         .map(|r| {
-            let score = if has_clauses {
+            let breakdown = if has_clauses {
                 clauses
                     .iter()
-                    .map(|c| scorer.score(*r as &dyn SearchRecord, c, scene))
-                    .max()
-                    .unwrap_or(0)
+                    .map(|c| scorer.explain(*r as &dyn SearchRecord, c, scene))
+                    .max_by(|a, b| a.score.cmp(&b.score))
+                    .unwrap_or_default()
             } else {
-                0
+                Default::default()
             };
             SearchHit {
                 record: (*r).clone(),
-                score,
+                score: breakdown.score,
+                match_reasons: breakdown.match_reasons,
             }
         })
         .filter(|hit| !has_clauses || hit.score > 0)
@@ -379,6 +387,44 @@ mod tests {
         assert_eq!(
             hits[0].record.backend_tool(),
             "maya_scene__export_selection"
+        );
+        assert!(hits[0].match_reasons.contains(&"skill_hint".to_string()));
+    }
+
+    #[test]
+    fn fuzzy_hits_carry_match_reasons() {
+        let records = vec![
+            mk(
+                "m.1.sphere",
+                "maya_primitives__create_sphere",
+                "Create a polygon sphere.",
+                &["modeling"],
+                true,
+            ),
+            mk(
+                "m.1.fbx",
+                "maya_geometry__export_fbx",
+                "Export the current Maya scene to FBX.",
+                &["interchange"],
+                true,
+            ),
+        ];
+
+        let hits = search(
+            &records,
+            &SearchQuery {
+                query: "create sphere".into(),
+                ..Default::default()
+            },
+        );
+        assert!(!hits.is_empty());
+        assert!(
+            hits[0]
+                .match_reasons
+                .iter()
+                .any(|reason| reason == "tool_lexical" || reason == "summary_lexical"),
+            "expected bounded explanation reasons on top hit: {:?}",
+            hits[0].match_reasons
         );
     }
 

--- a/crates/dcc-mcp-gateway-search/src/query.rs
+++ b/crates/dcc-mcp-gateway-search/src/query.rs
@@ -46,6 +46,15 @@ pub const DEFAULT_LIMIT: u32 = 25;
 /// Upper bound on the number of results returned in a single page.
 pub const MAX_LIMIT: u32 = 100;
 
+/// Score plus bounded explanation metadata for one ranking decision.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ScoreBreakdown {
+    /// Final score used for ordering.
+    pub score: u32,
+    /// Stable, low-cardinality reasons explaining which fields matched.
+    pub match_reasons: Vec<String>,
+}
+
 /// One ranked hit row.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound(
@@ -56,6 +65,9 @@ pub struct SearchHit<R> {
     #[serde(flatten)]
     pub record: R,
     pub score: u32,
+    /// Stable, low-cardinality reasons explaining why the row matched.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub match_reasons: Vec<String>,
 }
 
 /// Paginated search response envelope (issue #659).

--- a/crates/dcc-mcp-gateway-search/src/ranking.rs
+++ b/crates/dcc-mcp-gateway-search/src/ranking.rs
@@ -8,14 +8,39 @@ use nucleo_matcher::{
     pattern::{AtomKind, CaseMatching, Normalization, Pattern},
 };
 
-use crate::query::SearchMode;
+use crate::query::{ScoreBreakdown, SearchMode};
 use crate::record::SearchRecord;
 
 /// A pluggable scoring strategy for the capability index.
 pub trait Scorer {
+    /// Return the score and match reasons of `record` against the pre-lowercased
+    /// query `q`. A score of `0` means no match.
+    fn explain(
+        &mut self,
+        record: &dyn SearchRecord,
+        q: &str,
+        scene_hint: Option<&str>,
+    ) -> ScoreBreakdown;
+
     /// Return the score of `record` against the pre-lowercased query `q`.
     /// `0` means no match — search drops the row.
-    fn score(&mut self, record: &dyn SearchRecord, q: &str, scene_hint: Option<&str>) -> u32;
+    fn score(&mut self, record: &dyn SearchRecord, q: &str, scene_hint: Option<&str>) -> u32 {
+        self.explain(record, q, scene_hint).score
+    }
+}
+
+fn add_reason(reasons: &mut Vec<String>, reason: &'static str) {
+    if !reasons.iter().any(|existing| existing == reason) {
+        reasons.push(reason.to_string());
+    }
+}
+
+fn add_component(breakdown: &mut ScoreBreakdown, amount: u32, reason: &'static str) {
+    if amount == 0 {
+        return;
+    }
+    breakdown.score = breakdown.score.saturating_add(amount);
+    add_reason(&mut breakdown.match_reasons, reason);
 }
 
 /// Legacy substring scorer (pre-#659 table).
@@ -23,26 +48,31 @@ pub trait Scorer {
 pub struct SubstringScorer;
 
 impl Scorer for SubstringScorer {
-    fn score(&mut self, r: &dyn SearchRecord, q: &str, scene_hint: Option<&str>) -> u32 {
-        let mut score: u32 = 0;
+    fn explain(
+        &mut self,
+        r: &dyn SearchRecord,
+        q: &str,
+        scene_hint: Option<&str>,
+    ) -> ScoreBreakdown {
+        let mut out = ScoreBreakdown::default();
 
         if !q.is_empty() {
             let tool_lower = r.backend_tool().to_ascii_lowercase();
             if tool_lower == q {
-                score += 10;
+                add_component(&mut out, 10, "tool_exact");
             } else if tool_lower.contains(q) {
-                score += 6;
+                add_component(&mut out, 6, "tool_substring");
             }
             if r.tags().iter().any(|t| t.to_ascii_lowercase() == *q) {
-                score += 5;
+                add_component(&mut out, 5, "tag_exact");
             }
             if r.skill_name()
                 .is_some_and(|s| s.to_ascii_lowercase().contains(q))
             {
-                score += 4;
+                add_component(&mut out, 4, "skill_substring");
             }
             if r.summary().to_ascii_lowercase().contains(q) {
-                score += 2;
+                add_component(&mut out, 2, "summary_substring");
             }
         }
 
@@ -50,10 +80,10 @@ impl Scorer for SubstringScorer {
             && (r.summary().to_ascii_lowercase().contains(hint)
                 || r.tags().iter().any(|t| t.to_ascii_lowercase() == *hint))
         {
-            score += 2;
+            add_component(&mut out, 2, "scene_hint");
         }
 
-        score
+        out
     }
 }
 
@@ -247,35 +277,47 @@ impl Default for FuzzyScorer {
 }
 
 impl Scorer for FuzzyScorer {
-    fn score(&mut self, r: &dyn SearchRecord, q: &str, scene_hint: Option<&str>) -> u32 {
-        let mut score: u32 = 0;
+    fn explain(
+        &mut self,
+        r: &dyn SearchRecord,
+        q: &str,
+        scene_hint: Option<&str>,
+    ) -> ScoreBreakdown {
+        let mut out = ScoreBreakdown::default();
 
         if !q.is_empty() {
-            let mut deterministic = token_match_score(q, r.backend_tool(), 18, 12, 8)
-                + token_match_score(q, r.summary(), 8, 5, 3);
+            let tool_lexical = token_match_score(q, r.backend_tool(), 18, 12, 8);
+            let summary_lexical = token_match_score(q, r.summary(), 8, 5, 3);
+            let mut deterministic = tool_lexical + summary_lexical;
+            add_component(&mut out, tool_lexical, "tool_lexical");
+            add_component(&mut out, summary_lexical, "summary_lexical");
             if deterministic == 0 {
-                deterministic = deterministic.max(relaxed_multiword_haystack_score(r, q));
+                let multiword = relaxed_multiword_haystack_score(r, q);
+                deterministic = deterministic.max(multiword);
+                add_component(&mut out, multiword, "multi_token_lexical");
             }
-            score += deterministic;
+
+            if q.len() == AMBIGUOUS_SHORT_QUERY_LEN && deterministic == 0 {
+                return ScoreBreakdown::default();
+            }
 
             let pattern = Self::compile_pattern(q);
             let tool_lower = r.backend_tool().to_ascii_lowercase();
             let exact_tool = tool_lower == q;
             let prefix_tool = !exact_tool && tool_lower.starts_with(q);
 
-            score += self.score_field(&pattern, r.backend_tool(), FUZZY_FIELD_CAP, exact_tool);
+            let tool_fuzzy =
+                self.score_field(&pattern, r.backend_tool(), FUZZY_FIELD_CAP, exact_tool);
+            add_component(&mut out, tool_fuzzy, "tool_fuzzy");
             if exact_tool {
-                score += EXACT_BONUS;
+                add_component(&mut out, EXACT_BONUS, "tool_exact");
             } else if prefix_tool {
-                score += PREFIX_BONUS;
-            }
-
-            if q.len() == AMBIGUOUS_SHORT_QUERY_LEN && deterministic == 0 {
-                return 0;
+                add_component(&mut out, PREFIX_BONUS, "tool_prefix");
             }
 
             if let Some(skill) = r.skill_name() {
-                score += self.score_field(&pattern, skill, 7, false);
+                let skill_score = self.score_field(&pattern, skill, 7, false);
+                add_component(&mut out, skill_score, "skill_fuzzy");
             }
 
             let mut best_tag = 0;
@@ -288,9 +330,10 @@ impl Scorer for FuzzyScorer {
                     best_tag = s;
                 }
             }
-            score += best_tag;
+            add_component(&mut out, best_tag, "tag_fuzzy");
 
-            score += self.score_field(&pattern, r.summary(), 5, false);
+            let summary_fuzzy = self.score_field(&pattern, r.summary(), 5, false);
+            add_component(&mut out, summary_fuzzy, "summary_fuzzy");
 
             let mut best_schema = 0;
             for tag in r.tags() {
@@ -301,25 +344,26 @@ impl Scorer for FuzzyScorer {
                     }
                 }
             }
-            score += best_schema;
+            add_component(&mut out, best_schema, "schema_fuzzy");
 
             // Issue #994: meta-tools are excluded from results unless the
             // query directly targets the tool by name. This prevents verbose
             // meta-tool descriptions from leaking into the top-N for domain
             // queries. A "direct target" means `token_match_score` on the
             // backend_tool name returned a non-zero value.
-            if score > 0 && is_meta_tool(r.backend_tool()) {
+            if out.score > 0 && is_meta_tool(r.backend_tool()) {
                 let tool_name_score = token_match_score(q, r.backend_tool(), 18, 12, 8);
                 if tool_name_score == 0 {
                     // Query doesn't reference the meta-tool's name at all —
                     // all score came from description/tag token noise. Drop it.
-                    return 0;
+                    return ScoreBreakdown::default();
                 }
                 // Query does reference the tool name — keep it but demoted.
-                score /= META_TOOL_DIVISOR;
-                if score == 0 {
-                    score = 1;
+                out.score /= META_TOOL_DIVISOR;
+                if out.score == 0 {
+                    out.score = 1;
                 }
+                add_reason(&mut out.match_reasons, "meta_tool_demoted");
             }
         }
 
@@ -327,10 +371,10 @@ impl Scorer for FuzzyScorer {
             && (r.summary().to_ascii_lowercase().contains(hint)
                 || r.tags().iter().any(|t| t.to_ascii_lowercase() == *hint))
         {
-            score += 2;
+            add_component(&mut out, 2, "scene_hint");
         }
 
-        score
+        out
     }
 }
 
@@ -642,6 +686,30 @@ mod tests {
         assert!(
             via_tool > via_summary,
             "tool-name match ({via_tool}) should outweigh summary-only match ({via_summary})",
+        );
+    }
+
+    #[test]
+    fn fuzzy_scorer_explains_weighted_match_reasons() {
+        let mut s = FuzzyScorer::new();
+        let row = rec(
+            "maya_primitives__set_radius",
+            "Set primitive radius.",
+            Some("maya-primitives"),
+            &["modeling", "schema:radius"],
+            true,
+        );
+        let breakdown = s.explain(&row, "radius", None);
+        assert!(breakdown.score > 0);
+        assert!(
+            breakdown
+                .match_reasons
+                .contains(&"tool_lexical".to_string())
+        );
+        assert!(
+            breakdown
+                .match_reasons
+                .contains(&"schema_fuzzy".to_string())
         );
     }
 

--- a/crates/dcc-mcp-gateway/benches/search_bench.rs
+++ b/crates/dcc-mcp-gateway/benches/search_bench.rs
@@ -14,9 +14,11 @@
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use dcc_mcp_gateway::{
-    ScorerFactory, SearchMode, StrategyExactScorer, StrategyFuzzyScorer, StrategyScorer,
+    ScorerFactory, SearchMode, SearchQuery, StrategyExactScorer, StrategyFuzzyScorer,
+    StrategyScorer,
+    capability::{CapabilityRecord, IndexSnapshot, search},
 };
-use std::hint::black_box;
+use std::{hint::black_box, sync::Arc};
 
 // ---------------------------------------------------------------------------
 // Shared corpus
@@ -68,6 +70,64 @@ fn score_all(scorer: &dyn StrategyScorer) -> f32 {
     total
 }
 
+fn capability_snapshot(size: usize) -> IndexSnapshot {
+    let records: Vec<CapabilityRecord> = (0..size)
+        .map(|i| {
+            let dcc = match i % 4 {
+                0 => "maya",
+                1 => "blender",
+                2 => "photoshop",
+                _ => "customhost",
+            };
+            let family = match i % 6 {
+                0 => (
+                    "modeling",
+                    "create_poly_sphere",
+                    "Create a polygon sphere primitive.",
+                ),
+                1 => (
+                    "lookdev",
+                    "assign_material",
+                    "Assign material and lookdev data.",
+                ),
+                2 => (
+                    "uv",
+                    "unwrap_uv_shells",
+                    "Unwrap UV shells for texture export.",
+                ),
+                3 => (
+                    "export",
+                    "export_fbx",
+                    "Export selected assets to FBX destination path.",
+                ),
+                4 => (
+                    "render",
+                    "render_preview",
+                    "Render a preview frame for review.",
+                ),
+                _ => ("layers", "select_layer", "Select a layer or document node."),
+            };
+            let iid = uuid::Uuid::from_u128((i as u128) + 1);
+            CapabilityRecord::new(
+                format!("{dcc}.{:08x}.{}_{}", i, family.0, i),
+                format!("{}_{}", family.1, i),
+                format!("{}_{}", family.1, i),
+                Some(format!("{dcc}-{}", family.0)),
+                family.2,
+                vec![family.0.to_string(), format!("schema:field_{}", i % 17)],
+                dcc.to_string(),
+                iid,
+                true,
+                true,
+            )
+        })
+        .collect();
+    IndexSnapshot {
+        records: Arc::from(records.into_boxed_slice()),
+        fingerprints: Default::default(),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Benchmarks
 // ---------------------------------------------------------------------------
@@ -109,11 +169,41 @@ fn bench_factory_tag(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_hybrid_full_search_thousands(c: &mut Criterion) {
+    let snapshot = capability_snapshot(5_000);
+    let queries = [
+        "create poly sphere",
+        "destination path export",
+        "material lookdev",
+        "uv unwrap shells",
+        "render preview",
+        "selct layer", // typo fallback
+    ];
+    c.bench_function("hybrid_full_search/5000_records", |b| {
+        b.iter(|| {
+            let mut total = 0usize;
+            for query in queries {
+                let hits = search(
+                    black_box(&snapshot),
+                    &SearchQuery {
+                        query: query.to_string(),
+                        limit: Some(20),
+                        ..Default::default()
+                    },
+                );
+                total = total.saturating_add(hits.len());
+            }
+            black_box(total)
+        })
+    });
+}
+
 criterion_group!(
     benches,
     bench_fuzzy_direct,
     bench_exact_direct,
     bench_factory_dispatch,
     bench_factory_tag,
+    bench_hybrid_full_search_thousands,
 );
 criterion_main!(benches);

--- a/crates/dcc-mcp-gateway/src/gateway/response_codec.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/response_codec.rs
@@ -274,6 +274,7 @@ fn compact_record(record: &Value) -> Value {
     copy_field(&mut out, record, "load_state");
     copy_field(&mut out, record, "available_groups");
     copy_field(&mut out, record, "score");
+    copy_field(&mut out, record, "match_reasons");
     copy_field(&mut out, record, "annotations");
     copy_field(&mut out, record, "metadata");
     copy_field(&mut out, record, "next_step");
@@ -426,6 +427,7 @@ mod tests {
                 "has_schema": true,
                 "loaded": true,
                 "score": 93,
+                "match_reasons": ["tool_lexical", "summary_fuzzy"],
                 "annotations": {
                     "readOnlyHint": false,
                     "destructiveHint": false
@@ -576,6 +578,10 @@ mod tests {
         assert_eq!(body["hits"][0]["dcc_type"], "maya");
         assert_eq!(body["hits"][1]["dcc_type"], "photoshop");
         assert_eq!(body["hits"][0]["tool_slug"], "maya.abcdef01.create_sphere");
+        assert_eq!(
+            body["hits"][0]["match_reasons"],
+            json!(["tool_lexical", "summary_fuzzy"])
+        );
         assert_eq!(body["hits"][1]["next_step"]["action"], "load_skill");
         assert!(body["hits"][0].get("callable_id").is_none());
         assert_eq!(body["hits"][1]["callable_id"], "select_layer_by_name");

--- a/docs/guide/rest-api-surface.md
+++ b/docs/guide/rest-api-surface.md
@@ -434,12 +434,19 @@ Rules:
 }
 ```
 
-- `query` (required) — free-text. `mode: "fuzzy"` (default) uses a nucleo-matcher-backed scorer with typo / prefix tolerance; `mode: "exact"` falls back to the pre-#659 substring table.
+- `query` (required) — free-text. On the gateway, `mode: "fuzzy"`
+  (default) uses a hybrid ranker: weighted lexical matches over tool names,
+  skills, tags, summaries, and schema-field tokens first, then
+  nucleo-matcher fuzzy fallback for typos and partial names. `mode: "exact"`
+  falls back to the pre-#659 substring table.
 - `dcc_type`, `tags`, `loaded_only` — progressive filters. `loaded_only = false` surfaces unloaded skills as search hits so agents can discover `load_skill` candidates.
 - `limit` — the server enforces a ~512 B/hit token budget so search stays cheap for large catalogues.
 - Gateway policy filters run before the final hit list is returned. A missing
   hit may mean the capability is absent, unloaded, or intentionally hidden by
   DCC, skill, or tool allowlists.
+- Gateway hits include `score` plus bounded `match_reasons` such as
+  `tool_lexical`, `summary_fuzzy`, `schema_fuzzy`, or `multi_token_lexical`
+  so agents and maintainers can understand the rank without fetching schemas.
 
 Response shape (gateway + per-DCC are identical):
 
@@ -531,8 +538,8 @@ headers:
 
 The compact search shape preserves the workflow fields agents need next:
 `tool_slug`, `backend_tool`, `dcc_type`, `instance_id`, `loaded`,
-`load_state`, `available_groups`, `has_schema`, `score`, and `next_step` for
-unloaded skills. It omits redundant defaults such as `callable_id` when it
+`load_state`, `available_groups`, `has_schema`, `score`, `match_reasons`, and
+`next_step` for unloaded skills. It omits redundant defaults such as `callable_id` when it
 matches `backend_tool`, empty arrays, and empty objects. RTK's compaction model
 is treated as design guidance here; the
 gateway uses the deterministic in-process `toon-format` library so

--- a/docs/zh/guide/rest-api-surface.md
+++ b/docs/zh/guide/rest-api-surface.md
@@ -271,6 +271,12 @@ describe/call 路由、`/v1/call` 和 `/v1/call_batch` 默认仍返回旧版 JSO
 
 Gateway policy 会在返回最终搜索结果前过滤 capability。一个缺失的 hit 可能
 代表能力不存在、skill 未加载，或该能力被 DCC / skill / tool allowlist 有意隐藏。
+Gateway 默认 `mode: "fuzzy"` 使用 hybrid ranker：先对 tool name、skill、
+tag、summary 和 schema-field token 做加权 lexical 匹配，再用
+nucleo-matcher fuzzy fallback 保留 typo / partial-name 容错；`mode: "exact"`
+仍是旧 substring 表。Gateway hit 会带 `score` 和 bounded `match_reasons`
+（例如 `tool_lexical`、`summary_fuzzy`、`schema_fuzzy`、
+`multi_token_lexical`），让 agent 和维护者不取完整 schema 也能理解排序原因。
 
 ```bash
 curl -H 'Accept: application/toon' \
@@ -294,8 +300,8 @@ curl -H 'Accept: application/toon' \
 
 compact search 仍保留 agent 后续工作需要的字段：`tool_slug`、
 `backend_tool`、`dcc_type`、`instance_id`、`loaded`、`load_state`、
-`available_groups`、`has_schema`、`score`，以及 unloaded skill 的
-`next_step`。`next_step` 同时带 MCP (`tool` + `arguments`) 和 REST
+`available_groups`、`has_schema`、`score`、`match_reasons`，以及 unloaded
+skill 的 `next_step`。`next_step` 同时带 MCP (`tool` + `arguments`) 和 REST
 (`method` + `path` + `body`) 形态；Gateway REST 调用方可以直接 POST
 `next_step.arguments` 到 `/v1/load_skill`。它会省略冗余默认值，例如与
 `backend_tool` 相同的 `callable_id`、空数组和空 object。这里把 RTK 的

--- a/skills/dcc-mcp-skill-developer/SKILL.md
+++ b/skills/dcc-mcp-skill-developer/SKILL.md
@@ -87,6 +87,13 @@ into a faster authoring loop.
    `x-dcc-mcp-index-generation`. Compact batch examples may also read
    per-result `token_accounting` metadata, and batch request items may carry an
    optional `id` that is echoed next to the numeric result `index`.
+   Gateway search uses a hybrid ranker in default fuzzy mode: weighted lexical
+   matches over tool names, skill names, tags, summaries, and schema-field
+   tokens take precedence, while fuzzy fallback keeps typo tolerance. Search
+   hits may include bounded `match_reasons` such as `tool_lexical`,
+   `summary_fuzzy`, `schema_fuzzy`, and `multi_token_lexical`; use those for
+   debugging relevance, but keep agent logic driven by `tool_slug`,
+   `next_step`, and `describe` rather than hard-coding a single reason string.
    Gateway capability policy is a deployment boundary, not an adapter-local
    convention. Read-only gateway mode still allows discovery and describe, but
    denies `load_skill`, `unload_skill`, tool-group changes, and backend calls


### PR DESCRIPTION
## Summary
- add bounded match-reason metadata to gateway capability search hits
- keep the default fuzzy mode as a hybrid lexical-first ranker with fuzzy typo fallback
- add search benchmark coverage and document the ranking/debugging contract

Closes #1177

## Validation
- vx cargo fmt --all -- --check
- vx cargo test -p dcc-mcp-gateway-search --lib --tests
- vx cargo test -p dcc-mcp-gateway-core capability::search --lib
- DCC_MCP_ADMIN_UI_PREBUILT=1 vx cargo test -p dcc-mcp-gateway response_codec::tests --lib
- DCC_MCP_ADMIN_UI_PREBUILT=1 vx cargo test -p dcc-mcp-gateway --bench search_bench --no-run
- DCC_MCP_ADMIN_UI_PREBUILT=1 vx cargo clippy -p dcc-mcp-gateway-search --all-targets -- -D warnings
- DCC_MCP_ADMIN_UI_PREBUILT=1 vx cargo clippy -p dcc-mcp-gateway --all-targets -- -D warnings
- vx cargo clippy -p dcc-mcp-gateway-core --all-targets -- -D warnings
- DCC_MCP_ADMIN_UI_PREBUILT=1 vx cargo test -p dcc-mcp-gateway --lib
- DCC_MCP_ADMIN_UI_PREBUILT=1 vx cargo bench -p dcc-mcp-gateway --bench search_bench -- --sample-size 10 --warm-up-time 1 --measurement-time 1
- DCC_MCP_ADMIN_UI_PREBUILT=1 vx just dev