### PR TITLE
fix: make clawhub publish idempotent

### DIFF
--- a/scripts/clawhub_sync.py
+++ b/scripts/clawhub_sync.py
@@ -16,6 +16,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 MANIFEST = REPO_ROOT / ".github" / "clawhub-skills.json"
 DEFAULT_CLI = os.environ.get("CLAWHUB_CLI_PACKAGE", "clawhub@0.17.0")
 CLAWHUB_LICENSE = "MIT-0"
+VERSION_EXISTS_MARKER = "Version already exists"
 
 
 def parse_args() -> argparse.Namespace:
@@ -80,6 +81,20 @@ def npx_cmd(cli: str, *args: str) -> list[str]:
     return [npx, cli, *args]
 
 
+def print_completed_process_output(proc: subprocess.CompletedProcess[str]) -> None:
+    """Forward captured child-process output to the current process streams."""
+    if proc.stdout:
+        print(proc.stdout, end="")
+    if proc.stderr:
+        print(proc.stderr, end="", file=sys.stderr)
+
+
+def version_already_exists(proc: subprocess.CompletedProcess[str]) -> bool:
+    """Return True when ClawHub reports that the immutable version exists."""
+    output = "\n".join(part for part in (proc.stdout, proc.stderr) if part)
+    return VERSION_EXISTS_MARKER in output
+
+
 def publish_one(
     entry: dict[str, Any],
     *,
@@ -130,8 +145,12 @@ def publish_one(
         print("DRY-RUN:", " ".join(cmd))
         return 0
 
-    print(f"Publishing {slug}@{version} from {skill_dir} ...")
-    proc = subprocess.run(cmd, check=False)
+    print(f"Publishing {slug}@{version} from {skill_dir} ...", flush=True)
+    proc = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    print_completed_process_output(proc)
+    if proc.returncode != 0 and version_already_exists(proc):
+        print(f"{slug}@{version} already exists on ClawHub; skipping.")
+        return 0
     return int(proc.returncode)
 
 

--- a/tests/test_clawhub_sync.py
+++ b/tests/test_clawhub_sync.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 from pathlib import Path
 import subprocess
@@ -16,6 +17,16 @@ RELEASE_PLEASE_CONFIG = REPO_ROOT / "release-please-config.json"
 RELEASE_MANIFEST = REPO_ROOT / ".release-please-manifest.json"
 RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
 SYNC_SCRIPT = REPO_ROOT / "scripts" / "clawhub_sync.py"
+
+
+def load_sync_module():
+    """Load clawhub_sync.py as an importable module for focused unit tests."""
+    spec = importlib.util.spec_from_file_location("clawhub_sync_under_test", SYNC_SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 class TestClawhubSync:
@@ -39,6 +50,43 @@ class TestClawhubSync:
         assert "clawhub@0.17.0" in proc.stdout
         assert "dcc-rest-gateway" in proc.stdout
         assert "dcc-cli-gateway" in proc.stdout
+
+    def test_publish_skips_existing_clawhub_version(self, tmp_path, monkeypatch, capsys) -> None:
+        sync = load_sync_module()
+        skill_dir = tmp_path / "skills" / "example"
+        skill_dir.mkdir(parents=True)
+
+        class CleanReport:
+            is_clean = True
+            issues: tuple[str, ...] = ()
+
+        def fake_run(cmd, *, check, capture_output, text):
+            assert check is False
+            assert capture_output is True
+            assert text is True
+            return subprocess.CompletedProcess(
+                cmd,
+                1,
+                stdout="- Preparing example@1.2.3\n",
+                stderr="Error: Uncaught ConvexError: Version already exists\n",
+            )
+
+        monkeypatch.setattr(sync, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(sync, "skill_version", lambda _skill_dir: "1.2.3")
+        monkeypatch.setattr(sync, "skill_license", lambda _skill_dir: sync.CLAWHUB_LICENSE)
+        monkeypatch.setattr(sync.dcc_mcp_core, "validate_skill", lambda _skill_dir: CleanReport())
+        monkeypatch.setattr(sync.subprocess, "run", fake_run)
+
+        rc = sync.publish_one(
+            {"path": "skills/example", "slug": "example"},
+            dry_run=False,
+            cli="clawhub@test",
+        )
+
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert "Version already exists" in captured.err
+        assert "example@1.2.3 already exists on ClawHub; skipping." in captured.out
 
     def test_clawhub_skill_versions_follow_release_please(self) -> None:
         entries = json.loads(MANIFEST.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- treat ClawHub's immutable 'Version already exists' response as an idempotent publish success
- preserve captured ClawHub CLI output in CI logs
- add a focused regression test for already-published skill versions

## Validation
- python -m pytest tests/test_clawhub_sync.py -q
- python scripts/clawhub_sync.py --dry-run
- vx ruff check scripts/clawhub_sync.py tests/test_clawhub_sync.py
- vx ruff format --check scripts/clawhub_sync.py tests/test_clawhub_sync.py
- actionlint .github/workflows/clawhub.yml