### PR TITLE
feat: prefer skills helper in skill authoring

### DIFF
--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -550,6 +550,7 @@ fn lint_bundled_skills_are_present_and_clean() {
     let builtin_skill_roots = [
         workspace_root.join("skills/core"),
         workspace_root.join("skills/dcc-skills-creator"),
+        workspace_root.join("skills/dcc-mcp-skills-creator"),
         workspace_root.join("python/dcc_mcp_core/skills"),
     ];
 

--- a/crates/dcc-mcp-skills/src/validator/rules.rs
+++ b/crates/dcc-mcp-skills/src/validator/rules.rs
@@ -364,6 +364,9 @@ fn validate_scripts(skill_dir: &Path, meta: &SkillMetadata, report: &mut SkillVa
                         ),
                     ));
                 }
+                if ext_str.eq_ignore_ascii_case("py") {
+                    validate_python_script_helpers(skill_dir, tool, report);
+                }
             } else {
                 report.issues.push(SkillValidationIssue::warn(
                     IssueCategory::Scripts,
@@ -385,6 +388,97 @@ fn validate_scripts(skill_dir: &Path, meta: &SkillMetadata, report: &mut SkillVa
             ));
         }
     }
+}
+
+fn validate_python_script_helpers(
+    skill_dir: &Path,
+    tool: &ToolDeclaration,
+    report: &mut SkillValidationReport,
+) {
+    let path = skill_dir.join(&tool.source_file);
+    let content = match std::fs::read_to_string(&path) {
+        Ok(content) => content,
+        Err(err) => {
+            report.issues.push(SkillValidationIssue::warn(
+                IssueCategory::Scripts,
+                format!(
+                    "tool '{}' source_file '{}' could not be read for dependency linting: {err}",
+                    tool.name, tool.source_file
+                ),
+            ));
+            return;
+        }
+    };
+
+    let mut warned_requests = false;
+    let mut warned_yaml = false;
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with('#') {
+            continue;
+        }
+        if !warned_requests && imports_python_module(trimmed, "requests") {
+            warned_requests = true;
+            report.issues.push(SkillValidationIssue::warn(
+                IssueCategory::Scripts,
+                format!(
+                    "tool '{}' source_file '{}' imports requests; prefer \
+                     dcc_mcp_core.skills_helper.http_request/http_get_json/http_post_json \
+                     for bounded common JSON APIs, and keep requests only for sessions, \
+                     streaming, multipart upload, custom auth/retry flows, or API-specific behavior",
+                    tool.name, tool.source_file
+                ),
+            ));
+        }
+        if !warned_yaml && imports_python_module(trimmed, "yaml") {
+            warned_yaml = true;
+            report.issues.push(SkillValidationIssue::warn(
+                IssueCategory::Scripts,
+                format!(
+                    "tool '{}' source_file '{}' imports PyYAML; prefer \
+                     dcc_mcp_core.skills_helper.load_yaml_text/load_yaml_file/\
+                     dump_yaml_text/dump_yaml_file for dependency-free skill YAML, \
+                     and keep PyYAML only when preserving comments, anchors, or other \
+                     behavior the helper namespace does not cover",
+                    tool.name, tool.source_file
+                ),
+            ));
+        }
+        if warned_requests && warned_yaml {
+            break;
+        }
+    }
+}
+
+fn imports_python_module(trimmed_line: &str, module: &str) -> bool {
+    if let Some(rest) = trimmed_line.strip_prefix("from ") {
+        let imported = rest.split_whitespace().next().unwrap_or_default();
+        return import_module_name_matches(imported, module);
+    }
+
+    let Some(rest) = trimmed_line.strip_prefix("import ") else {
+        return false;
+    };
+    rest.split(',')
+        .any(|part| import_part_matches_module(part, module))
+}
+
+fn import_module_name_matches(name: &str, module: &str) -> bool {
+    let Some(rest) = name.strip_prefix(module) else {
+        return false;
+    };
+    rest.is_empty() || rest.starts_with('.')
+}
+
+fn import_part_matches_module(part: &str, module: &str) -> bool {
+    let part = part.trim_start();
+    let Some(rest) = part.strip_prefix(module) else {
+        return false;
+    };
+    rest.is_empty()
+        || rest.starts_with('.')
+        || rest.starts_with(" as ")
+        || rest.chars().next().is_some_and(char::is_whitespace)
 }
 
 fn validate_sidecars(

--- a/crates/dcc-mcp-skills/src/validator/tests.rs
+++ b/crates/dcc-mcp-skills/src/validator/tests.rs
@@ -290,3 +290,53 @@ fn test_unsupported_script_extension() {
             .any(|issue| issue.message.contains("unsupported extension"))
     );
 }
+
+#[test]
+fn test_python_script_requests_import_warns_about_skills_helper_http() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = make_skill_dir(
+        &tmp,
+        "http-skill",
+        "---\nname: http-skill\ndescription: test\ntools:\n  - name: fetch_asset\n    source_file: scripts/fetch_asset.py\n---\n",
+    );
+    let scripts_dir = dir.join("scripts");
+    std::fs::create_dir_all(&scripts_dir).unwrap();
+    std::fs::write(
+        scripts_dir.join("fetch_asset.py"),
+        "import os, requests as http\n\nrequests.get('https://example.invalid')\n",
+    )
+    .unwrap();
+
+    let report = validate_skill_dir(&dir);
+
+    assert!(report.issues.iter().any(|issue| {
+        issue.severity == IssueSeverity::Warning
+            && issue.category == IssueCategory::Scripts
+            && issue.message.contains("skills_helper.http_request")
+    }));
+}
+
+#[test]
+fn test_python_script_yaml_import_warns_about_skills_helper_yaml() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = make_skill_dir(
+        &tmp,
+        "yaml-skill",
+        "---\nname: yaml-skill\ndescription: test\ntools:\n  - name: read_config\n    source_file: scripts/read_config.py\n---\n",
+    );
+    let scripts_dir = dir.join("scripts");
+    std::fs::create_dir_all(&scripts_dir).unwrap();
+    std::fs::write(
+        scripts_dir.join("read_config.py"),
+        "from yaml import safe_load\n\nsafe_load('enabled: true')\n",
+    )
+    .unwrap();
+
+    let report = validate_skill_dir(&dir);
+
+    assert!(report.issues.iter().any(|issue| {
+        issue.severity == IssueSeverity::Warning
+            && issue.category == IssueCategory::Scripts
+            && issue.message.contains("load_yaml_text")
+    }));
+}

--- a/docs/api/skills.md
+++ b/docs/api/skills.md
@@ -692,6 +692,13 @@ Existing imports such as `from dcc_mcp_core import json_dumps` continue to work
 and re-export the same canonical functions. New helpers for skill authoring
 belong under `skills_helper`, not a vague `utils` namespace.
 
+Generated Python skill scripts should also import the standard runner and
+result helpers through this namespace when the full wheel is available:
+
+```python
+from dcc_mcp_core.skills_helper import run_main, skill_entry, skill_success
+```
+
 Use `skills_helper` when:
 
 - a skill needs dependency-free JSON or YAML parsing instead of `json`, PyYAML,
@@ -702,7 +709,7 @@ Use `skills_helper` when:
   `skill_error`, `success_result`, or `error_result`;
 - a tool wrapper needs `normalize_tool_arguments()` / `normalize_tool_meta()`
   to match the shared MCP/REST call-envelope contract;
-- long-running scripts need `check_cancelled()` / `check_dcc_cancelled()`.
+- long-running scripts need `check_cancelled()` / `check_dcc_cancelled()`;
 - a bounded HTTP or file/path helper is covered by this namespace in your
   installed version; use `requests` or domain-specific file libraries only for
   behavior that `skills_helper` does not provide.

--- a/docs/guide/skill-maintenance.md
+++ b/docs/guide/skill-maintenance.md
@@ -55,17 +55,22 @@ Before adding or changing bundled adapter skills, read [`docs/POLICY_SKILL_OWNER
   with `possible_solutions` instead of letting Maya open modal dialogs.
 - For writes: ensure parent directory exists or return a structured error.
 - After export: verify output file exists and non-zero size when feasible.
+- Prefer `dcc_mcp_core.skills_helper` for result helpers, JSON/YAML codecs,
+  bounded HTTP, file/path safety, hashing, compression, schema validation,
+  argument normalization, and cancellation checks. Keep `requests`, PyYAML, or
+  domain dependencies only for behavior the helper namespace does not cover.
 
-## Linting (dcc-mcp-maya)
+## Linting
 
-Run from the Maya adapter repo:
+Run the production CLI validator before loading a skill package:
 
 ```bash
-python tools/lint_skills.py
+dcc-mcp-cli lint path/to/skills
 ```
 
-Rules include IO description length hints and `references/` metadata coverage.
-Extend `tools/lint_skills.py` when you add new cross-cutting conventions.
+Repository CI runs the same validator through `just lint-skills`. Extend the
+Rust validator in `crates/dcc-mcp-skills/src/validator/` when you add new
+cross-cutting conventions.
 
 ## Gateway-facing agents
 

--- a/docs/zh/api/skills.md
+++ b/docs/zh/api/skills.md
@@ -574,9 +574,50 @@ shared-memory 层现有 LZ4 frame 实现，并强制显式 byte limit。
 里的 file helper 是单个 Skill 或 session root 内部的低层 building block，
 不替代更高层的 artefact store contract。
 
+有边界的 REST 调用应优先使用 Rust-backed HTTP helper，而不是为常见 JSON API
+额外引入 `requests`：
+
+```python
+from dcc_mcp_core.skills_helper import (
+    SkillHttpError,
+    http_get_json,
+    http_post_json,
+    skill_error_from_exception,
+)
+
+try:
+    info = http_get_json(
+        "https://pipeline.example/api/asset",
+        query={"name": asset_name},
+        headers={"Authorization": f"Bearer {token}"},
+        timeout_ms=5_000,
+        max_bytes=1_000_000,
+    )
+    created = http_post_json(
+        "https://pipeline.example/api/report",
+        {"asset": asset_name, "info": info},
+        timeout_ms=5_000,
+    )
+except SkillHttpError as exc:
+    return skill_error_from_exception(exc)
+```
+
+`http_request()` 返回 `HttpResponse`，包含 `status`、`headers`、`bytes`、
+`text`、`json()`、`url`、`elapsed_ms` 和 `truncated`。在错误或 audit metadata
+里回显 headers 前，先调用 `redact_http_headers()`。只有在需要 session、
+streaming protocol、multipart upload、自定义 auth/retry flow，或 API 专有行为时，
+才保留领域专用 HTTP client dependency。
+
 现有 `from dcc_mcp_core import json_dumps` 仍可使用，并 re-export 同一组
 canonical functions。新的 Skill authoring helper 应放在 `skills_helper`，
 不要放进含义模糊的 `utils` 命名空间。
+
+生成的 Python Skill 脚本在完整 wheel 可用时，也应通过这个命名空间导入标准
+runner 和结果 helper：
+
+```python
+from dcc_mcp_core.skills_helper import run_main, skill_entry, skill_success
+```
 
 适合使用 `skills_helper` 的场景：
 
@@ -585,7 +626,7 @@ canonical functions。新的 Skill authoring helper 应放在 `skills_helper`，
   本地 session file 的 LZ4 compression；
 - handler 需要 `skill_success`、`skill_error`、`success_result`、`error_result` 等标准结果 helper；
 - 工具 wrapper 需要 `normalize_tool_arguments()` / `normalize_tool_meta()` 来遵循共享 MCP/REST call envelope contract；
-- 长时间运行的脚本需要 `check_cancelled()` / `check_dcc_cancelled()`。
+- 长时间运行的脚本需要 `check_cancelled()` / `check_dcc_cancelled()`；
 - 当前安装版本的 `skills_helper` 已覆盖某个有边界的 HTTP 或 file/path
   helper；只有在 `skills_helper` 不覆盖所需行为时，才继续使用 `requests`
   或领域专用 file library。

--- a/justfile
+++ b/justfile
@@ -251,7 +251,7 @@ lint-py:
 
 # Lint bundled, example, and fixture skills with the built production CLI
 lint-skills: build-cli
-    {{CLI_BIN}} lint --max-depth 4 skills/core skills/dcc-skills-creator skills/dcc-mcp-skill-developer skills/dcc-cli-gateway skills/dcc-rest-gateway python/dcc_mcp_core/skills examples/skills examples/remote-server/skills examples/rez-skills tests/fixtures/skills tests/fixtures/prompts_skills
+    {{CLI_BIN}} lint --max-depth 4 skills/core skills/dcc-skills-creator skills/dcc-mcp-skills-creator skills/dcc-mcp-skill-developer skills/dcc-cli-gateway skills/dcc-rest-gateway python/dcc_mcp_core/skills examples/skills examples/remote-server/skills examples/rez-skills tests/fixtures/skills tests/fixtures/prompts_skills
 
 # Verify pure-Python sources parse on Python 3.7 (cp37 wheel parity).
 lint-py37-syntax:

--- a/skills/dcc-mcp-skills-creator/SKILL.md
+++ b/skills/dcc-mcp-skills-creator/SKILL.md
@@ -122,10 +122,16 @@ Generated `tools.yaml` entries follow the modern contract:
 1. Decide whether the skill is infrastructure, domain, thin-harness, or example.
 2. Give the skill a kebab-case name and each local tool a snake_case name.
 3. Keep host API calls inside scripts, with lazy imports so discovery works without the host running.
-4. Declare `execution`, `affinity`, `timeout_hint_secs`, schemas, annotations, and failure recovery chains in `tools.yaml`.
-5. Put long examples, recipes, and host-specific notes under `references/`.
-6. Validate with `validate_skill_dir` or `dcc_mcp_core.validate_skill()` before loading it in an adapter.
-7. If the desired behavior requires parsing core internals or adapter-private YAML at runtime, stop and request a core API instead.
+4. In Python scripts, prefer `dcc_mcp_core.skills_helper` for result helpers,
+   JSON/YAML, bounded HTTP, file/path safety, hashing, compression, schema
+   validation, argument normalization, and cancellation checks. Keep `requests`,
+   PyYAML, or domain libraries only when the helper namespace does not cover the
+   behavior, such as sessions, streaming, multipart upload, custom auth/retry
+   flows, YAML comment preservation, or host SDKs.
+5. Declare `execution`, `affinity`, `timeout_hint_secs`, schemas, annotations, and failure recovery chains in `tools.yaml`.
+6. Put long examples, recipes, and host-specific notes under `references/`.
+7. Validate with `validate_skill_dir`, `dcc_mcp_core.validate_skill()`, or `dcc-mcp-cli lint` before loading it in an adapter.
+8. If the desired behavior requires parsing core internals or adapter-private YAML at runtime, stop and request a core API instead.
 
 Read [AUTHORING_WORKFLOW.md](references/AUTHORING_WORKFLOW.md) and
 [DCC_TOOL_CONTRACTS.md](references/DCC_TOOL_CONTRACTS.md) before changing a

--- a/skills/dcc-mcp-skills-creator/references/AUTHORING_WORKFLOW.md
+++ b/skills/dcc-mcp-skills-creator/references/AUTHORING_WORKFLOW.md
@@ -33,6 +33,14 @@ Scripts should lazy-import host APIs inside the callable function. This keeps
 catalog discovery, validation, and server startup available without a running
 host process.
 
+When the full `dcc-mcp-core` wheel is available, Python scripts should import
+standard result helpers, dependency-light JSON/YAML codecs, bounded HTTP,
+file/path safety, hashing, compression, validation, normalization, and
+cancellation helpers from `dcc_mcp_core.skills_helper`. Keep `requests`,
+PyYAML, or domain-specific dependencies only for behavior that namespace does
+not cover, such as sessions, streaming, multipart upload, custom auth/retry
+flows, YAML comment preservation, or host SDKs.
+
 Use host-thread affinity only where needed:
 
 - `affinity: main` for host API calls and scene mutations.

--- a/skills/dcc-mcp-skills-creator/scripts/create_skill.py
+++ b/skills/dcc-mcp-skills-creator/scripts/create_skill.py
@@ -170,7 +170,7 @@ snake_case tool names in `tools.yaml`; dcc-mcp-core publishes them as
     example_script.write_text(
         '"""Example DCC-MCP skill tool implementation."""\n'
         "from __future__ import annotations\n\n"
-        "from dcc_mcp_core.skill import run_main, skill_entry, skill_success\n\n\n"
+        "from dcc_mcp_core.skills_helper import run_main, skill_entry, skill_success\n\n\n"
         "@skill_entry\n"
         'def main(label: str = "example", dry_run: bool = True, **params):\n'
         '    """Replace this scaffold with a concrete DCC operation."""\n'

--- a/skills/dcc-mcp-skills-creator/scripts/skill_template.py
+++ b/skills/dcc-mcp-skills-creator/scripts/skill_template.py
@@ -33,6 +33,11 @@ Write concise instructions for the AI agent:
 Tool names must be client-safe (`^[A-Za-z0-9_-]{1,64}$`). In `tools.yaml`, use
 local snake_case names such as `create_locator`; dcc-mcp-core publishes loaded
 tools as `<skill-name>__<tool_name>`.
+
+For Python scripts, import standard result helpers and dependency-light codecs,
+HTTP, file/path, validation, normalization, and cancellation helpers from
+`dcc_mcp_core.skills_helper` when the full wheel is available. Keep
+domain-specific dependencies only for behavior that namespace does not cover.
 """
 
 

--- a/skills/dcc-skills-creator/SKILL.md
+++ b/skills/dcc-skills-creator/SKILL.md
@@ -110,6 +110,22 @@ Generated `tools.yaml` entries follow the modern contract:
 - `enforce_thread_affinity: true` is emitted so adapter dispatch stays honest.
 - `annotations` use MCP hints: read-only, destructive, idempotent, open-world, and deferred.
 
+## Python Script Helpers
+
+Generated Python scripts should import standard result helpers from
+`dcc_mcp_core.skills_helper` when the full wheel is available:
+
+```python
+from dcc_mcp_core.skills_helper import run_main, skill_entry, skill_success
+```
+
+Use the same namespace for dependency-light JSON/YAML codecs, bounded HTTP
+requests, file/path safety, hashing, compression, schema validation, argument
+normalization, and cancellation checks. Keep `requests`, PyYAML, or domain
+libraries only when the helper namespace does not cover the behavior, such as
+sessions, streaming, multipart upload, custom auth/retry flows, YAML comment
+preservation, or host SDKs.
+
 ## Validation Rules
 
 The validator checks:

--- a/skills/dcc-skills-creator/scripts/create_skill.py
+++ b/skills/dcc-skills-creator/scripts/create_skill.py
@@ -170,7 +170,7 @@ snake_case tool names in `tools.yaml`; dcc-mcp-core publishes them as
     example_script.write_text(
         '"""Example DCC-MCP skill tool implementation."""\n'
         "from __future__ import annotations\n\n"
-        "from dcc_mcp_core.skill import run_main, skill_entry, skill_success\n\n\n"
+        "from dcc_mcp_core.skills_helper import run_main, skill_entry, skill_success\n\n\n"
         "@skill_entry\n"
         'def main(label: str = "example", dry_run: bool = True, **params):\n'
         '    """Replace this scaffold with a concrete DCC operation."""\n'

--- a/skills/dcc-skills-creator/scripts/skill_template.py
+++ b/skills/dcc-skills-creator/scripts/skill_template.py
@@ -33,6 +33,11 @@ Write concise instructions for the AI agent:
 Tool names must be client-safe (`^[A-Za-z0-9_-]{1,64}$`). In `tools.yaml`, use
 local snake_case names such as `create_locator`; dcc-mcp-core publishes loaded
 tools as `<skill-name>__<tool_name>`.
+
+For Python scripts, import standard result helpers and dependency-light codecs,
+HTTP, file/path, validation, normalization, and cancellation helpers from
+`dcc_mcp_core.skills_helper` when the full wheel is available. Keep
+domain-specific dependencies only for behavior that namespace does not cover.
 """
 
 

--- a/skills/integration-guide.md
+++ b/skills/integration-guide.md
@@ -326,7 +326,7 @@ The pattern is similar — a Python process bridges between MCP and ZBrush's API
 
 ```python
 # zbrush_adapter/server.py
-import requests
+from dcc_mcp_core.skills_helper import http_get_json
 from dcc_mcp_core.server_base import DccServerBase
 
 class ZBrushMcpServer(DccServerBase):
@@ -345,8 +345,11 @@ class ZBrushMcpServer(DccServerBase):
         return handle
 
     def _get_tool_info(self, params):
-        resp = requests.get(f"{self._zbrush_url}/api/tool/info")
-        return resp.json()
+        return http_get_json(
+            f"{self._zbrush_url}/api/tool/info",
+            timeout_ms=5_000,
+            max_bytes=1_000_000,
+        )
 ```
 
 ### After Effects example (ExtendScript bridge)

--- a/tests/test_dcc_skills_creator.py
+++ b/tests/test_dcc_skills_creator.py
@@ -19,6 +19,7 @@ from dcc_mcp_core._server.inprocess_executor import run_skill_script
 SKILL_DIR = REPO_ROOT / "skills" / "dcc-skills-creator"
 CREATE_SKILL_SCRIPT = SKILL_DIR / "scripts" / "create_skill.py"
 SKILL_TEMPLATE_SCRIPT = SKILL_DIR / "scripts" / "skill_template.py"
+MODERN_SKILL_DIR = REPO_ROOT / "skills" / "dcc-mcp-skills-creator"
 
 
 def _load_module(path: Path, name: str) -> ModuleType:
@@ -65,6 +66,8 @@ def test_create_skill_generates_valid_current_layout(tmp_path: Path) -> None:
     assert json.loads(meta.tools[0].output_schema)["type"] == "object"
     assert meta.tools[0].annotations["readOnlyHint"] is True
     assert "affinity: main" in (generated / "tools.yaml").read_text(encoding="utf-8")
+    script_text = (generated / "scripts" / "create_locator.py").read_text(encoding="utf-8")
+    assert "from dcc_mcp_core.skills_helper import run_main, skill_entry, skill_success" in script_text
 
 
 def test_create_skill_example_tool_runs_successfully(tmp_path: Path) -> None:
@@ -156,3 +159,16 @@ def test_skill_template_uses_valid_current_frontmatter(tmp_path: Path) -> None:
     report = dcc_mcp_core.validate_skill(str(skill_dir))
     assert report.is_clean, [(issue.severity, issue.message) for issue in report.issues]
     assert "client-safe" in module.skill_template()
+    assert "dcc_mcp_core.skills_helper" in module.skill_template()
+
+
+def test_modern_creator_generator_uses_skills_helper(tmp_path: Path) -> None:
+    module = _load_module(
+        MODERN_SKILL_DIR / "scripts" / "create_skill.py",
+        "dcc_mcp_skills_creator_create_skill",
+    )
+
+    generated = Path(module.create_skill("python-modern-tool", str(tmp_path)))
+    script_text = (generated / "scripts" / "example_tool.py").read_text(encoding="utf-8")
+
+    assert "from dcc_mcp_core.skills_helper import run_main, skill_entry, skill_success" in script_text


### PR DESCRIPTION
## Summary

- Update skill authoring docs, templates, and examples to prefer `dcc_mcp_core.skills_helper` for JSON/YAML, bounded HTTP, file/path safety, validation, normalization, cancellation, and result helpers.
- Generate new skill script scaffolds against `skills_helper` in both creator skill packages.
- Add skill-lint warnings for avoidable `requests` and PyYAML imports in Python skill scripts, and include `dcc-mcp-skills-creator` in bundled skill lint coverage.

## Validation

- `vx cargo test -p dcc-mcp-skills validator::tests --quiet`
- `vx cargo test -p dcc-mcp-cli lint_bundled_skills_are_present_and_clean --quiet`
- `.\.venv\Scripts\python.exe -m pytest tests\test_dcc_skills_creator.py -q --tb=short --show-capture=no`
- `vx ruff check skills\dcc-mcp-skills-creator\scripts\create_skill.py skills\dcc-mcp-skills-creator\scripts\skill_template.py skills\dcc-skills-creator\scripts\create_skill.py skills\dcc-skills-creator\scripts\skill_template.py tests\test_dcc_skills_creator.py`
- `vx just lint-skills`
- Commit hooks: ruff, ruff format, cargo fmt, cargo clippy

Skill guidance updated: `dcc-mcp-skills-creator` and compatibility `dcc-skills-creator` now document the `skills_helper` default path and domain-dependency boundary.

Closes #1259