### PR TITLE
feat: capture bounded agent turn context

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -118,8 +118,19 @@ type AgentContext = {
   agent_id?: string | null;
   agent_name?: string | null;
   agent_kind?: string | null;
+  model_provider?: string | null;
+  model_version?: string | null;
   model?: string | null;
+  reasoning_effort?: string | null;
+  session_id?: string | null;
+  turn_id?: string | null;
   task?: string | null;
+  user_intent_summary?: string | null;
+  agent_reply_summary?: string | null;
+  user_input_hash?: string | null;
+  agent_reply_hash?: string | null;
+  user_input_chars?: number | null;
+  agent_reply_chars?: number | null;
   reasoning_summary?: string | null;
   plan?: string[];
   observations?: string[];
@@ -241,8 +252,19 @@ type WorkflowAgent = {
   agent_id?: string | null;
   agent_name?: string | null;
   agent_kind?: string | null;
+  model_provider?: string | null;
+  model_version?: string | null;
   model?: string | null;
+  reasoning_effort?: string | null;
+  session_id?: string | null;
+  turn_id?: string | null;
   task?: string | null;
+  user_intent_summary?: string | null;
+  agent_reply_summary?: string | null;
+  user_input_hash?: string | null;
+  agent_reply_hash?: string | null;
+  user_input_chars?: number | null;
+  agent_reply_chars?: number | null;
   turn_index?: number | null;
   tags?: string[];
 };
@@ -292,6 +314,7 @@ type WorkflowRow = {
     session_id?: string | null;
     trace_id?: string | null;
     agent_id?: string | null;
+    turn_id?: string | null;
     request_ids?: string[];
     trace_ids?: string[];
     session_ids?: string[];
@@ -1844,8 +1867,19 @@ function buildAgentPacket(trace: TraceDetailPayload): string {
     agent_context: agent ? {
       agent_id: agent.agent_id,
       agent_name: agent.agent_name,
+      model_provider: agent.model_provider,
+      model_version: agent.model_version,
       model: agent.model,
+      reasoning_effort: agent.reasoning_effort,
+      session_id: agent.session_id,
+      turn_id: agent.turn_id,
       task: agent.task,
+      user_intent_summary: agent.user_intent_summary,
+      agent_reply_summary: agent.agent_reply_summary,
+      user_input_hash: agent.user_input_hash,
+      agent_reply_hash: agent.agent_reply_hash,
+      user_input_chars: agent.user_input_chars,
+      agent_reply_chars: agent.agent_reply_chars,
       reasoning_summary: agent.reasoning_summary,
       plan: agent.plan ?? [],
       observations: agent.observations ?? [],
@@ -1885,17 +1919,47 @@ function TraceLinks({ links }: { links: AdminLinks }) {
 }
 
 function workflowAgentLabel(agent: WorkflowAgent | null | undefined): string {
-  return agent?.agent_name || agent?.agent_id || agent?.agent_kind || agent?.model || 'unknown agent';
+  return agent?.agent_name || agent?.agent_id || agent?.agent_kind || agentModelLabel(agent) || 'unknown agent';
+}
+
+function agentModelLabel(agent: Pick<AgentContext, 'model' | 'model_provider' | 'model_version'> | null | undefined): string {
+  if (!agent) {
+    return '';
+  }
+  if (agent.model) {
+    return agent.model;
+  }
+  if (agent.model_provider && agent.model_version) {
+    return `${agent.model_provider}/${agent.model_version}`;
+  }
+  return agent.model_version || agent.model_provider || '';
 }
 
 function workflowMeta(workflow: WorkflowRow): string {
   const parts = [
     workflow.group_kind,
     workflow.correlation.session_id ? `session ${compactId(workflow.correlation.session_id)}` : '',
+    workflow.correlation.turn_id ? `turn ${compactId(workflow.correlation.turn_id)}` : '',
     workflow.correlation.trace_id ? `trace ${compactId(workflow.correlation.trace_id)}` : '',
     `${workflow.step_count} steps`,
   ];
   return parts.filter(Boolean).join(' · ');
+}
+
+function agentTurnChips(agent: WorkflowAgent | AgentContext | null | undefined): string[] {
+  if (!agent) {
+    return [];
+  }
+  return [
+    agentModelLabel(agent),
+    agent.reasoning_effort ? `effort ${agent.reasoning_effort}` : '',
+    agent.session_id ? `session ${compactId(agent.session_id)}` : '',
+    agent.turn_id ? `turn ${compactId(agent.turn_id)}` : '',
+    agent.user_input_chars != null ? `user ${agent.user_input_chars} chars` : '',
+    agent.agent_reply_chars != null ? `reply ${agent.agent_reply_chars} chars` : '',
+    agent.user_input_hash ? `user hash ${compactId(agent.user_input_hash)}` : '',
+    agent.agent_reply_hash ? `reply hash ${compactId(agent.agent_reply_hash)}` : '',
+  ].filter(Boolean);
 }
 
 function WorkflowSearchChips({ signal }: { signal: WorkflowSearchSignal | null | undefined }) {
@@ -1990,6 +2054,13 @@ function WorkflowCard({
         </div>
       </div>
       {workflow.agent?.task ? <p className="workflow-agent-task">{workflow.agent.task}</p> : null}
+      {workflow.agent?.user_intent_summary ? <p className="workflow-agent-task">{workflow.agent.user_intent_summary}</p> : null}
+      {workflow.agent?.agent_reply_summary ? <p className="workflow-agent-task muted">{workflow.agent.agent_reply_summary}</p> : null}
+      {agentTurnChips(workflow.agent).length ? (
+        <div className="workflow-chip-row">
+          {agentTurnChips(workflow.agent).map((chip) => <span key={chip}>{chip}</span>)}
+        </div>
+      ) : null}
       <div className="workflow-chip-row">
         <span>{workflow.discovery.search_count} search(es)</span>
         {workflow.discovery.zero_result_count ? <span>{workflow.discovery.zero_result_count} zero-result</span> : null}
@@ -2075,9 +2146,11 @@ function TraceDetailPanel({
         <div className="trace-detail-card agent-context-card">
           <div className="trace-card-head">
             <h3>{agentTitle}</h3>
-            {agent.model ? <span>{agent.model}</span> : null}
+            {agentModelLabel(agent) ? <span>{agentModelLabel(agent)}</span> : null}
           </div>
           {agent.task ? <p className="agent-task">{agent.task}</p> : null}
+          {agent.user_intent_summary ? <p className="agent-summary">{agent.user_intent_summary}</p> : null}
+          {agent.agent_reply_summary ? <p className="agent-summary muted">{agent.agent_reply_summary}</p> : null}
           {agent.reasoning_summary ? <p className="agent-summary">{agent.reasoning_summary}</p> : null}
           {agent.plan?.length ? (
             <div className="agent-list">
@@ -2092,6 +2165,7 @@ function TraceDetailPanel({
             </div>
           ) : null}
           <div className="agent-meta">
+            {agentTurnChips(agent).map((chip) => <span key={chip}>{chip}</span>)}
             {agent.parent_request_id ? <span>parent {compactId(agent.parent_request_id)}</span> : null}
             {agent.trace_id ? <span>trace {compactId(agent.trace_id)}</span> : null}
             {agent.tags?.map((tag) => <span key={tag}>{tag}</span>)}

--- a/admin-ui/tests/admin.spec.ts
+++ b/admin-ui/tests/admin.spec.ts
@@ -191,14 +191,26 @@ async function mockAdminApi(page: Page) {
             agent: {
               agent_id: 'agent-1',
               agent_name: 'Scene Builder',
+              model_provider: 'openai',
+              model_version: 'gpt-5.1',
               model: 'gpt-test',
+              reasoning_effort: 'medium',
+              session_id: 'session-1',
+              turn_id: 'turn-1',
               task: 'Create a sphere after discovery.',
+              user_intent_summary: 'Create a sphere with the least risky MCP path.',
+              agent_reply_summary: 'I found the tool and executed it successfully.',
+              user_input_hash: 'sha256:user',
+              agent_reply_hash: 'sha256:reply',
+              user_input_chars: 180,
+              agent_reply_chars: 220,
               tags: ['smoke'],
             },
             correlation: {
               session_id: 'session-1',
               trace_id: 'trace-workflow',
               agent_id: 'agent-1',
+              turn_id: 'turn-1',
               request_ids: ['req-search', 'req-describe', 'req-load', 'req-123'],
               trace_ids: ['trace-workflow'],
               session_ids: ['session-1'],
@@ -739,6 +751,9 @@ test.describe('Admin Page', () => {
     await page.goto('/admin/?panel=workflows');
     const panel = page.locator('.workflows-panel');
     await expect(panel).toContainText('Scene Builder');
+    await expect(panel).toContainText('turn turn-1');
+    await expect(panel).toContainText('Create a sphere with the least risky MCP path.');
+    await expect(panel).toContainText('reply 220 chars');
     await expect(panel).toContainText('search create sphere');
     await expect(panel).toContainText('describe');
     await expect(panel).toContainText('load_skill');

--- a/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
@@ -1264,7 +1264,10 @@ fn dispatch_trace_to_admin_row(t: &DispatchTrace, links: Option<AdminLinkBuilder
         .agent_context
         .as_ref()
         .and_then(|ctx| ctx.agent_name.clone());
-    let agent_model = t.agent_context.as_ref().and_then(|ctx| ctx.model.clone());
+    let agent_model = t
+        .agent_context
+        .as_ref()
+        .and_then(|ctx| ctx.model.clone().or_else(|| ctx.model_version.clone()));
     let mut row = json!({
         "timestamp": ts,
         "request_id": t.request_id,

--- a/crates/dcc-mcp-gateway/src/gateway/admin/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/state.rs
@@ -368,7 +368,7 @@ impl AuditSink for AdminAuditSink {
             agent_model: entry
                 .agent_context
                 .as_ref()
-                .and_then(|ctx| ctx.model.clone()),
+                .and_then(|ctx| ctx.model.clone().or_else(|| ctx.model_version.clone())),
             parent_request_id: entry.trace_context.parent_request_id.clone().or_else(|| {
                 entry
                     .agent_context

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -980,6 +980,7 @@ redact:
             }],
             trace_context: None,
             session_id: None,
+            agent_context: None,
         });
         assert!(gs.search_telemetry.record_followup(SearchFollowupInput {
             search_id,
@@ -1058,6 +1059,24 @@ redact:
             }],
             trace_context: Some(search_ctx),
             session_id: Some(session_id.clone()),
+            agent_context: Some(AgentContext {
+                agent_id: Some("agent-workflow".into()),
+                agent_name: Some("Scene Builder".into()),
+                model_provider: Some("openai".into()),
+                model_version: Some("gpt-test".into()),
+                reasoning_effort: Some("medium".into()),
+                session_id: Some(session_id.clone()),
+                turn_id: Some("turn-workflow".into()),
+                user_intent_summary: Some("Create a simple sphere through MCP search.".into()),
+                agent_reply_summary: Some("Selected the ranked sphere tool and called it.".into()),
+                user_input_hash: Some("sha256:user".into()),
+                agent_reply_hash: Some("sha256:reply".into()),
+                user_input_chars: Some(96),
+                agent_reply_chars: Some(128),
+                tags: vec!["smoke".into()],
+                metadata: json!({"workflow_id": "workflow-scene-build"}),
+                ..Default::default()
+            }),
         });
         tokio::time::sleep(Duration::from_millis(2)).await;
         assert!(gs.search_telemetry.record_followup(SearchFollowupInput {
@@ -1157,6 +1176,7 @@ redact:
             hits: vec![],
             trace_context: None,
             session_id: None,
+            agent_context: None,
         });
 
         let audit_log: Arc<AuditLog> = Arc::new(Mutex::new(vec![AdminAuditRecord {
@@ -1198,6 +1218,26 @@ redact:
         assert_eq!(session_workflow["group_kind"], "session");
         assert_eq!(session_workflow["status"], "completed");
         assert_eq!(session_workflow["agent"]["agent_name"], "Scene Builder");
+        assert_eq!(session_workflow["agent"]["model_provider"], "openai");
+        assert_eq!(session_workflow["agent"]["model_version"], "gpt-test");
+        assert_eq!(session_workflow["agent"]["reasoning_effort"], "medium");
+        assert_eq!(session_workflow["agent"]["turn_id"], "turn-workflow");
+        assert_eq!(
+            session_workflow["agent"]["user_intent_summary"],
+            "Create a simple sphere through MCP search."
+        );
+        assert_eq!(
+            session_workflow["agent"]["agent_reply_summary"],
+            "Selected the ranked sphere tool and called it."
+        );
+        assert_eq!(session_workflow["agent"]["user_input_hash"], "sha256:user");
+        assert_eq!(
+            session_workflow["agent"]["agent_reply_hash"],
+            "sha256:reply"
+        );
+        assert_eq!(session_workflow["agent"]["user_input_chars"], 96);
+        assert_eq!(session_workflow["agent"]["agent_reply_chars"], 128);
+        assert_eq!(session_workflow["correlation"]["turn_id"], "turn-workflow");
         assert_eq!(session_workflow["discovery"]["best_selected_rank"], 2);
         assert_eq!(session_workflow["discovery"]["selected_count"], 3);
         assert!(

--- a/crates/dcc-mcp-gateway/src/gateway/admin/trace.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/trace.rs
@@ -324,10 +324,68 @@ pub struct AgentContext {
     pub agent_name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_kind: Option<String>,
+    #[serde(
+        default,
+        alias = "modelProvider",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub model_provider: Option<String>,
+    #[serde(
+        default,
+        alias = "modelVersion",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub model_version: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
+    #[serde(
+        default,
+        alias = "reasoningEffort",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub reasoning_effort: Option<String>,
+    #[serde(default, alias = "sessionId", skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, alias = "turnId", skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub task: Option<String>,
+    #[serde(
+        default,
+        alias = "userIntentSummary",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub user_intent_summary: Option<String>,
+    #[serde(
+        default,
+        alias = "agentReplySummary",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub agent_reply_summary: Option<String>,
+    #[serde(
+        default,
+        alias = "userInputHash",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub user_input_hash: Option<String>,
+    #[serde(
+        default,
+        alias = "agentReplyHash",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub agent_reply_hash: Option<String>,
+    #[serde(
+        default,
+        alias = "userInputChars",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub user_input_chars: Option<u64>,
+    #[serde(
+        default,
+        alias = "agentReplyChars",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub agent_reply_chars: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_summary: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -373,8 +431,19 @@ impl AgentContext {
         self.agent_id.is_none()
             && self.agent_name.is_none()
             && self.agent_kind.is_none()
+            && self.model_provider.is_none()
+            && self.model_version.is_none()
             && self.model.is_none()
+            && self.reasoning_effort.is_none()
+            && self.session_id.is_none()
+            && self.turn_id.is_none()
             && self.task.is_none()
+            && self.user_intent_summary.is_none()
+            && self.agent_reply_summary.is_none()
+            && self.user_input_hash.is_none()
+            && self.agent_reply_hash.is_none()
+            && self.user_input_chars.is_none()
+            && self.agent_reply_chars.is_none()
             && self.reasoning_summary.is_none()
             && self.plan.is_empty()
             && self.observations.is_empty()
@@ -389,8 +458,17 @@ impl AgentContext {
         self.agent_id = self.agent_id.map(bound_context_string);
         self.agent_name = self.agent_name.map(bound_context_string);
         self.agent_kind = self.agent_kind.map(bound_context_string);
+        self.model_provider = self.model_provider.map(bound_context_string);
+        self.model_version = self.model_version.map(bound_context_string);
         self.model = self.model.map(bound_context_string);
+        self.reasoning_effort = self.reasoning_effort.map(bound_context_string);
+        self.session_id = self.session_id.map(bound_context_string);
+        self.turn_id = self.turn_id.map(bound_context_string);
         self.task = self.task.map(bound_context_string);
+        self.user_intent_summary = self.user_intent_summary.map(bound_context_string);
+        self.agent_reply_summary = self.agent_reply_summary.map(bound_context_string);
+        self.user_input_hash = self.user_input_hash.map(bound_context_string);
+        self.agent_reply_hash = self.agent_reply_hash.map(bound_context_string);
         self.reasoning_summary = self.reasoning_summary.map(bound_context_string);
         self.parent_request_id = self.parent_request_id.map(bound_context_string);
         self.trace_id = self.trace_id.map(bound_context_string);
@@ -452,11 +530,104 @@ fn merge_header_agent_context(ctx: &mut AgentContext, headers: &HeaderMap) {
     if ctx.agent_kind.is_none() {
         ctx.agent_kind = header_str(headers, "x-dcc-mcp-agent-kind").map(bound_context_string);
     }
+    if ctx.model_provider.is_none() {
+        ctx.model_provider = header_str_any(
+            headers,
+            &["x-dcc-mcp-agent-model-provider", "x-dcc-mcp-model-provider"],
+        )
+        .map(bound_context_string);
+    }
+    if ctx.model_version.is_none() {
+        ctx.model_version = header_str_any(
+            headers,
+            &["x-dcc-mcp-agent-model-version", "x-dcc-mcp-model-version"],
+        )
+        .map(bound_context_string);
+    }
     if ctx.model.is_none() {
         ctx.model = header_str(headers, "x-dcc-mcp-agent-model").map(bound_context_string);
     }
+    if ctx.reasoning_effort.is_none() {
+        ctx.reasoning_effort = header_str_any(
+            headers,
+            &[
+                "x-dcc-mcp-agent-reasoning-effort",
+                "x-dcc-mcp-reasoning-effort",
+            ],
+        )
+        .map(bound_context_string);
+    }
+    if ctx.session_id.is_none() {
+        ctx.session_id = header_str_any(
+            headers,
+            &["x-dcc-mcp-agent-session-id", "x-dcc-mcp-session-id"],
+        )
+        .map(bound_context_string);
+    }
+    if ctx.turn_id.is_none() {
+        ctx.turn_id = header_str_any(headers, &["x-dcc-mcp-agent-turn-id", "x-dcc-mcp-turn-id"])
+            .map(bound_context_string);
+    }
     if ctx.task.is_none() {
         ctx.task = header_str(headers, "x-dcc-mcp-agent-task").map(bound_context_string);
+    }
+    if ctx.user_intent_summary.is_none() {
+        ctx.user_intent_summary = header_str_any(
+            headers,
+            &[
+                "x-dcc-mcp-agent-user-intent-summary",
+                "x-dcc-mcp-user-intent-summary",
+            ],
+        )
+        .map(bound_context_string);
+    }
+    if ctx.agent_reply_summary.is_none() {
+        ctx.agent_reply_summary = header_str_any(
+            headers,
+            &[
+                "x-dcc-mcp-agent-reply-summary",
+                "x-dcc-mcp-agent-agent-reply-summary",
+            ],
+        )
+        .map(bound_context_string);
+    }
+    if ctx.user_input_hash.is_none() {
+        ctx.user_input_hash = header_str_any(
+            headers,
+            &[
+                "x-dcc-mcp-agent-user-input-hash",
+                "x-dcc-mcp-user-input-hash",
+            ],
+        )
+        .map(bound_context_string);
+    }
+    if ctx.agent_reply_hash.is_none() {
+        ctx.agent_reply_hash = header_str_any(
+            headers,
+            &[
+                "x-dcc-mcp-agent-reply-hash",
+                "x-dcc-mcp-agent-agent-reply-hash",
+            ],
+        )
+        .map(bound_context_string);
+    }
+    if ctx.user_input_chars.is_none() {
+        ctx.user_input_chars = header_u64_any(
+            headers,
+            &[
+                "x-dcc-mcp-agent-user-input-chars",
+                "x-dcc-mcp-user-input-chars",
+            ],
+        );
+    }
+    if ctx.agent_reply_chars.is_none() {
+        ctx.agent_reply_chars = header_u64_any(
+            headers,
+            &[
+                "x-dcc-mcp-agent-reply-chars",
+                "x-dcc-mcp-agent-agent-reply-chars",
+            ],
+        );
     }
     if ctx.reasoning_summary.is_none() {
         ctx.reasoning_summary =
@@ -483,6 +654,14 @@ fn header_str(headers: &HeaderMap, name: &str) -> Option<String> {
         .map(str::to_string)
 }
 
+fn header_str_any(headers: &HeaderMap, names: &[&str]) -> Option<String> {
+    names.iter().find_map(|name| header_str(headers, name))
+}
+
+fn header_u64_any(headers: &HeaderMap, names: &[&str]) -> Option<u64> {
+    header_str_any(headers, names).and_then(|value| value.parse::<u64>().ok())
+}
+
 fn bound_context_string(value: String) -> String {
     truncate_utf8(value, MAX_AGENT_CONTEXT_STRING_BYTES).0
 }
@@ -499,9 +678,10 @@ fn bound_context_metadata(value: Value) -> Value {
     if value.is_null() {
         return Value::Null;
     }
-    let raw = serde_json::to_string(&value).unwrap_or_default();
+    let sanitized = sanitize_context_metadata(value);
+    let raw = serde_json::to_string(&sanitized).unwrap_or_default();
     if raw.len() <= MAX_AGENT_CONTEXT_METADATA_BYTES {
-        return value;
+        return sanitized;
     }
     let (preview, _) = truncate_utf8(raw.clone(), MAX_AGENT_CONTEXT_METADATA_BYTES);
     json!({
@@ -509,6 +689,59 @@ fn bound_context_metadata(value: Value) -> Value {
         "original_size": raw.len(),
         "preview": preview,
     })
+}
+
+fn sanitize_context_metadata(value: Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut sanitized = serde_json::Map::new();
+            let mut redacted = 0usize;
+            for (key, value) in map {
+                if is_high_sensitivity_agent_key(&key) {
+                    redacted += 1;
+                } else {
+                    sanitized.insert(key, sanitize_context_metadata(value));
+                }
+            }
+            if redacted > 0 {
+                sanitized.insert(
+                    "redacted_high_sensitivity_fields".to_string(),
+                    json!(redacted),
+                );
+            }
+            Value::Object(sanitized)
+        }
+        Value::Array(values) => {
+            Value::Array(values.into_iter().map(sanitize_context_metadata).collect())
+        }
+        other => other,
+    }
+}
+
+fn is_high_sensitivity_agent_key(key: &str) -> bool {
+    let normalised = key
+        .chars()
+        .filter(|ch| *ch != '_' && *ch != '-' && *ch != ' ')
+        .flat_map(char::to_lowercase)
+        .collect::<String>();
+    matches!(
+        normalised.as_str(),
+        "agentreply"
+            | "agentresponse"
+            | "chainofthought"
+            | "hiddencot"
+            | "messages"
+            | "prompt"
+            | "prompts"
+            | "rawagentreply"
+            | "rawagentresponse"
+            | "rawprompt"
+            | "rawresponse"
+            | "rawuserinput"
+            | "reply"
+            | "response"
+            | "userinput"
+    ) || normalised.contains("secret")
 }
 
 // ── Span ──────────────────────────────────────────────────────────────────────
@@ -771,10 +1004,21 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("x-dcc-mcp-agent-id", "agent-7".parse().unwrap());
         headers.insert("x-dcc-mcp-agent-model", "gpt-test".parse().unwrap());
+        headers.insert("x-dcc-mcp-agent-model-provider", "openai".parse().unwrap());
+        headers.insert("x-dcc-mcp-agent-turn-id", "turn-9".parse().unwrap());
+        headers.insert("x-dcc-mcp-user-input-chars", "2500".parse().unwrap());
         let meta = json!({
             "agent_context": {
                 "agent_name": "Scene Planner",
+                "modelVersion": "gpt-5.1",
+                "reasoningEffort": "medium",
+                "sessionId": "session-meta",
                 "task": "inspect material bindings",
+                "userIntentSummary": "Inspect scene before editing.",
+                "agentReplySummary": "I will inspect the scene graph first.",
+                "userInputHash": "sha256:user",
+                "agentReplyHash": "sha256:reply",
+                "agentReplyChars": 140,
                 "reasoning_summary": "Need a lightweight scene read before edit.",
                 "plan": ["describe scene", "choose material patch"]
             }
@@ -785,6 +1029,23 @@ mod tests {
         assert_eq!(ctx.agent_id.as_deref(), Some("agent-7"));
         assert_eq!(ctx.agent_name.as_deref(), Some("Scene Planner"));
         assert_eq!(ctx.model.as_deref(), Some("gpt-test"));
+        assert_eq!(ctx.model_provider.as_deref(), Some("openai"));
+        assert_eq!(ctx.model_version.as_deref(), Some("gpt-5.1"));
+        assert_eq!(ctx.reasoning_effort.as_deref(), Some("medium"));
+        assert_eq!(ctx.session_id.as_deref(), Some("session-meta"));
+        assert_eq!(ctx.turn_id.as_deref(), Some("turn-9"));
+        assert_eq!(
+            ctx.user_intent_summary.as_deref(),
+            Some("Inspect scene before editing.")
+        );
+        assert_eq!(
+            ctx.agent_reply_summary.as_deref(),
+            Some("I will inspect the scene graph first.")
+        );
+        assert_eq!(ctx.user_input_hash.as_deref(), Some("sha256:user"));
+        assert_eq!(ctx.agent_reply_hash.as_deref(), Some("sha256:reply"));
+        assert_eq!(ctx.user_input_chars, Some(2500));
+        assert_eq!(ctx.agent_reply_chars, Some(140));
         assert_eq!(ctx.plan.len(), 2);
     }
 
@@ -797,6 +1058,46 @@ mod tests {
 
         assert_eq!(ctx.reasoning_summary.as_deref(), Some("manual smoke test"));
         assert_eq!(ctx.display_name(), None);
+    }
+
+    #[test]
+    fn agent_context_bounds_turn_summaries_and_excludes_raw_text() {
+        let headers = HeaderMap::new();
+        let raw_prompt = "secret production prompt".to_string();
+        let long_summary = "summary ".repeat(MAX_AGENT_CONTEXT_STRING_BYTES);
+        let body = json!({
+            "caller_context": {
+                "agent_id": "agent-raw",
+                "turnId": "turn-raw",
+                "userIntentSummary": long_summary,
+                "user_input": raw_prompt,
+                "agentReply": "raw reply should not be stored",
+                "metadata": {
+                    "workflow_id": "wf-1",
+                    "prompt": "raw prompt in metadata",
+                    "nested": {
+                        "rawAgentReply": "raw reply in nested metadata",
+                        "safe": "kept"
+                    }
+                }
+            }
+        });
+
+        let ctx = AgentContext::from_request_parts(&headers, Some(&body), None).unwrap();
+        let encoded = serde_json::to_string(&ctx).unwrap();
+
+        assert!(ctx.user_intent_summary.unwrap().len() <= MAX_AGENT_CONTEXT_STRING_BYTES);
+        assert!(!encoded.contains("secret production prompt"));
+        assert!(!encoded.contains("raw reply should not be stored"));
+        assert!(!encoded.contains("raw prompt in metadata"));
+        assert!(!encoded.contains("raw reply in nested metadata"));
+        assert_eq!(ctx.metadata["workflow_id"], "wf-1");
+        assert_eq!(ctx.metadata["nested"]["safe"], "kept");
+        assert_eq!(ctx.metadata["redacted_high_sensitivity_fields"], 1);
+        assert_eq!(
+            ctx.metadata["nested"]["redacted_high_sensitivity_fields"],
+            1
+        );
     }
 
     #[test]

--- a/crates/dcc-mcp-gateway/src/gateway/admin/workflows.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/workflows.rs
@@ -33,9 +33,31 @@ pub struct WorkflowAgent {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub agent_kind: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_provider: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub task: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_intent_summary: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_reply_summary: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_input_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_reply_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_input_chars: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_reply_chars: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub turn_index: Option<u64>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -50,6 +72,8 @@ pub struct WorkflowCorrelation {
     pub trace_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub agent_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub request_ids: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -331,6 +355,15 @@ impl WorkflowBuilder {
     }
 
     fn note_search(&mut self, search: &SearchTelemetryRecord) {
+        if self.agent.is_none() {
+            self.agent = search.agent_context.as_ref().map(agent_from_context);
+        }
+        if self.agent_id.is_none() {
+            self.agent_id = search
+                .agent_context
+                .as_ref()
+                .and_then(|ctx| ctx.agent_id.clone());
+        }
         if let Some(request_id) = search.request_id.as_deref() {
             self.request_ids.insert(request_id.to_string());
         }
@@ -403,6 +436,7 @@ impl WorkflowBuilder {
             session_id: session_ids.first().cloned(),
             trace_id: trace_ids.first().cloned(),
             agent_id: self.agent_id.clone(),
+            turn_id: self.agent.as_ref().and_then(|agent| agent.turn_id.clone()),
             request_ids,
             trace_ids,
             session_ids,
@@ -507,6 +541,14 @@ fn search_group_key(search: &SearchTelemetryRecord) -> (String, String, String) 
     }
     if let Some(trace_id) = search.trace_id.as_deref().filter(|value| !value.is_empty()) {
         return keyed("trace", trace_id.to_string());
+    }
+    if let Some(turn_id) = search
+        .agent_context
+        .as_ref()
+        .and_then(|ctx| ctx.turn_id.as_deref())
+        .filter(|value| !value.is_empty())
+    {
+        return keyed("turn", turn_id.to_string());
     }
     if let Some(request_id) = search
         .request_id
@@ -807,8 +849,19 @@ fn agent_from_context(ctx: &AgentContext) -> WorkflowAgent {
         agent_id: ctx.agent_id.clone(),
         agent_name: ctx.agent_name.clone(),
         agent_kind: ctx.agent_kind.clone(),
+        model_provider: ctx.model_provider.clone(),
+        model_version: ctx.model_version.clone(),
         model: ctx.model.clone(),
+        reasoning_effort: ctx.reasoning_effort.clone(),
+        session_id: ctx.session_id.clone(),
+        turn_id: ctx.turn_id.clone(),
         task: ctx.task.clone(),
+        user_intent_summary: ctx.user_intent_summary.clone(),
+        agent_reply_summary: ctx.agent_reply_summary.clone(),
+        user_input_hash: ctx.user_input_hash.clone(),
+        agent_reply_hash: ctx.agent_reply_hash.clone(),
+        user_input_chars: ctx.user_input_chars,
+        agent_reply_chars: ctx.agent_reply_chars,
         turn_index: ctx.turn_index,
         tags: ctx.tags.iter().take(MAX_AGENT_TAGS).cloned().collect(),
     }

--- a/crates/dcc-mcp-gateway/src/gateway/agent_telemetry.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/agent_telemetry.rs
@@ -32,7 +32,17 @@ pub(crate) struct AgentWorkflowEvent {
     agent_id: Option<String>,
     agent_name: Option<String>,
     agent_kind: Option<String>,
+    agent_model_provider: Option<String>,
+    agent_model_version: Option<String>,
     agent_model: Option<String>,
+    agent_reasoning_effort: Option<String>,
+    agent_turn_id: Option<String>,
+    agent_user_intent_summary: Option<String>,
+    agent_reply_summary: Option<String>,
+    agent_user_input_hash: Option<String>,
+    agent_reply_hash: Option<String>,
+    agent_user_input_chars: Option<u64>,
+    agent_reply_chars: Option<u64>,
     agent_task: Option<String>,
     agent_tags: Vec<String>,
     dcc_type: Option<String>,
@@ -65,7 +75,17 @@ impl AgentWorkflowEvent {
             agent_id: None,
             agent_name: None,
             agent_kind: None,
+            agent_model_provider: None,
+            agent_model_version: None,
             agent_model: None,
+            agent_reasoning_effort: None,
+            agent_turn_id: None,
+            agent_user_intent_summary: None,
+            agent_reply_summary: None,
+            agent_user_input_hash: None,
+            agent_reply_hash: None,
+            agent_user_input_chars: None,
+            agent_reply_chars: None,
             agent_task: None,
             agent_tags: Vec::new(),
             dcc_type: None,
@@ -101,9 +121,22 @@ impl AgentWorkflowEvent {
             self.agent_id = ctx.agent_id.clone();
             self.agent_name = ctx.agent_name.clone();
             self.agent_kind = ctx.agent_kind.clone();
+            self.agent_model_provider = ctx.model_provider.clone();
+            self.agent_model_version = ctx.model_version.clone();
             self.agent_model = ctx.model.clone();
+            self.agent_reasoning_effort = ctx.reasoning_effort.clone();
+            self.agent_turn_id = ctx.turn_id.clone();
+            self.agent_user_intent_summary = ctx.user_intent_summary.clone();
+            self.agent_reply_summary = ctx.agent_reply_summary.clone();
+            self.agent_user_input_hash = ctx.user_input_hash.clone();
+            self.agent_reply_hash = ctx.agent_reply_hash.clone();
+            self.agent_user_input_chars = ctx.user_input_chars;
+            self.agent_reply_chars = ctx.agent_reply_chars;
             self.agent_task = ctx.task.clone();
             self.agent_tags = ctx.tags.iter().take(16).cloned().collect();
+            if self.session_id.is_none() {
+                self.session_id = ctx.session_id.clone();
+            }
             if self.parent_request_id.is_none() {
                 self.parent_request_id = ctx.parent_request_id.clone();
             }
@@ -115,7 +148,9 @@ impl AgentWorkflowEvent {
     }
 
     pub(crate) fn with_session_id(mut self, session_id: Option<&str>) -> Self {
-        self.session_id = session_id.map(str::to_string);
+        if let Some(session_id) = session_id.filter(|value| !value.is_empty()) {
+            self.session_id = Some(session_id.to_string());
+        }
         self
     }
 
@@ -265,8 +300,58 @@ impl AgentWorkflowEvent {
         insert_opt(&mut attrs, "dcc_mcp.agent.kind", self.agent_kind.as_deref());
         insert_opt(
             &mut attrs,
+            "dcc_mcp.agent.model_provider",
+            self.agent_model_provider.as_deref(),
+        );
+        insert_opt(
+            &mut attrs,
+            "dcc_mcp.agent.model_version",
+            self.agent_model_version.as_deref(),
+        );
+        insert_opt(
+            &mut attrs,
             "dcc_mcp.agent.model",
             self.agent_model.as_deref(),
+        );
+        insert_opt(
+            &mut attrs,
+            "dcc_mcp.agent.reasoning_effort",
+            self.agent_reasoning_effort.as_deref(),
+        );
+        insert_opt(
+            &mut attrs,
+            "dcc_mcp.agent.turn_id",
+            self.agent_turn_id.as_deref(),
+        );
+        insert_opt(
+            &mut attrs,
+            "dcc_mcp.agent.user_intent_summary",
+            self.agent_user_intent_summary.as_deref(),
+        );
+        insert_opt(
+            &mut attrs,
+            "dcc_mcp.agent.reply_summary",
+            self.agent_reply_summary.as_deref(),
+        );
+        insert_opt(
+            &mut attrs,
+            "dcc_mcp.agent.user_input_hash",
+            self.agent_user_input_hash.as_deref(),
+        );
+        insert_opt(
+            &mut attrs,
+            "dcc_mcp.agent.reply_hash",
+            self.agent_reply_hash.as_deref(),
+        );
+        insert_u64(
+            &mut attrs,
+            "dcc_mcp.agent.user_input_chars",
+            self.agent_user_input_chars,
+        );
+        insert_u64(
+            &mut attrs,
+            "dcc_mcp.agent.reply_chars",
+            self.agent_reply_chars,
         );
         insert_opt(&mut attrs, "dcc_mcp.agent.task", self.agent_task.as_deref());
         if !self.agent_tags.is_empty() {
@@ -334,6 +419,8 @@ impl AgentWorkflowEvent {
         let score = self.score.unwrap_or_default() as u64;
         let total = self.total.unwrap_or_default() as u64;
         let batch_size = self.batch_size.unwrap_or_default() as u64;
+        let user_input_chars = self.agent_user_input_chars.unwrap_or_default();
+        let reply_chars = self.agent_reply_chars.unwrap_or_default();
         let success = self.success.unwrap_or(false);
         let zero_results = self.zero_results.unwrap_or(false);
 
@@ -351,7 +438,23 @@ impl AgentWorkflowEvent {
                     "dcc_mcp.agent.id" = self.agent_id.as_deref().unwrap_or(""),
                     "dcc_mcp.agent.name" = self.agent_name.as_deref().unwrap_or(""),
                     "dcc_mcp.agent.kind" = self.agent_kind.as_deref().unwrap_or(""),
+                    "dcc_mcp.agent.model_provider" =
+                        self.agent_model_provider.as_deref().unwrap_or(""),
+                    "dcc_mcp.agent.model_version" =
+                        self.agent_model_version.as_deref().unwrap_or(""),
                     "dcc_mcp.agent.model" = self.agent_model.as_deref().unwrap_or(""),
+                    "dcc_mcp.agent.reasoning_effort" =
+                        self.agent_reasoning_effort.as_deref().unwrap_or(""),
+                    "dcc_mcp.agent.turn_id" = self.agent_turn_id.as_deref().unwrap_or(""),
+                    "dcc_mcp.agent.user_intent_summary" =
+                        self.agent_user_intent_summary.as_deref().unwrap_or(""),
+                    "dcc_mcp.agent.reply_summary" =
+                        self.agent_reply_summary.as_deref().unwrap_or(""),
+                    "dcc_mcp.agent.user_input_hash" =
+                        self.agent_user_input_hash.as_deref().unwrap_or(""),
+                    "dcc_mcp.agent.reply_hash" = self.agent_reply_hash.as_deref().unwrap_or(""),
+                    "dcc_mcp.agent.user_input_chars" = user_input_chars,
+                    "dcc_mcp.agent.reply_chars" = reply_chars,
                     "dcc_mcp.agent.task" = self.agent_task.as_deref().unwrap_or(""),
                     "dcc_mcp.agent.tags" = %agent_tags,
                     "dcc_mcp.dcc.type" = self.dcc_type.as_deref().unwrap_or(""),
@@ -444,8 +547,58 @@ impl AgentWorkflowEvent {
         push_opt_attr(&mut attrs, "dcc_mcp.agent.kind", self.agent_kind.as_deref());
         push_opt_attr(
             &mut attrs,
+            "dcc_mcp.agent.model_provider",
+            self.agent_model_provider.as_deref(),
+        );
+        push_opt_attr(
+            &mut attrs,
+            "dcc_mcp.agent.model_version",
+            self.agent_model_version.as_deref(),
+        );
+        push_opt_attr(
+            &mut attrs,
             "dcc_mcp.agent.model",
             self.agent_model.as_deref(),
+        );
+        push_opt_attr(
+            &mut attrs,
+            "dcc_mcp.agent.reasoning_effort",
+            self.agent_reasoning_effort.as_deref(),
+        );
+        push_opt_attr(
+            &mut attrs,
+            "dcc_mcp.agent.turn_id",
+            self.agent_turn_id.as_deref(),
+        );
+        push_opt_attr(
+            &mut attrs,
+            "dcc_mcp.agent.user_intent_summary",
+            self.agent_user_intent_summary.as_deref(),
+        );
+        push_opt_attr(
+            &mut attrs,
+            "dcc_mcp.agent.reply_summary",
+            self.agent_reply_summary.as_deref(),
+        );
+        push_opt_attr(
+            &mut attrs,
+            "dcc_mcp.agent.user_input_hash",
+            self.agent_user_input_hash.as_deref(),
+        );
+        push_opt_attr(
+            &mut attrs,
+            "dcc_mcp.agent.reply_hash",
+            self.agent_reply_hash.as_deref(),
+        );
+        push_num_attr(
+            &mut attrs,
+            "dcc_mcp.agent.user_input_chars",
+            self.agent_user_input_chars.map(|value| value as i64),
+        );
+        push_num_attr(
+            &mut attrs,
+            "dcc_mcp.agent.reply_chars",
+            self.agent_reply_chars.map(|value| value as i64),
         );
         push_opt_attr(&mut attrs, "dcc_mcp.agent.task", self.agent_task.as_deref());
         if !self.agent_tags.is_empty() {
@@ -715,6 +868,13 @@ fn insert_num(attrs: &mut Map<String, Value>, key: &str, value: Option<u32>) {
 }
 
 #[cfg(test)]
+fn insert_u64(attrs: &mut Map<String, Value>, key: &str, value: Option<u64>) {
+    if let Some(value) = value {
+        attrs.insert(key.to_string(), json!(value));
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -738,7 +898,18 @@ mod tests {
                 agent_id: Some("agent-1".to_string()),
                 agent_name: Some("Codex".to_string()),
                 agent_kind: Some("coding-agent".to_string()),
+                model_provider: Some("openai".to_string()),
+                model_version: Some("gpt-5.1".to_string()),
                 model: Some("gpt-5".to_string()),
+                reasoning_effort: Some("high".to_string()),
+                session_id: Some("session-1".to_string()),
+                turn_id: Some("turn-1".to_string()),
+                user_intent_summary: Some("Fix gateway telemetry.".to_string()),
+                agent_reply_summary: Some("Implemented bounded context.".to_string()),
+                user_input_hash: Some("sha256:user".to_string()),
+                agent_reply_hash: Some("sha256:reply".to_string()),
+                user_input_chars: Some(2048),
+                agent_reply_chars: Some(512),
                 task: Some("fix issue 1180".to_string()),
                 reasoning_summary: Some("do not export me".to_string()),
                 tags: vec!["ci".to_string(), "gateway".to_string()],
@@ -752,7 +923,24 @@ mod tests {
 
         let attrs = event.attributes();
         assert_eq!(attrs["dcc_mcp.workflow.operation"], "gateway.search");
+        assert_eq!(attrs["dcc_mcp.session_id"], "session-1");
         assert_eq!(attrs["dcc_mcp.agent.id"], "agent-1");
+        assert_eq!(attrs["dcc_mcp.agent.model_provider"], "openai");
+        assert_eq!(attrs["dcc_mcp.agent.model_version"], "gpt-5.1");
+        assert_eq!(attrs["dcc_mcp.agent.reasoning_effort"], "high");
+        assert_eq!(attrs["dcc_mcp.agent.turn_id"], "turn-1");
+        assert_eq!(
+            attrs["dcc_mcp.agent.user_intent_summary"],
+            "Fix gateway telemetry."
+        );
+        assert_eq!(
+            attrs["dcc_mcp.agent.reply_summary"],
+            "Implemented bounded context."
+        );
+        assert_eq!(attrs["dcc_mcp.agent.user_input_hash"], "sha256:user");
+        assert_eq!(attrs["dcc_mcp.agent.reply_hash"], "sha256:reply");
+        assert_eq!(attrs["dcc_mcp.agent.user_input_chars"], 2048);
+        assert_eq!(attrs["dcc_mcp.agent.reply_chars"], 512);
         assert_eq!(attrs["dcc_mcp.agent.tags"], json!(["ci", "gateway"]));
         assert_eq!(attrs["dcc_mcp.search.id"], "search-1");
         assert_eq!(attrs["dcc_mcp.search.zero_results"], true);
@@ -854,6 +1042,7 @@ mod tests {
             }],
             trace_context: Some(trace_context()),
             session_id: Some("sess-1".to_string()),
+            agent_context: None,
         });
 
         let load_args =
@@ -928,6 +1117,7 @@ mod tests {
             }],
             trace_context: Some(trace_context()),
             session_id: Some("sess-1".to_string()),
+            agent_context: None,
         });
 
         let args = json!({

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/call.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/call.rs
@@ -14,15 +14,23 @@ pub async fn route_tools_call(
     tool: &str,
     args: &Value,
     meta: Option<&Value>,
-    _request_id: Option<String>,
     _client_session_id: Option<&str>,
     trace_context: Option<&crate::gateway::admin::trace::TraceContext>,
+    agent_context: Option<&crate::gateway::admin::trace::AgentContext>,
 ) -> (String, bool) {
     // ── Advertised gateway surface (read-only) ───────────────────────
     match tool {
         "search" => {
             return to_text_result(
-                tool_search(gs, args, meta, trace_context, _client_session_id).await,
+                tool_search(
+                    gs,
+                    args,
+                    meta,
+                    trace_context,
+                    _client_session_id,
+                    agent_context,
+                )
+                .await,
             );
         }
         "describe" => return to_text_result(tool_describe(gs, args, meta, trace_context).await),
@@ -54,7 +62,7 @@ pub async fn route_tools_call(
         "release_dcc_instance" => return to_text_result(tool_release_instance(gs, args).await),
         "search_tools" => {
             return to_text_result(
-                tool_search_tools(gs, args, trace_context, _client_session_id).await,
+                tool_search_tools(gs, args, trace_context, _client_session_id, agent_context).await,
             );
         }
         "describe_tool" => {

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
@@ -638,9 +638,9 @@ async fn handle_tools_call(
         tool,
         &effective_args,
         meta.as_ref(),
-        Some(id_str.to_string()),
         Some(session_id),
         Some(&ctx.trace_context),
+        ctx.agent_context.as_ref(),
     )
     .await;
 

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
@@ -366,7 +366,11 @@ pub async fn handle_v1_search(
         .into_iter()
         .map(|hit| search_hit_to_value_with_context(hit, Some(&search_context)))
         .collect();
-    let session_id = session_id_from_headers(&headers);
+    let session_id = session_id_from_headers(&headers).or_else(|| {
+        agent_context
+            .as_ref()
+            .and_then(|ctx| ctx.session_id.clone())
+    });
     let query_dcc_type = query.dcc_type.clone();
     let query_instance_id = query.instance_id.as_ref().map(ToString::to_string);
     gs.search_telemetry.record_search(SearchTelemetryInput {
@@ -383,6 +387,7 @@ pub async fn handle_v1_search(
         hits: telemetry_hits,
         trace_context: Some(trace_context.clone()),
         session_id: session_id.clone(),
+        agent_context: agent_context.clone(),
     });
     AgentWorkflowEvent::new("gateway.search", "rest")
         .with_trace_context(Some(&trace_context))

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
@@ -679,9 +679,9 @@ async fn mcp_search_followups_correlate_describe_load_call_and_batch() {
         "search",
         &search_args,
         None,
-        Some("req-mcp-search".to_string()),
         Some("session-mcp"),
         Some(&trace),
+        None,
     )
     .await;
     assert!(!search_is_error);
@@ -701,9 +701,9 @@ async fn mcp_search_followups_correlate_describe_load_call_and_batch() {
         "describe",
         &describe_args,
         Some(&meta),
-        Some("req-mcp-describe".to_string()),
         Some("session-mcp"),
         Some(&trace),
+        None,
     )
     .await;
     assert!(describe_is_error);
@@ -714,9 +714,9 @@ async fn mcp_search_followups_correlate_describe_load_call_and_batch() {
         "load_skill",
         &load_args,
         Some(&meta),
-        Some("req-mcp-load".to_string()),
         Some("session-mcp"),
         Some(&trace),
+        None,
     )
     .await;
     assert!(load_is_error);
@@ -727,9 +727,9 @@ async fn mcp_search_followups_correlate_describe_load_call_and_batch() {
         "call",
         &call_args,
         Some(&meta),
-        Some("req-mcp-call".to_string()),
         Some("session-mcp"),
         Some(&trace),
+        None,
     )
     .await;
     assert!(call_is_error);
@@ -741,9 +741,9 @@ async fn mcp_search_followups_correlate_describe_load_call_and_batch() {
         "call",
         &batch_args,
         None,
-        Some("req-mcp-batch".to_string()),
         Some("session-mcp"),
         Some(&trace),
+        None,
     )
     .await;
     assert!(batch_is_error);

--- a/crates/dcc-mcp-gateway/src/gateway/middleware/context.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/middleware/context.rs
@@ -140,6 +140,9 @@ impl CallContext {
 
     /// Builder: attach optional agent/caller telemetry context.
     pub fn with_agent_context(mut self, context: Option<AgentContext>) -> Self {
+        if self.session_id.is_none() {
+            self.session_id = context.as_ref().and_then(|ctx| ctx.session_id.clone());
+        }
         self.agent_context = context;
         self
     }

--- a/crates/dcc-mcp-gateway/src/gateway/search_telemetry.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/search_telemetry.rs
@@ -10,7 +10,7 @@ use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::gateway::admin::trace::TraceContext;
+use crate::gateway::admin::trace::{AgentContext, TraceContext};
 
 pub use dcc_mcp_gateway_core::capability::RANKER_VERSION;
 
@@ -67,6 +67,8 @@ pub struct SearchTelemetryRecord {
     pub trace_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_context: Option<AgentContext>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub query_preview: Option<String>,
     pub query_hash: String,
@@ -131,6 +133,7 @@ pub struct SearchTelemetryInput {
     pub hits: Vec<SearchTelemetryHit>,
     pub trace_context: Option<TraceContext>,
     pub session_id: Option<String>,
+    pub agent_context: Option<AgentContext>,
 }
 
 #[derive(Debug, Clone)]
@@ -185,10 +188,17 @@ impl SearchTelemetryStore {
         let mut inner = self.inner.lock();
         let now = SystemTime::now();
         let query_norm = normalise_query(&input.query);
+        let agent_context = input.agent_context.clone();
+        let session_id = input.session_id.or_else(|| {
+            agent_context
+                .as_ref()
+                .and_then(|ctx| ctx.session_id.clone())
+        });
         let correlation_key = correlation_key(
             input.trace_context.as_ref(),
-            input.session_id.as_deref(),
+            session_id.as_deref(),
             input.dcc_type.as_deref(),
+            agent_context.as_ref(),
         );
         let reformulation_of = correlation_key.as_ref().and_then(|key| {
             let previous = inner.last_by_correlation.get(key)?;
@@ -230,7 +240,8 @@ impl SearchTelemetryStore {
                 .as_ref()
                 .map(|ctx| ctx.request_id.clone()),
             trace_id: input.trace_context.as_ref().map(|ctx| ctx.trace_id.clone()),
-            session_id: input.session_id,
+            session_id,
+            agent_context,
             query_preview: query_preview(&input.query),
             query_hash: hash_query(&query_norm),
             dcc_type: input.dcc_type,
@@ -319,6 +330,7 @@ impl SearchTelemetryStore {
                     input.trace_context.as_ref(),
                     record.session_id.as_deref(),
                     record.dcc_type.as_deref(),
+                    record.agent_context.as_ref(),
                 )
             {
                 mark_success_for = Some((key, record.search_id.clone()));
@@ -528,10 +540,16 @@ fn correlation_key(
     trace_context: Option<&TraceContext>,
     session_id: Option<&str>,
     dcc_type: Option<&str>,
+    agent_context: Option<&AgentContext>,
 ) -> Option<String> {
     trace_context
         .map(|ctx| format!("trace:{}", ctx.trace_id))
         .or_else(|| session_id.map(|session| format!("session:{session}")))
+        .or_else(|| {
+            agent_context
+                .and_then(|ctx| ctx.turn_id.as_deref())
+                .map(|turn_id| format!("turn:{turn_id}"))
+        })
         .or_else(|| dcc_type.map(|dcc| format!("dcc:{dcc}")))
 }
 
@@ -682,6 +700,7 @@ mod tests {
             ],
             trace_context: Some(trace("search-1")),
             session_id: Some("sess-1".to_string()),
+            agent_context: None,
         });
         for (kind, slug, skill, success) in [
             ("describe", Some("maya.11111111.create_sphere"), None, true),
@@ -728,6 +747,7 @@ mod tests {
             hits: Vec::new(),
             trace_context: Some(trace("search-a")),
             session_id: None,
+            agent_context: None,
         });
         store.record_search(SearchTelemetryInput {
             search_id: "search-b".to_string(),
@@ -743,6 +763,7 @@ mod tests {
             hits: vec![hit("maya.11111111.create_sphere", "maya-geometry", 1)],
             trace_context: Some(trace("search-b")),
             session_id: None,
+            agent_context: None,
         });
 
         let snapshot = store.snapshot(10);
@@ -752,5 +773,73 @@ mod tests {
             snapshot.recent[1].query_preview.as_deref(),
             Some("[redacted] impossible query")
         );
+    }
+
+    #[test]
+    fn store_correlates_search_quality_with_agent_turn_context() {
+        let store = SearchTelemetryStore::with_capacity(10);
+        let turn_context = AgentContext {
+            model_provider: Some("openai".to_string()),
+            model_version: Some("gpt-5.1".to_string()),
+            turn_id: Some("turn-search".to_string()),
+            user_intent_summary: Some("Find a sphere creation tool.".to_string()),
+            user_input_hash: Some("sha256:user".to_string()),
+            user_input_chars: Some(48),
+            ..AgentContext::default()
+        };
+        store.record_search(SearchTelemetryInput {
+            search_id: "search-turn-a".to_string(),
+            transport: "mcp".to_string(),
+            kind: "tool".to_string(),
+            query: "missing sphere creator".to_string(),
+            dcc_type: Some("maya".to_string()),
+            instance_id: None,
+            limit: Some(5),
+            total: 0,
+            ranker_version: RANKER_VERSION.to_string(),
+            index_generation: "idx1".to_string(),
+            hits: Vec::new(),
+            trace_context: None,
+            session_id: None,
+            agent_context: Some(turn_context.clone()),
+        });
+        store.record_search(SearchTelemetryInput {
+            search_id: "search-turn-b".to_string(),
+            transport: "mcp".to_string(),
+            kind: "tool".to_string(),
+            query: "sphere".to_string(),
+            dcc_type: Some("maya".to_string()),
+            instance_id: None,
+            limit: Some(5),
+            total: 1,
+            ranker_version: RANKER_VERSION.to_string(),
+            index_generation: "idx1".to_string(),
+            hits: vec![hit("maya.11111111.create_sphere", "maya-geometry", 1)],
+            trace_context: None,
+            session_id: None,
+            agent_context: Some(turn_context),
+        });
+        assert!(store.record_followup(SearchFollowupInput {
+            search_id: "search-turn-b".to_string(),
+            kind: "call".to_string(),
+            tool_slug: Some("maya.11111111.create_sphere".to_string()),
+            skill_name: None,
+            success: true,
+            trace_context: None,
+        }));
+
+        let snapshot = store.snapshot(10);
+        let latest = &snapshot.recent[0];
+        let agent = latest.agent_context.as_ref().expect("agent turn context");
+
+        assert_eq!(snapshot.stats.query_reformulation_count, 1);
+        assert_eq!(latest.search_id, "search-turn-b");
+        assert_eq!(latest.reformulation_of.as_deref(), Some("search-turn-a"));
+        assert_eq!(latest.first_success_ms, latest.followups[0].elapsed_ms);
+        assert_eq!(latest.followups[0].selected_rank, Some(1));
+        assert_eq!(agent.model_provider.as_deref(), Some("openai"));
+        assert_eq!(agent.model_version.as_deref(), Some("gpt-5.1"));
+        assert_eq!(agent.turn_id.as_deref(), Some("turn-search"));
+        assert_eq!(agent.user_input_hash.as_deref(), Some("sha256:user"));
     }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/tools.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tools.rs
@@ -2,7 +2,7 @@
 
 use serde_json::{Value, json};
 
-use crate::gateway::admin::trace::TraceContext;
+use crate::gateway::admin::trace::{AgentContext, TraceContext};
 use crate::gateway::capability_service::{SearchResponseContext, search_hit_to_value_with_context};
 use crate::gateway::search_telemetry::{
     RANKER_VERSION, SearchFollowupInput, SearchTelemetryHit, SearchTelemetryInput,
@@ -156,6 +156,7 @@ pub async fn tool_search(
     meta: Option<&Value>,
     trace_context: Option<&TraceContext>,
     session_id: Option<&str>,
+    agent_context: Option<&AgentContext>,
 ) -> Result<String, String> {
     let kind = args
         .get("kind")
@@ -184,19 +185,27 @@ pub async fn tool_search(
                     &text,
                     trace_context,
                     session_id,
+                    agent_context,
                 ))
             }
         }
         "all" => {
-            let tools_json = tool_search_tools(gs, args, trace_context, session_id).await?;
+            let tools_json =
+                tool_search_tools(gs, args, trace_context, session_id, agent_context).await?;
             let (skills_text, skills_err) =
                 crate::gateway::aggregator::skill_mgmt_dispatch(gs, "list_skills", args).await;
             if skills_err {
                 return Err(skills_text);
             }
             let tools_value = serde_json::from_str::<Value>(&tools_json).unwrap_or(Value::Null);
-            let skills_json =
-                annotate_skill_search_payload(gs, args, &skills_text, trace_context, session_id);
+            let skills_json = annotate_skill_search_payload(
+                gs,
+                args,
+                &skills_text,
+                trace_context,
+                session_id,
+                agent_context,
+            );
             let skills_value = serde_json::from_str::<Value>(&skills_json).unwrap_or(Value::Null);
             let search_id = tools_value
                 .get("search_id")
@@ -224,7 +233,7 @@ pub async fn tool_search(
         }
         _ => {
             let _ = meta;
-            tool_search_tools(gs, args, trace_context, session_id).await
+            tool_search_tools(gs, args, trace_context, session_id, agent_context).await
         }
     }
 }
@@ -370,6 +379,7 @@ pub async fn tool_search_tools(
     args: &Value,
     trace_context: Option<&TraceContext>,
     session_id: Option<&str>,
+    agent_context: Option<&AgentContext>,
 ) -> Result<String, String> {
     // Refresh on demand so the first query after startup (or after
     // a skill load/unload) always sees current capabilities.
@@ -408,7 +418,10 @@ pub async fn tool_search_tools(
         index_generation: search_context.index_generation.clone(),
         hits: telemetry_hits,
         trace_context: trace_context.cloned(),
-        session_id: session_id.map(str::to_string),
+        session_id: session_id
+            .map(str::to_string)
+            .or_else(|| agent_context.and_then(|ctx| ctx.session_id.clone())),
+        agent_context: agent_context.cloned(),
     });
 
     serde_json::to_string_pretty(&json!({
@@ -819,6 +832,7 @@ fn annotate_skill_search_payload(
     text: &str,
     trace_context: Option<&TraceContext>,
     session_id: Option<&str>,
+    agent_context: Option<&AgentContext>,
 ) -> String {
     let search_id = crate::gateway::search_telemetry::SearchTelemetryStore::new_search_id();
     let index_generation =
@@ -947,7 +961,10 @@ fn annotate_skill_search_payload(
         index_generation,
         hits: telemetry_hits,
         trace_context: trace_context.cloned(),
-        session_id: session_id.map(str::to_string),
+        session_id: session_id
+            .map(str::to_string)
+            .or_else(|| agent_context.and_then(|ctx| ctx.session_id.clone())),
+        agent_context: agent_context.cloned(),
     });
     serde_json::to_string_pretty(&payload).unwrap_or_else(|_| text.to_string())
 }

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -143,7 +143,8 @@ compatibility layer; automation should prefer:
 MCP and REST callers may attach optional context so the Admin UI can correlate
 why a request was made with the request waterfall. This is a telemetry contract:
 callers should send concise summaries, plans, observations, tags, and correlation
-ids. The gateway does not attempt to capture hidden model chain-of-thought.
+ids. The gateway does not attempt to capture hidden model chain-of-thought, raw
+user input, or raw agent replies on the default path.
 
 Supported carriers:
 
@@ -151,7 +152,13 @@ Supported carriers:
 - REST body `agent_context`, `agentContext`, `caller_context`, or
   `meta.agent_context`
 - Headers such as `x-dcc-mcp-agent-id`, `x-dcc-mcp-agent-name`,
-  `x-dcc-mcp-agent-model`, `x-dcc-mcp-agent-task`,
+  `x-dcc-mcp-agent-model`, `x-dcc-mcp-agent-model-provider`,
+  `x-dcc-mcp-agent-model-version`, `x-dcc-mcp-agent-reasoning-effort`,
+  `x-dcc-mcp-agent-session-id`, `x-dcc-mcp-agent-turn-id`,
+  `x-dcc-mcp-agent-user-intent-summary`,
+  `x-dcc-mcp-agent-reply-summary`, `x-dcc-mcp-agent-user-input-hash`,
+  `x-dcc-mcp-agent-reply-hash`, `x-dcc-mcp-agent-user-input-chars`,
+  `x-dcc-mcp-agent-reply-chars`, `x-dcc-mcp-agent-task`,
   `x-dcc-mcp-reasoning-summary`, `x-dcc-mcp-parent-request-id`, and
   `x-dcc-mcp-agent-context` (JSON object)
 
@@ -165,8 +172,19 @@ Example REST request:
     "agent_context": {
       "agent_id": "agent-42",
       "agent_name": "Layout Inspector",
+      "model_provider": "openai",
+      "model_version": "gpt-5.1",
       "model": "gpt-5.4",
+      "reasoning_effort": "medium",
+      "session_id": "session-42",
+      "turn_id": "turn-7",
       "task": "Find the cheapest scene inspection path before editing",
+      "user_intent_summary": "User asked for a non-destructive scene inspection before editing.",
+      "agent_reply_summary": "The agent will inspect topology and material counts first.",
+      "user_input_hash": "sha256:...",
+      "agent_reply_hash": "sha256:...",
+      "user_input_chars": 128,
+      "agent_reply_chars": 192,
       "reasoning_summary": "Need scene topology and material counts before selecting an edit tool.",
       "plan": ["inspect scene", "choose edit target"],
       "observations": ["user asked for non-destructive update"],
@@ -186,10 +204,15 @@ span waterfall, and the same copyable links. These URLs are designed to be
 pasted directly into an LLM evaluation prompt or another agent's debugging task.
 The Workflows panel and `GET /admin/api/workflows` group the same bounded data
 by session, explicit workflow id, trace id, or request chain. Each workflow row
-shows the readable discovery/execution chain (`search` → `describe` →
-`load_skill` → `call`), selected search rank, zero-result searches,
+shows model identity, turn id, user/agent summaries, the readable
+discovery/execution chain (`search` → `describe` → `load_skill` → `call`),
+selected search rank, zero-result searches,
 time-to-first-success, and per-step links to trace detail, debug bundle, issue
 report JSON, OpenAPI Inspector/spec, and docs where a request id is available.
+Raw prompts and raw replies are high-sensitivity data: keep them out of
+`agent_context`; use only an explicitly configured traffic capture policy with
+redaction, sampling, retention, and operator visibility when raw text is needed
+for a private investigation.
 
 `request_id` and `trace_id` are intentionally different. `request_id` identifies
 one HTTP/MCP request (or JSON-RPC id), while `trace_id` identifies the
@@ -200,8 +223,11 @@ trace id, parent span id, and flags from `traceparent`.
 The Admin UI also exposes a standalone `GET /admin/api/issue-report/{request_id}`
 export. It returns a GitHub-attachable JSON report with a summary,
 `github_issue` title/body template, absolute links, and the correlated debug
-bundle. Review request/response payloads for secrets or proprietary scene paths
-before uploading the JSON to a public issue.
+bundle. Default exports include bounded summaries, hashes, character counts, and
+payload previews only. Review request/response payload previews for secrets or
+proprietary scene paths before uploading the JSON to a public issue; raw prompt
+or reply text belongs in an explicit safe-export/traffic-capture flow, not in
+default issue reports.
 
 The front-end product name is **Admin Dashboard**. The lower REST/OpenAPI
 contract view is named **OpenAPI Inspector**. It reads the live gateway

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -65,18 +65,21 @@ gateway-specific fields:
 | `dcc_mcp.workflow.operation` | One of the span names above. |
 | `dcc_mcp.transport` | `rest` or `mcp`. |
 | `dcc_mcp.trace_id`, `dcc_mcp.request_id`, `dcc_mcp.parent_request_id`, `dcc_mcp.session_id` | Correlation IDs that match Admin trace/debug-bundle surfaces. |
-| `dcc_mcp.agent.id`, `.name`, `.kind`, `.model`, `.task`, `.tags` | Bounded `agent_context` / caller metadata. |
+| `dcc_mcp.agent.id`, `.name`, `.kind`, `.model`, `.model_provider`, `.model_version`, `.reasoning_effort`, `.turn_id`, `.task`, `.tags` | Bounded `agent_context` / caller metadata. |
+| `dcc_mcp.agent.user_intent_summary`, `.reply_summary`, `.user_input_hash`, `.reply_hash`, `.user_input_chars`, `.reply_chars` | Low-sensitivity turn summaries, hashes, and lengths for evaluation correlation. |
 | `dcc_mcp.dcc.type`, `dcc_mcp.instance.id`, `dcc_mcp.skill.name`, `dcc_mcp.tool.slug` | Selected DCC route and skill/tool identity. |
 | `dcc_mcp.search.id`, `.ranker_version`, `.selected_rank`, `.score`, `.match_reasons`, `.total`, `.zero_results` | Search-quality context carried from `/v1/search` or gateway `search`. |
 | `dcc_mcp.policy.outcome`, `.reason` | Whether gateway policy allowed, denied, or throttled the action and why. |
 | `dcc_mcp.success`, `dcc_mcp.error.kind`, `dcc_mcp.batch.size` | Execution outcome fields. |
 
 The gateway intentionally does **not** export hidden chain-of-thought, raw
-prompts, unbounded request bodies, secrets, or arbitrary `agent_context`
-metadata. Put `search_id` in REST `meta.search_id` or MCP `_meta.search_id`
-when following a search hit into `describe`, `load_skill`, `call`, or
-`call_batch`; that is what lets OTLP traces connect selected rank and score to
-actual tool outcomes.
+prompts, raw agent replies, unbounded request bodies, secrets, or arbitrary
+`agent_context` metadata. Put `search_id` in REST `meta.search_id` or MCP
+`_meta.search_id` when following a search hit into `describe`, `load_skill`,
+`call`, or `call_batch`; that is what lets OTLP traces connect selected rank
+and score to actual tool outcomes. Add `turn_id` and model identity to
+`agent_context` when an evaluation needs to correlate search quality,
+time-to-first-success, and downstream call success back to one agent turn.
 
 ### Trace Context
 
@@ -237,9 +240,13 @@ MCP and REST clients can attach optional agent/caller context to correlate an
 operator-visible request with the caller's explicit plan and observations. Use
 `params._meta.agent_context` for MCP, REST `meta.agent_context` or
 `caller_context` fields, or `x-dcc-mcp-agent-*` headers. Fields are bounded and
-intended for concise telemetry such as `agent_id`, `agent_name`, `model`,
-`task`, `reasoning_summary`, `plan`, `observations`, `parent_request_id`, and
-tags; do not send hidden chain-of-thought or secrets. `trace_id`, `request_id`,
+intended for concise telemetry such as `agent_id`, `agent_name`,
+`model_provider`, `model_version`, `model`, `reasoning_effort`, `session_id`,
+`turn_id`, `user_intent_summary`, `agent_reply_summary`, `user_input_hash`,
+`agent_reply_hash`, `user_input_chars`, `agent_reply_chars`, `task`,
+`reasoning_summary`, `plan`, `observations`, `parent_request_id`, and tags; do
+not send hidden chain-of-thought, raw user input, raw agent replies, or secrets.
+`trace_id`, `request_id`,
 `span_id`, and `parent_span_id` are recorded separately so one trace can contain
 multiple request ids without losing per-request compatibility. Admin call and trace rows
 also include absolute `links` for the trace page, trace API, debug bundle,

--- a/docs/guide/rest-api-surface.md
+++ b/docs/guide/rest-api-surface.md
@@ -449,7 +449,22 @@ Rules:
   "tags": ["batch"],
   "loaded_only": false,
   "limit": 20,
-  "mode": "fuzzy"
+  "mode": "fuzzy",
+  "meta": {
+    "agent_context": {
+      "model_provider": "openai",
+      "model_version": "gpt-5.1",
+      "reasoning_effort": "medium",
+      "session_id": "session-42",
+      "turn_id": "turn-7",
+      "user_intent_summary": "Find the render tool before invoking it.",
+      "agent_reply_summary": "Search first, then describe or load the best hit.",
+      "user_input_hash": "sha256:...",
+      "agent_reply_hash": "sha256:...",
+      "user_input_chars": 128,
+      "agent_reply_chars": 160
+    }
+  }
 }
 ```
 
@@ -470,6 +485,11 @@ Rules:
 - Gateway hits include one-based `rank`. Generated `next_step` payloads carry
   `meta.search_id`, `meta.ranker_version`, and `meta.index_generation` for
   follow-up calls; clients may also pass the same object as MCP `_meta`.
+- Optional `meta.agent_context`, top-level `caller_context`, or
+  `x-dcc-mcp-agent-*` headers carry bounded turn metadata for Admin workflow,
+  search-quality, and OTLP correlation. Send concise summaries, hashes, and
+  character counts only; raw user input and raw agent replies are high
+  sensitivity and belong only in an explicit redacted traffic-capture flow.
 - Full `input_schema` remains behind `describe`. Search may carry only bounded
   `metadata.dcc.searchAliases` / `metadata.dcc.searchTokens` hints from a
   per-DCC backend to the gateway index; gateway search responses do not expose

--- a/docs/zh/guide/observability.md
+++ b/docs/zh/guide/observability.md
@@ -62,13 +62,14 @@ OTEL_SERVICE_NAME=dcc-mcp-gateway \
 | `dcc_mcp.workflow.operation` | 上表中的 span 名称。 |
 | `dcc_mcp.transport` | `rest` 或 `mcp`。 |
 | `dcc_mcp.trace_id`、`dcc_mcp.request_id`、`dcc_mcp.parent_request_id`、`dcc_mcp.session_id` | 与 Admin trace/debug bundle 对齐的关联 ID。 |
-| `dcc_mcp.agent.id`、`.name`、`.kind`、`.model`、`.task`、`.tags` | 有界的 `agent_context` / caller 元数据。 |
+| `dcc_mcp.agent.id`、`.name`、`.kind`、`.model`、`.model_provider`、`.model_version`、`.reasoning_effort`、`.turn_id`、`.task`、`.tags` | 有界的 `agent_context` / caller 元数据。 |
+| `dcc_mcp.agent.user_intent_summary`、`.reply_summary`、`.user_input_hash`、`.reply_hash`、`.user_input_chars`、`.reply_chars` | 用于评估关联的低敏 turn 摘要、哈希和长度。 |
 | `dcc_mcp.dcc.type`、`dcc_mcp.instance.id`、`dcc_mcp.skill.name`、`dcc_mcp.tool.slug` | 选中的 DCC 路由与技能/工具身份。 |
 | `dcc_mcp.search.id`、`.ranker_version`、`.selected_rank`、`.score`、`.match_reasons`、`.total`、`.zero_results` | 从 `/v1/search` 或 gateway `search` 继承的搜索质量上下文。 |
 | `dcc_mcp.policy.outcome`、`.reason` | 网关策略是否允许、拒绝或限流，以及原因。 |
 | `dcc_mcp.success`、`dcc_mcp.error.kind`、`dcc_mcp.batch.size` | 执行结果字段。 |
 
-网关不会导出隐藏推理、原始 prompt、无界请求体、secret 或任意 `agent_context` metadata。Agent 从搜索结果继续调用 `describe`、`load_skill`、`call` 或 `call_batch` 时，应保留 REST `meta.search_id` 或 MCP `_meta.search_id`，这样 OTLP trace 才能把 selected rank/score 和真实工具结果关联起来。
+网关不会导出隐藏推理、原始 prompt、原始 agent 回复、无界请求体、secret 或任意 `agent_context` metadata。Agent 从搜索结果继续调用 `describe`、`load_skill`、`call` 或 `call_batch` 时，应保留 REST `meta.search_id` 或 MCP `_meta.search_id`，这样 OTLP trace 才能把 selected rank/score 和真实工具结果关联起来。评估需要关联单个 agent turn 时，在 `agent_context` 中加入 `turn_id` 与模型身份字段。
 
 ### Rust 编程式配置
 

--- a/skills/dcc-mcp-skill-developer/SKILL.md
+++ b/skills/dcc-mcp-skill-developer/SKILL.md
@@ -61,8 +61,11 @@ into a faster authoring loop.
 7. When changing adapter server wiring or caller examples, keep Admin telemetry
    useful: pass optional `agent_context` / `caller_context` summaries through
    MCP `_meta`, REST `meta`, or `x-dcc-mcp-agent-*` headers when the caller is
-   an agent. Include only explicit summaries, plans, observations, and
-   correlation ids; never ask tools to expose hidden chain-of-thought. Preserve
+   an agent. Include only explicit summaries, plans, observations, model
+   identity (`model_provider`, `model_version`, optional legacy `model`),
+   turn correlation (`session_id`, `turn_id`), hashes, character counts, and
+   correlation ids; never ask tools to expose hidden chain-of-thought, raw user
+   input, or raw agent replies. Preserve
    Admin `links` fields in examples so every trace/debug bundle, OpenAPI
    Inspector/spec link, or issue-report JSON export can be copied as a complete
    URL into a follow-up agent, LLM evaluation prompt, or GitHub issue. When an
@@ -77,7 +80,8 @@ into a faster authoring loop.
    of the whole `search` -> `describe` -> `load_skill` -> `call` chain; it is a
    read-only projection over retained search telemetry, dispatch traces, and
    audit rows, including selected rank, zero-result searches, and
-   time-to-first-success without exposing hidden reasoning or raw prompts.
+   time-to-first-success with model/turn summaries, without exposing hidden
+   reasoning or raw prompts.
    Gateway `GET /v1/openapi.json` is gateway-specific: it documents only the
    mounted aggregating routes and intentionally omits per-DCC-only resources,
    prompts, jobs, and adapter-local `/v1/dcc/{dcc_type}/call`. Use a concrete
@@ -117,11 +121,16 @@ into a faster authoring loop.
    Gateway OTLP spans mirror the same agent workflow chain with bounded
    attributes: `gateway.search`, `gateway.describe`, `gateway.load_skill`,
    `gateway.call`, and `gateway.call_batch` use `openinference.span.kind` plus
-   `dcc_mcp.*` fields for agent id/name/kind/model/task/tags, DCC route,
+   `dcc_mcp.*` fields for agent id/name/kind/model provider/model version/
+   reasoning effort/turn id/task/tags, bounded user-intent and reply summaries,
+   user/reply hashes and character counts, DCC route,
    `search_id`, selected rank/score/match reasons, policy outcome, and
    success/error kind. Adapter docs and examples should preserve those
    correlation fields but must not put hidden reasoning, secrets, raw prompts,
-   or unbounded request bodies into `agent_context` metadata.
+   raw agent replies, or unbounded request bodies into `agent_context` metadata.
+   Raw prompt/reply capture belongs only in an explicitly configured traffic
+   capture policy with redaction, sampling, retention, and clear Admin
+   visibility.
    Gateway search uses a hybrid ranker in default fuzzy mode: weighted lexical
    matches over tool names, skill names, tags, summaries, author-declared
    aliases, and bounded schema-field tokens take precedence, while fuzzy


### PR DESCRIPTION
## Summary
- extend the gateway agent context contract with bounded model, session, turn, summary, hash, and length fields
- propagate agent turn context into search quality telemetry, admin workflow/session views, and OTLP attributes without default raw prompt/reply capture
- document the MCP/REST/header carriers and update skill developer guidance for the new observability contract

## Validation
- vx cargo fmt --all -- --check
- vx cargo test -p dcc-mcp-gateway --features admin --lib
- vx cargo clippy -p dcc-mcp-gateway --all-targets --features admin -- -D warnings
- vx npm --prefix admin-ui run build
- vx npm --prefix admin-ui test -- --grep "shows agent workflows"
- vx npm --prefix docs run docs:build

Closes #1198