### PR TITLE
feat: emit gateway handoff notifications

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
 use crate::gateway::admin::trace::{AgentContext, TraceContext};
 use crate::gateway::agent_telemetry::{
     AgentWorkflowEvent, error_kind_from_text, policy_reason_from_value,
@@ -12,9 +14,12 @@ use crate::gateway::capability_service::{
 };
 use crate::gateway::response_codec::{compact_call_batch_payload, compact_describe_payload};
 use crate::gateway::search_telemetry::{SearchTelemetryInput, search_id_from_payload};
+use dcc_mcp_transport::discovery::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry};
 
 use super::rest_support::*;
 use super::rest_trace::*;
+
+const GATEWAY_HANDOFF_GRACE: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Deserialize)]
 pub struct DccInstanceDescribeQuery {
@@ -36,6 +41,8 @@ pub async fn handle_gateway_yield(
     #[derive(Deserialize)]
     struct YieldRequest {
         challenger_version: Option<String>,
+        reason: Option<String>,
+        suggested_successor: Option<String>,
     }
 
     let request: YieldRequest = match serde_json::from_slice(&body) {
@@ -59,14 +66,28 @@ pub async fn handle_gateway_yield(
     }
 
     if is_newer_version(&challenger_version, &gs.server_version) {
+        let reason = request
+            .reason
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or("version_preempt");
         tracing::info!(
             challenger = %challenger_version,
             current = %gs.server_version,
+            reason = %reason,
             "Gateway yield requested — initiating graceful handoff"
         );
+        announce_gateway_handoff(
+            &gs,
+            &challenger_version,
+            reason,
+            request.suggested_successor.as_deref(),
+        )
+        .await;
         let _ = gs.yield_tx.send(true);
         Json(json!({
             "ok": true,
+            "handoff": true,
             "message": format!(
                 "Gateway v{} yielding to challenger v{}. Port will be free shortly.",
                 gs.server_version, challenger_version
@@ -83,6 +104,117 @@ pub async fn handle_gateway_yield(
             ),
         )
     }
+}
+
+async fn announce_gateway_handoff(
+    gs: &GatewayState,
+    challenger_version: &str,
+    reason: &str,
+    suggested_successor: Option<&str>,
+) {
+    let issued = SystemTime::now();
+    let deadline = issued + GATEWAY_HANDOFF_GRACE;
+    let sentinel = mark_active_gateway_sentinel_shutting_down(gs).await;
+    let from_instance_id = sentinel
+        .as_ref()
+        .map(|entry| entry.instance_id.to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    let in_flight_calls = gs.pending_calls.read().await.len();
+    let subscribed_clients = gs.events_tx.receiver_count();
+
+    crate::gateway::event_log::record_event(
+        &gs.event_log,
+        #[cfg(feature = "prometheus")]
+        &gs.gateway_metrics,
+        crate::gateway::event_log::EventKind::VoluntaryYield,
+        GATEWAY_SENTINEL_DCC_TYPE,
+        short_instance_id(&from_instance_id),
+        Some(format!(
+            "handoff reason={reason}; challenger_version={challenger_version}"
+        )),
+    );
+
+    let notification = json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/gateway/handoff",
+        "params": {
+            "from": from_instance_id,
+            "reason": reason,
+            "challenger_version": challenger_version,
+            "issued_unix_secs": unix_secs(issued),
+            "deadline_unix_secs": unix_secs(deadline),
+            "grace_ms": GATEWAY_HANDOFF_GRACE.as_millis() as u64,
+            "endpoint_after_handoff_will_be_same": true,
+            "in_flight_calls": in_flight_calls,
+            "subscribed_clients": subscribed_clients,
+            "suggested_successor": suggested_successor,
+        }
+    });
+
+    if gs.events_tx.receiver_count() > 0 {
+        let _ = gs.events_tx.send(notification.to_string());
+    }
+}
+
+async fn mark_active_gateway_sentinel_shutting_down(gs: &GatewayState) -> Option<ServiceEntry> {
+    let sentinel = {
+        let registry = gs.registry.read().await;
+        select_active_gateway_sentinel(
+            registry.list_instances(GATEWAY_SENTINEL_DCC_TYPE),
+            &gs.own_host,
+            gs.own_port,
+        )
+    }?;
+    let key = sentinel.key();
+    {
+        let registry = gs.registry.read().await;
+        if let Err(err) = registry.update_status(&key, ServiceStatus::ShuttingDown) {
+            tracing::warn!(
+                error = %err,
+                instance_id = %sentinel.instance_id,
+                "Failed to mark gateway sentinel as shutting down"
+            );
+            return Some(sentinel);
+        }
+    }
+    let mut updated = sentinel;
+    updated.status = ServiceStatus::ShuttingDown;
+    Some(updated)
+}
+
+fn select_active_gateway_sentinel(
+    sentinels: Vec<ServiceEntry>,
+    own_host: &str,
+    own_port: u16,
+) -> Option<ServiceEntry> {
+    sentinels
+        .iter()
+        .find(|entry| {
+            entry.host == own_host
+                && entry.port == own_port
+                && entry
+                    .metadata
+                    .get("gateway_role")
+                    .is_some_and(|role| role == "active")
+        })
+        .cloned()
+        .or_else(|| {
+            sentinels
+                .iter()
+                .find(|entry| entry.host == own_host && entry.port == own_port)
+                .cloned()
+        })
+        .or_else(|| sentinels.into_iter().next())
+}
+
+fn unix_secs(time: SystemTime) -> f64 {
+    time.duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs_f64())
+        .unwrap_or_default()
+}
+
+fn short_instance_id(instance_id: &str) -> String {
+    instance_id.chars().take(8).collect()
 }
 
 fn gateway_yield_unavailable_response(

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use axum::body::{Body, to_bytes};
 use axum::http::Request;
 use dcc_mcp_transport::discovery::file_registry::FileRegistry;
-use dcc_mcp_transport::discovery::types::ServiceEntry;
+use dcc_mcp_transport::discovery::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -830,6 +830,70 @@ async fn gateway_yield_newer_challenger_still_accepts() {
 
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["ok"], true);
+}
+
+#[tokio::test]
+async fn gateway_yield_broadcasts_handoff_and_marks_sentinel_shutting_down() {
+    let gs = test_gateway_state("1.2.3");
+    let mut sentinel = ServiceEntry::new(GATEWAY_SENTINEL_DCC_TYPE, "127.0.0.1", 9765);
+    sentinel.version = Some("1.2.3".to_string());
+    sentinel
+        .metadata
+        .insert("gateway_role".to_string(), "active".to_string());
+    let sentinel_key = sentinel.key();
+    let sentinel_id = sentinel.instance_id.to_string();
+    {
+        let registry = gs.registry.read().await;
+        registry.register(sentinel).unwrap();
+    }
+
+    let mut events_rx = gs.events_tx.subscribe();
+    let (status, body) = response_json(
+        handle_gateway_yield(
+            State(gs.clone()),
+            axum::body::Bytes::from_static(
+                br#"{"challenger_version":"1.2.4","suggested_successor":"peer-123"}"#,
+            ),
+        )
+        .await,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["handoff"], true);
+
+    let raw_event = tokio::time::timeout(Duration::from_secs(1), events_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let event: Value = serde_json::from_str(&raw_event).unwrap();
+    assert_eq!(event["method"], "notifications/gateway/handoff");
+    assert_eq!(event["params"]["from"], sentinel_id);
+    assert_eq!(event["params"]["reason"], "version_preempt");
+    assert_eq!(event["params"]["challenger_version"], "1.2.4");
+    assert_eq!(event["params"]["suggested_successor"], "peer-123");
+    assert_eq!(event["params"]["endpoint_after_handoff_will_be_same"], true);
+    assert!(event["params"]["deadline_unix_secs"].as_f64().unwrap() > 0.0);
+
+    {
+        let registry = gs.registry.read().await;
+        let updated = registry.get(&sentinel_key).unwrap();
+        assert_eq!(updated.status, ServiceStatus::ShuttingDown);
+    }
+
+    let events = gs.event_log.recent_events(1);
+    assert_eq!(
+        events[0].event,
+        crate::gateway::event_log::EventKind::VoluntaryYield
+    );
+    assert_eq!(events[0].dcc_type, GATEWAY_SENTINEL_DCC_TYPE);
+    assert!(
+        events[0]
+            .reason
+            .as_deref()
+            .unwrap_or_default()
+            .contains("challenger_version=1.2.4")
+    );
 }
 
 #[tokio::test]

--- a/crates/dcc-mcp-gateway/src/gateway/native_resources/agent_workflows.md
+++ b/crates/dcc-mcp-gateway/src/gateway/native_resources/agent_workflows.md
@@ -109,6 +109,10 @@ Where the gateway mounts them, mirror MCP with **`POST /v1/search`**, **`/v1/des
 
 MCP agents request the same compact TOON payloads through request metadata instead of HTTP `Accept`: compact-capable clients should set `params._meta.response_format="toon"` or `params._meta.compact=true` after `initialize` advertises `capabilities.experimental["dcc-mcp"].compactResponses`, and can set `params._meta.response_format="json"` to opt out for one request. Legacy clients that omit the metadata keep normal JSON results. The outer JSON-RPC envelope stays JSON. `tools/call` keeps the MCP `CallToolResult` shape and adds `mimeType: "application/toon"` to compact text content; JSON-RPC errors stay normal `error` objects.
 
+### Gateway handoff signals
+
+When a gateway accepts a cooperative `/gateway/yield`, connected SSE clients receive `notifications/gateway/handoff` before the listener shuts down. Treat it as a short retry window: pause new requests until `deadline_unix_secs`, refresh `gateway://instances`, then retry through the same stable endpoint. The gateway also marks its `__gateway__` sentinel as `shutting_down`, so registry readers can distinguish graceful handoff from a crash-driven failover.
+
 ### Path-style invocation (optional; for curl / service accounts)
 
 - **Gateway:** `POST /v1/dcc/{dcc_type}/instances/{instance_id}/call` with JSON `{ "backend_tool": "<name>", "arguments": {...}, "meta": {...} }` (aliases: `tool`, `action` for `backend_tool`). Same routing as `POST /v1/call` after composing the dotted `tool_slug`; use when you already know `dcc_type` + **`instance_id`** from **`GET /v1/instances`** or **`GET /v1/context`** (`instances` array mirrors `/v1/instances`).


### PR DESCRIPTION
## Summary
- Broadcast `notifications/gateway/handoff` before an accepted `/gateway/yield` releases the listener.
- Mark the active `__gateway__` sentinel as `shutting_down` and record a `VoluntaryYield` event for registry/event-log readers.
- Document the handoff signal in the embedded gateway agent workflow guide.

## Validation
- `vx cargo fmt --all -- --check`
- `vx cargo clippy -p dcc-mcp-gateway --all-targets --features admin -- -D warnings`
- `vx cargo test -p dcc-mcp-gateway --features admin --lib`
- `vx cargo test -p dcc-mcp-gateway gateway_yield --all-targets --features admin -- --nocapture`

Refs #1114