### PR TITLE
feat: add gateway search quality telemetry

### DIFF
--- a/crates/dcc-mcp-gateway-core/src/capability/mod.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/mod.rs
@@ -44,7 +44,8 @@ pub use record::{
 };
 pub use refresh::RefreshReason;
 pub use search::{
-    DEFAULT_LIMIT, MAX_LIMIT, SearchHit, SearchMode, SearchPage, SearchQuery, search, search_page,
+    DEFAULT_LIMIT, MAX_LIMIT, RANKER_VERSION, SearchHit, SearchMode, SearchPage, SearchQuery,
+    search, search_page,
 };
 pub use search_ranking::{
     ExactScorer, FuzzyScorer, Scorer, ScorerFactory, SearchRecord, StrategyExactScorer,

--- a/crates/dcc-mcp-gateway-core/src/capability/search.rs
+++ b/crates/dcc-mcp-gateway-core/src/capability/search.rs
@@ -7,7 +7,9 @@
 use super::index::IndexSnapshot;
 use super::record::CapabilityRecord;
 
-pub use dcc_mcp_gateway_search::{DEFAULT_LIMIT, MAX_LIMIT, SearchMode, SearchQuery};
+pub use dcc_mcp_gateway_search::{
+    DEFAULT_LIMIT, MAX_LIMIT, RANKER_VERSION, SearchMode, SearchQuery,
+};
 
 /// One result row (flattened [`CapabilityRecord`] + score).
 pub type SearchHit = dcc_mcp_gateway_search::SearchHit<CapabilityRecord>;
@@ -139,11 +141,13 @@ mod tests {
                 false,
                 true,
             ),
+            rank: 1,
             score: 42,
             match_reasons: vec!["tool_exact".to_string()],
         };
         let v: serde_json::Value = serde_json::to_value(&hit).unwrap();
         assert_eq!(v["tool_slug"], "maya.abcdef01.create_sphere");
+        assert_eq!(v["rank"], 1);
         assert_eq!(v["score"], 42);
         assert_eq!(v["match_reasons"], serde_json::json!(["tool_exact"]));
         assert!(v.get("record").is_none());

--- a/crates/dcc-mcp-gateway-search/src/engine.rs
+++ b/crates/dcc-mcp-gateway-search/src/engine.rs
@@ -103,11 +103,14 @@ pub fn search_page<R: SearchRecord + Clone>(records: &[R], query: &SearchQuery) 
     let effective_limit = effective_limit(query.limit);
     let offset = query.offset.unwrap_or(0).min(total);
     let end = offset.saturating_add(effective_limit).min(total);
-    let page = if offset < total {
+    let mut page = if offset < total {
         hits[offset as usize..end as usize].to_vec()
     } else {
         Vec::new()
     };
+    for (idx, hit) in page.iter_mut().enumerate() {
+        hit.rank = offset + idx as u32 + 1;
+    }
 
     SearchPage {
         hits: page,
@@ -162,6 +165,7 @@ fn rank_multi<R: SearchRecord + Clone, S: Scorer>(
             };
             SearchHit {
                 record: (*r).clone(),
+                rank: 0,
                 score: breakdown.score,
                 match_reasons: breakdown.match_reasons,
             }

--- a/crates/dcc-mcp-gateway-search/src/lib.rs
+++ b/crates/dcc-mcp-gateway-search/src/lib.rs
@@ -19,7 +19,9 @@ mod ranking;
 mod record;
 
 pub use engine::{search, search_page};
-pub use query::{DEFAULT_LIMIT, MAX_LIMIT, SearchHit, SearchMode, SearchPage, SearchQuery};
+pub use query::{
+    DEFAULT_LIMIT, MAX_LIMIT, RANKER_VERSION, SearchHit, SearchMode, SearchPage, SearchQuery,
+};
 pub use ranking::{
     ExactScorer, FuzzyScorer, Scorer, ScorerFactory, StrategyExactScorer, StrategyFuzzyScorer,
     StrategyScorer, SubstringScorer,

--- a/crates/dcc-mcp-gateway-search/src/query.rs
+++ b/crates/dcc-mcp-gateway-search/src/query.rs
@@ -45,6 +45,11 @@ pub struct SearchQuery {
 pub const DEFAULT_LIMIT: u32 = 25;
 /// Upper bound on the number of results returned in a single page.
 pub const MAX_LIMIT: u32 = 100;
+/// Stable identifier for the current gateway ranking contract.
+///
+/// Bump this when score weights, match-reason vocabulary, or indexed fields
+/// change in ways that can affect search telemetry dashboards.
+pub const RANKER_VERSION: &str = "gateway-hybrid-v2";
 
 /// Score plus bounded explanation metadata for one ranking decision.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -64,10 +69,17 @@ pub struct ScoreBreakdown {
 pub struct SearchHit<R> {
     #[serde(flatten)]
     pub record: R,
+    /// 1-based rank within the full filtered result set, after scoring.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub rank: u32,
     pub score: u32,
     /// Stable, low-cardinality reasons explaining why the row matched.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub match_reasons: Vec<String>,
+}
+
+fn is_zero(value: &u32) -> bool {
+    *value == 0
 }
 
 /// Paginated search response envelope (issue #659).

--- a/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
@@ -1026,6 +1026,26 @@ pub async fn handle_admin_stats(
     }
 }
 
+/// `GET /admin/api/search-telemetry?limit=200` — recent search-quality
+/// records plus aggregate hit-rate metrics.
+pub async fn handle_admin_search_telemetry(
+    State(s): State<AdminState>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> impl IntoResponse {
+    let limit = params
+        .get("limit")
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(200)
+        .clamp(1, 1_000);
+    Json(
+        serde_json::to_value(s.gateway.search_telemetry.snapshot(limit)).unwrap_or(json!({
+            "stats": {},
+            "total": 0,
+            "recent": [],
+        })),
+    )
+}
+
 #[derive(Debug, Deserialize)]
 pub struct SkillPathAddBody {
     pub path: String,

--- a/crates/dcc-mcp-gateway/src/gateway/admin/router.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/router.rs
@@ -5,11 +5,11 @@ use axum::{Router, routing};
 use super::handlers::{
     handle_admin_activity, handle_admin_calls, handle_admin_debug_bundle,
     handle_admin_deregistered, handle_admin_health, handle_admin_instances,
-    handle_admin_issue_report, handle_admin_logs, handle_admin_skill_detail,
-    handle_admin_skill_path_add, handle_admin_skill_path_delete, handle_admin_skill_paths,
-    handle_admin_skills, handle_admin_stats, handle_admin_tasks, handle_admin_tools,
-    handle_admin_trace_detail, handle_admin_traces, handle_admin_ui, handle_admin_workers,
-    handle_v1_debug_trace_lookup,
+    handle_admin_issue_report, handle_admin_logs, handle_admin_search_telemetry,
+    handle_admin_skill_detail, handle_admin_skill_path_add, handle_admin_skill_path_delete,
+    handle_admin_skill_paths, handle_admin_skills, handle_admin_stats, handle_admin_tasks,
+    handle_admin_tools, handle_admin_trace_detail, handle_admin_traces, handle_admin_ui,
+    handle_admin_workers, handle_v1_debug_trace_lookup,
 };
 use super::state::AdminState;
 
@@ -68,6 +68,10 @@ pub fn build_admin_router(state: AdminState) -> Router {
         .route("/api/logs", routing::get(handle_admin_logs))
         .route("/api/deregistered", routing::get(handle_admin_deregistered))
         .route("/api/stats", routing::get(handle_admin_stats))
+        .route(
+            "/api/search-telemetry",
+            routing::get(handle_admin_search_telemetry),
+        )
         .route("/api/workers", routing::get(handle_admin_workers))
         .route("/api/health", routing::get(handle_admin_health))
         .with_state(state)
@@ -103,6 +107,10 @@ pub fn build_v1_debug_router(state: AdminState) -> Router {
             routing::get(handle_admin_deregistered),
         )
         .route("/v1/debug/stats", routing::get(handle_admin_stats))
+        .route(
+            "/v1/debug/search-telemetry",
+            routing::get(handle_admin_search_telemetry),
+        )
         .route("/v1/debug/health", routing::get(handle_admin_health))
         .with_state(state)
 }

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -17,7 +17,7 @@ mod admin_tests {
 
     use dcc_mcp_gateway_core::naming::instance_short;
 
-    use crate::gateway::admin::router::build_admin_router;
+    use crate::gateway::admin::router::{build_admin_router, build_v1_debug_router};
     use crate::gateway::admin::state::{AdminAuditRecord, AdminState, AuditLog};
     use crate::gateway::router::build_gateway_router_with_admin;
     use crate::gateway::state::GatewayState;
@@ -129,6 +129,9 @@ mod admin_tests {
                 crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
             ),
             traffic_capture: Arc::new(crate::gateway::traffic::TrafficCapture::disabled()),
+            search_telemetry: Arc::new(
+                crate::gateway::search_telemetry::SearchTelemetryStore::new(),
+            ),
             debug_routes_enabled: false,
         }
     }
@@ -744,6 +747,70 @@ mod admin_tests {
             "expected trace event in activity payload"
         );
         assert_eq!(body["total"].as_u64(), Some(events.len() as u64));
+    }
+
+    #[tokio::test]
+    async fn test_admin_search_telemetry_exposes_prompt_safe_stats() {
+        use crate::gateway::search_telemetry::{
+            RANKER_VERSION, SearchFollowupInput, SearchTelemetryHit, SearchTelemetryInput,
+            SearchTelemetryStore,
+        };
+
+        let gs = make_gateway_state();
+        let search_id = SearchTelemetryStore::new_search_id();
+        gs.search_telemetry.record_search(SearchTelemetryInput {
+            search_id: search_id.clone(),
+            transport: "rest".to_string(),
+            kind: "tool".to_string(),
+            query: "token=abc123 render".to_string(),
+            dcc_type: Some("maya".to_string()),
+            instance_id: None,
+            limit: Some(5),
+            total: 1,
+            ranker_version: RANKER_VERSION.to_string(),
+            index_generation: "idx-admin".to_string(),
+            hits: vec![SearchTelemetryHit {
+                tool_slug: "maya.abcdef01.render_frame".to_string(),
+                skill_name: Some("maya-render".to_string()),
+                dcc_type: "maya".to_string(),
+                rank: 1,
+                score: 100,
+                match_reasons: vec!["tool_lexical".to_string()],
+                loaded: true,
+            }],
+            trace_context: None,
+            session_id: None,
+        });
+        assert!(gs.search_telemetry.record_followup(SearchFollowupInput {
+            search_id,
+            kind: "call".to_string(),
+            tool_slug: Some("maya.abcdef01.render_frame".to_string()),
+            skill_name: None,
+            success: true,
+            trace_context: None,
+        }));
+
+        let state = AdminState::new(gs);
+        let (admin_status, admin_body) = body_json(
+            build_admin_router(state.clone()),
+            "/api/search-telemetry?limit=5",
+        )
+        .await;
+        assert_eq!(admin_status, StatusCode::OK);
+        assert_eq!(admin_body["stats"]["total_searches"], 1);
+        assert_eq!(admin_body["stats"]["success_after_search_rate"], 1.0);
+        assert_eq!(
+            admin_body["recent"][0]["query_preview"],
+            "[redacted] render"
+        );
+
+        let (debug_status, debug_body) = body_json(
+            build_v1_debug_router(state),
+            "/v1/debug/search-telemetry?limit=5",
+        )
+        .await;
+        assert_eq!(debug_status, StatusCode::OK);
+        assert_eq!(debug_body["stats"]["top1_hit_rate"], 1.0);
     }
 
     #[tokio::test]

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/call.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/call.rs
@@ -20,8 +20,12 @@ pub async fn route_tools_call(
 ) -> (String, bool) {
     // ── Advertised gateway surface (read-only) ───────────────────────
     match tool {
-        "search" => return to_text_result(tool_search(gs, args).await),
-        "describe" => return to_text_result(tool_describe(gs, args).await),
+        "search" => {
+            return to_text_result(
+                tool_search(gs, args, meta, trace_context, _client_session_id).await,
+            );
+        }
+        "describe" => return to_text_result(tool_describe(gs, args, meta, trace_context).await),
         _ => {}
     }
 
@@ -29,7 +33,17 @@ pub async fn route_tools_call(
     match tool {
         "call" => return tool_call(gs, args, meta, trace_context).await,
         "lease" => return to_text_result(tool_lease(gs, args).await),
-        "load_skill" => return tool_load_skill(gs, args).await,
+        "load_skill" => {
+            let (text, is_error) = tool_load_skill(gs, args).await;
+            crate::gateway::tools::record_load_skill_search_followup(
+                gs,
+                args,
+                meta,
+                trace_context,
+                !is_error,
+            );
+            return (text, is_error);
+        }
         "unload_skill" => return skill_mgmt_dispatch(gs, "unload_skill", args).await,
         _ => {}
     }
@@ -38,8 +52,14 @@ pub async fn route_tools_call(
     match tool {
         "acquire_dcc_instance" => return to_text_result(tool_acquire_instance(gs, args).await),
         "release_dcc_instance" => return to_text_result(tool_release_instance(gs, args).await),
-        "search_tools" => return to_text_result(tool_search_tools(gs, args).await),
-        "describe_tool" => return to_text_result(tool_describe_tool(gs, args).await),
+        "search_tools" => {
+            return to_text_result(
+                tool_search_tools(gs, args, trace_context, _client_session_id).await,
+            );
+        }
+        "describe_tool" => {
+            return to_text_result(tool_describe_tool(gs, args, meta, trace_context).await);
+        }
         "call_tool" => return tool_call_tool(gs, args, meta, trace_context).await,
         "call_tools" => return tool_call_tools(gs, args, meta, trace_context).await,
         _ => {}

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/skill_mgmt.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/skill_mgmt.rs
@@ -34,6 +34,7 @@ pub(crate) async fn skill_mgmt_dispatch(
         "load_skill" | "unload_skill" | "activate_tool_group" | "deactivate_tool_group" => {
             match resolve_target(gs, target_instance, dcc_filter).await {
                 Ok(entry) => {
+                    let search_id = crate::gateway::search_telemetry::search_id_from_payload(&args);
                     let skill_names = requested_skill_names(&args);
                     if let Err(denial) = gs.policy.enforce_skill_operation(
                         GatewayPolicyOperation::LoadSkill,
@@ -46,6 +47,8 @@ pub(crate) async fn skill_mgmt_dispatch(
                     let mut forward_args = args.clone();
                     if let Some(obj) = forward_args.as_object_mut() {
                         obj.remove("instance_id");
+                        obj.remove("meta");
+                        obj.remove("_meta");
                         if tool == "load_skill" && !obj.contains_key("activate_groups") {
                             obj.insert("activate_groups".to_string(), Value::Bool(false));
                         }
@@ -104,7 +107,13 @@ pub(crate) async fn skill_mgmt_dispatch(
                                 }
                             }
                             let text = if !is_error && tool == "load_skill" {
-                                decorate_load_skill_success(gs, &entry, &forward_args, &text)
+                                decorate_load_skill_success(
+                                    gs,
+                                    &entry,
+                                    &forward_args,
+                                    &text,
+                                    search_id.as_deref(),
+                                )
                             } else {
                                 text
                             };
@@ -454,6 +463,7 @@ fn decorate_load_skill_success(
     entry: &ServiceEntry,
     forwarded_args: &Value,
     text: &str,
+    search_id: Option<&str>,
 ) -> String {
     let mut payload = serde_json::from_str::<Value>(text).unwrap_or_else(|_| {
         json!({
@@ -529,6 +539,8 @@ fn decorate_load_skill_success(
             .and_then(Value::as_array)
             .and_then(|items| items.first())
             .and_then(Value::as_str),
+        search_id,
+        obj.get("index_generation").and_then(Value::as_str),
     );
     obj.insert("next_step".to_string(), next_step);
 
@@ -565,15 +577,19 @@ fn suggested_post_load_next_step(
     dcc_type: &str,
     instance_id: Uuid,
     first_tool_slug: Option<&str>,
+    search_id: Option<&str>,
+    index_generation: Option<&str>,
 ) -> Value {
     if let Some(tool_slug) = first_tool_slug {
-        let arguments = json!({ "tool_slug": tool_slug });
+        let mut arguments = json!({ "tool_slug": tool_slug });
+        attach_search_meta(&mut arguments, search_id, index_generation);
         return json!({
             "action": "describe",
             "arguments": arguments.clone(),
             "mcp": {
                 "tool": "describe",
                 "arguments": arguments.clone(),
+                "_meta": arguments.get("meta").cloned().unwrap_or(Value::Null),
             },
             "rest": {
                 "method": "POST",
@@ -583,19 +599,21 @@ fn suggested_post_load_next_step(
         });
     }
 
-    let arguments = json!({
+    let mut arguments = json!({
         "query": skill_name.unwrap_or_default(),
         "skill_hint": skill_name.unwrap_or_default(),
         "dcc_type": dcc_type,
         "instance_id": instance_id.to_string(),
         "loaded_only": true,
     });
+    attach_search_meta(&mut arguments, search_id, index_generation);
     json!({
         "action": "search",
         "arguments": arguments.clone(),
         "mcp": {
             "tool": "search",
             "arguments": arguments.clone(),
+            "_meta": arguments.get("meta").cloned().unwrap_or(Value::Null),
         },
         "rest": {
             "method": "POST",
@@ -603,4 +621,24 @@ fn suggested_post_load_next_step(
             "body": arguments,
         },
     })
+}
+
+fn attach_search_meta(
+    arguments: &mut Value,
+    search_id: Option<&str>,
+    index_generation: Option<&str>,
+) {
+    let Some(search_id) = search_id else {
+        return;
+    };
+    let mut meta = json!({
+        "search_id": search_id,
+        "ranker_version": crate::gateway::search_telemetry::RANKER_VERSION,
+    });
+    if let Some(generation) = index_generation.filter(|value| !value.is_empty()) {
+        meta["index_generation"] = json!(generation);
+    }
+    if let Some(obj) = arguments.as_object_mut() {
+        obj.insert("meta".to_string(), meta);
+    }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/tests.rs
@@ -158,6 +158,9 @@ async fn aggregate_tools_list_returns_only_minimal_gateway_surface() {
             crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
         ),
         traffic_capture: std::sync::Arc::new(crate::gateway::traffic::TrafficCapture::disabled()),
+        search_telemetry: std::sync::Arc::new(
+            crate::gateway::search_telemetry::SearchTelemetryStore::new(),
+        ),
         debug_routes_enabled: false,
     };
 
@@ -319,6 +322,9 @@ async fn make_gateway_state(
             crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
         ),
         traffic_capture: std::sync::Arc::new(crate::gateway::traffic::TrafficCapture::disabled()),
+        search_telemetry: std::sync::Arc::new(
+            crate::gateway::search_telemetry::SearchTelemetryStore::new(),
+        ),
         debug_routes_enabled: false,
     }
 }
@@ -1187,6 +1193,9 @@ async fn gateway_state_with_instances(
             crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
         ),
         traffic_capture: std::sync::Arc::new(crate::gateway::traffic::TrafficCapture::disabled()),
+        search_telemetry: std::sync::Arc::new(
+            crate::gateway::search_telemetry::SearchTelemetryStore::new(),
+        ),
         debug_routes_enabled: false,
     };
     (state, dir, ids)

--- a/crates/dcc-mcp-gateway/src/gateway/capability/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/mod.rs
@@ -72,7 +72,8 @@ pub use record::{
 };
 pub use refresh::{RefreshReason, refresh_instance, remove_instance};
 pub use search::{
-    DEFAULT_LIMIT, MAX_LIMIT, SearchHit, SearchMode, SearchPage, SearchQuery, search, search_page,
+    DEFAULT_LIMIT, MAX_LIMIT, RANKER_VERSION, SearchHit, SearchMode, SearchPage, SearchQuery,
+    search, search_page,
 };
 // Ranking strategies migrated to `dcc-mcp-gateway-core::capability::
 // search_ranking` (issue #845). Re-exported here so historical paths

--- a/crates/dcc-mcp-gateway/src/gateway/capability/search.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability/search.rs
@@ -7,5 +7,6 @@
 //! path for source compatibility.
 
 pub use dcc_mcp_gateway_core::capability::search::{
-    DEFAULT_LIMIT, MAX_LIMIT, SearchHit, SearchMode, SearchPage, SearchQuery, search, search_page,
+    DEFAULT_LIMIT, MAX_LIMIT, RANKER_VERSION, SearchHit, SearchMode, SearchPage, SearchQuery,
+    search, search_page,
 };

--- a/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
@@ -28,11 +28,30 @@ use crate::gateway::admin::trace::TraceContext;
 
 use super::backend_client::{ForwardToolsCallRequest, forward_tools_call, try_describe_tool};
 use super::capability::{
-    CapabilityIndex, CapabilityRecord, RefreshReason, SearchHit, SearchQuery, parse_slug,
-    refresh_instance, remove_instance, search,
+    CapabilityIndex, CapabilityRecord, RANKER_VERSION, RefreshReason, SearchHit, SearchQuery,
+    parse_slug, refresh_instance, remove_instance, search,
 };
 use super::state::GatewayState;
 use dcc_mcp_gateway_core::naming::instance_short;
+
+/// Metadata attached to one gateway search response for follow-up correlation.
+#[derive(Debug, Clone)]
+pub struct SearchResponseContext {
+    pub search_id: String,
+    pub ranker_version: &'static str,
+    pub index_generation: String,
+}
+
+impl SearchResponseContext {
+    #[must_use]
+    pub fn new(search_id: String, index_generation: String) -> Self {
+        Self {
+            search_id,
+            ranker_version: RANKER_VERSION,
+            index_generation,
+        }
+    }
+}
 
 /// Shape of a structured error emitted by the call / describe paths.
 ///
@@ -135,6 +154,21 @@ pub fn search_service_rows_for_policy(
     query: &SearchQuery,
     policy: &GatewayPolicy,
 ) -> Vec<Value> {
+    search_service_hits_for_policy(index, query, policy)
+        .into_iter()
+        .map(search_hit_to_value)
+        .collect()
+}
+
+pub fn search_hit_to_value(hit: SearchHit) -> Value {
+    search_hit_to_value_with_context(hit, None)
+}
+
+pub fn search_service_hits_for_policy(
+    index: &CapabilityIndex,
+    query: &SearchQuery,
+    policy: &GatewayPolicy,
+) -> Vec<SearchHit> {
     search_service(index, query)
         .into_iter()
         .filter(|hit| {
@@ -142,27 +176,43 @@ pub fn search_service_rows_for_policy(
                 .enforce_record(GatewayPolicyOperation::Search, &hit.record)
                 .is_ok()
         })
-        .map(search_hit_to_value)
         .collect()
 }
 
-pub fn search_hit_to_value(hit: SearchHit) -> Value {
+pub fn search_service_rows_for_policy_with_context(
+    index: &CapabilityIndex,
+    query: &SearchQuery,
+    policy: &GatewayPolicy,
+    context: &SearchResponseContext,
+) -> Vec<Value> {
+    search_service_hits_for_policy(index, query, policy)
+        .into_iter()
+        .map(|hit| search_hit_to_value_with_context(hit, Some(context)))
+        .collect()
+}
+
+pub fn search_hit_to_value_with_context(
+    hit: SearchHit,
+    context: Option<&SearchResponseContext>,
+) -> Value {
     let mut value = serde_json::to_value(&hit).unwrap_or(Value::Null);
     if !hit.record.loaded {
         value["load_state"] = json!("unloaded");
         if let Some(skill_name) = &hit.record.skill_name {
-            let arguments = json!({
+            let mut arguments = json!({
                 "skill_name": skill_name,
                 "dcc": &hit.record.dcc_type,
                 "dcc_type": &hit.record.dcc_type,
                 "instance_id": hit.record.instance_id.to_string(),
             });
+            attach_search_meta(&mut arguments, context);
             value["next_step"] = json!({
                 "action": "load_skill",
                 "arguments": arguments.clone(),
                 "mcp": {
                     "tool": "load_skill",
                     "arguments": arguments.clone(),
+                    "_meta": search_meta(context),
                 },
                 "rest": {
                     "method": "POST",
@@ -173,8 +223,45 @@ pub fn search_hit_to_value(hit: SearchHit) -> Value {
         }
     } else if hit.record.loaded {
         value["load_state"] = json!("loaded");
+        let mut arguments = json!({
+            "tool_slug": hit.record.tool_slug,
+        });
+        attach_search_meta(&mut arguments, context);
+        value["next_step"] = json!({
+            "action": "describe",
+            "arguments": arguments.clone(),
+            "mcp": {
+                "tool": "describe",
+                "arguments": arguments.clone(),
+                "_meta": search_meta(context),
+            },
+            "rest": {
+                "method": "POST",
+                "path": "/v1/describe",
+                "body": arguments,
+            },
+        });
     }
     value
+}
+
+fn attach_search_meta(arguments: &mut Value, context: Option<&SearchResponseContext>) {
+    let Some(meta) = search_meta(context) else {
+        return;
+    };
+    if let Some(obj) = arguments.as_object_mut() {
+        obj.insert("meta".to_string(), meta);
+    }
+}
+
+fn search_meta(context: Option<&SearchResponseContext>) -> Option<Value> {
+    context.map(|ctx| {
+        json!({
+            "search_id": ctx.search_id,
+            "ranker_version": ctx.ranker_version,
+            "index_generation": ctx.index_generation,
+        })
+    })
 }
 
 /// Compute a stable, compact fingerprint for the current capability index.

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/debug_openapi.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/debug_openapi.rs
@@ -136,6 +136,12 @@ pub(crate) fn add_gateway_debug_openapi_paths(doc: &mut Value) {
             )],
         ),
         (
+            "/v1/debug/search-telemetry",
+            "Get search-quality telemetry",
+            "Recent prompt-safe search records and aggregate search-to-describe/load/call hit-rate metrics.",
+            limit_params.clone(),
+        ),
+        (
             "/v1/debug/health",
             "Get debug subsystem health",
             "Compact health and readiness summary for debug providers.",

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/mod.rs
@@ -30,6 +30,7 @@ mod notification_impl;
 mod proxy_impl;
 pub(crate) mod resources;
 mod rest_impl;
+mod rest_support;
 mod sse_impl;
 
 pub use lifecycle_impl::handle_v1_dcc_instance_stop;

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/resources.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/resources.rs
@@ -291,6 +291,9 @@ mod tests {
                 crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
             ),
             traffic_capture: Arc::new(crate::gateway::traffic::TrafficCapture::disabled()),
+            search_telemetry: Arc::new(
+                crate::gateway::search_telemetry::SearchTelemetryStore::new(),
+            ),
             debug_routes_enabled: false,
             #[cfg(feature = "prometheus")]
             gateway_metrics: Arc::new(crate::gateway::event_log::GatewayMetrics::new()),

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
@@ -3,13 +3,14 @@ use super::*;
 use crate::gateway::admin::trace::TraceContext;
 use crate::gateway::capability::{RefreshReason, parse_slug, tool_slug};
 use crate::gateway::capability_service::{
-    ServiceError, call_service, describe_tool_full, index_generation, parse_search_payload,
-    refresh_all_live_backends, search_service_rows_for_policy, service_error_to_json,
+    SearchResponseContext, ServiceError, call_service, describe_tool_full, index_generation,
+    parse_search_payload, refresh_all_live_backends, search_hit_to_value_with_context,
+    search_service_hits_for_policy, service_error_to_json,
 };
-use crate::gateway::response_codec::{
-    compact_call_batch_payload, compact_describe_payload, compact_search_payload,
-    negotiated_response,
-};
+use crate::gateway::response_codec::{compact_call_batch_payload, compact_describe_payload};
+use crate::gateway::search_telemetry::{SearchTelemetryInput, search_id_from_payload};
+
+use super::rest_support::*;
 
 #[derive(Debug, Deserialize)]
 pub struct DccInstanceDescribeQuery {
@@ -344,9 +345,38 @@ pub async fn handle_v1_search(
             }
         }
     }
-    let hits = search_service_rows_for_policy(&gs.capability_index, &query, &gs.policy);
+    let index_generation = index_generation(&gs.capability_index);
+    let search_context = SearchResponseContext::new(
+        crate::gateway::search_telemetry::SearchTelemetryStore::new_search_id(),
+        index_generation,
+    );
+    let hits = search_service_hits_for_policy(&gs.capability_index, &query, &gs.policy);
+    let telemetry_hits = search_hits_for_telemetry(&hits);
+    let hits: Vec<Value> = hits
+        .into_iter()
+        .map(|hit| search_hit_to_value_with_context(hit, Some(&search_context)))
+        .collect();
+    gs.search_telemetry.record_search(SearchTelemetryInput {
+        search_id: search_context.search_id.clone(),
+        transport: "rest".to_string(),
+        kind: "tool".to_string(),
+        query: query.query.clone(),
+        dcc_type: query.dcc_type.clone(),
+        instance_id: query.instance_id.map(|id| id.to_string()),
+        limit: query.limit,
+        total: hits.len(),
+        ranker_version: search_context.ranker_version.to_string(),
+        index_generation: search_context.index_generation.clone(),
+        hits: telemetry_hits,
+        trace_context: Some(trace_context.clone()),
+        session_id: session_id_from_headers(&headers),
+    });
     let metadata = RestResponseMetadata::from_trace_context(&trace_context)
-        .with_index_generation(index_generation(&gs.capability_index));
+        .with_index_generation(search_context.index_generation.clone())
+        .with_search(
+            search_context.search_id.clone(),
+            search_context.ranker_version.to_string(),
+        );
     search_response_with_metadata(&headers, &body, hits, &metadata)
 }
 
@@ -376,7 +406,19 @@ async fn skill_lifecycle_response(
     body: Value,
 ) -> Response {
     let trace_context = TraceContext::from_headers(headers);
+    let search_id = search_id_from_payload(&body);
     let (text, is_error) = crate::gateway::aggregator::skill_mgmt_dispatch(gs, tool, &body).await;
+    if tool == "load_skill" {
+        record_search_followup(
+            gs,
+            search_id.as_deref(),
+            "load_skill",
+            None,
+            skill_name_from_payload(&body),
+            !is_error,
+            &trace_context,
+        );
+    }
     let metadata = RestResponseMetadata::from_trace_context(&trace_context)
         .with_index_generation(index_generation(&gs.capability_index));
     if is_error {
@@ -499,12 +541,33 @@ async fn describe_slug_response(
     slug: &str,
     metadata: &RestResponseMetadata,
 ) -> Response {
+    let search_id = search_id_from_payload(body);
     match describe_tool_full(gs, slug).await {
         Ok((record, tool)) => {
-            let legacy = json!({
+            record_search_followup(
+                gs,
+                search_id.as_deref(),
+                "describe",
+                Some(slug),
+                None,
+                true,
+                &TraceContext {
+                    trace_id: metadata.trace_id.clone(),
+                    request_id: metadata.request_id.clone(),
+                    span_id: None,
+                    parent_span_id: None,
+                    parent_request_id: None,
+                    trace_flags: None,
+                    trace_state: None,
+                },
+            );
+            let mut legacy = json!({
                 "record": record,
                 "tool": tool,
             });
+            if let Some(search_id) = search_id.as_deref() {
+                legacy["next_step"] = call_next_step(slug, search_id, metadata);
+            }
             let compact = compact_describe_payload(&legacy);
             negotiated_response_with_metadata(
                 headers,
@@ -516,7 +579,26 @@ async fn describe_slug_response(
                 true,
             )
         }
-        Err(err) => service_error_response_with_metadata(headers, body, &err, metadata, true),
+        Err(err) => {
+            record_search_followup(
+                gs,
+                search_id.as_deref(),
+                "describe",
+                Some(slug),
+                None,
+                false,
+                &TraceContext {
+                    trace_id: metadata.trace_id.clone(),
+                    request_id: metadata.request_id.clone(),
+                    span_id: None,
+                    parent_span_id: None,
+                    parent_request_id: None,
+                    trace_flags: None,
+                    trace_state: None,
+                },
+            );
+            service_error_response_with_metadata(headers, body, &err, metadata, true)
+        }
     }
 }
 
@@ -882,6 +964,7 @@ async fn call_service_with_admin_trace(
         request_body,
         trace_context,
     } = request;
+    let search_id = search_id_from_payload(request_body);
 
     let mut ctx = CallContext::new(method, trace_context.request_id.clone(), arguments.clone())
         .with_tool_slug(slug)
@@ -949,6 +1032,15 @@ async fn call_service_with_admin_trace(
     }
 
     let response_ns = now_ns();
+    record_search_followup(
+        gs,
+        search_id.as_deref(),
+        "call",
+        Some(slug),
+        None,
+        result.is_ok(),
+        &ctx.trace_context,
+    );
     let (preview_text, is_error, output_value) = match &result {
         Ok(value) => (
             serde_json::to_string(value).unwrap_or_default(),
@@ -1104,235 +1196,6 @@ async fn call_batch_with_admin_trace(
     );
 
     result
-}
-
-#[derive(Debug, Clone)]
-struct RestResponseMetadata {
-    request_id: String,
-    trace_id: String,
-    traceparent: Option<String>,
-    index_generation: Option<String>,
-}
-
-impl RestResponseMetadata {
-    fn from_headers(headers: &HeaderMap) -> Self {
-        Self::from_trace_context(&TraceContext::from_headers(headers))
-    }
-
-    fn from_trace_context(trace_context: &TraceContext) -> Self {
-        Self {
-            request_id: trace_context.request_id.clone(),
-            trace_id: trace_context.trace_id.clone(),
-            traceparent: trace_context.traceparent(),
-            index_generation: None,
-        }
-    }
-
-    fn with_index_generation(mut self, generation: String) -> Self {
-        if !generation.is_empty() {
-            self.index_generation = Some(generation);
-        }
-        self
-    }
-
-    fn insert_body_fields(&self, value: &mut Value) {
-        if let Some(obj) = value.as_object_mut() {
-            obj.entry("request_id".to_string())
-                .or_insert_with(|| json!(self.request_id));
-            obj.entry("trace_id".to_string())
-                .or_insert_with(|| json!(self.trace_id));
-            if let Some(generation) = self.index_generation.as_deref() {
-                obj.entry("index_generation".to_string())
-                    .or_insert_with(|| json!(generation));
-            }
-        }
-    }
-
-    fn attach_headers(&self, headers: &mut HeaderMap) {
-        insert_header(
-            headers,
-            crate::gateway::response_codec::HEADER_REQUEST_ID,
-            &self.request_id,
-        );
-        insert_header(headers, "x-request-id", &self.request_id);
-        insert_header(
-            headers,
-            crate::gateway::response_codec::HEADER_TRACE_ID,
-            &self.trace_id,
-        );
-        if let Some(traceparent) = self.traceparent.as_deref() {
-            insert_header(headers, "traceparent", traceparent);
-        }
-        if let Some(generation) = self.index_generation.as_deref() {
-            insert_header(
-                headers,
-                crate::gateway::response_codec::HEADER_INDEX_GENERATION,
-                generation,
-            );
-        }
-    }
-}
-
-fn insert_header(headers: &mut HeaderMap, name: &'static str, value: &str) {
-    if let Ok(value) = axum::http::HeaderValue::from_str(value) {
-        headers.insert(name, value);
-    }
-}
-
-fn negotiated_response_with_metadata(
-    headers: &HeaderMap,
-    request_body: &Value,
-    status: StatusCode,
-    mut legacy_json: Value,
-    compact_json: Option<Value>,
-    metadata: &RestResponseMetadata,
-    include_body_metadata: bool,
-) -> Response {
-    let mut compact_json = compact_json;
-    if include_body_metadata {
-        metadata.insert_body_fields(&mut legacy_json);
-        if let Some(compact) = compact_json.as_mut() {
-            metadata.insert_body_fields(compact);
-        }
-    }
-    let mut response =
-        negotiated_response(headers, request_body, status, legacy_json, compact_json);
-    metadata.attach_headers(response.headers_mut());
-    response
-}
-
-fn search_response_with_metadata(
-    headers: &HeaderMap,
-    body: &Value,
-    hits: Vec<Value>,
-    metadata: &RestResponseMetadata,
-) -> Response {
-    let total = hits.len();
-    let mut legacy = json!({
-        "total": total,
-        "hits": hits,
-    });
-    metadata.insert_body_fields(&mut legacy);
-    let mut compact = compact_search_payload(
-        total,
-        legacy["hits"]
-            .as_array()
-            .map(Vec::as_slice)
-            .unwrap_or_default(),
-    );
-    metadata.insert_body_fields(&mut compact);
-    negotiated_response_with_metadata(
-        headers,
-        body,
-        StatusCode::OK,
-        legacy,
-        Some(compact),
-        metadata,
-        false,
-    )
-}
-
-struct RestTrafficFrame<'a> {
-    path: &'a str,
-    direction: &'static str,
-    leg: &'static str,
-    status: Option<u16>,
-    body: Value,
-}
-
-fn emit_rest_traffic_frame(
-    gs: &GatewayState,
-    ctx: &crate::gateway::middleware::CallContext,
-    headers: &HeaderMap,
-    frame: RestTrafficFrame<'_>,
-) {
-    gs.traffic_capture.emit_json_frame(
-        crate::gateway::traffic::TrafficFrame::json(
-            crate::gateway::traffic::gateway_source(
-                &gs.server_name,
-                &gs.server_version,
-                &gs.own_host,
-                gs.own_port,
-            ),
-            crate::gateway::traffic::correlation(
-                Some(&ctx.trace_context.request_id),
-                Some(&ctx.trace_context.trace_id),
-                ctx.session_id.as_deref(),
-            ),
-            frame.direction,
-            frame.leg,
-            "http",
-            frame.body,
-        )
-        .with_session_id(ctx.session_id.as_deref())
-        .with_http(crate::gateway::traffic::http_post(
-            frame.path,
-            Some(headers),
-            frame.status,
-        ))
-        .with_mcp(crate::gateway::traffic::mcp_message(
-            if frame.direction == "inbound" {
-                "request"
-            } else {
-                "response"
-            },
-            "tools/call",
-            None,
-        )),
-    );
-}
-
-fn session_id_from_headers(headers: &HeaderMap) -> Option<String> {
-    header_string(headers, "mcp-session-id")
-        .or_else(|| header_string(headers, "x-session-id"))
-        .or_else(|| header_string(headers, "x-dcc-mcp-session-id"))
-}
-
-fn header_string(headers: &HeaderMap, name: &str) -> Option<String> {
-    headers
-        .get(name)
-        .and_then(|value| value.to_str().ok())
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_string)
-}
-
-fn now_ns() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::SystemTime::UNIX_EPOCH)
-        .map(|d| d.as_nanos() as u64)
-        .unwrap_or(0)
-}
-
-fn service_error_status(err: &ServiceError) -> StatusCode {
-    match err.kind.as_str() {
-        "unknown-slug" => StatusCode::NOT_FOUND,
-        "ambiguous" => StatusCode::CONFLICT,
-        "instance-offline" => StatusCode::SERVICE_UNAVAILABLE,
-        "policy-denied" => StatusCode::FORBIDDEN,
-        "host-busy" => StatusCode::SERVICE_UNAVAILABLE,
-        "host-died" => StatusCode::BAD_GATEWAY,
-        "backend-error" | "schema-unavailable" => StatusCode::BAD_GATEWAY,
-        _ => StatusCode::BAD_REQUEST,
-    }
-}
-
-fn service_error_response_with_metadata(
-    headers: &HeaderMap,
-    body: &Value,
-    err: &ServiceError,
-    metadata: &RestResponseMetadata,
-    include_body_metadata: bool,
-) -> Response {
-    negotiated_response_with_metadata(
-        headers,
-        body,
-        service_error_status(err),
-        service_error_to_json(err),
-        None,
-        metadata,
-        include_body_metadata,
-    )
 }
 
 #[cfg(test)]

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
@@ -77,6 +77,7 @@ fn test_gateway_state_with_debug_routes(
             crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
         ),
         traffic_capture: Arc::new(crate::gateway::traffic::TrafficCapture::disabled()),
+        search_telemetry: Arc::new(crate::gateway::search_telemetry::SearchTelemetryStore::new()),
         debug_routes_enabled,
         #[cfg(feature = "prometheus")]
         gateway_metrics: Arc::new(crate::gateway::event_log::GatewayMetrics::new()),
@@ -475,6 +476,7 @@ async fn gateway_openapi_lists_stable_debug_routes() {
         "/v1/debug/logs",
         "/v1/debug/deregistered",
         "/v1/debug/stats",
+        "/v1/debug/search-telemetry",
         "/v1/debug/health",
     ] {
         assert!(
@@ -561,16 +563,42 @@ async fn gateway_rest_workflow_responses_expose_trace_and_index_metadata() {
     assert_eq!(status, StatusCode::OK);
     assert_trace_headers(&response_headers);
     assert_body_metadata(&search);
+    let search_id = search["search_id"]
+        .as_str()
+        .expect("search response should expose search_id")
+        .to_string();
+    assert_eq!(
+        response_headers
+            .get(crate::gateway::response_codec::HEADER_SEARCH_ID)
+            .and_then(|value| value.to_str().ok()),
+        Some(search_id.as_str())
+    );
+    assert_eq!(
+        response_headers
+            .get(crate::gateway::response_codec::HEADER_RANKER_VERSION)
+            .and_then(|value| value.to_str().ok()),
+        Some(crate::gateway::search_telemetry::RANKER_VERSION)
+    );
+    assert_eq!(
+        search["ranker_version"],
+        crate::gateway::search_telemetry::RANKER_VERSION
+    );
+    assert_eq!(search["hits"][0]["rank"], 1);
+    assert_eq!(
+        search["hits"][0]["next_step"]["arguments"]["meta"]["search_id"],
+        search_id
+    );
     let slug = search["hits"][0]["tool_slug"]
         .as_str()
         .expect("search should return seeded render capability")
         .to_string();
+    let search_meta = json!({"search_id": search_id});
 
     let (status, response_headers, describe) = response_json_with_headers(
         handle_v1_describe(
             State(gs.clone()),
             trace_headers(),
-            Json(json!({"tool_slug": slug})),
+            Json(json!({"tool_slug": slug.clone(), "meta": search_meta.clone()})),
         )
         .await,
     )
@@ -583,7 +611,7 @@ async fn gateway_rest_workflow_responses_expose_trace_and_index_metadata() {
         handle_v1_load_skill(
             State(gs.clone()),
             trace_headers(),
-            Json(json!({"skill_name": "maya-render", "dcc_type": "maya"})),
+            Json(json!({"skill_name": "maya-render", "dcc_type": "maya", "meta": search_meta.clone()})),
         )
         .await,
     )
@@ -596,7 +624,7 @@ async fn gateway_rest_workflow_responses_expose_trace_and_index_metadata() {
         handle_v1_call(
             State(gs.clone()),
             trace_headers(),
-            Json(json!({"tool_slug": "maya.00000000.render", "arguments": {}})),
+            Json(json!({"tool_slug": slug.clone(), "arguments": {}, "meta": search_meta.clone()})),
         )
         .await,
     )
@@ -610,9 +638,9 @@ async fn gateway_rest_workflow_responses_expose_trace_and_index_metadata() {
 
     let (status, response_headers, batch) = response_json_with_headers(
         handle_v1_call_batch(
-            State(gs),
+            State(gs.clone()),
             trace_headers(),
-            Json(json!({"calls": [{"id": "client-step-1"}]})),
+            Json(json!({"calls": [{"id": "client-step-1", "tool_slug": slug.clone(), "arguments": {}, "meta": search_meta.clone()}]})),
         )
         .await,
     )
@@ -623,6 +651,117 @@ async fn gateway_rest_workflow_responses_expose_trace_and_index_metadata() {
     assert_eq!(batch["results"][0]["index"], 0);
     assert_eq!(batch["results"][0]["id"], "client-step-1");
     assert_eq!(batch["results"][0]["ok"], false);
+
+    let telemetry = gs.search_telemetry.snapshot(10);
+    assert_eq!(telemetry.stats.total_searches, 1);
+    assert_eq!(telemetry.stats.describe_after_search_rate, 1.0);
+    assert_eq!(telemetry.stats.load_after_search_rate, 1.0);
+    assert_eq!(telemetry.stats.call_after_search_rate, 1.0);
+    assert_eq!(telemetry.stats.success_after_search_rate, 0.0);
+    assert_eq!(telemetry.stats.top1_hit_rate, 1.0);
+    assert!(
+        telemetry.recent[0]
+            .followups
+            .iter()
+            .any(|followup| followup.kind == "call")
+    );
+}
+
+#[tokio::test]
+async fn mcp_search_followups_correlate_describe_load_call_and_batch() {
+    let gs = test_gateway_state("1.2.3");
+    seed_unloaded_render_capability(&gs);
+    let trace = crate::gateway::admin::trace::TraceContext::from_headers(&trace_headers());
+
+    let search_args = json!({"query": "render"});
+    let (search_text, search_is_error) = crate::gateway::aggregator::route_tools_call(
+        &gs,
+        "search",
+        &search_args,
+        None,
+        Some("req-mcp-search".to_string()),
+        Some("session-mcp"),
+        Some(&trace),
+    )
+    .await;
+    assert!(!search_is_error);
+    let search: Value = serde_json::from_str(&search_text).unwrap();
+    let search_id = search["search_id"].as_str().unwrap().to_string();
+    let slug = search["hits"][0]["tool_slug"].as_str().unwrap().to_string();
+    assert_eq!(search["hits"][0]["rank"], 1);
+    assert_eq!(
+        search["hits"][0]["next_step"]["arguments"]["meta"]["search_id"],
+        search_id
+    );
+
+    let meta = json!({"search_id": search_id});
+    let describe_args = json!({"tool_slug": slug.clone()});
+    let (_describe_text, describe_is_error) = crate::gateway::aggregator::route_tools_call(
+        &gs,
+        "describe",
+        &describe_args,
+        Some(&meta),
+        Some("req-mcp-describe".to_string()),
+        Some("session-mcp"),
+        Some(&trace),
+    )
+    .await;
+    assert!(describe_is_error);
+
+    let load_args = json!({"skill_name": "maya-render", "dcc_type": "maya"});
+    let (_load_text, load_is_error) = crate::gateway::aggregator::route_tools_call(
+        &gs,
+        "load_skill",
+        &load_args,
+        Some(&meta),
+        Some("req-mcp-load".to_string()),
+        Some("session-mcp"),
+        Some(&trace),
+    )
+    .await;
+    assert!(load_is_error);
+
+    let call_args = json!({"tool_slug": slug.clone(), "arguments": {}});
+    let (_call_text, call_is_error) = crate::gateway::aggregator::route_tools_call(
+        &gs,
+        "call",
+        &call_args,
+        Some(&meta),
+        Some("req-mcp-call".to_string()),
+        Some("session-mcp"),
+        Some(&trace),
+    )
+    .await;
+    assert!(call_is_error);
+
+    let batch_args =
+        json!({"calls": [{"id": "batch-1", "tool_slug": slug, "arguments": {}, "meta": meta}]});
+    let (_batch_text, batch_is_error) = crate::gateway::aggregator::route_tools_call(
+        &gs,
+        "call",
+        &batch_args,
+        None,
+        Some("req-mcp-batch".to_string()),
+        Some("session-mcp"),
+        Some(&trace),
+    )
+    .await;
+    assert!(batch_is_error);
+
+    let telemetry = gs.search_telemetry.snapshot(10);
+    assert_eq!(telemetry.stats.total_searches, 1);
+    assert_eq!(telemetry.stats.describe_after_search_rate, 1.0);
+    assert_eq!(telemetry.stats.load_after_search_rate, 1.0);
+    assert_eq!(telemetry.stats.call_after_search_rate, 1.0);
+    assert_eq!(telemetry.stats.top1_hit_rate, 1.0);
+    assert!(
+        telemetry.recent[0]
+            .followups
+            .iter()
+            .filter(|followup| followup.kind == "call")
+            .count()
+            >= 2
+    );
 }
 
 #[tokio::test]

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_support.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_support.rs
@@ -1,0 +1,356 @@
+use super::*;
+
+use crate::gateway::admin::trace::TraceContext;
+use crate::gateway::capability_service::{ServiceError, service_error_to_json};
+use crate::gateway::response_codec::{compact_search_payload, negotiated_response};
+use crate::gateway::search_telemetry::{RANKER_VERSION, SearchFollowupInput, SearchTelemetryHit};
+
+#[derive(Debug, Clone)]
+pub(super) struct RestResponseMetadata {
+    pub(super) request_id: String,
+    pub(super) trace_id: String,
+    traceparent: Option<String>,
+    pub(super) index_generation: Option<String>,
+    search_id: Option<String>,
+    ranker_version: Option<String>,
+}
+
+impl RestResponseMetadata {
+    pub(super) fn from_headers(headers: &HeaderMap) -> Self {
+        Self::from_trace_context(&TraceContext::from_headers(headers))
+    }
+
+    pub(super) fn from_trace_context(trace_context: &TraceContext) -> Self {
+        Self {
+            request_id: trace_context.request_id.clone(),
+            trace_id: trace_context.trace_id.clone(),
+            traceparent: trace_context.traceparent(),
+            index_generation: None,
+            search_id: None,
+            ranker_version: None,
+        }
+    }
+
+    pub(super) fn with_index_generation(mut self, generation: String) -> Self {
+        if !generation.is_empty() {
+            self.index_generation = Some(generation);
+        }
+        self
+    }
+
+    pub(super) fn with_search(mut self, search_id: String, ranker_version: String) -> Self {
+        if !search_id.is_empty() {
+            self.search_id = Some(search_id);
+        }
+        if !ranker_version.is_empty() {
+            self.ranker_version = Some(ranker_version);
+        }
+        self
+    }
+
+    fn insert_body_fields(&self, value: &mut Value) {
+        if let Some(obj) = value.as_object_mut() {
+            obj.entry("request_id".to_string())
+                .or_insert_with(|| json!(self.request_id));
+            obj.entry("trace_id".to_string())
+                .or_insert_with(|| json!(self.trace_id));
+            if let Some(generation) = self.index_generation.as_deref() {
+                obj.entry("index_generation".to_string())
+                    .or_insert_with(|| json!(generation));
+            }
+            if let Some(search_id) = self.search_id.as_deref() {
+                obj.entry("search_id".to_string())
+                    .or_insert_with(|| json!(search_id));
+            }
+            if let Some(ranker_version) = self.ranker_version.as_deref() {
+                obj.entry("ranker_version".to_string())
+                    .or_insert_with(|| json!(ranker_version));
+            }
+        }
+    }
+
+    fn attach_headers(&self, headers: &mut HeaderMap) {
+        insert_header(
+            headers,
+            crate::gateway::response_codec::HEADER_REQUEST_ID,
+            &self.request_id,
+        );
+        insert_header(headers, "x-request-id", &self.request_id);
+        insert_header(
+            headers,
+            crate::gateway::response_codec::HEADER_TRACE_ID,
+            &self.trace_id,
+        );
+        if let Some(traceparent) = self.traceparent.as_deref() {
+            insert_header(headers, "traceparent", traceparent);
+        }
+        if let Some(generation) = self.index_generation.as_deref() {
+            insert_header(
+                headers,
+                crate::gateway::response_codec::HEADER_INDEX_GENERATION,
+                generation,
+            );
+        }
+        if let Some(search_id) = self.search_id.as_deref() {
+            insert_header(
+                headers,
+                crate::gateway::response_codec::HEADER_SEARCH_ID,
+                search_id,
+            );
+        }
+        if let Some(ranker_version) = self.ranker_version.as_deref() {
+            insert_header(
+                headers,
+                crate::gateway::response_codec::HEADER_RANKER_VERSION,
+                ranker_version,
+            );
+        }
+    }
+}
+
+fn insert_header(headers: &mut HeaderMap, name: &'static str, value: &str) {
+    if let Ok(value) = axum::http::HeaderValue::from_str(value) {
+        headers.insert(name, value);
+    }
+}
+
+pub(super) fn negotiated_response_with_metadata(
+    headers: &HeaderMap,
+    request_body: &Value,
+    status: StatusCode,
+    mut legacy_json: Value,
+    compact_json: Option<Value>,
+    metadata: &RestResponseMetadata,
+    include_body_metadata: bool,
+) -> Response {
+    let mut compact_json = compact_json;
+    if include_body_metadata {
+        metadata.insert_body_fields(&mut legacy_json);
+        if let Some(compact) = compact_json.as_mut() {
+            metadata.insert_body_fields(compact);
+        }
+    }
+    let mut response =
+        negotiated_response(headers, request_body, status, legacy_json, compact_json);
+    metadata.attach_headers(response.headers_mut());
+    response
+}
+
+pub(super) fn search_response_with_metadata(
+    headers: &HeaderMap,
+    body: &Value,
+    hits: Vec<Value>,
+    metadata: &RestResponseMetadata,
+) -> Response {
+    let total = hits.len();
+    let mut legacy = json!({
+        "total": total,
+        "hits": hits,
+    });
+    metadata.insert_body_fields(&mut legacy);
+    let mut compact = compact_search_payload(
+        total,
+        legacy["hits"]
+            .as_array()
+            .map(Vec::as_slice)
+            .unwrap_or_default(),
+    );
+    metadata.insert_body_fields(&mut compact);
+    negotiated_response_with_metadata(
+        headers,
+        body,
+        StatusCode::OK,
+        legacy,
+        Some(compact),
+        metadata,
+        false,
+    )
+}
+
+pub(super) fn search_hits_for_telemetry(
+    hits: &[crate::gateway::capability::SearchHit],
+) -> Vec<SearchTelemetryHit> {
+    hits.iter()
+        .map(|hit| SearchTelemetryHit {
+            tool_slug: hit.record.tool_slug.clone(),
+            skill_name: hit.record.skill_name.clone(),
+            dcc_type: hit.record.dcc_type.clone(),
+            rank: hit.rank,
+            score: hit.score,
+            match_reasons: hit.match_reasons.clone(),
+            loaded: hit.record.loaded,
+        })
+        .collect()
+}
+
+pub(super) fn record_search_followup(
+    gs: &GatewayState,
+    search_id: Option<&str>,
+    kind: &str,
+    tool_slug: Option<&str>,
+    skill_name: Option<String>,
+    success: bool,
+    trace_context: &TraceContext,
+) {
+    let Some(search_id) = search_id else {
+        return;
+    };
+    gs.search_telemetry.record_followup(SearchFollowupInput {
+        search_id: search_id.to_string(),
+        kind: kind.to_string(),
+        tool_slug: tool_slug.map(str::to_string),
+        skill_name,
+        success,
+        trace_context: Some(trace_context.clone()),
+    });
+}
+
+pub(super) fn skill_name_from_payload(payload: &Value) -> Option<String> {
+    payload
+        .get("skill_name")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| {
+            payload
+                .get("skill_names")
+                .and_then(Value::as_array)
+                .and_then(|items| items.iter().find_map(Value::as_str))
+                .map(str::to_string)
+        })
+}
+
+pub(super) fn call_next_step(
+    slug: &str,
+    search_id: &str,
+    metadata: &RestResponseMetadata,
+) -> Value {
+    let mut meta = json!({
+        "search_id": search_id,
+        "ranker_version": RANKER_VERSION,
+    });
+    if let Some(generation) = metadata.index_generation.as_deref() {
+        meta["index_generation"] = json!(generation);
+    }
+    let arguments = json!({
+        "tool_slug": slug,
+        "arguments": {},
+        "meta": meta,
+    });
+    json!({
+        "action": "call",
+        "arguments": arguments.clone(),
+        "mcp": {
+            "tool": "call",
+            "arguments": arguments.clone(),
+            "_meta": arguments["meta"].clone(),
+        },
+        "rest": {
+            "method": "POST",
+            "path": "/v1/call",
+            "body": arguments,
+        },
+    })
+}
+
+pub(super) struct RestTrafficFrame<'a> {
+    pub(super) path: &'a str,
+    pub(super) direction: &'static str,
+    pub(super) leg: &'static str,
+    pub(super) status: Option<u16>,
+    pub(super) body: Value,
+}
+
+pub(super) fn emit_rest_traffic_frame(
+    gs: &GatewayState,
+    ctx: &crate::gateway::middleware::CallContext,
+    headers: &HeaderMap,
+    frame: RestTrafficFrame<'_>,
+) {
+    gs.traffic_capture.emit_json_frame(
+        crate::gateway::traffic::TrafficFrame::json(
+            crate::gateway::traffic::gateway_source(
+                &gs.server_name,
+                &gs.server_version,
+                &gs.own_host,
+                gs.own_port,
+            ),
+            crate::gateway::traffic::correlation(
+                Some(&ctx.trace_context.request_id),
+                Some(&ctx.trace_context.trace_id),
+                ctx.session_id.as_deref(),
+            ),
+            frame.direction,
+            frame.leg,
+            "http",
+            frame.body,
+        )
+        .with_session_id(ctx.session_id.as_deref())
+        .with_http(crate::gateway::traffic::http_post(
+            frame.path,
+            Some(headers),
+            frame.status,
+        ))
+        .with_mcp(crate::gateway::traffic::mcp_message(
+            if frame.direction == "inbound" {
+                "request"
+            } else {
+                "response"
+            },
+            "tools/call",
+            None,
+        )),
+    );
+}
+
+pub(super) fn session_id_from_headers(headers: &HeaderMap) -> Option<String> {
+    header_string(headers, "mcp-session-id")
+        .or_else(|| header_string(headers, "x-session-id"))
+        .or_else(|| header_string(headers, "x-dcc-mcp-session-id"))
+}
+
+fn header_string(headers: &HeaderMap, name: &str) -> Option<String> {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+pub(super) fn now_ns() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0)
+}
+
+pub(super) fn service_error_status(err: &ServiceError) -> StatusCode {
+    match err.kind.as_str() {
+        "unknown-slug" => StatusCode::NOT_FOUND,
+        "ambiguous" => StatusCode::CONFLICT,
+        "instance-offline" => StatusCode::SERVICE_UNAVAILABLE,
+        "policy-denied" => StatusCode::FORBIDDEN,
+        "host-busy" => StatusCode::SERVICE_UNAVAILABLE,
+        "host-died" => StatusCode::BAD_GATEWAY,
+        "backend-error" | "schema-unavailable" => StatusCode::BAD_GATEWAY,
+        _ => StatusCode::BAD_REQUEST,
+    }
+}
+
+pub(super) fn service_error_response_with_metadata(
+    headers: &HeaderMap,
+    body: &Value,
+    err: &ServiceError,
+    metadata: &RestResponseMetadata,
+    include_body_metadata: bool,
+) -> Response {
+    negotiated_response_with_metadata(
+        headers,
+        body,
+        service_error_status(err),
+        service_error_to_json(err),
+        None,
+        metadata,
+        include_body_metadata,
+    )
+}

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/sse_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/sse_impl.rs
@@ -188,6 +188,9 @@ mod tests {
                 crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
             ),
             traffic_capture: Arc::new(crate::gateway::traffic::TrafficCapture::disabled()),
+            search_telemetry: Arc::new(
+                crate::gateway::search_telemetry::SearchTelemetryStore::new(),
+            ),
             debug_routes_enabled: false,
         }
     }

--- a/crates/dcc-mcp-gateway/src/gateway/metrics.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/metrics.rs
@@ -35,6 +35,64 @@ pub fn record_gateway_backend_error_kind(kind: &str) {
     }
 }
 
+/// Increment `dcc_mcp_gateway_searches_total` when the `prometheus`
+/// feature is enabled.
+#[inline]
+pub fn record_gateway_search(result: &str) {
+    #[cfg(feature = "prometheus")]
+    {
+        if let Some(exp) = GATEWAY_PROMETHEUS_EXPORTER.get() {
+            exp.record_gateway_search(result);
+        }
+    }
+    #[cfg(not(feature = "prometheus"))]
+    {
+        let _ = result;
+    }
+}
+
+/// Increment `dcc_mcp_gateway_search_followups_total` when the `prometheus`
+/// feature is enabled.
+#[inline]
+pub fn record_gateway_search_followup(kind: &str, rank_bucket: &str) {
+    #[cfg(feature = "prometheus")]
+    {
+        if let Some(exp) = GATEWAY_PROMETHEUS_EXPORTER.get() {
+            exp.record_gateway_search_followup(kind, rank_bucket);
+        }
+    }
+    #[cfg(not(feature = "prometheus"))]
+    {
+        let _ = (kind, rank_bucket);
+    }
+}
+
+/// Increment `dcc_mcp_gateway_search_reformulations_total` when enabled.
+#[inline]
+pub fn record_gateway_search_reformulation() {
+    #[cfg(feature = "prometheus")]
+    {
+        if let Some(exp) = GATEWAY_PROMETHEUS_EXPORTER.get() {
+            exp.record_gateway_search_reformulation();
+        }
+    }
+}
+
+/// Observe `dcc_mcp_gateway_search_time_to_first_success_seconds` when enabled.
+#[inline]
+pub fn observe_gateway_search_time_to_first_success(duration: std::time::Duration) {
+    #[cfg(feature = "prometheus")]
+    {
+        if let Some(exp) = GATEWAY_PROMETHEUS_EXPORTER.get() {
+            exp.observe_gateway_search_time_to_first_success(duration);
+        }
+    }
+    #[cfg(not(feature = "prometheus"))]
+    {
+        let _ = duration;
+    }
+}
+
 /// Attach the `/metrics` route to the gateway router.
 #[cfg(feature = "prometheus")]
 pub fn attach_gateway_metrics_route(router: Router) -> Router {

--- a/crates/dcc-mcp-gateway/src/gateway/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/mod.rs
@@ -50,6 +50,7 @@ pub mod resilience;
 pub(crate) mod response_codec;
 pub(crate) mod rest_openapi;
 pub mod router;
+pub mod search_telemetry;
 pub mod sse_subscriber;
 pub mod state;
 pub mod tools;

--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/agent_workflows.md
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/agent_workflows.md
@@ -9,7 +9,7 @@
 ## Use MCP the way the gateway expects
 
 1. **`tools/list`** — Small, stable set: exactly **`search`**, **`describe`**, **`load_skill`**, and **`call`**. Treat it as an **index of gateway verbs**, not the full catalog of every backend action.
-2. **Discover backend work** — `search(kind="tool")` → **`describe`** (read schema, descriptions, safety hints, **`affinity`**, **`execution`**, timeouts) → **`call`**. On REST, use `/v1/search`, `/v1/describe`, `/v1/call` (or the path-style `POST /v1/dcc/{dcc}/instances/{id}/call` from **REST clients** below). Skipping `describe` wastes retries and breaks validation.
+2. **Discover backend work** — `search(kind="tool")` → **`describe`** (read schema, descriptions, safety hints, **`affinity`**, **`execution`**, timeouts) → **`call`**. On REST, use `/v1/search`, `/v1/describe`, `/v1/call` (or the path-style `POST /v1/dcc/{dcc}/instances/{id}/call` from **REST clients** below). Skipping `describe` wastes retries and breaks validation. Preserve the returned `next_step.arguments.meta.search_id` (or the same object as MCP `_meta`) on `describe`, `load_skill`, and `call`; this lets the gateway measure selected rank and hit rate without storing full prompts.
 3. **Chaining** — **`call({calls:[...]})`** / **`POST /v1/call_batch`** runs up to **25** ordered calls when you have several **different** validated steps. Prefer fewer, well-formed calls over chatty micro-steps.
 4. **Skills vs tools** — `search(kind="skill")` / `load_skill` load packaged workflows on a host; `search(kind="tool")` resolves a **`tool_slug`** for the dynamic surface. Keep names straight; use `describe` before calling an unfamiliar slug. Unloaded hits carry `load_state`, `available_groups` when known, and `next_step` with both MCP and REST call shapes.
 5. **Progressive groups** — gateway `load_skill` defaults to lazy group activation (`activate_groups=false` unless you opt in). Default-active/core groups may become active; heavier groups should be activated explicitly through `load_skill(..., tool_group="...")`.
@@ -34,7 +34,7 @@ For Maya behind the gateway, prefer **`search(kind="skill")`** → **`load_skill
 
 ### `tool_slug` shape (and why it is not slash-separated yet)
 
-- Every `search(kind="tool")` hit includes **`tool_slug`**. Treat it as an opaque **routing token**: copy it **verbatim** into `describe` and `call` (and into REST `POST /v1/describe` / `/v1/call` bodies as the `tool_slug` field).
+- Every `search(kind="tool")` hit includes **`rank`**, **`tool_slug`**, and bounded **`match_reasons`**. Treat `tool_slug` as an opaque **routing token**: copy it **verbatim** into `describe` and `call` (and into REST `POST /v1/describe` / `/v1/call` bodies as the `tool_slug` field).
 - Format: **`<dcc_type>.<instance_prefix_or_uuid>.<backend_tool>`** — three dot-separated routing segments. Example: `maya.277685a7.maya_primitives__create_sphere`. This encodes the same tuple a path-style URL would use (`/<dcc>/<instance>/<backend_tool>`); the final `backend_tool` segment is the client-safe MCP name such as `project_save` or `maya_primitives__create_sphere`.
 - **Common agent mistake:** calling `call` with only `code` / `python` / `mel` at the **top level**. That shape belongs to **specific backend tools** inside **`arguments`**, only when their schema says so — the gateway wrapper **always** requires **`tool_slug`** plus optional **`arguments`** / **`meta`**.
 

--- a/crates/dcc-mcp-gateway/src/gateway/response_codec.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/response_codec.rs
@@ -24,6 +24,8 @@ pub(crate) const HEADER_SAVINGS_PERCENT: &str = "x-dcc-mcp-savings-pct";
 pub(crate) const HEADER_REQUEST_ID: &str = "x-dcc-mcp-request-id";
 pub(crate) const HEADER_TRACE_ID: &str = "x-dcc-mcp-trace-id";
 pub(crate) const HEADER_INDEX_GENERATION: &str = "x-dcc-mcp-index-generation";
+pub(crate) const HEADER_SEARCH_ID: &str = "x-dcc-mcp-search-id";
+pub(crate) const HEADER_RANKER_VERSION: &str = "x-dcc-mcp-ranker-version";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ResponseFormat {
@@ -229,6 +231,7 @@ pub(crate) fn compact_describe_payload(legacy: &Value) -> Value {
     copy_field(&mut out, legacy, "request_id");
     copy_field(&mut out, legacy, "trace_id");
     copy_field(&mut out, legacy, "index_generation");
+    copy_field(&mut out, legacy, "next_step");
     if let Some(record) = legacy.get("record") {
         out.insert("record".to_string(), compact_record(record));
     }
@@ -273,6 +276,7 @@ fn compact_record(record: &Value) -> Value {
     copy_field(&mut out, record, "loaded");
     copy_field(&mut out, record, "load_state");
     copy_field(&mut out, record, "available_groups");
+    copy_field(&mut out, record, "rank");
     copy_field(&mut out, record, "score");
     copy_field(&mut out, record, "match_reasons");
     copy_field(&mut out, record, "annotations");

--- a/crates/dcc-mcp-gateway/src/gateway/rest_openapi.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/rest_openapi.rs
@@ -288,6 +288,7 @@ fn common_schemas() -> Map<String, Value> {
         schemas.insert(name.to_string(), schema);
     }
     annotate_service_error_policy(&mut schemas);
+    annotate_search_quality_contract(&mut schemas);
 
     schemas
 }
@@ -315,6 +316,70 @@ fn annotate_service_error_policy(schemas: &mut Map<String, Value>) {
         "additionalProperties": true
     });
     schemas.insert("ServiceError".to_string(), gateway_error);
+}
+
+fn annotate_search_quality_contract(schemas: &mut Map<String, Value>) {
+    if let Some(search_response) = schemas.get_mut("SearchResponse")
+        && let Some(properties) = search_response
+            .get_mut("properties")
+            .and_then(Value::as_object_mut)
+    {
+        properties.insert(
+            "search_id".to_string(),
+            json!({
+                "type": "string",
+                "description": "Stable correlation id for this search result set. Pass it as meta.search_id on describe, load_skill, call, or batch follow-ups."
+            }),
+        );
+        properties.insert(
+            "ranker_version".to_string(),
+            json!({
+                "type": "string",
+                "description": "Bounded ranker identifier used for the response."
+            }),
+        );
+        properties.insert(
+            "index_generation".to_string(),
+            json!({
+                "type": "string",
+                "description": "Opaque capability-index fingerprint used to produce the result set."
+            }),
+        );
+    }
+
+    if let Some(skill_entry) = schemas.get_mut("SkillListEntry")
+        && let Some(properties) = skill_entry
+            .get_mut("properties")
+            .and_then(Value::as_object_mut)
+    {
+        properties.insert(
+            "rank".to_string(),
+            json!({
+                "type": "integer",
+                "minimum": 1,
+                "description": "One-based rank within the returned search result set."
+            }),
+        );
+        properties.insert(
+            "score".to_string(),
+            json!({"type": "integer", "minimum": 0}),
+        );
+        properties.insert(
+            "match_reasons".to_string(),
+            json!({
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Bounded ranking reason labels, for example tool_lexical or schema_fuzzy."
+            }),
+        );
+        properties.insert(
+            "next_step".to_string(),
+            json!({
+                "$ref": "#/components/schemas/ProgressiveNextStep",
+                "description": "Suggested follow-up with meta.search_id attached when the hit is unloaded or ready for describe/call."
+            }),
+        );
+    }
 }
 
 fn gateway_schemas() -> Vec<(&'static str, Value)> {
@@ -711,6 +776,14 @@ fn gateway_metadata_headers() -> Value {
             "description": "Opaque capability-index fingerprint when the route touches discovery, describe, load, or call state.",
             "schema": {"type": "string"}
         },
+        "x-dcc-mcp-search-id": {
+            "description": "Stable search correlation id when a route creates or consumes search-quality telemetry.",
+            "schema": {"type": "string"}
+        },
+        "x-dcc-mcp-ranker-version": {
+            "description": "Bounded search ranker identifier when a route creates or consumes search-quality telemetry.",
+            "schema": {"type": "string"}
+        },
         "traceparent": {
             "description": "W3C trace context for downstream HTTP clients.",
             "schema": {"type": "string"}
@@ -832,7 +905,20 @@ mod tests {
         assert!(search_headers.get("x-dcc-mcp-request-id").is_some());
         assert!(search_headers.get("x-dcc-mcp-trace-id").is_some());
         assert!(search_headers.get("x-dcc-mcp-index-generation").is_some());
+        assert!(search_headers.get("x-dcc-mcp-search-id").is_some());
+        assert!(search_headers.get("x-dcc-mcp-ranker-version").is_some());
         assert!(search_headers.get("traceparent").is_some());
+
+        let search_response = &doc["components"]["schemas"]["SearchResponse"];
+        assert!(search_response["properties"].get("search_id").is_some());
+        assert!(
+            search_response["properties"]
+                .get("ranker_version")
+                .is_some()
+        );
+        let search_hit = &doc["components"]["schemas"]["SkillListEntry"];
+        assert!(search_hit["properties"].get("rank").is_some());
+        assert!(search_hit["properties"].get("match_reasons").is_some());
 
         let batch_item = &doc["components"]["schemas"]["GatewayBatchCallItem"];
         assert!(batch_item["properties"].get("id").is_some());

--- a/crates/dcc-mcp-gateway/src/gateway/search_telemetry.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/search_telemetry.rs
@@ -1,0 +1,737 @@
+//! Search-quality telemetry for gateway discovery workflows.
+//!
+//! The store keeps bounded, prompt-safe search records and correlates later
+//! `describe`, `load_skill`, and `call` operations through `meta.search_id`.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::gateway::admin::trace::TraceContext;
+
+pub use dcc_mcp_gateway_core::capability::RANKER_VERSION;
+
+const DEFAULT_CAPACITY: usize = 1_000;
+const MAX_QUERY_PREVIEW_CHARS: usize = 120;
+const MAX_FOLLOWUPS_PER_SEARCH: usize = 32;
+const REFORMULATION_WINDOW: Duration = Duration::from_secs(10 * 60);
+
+/// One lightweight hit captured from a search response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchTelemetryHit {
+    pub tool_slug: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skill_name: Option<String>,
+    pub dcc_type: String,
+    pub rank: u32,
+    pub score: u32,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub match_reasons: Vec<String>,
+    pub loaded: bool,
+}
+
+/// One follow-up operation correlated with a prior search.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchFollowupTelemetry {
+    pub kind: String,
+    pub timestamp_ms: u64,
+    pub request_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_slug: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skill_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected_rank: Option<u32>,
+    pub success: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub elapsed_ms: Option<u64>,
+}
+
+/// Search event stored in the bounded in-memory ring.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchTelemetryRecord {
+    pub search_id: String,
+    pub timestamp_ms: u64,
+    pub transport: String,
+    pub kind: String,
+    pub ranker_version: String,
+    pub index_generation: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub query_preview: Option<String>,
+    pub query_hash: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dcc_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instance_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    pub total: usize,
+    pub zero_results: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reformulation_of: Option<String>,
+    pub hits: Vec<SearchTelemetryHit>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub followups: Vec<SearchFollowupTelemetry>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_success_ms: Option<u64>,
+}
+
+/// Aggregated search-quality metrics suitable for admin/debug APIs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchQualityStats {
+    pub total_searches: usize,
+    pub zero_result_count: usize,
+    pub zero_result_rate: f64,
+    pub selected_rank: Option<f64>,
+    pub selected_count: usize,
+    pub top1_hit_rate: f64,
+    pub top3_hit_rate: f64,
+    pub top5_hit_rate: f64,
+    pub describe_after_search_rate: f64,
+    pub load_after_search_rate: f64,
+    pub call_after_search_rate: f64,
+    pub success_after_search_rate: f64,
+    pub query_reformulation_count: usize,
+    pub query_reformulation_rate: f64,
+    pub time_to_first_success: Option<f64>,
+    pub time_to_first_success_ms: Option<f64>,
+}
+
+/// Admin/debug response envelope.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchTelemetrySnapshot {
+    pub stats: SearchQualityStats,
+    pub total: usize,
+    pub recent: Vec<SearchTelemetryRecord>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SearchTelemetryInput {
+    pub search_id: String,
+    pub transport: String,
+    pub kind: String,
+    pub query: String,
+    pub dcc_type: Option<String>,
+    pub instance_id: Option<String>,
+    pub limit: Option<u32>,
+    pub total: usize,
+    pub ranker_version: String,
+    pub index_generation: String,
+    pub hits: Vec<SearchTelemetryHit>,
+    pub trace_context: Option<TraceContext>,
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SearchFollowupInput {
+    pub search_id: String,
+    pub kind: String,
+    pub tool_slug: Option<String>,
+    pub skill_name: Option<String>,
+    pub success: bool,
+    pub trace_context: Option<TraceContext>,
+}
+
+#[derive(Debug, Clone)]
+struct LastSearch {
+    search_id: String,
+    query_norm: String,
+    timestamp: SystemTime,
+    first_success: bool,
+}
+
+#[derive(Debug, Default)]
+struct SearchTelemetryInner {
+    records: VecDeque<SearchTelemetryRecord>,
+    last_by_correlation: HashMap<String, LastSearch>,
+    query_reformulation_count: usize,
+}
+
+/// Bounded in-memory search telemetry store.
+#[derive(Debug)]
+pub struct SearchTelemetryStore {
+    inner: Mutex<SearchTelemetryInner>,
+    capacity: usize,
+}
+
+impl SearchTelemetryStore {
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_CAPACITY)
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            inner: Mutex::new(SearchTelemetryInner::default()),
+            capacity: capacity.max(1),
+        }
+    }
+
+    pub fn new_search_id() -> String {
+        uuid::Uuid::new_v4().to_string()
+    }
+
+    pub fn record_search(&self, input: SearchTelemetryInput) -> String {
+        let mut inner = self.inner.lock();
+        let now = SystemTime::now();
+        let query_norm = normalise_query(&input.query);
+        let correlation_key = correlation_key(
+            input.trace_context.as_ref(),
+            input.session_id.as_deref(),
+            input.dcc_type.as_deref(),
+        );
+        let reformulation_of = correlation_key.as_ref().and_then(|key| {
+            let previous = inner.last_by_correlation.get(key)?;
+            let recent = now
+                .duration_since(previous.timestamp)
+                .map(|age| age <= REFORMULATION_WINDOW)
+                .unwrap_or(false);
+            if recent
+                && !previous.first_success
+                && !query_norm.is_empty()
+                && previous.query_norm != query_norm
+            {
+                Some(previous.search_id.clone())
+            } else {
+                None
+            }
+        });
+        if reformulation_of.is_some() {
+            inner.query_reformulation_count += 1;
+            crate::gateway::metrics::record_gateway_search_reformulation();
+        }
+
+        let zero_results = input.total == 0;
+        crate::gateway::metrics::record_gateway_search(if zero_results {
+            "zero"
+        } else {
+            "nonzero"
+        });
+
+        let record = SearchTelemetryRecord {
+            search_id: input.search_id.clone(),
+            timestamp_ms: timestamp_ms(now),
+            transport: bound_label(input.transport, "unknown"),
+            kind: bound_label(input.kind, "tool"),
+            ranker_version: input.ranker_version,
+            index_generation: input.index_generation,
+            request_id: input
+                .trace_context
+                .as_ref()
+                .map(|ctx| ctx.request_id.clone()),
+            trace_id: input.trace_context.as_ref().map(|ctx| ctx.trace_id.clone()),
+            session_id: input.session_id,
+            query_preview: query_preview(&input.query),
+            query_hash: hash_query(&query_norm),
+            dcc_type: input.dcc_type,
+            instance_id: input.instance_id,
+            limit: input.limit,
+            total: input.total,
+            zero_results,
+            reformulation_of,
+            hits: input.hits,
+            followups: Vec::new(),
+            first_success_ms: None,
+        };
+
+        if let Some(key) = correlation_key {
+            inner.last_by_correlation.insert(
+                key,
+                LastSearch {
+                    search_id: input.search_id.clone(),
+                    query_norm,
+                    timestamp: now,
+                    first_success: false,
+                },
+            );
+        }
+
+        while inner.records.len() >= self.capacity {
+            inner.records.pop_front();
+        }
+        inner.records.push_back(record);
+        input.search_id
+    }
+
+    pub fn record_followup(&self, input: SearchFollowupInput) -> bool {
+        let mut inner = self.inner.lock();
+        let mut mark_success_for: Option<(String, String)> = None;
+        {
+            let Some(record) = inner
+                .records
+                .iter_mut()
+                .rev()
+                .find(|record| record.search_id == input.search_id)
+            else {
+                return false;
+            };
+            let now = SystemTime::now();
+            let selected_rank = selected_rank(
+                record,
+                input.tool_slug.as_deref(),
+                input.skill_name.as_deref(),
+            );
+            let elapsed_ms = now
+                .duration_since(UNIX_EPOCH + Duration::from_millis(record.timestamp_ms))
+                .ok()
+                .map(|duration| duration.as_millis() as u64);
+            let followup = SearchFollowupTelemetry {
+                kind: bound_label(input.kind, "unknown"),
+                timestamp_ms: timestamp_ms(now),
+                request_id: input
+                    .trace_context
+                    .as_ref()
+                    .map(|ctx| ctx.request_id.clone()),
+                trace_id: input.trace_context.as_ref().map(|ctx| ctx.trace_id.clone()),
+                tool_slug: input.tool_slug,
+                skill_name: input.skill_name,
+                selected_rank,
+                success: input.success,
+                elapsed_ms,
+            };
+            let rank_bucket = rank_bucket(selected_rank);
+            crate::gateway::metrics::record_gateway_search_followup(&followup.kind, rank_bucket);
+            if followup.kind == "call" && followup.success && record.first_success_ms.is_none() {
+                record.first_success_ms = elapsed_ms;
+                if let Some(ms) = elapsed_ms {
+                    crate::gateway::metrics::observe_gateway_search_time_to_first_success(
+                        Duration::from_millis(ms),
+                    );
+                }
+            }
+            record.followups.push(followup);
+            if record.followups.len() > MAX_FOLLOWUPS_PER_SEARCH {
+                record.followups.remove(0);
+            }
+
+            if record.first_success_ms.is_some()
+                && let Some(key) = correlation_key(
+                    input.trace_context.as_ref(),
+                    record.session_id.as_deref(),
+                    record.dcc_type.as_deref(),
+                )
+            {
+                mark_success_for = Some((key, record.search_id.clone()));
+            }
+        }
+        if let Some((key, search_id)) = mark_success_for
+            && let Some(last) = inner.last_by_correlation.get_mut(&key)
+            && last.search_id == search_id
+        {
+            last.first_success = true;
+        }
+        true
+    }
+
+    pub fn snapshot(&self, limit: usize) -> SearchTelemetrySnapshot {
+        let inner = self.inner.lock();
+        let recent: Vec<SearchTelemetryRecord> = inner
+            .records
+            .iter()
+            .rev()
+            .take(limit.max(1))
+            .cloned()
+            .collect();
+        SearchTelemetrySnapshot {
+            stats: compute_stats(&inner),
+            total: recent.len(),
+            recent,
+        }
+    }
+}
+
+impl Default for SearchTelemetryStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn search_id_from_payload(payload: &Value) -> Option<String> {
+    payload
+        .get("meta")
+        .or_else(|| payload.get("_meta"))
+        .and_then(search_id_from_meta)
+        .or_else(|| {
+            payload
+                .get("search_id")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
+        .and_then(normalise_search_id)
+}
+
+pub fn search_id_from_meta(meta: &Value) -> Option<String> {
+    meta.get("search_id")
+        .or_else(|| meta.get("searchId"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .and_then(normalise_search_id)
+}
+
+fn selected_rank(
+    record: &SearchTelemetryRecord,
+    tool_slug: Option<&str>,
+    skill_name: Option<&str>,
+) -> Option<u32> {
+    if let Some(slug) = tool_slug
+        && let Some(hit) = record.hits.iter().find(|hit| hit.tool_slug == slug)
+    {
+        return Some(hit.rank);
+    }
+    let skill = skill_name?.to_ascii_lowercase();
+    record
+        .hits
+        .iter()
+        .find(|hit| {
+            hit.skill_name
+                .as_deref()
+                .is_some_and(|candidate| candidate.eq_ignore_ascii_case(&skill))
+        })
+        .map(|hit| hit.rank)
+}
+
+fn compute_stats(inner: &SearchTelemetryInner) -> SearchQualityStats {
+    let total = inner.records.len();
+    if total == 0 {
+        return SearchQualityStats {
+            total_searches: 0,
+            zero_result_count: 0,
+            zero_result_rate: 0.0,
+            selected_rank: None,
+            selected_count: 0,
+            top1_hit_rate: 0.0,
+            top3_hit_rate: 0.0,
+            top5_hit_rate: 0.0,
+            describe_after_search_rate: 0.0,
+            load_after_search_rate: 0.0,
+            call_after_search_rate: 0.0,
+            success_after_search_rate: 0.0,
+            query_reformulation_count: inner.query_reformulation_count,
+            query_reformulation_rate: 0.0,
+            time_to_first_success: None,
+            time_to_first_success_ms: None,
+        };
+    }
+
+    let zero_result_count = inner
+        .records
+        .iter()
+        .filter(|record| record.zero_results)
+        .count();
+    let mut selected_ranks = Vec::new();
+    let mut top1 = 0usize;
+    let mut top3 = 0usize;
+    let mut top5 = 0usize;
+    let mut describe = 0usize;
+    let mut load = 0usize;
+    let mut call = 0usize;
+    let mut success = 0usize;
+    let mut first_success_ms = Vec::new();
+
+    for record in &inner.records {
+        let kinds: HashSet<&str> = record
+            .followups
+            .iter()
+            .map(|followup| followup.kind.as_str())
+            .collect();
+        if kinds.contains("describe") {
+            describe += 1;
+        }
+        if kinds.contains("load_skill") {
+            load += 1;
+        }
+        if kinds.contains("call") {
+            call += 1;
+        }
+        if record.first_success_ms.is_some() {
+            success += 1;
+        }
+        if let Some(ms) = record.first_success_ms {
+            first_success_ms.push(ms);
+        }
+        if let Some(rank) = record
+            .followups
+            .iter()
+            .find_map(|followup| followup.selected_rank)
+        {
+            selected_ranks.push(rank);
+            if rank <= 1 {
+                top1 += 1;
+            }
+            if rank <= 3 {
+                top3 += 1;
+            }
+            if rank <= 5 {
+                top5 += 1;
+            }
+        }
+    }
+
+    let selected_count = selected_ranks.len();
+    let selected_rank = (!selected_ranks.is_empty()).then(|| {
+        selected_ranks.iter().map(|rank| *rank as f64).sum::<f64>() / selected_ranks.len() as f64
+    });
+    let avg_success_ms = (!first_success_ms.is_empty()).then(|| {
+        first_success_ms.iter().map(|ms| *ms as f64).sum::<f64>() / first_success_ms.len() as f64
+    });
+
+    SearchQualityStats {
+        total_searches: total,
+        zero_result_count,
+        zero_result_rate: rate(zero_result_count, total),
+        selected_rank,
+        selected_count,
+        top1_hit_rate: rate(top1, total),
+        top3_hit_rate: rate(top3, total),
+        top5_hit_rate: rate(top5, total),
+        describe_after_search_rate: rate(describe, total),
+        load_after_search_rate: rate(load, total),
+        call_after_search_rate: rate(call, total),
+        success_after_search_rate: rate(success, total),
+        query_reformulation_count: inner.query_reformulation_count,
+        query_reformulation_rate: rate(inner.query_reformulation_count, total),
+        time_to_first_success: avg_success_ms.map(|ms| ms / 1_000.0),
+        time_to_first_success_ms: avg_success_ms,
+    }
+}
+
+fn correlation_key(
+    trace_context: Option<&TraceContext>,
+    session_id: Option<&str>,
+    dcc_type: Option<&str>,
+) -> Option<String> {
+    trace_context
+        .map(|ctx| format!("trace:{}", ctx.trace_id))
+        .or_else(|| session_id.map(|session| format!("session:{session}")))
+        .or_else(|| dcc_type.map(|dcc| format!("dcc:{dcc}")))
+}
+
+fn query_preview(query: &str) -> Option<String> {
+    let redacted = redact_query(query);
+    let trimmed = redacted.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(take_chars(trimmed, MAX_QUERY_PREVIEW_CHARS))
+}
+
+fn redact_query(query: &str) -> String {
+    query
+        .split_whitespace()
+        .map(|part| {
+            let lowered = part.to_ascii_lowercase();
+            if lowered.contains("token=")
+                || lowered.contains("api_key")
+                || lowered.contains("apikey")
+                || lowered.contains("secret")
+                || lowered.contains("password")
+            {
+                "[redacted]"
+            } else {
+                part
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn normalise_query(query: &str) -> String {
+    query
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase()
+}
+
+fn hash_query(query: &str) -> String {
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in query.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{hash:016x}")
+}
+
+fn normalise_search_id(raw: String) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed.len() > 128 {
+        return None;
+    }
+    if trimmed
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | ':' | '.'))
+    {
+        Some(trimmed.to_string())
+    } else {
+        None
+    }
+}
+
+fn timestamp_ms(time: SystemTime) -> u64 {
+    time.duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_millis() as u64
+}
+
+fn bound_label(value: String, fallback: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        fallback.to_string()
+    } else {
+        take_chars(trimmed, 40)
+    }
+}
+
+fn take_chars(value: &str, max: usize) -> String {
+    value.chars().take(max).collect()
+}
+
+fn rank_bucket(rank: Option<u32>) -> &'static str {
+    match rank {
+        Some(1) => "top1",
+        Some(2 | 3) => "top3",
+        Some(4 | 5) => "top5",
+        Some(_) => "beyond5",
+        None => "unknown",
+    }
+}
+
+fn rate(count: usize, total: usize) -> f64 {
+    if total == 0 {
+        0.0
+    } else {
+        count as f64 / total as f64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn trace(id: &str) -> TraceContext {
+        TraceContext {
+            trace_id: "4bf92f3577b34da6a3ce929d0e0e4736".to_string(),
+            request_id: id.to_string(),
+            span_id: Some("00f067aa0ba902b7".to_string()),
+            parent_span_id: None,
+            parent_request_id: None,
+            trace_flags: Some("01".to_string()),
+            trace_state: None,
+        }
+    }
+
+    fn hit(slug: &str, skill: &str, rank: u32) -> SearchTelemetryHit {
+        SearchTelemetryHit {
+            tool_slug: slug.to_string(),
+            skill_name: Some(skill.to_string()),
+            dcc_type: "maya".to_string(),
+            rank,
+            score: 100 - rank,
+            match_reasons: vec!["tool_lexical".to_string()],
+            loaded: true,
+        }
+    }
+
+    #[test]
+    fn store_correlates_describe_load_call_and_batch_followups() {
+        let store = SearchTelemetryStore::with_capacity(10);
+        let search_id = SearchTelemetryStore::new_search_id();
+        store.record_search(SearchTelemetryInput {
+            search_id: search_id.clone(),
+            transport: "rest".to_string(),
+            kind: "tool".to_string(),
+            query: "create sphere".to_string(),
+            dcc_type: Some("maya".to_string()),
+            instance_id: None,
+            limit: Some(5),
+            total: 2,
+            ranker_version: RANKER_VERSION.to_string(),
+            index_generation: "idx1".to_string(),
+            hits: vec![
+                hit("maya.11111111.create_sphere", "maya-geometry", 1),
+                hit("maya.11111111.create_cube", "maya-geometry", 2),
+            ],
+            trace_context: Some(trace("search-1")),
+            session_id: Some("sess-1".to_string()),
+        });
+        for (kind, slug, skill, success) in [
+            ("describe", Some("maya.11111111.create_sphere"), None, true),
+            ("load_skill", None, Some("maya-geometry"), true),
+            ("call", Some("maya.11111111.create_sphere"), None, false),
+            ("call", Some("maya.11111111.create_sphere"), None, true),
+            ("call", Some("maya.11111111.create_cube"), None, true),
+        ] {
+            store.record_followup(SearchFollowupInput {
+                search_id: search_id.clone(),
+                kind: kind.to_string(),
+                tool_slug: slug.map(str::to_string),
+                skill_name: skill.map(str::to_string),
+                success,
+                trace_context: Some(trace(kind)),
+            });
+        }
+
+        let snapshot = store.snapshot(10);
+        assert_eq!(snapshot.stats.total_searches, 1);
+        assert_eq!(snapshot.stats.describe_after_search_rate, 1.0);
+        assert_eq!(snapshot.stats.load_after_search_rate, 1.0);
+        assert_eq!(snapshot.stats.call_after_search_rate, 1.0);
+        assert_eq!(snapshot.stats.success_after_search_rate, 1.0);
+        assert_eq!(snapshot.stats.top1_hit_rate, 1.0);
+        assert_eq!(snapshot.recent[0].followups.len(), 5);
+    }
+
+    #[test]
+    fn store_counts_zero_results_and_reformulations_without_full_prompt_leak() {
+        let store = SearchTelemetryStore::with_capacity(10);
+        let first = "search-a".to_string();
+        store.record_search(SearchTelemetryInput {
+            search_id: first,
+            transport: "mcp".to_string(),
+            kind: "tool".to_string(),
+            query: "token=abc123 impossible query".to_string(),
+            dcc_type: Some("maya".to_string()),
+            instance_id: None,
+            limit: Some(5),
+            total: 0,
+            ranker_version: RANKER_VERSION.to_string(),
+            index_generation: "idx1".to_string(),
+            hits: Vec::new(),
+            trace_context: Some(trace("search-a")),
+            session_id: None,
+        });
+        store.record_search(SearchTelemetryInput {
+            search_id: "search-b".to_string(),
+            transport: "mcp".to_string(),
+            kind: "tool".to_string(),
+            query: "sphere".to_string(),
+            dcc_type: Some("maya".to_string()),
+            instance_id: None,
+            limit: Some(5),
+            total: 1,
+            ranker_version: RANKER_VERSION.to_string(),
+            index_generation: "idx1".to_string(),
+            hits: vec![hit("maya.11111111.create_sphere", "maya-geometry", 1)],
+            trace_context: Some(trace("search-b")),
+            session_id: None,
+        });
+
+        let snapshot = store.snapshot(10);
+        assert_eq!(snapshot.stats.zero_result_count, 1);
+        assert_eq!(snapshot.stats.query_reformulation_count, 1);
+        assert_eq!(
+            snapshot.recent[1].query_preview.as_deref(),
+            Some("[redacted] impossible query")
+        );
+    }
+}

--- a/crates/dcc-mcp-gateway/src/gateway/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state.rs
@@ -249,6 +249,9 @@ pub struct GatewayState {
     /// Opt-in development traffic capture (RFC 0003 P0).
     pub traffic_capture: Arc<super::traffic::TrafficCapture>,
 
+    /// Search-quality telemetry store used by admin/debug APIs and metrics.
+    pub search_telemetry: Arc<super::search_telemetry::SearchTelemetryStore>,
+
     /// Whether stable gateway `/v1/debug/*` routes are mounted on this router.
     ///
     /// The routes require the `admin` feature at compile time and an AdminState

--- a/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/state/tests.rs
@@ -53,6 +53,7 @@ fn test_gateway_state_with_own_and_unknown(
             crate::gateway::instance_diagnostics::InstanceDiagnosticsStore::new(),
         ),
         traffic_capture: Arc::new(crate::gateway::traffic::TrafficCapture::disabled()),
+        search_telemetry: Arc::new(crate::gateway::search_telemetry::SearchTelemetryStore::new()),
         debug_routes_enabled: false,
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/tasks.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tasks.rs
@@ -589,6 +589,7 @@ pub(crate) async fn start_gateway_tasks(
         middleware_chain: Arc::new(middleware_chain),
         instance_diagnostics: instance_diagnostics.clone(),
         traffic_capture,
+        search_telemetry: Arc::new(crate::gateway::search_telemetry::SearchTelemetryStore::new()),
         debug_routes_enabled: false,
     };
 

--- a/crates/dcc-mcp-gateway/src/gateway/tools.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tools.rs
@@ -3,6 +3,11 @@
 use serde_json::{Value, json};
 
 use crate::gateway::admin::trace::TraceContext;
+use crate::gateway::capability_service::{SearchResponseContext, search_hit_to_value_with_context};
+use crate::gateway::search_telemetry::{
+    RANKER_VERSION, SearchFollowupInput, SearchTelemetryHit, SearchTelemetryInput,
+    search_id_from_meta, search_id_from_payload,
+};
 
 use super::state::GatewayState;
 use dcc_mcp_jsonrpc::coerce_tool_arguments_object;
@@ -145,7 +150,13 @@ pub async fn tool_release_instance(gs: &GatewayState, args: &Value) -> Result<St
 // ── Gateway MCP tools ────────────────────────────────────────────────────
 
 /// Unified search: backend capabilities (`kind=tool`, default) or skills (`kind=skill`).
-pub async fn tool_search(gs: &GatewayState, args: &Value) -> Result<String, String> {
+pub async fn tool_search(
+    gs: &GatewayState,
+    args: &Value,
+    meta: Option<&Value>,
+    trace_context: Option<&TraceContext>,
+    session_id: Option<&str>,
+) -> Result<String, String> {
     let kind = args
         .get("kind")
         .and_then(Value::as_str)
@@ -164,33 +175,82 @@ pub async fn tool_search(gs: &GatewayState, args: &Value) -> Result<String, Stri
             };
             let (text, is_error) =
                 crate::gateway::aggregator::skill_mgmt_dispatch(gs, legacy, args).await;
-            if is_error { Err(text) } else { Ok(text) }
+            if is_error {
+                Err(text)
+            } else {
+                Ok(annotate_skill_search_payload(
+                    gs,
+                    args,
+                    &text,
+                    trace_context,
+                    session_id,
+                ))
+            }
         }
         "all" => {
-            let tools_json = tool_search_tools(gs, args).await?;
+            let tools_json = tool_search_tools(gs, args, trace_context, session_id).await?;
             let (skills_text, skills_err) =
                 crate::gateway::aggregator::skill_mgmt_dispatch(gs, "list_skills", args).await;
             if skills_err {
                 return Err(skills_text);
             }
+            let tools_value = serde_json::from_str::<Value>(&tools_json).unwrap_or(Value::Null);
+            let skills_json =
+                annotate_skill_search_payload(gs, args, &skills_text, trace_context, session_id);
+            let skills_value = serde_json::from_str::<Value>(&skills_json).unwrap_or(Value::Null);
+            let search_id = tools_value
+                .get("search_id")
+                .or_else(|| skills_value.get("search_id"))
+                .cloned()
+                .unwrap_or(Value::Null);
+            let ranker_version = tools_value
+                .get("ranker_version")
+                .or_else(|| skills_value.get("ranker_version"))
+                .cloned()
+                .unwrap_or_else(|| json!(RANKER_VERSION));
+            let index_generation = tools_value
+                .get("index_generation")
+                .or_else(|| skills_value.get("index_generation"))
+                .cloned()
+                .unwrap_or(Value::Null);
             Ok(serde_json::to_string_pretty(&json!({
-                "tools": serde_json::from_str::<Value>(&tools_json).unwrap_or(Value::Null),
-                "skills": serde_json::from_str::<Value>(&skills_text).unwrap_or(Value::Null),
+                "search_id": search_id,
+                "ranker_version": ranker_version,
+                "index_generation": index_generation,
+                "tools": tools_value,
+                "skills": skills_value,
             }))
             .map_err(|e| e.to_string())?)
         }
-        _ => tool_search_tools(gs, args).await,
+        _ => {
+            let _ = meta;
+            tool_search_tools(gs, args, trace_context, session_id).await
+        }
     }
 }
 
 /// Unified describe: `tool_slug` for backend schema, or `skill_name` for skill detail.
-pub async fn tool_describe(gs: &GatewayState, args: &Value) -> Result<String, String> {
+pub async fn tool_describe(
+    gs: &GatewayState,
+    args: &Value,
+    meta: Option<&Value>,
+    trace_context: Option<&TraceContext>,
+) -> Result<String, String> {
     if args.get("tool_slug").and_then(Value::as_str).is_some() {
-        return tool_describe_tool(gs, args).await;
+        return tool_describe_tool(gs, args, meta, trace_context).await;
     }
     if args.get("skill_name").and_then(Value::as_str).is_some() {
         let (text, is_error) =
             crate::gateway::aggregator::skill_mgmt_dispatch(gs, "get_skill_info", args).await;
+        record_search_followup(
+            gs,
+            search_id_from_inputs(args, meta).as_deref(),
+            "describe",
+            None,
+            skill_name_from_payload(args),
+            !is_error,
+            trace_context,
+        );
         if is_error { Err(text) } else { Ok(text) }
     } else {
         Err("describe requires `tool_slug` (from search) or `skill_name`".to_string())
@@ -305,7 +365,12 @@ pub async fn tool_load_skill(gs: &GatewayState, args: &Value) -> (String, bool) 
 ///
 /// Kept alongside the REST handler so both transports produce
 /// byte-identical responses for the same query.
-pub async fn tool_search_tools(gs: &GatewayState, args: &Value) -> Result<String, String> {
+pub async fn tool_search_tools(
+    gs: &GatewayState,
+    args: &Value,
+    trace_context: Option<&TraceContext>,
+    session_id: Option<&str>,
+) -> Result<String, String> {
     // Refresh on demand so the first query after startup (or after
     // a skill load/unload) always sees current capabilities.
     crate::gateway::capability_service::refresh_all_live_backends(
@@ -314,13 +379,42 @@ pub async fn tool_search_tools(gs: &GatewayState, args: &Value) -> Result<String
     )
     .await;
     let query = crate::gateway::capability_service::parse_search_payload(args);
-    let annotated = crate::gateway::capability_service::search_service_rows_for_policy(
+    let index_generation =
+        crate::gateway::capability_service::index_generation(&gs.capability_index);
+    let search_context = SearchResponseContext::new(
+        crate::gateway::search_telemetry::SearchTelemetryStore::new_search_id(),
+        index_generation,
+    );
+    let hits = crate::gateway::capability_service::search_service_hits_for_policy(
         &gs.capability_index,
         &query,
         &gs.policy,
     );
+    let telemetry_hits = search_hits_for_telemetry(&hits);
+    let annotated: Vec<Value> = hits
+        .into_iter()
+        .map(|hit| search_hit_to_value_with_context(hit, Some(&search_context)))
+        .collect();
+    gs.search_telemetry.record_search(SearchTelemetryInput {
+        search_id: search_context.search_id.clone(),
+        transport: "mcp".to_string(),
+        kind: "tool".to_string(),
+        query: query.query.clone(),
+        dcc_type: query.dcc_type.clone(),
+        instance_id: query.instance_id.map(|id| id.to_string()),
+        limit: query.limit,
+        total: annotated.len(),
+        ranker_version: search_context.ranker_version.to_string(),
+        index_generation: search_context.index_generation.clone(),
+        hits: telemetry_hits,
+        trace_context: trace_context.cloned(),
+        session_id: session_id.map(str::to_string),
+    });
 
     serde_json::to_string_pretty(&json!({
+        "search_id": search_context.search_id,
+        "ranker_version": search_context.ranker_version,
+        "index_generation": search_context.index_generation,
         "total": annotated.len(),
         "hits":  annotated,
     }))
@@ -329,7 +423,12 @@ pub async fn tool_search_tools(gs: &GatewayState, args: &Value) -> Result<String
 
 /// `describe_tool` — MCP wrapper around
 /// [`crate::gateway::capability_service::describe_service`].
-pub async fn tool_describe_tool(gs: &GatewayState, args: &Value) -> Result<String, String> {
+pub async fn tool_describe_tool(
+    gs: &GatewayState,
+    args: &Value,
+    meta: Option<&Value>,
+    trace_context: Option<&TraceContext>,
+) -> Result<String, String> {
     let Some(slug) = args.get("tool_slug").and_then(|v| v.as_str()) else {
         return Err("missing required argument: tool_slug".to_string());
     };
@@ -340,25 +439,47 @@ pub async fn tool_describe_tool(gs: &GatewayState, args: &Value) -> Result<Strin
         crate::gateway::capability::RefreshReason::Periodic,
     )
     .await;
+    let search_id = search_id_from_inputs(args, meta);
     match crate::gateway::capability_service::describe_tool_full(gs, slug).await {
         Ok((record, tool)) => {
+            record_search_followup(
+                gs,
+                search_id.as_deref(),
+                "describe",
+                Some(slug),
+                None,
+                true,
+                trace_context,
+            );
             let input_schema = tool.input_schema.clone();
             let required = input_schema
                 .get("required")
                 .cloned()
                 .unwrap_or_else(|| json!([]));
             let properties = input_schema.get("properties").cloned();
-            serde_json::to_string_pretty(&json!({
+            let mut payload = json!({
                 "record": record,
                 "tool": tool,
                 "input_schema": input_schema,
                 "required": required,
                 "properties": properties,
                 "hint": "Copy parameter names from `properties` / `required` into call.arguments (e.g. export_fbx uses `path`, not `destination`).",
-            }))
-            .map_err(|e| e.to_string())
+            });
+            if let Some(search_id) = search_id.as_deref() {
+                payload["next_step"] = call_next_step(slug, search_id);
+            }
+            serde_json::to_string_pretty(&payload).map_err(|e| e.to_string())
         }
         Err(err) => {
+            record_search_followup(
+                gs,
+                search_id.as_deref(),
+                "describe",
+                Some(slug),
+                None,
+                false,
+                trace_context,
+            );
             let payload = crate::gateway::capability_service::service_error_to_json(&err);
             Err(serde_json::to_string_pretty(&payload).unwrap_or_else(|_| err.message.clone()))
         }
@@ -384,6 +505,7 @@ pub async fn tool_call_tool(
         Err(msg) => return (msg, true),
     };
     let forwarded_meta = args.get("meta").cloned().or_else(|| meta.cloned());
+    let search_id = search_id_from_inputs(args, meta);
     // No refresh here on purpose: `call_tool` is the hot path and
     // we trust that the caller used `describe_tool` / `search_tools`
     // to obtain the slug, both of which refresh. An unknown-slug
@@ -399,10 +521,21 @@ pub async fn tool_call_tool(
     )
     .await
     {
-        Ok(result) => (
-            serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string()),
-            false,
-        ),
+        Ok(result) => {
+            record_search_followup(
+                gs,
+                search_id.as_deref(),
+                "call",
+                Some(slug),
+                None,
+                true,
+                trace_context,
+            );
+            (
+                serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string()),
+                false,
+            )
+        }
         Err(err) if err.kind == "unknown-slug" => {
             // Refresh once in case the caller supplied a slug that
             // just became valid (e.g. a skill loaded between
@@ -421,11 +554,32 @@ pub async fn tool_call_tool(
             )
             .await
             {
-                Ok(result) => (
-                    serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string()),
-                    false,
-                ),
+                Ok(result) => {
+                    record_search_followup(
+                        gs,
+                        search_id.as_deref(),
+                        "call",
+                        Some(slug),
+                        None,
+                        true,
+                        trace_context,
+                    );
+                    (
+                        serde_json::to_string_pretty(&result)
+                            .unwrap_or_else(|_| result.to_string()),
+                        false,
+                    )
+                }
                 Err(err2) => {
+                    record_search_followup(
+                        gs,
+                        search_id.as_deref(),
+                        "call",
+                        Some(slug),
+                        None,
+                        false,
+                        trace_context,
+                    );
                     let payload = crate::gateway::capability_service::service_error_to_json(&err2);
                     (
                         serde_json::to_string_pretty(&payload)
@@ -436,6 +590,15 @@ pub async fn tool_call_tool(
             }
         }
         Err(err) => {
+            record_search_followup(
+                gs,
+                search_id.as_deref(),
+                "call",
+                Some(slug),
+                None,
+                false,
+                trace_context,
+            );
             let payload = crate::gateway::capability_service::service_error_to_json(&err);
             (
                 serde_json::to_string_pretty(&payload).unwrap_or_else(|_| err.message.clone()),
@@ -513,6 +676,10 @@ pub async fn gateway_call_batch_inner(
             Err(msg) => return Err(msg),
         };
         let forwarded_meta = call.get("meta").cloned().or_else(|| mcp_meta.cloned());
+        let search_id = call
+            .get("meta")
+            .and_then(search_id_from_meta)
+            .or_else(|| mcp_meta.and_then(search_id_from_meta));
 
         let single_outcome = async {
             match crate::gateway::capability_service::call_service(
@@ -547,6 +714,15 @@ pub async fn gateway_call_batch_inner(
 
         match single_outcome {
             Ok(result) => {
+                record_search_followup(
+                    gs,
+                    search_id.as_deref(),
+                    "call",
+                    Some(slug),
+                    None,
+                    true,
+                    trace_context,
+                );
                 let mut item = json!({
                     "index": idx,
                     "tool_slug": slug,
@@ -559,6 +735,15 @@ pub async fn gateway_call_batch_inner(
                 results.push(item);
             }
             Err(err) => {
+                record_search_followup(
+                    gs,
+                    search_id.as_deref(),
+                    "call",
+                    Some(slug),
+                    None,
+                    false,
+                    trace_context,
+                );
                 all_ok = false;
                 let payload = crate::gateway::capability_service::service_error_to_json(&err);
                 let mut item = json!({
@@ -609,6 +794,254 @@ pub async fn tool_call_tools(
 }
 
 // ── private helpers ────────────────────────────────────────────────────────
+
+pub(crate) fn record_load_skill_search_followup(
+    gs: &GatewayState,
+    args: &Value,
+    meta: Option<&Value>,
+    trace_context: Option<&TraceContext>,
+    success: bool,
+) {
+    record_search_followup(
+        gs,
+        search_id_from_inputs(args, meta).as_deref(),
+        "load_skill",
+        None,
+        skill_name_from_payload(args),
+        success,
+        trace_context,
+    );
+}
+
+fn annotate_skill_search_payload(
+    gs: &GatewayState,
+    args: &Value,
+    text: &str,
+    trace_context: Option<&TraceContext>,
+    session_id: Option<&str>,
+) -> String {
+    let search_id = crate::gateway::search_telemetry::SearchTelemetryStore::new_search_id();
+    let index_generation =
+        crate::gateway::capability_service::index_generation(&gs.capability_index);
+    let mut payload = serde_json::from_str::<Value>(text).unwrap_or_else(|_| json!({"raw": text}));
+    let mut telemetry_hits = Vec::new();
+    let skills = payload
+        .get_mut("skills")
+        .and_then(Value::as_array_mut)
+        .map(|items| {
+            for (idx, skill) in items.iter_mut().enumerate() {
+                if let Some(obj) = skill.as_object_mut() {
+                    let rank = (idx + 1) as u32;
+                    obj.entry("rank".to_string()).or_insert_with(|| json!(rank));
+                    let skill_name = obj
+                        .get("name")
+                        .or_else(|| obj.get("skill_name"))
+                        .or_else(|| obj.get("skill"))
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string();
+                    let tool_slug = obj
+                        .get("tool_slug")
+                        .or_else(|| obj.get("slug"))
+                        .and_then(Value::as_str)
+                        .unwrap_or(skill_name.as_str())
+                        .to_string();
+                    let dcc_type = obj
+                        .get("_dcc_type")
+                        .or_else(|| obj.get("dcc_type"))
+                        .or_else(|| obj.get("dcc"))
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string();
+                    let instance_id = obj
+                        .get("_instance_id")
+                        .or_else(|| obj.get("instance_id"))
+                        .and_then(Value::as_str)
+                        .map(str::to_string);
+                    telemetry_hits.push(SearchTelemetryHit {
+                        tool_slug,
+                        skill_name: (!skill_name.is_empty()).then_some(skill_name.clone()),
+                        dcc_type: dcc_type.clone(),
+                        rank,
+                        score: obj
+                            .get("score")
+                            .and_then(Value::as_u64)
+                            .map_or(0, |score| score as u32),
+                        match_reasons: obj
+                            .get("match_reasons")
+                            .and_then(Value::as_array)
+                            .map(|items| {
+                                items
+                                    .iter()
+                                    .filter_map(Value::as_str)
+                                    .map(str::to_string)
+                                    .collect()
+                            })
+                            .unwrap_or_default(),
+                        loaded: obj.get("loaded").and_then(Value::as_bool).unwrap_or(false),
+                    });
+                    let mut next_args = json!({
+                        "skill_name": skill_name,
+                    });
+                    if !dcc_type.is_empty() {
+                        next_args["dcc"] = json!(dcc_type);
+                    }
+                    if let Some(instance_id) = instance_id {
+                        next_args["instance_id"] = json!(instance_id);
+                    }
+                    attach_search_meta(&mut next_args, &search_id, &index_generation);
+                    obj.insert(
+                        "next_step".to_string(),
+                        json!({
+                            "action": "load_skill",
+                            "arguments": next_args.clone(),
+                            "mcp": {
+                                "tool": "load_skill",
+                                "arguments": next_args.clone(),
+                                "_meta": next_args["meta"].clone(),
+                            },
+                            "rest": {
+                                "method": "POST",
+                                "path": "/v1/load_skill",
+                                "body": next_args,
+                            },
+                        }),
+                    );
+                }
+            }
+            items.len()
+        })
+        .unwrap_or(0);
+    if let Some(obj) = payload.as_object_mut() {
+        obj.insert("search_id".to_string(), json!(search_id.clone()));
+        obj.insert("ranker_version".to_string(), json!(RANKER_VERSION));
+        obj.insert(
+            "index_generation".to_string(),
+            json!(index_generation.clone()),
+        );
+    }
+    gs.search_telemetry.record_search(SearchTelemetryInput {
+        search_id,
+        transport: "mcp".to_string(),
+        kind: "skill".to_string(),
+        query: args
+            .get("query")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        dcc_type: args
+            .get("dcc_type")
+            .or_else(|| args.get("dcc"))
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        instance_id: args
+            .get("instance_id")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        limit: args
+            .get("limit")
+            .and_then(Value::as_u64)
+            .map(|value| value as u32),
+        total: skills,
+        ranker_version: RANKER_VERSION.to_string(),
+        index_generation,
+        hits: telemetry_hits,
+        trace_context: trace_context.cloned(),
+        session_id: session_id.map(str::to_string),
+    });
+    serde_json::to_string_pretty(&payload).unwrap_or_else(|_| text.to_string())
+}
+
+fn search_hits_for_telemetry(
+    hits: &[crate::gateway::capability::SearchHit],
+) -> Vec<SearchTelemetryHit> {
+    hits.iter()
+        .map(|hit| SearchTelemetryHit {
+            tool_slug: hit.record.tool_slug.clone(),
+            skill_name: hit.record.skill_name.clone(),
+            dcc_type: hit.record.dcc_type.clone(),
+            rank: hit.rank,
+            score: hit.score,
+            match_reasons: hit.match_reasons.clone(),
+            loaded: hit.record.loaded,
+        })
+        .collect()
+}
+
+fn record_search_followup(
+    gs: &GatewayState,
+    search_id: Option<&str>,
+    kind: &str,
+    tool_slug: Option<&str>,
+    skill_name: Option<String>,
+    success: bool,
+    trace_context: Option<&TraceContext>,
+) {
+    let Some(search_id) = search_id else {
+        return;
+    };
+    gs.search_telemetry.record_followup(SearchFollowupInput {
+        search_id: search_id.to_string(),
+        kind: kind.to_string(),
+        tool_slug: tool_slug.map(str::to_string),
+        skill_name,
+        success,
+        trace_context: trace_context.cloned(),
+    });
+}
+
+fn search_id_from_inputs(args: &Value, meta: Option<&Value>) -> Option<String> {
+    search_id_from_payload(args).or_else(|| meta.and_then(search_id_from_meta))
+}
+
+fn skill_name_from_payload(payload: &Value) -> Option<String> {
+    payload
+        .get("skill_name")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| {
+            payload
+                .get("skill_names")
+                .and_then(Value::as_array)
+                .and_then(|items| items.iter().find_map(Value::as_str))
+                .map(str::to_string)
+        })
+}
+
+fn call_next_step(slug: &str, search_id: &str) -> Value {
+    let mut arguments = json!({
+        "tool_slug": slug,
+        "arguments": {},
+    });
+    attach_search_meta(&mut arguments, search_id, "");
+    json!({
+        "action": "call",
+        "arguments": arguments.clone(),
+        "mcp": {
+            "tool": "call",
+            "arguments": arguments.clone(),
+            "_meta": arguments["meta"].clone(),
+        },
+        "rest": {
+            "method": "POST",
+            "path": "/v1/call",
+            "body": arguments,
+        },
+    })
+}
+
+fn attach_search_meta(arguments: &mut Value, search_id: &str, index_generation: &str) {
+    if let Some(obj) = arguments.as_object_mut() {
+        let mut meta = json!({
+            "search_id": search_id,
+            "ranker_version": RANKER_VERSION,
+        });
+        if !index_generation.is_empty() {
+            meta["index_generation"] = json!(index_generation);
+        }
+        obj.insert("meta".to_string(), meta);
+    }
+}
 
 /// Return the advertised gateway MCP workflow surface.
 ///

--- a/crates/dcc-mcp-telemetry/src/prometheus.rs
+++ b/crates/dcc-mcp-telemetry/src/prometheus.rs
@@ -31,15 +31,19 @@
 //! | `dcc_mcp_notifications_sent_total`  | counter   | `channel` |
 //! | `dcc_mcp_active_sessions`           | gauge     | — |
 //! | `dcc_mcp_registered_tools`          | gauge     | — |
-//! | `dcc_mcp_gateway_backend_errors_total` | counter | `kind` (gateway → backend hop) |
+//! | `dcc_mcp_gateway_backend_errors_total` | counter | `kind` (gateway -> backend hop) |
+//! | `dcc_mcp_gateway_searches_total` | counter | `result` (`zero`, `nonzero`) |
+//! | `dcc_mcp_gateway_search_followups_total` | counter | `kind`, `rank_bucket` |
+//! | `dcc_mcp_gateway_search_reformulations_total` | counter | - |
+//! | `dcc_mcp_gateway_search_time_to_first_success_seconds` | histogram | - |
 //! | `dcc_mcp_build_info`                | gauge     | `version`, `crate` (always 1) |
 
 use std::sync::Arc;
 
 use parking_lot::Mutex;
 use prometheus::{
-    Encoder, Gauge, GaugeVec, HistogramOpts, HistogramVec, IntCounterVec, IntGauge, IntGaugeVec,
-    Opts, Registry, TextEncoder,
+    Encoder, Gauge, GaugeVec, Histogram, HistogramOpts, HistogramVec, IntCounter, IntCounterVec,
+    IntGauge, IntGaugeVec, Opts, Registry, TextEncoder,
 };
 
 use crate::recorder::ToolRecorder;
@@ -88,6 +92,10 @@ struct Inner {
     /// Gateway-only: backend hop failures by coarse error class (`transport`,
     /// `http_5xx`, `jsonrpc_backend`, …). See `PrometheusExporter::record_gateway_backend_error`.
     gateway_backend_errors_total: IntCounterVec,
+    gateway_searches_total: IntCounterVec,
+    gateway_search_followups_total: IntCounterVec,
+    gateway_search_reformulations_total: IntCounter,
+    gateway_search_time_to_first_success_seconds: Histogram,
 
     #[allow(dead_code)]
     build_info: GaugeVec,
@@ -281,6 +289,53 @@ impl PrometheusExporter {
             .register(Box::new(gateway_backend_errors_total.clone()))
             .expect("unique registration");
 
+        let gateway_searches_total = IntCounterVec::new(
+            Opts::new(
+                "dcc_mcp_gateway_searches_total",
+                "Gateway search requests by bounded result class.",
+            ),
+            &["result"],
+        )
+        .expect("static metric definition");
+        registry
+            .register(Box::new(gateway_searches_total.clone()))
+            .expect("unique registration");
+
+        let gateway_search_followups_total = IntCounterVec::new(
+            Opts::new(
+                "dcc_mcp_gateway_search_followups_total",
+                "Gateway search follow-up operations by type and selected-rank bucket.",
+            ),
+            &["kind", "rank_bucket"],
+        )
+        .expect("static metric definition");
+        registry
+            .register(Box::new(gateway_search_followups_total.clone()))
+            .expect("unique registration");
+
+        let gateway_search_reformulations_total = IntCounter::with_opts(Opts::new(
+            "dcc_mcp_gateway_search_reformulations_total",
+            "Gateway searches that reformulate a recent unsuccessful query.",
+        ))
+        .expect("static metric definition");
+        registry
+            .register(Box::new(gateway_search_reformulations_total.clone()))
+            .expect("unique registration");
+
+        let gateway_search_time_to_first_success_seconds = Histogram::with_opts(
+            HistogramOpts::new(
+                "dcc_mcp_gateway_search_time_to_first_success_seconds",
+                "Seconds from a gateway search to the first successful correlated tool call.",
+            )
+            .buckets(DURATION_BUCKETS_SECONDS.to_vec()),
+        )
+        .expect("static metric definition");
+        registry
+            .register(Box::new(
+                gateway_search_time_to_first_success_seconds.clone(),
+            ))
+            .expect("unique registration");
+
         Self {
             inner: Arc::new(Inner {
                 registry,
@@ -297,6 +352,10 @@ impl PrometheusExporter {
                 request_duration_seconds,
                 requests_failed_total,
                 gateway_backend_errors_total,
+                gateway_searches_total,
+                gateway_search_followups_total,
+                gateway_search_reformulations_total,
+                gateway_search_time_to_first_success_seconds,
                 build_info,
                 recorder: Mutex::new(None),
             }),
@@ -421,6 +480,34 @@ impl PrometheusExporter {
             .inc();
     }
 
+    /// Record a gateway search request by bounded result class (`zero` or `nonzero`).
+    pub fn record_gateway_search(&self, result: &str) {
+        self.inner
+            .gateway_searches_total
+            .with_label_values(&[result])
+            .inc();
+    }
+
+    /// Record a follow-up selected from a prior search.
+    pub fn record_gateway_search_followup(&self, kind: &str, rank_bucket: &str) {
+        self.inner
+            .gateway_search_followups_total
+            .with_label_values(&[kind, rank_bucket])
+            .inc();
+    }
+
+    /// Record a query reformulation after a recent unsuccessful search.
+    pub fn record_gateway_search_reformulation(&self) {
+        self.inner.gateway_search_reformulations_total.inc();
+    }
+
+    /// Observe the time from search response to first successful correlated call.
+    pub fn observe_gateway_search_time_to_first_success(&self, duration: std::time::Duration) {
+        self.inner
+            .gateway_search_time_to_first_success_seconds
+            .observe(duration.as_secs_f64());
+    }
+
     /// Render the current metric state as a Prometheus text-exposition
     /// payload. This is what `/metrics` hands back to scrapers.
     ///
@@ -521,6 +608,10 @@ mod tests {
         exp.observe_job_wait("seed", Duration::from_millis(1));
         exp.record_notification_sent("seed");
         exp.record_gateway_backend_error("seed");
+        exp.record_gateway_search("nonzero");
+        exp.record_gateway_search_followup("describe", "top1");
+        exp.record_gateway_search_reformulation();
+        exp.observe_gateway_search_time_to_first_success(Duration::from_millis(10));
     }
 
     #[test]
@@ -539,6 +630,10 @@ mod tests {
             "dcc_mcp_active_sessions",
             "dcc_mcp_registered_tools",
             "dcc_mcp_gateway_backend_errors_total",
+            "dcc_mcp_gateway_searches_total",
+            "dcc_mcp_gateway_search_followups_total",
+            "dcc_mcp_gateway_search_reformulations_total",
+            "dcc_mcp_gateway_search_time_to_first_success_seconds",
             "dcc_mcp_build_info",
         ] {
             assert!(
@@ -559,6 +654,27 @@ mod tests {
         assert!(out.contains("# TYPE dcc_mcp_tool_calls_total counter"));
         assert!(out.contains("# TYPE dcc_mcp_tool_duration_seconds histogram"));
         assert!(out.contains("# TYPE dcc_mcp_active_sessions gauge"));
+        assert!(out.contains("# TYPE dcc_mcp_gateway_searches_total counter"));
+        assert!(
+            out.contains("# TYPE dcc_mcp_gateway_search_time_to_first_success_seconds histogram")
+        );
+    }
+
+    #[test]
+    fn gateway_search_metrics_are_recorded() {
+        let exp = PrometheusExporter::new();
+        exp.record_gateway_search("zero");
+        exp.record_gateway_search_followup("call", "top3");
+        exp.record_gateway_search_reformulation();
+        exp.observe_gateway_search_time_to_first_success(Duration::from_millis(250));
+
+        let out = exp.render().unwrap();
+        assert!(out.contains(r#"dcc_mcp_gateway_searches_total{result="zero"} 1"#));
+        assert!(out.contains(
+            r#"dcc_mcp_gateway_search_followups_total{kind="call",rank_bucket="top3"} 1"#
+        ));
+        assert!(out.contains("dcc_mcp_gateway_search_reformulations_total 1"));
+        assert!(out.contains("dcc_mcp_gateway_search_time_to_first_success_seconds_count 1"));
     }
 
     #[test]

--- a/docs/guide/rest-api-surface.md
+++ b/docs/guide/rest-api-surface.md
@@ -383,11 +383,17 @@ single-call, and batch execution also expose stable observability headers:
 | `x-dcc-mcp-trace-id` | End-to-end trace id for gateway, sidecar, and host correlation. |
 | `traceparent` | W3C trace context for clients that continue the HTTP trace. |
 | `x-dcc-mcp-index-generation` | Opaque capability-index fingerprint when the route touches discovery/call state. |
+| `x-dcc-mcp-search-id` | Search-quality correlation id when a route creates or consumes a search result set. |
+| `x-dcc-mcp-ranker-version` | Bounded ranker identifier for the correlated search result set. |
 
 `/v1/search`, `/v1/describe`, `/v1/load_skill`, and `/v1/call_batch` also include
 `request_id`, `trace_id`, and `index_generation` in JSON/TOON bodies. `/v1/call`
 keeps the backend result envelope byte-shape compatible and exposes this metadata
 through headers only.
+Search responses also include `search_id`, `ranker_version`, and
+`index_generation`; pass `meta.search_id` from the returned `next_step` into
+`/v1/describe`, `/v1/load_skill`, `/v1/call`, or `/v1/call_batch` so gateway
+telemetry can measure the search-to-action path without storing full prompts.
 
 ---
 
@@ -448,18 +454,25 @@ Rules:
   `tool_lexical`, `alias_lexical`, `schema_lexical`, `summary_fuzzy`,
   `schema_fuzzy`, or `multi_token_lexical`
   so agents and maintainers can understand the rank without fetching schemas.
+- Gateway hits include one-based `rank`. Generated `next_step` payloads carry
+  `meta.search_id`, `meta.ranker_version`, and `meta.index_generation` for
+  follow-up calls; clients may also pass the same object as MCP `_meta`.
 - Full `input_schema` remains behind `describe`. Search may carry only bounded
   `metadata.dcc.searchAliases` / `metadata.dcc.searchTokens` hints from a
   per-DCC backend to the gateway index; gateway search responses do not expose
   those internal index tokens as public fields.
 
-Response shape (gateway + per-DCC are identical):
+Gateway response shape:
 
 ```json
 {
+  "search_id": "9c8a1e9f-8d6f-4f3f-86e5-a9caa9138a5d",
+  "ranker_version": "gateway-hybrid-v2",
+  "index_generation": "1:ab12cd34",
   "total": 3,
   "hits": [
     {
+      "rank": 1,
       "slug": "maya.a1b2c3d4.render_frame",
       "skill_name": "maya-render",
       "action_name": "render_frame",
@@ -481,14 +494,29 @@ Response shape (gateway + per-DCC are identical):
           "skill_name": "maya-render",
           "dcc": "maya",
           "dcc_type": "maya",
-          "instance_id": "a1b2c3d4-0000-0000-0000-000000000001"
+          "instance_id": "a1b2c3d4-0000-0000-0000-000000000001",
+          "meta": {
+            "search_id": "9c8a1e9f-8d6f-4f3f-86e5-a9caa9138a5d",
+            "ranker_version": "gateway-hybrid-v2",
+            "index_generation": "1:ab12cd34"
+          }
         },
         "mcp": {
           "tool": "load_skill",
           "arguments": {
             "skill_name": "maya-render",
             "dcc_type": "maya",
-            "instance_id": "a1b2c3d4-0000-0000-0000-000000000001"
+            "instance_id": "a1b2c3d4-0000-0000-0000-000000000001",
+            "meta": {
+              "search_id": "9c8a1e9f-8d6f-4f3f-86e5-a9caa9138a5d",
+              "ranker_version": "gateway-hybrid-v2",
+              "index_generation": "1:ab12cd34"
+            }
+          },
+          "_meta": {
+            "search_id": "9c8a1e9f-8d6f-4f3f-86e5-a9caa9138a5d",
+            "ranker_version": "gateway-hybrid-v2",
+            "index_generation": "1:ab12cd34"
           }
         },
         "rest": {
@@ -497,7 +525,12 @@ Response shape (gateway + per-DCC are identical):
           "body": {
             "skill_name": "maya-render",
             "dcc_type": "maya",
-            "instance_id": "a1b2c3d4-0000-0000-0000-000000000001"
+            "instance_id": "a1b2c3d4-0000-0000-0000-000000000001",
+            "meta": {
+              "search_id": "9c8a1e9f-8d6f-4f3f-86e5-a9caa9138a5d",
+              "ranker_version": "gateway-hybrid-v2",
+              "index_generation": "1:ab12cd34"
+            }
           }
         }
       }
@@ -544,7 +577,7 @@ headers:
 The compact search shape preserves the workflow fields agents need next:
 `tool_slug`, `backend_tool`, `dcc_type`, `instance_id`, `loaded`,
 `load_state`, `available_groups`, `has_schema`, `score`, `match_reasons`, and
-`next_step` for unloaded skills. It omits redundant defaults such as `callable_id` when it
+`rank`, `search_id`, `ranker_version`, `index_generation`, and `next_step` for unloaded skills. It omits redundant defaults such as `callable_id` when it
 matches `backend_tool`, empty arrays, and empty objects. RTK's compaction model
 is treated as design guidance here; the
 gateway uses the deterministic in-process `toon-format` library so
@@ -587,7 +620,9 @@ definition (`input_schema`, annotations, next-tool hints). `include_schema`
 defaults to `true`; set `false` on follow-up calls where only the metadata
 has changed.
 The response includes the current `index_generation` so generated clients can
-detect stale describe/call sequences without parsing logs.
+detect stale describe/call sequences without parsing logs. When the describe
+request includes `meta.search_id`, the response `next_step` for `call` carries
+that search id forward and the gateway records selected-rank telemetry.
 
 ---
 

--- a/docs/zh/guide/rest-api-surface.md
+++ b/docs/zh/guide/rest-api-surface.md
@@ -254,11 +254,17 @@ Gateway REST 响应也会带稳定观测头：
 | `x-dcc-mcp-trace-id` | 跨 gateway、sidecar、host 的 end-to-end trace id。 |
 | `traceparent` | W3C trace context，方便 HTTP 客户端继续传播 trace。 |
 | `x-dcc-mcp-index-generation` | 触及 discovery/call 状态时返回的 capability-index opaque fingerprint。 |
+| `x-dcc-mcp-search-id` | 创建或消费 search result set 时返回的 search-quality 关联 id。 |
+| `x-dcc-mcp-ranker-version` | 关联 search result set 使用的 bounded ranker id。 |
 
 `/v1/search`、`/v1/describe`、`/v1/load_skill` 和 `/v1/call_batch` 的
 JSON/TOON body 也会包含 `request_id`、`trace_id`、`index_generation`。
 `/v1/call` 为保持 backend result envelope 向后兼容，只通过 headers 暴露
 这些 metadata。
+Search response 还会包含 `search_id`、`ranker_version` 和
+`index_generation`；后续 `/v1/describe`、`/v1/load_skill`、`/v1/call` 或
+`/v1/call_batch` 应把 `next_step` 中的 `meta.search_id` 原样传回，
+这样 gateway 可以统计 search-to-action 质量，同时不记录完整 prompt。
 
 ---
 
@@ -277,6 +283,10 @@ nucleo-matcher fuzzy fallback 保留 typo / partial-name 容错；`mode: "exact"
 仍是旧 substring 表。Gateway hit 会带 `score` 和 bounded `match_reasons`
 （例如 `tool_lexical`、`alias_lexical`、`schema_lexical`、`summary_fuzzy`、`schema_fuzzy`、
 `multi_token_lexical`），让 agent 和维护者不取完整 schema 也能理解排序原因。
+Gateway hit 还带 1-based `rank`。生成的 `next_step` 会携带
+`meta.search_id`、`meta.ranker_version` 和 `meta.index_generation`，REST
+调用方把它放进 body，MCP 调用方也可以把同一对象作为 `_meta` 传给
+后续 `describe` / `load_skill` / `call`。
 完整 `input_schema` 仍只通过 `describe` 返回；搜索阶段只允许 per-DCC backend
 通过 bounded `metadata.dcc.searchAliases` / `metadata.dcc.searchTokens` 把小型
 索引提示交给 gateway，gateway 搜索响应不会把这些内部 token 暴露成公开字段。
@@ -303,8 +313,9 @@ curl -H 'Accept: application/toon' \
 
 compact search 仍保留 agent 后续工作需要的字段：`tool_slug`、
 `backend_tool`、`dcc_type`、`instance_id`、`loaded`、`load_state`、
-`available_groups`、`has_schema`、`score`、`match_reasons`，以及 unloaded
-skill 的 `next_step`。`next_step` 同时带 MCP (`tool` + `arguments`) 和 REST
+`available_groups`、`has_schema`、`score`、`match_reasons`、`rank`、
+`search_id`、`ranker_version`、`index_generation`，以及 unloaded skill 的
+`next_step`。`next_step` 同时带 MCP (`tool` + `arguments`) 和 REST
 (`method` + `path` + `body`) 形态；Gateway REST 调用方可以直接 POST
 `next_step.arguments` 到 `/v1/load_skill`。它会省略冗余默认值，例如与
 `backend_tool` 相同的 `callable_id`、空数组和空 object。这里把 RTK 的

--- a/skills/dcc-mcp-skill-developer/SKILL.md
+++ b/skills/dcc-mcp-skill-developer/SKILL.md
@@ -88,7 +88,13 @@ into a faster authoring loop.
    `request_id`, `trace_id`, and `index_generation`; `/v1/call` keeps the
    backend envelope body compatible and exposes those values through
    `x-dcc-mcp-request-id`, `x-dcc-mcp-trace-id`, `traceparent`, and
-   `x-dcc-mcp-index-generation`. Compact batch examples may also read
+   `x-dcc-mcp-index-generation`. Gateway search responses also carry
+   `search_id`, `ranker_version`, `index_generation`, and per-hit `rank`; when
+   examples follow a search result into `describe`, `load_skill`, `call`, or
+   batch `call`, preserve the generated `next_step.arguments.meta.search_id`
+   (or the same object as MCP `_meta`) so search-quality telemetry can
+   correlate selected rank, hit-rate, and time-to-first-success without storing
+   full prompts. Compact batch examples may also read
    per-result `token_accounting` metadata, and batch request items may carry an
    optional `id` that is echoed next to the numeric result `index`.
    Gateway search uses a hybrid ranker in default fuzzy mode: weighted lexical


### PR DESCRIPTION
## Summary
- Add prompt-safe gateway search telemetry with search IDs, ranker versioning, hit ranks, and bounded follow-up correlation.
- Correlate REST and MCP search follow-ups across describe, load_skill, call, and batch workflows, with Prometheus counters/histograms plus admin/debug snapshots.
- Document the REST metadata contract and update agent-facing gateway workflow guidance.

## Validation
- `vx cargo fmt --all`
- `vx cargo check -p dcc-mcp-gateway-search -p dcc-mcp-gateway-core -p dcc-mcp-telemetry -p dcc-mcp-gateway`
- `vx cargo test -p dcc-mcp-gateway --lib --features admin`
- `vx cargo clippy -p dcc-mcp-gateway --all-targets --features admin -- -D warnings`
- Full Python pytest suite via the project virtual environment

Closes #1179