### PR TITLE
ci: run mcpcall through vx

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -60,7 +60,7 @@ runs:
         components: clippy rustfmt
 
     - name: Install vx
-      uses: loonghao/vx@v0.8.36
+      uses: loonghao/vx@v0.9.2
       with:
         cache: "false"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: loonghao/vx@v0.8.36
+      - uses: loonghao/vx@v0.9.2
       - name: Build admin UI bundle
         shell: bash
         run: scripts/release/prebuild_admin_ui.sh
@@ -130,7 +130,7 @@ jobs:
           echo "CARGO=${CARGO_BIN}" >> "$GITHUB_ENV"
           echo "RUSTC=$(rustup which rustc)" >> "$GITHUB_ENV"
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-      - uses: loonghao/vx@v0.8.36
+      - uses: loonghao/vx@v0.9.2
       - name: Prepare admin UI dependencies
         shell: bash
         run: |
@@ -234,7 +234,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: loonghao/vx@v0.8.36
+      - uses: loonghao/vx@v0.9.2
       - name: Download wheel
         uses: actions/download-artifact@v8
         with:
@@ -307,7 +307,7 @@ jobs:
         with:
           python-version: "3.14"
 
-      - uses: loonghao/vx@v0.8.36
+      - uses: loonghao/vx@v0.9.2
 
       - name: Install dev deps
         run: vx just install-dev-deps
@@ -349,6 +349,8 @@ jobs:
         with:
           python-version: "3.14"
 
+      - uses: loonghao/vx@v0.9.2
+
       - name: Download wheel
         uses: actions/download-artifact@v8
         with:
@@ -359,15 +361,12 @@ jobs:
         run: pip install --no-index --find-links dist dcc-mcp-core && pip install pytest anyio
         shell: bash
 
-      - name: Install mcpcall
-        uses: loonghao/mcpcall/.github/actions/setup-mcpcall@mcpcall-v0.2.0
-        with:
-          version: mcpcall-v0.2.0
-
       - name: Verify mcpcall
-        run: mcpcall --version
+        run: vx mcpcall --version
         shell: bash
 
       - name: Run mcpcall e2e tests
+        env:
+          MCPCALL_CMD: vx mcpcall
         run: pytest tests/test_mcp_mcpcall_e2e.py -v --tb=short
         shell: bash

--- a/.github/workflows/dcc-integration.yml
+++ b/.github/workflows/dcc-integration.yml
@@ -99,7 +99,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-      - uses: loonghao/vx@v0.8.36
+      - uses: loonghao/vx@v0.9.2
       - name: Cache Cargo
         uses: actions/cache@v5
         with:

--- a/.github/workflows/python-matrix-full.yml
+++ b/.github/workflows/python-matrix-full.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: loonghao/vx@v0.8.36
+      - uses: loonghao/vx@v0.9.2
       - uses: dtolnay/rust-toolchain@stable
       - name: Build wheel
         run: vx just build

--- a/.github/workflows/release-please-lock-sync.yml
+++ b/.github/workflows/release-please-lock-sync.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: loonghao/vx@v0.8.36
+      - uses: loonghao/vx@v0.9.2
 
       - uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
 
-      - uses: loonghao/vx@v0.8.36
+      - uses: loonghao/vx@v0.9.2
 
       - name: Build admin UI bundle
         shell: bash
@@ -183,7 +183,7 @@ jobs:
           toolchain: '1.95.0'
           targets: aarch64-apple-darwin  # needed for macOS universal2 lipo
 
-      - uses: loonghao/vx@v0.8.36
+      - uses: loonghao/vx@v0.9.2
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - uses: loonghao/vx@v0.8.36
+      - uses: loonghao/vx@v0.9.2
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
         with:

--- a/justfile
+++ b/justfile
@@ -213,7 +213,7 @@ test:
 test-cov:
     pytest tests/ -q --tb=short --show-capture=no --cov=dcc_mcp_core --cov-report=term --cov-report=xml:coverage.xml
 
-# Run mcpcall MCP end-to-end tests (requires: mcpcall on PATH)
+# Run mcpcall MCP end-to-end tests (set MCPCALL_CMD="vx mcpcall" for vx-managed local runs)
 test-e2e:
     pytest tests/test_mcp_mcpcall_e2e.py -v --tb=short
 

--- a/tests/test_mcp_mcpcall_e2e.py
+++ b/tests/test_mcp_mcpcall_e2e.py
@@ -15,14 +15,15 @@ These tests start real McpHttpServer instances, then exercise them through
 - Gateway facade discovery through the canonical search/describe/load/call flow
 
 Requirements:
-    mcpcall binary available in PATH, or MCPCALL_BIN pointing to the binary
+    MCPCALL_CMD="vx mcpcall" (requires vx >= 0.9.0), mcpcall binary available
+    in PATH, or MCPCALL_BIN pointing to the binary
     dcc_mcp_core Python package installed (Rust wheel)
 
 The tests are skipped automatically when ``mcpcall`` is not found.
 
 CI status: this file runs in the dedicated ``mcpcall-e2e`` job
-(``.github/workflows/ci.yml``), which installs ``mcpcall`` with the upstream
-setup action and executes ``pytest tests/test_mcp_mcpcall_e2e.py`` against a
+(``.github/workflows/ci.yml``), which runs ``vx mcpcall`` and executes
+``pytest tests/test_mcp_mcpcall_e2e.py`` against a
 Linux wheel built earlier in the run. It also auto-skips inside the standard
 ``pytest tests/`` matrix cells when ``mcpcall`` is absent. Do **not** add this
 file to local ``--ignore`` lists in CI workflows or shared scripts.
@@ -36,6 +37,7 @@ import json
 import os
 from pathlib import Path
 import platform
+import shlex
 import socket
 import subprocess
 import sys
@@ -59,18 +61,31 @@ EXAMPLES_SKILLS_DIR = str(REPO_ROOT / "examples" / "skills")
 # ---------------------------------------------------------------------------
 
 _IS_WINDOWS = platform.system() == "Windows"
-_MCPCALL_BIN = os.environ.get("MCPCALL_BIN") or ("mcpcall.exe" if _IS_WINDOWS else "mcpcall")
 
 # Timeout budget per mcpcall invocation.
 # 120 s is generous enough for slow CI runners but prevents hanging forever.
 _MCPCALL_TIMEOUT = int(os.environ.get("MCPCALL_TIMEOUT", "120"))
 
 
-def _probe_cmd(cmd: str, timeout: int = 10) -> bool:
+def _mcpcall_command() -> tuple[str, ...]:
+    """Resolve the command used to launch mcpcall."""
+    cmd = os.environ.get("MCPCALL_CMD")
+    if cmd:
+        return tuple(shlex.split(cmd, posix=not _IS_WINDOWS))
+    binary = os.environ.get("MCPCALL_BIN")
+    if binary:
+        return (binary,)
+    return ("mcpcall.exe" if _IS_WINDOWS else "mcpcall",)
+
+
+_MCPCALL_CMD = _mcpcall_command()
+
+
+def _probe_cmd(cmd: tuple[str, ...], timeout: int = 10) -> bool:
     """Return True if ``cmd --version`` succeeds within *timeout* seconds."""
     try:
         r = subprocess.run(
-            [cmd, "--version"],
+            [*cmd, "--version"],
             capture_output=True,
             text=True,
             timeout=timeout,
@@ -83,7 +98,7 @@ def _probe_cmd(cmd: str, timeout: int = 10) -> bool:
 def _run_mcpcall(*args: str, timeout: int | None = None) -> subprocess.CompletedProcess:
     """Run mcpcall portably."""
     t = timeout if timeout is not None else _MCPCALL_TIMEOUT
-    cmd = [_MCPCALL_BIN, *args]
+    cmd = [*_MCPCALL_CMD, *args]
     return subprocess.run(cmd, capture_output=True, text=True, timeout=t)
 
 
@@ -113,7 +128,7 @@ def _wait_tcp_reachable(host: str, port: int, budget: float = 5.0) -> bool:
 
 def _mcpcall_available() -> bool:
     """Return True if mcpcall is reachable."""
-    return _probe_cmd(_MCPCALL_BIN, timeout=min(_MCPCALL_TIMEOUT, 10))
+    return _probe_cmd(_MCPCALL_CMD, timeout=min(_MCPCALL_TIMEOUT, 10))
 
 
 MCPCALL_AVAILABLE = _mcpcall_available()


### PR DESCRIPTION
## Summary

- Upgrade GitHub Actions `loonghao/vx` pins from `v0.8.36` to `v0.9.2`.
- Run the dedicated MCP E2E job through `vx mcpcall` instead of the older setup action.
- Add `MCPCALL_CMD` support so local E2E can use `MCPCALL_CMD="vx mcpcall"` while normal pytest matrices remain skip-friendly.

Refs #1212.

## Validation

- `vx --version` -> `vx 0.9.2`
- `vx mcpcall --version` -> `mcpcall 0.3.0`
- `python -m compileall -q tests/test_mcp_mcpcall_e2e.py`
- `MCPCALL_CMD="vx mcpcall" python -m pytest tests/test_mcp_mcpcall_e2e.py::TestMcpcallToolsList::test_list_shows_registered_actions -q --tb=short`
- `python -m pytest tests/test_mcp_mcpcall_e2e.py::TestMcpcallAvailability::test_mcpcall_availability_logged -q --tb=short`
- `vx uvx --from actionlint-py==1.7.12.24 actionlint .github/workflows/ci.yml .github/workflows/dcc-integration.yml .github/workflows/python-matrix-full.yml .github/workflows/release-please-lock-sync.yml .github/workflows/release.yml .github/workflows/rust-coverage.yml`