### PR TITLE
test: cover admin ui i18n regressions

### DIFF
--- a/admin-ui/tests/admin.spec.ts
+++ b/admin-ui/tests/admin.spec.ts
@@ -809,6 +809,34 @@ test.describe('Admin Page', () => {
     await context.close();
   });
 
+  test('renders an admin flow under Simplified Chinese without translating machine data', async ({ browser }) => {
+    const context = await browser.newContext({ locale: 'zh-CN' });
+    const page = await context.newPage();
+    await mockAdminApi(page);
+
+    await page.goto('/admin/?panel=governance');
+
+    await expect(page.locator('html')).toHaveAttribute('lang', 'zh-CN');
+    await expect(page.getByRole('navigation').getByRole('link', { name: '治理' })).toHaveClass(/active/);
+    const panel = page.locator('.governance-panel');
+    await expect(panel).toContainText('流量治理');
+    await expect(panel).toContainText('生效策略');
+    await expect(panel).toContainText('最近请求决策');
+    await expect(panel).toContainText('结果');
+    await expect(panel).toContainText('捕获');
+
+    await expect(panel).toContainText('req-policy');
+    await expect(panel).toContainText('maya, customhost');
+    await expect(panel).toContainText('body.data.params.arguments.api_key');
+
+    await page.getByLabel('筛选当前面板').fill('quota');
+    await expect(page.locator('.list-search-meta')).toContainText('1 / 2');
+    await expect(panel).toContainText('req-quota');
+    await expect(panel).not.toContainText('req-policy');
+
+    await context.close();
+  });
+
   test('shows platform-specific IDE config paths', async ({ page }) => {
     await page.addInitScript(() => {
       Object.defineProperty(navigator, 'userAgentData', {

--- a/admin-ui/tests/i18n.spec.ts
+++ b/admin-ui/tests/i18n.spec.ts
@@ -22,6 +22,13 @@ test.describe('i18n locale detection', () => {
     expect(normalizeLocaleTag('ko-KR')).toBe('ko');
   });
 
+  test('detects every supported runtime locale from browser preferences', () => {
+    expect(detectLocale({ navigatorLanguages: ['en-US'] })).toMatchObject({ locale: 'en', source: 'navigator' });
+    expect(detectLocale({ navigatorLanguages: ['zh-Hans-CN'] })).toMatchObject({ locale: 'zh-CN', source: 'navigator' });
+    expect(detectLocale({ navigatorLanguages: ['ja-JP'] })).toMatchObject({ locale: 'ja', source: 'navigator' });
+    expect(detectLocale({ navigatorLanguages: ['ko-KR'] })).toMatchObject({ locale: 'ko', source: 'navigator' });
+  });
+
   test('falls back to English when preferences are unsupported', () => {
     expect(detectLocale({ navigatorLanguages: ['fr-FR', 'de-DE'] })).toEqual({
       locale: 'en',

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -98,6 +98,36 @@ so missing keys are caught before release. Future manual language selection
 should pass an explicit override through the same detection helper instead of
 bypassing the runtime.
 
+### Maintaining Admin UI Translations
+
+When adding a panel or changing visible UI chrome:
+
+1. Add or update the feature namespace in `admin-ui/src/i18n.ts`.
+2. Provide every key for all supported locales: `en`, `zh-CN`, `ja`, and `ko`.
+3. Keep shared actions, table labels, status notices, and search metadata in
+   `common` or `search` when they are reused across panels.
+4. Use interpolation placeholders such as `{count}` or `{value}` for dynamic
+   grammar instead of assembling translated sentences with string
+   concatenation in React code.
+5. Do not translate machine identifiers or raw technical payloads: tool slugs,
+   request IDs, trace IDs, DCC types, file paths, JSON keys, HTTP methods,
+   status codes, log messages, and backend-provided payload text must remain
+   exact.
+
+Validation for i18n changes:
+
+```bash
+vx npm run build
+vx npx playwright test tests/i18n.spec.ts tests/admin.spec.ts
+vx just admin-build
+vx git diff --check
+```
+
+`tests/i18n.spec.ts` verifies locale normalization and namespace parity for all
+supported locales. `tests/admin.spec.ts` includes mocked admin API flows in both
+English and non-English browser locales so UI chrome is localized while machine
+data remains stable.
+
 ## Dashboard Screenshots
 
 The screenshots below use representative demo data and show the browser-first

--- a/docs/zh/guide/admin-ui.md
+++ b/docs/zh/guide/admin-ui.md
@@ -69,6 +69,46 @@ let config = GatewayConfig {
 
 直接使用 `dcc-mcp-gateway` 时需要启用 `admin` Cargo feature。`dcc-mcp-http` 与发布的 server 二进制已在内嵌网关路径中启用。
 
+## Locale 检测
+
+内嵌 Admin UI 带有一个随 bundle 发布的小型 i18n runtime。它读取
+`navigator.languages` / `navigator.language`，把浏览器语言标签规范化为
+受支持的 locale；没有匹配项时回退到英文。运行时不会从网络加载额外翻译资产。
+
+当前支持的 runtime locale：
+
+- `en`
+- `zh-CN`，覆盖 `zh`、`zh-Hans`、`zh-CN` 等简体中文标签
+- `ja`，覆盖 `ja` / `ja-JP`
+- `ko`，覆盖 `ko` / `ko-KR`
+
+翻译条目按 feature namespace 放在 `admin-ui/src/i18n.ts`。共享按钮、表格、
+状态提示和搜索元数据优先放在 `common` 或 `search`；面板自己的文案放在
+对应 namespace（例如 `setup`、`health`、`openapi`、`traces`、`stats`、
+`governance`、`logs`、`skillPaths`）。
+
+维护翻译时：
+
+1. 新增或修改面板时，先新增/更新对应 feature namespace。
+2. 每个 key 都必须同时提供 `en`、`zh-CN`、`ja`、`ko`。
+3. 动态文本使用 `{count}` / `{value}` 等插值占位，不要在 React 里拼接翻译句子。
+4. 不要翻译机器标识或原始技术 payload：tool slug、request ID、trace ID、
+   DCC 类型、文件路径、JSON key、HTTP method、status code、日志消息和后端返回的
+   payload 文本都应保持原样。
+
+i18n 相关修改建议运行：
+
+```bash
+vx npm run build
+vx npx playwright test tests/i18n.spec.ts tests/admin.spec.ts
+vx just admin-build
+vx git diff --check
+```
+
+`tests/i18n.spec.ts` 会验证所有支持 locale 的检测和 namespace key parity；
+`tests/admin.spec.ts` 使用 mock admin API 覆盖英文与非英文浏览器 locale 下的
+真实面板流程，确保 UI chrome 被本地化，同时机器数据保持稳定。
+
 ## 仪表盘截图
 
 以下截图使用代表性的演示数据，展示嵌入式 Admin Dashboard 中面向浏览器的运维工作流。


### PR DESCRIPTION
## Summary
- Add locale detection coverage for every supported admin UI runtime locale.
- Add a mocked Simplified Chinese admin UI flow that verifies localized chrome while preserving machine identifiers and raw technical values.
- Document the admin UI translation maintenance workflow, non-translatable values, and validation commands in English and Chinese docs.

## Validation
- `vx npm run build`
- `vx npx playwright test tests/i18n.spec.ts tests/admin.spec.ts`
- `vx just admin-build`
- `vx npm --prefix docs ci`
- `vx npm --prefix docs run docs:build`
- `vx npx markdownlint-cli2 "docs/**/*.md" "README.md" "README_zh.md" "!docs/node_modules"`
- `vx git diff --check`

Skill developer guidance update: not needed; this only adds admin UI i18n tests and documentation and does not affect public APIs, adapter/server wiring, skill authoring rules, tool schemas, or agent workflow contracts.

Closes #1240