### PR TITLE
feat: add skills helper namespace

### DIFF
--- a/docs/api/skills.md
+++ b/docs/api/skills.md
@@ -552,6 +552,59 @@ Examples:
 
 ---
 
+## Rust-Backed Skill Helpers
+
+`dcc_mcp_core.skills_helper` is the canonical import path for dependency-light
+helpers that skill scripts can rely on when the full `dcc-mcp-core` wheel is
+available. Prefer it over ad-hoc `utils` modules or adding small runtime
+dependencies for JSON, YAML, schema validation, result envelopes, argument
+normalization, or cancellation checks.
+
+```python
+from dcc_mcp_core.skills_helper import (
+    check_cancelled,
+    json_dumps,
+    json_loads,
+    normalize_tool_arguments,
+    skill_success,
+    yaml_dumps,
+    yaml_loads,
+)
+```
+
+The JSON and YAML helpers are backed by the Rust/PyO3 bridge and remain
+available as backwards-compatible top-level imports:
+
+```python
+from dcc_mcp_core.skills_helper import json_dumps, json_loads, yaml_dumps, yaml_loads
+
+payload = json_loads('{"name": "cube"}')
+text = json_dumps(payload, ensure_ascii=False)
+config = yaml_loads("enabled: true\n")
+```
+
+Existing imports such as `from dcc_mcp_core import json_dumps` continue to work
+and re-export the same canonical functions. New helpers for skill authoring
+belong under `skills_helper`, not a vague `utils` namespace.
+
+Use `skills_helper` when:
+
+- a skill needs dependency-free JSON or YAML parsing instead of `json`, PyYAML,
+  or local wrapper modules;
+- a handler needs standard result helpers such as `skill_success`,
+  `skill_error`, `success_result`, or `error_result`;
+- a tool wrapper needs `normalize_tool_arguments()` / `normalize_tool_meta()`
+  to match the shared MCP/REST call-envelope contract;
+- long-running scripts need `check_cancelled()` / `check_dcc_cancelled()`.
+- a bounded HTTP or file/path helper is covered by this namespace in your
+  installed version; use `requests` or domain-specific file libraries only for
+  behavior that `skills_helper` does not provide.
+
+Use a domain-specific Python dependency only when the dependency owns real
+domain behavior that `skills_helper` does not cover.
+
+---
+
 ## Skill Script Helpers (pure-Python)
 
 `dcc_mcp_core.skill` is a **pure-Python** sub-module — no compiled extension required.

--- a/docs/zh/api/skills.md
+++ b/docs/zh/api/skills.md
@@ -485,6 +485,54 @@ get_app_skill_paths_from_env(app_name: str) -> list[str]
 
 ---
 
+## Rust 后端 Skill 辅助工具
+
+`dcc_mcp_core.skills_helper` 是面向 Skill 脚本的 canonical import path。
+当完整 `dcc-mcp-core` wheel 可用时，Skill 作者应优先从这里导入轻量辅助
+API，而不是创建零散的 `utils` 模块，或为 JSON、YAML、schema validation、
+结果 envelope、参数规范化、取消检查等小功能新增 Python runtime dependency。
+
+```python
+from dcc_mcp_core.skills_helper import (
+    check_cancelled,
+    json_dumps,
+    json_loads,
+    normalize_tool_arguments,
+    skill_success,
+    yaml_dumps,
+    yaml_loads,
+)
+```
+
+JSON 和 YAML helper 由 Rust/PyO3 bridge 提供，并继续保留向后兼容的顶层导入：
+
+```python
+from dcc_mcp_core.skills_helper import json_dumps, json_loads, yaml_dumps, yaml_loads
+
+payload = json_loads('{"name": "cube"}')
+text = json_dumps(payload, ensure_ascii=False)
+config = yaml_loads("enabled: true\n")
+```
+
+现有 `from dcc_mcp_core import json_dumps` 仍可使用，并 re-export 同一组
+canonical functions。新的 Skill authoring helper 应放在 `skills_helper`，
+不要放进含义模糊的 `utils` 命名空间。
+
+适合使用 `skills_helper` 的场景：
+
+- Skill 需要 dependency-free JSON 或 YAML parsing，而不是 `json`、PyYAML 或本地 wrapper；
+- handler 需要 `skill_success`、`skill_error`、`success_result`、`error_result` 等标准结果 helper；
+- 工具 wrapper 需要 `normalize_tool_arguments()` / `normalize_tool_meta()` 来遵循共享 MCP/REST call envelope contract；
+- 长时间运行的脚本需要 `check_cancelled()` / `check_dcc_cancelled()`。
+- 当前安装版本的 `skills_helper` 已覆盖某个有边界的 HTTP 或 file/path
+  helper；只有在 `skills_helper` 不覆盖所需行为时，才继续使用 `requests`
+  或领域专用 file library。
+
+只有当某个 Python dependency 承载 `skills_helper` 不覆盖的真实领域行为时，
+才应继续引入该 dependency。
+
+---
+
 ## Skill Script 辅助工具（纯 Python）
 
 `dcc_mcp_core.skill` 是**纯 Python** 子模块 — 无需编译扩展即可使用。

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -597,6 +597,26 @@ for s in skills:
     # Action names: f"{s.name.replace('-', '_')}__{stem}" for stem in script stems
 ```
 
+### skills_helper
+
+```python
+from dcc_mcp_core.skills_helper import (
+    check_cancelled,
+    json_dumps,
+    json_loads,
+    normalize_tool_arguments,
+    skill_success,
+    yaml_dumps,
+    yaml_loads,
+)
+```
+
+Canonical skill-authoring namespace for Rust-backed, dependency-light helpers.
+Use it for JSON/YAML codecs, standard result helpers, schema validation,
+MCP/REST argument normalization, and cancellation checks. Legacy imports such
+as `from dcc_mcp_core import json_dumps` remain compatibility re-exports of
+the same functions.
+
 ### register_metadata_driven_tools
 
 ```python

--- a/llms.txt
+++ b/llms.txt
@@ -115,7 +115,8 @@
 | Skill hot-reload without server restart | `DccSkillHotReloader(dcc_name, server)` — monitors skill directories and auto-reloads on change |
 | Singleton DCC server factory | `create_dcc_server(instance_holder, lock, server_class, ...)` / `make_start_stop(ServerClass)` — zero-boilerplate singleton server pattern |
 | Skill validation | `validate_skill(skill_dir)` → `SkillValidationReport` with `SkillValidationIssue` list |
-| Rust-powered JSON/YAML | `json_dumps(obj)` / `json_loads(s)` / `yaml_dumps(obj)` / `yaml_loads(s)` — zero-dependency serialization |
+| Rust-backed skill helpers (issue #1255) | `from dcc_mcp_core.skills_helper import json_dumps, json_loads, yaml_dumps, yaml_loads, skill_success, check_cancelled` — canonical skill-authoring namespace for dependency-light helper APIs; legacy top-level codec imports still work |
+| Rust-powered JSON/YAML | `json_dumps(obj)` / `json_loads(s)` / `yaml_dumps(obj)` / `yaml_loads(s)` — zero-dependency serialization, canonically exported from `dcc_mcp_core.skills_helper` |
 | Canonical MCP/REST wire normalization | Rust: `dcc-mcp-wire::{normalize_arguments, normalize_meta, decode_call_tool, decode_rest_call}`; Python host wrappers: `from dcc_mcp_core.host import normalize_tool_arguments, normalize_tool_meta`. Missing / `null` / empty-string arguments become `{}`; objects pass through; object-shaped JSON strings are accepted; arrays/numbers/booleans/non-object strings are rejected. |
 | Discover team-level skills | `scan_and_load_team()` / `scan_and_load_team_lenient()` |
 | Discover user-level skills | `scan_and_load_user()` / `scan_and_load_user_lenient()` |
@@ -695,12 +696,13 @@ tools:
 - `TOOL_NAME_RE` / `ACTION_ID_RE` — regex patterns for client-safe tool names and internal action IDs
 - `MAX_TOOL_NAME_LEN = 64` — maximum tool name length
 
-### Serialization — Rust-Powered (`dcc_mcp_core`)
+### Serialization — Rust-Powered (`dcc_mcp_core.skills_helper`)
 
 - `json_dumps(obj) -> str` — serialize to JSON string (zero-dependency, Rust-powered)
 - `json_loads(s) -> obj` — deserialize from JSON string (zero-dependency, Rust-powered)
 - `yaml_dumps(obj) -> str` — serialize to YAML string (zero-dependency, Rust-powered)
 - `yaml_loads(s) -> obj` — deserialize from YAML string (zero-dependency, Rust-powered)
+- Existing `from dcc_mcp_core import json_dumps` style imports are compatibility re-exports of `dcc_mcp_core.skills_helper`.
 
 ### Skill Validation (`dcc_mcp_core`)
 

--- a/python/dcc_mcp_core/_exports.py
+++ b/python/dcc_mcp_core/_exports.py
@@ -214,8 +214,8 @@ _LAZY: dict[str, str] = {
     "init_file_logging": "dcc_mcp_core._core",
     "is_gui_executable": "dcc_mcp_core._core",
     "is_telemetry_initialized": "dcc_mcp_core._core",
-    "json_dumps": "dcc_mcp_core._core",
-    "json_loads": "dcc_mcp_core._core",
+    "json_dumps": "dcc_mcp_core.skills_helper",
+    "json_loads": "dcc_mcp_core.skills_helper",
     "mpu_to_units": "dcc_mcp_core._core",
     "parse_schedules_yaml": "dcc_mcp_core._core",
     "parse_skill_md": "dcc_mcp_core._core",
@@ -246,8 +246,8 @@ _LAZY: dict[str, str] = {
     "validate_tool_name": "dcc_mcp_core._core",
     "verify_hub_signature_256": "dcc_mcp_core._core",
     "wrap_value": "dcc_mcp_core._core",
-    "yaml_dumps": "dcc_mcp_core._core",
-    "yaml_loads": "dcc_mcp_core._core",
+    "yaml_dumps": "dcc_mcp_core.skills_helper",
+    "yaml_loads": "dcc_mcp_core.skills_helper",
     # Optional _core symbols (try/except ImportError in old code)
     # Returns None when the feature is not compiled in.
     "BackoffKind": "dcc_mcp_core._core",
@@ -494,6 +494,8 @@ _LAZY: dict[str, str] = {
     "normalize_tool_arguments": "dcc_mcp_core.host",
     "normalize_tool_meta": "dcc_mcp_core.host",
     "readiness_report_subset": "dcc_mcp_core.readiness",
+    "SkillHelperError": "dcc_mcp_core.skills_helper",
+    "skill_error_from_exception": "dcc_mcp_core.skills_helper",
     # skill helpers (pure-Python, used inside skill scripts)
     "get_bundled_skill_paths": "dcc_mcp_core.skill",
     "get_bundled_skills_dir": "dcc_mcp_core.skill",

--- a/python/dcc_mcp_core/skills_helper.py
+++ b/python/dcc_mcp_core/skills_helper.py
@@ -1,0 +1,123 @@
+"""Stable Rust-backed helper namespace for DCC-MCP skill scripts.
+
+Skill authors should import dependency-light helpers from this module instead
+of reaching across implementation modules or adding small third-party runtime
+dependencies for JSON, YAML, validation, result envelopes, or cancellation.
+
+The module intentionally keeps imports lazy: importing
+``dcc_mcp_core.skills_helper`` does not load the PyO3 extension until a
+Rust-backed helper is used.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+
+class SkillHelperError(Exception):
+    """Base exception for skill-helper failures raised by future helpers."""
+
+
+def _core_symbol(name: str) -> Any:
+    from dcc_mcp_core import _core
+
+    return getattr(_core, name)
+
+
+def json_dumps(obj: Any, *, ensure_ascii: bool = True, indent: int | None = None) -> str:
+    """Serialize *obj* to JSON using the Rust-backed codec."""
+    return _core_symbol("json_dumps")(obj, ensure_ascii=ensure_ascii, indent=indent)
+
+
+def json_loads(s: str) -> Any:
+    """Deserialize JSON text using the Rust-backed codec."""
+    return _core_symbol("json_loads")(s)
+
+
+def yaml_dumps(obj: Any) -> str:
+    """Serialize *obj* to YAML using the Rust-backed codec."""
+    return _core_symbol("yaml_dumps")(obj)
+
+
+def yaml_loads(s: str) -> Any:
+    """Deserialize YAML text using the Rust-backed codec."""
+    return _core_symbol("yaml_loads")(s)
+
+
+def skill_error_from_exception(
+    exc: BaseException,
+    *,
+    message: str | None = None,
+    error: str | None = None,
+    prompt: str | None = None,
+    **context: Any,
+) -> dict[str, Any]:
+    """Convert an exception into the standard skill error dictionary shape."""
+    from dcc_mcp_core.skill import skill_error
+
+    return skill_error(
+        message or str(exc) or type(exc).__name__,
+        error or type(exc).__name__,
+        prompt=prompt,
+        **context,
+    )
+
+
+_LAZY_EXPORTS: dict[str, str] = {
+    # Result envelopes and validation from the Rust extension.
+    "deserialize_result": "dcc_mcp_core._core",
+    "error_result": "dcc_mcp_core._core",
+    "from_exception": "dcc_mcp_core._core",
+    "serialize_result": "dcc_mcp_core._core",
+    "success_result": "dcc_mcp_core._core",
+    "ToolValidator": "dcc_mcp_core._core",
+    "validate_action_result": "dcc_mcp_core._core",
+    # Shared MCP/REST call envelope normalization.
+    "normalize_tool_arguments": "dcc_mcp_core.host",
+    "normalize_tool_meta": "dcc_mcp_core.host",
+    # Schema derivation helpers.
+    "derive_parameters_schema": "dcc_mcp_core.schema",
+    "derive_schema": "dcc_mcp_core.schema",
+    "schema_from_doc": "dcc_mcp_core.schema",
+    "tool_spec_from_callable": "dcc_mcp_core.schema",
+    # Cooperative cancellation.
+    "CancelledError": "dcc_mcp_core.cancellation",
+    "check_cancelled": "dcc_mcp_core.cancellation",
+    "check_dcc_cancelled": "dcc_mcp_core.cancellation",
+    # Pure-Python skill script result helpers.
+    "run_main": "dcc_mcp_core.skill",
+    "skill_entry": "dcc_mcp_core.skill",
+    "skill_error": "dcc_mcp_core.skill",
+    "skill_error_with_trace": "dcc_mcp_core.skill",
+    "skill_exception": "dcc_mcp_core.skill",
+    "skill_success": "dcc_mcp_core.skill",
+    "skill_warning": "dcc_mcp_core.skill",
+}
+
+
+def __getattr__(name: str) -> Any:
+    module_path = _LAZY_EXPORTS.get(name)
+    if module_path is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = importlib.import_module(module_path)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)
+
+
+_DIRECT_EXPORTS = [
+    "SkillHelperError",
+    "json_dumps",
+    "json_loads",
+    "skill_error_from_exception",
+    "yaml_dumps",
+    "yaml_loads",
+]
+
+
+__all__ = sorted([*_DIRECT_EXPORTS, *_LAZY_EXPORTS])

--- a/skills/dcc-mcp-skill-developer/SKILL.md
+++ b/skills/dcc-mcp-skill-developer/SKILL.md
@@ -79,6 +79,10 @@ into a faster authoring loop.
    instead of copying recipes/reference-docs import wrappers. Omit `skills`
    only when the helper should own the `scan_and_load_lenient(...)` pass; pass
    explicit `skills` when startup already scanned roots.
+   Skill scripts that need JSON/YAML codecs, result helpers, argument
+   normalization, schema validation, or cancellation checks should import them
+   from `dcc_mcp_core.skills_helper`. Keep legacy top-level imports working for
+   old skills, but write new examples against `skills_helper`.
 7. When changing adapter server wiring or caller examples, keep Admin telemetry
    useful: pass optional `agent_context` / `caller_context` summaries through
    MCP `_meta`, REST `meta`, or `x-dcc-mcp-agent-*` headers when the caller is

--- a/tests/test_skills_helper.py
+++ b/tests/test_skills_helper.py
@@ -1,0 +1,75 @@
+"""Tests for the canonical skill-helper namespace."""
+
+from __future__ import annotations
+
+import pytest
+
+import dcc_mcp_core
+from dcc_mcp_core import skills_helper
+from dcc_mcp_core.skills_helper import ToolValidator
+from dcc_mcp_core.skills_helper import normalize_tool_arguments
+from dcc_mcp_core.skills_helper import skill_error_from_exception
+from dcc_mcp_core.skills_helper import skill_success
+
+
+def test_skills_helper_json_yaml_codecs_roundtrip() -> None:
+    payload = {"name": "café", "frames": [1, 2, 3], "enabled": True}
+
+    encoded = skills_helper.json_dumps(payload, ensure_ascii=False)
+    assert "café" in encoded
+    assert skills_helper.json_loads(encoded) == payload
+
+    yaml_encoded = skills_helper.yaml_dumps(payload)
+    assert skills_helper.yaml_loads(yaml_encoded) == payload
+
+
+def test_legacy_top_level_codecs_reexport_skills_helper() -> None:
+    assert dcc_mcp_core.json_dumps is skills_helper.json_dumps
+    assert dcc_mcp_core.json_loads is skills_helper.json_loads
+    assert dcc_mcp_core.yaml_dumps is skills_helper.yaml_dumps
+    assert dcc_mcp_core.yaml_loads is skills_helper.yaml_loads
+
+    assert dcc_mcp_core.json_loads(dcc_mcp_core.json_dumps({"ok": True})) == {"ok": True}
+
+
+def test_skills_helper_reexports_validation_and_normalization() -> None:
+    validator = ToolValidator.from_schema_json(
+        skills_helper.json_dumps(
+            {
+                "type": "object",
+                "required": ["name"],
+                "properties": {"name": {"type": "string"}},
+            }
+        )
+    )
+
+    ok, errors = validator.validate(skills_helper.json_dumps({"name": "maya"}))
+
+    assert ok is True
+    assert errors == []
+    assert normalize_tool_arguments('{"name":"maya"}') == {"name": "maya"}
+
+
+def test_skills_helper_reexports_skill_result_helpers() -> None:
+    result = skill_success("Created cube", object_name="cube1")
+
+    assert result["success"] is True
+    assert result["message"] == "Created cube"
+    assert result["context"] == {"object_name": "cube1"}
+
+
+def test_skill_error_from_exception_uses_standard_skill_error_shape() -> None:
+    exc = ValueError("bad radius")
+
+    result = skill_error_from_exception(exc, prompt="Use a positive radius.", radius=-1)
+
+    assert result["success"] is False
+    assert result["message"] == "bad radius"
+    assert result["error"] == "ValueError"
+    assert result["prompt"] == "Use a positive radius."
+    assert result["context"] == {"radius": -1}
+
+
+def test_skills_helper_reports_invalid_json_errors() -> None:
+    with pytest.raises(ValueError):
+        skills_helper.json_loads("{not json}")


### PR DESCRIPTION
## Summary
- add `dcc_mcp_core.skills_helper` as the canonical Rust-backed helper namespace for skill scripts
- re-export JSON/YAML codecs through the new namespace while preserving legacy top-level imports
- document the skill-authoring guidance and cover import stability, codecs, validation, normalization, and skill error conversion

Closes #1255

## Validation
- `vx just admin-build`
- `DCC_MCP_ADMIN_UI_PREBUILT=1 vx just dev`
- `.venv\Scripts\python.exe -m pytest tests/test_skills_helper.py tests/test_serialize_result_roundtrip.py tests/test_host_wire_python.py -q --tb=short --show-capture=no`
- `vx just lint-py`
- `vx python@3.7 scripts/check_py37_syntax.py`
- `vx npm --prefix docs ci`
- `vx npm --prefix docs run docs:build`
- `vx npx markdownlint-cli2 "docs/**/*.md" "README.md" "README_zh.md" "!docs/node_modules"`
- `vx git diff --check`

`skills/dcc-mcp-skill-developer/SKILL.md` was updated because this changes skill authoring guidance.