### PR TITLE
feat: add gateway agent workflow spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,6 +920,7 @@ dependencies = [
  "dcc-mcp-transport",
  "futures",
  "http",
+ "opentelemetry",
  "parking_lot",
  "prometheus",
  "proptest",

--- a/crates/dcc-mcp-gateway/Cargo.toml
+++ b/crates/dcc-mcp-gateway/Cargo.toml
@@ -21,6 +21,7 @@ dcc-mcp-telemetry = { path = "../dcc-mcp-telemetry", optional = true }
 dcc-mcp-skill-rest = { path = "../dcc-mcp-skill-rest" }
 dcc-mcp-skills = { path = "../dcc-mcp-skills", default-features = false }
 dcc-mcp-catalog = { path = "../dcc-mcp-catalog" }
+opentelemetry = { version = "0.31", features = ["trace"], optional = true }
 prometheus = { version = "0.14", default-features = false, optional = true }
 
 # Workspace shared
@@ -58,7 +59,8 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 default = ["prometheus"]
 admin = []
 admin-persist-sqlite = ["admin", "dcc-mcp-db/gateway-admin-sqlite"]
-prometheus = ["dep:dcc-mcp-telemetry", "dcc-mcp-telemetry/prometheus", "dep:prometheus"]
+telemetry = ["dep:dcc-mcp-telemetry", "dep:opentelemetry"]
+prometheus = ["telemetry", "dcc-mcp-telemetry/prometheus", "dep:prometheus"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/dcc-mcp-gateway/src/gateway/agent_telemetry.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/agent_telemetry.rs
@@ -1,0 +1,960 @@
+//! Agent workflow telemetry spans for gateway discovery and execution.
+//!
+//! This module intentionally emits bounded semantic attributes only. It links
+//! gateway-local Admin trace IDs with OTLP/OpenInference-style spans without
+//! exporting raw prompts, request bodies, hidden reasoning, or secrets.
+
+#[cfg(feature = "telemetry")]
+use opentelemetry::trace::{Span as _, Status, Tracer as _};
+#[cfg(feature = "telemetry")]
+use opentelemetry::{KeyValue, global};
+use serde_json::Value;
+#[cfg(test)]
+use serde_json::{Map, json};
+
+use crate::gateway::admin::trace::{AgentContext, TraceContext};
+use crate::gateway::capability::parse_slug;
+use crate::gateway::search_telemetry::{
+    RANKER_VERSION, SearchTelemetryHit, SearchTelemetryStore, search_id_from_meta,
+    search_id_from_payload,
+};
+
+const MATCH_REASON_LIMIT: usize = 5;
+
+#[derive(Debug, Clone)]
+pub(crate) struct AgentWorkflowEvent {
+    operation: &'static str,
+    transport: String,
+    trace_id: Option<String>,
+    request_id: Option<String>,
+    parent_request_id: Option<String>,
+    session_id: Option<String>,
+    agent_id: Option<String>,
+    agent_name: Option<String>,
+    agent_kind: Option<String>,
+    agent_model: Option<String>,
+    agent_task: Option<String>,
+    agent_tags: Vec<String>,
+    dcc_type: Option<String>,
+    instance_id: Option<String>,
+    skill_name: Option<String>,
+    tool_slug: Option<String>,
+    search_id: Option<String>,
+    ranker_version: Option<String>,
+    selected_rank: Option<u32>,
+    score: Option<u32>,
+    match_reasons: Vec<String>,
+    policy_outcome: Option<String>,
+    policy_reason: Option<String>,
+    success: Option<bool>,
+    error_kind: Option<String>,
+    total: Option<usize>,
+    zero_results: Option<bool>,
+    batch_size: Option<usize>,
+}
+
+impl AgentWorkflowEvent {
+    pub(crate) fn new(operation: &'static str, transport: impl Into<String>) -> Self {
+        Self {
+            operation,
+            transport: transport.into(),
+            trace_id: None,
+            request_id: None,
+            parent_request_id: None,
+            session_id: None,
+            agent_id: None,
+            agent_name: None,
+            agent_kind: None,
+            agent_model: None,
+            agent_task: None,
+            agent_tags: Vec::new(),
+            dcc_type: None,
+            instance_id: None,
+            skill_name: None,
+            tool_slug: None,
+            search_id: None,
+            ranker_version: None,
+            selected_rank: None,
+            score: None,
+            match_reasons: Vec::new(),
+            policy_outcome: None,
+            policy_reason: None,
+            success: None,
+            error_kind: None,
+            total: None,
+            zero_results: None,
+            batch_size: None,
+        }
+    }
+
+    pub(crate) fn with_trace_context(mut self, trace_context: Option<&TraceContext>) -> Self {
+        if let Some(trace_context) = trace_context {
+            self.trace_id = Some(trace_context.trace_id.clone());
+            self.request_id = Some(trace_context.request_id.clone());
+            self.parent_request_id = trace_context.parent_request_id.clone();
+        }
+        self
+    }
+
+    pub(crate) fn with_agent_context(mut self, agent_context: Option<&AgentContext>) -> Self {
+        if let Some(ctx) = agent_context {
+            self.agent_id = ctx.agent_id.clone();
+            self.agent_name = ctx.agent_name.clone();
+            self.agent_kind = ctx.agent_kind.clone();
+            self.agent_model = ctx.model.clone();
+            self.agent_task = ctx.task.clone();
+            self.agent_tags = ctx.tags.iter().take(16).cloned().collect();
+            if self.parent_request_id.is_none() {
+                self.parent_request_id = ctx.parent_request_id.clone();
+            }
+            if self.trace_id.is_none() {
+                self.trace_id = ctx.trace_id.clone();
+            }
+        }
+        self
+    }
+
+    pub(crate) fn with_session_id(mut self, session_id: Option<&str>) -> Self {
+        self.session_id = session_id.map(str::to_string);
+        self
+    }
+
+    pub(crate) fn with_route(
+        mut self,
+        tool_slug: Option<&str>,
+        skill_name: Option<&str>,
+        dcc_type: Option<&str>,
+        instance_id: Option<&str>,
+    ) -> Self {
+        if let Some(slug) = tool_slug.filter(|value| !value.is_empty()) {
+            self.tool_slug = Some(slug.to_string());
+            if let Some((parsed_dcc, parsed_instance, _)) = parse_slug(slug) {
+                if self.dcc_type.is_none() {
+                    self.dcc_type = Some(parsed_dcc.to_string());
+                }
+                if self.instance_id.is_none() {
+                    self.instance_id = Some(parsed_instance.to_string());
+                }
+            }
+        }
+        if self.skill_name.is_none() {
+            self.skill_name = skill_name
+                .filter(|value| !value.is_empty())
+                .map(str::to_string);
+        }
+        if self.dcc_type.is_none() {
+            self.dcc_type = dcc_type
+                .filter(|value| !value.is_empty())
+                .map(str::to_string);
+        }
+        if self.instance_id.is_none() {
+            self.instance_id = instance_id
+                .filter(|value| !value.is_empty())
+                .map(str::to_string);
+        }
+        self
+    }
+
+    pub(crate) fn with_search_id(mut self, search_id: Option<&str>) -> Self {
+        self.search_id = search_id
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        self
+    }
+
+    pub(crate) fn with_ranker_version(mut self, ranker_version: Option<&str>) -> Self {
+        self.ranker_version = ranker_version
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .or_else(|| Some(RANKER_VERSION.to_string()));
+        self
+    }
+
+    pub(crate) fn with_search_result(mut self, value: &Value) -> Self {
+        if self.search_id.is_none() {
+            self.search_id = value
+                .get("search_id")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+        }
+        if self.ranker_version.is_none() {
+            self.ranker_version = value
+                .get("ranker_version")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+        }
+        let total = value
+            .get("total")
+            .and_then(Value::as_u64)
+            .map(|value| value as usize)
+            .or_else(|| {
+                value
+                    .get("hits")
+                    .and_then(Value::as_array)
+                    .map(|items| items.len())
+            });
+        self.total = total;
+        self.zero_results = total.map(|value| value == 0);
+        self
+    }
+
+    pub(crate) fn with_selected_hit(mut self, hit: Option<&SearchTelemetryHit>) -> Self {
+        if let Some(hit) = hit {
+            if self.tool_slug.is_none() && !hit.tool_slug.is_empty() {
+                self.tool_slug = Some(hit.tool_slug.clone());
+            }
+            if self.skill_name.is_none() {
+                self.skill_name = hit.skill_name.clone();
+            }
+            if self.dcc_type.is_none() && !hit.dcc_type.is_empty() {
+                self.dcc_type = Some(hit.dcc_type.clone());
+            }
+            self.selected_rank = Some(hit.rank);
+            self.score = Some(hit.score);
+            self.match_reasons = hit
+                .match_reasons
+                .iter()
+                .take(MATCH_REASON_LIMIT)
+                .cloned()
+                .collect();
+        }
+        self
+    }
+
+    pub(crate) fn with_batch_size(mut self, batch_size: Option<usize>) -> Self {
+        self.batch_size = batch_size;
+        self
+    }
+
+    pub(crate) fn with_outcome(mut self, success: bool, error_kind: Option<&str>) -> Self {
+        self.success = Some(success);
+        self.error_kind = error_kind
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        self.policy_outcome = Some(policy_outcome(error_kind).to_string());
+        self
+    }
+
+    pub(crate) fn with_policy_reason(mut self, policy_reason: Option<&str>) -> Self {
+        self.policy_reason = policy_reason
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn attributes(&self) -> Map<String, Value> {
+        let mut attrs = Map::new();
+        insert_str(
+            &mut attrs,
+            "openinference.span.kind",
+            self.openinference_kind(),
+        );
+        insert_str(&mut attrs, "dcc_mcp.workflow.operation", self.operation);
+        insert_str(&mut attrs, "dcc_mcp.transport", &self.transport);
+        insert_opt(&mut attrs, "dcc_mcp.trace_id", self.trace_id.as_deref());
+        insert_opt(&mut attrs, "dcc_mcp.request_id", self.request_id.as_deref());
+        insert_opt(
+            &mut attrs,
+            "dcc_mcp.parent_request_id",
+            self.parent_request_id.as_deref(),
+        );
+        insert_opt(&mut attrs, "dcc_mcp.session_id", self.session_id.as_deref());
+        insert_opt(&mut attrs, "dcc_mcp.agent.id", self.agent_id.as_deref());
+        insert_opt(&mut attrs, "dcc_mcp.agent.name", self.agent_name.as_deref());
+        insert_opt(&mut attrs, "dcc_mcp.agent.kind", self.agent_kind.as_deref());
+        insert_opt(
+            &mut attrs,
+            "dcc_mcp.agent.model",
+            self.agent_model.as_deref(),
+        );
+        insert_opt(&mut attrs, "dcc_mcp.agent.task", self.agent_task.as_deref());
+        if !self.agent_tags.is_empty() {
+            attrs.insert("dcc_mcp.agent.tags".to_string(), json!(self.agent_tags));
+        }
+        insert_opt(&mut attrs, "dcc_mcp.dcc.type", self.dcc_type.as_deref());
+        insert_opt(
+            &mut attrs,
+            "dcc_mcp.instance.id",
+            self.instance_id.as_deref(),
+        );
+        insert_opt(&mut attrs, "dcc_mcp.skill.name", self.skill_name.as_deref());
+        insert_opt(&mut attrs, "dcc_mcp.tool.slug", self.tool_slug.as_deref());
+        insert_opt(&mut attrs, "dcc_mcp.search.id", self.search_id.as_deref());
+        insert_opt(
+            &mut attrs,
+            "dcc_mcp.search.ranker_version",
+            self.ranker_version.as_deref(),
+        );
+        insert_num(
+            &mut attrs,
+            "dcc_mcp.search.selected_rank",
+            self.selected_rank,
+        );
+        insert_num(&mut attrs, "dcc_mcp.search.score", self.score);
+        if !self.match_reasons.is_empty() {
+            attrs.insert(
+                "dcc_mcp.search.match_reasons".to_string(),
+                json!(self.match_reasons),
+            );
+        }
+        insert_opt(
+            &mut attrs,
+            "dcc_mcp.policy.outcome",
+            self.policy_outcome.as_deref(),
+        );
+        insert_opt(
+            &mut attrs,
+            "dcc_mcp.policy.reason",
+            self.policy_reason.as_deref(),
+        );
+        if let Some(success) = self.success {
+            attrs.insert("dcc_mcp.success".to_string(), json!(success));
+        }
+        insert_opt(&mut attrs, "dcc_mcp.error.kind", self.error_kind.as_deref());
+        if let Some(total) = self.total {
+            attrs.insert("dcc_mcp.search.total".to_string(), json!(total));
+        }
+        if let Some(zero_results) = self.zero_results {
+            attrs.insert(
+                "dcc_mcp.search.zero_results".to_string(),
+                json!(zero_results),
+            );
+        }
+        if let Some(batch_size) = self.batch_size {
+            attrs.insert("dcc_mcp.batch.size".to_string(), json!(batch_size));
+        }
+        attrs
+    }
+
+    pub(crate) fn emit(&self) {
+        let match_reasons = self.match_reasons.join(",");
+        let agent_tags = self.agent_tags.join(",");
+        let selected_rank = self.selected_rank.unwrap_or_default() as u64;
+        let score = self.score.unwrap_or_default() as u64;
+        let total = self.total.unwrap_or_default() as u64;
+        let batch_size = self.batch_size.unwrap_or_default() as u64;
+        let success = self.success.unwrap_or(false);
+        let zero_results = self.zero_results.unwrap_or(false);
+
+        macro_rules! emit_span {
+            ($name:literal) => {{
+                let span = tracing::info_span!(
+                    $name,
+                    "openinference.span.kind" = %self.openinference_kind(),
+                    "dcc_mcp.workflow.operation" = self.operation,
+                    "dcc_mcp.transport" = %self.transport,
+                    "dcc_mcp.trace_id" = self.trace_id.as_deref().unwrap_or(""),
+                    "dcc_mcp.request_id" = self.request_id.as_deref().unwrap_or(""),
+                    "dcc_mcp.parent_request_id" = self.parent_request_id.as_deref().unwrap_or(""),
+                    "dcc_mcp.session_id" = self.session_id.as_deref().unwrap_or(""),
+                    "dcc_mcp.agent.id" = self.agent_id.as_deref().unwrap_or(""),
+                    "dcc_mcp.agent.name" = self.agent_name.as_deref().unwrap_or(""),
+                    "dcc_mcp.agent.kind" = self.agent_kind.as_deref().unwrap_or(""),
+                    "dcc_mcp.agent.model" = self.agent_model.as_deref().unwrap_or(""),
+                    "dcc_mcp.agent.task" = self.agent_task.as_deref().unwrap_or(""),
+                    "dcc_mcp.agent.tags" = %agent_tags,
+                    "dcc_mcp.dcc.type" = self.dcc_type.as_deref().unwrap_or(""),
+                    "dcc_mcp.instance.id" = self.instance_id.as_deref().unwrap_or(""),
+                    "dcc_mcp.skill.name" = self.skill_name.as_deref().unwrap_or(""),
+                    "dcc_mcp.tool.slug" = self.tool_slug.as_deref().unwrap_or(""),
+                    "dcc_mcp.search.id" = self.search_id.as_deref().unwrap_or(""),
+                    "dcc_mcp.search.ranker_version" =
+                        self.ranker_version.as_deref().unwrap_or(RANKER_VERSION),
+                    "dcc_mcp.search.selected_rank" = selected_rank,
+                    "dcc_mcp.search.score" = score,
+                    "dcc_mcp.search.match_reasons" = %match_reasons,
+                    "dcc_mcp.policy.outcome" = self.policy_outcome.as_deref().unwrap_or(""),
+                    "dcc_mcp.policy.reason" = self.policy_reason.as_deref().unwrap_or(""),
+                    "dcc_mcp.success" = success,
+                    "dcc_mcp.error.kind" = self.error_kind.as_deref().unwrap_or(""),
+                    "dcc_mcp.search.total" = total,
+                    "dcc_mcp.search.zero_results" = zero_results,
+                    "dcc_mcp.batch.size" = batch_size,
+                );
+                span.in_scope(|| {
+                    tracing::info!("gateway agent workflow telemetry");
+                });
+                #[cfg(feature = "telemetry")]
+                if dcc_mcp_telemetry::provider::direct_span_fallback_enabled() {
+                    self.emit_otel_span($name);
+                }
+            }};
+        }
+
+        match self.operation {
+            "gateway.search" => emit_span!("gateway.search"),
+            "gateway.describe" => emit_span!("gateway.describe"),
+            "gateway.load_skill" => emit_span!("gateway.load_skill"),
+            "gateway.call" => emit_span!("gateway.call"),
+            "gateway.call_batch" => emit_span!("gateway.call_batch"),
+            _ => emit_span!("gateway.workflow"),
+        }
+    }
+
+    fn openinference_kind(&self) -> &'static str {
+        match self.operation {
+            "gateway.call" | "gateway.call_batch" | "gateway.describe" | "gateway.load_skill" => {
+                "TOOL"
+            }
+            _ => "CHAIN",
+        }
+    }
+
+    #[cfg(feature = "telemetry")]
+    fn emit_otel_span(&self, name: &'static str) {
+        let tracer = global::tracer("dcc-mcp-gateway");
+        let mut span = tracer.start(name);
+        span.set_attributes(self.otel_attributes());
+        match self.success {
+            Some(true) => span.set_status(Status::Ok),
+            Some(false) => {
+                let description = self
+                    .error_kind
+                    .as_deref()
+                    .unwrap_or("gateway workflow failed")
+                    .to_string();
+                span.set_status(Status::error(description));
+            }
+            None => {}
+        }
+        span.end();
+    }
+
+    #[cfg(feature = "telemetry")]
+    fn otel_attributes(&self) -> Vec<KeyValue> {
+        let mut attrs = Vec::new();
+        push_attr(
+            &mut attrs,
+            "openinference.span.kind",
+            self.openinference_kind(),
+        );
+        push_attr(&mut attrs, "dcc_mcp.workflow.operation", self.operation);
+        push_attr(&mut attrs, "dcc_mcp.transport", &self.transport);
+        push_opt_attr(&mut attrs, "dcc_mcp.trace_id", self.trace_id.as_deref());
+        push_opt_attr(&mut attrs, "dcc_mcp.request_id", self.request_id.as_deref());
+        push_opt_attr(
+            &mut attrs,
+            "dcc_mcp.parent_request_id",
+            self.parent_request_id.as_deref(),
+        );
+        push_opt_attr(&mut attrs, "dcc_mcp.session_id", self.session_id.as_deref());
+        push_opt_attr(&mut attrs, "dcc_mcp.agent.id", self.agent_id.as_deref());
+        push_opt_attr(&mut attrs, "dcc_mcp.agent.name", self.agent_name.as_deref());
+        push_opt_attr(&mut attrs, "dcc_mcp.agent.kind", self.agent_kind.as_deref());
+        push_opt_attr(
+            &mut attrs,
+            "dcc_mcp.agent.model",
+            self.agent_model.as_deref(),
+        );
+        push_opt_attr(&mut attrs, "dcc_mcp.agent.task", self.agent_task.as_deref());
+        if !self.agent_tags.is_empty() {
+            attrs.push(KeyValue::new(
+                "dcc_mcp.agent.tags",
+                self.agent_tags.join(","),
+            ));
+        }
+        push_opt_attr(&mut attrs, "dcc_mcp.dcc.type", self.dcc_type.as_deref());
+        push_opt_attr(
+            &mut attrs,
+            "dcc_mcp.instance.id",
+            self.instance_id.as_deref(),
+        );
+        push_opt_attr(&mut attrs, "dcc_mcp.skill.name", self.skill_name.as_deref());
+        push_opt_attr(&mut attrs, "dcc_mcp.tool.slug", self.tool_slug.as_deref());
+        push_opt_attr(&mut attrs, "dcc_mcp.search.id", self.search_id.as_deref());
+        push_opt_attr(
+            &mut attrs,
+            "dcc_mcp.search.ranker_version",
+            self.ranker_version.as_deref(),
+        );
+        push_num_attr(
+            &mut attrs,
+            "dcc_mcp.search.selected_rank",
+            self.selected_rank.map(i64::from),
+        );
+        push_num_attr(
+            &mut attrs,
+            "dcc_mcp.search.score",
+            self.score.map(i64::from),
+        );
+        if !self.match_reasons.is_empty() {
+            attrs.push(KeyValue::new(
+                "dcc_mcp.search.match_reasons",
+                self.match_reasons.join(","),
+            ));
+        }
+        push_opt_attr(
+            &mut attrs,
+            "dcc_mcp.policy.outcome",
+            self.policy_outcome.as_deref(),
+        );
+        push_opt_attr(
+            &mut attrs,
+            "dcc_mcp.policy.reason",
+            self.policy_reason.as_deref(),
+        );
+        if let Some(success) = self.success {
+            attrs.push(KeyValue::new("dcc_mcp.success", success));
+        }
+        push_opt_attr(&mut attrs, "dcc_mcp.error.kind", self.error_kind.as_deref());
+        push_num_attr(
+            &mut attrs,
+            "dcc_mcp.search.total",
+            self.total.map(|value| value as i64),
+        );
+        if let Some(zero_results) = self.zero_results {
+            attrs.push(KeyValue::new("dcc_mcp.search.zero_results", zero_results));
+        }
+        push_num_attr(
+            &mut attrs,
+            "dcc_mcp.batch.size",
+            self.batch_size.map(|value| value as i64),
+        );
+        attrs
+    }
+}
+
+pub(crate) struct McpToolTelemetryInput<'a> {
+    pub(crate) search_telemetry: &'a SearchTelemetryStore,
+    pub(crate) tool: &'a str,
+    pub(crate) args: &'a Value,
+    pub(crate) meta: Option<&'a Value>,
+    pub(crate) trace_context: Option<&'a TraceContext>,
+    pub(crate) agent_context: Option<&'a AgentContext>,
+    pub(crate) session_id: Option<&'a str>,
+    pub(crate) text: &'a str,
+    pub(crate) is_error: bool,
+}
+
+pub(crate) fn emit_mcp_tool_event(input: McpToolTelemetryInput<'_>) {
+    if let Some(event) = build_mcp_tool_event(input) {
+        event.emit();
+    }
+}
+
+pub(crate) fn build_mcp_tool_event(input: McpToolTelemetryInput<'_>) -> Option<AgentWorkflowEvent> {
+    let McpToolTelemetryInput {
+        search_telemetry,
+        tool,
+        args,
+        meta,
+        trace_context,
+        agent_context,
+        session_id,
+        text,
+        is_error,
+    } = input;
+    let operation = operation_for_mcp_tool(tool, args)?;
+    let result_value = serde_json::from_str::<Value>(text).ok();
+    let error_kind = is_error
+        .then(|| {
+            result_value
+                .as_ref()
+                .and_then(error_kind_from_value)
+                .or_else(|| error_kind_from_text(text))
+        })
+        .flatten();
+    let policy_reason = result_value.as_ref().and_then(policy_reason_from_value);
+
+    let mut event = AgentWorkflowEvent::new(operation, "mcp")
+        .with_trace_context(trace_context)
+        .with_agent_context(agent_context)
+        .with_session_id(session_id)
+        .with_outcome(!is_error, error_kind.as_deref())
+        .with_policy_reason(policy_reason.as_deref());
+
+    if operation == "gateway.search" {
+        if let Some(value) = result_value.as_ref() {
+            event = event.with_search_result(value);
+        }
+        let dcc_type = args
+            .get("dcc_type")
+            .or_else(|| args.get("dcc"))
+            .and_then(Value::as_str);
+        let instance_id = args.get("instance_id").and_then(Value::as_str);
+        return Some(event.with_route(None, None, dcc_type, instance_id));
+    }
+
+    let search_id = search_id_from_payload(args).or_else(|| meta.and_then(search_id_from_meta));
+    let (tool_slug, batch_size) = route_from_args(args);
+    let skill_name = skill_name_from_payload(args);
+    let selected_hit = search_id.as_deref().and_then(|search_id| {
+        search_telemetry.selected_hit(search_id, tool_slug, skill_name.as_deref())
+    });
+
+    Some(
+        event
+            .with_search_id(search_id.as_deref())
+            .with_ranker_version(Some(RANKER_VERSION))
+            .with_route(
+                tool_slug,
+                skill_name.as_deref(),
+                dcc_type_from_args(args),
+                None,
+            )
+            .with_selected_hit(selected_hit.as_ref())
+            .with_batch_size(batch_size),
+    )
+}
+
+pub(crate) fn error_kind_from_text(text: &str) -> Option<String> {
+    serde_json::from_str::<Value>(text)
+        .ok()
+        .and_then(|value| error_kind_from_value(&value))
+}
+
+pub(crate) fn error_kind_from_value(value: &Value) -> Option<String> {
+    value
+        .pointer("/error/kind")
+        .or_else(|| value.pointer("/error/error/kind"))
+        .or_else(|| value.pointer("/result/error/kind"))
+        .or_else(|| value.pointer("/output/error/kind"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+pub(crate) fn policy_reason_from_value(value: &Value) -> Option<String> {
+    value
+        .pointer("/error/policy/reason")
+        .or_else(|| value.pointer("/error/error/policy/reason"))
+        .or_else(|| value.pointer("/result/error/policy/reason"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+fn operation_for_mcp_tool(tool: &str, args: &Value) -> Option<&'static str> {
+    match tool {
+        "search" | "search_tools" | "search_skills" | "list_skills" => Some("gateway.search"),
+        "describe" | "describe_tool" | "get_skill_info" => Some("gateway.describe"),
+        "load_skill" => Some("gateway.load_skill"),
+        "call" if args.get("calls").and_then(Value::as_array).is_some() => {
+            Some("gateway.call_batch")
+        }
+        "call" | "call_tool" => Some("gateway.call"),
+        "call_tools" => Some("gateway.call_batch"),
+        _ => None,
+    }
+}
+
+fn route_from_args(args: &Value) -> (Option<&str>, Option<usize>) {
+    if let Some(calls) = args.get("calls").and_then(Value::as_array) {
+        let slug = calls
+            .first()
+            .and_then(|call| call.get("tool_slug"))
+            .and_then(Value::as_str);
+        return (slug, Some(calls.len()));
+    }
+    (args.get("tool_slug").and_then(Value::as_str), None)
+}
+
+fn skill_name_from_payload(payload: &Value) -> Option<String> {
+    payload
+        .get("skill_name")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| {
+            payload
+                .get("skill_names")
+                .and_then(Value::as_array)
+                .and_then(|items| items.iter().find_map(Value::as_str))
+                .map(str::to_string)
+        })
+}
+
+fn dcc_type_from_args(args: &Value) -> Option<&str> {
+    args.get("dcc_type")
+        .or_else(|| args.get("dcc"))
+        .and_then(Value::as_str)
+}
+
+fn policy_outcome(error_kind: Option<&str>) -> &'static str {
+    if error_kind == Some("policy-denied") {
+        "denied"
+    } else {
+        "allowed"
+    }
+}
+
+#[cfg(feature = "telemetry")]
+fn push_attr(attrs: &mut Vec<KeyValue>, key: &'static str, value: &str) {
+    attrs.push(KeyValue::new(key, value.to_string()));
+}
+
+#[cfg(feature = "telemetry")]
+fn push_opt_attr(attrs: &mut Vec<KeyValue>, key: &'static str, value: Option<&str>) {
+    if let Some(value) = value.filter(|value| !value.is_empty()) {
+        push_attr(attrs, key, value);
+    }
+}
+
+#[cfg(feature = "telemetry")]
+fn push_num_attr(attrs: &mut Vec<KeyValue>, key: &'static str, value: Option<i64>) {
+    if let Some(value) = value {
+        attrs.push(KeyValue::new(key, value));
+    }
+}
+
+#[cfg(test)]
+fn insert_str(attrs: &mut Map<String, Value>, key: &str, value: &str) {
+    attrs.insert(key.to_string(), json!(value));
+}
+
+#[cfg(test)]
+fn insert_opt(attrs: &mut Map<String, Value>, key: &str, value: Option<&str>) {
+    if let Some(value) = value.filter(|value| !value.is_empty()) {
+        attrs.insert(key.to_string(), json!(value));
+    }
+}
+
+#[cfg(test)]
+fn insert_num(attrs: &mut Map<String, Value>, key: &str, value: Option<u32>) {
+    if let Some(value) = value {
+        attrs.insert(key.to_string(), json!(value));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn trace_context() -> TraceContext {
+        TraceContext {
+            trace_id: "4bf92f3577b34da6a3ce929d0e0e4736".to_string(),
+            request_id: "req-1180".to_string(),
+            span_id: Some("00f067aa0ba902b7".to_string()),
+            parent_span_id: None,
+            parent_request_id: Some("parent-1".to_string()),
+            trace_flags: Some("01".to_string()),
+            trace_state: None,
+        }
+    }
+
+    #[test]
+    fn attributes_include_bounded_agent_and_search_fields_without_reasoning_payloads() {
+        let event = AgentWorkflowEvent::new("gateway.search", "rest")
+            .with_trace_context(Some(&trace_context()))
+            .with_agent_context(Some(&AgentContext {
+                agent_id: Some("agent-1".to_string()),
+                agent_name: Some("Codex".to_string()),
+                agent_kind: Some("coding-agent".to_string()),
+                model: Some("gpt-5".to_string()),
+                task: Some("fix issue 1180".to_string()),
+                reasoning_summary: Some("do not export me".to_string()),
+                tags: vec!["ci".to_string(), "gateway".to_string()],
+                metadata: json!({"api_key": "secret"}),
+                ..AgentContext::default()
+            }))
+            .with_search_id(Some("search-1"))
+            .with_ranker_version(Some("gateway-hybrid-v2"))
+            .with_search_result(&json!({"total": 0, "hits": []}))
+            .with_outcome(true, None);
+
+        let attrs = event.attributes();
+        assert_eq!(attrs["dcc_mcp.workflow.operation"], "gateway.search");
+        assert_eq!(attrs["dcc_mcp.agent.id"], "agent-1");
+        assert_eq!(attrs["dcc_mcp.agent.tags"], json!(["ci", "gateway"]));
+        assert_eq!(attrs["dcc_mcp.search.id"], "search-1");
+        assert_eq!(attrs["dcc_mcp.search.zero_results"], true);
+        assert!(!attrs.contains_key("dcc_mcp.agent.reasoning_summary"));
+        assert!(!attrs.contains_key("dcc_mcp.agent.metadata"));
+    }
+
+    #[test]
+    fn selected_hit_populates_rank_score_and_match_reason_summary() {
+        let hit = SearchTelemetryHit {
+            tool_slug: "maya.abcdef01.model__create_cube".to_string(),
+            skill_name: Some("maya-modeling".to_string()),
+            dcc_type: "maya".to_string(),
+            rank: 2,
+            score: 87,
+            match_reasons: vec![
+                "alias".to_string(),
+                "schema".to_string(),
+                "summary".to_string(),
+                "extra".to_string(),
+                "extra2".to_string(),
+                "extra3".to_string(),
+            ],
+            loaded: true,
+        };
+
+        let attrs = AgentWorkflowEvent::new("gateway.call", "mcp")
+            .with_selected_hit(Some(&hit))
+            .attributes();
+
+        assert_eq!(attrs["dcc_mcp.search.selected_rank"], 2);
+        assert_eq!(attrs["dcc_mcp.search.score"], 87);
+        assert_eq!(
+            attrs["dcc_mcp.search.match_reasons"],
+            json!(["alias", "schema", "summary", "extra", "extra2"])
+        );
+        assert_eq!(attrs["dcc_mcp.dcc.type"], "maya");
+    }
+
+    #[test]
+    fn mcp_search_event_records_bounded_result_attributes() {
+        let store = SearchTelemetryStore::with_capacity(4);
+        let args = json!({"query": "cube", "dcc_type": "maya", "instance_id": "abcdef01"});
+        let agent_context = AgentContext {
+            agent_id: Some("agent-1".to_string()),
+            tags: vec!["eval".to_string()],
+            metadata: json!({"raw_prompt": "do not export"}),
+            ..AgentContext::default()
+        };
+        let trace_context = trace_context();
+        let event = build_mcp_tool_event(McpToolTelemetryInput {
+            search_telemetry: &store,
+            tool: "search",
+            args: &args,
+            meta: None,
+            trace_context: Some(&trace_context),
+            agent_context: Some(&agent_context),
+            session_id: Some("sess-1"),
+            text: r#"{"search_id":"search-1","ranker_version":"gateway-hybrid-v2","total":2,"hits":[{"tool_slug":"maya.abcdef01.model__create_cube"}]}"#,
+            is_error: false,
+        })
+        .expect("search emits telemetry");
+
+        let attrs = event.attributes();
+        assert_eq!(attrs["openinference.span.kind"], "CHAIN");
+        assert_eq!(attrs["dcc_mcp.workflow.operation"], "gateway.search");
+        assert_eq!(attrs["dcc_mcp.dcc.type"], "maya");
+        assert_eq!(attrs["dcc_mcp.instance.id"], "abcdef01");
+        assert_eq!(attrs["dcc_mcp.search.id"], "search-1");
+        assert_eq!(attrs["dcc_mcp.search.total"], 2);
+        assert_eq!(attrs["dcc_mcp.search.zero_results"], false);
+        assert_eq!(attrs["dcc_mcp.agent.tags"], json!(["eval"]));
+        assert!(!attrs.contains_key("dcc_mcp.agent.metadata"));
+    }
+
+    #[test]
+    fn mcp_events_cover_load_skill_success_and_call_failure() {
+        let store = SearchTelemetryStore::with_capacity(4);
+        let search_id = SearchTelemetryStore::new_search_id();
+        store.record_search(crate::gateway::search_telemetry::SearchTelemetryInput {
+            search_id: search_id.clone(),
+            transport: "mcp".to_string(),
+            kind: "tool".to_string(),
+            query: "cube".to_string(),
+            dcc_type: Some("maya".to_string()),
+            instance_id: None,
+            limit: Some(5),
+            total: 1,
+            ranker_version: RANKER_VERSION.to_string(),
+            index_generation: "gen-1".to_string(),
+            hits: vec![SearchTelemetryHit {
+                tool_slug: "maya.abcdef01.model__create_cube".to_string(),
+                skill_name: Some("maya-modeling".to_string()),
+                dcc_type: "maya".to_string(),
+                rank: 3,
+                score: 80,
+                match_reasons: vec!["skill_lexical".to_string()],
+                loaded: false,
+            }],
+            trace_context: Some(trace_context()),
+            session_id: Some("sess-1".to_string()),
+        });
+
+        let load_args =
+            json!({"skill_name": "maya-modeling", "meta": {"search_id": search_id.clone()}});
+        let trace_context = trace_context();
+        let load = build_mcp_tool_event(McpToolTelemetryInput {
+            search_telemetry: &store,
+            tool: "load_skill",
+            args: &load_args,
+            meta: None,
+            trace_context: Some(&trace_context),
+            agent_context: None,
+            session_id: Some("sess-1"),
+            text: r#"{"success":true}"#,
+            is_error: false,
+        })
+        .expect("load_skill emits telemetry")
+        .attributes();
+        assert_eq!(load["openinference.span.kind"], "TOOL");
+        assert_eq!(load["dcc_mcp.workflow.operation"], "gateway.load_skill");
+        assert_eq!(load["dcc_mcp.skill.name"], "maya-modeling");
+        assert_eq!(load["dcc_mcp.search.selected_rank"], 3);
+        assert_eq!(load["dcc_mcp.success"], true);
+
+        let call_args = json!({
+                "tool_slug": "maya.abcdef01.model__create_cube",
+                "arguments": {},
+                "meta": {"search_id": search_id}
+        });
+        let failed_call = build_mcp_tool_event(McpToolTelemetryInput {
+            search_telemetry: &store,
+            tool: "call",
+            args: &call_args,
+            meta: None,
+            trace_context: Some(&trace_context),
+            agent_context: None,
+            session_id: Some("sess-1"),
+            text: r#"{"error":{"kind":"backend-timeout","message":"timed out"}}"#,
+            is_error: true,
+        })
+        .expect("failed call emits telemetry")
+        .attributes();
+        assert_eq!(failed_call["dcc_mcp.workflow.operation"], "gateway.call");
+        assert_eq!(failed_call["dcc_mcp.error.kind"], "backend-timeout");
+        assert_eq!(failed_call["dcc_mcp.success"], false);
+        assert_eq!(failed_call["dcc_mcp.search.selected_rank"], 3);
+    }
+
+    #[test]
+    fn mcp_event_correlates_call_to_search_hit_and_policy_error() {
+        let store = SearchTelemetryStore::with_capacity(4);
+        let search_id = SearchTelemetryStore::new_search_id();
+        store.record_search(crate::gateway::search_telemetry::SearchTelemetryInput {
+            search_id: search_id.clone(),
+            transport: "mcp".to_string(),
+            kind: "tool".to_string(),
+            query: "cube".to_string(),
+            dcc_type: Some("maya".to_string()),
+            instance_id: None,
+            limit: Some(5),
+            total: 1,
+            ranker_version: RANKER_VERSION.to_string(),
+            index_generation: "gen-1".to_string(),
+            hits: vec![SearchTelemetryHit {
+                tool_slug: "maya.abcdef01.model__create_cube".to_string(),
+                skill_name: Some("maya-modeling".to_string()),
+                dcc_type: "maya".to_string(),
+                rank: 1,
+                score: 99,
+                match_reasons: vec!["tool_lexical".to_string()],
+                loaded: true,
+            }],
+            trace_context: Some(trace_context()),
+            session_id: Some("sess-1".to_string()),
+        });
+
+        let args = json!({
+                "tool_slug": "maya.abcdef01.model__create_cube",
+                "arguments": {},
+                "meta": {"search_id": search_id}
+        });
+        let trace_context = trace_context();
+        let event = build_mcp_tool_event(McpToolTelemetryInput {
+            search_telemetry: &store,
+            tool: "call",
+            args: &args,
+            meta: None,
+            trace_context: Some(&trace_context),
+            agent_context: None,
+            session_id: Some("sess-1"),
+            text: r#"{"error":{"kind":"policy-denied","policy":{"reason":"read-only"}}}"#,
+            is_error: true,
+        })
+        .expect("call emits telemetry");
+
+        let attrs = event.attributes();
+        assert_eq!(attrs["dcc_mcp.workflow.operation"], "gateway.call");
+        assert_eq!(attrs["dcc_mcp.search.selected_rank"], 1);
+        assert_eq!(attrs["dcc_mcp.search.score"], 99);
+        assert_eq!(attrs["dcc_mcp.policy.outcome"], "denied");
+        assert_eq!(attrs["dcc_mcp.policy.reason"], "read-only");
+        assert_eq!(attrs["dcc_mcp.success"], false);
+    }
+}

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
@@ -445,6 +445,20 @@ async fn handle_tools_call(
     )
     .await;
 
+    crate::gateway::agent_telemetry::emit_mcp_tool_event(
+        crate::gateway::agent_telemetry::McpToolTelemetryInput {
+            search_telemetry: &gs.search_telemetry,
+            tool,
+            args: &effective_args,
+            meta: meta.as_ref(),
+            trace_context: Some(&ctx.trace_context),
+            agent_context: ctx.agent_context.as_ref(),
+            session_id: Some(session_id),
+            text: &text,
+            is_error,
+        },
+    );
+
     {
         use crate::gateway::admin::trace::{MAX_OUTPUT_BYTES, TracePayload};
         let response_ns = std::time::SystemTime::now()

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
@@ -1,6 +1,9 @@
 use super::*;
 
-use crate::gateway::admin::trace::TraceContext;
+use crate::gateway::admin::trace::{AgentContext, TraceContext};
+use crate::gateway::agent_telemetry::{
+    AgentWorkflowEvent, error_kind_from_text, policy_reason_from_value,
+};
 use crate::gateway::capability::{RefreshReason, parse_slug, tool_slug};
 use crate::gateway::capability_service::{
     SearchResponseContext, ServiceError, call_service, describe_tool_full, index_generation,
@@ -323,6 +326,11 @@ pub async fn handle_v1_search(
     Json(body): Json<Value>,
 ) -> Response {
     let trace_context = TraceContext::from_headers(&headers);
+    let agent_context = AgentContext::from_request_parts(
+        &headers,
+        Some(&body),
+        body.get("meta").or_else(|| body.get("_meta")),
+    );
     // Refresh-on-demand so the first call after startup or a skill
     // load sees fresh capabilities without waiting for a watcher tick.
     refresh_all_live_backends(&gs, RefreshReason::Periodic).await;
@@ -352,25 +360,44 @@ pub async fn handle_v1_search(
     );
     let hits = search_service_hits_for_policy(&gs.capability_index, &query, &gs.policy);
     let telemetry_hits = search_hits_for_telemetry(&hits);
+    let total = hits.len();
     let hits: Vec<Value> = hits
         .into_iter()
         .map(|hit| search_hit_to_value_with_context(hit, Some(&search_context)))
         .collect();
+    let session_id = session_id_from_headers(&headers);
+    let query_dcc_type = query.dcc_type.clone();
+    let query_instance_id = query.instance_id.as_ref().map(ToString::to_string);
     gs.search_telemetry.record_search(SearchTelemetryInput {
         search_id: search_context.search_id.clone(),
         transport: "rest".to_string(),
         kind: "tool".to_string(),
         query: query.query.clone(),
-        dcc_type: query.dcc_type.clone(),
-        instance_id: query.instance_id.map(|id| id.to_string()),
+        dcc_type: query_dcc_type.clone(),
+        instance_id: query_instance_id.clone(),
         limit: query.limit,
-        total: hits.len(),
+        total,
         ranker_version: search_context.ranker_version.to_string(),
         index_generation: search_context.index_generation.clone(),
         hits: telemetry_hits,
         trace_context: Some(trace_context.clone()),
-        session_id: session_id_from_headers(&headers),
+        session_id: session_id.clone(),
     });
+    AgentWorkflowEvent::new("gateway.search", "rest")
+        .with_trace_context(Some(&trace_context))
+        .with_agent_context(agent_context.as_ref())
+        .with_session_id(session_id.as_deref())
+        .with_route(
+            None,
+            None,
+            query_dcc_type.as_deref(),
+            query_instance_id.as_deref(),
+        )
+        .with_search_id(Some(&search_context.search_id))
+        .with_ranker_version(Some(search_context.ranker_version))
+        .with_search_result(&json!({"total": total, "hits": hits}))
+        .with_outcome(true, None)
+        .emit();
     let metadata = RestResponseMetadata::from_trace_context(&trace_context)
         .with_index_generation(search_context.index_generation.clone())
         .with_search(
@@ -406,7 +433,13 @@ async fn skill_lifecycle_response(
     body: Value,
 ) -> Response {
     let trace_context = TraceContext::from_headers(headers);
+    let agent_context = AgentContext::from_request_parts(
+        headers,
+        Some(&body),
+        body.get("meta").or_else(|| body.get("_meta")),
+    );
     let search_id = search_id_from_payload(&body);
+    let skill_name = skill_name_from_payload(&body);
     let (text, is_error) = crate::gateway::aggregator::skill_mgmt_dispatch(gs, tool, &body).await;
     if tool == "load_skill" {
         record_search_followup(
@@ -414,10 +447,32 @@ async fn skill_lifecycle_response(
             search_id.as_deref(),
             "load_skill",
             None,
-            skill_name_from_payload(&body),
+            skill_name.clone(),
             !is_error,
             &trace_context,
         );
+        let selected_hit = search_id.as_deref().and_then(|search_id| {
+            gs.search_telemetry
+                .selected_hit(search_id, None, skill_name.as_deref())
+        });
+        let parsed = serde_json::from_str::<Value>(&text).ok();
+        let error_kind = if is_error {
+            error_kind_from_text(&text)
+                .or_else(|| Some(classify_skill_lifecycle_error(tool, &text).to_string()))
+        } else {
+            None
+        };
+        let policy_reason = parsed.as_ref().and_then(policy_reason_from_value);
+        AgentWorkflowEvent::new("gateway.load_skill", "rest")
+            .with_trace_context(Some(&trace_context))
+            .with_agent_context(agent_context.as_ref())
+            .with_search_id(search_id.as_deref())
+            .with_ranker_version(Some(crate::gateway::search_telemetry::RANKER_VERSION))
+            .with_route(None, skill_name.as_deref(), None, None)
+            .with_selected_hit(selected_hit.as_ref())
+            .with_outcome(!is_error, error_kind.as_deref())
+            .with_policy_reason(policy_reason.as_deref())
+            .emit();
     }
     let metadata = RestResponseMetadata::from_trace_context(&trace_context)
         .with_index_generation(index_generation(&gs.capability_index));
@@ -502,6 +557,11 @@ pub async fn handle_v1_describe(
     Json(body): Json<Value>,
 ) -> Response {
     let trace_context = TraceContext::from_headers(&headers);
+    let agent_context = AgentContext::from_request_parts(
+        &headers,
+        Some(&body),
+        body.get("meta").or_else(|| body.get("_meta")),
+    );
     let Some(slug) = body.get("tool_slug").and_then(Value::as_str) else {
         let metadata = RestResponseMetadata::from_trace_context(&trace_context)
             .with_index_generation(index_generation(&gs.capability_index));
@@ -517,7 +577,16 @@ pub async fn handle_v1_describe(
     let metadata = RestResponseMetadata::from_trace_context(&trace_context)
         .with_index_generation(index_generation(&gs.capability_index));
 
-    describe_slug_response(&gs, &headers, &body, slug, &metadata).await
+    describe_slug_response(
+        &gs,
+        &headers,
+        &body,
+        slug,
+        &metadata,
+        &trace_context,
+        agent_context.as_ref(),
+    )
+    .await
 }
 
 /// `GET /v1/tools/{slug}` — path form of describe.
@@ -527,11 +596,21 @@ pub async fn handle_v1_describe_path(
     Path(slug): Path<String>,
 ) -> Response {
     let trace_context = TraceContext::from_headers(&headers);
+    let agent_context = AgentContext::from_request_parts(&headers, None, None);
     refresh_all_live_backends(&gs, RefreshReason::Periodic).await;
     let body = json!({});
     let metadata = RestResponseMetadata::from_trace_context(&trace_context)
         .with_index_generation(index_generation(&gs.capability_index));
-    describe_slug_response(&gs, &headers, &body, &slug, &metadata).await
+    describe_slug_response(
+        &gs,
+        &headers,
+        &body,
+        &slug,
+        &metadata,
+        &trace_context,
+        agent_context.as_ref(),
+    )
+    .await
 }
 
 async fn describe_slug_response(
@@ -540,10 +619,15 @@ async fn describe_slug_response(
     body: &Value,
     slug: &str,
     metadata: &RestResponseMetadata,
+    trace_context: &TraceContext,
+    agent_context: Option<&AgentContext>,
 ) -> Response {
     let search_id = search_id_from_payload(body);
     match describe_tool_full(gs, slug).await {
         Ok((record, tool)) => {
+            let dcc_type = record.dcc_type.clone();
+            let instance_id = record.instance_id.to_string();
+            let skill_name = record.skill_name.clone();
             record_search_followup(
                 gs,
                 search_id.as_deref(),
@@ -561,6 +645,24 @@ async fn describe_slug_response(
                     trace_state: None,
                 },
             );
+            let selected_hit = search_id.as_deref().and_then(|search_id| {
+                gs.search_telemetry
+                    .selected_hit(search_id, Some(slug), None)
+            });
+            AgentWorkflowEvent::new("gateway.describe", "rest")
+                .with_trace_context(Some(trace_context))
+                .with_agent_context(agent_context)
+                .with_search_id(search_id.as_deref())
+                .with_ranker_version(Some(crate::gateway::search_telemetry::RANKER_VERSION))
+                .with_route(
+                    Some(slug),
+                    skill_name.as_deref(),
+                    Some(dcc_type.as_str()),
+                    Some(instance_id.as_str()),
+                )
+                .with_selected_hit(selected_hit.as_ref())
+                .with_outcome(true, None)
+                .emit();
             let mut legacy = json!({
                 "record": record,
                 "tool": tool,
@@ -580,6 +682,8 @@ async fn describe_slug_response(
             )
         }
         Err(err) => {
+            let err_payload = crate::gateway::capability_service::service_error_to_json(&err);
+            let policy_reason = policy_reason_from_value(&err_payload);
             record_search_followup(
                 gs,
                 search_id.as_deref(),
@@ -597,6 +701,20 @@ async fn describe_slug_response(
                     trace_state: None,
                 },
             );
+            let selected_hit = search_id.as_deref().and_then(|search_id| {
+                gs.search_telemetry
+                    .selected_hit(search_id, Some(slug), None)
+            });
+            AgentWorkflowEvent::new("gateway.describe", "rest")
+                .with_trace_context(Some(trace_context))
+                .with_agent_context(agent_context)
+                .with_search_id(search_id.as_deref())
+                .with_ranker_version(Some(crate::gateway::search_telemetry::RANKER_VERSION))
+                .with_route(Some(slug), None, None, None)
+                .with_selected_hit(selected_hit.as_ref())
+                .with_outcome(false, Some(err.kind.as_str()))
+                .with_policy_reason(policy_reason.as_deref())
+                .emit();
             service_error_response_with_metadata(headers, body, &err, metadata, true)
         }
     }
@@ -615,6 +733,8 @@ pub async fn handle_v1_dcc_instance_describe(
     Query(q): Query<DccInstanceDescribeQuery>,
 ) -> Response {
     let body = json!({});
+    let trace_context = TraceContext::from_headers(&headers);
+    let agent_context = AgentContext::from_request_parts(&headers, None, None);
     let backend_tool = q.backend_tool.trim();
     if backend_tool.is_empty() {
         let metadata = RestResponseMetadata::from_headers(&headers)
@@ -631,7 +751,6 @@ pub async fn handle_v1_dcc_instance_describe(
         );
     }
 
-    let trace_context = TraceContext::from_headers(&headers);
     refresh_all_live_backends(&gs, RefreshReason::Periodic).await;
     let metadata = RestResponseMetadata::from_trace_context(&trace_context)
         .with_index_generation(index_generation(&gs.capability_index));
@@ -664,7 +783,16 @@ pub async fn handle_v1_dcc_instance_describe(
     }
 
     let slug = tool_slug(&entry.dcc_type, &entry.instance_id, backend_tool);
-    describe_slug_response(&gs, &headers, &body, &slug, &metadata).await
+    describe_slug_response(
+        &gs,
+        &headers,
+        &body,
+        &slug,
+        &metadata,
+        &trace_context,
+        agent_context.as_ref(),
+    )
+    .await
 }
 
 /// `POST /v1/call` — invoke a backend action by slug.
@@ -1069,8 +1197,48 @@ async fn call_service_with_admin_trace(
     if !gs.middleware_chain.is_empty()
         && let Err(err) = gs.middleware_chain.run_after(&ctx, &mut call_result).await
     {
+        let selected_hit = selected_search_hit(gs, search_id.as_deref(), Some(slug), None);
+        AgentWorkflowEvent::new("gateway.call", "rest")
+            .with_trace_context(Some(&ctx.trace_context))
+            .with_agent_context(ctx.agent_context.as_ref())
+            .with_session_id(ctx.session_id.as_deref())
+            .with_search_id(search_id.as_deref())
+            .with_ranker_version(Some(crate::gateway::search_telemetry::RANKER_VERSION))
+            .with_route(
+                Some(slug),
+                None,
+                ctx.dcc_type.as_deref(),
+                ctx.instance_id.as_deref(),
+            )
+            .with_selected_hit(selected_hit.as_ref())
+            .with_outcome(false, Some("middleware-error"))
+            .emit();
         return Err(ServiceError::new("middleware-error", err.to_string()));
     }
+
+    let selected_hit = selected_search_hit(gs, search_id.as_deref(), Some(slug), None);
+    let error_kind = result.as_ref().err().map(|err| err.kind.as_str());
+    let error_payload = result
+        .as_ref()
+        .err()
+        .map(crate::gateway::capability_service::service_error_to_json);
+    let policy_reason = error_payload.as_ref().and_then(policy_reason_from_value);
+    AgentWorkflowEvent::new("gateway.call", "rest")
+        .with_trace_context(Some(&ctx.trace_context))
+        .with_agent_context(ctx.agent_context.as_ref())
+        .with_session_id(ctx.session_id.as_deref())
+        .with_search_id(search_id.as_deref())
+        .with_ranker_version(Some(crate::gateway::search_telemetry::RANKER_VERSION))
+        .with_route(
+            Some(slug),
+            None,
+            ctx.dcc_type.as_deref(),
+            ctx.instance_id.as_deref(),
+        )
+        .with_selected_hit(selected_hit.as_ref())
+        .with_outcome(!is_error, error_kind)
+        .with_policy_reason(policy_reason.as_deref())
+        .emit();
 
     emit_rest_traffic_frame(
         gs,
@@ -1176,11 +1344,60 @@ async fn call_batch_with_admin_trace(
     ctx.output_payload = Some(TracePayload::from_value(&output_value, MAX_OUTPUT_BYTES));
 
     let mut call_result = CallResult::from_tuple(preview_text, is_error);
+    let search_id = search_id_from_payload(request_body);
+    let batch_size = call_batch_size(request_body);
+    let first_slug = first_batch_tool_slug(request_body);
+    let selected_hit = selected_search_hit(gs, search_id.as_deref(), first_slug, None);
     if !gs.middleware_chain.is_empty()
         && let Err(err) = gs.middleware_chain.run_after(&ctx, &mut call_result).await
     {
+        AgentWorkflowEvent::new("gateway.call_batch", "rest")
+            .with_trace_context(Some(&ctx.trace_context))
+            .with_agent_context(ctx.agent_context.as_ref())
+            .with_session_id(ctx.session_id.as_deref())
+            .with_search_id(search_id.as_deref())
+            .with_ranker_version(Some(crate::gateway::search_telemetry::RANKER_VERSION))
+            .with_route(first_slug, None, None, None)
+            .with_selected_hit(selected_hit.as_ref())
+            .with_batch_size(batch_size)
+            .with_outcome(false, Some("middleware-error"))
+            .emit();
         return Err(err.to_string());
     }
+
+    let batch_success = result
+        .as_ref()
+        .ok()
+        .and_then(|value| value.get("success"))
+        .and_then(Value::as_bool)
+        .unwrap_or(!is_error);
+    AgentWorkflowEvent::new("gateway.call_batch", "rest")
+        .with_trace_context(Some(&ctx.trace_context))
+        .with_agent_context(ctx.agent_context.as_ref())
+        .with_session_id(ctx.session_id.as_deref())
+        .with_search_id(search_id.as_deref())
+        .with_ranker_version(Some(crate::gateway::search_telemetry::RANKER_VERSION))
+        .with_route(first_slug, None, None, None)
+        .with_selected_hit(selected_hit.as_ref())
+        .with_batch_size(batch_size)
+        .with_outcome(
+            batch_success,
+            if batch_success {
+                None
+            } else if result.is_err() {
+                Some("bad-request")
+            } else {
+                Some("call-failed")
+            },
+        )
+        .with_policy_reason(
+            result
+                .as_ref()
+                .ok()
+                .and_then(policy_reason_from_value)
+                .as_deref(),
+        )
+        .emit();
 
     emit_rest_traffic_frame(
         gs,
@@ -1196,6 +1413,34 @@ async fn call_batch_with_admin_trace(
     );
 
     result
+}
+
+fn selected_search_hit(
+    gs: &GatewayState,
+    search_id: Option<&str>,
+    tool_slug: Option<&str>,
+    skill_name: Option<&str>,
+) -> Option<crate::gateway::search_telemetry::SearchTelemetryHit> {
+    search_id.and_then(|search_id| {
+        gs.search_telemetry
+            .selected_hit(search_id, tool_slug, skill_name)
+    })
+}
+
+fn first_batch_tool_slug(request_body: &Value) -> Option<&str> {
+    request_body
+        .get("calls")
+        .and_then(Value::as_array)
+        .and_then(|calls| calls.first())
+        .and_then(|call| call.get("tool_slug"))
+        .and_then(Value::as_str)
+}
+
+fn call_batch_size(request_body: &Value) -> Option<usize> {
+    request_body
+        .get("calls")
+        .and_then(Value::as_array)
+        .map(Vec::len)
 }
 
 #[cfg(test)]

--- a/crates/dcc-mcp-gateway/src/gateway/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/mod.rs
@@ -31,6 +31,7 @@
 //! # }
 //! ```
 
+pub(crate) mod agent_telemetry;
 pub mod aggregator;
 pub mod backend_client;
 pub mod capability;

--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/agent_workflows.md
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/agent_workflows.md
@@ -14,6 +14,17 @@
 4. **Skills vs tools** — `search(kind="skill")` / `load_skill` load packaged workflows on a host; `search(kind="tool")` resolves a **`tool_slug`** for the dynamic surface. Keep names straight; use `describe` before calling an unfamiliar slug. Unloaded hits carry `load_state`, `available_groups` when known, and `next_step` with both MCP and REST call shapes.
 5. **Progressive groups** — gateway `load_skill` defaults to lazy group activation (`activate_groups=false` unless you opt in). Default-active/core groups may become active; heavier groups should be activated explicitly through `load_skill(..., tool_group="...")`.
 
+### Telemetry correlation
+
+When you use a `next_step` from `search`, keep its `meta.search_id` as REST
+`meta.search_id` or MCP `_meta.search_id` on `describe`, `load_skill`, `call`,
+and batched `call` requests. The gateway emits `gateway.search`,
+`gateway.describe`, `gateway.load_skill`, `gateway.call`, and
+`gateway.call_batch` OTLP spans with bounded `dcc_mcp.*` attributes, including
+selected rank, score, match reasons, policy outcome, and success/failure kind.
+Only explicit bounded `agent_context` fields are exported; do not send hidden
+reasoning, secrets, or raw prompt bodies as telemetry metadata.
+
 ### Host / connector wrappers (common mistakes)
 
 If your IDE or orchestration layer exposes **non-standard** tool names (for example `defer_execute_tool`, `get_sessions`, `tool_search`), they **must** map onto the gateway verbs above — those names are **not** part of `dcc-mcp-gateway`’s native `tools/list`.

--- a/crates/dcc-mcp-gateway/src/gateway/search_telemetry.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/search_telemetry.rs
@@ -333,6 +333,21 @@ impl SearchTelemetryStore {
         true
     }
 
+    pub fn selected_hit(
+        &self,
+        search_id: &str,
+        tool_slug: Option<&str>,
+        skill_name: Option<&str>,
+    ) -> Option<SearchTelemetryHit> {
+        let inner = self.inner.lock();
+        let record = inner
+            .records
+            .iter()
+            .rev()
+            .find(|record| record.search_id == search_id)?;
+        selected_hit(record, tool_slug, skill_name).cloned()
+    }
+
     pub fn snapshot(&self, limit: usize) -> SearchTelemetrySnapshot {
         let inner = self.inner.lock();
         let recent: Vec<SearchTelemetryRecord> = inner
@@ -383,21 +398,25 @@ fn selected_rank(
     tool_slug: Option<&str>,
     skill_name: Option<&str>,
 ) -> Option<u32> {
+    selected_hit(record, tool_slug, skill_name).map(|hit| hit.rank)
+}
+
+fn selected_hit<'a>(
+    record: &'a SearchTelemetryRecord,
+    tool_slug: Option<&str>,
+    skill_name: Option<&str>,
+) -> Option<&'a SearchTelemetryHit> {
     if let Some(slug) = tool_slug
         && let Some(hit) = record.hits.iter().find(|hit| hit.tool_slug == slug)
     {
-        return Some(hit.rank);
+        return Some(hit);
     }
     let skill = skill_name?.to_ascii_lowercase();
-    record
-        .hits
-        .iter()
-        .find(|hit| {
-            hit.skill_name
-                .as_deref()
-                .is_some_and(|candidate| candidate.eq_ignore_ascii_case(&skill))
-        })
-        .map(|hit| hit.rank)
+    record.hits.iter().find(|hit| {
+        hit.skill_name
+            .as_deref()
+            .is_some_and(|candidate| candidate.eq_ignore_ascii_case(&skill))
+    })
 }
 
 fn compute_stats(inner: &SearchTelemetryInner) -> SearchQualityStats {

--- a/crates/dcc-mcp-telemetry/src/provider.rs
+++ b/crates/dcc-mcp-telemetry/src/provider.rs
@@ -4,6 +4,7 @@
 //! Afterwards use [`tracer`] / [`meter`] helper functions anywhere in the crate.
 
 use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use opentelemetry::metrics::Meter;
 use opentelemetry::trace::{Tracer, TracerProvider as _};
@@ -47,6 +48,8 @@ impl TelemetryHandle {
 }
 
 static HANDLE: OnceLock<TelemetryHandle> = OnceLock::new();
+static ACTIVE: AtomicBool = AtomicBool::new(false);
+static DIRECT_SPAN_FALLBACK: AtomicBool = AtomicBool::new(false);
 
 // ── Init ──────────────────────────────────────────────────────────────────────
 
@@ -104,8 +107,23 @@ pub fn init(cfg: &TelemetryConfig) -> Result<(), TelemetryError> {
         None
     };
 
-    // Install tracing subscriber
-    install_subscriber(cfg, tracer_provider.as_ref())?;
+    if let Some(ref tp) = tracer_provider {
+        global::set_tracer_provider(tp.clone());
+    }
+
+    // Install tracing subscriber. Some hosts initialise the shared logging
+    // subscriber before telemetry so file logging can be attached later. In
+    // that case direct OpenTelemetry spans still export through the global
+    // provider above, even though a tracing-opentelemetry layer cannot be
+    // installed retroactively.
+    let mut direct_span_fallback = false;
+    if let Err(err) = install_subscriber(cfg, tracer_provider.as_ref()) {
+        if is_global_subscriber_already_set(&err) {
+            direct_span_fallback = tracer_provider.is_some();
+        } else {
+            return Err(err);
+        }
+    }
 
     let handle = TelemetryHandle {
         tracer_provider,
@@ -120,6 +138,8 @@ pub fn init(cfg: &TelemetryConfig) -> Result<(), TelemetryError> {
     HANDLE
         .set(handle)
         .map_err(|_| TelemetryError::AlreadyInitialized)?;
+    ACTIVE.store(true, Ordering::Release);
+    DIRECT_SPAN_FALLBACK.store(direct_span_fallback, Ordering::Release);
 
     Ok(())
 }
@@ -129,11 +149,23 @@ pub fn shutdown() {
     if let Some(h) = HANDLE.get() {
         h.shutdown();
     }
+    ACTIVE.store(false, Ordering::Release);
+    DIRECT_SPAN_FALLBACK.store(false, Ordering::Release);
 }
 
 /// Returns `true` if the global telemetry provider has been initialised.
 pub fn is_initialized() -> bool {
-    HANDLE.get().is_some()
+    ACTIVE.load(Ordering::Acquire)
+}
+
+/// Returns true when telemetry was initialised after another tracing subscriber
+/// had already been installed.
+///
+/// In that mode a `tracing-opentelemetry` layer cannot be added retroactively,
+/// so callers that own high-value semantic spans can emit them directly through
+/// the global OpenTelemetry tracer provider.
+pub fn direct_span_fallback_enabled() -> bool {
+    ACTIVE.load(Ordering::Acquire) && DIRECT_SPAN_FALLBACK.load(Ordering::Acquire)
 }
 
 /// Initialise a minimal no-op telemetry provider if one has not been set yet.
@@ -304,6 +336,10 @@ fn install_subscriber(
     Ok(())
 }
 
+fn is_global_subscriber_already_set(err: &TelemetryError) -> bool {
+    matches!(err, TelemetryError::TracerProviderSetup(message) if message.contains("global default") && message.contains("already"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -318,6 +354,11 @@ mod tests {
             // returns a bool without panicking.
             let _ = is_initialized();
         }
+
+        #[test]
+        fn direct_span_fallback_returns_bool_without_panic() {
+            let _ = direct_span_fallback_enabled();
+        }
     }
 
     mod test_shutdown {
@@ -327,6 +368,17 @@ mod tests {
         fn shutdown_before_init_is_safe() {
             // If not initialized, shutdown should be a no-op.
             shutdown(); // must not panic
+        }
+
+        #[test]
+        fn shutdown_marks_provider_inactive() {
+            ACTIVE.store(true, Ordering::Release);
+            DIRECT_SPAN_FALLBACK.store(true, Ordering::Release);
+
+            shutdown();
+
+            assert!(!is_initialized());
+            assert!(!direct_span_fallback_enabled());
         }
     }
 
@@ -363,6 +415,24 @@ mod tests {
                 Ok(_) => {}
                 Err(e) => panic!("unexpected error: {e}"),
             }
+        }
+    }
+
+    mod test_subscriber_error_classification {
+        use super::*;
+
+        #[test]
+        fn detects_existing_global_subscriber_error() {
+            let err = TelemetryError::TracerProviderSetup(
+                "a global default trace dispatcher has already been set".to_string(),
+            );
+            assert!(is_global_subscriber_already_set(&err));
+        }
+
+        #[test]
+        fn rejects_unrelated_subscriber_errors() {
+            let err = TelemetryError::TracerProviderSetup("invalid layer".to_string());
+            assert!(!is_global_subscriber_already_set(&err));
         }
     }
 

--- a/docs/guide/INDEX.md
+++ b/docs/guide/INDEX.md
@@ -73,7 +73,7 @@ document without scanning every file.
 | [adapter-runtime-contracts.md](adapter-runtime-contracts.md) | Session events, artefact refs, debug descriptors, `app_ui` automation contracts |
 | [app-ui-workflows.md](app-ui-workflows.md) | Agent workflows for scoped `app_ui` UI automation, recovery, and VRS coverage |
 | [telemetry.md](telemetry.md) | ToolMetrics, ToolRecorder, RecordingGuard |
-| [observability.md](observability.md) | OTLP exporter, gateway event log (`resources://gateway/events`), Prometheus counters |
+| [observability.md](observability.md) | OTLP exporter, agent workflow spans, gateway event log (`resources://gateway/events`), Prometheus counters |
 | [scheduler.md](scheduler.md) | ScheduleSpec, TriggerSpec, cron/webhook scheduling |
 | [workflows.md](workflows.md) | WorkflowSpec engine: step kinds, policies, persistence |
 | [job-persistence.md](job-persistence.md) | SQLite-backed job/workflow persistence and resume |

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -43,6 +43,41 @@ Every `tools/call` trace includes:
 | `mcp.session_id` | `"sess-..."` | MCP session ID |
 | `mcp.request_id` | `"req-..."` | Per-request unique ID |
 
+### Gateway Agent Workflow Spans (#1180)
+
+The gateway also emits bounded agent workflow spans when discovery and dynamic
+capability calls pass through REST or MCP:
+
+| Span | Meaning |
+|------|---------|
+| `gateway.search` | Agent searched for a tool or skill. |
+| `gateway.describe` | Agent inspected a selected tool. |
+| `gateway.load_skill` | Agent loaded a skill discovered through search. |
+| `gateway.call` | Agent invoked one selected backend tool. |
+| `gateway.call_batch` | Agent invoked an ordered batch. |
+
+These spans use `openinference.span.kind` (`CHAIN` for search and `TOOL` for
+describe/load/call) plus a documented `dcc_mcp.*` attribute namespace for
+gateway-specific fields:
+
+| Attribute | Description |
+|-----------|-------------|
+| `dcc_mcp.workflow.operation` | One of the span names above. |
+| `dcc_mcp.transport` | `rest` or `mcp`. |
+| `dcc_mcp.trace_id`, `dcc_mcp.request_id`, `dcc_mcp.parent_request_id`, `dcc_mcp.session_id` | Correlation IDs that match Admin trace/debug-bundle surfaces. |
+| `dcc_mcp.agent.id`, `.name`, `.kind`, `.model`, `.task`, `.tags` | Bounded `agent_context` / caller metadata. |
+| `dcc_mcp.dcc.type`, `dcc_mcp.instance.id`, `dcc_mcp.skill.name`, `dcc_mcp.tool.slug` | Selected DCC route and skill/tool identity. |
+| `dcc_mcp.search.id`, `.ranker_version`, `.selected_rank`, `.score`, `.match_reasons`, `.total`, `.zero_results` | Search-quality context carried from `/v1/search` or gateway `search`. |
+| `dcc_mcp.policy.outcome`, `.reason` | Whether gateway policy allowed or denied the action and why. |
+| `dcc_mcp.success`, `dcc_mcp.error.kind`, `dcc_mcp.batch.size` | Execution outcome fields. |
+
+The gateway intentionally does **not** export hidden chain-of-thought, raw
+prompts, unbounded request bodies, secrets, or arbitrary `agent_context`
+metadata. Put `search_id` in REST `meta.search_id` or MCP `_meta.search_id`
+when following a search hit into `describe`, `load_skill`, `call`, or
+`call_batch`; that is what lets OTLP traces connect selected rank and score to
+actual tool outcomes.
+
 ### Trace Context
 
 Gateway observability keeps these identifiers separate:
@@ -103,6 +138,41 @@ services:
 
 ```bash
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 dcc-mcp-server ...
+```
+
+### Quick Start: Phoenix Through an OTLP Collector
+
+Phoenix accepts OTLP/HTTP traces at `/v1/traces`. The Rust gateway exporter
+uses OTLP/gRPC today, so route it through the OpenTelemetry Collector:
+
+```yaml
+# otel-collector.yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+exporters:
+  otlphttp/phoenix:
+    traces_endpoint: http://phoenix:6006/v1/traces
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlphttp/phoenix]
+```
+
+```bash
+docker run -d --name phoenix -p 6006:6006 arizephoenix/phoenix:latest
+docker run --rm -p 4317:4317 \
+  -v "$PWD/otel-collector.yaml:/etc/otelcol-contrib/config.yaml" \
+  otel/opentelemetry-collector-contrib:latest
+
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
+OTEL_SERVICE_NAME=dcc-mcp-gateway \
+  dcc-mcp-server ...
 ```
 
 ---

--- a/docs/zh/guide/INDEX.md
+++ b/docs/zh/guide/INDEX.md
@@ -67,7 +67,7 @@
 | [usd.md](usd.md) | OpenUSD 桥接：UsdStage、场景信息 JSON |
 | [artefacts.md](artefacts.md) | FileRef + ArtefactStore — 跨工具文件交接 |
 | [telemetry.md](telemetry.md) | ToolMetrics、ToolRecorder、RecordingGuard |
-| [observability.md](observability.md) | OTLP exporter、网关事件日志（`resources://gateway/events`）、Prometheus 计数器 |
+| [observability.md](observability.md) | OTLP exporter、agent workflow spans、网关事件日志（`resources://gateway/events`）、Prometheus 计数器 |
 | [scheduler.md](scheduler.md) | ScheduleSpec、TriggerSpec、cron/webhook 调度 |
 | [workflows.md](workflows.md) | WorkflowSpec 引擎：步骤类型、策略、持久化 |
 | [job-persistence.md](job-persistence.md) | SQLite 支持的作业/工作流持久化与恢复 |

--- a/docs/zh/guide/observability.md
+++ b/docs/zh/guide/observability.md
@@ -43,6 +43,33 @@ OTEL_SERVICE_NAME=dcc-mcp-gateway \
 | `mcp.session_id` | `"sess-..."` | MCP 会话 ID |
 | `mcp.request_id` | `"req-..."` | 每次请求的唯一 ID |
 
+### Gateway Agent Workflow Spans（#1180）
+
+当 agent 通过 REST 或 MCP 进行动态能力发现与调用时，网关会额外发送有界工作流 span：
+
+| Span | 含义 |
+|------|------|
+| `gateway.search` | Agent 搜索工具或技能。 |
+| `gateway.describe` | Agent 查看选中工具的 schema/说明。 |
+| `gateway.load_skill` | Agent 加载搜索得到的技能。 |
+| `gateway.call` | Agent 调用一个后端工具。 |
+| `gateway.call_batch` | Agent 执行有序批量调用。 |
+
+这些 span 使用 `openinference.span.kind`（search 为 `CHAIN`，describe/load/call 为 `TOOL`），并用 `dcc_mcp.*` 命名空间记录网关语义字段：
+
+| 属性 | 说明 |
+|------|------|
+| `dcc_mcp.workflow.operation` | 上表中的 span 名称。 |
+| `dcc_mcp.transport` | `rest` 或 `mcp`。 |
+| `dcc_mcp.trace_id`、`dcc_mcp.request_id`、`dcc_mcp.parent_request_id`、`dcc_mcp.session_id` | 与 Admin trace/debug bundle 对齐的关联 ID。 |
+| `dcc_mcp.agent.id`、`.name`、`.kind`、`.model`、`.task`、`.tags` | 有界的 `agent_context` / caller 元数据。 |
+| `dcc_mcp.dcc.type`、`dcc_mcp.instance.id`、`dcc_mcp.skill.name`、`dcc_mcp.tool.slug` | 选中的 DCC 路由与技能/工具身份。 |
+| `dcc_mcp.search.id`、`.ranker_version`、`.selected_rank`、`.score`、`.match_reasons`、`.total`、`.zero_results` | 从 `/v1/search` 或 gateway `search` 继承的搜索质量上下文。 |
+| `dcc_mcp.policy.outcome`、`.reason` | 网关策略是否允许/拒绝以及原因。 |
+| `dcc_mcp.success`、`dcc_mcp.error.kind`、`dcc_mcp.batch.size` | 执行结果字段。 |
+
+网关不会导出隐藏推理、原始 prompt、无界请求体、secret 或任意 `agent_context` metadata。Agent 从搜索结果继续调用 `describe`、`load_skill`、`call` 或 `call_batch` 时，应保留 REST `meta.search_id` 或 MCP `_meta.search_id`，这样 OTLP trace 才能把 selected rank/score 和真实工具结果关联起来。
+
 ### Rust 编程式配置
 
 ```rust
@@ -86,6 +113,40 @@ services:
 
 ```bash
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 dcc-mcp-server ...
+```
+
+### 快速启动：通过 OTLP Collector 写入 Phoenix
+
+Phoenix 可在 `/v1/traces` 接收 OTLP/HTTP traces。当前 Rust 网关 exporter 使用 OTLP/gRPC，因此建议用 OpenTelemetry Collector 做 gRPC 到 HTTP 的桥接：
+
+```yaml
+# otel-collector.yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+exporters:
+  otlphttp/phoenix:
+    traces_endpoint: http://phoenix:6006/v1/traces
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlphttp/phoenix]
+```
+
+```bash
+docker run -d --name phoenix -p 6006:6006 arizephoenix/phoenix:latest
+docker run --rm -p 4317:4317 \
+  -v "$PWD/otel-collector.yaml:/etc/otelcol-contrib/config.yaml" \
+  otel/opentelemetry-collector-contrib:latest
+
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
+OTEL_SERVICE_NAME=dcc-mcp-gateway \
+  dcc-mcp-server ...
 ```
 
 ---

--- a/skills/dcc-mcp-skill-developer/SKILL.md
+++ b/skills/dcc-mcp-skill-developer/SKILL.md
@@ -97,6 +97,14 @@ into a faster authoring loop.
    full prompts. Compact batch examples may also read
    per-result `token_accounting` metadata, and batch request items may carry an
    optional `id` that is echoed next to the numeric result `index`.
+   Gateway OTLP spans mirror the same agent workflow chain with bounded
+   attributes: `gateway.search`, `gateway.describe`, `gateway.load_skill`,
+   `gateway.call`, and `gateway.call_batch` use `openinference.span.kind` plus
+   `dcc_mcp.*` fields for agent id/name/kind/model/task/tags, DCC route,
+   `search_id`, selected rank/score/match reasons, policy outcome, and
+   success/error kind. Adapter docs and examples should preserve those
+   correlation fields but must not put hidden reasoning, secrets, raw prompts,
+   or unbounded request bodies into `agent_context` metadata.
    Gateway search uses a hybrid ranker in default fuzzy mode: weighted lexical
    matches over tool names, skill names, tags, summaries, author-declared
    aliases, and bounded schema-field tokens take precedence, while fuzzy


### PR DESCRIPTION
## Summary
- add bounded OpenInference-compatible gateway workflow spans for search, describe, load_skill, call, and call_batch
- correlate spans with gateway trace/search IDs and selected search hits without exporting prompts, reasoning, secrets, or arbitrary metadata
- document OTLP/Phoenix setup and update skill developer guidance for agent-facing telemetry expectations

## Validation
- vx cargo fmt --all
- vx cargo check -p dcc-mcp-gateway
- vx cargo check -p dcc-mcp-telemetry
- vx cargo check -p dcc-mcp-server --features otlp-exporter
- vx cargo test -p dcc-mcp-telemetry --lib
- vx cargo test -p dcc-mcp-gateway agent_telemetry --lib
- vx cargo test -p dcc-mcp-gateway search_telemetry --lib
- vx cargo test -p dcc-mcp-gateway --lib --features admin
- vx cargo clippy -p dcc-mcp-gateway --all-targets --features admin -- -D warnings
- vx cargo clippy -p dcc-mcp-telemetry --all-targets -- -D warnings
- vx cargo clippy -p dcc-mcp-server --features otlp-exporter -- -D warnings
- vx cargo check -p dcc-mcp-gateway --no-default-features --features admin
- vx cargo check -p dcc-mcp-gateway --no-default-features --features telemetry
- vx just dev
- git diff --check

Closes #1180