### PR TITLE
fix: add public-safe admin issue reports

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -1135,6 +1135,38 @@ function traceLinks(requestId: string, provided?: AdminLinks): AdminLinks {
   };
 }
 
+function adminPathBases(): { adminBase: string; apiBase: string } {
+  try {
+    const apiBase = new URL(API_BASE).pathname.replace(/\/+$/, '') || '/admin/api';
+    const adminBase = apiBase.endsWith('/api') ? apiBase.slice(0, -'/api'.length) || '/admin' : '/admin';
+    return { adminBase, apiBase };
+  } catch {
+    return { adminBase: '/admin', apiBase: '/admin/api' };
+  }
+}
+
+function publicSafeIssuePaths(requestId: string): Record<string, string> {
+  const encoded = encodeURIComponent(requestId);
+  const { adminBase, apiBase } = adminPathBases();
+  return {
+    admin_trace_path: `${adminBase}?panel=traces&trace=${encoded}`,
+    trace_api_path: `${apiBase}/traces/${encoded}`,
+    safe_issue_report_path: `${apiBase}/issue-report/${encoded}`,
+    raw_issue_report_path: `${apiBase}/issue-report/${encoded}?mode=raw`,
+    stable_safe_issue_report_path: `/v1/debug/issue-reports/${encoded}`,
+    stable_raw_issue_report_path: `/v1/debug/issue-reports/${encoded}?mode=raw`,
+    openapi_spec_path: '/v1/openapi.json',
+    docs_path: '/docs',
+  };
+}
+
+function publicToolFamily(tool: string | null | undefined, method: string): string {
+  const raw = tool || method || 'unknown';
+  const lastSegment = raw.split('.').filter(Boolean).pop() || raw;
+  const family = lastSegment.includes('__') ? lastSegment.split('__').pop() || lastSegment : lastSegment;
+  return family.replace(/[^A-Za-z0-9_.-]+/g, '-').replace(/^-+|-+$/g, '') || 'unknown';
+}
+
 function readPanelFromUrl(): Panel {
   const u = new URL(window.location.href);
   const raw = u.searchParams.get('panel');
@@ -1841,6 +1873,23 @@ function safeCallerContext(agent: AgentContext | null | undefined): Record<strin
   };
 }
 
+function publicSafeCallerContext(agent: AgentContext | null | undefined): Record<string, unknown> | null {
+  if (!agent) {
+    return null;
+  }
+  return {
+    agent_kind: agent.agent_kind ?? null,
+    model_provider: agent.model_provider ?? null,
+    model_version: agent.model_version ?? null,
+    reasoning_effort: agent.reasoning_effort ?? null,
+    client_platform: agent.client_platform ?? null,
+    plan_step_count: agent.plan?.length ?? 0,
+    observation_count: agent.observations?.length ?? 0,
+    has_user_intent_summary: Boolean(agent.user_intent_summary),
+    has_agent_reply_summary: Boolean(agent.agent_reply_summary),
+  };
+}
+
 function tokenAccounting(row: TokenCarrier | null | undefined): TokenAccounting | null {
   if (!row) {
     return null;
@@ -2122,16 +2171,15 @@ function payloadPreview(payload: TracePayload | null | undefined, t: Translator)
 }
 
 function buildAgentPacket(trace: TraceDetailPayload): string {
-  const links = traceLinks(trace.request_id, trace.links);
   const agent = trace.agent_context;
   const tokens = detailTraceTokens(trace);
   return JSON.stringify({
-    purpose: 'dcc-mcp admin trace packet for LLM evaluation and code optimization',
+    purpose: 'dcc-mcp public-safe admin trace packet for LLM evaluation and issue triage',
+    privacy_mode: 'public-safe',
     request_id: trace.request_id,
     method: trace.method,
-    tool: trace.tool_slug ?? trace.method,
+    tool_family: publicToolFamily(trace.tool_slug, trace.method),
     dcc_type: trace.dcc_type,
-    instance_id: trace.instance_id,
     transport: trace.transport,
     status: trace.ok ? 'ok' : 'err',
     total_ms: trace.total_ms,
@@ -2143,13 +2191,18 @@ function buildAgentPacket(trace: TraceDetailPayload): string {
       estimated: tokens.estimatedTokens,
       estimator: tokens.estimator,
     },
-    agent_context: safeCallerContext(agent),
+    agent_context: publicSafeCallerContext(agent),
     slowest_span: [...(trace.spans ?? [])]
       .sort((a, b) => (b.duration_ns ?? 0) - (a.duration_ns ?? 0))
       .slice(0, 1)
-      .map((span) => ({ name: span.name, duration_ms: Math.round((span.duration_ns ?? 0) / 1_000_000), ok: span.ok, attributes: span.attributes }))
+      .map((span) => ({ name: span.name, duration_ms: Math.round((span.duration_ns ?? 0) / 1_000_000), ok: span.ok }))
       [0] ?? null,
-    links,
+    links: publicSafeIssuePaths(trace.request_id),
+    raw_debug_bundle: {
+      available: true,
+      mode_query: 'mode=raw',
+      privacy_note: 'Raw debug bundles may contain payload previews, prompts, scripts, auth material, local URLs, filesystem paths, or private scene identifiers. Review before sharing publicly.',
+    },
   }, null, 2);
 }
 

--- a/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/handlers.rs
@@ -13,7 +13,7 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 
 use super::html::ADMIN_HTML;
-use super::issue_report::{issue_report_filename, issue_report_json};
+use super::issue_report::{IssueReportMode, issue_report_filename, issue_report_json};
 use super::links::AdminLinkBuilder;
 use super::state::{AdminAuditRecord, AdminState};
 use super::trace::{AgentContext, DispatchTrace};
@@ -150,6 +150,31 @@ pub struct AdminSkillDetailQuery {
     pub dcc: Option<String>,
     pub dcc_type: Option<String>,
     pub instance_id: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct IssueReportQuery {
+    /// Default is public-safe. Use `mode=raw` for local evidence review.
+    mode: Option<String>,
+    /// Compatibility flag for explicit raw export requests.
+    include_raw: Option<String>,
+}
+
+impl IssueReportQuery {
+    fn mode(&self) -> IssueReportMode {
+        if self
+            .mode
+            .as_deref()
+            .is_some_and(|value| value.eq_ignore_ascii_case("raw"))
+            || self.include_raw.as_deref().is_some_and(|value| {
+                matches!(value.to_ascii_lowercase().as_str(), "1" | "true" | "yes")
+            })
+        {
+            IssueReportMode::RawDebugBundle
+        } else {
+            IssueReportMode::PublicSafe
+        }
+    }
 }
 
 /// `GET /admin/api/instances` — list current routable instances by default.
@@ -1010,6 +1035,7 @@ pub async fn handle_admin_issue_report(
     State(s): State<AdminState>,
     headers: HeaderMap,
     OriginalUri(uri): OriginalUri,
+    Query(params): Query<IssueReportQuery>,
     axum::extract::Path(request_id): axum::extract::Path<String>,
 ) -> impl IntoResponse {
     let links = AdminLinkBuilder::from_request(&headers, &uri);
@@ -1017,7 +1043,7 @@ pub async fn handle_admin_issue_report(
         Some(mut bundle) => {
             let request_links = links.request_links(&request_id);
             bundle["links"] = request_links.clone();
-            let report = issue_report_json(&request_id, bundle, request_links);
+            let report = issue_report_json(&request_id, bundle, request_links, params.mode());
             let mut response = (StatusCode::OK, Json(report)).into_response();
             if let Ok(value) = HeaderValue::from_str(&format!(
                 "attachment; filename=\"{}\"",

--- a/crates/dcc-mcp-gateway/src/gateway/admin/issue_report.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/issue_report.rs
@@ -4,6 +4,12 @@ use serde_json::{Value, json};
 
 use crate::gateway::response_codec::TOKEN_ESTIMATOR;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum IssueReportMode {
+    PublicSafe,
+    RawDebugBundle,
+}
+
 pub(super) fn issue_report_filename(request_id: &str) -> String {
     let mut safe = String::with_capacity(request_id.len());
     for ch in request_id.chars() {
@@ -42,7 +48,177 @@ fn trace_payload_token_summary(trace: &Value) -> Value {
     })
 }
 
-pub(super) fn issue_report_json(request_id: &str, bundle: Value, links: Value) -> Value {
+fn public_label(value: &str) -> String {
+    let mut safe = String::with_capacity(value.len().min(96));
+    for ch in value.chars().take(96) {
+        if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' || ch == '.' {
+            safe.push(ch);
+        } else {
+            safe.push('-');
+        }
+    }
+    let safe = safe.trim_matches('-').to_string();
+    if safe.is_empty() {
+        "unknown".to_string()
+    } else {
+        safe
+    }
+}
+
+fn tool_family(tool: &str) -> String {
+    let last_segment = tool
+        .split('.')
+        .rfind(|part| !part.is_empty())
+        .unwrap_or(tool);
+    let family = last_segment
+        .rsplit_once("__")
+        .map(|(_, tail)| tail)
+        .unwrap_or(last_segment);
+    public_label(family)
+}
+
+fn encode_url_component(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char);
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
+}
+
+fn public_safe_links(request_id: &str) -> Value {
+    let encoded = encode_url_component(request_id);
+    json!({
+        "admin_trace_path": format!("/admin?panel=traces&trace={encoded}"),
+        "trace_api_path": format!("/admin/api/traces/{encoded}"),
+        "debug_bundle_path": format!("/admin/api/debug-bundle/{encoded}"),
+        "safe_issue_report_path": format!("/admin/api/issue-report/{encoded}"),
+        "raw_issue_report_path": format!("/admin/api/issue-report/{encoded}?mode=raw"),
+        "stable_debug_bundle_path": format!("/v1/debug/bundles/{encoded}"),
+        "stable_safe_issue_report_path": format!("/v1/debug/issue-reports/{encoded}"),
+        "stable_raw_issue_report_path": format!("/v1/debug/issue-reports/{encoded}?mode=raw"),
+        "openapi_spec_path": "/v1/openapi.json",
+        "docs_path": "/docs",
+    })
+}
+
+fn redaction_marker_detected(value: &Value) -> bool {
+    match value {
+        Value::String(text) => text.contains("[REDACTED]"),
+        Value::Array(items) => items.iter().any(redaction_marker_detected),
+        Value::Object(map) => map.values().any(redaction_marker_detected),
+        _ => false,
+    }
+}
+
+fn find_error_text(value: &Value) -> Option<&str> {
+    match value {
+        Value::Object(map) => {
+            if let Some(text) = map
+                .get("error")
+                .and_then(Value::as_str)
+                .filter(|text| !text.trim().is_empty())
+            {
+                return Some(text);
+            }
+            map.values().find_map(find_error_text)
+        }
+        Value::Array(items) => items.iter().find_map(find_error_text),
+        _ => None,
+    }
+}
+
+fn contains_text_marker(value: &Value, markers: &[&str]) -> bool {
+    match value {
+        Value::String(text) => {
+            let lower = text.to_ascii_lowercase();
+            markers.iter().any(|marker| lower.contains(marker))
+        }
+        Value::Array(items) => items.iter().any(|item| contains_text_marker(item, markers)),
+        Value::Object(map) => map
+            .values()
+            .any(|value| contains_text_marker(value, markers)),
+        _ => false,
+    }
+}
+
+fn failed_without_error(trace: &Value, audit: &Value) -> bool {
+    trace
+        .get("ok")
+        .and_then(Value::as_bool)
+        .is_some_and(|ok| !ok)
+        || audit
+            .get("success")
+            .and_then(Value::as_bool)
+            .is_some_and(|success| !success)
+}
+
+fn sanitized_error_kind(trace: &Value, audit: &Value, bundle: &Value) -> Value {
+    let raw = trace
+        .get("error")
+        .or_else(|| audit.get("error"))
+        .and_then(Value::as_str)
+        .or_else(|| find_error_text(bundle));
+    let raw = raw.or_else(|| {
+        if contains_text_marker(
+            bundle,
+            &[
+                "host_died",
+                "host died",
+                "connection refused",
+                "unreachable",
+                "disconnected",
+            ],
+        ) {
+            Some("backend unavailable")
+        } else if failed_without_error(trace, audit) {
+            Some("failed")
+        } else {
+            None
+        }
+    });
+    let Some(raw) = raw else {
+        return json!({
+            "kind": null,
+            "present": false,
+            "message_redacted": false,
+        });
+    };
+
+    let lower = raw.to_ascii_lowercase();
+    let kind = if lower.contains("timeout") || lower.contains("timed out") {
+        "timeout"
+    } else if lower.contains("auth") || lower.contains("permission") || lower.contains("forbidden")
+    {
+        "auth"
+    } else if lower.contains("not found") || lower.contains("unknown") {
+        "not-found"
+    } else if lower.contains("host_died")
+        || lower.contains("host died")
+        || lower.contains("connection refused")
+        || lower.contains("unreachable")
+        || lower.contains("disconnected")
+        || lower.contains("backend unavailable")
+    {
+        "backend-unavailable"
+    } else if lower.contains("invalid") || lower.contains("validation") {
+        "validation"
+    } else {
+        "error"
+    };
+
+    json!({
+        "kind": kind,
+        "present": true,
+        "message_redacted": true,
+    })
+}
+
+fn build_summary(request_id: &str, bundle: &Value) -> (Value, String) {
     let trace = bundle.get("trace").cloned().unwrap_or(Value::Null);
     let audit = bundle.get("audit").cloned().unwrap_or(Value::Null);
     let tool = trace
@@ -56,6 +232,7 @@ pub(super) fn issue_report_json(request_id: &str, bundle: Value, links: Value) -
         .or_else(|| audit.get("dcc_type"))
         .and_then(Value::as_str)
         .unwrap_or("unknown");
+    let dcc_type = public_label(dcc_type);
     let status = trace
         .get("ok")
         .and_then(Value::as_bool)
@@ -73,10 +250,6 @@ pub(super) fn issue_report_json(request_id: &str, bundle: Value, links: Value) -
         .cloned()
         .unwrap_or(Value::Null);
     let payload_tokens = trace_payload_token_summary(&trace);
-    let trace_id = bundle
-        .get("trace_id")
-        .cloned()
-        .unwrap_or_else(|| trace.get("trace_id").cloned().unwrap_or(Value::Null));
     let postmortem = bundle.get("postmortem").cloned().unwrap_or(Value::Null);
     let previous_call_count = postmortem
         .get("previous_calls")
@@ -88,38 +261,174 @@ pub(super) fn issue_report_json(request_id: &str, bundle: Value, links: Value) -
         .and_then(Value::as_array)
         .map(Vec::len)
         .unwrap_or(0);
+    let tool_family = tool_family(tool);
+    let title = format!("DCC-MCP request {request_id} {status}: {tool_family}");
+    let error = sanitized_error_kind(&trace, &audit, bundle);
+    let summary = json!({
+        "title": title,
+        "status": status,
+        "dcc_type": dcc_type,
+        "tool_family": tool_family,
+        "total_ms": total_ms,
+        "error": error,
+        "token_accounting": token_accounting,
+        "payload_tokens": payload_tokens,
+        "redaction_status": {
+            "mode": "public-safe",
+            "raw_payloads_excluded": true,
+            "payload_previews_excluded": true,
+            "prompts_excluded": true,
+            "scripts_excluded": true,
+            "auth_material_excluded": true,
+            "local_urls_excluded": true,
+            "absolute_paths_excluded": true,
+            "private_identifiers_excluded": true,
+            "redaction_markers_detected": redaction_marker_detected(bundle),
+        },
+        "postmortem": {
+            "previous_call_count": previous_call_count,
+            "gateway_event_count": gateway_event_count,
+        },
+    });
+    (summary, title)
+}
+
+fn public_safe_body_template(request_id: &str, summary: &Value) -> String {
+    let status = summary
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let dcc_type = summary
+        .get("dcc_type")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let tool_family = summary
+        .get("tool_family")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let error_kind = summary
+        .get("error")
+        .and_then(|error| error.get("kind"))
+        .and_then(Value::as_str)
+        .unwrap_or("none");
+    let total_ms = match summary.get("total_ms") {
+        Some(Value::Number(value)) => format!("{value} ms"),
+        _ => "unknown".to_string(),
+    };
+
+    format!(
+        "## Summary\n\nRequest `{request_id}` returned `{status}` for `{tool_family}` on `{dcc_type}`.\n\n## Public-safe diagnostics\n\n- Status: `{status}`\n- DCC type: `{dcc_type}`\n- Tool family: `{tool_family}`\n- Duration: `{total_ms}`\n- Sanitized error kind: `{error_kind}`\n\n## Evidence policy\n\nThis issue report intentionally excludes request/response payload previews, prompts, scripts, auth material, local URLs, absolute filesystem paths, and private scene or project identifiers. Use the explicit raw export only after reviewing it for public sharing."
+    )
+}
+
+fn public_safe_issue_report(request_id: &str, bundle: Value) -> Value {
     let generated_at = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
-    let title = format!("DCC-MCP request {request_id} {status}: {tool}");
-    let body_template = format!(
-        "## Summary\n\nRequest `{request_id}` returned `{status}` for `{tool}` on `{dcc_type}`.\n\n## Attached data\n\nUpload this JSON export to the issue so maintainers can inspect trace spans, audit metadata, payload previews, postmortem context, and links.\n\n## Notes\n\nReview the JSON for secrets or proprietary scene paths before uploading."
-    );
+    let trace_id = bundle.get("trace_id").cloned().unwrap_or_else(|| {
+        bundle["trace"]
+            .get("trace_id")
+            .cloned()
+            .unwrap_or(Value::Null)
+    });
+    let (summary, title) = build_summary(request_id, &bundle);
+    let body_template = public_safe_body_template(request_id, &summary);
+    let links = public_safe_links(request_id);
+    let raw_admin_path = links["raw_issue_report_path"].clone();
+    let raw_stable_path = links["stable_raw_issue_report_path"].clone();
 
     json!({
         "schema_version": "dcc-mcp.admin.issue-report.v1",
-        "report_type": "github_issue_debug_json",
+        "report_type": "github_issue_public_safe",
+        "privacy_mode": "public-safe",
         "generated_at": generated_at,
         "request_id": request_id,
         "trace_id": trace_id,
-        "summary": {
-            "title": title,
-            "status": status,
-            "tool": tool,
-            "dcc_type": dcc_type,
-            "total_ms": total_ms,
-            "token_accounting": token_accounting,
-            "payload_tokens": payload_tokens,
-            "postmortem": {
-                "previous_call_count": previous_call_count,
-                "gateway_event_count": gateway_event_count,
-            },
-        },
+        "summary": summary,
         "github_issue": {
             "title": title,
             "body_template": body_template,
             "suggested_labels": ["bug", "admin-telemetry"],
         },
         "links": links,
-        "privacy_note": "Review request and response payloads before uploading; this export may include scene paths, prompts, tokens, or proprietary data.",
+        "raw_debug_bundle": {
+            "available": true,
+            "mode_query": "mode=raw",
+            "admin_path": raw_admin_path,
+            "stable_path": raw_stable_path,
+            "privacy_note": "Raw exports may include payload previews, prompts, script snippets, scene paths, local URLs, auth material, or proprietary data. Review before sharing publicly.",
+        },
+        "privacy_note": "Public-safe mode excludes raw payload previews and local/private evidence by default. Use ?mode=raw only for reviewed local diagnostics.",
+    })
+}
+
+fn raw_issue_report(request_id: &str, bundle: Value, links: Value) -> Value {
+    let generated_at = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    let trace_id = bundle.get("trace_id").cloned().unwrap_or_else(|| {
+        bundle["trace"]
+            .get("trace_id")
+            .cloned()
+            .unwrap_or(Value::Null)
+    });
+    let (mut summary, title) = build_summary(request_id, &bundle);
+    if let Some(map) = summary.as_object_mut() {
+        map.insert(
+            "redaction_status".to_string(),
+            json!({
+                "mode": "raw-local-evidence",
+                "raw_payloads_excluded": false,
+                "payload_previews_excluded": false,
+                "local_urls_excluded": false,
+                "absolute_paths_excluded": false,
+                "private_identifiers_excluded": false,
+                "redaction_markers_detected": redaction_marker_detected(&bundle),
+            }),
+        );
+    }
+    let tool = bundle["trace"]
+        .get("tool_slug")
+        .or_else(|| bundle["trace"].get("method"))
+        .or_else(|| bundle["audit"].get("tool"))
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let dcc_type = bundle["trace"]
+        .get("dcc_type")
+        .or_else(|| bundle["audit"].get("dcc_type"))
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let status = summary
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let body_template = format!(
+        "## Summary\n\nRequest `{request_id}` returned `{status}` for `{tool}` on `{dcc_type}`.\n\n## Attached data\n\nThis explicit raw export includes the correlated debug bundle for private/local diagnostics.\n\n## Notes\n\nReview the JSON for secrets, local URLs, payload previews, prompts, scripts, auth material, proprietary scene paths, or private project identifiers before uploading."
+    );
+
+    json!({
+        "schema_version": "dcc-mcp.admin.issue-report.v1",
+        "report_type": "github_issue_debug_json",
+        "privacy_mode": "raw-local-evidence",
+        "generated_at": generated_at,
+        "request_id": request_id,
+        "trace_id": trace_id,
+        "summary": summary,
+        "github_issue": {
+            "title": title,
+            "body_template": body_template,
+            "suggested_labels": ["bug", "admin-telemetry"],
+        },
+        "links": links,
+        "privacy_note": "Raw export: review request and response payloads before uploading; this may include scene paths, prompts, tokens, local URLs, auth material, or proprietary data.",
         "debug_bundle": bundle,
     })
+}
+
+pub(super) fn issue_report_json(
+    request_id: &str,
+    bundle: Value,
+    links: Value,
+    mode: IssueReportMode,
+) -> Value {
+    match mode {
+        IssueReportMode::PublicSafe => public_safe_issue_report(request_id, bundle),
+        IssueReportMode::RawDebugBundle => raw_issue_report(request_id, bundle, links),
+    }
 }

--- a/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/tests.rs
@@ -1572,7 +1572,10 @@ sinks:
             action: "maya.inst.long_task".into(),
             dcc_type: Some("maya".into()),
             success: false,
-            error: Some("host died".into()),
+            error: Some(
+                "host died while opening C:\\studio\\secret\\shot.ma via http://127.0.0.1:8765/callback"
+                    .into(),
+            ),
             duration_ms: Some(25),
             token_accounting: Some(token_telemetry("toon", 100, 40)),
         }]));
@@ -1719,19 +1722,41 @@ sinks:
         );
 
         let (v1_report_status, v1_report_body) =
-            body_json(v1_router, "/v1/debug/issue-reports/req-task").await;
+            body_json(v1_router.clone(), "/v1/debug/issue-reports/req-task").await;
         assert_eq!(v1_report_status, StatusCode::OK);
         assert_eq!(v1_report_body["request_id"], "req-task");
-        assert_eq!(v1_report_body["debug_bundle"]["trace_id"], "trace-task");
+        assert_eq!(v1_report_body["privacy_mode"], "public-safe");
+        assert_eq!(
+            v1_report_body["summary"]["error"]["kind"],
+            "backend-unavailable"
+        );
+        assert!(v1_report_body.get("debug_bundle").is_none());
+        let (v1_raw_report_status, v1_raw_report_body) = body_json(
+            v1_router,
+            "/v1/debug/issue-reports/req-task?include_raw=true",
+        )
+        .await;
+        assert_eq!(v1_raw_report_status, StatusCode::OK);
+        assert_eq!(v1_raw_report_body["privacy_mode"], "raw-local-evidence");
+        assert_eq!(v1_raw_report_body["debug_bundle"]["trace_id"], "trace-task");
 
-        let (report_status, report_body) = body_json(router, "/api/issue-report/req-task").await;
+        let (report_status, report_body) =
+            body_json(router.clone(), "/api/issue-report/req-task").await;
         assert_eq!(report_status, StatusCode::OK);
         assert_eq!(
             report_body["schema_version"],
             "dcc-mcp.admin.issue-report.v1"
         );
+        assert_eq!(report_body["report_type"], "github_issue_public_safe");
+        assert_eq!(report_body["privacy_mode"], "public-safe");
         assert_eq!(report_body["request_id"], "req-task");
         assert_eq!(report_body["summary"]["status"], "failed");
+        assert_eq!(report_body["summary"]["dcc_type"], "maya");
+        assert_eq!(report_body["summary"]["tool_family"], "long_task");
+        assert_eq!(
+            report_body["summary"]["error"]["kind"],
+            "backend-unavailable"
+        );
         assert_eq!(
             report_body["summary"]["postmortem"]["previous_call_count"],
             1
@@ -1752,21 +1777,72 @@ sinks:
             report_body["summary"]["token_accounting"]["saved_tokens"],
             60
         );
-        assert_eq!(report_body["debug_bundle"]["request_id"], "req-task");
+        assert_eq!(
+            report_body["summary"]["redaction_status"]["raw_payloads_excluded"],
+            true
+        );
+        assert_eq!(
+            report_body["summary"]["redaction_status"]["redaction_markers_detected"],
+            true
+        );
+        assert!(report_body.get("debug_bundle").is_none());
         assert!(
             report_body["github_issue"]["body_template"]
                 .as_str()
-                .is_some_and(|body| body.contains("Upload this JSON export"))
+                .is_some_and(|body| body.contains("Public-safe diagnostics"))
         );
         assert!(
-            report_body["links"]["issue_report_url"]
+            report_body["links"]["safe_issue_report_path"]
                 .as_str()
-                .is_some_and(|url| url.ends_with("/admin/api/issue-report/req-task"))
+                .is_some_and(|url| url == "/admin/api/issue-report/req-task")
         );
         assert!(
-            report_body["links"]["openapi_docs_url"]
+            report_body["links"]["docs_path"]
                 .as_str()
-                .is_some_and(|url| url.ends_with("/docs"))
+                .is_some_and(|url| url == "/docs")
+        );
+        assert!(
+            report_body["raw_debug_bundle"]["admin_path"]
+                .as_str()
+                .is_some_and(|url| url == "/admin/api/issue-report/req-task?mode=raw")
+        );
+        let report_text = serde_json::to_string(&report_body).unwrap();
+        for forbidden in [
+            "http://",
+            "127.0.0.1",
+            "C:\\studio",
+            "secret",
+            "shot.ma",
+            "callback",
+            "scene.ma",
+            "[REDACTED]",
+            "host died while opening",
+        ] {
+            assert!(
+                !report_text.contains(forbidden),
+                "safe issue report leaked {forbidden}: {report_text}"
+            );
+        }
+        let issue_body = report_body["github_issue"]["body_template"]
+            .as_str()
+            .unwrap();
+        for forbidden in ["http://", "127.0.0.1", "C:\\studio", "shot.ma", "scene.ma"] {
+            assert!(
+                !issue_body.contains(forbidden),
+                "safe issue body leaked {forbidden}: {issue_body}"
+            );
+        }
+
+        let (raw_report_status, raw_report_body) =
+            body_json(router, "/api/issue-report/req-task?mode=raw").await;
+        assert_eq!(raw_report_status, StatusCode::OK);
+        assert_eq!(raw_report_body["privacy_mode"], "raw-local-evidence");
+        assert_eq!(raw_report_body["debug_bundle"]["request_id"], "req-task");
+        assert_eq!(raw_report_body["debug_bundle"]["trace_id"], "trace-task");
+        assert!(
+            serde_json::to_string(&raw_report_body)
+                .unwrap()
+                .contains("scene.ma")
         );
     }
 

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/debug_openapi.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/debug_openapi.rs
@@ -116,8 +116,20 @@ pub(crate) fn add_gateway_debug_openapi_paths(doc: &mut Value) {
         (
             "/v1/debug/issue-reports/{request_id}",
             "Get issue-report debug JSON",
-            "GitHub-attachable debug report for one request.",
-            vec![path_param("request_id", "Gateway request id.")],
+            "Public-safe GitHub issue report by default. Use mode=raw only for reviewed local evidence.",
+            vec![
+                path_param("request_id", "Gateway request id."),
+                query_param(
+                    "mode",
+                    json!({"type": "string", "enum": ["public-safe", "raw"]}),
+                    "Report privacy mode. Defaults to public-safe; raw includes the full debug bundle.",
+                ),
+                query_param(
+                    "include_raw",
+                    json!({"type": "boolean"}),
+                    "Compatibility flag for explicit raw bundle exports.",
+                ),
+            ],
         ),
         (
             "/v1/debug/logs",

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -192,7 +192,7 @@ compatibility layer; automation should prefer:
 | `GET /v1/debug/traffic/export?limit=1000` | `/admin/api/traffic/export` |
 | `GET /v1/debug/trace-context/{lookup_id}` | trace id or request id lookup |
 | `GET /v1/debug/bundles/{request_id_or_trace_id}` | `/admin/api/debug-bundle/{request_id}` |
-| `GET /v1/debug/issue-reports/{request_id}` | `/admin/api/issue-report/{request_id}` |
+| `GET /v1/debug/issue-reports/{request_id}` | `/admin/api/issue-report/{request_id}`; public-safe by default, `?mode=raw` for reviewed local evidence |
 | `GET /v1/debug/workflows` | `/admin/api/workflows` |
 | `GET /v1/debug/tasks` | `/admin/api/tasks` |
 | `GET /v1/debug/calls` | `/admin/api/calls` |
@@ -331,13 +331,14 @@ end-to-end unit of work. REST callers may send both `X-Request-Id` and W3C
 trace id, parent span id, and flags from `traceparent`.
 
 The Admin UI also exposes a standalone `GET /admin/api/issue-report/{request_id}`
-export. It returns a GitHub-attachable JSON report with a summary,
-`github_issue` title/body template, absolute links, and the correlated debug
-bundle. Default exports include bounded summaries, hashes, character counts, and
-payload previews only. Review request/response payload previews for secrets or
-proprietary scene paths before uploading the JSON to a public issue; raw prompt
-or reply text belongs in an explicit safe-export/traffic-capture flow, not in
-default issue reports.
+export. It returns a public-safe GitHub issue report by default with summary,
+status, DCC type, tool family, timing, sanitized error kind, token accounting,
+redaction status, and relative same-session links. Default exports intentionally
+exclude raw payload previews, prompts, scripts, auth material, local callback
+URLs, absolute filesystem paths, and private scene/project identifiers. Use
+`GET /admin/api/issue-report/{request_id}?mode=raw` only for reviewed local
+evidence; raw mode embeds the correlated debug bundle and should not be pasted
+into a public issue without inspection.
 
 The front-end product name is **Admin Dashboard**. The lower REST/OpenAPI
 contract view is named **OpenAPI Inspector**. It reads the live gateway
@@ -587,14 +588,20 @@ matching Scalar reference.
 // GET /admin/api/issue-report/req-123
 {
   "schema_version": "dcc-mcp.admin.issue-report.v1",
-  "report_type": "github_issue_debug_json",
+  "report_type": "github_issue_public_safe",
+  "privacy_mode": "public-safe",
   "request_id": "req-123",
   "summary": {
-    "title": "DCC-MCP request req-123 failed: maya.abcdef01.maya__open_scene",
+    "title": "DCC-MCP request req-123 failed: open_scene",
     "status": "failed",
-    "tool": "maya.abcdef01.maya__open_scene",
     "dcc_type": "maya",
+    "tool_family": "open_scene",
     "total_ms": 48,
+    "error": {
+      "kind": "backend-unavailable",
+      "present": true,
+      "message_redacted": true
+    },
     "token_accounting": {
       "response_format": "toon",
       "token_estimator": "dcc-mcp-byte4-v1",
@@ -602,23 +609,47 @@ matching Scalar reference.
       "saved_tokens": 66,
       "savings_pct": 55.0
     },
+    "redaction_status": {
+      "mode": "public-safe",
+      "raw_payloads_excluded": true,
+      "payload_previews_excluded": true,
+      "local_urls_excluded": true,
+      "absolute_paths_excluded": true,
+      "private_identifiers_excluded": true
+    },
     "postmortem": {
       "previous_call_count": 1,
       "gateway_event_count": 0
     }
   },
   "github_issue": {
-    "title": "DCC-MCP request req-123 failed: maya.abcdef01.maya__open_scene",
+    "title": "DCC-MCP request req-123 failed: open_scene",
     "body_template": "## Summary\n\nRequest `req-123` returned `failed`...",
     "suggested_labels": ["bug", "admin-telemetry"]
   },
   "links": {
-    "admin_trace_url": "http://127.0.0.1:9765/admin?panel=traces&trace=req-123",
-    "issue_report_url": "http://127.0.0.1:9765/admin/api/issue-report/req-123",
-    "openapi_inspector_url": "http://127.0.0.1:9765/admin?panel=openapi",
-    "openapi_spec_url": "http://127.0.0.1:9765/v1/openapi.json",
-    "openapi_docs_url": "http://127.0.0.1:9765/docs"
+    "admin_trace_path": "/admin?panel=traces&trace=req-123",
+    "safe_issue_report_path": "/admin/api/issue-report/req-123",
+    "raw_issue_report_path": "/admin/api/issue-report/req-123?mode=raw",
+    "stable_safe_issue_report_path": "/v1/debug/issue-reports/req-123",
+    "stable_raw_issue_report_path": "/v1/debug/issue-reports/req-123?mode=raw",
+    "openapi_spec_path": "/v1/openapi.json",
+    "docs_path": "/docs"
   },
+  "raw_debug_bundle": {
+    "available": true,
+    "mode_query": "mode=raw",
+    "admin_path": "/admin/api/issue-report/req-123?mode=raw",
+    "stable_path": "/v1/debug/issue-reports/req-123?mode=raw"
+  }
+}
+
+// GET /admin/api/issue-report/req-123?mode=raw
+{
+  "schema_version": "dcc-mcp.admin.issue-report.v1",
+  "report_type": "github_issue_debug_json",
+  "privacy_mode": "raw-local-evidence",
+  "request_id": "req-123",
   "debug_bundle": { "request_id": "req-123" }
 }
 

--- a/docs/guide/rest-api-surface.md
+++ b/docs/guide/rest-api-surface.md
@@ -52,7 +52,7 @@ continue to serve their own adapter OpenAPI contract from the same path.
 | `GET` | `/v1/debug/traffic/export` | Gateway only: retained live traffic-capture frames as JSONL. |
 | `GET` | `/v1/debug/trace-context/{lookup_id}` | Gateway only: resolve trace id or request id to the primary trace context. |
 | `GET` | `/v1/debug/bundles/{request_id}` | Gateway only: full-chain debug bundle by request id or trace id. |
-| `GET` | `/v1/debug/issue-reports/{request_id}` | Gateway only: GitHub-attachable debug report JSON. |
+| `GET` | `/v1/debug/issue-reports/{request_id}` | Gateway only: public-safe GitHub issue report JSON by default; `?mode=raw` includes reviewed local evidence. |
 | `GET` | `/v1/debug/tasks` | Gateway only: task-like snapshots reconstructed from traces. |
 | `GET` | `/v1/debug/calls` | Gateway only: recent audited calls. |
 | `GET` | `/v1/debug/logs` | Gateway only: merged gateway events, file logs, and audit summaries. |
@@ -122,7 +122,7 @@ so operators and agents can compare results one-to-one:
 | `/v1/debug/traffic/export?limit=1000` | `/admin/api/traffic/export?limit=1000` | Retained live traffic-capture frames as JSONL. |
 | `/v1/debug/trace-context/{lookup_id}` | n/a | Trace-context lookup by `trace_id` or `request_id`. |
 | `/v1/debug/bundles/{request_id}` | `/admin/api/debug-bundle/{request_id}` | Accepts request ids and retained trace ids. |
-| `/v1/debug/issue-reports/{request_id}` | `/admin/api/issue-report/{request_id}` | JSON export suitable for GitHub issue attachment. |
+| `/v1/debug/issue-reports/{request_id}` | `/admin/api/issue-report/{request_id}` | Public-safe JSON export suitable for GitHub issue attachment by default; `?mode=raw` includes the full debug bundle for reviewed local evidence. |
 | `/v1/debug/workflows` | `/admin/api/workflows` | Agent session/workflow projection from retained search telemetry, traces, and audits. |
 | `/v1/debug/tasks` | `/admin/api/tasks` | Task projection from retained traces. |
 | `/v1/debug/calls` | `/admin/api/calls` | Recent audit rows. |

--- a/docs/zh/guide/rest-api-surface.md
+++ b/docs/zh/guide/rest-api-surface.md
@@ -49,7 +49,7 @@ OpenAPI 契约。
 | `GET` | `/v1/debug/traffic/export` | 仅网关：把保留的 live traffic-capture frames 导出为 JSONL。 |
 | `GET` | `/v1/debug/trace-context/{lookup_id}` | 仅网关：按 trace id 或 request id 解析 primary trace context。 |
 | `GET` | `/v1/debug/bundles/{request_id}` | 仅网关：按 request id 或 trace id 取 full-chain debug bundle。 |
-| `GET` | `/v1/debug/issue-reports/{request_id}` | 仅网关：可附到 GitHub issue 的 debug report JSON。 |
+| `GET` | `/v1/debug/issue-reports/{request_id}` | 仅网关：默认 public-safe、可附到 GitHub issue 的 debug report JSON；`?mode=raw` 返回已审阅本地证据用的完整 bundle。 |
 | `GET` | `/v1/debug/workflows` | 仅网关：由 retained search telemetry、traces 和 audits 重建的 agent session/workflow 投影视图。 |
 | `GET` | `/v1/debug/tasks` | 仅网关：从 traces 重建的 task-like snapshot。 |
 | `GET` | `/v1/debug/calls` | 仅网关：最近 audit call rows。 |
@@ -119,7 +119,7 @@ Phase-1 debug routes 会保留现有 Admin payload 字段，让 operator 和 age
 | `/v1/debug/traffic/export?limit=1000` | `/admin/api/traffic/export?limit=1000` | 保留的 live traffic-capture frames JSONL。 |
 | `/v1/debug/trace-context/{lookup_id}` | n/a | 按 `trace_id` 或 `request_id` 做 trace-context lookup。 |
 | `/v1/debug/bundles/{request_id}` | `/admin/api/debug-bundle/{request_id}` | 接受 request ids 和 retained trace ids。 |
-| `/v1/debug/issue-reports/{request_id}` | `/admin/api/issue-report/{request_id}` | 适合附到 GitHub issue 的 JSON export。 |
+| `/v1/debug/issue-reports/{request_id}` | `/admin/api/issue-report/{request_id}` | 默认适合附到 GitHub issue 的 public-safe JSON export；`?mode=raw` 返回完整 debug bundle 供本地审阅。 |
 | `/v1/debug/workflows` | `/admin/api/workflows` | 从 retained search telemetry、traces 和 audits 聚合 agent session/workflow。 |
 | `/v1/debug/tasks` | `/admin/api/tasks` | retained traces 的 task projection。 |
 | `/v1/debug/calls` | `/admin/api/calls` | 最近 audit rows。 |

--- a/skills/dcc-mcp-creator/references/ADAPTER_WORKFLOW.md
+++ b/skills/dcc-mcp-creator/references/ADAPTER_WORKFLOW.md
@@ -97,3 +97,9 @@ Escalate to core when more than one adapter would need the same helper:
 
 Adapter repositories should contain host facts and host API calls. Core should
 own reusable MCP, gateway, catalog, lifecycle, and wire contracts.
+
+Admin issue reports are public-safe by default. They should expose request
+status, DCC type, tool family, timing, sanitized error kind, token accounting,
+redaction status, and relative debug links without raw payload previews or local
+machine details. Full debug bundles remain a core-owned explicit raw export
+(`?mode=raw`) for reviewed local evidence only.

--- a/tests/vrs/traces/core-1092-stable-debug-api.jsonl
+++ b/tests/vrs/traces/core-1092-stable-debug-api.jsonl
@@ -10,5 +10,6 @@
 {"id": "debug_stats", "http": {"method": "GET", "path": "/v1/debug/stats?range=all"}, "expect": {"status": 200, "json_subset": {"range": "all"}}}
 {"id": "debug_health", "http": {"method": "GET", "path": "/v1/debug/health"}, "expect": {"status": 200, "body_contains": "status"}}
 {"id": "debug_bundle_by_trace_id", "http": {"method": "GET", "path": "/v1/debug/bundles/7bf92f3577b34da6a3ce929d0e0e1092"}, "expect": {"status": 200, "json_subset": {"trace_id": "7bf92f3577b34da6a3ce929d0e0e1092", "request_id": "vrs-core-1092-request"}}}
-{"id": "debug_issue_report", "http": {"method": "GET", "path": "/v1/debug/issue-reports/vrs-core-1092-request"}, "expect": {"status": 200, "json_subset": {"request_id": "vrs-core-1092-request", "debug_bundle": {"trace_id": "7bf92f3577b34da6a3ce929d0e0e1092"}}}}
+{"id": "debug_issue_report", "http": {"method": "GET", "path": "/v1/debug/issue-reports/vrs-core-1092-request"}, "expect": {"status": 200, "json_subset": {"request_id": "vrs-core-1092-request", "privacy_mode": "public-safe", "report_type": "github_issue_public_safe"}}}
+{"id": "debug_issue_report_raw", "http": {"method": "GET", "path": "/v1/debug/issue-reports/vrs-core-1092-request?mode=raw"}, "expect": {"status": 200, "json_subset": {"request_id": "vrs-core-1092-request", "privacy_mode": "raw-local-evidence", "debug_bundle": {"trace_id": "7bf92f3577b34da6a3ce929d0e0e1092"}}}}
 {"id": "openapi_lists_debug_routes", "http": {"method": "GET", "path": "/v1/openapi.json"}, "expect": {"status": 200, "body_contains": "/v1/debug/health"}}


### PR DESCRIPTION
## Summary
- make admin issue reports public-safe by default and move full debug bundle export behind explicit raw mode
- add sanitized error classification, tool-family summaries, relative links, and redaction status for agent workflows
- update Admin UI agent packets, OpenAPI docs, VRS trace, and adapter guidance for the public-safe contract

Closes #1307

## Validation
- vx npm run build (admin-ui)
- vx cargo test -p dcc-mcp-gateway --features admin test_admin_tasks_and_debug_bundle_from_trace -- --nocapture
- vx cargo test -p dcc-mcp-gateway --features admin gateway_openapi_lists_stable_debug_routes -- --nocapture
- python scripts\vrs_replay.py --base-url http://127.0.0.1:1 --dry-run --trace tests\vrs\traces\core-1092-stable-debug-api.jsonl
- vx cargo clippy -p dcc-mcp-gateway --features admin --lib -- -D warnings
- vx git diff --check

## Skill guidance
- Updated dcc-mcp-creator adapter workflow guidance because this changes gateway issue-report behavior.