### PR TITLE
feat: expand skill data codec helpers

### DIFF
--- a/docs/api/skills.md
+++ b/docs/api/skills.md
@@ -583,6 +583,26 @@ text = json_dumps(payload, ensure_ascii=False)
 config = yaml_loads("enabled: true\n")
 ```
 
+For files, prefer the source-aware helpers so UTF-8 handling, byte limits, and
+parse errors are consistent across skills:
+
+```python
+from dcc_mcp_core.skills_helper import (
+    SkillCodecError,
+    dump_json_file,
+    load_json_file,
+    load_yaml_file,
+)
+
+try:
+    manifest = load_json_file("manifest.json", require_mapping=True, max_bytes=1_000_000)
+    settings = load_yaml_file("settings.yaml", require_mapping=True)
+except SkillCodecError as exc:
+    return skill_error_from_exception(exc)
+
+dump_json_file("out/report.json", manifest, ensure_ascii=False)
+```
+
 Existing imports such as `from dcc_mcp_core import json_dumps` continue to work
 and re-export the same canonical functions. New helpers for skill authoring
 belong under `skills_helper`, not a vague `utils` namespace.
@@ -602,6 +622,12 @@ Use `skills_helper` when:
 
 Use a domain-specific Python dependency only when the dependency owns real
 domain behavior that `skills_helper` does not cover.
+
+TOML helpers are intentionally not exposed yet. The current adapter and bundled
+skill use cases read TOML as metadata handled by core loaders rather than skill
+script runtime code, and Python 3.7 support would require adding another
+runtime dependency for a stable read/write API. Revisit TOML helpers when a
+skill script needs dependency-free TOML at runtime.
 
 ---
 

--- a/docs/zh/api/skills.md
+++ b/docs/zh/api/skills.md
@@ -514,6 +514,26 @@ text = json_dumps(payload, ensure_ascii=False)
 config = yaml_loads("enabled: true\n")
 ```
 
+处理文件时，优先使用带 source context 的 helper，让 UTF-8、大小限制和解析
+错误在不同 Skill 中保持一致：
+
+```python
+from dcc_mcp_core.skills_helper import (
+    SkillCodecError,
+    dump_json_file,
+    load_json_file,
+    load_yaml_file,
+)
+
+try:
+    manifest = load_json_file("manifest.json", require_mapping=True, max_bytes=1_000_000)
+    settings = load_yaml_file("settings.yaml", require_mapping=True)
+except SkillCodecError as exc:
+    return skill_error_from_exception(exc)
+
+dump_json_file("out/report.json", manifest, ensure_ascii=False)
+```
+
 现有 `from dcc_mcp_core import json_dumps` 仍可使用，并 re-export 同一组
 canonical functions。新的 Skill authoring helper 应放在 `skills_helper`，
 不要放进含义模糊的 `utils` 命名空间。
@@ -530,6 +550,11 @@ canonical functions。新的 Skill authoring helper 应放在 `skills_helper`，
 
 只有当某个 Python dependency 承载 `skills_helper` 不覆盖的真实领域行为时，
 才应继续引入该 dependency。
+
+暂不暴露 TOML helper。当前 adapter 与 bundled skill 的 TOML 使用主要是由
+core loader 处理的 metadata，并不是 Skill runtime 脚本直接读写；同时为了
+支持 Python 3.7，稳定 TOML read/write API 会引入额外 runtime dependency。
+等 Skill runtime 里出现 dependency-free TOML 需求时再补充。
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -601,9 +601,13 @@ for s in skills:
 
 ```python
 from dcc_mcp_core.skills_helper import (
+    SkillCodecError,
     check_cancelled,
+    dump_json_file,
     json_dumps,
     json_loads,
+    load_json_file,
+    load_yaml_file,
     normalize_tool_arguments,
     skill_success,
     yaml_dumps,
@@ -615,7 +619,10 @@ Canonical skill-authoring namespace for Rust-backed, dependency-light helpers.
 Use it for JSON/YAML codecs, standard result helpers, schema validation,
 MCP/REST argument normalization, and cancellation checks. Legacy imports such
 as `from dcc_mcp_core import json_dumps` remain compatibility re-exports of
-the same functions.
+the same functions. Use `load_json_file` / `load_yaml_file` when a skill needs
+explicit UTF-8 handling, byte limits, source-aware errors, or mapping-root
+validation. TOML runtime helpers are intentionally deferred until a real skill
+script use case needs dependency-free TOML read/write support on Python 3.7.
 
 ### register_metadata_driven_tools
 

--- a/llms.txt
+++ b/llms.txt
@@ -115,8 +115,8 @@
 | Skill hot-reload without server restart | `DccSkillHotReloader(dcc_name, server)` — monitors skill directories and auto-reloads on change |
 | Singleton DCC server factory | `create_dcc_server(instance_holder, lock, server_class, ...)` / `make_start_stop(ServerClass)` — zero-boilerplate singleton server pattern |
 | Skill validation | `validate_skill(skill_dir)` → `SkillValidationReport` with `SkillValidationIssue` list |
-| Rust-backed skill helpers (issue #1255) | `from dcc_mcp_core.skills_helper import json_dumps, json_loads, yaml_dumps, yaml_loads, skill_success, check_cancelled` — canonical skill-authoring namespace for dependency-light helper APIs; legacy top-level codec imports still work |
-| Rust-powered JSON/YAML | `json_dumps(obj)` / `json_loads(s)` / `yaml_dumps(obj)` / `yaml_loads(s)` — zero-dependency serialization, canonically exported from `dcc_mcp_core.skills_helper` |
+| Rust-backed skill helpers (issues #1255, #1257) | `from dcc_mcp_core.skills_helper import json_dumps, json_loads, yaml_dumps, yaml_loads, load_json_file, dump_json_file, SkillCodecError, skill_success, check_cancelled` — canonical skill-authoring namespace for dependency-light helper APIs; legacy top-level codec imports still work |
+| Rust-powered JSON/YAML | `json_dumps(obj)` / `json_loads(s)` / `yaml_dumps(obj)` / `yaml_loads(s)` plus `load_json_file(...)` / `load_yaml_file(...)` — zero-dependency serialization, canonically exported from `dcc_mcp_core.skills_helper`; TOML runtime helpers are intentionally deferred until a real skill runtime use case appears |
 | Canonical MCP/REST wire normalization | Rust: `dcc-mcp-wire::{normalize_arguments, normalize_meta, decode_call_tool, decode_rest_call}`; Python host wrappers: `from dcc_mcp_core.host import normalize_tool_arguments, normalize_tool_meta`. Missing / `null` / empty-string arguments become `{}`; objects pass through; object-shaped JSON strings are accepted; arrays/numbers/booleans/non-object strings are rejected. |
 | Discover team-level skills | `scan_and_load_team()` / `scan_and_load_team_lenient()` |
 | Discover user-level skills | `scan_and_load_user()` / `scan_and_load_user_lenient()` |
@@ -702,6 +702,10 @@ tools:
 - `json_loads(s) -> obj` — deserialize from JSON string (zero-dependency, Rust-powered)
 - `yaml_dumps(obj) -> str` — serialize to YAML string (zero-dependency, Rust-powered)
 - `yaml_loads(s) -> obj` — deserialize from YAML string (zero-dependency, Rust-powered)
+- `load_text(path, max_bytes=None) -> str` / `dump_text(path, text) -> Path` — explicit UTF-8 file helpers
+- `load_json_file(path, require_mapping=False, max_bytes=None) -> obj` / `dump_json_file(path, obj, ensure_ascii=True, indent=2) -> Path`
+- `load_yaml_file(path, require_mapping=False, max_bytes=None) -> obj` / `dump_yaml_file(path, obj) -> Path`
+- `SkillCodecError` includes codec and source context for actionable skill errors
 - Existing `from dcc_mcp_core import json_dumps` style imports are compatibility re-exports of `dcc_mcp_core.skills_helper`.
 
 ### Skill Validation (`dcc_mcp_core`)

--- a/python/dcc_mcp_core/skills_helper.py
+++ b/python/dcc_mcp_core/skills_helper.py
@@ -11,12 +11,26 @@ Rust-backed helper is used.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 import importlib
+from pathlib import Path
 from typing import Any
 
 
 class SkillHelperError(Exception):
     """Base exception for skill-helper failures raised by future helpers."""
+
+
+class SkillCodecError(SkillHelperError):
+    """Raised when a skill helper cannot load or dump structured data."""
+
+    def __init__(self, message: str, *, codec: str, source: str | None = None) -> None:
+        self.codec = codec
+        self.source = source
+        detail = f"{codec}: {message}"
+        if source:
+            detail = f"{source}: {detail}"
+        super().__init__(detail)
 
 
 def _core_symbol(name: str) -> Any:
@@ -43,6 +57,126 @@ def yaml_dumps(obj: Any) -> str:
 def yaml_loads(s: str) -> Any:
     """Deserialize YAML text using the Rust-backed codec."""
     return _core_symbol("yaml_loads")(s)
+
+
+def _source_name(path: str | Path) -> str:
+    return str(path)
+
+
+def _require_mapping_root(value: Any, *, codec: str, source: str | None, require_mapping: bool) -> Any:
+    if require_mapping and not isinstance(value, Mapping):
+        raise SkillCodecError(
+            f"expected a mapping root, got {type(value).__name__}",
+            codec=codec,
+            source=source,
+        )
+    return value
+
+
+def load_text(path: str | Path, *, max_bytes: int | None = None) -> str:
+    """Read a UTF-8 text file with an optional byte-size guard."""
+    p = Path(path)
+    try:
+        data = p.read_bytes()
+    except OSError as exc:
+        raise SkillCodecError(str(exc), codec="text", source=_source_name(p)) from exc
+    if max_bytes is not None and len(data) > max_bytes:
+        raise SkillCodecError(
+            f"file is {len(data)} bytes, exceeding max_bytes={max_bytes}",
+            codec="text",
+            source=_source_name(p),
+        )
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise SkillCodecError(str(exc), codec="text", source=_source_name(p)) from exc
+
+
+def dump_text(path: str | Path, text: str, *, create_parents: bool = True) -> Path:
+    """Write UTF-8 text and return the written path."""
+    p = Path(path)
+    if create_parents:
+        p.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        p.write_text(text, encoding="utf-8")
+    except OSError as exc:
+        raise SkillCodecError(str(exc), codec="text", source=_source_name(p)) from exc
+    return p
+
+
+def load_json_text(text: str, *, source: str | None = None, require_mapping: bool = False) -> Any:
+    """Load JSON text and wrap parse/root-shape errors with source context."""
+    try:
+        value = json_loads(text)
+    except Exception as exc:
+        raise SkillCodecError(str(exc), codec="json", source=source) from exc
+    return _require_mapping_root(value, codec="json", source=source, require_mapping=require_mapping)
+
+
+def dump_json_text(obj: Any, *, ensure_ascii: bool = True, indent: int | None = None) -> str:
+    """Dump JSON text with the Rust-backed codec."""
+    try:
+        return json_dumps(obj, ensure_ascii=ensure_ascii, indent=indent)
+    except Exception as exc:
+        raise SkillCodecError(str(exc), codec="json") from exc
+
+
+def load_json_file(path: str | Path, *, require_mapping: bool = False, max_bytes: int | None = None) -> Any:
+    """Load a UTF-8 JSON file with source-aware parse errors."""
+    p = Path(path)
+    return load_json_text(
+        load_text(p, max_bytes=max_bytes),
+        source=_source_name(p),
+        require_mapping=require_mapping,
+    )
+
+
+def dump_json_file(
+    path: str | Path,
+    obj: Any,
+    *,
+    ensure_ascii: bool = True,
+    indent: int | None = 2,
+    create_parents: bool = True,
+) -> Path:
+    """Serialize JSON with the Rust-backed codec and write it as UTF-8."""
+    return dump_text(
+        path,
+        dump_json_text(obj, ensure_ascii=ensure_ascii, indent=indent),
+        create_parents=create_parents,
+    )
+
+
+def load_yaml_text(text: str, *, source: str | None = None, require_mapping: bool = False) -> Any:
+    """Load YAML text and wrap parse/root-shape errors with source context."""
+    try:
+        value = yaml_loads(text)
+    except Exception as exc:
+        raise SkillCodecError(str(exc), codec="yaml", source=source) from exc
+    return _require_mapping_root(value, codec="yaml", source=source, require_mapping=require_mapping)
+
+
+def dump_yaml_text(obj: Any) -> str:
+    """Dump YAML text with the Rust-backed codec."""
+    try:
+        return yaml_dumps(obj)
+    except Exception as exc:
+        raise SkillCodecError(str(exc), codec="yaml") from exc
+
+
+def load_yaml_file(path: str | Path, *, require_mapping: bool = False, max_bytes: int | None = None) -> Any:
+    """Load a UTF-8 YAML file with source-aware parse errors."""
+    p = Path(path)
+    return load_yaml_text(
+        load_text(p, max_bytes=max_bytes),
+        source=_source_name(p),
+        require_mapping=require_mapping,
+    )
+
+
+def dump_yaml_file(path: str | Path, obj: Any, *, create_parents: bool = True) -> Path:
+    """Serialize YAML with the Rust-backed codec and write it as UTF-8."""
+    return dump_text(path, dump_yaml_text(obj), create_parents=create_parents)
 
 
 def skill_error_from_exception(
@@ -111,9 +245,20 @@ def __dir__() -> list[str]:
 
 
 _DIRECT_EXPORTS = [
+    "SkillCodecError",
     "SkillHelperError",
+    "dump_json_file",
+    "dump_json_text",
+    "dump_text",
+    "dump_yaml_file",
+    "dump_yaml_text",
     "json_dumps",
     "json_loads",
+    "load_json_file",
+    "load_json_text",
+    "load_text",
+    "load_yaml_file",
+    "load_yaml_text",
     "skill_error_from_exception",
     "yaml_dumps",
     "yaml_loads",

--- a/skills/dcc-mcp-skill-developer/SKILL.md
+++ b/skills/dcc-mcp-skill-developer/SKILL.md
@@ -83,6 +83,9 @@ into a faster authoring loop.
    normalization, schema validation, or cancellation checks should import them
    from `dcc_mcp_core.skills_helper`. Keep legacy top-level imports working for
    old skills, but write new examples against `skills_helper`.
+   Prefer `load_json_file`, `load_yaml_file`, `dump_json_file`, and
+   `dump_yaml_file` from the same namespace when a script needs explicit UTF-8,
+   source-aware parse errors, byte guards, or mapping-root validation.
 7. When changing adapter server wiring or caller examples, keep Admin telemetry
    useful: pass optional `agent_context` / `caller_context` summaries through
    MCP `_meta`, REST `meta`, or `x-dcc-mcp-agent-*` headers when the caller is

--- a/tests/test_skills_helper.py
+++ b/tests/test_skills_helper.py
@@ -6,6 +6,7 @@ import pytest
 
 import dcc_mcp_core
 from dcc_mcp_core import skills_helper
+from dcc_mcp_core.skills_helper import SkillCodecError
 from dcc_mcp_core.skills_helper import ToolValidator
 from dcc_mcp_core.skills_helper import normalize_tool_arguments
 from dcc_mcp_core.skills_helper import skill_error_from_exception
@@ -73,3 +74,45 @@ def test_skill_error_from_exception_uses_standard_skill_error_shape() -> None:
 def test_skills_helper_reports_invalid_json_errors() -> None:
     with pytest.raises(ValueError):
         skills_helper.json_loads("{not json}")
+
+
+def test_skills_helper_json_file_helpers_add_source_context(tmp_path) -> None:
+    path = tmp_path / "nested" / "payload.json"
+
+    written = skills_helper.dump_json_file(path, {"name": "café"}, ensure_ascii=False)
+
+    assert written == path
+    assert skills_helper.load_json_file(path, require_mapping=True) == {"name": "café"}
+    assert "café" in path.read_text(encoding="utf-8")
+
+    bad = tmp_path / "bad.json"
+    bad.write_text("{bad", encoding="utf-8")
+    with pytest.raises(SkillCodecError, match=r"bad\.json: json:"):
+        skills_helper.load_json_file(bad)
+
+
+def test_skills_helper_yaml_file_helpers_support_empty_and_unicode_roots(tmp_path) -> None:
+    path = tmp_path / "payload.yaml"
+
+    skills_helper.dump_yaml_file(path, {"label": "动画", "items": [1, 2]})
+
+    assert skills_helper.load_yaml_file(path, require_mapping=True) == {"label": "动画", "items": [1, 2]}
+    assert skills_helper.load_yaml_text("", source="empty.yaml") is None
+
+
+def test_skills_helper_mapping_root_validation_reports_actual_root_type(tmp_path) -> None:
+    path = tmp_path / "list.yaml"
+    path.write_text("- a\n- b\n", encoding="utf-8")
+
+    with pytest.raises(SkillCodecError, match="expected a mapping root, got list"):
+        skills_helper.load_yaml_file(path, require_mapping=True)
+
+
+def test_skills_helper_text_helpers_are_utf8_and_bounded(tmp_path) -> None:
+    path = tmp_path / "note.txt"
+
+    skills_helper.dump_text(path, "hello 世界")
+
+    assert skills_helper.load_text(path) == "hello 世界"
+    with pytest.raises(SkillCodecError, match="exceeding max_bytes=4"):
+        skills_helper.load_text(path, max_bytes=4)


### PR DESCRIPTION
## Summary
- add source-aware text, JSON, and YAML file helpers to `dcc_mcp_core.skills_helper`
- add `SkillCodecError` plus mapping-root validation and max-byte guards for skill runtime data loading
- document stable codec usage and explicitly defer TOML runtime helpers until a real skill-script use case needs them

Closes #1257

## Validation
- `vx just admin-build`
- `DCC_MCP_ADMIN_UI_PREBUILT=1 vx just dev`
- `.venv\Scripts\python.exe -m pytest tests/test_skills_helper.py tests/test_serialize_result_roundtrip.py tests/test_host_wire_python.py -q --tb=short --show-capture=no`
- `vx just lint-py`
- `vx python@3.7 scripts/check_py37_syntax.py`
- `vx npm --prefix docs ci`
- `vx npm --prefix docs run docs:build`
- `vx npx markdownlint-cli2 "docs/**/*.md" "README.md" "README_zh.md" "!docs/node_modules"`
- `vx git diff --check`

`skills/dcc-mcp-skill-developer/SKILL.md` was updated because this changes skill authoring guidance.