### PR TITLE
ci: skip duplicate wheel stub generation

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: 'Generate Python type stubs before building the wheel'
     required: false
     default: 'true'
+  prebuild-admin-ui:
+    description: 'Build the admin UI bundle before invoking maturin'
+    required: false
+    default: 'true'
   artifact-name:
     description: 'Artifact name'
     required: false
@@ -118,6 +122,7 @@ runs:
     # npm config / npm crashes). `DCC_MCP_ADMIN_UI_PREBUILT` in the stubgen step
     # makes build.rs reuse `generated/index.html` from this step.
     - name: Pre-build admin UI for manylinux Docker
+      if: inputs.prebuild-admin-ui == 'true'
       shell: bash
       run: |
         set -eux
@@ -126,18 +131,16 @@ runs:
         test -f crates/dcc-mcp-gateway/src/gateway/admin/generated/index.html
 
     - name: Generate type stubs
-      if: inputs.generate-stubs == 'true'
+      if: inputs.generate-stubs == 'true' && inputs.python-version != '3.7'
       shell: bash
       env:
         DCC_MCP_ADMIN_UI_PREBUILT: "1"
       run: |
         # pyo3-stub-gen v0.22.x unconditionally references PyEncodingWarning,
         # which only exists in pyo3 when targeting Python >= 3.10.
-        # For Python 3.7 builds we skip regeneration and use the committed stubs.
-        # The abi3 (Python 3.11) build regenerates and commits the authoritative stubs.
-        if [[ "${{ inputs.python-version }}" != "3.7" ]]; then
-          vx just stubgen
-        fi
+        # For Python 3.7 builds, and for CI jobs that already ran the dedicated
+        # stub drift check, use the committed stubs instead of regenerating them.
+        vx just stubgen
 
     - name: Build wheel
       uses: PyO3/maturin-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,7 @@ jobs:
   # concurrently instead of serially.
   build-wheel:
     name: Build wheel (${{ matrix.os }})
+    needs: [admin-ui-bundle]
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -225,6 +226,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
+      - name: Download admin UI bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: admin-ui-bundle
+          path: crates/dcc-mcp-gateway/src/gateway/admin/generated
       # Use the same composite wheel builder as release builds and py3.7 CI.
       # It owns Rust/Python setup, Cargo cache, sccache, feature resolution,
       # wheel-content validation, and artifact upload, avoiding duplicated
@@ -232,9 +238,15 @@ jobs:
       - uses: ./.github/actions/build-wheel
         with:
           python-version: "3.11"
-          generate-stubs: "false"
           test-wheel: "false"
           artifact-name: wheel-${{ matrix.os }}
+          # The Linux Rust gate runs `stubgen-check`, so PR wheel builds can
+          # reuse committed stubs and avoid repeating PyO3 stub generation on
+          # every wheel platform.
+          generate-stubs: "false"
+          # Reuse the single Admin UI bundle built above instead of running
+          # npm install/build in every wheel job.
+          prebuild-admin-ui: "false"
 
   # ── Python tests: trimmed OS × Python matrix (7 cells, was 18) ──
   # Covers every supported Python version on ubuntu (cheapest) + endpoint
@@ -323,6 +335,7 @@ jobs:
   # Note: Must use older OS runners where Python 3.7 is still available via setup-python
   build-wheel-py37:
     name: Build wheel (py3.7, ${{ matrix.os }})
+    needs: [admin-ui-bundle]
     strategy:
       matrix:
         include:
@@ -334,6 +347,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
+      - name: Download admin UI bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: admin-ui-bundle
+          path: crates/dcc-mcp-gateway/src/gateway/admin/generated
       - uses: ./.github/actions/build-wheel
         with:
           target: ${{ matrix.target }}
@@ -342,6 +360,7 @@ jobs:
           test-wheel: 'true'
           artifact-name: wheel-py37-${{ matrix.os }}
           use-sccache: 'false'
+          prebuild-admin-ui: "false"
 
   # ── Lint Python source ──
   # ubuntu-22.04: setup-python still offers 3.7 for the cp37 syntax gate.

--- a/.github/workflows/rust-matrix-full.yml
+++ b/.github/workflows/rust-matrix-full.yml
@@ -78,9 +78,9 @@ jobs:
           echo ""
           echo "::error::Run 'cargo hakari generate' and commit the changes to fix this CI step."
           exit 1
-      - name: Stub generation
+      - name: Stub generation check
         if: runner.os == 'Linux'
-        run: vx just stubgen
+        run: vx just stubgen-check
       - name: Rust format check
         if: runner.os == 'Linux'
         run: vx just fmt-check


### PR DESCRIPTION
## Summary

- add explicit `generate-stubs` and `prebuild-admin-ui` switches to the shared wheel-build action
- make PR ABI3 wheel jobs reuse committed stubs after the Linux Rust `stubgen-check`
- make PR wheel jobs reuse the single Admin UI bundle artifact instead of running npm install/build per wheel platform
- make the scheduled full Rust matrix use the same stub drift check

## Validation

- `vx actionlint .github/workflows/ci.yml .github/workflows/rust-matrix-full.yml .github/workflows/build-wheels.yml .github/workflows/release.yml`
- `vx yq '.inputs."generate-stubs", .inputs."prebuild-admin-ui"' .github/actions/build-wheel/action.yml`
- `vx yq '.runs.steps[] | select(.name == "Generate type stubs") | .if' .github/actions/build-wheel/action.yml`
- `vx yq '.runs.steps[] | select(.name == "Pre-build admin UI for manylinux Docker") | .if' .github/actions/build-wheel/action.yml`
- `vx yq '.jobs."build-wheel".needs, .jobs."build-wheel-py37".needs' .github/workflows/ci.yml`
- `vx git diff --check`
- `DCC_MCP_ADMIN_UI_PREBUILT=1 vx just stubgen-check`

No update needed for `skills/dcc-mcp-skill-developer/SKILL.md`; this only changes CI wiring.

Fixes #1293