### PR TITLE
fix: tolerate raw async dispatch output

### DIFF
--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/wire.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/wire.rs
@@ -5,6 +5,8 @@ use serde_json::{Value, json};
 use dcc_mcp_actions::{DispatchError, DispatchResult};
 use dcc_mcp_models::ThreadAffinity;
 
+const MALFORMED_DISPATCH_WIRE_PAYLOAD: &str = "malformed dispatch wire payload";
+
 pub(crate) fn use_main_thread_route(
     thread_affinity: ThreadAffinity,
     executor_present: bool,
@@ -102,7 +104,7 @@ pub(crate) fn decode_dispatch_wire(json_str: &str) -> Result<DispatchResult, Dis
         return Err(DispatchError::HandlerError(err.to_string()));
     }
     Err(DispatchError::HandlerError(
-        "malformed dispatch wire payload".to_string(),
+        MALFORMED_DISPATCH_WIRE_PAYLOAD.to_string(),
     ))
 }
 
@@ -178,9 +180,14 @@ fn decode_dispatch_error_payload(value: &Value) -> DispatchError {
 
 /// MCP hot path — callers only need the handler output [`Value`].
 pub(crate) fn decode_dispatch_output(json_str: &str) -> Result<Value, String> {
-    decode_dispatch_wire(json_str)
-        .map(|r| r.output)
-        .map_err(|e| e.to_string())
+    match decode_dispatch_wire(json_str) {
+        Ok(result) => Ok(result.output),
+        Err(DispatchError::HandlerError(message)) if message == MALFORMED_DISPATCH_WIRE_PAYLOAD => {
+            serde_json::from_str(json_str)
+                .map_err(|_| DispatchError::HandlerError(message).to_string())
+        }
+        Err(err) => Err(err.to_string()),
+    }
 }
 
 #[cfg(test)]
@@ -207,5 +214,28 @@ mod tests {
                 && code == "policy_denied"
                 && reason == "destructive tools are disabled"
         ));
+    }
+
+    #[test]
+    fn async_output_decoder_accepts_raw_json_handler_output() {
+        let raw = json!({
+            "received": {
+                "output_dir": "C:/tmp/blender-bakes",
+                "maps": ["base_color", "normal", "roughness"],
+            }
+        })
+        .to_string();
+
+        let decoded = decode_dispatch_output(&raw).expect("raw handler output should decode");
+
+        assert_eq!(
+            decoded,
+            json!({
+                "received": {
+                    "output_dir": "C:/tmp/blender-bakes",
+                    "maps": ["base_color", "normal", "roughness"],
+                }
+            })
+        );
     }
 }

--- a/tests/test_host_http_integration.py
+++ b/tests/test_host_http_integration.py
@@ -87,6 +87,21 @@ def _rest_call(
         return exc.code, json.loads(body) if body else {}
 
 
+def _poll_job_status(url: str, job_id: str, *, timeout_secs: float = 5.0) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout_secs
+    while time.monotonic() < deadline:
+        poll = _call_tool(
+            url,
+            "jobs_get_status",
+            {"job_id": job_id, "include_result": True},
+        )
+        env = poll["result"]["structuredContent"]
+        if env["status"] in {"completed", "failed", "cancelled", "interrupted"}:
+            return env
+        time.sleep(0.05)
+    raise AssertionError(f"job {job_id} did not reach a terminal state")
+
+
 def _start_routed_server(
     server_name: str,
 ) -> tuple[McpHttpServer, ToolRegistry, StandaloneHost, Any]:
@@ -425,6 +440,55 @@ def test_v1_call_reports_validation_skipped_for_empty_schema() -> None:
         status, body = _rest_call(handle.mcp_url(), "loose_probe", {"anything": "goes"})
         assert status == 200, body
         assert body.get("validation_skipped") is True, body
+    finally:
+        handle.shutdown()
+        host.stop()
+
+
+def test_async_main_affinity_job_preserves_structured_arguments() -> None:
+    """Async main-affinity jobs must dispatch the original JSON arguments."""
+    server, reg = _make_server("async-main-affinity-args")
+    captured: dict[str, Any] = {}
+
+    def _probe(params: dict) -> dict:
+        captured.update(params)
+        return {"received": params}
+
+    server.register_handler("bake_textures", _probe, thread_affinity="main")
+    reg.register(
+        "bake_textures",
+        description="Bake texture maps.",
+        category="test",
+        dcc="test",
+        version="1.0.0",
+        execution="sync",
+        timeout_hint_secs=30,
+        thread_affinity="main",
+        enforce_thread_affinity=True,
+    )
+
+    dispatcher = QueueDispatcher()
+    server.attach_dispatcher(dispatcher)
+    host = StandaloneHost(dispatcher, tick_interval=0.005)
+    host.start()
+    handle = server.start()
+    try:
+        time.sleep(0.2)
+        arguments = {
+            "output_dir": "C:/tmp/blender-bakes",
+            "maps": ["base_color", "normal", "roughness"],
+        }
+        queued = _call_tool(handle.mcp_url(), "bake_textures", arguments)
+        assert queued.get("error") is None, queued
+        result = queued["result"]
+        assert result["isError"] is False, result
+        job_id = result["structuredContent"]["job_id"]
+
+        final = _poll_job_status(handle.mcp_url(), job_id)
+
+        assert final["status"] == "completed", final
+        assert final["result"]["received"] == arguments
+        assert captured == arguments
     finally:
         handle.shutdown()
         host.stop()


### PR DESCRIPTION
## Summary
- Decode raw JSON handler output in the async dispatch output path when a main-thread bridge returns legacy output without the internal dispatch wire envelope.
- Preserve structured dispatch wire errors while keeping invalid non-JSON payloads as malformed dispatch wire failures.
- Add regression coverage for async main-affinity jobs with string path and array arguments through job polling.

## Validation
- `vx cargo fmt --all`
- `vx ruff check tests\test_host_http_integration.py`
- `vx cargo test -p dcc-mcp-http-server rmcp_tool_call_dispatch::wire::tests --quiet`
- `.\.venv\Scripts\python.exe -m pytest tests\test_host_http_integration.py::test_async_main_affinity_job_preserves_structured_arguments tests\test_host_http_integration.py::test_v1_call_routes_through_dispatcher -q --tb=short --show-capture=no`
- `vx git diff --check`
- Commit hook cargo clippy passed.

Skill guidance update: not needed; this is internal async dispatch decoder compatibility and does not change public skill authoring or adapter workflow guidance.

Closes #1290