### PR TITLE
refactor: clean up admin ui instance naming

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -631,7 +631,7 @@ type GovernanceDecisionRow = {
   pressure?: { quota_active?: boolean; throttled?: boolean };
 };
 
-type WorkerRow = {
+type InstanceRow = {
   instance_id: string;
   display_name: string | null;
   dcc_type: string;
@@ -651,7 +651,7 @@ type WorkerRow = {
   failure_stage?: string | null;
 };
 
-type WorkerSummary = {
+type InstanceSummary = {
   live: number;
   stale: number;
   unhealthy: number;
@@ -1111,10 +1111,7 @@ function traceLinks(requestId: string, provided?: AdminLinks): AdminLinks {
 
 function readPanelFromUrl(): Panel {
   const u = new URL(window.location.href);
-  const raw = u.searchParams.get('panel') ?? u.searchParams.get('tab');
-  if (raw === 'workers') {
-    return 'instances';
-  }
+  const raw = u.searchParams.get('panel');
   return isPanelId(raw) ? raw : 'setup';
 }
 
@@ -1214,8 +1211,8 @@ function lanGatewayMcpUrl(): string | null {
   return gatewayMcpUrlFromPage();
 }
 
-function workerSetupLabel(worker: WorkerRow): string {
-  return `${worker.display_name || worker.dcc_type} (${worker.instance_id.slice(0, 8)})`;
+function instanceSetupLabel(instance: InstanceRow): string {
+  return `${instance.display_name || instance.dcc_type} (${instance.instance_id.slice(0, 8)})`;
 }
 
 function detectClientPlatform(): ClientPlatform {
@@ -1260,9 +1257,9 @@ function configPathFileUrl(path: string): string | null {
   return normalized.match(/^[A-Za-z]:\//) ? `file:///${normalized}` : null;
 }
 
-function workerOpenApiSource(worker: WorkerRow): OpenApiSource {
-  const urls = backendAccessUrls(worker.mcp_url);
-  const label = `${worker.display_name || worker.dcc_type} ${worker.instance_id.slice(0, 8)}`;
+function instanceOpenApiSource(instance: InstanceRow): OpenApiSource {
+  const urls = backendAccessUrls(instance.mcp_url);
+  const label = `${instance.display_name || instance.dcc_type} ${instance.instance_id.slice(0, 8)}`;
   return {
     label,
     specUrl: urls.openapi,
@@ -1322,9 +1319,9 @@ async function apiJson<T>(path: string): Promise<T> {
   }
 }
 
-function BackendOpenApiLinks({ worker }: { worker: WorkerRow }) {
+function BackendOpenApiLinks({ instance }: { instance: InstanceRow }) {
   try {
-    const source = workerOpenApiSource(worker);
+    const source = instanceOpenApiSource(instance);
     return (
       <span className="mcp-backend-links openapi-backend-links">
         <a href={source.inspectorUrl}>Inspector</a>
@@ -1335,7 +1332,7 @@ function BackendOpenApiLinks({ worker }: { worker: WorkerRow }) {
       </span>
     );
   } catch {
-    return <span className="mono-path">{worker.mcp_url}</span>;
+    return <span className="mono-path">{instance.mcp_url}</span>;
   }
 }
 
@@ -1865,8 +1862,8 @@ function toolGroupLabel(tool: ToolRow): string {
   return appTypeLabel(tool.dcc_type);
 }
 
-function workerGroupLabel(worker: WorkerRow): string {
-  return appTypeLabel(worker.dcc_type);
+function instanceGroupLabel(instance: InstanceRow): string {
+  return appTypeLabel(instance.dcc_type);
 }
 
 function callGroupLabel(call: CallRow): string {
@@ -2761,8 +2758,8 @@ function App() {
   const [openApiSource, setOpenApiSource] = useState<OpenApiSource>(() => readOpenApiSourceFromUrl());
   const [openApiSpec, setOpenApiSpec] = useState<OpenApiSpec | null>(null);
   const [openApiRaw, setOpenApiRaw] = useState('');
-  const [workers, setWorkers] = useState<WorkerRow[]>([]);
-  const [workerSummary, setWorkerSummary] = useState<WorkerSummary>({ live: 0, stale: 0, unhealthy: 0 });
+  const [instanceRows, setInstanceRows] = useState<InstanceRow[]>([]);
+  const [instanceSummary, setInstanceSummary] = useState<InstanceSummary>({ live: 0, stale: 0, unhealthy: 0 });
   const [setupUrlMode, setSetupUrlMode] = useState<SetupUrlMode>('local');
   const [clientPlatform] = useState<ClientPlatform>(() => detectClientPlatform());
   const [directInstanceId, setDirectInstanceId] = useState<string>('');
@@ -2816,14 +2813,6 @@ function App() {
       delete document.documentElement.dataset.adminLocaleMatchedTag;
     }
   }, [localeDetection]);
-
-  useEffect(() => {
-    const u = new URL(window.location.href);
-    if (u.searchParams.get('panel') === 'workers') {
-      u.searchParams.set('panel', 'instances');
-      window.history.replaceState({}, '', `${u.pathname}${u.search}`);
-    }
-  }, []);
 
   useEffect(() => {
     setListSearch('');
@@ -3028,12 +3017,12 @@ function App() {
     );
   }, [workflows, listSearch]);
 
-  const filteredWorkers = useMemo(() => {
+  const filteredInstanceRows = useMemo(() => {
     const q = listSearch.trim().toLowerCase();
     if (!q) {
-      return workers;
+      return instanceRows;
     }
-    return workers.filter((w) =>
+    return instanceRows.filter((w) =>
       matchesListFilter(
         q,
         haystack(
@@ -3049,36 +3038,36 @@ function App() {
         ),
       ),
     );
-  }, [workers, listSearch]);
+  }, [instanceRows, listSearch]);
 
-  const directSetupWorkers = useMemo(
-    () => workers.filter((worker) => !worker.stale && worker.mcp_url && !worker.mcp_url.includes(':0/')),
-    [workers],
+  const directSetupInstanceRows = useMemo(
+    () => instanceRows.filter((instance) => !instance.stale && instance.mcp_url && !instance.mcp_url.includes(':0/')),
+    [instanceRows],
   );
-  const selectedDirectWorker = useMemo(
-    () => directSetupWorkers.find((worker) => worker.instance_id === directInstanceId) ?? directSetupWorkers[0] ?? null,
-    [directInstanceId, directSetupWorkers],
+  const selectedDirectInstance = useMemo(
+    () => directSetupInstanceRows.find((instance) => instance.instance_id === directInstanceId) ?? directSetupInstanceRows[0] ?? null,
+    [directInstanceId, directSetupInstanceRows],
   );
   const lanUrl = useMemo(() => lanGatewayMcpUrl(), []);
   const setupMcpUrl = useMemo(() => {
     if (setupUrlMode === 'lan' && lanUrl) {
       return lanUrl;
     }
-    if (setupUrlMode === 'direct' && selectedDirectWorker) {
+    if (setupUrlMode === 'direct' && selectedDirectInstance) {
       try {
-        return backendAccessUrls(selectedDirectWorker.mcp_url).mcp;
+        return backendAccessUrls(selectedDirectInstance.mcp_url).mcp;
       } catch {
-        return selectedDirectWorker.mcp_url;
+        return selectedDirectInstance.mcp_url;
       }
     }
     return gatewayMcpUrl(health);
-  }, [health, lanUrl, selectedDirectWorker, setupUrlMode]);
+  }, [health, lanUrl, selectedDirectInstance, setupUrlMode]);
 
   useEffect(() => {
-    if (!directInstanceId && directSetupWorkers.length > 0) {
-      setDirectInstanceId(directSetupWorkers[0].instance_id);
+    if (!directInstanceId && directSetupInstanceRows.length > 0) {
+      setDirectInstanceId(directSetupInstanceRows[0].instance_id);
     }
-  }, [directInstanceId, directSetupWorkers]);
+  }, [directInstanceId, directSetupInstanceRows]);
 
   const filteredLogs = useMemo(() => {
     const q = listSearch.trim().toLowerCase();
@@ -3198,9 +3187,9 @@ function App() {
     [logs],
   );
 
-  const unhealthyWorkers = useMemo(
-    () => workers.filter((worker) => worker.stale || !statusClass(worker.status).includes('ok')),
-    [workers],
+  const unhealthyInstanceRows = useMemo(
+    () => instanceRows.filter((instance) => instance.stale || !statusClass(instance.status).includes('ok')),
+    [instanceRows],
   );
 
   const filteredTopTools = useMemo(() => {
@@ -3399,12 +3388,12 @@ function App() {
         traceId: first.request_id,
       });
     }
-    if (unhealthyWorkers.length > 0) {
-      const first = unhealthyWorkers[0];
+    if (unhealthyInstanceRows.length > 0) {
+      const first = unhealthyInstanceRows[0];
       signals.push({
         key: 'instances',
         label: t('debug.signal.instanceHealth'),
-        value: t('debug.detail.flagged', { count: unhealthyWorkers.length }),
+        value: t('debug.detail.flagged', { count: unhealthyInstanceRows.length }),
         detail: first.failure_reason || first.failure_stage || `${first.dcc_type} ${first.status}`,
         tone: 'warn',
         panel: 'instances',
@@ -3473,7 +3462,7 @@ function App() {
       return [{
         key: 'ready',
         label: t('debug.signal.gatewayReady'),
-        value: t('debug.detail.live', { count: workerSummary.live }),
+        value: t('debug.detail.live', { count: instanceSummary.live }),
         detail: t('debug.detail.noWarnings'),
         tone: 'ok',
         panel: 'health',
@@ -3493,8 +3482,8 @@ function App() {
     tokenPressure,
     traceSummary.agentContext,
     traces.length,
-    unhealthyWorkers,
-    workerSummary.live,
+    unhealthyInstanceRows,
+    instanceSummary.live,
     workflowSummary.zeroResults,
   ]);
 
@@ -3597,9 +3586,9 @@ function App() {
 
   const fetchInstanceBackends = useCallback(async () => {
     try {
-      const payload = await apiJson<{ workers: WorkerRow[]; summary: WorkerSummary }>('/workers');
-      setWorkers(payload.workers);
-      setWorkerSummary(payload.summary);
+      const payload = await apiJson<{ workers: InstanceRow[]; summary: InstanceSummary }>('/workers');
+      setInstanceRows(payload.workers);
+      setInstanceSummary(payload.summary);
       markUpdated(
         'instances',
         t('common.updated.instances', { count: payload.workers.length, live: payload.summary.live, stale: payload.summary.stale, unhealthy: payload.summary.unhealthy, time: new Date().toLocaleTimeString() }),
@@ -4062,7 +4051,7 @@ function App() {
             {listSearch.trim() ? (
               <span className="list-search-meta">
                 {activePanel === 'activity' ? `${filteredActivity.length} / ${activity.length}` : ''}
-                {activePanel === 'instances' ? `${filteredWorkers.length} / ${workers.length}` : ''}
+                {activePanel === 'instances' ? `${filteredInstanceRows.length} / ${instanceRows.length}` : ''}
                 {activePanel === 'tools' ? `${filteredTools.length} / ${tools.length}` : ''}
                 {activePanel === 'workflows' ? `${filteredWorkflows.length} / ${workflows.length}` : ''}
                 {activePanel === 'openapi' ? `${filteredOpenApiOperations.length} / ${openApiOperations.length}` : ''}
@@ -4110,8 +4099,8 @@ function App() {
                   className={setupUrlMode === 'direct' ? 'setup-mode active' : 'setup-mode'}
                   type="button"
                   aria-pressed={setupUrlMode === 'direct'}
-                  disabled={directSetupWorkers.length === 0}
-                  onClick={() => directSetupWorkers.length > 0 && setSetupUrlMode('direct')}
+                  disabled={directSetupInstanceRows.length === 0}
+                  onClick={() => directSetupInstanceRows.length > 0 && setSetupUrlMode('direct')}
                 >
                   {t('setup.mode.direct')}
                 </button>
@@ -4127,13 +4116,13 @@ function App() {
                 <label className="setup-instance-picker">
                   <span>Instance</span>
                   <select
-                    value={selectedDirectWorker?.instance_id ?? ''}
+                    value={selectedDirectInstance?.instance_id ?? ''}
                     onChange={(event) => setDirectInstanceId(event.target.value)}
-                    disabled={directSetupWorkers.length === 0}
+                    disabled={directSetupInstanceRows.length === 0}
                   >
-                    {directSetupWorkers.map((worker) => (
-                      <option key={worker.instance_id} value={worker.instance_id}>
-                        {workerSetupLabel(worker)}
+                    {directSetupInstanceRows.map((instance) => (
+                      <option key={instance.instance_id} value={instance.instance_id}>
+                        {instanceSetupLabel(instance)}
                       </option>
                     ))}
                   </select>
@@ -4182,7 +4171,7 @@ function App() {
             </div>
             <div className="debug-grid">
               <HealthCard tone={health?.status === 'ok' ? 'ok' : 'warn'} label={t('debug.metric.gateway')} value={gatewayLabel(health)} />
-              <HealthCard tone={unhealthyWorkers.length ? 'warn' : 'ok'} label={t('debug.metric.instances')} value={t('debug.detail.liveFlagged', { live: workerSummary.live, flagged: unhealthyWorkers.length })} />
+              <HealthCard tone={unhealthyInstanceRows.length ? 'warn' : 'ok'} label={t('debug.metric.instances')} value={t('debug.detail.liveFlagged', { live: instanceSummary.live, flagged: unhealthyInstanceRows.length })} />
               <HealthCard tone={errorRateTone(stats)} label={t('debug.metric.success')} value={stats ? `${stats.success_rate.toFixed(1)}%` : '?'} />
               <HealthCard tone={latencyTone(stats?.latency_ms?.p95_ms ?? stats?.p95_ms)} label={t('debug.metric.latency')} value={stats?.latency_ms?.p95_ms ?? stats?.p95_ms ?? '-'} />
               <HealthCard label={t('debug.metric.tokensPerCall')} value={formatTokenCount(tokenPressure.avg)} />
@@ -4277,12 +4266,12 @@ function App() {
                   <h3>{t('debug.section.instanceSignals')}</h3>
                   <button className="linkish" type="button" onClick={() => goToPanel('instances')}>{t('debug.action.openInstances')}</button>
                 </div>
-                {unhealthyWorkers.length === 0 ? <p className="empty">{t('debug.empty.instances')}</p> : unhealthyWorkers.slice(0, 8).map((worker) => (
-                  <div key={worker.instance_id} className="debug-row static">
-                    <span><StatusBadge value={worker.stale ? 'stale' : worker.status} /></span>
-                    <span>{worker.dcc_type}</span>
-                    <span title={worker.failure_reason ?? worker.failure_stage ?? worker.instance_id}>
-                      {worker.display_name} · {worker.failure_reason ?? worker.failure_stage ?? compactId(worker.instance_id)}
+                {unhealthyInstanceRows.length === 0 ? <p className="empty">{t('debug.empty.instances')}</p> : unhealthyInstanceRows.slice(0, 8).map((instance) => (
+                  <div key={instance.instance_id} className="debug-row static">
+                    <span><StatusBadge value={instance.stale ? 'stale' : instance.status} /></span>
+                    <span>{instance.dcc_type}</span>
+                    <span title={instance.failure_reason ?? instance.failure_stage ?? instance.instance_id}>
+                      {instance.display_name} · {instance.failure_reason ?? instance.failure_stage ?? compactId(instance.instance_id)}
                     </span>
                   </div>
                 ))}
@@ -4293,19 +4282,19 @@ function App() {
                   <h3>{t('debug.section.openapiEntryPoints')}</h3>
                   <button className="linkish" type="button" onClick={() => goToPanel('openapi')}>{t('debug.action.gatewaySpec')}</button>
                 </div>
-                {workers.length === 0 ? <p className="empty">{t('debug.empty.openapi')}</p> : (
-                  Array.from(groupRows(workers.slice(0, 8), workerGroupLabel).entries())
+                {instanceRows.length === 0 ? <p className="empty">{t('debug.empty.openapi')}</p> : (
+                  Array.from(groupRows(instanceRows.slice(0, 8), instanceGroupLabel).entries())
                     .sort(([a], [b]) => a.localeCompare(b))
-                    .map(([group, groupWorkers]) => (
+                    .map(([group, groupInstances]) => (
                       <div key={group} className="contract-group">
                         <h4>{group}</h4>
-                        {groupWorkers.map((worker) => (
-                          <div key={worker.instance_id} className="contract-row">
+                        {groupInstances.map((instance) => (
+                          <div key={instance.instance_id} className="contract-row">
                             <span>
-                              <strong>{worker.display_name}</strong>
-                              <em>{worker.dcc_type} · {compactInstanceId(worker.instance_id)}</em>
+                              <strong>{instance.display_name}</strong>
+                              <em>{instance.dcc_type} · {compactInstanceId(instance.instance_id)}</em>
                             </span>
-                            <BackendOpenApiLinks worker={worker} />
+                            <BackendOpenApiLinks instance={instance} />
                           </div>
                         ))}
                       </div>
@@ -4426,47 +4415,47 @@ function App() {
               {t('instances.description')}
             </p>
             <StatusLine text={updatedAt.instances} error={errors.instances} />
-            {workers.length === 0 ? (
+            {instanceRows.length === 0 ? (
               <p className="empty">{t('instances.empty.none')}</p>
-            ) : filteredWorkers.length === 0 ? (
+            ) : filteredInstanceRows.length === 0 ? (
               <p className="empty">{t('instances.empty.search')}</p>
             ) : (
-              <div className="worker-groups">
-                {Array.from(groupRows(filteredWorkers, workerGroupLabel).entries())
+              <div className="instance-groups">
+                {Array.from(groupRows(filteredInstanceRows, instanceGroupLabel).entries())
                   .sort(([a], [b]) => a.localeCompare(b))
-                  .map(([group, groupWorkers]) => {
-                    const flagged = groupWorkers.filter((worker) => worker.stale || !statusClass(worker.status).includes('ok')).length;
+                  .map(([group, groupInstances]) => {
+                    const flagged = groupInstances.filter((instance) => instance.stale || !statusClass(instance.status).includes('ok')).length;
                     return (
-                      <div key={group} className="worker-group">
-                        <div className="worker-group-head">
+                      <div key={group} className="instance-group">
+                        <div className="instance-group-head">
                           <h3>{group}</h3>
-                          <span>{t('instances.group.meta', { count: groupWorkers.length, flagged })}</span>
+                          <span>{t('instances.group.meta', { count: groupInstances.length, flagged })}</span>
                         </div>
-                        <div className="workers-grid">
-                          {groupWorkers.map((worker) => (
-                            <div key={worker.instance_id} className={`worker-card ${worker.stale ? 'stale' : statusClass(worker.status).replace('badge badge-', '')}`}>
-                              <div className="wname">
-                                <img src={resolveDccIcon(worker.dcc_type)} alt="" className="dcc-icon" aria-hidden />
-                                {worker.display_name} <span>{compactInstanceId(worker.instance_id)}</span>
+                        <div className="instances-grid">
+                          {groupInstances.map((instance) => (
+                            <div key={instance.instance_id} className={`instance-card ${instance.stale ? 'stale' : statusClass(instance.status).replace('badge badge-', '')}`}>
+                              <div className="instance-name">
+                                <img src={resolveDccIcon(instance.dcc_type)} alt="" className="dcc-icon" aria-hidden />
+                                {instance.display_name} <span>{compactInstanceId(instance.instance_id)}</span>
                               </div>
-                              <div className="wkv">
-                                <span>App type</span><span>{worker.dcc_type}</span>
-                                <span>Status</span><span><StatusBadge value={worker.status} /></span>
-                                {worker.failure_reason ? (
+                              <div className="instance-kv">
+                                <span>App type</span><span>{instance.dcc_type}</span>
+                                <span>Status</span><span><StatusBadge value={instance.status} /></span>
+                                {instance.failure_reason ? (
                                   <>
-                                    <span>Failure</span><span>{worker.failure_reason}</span>
+                                    <span>Failure</span><span>{instance.failure_reason}</span>
                                   </>
                                 ) : null}
-                                <span>PID</span><span>{worker.pid ?? '-'}</span>
-                                <span>Uptime</span><span>{formatUptime(worker.uptime_secs)}</span>
-                                <span>Version</span><span>{worker.version ?? '-'}</span>
-                                <span>Adapter</span><span>{worker.adapter_version ?? '-'}</span>
-                                <span>Scene</span><span>{worker.scene ?? '-'}</span>
-                                <span>CPU%</span><span>{worker.cpu_percent == null ? '-' : worker.cpu_percent.toFixed(1)}</span>
-                                <span>Memory</span><span>{formatBytes(worker.memory_bytes)}</span>
-                                <span>Access URL</span><span><BackendAccessUrl mcpUrl={worker.mcp_url} /></span>
-                                <span>Endpoints</span><span><McpBackendLinks mcpUrl={worker.mcp_url} /></span>
-                                <span>OpenAPI</span><span><BackendOpenApiLinks worker={worker} /></span>
+                                <span>PID</span><span>{instance.pid ?? '-'}</span>
+                                <span>Uptime</span><span>{formatUptime(instance.uptime_secs)}</span>
+                                <span>Version</span><span>{instance.version ?? '-'}</span>
+                                <span>Adapter</span><span>{instance.adapter_version ?? '-'}</span>
+                                <span>Scene</span><span>{instance.scene ?? '-'}</span>
+                                <span>CPU%</span><span>{instance.cpu_percent == null ? '-' : instance.cpu_percent.toFixed(1)}</span>
+                                <span>Memory</span><span>{formatBytes(instance.memory_bytes)}</span>
+                                <span>Access URL</span><span><BackendAccessUrl mcpUrl={instance.mcp_url} /></span>
+                                <span>Endpoints</span><span><McpBackendLinks mcpUrl={instance.mcp_url} /></span>
+                                <span>OpenAPI</span><span><BackendOpenApiLinks instance={instance} /></span>
                               </div>
                             </div>
                           ))}
@@ -4476,7 +4465,7 @@ function App() {
                   })}
               </div>
             )}
-            <div className="status-bar">Summary: live {workerSummary.live}, stale {workerSummary.stale}, unhealthy {workerSummary.unhealthy}</div>
+            <div className="status-bar">Summary: live {instanceSummary.live}, stale {instanceSummary.stale}, unhealthy {instanceSummary.unhealthy}</div>
             <button className="refresh-btn" type="button" onClick={fetchInstanceBackends}>{t('common.action.refresh')}</button>
           </section>
         )}

--- a/admin-ui/src/i18n.ts
+++ b/admin-ui/src/i18n.ts
@@ -736,28 +736,28 @@ const HEALTH_MESSAGES = defineNamespace({
 const INSTANCES_MESSAGES = defineNamespace({
   en: {
     title: 'Instances',
-    description: 'One row per registered DCC backend (same data as the former Workers tab). Use the links to open the adapter HTTP host, MCP streamable endpoint, or /docs when the host exposes it.',
+    description: 'One card per registered DCC backend. Use the links to open the adapter HTTP host, MCP streamable endpoint, or /docs when the host exposes it.',
     'empty.none': 'No instances registered.',
     'empty.search': 'No instances match your search.',
     'group.meta': '{count} instance(s) · {flagged} flagged',
   },
   'zh-CN': {
     title: '实例',
-    description: '每个已注册 DCC 后端一行（与旧 Workers 标签页相同的数据）。可用链接打开适配器 HTTP 主机、MCP streamable 端点，或主机暴露的 /docs。',
+    description: '每个已注册 DCC 后端一张卡片。可用链接打开适配器 HTTP 主机、MCP streamable 端点，或主机暴露的 /docs。',
     'empty.none': '没有已注册实例。',
     'empty.search': '没有匹配搜索的实例。',
     'group.meta': '{count} 个实例 · {flagged} 个已标记',
   },
   ja: {
     title: 'インスタンス',
-    description: '登録済み DCC バックエンドを 1 行ずつ表示します（旧 Workers タブと同じデータ）。リンクからアダプター HTTP ホスト、MCP streamable エンドポイント、またはホストが公開する /docs を開けます。',
+    description: '登録済み DCC バックエンドをカードで表示します。リンクからアダプター HTTP ホスト、MCP streamable エンドポイント、またはホストが公開する /docs を開けます。',
     'empty.none': '登録済みインスタンスはありません。',
     'empty.search': '検索に一致するインスタンスはありません。',
     'group.meta': '{count} 件のインスタンス · {flagged} 件 flagged',
   },
   ko: {
     title: '인스턴스',
-    description: '등록된 DCC 백엔드를 한 행씩 표시합니다(이전 Workers 탭과 동일한 데이터). 링크로 어댑터 HTTP 호스트, MCP streamable 엔드포인트 또는 호스트가 제공하는 /docs를 열 수 있습니다.',
+    description: '등록된 DCC 백엔드를 카드로 표시합니다. 링크로 어댑터 HTTP 호스트, MCP streamable 엔드포인트 또는 호스트가 제공하는 /docs를 열 수 있습니다.',
     'empty.none': '등록된 인스턴스가 없습니다.',
     'empty.search': '검색과 일치하는 인스턴스가 없습니다.',
     'group.meta': '{count}개 인스턴스 · {flagged}개 표시됨',

--- a/admin-ui/src/styles.css
+++ b/admin-ui/src/styles.css
@@ -1564,17 +1564,17 @@ tbody tr:hover td {
   word-break: break-word;
 }
 
-.worker-groups {
+.instance-groups {
   display: grid;
   gap: 1.1rem;
 }
 
-.worker-group {
+.instance-group {
   display: grid;
   gap: 0.75rem;
 }
 
-.worker-group-head {
+.instance-group-head {
   align-items: center;
   border-bottom: 1px solid var(--border);
   display: flex;
@@ -1583,25 +1583,25 @@ tbody tr:hover td {
   padding-bottom: 0.45rem;
 }
 
-.worker-group-head h3 {
+.instance-group-head h3 {
   font-size: 0.85rem;
   font-weight: 800;
 }
 
-.worker-group-head span {
+.instance-group-head span {
   color: var(--muted-foreground);
   font-family: var(--font-mono);
   font-size: 0.75rem;
 }
 
-.workers-grid {
+.instances-grid {
   display: grid;
   gap: 1rem;
   grid-template-columns: repeat(auto-fit, minmax(288px, 1fr));
   margin-bottom: 1rem;
 }
 
-.worker-card {
+.instance-card {
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
@@ -1611,25 +1611,25 @@ tbody tr:hover td {
   transition: box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
-.worker-card:hover {
+.instance-card:hover {
   border-color: var(--ring);
   box-shadow: 0 10px 32px rgba(20, 20, 19, 0.07);
 }
 
-.worker-card.ok {
+.instance-card.ok {
   border-color: rgba(56, 193, 114, 0.35);
 }
 
-.worker-card.stale,
-.worker-card.warn {
+.instance-card.stale,
+.instance-card.warn {
   border-color: rgba(242, 184, 75, 0.4);
 }
 
-.worker-card.err {
+.instance-card.err {
   border-color: rgba(239, 91, 99, 0.45);
 }
 
-.worker-card .wname {
+.instance-card .instance-name {
   color: var(--foreground);
   font-family: var(--font-sans);
   font-size: 1rem;
@@ -1638,33 +1638,33 @@ tbody tr:hover td {
   word-break: break-all;
 }
 
-.worker-card .wname span {
+.instance-card .instance-name span {
   color: var(--muted-foreground);
   font-family: var(--font-mono);
   font-size: 0.75rem;
   font-weight: 500;
 }
 
-.worker-card .wkv {
+.instance-card .instance-kv {
   color: var(--muted-foreground);
   display: grid;
   gap: 0.2rem 0.75rem;
   grid-template-columns: 5.5rem 1fr;
 }
 
-.worker-card .wkv span:nth-child(2n) {
+.instance-card .instance-kv span:nth-child(2n) {
   color: var(--foreground);
   word-break: break-all;
 }
 
-.worker-card a,
+.instance-card a,
 .mcp-backend-links a {
   color: #9cc3ff;
   font-weight: 700;
   text-decoration: none;
 }
 
-.worker-card a:hover,
+.instance-card a:hover,
 .mcp-backend-links a:hover {
   color: #cfe2ff;
   text-decoration: underline;
@@ -2496,7 +2496,7 @@ button.linkish:disabled {
     height: 112px;
   }
 
-  .workers-grid,
+  .instances-grid,
   .openapi-layout,
   .stats-charts {
     grid-template-columns: 1fr;

--- a/admin-ui/tests/admin.spec.ts
+++ b/admin-ui/tests/admin.spec.ts
@@ -892,11 +892,11 @@ test.describe('Admin Page', () => {
     await expect(page.locator('.instances-panel')).toContainText('Access URL');
     await expect(page.locator('.instances-panel')).toContainText('http://127.0.0.1:8765');
     await expect(page.locator('.instances-panel')).toContainText('host-rpc connect failed');
-    const mayaCard = page.locator('.worker-card').filter({ hasText: 'Maya Layout' });
+    const mayaCard = page.locator('.instance-card').filter({ hasText: 'Maya Layout' });
     await expect(mayaCard.getByRole('link', { name: 'docs' }).first()).toHaveAttribute('href', 'http://127.0.0.1:8765/docs');
     await page.getByLabel('Filter current panel').fill('blender');
-    await expect(page.locator('.worker-card')).toHaveCount(1);
-    await expect(page.locator('.worker-card')).toContainText('Blender Lookdev');
+    await expect(page.locator('.instance-card')).toHaveCount(1);
+    await expect(page.locator('.instance-card')).toContainText('Blender Lookdev');
   });
 
   test('opens trace detail from the calls panel and keeps the URL shareable', async ({ page }) => {

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -169,7 +169,7 @@ Markdown body for developer review.
 | `GET /admin/api/debug-bundle/{request_id}` | `application/json` | One-stop debug bundle containing the trace, matching audit row, related activity, and hints |
 | `GET /admin/api/stats?range=1h\|24h\|7d` | `application/json` | Aggregated call counts, success rate, latency, top tools/instances/agents, and token-savings totals |
 | `GET /admin/api/governance?limit=300` | `application/json` | Effective gateway policy, traffic capture, redaction, middleware controls, and recent allow/deny/throttle decisions |
-| `GET /admin/api/workers` | `application/json` | Per-instance worker cards from the live registry |
+| `GET /admin/api/workers` | `application/json` | Per-instance cards from the live registry; response field names remain `workers` for compatibility |
 | `GET /admin/api/logs` | `application/json` | Merged gateway contention events, on-disk `*.log` rows, and audited call summaries |
 | `GET /admin/api/health` | `application/json` | Service health summary, including active response-format defaults and token estimator metadata |
 | `GET /admin/api/skills` | `application/json` | Live skill inventory grouped by DCC type, skill name, load state, tools, and backend instance |
@@ -699,9 +699,9 @@ The HTML dashboard includes:
 - **Left navigation**: Debug / Activity / Health / Instances / Tools / Tasks / OpenAPI Inspector / Calls / Traces / Stats / Skill paths / Logs panels
 - **Auto-refresh**: Panels poll their JSON endpoints every 5 seconds
 - **DCC icons**: common hosts such as Maya/Autodesk, Blender, GIMP, Inkscape, Krita, Unity, and Unreal get recognizable icons, with a safe fallback for custom hosts.
-- **Worker cards**: Per-instance status, heartbeat, and routing metadata
+- **Instance cards**: Per-instance status, heartbeat, and routing metadata
 - **OpenAPI Inspector**: summarizes the gateway or selected instance `/v1/openapi.json` contract, filters REST operations by method/path/tag, and exposes copy/download links for the raw JSON plus the matching `/docs`.
-- **Instance OpenAPI links**: Debug Workbench and instance cards expose `Inspector`, `spec`, and `docs` links generated from each worker `mcp_url`, so an operator can jump from MCP-level telemetry to the lower OpenAPI contract for that exact backend.
+- **Instance OpenAPI links**: Debug Workbench and instance cards expose `Inspector`, `spec`, and `docs` links generated from each backend `mcp_url`, so an operator can jump from MCP-level telemetry to the lower OpenAPI contract for that exact backend.
 - **Calls table**: request ids, error previews, and trace-detail links; DCC is displayed from the resolved backend slug when available, otherwise from explicit call arguments such as `dcc` / `dcc_type`.
 - **Trace drill-down**: `/admin/api/traces/{request_id}` exposes the full waterfall, optional agent/caller context, and bounded/redacted input/output payloads for one call.
 - **Traffic panel**: when a traffic config includes `kind: admin_live`, `/admin/api/traffic` exposes the retained in-memory frame ring and `/admin/api/traffic/export` downloads it as JSONL.

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -227,7 +227,7 @@ The elected gateway exposes a read-only HTML dashboard at `GET /admin` and machi
 | `GET /admin/api/workflows?limit=200` | Group retained searches, describes, skill loads, calls, traces, and audits into agent session/workflow chains. |
 | `GET /admin/api/stats?range=1h\|24h\|7d` | Compute success rate, latency percentiles, and top tools/instances/agents from the trace log. |
 | `GET /admin/api/governance?limit=300` / `GET /v1/debug/governance` | Inspect effective policy, read-only state, traffic capture guardrails, redaction paths, middleware quota state, and recent allowed/denied/throttled decisions. |
-| `GET /admin/api/workers` | Inspect per-instance worker cards from the live registry. |
+| `GET /admin/api/workers` | Inspect per-instance cards from the live registry. |
 
 By default these buffers are in memory only. Set `DCC_MCP_GATEWAY_AUDIT_DIR` to append bounded JSONL files:
 

--- a/docs/zh/guide/admin-ui.md
+++ b/docs/zh/guide/admin-ui.md
@@ -143,7 +143,7 @@ vx git diff --check
 | `GET /admin/api/debug-bundle/{request_id}` | `application/json` | 单次请求的一站式 debug bundle，包含 trace、匹配审计行、相关活动和提示 |
 | `GET /admin/api/stats?range=1h\|24h\|7d` | `application/json` | 聚合调用数、成功率、延迟、top tools/instances 和 token savings totals |
 | `GET /admin/api/governance?limit=300` | `application/json` | 当前 gateway policy、traffic capture、redaction、中间件控制和最近 allow/deny/throttle 决策 |
-| `GET /admin/api/workers` | `application/json` | 来自 live registry 的实例 worker 卡片 |
+| `GET /admin/api/workers` | `application/json` | 来自 live registry 的实例卡片；响应字段名保留 `workers` 以兼容现有客户端 |
 | `GET /admin/api/logs` | `application/json` | 合并后的网关竞争事件、磁盘 `*.log` 行和审计调用摘要 |
 | `GET /admin/api/health` | `application/json` | 服务健康摘要 |
 | `GET /admin/api/skills` | `application/json` | 按 DCC 类型、skill 名、加载状态、工具和后端实例聚合的实时 skill 清单 |
@@ -428,7 +428,7 @@ HTML 仪表盘包含：
 - **左侧导航**：Debug / Activity / Health / 实例 / 工具 / Tasks / Calls / Traces / Traffic / Stats / Skill paths / 日志面板
 - **自动刷新**：每个面板每 5 秒轮询对应 JSON 端点
 - **DCC 图标**：Maya/Autodesk、Blender、GIMP、Inkscape、Krita、Unity、Unreal 等常见宿主显示可识别图标，自定义宿主使用安全 fallback
-- **Worker 卡片**：按实例展示状态、心跳与路由元数据
+- **实例卡片**：按实例展示状态、心跳与路由元数据
 - **Calls 表格**：展示 request id、错误摘要与 trace detail 链接；DCC 优先从解析后的 backend slug 展示，其次使用调用参数中的 `dcc` / `dcc_type`
 - **Trace 下钻**：`/admin/api/traces/{request_id}` 暴露单次调用的完整 waterfall，以及有界/已脱敏的输入输出 payload
 - **Traffic 面板**：当 traffic config 包含 `kind: admin_live` 时，`/admin/api/traffic` 暴露内存环形缓冲区中的 frame，`/admin/api/traffic/export` 可下载 JSONL

--- a/docs/zh/guide/observability.md
+++ b/docs/zh/guide/observability.md
@@ -197,7 +197,7 @@ result = resources.read("resources://gateway/events")
 | `GET /admin/api/workflows?limit=200` | 将 retained searches、describes、skill loads、calls、traces 和 audits 聚合为 agent session/workflow 链。 |
 | `GET /admin/api/stats?range=1h\|24h\|7d` | 基于 trace log 计算成功率、延迟分位数和 top tools/instances。 |
 | `GET /admin/api/governance?limit=300` / `GET /v1/debug/governance` | 查看当前 policy、read-only 状态、traffic capture guardrail、redaction paths、中间件 quota 状态，以及最近 allowed/denied/throttled 决策。 |
-| `GET /admin/api/workers` | 查看 live registry 中每个实例的 worker 卡片。 |
+| `GET /admin/api/workers` | 查看 live registry 中每个实例的卡片。 |
 
 默认情况下这些缓冲区只保存在内存中。设置 `DCC_MCP_GATEWAY_AUDIT_DIR` 后会追加有界 JSONL 文件：
 


### PR DESCRIPTION
## Summary

- remove obsolete `workers` panel URL compatibility and stale Workers-tab copy from the admin UI
- align admin UI instance card types, state, DOM classes, and tests with the current Instances panel naming
- refresh English and Chinese admin/observability docs while preserving the `/admin/api/workers` response contract

Closes #1242

## Validation

- `vx npm run build` (admin-ui)
- `vx npx playwright test tests/i18n.spec.ts tests/admin.spec.ts` (admin-ui)
- `vx just admin-build`
- `vx npm --prefix docs ci`
- `vx npm --prefix docs run docs:build`
- `vx npx markdownlint-cli2 "docs/**/*.md" "README.md" "README_zh.md" "!docs/node_modules"`
- `vx git diff --check`

`skills/dcc-mcp-skill-developer/SKILL.md` does not need an update because this only cleans the admin UI and docs naming around existing instance cards.