### PR TITLE
fix: compact materialize script tool listing

### DIFF
--- a/python/dcc_mcp_core/script_materialization_tools.py
+++ b/python/dcc_mcp_core/script_materialization_tools.py
@@ -20,51 +20,51 @@ _MATERIALIZE_INPUT_SCHEMA: dict[str, Any] = {
     "properties": {
         "content": {
             "type": "string",
-            "description": "Script source to write on the DCC host. The response never echoes this value.",
+            "description": "Script source; never echoed.",
         },
         "code": {
             "type": "string",
-            "description": "Compatibility alias for content.",
+            "description": "Alias for content.",
         },
         "language": {
             "type": "string",
             "default": "python",
-            "description": "Script language label used for metadata and MIME type.",
+            "description": "Language/MIME label.",
         },
         "suffix": {
             "type": "string",
             "default": ".py",
-            "description": "File suffix for the materialized host-local script.",
+            "description": "Host-local file suffix.",
         },
         "display_name": {
             "type": "string",
-            "description": "Optional human-readable filename prefix.",
+            "description": "Optional filename prefix.",
         },
         "reuse": {
             "type": "boolean",
             "default": False,
-            "description": "When true, reuse an existing unexpired script for the same content and reuse key.",
+            "description": "Reuse unexpired matching content.",
         },
         "reuse_key": {
             "type": "string",
-            "description": "Optional stable reuse namespace.",
+            "description": "Optional reuse namespace.",
         },
         "ttl_secs": {
             "type": "integer",
             "minimum": 1,
-            "description": "Optional expiry in seconds.",
+            "description": "Expiry in seconds.",
         },
         "session_id": {
             "type": "string",
-            "description": "Logical MCP or adapter session id.",
+            "description": "Logical session id.",
         },
         "tool_call_id": {
             "type": "string",
-            "description": "Optional caller tool-call id for audit correlation.",
+            "description": "Optional audit call id.",
         },
         "correlation_id": {
             "type": "string",
-            "description": "Optional trace/correlation id.",
+            "description": "Optional trace id.",
         },
     },
     "anyOf": [{"required": ["content"]}, {"required": ["code"]}],
@@ -140,10 +140,8 @@ def register_script_materialization_tools(
             ToolSpec(
                 name="materialize_script",
                 description=(
-                    "Materialize ad-hoc script source on the DCC host and return a FileRef descriptor. "
-                    "Use before execute-python style tools that accept file_path; the response includes "
-                    "file_path, file_ref, sha256, bytes, ttl, reuse, session, tool-call, and correlation metadata "
-                    "but never echoes raw source. Compatibility replacement for write_temp_script workflows."
+                    "Write script source to the DCC host and return FileRef/path/hash metadata. "
+                    "Use before execute-python tools that accept file_path; raw source is never echoed."
                 ),
                 input_schema=_MATERIALIZE_INPUT_SCHEMA,
                 output_schema=_MATERIALIZE_OUTPUT_SCHEMA,

--- a/tests/test_script_materialization_tools.py
+++ b/tests/test_script_materialization_tools.py
@@ -42,6 +42,41 @@ def test_register_script_materialization_tool_is_exported() -> None:
     assert "register_script_materialization_tools" in dcc_mcp_core.__all__
 
 
+def test_materialize_script_tool_list_entry_stays_compact(tmp_path: Path) -> None:
+    registry = ToolRegistry()
+    server = McpHttpServer(registry, McpHttpConfig(port=0, server_name="materialize-script-size-test"))
+    register_script_materialization_tools(
+        server,
+        dcc_name="custom",
+        instance_id="inst-1",
+        session_id="sess-1",
+        root=tmp_path,
+    )
+
+    handle = server.start()
+    try:
+        client = McpClient(handle.mcp_url())
+        code, body = client.post({"jsonrpc": "2.0", "id": "list-1", "method": "tools/list"})
+
+        assert code == 200
+        tool = next(tool for tool in body["result"]["tools"] if tool["name"] == "materialize_script")
+        payload = json.dumps(tool, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        assert len(payload) < 2048
+        assert tool["inputSchema"]["anyOf"] == [{"required": ["content"]}, {"required": ["code"]}]
+        assert set(tool["outputSchema"]["required"]) == {
+            "file_ref",
+            "file_path",
+            "sha256",
+            "bytes",
+            "dcc_type",
+            "instance_id",
+            "session_id",
+            "reused",
+        }
+    finally:
+        handle.shutdown()
+
+
 def test_materialize_script_tool_supports_mcp_and_rest(tmp_path: Path) -> None:
     registry = ToolRegistry()
     server = McpHttpServer(registry, McpHttpConfig(port=0, server_name="materialize-script-test"))


### PR DESCRIPTION
## Summary
- compact the `materialize_script` tools/list description and input schema descriptions
- keep both inputSchema and outputSchema visible in tools/list for existing clients
- add a regression test that keeps the serialized `materialize_script` tools/list entry below 2 KB

## Validation
- `MCP_LOG_LEVEL=warn .\.venv\Scripts\python.exe -m pytest tests\test_script_materialization_tools.py -q`
- `vx ruff check python\dcc_mcp_core\script_materialization_tools.py tests\test_script_materialization_tools.py`
- `vx git diff --check`

Skill guidance: no update needed because the public workflow and schema availability are unchanged.

Closes #1234