### PR TITLE
feat: promote skill helper adoption

### DIFF
--- a/docs/api/skills.md
+++ b/docs/api/skills.md
@@ -559,6 +559,9 @@ helpers that skill scripts can rely on when the full `dcc-mcp-core` wheel is
 available. Prefer it over ad-hoc `utils` modules or adding small runtime
 dependencies for JSON, YAML, file/path work, LZ4 payload compression, schema
 validation, result envelopes, argument normalization, or cancellation checks.
+Skill authoring docs, templates, and generator output should show this module
+as the preferred import path even though older top-level imports remain
+available for compatibility.
 
 ```python
 from dcc_mcp_core.skills_helper import (
@@ -709,6 +712,13 @@ Use `skills_helper` when:
 
 Use a domain-specific Python dependency only when the dependency owns real
 domain behavior that `skills_helper` does not cover.
+
+The bundled `dcc-mcp-skills-creator` and compatibility `dcc-skills-creator`
+validation tools add `skill-helper-adoption` warnings when a skill script
+imports avoidable helpers covered by this namespace, such as `requests`,
+`httpx`, PyYAML, or local `json_utils` / `http_utils` / `file_utils` modules.
+Warnings are advisory for existing skills but should be treated as blockers for
+new generated/reference skills.
 
 TOML helpers are intentionally not exposed yet. The current adapter and bundled
 skill use cases read TOML as metadata handled by core loaders rather than skill

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -103,6 +103,63 @@ runtimes report `degraded`, while required missing runtimes report `missing`.
 describe surfaces expose the resolved state so agents can decide whether to
 load/call a skill before invoking any adapter code.
 
+### Preferred Runtime Helpers
+
+New skill scripts should import dependency-light helper APIs from
+`dcc_mcp_core.skills_helper` before adding small Python dependencies or local
+utility modules:
+
+```python
+from dcc_mcp_core.skills_helper import (
+    SkillFileError,
+    SkillHttpError,
+    ToolValidator,
+    atomic_write_text,
+    http_get_json,
+    json_dumps,
+    json_loads,
+    load_yaml_file,
+    normalize_tool_arguments,
+    skill_entry,
+    skill_error_from_exception,
+    skill_success,
+    yaml_dumps,
+    yaml_loads,
+)
+```
+
+Use `json_dumps` / `json_loads` and `yaml_dumps` / `yaml_loads` instead of
+adding PyYAML or local JSON/YAML wrappers for ordinary skill payloads. Use
+`http_request`, `http_get_json`, and `http_post_json` for bounded synchronous
+JSON REST calls; always set `timeout_ms` and `max_bytes`, and redact headers
+before surfacing them in errors or audit metadata. Use file/path helpers such
+as `ensure_within_root`, `atomic_write_text`, `load_json_file`,
+`load_yaml_file`, and `file_digest` for local session files. Use
+`ToolValidator`, `normalize_tool_arguments`, result helpers, and cancellation
+checks from the same namespace so scripts do not mix helper import paths.
+
+Keep a domain-specific dependency only when it owns behavior that
+`skills_helper` intentionally does not cover: sessions, streaming, multipart
+upload, custom retry/auth flows, SDK-specific API models, non-JSON protocols,
+or rich domain file formats. Existing top-level imports such as
+`from dcc_mcp_core import json_dumps` remain supported for compatibility, but
+new docs, generators, and templates should show `dcc_mcp_core.skills_helper`
+as the canonical path.
+
+When migrating old skills, replace one concern at a time and keep the old test
+fixtures running:
+
+1. Replace direct `requests.get(...).json()` calls with `http_get_json(...)`
+   where the call is a simple bounded JSON request.
+2. Replace PyYAML or local YAML helpers with `load_yaml_file(...)` /
+   `yaml_loads(...)` for bounded configs.
+3. Replace ad-hoc path containment and temp-file writes with
+   `ensure_within_root(...)` and `atomic_write_text(...)`.
+4. Re-run `dcc_mcp_skills_creator__validate_skill_dir`; it now reports
+   `skill-helper-adoption` warnings for generated/reference skills importing
+   avoidable dependencies such as `requests`, `httpx`, PyYAML, or local helper
+   modules covered by `skills_helper`.
+
 ### 3. Set Environment Variable
 
 ```bash

--- a/skills/README.md
+++ b/skills/README.md
@@ -69,6 +69,13 @@ Then use the skill's tools:
 - `validate_skill_dir` — validate a skill against the spec
 - `skill_template` — get a current SKILL.md template
 
+Generated scripts import dependency-light runtime helpers from
+`dcc_mcp_core.skills_helper` by default. That namespace is the preferred path
+for JSON/YAML, bounded HTTP, safe file/path helpers, validation, cancellation,
+and result helpers; `validate_skill_dir` reports `skill-helper-adoption`
+warnings when generated/reference skills import avoidable dependencies such as
+`requests`, `httpx`, PyYAML, or local JSON/HTTP/file helpers for covered cases.
+
 ### Manual Template Copy
 
 ```bash

--- a/skills/dcc-mcp-skill-developer/SKILL.md
+++ b/skills/dcc-mcp-skill-developer/SKILL.md
@@ -99,6 +99,10 @@ into a faster authoring loop.
    before returning request headers in skill errors or audit metadata. Use a
    domain-specific HTTP dependency only for sessions, streaming, multipart
    upload, custom retry/auth flows, or API behavior these helpers do not cover.
+   Run `dcc_mcp_skills_creator__validate_skill_dir` or
+   `dcc_skills_creator__validate_skill_dir` after generator/template changes;
+   treat `skill-helper-adoption` warnings as blockers for new generated or
+   reference skills, and as migration prompts for older production skills.
 7. When changing adapter server wiring or caller examples, keep Admin telemetry
    useful: pass optional `agent_context` / `caller_context` summaries through
    MCP `_meta`, REST `meta`, `x-dcc-mcp-agent-*`, `x-dcc-mcp-actor-*`, or

--- a/skills/dcc-mcp-skills-creator/SKILL.md
+++ b/skills/dcc-mcp-skills-creator/SKILL.md
@@ -122,10 +122,11 @@ Generated `tools.yaml` entries follow the modern contract:
 1. Decide whether the skill is infrastructure, domain, thin-harness, or example.
 2. Give the skill a kebab-case name and each local tool a snake_case name.
 3. Keep host API calls inside scripts, with lazy imports so discovery works without the host running.
-4. Declare `execution`, `affinity`, `timeout_hint_secs`, schemas, annotations, and failure recovery chains in `tools.yaml`.
-5. Put long examples, recipes, and host-specific notes under `references/`.
-6. Validate with `validate_skill_dir` or `dcc_mcp_core.validate_skill()` before loading it in an adapter.
-7. If the desired behavior requires parsing core internals or adapter-private YAML at runtime, stop and request a core API instead.
+4. Import dependency-light runtime helpers from `dcc_mcp_core.skills_helper` first: JSON/YAML codecs, bounded HTTP helpers, safe file/path helpers, validation, cancellation checks, and result helpers.
+5. Declare `execution`, `affinity`, `timeout_hint_secs`, schemas, annotations, and failure recovery chains in `tools.yaml`.
+6. Put long examples, recipes, and host-specific notes under `references/`.
+7. Validate with `validate_skill_dir` or `dcc_mcp_core.validate_skill()` before loading it in an adapter.
+8. If the desired behavior requires parsing core internals or adapter-private YAML at runtime, stop and request a core API instead.
 
 Read [AUTHORING_WORKFLOW.md](references/AUTHORING_WORKFLOW.md) and
 [DCC_TOOL_CONTRACTS.md](references/DCC_TOOL_CONTRACTS.md) before changing a
@@ -145,3 +146,4 @@ The validator checks:
 - **Sidecar files**: `metadata.dcc-mcp.tools/groups/prompts` references exist
 - **Dependencies**: `metadata.dcc-mcp.depends` consistency
 - **Spec compliance**: non-standard top-level keys are frontmatter errors; dcc-mcp-core extensions must live under `metadata.dcc-mcp.*` and point to sibling files
+- **Skill helper adoption**: `validate_skill_dir` emits `skill-helper-adoption` warnings when scripts import avoidable dependencies covered by `dcc_mcp_core.skills_helper`, such as `requests`, `httpx`, PyYAML, or local JSON/HTTP/file/path helper modules

--- a/skills/dcc-mcp-skills-creator/references/AUTHORING_WORKFLOW.md
+++ b/skills/dcc-mcp-skills-creator/references/AUTHORING_WORKFLOW.md
@@ -33,6 +33,15 @@ Scripts should lazy-import host APIs inside the callable function. This keeps
 catalog discovery, validation, and server startup available without a running
 host process.
 
+Import shared helper APIs from `dcc_mcp_core.skills_helper` before adding small
+dependencies or local utility modules. That namespace is the preferred path for
+JSON/YAML codecs, bounded HTTP requests, safe file/path helpers, validation,
+result envelopes, argument normalization, and cancellation checks. Keep
+`requests`, PyYAML, custom HTTP/file helpers, or SDK-specific libraries only
+when they provide behavior `skills_helper` intentionally does not cover, such
+as sessions, streaming, multipart upload, custom retry/auth flows, or rich
+domain file formats.
+
 Use host-thread affinity only where needed:
 
 - `affinity: main` for host API calls and scene mutations.
@@ -43,3 +52,8 @@ Use host-thread affinity only where needed:
 Run the creator validation tool or `dcc_mcp_core.validate_skill()` before adding
 the skill to an adapter's default path. Treat validation warnings as design
 feedback, not only syntax feedback.
+
+`validate_skill_dir` adds `skill-helper-adoption` warnings for scripts that
+import avoidable dependencies covered by `skills_helper`. New generated and
+reference skills should ship without those warnings; legacy production skills
+can migrate one helper category at a time while their existing tests stay green.

--- a/skills/dcc-mcp-skills-creator/scripts/create_skill.py
+++ b/skills/dcc-mcp-skills-creator/scripts/create_skill.py
@@ -119,6 +119,11 @@ tool returns, and what to inspect after success or failure.
 Tool names must stay client-safe (`^[A-Za-z0-9_-]{{1,64}}$`). Use local
 snake_case tool names in `tools.yaml`; dcc-mcp-core publishes them as
 `{name}__tool_name` after the skill is loaded.
+
+Runtime scripts should import dependency-light helpers from
+`dcc_mcp_core.skills_helper` first. It provides JSON/YAML, bounded HTTP, safe
+file/path helpers, validation, cancellation checks, and result helpers without
+adding small Python dependencies to DCC hosts.
 """,
         encoding="utf-8",
     )
@@ -170,7 +175,7 @@ snake_case tool names in `tools.yaml`; dcc-mcp-core publishes them as
     example_script.write_text(
         '"""Example DCC-MCP skill tool implementation."""\n'
         "from __future__ import annotations\n\n"
-        "from dcc_mcp_core.skill import run_main, skill_entry, skill_success\n\n\n"
+        "from dcc_mcp_core.skills_helper import run_main, skill_entry, skill_success\n\n\n"
         "@skill_entry\n"
         'def main(label: str = "example", dry_run: bool = True, **params):\n'
         '    """Replace this scaffold with a concrete DCC operation."""\n'

--- a/skills/dcc-mcp-skills-creator/scripts/skill_template.py
+++ b/skills/dcc-mcp-skills-creator/scripts/skill_template.py
@@ -33,6 +33,12 @@ Write concise instructions for the AI agent:
 Tool names must be client-safe (`^[A-Za-z0-9_-]{1,64}$`). In `tools.yaml`, use
 local snake_case names such as `create_locator`; dcc-mcp-core publishes loaded
 tools as `<skill-name>__<tool_name>`.
+
+Runtime scripts should import dependency-light helpers from
+`dcc_mcp_core.skills_helper` first. It provides JSON/YAML, bounded HTTP, safe
+file/path helpers, validation, cancellation checks, and result helpers while
+keeping generated skills free of small Python dependencies such as `requests`
+or PyYAML for covered cases.
 """
 
 

--- a/skills/dcc-mcp-skills-creator/scripts/validate_skill_dir.py
+++ b/skills/dcc-mcp-skills-creator/scripts/validate_skill_dir.py
@@ -2,7 +2,23 @@
 
 from __future__ import annotations
 
+import ast
+from pathlib import Path
 import sys
+
+_AVOIDABLE_IMPORTS = {
+    "requests": "use http_request/http_get_json/http_post_json from dcc_mcp_core.skills_helper for bounded REST calls",
+    "httpx": "use http_request/http_get_json/http_post_json from dcc_mcp_core.skills_helper for bounded REST calls",
+    "yaml": "use yaml_loads/yaml_dumps or load_yaml_file/dump_yaml_file from dcc_mcp_core.skills_helper",
+    "ruamel": "use yaml_loads/yaml_dumps or load_yaml_file/dump_yaml_file from dcc_mcp_core.skills_helper",
+}
+_LOCAL_HELPER_MODULES = {
+    "file_utils",
+    "http_utils",
+    "json_utils",
+    "path_utils",
+    "yaml_utils",
+}
 
 
 def validate_skill_dir(skill_dir: str) -> dict:
@@ -18,12 +34,69 @@ def validate_skill_dir(skill_dir: str) -> dict:
     from dcc_mcp_core import validate_skill
 
     report = validate_skill(skill_dir)
+    issues = [{"severity": i.severity, "category": i.category, "message": i.message} for i in report.issues]
+    issues.extend(_skill_helper_adoption_warnings(skill_dir))
+    has_errors = any(issue["severity"] == "error" for issue in issues)
+    has_warnings = any(issue["severity"] == "warning" for issue in issues)
     return {
         "skill_dir": report.skill_dir,
-        "is_clean": report.is_clean,
-        "has_errors": report.has_errors,
-        "issues": [{"severity": i.severity, "category": i.category, "message": i.message} for i in report.issues],
+        "is_clean": not has_errors and not has_warnings,
+        "has_errors": has_errors,
+        "has_warnings": has_warnings,
+        "issues": issues,
     }
+
+
+def _skill_helper_adoption_warnings(skill_dir: str) -> list[dict]:
+    """Warn when skill scripts import dependencies covered by skills_helper."""
+    scripts_dir = Path(skill_dir) / "scripts"
+    if not scripts_dir.is_dir():
+        return []
+
+    warnings: list[dict] = []
+    seen: set[tuple[str, str]] = set()
+    for script in sorted(scripts_dir.rglob("*.py")):
+        try:
+            tree = ast.parse(script.read_text(encoding="utf-8"), filename=str(script))
+        except (OSError, SyntaxError):
+            continue
+        rel = script.relative_to(skill_dir).as_posix()
+        for node in ast.walk(tree):
+            for module, hint in _iter_import_hints(node):
+                key = (rel, module)
+                if key in seen:
+                    continue
+                seen.add(key)
+                warnings.append(
+                    {
+                        "severity": "warning",
+                        "category": "skill-helper-adoption",
+                        "message": f"{rel} imports {module!r}; {hint}.",
+                    }
+                )
+    return warnings
+
+
+def _iter_import_hints(node: ast.AST):
+    if isinstance(node, ast.Import):
+        for alias in node.names:
+            module = alias.name.split(".", 1)[0]
+            hint = _AVOIDABLE_IMPORTS.get(module)
+            if hint:
+                yield module, hint
+            elif module in _LOCAL_HELPER_MODULES:
+                yield module, "review whether dcc_mcp_core.skills_helper already covers this local helper"
+    elif isinstance(node, ast.ImportFrom):
+        module = node.module or ""
+        root = module.split(".", 1)[0]
+        basename = module.rsplit(".", 1)[-1]
+        hint = _AVOIDABLE_IMPORTS.get(root)
+        if hint:
+            yield root, hint
+        elif node.level and basename in _LOCAL_HELPER_MODULES:
+            yield basename, "review whether dcc_mcp_core.skills_helper already covers this local helper"
+        elif root in _LOCAL_HELPER_MODULES:
+            yield root, "review whether dcc_mcp_core.skills_helper already covers this local helper"
 
 
 if __name__ == "__main__":
@@ -34,5 +107,6 @@ if __name__ == "__main__":
     print(f"Skill: {result['skill_dir']}")
     print(f"Clean: {result['is_clean']}")
     print(f"Errors: {result['has_errors']}")
+    print(f"Warnings: {result['has_warnings']}")
     for issue in result["issues"]:
         print(f"  [{issue['severity']}] {issue['category']}: {issue['message']}")

--- a/skills/dcc-mcp-skills-creator/tools.yaml
+++ b/skills/dcc-mcp-skills-creator/tools.yaml
@@ -85,6 +85,8 @@ tools:
           type: boolean
         has_errors:
           type: boolean
+        has_warnings:
+          type: boolean
         issues:
           type: array
     execution: sync

--- a/skills/dcc-skills-creator/SKILL.md
+++ b/skills/dcc-skills-creator/SKILL.md
@@ -110,6 +110,11 @@ Generated `tools.yaml` entries follow the modern contract:
 - `enforce_thread_affinity: true` is emitted so adapter dispatch stays honest.
 - `annotations` use MCP hints: read-only, destructive, idempotent, open-world, and deferred.
 
+Generated scripts should import dependency-light runtime helpers from
+`dcc_mcp_core.skills_helper` first. That namespace provides JSON/YAML codecs,
+bounded HTTP helpers, safe file/path helpers, validation, cancellation checks,
+and result helpers without adding small dependencies to DCC hosts.
+
 ## Validation Rules
 
 The validator checks:
@@ -124,3 +129,4 @@ The validator checks:
 - **Sidecar files**: `metadata.dcc-mcp.tools/groups/prompts` references exist
 - **Dependencies**: `depends` vs `metadata/depends.md` consistency
 - **Spec compliance**: non-standard top-level keys are frontmatter errors; dcc-mcp-core extensions must live under `metadata.dcc-mcp.*` and point to sibling files
+- **Skill helper adoption**: `validate_skill_dir` emits `skill-helper-adoption` warnings when scripts import avoidable dependencies covered by `dcc_mcp_core.skills_helper`, such as `requests`, `httpx`, PyYAML, or local JSON/HTTP/file/path helper modules

--- a/skills/dcc-skills-creator/scripts/create_skill.py
+++ b/skills/dcc-skills-creator/scripts/create_skill.py
@@ -119,6 +119,11 @@ tool returns, and what to inspect after success or failure.
 Tool names must stay client-safe (`^[A-Za-z0-9_-]{{1,64}}$`). Use local
 snake_case tool names in `tools.yaml`; dcc-mcp-core publishes them as
 `{name}__tool_name` after the skill is loaded.
+
+Runtime scripts should import dependency-light helpers from
+`dcc_mcp_core.skills_helper` first. It provides JSON/YAML, bounded HTTP, safe
+file/path helpers, validation, cancellation checks, and result helpers without
+adding small Python dependencies to DCC hosts.
 """,
         encoding="utf-8",
     )
@@ -170,7 +175,7 @@ snake_case tool names in `tools.yaml`; dcc-mcp-core publishes them as
     example_script.write_text(
         '"""Example DCC-MCP skill tool implementation."""\n'
         "from __future__ import annotations\n\n"
-        "from dcc_mcp_core.skill import run_main, skill_entry, skill_success\n\n\n"
+        "from dcc_mcp_core.skills_helper import run_main, skill_entry, skill_success\n\n\n"
         "@skill_entry\n"
         'def main(label: str = "example", dry_run: bool = True, **params):\n'
         '    """Replace this scaffold with a concrete DCC operation."""\n'

--- a/skills/dcc-skills-creator/scripts/skill_template.py
+++ b/skills/dcc-skills-creator/scripts/skill_template.py
@@ -33,6 +33,12 @@ Write concise instructions for the AI agent:
 Tool names must be client-safe (`^[A-Za-z0-9_-]{1,64}$`). In `tools.yaml`, use
 local snake_case names such as `create_locator`; dcc-mcp-core publishes loaded
 tools as `<skill-name>__<tool_name>`.
+
+Runtime scripts should import dependency-light helpers from
+`dcc_mcp_core.skills_helper` first. It provides JSON/YAML, bounded HTTP, safe
+file/path helpers, validation, cancellation checks, and result helpers while
+keeping generated skills free of small Python dependencies such as `requests`
+or PyYAML for covered cases.
 """
 
 

--- a/skills/dcc-skills-creator/scripts/validate_skill_dir.py
+++ b/skills/dcc-skills-creator/scripts/validate_skill_dir.py
@@ -2,7 +2,23 @@
 
 from __future__ import annotations
 
+import ast
+from pathlib import Path
 import sys
+
+_AVOIDABLE_IMPORTS = {
+    "requests": "use http_request/http_get_json/http_post_json from dcc_mcp_core.skills_helper for bounded REST calls",
+    "httpx": "use http_request/http_get_json/http_post_json from dcc_mcp_core.skills_helper for bounded REST calls",
+    "yaml": "use yaml_loads/yaml_dumps or load_yaml_file/dump_yaml_file from dcc_mcp_core.skills_helper",
+    "ruamel": "use yaml_loads/yaml_dumps or load_yaml_file/dump_yaml_file from dcc_mcp_core.skills_helper",
+}
+_LOCAL_HELPER_MODULES = {
+    "file_utils",
+    "http_utils",
+    "json_utils",
+    "path_utils",
+    "yaml_utils",
+}
 
 
 def validate_skill_dir(skill_dir: str) -> dict:
@@ -18,12 +34,69 @@ def validate_skill_dir(skill_dir: str) -> dict:
     from dcc_mcp_core import validate_skill
 
     report = validate_skill(skill_dir)
+    issues = [{"severity": i.severity, "category": i.category, "message": i.message} for i in report.issues]
+    issues.extend(_skill_helper_adoption_warnings(skill_dir))
+    has_errors = any(issue["severity"] == "error" for issue in issues)
+    has_warnings = any(issue["severity"] == "warning" for issue in issues)
     return {
         "skill_dir": report.skill_dir,
-        "is_clean": report.is_clean,
-        "has_errors": report.has_errors,
-        "issues": [{"severity": i.severity, "category": i.category, "message": i.message} for i in report.issues],
+        "is_clean": not has_errors and not has_warnings,
+        "has_errors": has_errors,
+        "has_warnings": has_warnings,
+        "issues": issues,
     }
+
+
+def _skill_helper_adoption_warnings(skill_dir: str) -> list[dict]:
+    """Warn when skill scripts import dependencies covered by skills_helper."""
+    scripts_dir = Path(skill_dir) / "scripts"
+    if not scripts_dir.is_dir():
+        return []
+
+    warnings: list[dict] = []
+    seen: set[tuple[str, str]] = set()
+    for script in sorted(scripts_dir.rglob("*.py")):
+        try:
+            tree = ast.parse(script.read_text(encoding="utf-8"), filename=str(script))
+        except (OSError, SyntaxError):
+            continue
+        rel = script.relative_to(skill_dir).as_posix()
+        for node in ast.walk(tree):
+            for module, hint in _iter_import_hints(node):
+                key = (rel, module)
+                if key in seen:
+                    continue
+                seen.add(key)
+                warnings.append(
+                    {
+                        "severity": "warning",
+                        "category": "skill-helper-adoption",
+                        "message": f"{rel} imports {module!r}; {hint}.",
+                    }
+                )
+    return warnings
+
+
+def _iter_import_hints(node: ast.AST):
+    if isinstance(node, ast.Import):
+        for alias in node.names:
+            module = alias.name.split(".", 1)[0]
+            hint = _AVOIDABLE_IMPORTS.get(module)
+            if hint:
+                yield module, hint
+            elif module in _LOCAL_HELPER_MODULES:
+                yield module, "review whether dcc_mcp_core.skills_helper already covers this local helper"
+    elif isinstance(node, ast.ImportFrom):
+        module = node.module or ""
+        root = module.split(".", 1)[0]
+        basename = module.rsplit(".", 1)[-1]
+        hint = _AVOIDABLE_IMPORTS.get(root)
+        if hint:
+            yield root, hint
+        elif node.level and basename in _LOCAL_HELPER_MODULES:
+            yield basename, "review whether dcc_mcp_core.skills_helper already covers this local helper"
+        elif root in _LOCAL_HELPER_MODULES:
+            yield root, "review whether dcc_mcp_core.skills_helper already covers this local helper"
 
 
 if __name__ == "__main__":
@@ -34,5 +107,6 @@ if __name__ == "__main__":
     print(f"Skill: {result['skill_dir']}")
     print(f"Clean: {result['is_clean']}")
     print(f"Errors: {result['has_errors']}")
+    print(f"Warnings: {result['has_warnings']}")
     for issue in result["issues"]:
         print(f"  [{issue['severity']}] {issue['category']}: {issue['message']}")

--- a/skills/dcc-skills-creator/tools.yaml
+++ b/skills/dcc-skills-creator/tools.yaml
@@ -85,6 +85,8 @@ tools:
           type: boolean
         has_errors:
           type: boolean
+        has_warnings:
+          type: boolean
         issues:
           type: array
     execution: sync

--- a/skills/templates/dcc-specific/scripts/execute.py
+++ b/skills/templates/dcc-specific/scripts/execute.py
@@ -8,9 +8,9 @@ Replace the body with actual DCC API calls (e.g. maya.cmds, bpy, hou).
 
 from __future__ import annotations
 
-from dcc_mcp_core.skill import skill_entry
-from dcc_mcp_core.skill import skill_error
-from dcc_mcp_core.skill import skill_success
+from dcc_mcp_core.skills_helper import skill_entry
+from dcc_mcp_core.skills_helper import skill_error
+from dcc_mcp_core.skills_helper import skill_success
 
 
 def main(params: dict) -> dict:

--- a/skills/templates/domain-skill/scripts/primary_action.py
+++ b/skills/templates/domain-skill/scripts/primary_action.py
@@ -6,9 +6,9 @@ The dispatcher calls `main(**kwargs)` and captures the return value as the tool 
 
 from __future__ import annotations
 
-from dcc_mcp_core.skill import skill_entry
-from dcc_mcp_core.skill import skill_error
-from dcc_mcp_core.skill import skill_success
+from dcc_mcp_core.skills_helper import skill_entry
+from dcc_mcp_core.skills_helper import skill_error
+from dcc_mcp_core.skills_helper import skill_success
 
 
 @skill_entry

--- a/skills/templates/domain-skill/scripts/read_only_query.py
+++ b/skills/templates/domain-skill/scripts/read_only_query.py
@@ -6,8 +6,8 @@ Mark them with read_only: true and idempotent: true in SKILL.md.
 
 from __future__ import annotations
 
-from dcc_mcp_core.skill import skill_entry
-from dcc_mcp_core.skill import skill_success
+from dcc_mcp_core.skills_helper import skill_entry
+from dcc_mcp_core.skills_helper import skill_success
 
 
 @skill_entry

--- a/skills/templates/minimal/scripts/hello.py
+++ b/skills/templates/minimal/scripts/hello.py
@@ -6,8 +6,8 @@ It receives parameters as JSON on stdin and must print a JSON result to stdout.
 
 from __future__ import annotations
 
-from dcc_mcp_core.skill import skill_entry
-from dcc_mcp_core.skill import skill_success
+from dcc_mcp_core.skills_helper import skill_entry
+from dcc_mcp_core.skills_helper import skill_success
 
 
 def main(params: dict) -> dict:

--- a/skills/templates/verifier-harness/scripts/import_and_inspect.py
+++ b/skills/templates/verifier-harness/scripts/import_and_inspect.py
@@ -19,9 +19,9 @@ The output MUST match the :class:`dcc_mcp_core.SceneStats` contract:
 from __future__ import annotations
 
 from dcc_mcp_core import SceneStats
-from dcc_mcp_core.skill import skill_entry
-from dcc_mcp_core.skill import skill_error
-from dcc_mcp_core.skill import skill_success
+from dcc_mcp_core.skills_helper import skill_entry
+from dcc_mcp_core.skills_helper import skill_error
+from dcc_mcp_core.skills_helper import skill_success
 
 
 def main(params: dict) -> dict:

--- a/skills/templates/with-groups/scripts/advanced_action.py
+++ b/skills/templates/with-groups/scripts/advanced_action.py
@@ -7,9 +7,9 @@ tool appears in tools/list. Replace with your power-user tool logic.
 
 from __future__ import annotations
 
-from dcc_mcp_core.skill import skill_entry
-from dcc_mcp_core.skill import skill_error
-from dcc_mcp_core.skill import skill_success
+from dcc_mcp_core.skills_helper import skill_entry
+from dcc_mcp_core.skills_helper import skill_error
+from dcc_mcp_core.skills_helper import skill_success
 
 
 def main(params: dict) -> dict:

--- a/skills/templates/with-groups/scripts/basic_action.py
+++ b/skills/templates/with-groups/scripts/basic_action.py
@@ -6,8 +6,8 @@ is loaded. Replace with your default-active tool logic.
 
 from __future__ import annotations
 
-from dcc_mcp_core.skill import skill_entry
-from dcc_mcp_core.skill import skill_success
+from dcc_mcp_core.skills_helper import skill_entry
+from dcc_mcp_core.skills_helper import skill_success
 
 
 def main(params: dict) -> dict:

--- a/tests/test_dcc_skills_creator.py
+++ b/tests/test_dcc_skills_creator.py
@@ -19,6 +19,11 @@ from dcc_mcp_core._server.inprocess_executor import run_skill_script
 SKILL_DIR = REPO_ROOT / "skills" / "dcc-skills-creator"
 CREATE_SKILL_SCRIPT = SKILL_DIR / "scripts" / "create_skill.py"
 SKILL_TEMPLATE_SCRIPT = SKILL_DIR / "scripts" / "skill_template.py"
+VALIDATE_SKILL_SCRIPT = SKILL_DIR / "scripts" / "validate_skill_dir.py"
+CREATOR_SKILL_DIRS = [
+    REPO_ROOT / "skills" / "dcc-skills-creator",
+    REPO_ROOT / "skills" / "dcc-mcp-skills-creator",
+]
 
 
 def _load_module(path: Path, name: str) -> ModuleType:
@@ -109,6 +114,52 @@ def test_create_skill_example_tool_runs_with_inprocess_executor(tmp_path: Path) 
     assert payload["context"]["extra_params"] == {"unused_param": "accepted"}
 
 
+@pytest.mark.parametrize("skill_dir", CREATOR_SKILL_DIRS)
+def test_create_skill_generated_script_prefers_skills_helper(tmp_path: Path, skill_dir: Path) -> None:
+    module = _load_module(skill_dir / "scripts" / "create_skill.py", f"{skill_dir.name.replace('-', '_')}_create")
+    validate_module = _load_module(
+        skill_dir / "scripts" / "validate_skill_dir.py",
+        f"{skill_dir.name.replace('-', '_')}_validate",
+    )
+    generated = Path(module.create_skill(f"{skill_dir.name}-smoke", str(tmp_path)))
+    script = generated / "scripts" / "example_tool.py"
+    source = script.read_text(encoding="utf-8")
+
+    assert "from dcc_mcp_core.skills_helper import" in source
+    assert "from dcc_mcp_core.skill import" not in source
+
+    report = validate_module.validate_skill_dir(str(generated))
+    assert report["is_clean"] is True
+    assert report["has_warnings"] is False
+    assert not report["issues"]
+
+
+def test_validate_skill_dir_warns_about_avoidable_helper_deps(tmp_path: Path) -> None:
+    create_module = _load_module(CREATE_SKILL_SCRIPT, "dcc_skills_creator_create_skill_deps")
+    validate_module = _load_module(VALIDATE_SKILL_SCRIPT, "dcc_skills_creator_validate_skill_deps")
+    generated = Path(create_module.create_skill("python-dependency-warning", str(tmp_path)))
+    (generated / "scripts" / "example_tool.py").write_text(
+        "import file_utils\n"
+        "import requests\n"
+        "import yaml\n"
+        "from dcc_mcp_core.skills_helper import skill_success\n\n"
+        "def main():\n"
+        "    return skill_success('ok')\n",
+        encoding="utf-8",
+    )
+
+    report = validate_module.validate_skill_dir(str(generated))
+    messages = "\n".join(issue["message"] for issue in report["issues"])
+
+    assert report["has_errors"] is False
+    assert report["has_warnings"] is True
+    assert report["is_clean"] is False
+    assert "skill-helper-adoption" in {issue["category"] for issue in report["issues"]}
+    assert "requests" in messages
+    assert "yaml" in messages
+    assert "file_utils" in messages
+
+
 def test_create_skill_rejects_non_kebab_case_name(tmp_path: Path) -> None:
     module = _load_module(CREATE_SKILL_SCRIPT, "dcc_skills_creator_create_skill_invalid")
 
@@ -156,3 +207,4 @@ def test_skill_template_uses_valid_current_frontmatter(tmp_path: Path) -> None:
     report = dcc_mcp_core.validate_skill(str(skill_dir))
     assert report.is_clean, [(issue.severity, issue.message) for issue in report.issues]
     assert "client-safe" in module.skill_template()
+    assert "dcc_mcp_core.skills_helper" in module.skill_template()


### PR DESCRIPTION
## Summary
- update skill authoring docs to make dcc_mcp_core.skills_helper the preferred helper import path
- make creator scaffolds and skill templates import result helpers from skills_helper
- add validate_skill_dir adoption warnings for avoidable helper dependencies

Closes #1259

## Validation
- vx ruff check skills/dcc-mcp-skills-creator/scripts/create_skill.py skills/dcc-skills-creator/scripts/create_skill.py skills/dcc-mcp-skills-creator/scripts/skill_template.py skills/dcc-skills-creator/scripts/skill_template.py skills/dcc-mcp-skills-creator/scripts/validate_skill_dir.py skills/dcc-skills-creator/scripts/validate_skill_dir.py tests/test_dcc_skills_creator.py
- vx npm --prefix admin-ui ci
- vx npm --prefix admin-ui run build
- $env:DCC_MCP_ADMIN_UI_PREBUILT='1'; vx just dev
- & .\.venv\Scripts\python.exe -m pytest tests\test_dcc_skills_creator.py -q
- & .\.venv\Scripts\python.exe -m pytest tests\test_bundled_skill_metadata.py tests\test_skills_loader.py -q
- git diff --check