### PR TITLE
feat: propagate caller attribution

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/admin/trace.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/trace.rs
@@ -98,6 +98,18 @@ impl TraceContext {
         span
     }
 
+    pub fn child_request(&self, request_id: impl Into<String>) -> Self {
+        Self {
+            trace_id: self.trace_id.clone(),
+            request_id: request_id.into(),
+            span_id: Some(new_span_id()),
+            parent_span_id: self.span_id.clone(),
+            parent_request_id: Some(self.request_id.clone()),
+            trace_flags: self.trace_flags.clone(),
+            trace_state: self.trace_state.clone(),
+        }
+    }
+
     pub fn traceparent(&self) -> Option<String> {
         let span_id = self.span_id.as_deref()?;
         Some(format!(
@@ -512,6 +524,17 @@ impl AgentContext {
             .unwrap_or_default();
 
         merge_header_agent_context(&mut ctx, headers);
+        if ctx.is_empty() { None } else { Some(ctx) }
+    }
+
+    pub fn from_request_parts_with_server_network(
+        headers: &HeaderMap,
+        body: Option<&Value>,
+        meta: Option<&Value>,
+    ) -> Option<Self> {
+        let mut ctx = Self::from_request_parts(headers, body, meta).unwrap_or_default();
+        let network = crate::gateway::caller_attribution::internal_network_attribution(headers);
+        ctx = ctx.with_server_network_source(network.source_ip, network.forwarded_for);
         if ctx.is_empty() { None } else { Some(ctx) }
     }
 
@@ -1363,6 +1386,36 @@ mod tests {
     }
 
     #[test]
+    fn caller_attribution_reads_only_internal_server_network_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-dcc-mcp-source-ip", "203.0.113.99".parse().unwrap());
+        headers.insert(
+            crate::gateway::caller_attribution::INTERNAL_SOURCE_IP_HEADER,
+            "192.0.2.44".parse().unwrap(),
+        );
+        headers.insert(
+            crate::gateway::caller_attribution::INTERNAL_FORWARDED_FOR_HEADER,
+            "198.51.100.2, 203.0.113.3".parse().unwrap(),
+        );
+        let body = json!({
+            "caller_context": {
+                "actor_id": "artist-1",
+                "sourceIp": "203.0.113.100"
+            }
+        });
+
+        let ctx = AgentContext::from_request_parts_with_server_network(&headers, Some(&body), None)
+            .unwrap();
+
+        assert_eq!(ctx.actor_id.as_deref(), Some("artist-1"));
+        assert_eq!(ctx.source_ip.as_deref(), Some("192.0.2.44"));
+        assert_eq!(
+            ctx.forwarded_for,
+            vec!["198.51.100.2".to_string(), "203.0.113.3".to_string()]
+        );
+    }
+
+    #[test]
     fn agent_context_bounds_turn_summaries_and_excludes_raw_text() {
         let headers = HeaderMap::new();
         let raw_prompt = "secret production prompt".to_string();
@@ -1431,6 +1484,26 @@ mod tests {
         assert_eq!(ctx.span_id.as_deref().unwrap_or_default().len(), 16);
         assert!(!ctx.request_id.is_empty());
         assert!(ctx.traceparent().is_some());
+    }
+
+    #[test]
+    fn trace_context_child_request_preserves_trace_with_distinct_request_id() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-request-id", "batch-parent".parse().unwrap());
+        headers.insert(
+            "traceparent",
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+                .parse()
+                .unwrap(),
+        );
+        let parent = TraceContext::from_headers(&headers);
+        let child = parent.child_request("batch-parent:batch-0");
+
+        assert_eq!(child.trace_id, parent.trace_id);
+        assert_eq!(child.request_id, "batch-parent:batch-0");
+        assert_eq!(child.parent_request_id.as_deref(), Some("batch-parent"));
+        assert_ne!(child.span_id, parent.span_id);
+        assert_eq!(child.parent_span_id, parent.span_id);
     }
 
     #[test]

--- a/crates/dcc-mcp-gateway/src/gateway/aggregator/call.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/aggregator/call.rs
@@ -39,7 +39,7 @@ pub async fn route_tools_call(
 
     // ── Hidden compatibility routes ──────────────────────────────────
     match tool {
-        "call" => return tool_call(gs, args, meta, trace_context).await,
+        "call" => return tool_call(gs, args, meta, trace_context, agent_context).await,
         "lease" => return to_text_result(tool_lease(gs, args).await),
         "load_skill" => {
             let (text, is_error) = tool_load_skill(gs, args).await;
@@ -68,8 +68,10 @@ pub async fn route_tools_call(
         "describe_tool" => {
             return to_text_result(tool_describe_tool(gs, args, meta, trace_context).await);
         }
-        "call_tool" => return tool_call_tool(gs, args, meta, trace_context).await,
-        "call_tools" => return tool_call_tools(gs, args, meta, trace_context).await,
+        "call_tool" => return tool_call_tool(gs, args, meta, trace_context, agent_context).await,
+        "call_tools" => {
+            return tool_call_tools(gs, args, meta, trace_context, agent_context).await;
+        }
         _ => {}
     }
 

--- a/crates/dcc-mcp-gateway/src/gateway/caller_attribution.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/caller_attribution.rs
@@ -1,0 +1,241 @@
+//! Server-derived caller-attribution helpers for gateway ingress.
+
+use std::net::{IpAddr, SocketAddr};
+
+use axum::body::Body;
+use axum::extract::ConnectInfo;
+use axum::http::{HeaderMap, HeaderValue, Request};
+use axum::middleware::Next;
+use axum::response::Response;
+
+use super::resilience::gateway_limits;
+
+pub(crate) const INTERNAL_SOURCE_IP_HEADER: &str = "x-dcc-mcp-internal-source-ip";
+pub(crate) const INTERNAL_FORWARDED_FOR_HEADER: &str = "x-dcc-mcp-internal-forwarded-for";
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct ClientNetworkAttribution {
+    pub(crate) source_ip: Option<String>,
+    pub(crate) forwarded_for: Vec<String>,
+}
+
+/// Attach server-derived network attribution for downstream handlers.
+///
+/// These internal headers are overwritten at the gateway boundary so external
+/// clients cannot set `source_ip` or `forwarded_for` through ordinary request
+/// metadata. Handlers convert them into `AgentContext` server fields.
+pub(crate) async fn caller_attribution_middleware(
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    mut req: Request<Body>,
+    next: Next,
+) -> Response {
+    {
+        let headers = req.headers_mut();
+        headers.remove(INTERNAL_SOURCE_IP_HEADER);
+        headers.remove(INTERNAL_FORWARDED_FOR_HEADER);
+    }
+
+    let attribution = derive_client_network_attribution(&addr, req.headers());
+    if let Some(source_ip) = attribution.source_ip
+        && let Ok(value) = HeaderValue::from_str(&source_ip)
+    {
+        req.headers_mut().insert(INTERNAL_SOURCE_IP_HEADER, value);
+    }
+    if !attribution.forwarded_for.is_empty() {
+        let value = attribution.forwarded_for.join(", ");
+        if let Ok(value) = HeaderValue::from_str(&value) {
+            req.headers_mut()
+                .insert(INTERNAL_FORWARDED_FOR_HEADER, value);
+        }
+    }
+
+    next.run(req).await
+}
+
+#[must_use]
+pub(crate) fn derive_client_network_attribution(
+    connect: &SocketAddr,
+    headers: &HeaderMap,
+) -> ClientNetworkAttribution {
+    derive_client_network_attribution_with_depth(
+        connect,
+        headers,
+        gateway_limits().xff_trusted_depth as usize,
+    )
+}
+
+#[must_use]
+pub(crate) fn derive_client_network_attribution_with_depth(
+    connect: &SocketAddr,
+    headers: &HeaderMap,
+    trusted_depth: usize,
+) -> ClientNetworkAttribution {
+    let forwarded_for = forwarded_for_chain(headers);
+    let source = effective_client_ip_from_chain(connect.ip(), &forwarded_for, trusted_depth);
+    let forwarded_for = if trusted_depth > 0 {
+        forwarded_for
+    } else {
+        Vec::new()
+    };
+    ClientNetworkAttribution {
+        source_ip: Some(source.to_string()),
+        forwarded_for,
+    }
+}
+
+#[must_use]
+pub(crate) fn effective_client_ip(connect: &SocketAddr, headers: &HeaderMap) -> IpAddr {
+    derive_client_network_attribution(connect, headers)
+        .source_ip
+        .and_then(|value| value.parse::<IpAddr>().ok())
+        .unwrap_or_else(|| connect.ip())
+}
+
+#[must_use]
+pub(crate) fn internal_network_attribution(headers: &HeaderMap) -> ClientNetworkAttribution {
+    ClientNetworkAttribution {
+        source_ip: header_str(headers, INTERNAL_SOURCE_IP_HEADER),
+        forwarded_for: headers
+            .get(INTERNAL_FORWARDED_FOR_HEADER)
+            .and_then(|value| value.to_str().ok())
+            .map(parse_ip_list)
+            .unwrap_or_default(),
+    }
+}
+
+fn effective_client_ip_from_chain(
+    peer_ip: IpAddr,
+    forwarded_for: &[String],
+    trusted_depth: usize,
+) -> IpAddr {
+    if trusted_depth == 0 || forwarded_for.len() <= trusted_depth {
+        return peer_ip;
+    }
+    let idx = forwarded_for.len() - 1 - trusted_depth;
+    forwarded_for[idx].parse().unwrap_or(peer_ip)
+}
+
+fn forwarded_for_chain(headers: &HeaderMap) -> Vec<String> {
+    if let Some(raw) = header_str(headers, "x-forwarded-for") {
+        let parsed = parse_ip_list(&raw);
+        if !parsed.is_empty() {
+            return parsed;
+        }
+    }
+    headers
+        .get("forwarded")
+        .and_then(|value| value.to_str().ok())
+        .map(parse_forwarded_header)
+        .unwrap_or_default()
+}
+
+fn parse_ip_list(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .filter_map(|segment| normalise_forwarded_for_value(segment.trim()))
+        .collect()
+}
+
+fn parse_forwarded_header(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .filter_map(|entry| {
+            entry.split(';').find_map(|pair| {
+                let (key, value) = pair.split_once('=')?;
+                key.trim()
+                    .eq_ignore_ascii_case("for")
+                    .then(|| normalise_forwarded_for_value(value.trim()))
+                    .flatten()
+            })
+        })
+        .collect()
+}
+
+fn normalise_forwarded_for_value(raw: &str) -> Option<String> {
+    let value = raw.trim_matches('"').trim();
+    if value.is_empty() || value.eq_ignore_ascii_case("unknown") {
+        return None;
+    }
+    let value = if let Some(rest) = value.strip_prefix('[') {
+        rest.split_once(']').map(|(ip, _)| ip).unwrap_or(rest)
+    } else if let Some((host, _port)) = value.rsplit_once(':') {
+        if host.parse::<IpAddr>().is_ok() {
+            host
+        } else {
+            value
+        }
+    } else {
+        value
+    };
+    value.parse::<IpAddr>().ok().map(|ip| ip.to_string())
+}
+
+fn header_str(headers: &HeaderMap, name: &str) -> Option<String> {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn peer() -> SocketAddr {
+        SocketAddr::new("10.0.0.10".parse().unwrap(), 1234)
+    }
+
+    #[test]
+    fn source_ip_ignores_forwarded_headers_without_trusted_depth() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-forwarded-for",
+            "198.51.100.1, 10.0.0.20".parse().unwrap(),
+        );
+
+        let attribution = derive_client_network_attribution_with_depth(&peer(), &headers, 0);
+
+        assert_eq!(attribution.source_ip.as_deref(), Some("10.0.0.10"));
+        assert!(attribution.forwarded_for.is_empty());
+    }
+
+    #[test]
+    fn source_ip_uses_xff_left_of_trusted_proxy_hops() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-forwarded-for",
+            "198.51.100.1, 203.0.113.9, 10.0.0.20".parse().unwrap(),
+        );
+
+        let attribution = derive_client_network_attribution_with_depth(&peer(), &headers, 1);
+
+        assert_eq!(attribution.source_ip.as_deref(), Some("203.0.113.9"));
+        assert_eq!(
+            attribution.forwarded_for,
+            vec![
+                "198.51.100.1".to_string(),
+                "203.0.113.9".to_string(),
+                "10.0.0.20".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn source_ip_can_use_forwarded_header_when_xff_is_absent() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "forwarded",
+            "for=198.51.100.7;proto=https, for=\"[2001:db8::1]\""
+                .parse()
+                .unwrap(),
+        );
+
+        let attribution = derive_client_network_attribution_with_depth(&peer(), &headers, 1);
+
+        assert_eq!(attribution.source_ip.as_deref(), Some("198.51.100.7"));
+        assert_eq!(
+            attribution.forwarded_for,
+            vec!["198.51.100.7".to_string(), "2001:db8::1".to_string()]
+        );
+    }
+}

--- a/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
@@ -26,6 +26,7 @@ use dcc_mcp_transport::discovery::types::ServiceEntry;
 
 use crate::gateway::admin::trace::TraceContext;
 
+use super::admin::trace::AgentContext;
 use super::backend_client::{ForwardToolsCallRequest, forward_tools_call, try_describe_tool};
 use super::capability::{
     CapabilityIndex, CapabilityRecord, RANKER_VERSION, RefreshReason, SearchHit, SearchQuery,
@@ -411,6 +412,7 @@ pub async fn call_service(
     arguments: Value,
     meta: Option<Value>,
     trace_context: Option<&TraceContext>,
+    agent_context: Option<&AgentContext>,
 ) -> Result<Value, ServiceError> {
     let record = describe_service(&gs.capability_index, slug)?;
     enforce_record_policy(&gs.policy, GatewayPolicyOperation::Call, &record)?;
@@ -440,7 +442,7 @@ pub async fn call_service(
         ForwardToolsCallRequest {
             tool_name: &record.callable_id,
             arguments: Some(arguments),
-            meta,
+            meta: meta_with_agent_context(meta, agent_context),
             request_id: None,
             trace_context,
             traffic_capture: Some(&gs.traffic_capture),
@@ -477,6 +479,27 @@ pub async fn call_service(
             )
             .with_backend(backend_attachment))
         }
+    }
+}
+
+fn meta_with_agent_context(
+    meta: Option<Value>,
+    agent_context: Option<&AgentContext>,
+) -> Option<Value> {
+    let Some(agent_context) = agent_context else {
+        return meta;
+    };
+    let agent_context = serde_json::to_value(agent_context).ok()?;
+    match meta {
+        Some(Value::Object(mut map)) => {
+            map.insert("agent_context".to_string(), agent_context);
+            Some(Value::Object(map))
+        }
+        Some(other) => Some(json!({
+            "agent_context": agent_context,
+            "upstream_meta": other,
+        })),
+        None => Some(json!({ "agent_context": agent_context })),
     }
 }
 
@@ -915,6 +938,30 @@ mod unit_tests {
         );
         assert_eq!(result["_meta"]["dcc"]["instance_short"], "abcdef01");
         assert_eq!(result["_meta"]["dcc"]["display_id"], "maya@2026-abcdef01");
+    }
+
+    #[test]
+    fn forwarded_meta_includes_canonical_agent_context() {
+        let merged = meta_with_agent_context(
+            Some(json!({"search_id": "search-1"})),
+            Some(&AgentContext {
+                actor_id: Some("artist-1".to_string()),
+                client_platform: Some("cursor".to_string()),
+                source_ip: Some("192.0.2.44".to_string()),
+                forwarded_for: vec!["198.51.100.7".to_string()],
+                ..AgentContext::default()
+            }),
+        )
+        .expect("merged meta");
+
+        assert_eq!(merged["search_id"], "search-1");
+        assert_eq!(merged["agent_context"]["actor_id"], "artist-1");
+        assert_eq!(merged["agent_context"]["client_platform"], "cursor");
+        assert_eq!(merged["agent_context"]["source_ip"], "192.0.2.44");
+        assert_eq!(
+            merged["agent_context"]["forwarded_for"],
+            json!(["198.51.100.7"])
+        );
     }
 
     #[test]

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/mcp_impl.rs
@@ -501,11 +501,12 @@ async fn handle_tools_call(
         .as_ref()
         .and_then(|params| params.get("_meta"))
         .cloned();
-    let agent_context = crate::gateway::admin::trace::AgentContext::from_request_parts(
-        headers,
-        req.params.as_ref(),
-        meta.as_ref(),
-    );
+    let agent_context =
+        crate::gateway::admin::trace::AgentContext::from_request_parts_with_server_network(
+            headers,
+            req.params.as_ref(),
+            meta.as_ref(),
+        );
     let trace_context = crate::gateway::admin::trace::TraceContext::from_headers_with_request_id(
         headers,
         id_str.to_string(),
@@ -1060,6 +1061,45 @@ mod tests {
         let decoded: Value = toon_format::decode_default(text).expect("tool content is TOON");
         assert_eq!(decoded["total"], 0);
         assert!(decoded["hits"].as_array().is_some());
+    }
+
+    #[tokio::test]
+    async fn tools_call_search_records_meta_and_server_network_attribution() {
+        let gs = test_gateway_state();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            crate::gateway::caller_attribution::INTERNAL_SOURCE_IP_HEADER,
+            "192.0.2.44".parse().unwrap(),
+        );
+        let req = request(
+            "tools/call",
+            json!("attributed-search"),
+            Some(json!({
+                "name": "search",
+                "arguments": {"kind": "tool", "query": "sphere"},
+                "_meta": {
+                    "agent_context": {
+                        "actor_id": "artist-1",
+                        "client_platform": "cursor",
+                        "sourceIp": "203.0.113.100"
+                    }
+                }
+            })),
+        );
+
+        let response = dispatch_single_request(&gs, &req, "test-session", &headers)
+            .await
+            .expect("request has id");
+
+        assert_eq!(response["result"]["isError"], false);
+        let telemetry = gs.search_telemetry.snapshot(10);
+        let agent = telemetry.recent[0]
+            .agent_context
+            .as_ref()
+            .expect("MCP search should keep attribution");
+        assert_eq!(agent.actor_id.as_deref(), Some("artist-1"));
+        assert_eq!(agent.client_platform.as_deref(), Some("cursor"));
+        assert_eq!(agent.source_ip.as_deref(), Some("192.0.2.44"));
     }
 
     #[tokio::test]

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl.rs
@@ -459,7 +459,7 @@ pub async fn handle_v1_search(
     Json(body): Json<Value>,
 ) -> Response {
     let trace_context = TraceContext::from_headers(&headers);
-    let agent_context = AgentContext::from_request_parts(
+    let agent_context = AgentContext::from_request_parts_with_server_network(
         &headers,
         Some(&body),
         body.get("meta").or_else(|| body.get("_meta")),
@@ -571,7 +571,7 @@ async fn skill_lifecycle_response(
     body: Value,
 ) -> Response {
     let trace_context = TraceContext::from_headers(headers);
-    let agent_context = AgentContext::from_request_parts(
+    let agent_context = AgentContext::from_request_parts_with_server_network(
         headers,
         Some(&body),
         body.get("meta").or_else(|| body.get("_meta")),
@@ -695,7 +695,7 @@ pub async fn handle_v1_describe(
     Json(body): Json<Value>,
 ) -> Response {
     let trace_context = TraceContext::from_headers(&headers);
-    let agent_context = AgentContext::from_request_parts(
+    let agent_context = AgentContext::from_request_parts_with_server_network(
         &headers,
         Some(&body),
         body.get("meta").or_else(|| body.get("_meta")),
@@ -734,7 +734,7 @@ pub async fn handle_v1_describe_path(
     Path(slug): Path<String>,
 ) -> Response {
     let trace_context = TraceContext::from_headers(&headers);
-    let agent_context = AgentContext::from_request_parts(&headers, None, None);
+    let agent_context = AgentContext::from_request_parts_with_server_network(&headers, None, None);
     refresh_all_live_backends(&gs, RefreshReason::Periodic).await;
     let body = json!({});
     let metadata = RestResponseMetadata::from_trace_context(&trace_context)
@@ -872,7 +872,7 @@ pub async fn handle_v1_dcc_instance_describe(
 ) -> Response {
     let body = json!({});
     let trace_context = TraceContext::from_headers(&headers);
-    let agent_context = AgentContext::from_request_parts(&headers, None, None);
+    let agent_context = AgentContext::from_request_parts_with_server_network(&headers, None, None);
     let backend_tool = q.backend_tool.trim();
     if backend_tool.is_empty() {
         let metadata = RestResponseMetadata::from_headers(&headers)

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_impl_tests.rs
@@ -142,6 +142,20 @@ fn trace_headers() -> HeaderMap {
     headers
 }
 
+fn attributed_trace_headers() -> HeaderMap {
+    let mut headers = trace_headers();
+    headers.insert("x-dcc-mcp-actor-id", "artist-1".parse().unwrap());
+    headers.insert(
+        crate::gateway::caller_attribution::INTERNAL_SOURCE_IP_HEADER,
+        "192.0.2.44".parse().unwrap(),
+    );
+    headers.insert(
+        crate::gateway::caller_attribution::INTERNAL_FORWARDED_FOR_HEADER,
+        "198.51.100.7, 203.0.113.9".parse().unwrap(),
+    );
+    headers
+}
+
 fn assert_trace_headers(headers: &HeaderMap) {
     assert_eq!(
         headers
@@ -688,6 +702,44 @@ async fn gateway_rest_workflow_responses_expose_trace_and_index_metadata() {
 }
 
 #[tokio::test]
+async fn rest_search_records_server_network_attribution() {
+    let gs = test_gateway_state("1.2.3");
+    let headers = attributed_trace_headers();
+
+    let (status, _body) = response_json(
+        handle_v1_search(
+            State(gs.clone()),
+            headers,
+            Json(json!({
+                "query": "render",
+                "meta": {
+                    "agent_context": {
+                        "client_platform": "custom-http",
+                        "sourceIp": "203.0.113.100"
+                    }
+                }
+            })),
+        )
+        .await,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let telemetry = gs.search_telemetry.snapshot(10);
+    let agent = telemetry.recent[0]
+        .agent_context
+        .as_ref()
+        .expect("search telemetry should keep attribution");
+    assert_eq!(agent.actor_id.as_deref(), Some("artist-1"));
+    assert_eq!(agent.client_platform.as_deref(), Some("custom-http"));
+    assert_eq!(agent.source_ip.as_deref(), Some("192.0.2.44"));
+    assert_eq!(
+        agent.forwarded_for,
+        vec!["198.51.100.7".to_string(), "203.0.113.9".to_string()]
+    );
+}
+
+#[tokio::test]
 async fn mcp_search_followups_correlate_describe_load_call_and_batch() {
     let gs = test_gateway_state("1.2.3");
     seed_unloaded_render_capability(&gs);
@@ -1145,6 +1197,47 @@ async fn rest_traceparent_does_not_replace_request_id() {
     assert_eq!(tokens.response_format, "json");
     assert_eq!(tokens.saved_tokens, 0);
     assert_eq!(tokens.original_tokens, tokens.returned_tokens);
+}
+
+#[tokio::test]
+async fn rest_audit_rows_include_server_network_attribution() {
+    use crate::gateway::middleware::{AuditMiddleware, MiddlewareChain};
+
+    let sink = Arc::new(CaptureSink::default());
+    let chain = MiddlewareChain::new().with_after(Arc::new(AuditMiddleware::new(sink.clone())));
+    let mut gs = test_gateway_state("1.2.3");
+    gs.middleware_chain = Arc::new(chain);
+
+    let headers = attributed_trace_headers();
+    let request_body = json!({
+        "tool_slug": "maya.abcdef01.render",
+        "arguments": {},
+        "meta": {"agent_context": {"agent_id": "agent-1"}},
+        "response_format": "json"
+    });
+
+    let _ = call_service_with_admin_trace(
+        &gs,
+        &headers,
+        RestCallTraceRequest {
+            method: "v1/call",
+            slug: "maya.abcdef01.render",
+            arguments: json!({}),
+            meta: request_body.get("meta").cloned(),
+            request_body: &request_body,
+            trace_context: crate::gateway::admin::trace::TraceContext::from_headers(&headers),
+        },
+    )
+    .await;
+
+    let entries = sink.0.lock().unwrap();
+    let agent = entries[0]
+        .agent_context
+        .as_ref()
+        .expect("audit should keep attribution");
+    assert_eq!(agent.agent_id.as_deref(), Some("agent-1"));
+    assert_eq!(agent.actor_id.as_deref(), Some("artist-1"));
+    assert_eq!(agent.source_ip.as_deref(), Some("192.0.2.44"));
 }
 
 #[tokio::test]

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/rest_trace.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/rest_trace.rs
@@ -40,7 +40,7 @@ pub(super) async fn call_service_with_admin_trace(
     let mut ctx = CallContext::new(method, trace_context.request_id.clone(), arguments.clone())
         .with_tool_slug(slug)
         .with_transport("rest")
-        .with_agent_context(AgentContext::from_request_parts(
+        .with_agent_context(AgentContext::from_request_parts_with_server_network(
             headers,
             Some(request_body),
             meta.as_ref(),
@@ -121,6 +121,7 @@ pub(super) async fn call_service_with_admin_trace(
         effective_arguments.clone(),
         meta.clone(),
         Some(&ctx.trace_context),
+        ctx.agent_context.as_ref(),
     )
     .await;
     if matches!(&result, Err(err) if err.kind == "unknown-slug") {
@@ -131,6 +132,7 @@ pub(super) async fn call_service_with_admin_trace(
             effective_arguments,
             meta,
             Some(&ctx.trace_context),
+            ctx.agent_context.as_ref(),
         )
         .await;
     }
@@ -254,7 +256,7 @@ pub(super) async fn call_batch_with_admin_trace(
     )
     .with_tool_slug("call_batch")
     .with_transport("rest")
-    .with_agent_context(AgentContext::from_request_parts(
+    .with_agent_context(AgentContext::from_request_parts_with_server_network(
         headers,
         Some(request_body),
         request_body.get("meta"),
@@ -315,8 +317,9 @@ pub(super) async fn call_batch_with_admin_trace(
     let result = crate::gateway::tools::gateway_call_batch_inner(
         gs,
         &ctx.args,
-        None,
+        request_body.get("meta"),
         Some(&ctx.trace_context),
+        ctx.agent_context.as_ref(),
     )
     .await;
     let response_ns = now_ns();

--- a/crates/dcc-mcp-gateway/src/gateway/http_limits.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/http_limits.rs
@@ -15,11 +15,12 @@ use std::sync::LazyLock;
 
 use axum::body::Body;
 use axum::extract::ConnectInfo;
-use axum::http::{HeaderMap, Request, StatusCode};
+use axum::http::{Request, StatusCode};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use parking_lot::Mutex;
 
+use super::caller_attribution::effective_client_ip;
 use super::resilience::gateway_limits;
 
 struct MinuteWindow {
@@ -44,32 +45,6 @@ fn current_minute_epoch() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs() / 60)
         .unwrap_or(0)
-}
-
-/// Derive the client IP for rate limiting: either the TCP peer or a field from
-/// `X-Forwarded-For` when `xff_trusted_depth > 0`.
-fn effective_client_ip(connect: &SocketAddr, headers: &HeaderMap) -> IpAddr {
-    let depth = gateway_limits().xff_trusted_depth as usize;
-    if depth == 0 {
-        return connect.ip();
-    }
-    let Some(raw) = headers.get("X-Forwarded-For").and_then(|v| v.to_str().ok()) else {
-        return connect.ip();
-    };
-    let segments: Vec<&str> = raw
-        .split(',')
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .collect();
-    if segments.len() <= depth {
-        return connect.ip();
-    }
-    let idx = segments.len() - 1 - depth;
-    if let Ok(ip) = segments[idx].parse::<IpAddr>() {
-        ip
-    } else {
-        connect.ip()
-    }
 }
 
 fn allow_request(client_ip: IpAddr) -> bool {

--- a/crates/dcc-mcp-gateway/src/gateway/mod.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/mod.rs
@@ -34,6 +34,7 @@
 pub(crate) mod agent_telemetry;
 pub mod aggregator;
 pub mod backend_client;
+pub(crate) mod caller_attribution;
 pub mod capability;
 #[allow(clippy::result_large_err)]
 // ServiceError carries disambiguation candidates (#1076 backend attachment)

--- a/crates/dcc-mcp-gateway/src/gateway/router.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/router.rs
@@ -5,6 +5,7 @@ use tower_http::cors::{Any, CorsLayer};
 use tower_http::limit::RequestBodyLimitLayer;
 use tower_http::trace::TraceLayer;
 
+use super::caller_attribution::caller_attribution_middleware;
 use super::handlers::{
     handle_gateway_get, handle_gateway_mcp, handle_gateway_yield, handle_health, handle_instances,
     handle_proxy_dcc, handle_proxy_instance, handle_v1_call, handle_v1_call_batch,
@@ -51,6 +52,7 @@ pub fn build_gateway_router(mut state: GatewayState) -> Router {
     let limits = gateway_limits();
     let mut r = build_base_router(state);
     r = r.layer(RequestBodyLimitLayer::new(limits.body_max_bytes));
+    r = r.layer(middleware::from_fn(caller_attribution_middleware));
     if limits.rate_limit_per_minute_per_ip > 0 {
         r = r.layer(middleware::from_fn(rate_limit_middleware));
     }
@@ -81,6 +83,7 @@ pub fn build_gateway_router_with_admin(
     let limits = gateway_limits();
     let mut router = build_base_router(state);
     router = router.layer(RequestBodyLimitLayer::new(limits.body_max_bytes));
+    router = router.layer(middleware::from_fn(caller_attribution_middleware));
     if limits.rate_limit_per_minute_per_ip > 0 {
         router = router.layer(middleware::from_fn(rate_limit_middleware));
     }

--- a/crates/dcc-mcp-gateway/src/gateway/tools.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/tools.rs
@@ -272,11 +272,12 @@ pub async fn tool_call(
     args: &Value,
     meta: Option<&Value>,
     trace_context: Option<&TraceContext>,
+    agent_context: Option<&AgentContext>,
 ) -> (String, bool) {
     if args.get("calls").and_then(Value::as_array).is_some() {
-        tool_call_tools(gs, args, meta, trace_context).await
+        tool_call_tools(gs, args, meta, trace_context, agent_context).await
     } else {
-        tool_call_tool(gs, args, meta, trace_context).await
+        tool_call_tool(gs, args, meta, trace_context, agent_context).await
     }
 }
 
@@ -509,6 +510,7 @@ pub async fn tool_call_tool(
     args: &Value,
     meta: Option<&Value>,
     trace_context: Option<&TraceContext>,
+    agent_context: Option<&AgentContext>,
 ) -> (String, bool) {
     let Some(slug) = args.get("tool_slug").and_then(|v| v.as_str()) else {
         return ("missing required argument: tool_slug".to_string(), true);
@@ -531,6 +533,7 @@ pub async fn tool_call_tool(
         arguments.clone(),
         forwarded_meta.clone(),
         trace_context,
+        agent_context,
     )
     .await
     {
@@ -564,6 +567,7 @@ pub async fn tool_call_tool(
                 arguments,
                 forwarded_meta,
                 trace_context,
+                agent_context,
             )
             .await
             {
@@ -645,6 +649,7 @@ pub async fn gateway_call_batch_inner(
     args: &Value,
     mcp_meta: Option<&Value>,
     trace_context: Option<&TraceContext>,
+    agent_context: Option<&AgentContext>,
 ) -> Result<Value, String> {
     let calls = args
         .get("calls")
@@ -693,6 +698,9 @@ pub async fn gateway_call_batch_inner(
             .get("meta")
             .and_then(search_id_from_meta)
             .or_else(|| mcp_meta.and_then(search_id_from_meta));
+        let child_trace_context =
+            trace_context.map(|ctx| ctx.child_request(format!("{}:batch-{idx}", ctx.request_id)));
+        let child_trace_context = child_trace_context.as_ref().or(trace_context);
 
         let single_outcome = async {
             match crate::gateway::capability_service::call_service(
@@ -700,7 +708,8 @@ pub async fn gateway_call_batch_inner(
                 slug,
                 arguments.clone(),
                 forwarded_meta.clone(),
-                trace_context,
+                child_trace_context,
+                agent_context,
             )
             .await
             {
@@ -716,7 +725,8 @@ pub async fn gateway_call_batch_inner(
                         slug,
                         arguments,
                         forwarded_meta,
-                        trace_context,
+                        child_trace_context,
+                        agent_context,
                     )
                     .await
                 }
@@ -789,9 +799,9 @@ pub async fn tool_call_tools(
     args: &Value,
     meta: Option<&Value>,
     trace_context: Option<&TraceContext>,
+    agent_context: Option<&AgentContext>,
 ) -> (String, bool) {
-    let _ = meta;
-    match gateway_call_batch_inner(gs, args, meta, trace_context).await {
+    match gateway_call_batch_inner(gs, args, meta, trace_context, agent_context).await {
         Ok(value) => {
             let is_error = !value
                 .get("success")


### PR DESCRIPTION
## Summary
- derive caller network attribution at the gateway boundary and ignore spoofed internal headers
- propagate canonical agent context through MCP/REST calls, batch fan-out, backend forwarding, audit rows, and search traces
- add regression coverage for REST, MCP, backend forwarding, and trusted forwarded-header parsing

## Validation
- `vx cargo fmt --all`
- `vx cargo test -p dcc-mcp-gateway attribution -- --nocapture`
- `vx cargo test -p dcc-mcp-gateway forwarded_meta_includes_canonical_agent_context -- --nocapture`
- `vx cargo test -p dcc-mcp-gateway trace_context_child_request_preserves_trace_with_distinct_request_id -- --nocapture`
- `vx cargo clippy -p dcc-mcp-gateway --all-targets -- -D warnings -A dead-code`
- `vx git diff --check`

Skill guidance was not updated; the existing caller attribution guidance from #1260 already covers the public carriers and server-derived source fields.

Closes #1261