### PR TITLE
feat: add admin live traffic capture

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -16,7 +16,7 @@ import puzzleIcon from './assets/icons/puzzle.svg';
 import vscodeIcon from './assets/icons/vscode.svg';
 import { formatTime, timestampTitle } from './time';
 
-type Panel = 'setup' | 'debug' | 'activity' | 'health' | 'instances' | 'tools' | 'workflows' | 'tasks' | 'openapi' | 'calls' | 'traces' | 'stats' | 'governance' | 'logs' | 'skill-paths';
+type Panel = 'setup' | 'debug' | 'activity' | 'health' | 'instances' | 'tools' | 'workflows' | 'tasks' | 'openapi' | 'calls' | 'traces' | 'traffic' | 'stats' | 'governance' | 'logs' | 'skill-paths';
 
 type HealthPayload = {
   status: string;
@@ -159,6 +159,58 @@ type AdminLinks = {
   stats_url?: string;
   admin_traces_url?: string;
   admin_workflows_url?: string;
+};
+
+type TrafficLinks = {
+  admin_traffic_url?: string;
+  traffic_api_url?: string;
+  traffic_export_jsonl_url?: string;
+};
+
+type TrafficFrameEnvelope = {
+  schema_version?: number;
+  name?: string;
+  id?: string;
+  timestamp_ns?: number;
+  source?: Record<string, unknown>;
+  correlation?: {
+    request_id?: string;
+    trace_id?: string;
+    session_id?: string;
+    [key: string]: unknown;
+  };
+  attributes?: TrafficFrameAttributes;
+};
+
+type TrafficFrameAttributes = {
+  capture_id?: string;
+  session_id?: string | null;
+  direction?: string;
+  leg?: string;
+  transport?: string;
+  http?: {
+    method?: string;
+    url?: string;
+    status?: number | null;
+    headers?: Record<string, string>;
+  };
+  mcp?: {
+    kind?: string;
+    method?: string;
+    id?: unknown;
+  };
+  body?: {
+    encoding?: string;
+    data?: unknown;
+    size_bytes?: number;
+    redacted_paths?: string[];
+  };
+};
+
+type TrafficPayload = {
+  total?: number;
+  frames?: TrafficFrameEnvelope[];
+  links?: TrafficLinks;
 };
 
 type AgentContext = {
@@ -907,6 +959,7 @@ const PANELS: { id: Panel; label: string; group: string }[] = [
   { id: 'openapi', label: 'OpenAPI Inspector', group: 'Contracts' },
   { id: 'stats', label: 'Stats', group: 'Observability' },
   { id: 'governance', label: 'Governance', group: 'Observability' },
+  { id: 'traffic', label: 'Traffic', group: 'Observability' },
   { id: 'traces', label: 'Traces', group: 'Observability' },
   { id: 'calls', label: 'Calls', group: 'Observability' },
   { id: 'logs', label: 'Logs', group: 'Observability' },
@@ -1431,6 +1484,7 @@ function NavIcon({ panel }: { panel: Panel }) {
     tasks: ['M6 7h12', 'M6 12h12', 'M6 17h12', 'M4 7h.01', 'M4 12h.01', 'M4 17h.01'],
     calls: ['M7 7h10v10H7z', 'M10 10h4v4h-4z'],
     traces: ['M5 7h4v4H5z', 'M15 13h4v4h-4z', 'M9 9l6 6'],
+    traffic: ['M4 8h4l2 8 4-12 2 8h4', 'M4 16h4', 'M16 16h4'],
     stats: ['M5 18V9', 'M12 18V5', 'M19 18v-6', 'M4 18h16'],
     governance: ['M12 4l7 4v5c0 4-3 7-7 8-4-1-7-4-7-8V8z', 'M9 12l2 2 4-5'],
     logs: ['M7 5h8l3 3v11H7z', 'M15 5v4h4', 'M10 13h6', 'M10 16h5'],
@@ -1902,6 +1956,37 @@ function compactId(value: string | null | undefined): string {
     return '-';
   }
   return value.length > 12 ? value.slice(0, 12) : value;
+}
+
+function trafficTimestamp(frame: TrafficFrameEnvelope): string | undefined {
+  if (typeof frame.timestamp_ns === 'number') {
+    return new Date(frame.timestamp_ns / 1_000_000).toISOString();
+  }
+  return undefined;
+}
+
+function trafficMethod(frame: TrafficFrameEnvelope): string {
+  return frame.attributes?.mcp?.method ?? '-';
+}
+
+function trafficRequestId(frame: TrafficFrameEnvelope): string | undefined {
+  return frame.correlation?.request_id;
+}
+
+function trafficSessionId(frame: TrafficFrameEnvelope): string | undefined {
+  return frame.attributes?.session_id ?? frame.correlation?.session_id;
+}
+
+function trafficBodyBytes(frame: TrafficFrameEnvelope): number | undefined {
+  return frame.attributes?.body?.size_bytes;
+}
+
+function trafficRedactedPaths(frame: TrafficFrameEnvelope): string[] {
+  return frame.attributes?.body?.redacted_paths ?? [];
+}
+
+function trafficFrameDetail(frame: TrafficFrameEnvelope): string {
+  return JSON.stringify(frame, null, 2);
 }
 
 function compactList(values: string[] | null | undefined, empty = 'Any'): string {
@@ -2536,6 +2621,7 @@ function App() {
   const [tasks, setTasks] = useState<TaskRow[]>([]);
   const [calls, setCalls] = useState<CallRow[]>([]);
   const [traces, setTraces] = useState<TraceRow[]>([]);
+  const [traffic, setTraffic] = useState<TrafficPayload | null>(null);
   const [stats, setStats] = useState<StatsPayload | null>(null);
   const [governance, setGovernance] = useState<GovernancePayload | null>(null);
   const [statsRange, setStatsRange] = useState(() => readStatsRangeFromUrl());
@@ -2558,6 +2644,7 @@ function App() {
   const [skillDetailBusy, setSkillDetailBusy] = useState(false);
   const [traceDetail, setTraceDetail] = useState<string>('Select a trace row for detail.');
   const [traceDetailPayload, setTraceDetailPayload] = useState<TraceDetailPayload | null>(null);
+  const [trafficDetail, setTrafficDetail] = useState<string>('Select a traffic frame row for detail.');
   const [callDetail, setCallDetail] = useState<string>('Select a call row for trace detail.');
   const [copiedNotice, setCopiedNotice] = useState<string>('');
   const [updatedAt, setUpdatedAt] = useState<Record<Panel, string>>({
@@ -2572,6 +2659,7 @@ function App() {
     openapi: 'Loading…',
     calls: 'Loading…',
     traces: 'Loading…',
+    traffic: 'Loading…',
     stats: 'Loading…',
     governance: 'Loading…',
     logs: 'Loading…',
@@ -2706,6 +2794,36 @@ function App() {
       ),
     );
   }, [traces, listSearch]);
+
+  const trafficFrames = useMemo(() => traffic?.frames ?? [], [traffic]);
+  const filteredTrafficFrames = useMemo(() => {
+    const q = listSearch.trim().toLowerCase();
+    if (!q) {
+      return trafficFrames;
+    }
+    return trafficFrames.filter((frame) =>
+      matchesListFilter(
+        q,
+        haystack(
+          frame.id ?? '',
+          frame.name ?? '',
+          trafficRequestId(frame) ?? '',
+          frame.correlation?.trace_id ?? '',
+          trafficSessionId(frame) ?? '',
+          frame.attributes?.capture_id ?? '',
+          frame.attributes?.direction ?? '',
+          frame.attributes?.leg ?? '',
+          frame.attributes?.transport ?? '',
+          frame.attributes?.http?.method ?? '',
+          frame.attributes?.http?.url ?? '',
+          String(frame.attributes?.http?.status ?? ''),
+          frame.attributes?.mcp?.kind ?? '',
+          trafficMethod(frame),
+          trafficRedactedPaths(frame).join(' '),
+        ),
+      ),
+    );
+  }, [trafficFrames, listSearch]);
 
   const filteredTasks = useMemo(() => {
     const q = listSearch.trim().toLowerCase();
@@ -3012,6 +3130,14 @@ function App() {
     return { ok, failed, p95, agentContext, spans };
   }, [stats, traces]);
 
+  const trafficSummary = useMemo(() => {
+    const sessions = new Set(trafficFrames.map(trafficSessionId).filter(Boolean)).size;
+    const redacted = trafficFrames.reduce((sum, frame) => sum + trafficRedactedPaths(frame).length, 0);
+    const bytes = trafficFrames.reduce((sum, frame) => sum + (trafficBodyBytes(frame) ?? 0), 0);
+    const transports = new Set(trafficFrames.map((frame) => frame.attributes?.transport).filter(Boolean)).size;
+    return { sessions, redacted, bytes, transports };
+  }, [trafficFrames]);
+
   const statsSummary = useMemo(() => {
     const failed = stats?.failed_calls ?? Math.max(0, (stats?.total_calls ?? 0) - (stats?.successful_calls ?? 0));
     const success = stats?.successful_calls ?? Math.max(0, (stats?.total_calls ?? 0) - failed);
@@ -3171,6 +3297,17 @@ function App() {
     }
   }, [markError, markUpdated]);
 
+  const fetchTraffic = useCallback(async () => {
+    try {
+      const payload = await apiJson<TrafficPayload>('/traffic?limit=300');
+      const rows = Array.isArray(payload.frames) ? payload.frames : [];
+      setTraffic({ ...payload, frames: rows });
+      markUpdated('traffic', `${rows.length} frame(s) — ${new Date().toLocaleTimeString()}`);
+    } catch (error) {
+      markError('traffic', error);
+    }
+  }, [markError, markUpdated]);
+
   const fetchTasks = useCallback(async () => {
     try {
       const payload = await apiJson<{ tasks: TaskRow[] }>('/tasks?limit=300');
@@ -3297,12 +3434,13 @@ function App() {
       fetchActivity(),
       fetchCalls(),
       fetchTraces(),
+      fetchTraffic(),
       fetchStats(),
       fetchGovernance(),
       fetchLogs(),
     ]);
     markUpdated('debug', `Debug snapshot — ${new Date().toLocaleTimeString()}`);
-  }, [fetchActivity, fetchCalls, fetchGovernance, fetchHealth, fetchInstanceBackends, fetchLogs, fetchStats, fetchTraces, markUpdated]);
+  }, [fetchActivity, fetchCalls, fetchGovernance, fetchHealth, fetchInstanceBackends, fetchLogs, fetchStats, fetchTraces, fetchTraffic, markUpdated]);
 
   const addSkillPath = useCallback(async () => {
     const path = skillPathInput.trim();
@@ -3496,11 +3634,12 @@ function App() {
     if (panel === 'tasks') void fetchTasks();
     if (panel === 'calls') void fetchCalls();
     if (panel === 'traces') void fetchTraces();
+    if (panel === 'traffic') void fetchTraffic();
     if (panel === 'stats') void fetchStats();
     if (panel === 'governance') void fetchGovernance();
     if (panel === 'skill-paths') void fetchSkillInventory();
     if (panel === 'logs') void fetchLogs();
-  }, [fetchActivity, fetchCalls, fetchDebug, fetchGovernance, fetchHealth, fetchInstanceBackends, fetchLogs, fetchOpenApi, fetchSetup, fetchSkillInventory, fetchStats, fetchTasks, fetchTools, fetchTraces, fetchWorkflows]);
+  }, [fetchActivity, fetchCalls, fetchDebug, fetchGovernance, fetchHealth, fetchInstanceBackends, fetchLogs, fetchOpenApi, fetchSetup, fetchSkillInventory, fetchStats, fetchTasks, fetchTools, fetchTraces, fetchTraffic, fetchWorkflows]);
 
   useEffect(() => {
     fetchPanel(activePanel);
@@ -3574,6 +3713,7 @@ function App() {
                 {activePanel === 'tasks' ? `${filteredTasks.length} / ${tasks.length}` : ''}
                 {activePanel === 'calls' ? `${filteredCalls.length} / ${calls.length}` : ''}
                 {activePanel === 'traces' ? `${filteredTraces.length} / ${traces.length}` : ''}
+                {activePanel === 'traffic' ? `${filteredTrafficFrames.length} / ${trafficFrames.length}` : ''}
                 {activePanel === 'governance' ? `${filteredGovernanceDecisions.length} / ${governance?.recent_decisions?.length ?? 0}` : ''}
                 {activePanel === 'skill-paths' ? `${filteredSkills.length} skill(s), ${filteredSkillPaths.length} path(s)` : ''}
                 {activePanel === 'logs' ? `${filteredLogs.length} / ${logs.length}` : ''}
@@ -4172,6 +4312,103 @@ function App() {
                   onCopyIssueReport={(requestId) => void copyIssueReport(requestId)}
                   onDownloadIssueReport={(requestId) => void downloadIssueReport(requestId)}
                 />
+              </div>
+            )}
+          </section>
+        )}
+
+        {activePanel === 'traffic' && (
+          <section className="panel active traffic-panel" data-panel="traffic">
+            <PanelHeader
+              title="Traffic"
+              meta="Live retained MCP/HTTP frames from the admin_live traffic sink."
+              action={(
+                <div className="table-actions">
+                  <a
+                    className="refresh-btn"
+                    href={traffic?.links?.traffic_export_jsonl_url ?? `${API_BASE}/traffic/export?limit=1000`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Export JSONL
+                  </a>
+                  <button className="refresh-btn" type="button" onClick={fetchTraffic}>Refresh</button>
+                </div>
+              )}
+            />
+            <StatusLine text={copiedNotice || updatedAt.traffic} error={errors.traffic} />
+            <div className="metric-grid compact">
+              <MetricTile label="Retained" value={trafficFrames.length} detail={`${filteredTrafficFrames.length} visible`} />
+              <MetricTile label="Sessions" value={trafficSummary.sessions} />
+              <MetricTile label="Transports" value={trafficSummary.transports} />
+              <MetricTile tone={trafficSummary.redacted > 0 ? 'warn' : undefined} label="Redactions" value={trafficSummary.redacted} />
+              <MetricTile label="Payload" value={formatBytes(trafficSummary.bytes)} />
+            </div>
+            {trafficFrames.length === 0 ? <p className="empty">No live traffic frames retained. Configure a traffic sink with kind admin_live to populate this panel.</p> : filteredTrafficFrames.length === 0 ? (
+              <p className="empty">No traffic frames match your search.</p>
+            ) : (
+              <div className="trace-layout">
+                <div className="trace-list">
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>Time</th>
+                        <th>Request</th>
+                        <th>Method</th>
+                        <th>Leg</th>
+                        <th>HTTP</th>
+                        <th>Session</th>
+                        <th>Bytes</th>
+                        <th>Redaction</th>
+                        <th>Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {filteredTrafficFrames.map((frame, index) => {
+                        const requestId = trafficRequestId(frame);
+                        return (
+                          <tr key={frame.id ?? `${requestId ?? 'traffic'}-${index}`}>
+                            <td><TimeValue value={trafficTimestamp(frame)} /></td>
+                            <td>
+                              <span className="mono-path">{compactId(requestId)}</span>
+                              <div className="muted">{compactId(frame.correlation?.trace_id)}</div>
+                            </td>
+                            <td>
+                              <span className="mono-path">{trafficMethod(frame)}</span>
+                              <div className="muted">{frame.attributes?.mcp?.kind ?? '-'}</div>
+                            </td>
+                            <td>
+                              {frame.attributes?.leg ?? '-'}
+                              <div className="muted">{frame.attributes?.transport ?? '-'}</div>
+                            </td>
+                            <td>
+                              {frame.attributes?.http?.method ?? '-'} {frame.attributes?.http?.url ?? ''}
+                              <div className="muted">{frame.attributes?.http?.status ?? '-'}</div>
+                            </td>
+                            <td className="mono-path">{compactId(trafficSessionId(frame))}</td>
+                            <td>{formatBytes(trafficBodyBytes(frame))}</td>
+                            <td className="mono-path">{compactList(trafficRedactedPaths(frame), 'none')}</td>
+                            <td>
+                              <div className="table-actions">
+                                <button className="refresh-btn" type="button" onClick={() => setTrafficDetail(trafficFrameDetail(frame))}>View</button>
+                                {requestId ? (
+                                  <button className="refresh-btn" type="button" onClick={() => goToPanel('traces', { traceId: requestId })}>Trace</button>
+                                ) : null}
+                              </div>
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+                <div className="trace-detail-card">
+                  <div className="trace-card-head">
+                    <h3>Frame JSON</h3>
+                    <button className="refresh-btn" type="button" onClick={() => void copyText(trafficDetail, 'traffic frame JSON')}>Copy</button>
+                  </div>
+                  <pre className="payload-pre">{trafficDetail}</pre>
+                </div>
               </div>
             )}
           </section>

--- a/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
@@ -44,6 +44,10 @@ fn issue_report_filename(request_id: &str) -> String {
     format!("dcc-mcp-issue-report-{safe}.json")
 }
 
+fn traffic_export_filename() -> &'static str {
+    "dcc-mcp-traffic-capture.jsonl"
+}
+
 /// `GET /admin` — serve the inline HTML dashboard.
 pub async fn handle_admin_ui() -> impl IntoResponse {
     let mut resp = axum::response::Html(ADMIN_HTML).into_response();
@@ -70,6 +74,62 @@ pub async fn handle_admin_governance(
 ) -> impl IntoResponse {
     let limit = params.limit(200, 1_000);
     Json(crate::gateway::admin::governance::build_governance_payload(&s, limit).await)
+}
+
+/// `GET /admin/api/traffic?limit=200` — retained live traffic frames.
+pub async fn handle_admin_traffic(
+    State(s): State<AdminState>,
+    headers: HeaderMap,
+    OriginalUri(uri): OriginalUri,
+    Query(params): Query<DebugListQuery>,
+) -> impl IntoResponse {
+    let links = AdminLinkBuilder::from_request(&headers, &uri);
+    let limit = params.limit(200, 1_000);
+    let frames: Vec<Value> = s
+        .gateway
+        .traffic_capture
+        .recent_frames(limit)
+        .into_iter()
+        .map(|frame| frame.to_value())
+        .collect();
+    Json(json!({
+        "total": frames.len(),
+        "frames": frames,
+        "links": {
+            "admin_traffic_url": links.panel_url("traffic"),
+            "traffic_api_url": links.api_url("/traffic"),
+            "traffic_export_jsonl_url": links.api_url("/traffic/export"),
+        }
+    }))
+}
+
+/// `GET /admin/api/traffic/export?limit=1000` — retained live frames as JSONL.
+pub async fn handle_admin_traffic_export(
+    State(s): State<AdminState>,
+    Query(params): Query<DebugListQuery>,
+) -> impl IntoResponse {
+    let limit = params.limit(1_000, 10_000);
+    let mut body = String::new();
+    for frame in s.gateway.traffic_capture.recent_frames(limit) {
+        if let Ok(line) = serde_json::to_string(&frame.to_value()) {
+            body.push_str(&line);
+            body.push('\n');
+        }
+    }
+    let mut response = (StatusCode::OK, body).into_response();
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/x-ndjson; charset=utf-8"),
+    );
+    response.headers_mut().insert(
+        header::CONTENT_DISPOSITION,
+        HeaderValue::from_str(&format!(
+            "attachment; filename=\"{}\"",
+            traffic_export_filename()
+        ))
+        .unwrap_or_else(|_| HeaderValue::from_static("attachment")),
+    );
+    response
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/crates/dcc-mcp-gateway/src/gateway/admin/links.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/links.rs
@@ -62,6 +62,15 @@ impl AdminLinkBuilder {
     pub(super) fn panel_url(&self, panel: &str) -> String {
         format!("{}{}?panel={panel}", self.origin, self.admin_base)
     }
+
+    pub(super) fn api_url(&self, path: &str) -> String {
+        let suffix = if path.starts_with('/') {
+            path.to_string()
+        } else {
+            format!("/{path}")
+        };
+        format!("{}{}/api{suffix}", self.origin, self.admin_base)
+    }
 }
 
 fn header_value(headers: &HeaderMap, name: &str) -> Option<String> {

--- a/crates/dcc-mcp-gateway/src/gateway/admin/router.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/router.rs
@@ -9,8 +9,8 @@ use super::handlers::{
     handle_admin_search_telemetry, handle_admin_skill_detail, handle_admin_skill_path_add,
     handle_admin_skill_path_delete, handle_admin_skill_paths, handle_admin_skills,
     handle_admin_stats, handle_admin_tasks, handle_admin_tools, handle_admin_trace_detail,
-    handle_admin_traces, handle_admin_ui, handle_admin_workers, handle_admin_workflows,
-    handle_v1_debug_trace_lookup,
+    handle_admin_traces, handle_admin_traffic, handle_admin_traffic_export, handle_admin_ui,
+    handle_admin_workers, handle_admin_workflows, handle_v1_debug_trace_lookup,
 };
 use super::state::AdminState;
 
@@ -28,6 +28,8 @@ use super::state::AdminState;
 /// - `GET  /api/calls`              → JSON recent calls
 /// - `GET  /api/traces`             → JSON recent dispatch traces (Phase 2)
 /// - `GET  /api/traces/{request_id}` → full trace waterfall for one call
+/// - `GET  /api/traffic`            → retained live traffic capture frames
+/// - `GET  /api/traffic/export`     → retained live traffic frames as JSONL
 /// - `GET  /api/issue-report/{request_id}` → downloadable JSON issue report
 /// - `GET  /api/workflows`          → agent/session workflow projection
 /// - `GET  /api/stats?range=1h|24h|7d` → aggregated call statistics (Phase 3)
@@ -46,6 +48,11 @@ pub fn build_admin_router(state: AdminState) -> Router {
         .route("/api/skill-detail", routing::get(handle_admin_skill_detail))
         .route("/api/calls", routing::get(handle_admin_calls))
         .route("/api/traces", routing::get(handle_admin_traces))
+        .route("/api/traffic", routing::get(handle_admin_traffic))
+        .route(
+            "/api/traffic/export",
+            routing::get(handle_admin_traffic_export),
+        )
         .route(
             "/api/traces/{request_id}",
             routing::get(handle_admin_trace_detail),
@@ -89,6 +96,11 @@ pub fn build_v1_debug_router(state: AdminState) -> Router {
         .route("/v1/debug/activity", routing::get(handle_admin_activity))
         .route("/v1/debug/calls", routing::get(handle_admin_calls))
         .route("/v1/debug/traces", routing::get(handle_admin_traces))
+        .route("/v1/debug/traffic", routing::get(handle_admin_traffic))
+        .route(
+            "/v1/debug/traffic/export",
+            routing::get(handle_admin_traffic_export),
+        )
         .route(
             "/v1/debug/traces/{request_id}",
             routing::get(handle_admin_trace_detail),

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -161,6 +161,21 @@ mod admin_tests {
         (status, json)
     }
 
+    async fn body_text(router: Router, uri: &str) -> (StatusCode, String) {
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri(uri)
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = resp.status();
+        let bytes = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
+        (status, String::from_utf8(bytes.to_vec()).unwrap())
+    }
+
     fn audit_record(
         request_id: &str,
         action: &str,
@@ -229,6 +244,51 @@ redact:
         )
         .unwrap();
         crate::gateway::traffic::TrafficCapture::from_config_path(config_path).unwrap()
+    }
+
+    fn admin_live_capture() -> crate::gateway::traffic::TrafficCapture {
+        let suffix = uuid::Uuid::new_v4().simple().to_string();
+        let config_path = std::env::temp_dir().join(format!("dcc-mcp-admin-live-{suffix}.yaml"));
+        std::fs::write(
+            &config_path,
+            r#"
+enabled: true
+sinks:
+  - kind: admin_live
+    ring_buffer: 2
+"#,
+        )
+        .unwrap();
+        crate::gateway::traffic::TrafficCapture::from_config_path(config_path).unwrap()
+    }
+
+    fn traffic_frame(
+        method: &'static str,
+        request_id: &str,
+    ) -> crate::gateway::traffic::TrafficFrame {
+        crate::gateway::traffic::TrafficFrame::json(
+            crate::gateway::traffic::basic_gateway_source(),
+            crate::gateway::traffic::correlation(
+                Some(request_id),
+                Some("trace-traffic"),
+                Some("session-traffic"),
+            ),
+            "inbound",
+            "client_to_gateway",
+            "mcp-http",
+            json!({
+                "jsonrpc": "2.0",
+                "method": method,
+                "id": request_id,
+            }),
+        )
+        .with_session_id(Some("session-traffic"))
+        .with_http(crate::gateway::traffic::http_post("/mcp", None, Some(200)))
+        .with_mcp(crate::gateway::traffic::mcp_message(
+            "request",
+            method,
+            Some(json!(request_id)),
+        ))
     }
 
     async fn spawn_search_backend(hits: Value) -> (u16, oneshot::Sender<()>) {
@@ -365,6 +425,8 @@ redact:
         let (status, doc) = body_json(router, "/v1/openapi.json").await;
         assert_eq!(status, StatusCode::OK);
         assert!(doc["paths"].get("/v1/debug/instances").is_some());
+        assert!(doc["paths"].get("/v1/debug/traffic").is_some());
+        assert!(doc["paths"].get("/v1/debug/traffic/export").is_some());
         assert!(doc["paths"].get("/v1/debug/deregistered").is_some());
     }
 
@@ -879,6 +941,55 @@ redact:
         assert_eq!(debug_status, StatusCode::OK);
         assert_eq!(debug_body["stats"]["recent_policy_denied"], 1);
         assert_eq!(debug_body["stats"]["recent_throttled"], 1);
+    }
+
+    #[tokio::test]
+    async fn test_admin_traffic_returns_live_frames_and_export() {
+        let capture = admin_live_capture();
+        capture.emit_json_frame(traffic_frame("tools/list", "req-live-1"));
+        capture.emit_json_frame(traffic_frame("tools/call", "req-live-2"));
+        capture.emit_json_frame(traffic_frame("resources/read", "req-live-3"));
+
+        let mut gs = make_gateway_state();
+        gs.traffic_capture = Arc::new(capture);
+        let state = AdminState::new(gs);
+        let router = build_admin_router(state.clone());
+
+        let (status, body) = body_json(router.clone(), "/api/traffic?limit=10").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["total"], 2);
+        let frames = body["frames"].as_array().unwrap();
+        assert_eq!(frames[0]["attributes"]["mcp"]["method"], "resources/read");
+        assert_eq!(frames[0]["correlation"]["request_id"], "req-live-3");
+        assert_eq!(frames[1]["attributes"]["mcp"]["method"], "tools/call");
+        assert!(
+            body["links"]["admin_traffic_url"]
+                .as_str()
+                .is_some_and(|url| url.ends_with("/admin?panel=traffic"))
+        );
+        assert!(
+            body["links"]["traffic_export_jsonl_url"]
+                .as_str()
+                .is_some_and(|url| url.ends_with("/admin/api/traffic/export"))
+        );
+
+        let (export_status, export_body) =
+            body_text(router.clone(), "/api/traffic/export?limit=10").await;
+        assert_eq!(export_status, StatusCode::OK);
+        let lines: Vec<&str> = export_body.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("\"traffic.frame\""));
+        assert!(lines[0].contains("\"resources/read\""));
+        assert!(lines[1].contains("\"tools/call\""));
+
+        let v1_router = build_v1_debug_router(state);
+        let (debug_status, debug_body) = body_json(v1_router, "/v1/debug/traffic?limit=1").await;
+        assert_eq!(debug_status, StatusCode::OK);
+        assert_eq!(debug_body["total"], 1);
+        assert_eq!(
+            debug_body["frames"][0]["attributes"]["mcp"]["method"],
+            "resources/read"
+        );
     }
 
     #[tokio::test]

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/debug_openapi.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/debug_openapi.rs
@@ -1,4 +1,4 @@
-use serde_json::{Value, json};
+use serde_json::{Map, Value, json};
 
 #[cfg(feature = "admin")]
 pub(crate) fn add_gateway_debug_openapi_paths(doc: &mut Value) {
@@ -84,6 +84,12 @@ pub(crate) fn add_gateway_debug_openapi_paths(doc: &mut Value) {
             list_params.clone(),
         ),
         (
+            "/v1/debug/traffic",
+            "List live traffic capture frames",
+            "Stable agent-facing retained traffic.frame list from an explicit admin_live traffic sink.",
+            list_params.clone(),
+        ),
+        (
             "/v1/debug/traces/{request_id}",
             "Get one debug trace by request id",
             "Stable agent-facing dispatch trace detail lookup.",
@@ -159,6 +165,16 @@ pub(crate) fn add_gateway_debug_openapi_paths(doc: &mut Value) {
             debug_get_path(summary, description, params),
         );
     }
+    paths.insert(
+        "/v1/debug/traffic/export".to_string(),
+        debug_get_path_with_content(
+            "Export live traffic capture JSONL",
+            "Download the retained admin_live traffic.frame window as newline-delimited JSON.",
+            limit_params.clone(),
+            "application/x-ndjson",
+            json!({"type": "string", "format": "binary"}),
+        ),
+    );
 
     if let Some(schemas) = doc
         .pointer_mut("/components/schemas")
@@ -190,6 +206,25 @@ pub(crate) fn add_gateway_debug_openapi_paths(doc: &mut Value) {
 
 #[cfg(feature = "admin")]
 fn debug_get_path(summary: &str, description: &str, parameters: Vec<Value>) -> Value {
+    debug_get_path_with_content(
+        summary,
+        description,
+        parameters,
+        "application/json",
+        json!({"$ref": "#/components/schemas/GatewayDebugPayload"}),
+    )
+}
+
+#[cfg(feature = "admin")]
+fn debug_get_path_with_content(
+    summary: &str,
+    description: &str,
+    parameters: Vec<Value>,
+    content_type: &str,
+    schema: Value,
+) -> Value {
+    let mut content = Map::new();
+    content.insert(content_type.to_string(), json!({ "schema": schema }));
     json!({
         "get": {
             "tags": ["debug"],
@@ -199,11 +234,7 @@ fn debug_get_path(summary: &str, description: &str, parameters: Vec<Value>) -> V
             "responses": {
                 "200": {
                     "description": "Debug payload",
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/GatewayDebugPayload"}
-                        }
-                    }
+                    "content": Value::Object(content)
                 },
                 "404": {
                     "description": "Debug record not found",

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
@@ -486,6 +486,8 @@ async fn gateway_openapi_lists_stable_debug_routes() {
         "/v1/debug/activity",
         "/v1/debug/calls",
         "/v1/debug/traces",
+        "/v1/debug/traffic",
+        "/v1/debug/traffic/export",
         "/v1/debug/traces/{request_id}",
         "/v1/debug/trace-context/{lookup_id}",
         "/v1/debug/tasks",

--- a/crates/dcc-mcp-gateway/src/gateway/traffic/config.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/traffic/config.rs
@@ -16,7 +16,6 @@ pub(super) struct TrafficCaptureDocument {
 pub(super) struct TrafficSinkDocument {
     pub(super) kind: String,
     pub(super) path: Option<String>,
-    #[allow(dead_code)]
     pub(super) ring_buffer: Option<usize>,
 }
 

--- a/crates/dcc-mcp-gateway/src/gateway/traffic/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/traffic/mod.rs
@@ -29,7 +29,7 @@ pub use self::frame::{
     TrafficFrame, basic_gateway_source, correlation, gateway_source, http_post, mcp_message,
 };
 use self::redaction::{TrafficRedactionSnapshot, TrafficRedactor};
-use self::sink::{JsonlTrafficSink, SqliteTrafficSink, TrafficSink};
+use self::sink::{JsonlTrafficSink, LiveTrafficSink, SqliteTrafficSink, TrafficSink};
 
 pub const TRAFFIC_FRAME_EVENT: &str = "traffic.frame";
 pub const TRAFFIC_FRAME_SCHEMA_VERSION: u32 = 1;
@@ -38,12 +38,15 @@ const ENV_CONFIG: &str = "DCC_MCP_TRAFFIC_CONFIG";
 const ENV_PROD_PROFILE: &str = "DCC_MCP_PROD_PROFILE";
 const ENV_FORCE_CAPTURE: &str = "DCC_MCP_FORCE_TRAFFIC_CAPTURE";
 const DECISION_LOG_CAPACITY: usize = 200;
+const DEFAULT_LIVE_RING_CAPACITY: usize = 5_000;
+const MAX_LIVE_RING_CAPACITY: usize = 10_000;
 
 /// Gateway traffic capture bus plus optional sinks.
 pub struct TrafficCapture {
     event_bus: EventBus,
     sinks: Vec<Arc<dyn TrafficSink>>,
     sink_descriptors: Vec<TrafficSinkSnapshot>,
+    live_sink: Option<Arc<LiveTrafficSink>>,
     filter: TrafficFilter,
     redactor: TrafficRedactor,
     next_capture_id: AtomicU64,
@@ -56,6 +59,7 @@ impl std::fmt::Debug for TrafficCapture {
             .field("event_bus", &self.event_bus)
             .field("sink_count", &self.sinks.len())
             .field("sink_descriptors", &self.sink_descriptors)
+            .field("live_sink", &self.live_sink.is_some())
             .field("filter", &self.filter)
             .field("redactor", &self.redactor)
             .finish()
@@ -75,6 +79,7 @@ impl TrafficCapture {
             event_bus: EventBus::new(),
             sinks: Vec::new(),
             sink_descriptors: Vec::new(),
+            live_sink: None,
             filter: TrafficFilter::default(),
             redactor: TrafficRedactor::default(),
             next_capture_id: AtomicU64::new(0),
@@ -129,7 +134,9 @@ impl TrafficCapture {
             sink_descriptors: vec![TrafficSinkSnapshot {
                 kind: "jsonl".to_string(),
                 path: Some(path.as_ref().to_string_lossy().to_string()),
+                ring_buffer_capacity: None,
             }],
+            live_sink: None,
             filter: TrafficFilter::default(),
             redactor: TrafficRedactor::default(),
             next_capture_id: AtomicU64::new(0),
@@ -145,14 +152,15 @@ impl TrafficCapture {
         let redactor = TrafficRedactor::from_document(document.redact)?;
         let mut sinks: Vec<Arc<dyn TrafficSink>> = Vec::new();
         let mut sink_descriptors = Vec::new();
+        let mut live_sink = None;
 
         for sink in document.sinks.unwrap_or_default() {
-            let descriptor = sink_descriptor(&sink, base_dir)?;
-            if let Some(sink) = open_sink(sink, base_dir)? {
-                sinks.push(sink);
-                if let Some(descriptor) = descriptor {
-                    sink_descriptors.push(descriptor);
+            if let Some(opened) = open_sink(sink, base_dir)? {
+                if let Some(live) = opened.live_sink.clone() {
+                    live_sink = Some(live);
                 }
+                sink_descriptors.push(opened.descriptor);
+                sinks.push(opened.sink);
             }
         }
 
@@ -160,6 +168,7 @@ impl TrafficCapture {
             event_bus: EventBus::new(),
             sinks,
             sink_descriptors,
+            live_sink,
             filter,
             redactor,
             next_capture_id: AtomicU64::new(0),
@@ -270,6 +279,14 @@ impl TrafficCapture {
         }
     }
 
+    #[must_use]
+    pub fn recent_frames(&self, limit: usize) -> Vec<EventEnvelope> {
+        self.live_sink
+            .as_ref()
+            .map(|sink| sink.recent(limit))
+            .unwrap_or_default()
+    }
+
     fn next_frame_id(&self) -> String {
         let seq = self.next_capture_id.fetch_add(1, Ordering::Relaxed) + 1;
         format!("cap_{seq:016x}")
@@ -302,6 +319,8 @@ pub struct TrafficSinkSnapshot {
     pub kind: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ring_buffer_capacity: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -411,21 +430,49 @@ pub enum TrafficCaptureError {
 fn open_sink(
     sink: TrafficSinkDocument,
     base_dir: &Path,
-) -> Result<Option<Arc<dyn TrafficSink>>, TrafficCaptureError> {
+) -> Result<Option<OpenedTrafficSink>, TrafficCaptureError> {
     match sink.kind.trim().to_ascii_lowercase().as_str() {
         "file_jsonl" | "jsonl" => {
             let path = sink.path_required()?;
-            Ok(Some(Arc::new(JsonlTrafficSink::open(
-                &resolve_capture_path(base_dir, &path),
-            )?)))
+            let resolved = resolve_capture_path(base_dir, &path);
+            Ok(Some(OpenedTrafficSink {
+                sink: Arc::new(JsonlTrafficSink::open(&resolved)?),
+                descriptor: TrafficSinkSnapshot {
+                    kind: sink.kind.trim().to_ascii_lowercase(),
+                    path: Some(resolved.to_string_lossy().to_string()),
+                    ring_buffer_capacity: None,
+                },
+                live_sink: None,
+            }))
         }
         "sqlite" => {
             let path = sink.path_required()?;
-            Ok(Some(Arc::new(SqliteTrafficSink::open(
-                &resolve_capture_path(base_dir, &path),
-            )?)))
+            let resolved = resolve_capture_path(base_dir, &path);
+            Ok(Some(OpenedTrafficSink {
+                sink: Arc::new(SqliteTrafficSink::open(&resolved)?),
+                descriptor: TrafficSinkSnapshot {
+                    kind: "sqlite".to_string(),
+                    path: Some(resolved.to_string_lossy().to_string()),
+                    ring_buffer_capacity: None,
+                },
+                live_sink: None,
+            }))
         }
-        "admin_live" | "ot_exporter" => {
+        "admin_live" => {
+            let capacity = live_ring_capacity(sink.ring_buffer);
+            let live = Arc::new(LiveTrafficSink::new(capacity));
+            let trait_sink: Arc<dyn TrafficSink> = live.clone();
+            Ok(Some(OpenedTrafficSink {
+                sink: trait_sink,
+                descriptor: TrafficSinkSnapshot {
+                    kind: "admin_live".to_string(),
+                    path: None,
+                    ring_buffer_capacity: Some(capacity),
+                },
+                live_sink: Some(live),
+            }))
+        }
+        "ot_exporter" => {
             tracing::warn!(
                 kind = %sink.kind,
                 "traffic capture sink is reserved for a later RFC 0003 phase; skipping"
@@ -436,25 +483,16 @@ fn open_sink(
     }
 }
 
-fn sink_descriptor(
-    sink: &TrafficSinkDocument,
-    base_dir: &Path,
-) -> Result<Option<TrafficSinkSnapshot>, TrafficCaptureError> {
-    match sink.kind.trim().to_ascii_lowercase().as_str() {
-        "file_jsonl" | "jsonl" | "sqlite" => {
-            let path = sink.path_required()?;
-            Ok(Some(TrafficSinkSnapshot {
-                kind: sink.kind.trim().to_ascii_lowercase(),
-                path: Some(
-                    resolve_capture_path(base_dir, &path)
-                        .to_string_lossy()
-                        .to_string(),
-                ),
-            }))
-        }
-        "admin_live" | "ot_exporter" => Ok(None),
-        other => Err(TrafficCaptureError::UnsupportedSink(other.to_string())),
-    }
+struct OpenedTrafficSink {
+    sink: Arc<dyn TrafficSink>,
+    descriptor: TrafficSinkSnapshot,
+    live_sink: Option<Arc<LiveTrafficSink>>,
+}
+
+fn live_ring_capacity(configured: Option<usize>) -> usize {
+    configured
+        .unwrap_or(DEFAULT_LIVE_RING_CAPACITY)
+        .clamp(1, MAX_LIVE_RING_CAPACITY)
 }
 
 fn resolve_capture_path(base_dir: &Path, raw: &str) -> PathBuf {
@@ -652,6 +690,50 @@ filters:
         assert_eq!(row.1, "sess-1");
         assert_eq!(row.2, "tools/call");
         assert_eq!(row.3, "/mcp");
+    }
+
+    #[test]
+    fn admin_live_sink_retains_recent_frames() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("traffic_capture.yaml");
+        std::fs::write(
+            &config_path,
+            r#"
+enabled: true
+sinks:
+  - kind: admin_live
+    ring_buffer: 2
+"#,
+        )
+        .unwrap();
+
+        let capture = TrafficCapture::from_config_path(&config_path).unwrap();
+        capture.emit_json_frame(sample_frame("tools/list", "/mcp"));
+        capture.emit_json_frame(sample_frame("tools/call", "/mcp"));
+        capture.emit_json_frame(sample_frame("resources/read", "/mcp"));
+
+        let frames = capture.recent_frames(10);
+        assert_eq!(frames.len(), 2);
+        assert_eq!(
+            frames[0]
+                .attributes
+                .pointer("/mcp/method")
+                .and_then(Value::as_str),
+            Some("resources/read")
+        );
+        assert_eq!(
+            frames[1]
+                .attributes
+                .pointer("/mcp/method")
+                .and_then(Value::as_str),
+            Some("tools/call")
+        );
+
+        let snapshot = capture.governance_snapshot();
+        assert!(snapshot.enabled);
+        assert_eq!(snapshot.sink_count, 1);
+        assert_eq!(snapshot.sinks[0].kind, "admin_live");
+        assert_eq!(snapshot.sinks[0].ring_buffer_capacity, Some(2));
     }
 
     #[test]

--- a/crates/dcc-mcp-gateway/src/gateway/traffic/sink.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/traffic/sink.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::path::Path;
@@ -11,6 +12,42 @@ use super::TrafficCaptureError;
 
 pub(super) trait TrafficSink: Send + Sync + std::fmt::Debug {
     fn record(&self, event: &EventEnvelope);
+}
+
+#[derive(Debug)]
+pub(super) struct LiveTrafficSink {
+    capacity: usize,
+    frames: Mutex<VecDeque<EventEnvelope>>,
+}
+
+impl LiveTrafficSink {
+    pub(super) fn new(capacity: usize) -> Self {
+        Self {
+            capacity: capacity.max(1),
+            frames: Mutex::new(VecDeque::with_capacity(capacity.max(1))),
+        }
+    }
+
+    pub(super) fn recent(&self, limit: usize) -> Vec<EventEnvelope> {
+        let Ok(frames) = self.frames.lock() else {
+            tracing::warn!("traffic capture: live sink lock poisoned");
+            return Vec::new();
+        };
+        frames.iter().rev().take(limit).cloned().collect()
+    }
+}
+
+impl TrafficSink for LiveTrafficSink {
+    fn record(&self, event: &EventEnvelope) {
+        let Ok(mut frames) = self.frames.lock() else {
+            tracing::warn!("traffic capture: live sink lock poisoned");
+            return;
+        };
+        frames.push_back(event.clone());
+        while frames.len() > self.capacity {
+            frames.pop_front();
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -105,6 +105,8 @@ Markdown body for developer review.
 | `GET /admin/api/calls` | `application/json` | Recent tool calls, including compact/JSON token accounting when available (requires `AuditMiddleware`) |
 | `GET /admin/api/traces` | `application/json` | Recent per-call dispatch traces with payload sizes and token accounting; accepts `?limit=200` |
 | `GET /admin/api/traces/{request_id}` | `application/json` | Full waterfall for one recorded dispatch trace, including token accounting without storing unbounded payloads |
+| `GET /admin/api/traffic?limit=300` | `application/json` | Retained live `traffic.frame` envelopes from an explicit `admin_live` traffic sink |
+| `GET /admin/api/traffic/export?limit=1000` | `application/x-ndjson` | Retained live traffic frames as JSONL for local capture replay/diff workflows |
 | `GET /admin/api/debug-bundle/{request_id}` | `application/json` | One-stop debug bundle containing the trace, matching audit row, related activity, and hints |
 | `GET /admin/api/stats?range=1h\|24h\|7d` | `application/json` | Aggregated call counts, success rate, latency, top tools/instances/agents, and token-savings totals |
 | `GET /admin/api/governance?limit=300` | `application/json` | Effective gateway policy, traffic capture, redaction, middleware controls, and recent allow/deny/throttle decisions |
@@ -127,6 +129,8 @@ compatibility layer; automation should prefer:
 | `GET /v1/debug/activity?limit=300` | `/admin/api/activity` |
 | `GET /v1/debug/traces?limit=200` | `/admin/api/traces` |
 | `GET /v1/debug/traces/{request_id}` | `/admin/api/traces/{request_id}` |
+| `GET /v1/debug/traffic?limit=300` | `/admin/api/traffic` |
+| `GET /v1/debug/traffic/export?limit=1000` | `/admin/api/traffic/export` |
 | `GET /v1/debug/trace-context/{lookup_id}` | trace id or request id lookup |
 | `GET /v1/debug/bundles/{request_id_or_trace_id}` | `/admin/api/debug-bundle/{request_id}` |
 | `GET /v1/debug/issue-reports/{request_id}` | `/admin/api/issue-report/{request_id}` |
@@ -641,6 +645,7 @@ The HTML dashboard includes:
 - **Instance OpenAPI links**: Debug Workbench and instance cards expose `Inspector`, `spec`, and `docs` links generated from each worker `mcp_url`, so an operator can jump from MCP-level telemetry to the lower OpenAPI contract for that exact backend.
 - **Calls table**: request ids, error previews, and trace-detail links; DCC is displayed from the resolved backend slug when available, otherwise from explicit call arguments such as `dcc` / `dcc_type`.
 - **Trace drill-down**: `/admin/api/traces/{request_id}` exposes the full waterfall, optional agent/caller context, and bounded/redacted input/output payloads for one call.
+- **Traffic panel**: when a traffic config includes `kind: admin_live`, `/admin/api/traffic` exposes the retained in-memory frame ring and `/admin/api/traffic/export` downloads it as JSONL.
 - **Governance panel**: shows read-only state, allowlists, traffic capture mode/sinks, production guardrails, redaction path summaries, middleware rate-limit controls, and recent allowed/denied/throttled/capture decisions.
 - **Logs panel**: groups normalized `contention`, `file`, and `audit` rows so operators can correlate routing events, rolling files, and tool calls in one timeline. File log reads are bounded to recent files and tail slices so the admin API does not scan unbounded historical logs.
 - **Durable audit option**: `DCC_MCP_GATEWAY_AUDIT_DIR` preserves the Calls and Traces panels across restarts without changing the JSON API shapes.

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -160,6 +160,11 @@ Admin audit/trace persistence is configured by environment only: set `DCC_MCP_GA
 It never enables capture itself and does not need a live DCC unless you use
 `replay`.
 
+If the YAML config includes an `admin_live` sink, the retained in-memory window
+can be downloaded as JSONL from `/admin/api/traffic/export` (or the stable
+mirror `/v1/debug/traffic/export`) and then passed to `capture replay` or
+`capture diff` like any other capture file.
+
 ```bash
 # Replay recorded client -> gateway requests against a live gateway MCP endpoint.
 dcc-mcp-server capture replay ./captures/run.sqlite \

--- a/docs/guide/events.md
+++ b/docs/guide/events.md
@@ -158,6 +158,8 @@ sinks:
     path: ./captures/run-${TIMESTAMP}.db
   - kind: jsonl
     path: ./captures/run-${TIMESTAMP}.jsonl
+  - kind: admin_live
+    ring_buffer: 500
 filters:
   include:
     - mcp.method: tools/call
@@ -171,6 +173,8 @@ redact:
 Start the gateway with `DCC_MCP_TRAFFIC_CONFIG=./traffic_capture.yaml`. Relative
 sink paths resolve from the config file's directory, and `${TIMESTAMP}` expands
 once when the sink opens.
+The optional `admin_live` sink keeps a bounded in-memory ring for
+`/admin/api/traffic`, `/v1/debug/traffic`, and their JSONL export routes.
 
 ## Event Webhooks
 

--- a/docs/guide/gateway-diagnostics.md
+++ b/docs/guide/gateway-diagnostics.md
@@ -48,6 +48,8 @@ enabled: true
 sinks:
   - kind: sqlite
     path: ./captures/run-${TIMESTAMP}.db
+  - kind: admin_live
+    ring_buffer: 500
 filters:
   include:
     - mcp.method: tools/call
@@ -62,6 +64,11 @@ ORed, exclude rules win over includes, and simple `*` wildcards are supported
 for string fields such as `http.url`. Redaction paths are exact JSON paths under
 the frame attributes and are applied before JSONL or SQLite writes; changed
 paths are recorded in `attributes.body.redacted_paths`.
+
+The optional `admin_live` sink keeps a bounded in-memory ring buffer for the
+Admin Traffic panel and stable debug API. Inspect it through
+`GET /admin/api/traffic` or `GET /v1/debug/traffic`; export the retained window
+as JSONL with `/admin/api/traffic/export` or `/v1/debug/traffic/export`.
 
 Because frames can contain prompts, tool arguments, scene paths, and result
 payloads, treat capture files like debugging artifacts, not production audit

--- a/docs/guide/rest-api-surface.md
+++ b/docs/guide/rest-api-surface.md
@@ -48,6 +48,8 @@ continue to serve their own adapter OpenAPI contract from the same path.
 | `GET` | `/v1/debug/activity` | Gateway only: stable activity feed from audits, traces, and gateway events. |
 | `GET` | `/v1/debug/traces` | Gateway only: recent dispatch trace list. |
 | `GET` | `/v1/debug/traces/{request_id}` | Gateway only: dispatch trace detail by request id. |
+| `GET` | `/v1/debug/traffic` | Gateway only: retained live traffic-capture frames from an explicit `admin_live` sink. |
+| `GET` | `/v1/debug/traffic/export` | Gateway only: retained live traffic-capture frames as JSONL. |
 | `GET` | `/v1/debug/trace-context/{lookup_id}` | Gateway only: resolve trace id or request id to the primary trace context. |
 | `GET` | `/v1/debug/bundles/{request_id}` | Gateway only: full-chain debug bundle by request id or trace id. |
 | `GET` | `/v1/debug/issue-reports/{request_id}` | Gateway only: GitHub-attachable debug report JSON. |
@@ -116,6 +118,8 @@ so operators and agents can compare results one-to-one:
 | `/v1/debug/activity?limit=200` | `/admin/api/activity?limit=200` | Unified activity feed. |
 | `/v1/debug/traces?limit=200` | `/admin/api/traces?limit=200` | Recent dispatch trace rows. |
 | `/v1/debug/traces/{request_id}` | `/admin/api/traces/{request_id}` | Exact request-id trace detail. |
+| `/v1/debug/traffic?limit=300` | `/admin/api/traffic?limit=300` | Recent live traffic-capture frames from an `admin_live` sink. |
+| `/v1/debug/traffic/export?limit=1000` | `/admin/api/traffic/export?limit=1000` | Retained live traffic-capture frames as JSONL. |
 | `/v1/debug/trace-context/{lookup_id}` | n/a | Trace-context lookup by `trace_id` or `request_id`. |
 | `/v1/debug/bundles/{request_id}` | `/admin/api/debug-bundle/{request_id}` | Accepts request ids and retained trace ids. |
 | `/v1/debug/issue-reports/{request_id}` | `/admin/api/issue-report/{request_id}` | JSON export suitable for GitHub issue attachment. |

--- a/docs/zh/guide/admin-ui.md
+++ b/docs/zh/guide/admin-ui.md
@@ -98,6 +98,8 @@ let config = GatewayConfig {
 | `GET /admin/api/calls` | `application/json` | 最近的工具调用；可用时包含 compact/JSON token accounting（需要 `AuditMiddleware`） |
 | `GET /admin/api/traces` | `application/json` | 最近的逐调用 dispatch traces，包含 payload size 与 token accounting；支持 `?limit=200` |
 | `GET /admin/api/traces/{request_id}` | `application/json` | 某次调用的完整 waterfall trace，包含 token accounting 且不写入无界 payload |
+| `GET /admin/api/traffic?limit=300` | `application/json` | 显式 `admin_live` traffic sink 保留的 live `traffic.frame` envelopes |
+| `GET /admin/api/traffic/export?limit=1000` | `application/x-ndjson` | 将保留的 live traffic frames 导出为 JSONL，便于本地 replay/diff |
 | `GET /admin/api/debug-bundle/{request_id}` | `application/json` | 单次请求的一站式 debug bundle，包含 trace、匹配审计行、相关活动和提示 |
 | `GET /admin/api/stats?range=1h\|24h\|7d` | `application/json` | 聚合调用数、成功率、延迟、top tools/instances 和 token savings totals |
 | `GET /admin/api/governance?limit=300` | `application/json` | 当前 gateway policy、traffic capture、redaction、中间件控制和最近 allow/deny/throttle 决策 |
@@ -117,6 +119,8 @@ Admin 路由仍作为 dashboard 兼容层；自动化调用优先使用：
 |----------|------|
 | `GET /v1/debug/stats` | `/admin/api/stats` |
 | `GET /v1/debug/governance?limit=300` | `/admin/api/governance` |
+| `GET /v1/debug/traffic?limit=300` | `/admin/api/traffic` |
+| `GET /v1/debug/traffic/export?limit=1000` | `/admin/api/traffic/export` |
 | `GET /v1/debug/search-telemetry` | `/admin/api/search-telemetry` |
 | `GET /v1/debug/health` | `/admin/api/health` |
 
@@ -381,12 +385,13 @@ GatewayConfig {
 HTML 仪表盘包含：
 - **Debug Workbench**：默认首屏会组合 health、instances、calls、traces、stats 和 warning logs，方便排查 gateway 故障时不用在多个面板之间来回跳转
 - **Gateway owner identity**：Health 和 Debug 面板会展示来自 `gateway_name` / `DCC_MCP_GATEWAY_NAME` 的当前 `__gateway__` sentinel 标签，以及 challenger 候选
-- **左侧导航**：Debug / Activity / Health / 实例 / 工具 / Tasks / Calls / Traces / Stats / Skill paths / 日志面板
+- **左侧导航**：Debug / Activity / Health / 实例 / 工具 / Tasks / Calls / Traces / Traffic / Stats / Skill paths / 日志面板
 - **自动刷新**：每个面板每 5 秒轮询对应 JSON 端点
 - **DCC 图标**：Maya/Autodesk、Blender、GIMP、Inkscape、Krita、Unity、Unreal 等常见宿主显示可识别图标，自定义宿主使用安全 fallback
 - **Worker 卡片**：按实例展示状态、心跳与路由元数据
 - **Calls 表格**：展示 request id、错误摘要与 trace detail 链接；DCC 优先从解析后的 backend slug 展示，其次使用调用参数中的 `dcc` / `dcc_type`
 - **Trace 下钻**：`/admin/api/traces/{request_id}` 暴露单次调用的完整 waterfall，以及有界/已脱敏的输入输出 payload
+- **Traffic 面板**：当 traffic config 包含 `kind: admin_live` 时，`/admin/api/traffic` 暴露内存环形缓冲区中的 frame，`/admin/api/traffic/export` 可下载 JSONL
 - **Governance 面板**：展示 read-only 状态、allowlists、traffic capture 模式/sink、生产 guardrail、redaction path 汇总、中间件限流控制，以及最近 allowed/denied/throttled/capture 决策
 - **Logs 面板**：将标准化的 `contention`、`file`、`audit` 行分组，方便在一条时间线里关联路由事件、滚动日志和工具调用。文件日志读取会限制为最近文件与尾部片段，避免 admin API 扫描无界历史日志
 - **可选持久化**：`DCC_MCP_GATEWAY_AUDIT_DIR` 可让 Calls 与 Traces 面板跨重启保留，且不改变 JSON API 结构

--- a/docs/zh/guide/cli-reference.md
+++ b/docs/zh/guide/cli-reference.md
@@ -153,6 +153,10 @@ Admin 审计/trace 持久化只通过环境变量配置：设置 `DCC_MCP_GATEWA
 产生的离线 traffic capture 文件。它不会自动开启 capture；只有 `replay`
 模式需要一个在线 gateway。
 
+如果 YAML 配置包含 `admin_live` sink，可以从 `/admin/api/traffic/export`
+（或稳定镜像 `/v1/debug/traffic/export`）把保留在内存里的窗口下载为 JSONL，
+然后像其他 capture 文件一样交给 `capture replay` 或 `capture diff`。
+
 ```bash
 # 把记录下来的 client -> gateway 请求重放到在线 gateway MCP endpoint。
 dcc-mcp-server capture replay ./captures/run.sqlite \

--- a/docs/zh/guide/gateway-diagnostics.md
+++ b/docs/zh/guide/gateway-diagnostics.md
@@ -43,6 +43,8 @@ enabled: true
 sinks:
   - kind: sqlite
     path: ./captures/run-${TIMESTAMP}.db
+  - kind: admin_live
+    ring_buffer: 500
 filters:
   include:
     - mcp.method: tools/call
@@ -56,6 +58,11 @@ redact:
 OR 处理，exclude 优先于 include，字符串字段支持简单 `*` 通配符。redact 路径
 是 frame attributes 下的精确 JSON path，并且会在 JSONL / SQLite 写入前应用；
 被改写的路径记录在 `attributes.body.redacted_paths`。
+
+可选的 `admin_live` sink 会保留一个有界内存环形缓冲区，供 Admin Traffic
+面板和稳定 debug API 查看。通过 `GET /admin/api/traffic` 或
+`GET /v1/debug/traffic` 检查，使用 `/admin/api/traffic/export` 或
+`/v1/debug/traffic/export` 将保留窗口导出为 JSONL。
 
 捕获内容可能包含 prompt、工具参数、场景路径和结果 payload；把它当成本地调试
 产物，而不是生产审计日志。

--- a/docs/zh/guide/rest-api-surface.md
+++ b/docs/zh/guide/rest-api-surface.md
@@ -45,6 +45,8 @@ OpenAPI 契约。
 | `GET` | `/v1/debug/activity` | 仅网关：来自 audit、trace、gateway event 的稳定 activity feed。 |
 | `GET` | `/v1/debug/traces` | 仅网关：最近的 dispatch trace 列表。 |
 | `GET` | `/v1/debug/traces/{request_id}` | 仅网关：按 request id 查看 dispatch trace 详情。 |
+| `GET` | `/v1/debug/traffic` | 仅网关：显式 `admin_live` sink 保留的 live traffic-capture frames。 |
+| `GET` | `/v1/debug/traffic/export` | 仅网关：把保留的 live traffic-capture frames 导出为 JSONL。 |
 | `GET` | `/v1/debug/trace-context/{lookup_id}` | 仅网关：按 trace id 或 request id 解析 primary trace context。 |
 | `GET` | `/v1/debug/bundles/{request_id}` | 仅网关：按 request id 或 trace id 取 full-chain debug bundle。 |
 | `GET` | `/v1/debug/issue-reports/{request_id}` | 仅网关：可附到 GitHub issue 的 debug report JSON。 |
@@ -113,6 +115,8 @@ Phase-1 debug routes 会保留现有 Admin payload 字段，让 operator 和 age
 | `/v1/debug/activity?limit=200` | `/admin/api/activity?limit=200` | 统一 activity feed。 |
 | `/v1/debug/traces?limit=200` | `/admin/api/traces?limit=200` | 最近 dispatch trace rows。 |
 | `/v1/debug/traces/{request_id}` | `/admin/api/traces/{request_id}` | 精确 request-id trace detail。 |
+| `/v1/debug/traffic?limit=300` | `/admin/api/traffic?limit=300` | 来自 `admin_live` sink 的 live traffic-capture frames。 |
+| `/v1/debug/traffic/export?limit=1000` | `/admin/api/traffic/export?limit=1000` | 保留的 live traffic-capture frames JSONL。 |
 | `/v1/debug/trace-context/{lookup_id}` | n/a | 按 `trace_id` 或 `request_id` 做 trace-context lookup。 |
 | `/v1/debug/bundles/{request_id}` | `/admin/api/debug-bundle/{request_id}` | 接受 request ids 和 retained trace ids。 |
 | `/v1/debug/issue-reports/{request_id}` | `/admin/api/issue-report/{request_id}` | 适合附到 GitHub issue 的 JSON export。 |

--- a/skills/dcc-mcp-skill-developer/SKILL.md
+++ b/skills/dcc-mcp-skill-developer/SKILL.md
@@ -187,10 +187,14 @@ into a faster authoring loop.
    For local traffic debugging, prefer the gateway `traffic.frame` capture
    stream (`DCC_MCP_TRAFFIC_CAPTURE=jsonl:<path>` for quick capture, or
    `DCC_MCP_TRAFFIC_CONFIG=traffic_capture.yaml` for SQLite/filter/redact
-   capture) over ad-hoc print logging. Redactions are write-time exact JSON
+   capture plus optional `admin_live` in-memory inspection) over ad-hoc print
+   logging. Redactions are write-time exact JSON
    paths such as `body.data.params.arguments.api_key`, and capture files can
    contain prompts, scene paths, and tool arguments, so keep them as local
    debugging artifacts unless redaction has been applied. Use
+   `GET /v1/debug/traffic` to inspect retained `admin_live` frames and
+   `GET /v1/debug/traffic/export` to download the retained window as JSONL.
+   Use
    `dcc-mcp-server capture replay <capture> --target <gateway>/mcp` to replay
    captured client requests after a skill or prompt change, and
    `dcc-mcp-server capture diff <before> <after>` to compare observable


### PR DESCRIPTION
## Summary
- add the `admin_live` traffic capture sink with bounded in-memory retention
- expose retained frames through `/admin/api/traffic`, `/admin/api/traffic/export`, and stable `/v1/debug/traffic*` routes
- add the Admin Traffic panel plus docs and skill guidance for live inspection/export

Refs #1116

## Validation
- `vx npm --prefix admin-ui run build`
- `vx cargo test -p dcc-mcp-gateway --features admin --lib`
- `$env:DCC_MCP_ADMIN_UI_PREBUILT='1'; vx just preflight`