### PR TITLE
feat: define caller attribution schema

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/admin/trace.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/trace.rs
@@ -365,25 +365,43 @@ fn round_two(value: f64) -> f64 {
 /// fields as ordinary caller context.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AgentContext {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, alias = "actorId", skip_serializing_if = "Option::is_none")]
+    pub actor_id: Option<String>,
+    #[serde(default, alias = "actorName", skip_serializing_if = "Option::is_none")]
+    pub actor_name: Option<String>,
+    #[serde(
+        default,
+        alias = "actorEmailHash",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub actor_email_hash: Option<String>,
+    #[serde(default, alias = "agentId", skip_serializing_if = "Option::is_none")]
     pub agent_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, alias = "agentName", skip_serializing_if = "Option::is_none")]
     pub agent_name: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, alias = "agentKind", skip_serializing_if = "Option::is_none")]
     pub agent_kind: Option<String>,
     #[serde(
         default,
+        alias = "agentVersion",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub agent_version: Option<String>,
+    #[serde(
+        default,
         alias = "modelProvider",
+        alias = "agentModelProvider",
         skip_serializing_if = "Option::is_none"
     )]
     pub model_provider: Option<String>,
     #[serde(
         default,
         alias = "modelVersion",
+        alias = "agentModelVersion",
         skip_serializing_if = "Option::is_none"
     )]
     pub model_version: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, alias = "agentModel", skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     #[serde(
         default,
@@ -397,6 +415,36 @@ pub struct AgentContext {
     pub turn_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub task: Option<String>,
+    #[serde(
+        default,
+        alias = "clientPlatform",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub client_platform: Option<String>,
+    #[serde(
+        default,
+        alias = "clientOs",
+        alias = "clientOS",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub client_os: Option<String>,
+    #[serde(default, alias = "clientHost", skip_serializing_if = "Option::is_none")]
+    pub client_host: Option<String>,
+    #[serde(
+        default,
+        alias = "authSubject",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub auth_subject: Option<String>,
+    /// Server-derived remote address. Request metadata and headers must not set
+    /// this field; use [`AgentContext::with_server_network_source`] at the
+    /// transport boundary after proxy trust policy has been applied.
+    #[serde(default, alias = "sourceIp", skip_serializing_if = "Option::is_none")]
+    pub source_ip: Option<String>,
+    /// Server-derived forwarded chain after proxy trust policy has been
+    /// applied. Client-supplied request metadata is ignored.
+    #[serde(default, alias = "forwardedFor", skip_serializing_if = "Vec::is_empty")]
+    pub forwarded_for: Vec<String>,
     #[serde(
         default,
         alias = "userIntentSummary",
@@ -468,16 +516,33 @@ impl AgentContext {
     }
 
     pub fn display_name(&self) -> Option<&str> {
-        self.agent_name
+        self.actor_name
             .as_deref()
+            .or(self.actor_id.as_deref())
+            .or(self.agent_name.as_deref())
             .or(self.agent_id.as_deref())
             .or(self.agent_kind.as_deref())
     }
 
+    #[must_use]
+    pub fn with_server_network_source(
+        mut self,
+        source_ip: Option<String>,
+        forwarded_for: Vec<String>,
+    ) -> Self {
+        self.source_ip = source_ip.map(bound_context_string);
+        self.forwarded_for = bound_context_list(forwarded_for);
+        self
+    }
+
     fn is_empty(&self) -> bool {
-        self.agent_id.is_none()
+        self.actor_id.is_none()
+            && self.actor_name.is_none()
+            && self.actor_email_hash.is_none()
+            && self.agent_id.is_none()
             && self.agent_name.is_none()
             && self.agent_kind.is_none()
+            && self.agent_version.is_none()
             && self.model_provider.is_none()
             && self.model_version.is_none()
             && self.model.is_none()
@@ -485,6 +550,12 @@ impl AgentContext {
             && self.session_id.is_none()
             && self.turn_id.is_none()
             && self.task.is_none()
+            && self.client_platform.is_none()
+            && self.client_os.is_none()
+            && self.client_host.is_none()
+            && self.auth_subject.is_none()
+            && self.source_ip.is_none()
+            && self.forwarded_for.is_empty()
             && self.user_intent_summary.is_none()
             && self.agent_reply_summary.is_none()
             && self.user_input_hash.is_none()
@@ -502,9 +573,13 @@ impl AgentContext {
     }
 
     fn normalise(mut self) -> Self {
+        self.actor_id = self.actor_id.map(bound_context_string);
+        self.actor_name = self.actor_name.map(bound_context_string);
+        self.actor_email_hash = self.actor_email_hash.map(bound_context_string);
         self.agent_id = self.agent_id.map(bound_context_string);
         self.agent_name = self.agent_name.map(bound_context_string);
         self.agent_kind = self.agent_kind.map(bound_context_string);
+        self.agent_version = self.agent_version.map(bound_context_string);
         self.model_provider = self.model_provider.map(bound_context_string);
         self.model_version = self.model_version.map(bound_context_string);
         self.model = self.model.map(bound_context_string);
@@ -512,6 +587,12 @@ impl AgentContext {
         self.session_id = self.session_id.map(bound_context_string);
         self.turn_id = self.turn_id.map(bound_context_string);
         self.task = self.task.map(bound_context_string);
+        self.client_platform = self.client_platform.map(bound_context_string);
+        self.client_os = self.client_os.map(bound_context_string);
+        self.client_host = self.client_host.map(bound_context_string);
+        self.auth_subject = self.auth_subject.map(bound_context_string);
+        self.source_ip = None;
+        self.forwarded_for.clear();
         self.user_intent_summary = self.user_intent_summary.map(bound_context_string);
         self.agent_reply_summary = self.agent_reply_summary.map(bound_context_string);
         self.user_input_hash = self.user_input_hash.map(bound_context_string);
@@ -568,6 +649,16 @@ fn agent_context_from_header(headers: &HeaderMap) -> Option<AgentContext> {
 }
 
 fn merge_header_agent_context(ctx: &mut AgentContext, headers: &HeaderMap) {
+    if ctx.actor_id.is_none() {
+        ctx.actor_id = header_str(headers, "x-dcc-mcp-actor-id").map(bound_context_string);
+    }
+    if ctx.actor_name.is_none() {
+        ctx.actor_name = header_str(headers, "x-dcc-mcp-actor-name").map(bound_context_string);
+    }
+    if ctx.actor_email_hash.is_none() {
+        ctx.actor_email_hash =
+            header_str(headers, "x-dcc-mcp-actor-email-hash").map(bound_context_string);
+    }
     if ctx.agent_id.is_none() {
         ctx.agent_id = header_str(headers, "x-dcc-mcp-agent-id").map(bound_context_string);
     }
@@ -576,6 +667,10 @@ fn merge_header_agent_context(ctx: &mut AgentContext, headers: &HeaderMap) {
     }
     if ctx.agent_kind.is_none() {
         ctx.agent_kind = header_str(headers, "x-dcc-mcp-agent-kind").map(bound_context_string);
+    }
+    if ctx.agent_version.is_none() {
+        ctx.agent_version =
+            header_str(headers, "x-dcc-mcp-agent-version").map(bound_context_string);
     }
     if ctx.model_provider.is_none() {
         ctx.model_provider = header_str_any(
@@ -617,6 +712,19 @@ fn merge_header_agent_context(ctx: &mut AgentContext, headers: &HeaderMap) {
     }
     if ctx.task.is_none() {
         ctx.task = header_str(headers, "x-dcc-mcp-agent-task").map(bound_context_string);
+    }
+    if ctx.client_platform.is_none() {
+        ctx.client_platform =
+            header_str(headers, "x-dcc-mcp-client-platform").map(bound_context_string);
+    }
+    if ctx.client_os.is_none() {
+        ctx.client_os = header_str(headers, "x-dcc-mcp-client-os").map(bound_context_string);
+    }
+    if ctx.client_host.is_none() {
+        ctx.client_host = header_str(headers, "x-dcc-mcp-client-host").map(bound_context_string);
+    }
+    if ctx.auth_subject.is_none() {
+        ctx.auth_subject = header_str(headers, "x-dcc-mcp-auth-subject").map(bound_context_string);
     }
     if ctx.user_intent_summary.is_none() {
         ctx.user_intent_summary = header_str_any(
@@ -1094,13 +1202,20 @@ mod tests {
     #[test]
     fn agent_context_reads_meta_and_headers() {
         let mut headers = HeaderMap::new();
+        headers.insert("x-dcc-mcp-actor-id", "user-7".parse().unwrap());
+        headers.insert("x-dcc-mcp-actor-name", "Morgan Artist".parse().unwrap());
         headers.insert("x-dcc-mcp-agent-id", "agent-7".parse().unwrap());
+        headers.insert("x-dcc-mcp-agent-version", "0.9.0".parse().unwrap());
         headers.insert("x-dcc-mcp-agent-model", "gpt-test".parse().unwrap());
         headers.insert("x-dcc-mcp-agent-model-provider", "openai".parse().unwrap());
         headers.insert("x-dcc-mcp-agent-turn-id", "turn-9".parse().unwrap());
+        headers.insert("x-dcc-mcp-client-platform", "custom-http".parse().unwrap());
+        headers.insert("x-dcc-mcp-client-os", "windows".parse().unwrap());
+        headers.insert("x-dcc-mcp-auth-subject", "apikey:team-a".parse().unwrap());
         headers.insert("x-dcc-mcp-user-input-chars", "2500".parse().unwrap());
         let meta = json!({
             "agent_context": {
+                "actorEmailHash": "sha256:actor",
                 "agent_name": "Scene Planner",
                 "modelVersion": "gpt-5.1",
                 "reasoningEffort": "medium",
@@ -1118,8 +1233,12 @@ mod tests {
 
         let ctx = AgentContext::from_request_parts(&headers, None, Some(&meta)).unwrap();
 
+        assert_eq!(ctx.actor_id.as_deref(), Some("user-7"));
+        assert_eq!(ctx.actor_name.as_deref(), Some("Morgan Artist"));
+        assert_eq!(ctx.actor_email_hash.as_deref(), Some("sha256:actor"));
         assert_eq!(ctx.agent_id.as_deref(), Some("agent-7"));
         assert_eq!(ctx.agent_name.as_deref(), Some("Scene Planner"));
+        assert_eq!(ctx.agent_version.as_deref(), Some("0.9.0"));
         assert_eq!(ctx.model.as_deref(), Some("gpt-test"));
         assert_eq!(ctx.model_provider.as_deref(), Some("openai"));
         assert_eq!(ctx.model_version.as_deref(), Some("gpt-5.1"));
@@ -1134,11 +1253,15 @@ mod tests {
             ctx.agent_reply_summary.as_deref(),
             Some("I will inspect the scene graph first.")
         );
+        assert_eq!(ctx.client_platform.as_deref(), Some("custom-http"));
+        assert_eq!(ctx.client_os.as_deref(), Some("windows"));
+        assert_eq!(ctx.auth_subject.as_deref(), Some("apikey:team-a"));
         assert_eq!(ctx.user_input_hash.as_deref(), Some("sha256:user"));
         assert_eq!(ctx.agent_reply_hash.as_deref(), Some("sha256:reply"));
         assert_eq!(ctx.user_input_chars, Some(2500));
         assert_eq!(ctx.agent_reply_chars, Some(140));
         assert_eq!(ctx.plan.len(), 2);
+        assert_eq!(ctx.display_name(), Some("Morgan Artist"));
     }
 
     #[test]
@@ -1150,6 +1273,93 @@ mod tests {
 
         assert_eq!(ctx.reasoning_summary.as_deref(), Some("manual smoke test"));
         assert_eq!(ctx.display_name(), None);
+    }
+
+    #[test]
+    fn caller_attribution_handles_missing_partial_and_malformed_metadata() {
+        let headers = HeaderMap::new();
+        assert!(AgentContext::from_request_parts(&headers, None, None).is_none());
+
+        let partial = json!({
+            "caller_context": {
+                "actor_id": "artist-1"
+            }
+        });
+        let partial_ctx = AgentContext::from_request_parts(&headers, Some(&partial), None).unwrap();
+        assert_eq!(partial_ctx.actor_id.as_deref(), Some("artist-1"));
+        assert_eq!(partial_ctx.agent_id, None);
+        assert_eq!(partial_ctx.source_ip, None);
+
+        let mut header_fallback = HeaderMap::new();
+        header_fallback.insert("x-dcc-mcp-client-platform", "studio-tool".parse().unwrap());
+        let malformed = json!({
+            "caller_context": {
+                "actor_id": { "nested": "not a string" }
+            }
+        });
+        let ctx =
+            AgentContext::from_request_parts(&header_fallback, Some(&malformed), None).unwrap();
+        assert_eq!(ctx.actor_id, None);
+        assert_eq!(ctx.client_platform.as_deref(), Some("studio-tool"));
+    }
+
+    #[test]
+    fn caller_attribution_bounds_fields_and_ignores_client_network_source() {
+        let headers = HeaderMap::new();
+        let long_actor = "artist".repeat(MAX_AGENT_CONTEXT_STRING_BYTES);
+        let body = json!({
+            "caller_context": {
+                "actorId": long_actor,
+                "actorName": "Morgan Artist",
+                "agentId": "agent-camel",
+                "agentVersion": "1.2.3",
+                "agentModel": "gpt-test",
+                "clientPlatform": "cursor",
+                "clientOs": "macos",
+                "clientHost": "workstation-42",
+                "authSubject": "oauth:user-7",
+                "sourceIp": "203.0.113.99",
+                "forwardedFor": ["198.51.100.10"]
+            }
+        });
+
+        let ctx = AgentContext::from_request_parts(&headers, Some(&body), None).unwrap();
+
+        assert!(
+            ctx.actor_id.as_ref().unwrap().len() <= MAX_AGENT_CONTEXT_STRING_BYTES,
+            "actor_id should be bounded"
+        );
+        assert_eq!(ctx.actor_name.as_deref(), Some("Morgan Artist"));
+        assert_eq!(ctx.agent_id.as_deref(), Some("agent-camel"));
+        assert_eq!(ctx.agent_version.as_deref(), Some("1.2.3"));
+        assert_eq!(ctx.model.as_deref(), Some("gpt-test"));
+        assert_eq!(ctx.client_platform.as_deref(), Some("cursor"));
+        assert_eq!(ctx.client_os.as_deref(), Some("macos"));
+        assert_eq!(ctx.client_host.as_deref(), Some("workstation-42"));
+        assert_eq!(ctx.auth_subject.as_deref(), Some("oauth:user-7"));
+        assert_eq!(ctx.source_ip, None, "source_ip must be server-derived");
+        assert!(
+            ctx.forwarded_for.is_empty(),
+            "forwarded_for must be server-derived"
+        );
+    }
+
+    #[test]
+    fn caller_attribution_network_source_can_be_added_by_server_boundary() {
+        let ctx = AgentContext {
+            actor_id: Some("user-7".to_string()),
+            ..AgentContext::default()
+        }
+        .with_server_network_source(
+            Some("192.0.2.44".to_string()),
+            vec!["198.51.100.2".to_string(), "203.0.113.3".to_string()],
+        );
+
+        assert_eq!(ctx.source_ip.as_deref(), Some("192.0.2.44"));
+        assert_eq!(
+            ctx.forwarded_for,
+            vec!["198.51.100.2".to_string(), "203.0.113.3".to_string()]
+        );
     }
 
     #[test]

--- a/crates/dcc-mcp-gateway/src/gateway/agent_telemetry.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/agent_telemetry.rs
@@ -29,9 +29,13 @@ pub(crate) struct AgentWorkflowEvent {
     request_id: Option<String>,
     parent_request_id: Option<String>,
     session_id: Option<String>,
+    actor_id: Option<String>,
+    actor_name: Option<String>,
+    actor_email_hash: Option<String>,
     agent_id: Option<String>,
     agent_name: Option<String>,
     agent_kind: Option<String>,
+    agent_version: Option<String>,
     agent_model_provider: Option<String>,
     agent_model_version: Option<String>,
     agent_model: Option<String>,
@@ -45,6 +49,12 @@ pub(crate) struct AgentWorkflowEvent {
     agent_reply_chars: Option<u64>,
     agent_task: Option<String>,
     agent_tags: Vec<String>,
+    client_platform: Option<String>,
+    client_os: Option<String>,
+    client_host: Option<String>,
+    auth_subject: Option<String>,
+    source_ip: Option<String>,
+    forwarded_for: Vec<String>,
     dcc_type: Option<String>,
     instance_id: Option<String>,
     skill_name: Option<String>,
@@ -72,9 +82,13 @@ impl AgentWorkflowEvent {
             request_id: None,
             parent_request_id: None,
             session_id: None,
+            actor_id: None,
+            actor_name: None,
+            actor_email_hash: None,
             agent_id: None,
             agent_name: None,
             agent_kind: None,
+            agent_version: None,
             agent_model_provider: None,
             agent_model_version: None,
             agent_model: None,
@@ -88,6 +102,12 @@ impl AgentWorkflowEvent {
             agent_reply_chars: None,
             agent_task: None,
             agent_tags: Vec::new(),
+            client_platform: None,
+            client_os: None,
+            client_host: None,
+            auth_subject: None,
+            source_ip: None,
+            forwarded_for: Vec::new(),
             dcc_type: None,
             instance_id: None,
             skill_name: None,
@@ -118,9 +138,13 @@ impl AgentWorkflowEvent {
 
     pub(crate) fn with_agent_context(mut self, agent_context: Option<&AgentContext>) -> Self {
         if let Some(ctx) = agent_context {
+            self.actor_id = ctx.actor_id.clone();
+            self.actor_name = ctx.actor_name.clone();
+            self.actor_email_hash = ctx.actor_email_hash.clone();
             self.agent_id = ctx.agent_id.clone();
             self.agent_name = ctx.agent_name.clone();
             self.agent_kind = ctx.agent_kind.clone();
+            self.agent_version = ctx.agent_version.clone();
             self.agent_model_provider = ctx.model_provider.clone();
             self.agent_model_version = ctx.model_version.clone();
             self.agent_model = ctx.model.clone();
@@ -134,6 +158,12 @@ impl AgentWorkflowEvent {
             self.agent_reply_chars = ctx.agent_reply_chars;
             self.agent_task = ctx.task.clone();
             self.agent_tags = ctx.tags.iter().take(16).cloned().collect();
+            self.client_platform = ctx.client_platform.clone();
+            self.client_os = ctx.client_os.clone();
+            self.client_host = ctx.client_host.clone();
+            self.auth_subject = ctx.auth_subject.clone();
+            self.source_ip = ctx.source_ip.clone();
+            self.forwarded_for = ctx.forwarded_for.iter().take(16).cloned().collect();
             if self.session_id.is_none() {
                 self.session_id = ctx.session_id.clone();
             }
@@ -295,9 +325,21 @@ impl AgentWorkflowEvent {
             self.parent_request_id.as_deref(),
         );
         insert_opt(&mut attrs, "dcc_mcp.session_id", self.session_id.as_deref());
+        insert_opt(&mut attrs, "dcc_mcp.actor.id", self.actor_id.as_deref());
+        insert_opt(&mut attrs, "dcc_mcp.actor.name", self.actor_name.as_deref());
+        insert_opt(
+            &mut attrs,
+            "dcc_mcp.actor.email_hash",
+            self.actor_email_hash.as_deref(),
+        );
         insert_opt(&mut attrs, "dcc_mcp.agent.id", self.agent_id.as_deref());
         insert_opt(&mut attrs, "dcc_mcp.agent.name", self.agent_name.as_deref());
         insert_opt(&mut attrs, "dcc_mcp.agent.kind", self.agent_kind.as_deref());
+        insert_opt(
+            &mut attrs,
+            "dcc_mcp.agent.version",
+            self.agent_version.as_deref(),
+        );
         insert_opt(
             &mut attrs,
             "dcc_mcp.agent.model_provider",
@@ -356,6 +398,29 @@ impl AgentWorkflowEvent {
         insert_opt(&mut attrs, "dcc_mcp.agent.task", self.agent_task.as_deref());
         if !self.agent_tags.is_empty() {
             attrs.insert("dcc_mcp.agent.tags".to_string(), json!(self.agent_tags));
+        }
+        insert_opt(
+            &mut attrs,
+            "dcc_mcp.client.platform",
+            self.client_platform.as_deref(),
+        );
+        insert_opt(&mut attrs, "dcc_mcp.client.os", self.client_os.as_deref());
+        insert_opt(
+            &mut attrs,
+            "dcc_mcp.client.host",
+            self.client_host.as_deref(),
+        );
+        insert_opt(
+            &mut attrs,
+            "dcc_mcp.auth.subject",
+            self.auth_subject.as_deref(),
+        );
+        insert_opt(&mut attrs, "dcc_mcp.source.ip", self.source_ip.as_deref());
+        if !self.forwarded_for.is_empty() {
+            attrs.insert(
+                "dcc_mcp.forwarded_for".to_string(),
+                json!(self.forwarded_for),
+            );
         }
         insert_opt(&mut attrs, "dcc_mcp.dcc.type", self.dcc_type.as_deref());
         insert_opt(
@@ -895,9 +960,13 @@ mod tests {
         let event = AgentWorkflowEvent::new("gateway.search", "rest")
             .with_trace_context(Some(&trace_context()))
             .with_agent_context(Some(&AgentContext {
+                actor_id: Some("user-1".to_string()),
+                actor_name: Some("Morgan Artist".to_string()),
+                actor_email_hash: Some("sha256:actor".to_string()),
                 agent_id: Some("agent-1".to_string()),
                 agent_name: Some("Codex".to_string()),
                 agent_kind: Some("coding-agent".to_string()),
+                agent_version: Some("0.9.0".to_string()),
                 model_provider: Some("openai".to_string()),
                 model_version: Some("gpt-5.1".to_string()),
                 model: Some("gpt-5".to_string()),
@@ -911,6 +980,12 @@ mod tests {
                 user_input_chars: Some(2048),
                 agent_reply_chars: Some(512),
                 task: Some("fix issue 1180".to_string()),
+                client_platform: Some("cursor".to_string()),
+                client_os: Some("windows".to_string()),
+                client_host: Some("workstation-42".to_string()),
+                auth_subject: Some("oauth:user-1".to_string()),
+                source_ip: Some("192.0.2.44".to_string()),
+                forwarded_for: vec!["198.51.100.7".to_string()],
                 reasoning_summary: Some("do not export me".to_string()),
                 tags: vec!["ci".to_string(), "gateway".to_string()],
                 metadata: json!({"api_key": "secret"}),
@@ -924,7 +999,11 @@ mod tests {
         let attrs = event.attributes();
         assert_eq!(attrs["dcc_mcp.workflow.operation"], "gateway.search");
         assert_eq!(attrs["dcc_mcp.session_id"], "session-1");
+        assert_eq!(attrs["dcc_mcp.actor.id"], "user-1");
+        assert_eq!(attrs["dcc_mcp.actor.name"], "Morgan Artist");
+        assert_eq!(attrs["dcc_mcp.actor.email_hash"], "sha256:actor");
         assert_eq!(attrs["dcc_mcp.agent.id"], "agent-1");
+        assert_eq!(attrs["dcc_mcp.agent.version"], "0.9.0");
         assert_eq!(attrs["dcc_mcp.agent.model_provider"], "openai");
         assert_eq!(attrs["dcc_mcp.agent.model_version"], "gpt-5.1");
         assert_eq!(attrs["dcc_mcp.agent.reasoning_effort"], "high");
@@ -942,6 +1021,12 @@ mod tests {
         assert_eq!(attrs["dcc_mcp.agent.user_input_chars"], 2048);
         assert_eq!(attrs["dcc_mcp.agent.reply_chars"], 512);
         assert_eq!(attrs["dcc_mcp.agent.tags"], json!(["ci", "gateway"]));
+        assert_eq!(attrs["dcc_mcp.client.platform"], "cursor");
+        assert_eq!(attrs["dcc_mcp.client.os"], "windows");
+        assert_eq!(attrs["dcc_mcp.client.host"], "workstation-42");
+        assert_eq!(attrs["dcc_mcp.auth.subject"], "oauth:user-1");
+        assert_eq!(attrs["dcc_mcp.source.ip"], "192.0.2.44");
+        assert_eq!(attrs["dcc_mcp.forwarded_for"], json!(["198.51.100.7"]));
         assert_eq!(attrs["dcc_mcp.search.id"], "search-1");
         assert_eq!(attrs["dcc_mcp.search.zero_results"], true);
         assert!(!attrs.contains_key("dcc_mcp.agent.reasoning_summary"));

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -214,16 +214,36 @@ Supported carriers:
 - MCP `tools/call` `params._meta.agent_context`
 - REST body `agent_context`, `agentContext`, `caller_context`, or
   `meta.agent_context`
-- Headers such as `x-dcc-mcp-agent-id`, `x-dcc-mcp-agent-name`,
-  `x-dcc-mcp-agent-model`, `x-dcc-mcp-agent-model-provider`,
-  `x-dcc-mcp-agent-model-version`, `x-dcc-mcp-agent-reasoning-effort`,
-  `x-dcc-mcp-agent-session-id`, `x-dcc-mcp-agent-turn-id`,
-  `x-dcc-mcp-agent-user-intent-summary`,
+- Headers such as `x-dcc-mcp-actor-id`, `x-dcc-mcp-actor-name`,
+  `x-dcc-mcp-actor-email-hash`, `x-dcc-mcp-agent-id`,
+  `x-dcc-mcp-agent-name`, `x-dcc-mcp-agent-kind`,
+  `x-dcc-mcp-agent-version`, `x-dcc-mcp-agent-model`,
+  `x-dcc-mcp-agent-model-provider`, `x-dcc-mcp-agent-model-version`,
+  `x-dcc-mcp-agent-reasoning-effort`, `x-dcc-mcp-client-platform`,
+  `x-dcc-mcp-client-os`, `x-dcc-mcp-client-host`,
+  `x-dcc-mcp-auth-subject`, `x-dcc-mcp-agent-session-id`,
+  `x-dcc-mcp-agent-turn-id`, `x-dcc-mcp-agent-user-intent-summary`,
   `x-dcc-mcp-agent-reply-summary`, `x-dcc-mcp-agent-user-input-hash`,
   `x-dcc-mcp-agent-reply-hash`, `x-dcc-mcp-agent-user-input-chars`,
   `x-dcc-mcp-agent-reply-chars`, `x-dcc-mcp-agent-task`,
   `x-dcc-mcp-reasoning-summary`, `x-dcc-mcp-parent-request-id`, and
   `x-dcc-mcp-agent-context` (JSON object)
+
+Caller attribution separates five concepts:
+
+| Concept | Fields | Notes |
+| --- | --- | --- |
+| Human or service actor | `actor_id`, `actor_name`, `actor_email_hash` | Optional, bounded identifiers. Hash email addresses before sending them. |
+| Agent runtime | `agent_id`, `agent_name`, `agent_kind`, `agent_version`, `model`, `model_provider`, `model_version` | `model` also accepts `agentModel`; `model_version` also accepts `agentModelVersion`. |
+| Client platform | `client_platform`, `client_os`, `client_host` | Examples: `cursor`, `claude-desktop`, `openclaw`, `clawhub`, `custom-http`, `studio-tool`. |
+| Auth subject | `auth_subject` | API-key, bearer-token, OAuth, or local identity subject after authentication. |
+| Network source | `source_ip`, `forwarded_for` | Server-derived only. MCP `_meta`, REST request bodies, and caller headers cannot set these fields. |
+
+Cursor-like MCP clients can place attribution in `_meta.agent_context`, custom
+REST clients can use `meta.agent_context`, and LAN studio tools that cannot
+shape JSON bodies can use the `x-dcc-mcp-*` headers above. Do not send hidden
+reasoning, full prompts, raw user messages, secrets, bearer tokens, or raw agent
+replies in any caller-attribution field.
 
 Example REST request:
 
@@ -233,8 +253,17 @@ Example REST request:
   "arguments": { "include_materials": true },
   "meta": {
     "agent_context": {
+      "actor_id": "artist-42",
+      "actor_name": "Morgan Artist",
+      "actor_email_hash": "sha256:...",
       "agent_id": "agent-42",
       "agent_name": "Layout Inspector",
+      "agent_kind": "coding-agent",
+      "agent_version": "0.9.0",
+      "client_platform": "custom-http",
+      "client_os": "windows",
+      "client_host": "workstation-42",
+      "auth_subject": "apikey:team-layout",
       "model_provider": "openai",
       "model_version": "gpt-5.1",
       "model": "gpt-5.4",

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -65,7 +65,10 @@ gateway-specific fields:
 | `dcc_mcp.workflow.operation` | One of the span names above. |
 | `dcc_mcp.transport` | `rest` or `mcp`. |
 | `dcc_mcp.trace_id`, `dcc_mcp.request_id`, `dcc_mcp.parent_request_id`, `dcc_mcp.session_id` | Correlation IDs that match Admin trace/debug-bundle surfaces. |
-| `dcc_mcp.agent.id`, `.name`, `.kind`, `.model`, `.model_provider`, `.model_version`, `.reasoning_effort`, `.turn_id`, `.task`, `.tags` | Bounded `agent_context` / caller metadata. |
+| `dcc_mcp.actor.id`, `.name`, `.email_hash` | Bounded human/service actor attribution when supplied. |
+| `dcc_mcp.agent.id`, `.name`, `.kind`, `.version`, `.model`, `.model_provider`, `.model_version`, `.reasoning_effort`, `.turn_id`, `.task`, `.tags` | Bounded agent runtime metadata. |
+| `dcc_mcp.client.platform`, `.os`, `.host`, `dcc_mcp.auth.subject` | Bounded client-surface and authenticated-subject metadata. |
+| `dcc_mcp.source.ip`, `dcc_mcp.forwarded_for` | Server-derived network source fields after proxy trust policy has been applied. |
 | `dcc_mcp.agent.user_intent_summary`, `.reply_summary`, `.user_input_hash`, `.reply_hash`, `.user_input_chars`, `.reply_chars` | Low-sensitivity turn summaries, hashes, and lengths for evaluation correlation. |
 | `dcc_mcp.dcc.type`, `dcc_mcp.instance.id`, `dcc_mcp.skill.name`, `dcc_mcp.tool.slug` | Selected DCC route and skill/tool identity. |
 | `dcc_mcp.search.id`, `.ranker_version`, `.selected_rank`, `.score`, `.match_reasons`, `.total`, `.zero_results` | Search-quality context carried from `/v1/search` or gateway `search`. |
@@ -239,13 +242,17 @@ By default these buffers are in memory only. Set `DCC_MCP_GATEWAY_AUDIT_DIR` to 
 MCP and REST clients can attach optional agent/caller context to correlate an
 operator-visible request with the caller's explicit plan and observations. Use
 `params._meta.agent_context` for MCP, REST `meta.agent_context` or
-`caller_context` fields, or `x-dcc-mcp-agent-*` headers. Fields are bounded and
-intended for concise telemetry such as `agent_id`, `agent_name`,
-`model_provider`, `model_version`, `model`, `reasoning_effort`, `session_id`,
-`turn_id`, `user_intent_summary`, `agent_reply_summary`, `user_input_hash`,
+`caller_context` fields, or `x-dcc-mcp-*` attribution headers. Fields are
+bounded and intended for concise telemetry such as `actor_id`, `actor_name`,
+`actor_email_hash`, `agent_id`, `agent_name`, `agent_kind`, `agent_version`,
+`client_platform`, `client_os`, `client_host`, `auth_subject`, `model_provider`,
+`model_version`, `model`, `reasoning_effort`, `session_id`, `turn_id`,
+`user_intent_summary`, `agent_reply_summary`, `user_input_hash`,
 `agent_reply_hash`, `user_input_chars`, `agent_reply_chars`, `task`,
-`reasoning_summary`, `plan`, `observations`, `parent_request_id`, and tags; do
-not send hidden chain-of-thought, raw user input, raw agent replies, or secrets.
+`reasoning_summary`, `plan`, `observations`, `parent_request_id`, and tags.
+`source_ip` and `forwarded_for` are server-derived only after proxy trust policy
+has been applied; caller-supplied request metadata cannot set them. Do not send
+hidden chain-of-thought, raw user input, raw agent replies, or secrets.
 `trace_id`, `request_id`,
 `span_id`, and `parent_span_id` are recorded separately so one trace can contain
 multiple request ids without losing per-request compatibility. Admin call and trace rows

--- a/docs/guide/rest-api-surface.md
+++ b/docs/guide/rest-api-surface.md
@@ -412,6 +412,29 @@ Search responses also include `search_id`, `ranker_version`, and
 `/v1/describe`, `/v1/load_skill`, `/v1/call`, or `/v1/call_batch` so gateway
 telemetry can measure the search-to-action path without storing full prompts.
 
+### Caller Attribution
+
+REST callers may add bounded caller attribution in `meta.agent_context`,
+top-level `agent_context` / `caller_context`, or headers. MCP callers use the
+same shape in `params._meta.agent_context`. This schema is metadata only; do
+not send hidden reasoning, full prompts, raw user messages, secrets, bearer
+tokens, or raw agent replies.
+
+| Concept | JSON fields | Header fields |
+|---|---|---|
+| Actor | `actor_id`, `actor_name`, `actor_email_hash` | `x-dcc-mcp-actor-id`, `x-dcc-mcp-actor-name`, `x-dcc-mcp-actor-email-hash` |
+| Agent runtime | `agent_id`, `agent_name`, `agent_kind`, `agent_version`, `model`, `model_provider`, `model_version` | `x-dcc-mcp-agent-id`, `x-dcc-mcp-agent-name`, `x-dcc-mcp-agent-kind`, `x-dcc-mcp-agent-version`, `x-dcc-mcp-agent-model`, `x-dcc-mcp-agent-model-provider`, `x-dcc-mcp-agent-model-version` |
+| Client platform | `client_platform`, `client_os`, `client_host` | `x-dcc-mcp-client-platform`, `x-dcc-mcp-client-os`, `x-dcc-mcp-client-host` |
+| Auth subject | `auth_subject` | `x-dcc-mcp-auth-subject` |
+| Network source | `source_ip`, `forwarded_for` | Server-derived only |
+
+All string fields are bounded before storage. `source_ip` and `forwarded_for`
+are reserved for server-derived network data after proxy trust policy has been
+applied; values supplied in REST request bodies, MCP `_meta`, or caller headers
+are ignored. Use `client_platform` values such as `cursor`, `claude-desktop`,
+`openclaw`, `clawhub`, `custom-http`, or `studio-tool` to distinguish surfaces
+without overloading agent identity.
+
 ---
 
 ## `POST /v1/call_batch` — gateway ordered batches
@@ -490,10 +513,11 @@ Rules:
   `meta.search_id`, `meta.ranker_version`, and `meta.index_generation` for
   follow-up calls; clients may also pass the same object as MCP `_meta`.
 - Optional `meta.agent_context`, top-level `caller_context`, or
-  `x-dcc-mcp-agent-*` headers carry bounded turn metadata for Admin workflow,
-  search-quality, and OTLP correlation. Send concise summaries, hashes, and
-  character counts only; raw user input and raw agent replies are high
-  sensitivity and belong only in an explicit redacted traffic-capture flow.
+  `x-dcc-mcp-*` attribution headers carry bounded actor, agent, client, auth,
+  and turn metadata for Admin workflow, search-quality, and OTLP correlation.
+  Send concise summaries, hashes, and character counts only; raw user input and
+  raw agent replies are high sensitivity and belong only in an explicit
+  redacted traffic-capture flow.
 - Full `input_schema` remains behind `describe`. Search may carry only bounded
   `metadata.dcc.searchAliases` / `metadata.dcc.searchTokens` hints from a
   per-DCC backend to the gateway index; gateway search responses do not expose

--- a/docs/zh/guide/observability.md
+++ b/docs/zh/guide/observability.md
@@ -62,7 +62,10 @@ OTEL_SERVICE_NAME=dcc-mcp-gateway \
 | `dcc_mcp.workflow.operation` | 上表中的 span 名称。 |
 | `dcc_mcp.transport` | `rest` 或 `mcp`。 |
 | `dcc_mcp.trace_id`、`dcc_mcp.request_id`、`dcc_mcp.parent_request_id`、`dcc_mcp.session_id` | 与 Admin trace/debug bundle 对齐的关联 ID。 |
-| `dcc_mcp.agent.id`、`.name`、`.kind`、`.model`、`.model_provider`、`.model_version`、`.reasoning_effort`、`.turn_id`、`.task`、`.tags` | 有界的 `agent_context` / caller 元数据。 |
+| `dcc_mcp.actor.id`、`.name`、`.email_hash` | 有界的人类或服务账号 actor 归因。 |
+| `dcc_mcp.agent.id`、`.name`、`.kind`、`.version`、`.model`、`.model_provider`、`.model_version`、`.reasoning_effort`、`.turn_id`、`.task`、`.tags` | 有界的 agent runtime 元数据。 |
+| `dcc_mcp.client.platform`、`.os`、`.host`、`dcc_mcp.auth.subject` | 有界的客户端入口与认证主体元数据。 |
+| `dcc_mcp.source.ip`、`dcc_mcp.forwarded_for` | 应用 proxy trust policy 后由服务端派生的网络来源字段。 |
 | `dcc_mcp.agent.user_intent_summary`、`.reply_summary`、`.user_input_hash`、`.reply_hash`、`.user_input_chars`、`.reply_chars` | 用于评估关联的低敏 turn 摘要、哈希和长度。 |
 | `dcc_mcp.dcc.type`、`dcc_mcp.instance.id`、`dcc_mcp.skill.name`、`dcc_mcp.tool.slug` | 选中的 DCC 路由与技能/工具身份。 |
 | `dcc_mcp.search.id`、`.ranker_version`、`.selected_rank`、`.score`、`.match_reasons`、`.total`、`.zero_results` | 从 `/v1/search` 或 gateway `search` 继承的搜索质量上下文。 |

--- a/docs/zh/guide/rest-api-surface.md
+++ b/docs/zh/guide/rest-api-surface.md
@@ -282,6 +282,25 @@ Search response 还会包含 `search_id`、`ranker_version` 和
 `/v1/call_batch` 应把 `next_step` 中的 `meta.search_id` 原样传回，
 这样 gateway 可以统计 search-to-action 质量，同时不记录完整 prompt。
 
+### Caller Attribution
+
+REST 调用方可以在 `meta.agent_context`、顶层 `agent_context` /
+`caller_context`，或 `x-dcc-mcp-*` headers 中提供有界归因元数据。MCP
+调用方使用同样的 shape，放在 `params._meta.agent_context`。这些字段只用于
+遥测和 Admin 调试；不要发送隐藏推理、完整 prompt、原始用户消息、secret、
+bearer token 或原始 agent 回复。
+
+| 概念 | JSON 字段 | Header 字段 |
+|---|---|---|
+| Actor | `actor_id`、`actor_name`、`actor_email_hash` | `x-dcc-mcp-actor-id`、`x-dcc-mcp-actor-name`、`x-dcc-mcp-actor-email-hash` |
+| Agent runtime | `agent_id`、`agent_name`、`agent_kind`、`agent_version`、`model`、`model_provider`、`model_version` | `x-dcc-mcp-agent-id`、`x-dcc-mcp-agent-name`、`x-dcc-mcp-agent-kind`、`x-dcc-mcp-agent-version`、`x-dcc-mcp-agent-model`、`x-dcc-mcp-agent-model-provider`、`x-dcc-mcp-agent-model-version` |
+| Client platform | `client_platform`、`client_os`、`client_host` | `x-dcc-mcp-client-platform`、`x-dcc-mcp-client-os`、`x-dcc-mcp-client-host` |
+| Auth subject | `auth_subject` | `x-dcc-mcp-auth-subject` |
+| Network source | `source_ip`、`forwarded_for` | 仅服务端派生 |
+
+`source_ip` 和 `forwarded_for` 必须在 transport 边界按 proxy trust policy
+派生；REST body、MCP `_meta` 或 caller headers 中提供的同名字段会被忽略。
+
 ---
 
 ## `POST /v1/search` —— compact discovery

--- a/skills/dcc-mcp-skill-developer/SKILL.md
+++ b/skills/dcc-mcp-skill-developer/SKILL.md
@@ -94,12 +94,19 @@ into a faster authoring loop.
    boundaries.
 7. When changing adapter server wiring or caller examples, keep Admin telemetry
    useful: pass optional `agent_context` / `caller_context` summaries through
-   MCP `_meta`, REST `meta`, or `x-dcc-mcp-agent-*` headers when the caller is
-   an agent. Include only explicit summaries, plans, observations, model
-   identity (`model_provider`, `model_version`, optional legacy `model`),
+   MCP `_meta`, REST `meta`, `x-dcc-mcp-agent-*`, `x-dcc-mcp-actor-*`, or
+   `x-dcc-mcp-client-*` headers when the caller is an agent. Include only
+   explicit summaries, plans, observations, actor identity
+   (`actor_id`, `actor_name`, optional `actor_email_hash`), agent identity
+   (`agent_id`, `agent_name`, `agent_kind`, `agent_version`,
+   `model_provider`, `model_version`, optional legacy `model`), client
+   identity (`client_platform`, `client_os`, `client_host`), auth subject,
    turn correlation (`session_id`, `turn_id`), hashes, character counts, and
    correlation ids; never ask tools to expose hidden chain-of-thought, raw user
-   input, or raw agent replies. Preserve
+   input, or raw agent replies. Treat `source_ip` and `forwarded_for` as
+   server-derived fields only: caller metadata and examples must not spoof
+   them, and adapters should let the HTTP/gateway boundary attach those values.
+   Preserve
    Admin `links` fields in examples so every trace/debug bundle, OpenAPI
    Inspector/spec link, or issue-report JSON export can be copied as a complete
    URL into a follow-up agent, LLM evaluation prompt, or GitHub issue. When an
@@ -168,13 +175,15 @@ into a faster authoring loop.
    Gateway OTLP spans mirror the same agent workflow chain with bounded
    attributes: `gateway.search`, `gateway.describe`, `gateway.load_skill`,
    `gateway.call`, and `gateway.call_batch` use `openinference.span.kind` plus
-   `dcc_mcp.*` fields for agent id/name/kind/model provider/model version/
-   reasoning effort/turn id/task/tags, bounded user-intent and reply summaries,
-   user/reply hashes and character counts, DCC route,
-   `search_id`, selected rank/score/match reasons, policy outcome, and
-   success/error kind. Adapter docs and examples should preserve those
-   correlation fields but must not put hidden reasoning, secrets, raw prompts,
-   raw agent replies, or unbounded request bodies into `agent_context` metadata.
+   `dcc_mcp.*` fields for actor id/name/email hash, agent
+   id/name/kind/version/model provider/model version/reasoning effort, client
+   platform/os/host, auth subject, server-derived source ip/forwarded-for,
+   turn id/task/tags, bounded user-intent and reply summaries, user/reply
+   hashes and character counts, DCC route, `search_id`, selected
+   rank/score/match reasons, policy outcome, and success/error kind. Adapter
+   docs and examples should preserve those correlation fields but must not put
+   hidden reasoning, secrets, raw prompts, raw agent replies, or unbounded
+   request bodies into `agent_context` metadata.
    Raw prompt/reply capture belongs only in an explicitly configured traffic
    capture policy with redaction, sampling, retention, and clear Admin
    visibility.
@@ -343,7 +352,7 @@ into a faster authoring loop.
     app_ui roles, keep raw coordinate and keyboard shortcut fallbacks disabled
     by default, and skip live UIA tests cleanly when Windows accessibility APIs
     are unavailable.
-15. For headless USD/OpenUSD-style adapters, expose filesystem-backed project
+16. For headless USD/OpenUSD-style adapters, expose filesystem-backed project
     state with `register_usd_project_resources(...)` instead of inventing
     adapter-local URI shapes. Keep the canonical `openusd://stage`,
     `openusd://layers`, `openusd://assets`, `openusd://materials`,


### PR DESCRIPTION
## Summary
- Define bounded actor, agent, client, auth, and server-derived network attribution fields for gateway agent context.
- Preserve existing agent_context compatibility while rejecting client-supplied source_ip and forwarded_for metadata.
- Add OTLP attribute coverage plus English/Chinese docs and skill-developer guidance for the MCP, REST, and header carriers.

Closes #1260

## Validation
- `vx cargo fmt --all`
- `vx cargo test -p dcc-mcp-gateway caller_attribution -- --nocapture`
- `vx cargo test -p dcc-mcp-gateway agent_context -- --nocapture`
- `vx cargo test -p dcc-mcp-gateway attributes_include_bounded_agent_and_search_fields_without_reasoning_payloads -- --nocapture`
- `vx cargo clippy -p dcc-mcp-gateway --all-targets -- -D warnings -A dead-code`
- `vx npx markdownlint-cli2 "docs/guide/admin-ui.md" "docs/guide/rest-api-surface.md" "docs/guide/observability.md" "docs/zh/guide/observability.md" "docs/zh/guide/rest-api-surface.md" "skills/dcc-mcp-skill-developer/SKILL.md"`
- `vx git diff --check`