### PR TITLE
feat(admin): add admin token diagnostics and layout improvements

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -18,6 +18,26 @@ import { formatTime, timestampTitle } from './time';
 
 type Panel = 'setup' | 'debug' | 'activity' | 'health' | 'instances' | 'tools' | 'workflows' | 'tasks' | 'openapi' | 'calls' | 'traces' | 'traffic' | 'stats' | 'governance' | 'logs' | 'skill-paths';
 
+type SignalTone = 'ok' | 'warn' | 'err';
+
+type DebugSignal = {
+  key: string;
+  label: string;
+  value: string;
+  detail: string;
+  tone: SignalTone;
+  panel: Panel;
+  traceId?: string;
+};
+
+type FailureSignal = {
+  request_id: string;
+  status: string;
+  tool: string;
+  detail: string;
+  ms: number | null;
+};
+
 type HealthPayload = {
   status: string;
   instances_ready: number;
@@ -122,6 +142,10 @@ type TraceRow = {
   returned_tokens?: number | null;
   saved_tokens?: number | null;
   savings_pct?: number | string | null;
+  input_tokens?: number | null;
+  output_tokens?: number | null;
+  total_tokens?: number | null;
+  payload_token_estimator?: string | null;
   links?: AdminLinks;
 };
 
@@ -245,6 +269,7 @@ type TracePayload = {
   mime_type: string;
   truncated: boolean;
   original_size: number;
+  estimated_tokens?: number | null;
 };
 
 type TraceSpan = {
@@ -279,6 +304,12 @@ type TraceDetailPayload = {
   returned_tokens?: number | null;
   saved_tokens?: number | null;
   savings_pct?: number | string | null;
+  estimated_tokens?: number | null;
+  estimated_total_tokens?: number | null;
+  input_tokens?: number | null;
+  output_tokens?: number | null;
+  total_tokens?: number | null;
+  payload_token_estimator?: string | null;
   links?: AdminLinks;
 };
 
@@ -478,9 +509,18 @@ type StatsPayload = {
   successful_calls?: number;
   failed_calls?: number;
   success_rate: number;
+  total_tokens?: number | null;
+  total_input_tokens?: number | null;
+  total_output_tokens?: number | null;
+  avg_tokens_per_call?: number | null;
+  avg_input_tokens_per_call?: number | null;
+  avg_output_tokens_per_call?: number | null;
+  avg_total_tokens_per_call?: number | null;
+  payload_token_estimator?: string | null;
   p50_ms?: number | null;
   p95_ms?: number | null;
   latency_ms?: LatencyBlock;
+  top_app_types?: TopEntry[];
   top_tools?: TopEntry[];
   top_instances?: TopEntry[];
   top_agents?: TopEntry[];
@@ -1398,6 +1438,39 @@ function formatBytes(value: number | null | undefined): string {
   return `${size.toFixed(1)} ${units[index]}`;
 }
 
+function totalTraceTokens(row: TraceRow): number | null {
+  if (row.total_tokens != null) {
+    return row.total_tokens;
+  }
+  if (row.input_tokens == null && row.output_tokens == null) {
+    return null;
+  }
+  return (row.input_tokens ?? 0) + (row.output_tokens ?? 0);
+}
+
+function detailTraceTokens(trace: TraceDetailPayload): {
+  inputTokens: number | null;
+  outputTokens: number | null;
+  totalTokens: number | null;
+  estimatedTokens: number | null;
+  estimator: string | null;
+} {
+  const inputTokens = trace.input_tokens ?? trace.input?.estimated_tokens ?? null;
+  const outputTokens = trace.output_tokens ?? trace.output?.estimated_tokens ?? null;
+  const totalTokens = (() => {
+    if (trace.total_tokens != null) {
+      return trace.total_tokens;
+    }
+    if (inputTokens == null && outputTokens == null) {
+      return null;
+    }
+    return (inputTokens ?? 0) + (outputTokens ?? 0);
+  })();
+  const estimatedTokens = trace.estimated_total_tokens ?? trace.estimated_tokens ?? totalTokens;
+  const estimator = trace.payload_token_estimator ?? trace.token_accounting?.token_estimator ?? trace.token_estimator ?? null;
+  return { inputTokens, outputTokens, totalTokens, estimatedTokens, estimator };
+}
+
 function statusClass(value: string): string {
   const status = value.toLowerCase();
   if (status.includes('fail') || status.includes('error') || status.includes('err') || status.includes('rejected') || status.includes('cancel')) {
@@ -1765,35 +1838,40 @@ function SkillDetailPanel({
   );
 }
 
+function appTypeLabel(value: string | null | undefined): string {
+  const app = (value ?? 'unknown').trim() || 'unknown';
+  return `app-type: ${app}`;
+}
+
+function compactInstanceId(value: string | null | undefined): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    return 'unrouted';
+  }
+  return value.length > 8 ? value.slice(0, 8) : value;
+}
+
+function toolInstanceLabel(tool: ToolRow): string {
+  return tool.instance_prefix ?? compactInstanceId(tool.instance_id);
+}
+
 function toolGroupLabel(tool: ToolRow): string {
-  const p = tool.instance_prefix ?? '—';
-  return `${tool.dcc_type} · instance ${p}`;
+  return appTypeLabel(tool.dcc_type);
+}
+
+function workerGroupLabel(worker: WorkerRow): string {
+  return appTypeLabel(worker.dcc_type);
 }
 
 function callGroupLabel(call: CallRow): string {
-  const id = call.instance_id;
-  if (typeof id === 'string' && id.length > 0) {
-    return `${call.dcc_type} · ${id.length > 8 ? id.slice(0, 8) : id}`;
-  }
-  return `${call.dcc_type} · unrouted`;
+  return appTypeLabel(call.dcc_type);
 }
 
 function traceGroupLabel(trace: TraceRow): string {
-  const id = trace.instance_id;
-  if (typeof id === 'string' && id.length > 0) {
-    const dcc = trace.dcc_type ?? '?';
-    return `${dcc} · ${id.length > 8 ? id.slice(0, 8) : id}`;
-  }
-  return `${trace.dcc_type ?? '?'} · unrouted`;
+  return appTypeLabel(trace.dcc_type);
 }
 
 function gatewayLogGroupLabel(log: LogRow): string {
-  const dcc = log.dcc_type ?? '?';
-  const raw = log.instance_id;
-  if (typeof raw === 'string' && raw.length > 0) {
-    return `${dcc} · ${raw.length > 8 ? raw.slice(0, 8) : raw}`;
-  }
-  return `${dcc} · gateway`;
+  return appTypeLabel(log.dcc_type ?? 'gateway');
 }
 
 function logStepTitle(log: LogRow): string {
@@ -2130,6 +2208,7 @@ function payloadPreview(payload: TracePayload | null | undefined): string {
 function buildAgentPacket(trace: TraceDetailPayload): string {
   const links = traceLinks(trace.request_id, trace.links);
   const agent = trace.agent_context;
+  const tokens = detailTraceTokens(trace);
   return JSON.stringify({
     purpose: 'dcc-mcp admin trace packet for LLM evaluation and code optimization',
     request_id: trace.request_id,
@@ -2141,6 +2220,13 @@ function buildAgentPacket(trace: TraceDetailPayload): string {
     status: trace.ok ? 'ok' : 'err',
     total_ms: trace.total_ms,
     token_accounting: tokenAccounting(trace),
+    tokens: {
+      input: tokens.inputTokens,
+      output: tokens.outputTokens,
+      total: tokens.totalTokens,
+      estimated: tokens.estimatedTokens,
+      estimator: tokens.estimator,
+    },
     agent_context: agent ? {
       agent_id: agent.agent_id,
       agent_name: agent.agent_name,
@@ -2380,6 +2466,7 @@ function TraceDetailPanel({
   const agent = trace.agent_context ?? null;
   const agentTitle = agent?.agent_name || agent?.agent_id || agent?.agent_kind || 'Caller context';
   const links = traceLinks(trace.request_id, trace.links);
+  const tokens = detailTraceTokens(trace);
   const attrsPreview = (attrs?: Record<string, unknown>) => {
     if (!attrs || Object.keys(attrs).length === 0) {
       return '';
@@ -2412,6 +2499,10 @@ function TraceDetailPanel({
           <span><strong>Tool</strong>{trace.tool_slug ?? trace.method}</span>
           <span><strong>Status</strong>{trace.ok ? 'ok' : 'err'}</span>
           <span><strong>Latency</strong>{formatDurationMs(trace.total_ms)}</span>
+          <span><strong>Input tokens</strong>{tokens.inputTokens == null ? '-' : formatTokenCount(tokens.inputTokens)}</span>
+          <span><strong>Output tokens</strong>{tokens.outputTokens == null ? '-' : formatTokenCount(tokens.outputTokens)}</span>
+          <span><strong>Total tokens</strong>{tokens.totalTokens == null ? '-' : formatTokenCount(tokens.totalTokens)}</span>
+          <span><strong>Estimator</strong>{tokens.estimator ?? '-'}</span>
           <span><strong>Transport</strong>{trace.transport ?? '-'}</span>
           <span><strong>Started</strong>{formatTraceDate(trace.started_at)}</span>
           <span><strong>Spans</strong>{spans.length}</span>
@@ -2477,14 +2568,20 @@ function TraceDetailPanel({
         <div className="trace-detail-card">
           <div className="trace-card-head">
             <h3>Input</h3>
-            <span>{formatBytes(trace.input?.original_size)}</span>
+            <span>
+              {formatBytes(trace.input?.original_size)}
+              {trace.input ? ` / ${formatTokenCount(trace.input.estimated_tokens)} tok` : ''}
+            </span>
           </div>
           <pre className="payload-pre">{payloadPreview(trace.input)}</pre>
         </div>
         <div className="trace-detail-card">
           <div className="trace-card-head">
             <h3>Output</h3>
-            <span>{formatBytes(trace.output?.original_size)}</span>
+            <span>
+              {formatBytes(trace.output?.original_size)}
+              {trace.output ? ` / ${formatTokenCount(trace.output.estimated_tokens)} tok` : ''}
+            </span>
           </div>
           <pre className="payload-pre">{payloadPreview(trace.output)}</pre>
         </div>
@@ -2790,6 +2887,9 @@ function App() {
           t.agent_name ?? '',
           t.agent_model ?? '',
           t.slowest_span_name ?? '',
+          t.input_tokens != null ? String(t.input_tokens) : '',
+          t.output_tokens != null ? String(t.output_tokens) : '',
+          t.total_tokens != null ? String(t.total_tokens) : '',
         ),
       ),
     );
@@ -2990,13 +3090,49 @@ function App() {
     );
   }, [skills, listSearch]);
 
-  const failedCalls = useMemo(
-    () => calls.filter((call) => call.success === false || call.status.toLowerCase().includes('err') || call.status.toLowerCase().includes('fail')).slice(0, 8),
-    [calls],
-  );
+  const failureSignals = useMemo<FailureSignal[]>(() => {
+    const rows = new Map<string, FailureSignal>();
+    for (const call of calls) {
+      if (call.success !== false && !isErrStatus(call.status)) {
+        continue;
+      }
+      rows.set(call.request_id, {
+        request_id: call.request_id,
+        status: call.status || 'failed',
+        tool: call.tool,
+        detail: call.error || call.dcc_type || call.instance_id || 'call failed',
+        ms: call.duration_ms,
+      });
+    }
+    for (const trace of traces) {
+      if (trace.success !== false && !isErrStatus(trace.status)) {
+        continue;
+      }
+      const current = rows.get(trace.request_id);
+      const detail = trace.slowest_span_name
+        ? `${trace.slowest_span_name} span`
+        : trace.dcc_type || trace.instance_id || 'trace failed';
+      rows.set(trace.request_id, {
+        request_id: trace.request_id,
+        status: current?.status || trace.status || 'failed',
+        tool: current?.tool || trace.tool,
+        detail: current?.detail || detail,
+        ms: current?.ms ?? trace.total_ms ?? null,
+      });
+    }
+    return Array.from(rows.values()).slice(0, 8);
+  }, [calls, traces]);
 
   const slowTraces = useMemo(
     () => [...traces].filter((trace) => trace.total_ms != null).sort((a, b) => traceLatency(b) - traceLatency(a)).slice(0, 8),
+    [traces],
+  );
+
+  const tokenHeavyTraces = useMemo(
+    () => [...traces]
+      .filter((trace) => totalTraceTokens(trace) != null)
+      .sort((a, b) => (totalTraceTokens(b) ?? 0) - (totalTraceTokens(a) ?? 0))
+      .slice(0, 8),
     [traces],
   );
 
@@ -3014,8 +3150,6 @@ function App() {
     () => workers.filter((worker) => worker.stale || !statusClass(worker.status).includes('ok')),
     [workers],
   );
-
-  const debugIssues = failedCalls.length + problemActivity.length + problemLogs.length + unhealthyWorkers.length;
 
   const filteredTopTools = useMemo(() => {
     const q = listSearch.trim().toLowerCase();
@@ -3038,6 +3172,15 @@ function App() {
   const filteredTopAgents = useMemo(() => {
     const q = listSearch.trim().toLowerCase();
     const rows = stats?.top_agents ?? [];
+    if (!q) {
+      return rows;
+    }
+    return rows.filter((r) => r.name.toLowerCase().includes(q));
+  }, [stats, listSearch]);
+
+  const filteredTopAppTypes = useMemo(() => {
+    const q = listSearch.trim().toLowerCase();
+    const rows = stats?.top_app_types ?? [];
     if (!q) {
       return rows;
     }
@@ -3127,7 +3270,24 @@ function App() {
     const p95 = stats?.latency_ms?.p95_ms ?? stats?.p95_ms ?? null;
     const agentContext = traces.filter((trace) => agentLabel(trace) !== '-').length;
     const spans = traces.reduce((sum, trace) => sum + (trace.span_count ?? 0), 0);
-    return { ok, failed, p95, agentContext, spans };
+    const totalTokens = traces.reduce((sum, trace) => {
+      const next = totalTraceTokens(trace);
+      return sum + (next ?? 0);
+    }, 0);
+    const avgTokens = traces.length > 0 ? totalTokens / traces.length : 0;
+    const totalInputTokens = traces.reduce((sum, trace) => sum + (trace.input_tokens ?? 0), 0);
+    const totalOutputTokens = traces.reduce((sum, trace) => sum + (trace.output_tokens ?? 0), 0);
+    return {
+      ok,
+      failed,
+      p95,
+      agentContext,
+      spans,
+      totalTokens,
+      avgTokens,
+      totalInputTokens,
+      totalOutputTokens,
+    };
   }, [stats, traces]);
 
   const trafficSummary = useMemo(() => {
@@ -3141,8 +3301,151 @@ function App() {
   const statsSummary = useMemo(() => {
     const failed = stats?.failed_calls ?? Math.max(0, (stats?.total_calls ?? 0) - (stats?.successful_calls ?? 0));
     const success = stats?.successful_calls ?? Math.max(0, (stats?.total_calls ?? 0) - failed);
-    return { success, failed };
-  }, [stats]);
+    return {
+      success,
+      failed,
+      totalTokens: stats?.total_tokens ?? traceSummary.totalTokens,
+      totalInputTokens: stats?.total_input_tokens ?? traceSummary.totalInputTokens,
+      totalOutputTokens: stats?.total_output_tokens ?? traceSummary.totalOutputTokens,
+      avgTokens: stats?.avg_tokens_per_call ?? stats?.avg_total_tokens_per_call ?? traceSummary.avgTokens,
+    };
+  }, [stats, traceSummary]);
+
+  const tokenPressure = useMemo(() => ({
+    total: statsSummary.totalTokens,
+    input: statsSummary.totalInputTokens,
+    output: statsSummary.totalOutputTokens,
+    avg: statsSummary.avgTokens,
+    returned: stats?.token_usage?.total_returned_tokens ?? 0,
+    saved: stats?.token_usage?.total_saved_tokens ?? 0,
+    estimator: stats?.payload_token_estimator ?? health?.response_format?.token_estimator ?? '-',
+  }), [health, stats, statsSummary]);
+
+  const debugSignals = useMemo<DebugSignal[]>(() => {
+    const signals: DebugSignal[] = [];
+    const p95Latency = stats?.latency_ms?.p95_ms ?? stats?.p95_ms ?? null;
+    const eventWarnings = problemLogs.length + problemActivity.length;
+    if (health && !isOkStatus(health.status)) {
+      signals.push({
+        key: 'gateway',
+        label: 'Gateway health',
+        value: health.status,
+        detail: `${health.instances_ready}/${health.instances_total} instances ready`,
+        tone: 'err',
+        panel: 'health',
+      });
+    }
+    if (failureSignals.length > 0) {
+      const first = failureSignals[0];
+      signals.push({
+        key: 'failures',
+        label: 'Failed execution',
+        value: `${failureSignals.length} request(s)`,
+        detail: `${compactId(first.request_id)} · ${first.detail}`,
+        tone: 'err',
+        panel: 'traces',
+        traceId: first.request_id,
+      });
+    }
+    if (unhealthyWorkers.length > 0) {
+      const first = unhealthyWorkers[0];
+      signals.push({
+        key: 'instances',
+        label: 'Instance health',
+        value: `${unhealthyWorkers.length} flagged`,
+        detail: first.failure_reason || first.failure_stage || `${first.dcc_type} ${first.status}`,
+        tone: 'warn',
+        panel: 'instances',
+      });
+    }
+    if (governanceSummary.denied > 0 || governanceSummary.throttled > 0) {
+      signals.push({
+        key: 'governance',
+        label: 'Governance pressure',
+        value: `${governanceSummary.denied} denied / ${governanceSummary.throttled} throttled`,
+        detail: governanceSummary.redacted ? `${governanceSummary.redacted} redacted path(s)` : 'policy and quota decisions',
+        tone: governanceSummary.denied > 0 ? 'err' : 'warn',
+        panel: 'governance',
+      });
+    }
+    if (workflowSummary.zeroResults > 0) {
+      signals.push({
+        key: 'discovery',
+        label: 'Discovery quality',
+        value: `${workflowSummary.zeroResults} zero-result workflow(s)`,
+        detail: 'search/load-skill traces need review',
+        tone: 'warn',
+        panel: 'workflows',
+      });
+    }
+    if (p95Latency != null && p95Latency > 5_000) {
+      signals.push({
+        key: 'latency',
+        label: 'Latency',
+        value: `${formatDurationMs(p95Latency)} p95`,
+        detail: slowTraces[0] ? `${compactId(slowTraces[0].request_id)} · ${slowTraces[0].tool}` : 'retained gateway calls',
+        tone: 'warn',
+        panel: 'traces',
+        traceId: slowTraces[0]?.request_id,
+      });
+    }
+    if (eventWarnings > 0) {
+      signals.push({
+        key: 'events',
+        label: 'Warning events',
+        value: `${eventWarnings} retained`,
+        detail: problemLogs[0]?.message || problemActivity[0]?.message || 'logs/activity warnings',
+        tone: 'warn',
+        panel: problemLogs.length ? 'logs' : 'activity',
+      });
+    }
+    if (tokenPressure.total > 0) {
+      signals.push({
+        key: 'tokens',
+        label: 'Payload budget',
+        value: `${formatTokenCount(tokenPressure.avg)} / call`,
+        detail: `${formatTokenCount(tokenPressure.total)} total · ${formatTokenCount(tokenPressure.saved)} response tokens saved`,
+        tone: tokenPressure.avg > 4_000 ? 'warn' : 'ok',
+        panel: 'stats',
+      });
+    }
+    signals.push({
+      key: 'coverage',
+      label: 'Evidence coverage',
+      value: `${traces.length} traces`,
+      detail: `${calls.length} calls · ${traceSummary.agentContext} with agent context`,
+      tone: traces.length > 0 && traceSummary.agentContext === 0 ? 'warn' : 'ok',
+      panel: 'traces',
+    });
+    if (signals.length === 1 && signals[0].key === 'coverage' && signals[0].tone === 'ok') {
+      return [{
+        key: 'ready',
+        label: 'Gateway ready',
+        value: `${workerSummary.live} live`,
+        detail: 'no retained warning signals',
+        tone: 'ok',
+        panel: 'health',
+      }, signals[0]];
+    }
+    return signals.slice(0, 8);
+  }, [
+    calls.length,
+    failureSignals,
+    governanceSummary,
+    health,
+    problemActivity,
+    problemLogs,
+    slowTraces,
+    stats,
+    tokenPressure,
+    traceSummary.agentContext,
+    traces.length,
+    unhealthyWorkers,
+    workerSummary.live,
+    workflowSummary.zeroResults,
+  ]);
+
+  const debugIssues = debugSignals.filter((signal) => signal.tone !== 'ok').length;
 
   const markUpdated = useCallback((panel: Panel, text: string) => {
     setUpdatedAt((current) => ({ ...current, [panel]: text }));
@@ -3717,7 +4020,7 @@ function App() {
                 {activePanel === 'governance' ? `${filteredGovernanceDecisions.length} / ${governance?.recent_decisions?.length ?? 0}` : ''}
                 {activePanel === 'skill-paths' ? `${filteredSkills.length} skill(s), ${filteredSkillPaths.length} path(s)` : ''}
                 {activePanel === 'logs' ? `${filteredLogs.length} / ${logs.length}` : ''}
-                {activePanel === 'stats' ? `charts: ${filteredTopTools.length} tools / ${filteredTopInstances.length} instances / ${filteredTopAgents.length} agents / ${filteredTokenByFormat.length} formats` : ''}
+                {activePanel === 'stats' ? `charts: ${filteredTopAppTypes.length} app types / ${filteredTopTools.length} tools / ${filteredTopInstances.length} instances / ${filteredTopAgents.length} agents / ${filteredTokenByFormat.length} formats` : ''}
                 {activePanel === 'governance' ? `${governanceSummary.denied} denied / ${governanceSummary.throttled} throttled` : ''}
               </span>
             ) : null}
@@ -3829,8 +4132,30 @@ function App() {
               <HealthCard tone={unhealthyWorkers.length ? 'warn' : 'ok'} label="Instances" value={`${workerSummary.live} live / ${unhealthyWorkers.length} flagged`} />
               <HealthCard tone={errorRateTone(stats)} label="Success" value={stats ? `${stats.success_rate.toFixed(1)}%` : '?'} />
               <HealthCard tone={latencyTone(stats?.latency_ms?.p95_ms ?? stats?.p95_ms)} label="p95 latency" value={stats?.latency_ms?.p95_ms ?? stats?.p95_ms ?? '-'} />
+              <HealthCard label="Tokens / call" value={formatTokenCount(tokenPressure.avg)} />
             </div>
             <div className="debug-map">
+              <div className="debug-card debug-wide">
+                <div className="debug-card-head">
+                  <h3>Agent Triage</h3>
+                  <button className="linkish" type="button" onClick={() => goToPanel('traces')}>Open evidence</button>
+                </div>
+                <div className="debug-signal-list">
+                  {debugSignals.map((signal) => (
+                    <button
+                      key={signal.key}
+                      className={`debug-signal ${signal.tone}`}
+                      type="button"
+                      onClick={() => goToPanel(signal.panel, signal.traceId ? { traceId: signal.traceId } : undefined)}
+                    >
+                      <span>{signal.label}</span>
+                      <strong>{signal.value}</strong>
+                      <em>{signal.detail}</em>
+                    </button>
+                  ))}
+                </div>
+              </div>
+
               <div className="debug-card debug-wide">
                 <div className="debug-card-head">
                   <h3>Traffic Shape</h3>
@@ -3841,19 +4166,41 @@ function App() {
                   <span>{stats?.total_calls ?? 0} calls</span>
                   <span>{stats?.latency_ms?.p50_ms ?? stats?.p50_ms ?? '-'} ms p50</span>
                   <span>{stats?.latency_ms?.p99_ms ?? '-'} ms p99</span>
+                  <span>{formatTokenCount(tokenPressure.total)} payload tokens</span>
                 </div>
               </div>
 
               <div className="debug-card">
                 <div className="debug-card-head">
-                  <h3>Failed Calls</h3>
+                  <h3>Token Pressure</h3>
+                  <button className="linkish" type="button" onClick={() => goToPanel('stats')}>Open stats</button>
+                </div>
+                <div className="debug-metrics">
+                  <span>{formatTokenCount(tokenPressure.total)} total</span>
+                  <span>{formatTokenCount(tokenPressure.input)} in</span>
+                  <span>{formatTokenCount(tokenPressure.output)} out</span>
+                  <span>{formatTokenCount(tokenPressure.saved)} saved</span>
+                  <span>{tokenPressure.estimator}</span>
+                </div>
+                {tokenHeavyTraces.length === 0 ? <p className="empty">No payload token estimates in the retained traces.</p> : tokenHeavyTraces.map((trace) => (
+                  <button key={trace.request_id} className="debug-row" type="button" onClick={() => goToPanel('traces', { traceId: trace.request_id })}>
+                    <span>{formatTokenCount(totalTraceTokens(trace))} tok</span>
+                    <span>{compactId(trace.request_id)}</span>
+                    <span title={trace.tool}>{trace.tool}</span>
+                  </button>
+                ))}
+              </div>
+
+              <div className="debug-card">
+                <div className="debug-card-head">
+                  <h3>Failures</h3>
                   <button className="linkish" type="button" onClick={() => goToPanel('calls')}>Open calls</button>
                 </div>
-                {failedCalls.length === 0 ? <p className="empty">No failed calls in the retained window.</p> : failedCalls.map((call) => (
-                  <button key={call.request_id} className="debug-row" type="button" onClick={() => goToPanel('traces', { traceId: call.request_id })}>
-                    <span><StatusBadge value={call.status} /></span>
-                    <span>{compactId(call.request_id)}</span>
-                    <span title={call.error ?? call.tool}>{call.error ?? call.tool}</span>
+                {failureSignals.length === 0 ? <p className="empty">No failed calls or traces in the retained window.</p> : failureSignals.map((failure) => (
+                  <button key={failure.request_id} className="debug-row" type="button" onClick={() => goToPanel('traces', { traceId: failure.request_id })}>
+                    <span><StatusBadge value={failure.status} /></span>
+                    <span>{compactId(failure.request_id)}</span>
+                    <span title={`${failure.tool} · ${failure.detail}`}>{failure.detail}</span>
                   </button>
                 ))}
               </div>
@@ -3881,7 +4228,9 @@ function App() {
                   <div key={worker.instance_id} className="debug-row static">
                     <span><StatusBadge value={worker.stale ? 'stale' : worker.status} /></span>
                     <span>{worker.dcc_type}</span>
-                    <span>{worker.display_name} · {compactId(worker.instance_id)}</span>
+                    <span title={worker.failure_reason ?? worker.failure_stage ?? worker.instance_id}>
+                      {worker.display_name} · {worker.failure_reason ?? worker.failure_stage ?? compactId(worker.instance_id)}
+                    </span>
                   </div>
                 ))}
               </div>
@@ -3891,15 +4240,24 @@ function App() {
                   <h3>OpenAPI Entry Points</h3>
                   <button className="linkish" type="button" onClick={() => goToPanel('openapi')}>Gateway spec</button>
                 </div>
-                {workers.length === 0 ? <p className="empty">No instance OpenAPI endpoints available yet.</p> : workers.slice(0, 8).map((worker) => (
-                  <div key={worker.instance_id} className="contract-row">
-                    <span>
-                      <strong>{worker.display_name}</strong>
-                      <em>{worker.dcc_type} · {compactId(worker.instance_id)}</em>
-                    </span>
-                    <BackendOpenApiLinks worker={worker} />
-                  </div>
-                ))}
+                {workers.length === 0 ? <p className="empty">No instance OpenAPI endpoints available yet.</p> : (
+                  Array.from(groupRows(workers.slice(0, 8), workerGroupLabel).entries())
+                    .sort(([a], [b]) => a.localeCompare(b))
+                    .map(([group, groupWorkers]) => (
+                      <div key={group} className="contract-group">
+                        <h4>{group}</h4>
+                        {groupWorkers.map((worker) => (
+                          <div key={worker.instance_id} className="contract-row">
+                            <span>
+                              <strong>{worker.display_name}</strong>
+                              <em>{worker.dcc_type} · {compactInstanceId(worker.instance_id)}</em>
+                            </span>
+                            <BackendOpenApiLinks worker={worker} />
+                          </div>
+                        ))}
+                      </div>
+                    ))
+                )}
               </div>
 
               <div className="debug-card">
@@ -4015,41 +4373,56 @@ function App() {
               One row per registered DCC backend (same data as the former Workers tab). Use the links to open the adapter HTTP host, MCP streamable endpoint, or <code>/docs</code> when the host exposes it.
             </p>
             <StatusLine text={updatedAt.instances} error={errors.instances} />
-            <div className="workers-grid">
-              {workers.length === 0 ? (
-                <p className="empty">No instances registered.</p>
-              ) : filteredWorkers.length === 0 ? (
-                <p className="empty">No instances match your search.</p>
-              ) : (
-                filteredWorkers.map((worker) => (
-                  <div key={worker.instance_id} className={`worker-card ${worker.stale ? 'stale' : statusClass(worker.status).replace('badge badge-', '')}`}>
-                    <div className="wname">
-                      <img src={resolveDccIcon(worker.dcc_type)} alt="" className="dcc-icon" aria-hidden />
-                      {worker.display_name} <span>{worker.instance_id.slice(0, 8)}</span>
-                    </div>
-                    <div className="wkv">
-                      <span>DCC</span><span>{worker.dcc_type}</span>
-                      <span>Status</span><span><StatusBadge value={worker.status} /></span>
-                      {worker.failure_reason ? (
-                        <>
-                          <span>Failure</span><span>{worker.failure_reason}</span>
-                        </>
-                      ) : null}
-                      <span>PID</span><span>{worker.pid ?? '-'}</span>
-                      <span>Uptime</span><span>{formatUptime(worker.uptime_secs)}</span>
-                      <span>Version</span><span>{worker.version ?? '-'}</span>
-                      <span>Adapter</span><span>{worker.adapter_version ?? '-'}</span>
-                      <span>Scene</span><span>{worker.scene ?? '-'}</span>
-                      <span>CPU%</span><span>{worker.cpu_percent == null ? '-' : worker.cpu_percent.toFixed(1)}</span>
-                      <span>Memory</span><span>{formatBytes(worker.memory_bytes)}</span>
-                      <span>Access URL</span><span><BackendAccessUrl mcpUrl={worker.mcp_url} /></span>
-                      <span>Endpoints</span><span><McpBackendLinks mcpUrl={worker.mcp_url} /></span>
-                      <span>OpenAPI</span><span><BackendOpenApiLinks worker={worker} /></span>
-                    </div>
-                  </div>
-                ))
-              )}
-            </div>
+            {workers.length === 0 ? (
+              <p className="empty">No instances registered.</p>
+            ) : filteredWorkers.length === 0 ? (
+              <p className="empty">No instances match your search.</p>
+            ) : (
+              <div className="worker-groups">
+                {Array.from(groupRows(filteredWorkers, workerGroupLabel).entries())
+                  .sort(([a], [b]) => a.localeCompare(b))
+                  .map(([group, groupWorkers]) => {
+                    const flagged = groupWorkers.filter((worker) => worker.stale || !statusClass(worker.status).includes('ok')).length;
+                    return (
+                      <div key={group} className="worker-group">
+                        <div className="worker-group-head">
+                          <h3>{group}</h3>
+                          <span>{groupWorkers.length} instance(s) · {flagged} flagged</span>
+                        </div>
+                        <div className="workers-grid">
+                          {groupWorkers.map((worker) => (
+                            <div key={worker.instance_id} className={`worker-card ${worker.stale ? 'stale' : statusClass(worker.status).replace('badge badge-', '')}`}>
+                              <div className="wname">
+                                <img src={resolveDccIcon(worker.dcc_type)} alt="" className="dcc-icon" aria-hidden />
+                                {worker.display_name} <span>{compactInstanceId(worker.instance_id)}</span>
+                              </div>
+                              <div className="wkv">
+                                <span>App type</span><span>{worker.dcc_type}</span>
+                                <span>Status</span><span><StatusBadge value={worker.status} /></span>
+                                {worker.failure_reason ? (
+                                  <>
+                                    <span>Failure</span><span>{worker.failure_reason}</span>
+                                  </>
+                                ) : null}
+                                <span>PID</span><span>{worker.pid ?? '-'}</span>
+                                <span>Uptime</span><span>{formatUptime(worker.uptime_secs)}</span>
+                                <span>Version</span><span>{worker.version ?? '-'}</span>
+                                <span>Adapter</span><span>{worker.adapter_version ?? '-'}</span>
+                                <span>Scene</span><span>{worker.scene ?? '-'}</span>
+                                <span>CPU%</span><span>{worker.cpu_percent == null ? '-' : worker.cpu_percent.toFixed(1)}</span>
+                                <span>Memory</span><span>{formatBytes(worker.memory_bytes)}</span>
+                                <span>Access URL</span><span><BackendAccessUrl mcpUrl={worker.mcp_url} /></span>
+                                <span>Endpoints</span><span><McpBackendLinks mcpUrl={worker.mcp_url} /></span>
+                                <span>OpenAPI</span><span><BackendOpenApiLinks worker={worker} /></span>
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    );
+                  })}
+              </div>
+            )}
             <div className="status-bar">Summary: live {workerSummary.live}, stale {workerSummary.stale}, unhealthy {workerSummary.unhealthy}</div>
             <button className="refresh-btn" type="button" onClick={fetchInstanceBackends}>Refresh</button>
           </section>
@@ -4069,12 +4442,13 @@ function App() {
                   <h3 className="group-title">{group}</h3>
                   <p className="group-meta">{groupTools.length} tool(s)</p>
                   <table>
-                    <thead><tr><th>Slug</th><th>DCC</th><th>Summary</th></tr></thead>
+                    <thead><tr><th>Slug</th><th>App type</th><th>Instance</th><th>Summary</th></tr></thead>
                     <tbody>
                       {groupTools.map((tool) => (
                         <tr key={tool.slug}>
                           <td>{tool.slug}</td>
                           <td>{tool.dcc_type}</td>
+                          <td>{toolInstanceLabel(tool)}</td>
                           <td>{tool.summary.slice(0, 120)}</td>
                         </tr>
                       ))}
@@ -4216,7 +4590,7 @@ function App() {
                 <div key={group} className="group-block">
                   <h3 className="group-title">{group}</h3>
                   <table>
-                    <thead><tr><th>Time</th><th>Request</th><th>Tool</th><th>DCC</th><th>Agent</th><th>Transport</th><th>Format</th><th>Returned</th><th>Saved</th><th>Status</th><th>Error</th><th>ms</th><th>Detail</th></tr></thead>
+                    <thead><tr><th>Time</th><th>Request</th><th>Tool</th><th>App type</th><th>Instance</th><th>Agent</th><th>Transport</th><th>Format</th><th>Returned</th><th>Saved</th><th>Status</th><th>Error</th><th>ms</th><th>Detail</th></tr></thead>
                     <tbody>
                       {groupCalls.map((call) => (
                         <tr key={call.request_id}>
@@ -4228,6 +4602,7 @@ function App() {
                           </td>
                           <td>{call.tool}</td>
                           <td>{call.dcc_type}</td>
+                          <td>{compactInstanceId(call.instance_id)}</td>
                           <td title={call.agent_id ?? call.agent_name ?? ''}>{agentLabel(call)}</td>
                           <td>{call.transport ?? '-'}</td>
                           <td>{responseFormatLabel(call)}</td>
@@ -4266,6 +4641,7 @@ function App() {
               <MetricTile tone="ok" label="OK" value={traceSummary.ok} />
               <MetricTile tone={traceSummary.failed > 0 ? 'err' : undefined} label="Failed" value={traceSummary.failed} />
               <MetricTile tone={latencyTone(traceSummary.p95)} label="p95 latency" value={formatDurationMs(traceSummary.p95)} />
+              <MetricTile label="Total tokens" value={formatTokenCount(traceSummary.totalTokens)} detail={`${formatTokenCount(traceSummary.totalInputTokens)} in / ${formatTokenCount(traceSummary.totalOutputTokens)} out`} />
               <MetricTile label="Agent ctx" value={traceSummary.agentContext} />
               <MetricTile label="Spans" value={traceSummary.spans} />
               <MetricTile label="Visible" value={`${filteredTraces.length} / ${traces.length}`} />
@@ -4292,13 +4668,14 @@ function App() {
                         >
                           <span className="trace-item-main">
                             <strong>{trace.tool}</strong>
-                            <span>{compactId(trace.request_id)} - <TimeValue value={trace.timestamp} /> - {trace.transport ?? '?'}</span>
+                            <span>{compactId(trace.request_id)} - {compactInstanceId(trace.instance_id)} - <TimeValue value={trace.timestamp} /> - {trace.transport ?? '?'}</span>
                             <span>{agentLabel(trace)}{trace.slowest_span_name ? ` - slowest ${trace.slowest_span_name} ${formatDurationMs(trace.slowest_span_ms)}` : ''}</span>
                           </span>
                           <span className="trace-item-side">
                             <StatusBadge value={trace.status} />
                             <span>{formatDurationMs(trace.total_ms)}</span>
                             <span>{trace.span_count ?? 0} spans</span>
+                            <span>{formatTokenCount(totalTraceTokens(trace))} tok</span>
                           </span>
                         </button>
                       ))}
@@ -4448,26 +4825,29 @@ function App() {
             <div className="metric-grid">
               <MetricTile label="Calls" value={stats?.total_calls ?? 0} detail={`${statsRange} window`} />
               <MetricTile tone={errorRateTone(stats)} label="Success" value={stats ? `${stats.success_rate.toFixed(1)}%` : '0.0%'} detail={`${statsSummary.success} ok / ${statsSummary.failed} failed`} />
+              <MetricTile label="Payload tokens" value={formatTokenCount(stats?.total_tokens ?? statsSummary.totalTokens)} detail={`avg ${formatTokenCount(stats?.avg_tokens_per_call ?? stats?.avg_total_tokens_per_call ?? statsSummary.avgTokens)} / call`} />
+              <MetricTile label="Input / Output tokens" value={formatTokenCount(stats?.total_input_tokens ?? statsSummary.totalInputTokens)} detail={`out: ${formatTokenCount(stats?.total_output_tokens ?? statsSummary.totalOutputTokens)}`} />
               <MetricTile tone={latencyTone(stats?.latency_ms?.p50_ms ?? stats?.p50_ms)} label="p50 latency" value={formatDurationMs(stats?.latency_ms?.p50_ms ?? stats?.p50_ms)} />
               <MetricTile tone={latencyTone(stats?.latency_ms?.p95_ms ?? stats?.p95_ms)} label="p95 latency" value={formatDurationMs(stats?.latency_ms?.p95_ms ?? stats?.p95_ms)} />
               <MetricTile
-                label="Returned tokens"
+                label="Response tokens returned"
                 value={formatTokenCount(stats?.token_usage?.total_returned_tokens)}
                 detail={`${formatTokenCount(stats?.token_usage?.total_original_tokens)} original`}
               />
               <MetricTile
                 tone={(stats?.token_usage?.total_saved_tokens ?? 0) > 0 ? 'ok' : undefined}
-                label="Saved tokens"
+                label="Response tokens saved"
                 value={formatTokenCount(stats?.token_usage?.total_saved_tokens)}
                 detail={`${formatSavingsPct(stats?.token_usage?.average_savings_pct)} average`}
               />
               <MetricTile
                 label="Response format"
                 value={health?.response_format?.default ?? 'toon'}
-                detail={health?.response_format?.token_estimator ?? 'token estimator unavailable'}
+                detail={stats?.payload_token_estimator ?? health?.response_format?.token_estimator ?? 'token estimator unavailable'}
               />
             </div>
             <div className="stats-charts">
+              <StatBarList title="Top app types" items={filteredTopAppTypes} />
               <StatBarList title="Top tools" items={filteredTopTools} />
               <StatBarList title="Top instances" items={filteredTopInstances} />
               <StatBarList title="Top agents" items={filteredTopAgents} />

--- a/admin-ui/src/styles.css
+++ b/admin-ui/src/styles.css
@@ -639,6 +639,60 @@ td .refresh-btn:hover {
   font-weight: 750;
 }
 
+.debug-signal-list {
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+}
+
+.debug-signal {
+  background: var(--muted);
+  border: 1px solid var(--border);
+  border-left: 4px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--foreground);
+  cursor: pointer;
+  display: grid;
+  gap: 0.25rem;
+  min-width: 0;
+  padding: 0.75rem;
+  text-align: left;
+}
+
+.debug-signal.ok {
+  border-left-color: var(--ok);
+}
+
+.debug-signal.warn {
+  border-left-color: var(--warn);
+}
+
+.debug-signal.err {
+  border-left-color: var(--err);
+}
+
+.debug-signal span {
+  color: var(--muted-foreground);
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.debug-signal strong {
+  font-family: var(--font-mono);
+  font-size: 1.05rem;
+  overflow-wrap: anywhere;
+}
+
+.debug-signal em {
+  color: var(--muted-foreground);
+  font-size: 0.78rem;
+  font-style: normal;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
 .contract-row {
   align-items: center;
   border-bottom: 1px solid var(--border);
@@ -672,6 +726,25 @@ td .refresh-btn:hover {
   font-size: 0.72rem;
   font-style: normal;
   overflow-wrap: anywhere;
+}
+
+.contract-group {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.contract-group + .contract-group {
+  border-top: 1px solid var(--border);
+  margin-top: 0.55rem;
+  padding-top: 0.55rem;
+}
+
+.contract-group h4 {
+  color: var(--muted-foreground);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .openapi-backend-links {
@@ -1131,12 +1204,17 @@ tbody tr:hover td {
   display: grid;
   gap: 1rem;
   grid-template-columns: minmax(18rem, 0.95fr) minmax(20rem, 1.25fr);
+  min-height: 0;
+  max-height: calc(100vh - 17rem);
 }
 
 .trace-list {
   display: grid;
   gap: 0.75rem;
   min-width: 0;
+  max-height: calc(100vh - 17rem);
+  overflow-y: auto;
+  padding-right: 0.15rem;
 }
 
 .trace-group {
@@ -1237,6 +1315,9 @@ tbody tr:hover td {
   display: grid;
   gap: 0.85rem;
   min-width: 0;
+  max-height: calc(100vh - 17rem);
+  min-height: 0;
+  overflow: auto;
 }
 
 .trace-detail-card {
@@ -1483,6 +1564,36 @@ tbody tr:hover td {
   word-break: break-word;
 }
 
+.worker-groups {
+  display: grid;
+  gap: 1.1rem;
+}
+
+.worker-group {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.worker-group-head {
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+  padding-bottom: 0.45rem;
+}
+
+.worker-group-head h3 {
+  font-size: 0.85rem;
+  font-weight: 800;
+}
+
+.worker-group-head span {
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+}
+
 .workers-grid {
   display: grid;
   gap: 1rem;
@@ -1574,6 +1685,9 @@ tbody tr:hover td {
 .live-log-board {
   display: grid;
   gap: 1rem;
+  max-height: calc(100vh - 16.5rem);
+  overflow: auto;
+  padding-right: 0.15rem;
 }
 
 .request-run {
@@ -2411,6 +2525,13 @@ button.linkish:disabled {
 
   .openapi-spec-card {
     position: static;
+  }
+
+  .trace-layout,
+  .trace-list,
+  .trace-detail-panel,
+  .live-log-board {
+    max-height: calc(100vh - 11rem);
   }
 
   .task-side,

--- a/admin-ui/tests/admin.spec.ts
+++ b/admin-ui/tests/admin.spec.ts
@@ -401,6 +401,10 @@ async function mockAdminApi(page: Page) {
             success: true,
             total_ms: 42,
             instance_id: 'maya-1234567890',
+            input_tokens: 28,
+            output_tokens: 18,
+            total_tokens: 46,
+            payload_token_estimator: 'dcc-mcp-byte4-v1',
             token_accounting: {
               response_format: 'toon',
               token_estimator: 'dcc-mcp-byte4-v1',
@@ -431,6 +435,25 @@ async function mockAdminApi(page: Page) {
         total_ms: 42,
         ok: true,
         spans: [{ name: 'dispatch', duration_ns: 42000000, ok: true }],
+        input: {
+          content: '{"radius":1}',
+          mime_type: 'application/json',
+          truncated: false,
+          original_size: 12,
+          estimated_tokens: 3,
+        },
+        output: {
+          content: '{"ok":true}',
+          mime_type: 'application/json',
+          truncated: false,
+          original_size: 11,
+          estimated_tokens: 3,
+        },
+        input_tokens: 3,
+        output_tokens: 3,
+        total_tokens: 6,
+        estimated_total_tokens: 6,
+        payload_token_estimator: 'dcc-mcp-byte4-v1',
         token_accounting: {
           response_format: 'toon',
           token_estimator: 'dcc-mcp-byte4-v1',
@@ -450,6 +473,15 @@ async function mockAdminApi(page: Page) {
         failed_calls: 1,
         success_rate: 75,
         latency_ms: { p50_ms: 20, p95_ms: 90 },
+        total_input_tokens: 120,
+        total_output_tokens: 130,
+        total_tokens: 250,
+        avg_input_tokens_per_call: 30,
+        avg_output_tokens_per_call: 32.5,
+        avg_total_tokens_per_call: 62.5,
+        avg_tokens_per_call: 62.5,
+        payload_token_estimator: 'dcc-mcp-byte4-v1',
+        top_app_types: [{ name: 'maya', count: 3 }, { name: 'blender', count: 1 }],
         top_tools: [{ name: 'maya-1234__create_sphere', count: 3 }],
         top_instances: [{ name: 'maya-1234567890', count: 3 }],
         top_agents: [{ name: 'Scene Builder', count: 2 }],
@@ -750,7 +782,12 @@ test.describe('Admin Page', () => {
     await expect(page.locator('.setup-panel .ide-config-preview').first()).toContainText('http://127.0.0.1:8765/mcp');
     await page.getByRole('navigation').getByRole('link', { name: 'Debug' }).click();
     await expect(page.locator('.debug-panel')).toContainText('Debug Workbench');
+    await expect(page.locator('.debug-panel')).toContainText('Agent Triage');
+    await expect(page.locator('.debug-panel')).toContainText('Failed execution');
+    await expect(page.locator('.debug-panel')).toContainText('req-err');
     await expect(page.locator('.debug-panel')).toContainText('Traffic Shape');
+    await expect(page.locator('.debug-panel')).toContainText('Token Pressure');
+    await expect(page.locator('.debug-panel')).toContainText('250 payload tokens');
     await page.getByRole('navigation').getByRole('link', { name: 'Health' }).click();
     await expect(page.locator('.health-panel')).toContainText('0.17.7');
     await expect(page.locator('.health-panel')).toContainText('toon / dcc-mcp-byte4-v1');
@@ -806,10 +843,13 @@ test.describe('Admin Page', () => {
     await page.getByRole('navigation').getByRole('link', { name: 'Instances' }).click();
     await expect(page.locator('.instances-panel')).toBeVisible();
     await expect(page.locator('.dcc-icon')).toHaveCount(2);
+    await expect(page.locator('.instances-panel')).toContainText('app-type: maya');
+    await expect(page.locator('.instances-panel')).toContainText('app-type: blender');
     await expect(page.locator('.instances-panel')).toContainText('Access URL');
     await expect(page.locator('.instances-panel')).toContainText('http://127.0.0.1:8765');
     await expect(page.locator('.instances-panel')).toContainText('host-rpc connect failed');
-    await expect(page.locator('.instances-panel').getByRole('link', { name: 'docs' }).first()).toHaveAttribute('href', 'http://127.0.0.1:8765/docs');
+    const mayaCard = page.locator('.worker-card').filter({ hasText: 'Maya Layout' });
+    await expect(mayaCard.getByRole('link', { name: 'docs' }).first()).toHaveAttribute('href', 'http://127.0.0.1:8765/docs');
     await page.getByLabel('Filter current panel').fill('blender');
     await expect(page.locator('.worker-card')).toHaveCount(1);
     await expect(page.locator('.worker-card')).toContainText('Blender Lookdev');
@@ -833,6 +873,8 @@ test.describe('Admin Page', () => {
     await expect(page.locator('.trace-detail-panel')).toContainText('dispatch');
     await expect(page.locator('.trace-detail-panel')).toContainText('Token accounting');
     await expect(page.locator('.trace-detail-panel')).toContainText('dcc-mcp-byte4-v1');
+    await expect(page.locator('.trace-detail-panel')).toContainText(/Input tokens\s*3/);
+    await expect(page.locator('.trace-detail-panel')).toContainText(/Total tokens\s*6/);
     await expect(page.locator('.trace-detail-panel')).toContainText('Returned40');
     await expect(page.locator('.trace-detail-panel')).toContainText('Savings60.0%');
   });
@@ -873,10 +915,15 @@ test.describe('Admin Page', () => {
     await page.goto('/admin/?panel=stats&range=1h');
     await expect(page.locator('.stats-panel')).toBeVisible();
     await expect(page.getByLabel('Range')).toHaveValue('1h');
-    await expect(page.locator('.stats-panel')).toContainText('Returned tokens');
+    await expect(page.locator('.stats-panel')).toContainText('Response tokens returned');
     await expect(page.locator('.stats-panel')).toContainText('160');
-    await expect(page.locator('.stats-panel')).toContainText('Saved tokens');
+    await expect(page.locator('.stats-panel')).toContainText('Payload tokens');
+    await expect(page.locator('.stats-panel')).toContainText('250');
+    await expect(page.locator('.stats-panel')).toContainText('Input / Output tokens');
+    await expect(page.locator('.stats-panel')).toContainText('Response tokens saved');
     await expect(page.locator('.stats-panel')).toContainText('140');
+    await expect(page.locator('.stats-panel')).toContainText('Top app types');
+    await expect(page.locator('.stats-panel')).toContainText('maya');
     await expect(page.locator('.stats-panel')).toContainText('Token savings by transport');
     await expect(page.locator('.stats-panel')).toContainText('rest');
     await expect(page.locator('.stats-panel')).toContainText('json');

--- a/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
@@ -1038,6 +1038,14 @@ pub async fn handle_admin_stats(
                     "governance".to_string(),
                     crate::gateway::admin::governance::build_governance_stats(&s),
                 );
+                obj.insert(
+                    "avg_tokens_per_call".to_string(),
+                    json!(stats.avg_total_tokens_per_call),
+                );
+                obj.insert(
+                    "payload_token_estimator".to_string(),
+                    json!(TOKEN_ESTIMATOR),
+                );
                 // Embedded admin UI expects a 0–100 percentage in `success_rate`.
                 obj.insert(
                     "success_rate".to_string(),
@@ -1050,6 +1058,17 @@ pub async fn handle_admin_stats(
             "error": "stats aggregator not available — admin feature may be disabled",
             "range": range_str,
             "total_calls": 0,
+            "successful_calls": 0,
+            "failed_calls": 0,
+            "success_rate": 0.0,
+            "total_input_tokens": 0,
+            "total_output_tokens": 0,
+            "total_tokens": 0,
+            "avg_input_tokens_per_call": 0.0,
+            "avg_output_tokens_per_call": 0.0,
+            "avg_total_tokens_per_call": 0.0,
+            "avg_tokens_per_call": 0.0,
+            "payload_token_estimator": TOKEN_ESTIMATOR,
             "token_usage": crate::gateway::admin::stats::TokenUsageStats::default(),
             "governance": crate::gateway::admin::governance::build_governance_stats(&s),
         })),
@@ -1236,10 +1255,47 @@ pub async fn handle_admin_workers(State(s): State<AdminState>) -> impl IntoRespo
 
 fn trace_detail_json(trace: &DispatchTrace, links: Option<Value>) -> Value {
     let mut value = serde_json::to_value(trace).unwrap_or(json!({}));
+    let input_tokens = trace.input_tokens();
+    let output_tokens = trace.output_tokens();
+    let total_tokens = trace.total_tokens();
     if let Some(links) = links {
         value["links"] = links;
     }
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert("input_tokens".to_string(), json!(input_tokens));
+        obj.insert("output_tokens".to_string(), json!(output_tokens));
+        obj.insert("total_tokens".to_string(), json!(total_tokens));
+        obj.insert("estimated_tokens".to_string(), json!(total_tokens));
+        obj.insert("estimated_total_tokens".to_string(), json!(total_tokens));
+        obj.insert(
+            "payload_token_estimator".to_string(),
+            json!(TOKEN_ESTIMATOR),
+        );
+    }
     value
+}
+
+fn trace_payload_token_summary(trace: &Value) -> Value {
+    let input_tokens = trace
+        .get("input")
+        .and_then(|payload| payload.get("estimated_tokens"))
+        .and_then(Value::as_u64);
+    let output_tokens = trace
+        .get("output")
+        .and_then(|payload| payload.get("estimated_tokens"))
+        .and_then(Value::as_u64);
+    let total_tokens = match (input_tokens, output_tokens) {
+        (Some(input), Some(output)) => Some(input.saturating_add(output)),
+        (Some(input), None) => Some(input),
+        (None, Some(output)) => Some(output),
+        (None, None) => None,
+    };
+    json!({
+        "estimator": TOKEN_ESTIMATOR,
+        "input": input_tokens,
+        "output": output_tokens,
+        "total": total_tokens,
+    })
 }
 
 fn issue_report_json(request_id: &str, bundle: Value, links: Value) -> Value {
@@ -1272,6 +1328,7 @@ fn issue_report_json(request_id: &str, bundle: Value, links: Value) -> Value {
         .or_else(|| audit.get("token_accounting"))
         .cloned()
         .unwrap_or(Value::Null);
+    let payload_tokens = trace_payload_token_summary(&trace);
     let trace_id = bundle
         .get("trace_id")
         .cloned()
@@ -1306,6 +1363,7 @@ fn issue_report_json(request_id: &str, bundle: Value, links: Value) -> Value {
             "dcc_type": dcc_type,
             "total_ms": total_ms,
             "token_accounting": token_accounting,
+            "payload_tokens": payload_tokens,
             "postmortem": {
                 "previous_call_count": previous_call_count,
                 "gateway_event_count": gateway_event_count,
@@ -1331,6 +1389,9 @@ fn dispatch_trace_to_admin_row(t: &DispatchTrace, links: Option<AdminLinkBuilder
         .slowest_span()
         .map(|(span, ms)| (Some(span.name.clone()), Some(ms)))
         .unwrap_or((None, None));
+    let input_tokens = t.input_tokens();
+    let output_tokens = t.output_tokens();
+    let total_tokens = t.total_tokens();
     let agent_id = t
         .agent_context
         .as_ref()
@@ -1363,6 +1424,10 @@ fn dispatch_trace_to_admin_row(t: &DispatchTrace, links: Option<AdminLinkBuilder
         "span_count": t.span_count(),
         "input_bytes": t.input_bytes(),
         "output_bytes": t.output_bytes(),
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": total_tokens,
+        "payload_token_estimator": TOKEN_ESTIMATOR,
         "slowest_span_name": slowest_span_name,
         "slowest_span_ms": slowest_span_ms,
     });

--- a/crates/dcc-mcp-gateway/src/gateway/admin/stats.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/stats.rs
@@ -80,8 +80,22 @@ pub struct GatewayStats {
     pub failed_calls: usize,
     /// Success rate as a fraction [0.0, 1.0].
     pub success_rate: f64,
+    /// Sum of input payload token estimates in the selected range.
+    pub total_input_tokens: u64,
+    /// Sum of output payload token estimates in the selected range.
+    pub total_output_tokens: u64,
+    /// Sum of all payload token estimates in the selected range.
+    pub total_tokens: u64,
+    /// Average input token estimate per call.
+    pub avg_input_tokens_per_call: f64,
+    /// Average output token estimate per call.
+    pub avg_output_tokens_per_call: f64,
+    /// Average combined token estimate per call.
+    pub avg_total_tokens_per_call: f64,
     /// Latency statistics in milliseconds.
     pub latency_ms: LatencyStats,
+    /// Top DCC app types by call count (up to 10).
+    pub top_app_types: Vec<TopEntry>,
     /// Top tools by call count (up to 10).
     pub top_tools: Vec<TopEntry>,
     /// Top DCC instances by call count (up to 10).
@@ -205,7 +219,14 @@ fn compute_from_traces(in_range: &[DispatchTrace], range: StatsRange) -> Gateway
             successful_calls: 0,
             failed_calls: 0,
             success_rate: 0.0,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            total_tokens: 0,
+            avg_input_tokens_per_call: 0.0,
+            avg_output_tokens_per_call: 0.0,
+            avg_total_tokens_per_call: 0.0,
             latency_ms: LatencyStats::default(),
+            top_app_types: vec![],
             top_tools: vec![],
             top_instances: vec![],
             top_agents: vec![],
@@ -217,10 +238,27 @@ fn compute_from_traces(in_range: &[DispatchTrace], range: StatsRange) -> Gateway
     let successful_calls = in_range.iter().filter(|t| t.ok).count();
     let failed_calls = total_calls - successful_calls;
     let success_rate = successful_calls as f64 / total_calls as f64;
+    let mut total_input_tokens = 0u64;
+    let mut total_output_tokens = 0u64;
+    for t in in_range {
+        total_input_tokens += t.input_tokens().unwrap_or(0) as u64;
+        total_output_tokens += t.output_tokens().unwrap_or(0) as u64;
+    }
+    let total_tokens = total_input_tokens + total_output_tokens;
+    let avg_input_tokens_per_call = total_input_tokens as f64 / total_calls as f64;
+    let avg_output_tokens_per_call = total_output_tokens as f64 / total_calls as f64;
+    let avg_total_tokens_per_call = total_tokens as f64 / total_calls as f64;
 
     let mut latencies: Vec<u64> = in_range.iter().map(|t| t.total_ms).collect();
     latencies.sort_unstable();
     let latency_ms = compute_latency_stats(&latencies);
+
+    let mut app_type_counts: HashMap<String, usize> = HashMap::new();
+    for t in in_range {
+        let key = t.dcc_type.clone().unwrap_or_else(|| "unknown".to_string());
+        *app_type_counts.entry(key).or_insert(0) += 1;
+    }
+    let top_app_types = top_n(app_type_counts, 10);
 
     let mut tool_counts: HashMap<String, usize> = HashMap::new();
     for t in in_range {
@@ -268,7 +306,14 @@ fn compute_from_traces(in_range: &[DispatchTrace], range: StatsRange) -> Gateway
         successful_calls,
         failed_calls,
         success_rate,
+        total_input_tokens,
+        total_output_tokens,
+        total_tokens,
+        avg_input_tokens_per_call,
+        avg_output_tokens_per_call,
+        avg_total_tokens_per_call,
         latency_ms,
+        top_app_types,
         top_tools,
         top_instances,
         top_agents,
@@ -443,7 +488,10 @@ mod tests {
     use std::time::SystemTime;
 
     use super::*;
-    use crate::gateway::admin::trace::{AgentContext, DispatchTrace, TokenTelemetry, TraceLog};
+    use crate::gateway::admin::trace::{
+        AgentContext, DispatchTrace, TokenTelemetry, TraceLog, TracePayload,
+    };
+    use serde_json::json;
 
     fn make_trace(ok: bool, total_ms: u64, tool: &str, instance: &str) -> DispatchTrace {
         DispatchTrace {
@@ -610,6 +658,14 @@ mod tests {
         log.push(mcp_compact);
 
         let stats = StatsAggregator::new(log).compute(StatsRange::All);
+        assert_eq!(stats.top_app_types[0].name, "maya");
+        assert_eq!(stats.top_app_types[0].count, 2);
+        assert!(
+            stats
+                .top_app_types
+                .iter()
+                .any(|entry| entry.name == "photoshop" && entry.count == 1)
+        );
         assert_eq!(stats.token_usage.total_original_tokens, 300);
         assert_eq!(stats.token_usage.total_returned_tokens, 180);
         assert_eq!(stats.token_usage.total_saved_tokens, 120);
@@ -631,6 +687,30 @@ mod tests {
                 .iter()
                 .any(|entry| entry.name == "Planner" && entry.calls == 2)
         );
+    }
+
+    #[test]
+    fn token_stats_are_aggregated() {
+        let log = Arc::new(TraceLog::new(10));
+        let mut with_input = make_trace(true, 10, "maya.t", "inst-1");
+        with_input.input = Some(TracePayload::from_value(
+            &json!({"prompt": "a lightweight prompt"}),
+            1024,
+        ));
+        let mut with_output = make_trace(false, 12, "maya.t", "inst-1");
+        with_output.output = Some(TracePayload::from_value(&json!({"result": "ok"}), 1024));
+        log.push(with_input);
+        log.push(with_output);
+
+        let agg = StatsAggregator::new(log);
+        let s = agg.compute(StatsRange::All);
+        assert_eq!(s.total_calls, 2);
+        assert!(s.total_input_tokens > 0);
+        assert!(s.total_output_tokens > 0);
+        assert_eq!(s.total_tokens, s.total_input_tokens + s.total_output_tokens);
+        assert!(s.avg_input_tokens_per_call > 0.0);
+        assert!(s.avg_output_tokens_per_call > 0.0);
+        assert!(s.avg_total_tokens_per_call > 0.0);
     }
 
     // ── Property-based tests (#846) ────────────────────────────────────────

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -2010,7 +2010,13 @@ sinks:
         assert_eq!(body["total_calls"], 2);
         assert_eq!(body["successful_calls"], 1);
         assert_eq!(body["failed_calls"], 1);
+        assert_eq!(body["success_rate"], 50.0);
+        assert_eq!(body["payload_token_estimator"], "dcc-mcp-byte4-v1");
+        assert!(body["total_tokens"].as_u64().is_some());
+        assert!(body["avg_tokens_per_call"].as_f64().is_some());
         assert!(body["latency_ms"]["p50_ms"].as_u64().unwrap() > 0);
+        assert!(body["top_app_types"].is_array());
+        assert_eq!(body["top_app_types"][0]["name"], "maya");
         assert!(body["top_tools"].is_array());
         assert!(body["hourly_distribution"].is_array());
         assert_eq!(body["hourly_distribution"].as_array().unwrap().len(), 24);
@@ -2022,6 +2028,139 @@ sinks:
         assert_eq!(status, StatusCode::OK);
         // Unknown range should fall back to "all".
         assert!(body["range"] == "all" || body.get("error").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_admin_traces_returns_rows_with_token_fields() {
+        use crate::gateway::admin::trace::{DispatchTrace, TraceLog, TracePayload};
+        use std::sync::Arc;
+        use std::time::SystemTime;
+        let log = Arc::new(TraceLog::new(100));
+
+        let mut with_input = DispatchTrace {
+            request_id: "trace-row-input".into(),
+            trace_id: "trace-row-input".into(),
+            span_id: None,
+            parent_span_id: None,
+            parent_request_id: None,
+            trace_flags: None,
+            trace_state: None,
+            method: "tools/call".into(),
+            tool_slug: Some("maya.create_sphere".into()),
+            instance_id: None,
+            session_id: None,
+            dcc_type: Some("maya".into()),
+            transport: None,
+            agent_context: None,
+            started_at: SystemTime::now(),
+            total_ms: 123,
+            ok: true,
+            spans: vec![],
+            input: Some(TracePayload::from_value(
+                &serde_json::json!({"prompt": "a short prompt for tracing"}),
+                1024,
+            )),
+            output: None,
+            token_accounting: None,
+        };
+        with_input.trace_id = "trace-row-input-trace-id".into();
+        log.push(with_input);
+
+        let with_output = DispatchTrace {
+            request_id: "trace-row-output".into(),
+            trace_id: "trace-row-output-trace-id".into(),
+            span_id: None,
+            parent_span_id: None,
+            parent_request_id: None,
+            trace_flags: None,
+            trace_state: None,
+            method: "tools/call".into(),
+            tool_slug: Some("maya.close_file".into()),
+            instance_id: None,
+            session_id: None,
+            dcc_type: Some("maya".into()),
+            transport: None,
+            agent_context: None,
+            started_at: SystemTime::now(),
+            total_ms: 91,
+            ok: false,
+            spans: vec![],
+            input: None,
+            output: Some(TracePayload::from_value(
+                &serde_json::json!({"result": "ok"}),
+                1024,
+            )),
+            token_accounting: None,
+        };
+        log.push(with_output);
+
+        let state = make_admin_state().with_trace_log(log, None);
+        let router = build_admin_router(state);
+        let (status, body) = body_json(router, "/api/traces?limit=20").await;
+        assert_eq!(status, StatusCode::OK);
+        let traces = body["traces"].as_array().unwrap();
+        assert_eq!(traces.len(), 2);
+
+        let rows_with_inputs: Vec<_> = traces
+            .iter()
+            .filter(|t| t["request_id"] == "trace-row-input")
+            .collect();
+        let rows_with_outputs: Vec<_> = traces
+            .iter()
+            .filter(|t| t["request_id"] == "trace-row-output")
+            .collect();
+        assert_eq!(rows_with_inputs.len(), 1);
+        assert_eq!(rows_with_outputs.len(), 1);
+        assert!(rows_with_inputs[0]["input_tokens"].as_u64().is_some());
+        assert!(rows_with_outputs[0]["output_tokens"].as_u64().is_some());
+        assert!(rows_with_inputs[0]["total_tokens"].as_u64().is_some());
+        assert!(rows_with_outputs[0]["total_tokens"].as_u64().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_admin_trace_detail_returns_token_totals() {
+        use crate::gateway::admin::trace::{DispatchTrace, TraceLog, TracePayload};
+        use std::sync::Arc;
+        use std::time::SystemTime;
+        let log = Arc::new(TraceLog::new(10));
+        let trace = DispatchTrace {
+            request_id: "trace-detail-input".into(),
+            trace_id: "trace-detail-trace-id".into(),
+            span_id: None,
+            parent_span_id: None,
+            parent_request_id: None,
+            trace_flags: None,
+            trace_state: None,
+            method: "tools/call".into(),
+            tool_slug: Some("maya.delete_node".into()),
+            instance_id: None,
+            session_id: None,
+            dcc_type: Some("maya".into()),
+            transport: None,
+            agent_context: None,
+            started_at: SystemTime::now(),
+            total_ms: 42,
+            ok: true,
+            spans: vec![],
+            input: Some(TracePayload::from_str("response body", 1024)),
+            output: Some(TracePayload::from_value(
+                &serde_json::json!({"ok": true}),
+                1024,
+            )),
+            token_accounting: None,
+        };
+        log.push(trace);
+        let state = make_admin_state().with_trace_log(log, None);
+        let router = build_admin_router(state);
+        let (status, body) = body_json(router, "/api/traces/trace-detail-input").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["request_id"], "trace-detail-input");
+        assert!(body["input_tokens"].as_u64().is_some());
+        assert!(body["output_tokens"].as_u64().is_some());
+        assert!(body["total_tokens"].as_u64().is_some());
+        assert_eq!(body["estimated_tokens"], body["total_tokens"]);
+        assert_eq!(body["estimated_total_tokens"], body["total_tokens"]);
+        assert_eq!(body["payload_token_estimator"], "dcc-mcp-byte4-v1");
     }
 
     // ── /api/workers (Phase 4) ────────────────────────────────────────────

--- a/crates/dcc-mcp-gateway/src/gateway/admin/trace.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/trace.rs
@@ -202,6 +202,13 @@ pub struct TracePayload {
     pub truncated: bool,
     /// Original byte length before truncation.
     pub original_size: usize,
+    /// Approximate token count inferred from the raw JSON/string payload.
+    ///
+    /// This is a deterministic, lightweight estimate intended for
+    /// call-size triage; it intentionally does not require any tokenization
+    /// runtime or model-specific encoder.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub estimated_tokens: Option<usize>,
 }
 
 impl TracePayload {
@@ -210,6 +217,7 @@ impl TracePayload {
         let raw = serde_json::to_string(v).unwrap_or_default();
         let original_size = raw.len();
         let truncated = original_size > cap;
+        let estimated_tokens = crate::gateway::response_codec::estimate_tokens(raw.as_bytes());
         let content = if truncated {
             // Truncate at a valid UTF-8 boundary.
             let boundary = raw
@@ -227,6 +235,7 @@ impl TracePayload {
             mime_type: "application/json".to_string(),
             truncated,
             original_size,
+            estimated_tokens: Some(estimated_tokens),
         }
     }
 
@@ -261,6 +270,9 @@ impl TracePayload {
             mime_type: "text/plain".to_string(),
             truncated,
             original_size,
+            estimated_tokens: Some(crate::gateway::response_codec::estimate_tokens(
+                s.as_bytes(),
+            )),
         }
     }
 }
@@ -910,6 +922,23 @@ impl DispatchTrace {
         self.output.as_ref().map(|p| p.original_size)
     }
 
+    pub fn input_tokens(&self) -> Option<usize> {
+        self.input.as_ref().and_then(|p| p.estimated_tokens)
+    }
+
+    pub fn output_tokens(&self) -> Option<usize> {
+        self.output.as_ref().and_then(|p| p.estimated_tokens)
+    }
+
+    pub fn total_tokens(&self) -> Option<usize> {
+        match (self.input_tokens(), self.output_tokens()) {
+            (Some(input), Some(output)) => Some(input.saturating_add(output)),
+            (Some(input), None) => Some(input),
+            (None, Some(output)) => Some(output),
+            (None, None) => None,
+        }
+    }
+
     pub fn slowest_span(&self) -> Option<(&TraceSpan, u64)> {
         self.spans
             .iter()
@@ -1024,6 +1053,13 @@ mod tests {
         assert!(p.truncated);
         assert!(p.content.len() <= 50);
         assert!(p.original_size > 50);
+    }
+
+    #[test]
+    fn payload_estimates_tokens_for_json() {
+        let p = TracePayload::from_value(&json!("hello world"), 1024);
+        assert!(p.estimated_tokens.is_some());
+        assert!(p.estimated_tokens.unwrap() > 0);
     }
 
     #[test]

--- a/crates/dcc-mcp-gateway/src/gateway/response_codec.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/response_codec.rs
@@ -389,7 +389,7 @@ fn accept_format(headers: &HeaderMap) -> Option<ResponseFormat> {
     None
 }
 
-fn estimate_tokens(body: &[u8]) -> usize {
+pub(crate) fn estimate_tokens(body: &[u8]) -> usize {
     if body.is_empty() {
         0
     } else {


### PR DESCRIPTION
- Add trace token estimation and input/output token fields for admin traces.
- Show per-call/total token usage in trace list, trace detail, and stats APIs.
- Aggregate input/output/total token totals in /admin/api/stats.
- Improve admin-ui layout for trace/log panels and add better debugging visibility.
- Add/extend regression tests for token fields and stats aggregation.
