### PR TITLE
feat: add unified dcc mcp creator skills

### DIFF
--- a/.github/clawhub-skills.json
+++ b/.github/clawhub-skills.json
@@ -6,5 +6,13 @@
   {
     "path": "skills/dcc-cli-gateway",
     "slug": "dcc-cli-gateway"
+  },
+  {
+    "path": "skills/dcc-mcp-skills-creator",
+    "slug": "dcc-mcp-skills-creator"
+  },
+  {
+    "path": "skills/dcc-mcp-creator",
+    "slug": "dcc-mcp-creator"
   }
 ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,18 +75,21 @@
 | Detailed rules | [`docs/guide/agents-reference.md`](docs/guide/agents-reference.md) | Before writing code — traps, do/don't, code style |
 | Conceptual docs | [`docs/guide/INDEX.md`](docs/guide/INDEX.md) + `docs/api/` | Building a new adapter or skill — see INDEX.md for topic list |
 | Skill authoring | `skills/README.md` + `examples/skills/` | Creating or modifying skills |
-| Skill developer guidance | [`skills/dcc-mcp-skill-developer/SKILL.md`](skills/dcc-mcp-skill-developer/SKILL.md) | After code changes that affect adapter skill authoring, tool schemas, server wiring, testing, or agent-facing workflows |
+| Adapter developer guidance | [`skills/dcc-mcp-creator/SKILL.md`](skills/dcc-mcp-creator/SKILL.md) | Before creating or changing DCC adapter server/runtime wiring, dispatcher bridges, readiness, resources, gateway behavior, or core-escalation plans |
+| Skill creator guidance | [`skills/dcc-mcp-skills-creator/SKILL.md`](skills/dcc-mcp-skills-creator/SKILL.md) | Before creating or changing adapter skill authoring, tool schemas, scripts, skill taxonomy, testing, or agent-facing workflows |
 | Gateway REST regressions (VRS) | [`tests/vrs/README.md`](tests/vrs/README.md) + `scripts/vrs_replay.py` | After gateway `/v1/*` or live-adapter bugs — add a JSONL trace per regression |
 
 ---
 
 ## Agent-Facing Skill Sync
 
-- After any code change, check whether the installed skill developer guidance
-  at `skills/dcc-mcp-skill-developer/SKILL.md` needs to change.
-- If the change affects public APIs, adapter/server wiring, skill authoring
-  rules, tool/resource/prompt schemas, testing expectations, or agent workflow,
-  update that `SKILL.md` in the same PR.
+- After any code change, check whether the installed adapter and skill guidance
+  in `skills/dcc-mcp-creator/` or
+  `skills/dcc-mcp-skills-creator/` needs to change.
+- If the change affects public APIs, adapter/server wiring, dispatcher
+  contracts, readiness, resources, gateway behavior, skill authoring rules,
+  tool/resource/prompt schemas, testing expectations, or agent workflow, update
+  the relevant skill guidance in the same PR.
 - If no update is needed, mention that explicitly in the PR validation notes.
 
 ## Quick Orientation

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -49,6 +49,14 @@
         },
         {
           "type": "generic",
+          "path": "skills/dcc-mcp-skills-creator/SKILL.md"
+        },
+        {
+          "type": "generic",
+          "path": "skills/dcc-mcp-creator/SKILL.md"
+        },
+        {
+          "type": "generic",
           "path": "docs/.vitepress/config.mts"
         },
         {

--- a/skills/README.md
+++ b/skills/README.md
@@ -13,8 +13,18 @@ Official skills and starter templates for the dcc-mcp-core ecosystem.
 |-------|-------------|----------|
 | [`dcc-rest-gateway`](dcc-rest-gateway/) | Control any DCC via gateway REST only (no MCP); instance inventory and zero-instance setup | `skills/dcc-rest-gateway/` |
 | [`dcc-cli-gateway`](dcc-cli-gateway/) | Control any DCC through `dcc-mcp-cli`; instance inventory, search, describe, and call workflow | `skills/dcc-cli-gateway/` |
-| [`dcc-skills-creator`](dcc-skills-creator/) | Create, validate, and scaffold DCC skills | `skills/dcc-skills-creator/` |
-| [`dcc-mcp-skill-developer`](dcc-mcp-skill-developer/) | Guide agents through DCC-MCP adapter skill design, implementation, and testing | `skills/dcc-mcp-skill-developer/` |
+| [`dcc-mcp-skills-creator`](dcc-mcp-skills-creator/) | Create, validate, scaffold, and review DCC-MCP skill packages | `skills/dcc-mcp-skills-creator/` |
+| [`dcc-mcp-creator`](dcc-mcp-creator/) | Guide developers and agents through full DCC-MCP adapter creation and modernization | `skills/dcc-mcp-creator/` |
+
+### Compatibility Entries
+
+Older entrypoints remain available for existing users while new guidance should
+prefer the unified names above:
+
+| Skill | Preferred Entry |
+|-------|-----------------|
+| [`dcc-skills-creator`](dcc-skills-creator/) | [`dcc-mcp-skills-creator`](dcc-mcp-skills-creator/) |
+| [`dcc-mcp-skill-developer`](dcc-mcp-skill-developer/) | [`dcc-mcp-skills-creator`](dcc-mcp-skills-creator/) |
 
 ### Install and validate
 
@@ -37,13 +47,13 @@ python -c "from dcc_mcp_core import validate_skill; print(validate_skill('skills
 
 ## Quick Start
 
-### Using the dcc-skills-creator
+### Using the dcc-mcp-skills-creator
 
 ```bash
 # Add the skills directory to your path
 export DCC_MCP_SKILL_PATHS="/path/to/dcc-mcp-core/skills"
 
-# Start the MCP server — dcc-skills-creator appears in tools/list
+# Start the MCP server. dcc-mcp-skills-creator appears in tools/list.
 python -c "
 from dcc_mcp_core import create_skill_server, McpHttpConfig
 server = create_skill_server('maya', McpHttpConfig(port=8765))
@@ -298,7 +308,8 @@ skills shipped in `examples/skills/`, or browse them directly:
 | [ffmpeg-media](../examples/skills/ffmpeg-media/) | infrastructure | python | External binary deps |
 | [imagemagick-tools](../examples/skills/imagemagick-tools/) | infrastructure | python | OpenClaw install |
 | [git-automation](../examples/skills/git-automation/) | infrastructure | python | OpenClaw format |
-| [dcc-mcp-skill-developer](dcc-mcp-skill-developer/) | infrastructure | python | Adapter skill authoring guidance |
+| [dcc-mcp-skills-creator](dcc-mcp-skills-creator/) | infrastructure | python | Skill package creation, validation, and authoring guidance |
+| [dcc-mcp-creator](dcc-mcp-creator/) | infrastructure | python | Adapter repository creation, runtime, and core-escalation guidance |
 | [maya-geometry](../examples/skills/maya-geometry/) | domain | maya | Tool groups |
 | [maya-pipeline](../examples/skills/maya-pipeline/) | domain | maya | Dependencies + metadata/ |
 
@@ -321,6 +332,11 @@ paths = get_bundled_skill_paths()  # [".../dcc_mcp_core/skills"]
 
 Building a new MCP adapter for a DCC application? See the
 **[Integration Guide](integration-guide.md)** for complete architecture patterns:
+For agent-facing execution guidance, load
+[`dcc-mcp-creator`](dcc-mcp-creator/) before changing
+adapter server/runtime code, and load
+[`dcc-mcp-skills-creator`](dcc-mcp-skills-creator/) before changing bundled
+skill packages.
 
 | Architecture | For | Base Class | Examples |
 |---|---|---|---|

--- a/skills/dcc-mcp-creator/SKILL.md
+++ b/skills/dcc-mcp-creator/SKILL.md
@@ -6,14 +6,14 @@ description: >-
   ZBrush, Houdini, Maya, and custom studio tools. Use when building server,
   dispatcher, gateway, packaging, and runtime integration. Not for authoring
   individual SKILL.md tool packages - use dcc-mcp-skills-creator.
-license: MIT
+license: MIT-0
 compatibility: "dcc-mcp-core 0.17+, Python 3.7+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:
     dcc: python
     layer: infrastructure
-    version: "1.0.0"
+    version: "0.17.30"  # x-release-please-version
     search-hint: >-
       create DCC MCP adapter, Nuke MCP, DccServerBase, HostExecutionBridge,
       dispatcher, readiness, resources, gateway, Blender, 3ds Max, Unreal,
@@ -21,6 +21,8 @@ metadata:
     tags: "adapter-development, host-runtime, dispatcher, gateway, nuke, blender, 3dsmax, unreal, zbrush"
     skill-reference-docs:
       - "references/*.md"
+  openclaw:
+    homepage: https://github.com/loonghao/dcc-mcp-core/blob/main/skills/dcc-mcp-creator/SKILL.md
 ---
 
 # DCC-MCP Creator

--- a/skills/dcc-mcp-creator/SKILL.md
+++ b/skills/dcc-mcp-creator/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: dcc-mcp-creator
+description: >-
+  Infrastructure skill - guide developers and agents through creating or
+  modernizing a full DCC-MCP adapter for Nuke, Blender, 3ds Max, Unreal,
+  ZBrush, Houdini, Maya, and custom studio tools. Use when building server,
+  dispatcher, gateway, packaging, and runtime integration. Not for authoring
+  individual SKILL.md tool packages - use dcc-mcp-skills-creator.
+license: MIT
+compatibility: "dcc-mcp-core 0.17+, Python 3.7+"
+allowed-tools: Bash Read Write Edit
+metadata:
+  dcc-mcp:
+    dcc: python
+    layer: infrastructure
+    version: "1.0.0"
+    search-hint: >-
+      create DCC MCP adapter, Nuke MCP, DccServerBase, HostExecutionBridge,
+      dispatcher, readiness, resources, gateway, Blender, 3ds Max, Unreal,
+      ZBrush, Houdini, Maya
+    tags: "adapter-development, host-runtime, dispatcher, gateway, nuke, blender, 3dsmax, unreal, zbrush"
+    skill-reference-docs:
+      - "references/*.md"
+---
+
+# DCC-MCP Creator
+
+Use this skill when you are creating a new DCC-MCP adapter or modernizing an
+existing adapter repository: server composition, host-thread dispatch,
+sidecar/gateway wiring, readiness, resources, project state, diagnostics,
+install lifecycle, or cross-DCC verification.
+
+For individual skill packages (`SKILL.md`, `tools.yaml`, scripts, groups, and
+skill taxonomy), load `dcc-mcp-skills-creator` instead.
+
+## Fast Workflow
+
+1. Classify the host integration:
+   - Embedded Python host: Blender, 3ds Max Python, Houdini, Maya, Nuke.
+   - External bridge host: ZBrush, Photoshop, Unity, custom tools.
+   - Game/editor host with mixed Python or C++ bridge: Unreal, Unity.
+2. Read the relevant reference:
+   - [ADAPTER_WORKFLOW.md](references/ADAPTER_WORKFLOW.md) for the build path.
+   - [HOST_PATTERN_MATRIX.md](references/HOST_PATTERN_MATRIX.md) for host-specific wiring.
+   - [CORE_ESCALATION_CHECKLIST.md](references/CORE_ESCALATION_CHECKLIST.md) before adding adapter-local glue.
+   - [TESTING_AND_RELEASE.md](references/TESTING_AND_RELEASE.md) before validating or publishing.
+3. Start from `DccServerBase` + `DccServerOptions.from_env(...)`.
+4. Route host API calls through `HostExecutionBridge`; do not hand-roll a second script executor.
+5. Keep DCC identity data-driven: `dcc_name`, `server_name`, env-var prefix, skill names, and gateway metadata.
+6. Use core helpers for skill discovery, `MinimalModeConfig`, project tools, resources, diagnostics, context snapshots, install lifecycle, and gateway failover before writing adapter-local wrappers.
+7. When the adapter needs a lifecycle hook or metadata transform that core cannot express, open a focused core issue/RFC instead of parsing YAML or mutating private state in the adapter.
+8. Add one executable smoke path: unit tests for construction plus either headless DCC, mock dispatcher MCP calls, or gateway REST replay.
+
+## Example: New Nuke Adapter
+
+When asked to create a Nuke MCP adapter, start by mapping the host lifecycle:
+how Python is loaded, how the UI/main thread must be entered, what headless
+mode is available, how plugins are installed, and which operations should be
+bundled as default skills. Then scaffold the adapter around core primitives:
+
+- `DccServerBase` for MCP/HTTP and skill catalog behavior.
+- `DccServerOptions.from_env("NUKE")` or an adapter-specific equivalent for env-driven configuration.
+- `HostExecutionBridge` plus a Nuke dispatcher for all Nuke API calls.
+- Core project, readiness, resource, diagnostics, and gateway helpers before adapter-local glue.
+- `dcc-mcp-skills-creator` for the first `nuke-*` skill packages.
+
+## Non-Negotiables
+
+- Do not touch a DCC API from a Tokio/HTTP worker thread.
+- Do not parse or rewrite `SKILL.md`, `tools.yaml`, `groups.yaml`, or prompt/workflow files in adapter runtime code when core exposes a typed object or catalog API.
+- Do not reach into `server._server` unless no public core API exists; if you must, file a core issue and keep the adapter shim small.
+- Do not create Maya-only abstractions in shared core or adapter templates.
+- Do not expose raw script execution as the primary user workflow when a typed skill can cover the task.
+- Do not publish local paths, private machine names, or source-attribution markers in public issues or PR text.

--- a/skills/dcc-mcp-creator/references/ADAPTER_WORKFLOW.md
+++ b/skills/dcc-mcp-creator/references/ADAPTER_WORKFLOW.md
@@ -1,0 +1,99 @@
+# Adapter Workflow
+
+Use this reference to build a new adapter or simplify an existing one.
+
+## 1. Choose the Runtime Shape
+
+Use the smallest shape that can honestly run the host API:
+
+| Host shape | Typical DCCs | Recommended path |
+|---|---|---|
+| Embedded Python, GUI | Blender, Houdini, Maya, 3ds Max Python | `DccServerBase` with `HostExecutionBridge` and a host dispatcher |
+| Embedded Python, headless | mayapy, Blender background, Houdini hython | `DccServerBase` with inline or blocking dispatcher |
+| External bridge | ZBrush, Photoshop, Unity, proprietary tools | `DccServerBase` plus IPC/WebSocket/HTTP bridge helpers |
+| Editor/game engine | Unreal, Unity | Adapter-owned plugin bridge plus typed skill tools; keep Python optional |
+
+## 2. Build the Composition Root
+
+Adapter server modules should be composition roots, not utility bins. Keep them
+responsible for wiring only:
+
+- Resolve options with `DccServerOptions.from_env(...)`.
+- Pass the adapter's bundled `skills/` directory.
+- Attach `HostExecutionBridge` before skill discovery.
+- Register resources, project tools, diagnostics, prompts, and adapter
+  instruction resources before `start()`.
+- Keep `start_server()` and `stop_server()` thin wrappers.
+
+Minimal skeleton:
+
+```python
+from pathlib import Path
+
+from dcc_mcp_core import DccServerBase, DccServerOptions, HostExecutionBridge
+
+
+class MyDccServer(DccServerBase):
+    def __init__(self, port: int = 8765, dispatcher=None, **kwargs):
+        bridge = HostExecutionBridge(dispatcher=dispatcher) if dispatcher else None
+        options = DccServerOptions.from_env(
+            "mydcc",
+            Path(__file__).parent / "skills",
+            port=port,
+            execution_bridge=bridge,
+            **kwargs,
+        )
+        super().__init__(options=options)
+
+    def _version_string(self) -> str:
+        return "unknown"
+```
+
+## 3. Add Progressive Skills
+
+Use `MinimalModeConfig` for startup policy:
+
+```python
+from dcc_mcp_core import MinimalModeConfig
+
+minimal = MinimalModeConfig(
+    skills=("mydcc-scripting", "mydcc-scene"),
+    deactivate_groups={"mydcc-scene": ("heavy",)},
+    env_var_minimal="DCC_MCP_MYDCC_MINIMAL",
+    env_var_default_tools="DCC_MCP_MYDCC_DEFAULT_TOOLS",
+)
+server.register_builtin_actions(minimal_mode=minimal)
+```
+
+Only eager-load the skills needed for discovery, diagnostics, and a first useful
+scene query. Leave authoring, render, export, and pipeline skills loadable on
+demand.
+
+## 4. Publish Adapter Context
+
+Prefer core-owned surfaces:
+
+- `set_context_snapshot_provider(...)` for post-tool scene/document context.
+- `register_adapter_instructions(...)` for adapter instruction resources.
+- `register_project_tools(...)` for resumable project state.
+- `server.resources()` or a public resource binder when available.
+- `plugin_manifest(...)` for machine-readable install metadata.
+
+If a needed adapter context requires private inner-server access, keep the shim
+in one adapter-local module and open a core issue.
+
+## 5. Decide What Belongs in Core
+
+Escalate to core when more than one adapter would need the same helper:
+
+- skill metadata lifecycle hooks;
+- host-thread readiness bits;
+- resource registration patterns;
+- sidecar/install lifecycle;
+- gateway search/describe/call response shape;
+- app UI automation contracts;
+- file/artifact handoff;
+- diagnostics and issue-report exports.
+
+Adapter repositories should contain host facts and host API calls. Core should
+own reusable MCP, gateway, catalog, lifecycle, and wire contracts.

--- a/skills/dcc-mcp-creator/references/CORE_ESCALATION_CHECKLIST.md
+++ b/skills/dcc-mcp-creator/references/CORE_ESCALATION_CHECKLIST.md
@@ -1,0 +1,60 @@
+# Core Escalation Checklist
+
+Use this before adding adapter-local framework code. If the answer is "yes" for
+two or more adapters, prefer a core issue/RFC.
+
+## Escalate to Core
+
+Open a core issue when the adapter needs:
+
+- a lifecycle hook around skill discovery, skill load, unload, group activation,
+  resource subscription, client initialize, or tool dispatch;
+- a typed skill object transform that must apply to programmatic, MCP, REST, and
+  gateway load paths;
+- a public `DccServerBase` wrapper over a private inner server API;
+- a reusable resource/prompt/project registration pattern;
+- a readiness bit or health check shared by host dispatchers;
+- a gateway search/describe/call response field;
+- install, uninstall, or sidecar lifecycle behavior;
+- cross-DCC app UI automation contracts;
+- common artefact/file handoff and retention behavior;
+- policy, audit, telemetry, or debug bundle fields.
+
+## Keep Local to the Adapter
+
+Keep code adapter-local when it is only:
+
+- the host's import path, version query, or startup hook;
+- the exact host API call, such as `bpy.ops`, `pymxs.runtime`, or Unreal editor APIs;
+- a DCC-specific menu, shelf, plugin, or bootstrap script;
+- domain tool behavior that belongs to one DCC skill package;
+- a studio-specific deployment policy.
+
+## Current Core Requests From Adapter Review
+
+- [RFC: add adapter skill-load transform hooks](https://github.com/loonghao/dcc-mcp-core/issues/1204): adapters need a core-owned hook so metadata transforms apply consistently to programmatic `load_skill`, MCP `load_skill`, REST `/v1/load_skill`, and gateway-mediated loads.
+- [RFC: expose public DccServerBase resource registration surface](https://github.com/loonghao/dcc-mcp-core/issues/1205): adapters need a public resource handle/helper instead of private inner-server access.
+- [RFC: add reusable adapter readiness binder](https://github.com/loonghao/dcc-mcp-core/issues/1206): embedded adapters need a shared readiness binder for process, dispatcher, host-execution, main-thread, and DCC-ready state.
+
+## Issue Template
+
+```markdown
+## Problem
+
+Describe the adapter-local code that should not be repeated in every DCC repo.
+
+## Requested Core Surface
+
+- API name or shape.
+- Which load/call/resource/readiness paths it must cover.
+- Expected error and observability behavior.
+
+## Acceptance Criteria
+
+- At least one Python adapter test.
+- At least one MCP or REST path test when the behavior crosses HTTP.
+- Backward compatibility notes for existing adapters.
+```
+
+Public issue text must be portable. Do not include local paths, private
+hostnames, machine-specific logs, or source-attribution markers.

--- a/skills/dcc-mcp-creator/references/HOST_PATTERN_MATRIX.md
+++ b/skills/dcc-mcp-creator/references/HOST_PATTERN_MATRIX.md
@@ -1,0 +1,36 @@
+# Host Pattern Matrix
+
+Use this table when choosing adapter runtime wiring for a new DCC.
+
+| DCC family | Host API | Dispatcher approach | Notes |
+|---|---|---|---|
+| Blender | `bpy` | GUI timers or background blocking dispatcher | Keep `bpy` imports lazy so discovery works outside Blender. |
+| 3ds Max | `pymxs` / MaxPlus | Main-thread dispatcher; Python entry from startup scripts or plugin bootstrap | Treat scene mutations as main-thread-only unless proven safe. |
+| Unreal | Python, C++ plugin, or remote control | Prefer an editor plugin bridge; use Python only where deployed | Long operations should become async jobs with progress/cancellation. |
+| ZBrush | ZScript, GoZ, HTTP/IPC helper | External bridge; no embedded Python assumption | Keep bridge commands typed and bounded; avoid generic remote execution. |
+| Houdini | `hou` | Event-loop callback or headless hython dispatcher | Node graph writes are main-thread-sensitive. |
+| Maya | `maya.cmds` / OpenMaya | UI dispatcher in GUI; standalone serialized dispatcher in mayapy | Do not special-case Maya patterns into core without parameterizing host identity. |
+| Photoshop / Adobe | UXP/CEP/ExtendScript | External bridge or app UI contract | Use structured bridge calls; do not depend on a Python-in-host runtime. |
+| Custom studio tool | Python, socket, HTTP, or CLI | Start with the least-powerful bridge that can satisfy typed tools | Document auth, scope, and shutdown behavior up front. |
+
+## Host API Rules
+
+- Import host modules inside callables or skill script entry points, never at
+  package import time.
+- Mark scene-touching tools `affinity: main`.
+- Use `affinity: any` only for pure file, validation, serialization, or metadata
+  operations.
+- If a tool can exceed two seconds, declare `execution: async` and a realistic
+  `timeout_hint_secs`.
+- Long host loops must check core cancellation where available.
+- Every bridge path must normalize arguments and return structured envelopes.
+
+## Dispatcher Smoke Tests
+
+Each adapter should have at least one smoke that proves:
+
+- the server starts without a GUI import at discovery time;
+- a main-affinity tool runs through the host dispatcher, not the HTTP worker;
+- a pure `any` tool can run without blocking the host UI;
+- cancellation or timeout produces a structured error;
+- gateway REST or direct MCP can search, load, describe, and call one typed tool.

--- a/skills/dcc-mcp-creator/references/TESTING_AND_RELEASE.md
+++ b/skills/dcc-mcp-creator/references/TESTING_AND_RELEASE.md
@@ -1,0 +1,57 @@
+# Testing And Release
+
+Use the smallest test that proves the adapter contract, then add one live or
+HTTP-level smoke when behavior crosses process boundaries.
+
+## Test Layers
+
+| Layer | What to prove |
+|---|---|
+| Unit | option resolution, server construction, env vars, skill path collection |
+| Dispatcher | main-affinity calls run on the host dispatcher and return envelopes |
+| Skill lifecycle | `search_skills` -> `load_skill` -> typed tool -> `unload_skill` |
+| REST/MCP | direct `/mcp` or `/v1/*` search, describe, load, and call |
+| Gateway | multi-instance routing, policy, compact responses, debug traces |
+| Live DCC | one host smoke that creates/queries/cleans up real scene state |
+| Packaging | wheel or plugin archive installs into the target host runtime |
+
+## Validation Commands
+
+Prefer repository-native commands. For Python projects, prefer `vx uv` when it
+is available in the environment, then fall back to direct Python only when the
+wrapper is unavailable or hides behavior you need to inspect.
+
+Typical gates:
+
+```bash
+python -m ruff check src tests
+python -m ruff format --check src tests
+python -m pytest
+```
+
+For Rust/PyO3 core changes, run the workspace's `just` or `cargo` gates that
+match the touched crates.
+
+## Live-DCC Smoke Shape
+
+Every adapter should eventually provide one documented smoke:
+
+1. Start the DCC host in the supported mode.
+2. Start or load the adapter.
+3. Discover one skill.
+4. Load it.
+5. Call one safe typed tool.
+6. Verify host-visible state.
+7. Stop the adapter and ensure registry rows are gone.
+
+If CI cannot run the real DCC, keep the mock HTTP test in CI and document the
+manual live smoke command in the adapter repository.
+
+## PR Notes
+
+PR descriptions should include:
+
+- short summary of runtime or skill behavior changed;
+- validation commands, without machine-specific paths;
+- any live-DCC gap that remains;
+- linked core issues for deferred shared APIs.

--- a/skills/dcc-mcp-skill-developer/SKILL.md
+++ b/skills/dcc-mcp-skill-developer/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: dcc-mcp-skill-developer
 description: >-
-  Infrastructure skill - guide agents through designing, implementing, testing,
-  and reviewing DCC-MCP adapter skill packages for Maya, Blender, 3ds Max,
-  Houdini, Photoshop, ZBrush, Unreal, Unity, and custom studio hosts. Use when
-  adding or changing SKILL.md, tools.yaml, scripts, server wiring, or adapter
-  skill taxonomy in dcc-mcp-* repositories. Not for driving a live DCC scene -
-  use domain skills or dcc-cli-gateway for that.
+  Compatibility skill - legacy guide for designing, implementing, testing, and
+  reviewing DCC-MCP skill packages. Prefer dcc-mcp-skills-creator for new skill
+  package work. Not for full adapter server/runtime work - use dcc-mcp-creator.
 license: MIT
 compatibility: "dcc-mcp-core 0.17+, Python 3.7+"
 allowed-tools: Bash Read Write Edit
@@ -16,14 +13,18 @@ metadata:
     layer: infrastructure
     version: "1.0.0"
     search-hint: >-
-      develop dcc-mcp skill, adapter skill authoring, tools.yaml, SKILL.md,
-      Maya Blender 3ds Max, affinity, execution, stage taxonomy, gateway
-    tags: "skill-authoring, adapter, maya, blender, 3dsmax, future-dcc"
+      legacy dcc-mcp skill developer, skill package authoring, tools.yaml,
+      SKILL.md, affinity, execution, stage taxonomy
+    tags: "skill-authoring, compatibility, maya, blender, 3dsmax, future-dcc"
     skill-reference-docs:
       - "references/*.md"
 ---
 
 # DCC-MCP Skill Developer
+
+Compatibility entrypoint. Prefer `dcc-mcp-skills-creator` for new DCC-MCP
+skill package work, and use `dcc-mcp-creator` for full adapter repository or
+server/runtime work.
 
 Use this skill when you are changing or creating DCC-MCP adapter skill packages.
 It distills patterns from dcc-mcp-maya, dcc-mcp-blender, and dcc-mcp-3dsmax
@@ -31,8 +32,9 @@ into a faster authoring loop.
 
 ## Fast Workflow
 
-1. Classify the work: new host adapter, new domain skill, new infrastructure
-   skill, or porting an existing skill to another DCC.
+1. Classify the work. For a full host adapter or server/runtime change, switch
+   to `dcc-mcp-creator`; continue here only for domain skills, infrastructure
+   skills, or porting an existing skill to another DCC.
 2. Read only the reference you need:
    - [ADAPTER_PATTERNS.md](references/ADAPTER_PATTERNS.md) for server and
      composition-root patterns.

--- a/skills/dcc-mcp-skills-creator/SKILL.md
+++ b/skills/dcc-mcp-skills-creator/SKILL.md
@@ -98,9 +98,9 @@ my-skill/
 |-- tools.yaml            # Required when metadata.dcc-mcp.tools points here
 |-- scripts/              # Optional: tool implementation scripts
 |   `-- create_locator.py
-`-- metadata/             # Optional: documentation and dependencies
-    |-- depends.md
-    `-- help.md
+`-- references/           # Optional: recipes, examples, and long-form docs
+    |-- RECIPES.md
+    `-- NOTES.md
 ```
 
 ## Current Tool Contract
@@ -141,5 +141,5 @@ The validator checks:
 - **Tool declarations**: non-empty names, no duplicates, snake_case client-safe format
 - **Script files**: `source_file` references exist in `scripts/`
 - **Sidecar files**: `metadata.dcc-mcp.tools/groups/prompts` references exist
-- **Dependencies**: `depends` vs `metadata/depends.md` consistency
+- **Dependencies**: `metadata.dcc-mcp.depends` consistency
 - **Spec compliance**: non-standard top-level keys are frontmatter errors; dcc-mcp-core extensions must live under `metadata.dcc-mcp.*` and point to sibling files

--- a/skills/dcc-mcp-skills-creator/SKILL.md
+++ b/skills/dcc-mcp-skills-creator/SKILL.md
@@ -1,9 +1,10 @@
 ---
-name: dcc-skills-creator
+name: dcc-mcp-skills-creator
 description: >-
-  Compatibility skill - legacy entrypoint for creating, validating, and
-  scaffolding DCC-MCP skills. Prefer dcc-mcp-skills-creator for new work.
-  Not for creating full adapter repositories - use dcc-mcp-creator.
+  Infrastructure skill - create, validate, scaffold, and review DCC-MCP skills
+  for the dcc-mcp-core ecosystem. Use when authoring SKILL.md, tools.yaml,
+  scripts, groups, prompts, or skill taxonomy. Not for creating a full DCC-MCP
+  adapter repository - use dcc-mcp-creator.
 license: MIT
 compatibility: "Python 3.7+, dcc-mcp-core 0.17+"
 allowed-tools: Bash Read Write Edit
@@ -12,19 +13,23 @@ metadata:
     dcc: python
     version: "1.0.0"
     layer: infrastructure
-    search-hint: "legacy skill creator, create skill, validate skill, scaffold skill, SKILL.md, tools.yaml"
+    search-hint: "create dcc mcp skill, validate skill, scaffold skill, SKILL.md, tools.yaml, scripts, groups, prompts, skill taxonomy"
     tools: tools.yaml
+    skill-reference-docs:
+      - "references/*.md"
 ---
 
-# DCC Skills Creator
+# DCC-MCP Skills Creator
 
-Compatibility entrypoint. Prefer `dcc-mcp-skills-creator` for new work; it
-combines this scaffold/validation tooling with the DCC-MCP skill authoring
-workflow.
+A first-class meta-skill for creating, validating, and reviewing DCC-MCP skill
+packages. It combines the scaffold/validation tools from `dcc-skills-creator`
+with agent-facing authoring guidance for `SKILL.md`, `tools.yaml`, scripts,
+groups, prompts, and progressive-loading taxonomy.
 
-A first-class meta-skill for creating and validating DCC skills in the dcc-mcp-core ecosystem.
-It emits the current `metadata.dcc-mcp.*` layout, sibling `tools.yaml`, explicit
-schemas, annotations, execution mode, and thread-affinity metadata.
+Use `dcc-mcp-creator` when the task is to create a full adapter repository for
+a host such as Nuke, Blender, 3ds Max, Unreal, ZBrush, Houdini, or Maya. Use
+this skill when the task is to create or improve the skill packages loaded by
+those adapters.
 
 ## Installation
 
@@ -56,7 +61,7 @@ server = create_skill_server(
 
 ```python
 # Call the loaded MCP tool:
-# dcc_skills_creator__create_skill(
+# dcc_mcp_skills_creator__create_skill(
 #     name="maya-rigging",
 #     parent_dir="/path/to/skills/dir",
 #     dcc="maya",
@@ -82,20 +87,20 @@ else:
 
 ```python
 # Call the loaded MCP tool:
-# dcc_skills_creator__skill_template()
+# dcc_mcp_skills_creator__skill_template()
 ```
 
 ## Skill Directory Structure
 
 ```
 my-skill/
-├── SKILL.md              # Required: metadata frontmatter + instructions
-├── tools.yaml            # Required when metadata.dcc-mcp.tools points here
-├── scripts/              # Optional: tool implementation scripts
-│   └── create_locator.py
-└── metadata/             # Optional: documentation and dependencies
-    ├── depends.md
-    └── help.md
+|-- SKILL.md              # Required: metadata frontmatter + instructions
+|-- tools.yaml            # Required when metadata.dcc-mcp.tools points here
+|-- scripts/              # Optional: tool implementation scripts
+|   `-- create_locator.py
+`-- metadata/             # Optional: documentation and dependencies
+    |-- depends.md
+    `-- help.md
 ```
 
 ## Current Tool Contract
@@ -110,6 +115,20 @@ Generated `tools.yaml` entries follow the modern contract:
 - `enforce_thread_affinity: true` is emitted so adapter dispatch stays honest.
 - `annotations` use MCP hints: read-only, destructive, idempotent, open-world, and deferred.
 
+## Authoring Workflow
+
+1. Decide whether the skill is infrastructure, domain, thin-harness, or example.
+2. Give the skill a kebab-case name and each local tool a snake_case name.
+3. Keep host API calls inside scripts, with lazy imports so discovery works without the host running.
+4. Declare `execution`, `affinity`, `timeout_hint_secs`, schemas, annotations, and failure recovery chains in `tools.yaml`.
+5. Put long examples, recipes, and host-specific notes under `references/`.
+6. Validate with `validate_skill_dir` or `dcc_mcp_core.validate_skill()` before loading it in an adapter.
+7. If the desired behavior requires parsing core internals or adapter-private YAML at runtime, stop and request a core API instead.
+
+Read [AUTHORING_WORKFLOW.md](references/AUTHORING_WORKFLOW.md) and
+[DCC_TOOL_CONTRACTS.md](references/DCC_TOOL_CONTRACTS.md) before changing a
+production skill package.
+
 ## Validation Rules
 
 The validator checks:
@@ -117,8 +136,8 @@ The validator checks:
 - **SKILL.md** exists and is readable
 - **YAML frontmatter** is well-formed
 - **Required fields**: `name`, `description`
-- **Name format**: kebab-case, ≤64 chars, matches directory name
-- **Field lengths**: description ≤1024, compatibility ≤500
+- **Name format**: kebab-case, <=64 chars, matches directory name
+- **Field lengths**: description <=1024, compatibility <=500
 - **Tool declarations**: non-empty names, no duplicates, snake_case client-safe format
 - **Script files**: `source_file` references exist in `scripts/`
 - **Sidecar files**: `metadata.dcc-mcp.tools/groups/prompts` references exist

--- a/skills/dcc-mcp-skills-creator/SKILL.md
+++ b/skills/dcc-mcp-skills-creator/SKILL.md
@@ -5,18 +5,20 @@ description: >-
   for the dcc-mcp-core ecosystem. Use when authoring SKILL.md, tools.yaml,
   scripts, groups, prompts, or skill taxonomy. Not for creating a full DCC-MCP
   adapter repository - use dcc-mcp-creator.
-license: MIT
+license: MIT-0
 compatibility: "Python 3.7+, dcc-mcp-core 0.17+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:
     dcc: python
-    version: "1.0.0"
+    version: "0.17.30"  # x-release-please-version
     layer: infrastructure
     search-hint: "create dcc mcp skill, validate skill, scaffold skill, SKILL.md, tools.yaml, scripts, groups, prompts, skill taxonomy"
     tools: tools.yaml
     skill-reference-docs:
       - "references/*.md"
+  openclaw:
+    homepage: https://github.com/loonghao/dcc-mcp-core/blob/main/skills/dcc-mcp-skills-creator/SKILL.md
 ---
 
 # DCC-MCP Skills Creator

--- a/skills/dcc-mcp-skills-creator/references/AUTHORING_WORKFLOW.md
+++ b/skills/dcc-mcp-skills-creator/references/AUTHORING_WORKFLOW.md
@@ -1,0 +1,40 @@
+# DCC-MCP Skill Authoring Workflow
+
+Use this workflow when creating or modernizing a skill package that will be
+loaded by a DCC-MCP adapter.
+
+## 1. Pick The Right Scope
+
+- Use `infrastructure` for reusable primitives shared across hosts.
+- Use `domain` for host or workflow-specific operations, such as `nuke-comp` or `maya-geometry`.
+- Use `thin-harness` for a deliberately small raw scripting fallback with recipes.
+- Use `example` for authoring references that should not be loaded in production.
+
+If the task is to create the adapter repository itself, switch to
+`dcc-mcp-creator`.
+
+## 2. Shape Discovery First
+
+Agents find skills from `name`, `description`, and `metadata.dcc-mcp.search-hint`.
+Keep those fields concrete:
+
+- Say what the skill does.
+- Say when to use it.
+- Say when not to use it, and name the better skill when one exists.
+
+## 3. Keep Runtime Scripts Host-Safe
+
+Scripts should lazy-import host APIs inside the callable function. This keeps
+catalog discovery, validation, and server startup available without a running
+host process.
+
+Use host-thread affinity only where needed:
+
+- `affinity: main` for host API calls and scene mutations.
+- `affinity: any` for pure filesystem, math, parsing, or metadata work.
+
+## 4. Validate Before Loading
+
+Run the creator validation tool or `dcc_mcp_core.validate_skill()` before adding
+the skill to an adapter's default path. Treat validation warnings as design
+feedback, not only syntax feedback.

--- a/skills/dcc-mcp-skills-creator/references/AUTHORING_WORKFLOW.md
+++ b/skills/dcc-mcp-skills-creator/references/AUTHORING_WORKFLOW.md
@@ -22,6 +22,11 @@ Keep those fields concrete:
 - Say when to use it.
 - Say when not to use it, and name the better skill when one exists.
 
+The `metadata:` configuration block belongs in `SKILL.md` frontmatter. Put
+DCC-MCP extension pointers such as `tools`, `prompts`, `recipes`, `workflows`,
+and `depends` under `metadata.dcc-mcp.*`. Use `references/` for long-form docs,
+recipes, examples, and notes that agents should load only when needed.
+
 ## 3. Keep Runtime Scripts Host-Safe
 
 Scripts should lazy-import host APIs inside the callable function. This keeps

--- a/skills/dcc-mcp-skills-creator/references/DCC_TOOL_CONTRACTS.md
+++ b/skills/dcc-mcp-skills-creator/references/DCC_TOOL_CONTRACTS.md
@@ -23,7 +23,11 @@ the recovery target.
 
 ## Core Boundary
 
+Keep configuration in `SKILL.md` frontmatter under `metadata.dcc-mcp.*`, and
+keep large payloads in sibling files such as `tools.yaml`, `prompts/*.yaml`,
+`workflows/*.yaml`, or `references/*.md`.
+
 Do not parse `SKILL.md`, `tools.yaml`, `groups.yaml`, prompts, or workflows from
 adapter runtime code when core exposes a catalog or typed skill object API. If a
-needed transform or hook is missing, create a core RFC and keep the adapter
-shim narrow until the core API exists.
+needed transform or hook is missing, create a core RFC and keep the adapter shim
+narrow until the core API exists.

--- a/skills/dcc-mcp-skills-creator/references/DCC_TOOL_CONTRACTS.md
+++ b/skills/dcc-mcp-skills-creator/references/DCC_TOOL_CONTRACTS.md
@@ -1,0 +1,29 @@
+# DCC-MCP Tool Contracts
+
+Use this checklist for every `tools.yaml` entry.
+
+## Required Shape
+
+- `name`: local snake_case tool name, never dotted.
+- `description`: concise action description shown to agents.
+- `source_file`: script path relative to the skill directory.
+- `input_schema`: JSON Schema for parameters.
+- `output_schema`: JSON Schema for returned data when practical.
+- `execution`: `sync` for quick calls, `async` for long-running work.
+- `affinity`: `main` for host API calls, `any` for pure work.
+- `timeout_hint_secs`: realistic upper bound for dispatch and UX.
+- `annotations`: MCP safety hints.
+
+## Recovery Chains
+
+Domain tools should include `next-tools.on-failure` entries that point to
+diagnostic or observation tools, such as screenshots, audit logs, or scene
+snapshots. Infrastructure tools can omit failure chains when they are already
+the recovery target.
+
+## Core Boundary
+
+Do not parse `SKILL.md`, `tools.yaml`, `groups.yaml`, prompts, or workflows from
+adapter runtime code when core exposes a catalog or typed skill object API. If a
+needed transform or hook is missing, create a core RFC and keep the adapter
+shim narrow until the core API exists.

--- a/skills/dcc-mcp-skills-creator/scripts/create_skill.py
+++ b/skills/dcc-mcp-skills-creator/scripts/create_skill.py
@@ -86,7 +86,7 @@ def create_skill(
 
     skill_dir.mkdir(parents=True)
     (skill_dir / "scripts").mkdir()
-    (skill_dir / "metadata").mkdir()
+    (skill_dir / "references").mkdir()
 
     title = name.replace("-", " ").title()
     script_file = f"scripts/{tool_name}.py"

--- a/skills/dcc-mcp-skills-creator/scripts/create_skill.py
+++ b/skills/dcc-mcp-skills-creator/scripts/create_skill.py
@@ -1,0 +1,197 @@
+"""Scaffold a new DCC skill directory using the current DCC-MCP contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import sys
+
+_KEBAB_CASE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+_DCC_NAME = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+_TOOL_NAME = re.compile(r"^[a-z0-9]+(?:_[a-z0-9]+)*$")
+_AFFINITIES = {"any", "main"}
+_EXECUTION_MODES = {"sync", "async"}
+
+
+def _validate_skill_name(name: str) -> None:
+    if not _KEBAB_CASE.fullmatch(name):
+        raise ValueError("Skill name must be kebab-case, e.g. 'maya-rigging-tools'")
+
+
+def _validate_dcc_name(dcc: str) -> None:
+    if not _DCC_NAME.fullmatch(dcc):
+        raise ValueError("DCC name must be client-safe: letters, digits, '_' or '-', max 64 chars")
+
+
+def _validate_tool_name(tool_name: str) -> None:
+    if not _TOOL_NAME.fullmatch(tool_name):
+        raise ValueError(
+            "Tool name must be snake_case and client-safe, e.g. 'create_locator'; dotted names are not supported"
+        )
+
+
+def _validate_choice(value: str, allowed: set, label: str) -> None:
+    if value not in allowed:
+        expected = ", ".join(sorted(allowed))
+        raise ValueError(f"{label} must be one of: {expected}")
+
+
+def _stage_line(stage: str) -> str:
+    return f"    stage: {stage}\n" if stage else ""
+
+
+def create_skill(
+    name: str,
+    parent_dir: str,
+    dcc: str = "python",
+    *,
+    tool_name: str = "example_tool",
+    layer: str = "thin-harness",
+    stage: str = "",
+    affinity: str = "any",
+    execution: str = "sync",
+) -> str:
+    """Create a new skill directory with the modern standard structure.
+
+    Args:
+        name: Skill name in kebab-case.
+        parent_dir: Directory where the skill folder will be created.
+        dcc: Target DCC (e.g. "maya", "blender", "houdini", "python").
+        tool_name: First generated tool name. Must be snake_case, never dotted.
+        layer: Skill taxonomy layer, usually thin-harness, infrastructure, domain, or example.
+        stage: Optional progressive-loading stage such as scene, authoring, or pipeline.
+        affinity: Tool thread affinity. Use "main" for host API / scene work.
+        execution: "sync" or "async".
+
+    Returns:
+        Absolute path to the created skill directory.
+
+    """
+    dcc = dcc.strip()
+    tool_name = tool_name.strip()
+    layer = layer.strip() or "thin-harness"
+    stage = stage.strip()
+    affinity = affinity.strip().lower() or "any"
+    execution = execution.strip().lower() or "sync"
+
+    _validate_skill_name(name)
+    _validate_dcc_name(dcc)
+    _validate_tool_name(tool_name)
+    _validate_choice(affinity, _AFFINITIES, "affinity")
+    _validate_choice(execution, _EXECUTION_MODES, "execution")
+
+    skill_dir = Path(parent_dir).expanduser() / name
+    if skill_dir.exists():
+        raise FileExistsError(f"Skill directory already exists: {skill_dir}")
+
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "scripts").mkdir()
+    (skill_dir / "metadata").mkdir()
+
+    title = name.replace("-", " ").title()
+    script_file = f"scripts/{tool_name}.py"
+
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(
+        f"""---
+name: {name}
+description: >-
+  DCC skill - TODO: describe the user intent this skill serves. Use when an
+  agent needs TODO. Not for TODO.
+license: MIT
+compatibility: "Python 3.7+; dcc-mcp-core 0.17+"
+allowed-tools: Bash Read Write Edit
+metadata:
+  dcc-mcp:
+    dcc: {dcc}
+    version: "0.1.0"
+    layer: {layer}
+{_stage_line(stage)}    tags: ["generated", "{dcc}"]
+    search-hint: "TODO: add search keywords for this skill"
+    tools: tools.yaml
+---
+
+# {title}
+
+Keep instructions focused on when an agent should use this skill, what each
+tool returns, and what to inspect after success or failure.
+
+Tool names must stay client-safe (`^[A-Za-z0-9_-]{{1,64}}$`). Use local
+snake_case tool names in `tools.yaml`; dcc-mcp-core publishes them as
+`{name}__tool_name` after the skill is loaded.
+""",
+        encoding="utf-8",
+    )
+
+    tools_yaml = skill_dir / "tools.yaml"
+    tools_yaml.write_text(
+        f"""tools:
+  - name: {tool_name}
+    description: "Example read-only scaffold. Replace with one concrete DCC intent and describe side effects."
+    source_file: {script_file}
+    input_schema:
+      type: object
+      properties:
+        label:
+          type: string
+          description: "Optional label echoed by the scaffold implementation."
+        dry_run:
+          type: boolean
+          description: "Keep true until this scaffold performs real host work."
+          default: true
+      additionalProperties: false
+    output_schema:
+      type: object
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    execution: {execution}
+    affinity: {affinity}
+    enforce_thread_affinity: true
+    timeout_hint_secs: 30
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+      deferred_hint: false
+    next-tools:
+      on-success: []
+      on-failure: []
+""",
+        encoding="utf-8",
+    )
+
+    example_script = skill_dir / script_file
+    example_script.write_text(
+        '"""Example DCC-MCP skill tool implementation."""\n'
+        "from __future__ import annotations\n\n"
+        "from dcc_mcp_core.skill import run_main, skill_entry, skill_success\n\n\n"
+        "@skill_entry\n"
+        'def main(label: str = "example", dry_run: bool = True, **params):\n'
+        '    """Replace this scaffold with a concrete DCC operation."""\n'
+        "    return skill_success(\n"
+        '        "Example tool completed",\n'
+        '        prompt="Replace this scaffold with a concrete DCC operation.",\n'
+        "        label=label,\n"
+        "        dry_run=dry_run,\n"
+        "        extra_params=params,\n"
+        "    )\n\n\n"
+        'if __name__ == "__main__":\n'
+        "    run_main(main)\n",
+        encoding="utf-8",
+    )
+
+    return str(skill_dir.resolve())
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print("Usage: python create_skill.py <name> <parent_dir> [dcc]")
+        sys.exit(1)
+    path = create_skill(sys.argv[1], sys.argv[2], sys.argv[3] if len(sys.argv) > 3 else "python")
+    print(f"Created skill at: {path}")

--- a/skills/dcc-mcp-skills-creator/scripts/skill_template.py
+++ b/skills/dcc-mcp-skills-creator/scripts/skill_template.py
@@ -1,0 +1,51 @@
+"""Return a SKILL.md template using the current dcc-mcp-core layout."""
+
+from __future__ import annotations
+
+SKILL_TEMPLATE = """---
+name: my-skill
+description: >-
+  DCC skill - Describe the durable user intent this skill serves. Use when an
+  AI agent needs that intent. Not for unrelated diagnostics or raw code eval.
+license: MIT
+compatibility: "Python 3.7+; dcc-mcp-core 0.17+"
+allowed-tools: Bash Read Write Edit
+metadata:
+  dcc-mcp:
+    dcc: maya
+    version: "1.0.0"
+    layer: thin-harness
+    stage: authoring
+    tags: ["modeling", "animation", "example"]
+    search-hint: "create object, inspect scene, export asset"
+    tools: tools.yaml
+---
+
+# My Skill
+
+Write concise instructions for the AI agent:
+
+- when to load this skill;
+- what each tool changes or reads;
+- what to verify after success;
+- what diagnostic tool to call after failure.
+
+Tool names must be client-safe (`^[A-Za-z0-9_-]{1,64}$`). In `tools.yaml`, use
+local snake_case names such as `create_locator`; dcc-mcp-core publishes loaded
+tools as `<skill-name>__<tool_name>`.
+"""
+
+
+def skill_template() -> str:
+    """Return a current SKILL.md template.
+
+    Tool declarations live in the sibling ``tools.yaml`` referenced by
+    ``metadata.dcc-mcp.tools``. Use the creator scaffold for a full
+    SKILL.md + tools.yaml + scripts/ example with schemas, annotations, and
+    thread-affinity metadata.
+    """
+    return SKILL_TEMPLATE
+
+
+if __name__ == "__main__":
+    print(skill_template())

--- a/skills/dcc-mcp-skills-creator/scripts/validate_skill_dir.py
+++ b/skills/dcc-mcp-skills-creator/scripts/validate_skill_dir.py
@@ -1,0 +1,38 @@
+"""Validate a skill directory using dcc_mcp_core.validate_skill."""
+
+from __future__ import annotations
+
+import sys
+
+
+def validate_skill_dir(skill_dir: str) -> dict:
+    """Validate a skill directory and return a structured report.
+
+    Args:
+        skill_dir: Path to the skill directory.
+
+    Returns:
+        Dict with 'skill_dir', 'is_clean', 'has_errors', and 'issues' list.
+
+    """
+    from dcc_mcp_core import validate_skill
+
+    report = validate_skill(skill_dir)
+    return {
+        "skill_dir": report.skill_dir,
+        "is_clean": report.is_clean,
+        "has_errors": report.has_errors,
+        "issues": [{"severity": i.severity, "category": i.category, "message": i.message} for i in report.issues],
+    }
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python validate_skill_dir.py <skill_dir>")
+        sys.exit(1)
+    result = validate_skill_dir(sys.argv[1])
+    print(f"Skill: {result['skill_dir']}")
+    print(f"Clean: {result['is_clean']}")
+    print(f"Errors: {result['has_errors']}")
+    for issue in result["issues"]:
+        print(f"  [{issue['severity']}] {issue['category']}: {issue['message']}")

--- a/skills/dcc-mcp-skills-creator/tools.yaml
+++ b/skills/dcc-mcp-skills-creator/tools.yaml
@@ -1,0 +1,119 @@
+tools:
+  - name: create_skill
+    description: "Scaffold a current DCC-MCP skill package with client-safe tool names, schemas, annotations, and scripts."
+    source_file: scripts/create_skill.py
+    input_schema:
+      type: object
+      required: [name, parent_dir]
+      properties:
+        name:
+          type: string
+          pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+          description: "Skill directory and package name in kebab-case."
+        parent_dir:
+          type: string
+          description: "Directory that will receive the new skill folder."
+        dcc:
+          type: string
+          pattern: "^[A-Za-z0-9_-]{1,64}$"
+          default: python
+          description: "Target host, such as maya, blender, houdini, or python."
+        tool_name:
+          type: string
+          pattern: "^[a-z0-9]+(?:_[a-z0-9]+)*$"
+          default: example_tool
+          description: "First local tool name. Must be snake_case, never dotted."
+        layer:
+          type: string
+          enum: [thin-harness, infrastructure, domain, example]
+          default: thin-harness
+          description: "Skill taxonomy layer."
+        stage:
+          type: string
+          description: "Optional progressive-loading stage, for example scene or authoring."
+        affinity:
+          type: string
+          enum: [any, main]
+          default: any
+          description: "Use main for host API or scene mutation work."
+        execution:
+          type: string
+          enum: [sync, async]
+          default: sync
+          description: "Use async for long-running work surfaced as deferred MCP execution."
+      additionalProperties: false
+    output_schema:
+      type: object
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    execution: sync
+    affinity: any
+    enforce_thread_affinity: true
+    timeout_hint_secs: 30
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: true
+      deferred_hint: false
+    next-tools:
+      on-success: [validate_skill_dir]
+      on-failure: []
+
+  - name: validate_skill_dir
+    description: "Validate a skill directory against the current dcc-mcp-core skill specification."
+    source_file: scripts/validate_skill_dir.py
+    input_schema:
+      type: object
+      required: [skill_dir]
+      properties:
+        skill_dir:
+          type: string
+          description: "Path to the skill directory containing SKILL.md."
+      additionalProperties: false
+    output_schema:
+      type: object
+      properties:
+        skill_dir:
+          type: string
+        is_clean:
+          type: boolean
+        has_errors:
+          type: boolean
+        issues:
+          type: array
+    execution: sync
+    affinity: any
+    enforce_thread_affinity: true
+    timeout_hint_secs: 10
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: true
+      deferred_hint: false
+
+  - name: skill_template
+    description: "Return a current SKILL.md template that references sibling tools.yaml declarations."
+    source_file: scripts/skill_template.py
+    input_schema:
+      type: object
+      properties: {}
+      additionalProperties: false
+    output_schema:
+      type: string
+    execution: sync
+    affinity: any
+    enforce_thread_affinity: true
+    timeout_hint_secs: 5
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+      deferred_hint: false

--- a/tests/test_bundled_skill_metadata.py
+++ b/tests/test_bundled_skill_metadata.py
@@ -9,6 +9,8 @@ from dcc_mcp_core.skill_reference_docs import _handle_list
 SKILL_ROOTS = [
     REPO_ROOT / "skills" / "dcc-skills-creator",
     REPO_ROOT / "skills" / "dcc-mcp-skill-developer",
+    REPO_ROOT / "skills" / "dcc-mcp-skills-creator",
+    REPO_ROOT / "skills" / "dcc-mcp-creator",
     REPO_ROOT / "skills" / "dcc-cli-gateway",
     REPO_ROOT / "skills" / "dcc-rest-gateway",
     REPO_ROOT / "python" / "dcc_mcp_core" / "skills" / "app-ui",

--- a/tests/test_clawhub_sync.py
+++ b/tests/test_clawhub_sync.py
@@ -35,6 +35,8 @@ class TestClawhubSync:
         slugs = {e["slug"] for e in entries}
         assert "dcc-rest-gateway" in slugs
         assert "dcc-cli-gateway" in slugs
+        assert "dcc-mcp-skills-creator" in slugs
+        assert "dcc-mcp-creator" in slugs
 
     def test_dry_run_exits_zero(self) -> None:
         proc = subprocess.run(
@@ -50,6 +52,8 @@ class TestClawhubSync:
         assert "clawhub@0.17.0" in proc.stdout
         assert "dcc-rest-gateway" in proc.stdout
         assert "dcc-cli-gateway" in proc.stdout
+        assert "dcc-mcp-skills-creator" in proc.stdout
+        assert "dcc-mcp-creator" in proc.stdout
 
     def test_publish_skips_existing_clawhub_version(self, tmp_path, monkeypatch, capsys) -> None:
         sync = load_sync_module()


### PR DESCRIPTION
## Summary
- Add `dcc-mcp-creator` as the developer-facing skill for creating or modernizing full DCC-MCP adapter repositories.
- Add `dcc-mcp-skills-creator` as the unified agent-facing skill for creating, validating, and reviewing DCC-MCP skill packages.
- Keep `dcc-skills-creator` and `dcc-mcp-skill-developer` as compatibility entrypoints that point users toward the unified names.

## Related RFCs
- #1204
- #1205
- #1206

## Validation
- `vx uv run --no-project --with dcc-mcp-core python -c "from dcc_mcp_core import validate_skill; import sys; paths=['skills/dcc-mcp-creator','skills/dcc-mcp-skills-creator','skills/dcc-skills-creator','skills/dcc-mcp-skill-developer']; ok=True; [print(p, 'clean=', (r:=validate_skill(p)).is_clean) or (print(r) if not r.is_clean else None) or (globals().__setitem__('ok', False) if not r.is_clean else None) for p in paths]; sys.exit(0 if ok else 1)"`
- `git diff --check`
- Commit hooks: YAML, whitespace, Ruff, Ruff format