### PR TITLE
feat: add attribution trust guardrails

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -96,6 +96,25 @@ type ToolRow = {
   instance_prefix?: string;
 };
 
+type AttributionTrust = {
+  actor_id?: string | null;
+  actor_name?: string | null;
+  actor_email_hash?: string | null;
+  agent_id?: string | null;
+  agent_name?: string | null;
+  agent_kind?: string | null;
+  agent_version?: string | null;
+  model?: string | null;
+  model_provider?: string | null;
+  model_version?: string | null;
+  client_platform?: string | null;
+  client_os?: string | null;
+  client_host?: string | null;
+  auth_subject?: string | null;
+  source_ip?: string | null;
+  forwarded_for?: string | null;
+};
+
 type CallRow = {
   timestamp: string;
   request_id: string;
@@ -119,6 +138,7 @@ type CallRow = {
   client_host?: string | null;
   auth_subject?: string | null;
   source_ip?: string | null;
+  attribution_trust?: AttributionTrust | null;
   parent_request_id?: string | null;
   token_accounting?: TokenAccounting | null;
   response_format?: string | null;
@@ -154,6 +174,7 @@ type TraceRow = {
   client_host?: string | null;
   auth_subject?: string | null;
   source_ip?: string | null;
+  attribution_trust?: AttributionTrust | null;
   span_count?: number | null;
   input_bytes?: number | null;
   output_bytes?: number | null;
@@ -284,6 +305,7 @@ type AgentContext = {
   auth_subject?: string | null;
   source_ip?: string | null;
   forwarded_for?: string[];
+  trust?: AttributionTrust;
   user_intent_summary?: string | null;
   agent_reply_summary?: string | null;
   user_input_hash?: string | null;
@@ -1760,6 +1782,24 @@ function sourceIpLabel(row: { source_ip?: string | null }): string {
   return row.source_ip || '-';
 }
 
+function trustFor(row: { attribution_trust?: AttributionTrust | null; trust?: AttributionTrust | null }, field: keyof AttributionTrust): string | null {
+  return row.attribution_trust?.[field] ?? row.trust?.[field] ?? null;
+}
+
+function firstTrust(row: { attribution_trust?: AttributionTrust | null; trust?: AttributionTrust | null }, fields: (keyof AttributionTrust)[]): string | null {
+  for (const field of fields) {
+    const value = trustFor(row, field);
+    if (value) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function trustChip(source: string | null | undefined): ReactNode {
+  return source ? <span className="trust-chip" title={`trust: ${source}`}>{source}</span> : null;
+}
+
 function safeCallerContext(agent: AgentContext | null | undefined): Record<string, unknown> | null {
   if (!agent) {
     return null;
@@ -1784,6 +1824,7 @@ function safeCallerContext(agent: AgentContext | null | undefined): Record<strin
     auth_subject: agent.auth_subject ?? null,
     source_ip: agent.source_ip ?? null,
     forwarded_for: agent.forwarded_for ?? [],
+    trust: agent.trust ?? {},
     task: agent.task ?? null,
     user_intent_summary: agent.user_intent_summary ?? null,
     agent_reply_summary: agent.agent_reply_summary ?? null,
@@ -2394,10 +2435,10 @@ function TraceDetailPanel({
             </div>
           ) : null}
           <div className="agent-meta">
-            {actorLabel(agent) !== '-' ? <span>{t('common.table.actor')} {actorLabel(agent)}</span> : null}
-            {platformLabel(agent) !== '-' ? <span>{t('common.table.platform')} {platformLabel(agent)}</span> : null}
-            {sourceIpLabel(agent) !== '-' ? <span>{t('common.table.sourceIp')} {sourceIpLabel(agent)}</span> : null}
-            {agent.auth_subject ? <span>{t('common.table.auth')} {agent.auth_subject}</span> : null}
+            {actorLabel(agent) !== '-' ? <span>{t('common.table.actor')} {actorLabel(agent)} {trustChip(firstTrust(agent, ['actor_name', 'actor_id', 'actor_email_hash']))}</span> : null}
+            {platformLabel(agent) !== '-' ? <span>{t('common.table.platform')} {platformLabel(agent)} {trustChip(firstTrust(agent, ['client_platform', 'client_os', 'client_host']))}</span> : null}
+            {sourceIpLabel(agent) !== '-' ? <span>{t('common.table.sourceIp')} {sourceIpLabel(agent)} {trustChip(trustFor(agent, 'source_ip'))}</span> : null}
+            {agent.auth_subject ? <span>{t('common.table.auth')} {agent.auth_subject} {trustChip(trustFor(agent, 'auth_subject'))}</span> : null}
             {agentTurnChips(agent, t).map((chip) => <span key={chip}>{chip}</span>)}
             {agent.parent_request_id ? <span>parent {compactId(agent.parent_request_id)}</span> : null}
             {agent.trace_id ? <span>trace {compactId(agent.trace_id)}</span> : null}
@@ -2776,6 +2817,7 @@ function App() {
           c.client_host ?? '',
           c.auth_subject ?? '',
           c.source_ip ?? '',
+          ...Object.values(c.attribution_trust ?? {}),
           c.parent_request_id ?? '',
         ),
       ),
@@ -2811,6 +2853,7 @@ function App() {
           t.client_host ?? '',
           t.auth_subject ?? '',
           t.source_ip ?? '',
+          ...Object.values(t.attribution_trust ?? {}),
           t.slowest_span_name ?? '',
           t.input_tokens != null ? String(t.input_tokens) : '',
           t.output_tokens != null ? String(t.output_tokens) : '',
@@ -4568,10 +4611,14 @@ function App() {
                           <td>{call.tool}</td>
                           <td>{call.dcc_type}</td>
                           <td>{compactInstanceId(call.instance_id)}</td>
-                          <td title={call.actor_id ?? call.auth_subject ?? ''}>{actorLabel(call)}</td>
+                          <td title={call.actor_id ?? call.auth_subject ?? ''}>
+                            <span className="trust-cell">{actorLabel(call)}{trustChip(firstTrust(call, ['actor_name', 'actor_id', 'actor_email_hash', 'auth_subject']))}</span>
+                          </td>
                           <td title={call.agent_id ?? call.agent_name ?? ''}>{agentLabel(call)}</td>
-                          <td title={[call.client_platform, call.client_os, call.client_host].filter(Boolean).join(' / ')}>{platformLabel(call)}</td>
-                          <td>{sourceIpLabel(call)}</td>
+                          <td title={[call.client_platform, call.client_os, call.client_host].filter(Boolean).join(' / ')}>
+                            <span className="trust-cell">{platformLabel(call)}{trustChip(firstTrust(call, ['client_platform', 'client_os', 'client_host']))}</span>
+                          </td>
+                          <td><span className="trust-cell">{sourceIpLabel(call)}{trustChip(trustFor(call, 'source_ip'))}</span></td>
                           <td>{call.transport ?? '-'}</td>
                           <td>{responseFormatLabel(call)}</td>
                           <td>{returnedTokensLabel(call)}</td>
@@ -4637,7 +4684,13 @@ function App() {
                           <span className="trace-item-main">
                             <strong>{trace.tool}</strong>
                             <span>{compactId(trace.request_id)} - {compactInstanceId(trace.instance_id)} - <TimeValue value={trace.timestamp} /> - {trace.transport ?? '?'}</span>
-                            <span>{actorLabel(trace)} - {platformLabel(trace)} - {sourceIpLabel(trace)}</span>
+                            <span>
+                              {actorLabel(trace)} {trustChip(firstTrust(trace, ['actor_name', 'actor_id', 'actor_email_hash', 'auth_subject']))}
+                              {' - '}
+                              {platformLabel(trace)} {trustChip(firstTrust(trace, ['client_platform', 'client_os', 'client_host']))}
+                              {' - '}
+                              {sourceIpLabel(trace)} {trustChip(trustFor(trace, 'source_ip'))}
+                            </span>
                             <span>{agentLabel(trace)}{trace.slowest_span_name ? ` - ${t('traces.detail.slowestSpan', { name: trace.slowest_span_name, duration: formatDurationMs(trace.slowest_span_ms) })}` : ''}</span>
                           </span>
                           <span className="trace-item-side">

--- a/admin-ui/src/styles.css
+++ b/admin-ui/src/styles.css
@@ -351,6 +351,28 @@ h2 {
   color: var(--muted-foreground);
 }
 
+.trust-cell {
+  align-items: center;
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.trust-chip {
+  background: rgba(154, 167, 184, 0.12);
+  border: 1px solid rgba(154, 167, 184, 0.2);
+  border-radius: 999px;
+  color: var(--muted-foreground);
+  display: inline-flex;
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  font-weight: 600;
+  line-height: 1;
+  padding: 0.16rem 0.35rem;
+  text-transform: uppercase;
+  vertical-align: middle;
+}
+
 .status-bar {
   background: var(--muted);
   border: 1px solid var(--border);

--- a/admin-ui/tests/admin.spec.ts
+++ b/admin-ui/tests/admin.spec.ts
@@ -358,6 +358,15 @@ async function mockAdminApi(page: Page) {
             client_host: 'workstation-7',
             auth_subject: 'user:artist-1',
             source_ip: '192.0.2.44',
+            attribution_trust: {
+              actor_id: 'self_reported',
+              actor_name: 'self_reported',
+              client_platform: 'header',
+              client_os: 'header',
+              client_host: 'header',
+              auth_subject: 'auth',
+              source_ip: 'server_derived',
+            },
             token_accounting: {
               response_format: 'toon',
               token_estimator: 'dcc-mcp-byte4-v1',
@@ -421,6 +430,15 @@ async function mockAdminApi(page: Page) {
             client_host: 'workstation-7',
             auth_subject: 'user:artist-1',
             source_ip: '192.0.2.44',
+            attribution_trust: {
+              actor_id: 'self_reported',
+              actor_name: 'self_reported',
+              client_platform: 'header',
+              client_os: 'header',
+              client_host: 'header',
+              auth_subject: 'auth',
+              source_ip: 'server_derived',
+            },
             input_tokens: 28,
             output_tokens: 18,
             total_tokens: 46,
@@ -467,6 +485,16 @@ async function mockAdminApi(page: Page) {
           auth_subject: 'user:artist-1',
           source_ip: '192.0.2.44',
           forwarded_for: ['198.51.100.7'],
+          trust: {
+            actor_id: 'self_reported',
+            actor_name: 'self_reported',
+            client_platform: 'header',
+            client_os: 'header',
+            client_host: 'header',
+            auth_subject: 'auth',
+            source_ip: 'trusted_proxy',
+            forwarded_for: 'trusted_proxy',
+          },
           model: 'gpt-test',
           session_id: 'session-1',
         },
@@ -985,6 +1013,8 @@ test.describe('Admin Page', () => {
     await expect(callsPanel).toContainText('Layout Artist');
     await expect(callsPanel).toContainText('cursor / windows / workstation-7');
     await expect(callsPanel).toContainText('192.0.2.44');
+    await expect(callsPanel).toContainText('self_reported');
+    await expect(callsPanel).toContainText('server_derived');
     await page.getByLabel('Filter current panel').fill('192.0.2.44');
     await expect(page.locator('.list-search-meta')).toContainText('1 / 3');
     await expect(callsPanel).toContainText('req-123');
@@ -1006,7 +1036,9 @@ test.describe('Admin Page', () => {
     await expect(page.locator('.trace-detail-panel')).toContainText('Layout Artist');
     await expect(page.locator('.trace-detail-panel')).toContainText('cursor / windows / workstation-7');
     await expect(page.locator('.trace-detail-panel')).toContainText('192.0.2.44');
+    await expect(page.locator('.trace-detail-panel')).toContainText('trusted_proxy');
     await expect(page.locator('.caller-context-pre')).toContainText('"auth_subject": "user:artist-1"');
+    await expect(page.locator('.caller-context-pre')).toContainText('"auth_subject": "auth"');
   });
 
   test('shows reconstructed tasks and links them to traces', async ({ page }) => {

--- a/crates/dcc-mcp-db/src/domain/gateway_admin_audit.rs
+++ b/crates/dcc-mcp-db/src/domain/gateway_admin_audit.rs
@@ -42,6 +42,8 @@ pub struct GatewayAdminAuditPersistedJson {
     #[serde(default)]
     pub source_ip: Option<String>,
     #[serde(default)]
+    pub attribution_trust: Option<Value>,
+    #[serde(default)]
     pub parent_request_id: Option<String>,
     pub action: String,
     pub dcc_type: Option<String>,

--- a/crates/dcc-mcp-db/src/infra/gateway_admin_sqlite.rs
+++ b/crates/dcc-mcp-db/src/infra/gateway_admin_sqlite.rs
@@ -410,6 +410,11 @@ mod tests {
             client_host: Some("workstation-7".into()),
             auth_subject: Some("user:artist-1".into()),
             source_ip: Some("192.0.2.44".into()),
+            attribution_trust: Some(serde_json::json!({
+                "actor_id": "self_reported",
+                "auth_subject": "auth",
+                "source_ip": "server_derived",
+            })),
             parent_request_id: None,
             action: "x".into(),
             dcc_type: Some("maya".into()),
@@ -433,6 +438,7 @@ mod tests {
         assert_eq!(back.actor_id.as_deref(), Some("artist-1"));
         assert_eq!(back.client_platform.as_deref(), Some("custom-http"));
         assert_eq!(back.source_ip.as_deref(), Some("192.0.2.44"));
+        assert_eq!(back.attribution_trust.unwrap()["auth_subject"], "auth");
         assert_eq!(back.token_accounting.unwrap()["saved_tokens"], 12);
     }
 

--- a/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
@@ -534,6 +534,7 @@ fn admin_audit_row_json(r: &AdminAuditRecord, links: Option<AdminLinkBuilder>) -
         "client_host": r.client_host,
         "auth_subject": r.auth_subject,
         "source_ip": r.source_ip,
+        "attribution_trust": r.attribution_trust,
         "parent_request_id": r.parent_request_id,
         "tool": r.action,
         "dcc_type": r.dcc_type,
@@ -1474,6 +1475,11 @@ fn dispatch_trace_to_admin_row(t: &DispatchTrace, links: Option<AdminLinkBuilder
         .agent_context
         .as_ref()
         .and_then(|ctx| ctx.source_ip.clone());
+    let attribution_trust = t
+        .agent_context
+        .as_ref()
+        .map(|ctx| ctx.trust.clone())
+        .filter(|trust| !trust.is_empty());
     let mut row = json!({
         "timestamp": ts,
         "request_id": t.request_id,
@@ -1500,6 +1506,7 @@ fn dispatch_trace_to_admin_row(t: &DispatchTrace, links: Option<AdminLinkBuilder
         "client_host": client_host,
         "auth_subject": auth_subject,
         "source_ip": source_ip,
+        "attribution_trust": attribution_trust,
         "span_count": t.span_count(),
         "input_bytes": t.input_bytes(),
         "output_bytes": t.output_bytes(),

--- a/crates/dcc-mcp-gateway/src/gateway/admin/sqlite_lane.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/sqlite_lane.rs
@@ -110,6 +110,9 @@ fn admin_audit_from_persisted(p: GatewayAdminAuditPersistedJson) -> AdminAuditRe
         client_host: p.client_host,
         auth_subject: p.auth_subject,
         source_ip: p.source_ip,
+        attribution_trust: p
+            .attribution_trust
+            .and_then(|value| serde_json::from_value(value).ok()),
         parent_request_id: p.parent_request_id,
         action: p.action,
         dcc_type: p.dcc_type,
@@ -203,6 +206,10 @@ fn audit_to_persisted(r: &AdminAuditRecord) -> GatewayAdminAuditPersistedJson {
         client_host: r.client_host.clone(),
         auth_subject: r.auth_subject.clone(),
         source_ip: r.source_ip.clone(),
+        attribution_trust: r
+            .attribution_trust
+            .as_ref()
+            .and_then(|value| serde_json::to_value(value).ok()),
         parent_request_id: r.parent_request_id.clone(),
         action: r.action.clone(),
         dcc_type: r.dcc_type.clone(),

--- a/crates/dcc-mcp-gateway/src/gateway/admin/state.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/state.rs
@@ -16,7 +16,7 @@ use crate::gateway::middleware::{AuditEntry, AuditSink};
 use crate::gateway::state::GatewayState;
 
 use super::stats::StatsAggregator;
-use super::trace::{DispatchTrace, TokenTelemetry, TraceLog};
+use super::trace::{AgentContextTrust, DispatchTrace, TokenTelemetry, TraceLog};
 
 type SqliteTracePersistFn = Arc<dyn Fn(&DispatchTrace) + Send + Sync>;
 type SqliteAuditPersistFn = Arc<dyn Fn(&AdminAuditRecord) + Send + Sync>;
@@ -64,6 +64,8 @@ pub struct AdminAuditRecord {
     pub auth_subject: Option<String>,
     /// Server-derived source IP after proxy trust policy.
     pub source_ip: Option<String>,
+    /// Server-computed trust source labels for attribution fields.
+    pub attribution_trust: Option<AgentContextTrust>,
     /// Parent request id for request-chain correlation.
     pub parent_request_id: Option<String>,
     /// Tool slug or MCP method name.
@@ -127,6 +129,8 @@ struct PersistedAuditRecord {
     auth_subject: Option<String>,
     #[serde(default)]
     source_ip: Option<String>,
+    #[serde(default)]
+    attribution_trust: Option<AgentContextTrust>,
     #[serde(default)]
     parent_request_id: Option<String>,
     action: String,
@@ -295,6 +299,7 @@ impl From<&AdminAuditRecord> for PersistedAuditRecord {
             client_host: record.client_host.clone(),
             auth_subject: record.auth_subject.clone(),
             source_ip: record.source_ip.clone(),
+            attribution_trust: record.attribution_trust.clone(),
             parent_request_id: record.parent_request_id.clone(),
             action: record.action.clone(),
             dcc_type: record.dcc_type.clone(),
@@ -329,6 +334,7 @@ impl From<PersistedAuditRecord> for AdminAuditRecord {
             client_host: record.client_host,
             auth_subject: record.auth_subject,
             source_ip: record.source_ip,
+            attribution_trust: record.attribution_trust,
             parent_request_id: record.parent_request_id,
             action: record.action,
             dcc_type: record.dcc_type,
@@ -418,6 +424,9 @@ impl AuditSink for AdminAuditSink {
             client_host: agent_context.and_then(|ctx| ctx.client_host.clone()),
             auth_subject: agent_context.and_then(|ctx| ctx.auth_subject.clone()),
             source_ip: agent_context.and_then(|ctx| ctx.source_ip.clone()),
+            attribution_trust: agent_context
+                .map(|ctx| ctx.trust.clone())
+                .filter(|trust| !trust.is_empty()),
             parent_request_id: entry
                 .trace_context
                 .parent_request_id
@@ -513,6 +522,7 @@ mod durable_tests {
             client_host: None,
             auth_subject: None,
             source_ip: None,
+            attribution_trust: None,
             parent_request_id: None,
             action: "maya.abcdef01.create_sphere".to_string(),
             dcc_type: Some("maya".to_string()),

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -19,7 +19,7 @@ mod admin_tests {
 
     use crate::gateway::admin::router::{build_admin_router, build_v1_debug_router};
     use crate::gateway::admin::state::{AdminAuditRecord, AdminState, AuditLog};
-    use crate::gateway::admin::trace::TokenTelemetry;
+    use crate::gateway::admin::trace::{AgentContextTrust, TokenTelemetry};
     use crate::gateway::router::build_gateway_router_with_admin;
     use crate::gateway::state::GatewayState;
     use dcc_mcp_transport::discovery::file_registry::FileRegistry;
@@ -203,6 +203,7 @@ mod admin_tests {
             client_host: None,
             auth_subject: None,
             source_ip: None,
+            attribution_trust: None,
             parent_request_id: None,
             action: action.to_string(),
             dcc_type: Some("maya".to_string()),
@@ -734,6 +735,14 @@ sinks:
                 client_host: Some("workstation-7".to_string()),
                 auth_subject: Some("user:artist-1".to_string()),
                 source_ip: Some("192.0.2.44".to_string()),
+                attribution_trust: Some(AgentContextTrust {
+                    actor_id: Some("self_reported".to_string()),
+                    actor_name: Some("self_reported".to_string()),
+                    client_platform: Some("header".to_string()),
+                    auth_subject: Some("auth".to_string()),
+                    source_ip: Some("server_derived".to_string()),
+                    ..AgentContextTrust::default()
+                }),
                 parent_request_id: None,
                 action: "tools/call:maya__open_scene".to_string(),
                 dcc_type: Some("maya".to_string()),
@@ -763,6 +772,7 @@ sinks:
                 client_host: None,
                 auth_subject: None,
                 source_ip: None,
+                attribution_trust: None,
                 parent_request_id: None,
                 action: "tools/call:blender__render".to_string(),
                 dcc_type: Some("blender".to_string()),
@@ -814,6 +824,15 @@ sinks:
         assert_eq!(successes[0]["client_host"], "workstation-7");
         assert_eq!(successes[0]["auth_subject"], "user:artist-1");
         assert_eq!(successes[0]["source_ip"], "192.0.2.44");
+        assert_eq!(
+            successes[0]["attribution_trust"]["actor_id"],
+            "self_reported"
+        );
+        assert_eq!(successes[0]["attribution_trust"]["auth_subject"], "auth");
+        assert_eq!(
+            successes[0]["attribution_trust"]["source_ip"],
+            "server_derived"
+        );
         assert_eq!(failures[0]["request_id"], "req-fail");
         assert_eq!(failures[0]["instance_id"], "blender-instance");
 
@@ -846,6 +865,7 @@ sinks:
             client_host: None,
             auth_subject: None,
             source_ip: None,
+            attribution_trust: None,
             parent_request_id: None,
             action: "tools/call:photoshop__save".to_string(),
             dcc_type: None,
@@ -1057,6 +1077,7 @@ sinks:
             client_host: None,
             auth_subject: None,
             source_ip: None,
+            attribution_trust: None,
             parent_request_id: Some("parent-1".to_string()),
             action: "maya.inst.tool".to_string(),
             dcc_type: Some("maya".to_string()),
@@ -1363,6 +1384,7 @@ sinks:
             client_host: None,
             auth_subject: None,
             source_ip: None,
+            attribution_trust: None,
             parent_request_id: Some("req-missing-parent".into()),
             action: "photoshop.12345678.save_document".into(),
             dcc_type: Some("photoshop".into()),
@@ -1545,6 +1567,7 @@ sinks:
             client_host: None,
             auth_subject: None,
             source_ip: None,
+            attribution_trust: None,
             parent_request_id: Some("req-prev".into()),
             action: "maya.inst.long_task".into(),
             dcc_type: Some("maya".into()),
@@ -1910,6 +1933,7 @@ sinks:
                 client_host: None,
                 auth_subject: None,
                 source_ip: None,
+                attribution_trust: None,
                 parent_request_id: None,
                 action: "maya.deadbeef.scene__info".into(),
                 dcc_type: Some("maya".into()),
@@ -1939,6 +1963,7 @@ sinks:
                 client_host: None,
                 auth_subject: None,
                 source_ip: None,
+                attribution_trust: None,
                 parent_request_id: None,
                 action: "blender.cafebabe.scene__info".into(),
                 dcc_type: Some("blender".into()),
@@ -2159,6 +2184,13 @@ sinks:
             client_host: Some("workstation-7".into()),
             auth_subject: Some("user:artist-1".into()),
             source_ip: Some("192.0.2.44".into()),
+            trust: AgentContextTrust {
+                actor_id: Some("self_reported".into()),
+                client_platform: Some("header".into()),
+                auth_subject: Some("auth".into()),
+                source_ip: Some("server_derived".into()),
+                ..AgentContextTrust::default()
+            },
             ..AgentContext::default()
         });
         log.push(with_input);
@@ -2218,6 +2250,10 @@ sinks:
         assert_eq!(rows_with_inputs[0]["client_host"], "workstation-7");
         assert_eq!(rows_with_inputs[0]["auth_subject"], "user:artist-1");
         assert_eq!(rows_with_inputs[0]["source_ip"], "192.0.2.44");
+        assert_eq!(
+            rows_with_inputs[0]["attribution_trust"]["auth_subject"],
+            "auth"
+        );
     }
 
     #[tokio::test]

--- a/crates/dcc-mcp-gateway/src/gateway/admin/trace.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/trace.rs
@@ -369,6 +369,113 @@ fn round_two(value: f64) -> f64 {
 
 // ── Agent / caller context ───────────────────────────────────────────────────
 
+pub const TRUST_SELF_REPORTED: &str = "self_reported";
+pub const TRUST_HEADER: &str = "header";
+pub const TRUST_AUTH: &str = "auth";
+pub const TRUST_SERVER_DERIVED: &str = "server_derived";
+pub const TRUST_TRUSTED_PROXY: &str = "trusted_proxy";
+
+/// Server-computed trust source for caller-attribution fields.
+///
+/// This map is deliberately ignored while parsing external request metadata and
+/// filled by the gateway after each carrier has been normalised. Persisted admin
+/// rows can still deserialize it so historical traces keep their trust labels.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentContextTrust {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor_email_hash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_platform: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_os: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_host: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_subject: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_ip: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub forwarded_for: Option<String>,
+}
+
+impl AgentContextTrust {
+    pub fn is_empty(&self) -> bool {
+        self.actor_id.is_none()
+            && self.actor_name.is_none()
+            && self.actor_email_hash.is_none()
+            && self.agent_id.is_none()
+            && self.agent_name.is_none()
+            && self.agent_kind.is_none()
+            && self.agent_version.is_none()
+            && self.model.is_none()
+            && self.model_provider.is_none()
+            && self.model_version.is_none()
+            && self.client_platform.is_none()
+            && self.client_os.is_none()
+            && self.client_host.is_none()
+            && self.auth_subject.is_none()
+            && self.source_ip.is_none()
+            && self.forwarded_for.is_none()
+    }
+
+    fn mark_present(&mut self, ctx: &AgentContext, source: &str) {
+        set_trust_if_present(&mut self.actor_id, ctx.actor_id.as_ref(), source);
+        set_trust_if_present(&mut self.actor_name, ctx.actor_name.as_ref(), source);
+        set_trust_if_present(
+            &mut self.actor_email_hash,
+            ctx.actor_email_hash.as_ref(),
+            source,
+        );
+        set_trust_if_present(&mut self.agent_id, ctx.agent_id.as_ref(), source);
+        set_trust_if_present(&mut self.agent_name, ctx.agent_name.as_ref(), source);
+        set_trust_if_present(&mut self.agent_kind, ctx.agent_kind.as_ref(), source);
+        set_trust_if_present(&mut self.agent_version, ctx.agent_version.as_ref(), source);
+        set_trust_if_present(&mut self.model, ctx.model.as_ref(), source);
+        set_trust_if_present(
+            &mut self.model_provider,
+            ctx.model_provider.as_ref(),
+            source,
+        );
+        set_trust_if_present(&mut self.model_version, ctx.model_version.as_ref(), source);
+        set_trust_if_present(
+            &mut self.client_platform,
+            ctx.client_platform.as_ref(),
+            source,
+        );
+        set_trust_if_present(&mut self.client_os, ctx.client_os.as_ref(), source);
+        set_trust_if_present(&mut self.client_host, ctx.client_host.as_ref(), source);
+        set_trust_if_present(&mut self.auth_subject, ctx.auth_subject.as_ref(), source);
+    }
+}
+
+fn set_trust_if_present(slot: &mut Option<String>, value: Option<&String>, source: &str) {
+    if value.is_some() {
+        *slot = Some(source.to_string());
+    }
+}
+
+fn set_trust(slot: &mut Option<String>, source: &str) {
+    *slot = Some(source.to_string());
+}
+
 /// Optional client-supplied context that explains why a request was made.
 ///
 /// This is deliberately a telemetry contract, not an instruction to capture a
@@ -509,6 +616,8 @@ pub struct AgentContext {
     pub turn_index: Option<u64>,
     #[serde(default, skip_serializing_if = "Value::is_null")]
     pub metadata: Value,
+    #[serde(default, skip_serializing_if = "AgentContextTrust::is_empty")]
+    pub trust: AgentContextTrust,
 }
 
 impl AgentContext {
@@ -518,8 +627,8 @@ impl AgentContext {
         meta: Option<&Value>,
     ) -> Option<Self> {
         let mut ctx = body
-            .and_then(agent_context_from_value)
-            .or_else(|| meta.and_then(agent_context_from_value))
+            .and_then(|value| agent_context_from_value(value, TRUST_SELF_REPORTED))
+            .or_else(|| meta.and_then(|value| agent_context_from_value(value, TRUST_SELF_REPORTED)))
             .or_else(|| agent_context_from_header(headers))
             .unwrap_or_default();
 
@@ -555,6 +664,17 @@ impl AgentContext {
     ) -> Self {
         self.source_ip = source_ip.map(bound_context_string);
         self.forwarded_for = bound_context_list(forwarded_for);
+        if self.source_ip.is_some() {
+            let source = if self.forwarded_for.is_empty() {
+                TRUST_SERVER_DERIVED
+            } else {
+                TRUST_TRUSTED_PROXY
+            };
+            set_trust(&mut self.trust.source_ip, source);
+        }
+        if !self.forwarded_for.is_empty() {
+            set_trust(&mut self.trust.forwarded_for, TRUST_TRUSTED_PROXY);
+        }
         self
     }
 
@@ -593,9 +713,11 @@ impl AgentContext {
             && self.trace_id.is_none()
             && self.turn_index.is_none()
             && self.metadata.is_null()
+            && self.trust.is_empty()
     }
 
     fn normalise(mut self) -> Self {
+        self.trust = AgentContextTrust::default();
         self.actor_id = self.actor_id.map(bound_context_string);
         self.actor_name = self.actor_name.map(bound_context_string);
         self.actor_email_hash = self.actor_email_hash.map(bound_context_string);
@@ -631,7 +753,7 @@ impl AgentContext {
     }
 }
 
-fn agent_context_from_value(value: &Value) -> Option<AgentContext> {
+fn agent_context_from_value(value: &Value, trust_source: &str) -> Option<AgentContext> {
     let raw = value
         .get("agent_context")
         .or_else(|| value.get("agentContext"))
@@ -650,7 +772,12 @@ fn agent_context_from_value(value: &Value) -> Option<AgentContext> {
         }),
         Value::Object(_) => serde_json::from_value::<AgentContext>(raw.clone())
             .ok()
-            .map(AgentContext::normalise),
+            .map(AgentContext::normalise)
+            .map(|mut ctx| {
+                let snapshot = ctx.clone();
+                ctx.trust.mark_present(&snapshot, trust_source);
+                ctx
+            }),
         _ => None,
     }
 }
@@ -666,52 +793,105 @@ fn agent_context_from_header(headers: &HeaderMap) -> Option<AgentContext> {
             }),
             Value::Object(_) => serde_json::from_value::<AgentContext>(v)
                 .ok()
-                .map(AgentContext::normalise),
+                .map(AgentContext::normalise)
+                .map(|mut ctx| {
+                    let snapshot = ctx.clone();
+                    ctx.trust.mark_present(&snapshot, TRUST_HEADER);
+                    ctx
+                }),
             _ => None,
         })
 }
 
+fn fill_header_trusted_string(
+    slot: &mut Option<String>,
+    trust_slot: &mut Option<String>,
+    headers: &HeaderMap,
+    name: &str,
+) {
+    if slot.is_none()
+        && let Some(value) = header_str(headers, name).map(bound_context_string)
+    {
+        *slot = Some(value);
+        set_trust(trust_slot, TRUST_HEADER);
+    }
+}
+
+fn fill_header_trusted_string_any(
+    slot: &mut Option<String>,
+    trust_slot: &mut Option<String>,
+    headers: &HeaderMap,
+    names: &[&str],
+) {
+    if slot.is_none()
+        && let Some(value) = header_str_any(headers, names).map(bound_context_string)
+    {
+        *slot = Some(value);
+        set_trust(trust_slot, TRUST_HEADER);
+    }
+}
+
 fn merge_header_agent_context(ctx: &mut AgentContext, headers: &HeaderMap) {
-    if ctx.actor_id.is_none() {
-        ctx.actor_id = header_str(headers, "x-dcc-mcp-actor-id").map(bound_context_string);
-    }
-    if ctx.actor_name.is_none() {
-        ctx.actor_name = header_str(headers, "x-dcc-mcp-actor-name").map(bound_context_string);
-    }
-    if ctx.actor_email_hash.is_none() {
-        ctx.actor_email_hash =
-            header_str(headers, "x-dcc-mcp-actor-email-hash").map(bound_context_string);
-    }
-    if ctx.agent_id.is_none() {
-        ctx.agent_id = header_str(headers, "x-dcc-mcp-agent-id").map(bound_context_string);
-    }
-    if ctx.agent_name.is_none() {
-        ctx.agent_name = header_str(headers, "x-dcc-mcp-agent-name").map(bound_context_string);
-    }
-    if ctx.agent_kind.is_none() {
-        ctx.agent_kind = header_str(headers, "x-dcc-mcp-agent-kind").map(bound_context_string);
-    }
-    if ctx.agent_version.is_none() {
-        ctx.agent_version =
-            header_str(headers, "x-dcc-mcp-agent-version").map(bound_context_string);
-    }
-    if ctx.model_provider.is_none() {
-        ctx.model_provider = header_str_any(
-            headers,
-            &["x-dcc-mcp-agent-model-provider", "x-dcc-mcp-model-provider"],
-        )
-        .map(bound_context_string);
-    }
-    if ctx.model_version.is_none() {
-        ctx.model_version = header_str_any(
-            headers,
-            &["x-dcc-mcp-agent-model-version", "x-dcc-mcp-model-version"],
-        )
-        .map(bound_context_string);
-    }
-    if ctx.model.is_none() {
-        ctx.model = header_str(headers, "x-dcc-mcp-agent-model").map(bound_context_string);
-    }
+    fill_header_trusted_string(
+        &mut ctx.actor_id,
+        &mut ctx.trust.actor_id,
+        headers,
+        "x-dcc-mcp-actor-id",
+    );
+    fill_header_trusted_string(
+        &mut ctx.actor_name,
+        &mut ctx.trust.actor_name,
+        headers,
+        "x-dcc-mcp-actor-name",
+    );
+    fill_header_trusted_string(
+        &mut ctx.actor_email_hash,
+        &mut ctx.trust.actor_email_hash,
+        headers,
+        "x-dcc-mcp-actor-email-hash",
+    );
+    fill_header_trusted_string(
+        &mut ctx.agent_id,
+        &mut ctx.trust.agent_id,
+        headers,
+        "x-dcc-mcp-agent-id",
+    );
+    fill_header_trusted_string(
+        &mut ctx.agent_name,
+        &mut ctx.trust.agent_name,
+        headers,
+        "x-dcc-mcp-agent-name",
+    );
+    fill_header_trusted_string(
+        &mut ctx.agent_kind,
+        &mut ctx.trust.agent_kind,
+        headers,
+        "x-dcc-mcp-agent-kind",
+    );
+    fill_header_trusted_string(
+        &mut ctx.agent_version,
+        &mut ctx.trust.agent_version,
+        headers,
+        "x-dcc-mcp-agent-version",
+    );
+    fill_header_trusted_string_any(
+        &mut ctx.model_provider,
+        &mut ctx.trust.model_provider,
+        headers,
+        &["x-dcc-mcp-agent-model-provider", "x-dcc-mcp-model-provider"],
+    );
+    fill_header_trusted_string_any(
+        &mut ctx.model_version,
+        &mut ctx.trust.model_version,
+        headers,
+        &["x-dcc-mcp-agent-model-version", "x-dcc-mcp-model-version"],
+    );
+    fill_header_trusted_string(
+        &mut ctx.model,
+        &mut ctx.trust.model,
+        headers,
+        "x-dcc-mcp-agent-model",
+    );
     if ctx.reasoning_effort.is_none() {
         ctx.reasoning_effort = header_str_any(
             headers,
@@ -736,18 +916,37 @@ fn merge_header_agent_context(ctx: &mut AgentContext, headers: &HeaderMap) {
     if ctx.task.is_none() {
         ctx.task = header_str(headers, "x-dcc-mcp-agent-task").map(bound_context_string);
     }
-    if ctx.client_platform.is_none() {
-        ctx.client_platform =
-            header_str(headers, "x-dcc-mcp-client-platform").map(bound_context_string);
-    }
-    if ctx.client_os.is_none() {
-        ctx.client_os = header_str(headers, "x-dcc-mcp-client-os").map(bound_context_string);
-    }
-    if ctx.client_host.is_none() {
-        ctx.client_host = header_str(headers, "x-dcc-mcp-client-host").map(bound_context_string);
-    }
-    if ctx.auth_subject.is_none() {
-        ctx.auth_subject = header_str(headers, "x-dcc-mcp-auth-subject").map(bound_context_string);
+    fill_header_trusted_string(
+        &mut ctx.client_platform,
+        &mut ctx.trust.client_platform,
+        headers,
+        "x-dcc-mcp-client-platform",
+    );
+    fill_header_trusted_string(
+        &mut ctx.client_os,
+        &mut ctx.trust.client_os,
+        headers,
+        "x-dcc-mcp-client-os",
+    );
+    fill_header_trusted_string(
+        &mut ctx.client_host,
+        &mut ctx.trust.client_host,
+        headers,
+        "x-dcc-mcp-client-host",
+    );
+    if let Some(value) = header_str(
+        headers,
+        crate::gateway::caller_attribution::INTERNAL_AUTH_SUBJECT_HEADER,
+    )
+    .map(bound_context_string)
+    {
+        ctx.auth_subject = Some(value);
+        set_trust(&mut ctx.trust.auth_subject, TRUST_AUTH);
+    } else if ctx.auth_subject.is_none()
+        && let Some(value) = header_str(headers, "x-dcc-mcp-auth-subject").map(bound_context_string)
+    {
+        ctx.auth_subject = Some(value);
+        set_trust(&mut ctx.trust.auth_subject, TRUST_HEADER);
     }
     if ctx.user_intent_summary.is_none() {
         ctx.user_intent_summary = header_str_any(
@@ -906,9 +1105,15 @@ fn is_high_sensitivity_agent_key(key: &str) -> bool {
         normalised.as_str(),
         "agentreply"
             | "agentresponse"
+            | "apikey"
+            | "authsubject"
+            | "authorization"
+            | "bearertoken"
             | "chainofthought"
+            | "email"
             | "hiddencot"
             | "messages"
+            | "password"
             | "prompt"
             | "prompts"
             | "rawagentreply"
@@ -918,8 +1123,12 @@ fn is_high_sensitivity_agent_key(key: &str) -> bool {
             | "rawuserinput"
             | "reply"
             | "response"
+            | "token"
             | "userinput"
     ) || normalised.contains("secret")
+        || normalised.contains("email")
+        || normalised.contains("apikey")
+        || normalised.contains("token")
 }
 
 // ── Span ──────────────────────────────────────────────────────────────────────
@@ -1285,6 +1494,21 @@ mod tests {
         assert_eq!(ctx.agent_reply_chars, Some(140));
         assert_eq!(ctx.plan.len(), 2);
         assert_eq!(ctx.display_name(), Some("Morgan Artist"));
+        assert_eq!(ctx.trust.actor_id.as_deref(), Some(TRUST_HEADER));
+        assert_eq!(ctx.trust.actor_name.as_deref(), Some(TRUST_HEADER));
+        assert_eq!(
+            ctx.trust.actor_email_hash.as_deref(),
+            Some(TRUST_SELF_REPORTED)
+        );
+        assert_eq!(ctx.trust.agent_id.as_deref(), Some(TRUST_HEADER));
+        assert_eq!(ctx.trust.agent_name.as_deref(), Some(TRUST_SELF_REPORTED));
+        assert_eq!(ctx.trust.model.as_deref(), Some(TRUST_HEADER));
+        assert_eq!(
+            ctx.trust.model_version.as_deref(),
+            Some(TRUST_SELF_REPORTED)
+        );
+        assert_eq!(ctx.trust.client_platform.as_deref(), Some(TRUST_HEADER));
+        assert_eq!(ctx.trust.auth_subject.as_deref(), Some(TRUST_HEADER));
     }
 
     #[test]
@@ -1312,6 +1536,10 @@ mod tests {
         assert_eq!(partial_ctx.actor_id.as_deref(), Some("artist-1"));
         assert_eq!(partial_ctx.agent_id, None);
         assert_eq!(partial_ctx.source_ip, None);
+        assert_eq!(
+            partial_ctx.trust.actor_id.as_deref(),
+            Some(TRUST_SELF_REPORTED)
+        );
 
         let mut header_fallback = HeaderMap::new();
         header_fallback.insert("x-dcc-mcp-client-platform", "studio-tool".parse().unwrap());
@@ -1324,6 +1552,7 @@ mod tests {
             AgentContext::from_request_parts(&header_fallback, Some(&malformed), None).unwrap();
         assert_eq!(ctx.actor_id, None);
         assert_eq!(ctx.client_platform.as_deref(), Some("studio-tool"));
+        assert_eq!(ctx.trust.client_platform.as_deref(), Some(TRUST_HEADER));
     }
 
     #[test]
@@ -1341,12 +1570,14 @@ mod tests {
                 "clientOs": "macos",
                 "clientHost": "workstation-42",
                 "authSubject": "oauth:user-7",
+                "actorEmail": "morgan@example.invalid",
                 "sourceIp": "203.0.113.99",
                 "forwardedFor": ["198.51.100.10"]
             }
         });
 
         let ctx = AgentContext::from_request_parts(&headers, Some(&body), None).unwrap();
+        let encoded = serde_json::to_string(&ctx).unwrap();
 
         assert!(
             ctx.actor_id.as_ref().unwrap().len() <= MAX_AGENT_CONTEXT_STRING_BYTES,
@@ -1365,6 +1596,14 @@ mod tests {
             ctx.forwarded_for.is_empty(),
             "forwarded_for must be server-derived"
         );
+        assert_eq!(ctx.trust.actor_id.as_deref(), Some(TRUST_SELF_REPORTED));
+        assert_eq!(
+            ctx.trust.client_platform.as_deref(),
+            Some(TRUST_SELF_REPORTED)
+        );
+        assert_eq!(ctx.trust.auth_subject.as_deref(), Some(TRUST_SELF_REPORTED));
+        assert!(ctx.trust.source_ip.is_none());
+        assert!(!encoded.contains("morgan@example.invalid"));
     }
 
     #[test]
@@ -1382,6 +1621,11 @@ mod tests {
         assert_eq!(
             ctx.forwarded_for,
             vec!["198.51.100.2".to_string(), "203.0.113.3".to_string()]
+        );
+        assert_eq!(ctx.trust.source_ip.as_deref(), Some(TRUST_TRUSTED_PROXY));
+        assert_eq!(
+            ctx.trust.forwarded_for.as_deref(),
+            Some(TRUST_TRUSTED_PROXY)
         );
     }
 
@@ -1413,6 +1657,53 @@ mod tests {
             ctx.forwarded_for,
             vec!["198.51.100.2".to_string(), "203.0.113.3".to_string()]
         );
+        assert_eq!(ctx.trust.actor_id.as_deref(), Some(TRUST_SELF_REPORTED));
+        assert_eq!(ctx.trust.source_ip.as_deref(), Some(TRUST_TRUSTED_PROXY));
+    }
+
+    #[test]
+    fn caller_attribution_auth_subject_prefers_internal_auth_boundary() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-dcc-mcp-auth-subject", "header:spoofed".parse().unwrap());
+        headers.insert(
+            crate::gateway::caller_attribution::INTERNAL_AUTH_SUBJECT_HEADER,
+            "oauth:artist-1".parse().unwrap(),
+        );
+        let body = json!({
+            "caller_context": {
+                "authSubject": "body:spoofed"
+            }
+        });
+
+        let ctx = AgentContext::from_request_parts(&headers, Some(&body), None).unwrap();
+
+        assert_eq!(ctx.auth_subject.as_deref(), Some("oauth:artist-1"));
+        assert_eq!(ctx.trust.auth_subject.as_deref(), Some(TRUST_AUTH));
+    }
+
+    #[test]
+    fn caller_attribution_ignores_mcp_meta_network_spoofing() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            crate::gateway::caller_attribution::INTERNAL_SOURCE_IP_HEADER,
+            "192.0.2.44".parse().unwrap(),
+        );
+        let meta = json!({
+            "agent_context": {
+                "actor_id": "artist-1",
+                "sourceIp": "203.0.113.200",
+                "forwardedFor": ["203.0.113.201"]
+            }
+        });
+
+        let ctx = AgentContext::from_request_parts_with_server_network(&headers, None, Some(&meta))
+            .unwrap();
+
+        assert_eq!(ctx.actor_id.as_deref(), Some("artist-1"));
+        assert_eq!(ctx.source_ip.as_deref(), Some("192.0.2.44"));
+        assert!(ctx.forwarded_for.is_empty());
+        assert_eq!(ctx.trust.actor_id.as_deref(), Some(TRUST_SELF_REPORTED));
+        assert_eq!(ctx.trust.source_ip.as_deref(), Some(TRUST_SERVER_DERIVED));
     }
 
     #[test]

--- a/crates/dcc-mcp-gateway/src/gateway/caller_attribution.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/caller_attribution.rs
@@ -12,6 +12,7 @@ use super::resilience::gateway_limits;
 
 pub(crate) const INTERNAL_SOURCE_IP_HEADER: &str = "x-dcc-mcp-internal-source-ip";
 pub(crate) const INTERNAL_FORWARDED_FOR_HEADER: &str = "x-dcc-mcp-internal-forwarded-for";
+pub(crate) const INTERNAL_AUTH_SUBJECT_HEADER: &str = "x-dcc-mcp-internal-auth-subject";
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct ClientNetworkAttribution {
@@ -33,6 +34,7 @@ pub(crate) async fn caller_attribution_middleware(
         let headers = req.headers_mut();
         headers.remove(INTERNAL_SOURCE_IP_HEADER);
         headers.remove(INTERNAL_FORWARDED_FOR_HEADER);
+        headers.remove(INTERNAL_AUTH_SUBJECT_HEADER);
     }
 
     let attribution = derive_client_network_attribution(&addr, req.headers());

--- a/crates/dcc-mcp-gateway/src/gateway/traffic/redaction.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/traffic/redaction.rs
@@ -43,6 +43,7 @@ impl TrafficRedactor {
                 redacted_paths.push(rule.display_path.clone());
             }
         }
+        redact_default_attribution_fields(attributes, &mut Vec::new(), &mut redacted_paths);
         redacted_paths
     }
 
@@ -98,6 +99,58 @@ fn replace_path(value: &mut Value, path: &[String], replacement: &str) -> bool {
     true
 }
 
+fn redact_default_attribution_fields(
+    value: &mut Value,
+    path: &mut Vec<String>,
+    redacted_paths: &mut Vec<String>,
+) {
+    match value {
+        Value::Object(map) => {
+            for (key, child) in map.iter_mut() {
+                path.push(key.clone());
+                if is_sensitive_attribution_key(key) {
+                    if !child.is_null() {
+                        *child = Value::String("[REDACTED_ATTRIBUTION]".to_string());
+                        redacted_paths.push(path.join("."));
+                    }
+                } else {
+                    redact_default_attribution_fields(child, path, redacted_paths);
+                }
+                path.pop();
+            }
+        }
+        Value::Array(items) => {
+            for (idx, child) in items.iter_mut().enumerate() {
+                path.push(idx.to_string());
+                redact_default_attribution_fields(child, path, redacted_paths);
+                path.pop();
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_sensitive_attribution_key(key: &str) -> bool {
+    let normalised = key
+        .chars()
+        .filter(|ch| *ch != '_' && *ch != '-' && *ch != ' ')
+        .flat_map(char::to_lowercase)
+        .collect::<String>();
+    matches!(
+        normalised.as_str(),
+        "actorid"
+            | "actorname"
+            | "actoremail"
+            | "actoremailhash"
+            | "authsubject"
+            | "clienthost"
+            | "forwardedfor"
+            | "sourceip"
+            | "userinputhash"
+            | "agentreplyhash"
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -128,6 +181,50 @@ mod tests {
         assert_eq!(
             attrs["body"]["data"]["params"]["arguments"]["api_key"],
             "[REDACTED]"
+        );
+    }
+
+    #[test]
+    fn redacts_attribution_fields_by_default() {
+        let redactor = TrafficRedactor::default();
+        let mut attrs = json!({
+            "body": {
+                "data": {
+                    "params": {
+                        "_meta": {
+                            "agent_context": {
+                                "actor_id": "artist-1",
+                                "actor_name": "Morgan Artist",
+                                "client_platform": "cursor",
+                                "client_host": "workstation-7",
+                                "auth_subject": "oauth:artist-1",
+                                "source_ip": "203.0.113.10"
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        let redacted = redactor.redact(&mut attrs);
+
+        assert_eq!(
+            attrs["body"]["data"]["params"]["_meta"]["agent_context"]["actor_id"],
+            "[REDACTED_ATTRIBUTION]"
+        );
+        assert_eq!(
+            attrs["body"]["data"]["params"]["_meta"]["agent_context"]["client_platform"],
+            "cursor"
+        );
+        assert!(
+            redacted
+                .iter()
+                .any(|path| path.ends_with("agent_context.actor_id"))
+        );
+        assert!(
+            redacted
+                .iter()
+                .any(|path| path.ends_with("agent_context.auth_subject"))
         );
     }
 }

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -239,11 +239,26 @@ Caller attribution separates five concepts:
 | Auth subject | `auth_subject` | API-key, bearer-token, OAuth, or local identity subject after authentication. |
 | Network source | `source_ip`, `forwarded_for` | Server-derived only. MCP `_meta`, REST request bodies, and caller headers cannot set these fields. |
 
+Stored `agent_context` values include a server-computed `trust` map, and Admin
+call/trace rows expose the same data as `attribution_trust`. Trust values are:
+
+| Trust value | Meaning |
+| --- | --- |
+| `self_reported` | Supplied by REST body or MCP `_meta`; useful for filtering, not identity proof. |
+| `header` | Supplied by `x-dcc-mcp-*` attribution headers; still self-asserted unless a trusted proxy/auth layer owns those headers. |
+| `auth` | Derived from gateway authentication or an identity-provider integration. |
+| `server_derived` | Derived by the gateway from the socket peer after stripping caller-supplied network fields. |
+| `trusted_proxy` | Derived from `Forwarded` / `X-Forwarded-For` after the configured trusted-proxy depth has been applied. |
+
 Cursor-like MCP clients can place attribution in `_meta.agent_context`, custom
 REST clients can use `meta.agent_context`, and LAN studio tools that cannot
 shape JSON bodies can use the `x-dcc-mcp-*` headers above. Do not send hidden
 reasoning, full prompts, raw user messages, secrets, bearer tokens, or raw agent
-replies in any caller-attribution field.
+replies in any caller-attribution field. LAN operators must not treat
+`self_reported` or `header` actor fields as access control; use gateway auth or
+a trusted proxy/identity provider before relying on actor metadata for
+permissions. Raw actor email is not a supported field; send `actor_email_hash`
+only after hashing or otherwise pseudonymizing it.
 
 Example REST request:
 
@@ -304,7 +319,10 @@ report JSON, OpenAPI Inspector/spec, and docs where a request id is available.
 Raw prompts and raw replies are high-sensitivity data: keep them out of
 `agent_context`; use only an explicitly configured traffic capture policy with
 redaction, sampling, retention, and operator visibility when raw text is needed
-for a private investigation.
+for a private investigation. Traffic capture also treats actor/user/platform
+metadata as potentially sensitive: built-in redaction masks common attribution
+identity fields, and capture configs can add explicit `redact:` rules for
+deployment-specific metadata paths.
 
 `request_id` and `trace_id` are intentionally different. `request_id` identifies
 one HTTP/MCP request (or JSON-RPC id), while `trace_id` identifies the

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -253,6 +253,15 @@ bounded and intended for concise telemetry such as `actor_id`, `actor_name`,
 `source_ip` and `forwarded_for` are server-derived only after proxy trust policy
 has been applied; caller-supplied request metadata cannot set them. Do not send
 hidden chain-of-thought, raw user input, raw agent replies, or secrets.
+Stored context also includes a gateway-computed `trust` map:
+`self_reported` for REST body / MCP `_meta`, `header` for ordinary attribution
+headers, `auth` for authentication-derived subjects, `server_derived` for peer
+addresses, and `trusted_proxy` for accepted forwarded addresses. On a LAN,
+operators should treat `self_reported` and `header` actor fields as filtering
+hints, not access-control facts. Raw actor email is intentionally unsupported;
+use `actor_email_hash` after pseudonymization. Opt-in traffic capture masks
+common attribution identity fields by default and can apply additional
+deployment-specific redaction rules.
 `trace_id`, `request_id`,
 `span_id`, and `parent_span_id` are recorded separately so one trace can contain
 multiple request ids without losing per-request compatibility. Admin call and trace rows

--- a/docs/guide/rest-api-surface.md
+++ b/docs/guide/rest-api-surface.md
@@ -435,6 +435,19 @@ are ignored. Use `client_platform` values such as `cursor`, `claude-desktop`,
 `openclaw`, `clawhub`, `custom-http`, or `studio-tool` to distinguish surfaces
 without overloading agent identity.
 
+The gateway annotates stored context with a server-computed `trust` map and
+Admin rows expose the same map as `attribution_trust`. Values are
+`self_reported` for REST body / MCP `_meta`, `header` for ordinary
+`x-dcc-mcp-*` headers, `auth` for authentication-derived subjects,
+`server_derived` for peer-address network data, and `trusted_proxy` for
+forwarded addresses accepted by the configured trusted-proxy depth. Treat
+`self_reported` and `header` actor fields as filtering hints only; do not use
+them for access control on a LAN unless gateway auth or a trusted proxy owns the
+identity boundary. Raw actor email is intentionally unsupported; send only
+`actor_email_hash` after pseudonymizing the address. Opt-in traffic capture
+masks common attribution identity fields by default and supports explicit
+`redact:` rules for any studio-specific metadata paths.
+
 ---
 
 ## `POST /v1/call_batch` — gateway ordered batches

--- a/skills/dcc-mcp-skill-developer/SKILL.md
+++ b/skills/dcc-mcp-skill-developer/SKILL.md
@@ -106,6 +106,10 @@ into a faster authoring loop.
    input, or raw agent replies. Treat `source_ip` and `forwarded_for` as
    server-derived fields only: caller metadata and examples must not spoof
    them, and adapters should let the HTTP/gateway boundary attach those values.
+   Treat Admin `attribution_trust` / `agent_context.trust` as gateway-computed
+   evidence labels (`self_reported`, `header`, `auth`, `server_derived`,
+   `trusted_proxy`), not client-supplied metadata; adapter examples should
+   demonstrate caller fields, not forged trust fields.
    Preserve
    Admin `links` fields in examples so every trace/debug bundle, OpenAPI
    Inspector/spec link, or issue-report JSON export can be copied as a complete


### PR DESCRIPTION
## Summary
- add gateway-computed trust labels for caller attribution fields
- persist and expose attribution trust in Admin calls/traces and SQLite audit rows
- redact sensitive attribution fields in traffic capture and document LAN spoofing/privacy boundaries
- show trust chips in the Admin UI and update skill developer guidance

Closes #1263

## Validation
- vx cargo fmt --all
- vx cargo test -p dcc-mcp-gateway caller_attribution --features admin -- --nocapture
- vx cargo test -p dcc-mcp-gateway --features admin redacts_attribution_fields_by_default -- --nocapture
- vx cargo test -p dcc-mcp-gateway --features admin test_admin_calls_returns_two_audit_records -- --nocapture
- vx cargo test -p dcc-mcp-gateway --features admin test_admin_traces_returns_rows_with_token_fields -- --nocapture
- vx cargo test -p dcc-mcp-db --features gateway-admin-sqlite roundtrip_audit_json -- --nocapture
- vx npm --prefix admin-ui run build
- vx npm --prefix admin-ui test -- --grep "opens trace detail"
- vx npm --prefix admin-ui test -- admin.spec.ts
- vx cargo clippy -p dcc-mcp-db --features gateway-admin-sqlite --all-targets -- -D warnings
- vx cargo clippy -p dcc-mcp-gateway --features admin,admin-persist-sqlite --all-targets -- -D warnings -A dead-code
- git diff --check

## Skill guidance
- Updated skills/dcc-mcp-skill-developer/SKILL.md to clarify that Admin attribution trust labels are gateway-computed and must not be forged by adapter examples.