### PR TITLE
ci: pin vx action install version

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -62,6 +62,8 @@ runs:
     - name: Install vx
       uses: loonghao/vx@v0.9.2
       with:
+        version: "0.9.2"
+        cache-key-prefix: "vx-tools-v0.9.2"
         cache: "false"
 
     - name: Cache Cargo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: loonghao/vx@v0.9.2
+        with:
+          version: "0.9.2"
+          cache-key-prefix: "vx-tools-v0.9.2"
       - name: Build admin UI bundle
         shell: bash
         run: scripts/release/prebuild_admin_ui.sh
@@ -131,6 +134,9 @@ jobs:
           echo "RUSTC=$(rustup which rustc)" >> "$GITHUB_ENV"
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
       - uses: loonghao/vx@v0.9.2
+        with:
+          version: "0.9.2"
+          cache-key-prefix: "vx-tools-v0.9.2"
       - name: Prepare admin UI dependencies
         shell: bash
         run: |
@@ -235,6 +241,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - uses: loonghao/vx@v0.9.2
+        with:
+          version: "0.9.2"
+          cache-key-prefix: "vx-tools-v0.9.2"
       - name: Download wheel
         uses: actions/download-artifact@v8
         with:
@@ -308,6 +317,9 @@ jobs:
           python-version: "3.14"
 
       - uses: loonghao/vx@v0.9.2
+        with:
+          version: "0.9.2"
+          cache-key-prefix: "vx-tools-v0.9.2"
 
       - name: Install dev deps
         run: vx just install-dev-deps
@@ -350,6 +362,9 @@ jobs:
           python-version: "3.14"
 
       - uses: loonghao/vx@v0.9.2
+        with:
+          version: "0.9.2"
+          cache: "false"
 
       - name: Download wheel
         uses: actions/download-artifact@v8

--- a/.github/workflows/dcc-integration.yml
+++ b/.github/workflows/dcc-integration.yml
@@ -100,6 +100,9 @@ jobs:
         with:
           python-version: "3.14"
       - uses: loonghao/vx@v0.9.2
+        with:
+          version: "0.9.2"
+          cache-key-prefix: "vx-tools-v0.9.2"
       - name: Cache Cargo
         uses: actions/cache@v5
         with:

--- a/.github/workflows/python-matrix-full.yml
+++ b/.github/workflows/python-matrix-full.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - uses: loonghao/vx@v0.9.2
+        with:
+          version: "0.9.2"
+          cache-key-prefix: "vx-tools-v0.9.2"
       - uses: dtolnay/rust-toolchain@stable
       - name: Build wheel
         run: vx just build

--- a/.github/workflows/release-please-lock-sync.yml
+++ b/.github/workflows/release-please-lock-sync.yml
@@ -39,6 +39,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: loonghao/vx@v0.9.2
+        with:
+          version: "0.9.2"
+          cache-key-prefix: "vx-tools-v0.9.2"
 
       - uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,9 @@ jobs:
           ref: ${{ needs.release-please.outputs.tag_name }}
 
       - uses: loonghao/vx@v0.9.2
+        with:
+          version: "0.9.2"
+          cache-key-prefix: "vx-tools-v0.9.2"
 
       - name: Build admin UI bundle
         shell: bash
@@ -184,6 +187,9 @@ jobs:
           targets: aarch64-apple-darwin  # needed for macOS universal2 lipo
 
       - uses: loonghao/vx@v0.9.2
+        with:
+          version: "0.9.2"
+          cache-key-prefix: "vx-tools-v0.9.2"
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -26,6 +26,9 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: loonghao/vx@v0.9.2
+        with:
+          version: "0.9.2"
+          cache-key-prefix: "vx-tools-v0.9.2"
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## Summary
- Pin the `loonghao/vx@v0.9.2` action input to install vx `0.9.2` instead of the floating `latest` default.
- Isolate the vx tool cache with a `vx-tools-v0.9.2` prefix so stale cached binaries cannot satisfy a newer install contract.
- Disable the vx action cache for `mcpcall e2e`, which must prove the current mcpcall-capable vx binary is installed.

Closes #1212

## Validation
- `vx --version` (vx 0.9.2)
- `vx mcpcall --version` (mcpcall 0.3.0)
- checked every `loonghao/vx@v0.9.2` use under `.github` declares `version: "0.9.2"` and either isolated cache prefix or `cache: "false"`
- `git diff --check`
- pre-commit hooks on commit: `check yaml`, `actionlint`, EOF/trailing whitespace checks