### PR TITLE
feat: index capability aliases and schema tokens

### DIFF
--- a/crates/dcc-mcp-actions/src/registry/meta.rs
+++ b/crates/dcc-mcp-actions/src/registry/meta.rs
@@ -13,6 +13,9 @@ pub struct ToolMeta {
     pub category: String,
     /// Searchable tags for discovery.
     pub tags: Vec<String>,
+    /// Bounded search-only aliases and synonyms for discovery.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub search_aliases: Vec<String>,
     /// Target DCC application (e.g. "maya", "blender").
     pub dcc: String,
     /// Semantic version string.
@@ -115,6 +118,7 @@ impl Default for ToolMeta {
             description: String::new(),
             category: String::new(),
             tags: Vec::new(),
+            search_aliases: Vec::new(),
             dcc: String::new(),
             version: String::new(),
             input_schema: serde_json::Value::Null,
@@ -151,6 +155,7 @@ impl RegistryEntry for ToolMeta {
             self.description.clone(),
         ];
         tags.extend(self.tags.iter().cloned());
+        tags.extend(self.search_aliases.iter().cloned());
         tags.retain(|t| !t.is_empty());
         tags
     }

--- a/crates/dcc-mcp-actions/src/registry/python.rs
+++ b/crates/dcc-mcp-actions/src/registry/python.rs
@@ -53,6 +53,14 @@ impl ToolRegistry {
                 .flatten()
                 .and_then(|v| v.extract().ok())
                 .unwrap_or_default();
+            let search_aliases: Vec<String> = dict
+                .get_item("search_aliases")
+                .ok()
+                .flatten()
+                .or_else(|| dict.get_item("search-aliases").ok().flatten())
+                .or_else(|| dict.get_item("aliases").ok().flatten())
+                .and_then(|v| v.extract().ok())
+                .unwrap_or_default();
             let dcc: String = dict
                 .get_item("dcc")
                 .ok()
@@ -158,6 +166,7 @@ impl ToolRegistry {
                 description,
                 category,
                 tags,
+                search_aliases,
                 dcc,
                 version,
                 input_schema,
@@ -184,7 +193,7 @@ impl ToolRegistry {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (name, description="".to_string(), category="".to_string(), tags=vec![], dcc=DEFAULT_DCC.to_string(), version=DEFAULT_VERSION.to_string(), input_schema=None, output_schema=None, source_file=None, skill_name=None, group="".to_string(), enabled=true, required_capabilities=None, execution="sync".to_string(), timeout_hint_secs=None, thread_affinity="any".to_string(), enforce_thread_affinity=false))]
+    #[pyo3(signature = (name, description="".to_string(), category="".to_string(), tags=vec![], dcc=DEFAULT_DCC.to_string(), version=DEFAULT_VERSION.to_string(), input_schema=None, output_schema=None, source_file=None, skill_name=None, group="".to_string(), enabled=true, required_capabilities=None, execution="sync".to_string(), timeout_hint_secs=None, thread_affinity="any".to_string(), enforce_thread_affinity=false, search_aliases=None))]
     fn register(
         &self,
         name: String,
@@ -204,6 +213,7 @@ impl ToolRegistry {
         timeout_hint_secs: Option<u32>,
         thread_affinity: String,
         enforce_thread_affinity: bool,
+        search_aliases: Option<Vec<String>>,
     ) -> pyo3::PyResult<()> {
         validate_tool_name(&name).map_err(|err| {
             pyo3::exceptions::PyValueError::new_err(format!(
@@ -233,6 +243,7 @@ impl ToolRegistry {
             description,
             category,
             tags,
+            search_aliases: search_aliases.unwrap_or_default(),
             dcc,
             version,
             input_schema,

--- a/crates/dcc-mcp-actions/src/registry/tests/serialization.rs
+++ b/crates/dcc-mcp-actions/src/registry/tests/serialization.rs
@@ -11,6 +11,7 @@ fn test_action_meta_serde_round_trip() {
         description: "Renders the active scene".into(),
         category: "rendering".into(),
         tags: vec!["render".into(), "output".into()],
+        search_aliases: vec!["batch render".into()],
         dcc: "houdini".into(),
         version: "3.1.0".into(),
         input_schema: serde_json::json!({"type": "object"}),

--- a/crates/dcc-mcp-gateway-core/src/capability/record.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/record.rs
@@ -241,6 +241,11 @@ pub struct CapabilityRecord {
     /// keywords the description itself might lack.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
+    /// Bounded search-only tokens derived from aliases and schemas.
+    ///
+    /// These improve recall without expanding the public search response.
+    #[serde(default, skip_serializing, skip_deserializing)]
+    pub search_tokens: Vec<String>,
     /// DCC type bucket (e.g. `"maya"`).
     pub dcc_type: String,
     /// UUID of the owning instance, serialised as a canonical string.
@@ -303,6 +308,7 @@ impl CapabilityRecord {
             skill_name,
             summary: normalise_summary(summary),
             tags,
+            search_tokens: Vec::new(),
             dcc_type,
             instance_id,
             has_schema,
@@ -338,6 +344,13 @@ impl CapabilityRecord {
         self
     }
 
+    /// Attach bounded internal search tokens derived from aliases/schemas.
+    #[must_use]
+    pub fn with_search_tokens(mut self, tokens: Vec<String>) -> Self {
+        self.search_tokens = normalise_search_tokens(tokens);
+        self
+    }
+
     /// Build a record for a tool from an **unloaded** skill's metadata.
     ///
     /// Used by the gateway's `update_unloaded_skills` refresh path to
@@ -365,6 +378,7 @@ impl CapabilityRecord {
             skill_name: Some(skill_name.to_string()),
             summary: normalise_summary(tool_description),
             tags: Vec::new(),
+            search_tokens: Vec::new(),
             dcc_type: dcc_type.to_string(),
             instance_id: nil,
             has_schema: false, // unknown until loaded
@@ -397,6 +411,10 @@ impl dcc_mcp_gateway_search::SearchRecord for CapabilityRecord {
         &self.tags
     }
 
+    fn search_tokens(&self) -> &[String] {
+        &self.search_tokens
+    }
+
     fn dcc_type(&self) -> &str {
         &self.dcc_type
     }
@@ -408,6 +426,26 @@ impl dcc_mcp_gateway_search::SearchRecord for CapabilityRecord {
     fn loaded(&self) -> bool {
         self.loaded
     }
+}
+
+fn normalise_search_tokens(tokens: Vec<String>) -> Vec<String> {
+    let mut out = Vec::with_capacity(tokens.len().min(64));
+    let mut seen = std::collections::HashSet::new();
+    for raw in tokens {
+        let token = raw.split_whitespace().collect::<Vec<_>>().join(" ");
+        let token = token.trim();
+        if token.len() < 2 || token.len() > 64 {
+            continue;
+        }
+        let key = token.to_ascii_lowercase();
+        if seen.insert(key) {
+            out.push(token.to_string());
+        }
+        if out.len() >= 64 {
+            break;
+        }
+    }
+    out
 }
 
 /// Truncate a description to [`CapabilityRecord::MAX_SUMMARY_LEN`] and

--- a/crates/dcc-mcp-gateway-core/src/capability/search.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/search.rs
@@ -190,6 +190,68 @@ mod tests {
     }
 
     #[test]
+    fn search_matches_alias_and_schema_tokens_with_reasons() {
+        let iid = Uuid::from_u128(11);
+        let snap = snapshot(vec![
+            record(
+                "maya",
+                iid,
+                "create_sphere",
+                "Create polygon mesh",
+                &[],
+                true,
+                true,
+            )
+            .with_search_tokens(vec!["alias:primitive ball".into(), "schema:radius".into()]),
+            record(
+                "photoshop",
+                iid,
+                "resize_canvas",
+                "Resize document",
+                &[],
+                true,
+                true,
+            )
+            .with_search_tokens(vec![
+                "alias:document bounds".into(),
+                "required:height_pixels".into(),
+            ]),
+        ]);
+
+        let alias_hits = search(
+            &snap,
+            &SearchQuery {
+                query: "primitive ball".into(),
+                dcc_type: Some("maya".into()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(alias_hits.len(), 1);
+        assert_eq!(alias_hits[0].record.backend_tool, "create_sphere");
+        assert!(
+            alias_hits[0]
+                .match_reasons
+                .contains(&"alias_lexical".to_string())
+        );
+
+        let schema_hits = search(
+            &snap,
+            &SearchQuery {
+                query: "height_pixels".into(),
+                dcc_type: Some("photoshop".into()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(schema_hits.len(), 1);
+        assert_eq!(schema_hits[0].record.backend_tool, "resize_canvas");
+        assert!(
+            schema_hits[0]
+                .match_reasons
+                .contains(&"schema_lexical".to_string())
+        );
+    }
+
+    #[test]
     fn exact_mode_preserves_legacy_table() {
         let a = Uuid::from_u128(1);
         let b = Uuid::from_u128(2);

--- a/crates/dcc-mcp-gateway-search/src/ranking.rs
+++ b/crates/dcc-mcp-gateway-search/src/ranking.rs
@@ -114,6 +114,10 @@ fn relaxed_multiword_haystack_score(r: &dyn SearchRecord, q: &str) -> u32 {
         hay.push(' ');
         hay.push_str(&t.to_ascii_lowercase());
     }
+    for t in r.search_tokens() {
+        hay.push(' ');
+        hay.push_str(&search_token_text(t).to_ascii_lowercase());
+    }
 
     let words: Vec<&str> = q.split_whitespace().filter(|w| w.len() >= 2).collect();
     if words.len() < 2 {
@@ -144,6 +148,25 @@ fn relaxed_multiword_haystack_score(r: &dyn SearchRecord, q: &str) -> u32 {
         return 0;
     }
     (matched * 5).min(30)
+}
+
+fn search_token_text(token: &str) -> &str {
+    token
+        .strip_prefix("alias:")
+        .or_else(|| token.strip_prefix("schema:"))
+        .or_else(|| token.strip_prefix("required:"))
+        .unwrap_or(token)
+}
+
+fn search_tokens_joined<'a>(tokens: impl Iterator<Item = &'a String>) -> String {
+    let mut out = String::new();
+    for token in tokens {
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.push_str(search_token_text(token));
+    }
+    out
 }
 
 fn search_tokens(value: &str) -> Vec<String> {
@@ -288,9 +311,29 @@ impl Scorer for FuzzyScorer {
         if !q.is_empty() {
             let tool_lexical = token_match_score(q, r.backend_tool(), 18, 12, 8);
             let summary_lexical = token_match_score(q, r.summary(), 8, 5, 3);
-            let mut deterministic = tool_lexical + summary_lexical;
+            let alias_tokens =
+                search_tokens_joined(r.search_tokens().iter().filter(|t| t.starts_with("alias:")));
+            let schema_tokens = search_tokens_joined(
+                r.search_tokens()
+                    .iter()
+                    .filter(|t| t.starts_with("schema:") || t.starts_with("required:")),
+            );
+            let generic_tokens = search_tokens_joined(r.search_tokens().iter().filter(|t| {
+                !t.starts_with("alias:") && !t.starts_with("schema:") && !t.starts_with("required:")
+            }));
+            let alias_lexical = token_match_score(q, &alias_tokens, 14, 10, 6);
+            let schema_lexical = token_match_score(q, &schema_tokens, 12, 8, 5);
+            let search_token_lexical = token_match_score(q, &generic_tokens, 10, 7, 4);
+            let mut deterministic = tool_lexical
+                + summary_lexical
+                + alias_lexical
+                + schema_lexical
+                + search_token_lexical;
             add_component(&mut out, tool_lexical, "tool_lexical");
             add_component(&mut out, summary_lexical, "summary_lexical");
+            add_component(&mut out, alias_lexical, "alias_lexical");
+            add_component(&mut out, schema_lexical, "schema_lexical");
+            add_component(&mut out, search_token_lexical, "search_token_lexical");
             if deterministic == 0 {
                 let multiword = relaxed_multiword_haystack_score(r, q);
                 deterministic = deterministic.max(multiword);
@@ -344,7 +387,26 @@ impl Scorer for FuzzyScorer {
                     }
                 }
             }
+            for token in r.search_tokens() {
+                if token.starts_with("schema:") || token.starts_with("required:") {
+                    let s = self.score_field(&pattern, search_token_text(token), 4, false);
+                    if s > best_schema {
+                        best_schema = s;
+                    }
+                }
+            }
             add_component(&mut out, best_schema, "schema_fuzzy");
+
+            let mut best_alias = 0;
+            for token in r.search_tokens() {
+                if let Some(alias) = token.strip_prefix("alias:") {
+                    let s = self.score_field(&pattern, alias, 5, false);
+                    if s > best_alias {
+                        best_alias = s;
+                    }
+                }
+            }
+            add_component(&mut out, best_alias, "alias_fuzzy");
 
             // Issue #994: meta-tools are excluded from results unless the
             // query directly targets the tool by name. This prevents verbose

--- a/crates/dcc-mcp-gateway-search/src/record.rs
+++ b/crates/dcc-mcp-gateway-search/src/record.rs
@@ -18,6 +18,10 @@ pub trait SearchRecord {
     fn skill_name(&self) -> Option<&str>;
     /// Free-form tags.
     fn tags(&self) -> &[String];
+    /// Bounded internal search-only tokens, such as aliases or schema terms.
+    fn search_tokens(&self) -> &[String] {
+        &[]
+    }
     /// DCC bucket (`maya`, `blender`, …).
     fn dcc_type(&self) -> &str;
     /// Owning instance id.

--- a/crates/dcc-mcp-gateway/src/gateway/backend_client/ops.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/backend_client/ops.rs
@@ -25,6 +25,7 @@ pub struct UnloadedCapabilityHint {
     pub skill_name: String,
     pub tool_name: String,
     pub summary: String,
+    pub search_tokens: Vec<String>,
     pub available_groups: Vec<CapabilityGroupInfo>,
 }
 
@@ -222,7 +223,8 @@ pub async fn try_fetch_tools(
 
             if loaded {
                 let annotations = parse_tool_annotations(v.get("annotations"));
-                let meta = mcp_meta_from_rest_metadata(v.get("metadata"), v.get("skill"));
+                let metadata = v.get("metadata");
+                let meta = mcp_meta_from_rest_metadata(metadata, v.get("skill"));
                 loaded_tools.push(McpTool {
                     name: action,
                     description,
@@ -244,6 +246,7 @@ pub async fn try_fetch_tools(
                     .and_then(Value::as_str)
                     .unwrap_or("")
                     .to_owned();
+                let metadata = v.get("metadata");
                 let available_groups = v
                     .get("available_groups")
                     .cloned()
@@ -253,6 +256,7 @@ pub async fn try_fetch_tools(
                     skill_name,
                     tool_name: action,
                     summary: description,
+                    search_tokens: rest_metadata_search_tokens(metadata),
                     available_groups,
                 });
             }
@@ -363,6 +367,57 @@ fn mcp_meta_from_rest_metadata(
         }
     }
     (!map.is_empty()).then_some(map)
+}
+
+fn rest_metadata_search_tokens(value: Option<&Value>) -> Vec<String> {
+    let Some(dcc) = value
+        .and_then(Value::as_object)
+        .and_then(|map| map.get("dcc"))
+        .and_then(Value::as_object)
+    else {
+        return Vec::new();
+    };
+
+    let mut out = Vec::new();
+    append_metadata_values(dcc.get("searchAliases"), "alias:", &mut out);
+    append_metadata_values(dcc.get("search_aliases"), "alias:", &mut out);
+    append_metadata_values(dcc.get("aliases"), "alias:", &mut out);
+    append_metadata_values(dcc.get("searchTokens"), "", &mut out);
+    append_metadata_values(dcc.get("search_tokens"), "", &mut out);
+    out
+}
+
+fn append_metadata_values(value: Option<&Value>, prefix: &str, out: &mut Vec<String>) {
+    match value {
+        Some(Value::String(s)) => {
+            for item in s.split(',') {
+                let item = item.trim();
+                if !item.is_empty() {
+                    out.push(prefixed_search_token(prefix, item));
+                }
+            }
+        }
+        Some(Value::Array(items)) => {
+            for item in items {
+                if let Some(s) = item.as_str().map(str::trim).filter(|s| !s.is_empty()) {
+                    out.push(prefixed_search_token(prefix, s));
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn prefixed_search_token(prefix: &str, value: &str) -> String {
+    if prefix.is_empty()
+        || value.starts_with("alias:")
+        || value.starts_with("schema:")
+        || value.starts_with("required:")
+    {
+        value.to_string()
+    } else {
+        format!("{prefix}{value}")
+    }
 }
 
 /// Fetch tool list from a backend; fail-soft on errors.

--- a/crates/dcc-mcp-gateway/src/gateway/backend_client/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/backend_client/tests.rs
@@ -153,7 +153,21 @@ async fn skill_rest_metadata_survives_fetch_and_describe() {
                                 "affinity": "any",
                                 "execution": "sync",
                                 "timeoutHintSecs": 2,
-                                "risk": "read-only"
+                                "risk": "read-only",
+                                "searchAliases": ["screen capture"],
+                                "searchTokens": ["schema:session_id"]
+                            }
+                        }
+                    }, {
+                        "action": "loadable_export__save",
+                        "skill": "loadable-export",
+                        "summary": "Save the current document",
+                        "has_schema": true,
+                        "loaded": false,
+                        "metadata": {
+                            "dcc": {
+                                "searchAliases": ["write file"],
+                                "searchTokens": ["required:destination_path"]
                             }
                         }
                     }]
@@ -185,7 +199,18 @@ async fn skill_rest_metadata_survives_fetch_and_describe() {
     let (tools, unloaded) = try_fetch_tools(&client, &mcp_url, Duration::from_secs(2))
         .await
         .expect("search");
-    assert!(unloaded.is_empty());
+    assert_eq!(unloaded.len(), 1);
+    assert_eq!(unloaded[0].skill_name, "loadable-export");
+    assert!(
+        unloaded[0]
+            .search_tokens
+            .contains(&"alias:write file".to_string())
+    );
+    assert!(
+        unloaded[0]
+            .search_tokens
+            .contains(&"required:destination_path".to_string())
+    );
     assert_eq!(tools[0].name, "app_ui__snapshot");
     assert_eq!(
         tools[0]
@@ -202,6 +227,17 @@ async fn skill_rest_metadata_survives_fetch_and_describe() {
             .and_then(|dcc| dcc.get("timeoutHintSecs"))
             .and_then(Value::as_u64),
         Some(2)
+    );
+    assert_eq!(
+        tools[0]
+            .meta
+            .as_ref()
+            .and_then(|meta| meta.get("dcc"))
+            .and_then(|dcc| dcc.get("searchTokens"))
+            .and_then(Value::as_array)
+            .and_then(|items| items.first())
+            .and_then(Value::as_str),
+        Some("schema:session_id")
     );
 
     let described = try_describe_tool(

--- a/crates/dcc-mcp-gateway/src/gateway/capability/builder.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/builder.rs
@@ -88,6 +88,7 @@ pub fn build_records_from_backend(input: BuildInput<'_>) -> BuildOutcome {
         let skill_name = skill_name_from_meta(tool.meta.as_ref()).or(name_skill);
         let callable_id = tool.name.clone();
         let tags = extract_tags(&tool.annotations, tool.meta.as_ref());
+        let search_tokens = extract_search_tokens(tool);
         let has_schema = has_meaningful_schema(&tool.input_schema);
         let summary = if tool.description.is_empty() && has_schema {
             // Keep the search text non-empty even when the backend
@@ -115,7 +116,8 @@ pub fn build_records_from_backend(input: BuildInput<'_>) -> BuildOutcome {
             .with_surface_metadata(
                 extract_annotations(&tool.annotations),
                 extract_metadata(tool.meta.as_ref()),
-            ),
+            )
+            .with_search_tokens(search_tokens),
         );
     }
 
@@ -256,8 +258,135 @@ fn compute_fingerprint(records: &[CapabilityRecord]) -> InstanceFingerprint {
         for t in &r.tags {
             t.hash(&mut hasher);
         }
+        for t in &r.search_tokens {
+            t.hash(&mut hasher);
+        }
     }
     InstanceFingerprint(hasher.finish())
+}
+
+fn extract_search_tokens(tool: &McpTool) -> Vec<String> {
+    let mut tokens = Vec::new();
+    if let Some(meta) = tool.meta.as_ref() {
+        tokens.extend(meta_search_values(
+            meta,
+            &["searchAliases", "search_aliases", "aliases"],
+            "alias:",
+        ));
+        tokens.extend(meta_search_values(
+            meta,
+            &["searchTokens", "search_tokens"],
+            "",
+        ));
+    }
+    tokens.extend(schema_search_tokens(&tool.input_schema));
+    tokens
+}
+
+fn meta_search_values(
+    meta: &serde_json::Map<String, Value>,
+    keys: &[&str],
+    nested_prefix: &str,
+) -> Vec<String> {
+    let Some(dcc) = meta.get("dcc").and_then(Value::as_object) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for key in keys {
+        if let Some(value) = dcc.get(*key) {
+            append_search_values(value, nested_prefix, &mut out);
+        }
+    }
+    out
+}
+
+fn append_search_values(value: &Value, prefix: &str, out: &mut Vec<String>) {
+    match value {
+        Value::String(s) => {
+            for item in s.split(',') {
+                let item = item.trim();
+                if !item.is_empty() {
+                    out.push(prefixed(prefix, item));
+                }
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                if let Some(s) = item.as_str().map(str::trim).filter(|s| !s.is_empty()) {
+                    out.push(prefixed(prefix, s));
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn prefixed(prefix: &str, value: &str) -> String {
+    if prefix.is_empty()
+        || value.starts_with("alias:")
+        || value.starts_with("schema:")
+        || value.starts_with("required:")
+    {
+        value.to_string()
+    } else {
+        format!("{prefix}{value}")
+    }
+}
+
+fn schema_search_tokens(schema: &Value) -> Vec<String> {
+    let mut out = Vec::new();
+    collect_schema_search_tokens(schema, 0, &mut out);
+    out
+}
+
+fn collect_schema_search_tokens(schema: &Value, depth: usize, out: &mut Vec<String>) {
+    if depth > 2 || out.len() >= 48 {
+        return;
+    }
+    let Some(obj) = schema.as_object() else {
+        return;
+    };
+
+    if let Some(required) = obj.get("required").and_then(Value::as_array) {
+        for field in required.iter().filter_map(Value::as_str) {
+            push_schema_token(out, "required:", field);
+        }
+    }
+
+    let Some(props) = obj.get("properties").and_then(Value::as_object) else {
+        return;
+    };
+    let mut names: Vec<&String> = props.keys().collect();
+    names.sort();
+    for name in names {
+        push_schema_token(out, "schema:", name);
+        let Some(prop) = props.get(name) else {
+            continue;
+        };
+        if let Some(description) = prop.get("description").and_then(Value::as_str) {
+            push_schema_token(out, "schema:", &short_description(description));
+        }
+        collect_schema_search_tokens(prop, depth + 1, out);
+        if out.len() >= 48 {
+            break;
+        }
+    }
+}
+
+fn push_schema_token(out: &mut Vec<String>, prefix: &str, value: &str) {
+    let value = value.trim();
+    if value.is_empty() {
+        return;
+    }
+    out.push(prefixed(prefix, value));
+}
+
+fn short_description(description: &str) -> String {
+    description
+        .split_whitespace()
+        .take(8)
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 fn extract_annotations(
@@ -422,6 +551,104 @@ mod unit_tests {
             out.records[0].skill_name.as_deref(),
             Some("maya-primitives")
         );
+    }
+
+    #[test]
+    fn indexes_aliases_and_schema_tokens_without_serializing_them() {
+        let iid = Uuid::from_u128(33);
+        let tools = vec![tool_with_meta(
+            "photoshop-export__save_document",
+            "Save the active Photoshop document.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "destination_path": {
+                        "type": "string",
+                        "description": "Absolute output file path"
+                    },
+                    "flatten_layers": {"type": "boolean"}
+                },
+                "required": ["destination_path"]
+            }),
+            json!({
+                "dcc": {
+                    "skill": "photoshop-export",
+                    "searchAliases": ["write file", "export image"],
+                    "searchTokens": ["schema:existing_hint"]
+                }
+            }),
+        )];
+        let out = build_records_from_backend(BuildInput {
+            instance_id: iid,
+            dcc_type: "photoshop",
+            backend_tools: &tools,
+        });
+
+        let record = &out.records[0];
+        assert!(
+            record
+                .search_tokens
+                .contains(&"alias:write file".to_string())
+        );
+        assert!(
+            record
+                .search_tokens
+                .contains(&"alias:export image".to_string())
+        );
+        assert!(
+            record
+                .search_tokens
+                .contains(&"required:destination_path".to_string())
+        );
+        assert!(
+            record
+                .search_tokens
+                .contains(&"schema:destination_path".to_string())
+        );
+        assert!(
+            record
+                .search_tokens
+                .contains(&"schema:existing_hint".to_string())
+        );
+
+        let serialized = serde_json::to_value(record).unwrap();
+        assert!(
+            serialized.get("search_tokens").is_none(),
+            "search-only tokens must not become public gateway search fields"
+        );
+    }
+
+    #[test]
+    fn fingerprint_changes_when_search_tokens_change() {
+        let iid = Uuid::from_u128(34);
+        let schema = json!({"type": "object"});
+        let before = vec![tool_with_meta(
+            "custom-export__write",
+            "Write custom payload",
+            schema.clone(),
+            json!({"dcc": {"searchAliases": ["old alias"]}}),
+        )];
+        let after = vec![tool_with_meta(
+            "custom-export__write",
+            "Write custom payload",
+            schema,
+            json!({"dcc": {"searchAliases": ["new alias"]}}),
+        )];
+
+        let fp_before = build_records_from_backend(BuildInput {
+            instance_id: iid,
+            dcc_type: "custom",
+            backend_tools: &before,
+        })
+        .fingerprint;
+        let fp_after = build_records_from_backend(BuildInput {
+            instance_id: iid,
+            dcc_type: "custom",
+            backend_tools: &after,
+        })
+        .fingerprint;
+
+        assert_ne!(fp_before, fp_after);
     }
 
     #[test]

--- a/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/refresh.rs
@@ -119,7 +119,8 @@ fn build_unloaded_records(
                 &hint.summary,
                 dcc_type,
             )
-            .with_available_groups(hint.available_groups);
+            .with_available_groups(hint.available_groups)
+            .with_search_tokens(hint.search_tokens);
             rec.instance_id = instance_id;
             rec.tool_slug = tool_slug(dcc_type, &instance_id, &hint.tool_name);
             Some(rec)
@@ -140,6 +141,9 @@ fn compute_fingerprint(records: &[CapabilityRecord]) -> InstanceFingerprint {
             group.active.hash(&mut hasher);
         }
         for t in &r.tags {
+            t.hash(&mut hasher);
+        }
+        for t in &r.search_tokens {
             t.hash(&mut hasher);
         }
     }
@@ -245,6 +249,7 @@ mod unit_tests {
                 skill_name: "maya-primitives".to_string(),
                 tool_name: "maya_primitives__create_sphere".to_string(),
                 summary: "Create a primitive sphere".to_string(),
+                search_tokens: Vec::new(),
                 available_groups: Vec::new(),
             }],
             iid,
@@ -321,6 +326,7 @@ mod unit_tests {
                     skill_name: "maya-primitives".to_string(),
                     tool_name: "maya_primitives__create_sphere".to_string(),
                     summary: "Create a primitive sphere".to_string(),
+                    search_tokens: Vec::new(),
                     available_groups: Vec::new(),
                 }],
                 iid,

--- a/crates/dcc-mcp-http-server/src/mcp_tool_catalog.rs
+++ b/crates/dcc-mcp-http-server/src/mcp_tool_catalog.rs
@@ -181,7 +181,13 @@ pub fn build_tool_meta(
     let has_timeout = meta.timeout_hint_secs.is_some();
     let missing = missing_capabilities(&meta.required_capabilities, declared_capabilities);
     let has_required_caps = !meta.required_capabilities.is_empty();
-    if !has_timeout && !deferred && !has_required_caps && !schema_is_incomplete {
+    let has_search_aliases = !meta.search_aliases.is_empty();
+    if !has_timeout
+        && !deferred
+        && !has_required_caps
+        && !schema_is_incomplete
+        && !has_search_aliases
+    {
         return None;
     }
 
@@ -203,6 +209,12 @@ pub fn build_tool_meta(
                 serde_json::json!(missing),
             );
         }
+    }
+    if has_search_aliases {
+        dcc_meta.insert(
+            "searchAliases".to_string(),
+            serde_json::json!(meta.search_aliases),
+        );
     }
     if schema_is_incomplete {
         dcc_meta.insert("incompleteSchema".to_string(), serde_json::json!(true));

--- a/crates/dcc-mcp-models/src/python/skill_metadata.rs
+++ b/crates/dcc-mcp-models/src/python/skill_metadata.rs
@@ -24,6 +24,7 @@ impl SkillMetadata {
         dcc = DEFAULT_DCC.to_string(),
         tags = vec![],
         search_hint = "".to_string(),
+        search_aliases = vec![],
         scripts = vec![],
         skill_path = "".to_string(),
         version = DEFAULT_VERSION.to_string(),
@@ -41,6 +42,7 @@ impl SkillMetadata {
         dcc: String,
         tags: Vec<String>,
         search_hint: String,
+        search_aliases: Vec<String>,
         scripts: Vec<String>,
         skill_path: String,
         version: String,
@@ -57,6 +59,7 @@ impl SkillMetadata {
             dcc,
             tags,
             search_hint,
+            search_aliases,
             scripts,
             skill_path,
             version,
@@ -91,7 +94,7 @@ impl SkillMetadata {
 
     // ── Trivial accessors emitted by `#[derive(PyWrapper)]` (#528 M3.3) ─
     // `name`, `description`, `dcc`, `version`, `license`, `compatibility`,
-    // `skill_path`, `search_hint` (String → &str + setter), `tags`,
+    // `skill_path`, `search_hint` (String → &str + setter), `tags`, `search_aliases`,
     // `scripts`, `depends`, `metadata_files`, `allowed_tools`, `tools`,
     // `groups`, `layer`, `stage` (Vec<T> / Option<T> clone + setter).
     // See `crate::skill_metadata::SkillMetadata`'s `#[py_wrapper(...)]`

--- a/crates/dcc-mcp-models/src/python/tool_declaration.rs
+++ b/crates/dcc-mcp-models/src/python/tool_declaration.rs
@@ -40,7 +40,7 @@ impl SkillGroup {
 #[pymethods]
 impl ToolDeclaration {
     #[new]
-    #[pyo3(signature = (name, description="".to_string(), input_schema=None, output_schema=None, read_only=false, destructive=false, idempotent=false, defer_loading=false, source_file="".to_string(), group="".to_string(), execution="sync".to_string(), timeout_hint_secs=None, thread_affinity="any".to_string(), enforce_thread_affinity=false))]
+    #[pyo3(signature = (name, description="".to_string(), input_schema=None, output_schema=None, read_only=false, destructive=false, idempotent=false, defer_loading=false, source_file="".to_string(), group="".to_string(), execution="sync".to_string(), timeout_hint_secs=None, thread_affinity="any".to_string(), enforce_thread_affinity=false, search_aliases=vec![]))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         name: String,
@@ -57,6 +57,7 @@ impl ToolDeclaration {
         timeout_hint_secs: Option<u32>,
         thread_affinity: String,
         enforce_thread_affinity: bool,
+        search_aliases: Vec<String>,
     ) -> pyo3::PyResult<Self> {
         let input_schema = input_schema
             .and_then(|schema| serde_json::from_str(&schema).ok())
@@ -85,6 +86,7 @@ impl ToolDeclaration {
             _deferred_guard: None,
             annotations: ToolAnnotations::default(),
             required_capabilities: Vec::new(),
+            search_aliases,
         })
     }
 
@@ -92,7 +94,7 @@ impl ToolDeclaration {
     // `name`, `description`, `read_only`, `destructive`, `idempotent`,
     // `defer_loading`, `source_file`, `group`, `enforce_thread_affinity`
     // (read+write), plus `timeout_hint_secs` (Option<u32>) and `required_capabilities`
-    // (Vec<String>). See `crate::skill_metadata::ToolDeclaration`'s
+    // (Vec<String>) and `search_aliases` (Vec<String>). See `crate::skill_metadata::ToolDeclaration`'s
     // `#[py_wrapper(...)]` table for the canonical list.
 
     #[getter]

--- a/crates/dcc-mcp-models/src/skill_metadata/mod.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata/mod.rs
@@ -95,6 +95,7 @@ use serde_impl::{
         dcc: String => [get(by_str), set],
         tags: Vec<String> => [get(clone), set],
         search_hint: String => [get(by_str), set],
+        search_aliases: Vec<String> => [get(clone), set],
         scripts: Vec<String> => [get(clone), set],
         skill_path: String => [get(by_str), set],
         version: String => [get(by_str), set],
@@ -188,6 +189,18 @@ pub struct SkillMetadata {
     /// Falls back to `description` if not set.
     #[serde(default, rename = "search-hint", alias = "search_hint")]
     pub search_hint: String,
+
+    /// Bounded search-only aliases and synonyms shared by every tool in the
+    /// skill. Tool declarations can add their own `search_aliases`.
+    ///
+    /// Set from `metadata.dcc-mcp.search-aliases` in SKILL.md frontmatter.
+    #[serde(
+        default,
+        rename = "search-aliases",
+        alias = "search_aliases",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub search_aliases: Vec<String>,
 
     /// MCP tool declarations — defines the tools this skill exposes.
     ///

--- a/crates/dcc-mcp-models/src/skill_metadata/tests.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata/tests.rs
@@ -80,6 +80,27 @@ fn test_tool_declaration_parses_required_capabilities() {
 }
 
 #[test]
+fn test_skill_and_tool_search_aliases_parse() {
+    let json = r#"{
+            "name": "export-skill",
+            "search-aliases": ["write file", "interchange"],
+            "tools": [{
+                "name": "export_fbx",
+                "search_aliases": ["destination path", "fbx"]
+            }]
+        }"#;
+    let meta: SkillMetadata = serde_json::from_str(json).unwrap();
+    assert_eq!(
+        meta.search_aliases,
+        vec!["write file".to_string(), "interchange".to_string()]
+    );
+    assert_eq!(
+        meta.tools[0].search_aliases,
+        vec!["destination path".to_string(), "fbx".to_string()]
+    );
+}
+
+#[test]
 fn test_tool_declaration_parses_thread_affinity_enforcement() {
     let json = r#"{
             "name": "bake_simulation",
@@ -335,6 +356,7 @@ fn test_skill_metadata_serde_round_trip() {
         dcc: "blender".to_string(),
         tags: vec!["modeling".to_string()],
         search_hint: "mesh, modeling, geometry".to_string(),
+        search_aliases: vec!["mesh authoring".to_string()],
         scripts: vec!["init.py".to_string()],
         skill_path: "/skills/full".to_string(),
         version: "1.2.3".to_string(),

--- a/crates/dcc-mcp-models/src/skill_metadata/tool_declaration.rs
+++ b/crates/dcc-mcp-models/src/skill_metadata/tool_declaration.rs
@@ -153,6 +153,7 @@ impl ToolAnnotations {
         timeout_hint_secs: Option<u32> => [get, set],
         enforce_thread_affinity: bool => [get, set],
         required_capabilities: Vec<String> => [get(clone), set],
+        search_aliases: Vec<String> => [get(clone), set],
     ))
 )]
 pub struct ToolDeclaration {
@@ -340,6 +341,25 @@ pub struct ToolDeclaration {
         skip_serializing_if = "Vec::is_empty"
     )]
     pub required_capabilities: Vec<String>,
+
+    /// Bounded search-only aliases and synonyms for discovery.
+    ///
+    /// These terms improve gateway/per-DCC search recall without changing the
+    /// tool name, summary, tags, or full schema. They are not dispatch inputs.
+    ///
+    /// ```yaml
+    /// tools:
+    ///   - name: export_fbx
+    ///     search_aliases: [destination path, interchange, fbx]
+    /// ```
+    #[serde(
+        default,
+        rename = "search_aliases",
+        alias = "search-aliases",
+        alias = "aliases",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub search_aliases: Vec<String>,
 }
 
 // ── ToolDeclaration custom deserializer (issue #344) ──────────────────────
@@ -441,6 +461,14 @@ impl<'de> serde::Deserialize<'de> for ToolDeclaration {
                 alias = "required-capabilities"
             )]
             required_capabilities: Vec<String>,
+
+            #[serde(
+                default,
+                rename = "search_aliases",
+                alias = "search-aliases",
+                alias = "aliases"
+            )]
+            search_aliases: Vec<String>,
         }
 
         let w = Wire::deserialize(deserializer)?;
@@ -490,6 +518,7 @@ impl<'de> serde::Deserialize<'de> for ToolDeclaration {
             _deferred_guard: None,
             annotations,
             required_capabilities: w.required_capabilities,
+            search_aliases: w.search_aliases,
         })
     }
 }

--- a/crates/dcc-mcp-skill-rest/src/lib.rs
+++ b/crates/dcc-mcp-skill-rest/src/lib.rs
@@ -70,6 +70,7 @@ mod errors;
 pub mod openapi;
 mod readiness;
 mod router;
+mod search_index;
 mod service;
 mod thread_affinity_diagnostics;
 

--- a/crates/dcc-mcp-skill-rest/src/search_index.rs
+++ b/crates/dcc-mcp-skill-rest/src/search_index.rs
@@ -1,0 +1,207 @@
+//! Bounded search-index helpers for the per-DCC REST service.
+//!
+//! Keep full schemas behind `/v1/describe`; this module derives small aliases
+//! and schema terms for `/v1/search` and gateway capability indexing.
+
+use serde_json::Value;
+
+use crate::service::CatalogAction;
+use dcc_mcp_models::ToolAnnotations;
+
+pub(crate) fn action_metadata(action: &CatalogAction) -> Value {
+    let mut dcc = serde_json::Map::new();
+    dcc.insert(
+        "affinity".to_string(),
+        Value::String(action.thread_affinity.as_str().to_string()),
+    );
+    dcc.insert(
+        "execution".to_string(),
+        Value::String(
+            match action.execution {
+                dcc_mcp_models::ExecutionMode::Sync => "sync",
+                dcc_mcp_models::ExecutionMode::Async => "async",
+            }
+            .to_string(),
+        ),
+    );
+    if let Some(timeout) = action.timeout_hint_secs {
+        dcc.insert("timeoutHintSecs".to_string(), serde_json::json!(timeout));
+    }
+    dcc.insert(
+        "enforceThreadAffinity".to_string(),
+        Value::Bool(action.enforce_thread_affinity),
+    );
+    dcc.insert(
+        "risk".to_string(),
+        Value::String(action_risk(&action.annotations).to_string()),
+    );
+
+    let mut out = serde_json::Map::new();
+    out.insert("dcc".to_string(), Value::Object(dcc));
+    Value::Object(out)
+}
+
+pub(crate) fn search_metadata(action: &CatalogAction) -> Option<Value> {
+    let has_non_default_execution = action.thread_affinity.is_main()
+        || action.execution.is_deferred()
+        || action.timeout_hint_secs.is_some()
+        || action.enforce_thread_affinity
+        || !action.annotations.is_empty();
+    if !has_non_default_execution
+        && action.search_aliases.is_empty()
+        && action.search_tokens.is_empty()
+    {
+        return None;
+    }
+
+    let mut metadata = if has_non_default_execution {
+        action_metadata(action)
+    } else {
+        serde_json::json!({"dcc": {}})
+    };
+    if let Some(dcc) = metadata.get_mut("dcc").and_then(Value::as_object_mut) {
+        if !action.search_aliases.is_empty() {
+            dcc.insert(
+                "searchAliases".to_string(),
+                serde_json::json!(action.search_aliases),
+            );
+        }
+        if !action.search_tokens.is_empty() {
+            dcc.insert(
+                "searchTokens".to_string(),
+                serde_json::json!(action.search_tokens),
+            );
+        }
+    }
+    Some(metadata)
+}
+
+pub(crate) fn search_haystack(action: &CatalogAction) -> String {
+    let mut hay = String::new();
+    for part in [
+        action.action_name.as_str(),
+        action.skill_name.as_str(),
+        action.description.as_str(),
+    ] {
+        hay.push(' ');
+        hay.push_str(&part.to_ascii_lowercase());
+    }
+    hay.push(' ');
+    hay.push_str(&action.tags.join(" ").to_ascii_lowercase());
+    hay.push(' ');
+    hay.push_str(&action.search_aliases.join(" ").to_ascii_lowercase());
+    for token in &action.search_tokens {
+        hay.push(' ');
+        hay.push_str(&search_token_text(token).to_ascii_lowercase());
+    }
+    hay
+}
+
+pub(crate) fn merged_search_aliases(
+    skill_aliases: &[String],
+    tool_aliases: &[String],
+) -> Vec<String> {
+    normalise_search_values(
+        skill_aliases
+            .iter()
+            .chain(tool_aliases)
+            .cloned()
+            .collect::<Vec<_>>(),
+        24,
+    )
+}
+
+pub(crate) fn normalise_search_values(values: Vec<String>, limit: usize) -> Vec<String> {
+    let mut out = Vec::with_capacity(values.len().min(limit));
+    let mut seen = std::collections::HashSet::new();
+    for value in values {
+        for item in value.split(',') {
+            let token = item.split_whitespace().collect::<Vec<_>>().join(" ");
+            let token = token.trim();
+            if token.len() < 2 || token.len() > 64 {
+                continue;
+            }
+            let key = token.to_ascii_lowercase();
+            if seen.insert(key) {
+                out.push(token.to_string());
+            }
+            if out.len() >= limit {
+                return out;
+            }
+        }
+    }
+    out
+}
+
+pub(crate) fn schema_search_tokens(schema: &Value) -> Vec<String> {
+    let mut tokens = Vec::new();
+    collect_schema_search_tokens(schema, 0, &mut tokens);
+    normalise_search_values(tokens, 48)
+}
+
+fn collect_schema_search_tokens(schema: &Value, depth: usize, out: &mut Vec<String>) {
+    if depth > 2 || out.len() >= 48 {
+        return;
+    }
+    let Some(obj) = schema.as_object() else {
+        return;
+    };
+
+    if let Some(required) = obj.get("required").and_then(Value::as_array) {
+        for field in required.iter().filter_map(Value::as_str) {
+            out.push(format!("required:{field}"));
+            if out.len() >= 48 {
+                return;
+            }
+        }
+    }
+
+    let Some(props) = obj.get("properties").and_then(Value::as_object) else {
+        return;
+    };
+    let mut names: Vec<&String> = props.keys().collect();
+    names.sort();
+    for name in names {
+        out.push(format!("schema:{name}"));
+        if out.len() >= 48 {
+            return;
+        }
+        let Some(prop) = props.get(name) else {
+            continue;
+        };
+        if let Some(description) = prop.get("description").and_then(Value::as_str) {
+            let description = description
+                .split_whitespace()
+                .take(8)
+                .collect::<Vec<_>>()
+                .join(" ");
+            if !description.is_empty() {
+                out.push(format!("schema:{description}"));
+            }
+        }
+        collect_schema_search_tokens(prop, depth + 1, out);
+        if out.len() >= 48 {
+            return;
+        }
+    }
+}
+
+fn search_token_text(token: &str) -> &str {
+    token
+        .strip_prefix("alias:")
+        .or_else(|| token.strip_prefix("schema:"))
+        .or_else(|| token.strip_prefix("required:"))
+        .unwrap_or(token)
+}
+
+fn action_risk(annotations: &ToolAnnotations) -> &'static str {
+    if annotations.destructive_hint == Some(true) {
+        "destructive"
+    } else if annotations.open_world_hint == Some(true) {
+        "open-world"
+    } else if annotations.read_only_hint == Some(true) {
+        "read-only"
+    } else {
+        "mutation"
+    }
+}

--- a/crates/dcc-mcp-skill-rest/src/service.rs
+++ b/crates/dcc-mcp-skill-rest/src/service.rs
@@ -29,6 +29,10 @@ use dcc_mcp_models::{ExecutionMode, ThreadAffinity, ToolAnnotations};
 use dcc_mcp_skills::SkillCatalog;
 
 use super::errors::{ServiceError, ServiceErrorKind};
+use crate::search_index::{
+    action_metadata, merged_search_aliases, normalise_search_values, schema_search_tokens,
+    search_haystack, search_metadata,
+};
 
 // ── Requests / responses ─────────────────────────────────────────────
 
@@ -303,6 +307,8 @@ pub struct CatalogAction {
     pub dcc: String,
     pub description: String,
     pub tags: Vec<String>,
+    pub search_aliases: Vec<String>,
+    pub search_tokens: Vec<String>,
     pub input_schema: Value,
     pub loaded: bool,
     pub scope: String,
@@ -555,12 +561,15 @@ impl SkillCatalogSource for CatalogSource {
                     (true, "core".to_string(), meta.dcc.clone())
                 });
             seen.insert(meta.name.clone());
+            let search_tokens = schema_search_tokens(&meta.input_schema);
             out.push(CatalogAction {
                 action_name: meta.name,
                 skill_name: skill_name.clone(),
                 dcc: meta.dcc,
                 description: meta.description,
                 tags: meta.tags,
+                search_aliases: normalise_search_values(meta.search_aliases, 24),
+                search_tokens,
                 input_schema: meta.input_schema,
                 loaded,
                 scope,
@@ -601,12 +610,17 @@ impl SkillCatalogSource for CatalogSource {
                 } else {
                     tool_decl.input_schema.clone()
                 };
+                let search_aliases =
+                    merged_search_aliases(&detail.search_aliases, &tool_decl.search_aliases);
+                let search_tokens = schema_search_tokens(&input_schema);
                 out.push(CatalogAction {
                     action_name,
                     skill_name: detail.name.clone(),
                     dcc: detail.dcc.clone(),
                     description,
                     tags: detail.tags.clone(),
+                    search_aliases,
+                    search_tokens,
                     input_schema,
                     loaded: false,
                     scope: detail.scope.clone(),
@@ -893,13 +907,7 @@ impl SkillRestService {
                     }
                 }
                 if !query.is_empty() {
-                    let hay = format!(
-                        "{} {} {} {}",
-                        a.action_name.to_ascii_lowercase(),
-                        a.skill_name.to_ascii_lowercase(),
-                        a.description.to_ascii_lowercase(),
-                        a.tags.join(" ").to_ascii_lowercase(),
-                    );
+                    let hay = search_haystack(a);
                     if !hay.contains(&query) {
                         return false;
                     }
@@ -1209,60 +1217,6 @@ fn safety_annotations(annotations: &ToolAnnotations) -> Option<Value> {
         out.insert("openWorldHint".to_string(), Value::Bool(open_world));
     }
     (!out.is_empty()).then_some(Value::Object(out))
-}
-
-fn action_metadata(action: &CatalogAction) -> Value {
-    let mut dcc = serde_json::Map::new();
-    dcc.insert(
-        "affinity".to_string(),
-        Value::String(action.thread_affinity.as_str().to_string()),
-    );
-    dcc.insert(
-        "execution".to_string(),
-        Value::String(
-            match action.execution {
-                ExecutionMode::Sync => "sync",
-                ExecutionMode::Async => "async",
-            }
-            .to_string(),
-        ),
-    );
-    if let Some(timeout) = action.timeout_hint_secs {
-        dcc.insert("timeoutHintSecs".to_string(), serde_json::json!(timeout));
-    }
-    dcc.insert(
-        "enforceThreadAffinity".to_string(),
-        Value::Bool(action.enforce_thread_affinity),
-    );
-    dcc.insert(
-        "risk".to_string(),
-        Value::String(action_risk(&action.annotations).to_string()),
-    );
-
-    let mut out = serde_json::Map::new();
-    out.insert("dcc".to_string(), Value::Object(dcc));
-    Value::Object(out)
-}
-
-fn search_metadata(action: &CatalogAction) -> Option<Value> {
-    let has_non_default_execution = action.thread_affinity.is_main()
-        || action.execution.is_deferred()
-        || action.timeout_hint_secs.is_some()
-        || action.enforce_thread_affinity
-        || !action.annotations.is_empty();
-    has_non_default_execution.then(|| action_metadata(action))
-}
-
-fn action_risk(annotations: &ToolAnnotations) -> &'static str {
-    if annotations.destructive_hint == Some(true) {
-        "destructive"
-    } else if annotations.open_world_hint == Some(true) {
-        "open-world"
-    } else if annotations.read_only_hint == Some(true) {
-        "read-only"
-    } else {
-        "mutation"
-    }
 }
 
 fn truncate(s: &str, n: usize) -> String {

--- a/crates/dcc-mcp-skill-rest/src/service_tests.rs
+++ b/crates/dcc-mcp-skill-rest/src/service_tests.rs
@@ -94,6 +94,8 @@ fn sphere_action(loaded: bool) -> CatalogAction {
         dcc: "maya".into(),
         description: "Create a polygon sphere".into(),
         tags: vec!["geometry".into(), "poly".into()],
+        search_aliases: Vec::new(),
+        search_tokens: Vec::new(),
         input_schema: serde_json::json!({"type":"object"}),
         loaded,
         scope: "repo".into(),
@@ -234,6 +236,80 @@ fn search_query_matches_description() {
         ..Default::default()
     };
     assert_eq!(svc.search(&req).total, 0);
+}
+
+#[test]
+fn search_matches_aliases_and_schema_tokens_without_schema_expansion() {
+    let mut maya = sphere_action(true);
+    maya.search_aliases = vec!["primitive ball".into()];
+    maya.input_schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "radius": {"type": "number", "description": "Sphere radius in scene units"}
+        },
+        "required": ["radius"]
+    });
+    maya.search_tokens = vec!["schema:radius".into(), "required:radius".into()];
+
+    let photoshop = CatalogAction {
+        action_name: "resize_canvas".into(),
+        skill_name: "photoshop-canvas".into(),
+        dcc: "photoshop".into(),
+        description: "Resize the active document canvas".into(),
+        tags: vec!["image".into()],
+        search_aliases: vec!["document bounds".into()],
+        search_tokens: vec![
+            "schema:width_pixels".into(),
+            "required:height_pixels".into(),
+        ],
+        input_schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "width_pixels": {"type": "integer"},
+                "height_pixels": {"type": "integer"}
+            },
+            "required": ["height_pixels"]
+        }),
+        loaded: true,
+        scope: "repo".into(),
+        annotations: Default::default(),
+        execution: Default::default(),
+        timeout_hint_secs: None,
+        thread_affinity: Default::default(),
+        enforce_thread_affinity: false,
+        available_groups: Vec::new(),
+    };
+
+    let (svc, _) = build_service(vec![maya, photoshop]);
+
+    let alias_hits = svc.search(&SearchRequest {
+        query: Some("primitive ball".into()),
+        ..Default::default()
+    });
+    assert_eq!(alias_hits.total, 1);
+    assert_eq!(alias_hits.hits[0].action, "create_sphere");
+    assert_eq!(
+        alias_hits.hits[0].metadata.as_ref().unwrap()["dcc"]["searchAliases"],
+        serde_json::json!(["primitive ball"])
+    );
+
+    let schema_hits = svc.search(&SearchRequest {
+        query: Some("width_pixels".into()),
+        dcc_type: Some("photoshop".into()),
+        ..Default::default()
+    });
+    assert_eq!(schema_hits.total, 1);
+    assert_eq!(schema_hits.hits[0].action, "resize_canvas");
+    assert_eq!(
+        schema_hits.hits[0].metadata.as_ref().unwrap()["dcc"]["searchTokens"],
+        serde_json::json!(["schema:width_pixels", "required:height_pixels"])
+    );
+
+    let serialized = serde_json::to_string(&schema_hits.hits[0]).unwrap();
+    assert!(
+        !serialized.contains("input_schema"),
+        "search hits must stay compact and keep full schemas behind describe"
+    );
 }
 
 #[test]

--- a/crates/dcc-mcp-skills/src/catalog/catalog.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog.rs
@@ -131,6 +131,7 @@ impl SkillCatalog {
                 name: e.metadata.name.clone(),
                 description: e.metadata.description.clone(),
                 tags: e.metadata.tags.clone(),
+                search_aliases: e.metadata.search_aliases.clone(),
                 dcc: e.metadata.dcc.clone(),
                 version: e.metadata.version.clone(),
                 depends: e.metadata.depends.clone(),

--- a/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
+++ b/crates/dcc-mcp-skills/src/catalog/catalog_loading.rs
@@ -331,6 +331,10 @@ impl SkillCatalog {
                 },
                 category: metadata.tags.first().cloned().unwrap_or_default(),
                 tags: metadata.tags.clone(),
+                search_aliases: merged_search_aliases(
+                    &metadata.search_aliases,
+                    &tool_decl.search_aliases,
+                ),
                 dcc: metadata.dcc.clone(),
                 version: metadata.version.clone(),
                 input_schema,
@@ -399,6 +403,7 @@ impl SkillCatalog {
                     description: format!("[{}] {}", metadata.name, metadata.description),
                     category: metadata.tags.first().cloned().unwrap_or_default(),
                     tags: metadata.tags.clone(),
+                    search_aliases: metadata.search_aliases.clone(),
                     dcc: metadata.dcc.clone(),
                     version: metadata.version.clone(),
                     input_schema,
@@ -562,6 +567,23 @@ impl SkillCatalog {
         }
         self.entries.clear();
     }
+}
+
+fn merged_search_aliases(skill_aliases: &[String], tool_aliases: &[String]) -> Vec<String> {
+    let mut out = Vec::with_capacity(skill_aliases.len() + tool_aliases.len());
+    let mut seen = std::collections::HashSet::new();
+    for alias in skill_aliases.iter().chain(tool_aliases.iter()) {
+        let trimmed = alias.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let key = trimmed.to_ascii_lowercase();
+        if seen.insert(key) {
+            out.push(trimmed.to_string());
+        }
+    }
+    out.truncate(24);
+    out
 }
 
 fn skill_event_payload(

--- a/crates/dcc-mcp-skills/src/catalog/scoring.rs
+++ b/crates/dcc-mcp-skills/src/catalog/scoring.rs
@@ -11,8 +11,10 @@
 //! | `name`                                   | 5.0    |
 //! | `tags`                                   | 3.0    |
 //! | `search_hint`                            | 3.0    |
+//! | `search_aliases`                         | 3.0    |
 //! | `description`                            | 2.0    |
 //! | sibling tool names (from `tools.yaml`)   | 2.0    |
+//! | sibling tool search aliases              | 2.0    |
 //! | sibling tool descriptions                | 1.0    |
 //! | `dcc` (exact token match only)           | 4.0    |
 //!
@@ -40,8 +42,10 @@ const B: f64 = 0.75;
 pub const W_NAME: f64 = 5.0;
 pub const W_TAGS: f64 = 3.0;
 pub const W_HINT: f64 = 3.0;
+pub const W_ALIASES: f64 = 3.0;
 pub const W_DESCRIPTION: f64 = 2.0;
 pub const W_TOOL_NAME: f64 = 2.0;
+pub const W_TOOL_ALIAS: f64 = 2.0;
 pub const W_TOOL_DESCRIPTION: f64 = 1.0;
 pub const W_DCC: f64 = 4.0;
 
@@ -70,8 +74,10 @@ pub struct FieldTokens {
     pub name: Vec<String>,
     pub tags: Vec<String>,
     pub hint: Vec<String>,
+    pub aliases: Vec<String>,
     pub description: Vec<String>,
     pub tool_names: Vec<String>,
+    pub tool_aliases: Vec<String>,
     pub tool_descriptions: Vec<String>,
     pub dcc: Vec<String>,
 }
@@ -82,8 +88,10 @@ impl FieldTokens {
         self.name.len()
             + self.tags.len()
             + self.hint.len()
+            + self.aliases.len()
             + self.description.len()
             + self.tool_names.len()
+            + self.tool_aliases.len()
             + self.tool_descriptions.len()
             + self.dcc.len()
     }
@@ -98,9 +106,13 @@ impl FieldTokens {
         };
 
         let mut tool_names = Vec::new();
+        let mut tool_aliases = Vec::new();
         let mut tool_descriptions = Vec::new();
         for t in &meta.tools {
             tool_names.extend(tokenize(&t.name));
+            for alias in &t.search_aliases {
+                tool_aliases.extend(tokenize(alias));
+            }
             tool_descriptions.extend(tokenize(&t.description));
         }
 
@@ -108,13 +120,19 @@ impl FieldTokens {
         for tag in &meta.tags {
             tag_tokens.extend(tokenize(tag));
         }
+        let mut alias_tokens = Vec::new();
+        for alias in &meta.search_aliases {
+            alias_tokens.extend(tokenize(alias));
+        }
 
         Self {
             name: tokenize(&meta.name),
             tags: tag_tokens,
             hint: tokenize(hint_source),
+            aliases: alias_tokens,
             description: tokenize(&meta.description),
             tool_names,
+            tool_aliases,
             tool_descriptions,
             dcc: tokenize(&meta.dcc),
         }
@@ -206,8 +224,10 @@ pub fn score_skills(query: &str, skills: &[&SkillMetadata], scopes: &[SkillScope
                     count_occurrences(&f.name, q) > 0
                         || count_occurrences(&f.tags, q) > 0
                         || count_occurrences(&f.hint, q) > 0
+                        || count_occurrences(&f.aliases, q) > 0
                         || count_occurrences(&f.description, q) > 0
                         || count_occurrences(&f.tool_names, q) > 0
+                        || count_occurrences(&f.tool_aliases, q) > 0
                         || count_occurrences(&f.tool_descriptions, q) > 0
                         || count_occurrences(&f.dcc, q) > 0
                 })
@@ -228,9 +248,12 @@ pub fn score_skills(query: &str, skills: &[&SkillMetadata], scopes: &[SkillScope
             let contrib = W_NAME * field_bm25(count_occurrences(&fields_i.name, q), dl, avgdl)
                 + W_TAGS * field_bm25(count_occurrences(&fields_i.tags, q), dl, avgdl)
                 + W_HINT * field_bm25(count_occurrences(&fields_i.hint, q), dl, avgdl)
+                + W_ALIASES * field_bm25(count_occurrences(&fields_i.aliases, q), dl, avgdl)
                 + W_DESCRIPTION
                     * field_bm25(count_occurrences(&fields_i.description, q), dl, avgdl)
                 + W_TOOL_NAME * field_bm25(count_occurrences(&fields_i.tool_names, q), dl, avgdl)
+                + W_TOOL_ALIAS
+                    * field_bm25(count_occurrences(&fields_i.tool_aliases, q), dl, avgdl)
                 + W_TOOL_DESCRIPTION
                     * field_bm25(count_occurrences(&fields_i.tool_descriptions, q), dl, avgdl)
                 + W_DCC * field_bm25(count_occurrences(&fields_i.dcc, q), dl, avgdl);
@@ -442,6 +465,41 @@ mod tests {
         let scopes = vec![SkillScope::Repo, SkillScope::Repo];
         let out = score_skills("turntable", &skills, &scopes);
         assert_eq!(out.len(), 1, "sibling tool name must be scorable");
+        assert_eq!(out[0].name, "scene-utils");
+    }
+
+    #[test]
+    fn test_skill_search_alias_hit() {
+        let mut a = mk_full("geometry-tools", "scene helpers", "", &[], "maya", &[]);
+        a.search_aliases = vec!["primitive ball".to_string()];
+        let b = mk_full("other", "unrelated stuff", "", &[], "maya", &[]);
+        let skills = vec![&a, &b];
+        let scopes = vec![SkillScope::Repo, SkillScope::Repo];
+
+        let out = score_skills("primitive ball", &skills, &scopes);
+
+        assert_eq!(out.len(), 1, "skill search aliases must be scorable");
+        assert_eq!(out[0].name, "geometry-tools");
+    }
+
+    #[test]
+    fn test_sibling_tool_search_alias_hit() {
+        let mut a = mk_full(
+            "scene-utils",
+            "scene helpers",
+            "",
+            &[],
+            "maya",
+            &[("create_sphere", "create mesh")],
+        );
+        a.tools[0].search_aliases = vec!["mesh globe".to_string()];
+        let b = mk_full("other", "unrelated stuff", "", &[], "maya", &[]);
+        let skills = vec![&a, &b];
+        let scopes = vec![SkillScope::Repo, SkillScope::Repo];
+
+        let out = score_skills("mesh globe", &skills, &scopes);
+
+        assert_eq!(out.len(), 1, "tool search aliases must be scorable");
         assert_eq!(out[0].name, "scene-utils");
     }
 

--- a/crates/dcc-mcp-skills/src/catalog/types.rs
+++ b/crates/dcc-mcp-skills/src/catalog/types.rs
@@ -136,6 +136,8 @@ pub struct SkillDetail {
     pub name: String,
     pub description: String,
     pub tags: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub search_aliases: Vec<String>,
     pub dcc: String,
     pub version: String,
     pub depends: Vec<String>,
@@ -180,6 +182,7 @@ impl RegistryEntry for SkillEntry {
             self.metadata.search_hint.clone(),
         ];
         tags.extend(self.metadata.tags.iter().cloned());
+        tags.extend(self.metadata.search_aliases.iter().cloned());
         tags.retain(|t| !t.is_empty());
         tags
     }

--- a/crates/dcc-mcp-skills/src/loader/mod.rs
+++ b/crates/dcc-mcp-skills/src/loader/mod.rs
@@ -198,6 +198,9 @@ fn apply_dcc_mcp_metadata_overrides(
                     meta.search_hint = s.to_string();
                 }
             }
+            "search-aliases" | "search_aliases" | "aliases" => {
+                meta.search_aliases = parse_csv_or_list(&value);
+            }
             "depends" => {
                 meta.depends = parse_csv_or_list(&value);
             }

--- a/crates/dcc-mcp-skills/src/loader/tests/test_metadata_compat.rs
+++ b/crates/dcc-mcp-skills/src/loader/tests/test_metadata_compat.rs
@@ -70,6 +70,7 @@ metadata:
     version: "2.0.0"
     tags: "a, b"
     search-hint: "hint words"
+    search-aliases: [make sphere, primitive ball]
     depends: "other-skill"
 ---
 # body
@@ -80,6 +81,10 @@ metadata:
     assert_eq!(meta.version, "2.0.0");
     assert_eq!(meta.tags, vec!["a".to_string(), "b".to_string()]);
     assert_eq!(meta.search_hint, "hint words");
+    assert_eq!(
+        meta.search_aliases,
+        vec!["make sphere".to_string(), "primitive ball".to_string()]
+    );
     assert_eq!(meta.depends, vec!["other-skill".to_string()]);
 }
 
@@ -91,7 +96,7 @@ fn nested_form_with_inline_tools_list_parses() {
     std::fs::create_dir_all(&dir).unwrap();
     std::fs::write(
         dir.join("tools.yaml"),
-        "tools:\n  - name: create_sphere\n    description: make a sphere\n",
+        "tools:\n  - name: create_sphere\n    description: make a sphere\n    search_aliases: [primitive ball, mesh globe]\n",
     )
     .unwrap();
     let body = r#"---
@@ -115,6 +120,10 @@ metadata:
     assert_eq!(meta.search_hint, "keyframe, timeline");
     assert_eq!(meta.tools.len(), 1);
     assert_eq!(meta.tools[0].name, "create_sphere");
+    assert_eq!(
+        meta.tools[0].search_aliases,
+        vec!["primitive ball".to_string(), "mesh globe".to_string()]
+    );
 }
 
 #[test]

--- a/docs/guide/rest-api-surface.md
+++ b/docs/guide/rest-api-surface.md
@@ -436,7 +436,7 @@ Rules:
 
 - `query` (required) — free-text. On the gateway, `mode: "fuzzy"`
   (default) uses a hybrid ranker: weighted lexical matches over tool names,
-  skills, tags, summaries, and schema-field tokens first, then
+  skills, tags, summaries, author-declared aliases, and schema-field tokens first, then
   nucleo-matcher fuzzy fallback for typos and partial names. `mode: "exact"`
   falls back to the pre-#659 substring table.
 - `dcc_type`, `tags`, `loaded_only` — progressive filters. `loaded_only = false` surfaces unloaded skills as search hits so agents can discover `load_skill` candidates.
@@ -445,8 +445,13 @@ Rules:
   hit may mean the capability is absent, unloaded, or intentionally hidden by
   DCC, skill, or tool allowlists.
 - Gateway hits include `score` plus bounded `match_reasons` such as
-  `tool_lexical`, `summary_fuzzy`, `schema_fuzzy`, or `multi_token_lexical`
+  `tool_lexical`, `alias_lexical`, `schema_lexical`, `summary_fuzzy`,
+  `schema_fuzzy`, or `multi_token_lexical`
   so agents and maintainers can understand the rank without fetching schemas.
+- Full `input_schema` remains behind `describe`. Search may carry only bounded
+  `metadata.dcc.searchAliases` / `metadata.dcc.searchTokens` hints from a
+  per-DCC backend to the gateway index; gateway search responses do not expose
+  those internal index tokens as public fields.
 
 Response shape (gateway + per-DCC are identical):
 

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -37,6 +37,7 @@ metadata:
     layer: domain
     tags: [geometry, create]
     search-hint: "polygon modeling, sphere, bevel, extrude, mesh editing"
+    search-aliases: [primitive ball, mesh globe]
     tools: tools.yaml
 ---
 # Maya Geometry Skill
@@ -49,6 +50,7 @@ Use these tools to create and modify geometry in Maya.
 tools:
   - name: create_sphere
     description: Create a polygon sphere with the given radius.
+    search_aliases: [primitive ball, mesh globe]
     source_file: scripts/create_sphere.py
     annotations:
       read_only_hint: false
@@ -61,7 +63,7 @@ tools:
     source_file: scripts/export_fbx.bat
 ```
 
-The `metadata.dcc-mcp.search-hint` field provides comma-separated keywords for efficient skill discovery via `search_skills` without loading full tool schemas.
+The `metadata.dcc-mcp.search-hint` field provides comma-separated keywords for efficient skill discovery via `search_skills` without loading full tool schemas. Use bounded `metadata.dcc-mcp.search-aliases` and per-tool `search_aliases` in `tools.yaml` for domain synonyms, localized terms, or common user phrases that should improve gateway/per-DCC search recall without changing tool names, summaries, tags, or dispatch inputs.
 
 ### 3. Set Environment Variable
 
@@ -178,6 +180,8 @@ tools:
       properties:
         radius:
           type: number
+          description: Sphere radius in scene units
+    search_aliases: [primitive ball, mesh globe]
     outputSchema:
       type: object
       properties:
@@ -211,6 +215,7 @@ decl = ToolDeclaration(
 | `description` | `str` | `""` | Human-readable description |
 | `input_schema` | `str` (JSON) | `None` | JSON Schema for input parameters; YAML also accepts `inputSchema` |
 | `output_schema` | `str` (JSON) | `None` | JSON Schema for output; YAML also accepts `outputSchema` |
+| `search_aliases` | `List[str]` | `[]` | Bounded search-only synonyms. These are indexed for discovery with schema field names, but are not tool arguments and are not a replacement for a concise description. |
 | `read_only` | `bool` | `False` | Whether this tool only reads data |
 | `destructive` | `bool` | `False` | Whether this tool may cause destructive changes |
 | `idempotent` | `bool` | `False` | Whether calling with same args always produces same result |
@@ -999,9 +1004,10 @@ Calling an unloaded skill stub (`__skill__<name>`) returns an error with a hint:
 }
 ```
 
-Searches across: `name`, `description`, `search_hint`, `tags`, `dcc`, and the
-sibling `tools.yaml` entries (`name` + `description`). The `search_hint` field
-(from `metadata.dcc-mcp.search-hint`) improves keyword matching without loading full
+Searches across: `name`, `description`, `search_hint`, `search_aliases`,
+`tags`, `dcc`, and the sibling `tools.yaml` entries (`name`, `description`,
+and per-tool `search_aliases`). The `search_hint` field (from
+`metadata.dcc-mcp.search-hint`) improves keyword matching without loading full
 schemas.
 
 #### How `search_skills` ranks results
@@ -1022,8 +1028,10 @@ fuzzy match.
 | `dcc` (exact token match only)           | 4.0 |
 | `tags`                                   | 3.0 |
 | `search_hint`                            | 3.0 |
+| `search_aliases`                         | 3.0 |
 | `description`                            | 2.0 |
 | sibling tool names (from `tools.yaml`)   | 2.0 |
+| sibling tool search aliases              | 2.0 |
 | sibling tool descriptions                | 1.0 |
 
 **Scoring** — standard BM25 per query token with `k1=1.2`, `b=0.75`, document

--- a/docs/zh/guide/rest-api-surface.md
+++ b/docs/zh/guide/rest-api-surface.md
@@ -272,11 +272,14 @@ describe/call 路由、`/v1/call` 和 `/v1/call_batch` 默认仍返回旧版 JSO
 Gateway policy 会在返回最终搜索结果前过滤 capability。一个缺失的 hit 可能
 代表能力不存在、skill 未加载，或该能力被 DCC / skill / tool allowlist 有意隐藏。
 Gateway 默认 `mode: "fuzzy"` 使用 hybrid ranker：先对 tool name、skill、
-tag、summary 和 schema-field token 做加权 lexical 匹配，再用
+tag、summary、作者声明的 alias 和 schema-field token 做加权 lexical 匹配，再用
 nucleo-matcher fuzzy fallback 保留 typo / partial-name 容错；`mode: "exact"`
 仍是旧 substring 表。Gateway hit 会带 `score` 和 bounded `match_reasons`
-（例如 `tool_lexical`、`summary_fuzzy`、`schema_fuzzy`、
+（例如 `tool_lexical`、`alias_lexical`、`schema_lexical`、`summary_fuzzy`、`schema_fuzzy`、
 `multi_token_lexical`），让 agent 和维护者不取完整 schema 也能理解排序原因。
+完整 `input_schema` 仍只通过 `describe` 返回；搜索阶段只允许 per-DCC backend
+通过 bounded `metadata.dcc.searchAliases` / `metadata.dcc.searchTokens` 把小型
+索引提示交给 gateway，gateway 搜索响应不会把这些内部 token 暴露成公开字段。
 
 ```bash
 curl -H 'Accept: application/toon' \

--- a/docs/zh/guide/skills.md
+++ b/docs/zh/guide/skills.md
@@ -30,6 +30,7 @@ metadata:
     version: "1.0.0"
     tags: ["geometry", "create"]
     search-hint: "polygon modeling, sphere, bevel, extrude, mesh editing"
+    search-aliases: [primitive ball, mesh globe]
     tools: tools.yaml
 ---
 # Maya Geometry Skill
@@ -43,12 +44,19 @@ metadata:
 tools:
   - name: create_sphere
     description: "根据给定半径创建多边形球体"
+    search_aliases: [primitive ball, mesh globe]
     source_file: scripts/create_sphere.py
     read_only: false
   - name: export_fbx
     description: "将选中对象导出为 FBX"
     source_file: scripts/export_fbx.bat
 ```
+
+`metadata.dcc-mcp.search-hint` 提供不加载完整工具 schema 也能用于
+`search_skills` 的关键词。`metadata.dcc-mcp.search-aliases` 和 `tools.yaml`
+中的 per-tool `search_aliases` 用来声明有界的搜索同义词、本地化词或常见
+用户说法；它们只改善 gateway/per-DCC 搜索召回，不改变 tool name、summary、
+tag 或实际调用参数。
 
 ### 3. 设置环境变量
 
@@ -150,6 +158,7 @@ tools:
   - name: create_sphere
     description: "创建多边形球体"
     input_schema: '{"type":"object","properties":{"radius":{"type":"number"}}}'
+    search_aliases: [primitive ball, mesh globe]
     read_only: false
     destructive: false
     idempotent: false
@@ -178,6 +187,7 @@ decl = ToolDeclaration(
 | `description` | `str` | `""` | 人类可读的描述 |
 | `input_schema` | `str`（JSON）| `None` | 输入参数的 JSON Schema |
 | `output_schema` | `str`（JSON）| `None` | 输出的 JSON Schema |
+| `search_aliases` | `list[str]` | `[]` | 有界的搜索同义词；会和 schema 字段名一起参与发现索引，但不是工具参数，也不能替代简洁描述。 |
 | `read_only` | `bool` | `False` | 仅读取数据（无副作用）|
 | `destructive` | `bool` | `False` | 可能导致破坏性修改 |
 | `idempotent` | `bool` | `False` | 相同参数始终产生相同结果 |
@@ -492,7 +502,10 @@ def create_skill_server(
 }
 ```
 
-搜索范围：`name`、`description`、`search_hint`、`tool_names`。`search_hint` 字段（来自 SKILL.md `search-hint:`）无需加载完整 schema 即可改善关键词匹配。
+搜索范围：`name`、`description`、`search_hint`、`search_aliases`、`tags`、
+`dcc`，以及同级 `tools.yaml` 中的工具 `name`、`description` 和 per-tool
+`search_aliases`。`search_hint` 字段（来自 SKILL.md `search-hint:`）无需加载
+完整 schema 即可改善关键词匹配。
 
 `create_skill_server()` 启动时只调用 `discover()` — Skills **不会**自动加载。这保持了初始工具列表的精简，让 Agent 按需加载。
 

--- a/skills/dcc-mcp-skill-developer/SKILL.md
+++ b/skills/dcc-mcp-skill-developer/SKILL.md
@@ -49,6 +49,10 @@ into a faster authoring loop.
    safety annotations, and `timeout_hint_secs` for async tools.
    Published MCP tool names must be client-safe
    `^[A-Za-z0-9_-]{1,64}$`; use underscores instead of dotted tool names.
+   Use bounded `metadata.dcc-mcp.search-aliases` and per-tool
+   `search_aliases` in `tools.yaml` for domain synonyms, localized phrases, or
+   common user wording. Do not stuff long prose or schema dumps into tags or
+   summaries just to improve search recall.
 6. Treat `metadata.dcc-mcp.depends` as soft during discovery. Composition
    skills may remain searchable with `status: pending_deps` while host-specific
    dependencies are injected later through `DCC_MCP_*_SKILL_PATHS`. `load_skill`
@@ -88,12 +92,16 @@ into a faster authoring loop.
    per-result `token_accounting` metadata, and batch request items may carry an
    optional `id` that is echoed next to the numeric result `index`.
    Gateway search uses a hybrid ranker in default fuzzy mode: weighted lexical
-   matches over tool names, skill names, tags, summaries, and schema-field
-   tokens take precedence, while fuzzy fallback keeps typo tolerance. Search
+   matches over tool names, skill names, tags, summaries, author-declared
+   aliases, and bounded schema-field tokens take precedence, while fuzzy
+   fallback keeps typo tolerance. Search
    hits may include bounded `match_reasons` such as `tool_lexical`,
-   `summary_fuzzy`, `schema_fuzzy`, and `multi_token_lexical`; use those for
-   debugging relevance, but keep agent logic driven by `tool_slug`,
-   `next_step`, and `describe` rather than hard-coding a single reason string.
+   `alias_lexical`, `schema_lexical`, `summary_fuzzy`, `schema_fuzzy`, and
+   `multi_token_lexical`; use those for debugging relevance, but keep agent
+   logic driven by `tool_slug`, `next_step`, and `describe` rather than
+   hard-coding a single reason string. Full `input_schema` stays behind
+   `describe`; the search path may carry only bounded internal
+   `metadata.dcc.searchAliases` / `metadata.dcc.searchTokens` hints.
    Gateway capability policy is a deployment boundary, not an adapter-local
    convention. Read-only gateway mode still allows discovery and describe, but
    denies `load_skill`, `unload_skill`, tool-group changes, and backend calls


### PR DESCRIPTION
Closes #1178

## Summary
- add bounded skill/tool search aliases and schema-derived search tokens
- carry alias/schema tokens through per-DCC REST search into gateway capability ranking
- document alias authoring and update skill developer guidance

## Validation
- `vx cargo check -p dcc-mcp-actions -p dcc-mcp-models -p dcc-mcp-skills -p dcc-mcp-http-server -p dcc-mcp-skill-rest -p dcc-mcp-gateway-search -p dcc-mcp-gateway-core -p dcc-mcp-gateway`
- `vx cargo test -p dcc-mcp-models skill_metadata --lib`
- `vx cargo test -p dcc-mcp-skills metadata_compat --lib`
- `vx cargo test -p dcc-mcp-skill-rest --lib`
- `vx cargo test -p dcc-mcp-gateway-core capability::search --lib`
- `vx cargo test -p dcc-mcp-gateway capability::builder --lib`
- `vx cargo test -p dcc-mcp-gateway backend_client --lib`
- `vx cargo test -p dcc-mcp-actions --lib`
- `vx cargo test -p dcc-mcp-skills catalog::scoring --lib`
- `vx cargo clippy -p dcc-mcp-actions -p dcc-mcp-models -p dcc-mcp-skills -p dcc-mcp-skill-rest -p dcc-mcp-gateway-search -p dcc-mcp-gateway-core -p dcc-mcp-gateway --all-targets -- -D warnings`
- `vx npm run build` (admin-ui)
- `DCC_MCP_ADMIN_UI_PREBUILT=1 vx just dev`