### PR TITLE
feat: add admin workflow view

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -16,7 +16,7 @@ import puzzleIcon from './assets/icons/puzzle.svg';
 import vscodeIcon from './assets/icons/vscode.svg';
 import { formatTime, timestampTitle } from './time';
 
-type Panel = 'setup' | 'debug' | 'activity' | 'health' | 'instances' | 'tools' | 'tasks' | 'openapi' | 'calls' | 'traces' | 'stats' | 'logs' | 'skill-paths';
+type Panel = 'setup' | 'debug' | 'activity' | 'health' | 'instances' | 'tools' | 'workflows' | 'tasks' | 'openapi' | 'calls' | 'traces' | 'stats' | 'logs' | 'skill-paths';
 
 type HealthPayload = {
   status: string;
@@ -111,6 +111,7 @@ type AdminLinks = {
   openapi_docs_url?: string;
   stats_url?: string;
   admin_traces_url?: string;
+  admin_workflows_url?: string;
 };
 
 type AgentContext = {
@@ -234,6 +235,77 @@ type TaskRow = {
   started_at: string;
   duration_ms?: number | null;
   correlation?: ActivityEvent['correlation'];
+};
+
+type WorkflowAgent = {
+  agent_id?: string | null;
+  agent_name?: string | null;
+  agent_kind?: string | null;
+  model?: string | null;
+  task?: string | null;
+  turn_index?: number | null;
+  tags?: string[];
+};
+
+type WorkflowSearchSignal = {
+  search_id: string;
+  selected_rank?: number | null;
+  selected_score?: number | null;
+  match_reasons?: string[];
+  zero_results?: boolean | null;
+  result_count?: number | null;
+  first_success_ms?: number | null;
+};
+
+type WorkflowStep = {
+  step_id: string;
+  kind: string;
+  title: string;
+  timestamp: string;
+  status: string;
+  success?: boolean | null;
+  request_id?: string | null;
+  trace_id?: string | null;
+  parent_request_id?: string | null;
+  session_id?: string | null;
+  dcc_type?: string | null;
+  instance_id?: string | null;
+  tool?: string | null;
+  transport?: string | null;
+  duration_ms?: number | null;
+  search?: WorkflowSearchSignal | null;
+  links?: AdminLinks;
+};
+
+type WorkflowRow = {
+  workflow_id: string;
+  group_kind: string;
+  title: string;
+  status: string;
+  started_at: string;
+  finished_at: string;
+  duration_ms?: number | null;
+  step_count: number;
+  failed_steps: number;
+  agent?: WorkflowAgent | null;
+  correlation: {
+    session_id?: string | null;
+    trace_id?: string | null;
+    agent_id?: string | null;
+    request_ids?: string[];
+    trace_ids?: string[];
+    session_ids?: string[];
+  };
+  discovery: {
+    search_count: number;
+    zero_result_count: number;
+    selected_count: number;
+    best_selected_rank?: number | null;
+    time_to_first_success_ms?: number | null;
+    search_ids?: string[];
+  };
+  steps: WorkflowStep[];
+  links?: AdminLinks;
 };
 
 type LatencyBlock = {
@@ -628,6 +700,7 @@ const PANELS: { id: Panel; label: string; group: string }[] = [
   { id: 'instances', label: 'Instances', group: 'Operations' },
   { id: 'activity', label: 'Activity', group: 'Operations' },
   { id: 'health', label: 'Health', group: 'Operations' },
+  { id: 'workflows', label: 'Workflows', group: 'Workspace' },
   { id: 'tasks', label: 'Tasks', group: 'Workspace' },
   { id: 'tools', label: 'Tools', group: 'Workspace' },
   { id: 'openapi', label: 'OpenAPI Inspector', group: 'Contracts' },
@@ -1078,7 +1151,7 @@ function statusClass(value: string): string {
   if (status.includes('ok') || status.includes('success') || status.includes('complete') || status.includes('completed') || status.includes('done') || status.includes('ready') || status.includes('available')) {
     return 'badge badge-ok';
   }
-  if (status.includes('stale') || status.includes('booting') || status.includes('warn') || status.includes('pending') || status.includes('running') || status.includes('busy') || status.includes('queued')) {
+  if (status.includes('stale') || status.includes('booting') || status.includes('warn') || status.includes('zero') || status.includes('pending') || status.includes('running') || status.includes('busy') || status.includes('queued')) {
     return 'badge badge-warn';
   }
   return 'badge badge-muted';
@@ -1152,6 +1225,7 @@ function NavIcon({ panel }: { panel: Panel }) {
     health: ['M12 4l7 4v5c0 4-3 7-7 8-4-1-7-4-7-8V8z'],
     instances: ['M6 7h12v10H6z', 'M9 4h6', 'M9 20h6'],
     tools: ['M5 19l5-5', 'M14 5l5 5', 'M12 7l5 5-5 5-5-5z'],
+    workflows: ['M5 6h4v4H5z', 'M15 6h4v4h-4z', 'M5 15h4v4H5z', 'M9 8h6', 'M7 10v5'],
     tasks: ['M6 7h12', 'M6 12h12', 'M6 17h12', 'M4 7h.01', 'M4 12h.01', 'M4 17h.01'],
     calls: ['M7 7h10v10H7z', 'M10 10h4v4h-4z'],
     traces: ['M5 7h4v4H5z', 'M15 13h4v4h-4z', 'M9 9l6 6'],
@@ -1698,6 +1772,133 @@ function TraceLinks({ links }: { links: AdminLinks }) {
   );
 }
 
+function workflowAgentLabel(agent: WorkflowAgent | null | undefined): string {
+  return agent?.agent_name || agent?.agent_id || agent?.agent_kind || agent?.model || 'unknown agent';
+}
+
+function workflowMeta(workflow: WorkflowRow): string {
+  const parts = [
+    workflow.group_kind,
+    workflow.correlation.session_id ? `session ${compactId(workflow.correlation.session_id)}` : '',
+    workflow.correlation.trace_id ? `trace ${compactId(workflow.correlation.trace_id)}` : '',
+    `${workflow.step_count} steps`,
+  ];
+  return parts.filter(Boolean).join(' · ');
+}
+
+function WorkflowSearchChips({ signal }: { signal: WorkflowSearchSignal | null | undefined }) {
+  if (!signal) {
+    return null;
+  }
+  const chips = [
+    `search ${compactId(signal.search_id)}`,
+    signal.result_count != null ? `${signal.result_count} hit(s)` : '',
+    signal.zero_results ? 'zero results' : '',
+    signal.selected_rank != null ? `rank ${signal.selected_rank}` : '',
+    signal.selected_score != null ? `score ${signal.selected_score}` : '',
+    signal.first_success_ms != null ? `first success ${formatDurationMs(signal.first_success_ms)}` : '',
+    ...(signal.match_reasons ?? []).slice(0, 3),
+  ].filter(Boolean);
+  return (
+    <div className="workflow-chip-row">
+      {chips.map((chip) => <span key={chip}>{chip}</span>)}
+    </div>
+  );
+}
+
+function WorkflowStepCard({
+  step,
+  onOpenTrace,
+  onCopyIssueReport,
+}: {
+  step: WorkflowStep;
+  onOpenTrace: (requestId: string) => void;
+  onCopyIssueReport: (requestId: string) => void;
+}) {
+  const requestId = step.request_id ?? undefined;
+  const links = requestId ? traceLinks(requestId, step.links) : step.links;
+  return (
+    <article className={`workflow-step ${isErrStatus(step.status) ? 'err' : isWarnStatus(step.status) ? 'warn' : isOkStatus(step.status) ? 'ok' : ''}`}>
+      <div className="workflow-step-line" />
+      <div className="workflow-step-body">
+        <div className="workflow-step-head">
+          <span className="workflow-kind">{step.kind}</span>
+          <StatusBadge value={step.status} />
+          <TimeValue value={step.timestamp} />
+          <span>{formatDurationMs(step.duration_ms)}</span>
+        </div>
+        <h4 title={step.title}>{step.title}</h4>
+        <div className="workflow-step-meta">
+          <span>{step.dcc_type ?? 'gateway'}</span>
+          <span>{step.transport ?? '-'}</span>
+          <span>{compactId(step.instance_id)}</span>
+          {step.parent_request_id ? <span>parent {compactId(step.parent_request_id)}</span> : null}
+        </div>
+        <WorkflowSearchChips signal={step.search} />
+        <div className="workflow-step-actions">
+          {requestId ? (
+            <button className="refresh-btn" type="button" title={requestId} onClick={() => onOpenTrace(requestId)}>
+              Trace
+            </button>
+          ) : null}
+          {links?.debug_bundle_url ? <a className="link-chip" href={links.debug_bundle_url} target="_blank" rel="noopener noreferrer">Bundle</a> : null}
+          {links?.issue_report_url ? <a className="link-chip" href={links.issue_report_url} target="_blank" rel="noopener noreferrer">Issue JSON</a> : null}
+          {links?.openapi_docs_url ? <a className="link-chip" href={links.openapi_docs_url} target="_blank" rel="noopener noreferrer">Docs</a> : null}
+          {requestId ? (
+            <button className="refresh-btn" type="button" onClick={() => onCopyIssueReport(requestId)}>
+              Copy JSON
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function WorkflowCard({
+  workflow,
+  onOpenTrace,
+  onCopyIssueReport,
+}: {
+  workflow: WorkflowRow;
+  onOpenTrace: (requestId: string) => void;
+  onCopyIssueReport: (requestId: string) => void;
+}) {
+  return (
+    <article className={`workflow-card ${isErrStatus(workflow.status) ? 'err' : isWarnStatus(workflow.status) ? 'warn' : 'ok'}`}>
+      <div className="workflow-card-head">
+        <div>
+          <div className="workflow-kicker">{workflowAgentLabel(workflow.agent)}</div>
+          <h3 title={workflow.title}>{workflow.title}</h3>
+          <div className="workflow-subline">{workflowMeta(workflow)}</div>
+        </div>
+        <div className="workflow-status">
+          <StatusBadge value={workflow.status} />
+          <span>{formatDurationMs(workflow.duration_ms)}</span>
+        </div>
+      </div>
+      {workflow.agent?.task ? <p className="workflow-agent-task">{workflow.agent.task}</p> : null}
+      <div className="workflow-chip-row">
+        <span>{workflow.discovery.search_count} search(es)</span>
+        {workflow.discovery.zero_result_count ? <span>{workflow.discovery.zero_result_count} zero-result</span> : null}
+        {workflow.discovery.best_selected_rank != null ? <span>best rank {workflow.discovery.best_selected_rank}</span> : null}
+        {workflow.discovery.time_to_first_success_ms != null ? <span>first success {formatDurationMs(workflow.discovery.time_to_first_success_ms)}</span> : null}
+        {workflow.failed_steps ? <span>{workflow.failed_steps} failed</span> : null}
+      </div>
+      <div className="workflow-steps">
+        {workflow.steps.map((step) => (
+          <WorkflowStepCard
+            key={step.step_id}
+            step={step}
+            onOpenTrace={onOpenTrace}
+            onCopyIssueReport={onCopyIssueReport}
+          />
+        ))}
+      </div>
+    </article>
+  );
+}
+
 function TraceDetailPanel({
   trace,
   fallback,
@@ -1926,6 +2127,7 @@ function App() {
   const [health, setHealth] = useState<HealthPayload | null>(null);
   const [activity, setActivity] = useState<ActivityEvent[]>([]);
   const [tools, setTools] = useState<ToolRow[]>([]);
+  const [workflows, setWorkflows] = useState<WorkflowRow[]>([]);
   const [tasks, setTasks] = useState<TaskRow[]>([]);
   const [calls, setCalls] = useState<CallRow[]>([]);
   const [traces, setTraces] = useState<TraceRow[]>([]);
@@ -1959,6 +2161,7 @@ function App() {
     health: 'Loading…',
     instances: 'Loading…',
     tools: 'Loading…',
+    workflows: 'Loading…',
     tasks: 'Loading…',
     openapi: 'Loading…',
     calls: 'Loading…',
@@ -2121,6 +2324,32 @@ function App() {
       ),
     );
   }, [tasks, listSearch]);
+
+  const filteredWorkflows = useMemo(() => {
+    const q = listSearch.trim().toLowerCase();
+    if (!q) {
+      return workflows;
+    }
+    return workflows.filter((workflow) =>
+      matchesListFilter(
+        q,
+        haystack(
+          workflow.workflow_id,
+          workflow.group_kind,
+          workflow.title,
+          workflow.status,
+          workflow.agent?.agent_id ?? '',
+          workflow.agent?.agent_name ?? '',
+          workflow.agent?.model ?? '',
+          workflow.agent?.task ?? '',
+          workflow.correlation.session_id ?? '',
+          workflow.correlation.trace_id ?? '',
+          workflow.discovery.search_ids?.join(' ') ?? '',
+          workflow.steps.map((step) => haystack(step.kind, step.title, step.request_id ?? '', step.search?.search_id ?? '')).join(' '),
+        ),
+      ),
+    );
+  }, [workflows, listSearch]);
 
   const filteredWorkers = useMemo(() => {
     const q = listSearch.trim().toLowerCase();
@@ -2297,6 +2526,14 @@ function App() {
     return { completed, failed, active };
   }, [tasks]);
 
+  const workflowSummary = useMemo(() => {
+    const completed = workflows.filter((workflow) => isOkStatus(workflow.status)).length;
+    const failed = workflows.filter((workflow) => isErrStatus(workflow.status)).length;
+    const warning = workflows.filter((workflow) => isWarnStatus(workflow.status)).length;
+    const zeroResults = workflows.filter((workflow) => workflow.discovery.zero_result_count > 0).length;
+    return { completed, failed, warning, zeroResults };
+  }, [workflows]);
+
   const traceSummary = useMemo(() => {
     const ok = traces.filter((trace) => isOkStatus(trace.status)).length;
     const failed = traces.filter((trace) => isErrStatus(trace.status)).length;
@@ -2472,6 +2709,17 @@ function App() {
       markUpdated('tasks', `${payload.tasks?.length ?? 0} task(s) — ${new Date().toLocaleTimeString()}`);
     } catch (error) {
       markError('tasks', error);
+    }
+  }, [markError, markUpdated]);
+
+  const fetchWorkflows = useCallback(async () => {
+    try {
+      const payload = await apiJson<{ workflows: WorkflowRow[] }>('/workflows?limit=200');
+      const rows = Array.isArray(payload.workflows) ? payload.workflows : [];
+      setWorkflows(rows);
+      markUpdated('workflows', `${rows.length} workflow(s) — ${new Date().toLocaleTimeString()}`);
+    } catch (error) {
+      markError('workflows', error);
     }
   }, [markError, markUpdated]);
 
@@ -2764,13 +3012,14 @@ function App() {
     if (panel === 'instances') void fetchInstanceBackends();
     if (panel === 'tools') void fetchTools();
     if (panel === 'openapi') void fetchOpenApi();
+    if (panel === 'workflows') void fetchWorkflows();
     if (panel === 'tasks') void fetchTasks();
     if (panel === 'calls') void fetchCalls();
     if (panel === 'traces') void fetchTraces();
     if (panel === 'stats') void fetchStats();
     if (panel === 'skill-paths') void fetchSkillInventory();
     if (panel === 'logs') void fetchLogs();
-  }, [fetchActivity, fetchCalls, fetchDebug, fetchHealth, fetchInstanceBackends, fetchLogs, fetchOpenApi, fetchSetup, fetchSkillInventory, fetchStats, fetchTasks, fetchTools, fetchTraces]);
+  }, [fetchActivity, fetchCalls, fetchDebug, fetchHealth, fetchInstanceBackends, fetchLogs, fetchOpenApi, fetchSetup, fetchSkillInventory, fetchStats, fetchTasks, fetchTools, fetchTraces, fetchWorkflows]);
 
   useEffect(() => {
     fetchPanel(activePanel);
@@ -2839,6 +3088,7 @@ function App() {
                 {activePanel === 'activity' ? `${filteredActivity.length} / ${activity.length}` : ''}
                 {activePanel === 'instances' ? `${filteredWorkers.length} / ${workers.length}` : ''}
                 {activePanel === 'tools' ? `${filteredTools.length} / ${tools.length}` : ''}
+                {activePanel === 'workflows' ? `${filteredWorkflows.length} / ${workflows.length}` : ''}
                 {activePanel === 'openapi' ? `${filteredOpenApiOperations.length} / ${openApiOperations.length}` : ''}
                 {activePanel === 'tasks' ? `${filteredTasks.length} / ${tasks.length}` : ''}
                 {activePanel === 'calls' ? `${filteredCalls.length} / ${calls.length}` : ''}
@@ -3238,6 +3488,38 @@ function App() {
               operations={filteredOpenApiOperations}
               source={openApiSource}
             />
+          </section>
+        )}
+
+        {activePanel === 'workflows' && (
+          <section className="panel active workflows-panel">
+            <PanelHeader
+              title="Workflows"
+              meta="Agent sessions reconstructed from search, trace, and audit correlation."
+              action={<button className="refresh-btn" type="button" onClick={fetchWorkflows}>Refresh</button>}
+            />
+            <StatusLine text={copiedNotice || updatedAt.workflows} error={errors.workflows} />
+            <div className="metric-grid compact">
+              <MetricTile tone="ok" label="Completed" value={workflowSummary.completed} />
+              <MetricTile tone={workflowSummary.warning > 0 ? 'warn' : undefined} label="Warnings" value={workflowSummary.warning} />
+              <MetricTile tone={workflowSummary.failed > 0 ? 'err' : undefined} label="Failed" value={workflowSummary.failed} />
+              <MetricTile tone={workflowSummary.zeroResults > 0 ? 'warn' : undefined} label="Zero-result" value={workflowSummary.zeroResults} />
+              <MetricTile label="Visible" value={`${filteredWorkflows.length} / ${workflows.length}`} />
+            </div>
+            {workflows.length === 0 ? <p className="empty">No agent workflows reconstructed yet.</p> : filteredWorkflows.length === 0 ? (
+              <p className="empty">No workflows match your search.</p>
+            ) : (
+              <div className="workflow-board">
+                {filteredWorkflows.map((workflow) => (
+                  <WorkflowCard
+                    key={`${workflow.group_kind}-${workflow.workflow_id}`}
+                    workflow={workflow}
+                    onOpenTrace={(requestId) => goToPanel('traces', { traceId: requestId })}
+                    onCopyIssueReport={(requestId) => void copyIssueReport(requestId)}
+                  />
+                ))}
+              </div>
+            )}
           </section>
         )}
 

--- a/admin-ui/src/styles.css
+++ b/admin-ui/src/styles.css
@@ -806,6 +806,154 @@ tbody tr:hover td {
   border-color: rgba(112, 165, 255, 0.45);
 }
 
+.workflow-board {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.workflow-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-left: 4px solid var(--ok);
+  border-radius: var(--radius);
+  display: grid;
+  gap: 0.8rem;
+  min-width: 0;
+  padding: 0.95rem;
+}
+
+.workflow-card.warn {
+  border-left-color: var(--warn);
+}
+
+.workflow-card.err {
+  border-left-color: var(--err);
+}
+
+.workflow-card-head {
+  align-items: start;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.workflow-kicker,
+.workflow-subline,
+.workflow-status,
+.workflow-step-head,
+.workflow-step-meta,
+.workflow-chip-row {
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+}
+
+.workflow-card h3,
+.workflow-step h4 {
+  color: var(--foreground);
+  font-size: 0.94rem;
+  font-weight: 800;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+.workflow-subline {
+  margin-top: 0.2rem;
+  overflow-wrap: anywhere;
+}
+
+.workflow-status {
+  display: grid;
+  gap: 0.28rem;
+  justify-items: end;
+  white-space: nowrap;
+}
+
+.workflow-agent-task {
+  color: var(--foreground);
+  font-size: 0.82rem;
+  overflow-wrap: anywhere;
+}
+
+.workflow-chip-row {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.workflow-chip-row span {
+  background: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.14rem 0.46rem;
+}
+
+.workflow-steps {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.workflow-step {
+  display: grid;
+  gap: 0.7rem;
+  grid-template-columns: 3px minmax(0, 1fr);
+}
+
+.workflow-step-line {
+  background: var(--muted-foreground);
+  border-radius: 999px;
+  min-height: 100%;
+}
+
+.workflow-step.ok .workflow-step-line {
+  background: var(--ok);
+}
+
+.workflow-step.warn .workflow-step-line {
+  background: var(--warn);
+}
+
+.workflow-step.err .workflow-step-line {
+  background: var(--err);
+}
+
+.workflow-step-body {
+  background: rgba(255, 255, 255, 0.035);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  display: grid;
+  gap: 0.45rem;
+  min-width: 0;
+  padding: 0.7rem 0.8rem;
+}
+
+.workflow-step-head,
+.workflow-step-meta {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.42rem;
+}
+
+.workflow-kind {
+  color: var(--foreground);
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.workflow-step-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.workflow-step-actions .link-chip {
+  border-radius: var(--radius);
+  text-decoration: none;
+}
+
 .openapi-inspector {
   display: grid;
   gap: 1rem;
@@ -2189,6 +2337,7 @@ button.linkish:disabled {
   }
 
   .task-card,
+  .workflow-card-head,
   .openapi-layout,
   .trace-layout,
   .trace-item {

--- a/admin-ui/tests/admin.spec.ts
+++ b/admin-ui/tests/admin.spec.ts
@@ -173,6 +173,146 @@ async function mockAdminApi(page: Page) {
           },
         ],
       };
+    } else if (path === '/workflows') {
+      body = {
+        total: 2,
+        summary: { failed: 1, warning: 0, zero_result_workflows: 1 },
+        workflows: [
+          {
+            workflow_id: 'session-1',
+            group_kind: 'session',
+            title: 'Scene Builder: maya-1234__create_sphere',
+            status: 'completed',
+            started_at: now,
+            finished_at: '2026-05-18T08:00:04.000Z',
+            duration_ms: 4000,
+            step_count: 4,
+            failed_steps: 0,
+            agent: {
+              agent_id: 'agent-1',
+              agent_name: 'Scene Builder',
+              model: 'gpt-test',
+              task: 'Create a sphere after discovery.',
+              tags: ['smoke'],
+            },
+            correlation: {
+              session_id: 'session-1',
+              trace_id: 'trace-workflow',
+              agent_id: 'agent-1',
+              request_ids: ['req-search', 'req-describe', 'req-load', 'req-123'],
+              trace_ids: ['trace-workflow'],
+              session_ids: ['session-1'],
+            },
+            discovery: {
+              search_count: 1,
+              zero_result_count: 0,
+              selected_count: 3,
+              best_selected_rank: 2,
+              time_to_first_success_ms: 310,
+              search_ids: ['search-1'],
+            },
+            steps: [
+              {
+                step_id: 'search:search-1',
+                kind: 'search',
+                title: 'search create sphere',
+                timestamp: now,
+                status: 'ok',
+                success: true,
+                request_id: 'req-search',
+                trace_id: 'trace-workflow',
+                session_id: 'session-1',
+                dcc_type: 'maya',
+                transport: 'rest',
+                search: { search_id: 'search-1', zero_results: false, result_count: 2, first_success_ms: 310 },
+              },
+              {
+                step_id: 'describe:req-describe',
+                kind: 'describe',
+                title: 'maya-1234__create_sphere',
+                timestamp: '2026-05-18T08:00:01.000Z',
+                status: 'ok',
+                success: true,
+                request_id: 'req-describe',
+                trace_id: 'trace-workflow',
+                parent_request_id: 'req-search',
+                session_id: 'session-1',
+                dcc_type: 'maya',
+                transport: 'rest',
+                search: { search_id: 'search-1', selected_rank: 2, selected_score: 88, match_reasons: ['skill_match'] },
+              },
+              {
+                step_id: 'load_skill:req-load',
+                kind: 'load_skill',
+                title: 'load_skill maya-modeling',
+                timestamp: '2026-05-18T08:00:02.000Z',
+                status: 'ok',
+                success: true,
+                request_id: 'req-load',
+                trace_id: 'trace-workflow',
+                parent_request_id: 'req-describe',
+                session_id: 'session-1',
+                dcc_type: 'maya',
+                transport: 'rest',
+                search: { search_id: 'search-1', selected_rank: 2, selected_score: 88 },
+              },
+              {
+                step_id: 'call:req-123',
+                kind: 'call',
+                title: 'maya-1234__create_sphere',
+                timestamp: '2026-05-18T08:00:04.000Z',
+                status: 'ok',
+                success: true,
+                request_id: 'req-123',
+                trace_id: 'trace-workflow',
+                parent_request_id: 'req-load',
+                session_id: 'session-1',
+                dcc_type: 'maya',
+                instance_id: 'maya-1234567890',
+                transport: 'rest',
+                duration_ms: 42,
+                search: { search_id: 'search-1', selected_rank: 2, selected_score: 88, first_success_ms: 310 },
+                links: {
+                  debug_bundle_url: 'http://127.0.0.1:3721/admin/api/debug-bundle/req-123',
+                  issue_report_url: 'http://127.0.0.1:3721/admin/api/issue-report/req-123',
+                  openapi_docs_url: 'http://127.0.0.1:3721/docs',
+                },
+              },
+            ],
+          },
+          {
+            workflow_id: 'search-zero',
+            group_kind: 'search',
+            title: 'search missing tool',
+            status: 'warning',
+            started_at: '2026-05-18T08:02:00.000Z',
+            finished_at: '2026-05-18T08:02:00.000Z',
+            duration_ms: 0,
+            step_count: 1,
+            failed_steps: 0,
+            correlation: { request_ids: [], trace_ids: [], session_ids: [] },
+            discovery: {
+              search_count: 1,
+              zero_result_count: 1,
+              selected_count: 0,
+              search_ids: ['search-zero'],
+            },
+            steps: [
+              {
+                step_id: 'search:search-zero',
+                kind: 'search',
+                title: 'search missing tool',
+                timestamp: '2026-05-18T08:02:00.000Z',
+                status: 'zero_results',
+                success: false,
+                dcc_type: 'blender',
+                transport: 'mcp',
+                search: { search_id: 'search-zero', zero_results: true, result_count: 0 },
+              },
+            ],
+          },
+        ],
+      };
     } else if (path === '/calls') {
       body = {
         total: 1,
@@ -342,7 +482,7 @@ test.describe('Admin Page', () => {
     await expect(page.locator('.brand-tag')).toContainText('DCC-MCP Gateway');
     await expect(page.locator('h1')).toContainText('Admin Dashboard');
     await expect(page.getByRole('navigation').getByRole('link', { name: 'Connect IDE' })).toHaveClass(/active/);
-    for (const label of ['Connect IDE', 'Debug', 'Activity', 'Health', 'Instances', 'Tools', 'Tasks', 'Calls', 'Traces', 'Stats', 'Skills', 'Logs', 'Docs']) {
+    for (const label of ['Connect IDE', 'Debug', 'Activity', 'Health', 'Instances', 'Tools', 'Workflows', 'Tasks', 'Calls', 'Traces', 'Stats', 'Skills', 'Logs', 'Docs']) {
       await expect(page.getByRole('navigation').getByRole('link', { name: label })).toBeVisible();
     }
     await expect(page.getByRole('navigation').getByRole('link', { name: 'Docs' })).toHaveAttribute('href', 'https://github.com/loonghao/dcc-mcp-core/tree/main/docs');
@@ -445,6 +585,24 @@ test.describe('Admin Page', () => {
     await expect(page).toHaveURL(/panel=traces/);
     await expect(page).toHaveURL(/trace=req-123/);
     await expect(page.locator('.trace-detail-panel')).toContainText('req-123');
+  });
+
+  test('shows agent workflows with discovery quality and trace links', async ({ page }) => {
+    await page.goto('/admin/?panel=workflows');
+    const panel = page.locator('.workflows-panel');
+    await expect(panel).toContainText('Scene Builder');
+    await expect(panel).toContainText('search create sphere');
+    await expect(panel).toContainText('describe');
+    await expect(panel).toContainText('load_skill');
+    await expect(panel).toContainText('best rank 2');
+    await expect(panel).toContainText('zero-result');
+    await page.getByLabel('Filter current panel').fill('missing tool');
+    await expect(page.locator('.workflow-card')).toHaveCount(1);
+    await expect(panel).toContainText('zero_results');
+    await page.getByLabel('Filter current panel').fill('');
+    await panel.getByRole('button', { name: 'Trace' }).last().click();
+    await expect(page).toHaveURL(/panel=traces/);
+    await expect(page).toHaveURL(/trace=req-123/);
   });
 
   test('updates stats when the range selector changes', async ({ page }) => {

--- a/crates/dcc-mcp-gateway/src/gateway/admin/activity.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/activity.rs
@@ -213,7 +213,7 @@ async fn collect_activity_events(state: &AdminState, limit: usize) -> Vec<Activi
     events
 }
 
-async fn collect_audits(state: &AdminState, limit: usize) -> Vec<AdminAuditRecord> {
+pub(super) async fn collect_audits(state: &AdminState, limit: usize) -> Vec<AdminAuditRecord> {
     let mut by_id: HashMap<String, AdminAuditRecord> = HashMap::new();
     if let Some(lane) = &state.admin_sqlite_lane {
         for rec in lane
@@ -234,7 +234,7 @@ async fn collect_audits(state: &AdminState, limit: usize) -> Vec<AdminAuditRecor
     rows
 }
 
-async fn collect_traces(state: &AdminState, limit: usize) -> Vec<DispatchTrace> {
+pub(super) async fn collect_traces(state: &AdminState, limit: usize) -> Vec<DispatchTrace> {
     let mut by_id: HashMap<String, DispatchTrace> = HashMap::new();
     if let Some(lane) = &state.admin_sqlite_lane {
         for trace in lane

--- a/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
@@ -6,13 +6,14 @@ use std::time::UNIX_EPOCH;
 
 use axum::Json;
 use axum::extract::{OriginalUri, Path, Query, State};
-use axum::http::{HeaderMap, HeaderValue, StatusCode, Uri, header};
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
 use axum::response::IntoResponse;
 use dcc_mcp_gateway_core::naming::instance_short;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
 use super::html::ADMIN_HTML;
+use super::links::AdminLinkBuilder;
 use super::state::{AdminAuditRecord, AdminState};
 use super::trace::DispatchTrace;
 use crate::gateway::capability::RefreshReason;
@@ -24,94 +25,6 @@ use dcc_mcp_db::read_gateway_log_dir_rows_recent;
 use dcc_mcp_transport::discovery::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry};
 
 const ADMIN_FILE_LOG_READ_TIMEOUT: Duration = Duration::from_millis(750);
-
-#[derive(Clone)]
-struct AdminLinkBuilder {
-    origin: String,
-    admin_base: String,
-}
-
-impl AdminLinkBuilder {
-    fn from_request(headers: &HeaderMap, uri: &Uri) -> Self {
-        let proto = header_value(headers, "x-forwarded-proto").unwrap_or_else(|| "http".into());
-        let host = header_value(headers, "x-forwarded-host")
-            .or_else(|| header_value(headers, "host"))
-            .unwrap_or_else(|| "127.0.0.1:9765".into());
-        let admin_base = admin_base_path(uri.path());
-        Self {
-            origin: format!("{proto}://{host}"),
-            admin_base,
-        }
-    }
-
-    fn request_links(&self, request_id: &str) -> Value {
-        let encoded = encode_url_component(request_id);
-        json!({
-            "admin_trace_url": format!(
-                "{}{}?panel=traces&trace={}",
-                self.origin, self.admin_base, encoded
-            ),
-            "trace_api_url": format!(
-                "{}{}/api/traces/{}",
-                self.origin, self.admin_base, encoded
-            ),
-            "debug_bundle_url": format!(
-                "{}{}/api/debug-bundle/{}",
-                self.origin, self.admin_base, encoded
-            ),
-            "issue_report_url": format!(
-                "{}{}/api/issue-report/{}",
-                self.origin, self.admin_base, encoded
-            ),
-            "openapi_inspector_url": self.panel_url("openapi"),
-            "openapi_spec_url": format!("{}/v1/openapi.json", self.origin),
-            "openapi_docs_url": format!("{}/docs", self.origin),
-            "stats_url": self.panel_url("stats"),
-        })
-    }
-
-    fn panel_url(&self, panel: &str) -> String {
-        format!("{}{}?panel={panel}", self.origin, self.admin_base)
-    }
-}
-
-fn header_value(headers: &HeaderMap, name: &str) -> Option<String> {
-    headers
-        .get(name)
-        .and_then(|value| value.to_str().ok())
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_string)
-}
-
-fn admin_base_path(path: &str) -> String {
-    if path.starts_with("/v1/debug/") {
-        return "/admin".to_string();
-    }
-    let base = path
-        .find("/api")
-        .map(|idx| &path[..idx])
-        .unwrap_or(path)
-        .trim_end_matches('/');
-    if base.is_empty() {
-        "/admin".to_string()
-    } else {
-        base.to_string()
-    }
-}
-
-fn encode_url_component(value: &str) -> String {
-    let mut out = String::with_capacity(value.len());
-    for byte in value.bytes() {
-        match byte {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
-                out.push(byte as char);
-            }
-            _ => out.push_str(&format!("%{byte:02X}")),
-        }
-    }
-    out
-}
 
 fn issue_report_filename(request_id: &str) -> String {
     let mut safe = String::with_capacity(request_id.len());
@@ -896,6 +809,19 @@ pub async fn handle_admin_tasks(
 ) -> impl IntoResponse {
     let limit = params.limit(200, 1_000);
     Json(crate::gateway::admin::activity::build_tasks_payload(&s, limit).await)
+}
+
+/// `GET /admin/api/workflows` — agent/session workflow projection over
+/// retained search telemetry, traces, and audit rows.
+pub async fn handle_admin_workflows(
+    State(s): State<AdminState>,
+    axum::extract::Query(params): axum::extract::Query<DebugListQuery>,
+    headers: HeaderMap,
+    OriginalUri(uri): OriginalUri,
+) -> impl IntoResponse {
+    let limit = params.limit(100, 500);
+    let links = AdminLinkBuilder::from_request(&headers, &uri);
+    Json(crate::gateway::admin::workflows::build_workflows_payload(&s, limit, links).await)
 }
 
 /// `GET /admin/api/debug-bundle/{request_id}` — correlated material for one request.

--- a/crates/dcc-mcp-gateway/src/gateway/admin/links.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/links.rs
@@ -1,0 +1,103 @@
+//! Link helpers shared by admin/debug JSON projections.
+
+use axum::http::{HeaderMap, Uri};
+use serde_json::{Value, json};
+
+#[derive(Clone)]
+pub(super) struct AdminLinkBuilder {
+    origin: String,
+    admin_base: String,
+}
+
+impl AdminLinkBuilder {
+    pub(super) fn from_request(headers: &HeaderMap, uri: &Uri) -> Self {
+        let proto = header_value(headers, "x-forwarded-proto").unwrap_or_else(|| "http".into());
+        let host = header_value(headers, "x-forwarded-host")
+            .or_else(|| header_value(headers, "host"))
+            .unwrap_or_else(|| "127.0.0.1:9765".into());
+        let admin_base = admin_base_path(uri.path());
+        Self {
+            origin: format!("{proto}://{host}"),
+            admin_base,
+        }
+    }
+
+    pub(super) fn request_links(&self, request_id: &str) -> Value {
+        let encoded = encode_url_component(request_id);
+        json!({
+            "admin_trace_url": format!(
+                "{}{}?panel=traces&trace={}",
+                self.origin, self.admin_base, encoded
+            ),
+            "trace_api_url": format!(
+                "{}{}/api/traces/{}",
+                self.origin, self.admin_base, encoded
+            ),
+            "debug_bundle_url": format!(
+                "{}{}/api/debug-bundle/{}",
+                self.origin, self.admin_base, encoded
+            ),
+            "issue_report_url": format!(
+                "{}{}/api/issue-report/{}",
+                self.origin, self.admin_base, encoded
+            ),
+            "openapi_inspector_url": self.panel_url("openapi"),
+            "openapi_spec_url": format!("{}/v1/openapi.json", self.origin),
+            "openapi_docs_url": format!("{}/docs", self.origin),
+            "stats_url": self.panel_url("stats"),
+        })
+    }
+
+    pub(super) fn workflow_links(&self) -> Value {
+        json!({
+            "admin_workflows_url": self.panel_url("workflows"),
+            "admin_traces_url": self.panel_url("traces"),
+            "openapi_inspector_url": self.panel_url("openapi"),
+            "openapi_spec_url": format!("{}/v1/openapi.json", self.origin),
+            "openapi_docs_url": format!("{}/docs", self.origin),
+            "stats_url": self.panel_url("stats"),
+        })
+    }
+
+    pub(super) fn panel_url(&self, panel: &str) -> String {
+        format!("{}{}?panel={panel}", self.origin, self.admin_base)
+    }
+}
+
+fn header_value(headers: &HeaderMap, name: &str) -> Option<String> {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn admin_base_path(path: &str) -> String {
+    if path.starts_with("/v1/debug/") {
+        return "/admin".to_string();
+    }
+    let base = path
+        .find("/api")
+        .map(|idx| &path[..idx])
+        .unwrap_or(path)
+        .trim_end_matches('/');
+    if base.is_empty() {
+        "/admin".to_string()
+    } else {
+        base.to_string()
+    }
+}
+
+fn encode_url_component(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char);
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
+}

--- a/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/mod.rs
@@ -45,11 +45,13 @@
 
 pub mod activity;
 mod html;
+mod links;
 pub mod sqlite_lane;
 pub mod state;
 pub mod stats;
 pub mod trace;
 pub mod workers;
+pub mod workflows;
 
 #[cfg(feature = "admin")]
 mod handlers;
@@ -66,6 +68,7 @@ pub use state::{AdminAuditRecord, AdminAuditSink, AdminState, AuditLog, DurableA
 pub use stats::{GatewayStats, LatencyStats, StatsAggregator, StatsRange, TopEntry};
 pub use trace::{DispatchTrace, TraceContext, TraceLog, TracePayload, TraceSpan};
 pub use workers::build_workers_payload;
+pub use workflows::{WorkflowDiscoverySummary, WorkflowStep, WorkflowView};
 
 #[cfg(feature = "admin")]
 pub use router::{build_admin_router, build_v1_debug_router};

--- a/crates/dcc-mcp-gateway/src/gateway/admin/router.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/router.rs
@@ -9,7 +9,7 @@ use super::handlers::{
     handle_admin_skill_detail, handle_admin_skill_path_add, handle_admin_skill_path_delete,
     handle_admin_skill_paths, handle_admin_skills, handle_admin_stats, handle_admin_tasks,
     handle_admin_tools, handle_admin_trace_detail, handle_admin_traces, handle_admin_ui,
-    handle_admin_workers, handle_v1_debug_trace_lookup,
+    handle_admin_workers, handle_admin_workflows, handle_v1_debug_trace_lookup,
 };
 use super::state::AdminState;
 
@@ -28,6 +28,7 @@ use super::state::AdminState;
 /// - `GET  /api/traces`             → JSON recent dispatch traces (Phase 2)
 /// - `GET  /api/traces/{request_id}` → full trace waterfall for one call
 /// - `GET  /api/issue-report/{request_id}` → downloadable JSON issue report
+/// - `GET  /api/workflows`          → agent/session workflow projection
 /// - `GET  /api/stats?range=1h|24h|7d` → aggregated call statistics (Phase 3)
 /// - `GET  /api/workers`            → per-instance worker cards (Phase 4)
 /// - `GET  /api/deregistered`       → recently auto-deregistered rows
@@ -48,6 +49,7 @@ pub fn build_admin_router(state: AdminState) -> Router {
             routing::get(handle_admin_trace_detail),
         )
         .route("/api/tasks", routing::get(handle_admin_tasks))
+        .route("/api/workflows", routing::get(handle_admin_workflows))
         .route(
             "/api/debug-bundle/{request_id}",
             routing::get(handle_admin_debug_bundle),
@@ -93,6 +95,7 @@ pub fn build_v1_debug_router(state: AdminState) -> Router {
             routing::get(handle_v1_debug_trace_lookup),
         )
         .route("/v1/debug/tasks", routing::get(handle_admin_tasks))
+        .route("/v1/debug/workflows", routing::get(handle_admin_workflows))
         .route(
             "/v1/debug/issue-reports/{request_id}",
             routing::get(handle_admin_issue_report),

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -814,6 +814,231 @@ mod admin_tests {
     }
 
     #[tokio::test]
+    async fn test_admin_workflows_group_steps_and_quality_signals() {
+        use crate::gateway::admin::trace::{AgentContext, DispatchTrace, TraceContext, TraceLog};
+        use crate::gateway::search_telemetry::{
+            RANKER_VERSION, SearchFollowupInput, SearchTelemetryHit, SearchTelemetryInput,
+            SearchTelemetryStore,
+        };
+        use std::time::SystemTime;
+
+        let gs = make_gateway_state();
+        let traces = Arc::new(TraceLog::new(20));
+        let trace_id = "4bf92f3577b34da6a3ce929d0e0e4736".to_string();
+        let session_id = "session-agent-1".to_string();
+        let search_id = SearchTelemetryStore::new_search_id();
+        let search_ctx = TraceContext {
+            trace_id: trace_id.clone(),
+            request_id: "req-search".to_string(),
+            span_id: None,
+            parent_span_id: None,
+            parent_request_id: None,
+            trace_flags: None,
+            trace_state: None,
+        };
+        gs.search_telemetry.record_search(SearchTelemetryInput {
+            search_id: search_id.clone(),
+            transport: "rest".to_string(),
+            kind: "tool".to_string(),
+            query: "create sphere".to_string(),
+            dcc_type: Some("maya".to_string()),
+            instance_id: Some("abcdef01-2345-6789-abcd-ef0123456789".to_string()),
+            limit: Some(5),
+            total: 2,
+            ranker_version: RANKER_VERSION.to_string(),
+            index_generation: "idx-workflow".to_string(),
+            hits: vec![SearchTelemetryHit {
+                tool_slug: "maya.abcdef01.create_sphere".to_string(),
+                skill_name: Some("maya-modeling".to_string()),
+                dcc_type: "maya".to_string(),
+                rank: 2,
+                score: 88,
+                match_reasons: vec!["skill_match".to_string(), "tool_lexical".to_string()],
+                loaded: true,
+            }],
+            trace_context: Some(search_ctx),
+            session_id: Some(session_id.clone()),
+        });
+        tokio::time::sleep(Duration::from_millis(2)).await;
+        assert!(gs.search_telemetry.record_followup(SearchFollowupInput {
+            search_id: search_id.clone(),
+            kind: "describe".to_string(),
+            tool_slug: Some("maya.abcdef01.create_sphere".to_string()),
+            skill_name: Some("maya-modeling".to_string()),
+            success: true,
+            trace_context: Some(TraceContext {
+                trace_id: trace_id.clone(),
+                request_id: "req-describe".to_string(),
+                span_id: None,
+                parent_span_id: None,
+                parent_request_id: Some("req-search".to_string()),
+                trace_flags: None,
+                trace_state: None,
+            }),
+        }));
+        tokio::time::sleep(Duration::from_millis(2)).await;
+        assert!(gs.search_telemetry.record_followup(SearchFollowupInput {
+            search_id: search_id.clone(),
+            kind: "load_skill".to_string(),
+            tool_slug: None,
+            skill_name: Some("maya-modeling".to_string()),
+            success: true,
+            trace_context: Some(TraceContext {
+                trace_id: trace_id.clone(),
+                request_id: "req-load".to_string(),
+                span_id: None,
+                parent_span_id: None,
+                parent_request_id: Some("req-describe".to_string()),
+                trace_flags: None,
+                trace_state: None,
+            }),
+        }));
+        tokio::time::sleep(Duration::from_millis(2)).await;
+        assert!(gs.search_telemetry.record_followup(SearchFollowupInput {
+            search_id: search_id.clone(),
+            kind: "call".to_string(),
+            tool_slug: Some("maya.abcdef01.create_sphere".to_string()),
+            skill_name: Some("maya-modeling".to_string()),
+            success: true,
+            trace_context: Some(TraceContext {
+                trace_id: trace_id.clone(),
+                request_id: "req-call".to_string(),
+                span_id: None,
+                parent_span_id: None,
+                parent_request_id: Some("req-load".to_string()),
+                trace_flags: None,
+                trace_state: None,
+            }),
+        }));
+        traces.push(DispatchTrace {
+            request_id: "req-call".into(),
+            trace_id: trace_id.clone(),
+            span_id: None,
+            parent_span_id: None,
+            parent_request_id: Some("req-load".into()),
+            trace_flags: None,
+            trace_state: None,
+            method: "tools/call".into(),
+            tool_slug: Some("maya.abcdef01.create_sphere".into()),
+            instance_id: Some("abcdef01-2345-6789-abcd-ef0123456789".into()),
+            session_id: Some(session_id.clone()),
+            dcc_type: Some("maya".into()),
+            transport: Some("rest".into()),
+            agent_context: Some(AgentContext {
+                agent_id: Some("agent-workflow".into()),
+                agent_name: Some("Scene Builder".into()),
+                model: Some("gpt-test".into()),
+                task: Some("Create a simple sphere".into()),
+                tags: vec!["smoke".into()],
+                metadata: json!({"workflow_id": "workflow-scene-build"}),
+                ..Default::default()
+            }),
+            started_at: SystemTime::now(),
+            total_ms: 31,
+            ok: true,
+            spans: vec![],
+            input: None,
+            output: None,
+        });
+
+        let zero_id = SearchTelemetryStore::new_search_id();
+        gs.search_telemetry.record_search(SearchTelemetryInput {
+            search_id: zero_id.clone(),
+            transport: "mcp".to_string(),
+            kind: "tool".to_string(),
+            query: "missing api".to_string(),
+            dcc_type: Some("blender".to_string()),
+            instance_id: None,
+            limit: Some(5),
+            total: 0,
+            ranker_version: RANKER_VERSION.to_string(),
+            index_generation: "idx-workflow".to_string(),
+            hits: vec![],
+            trace_context: None,
+            session_id: None,
+        });
+
+        let audit_log: Arc<AuditLog> = Arc::new(Mutex::new(vec![AdminAuditRecord {
+            timestamp: SystemTime::now(),
+            request_id: "req-audit-only".into(),
+            trace_id: None,
+            span_id: None,
+            parent_span_id: None,
+            method: Some("tools/call".into()),
+            instance_id: None,
+            session_id: None,
+            transport: Some("mcp".into()),
+            agent_id: Some("agent-audit".into()),
+            agent_name: None,
+            agent_model: Some("gpt-audit".into()),
+            parent_request_id: Some("req-missing-parent".into()),
+            action: "photoshop.12345678.save_document".into(),
+            dcc_type: Some("photoshop".into()),
+            success: false,
+            error: Some("document closed".into()),
+            duration_ms: Some(9),
+        }]));
+
+        let state = AdminState::new(gs)
+            .with_audit_log(audit_log)
+            .with_trace_log(traces, None);
+        let router = build_admin_router(state.clone());
+        let (status, body) = body_json(router, "/api/workflows?limit=10").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["total"].as_u64(), Some(3));
+        assert_eq!(body["summary"]["zero_result_workflows"], 1);
+
+        let workflows = body["workflows"].as_array().unwrap();
+        let session_workflow = workflows
+            .iter()
+            .find(|workflow| workflow["workflow_id"] == session_id)
+            .expect("session workflow");
+        assert_eq!(session_workflow["group_kind"], "session");
+        assert_eq!(session_workflow["status"], "completed");
+        assert_eq!(session_workflow["agent"]["agent_name"], "Scene Builder");
+        assert_eq!(session_workflow["discovery"]["best_selected_rank"], 2);
+        assert_eq!(session_workflow["discovery"]["selected_count"], 3);
+        assert!(
+            session_workflow["discovery"]["time_to_first_success_ms"]
+                .as_u64()
+                .is_some()
+        );
+        let step_kinds: Vec<_> = session_workflow["steps"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|step| step["kind"].as_str().unwrap())
+            .collect();
+        assert_eq!(step_kinds, vec!["search", "describe", "load_skill", "call"]);
+        let call_step = session_workflow["steps"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|step| step["kind"] == "call")
+            .unwrap();
+        assert_eq!(call_step["search"]["selected_rank"], 2);
+        assert_eq!(call_step["search"]["selected_score"], 88);
+        assert!(
+            call_step["links"]["debug_bundle_url"]
+                .as_str()
+                .unwrap()
+                .ends_with("/admin/api/debug-bundle/req-call")
+        );
+
+        let audit_workflow = workflows
+            .iter()
+            .find(|workflow| workflow["workflow_id"] == "req-audit-only")
+            .expect("partial audit workflow");
+        assert_eq!(audit_workflow["status"], "failed");
+        assert_eq!(audit_workflow["agent"]["agent_id"], "agent-audit");
+
+        let (debug_status, debug_body) =
+            body_json(build_v1_debug_router(state), "/v1/debug/workflows?limit=10").await;
+        assert_eq!(debug_status, StatusCode::OK);
+        assert_eq!(debug_body["total"].as_u64(), Some(3));
+    }
+
+    #[tokio::test]
     async fn test_admin_tasks_and_debug_bundle_from_trace() {
         use crate::gateway::admin::trace::{DispatchTrace, TraceLog, TracePayload};
         use crate::gateway::event_log::{ContendEvent, EventKind};
@@ -1310,6 +1535,7 @@ mod admin_tests {
             "/api/logs",
             "/api/stats",
             "/api/traces",
+            "/api/workflows",
         ] {
             let resp = admin_router()
                 .oneshot(

--- a/crates/dcc-mcp-gateway/src/gateway/admin/workflows.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/workflows.rs
@@ -1,0 +1,859 @@
+//! Agent session/workflow projection for the Admin UI.
+//!
+//! This is a read-only view over the existing trace, audit, and search
+//! telemetry stores. It deliberately keeps only bounded caller metadata and
+//! correlation IDs; hidden reasoning, raw prompts, and arbitrary request bodies
+//! stay in the existing trace/debug-bundle paths.
+
+use std::cmp::Reverse;
+use std::collections::{BTreeSet, HashMap};
+use std::time::{Duration, UNIX_EPOCH};
+
+use serde::Serialize;
+use serde_json::{Value, json};
+
+use super::activity::{collect_audits, collect_traces};
+use super::links::AdminLinkBuilder;
+use super::state::{AdminAuditRecord, AdminState};
+use super::trace::{AgentContext, DispatchTrace};
+use crate::gateway::search_telemetry::{
+    SearchFollowupTelemetry, SearchTelemetryHit, SearchTelemetryRecord,
+};
+
+const MAX_WORKFLOW_STEPS: usize = 64;
+const MAX_WORKFLOW_IDS: usize = 32;
+const MAX_AGENT_TAGS: usize = 16;
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct WorkflowAgent {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_index: Option<u64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct WorkflowCorrelation {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub request_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub trace_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub session_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct WorkflowSearchSignal {
+    pub search_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_rank: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_score: Option<u32>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub match_reasons: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub zero_results: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_success_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WorkflowStep {
+    pub step_id: String,
+    pub kind: String,
+    pub title: String,
+    pub timestamp: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub success: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_request_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dcc_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instance_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transport: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub search: Option<WorkflowSearchSignal>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub links: Option<Value>,
+    #[serde(skip)]
+    sort_ms: u64,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct WorkflowDiscoverySummary {
+    pub search_count: usize,
+    pub zero_result_count: usize,
+    pub selected_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub best_selected_rank: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_to_first_success_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub search_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WorkflowView {
+    pub workflow_id: String,
+    pub group_kind: String,
+    pub title: String,
+    pub status: String,
+    pub started_at: String,
+    pub finished_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+    pub step_count: usize,
+    pub failed_steps: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent: Option<WorkflowAgent>,
+    pub correlation: WorkflowCorrelation,
+    pub discovery: WorkflowDiscoverySummary,
+    pub steps: Vec<WorkflowStep>,
+    pub links: Value,
+    #[serde(skip)]
+    sort_ms: u64,
+}
+
+#[derive(Default)]
+struct WorkflowBuilder {
+    workflow_id: String,
+    group_kind: String,
+    steps: Vec<WorkflowStep>,
+    agent: Option<WorkflowAgent>,
+    request_ids: BTreeSet<String>,
+    trace_ids: BTreeSet<String>,
+    session_ids: BTreeSet<String>,
+    agent_id: Option<String>,
+}
+
+pub(super) async fn build_workflows_payload(
+    state: &AdminState,
+    limit: usize,
+    links: AdminLinkBuilder,
+) -> Value {
+    let fetch_limit = limit.saturating_mul(4).max(500);
+    let traces = collect_traces(state, fetch_limit).await;
+    let audits = collect_audits(state, fetch_limit).await;
+    let search_snapshot = state.gateway.search_telemetry.snapshot(fetch_limit);
+    let workflows = build_workflows(traces, audits, search_snapshot.recent, limit, links.clone());
+    let failed = workflows
+        .iter()
+        .filter(|workflow| workflow.status == "failed")
+        .count();
+    let warnings = workflows
+        .iter()
+        .filter(|workflow| workflow.status == "warning")
+        .count();
+    let zero_result_workflows = workflows
+        .iter()
+        .filter(|workflow| workflow.discovery.zero_result_count > 0)
+        .count();
+    json!({
+        "total": workflows.len(),
+        "summary": {
+            "failed": failed,
+            "warning": warnings,
+            "zero_result_workflows": zero_result_workflows,
+        },
+        "links": links.workflow_links(),
+        "workflows": workflows,
+    })
+}
+
+fn build_workflows(
+    traces: Vec<DispatchTrace>,
+    audits: Vec<AdminAuditRecord>,
+    searches: Vec<SearchTelemetryRecord>,
+    limit: usize,
+    links: AdminLinkBuilder,
+) -> Vec<WorkflowView> {
+    let trace_by_request: HashMap<String, DispatchTrace> = traces
+        .iter()
+        .map(|trace| (trace.request_id.clone(), trace.clone()))
+        .collect();
+    let audit_by_request: HashMap<String, AdminAuditRecord> = audits
+        .iter()
+        .map(|audit| (audit.request_id.clone(), audit.clone()))
+        .collect();
+    let parent_by_request = parent_index(&traces, &audits);
+    let mut represented_traces = BTreeSet::new();
+    let mut builders: HashMap<String, WorkflowBuilder> = HashMap::new();
+
+    for search in searches {
+        let (key, kind, id) = search_group_key(&search);
+        let builder = builders
+            .entry(key)
+            .or_insert_with(|| WorkflowBuilder::new(kind, id));
+        builder.push_step(search_step(&search));
+        builder.note_search(&search);
+
+        for followup in &search.followups {
+            let step = followup_step(&search, followup, &trace_by_request, &links);
+            let (f_key, f_kind, f_id) = followup
+                .request_id
+                .as_deref()
+                .and_then(|request_id| trace_by_request.get(request_id))
+                .map(|trace| trace_group_key(trace, &parent_by_request))
+                .unwrap_or_else(|| followup_group_key(&search, followup));
+            if let Some(request_id) = followup.request_id.as_deref() {
+                represented_traces.insert(request_id.to_string());
+            }
+            let followup_builder = builders
+                .entry(f_key)
+                .or_insert_with(|| WorkflowBuilder::new(f_kind, f_id));
+            if let Some(trace) = followup
+                .request_id
+                .as_deref()
+                .and_then(|request_id| trace_by_request.get(request_id))
+            {
+                followup_builder.note_trace(trace);
+            }
+            followup_builder.push_step(step);
+            followup_builder.note_search(&search);
+        }
+    }
+
+    for trace in traces {
+        if represented_traces.contains(&trace.request_id) {
+            continue;
+        }
+        let (key, kind, id) = trace_group_key(&trace, &parent_by_request);
+        let builder = builders
+            .entry(key)
+            .or_insert_with(|| WorkflowBuilder::new(kind, id));
+        builder.note_trace(&trace);
+        builder.push_step(trace_step(&trace, "call", None, &links));
+    }
+
+    for audit in audits {
+        if trace_by_request.contains_key(&audit.request_id) {
+            continue;
+        }
+        let (key, kind, id) = audit_group_key(&audit, &parent_by_request);
+        let builder = builders
+            .entry(key)
+            .or_insert_with(|| WorkflowBuilder::new(kind, id));
+        builder.note_audit(&audit);
+        builder.push_step(audit_step(&audit, &links));
+    }
+
+    let mut rows: Vec<WorkflowView> = builders
+        .into_values()
+        .filter(|builder| !builder.steps.is_empty())
+        .map(|builder| builder.finish(&audit_by_request, &links))
+        .collect();
+    rows.sort_by_key(|row| Reverse(row.sort_ms));
+    rows.truncate(limit);
+    rows
+}
+
+impl WorkflowBuilder {
+    fn new(group_kind: String, workflow_id: String) -> Self {
+        Self {
+            workflow_id,
+            group_kind,
+            ..Self::default()
+        }
+    }
+
+    fn push_step(&mut self, step: WorkflowStep) {
+        if let Some(request_id) = step.request_id.as_deref() {
+            self.request_ids.insert(request_id.to_string());
+        }
+        if let Some(trace_id) = step.trace_id.as_deref() {
+            self.trace_ids.insert(trace_id.to_string());
+        }
+        if let Some(session_id) = step.session_id.as_deref() {
+            self.session_ids.insert(session_id.to_string());
+        }
+        self.steps.push(step);
+    }
+
+    fn note_trace(&mut self, trace: &DispatchTrace) {
+        if self.agent.is_none() {
+            self.agent = trace.agent_context.as_ref().map(agent_from_context);
+        }
+        if self.agent_id.is_none() {
+            self.agent_id = trace
+                .agent_context
+                .as_ref()
+                .and_then(|ctx| ctx.agent_id.clone());
+        }
+    }
+
+    fn note_audit(&mut self, audit: &AdminAuditRecord) {
+        if self.agent.is_none()
+            && (audit.agent_id.is_some()
+                || audit.agent_name.is_some()
+                || audit.agent_model.is_some())
+        {
+            self.agent = Some(WorkflowAgent {
+                agent_id: audit.agent_id.clone(),
+                agent_name: audit.agent_name.clone(),
+                model: audit.agent_model.clone(),
+                ..WorkflowAgent::default()
+            });
+        }
+        if self.agent_id.is_none() {
+            self.agent_id = audit.agent_id.clone();
+        }
+    }
+
+    fn note_search(&mut self, search: &SearchTelemetryRecord) {
+        if let Some(request_id) = search.request_id.as_deref() {
+            self.request_ids.insert(request_id.to_string());
+        }
+        if let Some(trace_id) = search.trace_id.as_deref() {
+            self.trace_ids.insert(trace_id.to_string());
+        }
+        if let Some(session_id) = search.session_id.as_deref() {
+            self.session_ids.insert(session_id.to_string());
+        }
+    }
+
+    fn finish(
+        mut self,
+        audit_by_request: &HashMap<String, AdminAuditRecord>,
+        links: &AdminLinkBuilder,
+    ) -> WorkflowView {
+        self.steps.sort_by_key(|step| step.sort_ms);
+        self.steps.truncate(MAX_WORKFLOW_STEPS);
+        if self.agent.is_none() || self.agent_id.is_none() {
+            let audit_agent = self
+                .steps
+                .iter()
+                .filter_map(|step| step.request_id.as_deref())
+                .filter_map(|request_id| audit_by_request.get(request_id))
+                .find(|audit| {
+                    audit.agent_id.is_some()
+                        || audit.agent_name.is_some()
+                        || audit.agent_model.is_some()
+                });
+            if let Some(audit) = audit_agent {
+                if self.agent.is_none() {
+                    self.agent = Some(agent_from_audit(audit));
+                }
+                if self.agent_id.is_none() {
+                    self.agent_id = audit.agent_id.clone();
+                }
+            }
+        }
+
+        let started_ms = self.steps.first().map(|step| step.sort_ms).unwrap_or(0);
+        let finished_ms = self.steps.last().map(|step| step.sort_ms).unwrap_or(0);
+        let failed_steps = self
+            .steps
+            .iter()
+            .filter(|step| step.kind != "search" && step.success == Some(false))
+            .count();
+        let zero_result_steps = self
+            .steps
+            .iter()
+            .filter(|step| {
+                step.search
+                    .as_ref()
+                    .and_then(|search| search.zero_results)
+                    .unwrap_or(false)
+            })
+            .count();
+        let status = if failed_steps > 0 {
+            "failed"
+        } else if zero_result_steps > 0 {
+            "warning"
+        } else {
+            "completed"
+        }
+        .to_string();
+        let title = workflow_title(&self);
+        let request_ids = limit_set(self.request_ids);
+        let trace_ids = limit_set(self.trace_ids);
+        let session_ids = limit_set(self.session_ids);
+        let correlation = WorkflowCorrelation {
+            session_id: session_ids.first().cloned(),
+            trace_id: trace_ids.first().cloned(),
+            agent_id: self.agent_id.clone(),
+            request_ids,
+            trace_ids,
+            session_ids,
+        };
+        let discovery = discovery_summary(&self.steps);
+        let workflow_links = self
+            .steps
+            .iter()
+            .find_map(|step| step.request_id.as_deref())
+            .map(|request_id| links.request_links(request_id))
+            .unwrap_or_else(|| links.workflow_links());
+
+        WorkflowView {
+            workflow_id: self.workflow_id,
+            group_kind: self.group_kind,
+            title,
+            status,
+            started_at: rfc3339_ms(started_ms),
+            finished_at: rfc3339_ms(finished_ms),
+            duration_ms: (finished_ms >= started_ms).then_some(finished_ms - started_ms),
+            step_count: self.steps.len(),
+            failed_steps,
+            agent: self.agent,
+            correlation,
+            discovery,
+            steps: self.steps,
+            links: workflow_links,
+            sort_ms: finished_ms,
+        }
+    }
+}
+
+fn parent_index(
+    traces: &[DispatchTrace],
+    audits: &[AdminAuditRecord],
+) -> HashMap<String, Option<String>> {
+    let mut map = HashMap::new();
+    for trace in traces {
+        map.insert(trace.request_id.clone(), trace.parent_request_id.clone());
+    }
+    for audit in audits {
+        map.entry(audit.request_id.clone())
+            .or_insert_with(|| audit.parent_request_id.clone());
+    }
+    map
+}
+
+fn trace_group_key(
+    trace: &DispatchTrace,
+    parent_by_request: &HashMap<String, Option<String>>,
+) -> (String, String, String) {
+    if let Some(session_id) = trace
+        .session_id
+        .as_deref()
+        .filter(|value| !value.is_empty())
+    {
+        return keyed("session", session_id.to_string());
+    }
+    if let Some(workflow_id) = trace
+        .agent_context
+        .as_ref()
+        .and_then(workflow_id_from_context)
+    {
+        return keyed("workflow", workflow_id);
+    }
+    if !trace.trace_id.is_empty() {
+        return keyed("trace", trace.trace_id.clone());
+    }
+    keyed(
+        "request",
+        root_request_id(&trace.request_id, parent_by_request),
+    )
+}
+
+fn audit_group_key(
+    audit: &AdminAuditRecord,
+    parent_by_request: &HashMap<String, Option<String>>,
+) -> (String, String, String) {
+    if let Some(session_id) = audit
+        .session_id
+        .as_deref()
+        .filter(|value| !value.is_empty())
+    {
+        return keyed("session", session_id.to_string());
+    }
+    if let Some(trace_id) = audit.trace_id.as_deref().filter(|value| !value.is_empty()) {
+        return keyed("trace", trace_id.to_string());
+    }
+    keyed(
+        "request",
+        root_request_id(&audit.request_id, parent_by_request),
+    )
+}
+
+fn search_group_key(search: &SearchTelemetryRecord) -> (String, String, String) {
+    if let Some(session_id) = search
+        .session_id
+        .as_deref()
+        .filter(|value| !value.is_empty())
+    {
+        return keyed("session", session_id.to_string());
+    }
+    if let Some(trace_id) = search.trace_id.as_deref().filter(|value| !value.is_empty()) {
+        return keyed("trace", trace_id.to_string());
+    }
+    if let Some(request_id) = search
+        .request_id
+        .as_deref()
+        .filter(|value| !value.is_empty())
+    {
+        return keyed("request", request_id.to_string());
+    }
+    keyed("search", search.search_id.clone())
+}
+
+fn followup_group_key(
+    search: &SearchTelemetryRecord,
+    followup: &SearchFollowupTelemetry,
+) -> (String, String, String) {
+    if let Some(session_id) = search
+        .session_id
+        .as_deref()
+        .filter(|value| !value.is_empty())
+    {
+        return keyed("session", session_id.to_string());
+    }
+    if let Some(trace_id) = followup
+        .trace_id
+        .as_deref()
+        .filter(|value| !value.is_empty())
+    {
+        return keyed("trace", trace_id.to_string());
+    }
+    search_group_key(search)
+}
+
+fn keyed(kind: &str, id: String) -> (String, String, String) {
+    (format!("{kind}:{id}"), kind.to_string(), id)
+}
+
+fn root_request_id(
+    request_id: &str,
+    parent_by_request: &HashMap<String, Option<String>>,
+) -> String {
+    let mut current = request_id.to_string();
+    for _ in 0..32 {
+        let Some(Some(parent)) = parent_by_request.get(&current) else {
+            return current;
+        };
+        if parent == &current || parent.is_empty() {
+            return current;
+        }
+        if !parent_by_request.contains_key(parent) {
+            return current;
+        }
+        current = parent.clone();
+    }
+    current
+}
+
+fn search_step(search: &SearchTelemetryRecord) -> WorkflowStep {
+    let status = if search.zero_results {
+        "zero_results"
+    } else {
+        "ok"
+    };
+    WorkflowStep {
+        step_id: format!("search:{}", search.search_id),
+        kind: "search".to_string(),
+        title: search
+            .query_preview
+            .as_ref()
+            .map(|query| format!("search {query}"))
+            .unwrap_or_else(|| "search tools".to_string()),
+        timestamp: rfc3339_ms(search.timestamp_ms),
+        status: status.to_string(),
+        success: Some(!search.zero_results),
+        request_id: search.request_id.clone(),
+        trace_id: search.trace_id.clone(),
+        parent_request_id: None,
+        session_id: search.session_id.clone(),
+        dcc_type: search.dcc_type.clone(),
+        instance_id: search.instance_id.clone(),
+        tool: None,
+        transport: Some(search.transport.clone()),
+        duration_ms: None,
+        search: Some(WorkflowSearchSignal {
+            search_id: search.search_id.clone(),
+            zero_results: Some(search.zero_results),
+            result_count: Some(search.total),
+            first_success_ms: search.first_success_ms,
+            ..WorkflowSearchSignal::default()
+        }),
+        links: None,
+        sort_ms: search.timestamp_ms,
+    }
+}
+
+fn followup_step(
+    search: &SearchTelemetryRecord,
+    followup: &SearchFollowupTelemetry,
+    trace_by_request: &HashMap<String, DispatchTrace>,
+    links: &AdminLinkBuilder,
+) -> WorkflowStep {
+    let selected_hit = selected_hit(search, followup);
+    let signal = WorkflowSearchSignal {
+        search_id: search.search_id.clone(),
+        selected_rank: followup.selected_rank,
+        selected_score: selected_hit.map(|hit| hit.score),
+        match_reasons: selected_hit
+            .map(|hit| hit.match_reasons.clone())
+            .unwrap_or_default(),
+        zero_results: Some(search.zero_results),
+        result_count: Some(search.total),
+        first_success_ms: search.first_success_ms,
+    };
+    if let Some(trace) = followup
+        .request_id
+        .as_deref()
+        .and_then(|request_id| trace_by_request.get(request_id))
+    {
+        return trace_step(trace, &followup.kind, Some(signal), links);
+    }
+
+    let request_id = followup.request_id.clone();
+    WorkflowStep {
+        step_id: format!(
+            "{}:{}",
+            followup.kind,
+            request_id
+                .clone()
+                .unwrap_or_else(|| format!("{}:{}", search.search_id, followup.timestamp_ms))
+        ),
+        kind: followup.kind.clone(),
+        title: operation_title(
+            &followup.kind,
+            followup.tool_slug.as_deref(),
+            followup.skill_name.as_deref(),
+        ),
+        timestamp: rfc3339_ms(followup.timestamp_ms),
+        status: if followup.success { "ok" } else { "err" }.to_string(),
+        success: Some(followup.success),
+        request_id: request_id.clone(),
+        trace_id: followup
+            .trace_id
+            .clone()
+            .or_else(|| search.trace_id.clone()),
+        parent_request_id: None,
+        session_id: search.session_id.clone(),
+        dcc_type: search.dcc_type.clone(),
+        instance_id: search.instance_id.clone(),
+        tool: followup
+            .tool_slug
+            .clone()
+            .or_else(|| followup.skill_name.clone()),
+        transport: Some(search.transport.clone()),
+        duration_ms: followup.elapsed_ms,
+        search: Some(signal),
+        links: request_id.map(|request_id| links.request_links(&request_id)),
+        sort_ms: followup.timestamp_ms,
+    }
+}
+
+fn trace_step(
+    trace: &DispatchTrace,
+    kind: &str,
+    search: Option<WorkflowSearchSignal>,
+    links: &AdminLinkBuilder,
+) -> WorkflowStep {
+    let sort_ms = timestamp_ms(trace.started_at);
+    WorkflowStep {
+        step_id: format!("{kind}:{}", trace.request_id),
+        kind: kind.to_string(),
+        title: trace
+            .tool_slug
+            .clone()
+            .unwrap_or_else(|| trace.method.clone()),
+        timestamp: rfc3339_ms(sort_ms),
+        status: if trace.ok { "ok" } else { "err" }.to_string(),
+        success: Some(trace.ok),
+        request_id: Some(trace.request_id.clone()),
+        trace_id: Some(trace.trace_id.clone()),
+        parent_request_id: trace.parent_request_id.clone(),
+        session_id: trace.session_id.clone(),
+        dcc_type: trace.dcc_type.clone(),
+        instance_id: trace.instance_id.clone(),
+        tool: trace.tool_slug.clone(),
+        transport: trace.transport.clone(),
+        duration_ms: Some(trace.total_ms),
+        search,
+        links: Some(links.request_links(&trace.request_id)),
+        sort_ms,
+    }
+}
+
+fn audit_step(audit: &AdminAuditRecord, links: &AdminLinkBuilder) -> WorkflowStep {
+    let sort_ms = timestamp_ms(audit.timestamp);
+    WorkflowStep {
+        step_id: format!("audit:{}", audit.request_id),
+        kind: "call".to_string(),
+        title: audit.action.clone(),
+        timestamp: rfc3339_ms(sort_ms),
+        status: if audit.success { "ok" } else { "err" }.to_string(),
+        success: Some(audit.success),
+        request_id: Some(audit.request_id.clone()),
+        trace_id: audit.trace_id.clone(),
+        parent_request_id: audit.parent_request_id.clone(),
+        session_id: audit.session_id.clone(),
+        dcc_type: audit.dcc_type.clone(),
+        instance_id: audit.instance_id.clone(),
+        tool: Some(audit.action.clone()),
+        transport: audit.transport.clone(),
+        duration_ms: audit.duration_ms,
+        search: None,
+        links: Some(links.request_links(&audit.request_id)),
+        sort_ms,
+    }
+}
+
+fn selected_hit<'a>(
+    search: &'a SearchTelemetryRecord,
+    followup: &SearchFollowupTelemetry,
+) -> Option<&'a SearchTelemetryHit> {
+    if let Some(tool_slug) = followup.tool_slug.as_deref()
+        && let Some(hit) = search.hits.iter().find(|hit| hit.tool_slug == tool_slug)
+    {
+        return Some(hit);
+    }
+    let skill_name = followup.skill_name.as_deref()?;
+    search.hits.iter().find(|hit| {
+        hit.skill_name
+            .as_deref()
+            .is_some_and(|candidate| candidate.eq_ignore_ascii_case(skill_name))
+    })
+}
+
+fn operation_title(kind: &str, tool_slug: Option<&str>, skill_name: Option<&str>) -> String {
+    match (tool_slug, skill_name) {
+        (Some(tool), _) => tool.to_string(),
+        (None, Some(skill)) => format!("{kind} {skill}"),
+        (None, None) => kind.to_string(),
+    }
+}
+
+fn workflow_title(builder: &WorkflowBuilder) -> String {
+    let agent = builder
+        .agent
+        .as_ref()
+        .and_then(|agent| {
+            agent
+                .agent_name
+                .as_deref()
+                .or(agent.agent_id.as_deref())
+                .or(agent.agent_kind.as_deref())
+                .or(agent.model.as_deref())
+        })
+        .map(str::to_string);
+    let first_tool = builder
+        .steps
+        .iter()
+        .find_map(|step| step.tool.as_deref().or(Some(step.title.as_str())))
+        .map(str::to_string)
+        .unwrap_or_else(|| builder.workflow_id.clone());
+    match agent {
+        Some(agent) => format!("{agent}: {first_tool}"),
+        None => first_tool,
+    }
+}
+
+fn discovery_summary(steps: &[WorkflowStep]) -> WorkflowDiscoverySummary {
+    let mut search_ids = BTreeSet::new();
+    let mut zero_result_count = 0usize;
+    let mut selected_ranks = Vec::new();
+    let mut first_success_values = Vec::new();
+    for step in steps {
+        let Some(search) = step.search.as_ref() else {
+            continue;
+        };
+        search_ids.insert(search.search_id.clone());
+        if search.zero_results == Some(true) && step.kind == "search" {
+            zero_result_count += 1;
+        }
+        if let Some(rank) = search.selected_rank {
+            selected_ranks.push(rank);
+        }
+        if let Some(ms) = search.first_success_ms {
+            first_success_values.push(ms);
+        }
+    }
+    WorkflowDiscoverySummary {
+        search_count: search_ids.len(),
+        zero_result_count,
+        selected_count: selected_ranks.len(),
+        best_selected_rank: selected_ranks.into_iter().min(),
+        time_to_first_success_ms: first_success_values.into_iter().min(),
+        search_ids: search_ids.into_iter().take(MAX_WORKFLOW_IDS).collect(),
+    }
+}
+
+fn agent_from_context(ctx: &AgentContext) -> WorkflowAgent {
+    WorkflowAgent {
+        agent_id: ctx.agent_id.clone(),
+        agent_name: ctx.agent_name.clone(),
+        agent_kind: ctx.agent_kind.clone(),
+        model: ctx.model.clone(),
+        task: ctx.task.clone(),
+        turn_index: ctx.turn_index,
+        tags: ctx.tags.iter().take(MAX_AGENT_TAGS).cloned().collect(),
+    }
+}
+
+fn agent_from_audit(audit: &AdminAuditRecord) -> WorkflowAgent {
+    WorkflowAgent {
+        agent_id: audit.agent_id.clone(),
+        agent_name: audit.agent_name.clone(),
+        model: audit.agent_model.clone(),
+        ..WorkflowAgent::default()
+    }
+}
+
+fn workflow_id_from_context(ctx: &AgentContext) -> Option<String> {
+    let metadata = ctx.metadata.as_object()?;
+    for key in [
+        "workflow_id",
+        "workflowId",
+        "session_workflow_id",
+        "task_id",
+    ] {
+        if let Some(value) = metadata
+            .get(key)
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+fn limit_set(values: BTreeSet<String>) -> Vec<String> {
+    values.into_iter().take(MAX_WORKFLOW_IDS).collect()
+}
+
+fn timestamp_ms(time: std::time::SystemTime) -> u64 {
+    time.duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_millis() as u64
+}
+
+fn rfc3339_ms(ms: u64) -> String {
+    chrono::DateTime::<chrono::Utc>::from(UNIX_EPOCH + Duration::from_millis(ms))
+        .to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}

--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/agent_workflows.md
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/agent_workflows.md
@@ -72,6 +72,13 @@ When a gateway-proxied `call` / `POST /v1/call` fails with `thread-affinity-viol
 
 **Help and documentation from DCC hosts:** Adapters often expose **read-only** resources (e.g. command help, API signatures, scene snapshots). They appear in **`resources/list`** with stable schemes. Always **`resources/read`** the **exact** URI from the list — do not fabricate paths. If a `describe` response points to follow-up resources, prefer those over web search for DCC-accurate text.
 
+**Debugging an agent chain:** When Admin telemetry is enabled, prefer
+`GET /v1/debug/workflows` for a session-level view of `search` -> `describe`
+-> `load_skill` -> `call`. The payload reuses retained search telemetry,
+dispatch traces, and audit rows, so it shows selected rank, zero-result
+searches, time-to-first-success, and per-step trace/debug-bundle/issue-report
+links without exposing hidden reasoning or raw prompts.
+
 ---
 
 ## Efficiency (without a separate “bulk” playbook)

--- a/crates/dcc-mcp-gateway/src/gateway/tasks.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tasks.rs
@@ -815,7 +815,7 @@ pub(crate) async fn start_gateway_tasks(
     // yield is requested, dropping the group aborts the children instead of
     // detaching them as leaked background work.
     let supervisor_yield_rx = yield_rx.clone();
-    let mut task_handles = vec![
+    let task_handles = vec![
         cleanup_handle,
         watcher_handle,
         tools_watcher_handle,
@@ -827,6 +827,8 @@ pub(crate) async fn start_gateway_tasks(
         gw_handle,
         remote_handle,
     ];
+    #[cfg(feature = "prometheus")]
+    let mut task_handles = task_handles;
     #[cfg(feature = "prometheus")]
     task_handles.push(metrics_handle);
 

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -100,6 +100,7 @@ Markdown body for developer review.
 | `GET /admin/api/activity?limit=300` | `application/json` | Unified activity timeline built from audits, traces, and gateway events |
 | `GET /admin/api/instances` | `application/json` | Connected DCC instances |
 | `GET /admin/api/tools` | `application/json` | Registered MCP tools |
+| `GET /admin/api/workflows?limit=200` | `application/json` | Agent session/workflow view reconstructed from search telemetry, traces, and audits |
 | `GET /admin/api/tasks?limit=300` | `application/json` | Task-like snapshots reconstructed from dispatch traces |
 | `GET /admin/api/calls` | `application/json` | Recent tool calls (requires `AuditMiddleware`) |
 | `GET /admin/api/traces` | `application/json` | Recent per-call dispatch traces; accepts `?limit=200` |
@@ -128,6 +129,7 @@ compatibility layer; automation should prefer:
 | `GET /v1/debug/trace-context/{lookup_id}` | trace id or request id lookup |
 | `GET /v1/debug/bundles/{request_id_or_trace_id}` | `/admin/api/debug-bundle/{request_id}` |
 | `GET /v1/debug/issue-reports/{request_id}` | `/admin/api/issue-report/{request_id}` |
+| `GET /v1/debug/workflows` | `/admin/api/workflows` |
 | `GET /v1/debug/tasks` | `/admin/api/tasks` |
 | `GET /v1/debug/calls` | `/admin/api/calls` |
 | `GET /v1/debug/logs` | `/admin/api/logs` |
@@ -180,6 +182,12 @@ report JSON, OpenAPI Inspector, OpenAPI spec, OpenAPI docs, and stats page.
 Full trace rows include `agent_context`, request/response payload previews, a
 span waterfall, and the same copyable links. These URLs are designed to be
 pasted directly into an LLM evaluation prompt or another agent's debugging task.
+The Workflows panel and `GET /admin/api/workflows` group the same bounded data
+by session, explicit workflow id, trace id, or request chain. Each workflow row
+shows the readable discovery/execution chain (`search` → `describe` →
+`load_skill` → `call`), selected search rank, zero-result searches,
+time-to-first-success, and per-step links to trace detail, debug bundle, issue
+report JSON, OpenAPI Inspector/spec, and docs where a request id is available.
 
 `request_id` and `trace_id` are intentionally different. `request_id` identifies
 one HTTP/MCP request (or JSON-RPC id), while `trace_id` identifies the
@@ -257,6 +265,33 @@ matching Scalar reference.
         "instance_id": "abcdef01-2345-6789-abcd-ef0123456789",
         "dcc_type": "maya"
       }
+    }
+  ]
+}
+
+// GET /admin/api/workflows?limit=200
+{
+  "total": 1,
+  "workflows": [
+    {
+      "workflow_id": "session-1",
+      "group_kind": "session",
+      "title": "Layout Inspector: maya.abcdef01.scene__inspect",
+      "status": "completed",
+      "discovery": {
+        "search_count": 1,
+        "zero_result_count": 0,
+        "selected_count": 3,
+        "best_selected_rank": 2,
+        "time_to_first_success_ms": 310,
+        "search_ids": ["search-123"]
+      },
+      "steps": [
+        { "kind": "search", "title": "search scene inspect", "status": "ok" },
+        { "kind": "describe", "title": "maya.abcdef01.scene__inspect", "status": "ok" },
+        { "kind": "load_skill", "title": "load_skill scene", "status": "ok" },
+        { "kind": "call", "request_id": "req-123", "title": "maya.abcdef01.scene__inspect", "status": "ok" }
+      ]
     }
   ]
 }

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -221,6 +221,7 @@ The elected gateway exposes a read-only HTML dashboard at `GET /admin` and machi
 | `GET /admin/api/traces/{request_id}` | Drill into one call without scanning the whole trace ring. |
 | `GET /v1/debug/traces/{trace_id}` | Stable debug lookup by trace id or request id. |
 | `GET /v1/debug/bundles/{trace_id}` | Full-chain debug bundle across every retained request in a trace. |
+| `GET /admin/api/workflows?limit=200` | Group retained searches, describes, skill loads, calls, traces, and audits into agent session/workflow chains. |
 | `GET /admin/api/stats?range=1h\|24h\|7d` | Compute success rate, latency percentiles, and top tools/instances/agents from the trace log. |
 | `GET /admin/api/workers` | Inspect per-instance worker cards from the live registry. |
 
@@ -246,6 +247,10 @@ complete, replayable investigation target into an LLM evaluation or
 code-optimization prompt. The same link set includes `issue_report_url`, a
 standalone JSON export shaped for GitHub issue attachments with summary
 metadata, a suggested issue title/body, and the correlated debug bundle.
+`/admin/api/workflows` and `/v1/debug/workflows` reuse the same stores to show
+session/workflow rows with bounded agent metadata, selected search rank,
+zero-result searches, time-to-first-success, and step links back to trace
+detail, debug bundles, issue reports, OpenAPI, and docs.
 When a live worker exposes an `mcp_url`, the Admin Dashboard also derives that
 worker's `/v1/openapi.json`, `/docs`, and instance-scoped OpenAPI Inspector
 links, making it possible to follow a gateway trace down to the exact backend

--- a/docs/guide/rest-api-surface.md
+++ b/docs/guide/rest-api-surface.md
@@ -113,6 +113,7 @@ so operators and agents can compare results one-to-one:
 | `/v1/debug/trace-context/{lookup_id}` | n/a | Trace-context lookup by `trace_id` or `request_id`. |
 | `/v1/debug/bundles/{request_id}` | `/admin/api/debug-bundle/{request_id}` | Accepts request ids and retained trace ids. |
 | `/v1/debug/issue-reports/{request_id}` | `/admin/api/issue-report/{request_id}` | JSON export suitable for GitHub issue attachment. |
+| `/v1/debug/workflows` | `/admin/api/workflows` | Agent session/workflow projection from retained search telemetry, traces, and audits. |
 | `/v1/debug/tasks` | `/admin/api/tasks` | Task projection from retained traces. |
 | `/v1/debug/calls` | `/admin/api/calls` | Recent audit rows. |
 | `/v1/debug/logs` | `/admin/api/logs` | Merged gateway/file/audit logs. |

--- a/docs/zh/guide/admin-ui.md
+++ b/docs/zh/guide/admin-ui.md
@@ -93,6 +93,7 @@ let config = GatewayConfig {
 | `GET /admin/api/activity?limit=300` | `application/json` | 由审计、trace 和 gateway 事件合并得到的统一活动时间线 |
 | `GET /admin/api/instances` | `application/json` | 已连接的 DCC 实例 |
 | `GET /admin/api/tools` | `application/json` | 已注册的 MCP 工具 |
+| `GET /admin/api/workflows?limit=200` | `application/json` | 由 search telemetry、traces 和 audits 重建的 agent session/workflow 视图 |
 | `GET /admin/api/tasks?limit=300` | `application/json` | 从 dispatch traces 重建出的任务视图 |
 | `GET /admin/api/calls` | `application/json` | 最近的工具调用（需要 `AuditMiddleware`） |
 | `GET /admin/api/traces` | `application/json` | 最近的逐调用 dispatch traces；支持 `?limit=200` |
@@ -166,6 +167,33 @@ let config = GatewayConfig {
         "instance_id": "abcdef01-2345-6789-abcd-ef0123456789",
         "dcc_type": "maya"
       }
+    }
+  ]
+}
+
+// GET /admin/api/workflows?limit=200
+{
+  "total": 1,
+  "workflows": [
+    {
+      "workflow_id": "session-1",
+      "group_kind": "session",
+      "title": "Layout Inspector: maya.abcdef01.scene__inspect",
+      "status": "completed",
+      "discovery": {
+        "search_count": 1,
+        "zero_result_count": 0,
+        "selected_count": 3,
+        "best_selected_rank": 2,
+        "time_to_first_success_ms": 310,
+        "search_ids": ["search-123"]
+      },
+      "steps": [
+        { "kind": "search", "title": "search scene inspect", "status": "ok" },
+        { "kind": "describe", "title": "maya.abcdef01.scene__inspect", "status": "ok" },
+        { "kind": "load_skill", "title": "load_skill scene", "status": "ok" },
+        { "kind": "call", "request_id": "req-123", "title": "maya.abcdef01.scene__inspect", "status": "ok" }
+      ]
     }
   ]
 }

--- a/docs/zh/guide/observability.md
+++ b/docs/zh/guide/observability.md
@@ -193,6 +193,7 @@ result = resources.read("resources://gateway/events")
 | `GET /admin/api/calls` | 按 `request_id`、工具 slug、DCC 类型、实例、错误摘要和耗时关联最近调用。 |
 | `GET /admin/api/traces?limit=200` | 查看最近 dispatch waterfall、有界输入 payload（16 KiB）和有界输出 payload（64 KiB）。 |
 | `GET /admin/api/traces/{request_id}` | 不扫描整个 trace ring，直接下钻某一次调用。 |
+| `GET /admin/api/workflows?limit=200` | 将 retained searches、describes、skill loads、calls、traces 和 audits 聚合为 agent session/workflow 链。 |
 | `GET /admin/api/stats?range=1h\|24h\|7d` | 基于 trace log 计算成功率、延迟分位数和 top tools/instances。 |
 | `GET /admin/api/workers` | 查看 live registry 中每个实例的 worker 卡片。 |
 
@@ -202,6 +203,8 @@ result = resources.read("resources://gateway/events")
 - `traces.jsonl` —— 支撑 `/admin/api/traces` 和 stats 的 trace 行。
 
 `DCC_MCP_GATEWAY_AUDIT_MAX_ROWS`（默认 `5000`）限制每个文件保留行数。网关重启时会用这些文件回填内存中的 admin 缓冲区。持久化的 trace payload 使用与实时 API 相同的有界/已脱敏 `TracePayload`，不会保存无界原始请求体。
+
+`/admin/api/workflows` 和 `/v1/debug/workflows` 复用相同存储，按 session、显式 workflow id、trace id 或 request chain 展示 workflow 行；每行包含有界 agent metadata、selected search rank、zero-result search、time-to-first-success，并把步骤链接回 trace detail、debug bundle、issue report、OpenAPI 与 docs。
 
 ---
 

--- a/docs/zh/guide/rest-api-surface.md
+++ b/docs/zh/guide/rest-api-surface.md
@@ -44,6 +44,7 @@ OpenAPI 契约。
 | `GET` | `/v1/debug/trace-context/{lookup_id}` | 仅网关：按 trace id 或 request id 解析 primary trace context。 |
 | `GET` | `/v1/debug/bundles/{request_id}` | 仅网关：按 request id 或 trace id 取 full-chain debug bundle。 |
 | `GET` | `/v1/debug/issue-reports/{request_id}` | 仅网关：可附到 GitHub issue 的 debug report JSON。 |
+| `GET` | `/v1/debug/workflows` | 仅网关：由 retained search telemetry、traces 和 audits 重建的 agent session/workflow 投影视图。 |
 | `GET` | `/v1/debug/tasks` | 仅网关：从 traces 重建的 task-like snapshot。 |
 | `GET` | `/v1/debug/calls` | 仅网关：最近 audit call rows。 |
 | `GET` | `/v1/debug/logs` | 仅网关：合并 gateway events、file logs、audit summaries。 |
@@ -110,6 +111,7 @@ Phase-1 debug routes 会保留现有 Admin payload 字段，让 operator 和 age
 | `/v1/debug/trace-context/{lookup_id}` | n/a | 按 `trace_id` 或 `request_id` 做 trace-context lookup。 |
 | `/v1/debug/bundles/{request_id}` | `/admin/api/debug-bundle/{request_id}` | 接受 request ids 和 retained trace ids。 |
 | `/v1/debug/issue-reports/{request_id}` | `/admin/api/issue-report/{request_id}` | 适合附到 GitHub issue 的 JSON export。 |
+| `/v1/debug/workflows` | `/admin/api/workflows` | 从 retained search telemetry、traces 和 audits 聚合 agent session/workflow。 |
 | `/v1/debug/tasks` | `/admin/api/tasks` | retained traces 的 task projection。 |
 | `/v1/debug/calls` | `/admin/api/calls` | 最近 audit rows。 |
 | `/v1/debug/logs` | `/admin/api/logs` | 合并 gateway/file/audit logs。 |

--- a/skills/dcc-mcp-skill-developer/SKILL.md
+++ b/skills/dcc-mcp-skill-developer/SKILL.md
@@ -73,6 +73,11 @@ into a faster authoring loop.
    the shipped server paths enable the required gateway `admin` feature and
    Admin telemetry runtime state, while minimal direct `dcc-mcp-gateway` builds
    or runtimes started with Admin disabled may omit those debug routes.
+   Use `/v1/debug/workflows` when examples or tests need a session-level view
+   of the whole `search` -> `describe` -> `load_skill` -> `call` chain; it is a
+   read-only projection over retained search telemetry, dispatch traces, and
+   audit rows, including selected rank, zero-result searches, and
+   time-to-first-success without exposing hidden reasoning or raw prompts.
    Gateway `GET /v1/openapi.json` is gateway-specific: it documents only the
    mounted aggregating routes and intentionally omits per-DCC-only resources,
    prompts, jobs, and adapter-local `/v1/dcc/{dcc_type}/call`. Use a concrete


### PR DESCRIPTION
## Summary
- add `/admin/api/workflows` and `/v1/debug/workflows` to group retained search telemetry, traces, and audits into agent session/workflow chains
- add the Admin Dashboard Workflows panel with discovery quality signals, per-step trace/debug/export links, and Playwright coverage
- document the workflow projection in Admin, observability, REST debug, native agent workflow guidance, and skill developer docs

Closes #1181

## Validation
- `vx cargo fmt --all`
- `vx cargo test -p dcc-mcp-gateway admin_tests --features admin --lib`
- `vx cargo clippy -p dcc-mcp-gateway --all-targets --features admin -- -D warnings`
- `vx cargo check -p dcc-mcp-gateway --no-default-features --features admin`
- `vx npm --prefix admin-ui run build`
- `vx npm --prefix admin-ui test`
- Playwright browser smoke for `/admin/?panel=workflows`