### PR TITLE
feat: show admin token savings

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -25,6 +25,12 @@ type HealthPayload = {
   uptime_secs: number;
   version: string;
   rss_bytes?: number | null;
+  response_format?: {
+    default?: string | null;
+    legacy_mime?: string | null;
+    compact_mime?: string | null;
+    token_estimator?: string | null;
+  };
   gateway?: {
     current?: GatewaySentinel | null;
     candidates?: GatewaySentinel[];
@@ -77,6 +83,15 @@ type CallRow = {
   agent_name?: string | null;
   agent_model?: string | null;
   parent_request_id?: string | null;
+  token_accounting?: TokenAccounting | null;
+  response_format?: string | null;
+  token_estimator?: string | null;
+  original_bytes?: number | null;
+  returned_bytes?: number | null;
+  original_tokens?: number | null;
+  returned_tokens?: number | null;
+  saved_tokens?: number | null;
+  savings_pct?: number | string | null;
   links?: AdminLinks;
 };
 
@@ -98,7 +113,39 @@ type TraceRow = {
   output_bytes?: number | null;
   slowest_span_name?: string | null;
   slowest_span_ms?: number | null;
+  token_accounting?: TokenAccounting | null;
+  response_format?: string | null;
+  token_estimator?: string | null;
+  original_bytes?: number | null;
+  returned_bytes?: number | null;
+  original_tokens?: number | null;
+  returned_tokens?: number | null;
+  saved_tokens?: number | null;
+  savings_pct?: number | string | null;
   links?: AdminLinks;
+};
+
+type TokenAccounting = {
+  response_format?: string | null;
+  token_estimator?: string | null;
+  original_bytes?: number | null;
+  returned_bytes?: number | null;
+  original_tokens?: number | null;
+  returned_tokens?: number | null;
+  saved_tokens?: number | null;
+  savings_pct?: number | string | null;
+};
+
+type TokenCarrier = {
+  token_accounting?: TokenAccounting | null;
+  response_format?: string | null;
+  token_estimator?: string | null;
+  original_bytes?: number | null;
+  returned_bytes?: number | null;
+  original_tokens?: number | null;
+  returned_tokens?: number | null;
+  saved_tokens?: number | null;
+  savings_pct?: number | string | null;
 };
 
 type AdminLinks = {
@@ -171,6 +218,15 @@ type TraceDetailPayload = {
   spans: TraceSpan[];
   input?: TracePayload | null;
   output?: TracePayload | null;
+  token_accounting?: TokenAccounting | null;
+  response_format?: string | null;
+  token_estimator?: string | null;
+  original_bytes?: number | null;
+  returned_bytes?: number | null;
+  original_tokens?: number | null;
+  returned_tokens?: number | null;
+  saved_tokens?: number | null;
+  savings_pct?: number | string | null;
   links?: AdminLinks;
 };
 
@@ -342,6 +398,28 @@ type LatencyBlock = {
 
 type TopEntry = { name: string; count: number };
 
+type TokenBreakdownEntry = {
+  name: string;
+  calls: number;
+  returned_tokens: number;
+  saved_tokens: number;
+  savings_pct: number;
+};
+
+type TokenUsageStats = {
+  total_original_bytes?: number;
+  total_returned_bytes?: number;
+  total_original_tokens?: number;
+  total_returned_tokens?: number;
+  total_saved_tokens?: number;
+  average_savings_pct?: number;
+  by_tool?: TokenBreakdownEntry[];
+  by_instance?: TokenBreakdownEntry[];
+  by_agent?: TokenBreakdownEntry[];
+  by_transport?: TokenBreakdownEntry[];
+  by_response_format?: TokenBreakdownEntry[];
+};
+
 type StatsPayload = {
   range: string;
   total_calls: number;
@@ -354,6 +432,7 @@ type StatsPayload = {
   top_tools?: TopEntry[];
   top_instances?: TopEntry[];
   top_agents?: TopEntry[];
+  token_usage?: TokenUsageStats;
   hourly_distribution?: number[];
   governance?: GovernanceStats;
   error?: string;
@@ -1736,6 +1815,78 @@ function agentLabel(row: { agent_name?: string | null; agent_id?: string | null;
   return row.agent_name || row.agent_id || row.agent_model || '-';
 }
 
+function tokenAccounting(row: TokenCarrier | null | undefined): TokenAccounting | null {
+  if (!row) {
+    return null;
+  }
+  if (row.token_accounting) {
+    return row.token_accounting;
+  }
+  if (
+    row.response_format ||
+    row.token_estimator ||
+    row.original_tokens != null ||
+    row.returned_tokens != null ||
+    row.saved_tokens != null ||
+    row.savings_pct != null
+  ) {
+    return {
+      response_format: row.response_format,
+      token_estimator: row.token_estimator,
+      original_bytes: row.original_bytes,
+      returned_bytes: row.returned_bytes,
+      original_tokens: row.original_tokens,
+      returned_tokens: row.returned_tokens,
+      saved_tokens: row.saved_tokens,
+      savings_pct: row.savings_pct,
+    };
+  }
+  return null;
+}
+
+function numericValue(value: number | string | null | undefined): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function formatTokenCount(value: number | string | null | undefined): string {
+  const n = numericValue(value);
+  if (n == null) {
+    return '-';
+  }
+  return Math.round(n).toLocaleString();
+}
+
+function formatSavingsPct(value: number | string | null | undefined): string {
+  const n = numericValue(value);
+  if (n == null) {
+    return '-';
+  }
+  return `${n.toFixed(1)}%`;
+}
+
+function responseFormatLabel(row: TokenCarrier | null | undefined): string {
+  return tokenAccounting(row)?.response_format || '-';
+}
+
+function returnedTokensLabel(row: TokenCarrier | null | undefined): string {
+  return formatTokenCount(tokenAccounting(row)?.returned_tokens);
+}
+
+function savedTokensLabel(row: TokenCarrier | null | undefined): string {
+  const tokens = tokenAccounting(row);
+  if (!tokens) {
+    return '-';
+  }
+  return `${formatTokenCount(tokens.saved_tokens)} (${formatSavingsPct(tokens.savings_pct)})`;
+}
+
 function formatDurationMs(value: number | null | undefined): string {
   if (value == null) {
     return '-';
@@ -1813,6 +1964,46 @@ function StatBarList({ title, items }: { title: string; items: TopEntry[] }) {
   );
 }
 
+function TokenBreakdownList({ title, items }: { title: string; items: TokenBreakdownEntry[] }) {
+  const max = Math.max(1, ...items.map((row) => row.saved_tokens ?? 0));
+  return (
+    <div className="chart-card">
+      <h3 className="chart-title">{title}</h3>
+      {!items.length ? <p className="empty">No token data in this range.</p> : items.map((row) => (
+        <div className="hbar-row" key={`${title}-${row.name}`}>
+          <div className="hbar-label" title={row.name}>{row.name.length > 48 ? `${row.name.slice(0, 46)}...` : row.name}</div>
+          <div className="hbar-track">
+            <div className="hbar-fill" style={{ width: `${Math.max(2, ((row.saved_tokens ?? 0) / max) * 100)}%` }} />
+          </div>
+          <div className="hbar-count" title={`${row.calls} call(s), ${formatSavingsPct(row.savings_pct)} saved`}>
+            {formatTokenCount(row.saved_tokens)}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function TokenAccountingDetail({ row }: { row: TokenCarrier | null | undefined }) {
+  const tokens = tokenAccounting(row);
+  return (
+    <div className="trace-detail-card">
+      <div className="trace-card-head">
+        <h3>Token accounting</h3>
+        <span>{tokens?.token_estimator ?? 'no estimator'}</span>
+      </div>
+      <div className="trace-summary-grid">
+        <span><strong>Format</strong>{tokens?.response_format ?? '-'}</span>
+        <span><strong>Returned</strong>{formatTokenCount(tokens?.returned_tokens)}</span>
+        <span><strong>Saved</strong>{formatTokenCount(tokens?.saved_tokens)}</span>
+        <span><strong>Savings</strong>{formatSavingsPct(tokens?.savings_pct)}</span>
+        <span><strong>Original bytes</strong>{formatBytes(tokens?.original_bytes)}</span>
+        <span><strong>Returned bytes</strong>{formatBytes(tokens?.returned_bytes)}</span>
+      </div>
+    </div>
+  );
+}
+
 function HourlyChart({ buckets }: { buckets: number[] }) {
   if (!buckets.length) {
     return null;
@@ -1864,6 +2055,7 @@ function buildAgentPacket(trace: TraceDetailPayload): string {
     transport: trace.transport,
     status: trace.ok ? 'ok' : 'err',
     total_ms: trace.total_ms,
+    token_accounting: tokenAccounting(trace),
     agent_context: agent ? {
       agent_id: agent.agent_id,
       agent_name: agent.agent_name,
@@ -2172,6 +2364,8 @@ function TraceDetailPanel({
           </div>
         </div>
       ) : null}
+
+      <TokenAccountingDetail row={trace} />
 
       <div className="trace-detail-card">
         <div className="trace-card-head">
@@ -2731,6 +2925,21 @@ function App() {
     }
     return rows.filter((r) => r.name.toLowerCase().includes(q));
   }, [stats, listSearch]);
+
+  const filterTokenBreakdowns = useCallback((rows: TokenBreakdownEntry[] | undefined) => {
+    const q = listSearch.trim().toLowerCase();
+    const safeRows = rows ?? [];
+    if (!q) {
+      return safeRows;
+    }
+    return safeRows.filter((r) => r.name.toLowerCase().includes(q));
+  }, [listSearch]);
+
+  const filteredTokenByTool = useMemo(() => filterTokenBreakdowns(stats?.token_usage?.by_tool), [filterTokenBreakdowns, stats]);
+  const filteredTokenByInstance = useMemo(() => filterTokenBreakdowns(stats?.token_usage?.by_instance), [filterTokenBreakdowns, stats]);
+  const filteredTokenByAgent = useMemo(() => filterTokenBreakdowns(stats?.token_usage?.by_agent), [filterTokenBreakdowns, stats]);
+  const filteredTokenByTransport = useMemo(() => filterTokenBreakdowns(stats?.token_usage?.by_transport), [filterTokenBreakdowns, stats]);
+  const filteredTokenByFormat = useMemo(() => filterTokenBreakdowns(stats?.token_usage?.by_response_format), [filterTokenBreakdowns, stats]);
 
   const filteredGovernanceDecisions = useMemo(() => {
     const rows = governance?.recent_decisions ?? [];
@@ -3350,7 +3559,7 @@ function App() {
             <input
               type="search"
               className="list-search-input"
-              placeholder={activePanel === 'stats' ? 'Filter top tools / instances…' : activePanel === 'openapi' ? 'Filter operations, paths, tags…' : 'Search this panel…'}
+              placeholder={activePanel === 'stats' ? 'Filter stats charts...' : activePanel === 'openapi' ? 'Filter operations, paths, tags...' : 'Search this panel...'}
               value={listSearch}
               onChange={(e) => setListSearch(e.target.value)}
               aria-label="Filter current panel"
@@ -3368,7 +3577,7 @@ function App() {
                 {activePanel === 'governance' ? `${filteredGovernanceDecisions.length} / ${governance?.recent_decisions?.length ?? 0}` : ''}
                 {activePanel === 'skill-paths' ? `${filteredSkills.length} skill(s), ${filteredSkillPaths.length} path(s)` : ''}
                 {activePanel === 'logs' ? `${filteredLogs.length} / ${logs.length}` : ''}
-                {activePanel === 'stats' ? `charts: ${filteredTopTools.length} tools / ${filteredTopInstances.length} instances / ${filteredTopAgents.length} agents` : ''}
+                {activePanel === 'stats' ? `charts: ${filteredTopTools.length} tools / ${filteredTopInstances.length} instances / ${filteredTopAgents.length} agents / ${filteredTokenByFormat.length} formats` : ''}
                 {activePanel === 'governance' ? `${governanceSummary.denied} denied / ${governanceSummary.throttled} throttled` : ''}
               </span>
             ) : null}
@@ -3633,6 +3842,10 @@ function App() {
               <HealthCard label="Version" value={health?.version ?? '?'} />
               <HealthCard label="Gateway owner" value={gatewayLabel(health)} />
               <HealthCard label="Gateway candidates" value={String(health?.gateway?.candidates?.length ?? 0)} />
+              <HealthCard
+                label="Response format"
+                value={`${health?.response_format?.default ?? 'json'} / ${health?.response_format?.token_estimator ?? '-'}`}
+              />
               <HealthCard label="RSS" value={formatBytes(health?.rss_bytes ?? undefined)} />
               <HealthCard label="Body limit" value={health?.limits ? formatBytes(health.limits.body_max_bytes) : '?'} />
               <HealthCard
@@ -3863,7 +4076,7 @@ function App() {
                 <div key={group} className="group-block">
                   <h3 className="group-title">{group}</h3>
                   <table>
-                    <thead><tr><th>Time</th><th>Request</th><th>Tool</th><th>DCC</th><th>Agent</th><th>Transport</th><th>Status</th><th>Error</th><th>ms</th><th>Detail</th></tr></thead>
+                    <thead><tr><th>Time</th><th>Request</th><th>Tool</th><th>DCC</th><th>Agent</th><th>Transport</th><th>Format</th><th>Returned</th><th>Saved</th><th>Status</th><th>Error</th><th>ms</th><th>Detail</th></tr></thead>
                     <tbody>
                       {groupCalls.map((call) => (
                         <tr key={call.request_id}>
@@ -3877,6 +4090,9 @@ function App() {
                           <td>{call.dcc_type}</td>
                           <td title={call.agent_id ?? call.agent_name ?? ''}>{agentLabel(call)}</td>
                           <td>{call.transport ?? '-'}</td>
+                          <td>{responseFormatLabel(call)}</td>
+                          <td>{returnedTokensLabel(call)}</td>
+                          <td>{savedTokensLabel(call)}</td>
                           <td><StatusBadge value={call.status} /></td>
                           <td title={call.error ?? ''}>{call.error ? call.error.slice(0, 80) : '-'}</td>
                           <td>{call.duration_ms ?? '-'}</td>
@@ -3997,12 +4213,33 @@ function App() {
               <MetricTile tone={errorRateTone(stats)} label="Success" value={stats ? `${stats.success_rate.toFixed(1)}%` : '0.0%'} detail={`${statsSummary.success} ok / ${statsSummary.failed} failed`} />
               <MetricTile tone={latencyTone(stats?.latency_ms?.p50_ms ?? stats?.p50_ms)} label="p50 latency" value={formatDurationMs(stats?.latency_ms?.p50_ms ?? stats?.p50_ms)} />
               <MetricTile tone={latencyTone(stats?.latency_ms?.p95_ms ?? stats?.p95_ms)} label="p95 latency" value={formatDurationMs(stats?.latency_ms?.p95_ms ?? stats?.p95_ms)} />
+              <MetricTile
+                label="Returned tokens"
+                value={formatTokenCount(stats?.token_usage?.total_returned_tokens)}
+                detail={`${formatTokenCount(stats?.token_usage?.total_original_tokens)} original`}
+              />
+              <MetricTile
+                tone={(stats?.token_usage?.total_saved_tokens ?? 0) > 0 ? 'ok' : undefined}
+                label="Saved tokens"
+                value={formatTokenCount(stats?.token_usage?.total_saved_tokens)}
+                detail={`${formatSavingsPct(stats?.token_usage?.average_savings_pct)} average`}
+              />
+              <MetricTile
+                label="Response format"
+                value={health?.response_format?.default ?? 'json'}
+                detail={health?.response_format?.token_estimator ?? 'token estimator unavailable'}
+              />
             </div>
             <div className="stats-charts">
               <StatBarList title="Top tools" items={filteredTopTools} />
               <StatBarList title="Top instances" items={filteredTopInstances} />
               <StatBarList title="Top agents" items={filteredTopAgents} />
               {stats?.hourly_distribution?.length ? <HourlyChart buckets={stats.hourly_distribution} /> : null}
+              <TokenBreakdownList title="Token savings by tool" items={filteredTokenByTool} />
+              <TokenBreakdownList title="Token savings by instance" items={filteredTokenByInstance} />
+              <TokenBreakdownList title="Token savings by agent" items={filteredTokenByAgent} />
+              <TokenBreakdownList title="Token savings by transport" items={filteredTokenByTransport} />
+              <TokenBreakdownList title="Token savings by format" items={filteredTokenByFormat} />
             </div>
           </section>
         )}

--- a/admin-ui/tests/admin.spec.ts
+++ b/admin-ui/tests/admin.spec.ts
@@ -25,6 +25,12 @@ async function mockAdminApi(page: Page) {
         uptime_secs: 3723,
         version: '0.17.7',
         rss_bytes: 2097152,
+        response_format: {
+          default: 'json',
+          legacy_mime: 'application/json',
+          compact_mime: 'application/toon',
+          token_estimator: 'dcc-mcp-byte4-v1',
+        },
         gateway: {
           current: {
             name: 'local-gateway',
@@ -327,7 +333,7 @@ async function mockAdminApi(page: Page) {
       };
     } else if (path === '/calls') {
       body = {
-        total: 1,
+        total: 3,
         calls: [
           {
             timestamp: now,
@@ -339,6 +345,46 @@ async function mockAdminApi(page: Page) {
             error: null,
             duration_ms: 42,
             instance_id: 'maya-1234567890',
+            transport: 'rest',
+            token_accounting: {
+              response_format: 'toon',
+              token_estimator: 'dcc-mcp-byte4-v1',
+              original_bytes: 400,
+              returned_bytes: 160,
+              original_tokens: 100,
+              returned_tokens: 40,
+              saved_tokens: 60,
+              savings_pct: 60,
+            },
+          },
+          {
+            timestamp: '2026-05-18T08:00:30.000Z',
+            request_id: 'req-json',
+            tool: 'maya-1234__describe',
+            dcc_type: 'maya',
+            status: 'ok',
+            success: true,
+            error: null,
+            duration_ms: 18,
+            instance_id: 'maya-1234567890',
+            transport: 'mcp',
+            response_format: 'json',
+            token_estimator: 'dcc-mcp-byte4-v1',
+            original_tokens: 50,
+            returned_tokens: 50,
+            saved_tokens: 0,
+            savings_pct: 0,
+          },
+          {
+            timestamp: '2026-05-18T08:01:00.000Z',
+            request_id: 'req-legacy',
+            tool: 'blender-abcd__render_preview',
+            dcc_type: 'blender',
+            status: 'ok',
+            success: true,
+            error: null,
+            duration_ms: 77,
+            instance_id: 'blender-abcdef1234',
           },
         ],
       };
@@ -355,6 +401,16 @@ async function mockAdminApi(page: Page) {
             success: true,
             total_ms: 42,
             instance_id: 'maya-1234567890',
+            token_accounting: {
+              response_format: 'toon',
+              token_estimator: 'dcc-mcp-byte4-v1',
+              original_bytes: 400,
+              returned_bytes: 160,
+              original_tokens: 100,
+              returned_tokens: 40,
+              saved_tokens: 60,
+              savings_pct: 60,
+            },
           },
           {
             timestamp: '2026-05-18T08:01:00.000Z',
@@ -372,7 +428,19 @@ async function mockAdminApi(page: Page) {
       body = {
         request_id: 'req-123',
         method: 'tools/call',
-        spans: [{ name: 'dispatch', duration_ms: 42 }],
+        total_ms: 42,
+        ok: true,
+        spans: [{ name: 'dispatch', duration_ns: 42000000, ok: true }],
+        token_accounting: {
+          response_format: 'toon',
+          token_estimator: 'dcc-mcp-byte4-v1',
+          original_bytes: 400,
+          returned_bytes: 160,
+          original_tokens: 100,
+          returned_tokens: 40,
+          saved_tokens: 60,
+          savings_pct: 60,
+        },
       };
     } else if (path === '/stats') {
       body = {
@@ -384,6 +452,26 @@ async function mockAdminApi(page: Page) {
         latency_ms: { p50_ms: 20, p95_ms: 90 },
         top_tools: [{ name: 'maya-1234__create_sphere', count: 3 }],
         top_instances: [{ name: 'maya-1234567890', count: 3 }],
+        top_agents: [{ name: 'Scene Builder', count: 2 }],
+        token_usage: {
+          total_original_bytes: 1200,
+          total_returned_bytes: 640,
+          total_original_tokens: 300,
+          total_returned_tokens: 160,
+          total_saved_tokens: 140,
+          average_savings_pct: 46.67,
+          by_tool: [{ name: 'maya-1234__create_sphere', calls: 2, returned_tokens: 80, saved_tokens: 120, savings_pct: 60 }],
+          by_instance: [{ name: 'maya-1234567890', calls: 2, returned_tokens: 80, saved_tokens: 120, savings_pct: 60 }],
+          by_agent: [{ name: 'Scene Builder', calls: 2, returned_tokens: 80, saved_tokens: 120, savings_pct: 60 }],
+          by_transport: [
+            { name: 'rest', calls: 2, returned_tokens: 80, saved_tokens: 120, savings_pct: 60 },
+            { name: 'mcp', calls: 1, returned_tokens: 80, saved_tokens: 20, savings_pct: 20 },
+          ],
+          by_response_format: [
+            { name: 'toon', calls: 2, returned_tokens: 110, saved_tokens: 140, savings_pct: 56 },
+            { name: 'json', calls: 1, returned_tokens: 50, saved_tokens: 0, savings_pct: 0 },
+          ],
+        },
         hourly_distribution: Array.from({ length: 24 }, (_, i) => (i === 8 ? 4 : 0)),
         governance: {
           recent_allowed: 1,
@@ -665,6 +753,7 @@ test.describe('Admin Page', () => {
     await expect(page.locator('.debug-panel')).toContainText('Traffic Shape');
     await page.getByRole('navigation').getByRole('link', { name: 'Health' }).click();
     await expect(page.locator('.health-panel')).toContainText('0.17.7');
+    await expect(page.locator('.health-panel')).toContainText('json / dcc-mcp-byte4-v1');
   });
 
   test('shows platform-specific IDE config paths', async ({ page }) => {
@@ -729,11 +818,23 @@ test.describe('Admin Page', () => {
   test('opens trace detail from the calls panel and keeps the URL shareable', async ({ page }) => {
     await page.goto('/admin/');
     await page.getByRole('navigation').getByRole('link', { name: 'Calls' }).click();
+    const callsPanel = page.locator('.calls-panel');
+    await expect(callsPanel).toContainText('toon');
+    await expect(callsPanel).toContainText('40');
+    await expect(callsPanel).toContainText('60 (60.0%)');
+    await expect(callsPanel).toContainText('json');
+    await expect(callsPanel).toContainText('0 (0.0%)');
+    await expect(callsPanel).toContainText('req-legacy');
+    await expect(callsPanel.locator('tr', { hasText: 'req-legacy' })).toContainText('-');
     await page.getByRole('button', { name: 'req-123' }).click();
     await expect(page).toHaveURL(/panel=traces/);
     await expect(page).toHaveURL(/trace=req-123/);
     await expect(page.locator('.trace-detail-panel')).toContainText('req-123');
     await expect(page.locator('.trace-detail-panel')).toContainText('dispatch');
+    await expect(page.locator('.trace-detail-panel')).toContainText('Token accounting');
+    await expect(page.locator('.trace-detail-panel')).toContainText('dcc-mcp-byte4-v1');
+    await expect(page.locator('.trace-detail-panel')).toContainText('Returned40');
+    await expect(page.locator('.trace-detail-panel')).toContainText('Savings60.0%');
   });
 
   test('shows reconstructed tasks and links them to traces', async ({ page }) => {
@@ -772,9 +873,18 @@ test.describe('Admin Page', () => {
     await page.goto('/admin/?panel=stats&range=1h');
     await expect(page.locator('.stats-panel')).toBeVisible();
     await expect(page.getByLabel('Range')).toHaveValue('1h');
+    await expect(page.locator('.stats-panel')).toContainText('Returned tokens');
+    await expect(page.locator('.stats-panel')).toContainText('160');
+    await expect(page.locator('.stats-panel')).toContainText('Saved tokens');
+    await expect(page.locator('.stats-panel')).toContainText('140');
+    await expect(page.locator('.stats-panel')).toContainText('Token savings by transport');
+    await expect(page.locator('.stats-panel')).toContainText('rest');
+    await expect(page.locator('.stats-panel')).toContainText('json');
     await page.getByLabel('Range').selectOption('7d');
     await expect(page).toHaveURL(/range=7d/);
     await expect(page.locator('.stats-panel')).toContainText('Range 7d');
+    await page.getByLabel('Filter current panel').fill('rest');
+    await expect(page.locator('.stats-panel')).toContainText('rest');
   });
 
   test('shows governance controls and request decisions', async ({ page }) => {

--- a/crates/dcc-mcp-gateway/src/gateway/admin/activity.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/activity.rs
@@ -57,6 +57,8 @@ pub struct ActivityEvent {
     pub tool: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duration_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_accounting: Option<super::trace::TokenTelemetry>,
     pub correlation: ActivityCorrelation,
 }
 
@@ -279,6 +281,7 @@ fn audit_event(record: &AdminAuditRecord) -> ActivityEvent {
         ),
         tool: Some(record.action.clone()),
         duration_ms: record.duration_ms,
+        token_accounting: record.token_accounting.clone(),
         correlation: ActivityCorrelation {
             trace_id: record.trace_id.clone(),
             span_id: record.span_id.clone(),
@@ -309,6 +312,7 @@ fn trace_event(trace: &DispatchTrace) -> ActivityEvent {
         message: format!("{} completed in {}ms", tool, trace.total_ms),
         tool: Some(tool),
         duration_ms: Some(trace.total_ms),
+        token_accounting: trace.token_accounting.clone(),
         correlation: trace_correlation(trace),
     }
 }
@@ -332,6 +336,7 @@ fn gateway_event(event: &ContendEvent) -> ActivityEvent {
         }),
         tool: None,
         duration_ms: None,
+        token_accounting: None,
         correlation: ActivityCorrelation {
             trace_id: None,
             span_id: None,

--- a/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
@@ -20,6 +20,7 @@ use crate::gateway::capability::RefreshReason;
 use crate::gateway::capability_service::refresh_all_live_backends;
 use crate::gateway::event_log::{ContendEvent, EventKind};
 use crate::gateway::resilience::{self as gw_resilience, gateway_limits};
+use crate::gateway::response_codec::{JSON_MIME, TOKEN_ESTIMATOR, TOON_MIME};
 use dcc_mcp_db::env::ENV_DCC_MCP_LOG_DIR;
 use dcc_mcp_db::read_gateway_log_dir_rows_recent;
 use dcc_mcp_transport::discovery::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry};
@@ -657,6 +658,12 @@ pub async fn handle_admin_health(State(s): State<AdminState>) -> impl IntoRespon
             "uptime_secs": uptime_secs,
             "version": s.gateway.server_version,
             "rss_bytes": rss_bytes,
+            "response_format": {
+                "default": "json",
+                "legacy_mime": JSON_MIME,
+                "compact_mime": TOON_MIME,
+                "token_estimator": TOKEN_ESTIMATOR,
+            },
             "gateway": gateway_health_snapshot(&gateway_sentinels),
             "limits": {
                 "body_max_bytes": limits.body_max_bytes,
@@ -1198,6 +1205,11 @@ fn issue_report_json(request_id: &str, bundle: Value, links: Value) -> Value {
         .or_else(|| audit.get("duration_ms"))
         .cloned()
         .unwrap_or(Value::Null);
+    let token_accounting = trace
+        .get("token_accounting")
+        .or_else(|| audit.get("token_accounting"))
+        .cloned()
+        .unwrap_or(Value::Null);
     let trace_id = bundle
         .get("trace_id")
         .cloned()
@@ -1231,6 +1243,7 @@ fn issue_report_json(request_id: &str, bundle: Value, links: Value) -> Value {
             "tool": tool,
             "dcc_type": dcc_type,
             "total_ms": total_ms,
+            "token_accounting": token_accounting,
             "postmortem": {
                 "previous_call_count": previous_call_count,
                 "gateway_event_count": gateway_event_count,

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -484,6 +484,11 @@ redact:
         assert!(body.get("limits").is_some(), "expected limits object");
         assert!(body.get("circuits").is_some(), "expected circuits object");
         assert!(body.get("rss_bytes").is_some(), "expected rss_bytes field");
+        assert_eq!(body["response_format"]["default"], "json");
+        assert_eq!(
+            body["response_format"]["token_estimator"],
+            "dcc-mcp-byte4-v1"
+        );
     }
 
     // ── /api/tools ────────────────────────────────────────────────────────
@@ -928,7 +933,7 @@ redact:
             spans: vec![],
             input: None,
             output: None,
-            token_accounting: None,
+            token_accounting: Some(token_telemetry("toon", 100, 40)),
         });
         let state = AdminState::new(make_gateway_state())
             .with_audit_log(audit_log)
@@ -1158,7 +1163,7 @@ redact:
             spans: vec![],
             input: None,
             output: None,
-            token_accounting: None,
+            token_accounting: Some(token_telemetry("toon", 100, 40)),
         });
 
         let zero_id = SearchTelemetryStore::new_search_id();
@@ -1363,7 +1368,7 @@ redact:
             success: false,
             error: Some("host died".into()),
             duration_ms: Some(25),
-            token_accounting: None,
+            token_accounting: Some(token_telemetry("toon", 100, 40)),
         }]));
         let state = AdminState::new(gateway)
             .with_audit_log(audit_log)
@@ -1528,6 +1533,18 @@ redact:
         assert_eq!(
             report_body["summary"]["postmortem"]["gateway_event_count"],
             1
+        );
+        assert_eq!(
+            report_body["summary"]["token_accounting"]["response_format"],
+            "toon"
+        );
+        assert_eq!(
+            report_body["summary"]["token_accounting"]["returned_tokens"],
+            40
+        );
+        assert_eq!(
+            report_body["summary"]["token_accounting"]["saved_tokens"],
+            60
         );
         assert_eq!(report_body["debug_bundle"]["request_id"], "req-task");
         assert!(

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -110,7 +110,7 @@ Markdown body for developer review.
 | `GET /admin/api/governance?limit=300` | `application/json` | Effective gateway policy, traffic capture, redaction, middleware controls, and recent allow/deny/throttle decisions |
 | `GET /admin/api/workers` | `application/json` | Per-instance worker cards from the live registry |
 | `GET /admin/api/logs` | `application/json` | Merged gateway contention events, on-disk `*.log` rows, and audited call summaries |
-| `GET /admin/api/health` | `application/json` | Service health summary |
+| `GET /admin/api/health` | `application/json` | Service health summary, including active response-format defaults and token estimator metadata |
 | `GET /admin/api/skills` | `application/json` | Live skill inventory grouped by DCC type, skill name, load state, tools, and backend instance |
 | `GET /admin/api/skill-detail?name=...` | `application/json` | One skill's backend detail payload, including rendered-review `SKILL.md` markdown when available |
 | `GET /admin/api/skill-paths` | `application/json` | Current skill discovery roots, including environment, local defaults, bundled paths, and admin custom paths |
@@ -243,7 +243,13 @@ matching Scalar reference.
   "status": "ok",
   "uptime_secs": 3600,
   "instances_total": 3,
-  "instances_ready": 2
+  "instances_ready": 2,
+  "response_format": {
+    "default": "json",
+    "legacy_mime": "application/json",
+    "compact_mime": "application/toon",
+    "token_estimator": "dcc-mcp-byte4-v1"
+  }
 }
 
 // GET /admin/api/instances
@@ -479,6 +485,13 @@ matching Scalar reference.
     "tool": "maya.abcdef01.maya__open_scene",
     "dcc_type": "maya",
     "total_ms": 48,
+    "token_accounting": {
+      "response_format": "toon",
+      "token_estimator": "dcc-mcp-byte4-v1",
+      "returned_tokens": 54,
+      "saved_tokens": 66,
+      "savings_pct": 55.0
+    },
     "postmortem": {
       "previous_call_count": 1,
       "gateway_event_count": 0
@@ -507,9 +520,22 @@ matching Scalar reference.
   "latency_ms": { "p50_ms": 12, "p95_ms": 48 },
   "top_agents": [{ "name": "Layout Inspector", "count": 12 }],
   "token_usage": {
+    "total_original_tokens": 7500,
     "total_returned_tokens": 5400,
     "total_saved_tokens": 2100,
     "average_savings_pct": 28.0,
+    "by_tool": [
+      { "name": "maya.a1b2.render_preview", "calls": 8, "returned_tokens": 900, "saved_tokens": 700, "savings_pct": 43.75 }
+    ],
+    "by_instance": [
+      { "name": "maya-a1b2", "calls": 14, "returned_tokens": 1800, "saved_tokens": 900, "savings_pct": 33.33 }
+    ],
+    "by_agent": [
+      { "name": "Layout Inspector", "calls": 12, "returned_tokens": 1500, "saved_tokens": 820, "savings_pct": 35.34 }
+    ],
+    "by_transport": [
+      { "name": "rest", "calls": 18, "returned_tokens": 2500, "saved_tokens": 1300, "savings_pct": 34.21 }
+    ],
     "by_response_format": [
       { "name": "toon", "calls": 24, "returned_tokens": 3200, "saved_tokens": 2100, "savings_pct": 39.62 },
       { "name": "json", "calls": 18, "returned_tokens": 2200, "saved_tokens": 0, "savings_pct": 0.0 }

--- a/skills/dcc-mcp-skill-developer/SKILL.md
+++ b/skills/dcc-mcp-skill-developer/SKILL.md
@@ -118,6 +118,9 @@ into a faster authoring loop.
    fields (`response_format`, estimator, bytes, tokens, saved tokens, and
    savings percent) for both compact and legacy JSON traffic; tests should
    assert those fields without depending on full retained payload bodies.
+   Admin health exposes the active default response format and token estimator,
+   and default issue-report exports preserve bounded token accounting summaries
+   so debugging artefacts carry cost context without raw response bodies.
    Gateway OTLP spans mirror the same agent workflow chain with bounded
    attributes: `gateway.search`, `gateway.describe`, `gateway.load_skill`,
    `gateway.call`, and `gateway.call_batch` use `openinference.span.kind` plus


### PR DESCRIPTION
## Summary
- surface token accounting in Admin calls, traces, stats, health, and issue-report summaries
- add UI handling for compact, legacy JSON, and older rows missing token fields
- document token-savings admin payloads and update skill developer guidance

## Validation
- vx npm --prefix admin-ui run build
- vx npm --prefix admin-ui test -- --grep "loads the connect|opens trace detail|updates stats"
- vx cargo test -p dcc-mcp-gateway --features admin --lib
- vx cargo clippy -p dcc-mcp-gateway --all-targets --features admin -- -D warnings
- vx npm --prefix docs run docs:build

Closes #1156