### PR TITLE
fix: keep skill result fallback source-only

### DIFF
--- a/python/dcc_mcp_core/skill.py
+++ b/python/dcc_mcp_core/skill.py
@@ -664,10 +664,17 @@ def _json_dumps_for_fallback() -> Callable[..., str]:
     """Return the fastest JSON dumper available without a top-level _core dependency."""
     try:
         # Lazy import: source-only DCC environments may not have the compiled extension.
-        from dcc_mcp_core import json_dumps
+        from dcc_mcp_core import json_dumps as core_json_dumps
     except (AttributeError, ImportError):
         return json.dumps
-    return json_dumps
+
+    def dumps(payload: Any, **kwargs: Any) -> str:
+        try:
+            return core_json_dumps(payload, **kwargs)
+        except ImportError:
+            return json.dumps(payload, **kwargs)
+
+    return dumps
 
 
 _DCC_IMPORT_LABELS = {

--- a/tests/test_py37_syntax_gate.py
+++ b/tests/test_py37_syntax_gate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 import subprocess
 import sys
@@ -10,6 +11,7 @@ import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _CHECKER = _REPO_ROOT / "scripts" / "check_py37_syntax.py"
+_HOST_PUMP = _REPO_ROOT / "python" / "dcc_mcp_core" / "_server" / "host_pump.py"
 
 
 @pytest.mark.skipif(sys.version_info[:2] != (3, 7), reason="requires Python 3.7 interpreter")
@@ -30,3 +32,18 @@ def test_check_py37_syntax_rejects_pep604_union(tmp_path: Path) -> None:
     source = bad.read_text(encoding="utf-8")
     with pytest.raises(SyntaxError):
         compile(source, str(bad), "exec")
+
+
+def test_host_pump_runtime_aliases_avoid_pep604_unions() -> None:
+    """Runtime aliases are evaluated during Python 3.7 wheel import smoke."""
+    tree = ast.parse(_HOST_PUMP.read_text(encoding="utf-8"), filename=str(_HOST_PUMP))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == "HostTick" for target in node.targets):
+            continue
+        assert not any(
+            isinstance(child, ast.BinOp) and isinstance(child.op, ast.BitOr) for child in ast.walk(node.value)
+        )
+        return
+    pytest.fail("HostTick runtime alias not found")

--- a/tests/test_serialize_result_roundtrip.py
+++ b/tests/test_serialize_result_roundtrip.py
@@ -564,6 +564,34 @@ class TestSkillSerializeResult:
         assert calls
         assert json.loads(output)["message"] == "fast"
 
+    def test_serialize_result_fallback_handles_lazy_core_json_missing(self, monkeypatch):
+        """If top-level json_dumps resolves but needs _core at call time, use stdlib JSON."""
+        import builtins
+        import importlib
+
+        original_import = builtins.__import__
+
+        def mock_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "dcc_mcp_core._core":
+                raise ImportError("simulated missing validation path")
+            return original_import(name, globals, locals, fromlist, level)
+
+        def unavailable_json_dumps(_payload, **_kwargs):
+            raise ModuleNotFoundError("No module named 'dcc_mcp_core._core'")
+
+        import dcc_mcp_core.skill as skill_mod
+
+        importlib.reload(skill_mod)
+
+        with monkeypatch.context() as mp:
+            mp.setattr(builtins, "__import__", mock_import)
+            mp.setattr(dcc_mcp_core, "json_dumps", unavailable_json_dumps, raising=False)
+            result = {"success": True, "message": "source-only", "prompt": None, "error": None, "context": {}}
+
+            output = skill_mod._serialize_result(result)
+
+        assert json.loads(output)["message"] == "source-only"
+
 
 # ---------------------------------------------------------------------------
 # Cross-format compatibility check


### PR DESCRIPTION
## Summary
- fall back to stdlib JSON when the exported Rust-backed `json_dumps` resolves but `_core` is unavailable at call time
- keep the host pump runtime callback alias Python 3.7-compatible for wheel import smoke
- add regression coverage for source-only skill result serialization and runtime PEP 604 alias drift

## Validation
- `python -m pytest tests/test_dcc_skills_creator.py::test_create_skill_example_tool_runs_successfully -q --tb=short --show-capture=no`
- `PYTHONPATH=python python -c "from dcc_mcp_core.skill import _serialize_result; ..."`
- `vx ruff check python\dcc_mcp_core\skill.py tests\test_serialize_result_roundtrip.py`
- `python -m py_compile python\dcc_mcp_core\skill.py tests\test_serialize_result_roundtrip.py`
- `vx ruff check python\dcc_mcp_core\_server\host_pump.py tests\test_py37_syntax_gate.py`
- `python -m py_compile python\dcc_mcp_core\_server\host_pump.py tests\test_py37_syntax_gate.py`
- `python -m pytest tests/test_py37_syntax_gate.py tests/test_imports.py::test_dcc_mcp_core_import_smoke -q --tb=short --show-capture=no`
- `python -m pytest tests/test_dcc_skills_creator.py::test_create_skill_example_tool_runs_successfully -q --tb=short --show-capture=no`
- `vx cargo test -p dcc-mcp-gateway gateway_router_ --features admin -- --nocapture`
- `vx git diff --check`

Skill guidance update: not needed; this restores internal fallback/import compatibility and does not change public skill authoring guidance.

Closes #1297
Closes #1299