### PR TITLE
feat: namespace admin ui translations

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -991,22 +991,22 @@ const IDE_TARGETS: IdeTarget[] = [
 type PanelDefinition = { id: Panel; labelKey: MessageKey; groupKey: MessageKey };
 
 const PANELS: PanelDefinition[] = [
-  { id: 'setup', labelKey: 'panel.setup', groupKey: 'panelGroup.onboarding' },
-  { id: 'debug', labelKey: 'panel.debug', groupKey: 'panelGroup.operations' },
-  { id: 'instances', labelKey: 'panel.instances', groupKey: 'panelGroup.operations' },
-  { id: 'activity', labelKey: 'panel.activity', groupKey: 'panelGroup.operations' },
-  { id: 'health', labelKey: 'panel.health', groupKey: 'panelGroup.operations' },
-  { id: 'workflows', labelKey: 'panel.workflows', groupKey: 'panelGroup.workspace' },
-  { id: 'tasks', labelKey: 'panel.tasks', groupKey: 'panelGroup.workspace' },
-  { id: 'tools', labelKey: 'panel.tools', groupKey: 'panelGroup.workspace' },
-  { id: 'openapi', labelKey: 'panel.openapi', groupKey: 'panelGroup.contracts' },
-  { id: 'stats', labelKey: 'panel.stats', groupKey: 'panelGroup.observability' },
-  { id: 'governance', labelKey: 'panel.governance', groupKey: 'panelGroup.observability' },
-  { id: 'traffic', labelKey: 'panel.traffic', groupKey: 'panelGroup.observability' },
-  { id: 'traces', labelKey: 'panel.traces', groupKey: 'panelGroup.observability' },
-  { id: 'calls', labelKey: 'panel.calls', groupKey: 'panelGroup.observability' },
-  { id: 'logs', labelKey: 'panel.logs', groupKey: 'panelGroup.observability' },
-  { id: 'skill-paths', labelKey: 'panel.skillPaths', groupKey: 'panelGroup.configuration' },
+  { id: 'setup', labelKey: 'navigation.panel.setup', groupKey: 'navigation.group.onboarding' },
+  { id: 'debug', labelKey: 'navigation.panel.debug', groupKey: 'navigation.group.operations' },
+  { id: 'instances', labelKey: 'navigation.panel.instances', groupKey: 'navigation.group.operations' },
+  { id: 'activity', labelKey: 'navigation.panel.activity', groupKey: 'navigation.group.operations' },
+  { id: 'health', labelKey: 'navigation.panel.health', groupKey: 'navigation.group.operations' },
+  { id: 'workflows', labelKey: 'navigation.panel.workflows', groupKey: 'navigation.group.workspace' },
+  { id: 'tasks', labelKey: 'navigation.panel.tasks', groupKey: 'navigation.group.workspace' },
+  { id: 'tools', labelKey: 'navigation.panel.tools', groupKey: 'navigation.group.workspace' },
+  { id: 'openapi', labelKey: 'navigation.panel.openapi', groupKey: 'navigation.group.contracts' },
+  { id: 'stats', labelKey: 'navigation.panel.stats', groupKey: 'navigation.group.observability' },
+  { id: 'governance', labelKey: 'navigation.panel.governance', groupKey: 'navigation.group.observability' },
+  { id: 'traffic', labelKey: 'navigation.panel.traffic', groupKey: 'navigation.group.observability' },
+  { id: 'traces', labelKey: 'navigation.panel.traces', groupKey: 'navigation.group.observability' },
+  { id: 'calls', labelKey: 'navigation.panel.calls', groupKey: 'navigation.group.observability' },
+  { id: 'logs', labelKey: 'navigation.panel.logs', groupKey: 'navigation.group.observability' },
+  { id: 'skill-paths', labelKey: 'navigation.panel.skillPaths', groupKey: 'navigation.group.configuration' },
 ];
 
 const PANEL_ID_SET = new Set<Panel>(PANELS.map((p) => p.id));
@@ -2750,22 +2750,22 @@ function App() {
   const [callDetail, setCallDetail] = useState<string>('Select a call row for trace detail.');
   const [copiedNotice, setCopiedNotice] = useState<string>('');
   const [updatedAt, setUpdatedAt] = useState<Record<Panel, string>>(() => ({
-    setup: t('status.loading'),
-    debug: t('status.loading'),
-    activity: t('status.loading'),
-    health: t('status.loading'),
-    instances: t('status.loading'),
-    tools: t('status.loading'),
-    workflows: t('status.loading'),
-    tasks: t('status.loading'),
-    openapi: t('status.loading'),
-    calls: t('status.loading'),
-    traces: t('status.loading'),
-    traffic: t('status.loading'),
-    stats: t('status.loading'),
-    governance: t('status.loading'),
-    logs: t('status.loading'),
-    'skill-paths': t('status.loading'),
+    setup: t('common.status.loading'),
+    debug: t('common.status.loading'),
+    activity: t('common.status.loading'),
+    health: t('common.status.loading'),
+    instances: t('common.status.loading'),
+    tools: t('common.status.loading'),
+    workflows: t('common.status.loading'),
+    tasks: t('common.status.loading'),
+    openapi: t('common.status.loading'),
+    calls: t('common.status.loading'),
+    traces: t('common.status.loading'),
+    traffic: t('common.status.loading'),
+    stats: t('common.status.loading'),
+    governance: t('common.status.loading'),
+    logs: t('common.status.loading'),
+    'skill-paths': t('common.status.loading'),
   }));
   const [errors, setErrors] = useState<Partial<Record<Panel, string>>>({});
   const [listSearch, setListSearch] = useState('');
@@ -3977,8 +3977,8 @@ function App() {
         <div className="brand-lockup">
           <div className="brand-accent" aria-hidden="true" />
           <div className="brand-text">
-            <h1>{t('app.title')}</h1>
-            <p className="brand-tag">{t('app.subtitle')}</p>
+            <h1>{t('chrome.app.title')}</h1>
+            <p className="brand-tag">{t('chrome.app.subtitle')}</p>
           </div>
         </div>
         <div className="nav-links">
@@ -4008,10 +4008,10 @@ function App() {
               className="nav-link"
               target="_blank"
               rel="noopener noreferrer"
-              title={t('nav.docs.title')}
+              title={t('navigation.docs.title')}
             >
               <DocsIcon />
-              <span>{t('nav.docs')}</span>
+              <span>{t('navigation.docs.label')}</span>
             </a>
           </div>
         </div>
@@ -4022,10 +4022,10 @@ function App() {
             <input
               type="search"
               className="list-search-input"
-              placeholder={activePanel === 'stats' ? t('search.stats') : activePanel === 'openapi' ? t('search.openapi') : t('search.default')}
+              placeholder={activePanel === 'stats' ? t('search.input.stats') : activePanel === 'openapi' ? t('search.input.openapi') : t('search.input.default')}
               value={listSearch}
               onChange={(e) => setListSearch(e.target.value)}
-              aria-label={t('search.ariaLabel')}
+              aria-label={t('search.input.ariaLabel')}
             />
             {listSearch.trim() ? (
               <span className="list-search-meta">
@@ -4050,9 +4050,9 @@ function App() {
         {activePanel === 'setup' && (
           <section className="panel active setup-panel">
             <PanelHeader
-              title={t('panel.setup')}
+              title={t('navigation.panel.setup')}
               meta={setupMcpUrl}
-              action={<button className="refresh-btn" type="button" onClick={fetchSetup}>{t('action.refresh')}</button>}
+              action={<button className="refresh-btn" type="button" onClick={fetchSetup}>{t('common.action.refresh')}</button>}
             />
             <StatusLine text={copiedNotice || updatedAt.setup} error={errors.setup} />
             <div className="setup-controls">

--- a/admin-ui/src/i18n.ts
+++ b/admin-ui/src/i18n.ts
@@ -10,16 +10,28 @@ export type LocaleDetection = {
   matchedTag?: string;
 };
 
+export type InterpolationValues = Record<string, string | number | boolean | null | undefined>;
+
 export const DEFAULT_LOCALE: SupportedLocale = 'en';
 
 const SUPPORTED_LOCALE_SET = new Set<string>(SUPPORTED_LOCALES);
 
-const EN_MESSAGES = {
+const EMPTY_MESSAGES = {} as const;
+
+const COMMON_MESSAGES = {
+  'action.refresh': 'Refresh',
+  'status.loading': 'Loading...',
+  'status.labelValue': '{label}: {value}',
+} as const;
+
+const CHROME_MESSAGES = {
   'app.title': 'Admin Dashboard',
   'app.subtitle': 'DCC-MCP Gateway',
-  'action.refresh': 'Refresh',
-  'nav.docs': 'Docs',
-  'nav.docs.title': 'Open project docs on GitHub',
+} as const;
+
+const NAVIGATION_MESSAGES = {
+  'docs.label': 'Docs',
+  'docs.title': 'Open project docs on GitHub',
   'panel.setup': 'Connect IDE',
   'panel.debug': 'Debug',
   'panel.instances': 'Instances',
@@ -36,28 +48,68 @@ const EN_MESSAGES = {
   'panel.calls': 'Calls',
   'panel.logs': 'Logs',
   'panel.skillPaths': 'Skills',
-  'panelGroup.onboarding': 'Onboarding',
-  'panelGroup.operations': 'Operations',
-  'panelGroup.workspace': 'Workspace',
-  'panelGroup.contracts': 'Contracts',
-  'panelGroup.observability': 'Observability',
-  'panelGroup.configuration': 'Configuration',
-  'search.ariaLabel': 'Filter current panel',
-  'search.default': 'Search this panel...',
-  'search.openapi': 'Filter operations, paths, tags...',
-  'search.stats': 'Filter stats charts...',
-  'status.loading': 'Loading...',
+  'group.onboarding': 'Onboarding',
+  'group.operations': 'Operations',
+  'group.workspace': 'Workspace',
+  'group.contracts': 'Contracts',
+  'group.observability': 'Observability',
+  'group.configuration': 'Configuration',
 } as const;
 
-export type MessageKey = keyof typeof EN_MESSAGES;
+const SEARCH_MESSAGES = {
+  'input.ariaLabel': 'Filter current panel',
+  'input.default': 'Search this panel...',
+  'input.openapi': 'Filter operations, paths, tags...',
+  'input.stats': 'Filter stats charts...',
+} as const;
 
-type LocaleMessages = Partial<Record<MessageKey, string>>;
+function mirrorNamespace<const T extends Record<string, string>>(messages: T): Record<SupportedLocale, T> {
+  return {
+    en: messages,
+    'zh-CN': messages,
+    ja: messages,
+    ko: messages,
+  };
+}
 
-const LOCALE_MESSAGES: Record<SupportedLocale, LocaleMessages> = {
-  en: EN_MESSAGES,
-  'zh-CN': {},
-  ja: {},
-  ko: {},
+export const I18N_MESSAGES = {
+  common: mirrorNamespace(COMMON_MESSAGES),
+  chrome: mirrorNamespace(CHROME_MESSAGES),
+  navigation: mirrorNamespace(NAVIGATION_MESSAGES),
+  search: mirrorNamespace(SEARCH_MESSAGES),
+  setup: mirrorNamespace(EMPTY_MESSAGES),
+  health: mirrorNamespace(EMPTY_MESSAGES),
+  instances: mirrorNamespace(EMPTY_MESSAGES),
+  tools: mirrorNamespace(EMPTY_MESSAGES),
+  workflows: mirrorNamespace(EMPTY_MESSAGES),
+  tasks: mirrorNamespace(EMPTY_MESSAGES),
+  openapi: mirrorNamespace(EMPTY_MESSAGES),
+  calls: mirrorNamespace(EMPTY_MESSAGES),
+  traces: mirrorNamespace(EMPTY_MESSAGES),
+  traffic: mirrorNamespace(EMPTY_MESSAGES),
+  stats: mirrorNamespace(EMPTY_MESSAGES),
+  governance: mirrorNamespace(EMPTY_MESSAGES),
+  logs: mirrorNamespace(EMPTY_MESSAGES),
+  skillPaths: mirrorNamespace(EMPTY_MESSAGES),
+} as const;
+
+export type I18nNamespace = keyof typeof I18N_MESSAGES;
+export const I18N_NAMESPACES = Object.keys(I18N_MESSAGES) as I18nNamespace[];
+
+type NamespaceMessages<N extends I18nNamespace> = (typeof I18N_MESSAGES)[N]['en'];
+type NamespaceLocalKey<N extends I18nNamespace> = Extract<keyof NamespaceMessages<N>, string>;
+
+export type ScopedMessageKey<N extends I18nNamespace = I18nNamespace> = {
+  [Key in I18nNamespace]: NamespaceLocalKey<Key> extends never ? never : `${Key}.${NamespaceLocalKey<Key>}`;
+}[N];
+
+export type MessageKey = ScopedMessageKey;
+
+export type NamespaceAuditIssue = {
+  namespace: I18nNamespace;
+  locale: SupportedLocale;
+  missingKeys: string[];
+  extraKeys: string[];
 };
 
 function cleanLocaleTag(tag: string): string {
@@ -94,6 +146,22 @@ function canonicalSupportedLocale(tag: string): SupportedLocale | null {
   }
 
   return null;
+}
+
+function splitMessageKey(key: MessageKey): [I18nNamespace, string] {
+  const [namespace, ...localParts] = key.split('.');
+  return [namespace as I18nNamespace, localParts.join('.')];
+}
+
+function interpolate(template: string, values?: InterpolationValues): string {
+  if (!values) {
+    return template;
+  }
+
+  return template.replace(/\{([A-Za-z0-9_.-]+)\}/g, (match, key: string) => {
+    const value = values[key];
+    return value == null ? match : String(value);
+  });
 }
 
 export function normalizeLocaleTag(tag: string | null | undefined): SupportedLocale | null {
@@ -141,10 +209,49 @@ export function detectBrowserLocale(override?: string | null): LocaleDetection {
   });
 }
 
-export function translate(locale: SupportedLocale, key: MessageKey): string {
-  return LOCALE_MESSAGES[locale]?.[key] ?? EN_MESSAGES[key];
+export function translate(locale: SupportedLocale, key: MessageKey, values?: InterpolationValues): string {
+  const [namespace, localKey] = splitMessageKey(key);
+  const namespaceMessages = I18N_MESSAGES[namespace];
+  const localizedMessages = namespaceMessages[locale] as Partial<Record<string, string>>;
+  const fallbackMessages = namespaceMessages[DEFAULT_LOCALE] as Partial<Record<string, string>>;
+  const localized = localizedMessages[localKey];
+  const fallback = fallbackMessages[localKey];
+  return interpolate(String(localized ?? fallback ?? key), values);
 }
 
-export function createTranslator(locale: SupportedLocale): (key: MessageKey) => string {
-  return (key) => translate(locale, key);
+export function createTranslator(locale: SupportedLocale): (key: MessageKey, values?: InterpolationValues) => string {
+  return (key, values) => translate(locale, key, values);
+}
+
+export function createNamespaceTranslator<N extends I18nNamespace>(
+  locale: SupportedLocale,
+  namespaces: readonly N[],
+): (key: ScopedMessageKey<N>, values?: InterpolationValues) => string {
+  const allowed = new Set<I18nNamespace>(namespaces);
+  return (key, values) => {
+    const [namespace] = splitMessageKey(key as MessageKey);
+    if (!allowed.has(namespace)) {
+      throw new Error(`Translation key "${key}" is outside requested namespaces: ${namespaces.join(', ')}`);
+    }
+    return translate(locale, key as MessageKey, values);
+  };
+}
+
+export function auditI18nNamespaces(): NamespaceAuditIssue[] {
+  const issues: NamespaceAuditIssue[] = [];
+
+  for (const namespace of I18N_NAMESPACES) {
+    const expectedKeys = new Set(Object.keys(I18N_MESSAGES[namespace][DEFAULT_LOCALE]));
+    for (const locale of SUPPORTED_LOCALES) {
+      const localeMessages = I18N_MESSAGES[namespace][locale];
+      const actualKeys = new Set(Object.keys(localeMessages));
+      const missingKeys = [...expectedKeys].filter((key) => !actualKeys.has(key)).sort();
+      const extraKeys = [...actualKeys].filter((key) => !expectedKeys.has(key)).sort();
+      if (missingKeys.length > 0 || extraKeys.length > 0) {
+        issues.push({ namespace, locale, missingKeys, extraKeys });
+      }
+    }
+  }
+
+  return issues;
 }

--- a/admin-ui/tests/i18n.spec.ts
+++ b/admin-ui/tests/i18n.spec.ts
@@ -1,6 +1,16 @@
 import { expect, test } from '@playwright/test';
 
-import { createTranslator, detectLocale, normalizeLocaleTag, translate } from '../src/i18n';
+import {
+  I18N_MESSAGES,
+  I18N_NAMESPACES,
+  SUPPORTED_LOCALES,
+  auditI18nNamespaces,
+  createNamespaceTranslator,
+  createTranslator,
+  detectLocale,
+  normalizeLocaleTag,
+  translate,
+} from '../src/i18n';
 
 test.describe('i18n locale detection', () => {
   test('normalizes supported browser locale variants', () => {
@@ -35,10 +45,27 @@ test.describe('i18n locale detection', () => {
     });
   });
 
-  test('returns English strings instead of missing translation keys', () => {
+  test('keeps every namespace covered for every supported locale', () => {
+    expect(auditI18nNamespaces()).toEqual([]);
+    for (const namespace of I18N_NAMESPACES) {
+      expect(Object.keys(I18N_MESSAGES[namespace]).sort()).toEqual(
+        [...SUPPORTED_LOCALES].sort(),
+      );
+    }
+  });
+
+  test('returns namespaced strings instead of missing translation keys', () => {
     const t = createTranslator('ja');
 
-    expect(t('panel.setup')).toBe('Connect IDE');
-    expect(translate('zh-CN', 'search.default')).toBe('Search this panel...');
+    expect(t('navigation.panel.setup')).toBe('Connect IDE');
+    expect(translate('zh-CN', 'search.input.default')).toBe('Search this panel...');
+  });
+
+  test('scopes panel translators and interpolates dynamic values', () => {
+    const t = createNamespaceTranslator('en', ['common', 'navigation']);
+
+    expect(t('navigation.panel.health')).toBe('Health');
+    expect(t('common.status.labelValue', { label: 'Ready', value: 2 })).toBe('Ready: 2');
+    expect(() => (t as (key: string) => string)('search.input.default')).toThrow(/outside requested namespaces/);
   });
 });

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -83,10 +83,20 @@ Supported runtime locales are:
 - `ja` for `ja` / `ja-JP`
 - `ko` for `ko` / `ko-KR`
 
-The runtime exposes a typed translation lookup surface in `admin-ui/src/i18n.ts`.
-Missing localized strings fall back to English so panels never render raw
-message keys. Future manual language selection should pass an explicit override
-through the same detection helper instead of bypassing the runtime.
+Translation entries live in feature namespaces in `admin-ui/src/i18n.ts`.
+Shared chrome and status labels use `common`, app shell text uses `chrome`,
+navigation labels use `navigation`, and panel-owned copy can live in its own
+namespace such as `setup`, `health`, `instances`, `tools`, `tasks`, `openapi`,
+`calls`, `traces`, `stats`, `logs`, or `skillPaths`.
+
+Panels should request only their own namespace plus shared namespaces via the
+typed namespace translator. Dynamic text should use the interpolation helper
+instead of string concatenation so future translations can reorder grammar.
+Machine identifiers such as tool slugs, request ids, DCC types, JSON fields,
+and log payloads should remain unmodified. Tests audit namespace/locale parity
+so missing keys are caught before release. Future manual language selection
+should pass an explicit override through the same detection helper instead of
+bypassing the runtime.
 
 ## Dashboard Screenshots
 


### PR DESCRIPTION
Fixes #1238

## Summary
- reorganize admin UI translation messages into feature namespaces with locale coverage for English, Simplified Chinese, Japanese, and Korean
- add typed namespace translators, interpolation support, and namespace parity audits
- update admin shell keys to use `namespace.localKey` message ids while leaving raw machine data untouched
- document namespace ownership and interpolation expectations for future panel copy

## Validation
- `vx npm run build` in `admin-ui`
- `vx npx playwright test tests/i18n.spec.ts tests/admin.spec.ts` in `admin-ui`
- `vx just admin-build`
- `vx npm --prefix docs ci && vx npm --prefix docs run docs:build`
- `vx npx markdownlint-cli2 "docs/**/*.md" "README.md" "README_zh.md" "!docs/node_modules"`
- `vx git diff --check`

Skill developer guidance was not updated because this change only affects the admin UI translation runtime.