### PR TITLE
fix: support standalone main-affinity execution

### DIFF
--- a/crates/dcc-mcp-http-py/src/config.rs
+++ b/crates/dcc-mcp-http-py/src/config.rs
@@ -337,6 +337,18 @@ impl PyMcpHttpConfig {
         self.inner.features.enable_prompts = v;
     }
 
+    /// Treat this standalone interpreter as the safe main-thread execution lane.
+    #[getter]
+    fn standalone_main_thread_execution(&self) -> bool {
+        self.inner.features.standalone_main_thread_execution
+    }
+
+    /// Treat this standalone interpreter as the safe main-thread execution lane.
+    #[setter]
+    fn set_standalone_main_thread_execution(&mut self, v: bool) {
+        self.inner.features.standalone_main_thread_execution = v;
+    }
+
     // ── GatewayConfig getters/setters ───────────────────────────────
 
     /// Gateway port to compete for. ``0`` disables the gateway.

--- a/crates/dcc-mcp-http-py/src/config/tests.rs
+++ b/crates/dcc-mcp-http-py/src/config/tests.rs
@@ -57,6 +57,7 @@ fn all_mcp_http_config_fields_have_py_getters() {
     let _ = cfg.enable_resources();
     let _ = cfg.enable_artefact_resources();
     let _ = cfg.enable_prompts();
+    let _ = cfg.standalone_main_thread_execution();
 
     // ── GatewayConfig ────────────────────────────────────────────
     let _ = cfg.gateway_port();

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_async.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_async.rs
@@ -87,8 +87,13 @@ async fn run_async_execution_lane(
 ) -> Result<Value, String> {
     let dispatcher = state.dispatcher.as_ref().clone();
     let use_main_thread = use_main_thread_route(thread_affinity, state.executor.is_some());
+    let standalone_main =
+        state.standalone_main_thread_execution && matches!(thread_affinity, ThreadAffinity::Main);
 
-    if matches!(thread_affinity, ThreadAffinity::Main) && state.executor.is_none() {
+    if matches!(thread_affinity, ThreadAffinity::Main)
+        && state.executor.is_none()
+        && !standalone_main
+    {
         if enforce_thread_affinity {
             return Err(
                 "THREAD_AFFINITY_UNAVAILABLE: tool declares thread_affinity=main, \
@@ -141,8 +146,14 @@ async fn run_async_execution_lane(
             if dispatch_cancel.is_cancelled() {
                 return Err("CANCELLED".to_string());
             }
-            dispatch
-                .dispatch(&dispatch_name, dispatch_params)
+            let result = if standalone_main {
+                dcc_mcp_actions::with_thread_affinity(ThreadAffinity::Main, || {
+                    dispatch.dispatch(&dispatch_name, dispatch_params)
+                })
+            } else {
+                dispatch.dispatch(&dispatch_name, dispatch_params)
+            };
+            result
                 .map(|result| result.output)
                 .map_err(|err| err.to_string())
         });

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/thread_route.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/thread_route.rs
@@ -39,10 +39,18 @@ async fn run_on_worker(
     resolved_name: String,
     call_params: Value,
     exec_ctx: DispatchExecutionContext,
+    standalone_main_thread_execution: bool,
+    thread_affinity: ThreadAffinity,
 ) -> Result<DispatchResult, DispatchError> {
     let dispatch_fut = tokio::task::spawn_blocking(move || {
         with_execution_context(exec_ctx, || {
-            dispatcher.dispatch(&resolved_name, call_params)
+            if standalone_main_thread_execution && matches!(thread_affinity, ThreadAffinity::Main) {
+                dcc_mcp_actions::with_thread_affinity(ThreadAffinity::Main, || {
+                    dispatcher.dispatch(&resolved_name, call_params)
+                })
+            } else {
+                dispatcher.dispatch(&resolved_name, call_params)
+            }
         })
     });
     let cancel_wait = async {
@@ -71,14 +79,17 @@ pub async fn dispatch_action_with_thread_routing(
     call_params: Value,
     thread_affinity: ThreadAffinity,
     enforce_thread_affinity: bool,
+    standalone_main_thread_execution: bool,
 ) -> Result<DispatchResult, DispatchError> {
     let executor_present = executor.is_some();
+    let standalone_main =
+        standalone_main_thread_execution && matches!(thread_affinity, ThreadAffinity::Main);
     let on_main = use_main_thread_route(thread_affinity, executor_present);
     let exec_ctx = DispatchExecutionContext {
         host_dispatcher_attached: Some(executor_present),
     };
 
-    if matches!(thread_affinity, ThreadAffinity::Main) && !executor_present {
+    if matches!(thread_affinity, ThreadAffinity::Main) && !executor_present && !standalone_main {
         if enforce_thread_affinity {
             return Err(DispatchError::HandlerError(format!(
                 "THREAD_AFFINITY_UNAVAILABLE: action '{resolved_name}' declares thread_affinity=main, \
@@ -103,7 +114,15 @@ pub async fn dispatch_action_with_thread_routing(
         )
         .await
     } else {
-        run_on_worker(dispatcher, resolved_name.to_string(), call_params, exec_ctx).await
+        run_on_worker(
+            dispatcher,
+            resolved_name.to_string(),
+            call_params,
+            exec_ctx,
+            standalone_main,
+            thread_affinity,
+        )
+        .await
     }
 }
 
@@ -121,6 +140,7 @@ pub(super) async fn execute_threaded_dispatch(
         call_params,
         thread_affinity,
         enforce_thread_affinity,
+        state.standalone_main_thread_execution,
     )
     .await
     .map(|r| r.output)

--- a/crates/dcc-mcp-http-server/src/server_state.rs
+++ b/crates/dcc-mcp-http-server/src/server_state.rs
@@ -82,6 +82,9 @@ pub struct ServerState {
     pub sessions: SessionManager,
     /// Optional DCC main-thread executor.
     pub executor: Option<DccExecutorHandle>,
+    /// Explicit opt-in for standalone/batch hosts where the in-process lane is
+    /// already safe for main-affinity calls even without a GUI dispatcher.
+    pub standalone_main_thread_execution: bool,
     /// Server name surfaced in `initialize`.
     pub server_name: String,
     /// Server version surfaced in `initialize`.
@@ -135,6 +138,7 @@ impl ServerState {
                 catalog,
                 sessions: sessions.clone(),
                 executor: None,
+                standalone_main_thread_execution: false,
                 server_name: "dcc-mcp-http".to_owned(),
                 server_version: env!("CARGO_PKG_VERSION").to_owned(),
                 cancelled_requests: Arc::new(DashMap::new()),
@@ -195,6 +199,14 @@ impl ServerStateBuilder {
     #[must_use]
     pub fn with_executor(mut self, executor: Option<DccExecutorHandle>) -> Self {
         self.state.executor = executor;
+        self
+    }
+
+    /// Allow main-affinity tools to run without a host dispatcher when the
+    /// embedding adapter has explicitly declared a standalone-safe main lane.
+    #[must_use]
+    pub fn with_standalone_main_thread_execution(mut self, enabled: bool) -> Self {
+        self.state.standalone_main_thread_execution = enabled;
         self
     }
 

--- a/crates/dcc-mcp-http-server/src/thread_routed_invoker.rs
+++ b/crates/dcc-mcp-http-server/src/thread_routed_invoker.rs
@@ -85,6 +85,7 @@ impl ToolInvoker for ThreadRoutedInvoker {
                             params,
                             affinity,
                             enforce,
+                            false,
                         ))
                     },
                 )

--- a/crates/dcc-mcp-http-types/src/config/aggregate.rs
+++ b/crates/dcc-mcp-http-types/src/config/aggregate.rs
@@ -330,6 +330,12 @@ impl McpHttpConfig {
     pub fn set_exclude_group_stubs_from_tools_list(&mut self, v: bool) {
         self.features.exclude_group_stubs_from_tools_list = v;
     }
+    pub fn standalone_main_thread_execution(&self) -> bool {
+        self.features.standalone_main_thread_execution
+    }
+    pub fn set_standalone_main_thread_execution(&mut self, v: bool) {
+        self.features.standalone_main_thread_execution = v;
+    }
     /// Set both skill and group stub exclusion flags together (issue #174 / #238).
     pub fn set_exclude_progressive_stubs_from_tools_list(&mut self, v: bool) {
         self.features.exclude_skill_stubs_from_tools_list = v;
@@ -515,6 +521,14 @@ impl McpHttpConfig {
     /// would be unique (#307).
     pub fn without_bare_tool_names(mut self) -> Self {
         self.features.bare_tool_names = false;
+        self
+    }
+
+    /// Builder: allow main-affinity tools without a GUI dispatcher in a
+    /// standalone interpreter where the adapter has verified the current
+    /// in-process execution lane is DCC-safe.
+    pub fn with_standalone_main_thread_execution(mut self) -> Self {
+        self.features.standalone_main_thread_execution = true;
         self
     }
 

--- a/crates/dcc-mcp-http-types/src/config/feature_flags.rs
+++ b/crates/dcc-mcp-http-types/src/config/feature_flags.rs
@@ -74,6 +74,15 @@ pub struct FeatureFlags {
     /// full token-budget win documented on Maya issue #174 / #238.
     #[serde(default)]
     pub exclude_group_stubs_from_tools_list: bool,
+
+    /// Treat the current standalone interpreter as a valid main-thread lane.
+    ///
+    /// This is an explicit opt-in for mayapy / hython / batch hosts where no
+    /// GUI dispatcher exists and the adapter has verified that executing DCC
+    /// API calls from the server's in-process lane is safe. GUI hosts should
+    /// keep this false and wire a real dispatcher instead.
+    #[serde(default)]
+    pub standalone_main_thread_execution: bool,
 }
 
 impl Default for FeatureFlags {
@@ -88,6 +97,7 @@ impl Default for FeatureFlags {
             shutdown_on_drop: false,
             exclude_skill_stubs_from_tools_list: false,
             exclude_group_stubs_from_tools_list: false,
+            standalone_main_thread_execution: false,
         }
     }
 }

--- a/crates/dcc-mcp-http-types/src/config/tests.rs
+++ b/crates/dcc-mcp-http-types/src/config/tests.rs
@@ -235,6 +235,7 @@ fn feature_flags_default_matches_documented_pre_852_surface() {
     assert!(!f.shutdown_on_drop);
     assert!(!f.exclude_skill_stubs_from_tools_list);
     assert!(!f.exclude_group_stubs_from_tools_list);
+    assert!(!f.standalone_main_thread_execution);
 }
 
 #[test]
@@ -257,6 +258,16 @@ fn feature_flags_round_trip() {
         back.exclude_group_stubs_from_tools_list,
         f.exclude_group_stubs_from_tools_list
     );
+    assert_eq!(
+        back.standalone_main_thread_execution,
+        f.standalone_main_thread_execution
+    );
+}
+
+#[test]
+fn standalone_main_thread_execution_builder_opts_in() {
+    let cfg = McpHttpConfig::default().with_standalone_main_thread_execution();
+    assert!(cfg.standalone_main_thread_execution());
 }
 
 /// Critical contract: an empty `{}` body must deserialise into

--- a/crates/dcc-mcp-http/src/server/mod.rs
+++ b/crates/dcc-mcp-http/src/server/mod.rs
@@ -502,6 +502,11 @@ impl McpHttpServer {
                         self.dispatcher.clone(),
                     ))
                 }
+                _ if self.config.features.standalone_main_thread_execution => std::sync::Arc::new(
+                    dcc_mcp_skill_rest::DispatcherInvoker::new_standalone_main_thread(
+                        self.dispatcher.clone(),
+                    ),
+                ),
                 _ => std::sync::Arc::new(dcc_mcp_skill_rest::DispatcherInvoker::new(
                     self.dispatcher.clone(),
                 )),
@@ -527,6 +532,9 @@ impl McpHttpServer {
             dcc_mcp_http_server::ServerState::builder(self.registry, self.dispatcher, catalog)
                 .with_sessions(sessions)
                 .with_executor(self.executor)
+                .with_standalone_main_thread_execution(
+                    self.config.features.standalone_main_thread_execution,
+                )
                 .with_server_identity(
                     self.config.server.server_name.clone(),
                     self.config.server.server_version.clone(),

--- a/crates/dcc-mcp-skill-rest/src/service.rs
+++ b/crates/dcc-mcp-skill-rest/src/service.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use utoipa::ToSchema;
 
-use dcc_mcp_actions::dispatcher::{DispatchError, ToolDispatcher};
+use dcc_mcp_actions::dispatcher::{DispatchError, ToolDispatcher, with_thread_affinity};
 use dcc_mcp_actions::{
     DispatchExecutionContext, current_execution_context, with_execution_context,
 };
@@ -671,11 +671,22 @@ impl SkillCatalogSource for CatalogSource {
 /// handler.
 pub struct DispatcherInvoker {
     dispatcher: Arc<ToolDispatcher>,
+    standalone_main_thread_execution: bool,
 }
 
 impl DispatcherInvoker {
     pub fn new(dispatcher: Arc<ToolDispatcher>) -> Self {
-        Self { dispatcher }
+        Self {
+            dispatcher,
+            standalone_main_thread_execution: false,
+        }
+    }
+
+    pub fn new_standalone_main_thread(dispatcher: Arc<ToolDispatcher>) -> Self {
+        Self {
+            dispatcher,
+            standalone_main_thread_execution: true,
+        }
     }
 }
 
@@ -769,8 +780,21 @@ impl ToolInvoker for DispatcherInvoker {
         let exec_ctx = DispatchExecutionContext {
             host_dispatcher_attached: Some(false),
         };
+        let standalone_main = self.standalone_main_thread_execution
+            && self
+                .dispatcher
+                .registry()
+                .get_action(action_name, None)
+                .is_some_and(|meta| matches!(meta.thread_affinity, ThreadAffinity::Main));
         with_execution_context(exec_ctx, || {
-            match self.dispatcher.dispatch(action_name, params) {
+            let dispatched = if standalone_main {
+                with_thread_affinity(ThreadAffinity::Main, || {
+                    self.dispatcher.dispatch(action_name, params)
+                })
+            } else {
+                self.dispatcher.dispatch(action_name, params)
+            };
+            match dispatched {
                 Ok(r) => Ok(CallOutcome {
                     slug: ToolSlug(r.action.clone()),
                     output: r.output,

--- a/docs/guide/dcc-thread-safety.md
+++ b/docs/guide/dcc-thread-safety.md
@@ -158,14 +158,42 @@ Concretely:
 
 - `ThreadAffinity::Main` + executor present → runs on DCC main thread via
   `DeferredExecutor`.
+- `ThreadAffinity::Main` + explicit standalone opt-in → runs through the
+  in-process standalone lane and is marked as main-affinity for enforcement.
 - `ThreadAffinity::Main` + no executor → falls back to `spawn_blocking`
-  with a warning (scene API calls would be unsafe).
+  with a warning, or returns `THREAD_AFFINITY_UNAVAILABLE` when the tool
+  requires enforcement.
 - `ThreadAffinity::Any` → always runs on a Tokio worker via
   `spawn_blocking`, even when an executor is wired.
 
 Sync and async paths share this decision via
 `use_main_thread_route(thread_affinity, executor_present)` in
 `crates/dcc-mcp-http/src/handlers/tools_call/mod.rs`.
+
+### Standalone main-thread mode
+
+Batch interpreters such as `mayapy` or `hython` may have no GUI event loop and
+no dispatcher to pump, while still being safe for DCC API calls from the
+adapter-owned in-process lane. In that case, opt in explicitly:
+
+```python
+from dcc_mcp_core import DccServerBase, DccServerOptions
+
+opts = DccServerOptions.from_env(
+    "maya",
+    skills_dir,
+    standalone_main_thread=True,
+)
+server = DccServerBase(opts)
+server.register_builtin_actions()
+```
+
+This mode is intentionally not automatic. It installs the inline in-process
+skill executor before skill discovery and lets MCP `tools/call` plus REST
+`/v1/call` satisfy `thread_affinity: main` / `enforce_thread_affinity: true`
+without a `DeferredExecutor`. Do not use it for interactive GUI sessions; wire a
+real dispatcher there so the DCC UI thread remains the only scene-mutating
+thread.
 
 #### Long-running async tools (cooperative contract)
 

--- a/docs/guide/host-adapter.md
+++ b/docs/guide/host-adapter.md
@@ -102,27 +102,32 @@ worker thread.
 
 ## Adapter skill-load policy
 
-If a host needs to adjust discovered skill metadata at runtime, install a
-catalog transform before agents can call `load_skill`:
+Do not weaken main-thread metadata in `tools.yaml` just because the host is
+running headless. Main-affinity declarations are part of the skill contract and
+should stay truthful across GUI and batch modes.
 
 ```python
-def adapt_skill_for_runtime(skill):
-    tools = list(skill.tools)
-    for tool in tools:
-        if tool.name in standalone_safe_tools and running_standalone:
-            tool.enforce_thread_affinity = False
-    skill.tools = tools
-    return None  # use the mutated object
+from dcc_mcp_core import DccServerBase, DccServerOptions
 
-server.set_skill_load_transform(adapt_skill_for_runtime)
+opts = DccServerOptions.from_env(
+    "maya",
+    skills_dir,
+    standalone_main_thread=True,  # mayapy/batch only, never GUI sessions
+)
+server = DccServerBase(opts)
+server.register_builtin_actions()
 ```
 
-The hook is owned by the core `SkillCatalog`, so the same policy applies to
-direct Python `load_skill`, MCP `tools/call load_skill`, REST
-`POST /v1/load_skill`, and multi-skill/group activation paths. Raise an
-exception from the transform to veto before tools are registered. Use
-`set_after_load_skill_hook(lambda skill, actions: ...)` only for observation or
-adapter bookkeeping after registration.
+`standalone_main_thread=True` tells core that this interpreter process has no
+GUI dispatcher and that its in-process execution lane is safe for tools that
+declare `thread_affinity: main`. Core then installs the inline in-process skill
+executor before discovery and lets MCP `tools/call` plus REST `/v1/call` satisfy
+enforced main-affinity tools without adapter-local metadata mutation.
+
+Keep using a real `QueueDispatcher` / `BlockingDispatcher` for GUI hosts. Use
+`set_skill_load_transform(...)` only for runtime policy that does not lie about
+thread-affinity, such as vetoing unsupported tools or injecting adapter-specific
+resource paths before registration.
 
 ## Readiness binding
 

--- a/python/dcc_mcp_core/_exports.py
+++ b/python/dcc_mcp_core/_exports.py
@@ -312,6 +312,7 @@ _LAZY: dict[str, str] = {
     "GatewayOptions": "dcc_mcp_core._server.options",
     "InlineExecution": "dcc_mcp_core._server.options",
     "ObservabilityOptions": "dcc_mcp_core._server.options",
+    "StandaloneMainThreadExecution": "dcc_mcp_core._server.options",
     # DccServerBase + factory
     "DccServerBase": "dcc_mcp_core.server_base",
     "create_dcc_server": "dcc_mcp_core.factory",

--- a/python/dcc_mcp_core/_server/__init__.py
+++ b/python/dcc_mcp_core/_server/__init__.py
@@ -55,6 +55,7 @@ from dcc_mcp_core._server.options import ExecutionOptions
 from dcc_mcp_core._server.options import GatewayOptions
 from dcc_mcp_core._server.options import InlineExecution
 from dcc_mcp_core._server.options import ObservabilityOptions
+from dcc_mcp_core._server.options import StandaloneMainThreadExecution
 from dcc_mcp_core._server.runtime import ServerRuntimeController
 from dcc_mcp_core._server.skill_query import SkillQueryClient
 from dcc_mcp_core._server.tools_list_policy import ENV_EXCLUDE_STUBS_FROM_TOOLS_LIST
@@ -105,6 +106,7 @@ __all__ = [
     "ServerLifecycleController",
     "ServerRuntimeController",
     "SkillQueryClient",
+    "StandaloneMainThreadExecution",
     "TelemetryManager",
     "ToolsListStubPolicy",
     "WindowResolver",

--- a/python/dcc_mcp_core/_server/config.py
+++ b/python/dcc_mcp_core/_server/config.py
@@ -20,6 +20,7 @@ from dcc_mcp_core._server.options import ExecutionMode
 from dcc_mcp_core._server.options import ObservabilityOptions
 from dcc_mcp_core._server.options import _BridgeExecution
 from dcc_mcp_core._server.options import _DispatcherExecution
+from dcc_mcp_core._server.options import _StandaloneMainThreadExecution
 from dcc_mcp_core._server.tools_list_policy import apply_tools_list_stub_policy
 
 if TYPE_CHECKING:
@@ -52,6 +53,8 @@ class ExecutionBinding:
 
     bridge: HostExecutionBridge | None
     dispatcher: BaseDccCallableDispatcher | None
+    standalone_main_thread: bool = False
+    register_inprocess_executor: bool = False
 
 
 CONTEXT_METADATA_ENV: dict[str, str] = {
@@ -98,9 +101,24 @@ def resolve_diagnostics_state(options: DiagnosticsOptions) -> DiagnosticsState:
 def resolve_execution_binding(mode: ExecutionMode) -> ExecutionBinding:
     """Resolve the execution tagged union to concrete collaborators."""
     if isinstance(mode, _BridgeExecution):
-        return ExecutionBinding(bridge=mode.bridge, dispatcher=mode.bridge.dispatcher)
+        return ExecutionBinding(
+            bridge=mode.bridge,
+            dispatcher=mode.bridge.dispatcher,
+            register_inprocess_executor=True,
+        )
     if isinstance(mode, _DispatcherExecution):
-        return ExecutionBinding(bridge=None, dispatcher=mode.dispatcher)
+        return ExecutionBinding(
+            bridge=None,
+            dispatcher=mode.dispatcher,
+            register_inprocess_executor=True,
+        )
+    if isinstance(mode, _StandaloneMainThreadExecution):
+        return ExecutionBinding(
+            bridge=None,
+            dispatcher=None,
+            standalone_main_thread=True,
+            register_inprocess_executor=True,
+        )
     return ExecutionBinding(bridge=None, dispatcher=None)
 
 
@@ -144,6 +162,7 @@ def build_mcp_http_config(
 
     config.dcc_type = options.dcc_name
     config.instance_metadata = collect_context_metadata_from_env(options.dcc_name)
+    config.standalone_main_thread_execution = resolve_execution_binding(options.execution.mode).standalone_main_thread
     apply_tools_list_stub_policy(config, options.dcc_name)
     return config
 

--- a/python/dcc_mcp_core/_server/options.py
+++ b/python/dcc_mcp_core/_server/options.py
@@ -160,11 +160,24 @@ class _BridgeExecution:
     kind: str = field(default="bridge", init=False)
 
 
+@dataclass(frozen=True)
+class _StandaloneMainThreadExecution:
+    """Run in-process skills inline and treat that lane as main-thread safe."""
+
+    kind: str = field(default="standalone-main-thread", init=False)
+
+
 #: Tagged union — only one of the three variants is valid at a time.
-ExecutionMode = Union[_InlineExecution, _DispatcherExecution, _BridgeExecution]
+ExecutionMode = Union[
+    _InlineExecution,
+    _DispatcherExecution,
+    _BridgeExecution,
+    _StandaloneMainThreadExecution,
+]
 
 # Convenience constructors (avoids importing the private variants everywhere).
 InlineExecution: _InlineExecution = _InlineExecution()
+StandaloneMainThreadExecution: _StandaloneMainThreadExecution = _StandaloneMainThreadExecution()
 
 
 def DispatcherExecution(dispatcher: BaseDccCallableDispatcher) -> _DispatcherExecution:
@@ -182,7 +195,8 @@ class ExecutionOptions:
     """Execution mode selection.
 
     Args:
-        mode: One of :data:`InlineExecution`, ``DispatcherExecution(d)``,
+        mode: One of :data:`InlineExecution`,
+            :data:`StandaloneMainThreadExecution`, ``DispatcherExecution(d)``,
             or ``BridgeExecution(b)``.  Defaults to :data:`InlineExecution`.
 
     """
@@ -254,6 +268,7 @@ class DccServerOptions:
         # execution kwargs
         dispatcher: BaseDccCallableDispatcher | None = None,
         execution_bridge: HostExecutionBridge | None = None,
+        standalone_main_thread: bool = False,
     ) -> DccServerOptions:
         """Build a :class:`DccServerOptions` from keyword arguments + env vars.
 
@@ -262,11 +277,13 @@ class DccServerOptions:
         producing a fully-resolved frozen object.
 
         Raises:
-            ValueError: If both ``dispatcher`` and ``execution_bridge`` are provided.
+            ValueError: If more than one execution mode is provided.
 
         """
         if dispatcher is not None and execution_bridge is not None:
             raise ValueError("Pass either dispatcher or execution_bridge, not both")
+        if standalone_main_thread and (dispatcher is not None or execution_bridge is not None):
+            raise ValueError("standalone_main_thread cannot be combined with dispatcher or execution_bridge")
 
         gateway = GatewayOptions.from_env(
             port=gateway_port,
@@ -291,6 +308,8 @@ class DccServerOptions:
             exec_mode: ExecutionMode = BridgeExecution(execution_bridge)
         elif dispatcher is not None:
             exec_mode = DispatcherExecution(dispatcher)
+        elif standalone_main_thread:
+            exec_mode = StandaloneMainThreadExecution
         else:
             exec_mode = InlineExecution
 

--- a/python/dcc_mcp_core/server_base.py
+++ b/python/dcc_mcp_core/server_base.py
@@ -102,6 +102,7 @@ class DccServerBase:
         execution = resolve_execution_binding(options.execution.mode)
         self._execution_bridge: HostExecutionBridge | None = execution.bridge
         self._dcc_dispatcher: BaseDccCallableDispatcher | None = execution.dispatcher
+        self._standalone_main_thread: bool = execution.standalone_main_thread
 
         self._inprocess_executor_registered: bool = False
         self._cached_hwnd: int | None = None
@@ -136,6 +137,8 @@ class DccServerBase:
             self.register_host_execution_bridge(execution.bridge)
         elif execution.dispatcher is not None:
             self.register_inprocess_executor(execution.dispatcher)
+        elif execution.register_inprocess_executor:
+            self.register_inprocess_executor(None)
 
         # Composed collaborators
         self._skill_client = SkillQueryClient(self._server, options.dcc_name)
@@ -381,7 +384,9 @@ class DccServerBase:
                 leaving every skill as a stub.
 
         """
-        if self._dcc_dispatcher is not None and not self._inprocess_executor_registered:
+        if (
+            self._dcc_dispatcher is not None or self._standalone_main_thread
+        ) and not self._inprocess_executor_registered:
             self.register_inprocess_executor(self._dcc_dispatcher)
 
         skill_paths = self.collect_skill_search_paths(

--- a/skills/dcc-mcp-skill-developer/SKILL.md
+++ b/skills/dcc-mcp-skill-developer/SKILL.md
@@ -242,8 +242,7 @@ into a faster authoring loop.
 10. Skill script entry points may use either modern `main(**params)` or legacy
     `main(params)` signatures; prefer `main(**params)` for new scripts and keep
     dict-style wrappers only for compatibility during adapter migrations.
-11. When an adapter must adjust discovered skill metadata before registration
-    (for example disabling thread-affinity enforcement for a standalone path),
+11. When an adapter must adjust discovered skill metadata before registration,
     install `server.set_skill_load_transform(fn)` before exposing the server to
     agents. The transform receives a mutable `SkillMetadata` and applies to
     direct Python `load_skill`, MCP `tools/call load_skill`, REST
@@ -253,7 +252,16 @@ into a faster authoring loop.
     registration, and keep `get_skill()` / `load_skill_object()` for explicit
     one-off object loads. Do not parse or rewrite `SKILL.md` / `tools.yaml` at
     adapter runtime. Keep `get_skill_info()` for serialized inspection only.
-12. For ad-hoc script execution, prefer file-backed boundaries. Use
+    Do not use this hook to clear `enforce_thread_affinity` for batch hosts.
+12. In mayapy/hython/batch hosts where no GUI dispatcher exists but the
+    adapter has verified the in-process lane is safe for DCC API calls, pass
+    `standalone_main_thread=True` to `DccServerOptions.from_env(...)` instead
+    of mutating loaded skill metadata. This core-owned opt-in registers the
+    inline in-process executor before discovery and lets MCP `tools/call` plus
+    REST `/v1/call` satisfy `thread_affinity: main` tools. Do not use it for
+    GUI sessions; wire `HostExecutionBridge(dispatcher=...)`,
+    `QueueDispatcher`, or `BlockingDispatcher` there.
+13. For ad-hoc script execution, prefer file-backed boundaries. Use
     `materialize_script(...)` (Python) or
     `ScriptMaterializationStore` (Rust) to create host-local scripts under the
     DCC/session-scoped root before calling `execute_python(file_path=...)` or
@@ -271,9 +279,9 @@ into a faster authoring loop.
     file before a later execution call. New script execution tool schemas must
     include `file_path` or `script_path` when they accept inline `code`;
     validation warns on unbounded inline-only code schemas.
-13. Add tests at the lowest executable layer, then one discovery/load/call or
+14. Add tests at the lowest executable layer, then one discovery/load/call or
     gateway REST path when behavior crosses MCP or REST boundaries.
-14. For application UI automation, use the generic `app_ui__*` contract rather
+15. For application UI automation, use the generic `app_ui__*` contract rather
     than DCC-specific names: snapshot -> find -> act -> wait_for -> verify.
     The Rust contract types live in `dcc-mcp-app-ui`; do not add Qt, OS
     accessibility, webview, PyO3, or HTTP runtime dependencies there.

--- a/tests/test_dcc_server_options.py
+++ b/tests/test_dcc_server_options.py
@@ -30,6 +30,7 @@ from dcc_mcp_core._server.options import ExecutionOptions
 from dcc_mcp_core._server.options import GatewayOptions
 from dcc_mcp_core._server.options import InlineExecution
 from dcc_mcp_core._server.options import ObservabilityOptions
+from dcc_mcp_core._server.options import StandaloneMainThreadExecution
 
 # ── GatewayOptions ────────────────────────────────────────────────────────────
 
@@ -124,6 +125,8 @@ class TestResolvedServerConfig:
 
         assert binding.bridge is None
         assert binding.dispatcher is dispatcher
+        assert binding.standalone_main_thread is False
+        assert binding.register_inprocess_executor is True
 
     def test_execution_binding_resolves_bridge_dispatcher(self):
         dispatcher = MagicMock()
@@ -133,6 +136,16 @@ class TestResolvedServerConfig:
 
         assert binding.bridge is bridge
         assert binding.dispatcher is dispatcher
+        assert binding.standalone_main_thread is False
+        assert binding.register_inprocess_executor is True
+
+    def test_execution_binding_resolves_standalone_main_thread(self):
+        binding = resolve_execution_binding(StandaloneMainThreadExecution)
+
+        assert binding.bridge is None
+        assert binding.dispatcher is None
+        assert binding.standalone_main_thread is True
+        assert binding.register_inprocess_executor is True
 
     def test_context_metadata_from_env_includes_dcc_specific_paths(self, monkeypatch):
         monkeypatch.setenv("DCC_MCP_PROJECT", "show-a")
@@ -168,6 +181,23 @@ class TestResolvedServerConfig:
         assert config.dcc_version == "25.0"
         assert config.scene == "C:/scene.psd"
         assert config.dcc_type == "photoshop"
+        assert config.standalone_main_thread_execution is False
+
+    def test_build_mcp_http_config_propagates_standalone_main_thread(self, tmp_path):
+        opts = DccServerOptions.from_env(
+            "maya",
+            tmp_path,
+            port=0,
+            standalone_main_thread=True,
+        )
+
+        config = build_mcp_http_config(
+            opts,
+            package_version="9.9.9",
+            version_provider=lambda: "unused",
+        )
+
+        assert config.standalone_main_thread_execution is True
 
 
 # ── DiagnosticsOptions ────────────────────────────────────────────────────────
@@ -196,6 +226,7 @@ class TestExecutionMode:
         exec_opts = ExecutionOptions()
         assert exec_opts.mode is InlineExecution
         assert InlineExecution.kind == "inline"
+        assert StandaloneMainThreadExecution.kind == "standalone-main-thread"
 
     def test_dispatcher_execution(self):
         dispatcher = MagicMock()
@@ -246,6 +277,10 @@ class TestDccServerOptions:
         assert opts.execution.mode.kind == "bridge"
         assert opts.execution.mode.bridge is bridge
 
+    def test_from_env_standalone_main_thread(self, tmp_path):
+        opts = DccServerOptions.from_env("maya", tmp_path, standalone_main_thread=True)
+        assert opts.execution.mode is StandaloneMainThreadExecution
+
     def test_from_env_mutex_raises(self, tmp_path):
         """Passing both dispatcher and execution_bridge must raise ValueError at build time."""
         with pytest.raises(ValueError, match=r"dispatcher.*execution_bridge|execution_bridge.*dispatcher"):
@@ -254,6 +289,15 @@ class TestDccServerOptions:
                 tmp_path,
                 dispatcher=MagicMock(),
                 execution_bridge=MagicMock(),
+            )
+
+    def test_from_env_standalone_mutex_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="standalone_main_thread"):
+            DccServerOptions.from_env(
+                "maya",
+                tmp_path,
+                dispatcher=MagicMock(),
+                standalone_main_thread=True,
             )
 
     def test_from_env_gateway_port_from_kwarg(self, tmp_path, monkeypatch):
@@ -432,7 +476,9 @@ class TestDccServerBasePublicImport:
         from dcc_mcp_core._server.options import BridgeExecution
         from dcc_mcp_core._server.options import DispatcherExecution
         from dcc_mcp_core._server.options import InlineExecution
+        from dcc_mcp_core._server.options import StandaloneMainThreadExecution
 
         assert InlineExecution is not None
         assert DispatcherExecution is not None
         assert BridgeExecution is not None
+        assert StandaloneMainThreadExecution is not None

--- a/tests/test_host_http_integration.py
+++ b/tests/test_host_http_integration.py
@@ -214,6 +214,69 @@ def test_without_dispatcher_backcompat() -> None:
         handle.shutdown()
 
 
+def test_enforced_main_affinity_without_dispatcher_fails_clearly() -> None:
+    """Default path still rejects main-affinity tools without a dispatcher."""
+    server, reg = _make_server("p2b-no-dispatcher-main-affinity")
+    reg.register(
+        "thread_probe",
+        description="Return the thread id handling the call.",
+        category="test",
+        dcc="test",
+        version="1.0.0",
+        thread_affinity="main",
+        enforce_thread_affinity=True,
+    )
+    server.register_handler("thread_probe", lambda _params: {"ok": True}, thread_affinity="main")
+    handle = server.start()
+    try:
+        time.sleep(0.2)
+        resp = _call_tool(handle.mcp_url(), "thread_probe")
+        assert resp["result"]["isError"] is True, resp
+        assert "THREAD_AFFINITY_UNAVAILABLE" in resp["result"]["content"][0]["text"]
+    finally:
+        handle.shutdown()
+
+
+def test_standalone_main_thread_execution_satisfies_main_affinity_without_dispatcher() -> None:
+    """Mayapy-style standalone hosts can explicitly opt into inline main-affinity execution."""
+    reg = ToolRegistry()
+    cfg = McpHttpConfig(port=0, server_name="standalone-main-affinity")
+    cfg.standalone_main_thread_execution = True
+    server = McpHttpServer(reg, cfg)
+    reg.register(
+        "thread_probe",
+        description="Return the thread id handling the call.",
+        category="test",
+        dcc="test",
+        version="1.0.0",
+        thread_affinity="main",
+        enforce_thread_affinity=True,
+    )
+    captured: dict[str, int | None] = {"tid": None}
+
+    def _probe(_params: dict) -> dict:
+        captured["tid"] = threading.get_ident()
+        return {"ok": True, "tid": captured["tid"]}
+
+    server.register_handler("thread_probe", _probe, thread_affinity="main")
+    handle = server.start()
+    try:
+        time.sleep(0.2)
+
+        resp = _call_tool(handle.mcp_url(), "thread_probe")
+        assert resp.get("error") is None, resp
+        assert resp["result"]["isError"] is False, resp
+        assert "THREAD_AFFINITY_UNAVAILABLE" not in json.dumps(resp)
+        assert captured["tid"] is not None
+
+        status, body = _rest_call(handle.mcp_url(), "test.core.thread_probe", {})
+        assert status == 200, body
+        assert "THREAD_AFFINITY" not in json.dumps(body)
+        assert body["output"]["ok"] is True
+    finally:
+        handle.shutdown()
+
+
 def test_dispatcher_shutdown_during_call_surfaces_error() -> None:
     """If the dispatcher is shut down while a call is in flight, the
     HTTP caller receives a clean error envelope, not a hang.

--- a/tests/test_inprocess_executor.py
+++ b/tests/test_inprocess_executor.py
@@ -654,6 +654,45 @@ def test_dcc_server_base_constructor_registers_execution_bridge_before_discovery
     assert events == ["set_in_process_executor", "discover"]
 
 
+def test_dcc_server_base_standalone_main_thread_registers_inline_executor_before_discovery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from dcc_mcp_core._server.options import DccServerOptions
+    from dcc_mcp_core.server_base import DccServerBase
+
+    events: list[str] = []
+
+    class _Server:
+        def set_in_process_executor(self, executor: Callable[..., Any]) -> None:
+            events.append("set_in_process_executor")
+            self.executor = executor
+
+        def discover(self, extra_paths: list[str]) -> int:
+            events.append("discover")
+            return len(extra_paths)
+
+    fake_server = _Server()
+    import dcc_mcp_core.server_base as server_base
+
+    monkeypatch.setattr(server_base, "create_skill_server", lambda *_args, **_kwargs: fake_server)
+
+    opts = DccServerOptions.from_env(
+        "test_standalone_ctor",
+        tmp_path,
+        port=0,
+        standalone_main_thread=True,
+        enable_file_logging=False,
+        enable_job_persistence=False,
+        enable_telemetry=False,
+    )
+    base = DccServerBase(opts)
+    base.register_builtin_actions(include_bundled=False)
+
+    assert events == ["set_in_process_executor", "discover"]
+    assert base._standalone_main_thread is True
+
+
 def test_dcc_server_base_execution_bridge_attaches_queue_dispatcher_before_discovery(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- add an explicit standalone main-thread execution opt-in for batch hosts such as mayapy/hython
- let MCP tools/call and REST /v1/call satisfy enforced main-affinity tools without adapter-local metadata mutation
- keep the default THREAD_AFFINITY_UNAVAILABLE error when no dispatcher, bridge, or standalone opt-in is configured
- document the new mode and update skill developer guidance

## Validation
- vx cargo fmt --all -- --check
- vx cargo clippy -p dcc-mcp-http-types -p dcc-mcp-http-server -p dcc-mcp-skill-rest -p dcc-mcp-http-py --all-targets -- -D warnings
- vx cargo test -p dcc-mcp-http-types -p dcc-mcp-http-server -p dcc-mcp-skill-rest -p dcc-mcp-http-py
- vx ruff check python/dcc_mcp_core/_server/options.py python/dcc_mcp_core/_server/config.py python/dcc_mcp_core/server_base.py tests/test_dcc_server_options.py tests/test_host_http_integration.py tests/test_inprocess_executor.py
- vx ruff format --check python/dcc_mcp_core/_server/options.py python/dcc_mcp_core/_server/config.py python/dcc_mcp_core/server_base.py tests/test_dcc_server_options.py tests/test_host_http_integration.py tests/test_inprocess_executor.py
- python -m pytest tests/test_host_http_integration.py tests/test_dcc_server_options.py tests/test_inprocess_executor.py -q

Closes #1235