### PR TITLE
ci: add tiered Rust validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ on:
       - ".github/workflows/ci.yml"
       - ".github/workflows/dcc-integration.yml"
       - ".github/workflows/release.yml"
+      - ".github/workflows/rust-matrix-full.yml"
       - ".github/actions/build-wheel/**"
   push:
     branches: [main]
@@ -43,6 +44,7 @@ on:
       - ".github/workflows/ci.yml"
       - ".github/workflows/dcc-integration.yml"
       - ".github/workflows/release.yml"
+      - ".github/workflows/rust-matrix-full.yml"
       - ".github/actions/build-wheel/**"
 
 permissions:
@@ -106,12 +108,24 @@ jobs:
           name: admin-ui-bundle
           path: crates/dcc-mcp-gateway/src/gateway/admin/generated/index.html
 
-  # ── Rust checks (stub drift + clippy + fmt + cargo test) ──
+  # ── Rust checks ────────────────────────────────────────────────────────────
+  # Keep the PR critical path focused:
+  # - Linux runs the full Rust gate: stub generation, fmt, clippy, nextest, docs.
+  # - Windows/macOS run all-target compile smoke checks here; wheel + Python jobs
+  #   still compile, package, install, and exercise those OSes on every PR.
+  # - Full three-OS clippy + nextest runs in rust-matrix-full.yml on schedule or
+  #   manual dispatch for drift detection outside the PR fast path.
   rust-check:
     name: Rust (${{ matrix.os }})
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            rust-validation: full
+          - os: windows-latest
+            rust-validation: smoke
+          - os: macos-latest
+            rust-validation: smoke
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -179,19 +193,23 @@ jobs:
           echo ""
           echo "::error::Run 'cargo hakari generate' and commit the changes to fix this CI step."
           exit 1
-      # `cargo check` is intentionally omitted here: `cargo clippy --workspace`
-      # and `cargo nextest run --workspace` still compile the workspace, while
-      # stub generation and formatting are OS-independent and only need one pass.
+      # The full Linux path compiles through clippy + nextest. Smoke OSes still
+      # compile every workspace target, but skip duplicate Rust test execution.
       - name: Stub generation
-        if: runner.os == 'Linux'
+        if: matrix.rust-validation == 'full'
         run: vx just stubgen
       - name: Rust format check
-        if: runner.os == 'Linux'
+        if: matrix.rust-validation == 'full'
         run: vx just fmt-check
       - name: Clippy
+        if: matrix.rust-validation == 'full'
         run: vx just clippy
       - name: Rust tests
+        if: matrix.rust-validation == 'full'
         run: vx just test-rust
+      - name: Rust compile smoke
+        if: matrix.rust-validation == 'smoke'
+        run: vx cargo check --workspace --all-targets
 
   # ── Build ABI3 wheel (one per OS, reused by python-test) ──
   # Intentionally does NOT `needs: [rust-check]` — maturin runs its own compile

--- a/.github/workflows/rust-matrix-full.yml
+++ b/.github/workflows/rust-matrix-full.yml
@@ -1,0 +1,90 @@
+name: Rust Full Matrix
+
+# Full cross-platform Rust validation for drift detection outside the PR fast
+# path. The main CI workflow still runs Linux full Rust checks plus
+# Windows/macOS compile, wheel, install, and Python coverage on every PR.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 4 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rust-matrix-full-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rust-full:
+    name: Rust full (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - name: Fix cargo PATH on macOS
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          CARGO_BIN="$(rustup which cargo)"
+          echo "CARGO=${CARGO_BIN}" >> "$GITHUB_ENV"
+          echo "RUSTC=$(rustup which rustc)" >> "$GITHUB_ENV"
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+      - uses: loonghao/vx@v0.9.2
+        with:
+          version: "0.9.2"
+          cache-key-prefix: "vx-tools-v0.9.2"
+      - name: Prepare admin UI dependencies
+        shell: bash
+        run: |
+          vx node --version
+          vx npm --prefix admin-ui ci --ignore-scripts
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: rust-full-${{ runner.os }}
+          shared-key: rust-full-${{ runner.os }}
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hakari
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+      - name: Verify workspace-hack is up to date
+        shell: bash
+        run: |
+          export PATH="$HOME/.cargo/bin:$PATH"
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            export CARGO="$(rustup which cargo 2>/dev/null || which cargo)"
+          fi
+          cargo-hakari hakari verify && exit 0
+
+          echo "::error::workspace-hack is out of date - run 'cargo hakari generate' locally"
+          echo ""
+          echo "Expected changes to crates/workspace-hack/Cargo.toml:"
+          cargo-hakari hakari generate
+          git diff --no-color crates/workspace-hack/Cargo.toml
+          echo ""
+          echo "::error::Run 'cargo hakari generate' and commit the changes to fix this CI step."
+          exit 1
+      - name: Stub generation
+        if: runner.os == 'Linux'
+        run: vx just stubgen
+      - name: Rust format check
+        if: runner.os == 'Linux'
+        run: vx just fmt-check
+      - name: Clippy
+        run: vx just clippy
+      - name: Rust tests
+        run: vx just test-rust


### PR DESCRIPTION
## Summary
- trim PR Rust validation by keeping Linux as the full stubgen/fmt/clippy/nextest gate
- switch Windows/macOS Rust jobs to all-target compile smoke checks in the main CI path
- add a scheduled/manual Rust Full Matrix workflow for three-OS clippy + nextest drift detection

Closes #1269.

## Validation
- `vx actionlint .github/workflows/ci.yml .github/workflows/rust-matrix-full.yml`
- `vx git diff --check`
- `vx cargo check --workspace --all-targets`

Skill developer guidance update: not needed; this only changes CI workflow scheduling and validation tiers.
