### PR TITLE
feat: add admin ui i18n runtime

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -14,6 +14,7 @@ import unrealIcon from './assets/icons/unrealengine.svg';
 import substancePainterIcon from './assets/icons/photoshop.svg';
 import puzzleIcon from './assets/icons/puzzle.svg';
 import vscodeIcon from './assets/icons/vscode.svg';
+import { createTranslator, detectBrowserLocale, type MessageKey } from './i18n';
 import { formatTime, timestampTitle } from './time';
 
 type Panel = 'setup' | 'debug' | 'activity' | 'health' | 'instances' | 'tools' | 'workflows' | 'tasks' | 'openapi' | 'calls' | 'traces' | 'traffic' | 'stats' | 'governance' | 'logs' | 'skill-paths';
@@ -987,23 +988,25 @@ const IDE_TARGETS: IdeTarget[] = [
     build: buildCodexConfig,
   },
 ];
-const PANELS: { id: Panel; label: string; group: string }[] = [
-  { id: 'setup', label: 'Connect IDE', group: 'Onboarding' },
-  { id: 'debug', label: 'Debug', group: 'Operations' },
-  { id: 'instances', label: 'Instances', group: 'Operations' },
-  { id: 'activity', label: 'Activity', group: 'Operations' },
-  { id: 'health', label: 'Health', group: 'Operations' },
-  { id: 'workflows', label: 'Workflows', group: 'Workspace' },
-  { id: 'tasks', label: 'Tasks', group: 'Workspace' },
-  { id: 'tools', label: 'Tools', group: 'Workspace' },
-  { id: 'openapi', label: 'OpenAPI Inspector', group: 'Contracts' },
-  { id: 'stats', label: 'Stats', group: 'Observability' },
-  { id: 'governance', label: 'Governance', group: 'Observability' },
-  { id: 'traffic', label: 'Traffic', group: 'Observability' },
-  { id: 'traces', label: 'Traces', group: 'Observability' },
-  { id: 'calls', label: 'Calls', group: 'Observability' },
-  { id: 'logs', label: 'Logs', group: 'Observability' },
-  { id: 'skill-paths', label: 'Skills', group: 'Configuration' },
+type PanelDefinition = { id: Panel; labelKey: MessageKey; groupKey: MessageKey };
+
+const PANELS: PanelDefinition[] = [
+  { id: 'setup', labelKey: 'panel.setup', groupKey: 'panelGroup.onboarding' },
+  { id: 'debug', labelKey: 'panel.debug', groupKey: 'panelGroup.operations' },
+  { id: 'instances', labelKey: 'panel.instances', groupKey: 'panelGroup.operations' },
+  { id: 'activity', labelKey: 'panel.activity', groupKey: 'panelGroup.operations' },
+  { id: 'health', labelKey: 'panel.health', groupKey: 'panelGroup.operations' },
+  { id: 'workflows', labelKey: 'panel.workflows', groupKey: 'panelGroup.workspace' },
+  { id: 'tasks', labelKey: 'panel.tasks', groupKey: 'panelGroup.workspace' },
+  { id: 'tools', labelKey: 'panel.tools', groupKey: 'panelGroup.workspace' },
+  { id: 'openapi', labelKey: 'panel.openapi', groupKey: 'panelGroup.contracts' },
+  { id: 'stats', labelKey: 'panel.stats', groupKey: 'panelGroup.observability' },
+  { id: 'governance', labelKey: 'panel.governance', groupKey: 'panelGroup.observability' },
+  { id: 'traffic', labelKey: 'panel.traffic', groupKey: 'panelGroup.observability' },
+  { id: 'traces', labelKey: 'panel.traces', groupKey: 'panelGroup.observability' },
+  { id: 'calls', labelKey: 'panel.calls', groupKey: 'panelGroup.observability' },
+  { id: 'logs', labelKey: 'panel.logs', groupKey: 'panelGroup.observability' },
+  { id: 'skill-paths', labelKey: 'panel.skillPaths', groupKey: 'panelGroup.configuration' },
 ];
 
 const PANEL_ID_SET = new Set<Panel>(PANELS.map((p) => p.id));
@@ -2710,6 +2713,8 @@ function groupRows<T>(rows: T[], keyFn: (row: T) => string): Map<string, T[]> {
 }
 
 function App() {
+  const [localeDetection] = useState(() => detectBrowserLocale());
+  const t = useMemo(() => createTranslator(localeDetection.locale), [localeDetection.locale]);
   const [activePanel, setActivePanel] = useState<Panel>(() => readPanelFromUrl());
   const [health, setHealth] = useState<HealthPayload | null>(null);
   const [activity, setActivity] = useState<ActivityEvent[]>([]);
@@ -2744,26 +2749,42 @@ function App() {
   const [trafficDetail, setTrafficDetail] = useState<string>('Select a traffic frame row for detail.');
   const [callDetail, setCallDetail] = useState<string>('Select a call row for trace detail.');
   const [copiedNotice, setCopiedNotice] = useState<string>('');
-  const [updatedAt, setUpdatedAt] = useState<Record<Panel, string>>({
-    setup: 'Loading…',
-    debug: 'Loading…',
-    activity: 'Loading…',
-    health: 'Loading…',
-    instances: 'Loading…',
-    tools: 'Loading…',
-    workflows: 'Loading…',
-    tasks: 'Loading…',
-    openapi: 'Loading…',
-    calls: 'Loading…',
-    traces: 'Loading…',
-    traffic: 'Loading…',
-    stats: 'Loading…',
-    governance: 'Loading…',
-    logs: 'Loading…',
-    'skill-paths': 'Loading…',
-  });
+  const [updatedAt, setUpdatedAt] = useState<Record<Panel, string>>(() => ({
+    setup: t('status.loading'),
+    debug: t('status.loading'),
+    activity: t('status.loading'),
+    health: t('status.loading'),
+    instances: t('status.loading'),
+    tools: t('status.loading'),
+    workflows: t('status.loading'),
+    tasks: t('status.loading'),
+    openapi: t('status.loading'),
+    calls: t('status.loading'),
+    traces: t('status.loading'),
+    traffic: t('status.loading'),
+    stats: t('status.loading'),
+    governance: t('status.loading'),
+    logs: t('status.loading'),
+    'skill-paths': t('status.loading'),
+  }));
   const [errors, setErrors] = useState<Partial<Record<Panel, string>>>({});
   const [listSearch, setListSearch] = useState('');
+
+  const panels = useMemo(
+    () => PANELS.map((panel) => ({ ...panel, label: t(panel.labelKey), group: t(panel.groupKey) })),
+    [t],
+  );
+
+  useEffect(() => {
+    document.documentElement.lang = localeDetection.locale;
+    document.documentElement.dataset.adminLocale = localeDetection.locale;
+    document.documentElement.dataset.adminLocaleSource = localeDetection.source;
+    if (localeDetection.matchedTag) {
+      document.documentElement.dataset.adminLocaleMatchedTag = localeDetection.matchedTag;
+    } else {
+      delete document.documentElement.dataset.adminLocaleMatchedTag;
+    }
+  }, [localeDetection]);
 
   useEffect(() => {
     const u = new URL(window.location.href);
@@ -3956,13 +3977,13 @@ function App() {
         <div className="brand-lockup">
           <div className="brand-accent" aria-hidden="true" />
           <div className="brand-text">
-            <h1>Admin Dashboard</h1>
-            <p className="brand-tag">DCC-MCP Gateway</p>
+            <h1>{t('app.title')}</h1>
+            <p className="brand-tag">{t('app.subtitle')}</p>
           </div>
         </div>
         <div className="nav-links">
-          {PANELS.map((panel, index) => {
-            const showGroup = index === 0 || PANELS[index - 1].group !== panel.group;
+          {panels.map((panel, index) => {
+            const showGroup = index === 0 || panels[index - 1].group !== panel.group;
             return (
               <div className="nav-entry" key={panel.id}>
                 {showGroup ? <div className="nav-section-title">{panel.group}</div> : null}
@@ -3987,10 +4008,10 @@ function App() {
               className="nav-link"
               target="_blank"
               rel="noopener noreferrer"
-              title="Open project docs on GitHub"
+              title={t('nav.docs.title')}
             >
               <DocsIcon />
-              <span>Docs</span>
+              <span>{t('nav.docs')}</span>
             </a>
           </div>
         </div>
@@ -4001,10 +4022,10 @@ function App() {
             <input
               type="search"
               className="list-search-input"
-              placeholder={activePanel === 'stats' ? 'Filter stats charts...' : activePanel === 'openapi' ? 'Filter operations, paths, tags...' : 'Search this panel...'}
+              placeholder={activePanel === 'stats' ? t('search.stats') : activePanel === 'openapi' ? t('search.openapi') : t('search.default')}
               value={listSearch}
               onChange={(e) => setListSearch(e.target.value)}
-              aria-label="Filter current panel"
+              aria-label={t('search.ariaLabel')}
             />
             {listSearch.trim() ? (
               <span className="list-search-meta">
@@ -4029,9 +4050,9 @@ function App() {
         {activePanel === 'setup' && (
           <section className="panel active setup-panel">
             <PanelHeader
-              title="Connect IDE"
+              title={t('panel.setup')}
               meta={setupMcpUrl}
-              action={<button className="refresh-btn" type="button" onClick={fetchSetup}>Refresh</button>}
+              action={<button className="refresh-btn" type="button" onClick={fetchSetup}>{t('action.refresh')}</button>}
             />
             <StatusLine text={copiedNotice || updatedAt.setup} error={errors.setup} />
             <div className="setup-controls">

--- a/admin-ui/src/i18n.ts
+++ b/admin-ui/src/i18n.ts
@@ -1,0 +1,150 @@
+export const SUPPORTED_LOCALES = ['en', 'zh-CN', 'ja', 'ko'] as const;
+
+export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
+
+export type LocaleDetectionSource = 'override' | 'navigator' | 'fallback';
+
+export type LocaleDetection = {
+  locale: SupportedLocale;
+  source: LocaleDetectionSource;
+  matchedTag?: string;
+};
+
+export const DEFAULT_LOCALE: SupportedLocale = 'en';
+
+const SUPPORTED_LOCALE_SET = new Set<string>(SUPPORTED_LOCALES);
+
+const EN_MESSAGES = {
+  'app.title': 'Admin Dashboard',
+  'app.subtitle': 'DCC-MCP Gateway',
+  'action.refresh': 'Refresh',
+  'nav.docs': 'Docs',
+  'nav.docs.title': 'Open project docs on GitHub',
+  'panel.setup': 'Connect IDE',
+  'panel.debug': 'Debug',
+  'panel.instances': 'Instances',
+  'panel.activity': 'Activity',
+  'panel.health': 'Health',
+  'panel.workflows': 'Workflows',
+  'panel.tasks': 'Tasks',
+  'panel.tools': 'Tools',
+  'panel.openapi': 'OpenAPI Inspector',
+  'panel.stats': 'Stats',
+  'panel.governance': 'Governance',
+  'panel.traffic': 'Traffic',
+  'panel.traces': 'Traces',
+  'panel.calls': 'Calls',
+  'panel.logs': 'Logs',
+  'panel.skillPaths': 'Skills',
+  'panelGroup.onboarding': 'Onboarding',
+  'panelGroup.operations': 'Operations',
+  'panelGroup.workspace': 'Workspace',
+  'panelGroup.contracts': 'Contracts',
+  'panelGroup.observability': 'Observability',
+  'panelGroup.configuration': 'Configuration',
+  'search.ariaLabel': 'Filter current panel',
+  'search.default': 'Search this panel...',
+  'search.openapi': 'Filter operations, paths, tags...',
+  'search.stats': 'Filter stats charts...',
+  'status.loading': 'Loading...',
+} as const;
+
+export type MessageKey = keyof typeof EN_MESSAGES;
+
+type LocaleMessages = Partial<Record<MessageKey, string>>;
+
+const LOCALE_MESSAGES: Record<SupportedLocale, LocaleMessages> = {
+  en: EN_MESSAGES,
+  'zh-CN': {},
+  ja: {},
+  ko: {},
+};
+
+function cleanLocaleTag(tag: string): string {
+  return tag.trim().replace(/_/g, '-');
+}
+
+function canonicalSupportedLocale(tag: string): SupportedLocale | null {
+  if (SUPPORTED_LOCALE_SET.has(tag)) {
+    return tag as SupportedLocale;
+  }
+
+  const parts = tag.split('-').filter(Boolean);
+  const language = parts[0]?.toLowerCase();
+  const regionsAndScripts = parts.slice(1).map((part) => part.toLowerCase());
+
+  if (language === 'en') {
+    return 'en';
+  }
+  if (language === 'ja') {
+    return 'ja';
+  }
+  if (language === 'ko') {
+    return 'ko';
+  }
+  if (language === 'zh') {
+    if (
+      parts.length === 1
+      || regionsAndScripts.includes('hans')
+      || regionsAndScripts.includes('cn')
+      || regionsAndScripts.includes('sg')
+    ) {
+      return 'zh-CN';
+    }
+  }
+
+  return null;
+}
+
+export function normalizeLocaleTag(tag: string | null | undefined): SupportedLocale | null {
+  if (!tag) {
+    return null;
+  }
+  return canonicalSupportedLocale(cleanLocaleTag(tag));
+}
+
+export function detectLocale(options?: {
+  override?: string | null;
+  navigatorLanguages?: readonly string[] | null;
+  navigatorLanguage?: string | null;
+  fallback?: SupportedLocale;
+}): LocaleDetection {
+  const fallback = options?.fallback ?? DEFAULT_LOCALE;
+  const override = normalizeLocaleTag(options?.override);
+  if (override) {
+    return { locale: override, source: 'override', matchedTag: options?.override ?? undefined };
+  }
+
+  const candidates = [
+    ...(options?.navigatorLanguages ?? []),
+    ...(options?.navigatorLanguage ? [options.navigatorLanguage] : []),
+  ];
+  for (const tag of candidates) {
+    const locale = normalizeLocaleTag(tag);
+    if (locale) {
+      return { locale, source: 'navigator', matchedTag: tag };
+    }
+  }
+
+  return { locale: fallback, source: 'fallback' };
+}
+
+export function detectBrowserLocale(override?: string | null): LocaleDetection {
+  if (typeof navigator === 'undefined') {
+    return detectLocale({ override });
+  }
+
+  return detectLocale({
+    override,
+    navigatorLanguages: navigator.languages,
+    navigatorLanguage: navigator.language,
+  });
+}
+
+export function translate(locale: SupportedLocale, key: MessageKey): string {
+  return LOCALE_MESSAGES[locale]?.[key] ?? EN_MESSAGES[key];
+}
+
+export function createTranslator(locale: SupportedLocale): (key: MessageKey) => string {
+  return (key) => translate(locale, key);
+}

--- a/admin-ui/tests/admin.spec.ts
+++ b/admin-ui/tests/admin.spec.ts
@@ -759,6 +759,8 @@ test.beforeEach(async ({ page }) => {
 test.describe('Admin Page', () => {
   test('loads the connect panel and navigation', async ({ page }) => {
     await page.goto('/admin/');
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en');
+    await expect(page.locator('html')).toHaveAttribute('data-admin-locale', 'en');
     await expect(page.locator('.brand-tag')).toContainText('DCC-MCP Gateway');
     await expect(page.locator('h1')).toContainText('Admin Dashboard');
     await expect(page.getByRole('navigation').getByRole('link', { name: 'Connect IDE' })).toHaveClass(/active/);
@@ -791,6 +793,20 @@ test.describe('Admin Page', () => {
     await page.getByRole('navigation').getByRole('link', { name: 'Health' }).click();
     await expect(page.locator('.health-panel')).toContainText('0.17.7');
     await expect(page.locator('.health-panel')).toContainText('toon / dcc-mcp-byte4-v1');
+  });
+
+  test('normalizes the browser locale onto the document element', async ({ browser }) => {
+    const context = await browser.newContext({ locale: 'ja-JP' });
+    const page = await context.newPage();
+    await mockAdminApi(page);
+
+    await page.goto('/admin/');
+
+    await expect(page.locator('html')).toHaveAttribute('lang', 'ja');
+    await expect(page.locator('html')).toHaveAttribute('data-admin-locale-source', 'navigator');
+    await expect(page.locator('.brand-tag')).toContainText('DCC-MCP Gateway');
+
+    await context.close();
   });
 
   test('shows platform-specific IDE config paths', async ({ page }) => {

--- a/admin-ui/tests/i18n.spec.ts
+++ b/admin-ui/tests/i18n.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '@playwright/test';
+
+import { createTranslator, detectLocale, normalizeLocaleTag, translate } from '../src/i18n';
+
+test.describe('i18n locale detection', () => {
+  test('normalizes supported browser locale variants', () => {
+    expect(normalizeLocaleTag('en-US')).toBe('en');
+    expect(normalizeLocaleTag('zh')).toBe('zh-CN');
+    expect(normalizeLocaleTag('zh-Hans')).toBe('zh-CN');
+    expect(normalizeLocaleTag('zh_CN')).toBe('zh-CN');
+    expect(normalizeLocaleTag('ja-JP')).toBe('ja');
+    expect(normalizeLocaleTag('ko-KR')).toBe('ko');
+  });
+
+  test('falls back to English when preferences are unsupported', () => {
+    expect(detectLocale({ navigatorLanguages: ['fr-FR', 'de-DE'] })).toEqual({
+      locale: 'en',
+      source: 'fallback',
+    });
+  });
+
+  test('prefers explicit overrides for future manual selection', () => {
+    expect(detectLocale({ override: 'ko-KR', navigatorLanguages: ['ja-JP'] })).toEqual({
+      locale: 'ko',
+      source: 'override',
+      matchedTag: 'ko-KR',
+    });
+  });
+
+  test('uses navigator language order before the fallback language field', () => {
+    expect(detectLocale({ navigatorLanguages: ['fr-FR', 'zh-Hans'], navigatorLanguage: 'ja-JP' })).toEqual({
+      locale: 'zh-CN',
+      source: 'navigator',
+      matchedTag: 'zh-Hans',
+    });
+  });
+
+  test('returns English strings instead of missing translation keys', () => {
+    const t = createTranslator('ja');
+
+    expect(t('panel.setup')).toBe('Connect IDE');
+    expect(translate('zh-CN', 'search.default')).toBe('Search this panel...');
+  });
+});

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -69,6 +69,25 @@ let config = GatewayConfig {
 
 When using `dcc-mcp-gateway` directly, compile with the `admin` Cargo feature. `dcc-mcp-http` and the shipped server binary enable this for their embedded gateway path.
 
+## Locale Detection
+
+The embedded Admin UI includes a small in-bundle i18n runtime. It reads
+`navigator.languages` / `navigator.language`, normalizes supported browser tags,
+and falls back to English when no supported preference is present. No
+translation assets are fetched over the network.
+
+Supported runtime locales are:
+
+- `en`
+- `zh-CN` for `zh`, `zh-Hans`, `zh-CN`, and other Simplified Chinese tags
+- `ja` for `ja` / `ja-JP`
+- `ko` for `ko` / `ko-KR`
+
+The runtime exposes a typed translation lookup surface in `admin-ui/src/i18n.ts`.
+Missing localized strings fall back to English so panels never render raw
+message keys. Future manual language selection should pass an explicit override
+through the same detection helper instead of bypassing the runtime.
+
 ## Dashboard Screenshots
 
 The screenshots below use representative demo data and show the browser-first


### PR DESCRIPTION
Fixes #1237

## Summary
- add a typed admin UI i18n runtime with locale normalization, browser preference detection, English fallback, and future override support
- wire the admin shell to the runtime, including document locale metadata and typed navigation/search labels
- add unit and browser coverage for locale normalization, fallback behavior, and DOM integration
- document the embedded admin locale detection contract

## Validation
- `vx npm run build` in `admin-ui`
- `vx npx playwright test tests/i18n.spec.ts tests/admin.spec.ts` in `admin-ui`
- `vx just admin-build`
- `vx npm --prefix docs ci && vx npm --prefix docs run docs:build`
- `vx npx markdownlint-cli2 "docs/**/*.md" "README.md" "README_zh.md" "!docs/node_modules"`
- `vx git diff --check`

`vx just docs-check` could not run on this Windows environment because `just` could not find `cygpath` for its bash shebang; the underlying docs build command was run directly instead.

Skill developer guidance was not updated because this change only affects the admin UI runtime.